### PR TITLE
feat: add back dashboard sidebar and fix sizing

### DIFF
--- a/src/components/Layout/Header/NavBar/MainNavLink.tsx
+++ b/src/components/Layout/Header/NavBar/MainNavLink.tsx
@@ -1,43 +1,48 @@
-import { Button, IconButtonProps } from '@chakra-ui/react'
+import { Box, Button, ButtonProps, forwardRef, useMediaQuery } from '@chakra-ui/react'
 import { memo } from 'react'
-import { Link as ReactRouterLink, NavLinkProps, useLocation } from 'react-router-dom'
+import { NavLinkProps, useLocation } from 'react-router-dom'
+import { breakpoints } from 'theme/theme'
 
 type SidebarLinkProps = {
-  icon?: React.ReactElement
-  href: string
+  href?: string
   label: string
   children?: React.ReactNode
-} & NavLinkProps &
-  IconButtonProps
+  to?: NavLinkProps['to']
+  isCompact?: boolean
+} & ButtonProps
 
-export const MainNavLink = memo((props: SidebarLinkProps) => {
-  const { href, icon, label } = props
-  const location = useLocation()
-  const active = location?.pathname.includes(href ?? '')
-  return (
-    <Button
-      as={ReactRouterLink}
-      {...props}
-      leftIcon={icon}
-      width='full'
-      justifyContent='flex-start'
-      variant='ghost'
-      isActive={active}
-    >
-      {label}
-    </Button>
-    // <Tooltip label={label} fontSize='md' px={4} hasArrow>
-    //   <IconButton
-    //     icon={icon}
-    //     as={ReactRouterLink}
-    //     rounded='full'
-    //     isActive={active}
-    //     _active={{
-    //       bg: 'blue.500',
-    //       color: 'white'
-    //     }}
-    //     {...props}
-    //   />
-    // </Tooltip>
-  )
-})
+export const MainNavLink = memo(
+  forwardRef<SidebarLinkProps, 'div'>((props: SidebarLinkProps, ref) => {
+    const { href, label } = props
+    const [isLargerThan2xl] = useMediaQuery(`(min-width: ${breakpoints['2xl']})`)
+    const location = useLocation()
+    const active = location?.pathname.includes(href ?? '')
+    return (
+      <Button
+        width='full'
+        justifyContent='flex-start'
+        variant='ghost'
+        isActive={href ? active : false}
+        minWidth={props?.isCompact ? 'auto' : 10}
+        iconSpacing={isLargerThan2xl ? 4 : props?.isCompact ? 0 : 4}
+        ref={ref}
+        {...props}
+      >
+        <Box display={{ base: props?.isCompact ? 'none' : 'flex', '2xl': 'block' }}>{label}</Box>
+      </Button>
+      // <Tooltip label={label} fontSize='md' px={4} hasArrow>
+      //   <IconButton
+      //     icon={icon}
+      //     as={ReactRouterLink}
+      //     rounded='full'
+      //     isActive={active}
+      //     _active={{
+      //       bg: 'blue.500',
+      //       color: 'white'
+      //     }}
+      //     {...props}
+      //   />
+      // </Tooltip>
+    )
+  })
+)

--- a/src/components/Layout/Header/NavBar/MainNavLink.tsx
+++ b/src/components/Layout/Header/NavBar/MainNavLink.tsx
@@ -30,19 +30,6 @@ export const MainNavLink = memo(
       >
         <Box display={{ base: props?.isCompact ? 'none' : 'flex', '2xl': 'block' }}>{label}</Box>
       </Button>
-      // <Tooltip label={label} fontSize='md' px={4} hasArrow>
-      //   <IconButton
-      //     icon={icon}
-      //     as={ReactRouterLink}
-      //     rounded='full'
-      //     isActive={active}
-      //     _active={{
-      //       bg: 'blue.500',
-      //       color: 'white'
-      //     }}
-      //     {...props}
-      //   />
-      // </Tooltip>
     )
   })
 )

--- a/src/components/Layout/Header/NavBar/NavBar.tsx
+++ b/src/components/Layout/Header/NavBar/NavBar.tsx
@@ -2,21 +2,29 @@ import { Stack, StackProps } from '@chakra-ui/react'
 import union from 'lodash/union'
 import { pluginManager } from 'plugins'
 import { useTranslate } from 'react-polyglot'
