### PR TITLE
fix: fix receive erc20 not finding proper accounts

### DIFF
--- a/src/state/slices/portfolioSlice/utils.test.ts
+++ b/src/state/slices/portfolioSlice/utils.test.ts
@@ -2,8 +2,10 @@ import {
   accountIdToChainId,
   accountIdToLabel,
   accountIdToSpecifier,
+  assetIdtoChainId,
   btcChainId,
-  ethChainId
+  ethChainId,
+  findAccountsByAssetId
 } from './utils'
 
 describe('accountIdToChainId', () => {
@@ -63,5 +65,65 @@ describe('accountIdToLabel', () => {
     const accountId = 'bip122:000000000019d6689c085ae165831e93:zpubfoobarbaz'
     const result = accountIdToLabel(accountId)
     expect(result).toEqual(label)
+  })
+})
+
+describe('assetIdtoChainId', () => {
+  it('returns a ETH chainId for a given ETH assetId', () => {
+    const ethAssetId = 'eip155:1/erc20:0x3155ba85d5f96b2d030a4966af206230e46849cb'
+    const chainId = 'eip155:1'
+    const result = assetIdtoChainId(ethAssetId)
+    expect(result).toEqual(chainId)
+  })
+
+  it('returns a BTC chainId for a given BTC assetId', () => {
+    const btcAssetId = 'bip122:000000000019d6689c085ae165831e93/slip44:0'
+    const btcChainId = 'bip122:000000000019d6689c085ae165831e93'
+    const result = assetIdtoChainId(btcAssetId)
+    expect(result).toEqual(btcChainId)
+  })
+})
+
+describe('findAccountsByAssetId', () => {
+  const ethAccountId = 'eip155:1:0xdef1cafe'
+  const ethAccount2Id = 'eip155:1:0xryankk'
+  const ethAssetId = 'eip155:1/erc20:0xdef1cafe'
+  const ethAsset2Id = 'eip155:1/erc20:0xryankk'
+
+  it('returns correct accountId for a given assetId', () => {
+    const portolioAccounts = {
+      [ethAccountId]: [ethAssetId],
+      [ethAccount2Id]: [ethAsset2Id]
+    }
+
+    const result = findAccountsByAssetId(portolioAccounts, ethAssetId)
+    expect(result).toEqual([ethAccountId])
+  })
+
+  it('returns correct accountIds for a given assetId', () => {
+    const portolioAccounts = {
+      [ethAccountId]: [ethAssetId, ethAsset2Id],
+      [ethAccount2Id]: [ethAsset2Id]
+    }
+
+    const result = findAccountsByAssetId(portolioAccounts, ethAsset2Id)
+    expect(result).toEqual([ethAccountId, ethAccount2Id])
+  })
+
+  it('returns accountIds for a given chain if assetId is not found in any current accounts', () => {
+    const btcAssetId = 'bip122:000000000019d6689c085ae165831e93/slip44:0'
+    const btcAccountId = 'bip122:000000000019d6689c085ae165831e93:zpubfoobarbaz'
+
+    const portolioAccounts = {
+      [ethAccountId]: [ethAsset2Id],
+      [ethAccount2Id]: [],
+      [btcAccountId]: []
+    }
+
+    const result = findAccountsByAssetId(portolioAccounts, ethAssetId)
+    expect(result).toEqual([ethAccountId, ethAccount2Id])
+
+    const result2 = findAccountsByAssetId(portolioAccounts, btcAssetId)
+    expect(result2).toEqual([btcAccountId])
   })
 })

--- a/src/state/slices/portfolioSlice/utils.ts
+++ b/src/state/slices/portfolioSlice/utils.ts
@@ -31,6 +31,10 @@ const caip2toCaip19: Record<string, string> = {
   [btcChainId]: 'bip122:000000000019d6689c085ae165831e93/slip44:0'
 }
 
+export const assetIdtoChainId = (caip19: CAIP19): string => {
+  return caip19.split('/')[0]
+}
+
 export const accountIdToChainId = (accountId: AccountSpecifier): CAIP2 => {
   // accountId = 'eip155:1:0xdef1...cafe
   const [chain, network] = accountId.split(':')
@@ -120,6 +124,14 @@ export const findAccountsByAssetId = (
     },
     []
   )
+
+  // If we don't find an account that has the given asset,
+  // return the account(s) for that given assets chain
+  if (result.length === 0) {
+    return Object.keys(portfolioAccounts).filter(
+      accountId => assetIdtoChainId(assetId) === accountIdToChainId(accountId)
+    )
+  }
   return result
 }
 


### PR DESCRIPTION
## Description

If a user picks an erc20 token that they doesn't have a balance, when the user clicks `send` or `receive`, the `Accounts` modal is opened with no Accounts to pick from. This fixes that issue by returning all the accounts for a given chain if the asset does not have a balance.

## Notice

Before submitting a pull request, please make sure you have answered the following:

- [x] Have you followed the guidelines in our [Contributing]('https://github.com/shapeshift/web/CONTRIBUTING.md) guide?
- [x] Have you checked to ensure there aren't other open [Pull Requests](https://github.com/shapeshift/web/pulls) for the same update/change?
- [x] Do all new and existing tests pass? Does the linter pass?

## Pull Request Type

- [x] :bug: Bug fix (Non-breaking Change: Fixes an issue)
- [ ] :hammer_and_wrench: Chore (Non-breaking Change: Doc updates, pkg upgrades, typos, etc..)
- [ ] :nail_care: New Feature (Breaking/Non-breaking Change)

## Issue (if applicable)

If applicable, please link to the github issue and put `closes #XXXX` in your comment to auto-close the issue that your PR fixes.

closes #852 

## Testing

Please outline all testing steps

1. Pull branch locally and run `yarn` to install new deps
2. etc...

## Screenshots (if applicable)
