### PR TITLE
fix(useSendDetails): update errored state properly on input change

### DIFF
--- a/src/components/Modals/Send/hooks/useSendDetails/useSendDetails.tsx
+++ b/src/components/Modals/Send/hooks/useSendDetails/useSendDetails.tsx
@@ -270,25 +270,22 @@ export const useSendDetails = (): UseSendDetailsReturnType => {
       async (inputValue: string) => {
         setLoading(true)
         setValue(SendFormFields.SendMax, false)
-        if (inputValue === '') {
-          /**
-           * The input is empty so removing errors if they are present
-           * and stop the loading, and return because next lines don't need
-           * to run.
-           */
-          setValue(SendFormFields.AmountFieldError, '')
-          setLoading(false)
-          return
-        }
         const key =
           fieldName !== SendFormFields.FiatAmount
             ? SendFormFields.FiatAmount
             : SendFormFields.CryptoAmount
+        if (inputValue === '') {
+          // Don't show an error message when the input is empty
+          setValue(SendFormFields.AmountFieldError, '')
+          setLoading(false)
+          // Set value of the other input to an empty string as well
+          setValue(key, '')
+          return
+        }
         const amount =
           fieldName === SendFormFields.FiatAmount
             ? bnOrZero(bn(inputValue).div(price)).toString()
             : bnOrZero(bn(inputValue).times(price)).toString()
-
         setValue(key, amount)
 
         let estimatedFees
@@ -318,10 +315,7 @@ export const useSendDetails = (): UseSendDetailsReturnType => {
             { asset: feeAsset.symbol }
           ])
         } else {
-          /**
-           * the balance is enough for transfer, so removing errors if previously the balance was too low,
-           * and user got insufficientFunds or notEnoughNativeToken errors.
-           */
+          // Remove existing error messages because the send amount is valid
           setValue(SendFormFields.AmountFieldError, '')
         }
         setLoading(false)

--- a/src/components/Modals/Send/hooks/useSendDetails/useSendDetails.tsx
+++ b/src/components/Modals/Send/hooks/useSendDetails/useSendDetails.tsx
@@ -270,6 +270,16 @@ export const useSendDetails = (): UseSendDetailsReturnType => {
       async (inputValue: string) => {
         setLoading(true)
         setValue(SendFormFields.SendMax, false)
+        if (inputValue === '') {
+          /**
+           * The input is empty so removing errors if they are present
+           * and stop the loading, and return because next lines don't need
+           * to run.
+           */
+          setValue(SendFormFields.AmountFieldError, '')
+          setLoading(false)
+          return
+        }
         const key =
           fieldName !== SendFormFields.FiatAmount
             ? SendFormFields.FiatAmount
@@ -307,6 +317,12 @@ export const useSendDetails = (): UseSendDetailsReturnType => {
             'modals.send.errors.notEnoughNativeToken',
             { asset: feeAsset.symbol }
           ])
+        } else {
+          /**
+           * the balance is enough for transfer, so removing errors if previously the balance was too low,
+           * and user got insufficientFunds or notEnoughNativeToken errors.
+           */
+          setValue(SendFormFields.AmountFieldError, '')
         }
         setLoading(false)
       },

--- a/src/components/TokenRow/TokenRow.tsx
+++ b/src/components/TokenRow/TokenRow.tsx
@@ -65,8 +65,8 @@ export function TokenRow<C extends FieldValues>({
               value={value}
               disabled={disabled}
               onValueChange={e => {
-                onInputChange && e.value !== value && onInputChange(e.value)
                 onChange(e.value)
+                if (onInputChange && e.value !== value) onInputChange(e.value)
               }}
             />
           )


### PR DESCRIPTION
## Description

fixed wrong button title on Send modal if the input is dirty.

## Notice

Before submitting a pull request, please make sure you have answered the following:

- [x] Have you followed the guidelines in our [Contributing]('https://github.com/shapeshift/web/CONTRIBUTING.md) guide?
- [x] Have you checked to ensure there aren't other open [Pull Requests](https://github.com/shapeshift/web/pulls) for the same update/change?

## Pull Request Type

- [x] :bug: Bug fix (Non-breaking Change: Fixes an issue)
- [ ] :hammer_and_wrench: Chore (Non-breaking Change: Doc updates, pkg upgrades, typos, etc..)
- [ ] :nail_care: New Feature (Breaking/Non-breaking Change)

## Issue (if applicable)

closes #1051

## Risk

## Testing

Open Send modal, enter amount higher than your balance and change it to something you can afford, you must be able to go to the next step.

## Screenshots (if applicable)
