### PR TITLE
fix: comment the explanations inside pr template

### DIFF
--- a/.github/PULL_REQUEST_TEMPLATE.md
+++ b/.github/PULL_REQUEST_TEMPLATE.md
@@ -1,10 +1,10 @@
 ## Description
 
-Please describe your changes
+<!-- Please describe your changes -->
 
 ## Notice
 
-Before submitting a pull request, please make sure you have answered the following:
+<!-- Before submitting a pull request, please make sure you have answered the following: -->
 
 - [ ] Have you followed the guidelines in our [Contributing]('https://github.com/shapeshift/web/CONTRIBUTING.md) guide?
 - [ ] Have you checked to ensure there aren't other open [Pull Requests](https://github.com/shapeshift/web/pulls) for the same update/change?
@@ -17,18 +17,24 @@ Before submitting a pull request, please make sure you have answered the followi
 
 ## Issue (if applicable)
 
+<!-----------------------------------------------------------------------------
 If applicable, please link to the github issue and put `closes #XXXX` in your comment to auto-close the issue that your PR fixes.
+------------------------------------------------------------------------------>
 
 ## Risk
 
+<!-----------------------------------------------------------------------------
 Outline the scope of your changes and the risk associated with them. You must use your discretion as an engineer to determine the potential impact of your changes.
 
 E.g. an upgrade to `hdwallet` or core state management would be considered higher risk, and might require a full regression test. UI or isolated view changes, or something behind a feature flag may have near zero risk. Small bug fixes might require testing isolated to the specific fix.
+------------------------------------------------------------------------------>
 
 ## Testing
 
+<!-----------------------------------------------------------------------------
 If your testing steps are technical, outline steps for an engineer to verify.
 
 If your testing steps are functional, please provide a full guide with any features requiring special attention for operations to test your branch in the preview environment.
+------------------------------------------------------------------------------>
 
 ## Screenshots (if applicable)


### PR DESCRIPTION
## Description

Noticed that sometimes contributors forget to remove the explanations from their Pull Request.

Also, it's easier for reviewers and maintainers to detect empty parts because they will really be empty!

## Notice

- [x] Have you followed the guidelines in our [Contributing]('https://github.com/shapeshift/web/CONTRIBUTING.md) guide?
- [x] Have you checked to ensure there aren't other open [Pull Requests](https://github.com/shapeshift/web/pulls) for the same update/change?

## Pull Request Type

- [ ] :bug: Bug fix (Non-breaking Change: Fixes an issue)
- [x] :hammer_and_wrench: Chore (Non-breaking Change: Doc updates, pkg upgrades, typos, etc..)
- [ ] :nail_care: New Feature (Breaking/Non-breaking Change)

## Risk

No risk

## Testing

Can't really test until it's merged
