### PR TITLE
fix: fixes crash when opening eth receive

### DIFF
--- a/src/components/Modals/Receive/ReceiveInfo.tsx
+++ b/src/components/Modals/Receive/ReceiveInfo.tsx
@@ -28,7 +28,7 @@ import { Text } from 'components/Text'
 import { useChainAdapters } from 'context/ChainAdaptersProvider/ChainAdaptersProvider'
 import { useWallet } from 'context/WalletProvider/WalletProvider'
 import { AccountSpecifier } from 'state/slices/portfolioSlice/portfolioSlice'
-import { accountIdToUtxoparams } from 'state/slices/portfolioSlice/utils'
+import { accountIdToUtxoParams } from 'state/slices/portfolioSlice/utils'
 
 import { ReceiveRoutes } from './Receive'
 
@@ -48,7 +48,7 @@ export const ReceiveInfo = ({ asset, accountId }: ReceivePropsType) => {
   const { wallet } = state
   const chainAdapter = chainAdapterManager.byChain(chain)
 
-  const { utxoParams, accountType } = accountIdToUtxoparams(asset, accountId, 0)
+  const { utxoParams, accountType } = accountIdToUtxoParams(asset, accountId, 0)
 
   useEffect(() => {
     ;(async () => {
@@ -57,7 +57,7 @@ export const ReceiveInfo = ({ asset, accountId }: ReceivePropsType) => {
       setReceiveAddress(
         await chainAdapter.getAddress({
           wallet,
-          accountType: accountType,
+          accountType,
           ...accountParams
         })
       )
@@ -71,7 +71,7 @@ export const ReceiveInfo = ({ asset, accountId }: ReceivePropsType) => {
     const deviceAddress = await chainAdapter.getAddress({
       wallet,
       showOnDevice: true,
-      accountType: accountType,
+      accountType,
       ...accountParams
     })
 

--- a/src/components/Modals/Receive/ReceiveInfo.tsx
+++ b/src/components/Modals/Receive/ReceiveInfo.tsx
@@ -17,8 +17,7 @@ import {
   useColorModeValue,
   useToast
 } from '@chakra-ui/react'
-import { utxoAccountParams } from '@shapeshiftoss/chain-adapters'
-import { Asset, ChainTypes, UtxoAccountType } from '@shapeshiftoss/types'
+import { Asset } from '@shapeshiftoss/types'
 import { useEffect, useState } from 'react'
 import { useTranslate } from 'react-polyglot'
 import { RouteComponentProps, useHistory } from 'react-router-dom'
@@ -29,7 +28,7 @@ import { Text } from 'components/Text'
 import { useChainAdapters } from 'context/ChainAdaptersProvider/ChainAdaptersProvider'
 import { useWallet } from 'context/WalletProvider/WalletProvider'
 import { AccountSpecifier } from 'state/slices/portfolioSlice/portfolioSlice'
-import { accountIdToAccountType } from 'state/slices/portfolioSlice/utils'
+import { accountIdToUtxoparams } from 'state/slices/portfolioSlice/utils'
 
 import { ReceiveRoutes } from './Receive'
 
@@ -48,37 +47,31 @@ export const ReceiveInfo = ({ asset, accountId }: ReceivePropsType) => {
 
   const { wallet } = state
   const chainAdapter = chainAdapterManager.byChain(chain)
-  let accountType = ''
-  if (chain === ChainTypes.Bitcoin) {
-    accountType = accountIdToAccountType(accountId)
-  }
+
+  const { utxoParams, accountType } = accountIdToUtxoparams(asset, accountId, 0)
 
   useEffect(() => {
     ;(async () => {
       if (!(wallet && chainAdapter)) return
-      const accountParams = accountType
-        ? utxoAccountParams(asset, accountType as UtxoAccountType, 0)
-        : {}
+      const accountParams = utxoParams
       setReceiveAddress(
         await chainAdapter.getAddress({
           wallet,
-          accountType: accountType as UtxoAccountType,
+          accountType: accountType,
           ...accountParams
         })
       )
     })()
-  }, [setReceiveAddress, accountType, asset, wallet, chainAdapter])
+  }, [setReceiveAddress, accountType, asset, wallet, chainAdapter, utxoParams])
 
   const handleVerify = async () => {
-    const accountParams = accountType
-      ? utxoAccountParams(asset, accountType as UtxoAccountType, 0)
-      : {}
+    const accountParams = utxoParams
 
     if (!(wallet && chainAdapter && receiveAddress)) return
     const deviceAddress = await chainAdapter.getAddress({
       wallet,
       showOnDevice: true,
-      accountType: accountType as UtxoAccountType,
+      accountType: accountType,
       ...accountParams
     })
 

--- a/src/components/Modals/Receive/ReceiveInfo.tsx
+++ b/src/components/Modals/Receive/ReceiveInfo.tsx
@@ -18,7 +18,7 @@ import {
   useToast
 } from '@chakra-ui/react'
 import { utxoAccountParams } from '@shapeshiftoss/chain-adapters'
-import { Asset, UtxoAccountType } from '@shapeshiftoss/types'
+import { Asset, ChainTypes, UtxoAccountType } from '@shapeshiftoss/types'
 import { useEffect, useState } from 'react'
 import { useTranslate } from 'react-polyglot'
 import { RouteComponentProps, useHistory } from 'react-router-dom'
@@ -48,12 +48,17 @@ export const ReceiveInfo = ({ asset, accountId }: ReceivePropsType) => {
 
   const { wallet } = state
   const chainAdapter = chainAdapterManager.byChain(chain)
-  const accountType = accountIdToAccountType(accountId)
+  let accountType = ''
+  if (chain === ChainTypes.Bitcoin) {
+    accountType = accountIdToAccountType(accountId)
+  }
 
   useEffect(() => {
     ;(async () => {
       if (!(wallet && chainAdapter)) return
-      const accountParams = accountType ? utxoAccountParams(asset, accountType, 0) : {}
+      const accountParams = accountType
+        ? utxoAccountParams(asset, accountType as UtxoAccountType, 0)
+        : {}
       setReceiveAddress(
         await chainAdapter.getAddress({
           wallet,
@@ -65,13 +70,15 @@ export const ReceiveInfo = ({ asset, accountId }: ReceivePropsType) => {
   }, [setReceiveAddress, accountType, asset, wallet, chainAdapter])
 
   const handleVerify = async () => {
-    const accountParams = accountType ? utxoAccountParams(asset, accountType, 0) : {}
+    const accountParams = accountType
+      ? utxoAccountParams(asset, accountType as UtxoAccountType, 0)
+      : {}
 
     if (!(wallet && chainAdapter && receiveAddress)) return
     const deviceAddress = await chainAdapter.getAddress({
       wallet,
       showOnDevice: true,
-      accountType,
+      accountType: accountType as UtxoAccountType,
       ...accountParams
     })
 

--- a/src/state/slices/portfolioSlice/utils.ts
+++ b/src/state/slices/portfolioSlice/utils.ts
@@ -1,5 +1,6 @@
 import { CAIP2 } from '@shapeshiftoss/caip'
-import { UtxoAccountType } from '@shapeshiftoss/types'
+import { utxoAccountParams } from '@shapeshiftoss/chain-adapters'
+import { Asset, UtxoAccountType } from '@shapeshiftoss/types'
 import last from 'lodash/last'
 
 import { AccountSpecifier } from './portfolioSlice'
@@ -78,5 +79,26 @@ export const accountIdToAccountType = (accountId: AccountSpecifier): UtxoAccount
   if (pubkeyVariant?.startsWith('xpub')) return UtxoAccountType.P2pkh
   if (pubkeyVariant?.startsWith('ypub')) return UtxoAccountType.SegwitP2sh
   if (pubkeyVariant?.startsWith('zpub')) return UtxoAccountType.SegwitNative
-  throw new Error('useSendDetails: could not get accountType from accountId')
+  throw new Error('accountIdToAccountType: could not get accountType from accountId')
+}
+
+export const accountIdToUtxoparams = (
+  asset: Asset,
+  accountId: AccountSpecifier,
+  accountIndex: number
+) => {
+  try {
+    const utxoAccountType = accountIdToAccountType(accountId)
+    return {
+      utxoParams: utxoAccountParams(asset, utxoAccountType, accountIndex),
+      accountType: utxoAccountType
+    }
+  } catch (err) {
+    // For non-utxo coins we want to return an empty object, but accountIdToAccountType will throw
+    // so we need to catch.
+    return {
+      utxoParams: {},
+      accountType: null
+    }
+  }
 }

--- a/src/state/slices/portfolioSlice/utils.ts
+++ b/src/state/slices/portfolioSlice/utils.ts
@@ -82,7 +82,7 @@ export const accountIdToAccountType = (accountId: AccountSpecifier): UtxoAccount
   throw new Error('accountIdToAccountType: could not get accountType from accountId')
 }
 
-export const accountIdToUtxoparams = (
+export const accountIdToUtxoParams = (
   asset: Asset,
   accountId: AccountSpecifier,
   accountIndex: number
@@ -97,8 +97,7 @@ export const accountIdToUtxoparams = (
     // For non-utxo coins we want to return an empty object, but accountIdToAccountType will throw
     // so we need to catch.
     return {
-      utxoParams: {},
-      accountType: null
+      utxoParams: {}
     }
   }
 }


### PR DESCRIPTION
## Description

accountIdToAccountType throws an error if it can't find an account type, but ReceiveInfo.tsx also takes in eth assets, which don't have an accountType. So we need either to only run this function for BTC, or catch the error.

## Notice

Before submitting a pull request, please make sure you have answered the following:

- [x] Have you followed the guidelines in our [Contributing]('https://github.com/shapeshift/web/CONTRIBUTING.md) guide?
- [x] Have you checked to ensure there aren't other open [Pull Requests](https://github.com/shapeshift/web/pulls) for the same update/change?
- [x] Do all new and existing tests pass? Does the linter pass?

## Pull Request Type

- [x] :bug: Bug fix (Non-breaking Change: Fixes an issue)
- [ ] :hammer_and_wrench: Chore (Non-breaking Change: Doc updates, pkg upgrades, typos, etc..)
- [ ] :nail_care: New Feature (Breaking/Non-breaking Change)

## Issue (if applicable)

No ticket.

## Testing

Please outline all testing steps

1. Open ETH asset.
2. Click receive.
3. App should show your ETH address.

## Screenshots (if applicable)
