### PR TITLE
fix: account allocation percent

### DIFF
--- a/src/components/AssetAccounts/AssetAccountRow.tsx
+++ b/src/components/AssetAccounts/AssetAccountRow.tsx
@@ -18,7 +18,7 @@ import { RawText } from 'components/Text'
 import { selectAssetByCAIP19 } from 'state/slices/assetsSlice/assetsSlice'
 import {
   AccountSpecifier,
-  selectPortfolioAllocationPercentByAccountId,
+  selectPortfolioAllocationPercentByFilter,
   selectPortfolioCryptoBalanceByFilter,
   selectPortfolioFiatBalanceByFilter
 } from 'state/slices/portfolioSlice/portfolioSlice'
@@ -53,7 +53,7 @@ export const AssetAccountRow = ({
   const fiatBalance = useAppSelector(state => selectPortfolioFiatBalanceByFilter(state, filter))
   const cryptoBalance = useAppSelector(state => selectPortfolioCryptoBalanceByFilter(state, filter))
   const allocation = useAppSelector(state =>
-    selectPortfolioAllocationPercentByAccountId(state, { accountId, assetId })
+    selectPortfolioAllocationPercentByFilter(state, { accountId, assetId })
   )
   const path = generatePath('/accounts/:accountId/:assetId', filter)
   const label = accountIdToLabel(accountId)

--- a/src/state/slices/portfolioSlice/portfolioSlice.test.ts
+++ b/src/state/slices/portfolioSlice/portfolioSlice.test.ts
@@ -14,8 +14,7 @@ import {
   selectPortfolioCryptoHumanBalanceByFilter,
   selectPortfolioFiatAccountBalances,
   selectPortfolioFiatBalanceByFilter,
-  selectPortfolioTotalFiatBalanceByAccount,
-  selectPortfolioTotalFiatBalancesForFeeAssetOnly
+  selectPortfolioTotalFiatBalanceByAccount
 } from './portfolioSlice'
 
 const ethCaip2 = 'eip155:1'
@@ -439,18 +438,6 @@ describe('Fiat Balance Selectors', () => {
 
       const result = selectPortfolioTotalFiatBalanceByAccount(state)
       expect(result).toEqual(expected)
-    })
-  })
-
-  describe('selectPortfolioTotalFiatBalancesForFeeAssetOnly', () => {
-    it('should return the total balances by account for fee asssets only - ie Bitcoin/Ethereum', () => {
-      const expected = {
-        [ethAccountSpecifier1]: '27.80',
-        [ethAccountSpecifier2]: '87.80'
-      }
-
-      const result = selectPortfolioTotalFiatBalancesForFeeAssetOnly(state)
-      expect(expected).toEqual(result)
     })
   })
 })

