### PR TITLE
fix: metamask on mobile should always go to the right place

### DIFF
--- a/sample.env
+++ b/sample.env
@@ -10,4 +10,3 @@ REACT_APP_UNCHAINED_BITCOIN_HTTP_URL=https://dev-api.bitcoin.shapeshift.com
 REACT_APP_UNCHAINED_BITCOIN_WS_URL=wss://dev-api.bitcoin.shapeshift.com
 REACT_APP_PORTIS_DAPP_ID=<get dapp ID from someone>
 REACT_APP_ETHEREUM_NODE_URL=<get free key from infura or other provider>
-REACT_APP_METAMASK_DEEPLINK_URL=https://metamask.app.link/dapp/app.shapeshift.com

--- a/src/config.ts
+++ b/src/config.ts
@@ -14,8 +14,7 @@ const validators = {
   REACT_APP_UNCHAINED_BITCOIN_WS_URL: url(),
   REACT_APP_ETHEREUM_NODE_URL: url(),
   REACT_APP_PORTIS_DAPP_ID: str(),
-  REACT_APP_HIDE_SPLASH: bool({ default: false }),
-  REACT_APP_METAMASK_DEEPLINK_URL: url()
+  REACT_APP_HIDE_SPLASH: bool({ default: false })
 }
 
 function reporter<T>({ errors }: envalid.ReporterOptions<T>) {

--- a/src/context/WalletProvider/MetaMask/components/Connect.tsx
+++ b/src/context/WalletProvider/MetaMask/components/Connect.tsx
@@ -1,5 +1,4 @@
 import detectEthereumProvider from '@metamask/detect-provider'
-import { getConfig } from 'config'
 import React, { useState } from 'react'
 import { isMobile } from 'react-device-detect'
 import { RouteComponentProps } from 'react-router-dom'
@@ -91,13 +90,20 @@ export const MetaMaskConnect = ({ history }: MetaMaskSetupProps) => {
     setLoading(false)
   }
 
+  // This constructs the MetaMask deep-linking target from the currently-loaded
+  // window.location. The port will be blank if not specified, in which case it
+  // should be omitted.
+  const mmDeeplinkTarget = [window.location.hostname, window.location.port]
+    .filter(x => !!x)
+    .join(':')
+
   return isMobile ? (
     <RedirectModal
       headerText={'walletProvider.metaMask.redirect.header'}
       bodyText={'walletProvider.metaMask.redirect.body'}
       buttonText={'walletProvider.metaMask.redirect.button'}
       onClickAction={(): any => {
-        window.location.assign(getConfig().REACT_APP_METAMASK_DEEPLINK_URL)
+        window.location.assign(`https://metamask.app.link/dapp/${mmDeeplinkTarget}`)
       }}
       loading={loading}
       error={error}


### PR DESCRIPTION
## Description

Instead of hardcoding it in `REACT_APP_METAMASK_DEEPLINK_URL`, calculate the MM deeplink URL from `window.location`. This ensures that non-prod branches don't get redirects to prod by accident.

## Notice

Before submitting a pull request, please make sure you have answered the following:

- [x] Have you followed the guidelines in our [Contributing]('https://github.com/shapeshift/web/CONTRIBUTING.md) guide?
- [x] Have you checked to ensure there aren't other open [Pull Requests](https://github.com/shapeshift/web/pulls) for the same update/change?
- [x] Do all new and existing tests pass? Does the linter pass?

## Pull Request Type

- [x] :bug: Bug fix (Non-breaking Change: Fixes an issue)
- [ ] :hammer_and_wrench: Chore (Non-breaking Change: Doc updates, pkg upgrades, typos, etc..)
- [ ] :nail_care: New Feature (Breaking/Non-breaking Change)
