### PR TITLE
chore: fix cypress in CI

### DIFF
--- a/cypress/integration/dashboard_spec.ts
+++ b/cypress/integration/dashboard_spec.ts
@@ -44,7 +44,7 @@ describe('The Dashboard', () => {
     cy.getBySel('trade-preview-button').should('be.disabled')
     cy.getBySel('token-row-sell-max-button').click()
     // TODO@0xApotheosis - this timeout won't be necessary once external request bounty complete
-    cy.getBySel('trade-preview-button').should('have.text', 'Insufficient Funds', {
+    cy.getBySel('trade-preview-button').should('contain.text', 'Insufficient Funds', {
       timeout: 30000
     })
     // TODO - We are now at the approval screen - test the rest of the flow

--- a/cypress/integration/dashboard_spec.ts
+++ b/cypress/integration/dashboard_spec.ts
@@ -44,7 +44,7 @@ describe('The Dashboard', () => {
     cy.getBySel('trade-preview-button').should('be.disabled')
     cy.getBySel('token-row-sell-max-button').click()
     // TODO@0xApotheosis - this timeout won't be necessary once external request bounty complete
-    cy.getBySel('trade-preview-button').should('have.text', 'Not enough ETH to cover gas', {
+    cy.getBySel('trade-preview-button').should('have.text', 'Insufficient Funds', {
       timeout: 30000
     })
     // TODO - We are now at the approval screen - test the rest of the flow

--- a/src/components/Trade/TradeInput.tsx
+++ b/src/components/Trade/TradeInput.tsx
@@ -162,7 +162,7 @@ export const TradeInput = ({ history }: RouterProps) => {
     })
   }
 
-  const switchAssets = () => {
+  const switchAssets = async () => {
     const currentSellAsset = getValues('sellAsset')
     const currentBuyAsset = getValues('buyAsset')
     const action = currentBuyAsset.amount ? TradeActions.SELL : undefined
@@ -170,7 +170,7 @@ export const TradeInput = ({ history }: RouterProps) => {
     setValue('sellAsset', currentBuyAsset)
     setValue('buyAsset', currentSellAsset)
     setValue('quote', undefined)
-    getQuote({
+    await getQuote({
       amount: currentBuyAsset.amount ?? '0',
       sellAsset: currentBuyAsset,
       buyAsset: currentSellAsset,


### PR DESCRIPTION
## Description

- Recent changes to `web` fixed a bug where `hasValidTradeBalance` was incorrectly resolving to `true`. This broke Cypress because Cypress assumed the buggy behaviour was correct
- Also adds an `await` to a usage of `getQuote`

## Notice

<!-- Before submitting a pull request, please make sure you have answered the following: -->

- [x] Have you followed the guidelines in our [Contributing]('https://github.com/shapeshift/web/CONTRIBUTING.md) guide?
- [x] Have you checked to ensure there aren't other open [Pull Requests](https://github.com/shapeshift/web/pulls) for the same update/change?

## Pull Request Type

- [x] :bug: Bug fix (Non-breaking Change: Fixes an issue)
- [ ] :hammer_and_wrench: Chore (Non-breaking Change: Doc updates, pkg upgrades, typos, etc..)
- [ ] :nail_care: New Feature (Breaking/Non-breaking Change)

## Issue (if applicable)

Closes https://github.com/shapeshift/web/issues/1287

## Risk

N/A

## Testing

CI should pass.

## Screenshots (if applicable)

N/A
