### PR TITLE
feat: add account label to asset details

### DIFF
--- a/src/assets/translations/messages-en.json
+++ b/src/assets/translations/messages-en.json
@@ -27,7 +27,9 @@
     "somethingWentWrongBody": "Something went wrong",
     "transactionFailed": "Transaction Failed",
     "transactionFailedBody": "Transaction Failed",
-    "submitFeedback": "Submit Feedback"
+    "submitFeedback": "Submit Feedback",
+    "send": "Send",
+    "receive": "Receive"
   },
   "updateToast": {
     "body": "A new version of the app is available",

--- a/src/components/AssetHeader/AccountLabel.tsx
+++ b/src/components/AssetHeader/AccountLabel.tsx
@@ -1,0 +1,30 @@
+import { HStack, Tag, TagLabel } from '@chakra-ui/react'
+import { RawText } from 'components/Text'
+import { selectAssetByCAIP19 } from 'state/slices/assetsSlice/assetsSlice'
+import { AccountSpecifier } from 'state/slices/portfolioSlice/portfolioSlice'
+import { accountIdToFeeAssetId, accountIdToLabel } from 'state/slices/portfolioSlice/utils'
+import { useAppSelector } from 'state/store'
+
+export const AccountLabel = ({ accountId }: { accountId: AccountSpecifier }) => {
+  const label = accountId ? accountIdToLabel(accountId) : null
+  const feeAssetId = accountIdToFeeAssetId(accountId)
+  const feeAsset = useAppSelector(state => selectAssetByCAIP19(state, feeAssetId))
+  return (
+    <HStack fontSize='small' fontWeight='bold' spacing={1}>
+      <RawText color='gray.500' textTransform='uppercase' lineHeight='shorter'>
+        {feeAsset.name}
+      </RawText>
+      <Tag
+        whiteSpace='nowrap'
+        colorScheme='blue'
+        fontSize='x-small'
+        fontWeight='bold'
+        minHeight='auto'
+        lineHeight='shorter'
+        py={1}
+      >
+        <TagLabel>{label}</TagLabel>
+      </Tag>
+    </HStack>
+  )
+}

--- a/src/components/AssetHeader/AssetActions.tsx
+++ b/src/components/AssetHeader/AssetActions.tsx
@@ -1,6 +1,7 @@
 import { ArrowDownIcon, ArrowUpIcon } from '@chakra-ui/icons'
-import { Button, ButtonGroup, Skeleton } from '@chakra-ui/react'
+import { ButtonGroup, IconButton, Skeleton, Tooltip } from '@chakra-ui/react'
 import { CAIP19 } from '@shapeshiftoss/caip'
+import { useTranslate } from 'react-polyglot'
 import { useModal } from 'context/ModalProvider/ModalProvider'
 import { useWallet, WalletActions } from 'context/WalletProvider/WalletProvider'
 import { selectAssetByCAIP19 } from 'state/slices/assetsSlice/assetsSlice'
@@ -15,6 +16,7 @@ type AssetActionProps = {
 
 export const AssetActions = ({ isLoaded, assetId, accountId }: AssetActionProps) => {
   const { send, receive } = useModal()
+  const translate = useTranslate()
   const {
     state: { isConnected },
     dispatch
@@ -35,14 +37,26 @@ export const AssetActions = ({ isLoaded, assetId, accountId }: AssetActionProps)
       width={{ base: 'full', lg: 'auto' }}
     >
       <Skeleton isLoaded={isLoaded} width={{ base: 'full', lg: 'auto' }}>
-        <Button onClick={handleSendClick} isFullWidth leftIcon={<ArrowUpIcon />}>
-          Send
-        </Button>
+        <Tooltip label={translate('common.send')} fontSize='md' px={4} hasArrow>
+          <IconButton
+            onClick={handleSendClick}
+            isRound
+            width='full'
+            icon={<ArrowUpIcon />}
+            aria-label={translate('common.send')}
+          />
+        </Tooltip>
       </Skeleton>
       <Skeleton isLoaded={isLoaded} width={{ base: 'full', lg: 'auto' }}>
-        <Button onClick={handleReceiveClick} isFullWidth leftIcon={<ArrowDownIcon />}>
-          Receive
-        </Button>
+        <Tooltip label={translate('common.receive')} fontSize='md' px={4} hasArrow>
+          <IconButton
+            onClick={handleReceiveClick}
+            isRound
+            width='full'
+            icon={<ArrowDownIcon />}
+            aria-label={translate('common.receive')}
+          />
+        </Tooltip>
       </Skeleton>
     </ButtonGroup>
   )

--- a/src/components/AssetHeader/AssetHeader.tsx
+++ b/src/components/AssetHeader/AssetHeader.tsx
@@ -43,6 +43,7 @@ import {
 import { useAppSelector } from 'state/store'
 import { breakpoints } from 'theme/theme'
 
+import { AccountLabel } from './AccountLabel'
 import { AssetActions } from './AssetActions'
 import { AssetMarketData } from './AssetMarketData'
 
@@ -95,31 +96,29 @@ export const AssetHeader: React.FC<AssetHeaderProps> = ({ assetId, accountId }) 
 
   return (
     <Card variant='footer-stub'>
-      <Card.Header display='flex' alignItems='center' flexDir={{ base: 'column', lg: 'row' }}>
-        <Flex alignItems='center' mr='auto'>
-          <SkeletonCircle boxSize='60px' isLoaded={isLoaded}>
-            <Image src={icon} boxSize='60px' fallback={<SkeletonCircle boxSize='60px' />} />
-          </SkeletonCircle>
-          <Box ml={3} textAlign='left'>
-            <Skeleton isLoaded={isLoaded}>
-              <Heading fontSize='2xl' mb={1} lineHeight={1}>
-                {name}
-              </Heading>
-            </Skeleton>
-            <Skeleton isLoaded={isLoaded}>
-              <RawText fontSize='lg' color='gray.500' textTransform='uppercase' lineHeight={1}>
-                {symbol}
-              </RawText>
-            </Skeleton>
-          </Box>
+      <Card.Header>
+        <Flex alignItems='center' flexDir={{ base: 'column', lg: 'row' }}>
+          <Flex alignItems='center' mr='auto'>
+            <SkeletonCircle boxSize='40px' isLoaded={isLoaded}>
+              <Image src={icon} boxSize='40px' fallback={<SkeletonCircle boxSize='40px' />} />
+            </SkeletonCircle>
+            <Box ml={3} textAlign='left'>
+              {accountId && <AccountLabel accountId={accountId} />}
+              <Skeleton isLoaded={isLoaded}>
+                <Heading fontSize='2xl' lineHeight='shorter'>
+                  {name} {`(${symbol})`}
+                </Heading>
+              </Skeleton>
+            </Box>
+          </Flex>
+          {walletSupportsChain ? (
+            <AssetActions
+              isLoaded={isLoaded}
+              assetId={assetId}
+              accountId={accountId ? accountId : singleAccount}
+            />
+          ) : null}
         </Flex>
-        {walletSupportsChain ? (
-          <AssetActions
-            isLoaded={isLoaded}
-            assetId={assetId}
-            accountId={accountId ? accountId : singleAccount}
-          />
-        ) : null}
       </Card.Header>
       <Card.Body>
         <Box>

--- a/src/components/Layout/Header/NavBar/MainNavLink.tsx
+++ b/src/components/Layout/Header/NavBar/MainNavLink.tsx
@@ -15,7 +15,7 @@ export const MainNavLink = memo((props: SidebarLinkProps) => {
   const location = useLocation()
   const active = location?.pathname.includes(href ?? '')
   return (
-    <Tooltip label={label} fontSize='md' px={4}>
+    <Tooltip label={label} fontSize='md' px={4} hasArrow>
       <IconButton
         icon={icon}
         as={ReactRouterLink}

--- a/src/components/Tooltip/Tooltip.theme.ts
+++ b/src/components/Tooltip/Tooltip.theme.ts
@@ -1,0 +1,12 @@
+export const TooltipStyle = {
+  // Styles for the base style
+  baseStyle: (props: Record<string, any>) => ({
+    borderRadius: 'lg'
+  }),
+  // Styles for the size variations
+  sizes: {},
+  // Styles for the visual style variations
+  variants: {},
+  // The default `size` or `variant` values
+  defaultProps: {}
+}

--- a/src/theme/theme.ts
+++ b/src/theme/theme.ts
@@ -18,6 +18,7 @@ import { SpinnerStyle as Spinner } from 'components/Spinner/Spinner.theme'
 import { StatStyle as Stat } from 'components/Stat/Stat.theme'
 import { TabsStyle as Tabs } from 'components/Tabs/Tabs.theme'
 import { TextareaStyle as Textarea } from 'components/Textarea/Textarea.theme'
+import { TooltipStyle as Tooltip } from 'components/Tooltip/Tooltip.theme'
 
 import { colors } from './colors'
 
@@ -106,6 +107,7 @@ export const theme = extendTheme({
     Row,
     Drawer,
     Textarea,
+    Tooltip,
     Skeleton,
     Steps,
     Popover


### PR DESCRIPTION
## Description

- Added the account label to the asset details header
- Changed asset actions over to match the rounded style we use everywhere
- Added translations for asset action buttons
- Added theme file for tooltip

## Notice

Before submitting a pull request, please make sure you have answered the following:

- [x] Have you followed the guidelines in our [Contributing]('https://github.com/shapeshift/web/CONTRIBUTING.md) guide?
- [x] Have you checked to ensure there aren't other open [Pull Requests](https://github.com/shapeshift/web/pulls) for the same update/change?
- [x] Do all new and existing tests pass? Does the linter pass?

## Pull Request Type

- [ ] :bug: Bug fix (Non-breaking Change: Fixes an issue)
- [ ] :hammer_and_wrench: Chore (Non-breaking Change: Doc updates, pkg upgrades, typos, etc..)
- [x] :nail_care: New Feature (Breaking/Non-breaking Change)

## Issue (if applicable)

If applicable, please link to the github issue and put `closes #XXXX` in your comment to auto-close the issue that your PR fixes.

## Testing

Please outline all testing steps

1. Pull branch locally and run `yarn` to install new deps
2. etc...

## Screenshots (if applicable)
![Screen Shot 2022-01-24 at 3 46 01 PM](https://user-images.githubusercontent.com/89934888/150870376-4e50dd39-0863-4f09-b94b-b6895a913c8a.png)
![Screen Shot 2022-01-24 at 3 46 15 PM](https://user-images.githubusercontent.com/89934888/150870378-ee024126-aed8-4d4b-8e07-83cac421d592.png)

