### PR TITLE
fix: confirm trade assets names stay consistent on line break

### DIFF
--- a/src/components/Trade/TradeConfirm/AssetToAsset.tsx
+++ b/src/components/Trade/TradeConfirm/AssetToAsset.tsx
@@ -56,7 +56,7 @@ export const AssetToAsset = ({
 
   return (
     <Flex width='full' justifyContent='space-between' alignItems='stretch' {...rest}>
-      <Box flex={1}>
+      <Box flex={1} maxWidth='calc(50% - 11px)'>
         <Flex alignItems='center'>
           <AssetIcon src={sellAsset.currency.icon} boxSize={boxSize} />
           <Divider flex={1} bgColor={sellAssetColor} />
@@ -84,7 +84,7 @@ export const AssetToAsset = ({
           {renderIcon()}
         </Circle>
       </Flex>
-      <Flex flexDirection='column' flex={1}>
+      <Flex flexDirection='column' flex={1} maxWidth='calc(50% - 11px)'>
         <Flex alignItems='center' flex={1} justify='flex-start'>
           <Divider flex={1} bgColor={buyAssetColor} />
           <AssetIcon src={buyAsset.currency.icon} boxSize={boxSize} />

--- a/src/components/Trade/TradeConfirm/AssetToAsset.tsx
+++ b/src/components/Trade/TradeConfirm/AssetToAsset.tsx
@@ -55,7 +55,7 @@ export const AssetToAsset = ({
   }
 
   return (
-    <Flex width='full' justifyContent='space-between' {...rest}>
+    <Flex width='full' justifyContent='space-between' alignItems='stretch' {...rest}>
       <Box flex={1}>
         <Flex alignItems='center'>
           <AssetIcon src={sellAsset.currency.icon} boxSize={boxSize} />
@@ -84,12 +84,18 @@ export const AssetToAsset = ({
           {renderIcon()}
         </Circle>
       </Flex>
-      <Flex flexDir='column' flex={1}>
+      <Flex flexDirection='column' flex={1}>
         <Flex alignItems='center' flex={1} justify='flex-start'>
           <Divider flex={1} bgColor={buyAssetColor} />
           <AssetIcon src={buyAsset.currency.icon} boxSize={boxSize} />
         </Flex>
-        <Box textAlign='right' mt={2}>
+        <Flex
+          flexDirection='column'
+          justifyContent='space-between'
+          textAlign='right'
+          height='100%'
+          mt={2}
+        >
           <Text fontWeight='medium'>
             {toCrypto(Number(buyAsset.amount), buyAsset.currency.symbol)}
           </Text>
@@ -100,7 +106,7 @@ export const AssetToAsset = ({
                 .toNumber()
             )}
           </Text>
-        </Box>
+        </Flex>
       </Flex>
     </Flex>
   )

--- a/src/components/Trade/TradeConfirm/AssetToAsset.tsx
+++ b/src/components/Trade/TradeConfirm/AssetToAsset.tsx
@@ -56,7 +56,7 @@ export const AssetToAsset = ({
 
   return (
     <Flex width='full' justifyContent='space-between' alignItems='stretch' {...rest}>
-      <Box flex={1} maxWidth='calc(50% - 11px)'>
+      <Box flex={1} maxWidth={`calc(50% - ${boxSize} / 2)`}>
         <Flex alignItems='center'>
           <AssetIcon src={sellAsset.currency.icon} boxSize={boxSize} />
           <Divider flex={1} bgColor={sellAssetColor} />
@@ -84,7 +84,7 @@ export const AssetToAsset = ({
           {renderIcon()}
         </Circle>
       </Flex>
-      <Flex flexDirection='column' flex={1} maxWidth='calc(50% - 11px)'>
+      <Flex flexDirection='column' flex={1} maxWidth={`calc(50% - ${boxSize} / 2)`}>
         <Flex alignItems='center' flex={1} justify='flex-start'>
           <Divider flex={1} bgColor={buyAssetColor} />
           <AssetIcon src={buyAsset.currency.icon} boxSize={boxSize} />


### PR DESCRIPTION
## Description

I did adapt the asset trading header with flexbox in order to stick asset value on the top instead, so it's aligned on line break.

There was another wrong behavior on really big asset number that I fixed by limiting the width of right and left columns

## Notice

Before submitting a pull request, please make sure you have answered the following:

- [x] Have you followed the guidelines in our [Contributing]('https://github.com/shapeshift/web/CONTRIBUTING.md) guide?
- [x] Have you checked to ensure there aren't other open [Pull Requests](https://github.com/shapeshift/web/pulls) for the same update/change?

## Pull Request Type

- [x] :bug: Bug fix (Non-breaking Change: Fixes an issue)
- [ ] :hammer_and_wrench: Chore (Non-breaking Change: Doc updates, pkg upgrades, typos, etc..)
- [ ] :nail_care: New Feature (Breaking/Non-breaking Change)

## Issue (if applicable)

closes #1164

## Risk

No specific risk

## Testing

- Go to an asset page, such as Ethereum for example
- Try to trade with FOX, the best way is to trade any value then edit in the devtools console so you get a bigger value
- It shouldn't break on line-break with big values

## Screenshots (if applicable)

### Before
<img width="398" alt="image" src="https://user-images.githubusercontent.com/14963751/158900976-09ce4c91-b34d-45cf-a5dc-998d2ded50f5.png">

### After
<img width="398" alt="image" src="https://user-images.githubusercontent.com/14963751/158900242-2d448f32-3825-4eac-b05d-b31938672000.png">

Also tested with really really big values because there was a buggy behavior too:

### Before
<img width="445" alt="image" src="https://user-images.githubusercontent.com/14963751/158902078-3512605a-1682-449d-901a-240c3b8d3623.png">

### After
<img width="413" alt="image" src="https://user-images.githubusercontent.com/14963751/158901917-c72f6bcf-2189-4c6e-b1a8-b5b319c368e6.png">
