### PR TITLE
fix: dynamic asset precision and use 6 instead of 4 decimals small btc amounts dont show as 0

### DIFF
--- a/src/components/Modals/Send/TxFeeRadioGroup.tsx
+++ b/src/components/Modals/Send/TxFeeRadioGroup.tsx
@@ -111,7 +111,7 @@ export const TxFeeRadioGroup = ({ fees }: TxFeeRadioGroupProps) => {
             <Amount.Crypto
               fontSize='sm'
               fontWeight='normal'
-              maximumFractionDigits={4}
+              maximumFractionDigits={6}
               symbol={asset.tokenId ? 'ETH' : asset.symbol}
               value={current.txFee}
             />

--- a/src/components/Modals/Send/TxFeeRadioGroup.tsx
+++ b/src/components/Modals/Send/TxFeeRadioGroup.tsx
@@ -111,7 +111,7 @@ export const TxFeeRadioGroup = ({ fees }: TxFeeRadioGroupProps) => {
             <Amount.Crypto
               fontSize='sm'
               fontWeight='normal'
-              maximumFractionDigits={6}
+              maximumFractionDigits={Math.min(6, asset.precision)}
               symbol={asset.tokenId ? 'ETH' : asset.symbol}
               value={current.txFee}
             />

--- a/src/components/Modals/Send/TxFeeRadioGroup.tsx
+++ b/src/components/Modals/Send/TxFeeRadioGroup.tsx
@@ -111,7 +111,7 @@ export const TxFeeRadioGroup = ({ fees }: TxFeeRadioGroupProps) => {
             <Amount.Crypto
               fontSize='sm'
               fontWeight='normal'
-              maximumFractionDigits={Math.min(6, asset.precision)}
+              maximumFractionDigits={6}
               symbol={asset.tokenId ? 'ETH' : asset.symbol}
               value={current.txFee}
             />

--- a/src/components/Modals/Send/views/Confirm.tsx
+++ b/src/components/Modals/Send/views/Confirm.tsx
@@ -120,7 +120,7 @@ export const Confirm = () => {
             <Row.Value>
               <Amount.Crypto
                 textTransform='uppercase'
-                maximumFractionDigits={6}
+                maximumFractionDigits={Math.min(6, asset.precision)}
                 symbol={crypto.symbol}
                 value={crypto.amount}
               />

--- a/src/components/Modals/Send/views/Confirm.tsx
+++ b/src/components/Modals/Send/views/Confirm.tsx
@@ -120,7 +120,7 @@ export const Confirm = () => {
             <Row.Value>
               <Amount.Crypto
                 textTransform='uppercase'
-                maximumFractionDigits={4}
+                maximumFractionDigits={6}
                 symbol={crypto.symbol}
                 value={crypto.amount}
               />

--- a/src/components/Modals/Send/views/Confirm.tsx
+++ b/src/components/Modals/Send/views/Confirm.tsx
@@ -120,7 +120,7 @@ export const Confirm = () => {
             <Row.Value>
               <Amount.Crypto
                 textTransform='uppercase'
-                maximumFractionDigits={Math.min(6, asset.precision)}
+                maximumFractionDigits={6}
                 symbol={crypto.symbol}
                 value={crypto.amount}
               />

--- a/src/components/Transactions/TransactionRow.tsx
+++ b/src/components/Transactions/TransactionRow.tsx
@@ -75,7 +75,7 @@ export const TransactionRow = ({ tx }: { tx: Tx }) => {
             ml={1}
             value={fromBaseUnit(tx.value, asset.precision)}
             symbol={symbol}
-            maximumFractionDigits={Math.min(6, asset.precision)}
+            maximumFractionDigits={6}
             fontWeight='bold'
           />
         </Flex>
@@ -108,7 +108,7 @@ export const TransactionRow = ({ tx }: { tx: Tx }) => {
                 <Amount.Crypto
                   value={fromBaseUnit(tx?.fee?.value ?? '0', asset.precision)}
                   symbol={tx?.fee?.symbol}
-                  maximumFractionDigits={Math.min(6, asset.precision)}
+                  maximumFractionDigits={6}
                 />
               )}
             </Row.Value>

--- a/src/components/Transactions/TransactionRow.tsx
+++ b/src/components/Transactions/TransactionRow.tsx
@@ -73,9 +73,9 @@ export const TransactionRow = ({ tx }: { tx: Tx }) => {
           )}
           <Amount.Crypto
             ml={1}
-            value={fromBaseUnit(tx.value, 18)}
+            value={fromBaseUnit(tx.value, asset.precision)}
             symbol={symbol}
-            maximumFractionDigits={4}
+            maximumFractionDigits={6}
             fontWeight='bold'
           />
         </Flex>
@@ -106,9 +106,9 @@ export const TransactionRow = ({ tx }: { tx: Tx }) => {
             <Row.Value>
               {tx?.fee && (
                 <Amount.Crypto
-                  value={fromBaseUnit(tx?.fee?.value ?? '0', 18)}
+                  value={fromBaseUnit(tx?.fee?.value ?? '0', asset.precision)}
                   symbol={tx?.fee?.symbol}
-                  maximumFractionDigits={4}
+                  maximumFractionDigits={6}
                 />
               )}
             </Row.Value>

--- a/src/components/Transactions/TransactionRow.tsx
+++ b/src/components/Transactions/TransactionRow.tsx
@@ -75,7 +75,7 @@ export const TransactionRow = ({ tx }: { tx: Tx }) => {
             ml={1}
             value={fromBaseUnit(tx.value, asset.precision)}
             symbol={symbol}
-            maximumFractionDigits={6}
+            maximumFractionDigits={Math.min(6, asset.precision)}
             fontWeight='bold'
           />
         </Flex>
@@ -108,7 +108,7 @@ export const TransactionRow = ({ tx }: { tx: Tx }) => {
                 <Amount.Crypto
                   value={fromBaseUnit(tx?.fee?.value ?? '0', asset.precision)}
                   symbol={tx?.fee?.symbol}
-                  maximumFractionDigits={6}
+                  maximumFractionDigits={Math.min(6, asset.precision)}
                 />
               )}
             </Row.Value>


### PR DESCRIPTION
fix: dynamic asset precision and use 6 instead of 4 decimals small btc amounts dont show as 0