### PR TITLE
feat: cosmos UI for claiming rewards

### DIFF
--- a/src/assets/translations/messages-en.json
+++ b/src/assets/translations/messages-en.json
@@ -143,6 +143,7 @@
     "unstake": "Unstake",
     "stakeAsset": "Stake %{assetSymbol}",
     "unstakeAsset": "Unstake %{assetSymbol}",
+    "claimAsset": "Claim rewards",
     "claim": "Claim",
     "rewards": "Rewards",
     "unstaking": "Unstaking",

--- a/src/assets/translations/messages-en.json
+++ b/src/assets/translations/messages-en.json
@@ -124,6 +124,13 @@
           "validator": "The Validator is responsible for processing transactions, storing data and adding blocks to the blockchain.",
           "gasFees": "Gas fees on %{networkName} are much lower than those on Ethereum Mainnet. This fee is paid directly to the validators that secure and operate the network and is not paid to ShapeShift."
         }
+      },
+      "claim": {
+        "rewardDepositInfo": "Your rewards will be deposited into your primary wallet.",
+        "title": "Claim Staking Rewards",
+        "confirmAndClaim": "Confirm & Claim",
+        "rewardAmount": "Reward Amount",
+        "claimingRewards": "Claiming Rewards"
       }
     },
     "amountToStake": "Amount to Stake",
@@ -143,7 +150,7 @@
     "unstake": "Unstake",
     "stakeAsset": "Stake %{assetSymbol}",
     "unstakeAsset": "Unstake %{assetSymbol}",
-    "claimAsset": "Claim rewards",
+    "claimAsset": "Claim Staking Rewards",
     "claim": "Claim",
     "rewards": "Rewards",
     "unstaking": "Unstaking",

