### PR TITLE
fix: bitcoin sends respects account types

### DIFF
--- a/src/components/Modals/Send/hooks/useSendDetails/useSendDetails.test.tsx
+++ b/src/components/Modals/Send/hooks/useSendDetails/useSendDetails.test.tsx
@@ -14,8 +14,8 @@ import { selectMarketDataById } from 'state/slices/marketDataSlice/marketDataSli
 import {
   PortfolioBalancesById,
   selectPortfolioCryptoBalanceById,
-  selectPortfolioCryptoHumanBalanceById,
-  selectPortfolioFiatBalanceById
+  selectPortfolioCryptoHumanBalanceByAccountTypeAndAssetId,
+  selectPortfolioFiatBalanceByAccountTypeAndAssetId
 } from 'state/slices/portfolioSlice/portfolioSlice'
 
 import { useSendDetails } from './useSendDetails'
@@ -34,8 +34,8 @@ jest.mock('state/slices/assetsSlice/assetsSlice', () => ({
 jest.mock('state/slices/portfolioSlice/portfolioSlice', () => ({
   ...jest.requireActual('state/slices/portfolioSlice/portfolioSlice'),
   selectPortfolioCryptoBalanceById: jest.fn(),
-  selectPortfolioCryptoHumanBalanceById: jest.fn(),
-  selectPortfolioFiatBalanceById: jest.fn()
+  selectPortfolioCryptoHumanBalanceByAccountTypeAndAssetId: jest.fn(),
+  selectPortfolioFiatBalanceByAccountTypeAndAssetId: jest.fn()
 }))
 
 const ethCaip19 = 'eip155:1/slip44:60'
@@ -87,16 +87,18 @@ const setup = ({
     }
     return fakeMarketData[assetId]
   })
-  mocked(selectPortfolioFiatBalanceById).mockImplementation((_state, assetId) => {
-    const fakeFiatBalanceData = {
-      [mockEthereum.caip19]: '17500',
-      [mockRune.caip19]: '14490.00'
+  mocked(selectPortfolioFiatBalanceByAccountTypeAndAssetId).mockImplementation(
+    (_state, assetId) => {
+      const fakeFiatBalanceData = {
+        [mockEthereum.caip19]: '17500',
+        [mockRune.caip19]: '14490.00'
+      }
+      return fakeFiatBalanceData[assetId]
     }
-    return fakeFiatBalanceData[assetId]
-  })
+  )
   mocked(selectFeeAssetById).mockReturnValue(mockEthereum)
   mocked(selectPortfolioCryptoBalanceById).mockReturnValue(assetBalance)
-  mocked(selectPortfolioCryptoHumanBalanceById).mockReturnValue(
+  mocked(selectPortfolioCryptoHumanBalanceByAccountTypeAndAssetId).mockReturnValue(
     bnOrZero(assetBalance).div('1e18').toString()
   )
   ;(useFormContext as jest.Mock<unknown>).mockImplementation(() => ({

--- a/src/components/Modals/Send/hooks/useSendDetails/useSendDetails.tsx
+++ b/src/components/Modals/Send/hooks/useSendDetails/useSendDetails.tsx
@@ -4,7 +4,7 @@ import {
   utxoAccountParams
 } from '@shapeshiftoss/chain-adapters'
 import { bip32ToAddressNList } from '@shapeshiftoss/hdwallet-core'
-import { chainAdapters, ChainTypes } from '@shapeshiftoss/types'
+import { chainAdapters, ChainTypes, UtxoAccountType } from '@shapeshiftoss/types'
 import { debounce } from 'lodash'
 import { useCallback, useState } from 'react'
 import { useFormContext, useWatch } from 'react-hook-form'
@@ -19,7 +19,7 @@ import { selectFeeAssetById } from 'state/slices/assetsSlice/assetsSlice'
 import { selectMarketDataById } from 'state/slices/marketDataSlice/marketDataSlice'
 import {
   selectPortfolioCryptoBalanceById,
-  selectPortfolioCryptoHumanBalanceById,
+  selectPortfolioCryptoHumanBalanceByAccountTypeAndAssetId,
   selectPortfolioFiatBalanceById
 } from 'state/slices/portfolioSlice/portfolioSlice'
 import { useAppSelector } from 'state/store'
@@ -54,9 +54,17 @@ export const useSendDetails = (): UseSendDetailsReturnType => {
 
   const feeAsset = useAppSelector(state => selectFeeAssetById(state, asset.caip19))
   const balancesLoading = false
-  const cryptoHumanBalance = bnOrZero(
-    useAppSelector(state => selectPortfolioCryptoHumanBalanceById(state, asset.caip19))
+  const accountType: UtxoAccountType | undefined = useSelector(
+    (state: ReduxState) => state.preferences.accountTypes[asset.chain]
   )
+
+  // TODO(0xdef1cafe): this is a janky temporary fix till we implement accounts next week
+  const cryptoHumanBalance = bnOrZero(
+    useAppSelector(state =>
+      selectPortfolioCryptoHumanBalanceByAccountTypeAndAssetId(state, asset.caip19, accountType)
+    )
+  )
+
   const fiatBalance = bnOrZero(
     useAppSelector(state => selectPortfolioFiatBalanceById(state, asset.caip19))
   )

--- a/src/components/Modals/Send/hooks/useSendDetails/useSendDetails.tsx
+++ b/src/components/Modals/Send/hooks/useSendDetails/useSendDetails.tsx
@@ -20,7 +20,7 @@ import { selectMarketDataById } from 'state/slices/marketDataSlice/marketDataSli
 import {
   selectPortfolioCryptoBalanceById,
   selectPortfolioCryptoHumanBalanceByAccountTypeAndAssetId,
-  selectPortfolioFiatBalanceById
+  selectPortfolioFiatBalanceByAccountTypeAndAssetId
 } from 'state/slices/portfolioSlice/portfolioSlice'
 import { useAppSelector } from 'state/store'
 
@@ -66,7 +66,9 @@ export const useSendDetails = (): UseSendDetailsReturnType => {
   )
 
   const fiatBalance = bnOrZero(
-    useAppSelector(state => selectPortfolioFiatBalanceById(state, asset.caip19))
+    useAppSelector(state =>
+      selectPortfolioFiatBalanceByAccountTypeAndAssetId(state, asset.caip19, accountType)
+    )
   )
   const assetBalance = useAppSelector(state =>
     selectPortfolioCryptoBalanceById(state, asset.caip19)

--- a/src/state/slices/portfolioSlice/portfolioSlice.ts
+++ b/src/state/slices/portfolioSlice/portfolioSlice.ts
@@ -366,6 +366,14 @@ export const selectPortfolioCryptoHumanBalanceByAccountTypeAndAssetId = createSe
   }
 )
 
+export const selectPortfolioFiatBalanceByAccountTypeAndAssetId = createSelector(
+  selectPortfolioCryptoHumanBalanceByAccountTypeAndAssetId,
+  selectMarketData,
+  selectAssetIdParam,
+  (accountCryptoHumanBalance, marketData, assetId): string =>
+    bnOrZero(accountCryptoHumanBalance).times(bnOrZero(marketData[assetId]?.price)).toFixed(2)
+)
+
 export type PortfolioAssets = {
   [k: CAIP19]: Asset
 }

--- a/src/state/slices/portfolioSlice/portfolioSlice.ts
+++ b/src/state/slices/portfolioSlice/portfolioSlice.ts
@@ -1,7 +1,7 @@
 import { createSelector, createSlice } from '@reduxjs/toolkit'
 import { createApi, fetchBaseQuery } from '@reduxjs/toolkit/query/react'
 import { CAIP2, caip2, CAIP10, caip10, CAIP19 } from '@shapeshiftoss/caip'
-import { Asset, chainAdapters, ChainTypes } from '@shapeshiftoss/types'
+import { Asset, chainAdapters, ChainTypes, UtxoAccountType } from '@shapeshiftoss/types'
 import cloneDeep from 'lodash/cloneDeep'
 import isEmpty from 'lodash/isEmpty'
 import toLower from 'lodash/toLower'
@@ -327,6 +327,43 @@ export const selectPortfolioCryptoHumanBalanceById = createSelector(
   selectAssetIdParam,
   (assets, balances, assetId): string =>
     fromBaseUnit(bnOrZero(balances[assetId]), assets[assetId]?.precision ?? 0)
+)
+
+export const selectPortfolioAccountBalances = (state: ReduxState) =>
+  state.portfolio.accountBalances.byId
+
+// TODO(0xdef1cafe): this selector is a hack and needs to be deleted once the account pages are done
+// do not use it or i'll hurt you
+export const selectPortfolioCryptoHumanBalanceByAccountTypeAndAssetId = createSelector(
+  selectAssets,
+  selectPortfolioBalances,
+  selectPortfolioAccountBalances,
+  selectAssetIdParam,
+  (_state: ReduxState, _assetId: string, accountType: UtxoAccountType | undefined) => accountType,
+  (assets, balances, accountBalances, assetId, accountType): string => {
+    if (!accountType) {
+      // in the case of eth, this was working ok, and we only support a single account at the moment,
+      // so we can use the portfolio balance
+      // TODO(0xdef1cafe): we need to fix this to use the accountId and the assetId when we're implementing
+      // account pages - this will break once we support more than accountIndex 0 for account based chains
+      return fromBaseUnit(bnOrZero(balances[assetId]), assets[assetId]?.precision ?? 0)
+    } else {
+      const accountTypeToPubMap = {
+        [UtxoAccountType.P2pkh]: 'xpub', // legacy
+        [UtxoAccountType.SegwitP2sh]: 'ypub', // segwit
+        [UtxoAccountType.SegwitNative]: 'zpub' // segwit native
+      }
+      const searchString = accountTypeToPubMap[accountType]
+      const accountId = Object.keys(accountBalances).find(key => {
+        // only find bitcoin accounts
+        return key.startsWith(assets[assetId].caip2) && key.includes(`:${searchString}`)
+      })!
+      return fromBaseUnit(
+        bnOrZero(accountBalances[accountId]?.[assetId]),
+        assets[assetId]?.precision ?? 0
+      )
+    }
+  }
 )
 
 export type PortfolioAssets = {


### PR DESCRIPTION
## Description

after i refactored everything i ignored using account types for bitcoin. the send modal was looking at the portfolio balance for bitcoin - aggregated across all account types. this would try and create sends from the selected account type where a user may not have a balance, causing txs to fail.

## Notice

Before submitting a pull request, please make sure you have answered the following:

- [x] Have you followed the guidelines in our [Contributing]('https://github.com/shapeshift/web/CONTRIBUTING.md) guide?
- [x] Have you checked to ensure there aren't other open [Pull Requests](https://github.com/shapeshift/web/pulls) for the same update/change?
- [?] Do all new and existing tests pass? Does the linter pass?

## Pull Request Type

- [x] :bug: Bug fix (Non-breaking Change: Fixes an issue)
- [ ] :hammer_and_wrench: Chore (Non-breaking Change: Doc updates, pkg upgrades, typos, etc..)
- [ ] :nail_care: New Feature (Breaking/Non-breaking Change)

## Issue (if applicable)

If applicable, please link to the github issue and put `closes #XXXX` in your comment to auto-close the issue that your PR fixes.

## Testing

1. go to the bitcoin asset page with a wallet with bitcoin
2. click the send button
3. ensure the that balance displayed in the send modal is the same as the balance that you have for that account type

## Screenshots (if applicable)

n/a