### PR TITLE
fix: improve Brave Linux path

### DIFF
--- a/cypress/scripts/linux-brave-version.sh
+++ b/cypress/scripts/linux-brave-version.sh
@@ -1,7 +1,7 @@
 #!/usr/bin/env bash
 
 # TODO - replace `which` with `/usr/bin/which` and test on Linux
-BRAVE_PATH=$(which brave-browser)
+BRAVE_PATH=$(/usr/bin/which brave-browser)
 BRAVE_CODE=$?
 
 if [ $BRAVE_CODE -eq 0 ]; then


### PR DESCRIPTION
## Description

As suggested by @gomesalexandre in https://github.com/shapeshift/web/pull/954#discussion_r800595317:

`/usr/bin/which` might be a safer way to use `which`, since `which` is often aliased by some linux systems with a few additional flags like `--show-dot` or `--show-tilde`.
## Notice

Before submitting a pull request, please make sure you have answered the following:

- [x] Have you followed the guidelines in our [Contributing]('https://github.com/shapeshift/web/CONTRIBUTING.md) guide?
- [x] Have you checked to ensure there aren't other open [Pull Requests](https://github.com/shapeshift/web/pulls) for the same update/change?

## Pull Request Type

- [ ] :bug: Bug fix (Non-breaking Change: Fixes an issue)
- [ ] :hammer_and_wrench: Chore (Non-breaking Change: Doc updates, pkg upgrades, typos, etc..)
- [ ] :nail_care: New Feature (Breaking/Non-breaking Change)

## Issue (if applicable)

N/A

## Testing

Please outline all testing steps

Run using GUI: `yarn test:cypress`
