### PR TITLE
feat: add link button to the explorer on asset page

### DIFF
--- a/src/assets/translations/es/main.json
+++ b/src/assets/translations/es/main.json
@@ -247,7 +247,8 @@
         "body": "No ha depositado en ningún pool de liquidez.",
         "cta": "Ver Oportunidades"
       }
-    }
+    },
+    "viewOnChain": "Ver en cadena"
   },
   "staking": {
     "staking": "Staking",
@@ -781,7 +782,6 @@
       "trade": "Intercambiar"
     },
     "assets": "Activos",
-    "viewOnChain": "Ver en cadena",
     "txid": "ID de TX",
     "fee": "Tarifa",
     "youSent": "Enviaste",

--- a/src/assets/translations/fr/main.json
+++ b/src/assets/translations/fr/main.json
@@ -246,7 +246,8 @@
         "body": "Vous n'avez pas encore fait de dépôt dans les pools de liquidité.",
         "cta": "Voir les opportunités"
       }
-    }
+    },
+    "viewOnChain": "Vue sur la chaîne"
   },
   "staking": {
     "staking": "Placements",
@@ -780,7 +781,6 @@
       "trade": "Échange"
     },
     "assets": "Actifs",
-    "viewOnChain": "Vue sur la chaîne",
     "txid": "ID TX",
     "fee": "Frais",
     "youSent": "Vous avez envoyé",

--- a/src/assets/translations/ko/main.json
+++ b/src/assets/translations/ko/main.json
@@ -247,7 +247,8 @@
         "body": "예치한 유동성 풀이 없습니다",
         "cta": "유동성 풀 찾아보기"
       }
-    }
+    },
+    "viewOnChain": "체인에서 확인하기"
   },
   "staking": {
     "staking": "스테이킹",
@@ -781,7 +782,6 @@
       "trade": "거래"
     },
     "assets": "자산",
-    "viewOnChain": "체인에서 확인하기",
     "txid": "TX ID",
     "fee": "수수료",
     "youSent": "보낸 금액",

--- a/src/assets/translations/main.json
+++ b/src/assets/translations/main.json
@@ -250,7 +250,8 @@
         "body": "You have not deposited into any liquidity pools.",
         "cta": "View Opportunities"
       }
-    }
+    },
+    "viewOnChain": "View on chain"
   },
   "staking": {
     "staking": "Staking",
@@ -785,7 +786,6 @@
       "trade": "Trade"
     },
     "assets": "Assets",
-    "viewOnChain": "View on chain",
     "txid": "TX ID",
     "fee": "Fee",
     "youSent": "You Sent",

--- a/src/assets/translations/pt/main.json
+++ b/src/assets/translations/pt/main.json
@@ -236,7 +236,8 @@
         "body": "Você não possui nenhuma Pool ativa.",
         "cta": "Descobrir Oportunidades"
       }
-    }
+    },
+    "viewOnChain": "Ver na cadeia"
   },
   "staking": {
     "staking": "Poupança",
@@ -743,7 +744,6 @@
       "trade": "Troca"
     },
     "assets": "Bens",
-    "viewOnChain": "Ver na cadeia",
     "txid": "ID TX",
     "fee": "Taxa",
     "youSent": "Você enviou",

--- a/src/components/AssetHeader/AssetActions.tsx
+++ b/src/components/AssetHeader/AssetActions.tsx
@@ -1,5 +1,5 @@
-import { ArrowDownIcon, ArrowUpIcon } from '@chakra-ui/icons'
-import { ButtonGroup, IconButton, Skeleton, Tooltip } from '@chakra-ui/react'
+import { ArrowDownIcon, ArrowUpIcon, ExternalLinkIcon } from '@chakra-ui/icons'
+import { Button, ButtonGroup, Link, Skeleton } from '@chakra-ui/react'
 import { CAIP19 } from '@shapeshiftoss/caip'
 import { bnOrZero } from '@shapeshiftoss/chain-adapters'
 import { useTranslate } from 'react-polyglot'
