### PR TITLE
chore: add effort estimate to bounty template

### DIFF
--- a/.github/ISSUE_TEMPLATE/bounty.yml
+++ b/.github/ISSUE_TEMPLATE/bounty.yml
@@ -56,6 +56,12 @@ body:
         - label: As the sponsor of this bounty I will review the changes in a preview environment (ops/product) or review the PR (engineering)
           required: true
   - type: input
+    id: estimate
+    attributes:
+      label: Estimated effort
+      description: "Estimated effort to complete the bounty, in hours or days"
+      placeholder: "Half a day"
+  - type: input
     id: stakeholder
     attributes:
       label: Sponsor / Stakeholder


### PR DESCRIPTION
## Description

Help the bounty poster, aka 0xean, assign an appropriate payout for the bounty.

## Notice

<!-- Before submitting a pull request, please make sure you have answered the following: -->

- [x] Have you followed the guidelines in our [Contributing]('https://github.com/shapeshift/web/CONTRIBUTING.md) guide?
- [x] Have you checked to ensure there aren't other open [Pull Requests](https://github.com/shapeshift/web/pulls) for the same update/change?

## Pull Request Type

- [ ] :bug: Bug fix (Non-breaking Change: Fixes an issue)
- [ ] :hammer_and_wrench: Chore (Non-breaking Change: Doc updates, pkg upgrades, typos, etc..)
- [x] :nail_care: New Feature (Breaking/Non-breaking Change)

## Issue (if applicable)

N/A

## Risk

N/A

## Testing

Create a new bounty - an input box to enter estimated effort should show.

## Screenshots (if applicable)

<img width="389" alt="Screen Shot 2022-03-26 at 6 54 17 pm" src="https://user-images.githubusercontent.com/97164662/160230341-0346cab4-0bd3-4b24-be3b-70386a43d778.png">