### PR TITLE
feat(defi): inject dynamic providers dynamically

### DIFF
--- a/src/features/defi/contexts/DefiManagerProvider/DefiManagerProvider.tsx
+++ b/src/features/defi/contexts/DefiManagerProvider/DefiManagerProvider.tsx
@@ -1,7 +1,7 @@
 import { ChainTypes } from '@shapeshiftoss/types'
 import { YearnProvider } from 'features/defi/contexts/YearnProvider/YearnProvider'
 import React, { useContext } from 'react'
-import { Route, useLocation } from 'react-router-dom'
+import { Route, Switch, useLocation } from 'react-router-dom'
 import { NotFound } from 'pages/NotFound/NotFound'
 
 import { DefiModal } from '../../components/DefiModal/DefiModal'
@@ -50,25 +50,37 @@ const DefiModules = {
   [DefiProvider.Yearn]: YearnManager
 }
 
+const DefiProviders = {
+  [DefiProvider.Yearn]: YearnProvider
+}
+
 export function DefiManagerProvider({ children }: DefiManagerProviderProps) {
   const location = useLocation<{ background: any }>()
   const background = location.state && location.state.background
 
   return (
     <DefiManagerContext.Provider value={null}>
-      <YearnProvider>
-        {children}
-        {background && (
-          <Route
-            path='/defi/:earnType/:provider/:action'
-            render={({ match: { params } }) => {
-              const { provider } = params
-              const Module = DefiModules[provider as DefiProvider]
-              return <DefiModal>{Module ? <Module /> : <NotFound />}</DefiModal>
-            }}
-          />
-        )}
-      </YearnProvider>
+      <Switch>
+        <YearnProvider>
+          {background && (
+            <Route
+              path='/defi/:earnType/:provider/:action'
+              render={({ match: { params } }) => {
+                const { provider } = params
+                const Module = DefiModules[provider as DefiProvider]
+                const Provider = DefiProviders[provider as DefiProvider]
+                return (
+                  <Provider>
+                    {children}
+                    <DefiModal>{Module ? <Module /> : <NotFound />}</DefiModal>
+                  </Provider>
+                )
+              }}
+            />
+          )}
+          <Route path='/*'>{children}</Route>
+        </YearnProvider>
+      </Switch>
     </DefiManagerContext.Provider>
   )
 }


### PR DESCRIPTION
## Description

The two occurrences of "dynamic" aren't a mistake:

- Inject DeFi provider dynamically - only within defi routes
- Inject specific DeFi provider dynamically depending on the current provider type in the querystring

This prepares for some Cosmos SDK features to be worked on, e.g https://github.com/shapeshift/web/issues/658. Currently, the `DefiManagerProvider.tsx` is not so much of a DefiManager provider but rather a YearnManager provider. This little inversion of control that allows us to use other Managers/Providers will allow us to get started. 

## Notice

Before submitting a pull request, please make sure you have answered the following:

- [x] Have you followed the guidelines in our [Contributing]('https://github.com/shapeshift/web/CONTRIBUTING.md) guide?
- [x] Have you checked to ensure there aren't other open [Pull Requests](https://github.com/shapeshift/web/pulls) for the same update/change?

## Pull Request Type

- [ ] :bug: Bug fix (Non-breaking Change: Fixes an issue)
- [ ] :hammer_and_wrench: Chore (Non-breaking Change: Doc updates, pkg upgrades, typos, etc..)
- [x] :nail_care: New Feature (Breaking/Non-breaking Change)