### PR TITLE
fix: sort txHistory when using byAccount and byAsset

### DIFF
--- a/src/hooks/useBalanceChartData/useBalanceChartData.test.ts
+++ b/src/hooks/useBalanceChartData/useBalanceChartData.test.ts
@@ -1,6 +1,6 @@
 import { HistoryTimeframe } from '@shapeshiftoss/types'
 import { ethereum, fox } from 'test/mocks/assets'
-import { FOXSend, testTxs } from 'test/mocks/txs'
+import { ethereumTransactions, FOXSend } from 'test/mocks/txs'
 import { bn } from 'lib/bignumber/bignumber'
 import { PriceHistoryData } from 'state/slices/marketDataSlice/marketDataSlice'
 import { PortfolioAssets } from 'state/slices/portfolioSlice/portfolioSlice'
@@ -61,10 +61,7 @@ describe('bucketTxs', () => {
 
     const bucketedTxs = bucketTxs(txs, buckets)
 
-    const totalTxs = bucketedTxs.reduce<number>(
-      (acc, bucket: Bucket) => (acc += bucket.txs.length),
-      0
-    )
+    const totalTxs = bucketedTxs.reduce<number>((acc, bucket: Bucket) => acc + bucket.txs.length, 0)
 
     // if this non null assertion is false we fail anyway
     const expectedBucket = bucketedTxs.find(bucket => bucket.txs.length)!
@@ -120,7 +117,7 @@ describe('calculateBucketPrices', () => {
   })
 
   it('has zero balance 1 year back', () => {
-    const txs = testTxs
+    const txs = [...ethereumTransactions]
     const balances = {
       [ethCaip19]: '52430152924656054'
     }

--- a/src/state/slices/txHistorySlice/txHistorySlice.ts
+++ b/src/state/slices/txHistorySlice/txHistorySlice.ts
@@ -7,11 +7,10 @@ import last from 'lodash/last'
 import orderBy from 'lodash/orderBy'
 import values from 'lodash/values'
 import { createSelector } from 'reselect'
-import { upsertArray } from 'lib/utils'
 import { ReduxState } from 'state/reducer'
 import { AccountSpecifier } from 'state/slices/portfolioSlice/portfolioSlice'
 
-import { getRelatedAssetIds } from './utils'
+import { addToIndex, getRelatedAssetIds } from './utils'
 
 type TxId = string
 export type Tx = chainAdapters.SubscribeTxsMessage<ChainTypes> & { accountType?: UtxoAccountType }
@@ -92,15 +91,17 @@ const updateOrInsert = (txHistory: TxHistory, tx: Tx, accountSpecifier: string) 
   // for a given tx, find all the related assetIds, and keep an index of
   // txids related to each asset id
   getRelatedAssetIds(tx).forEach(relatedAssetId => {
-    txHistory.byAssetId[relatedAssetId] = upsertArray(
-      txHistory.byAssetId[relatedAssetId] ?? [],
+    txHistory.byAssetId[relatedAssetId] = addToIndex(
+      txHistory.ids,
+      txHistory.byAssetId[relatedAssetId],
       tx.txid
     )
   })
 
   // index the tx by the account that it belongs to
-  txHistory.byAccountId[accountSpecifier] = upsertArray(
-    txHistory.byAccountId[accountSpecifier] ?? [],
+  txHistory.byAccountId[accountSpecifier] = addToIndex(
+    txHistory.ids,
+    txHistory.byAccountId[accountSpecifier],
     tx.txid
   )
 

--- a/src/state/slices/txHistorySlice/utils.test.ts
+++ b/src/state/slices/txHistorySlice/utils.test.ts
@@ -1,44 +1,64 @@
 import { BtcSend, EthReceive, EthSend, FOXSend, yearnVaultDeposit } from 'test/mocks/txs'
 
-import { getRelatedAssetIds } from './utils'
+import { addToIndex, getRelatedAssetIds } from './utils'
 
-describe('getRelatedAssetIds', () => {
-  const ethCAIP19 = 'eip155:1/slip44:60'
-  const btcCAIP19 = 'bip122:000000000019d6689c085ae165831e93/slip44:0'
-  const foxCAIP19 = 'eip155:1/erc20:0xc770eefad204b5180df6a14ee197d99d808ee52d'
-  const usdcCAIP19 = 'eip155:1/erc20:0xa0b86991c6218b36c1d19d4a2e9eb0ce3606eb48'
-  const yvusdcCAIP19 = 'eip155:1/erc20:0x5f18c75abdae578b483e5f43f12a39cf75b973a9'
+describe('txHistorySlice:utils', () => {
+  describe('getRelatedAssetIds', () => {
+    const ethCAIP19 = 'eip155:1/slip44:60'
+    const btcCAIP19 = 'bip122:000000000019d6689c085ae165831e93/slip44:0'
+    const foxCAIP19 = 'eip155:1/erc20:0xc770eefad204b5180df6a14ee197d99d808ee52d'
+    const usdcCAIP19 = 'eip155:1/erc20:0xa0b86991c6218b36c1d19d4a2e9eb0ce3606eb48'
+    const yvusdcCAIP19 = 'eip155:1/erc20:0x5f18c75abdae578b483e5f43f12a39cf75b973a9'
 
-  it('can get related asset ids from eth send', () => {
-    const relatedAssetIds = getRelatedAssetIds(EthSend)
-    expect(relatedAssetIds.length).toEqual(1)
-    expect(relatedAssetIds.includes(ethCAIP19)).toBeTruthy()
+    it('can get related asset ids from eth send', () => {
+      const relatedAssetIds = getRelatedAssetIds(EthSend)
+      expect(relatedAssetIds.length).toEqual(1)
+      expect(relatedAssetIds.includes(ethCAIP19)).toBeTruthy()
+    })
+
+    it('can get related asset ids from btc send', () => {
+      const relatedAssetIds = getRelatedAssetIds(BtcSend)
+      expect(relatedAssetIds.length).toEqual(1)
+      expect(relatedAssetIds.includes(btcCAIP19)).toBeTruthy()
+    })
+
+    it('can get related asset ids from eth receive', () => {
+      const relatedAssetIds = getRelatedAssetIds(EthReceive)
+      expect(relatedAssetIds.length).toEqual(1)
+      expect(relatedAssetIds.includes(ethCAIP19)).toBeTruthy()
+    })
+
+    it('can get related asset ids from fox send', () => {
+      const relatedAssetIds = getRelatedAssetIds(FOXSend)
+      expect(relatedAssetIds.length).toEqual(2)
+      expect(relatedAssetIds.includes(foxCAIP19)).toBeTruthy()
+      expect(relatedAssetIds.includes(ethCAIP19)).toBeTruthy()
+    })
+
+    it('can get related asset ids from yearn vault deposit', () => {
+      const relatedAssetIds = getRelatedAssetIds(yearnVaultDeposit)
+      expect(relatedAssetIds.length).toEqual(3)
+      expect(relatedAssetIds.includes(ethCAIP19)).toBeTruthy()
+      expect(relatedAssetIds.includes(usdcCAIP19)).toBeTruthy()
+      expect(relatedAssetIds.includes(yvusdcCAIP19)).toBeTruthy()
+    })
   })
 
-  it('can get related asset ids from btc send', () => {
-    const relatedAssetIds = getRelatedAssetIds(BtcSend)
-    expect(relatedAssetIds.length).toEqual(1)
-    expect(relatedAssetIds.includes(btcCAIP19)).toBeTruthy()
-  })
+  describe('addToIndex', () => {
+    it('should add a new item to an empty index', () => {
+      expect(addToIndex([1, 2], [], 2)).toStrictEqual([2])
+    })
 
-  it('can get related asset ids from eth receive', () => {
-    const relatedAssetIds = getRelatedAssetIds(EthReceive)
-    expect(relatedAssetIds.length).toEqual(1)
-    expect(relatedAssetIds.includes(ethCAIP19)).toBeTruthy()
-  })
+    it('should add a new item to an existing index', () => {
+      expect(addToIndex([1, 2], [1], 2)).toStrictEqual([1, 2])
+    })
 
-  it('can get related asset ids from fox send', () => {
-    const relatedAssetIds = getRelatedAssetIds(FOXSend)
-    expect(relatedAssetIds.length).toEqual(2)
-    expect(relatedAssetIds.includes(foxCAIP19)).toBeTruthy()
-    expect(relatedAssetIds.includes(ethCAIP19)).toBeTruthy()
-  })
+    it('should not add a new item if it does not exist in the parent', () => {
+      expect(addToIndex([1, 2], [1], 3)).toStrictEqual([1])
+    })
 
-  it('can get related asset ids from yearn vault deposit', () => {
-    const relatedAssetIds = getRelatedAssetIds(yearnVaultDeposit)
-    expect(relatedAssetIds.length).toEqual(3)
-    expect(relatedAssetIds.includes(ethCAIP19)).toBeTruthy()
-    expect(relatedAssetIds.includes(usdcCAIP19)).toBeTruthy()
-    expect(relatedAssetIds.includes(yvusdcCAIP19)).toBeTruthy()
+    it('should maintain the sort order from the parent', () => {
+      expect(addToIndex([2, 1, 3], [3], 1)).toStrictEqual([1, 3])
+    })
   })
 })

--- a/src/state/slices/txHistorySlice/utils.ts
+++ b/src/state/slices/txHistorySlice/utils.ts
@@ -1,4 +1,6 @@
 import { CAIP19 } from '@shapeshiftoss/caip'
+import intersection from 'lodash/intersection'
+import union from 'lodash/union'
 
 import { Tx } from './txHistorySlice'
 
@@ -11,3 +13,13 @@ export const getRelatedAssetIds = (tx: Tx): CAIP19[] => {
   tx.transfers.forEach(transfer => relatedAssets.add(transfer.caip19))
   return Array.from(relatedAssets)
 }
+
+/**
+ * Add a new item into an index
+ *
+ * @param parentIndex - The parent index holds ALL indexed values
+ * @param childIndex - The child index holds SOME of the values in the parent index
+ * @param newItem - The new item to add to the CHILD index
+ */
+export const addToIndex = <T>(parentIndex: T[], childIndex: T[], newItem: T): T[] =>
+  intersection(parentIndex, union(childIndex, [newItem]))

--- a/src/test/mocks/txs.ts
+++ b/src/test/mocks/txs.ts
@@ -106,8 +106,8 @@ export const FOXSend: Tx = {
 const test1: Tx = {
   address: '0xA44C286BA83Bb771cd0107B2c1Df678435Bd1535',
   blockHash: '0xc2f42f9dfbeb1c600ecd13dbcd624af1ea70631e13ad4d972b83a2a7c805360c',
-  blockHeight: 13636644,
-  blockTime: 1637201795,
+  blockHeight: 1,
+  blockTime: 1637201790,
   confirmations: 29807,
   caip2: 'eip155:1',
   txid: '0x5b25d67e43ba2cdfcb584c8069330874e838607d06b9dc64bf174547ca11e171',
@@ -131,8 +131,8 @@ const test1: Tx = {
 const test2: Tx = {
   address: '0xA44C286BA83Bb771cd0107B2c1Df678435Bd1535',
   blockHash: '0x2761caf9c664bb0dc9b59b18f24e7a29974c867b1181cbcefd415f881801a16e',
-  blockHeight: 13508504,
-  blockTime: 1635461430,
+  blockHeight: 2,
+  blockTime: 1637201791,
   confirmations: 157947,
   caip2: 'eip155:1',
   txid: '0x16ed49d739d0b5f56a33675a69d4f0ec85b6abdcbba0213b6242fde8646d28c5',
@@ -156,8 +156,8 @@ const test2: Tx = {
 const test3: Tx = {
   address: '0xA44C286BA83Bb771cd0107B2c1Df678435Bd1535',
   blockHash: '0xe594af3d97c1ee001ab72a16671a0e05edf1ae50201eb6645dd4e5fd406e48a7',
-  blockHeight: 12730373,
-  blockTime: 1624989066,
+  blockHeight: 3,
+  blockTime: 1637201792,
   confirmations: 936078,
   caip2: 'eip155:1',
   txid: '0x62b16b9ca0526bea116917c4a563f6e47d4b8108adde2888a1d76d14fd261348',
@@ -177,8 +177,8 @@ const test3: Tx = {
 const test4: Tx = {
   address: '0xA44C286BA83Bb771cd0107B2c1Df678435Bd1535',
   blockHash: '0x4e427bef8984df1c1cffcd88bbc4b3f5a62c51a3f0a315cf2c49d8783d0c7603',
-  blockHeight: 12279659,
-  blockTime: 1618955989,
+  blockHeight: 4,
+  blockTime: 1637201793,
   confirmations: 1386792,
   caip2: 'eip155:1',
   txid: '0x0c8259d5c2de8266c15bc799336dee77d7ecea9987bf9d7425a51a16d49e0647',
@@ -202,8 +202,8 @@ const test4: Tx = {
 const test5: Tx = {
   address: '0xA44C286BA83Bb771cd0107B2c1Df678435Bd1535',
   blockHash: '0x238168ad84a353e0245399f779ee20ef352ce303ef78681c70c5c269574375e9',
-  blockHeight: 11635278,
-  blockTime: 1610390199,
+  blockHeight: 5,
+  blockTime: 1637201794,
   confirmations: 2031173,
   caip2: 'eip155:1',
   txid: '0x7c7ba2815df596209c99fb79776f6935bd6d17f3ad5b3500d8705f8d01e2d79e',
@@ -223,8 +223,8 @@ const test5: Tx = {
 const test6: Tx = {
   address: '0xA44C286BA83Bb771cd0107B2c1Df678435Bd1535',
   blockHash: '0xe6c0ce54e78c22c2297fe8d058ba3cf944b35185016a2047974532cfe0627d17',
-  blockHeight: 11615644,
-  blockTime: 1610129683,
+  blockHeight: 6,
+  blockTime: 1637201795,
   confirmations: 2050807,
   caip2: 'eip155:1',
   txid: '0x88bd4c0860a141b7d7e3675adfb50900a4e5ff5a5e8c7b80f66249b67f582872',
@@ -245,8 +245,8 @@ const test6: Tx = {
 const test7: Tx = {
   address: '0xA44C286BA83Bb771cd0107B2c1Df678435Bd1535',
   blockHash: '0x9f24e77cfe543625ca98539f73d3f2a60d475b715a759bb5dc43334d0fa660dd',
-  blockHeight: 12826450,
-  blockTime: 1626283441,
+  blockHeight: 7,
+  blockTime: 1637201796,
   confirmations: 840458,
   caip2: 'eip155:1',
   txid: '0xf22e08bd1cd77ac589a0b7b4929ff00b3c7cac4f8b5b9e95fe30ef88caf75666',
@@ -306,4 +306,7 @@ export const yearnVaultDeposit: Tx = {
   txid: '0xded9a55622504979d7980b401d3b5fab234c0b64ee779f076df2023929b0f083'
 }
 
-export const testTxs = [test1, test2, test3, test4, test5, test6, test7]
+/**
+ * These are in block/blockTime order
+ */
+export const ethereumTransactions = [test1, test2, test3, test4, test5, test6, test7]


### PR DESCRIPTION
## Description

When using `txHistory.byAccountId` and `txHistory.byAssetId`, the return values should be sorted by block time

## Notice

Before submitting a pull request, please make sure you have answered the following:

- [X] Have you followed the guidelines in our [Contributing]('https://github.com/shapeshift/web/CONTRIBUTING.md) guide?
- [X] Have you checked to ensure there aren't other open [Pull Requests](https://github.com/shapeshift/web/pulls) for the same update/change?
- [X] Do all new and existing tests pass? Does the linter pass?

## Pull Request Type

- [X] :bug: Bug fix (Non-breaking Change: Fixes an issue)
- [ ] :hammer_and_wrench: Chore (Non-breaking Change: Doc updates, pkg upgrades, typos, etc..)
- [ ] :nail_care: New Feature (Breaking/Non-breaking Change)

## Issue (if applicable)

closes #729 
