### PR TITLE
fix: fall back to English if translation key is missing

### DIFF
--- a/src/context/I18nProvider/I18nProvider.tsx
+++ b/src/context/I18nProvider/I18nProvider.tsx
@@ -1,3 +1,4 @@
+import get from 'lodash/get'
 import { I18n } from 'react-polyglot'
 import { translations } from 'assets/translations'
 import { selectSelectedLocale } from 'state/slices/selectors'
@@ -6,8 +7,9 @@ import { useAppSelector } from 'state/store'
 export const I18nProvider = ({ children }: { children: React.ReactNode }) => {
   const locale: string = useAppSelector(selectSelectedLocale)
   const messages = translations[locale]
+  const onMissingKey = (key: string) => get(translations['en'], key)
   return (
-    <I18n locale={locale} messages={messages}>
+    <I18n locale={locale} messages={messages} allowMissing={true} onMissingKey={onMissingKey}>
       {children}
     </I18n>
   )


### PR DESCRIPTION
## Description

<!-- Please describe your changes -->
This PR adds fallback English translations in cases where a specific translation key is missing.
Relevant documentation for the underlying library can be found [here](https://github.com/airbnb/polyglot.js#options-overview).

While I was initially concerned that this approach may cause issues with the pluralization, it does not appear that this codebase is currently making use of that functionality anyway.
Additionally, it seems that there is already plenty of discussion underway re. [Making the translations fetched, granular and consistent](https://github.com/shapeshift/web/discussions/1063), so I took the min diff approach.

## Notice

<!-- Before submitting a pull request, please make sure you have answered the following: -->

- [x] Have you followed the guidelines in our [Contributing]('https://github.com/shapeshift/web/CONTRIBUTING.md) guide?
- [x] Have you checked to ensure there aren't other open [Pull Requests](https://github.com/shapeshift/web/pulls) for the same update/change?

## Pull Request Type

- [x] :bug: Bug fix (Non-breaking Change: Fixes an issue)
- [ ] :hammer_and_wrench: Chore (Non-breaking Change: Doc updates, pkg upgrades, typos, etc..)
- [ ] :nail_care: New Feature (Breaking/Non-breaking Change)

## Issue (if applicable)
Closes #1221 

<!-----------------------------------------------------------------------------
If applicable, please link to the github issue and put `closes #XXXX` in your comment to auto-close the issue that your PR fixes.
------------------------------------------------------------------------------>

## Risk

<!-----------------------------------------------------------------------------
Outline the scope of your changes and the risk associated with them. You must use your discretion as an engineer to determine the potential impact of your changes.

E.g. an upgrade to `hdwallet` or core state management would be considered higher risk, and might require a full regression test. UI or isolated view changes, or something behind a feature flag may have near zero risk. Small bug fixes might require testing isolated to the specific fix.
------------------------------------------------------------------------------>
This change could potentially cause some regression with the existing translations, but I would suggest that risk is on the low side. One possibility would be (as mentioned above), if we were to attempt to support pluralization under the current library. This would likely result in unexpected behaviour for some languages, in some circumstances, where a fallback translation is used.

## Testing

<!-----------------------------------------------------------------------------
If your testing steps are technical, outline steps for an engineer to verify.

If your testing steps are functional, please provide a full guide with any features requiring special attention for operations to test your branch in the preview environment.
------------------------------------------------------------------------------>
My intention was to include at least some integration/regression tests for these changes, though I am conscious that the changes, as they stand, are already going to conflict with #1216, and perhaps abstracting the provider (similarly to what was done in 1216) for the ease of testing might be out of scope for this change. 
@0xdef1cafe If you think it makes sense, or would prefer an alternative approach for testing the missing translations, I am happy to make the changes and include them in this PR.


## Screenshots (if applicable)
