### PR TITLE
feat(cosmos): claim staking and unstaking

### DIFF
--- a/src/assets/translations/main.json
+++ b/src/assets/translations/main.json
@@ -152,6 +152,8 @@
         "risks": "risks",
         "ofParticipating": "of participating in this feature and agreeing to the",
         "terms": "terms",
+        "stakingYourTokens": "Staking your tokens",
+        "unstakingYourTokens": "Unstaking your tokens",
         "tooltip": {
           "validator": "The Validator is responsible for processing transactions, storing data and adding blocks to the blockchain.",
           "gasFees": "Gas fees on %{networkName} are much lower than those on Ethereum Mainnet. This fee is paid directly to the validators that secure and operate the network and is not paid to ShapeShift."

--- a/src/plugins/cosmos/components/modals/GetStarted/views/GetStarted.tsx
+++ b/src/plugins/cosmos/components/modals/GetStarted/views/GetStarted.tsx
@@ -15,7 +15,7 @@ type GetStartedProps = {
 }
 
 // TODO: Abstract me in a service when I start to get too big
-const ASSET_ID_TO_MAX_APR: Record<string, string> = {
+const ASSET_ID_TO_MAX_APR: Record<CAIP19, string> = {
   'cosmos:cosmoshub-4/slip44:118': '12'
 }
 

--- a/src/plugins/cosmos/components/modals/GetStarted/views/GetStarted.tsx
+++ b/src/plugins/cosmos/components/modals/GetStarted/views/GetStarted.tsx
@@ -7,14 +7,16 @@ import { useHistory, useLocation } from 'react-router-dom'
 import osmosis from 'assets/osmosis.svg'
 import { Text } from 'components/Text'
 import { useModal } from 'hooks/useModal/useModal'
+import { selectAssetByCAIP19 } from 'state/slices/selectors'
+import { useAppSelector } from 'state/store'
 
 type GetStartedProps = {
   assetId: CAIP19
 }
 
 // TODO: Abstract me in a service when I start to get too big
-const ASSET_ID_TO_MAX_APR = {
-  'cosmoshub-4/slip44:118': '12'
+const ASSET_ID_TO_MAX_APR: Record<string, string> = {
+  'cosmos:cosmoshub-4/slip44:118': '12'
 }
 
 const SHAPESHIFT_VALIDATOR_ADDRESS = 'cosmosvaloper199mlc7fr6ll5t54w7tts7f4s0cvnqgc59nmuxf'
@@ -37,11 +39,10 @@ export const GetStarted = ({ assetId }: GetStartedProps) => {
     })
     cosmosGetStarted.close()
   }
-  // TODO: wire me up, parentheses are nice but let's get asset name from selectAssetNameById instead of this
-  const asset = (_ => ({
-    name: 'Osmosis'
-  }))(assetId)
-  const maxApr = ASSET_ID_TO_MAX_APR['cosmoshub-4/slip44:118']
+
+  const asset = useAppSelector(state => selectAssetByCAIP19(state, assetId))
+  const maxApr = ASSET_ID_TO_MAX_APR[assetId]
+
   return (
     <AnimatePresence exitBeforeEnter initial={false}>
       <Box pt='51px' pb='20px' px='24px'>

--- a/src/plugins/cosmos/components/modals/Staking/Staking.tsx
+++ b/src/plugins/cosmos/components/modals/Staking/Staking.tsx
@@ -11,19 +11,18 @@ import {
 import { CosmosActionButtons } from 'plugins/cosmos/components/CosmosActionButtons/CosmosActionButtons'
 import { useRef } from 'react'
 import { useTranslate } from 'react-polyglot'
-import { matchPath, MemoryRouter, Route, Switch, useHistory, useLocation } from 'react-router-dom'
+import { matchPath, MemoryRouter, Route, Switch, useLocation } from 'react-router-dom'
 import { RouteSteps } from 'components/RouteSteps/RouteSteps'
-import { useModal } from 'hooks/useModal/useModal'
 import { selectAccountSpecifier, selectAssetByCAIP19 } from 'state/slices/selectors'
 import { useAppSelector } from 'state/store'
 
+import { StakeFormManager } from './forms/StakeFormManager'
 import {
   ClaimPath,
   claimSteps,
   entries,
   StakeRoutes,
   stakeSteps,
-  StakingModalLocation,
   StakingModalProps,
   StakingPath,
   unstakeSteps,
@@ -40,8 +39,7 @@ import { UnstakeBroadcast } from './views/UnstakeBroadcast'
 import { UnstakeConfirm } from './views/UnstakeConfirm'
 
 const StakingModalContent = ({ assetId, validatorAddress }: StakingModalProps) => {
-  const location = useLocation<StakingModalLocation>()
-  const history = useHistory()
+  const location = useLocation()
   const translate = useTranslate()
 
   const isOverview = matchPath(location.pathname, {
@@ -74,17 +72,6 @@ const StakingModalContent = ({ assetId, validatorAddress }: StakingModalProps) =
   const headerBg = useColorModeValue('gray.50', 'gray.800')
 
   const initialRef = useRef<HTMLInputElement>(null)
-  const { cosmosStaking } = useModal()
-  const { close, isOpen } = cosmosStaking
-
-  const handleCancel = () => {
-    history.goBack()
-  }
-
-  const handleClose = () => {
-    history.push(StakeRoutes.Overview)
-    close()
-  }
 
   const asset = useAppSelector(state => selectAssetByCAIP19(state, assetId))
   const accountSpecifiersForChainId = useAppSelector(state =>
@@ -95,109 +82,100 @@ const StakingModalContent = ({ assetId, validatorAddress }: StakingModalProps) =
   if (!asset || !accountSpecifier) return null
 
   return (
-    <Modal isOpen={isOpen} onClose={handleClose} isCentered initialFocusRef={initialRef}>
-      <ModalOverlay />
-      <ModalContent width='100%' maxWidth='440px'>
-        <ModalHeader textAlign='center' bg={headerBg} borderTopRadius='xl'>
-          <Stack width='full' alignItems='center' spacing={2}>
-            <Heading textTransform='capitalize' textAlign='center' fontSize='md'>
-              {!isClaim
-                ? translate('defi.assetStaking', { assetName: asset.symbol })
-                : translate('defi.claimAsset')}
-            </Heading>
-            {!isClaim && <CosmosActionButtons asset={asset} />}
-          </Stack>
-        </ModalHeader>
-        {!isOverview && (
-          <RouteSteps assetSymbol={asset.symbol} routes={getCurrentSteps()} location={location} />
-        )}
-        <ModalCloseButton borderRadius='full' />
-        <Switch location={location}>
-          <Route exact key={StakeRoutes.Stake} path={StakeRoutes.Stake}>
-            <Stake
-              assetId={assetId}
-              apr='0.12'
-              cryptoAmountAvailable='4242'
-              fiatAmountAvailable='106050'
-              marketData={{
-                price: '25',
-                marketCap: '999999',
-                volume: '1000',
-                changePercent24Hr: 2
-              }}
-              validatorAddress={validatorAddress}
-            />
-          </Route>
-          <Route exact key={StakingPath.Confirm} path={StakingPath.Confirm}>
-            <StakeConfirm
-              apr={location.state?.apr}
-              cryptoStakeAmount={location.state?.cryptoAmount}
-              assetId={assetId}
-              fiatRate={location.state?.fiatRate}
-              onCancel={handleCancel}
-            />
-          </Route>
-          <Route exact key={StakingPath.Broadcast} path={StakingPath.Broadcast}>
-            <StakeBroadcast
-              apr={location.state?.apr}
-              cryptoStakeAmount={location.state?.cryptoAmount}
-              assetId={assetId}
-              fiatRate={location.state?.fiatRate}
-              onCancel={handleCancel}
-            />
-          </Route>
-          <Route exact key={UnstakingPath.Confirm} path={UnstakingPath.Confirm}>
-            <UnstakeConfirm
-              assetId={assetId}
-              cryptoUnstakeAmount={location.state?.cryptoAmount}
-              fiatRate={location.state?.fiatRate}
-              onCancel={handleCancel}
-            />
-          </Route>
-          <Route exact key={UnstakingPath.Broadcast} path={UnstakingPath.Broadcast}>
-            <UnstakeBroadcast
-              assetId={assetId}
-              cryptoUnstakeAmount={location.state?.cryptoAmount}
-              fiatRate={location.state?.fiatRate}
-              isLoading={true}
-              validatorName='Shapeshift Validator'
-            />
-          </Route>
-          <Route exact key={StakeRoutes.Unstake} path={StakeRoutes.Unstake}>
-            <Unstake
-              assetId={assetId}
-              apr='0.12'
-              cryptoAmountStaked='4242'
-              marketData={{
-                price: '25',
-                marketCap: '999999',
-                volume: '1000',
-                changePercent24Hr: 2
-              }}
-              validatorAddress={validatorAddress}
-            />
-          </Route>
-          <Route exact key={ClaimPath.Confirm} path={ClaimPath.Confirm}>
-            <ClaimConfirm assetId={assetId} accountSpecifier={accountSpecifier} />
-          </Route>
-          <Route exact key={ClaimPath.Broadcast} path={ClaimPath.Broadcast}>
-            <ClaimBroadcast
-              fiatRate={location.state?.fiatRate}
-              cryptoAmount={location.state?.cryptoAmount}
-              assetId={assetId}
-              isLoading={true}
-            />
-          </Route>
-          <Route key={StakeRoutes.Overview} path='/'>
-            <Overview
-              assetId={assetId}
-              accountSpecifier={accountSpecifier}
-              validatorAddress={validatorAddress}
-            />
-          </Route>
-        </Switch>
-      </ModalContent>
-    </Modal>
+    <StakeFormManager>
+      {({ handleCancel, handleClose, isOpen }) => (
+        <Modal isOpen={isOpen} onClose={handleClose} isCentered initialFocusRef={initialRef}>
+          <ModalOverlay />
+          <ModalContent width='100%' maxWidth='440px'>
+            <ModalHeader textAlign='center' bg={headerBg} borderTopRadius='xl'>
+              <Stack width='full' alignItems='center' spacing={2}>
+                <Heading textTransform='capitalize' textAlign='center' fontSize='md'>
+                  {!isClaim
+                    ? translate('defi.assetStaking', { assetName: asset.symbol })
+                    : translate('defi.claimAsset')}
+                </Heading>
+                {!isClaim && <CosmosActionButtons asset={asset} />}
+              </Stack>
+            </ModalHeader>
+            {!isOverview && (
+              <RouteSteps
+                assetSymbol={asset.symbol}
+                routes={getCurrentSteps()}
+                location={location}
+              />
+            )}
+            <ModalCloseButton borderRadius='full' />
+            <Switch location={location}>
+              <Route exact key={StakeRoutes.Stake} path={StakeRoutes.Stake}>
+                <Stake assetId={assetId} apr='0.12' validatorAddress={validatorAddress} />
+              </Route>
+              <Route exact key={StakingPath.Confirm} path={StakingPath.Confirm}>
+                <StakeConfirm
+                  assetId={assetId}
+                  accountSpecifier={accountSpecifier}
+                  validatorAddress={validatorAddress}
+                  onCancel={handleCancel}
+                />
+              </Route>
+              <Route exact key={StakingPath.Broadcast} path={StakingPath.Broadcast}>
+                <StakeBroadcast
+                  assetId={assetId}
+                  accountSpecifier={accountSpecifier}
+                  validatorAddress={validatorAddress}
+                  onClose={handleClose}
+                  onCancel={handleCancel}
+                />
+              </Route>
+              <Route exact key={UnstakingPath.Confirm} path={UnstakingPath.Confirm}>
+                <UnstakeConfirm
+                  assetId={assetId}
+                  accountSpecifier={accountSpecifier}
+                  validatorAddress={validatorAddress}
+                  onCancel={handleCancel}
+                />
+              </Route>
+              <Route exact key={UnstakingPath.Broadcast} path={UnstakingPath.Broadcast}>
+                <UnstakeBroadcast
+                  assetId={assetId}
+                  accountSpecifier={accountSpecifier}
+                  validatorAddress={validatorAddress}
+                  onClose={handleClose}
+                />
+              </Route>
+              <Route exact key={StakeRoutes.Unstake} path={StakeRoutes.Unstake}>
+                <Unstake
+                  assetId={assetId}
+                  apr='0.12'
+                  accountSpecifier={accountSpecifier}
+                  validatorAddress={validatorAddress}
+                />
+              </Route>
+              <Route exact key={ClaimPath.Confirm} path={ClaimPath.Confirm}>
+                <ClaimConfirm
+                  assetId={assetId}
+                  accountSpecifier={accountSpecifier}
+                  validatorAddress={validatorAddress}
+                />
+              </Route>
+              <Route exact key={ClaimPath.Broadcast} path={ClaimPath.Broadcast}>
+                <ClaimBroadcast
+                  assetId={assetId}
+                  validatorAddress={validatorAddress}
+                  onClose={handleClose}
+                />
+              </Route>
+              <Route key={StakeRoutes.Overview} path='/'>
+                <Overview
+                  assetId={assetId}
+                  accountSpecifier={accountSpecifier}
+                  validatorAddress={validatorAddress}
+                />
+              </Route>
+            </Switch>
+          </ModalContent>
+        </Modal>
+      )}
+    </StakeFormManager>
   )
 }
 export const StakingModal = ({ assetId, validatorAddress }: StakingModalProps) => (

--- a/src/plugins/cosmos/components/modals/Staking/StakingCommon.ts
+++ b/src/plugins/cosmos/components/modals/Staking/StakingCommon.ts
@@ -1,5 +1,5 @@
 import { CAIP19 } from '@shapeshiftoss/caip'
-import { BigNumber } from 'lib/bignumber/bignumber'
+import { chainAdapters } from '@shapeshiftoss/types'
 
 export enum StakingAction {
   Stake = 'stake',
@@ -11,13 +11,6 @@ export enum StakingAction {
 export type StakingModalProps = {
   assetId: CAIP19
   validatorAddress: string
-}
-
-export type StakingModalLocation = {
-  cryptoAmount: BigNumber
-  assetId: CAIP19
-  fiatRate: BigNumber
-  apr: string
 }
 
 export enum StakeRoutes {
@@ -60,13 +53,23 @@ export enum InputType {
 }
 
 export enum Field {
+  AmountFieldError = 'amountFieldError',
   FiatAmount = 'fiatAmount',
-  CryptoAmount = 'cryptoAmount'
+  CryptoAmount = 'cryptoAmount',
+  FeeType = 'feeType',
+  GasLimit = 'gasLimit',
+  TxFee = 'txFee',
+  FiatFee = 'fiatFee'
 }
 
 export type StakingValues = {
   [Field.FiatAmount]: string
   [Field.CryptoAmount]: string
+  [Field.FeeType]: chainAdapters.FeeDataKey
+  [Field.GasLimit]: string
+  [Field.TxFee]: string
+  [Field.FiatFee]: string
+  [Field.AmountFieldError]: string | [string, { asset: string }]
 }
 
 export const stakeSteps = [

--- a/src/plugins/cosmos/components/modals/Staking/forms/StakeFormManager.tsx
+++ b/src/plugins/cosmos/components/modals/Staking/forms/StakeFormManager.tsx
@@ -1,0 +1,56 @@
+import { chainAdapters } from '@shapeshiftoss/types'
+import React from 'react'
+import { FormProvider, useForm } from 'react-hook-form'
+import { useHistory } from 'react-router'
+import { useModal } from 'hooks/useModal/useModal'
+
+import { Field, StakeRoutes, StakingValues } from '../StakingCommon'
+
+type StakeFormManagerRenderProps = {
+  isOpen: boolean
+  handleCancel: () => void
+  handleClose: () => void
+}
+type StakeFormProps = {
+  children: ({ isOpen, handleClose, handleCancel }: StakeFormManagerRenderProps) => React.ReactNode
+}
+
+export const StakeFormManager = ({ children }: StakeFormProps) => {
+  const history = useHistory()
+  const { cosmosStaking } = useModal()
+  const { close, isOpen } = cosmosStaking
+
+  const methods = useForm<StakingValues>({
+    mode: 'onChange',
+    defaultValues: {
+      [Field.AmountFieldError]: '',
+      [Field.FiatAmount]: '',
+      [Field.CryptoAmount]: '',
+      [Field.FeeType]: chainAdapters.FeeDataKey.Average,
+      [Field.GasLimit]: '',
+      [Field.TxFee]: '',
+      [Field.FiatFee]: ''
+    }
+  })
+
+  const handleCancel = () => {
+    history.goBack()
+  }
+
+  const handleClose = () => {
+    methods.reset()
+    close()
+    history.push(StakeRoutes.Overview)
+  }
+
+  const checkKeyDown = (event: React.KeyboardEvent<HTMLFormElement>) => {
+    if (event.key === 'Enter') event.preventDefault()
+  }
+
+  return (
+    <FormProvider {...methods}>
+      {/* eslint-disable-next-line jsx-a11y/no-noninteractive-element-interactions */}
+      <form onKeyDown={checkKeyDown}>{children({ handleCancel, handleClose, isOpen })}</form>
+    </FormProvider>
+  )
+}

--- a/src/plugins/cosmos/components/modals/Staking/views/ClaimBroadcast.tsx
+++ b/src/plugins/cosmos/components/modals/Staking/views/ClaimBroadcast.tsx
@@ -1,24 +1,28 @@
 import { InfoOutlineIcon } from '@chakra-ui/icons'
 import { Flex } from '@chakra-ui/layout'
-import { Button, Link, ModalCloseButton, Text as CText, Tooltip } from '@chakra-ui/react'
+import { Button, Link, Text as CText, Tooltip } from '@chakra-ui/react'
 import { CAIP19 } from '@shapeshiftoss/caip'
 import { chainAdapters } from '@shapeshiftoss/types'
-import { useMemo } from 'react'
+import {
+  StakingAction,
+  StakingValues
+} from 'plugins/cosmos/components/modals/Staking/StakingCommon'
+import { useStakingAction } from 'plugins/cosmos/hooks/useStakingAction/useStakingAction'
+import { useEffect, useState } from 'react'
+import { useFormContext, useWatch } from 'react-hook-form'
 import { useTranslate } from 'react-polyglot'
 import { Amount } from 'components/Amount/Amount'
 import { MiddleEllipsis } from 'components/MiddleEllipsis/MiddleEllipsis'
 import { SlideTransition } from 'components/SlideTransition'
 import { Text } from 'components/Text'
-import { useModal } from 'hooks/useModal/useModal'
-import { BigNumber, bnOrZero } from 'lib/bignumber/bignumber'
-import { selectAssetByCAIP19 } from 'state/slices/selectors'
+import { bnOrZero } from 'lib/bignumber/bignumber'
+import { selectAssetByCAIP19, selectMarketDataById } from 'state/slices/selectors'
 import { useAppSelector } from 'state/store'
 
 type ClaimBroadcastProps = {
   assetId: CAIP19
-  cryptoAmount: BigNumber
-  fiatRate: BigNumber
-  isLoading: boolean
+  validatorAddress: string
+  onClose: () => void
 }
 
 export enum Field {
@@ -29,38 +33,50 @@ export type ClaimBroadcastParams = {
   [Field.FeeType]: chainAdapters.FeeDataKey
 }
 
-export const ClaimBroadcast = ({
-  assetId,
-  cryptoAmount,
-  fiatRate,
-  isLoading
-}: ClaimBroadcastProps) => {
-  const { cosmosStaking } = useModal()
+export const ClaimBroadcast = ({ assetId, validatorAddress, onClose }: ClaimBroadcastProps) => {
+  const [loading, setLoading] = useState(true)
+  const [txId, setTxId] = useState<string | null>(null)
+
+  const { handleStakingAction } = useStakingAction()
+
+  const methods = useFormContext<StakingValues>()
+  const { control } = methods
+  const { txFee, fiatFee, gasLimit, cryptoAmount } = useWatch({ control })
+
+  const asset = useAppSelector(state => selectAssetByCAIP19(state, assetId))
+  const marketData = useAppSelector(state => selectMarketDataById(state, assetId))
+
+  // TODO(gomes): This currently fires the broadcat once on component mount. Move this to something like useFormSend
+  // We will also need to listen to incoming Txs (which are currently not coming from the websocket) to determine broadcasted
+  // state and react on broadcast errors instead of being optimistic
+  useEffect(() => {
+    ;(async () => {
+      // Satisfying react-hook-form typings, gasLimit should always be defined on initial render after the useWatch hook runs
+      if (!gasLimit) return
+      const broadcastTx = await handleStakingAction({
+        asset,
+        validator: validatorAddress,
+        chainSpecific: {
+          gas: gasLimit,
+          fee: bnOrZero(txFee).times(`1e+${asset?.precision}`).toString()
+        },
+        action: StakingAction.Claim
+      })
+
+      if (!broadcastTx) return
+
+      setTxId(broadcastTx)
+      setLoading(false)
+    })()
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, [])
 
   const translate = useTranslate()
 
-  const handleClose = cosmosStaking.close
+  if (!txFee || !fiatFee || !gasLimit || !cryptoAmount) return null
 
-  const asset = useAppSelector(state => selectAssetByCAIP19(state, assetId))
-
-  const rewardsCryptoAmountPrecision = useMemo(
-    () => bnOrZero(cryptoAmount).div(`1e+${asset.precision}`).toString(),
-    [asset.precision, cryptoAmount]
-  )
-  const rewardsFiatAmountPrecision = useMemo(
-    () => bnOrZero(rewardsCryptoAmountPrecision).times(fiatRate).toString(),
-    [fiatRate, rewardsCryptoAmountPrecision]
-  )
-
-  const txDetails = {
-    explorerTxLink: 'https://etherscan.io/tx/',
-    tx: {
-      txid: '42foobar42'
-    }
-  }
   return (
     <SlideTransition>
-      <ModalCloseButton borderRadius='full' />
       <Flex
         as='form'
         pt='14px'
@@ -73,10 +89,16 @@ export const ClaimBroadcast = ({
         <Flex width='100%' mb='20px' justifyContent='space-between'>
           <Text color='gray.500' translation={'defi.modals.claim.rewardAmount'} />
           <Flex flexDirection='column' alignItems='flex-end'>
-            <Amount.Fiat fontWeight='semibold' value={rewardsFiatAmountPrecision} />
+            <Amount.Fiat
+              fontWeight='semibold'
+              value={bnOrZero(cryptoAmount)
+                .div(`1e+${asset.precision}`)
+                .times(marketData.price)
+                .toString()}
+            />
             <Amount.Crypto
               color='gray.500'
-              value={rewardsCryptoAmountPrecision}
+              value={bnOrZero(cryptoAmount).div(`1e+${asset.precision}`).toString()}
               symbol={asset.symbol}
             />
           </Flex>
@@ -84,13 +106,11 @@ export const ClaimBroadcast = ({
 
         <Flex width='100%' mb='35px' justifyContent='space-between'>
           <Text translation={'transactionRow.txid'} color='gray.500' />
-          <Link
-            isExternal
-            color='blue.300'
-            href={`${txDetails.explorerTxLink}${txDetails.tx.txid}`}
-          >
-            <MiddleEllipsis address={txDetails.tx.txid} />
-          </Link>
+          {txId && asset && (
+            <Link isExternal color='blue.300' href={`${asset.explorerTxLink}${txId}`}>
+              <MiddleEllipsis address={txId} />
+            </Link>
+          )}
         </Flex>
 
         <Flex mb='6px' mt='6px' width='100%' justifyContent='space-between'>
@@ -106,22 +126,25 @@ export const ClaimBroadcast = ({
             </Tooltip>
           </CText>
           <Flex flexDirection='column' alignItems='flex-end'>
-            <Amount.Fiat value={'0.01'} />
-            <Amount.Crypto value='0.0005' symbol={asset.symbol} color='gray.500' />
+            <Amount.Fiat value={bnOrZero(fiatFee).toString()} />
+            <Amount.Crypto
+              value={bnOrZero(txFee).toString()}
+              symbol={asset.symbol}
+              color='gray.500'
+            />
           </Flex>
         </Flex>
 
         <Flex width='100%' flexDirection='column' alignItems='flex-end'>
           <Button
-            isLoading={isLoading}
-            onClick={handleClose}
-            loadingText={translate('defi.modals.claim.claimingRewards')}
+            isLoading={loading}
+            onClick={onClose}
+            loadingText={translate('defi.modals.staking.claimingRewards')}
             colorScheme={'blue'}
             minWidth='150px'
             mb='10px'
             mt='25px'
             size='lg'
-            type='submit'
           >
             <Text translation={'modals.status.close'} />
           </Button>

--- a/src/plugins/cosmos/components/modals/Staking/views/ClaimCommon.ts
+++ b/src/plugins/cosmos/components/modals/Staking/views/ClaimCommon.ts
@@ -1,4 +1,0 @@
-export enum ClaimPath {
-  Confirm = '/claim/confirm',
-  Broadcast = '/claim/broadcast'
-}

--- a/src/plugins/cosmos/components/modals/Staking/views/ClaimConfirm.tsx
+++ b/src/plugins/cosmos/components/modals/Staking/views/ClaimConfirm.tsx
@@ -10,17 +10,22 @@ import {
   Tooltip
 } from '@chakra-ui/react'
 import { CAIP10, CAIP19 } from '@shapeshiftoss/caip'
-import { chainAdapters } from '@shapeshiftoss/types'
+import { bnOrZero } from '@shapeshiftoss/chain-adapters'
+// @ts-ignore this will fail at 'file differs in casing' error
+import { ChainAdapter as CosmosChainAdapter } from '@shapeshiftoss/chain-adapters/dist/cosmosSdk/cosmos/CosmosChainAdapter'
+import { FeeDataKey } from '@shapeshiftoss/types/dist/chain-adapters'
 import { TxFeeRadioGroup } from 'plugins/cosmos/components/TxFeeRadioGroup/TxFeeRadioGroup'
-import { useMemo } from 'react'
-import { FormProvider, useForm } from 'react-hook-form'
+import { FeePrice, getFormFees } from 'plugins/cosmos/utils'
+import { useEffect, useMemo, useState } from 'react'
+import { FormProvider, useFormContext } from 'react-hook-form'
 import { useTranslate } from 'react-polyglot'
 import { useHistory } from 'react-router-dom'
 import { Amount } from 'components/Amount/Amount'
 import { SlideTransition } from 'components/SlideTransition'
 import { Text } from 'components/Text'
+import { useChainAdapters } from 'context/PluginProvider/PluginProvider'
 import { useModal } from 'hooks/useModal/useModal'
-import { bnOrZero } from 'lib/bignumber/bignumber'
+import { useWallet } from 'hooks/useWallet/useWallet'
 import {
   selectAssetByCAIP19,
   selectMarketDataById,
@@ -28,39 +33,52 @@ import {
 } from 'state/slices/selectors'
 import { useAppSelector } from 'state/store'
 
-import { ClaimPath } from '../StakingCommon'
-
-export enum Field {
-  FeeType = 'feeType'
-}
-
-export type StakingValues = {
-  [Field.FeeType]: chainAdapters.FeeDataKey
-}
+import { ClaimPath, Field, StakingValues } from '../StakingCommon'
 
 type ClaimConfirmProps = {
   assetId: CAIP19
   accountSpecifier: CAIP10
+  validatorAddress: string
 }
 
-const SHAPESHIFT_VALIDATOR_ADDRESS = 'cosmosvaloper199mlc7fr6ll5t54w7tts7f4s0cvnqgc59nmuxf'
+export const ClaimConfirm = ({
+  assetId,
+  accountSpecifier,
+  validatorAddress
+}: ClaimConfirmProps) => {
+  const [feeData, setFeeData] = useState<FeePrice | null>(null)
 
-export const ClaimConfirm = ({ assetId, accountSpecifier }: ClaimConfirmProps) => {
-  const methods = useForm<StakingValues>({
-    mode: 'onChange',
-    defaultValues: {
-      [Field.FeeType]: chainAdapters.FeeDataKey.Average
-    }
-  })
+  const asset = useAppSelector(state => selectAssetByCAIP19(state, assetId))
+
+  const methods = useFormContext<StakingValues>()
 
   const { handleSubmit } = methods
 
-  const asset = useAppSelector(state => selectAssetByCAIP19(state, assetId))
-  const rewardsCryptoAmount = useAppSelector(state =>
-    selectRewardsAmountByAssetId(state, accountSpecifier, SHAPESHIFT_VALIDATOR_ADDRESS, assetId)
-  )
+  const { cosmosStaking } = useModal()
+  const translate = useTranslate()
+  const memoryHistory = useHistory()
+  const chainAdapterManager = useChainAdapters()
+  const adapter = chainAdapterManager.byChain(asset.chain) as CosmosChainAdapter
 
   const marketData = useAppSelector(state => selectMarketDataById(state, assetId))
+
+  useEffect(() => {
+    ;(async () => {
+      const feeData = await adapter.getFeeData({})
+
+      const txFees = getFormFees(feeData, asset.precision, marketData.price)
+
+      setFeeData(txFees)
+    })()
+  }, [adapter, asset.precision, marketData.price])
+
+  const {
+    state: { wallet }
+  } = useWallet()
+
+  const rewardsCryptoAmount = useAppSelector(state =>
+    selectRewardsAmountByAssetId(state, accountSpecifier, validatorAddress, assetId)
+  )
 
   const rewardsCryptoAmountPrecision = useMemo(
     () => bnOrZero(rewardsCryptoAmount).div(`1e+${asset.precision}`).toString(),
@@ -71,18 +89,19 @@ export const ClaimConfirm = ({ assetId, accountSpecifier }: ClaimConfirmProps) =
     [marketData, rewardsCryptoAmountPrecision]
   )
 
-  const memoryHistory = useHistory()
+  const onSubmit = async ({ feeType }: { feeType: FeeDataKey }) => {
+    if (!wallet || !feeData) return
 
-  const onSubmit = (result: any) => {
-    memoryHistory.push(ClaimPath.Broadcast, {
-      cryptoAmount: rewardsCryptoAmount,
-      fiatRate: marketData.price
-    })
+    const fees = feeData[feeType]
+    const gas = fees.chainSpecific.gasLimit
+
+    methods.setValue(Field.GasLimit, gas)
+    methods.setValue(Field.TxFee, fees.txFee)
+    methods.setValue(Field.FiatFee, fees.fiatFee)
+    methods.setValue(Field.CryptoAmount, rewardsCryptoAmount)
+
+    memoryHistory.push(ClaimPath.Broadcast)
   }
-
-  const translate = useTranslate()
-
-  const { cosmosStaking } = useModal()
 
   const handleCancel = () => {
     memoryHistory.goBack()
@@ -131,24 +150,7 @@ export const ClaimConfirm = ({ assetId, accountSpecifier }: ClaimConfirmProps) =
             </CText>
           </Flex>
           <FormControl>
-            <TxFeeRadioGroup
-              asset={asset}
-              mb='10px'
-              fees={{
-                slow: {
-                  txFee: '0',
-                  fiatFee: '0'
-                },
-                average: {
-                  txFee: '0.01',
-                  fiatFee: '0.02'
-                },
-                fast: {
-                  txFee: '0.03',
-                  fiatFee: '0.04'
-                }
-              }}
-            />
+            <TxFeeRadioGroup asset={asset} mb='10px' fees={feeData} />
           </FormControl>
           <Text
             mt={1}

--- a/src/plugins/cosmos/components/modals/Staking/views/Overview.tsx
+++ b/src/plugins/cosmos/components/modals/Staking/views/Overview.tsx
@@ -11,10 +11,11 @@ import { Text } from 'components/Text'
 import { bnOrZero } from 'lib/bignumber/bignumber'
 import { selectAssetByCAIP19, selectMarketDataById } from 'state/slices/selectors'
 import {
+  selectAllUnbondingsEntriesByAssetIdAndValidator,
   selectRewardsAmountByAssetId,
+  selectSingleValidator,
   selectStakingDataIsLoaded,
-  selectTotalBondingsBalanceByAccountSpecifier,
-  selectUnbondingEntriesByAccountSpecifier
+  selectTotalBondingsBalanceByAssetId
 } from 'state/slices/stakingDataSlice/selectors'
 import { stakingDataApi } from 'state/slices/stakingDataSlice/stakingDataSlice'
 import { useAppDispatch, useAppSelector } from 'state/store'
@@ -49,16 +50,20 @@ export const Overview: React.FC<StakedProps> = ({
     })()
   }, [accountSpecifier, isLoaded, dispatch])
 
+  const validatorInfo = useAppSelector(state =>
+    selectSingleValidator(state, accountSpecifier, validatorAddress)
+  )
+
   const totalBondings = useAppSelector(state =>
-    selectTotalBondingsBalanceByAccountSpecifier(
+    selectTotalBondingsBalanceByAssetId(state, accountSpecifier, validatorAddress, asset.caip19)
+  )
+  const undelegationEntries = useAppSelector(state =>
+    selectAllUnbondingsEntriesByAssetIdAndValidator(
       state,
       accountSpecifier,
       validatorAddress,
       asset.caip19
     )
-  )
-  const undelegationEntries = useAppSelector(state =>
-    selectUnbondingEntriesByAccountSpecifier(state, accountSpecifier, validatorAddress)
   )
 
   const rewardsAmount = useAppSelector(state =>
@@ -87,7 +92,7 @@ export const Overview: React.FC<StakedProps> = ({
               cryptoStakedAmount={bnOrZero(totalBondings)
                 .div(`1e+${asset.precision}`)
                 .decimalPlaces(asset.precision)}
-              apr={bnOrZero('0.12')}
+              apr={bnOrZero(validatorInfo?.apr)}
             />
           </Skeleton>
           <Skeleton isLoaded={isLoaded} width='100%' mb='40px' justifyContent='space-between'>
@@ -109,7 +114,7 @@ export const Overview: React.FC<StakedProps> = ({
           <Skeleton isLoaded={isLoaded} width='100%' minHeight='68px' mb='20px'>
             <Text translation={'defi.unstaking'} color='gray.500' />
             <Box width='100%'>
-              {undelegationEntries.map((undelegation, i) => (
+              {undelegationEntries?.map((undelegation, i) => (
                 <UnbondingRow
                   key={i}
                   assetSymbol={asset.symbol}

--- a/src/plugins/cosmos/components/modals/Staking/views/StakeBroadcast.tsx
+++ b/src/plugins/cosmos/components/modals/Staking/views/StakeBroadcast.tsx
@@ -2,36 +2,35 @@ import { InfoOutlineIcon } from '@chakra-ui/icons'
 import { Flex } from '@chakra-ui/layout'
 import { Button, Link, ModalFooter, Stack, Text as CText, Tooltip } from '@chakra-ui/react'
 import { CAIP19 } from '@shapeshiftoss/caip'
-import { chainAdapters } from '@shapeshiftoss/types'
-import { Asset } from '@shapeshiftoss/types'
 import { AprTag } from 'plugins/cosmos/components/AprTag/AprTag'
-import { FormProvider, useForm } from 'react-hook-form'
+import { useStakingAction } from 'plugins/cosmos/hooks/useStakingAction/useStakingAction'
+import { useState } from 'react'
+import { useFormContext, useWatch } from 'react-hook-form'
 import { useTranslate } from 'react-polyglot'
 import { Amount } from 'components/Amount/Amount'
 import { MiddleEllipsis } from 'components/MiddleEllipsis/MiddleEllipsis'
 import { SlideTransition } from 'components/SlideTransition'
 import { Text } from 'components/Text'
-import { BigNumber } from 'lib/bignumber/bignumber'
 import { bnOrZero } from 'lib/bignumber/bignumber'
+import {
+  selectAssetByCAIP19,
+  selectMarketDataById,
+  selectSingleValidator
+} from 'state/slices/selectors'
+import { useAppSelector } from 'state/store'
+
+import { StakingAction, StakingValues } from '../StakingCommon'
 
 export enum InputType {
   Crypto = 'crypto',
   Fiat = 'fiat'
 }
 
-export enum Field {
-  FeeType = 'feeType'
-}
-
-export type StakingValues = {
-  [Field.FeeType]: chainAdapters.FeeDataKey
-}
-
 type StakeProps = {
   assetId: CAIP19
-  apr: string
-  fiatRate: BigNumber
-  cryptoStakeAmount: BigNumber
+  accountSpecifier: string
+  validatorAddress: string
+  onClose: () => void
   onCancel: () => void
 }
 
@@ -42,141 +41,167 @@ function calculateYearlyYield(apy: string, amount: string = '') {
 
 const DEFAULT_VALIDATOR_NAME = 'Shapeshift Validator'
 
-// TODO: Wire up the whole component with staked data
 export const StakeBroadcast = ({
-  apr,
   assetId,
-  cryptoStakeAmount,
-  fiatRate,
+  accountSpecifier,
+  validatorAddress,
+  onClose,
   onCancel
 }: StakeProps) => {
-  const methods = useForm<StakingValues>({
-    defaultValues: {
-      [Field.FeeType]: chainAdapters.FeeDataKey.Average
-    }
-  })
+  const [loading, setLoading] = useState(false)
+  const [broadcasted, setBroadcasted] = useState(false)
+  const [txId, setTxId] = useState<string | null>(null)
 
-  const { handleSubmit } = methods
+  const asset = useAppSelector(state => selectAssetByCAIP19(state, assetId))
 
-  const onSubmit = (_: any) => {
-    // TODO: handle submit when wired up
-  }
-
-  const cryptoYield = calculateYearlyYield(apr, cryptoStakeAmount.toPrecision())
-  const fiatYield = bnOrZero(cryptoYield).times(fiatRate).toPrecision()
-
+  const { handleStakingAction } = useStakingAction()
+  const marketData = useAppSelector(state => selectMarketDataById(state, assetId))
+  const validatorInfo = useAppSelector(state =>
+    selectSingleValidator(state, accountSpecifier, validatorAddress)
+  )
   const translate = useTranslate()
+  const methods = useFormContext<StakingValues>()
+  const { handleSubmit, control } = methods
+  const { txFee, fiatFee, cryptoAmount, gasLimit } = useWatch({ control })
 
-  // TODO: wire me up, parentheses are nice but let's get asset name from selectAssetNameById instead of this
-  const asset = (_ => ({
-    name: 'Osmosis',
-    symbol: 'OSMO',
-    caip19: assetId,
-    chain: 'osmosis'
-  }))(assetId) as Asset
-  const txDetails = {
-    explorerTxLink: 'https://etherscan.io/tx/',
-    tx: {
-      txid: '42foobar42'
+  if (!txFee || !fiatFee || !cryptoAmount || !gasLimit) return null
+
+  const onSubmit = async () => {
+    if (broadcasted) {
+      return onClose()
     }
+
+    // TODO(gomes): We will need to listen to incoming Txs (which are currently not coming from the websocket) to determine broadcasted
+    // state and react on broadcast errors instead of being optimistic
+    setLoading(true)
+
+    const broadcastTx = await handleStakingAction({
+      asset,
+      validator: validatorAddress,
+      chainSpecific: {
+        gas: gasLimit,
+        fee: bnOrZero(txFee).times(`1e+${asset?.precision}`).toString()
+      },
+      value: bnOrZero(cryptoAmount).times(`1e+${asset.precision}`).toString(),
+      action: StakingAction.Stake
+    })
+    setLoading(false)
+
+    if (!broadcastTx) return
+
+    setTxId(broadcastTx)
+    setBroadcasted(true)
   }
+
+  const cryptoYield = calculateYearlyYield(validatorInfo?.apr, bnOrZero(cryptoAmount).toPrecision())
+  const fiatYield = bnOrZero(cryptoYield).times(bnOrZero(marketData.price)).toPrecision()
+
   return (
-    <FormProvider {...methods}>
-      <SlideTransition>
-        <Flex
-          as='form'
-          pt='14px'
-          pb='18px'
-          px='30px'
-          onSubmit={handleSubmit(onSubmit)}
-          flexDirection='column'
-          alignItems='center'
-          justifyContent='space-between'
-        >
-          <Flex width='100%' mb='20px' justifyContent='space-between'>
-            <Text color='gray.500' translation={'defi.stake'} />
-            <Flex flexDirection='column' alignItems='flex-end'>
-              <Amount.Fiat
-                fontWeight='semibold'
-                value={cryptoStakeAmount.times(fiatRate).toPrecision()}
-              />
-              <Amount.Crypto
-                color='gray.500'
-                value={cryptoStakeAmount.toPrecision()}
-                symbol={asset.symbol}
-              />
-            </Flex>
+    <SlideTransition>
+      <Flex
+        as='form'
+        pt='14px'
+        pb='18px'
+        px='30px'
+        onSubmit={handleSubmit(onSubmit)}
+        flexDirection='column'
+        alignItems='center'
+        justifyContent='space-between'
+      >
+        <Flex width='100%' mb='20px' justifyContent='space-between'>
+          <Text color='gray.500' translation={'defi.stake'} />
+          <Flex flexDirection='column' alignItems='flex-end'>
+            <Amount.Fiat
+              fontWeight='semibold'
+              value={bnOrZero(cryptoAmount).times(marketData.price).toPrecision()}
+            />
+            <Amount.Crypto
+              color='gray.500'
+              value={bnOrZero(cryptoAmount).toPrecision()}
+              symbol={asset.symbol}
+            />
           </Flex>
-          <Flex width='100%' mb='30px' justifyContent='space-between'>
-            <CText display='inline-flex' alignItems='center' color='gray.500'>
-              {translate('defi.validator')}
-              &nbsp;
-              <Tooltip label={translate('defi.modals.staking.tooltip.validator')}>
-                <InfoOutlineIcon />
-              </Tooltip>
-            </CText>
-            <Link color={'blue.200'} target='_blank' href='#'>
-              {DEFAULT_VALIDATOR_NAME}
-            </Link>
-          </Flex>
-          <Flex width='100%' mb='35px' justifyContent='space-between'>
-            <Text translation={'transactionRow.txid'} color='gray.500' />
+        </Flex>
+        <Flex width='100%' mb='30px' justifyContent='space-between'>
+          <CText display='inline-flex' alignItems='center' color='gray.500'>
+            {translate('defi.validator')}
+            &nbsp;
+            <Tooltip label={translate('defi.modals.staking.tooltip.validator')}>
+              <InfoOutlineIcon />
+            </Tooltip>
+          </CText>
+          <Link color={'blue.200'} target='_blank' href='#'>
+            {DEFAULT_VALIDATOR_NAME}
+          </Link>
+        </Flex>
+        <Flex width='100%' mb='35px' justifyContent='space-between'>
+          <Text translation={'transactionRow.txid'} color='gray.500' />
+          {txId && asset && (
             <Link
               isExternal
               color='blue.200'
-              href={`${txDetails.explorerTxLink}${txDetails.tx.txid}`}
+              href={`${asset.explorerTxLink}${txId}`}
               target='_blank'
             >
-              <MiddleEllipsis address={txDetails.tx.txid} />
+              <MiddleEllipsis address={txId} />
             </Link>
-          </Flex>
-          <Flex width='100%' mb='35px' justifyContent='space-between'>
-            <Text translation={'defi.averageApr'} color='gray.500' />
-            <AprTag percentage='0.125' />
-          </Flex>
-          <Flex width='100%' mb='13px' justifyContent='space-between'>
-            <Text translation={'defi.estimatedYearlyRewards'} color='gray.500' />
-            <Flex flexDirection='column' alignItems='flex-end'>
-              <Amount.Crypto value={cryptoYield} symbol={asset.symbol} />
-              <Amount.Fiat color='gray.500' value={fiatYield} />
-            </Flex>
-          </Flex>
-          <Flex mb='6px' width='100%' justifyContent='space-between' mt='10px'>
-            <CText display='inline-flex' alignItems='center' color='gray.500'>
-              {translate('defi.gasFee')}
-              &nbsp;
-              <Tooltip
-                label={translate('defi.modals.staking.tooltip.gasFees', {
-                  networkName: asset.name
-                })}
-              >
-                <InfoOutlineIcon />
-              </Tooltip>
-            </CText>
-            <Flex flexDirection='column' alignItems='flex-end'>
-              <Amount.Crypto value='0.0005' symbol={asset.symbol} />
-              <Amount.Fiat color='gray.500' value={'0.01'} />
-            </Flex>
-          </Flex>
-          <ModalFooter width='100%' py='0' px='0' flexDir='column' textAlign='center' mt={1}>
-            <Text
-              textAlign='left'
-              fontSize='sm'
-              color='gray.500'
-              translation={['defi.unbondInfoItWillTake', { unbondingDays: '14' }]}
-              mb='18px'
-            />
-            <Stack direction='row' width='full' justifyContent='space-between'>
-              <Button onClick={onCancel} size='lg' variant='ghost'>
-                <Text translation='common.cancel' />
-              </Button>
-              <Button colorScheme={'blue'} mb={2} size='lg' type='submit'>
-                <Text translation={'defi.confirmAndBroadcast'} />
-              </Button>
-            </Stack>
-          </ModalFooter>
+          )}
         </Flex>
-      </SlideTransition>
-    </FormProvider>
+        <Flex width='100%' mb='35px' justifyContent='space-between'>
+          <Text translation={'defi.averageApr'} color='gray.500' />
+          <AprTag percentage={validatorInfo?.apr} />
+        </Flex>
+        <Flex width='100%' mb='13px' justifyContent='space-between'>
+          <Text translation={'defi.estimatedYearlyRewards'} color='gray.500' />
+          <Flex flexDirection='column' alignItems='flex-end'>
+            <Amount.Crypto value={cryptoYield} symbol={asset.symbol} />
+            <Amount.Fiat color='gray.500' value={fiatYield} />
+          </Flex>
+        </Flex>
+        <Flex mb='6px' width='100%' justifyContent='space-between' mt='10px'>
+          <CText display='inline-flex' alignItems='center' color='gray.500'>
+            {translate('defi.gasFee')}
+            &nbsp;
+            <Tooltip
+              label={translate('defi.modals.staking.tooltip.gasFees', {
+                networkName: asset.name
+              })}
+            >
+              <InfoOutlineIcon />
+            </Tooltip>
+          </CText>
+          <Flex flexDirection='column' alignItems='flex-end'>
+            <Amount.Crypto value={bnOrZero(txFee).toString()} symbol={asset.symbol} />
+            <Amount.Fiat color='gray.500' value={bnOrZero(fiatFee).toString()} />
+          </Flex>
+        </Flex>
+        <ModalFooter width='100%' py='0' px='0' flexDir='column' textAlign='center' mt={1}>
+          <Text
+            textAlign='left'
+            fontSize='sm'
+            color='gray.500'
+            translation={['defi.unbondInfoItWillTake', { unbondingDays: '21' }]}
+            mb='18px'
+          />
+          <Stack direction='row' width='full' justifyContent='space-between'>
+            <Button onClick={onCancel} size='lg' variant='ghost'>
+              <Text translation='common.cancel' />
+            </Button>
+            <Button
+              isLoading={loading}
+              loadingText={translate('defi.modals.staking.stakingYourTokens')}
+              colorScheme={'blue'}
+              mb={2}
+              size='lg'
+              type='submit'
+            >
+              <Text
+                translation={broadcasted ? 'modals.status.close' : 'defi.confirmAndBroadcast'}
+              />
+            </Button>
+          </Stack>
+        </ModalFooter>
+      </Flex>
+    </SlideTransition>
   )
 }

--- a/src/plugins/cosmos/components/modals/Staking/views/Unstake.tsx
+++ b/src/plugins/cosmos/components/modals/Staking/views/Unstake.tsx
@@ -10,13 +10,11 @@ import {
   VStack
 } from '@chakra-ui/react'
 import { CAIP19 } from '@shapeshiftoss/caip'
-import { Asset, MarketData } from '@shapeshiftoss/types'
-import get from 'lodash/get'
 import { AmountToStake } from 'plugins/cosmos/components/AmountToStake/AmountToStake'
 import { PercentOptionsRow } from 'plugins/cosmos/components/PercentOptionsRow/PercentOptionsRow'
 import { StakingInput } from 'plugins/cosmos/components/StakingInput/StakingInput'
 import { useRef, useState } from 'react'
-import { useForm, useWatch } from 'react-hook-form'
+import { useFormContext, useWatch } from 'react-hook-form'
 import { useTranslate } from 'react-polyglot'
 import { useHistory } from 'react-router'
 import { Amount } from 'components/Amount/Amount'
@@ -24,8 +22,14 @@ import { SlideTransition } from 'components/SlideTransition'
 import { Text } from 'components/Text'
 import { useModal } from 'hooks/useModal/useModal'
 import { bnOrZero } from 'lib/bignumber/bignumber'
+import {
+  selectAssetByCAIP19,
+  selectMarketDataById,
+  selectTotalBondingsBalanceByAssetId
+} from 'state/slices/selectors'
+import { useAppSelector } from 'state/store'
 
-import { UnstakingPath } from '../StakingCommon'
+import { Field, StakingValues, UnstakingPath } from '../StakingCommon'
 
 const UNBONDING_DURATION = '14'
 
@@ -34,51 +38,30 @@ export enum InputType {
   Fiat = 'fiat'
 }
 
-export enum Field {
-  FiatAmount = 'fiatAmount',
-  CryptoAmount = 'cryptoAmount'
-}
-
-export type UnstakingValues = {
-  [Field.FiatAmount]: string
-  [Field.CryptoAmount]: string
-}
-
 type UnstakeProps = {
   apr: string
   assetId: CAIP19
-  cryptoAmountStaked: string
-  marketData: MarketData
+  accountSpecifier: string
   validatorAddress: string
 }
 
-// TODO: Wire up the whole component with staked data
-export const Unstake = ({
-  assetId,
-  apr,
-  cryptoAmountStaked,
-  marketData,
-  validatorAddress
-}: UnstakeProps) => {
+export const Unstake = ({ assetId, apr, accountSpecifier, validatorAddress }: UnstakeProps) => {
   const {
-    clearErrors,
     control,
-    formState: { errors, isValid },
+    formState: { isValid },
     handleSubmit,
-    setError,
     setValue
-  } = useForm<UnstakingValues>({
-    mode: 'onChange',
-    defaultValues: {
-      [Field.FiatAmount]: '',
-      [Field.CryptoAmount]: ''
-    }
-  })
+  } = useFormContext<StakingValues>()
 
   const values = useWatch({ control })
-  const cryptoError = get(errors, 'cryptoAmount.message', null)
-  const fiatError = get(errors, 'fiatAmount.message', null)
-  const fieldError = cryptoError || fiatError
+
+  const asset = useAppSelector(state => selectAssetByCAIP19(state, assetId))
+  const marketData = useAppSelector(state => selectMarketDataById(state, assetId))
+  const totalBondings = useAppSelector(state =>
+    selectTotalBondingsBalanceByAssetId(state, accountSpecifier, validatorAddress, assetId)
+  )
+  const cryptoBalanceHuman = bnOrZero(totalBondings).div(`1e+${asset?.precision}`)
+
   const [percent, setPercent] = useState<number | null>(null)
   const [activeField, setActiveField] = useState<InputType>(InputType.Crypto)
 
@@ -93,7 +76,7 @@ export const Unstake = ({
 
   const onSubmit = (_: any) => {
     memoryHistory.push(UnstakingPath.Confirm, {
-      cryptoAmount: bnOrZero(values.cryptoAmount),
+      cryptoAmount: bnOrZero(values.cryptoAmount).times(`1e+${asset?.precision}`).toString(),
       assetId,
       fiatRate: bnOrZero(marketData.price)
     })
@@ -106,7 +89,7 @@ export const Unstake = ({
   }
 
   const handlePercentClick = (_percent: number) => {
-    const cryptoAmount = bnOrZero(cryptoAmountStaked).times(_percent)
+    const cryptoAmount = bnOrZero(cryptoBalanceHuman).times(_percent)
     const fiat = bnOrZero(cryptoAmount).times(marketData.price)
     if (activeField === InputType.Crypto) {
       setValue(Field.FiatAmount, fiat.toString(), { shouldValidate: true })
@@ -119,6 +102,11 @@ export const Unstake = ({
   }
 
   const handleInputChange = (value: string) => {
+    if (bnOrZero(value).gt(cryptoBalanceHuman)) {
+      setValue(Field.AmountFieldError, 'common.insufficientFunds', { shouldValidate: true })
+    } else if (values.amountFieldError) {
+      setValue(Field.AmountFieldError, '', { shouldValidate: true })
+    }
     setPercent(null)
     if (activeField === InputType.Crypto) {
       const fiat = bnOrZero(value).times(marketData.price)
@@ -131,20 +119,9 @@ export const Unstake = ({
 
   const handleInputToggle = () => {
     const field = activeField === InputType.Crypto ? InputType.Fiat : InputType.Crypto
-    if (fieldError) {
-      // Toggles an existing error to the other field if present
-      clearErrors(fiatError ? Field.FiatAmount : Field.CryptoAmount)
-      setError(fiatError ? Field.CryptoAmount : Field.FiatAmount, {
-        message: 'common.insufficientFunds'
-      })
-    }
     setActiveField(field)
   }
-  // TODO: wire me up, parentheses are nice but let's get asset name from selectAssetNameById instead of this
-  const asset = (_ => ({
-    name: 'Osmo',
-    symbol: 'OSMO'
-  }))(assetId) as Asset
+
   return (
     <SlideTransition>
       <Box
@@ -171,7 +148,7 @@ export const Unstake = ({
             />
             <Amount.Crypto
               fontWeight='bold'
-              value={cryptoAmountStaked || ''}
+              value={bnOrZero(totalBondings).div(`1e+${asset?.precision}`).toString()}
               symbol={asset.symbol}
             />
           </Flex>
@@ -235,13 +212,13 @@ export const Unstake = ({
                 <Text translation='common.cancel' />
               </Button>
               <Button
-                colorScheme={fieldError ? 'red' : 'blue'}
+                colorScheme={values.amountFieldError ? 'red' : 'blue'}
                 isDisabled={!isValid}
                 mb={2}
                 size='lg'
                 type='submit'
               >
-                <Text translation={fieldError || 'common.continue'} />
+                <Text translation={values.amountFieldError || 'common.continue'} />
               </Button>
             </Stack>
           </ModalFooter>

--- a/src/plugins/cosmos/components/modals/Staking/views/UnstakeBroadcast.tsx
+++ b/src/plugins/cosmos/components/modals/Staking/views/UnstakeBroadcast.tsx
@@ -2,70 +2,81 @@ import { InfoOutlineIcon } from '@chakra-ui/icons'
 import { Flex } from '@chakra-ui/layout'
 import { Button, Link, ModalCloseButton, Text as CText, Tooltip } from '@chakra-ui/react'
 import { CAIP19 } from '@shapeshiftoss/caip'
-import { Asset } from '@shapeshiftoss/types'
-import { chainAdapters } from '@shapeshiftoss/types'
-import { useForm } from 'react-hook-form'
+import { bnOrZero } from '@shapeshiftoss/chain-adapters'
+import { useStakingAction } from 'plugins/cosmos/hooks/useStakingAction/useStakingAction'
+import { useState } from 'react'
+import { useFormContext, useWatch } from 'react-hook-form'
 import { useTranslate } from 'react-polyglot'
 import { Amount } from 'components/Amount/Amount'
 import { MiddleEllipsis } from 'components/MiddleEllipsis/MiddleEllipsis'
 import { SlideTransition } from 'components/SlideTransition'
 import { Text } from 'components/Text'
-import { useModal } from 'hooks/useModal/useModal'
-import { BigNumber } from 'lib/bignumber/bignumber'
+import {
+  selectAssetByCAIP19,
+  selectMarketDataById,
+  selectSingleValidator
+} from 'state/slices/selectors'
+import { useAppSelector } from 'state/store'
+
+import { StakingAction, StakingValues } from '../StakingCommon'
 
 type UnstakeBroadcastProps = {
   assetId: CAIP19
-  cryptoUnstakeAmount: BigNumber
-  fiatRate: BigNumber
-  isLoading: boolean
-  validatorName: string
+  accountSpecifier: string
+  onClose: () => void
+  validatorAddress: string
 }
 
-export enum Field {
-  FeeType = 'feeType'
-}
-
-export type UnstakeBroadcastParams = {
-  [Field.FeeType]: chainAdapters.FeeDataKey
-}
-
-// TODO: Wire up the whole component with staked data
 export const UnstakeBroadcast = ({
   assetId,
-  cryptoUnstakeAmount,
-  fiatRate,
-  isLoading,
-  validatorName
+  accountSpecifier,
+  validatorAddress,
+  onClose
 }: UnstakeBroadcastProps) => {
-  const { cosmosStaking } = useModal()
+  const [loading, setLoading] = useState(false)
+  const [broadcasted, setBroadcasted] = useState(false)
+  const [txId, setTxId] = useState<string | null>(null)
+
+  const asset = useAppSelector(state => selectAssetByCAIP19(state, assetId))
+  const marketData = useAppSelector(state => selectMarketDataById(state, assetId))
+  const validatorInfo = useAppSelector(state =>
+    selectSingleValidator(state, accountSpecifier, validatorAddress)
+  )
 
   const translate = useTranslate()
 
-  const methods = useForm<UnstakeBroadcastParams>({
-    defaultValues: {
-      [Field.FeeType]: chainAdapters.FeeDataKey.Average
+  const methods = useFormContext<StakingValues>()
+  const { handleSubmit, control } = methods
+  const { handleStakingAction } = useStakingAction()
+  const { txFee, fiatFee, cryptoAmount, gasLimit } = useWatch({ control })
+
+  if (!txFee || !fiatFee || !cryptoAmount || !gasLimit) return null
+
+  // We will also need to listen to incoming Txs (which are currently not coming from the websocket) to determine broadcasted
+  // state and react on broadcast errors instead of being optimistic
+  const onSubmit = async () => {
+    if (broadcasted) {
+      return onClose()
     }
-  })
 
-  const { handleSubmit } = methods
+    setLoading(true)
+    const broadcastTx = await handleStakingAction({
+      asset,
+      validator: validatorAddress,
+      chainSpecific: {
+        gas: gasLimit,
+        fee: bnOrZero(txFee).times(`1e+${asset?.precision}`).toString()
+      },
+      value: bnOrZero(cryptoAmount).times(`1e+${asset?.precision}`).toString(),
+      action: StakingAction.Unstake
+    })
+    setLoading(false)
+    if (!broadcastTx) return
 
-  const onSubmit = (_: any) => {
-    // TODO: handle submit when wired up
+    setTxId(broadcastTx)
+    setBroadcasted(true)
   }
 
-  // TODO: wire me up, parentheses are nice but let's get asset name from selectAssetNameById instead of this
-  const asset = (_ => ({
-    name: 'Osmosis',
-    symbol: 'OSMO',
-    caip19: assetId,
-    chain: 'osmosis'
-  }))(assetId) as Asset
-  const txDetails = {
-    explorerTxLink: 'https://etherscan.io/tx/',
-    tx: {
-      txid: '0xae1eab9a514e1c926ca249e93a89654e610b4aae8b40a4ac99a2a7a675ad15b0'
-    }
-  }
   return (
     <SlideTransition>
       <ModalCloseButton borderRadius='full' />
@@ -84,11 +95,14 @@ export const UnstakeBroadcast = ({
           <Flex flexDirection='column' alignItems='flex-end'>
             <Amount.Fiat
               fontWeight='semibold'
-              value={cryptoUnstakeAmount.times(fiatRate).toPrecision()}
+              value={bnOrZero(cryptoAmount)
+                .div(`1e+${asset.precision}`)
+                .times(marketData.price)
+                .toPrecision()}
             />
             <Amount.Crypto
               color='gray.500'
-              value={cryptoUnstakeAmount.toPrecision()}
+              value={bnOrZero(cryptoAmount).toPrecision()}
               symbol={asset.symbol}
             />
           </Flex>
@@ -101,18 +115,16 @@ export const UnstakeBroadcast = ({
               <InfoOutlineIcon />
             </Tooltip>
           </CText>
-          <CText color='blue.300'>{validatorName}</CText>
+          <CText color='blue.300'>{validatorInfo?.moniker}</CText>
         </Flex>
 
         <Flex width='100%' mb='35px' justifyContent='space-between'>
           <Text translation={'transactionRow.txid'} color='gray.500' />
-          <Link
-            isExternal
-            color='blue.300'
-            href={`${txDetails.explorerTxLink}${txDetails.tx.txid}`}
-          >
-            <MiddleEllipsis address={txDetails.tx.txid} />
-          </Link>
+          {txId && asset && (
+            <Link isExternal color='blue.300' href={`${asset.explorerTxLink}${txId}`}>
+              <MiddleEllipsis address={txId} />
+            </Link>
+          )}
         </Flex>
 
         <Flex mb='6px' mt='6px' width='100%' justifyContent='space-between'>
@@ -128,16 +140,15 @@ export const UnstakeBroadcast = ({
             </Tooltip>
           </CText>
           <Flex flexDirection='column' alignItems='flex-end'>
-            <Amount.Fiat value={'0.01'} />
-            <Amount.Crypto value='0.0005' symbol={asset.symbol} color='gray.500' />
+            <Amount.Crypto value={bnOrZero(txFee).toString()} symbol={asset.symbol} />
+            <Amount.Fiat color='gray.500' value={bnOrZero(fiatFee).toString()} />
           </Flex>
         </Flex>
 
         <Flex width='100%' flexDirection='column' alignItems='flex-end'>
           <Button
-            isLoading={isLoading}
-            onClick={cosmosStaking.close}
-            loadingText={translate('defi.broadcastingTransaction')}
+            isLoading={loading}
+            loadingText={translate('defi.modals.staking.unstakingYourTokens')}
             colorScheme={'blue'}
             minWidth='150px'
             mb='10px'
@@ -146,7 +157,7 @@ export const UnstakeBroadcast = ({
             type='submit'
             fontWeight='normal'
           >
-            <Text translation={'modals.status.close'} />
+            <Text translation={broadcasted ? 'modals.status.close' : 'defi.confirmAndBroadcast'} />
           </Button>
         </Flex>
       </Flex>

--- a/src/plugins/cosmos/components/modals/Staking/views/UnstakeConfirm.tsx
+++ b/src/plugins/cosmos/components/modals/Staking/views/UnstakeConfirm.tsx
@@ -66,7 +66,7 @@ export const UnstakeConfirm = ({
   const chainAdapterManager = useChainAdapters()
   const adapter = chainAdapterManager.byChain(asset.chain) as CosmosChainAdapter
 
-  const fiatUntakeAmount = useMemo(
+  const fiatUnstakeAmount = useMemo(
     () => bnOrZero(cryptoAmount).times(marketData.price).toString(),
     [cryptoAmount, marketData.price]
   )
@@ -116,7 +116,7 @@ export const UnstakeConfirm = ({
           <Flex width='100%' mb='20px' justifyContent='space-between'>
             <Text color='gray.500' translation={'defi.unstake'} />
             <Flex flexDirection='column' alignItems='flex-end'>
-              <Amount.Fiat fontWeight='semibold' value={fiatUntakeAmount} />
+              <Amount.Fiat fontWeight='semibold' value={fiatUnstakeAmount} />
               <Amount.Crypto color='gray.500' value={cryptoAmount} symbol={asset.symbol} />
             </Flex>
           </Flex>

--- a/src/plugins/cosmos/components/modals/Staking/views/UnstakeConfirm.tsx
+++ b/src/plugins/cosmos/components/modals/Staking/views/UnstakeConfirm.tsx
@@ -10,74 +10,95 @@ import {
   Tooltip
 } from '@chakra-ui/react'
 import { CAIP19 } from '@shapeshiftoss/caip'
-import { chainAdapters } from '@shapeshiftoss/types'
-import { Asset } from '@shapeshiftoss/types'
+import { bnOrZero } from '@shapeshiftoss/chain-adapters'
+// @ts-ignore this will fail at 'file differs in casing' error
+import { ChainAdapter as CosmosChainAdapter } from '@shapeshiftoss/chain-adapters/dist/cosmosSdk/cosmos/CosmosChainAdapter'
+import { FeeDataKey } from '@shapeshiftoss/types/dist/chain-adapters'
 import { TxFeeRadioGroup } from 'plugins/cosmos/components/TxFeeRadioGroup/TxFeeRadioGroup'
-import { FormProvider, useForm } from 'react-hook-form'
+import { getFormFees } from 'plugins/cosmos/utils'
+import { FeePrice } from 'plugins/cosmos/utils'
+import { useEffect, useMemo, useState } from 'react'
+import { FormProvider, useFormContext, useWatch } from 'react-hook-form'
 import { useTranslate } from 'react-polyglot'
 import { useHistory } from 'react-router-dom'
 import { Amount } from 'components/Amount/Amount'
 import { SlideTransition } from 'components/SlideTransition'
 import { Text } from 'components/Text'
-import { BigNumber } from 'lib/bignumber/bignumber'
+import { useChainAdapters } from 'context/PluginProvider/PluginProvider'
+import { useWallet } from 'hooks/useWallet/useWallet'
+import {
+  selectAssetByCAIP19,
+  selectMarketDataById,
+  selectSingleValidator
+} from 'state/slices/selectors'
+import { useAppSelector } from 'state/store'
 
-import { UnstakingPath } from '../StakingCommon'
-
-export enum InputType {
-  Crypto = 'crypto',
-  Fiat = 'fiat'
-}
-
-export enum Field {
-  FeeType = 'feeType'
-}
-
-export type UnstakingValues = {
-  [Field.FeeType]: chainAdapters.FeeDataKey
-}
+import { Field, StakingValues, UnstakingPath } from '../StakingCommon'
 
 type UnstakeProps = {
   assetId: CAIP19
-  fiatRate: BigNumber
-  cryptoUnstakeAmount: BigNumber
+  accountSpecifier: string
+  validatorAddress: string
   onCancel: () => void
 }
 
-const DEFAULT_VALIDATOR_NAME = 'Shapeshift Validator'
-
-// TODO: Wire up the whole component with staked data
 export const UnstakeConfirm = ({
   assetId,
-  cryptoUnstakeAmount,
-  fiatRate,
+  accountSpecifier,
+  validatorAddress,
   onCancel
 }: UnstakeProps) => {
-  const methods = useForm<UnstakingValues>({
-    mode: 'onChange',
-    defaultValues: {
-      [Field.FeeType]: chainAdapters.FeeDataKey.Average
-    }
-  })
+  const [feeData, setFeeData] = useState<FeePrice | null>(null)
 
-  const { handleSubmit } = methods
+  const methods = useFormContext<StakingValues>()
+  const { handleSubmit, control } = methods
+  const { cryptoAmount } = useWatch({ control })
+
+  const validatorInfo = useAppSelector(state =>
+    selectSingleValidator(state, accountSpecifier, validatorAddress)
+  )
+  const {
+    state: { wallet }
+  } = useWallet()
+
+  const asset = useAppSelector(state => selectAssetByCAIP19(state, assetId))
+  const marketData = useAppSelector(state => selectMarketDataById(state, assetId))
+  const chainAdapterManager = useChainAdapters()
+  const adapter = chainAdapterManager.byChain(asset.chain) as CosmosChainAdapter
+
+  const fiatUntakeAmount = useMemo(
+    () => bnOrZero(cryptoAmount).times(marketData.price).toString(),
+    [cryptoAmount, marketData.price]
+  )
+
+  useEffect(() => {
+    ;(async () => {
+      const feeData = await adapter.getFeeData({})
+
+      const txFees = getFormFees(feeData, asset.precision, marketData.price)
+
+      setFeeData(txFees)
+    })()
+  }, [adapter, asset.precision, marketData.price])
 
   const history = useHistory()
-  const onSubmit = (_: any) => {
-    history.push(UnstakingPath.Broadcast, {
-      cryptoAmount: cryptoUnstakeAmount,
-      fiatRate
-    })
+  const onSubmit = async ({ feeType }: { feeType: FeeDataKey }) => {
+    if (!wallet || !feeData) return
+
+    const fees = feeData[feeType]
+    const gas = fees.chainSpecific.gasLimit
+
+    methods.setValue(Field.GasLimit, gas)
+    methods.setValue(Field.TxFee, fees.txFee)
+    methods.setValue(Field.FiatFee, fees.fiatFee)
+
+    history.push(UnstakingPath.Broadcast)
   }
 
   const translate = useTranslate()
 
-  // TODO: wire me up, parentheses are nice but let's get asset name from selectAssetNameById instead of this
-  const asset = (_ => ({
-    name: 'Osmosis',
-    symbol: 'OSMO',
-    caip19: assetId,
-    chain: 'osmosis'
-  }))(assetId) as Asset
+  if (!cryptoAmount) return null
+
   return (
     <FormProvider {...methods}>
       <SlideTransition>
@@ -95,15 +116,8 @@ export const UnstakeConfirm = ({
           <Flex width='100%' mb='20px' justifyContent='space-between'>
             <Text color='gray.500' translation={'defi.unstake'} />
             <Flex flexDirection='column' alignItems='flex-end'>
-              <Amount.Fiat
-                fontWeight='semibold'
-                value={cryptoUnstakeAmount.times(fiatRate).toPrecision()}
-              />
-              <Amount.Crypto
-                color='gray.500'
-                value={cryptoUnstakeAmount.toPrecision()}
-                symbol={asset.symbol}
-              />
+              <Amount.Fiat fontWeight='semibold' value={fiatUntakeAmount} />
+              <Amount.Crypto color='gray.500' value={cryptoAmount} symbol={asset.symbol} />
             </Flex>
           </Flex>
           <Flex width='100%' mb='30px' justifyContent='space-between'>
@@ -114,7 +128,7 @@ export const UnstakeConfirm = ({
                 <InfoOutlineIcon />
               </Tooltip>
             </CText>
-            <CText>{DEFAULT_VALIDATOR_NAME}</CText>
+            <CText>{validatorInfo?.moniker}</CText>
           </Flex>
           <Flex mb='6px' width='100%'>
             <CText display='inline-flex' alignItems='center' color='gray.500'>
@@ -130,30 +144,14 @@ export const UnstakeConfirm = ({
             </CText>
           </Flex>
           <FormControl>
-            <TxFeeRadioGroup
-              asset={asset}
-              fees={{
-                slow: {
-                  txFee: '0.004',
-                  fiatFee: '0.1'
-                },
-                average: {
-                  txFee: '0.008',
-                  fiatFee: '0.2'
-                },
-                fast: {
-                  txFee: '0.012',
-                  fiatFee: '0.3'
-                }
-              }}
-            />
+            <TxFeeRadioGroup asset={asset} fees={feeData} />
           </FormControl>
           <ModalFooter width='100%' py='0' px='0' flexDir='column' textAlign='center' mt={1}>
             <Text
               textAlign='left'
               fontSize='sm'
               color='gray.500'
-              translation={['defi.unbondInfoItWillTakeShort', { unbondingDays: '14' }]}
+              translation={['defi.unbondInfoItWillTakeShort', { unbondingDays: '21' }]}
               mb='18px'
             />
             <Stack direction='row' width='full' justifyContent='space-between'>

--- a/src/plugins/cosmos/hooks/useStakingAction/useStakingAction.tsx
+++ b/src/plugins/cosmos/hooks/useStakingAction/useStakingAction.tsx
@@ -1,0 +1,94 @@
+// @ts-ignore this will fail at 'file differs in casing' error
+import { ChainAdapter as CosmosChainAdapter } from '@shapeshiftoss/chain-adapters/dist/cosmosSdk/cosmos/CosmosChainAdapter'
+import { Asset, ChainTypes } from '@shapeshiftoss/types'
+import { BuildTxInput } from '@shapeshiftoss/types/dist/chain-adapters/cosmos'
+import { StakingAction } from 'plugins/cosmos/components/modals/Staking/StakingCommon'
+import { useChainAdapters } from 'context/PluginProvider/PluginProvider'
+import { useWallet } from 'hooks/useWallet/useWallet'
+
+type StakingInput =
+  | {
+      asset: Asset
+      chainSpecific: BuildTxInput
+      validator: string
+      action: StakingAction.Claim
+      value?: string
+    }
+  | {
+      asset: Asset
+      chainSpecific: BuildTxInput
+      validator: string
+      action: StakingAction.Stake | StakingAction.Unstake
+      value: string
+    }
+
+export const useStakingAction = () => {
+  const chainAdapterManager = useChainAdapters()
+  const {
+    state: { wallet }
+  } = useWallet()
+
+  const handleStakingAction = async (data: StakingInput) => {
+    if (wallet) {
+      try {
+        const adapter = chainAdapterManager.byChain(data.asset.chain)
+        const adapterType = adapter.getType()
+
+        let result
+
+        const { chainSpecific, validator, action, value } = data
+        if (adapterType === ChainTypes.Cosmos) {
+          switch (action) {
+            case StakingAction.Claim: {
+              result = await (adapter as CosmosChainAdapter).buildClaimRewardsTransaction({
+                wallet,
+                validator,
+                chainSpecific
+              })
+              break
+            }
+            case StakingAction.Stake: {
+              result = await (adapter as CosmosChainAdapter).buildDelegateTransaction({
+                wallet,
+                validator,
+                value,
+                chainSpecific
+              })
+              break
+            }
+            case StakingAction.Unstake: {
+              result = await (adapter as CosmosChainAdapter).buildUndelegateTransaction({
+                wallet,
+                validator,
+                value,
+                chainSpecific
+              })
+              break
+            }
+            default: {
+              break
+            }
+          }
+        } else if (adapterType === ChainTypes.Osmosis) {
+          // TODO(gomes): implement this
+        } else {
+          throw new Error('unsupported adapterType')
+        }
+        const txToSign = result?.txToSign
+
+        let broadcastTXID: string | undefined
+
+        // Native and KeepKey hdwallets only support offline signing, not broadcasting signed TXs like e.g Metamask
+        if (txToSign && wallet.supportsOfflineSigning()) {
+          broadcastTXID = await adapter.signAndBroadcastTransaction?.({ txToSign, wallet })
+          return broadcastTXID
+        } else {
+          throw new Error('Bad hdwallet config')
+        }
+      } catch (error) {}
+    }
+  }
+  return {
+    handleStakingAction
+  }
+}

--- a/src/plugins/cosmos/utils.ts
+++ b/src/plugins/cosmos/utils.ts
@@ -1,0 +1,54 @@
+import { bnOrZero } from '@shapeshiftoss/chain-adapters'
+import { chainAdapters, ChainTypes } from '@shapeshiftoss/types'
+import { FeeDataEstimate } from '@shapeshiftoss/types/dist/chain-adapters'
+
+export type FeePriceValueHuman = {
+  fiatFee: string
+  txFee: string
+  chainSpecific: chainAdapters.cosmos.FeeData
+}
+export type FeePrice = {
+  [key in chainAdapters.FeeDataKey]: FeePriceValueHuman
+}
+
+export const getFormFees = (
+  feeData: FeeDataEstimate<ChainTypes.Cosmos>,
+  precision: number,
+  fiatRate: string
+) => {
+  const initialFees = {
+    slow: {
+      fiatFee: '',
+      txFee: '',
+      chainSpecific: {
+        gasLimit: ''
+      }
+    },
+    average: {
+      fiatFee: '',
+      txFee: '',
+      chainSpecific: {
+        gasLimit: ''
+      }
+    },
+    fast: {
+      fiatFee: '',
+      txFee: '',
+      chainSpecific: {
+        gasLimit: ''
+      }
+    }
+  }
+  return (Object.keys(feeData) as chainAdapters.FeeDataKey[]).reduce<FeePrice>(
+    (acc: any, key: chainAdapters.FeeDataKey) => {
+      const chainSpecific = feeData[key].chainSpecific
+      const txFee = bnOrZero(feeData[key].txFee)
+        .dividedBy(bnOrZero(`1e+${precision}`))
+        .toPrecision()
+      const fiatFee = bnOrZero(txFee).times(fiatRate).toPrecision()
+      acc[key] = { txFee, fiatFee, chainSpecific }
+      return acc
+    },
+    initialFees
+  )
+}

--- a/src/state/slices/stakingDataSlice/selectors.ts
+++ b/src/state/slices/stakingDataSlice/selectors.ts
@@ -162,6 +162,12 @@ export const selectAllUnbondingsEntriesByAssetId = createDeepEqualOutputSelector
   }
 )
 
+export const selectAllUnbondingsEntriesByAssetIdAndValidator = createSelector(
+  selectAllUnbondingsEntriesByAssetId,
+  selectValidatorAddress,
+  (unbondingEntries, validatorAddress) => unbondingEntries[validatorAddress]
+)
+
 export const selectUnbondingCryptoAmountByAssetId = createSelector(
   selectUnbondingEntriesByAccountSpecifier,
   selectAssetIdParam,
@@ -178,15 +184,11 @@ export const selectUnbondingCryptoAmountByAssetId = createSelector(
   }
 )
 
-export const selectTotalBondingsBalanceByAccountSpecifier = createSelector(
+export const selectTotalBondingsBalanceByAssetId = createSelector(
   selectUnbondingCryptoAmountByAssetId,
   selectDelegationCryptoAmountByValidator,
-  selectRedelegationCryptoAmountByAssetId,
-  (unbondingCryptoBalance, delegationCryptoBalance, redelegationCryptoBalance): string =>
-    bnOrZero(unbondingCryptoBalance)
-      .plus(bnOrZero(delegationCryptoBalance))
-      .plus(bnOrZero(redelegationCryptoBalance))
-      .toString()
+  (unbondingCryptoBalance, delegationCryptoBalance): string =>
+    bnOrZero(unbondingCryptoBalance).plus(bnOrZero(delegationCryptoBalance)).toString()
 )
 
 export const selectRewardsByAccountSpecifier = createDeepEqualOutputSelector(


### PR DESCRIPTION
## Description

This implements the building of unsigned claim Tx for cosmos and broadcasting of the Tx with native wallet.

To be added in a follow-up PR(s):

- Broadcast errors (will require working WS txhistory messages)
- Don't claim 0 rewards, since it is possible at protocol level to broadcast such Tx but no rewards will effectively be claimed (it could be abstracted to something similar to `useSendDetails`) - we will probably need to add some rounding logic in a follow-up PR, since we never really get `0` as rewards amount, but rather a very small number
- Don't allow undelegations if greater than `MaxEntries` (https://docs.cosmos.network/master/modules/staking/03_messages.html) - we would need to expose this in the unchained response for `/api/v1/account/{pubkey}`, and then add it to the parsed data in chain-adapters before we can consume it in web. When that's done, it could be abstracted to something similar to `useSendDetails`.

## Notice

<!-- Before submitting a pull request, please make sure you have answered the following: -->

- [x] Have you followed the guidelines in our [Contributing]('https://github.com/shapeshift/web/CONTRIBUTING.md) guide?
- [x] Have you checked to ensure there aren't other open [Pull Requests](https://github.com/shapeshift/web/pulls) for the same update/change?

## Pull Request Type

- [ ] :bug: Bug fix (Non-breaking Change: Fixes an issue)
- [ ] :hammer_and_wrench: Chore (Non-breaking Change: Doc updates, pkg upgrades, typos, etc..)
- [x] :nail_care: New Feature (Breaking/Non-breaking Change)

## Issue (if applicable)

- closes #657
- closes #664
- closes #666
- closes #667
- closes #669 
- closes #670
- closes #671

## Risk

N/A, this is a separate domain. Errors are not properly handled yet and will need to as a follow-up.

## Testing

- Go to Cosmos Staking overview on an account with some rewards
- Click claim and continue with the claim flow
- It should display loading state while Tx is built/broadcasted 
- It should broadcast Tx and change the broadcast button to done/display the Txid

## Screenshots (if applicable)

### Claim
![image](https://user-images.githubusercontent.com/17035424/161162300-10e7863b-4af4-4152-823f-04035788df0f.png)
![image](https://user-images.githubusercontent.com/17035424/161162342-05ed0a78-4721-4aa7-9b82-f199114afa69.png)
![image](https://user-images.githubusercontent.com/17035424/161162374-877af1da-0713-4d81-b756-8667557cb4e9.png)
![image](https://user-images.githubusercontent.com/17035424/161162385-21926924-ce37-46b5-8dba-4f3c54d4f30d.png)

### Stake

<img width="477" alt="image" src="https://user-images.githubusercontent.com/17035424/161319015-0b22b176-c8f4-4731-bde0-4a9c1577a38d.png">
<img width="493" alt="image" src="https://user-images.githubusercontent.com/17035424/161319058-64c3fbc8-1a08-4f10-b205-8c120f53a997.png">
<img width="461" alt="image" src="https://user-images.githubusercontent.com/17035424/161319131-b806412e-78a4-4c47-b10b-1992a5402bc7.png">
<img width="500" alt="image" src="https://user-images.githubusercontent.com/17035424/161319191-30e2032d-19f6-4c06-877e-0fc2ce5850aa.png">
<img width="458" alt="image" src="https://user-images.githubusercontent.com/17035424/161319222-9060c02c-b7f1-4063-8ec8-37dd216d704e.png">

### Unstake

<img width="454" alt="image" src="https://user-images.githubusercontent.com/17035424/161319300-e367a1b9-e65a-41ff-b080-4cbdecb47c13.png">
<img width="464" alt="image" src="https://user-images.githubusercontent.com/17035424/161319584-45cfbf0e-23d3-47f2-ada2-18936835db1c.png">
<img width="458" alt="image" src="https://user-images.githubusercontent.com/17035424/161320836-dcbd1f01-b57f-4ce4-a2a4-196304967e4a.png">
<img width="484" alt="image" src="https://user-images.githubusercontent.com/17035424/161323188-2ceeec15-a8f0-4a98-b066-e025c73fd2dc.png">
<img width="458" alt="image" src="https://user-images.githubusercontent.com/17035424/161320898-e91a34af-42c9-4fe7-9682-84609d3e6105.png">
