### PR TITLE
fix: show correct BTC balance in portfolio and asset pages

### DIFF
--- a/src/hooks/useAccountSpecifiers/useAccountSpecifiers.ts
+++ b/src/hooks/useAccountSpecifiers/useAccountSpecifiers.ts
@@ -53,7 +53,7 @@ export const useAccountSpecifiers: UseAccountSpecifiers = () => {
           const bitcoin = assetsById[CAIP19]
 
           if (!bitcoin) continue
-          supportedAccountTypes.bitcoin.forEach(async accountType => {
+          for (const accountType of supportedAccountTypes.bitcoin) {
             const accountParams = utxoAccountParams(bitcoin, accountType, 0)
             const { bip44Params, scriptType } = accountParams
             const pubkeys = await wallet.getPublicKeys([
@@ -69,10 +69,10 @@ export const useAccountSpecifiers: UseAccountSpecifiers = () => {
             }
             pubkey = convertXpubVersion(pubkeys[0].xpub, accountType)
 
-            if (!pubkey) return
+            if (!pubkey) continue
             const CAIP2 = caip2.toCAIP2({ chain, network })
             acc.push({ [CAIP2]: pubkey })
-          })
+          }
           break
         }
         default:

--- a/src/pages/Assets/Asset.tsx
+++ b/src/pages/Assets/Asset.tsx
@@ -61,14 +61,14 @@ export const useAsset = () => {
   const contractType = ContractTypes.ERC20
   const extra = tokenId ? { contractType, tokenId } : undefined
   const assetCAIP19 = caip19.toCAIP19({ chain, network, ...extra })
+  const asset = useAppSelector(state => selectAssetByCAIP19(state, assetCAIP19))
+  const marketData = useAppSelector(state => selectMarketDataById(state, assetCAIP19))
 
   // Many, but not all, assets are initialized with market data on app load. This dispatch will
   // ensure that those assets not initialized on app load will reach over the network and populate
   // the store with market data once a user visits that asset page.
-  dispatch(marketApi.endpoints.findByCaip19.initiate(assetCAIP19))
+  if (!marketData) dispatch(marketApi.endpoints.findByCaip19.initiate(assetCAIP19))
 
-  const asset = useAppSelector(state => selectAssetByCAIP19(state, assetCAIP19))
-  const marketData = useAppSelector(state => selectMarketDataById(state, assetCAIP19))
   const loading = useAppSelector(state => selectMarketDataLoadingById(state, assetCAIP19))
 
   return {


### PR DESCRIPTION
## Description

fix: show correct BTC balance in portfolio and asset pages
fix: infinite loop in `useAsset` hook

## Notice

Before submitting a pull request, please make sure you have answered the following:

- [X] Have you followed the guidelines in our [Contributing]('https://github.com/shapeshift/web/CONTRIBUTING.md) guide?
- [X] Have you checked to ensure there aren't other open [Pull Requests](https://github.com/shapeshift/web/pulls) for the same update/change?
- [X] Do all new and existing tests pass? Does the linter pass?

## Pull Request Type

- [X] :bug: Bug fix (Non-breaking Change: Fixes an issue)
- [ ] :hammer_and_wrench: Chore (Non-breaking Change: Doc updates, pkg upgrades, typos, etc..)
- [ ] :nail_care: New Feature (Breaking/Non-breaking Change)

## Issue (if applicable)

closes #648 

## Testing

Please outline all testing steps

1. Connect a KeepKey with a BTC balance
2. Go to the Assets page

## Screenshots (if applicable)
![image](https://user-images.githubusercontent.com/1958266/148609853-575bd388-a8d2-46da-af82-69b021ca3465.png)
![image](https://user-images.githubusercontent.com/1958266/148609891-7af429ae-4f79-47e0-ba76-bfdc8f4bdcdd.png)
