### PR TITLE
feat: load env values from separate json file

### DIFF
--- a/package.json
+++ b/package.json
@@ -166,11 +166,13 @@
     "eslint-config-prettier": "^8.3.0",
     "eslint-plugin-prettier": "^4.0.0",
     "eslint-plugin-simple-import-sort": "^7.0.0",
+    "fast-json-stable-stringify": "^2.1.0",
     "prettier": "^2.3.2",
     "react-app-rewired": "^2.1.9",
     "storybook-dark-mode": "^1.0.8",
     "ts-jest": "^27.0.4",
     "typescript": "^4.5.2",
+    "val-loader": "^4.0.0",
     "web3-utils": "^1.5.2",
     "yarn-minify": "^1.0.1"
   },

--- a/react-app-rewired.config.js
+++ b/react-app-rewired.config.js
@@ -1,23 +1,13 @@
 /**
  * React App Rewired Config
  */
+const stableStringify = require('fast-json-stable-stringify')
 const _ = require('lodash')
 const path = require('path')
 const webpack = require('webpack')
 
 const headers = require('./headers')
 process.env.REACT_APP_CSP_META = headers.cspMeta ?? ''
-
-// This ensures environment variables will be enumerated in order, which affects the build products.
-const reactEnvEntries = Object.entries(process.env)
-  .filter(([k]) => k.startsWith('REACT_APP'))
-  .sort((a, b) => {
-    if (a[0] < b[0]) return -1
-    if (a[0] > b[0]) return 1
-    return 0
-  })
-reactEnvEntries.forEach(([k]) => delete process.env[k])
-reactEnvEntries.forEach(([k, v]) => (process.env[k] = v))
 
 module.exports = {
   webpack: (config, mode) => {
@@ -90,6 +80,81 @@ module.exports = {
           );
         }
       ],
+    })
+
+    // Collect env vars that would have been injected via DefinePlugin. We will emit them
+    // as dynamically-loaded JSON later instead of find/replacing the string 'process.env'.
+    // This ensures that the minified Webpack output will be the same no matter the build
+    // options being used.
+    const env = Object.fromEntries(
+      Object.entries(
+        config.plugins
+          .filter((plugin) => plugin.constructor.name === "DefinePlugin")
+          .reduceRight((x) => x).definitions?.["process.env"] || {}
+      ).filter(([k, v])=> v).map(([k, v]) => [k, JSON.parse(v)])
+    );
+    // Update the Webpack config to emit the collected env vars as `env.json` and load them
+    // dynamically instead of baking them into each chunk that might reference them.
+    _.merge(config, {
+      plugins: [...config.plugins.map(plugin => {
+        switch (plugin.constructor.name) {
+          case 'DefinePlugin': {
+            // Remove the 'process.env' entry from DefinePlugin; this will cause `process.env` to
+            // resolve via the ProvidePlugin `process` global.
+            delete plugin.definitions['process.env']
+            return plugin
+          }
+          case 'ProvidePlugin': {
+            // This is a thin wrapper around the process/browser.js module, which inserts the
+            // contents of `env.json` into `process.env` and freezes the object to prevent
+            // attacks on any code that might expect its environment variables to be immutable.
+            return new webpack.ProvidePlugin(Object.assign({}, plugin.definitions, {
+              process: [ path.join(__dirname, 'src/env/process.js') ],
+            }))
+          }
+          default: return plugin
+        }
+      })],
+      module: {
+        rules: [...config.module?.rules, {
+          // This rule causes the (placeholder) contents of `src/env/env.json` to be thrown away
+          // and replaced with `stableStringify(env)`, which is then written out to `build/env.json`.
+          //
+          // Note that simply adding this rule doesn't force `env.json` to be generated. That happens
+          // because `src/env/process.js` `require()`s it, and that module is provided via ProvidePlugin
+          // above. If nothing ever uses that `process` global, both `src/env/process.js` and `env.json`
+          // will be omitted from the build.
+          resource: path.join(__dirname, 'src/env/env.json'),
+          // Webpack loads resources by reading them from disk and feeding them through a series
+          // of loaders. It then emits them by feeding the result to a generator.
+          //
+          // The `val-loader` plugin is a customizable loader which `require()`s `executableFile`,
+          // expecting a single exported function which it uses to transform the on-disk module data.
+          // The stub loader, `src/env/loader.js`, simply takes a `code` function as an option and
+          // and replaces the module data with its result.
+          //
+          // Webpack requires both the module being loaded and the stub loader to exist as actual files
+          // on the filesystem, but this setup allows the actual content of a module to be generated
+          // at compile time.
+          use: [{
+            loader: 'val-loader',
+            options: {
+              executableFile: require.resolve(path.join(__dirname, 'src/env/loader.js')),
+              code: () => stableStringify(env),
+            },
+          }],
+          // The type ['asset/resource'](https://webpack.js.org/guides/asset-modules/#resource-assets)
+          // tells Webpack to a special generator that will emit the module as a separate file instead
+          // of inlining its contents into another chunk, as well as skip the normal plugin processing
+          // and minification steps and just write the raw as-loaded contents. The `generator.filename`
+          // option overrides the default output path so that the file ends up at `build/env.json`
+          // instead of the default `build/static/media/env.[hash].json`.
+          type: 'asset/resource',
+          generator: {
+            filename: '[base]',
+          },
+        }]
+      },
     })
 
     return config

