### PR TITLE
feat: improve error message on transaction rejected by user

### DIFF
--- a/src/assets/translations/messages-en.json
+++ b/src/assets/translations/messages-en.json
@@ -153,6 +153,7 @@
       "negativeMax": "Not enough funds for the miner fee on this transaction. Est miner fee %{estimatedMinerFee}",
       "invalidMax": "Invalid Amount. The maximum trade amount for this pair is %{maxLimit}.",
       "insufficientFunds": "Insufficient funds for miner fee and amount",
+      "transactionRejected": "User has rejected the transaction",
       "insufficientFundsForLimit": "Insufficient funds. The minimum trade amount for this pair is %{minLimit}",
       "insufficientFundsForAmount": "Insufficient funds. Your %{symbol} balance is less than the selected amount",
       "noLiquidityError": "Not enough liquidity available",

--- a/src/components/Trade/TradeConfirm/TradeConfirm.tsx
+++ b/src/components/Trade/TradeConfirm/TradeConfirm.tsx
@@ -72,10 +72,10 @@ export const TradeConfirm = ({ history }: RouterProps) => {
       }
     } catch (err) {
       console.error(`TradeConfirm:onSubmit - ${err}`)
-      // TODO: (ryankk) this needs to be revisited post bounty to handle actual errors coming back from unchained.
+      // Since this happens onSubmit, we can optimistically determine this was an user rejection
       toast({
         title: translate('trade.errors.title'),
-        description: translate(TRADE_ERRORS.INSUFFICIENT_FUNDS),
+        description: translate(TRADE_ERRORS.TRANSACTION_REJECTED),
         status: 'error',
         duration: 9000,
         isClosable: true,

--- a/src/components/Trade/TradeConfirm/TradeConfirm.tsx
+++ b/src/components/Trade/TradeConfirm/TradeConfirm.tsx
@@ -35,6 +35,8 @@ type TradeConfirmParams = {
   fiatRate: string
 }
 
+type SwapError = Error & { message: string }
+
 export const TradeConfirm = ({ history }: RouterProps) => {
   const [txid, setTxid] = useState('')
   const {
@@ -72,10 +74,20 @@ export const TradeConfirm = ({ history }: RouterProps) => {
       }
     } catch (err) {
       console.error(`TradeConfirm:onSubmit - ${err}`)
-      // Since this happens onSubmit, we can optimistically determine this was an user rejection
+      // TODO: (ryankk) this needs to be revisited post bounty to handle actual errors coming back from unchained.
+      let errorMessage
+      switch ((err as SwapError)?.message) {
+        case 'ZrxExecuteQuote - signAndBroadcastTransaction error: Error: Error signing & broadcasting tx': {
+          errorMessage = TRADE_ERRORS.TRANSACTION_REJECTED
+          break
+        }
+        default: {
+          errorMessage = TRADE_ERRORS.INSUFFICIENT_FUNDS
+        }
+      }
       toast({
         title: translate('trade.errors.title'),
-        description: translate(TRADE_ERRORS.TRANSACTION_REJECTED),
+        description: translate(errorMessage),
         status: 'error',
         duration: 9000,
         isClosable: true,

--- a/src/components/Trade/hooks/useSwapper/useSwapper.ts
+++ b/src/components/Trade/hooks/useSwapper/useSwapper.ts
@@ -48,6 +48,7 @@ export enum TRADE_ERRORS {
   INSUFFICIENT_FUNDS = 'trade.errors.insufficientFunds',
   INSUFFICIENT_FUNDS_FOR_LIMIT = 'trade.errors.insufficientFundsForLimit',
   INSUFFICIENT_FUNDS_FOR_AMOUNT = 'trade.errors.insufficientFundsForAmount',
+  TRANSACTION_REJECTED = 'trade.errors.transactionRejected',
   NO_LIQUIDITY = 'trade.errors.noLiquidityError',
   BALANCE_TO_LOW = 'trade.errors.balanceToLow',
   DEX_TRADE_FAILED = 'trade.errors.dexTradeFailed',


### PR DESCRIPTION
## Description

- This handles web3 client rejections of swaps, with a better error message. Before/After:
`Something went wrong - Insufficient funds for miner fee and amount` -> `"Something went wrong - User has rejected the transaction"`
- A new property `transactionRejected` was added, since we still want to handle the existing `"Insufficient funds for miner fee and amount"` error message - swapper not only returns errors on web3 client calls, but also on e.g XHRs to  `https://api.0x.org/swap/v1/quote`, in which case the error message is perfectly valid.

## Notice

Before submitting a pull request, please make sure you have answered the following:

- [x] Have you followed the guidelines in our [Contributing]('https://github.com/shapeshift/web/CONTRIBUTING.md) guide?
- [x] Have you checked to ensure there aren't other open [Pull Requests](https://github.com/shapeshift/web/pulls) for the same update/change?
- [x] Do all new and existing tests pass? Does the linter pass?

## Pull Request Type

- [ ] :bug: Bug fix (Non-breaking Change: Fixes an issue)
- [ ] :hammer_and_wrench: Chore (Non-breaking Change: Doc updates, pkg upgrades, typos, etc..)
- [x] :nail_care: New Feature (Breaking/Non-breaking Change)

## Issue

closes #638

## Testing

- In `/dashboard`, get a quote
- Preview trade
- Confirm and Trade
- On metamask popup, reject transaction

## Screenshots
![image](https://user-images.githubusercontent.com/17035424/148553562-cb55cdff-6c88-4f74-ad57-5738b453cf48.png)

