### PR TITLE
feat: lint cypress folder

### DIFF
--- a/package.json
+++ b/package.json
@@ -93,7 +93,7 @@
     "dev": "NODE_OPTIONS=--max-old-space-size=4096 ESLINT_NO_DEV_ERRORS=true TSC_COMPILE_ON_ERROR=true IMAGE_INLINE_SIZE_LIMIT=0 INLINE_RUNTIME_CHUNK=false react-app-rewired start",
     "dev:silent": "NODE_OPTIONS=--max-old-space-size=4096 ESLINT_NO_DEV_ERRORS=true TSC_COMPILE_ON_ERROR=true IMAGE_INLINE_SIZE_LIMIT=0 INLINE_RUNTIME_CHUNK=false BROWSER=none react-app-rewired start",
     "local-ci": "yarn lint && yarn type-check && yarn test && yarn build",
-    "lint": "eslint -c .eslintrc src --ext .ts,.tsx",
+    "lint": "eslint -c .eslintrc src cypress --ext .ts,.tsx",
     "lint:cypress": "eslint -c ./cypress/.eslintrc src --ext .ts,.tsx",
     "lint:fix": "yarn lint --fix",
     "lint:cypress:fix": "yarn lint:cypress --fix",


### PR DESCRIPTION
## Description

- add linting of cypress folder on `lint` script

## Notes

There's already a `lint:cypress` script but it doesn't run on CI, which would potentially make contributors commit changes in this folder containing lint violations.
@0xApotheosis since there is a lint script specifically for cypress, does it make more sense to move it to CI? If so, I suggest extending from our base lint rules.

## Notice

Before submitting a pull request, please make sure you have answered the following:

- [x] Have you followed the guidelines in our [Contributing]('https://github.com/shapeshift/web/CONTRIBUTING.md) guide?
- [x] Have you checked to ensure there aren't other open [Pull Requests](https://github.com/shapeshift/web/pulls) for the same update/change?

## Pull Request Type

- [ ] :bug: Bug fix (Non-breaking Change: Fixes an issue)
- [ ] :hammer_and_wrench: Chore (Non-breaking Change: Doc updates, pkg upgrades, typos, etc..)
- [x] :nail_care: New Feature (Breaking/Non-breaking Change)

## Issue (if applicable)

## Risk

## Testing

- make any modification to a file in /cypress that will make your editor not happy (since you might have autofix on, you might have to fire a vim/nano for that or disable it temporarily)
- `yarn lint` should produce errors

## Screenshots (if applicable)