### PR TITLE
fix: fix yarn link-packages script

### DIFF
--- a/package.json
+++ b/package.json
@@ -62,7 +62,7 @@
   },
   "scripts": {
     "show-linked-packages": "find node_modules node_modules/@* -depth 1 -type l -print",
-    "link-packages": "grep -oE '@shapeshiftoss/[a-z-]*' package.json | grep -v hdwallet | xargs yarn link",
+    "link-packages": "grep -oE '@shapeshiftoss\/[a-z-]*' package.json | grep -v hdwallet | xargs yarn link",
     "unlink-packages": "find node_modules node_modules/@* -depth 1 -type l -print | awk -F/ '{ printf \"%s/%s\\n\",$2,$3; }' | xargs yarn unlink && yarn install --force",
     "build": "react-scripts build",
     "dev": "react-scripts start",


### PR DESCRIPTION
## Description

note: this keeps getting munged by ide's or linters. please make sure you don't unbreak this again when committing stuff. the escape sequence is necessary in the grep command for the script to work.

## Notice

Before submitting a pull request, please make sure you have answered the following:

- [ ] Have you followed the guidelines in our [Contributing]('https://github.com/shapeshift/web/CONTRIBUTING.md) guide?
- [ ] Have you checked to ensure there aren't other open [Pull Requests](https://github.com/shapeshift/web/pulls) for the same update/change?
- [ ] Do all new and existing tests pass? Does the linter pass?

## Pull Request Type

- [ ] :bug: Bug fix (Non-breaking Change: Fixes an issue)
- [ ] :hammer_and_wrench: Chore (Non-breaking Change: Doc updates, pkg upgrades, typos, etc..)
- [ ] :nail_care: New Feature (Breaking/Non-breaking Change)

## Issue (if applicable)

If applicable, please link to the github issue and put `closes #XXXX` in your comment to auto-close the issue that your PR fixes.

## Testing

Please outline all testing steps

1. Pull branch locally and run `yarn` to install new deps
2. etc...

## Screenshots (if applicable)
