### PR TITLE
fix: handle long digits in amount inputs

### DIFF
--- a/src/components/FlexibleInputContainer/flexibleInputContainer.stories.tsx
+++ b/src/components/FlexibleInputContainer/flexibleInputContainer.stories.tsx
@@ -1,0 +1,32 @@
+/* eslint-disable import/no-anonymous-default-export */
+/* eslint-disable import/no-default-export */
+
+import { Box, Container, InputProps } from '@chakra-ui/react'
+import { Story } from '@storybook/react'
+
+import { FlexibleInputContainer } from './FlexibleInputContainer'
+
+export default {
+  title: 'Forms/FlexibleInputContainer',
+  component: FlexibleInputContainer,
+  args: {
+    value: 'Text long enough to cause some scaling'
+  },
+  decorators: [
+    (Story: any) => (
+      <Container centerContent>
+        <Box w={300}>
+          <Story />
+        </Box>
+      </Container>
+    )
+  ]
+}
+
+const Template: Story<InputProps> = args => (
+  <>
+    <FlexibleInputContainer placeholder='Text' {...args} />
+  </>
+)
+
+export const Basic = Template.bind({})

--- a/src/components/Modals/Send/views/Details.tsx
+++ b/src/components/Modals/Send/views/Details.tsx
@@ -126,6 +126,8 @@ export const Details = () => {
               inputLeftElement={
                 <Button
                   ml={1}
+                  mt={1}
+                  mb={1}
                   size='sm'
                   variant='ghost'
                   textTransform='uppercase'
@@ -149,6 +151,8 @@ export const Details = () => {
               inputLeftElement={
                 <Button
                   ml={1}
+                  mt={1}
+                  mb={1}
                   size='sm'
                   variant='ghost'
                   textTransform='uppercase'

--- a/src/components/TokenRow/TokenRow.tsx
+++ b/src/components/TokenRow/TokenRow.tsx
@@ -1,23 +1,19 @@
-import {
-  Input,
-  InputGroup,
-  InputGroupProps,
-  InputLeftElement,
-  InputProps,
-  InputRightElement
-} from '@chakra-ui/react'
+import { Box, Flex, InputGroupProps, InputProps, useStyleConfig } from '@chakra-ui/react'
 import { Control, Controller, ControllerProps, FieldValues, Path } from 'react-hook-form'
 import NumberFormat from 'react-number-format'
+import { FlexibleInputContainer } from 'components/FlexibleInputContainer/FlexibleInputContainer'
 import { useLocaleFormatter } from 'hooks/useLocaleFormatter/useLocaleFormatter'
 
 const CryptoInput = (props: InputProps) => (
-  <Input
-    pr='4.5rem'
-    pl='7.5rem'
+  <FlexibleInputContainer
     size='lg'
     type='number'
-    variant='filled'
+    textAlign='right'
     placeholder='Enter amount'
+    variant='unstyled'
+    pr={2}
+    borderRadius='0'
+    flexGrow={1}
     {...props}
   />
 )
@@ -46,13 +42,14 @@ export function TokenRow<C extends FieldValues>({
     number: { localeParts }
   } = useLocaleFormatter({ fiatType: 'USD' })
 
+  /** Duplicating chakra <Input variant='filled' /> border and background styles */
+  const styles = useStyleConfig('Input', { variant: 'filled', size: 'lg' })
+  const { bg, border, borderColor, borderRadius, _focus } = (styles as any).field
+  const filledCss = { bg, border, borderColor, borderRadius, _focusWithin: _focus }
+
   return (
-    <InputGroup size='lg' {...rest}>
-      {inputLeftElement && (
-        <InputLeftElement ml={1} width='auto'>
-          {inputLeftElement}
-        </InputLeftElement>
-      )}
+    <Flex size='lg' align='center' {...rest} sx={filledCss}>
+      {inputLeftElement && <Box m='2px'>{inputLeftElement}</Box>}
       <Controller
         render={({ field: { onChange, value } }) => {
           return (
@@ -75,9 +72,7 @@ export function TokenRow<C extends FieldValues>({
         control={control}
         rules={rules}
       />
-      {inputRightElement && (
-        <InputRightElement width='4.5rem'>{inputRightElement}</InputRightElement>
-      )}
-    </InputGroup>
+      {inputRightElement && <Box mr='8px'>{inputRightElement}</Box>}
+    </Flex>
   )
 }

--- a/src/components/Trade/TradeInput.tsx
+++ b/src/components/Trade/TradeInput.tsx
@@ -158,6 +158,7 @@ export const TradeInput = ({ history }: RouterProps) => {
                     inputMode='decimal'
                     thousandSeparator={localeParts.group}
                     decimalSeparator={localeParts.decimal}
+                    decimalScale={2}
                     prefix={localeParts.prefix}
                     suffix={localeParts.postfix}
                     value={value}


### PR DESCRIPTION
## Description

* fixes #868 - amount inputs scale to fit long digit numbers
* added FlexibleInputContainer to the storybook

https://www.loom.com/share/5f7f3b5dd37d4e77a5a86a7788a4221d

To make it work I had to change the TokenRow root element to Flex with the Input field as part of the Row, so the scaling could happen without breaking the style of the input, eg: borders.

Styling is copied from Input[variant='filled'] to the Flex container with :focus set as :focus-within.

### Design changes

* I propose to change the amount input text-align to right to keep it with convention. The only issue is "Max" button, which makes the top amount out of line with bottom one. However it doesn't look that bad, should it be checked by a designer?

<img src="https://user-images.githubusercontent.com/83549293/151672827-a851a0db-34a4-459e-8317-b3083cabc50d.png" width=300 />

As a next step: rates are getting fetched every time the amount is changed. It makes the UX quite slow. How about refreshing rate with some backoff timeout ala 1inch style?

## Notice

Before submitting a pull request, please make sure you have answered the following:

- [x] Have you followed the guidelines in our [Contributing]('https://github.com/shapeshift/web/CONTRIBUTING.md) guide?
- [x] Have you checked to ensure there aren't other open [Pull Requests](https://github.com/shapeshift/web/pulls) for the same update/change?
- [x] Do all new and existing tests pass? Does the linter pass?

## Pull Request Type

- [x] :bug: Bug fix (Non-breaking Change: Fixes an issue)

## Testing

Please outline all testing steps

1. Pull branch locally and run yarn to install new deps, cp .sample.env .env, yarn dev
2. Type in a long number into the amount input field.
3. Check how it works on different screen sizes.
