### PR TITLE
chore: bump axios to 0.26.1

### DIFF
--- a/.github/workflows/bootstrap.yml
+++ b/.github/workflows/bootstrap.yml
@@ -25,7 +25,8 @@ jobs:
     - name: Set node version
       uses: actions/setup-node@v2
       with:
-        node-version-file: '.nvmrc'
+        node-version: '16'
+        cache: yarn
 
       # Restore the previous yarn modules and Cypress binary archives.
       # Any updated archives will be saved automatically after the entire

--- a/.github/workflows/bootstrap.yml
+++ b/.github/workflows/bootstrap.yml
@@ -10,9 +10,6 @@ on:
 jobs:
   install-and-cache:
     runs-on: ubuntu-latest
-    container:
-      image: cypress/browsers:node16.13.2-chrome97-ff96
-      options: --user 1001
     env:
       REACT_APP_UNCHAINED_ETHEREUM_HTTP_URL: https://dev-api.ethereum.shapeshift.com
       REACT_APP_UNCHAINED_ETHEREUM_WS_URL: wss://dev-api.ethereum.shapeshift.com

--- a/.github/workflows/bootstrap.yml
+++ b/.github/workflows/bootstrap.yml
@@ -19,11 +19,6 @@ jobs:
       REACT_APP_ETHEREUM_NODE_URL: https://mainnet.infura.io/v3/d734c7eebcdf400185d7eb67322a7e57
       REACT_APP_FEATURE_COSMOS_INVESTOR: false
     steps:
-      - name: Set node version
-        uses: actions/setup-node@v2
-        with:
-          node-version: 16
-      - run: node -v
       - name: Checkout
         uses: actions/checkout@v2
 

--- a/.github/workflows/bootstrap.yml
+++ b/.github/workflows/bootstrap.yml
@@ -23,7 +23,6 @@ jobs:
         uses: actions/setup-node@v2
         with:
           node-version: 16
-          cache: yarn
       - run: node -v
       - name: Checkout
         uses: actions/checkout@v2

--- a/.github/workflows/bootstrap.yml
+++ b/.github/workflows/bootstrap.yml
@@ -22,14 +22,14 @@ jobs:
       REACT_APP_ETHEREUM_NODE_URL: https://mainnet.infura.io/v3/d734c7eebcdf400185d7eb67322a7e57
       REACT_APP_FEATURE_COSMOS_INVESTOR: false
     steps:
-      - name: Checkout
-        uses: actions/checkout@v2
-
       - name: Set node version
         uses: actions/setup-node@v2
         with:
-          node-version: '16'
+          node-version: 16
           cache: yarn
+      - run: node -v
+      - name: Checkout
+        uses: actions/checkout@v2
 
       # Restore the previous yarn modules and Cypress binary archives.
       # Any updated archives will be saved automatically after the entire

--- a/.github/workflows/bootstrap.yml
+++ b/.github/workflows/bootstrap.yml
@@ -22,6 +22,11 @@ jobs:
       - name: Checkout
         uses: actions/checkout@v2
 
+    - name: Set node version
+      uses: actions/setup-node@v2
+      with:
+        node-version-file: '.nvmrc'
+
       # Restore the previous yarn modules and Cypress binary archives.
       # Any updated archives will be saved automatically after the entire
       # workflow successfully finishes.

--- a/.github/workflows/bootstrap.yml
+++ b/.github/workflows/bootstrap.yml
@@ -22,6 +22,12 @@ jobs:
       - name: Checkout
         uses: actions/checkout@v2
 
+      - name: Set node version
+        uses: actions/setup-node@v2
+        with:
+          node-version: '16'
+          cache: yarn
+
       # Restore the previous yarn modules and Cypress binary archives.
       # Any updated archives will be saved automatically after the entire
       # workflow successfully finishes.

--- a/.github/workflows/bootstrap.yml
+++ b/.github/workflows/bootstrap.yml
@@ -22,12 +22,6 @@ jobs:
       - name: Checkout
         uses: actions/checkout@v2
 
