### PR TITLE
feat: language in settings-modal brought back to life

### DIFF
--- a/src/components/Modals/Settings/SettingsList.tsx
+++ b/src/components/Modals/Settings/SettingsList.tsx
@@ -60,24 +60,19 @@ export const SettingsList = ({ appHistory, ...routeProps }: SettingsListProps) =
             <Switch isChecked={isLightMode} pointerEvents='none' />
           </SettingsListItem>
           <Divider my={1} />
-          {/* TODO: remove the following condition when fallback locale is ready */}
-          {false && (
-            <>
-              <SettingsListItem
-                label='modals.settings.language'
-                onClick={() => routeProps.history.push(SettingsRoutes.Languages)}
-                icon={<Icon as={MdLanguage} color='gray.500' />}
-              >
-                <Flex alignItems='center'>
-                  <RawText color={selectedPreferenceValueColor} lineHeight={1} fontSize='sm'>
-                    {getLocaleLabel(selectedLocale)}
-                  </RawText>
-                  <MdChevronRight color='gray.500' size='1.5em' />
-                </Flex>
-              </SettingsListItem>
-              <Divider my={1} />
-            </>
-          )}
+          <SettingsListItem
+            label='modals.settings.language'
+            onClick={() => routeProps.history.push(SettingsRoutes.Languages)}
+            icon={<Icon as={MdLanguage} color='gray.500' />}
+          >
+            <Flex alignItems='center'>
+              <RawText color={selectedPreferenceValueColor} lineHeight={1} fontSize='sm'>
+                {getLocaleLabel(selectedLocale)}
+              </RawText>
+              <MdChevronRight color='gray.500' size='1.5em' />
+            </Flex>
+          </SettingsListItem>
+          <Divider my={1} />
           <SettingsListItem
             label='modals.settings.balanceThreshold'
             icon={<Icon as={FaGreaterThanEqual} color='gray.500' />}


### PR DESCRIPTION
## Description

Language section in settings modal brought back to life

## Notice

<!-- Before submitting a pull request, please make sure you have answered the following: -->

- [x] Have you followed the guidelines in our [Contributing]('https://github.com/shapeshift/web/CONTRIBUTING.md) guide?
- [x] Have you checked to ensure there aren't other open [Pull Requests](https://github.com/shapeshift/web/pulls) for the same update/change?

## Pull Request Type

- [ ] :bug: Bug fix (Non-breaking Change: Fixes an issue)
- [ ] :hammer_and_wrench: Chore (Non-breaking Change: Doc updates, pkg upgrades, typos, etc..)
- [x] :nail_care: New Feature (Breaking/Non-breaking Change)

## Issue (if applicable)

follow-up of settings-modal

## Risk

none

## Testing

Open up settings-modal, click on the language button, and select a language.
- The whole app should respect the selected language. if some key is missing in the selected language, the English fallback must be shown.
- Selected language should be persisted after reloading.

## Screenshots (if applicable)
