### PR TITLE
chore: normalize assets and market data in store

### DIFF
--- a/src/components/AccountRow/AccountRow.tsx
+++ b/src/components/AccountRow/AccountRow.tsx
@@ -1,5 +1,5 @@
 import { Flex, SimpleGrid, useColorModeValue } from '@chakra-ui/react'
-import { ChainTypes } from '@shapeshiftoss/types'
+import { CAIP19, caip19 } from '@shapeshiftoss/caip'
 import { useEffect, useMemo } from 'react'
 import { useDispatch, useSelector } from 'react-redux'
 import { Link } from 'react-router-dom'
@@ -18,21 +18,20 @@ import { Allocations } from './Allocations'
 export type AccountRowArgs = {
   allocationValue: number
   balance: string
-  tokenId?: string
-  chain: ChainTypes
+  CAIP19: CAIP19
 }
 
-export const AccountRow = ({ allocationValue, balance, tokenId, chain }: AccountRowArgs) => {
+export const AccountRow = ({ allocationValue, balance, CAIP19 }: AccountRowArgs) => {
   const dispatch = useDispatch()
   const rowHover = useColorModeValue('gray.100', 'gray.750')
-  const contract = useMemo(() => tokenId?.toLowerCase(), [tokenId])
+  const { chain, tokenId } = caip19.fromCAIP19(CAIP19)
   const url = useMemo(() => {
     let baseUrl = `/assets/${chain}`
-    if (contract) baseUrl = baseUrl + `/${contract}`
+    if (tokenId) baseUrl = baseUrl + `/${tokenId}`
     return baseUrl
-  }, [chain, contract])
+  }, [chain, tokenId])
 
-  const asset = useFetchAsset({ chain, tokenId: contract })
+  const asset = useFetchAsset(CAIP19)
   const marketData = useSelector(
     (state: ReduxState) => state.marketData.marketData[asset?.tokenId ?? asset?.chain]
   )

--- a/src/components/AccountRow/AccountRow.tsx
+++ b/src/components/AccountRow/AccountRow.tsx
@@ -11,7 +11,7 @@ import { useFetchAsset } from 'hooks/useFetchAsset/useFetchAsset'
 import { bn } from 'lib/bignumber/bignumber'
 import { fromBaseUnit } from 'lib/math'
 import { ReduxState } from 'state/reducer'
-import { fetchMarketData } from 'state/slices/marketDataSlice/marketDataSlice'
+import { fetchMarketData, selectMarketDataById } from 'state/slices/marketDataSlice/marketDataSlice'
 
 import { Allocations } from './Allocations'
 
@@ -32,23 +32,16 @@ export const AccountRow = ({ allocationValue, balance, CAIP19 }: AccountRowArgs)
   }, [chain, tokenId])
 
   const asset = useFetchAsset(CAIP19)
