### PR TITLE
feat: prompt user to enable persistent storage

### DIFF
--- a/src/assets/translations/messages-en.json
+++ b/src/assets/translations/messages-en.json
@@ -372,13 +372,13 @@
       },
       "start": {
         "header": "ShapeShift Wallet",
-        "body": "You can have multiple ShapeShift wallets. You may load a wallet, import a wallet from a backup phrase, or create a new wallet",
+        "body": "You can have multiple ShapeShift wallets. You may load a wallet, import a wallet from a backup phrase, or create a new wallet.",
         "import": "Import a wallet",
         "create": "Create a new wallet",
         "load": "Saved wallets"
       },
       "success": {
-        "encryptingWallet": "Encrypting your wallet...",
+        "encryptingWallet": "Encrypting your wallet... if your browser asks to store data in persistent storage, please click 'Allow'.",
         "header": "Wallet Connected",
         "success": "Your wallet has been connected",
         "error": "There was an error connecting your wallet"

--- a/src/context/WalletProvider/NativeWallet/hooks/useNativeSuccess.ts
+++ b/src/context/WalletProvider/NativeWallet/hooks/useNativeSuccess.ts
@@ -17,7 +17,8 @@ export const useNativeSuccess = ({ vault }: UseNativeSuccessPropTypes) => {
       const adapter = state.adapters?.get(KeyManager.Native)!
       try {
         await new Promise(resolve => setTimeout(resolve, 250))
-        await vault.save()
+        await Promise.all([navigator.storage?.persist?.(), vault.save()])
+
         const deviceId = vault.id
         const wallet = (await adapter.pairDevice(deviceId)) as NativeHDWallet
         const mnemonic = (await vault.get(


### PR DESCRIPTION
## Description
Use the StorageManager API, if present -- which it is, everywhere but Safari -- to prompt the user to enable persistent storage for native wallet vaults.

## Notice

Before submitting a pull request, please make sure you have answered the following:

- [x] Have you followed the guidelines in our [Contributing]('https://github.com/shapeshift/web/CONTRIBUTING.md) guide?
- [x] Have you checked to ensure there aren't other open [Pull Requests](https://github.com/shapeshift/web/pulls) for the same update/change?
- [x] Do all new and existing tests pass? Does the linter pass?

## Pull Request Type

- [ ] :bug: Bug fix (Non-breaking Change: Fixes an issue)
- [ ] :hammer_and_wrench: Chore (Non-breaking Change: Doc updates, pkg upgrades, typos, etc..)
- [x] :nail_care: New Feature (Breaking/Non-breaking Change)

## Screenshot

![image](https://user-images.githubusercontent.com/645226/142348829-4705c8b0-be4d-4417-bc00-ae3a3789ebe9.png)