### PR TITLE
fix: filter out vaults with 0 balance from list

### DIFF
--- a/src/pages/Earn/components/VaultList.tsx
+++ b/src/pages/Earn/components/VaultList.tsx
@@ -6,12 +6,15 @@ import { NavLink } from 'react-router-dom'
 import { Card } from 'components/Card/Card'
 import { IconCircle } from 'components/IconCircle'
 import { Text } from 'components/Text'
+import { bnOrZero } from 'lib/bignumber/bignumber'
 
 import { UseEarnBalancesReturn } from '../hooks/useEarnBalances'
 import { StakingCard } from './StakingCard'
 
 export const VaultList = ({ balances }: { balances: UseEarnBalancesReturn }) => {
-  const vaults = Object.values(balances?.vaults?.vaults || {})
+  const activeVaults = Object.values(balances?.vaults?.vaults || {}).filter(vault =>
+    bnOrZero(vault?.balance).gt(0)
+  )
 
   if (balances.vaults.loading) return null
 
@@ -40,11 +43,11 @@ export const VaultList = ({ balances }: { balances: UseEarnBalancesReturn }) => 
         gridTemplateColumns={{ base: 'repeat(1, 1fr)', lg: 'repeat(3, 1fr)' }}
         gridGap={6}
       >
-        {vaults.map(vault => {
+        {activeVaults.map(vault => {
           return <StakingCard isLoaded={true} key={vault.vaultAddress} {...vault} />
         })}
       </SimpleGrid>
-      {vaults.length === 0 && (
+      {activeVaults.length === 0 && (
         <Card textAlign='center' py={6} boxShadow='none'>
           <Card.Body>
             <Flex justifyContent='center' fontSize='xxx-large' mb={4} color='gray.500'>


### PR DESCRIPTION
## Description

Vaults with a historical balances were showing in the Earn overview page even if their current balance was 0.

## Notice

Before submitting a pull request, please make sure you have answered the following:

- [x] Have you followed the guidelines in our [Contributing]('https://github.com/shapeshift/web/CONTRIBUTING.md) guide?
- [x] Have you checked to ensure there aren't other open [Pull Requests](https://github.com/shapeshift/web/pulls) for the same update/change?
- [x] Do all new and existing tests pass? Does the linter pass?

## Pull Request Type

- [x] :bug: Bug fix (Non-breaking Change: Fixes an issue)
- [ ] :hammer_and_wrench: Chore (Non-breaking Change: Doc updates, pkg upgrades, typos, etc..)
- [ ] :nail_care: New Feature (Breaking/Non-breaking Change)

## Issue (if applicable)

closes #442 

## Testing

Please outline all testing steps

1. Pull branch locally and run `yarn` to install new deps
2. etc...

## Screenshots (if applicable)
