### PR TITLE
fix: use proper format for fiat in asset header

### DIFF
--- a/src/pages/Assets/AssetDetails/AssetHeader/AssetHeader.tsx
+++ b/src/pages/Assets/AssetDetails/AssetHeader/AssetHeader.tsx
@@ -28,6 +28,7 @@ import { RawText, Text } from 'components/Text'
 import { useWallet } from 'context/WalletProvider/WalletProvider'
 import { useBalanceChartData } from 'hooks/useBalanceChartData/useBalanceChartData'
 import { useFlattenedBalances } from 'hooks/useBalances/useFlattenedBalances'
+import { useLocaleFormatter } from 'hooks/useLocaleFormatter/useLocaleFormatter'
 import { useWalletSupportsChain } from 'hooks/useWalletSupportsChain/useWalletSupportsChain'
 import { fromBaseUnit } from 'lib/math'
 import { useAsset } from 'pages/Assets/Asset'
@@ -52,7 +53,10 @@ export const AssetHeader = ({ isLoaded }: { isLoaded: boolean }) => {
   const { name, symbol, description, icon } = asset || {}
   const { changePercent24Hr, price } = marketData || {}
   const percentChange = changePercent24Hr ?? 0
-  const assetPrice = price ?? 0
+  const {
+    number: { toFiat }
+  } = useLocaleFormatter({ fiatType: 'USD' })
+  const assetPrice = toFiat(price) ?? 0
   const [timeframe, setTimeframe] = useState(HistoryTimeframe.DAY)
   const translate = useTranslate()
   const [showDescription, setShowDescription] = useState(false)


### PR DESCRIPTION
## Description

Use proper format for fiat in asset header

## Notice

Before submitting a pull request, please make sure you have answered the following:

- [x] Have you followed the guidelines in our [Contributing]('https://github.com/shapeshift/web/CONTRIBUTING.md) guide?
- [x] Have you checked to ensure there aren't other open [Pull Requests](https://github.com/shapeshift/web/pulls) for the same update/change?
- [x] Do all new and existing tests pass? Does the linter pass?

## Pull Request Type

- [x] :bug: Bug fix (Non-breaking Change: Fixes an issue)
- [ ] :hammer_and_wrench: Chore (Non-breaking Change: Doc updates, pkg upgrades, typos, etc..)
- [ ] :nail_care: New Feature (Breaking/Non-breaking Change)

## Issue (if applicable)

closes #497 

## Screenshots (if applicable)

![2021-11-29_08-01](https://user-images.githubusercontent.com/5672954/143822964-442f912f-d291-4772-ae88-a94cd6948b2f.png)