### PR TITLE
fix: split headers into multiple lines

### DIFF
--- a/headers.js
+++ b/headers.js
@@ -103,12 +103,10 @@ const defaultMetas = Object.entries(baseMeta)
 // This will generate a new line for every single url
 const urlsMetas = Object.entries(baseMeta).reduce((result, [k, v]) => {
   // First we filter datas containing any url
-  const urlValues = v.filter(value => value && value.match('://') && value.match('://').length > 0)
+  const urlValues = v.filter(value => value && value.match('://'))
 
-  if (urlValues.length > 0) {
-    // For every url, we add a key/value pair object to the result of the reducer
-    urlValues.forEach(url => result.push({ key: 'Content-Security-Policy', value: `${k} ${url}` }))
-  }
+  // For every url, we add a key/value pair object to the result of the reducer
+  urlValues.forEach(url => result.push({ key: 'Content-Security-Policy', value: `${k} ${url}` }))
 
   return result
 }, [])

--- a/headers.js
+++ b/headers.js
@@ -94,7 +94,7 @@ const cspMeta = Object.entries(baseMeta)
 // This will filter basic meta datas and inline it for the first Content-Security-Policy line
 const defaultMetas = Object.entries(baseMeta)
   .map(([k, v]) => {
-    const keyValues = v.filter(value => !value.match('://'))
+    const keyValues = v.filter(value => value && !value.match('://'))
 
     return `${[k, ...keyValues].join(' ')}`
   })
