### PR TITLE
fix: fixed change in text for yearn modal

### DIFF
--- a/src/assets/translations/messages-en.json
+++ b/src/assets/translations/messages-en.json
@@ -302,6 +302,7 @@
       "estimatedGas": "Estimated Gas Fee",
       "gasUsed": "Total Gas Fee",
       "continue": "View Transaction",
+      "position": "View Position",
       "viewAsset": "View Asset",
       "close": "Close"
     },

--- a/src/features/earn/providers/yearn/components/YearnManager/Deposit/YearnDeposit.tsx
+++ b/src/features/earn/providers/yearn/components/YearnManager/Deposit/YearnDeposit.tsx
@@ -499,7 +499,7 @@ export const YearnDeposit = ({ api }: YearnDepositProps) => {
             loading={state.loading}
             statusText={statusText}
             statusIcon={statusIcon}
-            continueText='modals.status.continue'
+            continueText='modals.status.position'
             closeText='modals.status.close'
             assets={[
               {

--- a/src/features/earn/providers/yearn/components/YearnManager/Withdraw/YearnWithdraw.tsx
+++ b/src/features/earn/providers/yearn/components/YearnManager/Withdraw/YearnWithdraw.tsx
@@ -326,7 +326,7 @@ export const YearnWithdraw = ({ api }: YearnWithdrawProps) => {
             onClose={handleCancel}
             onContinue={handleViewPosition}
             loading={state.loading}
-            continueText='modals.status.continue'
+            continueText='modals.status.position'
             closeText='modals.status.close'
             statusText={statusText}
             statusIcon={statusIcon}


### PR DESCRIPTION
## Description

View Position was changed to View Transaction. For most txs, this may make sense, but for yearn deposits and withdraws, we want to show View Position

## Notice

Before submitting a pull request, please make sure you have answered the following:

- [x] Have you followed the guidelines in our [Contributing]('https://github.com/shapeshift/web/CONTRIBUTING.md) guide?
- [x] Have you checked to ensure there aren't other open [Pull Requests](https://github.com/shapeshift/web/pulls) for the same update/change?
- [x] Do all new and existing tests pass? Does the linter pass?

## Pull Request Type

- [x] :bug: Bug fix (Non-breaking Change: Fixes an issue)
- [ ] :hammer_and_wrench: Chore (Non-breaking Change: Doc updates, pkg upgrades, typos, etc..)
- [ ] :nail_care: New Feature (Breaking/Non-breaking Change)

## Issue (if applicable)

No ticket.

## Testing

Please outline all testing steps

1. After depositing or withdrawing from a yearn vault, the continue button in the modal should read "View Position" and should take you to the yearn overview page.

## Screenshots (if applicable)
