### PR TITLE
fix: translations, bitcoin/metamask

### DIFF
--- a/src/context/WalletProvider/KeepKey/components/Success.tsx
+++ b/src/context/WalletProvider/KeepKey/components/Success.tsx
@@ -18,10 +18,10 @@ export const KeepKeySuccess = () => {
         <Text
           fontSize='lg'
           fontWeight='bold'
-          translation={'walletProvider.shapeShift.nativeSuccess.header'}
+          translation={'walletProvider.shapeShift.success.success'}
         />
         {isSuccessful && (
-          <Text color='gray.500' translation={'walletProvider.shapeShift.nativeSuccess.success'} />
+          <Text color='gray.500' translation={'walletProvider.shapeShift.success.success'} />
         )}
       </ModalBody>
     </>

--- a/src/context/WalletProvider/MetaMask/components/Success.tsx
+++ b/src/context/WalletProvider/MetaMask/components/Success.tsx
@@ -3,8 +3,8 @@ import { SuccessModal } from 'context/WalletProvider/components/SuccessModal'
 export const MetaMaskSuccess = () => {
   return (
     <SuccessModal
-      headerText={'walletProvider.shapeShift.nativeSuccess.header'}
-      bodyText={'walletProvider.shapeShift.nativeSuccess.success'}
+      headerText={'walletProvider.shapeShift.success.header'}
+      bodyText={'walletProvider.shapeShift.success.success'}
     ></SuccessModal>
   )
 }

--- a/src/context/WalletProvider/Portis/components/Success.tsx
+++ b/src/context/WalletProvider/Portis/components/Success.tsx
@@ -3,8 +3,8 @@ import { SuccessModal } from 'context/WalletProvider/components/SuccessModal'
 export const PortisSuccess = () => {
   return (
     <SuccessModal
-      headerText={'walletProvider.shapeShift.nativeSuccess.header'}
-      bodyText={'walletProvider.shapeShift.nativeSuccess.success'}
+      headerText={'walletProvider.shapeShift.success.success'}
+      bodyText={'walletProvider.shapeShift.success.success'}
     ></SuccessModal>
   )
 }

--- a/src/hooks/useBalanceChartData/useBalanceChartData.ts
+++ b/src/hooks/useBalanceChartData/useBalanceChartData.ts
@@ -84,7 +84,9 @@ export const makeBuckets: MakeBuckets = args => {
 
   // current asset balances, we iterate over this later and adjust on each tx
   const assetBalances = assets.reduce<CryptoBalance>((acc, cur) => {
-    acc[cur] = Number(balances[cur].balance)
+    const account = balances[cur]
+    if (!account) return acc // we don't have a balance for this asset, e.g. metamask bitcoin
+    acc[cur] = Number(account.balance)
     return acc
   }, {})
 

--- a/src/hooks/useBalanceChartData/useBalanceChartData.ts
+++ b/src/hooks/useBalanceChartData/useBalanceChartData.ts
@@ -298,7 +298,7 @@ export const useBalanceChartData: UseBalanceChartData = args => {
   const { data: priceHistoryData, loading: priceHistoryLoading } = usePriceHistory(args)
 
   useEffect(() => {
-    if (!isNil(walletInfo?.deviceId)) return
+    if (isNil(walletInfo?.deviceId)) return
     if (priceHistoryLoading) return
     if (caip19BalancesLoading) return
     if (portfolioAssetsLoading) return

--- a/src/hooks/useBalanceChartData/useBalanceChartData.ts
+++ b/src/hooks/useBalanceChartData/useBalanceChartData.ts
@@ -13,6 +13,7 @@ import dayjs from 'dayjs'
 import fill from 'lodash/fill'
 import head from 'lodash/head'
 import isEmpty from 'lodash/isEmpty'
+import isNil from 'lodash/isNil'
 import reduce from 'lodash/reduce'
 import reverse from 'lodash/reverse'
 import { useEffect, useState } from 'react'
@@ -297,7 +298,7 @@ export const useBalanceChartData: UseBalanceChartData = args => {
   const { data: priceHistoryData, loading: priceHistoryLoading } = usePriceHistory(args)
 
   useEffect(() => {
-    if (!walletInfo?.deviceId) return
+    if (!isNil(walletInfo?.deviceId)) return
     if (priceHistoryLoading) return
     if (caip19BalancesLoading) return
     if (portfolioAssetsLoading) return

--- a/src/hooks/useWalletSupportsChain/useWalletSupportsChain.ts
+++ b/src/hooks/useWalletSupportsChain/useWalletSupportsChain.ts
@@ -5,6 +5,8 @@ import { Asset, ChainTypes, NetworkTypes } from '@shapeshiftoss/types'
 type UseWalletSupportsChainArgs = { asset: Asset; wallet: HDWallet | null }
 type UseWalletSupportsChain = (args: UseWalletSupportsChainArgs) => boolean
 
+// this whole thing should belong in chain adapters/future wallet SDK
+// it should also just accept a caip19 and a wallet
 export const useWalletSupportsChain: UseWalletSupportsChain = ({ asset, wallet }) => {
   if (!wallet) return false
   const ethCAIP2 = caip2.toCAIP2({ chain: ChainTypes.Ethereum, network: NetworkTypes.MAINNET })

--- a/src/hooks/useWalletSupportsChain/useWalletSupportsChain.ts
+++ b/src/hooks/useWalletSupportsChain/useWalletSupportsChain.ts
@@ -1,0 +1,25 @@
+import { caip2 } from '@shapeshiftoss/caip'
+import { HDWallet, supportsBTC, supportsETH } from '@shapeshiftoss/hdwallet-core'
+import { Asset, ChainTypes, NetworkTypes } from '@shapeshiftoss/types'
+
+type UseWalletSupportsChainArgs = { asset: Asset; wallet: HDWallet | null }
+type UseWalletSupportsChain = (args: UseWalletSupportsChainArgs) => boolean
+
+export const useWalletSupportsChain: UseWalletSupportsChain = ({ asset, wallet }) => {
+  if (!wallet) return false
+  const ethCAIP2 = caip2.toCAIP2({ chain: ChainTypes.Ethereum, network: NetworkTypes.MAINNET })
+  const btcCAIP2 = caip2.toCAIP2({ chain: ChainTypes.Bitcoin, network: NetworkTypes.MAINNET })
+  const assetCAIP2 = caip2.toCAIP2({ chain: asset.chain, network: asset.network })
+  switch (assetCAIP2) {
+    case ethCAIP2: {
+      return supportsETH(wallet)
+    }
+    case btcCAIP2: {
+      return supportsBTC(wallet)
+    }
+    default: {
+      console.error(`useWalletSupportsChain: unknown caip2 ${assetCAIP2}`)
+      return false
+    }
+  }
+}

--- a/src/pages/Assets/AssetDetails/AssetHeader/AssetHeader.tsx
+++ b/src/pages/Assets/AssetDetails/AssetHeader/AssetHeader.tsx
@@ -24,8 +24,10 @@ import { Graph } from 'components/Graph/Graph'
 import { TimeControls } from 'components/Graph/TimeControls'
 import { SanitizedHtml } from 'components/SanitizedHtml/SanitizedHtml'
 import { RawText, Text } from 'components/Text'
+import { useWallet } from 'context/WalletProvider/WalletProvider'
 import { useBalanceChartData } from 'hooks/useBalanceChartData/useBalanceChartData'
 import { useFlattenedBalances } from 'hooks/useBalances/useFlattenedBalances'
+import { useWalletSupportsChain } from 'hooks/useWalletSupportsChain/useWalletSupportsChain'
 import { fromBaseUnit } from 'lib/math'
 import { useAsset } from 'pages/Assets/Asset'
 import { usePercentChange } from 'pages/Assets/hooks/usePercentChange/usePercentChange'
@@ -57,6 +59,13 @@ export const AssetHeader = ({ isLoaded }: { isLoaded: boolean }) => {
     assets,
     timeframe
   })
+  const {
+    state: { wallet }
+  } = useWallet()
+  wallet?.getFeatures()
+
+  const walletSupportsChain = useWalletSupportsChain({ asset, wallet })
+
   const assetPriceHistoryData = useMemo(() => {
     if (isEmpty(priceHistoryData[asset?.caip19])) return []
     return priceHistoryData[asset.caip19].map(({ price, date }) => ({
@@ -64,6 +73,7 @@ export const AssetHeader = ({ isLoaded }: { isLoaded: boolean }) => {
       date: new Date(Number(date)).toISOString()
     }))
   }, [priceHistoryData, asset])
+
   const graphPercentChange = usePercentChange({
     data: assetPriceHistoryData,
     initPercentChange: percentChange
@@ -99,14 +109,19 @@ export const AssetHeader = ({ isLoaded }: { isLoaded: boolean }) => {
             </Skeleton>
           </Box>
         </Flex>
-        <AssetActions isLoaded={isLoaded} />
+        {walletSupportsChain ? <AssetActions isLoaded={isLoaded} /> : null}
       </Card.Header>
-      <SegwitSelectCard chain={asset.chain} />
+      {walletSupportsChain ? <SegwitSelectCard chain={asset.chain} /> : null}
       <Card.Body>
         <Box>
           <Flex justifyContent='space-between' width='full' flexDir={{ base: 'column', md: 'row' }}>
             <Skeleton isLoaded={isLoaded}>
-              <ButtonGroup size='sm' colorScheme='blue' variant='ghost'>
+              <ButtonGroup
+                hidden={!walletSupportsChain}
+                size='sm'
+                colorScheme='blue'
+                variant='ghost'
+              >
                 <Button isActive={view === Views.Balance} onClick={() => setView(Views.Balance)}>
                   <Text translation='assets.assetDetails.assetHeader.balance' />
                 </Button>

--- a/src/pages/Assets/AssetDetails/AssetHeader/AssetHeader.tsx
+++ b/src/pages/Assets/AssetDetails/AssetHeader/AssetHeader.tsx
@@ -62,7 +62,6 @@ export const AssetHeader = ({ isLoaded }: { isLoaded: boolean }) => {
   const {
     state: { wallet }
   } = useWallet()
-  wallet?.getFeatures()
 
   const walletSupportsChain = useWalletSupportsChain({ asset, wallet })
 

--- a/src/pages/Assets/AssetDetails/AssetHistory.tsx
+++ b/src/pages/Assets/AssetDetails/AssetHistory.tsx
@@ -5,6 +5,8 @@ import { useSelector } from 'react-redux'
 import { Card } from 'components/Card/Card'
 import { CircularProgress } from 'components/CircularProgress/CircularProgress'
 import { TransactionRow } from 'components/Transactions/TransactionRow'
+import { useWallet } from 'context/WalletProvider/WalletProvider'
+import { useWalletSupportsChain } from 'hooks/useWalletSupportsChain/useWalletSupportsChain'
 import { ReduxState } from 'state/reducer'
 import { selectTxHistory, Tx } from 'state/slices/txHistorySlice/txHistorySlice'
 
@@ -14,6 +16,13 @@ import { useInfiniteScroll } from '../hooks/useInfiniteScroll/useInfiniteScroll'
 export const AssetHistory = () => {
   const translate = useTranslate()
   const { asset } = useAsset()
+
+  const {
+    state: { wallet }
+  } = useWallet()
+  wallet?.getFeatures()
+
+  const walletSupportsChain = useWalletSupportsChain({ asset, wallet })
   const accountType = useSelector(
     (state: ReduxState) => state.preferences.accountTypes[asset.chain]
   )
@@ -25,6 +34,8 @@ export const AssetHistory = () => {
   )
 
   const { next, data, hasMore } = useInfiniteScroll(txs)
+
+  if (!walletSupportsChain) return null
 
   return (
     <Card>


### PR DESCRIPTION
- fix: translations on wallet pairing
- fix: add wallet to useBalanceChartData effect to fetch assets and market data on wallet switch
- fix: no white screen of death for metamask on bitcoin
- feat: useWalletsSupportsChain hook, hide send/receive, account type buttons, and tx history on bitcoin if metamask or other non btc wallet connected
