### PR TITLE
feat: generate SHA256SUMS on build

### DIFF
--- a/package.json
+++ b/package.json
@@ -80,7 +80,7 @@
     "show-linked-packages": "find node_modules node_modules/@* -depth 1 -type l -print",
     "link-packages": "./scripts/link-packages.sh",
     "unlink-packages": "find node_modules node_modules/@* -depth 1 -type l -print | awk -F/ '{ printf \"%s/%s\\n\",$2,$3; }' | xargs yarn unlink && yarn install --force",
-    "build": "NODE_OPTIONS=--max-old-space-size=4096 IMAGE_INLINE_SIZE_LIMIT=0 INLINE_RUNTIME_CHUNK=false REACT_APP_HIDE_SPLASH=false DISABLE_ESLINT_PLUGIN=true react-app-rewired build && node headers.js",
+    "build": "NODE_OPTIONS=--max-old-space-size=4096 IMAGE_INLINE_SIZE_LIMIT=0 INLINE_RUNTIME_CHUNK=false REACT_APP_HIDE_SPLASH=false DISABLE_ESLINT_PLUGIN=true react-app-rewired build && node headers.js && ./scripts/sha256sums.sh",
     "dev": "react-app-rewired start",
     "dev:silent": "BROWSER=none react-app-rewired start",
     "lint": "eslint -c .eslintrc src --ext .ts,.tsx",

--- a/scripts/sha256sums.sh
+++ b/scripts/sha256sums.sh
@@ -1,0 +1,6 @@
+#!/bin/sh -e
+
+rm -f ./build/SHA256SUMS
+TEMP=$(mktemp)
+find ./build -type f | xargs shasum -a 256 | sed -r 's/^([0-9a-f]{64}\s+)\.\/build\//\1/' | LC_ALL=C sort -k 2 | tee "$TEMP"
+mv "$TEMP" ./build/SHA256SUMS


### PR DESCRIPTION
## Description

This generates a SHA256SUMS file after building a production version that can be easily used to detect changes in build products via `sha256sums -c SHA256SUMS`. As we hone in on deterministic builds, this is a good first step to enable tools that people can use to verify the integrity of production code.

Also, dumps the hashes to the console so CI build logs will record them.

## Notice

Before submitting a pull request, please make sure you have answered the following:

- [x] Have you followed the guidelines in our [Contributing]('https://github.com/shapeshift/web/CONTRIBUTING.md) guide?
- [x] Have you checked to ensure there aren't other open [Pull Requests](https://github.com/shapeshift/web/pulls) for the same update/change?
- [x] Do all new and existing tests pass? Does the linter pass?

## Pull Request Type

- [ ] :bug: Bug fix (Non-breaking Change: Fixes an issue)
- [ ] :hammer_and_wrench: Chore (Non-breaking Change: Doc updates, pkg upgrades, typos, etc..)
- [x] :nail_care: New Feature (Breaking/Non-breaking Change)
