### PR TITLE
fix: bring back asset descriptions

### DIFF
--- a/src/hooks/useFetchAssetDescription/useFetchAssetDescription.ts
+++ b/src/hooks/useFetchAssetDescription/useFetchAssetDescription.ts
@@ -1,0 +1,8 @@
+import { CAIP19 } from '@shapeshiftoss/caip'
+import { assetApi } from 'state/slices/assetsSlice/assetsSlice'
+import { useAppDispatch } from 'state/store'
+
+export const useFetchAssetDescription = (assetId: CAIP19) => {
+  const dispatch = useAppDispatch()
+  dispatch(assetApi.endpoints.getAssetDescription.initiate(assetId))
+}

--- a/src/pages/Assets/AssetDetails/AssetHeader/AssetHeader.tsx
+++ b/src/pages/Assets/AssetDetails/AssetHeader/AssetHeader.tsx
@@ -26,6 +26,7 @@ import { PriceChart } from 'components/PriceChart/PriceChart'
 import { SanitizedHtml } from 'components/SanitizedHtml/SanitizedHtml'
 import { RawText, Text } from 'components/Text'
 import { useWallet } from 'context/WalletProvider/WalletProvider'
+import { useFetchAssetDescription } from 'hooks/useFetchAssetDescription/useFetchAssetDescription'
 import { useLocaleFormatter } from 'hooks/useLocaleFormatter/useLocaleFormatter'
 import { useWalletSupportsChain } from 'hooks/useWalletSupportsChain/useWalletSupportsChain'
 import { useAsset } from 'pages/Assets/Asset'
@@ -53,7 +54,8 @@ export const AssetHeader = ({ isLoaded }: { isLoaded: boolean }) => {
   const [showDescription, setShowDescription] = useState(false)
   const [view, setView] = useState(View.Price)
   const [isLargerThanMd] = useMediaQuery(`(min-width: ${breakpoints['md']})`)
-  const { name, symbol, description, icon } = asset || {}
+  const { name, symbol, description, icon, caip19 } = asset || {}
+  useFetchAssetDescription(caip19)
   const { price } = marketData || {}
   const {
     number: { toFiat }


### PR DESCRIPTION
## Description

fixes regression where asset descriptions aren't showing because i broke them

## Notice

Before submitting a pull request, please make sure you have answered the following:

- [x] Have you followed the guidelines in our [Contributing]('https://github.com/shapeshift/web/CONTRIBUTING.md) guide?
- [x] Have you checked to ensure there aren't other open [Pull Requests](https://github.com/shapeshift/web/pulls) for the same update/change?
- [x] Do all new and existing tests pass? Does the linter pass?

## Pull Request Type

- [x] :bug: Bug fix (Non-breaking Change: Fixes an issue)
- [ ] :hammer_and_wrench: Chore (Non-breaking Change: Doc updates, pkg upgrades, typos, etc..)
- [ ] :nail_care: New Feature (Breaking/Non-breaking Change)

## Issue (if applicable)

closes #681

## Testing

- go to asset page
- description should appear

## Screenshots (if applicable)
