### PR TITLE
fix: add cosmos to feeAsset const

### DIFF
--- a/src/state/slices/portfolioSlice/selectors.ts
+++ b/src/state/slices/portfolioSlice/selectors.ts
@@ -19,7 +19,7 @@ import {
 import { findAccountsByAssetId } from './utils'
 
 // We should prob change this once we add more chains
-const FEE_ASSET_IDS = ['eip155:1/slip44:60', 'bip122:000000000019d6689c085ae165831e93/slip44:0']
+const FEE_ASSET_IDS = ['eip155:1/slip44:60', 'bip122:000000000019d6689c085ae165831e93/slip44:0', 'cosmos:cosmoshub-4/slip44:118']
 
 export const selectPortfolioAssetIds = createDeepEqualOutputSelector(
   (state: ReduxState): PortfolioAssetBalances['ids'] => state.portfolio.assetBalances.ids,

--- a/src/state/slices/portfolioSlice/selectors.ts
+++ b/src/state/slices/portfolioSlice/selectors.ts
@@ -23,7 +23,7 @@ const FEE_ASSET_IDS = [
   'eip155:1/slip44:60',
   'bip122:000000000019d6689c085ae165831e93/slip44:0',
   'cosmos:cosmoshub-4/slip44:118',
-  'cosmos:osmosis-1/slip44:118''
+  'cosmos:osmosis-1/slip44:118'
 ]
 
 export const selectPortfolioAssetIds = createDeepEqualOutputSelector(

--- a/src/state/slices/portfolioSlice/selectors.ts
+++ b/src/state/slices/portfolioSlice/selectors.ts
@@ -19,7 +19,11 @@ import {
 import { findAccountsByAssetId } from './utils'
 
 // We should prob change this once we add more chains
-const FEE_ASSET_IDS = ['eip155:1/slip44:60', 'bip122:000000000019d6689c085ae165831e93/slip44:0', 'cosmos:cosmoshub-4/slip44:118']
+const FEE_ASSET_IDS = [
+  'eip155:1/slip44:60',
+  'bip122:000000000019d6689c085ae165831e93/slip44:0',
+  'cosmos:cosmoshub-4/slip44:118'
+]
 
 export const selectPortfolioAssetIds = createDeepEqualOutputSelector(
   (state: ReduxState): PortfolioAssetBalances['ids'] => state.portfolio.assetBalances.ids,

--- a/src/state/slices/portfolioSlice/selectors.ts
+++ b/src/state/slices/portfolioSlice/selectors.ts
@@ -22,7 +22,8 @@ import { findAccountsByAssetId } from './utils'
 const FEE_ASSET_IDS = [
   'eip155:1/slip44:60',
   'bip122:000000000019d6689c085ae165831e93/slip44:0',
-  'cosmos:cosmoshub-4/slip44:118'
+  'cosmos:cosmoshub-4/slip44:118',
+  'cosmos:osmosis-1/slip44:118''
 ]
 
 export const selectPortfolioAssetIds = createDeepEqualOutputSelector(


### PR DESCRIPTION
## Description

- Fix for cosmos showing up as an Account and a Token on the `Accounts` page.
-  The `Accounts` page relies on the selector `selectPortfolioAssetIdsByAccountIdExcludeFeeAsset` to exclude fee assets. All fee assets that are excluded need to be added to the constant array `FEE_ASSET_IDS` maually. This is definitely not ideal, and we should look at better ways to determine the fee assets of each chain dynamically so we don't have to manually add each fee asset as we implement more chains.

## Notice

<!-- Before submitting a pull request, please make sure you have answered the following: -->

- [x] Have you followed the guidelines in our [Contributing]('https://github.com/shapeshift/web/CONTRIBUTING.md) guide?
- [x] Have you checked to ensure there aren't other open [Pull Requests](https://github.com/shapeshift/web/pulls) for the same update/change?

## Pull Request Type

- [x] :bug: Bug fix (Non-breaking Change: Fixes an issue)
- [ ] :hammer_and_wrench: Chore (Non-breaking Change: Doc updates, pkg upgrades, typos, etc..)
- [ ] :nail_care: New Feature (Breaking/Non-breaking Change)

## Issue (if applicable)

closes #1273

## Risk
The risk associated with this fix is minimal, given the array is only used for this purpose.

## Testing

- Navigate to the `Accounts` page
- Cosmos should not have a token of the same name associated with it.

## Screenshots (if applicable)
