### PR TITLE
fix: portfolio balance charts work again

### DIFF
--- a/src/state/slices/txHistorySlice/txHistorySlice.ts
+++ b/src/state/slices/txHistorySlice/txHistorySlice.ts
@@ -215,6 +215,8 @@ export const selectTxIdsByFilter = createSelector(
   selectAccountIdsParamFromFilter,
   (txsByAssetId, txsByAccountId, assetIds, accountIds): TxId[] => {
     const assetTxIds = assetIds.map(assetId => txsByAssetId[assetId] ?? []).flat()
+    // because the same tx can be related to multiple assets, e.g.
+    // a FOX airdrop claim has an eth fee, after we combine the ids we need to dedupe them
     if (!accountIds.length) return Array.from(new Set([...assetTxIds]))
     const accountsTxIds = accountIds.map(accountId => txsByAccountId[accountId]).flat()
     return intersection(accountsTxIds, assetTxIds)

--- a/src/state/slices/txHistorySlice/txHistorySlice.ts
+++ b/src/state/slices/txHistorySlice/txHistorySlice.ts
@@ -215,7 +215,7 @@ export const selectTxIdsByFilter = createSelector(
   selectAccountIdsParamFromFilter,
   (txsByAssetId, txsByAccountId, assetIds, accountIds): TxId[] => {
     const assetTxIds = assetIds.map(assetId => txsByAssetId[assetId] ?? []).flat()
-    if (!accountIds.length) return assetTxIds
+    if (!accountIds.length) return Array.from(new Set([...assetTxIds]))
     const accountsTxIds = accountIds.map(accountId => txsByAccountId[accountId]).flat()
     return intersection(accountsTxIds, assetTxIds)
   },


### PR DESCRIPTION
## Description

fixes portfolio balance charts

when selecting all txs by all assets, we had duplicates, because the same tx can be related to two assets, so now we're deduping and charts work

## Notice

Before submitting a pull request, please make sure you have answered the following:

- [x] Have you followed the guidelines in our [Contributing]('https://github.com/shapeshift/web/CONTRIBUTING.md) guide?
- [x] Have you checked to ensure there aren't other open [Pull Requests](https://github.com/shapeshift/web/pulls) for the same update/change?
- [x] Do all new and existing tests pass? Does the linter pass?

## Pull Request Type

- [x] :bug: Bug fix (Non-breaking Change: Fixes an issue)
- [ ] :hammer_and_wrench: Chore (Non-breaking Change: Doc updates, pkg upgrades, typos, etc..)
- [ ] :nail_care: New Feature (Breaking/Non-breaking Change)

## Issue (if applicable)

closes #789 

## Testing

Please outline all testing steps

1. check portfolio balance chart all time - should go back to zero
2. please also check all asset and account pages

## Screenshots (if applicable)
