### PR TITLE
fix: normalize xpubs so blockbook generates correct addresses

### DIFF
--- a/package.json
+++ b/package.json
@@ -127,6 +127,7 @@
     "@testing-library/react-hooks": "^7.0.1",
     "@testing-library/user-event": "^13.2.1",
     "@types/bignumber.js": "^5.0.0",
+    "@types/bs58check": "^2.1.0",
     "@types/crypto-js": "^4.0.2",
     "@types/d3-array": "^3.0.1",
     "@types/d3-time-format": "^4.0.0",

--- a/src/hooks/useBalances/useBalances.tsx
+++ b/src/hooks/useBalances/useBalances.tsx
@@ -1,12 +1,15 @@
 import { toRootDerivationPath, utxoAccountParams } from '@shapeshiftoss/chain-adapters'
 import { bip32ToAddressNList } from '@shapeshiftoss/hdwallet-core'
 import { chainAdapters, ChainTypes, NetworkTypes } from '@shapeshiftoss/types'
+import { UtxoAccountType } from '@shapeshiftoss/types'
 import { useCallback, useEffect, useState } from 'react'
 import { useSelector } from 'react-redux'
 import { useChainAdapters } from 'context/ChainAdaptersProvider/ChainAdaptersProvider'
 import { useWallet } from 'context/WalletProvider/WalletProvider'
 import { getAssetService } from 'lib/assetService'
 import { ReduxState } from 'state/reducer'
