### PR TITLE
feat: generate SRI attributes for all assets

### DIFF
--- a/headers.js
+++ b/headers.js
@@ -64,6 +64,7 @@ const cspMeta = Object.entries({
   .join('; ')
 
 const headers = {
+  'Cache-Control': 'no-transform', // This will prevent middleboxes from munging our JS and breaking SRI if we're ever served over HTTP
   'Content-Security-Policy': `${cspMeta}; frame-ancestors 'none'`, // `; report-uri https://shapeshift.report-uri.com/r/d/csp/wizard`,
   'Cross-Origin-Opener-Policy': 'same-origin-allow-popups',
   'Permissions-Policy': 'document-domain=()',

--- a/package.json
+++ b/package.json
@@ -173,6 +173,7 @@
     "ts-jest": "^27.0.4",
     "typescript": "^4.5.2",
     "web3-utils": "^1.5.2",
+    "webpack": "5.65.0",
     "webpack-subresource-integrity": "^5.0.0",
     "yarn-minify": "^1.0.1"
   },

--- a/package.json
+++ b/package.json
@@ -166,13 +166,11 @@
     "eslint-config-prettier": "^8.3.0",
     "eslint-plugin-prettier": "^4.0.0",
     "eslint-plugin-simple-import-sort": "^7.0.0",
-    "fast-json-stable-stringify": "^2.1.0",
     "prettier": "^2.3.2",
     "react-app-rewired": "^2.1.9",
     "storybook-dark-mode": "^1.0.8",
     "ts-jest": "^27.0.4",
     "typescript": "^4.5.2",
-    "val-loader": "^4.0.0",
     "web3-utils": "^1.5.2",
     "yarn-minify": "^1.0.1"
   },

--- a/package.json
+++ b/package.json
@@ -168,10 +168,12 @@
     "eslint-plugin-simple-import-sort": "^7.0.0",
     "prettier": "^2.3.2",
     "react-app-rewired": "^2.1.9",
+    "ssri": "^8.0.1",
     "storybook-dark-mode": "^1.0.8",
     "ts-jest": "^27.0.4",
     "typescript": "^4.5.2",
     "web3-utils": "^1.5.2",
+    "webpack-subresource-integrity": "^5.0.0",
     "yarn-minify": "^1.0.1"
   },
   "resolutions": {

--- a/public/index.html
+++ b/public/index.html
@@ -5,8 +5,8 @@
     <meta name="referrer" content="no-referrer">
     <meta name="apple-mobile-web-app-status-bar-style" content="black-translucent">
     <meta http-equiv="Content-Security-Policy" content="%REACT_APP_CSP_META%" />
-    <link rel="icon" type="image/png" href="%PUBLIC_URL%/favicon.png" />
-    <link rel="icon" type="image/svg+xml" href="%PUBLIC_URL%/favicon.svg" />
+    <link rel="icon" type="image/png" href="%PUBLIC_URL%/favicon.png" integrity="%REACT_APP_SRI_FAVICON_PNG%" crossorigin="anonymous" />
+    <link rel="icon" type="image/svg+xml" href="%PUBLIC_URL%/favicon.svg" integrity="%REACT_APP_SRI_FAVICON_SVG%" crossorigin="anonymous" />
     <meta name="viewport" content="width=device-width, initial-scale=1, user-scalable=no,viewport-fit=cover" />
     <meta property="og:title" content="ShapeShift DAO">
     <meta property="og:type" content="website" />
@@ -20,13 +20,13 @@
       name="description"
       content="ShapeShift DAO | Your Web3 & DeFi Portal"
     />
-    <link rel="apple-touch-icon" sizes="192x192" href="%PUBLIC_URL%/icon-192x192.png">
-    <link rel="apple-touch-icon" sizes="512x512" href="%PUBLIC_URL%/icon-512x512.png">
+    <link rel="apple-touch-icon" sizes="192x192" href="%PUBLIC_URL%/icon-192x192.png" integrity="%REACT_APP_SRI_ICON_192X192_PNG%" crossorigin="anonymous" />
+    <link rel="apple-touch-icon" sizes="512x512" href="%PUBLIC_URL%/icon-512x512.png" integrity="%REACT_APP_SRI_ICON_512X512_PNG%" crossorigin="anonymous" />
     <!--
       manifest.json provides metadata used when your web app is installed on a
       user's mobile device or desktop. See https://developers.google.com/web/fundamentals/web-app-manifest/
     -->
-    <link rel="manifest" href="%PUBLIC_URL%/manifest.json" />
+    <link rel="manifest" href="%PUBLIC_URL%/manifest.json" integrity="%REACT_APP_SRI_MANIFEST_JSON%" crossorigin="anonymous" />
     <!--
       Notice the use of %PUBLIC_URL% in the tags above.
       It will be replaced with the URL of the `public` folder during the build.

--- a/react-app-rewired.config.js
+++ b/react-app-rewired.config.js
@@ -113,6 +113,22 @@ module.exports = {
       ],
     })
 
