### PR TITLE
fix: don't make balance charts explode on pending txs

### DIFF
--- a/src/hooks/useBalanceChartData/useBalanceChartData.ts
+++ b/src/hooks/useBalanceChartData/useBalanceChartData.ts
@@ -150,7 +150,9 @@ const bucketTxs = (txs: Tx[], bucketsAndMeta: MakeBucketsReturn): Bucket[] => {
     if (txDayjs.isBefore(start)) return acc
     const { unit } = meta
     // the number of time units from start of chart to this tx
-    const bucketIndex = txDayjs.diff(start, unit as dayjs.OpUnitType)
+    let bucketIndex = txDayjs.diff(start, unit as dayjs.OpUnitType)
+    // maybe a fix for pending tx coming in after charts were last rendered
+    if (bucketIndex >= buckets.length) bucketIndex = buckets.length - 1
     // add to the correct bucket
     acc[bucketIndex].txs.push(tx)
     return acc


### PR DESCRIPTION
## Description

i suspect if a pending tx comes in after the balance chart has rendered, we're trying to put it in a time bucket of the chart in the future that doesn't exist and everything explodes with a white page.

this will stick it in the last bucket. charts may be slightly wrong but it won't crash the app.

## Notice

Before submitting a pull request, please make sure you have answered the following:

- [ ] Have you followed the guidelines in our [Contributing]('https://github.com/shapeshift/web/CONTRIBUTING.md) guide?
- [ ] Have you checked to ensure there aren't other open [Pull Requests](https://github.com/shapeshift/web/pulls) for the same update/change?
- [ ] Do all new and existing tests pass? Does the linter pass?

## Pull Request Type

- [x] :bug: Bug fix (Non-breaking Change: Fixes an issue)
- [ ] :hammer_and_wrench: Chore (Non-breaking Change: Doc updates, pkg upgrades, typos, etc..)
- [ ] :nail_care: New Feature (Breaking/Non-breaking Change)

## Issue (if applicable)

If applicable, please link to the github issue and put `closes #XXXX` in your comment to auto-close the issue that your PR fixes.

## Testing

Please outline all testing steps

1. Pull branch locally and run `yarn` to install new deps
2. etc...

## Screenshots (if applicable)
