### PR TITLE
fix: ui tweaks for foxy

### DIFF
--- a/src/assets/translations/main.json
+++ b/src/assets/translations/main.json
@@ -448,7 +448,8 @@
       "amountToDeposit": "Amount To Deposit",
       "estimatedReturns": "Estimated Yearly Returns*",
       "estimateDisclaimer": "*Estimates fluctuate with market conditions.",
-      "footerDisclaimer": "By continuing you agree to our terms of service.",
+      "footerDisclaimer": "By continuing you agree to our ",
+      "footerDisclaimerLink": "terms of service.",
       "slippageSettings": "Slippage Settings"
     },
     "withdraw": {
@@ -472,7 +473,7 @@
       }
     },
     "approve": {
-      "header": "Allow ShapeShift DAO Router to spend your %{asset}",
+      "header": "Allow ShapeShift DAO Router to use your %{asset}",
       "body": "We need your permission to use your %{asset}",
       "learnMore": "Why do I need to do this?",
       "depositFee": "There will be separate gas fee to deposit.",

--- a/src/features/defi/components/Deposit/Deposit.tsx
+++ b/src/features/defi/components/Deposit/Deposit.tsx
@@ -41,7 +41,7 @@ import { Row } from 'components/Row/Row'
 import { SlideTransition } from 'components/SlideTransition'
 import { Slippage } from 'components/Slippage/Slippage'
 import { RawText, Text } from 'components/Text'
-import { useBrowserRouter } from 'context/BrowserRouterProvider/BrowserRouterProvider'
+import { useBrowserRouter } from 'hooks/useBrowserRouter/useBrowserRouter'
 import { useLocaleFormatter } from 'hooks/useLocaleFormatter/useLocaleFormatter'
 import { bnOrZero } from 'lib/bignumber/bignumber'
 

--- a/src/features/defi/components/Deposit/Deposit.tsx
+++ b/src/features/defi/components/Deposit/Deposit.tsx
@@ -13,6 +13,7 @@ import {
   InputLeftElement,
   InputProps,
   InputRightElement,
+  Link,
   ModalBody,
   ModalFooter,
   Popover,
@@ -40,6 +41,7 @@ import { Row } from 'components/Row/Row'
 import { SlideTransition } from 'components/SlideTransition'
 import { Slippage } from 'components/Slippage/Slippage'
 import { RawText, Text } from 'components/Text'
+import { useBrowserRouter } from 'context/BrowserRouterProvider/BrowserRouterProvider'
 import { useLocaleFormatter } from 'hooks/useLocaleFormatter/useLocaleFormatter'
 import { bnOrZero } from 'lib/bignumber/bignumber'
 
@@ -125,6 +127,7 @@ export const Deposit = ({
   const amountRef = useRef<string | null>(null)
   const bgColor = useColorModeValue('gray.50', 'gray.850')
   const borderColor = useColorModeValue('gray.100', 'gray.750')
+  const { history: browserHistory } = useBrowserRouter()
 
   const {
     clearErrors,
@@ -147,6 +150,10 @@ export const Deposit = ({
   const cryptoError = get(errors, 'cryptoAmount.message', null)
   const fiatError = get(errors, 'fiatAmount.message', null)
   const fieldError = cryptoError || fiatError
+
+  const handleTosLink = () => {
+    browserHistory.push('/legal/terms-of-service')
+  }
 
   const handleInputToggle = () => {
     const field = cryptoField ? InputType.Fiat : InputType.Crypto
@@ -400,14 +407,13 @@ export const Deposit = ({
             </FormControl>
           </Stack>
         </ModalBody>
-        <ModalFooter>
-          <Text
-            fontSize='sm'
-            color='gray.500'
-            mb={2}
-            width='full'
-            translation='modals.deposit.footerDisclaimer'
-          />
+        <ModalFooter as={Stack} direction={{ base: 'column', md: 'row' }}>
+          <RawText color='gray.500' fontSize='sm' mb={2}>
+            {translate('modals.deposit.footerDisclaimer')}
+            <Link onClick={handleTosLink} color={useColorModeValue('blue.500', 'blue.200')}>
+              {translate('modals.deposit.footerDisclaimerLink')}
+            </Link>
+          </RawText>
           <Button
             colorScheme={fieldError ? 'red' : 'blue'}
             isDisabled={!isValid}

--- a/src/features/defi/providers/foxy/components/FoxyManager/Deposit/FoxyDeposit.tsx
+++ b/src/features/defi/providers/foxy/components/FoxyManager/Deposit/FoxyDeposit.tsx
@@ -635,9 +635,9 @@ export const FoxyDeposit = ({ api }: FoxyDepositProps) => {
   const fiatAmountAvailable = bnOrZero(cryptoAmountAvailable).times(marketData.price)
 
   return (
-    <Flex width='full' minWidth={{ base: '100%', xl: '500px' }} flexDir='column'>
+    <Flex width='full' minWidth={{ base: '100%', md: '500px' }} flexDir='column'>
       <RouteSteps routes={routes} location={location} />
-      <Flex flexDir='column' width='full' minWidth='500px'>
+      <Flex flexDir='column' width='full'>
         <AnimatePresence exitBeforeEnter initial={false}>
           <Switch location={location} key={location.key}>
             {routes.map(route => {

--- a/src/features/defi/providers/foxy/components/FoxyManager/Overview/FoxyOverview.tsx
+++ b/src/features/defi/providers/foxy/components/FoxyManager/Overview/FoxyOverview.tsx
@@ -15,8 +15,8 @@ export const FoxyOverview = ({ api }: FoxyOverViewProps) => {
   const location = useLocation()
 
   return (
-    <Flex width='full' minWidth={{ base: '100%', xl: '500px' }} flexDir='column'>
-      <Flex flexDir='column' width='full' minWidth='400px'>
+    <Flex width='full' minWidth={{ base: '100%', md: '500px' }} flexDir='column'>
+      <Flex flexDir='column' width='full'>
         <AnimatePresence exitBeforeEnter initial={false}>
           <Switch location={location} key={location.key}>
             <Route exact path='/'>

--- a/src/features/defi/providers/foxy/components/FoxyManager/Overview/WithdrawCard.tsx
+++ b/src/features/defi/providers/foxy/components/FoxyManager/Overview/WithdrawCard.tsx
@@ -62,6 +62,7 @@ export const WithdrawCard = ({ asset, ...rest }: WithdrawCardProps) => {
           color={textColor}
           value={bnOrZero(amount).div(`1e+${asset.precision}`).toString()}
           symbol={asset.symbol}
+          maximumFractionDigits={4}
         />
         {isAvailable ? (
           <Stack direction='row' alignItems='center' color='blue.500'>

--- a/src/features/defi/providers/foxy/components/FoxyManager/Withdraw/FoxyWithdraw.tsx
+++ b/src/features/defi/providers/foxy/components/FoxyManager/Withdraw/FoxyWithdraw.tsx
@@ -630,9 +630,9 @@ export const FoxyWithdraw = ({ api }: FoxyWithdrawProps) => {
     )
 
   return (
-    <Flex width='full' minWidth={{ base: '100%', xl: '500px' }} flexDir='column'>
+    <Flex width='full' minWidth={{ base: '100%', md: '500px' }} flexDir='column'>
       <RouteSteps routes={routes} location={location} />
-      <Flex flexDir='column' width='full' minWidth='400px'>
+      <Flex flexDir='column' width='full'>
         <AnimatePresence exitBeforeEnter initial={false}>
           <Switch location={location} key={location.key}>
             {routes.map(route => {

--- a/src/features/defi/providers/yearn/components/YearnManager/Deposit/YearnDeposit.tsx
+++ b/src/features/defi/providers/yearn/components/YearnManager/Deposit/YearnDeposit.tsx
@@ -628,9 +628,9 @@ export const YearnDeposit = ({ api }: YearnDepositProps) => {
   const fiatAmountAvailable = bnOrZero(cryptoAmountAvailable).times(marketData.price)
 
   return (
-    <Flex width='full' minWidth={{ base: '100%', xl: '500px' }} flexDir='column'>
+    <Flex width='full' minWidth={{ base: '100%', md: '500px' }} flexDir='column'>
       <RouteSteps routes={routes} location={location} />
-      <Flex flexDir='column' width='full' minWidth='500px'>
+      <Flex flexDir='column' width='full'>
         <AnimatePresence exitBeforeEnter initial={false}>
           <Switch location={location} key={location.key}>
             {routes.map(route => {

--- a/src/features/defi/providers/yearn/components/YearnManager/Withdraw/YearnWithdraw.tsx
+++ b/src/features/defi/providers/yearn/components/YearnManager/Withdraw/YearnWithdraw.tsx
@@ -439,9 +439,9 @@ export const YearnWithdraw = ({ api }: YearnWithdrawProps) => {
     )
 
   return (
-    <Flex width='full' minWidth={{ base: '100%', xl: '500px' }} flexDir='column'>
+    <Flex width='full' minWidth={{ base: '100%', md: '500px' }} flexDir='column'>
       <RouteSteps routes={routes} location={location} />
-      <Flex flexDir='column' width='full' minWidth='400px'>
+      <Flex flexDir='column' width='full'>
         <AnimatePresence exitBeforeEnter initial={false}>
           <Switch location={location} key={location.key}>
             {routes.map(route => {


### PR DESCRIPTION
## Description

- fix the hardcoded width on the defi modals
- link up terms of service in the footer of the FoxyDeposit modal
- Update the approval copy to say "use" instead of spend
- Add minFractionalDigitals to the withdraw claim card

## Notice

<!-- Before submitting a pull request, please make sure you have answered the following: -->

- [x] Have you followed the guidelines in our [Contributing]('https://github.com/shapeshift/web/CONTRIBUTING.md) guide?
- [x] Have you checked to ensure there aren't other open [Pull Requests](https://github.com/shapeshift/web/pulls) for the same update/change?

## Pull Request Type

- [x] :bug: Bug fix (Non-breaking Change: Fixes an issue)
- [ ] :hammer_and_wrench: Chore (Non-breaking Change: Doc updates, pkg upgrades, typos, etc..)
- [ ] :nail_care: New Feature (Breaking/Non-breaking Change)

## Issue (if applicable)

closes #1381 

## Risk

Low risk, all UI code behind a feature flag

## Testing

Make sure the deposit/withdraw/overview modals scale correctly on mobile.

## Screenshots (if applicable)