@@ -36,43 +36,63 @@ export const AssetActions = ({ isLoaded, assetId, accountId, cryptoBalance }: As
 
   return (
     <ButtonGroup
-      ml={{ base: 0, lg: 'auto' }}
+      ml={{ base: 0, md: 'auto' }}
       mt={{ base: 6, lg: 0 }}
-      width={{ base: 'full', lg: 'auto' }}
+      spacing={{ base: 0, md: '0.5rem' }}
+      width={{ base: 'full', md: 'auto' }}
+      flexWrap={{ base: 'wrap', md: 'nowrap' }}
+      justifyContent={{ base: 'space-between', md: 'inherit' }}
     >
-      <Skeleton isLoaded={isLoaded} width={{ base: 'full', lg: 'auto' }}>
-        <Tooltip
-          label={
-            !hasValidBalance ? translate('common.insufficientFunds') : translate('common.send')
-          }
-          fontSize='md'
-          px={4}
-          hasArrow
+      <Skeleton
+        isLoaded={isLoaded}
+        width={{ base: 'full', md: 'auto' }}
+        order={{ base: 2, md: 0 }}
+        mt={{ base: '0.5rem', md: '0' }}
+      >
+        <Button
+          as={Link}
+          leftIcon={<ExternalLinkIcon />}
+          // If tokenId is undefined, redirect to the basic explorer link
+          // else redirect to the token explorer link
+          href={`${asset?.tokenId ? asset?.explorerAddressLink : asset?.explorer}${
+            asset?.tokenId ?? ''
+          }`}
+          variant='solid'
+          isExternal
+          width='full'
         >
-          <div>
-            <IconButton
-              onClick={handleSendClick}
-              isRound
-              width='full'
-              icon={<ArrowUpIcon />}
-              aria-label={translate('common.send')}
-              isDisabled={!hasValidBalance}
-              data-test='asset-action-send'
-            />
-          </div>
-        </Tooltip>
+          {translate('defi.viewOnChain')}
+        </Button>
       </Skeleton>
-      <Skeleton isLoaded={isLoaded} width={{ base: 'full', lg: 'auto' }}>
-        <Tooltip label={translate('common.receive')} fontSize='md' px={4} hasArrow>
-          <IconButton
-            onClick={handleReceiveClick}
-            isRound
-            width='full'
-            icon={<ArrowDownIcon />}
-            aria-label={translate('common.receive')}
-            data-test='asset-action-receive'
-          />
-        </Tooltip>
+      <Skeleton
+        isLoaded={isLoaded}
+        width={{ base: 'calc(50% - 0.25rem)', md: 'auto' }}
+        order={{ base: 0, md: 1 }}
+        ms='0'
+      >
+        <Button
+          onClick={handleSendClick}
+          leftIcon={<ArrowUpIcon />}
+          isDisabled={!hasValidBalance}
+          width='full'
+          data-test='asset-action-send'
+        >
+          {translate('common.send')}
+        </Button>
+      </Skeleton>
+      <Skeleton
+        isLoaded={isLoaded}
+        width={{ base: 'calc(50% - 0.25rem)', md: 'auto' }}
+        order={{ base: 1, md: 2 }}
+      >
+        <Button
+          onClick={handleReceiveClick}
+          leftIcon={<ArrowDownIcon />}
+          width='full'
+          data-test='asset-action-receive'
+        >
+          {translate('common.receive')}
+        </Button>
       </Skeleton>
     </ButtonGroup>
   )

--- a/src/components/Button/Button.theme.ts
+++ b/src/components/Button/Button.theme.ts
@@ -15,6 +15,7 @@ const baseStyle = {
     boxShadow: 'none',
   },
   _hover: {
+    textDecoration: 'none',
     _disabled: {
       bg: 'initial',
     },


### PR DESCRIPTION
## Description
- We wants to have a button on the top of the asset/account page in order to be able to open the explorer link
- In case you are on ETH, BTC, redirect to the basic explorer link, else, redirect to the token link
- Mooved the `viewOnChain` translation key to `defi` part because it shouldn't be inside `transactionHistory` anymore
- Under `md` breakpoint, every buttons are reordered and well placed (see screenshots)
<!-- Please describe your changes -->

## Notice

<!-- Before submitting a pull request, please make sure you have answered the following: -->

- [x] Have you followed the guidelines in our [Contributing]('https://github.com/shapeshift/web/CONTRIBUTING.md) guide?
- [x] Have you checked to ensure there aren't other open [Pull Requests](https://github.com/shapeshift/web/pulls) for the same update/change?

## Pull Request Type

- [ ] :bug: Bug fix (Non-breaking Change: Fixes an issue)
- [ ] :hammer_and_wrench: Chore (Non-breaking Change: Doc updates, pkg upgrades, typos, etc..)
- [x] :nail_care: New Feature (Breaking/Non-breaking Change)

## Issue (if applicable)
closes #1180
<!-----------------------------------------------------------------------------
If applicable, please link to the github issue and put `closes #XXXX` in your comment to auto-close the issue that your PR fixes.
------------------------------------------------------------------------------>

## Risk
In case the explorer link or implementation changes, it can redirect to a wrong link
<!-----------------------------------------------------------------------------
Outline the scope of your changes and the risk associated with them. You must use your discretion as an engineer to determine the potential impact of your changes.

E.g. an upgrade to `hdwallet` or core state management would be considered a higher risk, and might require a full regression test. UI or isolated view changes, or something behind a feature flag may have near zero risk. Small bug fixes might require testing isolated to the specific fix.
------------------------------------------------------------------------------>

## Testing
Try the button on BTC: It will redirect to blockcypher, because we don't have the link to the BTC page.
Try the button on ETH: It will redirect to etherscan home page.
Try the button on any ERC20: It will redirect to the contract page on etherscan.
Try the button on Cosmos: It will redirect to mintscan

<!-----------------------------------------------------------------------------
If your testing steps are technical, outline steps for an engineer to verify.

If your testing steps are functional, please provide a full guide with any features requiring special attention for operations to test your branch in the preview environment.
------------------------------------------------------------------------------>

## Screenshots (if applicable)
![image](https://user-images.githubusercontent.com/14963751/162275020-fa47d544-2c0f-4f13-aee9-6ca110c41585.png)

![image](https://user-images.githubusercontent.com/14963751/162805520-98eb0981-bd4a-424c-9778-2da2954d3efd.png)
