### PR TITLE
fix: subscriptions needs accountType

### DIFF
--- a/src/context/TransactionsProvider/TransactionsProvider.tsx
+++ b/src/context/TransactionsProvider/TransactionsProvider.tsx
@@ -41,7 +41,7 @@ export const TransactionsProvider = ({ children }: TransactionsProviderProps): J
           const accountParams = accountType ? utxoAccountParams(asset, accountType, 0) : {}
           try {
             await adapter.subscribeTxs(
-              { wallet, ...accountParams },
+              { wallet, accountType, ...accountParams },
               msg => {
                 dispatch(txHistory.actions.onMessage({ message: { ...msg, accountType } }))
               },

--- a/src/state/slices/preferencesSlice/preferencesSlice.ts
+++ b/src/state/slices/preferencesSlice/preferencesSlice.ts
@@ -16,7 +16,7 @@ export const supportedAccountTypes = {
 
 const initialState: Preferences = {
   accountTypes: {
-    [ChainTypes.Bitcoin]: UtxoAccountType.SegwitP2sh
+    [ChainTypes.Bitcoin]: UtxoAccountType.SegwitNative
   }
 }
 


### PR DESCRIPTION
## Description

chain-adapters was updated to require `accountType` for `subscribeTxs` and we were missing it

Change default BTC account type to SegwitNative
