### PR TITLE
fix: fix useHasAppUpdated hook to cache asset-manifest.json 

### DIFF
--- a/src/hooks/useHasAppUpdated/useHasAppUpdated.ts
+++ b/src/hooks/useHasAppUpdated/useHasAppUpdated.ts
@@ -1,7 +1,7 @@
 import { useInterval } from '@chakra-ui/hooks'
 import axios from 'axios'
+import isEqual from 'lodash/isEqual'
 import { useMemo, useState } from 'react'
-import { checkObjEquality } from 'lib/utils'
 
 import { getConfig } from '../../config'
 
@@ -34,8 +34,8 @@ export const useHasAppUpdated = () => {
       return
     }
     //deep equality check
-    let areEquals = checkObjEquality(initialManifestMainJs, manifestMainJs)
-    if (!areEquals) {
+    let isSameAssetManifest = isEqual(initialManifestMainJs, manifestMainJs)
+    if (!isSameAssetManifest) {
       console.info(
         `useHasAppUpdated: app updated, manifest: ${JSON.stringify(
           manifestMainJs

--- a/src/lib/utils.ts
+++ b/src/lib/utils.ts
@@ -1,3 +1,22 @@
 // we don't want utils to mutate by default, so spreading here is ok
 export const upsertArray = <T extends unknown>(arr: T[], item: T): T[] =>
   arr.includes(item) ? arr : [...arr, item]
+
+// recursive function to check if two objects are equal
+export const checkObjEquality = (a: any, b: any) => {
+  if (a === b) return true
+  if (typeof a != 'object' || typeof b != 'object' || a == null || b == null) return false
+  let keysA = Object.keys(a),
+    keysB = Object.keys(b)
+  if (keysA.length !== keysB.length) return false
+  for (let key of keysA) {
+    if (!keysB.includes(key)) return false
+    if (typeof a[key] === 'function' || typeof b[key] === 'function') {
+      if (a[key].toString() !== b[key].toString()) return false
+    } else {
+      if (!checkObjEquality(a[key], b[key])) return false
+    }
+  }
+
+  return true
+}

--- a/src/lib/utils.ts
+++ b/src/lib/utils.ts
@@ -1,22 +1,3 @@
 // we don't want utils to mutate by default, so spreading here is ok
 export const upsertArray = <T extends unknown>(arr: T[], item: T): T[] =>
   arr.includes(item) ? arr : [...arr, item]
-
-// recursive function to check if two objects are equal
-export const checkObjEquality = (a: any, b: any) => {
-  if (a === b) return true
-  if (typeof a != 'object' || typeof b != 'object' || a == null || b == null) return false
-  let keysA = Object.keys(a),
-    keysB = Object.keys(b)
-  if (keysA.length !== keysB.length) return false
-  for (let key of keysA) {
-    if (!keysB.includes(key)) return false
-    if (typeof a[key] === 'function' || typeof b[key] === 'function') {
-      if (a[key].toString() !== b[key].toString()) return false
-    } else {
-      if (!checkObjEquality(a[key], b[key])) return false
-    }
-  }
-
-  return true
-}


### PR DESCRIPTION
## Description

I've applied desired changes to useHasAppUpdated hook:
- Save asset-manifest.json on page load 
- Use isEqual lodash function for deep object equality check on useInterval to update flag if applies

closes #634

## Notice

Before submitting a pull request, please make sure you have answered the following:

- [x] Have you followed the guidelines in our [Contributing]('https://github.com/shapeshift/web/CONTRIBUTING.md) guide?
- [x] Have you checked to ensure there aren't other open [Pull Requests](https://github.com/shapeshift/web/pulls) for the same update/change?
- [x] Do all new and existing tests pass? Does the linter pass?

## Pull Request Type

- [x] :bug: Bug fix (Non-breaking Change: Fixes an issue)
- [ ] :hammer_and_wrench: Chore (Non-breaking Change: Doc updates, pkg upgrades, typos, etc..)
- [ ] :nail_care: New Feature (Breaking/Non-breaking Change)

## Issue (if applicable)
closes #634

## Testing

1. Pull branch locally and run it as usual
