### PR TITLE
fix: added filter to yearn vaults to remove new vaults with an absurd…

### DIFF
--- a/src/features/defi/helpers/normalizeOpportunity.tsx
+++ b/src/features/defi/helpers/normalizeOpportunity.tsx
@@ -63,11 +63,13 @@ const useTransformVault = (vaults: SupportedYearnVault[]): EarnOpportunityType[]
     // show vaults that are expired but have a balance
     // show vaults that don't have an APY but have a balance
     // don't show vaults that don't have a balance and don't have an APY
+    // don't show new vaults that have an APY over 20,000% APY
     if (assetIds.includes(assetCAIP19)) {
       if (
         vault.expired ||
         bnOrZero(vault?.metadata?.apy?.net_apy).isEqualTo(0) ||
-        bnOrZero(vault.underlyingTokenBalance.amountUsdc).isEqualTo(0)
+        bnOrZero(vault.underlyingTokenBalance.amountUsdc).isEqualTo(0) ||
+        (bnOrZero(vault?.metadata?.apy?.net_apy).gt(200) && vault?.metadata?.apy?.type === 'new')
       ) {
         if (bnOrZero(cryptoAmount).gt(0)) {
           acc.push(data)


### PR DESCRIPTION
…ly high apy

## Description

A new yearn vault just released and the net_apy from yearn is 2.4e+74. These values cause the UI to look terrible, break the ability to open the modal to deposit into the vault and are simply unrealistic apy values. The value is coming from yearn.finance, so we can't change the apy itself.

The fix here is to filter out a new vault that has an apy over 20,000% since an apy over that amount is not very realistic.
<!-- Please describe your changes -->

## Notice

<!-- Before submitting a pull request, please make sure you have answered the following: -->

- [x] Have you followed the guidelines in our [Contributing]('https://github.com/shapeshift/web/CONTRIBUTING.md) guide?
- [x] Have you checked to ensure there aren't other open [Pull Requests](https://github.com/shapeshift/web/pulls) for the same update/change?

## Pull Request Type

- [x] :bug: Bug fix (Non-breaking Change: Fixes an issue)
- [ ] :hammer_and_wrench: Chore (Non-breaking Change: Doc updates, pkg upgrades, typos, etc..)
- [ ] :nail_care: New Feature (Breaking/Non-breaking Change)

## Issue (if applicable)

<!-----------------------------------------------------------------------------
If applicable, please link to the github issue and put `closes #XXXX` in your comment to auto-close the issue that your PR fixes.
------------------------------------------------------------------------------>

## Risk

Minimal risk to the Earn Overview page listing all earn opportunities.
<!-----------------------------------------------------------------------------
Outline the scope of your changes and the risk associated with them. You must use your discretion as an engineer to determine the potential impact of your changes.

E.g. an upgrade to `hdwallet` or core state management would be considered higher risk, and might require a full regression test. UI or isolated view changes, or something behind a feature flag may have near zero risk. Small bug fixes might require testing isolated to the specific fix.
------------------------------------------------------------------------------>

## Testing

The new vault Curve Rocket Pool should not show unless it's APY drops below 20,000%
<!-----------------------------------------------------------------------------
If your testing steps are technical, outline steps for an engineer to verify.

If your testing steps are functional, please provide a full guide with any features requiring special attention for operations to test your branch in the preview environment.
------------------------------------------------------------------------------>

## Screenshots (if applicable)

<img width="1332" alt="Screen Shot 2022-04-05 at 15 08 27" src="https://user-images.githubusercontent.com/88169003/161849600-06598254-46cd-4745-8132-3c8de0e73c34.png">
<img width="1239" alt="Screen Shot 2022-04-05 at 15 09 22" src="https://user-images.githubusercontent.com/88169003/161849612-52a696c1-3a2d-4a8c-91b1-d4eaaf2686ca.png">