--- a/src/env/env.json
+++ b/src/env/env.json
@@ -1,0 +1,1 @@
+{"README":"This is a placeholder. It must exist, but its contents will be replaced at build time. See react-app-rewired.config.js for details."}

--- a/src/env/loader.js
+++ b/src/env/loader.js
@@ -1,0 +1,2 @@
+// This is a stub for use with the Webpack loader `val-loader`. See react-app-rewired.config.js for details.
+module.exports = ({ code }) => ({ cacheable: true, code: code() })

--- a/src/env/process.js
+++ b/src/env/process.js
@@ -1,0 +1,6 @@
+// This is a thin wrapper around the process/browser.js module which assigns the contents of
+// env.json to process.env and freezes things to prevent shenanigans. See react-app-rewired.config.js
+// for details.
+const process = require('process/browser.js')
+Object.freeze(Object.assign(process.env, require('./env.json')))
+module.exports = Object.freeze(process)

--- a/yarn.lock
+++ b/yarn.lock
@@ -19863,6 +19863,11 @@ v8-to-istanbul@^8.0.0, v8-to-istanbul@^8.1.0:
     convert-source-map "^1.6.0"
     source-map "^0.7.3"
 
+val-loader@^4.0.0:
+  version "4.0.0"
+  resolved "https://registry.yarnpkg.com/val-loader/-/val-loader-4.0.0.tgz#c5ccf8abfe486de412d2cd59fa56deb49d44ec8d"
+  integrity sha512-tpDHHpVo1hrO9xFhpEcOw+RCK4wnQqqNkZmylwHJ04iVeue1YSYxIdDwCdKd7LVQ8g/fsGX/EC5gLda9BXovkg==
+
 validate-npm-package-license@^3.0.1:
   version "3.0.4"
   resolved "https://registry.yarnpkg.com/validate-npm-package-license/-/validate-npm-package-license-3.0.4.tgz#fc91f6b9c7ba15c857f4cb2c5defeec39d4f410a"


### PR DESCRIPTION
## Description

CRA uses Webpack's DefinePlugin to inject process.env vars by literally replacing the string `process.env` with `{"REACT_APP_FOO":"foo","REACT_APP_BAR":"bar"}` everywhere it finds it. (As in, `process.env.REACT_APP_FOO` becomes `{"REACT_APP_FOO":"foo","REACT_APP_BAR":"bar"}.REACT_APP_FOO` everywhere!)This is highly duplicative, but it also means that the hash of any chunk which includes any process.env env var changes each time any env var changes, and is a constant PITA for deterministic builds.

This uses some Webpack magic to collect the env vars CRA _would_ have injected, emit them as `/env.json`, and load that file at runtime. The env vars are injected into the `process` polyfill, which is then frozen to prevent shenanigans.

Note that the generated `env.json` file will _not_ protected by SRI (from #550). This is intentional to ensure that the webpack bundles have consistent hashes even if compiled with different env vars.

## Notice

Before submitting a pull request, please make sure you have answered the following:

- [x] Have you followed the guidelines in our [Contributing]('https://github.com/shapeshift/web/CONTRIBUTING.md) guide?
- [x] Have you checked to ensure there aren't other open [Pull Requests](https://github.com/shapeshift/web/pulls) for the same update/change?
- [x] Do all new and existing tests pass? Does the linter pass?

## Pull Request Type

- [ ] :bug: Bug fix (Non-breaking Change: Fixes an issue)
- [ ] :hammer_and_wrench: Chore (Non-breaking Change: Doc updates, pkg upgrades, typos, etc..)
- [x] :nail_care: New Feature (Breaking/Non-breaking Change)
