### PR TITLE
fix: unbreak hot module reloading

### DIFF
--- a/react-app-rewired.config.js
+++ b/react-app-rewired.config.js
@@ -160,109 +160,119 @@ module.exports = {
     )
     // Update the Webpack config to emit the collected env vars as `env.json` and load them
     // dynamically instead of baking them into each chunk that might reference them.
-    _.merge(config, {
-      plugins: [
-        ...config.plugins.map(plugin => {
-          switch (plugin.constructor.name) {
-            case 'DefinePlugin': {
-              // Remove all REACT_APP_* 'process.env' entries from DefinePlugin; these will
-              // be pulled from env.json via src/config.ts and src/env/index.ts.
-              if (Object.keys(plugin.definitions).filter(x => x !== 'process.env').length !== 0) {
-                throw new Error('Unexpected DefinePlugin entries')
-              }
-              const definitions = Object.fromEntries(
-                Object.entries(env)
-                  .filter(([k]) => !k.startsWith('REACT_APP_'))
-                  .sort((a, b) => {
-                    if (a[0] < b[0]) return -1
-                    if (a[0] > b[0]) return 1
-                    return 0
-                  })
-              )
-              console.info('Embedded environment vars:', definitions)
-              return new webpack.DefinePlugin(
-                Object.fromEntries(
-                  Object.entries(definitions).map(([k, v]) => [
-                    `process.env.${k}`,
-                    JSON.stringify(v)
-                  ])
-                )
-              )
-            }
-            default:
-              return plugin
-          }
-        })
-      ],
-      module: {
-        rules: [
-          ...config.module?.rules,
-          {
-            // This rule causes the (placeholder) contents of `src/env/env.json` to be thrown away
-            // and replaced with `stableStringify(env)`, which is then written out to `build/env.json`.
-            //
-            // Note that simply adding this rule doesn't force `env.json` to be generated. That happens
-            // because `src/env/process.js` `require()`s it, and that module is provided via ProvidePlugin
-            // above. If nothing ever uses that `process` global, both `src/env/process.js` and `env.json`
-            // will be omitted from the build.
-            resource: path.join(__dirname, 'src/env/env.json'),
-            // Webpack loads resources by reading them from disk and feeding them through a series
-            // of loaders. It then emits them by feeding the result to a generator.
-            //
-            // The `val-loader` plugin is a customizable loader which `require()`s `executableFile`,
-            // expecting a single exported function which it uses to transform the on-disk module data.
-            // The stub loader, `src/env/loader.js`, simply takes a `code` function as an option and
-            // and replaces the module data with its result.
-            //
-            // Webpack requires both the module being loaded and the stub loader to exist as actual files
-            // on the filesystem, but this setup allows the actual content of a module to be generated
-            // at compile time.
-            use: [
-              {
-                loader: 'val-loader',
-                options: {
-                  executableFile: require.resolve(path.join(__dirname, 'src/env/loader.js')),
-                  code() {
-                    return stableStringify(
+    _.merge(
+      config,
+      isProduction
+        ? {
+            plugins: [
+              ...config.plugins.map(plugin => {
+                switch (plugin.constructor.name) {
+                  case 'DefinePlugin': {
+                    // Remove all REACT_APP_* 'process.env' entries from DefinePlugin; these will
+                    // be pulled from env.json via src/config.ts and src/env/index.ts.
+                    if (
+                      Object.keys(plugin.definitions).filter(x => x !== 'process.env').length !== 0
+                    ) {
+                      throw new Error('Unexpected DefinePlugin entries')
+                    }
+                    const definitions = Object.fromEntries(
+                      Object.entries(env)
+                        .filter(([k]) => !k.startsWith('REACT_APP_'))
+                        .sort((a, b) => {
+                          if (a[0] < b[0]) return -1
+                          if (a[0] > b[0]) return 1
+                          return 0
+                        })
+                    )
+                    console.info('Embedded environment vars:', definitions)
+                    return new webpack.DefinePlugin(
                       Object.fromEntries(
-                        Object.entries(env).filter(([k]) => k.startsWith('REACT_APP_'))
+                        Object.entries(definitions).map(([k, v]) => [
+                          `process.env.${k}`,
+                          JSON.stringify(v)
+                        ])
                       )
                     )
                   }
+                  default:
+                    return plugin
                 }
-              }
+              })
             ],
-            // The type ['asset/resource'](https://webpack.js.org/guides/asset-modules/#resource-assets)
-            // tells Webpack to a special generator that will emit the module as a separate file instead
-            // of inlining its contents into another chunk, as well as skip the normal plugin processing
-            // and minification steps and just write the raw as-loaded contents. The `generator.filename`
-            // option overrides the default output path so that the file ends up at `build/env.json`
-            // instead of the default `build/static/media/env.[hash].json`.
-            type: 'asset/resource',
-            generator: {
-              filename: '[base]'
+            module: {
+              rules: [
+                ...config.module?.rules,
+                {
+                  // This rule causes the (placeholder) contents of `src/env/env.json` to be thrown away
+                  // and replaced with `stableStringify(env)`, which is then written out to `build/env.json`.
+                  //
+                  // Note that simply adding this rule doesn't force `env.json` to be generated. That happens
+                  // because `src/env/process.js` `require()`s it, and that module is provided via ProvidePlugin
+                  // above. If nothing ever uses that `process` global, both `src/env/process.js` and `env.json`
+                  // will be omitted from the build.
+                  resource: path.join(__dirname, 'src/env/env.json'),
+                  // Webpack loads resources by reading them from disk and feeding them through a series
+                  // of loaders. It then emits them by feeding the result to a generator.
+                  //
+                  // The `val-loader` plugin is a customizable loader which `require()`s `executableFile`,
+                  // expecting a single exported function which it uses to transform the on-disk module data.
+                  // The stub loader, `src/env/loader.js`, simply takes a `code` function as an option and
+                  // and replaces the module data with its result.
+                  //
+                  // Webpack requires both the module being loaded and the stub loader to exist as actual files
+                  // on the filesystem, but this setup allows the actual content of a module to be generated
+                  // at compile time.
+                  use: [
+                    {
+                      loader: 'val-loader',
+                      options: {
+                        executableFile: require.resolve(path.join(__dirname, 'src/env/loader.js')),
+                        code() {
+                          return stableStringify(
+                            Object.fromEntries(
+                              Object.entries(env).filter(([k]) => k.startsWith('REACT_APP_'))
+                            )
+                          )
+                        }
+                      }
+                    }
+                  ],
+                  // The type ['asset/resource'](https://webpack.js.org/guides/asset-modules/#resource-assets)
+                  // tells Webpack to a special generator that will emit the module as a separate file instead
+                  // of inlining its contents into another chunk, as well as skip the normal plugin processing
+                  // and minification steps and just write the raw as-loaded contents. The `generator.filename`
+                  // option overrides the default output path so that the file ends up at `build/env.json`
+                  // instead of the default `build/static/media/env.[hash].json`.
+                  type: 'asset/resource',
+                  generator: {
+                    filename: '[base]'
+                  }
+                }
+              ]
+            },
+            // We can't use `fetch()` to load `env.json` when running tests because Jest doesn't do top-level await.
+            // We can't manually mock out the fetch because we'd either have to turn on automock, which mocks *everything*
+            // and breaks a lot of stuff, or call `jest.mock()`, which doesn't exist in the browser. It can't be called
+            // conditionally because that breaks Jest's magic hoisting BS, and we can't polyfill it because the existence
+            // of a global `jest` object causes various things to think they're being tested and complain that their
+            // "test harnesses" aren't set up correctly.
+            //
+            // Instead, we leave the jest-friendly behavior as the "default", and use this alias to swap in the behavior
+            // we want to happen in the browser during the build of the webpack bundle.
+            resolve: {
+              alias: {
+                [path.join(__dirname, 'src/env/index.ts')]: path.join(
+                  __dirname,
+                  'src/env/webpack.ts'
+                )
+              }
+            },
+            experiments: {
+              topLevelAwait: true
             }
           }
-        ]
-      },
-      // We can't use `fetch()` to load `env.json` when running tests because Jest doesn't do top-level await.
-      // We can't manually mock out the fetch because we'd either have to turn on automock, which mocks *everything*
-      // and breaks a lot of stuff, or call `jest.mock()`, which doesn't exist in the browser. It can't be called
-      // conditionally because that breaks Jest's magic hoisting BS, and we can't polyfill it because the existence
-      // of a global `jest` object causes various things to think they're being tested and complain that their
-      // "test harnesses" aren't set up correctly.
-      //
-      // Instead, we leave the jest-friendly behavior as the "default", and use this alias to swap in the behavior
-      // we want to happen in the browser during the build of the webpack bundle.
-      resolve: {
-        alias: {
-          [path.join(__dirname, 'src/env/index.ts')]: path.join(__dirname, 'src/env/webpack.ts')
-        }
-      },
-      experiments: {
-        topLevelAwait: true
-      }
-    })
+        : {}
+    )
 
     return config
   },


### PR DESCRIPTION
## Description

This is a quick-fix for some kind of hot module reloading regression introduced by #616. It's massive overkill, but it works. I've been fighting this all day and have not been able to narrow down what's actually busted because I can't reliably reproduce the issue -- or reliably reproduce _not_ having the issue. But even though my working tree is apparently cursed, this should unblock people until we can narrow it down properly.

## Notice

Before submitting a pull request, please make sure you have answered the following:

- [x] Have you followed the guidelines in our [Contributing]('https://github.com/shapeshift/web/CONTRIBUTING.md) guide?
- [x] Have you checked to ensure there aren't other open [Pull Requests](https://github.com/shapeshift/web/pulls) for the same update/change?
- [x] Do all new and existing tests pass? Does the linter pass?

## Pull Request Type

- [x] :bug: Bug fix (Non-breaking Change: Fixes an issue)
- [ ] :hammer_and_wrench: Chore (Non-breaking Change: Doc updates, pkg upgrades, typos, etc..)
- [ ] :nail_care: New Feature (Breaking/Non-breaking Change)
