### PR TITLE
fix: connect a wallet modal state issue after closing

### DIFF
--- a/src/context/WalletProvider/WalletProvider.tsx
+++ b/src/context/WalletProvider/WalletProvider.tsx
@@ -98,7 +98,13 @@ const reducer = (state: InitialState, action: ActionTypes) => {
     case WalletActions.SET_INITIAL_ROUTE:
       return { ...state, initialRoute: action.payload }
     case WalletActions.SET_WALLET_MODAL:
-      return { ...state, modal: action.payload }
+      const newState = { ...state, modal: action.payload }
+      // If we're closing the modal, then we need to forget the route we were on
+      // Otherwise the connect button for last wallet we clicked on won't work
+      if (!action.payload) {
+        newState.initialRoute = null
+      }
+      return newState
     case WalletActions.RESET_STATE:
       return {
         ...state,


### PR DESCRIPTION
## Description

When closing the modal, the 'initialRoute' value wouldn't change, so when you open the modal again, clicking a button for the same wallet wouldn't change the state value so the useEffect hook wouldn't fire and show the expected component

## Notice

Before submitting a pull request, please make sure you have answered the following:

- [X] Have you followed the guidelines in our [Contributing]('https://github.com/shapeshift/web/CONTRIBUTING.md) guide?
- [X] Have you checked to ensure there aren't other open [Pull Requests](https://github.com/shapeshift/web/pulls) for the same update/change?
- [X] Do all new and existing tests pass? Does the linter pass?

## Pull Request Type

- [X] :bug: Bug fix (Non-breaking Change: Fixes an issue)
- [ ] :hammer_and_wrench: Chore (Non-breaking Change: Doc updates, pkg upgrades, typos, etc..)
- [ ] :nail_care: New Feature (Breaking/Non-breaking Change)

## Issue

closes #387 