### PR TITLE
show toast when /env.json is updated

### DIFF
--- a/src/hooks/useHasAppUpdated/useHasAppUpdated.test.ts
+++ b/src/hooks/useHasAppUpdated/useHasAppUpdated.test.ts
@@ -9,7 +9,7 @@ jest.mock('axios')
 const mockAxios = axios as jest.Mocked<typeof axios>
 
 describe('appUpdated', () => {
-  let oldWindowLocation = window.location
+  const oldWindowLocation = window.location
 
   beforeAll(() => {
     delete (window as any).location
@@ -42,16 +42,16 @@ describe('appUpdated', () => {
     mockAxios.get.mockImplementation(url => {
       return Promise.resolve({ data: {} })
     })
-    let { result, waitFor } = renderHook(() => useHasAppUpdated())
+    const { result, waitFor } = renderHook(() => useHasAppUpdated())
 
-    expect(result.current).toBeFalsy()
+    expect(result.current).toBe(false)
     // eslint-disable-next-line testing-library/no-unnecessary-act
     await act(() => waitFor(() => expect(mockAxios.get).toHaveBeenCalledTimes(2)))
 
     jest.advanceTimersByTime(APP_UPDATE_CHECK_INTERVAL)
 
     await waitFor(() => expect(mockAxios.get).toHaveBeenCalledTimes(3))
-    expect(result.current).toBeFalsy()
+    expect(result.current).toBe(false)
   })
 
   it('is true when env is changed', async () => {
@@ -61,14 +61,14 @@ describe('appUpdated', () => {
       }
       return Promise.resolve({ data: {} })
     })
-    let { result, waitForNextUpdate, waitFor } = renderHook(() => useHasAppUpdated())
-    expect(result.current).toBeFalsy()
+    const { result, waitForNextUpdate, waitFor } = renderHook(() => useHasAppUpdated())
+    expect(result.current).toBe(false)
     // eslint-disable-next-line testing-library/no-unnecessary-act
     await act(() => waitFor(() => expect(mockAxios.get).toHaveBeenCalledTimes(2)))
 
     jest.advanceTimersByTime(APP_UPDATE_CHECK_INTERVAL)
     await waitForNextUpdate()
-    expect(result.current).toBeTruthy()
+    expect(result.current).toBe(true)
   })
   it('is true when manifest is changed', async () => {
     mockAxios.get.mockImplementation(url => {
@@ -77,13 +77,13 @@ describe('appUpdated', () => {
       }
       return Promise.resolve({ data: {} })
     })
-    let { result, waitForNextUpdate, waitFor } = renderHook(() => useHasAppUpdated())
-    expect(result.current).toBeFalsy()
+    const { result, waitForNextUpdate, waitFor } = renderHook(() => useHasAppUpdated())
+    expect(result.current).toBe(false)
     // eslint-disable-next-line testing-library/no-unnecessary-act
     await act(() => waitFor(() => expect(mockAxios.get).toHaveBeenCalledTimes(2)))
 
     jest.advanceTimersByTime(APP_UPDATE_CHECK_INTERVAL)
     await waitForNextUpdate()
-    expect(result.current).toBeTruthy()
+    expect(result.current).toBe(true)
   })
 })

--- a/src/hooks/useHasAppUpdated/useHasAppUpdated.test.ts
+++ b/src/hooks/useHasAppUpdated/useHasAppUpdated.test.ts
@@ -1,0 +1,80 @@
+import { renderHook } from '@testing-library/react-hooks'
+import { act } from '@testing-library/react-hooks'
+import axios from 'axios'
+
+import { useHasAppUpdated } from './useHasAppUpdated'
+import { APP_UPDATE_CHECK_INTERVAL } from './useHasAppUpdated'
+
+jest.mock('axios')
+const mockAxios = axios as jest.Mocked<typeof axios>
+
+global.window = Object.create(window)
+const url = 'http://dummy.com'
+Object.defineProperty(window, 'location', {
+  value: {
+    hostname: url
+  },
+  writable: true
+})
+
+describe('appUpdated', () => {
+  beforeEach(() => {
+    jest.useFakeTimers()
+  })
+  afterEach(() => {
+    mockAxios.get.mockReset()
+    jest.clearAllTimers()
+  })
+  afterAll(() => {
+    jest.useRealTimers()
+  })
+
+  it('is false when nothing is changed', async () => {
+    mockAxios.get.mockImplementation(url => {
+      return Promise.resolve({ data: {} })
+    })
+    let { result, waitFor } = renderHook(() => useHasAppUpdated())
+
+    expect(result.current).toBeFalsy()
+    // eslint-disable-next-line testing-library/no-unnecessary-act
+    await act(() => waitFor(() => expect(mockAxios.get).toHaveBeenCalledTimes(2)))
+
+    jest.advanceTimersByTime(APP_UPDATE_CHECK_INTERVAL)
+
+    await waitFor(() => expect(mockAxios.get).toHaveBeenCalledTimes(3))
+    expect(result.current).toBeFalsy()
+  })
+
+  it('is true when env is changed', async () => {
+    mockAxios.get.mockImplementation(url => {
+      if (url.includes('env.json')) {
+        return Promise.resolve({ data: { changing: Date.now() } })
+      }
+      return Promise.resolve({ data: {} })
+    })
+    let { result, waitForNextUpdate, waitFor } = renderHook(() => useHasAppUpdated())
+    expect(result.current).toBeFalsy()
+    // eslint-disable-next-line testing-library/no-unnecessary-act
+    await act(() => waitFor(() => expect(mockAxios.get).toHaveBeenCalledTimes(2)))
+
+    jest.advanceTimersByTime(APP_UPDATE_CHECK_INTERVAL)
+    await waitForNextUpdate()
+    expect(result.current).toBeTruthy()
+  })
+  it('is true when manifest is changed', async () => {
+    mockAxios.get.mockImplementation(url => {
+      if (url.includes('asset-manifest.json')) {
+        return Promise.resolve({ data: { changing: Date.now() } })
+      }
+      return Promise.resolve({ data: {} })
+    })
+    let { result, waitForNextUpdate, waitFor } = renderHook(() => useHasAppUpdated())
+    expect(result.current).toBeFalsy()
+    // eslint-disable-next-line testing-library/no-unnecessary-act
+    await act(() => waitFor(() => expect(mockAxios.get).toHaveBeenCalledTimes(2)))
+
+    jest.advanceTimersByTime(APP_UPDATE_CHECK_INTERVAL)
+    await waitForNextUpdate()
+    expect(result.current).toBeTruthy()
+  })
+})

--- a/src/hooks/useHasAppUpdated/useHasAppUpdated.test.ts
+++ b/src/hooks/useHasAppUpdated/useHasAppUpdated.test.ts
@@ -8,16 +8,24 @@ import { APP_UPDATE_CHECK_INTERVAL } from './useHasAppUpdated'
 jest.mock('axios')
 const mockAxios = axios as jest.Mocked<typeof axios>
 
-global.window = Object.create(window)
-const url = 'http://dummy.com'
-Object.defineProperty(window, 'location', {
-  value: {
-    hostname: url
-  },
-  writable: true
-})
-
 describe('appUpdated', () => {
+  let oldWindowLocation = window.location
+
+  beforeAll(() => {
+    delete (window as any).location
+    const url = 'http://dummy.com'
+    ;(window.location as any) = Object.defineProperties(
+      {},
+      {
+        ...Object.getOwnPropertyDescriptors(oldWindowLocation),
+        hostname: {
+          value: url,
+          writable: true,
+          configurable: true
+        }
+      }
+    )
+  })
   beforeEach(() => {
     jest.useFakeTimers()
   })
@@ -27,6 +35,7 @@ describe('appUpdated', () => {
   })
   afterAll(() => {
     jest.useRealTimers()
+    window.location = oldWindowLocation
   })
 
   it('is false when nothing is changed', async () => {

--- a/src/hooks/useHasAppUpdated/useHasAppUpdated.ts
+++ b/src/hooks/useHasAppUpdated/useHasAppUpdated.ts
@@ -26,7 +26,7 @@ export const useHasAppUpdated = () => {
   useMemo(storeInitialAsset, [])
   useInterval(async () => {
     // we don't care about updates locally obv
-    // if (window.location.hostname === 'localhost') return
+    if (window.location.hostname === 'localhost') return
 
     let manifestMainJs, env
     try {

--- a/src/hooks/useHasAppUpdated/useHasAppUpdated.ts
+++ b/src/hooks/useHasAppUpdated/useHasAppUpdated.ts
@@ -10,12 +10,12 @@ export const useHasAppUpdated = () => {
   const [initialManifestMainJs, setManifestMainJs] = useState(null)
   const [initialEnv, setEnv] = useState(null)
   // asset-manifest tells us the latest minified built files
-  const url = '/asset-manifest.json'
+  const assetManifestUrl = '/asset-manifest.json'
   const envUrl = '/env.json'
   const storeInitialAsset = () => {
     // dummy query param bypasses browser cache
     Promise.all<any>([
-      axios.get(`${url}?${new Date().valueOf()}`).then(({ data }) => {
+      axios.get(`${assetManifestUrl}?${new Date().valueOf()}`).then(({ data }) => {
         setManifestMainJs(data)
       }),
       axios.get(`${envUrl}?${new Date().valueOf()}`).then(({ data }) => {
@@ -30,7 +30,7 @@ export const useHasAppUpdated = () => {
 
     let manifestMainJs, env
     try {
-      const { data } = await axios.get(`${url}?${new Date().valueOf()}`)
+      const { data } = await axios.get(`${assetManifestUrl}?${new Date().valueOf()}`)
       manifestMainJs = data
     } catch (e) {
       console.error(`useHasAppUpdated: error fetching asset-manifest.json`, e)
@@ -50,20 +50,17 @@ export const useHasAppUpdated = () => {
       return
     }
     //deep equality check
-    let isSameAssetManifest = isEqual(initialManifestMainJs, manifestMainJs)
-    let isSameEnv = isEqual(initialEnv, env)
-    if (!isSameAssetManifest) {
+    const isSameAssetManifest = isEqual(initialManifestMainJs, manifestMainJs)
+    const isSameEnv = isEqual(initialEnv, env)
+    if (!isSameAssetManifest || !isSameEnv) {
       console.info(
-        `useHasAppUpdated: app updated, manifest: ${JSON.stringify(
-          manifestMainJs
-        )}, initial: ${JSON.stringify(initialManifestMainJs)}`
-      )
-      setHasUpdated(true)
-    } else if (!isSameEnv) {
-      console.info(
-        `useHasAppUpdated: app updated due to changing env, env: ${JSON.stringify(
-          manifestMainJs
-        )}, initial: ${JSON.stringify(initialManifestMainJs)}`
+        !isSameAssetManifest
+          ? `useHasAppUpdated: app updated, manifest: ${JSON.stringify(
+              manifestMainJs
+            )}, initial: ${JSON.stringify(initialManifestMainJs)}`
+          : `useHasAppUpdated: app updated due to changing env, env: ${JSON.stringify(
+              env
+            )}, initial: ${JSON.stringify(initialEnv)}`
       )
       setHasUpdated(true)
     }

--- a/src/hooks/useHasAppUpdated/useHasAppUpdated.ts
+++ b/src/hooks/useHasAppUpdated/useHasAppUpdated.ts
@@ -3,39 +3,65 @@ import axios from 'axios'
 import isEqual from 'lodash/isEqual'
 import { useMemo, useState } from 'react'
 
-const APP_UPDATE_CHECK_INTERVAL = 1000 * 60
+export const APP_UPDATE_CHECK_INTERVAL = 1000 * 60
 
 export const useHasAppUpdated = () => {
   const [hasUpdated, setHasUpdated] = useState(false)
   const [initialManifestMainJs, setManifestMainJs] = useState(null)
+  const [initialEnv, setEnv] = useState(null)
   // asset-manifest tells us the latest minified built files
   const url = '/asset-manifest.json'
-  const storeMainManifestJs = async () => {
+  const envUrl = '/env.json'
+  const storeInitialAsset = () => {
     // dummy query param bypasses browser cache
-    const { data } = await axios.get(`${url}?${new Date().valueOf()}`)
-    setManifestMainJs(data)
+    Promise.all<any>([
+      axios.get(`${url}?${new Date().valueOf()}`).then(({ data }) => {
+        setManifestMainJs(data)
+      }),
+      axios.get(`${envUrl}?${new Date().valueOf()}`).then(({ data }) => {
+        setEnv(data)
+      })
+    ])
   }
-  useMemo(storeMainManifestJs, [])
+  useMemo(storeInitialAsset, [])
   useInterval(async () => {
     // we don't care about updates locally obv
-    if (window.location.hostname === 'localhost') return
+    // if (window.location.hostname === 'localhost') return
 
-    let manifestMainJs
+    let manifestMainJs, env
     try {
       const { data } = await axios.get(`${url}?${new Date().valueOf()}`)
       manifestMainJs = data
     } catch (e) {
       console.error(`useHasAppUpdated: error fetching asset-manifest.json`, e)
     }
+    try {
+      const { data } = await axios.get(`${envUrl}?${new Date().valueOf()}`)
+      env = data
+    } catch (e) {
+      console.error(`useHasAppUpdated: error fetching env.json`, e)
+    }
     if (!manifestMainJs) {
       console.error(`useHasAppUpdated: can't find main.js in asset-manifest.json`)
       return
     }
+    if (!env) {
+      console.error(`useHasAppUpdated: can't find env in env.json`)
+      return
+    }
     //deep equality check
     let isSameAssetManifest = isEqual(initialManifestMainJs, manifestMainJs)
+    let isSameEnv = isEqual(initialEnv, env)
     if (!isSameAssetManifest) {
       console.info(
         `useHasAppUpdated: app updated, manifest: ${JSON.stringify(
+          manifestMainJs
+        )}, initial: ${JSON.stringify(initialManifestMainJs)}`
+      )
+      setHasUpdated(true)
+    } else if (!isSameEnv) {
+      console.info(
+        `useHasAppUpdated: app updated due to changing env, env: ${JSON.stringify(
           manifestMainJs
         )}, initial: ${JSON.stringify(initialManifestMainJs)}`
       )

--- a/src/hooks/useHasAppUpdated/useHasAppUpdated.ts
+++ b/src/hooks/useHasAppUpdated/useHasAppUpdated.ts
@@ -23,57 +23,65 @@ export const useHasAppUpdated = () => {
   const envUrl = '/env.json'
 
   const storeAndCompareAsset = async () => {
-    // we don't care about updates locally obv
-    if (window.location.hostname === 'localhost') return
+    try {
+      // we don't care about updates locally obv
+      if (window.location.hostname === 'localhost') return
 
-    // the changed manifest, will be null if there's no change
-    const changedManifest = await (async () => {
-      const manifestMainJs = await fetchAsset(assetManifestUrl)
-      if (!manifestMainJs) {
-        console.error(`useHasAppUpdated: can't find main.js in asset-manifest.json`)
+      // the changed manifest, will be null if there's no change
+      const changedManifest = await fetchAsset(assetManifestUrl)
+        .then(manifestMainJs => {
+          if (!manifestMainJs) {
+            console.error(`useHasAppUpdated: can't find main.js in asset-manifest.json`)
+          }
+          if (!initialManifestMainJs) {
+            // first run
+            if (manifestMainJs) setManifestMainJs(manifestMainJs)
+          } else {
+            // subsequent runs
+            if (manifestMainJs && !isEqual(manifestMainJs, initialManifestMainJs)) {
+              return manifestMainJs
+            }
+          }
+          return null
+        })
+        .catch(e => {
+          console.error(`useHasAppUpdated: error comparing ${assetManifestUrl} for changes`, e)
+        })
+
+      const changedEnv = await fetchAsset(envUrl)
+        .then(env => {
+          if (!env) {
+            console.error(`useHasAppUpdated: can't find env in env.json`)
+          }
+          if (!initialEnv) {
+            // first run
+            if (env) setEnv(env)
+          } else {
+            // subsequent runs
+            if (env && !isEqual(env, initialEnv)) {
+              return env
+            }
+          }
+          return null
+        })
+        .catch(e => {
+          console.error(`useHasAppUpdated: error comparing ${envUrl} for changes`, e)
+        })
+
+      if (changedManifest != null || changedEnv != null) {
+        console.info(
+          !changedManifest != null
+            ? `useHasAppUpdated: app updated, manifest: ${JSON.stringify(
+                changedManifest
+              )}, initial: ${JSON.stringify(initialManifestMainJs)}`
+            : `useHasAppUpdated: app updated due to changing env, env: ${JSON.stringify(
+                changedEnv
+              )}, initial: ${JSON.stringify(initialEnv)}`
+        )
+        setHasUpdated(true)
       }
-
-      if (!initialManifestMainJs) {
-        // first run
-        if (manifestMainJs) setManifestMainJs(manifestMainJs)
-      } else {
-        // subsequent runs
-        if (manifestMainJs && !isEqual(manifestMainJs, initialManifestMainJs)) {
-          return manifestMainJs
-        }
-      }
-      return null
-    })()
-
-    const changedEnv = await (async () => {
-      const env = await fetchAsset(envUrl)
-      if (!env) {
-        console.error(`useHasAppUpdated: can't find env in env.json`)
-      }
-
-      if (!initialEnv) {
-        // first run
-        if (env) setEnv(env)
-      } else {
-        // subsequent runs
-        if (env && !isEqual(env, initialEnv)) {
-          return env
-        }
-      }
-      return null
-    })()
-
-    if (changedManifest != null || changedEnv != null) {
-      console.info(
-        !changedManifest != null
-          ? `useHasAppUpdated: app updated, manifest: ${JSON.stringify(
-              changedManifest
-            )}, initial: ${JSON.stringify(initialManifestMainJs)}`
-          : `useHasAppUpdated: app updated due to changing env, env: ${JSON.stringify(
-              changedEnv
-            )}, initial: ${JSON.stringify(initialEnv)}`
-      )
-      setHasUpdated(true)
+    } catch (e) {
+      console.error(`useHasAppUpdated: error comparing assets`, e)
     }
   }
 

--- a/src/hooks/useHasAppUpdated/useHasAppUpdated.ts
+++ b/src/hooks/useHasAppUpdated/useHasAppUpdated.ts
@@ -7,6 +7,7 @@ export const APP_UPDATE_CHECK_INTERVAL = 1000 * 60
 
 const fetchAsset = async (url: string) => {
   try {
+    // dummy query param bypasses browser cache
     const { data } = await axios.get(`${url}?${new Date().valueOf()}`)
     return data
   } catch (e) {


### PR DESCRIPTION
## Description

<!-- Please describe your changes -->

## Notice

<!-- Before submitting a pull request, please make sure you have answered the following: -->

- [x] Have you followed the guidelines in our [Contributing]('https://github.com/shapeshift/web/CONTRIBUTING.md) guide?
- [x] Have you checked to ensure there aren't other open [Pull Requests](https://github.com/shapeshift/web/pulls) for the same update/change?

## Pull Request Type

- [ ] :bug: Bug fix (Non-breaking Change: Fixes an issue)
- [ ] :hammer_and_wrench: Chore (Non-breaking Change: Doc updates, pkg upgrades, typos, etc..)
- [x] :nail_care: New Feature (Breaking/Non-breaking Change)

## Issue (if applicable)

closes #1309 

## Risk

N/A

## Testing

Other than the unit test, we can test this by:
- Build the web app as static and serve the build.
- Edit either env.json or asset-manifest.json file.
- Wait for a subsequent check (every 60s)
- The app should show the toast that asks for a refresh

## Screenshots (if applicable)

N/A, the interface has no change
<img width="521" alt="image" src="https://user-images.githubusercontent.com/8097699/161089984-64954dda-2463-42cf-8b84-ab41ee5e2d05.png">

