### PR TITLE
feat: cosmos 'Confirm Staking - Broadcast' view

### DIFF
--- a/src/assets/translations/messages-en.json
+++ b/src/assets/translations/messages-en.json
@@ -128,6 +128,7 @@
     "amountToStake": "Amount to Stake",
     "amountToUnstake": "Amount to Unstake",
     "confirmDetails": "Confirm Details",
+    "broadcastingTransaction": "Broadcasting Transaction",
     "validator": "Validator",
     "unstakeFrom": "Unstake From",
     "gasFee": "Gas Fee",

--- a/src/plugins/cosmos/components/modals/Staking/views/StakeBroadcast.tsx
+++ b/src/plugins/cosmos/components/modals/Staking/views/StakeBroadcast.tsx
@@ -1,21 +1,18 @@
 import { InfoOutlineIcon } from '@chakra-ui/icons'
 import { Flex } from '@chakra-ui/layout'
-import { Button, FormControl, ModalHeader, Text as CText, Tooltip } from '@chakra-ui/react'
+import { Button, Link, ModalHeader, Text as CText, Tooltip } from '@chakra-ui/react'
 import { CAIP19 } from '@shapeshiftoss/caip'
 import { chainAdapters } from '@shapeshiftoss/types'
 import { Asset } from '@shapeshiftoss/types'
 import { AprTag } from 'plugins/cosmos/components/AprTag/AprTag'
-import { TxFeeRadioGroup } from 'plugins/cosmos/components/TxFeeRadioGroup/TxFeeRadioGroup'
 import { FormProvider, useForm } from 'react-hook-form'
 import { useTranslate } from 'react-polyglot'
-import { useHistory } from 'react-router-dom'
 import { Amount } from 'components/Amount/Amount'
+import { MiddleEllipsis } from 'components/MiddleEllipsis/MiddleEllipsis'
 import { SlideTransition } from 'components/SlideTransition'
 import { Text } from 'components/Text'
 import { BigNumber } from 'lib/bignumber/bignumber'
 import { bnOrZero } from 'lib/bignumber/bignumber'
