### PR TITLE
fix: sort REACT_APP env vars so build is deterministic

### DIFF
--- a/react-app-rewired.config.js
+++ b/react-app-rewired.config.js
@@ -4,6 +4,16 @@
 const headers = require('./headers')
 process.env.REACT_APP_CSP_META = headers.cspMeta ?? ''
 
+const reactEnvEntries = Object.entries(process.env)
+  .filter(([k]) => k.startsWith('REACT_APP'))
+  .sort((a, b) => {
+    if (a[0] < b[0]) return -1
+    if (a[0] > b[0]) return 1
+    return 0
+  })
+reactEnvEntries.forEach(([k]) => delete process.env[k])
+reactEnvEntries.forEach(([k, v]) => (process.env[k] = v))
+
 module.exports = {
   devServer: configFunction => {
     return (proxy, allowedHost) => {


### PR DESCRIPTION
## Description

Different build environments may import environment vars in different orders. This leads to non-determinism in the build, because the bundles contain webpack DefinePlugin output in different orders.

## Notice

Before submitting a pull request, please make sure you have answered the following:

- [x] Have you followed the guidelines in our [Contributing]('https://github.com/shapeshift/web/CONTRIBUTING.md) guide?
- [x] Have you checked to ensure there aren't other open [Pull Requests](https://github.com/shapeshift/web/pulls) for the same update/change?
- [x] Do all new and existing tests pass? Does the linter pass?

## Pull Request Type

- [x] :bug: Bug fix (Non-breaking Change: Fixes an issue)
- [x] :hammer_and_wrench: Chore (Non-breaking Change: Doc updates, pkg upgrades, typos, etc..)
- [ ] :nail_care: New Feature (Breaking/Non-breaking Change)
