### PR TITLE
fix: happy address UserMenu path

### DIFF
--- a/src/components/Layout/Header/NavBar/UserMenu.tsx
+++ b/src/components/Layout/Header/NavBar/UserMenu.tsx
@@ -101,6 +101,7 @@ const WalletButton: FC<WalletButtonProps> = ({
             setShouldShorten(false)
             return setWalletLabel(addressReverseLookup.name)
           }
+          return setWalletLabel(walletInfo?.meta?.address ?? '')
         } catch (_) {
           return setWalletLabel(walletInfo?.meta?.address ?? '')
         }


### PR DESCRIPTION
## Description

This fixes the "happy" path for `<UserMenu />`.
In https://github.com/shapeshift/web/pull/1139/files#diff-cf09d1257e0d923f05e5933d109cd808ac574231106cc258bdca19f02e0ce8dbR105, the unhappy path was handled on catch, but that left out the unhappy "happy" path, where there is no actual error, but rather an `{error: true}` property in `addressReverseLookup`.
As a result, the address isn't currently showing, only the ENS name. 

## Notice

Before submitting a pull request, please make sure you have answered the following:

- [x] Have you followed the guidelines in our [Contributing]('https://github.com/shapeshift/web/CONTRIBUTING.md) guide?
- [x] Have you checked to ensure there aren't other open [Pull Requests](https://github.com/shapeshift/web/pulls) for the same update/change?

## Pull Request Type

- [x] :bug: Bug fix (Non-breaking Change: Fixes an issue)
- [ ] :hammer_and_wrench: Chore (Non-breaking Change: Doc updates, pkg upgrades, typos, etc..)
- [ ] :nail_care: New Feature (Breaking/Non-breaking Change)

## Issue (if applicable)

N/A

## Risk

N/A

## Testing

Account address should be displayed in the user menu.

## Screenshots (if applicable)
<img width="210" alt="image" src="https://user-images.githubusercontent.com/17035424/158570202-44a35ac9-4228-4877-b197-554cd748b02a.png">
