### PR TITLE
fix: use Osmosis chain type

### DIFF
--- a/package.json
+++ b/package.json
@@ -16,7 +16,7 @@
     "@reduxjs/toolkit": "^1.7.2",
     "@shapeshiftoss/asset-service": "^1.19.0",
     "@shapeshiftoss/caip": "^1.11.1",
-    "@shapeshiftoss/chain-adapters": "^1.33.1",
+    "@shapeshiftoss/chain-adapters": "^1.35.1",
     "@shapeshiftoss/hdwallet-core": "^1.18.3",
     "@shapeshiftoss/hdwallet-keepkey": "^1.18.3",
     "@shapeshiftoss/hdwallet-keepkey-webusb": "^1.18.3",

--- a/src/hooks/useWalletSupportsChain/useWalletSupportsChain.ts
+++ b/src/hooks/useWalletSupportsChain/useWalletSupportsChain.ts
@@ -22,7 +22,7 @@ export const walletSupportChain: UseWalletSupportsChain = ({ chainId, wallet }) 
   })
 
   const osmosisCaip2 = caip2.toCAIP2({
-    chain: ChainTypes.Cosmos,
+    chain: ChainTypes.Osmosis,
     network: NetworkTypes.OSMOSIS_MAINNET
   })
   switch (chainId) {

--- a/yarn.lock
+++ b/yarn.lock
@@ -3565,12 +3565,12 @@
   resolved "https://registry.yarnpkg.com/@shapeshiftoss/caip/-/caip-1.11.1.tgz#3b81f4c8973b4d9af635256e2abbf993aa577eac"
   integrity sha512-8Cqn/4tqpNJDL6RHD2duQGe2U289I0A7gGp7bPQGMbtvy7cr5LIwo5nrPIuYfZUl2h1hvpyoVFkjkGWGMiqdRA==
 
-"@shapeshiftoss/chain-adapters@^1.31.1", "@shapeshiftoss/chain-adapters@^1.33.1":
-  version "1.33.1"
-  resolved "https://registry.yarnpkg.com/@shapeshiftoss/chain-adapters/-/chain-adapters-1.33.1.tgz#c9559ebd8d41615737db4335e0c46135401659c5"
-  integrity sha512-sufF4S4oB0AdD4H0VKgpY/j9NXUa1P46rcFKf+kgseDjDjyGHJZ0AKj8HSk9acGJnDhw+z/Ld12gmfgYMV2hJA==
+"@shapeshiftoss/chain-adapters@^1.31.1", "@shapeshiftoss/chain-adapters@^1.35.1":
+  version "1.35.1"
+  resolved "https://registry.yarnpkg.com/@shapeshiftoss/chain-adapters/-/chain-adapters-1.35.1.tgz#981ceb778b3ad5f6b9a03629441de36a153f0682"
+  integrity sha512-lGHk23QW1G0Var7ydY+yNXhedog+UtJiS0YjHYMgjy1dPye/1Ks8mzf6JSgAbuKvRFAE4kU7UO648R2ix76JrA==
   dependencies:
-    axios "^0.21.2"
+    axios "^0.26.0"
     bignumber.js "^9.0.1"
     bitcoinjs-lib "^5.2.0"
     coinselect "^3.1.12"
@@ -5199,7 +5199,7 @@
   dependencies:
     "@types/unist" "*"
 
-"@types/history@*", "@types/history@^4.7.11":
+"@types/history@^4.7.11":
   version "4.7.11"
   resolved "https://registry.yarnpkg.com/@types/history/-/history-4.7.11.tgz#56588b17ae8f50c53983a524fc3cc47437969d64"
   integrity sha512-qjDJRrmvBMiTx+jyLxvLfJU7UznFuokDv4f3WRuriHKERccVpFU+8XMQUAbDzoiJCsmexxRExQeMwwCdamSKDA==
@@ -6869,6 +6869,13 @@ axios@^0.24.0:
   integrity sha512-Q6cWsys88HoPgAaFAVUb0WpPk0O8iTeisR9IMqy9G8AbO4NlpVknrnQS03zzF9PGAWgO3cgletO3VjV/P7VztA==
   dependencies:
     follow-redirects "^1.14.4"
+
+axios@^0.26.0:
+  version "0.26.0"
+  resolved "https://registry.yarnpkg.com/axios/-/axios-0.26.0.tgz#9a318f1c69ec108f8cd5f3c3d390366635e13928"
+  integrity sha512-lKoGLMYtHvFrPVt3r+RBMp9nh34N0M8zEfCWqdWZx6phynIEhQqAdydpyBAAG211zlhX9Rgu08cOamy6XjE5Og==
+  dependencies:
+    follow-redirects "^1.14.8"
 
 axobject-query@^2.2.0:
   version "2.2.0"
@@ -11368,10 +11375,10 @@ follow-redirects@1.5.10:
   dependencies:
     debug "=3.1.0"
 
-follow-redirects@^1.0.0, follow-redirects@^1.10.0, follow-redirects@^1.14.0, follow-redirects@^1.14.4:
-  version "1.14.5"
-  resolved "https://registry.yarnpkg.com/follow-redirects/-/follow-redirects-1.14.5.tgz#f09a5848981d3c772b5392309778523f8d85c381"
-  integrity sha512-wtphSXy7d4/OR+MvIFbCVBDzZ5520qV8XfPklSN5QtxuMUJZ+b0Wnst1e1lCDocfzuCkHqj8k0FpZqO+UIaKNA==
+follow-redirects@^1.0.0, follow-redirects@^1.10.0, follow-redirects@^1.14.0, follow-redirects@^1.14.4, follow-redirects@^1.14.8:
+  version "1.14.9"
+  resolved "https://registry.yarnpkg.com/follow-redirects/-/follow-redirects-1.14.9.tgz#dd4ea157de7bfaf9ea9b3fbd85aa16951f78d8d7"
+  integrity sha512-MQDfihBQYMcyy5dhRDJUHcw7lb2Pv/TuE6xP1vyraLukNDHKbDxDNaOE3NbCAdKQApno+GPRyo1YAp89yCjK4w==
 
 for-in@^1.0.2:
   version "1.0.2"


### PR DESCRIPTION
## Description

Since [CAIP support was added for Osmosis](https://github.com/shapeshift/lib/commit/e0edc673732df2810dae32c5a49014cd174bad5a), and Chain Adapters `1.35.1` was released, a bug surfaced in `web`, where `useWalletSupportsChain.ts` will throw, caused by the addition of the `Osmosis` Chain Type.

This PR makes a small change that fixes the bug whilst bumping the Chain Adapters package.

## Notice

Before submitting a pull request, please make sure you have answered the following:

- [x] Have you followed the guidelines in our [Contributing]('https://github.com/shapeshift/web/CONTRIBUTING.md) guide?
- [x] Have you checked to ensure there aren't other open [Pull Requests](https://github.com/shapeshift/web/pulls) for the same update/change?

## Pull Request Type

- [x] :bug: Bug fix (Non-breaking Change: Fixes an issue)
- [ ] :hammer_and_wrench: Chore (Non-breaking Change: Doc updates, pkg upgrades, typos, etc..)
- [ ] :nail_care: New Feature (Breaking/Non-breaking Change)

## Issue (if applicable)

N/A

## Risk

N/A

## Testing

`yarn`
`yarn dev`

Navigate to `http://localhost:3000/assets/eip155:1/slip44:60`, confirm that you do not get the error in the screenshot below.

## Screenshots (if applicable)

<img width="512" alt="Screen Shot 2022-02-28 at 7 43 11 am" src="https://user-images.githubusercontent.com/97164662/155899197-ace2d392-e2ad-4145-9c10-ebc2947843d1.png">
