### PR TITLE
fix: calculate and validate fees on handleInputChange

### DIFF
--- a/src/components/Modals/Send/Form.tsx
+++ b/src/components/Modals/Send/Form.tsx
@@ -32,7 +32,8 @@ export enum SendFormFields {
   FiatAmount = 'fiat.amount',
   Fiat = 'fiat',
   FiatSymbol = 'fiat.symbol',
-  Transaction = 'transaction'
+  Transaction = 'transaction',
+  AmountFieldError = 'amountFieldError'
 }
 
 export type SendInput = {

--- a/src/components/Modals/Send/hooks/useSendDetails/useSendDetails.test.tsx
+++ b/src/components/Modals/Send/hooks/useSendDetails/useSendDetails.test.tsx
@@ -178,7 +178,6 @@ describe('useSendDetails', () => {
         assetBalance: balances.ethereum,
         accountBalances: getEthAccountBalances()
       })
-      expect(result.current.amountFieldError).toBe('')
       expect(result.current.balancesLoading).toBe(false)
       expect(result.current.fieldName).toBe('fiat.amount')
       expect(result.current.loading).toBe(false)

--- a/src/components/Modals/Send/hooks/useSendDetails/useSendDetails.tsx
+++ b/src/components/Modals/Send/hooks/useSendDetails/useSendDetails.tsx
@@ -232,6 +232,7 @@ export const useSendDetails = (): UseSendDetailsReturnType => {
       setValue(key, amount)
 
       const estimatedFees = await estimateFees()
+      setValue(SendFormFields.EstimatedFees, estimatedFees)
 
       const values = getValues()
 

--- a/src/components/Modals/Send/hooks/useSendDetails/useSendDetails.tsx
+++ b/src/components/Modals/Send/hooks/useSendDetails/useSendDetails.tsx
@@ -31,7 +31,7 @@ type UseSendDetailsReturnType = {
   balancesLoading: boolean
   fieldName: AmountFieldName
   handleInputChange(inputValue: string): void
-  handleNextClick(): Promise<void>
+  handleNextClick(): void
   handleSendMax(): Promise<void>
   loading: boolean
   toggleCurrency(): void

--- a/src/components/Modals/Send/hooks/useSendDetails/useSendDetails.tsx
+++ b/src/components/Modals/Send/hooks/useSendDetails/useSendDetails.tsx
@@ -27,7 +27,6 @@ import { useAccountBalances } from '../useAccountBalances/useAccountBalances'
 type AmountFieldName = SendFormFields.FiatAmount | SendFormFields.CryptoAmount
 
 type UseSendDetailsReturnType = {
-  amountFieldError: string
   balancesLoading: boolean
   fieldName: AmountFieldName
   handleInputChange(inputValue: string): void
@@ -62,8 +61,6 @@ export const useSendDetails = (): UseSendDetailsReturnType => {
   const { chain, tokenId } = asset
 
   const getAssetData = useGetAssetData({ chain, tokenId })
-
-  const [amountFieldError, setAmountFieldError] = useState('')
 
   useEffect(() => {
     if (balanceError) {
@@ -240,8 +237,8 @@ export const useSendDetails = (): UseSendDetailsReturnType => {
         .minus(fromBaseUnit(estimatedFees.fast.txFee, asset.precision))
         .gte(values.crypto.amount)
 
-      if (!hasValidBalance) setAmountFieldError('common.insufficientFunds')
-      else setAmountFieldError('')
+      if (!hasValidBalance) setValue(SendFormFields.AmountFieldError, 'common.insufficientFunds')
+      else setValue(SendFormFields.AmountFieldError, '')
     }, 1000),
     [
       asset.price,
@@ -267,7 +264,6 @@ export const useSendDetails = (): UseSendDetailsReturnType => {
   }
 
   return {
-    amountFieldError,
     balancesLoading,
     fieldName,
     accountBalances,

--- a/src/components/Modals/Send/hooks/useSendDetails/useSendDetails.tsx
+++ b/src/components/Modals/Send/hooks/useSendDetails/useSendDetails.tsx
@@ -6,8 +6,8 @@ import {
 } from '@shapeshiftoss/chain-adapters'
 import { bip32ToAddressNList } from '@shapeshiftoss/hdwallet-core'
 import { chainAdapters, ChainTypes } from '@shapeshiftoss/types'
-import get from 'lodash/get'
-import { useEffect, useState } from 'react'
+import { debounce } from 'lodash'
+import { useCallback, useEffect, useState } from 'react'
 import { useFormContext, useWatch } from 'react-hook-form'
 import { useTranslate } from 'react-polyglot'
 import { useSelector } from 'react-redux'
@@ -17,6 +17,7 @@ import { useWallet } from 'context/WalletProvider/WalletProvider'
 import { AssetMarketData, useGetAssetData } from 'hooks/useAsset/useAsset'
 import { useFlattenedBalances } from 'hooks/useBalances/useFlattenedBalances'
 import { BigNumber, bnOrZero } from 'lib/bignumber/bignumber'
+import { fromBaseUnit } from 'lib/math'
 import { ReduxState } from 'state/reducer'
 
 import { SendFormFields } from '../../Form'
@@ -34,8 +35,6 @@ type UseSendDetailsReturnType = {
   handleSendMax(): Promise<void>
   loading: boolean
   toggleCurrency(): void
-  validateCryptoAmount(value: string): boolean | string
-  validateFiatAmount(value: string): boolean | string
   accountBalances: {
     crypto: BigNumber
     fiat: BigNumber
@@ -48,13 +47,7 @@ export const useSendDetails = (): UseSendDetailsReturnType => {
   const history = useHistory()
   const toast = useToast()
   const translate = useTranslate()
-  const {
-    clearErrors,
-    getValues,
-    setValue,
-    setError,
-    formState: { errors }
-  } = useFormContext()
+  const { getValues, setValue } = useFormContext()
   const [asset, address] = useWatch({ name: [SendFormFields.Asset, SendFormFields.Address] }) as [
     AssetMarketData,
     string
@@ -69,6 +62,8 @@ export const useSendDetails = (): UseSendDetailsReturnType => {
   const { chain, tokenId } = asset
 
   const getAssetData = useGetAssetData({ chain, tokenId })
+
+  const [amountFieldError, setAmountFieldError] = useState('')
 
   useEffect(() => {
     if (balanceError) {
@@ -89,7 +84,7 @@ export const useSendDetails = (): UseSendDetailsReturnType => {
     (state: ReduxState) => state.preferences.accountTypes[asset.chain]
   )
 
-  const estimateFees = async (): Promise<chainAdapters.FeeDataEstimate<ChainTypes>> => {
+  const estimateFees = useCallback(async (): Promise<chainAdapters.FeeDataEstimate<ChainTypes>> => {
     const values = getValues()
 
     if (!wallet) throw new Error('No wallet connected')
@@ -133,13 +128,11 @@ export const useSendDetails = (): UseSendDetailsReturnType => {
       default:
         throw new Error('unsupported chain type')
     }
-  }
+  }, [adapter, asset, chainAdapterManager, currentAccountType, getValues, wallet])
 
   const handleNextClick = async () => {
     try {
       setLoading(true)
-      const estimatedFees = await estimateFees()
-      setValue(SendFormFields.EstimatedFees, estimatedFees)
       history.push(SendRoutes.Confirm)
     } catch (error) {
       console.error(error)
@@ -223,45 +216,47 @@ export const useSendDetails = (): UseSendDetailsReturnType => {
     }
   }
 
-  const handleInputChange = (inputValue: string) => {
-    const key =
-      fieldName !== SendFormFields.FiatAmount
-        ? SendFormFields.FiatAmount
-        : SendFormFields.CryptoAmount
-    const assetPrice = asset.price
-    const amount =
-      fieldName === SendFormFields.FiatAmount
-        ? bnOrZero(inputValue).div(assetPrice).toString()
-        : bnOrZero(inputValue).times(assetPrice).toString()
-    setValue(key, amount)
-  }
+  // eslint-disable-next-line react-hooks/exhaustive-deps
+  const handleInputChange = useCallback(
+    debounce(async (inputValue: string) => {
+      const key =
+        fieldName !== SendFormFields.FiatAmount
+          ? SendFormFields.FiatAmount
+          : SendFormFields.CryptoAmount
+      const assetPrice = asset.price
+      const amount =
+        fieldName === SendFormFields.FiatAmount
+          ? bnOrZero(inputValue).div(assetPrice).toString()
+          : bnOrZero(inputValue).times(assetPrice).toString()
 
-  const validateCryptoAmount = (value: string) => {
-    const hasValidBalance = accountBalances.crypto.gte(value)
-    const _value = bnOrZero(value)
-    if (_value.isEqualTo(0)) return ''
-    return hasValidBalance || 'common.insufficientFunds'
-  }
+      setValue(key, amount)
 
-  const validateFiatAmount = (value: string) => {
-    const hasValidBalance = accountBalances.fiat.gte(value)
-    const _value = bnOrZero(value)
-    if (_value.isEqualTo(0)) return ''
-    return hasValidBalance || 'common.insufficientFunds'
-  }
+      const estimatedFees = await estimateFees()
 
-  const cryptoError = get(errors, 'crypto.amount.message', null)
-  const fiatError = get(errors, 'fiat.amount.message', null)
-  const amountFieldError = cryptoError || fiatError
+      const values = getValues()
+
+      const hasValidBalance = accountBalances.crypto
+        .minus(fromBaseUnit(estimatedFees.fast.txFee, asset.precision))
+        .gte(values.crypto.amount)
+
+      if (!hasValidBalance) setAmountFieldError('common.insufficientFunds')
+      else setAmountFieldError('')
+    }, 1000),
+    [
+      asset.price,
+      fieldName,
+      setValue,
+      estimateFees,
+      adapter,
+      asset,
+      chainAdapterManager,
+      currentAccountType,
+      getValues,
+      wallet
+    ]
+  )
 
   const toggleCurrency = () => {
-    if (amountFieldError) {
-      // Toggles an existing error to the other field if present
-      const clearErrorKey = fiatError ? SendFormFields.FiatAmount : SendFormFields.CryptoAmount
-      const setErrorKey = fiatError ? SendFormFields.CryptoAmount : SendFormFields.FiatAmount
-      clearErrors(clearErrorKey)
-      setError(setErrorKey, { message: 'common.insufficientFunds' })
-    }
     setFieldName(
       fieldName === SendFormFields.FiatAmount
         ? SendFormFields.CryptoAmount
@@ -278,8 +273,6 @@ export const useSendDetails = (): UseSendDetailsReturnType => {
     handleNextClick,
     handleSendMax,
     loading,
-    toggleCurrency,
-    validateCryptoAmount,
-    validateFiatAmount
+    toggleCurrency
   }
 }

--- a/src/components/Modals/Send/hooks/useSendDetails/useSendDetails.tsx
+++ b/src/components/Modals/Send/hooks/useSendDetails/useSendDetails.tsx
@@ -252,7 +252,8 @@ export const useSendDetails = (): UseSendDetailsReturnType => {
       chainAdapterManager,
       currentAccountType,
       getValues,
-      wallet
+      wallet,
+      accountBalances
     ]
   )
 

--- a/src/components/Modals/Send/views/Details.tsx
+++ b/src/components/Modals/Send/views/Details.tsx
@@ -33,13 +33,17 @@ export const Details = () => {
   const history = useHistory()
   const translate = useTranslate()
 
-  const [asset, crypto, fiat] = useWatch({
-    name: [SendFormFields.Asset, SendFormFields.Crypto, SendFormFields.Fiat]
+  const [asset, crypto, fiat, amountFieldError] = useWatch({
+    name: [
+      SendFormFields.Asset,
+      SendFormFields.Crypto,
+      SendFormFields.Fiat,
+      SendFormFields.AmountFieldError
+    ]
   })
 
   const { send } = useModal()
   const {
-    amountFieldError,
     balancesLoading,
     fieldName,
     accountBalances,

--- a/src/components/Modals/Send/views/Details.tsx
+++ b/src/components/Modals/Send/views/Details.tsx
@@ -29,10 +29,7 @@ import { SendRoutes } from '../Send'
 import { SendMaxButton } from '../SendMaxButton/SendMaxButton'
 
 export const Details = () => {
-  const {
-    control,
-    formState: { isValid }
-  } = useFormContext()
+  const { control } = useFormContext()
   const history = useHistory()
   const translate = useTranslate()
 
@@ -50,9 +47,7 @@ export const Details = () => {
     handleNextClick,
     handleSendMax,
     loading,
-    toggleCurrency,
-    validateCryptoAmount,
-    validateFiatAmount
+    toggleCurrency
   } = useSendDetails()
 
   return (
@@ -125,8 +120,7 @@ export const Details = () => {
               }
               inputRightElement={<SendMaxButton onClick={handleSendMax} />}
               rules={{
-                required: true,
-                validate: { validateCryptoAmount }
+                required: true
               }}
             />
           )}
@@ -149,8 +143,7 @@ export const Details = () => {
               }
               inputRightElement={<SendMaxButton onClick={handleSendMax} />}
               rules={{
-                required: true,
-                validate: { validateFiatAmount }
+                required: true
               }}
             />
           )}
@@ -160,7 +153,7 @@ export const Details = () => {
         <Stack flex={1}>
           <Button
             isFullWidth
-            isDisabled={!isValid || loading}
+            isDisabled={!!amountFieldError || loading}
             colorScheme={amountFieldError ? 'red' : 'blue'}
             size='lg'
             onClick={handleNextClick}


### PR DESCRIPTION
- Add getFees call in handleInputChange and debounce
- set the fees on every input change and Validate that (balance-fee > sendAmount)
- no longer set the fees on clicking next.

- Got rid of the validateCryptoAmount and validateFiatAmount amount validators because we would need to redundantly do a debounced getFees call + logic there as well to correctly validate them.  The error message & disabled button is now only based on the amountFieldError string that gets set in handleInputChange
