### PR TITLE
feat: balance on send modal

### DIFF
--- a/src/assets/translations/messages-en.json
+++ b/src/assets/translations/messages-en.json
@@ -20,6 +20,7 @@
     "seeAll": "See All",
     "darkMode": "Dark Mode",
     "forget": "Forget?",
+    "available": "available",
     "somethingWentWrong": "Something went wrong",
     "somethingWentWrongBody": "Something went wrong",
     "transactionFailed": "Transaction Failed",

--- a/src/components/AccountCard.tsx
+++ b/src/components/AccountCard.tsx
@@ -1,0 +1,71 @@
+import { ChevronRightIcon } from '@chakra-ui/icons'
+import { Button, ButtonProps } from '@chakra-ui/react'
+import { SkeletonCircle, SkeletonText } from '@chakra-ui/skeleton'
+import { Asset } from '@shapeshiftoss/types'
+import { useTranslate } from 'react-polyglot'
+
+import { Amount } from './Amount/Amount'
+import { AssetIcon } from './AssetIcon'
+import { RawText } from './Text'
+
+type AccountCardProps = {
+  asset: Asset
+  isLoaded?: boolean
+  fiatAmountAvailable: string
+  cryptoAmountAvailable: string
+  showCrypto?: boolean
+  onClick?: () => void
+} & ButtonProps
+
+export const AccountCard = ({
+  asset,
+  isLoaded,
+  fiatAmountAvailable,
+  cryptoAmountAvailable,
+  showCrypto,
+  onClick,
+  ...rest
+}: AccountCardProps) => {
+  const translate = useTranslate()
+  return (
+    <Button
+      onClick={onClick}
+      isFullWidth
+      justifyContent='flex-start'
+      py={4}
+      height='auto'
+      textAlign='left'
+      leftIcon={
+        <SkeletonCircle isLoaded={isLoaded} boxSize='40px'>
+          <AssetIcon src={asset.icon} boxSize='40px' />
+        </SkeletonCircle>
+      }
+      rightIcon={<ChevronRightIcon boxSize={6} />}
+      {...rest}
+    >
+      <SkeletonText noOfLines={2} isLoaded={isLoaded} mr='auto'>
+        <RawText lineHeight='1' mb={1}>
+          {asset.name}
+        </RawText>
+
+        {showCrypto ? (
+          <Amount.Crypto
+            color='gray.500'
+            lineHeight='1'
+            maximumFractionDigits={6}
+            symbol={asset.symbol}
+            value={cryptoAmountAvailable}
+            suffix={translate('common.available')}
+          />
+        ) : (
+          <Amount.Fiat
+            value={fiatAmountAvailable}
+            lineHeight='1'
+            color='gray.500'
+            suffix={translate('common.available')}
+          />
+        )}
+      </SkeletonText>
+    </Button>
+  )
+}

--- a/src/components/Amount/Amount.tsx
+++ b/src/components/Amount/Amount.tsx
@@ -104,7 +104,7 @@ const Fiat = ({ value, fiatSymbolStyle, fiatType, prefix, suffix, ...props }: Fi
       <RawText {...props}>
         {prefix && `${prefix} `}
         {fiat}
-        {suffix && `${suffix} `}
+        {suffix && ` ${suffix}`}
       </RawText>
     )
   }

--- a/src/components/Modals/Send/hooks/useSendDetails/useSendDetails.tsx
+++ b/src/components/Modals/Send/hooks/useSendDetails/useSendDetails.tsx
@@ -16,7 +16,7 @@ import { useChainAdapters } from 'context/ChainAdaptersProvider/ChainAdaptersPro
 import { useWallet } from 'context/WalletProvider/WalletProvider'
 import { AssetMarketData, useGetAssetData } from 'hooks/useAsset/useAsset'
 import { useFlattenedBalances } from 'hooks/useBalances/useFlattenedBalances'
-import { bnOrZero } from 'lib/bignumber/bignumber'
+import { BigNumber, bnOrZero } from 'lib/bignumber/bignumber'
 import { ReduxState } from 'state/reducer'
 
 import { SendFormFields } from '../../Form'
