### PR TITLE
fix: fallback to address on ENS timeout

### DIFF
--- a/src/components/Layout/Header/NavBar/UserMenu.tsx
+++ b/src/components/Layout/Header/NavBar/UserMenu.tsx
@@ -91,22 +91,25 @@ const WalletButton: FC<WalletButtonProps> = ({
   const bgColor = useColorModeValue('gray.300', 'gray.800')
 
   useEffect(() => {
-    setShouldShorten(true)
-    if (!walletInfo || !walletInfo.meta) return setWalletLabel('')
-    if (walletInfo.meta.address) {
-      ensReverseLookup(walletInfo.meta.address).then(ens => {
-        if (!ens.error) {
-          setShouldShorten(false)
-          return setWalletLabel(ens.name)
+    ;(async () => {
+      setShouldShorten(true)
+      if (!walletInfo || !walletInfo.meta) return setWalletLabel('')
+      if (walletInfo.meta.address) {
+        try {
+          const addressReverseLookup = await ensReverseLookup(walletInfo.meta.address)
+          if (!addressReverseLookup.error) {
+            setShouldShorten(false)
+            return setWalletLabel(addressReverseLookup.name)
+          }
+        } catch (_) {
+          return setWalletLabel(walletInfo?.meta?.address ?? '')
         }
-        setWalletLabel(walletInfo?.meta?.address ?? '')
-      })
-      return
-    }
-    if (walletInfo.meta.label) {
-      setShouldShorten(false)
-      return setWalletLabel(walletInfo.meta.label)
-    }
+      }
+      if (walletInfo.meta.label) {
+        setShouldShorten(false)
+        return setWalletLabel(walletInfo.meta.label)
+      }
+    })()
   }, [walletInfo])
 
   return Boolean(walletInfo?.deviceId) || isLoadingLocalWallet ? (


### PR DESCRIPTION
## Description

Spotted while offline. When trying to get the reverse resolution for an address, ENS will timeout when offline and we do not gracefully handle this, the User Menu just shows "Metamask" (I didn't test it with other wallets):

<img width="190" alt="image" src="https://user-images.githubusercontent.com/17035424/156891160-f4c75d58-0584-467e-8d33-4af2e1b8a7a6.png">


Now, we don't have offline capabilities in the app to the extent that this fix would be useful when offline, but it's nice to know that any timeout to ENS reverse lookups - for any reason - will be gracefully handled.

## Notice

Before submitting a pull request, please make sure you have answered the following:

- [ ] Have you followed the guidelines in our [Contributing]('https://github.com/shapeshift/web/CONTRIBUTING.md) guide?
- [x] Have you checked to ensure there aren't other open [Pull Requests](https://github.com/shapeshift/web/pulls) for the same update/change?

## Pull Request Type

- [x] :bug: Bug fix (Non-breaking Change: Fixes an issue)
- [ ] :hammer_and_wrench: Chore (Non-breaking Change: Doc updates, pkg upgrades, typos, etc..)
- [ ] :nail_care: New Feature (Breaking/Non-breaking Change)

## Issue (if applicable)

N/A

## Risk

We should do some regression testing to make sure that the user menu doesn't break in other circumstances because of this. 

## Testing

- Go offline
- Run the app and connect to your wallet
- Current account's address should be displayed 

## Screenshots (if applicable)

<img width="208" alt="image" src="https://user-images.githubusercontent.com/17035424/156891149-3cea43b7-ffc3-44a1-84e2-36ca93d3211b.png">
