### PR TITLE
feat: tx ids by account id

### DIFF
--- a/src/components/TxHistory.tsx
+++ b/src/components/TxHistory.tsx
@@ -10,32 +10,36 @@ import { useWallet } from 'context/WalletProvider/WalletProvider'
 import { useInfiniteScroll } from 'hooks/useInfiniteScroll/useInfiniteScroll'
 import { useWalletSupportsChain } from 'hooks/useWalletSupportsChain/useWalletSupportsChain'
 import { selectAssetByCAIP19 } from 'state/slices/assetsSlice/assetsSlice'
-import { AccountSpecifier } from 'state/slices/portfolioSlice/portfolioSlice'
-import { selectAccountTypesByChain } from 'state/slices/preferencesSlice/preferencesSlice'
-import { selectTxIdsByAssetIdAccountType } from 'state/slices/txHistorySlice/txHistorySlice'
+import {
+  AccountSpecifier,
+  selectAccountIdsByAssetId
+} from 'state/slices/portfolioSlice/portfolioSlice'
+import { selectTxIdsByFilter } from 'state/slices/txHistorySlice/txHistorySlice'
 import { useAppSelector } from 'state/store'
 
-export const TxHistory = ({
-  assetId: caip19
-}: {
+type TxHistoryProps = {
   assetId: CAIP19
   accountId?: AccountSpecifier
-}) => {
+}
+
+export const TxHistory: React.FC<TxHistoryProps> = ({ assetId, accountId }) => {
   const translate = useTranslate()
   const {
     state: { wallet }
   } = useWallet()
 
-  const asset = useAppSelector(state => selectAssetByCAIP19(state, caip19))
+  const asset = useAppSelector(state => selectAssetByCAIP19(state, assetId))
+  const accountIds = useAppSelector(state => selectAccountIdsByAssetId(state, assetId))
+  const filter = useMemo(
+    // if we are passed an accountId, we're on an asset accoutn page, use that specifically.
+    // otherwise, we're on an asset page, use all accountIds related to this asset
+    () => ({ assetId, accountIds: accountId ? [accountId] : accountIds }),
+    [assetId, accountId, accountIds]
+  )
 
   const walletSupportsChain = useWalletSupportsChain({ asset, wallet })
-  const accountType = useAppSelector(state => selectAccountTypesByChain(state, asset.chain))
 
-  // TODO(0xdef1cafe): change this to use selectTxIdsByAssetId once we have
-  // the account -> address mapping in portfolio locked down
-  const txIds = useAppSelector(state =>
-    selectTxIdsByAssetIdAccountType(state, asset.caip19, accountType)
-  )
+  const txIds = useAppSelector(state => selectTxIdsByFilter(state, filter))
 
   const { next, data, hasMore } = useInfiniteScroll(txIds)
 

--- a/src/state/slices/preferencesSlice/preferencesSlice.ts
+++ b/src/state/slices/preferencesSlice/preferencesSlice.ts
@@ -1,4 +1,4 @@
-import { createSelector, createSlice } from '@reduxjs/toolkit'
+import { createSlice } from '@reduxjs/toolkit'
 import { ChainTypes, UtxoAccountType } from '@shapeshiftoss/types'
 import { ReduxState } from 'state/reducer'
 
@@ -33,8 +33,3 @@ export const preferences = createSlice({
 })
 
 export const selectAccountTypes = (state: ReduxState) => state.preferences.accountTypes
-export const selectAccountTypesByChain = createSelector(
-  selectAccountTypes,
-  (_state: ReduxState, chain: ChainTypes) => chain,
-  (accountTypes, chain) => accountTypes[chain]
-)

--- a/src/state/slices/txHistorySlice/txHistorySlice.ts
+++ b/src/state/slices/txHistorySlice/txHistorySlice.ts
@@ -2,7 +2,6 @@ import { createSlice } from '@reduxjs/toolkit'
 import { CAIP2, CAIP19 } from '@shapeshiftoss/caip'
 import { chainAdapters, ChainTypes, UtxoAccountType } from '@shapeshiftoss/types'
 import intersection from 'lodash/intersection'
-import isEmpty from 'lodash/isEmpty'
 import isEqual from 'lodash/isEqual'
 import last from 'lodash/last'
 import orderBy from 'lodash/orderBy'
@@ -171,7 +170,7 @@ export const selectTxsByAssetId = (state: ReduxState) => state.txHistory.byAsset
 
 const selectAssetIdParam = (_state: ReduxState, assetId: CAIP19) => assetId
 
-export const selectTxIdsByAssetId = createSelector(
+const selectTxIdsByAssetId = createSelector(
   selectTxsByAssetId,
   selectAssetIdParam,
   (txsByAssetId: TxIdByAssetId, assetId): string[] => txsByAssetId[assetId] ?? []
@@ -199,33 +198,6 @@ export const selectTxIdsByFilter = createSelector(
     const sorted = assetAccountsTxIds
     return sorted
   }
-)
-
-// TODO(0xdef1cafe): temporary, until we have an account -> address abstraction in portfolio
-// and only specific to bitcoin
-export const selectTxIdsByAssetIdAccountType = createSelector(
-  selectTxs,
-  selectTxsByAssetId,
-  selectAssetIdParam,
-  (_state: ReduxState, _assetId: CAIP19, accountType: UtxoAccountType) => accountType,
-  (
-    txsById: TxHistoryById,
-    txsByAssetId: TxIdByAssetId,
-    assetId: CAIP19,
-    accountType: UtxoAccountType
-  ): string[] => {
-    // this is specifically to support bitcoin, if we don't have accountType
-    // the txsByAssetId is correct
-    if (!accountType) return txsByAssetId[assetId] ?? []
-    if (isEmpty(txsByAssetId)) return []
-    const txIds = txsByAssetId[assetId] ?? []
-    // only deal with bitcoin txs rather than all
-    const txs = txIds.map(txid => txsById[txid])
-    // filter ids of bitcoin txs of specific account type
-    return txs.filter(tx => tx.accountType === accountType).map(tx => tx.txid)
-  },
-  // memoize outgoing txid[]
-  { memoizeOptions: { resultEqualityCheck: isEqual } }
 )
 
 // this is only used on trade confirm - new txs will be pushed

--- a/src/state/slices/txHistorySlice/txHistorySlice.ts
+++ b/src/state/slices/txHistorySlice/txHistorySlice.ts
@@ -194,10 +194,9 @@ export const selectTxIdsByFilter = createSelector(
     if (!accountIds.length) return txsByAssetId[assetId] ?? []
     const accountsTxIds = accountIds.map(accountId => txsByAccountId[accountId]).flat()
     const assetTxIds = txsByAssetId[assetId]
-    const assetAccountsTxIds = intersection(accountsTxIds, assetTxIds)
-    const sorted = assetAccountsTxIds
-    return sorted
-  }
+    return intersection(accountsTxIds, assetTxIds)
+  },
+  { memoizeOptions: { resultEqualityCheck: isEqual } }
 )
 
 // this is only used on trade confirm - new txs will be pushed


### PR DESCRIPTION
## Description

- feat: tx history selector by asset id and account ids filter
- chore: delete unused account types by chain selector
- chore: delete dead selector hack

## Notice

Before submitting a pull request, please make sure you have answered the following:

- [x] Have you followed the guidelines in our [Contributing]('https://github.com/shapeshift/web/CONTRIBUTING.md) guide?
- [x] Have you checked to ensure there aren't other open [Pull Requests](https://github.com/shapeshift/web/pulls) for the same update/change?
- [x] Do all new and existing tests pass? Does the linter pass?

## Pull Request Type

- [ ] :bug: Bug fix (Non-breaking Change: Fixes an issue)
- [ ] :hammer_and_wrench: Chore (Non-breaking Change: Doc updates, pkg upgrades, typos, etc..)
- [x] :nail_care: New Feature (Breaking/Non-breaking Change)

## Issue (if applicable)

closes #752

## Testing

1. go to an asset, it should should all tx's related to that asset
2. go to an account, it should show all tx's related to that account
3. go to an asset account, it should show only tx's related to that asset and account

## Screenshots (if applicable)

do it live