-    - name: Set node version
-      uses: actions/setup-node@v2
-      with:
-        node-version: '16'
-        cache: yarn
-
       # Restore the previous yarn modules and Cypress binary archives.
       # Any updated archives will be saved automatically after the entire
       # workflow successfully finishes.

--- a/.github/workflows/bootstrap.yml
+++ b/.github/workflows/bootstrap.yml
@@ -22,11 +22,6 @@ jobs:
       - name: Checkout
         uses: actions/checkout@v2
 
-      - name: Set node version
-        uses: actions/setup-node@v2
-        with:
-          node-version-file: '.nvmrc'
-
       # Restore the previous yarn modules and Cypress binary archives.
       # Any updated archives will be saved automatically after the entire
       # workflow successfully finishes.

--- a/.github/workflows/bootstrap.yml
+++ b/.github/workflows/bootstrap.yml
@@ -10,6 +10,9 @@ on:
 jobs:
   install-and-cache:
     runs-on: ubuntu-latest
+    container:
+      image: cypress/browsers:node16.13.2-chrome97-ff96
+      options: --user 1001
     env:
       REACT_APP_UNCHAINED_ETHEREUM_HTTP_URL: https://dev-api.ethereum.shapeshift.com
       REACT_APP_UNCHAINED_ETHEREUM_WS_URL: wss://dev-api.ethereum.shapeshift.com

--- a/.github/workflows/bootstrap.yml
+++ b/.github/workflows/bootstrap.yml
@@ -22,6 +22,11 @@ jobs:
       - name: Checkout
         uses: actions/checkout@v2
 
+      - name: Set node version
+        uses: actions/setup-node@v2
+        with:
+          node-version-file: '.nvmrc'
+
       # Restore the previous yarn modules and Cypress binary archives.
       # Any updated archives will be saved automatically after the entire
       # workflow successfully finishes.

--- a/.github/workflows/pr-cypress.yml
+++ b/.github/workflows/pr-cypress.yml
@@ -33,6 +33,9 @@ jobs:
   test-chrome:
     name: Run Cypress
     runs-on: ubuntu-latest
+    container:
+      image: cypress/browsers:node16.13.2-chrome97-ff96
+      options: --user 1001
     strategy:
       # When one test fails, do not cancel the other
       # containers, because this will kill Cypress processes,

--- a/.github/workflows/pr-cypress.yml
+++ b/.github/workflows/pr-cypress.yml
@@ -49,7 +49,7 @@ jobs:
       - name: Set node version
         uses: actions/setup-node@v2
         with:
-          node-version: '16.3.1'
+          node-version-file: '.nvmrc'
 
       # Restore the previous yarn modules and Cypress binary archives.
       # Any updated archives will be saved automatically after the entire

--- a/.github/workflows/pr-cypress.yml
+++ b/.github/workflows/pr-cypress.yml
@@ -33,9 +33,6 @@ jobs:
   test-chrome:
     name: Run Cypress
     runs-on: ubuntu-latest
-    container:
-      image: cypress/browsers:node16.13.2-chrome97-ff96
-      options: --user 1001
     strategy:
       # When one test fails, do not cancel the other
       # containers, because this will kill Cypress processes,

--- a/.github/workflows/pr-cypress.yml
+++ b/.github/workflows/pr-cypress.yml
@@ -47,14 +47,14 @@ jobs:
         containers: [1, 2, 3]
         node: [16]
     steps:
-      - name: Checkout
-        uses: actions/checkout@v2
-
       - name: Set node version
         uses: actions/setup-node@v2
         with:
           node-version: ${{ matrix.node }}
           cache: yarn
+      - run: node -v
+      - name: Checkout
+        uses: actions/checkout@v2
 
       # Restore the previous yarn modules and Cypress binary archives.
       # Any updated archives will be saved automatically after the entire

--- a/.github/workflows/pr-cypress.yml
+++ b/.github/workflows/pr-cypress.yml
@@ -42,13 +42,7 @@ jobs:
         # Run 3 copies of the current job in parallel
         # We can continue adding more as our test suite grows
         containers: [1, 2, 3]
-        node: [16]
     steps:
