### PR TITLE
fix: sort assets market cap

### DIFF
--- a/src/components/AssetSearch/AssetSearch.tsx
+++ b/src/components/AssetSearch/AssetSearch.tsx
@@ -9,6 +9,7 @@ import { fetchMarketCaps } from 'state/slices/marketDataSlice/marketDataSlice'
 
 import { AssetList } from './AssetList'
 import { filterAssetsBySearchTerm } from './helpers/filterAssetsBySearchTerm/filterAssetsBySearchTerm'
+import { marketCapLoadingStatus } from './selectors/marketCapLoadingStatus/marketCapLoadingStatus'
 import { selectAndSortAssets } from './selectors/selectAndSortAssets/selectAndSortAssets'
 
 type AssetSearchProps = {
@@ -18,6 +19,7 @@ type AssetSearchProps = {
 export const AssetSearch = ({ onClick }: AssetSearchProps) => {
   const dispatch = useDispatch()
   const assets = useSelector(selectAndSortAssets)
+  const [marketCapLoaded, marketCapLoading] = useSelector(marketCapLoadingStatus)
   const [filteredAssets, setFilteredAssets] = useState<Asset[]>([])
   const { register, watch } = useForm<{ search: string }>({
     mode: 'onChange',
@@ -30,9 +32,9 @@ export const AssetSearch = ({ onClick }: AssetSearchProps) => {
   const searching = useMemo(() => searchString.length > 0, [searchString])
 
   useEffect(() => {
-    Object.keys(assets).length < 100 && dispatch(fetchAssets({ network: NetworkTypes.MAINNET }))
-    Object.keys(assets).length < 100 && dispatch(fetchMarketCaps())
-  }, [assets, dispatch])
+    !assets.length && dispatch(fetchAssets({ network: NetworkTypes.MAINNET }))
+    !marketCapLoaded && !marketCapLoading && dispatch(fetchMarketCaps())
+  }, [assets, dispatch, marketCapLoaded, marketCapLoading])
 
   useEffect(() => {
     setFilteredAssets(searching ? filterAssetsBySearchTerm(searchString, assets) : assets)

--- a/src/components/AssetSearch/selectors/marketCapLoadingStatus/marketCapLoadingStatus.ts
+++ b/src/components/AssetSearch/selectors/marketCapLoadingStatus/marketCapLoadingStatus.ts
@@ -1,0 +1,8 @@
+import { createSelector } from '@reduxjs/toolkit'
+import { ReduxState } from 'state/reducer'
+
+export const marketCapLoadingStatus = createSelector(
+  (state: ReduxState) => Object.keys(state.marketData?.marketCap ?? {}).length,
+  (state: ReduxState) => state.marketData.loading,
+  (loaded, loading) => [loaded, loading]
+)

--- a/src/hooks/useBalanceChartData/useBalanceChartData.ts
+++ b/src/hooks/useBalanceChartData/useBalanceChartData.ts
@@ -188,6 +188,7 @@ const fiatBalanceAtBucket: FiatBalanceAtBucket = ({
     const price = priceAtBlockTime({ assetPriceHistoryData, time })
     const portfolioAsset = portfolioAssets[caip19]
     const { precision } = portfolioAsset
+    if (!portfolioAsset) return acc
     const assetFiatBalance = bn(assetCryptoBalance)
       .div(bn(10).exponentiatedBy(precision))
       .times(price)

--- a/src/hooks/useBalanceChartData/useBalanceChartData.ts
+++ b/src/hooks/useBalanceChartData/useBalanceChartData.ts
@@ -187,8 +187,8 @@ const fiatBalanceAtBucket: FiatBalanceAtBucket = ({
     const assetPriceHistoryData = priceHistoryData[caip19]
     const price = priceAtBlockTime({ assetPriceHistoryData, time })
     const portfolioAsset = portfolioAssets[caip19]
-    const { precision } = portfolioAsset
     if (!portfolioAsset) return acc
+    const { precision } = portfolioAsset
     const assetFiatBalance = bn(assetCryptoBalance)
       .div(bn(10).exponentiatedBy(precision))
       .times(price)


### PR DESCRIPTION
- fix: sort assets by market cap but don't overfetch
- fix: dont fail calculating balance charts if portfolio asset is not loaded
- chore: market cap loading status hook
