### PR TITLE
fix: address explorer link fixed

### DIFF
--- a/src/components/TransactionHistoryRows/TransactionContract.tsx
+++ b/src/components/TransactionHistoryRows/TransactionContract.tsx
@@ -72,7 +72,7 @@ export const TransactionContract = ({
         {txDetails.to && (
           <Row title='sentTo'>
             <Address
-              explorerTxLink={txDetails.explorerTxLink}
+              explorerAddressLink={txDetails.explorerAddressLink}
               address={txDetails.to}
               ens={txDetails.ensTo}
             />
@@ -99,7 +99,7 @@ export const TransactionContract = ({
         {txDetails.from && (
           <Row title='receivedFrom'>
             <Address
-              explorerTxLink={txDetails.explorerTxLink}
+              explorerAddressLink={txDetails.explorerAddressLink}
               address={txDetails.from}
               ens={txDetails.ensFrom}
             />

--- a/src/components/TransactionHistoryRows/TransactionDetails/Address.tsx
+++ b/src/components/TransactionHistoryRows/TransactionDetails/Address.tsx
@@ -2,11 +2,11 @@ import { Button, Link, useColorModeValue } from '@chakra-ui/react'
 import { MiddleEllipsis } from 'components/MiddleEllipsis/MiddleEllipsis'
 
 export const Address = ({
-  explorerTxLink,
+  explorerAddressLink,
   address,
   ens
 }: {
-  explorerTxLink: string
+  explorerAddressLink: string
   address: string
   ens?: string
 }) => (
@@ -14,7 +14,7 @@ export const Address = ({
     isExternal
     color={useColorModeValue('blue.400', 'blue.200')}
     _hover={{ textDecoration: 'none' }}
-    href={`${explorerTxLink}${ens || address}`}
+    href={`${explorerAddressLink}${ens || address}`}
     onClick={e => {
       // don't trigger parent onClick
       e.stopPropagation()

--- a/src/components/TransactionHistoryRows/TransactionReceive.tsx
+++ b/src/components/TransactionHistoryRows/TransactionReceive.tsx
@@ -44,7 +44,7 @@ export const TransactionReceive = ({
         </Row>
         <Row title='receivedFrom'>
           <Address
-            explorerTxLink={txDetails.explorerTxLink}
+            explorerAddressLink={txDetails.explorerAddressLink}
             address={txDetails.from}
             ens={txDetails.ensFrom}
           />

--- a/src/components/TransactionHistoryRows/TransactionSend.tsx
+++ b/src/components/TransactionHistoryRows/TransactionSend.tsx
@@ -44,7 +44,7 @@ export const TransactionSend = ({
         </Row>
         <Row title='sentTo'>
           <Address
-            explorerTxLink={txDetails.explorerTxLink}
+            explorerAddressLink={txDetails.explorerAddressLink}
             address={txDetails.to}
             ens={txDetails.ensTo}
           />

--- a/src/components/TransactionHistoryRows/TransactionTrade.tsx
+++ b/src/components/TransactionHistoryRows/TransactionTrade.tsx
@@ -66,7 +66,7 @@ export const TransactionTrade = ({
         )}
         <Row title='sentTo'>
           <Address
-            explorerTxLink={txDetails.explorerTxLink}
+            explorerAddressLink={txDetails.explorerAddressLink}
             address={txDetails.to}
             ens={txDetails.ensTo}
           />
@@ -91,7 +91,7 @@ export const TransactionTrade = ({
         )}
         <Row title='receivedFrom'>
           <Address
-            explorerTxLink={txDetails.explorerTxLink}
+            explorerAddressLink={txDetails.explorerAddressLink}
             address={txDetails.from}
             ens={txDetails.ensFrom}
           />

--- a/src/components/TransactionHistoryRows/UnknownTransaction.tsx
+++ b/src/components/TransactionHistoryRows/UnknownTransaction.tsx
@@ -68,7 +68,7 @@ export const UnknownTransaction = ({
         {txDetails.to && (
           <Row title='sentTo'>
             <Address
-              explorerTxLink={txDetails.explorerTxLink}
+              explorerAddressLink={txDetails.explorerAddressLink}
               address={txDetails.to}
               ens={txDetails.ensTo}
             />
@@ -95,7 +95,7 @@ export const UnknownTransaction = ({
         {txDetails.from && (
           <Row title='receivedFrom'>
             <Address
-              explorerTxLink={txDetails.explorerTxLink}
+              explorerAddressLink={txDetails.explorerAddressLink}
               address={txDetails.from}
               ens={txDetails.ensFrom}
             />


### PR DESCRIPTION
## Description

Fixes tx row address explorer link.

## Notice

<!-- Before submitting a pull request, please make sure you have answered the following: -->

- [x] Have you followed the guidelines in our [Contributing]('https://github.com/shapeshift/web/CONTRIBUTING.md) guide?
- [x] Have you checked to ensure there aren't other open [Pull Requests](https://github.com/shapeshift/web/pulls) for the same update/change?

## Pull Request Type

- [x] :bug: Bug fix (Non-breaking Change: Fixes an issue)
- [ ] :hammer_and_wrench: Chore (Non-breaking Change: Doc updates, pkg upgrades, typos, etc..)
- [ ] :nail_care: New Feature (Breaking/Non-breaking Change)

## Issue (if applicable)

## Risk

None

## Testing

Clicking on the addresses of a tx should open up a healthy valid page on the explorer.

## Screenshots (if applicable)
