### PR TITLE
fix: load a zero balance chart when using a wallet with zero balances

### DIFF
--- a/src/hooks/useBalanceChartData/useBalanceChartData.ts
+++ b/src/hooks/useBalanceChartData/useBalanceChartData.ts
@@ -5,7 +5,6 @@ import { BigNumber } from 'bignumber.js'
 import dayjs from 'dayjs'
 import fill from 'lodash/fill'
 import head from 'lodash/head'
-import isEmpty from 'lodash/isEmpty'
 import isNil from 'lodash/isNil'
 import last from 'lodash/last'
 import reduce from 'lodash/reduce'
@@ -333,10 +332,8 @@ export const useBalanceChartData: UseBalanceChartData = args => {
     // data prep
     const noDeviceId = isNil(walletInfo?.deviceId)
     const noAssetIds = !assetIds.length
-    const noTxs = !txs.length
-    const noBalances = isEmpty(balances)
     const noPriceHistory = priceHistoryDataLoading
-    if (noDeviceId || noAssetIds || noTxs || noBalances || noPriceHistory) {
+    if (noDeviceId || noAssetIds || noPriceHistory) {
       return setBalanceChartDataLoading(true)
     }
 


### PR DESCRIPTION
## Description

Load a zero balance chart when using a wallet with zero balances or trade history

## Notice

Before submitting a pull request, please make sure you have answered the following:

- [x] Have you followed the guidelines in our [Contributing]('https://github.com/shapeshift/web/CONTRIBUTING.md) guide?
- [x] Have you checked to ensure there aren't other open [Pull Requests](https://github.com/shapeshift/web/pulls) for the same update/change?
- [x] Do all new and existing tests pass? Does the linter pass?

## Pull Request Type

- [x] :bug: Bug fix (Non-breaking Change: Fixes an issue)
- [ ] :hammer_and_wrench: Chore (Non-breaking Change: Doc updates, pkg upgrades, typos, etc..)
- [ ] :nail_care: New Feature (Breaking/Non-breaking Change)

## Issue (if applicable)

closes #815

## Testing

1. Create a new fresh native wallet
2. The dashboard should display a flat line with 0 balance

## Screenshots (if applicable)

![2022-01-20_13-01](https://user-images.githubusercontent.com/5672954/150336563-3a821c25-f5d8-4bde-8d0c-3d40193326af.png)

