### PR TITLE
refactor: allow multiple transaction types in transactionRow

### DIFF
--- a/src/components/Transactions/TransactionReceive.tsx
+++ b/src/components/Transactions/TransactionReceive.tsx
@@ -1,0 +1,179 @@
+import { ArrowDownIcon, CheckCircleIcon, WarningTwoIcon } from '@chakra-ui/icons'
+import { Box, Collapse, Flex, Link, SimpleGrid, Tag } from '@chakra-ui/react'
+import { Asset, chainAdapters } from '@shapeshiftoss/types'
+import dayjs from 'dayjs'
+import { useState } from 'react'
+import { Amount } from 'components/Amount/Amount'
+import { CircularProgress } from 'components/CircularProgress/CircularProgress'
+import { IconCircle } from 'components/IconCircle'
+import { MiddleEllipsis } from 'components/MiddleEllipsis/MiddleEllipsis'
+import { Row } from 'components/Row/Row'
+import { RawText, Text } from 'components/Text'
+import { TxDetails } from 'hooks/useTxDetails/useTxDetails'
+import { fromBaseUnit } from 'lib/math'
+
+export const TransactionReceive = ({
+  txDetails
+}: {
+  txDetails: TxDetails
+  activeAsset?: Asset
+}) => {
+  const [isOpen, setIsOpen] = useState(false)
+  const toggleOpen = () => setIsOpen(!isOpen)
+
+  return (
+    <>
+      <Flex
+        alignItems='center'
+        flex={1}
+        justifyContent='space-between'
+        textAlign='left'
+        as='button'
+        w='full'
+        py={4}
+        onClick={toggleOpen}
+      >
+        <Flex alignItems='center' width='full'>
+          <IconCircle mr={3}>
+            <ArrowDownIcon color='green.500' />
+          </IconCircle>
+
+          <Flex justifyContent='flex-start' flex={1} alignItems='center'>
+            <Box flex={1}>
+              <Text
+                fontWeight='bold'
+                overflow='hidden'
+                flex={1}
+                textOverflow='ellipsis'
+                maxWidth='60%'
+                lineHeight='1'
+                whiteSpace='nowrap'
+                mb={2}
+                translation={[`transactionRow.${txDetails.type.toLowerCase()}`, { symbol: '' }]}
+              />
+              <RawText color='gray.500' fontSize='sm' lineHeight='1'>
+                {dayjs(txDetails.tx.blockTime * 1000).fromNow()}
+              </RawText>
+            </Box>
+
+            <Flex flexDir='column' ml='auto' textAlign='right'>
+              <Amount.Crypto
+                color='green.500'
+                value={fromBaseUnit(txDetails.value, txDetails.precision)}
+                symbol={txDetails.symbol}
+                maximumFractionDigits={6}
+                prefix=''
+              />
+            </Flex>
+          </Flex>
+        </Flex>
+      </Flex>
+      <Collapse in={isOpen} unmountOnExit>
+        <SimpleGrid gridTemplateColumns='repeat(auto-fit, minmax(180px, 1fr))' spacing='4' py={6}>
+          <Row variant='vertical'>
+            <Row.Label>
+              <Text translation='transactionRow.date' />
+            </Row.Label>
+            <Row.Value>{dayjs(Number(txDetails.tx.blockTime) * 1000).format('LLL')}</Row.Value>
+          </Row>
+          <Row variant='vertical'>
+            <Row.Label>
+              <Text translation='transactionRow.txid' />
+            </Row.Label>
+            <Row.Value>
+              <Link
+                isExternal
+                color='blue.500'
+                href={`${txDetails.explorerTxLink}${txDetails.tx.txid}`}
+              >
+                <MiddleEllipsis maxWidth='180px'>{txDetails.tx.txid}</MiddleEllipsis>
+              </Link>
+            </Row.Value>
+          </Row>
+
+          <Row variant='vertical' hidden={!txDetails.tradeTx}>
+            <Row.Label>
+              <Text translation={'transactionRow.amount'} />
+            </Row.Label>
+            <Row.Value>
+              <Amount.Crypto
+                value={fromBaseUnit(
+                  txDetails.sellTx?.value ?? '0',
+                  txDetails.sellAsset?.precision ?? 18
+                )}
+                symbol={txDetails.sellAsset?.symbol ?? ''}
+                maximumFractionDigits={6}
+              />
+              <Text translation='transactionRow.for' />
+              <Amount.Crypto
+                value={fromBaseUnit(
+                  txDetails.buyTx?.value ?? '0',
+                  txDetails.buyAsset?.precision ?? 18
+                )}
+                symbol={txDetails.buyAsset?.symbol ?? ''}
+                maximumFractionDigits={6}
+              />
+            </Row.Value>
+          </Row>
+
+          <Row variant='vertical'>
+            <Row.Label>
+              <Text translation='transactionRow.fee' />
+            </Row.Label>
+            <Row.Value>
+              {txDetails.tx?.fee && txDetails.feeAsset && (
+                <Amount.Crypto
+                  value={fromBaseUnit(
+                    txDetails.tx?.fee?.value ?? '0',
+                    txDetails.feeAsset?.precision ?? 18
+                  )}
+                  symbol={txDetails.feeAsset.symbol}
+                  maximumFractionDigits={6}
+                />
+              )}
+            </Row.Value>
+          </Row>
+          <Row variant='vertical'>
+            <Row.Label>
+              <Text translation='transactionRow.status' />
+            </Row.Label>
+            <Row.Value textAlign='left'>
+              {txDetails.tx.status === chainAdapters.TxStatus.Confirmed && (
+                <Tag colorScheme='green' size='lg'>
+                  <CheckCircleIcon mr={2} />
+                  <Text translation='transactionRow.confirmed' />
+                </Tag>
+              )}
+              {txDetails.tx.status === chainAdapters.TxStatus.Pending && (
+                <Tag colorScheme='blue' size='lg'>
+                  <CircularProgress mr={2} size='5' />
+                  <Text translation='transactionRow.pending' />
+                </Tag>
+              )}
+              {txDetails.tx.status === chainAdapters.TxStatus.Failed && (
+                <Tag colorScheme='red' size='lg'>
+                  <WarningTwoIcon mr={2} />
+                  <Text translation='transactionRow.failed' />
+                </Tag>
+              )}
+            </Row.Value>
+          </Row>
+          <Row variant='vertical'>
+            <Row.Label>
+              <Text translation={'transactionRow.from'} />
+            </Row.Label>
+            <Row.Value>
+              <Link
+                isExternal
+                color='blue.500'
+                href={`${txDetails.explorerAddressLink}${txDetails.to ?? txDetails.from}`}
+              >
+                <MiddleEllipsis maxWidth='180px'>{txDetails.to ?? txDetails.from}</MiddleEllipsis>
+              </Link>
+            </Row.Value>
+          </Row>
+        </SimpleGrid>
+      </Collapse>
+    </>
+  )
+}

