### PR TITLE
chore: translation copy changes

### DIFF
--- a/src/assets/translations/messages-en.json
+++ b/src/assets/translations/messages-en.json
@@ -249,7 +249,7 @@
       "slippageSettings": "Slippage Settings"
     },
     "approve": {
-      "header": "Allow ShapeShift.io to Spend Your %{asset}",
+      "header": "Allow ShapeShift DAO Router to spend your %{asset}",
       "body": "We need your permission to use your %{asset}",
       "learnMore": "Why do I need to do this?",
       "depositFee": "There will be separate gas fee to deposit.",
@@ -267,7 +267,7 @@
         "estimatedReturns": "Estimated Yearly Returns*",
         "preFooter": "Rewards accrue automatically"
       },
-      "withdrawFrom": "Withdraw From",
+      "withdrawFrom": "Withdrawal From",
       "withdrawTo": "Withdraw To",
       "depositTo": "Deposit To",
       "averageApy": "Average APY",
@@ -289,7 +289,7 @@
       "estimatedReturns": "Estimated Yearly Returns*",
       "estimatedGas": "Estimated Gas Fee",
       "gasUsed": "Total Gas Fee",
-      "continue": "View My Position",
+      "continue": "View Transaction",
       "viewAsset": "View Asset",
       "close": "Close"
     },
