### PR TITLE
fix: cannot update a component console warning

### DIFF
--- a/src/components/AssetHeader/AssetHeader.tsx
+++ b/src/components/AssetHeader/AssetHeader.tsx
@@ -173,7 +173,7 @@ export const AssetHeader: React.FC<AssetHeaderProps> = ({ assetId, accountId }) 
           </Box>
         </Box>
       </Card.Body>
-      {view === View.Balance ? (
+      <Box style={{ display: view === View.Balance ? 'block' : 'none' }}>
         <BalanceChart
           accountIds={accountIds}
           assetIds={assetIds}
@@ -181,14 +181,15 @@ export const AssetHeader: React.FC<AssetHeaderProps> = ({ assetId, accountId }) 
           percentChange={percentChange}
           setPercentChange={setPercentChange}
         />
-      ) : (
+      </Box>
+      <Box style={{ display: view === View.Price ? 'block' : 'none' }}>
         <PriceChart
           assetId={assetId}
           timeframe={timeframe}
           percentChange={percentChange}
           setPercentChange={setPercentChange}
         />
-      )}
+      </Box>
       {!isLargerThanMd && (
         <Skeleton isLoaded={isLoaded} textAlign='center'>
           <TimeControls

--- a/src/components/AssetHeader/AssetHeader.tsx
+++ b/src/components/AssetHeader/AssetHeader.tsx
@@ -173,6 +173,7 @@ export const AssetHeader: React.FC<AssetHeaderProps> = ({ assetId, accountId }) 
           </Box>
         </Box>
       </Card.Body>
+      {/* If the Child component call a function update state of Parent Compnent in UseEffect,the Child Component should avaiable on DOM */}
       <Box style={{ display: view === View.Balance ? 'block' : 'none' }}>
         <BalanceChart
           accountIds={accountIds}


### PR DESCRIPTION
**Component Change** : 
AssetHeader Component 
**Problem**: 
when Select **Price** to **Balance** and vice versa.We got error Warning: `Cannot update a component (`BalanceChart`) while rendering a different component (`AssetHeader`). To locate the bad setState() call inside `AssetHeader`, follow the stack trace as described in https://reactjs.org/link/setstate-in-render at AssetHeader `
**Root Cause**
The problem is when BalanceChart component queues an update in AssetHeader component, while the AssetHeader is rendering.
Explain when you select **Balance** the **BalanceChart** is render but during render **BalanceChart** call the function **setPercentChange** for update **percentChange** and then AssetHeader is re-render and BalanceChart update when
percentChange prop update. 
## Description
I add a wrap <Box> with display style block or none for each BalanceChart and PriceChart.
## Notice

Before submitting a pull request, please make sure you have answered the following:

- [x] Have you followed the guidelines in our [Contributing]('https://github.com/shapeshift/web/CONTRIBUTING.md) guide?
- [x] Have you checked to ensure there aren't other open [Pull Requests](https://github.com/shapeshift/web/pulls) for the same update/change?
- [x] Do all new and existing tests pass? Does the linter pass?

## Pull Request Type

- [x] :bug: Bug fix (Non-breaking Change: Fixes an issue)
- [ ] :hammer_and_wrench: Chore (Non-breaking Change: Doc updates, pkg upgrades, typos, etc..)
- [ ] :nail_care: New Feature (Breaking/Non-breaking Change)

## Issue (if applicable)

If applicable, please link to the github issue and put `closes #XXXX` in your comment to auto-close the issue that your PR fixes.

## Testing

Please outline all testing steps

1. Pull branch locally and run `yarn` to install new deps
2. etc...

## Screenshots (if applicable)
![Screen Shot 2022-01-15 at 01 49 11](https://user-images.githubusercontent.com/45158598/149573131-eb0452e1-e117-4ace-944b-2fe7a53e72b7.png)

