### PR TITLE
🐛 Bug Fix for invalid 'showBorder' prop- Closes #32

### DIFF
--- a/src/components/Layout/Header/NavBar/WalletButton.tsx
+++ b/src/components/Layout/Header/NavBar/WalletButton.tsx
@@ -35,7 +35,6 @@ const WalletImage: React.FC<WalletImageProps> = ({ isConnected, walletInfo }) =>
     <Image
       boxSize='24px'
       loading='lazy'
-      showBorder={false}
       objectFit='contain'
       bg='transparent'
       src={walletInfo?.icon}


### PR DESCRIPTION
 Link to issue [https://github.com/shapeshift/web/issues/32](https://github.com/shapeshift/web/issues/32)

## Description
I removed the `showBorder` property from the Image element as it is invalid syntax. I verified that nowhere in the application relies on this property in its invalid form or what would be valid as a custom property `showborder`. I also checked documentation for the Image element and confirmed the property does not exist.

## Testing
1. Got latest from develop branch and ran project locally
2. Saw the error when the WalletButton component was initialized
3. Removed invalid property
4. Re-ran application and confirmed no side effects from change
