### PR TITLE
fix: fallback values for unknown asset

### DIFF
--- a/src/components/TransactionHistoryRows/utils.ts
+++ b/src/components/TransactionHistoryRows/utils.ts
@@ -6,34 +6,39 @@ export enum AssetTypes {
   Fee = 'fee'
 }
 
+const fallbackValues = {
+  symbol: ' N/A',
+  precision: 18
+}
+
 export const parseRelevantAssetFromTx = (txDetails: TxDetails, assetType: AssetTypes | null) => {
   switch (assetType) {
     case AssetTypes.Source:
       return {
-        symbol: txDetails.sellAsset?.symbol ?? '',
+        symbol: txDetails.sellAsset?.symbol ?? fallbackValues.symbol,
         amount: txDetails.sellTransfer?.value ?? '0',
-        precision: txDetails.sellAsset?.precision ?? 0,
+        precision: txDetails.sellAsset?.precision ?? fallbackValues.precision,
         currentPrice: txDetails.sourceMarketData?.price
       }
     case AssetTypes.Destination:
       return {
-        symbol: txDetails.buyAsset?.symbol ?? '',
+        symbol: txDetails.buyAsset?.symbol ?? fallbackValues.symbol,
         amount: txDetails.buyTransfer?.value ?? '0',
-        precision: txDetails.buyAsset?.precision ?? 0,
+        precision: txDetails.buyAsset?.precision ?? fallbackValues.precision,
         currentPrice: txDetails.destinationMarketData?.price
       }
     case AssetTypes.Fee:
       return {
-        symbol: txDetails.feeAsset?.symbol ?? '',
+        symbol: txDetails.feeAsset?.symbol ?? fallbackValues.symbol,
         amount: txDetails.tx.fee?.value ?? '0',
-        precision: txDetails.feeAsset?.precision ?? 0,
+        precision: txDetails.feeAsset?.precision ?? fallbackValues.precision,
         currentPrice: txDetails.feeMarketData?.price
       }
     default:
       return {
-        symbol: txDetails.symbol,
+        symbol: txDetails.symbol ?? fallbackValues.symbol,
         amount: txDetails.value ?? '0',
-        precision: txDetails.precision,
+        precision: txDetails.precision ?? fallbackValues.precision,
         currentPrice: undefined
       }
   }

--- a/src/components/TransactionHistoryRows/utils.ts
+++ b/src/components/TransactionHistoryRows/utils.ts
@@ -6,7 +6,7 @@ export enum AssetTypes {
   Fee = 'fee'
 }
 
-const fallbackValues = {
+const fallback = {
   symbol: ' N/A',
   precision: 18
 }
@@ -15,30 +15,30 @@ export const parseRelevantAssetFromTx = (txDetails: TxDetails, assetType: AssetT
   switch (assetType) {
     case AssetTypes.Source:
       return {
-        symbol: txDetails.sellAsset?.symbol ?? fallbackValues.symbol,
+        symbol: txDetails.sellAsset?.symbol ?? fallback.symbol,
         amount: txDetails.sellTransfer?.value ?? '0',
-        precision: txDetails.sellAsset?.precision ?? fallbackValues.precision,
+        precision: txDetails.sellAsset?.precision ?? fallback.precision,
         currentPrice: txDetails.sourceMarketData?.price
       }
     case AssetTypes.Destination:
       return {
-        symbol: txDetails.buyAsset?.symbol ?? fallbackValues.symbol,
+        symbol: txDetails.buyAsset?.symbol ?? fallback.symbol,
         amount: txDetails.buyTransfer?.value ?? '0',
-        precision: txDetails.buyAsset?.precision ?? fallbackValues.precision,
+        precision: txDetails.buyAsset?.precision ?? fallback.precision,
         currentPrice: txDetails.destinationMarketData?.price
       }
     case AssetTypes.Fee:
       return {
-        symbol: txDetails.feeAsset?.symbol ?? fallbackValues.symbol,
+        symbol: txDetails.feeAsset?.symbol ?? fallback.symbol,
         amount: txDetails.tx.fee?.value ?? '0',
-        precision: txDetails.feeAsset?.precision ?? fallbackValues.precision,
+        precision: txDetails.feeAsset?.precision ?? fallback.precision,
         currentPrice: txDetails.feeMarketData?.price
       }
     default:
       return {
-        symbol: txDetails.symbol ?? fallbackValues.symbol,
+        symbol: txDetails.symbol ?? fallback.symbol,
         amount: txDetails.value ?? '0',
-        precision: txDetails.precision ?? fallbackValues.precision,
+        precision: txDetails.precision ?? fallback.precision,
         currentPrice: undefined
       }
   }


### PR DESCRIPTION
## Description

Fallback values for unknown assets. 
Note: this is using `18` precision as the fallback, so if that needs to be changed to `N/A` only without any numbers at all, please tell me.

## Notice

<!-- Before submitting a pull request, please make sure you have answered the following: -->

- [x] Have you followed the guidelines in our [Contributing]('https://github.com/shapeshift/web/CONTRIBUTING.md) guide?
- [x] Have you checked to ensure there aren't other open [Pull Requests](https://github.com/shapeshift/web/pulls) for the same update/change?

## Pull Request Type

- [x] :bug: Bug fix (Non-breaking Change: Fixes an issue)
- [ ] :hammer_and_wrench: Chore (Non-breaking Change: Doc updates, pkg upgrades, typos, etc..)
- [ ] :nail_care: New Feature (Breaking/Non-breaking Change)

## Issue (if applicable)
closes #1213

## Risk
none

## Screenshots (if applicable)
<img width="1058" alt="fallback" src="https://user-images.githubusercontent.com/20498757/161541682-1772102f-6296-4187-99c1-791c7917472f.png">
