### PR TITLE
chore: add validation logic to Native Wallet name

### DIFF
--- a/src/assets/translations/messages-en.json
+++ b/src/assets/translations/messages-en.json
@@ -185,7 +185,8 @@
         "error": {
           "invalid": "Invalid Password",
           "required": "Password is required",
-          "length": "Your password must be at least %{length} characters"
+          "length": "Your password must be at least %{length} characters",
+          "maxLength": "Nickname must be %{length} characters maximum"
         }
       }
     },
@@ -418,7 +419,8 @@
         "header": "Rename your wallet",
         "walletName": "New nickname for your wallet",
         "body": "Enter the new nickname of your wallet and your password to decrypt your wallet.",
-        "button": "Next"
+        "button": "Next",
+        "confirmDelete": "Are you sure you want to delete the nickname of this wallet?"
       }
     },
     "selectModal": {

--- a/src/context/WalletProvider/NativeWallet/components/NativeLoad.tsx
+++ b/src/context/WalletProvider/NativeWallet/components/NativeLoad.tsx
@@ -144,12 +144,11 @@ export const NativeLoad = ({ history }: RouteComponentProps) => {
                 >
                   <Box textAlign='left'>
                     <RawText
-                      overflow='hidden'
                       fontWeight='medium'
-                      textOverflow='ellipsis'
-                      maxWidth='290px'
+                      maxWidth='260px'
                       lineHeight='1.2'
                       mb={1}
+                      isTruncated
                     >
                       {wallet.name}
                     </RawText>
@@ -161,7 +160,7 @@ export const NativeLoad = ({ history }: RouteComponentProps) => {
                     />
                   </Box>
                 </Button>
-                <Box>
+                <Box display='flex'>
                   <IconButton
                     aria-label={translate('common.rename')}
                     variant='ghost'

--- a/src/context/WalletProvider/NativeWallet/components/NativePassword.tsx
+++ b/src/context/WalletProvider/NativeWallet/components/NativePassword.tsx
@@ -53,14 +53,20 @@ export const NativePassword = ({ history, location }: NativeSetupProps) => {
       <ModalBody>
         <Text mb={6} color='gray.500' translation={'walletProvider.shapeShift.password.body'} />
         <form onSubmit={handleSubmit(onSubmit)}>
-          <FormControl mb={6}>
+          <FormControl mb={6} isInvalid={errors.name}>
             <Input
-              {...register('name')}
+              {...register('name', {
+                maxLength: {
+                  value: 64,
+                  message: translate('modals.shapeShift.password.error.maxLength', { length: 64 })
+                }
+              })}
               size='lg'
               variant='filled'
               id='name'
               placeholder={translate('modals.shapeShift.password.walletName')}
             />
+            <FormErrorMessage>{errors?.name?.message}</FormErrorMessage>
           </FormControl>
           <FormControl mb={6} isInvalid={errors.password}>
             <InputGroup size='lg' variant='filled'>
@@ -90,7 +96,14 @@ export const NativePassword = ({ history, location }: NativeSetupProps) => {
             </InputGroup>
             <FormErrorMessage>{errors?.password?.message}</FormErrorMessage>
           </FormControl>
-          <Button colorScheme='blue' size='lg' isFullWidth type='submit' isLoading={isSubmitting}>
+          <Button
+            colorScheme='blue'
+            size='lg'
+            isFullWidth
+            type='submit'
+            isLoading={isSubmitting}
+            isDisabled={errors.name}
+          >
             <Text translation={'walletProvider.shapeShift.password.button'} />
           </Button>
         </form>


### PR DESCRIPTION
## Description

Add validation logic to Native Wallet name (aka nickname).

When both creating and renaming a Native Wallet:
- Set a maximum length of 64 characters for the name
- Show an error if the user inputs more than 64 characters and disable the Next button

When renaming a Native Wallet:
- If the length of the name is "0", display a confirm dialog to confirm the deletion of the name
  - If confirmed, the name meta property is deleted
  - If cancelled, we stay on the form

:nail_care: minor improvements of the UI of NativeLoad when we have several wallets with various name lengths.

:shield: the `name` field is only displayed through a `RawText` component (basically a wrapped chakra-ui `Text` component). I don't think there is an opportunity for HTML injection. I will be happy to modify something with guidance if someone has a different opinion.

## Notice

Before submitting a pull request, please make sure you have answered the following:

- [x] Have you followed the guidelines in our [Contributing]('https://github.com/shapeshift/web/CONTRIBUTING.md) guide?
- [x] Have you checked to ensure there aren't other open [Pull Requests](https://github.com/shapeshift/web/pulls) for the same update/change?
- [x] Do all new and existing tests pass? Does the linter pass?

## Pull Request Type

- [ ] :bug: Bug fix (Non-breaking Change: Fixes an issue)
- [x] :hammer_and_wrench: Chore (Non-breaking Change: Doc updates, pkg upgrades, typos, etc..)
- [ ] :nail_care: New Feature (Breaking/Non-breaking Change)

## Issue (if applicable)

#630 

## Testing

Please outline all testing steps

1. Pull branch locally and run `yarn` to install new deps
2. Play with the rename wallet form
3. Play with the create wallet form

## Screenshots (if applicable)

Name validation logic (here in rename, same in create)


https://user-images.githubusercontent.com/5672954/148419990-eb86429f-c1c6-471a-ab1c-d1cf18bc0de0.mov

Empty name renaming


https://user-images.githubusercontent.com/5672954/148420222-36841ee0-b6d3-4456-a240-8a2a3c66e749.mov


