### PR TITLE
chore: slightly tighter regex in isEthAddress

### DIFF
--- a/src/lib/utils.ts
+++ b/src/lib/utils.ts
@@ -3,5 +3,5 @@ export const upsertArray = <T extends unknown>(arr: T[], item: T): T[] =>
   arr.includes(item) ? arr : [...arr, item]
 
 export const isEthAddress = (address: string) => {
-  return /^(0x)?[0-9a-fA-F]{40}$/.test(address)
+  return /^0x[0-9A-Fa-f]{40}$/.test(address)
 }


### PR DESCRIPTION
## Description

I hunted down the history of this line and there wasn't a particular reason we made the `0x` optional; at the time it was added, though, this function wasn't necessarily supposed to be scoped to ETH addresses only. Now that it clearly is, there's no reason to leave the ambiguity. (I also swapped the `0-9a-fA-F` with `0-9A-Fa-f` so that the charater range is in ASCII lexographical order for OCD reasons.)

## Notice

Before submitting a pull request, please make sure you have answered the following:

- [x] Have you followed the guidelines in our [Contributing]('https://github.com/shapeshift/web/CONTRIBUTING.md) guide?
- [x] Have you checked to ensure there aren't other open [Pull Requests](https://github.com/shapeshift/web/pulls) for the same update/change?
- [x] Do all new and existing tests pass? Does the linter pass?

## Pull Request Type

- [ ] :bug: Bug fix (Non-breaking Change: Fixes an issue)
- [x] :hammer_and_wrench: Chore (Non-breaking Change: Doc updates, pkg upgrades, typos, etc..)
- [ ] :nail_care: New Feature (Breaking/Non-breaking Change)
