### PR TITLE
chore: upgrade react-hook-form to 7.28.1

### DIFF
--- a/package.json
+++ b/package.json
@@ -64,7 +64,7 @@
     "react-datepicker": "^4.7.0",
     "react-device-detect": "^2.1.2",
     "react-dom": "^17.0.2",
-    "react-hook-form": "7.21.2",
+    "react-hook-form": "7.28.1",
     "react-icons": "^4.2.0",
     "react-infinite-scroller": "^1.2.4",
     "react-json-csv": "^2.0.0",

--- a/yarn.lock
+++ b/yarn.lock
@@ -18053,10 +18053,10 @@ react-helmet-async@^1.0.7:
     react-fast-compare "^3.2.0"
     shallowequal "^1.1.0"
 
-react-hook-form@7.21.2:
-  version "7.21.2"
-  resolved "https://registry.yarnpkg.com/react-hook-form/-/react-hook-form-7.21.2.tgz#3faf1292b66b97f6897ba46138aeaf5a1f6031c6"
-  integrity sha512-G2qcUsZSoVolLMZi83nRcZR3VquUWI8lgAfMUyL2teL7vAFPKKwPMfKv2+tXFZjBMzNXHb+HxARdUGcETo8IqQ==
+react-hook-form@7.28.1:
+  version "7.28.1"
+  resolved "https://registry.yarnpkg.com/react-hook-form/-/react-hook-form-7.28.1.tgz#95fc37be6c6b9d57212eb7eca055fb36d079b3b7"
+  integrity sha512-mgwxvXuvt3FMY/mdnWbPc++Zf1U5xYzkhOaL05mtFMLvXc9MvUhMUlKtUVuO12sOrgT3nPXBgVFawtiJ4ONrgg==
 
 react-icons@^4.2.0:
   version "4.3.1"


### PR DESCRIPTION
## Description

chore: upgrade react-hook-form to 7.28.1

## Notice

<!-- Before submitting a pull request, please make sure you have answered the following: -->

- [X] Have you followed the guidelines in our [Contributing]('https://github.com/shapeshift/web/CONTRIBUTING.md) guide?
- [X] Have you checked to ensure there aren't other open [Pull Requests](https://github.com/shapeshift/web/pulls) for the same update/change?

## Pull Request Type

- [ ] :bug: Bug fix (Non-breaking Change: Fixes an issue)
- [X] :hammer_and_wrench: Chore (Non-breaking Change: Doc updates, pkg upgrades, typos, etc..)
- [ ] :nail_care: New Feature (Breaking/Non-breaking Change)

## Issue (if applicable)

N/A

## Risk

Anything form related, like trade widget, send, etc.

## Testing

Test that all forms work correctly

