### PR TITLE
fix: accounts balances by chain buckets

### DIFF
--- a/src/state/slices/portfolioSlice/selectors.ts
+++ b/src/state/slices/portfolioSlice/selectors.ts
@@ -1,6 +1,6 @@
 import { createSelector } from '@reduxjs/toolkit'
 import { CAIP10, CAIP19 } from '@shapeshiftoss/caip'
-import { Asset } from '@shapeshiftoss/types'
+import { Asset, ChainTypes } from '@shapeshiftoss/types'
 import toLower from 'lodash/toLower'
 import { bn, bnOrZero } from 'lib/bignumber/bignumber'
 import { fromBaseUnit } from 'lib/math'
@@ -16,7 +16,7 @@ import {
   PortfolioAssets,
   PortfolioBalancesById
 } from './portfolioSlice'
-import { findAccountsByAssetId } from './utils'
+import { accountIdToFeeAssetId, findAccountsByAssetId } from './utils'
 
 // We should prob change this once we add more chains
 const FEE_ASSET_IDS = ['eip155:1/slip44:60', 'bip122:000000000019d6689c085ae165831e93/slip44:0']
@@ -322,10 +322,30 @@ export const selectPortfolioAllocationPercentByFilter = createSelector(
 
 export const selectPortfolioAccountIdsSortedFiat = createSelector(
   selectPortfolioTotalFiatBalanceByAccount,
-  totalAccountBalances => {
-    return Object.entries(totalAccountBalances)
-      .sort(([_, a], [__, b]) => (bnOrZero(a).gte(bnOrZero(b)) ? -1 : 1))
-      .map(([acctId, _]) => acctId)
+  selectAssets,
+  (totalAccountBalances, assets) => {
+    const sortedAccountBalances = Object.entries(totalAccountBalances)
+      .sort(([_, accountBalanceA], [__, accountBalanceB]) =>
+        bnOrZero(accountBalanceA).gte(bnOrZero(accountBalanceB)) ? -1 : 1
+      )
+      .map(([accountId, _]) => accountId)
+
+    const sortedAccountBalancesByChainBuckets = sortedAccountBalances.reduce(
+      (acc: Record<ChainTypes, CAIP10[]>, accountId) => {
+        const assetId = accountIdToFeeAssetId(accountId)
+        const asset = assets[assetId]
+
+        if (!acc[asset.chain]) {
+          acc[asset.chain] = []
+        }
+
+        acc[asset.chain] = [...acc[asset.chain], accountId]
+        return acc
+      },
+      {} as Record<ChainTypes, CAIP10[]>
+    )
+
+    return Object.values(sortedAccountBalancesByChainBuckets).flat()
   }
 )
 


### PR DESCRIPTION
## Description

This sorts accounts balances by chain buckets in the accounts page. 

- tested on an account with a mixed balance of BTC (on Segwit, Segwit Native and Legacy) and ATOM on CosmosHub. 
- also tested on an account with ETH and ERC20 tokens exclusively, in isolation (without other assets)
- not tested with both of these two cases at the same time (an account with a mix of BTC (Segwit, Segwit Native and Legacy), Atom on CosmosHub and ETH + ERC20 tokens

## Notice

<!-- Before submitting a pull request, please make sure you have answered the following: -->

- [x] Have you followed the guidelines in our [Contributing]('https://github.com/shapeshift/web/CONTRIBUTING.md) guide?
- [x] Have you checked to ensure there aren't other open [Pull Requests](https://github.com/shapeshift/web/pulls) for the same update/change?

## Pull Request Type

- [x] :bug: Bug fix (Non-breaking Change: Fixes an issue)
- [ ] :hammer_and_wrench: Chore (Non-breaking Change: Doc updates, pkg upgrades, typos, etc..)
- [ ] :nail_care: New Feature (Breaking/Non-breaking Change)

## Issue (if applicable)

closes #1289

## Risk

- Is using `asset.chain` as a discriminator the right way to go? Is there any case in the future where this could break sorting, and do we have a better way to achieve this using account specifiers?
- This could potentially break the sorting in the case of a mix of assets and account tokens e.g ERC20s

## Testing

- Go to accounts page
- Accounts should be grouped by asset type
- Sorting by fiat balance should still be working

## Screenshots (if applicable)

<img width="1213" alt="image" src="https://user-images.githubusercontent.com/17035424/160153196-2d971328-e82d-4998-b3ae-61b85cc7bf8d.png">
<img width="1209" alt="image" src="https://user-images.githubusercontent.com/17035424/160153623-7ceffe56-561b-4230-9504-88baea75ad62.png">