### PR TITLE
feat: adjust fiat text size to avoid clipping in Trade modal

### DIFF
--- a/src/components/FiatInput/FiatInput.tsx
+++ b/src/components/FiatInput/FiatInput.tsx
@@ -1,0 +1,77 @@
+import { useMediaQuery } from '@chakra-ui/media-query'
+import { Input, InputProps } from '@chakra-ui/react'
+import { useRef } from 'react'
+import { width as rightSidebarWidth } from 'components/Layout/RightSidebar'
+import { breakpoints, theme } from 'theme/theme'
+
+import { computeFontSize } from './computeFontSize'
+
+const parentPadding = 2 * 24
+const defaultFontSizeCss = '5xl'
+const defaultFontSizeRem = theme.fontSizes[defaultFontSizeCss]
+const maxFontSize = parseInt(defaultFontSizeRem) * 16
+
+const getLgFontSize = (canvas: HTMLCanvasElement, fontFamily: string, text: string) => {
+  const maxWidth = rightSidebarWidth - parentPadding
+  const maxFontSize = computeFontSize(canvas, fontFamily, text, maxWidth - 10)
+  return `${maxFontSize}px`
+}
+
+const getSmToLgResponsiveFontSize = (
+  canvas: HTMLCanvasElement,
+  fontFamily: string,
+  text: string
+) => {
+  const maxBreakpoint = parseInt(breakpoints['lg'])
+  const minBreakpoint = 500
+  const maxWidth = maxBreakpoint - parentPadding
+  const minWidth = parseInt(breakpoints['sm']) - parentPadding
+
+  let lgMaxFontSize = computeFontSize(canvas, fontFamily, text, maxWidth)!
+  let smMaxFontSize = computeFontSize(canvas, fontFamily, text, minWidth)!
+  lgMaxFontSize = lgMaxFontSize >= maxFontSize ? maxFontSize : lgMaxFontSize
+  smMaxFontSize = smMaxFontSize >= maxFontSize ? maxFontSize : smMaxFontSize
+
+  // Calculate a clamp expr for linear interpolation, y = mx + b
+  // https://css-tricks.com/linearly-scale-font-size-with-css-clamp-based-on-the-viewport/
+  const m = (lgMaxFontSize - smMaxFontSize) / (maxBreakpoint - minBreakpoint)
+  const mAsVw = m * 100
+  const b = smMaxFontSize - minBreakpoint * m
+
+  return `clamp(${smMaxFontSize}px, ${b}px + ${mAsVw}vw, ${lgMaxFontSize}px)`
+}
+
+export const FiatInput = (props: InputProps) => {
+  const canvasRef = useRef<HTMLCanvasElement>(null)
+  const inputRef = useRef<HTMLInputElement>(null)
+
+  const [isLargerThanLg] = useMediaQuery(`(min-width: ${breakpoints['lg']})`)
+
+  let fontSizeCss = defaultFontSizeCss
+  if (canvasRef.current && inputRef.current && !!props.value) {
+    const fontFamily = getComputedStyle(inputRef.current)?.fontFamily
+    const text = inputRef.current.value
+
+    if (isLargerThanLg) {
+      fontSizeCss = getLgFontSize(canvasRef.current, fontFamily, text)
+    } else {
+      fontSizeCss = getSmToLgResponsiveFontSize(canvasRef.current, fontFamily, text)
+    }
+  }
+
+  return (
+    <>
+      <canvas ref={canvasRef} width={0} height={0} />
+      <Input
+        ref={inputRef}
+        variant='unstyled'
+        size='xl'
+        textAlign='center'
+        fontSize={fontSizeCss}
+        mb={6}
+        placeholder='$0.00'
+        {...props}
+      />
+    </>
+  )
+}

--- a/src/components/FiatInput/computeFontSize.ts
+++ b/src/components/FiatInput/computeFontSize.ts
@@ -1,0 +1,38 @@
+const BASE_FONT_SIZE_PX = 16
+
+const measureTextWidth = (ctx: CanvasRenderingContext2D, fontFamily: string, text: string) => {
+  ctx.font = `${BASE_FONT_SIZE_PX}px ${fontFamily}`
+  const textMetrics = ctx.measureText(text)
+  // More accurate than textMetrics.width, see https://developer.mozilla.org/en-US/docs/Web/API/TextMetrics#measuring_text_width
+  return Math.abs(textMetrics.actualBoundingBoxLeft) + Math.abs(textMetrics.actualBoundingBoxRight)
+}
+
+const getFittedTextSize = (maxWidth: number, actualWidth: number) => {
+  const fontSize = (maxWidth / actualWidth) * BASE_FONT_SIZE_PX
+  const fontSize1Dp = Math.round(fontSize * 10) / 10
+  return fontSize1Dp
+}
+
+/**
+ * Calculates the font size for an HTML element (if the text it presently displays is clipped) to
+ * be set to that would avoid the clipping.
+ * @param canvas The <canvas> element to be used to take text metric measurements.
+ * @param input The <input> element to be examined for text clipping.
+ * @param width The width that the text being displayed should not exceed.
+ * @returns `null` if font size could not be computed; otherwise, returns the font size (in pixels)
+ * that the element should be set to that would avoid text from clipping.
+ */
+export const computeFontSize = (
+  canvas: HTMLCanvasElement,
+  fontFamily: string,
+  text: string,
+  width: number
+): number | null => {
+  const ctx = canvas.getContext('2d')
+  if (!ctx) {
+    return null
+  }
+
+  const textWidthAtBaseSize = measureTextWidth(ctx, fontFamily, text)
+  return getFittedTextSize(width, textWidthAtBaseSize)
+}