+    // Remove synthetic CSP/SRI environment variables from DefinePlugin.
+    _.merge(config, {
+      plugins: config.plugins.map(plugin => {
+        if (plugin.constructor.name !== 'DefinePlugin') return plugin
+  
+        const definitions = JSON.parse(JSON.stringify(plugin.definitions))
+        const env = definitions['process.env'] || {}
+
+        for (const key in env) {
+          if (/^REACT_APP_(CSP|SRI)_.*$/.test(key)) delete env[key]
+        }
+
+        return new webpack.DefinePlugin(definitions)
+      }),
+    })
+
     // Generate and embed Subresource Integrity (SRI) attributes for all files.
     // Automatically embeds SRI hashes when generating the embedded webpack loaders
     // for split code.

--- a/react-app-rewired.config.js
+++ b/react-app-rewired.config.js
@@ -1,13 +1,23 @@
 /**
  * React App Rewired Config
  */
-const stableStringify = require('fast-json-stable-stringify')
 const _ = require('lodash')
 const path = require('path')
 const webpack = require('webpack')
 
 const headers = require('./headers')
 process.env.REACT_APP_CSP_META = headers.cspMeta ?? ''
+
+// This ensures environment variables will be enumerated in order, which affects the build products.
+const reactEnvEntries = Object.entries(process.env)
+  .filter(([k]) => k.startsWith('REACT_APP'))
+  .sort((a, b) => {
+    if (a[0] < b[0]) return -1
+    if (a[0] > b[0]) return 1
+    return 0
+  })
+reactEnvEntries.forEach(([k]) => delete process.env[k])
+reactEnvEntries.forEach(([k, v]) => (process.env[k] = v))
 
 module.exports = {
   webpack: (config, mode) => {
@@ -80,81 +90,6 @@ module.exports = {
           );
         }
       ],
-    })
-
-    // Collect env vars that would have been injected via DefinePlugin. We will emit them
-    // as dynamically-loaded JSON later instead of find/replacing the string 'process.env'.
-    // This ensures that the minified Webpack output will be the same no matter the build
-    // options being used.
-    const env = Object.fromEntries(
-      Object.entries(
-        config.plugins
-          .filter((plugin) => plugin.constructor.name === "DefinePlugin")
-          .reduceRight((x) => x).definitions?.["process.env"] || {}
-      ).filter(([k, v])=> v).map(([k, v]) => [k, JSON.parse(v)])
-    );
-    // Update the Webpack config to emit the collected env vars as `env.json` and load them
-    // dynamically instead of baking them into each chunk that might reference them.
-    _.merge(config, {
-      plugins: [...config.plugins.map(plugin => {
-        switch (plugin.constructor.name) {
-          case 'DefinePlugin': {
-            // Remove the 'process.env' entry from DefinePlugin; this will cause `process.env` to
-            // resolve via the ProvidePlugin `process` global.
-            delete plugin.definitions['process.env']
-            return plugin
-          }
-          case 'ProvidePlugin': {
-            // This is a thin wrapper around the process/browser.js module, which inserts the
-            // contents of `env.json` into `process.env` and freezes the object to prevent
-            // attacks on any code that might expect its environment variables to be immutable.
-            return new webpack.ProvidePlugin(Object.assign({}, plugin.definitions, {
-              process: [ path.join(__dirname, 'src/env/process.js') ],
-            }))
-          }
-          default: return plugin
-        }
-      })],
-      module: {
-        rules: [...config.module?.rules, {
-          // This rule causes the (placeholder) contents of `src/env/env.json` to be thrown away
-          // and replaced with `stableStringify(env)`, which is then written out to `build/env.json`.
-          //
-          // Note that simply adding this rule doesn't force `env.json` to be generated. That happens
-          // because `src/env/process.js` `require()`s it, and that module is provided via ProvidePlugin
-          // above. If nothing ever uses that `process` global, both `src/env/process.js` and `env.json`
-          // will be omitted from the build.
-          resource: path.join(__dirname, 'src/env/env.json'),
-          // Webpack loads resources by reading them from disk and feeding them through a series
-          // of loaders. It then emits them by feeding the result to a generator.
-          //
-          // The `val-loader` plugin is a customizable loader which `require()`s `executableFile`,
-          // expecting a single exported function which it uses to transform the on-disk module data.
-          // The stub loader, `src/env/loader.js`, simply takes a `code` function as an option and
-          // and replaces the module data with its result.
-          //
-          // Webpack requires both the module being loaded and the stub loader to exist as actual files
-          // on the filesystem, but this setup allows the actual content of a module to be generated
-          // at compile time.
-          use: [{
-            loader: 'val-loader',
-            options: {
-              executableFile: require.resolve(path.join(__dirname, 'src/env/loader.js')),
-              code: () => stableStringify(env),
-            },
-          }],
-          // The type ['asset/resource'](https://webpack.js.org/guides/asset-modules/#resource-assets)
-          // tells Webpack to a special generator that will emit the module as a separate file instead
-          // of inlining its contents into another chunk, as well as skip the normal plugin processing
-          // and minification steps and just write the raw as-loaded contents. The `generator.filename`
-          // option overrides the default output path so that the file ends up at `build/env.json`
-          // instead of the default `build/static/media/env.[hash].json`.
-          type: 'asset/resource',
-          generator: {
-            filename: '[base]',
-          },
-        }]
-      },
     })
 
     return config

