### PR TITLE
feat: remove passing down route prop and add error page

### DIFF
--- a/package.json
+++ b/package.json
@@ -63,6 +63,7 @@
     "react-countdown-circle-timer": "^2.5.4",
     "react-device-detect": "^2.1.2",
     "react-dom": "^17.0.2",
+    "react-error-boundary": "^3.1.4",
     "react-hook-form": "7.21.2",
     "react-icons": "^4.2.0",
     "react-infinite-scroller": "^1.2.4",

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -1,55 +1,19 @@
 import { Alert, AlertDescription } from '@chakra-ui/alert'
 import { Button } from '@chakra-ui/button'
 import { ToastId, useToast } from '@chakra-ui/toast'
-import { pluginManager, registerPlugins } from 'plugins'
-import { useEffect, useRef, useState } from 'react'
+import { useEffect, useRef } from 'react'
 import { FaSync } from 'react-icons/fa'
 import { useTranslate } from 'react-polyglot'
 import { Routes } from 'Routes/Routes'
 import { IconCircle } from 'components/IconCircle'
 import { useHasAppUpdated } from 'hooks/useHasAppUpdated/useHasAppUpdated'
-import { selectFeatureFlags } from 'state/slices/selectors'
-
-import { useChainAdapters } from './context/ChainAdaptersProvider/ChainAdaptersProvider'
-import { Route } from './Routes/helpers'
-import { useAppSelector } from './state/store'
 
 export const App = () => {
-  const [pluginRoutes, setPluginRoutes] = useState<Route[]>([])
-  const chainAdapterManager = useChainAdapters()
   const shouldUpdate = useHasAppUpdated()
   const toast = useToast()
   const toastIdRef = useRef<ToastId | null>(null)
   const updateId = 'update-app'
   const translate = useTranslate()
-  const featureFlags = useAppSelector(selectFeatureFlags)
-
-  useEffect(() => {
-    registerPlugins()
-      .then(() => {
-        let routes: Route[] = []
-
-        // Register Chain Adapters
-        for (const [, plugin] of pluginManager.entries()) {
-          // Ignore plugins that have their feature flag disabled
-          // If no featureFlag is present, then we assume it's enabled
-          if (!plugin.featureFlag || featureFlags[plugin.featureFlag]) {
-            // Routes
-            routes = routes.concat(plugin.routes)
-            // Chain Adapters
-            plugin.providers?.chainAdapters?.forEach(([chain, factory]) => {
-              chainAdapterManager.addChain(chain, factory)
-            })
-          }
-        }
-
-        setPluginRoutes(routes)
-      })
-      .catch(e => {
-        console.error('RegisterPlugins', e)
-        setPluginRoutes([])
-      })
-  }, [setPluginRoutes, chainAdapterManager, featureFlags])
 
   useEffect(() => {
     if (shouldUpdate && !toast.isActive(updateId)) {
@@ -83,5 +47,5 @@ export const App = () => {
     }
   }, [shouldUpdate, toast, translate])
 
-  return <Routes additionalRoutes={pluginRoutes} />
+  return <Routes />
 }

--- a/src/AppProviders.tsx
+++ b/src/AppProviders.tsx
@@ -52,27 +52,27 @@ export function AppProviders({ children }: ProvidersProps) {
           <BrowserRouter>
             <ScrollToTop />
             <BrowserRouterProvider>
-              <I18n locale={locale} messages={messages}>
-                <WalletProvider>
-                  <ChainAdaptersProvider unchainedUrls={unchainedUrls}>
-                    <PortfolioProvider>
-                      <MarketDataProvider>
-                        <TransactionsProvider>
-                          <ModalProvider>
-                            <DefiManagerProvider>
-                              <AppRouteProvider>
+              <AppRouteProvider>
+                <I18n locale={locale} messages={messages}>
+                  <WalletProvider>
+                    <ChainAdaptersProvider unchainedUrls={unchainedUrls}>
+                      <PortfolioProvider>
+                        <MarketDataProvider>
+                          <TransactionsProvider>
+                            <ModalProvider>
+                              <DefiManagerProvider>
                                 <ErrorBoundary FallbackComponent={ErrorPage}>
                                   {children}
                                 </ErrorBoundary>
-                              </AppRouteProvider>
-                            </DefiManagerProvider>
-                          </ModalProvider>
-                        </TransactionsProvider>
-                      </MarketDataProvider>
-                    </PortfolioProvider>
-                  </ChainAdaptersProvider>
-                </WalletProvider>
-              </I18n>
+                              </DefiManagerProvider>
+                            </ModalProvider>
+                          </TransactionsProvider>
+                        </MarketDataProvider>
+                      </PortfolioProvider>
+                    </ChainAdaptersProvider>
+                  </WalletProvider>
+                </I18n>
+              </AppRouteProvider>
             </BrowserRouterProvider>
           </BrowserRouter>
         </PersistGate>

--- a/src/AppProviders.tsx
+++ b/src/AppProviders.tsx
@@ -4,10 +4,12 @@ import { ChainTypes } from '@shapeshiftoss/types'
 import { getConfig } from 'config'
 import { DefiManagerProvider } from 'features/defi/contexts/DefiManagerProvider/DefiManagerProvider'
 import React from 'react'
+import { ErrorBoundary } from 'react-error-boundary'
 import { I18n } from 'react-polyglot'
 import { Provider as ReduxProvider } from 'react-redux'
 import { BrowserRouter } from 'react-router-dom'
 import { PersistGate } from 'redux-persist/integration/react'
+import { AppRouteProvider } from 'Routes/Routes'
 import { ScrollToTop } from 'Routes/ScrollToTop'
 import { translations } from 'assets/translations'
 import { BrowserRouterProvider } from 'context/BrowserRouterProvider/BrowserRouterProvider'
@@ -18,6 +20,7 @@ import { PortfolioProvider } from 'context/PortfolioProvider/PortfolioContext'
 import { TransactionsProvider } from 'context/TransactionsProvider/TransactionsProvider'
 import { WalletProvider } from 'context/WalletProvider/WalletProvider'
 import { simpleLocale } from 'lib/browserLocale'
+import { ErrorPage } from 'pages/ErrorPage/ErrorPage'
 import { SplashScreen } from 'pages/SplashScreen/SplashScreen'
 import { persistor, store } from 'state/store'
 import { theme } from 'theme/theme'
@@ -56,7 +59,13 @@ export function AppProviders({ children }: ProvidersProps) {
                       <MarketDataProvider>
                         <TransactionsProvider>
                           <ModalProvider>
-                            <DefiManagerProvider>{children}</DefiManagerProvider>
+                            <DefiManagerProvider>
+                              <AppRouteProvider>
+                                <ErrorBoundary FallbackComponent={ErrorPage}>
+                                  {children}
+                                </ErrorBoundary>
+                              </AppRouteProvider>
+                            </DefiManagerProvider>
                           </ModalProvider>
                         </TransactionsProvider>
                       </MarketDataProvider>

--- a/src/AppProviders.tsx
+++ b/src/AppProviders.tsx
@@ -52,10 +52,10 @@ export function AppProviders({ children }: ProvidersProps) {
           <BrowserRouter>
             <ScrollToTop />
             <BrowserRouterProvider>
-              <AppRouteProvider>
-                <I18n locale={locale} messages={messages}>
-                  <WalletProvider>
-                    <ChainAdaptersProvider unchainedUrls={unchainedUrls}>
+              <I18n locale={locale} messages={messages}>
+                <WalletProvider>
+                  <ChainAdaptersProvider unchainedUrls={unchainedUrls}>
+                    <AppRouteProvider>
                       <PortfolioProvider>
                         <MarketDataProvider>
                           <TransactionsProvider>
@@ -69,10 +69,10 @@ export function AppProviders({ children }: ProvidersProps) {
                           </TransactionsProvider>
                         </MarketDataProvider>
                       </PortfolioProvider>
-                    </ChainAdaptersProvider>
-                  </WalletProvider>
-                </I18n>
-              </AppRouteProvider>
+                    </AppRouteProvider>
+                  </ChainAdaptersProvider>
+                </WalletProvider>
+              </I18n>
             </BrowserRouterProvider>
           </BrowserRouter>
         </PersistGate>

--- a/src/assets/translations/messages-en.json
+++ b/src/assets/translations/messages-en.json
@@ -40,6 +40,11 @@
     "viewAsset": "View Asset",
     "days": "Days"
   },
+  "errorPage": {
+    "title": "Oops!",
+    "body": "Something went wrong",
+    "cta": "Try again"
+  },
   "updateToast": {
     "body": "A new version of the app is available",
     "cta": "Reload App"

--- a/src/components/AssetAccountDetails.tsx
+++ b/src/components/AssetAccountDetails.tsx
@@ -23,7 +23,7 @@ type AssetDetailsProps = {
 
 export const AssetAccountDetails = ({ assetId: caip19, accountId, route }: AssetDetailsProps) => {
   return (
-    <Main route={route} titleComponent={<AssetHeader assetId={caip19} accountId={accountId} />}>
+    <Main titleComponent={<AssetHeader assetId={caip19} accountId={accountId} />}>
       <Stack
         alignItems='flex-start'
         spacing={4}

--- a/src/components/Layout/Header/Header.tsx
+++ b/src/components/Layout/Header/Header.tsx
@@ -12,14 +12,13 @@ import {
 } from '@chakra-ui/react'
 import { useCallback, useEffect } from 'react'
 import { Link, useHistory } from 'react-router-dom'
-import { Route } from 'Routes/helpers'
 import { FoxIcon } from 'components/Icons/FoxIcon'
 
 import { AutoCompleteSearch } from './AutoCompleteSearch/AutoCompleteSearch'
 import { UserMenu } from './NavBar/UserMenu'
 import { SideNavContent } from './SideNavContent'
 
-export const Header = ({ route }: { route: Route }) => {
+export const Header = () => {
   const { onToggle, isOpen, onClose } = useDisclosure()
   const history = useHistory()
   const bg = useColorModeValue('white', 'gray.800')
@@ -86,7 +85,9 @@ export const Header = ({ route }: { route: Route }) => {
       </Flex>
       <Drawer isOpen={isOpen} onClose={onClose} placement='left'>
         <DrawerOverlay />
-        <DrawerContent>{route && <SideNavContent route={route} />}</DrawerContent>
+        <DrawerContent>
+          <SideNavContent />
+        </DrawerContent>
       </Drawer>
     </>
   )

--- a/src/components/Layout/Header/SideNav.tsx
+++ b/src/components/Layout/Header/SideNav.tsx
@@ -1,12 +1,11 @@
 import { chakra, useColorModeValue } from '@chakra-ui/react'
 import React from 'react'
-import { Route } from 'Routes/helpers'
 
 import { SideNavContent } from './SideNavContent'
 
 export const NAV_PADDING = { base: 6, lg: 16 }
 
-export const SideNav = ({ route }: { route: Route }) => {
+export const SideNav = () => {
   const bg = useColorModeValue('white', 'gray.850')
   const borderColor = useColorModeValue('gray.100', 'gray.750')
 
@@ -26,7 +25,7 @@ export const SideNav = ({ route }: { route: Route }) => {
         flex={{ base: 'inherit', '2xl': '1 1 0%' }}
         display={{ base: 'none', md: 'flex' }}
       >
-        <SideNavContent route={route} isCompact={true} />
+        <SideNavContent isCompact={true} />
       </chakra.header>
     </>
   )

--- a/src/components/Layout/Layout.tsx
+++ b/src/components/Layout/Layout.tsx
@@ -1,18 +1,18 @@
-import { Container, Flex } from '@chakra-ui/react'
+import { Container, ContainerProps, Flex } from '@chakra-ui/react'
 import React from 'react'
-import { Route } from 'Routes/helpers'
 
 import { Header } from './Header/Header'
 import { SideNav } from './Header/SideNav'
 
-export const Layout = ({ route }: { route: Route }) => {
-  const MainComponent = route.main
+type LayoutProps = ContainerProps
+
+export const Layout: React.FC<LayoutProps> = ({ children, ...rest }) => {
   return (
     <>
-      <Header route={route} />
+      <Header />
 
       <Flex>
-        <SideNav route={route} />
+        <SideNav />
         <Container
           as='main'
           maxWidth='full'
@@ -22,8 +22,9 @@ export const Layout = ({ route }: { route: Route }) => {
           paddingInlineStart='0'
           paddingInlineEnd='0'
           flex='1 1 0%'
+          {...rest}
         >
-          {MainComponent && <MainComponent route={route} />}
+          {children}
         </Container>
       </Flex>
     </>

--- a/src/components/Layout/Main.tsx
+++ b/src/components/Layout/Main.tsx
@@ -2,7 +2,7 @@ import { Box, Container, ContainerProps, HStack, Stack } from '@chakra-ui/layout
 import { useColorModeValue } from '@chakra-ui/react'
 import { useViewportScroll } from 'framer-motion'
 import { ReactNode, useEffect, useRef, useState } from 'react'
-import { Route } from 'Routes/helpers'
+import { useAppRoutes } from 'Routes/Routes'
 import { Breadcrumbs } from 'components/Breadcrumbs/Breadcrumbs'
 import { NestedMenu } from 'components/NestedMenu/NestedMenu'
 
@@ -10,11 +10,11 @@ import { Page } from './Page'
 
 export type MainProps = {
   titleComponent?: ReactNode
-  route?: Route
 } & ContainerProps
 
-export const Main: React.FC<MainProps> = ({ children, titleComponent, route, ...rest }) => {
+export const Main: React.FC<MainProps> = ({ children, titleComponent, ...rest }) => {
   const ref = useRef<HTMLDivElement>(null)
+  const { currentRoute } = useAppRoutes()
   const bg = useColorModeValue('white', 'gray.800')
   const borderColor = useColorModeValue('gray.100', 'gray.750')
   const [y, setY] = useState(0)
@@ -46,7 +46,7 @@ export const Main: React.FC<MainProps> = ({ children, titleComponent, route, ...
               {titleComponent}
             </Stack>
           </Container>
-          {route && <NestedMenu route={route} />}
+          {currentRoute && <NestedMenu route={currentRoute} />}
         </Box>
       )}
       <Container maxW='container.xl' py={8} px={{ base: 0, xl: 4 }} {...rest}>

--- a/src/pages/Accounts/AccountToken/AccountTokenTxHistory.tsx
+++ b/src/pages/Accounts/AccountToken/AccountTokenTxHistory.tsx
@@ -17,10 +17,7 @@ export const AccountTokenTxHistory: React.FC<AssetTransactionProps> = ({ route }
   const assetIdParam = decodeURIComponent(assetId)
   const asset = useAppSelector(state => selectAssetByCAIP19(state, assetIdParam))
   return !asset ? null : (
-    <Main
-      route={route}
-      titleComponent={<AssetHeader assetId={assetIdParam} accountId={accountId} />}
-    >
+    <Main titleComponent={<AssetHeader assetId={assetIdParam} accountId={accountId} />}>
       <AllTransactions assetId={assetIdParam} accountId={accountId} />
     </Main>
   )

--- a/src/pages/Accounts/AccountTxHistory.tsx
+++ b/src/pages/Accounts/AccountTxHistory.tsx
@@ -19,7 +19,7 @@ export const AccountTxHistory: React.FC<AssetTransactionProps> = ({ route }) => 
   const feeAssetId = accountIdToFeeAssetId(parsedAccountId)
   const feeAsset = useAppSelector(state => selectAssetByCAIP19(state, feeAssetId))
   return !feeAsset ? null : (
-    <Main route={route} titleComponent={<AssetHeader assetId={feeAssetId} accountId={accountId} />}>
+    <Main titleComponent={<AssetHeader assetId={feeAssetId} accountId={accountId} />}>
       <AllTransactions assetId={feeAssetId} accountId={accountId} />
     </Main>
   )

--- a/src/pages/Assets/AssetTxHistory.tsx
+++ b/src/pages/Assets/AssetTxHistory.tsx
@@ -16,7 +16,7 @@ export const AssetTxHistory: React.FC<AssetTransactionProps> = ({ route }) => {
   if (!params.assetSubId && !params.chainId) return null
 
   return (
-    <Main route={route} titleComponent={<AssetHeader assetId={assetId} />}>
+    <Main titleComponent={<AssetHeader assetId={assetId} />}>
       <AllTransactions assetId={assetId} />
     </Main>
   )

--- a/src/pages/Dashboard/Dashboard.tsx
+++ b/src/pages/Dashboard/Dashboard.tsx
@@ -1,5 +1,4 @@
 import { Stack } from '@chakra-ui/react'
-import { Route } from 'Routes/helpers'
 import { Main } from 'components/Layout/Main'
 
 import { DashboardSidebar } from './DashboardSidebar'
@@ -9,9 +8,9 @@ export type MatchParams = {
   assetId: string
 }
 
-export const Dashboard = ({ route }: { route?: Route }) => {
+export const Dashboard = () => {
   return (
-    <Main route={route}>
+    <Main>
       <Stack
         alignItems='flex-start'
         spacing={4}

--- a/src/pages/Defi/views/Overview.tsx
+++ b/src/pages/Defi/views/Overview.tsx
@@ -22,7 +22,7 @@ export const Overview = ({ route }: { route?: Route }) => {
   const balances = useEarnBalances()
   const walletBalance = useSelector(selectPortfolioTotalFiatBalance)
   return (
-    <Main titleComponent={<DefiHeader />} route={route}>
+    <Main titleComponent={<DefiHeader />}>
       <OverviewHeader earnBalance={balances} walletBalance={walletBalance} />
       <Stack spacing={4} divider={<Divider marginTop={0} />}>
         <VaultList balances={balances} />

--- a/src/pages/Defi/views/StakingVaults.tsx
+++ b/src/pages/Defi/views/StakingVaults.tsx
@@ -15,7 +15,7 @@ const DefiHeader = () => {
 
 export const StakingVaults = ({ route }: { route?: Route }) => {
   return (
-    <Main route={route} titleComponent={<DefiHeader />}>
+    <Main titleComponent={<DefiHeader />}>
       <AllEarnOpportunities />
     </Main>
   )

--- a/src/pages/ErrorPage/ErrorPage.tsx
+++ b/src/pages/ErrorPage/ErrorPage.tsx
@@ -1,12 +1,14 @@
 import { Button, Center, Heading, Stack } from '@chakra-ui/react'
 import { FallbackProps } from 'react-error-boundary'
 import { FaSadTear } from 'react-icons/fa'
+import { useTranslate } from 'react-polyglot'
 import { IconCircle } from 'components/IconCircle'
 import { Layout } from 'components/Layout/Layout'
 import { Main } from 'components/Layout/Main'
 import { RawText } from 'components/Text'
 
 export const ErrorPage = ({ error, resetErrorBoundary }: FallbackProps) => {
+  const translate = useTranslate()
   return (
     <Layout display='flex'>
       <Main height='100%' display='flex' width='full'>
@@ -16,12 +18,12 @@ export const ErrorPage = ({ error, resetErrorBoundary }: FallbackProps) => {
               <FaSadTear />
             </IconCircle>
             <Heading lineHeight='shorter' fontSize='6xl'>
-              Oops!
+              {translate('errorPage.title')}
             </Heading>
-            <RawText fontSize='xl'>Something went wrong</RawText>
+            <RawText fontSize='xl'>{translate('errorPage.body')}</RawText>
             <pre>{error.message}</pre>
             <Button colorScheme='blue' onClick={resetErrorBoundary}>
-              Try again
+              {translate('errorPage.cta')}
             </Button>
           </Stack>
         </Center>

--- a/src/pages/ErrorPage/ErrorPage.tsx
+++ b/src/pages/ErrorPage/ErrorPage.tsx
@@ -1,0 +1,31 @@
+import { Button, Center, Heading, Stack } from '@chakra-ui/react'
+import { FallbackProps } from 'react-error-boundary'
+import { FaSadTear } from 'react-icons/fa'
+import { IconCircle } from 'components/IconCircle'
+import { Layout } from 'components/Layout/Layout'
+import { Main } from 'components/Layout/Main'
+import { RawText } from 'components/Text'
+
+export const ErrorPage = ({ error, resetErrorBoundary }: FallbackProps) => {
+  return (
+    <Layout display='flex'>
+      <Main height='100%' display='flex' width='full'>
+        <Center width='full'>
+          <Stack justifyContent='center' alignItems='center'>
+            <IconCircle fontSize='6xl' boxSize='16' bg='blue.500' color='white'>
+              <FaSadTear />
+            </IconCircle>
+            <Heading lineHeight='shorter' fontSize='6xl'>
+              Oops!
+            </Heading>
+            <RawText fontSize='xl'>Something went wrong</RawText>
+            <pre>{error.message}</pre>
+            <Button colorScheme='blue' onClick={resetErrorBoundary}>
+              Try again
+            </Button>
+          </Stack>
+        </Center>
+      </Main>
+    </Layout>
+  )
+}

--- a/src/pages/Flags/Flags.tsx
+++ b/src/pages/Flags/Flags.tsx
@@ -55,7 +55,7 @@ export const Flags = ({ route }: FlagsPageProps) => {
   }
 
   return (
-    <Main route={route} titleComponent={<FlagHeader />}>
+    <Main titleComponent={<FlagHeader />}>
       <Card>
         <Card.Body>
           <Stack divider={<StackDivider />}>

--- a/yarn.lock
+++ b/yarn.lock
@@ -4033,12 +4033,7 @@
     retry-axios "^2.6.0"
     web3 "^1.6.1"
 
-"@shapeshiftoss/types@^2.0.0":
-  version "2.0.0"
-  resolved "https://registry.yarnpkg.com/@shapeshiftoss/types/-/types-2.0.0.tgz#de64b40bc777551d83c0938a319ba805069caf10"
-  integrity sha512-1NOcxKikRX9T8JRu6d+cSvaWscrnVzqanOrDhPkCzDfjmqZQ5JgVR1dz7bTN6s83oZiRcM80zAIfX9lJ06cHTg==
-
-"@shapeshiftoss/types@^2.1.0":
+"@shapeshiftoss/types@^2.0.0", "@shapeshiftoss/types@^2.1.0":
   version "2.1.0"
   resolved "https://registry.yarnpkg.com/@shapeshiftoss/types/-/types-2.1.0.tgz#6704f709f2650da671f212278687d32143269a10"
   integrity sha512-4v7ZyV6LvUZ3z0rTntNxyivpuzhwrAO6lYlxkSNcfoMlrAOiZp9a93QeYFs8enQgphZ3V7giO13LXAEyBWDKpw==
@@ -6547,18 +6542,7 @@
   resolved "https://registry.yarnpkg.com/@yarnpkg/lockfile/-/lockfile-1.1.0.tgz#e77a97fbd345b76d83245edcd17d393b1b41fb31"
   integrity sha512-GpSwvyXOcOOlV70vbnzjj4fW5xW/FdUF6nQEt1ENy7m4ZCczi1+/buVUPAqmGfqznsORNFzUMjctTIp8a9tuCQ==
 
-"@yfi/sdk@^1.0.29":
-  version "1.1.1"
-  resolved "https://registry.yarnpkg.com/@yfi/sdk/-/sdk-1.1.1.tgz#237899a175fe177e13b1f98111811027da01602d"
-  integrity sha512-UObLdc6T3DJpp7rUKLqM7eit62v4CBMRI2pcXgFLJ2PJraCLlpG+pUSxxwFFZLLgTavfqwleMvo8xML3gnnsbg==
-  dependencies:
-    bignumber.js "9.0.1"
-    cross-fetch "3.1.4"
-    dotenv "10.0.0"
-    emittery "0.8.1"
-    type-fest "1.2.1"
-
-"@yfi/sdk@^1.0.30":
+"@yfi/sdk@^1.0.29", "@yfi/sdk@^1.0.30":
   version "1.2.0"
   resolved "https://registry.yarnpkg.com/@yfi/sdk/-/sdk-1.2.0.tgz#b0635ced261cab41c57272ebb00ea7041702d74b"
   integrity sha512-o0GE+enTlUDwuP+W7TD7/5r5s2xuMTj93vPpUmDYePOunx3B85jwEl2FLUugTOdsku8eKhLLhLJTx6fJmSJLAw==
@@ -17991,10 +17975,10 @@ react-element-to-jsx-string@^14.3.4:
     is-plain-object "5.0.0"
     react-is "17.0.2"
 
-react-error-boundary@^3.1.0:
-  version "3.1.3"
-  resolved "https://registry.yarnpkg.com/react-error-boundary/-/react-error-boundary-3.1.3.tgz#276bfa05de8ac17b863587c9e0647522c25e2a0b"
-  integrity sha512-A+F9HHy9fvt9t8SNDlonq01prnU8AmkjvGKV4kk8seB9kU3xMEO8J/PQlLVmoOIDODl5U2kufSBs4vrWIqhsAA==
+react-error-boundary@^3.1.0, react-error-boundary@^3.1.4:
+  version "3.1.4"
+  resolved "https://registry.yarnpkg.com/react-error-boundary/-/react-error-boundary-3.1.4.tgz#255db92b23197108757a888b01e5b729919abde0"
+  integrity sha512-uM9uPzZJTF6wRQORmSrvOIgt4lJ9MC1sNgEOj2XGsDTRE4kmpWxg7ENK9EWNKJRMAOY9z0MuF4yIfl6gp4sotA==
   dependencies:
     "@babel/runtime" "^7.12.5"
 


### PR DESCRIPTION
## Description

- Add react error boundary
- Remove the need to pass down route using a context

## Notice

Before submitting a pull request, please make sure you have answered the following:

- [x] Have you followed the guidelines in our [Contributing]('https://github.com/shapeshift/web/CONTRIBUTING.md) guide?
- [x] Have you checked to ensure there aren't other open [Pull Requests](https://github.com/shapeshift/web/pulls) for the same update/change?

## Pull Request Type

- [ ] :bug: Bug fix (Non-breaking Change: Fixes an issue)
- [ ] :hammer_and_wrench: Chore (Non-breaking Change: Doc updates, pkg upgrades, typos, etc..)
- [x] :nail_care: New Feature (Breaking/Non-breaking Change)

## Issue (if applicable)

closes #1177

## Risk

Medium Risk
To add the error boundary with the layout component we needed to remove the required `route` prop. To do this I moved all of the route generation into a context. We can now call this context from any of the routes to find the currentRoute as well an array of all the routes including the plugin routes.

The useEffect that was originally inside `App.tsx` has been moved into this context as well.

## Testing

Confirm the routes still work and the nested menu still populates Asset/Overview/Transactions. Also make sure the plugins are still working as they should.

## Screenshots (if applicable)
