### PR TITLE
fix(useSendDetails): verify ETH balance for ETH/ERC20 send tx gas

### DIFF
--- a/src/assets/translations/messages-en.json
+++ b/src/assets/translations/messages-en.json
@@ -222,7 +222,7 @@
       "errorTitle": "Something went wrong",
       "errorDescription": "Your send of %{asset} failed.",
       "errors": {
-        "notEnoughNativeToken": "Not enough %{asset} to cover gas."
+        "notEnoughNativeToken": "Not enough %{asset} to cover gas"
       },
       "confirm": {
         "sendAsset": "Send %{asset}",

--- a/src/assets/translations/messages-en.json
+++ b/src/assets/translations/messages-en.json
@@ -221,6 +221,9 @@
       "sent": "%{asset} sent",
       "errorTitle": "Something went wrong",
       "errorDescription": "Your send of %{asset} failed.",
+      "errors": {
+        "notEnoughNativeToken": "Not enough %{asset} to cover gas."
+      },
       "confirm": {
         "sendAsset": "Send %{asset}",
         "send": "Send",

--- a/src/components/Modals/Send/Form.tsx
+++ b/src/components/Modals/Send/Form.tsx
@@ -42,7 +42,7 @@ export type SendInput = {
   [SendFormFields.Address]: string
   [SendFormFields.EnsName]?: string
   [SendFormFields.AccountId]: AccountSpecifier
-  [SendFormFields.AmountFieldError]: string
+  [SendFormFields.AmountFieldError]: string | [string, { asset: string }]
   [SendFormFields.Asset]: Asset
   [SendFormFields.FeeType]: chainAdapters.FeeDataKey
   [SendFormFields.EstimatedFees]: chainAdapters.FeeDataEstimate<ChainTypes>

--- a/src/components/Modals/Send/hooks/useSendDetails/useSendDetails.tsx
+++ b/src/components/Modals/Send/hooks/useSendDetails/useSendDetails.tsx
@@ -9,7 +9,6 @@ import { useChainAdapters } from 'context/ChainAdaptersProvider/ChainAdaptersPro
 import { useWallet } from 'context/WalletProvider/WalletProvider'
 import { BigNumber, bn, bnOrZero } from 'lib/bignumber/bignumber'
 import { ensLookup } from 'lib/ens'
-import { fromBaseUnit } from 'lib/math'
 import { isEthAddress } from 'lib/utils'
 import { selectFeeAssetById } from 'state/slices/assetsSlice/assetsSlice'
 import { selectMarketDataById } from 'state/slices/marketDataSlice/marketDataSlice'

--- a/src/components/Modals/Send/hooks/useSendDetails/useSendDetails.tsx
+++ b/src/components/Modals/Send/hooks/useSendDetails/useSendDetails.tsx
@@ -70,6 +70,12 @@ export const useSendDetails = (): UseSendDetailsReturnType => {
   const assetBalance = useAppSelector(state =>
     selectPortfolioCryptoBalanceByFilter(state, { assetId: asset.caip19, accountId })
   )
+
+  const nativeAssetBalance = bnOrZero(
+    useAppSelector(state =>
+      selectPortfolioCryptoBalanceByFilter(state, { assetId: feeAsset.caip19, accountId })
+    )
+  )
   const chainAdapterManager = useChainAdapters()
   const {
     state: { wallet }
@@ -149,13 +155,20 @@ export const useSendDetails = (): UseSendDetailsReturnType => {
   }
 
   const handleSendMax = async () => {
-    // we can always send the full balance of tokens, no need to make network
-    // calls to estimate fees
     if (feeAsset.caip19 !== asset.caip19) {
       setValue(SendFormFields.CryptoAmount, cryptoHumanBalance.toPrecision())
       setValue(SendFormFields.FiatAmount, fiatBalance.toFixed(2))
+      setLoading(true)
+
       const estimatedFees = await estimateFormFees()
-      setValue(SendFormFields.EstimatedFees, estimatedFees)
+
+      if (nativeAssetBalance.minus(estimatedFees.fast.txFee).isNegative()) {
+        setValue(SendFormFields.AmountFieldError, 'common.insufficientFunds')
+      } else {
+        setValue(SendFormFields.EstimatedFees, estimatedFees)
+      }
+
+      setLoading(false)
       return
     }
 
@@ -262,7 +275,9 @@ export const useSendDetails = (): UseSendDetailsReturnType => {
           .minus(fromBaseUnit(estimatedFees.fast.txFee, feeAsset.precision))
           .gte(values.cryptoAmount)
       } else {
-        hasValidBalance = cryptoHumanBalance.gte(values.cryptoAmount)
+        hasValidBalance =
+          nativeAssetBalance.minus(estimatedFees.fast.txFee).isPositive() &&
+          cryptoHumanBalance.gte(values.cryptoAmount)
       }
 
       setValue(SendFormFields.AmountFieldError, hasValidBalance ? '' : 'common.insufficientFunds')


### PR DESCRIPTION
## Description

- fix(useSendDetails): verify that user has enough of native token (ERC20 for now, but that can the same logic can be used for other caip19 in the future) to cover the gas fee.

## Notice

Before submitting a pull request, please make sure you have answered the following:

- [x] Have you followed the guidelines in our [Contributing]('https://github.com/shapeshift/web/CONTRIBUTING.md) guide?
- [x] Have you checked to ensure there aren't other open [Pull Requests](https://github.com/shapeshift/web/pulls) for the same update/change?
- [x] Do all new and existing tests pass? Does the linter pass?

## Pull Request Type

- [x] :bug: Bug fix (Non-breaking Change: Fixes an issue)
- [ ] :hammer_and_wrench: Chore (Non-breaking Change: Doc updates, pkg upgrades, typos, etc..)
- [ ] :nail_care: New Feature (Breaking/Non-breaking Change)

## Issue (if applicable)

#872

## Testing

Please outline all testing steps

1. Use an account without enough ETH to cover an ERC20 send tx gas fee
2. Try to send max, it should load for a few ms then display insufficient gas error button state
3. Try to send any amount of token (within the range of your balance), it should display insufficient gas message (loading state will be implemented separately in https://github.com/shapeshift/web/pull/873/ and I will update this then, but for now, you should just wait ~1s without clicking next and it will error out) 

## Screenshots (if applicable)

- ERC20 - sendMax with token balance but not enough ETH for gas

![image](https://user-images.githubusercontent.com/17035424/151801649-bd7eb4e0-1dc2-4e46-90bf-a75cd1209d05.png)


- ERC20 - user-input value with token balance but not enough ETH for gas

![image](https://user-images.githubusercontent.com/17035424/151802056-6281dafb-6f90-492f-b842-9045f0da2187.png)

- ETH - sendMax with ETH balance but not enough ETH for gas

![image](https://user-images.githubusercontent.com/17035424/151801825-cb795a01-da76-4bdc-8cf2-79c9f311401b.png)

- ETH - user-input value with ETH balance but not enough ETH for gas 

![image](https://user-images.githubusercontent.com/17035424/151801960-70cc36bb-31a4-4521-a501-9d485c570313.png)