### PR TITLE
fix: update logic for overview and disable cancel buttons when loading

### DIFF
--- a/src/features/defi/components/Approve/Approve.tsx
+++ b/src/features/defi/components/Approve/Approve.tsx
@@ -79,7 +79,7 @@ export const Approve = ({
         </Row>
       </ModalFooter>
       <ModalFooter py={4} justifyContent='space-between'>
-        <Button onClick={onCancel} size='lg' colorScheme='gray'>
+        <Button onClick={onCancel} size='lg' colorScheme='gray' isDisabled={loading}>
           {translate('modals.approve.reject')}
         </Button>
         <Button

--- a/src/features/defi/components/Confirm/Confirm.tsx
+++ b/src/features/defi/components/Confirm/Confirm.tsx
@@ -41,7 +41,7 @@ export const Confirm = ({
         <Stack width='full'>
           {prefooter}
           <Flex width='full' justifyContent='space-between'>
-            <Button size='lg' colorScheme='gray' onClick={onCancel}>
+            <Button size='lg' colorScheme='gray' onClick={onCancel} isDisabled={loading}>
               {translate('modals.confirm.cancel')}
             </Button>
             <Button

--- a/src/features/defi/providers/foxy/components/FoxyManager/Overview/FoxyDetails.tsx
+++ b/src/features/defi/providers/foxy/components/FoxyManager/Overview/FoxyDetails.tsx
@@ -34,6 +34,7 @@ export const FoxyDetails = ({ api }: FoxyDetailsProps) => {
   })
   const { chain, contractAddress, tokenId, rewardId } = query
   const opportunity = opportunities.find(e => e.contractAddress === contractAddress)
+  const rewardBalance = bnOrZero(opportunity?.withdrawInfo.amount)
   const foxyBalance = bnOrZero(opportunity?.balance)
   const network = NetworkTypes.MAINNET
   const assetNamespace = AssetNamespace.ERC20
@@ -59,7 +60,7 @@ export const FoxyDetails = ({ api }: FoxyDetailsProps) => {
       </Center>
     )
   }
-  if (foxyBalance.eq(0)) {
+  if (foxyBalance.eq(0) && rewardBalance.eq(0)) {
     return (
       <FoxyEmpty
         assets={[stakingAsset, rewardAsset]}


### PR DESCRIPTION
## Description

The logic on the overview section wasn't taking into account if the user had no balance but had a claim available.

Also don't want the user accidentally cancelling or rejecting in the middle of transaction being broadcast. So if the primary button is in a loading state we disable the cancel/reject. 

## Notice

<!-- Before submitting a pull request, please make sure you have answered the following: -->

- [x] Have you followed the guidelines in our [Contributing]('https://github.com/shapeshift/web/CONTRIBUTING.md) guide?
- [x] Have you checked to ensure there aren't other open [Pull Requests](https://github.com/shapeshift/web/pulls) for the same update/change?

## Pull Request Type

- [x] :bug: Bug fix (Non-breaking Change: Fixes an issue)
- [ ] :hammer_and_wrench: Chore (Non-breaking Change: Doc updates, pkg upgrades, typos, etc..)
- [ ] :nail_care: New Feature (Breaking/Non-breaking Change)

## Issue (if applicable)

## Risk

Very low risk, all behind a feature flag

## Testing

If you have a foxy balance, and withdraw max with delayed withdraw type. You should see a 0 FOXY balance, and the pending withdraw on the overview tab.

While waiting for confirm on wallet on the deposit/approval screens -- the cancel/reject buttons should be disabled.

## Screenshots (if applicable)
