### PR TITLE
fix: add loading state for tx rows

### DIFF
--- a/src/components/StakingVaults/EarnOpportunities.tsx
+++ b/src/components/StakingVaults/EarnOpportunities.tsx
@@ -64,6 +64,8 @@ export const EarnOpportunities = ({ assetId: caip19 }: EarnOpportunitiesProps) =
     })
   }
 
+  if (allRows.length === 0) return null
+
   return (
     <Card>
       <Card.Header flexDir='row' display='flex'>

--- a/src/components/TransactionHistory/TransactionHistoryList.tsx
+++ b/src/components/TransactionHistory/TransactionHistoryList.tsx
@@ -5,11 +5,22 @@ import { CircularProgress } from 'components/CircularProgress/CircularProgress'
 import { Text } from 'components/Text'
 import { TransactionsGroupByDate } from 'components/TransactionHistory/TransactionsGroupByDate'
 import { useInfiniteScroll } from 'hooks/useInfiniteScroll/useInfiniteScroll'
-import { TxId } from 'state/slices/txHistorySlice/txHistorySlice'
+import { selectTxHistoryStatus } from 'state/slices/selectors'
+import { TxHistoryStatus, TxId } from 'state/slices/txHistorySlice/txHistorySlice'
+import { useAppSelector } from 'state/store'
+
+import { TransactionsLoading } from './TransactionsLoading'
 
 type TransactionHistoryListProps = {
   txIds: TxId[]
   useCompactMode?: boolean
+  status?: TxHistoryStatus
+}
+
+enum HistoryStatus {
+  IDLE = 'idle',
+  LOADING = 'loading',
+  LOADED = 'loaded'
 }
 
 export const TransactionHistoryList: React.FC<TransactionHistoryListProps> = ({
@@ -17,7 +28,11 @@ export const TransactionHistoryList: React.FC<TransactionHistoryListProps> = ({
   useCompactMode = false
 }) => {
   const { next, data, hasMore } = useInfiniteScroll(txIds)
+  const txHistoryStatus = useAppSelector(selectTxHistoryStatus)
 
+  if (txHistoryStatus === HistoryStatus.LOADING) {
+    return <TransactionsLoading />
+  }
   return data?.length ? (
     <Card.Body px={0} pt={0}>
       <InfiniteScroll

--- a/src/components/TransactionHistory/TransactionHistoryList.tsx
+++ b/src/components/TransactionHistory/TransactionHistoryList.tsx
@@ -29,10 +29,10 @@ export const TransactionHistoryList: React.FC<TransactionHistoryListProps> = ({
   const { next, data, hasMore } = useInfiniteScroll(txIds)
   const txHistoryStatus = useAppSelector(selectTxHistoryStatus)
 
-  if (txHistoryStatus === HistoryStatus.LOADING) {
+  if (txHistoryStatus === HistoryStatus.LOADING && !data.length) {
     return <TransactionsLoading />
   }
-  return data?.length ? (
+  return data.length ? (
     <Card.Body px={0} pt={0}>
       <InfiniteScroll
         pageStart={0}
@@ -44,6 +44,7 @@ export const TransactionHistoryList: React.FC<TransactionHistoryListProps> = ({
           </Center>
         }
       >
+        {txHistoryStatus === HistoryStatus.LOADING && <TransactionsLoading count={1} />}
         <TransactionsGroupByDate txIds={txIds} useCompactMode={useCompactMode} />
       </InfiniteScroll>
     </Card.Body>

--- a/src/components/TransactionHistory/TransactionHistoryList.tsx
+++ b/src/components/TransactionHistory/TransactionHistoryList.tsx
@@ -6,7 +6,7 @@ import { Text } from 'components/Text'
 import { TransactionsGroupByDate } from 'components/TransactionHistory/TransactionsGroupByDate'
 import { useInfiniteScroll } from 'hooks/useInfiniteScroll/useInfiniteScroll'
 import { selectTxHistoryStatus } from 'state/slices/selectors'
-import { TxHistoryStatus, TxId } from 'state/slices/txHistorySlice/txHistorySlice'
+import { TxId } from 'state/slices/txHistorySlice/txHistorySlice'
 import { useAppSelector } from 'state/store'
 
 import { TransactionsLoading } from './TransactionsLoading'
@@ -14,7 +14,6 @@ import { TransactionsLoading } from './TransactionsLoading'
 type TransactionHistoryListProps = {
   txIds: TxId[]
   useCompactMode?: boolean
-  status?: TxHistoryStatus
 }
 
 enum HistoryStatus {

--- a/src/components/TransactionHistory/TransactionHistoryList.tsx
+++ b/src/components/TransactionHistory/TransactionHistoryList.tsx
@@ -16,12 +16,6 @@ type TransactionHistoryListProps = {
   useCompactMode?: boolean
 }
 
-enum HistoryStatus {
-  IDLE = 'idle',
-  LOADING = 'loading',
-  LOADED = 'loaded'
-}
-
 export const TransactionHistoryList: React.FC<TransactionHistoryListProps> = ({
   txIds,
   useCompactMode = false
@@ -29,7 +23,7 @@ export const TransactionHistoryList: React.FC<TransactionHistoryListProps> = ({
   const { next, data, hasMore } = useInfiniteScroll(txIds)
   const txHistoryStatus = useAppSelector(selectTxHistoryStatus)
 
-  if (txHistoryStatus === HistoryStatus.LOADING && !data.length) {
+  if (txHistoryStatus === 'loading' && !data.length) {
     return <TransactionsLoading />
   }
   return data.length ? (
@@ -44,7 +38,7 @@ export const TransactionHistoryList: React.FC<TransactionHistoryListProps> = ({
           </Center>
         }
       >
-        {txHistoryStatus === HistoryStatus.LOADING && <TransactionsLoading count={1} />}
+        {txHistoryStatus === 'loading' && <TransactionsLoading count={1} />}
         <TransactionsGroupByDate txIds={txIds} useCompactMode={useCompactMode} />
       </InfiniteScroll>
     </Card.Body>

--- a/src/components/TransactionHistory/TransactionHistoryList.tsx
+++ b/src/components/TransactionHistory/TransactionHistoryList.tsx
@@ -23,9 +23,8 @@ export const TransactionHistoryList: React.FC<TransactionHistoryListProps> = ({
   const { next, data, hasMore } = useInfiniteScroll(txIds)
   const txHistoryStatus = useAppSelector(selectTxHistoryStatus)
 
-  if (txHistoryStatus === 'loading' && !data.length) {
-    return <TransactionsLoading />
-  }
+  if (txHistoryStatus === 'loading' && !data.length) return <TransactionsLoading />
+
   return data.length ? (
     <Card.Body px={0} pt={0}>
       <InfiniteScroll

--- a/src/components/TransactionHistory/TransactionsLoading.tsx
+++ b/src/components/TransactionHistory/TransactionsLoading.tsx
@@ -1,0 +1,15 @@
+import { Stack } from '@chakra-ui/react'
+import { Card } from 'components/Card/Card'
+import { TransactionLoading } from 'components/TransactionHistoryRows/TransactionLoading'
+export const TransactionsLoading = () => {
+  const array = new Array(10).fill('')
+  return (
+    <Card.Body px={0} pt={0}>
+      <Stack px={2}>
+        {array.map(index => (
+          <TransactionLoading key={index} />
+        ))}
+      </Stack>
+    </Card.Body>
+  )
+}

--- a/src/components/TransactionHistory/TransactionsLoading.tsx
+++ b/src/components/TransactionHistory/TransactionsLoading.tsx
@@ -1,8 +1,13 @@
 import { Stack } from '@chakra-ui/react'
 import { Card } from 'components/Card/Card'
 import { TransactionLoading } from 'components/TransactionHistoryRows/TransactionLoading'
-export const TransactionsLoading = () => {
-  const array = new Array(10).fill('')
+
+type TransactionsLoadingProps = {
+  count?: number
+}
+
+export const TransactionsLoading: React.FC<TransactionsLoadingProps> = ({ count = 10 }) => {
+  const array = new Array(count).fill('')
   return (
     <Card.Body px={0} pt={0}>
       <Stack px={2}>

--- a/src/components/TransactionHistory/TransactionsLoading.tsx
+++ b/src/components/TransactionHistory/TransactionsLoading.tsx
@@ -6,7 +6,7 @@ export const TransactionsLoading = () => {
   return (
     <Card.Body px={0} pt={0}>
       <Stack px={2}>
-        {array.map(index => (
+        {array.map((_, index) => (
           <TransactionLoading key={index} />
         ))}
       </Stack>

--- a/src/components/TransactionHistoryRows/TransactionGenericRow.tsx
+++ b/src/components/TransactionHistoryRows/TransactionGenericRow.tsx
@@ -14,6 +14,26 @@ import { fromBaseUnit } from 'lib/math'
 import { TxId } from 'state/slices/txHistorySlice/txHistorySlice'
 import { breakpoints } from 'theme/theme'
 
+export const GetTxLayoutFormats = ({ parentWidth }: { parentWidth: number }) => {
+  const isLargerThanSm = parentWidth > parseInt(breakpoints['sm'], 10)
+  const isLargerThanMd = parentWidth > parseInt(breakpoints['md'], 10)
+  const isLargerThanLg = parentWidth > parseInt(breakpoints['lg'], 10)
+  let columns = '1fr'
+  let dateFormat = 'MM/DD/YYYY hh:mm A'
+
+  if (isLargerThanSm) {
+    columns = '1fr 2fr'
+    dateFormat = 'hh:mm A'
+  }
+  if (isLargerThanMd) {
+    columns = '1fr 2fr'
+  }
+  if (isLargerThanLg) {
+    columns = '1fr 2fr 1fr 1fr'
+  }
+  return { columns, dateFormat, breakPoints: [isLargerThanLg, isLargerThanMd, isLargerThanSm] }
+}
+
 const TransactionIcon = ({ type }: { type: string }) => {
   switch (type) {
     case chainAdapters.TxType.Send:
@@ -68,23 +88,11 @@ export const TransactionGenericRow = ({
   isFirstAssetOutgoing = false,
   parentWidth
 }: TransactionGenericRowProps) => {
-  const isLargerThanSm = parentWidth > parseInt(breakpoints['sm'], 10)
-  const isLargerThanMd = parentWidth > parseInt(breakpoints['md'], 10)
-  const isLargerThanLg = parentWidth > parseInt(breakpoints['lg'], 10)
-
-  let columns = '1fr'
-  let dateFormat = 'MM/DD/YYYY hh:mm A'
-
-  if (isLargerThanSm) {
-    columns = '1fr 2fr'
-    dateFormat = 'hh:mm A'
-  }
-  if (isLargerThanMd) {
-    columns = '1fr 2fr'
-  }
-  if (isLargerThanLg) {
-    columns = '1fr 2fr 1fr 1fr'
-  }
+  const {
+    columns,
+    dateFormat,
+    breakPoints: [isLargerThanLg]
+  } = GetTxLayoutFormats({ parentWidth })
   return (
     <Button
       height='auto'

--- a/src/components/TransactionHistoryRows/TransactionLoading.tsx
+++ b/src/components/TransactionHistoryRows/TransactionLoading.tsx
@@ -1,0 +1,10 @@
+import { SkeletonCircle, SkeletonText, Stack } from '@chakra-ui/react'
+
+export const TransactionLoading: React.FC = () => {
+  return (
+    <Stack px={4} py={2} direction='row' alignItems='center'>
+      <SkeletonCircle size='40px' />
+      <SkeletonText noOfLines={2} flex={1} />
+    </Stack>
+  )
+}

--- a/src/context/TransactionsProvider/TransactionsProvider.tsx
+++ b/src/context/TransactionsProvider/TransactionsProvider.tsx
@@ -160,7 +160,7 @@ export const TransactionsProvider = ({ children }: TransactionsProviderProps): J
     if (isEmpty(assets)) return
     if (!walletInfo?.deviceId) return // we can't be loaded if the wallet isn't connected
     if (txHistoryStatus !== 'loading') return // only start logic below once we know we're loading
-    const TX_DEBOUNCE_DELAY = 5000
+    const TX_DEBOUNCE_DELAY = 10000
     const timer = setTimeout(
       () => dispatch(txHistory.actions.setStatus('loaded')),
       TX_DEBOUNCE_DELAY


### PR DESCRIPTION
## Description

- Add loading state for TX history
- Adjusted timeout on the `TransactionsProvider`
- Hide earn when there are no opportunities available

## Notice

<!-- Before submitting a pull request, please make sure you have answered the following: -->

- [x] Have you followed the guidelines in our [Contributing]('https://github.com/shapeshift/web/CONTRIBUTING.md) guide?
- [x] Have you checked to ensure there aren't other open [Pull Requests](https://github.com/shapeshift/web/pulls) for the same update/change?

## Pull Request Type

- [x] :bug: Bug fix (Non-breaking Change: Fixes an issue)
- [ ] :hammer_and_wrench: Chore (Non-breaking Change: Doc updates, pkg upgrades, typos, etc..)
- [ ] :nail_care: New Feature (Breaking/Non-breaking Change)

## Issue (if applicable)

closes #1295 

## Risk

Very low risk

## Testing

Navigate to dashboard/asset page you should see a loading state on the history component then the tx history will populate


## Screenshots (if applicable)
![Screen Shot 2022-04-01 at 12 47 00 PM](https://user-images.githubusercontent.com/89934888/161315599-cbf72646-cb28-44aa-a524-5d165a1c385e.png)

