### PR TITLE
fix: http-equiv header missing 'child-src blob:' (#818)

### DIFF
--- a/headers.js
+++ b/headers.js
@@ -2,6 +2,7 @@ require('dotenv').config()
 
 const cspMeta = Object.entries({
   'default-src': ["'self'"],
+  'child-src': ["blob:"],
   'connect-src': [
     "'self'",
     // @shapeshiftoss/swapper@1.15.0: https://github.com/shapeshift/lib/blob/f833ac7f8c70dee801eaa24525336ca6992e5903/packages/swapper/src/swappers/zrx/utils/zrxService.ts#L4

--- a/headers.js
+++ b/headers.js
@@ -2,7 +2,7 @@ require('dotenv').config()
 
 const cspMeta = Object.entries({
   'default-src': ["'self'"],
-  'child-src': ["blob:"],
+  'child-src': ["'self'",  "blob:", "'report-sample'"],
   'connect-src': [
     "'self'",
     // @shapeshiftoss/swapper@1.15.0: https://github.com/shapeshift/lib/blob/f833ac7f8c70dee801eaa24525336ca6992e5903/packages/swapper/src/swappers/zrx/utils/zrxService.ts#L4


### PR DESCRIPTION
  Safari (WebKit in general?) on both desktop and
  iOS doesn't accept `script-src` for Workers.

  Adding `child-src blob:` gives `react-qr-reader`
  the required access to creating a Worker from
  a Blob, thus removing the fatal SecurityError
  and restoring expected behavior.

## Description

Added the `child-src` directive with a single `blob:` in the source list.

## Notice

- [x] Have you followed the guidelines in our [Contributing]('https://github.com/shapeshift/web/CONTRIBUTING.md) guide?
- [x] Have you checked to ensure there aren't other open [Pull Requests](https://github.com/shapeshift/web/pulls) for the same update/change?
- [x] Do all new and existing tests pass? Does the linter pass?

## Pull Request Type

- [x] :bug: Bug fix (Non-breaking Change: Fixes an issue)
- [ ] :hammer_and_wrench: Chore (Non-breaking Change: Doc updates, pkg upgrades, typos, etc..)
- [ ] :nail_care: New Feature (Breaking/Non-breaking Change)

## Issue (if applicable)

fixes #818 

## Testing

Please outline all testing steps

1. `yarn build` (There's some quirks when developing on mobile/browserstack devices, which have nothing to do with #818)
2. Host the build (Port and IP/host name depend on your mobile development setup; let me know if you want me to set up a netlify instance for this branch)
3. Connect a wallet
4. Send an asset
5. Tap the QR button in the send modal's address field

## Screenshots (if applicable)

The first two videos don't actually show a camera feed, since that's not supported by BrowserStack. You can see the QR reader flashing for a split second, though. 

https://user-images.githubusercontent.com/3411649/151058782-04ad2456-500c-4898-8419-b42e4baf6b5c.mp4

https://user-images.githubusercontent.com/3411649/151058792-d35026a1-601e-4195-8d02-4d4851ffd7b1.mp4

I could never reproduce #818 on Android, but for good measure, on a physical device with camera feed:

https://user-images.githubusercontent.com/3411649/151058213-1947de62-6cdc-42d1-9045-483fbb05b174.mp4
