### PR TITLE
fix: tokenrow onchange fixed alongside its side-effects

### DIFF
--- a/src/components/Modals/Send/hooks/useSendDetails/useSendDetails.tsx
+++ b/src/components/Modals/Send/hooks/useSendDetails/useSendDetails.tsx
@@ -274,6 +274,14 @@ export const useSendDetails = (): UseSendDetailsReturnType => {
           fieldName !== SendFormFields.FiatAmount
             ? SendFormFields.FiatAmount
             : SendFormFields.CryptoAmount
+        if (inputValue === '') {
+          // Don't show an error message when the input is empty
+          setValue(SendFormFields.AmountFieldError, '')
+          setLoading(false)
+          // Set value of the other input to an empty string as well
+          setValue(key, '')
+          return
+        }
         const amount =
           fieldName === SendFormFields.FiatAmount
             ? bnOrZero(bn(inputValue).div(price)).toString()
@@ -307,6 +315,9 @@ export const useSendDetails = (): UseSendDetailsReturnType => {
             'modals.send.errors.notEnoughNativeToken',
             { asset: feeAsset.symbol }
           ])
+        } else {
+          // Remove existing error messages because the send amount is valid
+          setValue(SendFormFields.AmountFieldError, '')
         }
         setLoading(false)
       },

--- a/src/components/TokenRow/TokenRow.tsx
+++ b/src/components/TokenRow/TokenRow.tsx
@@ -65,8 +65,8 @@ export function TokenRow<C extends FieldValues>({
               value={value}
               disabled={disabled}
               onValueChange={e => {
-                onInputChange && e.value !== value && onInputChange(e.value)
                 onChange(e.value)
+                if (onInputChange && e.value !== value) onInputChange(e.value)
               }}
             />
           )

--- a/src/components/Trade/TradeInput.tsx
+++ b/src/components/Trade/TradeInput.tsx
@@ -21,7 +21,7 @@ import {
 import { TradeState } from 'components/Trade/Trade'
 import { useWallet } from 'context/WalletProvider/WalletProvider'
 import { useLocaleFormatter } from 'hooks/useLocaleFormatter/useLocaleFormatter'
-import { bn, bnOrZero } from 'lib/bignumber/bignumber'
+import { bnOrZero } from 'lib/bignumber/bignumber'
 import { firstNonZeroDecimal } from 'lib/math'
 import {
   selectAssetByCAIP19,
@@ -253,11 +253,9 @@ export const TradeInput = ({ history }: RouterProps) => {
                 disabled={isSendMaxLoading}
                 rules={{ required: true }}
                 onInputChange={(amount: string) => {
-                  if (!bn(amount).eq(bnOrZero(sellAsset.amount))) {
-                    const action = amount ? TradeActions.SELL : undefined
-                    action ? setValue('action', action) : reset()
-                    getQuote({ amount, sellAsset, buyAsset, feeAsset, action })
-                  }
+                  const action = amount ? TradeActions.SELL : undefined
+                  action ? setValue('action', action) : reset()
+                  getQuote({ amount, sellAsset, buyAsset, feeAsset, action })
                 }}
                 inputLeftElement={
                   <TokenButton


### PR DESCRIPTION
## Description

`TokenRow` onChange fixed alongside its side-effects

## Notice

Before submitting a pull request, please make sure you have answered the following:

- [x] Have you followed the guidelines in our [Contributing]('https://github.com/shapeshift/web/CONTRIBUTING.md) guide?
- [x] Have you checked to ensure there aren't other open [Pull Requests](https://github.com/shapeshift/web/pulls) for the same update/change?

## Pull Request Type

- [x] :bug: Bug fix (Non-breaking Change: Fixes an issue)
- [ ] :hammer_and_wrench: Chore (Non-breaking Change: Doc updates, pkg upgrades, typos, etc..)
- [ ] :nail_care: New Feature (Breaking/Non-breaking Change)


## Testing

- Send modal amount input should handle errors correctly
- Trade card amount inputs should handle state correctly

## RISK

Throughout these two processes, your funds could be sent/traded which is irreversible.