--- a/src/state/slices/portfolioSlice/portfolioSlice.test.ts
+++ b/src/state/slices/portfolioSlice/portfolioSlice.test.ts
@@ -7,7 +7,7 @@ import {
   accountToPortfolio,
   Portfolio,
   selectAccountIdByAddress,
-  selectPortfolioAllocationPercentByAccountId,
+  selectPortfolioAllocationPercentByFilter,
   selectPortfolioAssetAccounts,
   selectPortfolioAssetIdsByAccountId,
   selectPortfolioCryptoBalanceByAssetId,
@@ -346,7 +346,7 @@ describe('selectPortfolioAllocationPercentByAccountId', () => {
   it('can select fiat allocation by accountId', () => {
     const returnValue = 75.94498745783237
 
-    const allocationByAccountId = selectPortfolioAllocationPercentByAccountId(state, {
+    const allocationByAccountId = selectPortfolioAllocationPercentByFilter(state, {
       accountId: ethAccountSpecifier2,
       assetId: ethCaip19
     })

--- a/src/state/slices/portfolioSlice/portfolioSlice.ts
+++ b/src/state/slices/portfolioSlice/portfolioSlice.ts
@@ -584,7 +584,7 @@ export const selectPortfolioTotalFiatBalancesForFeeAssetOnly = createSelector(
   }
 )
 
-export const selectPortfolioAllocationPercentByAccountId = createSelector(
+export const selectPortfolioAllocationPercentByFilter = createSelector(
   selectPortfolioFiatBalances,
   selectPortfolioTotalFiatBalancesForFeeAssetOnly,
   selectAccountIdParamFromFilter,

--- a/src/state/slices/portfolioSlice/portfolioSlice.ts
+++ b/src/state/slices/portfolioSlice/portfolioSlice.ts
@@ -559,43 +559,18 @@ export const selectPortfolioTotalFiatBalanceByAccount = createSelector(
   }
 )
 
-export const selectPortfolioTotalFiatBalancesForFeeAssetOnly = createSelector(
-  selectPortfolioFiatAccountBalances,
-  accountBalances => {
-    return Object.entries(accountBalances).reduce<{ [k: AccountSpecifier]: string }>(
-      (acc, [accountId, balanceObj]) => {
-        const totalAccountFiatBalance = Object.entries(balanceObj).reduce(
-          (totalBalance, [assetId, assetBalance]) => {
-            // If the asset is NOT a fee asset, skip it
-            if (!FEE_ASSET_IDS.includes(assetId)) {
-              return totalBalance
-            }
-
-            return bnOrZero(bn(totalBalance).plus(bn(assetBalance))).toFixed(2)
-          },
-          '0'
-        )
-
-        acc[accountId] = totalAccountFiatBalance
-        return acc
-      },
-      {}
-    )
-  }
-)
-
 export const selectPortfolioAllocationPercentByFilter = createSelector(
   selectPortfolioFiatBalances,
-  selectPortfolioTotalFiatBalancesForFeeAssetOnly,
+  selectPortfolioFiatAccountBalances,
   selectAccountIdParamFromFilter,
   selectAssetIdParamFromFilter,
-  (totalFiatBalances, totalBalancesByAccount, accountId, assetId) => {
-    const totalFiatBalance = totalFiatBalances[assetId]
-    const balanceAllocationById = Object.entries(totalBalancesByAccount).reduce<{
+  (assetFiatBalances, assetFiatBalancesByAccount, accountId, assetId) => {
+    const totalAssetFiatBalance = assetFiatBalances[assetId]
+    const balanceAllocationById = Object.entries(assetFiatBalancesByAccount).reduce<{
       [k: AccountSpecifier]: number
-    }>((acc, [currentAccountId, accountBalance]) => {
-      const allocation = bnOrZero(accountBalance)
-        .div(bnOrZero(totalFiatBalance))
+    }>((acc, [currentAccountId, assetAccountFiatBalance]) => {
+      const allocation = bnOrZero(assetAccountFiatBalance[assetId])
+        .div(bnOrZero(totalAssetFiatBalance))
         .times(100)
         .toNumber()
 


### PR DESCRIPTION
## Description

fixes account allocation for erc20s

## Notice

Before submitting a pull request, please make sure you have answered the following:

- [x] Have you followed the guidelines in our [Contributing]('https://github.com/shapeshift/web/CONTRIBUTING.md) guide?
- [x] Have you checked to ensure there aren't other open [Pull Requests](https://github.com/shapeshift/web/pulls) for the same update/change?
- [x] Do all new and existing tests pass? Does the linter pass?

## Pull Request Type

- [x] :bug: Bug fix (Non-breaking Change: Fixes an issue)
- [ ] :hammer_and_wrench: Chore (Non-breaking Change: Doc updates, pkg upgrades, typos, etc..)
- [ ] :nail_care: New Feature (Breaking/Non-breaking Change)

## Issue (if applicable)

n/a

## Testing

1. check account allocation percentage on an asset page, e.g. btc or fox
2. for assets with multiple accounts (btc) the allocation bars should add up to a full bar
3. for assets with a single account (eth or erc20s) the allocation bars should be 100% (until we have accountIndex > 0)

## Screenshots (if applicable)

nah