--- a/src/components/Transactions/TransactionRow.tsx
+++ b/src/components/Transactions/TransactionRow.tsx
@@ -1,218 +1,50 @@
-import { ArrowDownIcon, ArrowUpIcon, CheckCircleIcon, WarningTwoIcon } from '@chakra-ui/icons'
-import { Box, Collapse, Flex, Link, SimpleGrid, Tag, useColorModeValue } from '@chakra-ui/react'
-import { Asset, chainAdapters } from '@shapeshiftoss/types'
+import { Box, useColorModeValue } from '@chakra-ui/react'
+import { Asset } from '@shapeshiftoss/types'
+import { TradeType, TxType } from '@shapeshiftoss/types/dist/chain-adapters'
 import dayjs from 'dayjs'
 import localizedFormat from 'dayjs/plugin/localizedFormat'
 import relativeTime from 'dayjs/plugin/relativeTime'
-import { useRef, useState } from 'react'
-import { FaExchangeAlt } from 'react-icons/fa'
-import { useSelector } from 'react-redux'
-import { Amount } from 'components/Amount/Amount'
-import { CircularProgress } from 'components/CircularProgress/CircularProgress'
-import { IconCircle } from 'components/IconCircle'
-import { MiddleEllipsis } from 'components/MiddleEllipsis/MiddleEllipsis'
-import { Row } from 'components/Row/Row'
-import { RawText, Text } from 'components/Text'
-import { fromBaseUnit } from 'lib/math'
-import { ReduxState } from 'state/reducer'
-import { selectAssetByCAIP19 } from 'state/slices/assetsSlice/assetsSlice'
-import { selectTxById } from 'state/slices/txHistorySlice/txHistorySlice'
+import { useRef } from 'react'
+import { TransactionReceive } from 'components/Transactions/TransactionReceive'
+import { TransactionSend } from 'components/Transactions/TransactionSend'
+import { TransactionTrade } from 'components/Transactions/TransactionTrade'
+import { TxDetails, useTxDetails } from 'hooks/useTxDetails/useTxDetails'
 
 dayjs.extend(relativeTime)
 dayjs.extend(localizedFormat)
 
