### PR TITLE
fix: vault value color on both themes

### DIFF
--- a/src/pages/Defi/components/StakingCard.tsx
+++ b/src/pages/Defi/components/StakingCard.tsx
@@ -104,7 +104,7 @@ export const StakingCard = ({
             </Skeleton>
             <Skeleton isLoaded={isLoaded}>
               <StatNumber>
-                <Amount.Fiat color={expired ? 'red.500' : 'white'} value={fiatAmount} />
+                <Amount.Fiat color={expired ? 'red.500' : ''} value={fiatAmount} />
               </StatNumber>
             </Skeleton>
           </Stat>


### PR DESCRIPTION
## Description

Please describe your changes

## Notice

Before submitting a pull request, please make sure you have answered the following:

- [x] Have you followed the guidelines in our [Contributing]('https://github.com/shapeshift/web/CONTRIBUTING.md) guide?
- [x] Have you checked to ensure there aren't other open [Pull Requests](https://github.com/shapeshift/web/pulls) for the same update/change?

## Pull Request Type

- [x] :bug: Bug fix (Non-breaking Change: Fixes an issue)
- [ ] :hammer_and_wrench: Chore (Non-breaking Change: Doc updates, pkg upgrades, typos, etc..)
- [ ] :nail_care: New Feature (Breaking/Non-breaking Change)

## Issue (if applicable)

closes #1092

## Risk

Looks like there are no risks

## Testing

- Go to the DeFi page
- Have some assets staked
- Verify on light mode if the vault value is well displayed

## Screenshots (if applicable)
![image](https://user-images.githubusercontent.com/14963751/156821905-41cd4088-5b46-4d81-834e-e351876bce1d.png)

![image](https://user-images.githubusercontent.com/14963751/156821927-cf8fd1ff-f100-4309-90e6-72aa0d5bc1f4.png)


