### PR TITLE
chore: remove verify button on native wallet

### DIFF
--- a/src/components/Modals/Receive/ReceiveInfo.tsx
+++ b/src/components/Modals/Receive/ReceiveInfo.tsx
@@ -195,24 +195,31 @@ export const ReceiveInfo = ({ asset }: ReceivePropsType) => {
                 </Circle>
                 <Text translation='modals.receive.copy' />
               </Button>
-              <Button
-                color={verified ? 'green.500' : verified === false ? 'red.500' : 'gray.500'}
-                flexDir='column'
-                role='group'
-                variant='link'
-                isDisabled={!receiveAddress}
-                _hover={{ textDecoration: 'none', color: hoverColor }}
-                onClick={handleVerify}
-              >
-                <Circle bg={bg} mb={2} size='40px' _groupHover={{ bg: 'blue.500', color: 'white' }}>
-                  {verified ? <CheckIcon /> : <ViewIcon />}
-                </Circle>
-                <Text
-                  translation={`modals.receive.${
-                    verified ? 'verified' : verified === false ? 'notVerified' : 'verify'
-                  }`}
-                />
-              </Button>
+              {!(wallet.getVendor() === 'Native') ? (
+                <Button
+                  color={verified ? 'green.500' : verified === false ? 'red.500' : 'gray.500'}
+                  flexDir='column'
+                  role='group'
+                  variant='link'
+                  isDisabled={!receiveAddress}
+                  _hover={{ textDecoration: 'none', color: hoverColor }}
+                  onClick={handleVerify}
+                >
+                  <Circle
+                    bg={bg}
+                    mb={2}
+                    size='40px'
+                    _groupHover={{ bg: 'blue.500', color: 'white' }}
+                  >
+                    {verified ? <CheckIcon /> : <ViewIcon />}
+                  </Circle>
+                  <Text
+                    translation={`modals.receive.${
+                      verified ? 'verified' : verified === false ? 'notVerified' : 'verify'
+                    }`}
+                  />
+                </Button>
+              ) : undefined}
             </HStack>
           </ModalFooter>
         </>


### PR DESCRIPTION
## Description

Remove verify button on native wallet

## Notice

Before submitting a pull request, please make sure you have answered the following:

- [x] Have you followed the guidelines in our [Contributing]('https://github.com/shapeshift/web/CONTRIBUTING.md) guide?
- [x] Have you checked to ensure there aren't other open [Pull Requests](https://github.com/shapeshift/web/pulls) for the same update/change?
- [x] Do all new and existing tests pass? Does the linter pass?

## Pull Request Type

- [ ] :bug: Bug fix (Non-breaking Change: Fixes an issue)
- [x] :hammer_and_wrench: Chore (Non-breaking Change: Doc updates, pkg upgrades, typos, etc..)
- [ ] :nail_care: New Feature (Breaking/Non-breaking Change)

## Issue (if applicable)

closes #461 

## Testing

Connect with wallet other than native:

1. Click on _receive_ button from any asset page
2. The _verify_ button is displayed

Connect with native wallet:
1. Click on _receive_ button from any asset page
2. The _verify_ button is **not** displayed
