### PR TITLE
chore: fixed script to link and to unlink packages

### DIFF
--- a/package.json
+++ b/package.json
@@ -85,9 +85,9 @@
     "web3": "^1.6.1"
   },
   "scripts": {
-    "show-linked-packages": "find node_modules node_modules/@* -depth 1 -type l -print",
+    "show-linked-packages": "find node_modules node_modules/@* -maxdepth 1 -type l -print",
     "link-packages": "./scripts/link-packages.sh",
-    "unlink-packages": "find node_modules node_modules/@* -depth 1 -type l -print | awk -F/ '{ printf \"%s/%s\\n\",$2,$3; }' | xargs yarn unlink && yarn install --force",
+    "unlink-packages": "find node_modules node_modules/@* -maxdepth 1 -type l -print | awk -F/ '{ printf \"%s/%s\\n\",$2,$3; }' | xargs yarn unlink && yarn install --force",
     "build": "NODE_OPTIONS=--max-old-space-size=4096 IMAGE_INLINE_SIZE_LIMIT=0 INLINE_RUNTIME_CHUNK=false DISABLE_ESLINT_PLUGIN=true react-app-rewired build && node headers.js && ./scripts/sha256sums.sh && ./scripts/verifyWebpackHashes.sh",
     "dev": "NODE_OPTIONS=--max-old-space-size=4096 ESLINT_NO_DEV_ERRORS=true TSC_COMPILE_ON_ERROR=true IMAGE_INLINE_SIZE_LIMIT=0 INLINE_RUNTIME_CHUNK=false react-app-rewired start",
     "dev:silent": "NODE_OPTIONS=--max-old-space-size=4096 ESLINT_NO_DEV_ERRORS=true TSC_COMPILE_ON_ERROR=true IMAGE_INLINE_SIZE_LIMIT=0 INLINE_RUNTIME_CHUNK=false BROWSER=none react-app-rewired start",


### PR DESCRIPTION
## Description

Fixed script to link and to unlink packages. I work with **Ubuntu 20.04** and **zsh**. `find` command uses `-maxdepth` to set the max depth of folders. `depth` does not accept parameters.

From `man find`:

```shell
	Global options
              Global  options affect the operation of tests and actions speci‐
              fied on any part of the command line.  Global options always re‐
              turn  true.   The  -depth option for example makes find traverse
              the file system in a depth-first order.

	[...]

    -maxdepth levels
              Descend at most levels (a non-negative integer) levels of directories below the starting-points.  -maxdepth 0 means only apply the tests and actions to the starting-points themselves.
```

## Notice

Before submitting a pull request, please make sure you have answered the following:

- [x] Have you followed the guidelines in our [Contributing]('https://github.com/shapeshift/web/CONTRIBUTING.md) guide?
- [x] Have you checked to ensure there aren't other open [Pull Requests](https://github.com/shapeshift/web/pulls) for the same update/change?
- [x] Do all new and existing tests pass? Does the linter pass?

## Pull Request Type

- [ ] :bug: Bug fix (Non-breaking Change: Fixes an issue)
- [x] :hammer_and_wrench: Chore (Non-breaking Change: Doc updates, pkg upgrades, typos, etc..)
- [ ] :nail_care: New Feature (Breaking/Non-breaking Change)

## Issue (if applicable)

NA

## Testing

Before the fix:

```shell
❯ yarn link-packages
yarn run v1.22.17
$ ./scripts/link-packages.sh
success Using linked package for "@shapeshiftoss/asset-service".
success Using linked package for "@shapeshiftoss/caip".
success Using linked package for "@shapeshiftoss/chain-adapters".
success Using linked package for "@shapeshiftoss/market-service".
success Using linked package for "@shapeshiftoss/swapper".
success Using linked package for "@shapeshiftoss/types".
success Using linked package for "@shapeshiftoss/unchained-client".
success Using linked package for "@shapeshiftoss/unchained-tx-parser".
Done in 0.27s.

❯ yarn show-linked-packages
yarn run v1.22.17
$ find node_modules node_modules/@* -depth 1 -type l -print
find: paths must precede expression: `1'
error Command failed with exit code 1.
info Visit https://yarnpkg.com/en/docs/cli/run for documentation about this command.
```

After the fix:

```shell
❯ yarn show-linked-packages
yarn run v1.22.17
$ find node_modules node_modules/@* -maxdepth 1 -type l -print
node_modules/@shapeshiftoss/caip
node_modules/@shapeshiftoss/asset-service
node_modules/@shapeshiftoss/swapper
node_modules/@shapeshiftoss/chain-adapters
node_modules/@shapeshiftoss/types
node_modules/@shapeshiftoss/unchained-client
node_modules/@shapeshiftoss/market-service
node_modules/@shapeshiftoss/unchained-tx-parser
Done in 0.05s.
```

## Screenshots (if applicable)

NA