### PR TITLE
fix: redux selectors circular imports

### DIFF
--- a/src/components/Modals/Send/hooks/useSendDetails/useSendDetails.test.tsx
+++ b/src/components/Modals/Send/hooks/useSendDetails/useSendDetails.test.tsx
@@ -40,9 +40,7 @@ jest.mock('state/slices/selectors', () => ({
   selectPortfolioCryptoHumanBalanceByFilter: jest.fn(),
   selectPortfolioCryptoBalanceByFilter: jest.fn(),
   selectPortfolioFiatBalanceByFilter: jest.fn(),
-  selectMarketDataById: jest.fn(),
-  selectAssets: jest.fn(),
-  selectBalanceThreshold: jest.fn()
+  selectMarketDataById: jest.fn()
 }))
 
 const ethCaip19 = 'eip155:1/slip44:60'

--- a/src/components/Modals/Send/hooks/useSendFees/useSendFees.test.tsx
+++ b/src/components/Modals/Send/hooks/useSendFees/useSendFees.test.tsx
@@ -14,9 +14,7 @@ jest.mock('state/slices/selectors', () => ({
   ...jest.requireActual('state/slices/selectors'),
   selectAssetByCAIP19: (_state: ReduxState, _id: CAIP19) => mockEthAsset,
   selectFeeAssetById: (_state: ReduxState, _id: CAIP19) => mockEthAsset,
-  selectMarketDataById: () => mockEthAsset,
-  selectAssets: jest.fn(),
-  selectBalanceThreshold: jest.fn()
+  selectMarketDataById: () => mockEthAsset
 }))
 
 const fees = {

--- a/src/components/Trade/hooks/useTradeRoutes/useTradeRoutes.test.tsx
+++ b/src/components/Trade/hooks/useTradeRoutes/useTradeRoutes.test.tsx
@@ -16,7 +16,6 @@ jest.mock('lib/web3-instance')
 jest.mock('react-hook-form')
 jest.mock('../useSwapper/useSwapper')
 jest.mock('state/slices/selectors', () => ({
-  ...jest.requireActual('state/slices/selectors'),
   selectAssets: () => ({
     'eip155:1/slip44:60': mockETH,
     'eip155:1/erc20:0xc770eefad204b5180df6a14ee197d99d808ee52d': mockFOX

--- a/src/state/slices/assetsSlice/selectors.ts
+++ b/src/state/slices/assetsSlice/selectors.ts
@@ -4,7 +4,7 @@ import { Asset, ChainTypes, NetworkTypes } from '@shapeshiftoss/types'
 import cloneDeep from 'lodash/cloneDeep'
 import sortBy from 'lodash/sortBy'
 import { ReduxState } from 'state/reducer'
-import { selectMarketDataIds } from 'state/slices/selectors'
+import { selectMarketDataIds } from 'state/slices/marketDataSlice/selectors'
 
 export const selectAssetByCAIP19 = createSelector(
   (state: ReduxState) => state.assets.byId,

--- a/src/state/slices/portfolioSlice/selectors.ts
+++ b/src/state/slices/portfolioSlice/selectors.ts
@@ -6,7 +6,9 @@ import { bn, bnOrZero } from 'lib/bignumber/bignumber'
 import { fromBaseUnit } from 'lib/math'
 import { ReduxState } from 'state/reducer'
 import { createDeepEqualOutputSelector } from 'state/selector-utils'
-import { selectAssets, selectBalanceThreshold, selectMarketData } from 'state/slices/selectors'
+import { selectAssets } from 'state/slices/assetsSlice/selectors'
+import { selectMarketData } from 'state/slices/marketDataSlice/selectors'
+import { selectBalanceThreshold } from 'state/slices/preferencesSlice/selectors'
 
 import { AccountSpecifier } from '../accountSpecifiersSlice/accountSpecifiersSlice'
 import {

--- a/src/state/slices/selectors.ts
+++ b/src/state/slices/selectors.ts
@@ -1,6 +1,15 @@
-export * from './marketDataSlice/selectors'
-export * from './assetsSlice/selectors'
-export * from './preferencesSlice/selectors'
-export * from './portfolioSlice/selectors'
-export * from './txHistorySlice/selectors'
+/**
+ * IMPORTANT NOTE:
+ *  if you are importing selectors from another slice selectors file,
+ *  to avoid circular imports, those selectors must be imported from
+ *  `state/slices/[sliceName]/selectors` instead of this file.
+ *
+ * for the rest of the files, they CAN be imported from `state/slices/selectors`.
+ */
+
 export * from './accountSpecifiersSlice/selectors'
+export * from './assetsSlice/selectors'
+export * from './marketDataSlice/selectors'
+export * from './portfolioSlice/selectors'
+export * from './preferencesSlice/selectors'
+export * from './txHistorySlice/selectors'

--- a/src/state/store.ts
+++ b/src/state/store.ts
@@ -9,7 +9,7 @@ import { apiSlices, reducer, ReduxState, slices } from './reducer'
 import { assetApi } from './slices/assetsSlice/assetsSlice'
 import { marketApi } from './slices/marketDataSlice/marketDataSlice'
 import { portfolioApi } from './slices/portfolioSlice/portfolioSlice'
-import * as portfolioSelectors from './slices/portfolioSlice/selectors'
+import * as selectors from './slices/selectors'
 import { txHistoryApi } from './slices/txHistorySlice/txHistorySlice'
 
 const persistConfig = {
@@ -18,7 +18,7 @@ const persistConfig = {
   storage: localforage
 }
 
-registerSelectors(portfolioSelectors)
+registerSelectors(selectors)
 
 const apiMiddleware = [
   portfolioApi.middleware,


### PR DESCRIPTION
## Description

`state/slices/selectors` file had circular imports, this PR will fix that.

this PR also uses all selectors to show them up in `reselect-tools`

also, some test files were refactored, they were previously failing because of this circular importing issue and `jest.fn()` was used to make them pass.

## Notice

<!-- Before submitting a pull request, please make sure you have answered the following: -->

- [x] Have you followed the guidelines in our [Contributing]('https://github.com/shapeshift/web/CONTRIBUTING.md) guide?
- [x] Have you checked to ensure there aren't other open [Pull Requests](https://github.com/shapeshift/web/pulls) for the same update/change?

## Pull Request Type

- [x] :bug: Bug fix (Non-breaking Change: Fixes an issue)
- [ ] :hammer_and_wrench: Chore (Non-breaking Change: Doc updates, pkg upgrades, typos, etc..)
- [ ] :nail_care: New Feature (Breaking/Non-breaking Change)

## Issue (if applicable)

## Risk

## Testing

## Screenshots (if applicable)
