### PR TITLE
fix: debounce send input

### DIFF
--- a/src/components/Modals/Send/hooks/useSendDetails/useSendDetails.tsx
+++ b/src/components/Modals/Send/hooks/useSendDetails/useSendDetails.tsx
@@ -337,7 +337,7 @@ export const useSendDetails = (): UseSendDetailsReturnType => {
   }
 
   // eslint-disable-next-line react-hooks/exhaustive-deps
-  const handleInputChange = useMemo(() => debounce(inputHandler, 1000, { trailing: true }), [])
+  const handleInputChange = useMemo(() => debounce(inputHandler, 1000, { leading: true }), [])
 
   const toggleCurrency = () => {
     setFieldName(

--- a/src/components/Modals/Send/hooks/useSendDetails/useSendDetails.tsx
+++ b/src/components/Modals/Send/hooks/useSendDetails/useSendDetails.tsx
@@ -281,63 +281,69 @@ export const useSendDetails = (): UseSendDetailsReturnType => {
     }
   }
 
-  const inputHandler = async (inputValue: string) => {
-    setLoading(true)
-    setValue(SendFormFields.SendMax, false)
-    const key =
-      fieldName !== SendFormFields.FiatAmount
-        ? SendFormFields.FiatAmount
-        : SendFormFields.CryptoAmount
-    if (inputValue === '') {
-      // Don't show an error message when the input is empty
-      setValue(SendFormFields.AmountFieldError, '')
+  const inputHandler = useCallback(
+    async (inputValue: string) => {
+      setLoading(true)
+      setValue(SendFormFields.SendMax, false)
+      const key =
+        fieldName !== SendFormFields.FiatAmount
+          ? SendFormFields.FiatAmount
+          : SendFormFields.CryptoAmount
+      if (inputValue === '') {
+        // Don't show an error message when the input is empty
+        setValue(SendFormFields.AmountFieldError, '')
+        setLoading(false)
+        // Set value of the other input to an empty string as well
+        setValue(key, '')
+        return
+      }
+      const amount =
+        fieldName === SendFormFields.FiatAmount
+          ? bnOrZero(bn(inputValue).div(price)).toString()
+          : bnOrZero(bn(inputValue).times(price)).toString()
+
+      setValue(key, amount)
+
+      let estimatedFees
+
+      try {
+        estimatedFees = await estimateFormFees()
+        setValue(SendFormFields.EstimatedFees, estimatedFees)
+      } catch (e) {
+        setValue(SendFormFields.AmountFieldError, 'common.insufficientFunds')
+        setLoading(false)
+
+        throw e
+      }
+
+      const values = getValues()
+
+      const hasValidBalance = cryptoHumanBalance.gte(values.cryptoAmount)
+      const hasEnoughNativeTokenForGas = nativeAssetBalance
+        .minus(estimatedFees.fast.txFee)
+        .isPositive()
+
+      if (!hasValidBalance) {
+        setValue(SendFormFields.AmountFieldError, 'common.insufficientFunds')
+      } else if (!hasEnoughNativeTokenForGas) {
+        setValue(SendFormFields.AmountFieldError, [
+          'modals.send.errors.notEnoughNativeToken',
+          { asset: feeAsset.symbol }
+        ])
+      } else {
+        // Remove existing error messages because the send amount is valid
+        setValue(SendFormFields.AmountFieldError, '')
+      }
       setLoading(false)
-      // Set value of the other input to an empty string as well
-      setValue(key, '')
-      return
-    }
-    const amount =
-      fieldName === SendFormFields.FiatAmount
-        ? bnOrZero(bn(inputValue).div(price)).toString()
-        : bnOrZero(bn(inputValue).times(price)).toString()
+    },
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+    [estimateFormFees, feeAsset.symbol, fieldName, getValues, setValue]
+  )
 
-    setValue(key, amount)
-
-    let estimatedFees
-
-    try {
-      estimatedFees = await estimateFormFees()
-      setValue(SendFormFields.EstimatedFees, estimatedFees)
-    } catch (e) {
-      setValue(SendFormFields.AmountFieldError, 'common.insufficientFunds')
-      setLoading(false)
-
-      throw e
-    }
-
-    const values = getValues()
-
-    const hasValidBalance = cryptoHumanBalance.gte(values.cryptoAmount)
-    const hasEnoughNativeTokenForGas = nativeAssetBalance
-      .minus(estimatedFees.fast.txFee)
-      .isPositive()
-
-    if (!hasValidBalance) {
-      setValue(SendFormFields.AmountFieldError, 'common.insufficientFunds')
-    } else if (!hasEnoughNativeTokenForGas) {
-      setValue(SendFormFields.AmountFieldError, [
-        'modals.send.errors.notEnoughNativeToken',
-        { asset: feeAsset.symbol }
-      ])
-    } else {
-      // Remove existing error messages because the send amount is valid
-      setValue(SendFormFields.AmountFieldError, '')
-    }
-    setLoading(false)
-  }
-
-  // eslint-disable-next-line react-hooks/exhaustive-deps
-  const handleInputChange = useMemo(() => debounce(inputHandler, 1000, { leading: true }), [])
+  const handleInputChange = useMemo(
+    () => debounce(inputHandler, 1000, { leading: true }),
+    [inputHandler]
+  )
 
   const toggleCurrency = () => {
     setFieldName(


### PR DESCRIPTION
## Description

The debouncer in `useSendDetails` does not currently work, and so we make 3 network requests for every keystroke when sending.

This PR fixes that by memoizing the input handler. 

## Notice

<!-- Before submitting a pull request, please make sure you have answered the following: -->

- [x] Have you followed the guidelines in our [Contributing]('https://github.com/shapeshift/web/CONTRIBUTING.md) guide?
- [x] Have you checked to ensure there aren't other open [Pull Requests](https://github.com/shapeshift/web/pulls) for the same update/change?

## Pull Request Type

- [x] :bug: Bug fix (Non-breaking Change: Fixes an issue)
- [ ] :hammer_and_wrench: Chore (Non-breaking Change: Doc updates, pkg upgrades, typos, etc..)
- [ ] :nail_care: New Feature (Breaking/Non-breaking Change)

## Issue (if applicable)

N/A

## Risk

N/A

## Testing

Send a transaction and rapidly mutate the input value - check we only make 3 network requests when keystrokes are less than 1,000 ms apart.

## Screenshots (if applicable)

N/A
