### PR TITLE
chore: add fall-back cypress key for forks

### DIFF
--- a/.github/workflows/pr-cypress.yml
+++ b/.github/workflows/pr-cypress.yml
@@ -100,7 +100,7 @@ jobs:
           group: 'Chrome tests'
         env:
           CYPRESS_PROJECT_ID: 'vpyrho'
-          CYPRESS_RECORD_KEY: ${{ secrets.CYPRESS_RECORD_KEY }}
+          CYPRESS_RECORD_KEY: ${{ secrets.CYPRESS_RECORD_KEY || '05f1a79d-0c03-406b-8cf0-ca9ad10fa664' }}
           # Passing the GitHub token lets this action correctly
           # determine the unique run id necessary to re-run the checks
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}


### PR DESCRIPTION
## Description

Add a fallback Cypress key for forks by external contributors.

Testing on a fork to check validity. 

Note, this Cypress key should generally be secret - we've created a secondary burner key (committed in this PR) that we can rotate if it gets abused.

## Notice

Before submitting a pull request, please make sure you have answered the following:

- [x] Have you followed the guidelines in our [Contributing]('https://github.com/shapeshift/web/CONTRIBUTING.md) guide?
- [x] Have you checked to ensure there aren't other open [Pull Requests](https://github.com/shapeshift/web/pulls) for the same update/change?

## Pull Request Type

- [ ] :bug: Bug fix (Non-breaking Change: Fixes an issue)
- [x] :hammer_and_wrench: Chore (Non-breaking Change: Doc updates, pkg upgrades, typos, etc..)
- [ ] :nail_care: New Feature (Breaking/Non-breaking Change)

## Issue (if applicable)

Currently, PRs into `web` from external contributors fail due to missing environment variables.

## Risk

N/A

## Testing

PRs on forks should pass expected checks.

## Screenshots (if applicable)
