### PR TITLE
chore: refactor tx history state slice

### DIFF
--- a/package.json
+++ b/package.json
@@ -66,6 +66,7 @@
     "react-virtualized-auto-sizer": "^1.0.5",
     "react-window": "^1.8.6",
     "redux-persist": "^6.0.0",
+    "reselect": "^4.1.5",
     "scrypt-js": "^3.0.1",
     "web-vitals": "^2.1.0",
     "web3": "^1.6.0"

--- a/src/components/Trade/TradeConfirm/TradeConfirm.tsx
+++ b/src/components/Trade/TradeConfirm/TradeConfirm.tsx
@@ -9,7 +9,8 @@ import {
   Stack,
   useToast
 } from '@chakra-ui/react'
-import { ChainTypes, SwapperType } from '@shapeshiftoss/types'
+import { caip19 } from '@shapeshiftoss/caip'
+import { ChainTypes, ContractTypes, NetworkTypes, SwapperType } from '@shapeshiftoss/types'
 import { useState } from 'react'
 import { useFormContext } from 'react-hook-form'
 import { useTranslate } from 'react-polyglot'
@@ -27,7 +28,7 @@ import { useLocaleFormatter } from 'hooks/useLocaleFormatter/useLocaleFormatter'
 import { bnOrZero } from 'lib/bignumber/bignumber'
 import { firstNonZeroDecimal } from 'lib/math'
 import { ReduxState } from 'state/reducer'
-import { selectTxHistory } from 'state/slices/txHistorySlice/txHistorySlice'
+import { selectTxHistoryByFilter } from 'state/slices/txHistorySlice/txHistorySlice'
 
 import { AssetToAsset } from './AssetToAsset'
 
@@ -55,9 +56,12 @@ export const TradeConfirm = ({ history }: RouterProps) => {
     state: { wallet }
   } = useWallet()
   const { chain, tokenId } = sellAsset.currency
-  const asset = tokenId ?? chain
+  const network = NetworkTypes.MAINNET
+  const contractType = ContractTypes.ERC20
+  const extra = { contractType, tokenId }
+  const caip = caip19.toCAIP19({ chain, network, ...(tokenId ? extra : undefined) })
   const txs = useSelector((state: ReduxState) =>
-    selectTxHistory(state, { chain, filter: { identifier: asset, txid } })
+    selectTxHistoryByFilter(state, { caip19: caip, txid })
   )
   const transaction = txs[0]
   const status = transaction && transaction?.status

--- a/src/components/Transactions/TransactionRow.tsx
+++ b/src/components/Transactions/TransactionRow.tsx
@@ -16,15 +16,18 @@ import { RawText, Text } from 'components/Text'
 import { fromBaseUnit } from 'lib/math'
 import { ReduxState } from 'state/reducer'
 import { fetchAsset } from 'state/slices/assetsSlice/assetsSlice'
-import { Tx } from 'state/slices/txHistorySlice/txHistorySlice'
+import { selectTxById } from 'state/slices/txHistorySlice/txHistorySlice'
 
 dayjs.extend(relativeTime)
 dayjs.extend(localizedFormat)
 
