### PR TITLE
feat: support wallets in "disconnected" state

### DIFF
--- a/src/Routes/PrivateRoute.tsx
+++ b/src/Routes/PrivateRoute.tsx
@@ -2,15 +2,15 @@ import { getConfig } from 'config'
 import { Redirect, Route, RouteProps } from 'react-router-dom'
 
 type PrivateRouteProps = {
-  isConnected: boolean
+  hasWallet: boolean
 } & RouteProps
 
 const HIDE_SPLASH = getConfig().REACT_APP_HIDE_SPLASH
 
-export const PrivateRoute = ({ isConnected, ...rest }: PrivateRouteProps) => {
+export const PrivateRoute = ({ hasWallet, ...rest }: PrivateRouteProps) => {
   const { location } = rest
 
-  return isConnected || HIDE_SPLASH ? (
+  return hasWallet || HIDE_SPLASH ? (
     <Route {...rest} />
   ) : (
     <Redirect

--- a/src/Routes/Routes.tsx
+++ b/src/Routes/Routes.tsx
@@ -102,18 +102,18 @@ function useLocationBackground() {
 export const Routes = () => {
   const { background, location } = useLocationBackground()
   const { state, dispatch } = useWallet()
-  const { isConnected } = state
+  const hasWallet = Boolean(state.walletInfo?.deviceId)
   return (
     <Switch location={background || location}>
       {appRoutes.map((route, index) => {
         return (
-          <PrivateRoute key={index} path={route.path} exact isConnected={isConnected}>
+          <PrivateRoute key={index} path={route.path} exact hasWallet={hasWallet}>
             <Layout route={route} />
           </PrivateRoute>
         )
       })}
       <Route path='/connect-wallet'>
-        <ConnectWallet dispatch={dispatch} isConnected={isConnected} />
+        <ConnectWallet dispatch={dispatch} hasWallet={hasWallet} />
       </Route>
       <Redirect from='/' to='/dashboard' />
       <Route component={NotFound} />

--- a/src/assets/translations/messages-en.json
+++ b/src/assets/translations/messages-en.json
@@ -64,7 +64,8 @@
     "menu": {
       "triggerButton": "Connect Wallet",
       "switchWallet": "Switch Wallet Provider",
-      "disconnect": "Disconnect"
+      "disconnect": "Disconnect",
+      "disconnected": "(Disconnected)"
     }
   },
   "earn": {

--- a/src/context/WalletProvider/KeepKey/hooks/useKeepKeyEventHandler.ts
+++ b/src/context/WalletProvider/KeepKey/hooks/useKeepKeyEventHandler.ts
@@ -13,7 +13,6 @@ export const useKeepKeyEventHandler = (state: KeyringState, dispatch: Dispatch<A
 
   useEffect(() => {
     const handleEvent = (e: [deviceId: string, message: Event]) => {
-      console.info('KeepKey Event', e)
       switch (e[1].message_enum) {
         case MessageType.PASSPHRASEREQUEST:
           if (!keepkeyPassphrase.isOpen) {
@@ -45,34 +44,45 @@ export const useKeepKeyEventHandler = (state: KeyringState, dispatch: Dispatch<A
           }
           break
         default:
-          // If there wasn't an enum value, then we'll check the message type
-          console.info('KeepKey Unknown Event', e)
+        // Ignore unhandled events
       }
     }
 
-    const handleConnect = (deviceId: string) => {
-      console.info('KeepKey Connected: ', deviceId)
-      if (state.walletInfo?.deviceId === deviceId) {
+    const handleConnect = async (deviceId: string) => {
+      console.info('Device Connected: ', deviceId)
+      /*
+        Understanding KeepKey DeviceID aliases:
+
+        1. There is a hardware SerialNumber and a separate DeviceID written to flash on the device.
+        2. Out of the box, these two values ARE DIFFERENT.
+        3. After a "wipe" command, the DeviceID in flash is updated to match SerialNumber
+        4. Bootloader/firmware upgrades and device initialization do NOT change this value
+        5. Every KeepKey will have an alias DeviceID until a "wipe" is called
+       */
+      const id = keyring.getAlias(deviceId)
+      if (id === state.walletInfo?.deviceId) {
         dispatch({ type: WalletActions.SET_IS_CONNECTED, payload: true })
       }
     }
 
-    const handleDisconnect = (deviceId: string) => {
-      console.info('KeepKey Disconnected: ', deviceId)
-      if (state.walletInfo?.deviceId === deviceId) {
+    const handleDisconnect = async (deviceId: string) => {
+      console.info('Device Disconnected: ', deviceId)
+      const id = keyring.getAlias(deviceId)
+      if (id === state.walletInfo?.deviceId) {
         dispatch({ type: WalletActions.SET_IS_CONNECTED, payload: false })
       }
     }
 
     // Handle all KeepKey events
     keyring.on(['KeepKey', '*', '*'], handleEvent)
-    keyring.on(['KeepKey', '*', Events.CONNECT], handleConnect)
-    keyring.on(['KeepKey', '*', Events.DISCONNECT], handleDisconnect)
+    // HDWallet emits (DIS)CONNECT events as "KeepKey - {LABEL}" so we can't just listen for "KeepKey"
+    keyring.on(['*', '*', Events.CONNECT], handleConnect)
+    keyring.on(['*', '*', Events.DISCONNECT], handleDisconnect)
 
     return () => {
       keyring.off(['KeepKey', '*', '*'], handleEvent)
-      keyring.off(['KeepKey', '*', Events.CONNECT], handleConnect)
-      keyring.off(['KeepKey', '*', Events.DISCONNECT], handleDisconnect)
+      keyring.off(['*', '*', Events.CONNECT], handleConnect)
+      keyring.off(['*', '*', Events.DISCONNECT], handleDisconnect)
     }
   }, [dispatch, keepkeyPassphrase, keepkeyPin, keyring, state.walletInfo?.deviceId])
 }

--- a/src/pages/ConnectWallet/ConnectWallet.tsx
+++ b/src/pages/ConnectWallet/ConnectWallet.tsx
@@ -15,16 +15,16 @@ import { colors } from 'theme/colors'
 
 type NoWalletProps = {
   dispatch: Dispatch<ActionTypes>
-  isConnected: boolean
+  hasWallet: boolean
 }
 
-export const ConnectWallet = ({ dispatch, isConnected }: NoWalletProps) => {
+export const ConnectWallet = ({ dispatch, hasWallet }: NoWalletProps) => {
   const history = useHistory()
   const translate = useTranslate()
   const query = useQuery<{ returnUrl: string }>()
   useEffect(() => {
-    isConnected && history.push(query?.returnUrl ? query.returnUrl : '/dashboard')
-  }, [history, isConnected, query.returnUrl])
+    hasWallet && history.push(query?.returnUrl ? query.returnUrl : '/dashboard')
+  }, [history, hasWallet, query.returnUrl])
   return (
     <Page>
       <Flex


### PR DESCRIPTION
## Description

Hardware wallets can be paired but also disconnected (unplugged).

This allows us to use paired wallets for which we've already gotten the PublicKeys (for showing asset balances and transaction history) but which have been unplugged after pairing.

If a paired device (KeepKey) gets unplugged, show a warning icon in the wallet menu. When a device is reconnected, remove the warning.

**Possibly incomplete** There may be other places in the code than this that assume when `WalletProvider.state.isConnected` is `false` that there isn't a pair wallet. We should be using `WalletProvider.state.walletInfo` to determine if a wallet is *paired* and `isConnected` just to determine if we can talk to it right now or not.

## Notice

Before submitting a pull request, please make sure you have answered the following:

- [X] Have you followed the guidelines in our [Contributing]('https://github.com/shapeshift/web/CONTRIBUTING.md) guide?
- [X] Have you checked to ensure there aren't other open [Pull Requests](https://github.com/shapeshift/web/pulls) for the same update/change?
- [X] Do all new and existing tests pass? Does the linter pass?

## Pull Request Type

- [ ] :bug: Bug fix (Non-breaking Change: Fixes an issue)
- [ ] :hammer_and_wrench: Chore (Non-breaking Change: Doc updates, pkg upgrades, typos, etc..)
- [X] :nail_care: New Feature (Breaking/Non-breaking Change)

## Issue (if applicable)

closes #586 

## Testing

Please outline all testing steps

1. Pair a KeepKey
2. Unplug the KeepKey
3. Plugin the KeepKey

## Screenshots (if applicable)
Wallet Button
![image](https://user-images.githubusercontent.com/1958266/146155025-62a94f17-2ad8-4981-95a1-f3c099a0af0b.png)

User Menu
![image](https://user-images.githubusercontent.com/1958266/146155121-3e180bda-7630-42d2-a913-eac86aacfdb8.png)

User Menu (Wallet Connected)
![image](https://user-images.githubusercontent.com/1958266/146155198-a5caee2d-cade-4ee0-9768-746a218bf9e1.png)
