### PR TITLE
chore: change /assets routing to use CAIP19

### DIFF
--- a/src/Routes/Routes.tsx
+++ b/src/Routes/Routes.tsx
@@ -40,7 +40,7 @@ export const routes: Array<NestedRoute> = [
     icon: <AssetsIcon color='inherit' />,
     routes: [
       {
-        path: '/:chain/:tokenId?',
+        path: '/:assetId',
         label: 'Asset Details',
         main: <Asset />,
         leftSidebar: <AssetSidebar />,
@@ -108,13 +108,7 @@ export const routes: Array<NestedRoute> = [
         disable: true
       }
     ]
-  } /* ,
-  {
-    path: '/trade-history',
-    label: 'navBar.tradeHistory',
-    icon: <TimeIcon />,
-    main: <TradeHistory />
-  } */
+  }
 ]
 
 function useLocationBackground() {

--- a/src/components/AssetHeader/AssetHeader.tsx
+++ b/src/components/AssetHeader/AssetHeader.tsx
@@ -63,7 +63,7 @@ export const AssetHeader: React.FC<AssetHeaderProps> = ({ assetId, accountId }) 
   const [view, setView] = useState(accountId ? View.Balance : View.Price)
   const [isLargerThanMd] = useMediaQuery(`(min-width: ${breakpoints['md']})`)
   const asset = useAppSelector(state => selectAssetByCAIP19(state, assetId))
-  const chainId = asset.caip2
+  const chainId = asset?.caip2
   const marketData = useAppSelector(state => selectMarketDataById(state, assetId))
   const accountIds = useAppSelector(state => selectAccountIdsByAssetId(state, assetId))
   const singleAccount = accountIds && accountIds.length === 1 ? accountIds[0] : undefined

--- a/src/pages/Assets/Asset.tsx
+++ b/src/pages/Assets/Asset.tsx
@@ -1,13 +1,5 @@
 import { Flex } from '@chakra-ui/react'
-import { caip19 } from '@shapeshiftoss/caip'
-import {
-  Asset as A,
-  AssetDataSource,
-  ChainTypes,
-  ContractTypes,
-  MarketData,
-  NetworkTypes
-} from '@shapeshiftoss/types'
+import type { CAIP19 } from '@shapeshiftoss/caip'
 import { useParams } from 'react-router-dom'
 import { AssetAccountDetails } from 'components/AssetAccountDetails'
 import { Page } from 'components/Layout/Page'
@@ -21,60 +13,27 @@ import { useAppDispatch, useAppSelector } from 'state/store'
 
 import { LoadingAsset } from './LoadingAsset'
 export interface MatchParams {
-  chain: ChainTypes
-  tokenId: string
-}
-
-// TODO(0xdef1cafe): this has to die, we can't return invalid assets
-export const initAsset: A = {
-  caip2: '',
-  caip19: '',
-  chain: ChainTypes.Ethereum,
-  network: NetworkTypes.MAINNET,
-  symbol: '',
-  name: '',
-  precision: 18,
-  color: '',
-  secondaryColor: '',
-  icon: '',
-  sendSupport: true,
-  receiveSupport: true,
-  slip44: 60,
-  explorer: 'https://etherscan.io',
-  explorerTxLink: 'https://etherscan.io/tx/',
-  explorerAddressLink: '',
-  dataSource: AssetDataSource.CoinGecko,
-  description: ''
-}
-
-export const initMarketData: MarketData = {
-  price: '',
-  marketCap: '',
-  volume: '',
-  changePercent24Hr: 0
+  assetId: CAIP19
 }
 
 export const useAsset = () => {
   const dispatch = useAppDispatch()
 
-  const { chain, tokenId } = useParams<MatchParams>()
-  const network = NetworkTypes.MAINNET
-  const contractType = ContractTypes.ERC20
-  const extra = tokenId ? { contractType, tokenId } : undefined
-  const assetCAIP19 = caip19.toCAIP19({ chain, network, ...extra })
-  const asset = useAppSelector(state => selectAssetByCAIP19(state, assetCAIP19))
-  const marketData = useAppSelector(state => selectMarketDataById(state, assetCAIP19))
+  const params = useParams<MatchParams>()
+  const assetId = decodeURIComponent(params.assetId)
+  const asset = useAppSelector(state => selectAssetByCAIP19(state, assetId))
+  const marketData = useAppSelector(state => selectMarketDataById(state, assetId))
 
   // Many, but not all, assets are initialized with market data on app load. This dispatch will
   // ensure that those assets not initialized on app load will reach over the network and populate
   // the store with market data once a user visits that asset page.
-  if (!marketData) dispatch(marketApi.endpoints.findByCaip19.initiate(assetCAIP19))
+  if (!marketData) dispatch(marketApi.endpoints.findByCaip19.initiate(assetId))
 
-  const loading = useAppSelector(state => selectMarketDataLoadingById(state, assetCAIP19))
+  const loading = useAppSelector(state => selectMarketDataLoadingById(state, assetId))
 
   return {
-    asset: asset ?? initAsset,
-    marketData: marketData ?? initMarketData,
+    asset,
+    marketData,
     loading
   }
 }
@@ -82,7 +41,7 @@ export const useAsset = () => {
 export const Asset = () => {
   const { asset, marketData } = useAsset()
 
-  return !marketData ? (
+  return !(asset && marketData) ? (
     <Page style={{ flex: 1 }} key={asset?.tokenId}>
       <Flex role='main' flex={1} height='100%'>
         <LoadingAsset />

--- a/src/pages/Assets/AssetSidebar.tsx
+++ b/src/pages/Assets/AssetSidebar.tsx
@@ -6,7 +6,8 @@ import { LeftSidebarChildProps } from 'components/Layout/LeftSidebar'
 export const AssetSidebar = ({ onToggle }: LeftSidebarChildProps) => {
   const history = useHistory()
   const onClick = (asset: Asset) => {
-    const url = asset.tokenId ? `/assets/${asset.chain}/${asset.tokenId}` : `/assets/${asset.chain}`
+    // @see onClick handler in `src/pages/Assets/Assets.tsx` - this needs to work the same
+    const url = `/assets/${encodeURIComponent(asset.caip19)}`
     history.push(url)
     onToggle && onToggle()
   }

--- a/src/pages/Assets/Assets.tsx
+++ b/src/pages/Assets/Assets.tsx
@@ -7,7 +7,7 @@ import { Page } from 'components/Layout/Page'
 export const Assets = () => {
   const history = useHistory()
   const onClick = (asset: Asset) => {
-    const url = asset.tokenId ? `/assets/${asset.chain}/${asset.tokenId}` : `/assets/${asset.chain}`
+    const url = `/assets/${encodeURIComponent(asset.caip19)}`
     history.push(url)
   }
   return (


### PR DESCRIPTION
## Description

Current behavior is to take a chain name and tokenId then call "toCAIP19" with those.

We already KNOW the CAIP19 from the asset so we can just pass that straight through
and we can avoid conditional routing.

## Notice

Before submitting a pull request, please make sure you have answered the following:

- [X] Have you followed the guidelines in our [Contributing]('https://github.com/shapeshift/web/CONTRIBUTING.md) guide?
- [X] Have you checked to ensure there aren't other open [Pull Requests](https://github.com/shapeshift/web/pulls) for the same update/change?

## Pull Request Type

- [ ] :bug: Bug fix (Non-breaking Change: Fixes an issue)
- [X] :hammer_and_wrench: Chore (Non-breaking Change: Doc updates, pkg upgrades, typos, etc..)
- [ ] :nail_care: New Feature (Breaking/Non-breaking Change)

## Issue (if applicable)

there's no open issue for this.

## Risk

This could break the ability to view an asset detail page. Any place where we navigate to `/assets` is affected.

## Testing

1. Click Assets in the NavBar
2. Click on an Asset
3. on the Asset Details page, click on a different asset in the search bar on the left

## Screenshots (if applicable)
### Before
![image](https://user-images.githubusercontent.com/1958266/154159851-340acf12-c1e8-4543-a7c3-f89f14742541.png)

### After
![image](https://user-images.githubusercontent.com/1958266/154159711-3a66af38-93a7-4150-a862-c2436b57eeeb.png)