-
-import { StakingPath } from './StakeConfirmRouter'
 
 export enum InputType {
   Crypto = 'crypto',
@@ -46,7 +43,7 @@ function calculateYearlyYield(apy: string, amount: string = '') {
 const DEFAULT_VALIDATOR_NAME = 'Shapeshift Validator'
 
 // TODO: Wire up the whole component with staked data
-export const StakeConfirm = ({
+export const StakeBroadcast = ({
   apr,
   assetId,
   cryptoStakeAmount,
@@ -54,7 +51,6 @@ export const StakeConfirm = ({
   onCancel
 }: StakeProps) => {
   const methods = useForm<StakingValues>({
-    mode: 'onChange',
     defaultValues: {
       [Field.FeeType]: chainAdapters.FeeDataKey.Average
     }
@@ -62,9 +58,8 @@ export const StakeConfirm = ({
 
   const { handleSubmit } = methods
 
-  const memoryHistory = useHistory()
   const onSubmit = (_: any) => {
-    memoryHistory.push(StakingPath.Broadcast)
+    // TODO: handle submit when wired up
   }
 
   const cryptoYield = calculateYearlyYield(apr, cryptoStakeAmount.toPrecision())
@@ -79,6 +74,12 @@ export const StakeConfirm = ({
     caip19: assetId,
     chain: 'osmosis'
   }))(assetId) as Asset
+  const txDetails = {
+    explorerTxLink: 'https://etherscan.io/tx/',
+    tx: {
+      txid: '42foobar42'
+    }
+  }
   return (
     <FormProvider {...methods}>
       <SlideTransition>
@@ -88,14 +89,14 @@ export const StakeConfirm = ({
           pb='18px'
           px='30px'
           onSubmit={handleSubmit(onSubmit)}
-          direction='column'
+          flexDirection='column'
           alignItems='center'
           justifyContent='space-between'
         >
-          <ModalHeader textAlign='center'>{translate('defi.confirmDetails')}</ModalHeader>
+          <ModalHeader textAlign='center'>{translate('defi.broadcastingTransaction')}</ModalHeader>
           <Flex width='100%' mb='20px' justifyContent='space-between'>
             <Text color='gray.500' translation={'defi.stake'} />
-            <Flex direction='column' alignItems='flex-end'>
+            <Flex flexDirection='column' alignItems='flex-end'>
               <Amount.Fiat
                 fontWeight='semibold'
                 value={cryptoStakeAmount.times(fiatRate).toPrecision()}
@@ -118,17 +119,27 @@ export const StakeConfirm = ({
             <CText>{DEFAULT_VALIDATOR_NAME}</CText>
           </Flex>
           <Flex width='100%' mb='35px' justifyContent='space-between'>
+            <Text translation={'transactionRow.txid'} color='gray.500' />
+            <Link
+              isExternal
+              color='blue.500'
+              href={`${txDetails.explorerTxLink}${txDetails.tx.txid}`}
+            >
+              <MiddleEllipsis address={txDetails.tx.txid} />
+            </Link>
+          </Flex>
+          <Flex width='100%' mb='35px' justifyContent='space-between'>
             <Text translation={'defi.averageApr'} color='gray.500' />
             <AprTag percentage='0.125' />
           </Flex>
           <Flex width='100%' mb='13px' justifyContent='space-between'>
             <Text translation={'defi.estimatedYearlyRewards'} color='gray.500' />
-            <Flex direction='column' alignItems='flex-end'>
+            <Flex flexDirection='column' alignItems='flex-end'>
               <Amount.Crypto value={cryptoYield} symbol={asset.symbol} />
               <Amount.Fiat color='gray.500' value={fiatYield} />
             </Flex>
           </Flex>
-          <Flex mb='6px' width='100%'>
+          <Flex mb='6px' width='100%' justifyContent='space-between' mt='10px'>
             <CText display='inline-flex' alignItems='center' color='gray.500'>
               {translate('defi.gasFee')}
               &nbsp;
@@ -140,27 +151,11 @@ export const StakeConfirm = ({
                 <InfoOutlineIcon />
               </Tooltip>
             </CText>
+            <Flex flexDirection='column' alignItems='flex-end'>
+              <Amount.Crypto value='0.0005' symbol={asset.symbol} />
+              <Amount.Fiat color='gray.500' value={'0.01'} />
+            </Flex>
           </Flex>
-          <FormControl>
-            <TxFeeRadioGroup
-              asset={asset}
-              mb='10px'
-              fees={{
-                slow: {
-                  txFee: '0.004',
-                  fiatFee: '0.1'
-                },
-                average: {
-                  txFee: '0.008',
-                  fiatFee: '0.2'
-                },
-                fast: {
-                  txFee: '0.012',
-                  fiatFee: '0.3'
-                }
-              }}
-            />
-          </FormControl>
           <Text
             textAlign='center'
             fontSize='sm'

--- a/src/plugins/cosmos/components/modals/Staking/views/StakeConfirmRouter.tsx
+++ b/src/plugins/cosmos/components/modals/Staking/views/StakeConfirmRouter.tsx
@@ -1,12 +1,12 @@
 import { Flex } from '@chakra-ui/layout'
 import { CAIP19 } from '@shapeshiftoss/caip'
 import { Asset } from '@shapeshiftoss/types'
-import { AnimatePresence } from 'framer-motion'
 import { MemoryRouter, Route, Switch, useLocation } from 'react-router-dom'
 import { RouteSteps } from 'components/RouteSteps/RouteSteps'
 import { SlideTransition } from 'components/SlideTransition'
 import { BigNumber } from 'lib/bignumber/bignumber'
 
+import { StakeBroadcast } from './StakeBroadcast'
 import { StakeConfirm } from './StakeConfirm'
 
 export type StakingConfirmProps = {
@@ -44,7 +44,7 @@ const CosmosStakingRouter = ({
   }))(assetId) as Asset
 
   return (
-    <AnimatePresence exitBeforeEnter initial={false}>
+    <SlideTransition>
       <Switch location={location} key={location.key}>
         <Flex minWidth={{ base: '100%', xl: '500px' }} flexDir={{ base: 'column', lg: 'row' }}>
           <RouteSteps
@@ -71,13 +71,19 @@ const CosmosStakingRouter = ({
                 />
               </Route>
               <Route exact key={StakingPath.Broadcast} path={StakingPath.Broadcast}>
-                TODO Staking Broadcast component
+                <StakeBroadcast
+                  apr={apr}
+                  cryptoStakeAmount={cryptoAmount}
+                  assetId={assetId}
+                  fiatRate={fiatRate}
+                  onCancel={onCancel}
+                />
               </Route>
             </Flex>
           </Flex>
         </Flex>
       </Switch>
-    </AnimatePresence>
+    </SlideTransition>
   )
 }
 


### PR DESCRIPTION
## Description

- add `<Broadcast />` view and use it in `StakeConfirmRouter />`

## Notice

Before submitting a pull request, please make sure you have answered the following:

- [ ] Have you followed the guidelines in our [Contributing]('https://github.com/shapeshift/web/CONTRIBUTING.md) guide?
- [x] Have you checked to ensure there aren't other open [Pull Requests](https://github.com/shapeshift/web/pulls) for the same update/change?

## Pull Request Type

- [ ] :bug: Bug fix (Non-breaking Change: Fixes an issue)
- [ ] :hammer_and_wrench: Chore (Non-breaking Change: Doc updates, pkg upgrades, typos, etc..)
- [x] :nail_care: New Feature (Breaking/Non-breaking Change)

## Issue (if applicable)

#663

## Risk

This won't close #663 as it is not wired up yet and loading states will be added then.
It is not a product risk since it is a new component but it is an engineering issue to keep in mind.

## Testing

- Open cosmos staking modal
- Select any amount e.g 50%
- Click confirm

## Screenshots (if applicable)
<img width="735" alt="image" src="https://user-images.githubusercontent.com/17035424/156674114-81c297a7-a86e-41a3-8d37-7b2f69a07d69.png">
