### PR TITLE
feat: make asset description collapsible (#121)

### DIFF
--- a/src/assets/translations/messages-en.json
+++ b/src/assets/translations/messages-en.json
@@ -164,6 +164,10 @@
         "dayChange": "Day Change",
         "aboutAsset": "About %{asset}"
       },
+      "assetDescription": {
+        "showMore": "Show More",
+        "showLess": "Show Less"
+      },
       "assetHistory": {
         "transactionHistory": "Transaction History"
       }

--- a/src/pages/Assets/AssetDetails/AssetHeader/AssetHeader.tsx
+++ b/src/pages/Assets/AssetDetails/AssetHeader/AssetHeader.tsx
@@ -1,6 +1,7 @@
 import {
   Box,
   Button,
+  Collapse,
   Flex,
   Heading,
   HStack,
@@ -35,6 +36,8 @@ export const AssetHeader = ({ asset, isLoaded }: { asset: AssetMarketData; isLoa
   const [timeframe, setTimeframe] = useState(HistoryTimeframe.YEAR)
   const [graphPercentChange, setGraphPercentChange] = useState(percentChange)
   const translate = useTranslate()
+  const [showDescription, setShowDescription] = useState(false)
+  const handleToggle = () => setShowDescription(!showDescription)
 
   return (
     <Card variant='footer-stub'>
@@ -174,9 +177,16 @@ export const AssetHeader = ({ asset, isLoaded }: { asset: AssetMarketData; isLoa
             </Card.Heading>
           </Skeleton>
 
-          <SkeletonText isLoaded={isLoaded} noOfLines={4} spacing={2} skeletonHeight='20px'>
-            <SanitizedHtml color='gray.500' dirtyHtml={description} />
-          </SkeletonText>
+          <Collapse startingHeight={70} in={showDescription}>
+            <SkeletonText isLoaded={isLoaded} noOfLines={4} spacing={2} skeletonHeight='20px'>
+              <SanitizedHtml color='gray.500' dirtyHtml={description} />
+            </SkeletonText>
+          </Collapse>
+          <Button size='sm' onClick={handleToggle} mt='1rem'>
+            {showDescription
+              ? translate('assets.assetDetails.assetDescription.showLess')
+              : translate('assets.assetDetails.assetDescription.showMore')}
+          </Button>
         </Card.Footer>
       )}
     </Card>


### PR DESCRIPTION
Surround the asset description with a Collapse
Add a button to show more / show less

## Notice

Before submitting a pull request, please make sure you have answered the following:

- [x] Have you followed the guidelines in our [Contributing]('https://github.com/shapeshift/web/CONTRIBUTING.md) guide?
- [x] Have you checked to ensure there aren't other open [Pull Requests](https://github.com/shapeshift/web/pulls) for the same update/change?
- [x] Do all new and existing tests pass? Does the linter pass?

## Pull Request Type

- [ ] :bug: Bug fix (Non-breaking Change: Fixes an issue)
- [ ] :hammer_and_wrench: Chore (Non-breaking Change: Doc updates, pkg upgrades, typos, etc..)
- [x] :nail_care: New Feature (Non-breaking Change)

## Issue (if applicable)

closes #121 

## Description

* Make the description collapsible
* Add a button to toggle between collapsed / extended text
