### PR TITLE
fix: translate tooltips; refactor to use bnOrZero

### DIFF
--- a/src/assets/translations/messages-en.json
+++ b/src/assets/translations/messages-en.json
@@ -66,6 +66,11 @@
     "estimatedGasFee": "Estimated Gas Fee",
     "approvingAsset": "Approving %{symbol}",
     "viewTransaction": "View Transaction",
+    "tooltip": {
+      "rate": "This is the rate",
+      "minerFee": "This is the Miner Fee",
+      "shapeshiftFee": "This is the Shapeshift Fee"
+    },
     "errors": {
       "notEnoughEth": "Not enough Ethereum for the gas fee on this transaction. Est gas fee %{estimatedMinerFee}",
       "amountToSmall": "Amount too small. The minimum trade amount for this pair is %{minLimit}.",

--- a/src/components/Trade/TradeConfirm/TradeConfirm.tsx
+++ b/src/components/Trade/TradeConfirm/TradeConfirm.tsx
@@ -3,6 +3,7 @@ import { Box, Button, Divider, IconButton, Link, SimpleGrid, Stack } from '@chak
 import { chainAdapters, ChainTypes, SwapperType } from '@shapeshiftoss/types'
 import { useState } from 'react'
 import { useFormContext } from 'react-hook-form'
+import { useTranslate } from 'react-polyglot'
 import { useSelector } from 'react-redux'
 import { RouterProps, useLocation } from 'react-router-dom'
 import { Card } from 'components/Card/Card'
@@ -42,6 +43,7 @@ export const TradeConfirm = ({ history }: RouterProps) => {
   const {
     state: { wallet }
   } = useWallet()
+  const t = useTranslate()
   const { chain, tokenId } = sellAsset.currency
   const asset = tokenId ?? chain
   const txs = useSelector((state: ReduxState) => {
@@ -101,7 +103,7 @@ export const TradeConfirm = ({ history }: RouterProps) => {
                 </Row>
               )}
               <Row>
-                <HelperTooltip label='This is the rate'>
+                <HelperTooltip label={t('trade.tooltip.rate')}>
                   <Row.Label>
                     <Text translation='trade.rate' />
                   </Row.Label>
@@ -114,7 +116,7 @@ export const TradeConfirm = ({ history }: RouterProps) => {
                 </Box>
               </Row>
               <Row>
-                <HelperTooltip label='This is the Miner Fee'>
+                <HelperTooltip label={t('trade.tooltip.minerFee')}>
                   <Row.Label>
                     <Text translation='trade.minerFee' />
                   </Row.Label>
@@ -122,7 +124,7 @@ export const TradeConfirm = ({ history }: RouterProps) => {
                 <Row.Value>{toFiat(bnOrZero(fees?.fee).times(fiatRate).toNumber())}</Row.Value>
               </Row>
               <Row>
-                <HelperTooltip label='This is the Shapeshift Fee'>
+                <HelperTooltip label={t('trade.tooltip.shapeshiftFee')}>
                   <Row.Label>
                     <Text translation='trade.shapeshiftFee' />
                   </Row.Label>

--- a/src/components/Trade/hooks/useSwapper/useSwapper.ts
+++ b/src/components/Trade/hooks/useSwapper/useSwapper.ts
@@ -232,17 +232,15 @@ export const useSwapper = () => {
       ? sellAsset.currency.precision
       : isBuyAmount && buyAsset.currency.precision
     if (precision) {
-      formattedAmount = toBaseUnit(amount || '0', precision)
+      formattedAmount = toBaseUnit(bnOrZero(amount), precision)
     }
 
     const onFinish = (quote: Quote<ChainTypes, SwapperType>) => {
       if (isComponentMounted.current) {
         const { sellAsset, buyAsset, action, fiatAmount } = getValues()
-        const buyAmount = fromBaseUnit(quote.buyAmount || '0', buyAsset.currency.precision)
-        const sellAmount = fromBaseUnit(quote.sellAmount || '0', sellAsset.currency.precision)
-        const newFiatAmount = bn(buyAmount)
-          .times(buyAsset.fiatRate || 0)
-          .toFixed(2)
+        const buyAmount = fromBaseUnit(bnOrZero(quote.buyAmount), buyAsset.currency.precision)
+        const sellAmount = fromBaseUnit(bnOrZero(quote.sellAmount), sellAsset.currency.precision)
+        const newFiatAmount = bn(buyAmount).times(bnOrZero(buyAsset.fiatRate)).toFixed(2)
 
         if (action === TradeActions.SELL && isSellAmount && amount === sellAsset.amount) {
           setValue('buyAsset.amount', buyAmount)
@@ -255,11 +253,11 @@ export const useSwapper = () => {
         } else if (action === TradeActions.FIAT && isFiatAmount && amount === fiatAmount) {
           setValue(
             'buyAsset.amount',
-            fromBaseUnit(quote.buyAmount || '0', buyAsset.currency.precision)
+            fromBaseUnit(bnOrZero(quote.buyAmount), buyAsset.currency.precision)
           )
           setValue(
             'sellAsset.amount',
-            fromBaseUnit(quote.sellAmount || '0', sellAsset.currency.precision)
+            fromBaseUnit(bnOrZero(quote.sellAmount), sellAsset.currency.precision)
           )
           setValue('action', undefined)
         }

--- a/src/components/Trade/hooks/useSwapper/useSwapper.ts
+++ b/src/components/Trade/hooks/useSwapper/useSwapper.ts
@@ -238,8 +238,10 @@ export const useSwapper = () => {
     const onFinish = (quote: Quote<ChainTypes, SwapperType>) => {
       if (isComponentMounted.current) {
         const { sellAsset, buyAsset, action, fiatAmount } = getValues()
-        const buyAmount = fromBaseUnit(bnOrZero(quote.buyAmount), buyAsset.currency.precision)
-        const sellAmount = fromBaseUnit(bnOrZero(quote.sellAmount), sellAsset.currency.precision)
+        // TODO:(ryankk) should this return be handled with an error state instead?
+        if (!(quote.buyAmount && quote.sellAmount)) return
+        const buyAmount = fromBaseUnit(quote.buyAmount, buyAsset.currency.precision)
+        const sellAmount = fromBaseUnit(quote.sellAmount, sellAsset.currency.precision)
         const newFiatAmount = bn(buyAmount).times(bnOrZero(buyAsset.fiatRate)).toFixed(2)
 
         if (action === TradeActions.SELL && isSellAmount && amount === sellAsset.amount) {

--- a/src/components/Trade/hooks/useSwapper/useSwapper.ts
+++ b/src/components/Trade/hooks/useSwapper/useSwapper.ts
@@ -251,14 +251,8 @@ export const useSwapper = () => {
           setValue('fiatAmount', newFiatAmount)
           setValue('action', undefined)
         } else if (action === TradeActions.FIAT && isFiatAmount && amount === fiatAmount) {
-          setValue(
-            'buyAsset.amount',
-            fromBaseUnit(bnOrZero(quote.buyAmount), buyAsset.currency.precision)
-          )
-          setValue(
-            'sellAsset.amount',
-            fromBaseUnit(bnOrZero(quote.sellAmount), sellAsset.currency.precision)
-          )
+          setValue('buyAsset.amount', buyAmount)
+          setValue('sellAsset.amount', sellAmount)
           setValue('action', undefined)
         }
       }

--- a/src/components/Trade/hooks/useSwapper/useSwapper.ts
+++ b/src/components/Trade/hooks/useSwapper/useSwapper.ts
@@ -232,7 +232,7 @@ export const useSwapper = () => {
       ? sellAsset.currency.precision
       : isBuyAmount && buyAsset.currency.precision
     if (precision) {
-      formattedAmount = toBaseUnit(bnOrZero(amount), precision)
+      formattedAmount = toBaseUnit(amount, precision)
     }
 
     const onFinish = (quote: Quote<ChainTypes, SwapperType>) => {

--- a/src/lib/math.ts
+++ b/src/lib/math.ts
@@ -8,7 +8,7 @@ export const fromBaseUnit = (
   decimals: number,
   displayDecimals = 6
 ): string => {
-  return new BigNumber(value).div(`1e+${decimals}`).decimalPlaces(displayDecimals).toString()
+  return bnOrZero(value).div(`1e+${decimals}`).decimalPlaces(displayDecimals).toString()
 }
 
 export const toBaseUnit = (amount: BigNumber.Value | undefined, precision: number): string => {


### PR DESCRIPTION
## Description

Small changes to translate tooltips in TradeConfirm component. 
Refactor `onFinish` in useSwapper.ts to use `bnOrZero` 

## Notice

Before submitting a pull request, please make sure you have answered the following:

- [x] Have you followed the guidelines in our [Contributing]('https://github.com/shapeshift/web/CONTRIBUTING.md) guide?
- [x] Have you checked to ensure there aren't other open [Pull Requests](https://github.com/shapeshift/web/pulls) for the same update/change?
- [x] Do all new and existing tests pass? Does the linter pass?

## Pull Request Type

- [x] :bug: Bug fix (Non-breaking Change: Fixes an issue)
- [ ] :hammer_and_wrench: Chore (Non-breaking Change: Doc updates, pkg upgrades, typos, etc..)
- [ ] :nail_care: New Feature (Breaking/Non-breaking Change)

## Issue (if applicable)

If applicable, please link to the github issue and put `closes #XXXX` in your comment to auto-close the issue that your PR fixes.

## Testing

Please outline all testing steps

1. Pull branch locally and run `yarn` to install new deps
2. etc...

## Screenshots (if applicable)
