### PR TITLE
fix: aggregate asset balance across account types correctly

### DIFF
--- a/src/state/slices/portfolioSlice/portfolioSlice.test.ts
+++ b/src/state/slices/portfolioSlice/portfolioSlice.test.ts
@@ -55,7 +55,7 @@ const ethAccount1 = {
 }
 
 const btcAccount = {
-  balance: '27803816548287370',
+  balance: '1010',
   caip2: btcCaip2,
   caip19: btcCaip19,
   chain: ChainTypes.Bitcoin,

--- a/src/state/slices/portfolioSlice/portfolioSlice.ts
+++ b/src/state/slices/portfolioSlice/portfolioSlice.ts
@@ -2,6 +2,7 @@ import { createSelector, createSlice } from '@reduxjs/toolkit'
 import { createApi, fetchBaseQuery } from '@reduxjs/toolkit/query/react'
 import { CAIP2, caip2, CAIP10, caip10, CAIP19 } from '@shapeshiftoss/caip'
 import { Asset, chainAdapters, ChainTypes, UtxoAccountType } from '@shapeshiftoss/types'
+import { mergeWith } from 'lodash'
 import cloneDeep from 'lodash/cloneDeep'
 import isEmpty from 'lodash/isEmpty'
 import toLower from 'lodash/toLower'
@@ -99,6 +100,15 @@ const initialState: Portfolio = {
   }
 }
 
+// for assetBalances, they're aggregated across all accounts, so we need to
+// upsert and sum the balances by id
+// https://lodash.com/docs/4.17.15#mergeWith
+const upsertAndSum = (dest: string, src: string) => {
+  // if we have an existing balance for this asset, add to it
+  if (dest) return bnOrZero(dest).plus(bnOrZero(src)).toString()
+  // returning undefined uses default merge function, i.e. upsert
+}
+
 export const portfolio = createSlice({
   name: 'portfolio',
   initialState,
@@ -109,7 +119,13 @@ export const portfolio = createSlice({
       state.accounts.byId = { ...state.accounts.byId, ...payload.accounts.byId }
       const accountIds = Array.from(new Set([...state.accounts.ids, ...payload.accounts.ids]))
       state.accounts.ids = accountIds
-      state.assetBalances.byId = { ...state.assetBalances.byId, ...payload.assetBalances.byId }
+
+      state.assetBalances.byId = mergeWith(
+        state.assetBalances.byId,
+        payload.assetBalances.byId,
+        upsertAndSum
+      )
+
       state.accountBalances.byId = {
         ...state.accountBalances.byId,
         ...payload.accountBalances.byId
@@ -188,11 +204,11 @@ export const accountToPortfolio: AccountToPortfolio = args => {
         // Since btc the pubkeys (address) are base58Check encoded, we don't want to lowercase them and put them in state
         const accountSpecifier = `${caip2}:${pubkey}`
         const addresses = btcAccount.chainSpecific.addresses ?? []
-        if (addresses.length) {
-          portfolio.assetBalances.ids.push(caip19)
-          portfolio.accountBalances.ids.push(accountSpecifier)
-          portfolio.accountSpecifiers.ids.push(accountSpecifier)
-        }
+
+        portfolio.assetBalances.ids.push(caip19)
+        portfolio.accountBalances.ids.push(accountSpecifier)
+        portfolio.accountSpecifiers.ids.push(accountSpecifier)
+
         addresses.forEach(({ pubkey, balance }) => {
           // For tx history, we need to have CAIP10's of addresses that may have 0 balances
           // for accountSpecifier to CAIP10 mapping
@@ -546,6 +562,7 @@ export const selectFeeAssetIdByAccountId = (accountId: AccountSpecifier) => {
 
   return caip2toCaip19[caip2]
 }
+
 export const selectAccountIdsByAssetId = createSelector(
   selectPortfolioAccounts,
   selectAssetIdParam,


### PR DESCRIPTION
## Description

- fixes aggregate asset balances by upserting and summing in the portfolio reducer, previously the last account to come in would stomp on the previous asset balance
- simplifies logic in account to portfolio mapping for bitcoin, pulling account balances from top level of responses rather than aggregating address balances

## Notice

Before submitting a pull request, please make sure you have answered the following:

- [x] Have you followed the guidelines in our [Contributing]('https://github.com/shapeshift/web/CONTRIBUTING.md) guide?
- [x] Have you checked to ensure there aren't other open [Pull Requests](https://github.com/shapeshift/web/pulls) for the same update/change?
- [x] Do all new and existing tests pass? Does the linter pass?

## Pull Request Type

- [x] :bug: Bug fix (Non-breaking Change: Fixes an issue)
- [ ] :hammer_and_wrench: Chore (Non-breaking Change: Doc updates, pkg upgrades, typos, etc..)
- [ ] :nail_care: New Feature (Breaking/Non-breaking Change)

## Issue (if applicable)

#730

## Testing

Please outline all testing steps

1. have a bitcoin wallet with balances across multiple account types, i.e. legacy/segwit/segwit native
2. the asset balance on the dashboard should be the sum of all account types
3. verify against beta.shapeshift.com or another wallet

## Screenshots (if applicable)

n/a