### PR TITLE
feat: <AprTag />

### DIFF
--- a/src/components/Delegate/StakingOpportunitiesRow.tsx
+++ b/src/components/Delegate/StakingOpportunitiesRow.tsx
@@ -1,6 +1,6 @@
 import { Flex, HStack } from '@chakra-ui/layout'
 import { Button, Skeleton, SkeletonCircle } from '@chakra-ui/react'
-import { Tag } from '@chakra-ui/tag'
+import { AprTag } from 'features/defi/components/AprTag/AprTag'
 import { useHistory, useLocation } from 'react-router-dom'
 import { Amount } from 'components/Amount/Amount'
 import { AssetIcon } from 'components/AssetIcon'
@@ -42,9 +42,7 @@ export const StakingOpportunitiesRow = ({ name }: { name: string }) => {
           <RawText size='lg' fontWeight='bold'>{`${name}`}</RawText>
         </Skeleton>
         <Skeleton isLoaded={isLoaded} ml={4}>
-          <Tag colorScheme='green'>
-            <Amount.Percent value={'1.24'} />
-          </Tag>
+          <AprTag percentage='1.25' />
         </Skeleton>
       </Flex>
       <Flex>

--- a/src/features/defi/components/AprTag/AprTag.tsx
+++ b/src/features/defi/components/AprTag/AprTag.tsx
@@ -5,7 +5,7 @@ type AprTagProps = {
   percentage: string
 }
 
-export const AprTag = ({ percentage }: AprTagProps) => (
+export const AprTag: React.FC<AprTagProps> = ({ percentage }) => (
   <Tag colorScheme='green'>
     <Amount.Percent value={percentage} />
   </Tag>

--- a/src/features/defi/components/AprTag/AprTag.tsx
+++ b/src/features/defi/components/AprTag/AprTag.tsx
@@ -1,0 +1,12 @@
+import { Tag } from '@chakra-ui/tag'
+import { Amount } from 'components/Amount/Amount'
+
+type AprTagProps = {
+  percentage: string
+}
+
+export const AprTag = ({ percentage }: AprTagProps) => (
+  <Tag colorScheme='green'>
+    <Amount.Percent value={percentage} />
+  </Tag>
+)


### PR DESCRIPTION
## Description

This abstracts the APR tag into its own component, since it's going to be needed for many other views

- add `<AprTag />` component
- consume it in `<StakingOpportunitiesRow />`

## Notice

Before submitting a pull request, please make sure you have answered the following:

- [x] Have you followed the guidelines in our [Contributing]('https://github.com/shapeshift/web/CONTRIBUTING.md) guide?
- [x] Have you checked to ensure there aren't other open [Pull Requests](https://github.com/shapeshift/web/pulls) for the same update/change?

## Pull Request Type

- [ ] :bug: Bug fix (Non-breaking Change: Fixes an issue)
- [ ] :hammer_and_wrench: Chore (Non-breaking Change: Doc updates, pkg upgrades, typos, etc..)
- [x] :nail_care: New Feature (Breaking/Non-breaking Change)

## Issue (if applicable)

If applicable, please link to the github issue and put `closes #XXXX` in your comment to auto-close the issue that your PR fixes.

## Testing

Please outline all testing steps

1. Add `ChainTypes.Ethereum` to`useRenderForChains` in `<StakingOpportunities />`
2. Enable `REACT_APP_FEATURE_COSMOS_INVESTOR` feature flag
3. Go to Ethereum, and on Cosmos Validator opportunity, APR tag should still be visible

## Screenshots (if applicable)

![image](https://user-images.githubusercontent.com/17035424/153559343-c478da22-90cd-4e39-89e6-b8c3f3cd294d.png)