### PR TITLE
feat: add stakeholder input field to bounty template

### DIFF
--- a/.github/ISSUE_TEMPLATE/bounty.yml
+++ b/.github/ISSUE_TEMPLATE/bounty.yml
@@ -59,10 +59,8 @@ body:
     id: stakeholder
     attributes:
       label: Sponsor / stakeholder
-      description: "Who can the bounty huter go to for questions and support?"
+      description: "To whom can the bounty hunter go to for questions and support?"
       placeholder: "@github_handle"
-    validations:
-      required: true
   - type: textarea
     id: bounty-hunters
     attributes:

--- a/.github/ISSUE_TEMPLATE/bounty.yml
+++ b/.github/ISSUE_TEMPLATE/bounty.yml
@@ -55,6 +55,14 @@ body:
           required: true
         - label: As the sponsor of this bounty I will review the changes in a preview environment (ops/product) or review the PR (engineering)
           required: true
+  - type: input
+    id: stakeholder
+    attributes:
+      label: Sponsor / stakeholder
+      description: "Who can the bounty huter go to for questions and support?"
+      placeholder: "@github_handle"
+    validations:
+      required: true
   - type: textarea
     id: bounty-hunters
     attributes:

--- a/.github/ISSUE_TEMPLATE/bounty.yml
+++ b/.github/ISSUE_TEMPLATE/bounty.yml
@@ -60,7 +60,7 @@ body:
     attributes:
       label: Sponsor / stakeholder
       description: "To whom can the bounty hunter go to for questions and support?"
-      placeholder: "@github_handle"
+      placeholder: "github_handle or discord_handle"
   - type: textarea
     id: bounty-hunters
     attributes:

--- a/.github/ISSUE_TEMPLATE/bounty.yml
+++ b/.github/ISSUE_TEMPLATE/bounty.yml
@@ -58,7 +58,7 @@ body:
   - type: input
     id: stakeholder
     attributes:
-      label: Sponsor / stakeholder
+      label: Sponsor / Stakeholder
       description: "To whom can the bounty hunter go to for questions and support?"
       placeholder: "github_handle or discord_handle"
   - type: textarea


### PR DESCRIPTION
## Description

When a bountied issue is created by a member of a non-engineering workstream it's not always clear to the bounty hunter who the bounty's technical stakeholder is.

This PR adds the option to provide this during issue creation and leaves a placeholder heading for Engineering to add once the `needs-engineering` phase is complete if it's originally omitted.

## Notice

<!-- Before submitting a pull request, please make sure you have answered the following: -->

- [x] Have you followed the guidelines in our [Contributing]('https://github.com/shapeshift/web/CONTRIBUTING.md) guide?
- [x] Have you checked to ensure there aren't other open [Pull Requests](https://github.com/shapeshift/web/pulls) for the same update/change?

## Pull Request Type

- [ ] :bug: Bug fix (Non-breaking Change: Fixes an issue)
- [ ] :hammer_and_wrench: Chore (Non-breaking Change: Doc updates, pkg upgrades, typos, etc..)
- [x] :nail_care: New Feature (Breaking/Non-breaking Change)

## Issue (if applicable)

N/A

## Risk

N/A

## Testing

Create a new bounty issue and confirm the new input field displays as expected.

## Screenshots (if applicable)

<img width="401" alt="Screen Shot 2022-03-23 at 11 01 36 am" src="https://user-images.githubusercontent.com/97164662/159596199-39185a29-c5e2-49f4-904a-df009ee83d3e.png">