### PR TITLE
fix(cosmos): ui nitpicks

### DIFF
--- a/src/assets/translations/main.json
+++ b/src/assets/translations/main.json
@@ -254,7 +254,7 @@
   "staking": {
     "staking": "Staking",
     "itWillTake": "It will take",
-    "toUnlock": "to unlock your %{assetSymbol} after you unstake. Staking rewards will need to withdrawn separately.",
+    "toUnlock": "to unlock your %{assetSymbol} after you unstake. Staking rewards will need to be withdrawn separately.",
     "assetStakingBalance": "%{assetSymbol} Staking Balance"
   },
   "navBar": {

--- a/src/assets/translations/main.json
+++ b/src/assets/translations/main.json
@@ -254,8 +254,8 @@
   "staking": {
     "staking": "Staking",
     "itWillTake": "It will take",
-    "toUnlock": "to unlock your Osmo after you unstake. Staking rewards will need to withdrawn separately.",
-    "assetStakingBalance": "%{assetName} Staking Balance"
+    "toUnlock": "to unlock your %{assetSymbol} after you unstake. Staking rewards will need to withdrawn separately.",
+    "assetStakingBalance": "%{assetSymbol} Staking Balance"
   },
   "navBar": {
     "dashboard": "Dashboard",

--- a/src/plugins/cosmos/components/AssetClaimCard/AssetClaimCard.tsx
+++ b/src/plugins/cosmos/components/AssetClaimCard/AssetClaimCard.tsx
@@ -8,7 +8,6 @@ import { Card, CardProps } from 'components/Card/Card'
 
 type AssetClaimCardProps = {
   assetSymbol: string
-  assetName: string
   cryptoRewardsAmount: BigNumber
   fiatRate: BigNumber
   renderButton?: () => JSX.Element
@@ -16,7 +15,6 @@ type AssetClaimCardProps = {
 
 export const AssetClaimCard = ({
   assetSymbol,
-  assetName,
   cryptoRewardsAmount,
   fiatRate,
   renderButton,
@@ -29,7 +27,7 @@ export const AssetClaimCard = ({
           <AssetIcon src={osmosis} boxSize='40px' />
           <Box ml={2}>
             <CText fontWeight='bold' lineHeight='1' mb={1}>
-              {assetName}
+              {assetSymbol}
             </CText>
             <CText
               color='gray.500'

--- a/src/plugins/cosmos/components/modals/Staking/views/Overview.tsx
+++ b/src/plugins/cosmos/components/modals/Staking/views/Overview.tsx
@@ -100,7 +100,6 @@ export const Overview: React.FC<StakedProps> = ({
               <Text translation={'defi.rewards'} mb='12px' color='gray.500' />
               <AssetClaimCard
                 assetSymbol={asset.symbol}
-                assetName={asset.name}
                 cryptoRewardsAmount={bnOrZero(rewardsAmount)
                   .div(`1e+${asset.precision}`)
                   .decimalPlaces(asset.precision)}

--- a/src/plugins/cosmos/components/modals/Staking/views/Unstake.tsx
+++ b/src/plugins/cosmos/components/modals/Staking/views/Unstake.tsx
@@ -31,7 +31,8 @@ import { useAppSelector } from 'state/store'
 
 import { Field, StakingValues, UnstakingPath } from '../StakingCommon'
 
-const UNBONDING_DURATION = '14'
+// TODO(gomes): Make this dynamic, this should come from chain-adapters when ready there
+const UNBONDING_DURATION = '21'
 
 export enum InputType {
   Crypto = 'crypto',
@@ -144,7 +145,7 @@ export const Unstake = ({ assetId, apr, accountSpecifier, validatorAddress }: Un
             <Text
               lineHeight={1}
               color='gray.500'
-              translation={['staking.assetStakingBalance', { assetName: asset.name }]}
+              translation={['staking.assetStakingBalance', { assetSymbol: asset.symbol }]}
             />
             <Amount.Crypto
               fontWeight='bold'
@@ -201,7 +202,7 @@ export const Unstake = ({ assetId, apr, accountSpecifier, validatorAddress }: Un
               {`${UNBONDING_DURATION} ${translate('common.days')}`}
             </Box>
             <span> </span>
-            {translate('staking.toUnlock')}
+            {translate('staking.toUnlock', { assetSymbol: asset.symbol })}
           </CText>
 
           <Divider />


### PR DESCRIPTION
## Description

This PR is about small UI nitpicks after https://github.com/shapeshift/web/commit/435aa4d3a10334276205afcf07cd613d9f7d47aa and it:
- uses asset symbol vs. name everywhere in the cosmos staking modal for consistency and to match the mockups.
- uses the right hardcoded amount of days for Cosmos unbonding days (21).

## Notice

<!-- Before submitting a pull request, please make sure you have answered the following: -->

- [x] Have you followed the guidelines in our [Contributing]('https://github.com/shapeshift/web/CONTRIBUTING.md) guide?
- [x] Have you checked to ensure there aren't other open [Pull Requests](https://github.com/shapeshift/web/pulls) for the same update/change?

## Pull Request Type

- [x] :bug: Bug fix (Non-breaking Change: Fixes an issue)
- [ ] :hammer_and_wrench: Chore (Non-breaking Change: Doc updates, pkg upgrades, typos, etc..)
- [ ] :nail_care: New Feature (Breaking/Non-breaking Change)

## Issue (if applicable)

<!-----------------------------------------------------------------------------
If applicable, please link to the github issue and put `closes #XXXX` in your comment to auto-close the issue that your PR fixes.
------------------------------------------------------------------------------>

## Risk

N/A
<!-----------------------------------------------------------------------------
Outline the scope of your changes and the risk associated with them. You must use your discretion as an engineer to determine the potential impact of your changes.

E.g. an upgrade to `hdwallet` or core state management would be considered higher risk, and might require a full regression test. UI or isolated view changes, or something behind a feature flag may have near zero risk. Small bug fixes might require testing isolated to the specific fix.
------------------------------------------------------------------------------>

## Testing

- The right number of unbonding days should be displayed for Cosmos unstaking in the staking modal
- The symbol should consistently be used in place of the name in the staking modal

<!-----------------------------------------------------------------------------
If your testing steps are technical, outline steps for an engineer to verify.

If your testing steps are functional, please provide a full guide with any features requiring special attention for operations to test your branch in the preview environment.
------------------------------------------------------------------------------>

## Screenshots (if applicable)

<img width="464" alt="image" src="https://user-images.githubusercontent.com/17035424/162016373-a9a22e86-f165-4361-90fd-c13862dbdcce.png">
<img width="475" alt="image" src="https://user-images.githubusercontent.com/17035424/162016425-a80f54b2-616f-4745-b9e2-9f37fe76963c.png">
<img width="446" alt="image" src="https://user-images.githubusercontent.com/17035424/162016467-cc2a34f0-eab6-4a47-8e48-e4f52c417f68.png">
