### PR TITLE
fix: correctly pair a ss wallet if it's already initialized

### DIFF
--- a/src/context/WalletProvider/NativeWallet/components/NativeLoad.tsx
+++ b/src/context/WalletProvider/NativeWallet/components/NativeLoad.tsx
@@ -15,7 +15,7 @@ import { useEffect, useState } from 'react'
 import { RawText, Text } from 'components/Text'
 import { useWallet, WalletActions } from 'context/WalletProvider/WalletProvider'
 
-import { KeyManager } from '../../config'
+import { KeyManager, SUPPORTED_WALLETS } from '../../config'
 
 type VaultInfo = {
   id: string
@@ -55,10 +55,24 @@ export const NativeLoad = () => {
 
   const handleWalletSelect = async (item: VaultInfo) => {
     const adapter = state.adapters?.get(KeyManager.Native)
+    const deviceId = item.id
     if (adapter) {
+      const { name, icon } = SUPPORTED_WALLETS[KeyManager.Native]
       try {
-        const wallet = await adapter.pairDevice(item.id)
-        await wallet.initialize()
+        const wallet = await adapter.pairDevice(deviceId)
+        if (!(await wallet.isInitialized())) {
+          // This will trigger the password modal and the modal will set the wallet on state
+          // after the wallet has been decrypted. If we set it now, `getPublicKeys` calls will
+          // return null, and we don't have a retry mechanism
+          await wallet.initialize()
+        } else {
+          dispatch({
+            type: WalletActions.SET_WALLET,
+            payload: { wallet, name, icon, deviceId }
+          })
+          dispatch({ type: WalletActions.SET_IS_CONNECTED, payload: true })
+        }
+        // Always close the modal after trying to pair the wallet
         dispatch({ type: WalletActions.SET_WALLET_MODAL, payload: false })
       } catch (e) {
         setError('walletProvider.shapeShift.load.error.pair')


### PR DESCRIPTION
## Description

fix: correctly pair a ShapeShift wallet if it's already initialized (unlocked, decrypted)

## Notice

Before submitting a pull request, please make sure you have answered the following:

- [x] Have you followed the guidelines in our [Contributing]('https://github.com/shapeshift/web/CONTRIBUTING.md) guide?
- [x] Have you checked to ensure there aren't other open [Pull Requests](https://github.com/shapeshift/web/pulls) for the same update/change?
- [x] Do all new and existing tests pass? Does the linter pass?

## Pull Request Type

- [X] :bug: Bug fix (Non-breaking Change: Fixes an issue)
- [ ] :hammer_and_wrench: Chore (Non-breaking Change: Doc updates, pkg upgrades, typos, etc..)
- [ ] :nail_care: New Feature (Breaking/Non-breaking Change)
