### PR TITLE
fix(cosmos): crypto/fiat amount fixes

### DIFF
--- a/src/plugins/cosmos/components/modals/Staking/views/Stake.tsx
+++ b/src/plugins/cosmos/components/modals/Staking/views/Stake.tsx
@@ -99,7 +99,10 @@ export const Stake = ({ assetId, apr, validatorAddress }: StakeProps) => {
   }
 
   const handleInputChange = (value: string) => {
-    if (bnOrZero(value).gt(cryptoBalanceHuman)) {
+    if (
+      (activeField === InputType.Crypto && bnOrZero(value).gt(cryptoBalanceHuman)) ||
+      (activeField === InputType.Fiat && bnOrZero(value).gt(fiatAmountAvailable))
+    ) {
       setValue(Field.AmountFieldError, 'common.insufficientFunds', { shouldValidate: true })
     } else if (values.amountFieldError) {
       setValue(Field.AmountFieldError, '', { shouldValidate: true })

--- a/src/plugins/cosmos/components/modals/Staking/views/Stake.tsx
+++ b/src/plugins/cosmos/components/modals/Staking/views/Stake.tsx
@@ -23,7 +23,7 @@ import { useTranslate } from 'react-polyglot'
 import { useHistory } from 'react-router-dom'
 import { SlideTransition } from 'components/SlideTransition'
 import { Text } from 'components/Text'
-import { bnOrZero } from 'lib/bignumber/bignumber'
+import { BigNumber, bnOrZero } from 'lib/bignumber/bignumber'
 import {
   selectAssetByCAIP19,
   selectMarketDataById,
@@ -86,35 +86,48 @@ export const Stake = ({ assetId, apr, validatorAddress }: StakeProps) => {
   const translate = useTranslate()
 
   const handlePercentClick = (_percent: number) => {
+    if (values.amountFieldError) {
+      setValue(Field.AmountFieldError, '', { shouldValidate: true })
+    }
+
     const cryptoAmount = bnOrZero(cryptoBalanceHuman).times(_percent)
-    const fiat = bnOrZero(cryptoAmount).times(marketData.price)
+    const fiatAmount = bnOrZero(cryptoAmount).times(marketData.price)
     if (activeField === InputType.Crypto) {
-      setValue(Field.FiatAmount, fiat.toString(), { shouldValidate: true })
+      setValue(Field.FiatAmount, fiatAmount.toString(), { shouldValidate: true })
       setValue(Field.CryptoAmount, cryptoAmount.toString(), { shouldValidate: true })
     } else {
-      setValue(Field.FiatAmount, fiat.toString(), { shouldValidate: true })
+      setValue(Field.FiatAmount, fiatAmount.toString(), { shouldValidate: true })
       setValue(Field.CryptoAmount, cryptoAmount.toString(), { shouldValidate: true })
     }
     setPercent(_percent)
   }
 
   const handleInputChange = (value: string) => {
-    if (
-      (activeField === InputType.Crypto && bnOrZero(value).gt(cryptoBalanceHuman)) ||
-      (activeField === InputType.Fiat && bnOrZero(value).gt(fiatAmountAvailable))
-    ) {
-      setValue(Field.AmountFieldError, 'common.insufficientFunds', { shouldValidate: true })
-    } else if (values.amountFieldError) {
-      setValue(Field.AmountFieldError, '', { shouldValidate: true })
-    }
-
     setPercent(null)
     if (activeField === InputType.Crypto) {
-      const fiat = bnOrZero(value).times(marketData.price)
-      setValue(Field.FiatAmount, fiat.toString(), { shouldValidate: true })
+      const cryptoAmount = bnOrZero(value).dp(asset.precision, BigNumber.ROUND_DOWN)
+      const fiatAmount = bnOrZero(value).times(marketData.price)
+      setValue(Field.FiatAmount, fiatAmount.toString(), { shouldValidate: true })
+      setValue(Field.CryptoAmount, cryptoAmount.toString(), { shouldValidate: true })
+
+      if (cryptoAmount.gt(cryptoBalanceHuman)) {
+        setValue(Field.AmountFieldError, 'common.insufficientFunds', { shouldValidate: true })
+        return
+      }
     } else {
-      const crypto = bnOrZero(value).div(marketData.price)
-      setValue(Field.CryptoAmount, crypto.toString(), { shouldValidate: true })
+      const cryptoAmount = bnOrZero(value)
+        .div(marketData.price)
+        .dp(asset.precision, BigNumber.ROUND_DOWN)
+      setValue(Field.CryptoAmount, cryptoAmount.toString(), { shouldValidate: true })
+
+      if (bnOrZero(cryptoAmount).gt(bnOrZero(cryptoBalanceHuman))) {
+        setValue(Field.AmountFieldError, 'common.insufficientFunds', { shouldValidate: true })
+        return
+      }
+    }
+
+    if (values.amountFieldError) {
+      setValue(Field.AmountFieldError, '', { shouldValidate: true })
     }
   }
 

--- a/src/plugins/cosmos/components/modals/Staking/views/Unstake.tsx
+++ b/src/plugins/cosmos/components/modals/Staking/views/Unstake.tsx
@@ -57,7 +57,7 @@ export const Unstake = ({ assetId, apr, accountSpecifier, validatorAddress }: Un
 
   const asset = useAppSelector(state => selectAssetByCAIP19(state, assetId))
   const marketData = useAppSelector(state => selectMarketDataById(state, assetId))
-  const totalBondings = useAppSelector(state =>
+  const cryptoStakeBalance = useAppSelector(state =>
     selectDelegationCryptoAmountByAssetIdAndValidator(
       state,
       accountSpecifier,
@@ -65,7 +65,7 @@ export const Unstake = ({ assetId, apr, accountSpecifier, validatorAddress }: Un
       assetId
     )
   )
-  const cryptoStakeBalanceHuman = bnOrZero(totalBondings).div(`1e+${asset?.precision}`)
+  const cryptoStakeBalanceHuman = bnOrZero(cryptoStakeBalance).div(`1e+${asset?.precision}`)
 
   const [percent, setPercent] = useState<number | null>(null)
   const [activeField, setActiveField] = useState<InputType>(InputType.Crypto)
@@ -170,7 +170,7 @@ export const Unstake = ({ assetId, apr, accountSpecifier, validatorAddress }: Un
             />
             <Amount.Crypto
               fontWeight='bold'
-              value={bnOrZero(totalBondings).div(`1e+${asset?.precision}`).toString()}
+              value={bnOrZero(cryptoStakeBalance).div(`1e+${asset?.precision}`).toString()}
               symbol={asset.symbol}
             />
           </Flex>

--- a/src/plugins/cosmos/components/modals/Staking/views/Unstake.tsx
+++ b/src/plugins/cosmos/components/modals/Staking/views/Unstake.tsx
@@ -24,8 +24,8 @@ import { useModal } from 'hooks/useModal/useModal'
 import { bnOrZero } from 'lib/bignumber/bignumber'
 import {
   selectAssetByCAIP19,
-  selectMarketDataById,
-  selectTotalBondingsBalanceByAssetId
+  selectDelegationCryptoAmountByAssetIdAndValidator,
+  selectMarketDataById
 } from 'state/slices/selectors'
 import { useAppSelector } from 'state/store'
 
@@ -58,7 +58,12 @@ export const Unstake = ({ assetId, apr, accountSpecifier, validatorAddress }: Un
   const asset = useAppSelector(state => selectAssetByCAIP19(state, assetId))
   const marketData = useAppSelector(state => selectMarketDataById(state, assetId))
   const totalBondings = useAppSelector(state =>
-    selectTotalBondingsBalanceByAssetId(state, accountSpecifier, validatorAddress, assetId)
+    selectDelegationCryptoAmountByAssetIdAndValidator(
+      state,
+      accountSpecifier,
+      validatorAddress,
+      assetId
+    )
   )
   const cryptoBalanceHuman = bnOrZero(totalBondings).div(`1e+${asset?.precision}`)
 
@@ -102,7 +107,11 @@ export const Unstake = ({ assetId, apr, accountSpecifier, validatorAddress }: Un
   }
 
   const handleInputChange = (value: string) => {
-    if (bnOrZero(value).gt(cryptoBalanceHuman)) {
+    if (
+      (activeField === InputType.Crypto && bnOrZero(value).gt(cryptoBalanceHuman)) ||
+      (activeField === InputType.Fiat &&
+        bnOrZero(value).gt(bnOrZero(cryptoBalanceHuman).times(marketData.price)))
+    ) {
       setValue(Field.AmountFieldError, 'common.insufficientFunds', { shouldValidate: true })
     } else if (values.amountFieldError) {
       setValue(Field.AmountFieldError, '', { shouldValidate: true })

--- a/src/plugins/cosmos/components/modals/Staking/views/Unstake.tsx
+++ b/src/plugins/cosmos/components/modals/Staking/views/Unstake.tsx
@@ -21,7 +21,7 @@ import { Amount } from 'components/Amount/Amount'
 import { SlideTransition } from 'components/SlideTransition'
 import { Text } from 'components/Text'
 import { useModal } from 'hooks/useModal/useModal'
-import { bnOrZero } from 'lib/bignumber/bignumber'
+import { BigNumber, bnOrZero } from 'lib/bignumber/bignumber'
 import {
   selectAssetByCAIP19,
   selectDelegationCryptoAmountByAssetIdAndValidator,
@@ -65,7 +65,7 @@ export const Unstake = ({ assetId, apr, accountSpecifier, validatorAddress }: Un
       assetId
     )
   )
-  const cryptoBalanceHuman = bnOrZero(totalBondings).div(`1e+${asset?.precision}`)
+  const cryptoStakeBalanceHuman = bnOrZero(totalBondings).div(`1e+${asset?.precision}`)
 
   const [percent, setPercent] = useState<number | null>(null)
   const [activeField, setActiveField] = useState<InputType>(InputType.Crypto)
@@ -94,35 +94,48 @@ export const Unstake = ({ assetId, apr, accountSpecifier, validatorAddress }: Un
   }
 
   const handlePercentClick = (_percent: number) => {
-    const cryptoAmount = bnOrZero(cryptoBalanceHuman).times(_percent)
-    const fiat = bnOrZero(cryptoAmount).times(marketData.price)
+    if (values.amountFieldError) {
+      setValue(Field.AmountFieldError, '', { shouldValidate: true })
+    }
+
+    const cryptoAmount = bnOrZero(cryptoStakeBalanceHuman).times(_percent)
+    const fiatAmount = bnOrZero(cryptoAmount).times(marketData.price)
     if (activeField === InputType.Crypto) {
-      setValue(Field.FiatAmount, fiat.toString(), { shouldValidate: true })
+      setValue(Field.FiatAmount, fiatAmount.toString(), { shouldValidate: true })
       setValue(Field.CryptoAmount, cryptoAmount.toString(), { shouldValidate: true })
     } else {
-      setValue(Field.FiatAmount, fiat.toString(), { shouldValidate: true })
+      setValue(Field.FiatAmount, fiatAmount.toString(), { shouldValidate: true })
       setValue(Field.CryptoAmount, cryptoAmount.toString(), { shouldValidate: true })
     }
     setPercent(_percent)
   }
 
   const handleInputChange = (value: string) => {
-    if (
-      (activeField === InputType.Crypto && bnOrZero(value).gt(cryptoBalanceHuman)) ||
-      (activeField === InputType.Fiat &&
-        bnOrZero(value).gt(bnOrZero(cryptoBalanceHuman).times(marketData.price)))
-    ) {
-      setValue(Field.AmountFieldError, 'common.insufficientFunds', { shouldValidate: true })
-    } else if (values.amountFieldError) {
-      setValue(Field.AmountFieldError, '', { shouldValidate: true })
-    }
     setPercent(null)
     if (activeField === InputType.Crypto) {
-      const fiat = bnOrZero(value).times(marketData.price)
-      setValue(Field.FiatAmount, fiat.toString(), { shouldValidate: true })
+      const cryptoAmount = bnOrZero(value).dp(asset.precision, BigNumber.ROUND_DOWN)
+      const fiatAmount = bnOrZero(value).times(marketData.price)
+      setValue(Field.FiatAmount, fiatAmount.toString(), { shouldValidate: true })
+      setValue(Field.CryptoAmount, cryptoAmount.toString(), { shouldValidate: true })
+
+      if (cryptoAmount.gt(cryptoStakeBalanceHuman)) {
+        setValue(Field.AmountFieldError, 'common.insufficientFunds', { shouldValidate: true })
+        return
+      }
     } else {
-      const crypto = bnOrZero(value).div(marketData.price)
-      setValue(Field.CryptoAmount, crypto.toString(), { shouldValidate: true })
+      const cryptoAmount = bnOrZero(value)
+        .div(marketData.price)
+        .dp(asset.precision, BigNumber.ROUND_DOWN)
+      setValue(Field.CryptoAmount, cryptoAmount.toString(), { shouldValidate: true })
+
+      if (bnOrZero(cryptoAmount).gt(bnOrZero(cryptoStakeBalanceHuman))) {
+        setValue(Field.AmountFieldError, 'common.insufficientFunds', { shouldValidate: true })
+        return
+      }
+    }
+
+    if (values.amountFieldError) {
+      setValue(Field.AmountFieldError, '', { shouldValidate: true })
     }
   }
 

--- a/src/plugins/cosmos/components/modals/Staking/views/UnstakeBroadcast.tsx
+++ b/src/plugins/cosmos/components/modals/Staking/views/UnstakeBroadcast.tsx
@@ -95,10 +95,7 @@ export const UnstakeBroadcast = ({
           <Flex flexDirection='column' alignItems='flex-end'>
             <Amount.Fiat
               fontWeight='semibold'
-              value={bnOrZero(cryptoAmount)
-                .div(`1e+${asset.precision}`)
-                .times(marketData.price)
-                .toPrecision()}
+              value={bnOrZero(cryptoAmount).times(marketData.price).toPrecision()}
             />
             <Amount.Crypto
               color='gray.500'

--- a/src/state/slices/stakingDataSlice/selectors.ts
+++ b/src/state/slices/stakingDataSlice/selectors.ts
@@ -91,7 +91,7 @@ export const selectAllDelegationsCryptoAmountByAssetId = createSelector(
   }
 )
 
-export const selectDelegationCryptoAmountByValidator = createSelector(
+export const selectDelegationCryptoAmountByAssetIdAndValidator = createSelector(
   selectAllDelegationsCryptoAmountByAssetId,
   selectValidatorAddress,
   (allDelegations, validatorAddress): string => {
@@ -168,7 +168,7 @@ export const selectAllUnbondingsEntriesByAssetIdAndValidator = createSelector(
   (unbondingEntries, validatorAddress) => unbondingEntries[validatorAddress]
 )
 
-export const selectUnbondingCryptoAmountByAssetId = createSelector(
+export const selectUnbondingCryptoAmountByAssetIdAndValidator = createSelector(
   selectUnbondingEntriesByAccountSpecifier,
   selectAssetIdParam,
   (unbondingEntries, selectedAssetId): string => {
@@ -185,8 +185,8 @@ export const selectUnbondingCryptoAmountByAssetId = createSelector(
 )
 
 export const selectTotalBondingsBalanceByAssetId = createSelector(
-  selectUnbondingCryptoAmountByAssetId,
-  selectDelegationCryptoAmountByValidator,
+  selectUnbondingCryptoAmountByAssetIdAndValidator,
+  selectDelegationCryptoAmountByAssetIdAndValidator,
   (unbondingCryptoBalance, delegationCryptoBalance): string =>
     bnOrZero(unbondingCryptoBalance).plus(bnOrZero(delegationCryptoBalance)).toString()
 )


### PR DESCRIPTION
## Description

On Stake and Unstake steps of the staking modal, this:
- adds validation of staking/unstaking balance in the Stake/Unstake inputs.
- fixes the data shown as "Amount staked" in unstake (the amount that's available to unstake) which currently uses bondings total (staked + unstaked), which is wrong, since you can't unstake an already unstaked amount
- uses asset precision as decimal places for the crypto input amount. The fiat amount is left untouched as it is used for the crypto amount calculation
- resets crypto amount errors on percent click (since a percentage of the crypto balance/staked balance is guaranteed to be within bounds of availability)
- removes the division of crypto amount / asset precision for fiat rate calculation in `<UnstakeBroadcast />`, since that amount is already in human-readable ATOM format

## Notice

<!-- Before submitting a pull request, please make sure you have answered the following: -->

- [x] Have you followed the guidelines in our [Contributing]('https://github.com/shapeshift/web/CONTRIBUTING.md) guide?
- [x] Have you checked to ensure there aren't other open [Pull Requests](https://github.com/shapeshift/web/pulls) for the same update/change?

## Pull Request Type

- [x] :bug: Bug fix (Non-breaking Change: Fixes an issue)
- [ ] :hammer_and_wrench: Chore (Non-breaking Change: Doc updates, pkg upgrades, typos, etc..)
- [ ] :nail_care: New Feature (Breaking/Non-breaking Change)

## Issue (if applicable)

closes #1394
closes #1395
closes #1404 

<!-----------------------------------------------------------------------------
If applicable, please link to the github issue and put `closes #XXXX` in your comment to auto-close the issue that your PR fixes.
------------------------------------------------------------------------------>

## Risk

<!-----------------------------------------------------------------------------
Outline the scope of your changes and the risk associated with them. You must use your discretion as an engineer to determine the potential impact of your changes.

E.g. an upgrade to `hdwallet` or core state management would be considered higher risk, and might require a full regression test. UI or isolated view changes, or something behind a feature flag may have near zero risk. Small bug fixes might require testing isolated to the specific fix.
------------------------------------------------------------------------------>

## Testing

- It should be possible to input a fiat amount/use send max button in Stake and Unstake modal steps without any errored state as long as the input amount is within availability bounds
- The displayed "Amount Staked" should stricly match the Mintscan delegated amount for the current validator. It should NOT add the undelegated amount to that number.
- Inputting some amount should be limited to the asset precision for decimal places (6 in the case of ATOM in CosmosHub)
- Switching from Fiat to Crypto input should produce a number that's within the same decimal precisions
- In Unstake broadcast, the correct FIAT amount should be displayed

## Screenshots (if applicable)

<img width="430" alt="image" src="https://user-images.githubusercontent.com/17035424/161990087-742a26fa-4e36-4aa9-bc43-4638b7c84328.png">
<img width="867" alt="image" src="https://user-images.githubusercontent.com/17035424/161990175-3335b25b-7ac8-40dc-9b7f-2d4d2de7ead8.png">
