### PR TITLE
fix: brave support on Linux

### DIFF
--- a/cypress/README.md
+++ b/cypress/README.md
@@ -18,7 +18,9 @@ Fix lint: `lint:cypress:fix`
 
 **Where do I put them?**
 
-Add to an existing file in `cypress/interation`, or create your own if the tests fall into a new category.
+Add to an existing file in `cypress/integration`, or create your own if the tests fall into a new category.
+
+For test files to be recognised by Cypress they must be appended with `_spec`. For example, if we are testing a staking page, we might name the test file `staking_spec.ts`.
 
 **How do I find the element I want to test with Cypress?**
 

--- a/cypress/plugins/index.ts
+++ b/cypress/plugins/index.ts
@@ -1,4 +1,5 @@
 require('dotenv').config()
+const { execSync } = require('child_process')
 const { resolve } = require('path')
 const fs = require('fs')
 
@@ -13,7 +14,8 @@ const findBrave = (): Cypress.Browser | undefined => {
         return isBraveInstalled ? braveMacOsPath : undefined
       }
       case 'linux': {
-        return resolve(process.cwd(), 'cypress/scripts/linux-brave-version.sh')
+        const braveLinuxOsPath = execSync(resolve(process.cwd(), 'cypress/scripts/linux-brave-version.sh'))
+        return braveLinuxOsPath ? braveLinuxOsPath.toString().trim() : undefined
       }
       default: {
         return undefined

--- a/cypress/plugins/index.ts
+++ b/cypress/plugins/index.ts
@@ -14,7 +14,9 @@ const findBrave = (): Cypress.Browser | undefined => {
         return isBraveInstalled ? braveMacOsPath : undefined
       }
       case 'linux': {
-        const braveLinuxOsPath = execSync(resolve(process.cwd(), 'cypress/scripts/linux-brave-version.sh'))
+        const braveLinuxOsPath = execSync(
+          resolve(process.cwd(), 'cypress/scripts/linux-brave-version.sh')
+        )
         return braveLinuxOsPath ? braveLinuxOsPath.toString().trim() : undefined
       }
       default: {
@@ -23,24 +25,26 @@ const findBrave = (): Cypress.Browser | undefined => {
     }
   })()
 
