### PR TITLE
fix(useSendDetails): loading state on valid balance check

### DIFF
--- a/src/components/Modals/Send/hooks/useSendDetails/useSendDetails.tsx
+++ b/src/components/Modals/Send/hooks/useSendDetails/useSendDetails.tsx
@@ -279,13 +279,17 @@ export const useSendDetails = (): UseSendDetailsReturnType => {
 
         setValue(key, amount)
 
-        const estimatedFees = await estimateFormFees().catch(e => {
+        let estimatedFees
+
+        try {
+          estimatedFees = await estimateFormFees()
+          setValue(SendFormFields.EstimatedFees, estimatedFees)
+        } catch (e) {
           setValue(SendFormFields.AmountFieldError, 'common.insufficientFunds')
           setLoading(false)
 
           throw e
-        })
-        setValue(SendFormFields.EstimatedFees, estimatedFees)
+        }
 
         const values = getValues()
 

--- a/src/components/Modals/Send/hooks/useSendDetails/useSendDetails.tsx
+++ b/src/components/Modals/Send/hooks/useSendDetails/useSendDetails.tsx
@@ -264,38 +264,49 @@ export const useSendDetails = (): UseSendDetailsReturnType => {
 
   // eslint-disable-next-line react-hooks/exhaustive-deps
   const handleInputChange = useCallback(
-    debounce(async (inputValue: string) => {
-      setValue(SendFormFields.SendMax, false)
-      const key =
-        fieldName !== SendFormFields.FiatAmount
-          ? SendFormFields.FiatAmount
-          : SendFormFields.CryptoAmount
-      const amount =
-        fieldName === SendFormFields.FiatAmount
-          ? bnOrZero(bn(inputValue).div(price)).toString()
-          : bnOrZero(bn(inputValue).times(price)).toString()
+    debounce(
+      async (inputValue: string) => {
+        setLoading(true)
+        setValue(SendFormFields.SendMax, false)
+        const key =
+          fieldName !== SendFormFields.FiatAmount
+            ? SendFormFields.FiatAmount
+            : SendFormFields.CryptoAmount
+        const amount =
+          fieldName === SendFormFields.FiatAmount
+            ? bnOrZero(bn(inputValue).div(price)).toString()
+            : bnOrZero(bn(inputValue).times(price)).toString()
 
-      setValue(key, amount)
+        setValue(key, amount)
 
-      const estimatedFees = await estimateFormFees()
-      setValue(SendFormFields.EstimatedFees, estimatedFees)
+        const estimatedFees = await estimateFormFees().catch(e => {
+          setValue(SendFormFields.AmountFieldError, 'common.insufficientFunds')
+          setLoading(false)
 
-      const values = getValues()
+          throw e
+        })
+        setValue(SendFormFields.EstimatedFees, estimatedFees)
 
-      const hasValidBalance = cryptoHumanBalance.gte(values.cryptoAmount)
-      const hasEnoughNativeTokenForGas = nativeAssetBalance
-        .minus(estimatedFees.fast.txFee)
-        .isPositive()
+        const values = getValues()
 
-      if (!hasValidBalance) {
-        setValue(SendFormFields.AmountFieldError, 'common.insufficientFunds')
-      } else if (!hasEnoughNativeTokenForGas) {
-        setValue(SendFormFields.AmountFieldError, [
-          'modals.send.errors.notEnoughNativeToken',
-          { asset: feeAsset.symbol }
-        ])
-      }
-    }, 1000),
+        const hasValidBalance = cryptoHumanBalance.gte(values.cryptoAmount)
+        const hasEnoughNativeTokenForGas = nativeAssetBalance
+          .minus(estimatedFees.fast.txFee)
+          .isPositive()
+
+        if (!hasValidBalance) {
+          setValue(SendFormFields.AmountFieldError, 'common.insufficientFunds')
+        } else if (!hasEnoughNativeTokenForGas) {
+          setValue(SendFormFields.AmountFieldError, [
+            'modals.send.errors.notEnoughNativeToken',
+            { asset: feeAsset.symbol }
+          ])
+        }
+        setLoading(false)
+      },
+      1000,
+      { leading: true }
+    ),
     [asset, fieldName, setValue, estimateFormFees, getValues, cryptoHumanBalance, fiatBalance]
   )
 


### PR DESCRIPTION
## Description

- add missing setting of loading state during valid balance on `useSendDetails`'s input change handler
- don't debounce the leading call to `handleInputChange`, since it would miss out on trying to send [1-9]$ / 1ETH
- capture caught error on `estimateFormFees`, set error/loading state accordingly and rethrow it. This will make sure that the loading works as intended, as not handling the error would short-circuit the logic on thrown error which would result in an infinite loading state

## Notes

This can be improved on a follow-up PR by not even executing the calls to the gas estimate API in case the current `inputValue` is greater than the previous one, since it will obviously be out of user's fees range. 

## Notice

Before submitting a pull request, please make sure you have answered the following:

- [x] Have you followed the guidelines in our [Contributing]('https://github.com/shapeshift/web/CONTRIBUTING.md) guide?
- [x] Have you checked to ensure there aren't other open [Pull Requests](https://github.com/shapeshift/web/pulls) for the same update/change?
- [x] Do all new and existing tests pass? Does the linter pass?

## Pull Request Type

- [x] :bug: Bug fix (Non-breaking Change: Fixes an issue)
- [ ] :hammer_and_wrench: Chore (Non-breaking Change: Doc updates, pkg upgrades, typos, etc..)
- [ ] :nail_care: New Feature (Breaking/Non-breaking Change)

## Issue (if applicable)

#872

## Testing

Please outline all testing steps

1. Try to send ETH
2. There should be a loading state while the check occurs to determine if there is enough ETH to cover gas + ETH value 
3. The check and loading state should happen after the very first digit is typed. In other words, if you type anything between 1 and 9 ($) but have less than the ETH needed to cover the value of your 1-9$ + fee, there should be an error state. Error state will keep on happening on following digits typed,
