### PR TITLE
fix: replace the cosmos static icon to asset icon on overview

### DIFF
--- a/src/plugins/cosmos/components/AssetClaimCard/AssetClaimCard.tsx
+++ b/src/plugins/cosmos/components/AssetClaimCard/AssetClaimCard.tsx
@@ -1,13 +1,13 @@
 import { Box, Flex } from '@chakra-ui/layout'
 import { Text as CText } from '@chakra-ui/react'
 import BigNumber from 'bignumber.js'
-import osmosis from 'assets/osmosis.svg'
 import { Amount } from 'components/Amount/Amount'
 import { AssetIcon } from 'components/AssetIcon'
 import { Card, CardProps } from 'components/Card/Card'
 
 type AssetClaimCardProps = {
   assetSymbol: string
+  assetIcon: string
   assetName: string
   cryptoRewardsAmount: BigNumber
   fiatRate: BigNumber
@@ -16,6 +16,7 @@ type AssetClaimCardProps = {
 
 export const AssetClaimCard = ({
   assetSymbol,
+  assetIcon,
   assetName,
   cryptoRewardsAmount,
   fiatRate,
@@ -26,7 +27,7 @@ export const AssetClaimCard = ({
     <Card.Body p='10px'>
       <Flex justifyContent='space-between' alignItems='center'>
         <Flex alignItems='center'>
-          <AssetIcon src={osmosis} boxSize='40px' />
+          <AssetIcon src={assetIcon} boxSize='40px' />
           <Box ml={2}>
             <CText fontWeight='bold' lineHeight='1' mb={1}>
               {assetName}

--- a/src/plugins/cosmos/components/AssetHoldingsCard/AssetHoldingsCard.tsx
+++ b/src/plugins/cosmos/components/AssetHoldingsCard/AssetHoldingsCard.tsx
@@ -1,19 +1,20 @@
 import { Box, Flex } from '@chakra-ui/layout'
 import { Text as CText } from '@chakra-ui/react'
 import { useTranslate } from 'react-polyglot'
-import osmosis from 'assets/osmosis.svg'
 import { Amount } from 'components/Amount/Amount'
 import { AssetIcon } from 'components/AssetIcon'
 import { Card, CardProps } from 'components/Card/Card'
 
 type AssetHoldingsCardProps = {
   assetSymbol: string
+  assetIcon: string
   cryptoAmountAvailable: string
   fiatAmountAvailable: string
 } & CardProps
 
 export const AssetHoldingsCard = ({
   assetSymbol,
+  assetIcon,
   cryptoAmountAvailable,
   fiatAmountAvailable,
   ...styleProps
@@ -24,7 +25,7 @@ export const AssetHoldingsCard = ({
     <Card size='sm' width='full' variant='group' {...styleProps}>
       <Card.Body>
         <Flex alignItems='center'>
-          <AssetIcon src={osmosis} boxSize='40px' />
+          <AssetIcon src={assetIcon} boxSize='40px' />
           <Box ml={2}>
             <CText fontWeight='bold' lineHeight='1' mb={1}>
               {assetSymbol}

--- a/src/plugins/cosmos/components/StakedRow/StakedRow.tsx
+++ b/src/plugins/cosmos/components/StakedRow/StakedRow.tsx
@@ -1,6 +1,5 @@
 import { Flex, FlexProps } from '@chakra-ui/layout'
 import { AprTag } from 'plugins/cosmos/components/AprTag/AprTag'
-import osmosis from 'assets/osmosis.svg'
 import { Amount } from 'components/Amount/Amount'
 import { AssetIcon } from 'components/AssetIcon'
 import { Text } from 'components/Text'
@@ -8,14 +7,17 @@ import { BigNumber } from 'lib/bignumber/bignumber'
 
 type StakedRowProps = {
   assetSymbol: string
+  assetIcon: string
   cryptoStakedAmount: BigNumber
   fiatRate: BigNumber
   apr: BigNumber
 }
+
 export const StakedRow = ({
   cryptoStakedAmount,
   fiatRate,
   assetSymbol,
+  assetIcon,
   apr,
   ...styleProps
 }: StakedRowProps & FlexProps) => {
@@ -24,7 +26,7 @@ export const StakedRow = ({
       <Text translation={'defi.amountStaked'} color='gray.500' />
 
       <Flex alignItems='center'>
-        <AssetIcon src={osmosis} boxSize='40px' mr='24px' />
+        <AssetIcon src={assetIcon} boxSize='40px' mr='24px' />
         <Amount.Crypto fontSize='28' value={cryptoStakedAmount.toString()} symbol={assetSymbol} />
       </Flex>
       <AprTag height='20px' percentage={apr.toPrecision()} showAprSuffix={true} />

--- a/src/plugins/cosmos/components/modals/Staking/views/Overview.tsx
+++ b/src/plugins/cosmos/components/modals/Staking/views/Overview.tsx
@@ -83,6 +83,7 @@ export const Overview: React.FC<StakedProps> = ({
           >
             <StakedRow
               assetSymbol={asset.symbol}
+              assetIcon={asset.icon}
               fiatRate={bnOrZero(marketData.price)}
               cryptoStakedAmount={bnOrZero(totalBondings)
                 .div(`1e+${asset.precision}`)
@@ -96,6 +97,7 @@ export const Overview: React.FC<StakedProps> = ({
               <AssetClaimCard
                 assetSymbol={asset.symbol}
                 assetName={asset.name}
+                assetIcon={asset.icon}
                 cryptoRewardsAmount={bnOrZero(rewardsAmount)
                   .div(`1e+${asset.precision}`)
                   .decimalPlaces(asset.precision)}

--- a/src/plugins/cosmos/components/modals/Staking/views/Stake.tsx
+++ b/src/plugins/cosmos/components/modals/Staking/views/Stake.tsx
@@ -140,6 +140,7 @@ export const Stake = ({ assetId, apr, validatorAddress }: StakeProps) => {
           py='8px'
           mb={6}
           assetSymbol={asset.symbol}
+          assetIcon={asset.icon}
           cryptoAmountAvailable={cryptoBalanceHuman.toString()}
           fiatAmountAvailable={fiatAmountAvailable}
         />


### PR DESCRIPTION
## Description

The cosmos icon on the overview and staking modal was a static one, we should use the `asset.icon`

## Notice

<!-- Before submitting a pull request, please make sure you have answered the following: -->

- [x] Have you followed the guidelines in our [Contributing]('https://github.com/shapeshift/web/CONTRIBUTING.md) guide?
- [x] Have you checked to ensure there aren't other open [Pull Requests](https://github.com/shapeshift/web/pulls) for the same update/change?

## Pull Request Type

- [x] :bug: Bug fix (Non-breaking Change: Fixes an issue)
- [ ] :hammer_and_wrench: Chore (Non-breaking Change: Doc updates, pkg upgrades, typos, etc..)
- [ ] :nail_care: New Feature (Breaking/Non-breaking Change)

## Risk

No much risks

## Testing

Open the Overview and Staking modal of a cosmos asset and see if the icon is the right one

## Screenshots (if applicable)
![image](https://user-images.githubusercontent.com/14963751/161840813-3c71acd1-64a7-4517-93e3-91c6ff414bd8.png)

![image](https://user-images.githubusercontent.com/14963751/161860308-a5cfdeaa-fcef-418a-b3da-dee234a0073d.png)

