### PR TITLE
fix: fixes dead click if keepkey is connected on another tab, also fi…

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -25,7 +25,7 @@ yarn-error.log*
 
 # vs-code
 .history
-.vscode/settings.json 
+.vscode
 
 # idea
 *.iml

--- a/src/assets/translations/messages-en.json
+++ b/src/assets/translations/messages-en.json
@@ -297,7 +297,7 @@
       },
       "connect": {
         "header": "Pair Your KeepKey",
-        "body": "Connect a KeepKey device and click 'Pair.'",
+        "body": "Connect a KeepKey device and click Pair.",
         "button": "Pair",
         "conflictingApp": "Could not find your KeepKey. Another application may be trying to connect with your KeepKey."
       },

--- a/src/assets/translations/messages-en.json
+++ b/src/assets/translations/messages-en.json
@@ -299,7 +299,7 @@
         "header": "Pair Your KeepKey",
         "body": "Connect a KeepKey device and click 'Pair.'",
         "button": "Pair",
-        "conflictingApp": "Could not find your KeepKey. Another application may be trying to connect with your KeepKey?"
+        "conflictingApp": "Could not find your KeepKey. Another application may be trying to connect with your KeepKey."
       },
       "pin": {
         "header": "Enter Your Pin",

--- a/src/assets/translations/messages-en.json
+++ b/src/assets/translations/messages-en.json
@@ -299,7 +299,7 @@
         "header": "Pair Your KeepKey",
         "body": "Connect a KeepKey device and click 'Pair.'",
         "button": "Pair",
-        "conflictingApp": "Could not find your keepkey. Is there a conflicting application trying to connect your keepkey?"
+        "conflictingApp": "Could not find your KeepKey. Is there a conflicting application trying to connect your KeepKey?"
       },
       "pin": {
         "header": "Enter Your Pin",

--- a/src/assets/translations/messages-en.json
+++ b/src/assets/translations/messages-en.json
@@ -299,7 +299,7 @@
         "header": "Pair Your KeepKey",
         "body": "Connect a KeepKey device and click 'Pair.'",
         "button": "Pair",
-        "conflictingApp": "Could not find your KeepKey. Is there a conflicting application trying to connect your KeepKey?"
+        "conflictingApp": "Could not find your KeepKey. Another application may be trying to connect with your KeepKey?"
       },
       "pin": {
         "header": "Enter Your Pin",

--- a/src/assets/translations/messages-en.json
+++ b/src/assets/translations/messages-en.json
@@ -298,7 +298,8 @@
       "connect": {
         "header": "Pair Your KeepKey",
         "body": "Connect a KeepKey device and click 'Pair.'",
-        "button": "Pair"
+        "button": "Pair",
+        "conflictingApp": "Could not find your keepkey. Is there a conflicting application trying to connect your keepkey?"
       },
       "pin": {
         "header": "Enter Your Pin",

--- a/src/context/WalletProvider/KeepKey/components/Connect.tsx
+++ b/src/context/WalletProvider/KeepKey/components/Connect.tsx
@@ -9,9 +9,9 @@ import {
 import { Event } from '@shapeshiftoss/hdwallet-core'
 import React, { useState } from 'react'
 import { RouteComponentProps } from 'react-router-dom'
+import { CircularProgress } from 'components/CircularProgress/CircularProgress'
 import { Text } from 'components/Text'
 import { KeyManager, SUPPORTED_WALLETS } from 'context/WalletProvider/config'
-import { CircularProgress } from 'components/CircularProgress/CircularProgress'
 
 import { LocationState } from '../../NativeWallet/types'
 import { ActionTypes, useWallet, WalletActions } from '../../WalletProvider'
@@ -54,8 +54,8 @@ export const KeepKeyConnect = ({ history }: KeepKeySetupProps) => {
   const pairDevice = async () => {
     setError(null)
     setLoading(true)
-    // if keepkey is connected to another tab, it does not get added to state.adapters.
     if (state.adapters && !state.adapters.has(KeyManager.KeepKey)) {
+      // if keepkey is connected to another tab, it does not get added to state.adapters.
       setErrorLoading('walletProvider.keepKey.connect.conflictingApp')
       return
     }

--- a/src/context/WalletProvider/KeepKey/components/Connect.tsx
+++ b/src/context/WalletProvider/KeepKey/components/Connect.tsx
@@ -11,6 +11,7 @@ import React, { useState } from 'react'
 import { RouteComponentProps } from 'react-router-dom'
 import { Text } from 'components/Text'
 import { KeyManager, SUPPORTED_WALLETS } from 'context/WalletProvider/config'
+import { CircularProgress } from 'components/CircularProgress/CircularProgress'
 
 import { LocationState } from '../../NativeWallet/types'
 import { ActionTypes, useWallet, WalletActions } from '../../WalletProvider'
@@ -53,8 +54,24 @@ export const KeepKeyConnect = ({ history }: KeepKeySetupProps) => {
   const pairDevice = async () => {
     setError(null)
     setLoading(true)
+    // if keepkey is connected to another tab, it does not get added to state.adapters.
+    if (state.adapters && !state.adapters.has(KeyManager.KeepKey)) {
+      setErrorLoading('walletProvider.keepKey.connect.conflictingApp')
+      return
+    }
     if (state.adapters && state.adapters?.has(KeyManager.KeepKey)) {
-      const wallet = await state.adapters.get(KeyManager.KeepKey)?.pairDevice()
+      const wallet = await state.adapters
+        .get(KeyManager.KeepKey)
+        ?.pairDevice()
+        .catch(err => {
+          if (err.name === 'ConflictingApp') {
+            setErrorLoading('walletProvider.keepKey.connect.conflictingApp')
+            return
+          }
+          console.error('KeepKey Connect: There was an error initializing the wallet', err)
+          setErrorLoading('walletProvider.errors.walletNotFound')
+          return
+        })
       if (!wallet) {
         setErrorLoading('walletProvider.errors.walletNotFound')
         return
@@ -93,7 +110,11 @@ export const KeepKeyConnect = ({ history }: KeepKeySetupProps) => {
       <ModalBody>
         <Text mb={4} color='gray.500' translation={'walletProvider.keepKey.connect.body'} />
         <Button isFullWidth colorScheme='blue' onClick={pairDevice} disabled={loading}>
-          <Text translation={'walletProvider.keepKey.connect.button'} />
+          {loading ? (
+            <CircularProgress size='5' />
+          ) : (
+            <Text translation={'walletProvider.keepKey.connect.button'} />
+          )}
         </Button>
         {error && (
           <Alert status='info' mt={4}>

--- a/src/context/WalletProvider/WalletViewsSwitch.tsx
+++ b/src/context/WalletProvider/WalletViewsSwitch.tsx
@@ -45,7 +45,13 @@ export const WalletViewsSwitch = () => {
 
   return (
     <>
-      <Modal isOpen={state.modal} onClose={onClose} isCentered trapFocus={false}>
+      <Modal
+        isOpen={state.modal}
+        onClose={onClose}
+        isCentered
+        trapFocus={false}
+        closeOnOverlayClick={false}
+      >
         <ModalOverlay />
         <ModalContent justifyContent='center' px={3} pt={3} pb={6}>
           <Flex justifyContent='space-between' alignItems='center' position='relative'>


### PR DESCRIPTION
…xes browser error if user cancels usb connection

## Description

When a user tried to connect a keepkey while another application was already connected, clicking "Pair" provided a dead-click. Also, if a user cancelled the connection to the keepkey, a browser error was filled the page and was shown to the user.

This fixes both issues by asking the user if there is a conflicting application, and catches the error if the user cancels the connection in the webusb modal, then displays a message to the user about the inability to connect.

## Notice

Before submitting a pull request, please make sure you have answered the following:

- [x] Have you followed the guidelines in our [Contributing]('https://github.com/shapeshift/web/CONTRIBUTING.md) guide?
- [x] Have you checked to ensure there aren't other open [Pull Requests](https://github.com/shapeshift/web/pulls) for the same update/change?
- [x] Do all new and existing tests pass? Does the linter pass?

## Pull Request Type

- [x] :bug: Bug fix (Non-breaking Change: Fixes an issue)
- [ ] :hammer_and_wrench: Chore (Non-breaking Change: Doc updates, pkg upgrades, typos, etc..)
- [ ] :nail_care: New Feature (Breaking/Non-breaking Change)

## Issue (if applicable)

`closes #423 `

## Testing

Please outline all testing steps

Conflicting App:
1. Open tab of application that will connect to keepkey.
2. Open web v2 app.
3. Attempt to connect to keepkey.
4. Instead of deadclick, you should see a message asking if the user has their keepkey connected to a conflicting application.

User Cancel's keepkey connection:
1. Open web v2 app as the only app to connect to keepkey
2. Click Pair on the keepkey connect flow.
3. On WebUSB modal, click cancel.
4. Should see a message about how they couldn't connect, instead of a browser error.

## Screenshots (if applicable)

<img width="475" alt="Screen Shot 2021-11-22 at 2 17 58 PM" src="https://user-images.githubusercontent.com/88169003/142936628-80a7eb44-4bf6-4869-ba37-599521ab0da8.png">