-  const marketData = useSelector(
-    (state: ReduxState) => state.marketData.marketData[asset?.tokenId ?? asset?.chain]
-  )
+  const marketData = useSelector((state: ReduxState) => selectMarketDataById(state, CAIP19))
   const marketDataLoading = useSelector((state: ReduxState) => state.marketData.loading)
 
   useEffect(() => {
     ;(async () => {
       if (asset && !marketData) {
-        dispatch(
-          fetchMarketData({
-            chain: asset.chain,
-            tokenId: asset.tokenId
-          })
-        )
+        dispatch(fetchMarketData(CAIP19))
       }
     })()
-  }, [asset, dispatch, marketData])
+  }, [asset, CAIP19, dispatch, marketData])
 
   const displayValue = useMemo(
     () => (asset ? fromBaseUnit(balance, asset.precision) : 0),

--- a/src/components/AssetSearch/selectors/selectAndSortAssets/selectAndSortAssets.test.ts
+++ b/src/components/AssetSearch/selectors/selectAndSortAssets/selectAndSortAssets.test.ts
@@ -1,15 +1,19 @@
 import { aapl, ethereum, rune, zero } from 'jest/mocks/assets'
 import { mockStore } from 'jest/mocks/store'
+import { ReduxState } from 'state/reducer'
 
 import { selectAndSortAssets } from './selectAndSortAssets'
 
-const store = {
+const store: ReduxState = {
   ...mockStore,
   assets: {
-    [rune.tokenId as string]: rune,
-    [aapl.tokenId as string]: aapl,
-    [ethereum.chain as string]: ethereum,
-    [zero.tokenId as string]: zero
+    byId: {
+      [rune.tokenId as string]: rune,
+      [aapl.tokenId as string]: aapl,
+      [ethereum.chain as string]: ethereum,
+      [zero.tokenId as string]: zero
+    },
+    ids: []
   }
 }
 

--- a/src/components/AssetSearch/selectors/selectAndSortAssets/selectAndSortAssets.ts
+++ b/src/components/AssetSearch/selectors/selectAndSortAssets/selectAndSortAssets.ts
@@ -1,24 +1,24 @@
 import { MarketCapResult } from '@shapeshiftoss/types'
+import { Asset } from '@shapeshiftoss/types'
 import sortBy from 'lodash/sortBy'
 import { createSelector } from 'reselect'
 import { ReduxState } from 'state/reducer'
-import { AssetsState, FullAsset } from 'state/slices/assetsSlice/assetsSlice'
 
 export const selectAndSortAssets = createSelector(
-  (state: ReduxState) => state.assets,
+  (state: ReduxState) => state.assets.byId,
   (state: ReduxState) => state.marketData.marketCap,
-  (assets: AssetsState, marketCap?: MarketCapResult) => {
-    let sortedAssets: FullAsset[] = []
-    const assetsEntries = Object.entries(assets)
+  (assetsById, marketCap?: MarketCapResult) => {
+    let sortedAssets: Asset[] = []
+    const assetsEntries = Object.entries(assetsById)
     if (marketCap) {
       // we only fetch market data for the top 250 assets
       // and want this to be fairly performant so do some mutatey things
-      const assetsByCAIP19 = assetsEntries.reduce<Record<string, FullAsset>>((acc, [, cur]) => {
+      const assetsByCAIP19 = assetsEntries.reduce<Record<string, Asset>>((acc, [, cur]) => {
         acc[cur.caip19] = cur
         return acc
       }, {})
       const caip19ByMarketCap = Object.keys(marketCap)
-      const sortedWithMarketCap = caip19ByMarketCap.reduce<FullAsset[]>((acc, cur) => {
+      const sortedWithMarketCap = caip19ByMarketCap.reduce<Asset[]>((acc, cur) => {
         const asset = assetsByCAIP19[cur]
         if (!asset) return acc
         acc.push(asset)

--- a/src/components/Modals/Send/Form.tsx
+++ b/src/components/Modals/Send/Form.tsx
@@ -63,10 +63,7 @@ export const Form = ({ asset: initialAsset }: SendFormProps) => {
   const location = useLocation()
   const history = useHistory()
   const { handleSend } = useFormSend()
-  const getAssetData = useGetAssetData({
-    chain: initialAsset.chain,
-    tokenId: initialAsset.tokenId
-  })
+  const getAssetData = useGetAssetData(initialAsset.caip19)
 
   const methods = useForm<SendInput>({
     mode: 'onChange',

--- a/src/components/Modals/Send/hooks/useAccountBalances/useAccountBalances.tsx
+++ b/src/components/Modals/Send/hooks/useAccountBalances/useAccountBalances.tsx
@@ -15,10 +15,7 @@ type UseAccountBalancesProps = {
 
 export const useAccountBalances = ({ asset, balances }: UseAccountBalancesProps) => {
   const [marketData, setMarketData] = useState<MarketData | null>(null)
-  const getAssetData = useGetAssetData({
-    chain: asset.chain,
-    tokenId: asset.tokenId
-  })
+  const getAssetData = useGetAssetData(asset.caip19)
   const assetBalance = asset?.tokenId ? balances[asset?.tokenId] : balances[asset.chain]
 
   useEffect(() => {

--- a/src/components/Modals/Send/hooks/useSendDetails/useSendDetails.tsx
+++ b/src/components/Modals/Send/hooks/useSendDetails/useSendDetails.tsx
@@ -60,7 +60,7 @@ export const useSendDetails = (): UseSendDetailsReturnType => {
 
   const { chain, tokenId } = asset
 
-  const getAssetData = useGetAssetData({ chain, tokenId })
+  const getAssetData = useGetAssetData(asset.caip19)
 
   useEffect(() => {
     if (balanceError) {

--- a/src/components/Modals/Send/hooks/useSendFees/useSendFees.tsx
+++ b/src/components/Modals/Send/hooks/useSendFees/useSendFees.tsx
@@ -14,8 +14,8 @@ export const useSendFees = () => {
   const { asset, estimatedFees } = useWatch({
     control
   })
-  const getAssetData = useGetAssetData({ chain: asset?.chain })
-  const feeAsset = useFetchAsset({ chain: asset?.chain })
+  const getAssetData = useGetAssetData(asset.caip19)
+  const feeAsset = useFetchAsset(asset.caip19)
   const {
     state: { wallet }
   } = useWallet()

--- a/src/components/StakingVaults/StakingVaultRow.tsx
+++ b/src/components/StakingVaults/StakingVaultRow.tsx
@@ -37,10 +37,9 @@ export const StakingVaultRow = ({
   const network = NetworkTypes.MAINNET
   const contractType = ContractTypes.ERC20
   // asset
-  const asset = useFetchAsset(
-    caip19.toCAIP19({ chain, network, contractType, tokenId: tokenAddress })
-  )
-  const marketData = useMarketData({ chain, tokenId: tokenAddress })
+  const assetCAIP19 = caip19.toCAIP19({ chain, network, contractType, tokenId: tokenAddress })
+  const asset = useFetchAsset(assetCAIP19)
+  const marketData = useMarketData(assetCAIP19)
 
   // account info
   const chainAdapterManager = useChainAdapters()

--- a/src/components/StakingVaults/StakingVaultRow.tsx
+++ b/src/components/StakingVaults/StakingVaultRow.tsx
@@ -1,6 +1,8 @@
 import { Flex, HStack } from '@chakra-ui/layout'
 import { Button, Skeleton, SkeletonCircle } from '@chakra-ui/react'
 import { Tag } from '@chakra-ui/tag'
+import { caip19 } from '@shapeshiftoss/caip'
+import { ContractTypes, NetworkTypes } from '@shapeshiftoss/types'
 import { useYearn } from 'features/earn/contexts/YearnProvider/YearnProvider'
 import { YearnVault } from 'features/earn/providers/yearn/api/api'
 import { SupportedYearnVault } from 'features/earn/providers/yearn/constants/vaults'
@@ -32,8 +34,12 @@ export const StakingVaultRow = ({
   const history = useHistory()
   const location = useLocation()
 
+  const network = NetworkTypes.MAINNET
+  const contractType = ContractTypes.ERC20
   // asset
-  const asset = useFetchAsset({ chain, tokenId: tokenAddress })
+  const asset = useFetchAsset(
+    caip19.toCAIP19({ chain, network, contractType, tokenId: tokenAddress })
+  )
   const marketData = useMarketData({ chain, tokenId: tokenAddress })
 
   // account info

--- a/src/components/Transactions/TransactionRow.tsx
+++ b/src/components/Transactions/TransactionRow.tsx
@@ -1,6 +1,7 @@
 import { ArrowDownIcon, ArrowUpIcon, CheckCircleIcon, WarningTwoIcon } from '@chakra-ui/icons'
 import { Box, Collapse, Flex, Link, SimpleGrid, Tag, useColorModeValue } from '@chakra-ui/react'
-import { Asset, chainAdapters, NetworkTypes } from '@shapeshiftoss/types'
+import { caip19 } from '@shapeshiftoss/caip'
+import { Asset, chainAdapters } from '@shapeshiftoss/types'
 import dayjs from 'dayjs'
 import localizedFormat from 'dayjs/plugin/localizedFormat'
 import relativeTime from 'dayjs/plugin/relativeTime'
@@ -13,9 +14,10 @@ import { IconCircle } from 'components/IconCircle'
 import { MiddleEllipsis } from 'components/MiddleEllipsis/MiddleEllipsis'
 import { Row } from 'components/Row/Row'
 import { RawText, Text } from 'components/Text'
+import { caip19FromTx } from 'hooks/useBalanceChartData/useBalanceChartData'
 import { fromBaseUnit } from 'lib/math'
 import { ReduxState } from 'state/reducer'
-import { fetchAsset } from 'state/slices/assetsSlice/assetsSlice'
+import { fetchAsset, selectAssetBySymbol } from 'state/slices/assetsSlice/assetsSlice'
 import { selectTxById } from 'state/slices/txHistorySlice/txHistorySlice'
 
 dayjs.extend(relativeTime)
@@ -25,11 +27,11 @@ export const TransactionRow = ({ txId, activeAsset }: { txId: string; activeAsse
   const ref = useRef<HTMLHeadingElement>(null)
   const dispatch = useDispatch()
   const tx = useSelector((state: ReduxState) => selectTxById(state, txId))
-  const asset = useSelector(
-    (state: ReduxState) => state.assets?.[tx.asset.toLowerCase() ?? tx.chain]
-  )
+  const asset = useSelector((state: ReduxState) => state.assets.byId[caip19FromTx(tx)])
+  // TODO(0xdef1cafe): pull this directly from tx when we have it from unchained
+  const feeAssetCAIP19 = caip19.toCAIP19({ chain: tx.chain, network: tx.network })
   // stables need precision of eth (18) rather than 10
-  const chainAsset = useSelector((state: ReduxState) => state.assets[tx.chain])
+  const feeAsset = useSelector((state: ReduxState) => state.assets.byId[feeAssetCAIP19])
   const [isOpen, setIsOpen] = useState(false)
   const toggleOpen = () => setIsOpen(!isOpen)
   const sentTx = tx.type === chainAdapters.TxType.Send
@@ -37,17 +39,14 @@ export const TransactionRow = ({ txId, activeAsset }: { txId: string; activeAsse
   const tradeTx = tx.type === chainAdapters.TxType.Trade
   const symbol = tx?.chainSpecific?.token?.symbol ?? asset?.symbol
 
-  const allAssets = useSelector((state: ReduxState) => state.assets)
-
   // TODO compare using caip ids
   // Cant do this yet because unchained doesnt only returns symbol with trade data
-  const buyAsset = Object.values(allAssets).find(
-    asset => asset.symbol === tx?.tradeDetails?.buyAsset
+  const buyAsset = useSelector((state: ReduxState) =>
+    selectAssetBySymbol(state, tx?.tradeDetails?.buyAsset ?? '')
   )
-  const sellAsset = Object.values(allAssets).find(
-    asset => asset.symbol === tx?.tradeDetails?.sellAsset
+  const sellAsset = useSelector((state: ReduxState) =>
+    selectAssetBySymbol(state, tx?.tradeDetails?.sellAsset ?? '')
   )
-
   let value = tx.value
   let precision = asset?.precision
   let txSymbol = symbol
@@ -67,16 +66,11 @@ export const TransactionRow = ({ txId, activeAsset }: { txId: string; activeAsse
   }
 
   useEffect(() => {
-    if (!symbol) {
-      dispatch(
-        fetchAsset({
-          chain: tx.chain,
-          network: NetworkTypes.MAINNET,
-          ...(tx.asset ? { tokenId: tx.asset.toLowerCase() } : undefined)
-        })
-      )
-    }
-  }, [dispatch, symbol, tx.chain, tx.asset])
+    if (symbol) return
+    const assetCAIP19 = caip19FromTx(tx)
+    dispatch(fetchAsset(assetCAIP19))
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, [dispatch, symbol, tx.asset, tx.chain])
 
   return (
     <Box
@@ -185,7 +179,7 @@ export const TransactionRow = ({ txId, activeAsset }: { txId: string; activeAsse
             <Row.Value>
               {tx?.fee && (
                 <Amount.Crypto
-                  value={fromBaseUnit(tx?.fee?.value ?? '0', chainAsset?.precision)}
+                  value={fromBaseUnit(tx?.fee?.value ?? '0', feeAsset?.precision)}
                   symbol={tx?.fee?.symbol}
                   maximumFractionDigits={6}
                 />

--- a/src/features/earn/providers/yearn/components/YearnManager/Deposit/YearnDeposit.tsx
+++ b/src/features/earn/providers/yearn/components/YearnManager/Deposit/YearnDeposit.tsx
@@ -81,9 +81,9 @@ export const YearnDeposit = ({ api }: YearnDepositProps) => {
   const assetCAIP19 = caip19.toCAIP19({ chain, network, contractType, tokenId })
   const feeAssetCAIP19 = caip19.toCAIP19({ chain, network })
   const asset = useFetchAsset(assetCAIP19)
-  const marketData = useMarketData({ chain, tokenId })
+  const marketData = useMarketData(assetCAIP19)
   const feeAsset = useFetchAsset(feeAssetCAIP19)
-  const feeMarketData = useMarketData({ chain })
+  const feeMarketData = useMarketData(feeAssetCAIP19)
   const vaultCAIP19 = caip19.toCAIP19({ chain, network, contractType, tokenId: vaultAddress })
   const vaultAsset = useFetchAsset(vaultCAIP19)
 

--- a/src/features/earn/providers/yearn/components/YearnManager/Deposit/YearnDeposit.tsx
+++ b/src/features/earn/providers/yearn/components/YearnManager/Deposit/YearnDeposit.tsx
@@ -11,7 +11,8 @@ import {
   useColorModeValue,
   useToast
 } from '@chakra-ui/react'
-import { ChainTypes } from '@shapeshiftoss/types'
+import { caip19 } from '@shapeshiftoss/caip'
+import { ChainTypes, ContractTypes, NetworkTypes } from '@shapeshiftoss/types'
 import { Approve } from 'features/earn/components/Approve/Approve'
 import { Confirm } from 'features/earn/components/Confirm/Confirm'
 import { Deposit, DepositValues } from 'features/earn/components/Deposit/Deposit'
@@ -75,12 +76,16 @@ export const YearnDeposit = ({ api }: YearnDepositProps) => {
   const { chain, contractAddress: vaultAddress, tokenId } = query
   const alertText = useColorModeValue('blue.800', 'white')
 
-  // Asset info
-  const asset = useFetchAsset({ chain, tokenId })
+  const network = NetworkTypes.MAINNET
+  const contractType = ContractTypes.ERC20
+  const assetCAIP19 = caip19.toCAIP19({ chain, network, contractType, tokenId })
+  const feeAssetCAIP19 = caip19.toCAIP19({ chain, network })
+  const asset = useFetchAsset(assetCAIP19)
   const marketData = useMarketData({ chain, tokenId })
-  const feeAsset = useFetchAsset({ chain })
+  const feeAsset = useFetchAsset(feeAssetCAIP19)
   const feeMarketData = useMarketData({ chain })
-  const vaultAsset = useFetchAsset({ chain, tokenId: vaultAddress })
+  const vaultCAIP19 = caip19.toCAIP19({ chain, network, contractType, tokenId: vaultAddress })
+  const vaultAsset = useFetchAsset(vaultCAIP19)
 
   // user info
   const chainAdapterManager = useChainAdapters()

--- a/src/features/earn/providers/yearn/components/YearnManager/Withdraw/YearnWithdraw.tsx
+++ b/src/features/earn/providers/yearn/components/YearnManager/Withdraw/YearnWithdraw.tsx
@@ -64,7 +64,7 @@ export const YearnWithdraw = ({ api }: YearnWithdrawProps) => {
   const underlyingAsset = useFetchAsset(underlyingAssetCAIP19)
   const assetCAIP19 = caip19.toCAIP19({ chain, network, contractType, tokenId: vaultAddress })
   const asset = useFetchAsset(assetCAIP19)
-  const marketData = useMarketData(assetCAIP19)
+  const marketData = useMarketData(underlyingAssetCAIP19)
   const feeAssetCAIP19 = caip19.toCAIP19({ chain, network })
   const feeAsset = useFetchAsset(feeAssetCAIP19)
   const feeMarketData = useMarketData(feeAssetCAIP19)

--- a/src/features/earn/providers/yearn/components/YearnManager/Withdraw/YearnWithdraw.tsx
+++ b/src/features/earn/providers/yearn/components/YearnManager/Withdraw/YearnWithdraw.tsx
@@ -64,10 +64,10 @@ export const YearnWithdraw = ({ api }: YearnWithdrawProps) => {
   const underlyingAsset = useFetchAsset(underlyingAssetCAIP19)
   const assetCAIP19 = caip19.toCAIP19({ chain, network, contractType, tokenId: vaultAddress })
   const asset = useFetchAsset(assetCAIP19)
-  const marketData = useMarketData({ chain, tokenId })
+  const marketData = useMarketData(assetCAIP19)
   const feeAssetCAIP19 = caip19.toCAIP19({ chain, network })
   const feeAsset = useFetchAsset(feeAssetCAIP19)
-  const feeMarketData = useMarketData({ chain })
+  const feeMarketData = useMarketData(feeAssetCAIP19)
 
   // user info
   const chainAdapterManager = useChainAdapters()

--- a/src/features/earn/providers/yearn/components/YearnManager/Withdraw/YearnWithdraw.tsx
+++ b/src/features/earn/providers/yearn/components/YearnManager/Withdraw/YearnWithdraw.tsx
@@ -1,6 +1,7 @@
 import { ArrowForwardIcon, CheckIcon, CloseIcon } from '@chakra-ui/icons'
 import { Box, Center, Flex, Link, Stack } from '@chakra-ui/react'
-import { ChainTypes } from '@shapeshiftoss/types'
+import { caip19 } from '@shapeshiftoss/caip'
+import { ChainTypes, ContractTypes, NetworkTypes } from '@shapeshiftoss/types'
 import { Confirm } from 'features/earn/components/Confirm/Confirm'
 import { EarnActionButtons } from 'features/earn/components/EarnActionButtons'
 import { TxStatus } from 'features/earn/components/TxStatus/TxStatus'
@@ -56,11 +57,16 @@ export const YearnWithdraw = ({ api }: YearnWithdrawProps) => {
   const { query, history: browserHistory } = useBrowserRouter<EarnQueryParams, EarnParams>()
   const { chain, contractAddress: vaultAddress, tokenId } = query
 
+  const network = NetworkTypes.MAINNET
+  const contractType = ContractTypes.ERC20
   // Asset info
-  const underlyingAsset = useFetchAsset({ chain, tokenId })
-  const asset = useFetchAsset({ chain, tokenId: vaultAddress })
+  const underlyingAssetCAIP19 = caip19.toCAIP19({ chain, network, contractType, tokenId })
+  const underlyingAsset = useFetchAsset(underlyingAssetCAIP19)
+  const assetCAIP19 = caip19.toCAIP19({ chain, network, contractType, tokenId: vaultAddress })
+  const asset = useFetchAsset(assetCAIP19)
   const marketData = useMarketData({ chain, tokenId })
-  const feeAsset = useFetchAsset({ chain })
+  const feeAssetCAIP19 = caip19.toCAIP19({ chain, network })
+  const feeAsset = useFetchAsset(feeAssetCAIP19)
   const feeMarketData = useMarketData({ chain })
 
   // user info

--- a/src/hooks/useAsset/useAsset.tsx
+++ b/src/hooks/useAsset/useAsset.tsx
@@ -1,34 +1,21 @@
+import { CAIP19 } from '@shapeshiftoss/caip'
 import { getMarketData } from '@shapeshiftoss/market-service'
-import { Asset, ChainTypes, MarketData, NetworkTypes } from '@shapeshiftoss/types'
+import { Asset, ChainTypes, MarketData } from '@shapeshiftoss/types'
 import { useCallback, useEffect } from 'react'
 import { useDispatch, useSelector } from 'react-redux'
 import { ReduxState } from 'state/reducer'
-import { fetchAsset } from 'state/slices/assetsSlice/assetsSlice'
+import { fetchAsset, selectAssetByCAIP19 } from 'state/slices/assetsSlice/assetsSlice'
 
 export type AssetMarketData = Asset & MarketData & { description?: string }
 
-export const ALLOWED_CHAINS = {
-  [ChainTypes.Ethereum]: true,
-  [ChainTypes.Bitcoin]: true
-}
-
-export const useGetAssetData = ({ chain, tokenId }: { chain: ChainTypes; tokenId?: string }) => {
+export const useGetAssetData = (caip19: CAIP19) => {
   const dispatch = useDispatch()
-  const asset = useSelector((state: ReduxState) => state.assets[tokenId ?? chain])
+  const asset = useSelector((state: ReduxState) => selectAssetByCAIP19(state, caip19))
 
   useEffect(() => {
-    if (ALLOWED_CHAINS[chain]) {
-      if (!asset) {
-        dispatch(
-          fetchAsset({
-            chain,
-            network: NetworkTypes.MAINNET,
-            tokenId
-          })
-        )
-      }
-    }
-  }, [asset, chain, dispatch, tokenId])
+    if (asset) return
+    dispatch(fetchAsset(caip19))
+  }, [asset, caip19, dispatch])
 
   const fetchMarketData = useCallback(
     async ({ chain, tokenId }: { chain: ChainTypes; tokenId?: string }): Promise<MarketData> => {

--- a/src/hooks/useFetchAsset/useFetchAsset.tsx
+++ b/src/hooks/useFetchAsset/useFetchAsset.tsx
@@ -1,31 +1,17 @@
-import { ChainTypes, NetworkTypes } from '@shapeshiftoss/types'
+import { CAIP19 } from '@shapeshiftoss/caip'
 import { useEffect } from 'react'
 import { useDispatch, useSelector } from 'react-redux'
 import { ReduxState } from 'state/reducer'
-import { fetchAsset } from 'state/slices/assetsSlice/assetsSlice'
+import { fetchAsset, selectAssetByCAIP19 } from 'state/slices/assetsSlice/assetsSlice'
 
-export const ALLOWED_CHAINS = {
-  [ChainTypes.Ethereum]: true,
-  [ChainTypes.Bitcoin]: true
-}
-
-export const useFetchAsset = ({ chain, tokenId }: { chain: ChainTypes; tokenId?: string }) => {
+export const useFetchAsset = (caip19: CAIP19) => {
   const dispatch = useDispatch()
-  const asset = useSelector((state: ReduxState) => state.assets[tokenId ?? chain])
+  const asset = useSelector((state: ReduxState) => selectAssetByCAIP19(state, caip19))
 
   useEffect(() => {
-    if (ALLOWED_CHAINS[chain]) {
-      if (!asset) {
-        dispatch(
-          fetchAsset({
-            chain,
-            network: NetworkTypes.MAINNET,
-            tokenId
-          })
-        )
-      }
-    }
-  }, [asset, chain, dispatch, tokenId])
+    if (asset) return
+    dispatch(fetchAsset(caip19))
+  }, [asset, caip19, dispatch])
 
   return asset
 }

--- a/src/hooks/useMarketData/useMarketData.tsx
+++ b/src/hooks/useMarketData/useMarketData.tsx
@@ -1,4 +1,5 @@
 import { CAIP19 } from '@shapeshiftoss/caip'
+import isEmpty from 'lodash/isEmpty'
 import { useEffect } from 'react'
 import { useDispatch, useSelector } from 'react-redux'
 import { ReduxState } from 'state/reducer'
@@ -9,8 +10,9 @@ export function useMarketData(CAIP19: CAIP19) {
   const dispatch = useDispatch()
 
   useEffect(() => {
+    if (!isEmpty(marketData)) return
     dispatch(fetchMarketData(CAIP19))
-  }, [CAIP19, dispatch])
+  }, [CAIP19, dispatch, marketData])
 
   return marketData
 }

--- a/src/hooks/useMarketData/useMarketData.tsx
+++ b/src/hooks/useMarketData/useMarketData.tsx
@@ -1,25 +1,16 @@
-import { ChainTypes } from '@shapeshiftoss/types'
+import { CAIP19 } from '@shapeshiftoss/caip'
 import { useEffect } from 'react'
 import { useDispatch, useSelector } from 'react-redux'
 import { ReduxState } from 'state/reducer'
-import { fetchMarketData } from 'state/slices/marketDataSlice/marketDataSlice'
+import { fetchMarketData, selectMarketDataById } from 'state/slices/marketDataSlice/marketDataSlice'
 
-export function useMarketData({ chain, tokenId }: { chain: ChainTypes; tokenId?: string }) {
-  const marketData = useSelector(
-    (state: ReduxState) => state.marketData.marketData[tokenId ?? chain]
-  )
+export function useMarketData(CAIP19: CAIP19) {
+  const marketData = useSelector((state: ReduxState) => selectMarketDataById(state, CAIP19))
   const dispatch = useDispatch()
 
   useEffect(() => {
-    ;(async () => {
-      dispatch(
-        fetchMarketData({
-          chain,
-          tokenId
-        })
-      )
-    })()
-  }, [chain, tokenId]) // eslint-disable-line react-hooks/exhaustive-deps
+    dispatch(fetchMarketData(CAIP19))
+  }, [CAIP19, dispatch])
 
   return marketData
 }

--- a/src/jest/mocks/store.ts
+++ b/src/jest/mocks/store.ts
@@ -1,10 +1,16 @@
 import { HistoryTimeframe } from '@shapeshiftoss/types'
-import { TxHistory } from 'state/slices/txHistorySlice/txHistorySlice'
+import { ReduxState } from 'state/reducer'
 
-export const mockStore = {
-  assets: {},
+export const mockStore: ReduxState = {
+  assets: {
+    byId: {},
+    ids: []
+  },
   marketData: {
-    marketData: {},
+    marketData: {
+      byId: {},
+      ids: []
+    },
     priceHistory: {
       [HistoryTimeframe.DAY]: {},
       [HistoryTimeframe.HOUR]: {},
@@ -15,8 +21,11 @@ export const mockStore = {
     },
     loading: false
   },
-  txHistory: {} as TxHistory,
+  txHistory: {
+    byId: {},
+    ids: []
+  },
   preferences: {
     accountTypes: {}
   }
-} as const
+}

--- a/src/pages/Assets/Asset.tsx
+++ b/src/pages/Assets/Asset.tsx
@@ -43,7 +43,7 @@ export const useAsset = () => {
   const extra = tokenId ? { contractType, tokenId } : undefined
   const assetCAIP19 = caip19.toCAIP19({ chain, network, ...extra })
   const asset = useFetchAsset(assetCAIP19)
-  const marketData = useMarketData({ chain, tokenId })
+  const marketData = useMarketData(assetCAIP19)
   const loading = useSelector((state: ReduxState) => state.marketData.loading)
 
   return {

--- a/src/pages/Assets/Asset.tsx
+++ b/src/pages/Assets/Asset.tsx
@@ -40,7 +40,8 @@ export const useAsset = () => {
   const { chain, tokenId } = useParams<MatchParams>()
   const network = NetworkTypes.MAINNET
   const contractType = ContractTypes.ERC20
-  const assetCAIP19 = caip19.toCAIP19({ chain, network, contractType, tokenId })
+  const extra = tokenId ? { contractType, tokenId } : undefined
+  const assetCAIP19 = caip19.toCAIP19({ chain, network, ...extra })
   const asset = useFetchAsset(assetCAIP19)
   const marketData = useMarketData({ chain, tokenId })
   const loading = useSelector((state: ReduxState) => state.marketData.loading)

--- a/src/pages/Assets/Asset.tsx
+++ b/src/pages/Assets/Asset.tsx
@@ -1,5 +1,6 @@
 import { Flex } from '@chakra-ui/react'
-import { ChainTypes, NetworkTypes } from '@shapeshiftoss/types'
+import { caip19 } from '@shapeshiftoss/caip'
+import { ChainTypes, ContractTypes, NetworkTypes } from '@shapeshiftoss/types'
 import { useSelector } from 'react-redux'
 import { useParams } from 'react-router-dom'
 import { Page } from 'components/Layout/Page'
@@ -37,7 +38,10 @@ export const initAsset = {
 
 export const useAsset = () => {
   const { chain, tokenId } = useParams<MatchParams>()
-  const asset = useFetchAsset({ chain, tokenId })
+  const network = NetworkTypes.MAINNET
+  const contractType = ContractTypes.ERC20
+  const assetCAIP19 = caip19.toCAIP19({ chain, network, contractType, tokenId })
+  const asset = useFetchAsset(assetCAIP19)
   const marketData = useMarketData({ chain, tokenId })
   const loading = useSelector((state: ReduxState) => state.marketData.loading)
 

--- a/src/pages/Assets/AssetCards/UnderlyingToken/UnderlyingToken.tsx
+++ b/src/pages/Assets/AssetCards/UnderlyingToken/UnderlyingToken.tsx
@@ -1,5 +1,6 @@
 import { Box, Grid, Stack } from '@chakra-ui/react'
-import { Asset } from '@shapeshiftoss/types'
+import { caip19 } from '@shapeshiftoss/caip'
+import { Asset, ContractTypes, NetworkTypes } from '@shapeshiftoss/types'
 import { FeatureFlagEnum } from 'constants/FeatureFlagEnum'
 import { useYearn } from 'features/earn/contexts/YearnProvider/YearnProvider'
 import { SUPPORTED_VAULTS } from 'features/earn/providers/yearn/constants/vaults'
@@ -20,7 +21,7 @@ type UnderlyingTokenProps = {
 // In the future we should add a hook to get the provider interface by vault provider
 export const UnderlyingToken = ({ asset }: UnderlyingTokenProps) => {
   const earnFeature = useFeature(FeatureFlagEnum.Yearn)
-  const [tokenId, setTokenId] = useState('')
+  const [underlyingCAIP19, setUnderlyingCAIP19] = useState('')
   const [balance, setBalance] = useState('')
   const { loading, yearn } = useYearn()
 
@@ -47,12 +48,16 @@ export const UnderlyingToken = ({ asset }: UnderlyingTokenProps) => {
           userAddress
         })
         setBalance(_balance.toString())
-        setTokenId(toLower(token))
+        const chain = asset.chain
+        const network = NetworkTypes.MAINNET
+        const contractType = ContractTypes.ERC20
+        const tokenId = toLower(token)
+        setUnderlyingCAIP19(caip19.toCAIP19({ chain, network, contractType, tokenId }))
       } catch (error) {
         console.error(error)
       }
     })()
-  }, [shouldHide, asset.tokenId, chainAdapter, vault, wallet, yearn])
+  }, [shouldHide, asset.tokenId, asset.chain, chainAdapter, vault, wallet, yearn])
 
   if (shouldHide || loading) return null
 
@@ -89,12 +94,7 @@ export const UnderlyingToken = ({ asset }: UnderlyingTokenProps) => {
               display={{ base: 'none', lg: 'block' }}
             />
           </Grid>
-          <AccountRow
-            allocationValue={100}
-            balance={balance}
-            chain={asset.chain}
-            tokenId={tokenId}
-          />
+          <AccountRow allocationValue={100} balance={balance} CAIP19={underlyingCAIP19} />
         </Stack>
       </Card.Body>
     </Card>

--- a/src/pages/Dashboard/components/AccountList/AccountList.tsx
+++ b/src/pages/Dashboard/components/AccountList/AccountList.tsx
@@ -13,6 +13,7 @@ import { DashboardIcon } from 'components/Icons/Dashboard'
 import { Text } from 'components/Text'
 import { useModal } from 'context/ModalProvider/ModalProvider'
 import { useWallet, WalletActions } from 'context/WalletProvider/WalletProvider'
+import { useCAIP19Balances } from 'hooks/useBalances/useCAIP19Balances'
 import { bnOrZero } from 'lib/bignumber/bignumber'
 import { usePortfolio } from 'pages/Dashboard/contexts/PortfolioContext'
 import { sortByFiat } from 'pages/Dashboard/helpers/sortByFiat/sortByFiat'
@@ -63,7 +64,8 @@ export const AccountList = ({ loading }: { loading?: boolean }) => {
   } = useWallet()
   const assets = useSelector(selectAssetsById)
   const marketData = useSelector((state: ReduxState) => state.marketData.marketData)
-  const { balances, totalBalance } = usePortfolio()
+  const { balances } = useCAIP19Balances()
+  const { totalBalance } = usePortfolio()
 
   useEffect(() => {
     // arbitrary number to just make sure we dont fetch all assets if we already have

--- a/src/pages/Dashboard/components/AccountList/AccountList.tsx
+++ b/src/pages/Dashboard/components/AccountList/AccountList.tsx
@@ -63,7 +63,7 @@ export const AccountList = ({ loading }: { loading?: boolean }) => {
     dispatch: walletDispatch
   } = useWallet()
   const assets = useSelector(selectAssetsById)
-  const marketData = useSelector((state: ReduxState) => state.marketData.marketData)
+  const marketData = useSelector((state: ReduxState) => state.marketData.marketData.byId)
   const { balances } = useCAIP19Balances()
   const { totalBalance } = usePortfolio()
 

--- a/src/pages/Dashboard/components/AccountList/AccountList.tsx
+++ b/src/pages/Dashboard/components/AccountList/AccountList.tsx
@@ -17,7 +17,7 @@ import { bnOrZero } from 'lib/bignumber/bignumber'
 import { usePortfolio } from 'pages/Dashboard/contexts/PortfolioContext'
 import { sortByFiat } from 'pages/Dashboard/helpers/sortByFiat/sortByFiat'
 import { ReduxState } from 'state/reducer'
-import { fetchAssets } from 'state/slices/assetsSlice/assetsSlice'
+import { fetchAssets, selectAssetsById } from 'state/slices/assetsSlice/assetsSlice'
 
 const AccountHeader = () => (
   <Grid
@@ -61,7 +61,7 @@ export const AccountList = ({ loading }: { loading?: boolean }) => {
     state: { isConnected },
     dispatch: walletDispatch
   } = useWallet()
-  const assets = useSelector((state: ReduxState) => state.assets)
+  const assets = useSelector(selectAssetsById)
   const marketData = useSelector((state: ReduxState) => state.marketData.marketData)
   const { balances, totalBalance } = usePortfolio()
 
@@ -128,10 +128,9 @@ export const AccountList = ({ loading }: { loading?: boolean }) => {
                   .div(bnOrZero(totalBalance))
                   .times(100)
                   .toNumber()}
-                key={account.contract ?? account.chain}
                 balance={account.balance ?? '0'}
-                chain={account.chain}
-                tokenId={account.contract}
+                CAIP19={asset.caip19}
+                key={asset.caip19}
               />
             )
           })}

--- a/src/pages/Dashboard/components/AccountList/AccountList.tsx
+++ b/src/pages/Dashboard/components/AccountList/AccountList.tsx
@@ -67,7 +67,7 @@ export const AccountList = ({ loading }: { loading?: boolean }) => {
 
   useEffect(() => {
     // arbitrary number to just make sure we dont fetch all assets if we already have
-    if (Object.keys(assets).length < 100) {
+    if (Object.keys(assets ?? {}).length < 100) {
       dispatch(fetchAssets({ network: NetworkTypes.MAINNET }))
     }
     // eslint-disable-next-line react-hooks/exhaustive-deps
@@ -121,6 +121,8 @@ export const AccountList = ({ loading }: { loading?: boolean }) => {
               : bnOrZero(0)
             const market = marketData[key]
             const fiatValue = balance.times(bnOrZero(market?.price)).toNumber()
+
+            if (!asset?.caip19) return null
 
             return (
               <AccountRow

--- a/src/pages/Dashboard/helpers/sortByFiat/sortByFiat.ts
+++ b/src/pages/Dashboard/helpers/sortByFiat/sortByFiat.ts
@@ -4,7 +4,7 @@ import { AssetsState } from 'state/slices/assetsSlice/assetsSlice'
 
 type SortByFiatInput = {
   balances: Record<string, Partial<chainAdapters.Account<ChainTypes>>>
-  assets: AssetsState
+  assets: AssetsState['byId']
   marketData: Record<string, MarketData>
 }
 

--- a/src/pages/Dashboard/hooks/useTotalBalance/useTotalBalance.test.tsx
+++ b/src/pages/Dashboard/hooks/useTotalBalance/useTotalBalance.test.tsx
@@ -1,3 +1,4 @@
+import { caip19 } from '@shapeshiftoss/caip'
 import { getMarketData } from '@shapeshiftoss/market-service'
 import { Asset, ChainTypes, ContractTypes, MarketData, NetworkTypes } from '@shapeshiftoss/types'
 import { act, renderHook } from '@testing-library/react-hooks'
@@ -91,19 +92,13 @@ describe('useTotalBalance', () => {
         }
       })
 
-      await store.dispatch(
-        fetchAsset({
-          tokenId: rune.tokenId,
-          chain: ChainTypes.Ethereum,
-          network: NetworkTypes.MAINNET
-        })
-      )
-      await store.dispatch(
-        fetchMarketData({
-          tokenId: rune.tokenId,
-          chain: ChainTypes.Ethereum
-        })
-      )
+      const chain = ChainTypes.Ethereum
+      const network = NetworkTypes.MAINNET
+      const contractType = ContractTypes.ERC20
+      const tokenId = rune.tokenId
+      const runeCAIP19 = caip19.toCAIP19({ chain, network, contractType, tokenId })
+      await store.dispatch(fetchAsset(runeCAIP19))
+      await store.dispatch(fetchMarketData(runeCAIP19))
       await waitForValueToChange(() => result.current)
       expect(result.current).toBe(210)
     })

--- a/src/pages/Dashboard/hooks/useTotalBalance/useTotalBalance.ts
+++ b/src/pages/Dashboard/hooks/useTotalBalance/useTotalBalance.ts
@@ -1,22 +1,30 @@
+import { caip19 } from '@shapeshiftoss/caip'
+import { NetworkTypes } from '@shapeshiftoss/types'
 import { useEffect, useState } from 'react'
 import { useSelector } from 'react-redux'
 import { flattenTokenBalances } from 'hooks/useBalances/useFlattenedBalances'
 import { bn } from 'lib/bignumber/bignumber'
 import { fromBaseUnit } from 'lib/math'
 import { ReduxState } from 'state/reducer'
+import { selectAssetsById } from 'state/slices/assetsSlice/assetsSlice'
 
 export const useTotalBalance = (accounts: ReturnType<typeof flattenTokenBalances>) => {
   const marketData = useSelector((state: ReduxState) => state.marketData)
-  const assets = useSelector((state: ReduxState) => state.assets)
+  const assets = useSelector(selectAssetsById)
   const [balance, setBalance] = useState(0)
 
   useEffect(() => {
     let balance = 0
     Object.values(accounts).forEach(account => {
       if (!account) return
-      const identifier = account.contract ?? account.chain
-      const accountMarketData = marketData.marketData[identifier]
-      const accountAsset = assets[identifier]
+      const { chain } = account
+      const network = account?.network ?? NetworkTypes.MAINNET
+      const contractType = account?.contractType
+      const tokenId = account?.contract
+      // const identifier = account.contract ?? account.chain
+      const assetCAIP19 = caip19.toCAIP19({ chain, network, contractType, tokenId })
+      const accountMarketData = marketData.marketData[assetCAIP19]
+      const accountAsset = assets[assetCAIP19]
       if (accountMarketData && accountAsset) {
         const cryptoValue = fromBaseUnit(account.balance ?? '0', accountAsset.precision)
         const fiatValue = bn(cryptoValue)

--- a/src/pages/Dashboard/hooks/useTotalBalance/useTotalBalance.ts
+++ b/src/pages/Dashboard/hooks/useTotalBalance/useTotalBalance.ts
@@ -21,9 +21,8 @@ export const useTotalBalance = (accounts: ReturnType<typeof flattenTokenBalances
       const network = account?.network ?? NetworkTypes.MAINNET
       const contractType = account?.contractType
       const tokenId = account?.contract
-      // const identifier = account.contract ?? account.chain
       const assetCAIP19 = caip19.toCAIP19({ chain, network, contractType, tokenId })
-      const accountMarketData = marketData.marketData[assetCAIP19]
+      const accountMarketData = marketData.marketData.byId[assetCAIP19]
       const accountAsset = assets[assetCAIP19]
       if (accountMarketData && accountAsset) {
         const cryptoValue = fromBaseUnit(account.balance ?? '0', accountAsset.precision)

--- a/src/pages/Earn/components/StakingCard.tsx
+++ b/src/pages/Earn/components/StakingCard.tsx
@@ -8,6 +8,8 @@ import {
   StatLabel,
   StatNumber
 } from '@chakra-ui/react'
+import { caip19 } from '@shapeshiftoss/caip'
+import { ContractTypes, NetworkTypes } from '@shapeshiftoss/types'
 import { Amount } from 'components/Amount/Amount'
 import { AssetIcon } from 'components/AssetIcon'
 import { Card } from 'components/Card/Card'
@@ -30,7 +32,10 @@ export const StakingCard = ({
   cryptoAmount,
   fiatAmount
 }: StakingCardProps) => {
-  const asset = useFetchAsset({ chain, tokenId: tokenAddress })
+  const network = NetworkTypes.MAINNET
+  const contractType = ContractTypes.ERC20
+  const assetCAIP19 = caip19.toCAIP19({ chain, network, contractType, tokenId: tokenAddress })
+  const asset = useFetchAsset(assetCAIP19)
 
   if (!asset) return null
 

--- a/src/pages/Earn/components/VaultList.tsx
+++ b/src/pages/Earn/components/VaultList.tsx
@@ -62,7 +62,7 @@ export const VaultList = ({ balances }: { balances: UseEarnBalancesReturn }) => 
               color='gray.500'
               translation='earn.empty.stakingVaults.body'
             />
-            <Button variant='ghost' colorScheme='blue'>
+            <Button variant='ghost' colorScheme='blue' as={NavLink} to='/earn/staking-vaults'>
               <Text translation='earn.empty.stakingVaults.cta' />
             </Button>
           </Card.Body>

--- a/src/pages/Earn/hooks/useVaultBalances.tsx
+++ b/src/pages/Earn/hooks/useVaultBalances.tsx
@@ -102,19 +102,24 @@ export function useVaultBalances(): UseVaultBalancesReturn {
 
   const makeVaultFiatAmount = useCallback(
     vault => {
-      const vaultAddress = vault.vaultAddress
-      const asset = assets[vaultAddress]
-      const pricePerShare = bnOrZero(vault.pricePerShare).div(`1e+${asset?.precision}`)
-      const { chain } = asset
+      const chain = ChainTypes.Ethereum
       const network = NetworkTypes.MAINNET
       const contractType = ContractTypes.ERC20
-      const vaultCAIP19 = caip19.toCAIP19({
+      const vaultTokenCAIP19 = caip19.toCAIP19({
         chain,
         network,
         contractType,
         tokenId: vault.tokenAddress
       })
-      const marketPrice = marketData.byId[vaultCAIP19]?.price
+      const vaultContractCAIP19 = caip19.toCAIP19({
+        chain,
+        network,
+        contractType,
+        tokenId: vault.vaultAddress
+      })
+      const asset = assets[vaultContractCAIP19]
+      const pricePerShare = bnOrZero(vault.pricePerShare).div(`1e+${asset?.precision}`)
+      const marketPrice = marketData.byId[vaultTokenCAIP19]?.price
       return bnOrZero(vault.balance)
         .div(`1e+${asset?.precision}`)
         .times(pricePerShare)

--- a/src/pages/Earn/hooks/useVaultBalances.tsx
+++ b/src/pages/Earn/hooks/useVaultBalances.tsx
@@ -89,7 +89,7 @@ export function useVaultBalances(): UseVaultBalancesReturn {
             tokenId: vault.tokenAddress
           })
           dispatch(fetchAsset(tokenCAIP19))
-          dispatch(fetchMarketData({ chain: vault.chain, tokenId: vault.tokenAddress }))
+          dispatch(fetchMarketData(tokenCAIP19))
         })
         setVaults(yearnVaults)
       } catch (error) {
@@ -105,7 +105,16 @@ export function useVaultBalances(): UseVaultBalancesReturn {
       const vaultAddress = vault.vaultAddress
       const asset = assets[vaultAddress]
       const pricePerShare = bnOrZero(vault.pricePerShare).div(`1e+${asset?.precision}`)
-      const marketPrice = marketData[vault.tokenAddress]?.price
+      const { chain } = asset
+      const network = NetworkTypes.MAINNET
+      const contractType = ContractTypes.ERC20
+      const vaultCAIP19 = caip19.toCAIP19({
+        chain,
+        network,
+        contractType,
+        tokenId: vault.tokenAddress
+      })
+      const marketPrice = marketData.byId[vaultCAIP19]?.price
       return bnOrZero(vault.balance)
         .div(`1e+${asset?.precision}`)
         .times(pricePerShare)

--- a/src/state/slices/assetsSlice/assetsSlice.test.ts
+++ b/src/state/slices/assetsSlice/assetsSlice.test.ts
@@ -1,5 +1,6 @@
-import { Asset, ChainTypes, NetworkTypes } from '@shapeshiftoss/types'
-import { aapl, rune, zero } from 'jest/mocks/assets'
+import { caip19 } from '@shapeshiftoss/caip'
+import { Asset, ChainTypes, ContractTypes, NetworkTypes } from '@shapeshiftoss/types'
+import { rune, zero } from 'jest/mocks/assets'
 import { getAssetService } from 'lib/assetService'
 import { store } from 'state/store'
 
@@ -28,50 +29,40 @@ const setup = ({
 
 describe('assetsSlice', () => {
   it('returns empty object for initialState', async () => {
-    expect(store.getState().assets).toEqual({})
+    expect(store.getState().assets.byId).toEqual({})
+    expect(store.getState().assets.ids).toEqual([])
   })
 
   describe('fetchAsset', () => {
+    const chain = ChainTypes.Ethereum
+    const network = NetworkTypes.MAINNET
+    const contractType = ContractTypes.ERC20
+    const tokenId = rune.tokenId
+    const runeCAIP19 = caip19.toCAIP19({ chain, network, contractType, tokenId })
+
     it('does not update state if assetData does not exist', async () => {
       setup({ assetData: undefined, description: null })
-      expect(store.getState().assets[rune.tokenId as string]).toBeFalsy()
-      await store.dispatch(
-        fetchAsset({
-          tokenId: rune.tokenId,
-          chain: ChainTypes.Ethereum,
-          network: NetworkTypes.MAINNET
-        })
-      )
-      expect(store.getState().assets[rune.tokenId as string]).toBeFalsy()
+      expect(store.getState().assets.byId[rune.tokenId as string]).toBeFalsy()
+      await store.dispatch(fetchAsset(runeCAIP19))
+      expect(store.getState().assets.byId[rune.tokenId as string]).toBeFalsy()
     })
 
     it('updates state if assetData exists but description does not', async () => {
       setup({ assetData: rune, description: null })
-      expect(store.getState().assets[rune.tokenId as string]).toBeFalsy()
-      await store.dispatch(
-        fetchAsset({
-          tokenId: rune.tokenId,
-          chain: ChainTypes.Ethereum,
-          network: NetworkTypes.MAINNET
-        })
-      )
-      expect(store.getState().assets[rune.tokenId as string]).toBeTruthy()
-      expect(store.getState().assets[rune.tokenId as string].description).toBeFalsy()
+      expect(store.getState().assets.byId[rune.tokenId as string]).toBeFalsy()
+      await store.dispatch(fetchAsset(runeCAIP19))
+      expect(store.getState().assets.byId[runeCAIP19]).toBeTruthy()
+      expect(store.getState().assets.ids.includes(runeCAIP19)).toBeTruthy()
     })
 
     it('updates state if assetData & description exists', async () => {
       const runeDescription =
         'THORChain is building a chain-agnostic bridging protocol that will allow trustless and secure value-transfer connections with most other chains (such as Bitcoin, Ethereum, Monero and all of Binance Chain). Users will be able to instantly swap any asset at fair market prices and deep liquidity. Token holders will be able to stake any asset and earn on liquidity fees. Projects will be able to access manipulation resistant price feeds and accept payments in any currencies, no matter the type or liquidity.'
-      setup({ assetData: aapl, description: runeDescription })
-      await store.dispatch(
-        fetchAsset({
-          tokenId: aapl.tokenId,
-          chain: ChainTypes.Ethereum,
-          network: NetworkTypes.MAINNET
-        })
-      )
-      expect(store.getState().assets[aapl.tokenId as string]).toBeTruthy()
-      expect(store.getState().assets[aapl.tokenId as string].description).toBeTruthy()
+      setup({ assetData: rune, description: runeDescription })
+      await store.dispatch(fetchAsset(runeCAIP19))
+      expect(store.getState().assets.byId[runeCAIP19]).toBeTruthy()
+      expect(store.getState().assets.ids.includes(runeCAIP19)).toBeTruthy()
+      expect(store.getState().assets.byId[runeCAIP19].description).toEqual(runeDescription)
     })
 
     it('does not update state if error is thrown', async () => {
@@ -85,15 +76,12 @@ describe('assetsSlice', () => {
         })
       }))
 
-      expect(store.getState().assets[zero.tokenId as string]).toBeFalsy()
-      await store.dispatch(
-        fetchAsset({
-          tokenId: zero.tokenId,
-          chain: ChainTypes.Ethereum,
-          network: NetworkTypes.MAINNET
-        })
-      )
-      expect(store.getState().assets[zero.tokenId as string]).toBeFalsy()
+      const { tokenId } = zero
+      const zeroCAIP19 = caip19.toCAIP19({ chain, network, contractType, tokenId })
+
+      expect(store.getState().assets.byId[zeroCAIP19]).toBeFalsy()
+      await store.dispatch(fetchAsset(zeroCAIP19))
+      expect(store.getState().assets.byId[zeroCAIP19]).toBeFalsy()
       expect(console.error).toBeCalled()
       consoleError.mockRestore()
     })

--- a/src/state/slices/assetsSlice/assetsSlice.ts
+++ b/src/state/slices/assetsSlice/assetsSlice.ts
@@ -68,7 +68,7 @@ export const selectAssetByCAIP19 = createSelector(
   (byId, CAIP19) => byId[CAIP19]
 )
 
-// TODO(0xdef1cafe): remove this and find by buy/
+// TODO(0xdef1cafe): add caip19s to buy and sell assets in swapper and remove this
 export const selectAssetBySymbol = createSelector(
   (state: ReduxState) => state.assets.byId,
   (_state: ReduxState, symbol: string) => symbol,

--- a/src/state/slices/assetsSlice/assetsSlice.ts
+++ b/src/state/slices/assetsSlice/assetsSlice.ts
@@ -42,6 +42,7 @@ export const assets = createSlice({
       .addCase(fetchAsset.fulfilled, (state, { payload, meta }) => {
         const assetCAIP19 = meta.arg
         state.byId[assetCAIP19] = payload
+        if (!state.ids.includes(assetCAIP19)) state.ids.push(assetCAIP19)
       })
       .addCase(fetchAsset.rejected, (state, { payload, meta }) => {
         console.error('fetchAsset rejected')

--- a/src/state/slices/assetsSlice/assetsSlice.ts
+++ b/src/state/slices/assetsSlice/assetsSlice.ts
@@ -31,7 +31,10 @@ export const fetchAssets = createAsyncThunk(
   }
 )
 
-const initialState = {} as AssetsState
+const initialState: AssetsState = {
+  byId: {},
+  ids: []
+}
 
 export const assets = createSlice({
   name: 'asset',
@@ -45,9 +48,14 @@ export const assets = createSlice({
         state.byId[assetCAIP19].description = description
       })
       .addCase(fetchAssets.fulfilled, (state, { payload: assets }) => {
-        assets?.forEach(asset => {
-          const { caip19 } = asset
-          state.byId[caip19] = asset
+        const byId = assets.reduce<AssetsState['byId']>((acc, cur) => {
+          const { caip19 } = cur
+          acc[caip19] = cur
+          return acc
+        }, {})
+        state.byId = byId
+
+        assets?.forEach(({ caip19 }) => {
           if (!state.ids.includes(caip19)) state.ids.push(caip19)
         })
       })

--- a/src/state/slices/marketDataSlice/marketDataSlice.test.ts
+++ b/src/state/slices/marketDataSlice/marketDataSlice.test.ts
@@ -1,6 +1,7 @@
+import { caip19 } from '@shapeshiftoss/caip'
 import { getMarketData } from '@shapeshiftoss/market-service'
-import { ChainTypes } from '@shapeshiftoss/types'
-import { ethereum, rune } from 'jest/mocks/assets'
+import { ChainTypes, ContractTypes, NetworkTypes } from '@shapeshiftoss/types'
+import { rune } from 'jest/mocks/assets'
 import { store } from 'state/store'
 
 import { fetchMarketData } from './marketDataSlice'
@@ -10,24 +11,19 @@ jest.mock('@shapeshiftoss/market-service', () => ({
 }))
 
 describe('marketDataSlice', () => {
-  it('returns empty object for initialState', async () => {
-    expect(store.getState().assets).toEqual({})
-  })
-
   describe('fetchMarketData', () => {
+    const chain = ChainTypes.Ethereum
+    const network = NetworkTypes.MAINNET
+    const contractType = ContractTypes.ERC20
+    const tokenId = rune.tokenId
+    const runeCAIP19 = caip19.toCAIP19({ chain, network, contractType, tokenId })
     it('does not update state if marketData does not exist', async () => {
       ;(getMarketData as unknown as jest.Mock<unknown>).mockImplementation(() =>
         Promise.resolve(null)
       )
-      expect(store.getState().marketData.marketData[rune.tokenId as string]).toBeFalsy()
-      await store.dispatch(
-        fetchMarketData({
-          tokenId: rune.tokenId,
-          chain: ChainTypes.Ethereum
-        })
-      )
-
-      expect(store.getState().marketData.marketData[rune.tokenId as string]).toBeFalsy()
+      expect(store.getState().marketData.marketData.byId[runeCAIP19]).toBeFalsy()
+      await store.dispatch(fetchMarketData(runeCAIP19))
+      expect(store.getState().marketData.marketData.byId[runeCAIP19]).toBeFalsy()
     })
 
     it('updates state if marketData exists with tokenId', async () => {
@@ -39,15 +35,9 @@ describe('marketDataSlice', () => {
           volume: 90000
         })
       )
-      expect(store.getState().marketData.marketData[rune.tokenId as string]).toBeFalsy()
-      await store.dispatch(
-        fetchMarketData({
-          tokenId: rune.tokenId,
-          chain: ChainTypes.Ethereum
-        })
-      )
-
-      expect(store.getState().marketData.marketData[rune.tokenId as string]).toBeTruthy()
+      expect(store.getState().marketData.marketData.byId[runeCAIP19]).toBeFalsy()
+      await store.dispatch(fetchMarketData(runeCAIP19))
+      expect(store.getState().marketData.marketData.byId[runeCAIP19]).toBeTruthy()
     })
 
     it('updates state if marketData exists without tokenId', async () => {
@@ -59,14 +49,10 @@ describe('marketDataSlice', () => {
           volume: 90000
         })
       )
-      expect(store.getState().marketData.marketData[ethereum.chain]).toBeFalsy()
-      await store.dispatch(
-        fetchMarketData({
-          chain: ChainTypes.Ethereum
-        })
-      )
-
-      expect(store.getState().marketData.marketData[ethereum.chain]).toBeTruthy()
+      const ethCAIP19 = caip19.toCAIP19({ chain, network })
+      expect(store.getState().marketData.marketData.byId[ethCAIP19]).toBeFalsy()
+      await store.dispatch(fetchMarketData(ethCAIP19))
+      expect(store.getState().marketData.marketData.byId[ethCAIP19]).toBeTruthy()
     })
   })
 })


### PR DESCRIPTION
## Description

TODO: test trade before merging

we can now deal with assets, market data, price history data, market cap, all purely by caip19. we can currently do txs by caip19 in a hacky way that will be fixed soon upstream in unchained.

* normalizes assets in store
* normalizes market data in store
* allows us to join asset, market, and transaction data efficiently by a single id (caip19)
* stops the `chain ?? tokenId` insanity throughout the view layers

## Notice

Before submitting a pull request, please make sure you have answered the following:

- [x] Have you followed the guidelines in our [Contributing]('https://github.com/shapeshift/web/CONTRIBUTING.md) guide?
- [x] Have you checked to ensure there aren't other open [Pull Requests](https://github.com/shapeshift/web/pulls) for the same update/change?
- [x] Do all new and existing tests pass? Does the linter pass?

## Pull Request Type

- [ ] :bug: Bug fix (Non-breaking Change: Fixes an issue)
- [x] :hammer_and_wrench: Chore (Non-breaking Change: Doc updates, pkg upgrades, typos, etc..)
- [ ] :nail_care: New Feature (Breaking/Non-breaking Change)

## Issue (if applicable)

close #530

## Testing

Please outline all testing steps

this will require a full regression test as it covers all aspects of web, especially yearn bits

## Screenshots (if applicable)

<img width="446" alt="Screen Shot 2021-12-02 at 2 23 24 PM" src="https://user-images.githubusercontent.com/88504456/144505245-2919d781-2a7d-443a-bf74-2edc7e0158fe.png">

