### PR TITLE
fix: fixes bug where non-coingecko asset pages were showing a zero pr…

### DIFF
--- a/src/pages/Assets/Asset.tsx
+++ b/src/pages/Assets/Asset.tsx
@@ -12,10 +12,11 @@ import { useParams } from 'react-router-dom'
 import { Page } from 'components/Layout/Page'
 import { selectAssetByCAIP19 } from 'state/slices/assetsSlice/assetsSlice'
 import {
+  marketApi,
   selectMarketDataById,
   selectMarketDataLoadingById
 } from 'state/slices/marketDataSlice/marketDataSlice'
-import { useAppSelector } from 'state/store'
+import { useAppDispatch, useAppSelector } from 'state/store'
 
 import { AssetDetails } from './AssetDetails/AssetDetails'
 export interface MatchParams {
@@ -53,11 +54,14 @@ export const initMarketData: MarketData = {
 }
 
 export const useAsset = () => {
+  const dispatch = useAppDispatch()
+
   const { chain, tokenId } = useParams<MatchParams>()
   const network = NetworkTypes.MAINNET
   const contractType = ContractTypes.ERC20
   const extra = tokenId ? { contractType, tokenId } : undefined
   const assetCAIP19 = caip19.toCAIP19({ chain, network, ...extra })
+  dispatch(marketApi.endpoints.findByCaip19.initiate(assetCAIP19))
   const asset = useAppSelector(state => selectAssetByCAIP19(state, assetCAIP19))
   const marketData = useAppSelector(state => selectMarketDataById(state, assetCAIP19))
   const loading = useAppSelector(state => selectMarketDataLoadingById(state, assetCAIP19))

--- a/src/pages/Assets/Asset.tsx
+++ b/src/pages/Assets/Asset.tsx
@@ -61,7 +61,12 @@ export const useAsset = () => {
   const contractType = ContractTypes.ERC20
   const extra = tokenId ? { contractType, tokenId } : undefined
   const assetCAIP19 = caip19.toCAIP19({ chain, network, ...extra })
+
+  // Many, but not all, assets are initialized with market data on app load. This dispatch will
+  // ensure that those assets not initialized on app load will reach over the network and populate
+  // the store with market data once a user visits that asset page.
   dispatch(marketApi.endpoints.findByCaip19.initiate(assetCAIP19))
+
   const asset = useAppSelector(state => selectAssetByCAIP19(state, assetCAIP19))
   const marketData = useAppSelector(state => selectMarketDataById(state, assetCAIP19))
   const loading = useAppSelector(state => selectMarketDataLoadingById(state, assetCAIP19))


### PR DESCRIPTION
## Description

For asset pages we need to dispatch out to get a market price. Most asset prices will be populated in the store, but those not populated on initialization (non-coingecko, or assets the user does not have a balance for) will need to be populated in the store when the user goes to the asset page. This app dispatch will read first from the cache, if it is not there, then it will go out to get it.

## Notice

Before submitting a pull request, please make sure you have answered the following:

- [x] Have you followed the guidelines in our [Contributing]('https://github.com/shapeshift/web/CONTRIBUTING.md) guide?
- [x] Have you checked to ensure there aren't other open [Pull Requests](https://github.com/shapeshift/web/pulls) for the same update/change?
- [x] Do all new and existing tests pass? Does the linter pass?

## Pull Request Type

- [x] :bug: Bug fix (Non-breaking Change: Fixes an issue)
- [ ] :hammer_and_wrench: Chore (Non-breaking Change: Doc updates, pkg upgrades, typos, etc..)
- [ ] :nail_care: New Feature (Breaking/Non-breaking Change)

## Issue (if applicable)

If applicable, please link to the github issue and put `closes #XXXX` in your comment to auto-close the issue that your PR fixes.

## Testing

1. Visit the asset page of a Yearn asset for which your wallet does not have a balance.
2. The price of the yearn vault asset should not show 0.

## Screenshots (if applicable)

![Screen Shot 2022-01-05 at 15 44 58](https://user-images.githubusercontent.com/88169003/148300306-f77c0c8d-f1ae-438b-b5e3-f98fd34814b9.png)

