### PR TITLE
feat: reduce input whitespace when sending BTC

### DIFF
--- a/src/components/Modals/Send/AddressInput/AddressInput.tsx
+++ b/src/components/Modals/Send/AddressInput/AddressInput.tsx
@@ -1,4 +1,5 @@
 import { IconButton, Input, InputGroup, InputRightElement } from '@chakra-ui/react'
+import { ThemingProps } from '@chakra-ui/system/dist/declarations/src/system.types'
 import { Controller, ControllerProps, useFormContext } from 'react-hook-form'
 import { useTranslate } from 'react-polyglot'
 import { useHistory } from 'react-router-dom'
@@ -9,12 +10,14 @@ import { SendRoutes } from '../Send'
 
 type AddressInputProps = {
   rules: ControllerProps['rules']
+  inputFontSize?: ThemingProps['size']
 }
 
-export const AddressInput = ({ rules }: AddressInputProps) => {
+export const AddressInput = ({ rules, inputFontSize }: AddressInputProps) => {
   const { control } = useFormContext<SendInput>()
   const history = useHistory()
   const translate = useTranslate()
+  const reducePadding = inputFontSize ? new Set(['md', 'lg']).has(inputFontSize) : false
 
   const handleQrClick = () => {
     history.push(SendRoutes.Scan)
@@ -27,7 +30,8 @@ export const AddressInput = ({ rules }: AddressInputProps) => {
           <Input
             spellCheck={false}
             autoFocus // eslint-disable-line jsx-a11y/no-autofocus
-            fontSize='sm'
+            fontSize={inputFontSize || 'sm'}
+            px={reducePadding ? '2' : undefined} // If fontSize >= 'md' we reduce default inline-padding start and end
             onChange={onChange}
             placeholder={translate('modals.send.tokenAddress')}
             size='lg'

--- a/src/components/Modals/Send/views/Address.tsx
+++ b/src/components/Modals/Send/views/Address.tsx
@@ -76,6 +76,8 @@ export const Address = () => {
                 }
               }
             }}
+            // If we are sending BTC, use a larger input font size because the address is shorter
+            inputFontSize={asset.caip2 === 'bip122:000000000019d6689c085ae165831e93' ? 'md' : 'sm'}
           />
         </FormControl>
       </ModalBody>


### PR DESCRIPTION
## Description

- Increases the font size of the `AddressInput` component if the `asset` to be sent is Bitcoin
- Adds logic to dynamically reduce the default inline padding, as moving from `sm` to `md` font sizes causes Native Segwit addresses to clip against the QR code button

### Notes for the reviewer

- [`CAIP2`](https://github.com/ChainAgnostic/CAIPs/blob/master/CAIPs/caip-2.md) used as a stable way to check if the asset being sent is Bitcoin
- Font size is optimized for Native Segwit addresses (`P2SH` and `P2PKH` will still show some whitespace) - we could go down the path of working out what kind of Bitcoin account type has been entered (if valid), but this gets messy and is likely not necessary

## Notice

Before submitting a pull request, please make sure you have answered the following:

- [x] Have you followed the guidelines in our [Contributing]('https://github.com/shapeshift/web/CONTRIBUTING.md) guide?
- [x] Have you checked to ensure there aren't other open [Pull Requests](https://github.com/shapeshift/web/pulls) for the same update/change?
- [x] Do all new and existing tests pass? Does the linter pass?

## Pull Request Type

- [ ] :bug: Bug fix (Non-breaking Change: Fixes an issue)
- [ ] :hammer_and_wrench: Chore (Non-breaking Change: Doc updates, pkg upgrades, typos, etc..)
- [x] :nail_care: New Feature (Breaking/Non-breaking Change)

## Issue (if applicable)

Addresses https://github.com/shapeshift/web/issues/735.

## Testing

Please outline all testing steps

- Stage a BTC send transaction to each address type:
  1. Segwit: e.g. `bc1qar0srrr7xfkvy5l643lydnw9re59gtzzwf5mdq`
  2. P2SH: e.g. `3J98t1WpEZ73CNmQviecrnyiWrnqRhWNLy`
  3. P2PKH: e.g. `1BvBMSEYstWetqTFn5Au4m4GFg7xJaNVN2`

## Screenshots (if applicable)

New design:

<img width="621" alt="Screen Shot 2022-01-16 at 7 34 45 am" src="https://user-images.githubusercontent.com/97164662/149640413-6b090732-c73b-4c03-953a-7af1c7de41d1.png">