### PR TITLE
fix: allow to select same wallet option after back

### DIFF
--- a/src/context/WalletProvider/WalletViewsSwitch.tsx
+++ b/src/context/WalletProvider/WalletViewsSwitch.tsx
@@ -30,6 +30,7 @@ export const WalletViewsSwitch = () => {
 
   const handleBack = () => {
     history.goBack()
+    dispatch({ type: WalletActions.SET_WALLET_MODAL, payload: true })
   }
 
   useEffect(() => {


### PR DESCRIPTION
## Description

On connect wallet modal, allow to select the same wallet option after clicking on back arrow

## Notice

Before submitting a pull request, please make sure you have answered the following:

- [x] Have you followed the guidelines in our [Contributing]('https://github.com/shapeshift/web/CONTRIBUTING.md) guide?
- [x] Have you checked to ensure there aren't other open [Pull Requests](https://github.com/shapeshift/web/pulls) for the same update/change?
- [x] Do all new and existing tests pass? Does the linter pass?

## Pull Request Type

- [x] :bug: Bug fix (Non-breaking Change: Fixes an issue)
- [ ] :hammer_and_wrench: Chore (Non-breaking Change: Doc updates, pkg upgrades, typos, etc..)
- [ ] :nail_care: New Feature (Breaking/Non-breaking Change)

## Issue (if applicable)

closes #112 

## Testing

1. Pull branch locally and run `yarn` to install new deps
2. Run `yarn dev`
3. Select "Connect Wallet"
4. Select "Shapeshift"
5. Press back button on connect wallet modal
6. Try to select "Shapeshift" again.