### PR TITLE
after mnemonic is loaded dont rerun effect until app crashes

### DIFF
--- a/src/context/WalletProvider/NativeWallet/hooks/useNativeSuccess/useNativeSuccess.ts
+++ b/src/context/WalletProvider/NativeWallet/hooks/useNativeSuccess/useNativeSuccess.ts
@@ -1,14 +1,15 @@
 import { NativeAdapter } from '@shapeshiftoss/hdwallet-native'
 import { EncryptedWallet } from '@shapeshiftoss/hdwallet-native/dist/crypto'
-import { useEffect, useState } from 'react'
+import { useEffect } from 'react'
 import { SUPPORTED_WALLETS } from 'context/WalletProvider/config'
 import { useWallet, WalletActions } from 'context/WalletProvider/WalletProvider'
 import { useLocalStorage } from 'hooks/useLocalStorage/useLocalStorage'
+import { useStateIfMounted } from 'hooks/useStateIfMounted/useStateIfMounted'
 
 export type UseNativeSuccessPropTypes = { encryptedWallet?: EncryptedWallet }
 
 export const useNativeSuccess = ({ encryptedWallet }: UseNativeSuccessPropTypes) => {
-  const [isSuccessful, setIsSuccessful] = useState<boolean | null>(null)
+  const [isSuccessful, setIsSuccessful] = useStateIfMounted<boolean | null>(null)
   const [, setLocalStorageWallet] = useLocalStorage<Record<string, string>>('wallet', null)
   const { state, dispatch } = useWallet()
 
@@ -35,12 +36,10 @@ export const useNativeSuccess = ({ encryptedWallet }: UseNativeSuccessPropTypes)
           console.error('Failed to load device', error)
           setIsSuccessful(false)
         }
-      } else {
-        setIsSuccessful(false)
       }
     })()
     // eslint-disable-next-line react-hooks/exhaustive-deps
-  }, [encryptedWallet?.encryptedWallet, dispatch, setLocalStorageWallet, state.adapters])
+  }, [encryptedWallet?.encryptedWallet])
 
   return { isSuccessful }
 }


### PR DESCRIPTION
## Notice

Before submitting a pull request, please make sure you have answered the following:

- [ ] Have you followed the guidelines in our [Contributing]('https://github.com/shapeshift/web/CONTRIBUTING.md) guide?
- [ ] Have you checked to ensure there aren't other open [Pull Requests](https://github.com/shapeshift/web/pulls) for the same update/change?
- [ ] Do all new and existing tests pass? Does the linter pass?

## Pull Request Type

- [ ] :bug: Bug fix (Non-breaking Change: Fixes an issue)
- [ ] :hammer_and_wrench: Chore (Non-breaking Change: Doc updates, pkg upgrades, typos, etc..)
- [ ] :nail_care: New Feature (Breaking/Non-breaking Change)

## Issue (if applicable)

closes #155 

## Description

this effect was being called over and over again causing the app to crash after uploading a mnemonic

## Screenshots (if applicable)
