### PR TITLE
feat: add generic transaction row

### DIFF
--- a/src/assets/translations/messages-en.json
+++ b/src/assets/translations/messages-en.json
@@ -237,7 +237,8 @@
       "thor": {
         "transferOut": "Transfer out"
       }
-    }
+    },
+    "unknown": "Unknown transaction"
   },
   "trade": {
     "searchingRate": "Searching for best rate...",

--- a/src/assets/translations/messages-en.json
+++ b/src/assets/translations/messages-en.json
@@ -238,7 +238,7 @@
         "transferOut": "Transfer out"
       }
     },
-    "unknown": "Unknown transaction"
+    "unknown": "Transaction"
   },
   "trade": {
     "searchingRate": "Searching for best rate...",

--- a/src/components/Transactions/TransactionContract.tsx
+++ b/src/components/Transactions/TransactionContract.tsx
@@ -68,7 +68,7 @@ export const TransactionContract = ({ txDetails }: { txDetails: TxDetails }) => 
             </Box>
 
             <Flex flexDir='column' ml='auto' textAlign='right'>
-              {txDetails.direction !== 'in-place' && (
+              {txDetails.direction !== 'in-place' && txDetails.value && (
                 <Amount.Crypto
                   {...(txDetails.direction === 'inbound'
                     ? { color: 'green.500' }

--- a/src/components/Transactions/TransactionReceive.tsx
+++ b/src/components/Transactions/TransactionReceive.tsx
@@ -57,13 +57,15 @@ export const TransactionReceive = ({
             </Box>
 
             <Flex flexDir='column' ml='auto' textAlign='right'>
-              <Amount.Crypto
-                color='green.500'
-                value={fromBaseUnit(txDetails.value, txDetails.precision)}
-                symbol={txDetails.symbol}
-                maximumFractionDigits={6}
-                prefix=''
-              />
+              {txDetails.value && (
+                <Amount.Crypto
+                  color='green.500'
+                  value={fromBaseUnit(txDetails.value, txDetails.precision)}
+                  symbol={txDetails.symbol}
+                  maximumFractionDigits={6}
+                  prefix=''
+                />
+              )}
             </Flex>
           </Flex>
         </Flex>

--- a/src/components/Transactions/TransactionRow.tsx
+++ b/src/components/Transactions/TransactionRow.tsx
@@ -6,6 +6,7 @@ import localizedFormat from 'dayjs/plugin/localizedFormat'
 import relativeTime from 'dayjs/plugin/relativeTime'
 import { useRef } from 'react'
 import { TransactionContract } from 'components/Transactions/TransactionContract'
+import { TransactionGeneric } from 'components/Transactions/TransactionGeneric'
 import { TransactionReceive } from 'components/Transactions/TransactionReceive'
 import { TransactionSend } from 'components/Transactions/TransactionSend'
 import { TransactionTrade } from 'components/Transactions/TransactionTrade'
@@ -26,8 +27,8 @@ const renderTransactionType = (txDetails: TxDetails): JSX.Element | null => {
       case TxType.Contract:
         return <TransactionContract txDetails={txDetails} />
       default:
-        // Unhandled transaction type - don't render anything
-        return null
+        // Unhandled transaction type - render what a generic row
+        return <TransactionGeneric txDetails={txDetails} />
     }
   })()
 }
@@ -37,13 +38,6 @@ export const TransactionRow = ({ txId, activeAsset }: { txId: string; activeAsse
 
   const bg = useColorModeValue('gray.50', 'whiteAlpha.100')
   const txDetails = useTxDetails(txId, activeAsset)
-
-  // TODO(0xdef1cafe): support yearn vault deposit withdrawals
-  // log what transactions we are currently not parsing so we can update accordingly
-  if (!txDetails.type) {
-    // console.warn('unsupported transaction:', tx.txid)
-    return null
-  }
 
   return (
     <Box ref={ref} width='full' pl={3} pr={4} rounded='lg' _hover={{ bg }}>

--- a/src/components/Transactions/TransactionRow.tsx
+++ b/src/components/Transactions/TransactionRow.tsx
@@ -27,7 +27,7 @@ const renderTransactionType = (txDetails: TxDetails): JSX.Element | null => {
       case TxType.Contract:
         return <TransactionContract txDetails={txDetails} />
       default:
-        // Unhandled transaction type - render what a generic row
+        // Unhandled transaction type - render a generic row
         return <TransactionGeneric txDetails={txDetails} />
     }
   })()

--- a/src/components/Transactions/TransactionTrade.tsx
+++ b/src/components/Transactions/TransactionTrade.tsx
@@ -51,13 +51,15 @@ export const TransactionTrade = ({ txDetails }: { txDetails: TxDetails }) => {
             </Box>
 
             <Flex flexDir='column' ml='auto' textAlign='right'>
-              <Amount.Crypto
-                color='inherit'
-                value={fromBaseUnit(txDetails.value, txDetails.precision)}
-                symbol={txDetails.symbol}
-                maximumFractionDigits={6}
-                prefix=''
-              />
+              {txDetails.value && (
+                <Amount.Crypto
+                  color='inherit'
+                  value={fromBaseUnit(txDetails.value, txDetails.precision)}
+                  symbol={txDetails.symbol}
+                  maximumFractionDigits={6}
+                  prefix=''
+                />
+              )}
             </Flex>
           </Flex>
         </Flex>

--- a/src/hooks/useTxDetails/useTxDetails.ts
+++ b/src/hooks/useTxDetails/useTxDetails.ts
@@ -1,10 +1,10 @@
-import { Asset, chainAdapters } from '@shapeshiftoss/types'
-import { TradeType, TxTransfer, TxType } from '@shapeshiftoss/types/dist/chain-adapters'
+import { Asset, chainAdapters, ChainTypes } from '@shapeshiftoss/types'
+import { TradeType, TxStatus, TxTransfer, TxType } from '@shapeshiftoss/types/dist/chain-adapters'
 import { useEffect, useState } from 'react'
 import { useSelector } from 'react-redux'
 import { ensReverseLookup } from 'lib/ens'
 import { ReduxState } from 'state/reducer'
-import { selectAssetByCAIP19, selectTxById } from 'state/slices/selectors'
+import { selectAssetByCAIP19 } from 'state/slices/selectors'
 import { Tx } from 'state/slices/txHistorySlice/txHistorySlice'
 
 // Adding a new supported method? Also update transactionRow.parser translations accordingly
@@ -31,7 +31,7 @@ export interface TxDetails {
   feeAsset: Asset
   buyAsset: Asset
   sellAsset: Asset
-  value: string
+  value?: string
   to: string
   ensTo?: string
   from: string
@@ -93,7 +93,7 @@ export const useTxDetails = (txId: string, activeAsset?: Asset): TxDetails => {
   )
   const tradeAsset = activeAsset?.symbol === sellAsset?.symbol ? sellAsset : buyAsset
 
-  const value = standardTx?.value ?? tradeTx?.value ?? '0'
+  const value = standardTx?.value ?? tradeTx?.value ?? undefined
   const to = standardTx?.to ?? tradeTx?.to ?? ''
   const from = standardTx?.from ?? tradeTx?.from ?? ''
 

--- a/src/hooks/useTxDetails/useTxDetails.ts
+++ b/src/hooks/useTxDetails/useTxDetails.ts
@@ -41,7 +41,7 @@ export interface TxDetails {
   precision: number
   explorerTxLink: string
   explorerAddressLink: string
-  direction: Direction
+  direction?: Direction
 }
 
 export const getStandardTx = (tx: Tx) => (tx.transfers.length === 1 ? tx.transfers[0] : undefined)
@@ -59,7 +59,7 @@ export const useTxDetails = (txId: string, activeAsset?: Asset): TxDetails => {
   const buyTx = getBuyTx(tx)
   const sellTx = getSellTx(tx)
 
-  const direction: Direction = (() => {
+  const direction: Direction | undefined = (() => {
     switch (method) {
       case 'deposit':
       case 'addLiquidityETH':
@@ -68,8 +68,10 @@ export const useTxDetails = (txId: string, activeAsset?: Asset): TxDetails => {
       case 'withdraw':
       case 'removeLiquidityETH':
         return Direction.Inbound
-      default:
+      case 'approve':
         return Direction.InPlace
+      default:
+        return undefined
     }
   })()
 


### PR DESCRIPTION
## Description

Add a `TransactionGeneric` component that renders basic transaction details of transactions that we don't explicitly understand, e.g. any UniSwap V3 transactions, or unhandled UniSwap V2 transactions.

Also fixes the `direction` IIFE - we should default to `undefined`, not `in-place`, which gives the illusion of precision.

## Notice

Before submitting a pull request, please make sure you have answered the following:

- [x] Have you followed the guidelines in our [Contributing]('https://github.com/shapeshift/web/CONTRIBUTING.md) guide?
- [x] Have you checked to ensure there aren't other open [Pull Requests](https://github.com/shapeshift/web/pulls) for the same update/change?

## Pull Request Type

- [ ] :bug: Bug fix (Non-breaking Change: Fixes an issue)
- [ ] :hammer_and_wrench: Chore (Non-breaking Change: Doc updates, pkg upgrades, typos, etc..)
- [x] :nail_care: New Feature (Breaking/Non-breaking Change)

## Issue (if applicable)

Closes https://github.com/shapeshift/web/issues/1121

## Risk

Small regression risk, but it should be fairly safe.

## Testing

`yarn dev`, then Log into a wallet with transactions that aren't supported, e.g. from UniSwapV3, or a UniV2 approval.

## Screenshots (if applicable)

<img width="1148" alt="Screen Shot 2022-03-04 at 5 01 24 pm" src="https://user-images.githubusercontent.com/97164662/156708994-0c50a5bb-6f7c-4b63-af9d-f81736c7b63f.png">
