### PR TITLE
fix: fix asset search crash on enter press

### DIFF
--- a/src/components/AssetSearch/AssetSearch.tsx
+++ b/src/components/AssetSearch/AssetSearch.tsx
@@ -47,7 +47,7 @@ export const AssetSearch = ({ onClick, filterBy }: AssetSearchProps) => {
 
   return (
     <>
-      <Box as='form' mb={3} visibility='visible'>
+      <Box as='form' mb={3} visibility='visible' onSubmit={(e: any) => e.preventDefault()}>
         <InputGroup>
           <InputLeftElement pointerEvents='none'>
             <SearchIcon color='gray.300' />

--- a/src/components/AssetSearch/AssetSearch.tsx
+++ b/src/components/AssetSearch/AssetSearch.tsx
@@ -1,7 +1,7 @@
 import { SearchIcon } from '@chakra-ui/icons'
 import { Box, Input, InputGroup, InputLeftElement } from '@chakra-ui/react'
 import { Asset, NetworkTypes } from '@shapeshiftoss/types'
-import { useEffect, useMemo, useState } from 'react'
+import { FormEvent, useEffect, useMemo, useState } from 'react'
 import { useForm } from 'react-hook-form'
 import { useDispatch, useSelector } from 'react-redux'
 import { fetchAssets } from 'state/slices/assetsSlice/assetsSlice'
@@ -47,7 +47,12 @@ export const AssetSearch = ({ onClick, filterBy }: AssetSearchProps) => {
 
   return (
     <>
-      <Box as='form' mb={3} visibility='visible' onSubmit={(e: any) => e.preventDefault()}>
+      <Box
+        as='form'
+        mb={3}
+        visibility='visible'
+        onSubmit={(e: FormEvent<unknown>) => e.preventDefault()}
+      >
         <InputGroup>
           <InputLeftElement pointerEvents='none'>
             <SearchIcon color='gray.300' />


### PR DESCRIPTION
## Description

- fixes app crash when a user presses the enter button while using asset search.

closes #495 

## Notice

Before submitting a pull request, please make sure you have answered the following:

- [x] Have you followed the guidelines in our [Contributing]('https://github.com/shapeshift/web/CONTRIBUTING.md) guide?
- [x] Have you checked to ensure there aren't other open [Pull Requests](https://github.com/shapeshift/web/pulls) for the same update/change?
- [x] Do all new and existing tests pass? Does the linter pass?

## Pull Request Type

- [ ] :bug: Bug fix (Non-breaking Change: Fixes an issue)
- [ ] :hammer_and_wrench: Chore (Non-breaking Change: Doc updates, pkg upgrades, typos, etc..)
- [ ] :nail_care: New Feature (Breaking/Non-breaking Change)

## Issue (if applicable)

If applicable, please link to the github issue and put `closes #XXXX` in your comment to auto-close the issue that your PR fixes.

## Testing

Please outline all testing steps

1. Pull branch locally and run `yarn` to install new deps
2. etc...

## Screenshots (if applicable)
