### PR TITLE
feat: add transaction link to toast

### DIFF
--- a/src/assets/translations/messages-en.json
+++ b/src/assets/translations/messages-en.json
@@ -329,7 +329,8 @@
       "continue": "View Transaction",
       "position": "View Position",
       "viewAsset": "View Asset",
-      "close": "Close"
+      "close": "Close",
+      "viewExplorer": "View in Explorer"
     },
     "connect": {
       "loadingText": "Pairing Wallet"

--- a/src/components/Modals/Send/hooks/useFormSend/useFormSend.tsx
+++ b/src/components/Modals/Send/hooks/useFormSend/useFormSend.tsx
@@ -113,7 +113,7 @@ export const useFormSend = () => {
               </Text>
               {data.asset.explorerTxLink && (
                 <Link href={`${data.asset.explorerTxLink}${broadcastTXID}`} isExternal>
-                  View in Explorer <ExternalLinkIcon mx='2px' />
+                  {translate('modals.status.viewExplorer')} <ExternalLinkIcon mx='2px' />
                 </Link>
               )}
             </Text>

--- a/src/components/Modals/Send/hooks/useFormSend/useFormSend.tsx
+++ b/src/components/Modals/Send/hooks/useFormSend/useFormSend.tsx
@@ -1,4 +1,5 @@
-import { useToast } from '@chakra-ui/react'
+import { useToast, Link, Text } from '@chakra-ui/react'
+import { ExternalLinkIcon } from '@chakra-ui/icons'
 import { ChainAdapter } from '@shapeshiftoss/chain-adapters'
 import { chainAdapters, ChainTypes } from '@shapeshiftoss/types'
 import { useTranslate } from 'react-polyglot'
@@ -102,10 +103,18 @@ export const useFormSend = () => {
 
         toast({
           title: translate('modals.send.sent', { asset: data.asset.name }),
-          description: translate('modals.send.youHaveSent', {
-            amount: data.cryptoAmount,
-            symbol: data.cryptoSymbol
-          }),
+          description:
+          <Text>
+            <Text>
+              {translate('modals.send.youHaveSent', {
+                amount: data.cryptoAmount,
+                symbol: data.cryptoSymbol
+              })}
+            </Text>
+            <Link href={ data.asset.explorerTxLink } isExternal>
+              View in Explorer <ExternalLinkIcon mx='2px' />
+            </Link>
+          </Text>,
           status: 'success',
           duration: 9000,
           isClosable: true,

--- a/src/components/Modals/Send/hooks/useFormSend/useFormSend.tsx
+++ b/src/components/Modals/Send/hooks/useFormSend/useFormSend.tsx
@@ -1,5 +1,5 @@
-import { useToast, Link, Text } from '@chakra-ui/react'
 import { ExternalLinkIcon } from '@chakra-ui/icons'
+import { Link, Text, useToast } from '@chakra-ui/react'
 import { ChainAdapter } from '@shapeshiftoss/chain-adapters'
 import { chainAdapters, ChainTypes } from '@shapeshiftoss/types'
 import { useTranslate } from 'react-polyglot'
@@ -103,18 +103,21 @@ export const useFormSend = () => {
 
         toast({
           title: translate('modals.send.sent', { asset: data.asset.name }),
-          description:
-          <Text>
+          description: (
             <Text>
-              {translate('modals.send.youHaveSent', {
-                amount: data.cryptoAmount,
-                symbol: data.cryptoSymbol
-              })}
+              <Text>
+                {translate('modals.send.youHaveSent', {
+                  amount: data.cryptoAmount,
+                  symbol: data.cryptoSymbol
+                })}
+              </Text>
+              {data.asset.explorerTxLink && (
+                <Link href={`${data.asset.explorerTxLink}${broadcastTXID}`} isExternal>
+                  View in Explorer <ExternalLinkIcon mx='2px' />
+                </Link>
+              )}
             </Text>
-            <Link href={ data.asset.explorerTxLink } isExternal>
-              View in Explorer <ExternalLinkIcon mx='2px' />
-            </Link>
-          </Text>,
+          ),
           status: 'success',
           duration: 9000,
           isClosable: true,


### PR DESCRIPTION
## Description

Added transaction link to toast on a successful transaction.

## Notice

Before submitting a pull request, please make sure you have answered the following:

- [Yes ] Have you followed the guidelines in our [Contributing]('https://github.com/shapeshift/web/CONTRIBUTING.md) guide?
- [ Yes] Have you checked to ensure there aren't other open [Pull Requests](https://github.com/shapeshift/web/pulls) for the same update/change?

## Pull Request Type

- [ ] :bug: Bug fix (Non-breaking Change: Fixes an issue)
- [x] :hammer_and_wrench: Chore (Non-breaking Change: Doc updates, pkg upgrades, typos, etc..)
- [ ] :nail_care: New Feature (Breaking/Non-breaking Change)

## Issue (if applicable)
https://github.com/shapeshift/web/issues/986

## Risk
Very low risk, minor change to toast notification

## Testing
1) Visit app.shapeshift.com
2) Send funds from one address to another
3) Notice the toast notification signifying the successful txid
4) Click on the provided link to view transaction on the designated block explorer

## Screenshots (if applicable)
<img width="343" alt="Screen Shot 2022-02-15 at 11 20 48 PM" src="https://user-images.githubusercontent.com/56238058/154215958-7f2cf0f2-ac21-4a4e-b10a-20e4c731cb58.png">