+
+import { normalizeXpub } from '../../lib/xpubs'
 
 type UseBalancesReturnType = {
   balances: Record<string, chainAdapters.Account<ChainTypes>>
@@ -44,9 +47,10 @@ export const useBalances = (): UseBalancesReturnType => {
         if (adapter.getType() === 'ethereum') {
           addressOrXpub = await adapter.getAddress({ wallet })
         } else if (adapter.getType() === 'bitcoin') {
-          const accountType = accountTypes[key]
+          const accountType: UtxoAccountType = accountTypes[key]
           const accountParams = utxoAccountParams(asset, accountType, 0)
           const { bip32Params, scriptType } = accountParams
+          debugger
           const pubkeys = await wallet.getPublicKeys([
             {
               coin: adapter.getType(),
@@ -57,6 +61,8 @@ export const useBalances = (): UseBalancesReturnType => {
           ])
           if (!pubkeys || !pubkeys[0]) throw new Error('Error getting public key')
           addressOrXpub = pubkeys[0].xpub
+
+          normalizeXpub(addressOrXpub, accountType)
         } else {
           throw new Error('not implemented')
         }

--- a/src/lib/xpubs.test.ts
+++ b/src/lib/xpubs.test.ts
@@ -1,0 +1,31 @@
+import { UtxoAccountType } from '@shapeshiftoss/types'
+
+import { normalizeXpub } from './xpubs'
+
+const xpub =
+  'xpub6GPVbpBHJMUEK8BzF4ntoP1mdtpMgXJhNSfRQew9vMLLzHB9JyRfj5C5wmqyoRfRQiRL7V7GJkqKEnDEXn1cTBnodPyBW69ao498pg6stm6'
+const ypub =
+  'ypub6bDkuUrCT31iARP75RaX1U7Gorxod9JCHZBeC3q3JMiE3NzNZdbEM8rDxyoZoLKLpMY8rxhpmRBs84poFURdFRUQVjfc5zy54nCnDGGhnDa'
+const zpub =
+  'zpub6v42D9X7biZC1iaDunN9DZCmyq7FZmHhCfhrySivgN676UobpHknyCWMzBm9oEyGDzewcSJPE5YR1MSMyAqe3fA1N5N2funZLWGRbsRjA1s'
+
+describe('xpubs', () => {
+  describe('normalizeXpub', () => {
+    it.each([
+      [xpub, UtxoAccountType.P2pkh, xpub],
+      [xpub, UtxoAccountType.SegwitP2sh, ypub],
+      [xpub, UtxoAccountType.SegwitNative, zpub],
+      [ypub, UtxoAccountType.P2pkh, xpub],
+      [ypub, UtxoAccountType.SegwitP2sh, ypub],
+      [ypub, UtxoAccountType.SegwitNative, zpub],
+      [zpub, UtxoAccountType.P2pkh, xpub],
+      [zpub, UtxoAccountType.SegwitP2sh, ypub],
+      [zpub, UtxoAccountType.SegwitNative, zpub]
+    ])(
+      'should convert %s to %s',
+      async (input: string, type: UtxoAccountType, expected: string) => {
+        expect(normalizeXpub(input, type)).toBe(expected)
+      }
+    )
+  })
+})

--- a/src/lib/xpubs.ts
+++ b/src/lib/xpubs.ts
@@ -1,0 +1,45 @@
+/*
+ @see https://github.com/blockkeeper/blockkeeper-frontend-web/issues/38
+ */
+import { UtxoAccountType } from '@shapeshiftoss/types'
+import { decode, encode } from 'bs58check'
+
+/* ypub and zpub are not standard, it is an extension of the bip32 created by Trezor team
+ * and adopted by the community. Currently, it has a pretty wide support in multiple wallets
+ * including electrum. The only difference comparing to xpub is a prefix, but as it is
+ * a base58 encoded string with a checksum, checksum is also different
+ *
+ * The easiest way to fix it is to decode from base58check, replace the prefix to
+ * standard xpub or tpub and then to encode back to base58check. Then one can use this xpub
+ * as normal bip32 master key.
+ *
+ * It may make sense to remember the type of the public key as it tells what type of script
+ * is used in the wallet.
+ *
+ */
+
+enum PublicKeyType {
+  // mainnet
+  xpub = '0488b21e', // xpub
+  ypub = '049d7cb2', // ypub
+  zpub = '04b24746', // zpub
+  Ypub = '0295b43f', // Ypub
+  Zpub = '02aa7ed3' // Zpub
+}
+
+const accountTypeToVersion = {
+  [UtxoAccountType.P2pkh]: Buffer.from(PublicKeyType.xpub, 'hex'),
+  [UtxoAccountType.SegwitP2sh]: Buffer.from(PublicKeyType.ypub, 'hex'),
+  [UtxoAccountType.SegwitNative]: Buffer.from(PublicKeyType.zpub, 'hex')
+}
+
+export function normalizeXpub(xpub: string, accountType: UtxoAccountType) {
+  const payload = decode(xpub)
+  const version = payload.slice(0, 4)
+  if (version.compare(accountTypeToVersion[accountType]) !== 0) {
+    // Get the key without the version code at the front
+    const key = payload.slice(4)
+    return encode(Buffer.concat([accountTypeToVersion[accountType], key]))
+  }
+  return xpub
+}

--- a/yarn.lock
+++ b/yarn.lock
@@ -4961,6 +4961,13 @@
   resolved "https://registry.yarnpkg.com/@types/braces/-/braces-3.0.1.tgz#5a284d193cfc61abb2e5a50d36ebbc50d942a32b"
   integrity sha512-+euflG6ygo4bn0JHtn4pYqcXwRtLvElQ7/nnjDu7iYG56H0+OhCd7d6Ug0IE3WcFpZozBKW2+80FUbv5QGk5AQ==
 
+"@types/bs58check@^2.1.0":
+  version "2.1.0"
+  resolved "https://registry.yarnpkg.com/@types/bs58check/-/bs58check-2.1.0.tgz#7d25a8b88fe7a9e315d2647335ee3c43c8fdb0c0"
+  integrity sha512-OxsysnJQh82vy9DRbOcw9m2j/WiyqZLn0YBhKxdQ+aCwoHj+tWzyCgpwAkr79IfDXZKxc6h7k89T9pwS78CqTQ==
+  dependencies:
+    "@types/node" "*"
+
 "@types/color-convert@^2.0.0":
   version "2.0.0"
   resolved "https://registry.yarnpkg.com/@types/color-convert/-/color-convert-2.0.0.tgz#8f5ee6b9e863dcbee5703f5a517ffb13d3ea4e22"


### PR DESCRIPTION
## Description

Portis always returns an 'xpub' public key regardless of the account type. This will normalize the xpub to a ypub or zpub because that's how blockbook determines the account type for generating addresses.

## Notice

Before submitting a pull request, please make sure you have answered the following:

- [x] Have you followed the guidelines in our [Contributing]('https://github.com/shapeshift/web/CONTRIBUTING.md) guide?
- [x] Have you checked to ensure there aren't other open [Pull Requests](https://github.com/shapeshift/web/pulls) for the same update/change?
- [x] Do all new and existing tests pass? Does the linter pass?

## Pull Request Type

- [x] :bug: Bug fix (Non-breaking Change: Fixes an issue)
- [ ] :hammer_and_wrench: Chore (Non-breaking Change: Doc updates, pkg upgrades, typos, etc..)
- [ ] :nail_care: New Feature (Breaking/Non-breaking Change)

## Issue (if applicable)

Issue was reported in Discord but no ticket was made.

## Testing

Please outline all testing steps

1. Connect a Portis wallet that has a BTC balance
