### PR TITLE
feat: add allocation by account

### DIFF
--- a/src/state/slices/portfolioSlice/portfolioSlice.test.ts
+++ b/src/state/slices/portfolioSlice/portfolioSlice.test.ts
@@ -7,13 +7,13 @@ import {
   accountToPortfolio,
   Portfolio,
   selectAccountIdByAddress,
+  selectPortfolioAllocationPercentByAccountId,
   selectPortfolioAssetAccounts,
   selectPortfolioAssetIdsByAccountId,
   selectPortfolioCryptoBalanceByAssetId,
   selectPortfolioCryptoHumanBalanceByFilter,
   selectPortfolioFiatAccountBalances,
-  selectPortfolioFiatBalanceByFilter,
-  selectPortfolioAllocationPercentByAccountId
+  selectPortfolioFiatBalanceByFilter
 } from './portfolioSlice'
 
 const ethCaip2 = 'eip155:1'
@@ -344,7 +344,10 @@ describe('selectPortfolioAllocationPercentByAccountId', () => {
   it('can select fiat allocation by accountId', () => {
     const returnValue = 68.09155471117745
 
-    const allocationByAccountId = selectPortfolioAllocationPercentByAccountId(state, ethAccountSpecifier2)
+    const allocationByAccountId = selectPortfolioAllocationPercentByAccountId(
+      state,
+      ethAccountSpecifier2
+    )
     expect(allocationByAccountId).toEqual(returnValue)
   })
 })

--- a/src/state/slices/portfolioSlice/portfolioSlice.test.ts
+++ b/src/state/slices/portfolioSlice/portfolioSlice.test.ts
@@ -13,7 +13,8 @@ import {
   selectPortfolioCryptoBalanceByAssetId,
   selectPortfolioCryptoHumanBalanceByFilter,
   selectPortfolioFiatAccountBalances,
-  selectPortfolioFiatBalanceByFilter
+  selectPortfolioFiatBalanceByFilter,
+  selectPortfolioTotalFiatBalanceByAccount
 } from './portfolioSlice'
 
 const ethCaip2 = 'eip155:1'
