### PR TITLE
feat: add selectPortfolioTotalFiatBalancesForFeeAssetOnly for account allocations

### DIFF
--- a/src/state/slices/portfolioSlice/portfolioSlice.test.ts
+++ b/src/state/slices/portfolioSlice/portfolioSlice.test.ts
@@ -14,7 +14,8 @@ import {
   selectPortfolioCryptoHumanBalanceByFilter,
   selectPortfolioFiatAccountBalances,
   selectPortfolioFiatBalanceByFilter,
-  selectPortfolioTotalFiatBalanceByAccount
+  selectPortfolioTotalFiatBalanceByAccount,
+  selectPortfolioTotalFiatBalancesForFeeAssetOnly
 } from './portfolioSlice'
 
 const ethCaip2 = 'eip155:1'
@@ -343,12 +344,12 @@ describe('selectPortfolioAssetCryptoBalanceByAssetId', () => {
 
 describe('selectPortfolioAllocationPercentByAccountId', () => {
   it('can select fiat allocation by accountId', () => {
-    const returnValue = 68.09155471117745
+    const returnValue = 75.94498745783237
 
-    const allocationByAccountId = selectPortfolioAllocationPercentByAccountId(
-      state,
-      ethAccountSpecifier2
-    )
+    const allocationByAccountId = selectPortfolioAllocationPercentByAccountId(state, {
+      accountId: ethAccountSpecifier2,
+      assetId: ethCaip19
+    })
     expect(allocationByAccountId).toEqual(returnValue)
   })
 })
@@ -438,6 +439,18 @@ describe('Fiat Balance Selectors', () => {
 
       const result = selectPortfolioTotalFiatBalanceByAccount(state)
       expect(result).toEqual(expected)
+    })
+  })
+
+  describe('selectPortfolioTotalFiatBalancesForFeeAssetOnly', () => {
+    it('should return the total balances by account for fee asssets only - ie Bitcoin/Ethereum', () => {
+      const expected = {
+        [ethAccountSpecifier1]: '27.80',
+        [ethAccountSpecifier2]: '87.80'
+      }
+
+      const result = selectPortfolioTotalFiatBalancesForFeeAssetOnly(state)
+      expect(expected).toEqual(result)
     })
   })
 })

--- a/src/state/slices/portfolioSlice/portfolioSlice.ts
+++ b/src/state/slices/portfolioSlice/portfolioSlice.ts
@@ -357,10 +357,14 @@ const selectAssetIdParamFromFilter = (_state: ReduxState, paramFilter: ParamFilt
 const selectAccountIdParamFromFilter = (_state: ReduxState, paramFilter: ParamFilter) =>
   paramFilter.accountId
 
-const selectAssetIdParamFromFilterOptional = (_state: ReduxState, paramFilter: OptionalParamFilter) =>
-  paramFilter.assetId
-const selectAccountIdParamFromFilterOptional = (_state: ReduxState, paramFilter: OptionalParamFilter) =>
-  paramFilter.accountId
+const selectAssetIdParamFromFilterOptional = (
+  _state: ReduxState,
+  paramFilter: OptionalParamFilter
+) => paramFilter.assetId
+const selectAccountIdParamFromFilterOptional = (
+  _state: ReduxState,
+  paramFilter: OptionalParamFilter
+) => paramFilter.accountId
 
 const selectAccountAddressParam = (_state: ReduxState, id: CAIP10) => id
 const selectAccountIdParam = (_state: ReduxState, id: AccountSpecifier) => id
@@ -557,12 +561,11 @@ export const selectPortfolioTotalFiatBalanceByAccount = createSelector(
 
 export const selectPortfolioTotalFiatBalancesForFeeAssetOnly = createSelector(
   selectPortfolioFiatAccountBalances,
-  (accountBalances => {
+  accountBalances => {
     return Object.entries(accountBalances).reduce<{ [k: AccountSpecifier]: string }>(
       (acc, [accountId, balanceObj]) => {
         const totalAccountFiatBalance = Object.entries(balanceObj).reduce(
           (totalBalance, [assetId, assetBalance]) => {
-
             // If the asset is NOT a fee asset, skip it
             if (!FEE_ASSET_IDS.includes(assetId)) {
               return totalBalance
@@ -578,7 +581,7 @@ export const selectPortfolioTotalFiatBalancesForFeeAssetOnly = createSelector(
       },
       {}
     )
-  })
+  }
 )
 
 export const selectPortfolioAllocationPercentByAccountId = createSelector(


### PR DESCRIPTION
## Description

In order to get the correct allocation percentages, we needed to filter out any assets that were NOT the Fee asset for a given blockchain, ie if we're getting the allocation percentages for ETH, we need to filter out any token fiat balances from the total balance.

## Notice

Before submitting a pull request, please make sure you have answered the following:

- [x] Have you followed the guidelines in our [Contributing]('https://github.com/shapeshift/web/CONTRIBUTING.md) guide?
- [x] Have you checked to ensure there aren't other open [Pull Requests](https://github.com/shapeshift/web/pulls) for the same update/change?
- [x] Do all new and existing tests pass? Does the linter pass?

## Pull Request Type

- [x] :bug: Bug fix (Non-breaking Change: Fixes an issue)
- [ ] :hammer_and_wrench: Chore (Non-breaking Change: Doc updates, pkg upgrades, typos, etc..)
- [ ] :nail_care: New Feature (Breaking/Non-breaking Change)

## Issue (if applicable)

If applicable, please link to the github issue and put `closes #XXXX` in your comment to auto-close the issue that your PR fixes.

## Testing

Please outline all testing steps

1. Pull branch locally and run `yarn` to install new deps
2. etc...

## Screenshots (if applicable)
