### PR TITLE
feat: balance by account

### DIFF
--- a/src/components/AssetAccounts/AssetAccountRow.tsx
+++ b/src/components/AssetAccounts/AssetAccountRow.tsx
@@ -19,7 +19,7 @@ import { selectAssetByCAIP19 } from 'state/slices/assetsSlice/assetsSlice'
 import {
   AccountSpecifier,
   selectPortfolioCryptoBalanceByFilter,
-  selectPortfolioFiatBalancesByFilter
+  selectPortfolioFiatBalanceByFilter
 } from 'state/slices/portfolioSlice/portfolioSlice'
 import { accountIdToFeeAssetId, accountIdToLabel } from 'state/slices/portfolioSlice/utils'
 import { useAppSelector } from 'state/store'
@@ -49,7 +49,7 @@ export const AssetAccountRow = ({
   const asset = useAppSelector(state => selectAssetByCAIP19(state, assetId))
   const feeAsset = useAppSelector(state => selectAssetByCAIP19(state, feeAssetId))
   const filter = useMemo(() => ({ assetId, accountId }), [assetId, accountId])
-  const fiatBalance = useAppSelector(state => selectPortfolioFiatBalancesByFilter(state, filter))
+  const fiatBalance = useAppSelector(state => selectPortfolioFiatBalanceByFilter(state, filter))
   const cryptoBalance = useAppSelector(state => selectPortfolioCryptoBalanceByFilter(state, filter))
   const path = generatePath('/accounts/:accountId/:assetId', filter)
   const label = accountIdToLabel(accountId)

--- a/src/components/AssetHeader/AssetHeader.tsx
+++ b/src/components/AssetHeader/AssetHeader.tsx
@@ -37,8 +37,8 @@ import { selectMarketDataById } from 'state/slices/marketDataSlice/marketDataSli
 import {
   AccountSpecifier,
   selectPortfolioAssetAccounts,
-  selectPortfolioCryptoHumanBalanceByAssetId,
-  selectPortfolioFiatBalanceByAssetId
+  selectPortfolioCryptoHumanBalanceByFilter,
+  selectPortfolioFiatBalanceByFilter
 } from 'state/slices/portfolioSlice/portfolioSlice'
 import { useAppSelector } from 'state/store'
 import { breakpoints } from 'theme/theme'
@@ -83,11 +83,12 @@ export const AssetHeader: React.FC<AssetHeaderProps> = ({ assetId, accountId }) 
 
   const walletSupportsChain = useWalletSupportsChain({ asset, wallet })
 
+  const filter = useMemo(() => ({ assetId, accountId }), [assetId, accountId])
   const cryptoBalance = useAppSelector(state =>
-    selectPortfolioCryptoHumanBalanceByAssetId(state, assetId)
+    selectPortfolioCryptoHumanBalanceByFilter(state, filter)
   )
   const totalBalance = toFiat(
-    useAppSelector(state => selectPortfolioFiatBalanceByAssetId(state, assetId))
+    useAppSelector(state => selectPortfolioFiatBalanceByFilter(state, filter))
   )
 
   return (

--- a/src/components/Modals/Send/hooks/useSendDetails/useSendDetails.tsx
+++ b/src/components/Modals/Send/hooks/useSendDetails/useSendDetails.tsx
@@ -18,7 +18,7 @@ import { selectMarketDataById } from 'state/slices/marketDataSlice/marketDataSli
 import {
   selectPortfolioCryptoBalanceByFilter,
   selectPortfolioCryptoHumanBalanceByFilter,
-  selectPortfolioFiatBalancesByFilter
+  selectPortfolioFiatBalanceByFilter
 } from 'state/slices/portfolioSlice/portfolioSlice'
 import { accountIdToAccountType } from 'state/slices/portfolioSlice/utils'
 import { useAppSelector } from 'state/store'
@@ -65,7 +65,7 @@ export const useSendDetails = (): UseSendDetailsReturnType => {
 
   const fiatBalance = bnOrZero(
     useAppSelector(state =>
-      selectPortfolioFiatBalancesByFilter(state, { assetId: asset.caip19, accountId })
+      selectPortfolioFiatBalanceByFilter(state, { assetId: asset.caip19, accountId })
     )
   )
 

--- a/src/state/slices/portfolioSlice/portfolioSlice.test.ts
+++ b/src/state/slices/portfolioSlice/portfolioSlice.test.ts
@@ -12,7 +12,7 @@ import {
   selectPortfolioCryptoBalanceByAssetId,
   selectPortfolioCryptoHumanBalanceByFilter,
   selectPortfolioFiatAccountBalances,
-  selectPortfolioFiatBalancesByFilter
+  selectPortfolioFiatBalanceByFilter
 } from './portfolioSlice'
 
 const ethCaip2 = 'eip155:1'
@@ -384,13 +384,13 @@ describe('Fiat Balance Selectors', () => {
   describe('selectPortfolioFiatBalancesByFilter', () => {
     it('Should be able to filter by assetId', () => {
       const expected = '27.80'
-      const result = selectPortfolioFiatBalancesByFilter(state, { assetId: ethCaip19 })
+      const result = selectPortfolioFiatBalanceByFilter(state, { assetId: ethCaip19 })
       expect(result).toEqual(expected)
     })
 
     it('Should be able to filter by accountId and assetId', () => {
       const expected = '42.73'
-      const result = selectPortfolioFiatBalancesByFilter(state, {
+      const result = selectPortfolioFiatBalanceByFilter(state, {
         accountId: ethAccountSpecifier1,
         assetId: foxCaip19
       })

--- a/src/state/slices/portfolioSlice/portfolioSlice.ts
+++ b/src/state/slices/portfolioSlice/portfolioSlice.ts
@@ -394,12 +394,12 @@ export const selectPortfolioFiatBalanceByAssetId = createSelector(
   (portfolioFiatBalances, assetId) => portfolioFiatBalances[assetId]
 )
 
-export const selectPortfolioFiatBalancesByFilter = createSelector(
+export const selectPortfolioFiatBalanceByFilter = createSelector(
   selectPortfolioFiatBalances,
   selectPortfolioFiatAccountBalances,
   selectAssetIdParamFromFilter,
   selectAccountIdParamFromFilter,
-  (portfolioAssetFiatBalances, portfolioAccountFiatbalances, assetId, accountId) => {
+  (portfolioAssetFiatBalances, portfolioAccountFiatbalances, assetId, accountId): string => {
     if (assetId && !accountId) return portfolioAssetFiatBalances[assetId]
     if (assetId && accountId) return portfolioAccountFiatbalances[accountId][assetId]
     if (!assetId && accountId) {


### PR DESCRIPTION
## Description

- chore: rename selector to singular balance
- feat: use fiat balance by filter on asset header

## Notice

Before submitting a pull request, please make sure you have answered the following:

- [x] Have you followed the guidelines in our [Contributing]('https://github.com/shapeshift/web/CONTRIBUTING.md) guide?
- [x] Have you checked to ensure there aren't other open [Pull Requests](https://github.com/shapeshift/web/pulls) for the same update/change?
- [x] Do all new and existing tests pass? Does the linter pass?

## Pull Request Type

- [ ] :bug: Bug fix (Non-breaking Change: Fixes an issue)
- [x] :hammer_and_wrench: Chore (Non-breaking Change: Doc updates, pkg upgrades, typos, etc..)
- [x] :nail_care: New Feature (Breaking/Non-breaking Change)

## Issue (if applicable)

closes #772

## Testing

1. go to asset page, should show aggregated balance across all accounts
2. go to asset account page, should show account balance for asset

## Screenshots (if applicable)

n/a
