### PR TITLE
fix: fix infinite render clicking asset list

### DIFF
--- a/src/components/AssetHeader/AssetHeader.tsx
+++ b/src/components/AssetHeader/AssetHeader.tsx
@@ -27,10 +27,12 @@ import { PriceChart } from 'components/PriceChart/PriceChart'
 import { SanitizedHtml } from 'components/SanitizedHtml/SanitizedHtml'
 import { RawText, Text } from 'components/Text'
 import { useWallet } from 'context/WalletProvider/WalletProvider'
-import { useFetchAssetDescription } from 'hooks/useFetchAssetDescription/useFetchAssetDescription'
 import { useLocaleFormatter } from 'hooks/useLocaleFormatter/useLocaleFormatter'
 import { useWalletSupportsChain } from 'hooks/useWalletSupportsChain/useWalletSupportsChain'
-import { selectAssetByCAIP19 } from 'state/slices/assetsSlice/assetsSlice'
+import {
+  selectAssetByCAIP19,
+  useGetAssetDescriptionQuery
+} from 'state/slices/assetsSlice/assetsSlice'
 import { selectMarketDataById } from 'state/slices/marketDataSlice/marketDataSlice'
 import {
   AccountSpecifier,
@@ -66,7 +68,7 @@ export const AssetHeader: React.FC<AssetHeaderProps> = ({ assetId, accountId }) 
   const marketData = useAppSelector(state => selectMarketDataById(state, assetId))
   const isLoaded = !!marketData
   const { name, symbol, description, icon } = asset || {}
-  useFetchAssetDescription(assetId)
+  useGetAssetDescriptionQuery(assetId)
   const { price } = marketData || {}
   const {
     number: { toFiat }
@@ -108,7 +110,7 @@ export const AssetHeader: React.FC<AssetHeaderProps> = ({ assetId, accountId }) 
           </Box>
         </Flex>
         {walletSupportsChain ? (
-          <AssetActions isLoaded={isLoaded} assetId={asset.caip19} accountId={accountId} />
+          <AssetActions isLoaded={isLoaded} assetId={assetId} accountId={accountId} />
         ) : null}
       </Card.Header>
       {walletSupportsChain ? <SegwitSelectCard chain={asset.chain} /> : null}

--- a/src/hooks/useFetchAssetDescription/useFetchAssetDescription.ts
+++ b/src/hooks/useFetchAssetDescription/useFetchAssetDescription.ts
@@ -1,8 +1,0 @@
-import { CAIP19 } from '@shapeshiftoss/caip'
-import { assetApi } from 'state/slices/assetsSlice/assetsSlice'
-import { useAppDispatch } from 'state/store'
-
-export const useFetchAssetDescription = (assetId: CAIP19) => {
-  const dispatch = useAppDispatch()
-  dispatch(assetApi.endpoints.getAssetDescription.initiate(assetId))
-}

--- a/src/pages/Accounts/Accounts.tsx
+++ b/src/pages/Accounts/Accounts.tsx
@@ -24,7 +24,7 @@ export const Accounts = () => {
             <Text translation='accounts.accounts' />
           </Heading>
           {accountIds.map(accountId => (
-            <AccountRowWithTokens accountId={accountId} />
+            <AccountRowWithTokens accountId={accountId} key={accountId} />
           ))}
         </Stack>
       </Flex>

--- a/src/state/slices/assetsSlice/assetsSlice.ts
+++ b/src/state/slices/assetsSlice/assetsSlice.ts
@@ -98,7 +98,7 @@ export const assetApi = createApi({
   })
 })
 
-export const { useGetAssetsQuery } = assetApi
+export const { useGetAssetsQuery, useGetAssetDescriptionQuery } = assetApi
 
 export const selectAssetByCAIP19 = createSelector(
   (state: ReduxState) => state.assets.byId,


### PR DESCRIPTION
## Description

on clicking an asset from the left sidebar we'd infinitely dispatch fetching asset descriptions

this uses RTK query's fancy exported hooks to avoid an infinite render

also adds a key to stop react whinging

## Notice

Before submitting a pull request, please make sure you have answered the following:

- [x] Have you followed the guidelines in our [Contributing]('https://github.com/shapeshift/web/CONTRIBUTING.md) guide?
- [x] Have you checked to ensure there aren't other open [Pull Requests](https://github.com/shapeshift/web/pulls) for the same update/change?
- [x] Do all new and existing tests pass? Does the linter pass?

## Pull Request Type

- [x] :bug: Bug fix (Non-breaking Change: Fixes an issue)
- [ ] :hammer_and_wrench: Chore (Non-breaking Change: Doc updates, pkg upgrades, typos, etc..)
- [ ] :nail_care: New Feature (Breaking/Non-breaking Change)

## Issue (if applicable)

n/a

## Testing

1. click on assets from the *left sidebar*
2. asset should load without crashing app with a white screen

## Screenshots (if applicable)

n/a
