### PR TITLE
fix: use asset-manifest.json comparison in useHasAppUpdated hook

### DIFF
--- a/src/hooks/useHasAppUpdated/useHasAppUpdated.test.ts
+++ b/src/hooks/useHasAppUpdated/useHasAppUpdated.test.ts
@@ -1,0 +1,10 @@
+import { renderHook } from '@testing-library/react-hooks'
+
+import { useHasAppUpdated } from './useHasAppUpdated'
+
+describe('useHasAppUpdated', () => {
+  it('should return false before first interval is ran', () => {
+    const { result } = renderHook(() => useHasAppUpdated())
+    expect(result.current).toBe(false)
+  })
+})

--- a/src/hooks/useHasAppUpdated/useHasAppUpdated.ts
+++ b/src/hooks/useHasAppUpdated/useHasAppUpdated.ts
@@ -1,5 +1,6 @@
 import { useInterval } from '@chakra-ui/hooks'
 import axios from 'axios'
+import isEqual from 'lodash/isEqual'
 import { useState } from 'react'
 
 import { getConfig } from '../../config'
@@ -8,6 +9,7 @@ const APP_UPDATE_CHECK_INTERVAL = 1000 * 60
 
 export const useHasAppUpdated = () => {
   const [hasUpdated, setHasUpdated] = useState(false)
+  const [assetManifest, setAssetManifest] = useState({})
   useInterval(async () => {
     // we don't care about updates locally obv
     if (getConfig().isDevelopment) return
@@ -15,49 +17,36 @@ export const useHasAppUpdated = () => {
     const scriptIdentifier = '/static/js/main.'
     // asset-manifest tells us the latest minified built files
     const url = '/asset-manifest.json'
-    let manifestMainJs
     try {
       // dummy query param bypasses browser cache
       const { data } = await axios.get(`${url}?${new Date().valueOf()}`)
-      manifestMainJs = data?.files?.['main.js']
+      if (!Object.keys(assetManifest).length) {
+        setAssetManifest(data)
+      }
+      const manifestMainJs = data?.files?.['main.js']
+      if (!manifestMainJs) {
+        console.error(`useHasAppUpdated: can't find main.js in asset-manifest.json`)
+        return
+      }
+      if (!manifestMainJs.includes(scriptIdentifier)) {
+        console.error(
+          `useHasAppUpdated: manifest main.js doesn't start with identifier ${scriptIdentifier}`,
+          manifestMainJs
+        )
+        return
+      }
+      const scripts = document.getElementsByTagName('script')
+      if (!scripts.length) {
+        console.error(`useHasAppUpdated: can't find scripts in dom`)
+        return
+      }
+
+      const hasManifestChanged = !isEqual(assetManifest, data)
+      if (hasManifestChanged) {
+        return setHasUpdated(true)
+      }
     } catch (e) {
       console.error(`useHasAppUpdated: error fetching asset-manifest.json`, e)
-    }
-    if (!manifestMainJs) {
-      console.error(`useHasAppUpdated: can't find main.js in asset-manifest.json`)
-      return
-    }
-    if (!manifestMainJs.includes(scriptIdentifier)) {
-      console.error(
-        `useHasAppUpdated: manifest main.js doesn't start with identifier ${scriptIdentifier}`,
-        manifestMainJs
-      )
-      return
-    }
-    const scripts = document.getElementsByTagName('script')
-    if (!scripts.length) {
-      console.error(`useHasAppUpdated: can't find scripts in dom`)
-      return
-    }
-    // can't map/filter/reduce on HTMLCollectionOf
-    for (let i = 0; i < scripts.length; i++) {
-      let { src: scriptMainJs } = scripts[i]
-      if (!scriptMainJs) continue
-      // this is the main entry point to the app bundle
-      // create react app adds a hash to each build
-      if (!scriptMainJs.includes(scriptIdentifier)) continue
-      // if the asset-manifest.json main.js and current script main.js don't match we're out of date
-      try {
-        scriptMainJs = new URL(scriptMainJs).pathname
-      } catch {
-        // If it's not a absolute path, this will fail and that's OK
-      }
-      if (scriptMainJs !== manifestMainJs) {
-        console.info(
-          `useHasAppUpdated: app updated, manifest: ${manifestMainJs}, script: ${scriptMainJs}`
-        )
-        setHasUpdated(true)
-      }
     }
   }, APP_UPDATE_CHECK_INTERVAL)
   return hasUpdated


### PR DESCRIPTION
## Description

- This uses deep comparison of `asset-manifest.json` as a source of truth for `useAppUpdated` hook
- Unfortunately, because of the `useInterval` library imported from `@chakra-ui/hooks`, I wasn't able to test and advance timers to add unit tests except the initial one. I tested it manually by serving a new `asset-manifest.json` and checking the hook state.

## Pull Request Type

- [x] :bug: Bug fix (Non-breaking Change: Fixes an issue)
- [ ] :hammer_and_wrench: Chore (Non-breaking Change: Doc updates, pkg upgrades, typos, etc..)
- [ ] :nail_care: New Feature (Breaking/Non-breaking Change)

## Issue

closes #634