### PR TITLE
feat: trim leading and trailing whitespace on send addresses

### DIFF
--- a/src/components/Modals/Send/AddressInput/AddressInput.tsx
+++ b/src/components/Modals/Send/AddressInput/AddressInput.tsx
@@ -28,7 +28,7 @@ export const AddressInput = ({ rules }: AddressInputProps) => {
             spellCheck={false}
             autoFocus // eslint-disable-line jsx-a11y/no-autofocus
             fontSize='sm'
-            onChange={onChange}
+            onChange={e => onChange(e.target.value.trim())}
             placeholder={translate('modals.send.tokenAddress')}
             size='lg'
             value={value}


### PR DESCRIPTION
## Description

Trims leading and trailing whitespace for all "send" address inputs.

## Notice

Before submitting a pull request, please make sure you have answered the following:

- [x] Have you followed the guidelines in our [Contributing]('https://github.com/shapeshift/web/CONTRIBUTING.md) guide?
- [x] Have you checked to ensure there aren't other open [Pull Requests](https://github.com/shapeshift/web/pulls) for the same update/change?
- [x] Do all new and existing tests pass? Does the linter pass?

## Pull Request Type

- [ ] :bug: Bug fix (Non-breaking Change: Fixes an issue)
- [ ] :hammer_and_wrench: Chore (Non-breaking Change: Doc updates, pkg upgrades, typos, etc..)
- [x] :nail_care: New Feature (Breaking/Non-breaking Change)

## Issue (if applicable)

Addresses https://github.com/shapeshift/web/issues/735.

## Testing

Please outline all testing steps

Attempt to paste an address with leaving or trailing spaces into the send address.

## Screenshots (if applicable)

N/A