### PR TITLE
fix: don't load cosmos chain adapter unless enabled

### DIFF
--- a/src/App.tsx
+++ b/src/App.tsx
@@ -10,11 +10,13 @@ import { IconCircle } from 'components/IconCircle'
 import { useHasAppUpdated } from 'hooks/useHasAppUpdated/useHasAppUpdated'
 import { selectFeatureFlags } from 'state/slices/selectors'
 
+import { useChainAdapters } from './context/ChainAdaptersProvider/ChainAdaptersProvider'
 import { Route } from './Routes/helpers'
 import { useAppSelector } from './state/store'
 
 export const App = () => {
   const [pluginRoutes, setPluginRoutes] = useState<Route[]>([])
+  const chainAdapterManager = useChainAdapters()
   const shouldUpdate = useHasAppUpdated()
   const toast = useToast()
   const toastIdRef = useRef<ToastId | null>(null)
@@ -25,13 +27,29 @@ export const App = () => {
   useEffect(() => {
     registerPlugins()
       .then(() => {
-        setPluginRoutes(pluginManager.getRoutes())
+        let routes: Route[] = []
+
+        // Register Chain Adapters
+        for (const [, plugin] of pluginManager.entries()) {
+          // Ignore plugins that have their feature flag disabled
+          // If no featureFlag is present, then we assume it's enabled
+          if (!plugin.featureFlag || featureFlags[plugin.featureFlag]) {
+            // Routes
+            routes = routes.concat(plugin.routes)
+            // Chain Adapters
+            plugin.providers?.chainAdapters?.forEach(([chain, factory]) => {
+              chainAdapterManager.addChain(chain, factory)
+            })
+          }
+        }
+
+        setPluginRoutes(routes)
       })
       .catch(e => {
         console.error('RegisterPlugins', e)
         setPluginRoutes([])
       })
-  }, [setPluginRoutes, featureFlags])
+  }, [setPluginRoutes, chainAdapterManager, featureFlags])
 
   useEffect(() => {
     if (shouldUpdate && !toast.isActive(updateId)) {

--- a/src/AppProviders.tsx
+++ b/src/AppProviders.tsx
@@ -37,10 +37,6 @@ const unchainedUrls: UnchainedUrls = {
   [ChainTypes.Bitcoin]: {
     httpUrl: getConfig().REACT_APP_UNCHAINED_BITCOIN_HTTP_URL,
     wsUrl: getConfig().REACT_APP_UNCHAINED_BITCOIN_WS_URL
-  },
-  [ChainTypes.Cosmos]: {
-    httpUrl: getConfig().REACT_APP_UNCHAINED_COSMOS_HTTP_URL,
-    wsUrl: getConfig().REACT_APP_UNCHAINED_COSMOS_WS_URL
   }
 }
 

--- a/src/components/Layout/Header/NavBar/NavBar.tsx
+++ b/src/components/Layout/Header/NavBar/NavBar.tsx
@@ -1,6 +1,4 @@
 import { Stack, StackProps } from '@chakra-ui/react'
-import union from 'lodash/union'
-import { pluginManager } from 'plugins'
 import { useTranslate } from 'react-polyglot'
 import { Link as ReactRouterLink } from 'react-router-dom'
 import { routes } from 'Routes/Routes'
@@ -16,7 +14,7 @@ export const NavBar = ({ isCompact, ...rest }: NavBarProps) => {
 
   return (
     <Stack width='full' flex='1 1 0%' {...rest}>
-      {union(routes, pluginManager.getRoutes())
+      {routes
         .filter(route => !route.disable && !route.hide)
         .map((item, idx) => {
           return (

--- a/src/context/ChainAdaptersProvider/ChainAdaptersProvider.tsx
+++ b/src/context/ChainAdaptersProvider/ChainAdaptersProvider.tsx
@@ -1,5 +1,7 @@
 import { ChainAdapterManager, UnchainedUrls } from '@shapeshiftoss/chain-adapters'
-import React, { createContext, useContext, useMemo, useRef } from 'react'
+import React, { createContext, useEffect } from 'react'
+import { useSelector } from 'react-redux'
+import { selectFeatureFlags } from 'state/slices/preferencesSlice/selectors'
 
 type ChainAdaptersProviderProps = {
   children: React.ReactNode
@@ -26,16 +28,21 @@ export const ChainAdaptersProvider = ({
   children,
   unchainedUrls
 }: ChainAdaptersProviderProps): JSX.Element => {
-  setChainAdapters(new ChainAdapterManager(unchainedUrls))
-  const chainAdapterManager = useRef<ChainAdapterManager | null>(getChainAdapters())
+  const featureFlags = useSelector(selectFeatureFlags)
 
-  const context = useMemo(() => chainAdapterManager.current, [])
+  useEffect(() => {
+    setChainAdapters(new ChainAdapterManager(unchainedUrls))
+  }, [featureFlags, unchainedUrls])
 
-  return <ChainAdaptersContext.Provider value={context}>{children}</ChainAdaptersContext.Provider>
+  if (!_chainAdapters) {
+    setChainAdapters(new ChainAdapterManager(unchainedUrls))
+  }
+
+  return (
+    <ChainAdaptersContext.Provider value={_chainAdapters}>{children}</ChainAdaptersContext.Provider>
+  )
 }
 
 export const useChainAdapters = () => {
-  const context = useContext(ChainAdaptersContext)
-  if (!context) throw new Error('Chain Adapters cannot be used outside of its context')
-  return context
+  return getChainAdapters()
 }

--- a/src/hooks/useAccountSpecifiers/useAccountSpecifiers.ts
+++ b/src/hooks/useAccountSpecifiers/useAccountSpecifiers.ts
@@ -27,6 +27,8 @@ export const useAccountSpecifiers: UseAccountSpecifiers = () => {
   const [accountSpecifiers, setAccountSpecifiers] = useState<AccountSpecifierMap[]>([])
   const [loading, setLoading] = useState(false)
   const chainAdapter = useChainAdapters()
+  // Needed to trigger if we add new chain adapters from a plugin
+  const numSupportedChainAdapters = chainAdapter.getSupportedAdapters().length
   const {
     state: { wallet, walletInfo }
   } = useWallet()
@@ -131,7 +133,14 @@ export const useAccountSpecifiers: UseAccountSpecifiers = () => {
       )
     }
     // eslint-disable-next-line react-hooks/exhaustive-deps
-  }, [portfolioAssetIds, walletInfo?.deviceId, assetIds, wallet])
+  }, [
+    portfolioAssetIds,
+    walletInfo?.deviceId,
+    assetIds,
+    wallet,
+    chainAdapter,
+    numSupportedChainAdapters
+  ])
 
   return accountSpecifiers
 }

--- a/src/plugins/cosmos/index.tsx
+++ b/src/plugins/cosmos/index.tsx
@@ -1,3 +1,8 @@
+import { ChainAdapter as CosmosChainAdapter } from '@shapeshiftoss/chain-adapters/dist/cosmossdk/cosmos'
+import { ChainAdapter as OsmosisChainAdapter } from '@shapeshiftoss/chain-adapters/dist/cosmossdk/osmosis'
+import { ChainTypes } from '@shapeshiftoss/types'
+import * as unchained from '@shapeshiftoss/unchained-client'
+import { getConfig } from 'config'
 import { Plugins } from 'plugins'
 import { AssetIcon } from 'components/AssetIcon'
 
@@ -10,6 +15,35 @@ export function register(): Plugins {
       {
         name: 'plugins.cosmos.navBar',
         icon: <AssetIcon src='https://assets.coincap.io/assets/icons/atom@2x.png' />,
+        featureFlag: 'CosmosPlugin',
+        providers: {
+          chainAdapters: [
+            [
+              ChainTypes.Cosmos,
+              () => {
+                const http = new unchained.cosmos.api.V1Api(
+                  new unchained.cosmos.api.Configuration({
+                    basePath: getConfig().REACT_APP_UNCHAINED_COSMOS_HTTP_URL
+                  })
+                )
+
+                return new CosmosChainAdapter({ providers: { http }, coinName: 'Cosmos' })
+              }
+            ],
+            [
+              ChainTypes.Osmosis,
+              () => {
+                const http = new unchained.cosmos.api.V1Api(
+                  new unchained.cosmos.api.Configuration({
+                    basePath: getConfig().REACT_APP_UNCHAINED_COSMOS_HTTP_URL
+                  })
+                )
+
+                return new OsmosisChainAdapter({ providers: { http }, coinName: 'Osmosis' })
+              }
+            ]
+          ]
+        },
         routes: [
           {
             path: '/assets/cosmos\\:osmosis-1/:assetSubId',

--- a/src/plugins/index.ts
+++ b/src/plugins/index.ts
@@ -1,17 +1,21 @@
-import type { CAIP19 } from '@shapeshiftoss/caip'
+import { ChainAdapter } from '@shapeshiftoss/chain-adapters'
+import { ChainTypes } from '@shapeshiftoss/types'
+import { FeatureFlags } from 'state/slices/preferencesSlice/preferencesSlice'
 
 import { Route } from '../Routes/helpers'
 
 const activePlugins = ['cosmos']
 
-export type AssetProps = { assetId: CAIP19 }
 export type Plugins = [caip2: string, chain: Plugin][]
 export type RegistrablePlugin = { register: () => Plugins }
 
 export interface Plugin {
   name: string
   icon: JSX.Element
-  disabled?: boolean
+  featureFlag?: keyof FeatureFlags
+  providers?: {
+    chainAdapters?: Array<[ChainTypes, () => ChainAdapter<ChainTypes>]>
+  }
   routes: Route[]
 }
 
@@ -31,15 +35,8 @@ class PluginManager {
     }
   }
 
-  getRoutes(): Route[] {
-    let routes: Route[] = []
-    for (const [, plugin] of this.#pluginManager.entries()) {
-      if (!plugin.disabled) {
-        routes = routes.concat(plugin.routes)
-      }
-    }
-
-    return routes
+  entries(): [string, Plugin][] {
+    return [...this.#pluginManager.entries()]
   }
 }
 

--- a/src/state/slices/preferencesSlice/preferencesSlice.ts
+++ b/src/state/slices/preferencesSlice/preferencesSlice.ts
@@ -12,7 +12,6 @@ export type Preferences = {
 }
 
 const initialState: Preferences = {
-  // TODO(0xdef1cafe): this whole thing needs to be deleted once we have the account -> address abstraction
   featureFlags: {
     CosmosInvestor: getConfig().REACT_APP_FEATURE_COSMOS_INVESTOR,
     CosmosPlugin: getConfig().REACT_APP_FEATURE_PLUGIN_COSMOS


### PR DESCRIPTION
## Description

fix: don't load cosmos chain adapter unless enabled

## Notice

Before submitting a pull request, please make sure you have answered the following:

- [X] Have you followed the guidelines in our [Contributing]('https://github.com/shapeshift/web/CONTRIBUTING.md) guide?
- [X] Have you checked to ensure there aren't other open [Pull Requests](https://github.com/shapeshift/web/pulls) for the same update/change?

## Pull Request Type

- [X] :bug: Bug fix (Non-breaking Change: Fixes an issue)
- [ ] :hammer_and_wrench: Chore (Non-breaking Change: Doc updates, pkg upgrades, typos, etc..)
- [ ] :nail_care: New Feature (Breaking/Non-breaking Change)

## Issue (if applicable)

Known issue but not documented

## Risk

The dashboard will show assets it shouldn't or visa-versa

## Testing

1. Use a wallet that has ATOM
2. Load the dashboard
3. Press ALT+SHIFT+F to open Flags
4. disable/enable the `CosmosPlugin` flag
5. click "Reset App"
6. Repeat with different flags/wallets

## Screenshots (if applicable)
### Plugin ON
![image](https://user-images.githubusercontent.com/1958266/158257020-32270131-3c86-4e95-9e4a-c858d77058e6.png)

### Plugin OFF
![image](https://user-images.githubusercontent.com/1958266/158257708-504f3abb-d2dd-4b22-9427-e8b93a9ff31b.png)
