### PR TITLE
fix: send modal address check for Ethereum ens addresses

### DIFF
--- a/src/components/Modals/Send/views/Address.tsx
+++ b/src/components/Modals/Send/views/Address.tsx
@@ -10,8 +10,7 @@ import {
   ModalHeader,
   Stack
 } from '@chakra-ui/react'
-import { ChainAdapter } from '@shapeshiftoss/chain-adapters'
-import { ChainTypes } from '@shapeshiftoss/types'
+import { ChainAdapter as EthereumChainAdapter } from '@shapeshiftoss/chain-adapters/dist/ethereum/EthereumChainAdapter'
 import get from 'lodash/get'
 import { useState } from 'react'
 import { useFormContext, useWatch } from 'react-hook-form'
@@ -45,9 +44,6 @@ export const Address = () => {
   if (!(asset?.chain && asset?.name)) return null
 
   const adapter = chainAdapters.byChain(asset.chain)
-  const isEthereumChainAdapter = (
-    adapter: ChainAdapter<ChainTypes>
-  ): adapter is ChainAdapter<ChainTypes.Ethereum> => adapter.getType() === ChainTypes.Ethereum
 
   const handleNext = () => history.push(SendRoutes.Details)
 
@@ -87,7 +83,7 @@ export const Address = () => {
               validate: {
                 validateAddress: async (value: string) => {
                   const validAddress = await adapter.validateAddress(value)
-                  if (isEthereumChainAdapter(adapter)) {
+                  if (adapter instanceof EthereumChainAdapter) {
                     const validEnsAddress = await adapter.validateEnsAddress(value)
                     if (validEnsAddress.valid) {
                       // Verify that the ENS name resolves to an address


### PR DESCRIPTION
## Description

The generic type was removed for `validateEnsAddress` so we change the check to check for the actual `EthereumChainAdapter` class instead of the generic `ChainAdapter<ChainTypes.Ethereum>` interface

## Notice

Before submitting a pull request, please make sure you have answered the following:

- [X] Have you followed the guidelines in our [Contributing]('https://github.com/shapeshift/web/CONTRIBUTING.md) guide?
- [X] Have you checked to ensure there aren't other open [Pull Requests](https://github.com/shapeshift/web/pulls) for the same update/change?

## Pull Request Type

- [X] :bug: Bug fix (Non-breaking Change: Fixes an issue)
- [ ] :hammer_and_wrench: Chore (Non-breaking Change: Doc updates, pkg upgrades, typos, etc..)
- [ ] :nail_care: New Feature (Breaking/Non-breaking Change)

## Issue (if applicable)

N/A

## Risk

Affects ENS address lookups, but the risk here is basically none.

## Testing

Test Ethereum sends with an ENS address