+const renderTransactionType = (txDetails: TxDetails, activeAsset?: Asset): JSX.Element | null => {
+  return (() => {
+    switch (txDetails.type) {
+      case TxType.Send:
+        return <TransactionSend txDetails={txDetails} />
+      case TxType.Receive:
+        return <TransactionReceive txDetails={txDetails} />
+      case TradeType.Trade:
+        return <TransactionTrade txDetails={txDetails} activeAsset={activeAsset} />
+      default:
+        // Unhandled transaction type - don't render anything
+        return null
+    }
+  })()
+}
+
 export const TransactionRow = ({ txId, activeAsset }: { txId: string; activeAsset?: Asset }) => {
   const ref = useRef<HTMLHeadingElement>(null)
-  const [isOpen, setIsOpen] = useState(false)
-  const toggleOpen = () => setIsOpen(!isOpen)
 
   const bg = useColorModeValue('gray.50', 'whiteAlpha.100')
-
-  const tx = useSelector((state: ReduxState) => selectTxById(state, txId))
-
-  const standardTx = tx.transfers.length === 1 ? tx.transfers[0] : undefined
-  const buyTx = !!tx.tradeDetails
-    ? tx.transfers.find(t => t.type === chainAdapters.TxType.Receive)
-    : undefined
-  const sellTx = !!tx.tradeDetails
-    ? tx.transfers.find(t => t.type === chainAdapters.TxType.Send)
-    : undefined
-  const tradeTx = activeAsset?.caip19 === sellTx?.caip19 ? sellTx : buyTx
-
-  const standardAsset = useSelector((state: ReduxState) =>
-    selectAssetByCAIP19(state, standardTx?.caip19 ?? '')
-  )
-
-  // stables need precision of eth (18) rather than 10
-  const feeAsset = useSelector((state: ReduxState) =>
-    selectAssetByCAIP19(state, tx.fee?.caip19 ?? '')
-  )
-  const buyAsset = useSelector((state: ReduxState) =>
-    selectAssetByCAIP19(state, buyTx?.caip19 ?? '')
-  )
-  const sellAsset = useSelector((state: ReduxState) =>
-    selectAssetByCAIP19(state, sellTx?.caip19 ?? '')
-  )
-  const tradeAsset = activeAsset?.symbol === sellAsset?.symbol ? sellAsset : buyAsset
-
-  const value = standardTx?.value ?? tradeTx?.value ?? '0'
-  const to = standardTx?.to ?? tradeTx?.to ?? ''
-  const from = standardTx?.from ?? tradeTx?.from ?? ''
-  const type = standardTx?.type ?? tx.tradeDetails?.type ?? ''
-  const symbol = standardAsset?.symbol ?? tradeAsset?.symbol ?? ''
-  const precision = standardAsset?.precision ?? tradeAsset?.precision ?? 18
-  const explorerTxLink = standardAsset?.explorerTxLink ?? tradeAsset?.explorerTxLink ?? ''
-  const explorerAddressLink =
-    standardAsset?.explorerAddressLink ?? tradeAsset?.explorerAddressLink ?? ''
+  const txDetails = useTxDetails(txId, activeAsset)
 
   // TODO(0xdef1cafe): support yearn vault deposit withdrawals
   // log what transactions we are currently not parsing so we can update accordingly
-  if (!type) {
+  if (!txDetails.type) {
     // console.warn('unsupported transaction:', tx.txid)
     return null
   }
 
   return (
     <Box ref={ref} width='full' pl={3} pr={4} rounded='lg' _hover={{ bg }}>
-      <Flex
-        alignItems='center'
-        flex={1}
-        justifyContent='space-between'
-        textAlign='left'
-        as='button'
-        w='full'
-        py={4}
-        onClick={toggleOpen}
-      >
-        <Flex alignItems='center' width='full'>
-          <IconCircle mr={3}>
-            {type === chainAdapters.TxType.Send && <ArrowUpIcon />}
-            {type === chainAdapters.TxType.Receive && <ArrowDownIcon color='green.500' />}
-            {type === chainAdapters.TradeType.Trade && <FaExchangeAlt />}
-          </IconCircle>
-
-          <Flex justifyContent='flex-start' flex={1} alignItems='center'>
-            <Box flex={1}>
-              <Text
-                fontWeight='bold'
-                overflow='hidden'
-                flex={1}
-                textOverflow='ellipsis'
-                maxWidth='60%'
-                lineHeight='1'
-                whiteSpace='nowrap'
-                mb={2}
-                translation={[`transactionRow.${type.toLowerCase()}`, { symbol: '' }]}
-              />
-              <RawText color='gray.500' fontSize='sm' lineHeight='1'>
-                {dayjs(tx.blockTime * 1000).fromNow()}
-              </RawText>
-            </Box>
-
-            <Flex flexDir='column' ml='auto' textAlign='right'>
-              <Amount.Crypto
-                color={type === chainAdapters.TxType.Receive ? 'green.500' : 'inherit'}
-                value={fromBaseUnit(value, precision)}
-                symbol={symbol}
-                maximumFractionDigits={6}
-                prefix={type === chainAdapters.TxType.Send ? '-' : ''}
-              />
-            </Flex>
-          </Flex>
-        </Flex>
-      </Flex>
-      <Collapse in={isOpen} unmountOnExit>
-        <SimpleGrid gridTemplateColumns='repeat(auto-fit, minmax(180px, 1fr))' spacing='4' py={6}>
-          <Row variant='vertical'>
-            <Row.Label>
-              <Text translation='transactionRow.date' />
-            </Row.Label>
-            <Row.Value>{dayjs(Number(tx.blockTime) * 1000).format('LLL')}</Row.Value>
-          </Row>
-          <Row variant='vertical'>
-            <Row.Label>
-              <Text translation='transactionRow.txid' />
-            </Row.Label>
-            <Row.Value>
-              <Link isExternal color='blue.500' href={`${explorerTxLink}${tx.txid}`}>
-                <MiddleEllipsis maxWidth='180px'>{tx.txid}</MiddleEllipsis>
-              </Link>
-            </Row.Value>
-          </Row>
-
-          <Row variant='vertical' hidden={!tradeTx}>
-            <Row.Label>
-              <Text translation={'transactionRow.amount'} />
-            </Row.Label>
-            <Row.Value>
-              <Amount.Crypto
-                value={fromBaseUnit(sellTx?.value ?? '0', sellAsset?.precision ?? 18)}
-                symbol={sellAsset?.symbol ?? ''}
-                maximumFractionDigits={6}
-              />
-              <Text translation='transactionRow.for' />
-              <Amount.Crypto
-                value={fromBaseUnit(buyTx?.value ?? '0', buyAsset?.precision ?? 18)}
-                symbol={buyAsset?.symbol ?? ''}
-                maximumFractionDigits={6}
-              />
-            </Row.Value>
-          </Row>
-
-          <Row variant='vertical'>
-            <Row.Label>
-              <Text translation='transactionRow.fee' />
-            </Row.Label>
-            <Row.Value>
-              {tx?.fee && feeAsset && (
-                <Amount.Crypto
-                  value={fromBaseUnit(tx?.fee?.value ?? '0', feeAsset?.precision ?? 18)}
-                  symbol={feeAsset.symbol}
-                  maximumFractionDigits={6}
-                />
-              )}
-            </Row.Value>
-          </Row>
-          <Row variant='vertical'>
-            <Row.Label>
-              <Text translation='transactionRow.status' />
-            </Row.Label>
-            <Row.Value textAlign='left'>
-              {tx.status === chainAdapters.TxStatus.Confirmed && (
-                <Tag colorScheme='green' size='lg'>
-                  <CheckCircleIcon mr={2} />
-                  <Text translation='transactionRow.confirmed' />
-                </Tag>
-              )}
-              {tx.status === chainAdapters.TxStatus.Pending && (
-                <Tag colorScheme='blue' size='lg'>
-                  <CircularProgress mr={2} size='5' />
-                  <Text translation='transactionRow.pending' />
-                </Tag>
-              )}
-              {tx.status === chainAdapters.TxStatus.Failed && (
-                <Tag colorScheme='red' size='lg'>
-                  <WarningTwoIcon mr={2} />
-                  <Text translation='transactionRow.failed' />
-                </Tag>
-              )}
-            </Row.Value>
-          </Row>
-          <Row variant='vertical'>
-            <Row.Label>
-              {type === chainAdapters.TxType.Send && <Text translation={'transactionRow.to'} />}
-              {type === chainAdapters.TxType.Receive && (
-                <Text translation={'transactionRow.from'} />
-              )}
-            </Row.Label>
-            <Row.Value>
-              <Link isExternal color='blue.500' href={`${explorerAddressLink}${to ?? from}`}>
-                <MiddleEllipsis maxWidth='180px'>{to ?? from}</MiddleEllipsis>
-              </Link>
-            </Row.Value>
-          </Row>
-        </SimpleGrid>
-      </Collapse>
+      {renderTransactionType(txDetails)}
     </Box>
   )
 }

--- a/src/components/Transactions/TransactionSend.tsx
+++ b/src/components/Transactions/TransactionSend.tsx
@@ -1,0 +1,174 @@
+import { ArrowUpIcon, CheckCircleIcon, WarningTwoIcon } from '@chakra-ui/icons'
+import { Box, Collapse, Flex, Link, SimpleGrid, Tag } from '@chakra-ui/react'
+import { Asset, chainAdapters } from '@shapeshiftoss/types'
+import dayjs from 'dayjs'
+import { useState } from 'react'
+import { Amount } from 'components/Amount/Amount'
+import { CircularProgress } from 'components/CircularProgress/CircularProgress'
+import { IconCircle } from 'components/IconCircle'
+import { MiddleEllipsis } from 'components/MiddleEllipsis/MiddleEllipsis'
+import { Row } from 'components/Row/Row'
+import { RawText, Text } from 'components/Text'
+import { TxDetails } from 'hooks/useTxDetails/useTxDetails'
+import { fromBaseUnit } from 'lib/math'
+
+export const TransactionSend = ({ txDetails }: { txDetails: TxDetails; activeAsset?: Asset }) => {
+  const [isOpen, setIsOpen] = useState(false)
+  const toggleOpen = () => setIsOpen(!isOpen)
+
+  return (
+    <>
+      <Flex
+        alignItems='center'
+        flex={1}
+        justifyContent='space-between'
+        textAlign='left'
+        as='button'
+        w='full'
+        py={4}
+        onClick={toggleOpen}
+      >
+        <Flex alignItems='center' width='full'>
+          <IconCircle mr={3}>
+            <ArrowUpIcon />
+          </IconCircle>
+
+          <Flex justifyContent='flex-start' flex={1} alignItems='center'>
+            <Box flex={1}>
+              <Text
+                fontWeight='bold'
+                overflow='hidden'
+                flex={1}
+                textOverflow='ellipsis'
+                maxWidth='60%'
+                lineHeight='1'
+                whiteSpace='nowrap'
+                mb={2}
+                translation={[`transactionRow.${txDetails.type.toLowerCase()}`, { symbol: '' }]}
+              />
+              <RawText color='gray.500' fontSize='sm' lineHeight='1'>
+                {dayjs(txDetails.tx.blockTime * 1000).fromNow()}
+              </RawText>
+            </Box>
+
+            <Flex flexDir='column' ml='auto' textAlign='right'>
+              <Amount.Crypto
+                color='inherit'
+                value={fromBaseUnit(txDetails.value, txDetails.precision)}
+                symbol={txDetails.symbol}
+                maximumFractionDigits={6}
+                prefix='-'
+              />
+            </Flex>
+          </Flex>
+        </Flex>
+      </Flex>
+      <Collapse in={isOpen} unmountOnExit>
+        <SimpleGrid gridTemplateColumns='repeat(auto-fit, minmax(180px, 1fr))' spacing='4' py={6}>
+          <Row variant='vertical'>
+            <Row.Label>
+              <Text translation='transactionRow.date' />
+            </Row.Label>
+            <Row.Value>{dayjs(Number(txDetails.tx.blockTime) * 1000).format('LLL')}</Row.Value>
+          </Row>
+          <Row variant='vertical'>
+            <Row.Label>
+              <Text translation='transactionRow.txid' />
+            </Row.Label>
+            <Row.Value>
+              <Link
+                isExternal
+                color='blue.500'
+                href={`${txDetails.explorerTxLink}${txDetails.tx.txid}`}
+              >
+                <MiddleEllipsis maxWidth='180px'>{txDetails.tx.txid}</MiddleEllipsis>
+              </Link>
+            </Row.Value>
+          </Row>
+
+          <Row variant='vertical' hidden={!txDetails.tradeTx}>
+            <Row.Label>
+              <Text translation={'transactionRow.amount'} />
+            </Row.Label>
+            <Row.Value>
+              <Amount.Crypto
+                value={fromBaseUnit(
+                  txDetails.sellTx?.value ?? '0',
+                  txDetails.sellAsset?.precision ?? 18
+                )}
+                symbol={txDetails.sellAsset?.symbol ?? ''}
+                maximumFractionDigits={6}
+              />
+              <Text translation='transactionRow.for' />
+              <Amount.Crypto
+                value={fromBaseUnit(
+                  txDetails.buyTx?.value ?? '0',
+                  txDetails.buyAsset?.precision ?? 18
+                )}
+                symbol={txDetails.buyAsset?.symbol ?? ''}
+                maximumFractionDigits={6}
+              />
+            </Row.Value>
+          </Row>
+
+          <Row variant='vertical'>
+            <Row.Label>
+              <Text translation='transactionRow.fee' />
+            </Row.Label>
+            <Row.Value>
+              {txDetails.tx?.fee && txDetails.feeAsset && (
+                <Amount.Crypto
+                  value={fromBaseUnit(
+                    txDetails.tx?.fee?.value ?? '0',
+                    txDetails.feeAsset?.precision ?? 18
+                  )}
+                  symbol={txDetails.feeAsset.symbol}
+                  maximumFractionDigits={6}
+                />
+              )}
+            </Row.Value>
+          </Row>
+          <Row variant='vertical'>
+            <Row.Label>
+              <Text translation='transactionRow.status' />
+            </Row.Label>
+            <Row.Value textAlign='left'>
+              {txDetails.tx.status === chainAdapters.TxStatus.Confirmed && (
+                <Tag colorScheme='green' size='lg'>
+                  <CheckCircleIcon mr={2} />
+                  <Text translation='transactionRow.confirmed' />
+                </Tag>
+              )}
+              {txDetails.tx.status === chainAdapters.TxStatus.Pending && (
+                <Tag colorScheme='blue' size='lg'>
+                  <CircularProgress mr={2} size='5' />
+                  <Text translation='transactionRow.pending' />
+                </Tag>
+              )}
+              {txDetails.tx.status === chainAdapters.TxStatus.Failed && (
+                <Tag colorScheme='red' size='lg'>
+                  <WarningTwoIcon mr={2} />
+                  <Text translation='transactionRow.failed' />
+                </Tag>
+              )}
+            </Row.Value>
+          </Row>
+          <Row variant='vertical'>
+            <Row.Label>
+              <Text translation={'transactionRow.to'} />
+            </Row.Label>
+            <Row.Value>
+              <Link
+                isExternal
+                color='blue.500'
+                href={`${txDetails.explorerAddressLink}${txDetails.to ?? txDetails.from}`}
+              >
+                <MiddleEllipsis maxWidth='180px'>{txDetails.to ?? txDetails.from}</MiddleEllipsis>
+              </Link>
+            </Row.Value>
+          </Row>
+        </SimpleGrid>
+      </Collapse>
+    </>
+  )
+}

--- a/src/components/Transactions/TransactionTrade.tsx
+++ b/src/components/Transactions/TransactionTrade.tsx
@@ -1,0 +1,178 @@
+import { CheckCircleIcon, WarningTwoIcon } from '@chakra-ui/icons'
+import { Box, Collapse, Flex, Link, SimpleGrid, Tag } from '@chakra-ui/react'
+import { Asset, chainAdapters } from '@shapeshiftoss/types'
+import dayjs from 'dayjs'
+import { useState } from 'react'
+import { FaExchangeAlt } from 'react-icons/fa'
+import { Amount } from 'components/Amount/Amount'
+import { CircularProgress } from 'components/CircularProgress/CircularProgress'
+import { IconCircle } from 'components/IconCircle'
+import { MiddleEllipsis } from 'components/MiddleEllipsis/MiddleEllipsis'
+import { Row } from 'components/Row/Row'
+import { RawText, Text } from 'components/Text'
+import { TxDetails } from 'hooks/useTxDetails/useTxDetails'
+import { fromBaseUnit } from 'lib/math'
+
+export const TransactionTrade = ({
+  txDetails,
+  activeAsset
+}: {
+  txDetails: TxDetails
+  activeAsset?: Asset
+}) => {
+  const [isOpen, setIsOpen] = useState(false)
+  const toggleOpen = () => setIsOpen(!isOpen)
+
+  return (
+    <>
+      <Flex
+        alignItems='center'
+        flex={1}
+        justifyContent='space-between'
+        textAlign='left'
+        as='button'
+        w='full'
+        py={4}
+        onClick={toggleOpen}
+      >
+        <Flex alignItems='center' width='full'>
+          <IconCircle mr={3}>
+            <FaExchangeAlt />
+          </IconCircle>
+
+          <Flex justifyContent='flex-start' flex={1} alignItems='center'>
+            <Box flex={1}>
+              <Text
+                fontWeight='bold'
+                overflow='hidden'
+                flex={1}
+                textOverflow='ellipsis'
+                maxWidth='60%'
+                lineHeight='1'
+                whiteSpace='nowrap'
+                mb={2}
+                translation={[`transactionRow.${txDetails.type.toLowerCase()}`, { symbol: '' }]}
+              />
+              <RawText color='gray.500' fontSize='sm' lineHeight='1'>
+                {dayjs(txDetails.tx.blockTime * 1000).fromNow()}
+              </RawText>
+            </Box>
+
+            <Flex flexDir='column' ml='auto' textAlign='right'>
+              <Amount.Crypto
+                color='inherit'
+                value={fromBaseUnit(txDetails.value, txDetails.precision)}
+                symbol={txDetails.symbol}
+                maximumFractionDigits={6}
+                prefix=''
+              />
+            </Flex>
+          </Flex>
+        </Flex>
+      </Flex>
+      <Collapse in={isOpen} unmountOnExit>
+        <SimpleGrid gridTemplateColumns='repeat(auto-fit, minmax(180px, 1fr))' spacing='4' py={6}>
+          <Row variant='vertical'>
+            <Row.Label>
+              <Text translation='transactionRow.date' />
+            </Row.Label>
+            <Row.Value>{dayjs(Number(txDetails.tx.blockTime) * 1000).format('LLL')}</Row.Value>
+          </Row>
+          <Row variant='vertical'>
+            <Row.Label>
+              <Text translation='transactionRow.txid' />
+            </Row.Label>
+            <Row.Value>
+              <Link
+                isExternal
+                color='blue.500'
+                href={`${txDetails.explorerTxLink}${txDetails.tx.txid}`}
+              >
+                <MiddleEllipsis maxWidth='180px'>{txDetails.tx.txid}</MiddleEllipsis>
+              </Link>
+            </Row.Value>
+          </Row>
+
+          <Row variant='vertical' hidden={!txDetails.tradeTx}>
+            <Row.Label>
+              <Text translation={'transactionRow.amount'} />
+            </Row.Label>
+            <Row.Value>
+              <Amount.Crypto
+                value={fromBaseUnit(
+                  txDetails.sellTx?.value ?? '0',
+                  txDetails.sellAsset?.precision ?? 18
+                )}
+                symbol={txDetails.sellAsset?.symbol ?? ''}
+                maximumFractionDigits={6}
+              />
+              <Text translation='transactionRow.for' />
+              <Amount.Crypto
+                value={fromBaseUnit(
+                  txDetails.buyTx?.value ?? '0',
+                  txDetails.buyAsset?.precision ?? 18
+                )}
+                symbol={txDetails.buyAsset?.symbol ?? ''}
+                maximumFractionDigits={6}
+              />
+            </Row.Value>
+          </Row>
+
+          <Row variant='vertical'>
+            <Row.Label>
+              <Text translation='transactionRow.fee' />
+            </Row.Label>
+            <Row.Value>
+              {txDetails.tx?.fee && txDetails.feeAsset && (
+                <Amount.Crypto
+                  value={fromBaseUnit(
+                    txDetails.tx?.fee?.value ?? '0',
+                    txDetails.feeAsset?.precision ?? 18
+                  )}
+                  symbol={txDetails.feeAsset.symbol}
+                  maximumFractionDigits={6}
+                />
+              )}
+            </Row.Value>
+          </Row>
+          <Row variant='vertical'>
+            <Row.Label>
+              <Text translation='transactionRow.status' />
+            </Row.Label>
+            <Row.Value textAlign='left'>
+              {txDetails.tx.status === chainAdapters.TxStatus.Confirmed && (
+                <Tag colorScheme='green' size='lg'>
+                  <CheckCircleIcon mr={2} />
+                  <Text translation='transactionRow.confirmed' />
+                </Tag>
+              )}
+              {txDetails.tx.status === chainAdapters.TxStatus.Pending && (
+                <Tag colorScheme='blue' size='lg'>
+                  <CircularProgress mr={2} size='5' />
+                  <Text translation='transactionRow.pending' />
+                </Tag>
+              )}
+              {txDetails.tx.status === chainAdapters.TxStatus.Failed && (
+                <Tag colorScheme='red' size='lg'>
+                  <WarningTwoIcon mr={2} />
+                  <Text translation='transactionRow.failed' />
+                </Tag>
+              )}
+            </Row.Value>
+          </Row>
+          <Row variant='vertical'>
+            <Row.Value>
+              <Link
+                isExternal
+                color='blue.500'
+                href={`${txDetails.explorerAddressLink}${txDetails.to ?? txDetails.from}`}
+              >
+                <MiddleEllipsis maxWidth='180px'>{txDetails.to ?? txDetails.from}</MiddleEllipsis>
+              </Link>
+            </Row.Value>
+          </Row>
+        </SimpleGrid>
+      </Collapse>
+    </>
+  )
+}

--- a/src/hooks/useTxDetails/useTxDetails.test.ts
+++ b/src/hooks/useTxDetails/useTxDetails.test.ts
@@ -1,0 +1,25 @@
+import { BtcSend, EthReceive, EthSend, TradeTx } from 'test/mocks/txs'
+import { getBuyTx, getSellTx, getStandardTx } from 'hooks/useTxDetails/useTxDetails'
+
+describe('getStandardTx', () => {
+  it('returns the expected values', () => {
+    expect(getStandardTx(EthSend)).toEqual(EthSend.transfers[0]) // When 1 transfer (an ETH tx)
+    expect(getStandardTx(BtcSend)).toEqual(undefined) // When !== 1 transfer (a BTC tx)
+  })
+})
+
+describe('getBuyTx', () => {
+  it('returns the expected values', () => {
+    expect(getBuyTx(EthSend)).toEqual(undefined)
+    expect(getBuyTx(EthReceive)).toEqual(undefined)
+    expect(getBuyTx(TradeTx)).toEqual(TradeTx.transfers[0])
+  })
+})
+
+describe('getSellTx', () => {
+  it('returns the expected values', () => {
+    expect(getSellTx(EthSend)).toEqual(undefined)
+    expect(getSellTx(EthReceive)).toEqual(undefined)
+    expect(getSellTx(TradeTx)).toEqual(TradeTx.transfers[1])
+  })
+})

--- a/src/hooks/useTxDetails/useTxDetails.ts
+++ b/src/hooks/useTxDetails/useTxDetails.ts
@@ -1,0 +1,84 @@
+import { Asset, chainAdapters } from '@shapeshiftoss/types'
+import { TradeType, TxTransfer, TxType } from '@shapeshiftoss/types/dist/chain-adapters'
+import { useSelector } from 'react-redux'
+import { ReduxState } from 'state/reducer'
+import { selectAssetByCAIP19 } from 'state/slices/assetsSlice/assetsSlice'
+import { selectTxById, Tx } from 'state/slices/txHistorySlice/txHistorySlice'
+
+export interface TxDetails {
+  tx: Tx
+  buyTx: TxTransfer | undefined
+  sellTx: TxTransfer | undefined
+  tradeTx: TxTransfer | undefined
+  feeAsset: Asset
+  buyAsset: Asset
+  sellAsset: Asset
+  value: string
+  to: string
+  from: string
+  type: TradeType | TxType | ''
+  symbol: string
+  precision: number
+  explorerTxLink: string
+  explorerAddressLink: string
+}
+
+export const getStandardTx = (tx: Tx) => (tx.transfers.length === 1 ? tx.transfers[0] : undefined)
+export const getBuyTx = (tx: Tx) =>
+  !!tx.tradeDetails ? tx.transfers.find(t => t.type === chainAdapters.TxType.Receive) : undefined
+export const getSellTx = (tx: Tx) =>
+  !!tx.tradeDetails ? tx.transfers.find(t => t.type === chainAdapters.TxType.Send) : undefined
+
+export const useTxDetails = (txId: string, activeAsset?: Asset): TxDetails => {
+  const tx = useSelector((state: ReduxState) => selectTxById(state, txId))
+
+  const standardTx = getStandardTx(tx)
+  const buyTx = getBuyTx(tx)
+  const sellTx = getSellTx(tx)
+
+  const tradeTx = activeAsset?.caip19 === sellTx?.caip19 ? sellTx : buyTx
+
+  const standardAsset = useSelector((state: ReduxState) =>
+    selectAssetByCAIP19(state, standardTx?.caip19 ?? '')
+  )
+
+  // stables need precision of eth (18) rather than 10
+  const feeAsset = useSelector((state: ReduxState) =>
+    selectAssetByCAIP19(state, tx.fee?.caip19 ?? '')
+  )
+  const buyAsset = useSelector((state: ReduxState) =>
+    selectAssetByCAIP19(state, buyTx?.caip19 ?? '')
+  )
+  const sellAsset = useSelector((state: ReduxState) =>
+    selectAssetByCAIP19(state, sellTx?.caip19 ?? '')
+  )
+  const tradeAsset = activeAsset?.symbol === sellAsset?.symbol ? sellAsset : buyAsset
+
+  const value = standardTx?.value ?? tradeTx?.value ?? '0'
+  const to = standardTx?.to ?? tradeTx?.to ?? ''
+  const from = standardTx?.from ?? tradeTx?.from ?? ''
+  const type = standardTx?.type ?? tx.tradeDetails?.type ?? ''
+  const symbol = standardAsset?.symbol ?? tradeAsset?.symbol ?? ''
+  const precision = standardAsset?.precision ?? tradeAsset?.precision ?? 18
+  const explorerTxLink = standardAsset?.explorerTxLink ?? tradeAsset?.explorerTxLink ?? ''
+  const explorerAddressLink =
+    standardAsset?.explorerAddressLink ?? tradeAsset?.explorerAddressLink ?? ''
+
+  return {
+    tx,
+    buyTx,
+    sellTx,
+    tradeTx,
+    feeAsset,
+    buyAsset,
+    sellAsset,
+    value,
+    to,
+    from,
+    type,
+    symbol,
+    precision,
+    explorerTxLink,
+    explorerAddressLink
+  }
+}

--- a/src/test/mocks/txs.ts
+++ b/src/test/mocks/txs.ts
@@ -1,6 +1,6 @@
 import { chainAdapters, ChainTypes, UtxoAccountType } from '@shapeshiftoss/types'
-
-import { Tx } from '../../state/slices/txHistorySlice/txHistorySlice'
+import { TradeType } from '@shapeshiftoss/types/dist/chain-adapters'
+import { Tx } from 'state/slices/txHistorySlice/txHistorySlice'
 
 export const EthSend: Tx = {
   address: '0x9124248f2AD8c94fC4a403588BE7a77984B34bb8',
@@ -100,6 +100,42 @@ export const FOXSend: Tx = {
       type: chainAdapters.TxType.Send
     }
   ]
+}
+
+export const TradeTx: Tx = {
+  address: '0x934be745172066EDF795ffc5EA9F28f19b440c63',
+  blockHash: '0x17d278ffcb1fb940d69e72287339607445d373d0c6a654a61526b0bc805cf10c',
+  blockHeight: 13730189,
+  blockTime: 1638487560,
+  caip2: 'eip155:1',
+  chain: ChainTypes.Ethereum,
+  confirmations: 84026,
+  fee: {
+    caip19: 'eip155:1/slip44:60',
+    value: '9099683709794574'
+  },
+  status: chainAdapters.TxStatus.Confirmed,
+  tradeDetails: {
+    dexName: '',
+    type: TradeType.Trade
+  },
+  transfers: [
+    {
+      caip19: 'eip155:1/erc20:0x5f18c75abdae578b483e5f43f12a39cf75b973a9',
+      from: '0x0000000000000000000000000000000000000000',
+      to: '0x934be745172066EDF795ffc5EA9F28f19b440c63',
+      type: chainAdapters.TxType.Receive,
+      value: '9178352'
+    },
+    {
+      caip19: 'eip155:1/erc20:0xa0b86991c6218b36c1d19d4a2e9eb0ce3606eb48',
+      from: '0x934be745172066EDF795ffc5EA9F28f19b440c63',
+      to: '0x5f18C75AbDAe578b483E5F43f12a39cF75b973a9',
+      type: chainAdapters.TxType.Send,
+      value: '10000000'
+    }
+  ],
+  txid: '0xded9a55622504979d7980b401d3b5fab234c0b64ee779f076df2023929b0f083'
 }
 
 // these test txs were on an account with a start date jan 2021


