### PR TITLE
fix: optional chain a bunch of things

### DIFF
--- a/src/hooks/useBalanceChartData/useBalanceChartData.ts
+++ b/src/hooks/useBalanceChartData/useBalanceChartData.ts
@@ -98,7 +98,7 @@ export const makeBuckets: MakeBuckets = args => {
 
   // current asset balances, we iterate over this later and adjust on each tx
   const assetBalances = assetIds.reduce<CryptoBalance>((acc, cur) => {
-    acc[cur] = bnOrZero(balances[cur])
+    acc[cur] = bnOrZero(balances?.[cur])
     return acc
   }, {})
 

--- a/src/state/slices/portfolioSlice/selectors.ts
+++ b/src/state/slices/portfolioSlice/selectors.ts
@@ -127,8 +127,8 @@ export const selectPortfolioFiatBalanceByFilter = createSelector(
   selectAssetIdParamFromFilterOptional,
   selectAccountIdParamFromFilterOptional,
   (portfolioAssetFiatBalances, portfolioAccountFiatbalances, assetId, accountId): string => {
-    if (assetId && !accountId) return portfolioAssetFiatBalances[assetId]
-    if (assetId && accountId) return portfolioAccountFiatbalances[accountId][assetId]
+    if (assetId && !accountId) return portfolioAssetFiatBalances?.[assetId] ?? '0'
+    if (assetId && accountId) return portfolioAccountFiatbalances?.[accountId]?.[assetId] ?? '0'
     if (!assetId && accountId) {
       const accountBalances = portfolioAccountFiatbalances[accountId]
       const totalAccountBalances = Object.values(accountBalances).reduce(
@@ -158,7 +158,7 @@ export const selectPortfolioCryptoHumanBalanceByFilter = createSelector(
   (assets, accountBalances, assetBalances, accountId, assetId): string => {
     if (accountId && assetId) {
       return fromBaseUnit(
-        bnOrZero(accountBalances[accountId][assetId]),
+        bnOrZero(accountBalances?.[accountId]?.[assetId]),
         assets[assetId].precision ?? 0
       )
     }
@@ -176,14 +176,13 @@ export const selectPortfolioCryptoBalancesByAccountId = createSelector(
 )
 
 export const selectPortfolioCryptoBalanceByFilter = createSelector(
-  selectAssets,
   selectPortfolioAccountBalances,
   selectPortfolioAssetBalances,
   selectAccountIdParamFromFilterOptional,
   selectAssetIdParamFromFilterOptional,
-  (assets, accountBalances, assetBalances, accountId, assetId): string => {
+  (accountBalances, assetBalances, accountId, assetId): string => {
     if (accountId && assetId) {
-      return accountBalances[accountId][assetId] ?? '0'
+      return accountBalances?.[accountId]?.[assetId] ?? '0'
     }
     return assetBalances[assetId] ?? '0'
   }
@@ -346,7 +345,7 @@ export const selectPortfolioAssetIdsByAccountIdExcludeFeeAsset = createSelector(
   selectAccountIdParam,
   selectAssets,
   (accountAssets, accountId, assets) => {
-    const assetsByAccountIds = accountAssets[accountId]
+    const assetsByAccountIds = accountAssets?.[accountId] ?? {}
     return Object.keys(assetsByAccountIds).filter(
       assetId => !FEE_ASSET_IDS.includes(assetId) && assets[assetId]
     )


### PR DESCRIPTION
fix: optional chain a bunch of things that don't exist in the store on page reload when deep linked

## Description

with the new routing changes, things were loading quicker and the selectors were trying to read data from the store before it existed on deep link page reloads. this opt chains things until it worked again

## Notice

Before submitting a pull request, please make sure you have answered the following:

- [x] Have you followed the guidelines in our [Contributing]('https://github.com/shapeshift/web/CONTRIBUTING.md) guide?
- [x] Have you checked to ensure there aren't other open [Pull Requests](https://github.com/shapeshift/web/pulls) for the same update/change?

## Pull Request Type

- [x] :bug: Bug fix (Non-breaking Change: Fixes an issue)
- [ ] :hammer_and_wrench: Chore (Non-breaking Change: Doc updates, pkg upgrades, typos, etc..)
- [ ] :nail_care: New Feature (Breaking/Non-breaking Change)

## Issue (if applicable)

n/a - found in release branch testing

## Risk

some selectors could work incorrectly.

## Testing

go to an account page, and refresh the page. the page should loading without crashing.

## Screenshots (if applicable)

n/a