### PR TITLE
feat: add foxies to the overview tab

### DIFF
--- a/src/pages/Defi/components/OpportunityCard.tsx
+++ b/src/pages/Defi/components/OpportunityCard.tsx
@@ -12,6 +12,7 @@ import {
 } from '@chakra-ui/react'
 import { AssetNamespace, caip19 } from '@shapeshiftoss/caip'
 import { NetworkTypes } from '@shapeshiftoss/types'
+import { EarnOpportunityType } from 'features/defi/helpers/normalizeOpportunity'
 import qs from 'qs'
 import { useHistory, useLocation } from 'react-router'
 import { Amount } from 'components/Amount/Amount'
@@ -22,17 +23,15 @@ import { useWallet, WalletActions } from 'context/WalletProvider/WalletProvider'
 import { selectAssetByCAIP19 } from 'state/slices/selectors'
 import { useAppSelector } from 'state/store'
 
-import { MergedEarnVault } from '../hooks/useVaultBalances'
-
-type StakingCardProps = {
+type OpportunityCardProps = {
   isLoaded?: boolean
-} & MergedEarnVault
+} & EarnOpportunityType
 
-export const StakingCard = ({
+export const OpportunityCard = ({
   type,
-  symbol,
   tokenAddress,
-  vaultAddress,
+  rewardAddress,
+  contractAddress,
   provider,
   chain,
   isLoaded,
@@ -40,7 +39,7 @@ export const StakingCard = ({
   cryptoAmount,
   fiatAmount,
   expired
-}: StakingCardProps) => {
+}: OpportunityCardProps) => {
   const history = useHistory()
   const location = useLocation()
   const bgHover = useColorModeValue('gray.100', 'gray.700')
@@ -65,8 +64,9 @@ export const StakingCard = ({
           pathname: `/defi/${type}/${provider}/withdraw`,
           search: qs.stringify({
             chain,
-            contractAddress: vaultAddress,
-            tokenId: tokenAddress
+            contractAddress,
+            tokenId: tokenAddress,
+            rewardId: rewardAddress
           }),
           state: { background: location }
         })
@@ -87,9 +87,14 @@ export const StakingCard = ({
           <Box ml={4}>
             <SkeletonText isLoaded={isLoaded} noOfLines={2}>
               <RawText size='lg' fontWeight='bold' textTransform='uppercase' lineHeight={1} mb={1}>
-                {`${asset.symbol} ${type}`}
+                {`${asset.symbol} ${type?.replace('_', ' ')}`}
               </RawText>
-              <Amount.Crypto color='gray.500' value={cryptoAmount} symbol={symbol} lineHeight={1} />
+              <Amount.Crypto
+                color='gray.500'
+                value={cryptoAmount}
+                symbol={asset.symbol}
+                lineHeight={1}
+              />
             </SkeletonText>
           </Box>
         </Flex>

--- a/src/pages/Defi/components/OpportunityCardList.tsx
+++ b/src/pages/Defi/components/OpportunityCardList.tsx
@@ -9,14 +9,11 @@ import { Text } from 'components/Text'
 import { bnOrZero } from 'lib/bignumber/bignumber'
 
 import { UseEarnBalancesReturn } from '../hooks/useEarnBalances'
-import { StakingCard } from './StakingCard'
+import { OpportunityCard } from './OpportunityCard'
+export const OpportunityCardList = ({ balances }: { balances: UseEarnBalancesReturn }) => {
+  const activeOpportunities = balances?.opportunities.filter(o => bnOrZero(o.cryptoAmount).gt(0))
 
-export const VaultList = ({ balances }: { balances: UseEarnBalancesReturn }) => {
-  const activeVaults = Object.values(balances?.vaults?.vaults || {}).filter(vault =>
-    bnOrZero(vault?.balance).gt(0)
-  )
-
-  if (balances.vaults.loading) return null
+  if (balances.loading) return null
 
   return (
     <Box mb={6}>
@@ -43,11 +40,13 @@ export const VaultList = ({ balances }: { balances: UseEarnBalancesReturn }) => 
         gridTemplateColumns={{ base: 'repeat(1, 1fr)', lg: 'repeat(3, 1fr)' }}
         gridGap={6}
       >
-        {activeVaults.map(vault => {
-          return <StakingCard isLoaded={true} key={vault.vaultAddress} {...vault} />
+        {activeOpportunities.map(opportunity => {
+          return (
+            <OpportunityCard isLoaded={true} key={opportunity.contractAddress} {...opportunity} />
+          )
         })}
       </SimpleGrid>
-      {activeVaults.length === 0 && (
+      {activeOpportunities.length === 0 && (
         <Card textAlign='center' py={6} boxShadow='none'>
           <Card.Body>
             <Flex justifyContent='center' fontSize='xxx-large' mb={4} color='gray.500'>

--- a/src/pages/Defi/components/OpportunityCardList.tsx
+++ b/src/pages/Defi/components/OpportunityCardList.tsx
@@ -11,7 +11,7 @@ import { bnOrZero } from 'lib/bignumber/bignumber'
 import { UseEarnBalancesReturn } from '../hooks/useEarnBalances'
 import { OpportunityCard } from './OpportunityCard'
 export const OpportunityCardList = ({ balances }: { balances: UseEarnBalancesReturn }) => {
-  const activeOpportunities = balances?.opportunities.filter(o => bnOrZero(o.cryptoAmount).gt(0))
+  const activeOpportunities = balances.opportunities.filter(o => bnOrZero(o.cryptoAmount).gt(0))
 
   if (balances.loading) return null
 

--- a/src/pages/Defi/components/OverviewHeader.tsx
+++ b/src/pages/Defi/components/OverviewHeader.tsx
@@ -35,7 +35,7 @@ export const OverviewHeader = ({
   earnBalance: UseEarnBalancesReturn
   walletBalance: string
 }) => {
-  if (earnBalance.vaults.loading) return null
+  if (earnBalance.loading) return null
 
   const netWorth = bn(earnBalance.totalEarningBalance).plus(bn(walletBalance)).toString()
 

--- a/src/pages/Defi/views/Overview.tsx
+++ b/src/pages/Defi/views/Overview.tsx
@@ -4,8 +4,8 @@ import { useSelector } from 'react-redux'
 import { Main } from 'components/Layout/Main'
 import { selectPortfolioTotalFiatBalance } from 'state/slices/selectors'
 
+import { OpportunityCardList } from '../components/OpportunityCardList'
 import { OverviewHeader } from '../components/OverviewHeader'
-import { VaultList } from '../components/VaultList'
 import { useEarnBalances } from '../hooks/useEarnBalances'
 
 const DefiHeader = () => {
@@ -24,7 +24,7 @@ export const Overview = () => {
     <Main titleComponent={<DefiHeader />}>
       <OverviewHeader earnBalance={balances} walletBalance={walletBalance} />
       <Stack spacing={4} divider={<Divider marginTop={0} />}>
-        <VaultList balances={balances} />
+        <OpportunityCardList balances={balances} />
       </Stack>
     </Main>
   )


### PR DESCRIPTION
## Description

- Add the foxy opportunities to the overview tab
- Rename some stuff that was vault specific to just the generic Earn Opportunity

## Notice

<!-- Before submitting a pull request, please make sure you have answered the following: -->

- [x] Have you followed the guidelines in our [Contributing]('https://github.com/shapeshift/web/CONTRIBUTING.md) guide?
- [x] Have you checked to ensure there aren't other open [Pull Requests](https://github.com/shapeshift/web/pulls) for the same update/change?

## Pull Request Type

- [ ] :bug: Bug fix (Non-breaking Change: Fixes an issue)
- [ ] :hammer_and_wrench: Chore (Non-breaking Change: Doc updates, pkg upgrades, typos, etc..)
- [x] :nail_care: New Feature (Breaking/Non-breaking Change)

## Issue (if applicable)


## Risk

Low risk -- reworked the logic to display the vaults and foxy opportunities to be more generic, if this doesn't show the user can still see these in all other places that we display opportunities. So it will not prevent the user from interacting with their opportunities.

## Testing

Go to DeFi overview section, confirm your vaults are still showing.

## Screenshots (if applicable)