### PR DESCRIPTION
## Description

- Separates transaction type rendering logic from `transactionRow` into child components
- Moves common transaction detail logic into a custom hook, `useTxDetails.ts`
- Adds (very) basic tests for transaction detail logic in `useTxDetails.test.ts`

### Notes for the reviewer

We could reduce some duplication by making a generic component for the collapsed view, as I imagine this will stay fairly consistent (i.e. just passing in something like `icon`, `label`, `value`, `date`). 

The expanded view (everything inside the `Collapse` tag) is where I expect most of the transaction type-specific logic will sit, though without a full understanding of the direction I could be wrong here.

## Notice

Before submitting a pull request, please make sure you have answered the following:

- [x] Have you followed the guidelines in our [Contributing]('https://github.com/shapeshift/web/CONTRIBUTING.md) guide?
- [x] Have you checked to ensure there aren't other open [Pull Requests](https://github.com/shapeshift/web/pulls) for the same update/change?
- [x] Do all new and existing tests pass? Does the linter pass?

## Pull Request Type

- [ ] :bug: Bug fix (Non-breaking Change: Fixes an issue)
- [x] :hammer_and_wrench: Chore (Non-breaking Change: Doc updates, pkg upgrades, typos, etc..)
- [ ] :nail_care: New Feature (Breaking/Non-breaking Change)

## Issue (if applicable)

Issue: https://github.com/shapeshift/web/issues/560

## Testing

- Check tests still pass: `yarn test`
- Check that `TransactionRow` renders as expected on "Asset History" and "Recent Transactions" pages.

## Screenshots (if applicable)

N/A - no change in visual state