### PR TITLE
fix: update balance charts

### DIFF
--- a/src/components/AssetHeader/AssetHeader.tsx
+++ b/src/components/AssetHeader/AssetHeader.tsx
@@ -36,7 +36,6 @@ import {
 import { selectMarketDataById } from 'state/slices/marketDataSlice/marketDataSlice'
 import {
   AccountSpecifier,
-  selectPortfolioAssetAccounts,
   selectPortfolioCryptoHumanBalanceByFilter,
   selectPortfolioFiatBalanceByFilter
 } from 'state/slices/portfolioSlice/portfolioSlice'
@@ -75,7 +74,6 @@ export const AssetHeader: React.FC<AssetHeaderProps> = ({ assetId, accountId }) 
   const assetPrice = toFiat(price) ?? 0
   const handleToggle = () => setShowDescription(!showDescription)
   const assetIds = useMemo(() => [assetId].filter(Boolean), [assetId])
-  const accountIds = useAppSelector(state => selectPortfolioAssetAccounts(state, assetId))
 
   const {
     state: { wallet }
@@ -181,7 +179,7 @@ export const AssetHeader: React.FC<AssetHeaderProps> = ({ assetId, accountId }) 
       {/* If the Child component call a function update state of Parent Compnent in UseEffect,the Child Component should avaiable on DOM */}
       <Box style={{ display: view === View.Balance ? 'block' : 'none' }}>
         <BalanceChart
-          accountIds={accountIds}
+          accountId={accountId}
           assetIds={assetIds}
           timeframe={timeframe}
           percentChange={percentChange}

--- a/src/components/BalanceChart/BalanceChart.tsx
+++ b/src/components/BalanceChart/BalanceChart.tsx
@@ -9,7 +9,7 @@ import { AccountSpecifier } from 'state/slices/portfolioSlice/portfolioSlice'
 
 type BalanceChartArgs = {
   assetIds: CAIP19[]
-  accountIds?: AccountSpecifier[]
+  accountId?: AccountSpecifier
   timeframe: HistoryTimeframe
   percentChange: number
   setPercentChange: (percentChange: number) => void
@@ -17,14 +17,14 @@ type BalanceChartArgs = {
 
 export const BalanceChart: React.FC<BalanceChartArgs> = ({
   assetIds,
-  accountIds,
+  accountId,
   timeframe,
   percentChange,
   setPercentChange
 }) => {
   const { balanceChartData, balanceChartDataLoading } = useBalanceChartData({
     assetIds,
-    accountIds,
+    accountId,
     timeframe
   })
 

--- a/src/components/TxHistory.tsx
+++ b/src/components/TxHistory.tsx
@@ -33,7 +33,7 @@ export const TxHistory: React.FC<TxHistoryProps> = ({ assetId, accountId }) => {
   const filter = useMemo(
     // if we are passed an accountId, we're on an asset accoutn page, use that specifically.
     // otherwise, we're on an asset page, use all accountIds related to this asset
-    () => ({ assetId, accountIds: accountId ? [accountId] : accountIds }),
+    () => ({ assetIds: [assetId], accountIds: accountId ? [accountId] : accountIds }),
     [assetId, accountId, accountIds]
   )
 

--- a/src/context/TransactionsProvider/TransactionsProvider.tsx
+++ b/src/context/TransactionsProvider/TransactionsProvider.tsx
@@ -47,6 +47,9 @@ export const TransactionsProvider = ({ children }: TransactionsProviderProps): J
                 const caip10 = `${msg.caip2}:${msg.address}`
                 const state = store.getState()
                 const accountId = selectAccountIdByAddress(state, caip10)
+                if (msg.txid.startsWith('8d')) {
+                  console.info(msg)
+                }
                 dispatch(
                   txHistory.actions.onMessage({
                     message: { ...msg, accountType },

--- a/src/context/TransactionsProvider/TransactionsProvider.tsx
+++ b/src/context/TransactionsProvider/TransactionsProvider.tsx
@@ -47,9 +47,6 @@ export const TransactionsProvider = ({ children }: TransactionsProviderProps): J
                 const caip10 = `${msg.caip2}:${msg.address}`
                 const state = store.getState()
                 const accountId = selectAccountIdByAddress(state, caip10)
-                if (msg.txid.startsWith('8d')) {
-                  console.info(msg)
-                }
                 dispatch(
                   txHistory.actions.onMessage({
                     message: { ...msg, accountType },

--- a/src/hooks/useBalanceChartData/useBalanceChartData.ts
+++ b/src/hooks/useBalanceChartData/useBalanceChartData.ts
@@ -27,7 +27,7 @@ import {
   PortfolioAssets,
   PortfolioBalancesById,
   selectPortfolioAssets,
-  selectPortfolioCryptoBalancesByFilter
+  selectPortfolioCryptoBalancesByAccountId
 } from 'state/slices/portfolioSlice/portfolioSlice'
 import { selectTxsByFilter, Tx } from 'state/slices/txHistorySlice/txHistorySlice'
 import { useAppSelector } from 'state/store'
@@ -290,9 +290,8 @@ export const useBalanceChartData: UseBalanceChartData = args => {
   const [balanceChartDataLoading, setBalanceChartDataLoading] = useState(true)
   const [balanceChartData, setBalanceChartData] = useState<HistoryData[]>([])
   // dummy assetId - we're only filtering on account
-  const balanceFilter = useMemo(() => ({ assetId: '', accountId }), [accountId])
   const balances = useAppSelector(state =>
-    selectPortfolioCryptoBalancesByFilter(state, balanceFilter)
+    selectPortfolioCryptoBalancesByAccountId(state, accountId)
   )
   const portfolioAssets = useSelector(selectPortfolioAssets)
   const {

--- a/src/hooks/useBalanceChartData/useBalanceChartData.ts
+++ b/src/hooks/useBalanceChartData/useBalanceChartData.ts
@@ -29,7 +29,6 @@ import {
   selectPortfolioAssetBalances,
   selectPortfolioAssets
 } from 'state/slices/portfolioSlice/portfolioSlice'
-import { selectAccountTypes } from 'state/slices/preferencesSlice/preferencesSlice'
 import { selectTxsByAccountIds, Tx } from 'state/slices/txHistorySlice/txHistorySlice'
 import { useAppSelector } from 'state/store'
 
@@ -293,7 +292,6 @@ export const useBalanceChartData: UseBalanceChartData = args => {
   const [balanceChartDataLoading, setBalanceChartDataLoading] = useState(true)
   const [balanceChartData, setBalanceChartData] = useState<HistoryData[]>([])
   const balances = useSelector(selectPortfolioAssetBalances)
-  const accountTypes = useSelector(selectAccountTypes)
   const portfolioAssets = useSelector(selectPortfolioAssets)
   const {
     state: { walletInfo }
@@ -355,7 +353,6 @@ export const useBalanceChartData: UseBalanceChartData = args => {
     setBalanceChartDataLoading(false)
   }, [
     assetIds,
-    accountTypes,
     priceHistoryData,
     priceHistoryDataLoading,
     txs,

--- a/src/hooks/useBalanceChartData/useBalanceChartData.ts
+++ b/src/hooks/useBalanceChartData/useBalanceChartData.ts
@@ -11,7 +11,7 @@ import last from 'lodash/last'
 import reduce from 'lodash/reduce'
 import reverse from 'lodash/reverse'
 import sortedIndexBy from 'lodash/sortedIndexBy'
-import { useEffect, useState } from 'react'
+import { useEffect, useMemo, useState } from 'react'
 import { useSelector } from 'react-redux'
 import { useWallet } from 'context/WalletProvider/WalletProvider'
 import { useDebounce } from 'hooks/useDebounce/useDebounce'
@@ -29,7 +29,7 @@ import {
   selectPortfolioAssetBalances,
   selectPortfolioAssets
 } from 'state/slices/portfolioSlice/portfolioSlice'
-import { selectTxsByAccountIds, Tx } from 'state/slices/txHistorySlice/txHistorySlice'
+import { selectTxsByFilter, Tx } from 'state/slices/txHistorySlice/txHistorySlice'
 import { useAppSelector } from 'state/store'
 
 type PriceAtBlockTimeArgs = {
@@ -296,10 +296,12 @@ export const useBalanceChartData: UseBalanceChartData = args => {
   const {
     state: { walletInfo }
   } = useWallet()
+
+  const filter = useMemo(() => ({ assetIds, accountIds }), [assetIds, accountIds])
   // we can't tell if txs are finished loading over the websocket, so
   // debounce a bit before doing expensive computations
   const txs = useDebounce(
-    useAppSelector(state => selectTxsByAccountIds(state, accountIds ?? [])),
+    useAppSelector(state => selectTxsByFilter(state, filter)),
     500
   )
 

--- a/src/hooks/useBalanceChartData/useBalanceChartData.ts
+++ b/src/hooks/useBalanceChartData/useBalanceChartData.ts
@@ -1,5 +1,5 @@
 import { CAIP19 } from '@shapeshiftoss/caip'
-import { HistoryData, HistoryTimeframe } from '@shapeshiftoss/types'
+import { ChainTypes, HistoryData, HistoryTimeframe } from '@shapeshiftoss/types'
 import { TxType } from '@shapeshiftoss/types/dist/chain-adapters'
 import { BigNumber } from 'bignumber.js'
 import dayjs from 'dayjs'
@@ -219,9 +219,12 @@ export const calculateBucketPrices: CalculateBucketPrices = args => {
     txs.forEach(tx => {
       if (tx.fee && assetIds.includes(tx.fee.caip19)) {
         // balance history being built in descending order, so fee means we had more before
-        bucket.balance.crypto[tx.fee.caip19] = bucket.balance.crypto[tx.fee.caip19].plus(
-          bnOrZero(tx.fee.value)
-        )
+        // TODO(0xdef1cafe): this is awful but gets us out of trouble
+        if (tx.chain === ChainTypes.Ethereum) {
+          bucket.balance.crypto[tx.fee.caip19] = bucket.balance.crypto[tx.fee.caip19].plus(
+            bnOrZero(tx.fee.value)
+          )
+        }
       }
 
       tx.transfers.forEach(transfer => {

--- a/src/state/slices/portfolioSlice/portfolioSlice.ts
+++ b/src/state/slices/portfolioSlice/portfolioSlice.ts
@@ -438,17 +438,12 @@ export const selectPortfolioCryptoHumanBalanceByFilter = createSelector(
   }
 )
 
-export const selectPortfolioCryptoBalancesByFilter = createSelector(
+export const selectPortfolioCryptoBalancesByAccountId = createSelector(
   selectPortfolioAccountBalances,
   selectPortfolioAssetBalances,
-  selectAccountIdParamFromFilter,
-  (accountBalances, assetBalances, accountId): PortfolioBalancesById => {
-    if (accountId) {
-      return accountBalances[accountId]
-    } else {
-      return assetBalances
-    }
-  }
+  (_state: ReduxState, accountId?: string) => accountId,
+  (accountBalances, assetBalances, accountId): PortfolioBalancesById =>
+    accountId ? accountBalances[accountId] : assetBalances
 )
 
 // TODO(0xdef1cafe): i think this should/might be CryptoHumanBalance?

--- a/src/state/slices/portfolioSlice/portfolioSlice.ts
+++ b/src/state/slices/portfolioSlice/portfolioSlice.ts
@@ -346,10 +346,8 @@ type ParamFilter = {
 }
 
 const selectAssetIdParam = (_state: ReduxState, id: CAIP19) => id
-const selectAssetIdParamFromFilter = (_state: ReduxState, paramFilter: ParamFilter) =>
-  paramFilter.assetId
-const selectAccountIdParamFromFilter = (_state: ReduxState, paramFilter: ParamFilter) =>
-  paramFilter.accountId
+const selectAssetIdParamFromFilter = (_state: ReduxState, { assetId }: ParamFilter) => assetId
+const selectAccountIdParamFromFilter = (_state: ReduxState, { accountId }: ParamFilter) => accountId
 const selectAccountAddressParam = (_state: ReduxState, id: CAIP10) => id
 const selectAccountIdParam = (_state: ReduxState, id: AccountSpecifier) => id
 
@@ -440,6 +438,20 @@ export const selectPortfolioCryptoHumanBalanceByFilter = createSelector(
   }
 )
 
+export const selectPortfolioCryptoBalancesByFilter = createSelector(
+  selectPortfolioAccountBalances,
+  selectPortfolioAssetBalances,
+  selectAccountIdParamFromFilter,
+  (accountBalances, assetBalances, accountId): PortfolioBalancesById => {
+    if (accountId) {
+      return accountBalances[accountId]
+    } else {
+      return assetBalances
+    }
+  }
+)
+
+// TODO(0xdef1cafe): i think this should/might be CryptoHumanBalance?
 export const selectPortfolioCryptoBalanceByFilter = createSelector(
   selectAssets,
   selectPortfolioAccountBalances,

--- a/src/state/slices/txHistorySlice/txHistorySlice.test.ts
+++ b/src/state/slices/txHistorySlice/txHistorySlice.test.ts
@@ -174,16 +174,16 @@ describe('txHistorySlice', () => {
       )
 
       expect(store.getState().txHistory.byAccountId[ethAccountSpecifier]).toStrictEqual([
-        EthSend.txid,
-        EthReceive.txid
+        makeUniqueTxId(EthSend, ethAccountSpecifier),
+        makeUniqueTxId(EthReceive, ethAccountSpecifier)
       ])
 
       expect(store.getState().txHistory.byAccountId[segwitNativeAccountSpecifier]).toStrictEqual([
-        BtcSend.txid
+        makeUniqueTxId(BtcSend, segwitNativeAccountSpecifier)
       ])
 
       expect(store.getState().txHistory.byAccountId[segwitAccountSpecifier]).toStrictEqual([
-        BtcSendSegwit.txid
+        makeUniqueTxId(BtcSendSegwit, segwitAccountSpecifier)
       ])
     })
   })

--- a/src/state/slices/txHistorySlice/txHistorySlice.test.ts
+++ b/src/state/slices/txHistorySlice/txHistorySlice.test.ts
@@ -129,16 +129,17 @@ describe('txHistorySlice', () => {
         })
       )
 
-      expect(store.getState().txHistory.byId[EthReceivePending.txid].status).toBe(
-        chainAdapters.TxStatus.Pending
-      )
+      expect(
+        store.getState().txHistory.byId[makeUniqueTxId(EthReceivePending, ethAccountSpecifier)]
+          .status
+      ).toBe(chainAdapters.TxStatus.Pending)
 
       store.dispatch(
         txHistory.actions.onMessage({ message: EthReceive, accountSpecifier: ethAccountSpecifier })
       )
-      expect(store.getState().txHistory.byId[EthReceive.txid].status).toBe(
-        chainAdapters.TxStatus.Confirmed
-      )
+      expect(
+        store.getState().txHistory.byId[makeUniqueTxId(EthReceive, ethAccountSpecifier)].status
+      ).toBe(chainAdapters.TxStatus.Confirmed)
     })
 
     it('should add txids by accountSpecifier', async () => {

--- a/src/state/slices/txHistorySlice/txHistorySlice.test.ts
+++ b/src/state/slices/txHistorySlice/txHistorySlice.test.ts
@@ -4,7 +4,7 @@ import { mockStore } from 'test/mocks/store'
 import { BtcSend, ethereumTransactions, EthReceive, EthSend } from 'test/mocks/txs'
 import { store } from 'state/store'
 
-import { selectLastNTxIds, txHistory } from './txHistorySlice'
+import { makeUniqueTxId, selectLastNTxIds, txHistory } from './txHistorySlice'
 
 describe('txHistorySlice', () => {
   it('returns empty object for initialState', async () => {
@@ -26,15 +26,15 @@ describe('txHistorySlice', () => {
     it('can sort txs going into store', async () => {
       // testTxs are in ascending order by time
       const transactions = reverse([...ethereumTransactions])
+      const ethCAIP2 = EthSend.caip2
+      const accountSpecifier = `${ethCAIP2}:0xdef1cafe`
       // expected transaction order
-      const expected = map(transactions, 'txid')
+      const expected = map(transactions, tx => makeUniqueTxId(tx, accountSpecifier))
 
       store.dispatch(txHistory.actions.clear())
 
       // shuffle txs before inserting them into the store
       const shuffledTxs = reverse(transactions) // transactions in the wrong order
-      const ethCAIP2 = EthSend.caip2
-      const accountSpecifier = `${ethCAIP2}:0xdef1cafe`
       shuffledTxs.forEach(tx =>
         store.dispatch(txHistory.actions.onMessage({ message: tx, accountSpecifier }))
       )

--- a/src/state/slices/txHistorySlice/txHistorySlice.test.ts
+++ b/src/state/slices/txHistorySlice/txHistorySlice.test.ts
@@ -72,8 +72,12 @@ describe('txHistorySlice', () => {
       expect(Object.values(store.getState().txHistory.ids).length).toBe(2)
 
       // eth data exists
-      expect(store.getState().txHistory.byId[EthSend.txid]).toEqual(EthSend)
-      expect(store.getState().txHistory.byId[EthReceive.txid]).toEqual(EthReceive)
+      expect(store.getState().txHistory.byId[makeUniqueTxId(EthSend, ethAccountSpecifier)]).toEqual(
+        EthSend
+      )
+      expect(
+        store.getState().txHistory.byId[makeUniqueTxId(EthReceive, ethAccountSpecifier)]
+      ).toEqual(EthReceive)
 
       const segwitNativeAccountSpecifier = `${BtcSend.caip2}:zpub`
 
@@ -107,8 +111,12 @@ describe('txHistorySlice', () => {
       expect(Object.values(store.getState().txHistory.ids).length).toBe(4)
 
       // btc data exists
-      expect(store.getState().txHistory.byId[BtcSend.txid]).toEqual(BtcSend)
-      expect(store.getState().txHistory.byId[BtcSendSegwit.txid]).toEqual(BtcSendSegwit)
+      expect(
+        store.getState().txHistory.byId[makeUniqueTxId(BtcSend, segwitNativeAccountSpecifier)]
+      ).toEqual(BtcSend)
+      expect(
+        store.getState().txHistory.byId[makeUniqueTxId(BtcSendSegwit, segwitAccountSpecifier)]
+      ).toEqual(BtcSendSegwit)
     })
 
     it('should update existing transactions', async () => {

--- a/src/state/slices/txHistorySlice/txHistorySlice.ts
+++ b/src/state/slices/txHistorySlice/txHistorySlice.ts
@@ -200,6 +200,10 @@ export const selectTxIdsByFilter = createSelector(
   { memoizeOptions: { resultEqualityCheck: isEqual } }
 )
 
+export const selectTxsByFilter = createSelector(selectTxs, selectTxIdsByFilter, (txs, txIds) =>
+  txIds.map(txId => txs[txId])
+)
+
 // this is only used on trade confirm - new txs will be pushed
 // to the end of this array, so last is guaranteed to be latest
 // this can return undefined as we may be trading into this asset

--- a/src/state/slices/txHistorySlice/txHistorySlice.ts
+++ b/src/state/slices/txHistorySlice/txHistorySlice.ts
@@ -177,23 +177,24 @@ const selectTxIdsByAssetId = createSelector(
 )
 
 type TxHistoryFilter = {
-  assetId: CAIP19
+  assetIds: CAIP19[]
   accountIds?: AccountSpecifier[]
 }
 
-const selectAssetIdParamFromFilter = (_state: ReduxState, { assetId }: TxHistoryFilter) => assetId
+const selectAssetIdsParamFromFilter = (_state: ReduxState, { assetIds }: TxHistoryFilter) =>
+  assetIds
 const selectAccountIdsParamFromFilter = (_state: ReduxState, { accountIds }: TxHistoryFilter) =>
   accountIds ?? []
 
 export const selectTxIdsByFilter = createSelector(
   selectTxsByAssetId,
   selectTxIdsByAccountId,
-  selectAssetIdParamFromFilter,
+  selectAssetIdsParamFromFilter,
   selectAccountIdsParamFromFilter,
-  (txsByAssetId, txsByAccountId, assetId, accountIds): TxId[] => {
-    if (!accountIds.length) return txsByAssetId[assetId] ?? []
+  (txsByAssetId, txsByAccountId, assetIds, accountIds): TxId[] => {
+    const assetTxIds = assetIds.map(assetId => txsByAssetId[assetId] ?? []).flat()
+    if (!accountIds.length) return assetTxIds
     const accountsTxIds = accountIds.map(accountId => txsByAccountId[accountId]).flat()
-    const assetTxIds = txsByAssetId[assetId]
     return intersection(accountsTxIds, assetTxIds)
   },
   { memoizeOptions: { resultEqualityCheck: isEqual } }

--- a/src/state/slices/txHistorySlice/txHistorySlice.ts
+++ b/src/state/slices/txHistorySlice/txHistorySlice.ts
@@ -74,6 +74,25 @@ const initialState: TxHistory = {
  *
  * If transaction already exists, update the value, otherwise add the new transaction
  */
+
+/**
+ * now we support accounts, we have a new problem
+ * the same tx id can have multiple representations, depending on the
+ * account's persective, especially utxos.
+ *
+ * i.e. a bitcoin send will have a send component, and a receive component for
+ * the change, to a new address, but the same tx id.
+ * this means we can't uniquely index tx's simply by their id.
+ *
+ * we'll probably need to go back to some composite index that can be built from
+ * the txid and address, or account id, that can be deterministically generated,
+ * from the tx data and the account id - note, not the address.
+ *
+ * the correct solution is to not rely on the parsed representation of the tx
+ * as a "send" or "receive" from chain adapters, just index the tx related to the
+ * asset or account, and parse the tx closer to the view layer.
+ */
+
 const updateOrInsert = (txHistory: TxHistory, tx: Tx, accountSpecifier: string) => {
   const { txid } = tx
   const isNew = !txHistory.byId[txid]


### PR DESCRIPTION
## Description

fixes balance charts for everything except portfolio - eth, tokens, and btc asset and accounts all work correctly

## Notice

Before submitting a pull request, please make sure you have answered the following:

- [x] Have you followed the guidelines in our [Contributing]('https://github.com/shapeshift/web/CONTRIBUTING.md) guide?
- [x] Have you checked to ensure there aren't other open [Pull Requests](https://github.com/shapeshift/web/pulls) for the same update/change?
- [x] Do all new and existing tests pass? Does the linter pass?

## Pull Request Type

- [x] :bug: Bug fix (Non-breaking Change: Fixes an issue)
- [ ] :hammer_and_wrench: Chore (Non-breaking Change: Doc updates, pkg upgrades, typos, etc..)
- [ ] :nail_care: New Feature (Breaking/Non-breaking Change)

## Issue (if applicable)

closes #691

## Testing

1. go to bitcoin asset page and balance chart, right hand side of chart should end with full balance across all accounts
2. go to bitcoin account page and balance chart, right hand side of chart should end with balance for that account

## Screenshots (if applicable)

n/a
