### PR TITLE
chore: remove obsolete portfolio account selectors

### DIFF
--- a/src/components/Modals/Send/hooks/useSendDetails/useSendDetails.test.tsx
+++ b/src/components/Modals/Send/hooks/useSendDetails/useSendDetails.test.tsx
@@ -8,14 +8,11 @@ import { TestProviders } from 'test/TestProviders'
 import { mocked } from 'ts-jest/utils'
 import { useChainAdapters } from 'context/ChainAdaptersProvider/ChainAdaptersProvider'
 import { useWallet } from 'context/WalletProvider/WalletProvider'
-import { bnOrZero } from 'lib/bignumber/bignumber'
 import { selectFeeAssetById } from 'state/slices/assetsSlice/assetsSlice'
 import { selectMarketDataById } from 'state/slices/marketDataSlice/marketDataSlice'
 import {
   PortfolioBalancesById,
-  selectPortfolioCryptoBalanceByAssetId,
-  selectPortfolioCryptoHumanBalanceByAccountTypeAndAssetId,
-  selectPortfolioFiatBalanceByAccountTypeAndAssetId
+  selectPortfolioCryptoBalanceByAssetId
 } from 'state/slices/portfolioSlice/portfolioSlice'
 
 import { useSendDetails } from './useSendDetails'
@@ -33,9 +30,7 @@ jest.mock('state/slices/assetsSlice/assetsSlice', () => ({
 
 jest.mock('state/slices/portfolioSlice/portfolioSlice', () => ({
   ...jest.requireActual('state/slices/portfolioSlice/portfolioSlice'),
-  selectPortfolioCryptoBalanceByAssetId: jest.fn(),
-  selectPortfolioCryptoHumanBalanceByAccountTypeAndAssetId: jest.fn(),
-  selectPortfolioFiatBalanceByAccountTypeAndAssetId: jest.fn()
+  selectPortfolioCryptoBalanceByAssetId: jest.fn()
 }))
 
 const ethCaip19 = 'eip155:1/slip44:60'
@@ -87,20 +82,8 @@ const setup = ({
     }
     return fakeMarketData[assetId]
   })
-  mocked(selectPortfolioFiatBalanceByAccountTypeAndAssetId).mockImplementation(
-    (_state, assetId) => {
-      const fakeFiatBalanceData = {
-        [mockEthereum.caip19]: '17500',
-        [mockRune.caip19]: '14490.00'
-      }
-      return fakeFiatBalanceData[assetId]
-    }
-  )
   mocked(selectFeeAssetById).mockReturnValue(mockEthereum)
   mocked(selectPortfolioCryptoBalanceByAssetId).mockReturnValue(assetBalance)
-  mocked(selectPortfolioCryptoHumanBalanceByAccountTypeAndAssetId).mockReturnValue(
-    bnOrZero(assetBalance).div('1e18').toString()
-  )
   ;(useFormContext as jest.Mock<unknown>).mockImplementation(() => ({
     clearErrors: jest.fn(),
     setError,

--- a/src/state/slices/portfolioSlice/portfolioSlice.ts
+++ b/src/state/slices/portfolioSlice/portfolioSlice.ts
@@ -1,7 +1,7 @@
 import { createSelector, createSlice } from '@reduxjs/toolkit'
 import { createApi, fetchBaseQuery } from '@reduxjs/toolkit/query/react'
 import { CAIP2, caip2, CAIP10, caip10, CAIP19 } from '@shapeshiftoss/caip'
-import { Asset, chainAdapters, ChainTypes, UtxoAccountType } from '@shapeshiftoss/types'
+import { Asset, chainAdapters, ChainTypes } from '@shapeshiftoss/types'
 import { mergeWith } from 'lodash'
 import cloneDeep from 'lodash/cloneDeep'
 import isEmpty from 'lodash/isEmpty'
@@ -463,48 +463,6 @@ export const selectPortfolioCryptoHumanBalanceByAssetId = createSelector(
   selectAssetIdParam,
   (assets, balances, assetId): string =>
     fromBaseUnit(bnOrZero(balances[assetId]), assets[assetId]?.precision ?? 0)
-)
-
-// TODO(0xdef1cafe): this selector is a hack and needs to be deleted once the account pages are done
-// do not use it or i'll hurt you
-export const selectPortfolioCryptoHumanBalanceByAccountTypeAndAssetId = createSelector(
-  selectAssets,
-  selectPortfolioAssetBalances,
-  selectPortfolioAccountBalances,
-  selectAssetIdParam,
-  (_state: ReduxState, _assetId: string, accountType: UtxoAccountType | undefined) => accountType,
-  (assets, balances, accountBalances, assetId, accountType): string => {
-    if (!accountType) {
-      // in the case of eth, this was working ok, and we only support a single account at the moment,
-      // so we can use the portfolio balance
-      // TODO(0xdef1cafe): we need to fix this to use the accountId and the assetId when we're implementing
-      // account pages - this will break once we support more than accountIndex 0 for account based chains
-      return fromBaseUnit(bnOrZero(balances[assetId]), assets[assetId]?.precision ?? 0)
-    } else {
-      const accountTypeToPubMap = {
-        [UtxoAccountType.P2pkh]: 'xpub', // legacy
-        [UtxoAccountType.SegwitP2sh]: 'ypub', // segwit
-        [UtxoAccountType.SegwitNative]: 'zpub' // segwit native
-      }
-      const searchString = accountTypeToPubMap[accountType]
-      const accountId = Object.keys(accountBalances).find(key => {
-        // only find bitcoin accounts
-        return key.startsWith(assets[assetId].caip2) && key.includes(`:${searchString}`)
-      })!
-      return fromBaseUnit(
-        bnOrZero(accountBalances[accountId]?.[assetId]),
-        assets[assetId]?.precision ?? 0
-      )
-    }
-  }
-)
-
-export const selectPortfolioFiatBalanceByAccountTypeAndAssetId = createSelector(
-  selectPortfolioCryptoHumanBalanceByAccountTypeAndAssetId,
-  selectMarketData,
-  selectAssetIdParam,
-  (accountCryptoHumanBalance, marketData, assetId): string =>
-    bnOrZero(accountCryptoHumanBalance).times(bnOrZero(marketData[assetId]?.price)).toFixed(2)
 )
 
 export type PortfolioAssets = {


### PR DESCRIPTION
- selectPortfolioCryptoHumanBalanceByAccountTypeAndAssetId
- selectPortfolioFiatBalanceByAccountTypeAndAssetId

## Description

Removes obsolete selectors specified by #774

## Notice

Before submitting a pull request, please make sure you have answered the following:

- [x] Have you followed the guidelines in our [Contributing]('https://github.com/shapeshift/web/CONTRIBUTING.md) guide?
- [x] Have you checked to ensure there aren't other open [Pull Requests](https://github.com/shapeshift/web/pulls) for the same update/change?
- [x] Do all new and existing tests pass? Does the linter pass?

## Pull Request Type

- [ ] :bug: Bug fix (Non-breaking Change: Fixes an issue)
- [x] :hammer_and_wrench: Chore (Non-breaking Change: Doc updates, pkg upgrades, typos, etc..)
- [ ] :nail_care: New Feature (Breaking/Non-breaking Change)

## Issue

closes #774

## Testing

Please outline all testing steps

* run `yarn test`