@@ -381,8 +381,11 @@
       },
       "import": {
         "header": "Import your wallet",
-        "body": "Enter your seed phrase to import an existing wallet",
-        "button": "Next"
+        "body": "Enter your Secret Recovery Phrase to import an existing wallet",
+        "button": "Next",
+        "secretRecoveryPhraseError": "Enter your Secret Recovery Phrase with a single space in between words. Omit any commas, returns, or any additional characters.",
+        "secretRecoveryPhraseRequired": "Secret Recovery Phrase is required",
+        "secretRecoveryPhraseTooShort": "Secret Recovery Phrase is too short"
       },
       "password": {
         "header": "Enter Your Password",
@@ -390,7 +393,7 @@
         "button": "Next"
       },
       "create": {
-        "header": "Your Backup Seed Phrase",
+        "header": "Your Secret Recovery Phrase",
         "body": "Write these 12 words down and store them securely offline. This 12 word phrase is used to recover your wallet private keys.",
         "button": "Next",
         "hideWords": "Hide Words",
@@ -398,7 +401,7 @@
       },
       "start": {
         "header": "ShapeShift Wallet",
-        "body": "You can have multiple ShapeShift wallets. You may load a wallet, import a wallet from a backup phrase, or create a new wallet.",
+        "body": "You can have multiple ShapeShift wallets. You may load a wallet, import a wallet from a Secret Recovery Phrase, or create a new wallet.",
         "import": "Import a wallet",
         "create": "Create a new wallet",
         "load": "Saved wallets"
@@ -410,7 +413,7 @@
         "error": "There was an error connecting your wallet"
       },
       "testPhrase": {
-        "header": "Verify Your Backup Seed Phrase",
+        "header": "Verify Your Secret Recovery Phrase",
         "body": "Which of these is the",
         "body2": " word",
         "body3": "in your secret phrase.",

--- a/src/components/Trade/TradeInput.tsx
+++ b/src/components/Trade/TradeInput.tsx
@@ -133,7 +133,6 @@ export const TradeInput = ({ history }: RouterProps) => {
 
   const handleToast = (description: string) => {
     toast({
-      title: translate('trade.errors.title'),
       description,
       status: 'error',
       duration: 9000,

--- a/src/context/WalletProvider/NativeWallet/components/NativeCreate.tsx
+++ b/src/context/WalletProvider/NativeWallet/components/NativeCreate.tsx
@@ -86,7 +86,7 @@ export const NativeCreate = ({ history, location }: NativeSetupProps) => {
           )
         )
       } catch (e) {
-        console.error('failed to get seed:', e)
+        console.error('failed to get Secret Recovery Phrase:', e)
         setWords(null)
       }
     })()

--- a/src/context/WalletProvider/NativeWallet/components/NativeImport.tsx
+++ b/src/context/WalletProvider/NativeWallet/components/NativeImport.tsx
@@ -9,6 +9,7 @@ import {
 import { Vault } from '@shapeshiftoss/hdwallet-native-vault'
 import * as bip39 from 'bip39'
 import { FieldValues, useForm } from 'react-hook-form'
+import { useTranslate } from 'react-polyglot'
 import { RouteComponentProps } from 'react-router-dom'
 import { Text } from 'components/Text'
 
@@ -31,6 +32,8 @@ export const NativeImport = ({ history }: RouteComponentProps) => {
     formState: { errors, isSubmitting }
   } = useForm()
 
+  const translate = useTranslate()
+
   return (
     <>
       <ModalHeader>
@@ -46,10 +49,19 @@ export const NativeImport = ({ history }: RouteComponentProps) => {
               autoComplete='off'
               autoCorrect='off'
               {...register('mnemonic', {
-                required: 'Seed phrase is required',
-                minLength: { value: 47, message: 'Seed phrase is too short' },
+                required: translate(
+                  'walletProvider.shapeShift.import.secretRecoveryPhraseRequired'
+                ),
+                minLength: {
+                  value: 47,
+                  message: translate(
+                    'walletProvider.shapeShift.import.secretRecoveryPhraseTooShort'
+                  )
+                },
                 validate: {
-                  validMnemonic: value => bip39.validateMnemonic(value) || 'Invalid seed phrase'
+                  validMnemonic: value =>
+                    bip39.validateMnemonic(value) ||
+                    translate('walletProvider.shapeShift.import.secretRecoveryPhraseError')
                 }
               })}
             />

--- a/src/features/earn/providers/yearn/components/YearnManager/Withdraw/YearnWithdraw.tsx
+++ b/src/features/earn/providers/yearn/components/YearnManager/Withdraw/YearnWithdraw.tsx
@@ -46,7 +46,7 @@ enum WithdrawPath {
 }
 
 export const routes = [
-  { step: 0, path: WithdrawPath.Withdraw, label: 'Withdraw Amount' },
+  { step: 0, path: WithdrawPath.Withdraw, label: 'Withdrawal Amount' },
   { step: 1, path: WithdrawPath.Confirm, label: 'Confirm Withdraw' },
   { path: WithdrawPath.ConfirmSettings, label: 'Confirm Settings' },
   { step: 2, path: WithdrawPath.Status, label: 'Status' }


### PR DESCRIPTION
## Description

See issue #707 

1. (Copy )Update error messaging to"Enter your seed phrase with a single space in between words. Omit any commas, returns, or any additional characters. "
2. (Copy) Remove the title copy that says "Something went wrong"
3. (Copy) Update copy to "Allow ShapeShift DAO Router to spend your [ASSET NAME]"
4. (Copy) Replace 'View My Position' with 'View Transaction' (while pending) on Yearn withdrawal modal.
5. (Copy) Change any instance of "Backup Seed phrase", "backup phrase", or "seed phrase" to "Secret Recovery Phrase" throughout all pages of the above JSON file for V2
6. (Copy) Update "Withdraw amount" to "Withdrawal Amount"
7. (Copy) Update "Withdraw From" to "Withdrawal From"

I didn't change the point 8 as the _Reward Value_ in active opportunities has already been renamed in _Current Value_ 

## Notice

Before submitting a pull request, please make sure you have answered the following:

- [x] Have you followed the guidelines in our [Contributing]('https://github.com/shapeshift/web/CONTRIBUTING.md) guide?
- [x] Have you checked to ensure there aren't other open [Pull Requests](https://github.com/shapeshift/web/pulls) for the same update/change?
- [x] Do all new and existing tests pass? Does the linter pass?

## Pull Request Type

- [ ] :bug: Bug fix (Non-breaking Change: Fixes an issue)
- [x] :hammer_and_wrench: Chore (Non-breaking Change: Doc updates, pkg upgrades, typos, etc..)
- [ ] :nail_care: New Feature (Breaking/Non-breaking Change)

## Issue (if applicable)

closes #707 
