### PR TITLE
refactor: remove unused activeAsset param

### DIFF
--- a/src/components/Transactions/TransactionRow.tsx
+++ b/src/components/Transactions/TransactionRow.tsx
@@ -13,7 +13,7 @@ import { TxDetails, useTxDetails } from 'hooks/useTxDetails/useTxDetails'
 dayjs.extend(relativeTime)
 dayjs.extend(localizedFormat)
 
-const renderTransactionType = (txDetails: TxDetails, activeAsset?: Asset): JSX.Element | null => {
+const renderTransactionType = (txDetails: TxDetails): JSX.Element | null => {
   return (() => {
     switch (txDetails.type) {
       case TxType.Send:
@@ -21,7 +21,7 @@ const renderTransactionType = (txDetails: TxDetails, activeAsset?: Asset): JSX.E
       case TxType.Receive:
         return <TransactionReceive txDetails={txDetails} />
       case TradeType.Trade:
-        return <TransactionTrade txDetails={txDetails} activeAsset={activeAsset} />
+        return <TransactionTrade txDetails={txDetails} />
       default:
         // Unhandled transaction type - don't render anything
         return null


### PR DESCRIPTION
## Description

We accept `activeAsset` as a param for `renderTransactionType`, but never use it.

It's also likely that we'll be putting any future "active asset" logic inside `txDetails`.

## Notice

Before submitting a pull request, please make sure you have answered the following:

- [x] Have you followed the guidelines in our [Contributing]('https://github.com/shapeshift/web/CONTRIBUTING.md) guide?
- [x] Have you checked to ensure there aren't other open [Pull Requests](https://github.com/shapeshift/web/pulls) for the same update/change?

## Pull Request Type

- [ ] :bug: Bug fix (Non-breaking Change: Fixes an issue)
- [x] :hammer_and_wrench: Chore (Non-breaking Change: Doc updates, pkg upgrades, typos, etc..)
- [ ] :nail_care: New Feature (Breaking/Non-breaking Change)
