### PR TITLE
feat: add asset value in miner fees

### DIFF
--- a/src/components/Trade/TradeConfirm/TradeConfirm.tsx
+++ b/src/components/Trade/TradeConfirm/TradeConfirm.tsx
@@ -149,7 +149,10 @@ export const TradeConfirm = ({ history }: RouterProps) => {
                     <Text translation='trade.minerFee' />
                   </Row.Label>
                 </HelperTooltip>
-                <Row.Value>{toFiat(bnOrZero(fees?.fee).times(fiatRate).toNumber())}</Row.Value>
+                <Row.Value>
+                  {bnOrZero(fees?.fee).toNumber()} ≃{' '}
+                  {toFiat(bnOrZero(fees?.fee).times(fiatRate).toNumber())}
+                </Row.Value>
               </Row>
               <Row>
                 <HelperTooltip label={translate('trade.tooltip.shapeshiftFee')}>


### PR DESCRIPTION
## Description

Add the asset amount in the miner fee (addition to fiat value already displayed)

## Notice

Before submitting a pull request, please make sure you have answered the following:

- [x] Have you followed the guidelines in our [Contributing]('https://github.com/shapeshift/web/CONTRIBUTING.md) guide?
- [x] Have you checked to ensure there aren't other open [Pull Requests](https://github.com/shapeshift/web/pulls) for the same update/change?
- [x] Do all new and existing tests pass? Does the linter pass?

## Pull Request Type

- [ ] :bug: Bug fix (Non-breaking Change: Fixes an issue)
- [ ] :hammer_and_wrench: Chore (Non-breaking Change: Doc updates, pkg upgrades, typos, etc..)
- [x] :nail_care: New Feature (Non-breaking Change)

## Issue (if applicable)

closes #391 

## Screenshots (if applicable)

![2021-11-19_10-55](https://user-images.githubusercontent.com/5672954/142604180-3ea97276-b6f1-4ba2-954e-b1df8cebc990.png)
