### PR TITLE
chore: add fallback cypress key

### DIFF
--- a/.github/workflows/pr-cypress.yml
+++ b/.github/workflows/pr-cypress.yml
@@ -100,7 +100,7 @@ jobs:
           group: 'Chrome tests'
         env:
           CYPRESS_PROJECT_ID: 'vpyrho'
-          CYPRESS_RECORD_KEY: ${{ secrets.CYPRESS_RECORD_KEY }}
+          CYPRESS_RECORD_KEY: ${{ secrets.CYPRESS_RECORD_KEY || '05f1a79d-0c03-406b-8cf0-ca9ad10fa664' }}
           # Passing the GitHub token lets this action correctly
           # determine the unique run id necessary to re-run the checks
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}


### PR DESCRIPTION
## Description

Working with @0xApotheosis to add a fallback Cypress key for forks by external contributors. 

This PR is proof by construction that an external contributor with limited permissions can open a PR with passing tests.

## Notice

Before submitting a pull request, please make sure you have answered the following:

- [x] Have you followed the guidelines in our [Contributing]('https://github.com/shapeshift/web/CONTRIBUTING.md) guide?
- [x] Have you checked to ensure there aren't other open [Pull Requests](https://github.com/shapeshift/web/pulls) for the same update/change?

## Pull Request Type

- [ ] :bug: Bug fix (Non-breaking Change: Fixes an issue)
- [x] :hammer_and_wrench: Chore (Non-breaking Change: Doc updates, pkg upgrades, typos, etc..)
- [ ] :nail_care: New Feature (Breaking/Non-breaking Change)

## Issue (if applicable)

Closes #1136 

## Risk

N/A

## Testing

PRs on forks should pass expected checks.

## Screenshots (if applicable)

N/A
