### PR TITLE
fix: lowercase account specifier strings

### DIFF
--- a/src/pages/Accounts/AccountToken/AccountToken.tsx
+++ b/src/pages/Accounts/AccountToken/AccountToken.tsx
@@ -1,4 +1,5 @@
 import { CAIP19 } from '@shapeshiftoss/caip'
+import toLower from 'lodash/toLower'
 import { useSelector } from 'react-redux'
 import { Redirect, useParams } from 'react-router-dom'
 import { Route } from 'Routes/helpers'
@@ -24,7 +25,9 @@ export const AccountToken = ({ route }: AccountTokenProps) => {
    * in order to choose the account from beginning.
    */
   const accountSpecifierStrings = useSelector(selectAccountSpecifierStrings)
-  const isCurrentAccountIdOwner = Boolean(accountSpecifierStrings.includes(accountId))
+  const isCurrentAccountIdOwner = Boolean(
+    accountSpecifierStrings.map(toLower).includes(toLower(accountId))
+  )
   if (!isCurrentAccountIdOwner) return <Redirect to='/accounts' />
 
   const caip19 = assetId ? decodeURIComponent(assetId) : null

--- a/src/state/slices/accountSpecifiersSlice/selectors.ts
+++ b/src/state/slices/accountSpecifiersSlice/selectors.ts
@@ -6,5 +6,5 @@ export const selectAccountSpecifiers = (state: ReduxState) =>
 // returns an array of the full `caip2:pubkeyish` type, as used in URLs for account pages
 export const selectAccountSpecifierStrings = (state: ReduxState) =>
   state.accountSpecifiers.accountSpecifiers.map(accountSpecifier =>
-    Object.entries(accountSpecifier)[0].join(':')
+    Object.entries(accountSpecifier)[0].join(':').toLowerCase()
   )

--- a/src/state/slices/accountSpecifiersSlice/selectors.ts
+++ b/src/state/slices/accountSpecifiersSlice/selectors.ts
@@ -6,5 +6,5 @@ export const selectAccountSpecifiers = (state: ReduxState) =>
 // returns an array of the full `caip2:pubkeyish` type, as used in URLs for account pages
 export const selectAccountSpecifierStrings = (state: ReduxState) =>
   state.accountSpecifiers.accountSpecifiers.map(accountSpecifier =>
-    Object.entries(accountSpecifier)[0].join(':').toLowerCase()
+    Object.entries(accountSpecifier)[0].join(':')
   )


### PR DESCRIPTION
## Description

This fixes a bug we have in Portis/Native/KeepKey on latest develop and release branch after https://github.com/shapeshift/web/commit/ad806dee305535434440679906f1d74f130a8fa4, where clicking an account token will route back to accounts page.
The reason for this redirect is this condition:

https://github.com/shapeshift/web/blob/ad806dee305535434440679906f1d74f130a8fa4/src/pages/Accounts/AccountToken/AccountToken.tsx#L26-L28

Since account specifiers are CAIP19s containing checksummed addresses (with a mix of upper and lowercase characters), but the `accountId` is lowercase, the condition will only return true if we use Metamask, for which hdwallet-metamask calls ethereum JsonRPC's `eth_accounts` - which gets accounts lowercased.
For Portis, KK, and Native, it will always return false. 

## Notice

<!-- Before submitting a pull request, please make sure you have answered the following: -->

- [ ] Have you followed the guidelines in our [Contributing]('https://github.com/shapeshift/web/CONTRIBUTING.md) guide?
- [x] Have you checked to ensure there aren't other open [Pull Requests](https://github.com/shapeshift/web/pulls) for the same update/change?

## Pull Request Type

- [x] :bug: Bug fix (Non-breaking Change: Fixes an issue)
- [ ] :hammer_and_wrench: Chore (Non-breaking Change: Doc updates, pkg upgrades, typos, etc..)
- [ ] :nail_care: New Feature (Breaking/Non-breaking Change)

## Issue (if applicable)

No issue for this, this is hotfixing release branch.

## Risk

Grepped for `selectAccountSpecifierStrings` and it's used exclusively for `<AccountToken />` so it should not break anything anywhere else. 

## Testing

- Connect to any wallet that's not MetaMask
- Go to accounts page
- Clicking an account token should route to that token's page

## Screenshots (if applicable)

![image](https://user-images.githubusercontent.com/17035424/159970134-f164a220-5032-49ab-bc65-d9a0c36ffeb1.png)
