### PR TITLE
fix: make password modal work with password managers

### DIFF
--- a/src/context/WalletProvider/NativeWallet/components/NativePassword.tsx
+++ b/src/context/WalletProvider/NativeWallet/components/NativePassword.tsx
@@ -49,6 +49,7 @@ export const NativePassword = ({ history }: RouteComponentProps) => {
                 pr='4.5rem'
                 type={showPw ? 'text' : 'password'}
                 placeholder='Enter password'
+                id='password'
               />
               <InputRightElement>
                 <IconButton

--- a/src/context/WalletProvider/NativeWallet/components/NativePasswordRequired.tsx
+++ b/src/context/WalletProvider/NativeWallet/components/NativePasswordRequired.tsx
@@ -150,6 +150,7 @@ export const NativePasswordRequired = ({
                   pr='4.5rem'
                   type={showPw ? 'text' : 'password'}
                   placeholder='Enter password'
+                  id='password'
                 />
                 <InputRightElement>
                   <IconButton


### PR DESCRIPTION
## Description

Autogenerated input field id does not work with some password managers.
Force a proper _password_ id for the password field.

## Notice

Before submitting a pull request, please make sure you have answered the following:

- [x] Have you followed the guidelines in our [Contributing]('https://github.com/shapeshift/web/CONTRIBUTING.md) guide?
- [x] Have you checked to ensure there aren't other open [Pull Requests](https://github.com/shapeshift/web/pulls) for the same update/change?
- [x] Do all new and existing tests pass? Does the linter pass?

## Pull Request Type

- [x] :bug: Bug fix (Non-breaking Change: Fixes an issue)
- [ ] :hammer_and_wrench: Chore (Non-breaking Change: Doc updates, pkg upgrades, typos, etc..)
- [ ] :nail_care: New Feature (Breaking/Non-breaking Change)

## Issue (if applicable)

closes #344 

## Testing

I tested with `Bitwarden` and it works.
According to the documentation it should also work with `1password` and `lastpass`.