### PR TITLE
fix: defi modal routing

### DIFF
--- a/src/assets/translations/main.json
+++ b/src/assets/translations/main.json
@@ -478,7 +478,7 @@
       "header": "Allow ShapeShift DAO Router to use your %{asset}",
       "body": "We need your permission to use your %{asset}",
       "learnMore": "Why do I need to do this?",
-      "depositFee": "There will be separate gas fee to deposit.",
+      "depositFee": "There will be a separate gas fee to deposit.",
       "estimatedGas": "Estimated Gas Fee",
       "confirm": "Confirm",
       "reject": "Reject"

--- a/src/components/StakingVaults/AllEarnOpportunities.tsx
+++ b/src/components/StakingVaults/AllEarnOpportunities.tsx
@@ -43,7 +43,7 @@ export const AllEarnOpportunities = () => {
         return
       }
       history.push({
-        pathname: `/defi/${type}/${provider}/deposit`,
+        pathname: `/defi/${type}/${provider}/overview`,
         search: qs.stringify({
           chain,
           contractAddress,

--- a/src/features/defi/components/Deposit/Deposit.tsx
+++ b/src/features/defi/components/Deposit/Deposit.tsx
@@ -41,7 +41,6 @@ import { Row } from 'components/Row/Row'
 import { SlideTransition } from 'components/SlideTransition'
 import { Slippage } from 'components/Slippage/Slippage'
 import { RawText, Text } from 'components/Text'
-import { useBrowserRouter } from 'hooks/useBrowserRouter/useBrowserRouter'
 import { useLocaleFormatter } from 'hooks/useLocaleFormatter/useLocaleFormatter'
 import { bnOrZero } from 'lib/bignumber/bignumber'
 
@@ -127,7 +126,6 @@ export const Deposit = ({
   const amountRef = useRef<string | null>(null)
   const bgColor = useColorModeValue('gray.50', 'gray.850')
   const borderColor = useColorModeValue('gray.100', 'gray.750')
-  const { history: browserHistory } = useBrowserRouter()
 
   const {
     clearErrors,
@@ -152,7 +150,7 @@ export const Deposit = ({
   const fieldError = cryptoError || fiatError
 
   const handleTosLink = () => {
-    browserHistory.push('/legal/terms-of-service')
+    window.open('/legal/terms-of-service')
   }
 
   const handleInputToggle = () => {

--- a/src/features/defi/providers/foxy/components/FoxyManager/Deposit/FoxyDeposit.tsx
+++ b/src/features/defi/providers/foxy/components/FoxyManager/Deposit/FoxyDeposit.tsx
@@ -318,7 +318,7 @@ export const FoxyDeposit = ({ api }: FoxyDepositProps) => {
     browserHistory.push('/defi')
   }
 
-  const handleCancel = history.goBack
+  const handleCancel = browserHistory.goBack
 
   const validateCryptoAmount = (value: string) => {
     const crypto = bnOrZero(balance).div(`1e+${asset.precision}`)
@@ -413,7 +413,7 @@ export const FoxyDeposit = ({ api }: FoxyDepositProps) => {
       case DepositPath.Confirm:
         return (
           <Confirm
-            onCancel={handleCancel}
+            onCancel={() => history.push('/')}
             onConfirm={handleDeposit}
             loading={state.loading}
             loadingText={translate('common.confirmOnWallet')}

--- a/src/features/defi/providers/foxy/components/FoxyManager/Withdraw/FoxyWithdraw.tsx
+++ b/src/features/defi/providers/foxy/components/FoxyManager/Withdraw/FoxyWithdraw.tsx
@@ -331,9 +331,7 @@ export const FoxyWithdraw = ({ api }: FoxyWithdrawProps) => {
     browserHistory.push('/defi')
   }
 
-  const handleCancel = () => {
-    browserHistory.goBack()
-  }
+  const handleCancel = browserHistory.goBack
 
   const validateCryptoAmount = (value: string) => {
     const crypto = bnOrZero(bn(balance).div(`1e+${asset.precision}`))
@@ -448,7 +446,7 @@ export const FoxyWithdraw = ({ api }: FoxyWithdrawProps) => {
       case WithdrawPath.Confirm:
         return (
           <Confirm
-            onCancel={handleCancel}
+            onCancel={() => history.push('/')}
             headerText='modals.confirm.withdraw.header'
             onConfirm={handleConfirm}
             loading={state.loading}

--- a/src/features/defi/providers/yearn/components/YearnManager/YearnManager.tsx
+++ b/src/features/defi/providers/yearn/components/YearnManager/YearnManager.tsx
@@ -1,14 +1,19 @@
 import { Center, Heading, Stack } from '@chakra-ui/layout'
 import { ModalHeader, useColorModeValue } from '@chakra-ui/react'
 import { DefiActionButtons } from 'features/defi/components/DefiActionButtons'
-import { DefiParams } from 'features/defi/contexts/DefiManagerProvider/DefiCommon'
+import {
+  DefiAction,
+  DefiParams,
+  DefiQueryParams
+} from 'features/defi/contexts/DefiManagerProvider/DefiCommon'
 import { useYearn } from 'features/defi/contexts/YearnProvider/YearnProvider'
 import { AnimatePresence } from 'framer-motion'
 import { Location } from 'history'
-import { MemoryRouter, Route, Switch, useLocation, useParams } from 'react-router'
+import { useEffect } from 'react'
+import { matchPath, MemoryRouter, Route, Switch, useLocation, useParams } from 'react-router'
 import { CircularProgress } from 'components/CircularProgress/CircularProgress'
 import { SlideTransition } from 'components/SlideTransition'
-import { RawText } from 'components/Text'
+import { useBrowserRouter } from 'hooks/useBrowserRouter/useBrowserRouter'
 
 import { YearnDeposit } from './Deposit/YearnDeposit'
 import { YearnWithdraw } from './Withdraw/YearnWithdraw'
@@ -26,6 +31,24 @@ type YearnRouteProps = {
 const YearnRoutes = ({ parentLocation, provider, earnType }: YearnRouteProps) => {
   const { yearn } = useYearn()
   const headerBg = useColorModeValue('gray.50', 'gray.800')
+  const { location, history } = useBrowserRouter<DefiQueryParams, DefiParams>()
+  const match = matchPath<DefiParams>(location.pathname, {
+    path: '/defi/:earnType/:provider/:action',
+    exact: true
+  })
+
+  useEffect(() => {
+    // redirect from overview to deposit till we hook up overview for yearn vaults
+    if (location.pathname === YearnPath.Overview) {
+      if (match?.params) {
+        const { earnType, provider } = match.params
+        history.replace({
+          ...location,
+          pathname: `/defi/${earnType}/${provider}/${DefiAction.Deposit}/`
+        })
+      }
+    }
+  }, [history, location, match])
   if (!yearn)
     return (
       <Center minW='350px' minH='350px'>
@@ -57,9 +80,6 @@ const YearnRoutes = ({ parentLocation, provider, earnType }: YearnRouteProps) =>
                 <YearnWithdraw api={yearn} />
               </SlideTransition>
             </MemoryRouter>
-          </Route>
-          <Route path={YearnPath.Overview}>
-            <RawText>Overview</RawText>
           </Route>
         </Switch>
       </AnimatePresence>

--- a/src/pages/Defi/components/OpportunityCard.tsx
+++ b/src/pages/Defi/components/OpportunityCard.tsx
@@ -62,7 +62,7 @@ export const OpportunityCard = ({
   const handleClick = () => {
     isConnected
       ? history.push({
-          pathname: `/defi/${type}/${provider}/withdraw`,
+          pathname: `/defi/${type}/${provider}/overview`,
           search: qs.stringify({
             chain,
             contractAddress,


### PR DESCRIPTION
## Description

- fix routing for going back and cancel
- fix translation for the gas
- redirect to deposit on yearn vaults till we have an overview screen
- open TOS in a new window

## Notice

<!-- Before submitting a pull request, please make sure you have answered the following: -->

- [x] Have you followed the guidelines in our [Contributing]('https://github.com/shapeshift/web/CONTRIBUTING.md) guide?
- [x] Have you checked to ensure there aren't other open [Pull Requests](https://github.com/shapeshift/web/pulls) for the same update/change?

## Pull Request Type

- [x] :bug: Bug fix (Non-breaking Change: Fixes an issue)
- [ ] :hammer_and_wrench: Chore (Non-breaking Change: Doc updates, pkg upgrades, typos, etc..)
- [ ] :nail_care: New Feature (Breaking/Non-breaking Change)

## Issue (if applicable)



## Risk

low risk

## Testing

make sure the routing works correctly for yearn and foxy

1. Approval cancel, goes back to the input screen
2. Confirm goes back to the input screen
3. Status close takes you back to /defi

## Screenshots (if applicable)
