### PR TITLE
fix: dont show green check before trade is confirmed

### DIFF
--- a/src/components/Trade/TradeConfirm/TradeConfirm.tsx
+++ b/src/components/Trade/TradeConfirm/TradeConfirm.tsx
@@ -143,7 +143,12 @@ export const TradeConfirm = ({ history }: RouterProps) => {
                 <Text translation={txid ? 'trade.complete' : 'trade.confirmDetails'} />
               </Card.Heading>
             </WithBackButton>
-            <AssetToAsset buyAsset={buyAsset} sellAsset={sellAsset} mt={6} status={status} />
+            <AssetToAsset
+              buyAsset={buyAsset}
+              sellAsset={sellAsset}
+              mt={6}
+              status={txid ? status : undefined}
+            />
           </Card.Header>
           <Divider />
           <Card.Body pb={0} px={0}>


### PR DESCRIPTION
## Description

Fixes an issue that UI shows a green check before even confirming the tx.
~~This is marked as a draft as I can't get passed through the first step to see if it works as expected or not.~~
tested and worked as expected.

## Notice

<!-- Before submitting a pull request, please make sure you have answered the following: -->

- [x] Have you followed the guidelines in our [Contributing]('https://github.com/shapeshift/web/CONTRIBUTING.md) guide?
- [x] Have you checked to ensure there aren't other open [Pull Requests](https://github.com/shapeshift/web/pulls) for the same update/change?

## Pull Request Type

- [x] :bug: Bug fix (Non-breaking Change: Fixes an issue)
- [ ] :hammer_and_wrench: Chore (Non-breaking Change: Doc updates, pkg upgrades, typos, etc..)
- [ ] :nail_care: New Feature (Breaking/Non-breaking Change)

## Issue (if applicable)
closes #845 
## Risk
none

## Testing
Go to the trade card and choose a pair to trade, in the confirmation step, the icon between assets should be `->` instead of a green check.
## Screenshots (if applicable)
<img width="383" alt="trade" src="https://user-images.githubusercontent.com/20498757/166937211-797c73b1-8972-449b-ad6e-a93c9a00220a.png">

