### PR TITLE
fix: use back arrow in send confirm modal

### DIFF
--- a/src/components/Modals/Send/views/Confirm.tsx
+++ b/src/components/Modals/Send/views/Confirm.tsx
@@ -1,9 +1,11 @@
+import { ArrowBackIcon } from '@chakra-ui/icons'
 import {
   Box,
   Button,
   Flex,
   FormControl,
   FormLabel,
+  IconButton,
   ModalBody,
   ModalFooter,
   ModalHeader,
@@ -50,6 +52,18 @@ export const Confirm = () => {
 
   return (
     <SlideTransition>
+      <IconButton
+        variant='ghost'
+        icon={<ArrowBackIcon />}
+        aria-label={translate('common.back')}
+        position='absolute'
+        top={2}
+        left={3}
+        fontSize='xl'
+        size='sm'
+        isRound
+        onClick={() => history.push(SendRoutes.Details)}
+      />
       <ModalHeader textAlign='center'>
         <Text translation={['modals.send.confirm.sendAsset', { asset: asset.name }]} />
       </ModalHeader>
@@ -84,9 +98,6 @@ export const Confirm = () => {
               <TxFeeRadioGroup fees={fees} />
             </Row>
           </FormControl>
-          <Button width='full' onClick={() => history.push(SendRoutes.Details)}>
-            <Text translation={'modals.send.confirm.edit'} />
-          </Button>
         </Stack>
       </ModalBody>
       <ModalFooter


### PR DESCRIPTION
## Description

* remove confirm Edit button
* add back arrow as per the previous step in the modal flow

## Notice

Before submitting a pull request, please make sure you have answered the following:

- [x] Have you followed the guidelines in our [Contributing]('https://github.com/shapeshift/web/CONTRIBUTING.md) guide?
- [x] Have you checked to ensure there aren't other open [Pull Requests](https://github.com/shapeshift/web/pulls) for the same update/change?
- [x] Do all new and existing tests pass? Does the linter pass?

## Pull Request Type

- [x] :bug: Bug fix (Non-breaking Change: Fixes an issue)
- [ ] :hammer_and_wrench: Chore (Non-breaking Change: Doc updates, pkg upgrades, typos, etc..)
- [ ] :nail_care: New Feature (Breaking/Non-breaking Change)

## Issue (if applicable)

closes #167 

## Screenshots (if applicable)

**Before**

![before](https://user-images.githubusercontent.com/5672954/138309482-eae48825-6ad5-465f-a853-a84cf138761c.png)

**After**

![after](https://user-images.githubusercontent.com/5672954/138309510-e555a21f-8f2e-40d8-beb7-d720162a7fda.png)
