### PR TITLE
fix: asset price chart for french localization

### DIFF
--- a/src/pages/Assets/AssetDetails/AssetHeader/AssetHeader.tsx
+++ b/src/pages/Assets/AssetDetails/AssetHeader/AssetHeader.tsx
@@ -134,7 +134,7 @@ export const AssetHeader = ({ isLoaded }: { isLoaded: boolean }) => {
                   value={view === View.Price ? assetPrice : totalBalance}
                   displayType={'text'}
                   thousandSeparator={true}
-                  prefix={'$'}
+                  isNumericString={true}
                 />
               </Skeleton>
             </Card.Heading>


### PR DESCRIPTION
## Description

closes https://github.com/shapeshift/web/issues/705
I verified that there is no regression for en-US localization.

## Notice

Before submitting a pull request, please make sure you have answered the following:

- [X] Have you followed the guidelines in our [Contributing]('https://github.com/shapeshift/web/CONTRIBUTING.md) guide?
- [X] Have you checked to ensure there aren't other open [Pull Requests](https://github.com/shapeshift/web/pulls) for the same update/change?
- [X] Do all new and existing tests pass? Does the linter pass?

## Pull Request Type

- [X] :bug: Bug fix (Non-breaking Change: Fixes an issue)
- [ ] :hammer_and_wrench: Chore (Non-breaking Change: Doc updates, pkg upgrades, typos, etc..)
- [ ] :nail_care: New Feature (Breaking/Non-breaking Change)

## Issue (if applicable)

If applicable, please link to the github issue and put `closes #XXXX` in your comment to auto-close the issue that your PR fixes.

## Testing

Please outline all testing steps

1. Reproduced bug
2. Found place to fix
3. Checked NumericFormat component possible options
4. Compared with others NumericFormat usage in the app
5. Fix and test
6. Check no regression for en-US localization

## Screenshots (if applicable)

![eth_fr](https://user-images.githubusercontent.com/5720927/148923720-7f20eb14-c5eb-4e16-aaf3-9ea776bf8a2a.png)

![tether_fr](https://user-images.githubusercontent.com/5720927/148923729-7c7ab732-e01b-4f4e-96a7-4a29bf3c1277.png)

