### PR TITLE
fix: decimal places fix on percent click

### DIFF
--- a/src/plugins/cosmos/components/modals/Staking/views/Stake.tsx
+++ b/src/plugins/cosmos/components/modals/Staking/views/Stake.tsx
@@ -90,7 +90,9 @@ export const Stake = ({ assetId, apr, validatorAddress }: StakeProps) => {
       setValue(Field.AmountFieldError, '', { shouldValidate: true })
     }
 
-    const cryptoAmount = bnOrZero(cryptoBalanceHuman).times(_percent)
+    const cryptoAmount = bnOrZero(cryptoBalanceHuman)
+      .times(_percent)
+      .dp(asset.precision, BigNumber.ROUND_DOWN)
     const fiatAmount = bnOrZero(cryptoAmount).times(marketData.price)
     if (activeField === InputType.Crypto) {
       setValue(Field.FiatAmount, fiatAmount.toString(), { shouldValidate: true })

--- a/src/plugins/cosmos/components/modals/Staking/views/Unstake.tsx
+++ b/src/plugins/cosmos/components/modals/Staking/views/Unstake.tsx
@@ -99,7 +99,9 @@ export const Unstake = ({ assetId, apr, accountSpecifier, validatorAddress }: Un
       setValue(Field.AmountFieldError, '', { shouldValidate: true })
     }
 
-    const cryptoAmount = bnOrZero(cryptoStakeBalanceHuman).times(_percent)
+    const cryptoAmount = bnOrZero(cryptoStakeBalanceHuman)
+      .times(_percent)
+      .dp(asset.precision, BigNumber.ROUND_DOWN)
     const fiatAmount = bnOrZero(cryptoAmount).times(marketData.price)
     if (activeField === InputType.Crypto) {
       setValue(Field.FiatAmount, fiatAmount.toString(), { shouldValidate: true })


### PR DESCRIPTION
## Description

This fixes the percent click that's currently returning more than 6 decimal places currently depending on your staked/unstaked amount (it's not consistent, if the percentage has 6 or less decimal places, it would currently work)

## Notice

<!-- Before submitting a pull request, please make sure you have answered the following: -->

- [x] Have you followed the guidelines in our [Contributing]('https://github.com/shapeshift/web/CONTRIBUTING.md) guide?
- [x] Have you checked to ensure there aren't other open [Pull Requests](https://github.com/shapeshift/web/pulls) for the same update/change?

## Pull Request Type

- [x] :bug: Bug fix (Non-breaking Change: Fixes an issue)
- [ ] :hammer_and_wrench: Chore (Non-breaking Change: Doc updates, pkg upgrades, typos, etc..)
- [ ] :nail_care: New Feature (Breaking/Non-breaking Change)

## Issue (if applicable)

#1395

## Risk

N/A

## Testing

- Test staking and unstaking with multiple wallets that have various account balance/staked amounts
- The crypto amount should consistently be max. 6 decimal places

## Screenshots (if applicable)