@@ -103,7 +103,7 @@ const defaultMetas = Object.entries(baseMeta)
 // This will generate a new line for every single url
 const urlsMetas = Object.entries(baseMeta).reduce((result, [k, v]) => {
   // First we filter datas containing any url
-  const urlValues = v.filter(value => value.match('://') && value.match('://').length > 0)
+  const urlValues = v.filter(value => value && value.match('://') && value.match('://').length > 0)
 
   if (urlValues.length > 0) {
     // For every url, we add a key/value pair object to the result of the reducer


### PR DESCRIPTION
## Description

As the @mrnerdhair  asked me to avoid modifying the `cspMeta` object, I used a `.map` and a `.reduce` in order to generate the first CSP line of `_headers` and generate every line containing an URL

## Notice

<!-- Before submitting a pull request, please make sure you have answered the following: -->

- [x] Have you followed the guidelines in our [Contributing]('https://github.com/shapeshift/web/CONTRIBUTING.md) guide?
- [x] Have you checked to ensure there aren't other open [Pull Requests](https://github.com/shapeshift/web/pulls) for the same update/change?

## Pull Request Type

- [x] :bug: Bug fix (Non-breaking Change: Fixes an issue)
- [ ] :hammer_and_wrench: Chore (Non-breaking Change: Doc updates, pkg upgrades, typos, etc..)
- [ ] :nail_care: New Feature (Breaking/Non-breaking Change)

## Issue (if applicable)
closes #1024
<!-----------------------------------------------------------------------------
If applicable, please link to the github issue and put `closes #XXXX` in your comment to auto-close the issue that your PR fixes.
------------------------------------------------------------------------------>

## Risk
- CloudFlare headers could be wrong
<!-----------------------------------------------------------------------------
Outline the scope of your changes and the risk associated with them. You must use your discretion as an engineer to determine the potential impact of your changes.

E.g. an upgrade to `hdwallet` or core state management would be considered higher risk, and might require a full regression test. UI or isolated view changes, or something behind a feature flag may have near zero risk. Small bug fixes might require testing isolated to the specific fix.
------------------------------------------------------------------------------>

## Testing
- Try to build the app and verify the content of `build/_headers`
- As A/C said, it should be tested in the preview environment :(
<!-----------------------------------------------------------------------------
If your testing steps are technical, outline steps for an engineer to verify.

If your testing steps are functional, please provide a full guide with any features requiring special attention for operations to test your branch in the preview environment.
------------------------------------------------------------------------------>

## Screenshots (if applicable)
Content of the `_headers` file
```
/*
  Cache-Control: no-transform
  Content-Security-Policy: default-src 'self'; child-src 'self' blob: 'report-sample'; connect-src 'self' data:; frame-src; img-src 'self' data: blob: filesystem:; script-src 'self' blob: 'unsafe-eval' 'unsafe-inline' 'report-sample'; style-src 'self' 'unsafe-inline' 'report-sample'; base-uri 'none'; object-src 'none'; frame-ancestors 'none'
  Content-Security-Policy: connect-src https://api.0x.org
  Content-Security-Policy: connect-src https://gas.api.0x.org
  Content-Security-Policy: connect-src https://api.coingecko.com
  Content-Security-Policy: connect-src https://api.yearn.finance
  Content-Security-Policy: connect-src https://cache.yearn.finance/v1/chains/
  Content-Security-Policy: connect-src https://test-api.yearn.network/v1/
  Content-Security-Policy: connect-src https://api.thegraph.com/subgraphs/name/salazarguille/yearn-vaults-v2-subgraph-mainnet
  Content-Security-Policy: connect-src https://raw.githubusercontent.com/yearn/yearn-assets/
  Content-Security-Policy: connect-src https://raw.githack.com/trustwallet/assets/
  Content-Security-Policy: connect-src https://api.zapper.fi/v1/prices
  Content-Security-Policy: connect-src https://meta.yearn.network/vaults/1/all
  Content-Security-Policy: connect-src https://api.github.com/repos/yearn/yearn-assets/
  Content-Security-Policy: connect-src https://api.coincap.io/v2/assets
  Content-Security-Policy: connect-src https://api.coincap.io/v2/assets/
  Content-Security-Policy: connect-src https://api.gem.co/institutions/coinify/supported_currencies
  Content-Security-Policy: connect-src https://api.gem.co/institutions/wyre/supported_currencies
  Content-Security-Policy: connect-src https://gem-widgets-assets.s3-us-west-2.amazonaws.com/currencies/crypto/
  Content-Security-Policy: connect-src https://onramp.gem.co
  Content-Security-Policy: connect-src https://api-osmosis.imperator.co/tokens/
  Content-Security-Policy: connect-src https://mainnet.infura.io/v3/d734c7eebcdf400185d7eb67322a7e57
  Content-Security-Policy: connect-src https://dev-api.ethereum.shapeshift.com
  Content-Security-Policy: connect-src wss://dev-api.ethereum.shapeshift.com
  Content-Security-Policy: connect-src https://dev-api.bitcoin.shapeshift.com
  Content-Security-Policy: connect-src wss://dev-api.bitcoin.shapeshift.com
  Content-Security-Policy: connect-src https://dev-api.cosmos.shapeshift.com
  Content-Security-Policy: connect-src wss://dev-api.cosmos.shapeshift.com
  Content-Security-Policy: frame-src https://fwd.metamask.io/
  Content-Security-Policy: frame-src https://widget.portis.io
  Content-Security-Policy: img-src https://gem-widgets-assets.s3-us-west-2.amazonaws.com/currencies/crypto/
  Content-Security-Policy: img-src https://assets.coincap.io/assets/icons/
  Content-Security-Policy: img-src https://static.coincap.io/assets/icons/
  Content-Security-Policy: img-src https://assets.coingecko.com/coins/images/
  Content-Security-Policy: img-src https://raw.githack.com/trustwallet/assets/
  Content-Security-Policy: img-src https://rawcdn.githack.com/yearn/yearn-assets/
  Content-Security-Policy: img-src https://raw.githack.com/yearn/yearn-assets/
  Content-Security-Policy: img-src https://assets.yearn.network/tokens/
  Content-Security-Policy: img-src https://raw.githubusercontent.com/yearn/yearn-assets/
  Content-Security-Policy: img-src https://rawcdn.githack.com/trustwallet/assets/
  Content-Security-Policy: img-src https://raw.githubusercontent.com/osmosis-labs/
  Content-Security-Policy: img-src https://raw.githack.com/shapeshift/lib/
  Content-Security-Policy: img-src https://raw.githubusercontent.com/shapeshift/lib/
  Cross-Origin-Opener-Policy: same-origin-allow-popups
  Permissions-Policy: document-domain=()
  Referrer-Policy: no-referrer
  X-Content-Type-Options: nosniff
  X-Frame-Options: DENY
```