### PR TITLE
fix: address validation

### DIFF
--- a/src/components/Modals/Send/views/Address.tsx
+++ b/src/components/Modals/Send/views/Address.tsx
@@ -10,7 +10,6 @@ import {
   ModalHeader,
   Stack
 } from '@chakra-ui/react'
-import { ChainTypes } from '@shapeshiftoss/types'
 import get from 'lodash/get'
 import { useFormContext, useWatch } from 'react-hook-form'
 import { useTranslate } from 'react-polyglot'
@@ -32,7 +31,7 @@ export const Address = () => {
   } = useFormContext()
   const [address, asset] = useWatch({ name: [SendFormFields.Address, SendFormFields.Asset] })
   const chainAdapters = useChainAdapters()
-  const adapter = chainAdapters.byChain(ChainTypes.Ethereum)
+  const adapter = chainAdapters.byChain(asset.chain)
   const { send } = useModal()
 
   const handleNext = () => history.push(SendRoutes.Details)


### PR DESCRIPTION
Use the correct chain adapter for address validation. This fixes it in 99% of cases.

There are 2 edge cases it doesn't work for but its fine because hdwallet and / or unchained also fail for these:

1) Mixed case eth addresses that are not in checksum format fail.  Theres no reason we shouldn't be able to send to mixed case eth

2) mixed case bc1 addresses don't work. according to internet it should be fine.

Fixing these 2 cases would mean adding to our validation code and also changing unchained & hdwallet. Does not seem necessary at this time