### PR TITLE
chore: use cypress-io/github-action@v3

### DIFF
--- a/.github/workflows/pr-cypress.yml
+++ b/.github/workflows/pr-cypress.yml
@@ -100,7 +100,7 @@ jobs:
       # Because of "record" and "parallel" parameters
       # our workers will load balance all found tests among themselves
       - name: Cypress run
-        uses: cypress-io/github-action@v2
+        uses: cypress-io/github-action@v3
         with:
           install: false
           record: true


### PR DESCRIPTION
## Description

`github-action@v2` uses Node 12, which I suspect could be causing some of the flakeyness in CI.

`github-action@v3` uses Node 16, which may resolve these issues.

## Notice

<!-- Before submitting a pull request, please make sure you have answered the following: -->

- [x] Have you followed the guidelines in our [Contributing]('https://github.com/shapeshift/web/CONTRIBUTING.md) guide?
- [x] Have you checked to ensure there aren't other open [Pull Requests](https://github.com/shapeshift/web/pulls) for the same update/change?

## Pull Request Type

- [ ] :bug: Bug fix (Non-breaking Change: Fixes an issue)
- [x] :hammer_and_wrench: Chore (Non-breaking Change: Doc updates, pkg upgrades, typos, etc..)
- [ ] :nail_care: New Feature (Breaking/Non-breaking Change)

## Issue (if applicable)

Closes https://github.com/shapeshift/web/issues/1325

## Risk

It could make CI worse, but we'll mitigate that by testing exhaustively in this PR.

## Testing

CI on this PR should reliably pass.

## Screenshots (if applicable)

N/A