@@ -36,6 +36,10 @@ type UseSendDetailsReturnType = {
   toggleCurrency(): void
   validateCryptoAmount(value: string): boolean | string
   validateFiatAmount(value: string): boolean | string
+  accountBalances: {
+    crypto: BigNumber
+    fiat: BigNumber
+  }
 }
 
 export const useSendDetails = (): UseSendDetailsReturnType => {
@@ -269,6 +273,7 @@ export const useSendDetails = (): UseSendDetailsReturnType => {
     amountFieldError,
     balancesLoading,
     fieldName,
+    accountBalances,
     handleInputChange,
     handleNextClick,
     handleSendMax,

--- a/src/components/Modals/Send/views/Address.tsx
+++ b/src/components/Modals/Send/views/Address.tsx
@@ -78,7 +78,7 @@ export const Address = () => {
         <Stack flex={1}>
           <Button
             isFullWidth
-            isDisabled={!address}
+            isDisabled={!address || addressError}
             colorScheme={addressError ? 'red' : 'blue'}
             size='lg'
             onClick={handleNext}

--- a/src/components/Modals/Send/views/Details.tsx
+++ b/src/components/Modals/Send/views/Details.tsx
@@ -16,6 +16,7 @@ import {
 import { useFormContext, useWatch } from 'react-hook-form'
 import { useTranslate } from 'react-polyglot'
 import { useHistory } from 'react-router-dom'
+import { AccountCard } from 'components/AccountCard'
 import { Amount } from 'components/Amount/Amount'
 import { SlideTransition } from 'components/SlideTransition'
 import { Text } from 'components/Text'
@@ -44,6 +45,7 @@ export const Details = () => {
     amountFieldError,
     balancesLoading,
     fieldName,
+    accountBalances,
     handleInputChange,
     handleNextClick,
     handleSendMax,
@@ -72,7 +74,16 @@ export const Details = () => {
       </ModalHeader>
       <ModalCloseButton borderRadius='full' />
       <ModalBody>
-        <FormControl mt={4}>
+        <AccountCard
+          asset={asset}
+          isLoaded={!balancesLoading}
+          cryptoAmountAvailable={accountBalances.crypto.toString()}
+          fiatAmountAvailable={accountBalances.fiat.toString()}
+          showCrypto={fieldName === SendFormFields.CryptoAmount}
+          onClick={() => history.push('/send/select')}
+          mb={2}
+        />
+        <FormControl mt={6}>
           <Box display='flex' alignItems='center' justifyContent='space-between'>
             <FormLabel color='gray.500'>{translate('modals.send.sendForm.sendAmount')}</FormLabel>
             <FormHelperText
@@ -87,10 +98,10 @@ export const Details = () => {
               _hover={{ color: 'gray.400', transition: '.2s color ease' }}
             >
               {fieldName === SendFormFields.FiatAmount ? (
-                <Amount.Crypto value={crypto.amount} symbol={crypto.symbol} />
+                <Amount.Crypto value={crypto.amount} symbol={crypto.symbol} prefix='≈' />
               ) : (
                 <Flex>
-                  <Amount.Fiat value={fiat.amount} mr={1} /> {fiat.symbol}
+                  <Amount.Fiat value={fiat.amount} mr={1} prefix='≈' /> {fiat.symbol}
                 </Flex>
               )}
             </FormHelperText>


### PR DESCRIPTION
## Description

- Added an account card that shows balance also allows you to go switch the asset
- Disable next button when address is invalid

## Notice

Before submitting a pull request, please make sure you have answered the following:

- [ ] Have you followed the guidelines in our [Contributing]('https://github.com/shapeshift/web/CONTRIBUTING.md) guide?
- [ ] Have you checked to ensure there aren't other open [Pull Requests](https://github.com/shapeshift/web/pulls) for the same update/change?
- [ ] Do all new and existing tests pass? Does the linter pass?

## Pull Request Type

- [ ] :bug: Bug fix (Non-breaking Change: Fixes an issue)
- [ ] :hammer_and_wrench: Chore (Non-breaking Change: Doc updates, pkg upgrades, typos, etc..)
- [x] :nail_care: New Feature (Breaking/Non-breaking Change)

## Issue (if applicable)

closes #500 

## Testing

Please outline all testing steps

1. Pull branch locally and run `yarn` to install new deps
2. etc...

## Screenshots (if applicable)
![Screen Shot 2021-11-23 at 1 21 07 PM](https://user-images.githubusercontent.com/89934888/143089908-aab7413f-3266-4c52-974b-09a22f525e12.png)

