### PR TITLE
feat: sort token asset Ids by fiat balance

### DIFF
--- a/src/state/slices/portfolioSlice/portfolioSlice.test.ts
+++ b/src/state/slices/portfolioSlice/portfolioSlice.test.ts
@@ -11,12 +11,12 @@ import {
   selectPortfolioAllocationPercentByFilter,
   selectPortfolioAssetAccounts,
   selectPortfolioAssetIdsByAccountId,
+  selectPortfolioAssetIdsByAccountIdExcludeFeeAsset,
   selectPortfolioCryptoBalanceByAssetId,
   selectPortfolioCryptoHumanBalanceByFilter,
   selectPortfolioFiatAccountBalances,
   selectPortfolioFiatBalanceByFilter,
-  selectPortfolioTotalFiatBalanceByAccount,
-  selectPortfolioAssetIdsByAccountIdExcludeFeeAsset
+  selectPortfolioTotalFiatBalanceByAccount
 } from './portfolioSlice'
 
 const ethCaip2 = 'eip155:1'
@@ -465,7 +465,7 @@ describe('selectPortfolioAccountIdsSortedFiat', () => {
 describe('selectPortfolioAssetIdsByAccountIdExcludeFeeAsset', () => {
   it('should return assetIds (excluding fee assets, ie Ethereum) of a given account, sorted by fiat value', () => {
     // TODO(ryankk): refactor test state to make it easier to add new assets. This is a pretty pointless test with only two
-    // assets (one of them being a fee asset), so this needs to be refactored
+    // assets in state (one of them being a fee asset), but want to keep it here for reference.
     const expected = [foxCaip19]
     const result = selectPortfolioAssetIdsByAccountIdExcludeFeeAsset(state, ethAccountSpecifier1)
 

--- a/src/state/slices/portfolioSlice/portfolioSlice.test.ts
+++ b/src/state/slices/portfolioSlice/portfolioSlice.test.ts
@@ -15,7 +15,8 @@ import {
   selectPortfolioCryptoHumanBalanceByFilter,
   selectPortfolioFiatAccountBalances,
   selectPortfolioFiatBalanceByFilter,
-  selectPortfolioTotalFiatBalanceByAccount
+  selectPortfolioTotalFiatBalanceByAccount,
+  selectPortfolioAssetIdsByAccountIdExcludeFeeAsset
 } from './portfolioSlice'
 
 const ethCaip2 = 'eip155:1'
@@ -456,6 +457,17 @@ describe('selectPortfolioAccountIdsSortedFiat', () => {
   it('should return an array of account IDs sorted by fiat balance', () => {
     const expected = [ethAccountSpecifier2, ethAccountSpecifier1]
     const result = selectPortfolioAccountIdsSortedFiat(state)
+
+    expect(result).toEqual(expected)
+  })
+})
+
+describe('selectPortfolioAssetIdsByAccountIdExcludeFeeAsset', () => {
+  it('should return assetIds (excluding fee assets, ie Ethereum) of a given account, sorted by fiat value', () => {
+    // TODO(ryankk): refactor test state to make it easier to add new assets. This is a pretty pointless test with only two
+    // assets (one of them being a fee asset), so this needs to be refactored
+    const expected = [foxCaip19]
+    const result = selectPortfolioAssetIdsByAccountIdExcludeFeeAsset(state, ethAccountSpecifier1)
 
     expect(result).toEqual(expected)
   })

--- a/src/state/slices/portfolioSlice/portfolioSlice.ts
+++ b/src/state/slices/portfolioSlice/portfolioSlice.ts
@@ -475,7 +475,7 @@ export const selectPortfolioCryptoBalanceByFilter = createSelector(
     if (accountId && assetId) {
       return fromBaseUnit(
         bnOrZero(accountBalances[accountId][assetId]),
-        assets[assetId].precision ?? 0
+        assets[assetId]?.precision ?? 0
       )
     }
     return assetBalances[assetId] ?? 0
@@ -522,6 +522,22 @@ export const selectPortfolioAssetBalancesSortedFiat = createSelector(
         acc[assetId] = assetFiatBalance
         return acc
       }, {})
+)
+
+export const selectPortfolioAssetAccountBalancesSortedFiat = createSelector(
+  selectPortfolioFiatAccountBalances,
+  (portfolioFiatAccountBalances): { [k: AccountSpecifier]: [string, string][] } => {
+    return Object.entries(portfolioFiatAccountBalances).reduce<{
+      [k: AccountSpecifier]: [string, string][]
+    }>((acc, [accountId, assetBalanceObj]) => {
+      const sortedAssetsByFiatBalances = Object.entries(assetBalanceObj).sort(([_, a], [__, b]) =>
+        bnOrZero(a).gte(bnOrZero(b)) ? -1 : 1
+      )
+
+      acc[accountId] = sortedAssetsByFiatBalances
+      return acc
+    }, {})
+  }
 )
 
 export const selectPortfolioAssetIdsSortedFiat = createSelector(
@@ -620,10 +636,14 @@ export const selectPortfolioAssetIdsByAccountId = createSelector(
 )
 
 export const selectPortfolioAssetIdsByAccountIdExcludeFeeAsset = createSelector(
-  selectAssets,
-  selectPortfolioAssetIdsByAccountId,
-  (assets, assetIds) =>
-    assetIds.filter(assetId => !FEE_ASSET_IDS.includes(assetId) && assets[assetId])
+  selectPortfolioAssetAccountBalancesSortedFiat,
+  selectAccountIdParam,
+  (accountAssets, accountId) => {
+    const assetsByAccountIds = accountAssets[accountId]
+    return assetsByAccountIds
+      .map(([assetId, _]) => assetId)
+      .filter(assetId => !FEE_ASSET_IDS.includes(assetId))
+  }
 )
 
 export const selectAccountIdByAddress = createSelector(


### PR DESCRIPTION
## Description

refactor `selectPortfolioAssetIdsByAccountIdExcludeFeeAsset` to sort assetIds by fiat balance.

## Notice

Before submitting a pull request, please make sure you have answered the following:

- [x] Have you followed the guidelines in our [Contributing]('https://github.com/shapeshift/web/CONTRIBUTING.md) guide?
- [x] Have you checked to ensure there aren't other open [Pull Requests](https://github.com/shapeshift/web/pulls) for the same update/change?
- [x] Do all new and existing tests pass? Does the linter pass?

## Pull Request Type

- [ ] :bug: Bug fix (Non-breaking Change: Fixes an issue)
- [ ] :hammer_and_wrench: Chore (Non-breaking Change: Doc updates, pkg upgrades, typos, etc..)
- [x] :nail_care: New Feature (Breaking/Non-breaking Change)

## Issue (if applicable)

If applicable, please link to the github issue and put `closes #XXXX` in your comment to auto-close the issue that your PR fixes.

closes #788 

## Testing

Please outline all testing steps

1. Pull branch locally and run `yarn` to install new deps
2. etc...

## Screenshots (if applicable)
