### PR TITLE
fix: dropped down the max allowance for yearn deposits to 96 bits to compl…

### DIFF
--- a/src/constants/allowance.ts
+++ b/src/constants/allowance.ts
@@ -1,1 +1,3 @@
-export const MAX_ALLOWANCE = '0xfffffffffffffffffffffffffffffffffffffffffffffff'
+// Need to limit the max allowance to 96 bits because contracts like Uniswap and Compound have a
+// 96 bit max allowance.
+export const MAX_ALLOWANCE = '0xffffffffffffffffffffffff'

--- a/src/constants/allowance.ts
+++ b/src/constants/allowance.ts
@@ -1,3 +1,3 @@
 // Need to limit the max allowance to 96 bits because contracts like Uniswap and Compound have a
-// 96 bit max allowance.
+// will revert the transaction if giving allowance more than 96 bits.
 export const MAX_ALLOWANCE = '0xffffffffffffffffffffffff'

--- a/src/constants/allowance.ts
+++ b/src/constants/allowance.ts
@@ -1,3 +1,3 @@
-// Need to limit the max allowance to 96 bits because contracts like Uniswap and Compound have a
+// Need to limit the max allowance to 96 bits because ERC-20 contracts like Uniswap and Compound
 // will revert the transaction if giving allowance more than 96 bits.
 export const MAX_ALLOWANCE = '0xffffffffffffffffffffffff'


### PR DESCRIPTION
…y with limits on uniswap and compound

## Description

uniswap and compound ERC-20 contracts limit allowance to 96 bit numbers and will revert the transaction for attempting to approve anything higher.

## Notice

Before submitting a pull request, please make sure you have answered the following:

- [x] Have you followed the guidelines in our [Contributing]('https://github.com/shapeshift/web/CONTRIBUTING.md) guide?
- [x] Have you checked to ensure there aren't other open [Pull Requests](https://github.com/shapeshift/web/pulls) for the same update/change?
- [x] Do all new and existing tests pass? Does the linter pass?

## Pull Request Type

- [x] :bug: Bug fix (Non-breaking Change: Fixes an issue)
- [ ] :hammer_and_wrench: Chore (Non-breaking Change: Doc updates, pkg upgrades, typos, etc..)
- [ ] :nail_care: New Feature (Breaking/Non-breaking Change)

## Issue (if applicable)

If applicable, please link to the github issue and put `closes #XXXX` in your comment to auto-close the issue that your PR fixes.

## Testing

Please outline all testing steps

1. Should be able to approve uniswap and compound for deposit into a yearn vault.

## Screenshots (if applicable)
