### PR TITLE
fix: disable send form next button on empty input

### DIFF
--- a/src/components/Modals/Send/views/Details.tsx
+++ b/src/components/Modals/Send/views/Details.tsx
@@ -170,7 +170,7 @@ export const Details = () => {
         <Stack flex={1}>
           <Button
             isFullWidth
-            isDisabled={!!amountFieldError || loading}
+            isDisabled={!(cryptoAmount ?? fiatAmount) || !!amountFieldError || loading}
             colorScheme={amountFieldError ? 'red' : 'blue'}
             size='lg'
             onClick={handleNextClick}


### PR DESCRIPTION
## Description

- fix: disable send form next button en empty input

Currently, there is no condition to disable the Next button while input is empty, which produces a state with an empty gas estimation view after Next button click.

## Notice

Before submitting a pull request, please make sure you have answered the following:

- [x] Have you followed the guidelines in our [Contributing]('https://github.com/shapeshift/web/CONTRIBUTING.md) guide?
- [x] Have you checked to ensure there aren't other open [Pull Requests](https://github.com/shapeshift/web/pulls) for the same update/change?
- [x] Do all new and existing tests pass? Does the linter pass?

## Pull Request Type

- [x] :bug: Bug fix (Non-breaking Change: Fixes an issue)
- [ ] :hammer_and_wrench: Chore (Non-breaking Change: Doc updates, pkg upgrades, typos, etc..)
- [ ] :nail_care: New Feature (Breaking/Non-breaking Change)

## Testing

Please outline all testing steps

1. Click on `Send` for any asset
2. Enter a destination address and click `Next`
3. `Next` button should be disabled until you input some value

## Screenshots

![image](https://user-images.githubusercontent.com/17035424/151700667-21a56f6d-e883-44e3-8710-7cadd91123c0.png)