--- a/src/env/env.json
+++ b/src/env/env.json
@@ -1,1 +1,0 @@
-{"README":"This is a placeholder. It must exist, but its contents will be replaced at build time. See react-app-rewired.config.js for details."}

--- a/src/env/loader.js
+++ b/src/env/loader.js
@@ -1,2 +1,0 @@
-// This is a stub for use with the Webpack loader `val-loader`. See react-app-rewired.config.js for details.
-module.exports = ({ code }) => ({ cacheable: true, code: code() })

--- a/src/env/process.js
+++ b/src/env/process.js
@@ -1,6 +1,0 @@
-// This is a thin wrapper around the process/browser.js module which assigns the contents of
-// env.json to process.env and freezes things to prevent shenanigans. See react-app-rewired.config.js
-// for details.
-const process = require('process/browser.js')
-Object.freeze(Object.assign(process.env, require('./env.json')))
-module.exports = Object.freeze(process)

--- a/yarn.lock
+++ b/yarn.lock
@@ -19863,11 +19863,6 @@ v8-to-istanbul@^8.0.0, v8-to-istanbul@^8.1.0:
     convert-source-map "^1.6.0"
     source-map "^0.7.3"
 
-val-loader@^4.0.0:
-  version "4.0.0"
-  resolved "https://registry.yarnpkg.com/val-loader/-/val-loader-4.0.0.tgz#c5ccf8abfe486de412d2cd59fa56deb49d44ec8d"
-  integrity sha512-tpDHHpVo1hrO9xFhpEcOw+RCK4wnQqqNkZmylwHJ04iVeue1YSYxIdDwCdKd7LVQ8g/fsGX/EC5gLda9BXovkg==
-
 validate-npm-package-license@^3.0.1:
   version "3.0.4"
   resolved "https://registry.yarnpkg.com/validate-npm-package-license/-/validate-npm-package-license-3.0.4.tgz#fc91f6b9c7ba15c857f4cb2c5defeec39d4f410a"

--- a/yarn.lock
+++ b/yarn.lock
@@ -20458,7 +20458,7 @@ webpack@4:
     watchpack "^1.7.4"
     webpack-sources "^1.4.1"
 
-webpack@^5.64.4:
+webpack@5.65.0, webpack@^5.64.4:
   version "5.65.0"
   resolved "https://registry.yarnpkg.com/webpack/-/webpack-5.65.0.tgz#ed2891d9145ba1f0d318e4ea4f89c3fa18e6f9be"
   integrity sha512-Q5or2o6EKs7+oKmJo7LaqZaMOlDWQse9Tm5l1WAfU/ujLGN5Pb0SqGeVkN/4bpPmEqEP5RnVhiqsOtWtUVwGRw==

--- a/yarn.lock
+++ b/yarn.lock
@@ -11808,6 +11808,17 @@ html-void-elements@^1.0.0:
   resolved "https://registry.yarnpkg.com/html-void-elements/-/html-void-elements-1.0.5.tgz#ce9159494e86d95e45795b166c2021c2cfca4483"
   integrity sha512-uE/TxKuyNIcx44cIWnjr/rfIATDH7ZaOMmstu0CwhFG1Dunhlp4OC6/NMbhiwoq5BpW0ubi303qnEk/PZj614w==
 
+html-webpack-plugin@5.5.0, html-webpack-plugin@^5.5.0:
+  version "5.5.0"
+  resolved "https://registry.yarnpkg.com/html-webpack-plugin/-/html-webpack-plugin-5.5.0.tgz#c3911936f57681c1f9f4d8b68c158cd9dfe52f50"
+  integrity sha512-sy88PC2cRTVxvETRgUHFrL4No3UxvcH8G1NepGhqaTT+GXN2kTamqasot0inS5hXeg1cMbFDt27zzo9p35lZVw==
+  dependencies:
+    "@types/html-minifier-terser" "^6.0.0"
+    html-minifier-terser "^6.0.2"
+    lodash "^4.17.21"
+    pretty-error "^4.0.0"
+    tapable "^2.0.0"
+
 html-webpack-plugin@^4.0.0:
   version "4.5.2"
   resolved "https://registry.yarnpkg.com/html-webpack-plugin/-/html-webpack-plugin-4.5.2.tgz#76fc83fa1a0f12dd5f7da0404a54e2699666bc12"