@@ -395,13 +396,13 @@ describe('Fiat Balance Selectors', () => {
   })
 
   describe('selectPortfolioFiatBalanceByFilter', () => {
-    it('Should be able to filter by assetId', () => {
+    it('should be able to filter by assetId', () => {
       const expected = '115.61'
       const result = selectPortfolioFiatBalanceByFilter(state, { assetId: ethCaip19 })
       expect(result).toEqual(expected)
     })
 
-    it('Should be able to filter by accountId and assetId', () => {
+    it('should be able to filter by accountId and assetId', () => {
       const expected = '42.73'
       const result = selectPortfolioFiatBalanceByFilter(state, {
         accountId: ethAccountSpecifier1,
@@ -412,18 +413,30 @@ describe('Fiat Balance Selectors', () => {
   })
 
   describe('selectPortfolioCryptoHumanBalancesByFilter', () => {
-    it('Should be able to filter by assetId', () => {
+    it('should be able to filter by assetId', () => {
       const expected = '0.115607'
       const result = selectPortfolioCryptoHumanBalanceByFilter(state, { assetId: ethCaip19 })
       expect(result).toEqual(expected)
     })
 
-    it('Should be able to filter by accountId and assetId', () => {
+    it('should be able to filter by accountId and assetId', () => {
       const expected = '42.729243'
       const result = selectPortfolioCryptoHumanBalanceByFilter(state, {
         accountId: ethAccountSpecifier1,
         assetId: foxCaip19
       })
+      expect(result).toEqual(expected)
+    })
+  })
+
+  describe('selectPortfolioTotalFiatBalanceByAccount', () => {
+    it('should return total fiat balance by accountId', () => {
+      const expected = {
+        [ethAccountSpecifier1]: '70.53',
+        [ethAccountSpecifier2]: '150.53'
+      }
+
+      const result = selectPortfolioTotalFiatBalanceByAccount(state)
       expect(result).toEqual(expected)
     })
   })

--- a/src/state/slices/portfolioSlice/portfolioSlice.test.ts
+++ b/src/state/slices/portfolioSlice/portfolioSlice.test.ts
@@ -12,7 +12,8 @@ import {
   selectPortfolioCryptoBalanceByAssetId,
   selectPortfolioCryptoHumanBalanceByFilter,
   selectPortfolioFiatAccountBalances,
-  selectPortfolioFiatBalanceByFilter
+  selectPortfolioFiatBalanceByFilter,
+  selectPortfolioAllocationPercentByAccountId
 } from './portfolioSlice'
 
 const ethCaip2 = 'eip155:1'
@@ -214,8 +215,8 @@ const state = {
     ...mockStore.portfolio,
     assetBalances: {
       byId: {
-        [ethCaip19]: '27803816548287370',
-        [foxCaip19]: '42729243327349401946'
+        [ethCaip19]: '115607633096574740',
+        [foxCaip19]: '105458486654698803892'
       },
       ids: [ethCaip19, foxCaip19]
     },
@@ -339,6 +340,15 @@ describe('selectPortfolioAssetCryptoBalanceByAssetId', () => {
   })
 })
 
+describe('selectPortfolioAllocationPercentByAccountId', () => {
+  it('can select fiat allocation by accountId', () => {
+    const returnValue = 68.09155471117745
+
+    const allocationByAccountId = selectPortfolioAllocationPercentByAccountId(state, ethAccountSpecifier2)
+    expect(allocationByAccountId).toEqual(returnValue)
+  })
+})
+
 describe('Fiat Balance Selectors', () => {
   describe('selectPortfolioFiatAccountBalance', () => {
     it('can select crypto fiat account balance', () => {
@@ -381,9 +391,9 @@ describe('Fiat Balance Selectors', () => {
     })
   })
 
-  describe('selectPortfolioFiatBalancesByFilter', () => {
+  describe('selectPortfolioFiatBalanceByFilter', () => {
     it('Should be able to filter by assetId', () => {
-      const expected = '27.80'
+      const expected = '115.61'
       const result = selectPortfolioFiatBalanceByFilter(state, { assetId: ethCaip19 })
       expect(result).toEqual(expected)
     })
@@ -400,7 +410,7 @@ describe('Fiat Balance Selectors', () => {
 
   describe('selectPortfolioCryptoHumanBalancesByFilter', () => {
     it('Should be able to filter by assetId', () => {
-      const expected = '0.027803'
+      const expected = '0.115607'
       const result = selectPortfolioCryptoHumanBalanceByFilter(state, { assetId: ethCaip19 })
       expect(result).toEqual(expected)
     })

--- a/src/state/slices/portfolioSlice/portfolioSlice.ts
+++ b/src/state/slices/portfolioSlice/portfolioSlice.ts
@@ -560,7 +560,7 @@ export const selectPortfolioAllocationPercent = createSelector(
 export const selectPortfolioTotalFiatBalanceByAccount = createSelector(
   selectPortfolioFiatAccountBalances,
   accountBalances => {
-    return Object.entries(accountBalances).reduce<PortfolioAccountBalances['byId']>(
+    return Object.entries(accountBalances).reduce<{ [k: AccountSpecifier]: string }>(
       (acc, [accountId, balanceObj]) => {
         const totalAccountFiatBalance = Object.values(balanceObj).reduce(
           (totalBalance, currentBalance) => {
@@ -582,18 +582,17 @@ export const selectPortfolioAllocationPercentByAccountId = createSelector(
   selectPortfolioTotalFiatBalanceByAccount,
   selectAccountIdParam,
   (totalFiatBalance, totalBalancesByAccount, accountId) => {
-    const balanceAllocationById = Object.entries(totalBalancesByAccount).reduce(
-      (acc, [currentAccountId, accountBalance]) => {
-        const allocation = bnOrZero(accountBalance)
-          .div(bnOrZero(totalFiatBalance))
-          .times(100)
-          .toNumber()
+    const balanceAllocationById = Object.entries(totalBalancesByAccount).reduce<{
+      [k: AccountSpecifier]: number
+    }>((acc, [currentAccountId, accountBalance]) => {
+      const allocation = bnOrZero(accountBalance)
+        .div(bnOrZero(totalFiatBalance))
+        .times(100)
+        .toNumber()
 
-        acc[currentAccountId] = allocation
-        return acc
-      },
-      {}
-    )
+      acc[currentAccountId] = allocation
+      return acc
+    }, {})
 
     return balanceAllocationById[accountId]
   }


### PR DESCRIPTION
## Description

Add `selectPortfolioAllocationPercentByAccountId` to get allocation by account

## Notice

Before submitting a pull request, please make sure you have answered the following:

- [ ] Have you followed the guidelines in our [Contributing]('https://github.com/shapeshift/web/CONTRIBUTING.md) guide?
- [ ] Have you checked to ensure there aren't other open [Pull Requests](https://github.com/shapeshift/web/pulls) for the same update/change?
- [ ] Do all new and existing tests pass? Does the linter pass?

## Pull Request Type

- [ ] :bug: Bug fix (Non-breaking Change: Fixes an issue)
- [ ] :hammer_and_wrench: Chore (Non-breaking Change: Doc updates, pkg upgrades, typos, etc..)
- [ ] :nail_care: New Feature (Breaking/Non-breaking Change)

## Issue (if applicable)

If applicable, please link to the github issue and put `closes #XXXX` in your comment to auto-close the issue that your PR fixes.

## Testing

Please outline all testing steps

1. Pull branch locally and run `yarn` to install new deps
2. etc...

## Screenshots (if applicable)
