### PR TITLE
feat: handle ZrxExecuteQuote swapper errors

### DIFF
--- a/src/assets/translations/messages-en.json
+++ b/src/assets/translations/messages-en.json
@@ -154,13 +154,25 @@
       "invalidMax": "Invalid Amount. The maximum trade amount for this pair is %{maxLimit}.",
       "insufficientFunds": "Insufficient funds for miner fee and amount",
       "transactionRejected": "User has rejected the transaction",
+      "broadcastFailed": "An error occured while broadcasting the transaction",
       "insufficientFundsForLimit": "Insufficient funds. The minimum trade amount for this pair is %{minLimit}",
       "insufficientFundsForAmount": "Insufficient funds. Your %{symbol} balance is less than the selected amount",
       "noLiquidityError": "Not enough liquidity available",
       "overMaxSlippage": "This trade would result in over %{slippagePercentage}% slippage. Please trade a lower amount for a better price",
       "balanceToLow": "Balance too low. The minimum trade amount for this pair is %{minLimit}",
       "dexTradeFailed": "Trade Failed, Tokens Returned",
-      "quoteFailed": "An error occurred getting a quote for your trade."
+      "quoteFailed": "An error occurred getting a quote for your trade.",
+      "failedQuoteExecuted": "Cannot execute a failed quote",
+      "sellAssetRequired": "Cannot execute a quote without an asset to sell",
+      "sellAmountRequired": "Cannot execute a quote without an amount to sell",
+      "depositAddressRequired": "Cannot execute an ETH quote without a DEX address",
+      "sellAssetNetworkAndSymbolRequired": "Both asset network and symbol are required to execute a quote",
+      "hdwalletInvalidConfig": "An error occured communicating with your hardware wallet",
+      "signing": {
+        "failed": "An error occured signing the transaction",
+        "required": "A signed transaction is required"
+      }
+
     }
   },
   "modals": {

--- a/src/components/Trade/hooks/useSwapper/useSwapper.ts
+++ b/src/components/Trade/hooks/useSwapper/useSwapper.ts
@@ -49,11 +49,20 @@ export enum TRADE_ERRORS {
   INSUFFICIENT_FUNDS_FOR_LIMIT = 'trade.errors.insufficientFundsForLimit',
   INSUFFICIENT_FUNDS_FOR_AMOUNT = 'trade.errors.insufficientFundsForAmount',
   TRANSACTION_REJECTED = 'trade.errors.transactionRejected',
+  BROADCAST_FAILED = 'trade.errors.broadcastFailed',
   NO_LIQUIDITY = 'trade.errors.noLiquidityError',
   BALANCE_TO_LOW = 'trade.errors.balanceToLow',
   DEX_TRADE_FAILED = 'trade.errors.dexTradeFailed',
   QUOTE_FAILED = 'trade.errors.quoteFailed',
-  OVER_SLIP_SCORE = 'trade.errors.overSlipScore'
+  OVER_SLIP_SCORE = 'trade.errors.overSlipScore',
+  FAILED_QUOTE_EXECUTED = 'trade.errors.failedQuoteExecuted',
+  SELL_ASSET_REQUIRED = 'trade.errors.sellAssetRequired',
+  SELL_AMOUNT_REQUIRED = 'trade.errors.sellAmountRequired',
+  DEPOSIT_ADDRESS_REQUIRED = 'trade.errors.depositAddressRequired',
+  SELL_ASSET_NETWORK_AND_SYMBOL_REQUIRED = 'trade.errors.sellAssetNetworkAndSymbolRequired',
+  SIGNING_FAILED = 'trade.errors.signing.failed',
+  SIGNING_REQUIRED = 'trade.errors.signing.required',
+  HDWALLET_INVALID_CONFIG = 'trade.errors.hdwalletInvalidConfig'
 }
 
 // TODO: (ryankk) revisit the logic inside useSwapper post bounty to see

--- a/src/types/object.ts
+++ b/src/types/object.ts
@@ -1,0 +1,1 @@
+export type ValueOf<T> = T[keyof T]


### PR DESCRIPTION
## Description

This handles thrown `ZrxExecuteQuote` swap errors. Here are their messages in `@shapeshiftoss/swapper`: 

### Errors as a result of failed quote
 - [`ZrxSwapper:ZrxExecuteQuote Cannot execute a failed quote`](https://github.com/shapeshift/lib/blob/ca9e1b5ab18996f222dabd487835a9ab4b7b818a/packages/swapper/src/swappers/zrx/ZrxExecuteQuote/ZrxExecuteQuote.ts#L14)
 - [`ZrxSwapper:ZrxExecuteQuote sellAssetNetwork and sellAssetSymbol are required`](https://github.com/shapeshift/lib/blob/ca9e1b5ab18996f222dabd487835a9ab4b7b818a/packages/swapper/src/swappers/zrx/ZrxExecuteQuote/ZrxExecuteQuote.ts#L19)
 - [`ZrxSwapper:ZrxExecuteQuote sellAssetAccountId is required`](https://github.com/shapeshift/lib/blob/ca9e1b5ab18996f222dabd487835a9ab4b7b818a/packages/swapper/src/swappers/zrx/ZrxExecuteQuote/ZrxExecuteQuote.ts#L24)
 - [`ZrxSwapper:ZrxExecuteQuote sellAmount is required`](https://github.com/shapeshift/lib/blob/ca9e1b5ab18996f222dabd487835a9ab4b7b818a/packages/swapper/src/swappers/zrx/ZrxExecuteQuote/ZrxExecuteQuote.ts#L28)
 - [`ZrxSwapper:ZrxExecuteQuote depositAddress is required`](https://github.com/shapeshift/lib/blob/ca9e1b5ab18996f222dabd487835a9ab4b7b818a/packages/swapper/src/swappers/zrx/ZrxExecuteQuote/ZrxExecuteQuote.ts#L32)
 
Remarks: With the current implementation, the toasted message will be generic every time, ditching variables. This is by design because of how `swapper` throws. To be able to use variables in the message, `swapper` would need to throw tokenized errors.
 
### Signing errors
 - [`ZrxExecuteQuote - signTransaction error: ${error}`](https://github.com/shapeshift/lib/blob/ca9e1b5ab18996f222dabd487835a9ab4b7b818a/packages/swapper/src/swappers/zrx/ZrxExecuteQuote/ZrxExecuteQuote.ts#L66)
 - [`ZrxExecuteQuote - Signed transaction is required: ${signedTx}`](https://github.com/shapeshift/lib/blob/ca9e1b5ab18996f222dabd487835a9ab4b7b818a/packages/swapper/src/swappers/zrx/ZrxExecuteQuote/ZrxExecuteQuote.ts#L70)
 - [`ZrxExecuteQuote - broadcastTransaction error: ${error}`](https://github.com/shapeshift/lib/blob/ca9e1b5ab18996f222dabd487835a9ab4b7b818a/packages/swapper/src/swappers/zrx/ZrxExecuteQuote/ZrxExecuteQuote.ts#L76)
 
 ### HDWallet Errors 

 - [`ZrxExecuteQuote - invalid HDWallet config`](https://github.com/shapeshift/lib/blob/ca9e1b5ab18996f222dabd487835a9ab4b7b818a/packages/swapper/src/swappers/zrx/ZrxExecuteQuote/ZrxExecuteQuote.ts#L89)
 
## Notice

Before submitting a pull request, please make sure you have answered the following:

- [x] Have you followed the guidelines in our [Contributing]('https://github.com/shapeshift/web/CONTRIBUTING.md) guide?
- [x] Have you checked to ensure there aren't other open [Pull Requests](https://github.com/shapeshift/web/pulls) for the same update/change?
- [x] Do all new and existing tests pass? Does the linter pass?

## Pull Request Type

- [ ] :bug: Bug fix (Non-breaking Change: Fixes an issue)
- [ ] :hammer_and_wrench: Chore (Non-breaking Change: Doc updates, pkg upgrades, typos, etc..)
- [x] :nail_care: New Feature (Breaking/Non-breaking Change)

## Issue (if applicable)

N/A

## Testing

### Quote errors:

- Check all the scenarios for error throwing in [@shapeshiftoss/swapper/src/swappers/zrx/ZrxExecuteQuote/ZrxExecuteQuote.ts](https://github.com/shapeshift/lib/blob/ca9e1b5ab18996f222dabd487835a9ab4b7b818a/packages/swapper/src/swappers/zrx/ZrxExecuteQuote/ZrxExecuteQuote.ts#L13-L90)
- Reproduce each of them by passing a `quote` object to `executeQuote` that matches each scenario, in https://github.com/shapeshift/web/blob/125d03cab8986bf8a6a777507f200818a9a73bbb/src/components/Trade/hooks/useSwapper/useSwapper.ts#L207
For most properties, this can be done by mutating the quote object e.g `quote.success = false`, or `quote.success = undefined`.
However, some properties are read-only so you might need to pass a deep copy of the object with the changed nested properties, namely for the properties of `quote.sellAsset`.

### Signing and HDWallet errors

- `@shapeshiftoss/hdwallet-metamask` (to make [`supportsOfflineSigning`](https://github.com/shapeshift/hdwallet/blob/90acdd2bcaca9842761632fe742f4416eefae791/packages/hdwallet-metamask/src/metamask.ts#L110) return true) and `@shapeshiftoss/swappers` (to make each [`ZrxExecuteQuote`](https://github.com/shapeshift/lib/blob/ca9e1b5ab18996f222dabd487835a9ab4b7b818a/packages/swapper/src/swappers/zrx/ZrxExecuteQuote/ZrxExecuteQuote.ts#L62-L90) signing branch throw ) both need to be yarn linked
- In `@shapeshiftoss/swappers/src/swappers/zrx/ZrxExecuteQuote/ZrxExecuteQuote.ts`, edit implementation multiple times, so that each error gets thrown

## Screenshots

Will be added after copy is confirmed
