### PR TITLE
feat: add programmatic login when testing with cypress

### DIFF
--- a/cypress/support/commands.ts
+++ b/cypress/support/commands.ts
@@ -72,7 +72,7 @@ Cypress.Commands.add('login', () => {
   // We do, however, need to clear indexedDB during login to clear any saved wallet data
   cy.clearIndexedDB().then(() => {
     cy.addWallet(wallet).then(() => {
-      cy.visit(``)
+      cy.visit('')
       cy.url({ timeout: 8000 }).should('equal', `${baseUrl}dashboard`)
     })
   })

--- a/cypress/support/commands.ts
+++ b/cypress/support/commands.ts
@@ -57,8 +57,8 @@ Cypress.Commands.add(
     // Some tests currently require NativeWallet to be set in the IndexDB (e.g. login_spec.ts)
     await walletDb.setItem(wallet.key, wallet.value)
     // For programmatic login, we need to pass some parameters to the `connect-wallet` page.
-    localStorage.setItem('walletSeedCypress', seed)
-    localStorage.setItem('walletPasswordCypress', password)
+    localStorage.setItem('cypressWalletSeed', seed)
+    localStorage.setItem('cypressWalletPassword', password)
   }
 )
 

--- a/cypress/support/commands.ts
+++ b/cypress/support/commands.ts
@@ -56,7 +56,7 @@ Cypress.Commands.add(
     await walletDb.setItem(wallet.key, wallet.value)
     // For programmatic login, we need to pass some parameters to the `connect-wallet` page.
     localStorage.setItem('walletIdCypress', wallet.key)
-    localStorage.setItem('walletPwdCypress', password)
+    localStorage.setItem('walletPasswordCypress', password)
   }
 )
 

--- a/cypress/support/commands.ts
+++ b/cypress/support/commands.ts
@@ -12,6 +12,7 @@ import { makeChartDataResponse } from '../factories/coingecko/chartData'
 
 const baseUrl = Cypress.config().baseUrl
 const password = Cypress.env('testPassword')
+const seed = Cypress.env('testSeed')
 const publicKey = Cypress.env('testPublicKey')
 const ethereumApi = Cypress.env('REACT_APP_UNCHAINED_ETHEREUM_HTTP_URL')
 const bitcoinApi = Cypress.env('REACT_APP_UNCHAINED_BITCOIN_HTTP_URL')
@@ -53,9 +54,10 @@ Cypress.Commands.add(
   'addWallet',
   // @ts-ignore
   async (wallet: { key: string; value: Object<string, unknown> }) => {
+    // Some tests currently require NativeWallet to be set in the IndexDB (e.g. login_spec.ts)
     await walletDb.setItem(wallet.key, wallet.value)
     // For programmatic login, we need to pass some parameters to the `connect-wallet` page.
-    localStorage.setItem('walletIdCypress', wallet.key)
+    localStorage.setItem('walletSeedCypress', seed)
     localStorage.setItem('walletPasswordCypress', password)
   }
 )

--- a/cypress/support/commands.ts
+++ b/cypress/support/commands.ts
@@ -55,8 +55,8 @@ Cypress.Commands.add(
   async (wallet: { key: string; value: Object<string, unknown> }) => {
     await walletDb.setItem(wallet.key, wallet.value)
     // For programmatic login, we need to pass some parameters to the `connect-wallet` page.
-    localStorage.setItem("walletId-cypress", wallet.key)
-    localStorage.setItem("walletPwd-cypress", password)
+    localStorage.setItem('walletIdCypress', wallet.key)
+    localStorage.setItem('walletPwdCypress', password)
   }
 )
 
@@ -65,7 +65,6 @@ Cypress.Commands.add('clearIndexedDB', async () => {
   await walletDb.clear()
 })
 
