### PR TITLE
bug: add account id

### DIFF
--- a/src/components/AssetHeader/AssetHeader.tsx
+++ b/src/components/AssetHeader/AssetHeader.tsx
@@ -36,6 +36,7 @@ import {
 import { selectMarketDataById } from 'state/slices/marketDataSlice/marketDataSlice'
 import {
   AccountSpecifier,
+  selectAccountIdsByAssetId,
   selectPortfolioCryptoHumanBalanceByFilter,
   selectPortfolioFiatBalanceByFilter
 } from 'state/slices/portfolioSlice/portfolioSlice'
@@ -65,6 +66,8 @@ export const AssetHeader: React.FC<AssetHeaderProps> = ({ assetId, accountId }) 
   const asset = useAppSelector(state => selectAssetByCAIP19(state, assetId))
   const chainId = asset.caip2
   const marketData = useAppSelector(state => selectMarketDataById(state, assetId))
+  const accountIds = useAppSelector(state => selectAccountIdsByAssetId(state, assetId))
+  const singleAccount = accountIds && accountIds.length === 1 ? accountIds[0] : undefined
   const isLoaded = !!marketData
   const { name, symbol, description, icon } = asset || {}
   useGetAssetDescriptionQuery(assetId)
@@ -111,7 +114,11 @@ export const AssetHeader: React.FC<AssetHeaderProps> = ({ assetId, accountId }) 
           </Box>
         </Flex>
         {walletSupportsChain ? (
-          <AssetActions isLoaded={isLoaded} assetId={assetId} accountId={accountId} />
+          <AssetActions
+            isLoaded={isLoaded}
+            assetId={assetId}
+            accountId={accountId ? accountId : singleAccount}
+          />
         ) : null}
       </Card.Header>
       <Card.Body>

--- a/src/state/slices/portfolioSlice/portfolioSlice.ts
+++ b/src/state/slices/portfolioSlice/portfolioSlice.ts
@@ -638,15 +638,16 @@ export const selectPortfolioAssetIdsByAccountId = createSelector(
   (accounts, accountId) => Object.keys(accounts[accountId])
 )
 
+// @TODO: remove this assets check once we filter the portfolio on the way in
 export const selectPortfolioAssetIdsByAccountIdExcludeFeeAsset = createSelector(
   selectPortfolioAssetAccountBalancesSortedFiat,
   selectAccountIdParam,
   selectAssets,
   (accountAssets, accountId, assets) => {
     const assetsByAccountIds = accountAssets[accountId]
-    return Object.entries(assetsByAccountIds)
-      .map(([assetId, _]) => assetId)
-      .filter(assetId => !FEE_ASSET_IDS.includes(assetId) && assets[assetId])
+    return Object.keys(assetsByAccountIds).filter(
+      assetId => !FEE_ASSET_IDS.includes(assetId) && assets[assetId]
+    )
   }
 )
 

--- a/src/state/slices/portfolioSlice/portfolioSlice.ts
+++ b/src/state/slices/portfolioSlice/portfolioSlice.ts
@@ -641,11 +641,12 @@ export const selectPortfolioAssetIdsByAccountId = createSelector(
 export const selectPortfolioAssetIdsByAccountIdExcludeFeeAsset = createSelector(
   selectPortfolioAssetAccountBalancesSortedFiat,
   selectAccountIdParam,
-  (accountAssets, accountId) => {
+  selectAssets,
+  (accountAssets, accountId, assets) => {
     const assetsByAccountIds = accountAssets[accountId]
     return Object.entries(assetsByAccountIds)
       .map(([assetId, _]) => assetId)
-      .filter(assetId => !FEE_ASSET_IDS.includes(assetId))
+      .filter(assetId => !FEE_ASSET_IDS.includes(assetId) && assets[assetId])
   }
 )
 


### PR DESCRIPTION
## Description

- Added account ID to asset action if there is only one account
- Filter out tokens we don't support on the `selectPortfolioAssetIdsByAccountIdExcludeFeeAsset` selector

## Notice

Before submitting a pull request, please make sure you have answered the following:

- [x] Have you followed the guidelines in our [Contributing]('https://github.com/shapeshift/web/CONTRIBUTING.md) guide?
- [x] Have you checked to ensure there aren't other open [Pull Requests](https://github.com/shapeshift/web/pulls) for the same update/change?
- [x] Do all new and existing tests pass? Does the linter pass?

## Pull Request Type

- [x] :bug: Bug fix (Non-breaking Change: Fixes an issue)
- [ ] :hammer_and_wrench: Chore (Non-breaking Change: Doc updates, pkg upgrades, typos, etc..)
- [ ] :nail_care: New Feature (Breaking/Non-breaking Change)

## Issue (if applicable)

If applicable, please link to the github issue and put `closes #XXXX` in your comment to auto-close the issue that your PR fixes.

## Testing

Please outline all testing steps

1. Pull branch locally and run `yarn` to install new deps
2. etc...

## Screenshots (if applicable)