--- a/src/components/Layout/RightSidebar.tsx
+++ b/src/components/Layout/RightSidebar.tsx
@@ -1,5 +1,7 @@
 import { Rail } from 'components/Layout/Rail'
 
+export const width = 360
+
 export const RightSidebar: React.FC = ({ children }) => {
-  return <Rail minWidth={{ base: 'auto', lg: '360px' }}>{children}</Rail>
+  return <Rail minWidth={{ base: 'auto', lg: `${width}px` }}>{children}</Rail>
 }

--- a/src/components/Trade/TradeInput.tsx
+++ b/src/components/Trade/TradeInput.tsx
@@ -1,13 +1,4 @@
-import {
-  Box,
-  Button,
-  FormControl,
-  FormErrorMessage,
-  IconButton,
-  Input,
-  InputProps,
-  useToast
-} from '@chakra-ui/react'
+import { Box, Button, FormControl, FormErrorMessage, IconButton, useToast } from '@chakra-ui/react'
 import { ChainTypes, ContractTypes, SwapperType } from '@shapeshiftoss/types'
 import { useState } from 'react'
 import { Controller, useFormContext, useWatch } from 'react-hook-form'
@@ -16,6 +7,7 @@ import NumberFormat from 'react-number-format'
 import { useTranslate } from 'react-polyglot'
 import { RouterProps } from 'react-router-dom'
 import { Card } from 'components/Card/Card'
+import { FiatInput } from 'components/FiatInput/FiatInput'
 import { HelperTooltip } from 'components/HelperTooltip/HelperTooltip'
 import { SlideTransition } from 'components/SlideTransition'
 import { RawText, Text } from 'components/Text'
@@ -31,18 +23,6 @@ import { useWallet } from 'context/WalletProvider/WalletProvider'
 import { useLocaleFormatter } from 'hooks/useLocaleFormatter/useLocaleFormatter'
 import { bn, bnOrZero } from 'lib/bignumber/bignumber'
 import { firstNonZeroDecimal } from 'lib/math'
-
-const FiatInput = (props: InputProps) => (
-  <Input
-    variant='unstyled'
-    size='xl'
-    textAlign='center'
-    fontSize='5xl'
-    mb={6}
-    placeholder='$0.00'
-    {...props}
-  />
-)
 
 type TS = TradeState<ChainTypes, SwapperType>
 


### PR DESCRIPTION
## Description

Adjust fiat text size to avoid clipping in Trade modal. The approach taken here allows the initial font size to be specified using a themable value, eg. `5xl`. 

Think I did a good job? Feel free to [tip](https://gitcoin.co/tip?username=helr441) me! (thanks in advance)

## Notice

Before submitting a pull request, please make sure you have answered the following:

- [x] Have you followed the guidelines in our [Contributing]('https://github.com/shapeshift/web/CONTRIBUTING.md) guide?
- [x] Have you checked to ensure there aren't other open [Pull Requests](https://github.com/shapeshift/web/pulls) for the same update/change?
- [x] Do all new and existing tests pass? Does the linter pass?

## Pull Request Type

- [ ] :bug: Bug fix (Non-breaking Change: Fixes an issue)
- [ ] :hammer_and_wrench: Chore (Non-breaking Change: Doc updates, pkg upgrades, typos, etc..)
- [x] :nail_care: New Feature (~Breaking~/Non-breaking Change)

## Issue (if applicable)

Closes #709.

## Testing

Please outline all testing steps

1. Pull branch locally and run `yarn` to install new deps
2. Enter a large number in the ETH like 50,000 (depends on your locale) and wait for fiat rates to be fetched, and once fetched, see that fiat value displayed does not get clipped.

## Screenshots (if applicable)

using the ID locale:

![beyond lg breakpoint](https://user-images.githubusercontent.com/96822203/150821341-0159ce5b-adea-4f54-98bb-3349f8fcba5a.jpg)
![lg breakpoint](https://user-images.githubusercontent.com/96822203/150821379-a31f7bdc-265e-4c08-b435-7863c1f9e783.jpg)
![sm breakpoint](https://user-images.githubusercontent.com/96822203/150821393-cb47df5c-df09-460e-87b2-6935539b202d.jpg)

