### PR TITLE
fix: overlapping input number fixed by relative position

### DIFF
--- a/src/features/defi/components/Deposit/Deposit.tsx
+++ b/src/features/defi/components/Deposit/Deposit.tsx
@@ -73,6 +73,7 @@ const CryptoInput = (props: InputProps) => (
     type='number'
     border={0}
     borderBottomRadius={0}
+    borderTopLeftRadius={0}
     placeholder='Enter amount'
     {...props}
   />

--- a/src/features/defi/components/Deposit/Deposit.tsx
+++ b/src/features/defi/components/Deposit/Deposit.tsx
@@ -67,7 +67,8 @@ type DepositProps = {
 const CryptoInput = (props: InputProps) => (
   <Input
     pr='4.5rem'
-    pl='7.5rem'
+    pl='1rem'
+    ml='1rem'
     size='lg'
     type='number'
     border={0}
@@ -256,7 +257,7 @@ export const Deposit = ({
               spacing={0}
             >
               <InputGroup size='lg'>
-                <InputLeftElement ml={1} width='auto'>
+                <InputLeftElement pos='relative' ml={1} width='auto'>
                   <Button
                     ml={1}
                     size='sm'

--- a/src/features/defi/components/Withdraw/Withdraw.tsx
+++ b/src/features/defi/components/Withdraw/Withdraw.tsx
@@ -69,6 +69,7 @@ const CryptoInput = (props: InputProps) => (
     type='number'
     border={0}
     borderBottomRadius={0}
+    borderTopLeftRadius={0}
     placeholder='Enter amount'
     {...props}
   />

--- a/src/features/defi/components/Withdraw/Withdraw.tsx
+++ b/src/features/defi/components/Withdraw/Withdraw.tsx
@@ -63,7 +63,8 @@ type WithdrawProps = {
 const CryptoInput = (props: InputProps) => (
   <Input
     pr='4.5rem'
-    pl='7.5rem'
+    pl='1rem'
+    ml='1rem'
     size='lg'
     type='number'
     border={0}
@@ -244,7 +245,7 @@ export const Withdraw = ({
               spacing={0}
             >
               <InputGroup size='lg'>
-                <InputLeftElement ml={1} width='auto'>
+                <InputLeftElement pos='relative' ml={1} width='auto'>
                   <Button
                     ml={1}
                     size='sm'


### PR DESCRIPTION
## Description

By default the Chakra-UI `InputLeftElement` in `InputGroup` has the `position: absolute` property set, I changed the position to relative, this way, the cryptoInput will maintain a relative position to it, not having its value overlapping the asset button.

## Notice

- [x] Have you followed the guidelines in our [Contributing]('https://github.com/shapeshift/web/CONTRIBUTING.md) guide?
- [x] Have you checked to ensure there aren't other open [Pull Requests](https://github.com/shapeshift/web/pulls) for the same update/change?

## Pull Request Type

- [x] :bug: Bug fix (Non-breaking Change: Fixes an issue)

## Issue (if applicable)

closes issue https://github.com/shapeshift/web/issues/938

## Testing

Please outline all testing steps

1. Connect your wallet and arrive on the dashboard
2. Click on the DeFi tab, top center of the page
3. Click the get started button on any vault
4. Click deposit or withdraw
5. Type in a value or click a percentage of allotted asset
6. Numerical value isn't overlapping the name of the asset

## Screenshots (if applicable)
![image](https://user-images.githubusercontent.com/60587527/153074121-657eba63-0c0d-41fb-b044-9911af421162.png)
