### PR TITLE
feat: handle user-rejected send txs

### DIFF
--- a/src/assets/translations/messages-en.json
+++ b/src/assets/translations/messages-en.json
@@ -219,12 +219,11 @@
       "tokenAddress": "Token Address",
       "scanQrCode": "Scan QR Code",
       "sent": "%{asset} sent",
-      "errorDescription": "Your send of %{asset} failed.",
+      "errorTitle": "Your send of %{asset} failed",
       "errors": {
         "notEnoughNativeToken": "Not enough %{asset} to cover gas",
         "transactionRejected": "User has rejected the transaction"
       },
-      "errorTitle": "Your send of %{asset} failed.",
       "confirm": {
         "sendAsset": "Send %{asset}",
         "send": "Send",

--- a/src/assets/translations/messages-en.json
+++ b/src/assets/translations/messages-en.json
@@ -219,11 +219,12 @@
       "tokenAddress": "Token Address",
       "scanQrCode": "Scan QR Code",
       "sent": "%{asset} sent",
-      "errorTitle": "Something went wrong",
       "errorDescription": "Your send of %{asset} failed.",
       "errors": {
-        "notEnoughNativeToken": "Not enough %{asset} to cover gas"
+        "notEnoughNativeToken": "Not enough %{asset} to cover gas",
+        "transactionRejected": "User has rejected the transaction"
       },
+      "errorTitle": "Your send of %{asset} failed.",
       "confirm": {
         "sendAsset": "Send %{asset}",
         "send": "Send",

--- a/src/components/Modals/Send/hooks/useFormSend/useFormSend.tsx
+++ b/src/components/Modals/Send/hooks/useFormSend/useFormSend.tsx
@@ -113,8 +113,10 @@ export const useFormSend = () => {
         })
       } catch (error) {
         toast({
-          title: translate('modals.send.sent'),
-          description: translate('modals.send.errorTitle'),
+          title: translate('modals.send.errorTitle', {
+            asset: data.asset.name
+          }),
+          description: translate('modals.send.errors.transactionRejected'),
           status: 'error',
           duration: 9000,
           isClosable: true,

--- a/src/components/Modals/Send/hooks/useSendDetails/useSendDetails.test.tsx
+++ b/src/components/Modals/Send/hooks/useSendDetails/useSendDetails.test.tsx
@@ -257,8 +257,8 @@ describe('useSendDetails', () => {
       expect(setValue).toHaveBeenNthCalledWith(2, 'estimatedFees', {
         fast: { chainSpecific: { feePerTx: '6000000000000000' }, networkFee: '6000000000000000' }
       })
-      expect(setValue).toHaveBeenNthCalledWith(3, 'cryptoAmount', '5')
-      expect(setValue).toHaveBeenNthCalledWith(4, 'fiatAmount', '17500.00')
+      expect(setValue).toHaveBeenNthCalledWith(5, 'fiatAmount', '17500.00')
+      expect(setValue).toHaveBeenNthCalledWith(4, 'cryptoAmount', '5')
     })
   })
 


### PR DESCRIPTION
## Description

- feat: handle user-rejected send txs

This fixes the toast that is currently showing when sending of asset fails: "%{asset} sent. User has rejected the transaction" and instead shows "Your send of <token name> failed. User has rejected the transaction". The rest of the flow that leads to user being able to send an invalid tx in the first place is handled in a separate issue, see dev notes.

## Dev Notes

[ethSendTx](https://github.com/shapeshift/hdwallet/blob/f500e03e0f8f5bca076acaf3859ab6a14d363d66/packages/hdwallet-metamask/src/ethereum.ts#L90) in `hdwallet-metamask` currently captures the thrown Metamask error, `console.error`s it, and just returns null. Changing this would be a breaking change in many places. Since we have many checks in place before building, signing and broadcasting the tx, it should be safe to assume this is an error due to user-rejected transaction.

While implementing this, I've noted that we currently let the user send the transaction, even if not enough gas is present to cover it. We should fix this, as it will go through but the user will effectively be left with no option but to cancel it, since Metamask/Portis will not let it go through. Created https://github.com/shapeshift/web/issues/872 for it. 

## Notice

Before submitting a pull request, please make sure you have answered the following:

- [x] Have you followed the guidelines in our [Contributing]('https://github.com/shapeshift/web/CONTRIBUTING.md) guide?
- [x] Have you checked to ensure there aren't other open [Pull Requests](https://github.com/shapeshift/web/pulls) for the same update/change?
- [x] Do all new and existing tests pass? Does the linter pass?

## Pull Request Type

- [ ] :bug: Bug fix (Non-breaking Change: Fixes an issue)
- [ ] :hammer_and_wrench: Chore (Non-breaking Change: Doc updates, pkg upgrades, typos, etc..)
- [x] :nail_care: New Feature (Breaking/Non-breaking Change)

## Issue

#738

## Testing

Tested with Portis/Metamask and with ERC20(Fox) / ETH.

1. Try to send an asset
2. When your wallet asks you for send confirmation, refuse/close modal
3. A toast should pop with the title `Your send of <token name> failed.` and description `User has rejected the transaction`

## Screenshots

**Before:**

![image](https://user-images.githubusercontent.com/17035424/149370756-a61d0d7c-235a-4382-96ea-44c320a1f279.png)

**Now:**

![image](https://user-images.githubusercontent.com/17035424/151798527-5e4d550b-02fb-4a34-afe5-68107918d44d.png)
