### PR TITLE
fix: fix the "Connect Wallet" modal not working after clicking "Back"

### DIFF
--- a/src/assets/translations/messages-en.json
+++ b/src/assets/translations/messages-en.json
@@ -34,6 +34,13 @@
       "recentTransactions": "Recent Transactions"
     }
   },
+  "connectWallet": {
+    "menu": {
+      "triggerButton": "Connect Wallet",
+      "switchWallet": "Switch Wallet Provider",
+      "disconnect": "Disconnect"
+    }
+  },
   "earn": {
     "earn": "Earn",
     "earnBody": "Earn interest by depositing your assets.",

--- a/src/components/Icons/KeepKeyIcon.tsx
+++ b/src/components/Icons/KeepKeyIcon.tsx
@@ -6,7 +6,7 @@ export const KeepKeyIcon = createIcon({
     <path
       d='M20.625 0A9.375 9.375 0 0 1 30 9.375v11.25A9.375 9.375 0 0 1 20.625 30H9.375A9.375 9.375 0 0 1 0 20.625V9.375A9.375 9.375 0 0 1 9 .007v23.981h2.753v-7.897L19.94 24H24l-8.788-8.198 7.976-6.848H19.27l-7.517 6.623L11.752 0h8.873Z'
       fill='currentColor'
-      fill-rule='evenodd'
+      fillRule='evenodd'
     />
   ),
   viewBox: '0 0 30 30'

--- a/src/components/Layout/Header/NavBar/WalletButton.tsx
+++ b/src/components/Layout/Header/NavBar/WalletButton.tsx
@@ -1,28 +1,18 @@
-import {
-  ArrowDownIcon,
-  ArrowUpIcon,
-  ChevronRightIcon,
-  CloseIcon,
-  CopyIcon,
-  RepeatIcon,
-  TriangleDownIcon
-} from '@chakra-ui/icons'
+import { ChevronRightIcon, CloseIcon, RepeatIcon, TriangleDownIcon } from '@chakra-ui/icons'
 import {
   Box,
   Button,
   Circle,
   FlexProps,
-  HStack,
-  IconButton,
   Menu,
   MenuButton,
   MenuDivider,
   MenuGroup,
   MenuItem,
-  MenuList,
-  Tooltip
+  MenuList
 } from '@chakra-ui/react'
 import { FC } from 'react'
+import { Text } from 'components/Text'
 import { InitialState, useWallet, WalletActions } from 'context/WalletProvider/WalletProvider'
 
 type WalletImageProps = {
@@ -48,7 +38,7 @@ export const WalletButton: FC<FlexProps> = () => {
       rightIcon={<ChevronRightIcon h={6} w={6} />}
       mr={6}
     >
-      Connect Wallet
+      <Text translation={'connectWallet.menu.triggerButton'} />
     </Button>
   ) : (
     <Menu gutter={4}>
@@ -81,17 +71,6 @@ export const WalletButton: FC<FlexProps> = () => {
             >
               {walletInfo?.name}
             </Button>
-            <HStack ml={4}>
-              <Tooltip label='Send'>
-                <IconButton size='sm' icon={<ArrowUpIcon />} aria-label='Send' isRound />
-              </Tooltip>
-              <Tooltip label='Receive'>
-                <IconButton size='sm' icon={<ArrowDownIcon />} aria-label='Receive' isRound />
-              </Tooltip>
-              <Tooltip label='Copy Address'>
-                <IconButton size='sm' icon={<CopyIcon />} aria-label='Copy Address' isRound />
-              </Tooltip>
-            </HStack>
           </Box>
         </MenuGroup>
         <MenuDivider />
@@ -103,7 +82,7 @@ export const WalletButton: FC<FlexProps> = () => {
           }
           onClick={() => dispatch({ type: WalletActions.SET_WALLET_MODAL, payload: true })}
         >
-          Switch Wallet Provider
+          <Text translation={'connectWallet.menu.switchWallet'} />
         </MenuItem>
         <MenuItem
           icon={
@@ -113,7 +92,7 @@ export const WalletButton: FC<FlexProps> = () => {
           }
           onClick={disconnect}
         >
-          Disconnect
+          <Text translation={'connectWallet.menu.disconnect'} />
         </MenuItem>
       </MenuList>
     </Menu>

--- a/src/context/WalletProvider/WalletViewsSwitch.tsx
+++ b/src/context/WalletProvider/WalletViewsSwitch.tsx
@@ -31,6 +31,11 @@ export const WalletViewsSwitch = () => {
   const handleBack = () => {
     history.goBack()
     dispatch({ type: WalletActions.SET_WALLET_MODAL, payload: true })
+    // If we're back at the select wallet modal, remove the initial route
+    // otherwise clicking the button for the same wallet doesn't do anything
+    if (history.location.pathname === '/') {
+      dispatch({ type: WalletActions.SET_INITIAL_ROUTE, payload: '' })
+    }
   }
 
   useEffect(() => {


### PR DESCRIPTION
## Description

Fixes the state management issue that was preventing the "Connect Wallet" modal from allowing a user to go back and pick the same wallet again from the list.

Fixed missing transactions in Connect Wallet menu

Removed non-functional placeholder icons in the Connect Wallet menu

## Notice

Before submitting a pull request, please make sure you have answered the following:

- [x] Have you followed the guidelines in our [Contributing]('https://github.com/shapeshift/web/CONTRIBUTING.md) guide?
- [x] Have you checked to ensure there aren't other open [Pull Requests](https://github.com/shapeshift/web/pulls) for the same update/change?
- [x] Do all new and existing tests pass? Does the linter pass?

## Pull Request Type

- [X] :bug: Bug fix (Non-breaking Change: Fixes an issue)
- [x] :hammer_and_wrench: Chore (Non-breaking Change: Doc updates, pkg upgrades, typos, etc..)
- [ ] :nail_care: New Feature (Breaking/Non-breaking Change)

## Issue (if applicable)

closes #112

## Testing

Please outline all testing steps

1. Click Connect Wallet
2. Click ShapeShift
3. Enter a password
4. Click Back twice
5. At the Select Wallet modal, select ShapeShift again.

If fixed, you go to the password screen. If not fixed, nothing happens.