--- a/src/components/RouteSteps/RouteSteps.tsx
+++ b/src/components/RouteSteps/RouteSteps.tsx
@@ -50,7 +50,13 @@ export const RouteSteps = ({
       {...styleProps}
     >
       {assetSymbol && action && (
-        <Text mb={30} fontWeight='bold' translation={[`defi.${action}Asset`, { assetSymbol }]} />
+        <Text
+          my={10}
+          fontSize='lg'
+          fontWeight='semibold'
+          textAlign='center'
+          translation={[`defi.${action}Asset`, { assetSymbol }]}
+        />
       )}
       <VerticalStepper activeStep={activeStep?.step || 0} steps={steps} />
     </Box>

--- a/src/plugins/cosmos/components/ClaimButton/ClaimButton.tsx
+++ b/src/plugins/cosmos/components/ClaimButton/ClaimButton.tsx
@@ -1,0 +1,24 @@
+import { FlexProps } from '@chakra-ui/layout'
+import { Button } from '@chakra-ui/react'
+import { CAIP19 } from '@shapeshiftoss/caip'
+import { StakingAction } from 'plugins/cosmos/components/modals/Staking/Staking'
+import { Text } from 'components/Text'
+import { useModal } from 'context/ModalProvider/ModalProvider'
+
+type ClaimButtonProps = {
+  assetId: CAIP19
+}
+
+export const ClaimButton = ({ assetId }: ClaimButtonProps & FlexProps) => {
+  const { cosmosStaking } = useModal()
+
+  const handleClaimClick = () => {
+    cosmosStaking.open({ assetId, action: StakingAction.Claim })
+  }
+
+  return (
+    <Button onClick={handleClaimClick} width='100%' colorScheme='green'>
+      <Text translation={'defi.claim'} color='green' fontWeight='bold' />
+    </Button>
+  )
+}

--- a/src/plugins/cosmos/components/modals/Staking/Staking.tsx
+++ b/src/plugins/cosmos/components/modals/Staking/Staking.tsx
@@ -3,7 +3,9 @@ import { CAIP19 } from '@shapeshiftoss/caip'
 import { useRef } from 'react'
 import { matchPath, MemoryRouter, Route, Switch, useHistory, useLocation } from 'react-router-dom'
 import { useModal } from 'context/ModalProvider/ModalProvider'
+import { bnOrZero } from 'lib/bignumber/bignumber'
 
+import { ClaimConfirmRouter } from './views/ClaimConfirmRouter'
 import { Overview } from './views/Overview'
 import { Stake } from './views/Stake'
 import { StakeConfirmRouter, StakingConfirmProps } from './views/StakeConfirmRouter'
@@ -13,7 +15,8 @@ import { UnstakeConfirmRouter } from './views/UnstakeConfirmRouter'
 export enum StakingAction {
   Stake = 'stake',
   Unstake = 'unstake',
-  Overview = 'overview'
+  Overview = 'overview',
+  Claim = 'claim'
 }
 
 type StakingModalProps = {
@@ -26,7 +29,8 @@ export enum StakeRoutes {
   Unstake = '/unstake',
   StakeConfirm = '/stake/confirm',
   UnstakeConfirm = '/unstake/confirm',
-  Overview = '/stake/overview'
+  Overview = '/stake/overview',
+  Claim = '/claim'
 }
 
 export const entries = [
@@ -118,6 +122,19 @@ const StakingModalContent = ({ assetId, action }: StakingModalProps) => {
         <Route path='/'>
           <Overview assetId={assetId} />
         </Route>
+      )
+
+    if (action === StakingAction.Claim)
+      return (
+        <>
+          <Route exact path={StakeRoutes.Stake}>
+            <ClaimConfirmRouter
+              cryptoAmount={bnOrZero('4242')}
+              assetId={assetId}
+              onCancel={handleCancel}
+            />
+          </Route>
+        </>
       )
   }
 

--- a/src/plugins/cosmos/components/modals/Staking/Staking.tsx
+++ b/src/plugins/cosmos/components/modals/Staking/Staking.tsx
@@ -129,9 +129,9 @@ const StakingModalContent = ({ assetId, action }: StakingModalProps) => {
         <>
           <Route exact path={StakeRoutes.Stake}>
             <ClaimConfirmRouter
-              cryptoAmount={bnOrZero('4242')}
+              cryptoAmount={bnOrZero('0.04123')}
+              fiatAmountAvailable='0.2365'
               assetId={assetId}
-              onCancel={handleCancel}
             />
           </Route>
         </>

--- a/src/plugins/cosmos/components/modals/Staking/views/ClaimBroadcast.tsx
+++ b/src/plugins/cosmos/components/modals/Staking/views/ClaimBroadcast.tsx
@@ -1,0 +1,129 @@
+import { InfoOutlineIcon } from '@chakra-ui/icons'
+import { Flex } from '@chakra-ui/layout'
+import { Button, Link, ModalCloseButton, Text as CText, Tooltip } from '@chakra-ui/react'
+import { CAIP19 } from '@shapeshiftoss/caip'
+import { Asset } from '@shapeshiftoss/types'
+import { chainAdapters } from '@shapeshiftoss/types'
+import { useTranslate } from 'react-polyglot'
+import { Amount } from 'components/Amount/Amount'
+import { MiddleEllipsis } from 'components/MiddleEllipsis/MiddleEllipsis'
+import { SlideTransition } from 'components/SlideTransition'
+import { Text } from 'components/Text'
+import { useModal } from 'context/ModalProvider/ModalProvider'
+import { BigNumber } from 'lib/bignumber/bignumber'
+
+type ClaimBroadcastProps = {
+  assetId: CAIP19
+  cryptoStakeAmount: BigNumber
+  fiatAmountAvailable: string
+  isLoading: boolean
+}
+
+export enum Field {
+  FeeType = 'feeType'
+}
+
+export type ClaimBroadcastParams = {
+  [Field.FeeType]: chainAdapters.FeeDataKey
+}
+
+// TODO: Wire up the whole component with staked data
+export const ClaimBroadcast = ({
+  assetId,
+  cryptoStakeAmount,
+  fiatAmountAvailable,
+  isLoading
+}: ClaimBroadcastProps) => {
+  const { cosmosStaking } = useModal()
+
+  const translate = useTranslate()
+
+  const handleClose = () => {
+    cosmosStaking.close()
+  }
+
+  // TODO: wire me up, parentheses are nice but let's get asset name from selectAssetNameById instead of this
+  const asset = (_ => ({
+    name: 'Osmosis',
+    symbol: 'OSMO',
+    caip19: assetId,
+    chain: 'osmosis'
+  }))(assetId) as Asset
+  const txDetails = {
+    explorerTxLink: 'https://etherscan.io/tx/',
+    tx: {
+      txid: '42foobar42'
+    }
+  }
+  return (
+    <SlideTransition>
+      <ModalCloseButton borderRadius='full' />
+      <Flex
+        as='form'
+        pt='14px'
+        pb='18px'
+        px='30px'
+        flexDirection='column'
+        alignItems='center'
+        justifyContent='space-between'
+      >
+        <Flex width='100%' mb='20px' justifyContent='space-between'>
+          <Text color='gray.500' translation={'defi.modals.claim.rewardAmount'} />
+          <Flex flexDirection='column' alignItems='flex-end'>
+            <Amount.Fiat fontWeight='semibold' value={fiatAmountAvailable} />
+            <Amount.Crypto
+              color='gray.500'
+              value={cryptoStakeAmount.toPrecision()}
+              symbol={asset.symbol}
+            />
+          </Flex>
+        </Flex>
+
+        <Flex width='100%' mb='35px' justifyContent='space-between'>
+          <Text translation={'transactionRow.txid'} color='gray.500' />
+          <Link
+            isExternal
+            color='blue.300'
+            href={`${txDetails.explorerTxLink}${txDetails.tx.txid}`}
+          >
+            <MiddleEllipsis address={txDetails.tx.txid} />
+          </Link>
+        </Flex>
+
+        <Flex mb='6px' mt='6px' width='100%' justifyContent='space-between'>
+          <CText display='inline-flex' alignItems='center' color='gray.500'>
+            {translate('defi.gasFee')}
+            &nbsp;
+            <Tooltip
+              label={translate('defi.modals.staking.tooltip.gasFees', {
+                networkName: asset.name
+              })}
+            >
+              <InfoOutlineIcon />
+            </Tooltip>
+          </CText>
+          <Flex flexDirection='column' alignItems='flex-end'>
+            <Amount.Fiat value={'0.01'} />
+            <Amount.Crypto value='0.0005' symbol={asset.symbol} color='gray.500' />
+          </Flex>
+        </Flex>
+
+        <Flex width='100%' flexDirection='column' alignItems='flex-end'>
+          <Button
+            isLoading={isLoading}
+            onClick={handleClose}
+            loadingText={translate('defi.modals.claim.claimingRewards')}
+            colorScheme={'blue'}
+            minWidth='150px'
+            mb='10px'
+            mt='25px'
+            size='lg'
+            type='submit'
+          >
+            <Text translation={'modals.status.close'} />
+          </Button>
+        </Flex>
+      </Flex>
+    </SlideTransition>
+  )
+}

--- a/src/plugins/cosmos/components/modals/Staking/views/ClaimConfirm.tsx
+++ b/src/plugins/cosmos/components/modals/Staking/views/ClaimConfirm.tsx
@@ -1,0 +1,129 @@
+import { InfoOutlineIcon } from '@chakra-ui/icons'
+import { Flex } from '@chakra-ui/layout'
+import { Button, FormControl, ModalHeader, Text as CText, Tooltip } from '@chakra-ui/react'
+import { CAIP19 } from '@shapeshiftoss/caip'
+import { chainAdapters } from '@shapeshiftoss/types'
+import { Asset } from '@shapeshiftoss/types'
+import { TxFeeRadioGroup } from 'plugins/cosmos/components/TxFeeRadioGroup/TxFeeRadioGroup'
+import { FormProvider, useForm } from 'react-hook-form'
+import { useTranslate } from 'react-polyglot'
+import { useHistory } from 'react-router-dom'
+import { Amount } from 'components/Amount/Amount'
+import { SlideTransition } from 'components/SlideTransition'
+import { Text } from 'components/Text'
+import { BigNumber } from 'lib/bignumber/bignumber'
+
+import { StakingPath } from './StakeConfirmRouter'
+
+export enum InputType {
+  Crypto = 'crypto',
+  Fiat = 'fiat'
+}
+
+export enum Field {
+  FeeType = 'feeType'
+}
+
+export type StakingValues = {
+  [Field.FeeType]: chainAdapters.FeeDataKey
+}
+
+type ClaimConfirmProps = {
+  assetId: CAIP19
+  cryptoStakeAmount: BigNumber
+  onCancel: () => void
+}
+
+// TODO: Wire up the whole component with staked data
+export const ClaimConfirm = ({ assetId, cryptoStakeAmount, onCancel }: ClaimConfirmProps) => {
+  const methods = useForm<StakingValues>({
+    mode: 'onChange',
+    defaultValues: {
+      [Field.FeeType]: chainAdapters.FeeDataKey.Average
+    }
+  })
+
+  const { handleSubmit } = methods
+
+  const memoryHistory = useHistory()
+  const onSubmit = (_: any) => {
+    memoryHistory.push(StakingPath.Broadcast)
+  }
+
+  const translate = useTranslate()
+
+  // TODO: wire me up, parentheses are nice but let's get asset name from selectAssetNameById instead of this
+  const asset = (_ => ({
+    name: 'Osmosis',
+    symbol: 'OSMO',
+    caip19: assetId,
+    chain: 'osmosis'
+  }))(assetId) as Asset
+  return (
+    <FormProvider {...methods}>
+      <SlideTransition>
+        <Flex
+          as='form'
+          pt='14px'
+          pb='18px'
+          px='30px'
+          onSubmit={handleSubmit(onSubmit)}
+          direction='column'
+          alignItems='center'
+          justifyContent='space-between'
+        >
+          <ModalHeader textAlign='center'>{translate('defi.confirmDetails')}</ModalHeader>
+          <Flex width='100%' mb='20px' justifyContent='space-between'>
+            <Text color='gray.500' translation={'defi.stake'} />
+            <Flex direction='column' alignItems='flex-end'>
+              <Amount.Crypto
+                color='gray.500'
+                value={cryptoStakeAmount.toPrecision()}
+                symbol={asset.symbol}
+              />
+            </Flex>
+          </Flex>
+          <Flex mb='6px' width='100%'>
+            <CText display='inline-flex' alignItems='center' color='gray.500'>
+              {translate('defi.gasFee')}
+              &nbsp;
+              <Tooltip
+                label={translate('defi.modals.staking.tooltip.gasFees', {
+                  networkName: asset.name
+                })}
+              >
+                <InfoOutlineIcon />
+              </Tooltip>
+            </CText>
+          </Flex>
+          <FormControl>
+            <TxFeeRadioGroup
+              asset={asset}
+              mb='10px'
+              fees={{
+                slow: {
+                  txFee: '0.004',
+                  fiatFee: '0.1'
+                },
+                average: {
+                  txFee: '0.008',
+                  fiatFee: '0.2'
+                },
+                fast: {
+                  txFee: '0.012',
+                  fiatFee: '0.3'
+                }
+              }}
+            />
+          </FormControl>
+          <Button colorScheme={'blue'} mb={2} size='lg' type='submit' width='full'>
+            <Text translation={'defi.confirmAndBroadcast'} />
+          </Button>
+          <Button onClick={onCancel} size='lg' variant='ghost' width='full'>
+            <Text translation='common.cancel' />
+          </Button>
+        </Flex>
+      </SlideTransition>
+    </FormProvider>
+  )
+}

--- a/src/plugins/cosmos/components/modals/Staking/views/ClaimConfirmRouter.tsx
+++ b/src/plugins/cosmos/components/modals/Staking/views/ClaimConfirmRouter.tsx
@@ -7,12 +7,13 @@ import { SlideTransition } from 'components/SlideTransition'
 import { BigNumber } from 'lib/bignumber/bignumber'
 
 import { StakingAction } from '../Staking'
+import { ClaimBroadcast } from './ClaimBroadcast'
 import { ClaimConfirm } from './ClaimConfirm'
 
 export type ClaimConfirmProps = {
   cryptoAmount: BigNumber
+  fiatAmountAvailable: string
   assetId: CAIP19
-  onCancel: () => void
 }
 
 export enum ClaimPath {
@@ -21,11 +22,11 @@ export enum ClaimPath {
 }
 
 export const claimConfirmRoutes = [
-  { step: 0, path: ClaimPath.Confirm, label: 'Confirm Details' },
-  { step: 1, path: ClaimPath.Broadcast, label: 'Broadcast TX' }
+  { step: 0, path: ClaimPath.Confirm, label: 'Confirm' },
+  { step: 1, path: ClaimPath.Broadcast, label: 'Broadcast' }
 ]
 
-const CosmosClaimRouter = ({ cryptoAmount, onCancel, assetId }: ClaimConfirmProps) => {
+const CosmosClaimRouter = ({ cryptoAmount, fiatAmountAvailable, assetId }: ClaimConfirmProps) => {
   const location = useLocation<ClaimConfirmProps>()
 
   // TODO: wire me up, parentheses are nice but let's get asset name from selectAssetNameById instead of this
@@ -38,33 +39,30 @@ const CosmosClaimRouter = ({ cryptoAmount, onCancel, assetId }: ClaimConfirmProp
   return (
     <SlideTransition>
       <Switch location={location} key={location.key}>
-        <Flex minWidth={{ base: '100%', xl: '500px' }} flexDir={{ base: 'column', lg: 'row' }}>
+        <Flex minWidth={{ base: '100%', xl: '450px' }} flexDirection='column'>
           <RouteSteps
             assetSymbol={asset.symbol}
             action={StakingAction.Claim}
-            px={23}
-            py={43}
             routes={claimConfirmRoutes}
             location={location}
+            px={{ sm: '120px' }}
           />
-          <Flex
-            flexDir='column'
-            width='full'
-            minWidth={{ base: 'auto', lg: '450px' }}
-            maxWidth={{ base: 'auto', lg: '450px' }}
-          >
-            <Flex direction='column' minWidth='400px'>
-              <Route exact key={ClaimPath.Confirm} path={ClaimPath.Confirm}>
-                <ClaimConfirm
-                  cryptoStakeAmount={cryptoAmount}
-                  assetId={assetId}
-                  onCancel={onCancel}
-                />
-              </Route>
-              <Route exact key={ClaimPath.Broadcast} path={ClaimPath.Broadcast}>
-                TODO Claim Broadcast component
-              </Route>
-            </Flex>
+          <Flex direction='column' minWidth='450px'>
+            <Route exact key={ClaimPath.Confirm} path={ClaimPath.Confirm}>
+              <ClaimConfirm
+                cryptoStakeAmount={cryptoAmount}
+                fiatAmountAvailable={fiatAmountAvailable}
+                assetId={assetId}
+              />
+            </Route>
+            <Route exact key={ClaimPath.Broadcast} path={ClaimPath.Broadcast}>
+              <ClaimBroadcast
+                cryptoStakeAmount={cryptoAmount}
+                fiatAmountAvailable={fiatAmountAvailable}
+                assetId={assetId}
+                isLoading={true}
+              />
+            </Route>
           </Flex>
         </Flex>
       </Switch>

--- a/src/plugins/cosmos/components/modals/Staking/views/ClaimConfirmRouter.tsx
+++ b/src/plugins/cosmos/components/modals/Staking/views/ClaimConfirmRouter.tsx
@@ -1,0 +1,85 @@
+import { Flex } from '@chakra-ui/layout'
+import { CAIP19 } from '@shapeshiftoss/caip'
+import { Asset } from '@shapeshiftoss/types'
+import { MemoryRouter, Route, Switch, useLocation } from 'react-router-dom'
+import { RouteSteps } from 'components/RouteSteps/RouteSteps'
+import { SlideTransition } from 'components/SlideTransition'
+import { BigNumber } from 'lib/bignumber/bignumber'
+
+import { StakingAction } from '../Staking'
+import { ClaimConfirm } from './ClaimConfirm'
+
+export type ClaimConfirmProps = {
+  cryptoAmount: BigNumber
+  assetId: CAIP19
+  onCancel: () => void
+}
+
+export enum ClaimPath {
+  Confirm = '/claim/confirm',
+  Broadcast = '/claim/broadcast'
+}
+
+export const claimConfirmRoutes = [
+  { step: 0, path: ClaimPath.Confirm, label: 'Confirm Details' },
+  { step: 1, path: ClaimPath.Broadcast, label: 'Broadcast TX' }
+]
+
+const CosmosClaimRouter = ({ cryptoAmount, onCancel, assetId }: ClaimConfirmProps) => {
+  const location = useLocation<ClaimConfirmProps>()
+
+  // TODO: wire me up, parentheses are nice but let's get asset name from selectAssetNameById instead of this
+  const asset = (_ => ({
+    name: 'Osmosis',
+    symbol: 'OSMO',
+    caip19: assetId
+  }))(assetId) as Asset
+
+  return (
+    <SlideTransition>
+      <Switch location={location} key={location.key}>
+        <Flex minWidth={{ base: '100%', xl: '500px' }} flexDir={{ base: 'column', lg: 'row' }}>
+          <RouteSteps
+            assetSymbol={asset.symbol}
+            action={StakingAction.Claim}
+            px={23}
+            py={43}
+            routes={claimConfirmRoutes}
+            location={location}
+          />
+          <Flex
+            flexDir='column'
+            width='full'
+            minWidth={{ base: 'auto', lg: '450px' }}
+            maxWidth={{ base: 'auto', lg: '450px' }}
+          >
+            <Flex direction='column' minWidth='400px'>
+              <Route exact key={ClaimPath.Confirm} path={ClaimPath.Confirm}>
+                <ClaimConfirm
+                  cryptoStakeAmount={cryptoAmount}
+                  assetId={assetId}
+                  onCancel={onCancel}
+                />
+              </Route>
+              <Route exact key={ClaimPath.Broadcast} path={ClaimPath.Broadcast}>
+                TODO Claim Broadcast component
+              </Route>
+            </Flex>
+          </Flex>
+        </Flex>
+      </Switch>
+    </SlideTransition>
+  )
+}
+
+export const ClaimConfirmRouter = (props: ClaimConfirmProps) => (
+  <SlideTransition>
+    <MemoryRouter
+      key='stake'
+      initialIndex={0}
+      initialEntries={claimConfirmRoutes.map(route => route.path)}
+    >
+      <CosmosClaimRouter {...props} />
+    </MemoryRouter>
+  </SlideTransition>
+)

--- a/src/plugins/cosmos/components/modals/Staking/views/Overview.tsx
+++ b/src/plugins/cosmos/components/modals/Staking/views/Overview.tsx
@@ -1,14 +1,14 @@
 import { Box, Flex } from '@chakra-ui/layout'
-import { Button, ModalCloseButton } from '@chakra-ui/react'
+import { ModalCloseButton } from '@chakra-ui/react'
 import { CAIP19 } from '@shapeshiftoss/caip'
 import { Asset } from '@shapeshiftoss/types'
 import { AnimatePresence } from 'framer-motion'
+import { ClaimButton } from 'plugins/cosmos/components/ClaimButton/ClaimButton'
 import { OverviewHeader } from 'plugins/cosmos/components/OverviewHeader/OverviewHeader'
 import { RewardsRow } from 'plugins/cosmos/components/RewardsRow/RewardsRow'
 import { StakedRow } from 'plugins/cosmos/components/StakedRow/StakedRow'
 import { StakingButtons } from 'plugins/cosmos/components/StakingButtons/StakingButtons'
 import { UnbondingRow } from 'plugins/cosmos/components/UnbondingRow/UnbondingRow'
-import { Text } from 'components/Text'
 import { bnOrZero } from 'lib/bignumber/bignumber'
 
 type StakedProps = {
@@ -62,9 +62,7 @@ export const Overview = ({ assetId }: StakedProps) => {
             fiatRate={bnOrZero('8.47')}
             cryptoRewardsAmount={bnOrZero('23.24')}
           />
-          <Button width='100%' colorScheme='green'>
-            <Text translation={'defi.claim'} color='green' fontWeight='bold' />
-          </Button>
+          <ClaimButton assetId={assetId} />
         </Flex>
       </Box>
     </AnimatePresence>


### PR DESCRIPTION
## Description

- Add new modals `<ClaimBroadcast /> ` and `<ClaimConfirm />`, used in `<ClaimConfirmRouter/>`

## Notice

Before submitting a pull request, please make sure you have answered the following:

- [X] Have you followed the guidelines in our [Contributing]('https://github.com/shapeshift/web/CONTRIBUTING.md) guide?
- [X] Have you checked to ensure there aren't other open [Pull Requests](https://github.com/shapeshift/web/pulls) for the same update/change?

## Pull Request Type

- [ ] :bug: Bug fix (Non-breaking Change: Fixes an issue)
- [ ] :hammer_and_wrench: Chore (Non-breaking Change: Doc updates, pkg upgrades, typos, etc..)
- [X] :nail_care: New Feature (Breaking/Non-breaking Change)

## Issue (if applicable)

https://github.com/shapeshift/web/issues/670 and https://github.com/shapeshift/web/issues/671

## Risk

Functionality is not yet complete for both issues since it is not wired up yet.

## Testing

- Open cosmos modal
- click on "claim" button
- Select fee and click "confirm" button

## Screenshots (if applicable)

![claim1](https://user-images.githubusercontent.com/5720927/157710170-e8f54c56-3a1b-4ad1-a706-4b4f124d6dea.png)

![claim2](https://user-images.githubusercontent.com/5720927/157710198-27e2931c-49f5-4400-b3a4-1c3054557b91.png)

