### PR TITLE
fix(TransactionHistory): don't display receive Tx fees

### DIFF
--- a/src/components/TransactionHistoryRows/TransactionGenericRow.tsx
+++ b/src/components/TransactionHistoryRows/TransactionGenericRow.tsx
@@ -48,7 +48,7 @@ type TransactionGenericRowProps = {
   showDateAndGuide?: boolean
   compactMode?: boolean
   assets: TransactionRowAsset[]
-  fee: TransactionRowAsset
+  fee?: TransactionRowAsset
   txid: TxId
   blockTime: number
   explorerTxLink: string
@@ -157,29 +157,31 @@ export const TransactionGenericRow = ({
         {!compactMode && isLargerThanXl && (
           <Flex alignItems='flex-start' flex={1} flexDir='column'>
             {showDateAndGuide && <Guide title='fee' />}
-            <Flex alignItems='center' width='full'>
-              <Box flex={1}>
-                <Amount.Crypto
-                  color='inherit'
-                  fontWeight='bold'
-                  value={fromBaseUnit(fee.amount, fee.precision)}
-                  symbol={fee.symbol}
-                  maximumFractionDigits={6}
-                />
-                <Amount.Fiat
-                  color='gray.500'
-                  fontSize='sm'
-                  lineHeight='1'
-                  value={
-                    fee.amount
-                      ? bnOrZero(fromBaseUnit(fee.amount, fee.precision))
-                          .times(fee.currentPrice ?? 0)
-                          .toString()
-                      : '0'
-                  }
-                />
-              </Box>
-            </Flex>
+            {fee && (
+              <Flex alignItems='center' width='full'>
+                <Box flex={1}>
+                  <Amount.Crypto
+                    color='inherit'
+                    fontWeight='bold'
+                    value={fromBaseUnit(fee.amount, fee.precision)}
+                    symbol={fee.symbol}
+                    maximumFractionDigits={6}
+                  />
+                  <Amount.Fiat
+                    color='gray.500'
+                    fontSize='sm'
+                    lineHeight='1'
+                    value={
+                      fee.amount
+                        ? bnOrZero(fromBaseUnit(fee.amount, fee.precision))
+                            .times(fee.currentPrice ?? 0)
+                            .toString()
+                        : '0'
+                    }
+                  />
+                </Box>
+              </Flex>
+            )}
           </Flex>
         )}
         {!compactMode && isLargerThanLg && (

--- a/src/components/TransactionHistoryRows/TransactionReceive.tsx
+++ b/src/components/TransactionHistoryRows/TransactionReceive.tsx
@@ -24,7 +24,11 @@ export const TransactionReceive = ({
         blockTime={txDetails.tx.blockTime}
         symbol={txDetails.symbol}
         assets={[parseRelevantAssetFromTx(txDetails, AssetTypes.Destination)]}
-        fee={parseRelevantAssetFromTx(txDetails, AssetTypes.Fee)}
+        fee={
+          txDetails.tx?.fee &&
+          txDetails.feeAsset &&
+          parseRelevantAssetFromTx(txDetails, AssetTypes.Fee)
+        }
         explorerTxLink={txDetails.explorerTxLink}
         txid={txDetails.tx.txid}
         showDateAndGuide={showDateAndGuide}
@@ -50,11 +54,13 @@ export const TransactionReceive = ({
           />
         </Row>
         <Row title='minerFee'>
-          <Amount
-            value={txDetails.tx.fee?.value ?? '0'}
-            precision={txDetails.feeAsset?.precision ?? 0}
-            symbol={txDetails.feeAsset?.symbol ?? ''}
-          />
+          {txDetails.tx?.fee && txDetails.feeAsset && (
+            <Amount
+              value={txDetails.tx.fee?.value}
+              precision={txDetails.feeAsset?.precision ?? 0}
+              symbol={txDetails.feeAsset?.symbol ?? ''}
+            />
+          )}
         </Row>
         <Row title='status'>
           <Status status={txDetails.tx.status} />


### PR DESCRIPTION
## Description

This hides miner fees for receive Txs in TransactionHistory.

Currently, fees are displayed for receive Txs in the Transaction History section but we shouldn't display them, as unchained is not returning us fees for receive txs, which results in unwanted behavior where we're not able to surface the symbol. Confirmed with @kaladinlight that's the correct unchained behavior.

Not displaying Tx fees is also the current behavior in the Transactions section in dashboard - if we want to display it, it should be implemented in unchained and surfaced from it then displayed in both the Transactions section and Transactions History section and it would have to be a product decision, this PR just brings consistency.

## Notice

<!-- Before submitting a pull request, please make sure you have answered the following: -->

- [ ] Have you followed the guidelines in our [Contributing]('https://github.com/shapeshift/web/CONTRIBUTING.md) guide?
- [x] Have you checked to ensure there aren't other open [Pull Requests](https://github.com/shapeshift/web/pulls) for the same update/change?

## Pull Request Type

- [ ] :bug: Bug fix (Non-breaking Change: Fixes an issue)
- [ ] :hammer_and_wrench: Chore (Non-breaking Change: Doc updates, pkg upgrades, typos, etc..)
- [x] :nail_care: New Feature (Breaking/Non-breaking Change)

## Issue (if applicable)

closes #1239

## Risk

N/A, the hiding is only done for receive Txs so we don't have risks of e.g send Txs miner fees being hidden, unless they are categorized as receive Txs which would be a bigger issue.

## Testing

- Go to Transactions History section on an account with receive Txs
- "Fees" table header should be displayed, but the actual row should be empty for it
- Clicking on it should also bring empty "Miner Fee" info

## Screenshots (if applicable)
