### PR TITLE
fix: fixed bug where token precision differed with chain asset precision

### DIFF
--- a/src/components/Modals/Send/hooks/useSendFees/useSendFees.test.tsx
+++ b/src/components/Modals/Send/hooks/useSendFees/useSendFees.test.tsx
@@ -4,6 +4,7 @@ import { act, renderHook } from '@testing-library/react-hooks'
 import { useFormContext, useWatch } from 'react-hook-form'
 import { useWallet } from 'context/WalletProvider/WalletProvider'
 import { useGetAssetData } from 'hooks/useAsset/useAsset'
+import { useFetchAsset } from 'hooks/useFetchAsset/useFetchAsset'
 import { TestProviders } from 'jest/TestProviders'
 
 import { useSendFees } from './useSendFees'
@@ -12,6 +13,7 @@ jest.mock('@shapeshiftoss/market-service')
 jest.mock('react-hook-form')
 jest.mock('context/WalletProvider/WalletProvider')
 jest.mock('hooks/useAsset/useAsset')
+jest.mock('hooks/useFetchAsset/useFetchAsset')
 
 const fees = {
   [chainAdapters.FeeDataKey.Slow]: {
@@ -54,11 +56,12 @@ const getAssetData = () =>
     precision: 18
   })
 
-const setup = ({ asset = {}, estimatedFees = {}, wallet = {} }) => {
+const setup = ({ asset = {}, estimatedFees = {}, wallet = {}, feeAsset = {} }) => {
   ;(useWallet as jest.Mock<unknown>).mockImplementation(() => ({
     state: { wallet }
   }))
   ;(useWatch as jest.Mock<unknown>).mockImplementation(() => ({ asset, estimatedFees }))
+  ;(useFetchAsset as jest.Mock<unknown>).mockImplementation(() => feeAsset)
 
   const wrapper: React.FC = ({ children }) => <TestProviders>{children}</TestProviders>
 
@@ -73,7 +76,11 @@ describe('useSendFees', () => {
 
   it('returns the fees with market data', async () => {
     return await act(async () => {
-      const { waitForValueToChange, result } = setup({ asset: ethAsset, estimatedFees: fees })
+      const { waitForValueToChange, result } = setup({
+        asset: ethAsset,
+        estimatedFees: fees,
+        feeAsset: ethAsset
+      })
       await waitForValueToChange(() => result.current.fees)
       expect(result.current.fees?.slow.fiatFee).toBe('0.000147')
       expect(result.current.fees?.average.fiatFee).toBe('0.000147')

--- a/src/components/Modals/Send/hooks/useSendFees/useSendFees.tsx
+++ b/src/components/Modals/Send/hooks/useSendFees/useSendFees.tsx
@@ -3,6 +3,7 @@ import { useEffect, useState } from 'react'
 import { useFormContext, useWatch } from 'react-hook-form'
 import { useWallet } from 'context/WalletProvider/WalletProvider'
 import { useGetAssetData } from 'hooks/useAsset/useAsset'
+import { useFetchAsset } from 'hooks/useFetchAsset/useFetchAsset'
 import { bn, bnOrZero } from 'lib/bignumber/bignumber'
 
 import { FeePrice } from '../../views/Confirm'
@@ -14,6 +15,7 @@ export const useSendFees = () => {
     control
   })
   const getAssetData = useGetAssetData({ chain: asset?.chain })
+  const feeAsset = useFetchAsset({ chain: asset?.chain })
   const {
     state: { wallet }
   } = useWallet()
@@ -27,7 +29,7 @@ export const useSendFees = () => {
         const txFees = (Object.keys(estimatedFees) as chainAdapters.FeeDataKey[]).reduce(
           (acc: FeePrice, key: chainAdapters.FeeDataKey) => {
             const txFee = bnOrZero(estimatedFees[key].txFee)
-              .dividedBy(bn(10).exponentiatedBy(asset.precision))
+              .dividedBy(bn(`1e+${feeAsset.precision}`))
               .toPrecision()
             const fiatFee = bnOrZero(txFee).times(bnOrZero(marketData?.price)).toPrecision()
             acc[key] = { txFee, fiatFee }


### PR DESCRIPTION
## Description

If the token asset being sent was different than the chain asset used to calculate fees, then the estimated fees were grossly overshown.

## Notice

Before submitting a pull request, please make sure you have answered the following:

- [x] Have you followed the guidelines in our [Contributing]('https://github.com/shapeshift/web/CONTRIBUTING.md) guide?
- [x] Have you checked to ensure there aren't other open [Pull Requests](https://github.com/shapeshift/web/pulls) for the same update/change?
- [x] Do all new and existing tests pass? Does the linter pass?

## Pull Request Type

- [x] :bug: Bug fix (Non-breaking Change: Fixes an issue)
- [ ] :hammer_and_wrench: Chore (Non-breaking Change: Doc updates, pkg upgrades, typos, etc..)
- [ ] :nail_care: New Feature (Breaking/Non-breaking Change)

## Issue (if applicable)

If applicable, please link to the github issue and put `closes #XXXX` in your comment to auto-close the issue that your PR fixes.

## Testing

Please outline all testing steps

1. Pull branch locally and run `yarn` to install new deps
2. etc...

## Screenshots (if applicable)

<img width="453" alt="Screen Shot 2021-11-17 at 2 40 03 PM" src="https://user-images.githubusercontent.com/88169003/142286898-c1a20349-2ac2-4de9-a820-c251cf60b729.png">
