### PR TITLE
fix: fix trade max button rounding issue

### DIFF
--- a/src/lib/math.ts
+++ b/src/lib/math.ts
@@ -8,7 +8,10 @@ export const fromBaseUnit = (
   decimals: number,
   displayDecimals = 6
 ): string => {
-  return bnOrZero(value).div(`1e+${decimals}`).decimalPlaces(displayDecimals).toString()
+  return bnOrZero(value)
+    .div(`1e+${decimals}`)
+    .decimalPlaces(displayDecimals, BigNumber.ROUND_DOWN)
+    .toString()
 }
 
 export const toBaseUnit = (amount: BigNumber.Value | undefined, precision: number): string => {


### PR DESCRIPTION
## Description

- Add rounding down to `fromBaseUnit` by default. This fixes an issue with send max rounding the values up and failing because the amount is greater than the balance.

## Notice

Before submitting a pull request, please make sure you have answered the following:

- [x] Have you followed the guidelines in our [Contributing]('https://github.com/shapeshift/web/CONTRIBUTING.md) guide?
- [x] Have you checked to ensure there aren't other open [Pull Requests](https://github.com/shapeshift/web/pulls) for the same update/change?
- [x] Do all new and existing tests pass? Does the linter pass?

## Pull Request Type

- [x] :bug: Bug fix (Non-breaking Change: Fixes an issue)
- [ ] :hammer_and_wrench: Chore (Non-breaking Change: Doc updates, pkg upgrades, typos, etc..)
- [ ] :nail_care: New Feature (Breaking/Non-breaking Change)

## Issue (if applicable)

If applicable, please link to the github issue and put `closes #XXXX` in your comment to auto-close the issue that your PR fixes.

## Testing

Please outline all testing steps

1. Pull branch locally and run `yarn` to install new deps
2. etc...

## Screenshots (if applicable)
