### PR TITLE
chore: for yarn test, turn off watch mode except for test:dev

### DIFF
--- a/package.json
+++ b/package.json
@@ -78,7 +78,7 @@
     "dev:silent": "BROWSER=none react-scripts start",
     "lint": "eslint -c .eslintrc src --ext .ts,.tsx",
     "lint:fix": "yarn lint --fix",
-    "test": "react-scripts test --coverage",
+    "test": "react-scripts test --coverage --watchAll=false",
     "clean": "rimraf node_modules",
     "test:dev": "react-scripts test --watch",
     "type-check": "tsc --project ./tsconfig.json --noEmit",
@@ -100,7 +100,7 @@
     ]
   },
   "jest": {
-    "collectCoverageFrom": null
+    "collectCoverageFrom": []
   },
   "browserslist": {
     "production": [


### PR DESCRIPTION
## Description

Also fixes a Validation error because `collectCoverageFrom` can't be null, apparently

## Notice

Before submitting a pull request, please make sure you have answered the following:

- [X] Have you followed the guidelines in our [Contributing]('https://github.com/shapeshift/web/CONTRIBUTING.md) guide?
- [X] Have you checked to ensure there aren't other open [Pull Requests](https://github.com/shapeshift/web/pulls) for the same update/change?
- [X] Do all new and existing tests pass? Does the linter pass?

## Pull Request Type

- [ ] :bug: Bug fix (Non-breaking Change: Fixes an issue)
- [X] :hammer_and_wrench: Chore (Non-breaking Change: Doc updates, pkg upgrades, typos, etc..)
- [ ] :nail_care: New Feature (Breaking/Non-breaking Change)
