### PR TITLE
feat: disable send transactions when insufficient balance

### DIFF
--- a/src/components/AssetHeader/AssetActions.tsx
+++ b/src/components/AssetHeader/AssetActions.tsx
@@ -31,7 +31,7 @@ export const AssetActions = ({ isLoaded, assetId, accountId, cryptoBalance }: As
     isConnected ? send.open({ asset: asset, accountId }) : handleWalletModalOpen()
   const handleReceiveClick = () =>
     isConnected ? receive.open({ asset: asset, accountId }) : handleWalletModalOpen()
-  const notEnoughCryptoToSell = (): boolean => bnOrZero(cryptoBalance).eq(0)
+  const hasValidBalance = bnOrZero(cryptoBalance).gt(0)
 
   return (
     <ButtonGroup
@@ -42,9 +42,7 @@ export const AssetActions = ({ isLoaded, assetId, accountId, cryptoBalance }: As
       <Skeleton isLoaded={isLoaded} width={{ base: 'full', lg: 'auto' }}>
         <Tooltip
           label={
-            notEnoughCryptoToSell()
-              ? translate('common.insufficientFunds')
-              : translate('common.send')
+            !hasValidBalance ? translate('common.insufficientFunds') : translate('common.send')
           }
           fontSize='md'
           px={4}
@@ -57,7 +55,7 @@ export const AssetActions = ({ isLoaded, assetId, accountId, cryptoBalance }: As
               width='full'
               icon={<ArrowUpIcon />}
               aria-label={translate('common.send')}
-              isDisabled={notEnoughCryptoToSell()}
+              isDisabled={!hasValidBalance}
             />
           </div>
         </Tooltip>

--- a/src/components/AssetHeader/AssetActions.tsx
+++ b/src/components/AssetHeader/AssetActions.tsx
@@ -1,6 +1,7 @@
 import { ArrowDownIcon, ArrowUpIcon } from '@chakra-ui/icons'
 import { ButtonGroup, IconButton, Skeleton, Tooltip } from '@chakra-ui/react'
 import { CAIP19 } from '@shapeshiftoss/caip'
+import { bnOrZero } from '@shapeshiftoss/chain-adapters'
 import { useTranslate } from 'react-polyglot'
 import { useModal } from 'context/ModalProvider/ModalProvider'
 import { useWallet, WalletActions } from 'context/WalletProvider/WalletProvider'
@@ -12,9 +13,10 @@ type AssetActionProps = {
   isLoaded: boolean
   assetId: CAIP19
   accountId?: AccountSpecifier
+  cryptoBalance: string
 }
 
-export const AssetActions = ({ isLoaded, assetId, accountId }: AssetActionProps) => {
+export const AssetActions = ({ isLoaded, assetId, accountId, cryptoBalance }: AssetActionProps) => {
   const { send, receive } = useModal()
   const translate = useTranslate()
   const {
@@ -29,6 +31,7 @@ export const AssetActions = ({ isLoaded, assetId, accountId }: AssetActionProps)
     isConnected ? send.open({ asset: asset, accountId }) : handleWalletModalOpen()
   const handleReceiveClick = () =>
     isConnected ? receive.open({ asset: asset, accountId }) : handleWalletModalOpen()
+  const notEnoughCryptoToSell = (): boolean => bnOrZero(cryptoBalance).eq(0)
 
   return (
     <ButtonGroup
@@ -37,14 +40,26 @@ export const AssetActions = ({ isLoaded, assetId, accountId }: AssetActionProps)
       width={{ base: 'full', lg: 'auto' }}
     >
       <Skeleton isLoaded={isLoaded} width={{ base: 'full', lg: 'auto' }}>
-        <Tooltip label={translate('common.send')} fontSize='md' px={4} hasArrow>
-          <IconButton
-            onClick={handleSendClick}
-            isRound
-            width='full'
-            icon={<ArrowUpIcon />}
-            aria-label={translate('common.send')}
-          />
+        <Tooltip
+          label={
+            notEnoughCryptoToSell()
+              ? translate('common.insufficientFunds')
+              : translate('common.send')
+          }
+          fontSize='md'
+          px={4}
+          hasArrow
+        >
+          <div>
+            <IconButton
+              onClick={handleSendClick}
+              isRound
+              width='full'
+              icon={<ArrowUpIcon />}
+              aria-label={translate('common.send')}
+              isDisabled={notEnoughCryptoToSell()}
+            />
+          </div>
         </Tooltip>
       </Skeleton>
       <Skeleton isLoaded={isLoaded} width={{ base: 'full', lg: 'auto' }}>

--- a/src/components/AssetHeader/AssetHeader.tsx
+++ b/src/components/AssetHeader/AssetHeader.tsx
@@ -116,6 +116,7 @@ export const AssetHeader: React.FC<AssetHeaderProps> = ({ assetId, accountId }) 
               isLoaded={isLoaded}
               assetId={assetId}
               accountId={accountId ? accountId : singleAccount}
+              cryptoBalance={cryptoBalance}
             />
           ) : null}
         </Flex>

--- a/src/components/Trade/TradeInput.tsx
+++ b/src/components/Trade/TradeInput.tsx
@@ -146,6 +146,18 @@ export const TradeInput = ({ history }: RouterProps) => {
     })
   }
 
+  const getTranslationKey = () => {
+    if (!wallet) {
+      return 'common.connectWallet'
+    }
+
+    if (isValid && !hasValidTradeBalance) {
+      return 'common.insufficientFunds'
+    }
+
+    return error ?? 'trade.previewTrade'
+  }
+
   // TODO:(ryankk) fix error handling
   const error = errors?.quote?.value?.message ?? null
 
@@ -298,15 +310,7 @@ export const TradeInput = ({ history }: RouterProps) => {
                 wordWrap: 'break-word'
               }}
             >
-              <Text
-                translation={
-                  !wallet
-                    ? 'common.connectWallet'
-                    : isValid && !hasValidTradeBalance
-                    ? 'common.insufficientFunds'
-                    : error ?? 'trade.previewTrade'
-                }
-              />
+              <Text translation={getTranslationKey()} />
             </Button>
           </Card.Body>
         </Card>

--- a/src/components/Trade/TradeInput.tsx
+++ b/src/components/Trade/TradeInput.tsx
@@ -59,11 +59,10 @@ export const TradeInput = ({ history }: RouterProps) => {
     state: { wallet }
   } = useWallet()
 
-  const cryptoBalance = useAppSelector(state =>
-    selectPortfolioCryptoHumanBalanceByAssetId(state, buyAsset?.currency?.caip19)
+  const sellAssetBalance = useAppSelector(state =>
+    selectPortfolioCryptoHumanBalanceByAssetId(state, sellAsset?.currency?.caip19)
   )
-  const enoughCryptoToSell = (): boolean =>
-    bnOrZero(cryptoBalance).isGreaterThan(buyAsset?.amount || 0)
+  const hasValidBalance = bnOrZero(sellAssetBalance).gt(0)
 
   const onSubmit = async () => {
     if (!wallet) return
@@ -300,7 +299,7 @@ export const TradeInput = ({ history }: RouterProps) => {
               px={4}
               hasArrow
               isDisabled={
-                !isValid || isSubmitting || isSendMaxLoading || !!action || enoughCryptoToSell()
+                !isValid || isSubmitting || isSendMaxLoading || !!action || hasValidBalance
               }
             >
               <div>
@@ -310,7 +309,7 @@ export const TradeInput = ({ history }: RouterProps) => {
                   width='full'
                   colorScheme={error ? 'red' : 'blue'}
                   isLoading={isSubmitting || isSendMaxLoading || !!action}
-                  isDisabled={!isDirty || !isValid || !!action || !wallet || !enoughCryptoToSell()}
+                  isDisabled={!isDirty || !isValid || !!action || !wallet || !hasValidBalance}
                   style={{
                     whiteSpace: 'normal',
                     wordWrap: 'break-word'

--- a/src/components/Trade/TradeInput.tsx
+++ b/src/components/Trade/TradeInput.tsx
@@ -1,12 +1,4 @@
-import {
-  Box,
-  Button,
-  FormControl,
-  FormErrorMessage,
-  IconButton,
-  Tooltip,
-  useToast
-} from '@chakra-ui/react'
+import { Box, Button, FormControl, FormErrorMessage, IconButton, useToast } from '@chakra-ui/react'
 import { ChainTypes, ContractTypes, SwapperType } from '@shapeshiftoss/types'
 import { useState } from 'react'
 import { Controller, useFormContext, useWatch } from 'react-hook-form'
@@ -62,6 +54,7 @@ export const TradeInput = ({ history }: RouterProps) => {
   const sellAssetBalance = useAppSelector(state =>
     selectPortfolioCryptoHumanBalanceByAssetId(state, sellAsset?.currency?.caip19)
   )
+  const hasValidTradeBalance = bnOrZero(sellAssetBalance).gte(bnOrZero(sellAsset?.amount))
   const hasValidBalance = bnOrZero(sellAssetBalance).gt(0)
 
   const onSubmit = async () => {
@@ -231,7 +224,7 @@ export const TradeInput = ({ history }: RouterProps) => {
                     size='sm'
                     variant='ghost'
                     colorScheme='blue'
-                    isDisabled={isSendMaxLoading || !!action}
+                    isDisabled={isSendMaxLoading || !!action || !hasValidBalance}
                     onClick={onSwapMax}
                   >
                     Max
@@ -293,34 +286,28 @@ export const TradeInput = ({ history }: RouterProps) => {
                 }
               />
             </FormControl>
-            <Tooltip
-              label={translate('common.insufficientFunds')}
-              fontSize='md'
-              px={4}
-              hasArrow
-              isDisabled={
-                !isValid || isSubmitting || isSendMaxLoading || !!action || hasValidBalance
-              }
+            <Button
+              type='submit'
+              size='lg'
+              width='full'
+              colorScheme={error || (isValid && !hasValidTradeBalance && !action) ? 'red' : 'blue'}
+              isLoading={isSubmitting || isSendMaxLoading || !!action}
+              isDisabled={!isDirty || !isValid || !!action || !wallet || !hasValidTradeBalance}
+              style={{
+                whiteSpace: 'normal',
+                wordWrap: 'break-word'
+              }}
             >
-              <div>
-                <Button
-                  type='submit'
-                  size='lg'
-                  width='full'
-                  colorScheme={error ? 'red' : 'blue'}
-                  isLoading={isSubmitting || isSendMaxLoading || !!action}
-                  isDisabled={!isDirty || !isValid || !!action || !wallet || !hasValidBalance}
-                  style={{
-                    whiteSpace: 'normal',
-                    wordWrap: 'break-word'
-                  }}
-                >
-                  <Text
-                    translation={!wallet ? 'common.connectWallet' : error ?? 'trade.previewTrade'}
-                  />
-                </Button>
-              </div>
-            </Tooltip>
+              <Text
+                translation={
+                  !wallet
+                    ? 'common.connectWallet'
+                    : isValid && !hasValidTradeBalance
+                    ? 'common.insufficientFunds'
+                    : error ?? 'trade.previewTrade'
+                }
+              />
+            </Button>
           </Card.Body>
         </Card>
       </Box>


### PR DESCRIPTION
## Description

Restricts the users from sending tokens whenever their wallet balance is bellow 0 (Sell case) or the input amount is above wallet balance (trade flow).

## Notice

Before submitting a pull request, please make sure you have answered the following:

- [x] Have you followed the guidelines in our [Contributing]('https://github.com/shapeshift/web/CONTRIBUTING.md) guide?
- [x] Have you checked to ensure there aren't other open [Pull Requests](https://github.com/shapeshift/web/pulls) for the same update/change?

## Pull Request Type

- [ ] :bug: Bug fix (Non-breaking Change: Fixes an issue)
- [ ] :hammer_and_wrench: Chore (Non-breaking Change: Doc updates, pkg upgrades, typos, etc..)
- [x] :nail_care: New Feature (Breaking/Non-breaking Change)

## Issue

Closes: https://github.com/shapeshift/web/issues/736

## Testing

Please outline all testing steps

Sell flow:
1. Pull branch locally and  start the server
2. Under "Your Assets" select an asset which you used to have but currently shows 0 balance
3. Hover over "Sell" button

Trade flow:
1. Pull branch locally and  start the server
2. Input an amount in the Trade Input which is above the amount that is available on the user's wallet for that specific token.
3. Hover over "Trade" button

## Screenshots

Sell attempt whenever the user's wallet is below 0:
<img width="681" alt="sell" src="https://user-images.githubusercontent.com/29582253/151925850-e44dd16f-bf3e-43e2-a11e-69c2d042e31f.png">

Trade attempt whenever the input amount is bigger than the wallet amount:
<img width="379" alt="trade" src="https://user-images.githubusercontent.com/29582253/151925898-d46408bc-5c57-44cc-accf-54dbffe6072b.png">