-      - name: Set node version
-        uses: actions/setup-node@v2
-        with:
-          node-version: ${{ matrix.node }}
-      - run: node -v
       - name: Checkout
         uses: actions/checkout@v2
 
@@ -115,7 +109,7 @@ jobs:
           wait-on: 'http://localhost:3000'
           wait-on-timeout: 180
           browser: electron
-          group: Electron tests on Node v${{ matrix.node }}
+          group: Electron tests
         env:
           CYPRESS_PROJECT_ID: 'vpyrho'
           CYPRESS_RECORD_KEY: ${{ secrets.CYPRESS_RECORD_KEY || '05f1a79d-0c03-406b-8cf0-ca9ad10fa664' }}

--- a/.github/workflows/pr-cypress.yml
+++ b/.github/workflows/pr-cypress.yml
@@ -52,7 +52,8 @@ jobs:
       - name: Set node version
         uses: actions/setup-node@v2
         with:
-          node-version-file: '.nvmrc'
+          node-version: '16'
+          cache: yarn
 
       # Restore the previous yarn modules and Cypress binary archives.
       # Any updated archives will be saved automatically after the entire

--- a/.github/workflows/pr-cypress.yml
+++ b/.github/workflows/pr-cypress.yml
@@ -32,7 +32,7 @@ env:
 jobs:
   test-chrome:
     name: Run Cypress
-    runs-on: ubuntu-20.04
+    runs-on: ubuntu-latest
     strategy:
       # When one test fails, do not cancel the other
       # containers, because this will kill Cypress processes,

--- a/.github/workflows/pr-cypress.yml
+++ b/.github/workflows/pr-cypress.yml
@@ -45,6 +45,7 @@ jobs:
         # Run 3 copies of the current job in parallel
         # We can continue adding more as our test suite grows
         containers: [1, 2, 3]
+        node: [16]
     steps:
       - name: Checkout
         uses: actions/checkout@v2
@@ -52,7 +53,7 @@ jobs:
       - name: Set node version
         uses: actions/setup-node@v2
         with:
-          node-version: '16'
+          node-version: ${{ matrix.node }}
           cache: yarn
 
       # Restore the previous yarn modules and Cypress binary archives.
@@ -118,7 +119,7 @@ jobs:
           wait-on: 'http://localhost:3000'
           wait-on-timeout: 180
           browser: electron
-          group: 'Electron tests'
+          group: Electron tests on Node v${{ matrix.node }}
         env:
           CYPRESS_PROJECT_ID: 'vpyrho'
           CYPRESS_RECORD_KEY: ${{ secrets.CYPRESS_RECORD_KEY || '05f1a79d-0c03-406b-8cf0-ca9ad10fa664' }}

--- a/.github/workflows/pr-cypress.yml
+++ b/.github/workflows/pr-cypress.yml
@@ -33,8 +33,6 @@ jobs:
   test-chrome:
     name: Run Cypress
     runs-on: ubuntu-latest
-    container:
-      image: cypress/browsers:node16.13.2-chrome97-ff96
     strategy:
       # When one test fails, do not cancel the other
       # containers, because this will kill Cypress processes,
@@ -115,8 +113,8 @@ jobs:
           parallel: true
           wait-on: 'http://localhost:3000'
           wait-on-timeout: 180
-          browser: chrome
-          group: 'Chrome tests'
+          browser: electron
+          group: 'Electron tests'
         env:
           CYPRESS_PROJECT_ID: 'vpyrho'
           CYPRESS_RECORD_KEY: ${{ secrets.CYPRESS_RECORD_KEY || '05f1a79d-0c03-406b-8cf0-ca9ad10fa664' }}

--- a/.github/workflows/pr-cypress.yml
+++ b/.github/workflows/pr-cypress.yml
@@ -32,7 +32,9 @@ env:
 jobs:
   test-chrome:
     name: Run Cypress
-    runs-on: ubuntu-20.04
+    runs-on: ubuntu-latest
+    container:
+      image: cypress/browsers:node16.13.2-chrome97-ff96
     strategy:
       # When one test fails, do not cancel the other
       # containers, because this will kill Cypress processes,