-// TODO - Replace with programmatic login
 // @ts-ignore
 Cypress.Commands.add('login', () => {
   // Cypress already automatically clears localStorage, cookies, sessions, etc. before each test

--- a/cypress/support/commands.ts
+++ b/cypress/support/commands.ts
@@ -54,6 +54,9 @@ Cypress.Commands.add(
   // @ts-ignore
   async (wallet: { key: string; value: Object<string, unknown> }) => {
     await walletDb.setItem(wallet.key, wallet.value)
+    // For programmatic login, we need to pass some parameters to the `connect-wallet` page.
+    localStorage.setItem("walletId-cypress", wallet.key)
+    localStorage.setItem("walletPwd-cypress", password)
   }
 )
 
@@ -69,13 +72,7 @@ Cypress.Commands.add('login', () => {
   // We do, however, need to clear indexedDB during login to clear any saved wallet data
   cy.clearIndexedDB().then(() => {
     cy.addWallet(wallet).then(() => {
-      cy.visit('')
-      cy.getBySel('connect-wallet-button').click()
-      cy.getBySel('wallet-native-button').click()
-      cy.getBySel('wallet-native-load-button').click()
-      cy.getBySel('native-saved-wallet-button').click()
-      cy.getBySel('wallet-password-input').type(password)
-      cy.getBySel('wallet-password-submit-button').click()
+      cy.visit(``)
       cy.url({ timeout: 8000 }).should('equal', `${baseUrl}dashboard`)
     })
   })

--- a/src/Routes/Routes.tsx
+++ b/src/Routes/Routes.tsx
@@ -138,7 +138,7 @@ export const Routes = () => {
         )
       })}
       <Route path='/connect-wallet'>
-        <ConnectWallet dispatch={dispatch} hasWallet={hasWallet} />
+        <ConnectWallet dispatch={dispatch} state={state} />
       </Route>
       <Redirect from='/' to='/dashboard' />
       <Route component={NotFound} />

--- a/src/pages/ConnectWallet/ConnectWallet.tsx
+++ b/src/pages/ConnectWallet/ConnectWallet.tsx
@@ -38,7 +38,6 @@ async function connectCypressWallet(
   vault.seal()
   await vault.setPassword(walletPassword)
   vault.meta.set('name', 'CypressWallet')
-  await new Promise(resolve => setTimeout(resolve, 250))
   await Promise.all([navigator.storage?.persist?.(), vault.save()])
   // Load wallet
   const deviceId = vault.id
@@ -63,8 +62,8 @@ async function connectCypressWallet(
 
 export const ConnectWallet = ({ state, dispatch }: WalletProps) => {
   const isCypressTest =
-    localStorage.hasOwnProperty('walletSeedCypress') &&
-    localStorage.hasOwnProperty('walletPasswordCypress')
+    localStorage.hasOwnProperty('cypressWalletSeed') &&
+    localStorage.hasOwnProperty('cypressWalletPassword')
   const hasWallet = Boolean(state.walletInfo?.deviceId)
   const history = useHistory()
   const translate = useTranslate()
@@ -74,8 +73,8 @@ export const ConnectWallet = ({ state, dispatch }: WalletProps) => {
     // Programmatic login for Cypress tests
     // The first `!state.isConnected` filters any re-render if the wallet is already connected.
     if (isCypressTest && !state.isConnected) {
-      const walletSeed = localStorage.getItem('walletSeedCypress') || ''
-      const walletPassword = localStorage.getItem('walletPasswordCypress') || ''
+      const walletSeed = localStorage.getItem('cypressWalletSeed') || ''
+      const walletPassword = localStorage.getItem('cypressWalletPassword') || ''
       connectCypressWallet(state.keyring, dispatch, walletSeed, walletPassword)
         .then(() => {
           // The second `!state.isConnected` filters any intent to redirect if the redirecting had already happened.

--- a/src/pages/ConnectWallet/ConnectWallet.tsx
+++ b/src/pages/ConnectWallet/ConnectWallet.tsx
@@ -29,7 +29,7 @@ async function connectCypressWallet(
   keyring: Keyring,
   dispatch: Dispatch<ActionTypes>,
   walletId: string,
-  walletPwd: string
+  walletPassword: string
 ) {
   const adapter = SUPPORTED_WALLETS[KeyManager.Native].adapter.useKeyring(keyring)
   if (adapter) {
@@ -45,7 +45,7 @@ async function connectCypressWallet(
     }
 
     const wallet = keyring.get<NativeHDWallet>(deviceId)
-    const vault = await Vault.open(deviceId, decodeURIComponent(walletPwd))
+    const vault = await Vault.open(deviceId, decodeURIComponent(walletPassword))
     const mnemonic = (await vault.get('#mnemonic')) as native.crypto.Isolation.Core.BIP39.Mnemonic
     mnemonic.addRevoker?.(() => vault.revoke())
     await wallet?.loadDevice({
@@ -70,7 +70,7 @@ async function connectCypressWallet(
 export const ConnectWallet = ({ state, dispatch }: WalletProps) => {
   const isCypressTest =
     localStorage.hasOwnProperty('walletIdCypress') &&
-    localStorage.hasOwnProperty('walletPwdCypress')
+    localStorage.hasOwnProperty('walletPasswordCypress')
   const hasWallet = Boolean(state.walletInfo?.deviceId)
   const history = useHistory()
   const translate = useTranslate()
@@ -80,8 +80,8 @@ export const ConnectWallet = ({ state, dispatch }: WalletProps) => {
     // Programmatic login for Cypress tests
     if (isCypressTest) {
       const walletId = localStorage.getItem('walletIdCypress') || ''
-      const walletPwd = localStorage.getItem('walletPwdCypress') || ''
-      connectCypressWallet(state.keyring, dispatch, walletId, walletPwd)
+      const walletPassword = localStorage.getItem('walletPasswordCypress') || ''
+      connectCypressWallet(state.keyring, dispatch, walletId, walletPassword)
         .then(() => {
           history.push(query?.returnUrl ? query.returnUrl : '/dashboard')
         })

--- a/src/pages/ConnectWallet/ConnectWallet.tsx
+++ b/src/pages/ConnectWallet/ConnectWallet.tsx
@@ -2,6 +2,9 @@ import { Button } from '@chakra-ui/button'
 import { DarkMode } from '@chakra-ui/color-mode'
 import { ArrowForwardIcon } from '@chakra-ui/icons'
 import { Badge, Center, Circle, Flex } from '@chakra-ui/layout'
+import * as native from '@shapeshiftoss/hdwallet-native'
+import { NativeHDWallet } from '@shapeshiftoss/hdwallet-native'
+import { Vault } from '@shapeshiftoss/hdwallet-native-vault'
 import { Dispatch, useEffect } from 'react'
 import { isFirefox } from 'react-device-detect'
 import { useTranslate } from 'react-polyglot'
@@ -11,22 +14,79 @@ import OrbsStatic from 'assets/orbs-static.png'
 import { FoxIcon } from 'components/Icons/FoxIcon'
 import { Page } from 'components/Layout/Page'
 import { RawText, Text } from 'components/Text'
-import { ActionTypes, WalletActions } from 'context/WalletProvider/WalletProvider'
+import { ActionTypes, InitialState, WalletActions } from 'context/WalletProvider/WalletProvider'
 import { useQuery } from 'hooks/useQuery/useQuery'
 import { colors } from 'theme/colors'
 
-type NoWalletProps = {
+import { KeyManager, SUPPORTED_WALLETS } from '../../context/WalletProvider/config'
+
+type WalletProps = {
+  state: InitialState
   dispatch: Dispatch<ActionTypes>
-  hasWallet: boolean
 }
 
-export const ConnectWallet = ({ dispatch, hasWallet }: NoWalletProps) => {
+export const ConnectWallet = ({ state, dispatch }: WalletProps) => {
+  const hasWallet = Boolean(state.walletInfo?.deviceId)
   const history = useHistory()
   const translate = useTranslate()
   const query = useQuery<{ returnUrl: string }>()
   useEffect(() => {
     hasWallet && history.push(query?.returnUrl ? query.returnUrl : '/dashboard')
-  }, [history, hasWallet, query.returnUrl])
+    if (
+      !(
+        localStorage.hasOwnProperty('walletId-cypress') &&
+        localStorage.hasOwnProperty('walletPwd-cypress')
+      )
+    ) {
+      return
+    }
+    const walletId = localStorage.getItem('walletId-cypress') || ''
+    const walletPwd = localStorage.getItem('walletPwd-cypress') || ''
+    ;(async () => {
+      // Here goes the programmatic login in case we are testing
+      try {
+        const adapter = SUPPORTED_WALLETS[KeyManager.Native].adapter.useKeyring(state.keyring)
+        if (adapter) {
+          const wallet = await adapter.pairDevice(walletId)
+          await wallet.initialize()
+        }
+
+        const vaultIds = await Vault.list()
+        for (let index = 0; index < vaultIds.length; index++) {
+          const deviceId = vaultIds[index]
+          if (deviceId !== walletId) {
+            continue
+          }
+
+          const wallet = state.keyring.get<NativeHDWallet>(deviceId)
+          const vault = await Vault.open(deviceId, decodeURIComponent(walletPwd))
+          const mnemonic = (await vault.get(
+            '#mnemonic'
+          )) as native.crypto.Isolation.Core.BIP39.Mnemonic
+          mnemonic.addRevoker?.(() => vault.revoke())
+          await wallet?.loadDevice({
+            mnemonic,
+            deviceId
+          })
+          const { name, icon } = SUPPORTED_WALLETS[KeyManager.Native]
+          dispatch({
+            type: WalletActions.SET_WALLET,
+            payload: {
+              wallet,
+              name,
+              icon,
+              deviceId,
+              meta: { label: vault.meta.get('name') as string }
+            }
+          })
+          dispatch({ type: WalletActions.SET_IS_CONNECTED, payload: true })
+          history.push(query?.returnUrl ? query.returnUrl : '/dashboard')
+        }
+      } catch (e) {
+        console.error('WalletProvider:NativeWallet:Load - Cannot get vault', e)
+      }
+    })()
+  }, [history, hasWallet, query, state, dispatch])
   return (
     <Page>
       <Flex

--- a/src/pages/ConnectWallet/ConnectWallet.tsx
+++ b/src/pages/ConnectWallet/ConnectWallet.tsx
@@ -79,16 +79,13 @@ export const ConnectWallet = ({ state, dispatch }: WalletProps) => {
     hasWallet && history.push(query?.returnUrl ? query.returnUrl : '/dashboard')
     // Programmatic login for Cypress tests
     if (isCypressTest) {
-      try {
-        const walletId = localStorage.getItem('walletIdCypress') || ''
-        const walletPwd = localStorage.getItem('walletPwdCypress') || ''
-        // @ts-ignore
-        connectCypressWallet(state.keyring, dispatch, walletId, walletPwd).then(payload => {
+      const walletId = localStorage.getItem('walletIdCypress') || ''
+      const walletPwd = localStorage.getItem('walletPwdCypress') || ''
+      connectCypressWallet(state.keyring, dispatch, walletId, walletPwd)
+        .then(() => {
           history.push(query?.returnUrl ? query.returnUrl : '/dashboard')
         })
-      } catch (e) {
-        console.error(e)
-      }
+        .catch(e => console.error(e))
     }
   }, [history, hasWallet, query, state, dispatch, isCypressTest])
   return (


### PR DESCRIPTION
## Description

This PR adds programmatic login when testing with cypress.

Specifically, this PR set `walletId-cypress` and `walletPwd-cypress` in `localstorage` when testing. When `ConnectWallet.tsx` detects the above-mentioned fields during runtime, it will try to automatically connect the specified wallet by:
1. setting up the adapter.
2. initializing wallet.
3. find and open the vault.
4. decrypt the wallet.
5. set wallet by `dispatch()`
6. redirect to dashboard.

## Note
The `Password` modal will pop out due to the `MNEMONIC_REQUIRED` native event sent by `wallet.initialize()`. We can just ignore it as the wallet will be set programmatically.

## Notice

- [x] Have you followed the guidelines in our [Contributing]('https://github.com/shapeshift/web/CONTRIBUTING.md) guide?
- [x] Have you checked to ensure there aren't other open [Pull Requests](https://github.com/shapeshift/web/pulls) for the same update/change?

## Pull Request Type

- [ ] :bug: Bug fix (Non-breaking Change: Fixes an issue)
- [ ] :hammer_and_wrench: Chore (Non-breaking Change: Doc updates, pkg upgrades, typos, etc..)
- [x] :nail_care: New Feature (Breaking/Non-breaking Change)

## Issue (if applicable)

#948 

## Risk

The added logic in `ConnectWallet.tsx` will only be triggered during testing (i.e. `walletId-cypress` and `walletPwd-cypress` are appeared in `localstorage`) so there should be no risk for production.

## Testing

Cypress test is ran and its `login` command is successful.