### PR TITLE
fix: wrong allocation for account portofolio rows

### DIFF
--- a/src/state/slices/portfolioSlice/__snapshots__/portfolioSlice.test.ts.snap
+++ b/src/state/slices/portfolioSlice/__snapshots__/portfolioSlice.test.ts.snap
@@ -373,3 +373,41 @@ Object {
   },
 }
 `;
+
+exports[`portfolioSlice selectors selectPortfolioAccountRows should return correct portfolio rows in case of 100% allocation on one asset 1`] = `
+Array [
+  Object {
+    "allocation": 0,
+    "assetId": "eip155:1/slip44:60",
+    "cryptoAmount": "0",
+    "fiatAmount": "0.00",
+    "icon": "https://assets.coincap.io/assets/icons/eth@2x.png",
+    "name": "Ethereum",
+    "price": "1000",
+    "priceChange": 2,
+    "symbol": "ETH",
+  },
+  Object {
+    "allocation": 100,
+    "assetId": "eip155:1/erc20:0xc770eefad204b5180df6a14ee197d99d808ee52d",
+    "cryptoAmount": "0.123456",
+    "fiatAmount": "3.88",
+    "icon": "https://assets.coincap.io/assets/icons/fox@2x.png",
+    "name": "Fox",
+    "price": "31.39",
+    "priceChange": 2,
+    "symbol": "FOX",
+  },
+  Object {
+    "allocation": 0,
+    "assetId": "eip155:1/erc20:0xa0b86991c6218b36c1d19d4a2e9eb0ce3606eb48",
+    "cryptoAmount": "0",
+    "fiatAmount": "0.00",
+    "icon": "https://assets.coingecko.com/coins/images/12367/thumb/oF1_9R1K_400x400.jpg?1599345463",
+    "name": "USD Coin",
+    "price": "1",
+    "priceChange": 2,
+    "symbol": "ETH",
+  },
+]
+`;

--- a/src/state/slices/portfolioSlice/portfolioSlice.test.ts
+++ b/src/state/slices/portfolioSlice/portfolioSlice.test.ts
@@ -30,6 +30,7 @@ import { portfolio as portfolioSlice } from './portfolioSlice'
 import {
   selectAccountIdByAddress,
   selectPortfolioAccountIdsSortedFiat,
+  selectPortfolioAccountRows,
   selectPortfolioAllocationPercentByFilter,
   selectPortfolioAssetAccounts,
   selectPortfolioAssetIdsByAccountId,
@@ -725,6 +726,49 @@ describe('portfolioSlice', () => {
         const result = selectPortfolioAssetIdsByAccountIdExcludeFeeAsset(state, ethAccountId)
 
         expect(result).toEqual(expected)
+      })
+    })
+
+    describe('selectPortfolioAccountRows', () => {
+      const store = createStore()
+      const { ethAccount } = mockETHandBTCAccounts({
+        ethAccountObj: {
+          balance: '0',
+          chainSpecific: {
+            tokens: [
+              mockEthToken({ balance: '123456123456315537', caip19: foxCaip19 }),
+              mockEthToken({ balance: '0', caip19: usdcCaip19 })
+            ]
+          }
+        }
+      })
+
+      // dispatch portfolio data
+      store.dispatch(
+        portfolioSlice.actions.upsertPortfolio(mockUpsertPortfolio([ethAccount], assetIds))
+      )
+
+      // dispatch market data
+      const ethMarketData = mockMarketData({ price: '1000' })
+      const foxMarketData = mockMarketData({ price: '31.39' })
+      const usdcMarketData = mockMarketData({ price: '1' })
+
+      store.dispatch(
+        marketDataSlice.actions.setMarketData({
+          [ethCaip19]: ethMarketData,
+          [foxCaip19]: foxMarketData,
+          [usdcCaip19]: usdcMarketData
+        })
+      )
+
+      // dispatch asset data
+      const assetData = mockAssetState()
+      store.dispatch(assetsSlice.actions.setAssets(assetData))
+      const state = store.getState()
+
+      it('should return correct portfolio rows in case of 100% allocation on one asset', () => {
+        const result = selectPortfolioAccountRows(state)
+        expect(result).toMatchSnapshot()
       })
     })
   })

--- a/src/state/slices/portfolioSlice/selectors.ts
+++ b/src/state/slices/portfolioSlice/selectors.ts
@@ -526,7 +526,10 @@ export const selectPortfolioAccountRows = createDeepEqualOutputSelector(
          * continue to the next asset balance by returning acc
          */
         if (fiatAmount.lt(bnOrZero(balanceThreshold))) return acc
-        const allocation = fiatAmount.div(bnOrZero(totalPortfolioFiatBalance)).times(100).toNumber()
+        const allocation = bnOrZero(fiatAmount.toFixed(2))
+          .div(bnOrZero(totalPortfolioFiatBalance))
+          .times(100)
+          .toNumber()
         const priceChange = marketData[assetId]?.changePercent24Hr
         const data = {
           assetId,


### PR DESCRIPTION
## Description

Fixes the allocation computation for portfolio rows.

## Notice

<!-- Before submitting a pull request, please make sure you have answered the following: -->

- [X] Have you followed the guidelines in our [Contributing]('https://github.com/shapeshift/web/CONTRIBUTING.md) guide?
- [X] Have you checked to ensure there aren't other open [Pull Requests](https://github.com/shapeshift/web/pulls) for the same update/change?

## Pull Request Type

- [X] :bug: Bug fix (Non-breaking Change: Fixes an issue)
- [ ] :hammer_and_wrench: Chore (Non-breaking Change: Doc updates, pkg upgrades, typos, etc..)
- [ ] :nail_care: New Feature (Breaking/Non-breaking Change)

## Issue (if applicable)

<!-----------------------------------------------------------------------------
If applicable, please link to the github issue and put `closes #XXXX` in your comment to auto-close the issue that your PR fixes.
------------------------------------------------------------------------------>

## Risk

<!-----------------------------------------------------------------------------
Outline the scope of your changes and the risk associated with them. You must use your discretion as an engineer to determine the potential impact of your changes.

E.g. an upgrade to `hdwallet` or core state management would be considered higher risk, and might require a full regression test. UI or isolated view changes, or something behind a feature flag may have near zero risk. Small bug fixes might require testing isolated to the specific fix.
------------------------------------------------------------------------------>

## Testing

<!-----------------------------------------------------------------------------
If your testing steps are technical, outline steps for an engineer to verify.

If your testing steps are functional, please provide a full guide with any features requiring special attention for operations to test your branch in the preview environment.
------------------------------------------------------------------------------>
Can be verified with an account with only one asset allocation (100%), the computation always returned something like 99,99X% or 100.01%.
Verify that the allocation is now 100%

## Screenshots (if applicable)

Before fix
![allocation_cosmos](https://user-images.githubusercontent.com/5720927/161804311-042c40b9-6b31-47f5-9958-ecc4635b21c1.png)

After fix
![allocation_cosmos_fixed](https://user-images.githubusercontent.com/5720927/161804354-541b71b7-abfd-40c6-aa86-69fa326abcbb.png)


