### PR TITLE
fix: keep the route when we redirect to connect wallet

### DIFF
--- a/sample.env
+++ b/sample.env
@@ -12,3 +12,4 @@ REACT_APP_UNCHAINED_BITCOIN_HTTP_URL=https://dev-api.bitcoin.shapeshift.com
 REACT_APP_UNCHAINED_BITCOIN_WS_URL=wss://dev-api.bitcoin.shapeshift.com
 REACT_APP_PORTIS_DAPP_ID=<get dapp ID from someone>
 REACT_APP_ETHEREUM_NODE_URL="<get free key from infura or other provider>"
+REACT_APP_HIDE_SPLASH=false

--- a/src/Routes/PrivateRoute.tsx
+++ b/src/Routes/PrivateRoute.tsx
@@ -1,12 +1,16 @@
+import { getConfig } from 'config'
 import { Redirect, Route, RouteProps } from 'react-router-dom'
 
 type PrivateRouteProps = {
   isConnected: boolean
 } & RouteProps
 
+const HIDE_SPLASH = getConfig().REACT_APP_HIDE_SPLASH
+
 export const PrivateRoute = ({ isConnected, ...rest }: PrivateRouteProps) => {
   const { location } = rest
-  return isConnected || process.env.NODE_ENV !== 'production' ? (
+
+  return isConnected || HIDE_SPLASH ? (
     <Route {...rest} />
   ) : (
     <Redirect

--- a/src/Routes/PrivateRoute.tsx
+++ b/src/Routes/PrivateRoute.tsx
@@ -5,5 +5,15 @@ type PrivateRouteProps = {
 } & RouteProps
 
 export const PrivateRoute = ({ isConnected, ...rest }: PrivateRouteProps) => {
-  return isConnected ? <Route {...rest} /> : <Redirect to='/connect-wallet' />
+  const { location } = rest
+  return isConnected ? (
+    <Route {...rest} />
+  ) : (
+    <Redirect
+      to={{
+        pathname: '/connect-wallet',
+        search: `returnUrl=${location?.pathname ?? '/dashboard'}`
+      }}
+    />
+  )
 }

--- a/src/Routes/PrivateRoute.tsx
+++ b/src/Routes/PrivateRoute.tsx
@@ -6,7 +6,7 @@ type PrivateRouteProps = {
 
 export const PrivateRoute = ({ isConnected, ...rest }: PrivateRouteProps) => {
   const { location } = rest
-  return isConnected ? (
+  return isConnected || process.env.NODE_ENV !== 'production' ? (
     <Route {...rest} />
   ) : (
     <Redirect

--- a/src/config.ts
+++ b/src/config.ts
@@ -1,4 +1,5 @@
 import * as envalid from 'envalid'
+import { bool } from 'envalid'
 
 const { cleanEnv, str, url } = envalid
 
@@ -10,7 +11,8 @@ const validators = {
   REACT_APP_UNCHAINED_BITCOIN_HTTP_URL: url(),
   REACT_APP_UNCHAINED_BITCOIN_WS_URL: url(),
   REACT_APP_ETHEREUM_NODE_URL: url(),
-  REACT_APP_PORTIS_DAPP_ID: str()
+  REACT_APP_PORTIS_DAPP_ID: str(),
+  REACT_APP_HIDE_SPLASH: bool()
 }
 
 function reporter<T>({ errors }: envalid.ReporterOptions<T>) {

--- a/src/pages/ConnectWallet/ConnectWallet.tsx
+++ b/src/pages/ConnectWallet/ConnectWallet.tsx
@@ -10,6 +10,7 @@ import { FoxIcon } from 'components/Icons/FoxIcon'
 import { Page } from 'components/Layout/Page'
 import { RawText, Text } from 'components/Text'
 import { ActionTypes, WalletActions } from 'context/WalletProvider/WalletProvider'
+import { useQuery } from 'hooks/useQuery/useQuery'
 import { colors } from 'theme/colors'
 
 type NoWalletProps = {
@@ -20,9 +21,10 @@ type NoWalletProps = {
 export const ConnectWallet = ({ dispatch, isConnected }: NoWalletProps) => {
   const history = useHistory()
   const translate = useTranslate()
+  const query = useQuery<{ returnUrl: string }>()
   useEffect(() => {
-    isConnected && history.push('/dashboard')
-  }, [history, isConnected])
+    isConnected && history.push(query?.returnUrl ? query.returnUrl : '/dashboard')
+  }, [history, isConnected, query.returnUrl])
   return (
     <Page>
       <Flex


### PR DESCRIPTION
## Description

Retain the route the user was trying to navigate to as a query param so if they refresh/connect a wallet we can take them to the correct page.

## Notice

Before submitting a pull request, please make sure you have answered the following:

- [ ] Have you followed the guidelines in our [Contributing]('https://github.com/shapeshift/web/CONTRIBUTING.md) guide?
- [ ] Have you checked to ensure there aren't other open [Pull Requests](https://github.com/shapeshift/web/pulls) for the same update/change?
- [ ] Do all new and existing tests pass? Does the linter pass?

## Pull Request Type

- [x] :bug: Bug fix (Non-breaking Change: Fixes an issue)
- [ ] :hammer_and_wrench: Chore (Non-breaking Change: Doc updates, pkg upgrades, typos, etc..)
- [ ] :nail_care: New Feature (Breaking/Non-breaking Change)

## Issue (if applicable)

closed #353 

## Testing

Please outline all testing steps

1. Pull branch locally and run `yarn` to install new deps
2. etc...

## Screenshots (if applicable)
