### PR TITLE
fix: all input works regarding the language used

### DIFF
--- a/src/components/TokenRow/TokenRow.tsx
+++ b/src/components/TokenRow/TokenRow.tsx
@@ -61,6 +61,7 @@ export function TokenRow<C extends FieldValues>({
               thousandSeparator={localeParts.group}
               decimalSeparator={localeParts.decimal}
               customInput={CryptoInput}
+              isNumericString={true}
               value={value}
               disabled={disabled}
               onValueChange={e => {

--- a/src/components/Trade/TradeInput.tsx
+++ b/src/components/Trade/TradeInput.tsx
@@ -175,6 +175,7 @@ export const TradeInput = ({ history }: RouterProps) => {
                 suffix={localeParts.postfix}
                 value={value}
                 customInput={FiatInput}
+                isNumericString={true}
                 onValueChange={e => {
                   onChange(e.value)
                   if (e.value !== value) {

--- a/src/components/Trade/TradeInput.tsx
+++ b/src/components/Trade/TradeInput.tsx
@@ -249,16 +249,18 @@ export const TradeInput = ({ history }: RouterProps) => {
             isLoading={!quote || action || error ? true : false}
             _loading={{ color: 'blue.500' }}
           />
-          <Box display='flex' alignItems='center' color='gray.500'>
+          <Box display='flex' alignItems='center' color='gray.500' fontSize='sm' spacing='24px'>
             {!quote || action || error ? (
-              <Text fontSize='sm' translation={error ? 'common.error' : 'trade.searchingRate'} />
+              <Text translation={error ? 'common.error' : 'trade.searchingRate'} />
             ) : (
               <>
-                <RawText textAlign='right' fontSize='sm'>{`1 ${
-                  sellAsset.currency?.symbol
-                } = ${firstNonZeroDecimal(bnOrZero(quote?.rate))} ${
-                  buyAsset?.currency?.symbol
-                }`}</RawText>
+                <RawText whiteSpace={'pre'}>{`1 ${sellAsset.currency?.symbol} = `}</RawText>
+                <NumberFormat
+                  value={firstNonZeroDecimal(bnOrZero(quote?.rate))}
+                  displayType={'text'}
+                  thousandSeparator={true}
+                />
+                <RawText whiteSpace={'pre'}>{` ${buyAsset?.currency?.symbol}`}</RawText>
                 <HelperTooltip label={translate('trade.tooltip.rate')} />
               </>
             )}

--- a/src/features/earn/components/Deposit/Deposit.tsx
+++ b/src/features/earn/components/Deposit/Deposit.tsx
@@ -272,6 +272,7 @@ export const Deposit = ({
                       return (
                         <NumberFormat
                           customInput={CryptoInput}
+                          isNumericString={true}
                           decimalSeparator={localeParts.decimal}
                           inputMode='decimal'
                           thousandSeparator={localeParts.group}
@@ -298,6 +299,7 @@ export const Deposit = ({
                       return (
                         <NumberFormat
                           customInput={CryptoInput}
+                          isNumericString={true}
                           decimalSeparator={localeParts.decimal}
                           inputMode='decimal'
                           thousandSeparator={localeParts.group}

--- a/src/features/earn/components/Withdraw/Withdraw.tsx
+++ b/src/features/earn/components/Withdraw/Withdraw.tsx
@@ -262,6 +262,7 @@ export const Withdraw = ({
                       return (
                         <NumberFormat
                           customInput={CryptoInput}
+                          isNumericString={true}
                           decimalSeparator={localeParts.decimal}
                           inputMode='decimal'
                           thousandSeparator={localeParts.group}
@@ -288,6 +289,7 @@ export const Withdraw = ({
                       return (
                         <NumberFormat
                           customInput={CryptoInput}
+                          isNumericString={true}
                           decimalSeparator={localeParts.decimal}
                           inputMode='decimal'
                           thousandSeparator={localeParts.group}


### PR DESCRIPTION
## Description

It fix all inputs because the formatting didn't had isNumericString enabled which as the documentation says "If value is passed as string representation of numbers (unformatted) then this should be passed as true" which is our case.

## Notice

- [x] Have you followed the guidelines in our [Contributing]('https://github.com/shapeshift/web/CONTRIBUTING.md) guide?
- [x] Have you checked to ensure there aren't other open [Pull Requests](https://github.com/shapeshift/web/pulls) for the same update/change?
- [x] Do all new and existing tests pass? Does the linter pass?

## Pull Request Type

- [x] :bug: Bug fix (Non-breaking Change: Fixes an issue)
- [ ] :hammer_and_wrench: Chore (Non-breaking Change: Doc updates, pkg upgrades, typos, etc..)
- [ ] :nail_care: New Feature (Breaking/Non-breaking Change)

## Issue (if applicable)

closes #554

## Testing

No special yet

## Screenshots (if applicable)

![image](https://user-images.githubusercontent.com/72015889/145889405-1e433f99-1391-4b38-a463-33c68ef51b9b.png)