--- a/.github/workflows/pr-cypress.yml
+++ b/.github/workflows/pr-cypress.yml
@@ -32,7 +32,7 @@ env:
 jobs:
   test-chrome:
     name: Run Cypress
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-20.04
     strategy:
       # When one test fails, do not cancel the other
       # containers, because this will kill Cypress processes,

--- a/.github/workflows/pr-cypress.yml
+++ b/.github/workflows/pr-cypress.yml
@@ -46,6 +46,11 @@ jobs:
       - name: Checkout
         uses: actions/checkout@v2
 
+      - name: Set node version
+        uses: actions/setup-node@v2
+        with:
+          node-version: '16.3.1'
+
       # Restore the previous yarn modules and Cypress binary archives.
       # Any updated archives will be saved automatically after the entire
       # workflow successfully finishes.

--- a/.github/workflows/pr-cypress.yml
+++ b/.github/workflows/pr-cypress.yml
@@ -48,7 +48,6 @@ jobs:
         uses: actions/setup-node@v2
         with:
           node-version: ${{ matrix.node }}
-          cache: yarn
       - run: node -v
       - name: Checkout
         uses: actions/checkout@v2

--- a/.github/workflows/pr.yml
+++ b/.github/workflows/pr.yml
@@ -29,14 +29,14 @@ jobs:
       REACT_APP_GEM_API_KEY: bb4164a72246dae1e03010d664d6cdae4e19b2554de02e3bf6c3cd30aa7e359e
       REACT_APP_GEM_ENV: production
     steps:
-      - name: Checkout
-        uses: actions/checkout@v2
-
       - name: Set node version
         uses: actions/setup-node@v2
         with:
-          node-version: '16'
+          node-version: 16
           cache: yarn
+      - run: node -v
+      - name: Checkout
+        uses: actions/checkout@v2
 
       - name: Cache dependencies
         uses: actions/cache@v2

--- a/.github/workflows/pr.yml
+++ b/.github/workflows/pr.yml
@@ -6,9 +6,6 @@ on:
 jobs:
   commitlint-lint-typecheck-test-build:
     runs-on: ubuntu-latest
-    container:
-      image: cypress/browsers:node16.13.2-chrome97-ff96
-      options: --user 1001
     env:
       REACT_APP_UNCHAINED_ETHEREUM_HTTP_URL: https://dev-api.ethereum.shapeshift.com
       REACT_APP_UNCHAINED_ETHEREUM_WS_URL: wss://dev-api.ethereum.shapeshift.com

--- a/.github/workflows/pr.yml
+++ b/.github/workflows/pr.yml
@@ -32,7 +32,8 @@ jobs:
       - name: Set node version
         uses: actions/setup-node@v2
         with:
-          node-version-file: '.nvmrc'
+          node-version: '16'
+          cache: yarn
 
       - name: Cache dependencies
         uses: actions/cache@v2

--- a/.github/workflows/pr.yml
+++ b/.github/workflows/pr.yml
@@ -28,12 +28,6 @@ jobs:
     steps:
       - name: Checkout
         uses: actions/checkout@v2
-
-      - name: Set node version
-        uses: actions/setup-node@v2
-        with:
-          node-version-file: '.nvmrc'
-
       - name: Cache dependencies
         uses: actions/cache@v2
         with:

--- a/.github/workflows/pr.yml
+++ b/.github/workflows/pr.yml
@@ -28,6 +28,12 @@ jobs:
     steps:
       - name: Checkout
         uses: actions/checkout@v2
+
+      - name: Set node version
+        uses: actions/setup-node@v2
+        with:
+          node-version-file: '.nvmrc'
+
       - name: Cache dependencies
         uses: actions/cache@v2
         with:

--- a/.github/workflows/pr.yml
+++ b/.github/workflows/pr.yml
@@ -6,6 +6,9 @@ on:
 jobs:
   commitlint-lint-typecheck-test-build:
     runs-on: ubuntu-latest
