### PR TITLE
fix: switch to asset icon from symbol

### DIFF
--- a/src/components/TransactionHistoryRows/TransactionGenericRow.tsx
+++ b/src/components/TransactionHistoryRows/TransactionGenericRow.tsx
@@ -56,6 +56,7 @@ type TransactionRowAsset = {
   amount: string
   precision: number
   currentPrice?: string
+  icon?: string
 }
 
 type TransactionGenericRowProps = {
@@ -163,7 +164,7 @@ export const TransactionGenericRow = ({
                 }}
               >
                 <AssetIcon
-                  symbol={asset.symbol.toLowerCase()}
+                  src={asset.icon}
                   boxSize={{ base: '24px', md: compactMode ? '24px' : '40px' }}
                 />
                 <Box flex={1}>

--- a/src/components/TransactionHistoryRows/utils.ts
+++ b/src/components/TransactionHistoryRows/utils.ts
@@ -18,21 +18,24 @@ export const parseRelevantAssetFromTx = (txDetails: TxDetails, assetType: AssetT
         symbol: txDetails.sellAsset?.symbol ?? fallback.symbol,
         amount: txDetails.sellTransfer?.value ?? '0',
         precision: txDetails.sellAsset?.precision ?? fallback.precision,
-        currentPrice: txDetails.sourceMarketData?.price
+        currentPrice: txDetails.sourceMarketData?.price,
+        icon: txDetails.sellAsset?.icon
       }
     case AssetTypes.Destination:
       return {
         symbol: txDetails.buyAsset?.symbol ?? fallback.symbol,
         amount: txDetails.buyTransfer?.value ?? '0',
         precision: txDetails.buyAsset?.precision ?? fallback.precision,
-        currentPrice: txDetails.destinationMarketData?.price
+        currentPrice: txDetails.destinationMarketData?.price,
+        icon: txDetails.buyAsset?.icon
       }
     case AssetTypes.Fee:
       return {
         symbol: txDetails.feeAsset?.symbol ?? fallback.symbol,
         amount: txDetails.tx.fee?.value ?? '0',
         precision: txDetails.feeAsset?.precision ?? fallback.precision,
-        currentPrice: txDetails.feeMarketData?.price
+        currentPrice: txDetails.feeMarketData?.price,
+        icon: txDetails.feeAsset?.icon
       }
     default:
       return {


### PR DESCRIPTION
## Description

Using the asset icon instead of the symbol for the `<AssetIcon>` component

## Notice

<!-- Before submitting a pull request, please make sure you have answered the following: -->

- [x] Have you followed the guidelines in our [Contributing]('https://github.com/shapeshift/web/CONTRIBUTING.md) guide?
- [x] Have you checked to ensure there aren't other open [Pull Requests](https://github.com/shapeshift/web/pulls) for the same update/change?

## Pull Request Type

- [x] :bug: Bug fix (Non-breaking Change: Fixes an issue)
- [ ] :hammer_and_wrench: Chore (Non-breaking Change: Doc updates, pkg upgrades, typos, etc..)
- [ ] :nail_care: New Feature (Breaking/Non-breaking Change)

## Issue (if applicable)


## Risk

low risk

## Testing

Make sure the tx history icons are showing correctly

## Screenshots (if applicable)