+import { Link as ReactRouterLink } from 'react-router-dom'
 import { routes } from 'Routes/Routes'
 
 import { MainNavLink } from './MainNavLink'
-export const NavBar = (props: StackProps) => {
+
+type NavBarProps = {
+  isCompact?: boolean
+} & StackProps
+
+export const NavBar = ({ isCompact, ...rest }: NavBarProps) => {
   const translate = useTranslate()
 
   return (
-    <Stack width='full' flex='1 1 0%' {...props}>
+    <Stack width='full' flex='1 1 0%' {...rest}>
       {union(routes, pluginManager.getRoutes())
         .filter(route => !route.disable && !route.hide)
         .map((item, idx) => {
           return (
             <MainNavLink
+              as={ReactRouterLink}
               key={idx}
-              icon={item.icon}
+              leftIcon={item.icon}
+              isCompact={isCompact}
               href={item.path}
               to={item.path}
               label={translate(item.label)}

--- a/src/components/Layout/Header/SideNav.tsx
+++ b/src/components/Layout/Header/SideNav.tsx
@@ -23,10 +23,10 @@ export const SideNav = ({ route }: { route: Route }) => {
         position='sticky'
         top='4.5rem'
         maxWidth='xs'
-        flex='1 1 0%'
+        flex={{ base: 'inherit', '2xl': '1 1 0%' }}
         display={{ base: 'none', md: 'flex' }}
       >
-        <SideNavContent route={route} />
+        <SideNavContent route={route} isCompact={true} />
       </chakra.header>
     </>
   )

--- a/src/components/Layout/Header/SideNavContent.tsx
+++ b/src/components/Layout/Header/SideNavContent.tsx
@@ -1,30 +1,36 @@
 import { ChatIcon, SunIcon } from '@chakra-ui/icons'
 import {
   Box,
-  Button,
   Flex,
   FlexProps,
   HStack,
   Link,
   Stack,
   useColorMode,
-  useColorModeValue
+  useColorModeValue,
+  useMediaQuery
 } from '@chakra-ui/react'
 import { FaMoon } from 'react-icons/fa'
+import { useTranslate } from 'react-polyglot'
 import { Link as RouterLink } from 'react-router-dom'
 import { Route } from 'Routes/helpers'
 import { RawText, Text } from 'components/Text'
+import { breakpoints } from 'theme/theme'
 
 import { AutoCompleteSearch } from './AutoCompleteSearch/AutoCompleteSearch'
+import { MainNavLink } from './NavBar/MainNavLink'
 import { NavBar } from './NavBar/NavBar'
 import { UserMenu } from './NavBar/UserMenu'
 
 type HeaderContentProps = {
   route: Route
+  isCompact?: boolean
 } & FlexProps
 
-export const SideNavContent = ({ route }: HeaderContentProps) => {
+export const SideNavContent = ({ route, isCompact }: HeaderContentProps) => {
   const { toggleColorMode } = useColorMode()
+  const translate = useTranslate()
+  const [isLargerThanMd] = useMediaQuery(`(min-width: ${breakpoints['md']})`)
   const isActive = useColorModeValue(false, true)
   return (
     <Flex
@@ -36,34 +42,44 @@ export const SideNavContent = ({ route }: HeaderContentProps) => {
       flexDir='column'
       p={4}
     >
-      <Flex width='full' display={{ base: 'block', md: 'none' }}>
-        <UserMenu />
-      </Flex>
-      <Box mt={12} width='full' display={{ base: 'block', md: 'none' }}>
-        <AutoCompleteSearch />
-      </Box>
-      <NavBar mt={6} />
+      {!isLargerThanMd && (
+        <>
+          <Flex width='full'>
+            <UserMenu />
+          </Flex>
+          <Box mt={12} width='full'>
+            <AutoCompleteSearch />
+          </Box>
+        </>
+      )}
+
+      <NavBar isCompact={isCompact} mt={6} />
       <Stack width='full'>
-        <Button
+        <MainNavLink
           variant='ghost'
-          isFullWidth
+          isCompact={isCompact}
           onClick={toggleColorMode}
-          justifyContent='space-between'
+          label={translate(isActive ? 'common.lightTheme' : 'common.darkTheme')}
           leftIcon={isActive ? <SunIcon /> : <FaMoon />}
-        >
-          <Text mr='auto' translation={isActive ? 'common.lightTheme' : 'common.darkTheme'} />
-        </Button>
-        <Button
+        />
+        <MainNavLink
           leftIcon={<ChatIcon />}
           as={Link}
+          isCompact={isCompact}
           justifyContent='flex-start'
           variant='ghost'
+          label={translate('common.submitFeedback')}
           isExternal
           href='https://shapeshift.notion.site/Submit-Feedback-or-a-Feature-Request-af48a25fea574da4a05a980c347c055b'
+        />
+        <HStack
+          display={{ base: 'none', '2xl': 'flex' }}
+          divider={<RawText mx={1}>•</RawText>}
+          fontSize='sm'
+          px={4}
+          mt={4}
+          color='gray.500'
         >
-          <Text translation='common.submitFeedback' />
-        </Button>
-        <HStack divider={<RawText mx={1}>•</RawText>} fontSize='sm' px={4} mt={4} color='gray.500'>
           <Link as={RouterLink} justifyContent='flex-start' to='/legal/terms-of-service'>
             <Text translation='common.terms' />
           </Link>

--- a/src/pages/Dashboard/Dashboard.tsx
+++ b/src/pages/Dashboard/Dashboard.tsx
@@ -1,15 +1,30 @@
+import { Stack } from '@chakra-ui/react'
+import { Route } from 'Routes/helpers'
 import { Main } from 'components/Layout/Main'
 
+import { DashboardSidebar } from './DashboardSidebar'
 import { Portfolio } from './Portfolio'
 
 export type MatchParams = {
   assetId: string
 }
 
-export const Dashboard = () => {
+export const Dashboard = ({ route }: { route?: Route }) => {
   return (
-    <Main>
-      <Portfolio />
+    <Main route={route}>
+      <Stack
+        alignItems='flex-start'
+        spacing={4}
+        mx='auto'
+        direction={{ base: 'column', xl: 'row' }}
+      >
+        <Stack spacing={4} flex='1 1 0%' width='full'>
+          <Portfolio />
+        </Stack>
+        <Stack flex='1 1 0%' width='full' maxWidth={{ base: 'full', xl: 'sm' }} spacing={4}>
+          <DashboardSidebar />
+        </Stack>
+      </Stack>
     </Main>
   )
 }

--- a/src/pages/Dashboard/Portfolio.tsx
+++ b/src/pages/Dashboard/Portfolio.tsx
@@ -25,7 +25,7 @@ export const Portfolio = () => {
   const isLoaded = !loading
 
   return (
-    <Stack spacing={6} width='full' pt={{ base: 0, lg: 4 }} pr={{ base: 0, lg: 4 }}>
+    <Stack spacing={6} width='full'>
       <Card variant='footer-stub'>
         <Card.Header
           display='flex'

--- a/src/theme/theme.ts
+++ b/src/theme/theme.ts
@@ -28,7 +28,7 @@ export const breakpoints = createBreakpoints({
   md: '768px',
   lg: '992px',
   xl: '1280px',
-  '2xl': '1920px'
+  '2xl': '1440px'
 })
 
 const styles = {


### PR DESCRIPTION
## Description

- Added back the dashboard sidebar component
- Made the side nav all use the same component to streamline styling
- Navbar now goes compact on a specific screen size to give the main component more real estate

## Notice

Before submitting a pull request, please make sure you have answered the following:

- [x] Have you followed the guidelines in our [Contributing]('https://github.com/shapeshift/web/CONTRIBUTING.md) guide?
- [x] Have you checked to ensure there aren't other open [Pull Requests](https://github.com/shapeshift/web/pulls) for the same update/change?

## Pull Request Type

- [ ] :bug: Bug fix (Non-breaking Change: Fixes an issue)
- [ ] :hammer_and_wrench: Chore (Non-breaking Change: Doc updates, pkg upgrades, typos, etc..)
- [x] :nail_care: New Feature (Breaking/Non-breaking Change)

## Issue (if applicable)

closes #1150 

## Risk

Very low risk here, just styling fixes

## Testing

Test on large desktop, small desktop and mobile make sure all looks well.

## Screenshots (if applicable)
![Screen Shot 2022-03-08 at 11 20 34 AM](https://user-images.githubusercontent.com/89934888/157291154-9e0cdcad-5f4e-4c9f-8c91-ef1f416dce65.png)

