### PR TITLE
Reconnect native wallet correctly

### DIFF
--- a/src/context/WalletProvider/WalletViewsSwitch.tsx
+++ b/src/context/WalletProvider/WalletViewsSwitch.tsx
@@ -7,6 +7,7 @@ import {
   ModalContent,
   ModalOverlay
 } from '@chakra-ui/react'
+import { NativeHDWallet } from '@shapeshiftoss/hdwallet-native'
 import { SlideTransition } from 'components/SlideTransition'
 import { AnimatePresence } from 'framer-motion'
 import React, { useEffect } from 'react'
@@ -42,7 +43,10 @@ export const WalletViewsSwitch = (props: WalletViewProps) => {
   return (
     <>
       <NativePasswordRequired
-        onConnect={() => dispatch({ type: WalletActions.SET_IS_CONNECTED, payload: true })}
+        onConnect={(wallet: NativeHDWallet) => {
+          dispatch({ type: WalletActions.SET_WALLET, payload: wallet })
+          dispatch({ type: WalletActions.SET_IS_CONNECTED, payload: true })
+        }}
       />
       <Modal isOpen={props.modalOpen} onClose={onClose} isCentered>
         <ModalOverlay />


### PR DESCRIPTION
## Notice

Before submitting a pull request, please make sure you have answered the following:

- [x] Have you followed the guidelines in our [Contributing]('https://github.com/shapeshift/web/CONTRIBUTING.md) guide?
- [x] Have you checked to ensure there aren't other open [Pull Requests](https://github.com/shapeshift/web/pulls) for the same update/change?
- [x] Do all new and existing tests pass? Does the linter pass?

## Pull Request Type

- [x] :bug: Bug fix (Non-breaking Change: Fixes an issue)
- [ ] :hammer_and_wrench: Chore (Non-breaking Change: Doc updates, pkg upgrades, typos, etc..)
- [ ] :nail_care: New Feature (Breaking/Non-breaking Change)

## Issue (if applicable)

closes #35 

## Description

when reconnecting a wallet after refreshing a browser it would initialize the wallet but not actually add it to the state in the context - this adds it to the state so it's actually available in the hook

## Testing

Please outline all testing steps

1. import/create a wallet
2. refresh the page
3. enter your password
4. wallet should be available from `useWallet` hook

## Screenshots (if applicable)
