### PR TITLE
fix: disable COOP for popups to fix portis

### DIFF
--- a/headers.js
+++ b/headers.js
@@ -43,7 +43,7 @@ const csp = Object.entries({
 
 const headers = {
   'Content-Security-Policy': `${csp}`, // `; report-uri https://shapeshift.report-uri.com/r/d/csp/wizard`,
-  'Cross-Origin-Opener-Policy': 'same-origin',
+  'Cross-Origin-Opener-Policy': 'same-origin-allow-popups',
   'Permissions-Policy': 'document-domain=()',
   'Referrer-Policy': 'no-referrer',
   'X-Content-Type-Options': 'nosniff',


### PR DESCRIPTION
## Description

This relaxes the `Cross-Origin-Opener-Policy` from `same-origin` to `same-origin-allow-popups` so that Portis's `penpal` package can talk to its popup window.

## Notice

Before submitting a pull request, please make sure you have answered the following:

- [x] Have you followed the guidelines in our [Contributing]('https://github.com/shapeshift/web/CONTRIBUTING.md) guide?
- [x] Have you checked to ensure there aren't other open [Pull Requests](https://github.com/shapeshift/web/pulls) for the same update/change?
- [x] Do all new and existing tests pass? Does the linter pass?

## Pull Request Type

- [x] :bug: Bug fix (Non-breaking Change: Fixes an issue)
- [ ] :hammer_and_wrench: Chore (Non-breaking Change: Doc updates, pkg upgrades, typos, etc..)
- [ ] :nail_care: New Feature (Breaking/Non-breaking Change)