### PR TITLE
fix: fees part1 cleanup

### DIFF
--- a/src/components/Modals/Send/hooks/useFormSend/useFormSend.test.tsx
+++ b/src/components/Modals/Send/hooks/useFormSend/useFormSend.test.tsx
@@ -119,7 +119,8 @@ describe('useFormSend', () => {
         byChain: () => ({
           buildSendTransaction: () => Promise.resolve(textTxToSign),
           signTransaction: () => Promise.resolve(testSignedTx),
-          broadcastTransaction: () => Promise.resolve(expectedTx)
+          broadcastTransaction: () => Promise.resolve(expectedTx),
+          getType: () => ChainTypes.Ethereum
         })
       }))
 
@@ -149,7 +150,8 @@ describe('useFormSend', () => {
       ;(useChainAdapters as jest.Mock<unknown>).mockImplementation(() => ({
         byChain: () => ({
           buildSendTransaction: () => Promise.resolve(textTxToSign),
-          signAndBroadcastTransaction
+          signAndBroadcastTransaction,
+          getType: () => ChainTypes.Ethereum
         })
       }))
 

--- a/src/components/Modals/Send/hooks/useFormSend/useFormSend.tsx
+++ b/src/components/Modals/Send/hooks/useFormSend/useFormSend.tsx
@@ -56,7 +56,6 @@ export const useFormSend = () => {
           result = await adapter.buildSendTransaction({
             to: data.address,
             value,
-            erc20ContractAddress: data.asset.tokenId,
             wallet,
             fee,
             ...accountParams

--- a/src/components/Modals/Send/hooks/useSendDetails/useSendDetails.test.tsx
+++ b/src/components/Modals/Send/hooks/useSendDetails/useSendDetails.test.tsx
@@ -158,8 +158,7 @@ describe('useSendDetails', () => {
         getAddress: () => '0xMyWalletsAddress',
         getFeeData: () => estimatedFees,
         buildSendTransaction: () => ({
-          txToSign: {},
-          estimatedFees
+          txToSign: {}
         })
       })
     }))
@@ -339,8 +338,7 @@ describe('useSendDetails', () => {
       })
       await act(async () => {
         await result.current.handleNextClick()
-        expect(setValue).toHaveBeenNthCalledWith(1, 'transaction', {})
-        expect(setValue).toHaveBeenNthCalledWith(2, 'estimatedFees', estimatedFees)
+        expect(setValue).toHaveBeenNthCalledWith(1, 'estimatedFees', estimatedFees)
       })
     })
   })

--- a/src/components/Modals/Send/hooks/useSendDetails/useSendDetails.tsx
+++ b/src/components/Modals/Send/hooks/useSendDetails/useSendDetails.tsx
@@ -34,9 +34,6 @@ type UseSendDetailsReturnType = {
   validateFiatAmount(value: string): boolean | string
 }
 
-// TODO (technojak) this should be removed in favor of the asset-service. For now assume the fallback is eth
-const ETH_PRECISION = 18
-
 export const useSendDetails = (): UseSendDetailsReturnType => {
   const [fieldName, setFieldName] = useState<AmountFieldName>(SendFormFields.FiatAmount)
   const [loading, setLoading] = useState<boolean>(false)


### PR DESCRIPTION
- Use get feeData instead of buildSendTransaction to estimate fees.
- Make it work with new btc specific fee data from lib

- Depends on this pr: https://github.com/shapeshift/lib/pull/190

https://github.com/shapeshift/web/issues/215

This is part 1 of a series of PR's to clean up how to handle fees
