### PR TITLE
chore: header responsiveness for large screens

### DIFF
--- a/src/components/Layout/Header/Header.tsx
+++ b/src/components/Layout/Header/Header.tsx
@@ -33,6 +33,9 @@ export const Header = ({ route }: { route: Route }) => {
         left='0'
         right='0'
         width='full'
+        maxWidth={{ base: 'auto', '2xl': '1464px' }}
+        mx='auto'
+        paddingRight={{ base: 'none', lg: '8px' }}
       >
         <HeaderContent route={route} />
       </chakra.header>


### PR DESCRIPTION
## Description

Header looks off at `lg` breakpoint. Fixed the responsiveness to respond with the body.

Before: 

![image](https://user-images.githubusercontent.com/16395727/150237064-3b3f398c-57e6-4b92-acb0-b082c41d9f6b.png)

After:

![image](https://user-images.githubusercontent.com/16395727/150236180-a1a8386b-cc2e-4d24-bf11-89d658bbc9b6.png)

## Notice

Before submitting a pull request, please make sure you have answered the following:

- [x] Have you followed the guidelines in our [Contributing]('https://github.com/shapeshift/web/CONTRIBUTING.md) guide?
- [x] Have you checked to ensure there aren't other open [Pull Requests](https://github.com/shapeshift/web/pulls) for the same update/change?
- [ ] Do all new and existing tests pass? Does the linter pass?

## Pull Request Type

- [ ] :bug: Bug fix (Non-breaking Change: Fixes an issue)
- [x] :hammer_and_wrench: Chore (Non-breaking Change: Doc updates, pkg upgrades, typos, etc..)
- [ ] :nail_care: New Feature (Breaking/Non-breaking Change)
