### PR TITLE
fix: react keys rerender problems, use binary search for asset prices

### DIFF
--- a/src/context/WalletProvider/NativeWallet/components/NativeLoad.tsx
+++ b/src/context/WalletProvider/NativeWallet/components/NativeLoad.tsx
@@ -98,9 +98,10 @@ export const NativeLoad = () => {
       </ModalHeader>
       <ModalBody>
         <VStack mx={-4} spacing={0}>
-          {wallets.map(wallet => {
+          {wallets.map((wallet, i) => {
             return (
               <Row
+                key={i}
                 mx={-4}
                 py={2}
                 alignItems='center'

--- a/src/hooks/useBalanceChartData/useBalanceChartData.ts
+++ b/src/hooks/useBalanceChartData/useBalanceChartData.ts
@@ -154,7 +154,9 @@ const bucketTxs = (txs: Tx[], bucketsAndMeta: MakeBucketsReturn): Bucket[] => {
     if (txDayjs.isBefore(start)) return acc
     const { unit } = meta
     // the number of time units from start of chart to this tx
-    const bucketIndex = txDayjs.diff(start, unit as dayjs.OpUnitType)
+    let bucketIndex = txDayjs.diff(start, unit as dayjs.OpUnitType)
+    // maybe a fix for pending tx coming in after charts were last rendered
+    if (bucketIndex >= buckets.length) bucketIndex = buckets.length - 1
     // add to the correct bucket
     acc[bucketIndex].txs.push(tx)
     return acc

--- a/src/hooks/useBalanceChartData/useBalanceChartData.ts
+++ b/src/hooks/useBalanceChartData/useBalanceChartData.ts
@@ -10,6 +10,7 @@ import {
 } from '@shapeshiftoss/types'
 import { TxType } from '@shapeshiftoss/types/dist/chain-adapters'
 import dayjs from 'dayjs'
+import { sortedIndexBy } from 'lodash'
 import fill from 'lodash/fill'
 import head from 'lodash/head'
 import isEmpty from 'lodash/isEmpty'
@@ -38,11 +39,13 @@ type PriceAtBlockTimeArgs = {
 type PriceAtBlockTime = (args: PriceAtBlockTimeArgs) => number
 
 export const priceAtBlockTime: PriceAtBlockTime = ({ time, assetPriceHistoryData }): number => {
-  for (let i = 0; i < assetPriceHistoryData.length; i++) {
-    if (time > Number(assetPriceHistoryData[i].date)) continue
-    return assetPriceHistoryData[i].price
-  }
-  return assetPriceHistoryData[assetPriceHistoryData.length - 1].price
+  const { length } = assetPriceHistoryData
+  const i = sortedIndexBy(assetPriceHistoryData, { date: String(time), price: 0 }, ({ date }) =>
+    Number(date)
+  )
+  if (i === 0) return assetPriceHistoryData[i].price
+  if (i >= length) return assetPriceHistoryData[length - 1].price
+  return assetPriceHistoryData[i].price
 }
 
 type CryptoBalance = {

--- a/src/hooks/useBalanceChartData/useBalanceChartData.ts
+++ b/src/hooks/useBalanceChartData/useBalanceChartData.ts
@@ -40,6 +40,7 @@ type PriceAtBlockTime = (args: PriceAtBlockTimeArgs) => number
 
 export const priceAtBlockTime: PriceAtBlockTime = ({ time, assetPriceHistoryData }): number => {
   const { length } = assetPriceHistoryData
+  // https://lodash.com/docs/4.17.15#sortedIndexBy - binary search rather than O(n)
   const i = sortedIndexBy(assetPriceHistoryData, { date: String(time), price: 0 }, ({ date }) =>
     Number(date)
   )

--- a/src/pages/Dashboard/components/AccountList/AccountList.tsx
+++ b/src/pages/Dashboard/components/AccountList/AccountList.tsx
@@ -1,5 +1,6 @@
 import { Stack } from '@chakra-ui/layout'
 import { NetworkTypes } from '@shapeshiftoss/types'
+import range from 'lodash/range'
 import { useEffect } from 'react'
 import { useMemo } from 'react'
 import { useDispatch, useSelector } from 'react-redux'
@@ -16,7 +17,7 @@ export const AccountList = ({ loading }: { loading?: boolean }) => {
   const assets = useSelector((state: ReduxState) => state.assets)
   const marketData = useSelector((state: ReduxState) => state.marketData.marketData)
   const { balances, totalBalance } = usePortfolio()
-  const emptyAccounts = new Array(5).fill(null)
+  const emptyAccounts = range(5)
 
   useEffect(() => {
     // arbitrary number to just make sure we dont fetch all assets if we already have
@@ -60,7 +61,7 @@ export const AccountList = ({ loading }: { loading?: boolean }) => {
 
   return loading ? (
     <Stack>
-      {emptyAccounts.map(index => (
+      {emptyAccounts.map((_, index) => (
         <LoadingRow key={index} />
       ))}
     </Stack>

--- a/src/pages/Dashboard/components/AccountList/AccountList.tsx
+++ b/src/pages/Dashboard/components/AccountList/AccountList.tsx
@@ -17,7 +17,6 @@ export const AccountList = ({ loading }: { loading?: boolean }) => {
   const assets = useSelector((state: ReduxState) => state.assets)
   const marketData = useSelector((state: ReduxState) => state.marketData.marketData)
   const { balances, totalBalance } = usePortfolio()
-  const emptyAccounts = range(5)
 
   useEffect(() => {
     // arbitrary number to just make sure we dont fetch all assets if we already have
@@ -59,13 +58,15 @@ export const AccountList = ({ loading }: { loading?: boolean }) => {
     )
   }, [assets, balances, marketData, totalBalance])
 
-  return loading ? (
-    <Stack>
-      {emptyAccounts.map((_, index) => (
-        <LoadingRow key={index} />
-      ))}
-    </Stack>
-  ) : (
-    accountRows
+  const loadingRows = useMemo(
+    () => (
+      <Stack>
+        {range(5).map((_, index) => (
+          <LoadingRow key={index} />
+        ))}
+      </Stack>
+    ),
+    []
   )
+  return loading ? loadingRows : accountRows
 }


### PR DESCRIPTION
## Description

* slightly better perf on loading screen - memoize loading skeletons
* add key to wallets to avoid react warning on native dialog
* use binary search for asset prices in balance charts - ~4x quicker


## Notice

Before submitting a pull request, please make sure you have answered the following:

- [ ] Have you followed the guidelines in our [Contributing]('https://github.com/shapeshift/web/CONTRIBUTING.md) guide?
- [ ] Have you checked to ensure there aren't other open [Pull Requests](https://github.com/shapeshift/web/pulls) for the same update/change?
- [ ] Do all new and existing tests pass? Does the linter pass?

## Pull Request Type

- [ ] :bug: Bug fix (Non-breaking Change: Fixes an issue)
- [x] :hammer_and_wrench: Chore (Non-breaking Change: Doc updates, pkg upgrades, typos, etc..)
- [ ] :nail_care: New Feature (Breaking/Non-breaking Change)

## Issue (if applicable)

If applicable, please link to the github issue and put `closes #XXXX` in your comment to auto-close the issue that your PR fixes.

## Testing

Please outline all testing steps

1. Pull branch locally and run `yarn` to install new deps
2. etc...

## Screenshots (if applicable)