@@ -11822,17 +11833,6 @@ html-webpack-plugin@^4.0.0:
     pretty-error "^2.1.1"
     tapable "^1.1.3"
     util.promisify "1.0.0"
-
-html-webpack-plugin@^5.5.0:
-  version "5.5.0"
-  resolved "https://registry.yarnpkg.com/html-webpack-plugin/-/html-webpack-plugin-5.5.0.tgz#c3911936f57681c1f9f4d8b68c158cd9dfe52f50"
-  integrity sha512-sy88PC2cRTVxvETRgUHFrL4No3UxvcH8G1NepGhqaTT+GXN2kTamqasot0inS5hXeg1cMbFDt27zzo9p35lZVw==
-  dependencies:
-    "@types/html-minifier-terser" "^6.0.0"
-    html-minifier-terser "^6.0.2"
-    lodash "^4.17.21"
-    pretty-error "^4.0.0"
-    tapable "^2.0.0"
 
 htmlparser2@^6.1.0:
   version "6.1.0"
@@ -19436,6 +19436,11 @@ typecast@0.0.1:
   resolved "https://registry.yarnpkg.com/typecast/-/typecast-0.0.1.tgz#fffb75dcb6bdf1def8e293b6b6e893d6c1ed19de"
   integrity sha1-//t13La98d744pO2tuiT1sHtGd4=
 
+typed-assert@^1.0.8:
+  version "1.0.8"
+  resolved "https://registry.yarnpkg.com/typed-assert/-/typed-assert-1.0.8.tgz#4bf9f1ce7f3f974d09c3afd7c68d12e1391a233c"
+  integrity sha512-5NkbXZUlmCE73Fs7gvkp1XXJWHYetPkg60QnQ2NXQmBYNFxbBr2zA8GCtaH4K2s2WhOmSlgiSTmrjrcm5tnM5g==
+
 typedarray-to-buffer@^3.1.5:
   version "3.1.5"
   resolved "https://registry.yarnpkg.com/typedarray-to-buffer/-/typedarray-to-buffer-3.1.5.tgz#a97ee7a9ff42691b9f783ff1bc5112fe3fca9080"
@@ -20409,6 +20414,13 @@ webpack-sources@^3.2.2:
   version "3.2.2"
   resolved "https://registry.yarnpkg.com/webpack-sources/-/webpack-sources-3.2.2.tgz#d88e3741833efec57c4c789b6010db9977545260"
   integrity sha512-cp5qdmHnu5T8wRg2G3vZZHoJPN14aqQ89SyQ11NpGH5zEMDCclt49rzo+MaRazk7/UeILhAI+/sEtcM+7Fr0nw==
+
+webpack-subresource-integrity@^5.0.0:
+  version "5.0.0"
+  resolved "https://registry.yarnpkg.com/webpack-subresource-integrity/-/webpack-subresource-integrity-5.0.0.tgz#8268b9cc1a229a8f8129ca9eeb59cde52185b6b1"
+  integrity sha512-x9514FpLRydO+UAQ8DY4aLtCjxmdLkuQVcDFN1kGzuusREYJ1B0rzk/iIlWiL6dnvrhEGFj2+UsdxDkP8Z4UKg==
+  dependencies:
+    typed-assert "^1.0.8"
 
 webpack-virtual-modules@^0.2.2:
   version "0.2.2"


### PR DESCRIPTION
## Description

This uses the `webpack-subresource-integrity` plugin to add Subresource Integrity (SRI) attributes to everything. This includes all the `<script>` and `<link>` tags in the HTML, as well as the webpack async loader in `runtime-main.js`. After this change, the hash of `index.html` should implicate all other assets in the build (except for metadata like `manifest.json`, `asset-manifest.json`, and `robots.txt`).

It's possible that this may be useful as the basis for a runtime-verifiable signature scheme in the future.

## Notice

Before submitting a pull request, please make sure you have answered the following:

- [x] Have you followed the guidelines in our [Contributing]('https://github.com/shapeshift/web/CONTRIBUTING.md) guide?
- [x] Have you checked to ensure there aren't other open [Pull Requests](https://github.com/shapeshift/web/pulls) for the same update/change?
- [x] Do all new and existing tests pass? Does the linter pass?

## Pull Request Type

- [ ] :bug: Bug fix (Non-breaking Change: Fixes an issue)
- [ ] :hammer_and_wrench: Chore (Non-breaking Change: Doc updates, pkg upgrades, typos, etc..)
- [x] :nail_care: New Feature (Breaking/Non-breaking Change)
