### PR TITLE
fix: check for undefined feeAsset

### DIFF
--- a/src/components/Transactions/TransactionContract.tsx
+++ b/src/components/Transactions/TransactionContract.tsx
@@ -138,7 +138,7 @@ export const TransactionContract = ({ txDetails }: { txDetails: TxDetails }) => 
               <Row.Value>
                 <Amount.Crypto
                   value={fromBaseUnit(
-                    txDetails.tx?.fee?.value ?? '0',
+                    txDetails.tx?.fee?.value,
                     txDetails.feeAsset?.precision ?? 18
                   )}
                   symbol={txDetails.feeAsset.symbol}

--- a/src/components/Transactions/TransactionContract.tsx
+++ b/src/components/Transactions/TransactionContract.tsx
@@ -130,21 +130,23 @@ export const TransactionContract = ({ txDetails }: { txDetails: TxDetails }) => 
             </Row.Value>
           </Row>
 
-          <Row variant='vertical' hidden={!(txDetails.tx?.fee && txDetails.feeAsset)}>
-            <Row.Label>
-              <Text translation='transactionRow.fee' />
-            </Row.Label>
-            <Row.Value>
-              <Amount.Crypto
-                value={fromBaseUnit(
-                  txDetails.tx?.fee?.value ?? '0',
-                  txDetails.feeAsset?.precision ?? 18
-                )}
-                symbol={txDetails.feeAsset.symbol}
-                maximumFractionDigits={6}
-              />
-            </Row.Value>
-          </Row>
+          {txDetails.tx?.fee && txDetails.feeAsset && (
+            <Row variant='vertical'>
+              <Row.Label>
+                <Text translation='transactionRow.fee' />
+              </Row.Label>
+              <Row.Value>
+                <Amount.Crypto
+                  value={fromBaseUnit(
+                    txDetails.tx?.fee?.value ?? '0',
+                    txDetails.feeAsset?.precision ?? 18
+                  )}
+                  symbol={txDetails.feeAsset.symbol}
+                  maximumFractionDigits={6}
+                />
+              </Row.Value>
+            </Row>
+          )}
           <TransactionStatus txStatus={txDetails.tx.status} />
           {toAddress && (
             <Row variant='vertical'>

--- a/src/hooks/useTxDetails/useTxDetails.ts
+++ b/src/hooks/useTxDetails/useTxDetails.ts
@@ -112,11 +112,11 @@ export const useTxDetails = (txId: string, activeAsset?: Asset): TxDetails => {
   const symbol = standardAsset?.symbol ?? tradeAsset?.symbol ?? ''
   const precision = standardAsset?.precision ?? tradeAsset?.precision ?? 18
   const explorerTxLink =
-    standardAsset?.explorerTxLink ?? tradeAsset?.explorerTxLink ?? feeAsset.explorerTxLink ?? ''
+    standardAsset?.explorerTxLink ?? tradeAsset?.explorerTxLink ?? feeAsset?.explorerTxLink ?? ''
   const explorerAddressLink =
     standardAsset?.explorerAddressLink ??
     tradeAsset?.explorerAddressLink ??
-    feeAsset.explorerAddressLink ??
+    feeAsset?.explorerAddressLink ??
     ''
 
   return {

--- a/src/hooks/useTxDetails/useTxDetails.ts
+++ b/src/hooks/useTxDetails/useTxDetails.ts
@@ -1,11 +1,11 @@
 import { Asset, chainAdapters } from '@shapeshiftoss/types'
 import { TradeType, TxTransfer, TxType } from '@shapeshiftoss/types/dist/chain-adapters'
 import { useEffect, useState } from 'react'
-import { useSelector } from 'react-redux'
 import { ensReverseLookup } from 'lib/ens'
 import { ReduxState } from 'state/reducer'
 import { selectAssetByCAIP19, selectTxById } from 'state/slices/selectors'
 import { Tx } from 'state/slices/txHistorySlice/txHistorySlice'
+import { useAppSelector } from 'state/store'
 
 // Adding a new supported method? Also update transactionRow.parser translations accordingly
 const SUPPORTED_CONTRACT_METHODS = new Set([
@@ -25,12 +25,12 @@ enum Direction {
 
 export interface TxDetails {
   tx: Tx
-  buyTx: TxTransfer | undefined
-  sellTx: TxTransfer | undefined
-  tradeTx: TxTransfer | undefined
-  feeAsset: Asset
-  buyAsset: Asset
-  sellAsset: Asset
+  buyTx?: TxTransfer
+  sellTx?: TxTransfer
+  tradeTx?: TxTransfer
+  feeAsset?: Asset
+  buyAsset?: Asset
+  sellAsset?: Asset
   value: string
   to: string
   ensTo?: string
@@ -52,7 +52,7 @@ export const isSupportedContract = (tx: Tx) =>
   tx.data?.method ? SUPPORTED_CONTRACT_METHODS.has(tx.data?.method) : false
 
 export const useTxDetails = (txId: string, activeAsset?: Asset): TxDetails => {
-  const tx = useSelector((state: ReduxState) => selectTxById(state, txId))
+  const tx = useAppSelector((state: ReduxState) => selectTxById(state, txId))
   const method = tx.data?.method
 
   const standardTx = getStandardTx(tx)
@@ -75,18 +75,18 @@ export const useTxDetails = (txId: string, activeAsset?: Asset): TxDetails => {
 
   const tradeTx = activeAsset?.caip19 === sellTx?.caip19 ? sellTx : buyTx
 
-  const standardAsset = useSelector((state: ReduxState) =>
+  const standardAsset = useAppSelector((state: ReduxState) =>
     selectAssetByCAIP19(state, standardTx?.caip19 ?? '')
   )
 
   // stables need precision of eth (18) rather than 10
-  const feeAsset: Asset | undefined = useSelector((state: ReduxState) =>
+  const feeAsset = useAppSelector((state: ReduxState) =>
     selectAssetByCAIP19(state, tx.fee?.caip19 ?? '')
   )
-  const buyAsset: Asset | undefined = useSelector((state: ReduxState) =>
+  const buyAsset = useAppSelector((state: ReduxState) =>
     selectAssetByCAIP19(state, buyTx?.caip19 ?? '')
   )
-  const sellAsset: Asset | undefined = useSelector((state: ReduxState) =>
+  const sellAsset = useAppSelector((state: ReduxState) =>
     selectAssetByCAIP19(state, sellTx?.caip19 ?? '')
   )
   const tradeAsset = activeAsset?.symbol === sellAsset?.symbol ? sellAsset : buyAsset

--- a/src/hooks/useTxDetails/useTxDetails.ts
+++ b/src/hooks/useTxDetails/useTxDetails.ts
@@ -80,17 +80,10 @@ export const useTxDetails = (txId: string, activeAsset?: Asset): TxDetails => {
   )
 
   // stables need precision of eth (18) rather than 10
-  const feeAsset = useAppSelector((state: ReduxState) =>
-    selectAssetByCAIP19(state, tx.fee?.caip19 ?? '')
-  )
-  const buyAsset = useAppSelector((state: ReduxState) =>
-    selectAssetByCAIP19(state, buyTx?.caip19 ?? '')
-  )
-  const sellAsset = useAppSelector((state: ReduxState) =>
-    selectAssetByCAIP19(state, sellTx?.caip19 ?? '')
-  )
+  const feeAsset = useAppSelector(state => selectAssetByCAIP19(state, tx.fee?.caip19 ?? ''))
+  const buyAsset = useAppSelector(state => selectAssetByCAIP19(state, buyTx?.caip19 ?? ''))
+  const sellAsset = useAppSelector(state => selectAssetByCAIP19(state, sellTx?.caip19 ?? ''))
   const tradeAsset = activeAsset?.symbol === sellAsset?.symbol ? sellAsset : buyAsset
-
   const value = standardTx?.value ?? tradeTx?.value ?? '0'
   const to = standardTx?.to ?? tradeTx?.to ?? ''
   const from = standardTx?.from ?? tradeTx?.from ?? ''

--- a/src/hooks/useTxDetails/useTxDetails.ts
+++ b/src/hooks/useTxDetails/useTxDetails.ts
@@ -80,13 +80,13 @@ export const useTxDetails = (txId: string, activeAsset?: Asset): TxDetails => {
   )
 
   // stables need precision of eth (18) rather than 10
-  const feeAsset = useSelector((state: ReduxState) =>
+  const feeAsset: Asset | undefined = useSelector((state: ReduxState) =>
     selectAssetByCAIP19(state, tx.fee?.caip19 ?? '')
   )
-  const buyAsset = useSelector((state: ReduxState) =>
+  const buyAsset: Asset | undefined = useSelector((state: ReduxState) =>
     selectAssetByCAIP19(state, buyTx?.caip19 ?? '')
   )
-  const sellAsset = useSelector((state: ReduxState) =>
+  const sellAsset: Asset | undefined = useSelector((state: ReduxState) =>
     selectAssetByCAIP19(state, sellTx?.caip19 ?? '')
   )
   const tradeAsset = activeAsset?.symbol === sellAsset?.symbol ? sellAsset : buyAsset

--- a/src/state/slices/assetsSlice/selectors.ts
+++ b/src/state/slices/assetsSlice/selectors.ts
@@ -9,10 +9,12 @@ import { selectMarketDataIds } from 'state/slices/selectors'
 export const selectAssetByCAIP19 = createSelector(
   (state: ReduxState) => state.assets.byId,
   (_state: ReduxState, CAIP19: CAIP19) => CAIP19,
-  (byId, CAIP19) => byId[CAIP19]
+  (byId, CAIP19) => (CAIP19 !== '' ? byId[CAIP19] : undefined)
 )
 
-export const selectAssetNameById = createSelector(selectAssetByCAIP19, ({ name }) => name)
+export const selectAssetNameById = createSelector(selectAssetByCAIP19, asset =>
+  asset ? asset.name : undefined
+)
 
 export const selectAssets = (state: ReduxState) => state.assets.byId
 export const selectAssetIds = (state: ReduxState) => state.assets.ids

--- a/src/state/slices/assetsSlice/selectors.ts
+++ b/src/state/slices/assetsSlice/selectors.ts
@@ -9,7 +9,7 @@ import { selectMarketDataIds } from 'state/slices/selectors'
 export const selectAssetByCAIP19 = createSelector(
   (state: ReduxState) => state.assets.byId,
   (_state: ReduxState, CAIP19: CAIP19) => CAIP19,
-  (byId, CAIP19) => (CAIP19 !== '' ? byId[CAIP19] : undefined)
+  (byId, CAIP19) => byId[CAIP19] || undefined
 )
 
 export const selectAssetNameById = createSelector(selectAssetByCAIP19, asset =>


### PR DESCRIPTION
## Description

Fixes a bug introduced in a recent change to support unknown transaction types. 

We currently fall back to a `feeAsset`'s `explorerTxLink`s and `explorerAddressLink` for unknown transaction types but don't check for undefined `feeAsset`s.

## Notice

Before submitting a pull request, please make sure you have answered the following:

- [x] Have you followed the guidelines in our [Contributing]('https://github.com/shapeshift/web/CONTRIBUTING.md) guide?
- [x] Have you checked to ensure there aren't other open [Pull Requests](https://github.com/shapeshift/web/pulls) for the same update/change?

## Pull Request Type

- [x] :bug: Bug fix (Non-breaking Change: Fixes an issue)
- [ ] :hammer_and_wrench: Chore (Non-breaking Change: Doc updates, pkg upgrades, typos, etc..)
- [ ] :nail_care: New Feature (Breaking/Non-breaking Change)

## Issue (if applicable)

N/A

## Risk

N/A

## Testing

Rendering an unknown transaction without a `standardAsset` or `tradeAsset` should no longer throw.

## Screenshots (if applicable)

N/A
