### PR TITLE
fix: redirect user to accounts page if changed wallet while on an account

### DIFF
--- a/src/pages/Accounts/AccountToken.tsx
+++ b/src/pages/Accounts/AccountToken.tsx
@@ -1,10 +1,11 @@
 import { Flex } from '@chakra-ui/react'
 import { CAIP19 } from '@shapeshiftoss/caip'
-import { useParams } from 'react-router-dom'
+import { useSelector } from 'react-redux'
+import { Redirect, useParams } from 'react-router-dom'
 import { AssetAccountDetails } from 'components/AssetAccountDetails'
 import { Page } from 'components/Layout/Page'
 import { AccountSpecifier } from 'state/slices/portfolioSlice/portfolioSlice'
-
+import { selectPortfolioAccountIdsSortedFiat } from 'state/slices/portfolioSlice/selectors'
 export type MatchParams = {
   accountId: AccountSpecifier
   assetId: CAIP19
@@ -12,10 +13,20 @@ export type MatchParams = {
 
 export const AccountToken = () => {
   const { accountId, assetId } = useParams<MatchParams>()
+
+  /**
+   * if the user switches the wallet while visiting this page,
+   * the accountId is no longer valid for the app,
+   * so we'll redirect user to the "accounts" page,
+   * in order to choose the account from beginning.
+   */
+  const sortedAccountIds = useSelector(selectPortfolioAccountIdsSortedFiat)
+  if (!sortedAccountIds.includes(accountId)) return <Redirect to='/accounts' />
+
   const caip19 = assetId ? decodeURIComponent(assetId) : null
   if (!caip19) return null
   return (
-    <Page style={{ flex: 1 }} key={assetId}>
+    <Page style={{ flex: 1 }} key={accountId}>
       <Flex role='main' flex={1} height='100%'>
         <AssetAccountDetails assetId={caip19} accountId={accountId} />
       </Flex>


### PR DESCRIPTION
## Description

Redirecting users to the `accounts` page if they switched the connect wallet while visiting an account page (`/accounts/:accountId/:assetId?`), since these pages are related to the connected wallet there will be the necessity to select another account of the connected wallet.

## Notice

Before submitting a pull request, please make sure you have answered the following:

- [ x] Have you followed the guidelines in our [Contributing]('https://github.com/shapeshift/web/CONTRIBUTING.md) guide?
- [ x] Have you checked to ensure there aren't other open [Pull Requests](https://github.com/shapeshift/web/pulls) for the same update/change?

## Pull Request Type

- [ x] :bug: Bug fix (Non-breaking Change: Fixes an issue)
- [ ] :hammer_and_wrench: Chore (Non-breaking Change: Doc updates, pkg upgrades, typos, etc..)
- [ ] :nail_care: New Feature (Breaking/Non-breaking Change)

## Issue (if applicable)

closes #978 

## Testing

Please outline all testing steps

1. Pull branch locally and run `yarn` to install new deps
2. Connect to a wallet and go to the accounts page
3. Click on an account
4. Switch connected wallet
5. You should be redirected to the accounts page

## Screenshots (if applicable)
