### PR TITLE
fix: make HIDE_SPLASH have a default value of false

### DIFF
--- a/src/config.ts
+++ b/src/config.ts
@@ -12,7 +12,7 @@ const validators = {
   REACT_APP_UNCHAINED_BITCOIN_WS_URL: url(),
   REACT_APP_ETHEREUM_NODE_URL: url(),
   REACT_APP_PORTIS_DAPP_ID: str(),
-  REACT_APP_HIDE_SPLASH: bool()
+  REACT_APP_HIDE_SPLASH: bool({ default: false })
 }
 
 function reporter<T>({ errors }: envalid.ReporterOptions<T>) {


### PR DESCRIPTION
## Description

Make the HIDE_SPLASH environment variable have a default value of `false`. Without this, vercel crashes for not having the correct environment variables.

## Notice

Before submitting a pull request, please make sure you have answered the following:

- [X] Have you followed the guidelines in our [Contributing]('https://github.com/shapeshift/web/CONTRIBUTING.md) guide?
- [X] Have you checked to ensure there aren't other open [Pull Requests](https://github.com/shapeshift/web/pulls) for the same update/change?
- [X] Do all new and existing tests pass? Does the linter pass?

## Pull Request Type

- [X] :bug: Bug fix (Non-breaking Change: Fixes an issue)
- [ ] :hammer_and_wrench: Chore (Non-breaking Change: Doc updates, pkg upgrades, typos, etc..)
- [ ] :nail_care: New Feature (Breaking/Non-breaking Change)
