### PR TITLE
fix: use balance on accounts, price on assets, format balance correctly

### DIFF
--- a/src/components/AssetHeader/AssetHeader.tsx
+++ b/src/components/AssetHeader/AssetHeader.tsx
@@ -62,7 +62,7 @@ export const AssetHeader: React.FC<AssetHeaderProps> = ({ assetId, accountId }) 
   const [percentChange, setPercentChange] = useState(0)
   const [timeframe, setTimeframe] = useState(HistoryTimeframe.DAY)
   const [showDescription, setShowDescription] = useState(false)
-  const [view, setView] = useState(View.Price)
+  const [view, setView] = useState(accountId ? View.Balance : View.Price)
   const [isLargerThanMd] = useMediaQuery(`(min-width: ${breakpoints['md']})`)
   const asset = useAppSelector(state => selectAssetByCAIP19(state, assetId))
   const marketData = useAppSelector(state => selectMarketDataById(state, assetId))
@@ -87,7 +87,9 @@ export const AssetHeader: React.FC<AssetHeaderProps> = ({ assetId, accountId }) 
   const cryptoBalance = useAppSelector(state =>
     selectPortfolioCryptoHumanBalanceByAssetId(state, assetId)
   )
-  const totalBalance = useAppSelector(state => selectPortfolioFiatBalanceByAssetId(state, assetId))
+  const totalBalance = toFiat(
+    useAppSelector(state => selectPortfolioFiatBalanceByAssetId(state, assetId))
+  )
 
   return (
     <Card variant='footer-stub'>


### PR DESCRIPTION
## Description

use balance charts on account pages, price chart on asset pages by default

## Notice

Before submitting a pull request, please make sure you have answered the following:

- [x] Have you followed the guidelines in our [Contributing]('https://github.com/shapeshift/web/CONTRIBUTING.md) guide?
- [x] Have you checked to ensure there aren't other open [Pull Requests](https://github.com/shapeshift/web/pulls) for the same update/change?
- [x] Do all new and existing tests pass? Does the linter pass?

## Pull Request Type

- [x] :bug: Bug fix (Non-breaking Change: Fixes an issue)
- [ ] :hammer_and_wrench: Chore (Non-breaking Change: Doc updates, pkg upgrades, typos, etc..)
- [ ] :nail_care: New Feature (Breaking/Non-breaking Change)

## Issue (if applicable)

closes #762

## Testing

1. go to account page, should default to balance chart
2. go to asset page, should default to price chart

## Screenshots (if applicable)