-  return execa(browserPath, ['--version']).then((result: { stdout: string }) => {
-    // STDOUT will be like "Brave Browser 77.0.69.135"
-    // @ts-ignore
-    const [, version] = /Brave Browser (\d+\.\d+\.\d+\.\d+)/.exec(result.stdout)
-    const majorVersion = parseInt(version.split('.')[0])
+  return browserPath
+    ? execa(browserPath, ['--version']).then((result: { stdout: string }) => {
+        // STDOUT will be like "Brave Browser 77.0.69.135"
+        // @ts-ignore
+        const [, version] = /Brave Browser (\d+\.\d+\.\d+\.\d+)/.exec(result.stdout)
+        const majorVersion = parseInt(version.split('.')[0])
 
-    return browserPath
-      ? {
-          name: 'Brave',
-          channel: 'stable',
-          family: 'chromium',
-          displayName: 'Brave',
-          version,
-          path: browserPath,
-          majorVersion
-        }
-      : undefined
-  })
+        return browserPath
+          ? {
+              name: 'Brave',
+              channel: 'stable',
+              family: 'chromium',
+              displayName: 'Brave',
+              version,
+              path: browserPath,
+              majorVersion
+            }
+          : undefined
+      })
+    : undefined
 }
 
 /**

--- a/cypress/plugins/index.ts
+++ b/cypress/plugins/index.ts
@@ -27,7 +27,6 @@ const findBrave = (): Cypress.Browser | undefined => {
 
   return browserPath
     ? execa(browserPath, ['--version']).then((result: { stdout: string }) => {
-        // STDOUT will be like "Brave Browser 77.0.69.135"
         // @ts-ignore
         const [, version] = /Brave Browser (\d+\.\d+\.\d+\.\d+)/.exec(result.stdout)
         const majorVersion = parseInt(version.split('.')[0])

--- a/cypress/plugins/index.ts
+++ b/cypress/plugins/index.ts
@@ -27,6 +27,7 @@ const findBrave = (): Cypress.Browser | undefined => {
 
   return browserPath
     ? execa(browserPath, ['--version']).then((result: { stdout: string }) => {
+        // STDOUT will be like "Brave Browser 77.0.69.135"
         // @ts-ignore
         const [, version] = /Brave Browser (\d+\.\d+\.\d+\.\d+)/.exec(result.stdout)
         const majorVersion = parseInt(version.split('.')[0])

--- a/cypress/plugins/index.ts
+++ b/cypress/plugins/index.ts
@@ -50,7 +50,9 @@ module.exports = async (on: any, config: any) => {
   }
 
   const brave = await findBrave()
-  config.browsers = config.browsers.concat(brave)
+  if (brave) {
+    config.browsers = config.browsers.concat(brave)
+  }
 
   // Allow Cypress to see key Node environment variables via Cypress.env('some-variable')
   config.env.REACT_APP_UNCHAINED_ETHEREUM_HTTP_URL =

--- a/cypress/scripts/linux-brave-version.sh
+++ b/cypress/scripts/linux-brave-version.sh
@@ -2,11 +2,10 @@
 
 BRAVE_PATH=$(which brave-browser)
 BRAVE_CODE=$?
-BRAVE_VERSION=$($BRAVE_PATH --version 2> /dev/null)
 
+# STDOUT will be like "Brave Browser 77.0.69.135"
 if [ $BRAVE_CODE -eq 0 ]; then
   echo "$BRAVE_PATH"
-  echo "${BRAVE_VERSION/Brave Browser/}"
   exit 0
 else
   exit 1

--- a/cypress/scripts/linux-brave-version.sh
+++ b/cypress/scripts/linux-brave-version.sh
@@ -6,6 +6,4 @@ BRAVE_CODE=$?
 if [ $BRAVE_CODE -eq 0 ]; then
   echo "$BRAVE_PATH"
   exit 0
-else
-  exit 1
 fi

--- a/cypress/scripts/linux-brave-version.sh
+++ b/cypress/scripts/linux-brave-version.sh
@@ -1,0 +1,13 @@
+#!/usr/bin/env bash
+
+BRAVE_PATH=$(which brave-browser)
+BRAVE_CODE=$?
+BRAVE_VERSION=$($BRAVE_PATH --version 2> /dev/null)
+
+if [ $BRAVE_CODE -eq 0 ]; then
+  echo "$BRAVE_PATH"
+  echo "${BRAVE_VERSION/Brave Browser/}"
+  exit 0
+else
+  exit 1
+fi

--- a/cypress/scripts/linux-brave-version.sh
+++ b/cypress/scripts/linux-brave-version.sh
@@ -3,7 +3,6 @@
 BRAVE_PATH=$(which brave-browser)
 BRAVE_CODE=$?
 
-# STDOUT will be like "Brave Browser 77.0.69.135"
 if [ $BRAVE_CODE -eq 0 ]; then
   echo "$BRAVE_PATH"
   exit 0

--- a/cypress/scripts/linux-brave-version.sh
+++ b/cypress/scripts/linux-brave-version.sh
@@ -1,5 +1,6 @@
 #!/usr/bin/env bash
 
+# TODO - replace `which` with `/usr/bin/which` and test on Linux
 BRAVE_PATH=$(which brave-browser)
 BRAVE_CODE=$?
 


### PR DESCRIPTION
## Description

- Address Cypress feedback from @rbeer and fix Cypress Brave support on Linux.
- Handle bad paths / no Brave installed more gracefully

## Notice

Before submitting a pull request, please make sure you have answered the following:

- [x] Have you followed the guidelines in our [Contributing]('https://github.com/shapeshift/web/CONTRIBUTING.md) guide?
- [x] Have you checked to ensure there aren't other open [Pull Requests](https://github.com/shapeshift/web/pulls) for the same update/change?

## Pull Request Type

- [x] :bug: Bug fix (Non-breaking Change: Fixes an issue)
- [ ] :hammer_and_wrench: Chore (Non-breaking Change: Doc updates, pkg upgrades, typos, etc..)
- [ ] :nail_care: New Feature (Breaking/Non-breaking Change)

## Issue (if applicable)

A follow-on from https://github.com/shapeshift/web/pull/849

## Testing

Run using GUI: `yarn test:cypress`

## Screenshots (if applicable)
