### PR TITLE
fix: support different CSPs in meta and headers

### DIFF
--- a/headers.js
+++ b/headers.js
@@ -1,8 +1,7 @@
 require('dotenv').config()
 
-const csp = Object.entries({
+const cspMeta = Object.entries({
   'default-src': ["'self'"],
-  'frame-ancestors': ["'none'"],
   'connect-src': [
     "'self'",
     'https://api.0x.org',
@@ -42,7 +41,7 @@ const csp = Object.entries({
   .join('; ')
 
 const headers = {
-  'Content-Security-Policy': `${csp}`, // `; report-uri https://shapeshift.report-uri.com/r/d/csp/wizard`,
+  'Content-Security-Policy': `${cspMeta}; frame-ancestors: 'none'`, // `; report-uri https://shapeshift.report-uri.com/r/d/csp/wizard`,
   'Cross-Origin-Opener-Policy': 'same-origin',
   'Permissions-Policy': 'document-domain=()',
   'Referrer-Policy': 'no-referrer',
@@ -50,7 +49,10 @@ const headers = {
   'X-Frame-Options': 'DENY'
 }
 
-module.exports = headers
+module.exports = {
+  headers,
+  cspMeta
+}
 if (module.parent) return
 
 require('fs').writeFileSync(

--- a/public/index.html
+++ b/public/index.html
@@ -3,7 +3,7 @@
   <head>
     <meta charset="utf-8" />
     <meta name="referrer" content="no-referrer">
-    <meta http-equiv="Content-Security-Policy" content="%REACT_APP_CSP%" />
+    <meta http-equiv="Content-Security-Policy" content="%REACT_APP_CSP_META%" />
     <link rel="icon" href="%PUBLIC_URL%/favi-blue.png" />
     <meta name="viewport" content="width=device-width, initial-scale=1" />
     <meta name="theme-color" content="#000000" />

--- a/react-app-rewired.config.js
+++ b/react-app-rewired.config.js
@@ -2,13 +2,13 @@
  * React App Rewired Config
  */
 const headers = require('./headers')
-process.env.REACT_APP_CSP = headers['Content-Security-Policy'] ?? ''
+process.env.REACT_APP_CSP_META = headers.cspMeta ?? ''
 
 module.exports = {
   devServer: configFunction => {
     return (proxy, allowedHost) => {
       const config = configFunction(proxy, allowedHost)
-      config.headers = headers
+      config.headers = headers.headers
       return config
     }
   }


### PR DESCRIPTION
## Description

This will silence the console warning that the `frame-ancestors` directive isn't allowed in meta tags.

## Notice

Before submitting a pull request, please make sure you have answered the following:

- [x] Have you followed the guidelines in our [Contributing]('https://github.com/shapeshift/web/CONTRIBUTING.md) guide?
- [x] Have you checked to ensure there aren't other open [Pull Requests](https://github.com/shapeshift/web/pulls) for the same update/change?
- [x] Do all new and existing tests pass? Does the linter pass?

## Pull Request Type

- [x] :bug: Bug fix (Non-breaking Change: Fixes an issue)
- [ ] :hammer_and_wrench: Chore (Non-breaking Change: Doc updates, pkg upgrades, typos, etc..)
- [ ] :nail_care: New Feature (Breaking/Non-breaking Change)