-export const TransactionRow = ({ tx, activeAsset }: { tx: Tx; activeAsset?: Asset }) => {
+export const TransactionRow = ({ txId, activeAsset }: { txId: string; activeAsset?: Asset }) => {
   const ref = useRef<HTMLHeadingElement>(null)
   const dispatch = useDispatch()
-  const asset = useSelector((state: ReduxState) => state.assets[tx.asset.toLowerCase() ?? tx.chain])
+  const tx = useSelector((state: ReduxState) => selectTxById(state, txId))
+  const asset = useSelector(
+    (state: ReduxState) => state.assets?.[tx.asset.toLowerCase() ?? tx.chain]
+  )
   // stables need precision of eth (18) rather than 10
   const chainAsset = useSelector((state: ReduxState) => state.assets[tx.chain])
   const [isOpen, setIsOpen] = useState(false)

--- a/src/hooks/useBalanceChartData/useBalanceChartData.ts
+++ b/src/hooks/useBalanceChartData/useBalanceChartData.ts
@@ -28,7 +28,7 @@ import { bn, bnOrZero } from 'lib/bignumber/bignumber'
 import { usePriceHistory } from 'pages/Assets/hooks/usePriceHistory/usePriceHistory'
 import { PriceHistoryData } from 'pages/Assets/hooks/usePriceHistory/usePriceHistory'
 import { ReduxState } from 'state/reducer'
-import { selectTxHistory, Tx } from 'state/slices/txHistorySlice/txHistorySlice'
+import { selectTxs, Tx } from 'state/slices/txHistorySlice/txHistorySlice'
 
 type PriceAtBlockTimeArgs = {
   time: number
@@ -355,10 +355,7 @@ export const useBalanceChartData: UseBalanceChartData = args => {
   const { portfolioAssets, portfolioAssetsLoading } = usePortfolioAssets()
   // we can't tell if txs are finished loading over the websocket, so
   // debounce a bit before doing expensive computations
-  const txs = useDebounce(
-    useSelector((state: ReduxState) => selectTxHistory(state, {})),
-    500
-  )
+  const txs = useDebounce(useSelector(selectTxs), 500)
   const { data: priceHistoryData, loading: priceHistoryLoading } = usePriceHistory(args)
 
   useEffect(() => {

--- a/src/lib/txs.ts
+++ b/src/lib/txs.ts
@@ -2,8 +2,8 @@ import { CAIP2, caip2, CAIP19, caip19 } from '@shapeshiftoss/caip'
 import { ChainTypes, ContractTypes, NetworkTypes } from '@shapeshiftoss/types'
 import { Tx } from 'state/slices/txHistorySlice/txHistorySlice'
 
+// TODO(0xdef1cafe): remove this when we have caips from unchained :)
 export const caip2FromTx = ({ chain, network }: Tx): CAIP2 => caip2.toCAIP2({ chain, network })
-// ideally txs from unchained should include caip19
 export const caip19FromTx = (tx: Tx): CAIP19 => {
   const { chain, network, asset: tokenId } = tx
   const ethereumCAIP2 = caip2.toCAIP2({

--- a/src/lib/txs.ts
+++ b/src/lib/txs.ts
@@ -1,0 +1,20 @@
+import { CAIP2, caip2, CAIP19, caip19 } from '@shapeshiftoss/caip'
+import { ChainTypes, ContractTypes, NetworkTypes } from '@shapeshiftoss/types'
+import { Tx } from 'state/slices/txHistorySlice/txHistorySlice'
+
+export const caip2FromTx = ({ chain, network }: Tx): CAIP2 => caip2.toCAIP2({ chain, network })
+// ideally txs from unchained should include caip19
+export const caip19FromTx = (tx: Tx): CAIP19 => {
+  const { chain, network, asset: tokenId } = tx
+  const ethereumCAIP2 = caip2.toCAIP2({
+    chain: ChainTypes.Ethereum,
+    network: NetworkTypes.MAINNET
+  })
+  const assetCAIP2 = caip2FromTx(tx)
+  const contractType =
+    assetCAIP2 === ethereumCAIP2 && tokenId.startsWith('0x') ? ContractTypes.ERC20 : undefined
+
+  const extra = contractType ? { contractType, tokenId: tokenId.toLowerCase() } : undefined
+  const assetCAIP19 = caip19.toCAIP19({ chain, network, ...extra })
+  return assetCAIP19
+}

--- a/src/pages/Assets/AssetDetails/AssetHeader/SegwitSelectCard.tsx
+++ b/src/pages/Assets/AssetDetails/AssetHeader/SegwitSelectCard.tsx
@@ -42,7 +42,7 @@ export const SegwitSelectCard = ({ chain }: { chain: ChainTypes }) => {
             }
           >
             {accountTypes?.map(accountType => (
-              <MenuItemOption value={accountType} fontSize='sm'>
+              <MenuItemOption value={accountType} key={accountType} fontSize='sm'>
                 {accountType === UtxoAccountType.SegwitNative ? (
                   <Tooltip
                     label={translate('assets.assetDetails.assetHeader.SegwitNativeTooltip')}

--- a/src/pages/Assets/AssetDetails/AssetHistory.tsx
+++ b/src/pages/Assets/AssetDetails/AssetHistory.tsx
@@ -9,7 +9,7 @@ import { TransactionRow } from 'components/Transactions/TransactionRow'
 import { useWallet } from 'context/WalletProvider/WalletProvider'
 import { useWalletSupportsChain } from 'hooks/useWalletSupportsChain/useWalletSupportsChain'
 import { ReduxState } from 'state/reducer'
-import { selectTxIdsByCAIP19 } from 'state/slices/txHistorySlice/txHistorySlice'
+import { selectTxIdsByFilter } from 'state/slices/txHistorySlice/txHistorySlice'
 
 import { useAsset } from '../Asset'
 import { useInfiniteScroll } from '../hooks/useInfiniteScroll/useInfiniteScroll'
@@ -24,10 +24,12 @@ export const AssetHistory = () => {
   wallet?.getFeatures()
 
   const walletSupportsChain = useWalletSupportsChain({ asset, wallet })
-  // const accountType = useSelector(
-  //   (state: ReduxState) => state.preferences.accountTypes[asset.chain]
-  // )
-  const txIds = useSelector((state: ReduxState) => selectTxIdsByCAIP19(state, asset.caip19))
+  const accountType = useSelector(
+    (state: ReduxState) => state.preferences.accountTypes[asset.chain]
+  )
+  const txIds = useSelector((state: ReduxState) =>
+    selectTxIdsByFilter(state, { accountType, caip19: asset.caip19 })
+  )
 
   const { next, data, hasMore } = useInfiniteScroll(txIds)
 
@@ -47,20 +49,22 @@ export const AssetHistory = () => {
           {translate('assets.assetDetails.assetHistory.transactionHistory')}
         </Card.Heading>
       </Card.Header>
-      <Card.Body px={2} pt={0}>
-        <InfiniteScroll
-          pageStart={0}
-          loadMore={next}
-          hasMore={hasMore}
-          loader={
-            <Center key={0}>
-              <CircularProgress isIndeterminate />
-            </Center>
-          }
-        >
-          {txRows}
-        </InfiniteScroll>
-      </Card.Body>
+      {data?.length ? (
+        <Card.Body px={2} pt={0}>
+          <InfiniteScroll
+            pageStart={0}
+            loadMore={next}
+            hasMore={hasMore}
+            loader={
+              <Center key={0}>
+                <CircularProgress isIndeterminate />
+              </Center>
+            }
+          >
+            {txRows}
+          </InfiniteScroll>
+        </Card.Body>
+      ) : null}
     </Card>
   )
 }

--- a/src/pages/Assets/AssetDetails/AssetHistory.tsx
+++ b/src/pages/Assets/AssetDetails/AssetHistory.tsx
@@ -1,4 +1,5 @@
 import { Center } from '@chakra-ui/layout'
+import { useMemo } from 'react'
 import InfiniteScroll from 'react-infinite-scroller'
 import { useTranslate } from 'react-polyglot'
 import { useSelector } from 'react-redux'
@@ -8,7 +9,7 @@ import { TransactionRow } from 'components/Transactions/TransactionRow'
 import { useWallet } from 'context/WalletProvider/WalletProvider'
 import { useWalletSupportsChain } from 'hooks/useWalletSupportsChain/useWalletSupportsChain'
 import { ReduxState } from 'state/reducer'
-import { selectTxHistory, Tx } from 'state/slices/txHistorySlice/txHistorySlice'
+import { selectTxIdsByCAIP19 } from 'state/slices/txHistorySlice/txHistorySlice'
 
 import { useAsset } from '../Asset'
 import { useInfiniteScroll } from '../hooks/useInfiniteScroll/useInfiniteScroll'
@@ -23,21 +24,19 @@ export const AssetHistory = () => {
   wallet?.getFeatures()
 
   const walletSupportsChain = useWalletSupportsChain({ asset, wallet })
-  const accountType = useSelector(
-    (state: ReduxState) => state.preferences.accountTypes[asset.chain]
-  )
-  const txs = useSelector((state: ReduxState) =>
-    selectTxHistory(state, {
-      chain: asset.chain,
-      filter: {
-        identifier: asset.tokenId ?? asset.chain,
-        accountType,
-        tradeIdentifier: asset.symbol
-      }
-    })
-  )
+  // const accountType = useSelector(
+  //   (state: ReduxState) => state.preferences.accountTypes[asset.chain]
+  // )
+  const txIds = useSelector((state: ReduxState) => selectTxIdsByCAIP19(state, asset.caip19))
 
-  const { next, data, hasMore } = useInfiniteScroll(txs)
+  const { next, data, hasMore } = useInfiniteScroll(txIds)
+
+  const txRows = useMemo(() => {
+    if (!asset.caip19) return null
+    return data?.map((txId: string, i) => (
+      <TransactionRow key={txId} txId={txId} activeAsset={asset} />
+    ))
+  }, [asset, data])
 
   if (!walletSupportsChain) return null
 
@@ -59,13 +58,7 @@ export const AssetHistory = () => {
             </Center>
           }
         >
-          {data?.map((tx: Tx, i) => (
-            <TransactionRow
-              key={`${i}-${tx.type}-${tx.txid}-${tx.asset}`}
-              tx={tx}
-              activeAsset={asset}
-            />
-          ))}
+          {txRows}
         </InfiniteScroll>
       </Card.Body>
     </Card>

--- a/src/pages/Dashboard/RecentTransactions.tsx
+++ b/src/pages/Dashboard/RecentTransactions.tsx
@@ -1,13 +1,20 @@
 import { Stack } from '@chakra-ui/react'
+import { useMemo } from 'react'
 import { useSelector } from 'react-redux'
 import { Card } from 'components/Card/Card'
 import { Text } from 'components/Text'
 import { TransactionRow } from 'components/Transactions/TransactionRow'
 import { ReduxState } from 'state/reducer'
-import { selectTxHistory, Tx } from 'state/slices/txHistorySlice/txHistorySlice'
+import { selectLastNTxIds } from 'state/slices/txHistorySlice/txHistorySlice'
 
 export const RecentTransactions = () => {
-  const txs = useSelector((state: ReduxState) => selectTxHistory(state, {}))
+  const recentTxIds = useSelector((state: ReduxState) => selectLastNTxIds(state, 10))
+  const txRows = useMemo(
+    () => recentTxIds.map((txId, i) => <TransactionRow key={`${txId}-${i}`} txId={txId} />),
+
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+    [JSON.stringify(recentTxIds)]
+  )
 
   return (
     <Card>
@@ -17,11 +24,7 @@ export const RecentTransactions = () => {
         </Card.Heading>
       </Card.Header>
       <Card.Body px={2} pt={0}>
-        <Stack spacing={0}>
-          {txs?.slice(0, 10).map((tx: Tx, i) => (
-            <TransactionRow key={`${i}-${tx.type}-${tx.txid}-${tx.asset}`} tx={tx} />
-          ))}
-        </Stack>
+        <Stack spacing={0}>{txRows}</Stack>
       </Card.Body>
     </Card>
   )

--- a/src/pages/Dashboard/RecentTransactions.tsx
+++ b/src/pages/Dashboard/RecentTransactions.tsx
@@ -11,9 +11,7 @@ export const RecentTransactions = () => {
   const recentTxIds = useSelector((state: ReduxState) => selectLastNTxIds(state, 10))
   const txRows = useMemo(
     () => recentTxIds.map((txId, i) => <TransactionRow key={`${txId}-${i}`} txId={txId} />),
-
-    // eslint-disable-next-line react-hooks/exhaustive-deps
-    [JSON.stringify(recentTxIds)]
+    [recentTxIds]
   )
 
   return (

--- a/src/state/slices/txHistorySlice/txHistorySlice.test.ts
+++ b/src/state/slices/txHistorySlice/txHistorySlice.test.ts
@@ -18,13 +18,19 @@ describe('txHistorySlice', () => {
   describe('onMessage', () => {
     it('can sort txs going into store', async () => {
       store.dispatch(txHistory.actions.clear())
+
+      // shuffle txs before inserting them into the store
       const shuffledTxs = shuffle(testTxs)
       shuffledTxs.forEach(tx => store.dispatch(txHistory.actions.onMessage({ message: tx })))
       const history = store.getState().txHistory
+      // these ids should be sorted by the reducer going in
       const ids = history.ids
+
+      // this is the same sorting logic, by block time descending
       const txEntriesById = entries(history.byId)
       const sorted = orderBy(txEntriesById, ([_id, tx]: [string, Tx]) => tx.blockTime, ['desc'])
       const sortedIds = map(sorted, ([id]) => id)
+
       expect(ids).toEqual(sortedIds)
     })
 

--- a/src/state/slices/txHistorySlice/txHistorySlice.test.ts
+++ b/src/state/slices/txHistorySlice/txHistorySlice.test.ts
@@ -208,7 +208,7 @@ describe('selectTxHistory', () => {
 })
 
 describe('selectLastNTxIds', () => {
-  fit('should memoize', () => {
+  it('should memoize', () => {
     const state = {
       ...mockStore,
       txHistory: {

--- a/src/state/slices/txHistorySlice/txHistorySlice.test.ts
+++ b/src/state/slices/txHistorySlice/txHistorySlice.test.ts
@@ -1,206 +1,224 @@
-import { chainAdapters, ChainTypes } from '@shapeshiftoss/types'
-import { mockStore } from 'jest/mocks/store'
-import { BtcSend, EthReceive, EthSend } from 'jest/mocks/txs'
+import { UtxoAccountType } from '@shapeshiftoss/types'
+import entries from 'lodash/entries'
+import map from 'lodash/map'
+import orderBy from 'lodash/orderBy'
+import shuffle from 'lodash/shuffle'
+// import { mockStore } from 'jest/mocks/store'
+import { BtcSend, EthReceive, EthSend, testTxs } from 'jest/mocks/txs'
 import { store } from 'state/store'
 
-import { selectTxHistory, txHistory } from './txHistorySlice'
+import { makeTxId, Tx, txHistory } from './txHistorySlice'
 
 describe('txHistorySlice', () => {
   it('returns empty object for initialState', async () => {
-    expect(store.getState().txHistory).toEqual({
-      [ChainTypes.Ethereum]: {},
-      [ChainTypes.Bitcoin]: {}
-    })
+    expect(store.getState().txHistory).toEqual({ byId: {}, ids: [] })
   })
 
   describe('onMessage', () => {
-    it('should have correct starting state', async () => {
-      expect(store.getState().txHistory[ChainTypes.Ethereum]).toEqual({})
-      expect(store.getState().txHistory[ChainTypes.Bitcoin]).toEqual({})
+    it('can sort txs going into store', async () => {
+      store.dispatch(txHistory.actions.clear())
+      const shuffledTxs = shuffle(testTxs)
+      shuffledTxs.forEach(tx => store.dispatch(txHistory.actions.onMessage({ message: tx })))
+      const history = store.getState().txHistory
+      const ids = history.ids
+      const txEntriesById = entries(history.byId)
+      const sorted = orderBy(txEntriesById, ([_id, tx]: [string, Tx]) => tx.blockTime, ['desc'])
+      const sortedIds = map(sorted, ([id]) => id)
+      expect(ids).toEqual(sortedIds)
     })
 
     it('should add new transactions', async () => {
+      store.dispatch(txHistory.actions.clear())
+
       // new eth transaction (send)
       store.dispatch(txHistory.actions.onMessage({ message: EthSend }))
-      expect(Object.values(store.getState().txHistory[ChainTypes.Ethereum]).length).toBe(1)
+      expect(Object.values(store.getState().txHistory.ids).length).toBe(1)
 
       // duplicate eth transaction (send)
       store.dispatch(txHistory.actions.onMessage({ message: EthSend }))
-      expect(Object.values(store.getState().txHistory[ChainTypes.Ethereum]).length).toBe(1)
+      expect(Object.values(store.getState().txHistory.ids).length).toBe(1)
+
+      const ethSendTxid = makeTxId(EthSend)
+      const ethReceiveTxid = makeTxId(EthReceive)
 
       // new eth transaction (receive)
       store.dispatch(txHistory.actions.onMessage({ message: EthReceive }))
-      expect(Object.values(store.getState().txHistory[ChainTypes.Ethereum]).length).toBe(2)
+      expect(Object.values(store.getState().txHistory.ids).length).toBe(2)
 
       // eth data exists
-      expect(store.getState().txHistory[ChainTypes.Ethereum]).toBeTruthy()
+      expect(store.getState().txHistory.byId[ethSendTxid]).toEqual(EthSend)
+      expect(store.getState().txHistory.byId[ethReceiveTxid]).toEqual(EthReceive)
 
       // new btc transaction (send)
       store.dispatch(txHistory.actions.onMessage({ message: BtcSend }))
-      expect(Object.values(store.getState().txHistory[ChainTypes.Bitcoin]).length).toBe(1)
+      expect(Object.values(store.getState().txHistory.ids).length).toBe(3)
 
       // duplicate btc transaction (send)
       store.dispatch(txHistory.actions.onMessage({ message: BtcSend }))
-      expect(Object.values(store.getState().txHistory[ChainTypes.Bitcoin]).length).toBe(1)
+      expect(Object.values(store.getState().txHistory.ids).length).toBe(3)
 
       // same btc transaction, different account type (send)
-      store.dispatch(txHistory.actions.onMessage({ message: { ...BtcSend, accountType: 'foo' } }))
-      expect(Object.values(store.getState().txHistory[ChainTypes.Bitcoin]).length).toBe(2)
+      const BtcSendSegwit = { ...BtcSend, accountType: UtxoAccountType.SegwitNative }
+      store.dispatch(txHistory.actions.onMessage({ message: BtcSendSegwit }))
+      expect(Object.values(store.getState().txHistory.ids).length).toBe(4)
 
+      const btcSendTxId = makeTxId(BtcSend)
+      const btcSendSegwitTxId = makeTxId(BtcSendSegwit)
       // btc data exists
-      expect(store.getState().txHistory[ChainTypes.Bitcoin]).toBeTruthy()
+      expect(store.getState().txHistory.byId[btcSendTxId]).toEqual(BtcSend)
+      expect(store.getState().txHistory.byId[btcSendSegwitTxId]).toEqual(BtcSendSegwit)
     })
 
-    it('should update existing transactions', async () => {
-      store.dispatch(
-        txHistory.actions.onMessage({
-          message: { ...EthReceive, status: chainAdapters.TxStatus.Pending }
-        })
-      )
-      expect(
-        store.getState().txHistory[ChainTypes.Ethereum][
-          `${EthReceive.txid}${EthReceive.asset}receive`
-        ].status
-      ).toBe(chainAdapters.TxStatus.Pending)
+    //   it('should update existing transactions', async () => {
+    //     store.dispatch(
+    //       txHistory.actions.onMessage({
+    //         message: { ...EthReceive, status: chainAdapters.TxStatus.Pending }
+    //       })
+    //     )
+    //     expect(
+    //       store.getState().txHistory[ChainTypes.Ethereum][
+    //         `${EthReceive.txid}${EthReceive.asset}receive`
+    //       ].status
+    //     ).toBe(chainAdapters.TxStatus.Pending)
 
-      store.dispatch(txHistory.actions.onMessage({ message: EthReceive }))
-      expect(
-        store.getState().txHistory[ChainTypes.Ethereum][
-          `${EthReceive.txid}${EthReceive.asset}receive`
-        ].status
-      ).toBe(chainAdapters.TxStatus.Confirmed)
-    })
-  })
+    //     store.dispatch(txHistory.actions.onMessage({ message: EthReceive }))
+    //     expect(
+    //       store.getState().txHistory[ChainTypes.Ethereum][
+    //         `${EthReceive.txid}${EthReceive.asset}receive`
+    //       ].status
+    //     ).toBe(chainAdapters.TxStatus.Confirmed)
+    //   })
+    // })
 
-  describe('selectTxHistory', () => {
-    it('should return all txs', () => {
-      const store = {
-        ...mockStore,
-        txHistory: {
-          [ChainTypes.Ethereum]: {
-            [EthSend.txid]: EthSend
-          },
-          [ChainTypes.Bitcoin]: {
-            [BtcSend.txid]: BtcSend
-          }
-        }
-      }
+    // describe('selectTxHistory', () => {
+    //   it('should return all txs', () => {
+    //     const store = {
+    //       ...mockStore,
+    //       txHistory: {
+    //         [ChainTypes.Ethereum]: {
+    //           [EthSend.txid]: EthSend
+    //         },
+    //         [ChainTypes.Bitcoin]: {
+    //           [BtcSend.txid]: BtcSend
+    //         }
+    //       }
+    //     }
 
-      const result = selectTxHistory(store, {})
+    //     const result = selectTxHistory(store, {})
 
-      expect(result.length).toBe(2)
-    })
+    //     expect(result.length).toBe(2)
+    //   })
 
-    it('should return txs by chain', () => {
-      const store = {
-        ...mockStore,
-        txHistory: {
-          [ChainTypes.Ethereum]: {
-            [EthSend.txid]: EthSend
-          },
-          [ChainTypes.Bitcoin]: {
-            [BtcSend.txid]: BtcSend
-          }
-        }
-      }
+    //   it('should return txs by chain', () => {
+    //     const store = {
+    //       ...mockStore,
+    //       txHistory: {
+    //         [ChainTypes.Ethereum]: {
+    //           [EthSend.txid]: EthSend
+    //         },
+    //         [ChainTypes.Bitcoin]: {
+    //           [BtcSend.txid]: BtcSend
+    //         }
+    //       }
+    //     }
 
-      const result = selectTxHistory(store, { chain: ChainTypes.Ethereum })
+    //     const result = selectTxHistory(store, { chain: ChainTypes.Ethereum })
 
-      expect(result.length).toBe(1)
-    })
+    //     expect(result.length).toBe(1)
+    //   })
 
-    it('should filter txs', () => {
-      const store = {
-        ...mockStore,
-        txHistory: {
-          [ChainTypes.Ethereum]: {
-            [EthSend.txid]: EthSend,
-            [EthReceive.txid]: EthReceive,
-            [`${EthReceive.txid}z`]: { ...EthReceive, txid: `${EthReceive.txid}z`, asset: '123' }
-          },
-          [ChainTypes.Bitcoin]: {
-            [BtcSend.txid]: { ...BtcSend, accountType: 'segwit' },
-            [`${BtcSend.txid}x`]: { ...BtcSend, accountType: 'segwit-native' },
-            [`${BtcSend.txid}y`]: { ...BtcSend, accountType: 'segwit-native' }
-          }
-        }
-      }
+    //   it('should filter txs', () => {
+    //     const store = {
+    //       ...mockStore,
+    //       txHistory: {
+    //         [ChainTypes.Ethereum]: {
+    //           [EthSend.txid]: EthSend,
+    //           [EthReceive.txid]: EthReceive,
+    //           [`${EthReceive.txid}z`]: { ...EthReceive, txid: `${EthReceive.txid}z`, asset: '123' }
+    //         },
+    //         [ChainTypes.Bitcoin]: {
+    //           [BtcSend.txid]: { ...BtcSend, accountType: 'segwit' },
+    //           [`${BtcSend.txid}x`]: { ...BtcSend, accountType: 'segwit-native' },
+    //           [`${BtcSend.txid}y`]: { ...BtcSend, accountType: 'segwit-native' }
+    //         }
+    //       }
+    //     }
 
-      let result = selectTxHistory(store, {
-        chain: ChainTypes.Ethereum,
-        filter: {
-          identifier: ChainTypes.Ethereum
-        }
-      })
-      expect(result.length).toBe(2)
+    //     let result = selectTxHistory(store, {
+    //       chain: ChainTypes.Ethereum,
+    //       filter: {
+    //         identifier: ChainTypes.Ethereum
+    //       }
+    //     })
+    //     expect(result.length).toBe(2)
 
-      result = selectTxHistory(store, {
-        chain: ChainTypes.Ethereum,
-        filter: {
-          identifier: '123'
-        }
-      })
-      expect(result.length).toBe(1)
+    //     result = selectTxHistory(store, {
+    //       chain: ChainTypes.Ethereum,
+    //       filter: {
+    //         identifier: '123'
+    //       }
+    //     })
+    //     expect(result.length).toBe(1)
 
-      result = selectTxHistory(store, {
-        chain: ChainTypes.Ethereum,
-        filter: {
-          identifier: ChainTypes.Ethereum,
-          txid: `${EthReceive.txid}z`
-        }
-      })
-      expect(result.length).toBe(0)
+    //     result = selectTxHistory(store, {
+    //       chain: ChainTypes.Ethereum,
+    //       filter: {
+    //         identifier: ChainTypes.Ethereum,
+    //         txid: `${EthReceive.txid}z`
+    //       }
+    //     })
+    //     expect(result.length).toBe(0)
 
-      result = selectTxHistory(store, {
-        chain: ChainTypes.Ethereum,
-        filter: {
-          identifier: '123',
-          txid: `${EthReceive.txid}z`
-        }
-      })
-      expect(result.length).toBe(1)
+    //     result = selectTxHistory(store, {
+    //       chain: ChainTypes.Ethereum,
+    //       filter: {
+    //         identifier: '123',
+    //         txid: `${EthReceive.txid}z`
+    //       }
+    //     })
+    //     expect(result.length).toBe(1)
 
-      result = selectTxHistory(store, {
-        chain: ChainTypes.Bitcoin,
-        filter: {
-          accountType: 'segwit'
-        }
-      })
-      expect(result.length).toBe(1)
+    //     result = selectTxHistory(store, {
+    //       chain: ChainTypes.Bitcoin,
+    //       filter: {
+    //         accountType: 'segwit'
+    //       }
+    //     })
+    //     expect(result.length).toBe(1)
 
-      result = selectTxHistory(store, {
-        chain: ChainTypes.Bitcoin,
-        filter: {
-          accountType: 'segwit-native'
-        }
-      })
-      expect(result.length).toBe(2)
-    })
+    //     result = selectTxHistory(store, {
+    //       chain: ChainTypes.Bitcoin,
+    //       filter: {
+    //         accountType: 'segwit-native'
+    //       }
+    //     })
+    //     expect(result.length).toBe(2)
+    //   })
 
-    it('should sort txs', () => {
-      const store = {
-        ...mockStore,
-        txHistory: {
-          [ChainTypes.Ethereum]: {
-            [EthSend.txid]: { ...EthSend, blockTime: 1 },
-            [EthReceive.txid]: { ...EthReceive, blockTime: 2 },
-            [`${EthReceive.txid}z`]: {
-              ...EthReceive,
-              txid: `${EthReceive.txid}z`,
-              blockTime: 2,
-              status: chainAdapters.TxStatus.Pending
-            }
-          },
-          [ChainTypes.Bitcoin]: {}
-        }
-      }
+    //   it('should sort txs', () => {
+    //     const store = {
+    //       ...mockStore,
+    //       txHistory: {
+    //         [ChainTypes.Ethereum]: {
+    //           [EthSend.txid]: { ...EthSend, blockTime: 1 },
+    //           [EthReceive.txid]: { ...EthReceive, blockTime: 2 },
+    //           [`${EthReceive.txid}z`]: {
+    //             ...EthReceive,
+    //             txid: `${EthReceive.txid}z`,
+    //             blockTime: 2,
+    //             status: chainAdapters.TxStatus.Pending
+    //           }
+    //         },
+    //         [ChainTypes.Bitcoin]: {}
+    //       }
+    //     }
 
-      let result = selectTxHistory(store, {
-        chain: ChainTypes.Ethereum
-      })
-      expect(result[0].txid).toBe(`${EthReceive.txid}z`)
-      expect(result[1].txid).toBe(EthReceive.txid)
-      expect(result[2].txid).toBe(EthSend.txid)
-    })
+    //     let result = selectTxHistory(store, {
+    //       chain: ChainTypes.Ethereum
+    //     })
+    //     expect(result[0].txid).toBe(`${EthReceive.txid}z`)
+    //     expect(result[1].txid).toBe(EthReceive.txid)
+    //     expect(result[2].txid).toBe(EthSend.txid)
+    //   })
   })
 })

--- a/src/state/slices/txHistorySlice/txHistorySlice.test.ts
+++ b/src/state/slices/txHistorySlice/txHistorySlice.test.ts
@@ -8,7 +8,13 @@ import { mockStore } from 'jest/mocks/store'
 import { BtcSend, EthReceive, EthSend, testTxs } from 'jest/mocks/txs'
 import { store } from 'state/store'
 
-import { makeTxId, selectTxHistoryByFilter, Tx, txHistory } from './txHistorySlice'
+import {
+  makeTxId,
+  selectLastNTxIds,
+  selectTxHistoryByFilter,
+  Tx,
+  txHistory
+} from './txHistorySlice'
 
 describe('txHistorySlice', () => {
   it('returns empty object for initialState', async () => {
@@ -198,5 +204,32 @@ describe('selectTxHistory', () => {
       accountType: UtxoAccountType.SegwitP2sh
     })
     expect(result.length).toBe(1)
+  })
+})
+
+describe('selectLastNTxIds', () => {
+  fit('should memoize', () => {
+    const state = {
+      ...mockStore,
+      txHistory: {
+        byId: {},
+        ids: ['a', 'b']
+      }
+    }
+    const first = selectLastNTxIds(state, 1)
+
+    // redux will replace the array on update
+    const newState = {
+      ...mockStore,
+      txHistory: {
+        byId: {},
+        // this array will always change on every new tx
+        ids: ['a', 'b', 'c']
+      }
+    }
+    const second = selectLastNTxIds(newState, 1)
+
+    // toBe uses reference equality, not like isEqual deep equal check
+    expect(first).toBe(second)
   })
 })

--- a/src/state/slices/txHistorySlice/txHistorySlice.test.ts
+++ b/src/state/slices/txHistorySlice/txHistorySlice.test.ts
@@ -196,30 +196,4 @@ describe('selectTxHistory', () => {
   //     })
   //     expect(result.length).toBe(2)
   //   })
-
-  //   it('should sort txs', () => {
-  //     const store = {
-  //       ...mockStore,
-  //       txHistory: {
-  //         [ChainTypes.Ethereum]: {
-  //           [EthSend.txid]: { ...EthSend, blockTime: 1 },
-  //           [EthReceive.txid]: { ...EthReceive, blockTime: 2 },
-  //           [`${EthReceive.txid}z`]: {
-  //             ...EthReceive,
-  //             txid: `${EthReceive.txid}z`,
-  //             blockTime: 2,
-  //             status: chainAdapters.TxStatus.Pending
-  //           }
-  //         },
-  //         [ChainTypes.Bitcoin]: {}
-  //       }
-  //     }
-
-  //     let result = selectTxHistory(store, {
-  //       chain: ChainTypes.Ethereum
-  //     })
-  //     expect(result[0].txid).toBe(`${EthReceive.txid}z`)
-  //     expect(result[1].txid).toBe(EthReceive.txid)
-  //     expect(result[2].txid).toBe(EthSend.txid)
-  //   })
 })

--- a/src/state/slices/txHistorySlice/txHistorySlice.test.ts
+++ b/src/state/slices/txHistorySlice/txHistorySlice.test.ts
@@ -1,4 +1,4 @@
-import { UtxoAccountType } from '@shapeshiftoss/types'
+import { chainAdapters, UtxoAccountType } from '@shapeshiftoss/types'
 import entries from 'lodash/entries'
 import map from 'lodash/map'
 import orderBy from 'lodash/orderBy'
@@ -69,156 +69,151 @@ describe('txHistorySlice', () => {
       expect(store.getState().txHistory.byId[btcSendSegwitTxId]).toEqual(BtcSendSegwit)
     })
 
-    //   it('should update existing transactions', async () => {
-    //     store.dispatch(
-    //       txHistory.actions.onMessage({
-    //         message: { ...EthReceive, status: chainAdapters.TxStatus.Pending }
-    //       })
-    //     )
-    //     expect(
-    //       store.getState().txHistory[ChainTypes.Ethereum][
-    //         `${EthReceive.txid}${EthReceive.asset}receive`
-    //       ].status
-    //     ).toBe(chainAdapters.TxStatus.Pending)
+    it('should update existing transactions', async () => {
+      const EthReceivePending = { ...EthReceive, status: chainAdapters.TxStatus.Pending }
+      store.dispatch(txHistory.actions.onMessage({ message: EthReceivePending }))
+      const ethReceivePendingId = makeTxId(EthReceivePending)
 
-    //     store.dispatch(txHistory.actions.onMessage({ message: EthReceive }))
-    //     expect(
-    //       store.getState().txHistory[ChainTypes.Ethereum][
-    //         `${EthReceive.txid}${EthReceive.asset}receive`
-    //       ].status
-    //     ).toBe(chainAdapters.TxStatus.Confirmed)
-    //   })
-    // })
+      expect(store.getState().txHistory.byId[ethReceivePendingId].status).toBe(
+        chainAdapters.TxStatus.Pending
+      )
 
-    // describe('selectTxHistory', () => {
-    //   it('should return all txs', () => {
-    //     const store = {
-    //       ...mockStore,
-    //       txHistory: {
-    //         [ChainTypes.Ethereum]: {
-    //           [EthSend.txid]: EthSend
-    //         },
-    //         [ChainTypes.Bitcoin]: {
-    //           [BtcSend.txid]: BtcSend
-    //         }
-    //       }
-    //     }
-
-    //     const result = selectTxHistory(store, {})
-
-    //     expect(result.length).toBe(2)
-    //   })
-
-    //   it('should return txs by chain', () => {
-    //     const store = {
-    //       ...mockStore,
-    //       txHistory: {
-    //         [ChainTypes.Ethereum]: {
-    //           [EthSend.txid]: EthSend
-    //         },
-    //         [ChainTypes.Bitcoin]: {
-    //           [BtcSend.txid]: BtcSend
-    //         }
-    //       }
-    //     }
-
-    //     const result = selectTxHistory(store, { chain: ChainTypes.Ethereum })
-
-    //     expect(result.length).toBe(1)
-    //   })
-
-    //   it('should filter txs', () => {
-    //     const store = {
-    //       ...mockStore,
-    //       txHistory: {
-    //         [ChainTypes.Ethereum]: {
-    //           [EthSend.txid]: EthSend,
-    //           [EthReceive.txid]: EthReceive,
-    //           [`${EthReceive.txid}z`]: { ...EthReceive, txid: `${EthReceive.txid}z`, asset: '123' }
-    //         },
-    //         [ChainTypes.Bitcoin]: {
-    //           [BtcSend.txid]: { ...BtcSend, accountType: 'segwit' },
-    //           [`${BtcSend.txid}x`]: { ...BtcSend, accountType: 'segwit-native' },
-    //           [`${BtcSend.txid}y`]: { ...BtcSend, accountType: 'segwit-native' }
-    //         }
-    //       }
-    //     }
-
-    //     let result = selectTxHistory(store, {
-    //       chain: ChainTypes.Ethereum,
-    //       filter: {
-    //         identifier: ChainTypes.Ethereum
-    //       }
-    //     })
-    //     expect(result.length).toBe(2)
-
-    //     result = selectTxHistory(store, {
-    //       chain: ChainTypes.Ethereum,
-    //       filter: {
-    //         identifier: '123'
-    //       }
-    //     })
-    //     expect(result.length).toBe(1)
-
-    //     result = selectTxHistory(store, {
-    //       chain: ChainTypes.Ethereum,
-    //       filter: {
-    //         identifier: ChainTypes.Ethereum,
-    //         txid: `${EthReceive.txid}z`
-    //       }
-    //     })
-    //     expect(result.length).toBe(0)
-
-    //     result = selectTxHistory(store, {
-    //       chain: ChainTypes.Ethereum,
-    //       filter: {
-    //         identifier: '123',
-    //         txid: `${EthReceive.txid}z`
-    //       }
-    //     })
-    //     expect(result.length).toBe(1)
-
-    //     result = selectTxHistory(store, {
-    //       chain: ChainTypes.Bitcoin,
-    //       filter: {
-    //         accountType: 'segwit'
-    //       }
-    //     })
-    //     expect(result.length).toBe(1)
-
-    //     result = selectTxHistory(store, {
-    //       chain: ChainTypes.Bitcoin,
-    //       filter: {
-    //         accountType: 'segwit-native'
-    //       }
-    //     })
-    //     expect(result.length).toBe(2)
-    //   })
-
-    //   it('should sort txs', () => {
-    //     const store = {
-    //       ...mockStore,
-    //       txHistory: {
-    //         [ChainTypes.Ethereum]: {
-    //           [EthSend.txid]: { ...EthSend, blockTime: 1 },
-    //           [EthReceive.txid]: { ...EthReceive, blockTime: 2 },
-    //           [`${EthReceive.txid}z`]: {
-    //             ...EthReceive,
-    //             txid: `${EthReceive.txid}z`,
-    //             blockTime: 2,
-    //             status: chainAdapters.TxStatus.Pending
-    //           }
-    //         },
-    //         [ChainTypes.Bitcoin]: {}
-    //       }
-    //     }
-
-    //     let result = selectTxHistory(store, {
-    //       chain: ChainTypes.Ethereum
-    //     })
-    //     expect(result[0].txid).toBe(`${EthReceive.txid}z`)
-    //     expect(result[1].txid).toBe(EthReceive.txid)
-    //     expect(result[2].txid).toBe(EthSend.txid)
-    //   })
+      const ethReceiveConfirmedId = makeTxId(EthReceive)
+      store.dispatch(txHistory.actions.onMessage({ message: EthReceive }))
+      expect(store.getState().txHistory.byId[ethReceiveConfirmedId].status).toBe(
+        chainAdapters.TxStatus.Confirmed
+      )
+    })
   })
 })
+
+// describe('selectTxHistory', () => {
+//   it('should return all txs', () => {
+//     const store = {
+//       ...mockStore,
+//       txHistory: {
+//         [ChainTypes.Ethereum]: {
+//           [EthSend.txid]: EthSend
+//         },
+//         [ChainTypes.Bitcoin]: {
+//           [BtcSend.txid]: BtcSend
+//         }
+//       }
+//     }
+
+//     const result = selectTxHistory(store, {})
+
+//     expect(result.length).toBe(2)
+//   })
+
+//   it('should return txs by chain', () => {
+//     const store = {
+//       ...mockStore,
+//       txHistory: {
+//         [ChainTypes.Ethereum]: {
+//           [EthSend.txid]: EthSend
+//         },
+//         [ChainTypes.Bitcoin]: {
+//           [BtcSend.txid]: BtcSend
+//         }
+//       }
+//     }
+
+//     const result = selectTxHistory(store, { chain: ChainTypes.Ethereum })
+
+//     expect(result.length).toBe(1)
+//   })
+
+//   it('should filter txs', () => {
+//     const store = {
+//       ...mockStore,
+//       txHistory: {
+//         [ChainTypes.Ethereum]: {
+//           [EthSend.txid]: EthSend,
+//           [EthReceive.txid]: EthReceive,
+//           [`${EthReceive.txid}z`]: { ...EthReceive, txid: `${EthReceive.txid}z`, asset: '123' }
+//         },
+//         [ChainTypes.Bitcoin]: {
+//           [BtcSend.txid]: { ...BtcSend, accountType: 'segwit' },
+//           [`${BtcSend.txid}x`]: { ...BtcSend, accountType: 'segwit-native' },
+//           [`${BtcSend.txid}y`]: { ...BtcSend, accountType: 'segwit-native' }
+//         }
+//       }
+//     }
+
+//     let result = selectTxHistory(store, {
+//       chain: ChainTypes.Ethereum,
+//       filter: {
+//         identifier: ChainTypes.Ethereum
+//       }
+//     })
+//     expect(result.length).toBe(2)
+
+//     result = selectTxHistory(store, {
+//       chain: ChainTypes.Ethereum,
+//       filter: {
+//         identifier: '123'
+//       }
+//     })
+//     expect(result.length).toBe(1)
+
+//     result = selectTxHistory(store, {
+//       chain: ChainTypes.Ethereum,
+//       filter: {
+//         identifier: ChainTypes.Ethereum,
+//         txid: `${EthReceive.txid}z`
+//       }
+//     })
+//     expect(result.length).toBe(0)
+
+//     result = selectTxHistory(store, {
+//       chain: ChainTypes.Ethereum,
+//       filter: {
+//         identifier: '123',
+//         txid: `${EthReceive.txid}z`
+//       }
+//     })
+//     expect(result.length).toBe(1)
+
+//     result = selectTxHistory(store, {
+//       chain: ChainTypes.Bitcoin,
+//       filter: {
+//         accountType: 'segwit'
+//       }
+//     })
+//     expect(result.length).toBe(1)
+
+//     result = selectTxHistory(store, {
+//       chain: ChainTypes.Bitcoin,
+//       filter: {
+//         accountType: 'segwit-native'
+//       }
+//     })
+//     expect(result.length).toBe(2)
+//   })
+
+//   it('should sort txs', () => {
+//     const store = {
+//       ...mockStore,
+//       txHistory: {
+//         [ChainTypes.Ethereum]: {
+//           [EthSend.txid]: { ...EthSend, blockTime: 1 },
+//           [EthReceive.txid]: { ...EthReceive, blockTime: 2 },
+//           [`${EthReceive.txid}z`]: {
+//             ...EthReceive,
+//             txid: `${EthReceive.txid}z`,
+//             blockTime: 2,
+//             status: chainAdapters.TxStatus.Pending
+//           }
+//         },
+//         [ChainTypes.Bitcoin]: {}
+//       }
+//     }
+
+//     let result = selectTxHistory(store, {
+//       chain: ChainTypes.Ethereum
+//     })
+//     expect(result[0].txid).toBe(`${EthReceive.txid}z`)
+//     expect(result[1].txid).toBe(EthReceive.txid)
+//     expect(result[2].txid).toBe(EthSend.txid)
+//   })

--- a/src/state/slices/txHistorySlice/txHistorySlice.ts
+++ b/src/state/slices/txHistorySlice/txHistorySlice.ts
@@ -129,3 +129,12 @@ export const selectTxIdsByCAIP19 = createSelector(
   (_state: ReduxState, caip19: string) => caip19,
   (ids, caip19) => ids.filter(id => id.includes(caip19))
 )
+
+export const selectTxIdsByFilter = createSelector(
+  (state: ReduxState) => state.txHistory.ids,
+  (_state: ReduxState, filter: TxFilter) => filter,
+  (ids, txFilter) => {
+    const vals = filter(values(txFilter), Boolean) // only include non null filters
+    return filter(ids, id => vals.every(val => id.includes(val)))
+  }
+)

--- a/src/state/slices/txHistorySlice/txHistorySlice.ts
+++ b/src/state/slices/txHistorySlice/txHistorySlice.ts
@@ -1,46 +1,78 @@
 import { createSlice } from '@reduxjs/toolkit'
-import { chainAdapters, ChainTypes } from '@shapeshiftoss/types'
-import concat from 'lodash/concat'
+import { CAIP2, CAIP19 } from '@shapeshiftoss/caip'
+import { chainAdapters, ChainTypes, UtxoAccountType } from '@shapeshiftoss/types'
 import filter from 'lodash/filter'
 import isEqual from 'lodash/isEqual'
 import orderBy from 'lodash/orderBy'
-import { createSelectorCreator, defaultMemoize } from 'reselect'
+import values from 'lodash/values'
+import { createSelector, createSelectorCreator, defaultMemoize } from 'reselect'
+import { caip19FromTx } from 'lib/txs'
 import { ReduxState } from 'state/reducer'
 
-export type Tx = chainAdapters.SubscribeTxsMessage<ChainTypes> & { accountType?: string }
-export type TxHistory = Record<ChainTypes, Record<string, Tx>>
-export type TxMessage = { payload: { message: Tx } }
+export type Tx = chainAdapters.SubscribeTxsMessage<ChainTypes> & {
+  accountType?: UtxoAccountType
+  // TODO(0xdef1cafe): add these on the way into the store
+  // txCAIP19: CAIP19
+  // feeCAIP19: CAIP19
+}
 
-export type Filter = {
-  accountType?: string
-  identifier?: string
-  tradeIdentifier?: string // Temporary hack because unchained only returns symbols for trade details
+export type TxFilter = {
+  accountType?: UtxoAccountType
+  symbol?: string
+  caip19?: CAIP19
+  caip2?: CAIP2
   txid?: string
 }
-export type Sort = {
-  direction: 'asc' | 'desc'
-}
-export type TxHistorySelect = {
-  chain?: ChainTypes
-  filter?: Filter
-  sort?: Sort
+
+export type TxHistoryById = {
+  [k: string]: Tx
 }
 
-const initialState: TxHistory = {
-  [ChainTypes.Ethereum]: {},
-  [ChainTypes.Bitcoin]: {}
+export type TxHistory = {
+  byId: TxHistoryById
+  ids: string[]
 }
+
+export type TxMessage = { payload: { message: Tx } }
+
+// https://redux.js.org/usage/structuring-reducers/normalizing-state-shape#designing-a-normalized-state
+const initialState: TxHistory = {
+  byId: {},
+  ids: [] // sorted, newest first
+}
+
+const makeTxId = (tx: Tx): string =>
+  `${caip19FromTx(tx)}-${tx.txid}-${tx.asset}-${tx.accountType || ''}${tx.type}`
 
 /**
  * Manage state of the txHistory slice
  *
  * If transaction already exists, update the value, otherwise add the new transaction
  */
-const updateOrInsert = (txs: Record<string, Tx> | undefined, tx: Tx): Record<string, Tx> => {
-  const key = `${tx.txid}${tx.asset}${tx.accountType || ''}${tx.type}`
-  if (!txs) return { [key]: tx }
-  txs[key] = tx
-  return txs
+const updateOrInsert = (txHistory: TxHistory, tx: Tx) => {
+  // the unique id to key by
+  const id = makeTxId(tx)
+
+  // desc is newest first
+  const orderedTxs = orderBy(txHistory.byId, 'blockTime', ['desc'])
+
+  // where to insert the unique id in our sorted index
+  // unchained generally returns newest first, so iterate backwards
+  let index = 0
+  for (let i = txHistory.ids.length - 1; i >= 0; i--) {
+    if (tx.blockTime > orderedTxs[i]?.blockTime) continue
+    index = i + 1
+    break
+  }
+  // splice the new tx in the correct order
+  // this *mutates* the array, keeping the same ref
+  txHistory.ids.splice(index, 0, id)
+
+  // order in the object doesn't matter, but we must do this after
+  // figuring out the index
+  txHistory.byId[id] = tx
+
+  // return txHistory
 }
 
 export const txHistory = createSlice({
@@ -48,47 +80,92 @@ export const txHistory = createSlice({
   initialState,
   reducers: {
     clear: () => initialState,
-    onMessage: (state, { payload }: TxMessage) => {
-      const chain = payload.message.chain
-      state[chain] = updateOrInsert(state[chain], payload.message)
-    }
+    onMessage: (state, { payload }: TxMessage) => updateOrInsert(state, payload.message)
   }
 })
+
+export const selectTxs = (state: ReduxState) => values(state.txHistory.byId)
+
+export const selectTxHistoryByFilter = createSelector(
+  (state: ReduxState) => state.txHistory,
+  (_state: ReduxState, txFilter: TxFilter) => txFilter,
+  (txHistory: TxHistory, txFilter: TxFilter) => {
+    if (!txFilter) return values(txHistory.byId)
+    const { symbol, txid, accountType, caip19 } = txFilter
+    const filterFunc = (tx: Tx) => {
+      let hasItem = true
+      if (symbol && tx.tradeDetails) {
+        hasItem =
+          (tx.tradeDetails?.sellAsset === symbol || tx.tradeDetails?.buyAsset === symbol) && hasItem
+      } else if (caip19) {
+        hasItem = caip19FromTx(tx) === caip19 && hasItem
+      }
+
+      if (txid) hasItem = tx.txid === txid && hasItem
+      if (accountType) hasItem = tx.accountType === accountType && hasItem
+      return hasItem
+    }
+    return filter(txHistory.byId, filterFunc)
+  }
+)
+
+const createDeepEqualSelector = createSelectorCreator(defaultMemoize, isEqual)
+
+const _selectLastNTxIds = createSelector(
+  (state: ReduxState) => state.txHistory.ids, // ids
+  (_state: ReduxState, count: number) => count, // count
+  (ids, count) => ids.slice(0, count)
+)
+
+export const selectLastNTxIds = createDeepEqualSelector(_selectLastNTxIds, ids => ids)
+
+export const selectTxById = createSelector(
+  (state: ReduxState) => state.txHistory.byId,
+  (_state: ReduxState, txId: string) => txId,
+  (txsById, txId) => txsById[txId]
+)
+
+export const selectTxIdsByCAIP19 = createSelector(
+  (state: ReduxState) => state.txHistory.ids,
+  (_state: ReduxState, caip19: string) => caip19,
+  (ids, caip19) => ids.filter(id => id.includes(caip19))
+)
 
 // https://github.com/reduxjs/reselect#q-why-is-my-selector-recomputing-when-the-input-state-stays-the-same
 // TODO(0xdef1cafe): check this for performance
 // create a "selector creator" that uses lodash.isequal instead of ===
-const createDeepEqualSelector = createSelectorCreator(defaultMemoize, isEqual)
-export const selectTxHistory = createDeepEqualSelector(
-  (state: ReduxState, { chain }: TxHistorySelect) => {
-    return chain
-      ? Object.values(state.txHistory[chain] ?? {})
-      : concat(...Object.values(state.txHistory).map(txMap => Object.values(txMap)))
-  },
-  (_, { filter }: TxHistorySelect) => {
-    if (!filter) return
+// const createDeepEqualSelector = createSelectorCreator(defaultMemoize, isEqual)
+// export const selectTxHistory = createDeepEqualSelector(
+//   (state: ReduxState, { chain }: TxHistorySelect) => {
+//     return state.txHistory
+//     // return chain
+//     //   ? Object.values(state.txHistory[chain] ?? {})
+//     //   : concat(...Object.values(state.txHistory).map(txMap => Object.values(txMap)))
+//   },
+//   (_, { filter }: TxHistorySelect) => {
+//     if (!filter) return
 
-    return (tx: Tx): boolean => {
-      let hasItem = true
-      if (filter.tradeIdentifier && tx.tradeDetails) {
-        hasItem =
-          (tx.tradeDetails?.sellAsset === filter.tradeIdentifier ||
-            tx.tradeDetails?.buyAsset === filter.tradeIdentifier) &&
-          hasItem
-      } else if (filter.identifier)
-        hasItem = tx.asset.toLowerCase() === filter.identifier && hasItem
+//     return (tx: Tx): boolean => {
+//       let hasItem = true
+//       if (filter.tradeIdentifier && tx.tradeDetails) {
+//         hasItem =
+//           (tx.tradeDetails?.sellAsset === filter.tradeIdentifier ||
+//             tx.tradeDetails?.buyAsset === filter.tradeIdentifier) &&
+//           hasItem
+//       } else if (filter.identifier)
+//         hasItem = tx.asset.toLowerCase() === filter.identifier && hasItem
 
-      if (filter.txid) hasItem = tx.txid === filter.txid && hasItem
-      if (filter.accountType) hasItem = tx.accountType === filter.accountType && hasItem
-      return hasItem
-    }
-  },
-  (_, { sort }: TxHistorySelect) => ({
-    keys: ['blockTime', 'status'],
-    direction: [sort?.direction ?? 'desc', 'desc'] as Array<boolean | 'asc' | 'desc'>
-  }),
-  (txHistory, filterFunc, sort) => {
-    if (filterFunc) txHistory = filter(txHistory, filterFunc)
-    return orderBy(txHistory, sort.keys, sort.direction)
-  }
-)
+//       if (filter.txid) hasItem = tx.txid === filter.txid && hasItem
+//       if (filter.accountType) hasItem = tx.accountType === filter.accountType && hasItem
+//       return hasItem
+//     }
+//   },
+//   (_, { sort }: TxHistorySelect) => ({
+//     keys: ['blockTime', 'status'],
+//     direction: [sort?.direction ?? 'desc', 'desc'] as Array<boolean | 'asc' | 'desc'>
+//   }),
+//   (txHistory, filterFunc, sort) => {
+//     if (filterFunc) txHistory = filter(txHistory, filterFunc)
+//     return orderBy(txHistory, sort.keys, sort.direction)
+//   }
+// )

--- a/src/state/slices/txHistorySlice/txHistorySlice.ts
+++ b/src/state/slices/txHistorySlice/txHistorySlice.ts
@@ -6,7 +6,7 @@ import isEqual from 'lodash/isEqual'
 import orderBy from 'lodash/orderBy'
 import values from 'lodash/values'
 import { createSelector, createSelectorCreator, defaultMemoize } from 'reselect'
-import { caip19FromTx } from 'lib/txs'
+import { caip2FromTx, caip19FromTx } from 'lib/txs'
 import { ReduxState } from 'state/reducer'
 
 export type Tx = chainAdapters.SubscribeTxsMessage<ChainTypes> & {
@@ -91,7 +91,7 @@ export const selectTxHistoryByFilter = createSelector(
   (_state: ReduxState, txFilter: TxFilter) => txFilter,
   (txHistory: TxHistory, txFilter: TxFilter) => {
     if (!txFilter) return values(txHistory.byId)
-    const { symbol, txid, accountType, caip19 } = txFilter
+    const { symbol, txid, accountType, caip19, caip2 } = txFilter
     const filterFunc = (tx: Tx) => {
       let hasItem = true
       if (symbol && tx.tradeDetails) {
@@ -99,6 +99,8 @@ export const selectTxHistoryByFilter = createSelector(
           (tx.tradeDetails?.sellAsset === symbol || tx.tradeDetails?.buyAsset === symbol) && hasItem
       } else if (caip19) {
         hasItem = caip19FromTx(tx) === caip19 && hasItem
+      } else if (caip2) {
+        hasItem = caip2FromTx(tx) === caip2 && hasItem
       }
 
       if (txid) hasItem = tx.txid === txid && hasItem

--- a/src/state/slices/txHistorySlice/txHistorySlice.ts
+++ b/src/state/slices/txHistorySlice/txHistorySlice.ts
@@ -114,6 +114,8 @@ export const selectLastNTxIds = createSelector(
   (ids, count) => ids.slice(0, count),
   // https://github.com/reduxjs/reselect#createselectorinputselectors--inputselectors-resultfunc-selectoroptions
   // we're doing a deel equality check on the output
+  // meaning the selector returns the same array ref
+  // regardless of if the input has changed
   { memoizeOptions: { resultEqualityCheck: isEqual } }
 )
 

--- a/src/state/slices/txHistorySlice/txHistorySlice.ts
+++ b/src/state/slices/txHistorySlice/txHistorySlice.ts
@@ -2,10 +2,9 @@ import { createSlice } from '@reduxjs/toolkit'
 import { CAIP2, CAIP19 } from '@shapeshiftoss/caip'
 import { chainAdapters, ChainTypes, UtxoAccountType } from '@shapeshiftoss/types'
 import filter from 'lodash/filter'
-import isEqual from 'lodash/isEqual'
 import orderBy from 'lodash/orderBy'
 import values from 'lodash/values'
-import { createSelector, createSelectorCreator, defaultMemoize } from 'reselect'
+import { createSelector } from 'reselect'
 import { caip2FromTx, caip19FromTx } from 'lib/txs'
 import { ReduxState } from 'state/reducer'
 
@@ -105,26 +104,16 @@ export const selectTxHistoryByFilter = createSelector(
   }
 )
 
-const createDeepEqualSelector = createSelectorCreator(defaultMemoize, isEqual)
-
-const _selectLastNTxIds = createSelector(
-  (state: ReduxState) => state.txHistory.ids, // ids
-  (_state: ReduxState, count: number) => count, // count
+export const selectLastNTxIds = createSelector(
+  (state: ReduxState) => state.txHistory.ids,
+  (_state: ReduxState, count: number) => count,
   (ids, count) => ids.slice(0, count)
 )
-
-export const selectLastNTxIds = createDeepEqualSelector(_selectLastNTxIds, ids => ids)
 
 export const selectTxById = createSelector(
   (state: ReduxState) => state.txHistory.byId,
   (_state: ReduxState, txId: string) => txId,
   (txsById, txId) => txsById[txId]
-)
-
-export const selectTxIdsByCAIP19 = createSelector(
-  (state: ReduxState) => state.txHistory.ids,
-  (_state: ReduxState, caip19: string) => caip19,
-  (ids, caip19) => ids.filter(id => id.includes(caip19))
 )
 
 export const selectTxIdsByFilter = createSelector(

--- a/src/state/slices/txHistorySlice/txHistorySlice.ts
+++ b/src/state/slices/txHistorySlice/txHistorySlice.ts
@@ -62,6 +62,8 @@ const updateOrInsert = (txHistory: TxHistory, tx: Tx) => {
   // splice the new tx in the correct order
   if (!txHistory.ids.includes(id)) txHistory.ids.splice(index, 0, id)
 
+  // TODO(0xdef1cafe): we should maintain multiple indexes, e.g. by chain, asset, orders
+
   // order in the object doesn't matter, but we must do this after
   // figuring out the index
   txHistory.byId[id] = tx

--- a/src/state/slices/txHistorySlice/txHistorySlice.ts
+++ b/src/state/slices/txHistorySlice/txHistorySlice.ts
@@ -2,6 +2,7 @@ import { createSlice } from '@reduxjs/toolkit'
 import { CAIP2, CAIP19 } from '@shapeshiftoss/caip'
 import { chainAdapters, ChainTypes, UtxoAccountType } from '@shapeshiftoss/types'
 import filter from 'lodash/filter'
+import isEqual from 'lodash/isEqual'
 import orderBy from 'lodash/orderBy'
 import values from 'lodash/values'
 import { createSelector } from 'reselect'
@@ -107,9 +108,13 @@ export const selectTxHistoryByFilter = createSelector(
 )
 
 export const selectLastNTxIds = createSelector(
+  // ids will always change
   (state: ReduxState) => state.txHistory.ids,
   (_state: ReduxState, count: number) => count,
-  (ids, count) => ids.slice(0, count)
+  (ids, count) => ids.slice(0, count),
+  // https://github.com/reduxjs/reselect#createselectorinputselectors--inputselectors-resultfunc-selectoroptions
+  // we're doing a deel equality check on the output
+  { memoizeOptions: { resultEqualityCheck: isEqual } }
 )
 
 export const selectTxById = createSelector(

--- a/src/state/slices/txHistorySlice/txHistorySlice.ts
+++ b/src/state/slices/txHistorySlice/txHistorySlice.ts
@@ -9,12 +9,7 @@ import { createSelector, createSelectorCreator, defaultMemoize } from 'reselect'
 import { caip2FromTx, caip19FromTx } from 'lib/txs'
 import { ReduxState } from 'state/reducer'
 
-export type Tx = chainAdapters.SubscribeTxsMessage<ChainTypes> & {
-  accountType?: UtxoAccountType
-  // TODO(0xdef1cafe): add these on the way into the store
-  // txCAIP19: CAIP19
-  // feeCAIP19: CAIP19
-}
+export type Tx = chainAdapters.SubscribeTxsMessage<ChainTypes> & { accountType?: UtxoAccountType }
 
 export type TxFilter = {
   accountType?: UtxoAccountType
@@ -64,15 +59,17 @@ const updateOrInsert = (txHistory: TxHistory, tx: Tx) => {
     index = i + 1
     break
   }
+
   // splice the new tx in the correct order
-  // this *mutates* the array, keeping the same ref
   if (!txHistory.ids.includes(id)) txHistory.ids.splice(index, 0, id)
 
   // order in the object doesn't matter, but we must do this after
   // figuring out the index
   txHistory.byId[id] = tx
 
-  // return txHistory
+  // ^^^ redux toolkit uses the immer lib, which uses proxies under the hood
+  // this looks like it's not doing anything, but changes written to the proxy
+  // get applied to state when it goes out of scope
 }
 
 export const txHistory = createSlice({

--- a/src/state/slices/txHistorySlice/txHistorySlice.ts
+++ b/src/state/slices/txHistorySlice/txHistorySlice.ts
@@ -97,12 +97,9 @@ export const selectTxHistoryByFilter = createSelector(
       if (symbol && tx.tradeDetails) {
         hasItem =
           (tx.tradeDetails?.sellAsset === symbol || tx.tradeDetails?.buyAsset === symbol) && hasItem
-      } else if (caip19) {
-        hasItem = caip19FromTx(tx) === caip19 && hasItem
-      } else if (caip2) {
-        hasItem = caip2FromTx(tx) === caip2 && hasItem
       }
-
+      if (caip2) hasItem = caip2FromTx(tx) === caip2 && hasItem
+      if (caip19) hasItem = caip19FromTx(tx) === caip19 && hasItem
       if (txid) hasItem = tx.txid === txid && hasItem
       if (accountType) hasItem = tx.accountType === accountType && hasItem
       return hasItem
@@ -132,42 +129,3 @@ export const selectTxIdsByCAIP19 = createSelector(
   (_state: ReduxState, caip19: string) => caip19,
   (ids, caip19) => ids.filter(id => id.includes(caip19))
 )
-
-// https://github.com/reduxjs/reselect#q-why-is-my-selector-recomputing-when-the-input-state-stays-the-same
-// TODO(0xdef1cafe): check this for performance
-// create a "selector creator" that uses lodash.isequal instead of ===
-// const createDeepEqualSelector = createSelectorCreator(defaultMemoize, isEqual)
-// export const selectTxHistory = createDeepEqualSelector(
-//   (state: ReduxState, { chain }: TxHistorySelect) => {
-//     return state.txHistory
-//     // return chain
-//     //   ? Object.values(state.txHistory[chain] ?? {})
-//     //   : concat(...Object.values(state.txHistory).map(txMap => Object.values(txMap)))
-//   },
-//   (_, { filter }: TxHistorySelect) => {
-//     if (!filter) return
-
-//     return (tx: Tx): boolean => {
-//       let hasItem = true
-//       if (filter.tradeIdentifier && tx.tradeDetails) {
-//         hasItem =
-//           (tx.tradeDetails?.sellAsset === filter.tradeIdentifier ||
-//             tx.tradeDetails?.buyAsset === filter.tradeIdentifier) &&
-//           hasItem
-//       } else if (filter.identifier)
-//         hasItem = tx.asset.toLowerCase() === filter.identifier && hasItem
-
-//       if (filter.txid) hasItem = tx.txid === filter.txid && hasItem
-//       if (filter.accountType) hasItem = tx.accountType === filter.accountType && hasItem
-//       return hasItem
-//     }
-//   },
-//   (_, { sort }: TxHistorySelect) => ({
-//     keys: ['blockTime', 'status'],
-//     direction: [sort?.direction ?? 'desc', 'desc'] as Array<boolean | 'asc' | 'desc'>
-//   }),
-//   (txHistory, filterFunc, sort) => {
-//     if (filterFunc) txHistory = filter(txHistory, filterFunc)
-//     return orderBy(txHistory, sort.keys, sort.direction)
-//   }
-// )

--- a/src/state/slices/txHistorySlice/txHistorySlice.ts
+++ b/src/state/slices/txHistorySlice/txHistorySlice.ts
@@ -41,7 +41,7 @@ const initialState: TxHistory = {
   ids: [] // sorted, newest first
 }
 
-const makeTxId = (tx: Tx): string =>
+export const makeTxId = (tx: Tx): string =>
   `${caip19FromTx(tx)}-${tx.txid}-${tx.asset}-${tx.accountType || ''}${tx.type}`
 
 /**
@@ -66,7 +66,7 @@ const updateOrInsert = (txHistory: TxHistory, tx: Tx) => {
   }
   // splice the new tx in the correct order
   // this *mutates* the array, keeping the same ref
-  txHistory.ids.splice(index, 0, id)
+  if (!txHistory.ids.includes(id)) txHistory.ids.splice(index, 0, id)
 
   // order in the object doesn't matter, but we must do this after
   // figuring out the index

--- a/yarn.lock
+++ b/yarn.lock
@@ -17848,10 +17848,10 @@ requires-port@^1.0.0:
   resolved "https://registry.yarnpkg.com/requires-port/-/requires-port-1.0.0.tgz#925d2601d39ac485e091cf0da5c6e694dc3dcaff"
   integrity sha1-kl0mAdOaxIXgkc8NpcbmlNw9yv8=
 
-reselect@^4.0.0:
-  version "4.0.0"
-  resolved "https://registry.yarnpkg.com/reselect/-/reselect-4.0.0.tgz#f2529830e5d3d0e021408b246a206ef4ea4437f7"
-  integrity sha512-qUgANli03jjAyGlnbYVAV5vvnOmJnODyABz51RdBN7M4WaVu8mecZWgyQNkG8Yqe3KRGRt0l4K4B3XVEULC4CA==
+reselect@^4.0.0, reselect@^4.1.5:
+  version "4.1.5"
+  resolved "https://registry.yarnpkg.com/reselect/-/reselect-4.1.5.tgz#852c361247198da6756d07d9296c2b51eddb79f6"
+  integrity sha512-uVdlz8J7OO+ASpBYoz1Zypgx0KasCY20H+N8JD13oUMtPvSHQuscrHop4KbXrbsBcdB9Ds7lVK7eRkBIfO43vQ==
 
 resize-observer-polyfill@1.5.1:
   version "1.5.1"


### PR DESCRIPTION
## Description

* adopts best practises from here https://redux.js.org/usage/structuring-reducers/normalizing-state-shape#designing-a-normalized-state
* transaction rows now accept id and look up transaction data themselves
* this kind of abuses indexes for filters, but i want to keep this PR smol and write more efficient filter selectors later

## Notice

Before submitting a pull request, please make sure you have answered the following:

- [x] Have you followed the guidelines in our [Contributing]('https://github.com/shapeshift/web/CONTRIBUTING.md) guide?
- [x] Have you checked to ensure there aren't other open [Pull Requests](https://github.com/shapeshift/web/pulls) for the same update/change?
- [x] Do all new and existing tests pass? Does the linter pass?

## Pull Request Type

- [ ] :bug: Bug fix (Non-breaking Change: Fixes an issue)
- [x] :hammer_and_wrench: Chore (Non-breaking Change: Doc updates, pkg upgrades, typos, etc..)
- [ ] :nail_care: New Feature (Breaking/Non-breaking Change)

## Issue (if applicable)

If applicable, please link to the github issue and put `closes #XXXX` in your comment to auto-close the issue that your PR fixes.

## Testing

Please outline all testing steps

1. Pull branch locally and run `yarn` to install new deps
2. etc...

## Screenshots (if applicable)