+    container:
+      image: cypress/browsers:node16.13.2-chrome97-ff96
+      options: --user 1001
     env:
       REACT_APP_UNCHAINED_ETHEREUM_HTTP_URL: https://dev-api.ethereum.shapeshift.com
       REACT_APP_UNCHAINED_ETHEREUM_WS_URL: wss://dev-api.ethereum.shapeshift.com

--- a/.github/workflows/pr.yml
+++ b/.github/workflows/pr.yml
@@ -30,7 +30,6 @@ jobs:
         uses: actions/setup-node@v2
         with:
           node-version: 16
-          cache: yarn
       - run: node -v
       - name: Checkout
         uses: actions/checkout@v2

--- a/.github/workflows/pr.yml
+++ b/.github/workflows/pr.yml
@@ -26,11 +26,6 @@ jobs:
       REACT_APP_GEM_API_KEY: bb4164a72246dae1e03010d664d6cdae4e19b2554de02e3bf6c3cd30aa7e359e
       REACT_APP_GEM_ENV: production
     steps:
-      - name: Set node version
-        uses: actions/setup-node@v2
-        with:
-          node-version: 16
-      - run: node -v
       - name: Checkout
         uses: actions/checkout@v2
 

--- a/cypress/integration/dashboard_spec.ts
+++ b/cypress/integration/dashboard_spec.ts
@@ -44,7 +44,7 @@ describe('The Dashboard', () => {
     cy.getBySel('trade-preview-button').should('be.disabled')
     cy.getBySel('token-row-sell-max-button').click()
     // TODO@0xApotheosis - this timeout won't be necessary once external request bounty complete
-    cy.getBySel('trade-preview-button').should('have.text', 'Not enough ETH to cover gas', {
+    cy.getBySel('trade-preview-button').should('contain.text', 'Insufficient Funds', {
       timeout: 30000
     })
     // TODO - We are now at the approval screen - test the rest of the flow

--- a/package.json
+++ b/package.json
@@ -36,7 +36,7 @@
     "@visx/shape": "^2.4.0",
     "@visx/tooltip": "^2.8.0",
     "allsettled-polyfill": "^1.0.4",
-    "axios": "^0.24.0",
+    "axios": "^0.26.1",
     "bignumber.js": "^9.0.2",
     "bip39": "^3.0.4",
     "browserify-zlib": "^0.2.0",

--- a/package.json
+++ b/package.json
@@ -36,7 +36,7 @@
     "@visx/shape": "^2.4.0",
     "@visx/tooltip": "^2.8.0",
     "allsettled-polyfill": "^1.0.4",
-    "axios": "^0.26.1",
+    "axios": "0.26.0",
     "bignumber.js": "^9.0.2",
     "bip39": "^3.0.4",
     "browserify-zlib": "^0.2.0",

--- a/yarn.lock
+++ b/yarn.lock
@@ -7251,6 +7251,13 @@ axios@0.21.1:
   dependencies:
     follow-redirects "^1.10.0"
 
+axios@0.26.0:
+  version "0.26.0"
+  resolved "https://registry.yarnpkg.com/axios/-/axios-0.26.0.tgz#9a318f1c69ec108f8cd5f3c3d390366635e13928"
+  integrity sha512-lKoGLMYtHvFrPVt3r+RBMp9nh34N0M8zEfCWqdWZx6phynIEhQqAdydpyBAAG211zlhX9Rgu08cOamy6XjE5Og==
+  dependencies:
+    follow-redirects "^1.14.8"
+
 axios@^0.18.0:
   version "0.18.1"
   resolved "https://registry.yarnpkg.com/axios/-/axios-0.18.1.tgz#ff3f0de2e7b5d180e757ad98000f1081b87bcea3"
@@ -7266,7 +7273,7 @@ axios@^0.21.2:
   dependencies:
     follow-redirects "^1.14.0"
 
-axios@^0.26.0, axios@^0.26.1:
+axios@^0.26.0:
   version "0.26.1"
   resolved "https://registry.yarnpkg.com/axios/-/axios-0.26.1.tgz#1ede41c51fcf51bbbd6fd43669caaa4f0495aaa9"
   integrity sha512-fPwcX4EvnSHuInCMItEhAGnaSEXRBjtzh9fOtsE6E1G6p7vl7edEeZe11QHf18+6+9gR5PbKV/sGKNaD8YaMeA==

--- a/yarn.lock
+++ b/yarn.lock
@@ -7266,17 +7266,10 @@ axios@^0.21.2:
   dependencies:
     follow-redirects "^1.14.0"
 
-axios@^0.24.0:
-  version "0.24.0"
-  resolved "https://registry.yarnpkg.com/axios/-/axios-0.24.0.tgz#804e6fa1e4b9c5288501dd9dff56a7a0940d20d6"
-  integrity sha512-Q6cWsys88HoPgAaFAVUb0WpPk0O8iTeisR9IMqy9G8AbO4NlpVknrnQS03zzF9PGAWgO3cgletO3VjV/P7VztA==
-  dependencies:
-    follow-redirects "^1.14.4"
-
-axios@^0.26.0:
-  version "0.26.0"
-  resolved "https://registry.yarnpkg.com/axios/-/axios-0.26.0.tgz#9a318f1c69ec108f8cd5f3c3d390366635e13928"
-  integrity sha512-lKoGLMYtHvFrPVt3r+RBMp9nh34N0M8zEfCWqdWZx6phynIEhQqAdydpyBAAG211zlhX9Rgu08cOamy6XjE5Og==
+axios@^0.26.0, axios@^0.26.1:
+  version "0.26.1"
+  resolved "https://registry.yarnpkg.com/axios/-/axios-0.26.1.tgz#1ede41c51fcf51bbbd6fd43669caaa4f0495aaa9"
+  integrity sha512-fPwcX4EvnSHuInCMItEhAGnaSEXRBjtzh9fOtsE6E1G6p7vl7edEeZe11QHf18+6+9gR5PbKV/sGKNaD8YaMeA==
   dependencies:
     follow-redirects "^1.14.8"
 
@@ -11809,7 +11802,7 @@ follow-redirects@1.5.10:
   dependencies:
     debug "=3.1.0"
 
-follow-redirects@^1.0.0, follow-redirects@^1.10.0, follow-redirects@^1.14.0, follow-redirects@^1.14.4, follow-redirects@^1.14.8:
+follow-redirects@^1.0.0, follow-redirects@^1.10.0, follow-redirects@^1.14.0, follow-redirects@^1.14.8:
   version "1.14.9"
   resolved "https://registry.yarnpkg.com/follow-redirects/-/follow-redirects-1.14.9.tgz#dd4ea157de7bfaf9ea9b3fbd85aa16951f78d8d7"
   integrity sha512-MQDfihBQYMcyy5dhRDJUHcw7lb2Pv/TuE6xP1vyraLukNDHKbDxDNaOE3NbCAdKQApno+GPRyo1YAp89yCjK4w==


### PR DESCRIPTION
Note: parking until GitHub actions start working again. 

## Description

Make required changes to allow us to upgrade to axios `0.26.1`.

- Run Cypress with Cypress's built-in Electron version, which matches the local behavor of `yarn test:cypress:headless` - we want comfort that passing locally with pass in CI
- Run Cypress workers on `ubuntu-latest`
- Bump axios version
- Update trade test for correct behaviour

## Notice

<!-- Before submitting a pull request, please make sure you have answered the following: -->

- [x] Have you followed the guidelines in our [Contributing]('https://github.com/shapeshift/web/CONTRIBUTING.md) guide?
- [x] Have you checked to ensure there aren't other open [Pull Requests](https://github.com/shapeshift/web/pulls) for the same update/change?

## Pull Request Type

- [x] :bug: Bug fix (Non-breaking Change: Fixes an issue)
- [ ] :hammer_and_wrench: Chore (Non-breaking Change: Doc updates, pkg upgrades, typos, etc..)
- [ ] :nail_care: New Feature (Breaking/Non-breaking Change)

## Issue (if applicable)

A fast-follow to firm-up the CI pipeline after the shenanigans first noted in https://github.com/shapeshift/web/issues/1287.

## Risk

N/A

## Testing

CI tests (particularly Cypress) should pass.

## Screenshots (if applicable)

N/A