### PR TITLE
filtering out vaults that have disabled deposits and including vault …

### DIFF
--- a/src/features/defi/components/Deposit/Deposit.tsx
+++ b/src/features/defi/components/Deposit/Deposit.tsx
@@ -120,6 +120,8 @@ export const Deposit = ({
   const [activeField, setActiveField] = useState<InputType>(InputType.Crypto)
   const [percent, setPercent] = useState<number | null>(null)
   const amountRef = useRef<string | null>(null)
+  const bgColor = useColorModeValue('gray.50', 'gray.850')
+  const borderColor = useColorModeValue('gray.100', 'gray.750')
 
   const {
     clearErrors,
@@ -246,10 +248,10 @@ export const Deposit = ({
               </FormHelperText>
             </Box>
             <VStack
-              bg={useColorModeValue('gray.50', 'gray.850')}
+              bg={bgColor}
               borderRadius='xl'
               borderWidth={1}
-              borderColor={useColorModeValue('gray.100', 'gray.750')}
+              borderColor={borderColor}
               divider={<Divider />}
               spacing={0}
             >

--- a/src/features/defi/providers/yearn/api/api.ts
+++ b/src/features/defi/providers/yearn/api/api.ts
@@ -61,8 +61,8 @@ export class YearnVaultApi {
     return this.yearnSdk.vaults.get()
   }
 
-  findByDepositTokenId(tokenId: string) {
-    const vault = this.vaults.find(item => toLower(item.tokenId) === toLower(tokenId))
+  findByDepositVaultAddress(vaultAddress: string) {
+    const vault = this.vaults.find(item => toLower(item.address) === toLower(vaultAddress))
     if (!vault) return null
     return vault
   }

--- a/src/features/defi/providers/yearn/api/vaults.ts
+++ b/src/features/defi/providers/yearn/api/vaults.ts
@@ -1,3 +1,4 @@
+import { bnOrZero } from '@shapeshiftoss/chain-adapters'
 import { ChainTypes } from '@shapeshiftoss/types'
 import { Vault } from '@yfi/sdk'
 import {
@@ -21,15 +22,22 @@ export type SupportedYearnVault = {
 export const getSupportedVaults = async (): Promise<SupportedYearnVault[]> => {
   const vaults = await yearnSdk.vaults.get()
 
-  return vaults.map((vault: Vault) => {
-    return {
-      vaultAddress: toLower(vault.address),
-      name: vault.name,
-      symbol: vault.symbol,
-      tokenAddress: toLower(vault.token),
-      chain: ChainTypes.Ethereum,
-      provider: DefiProvider.Yearn,
-      type: DefiType.Vault
-    }
-  })
+  return vaults
+    .filter((vault: Vault) => {
+      // Currently filtering out all vaults where deposits are disabled or the deposit limit is 0.
+      // TODO: Update modal so that vaults with disabled deposit only show if a user has a balance
+      // and only display the option to withdraw from the vault.
+      return !vault.metadata.depositsDisabled && bnOrZero(vault.metadata.depositLimit).gt(0)
+    })
+    .map((vault: Vault) => {
+      return {
+        vaultAddress: toLower(vault.address),
+        name: `${vault.name} ${vault.version}`,
+        symbol: vault.symbol,
+        tokenAddress: toLower(vault.token),
+        chain: ChainTypes.Ethereum,
+        provider: DefiProvider.Yearn,
+        type: DefiType.Vault
+      }
+    })
 }

--- a/src/features/defi/providers/yearn/components/YearnManager/Deposit/YearnDeposit.tsx
+++ b/src/features/defi/providers/yearn/components/YearnManager/Deposit/YearnDeposit.tsx
@@ -112,10 +112,10 @@ export const YearnDeposit = ({ api }: YearnDepositProps) => {
   useEffect(() => {
     ;(async () => {
       try {
-        if (!walletState.wallet || !tokenId) return
+        if (!walletState.wallet || !vaultAddress) return
         const [address, vault, pricePerShare] = await Promise.all([
           chainAdapter.getAddress({ wallet: walletState.wallet }),
-          api.findByDepositTokenId(tokenId),
+          api.findByDepositVaultAddress(vaultAddress),
           api.pricePerShare({ vaultAddress })
         ])
         dispatch({ type: YearnDepositActionType.SET_USER_ADDRESS, payload: address })
@@ -129,7 +129,7 @@ export const YearnDeposit = ({ api }: YearnDepositProps) => {
         console.error('YearnDeposit error:', error)
       }
     })()
-  }, [api, chainAdapter, tokenId, vaultAddress, walletState.wallet])
+  }, [api, chainAdapter, vaultAddress, walletState.wallet])
 
   const getApproveGasEstimate = async () => {
     if (!state.userAddress || !tokenId) return

--- a/src/features/defi/providers/yearn/components/YearnManager/Withdraw/YearnWithdraw.tsx
+++ b/src/features/defi/providers/yearn/components/YearnManager/Withdraw/YearnWithdraw.tsx
@@ -88,10 +88,10 @@ export const YearnWithdraw = ({ api }: YearnWithdrawProps) => {
   useEffect(() => {
     ;(async () => {
       try {
-        if (!walletState.wallet || !tokenId) return
+        if (!walletState.wallet || !vaultAddress) return
         const [address, vault, pricePerShare] = await Promise.all([
           chainAdapter.getAddress({ wallet: walletState.wallet }),
-          api.findByDepositTokenId(tokenId),
+          api.findByDepositVaultAddress(vaultAddress),
           api.pricePerShare({ vaultAddress })
         ])
         dispatch({ type: YearnWithdrawActionType.SET_USER_ADDRESS, payload: address })
@@ -105,7 +105,7 @@ export const YearnWithdraw = ({ api }: YearnWithdrawProps) => {
         console.error('YearnWithdraw error:', error)
       }
     })()
-  }, [api, chainAdapter, tokenId, vaultAddress, walletState.wallet])
+  }, [api, chainAdapter, vaultAddress, walletState.wallet])
 
   const getWithdrawGasEstimate = async (withdraw: WithdrawValues) => {
     if (!state.userAddress || !tokenId) return


### PR DESCRIPTION
## Description

Due to the addition of all yearn vaults, some new UX issues were discovered related to old vaults with deposits disabled and 0 deposit limits (enforced on the contract level). With this PR, we are filtering out all vaults where deposits are disabled, or deposit limits are 0. Also including the version number of the vault with the name, and cleaned up some find logic to find based on the vault address, not the underlying token address.

## Notice

Before submitting a pull request, please make sure you have answered the following:

- [x] Have you followed the guidelines in our [Contributing]('https://github.com/shapeshift/web/CONTRIBUTING.md) guide?
- [x] Have you checked to ensure there aren't other open [Pull Requests](https://github.com/shapeshift/web/pulls) for the same update/change?

## Pull Request Type

- [x] :bug: Bug fix (Non-breaking Change: Fixes an issue)
- [ ] :hammer_and_wrench: Chore (Non-breaking Change: Doc updates, pkg upgrades, typos, etc..)
- [ ] :nail_care: New Feature (Breaking/Non-breaking Change)

## Issue (if applicable)

If applicable, please link to the github issue and put `closes #XXXX` in your comment to auto-close the issue that your PR fixes.

## Testing

Please outline all testing steps

1. Open app.
2. Go to Earn tab
3. You should see a list of yearn vaults to choose from.
4. Deposit/withdraw/approve should work for all vaults.
5. On the underlying assets page, you should see yearn vault information

## Screenshots (if applicable)

![Screen Shot 2022-02-01 at 14 21 20](https://user-images.githubusercontent.com/88169003/152053425-12030d71-4b9b-4e13-bbce-cb8492752821.png)