### PR TITLE
fixed double mobile nav, added explorer link

### DIFF
--- a/src/assets/translations/messages-en.json
+++ b/src/assets/translations/messages-en.json
@@ -229,7 +229,8 @@
       "setAmount": "Set Amount",
       "verify": "Verify",
       "verified": "Verified",
-      "notVerified": "Address Mismatch"
+      "notVerified": "Address Mismatch",
+      "blockExplorer": "Explorer"
     },
     "deposit": {
       "amountToDeposit": "Amount To Deposit",

--- a/src/components/Layout/Header/HeaderContent.tsx
+++ b/src/components/Layout/Header/HeaderContent.tsx
@@ -1,23 +1,13 @@
 import { ArrowBackIcon } from '@chakra-ui/icons'
-import {
-  Box,
-  Flex,
-  IconButton,
-  Portal,
-  Stack,
-  useColorModeValue,
-  useMediaQuery
-} from '@chakra-ui/react'
+import { Box, Flex, IconButton, Portal, Stack, useColorModeValue } from '@chakra-ui/react'
 import { Link as RouterLink } from 'react-router-dom'
 import { pathTo, Route } from 'Routes/helpers'
 import { FoxIcon } from 'components/Icons/FoxIcon'
-import { breakpoints } from 'theme/theme'
 
 import { NavBar } from './NavBar/NavBar'
 import { UserMenu } from './NavBar/UserMenu'
 
 export const HeaderContent = ({ route }: { route: Route }) => {
-  const [isLargerThanMd] = useMediaQuery(`(min-width: ${breakpoints['md']})`)
   const navbarBg = useColorModeValue('white', 'gray.800')
   const navbarBorder = useColorModeValue('gray.100', 'gray.750')
   const navShadow = useColorModeValue('lg', 'dark-lg')
@@ -61,27 +51,25 @@ export const HeaderContent = ({ route }: { route: Route }) => {
           <UserMenu />
         </Flex>
       </Flex>
-      {isLargerThanMd ? null : (
-        <Portal>
-          <Box
-            position='fixed'
-            width='full'
-            bottom={0}
-            pb={'env(safe-area-inset-bottom)'}
-            left='50%'
-            transform='translateX(-50%)'
-            display='inline-block'
-            bg={navbarBg}
-            borderTopWidth={1}
-            borderColor={navbarBorder}
-            boxShadow={navShadow}
-          >
-            <Stack as={'nav'} spacing={4} p={2}>
-              <NavBar />
-            </Stack>
-          </Box>
-        </Portal>
-      )}
+      <Portal>
+        <Box
+          position='fixed'
+          width='full'
+          display={{ base: 'inline-block', md: 'none' }}
+          bottom={0}
+          pb={'env(safe-area-inset-bottom)'}
+          left='50%'
+          transform='translateX(-50%)'
+          bg={navbarBg}
+          borderTopWidth={1}
+          borderColor={navbarBorder}
+          boxShadow={navShadow}
+        >
+          <Stack as={'nav'} spacing={4} p={2}>
+            <NavBar />
+          </Stack>
+        </Box>
+      </Portal>
     </Flex>
   )
 }

--- a/src/components/Modals/Receive/ReceiveInfo.tsx
+++ b/src/components/Modals/Receive/ReceiveInfo.tsx
@@ -1,4 +1,4 @@
-import { ArrowBackIcon, CheckIcon, CopyIcon, ViewIcon } from '@chakra-ui/icons'
+import { ArrowBackIcon, CheckIcon, CopyIcon, ExternalLinkIcon, ViewIcon } from '@chakra-ui/icons'
 import {
   Box,
   Button,
@@ -7,6 +7,7 @@ import {
   HStack,
   IconButton,
   LightMode,
+  Link,
   ModalBody,
   ModalCloseButton,
   ModalFooter,
@@ -220,6 +221,23 @@ export const ReceiveInfo = ({ asset }: ReceivePropsType) => {
                   />
                 </Button>
               ) : undefined}
+              <Button
+                as={Link}
+                href={`${asset?.explorerAddressLink}${receiveAddress}`}
+                isExternal
+                padding={2}
+                color='gray.500'
+                flexDir='column'
+                role='group'
+                isDisabled={!receiveAddress}
+                variant='link'
+                _hover={{ textDecoration: 'none', color: hoverColor }}
+              >
+                <Circle bg={bg} mb={2} size='40px' _groupHover={{ bg: 'blue.500', color: 'white' }}>
+                  <ExternalLinkIcon />
+                </Circle>
+                <Text translation='modals.receive.blockExplorer' />
+              </Button>
             </HStack>
           </ModalFooter>
         </>


### PR DESCRIPTION
## Description

- Mobile nav would appear and stay after going down to MD sizes, this prevents that from happening.
- Added explorer link on the receive modal

## Notice

Before submitting a pull request, please make sure you have answered the following:

- [ ] Have you followed the guidelines in our [Contributing]('https://github.com/shapeshift/web/CONTRIBUTING.md) guide?
- [ ] Have you checked to ensure there aren't other open [Pull Requests](https://github.com/shapeshift/web/pulls) for the same update/change?
- [ ] Do all new and existing tests pass? Does the linter pass?

## Pull Request Type

- [ ] :bug: Bug fix (Non-breaking Change: Fixes an issue)
- [ ] :hammer_and_wrench: Chore (Non-breaking Change: Doc updates, pkg upgrades, typos, etc..)
- [ ] :nail_care: New Feature (Breaking/Non-breaking Change)

## Issue (if applicable)

If applicable, please link to the github issue and put `closes #XXXX` in your comment to auto-close the issue that your PR fixes.

## Testing

Please outline all testing steps

1. Pull branch locally and run `yarn` to install new deps
2. etc...

## Screenshots (if applicable)
