### PR TITLE
chore: set up git-blame-ignore-revs

### DIFF
--- a/.git-blame-ignore-revs
+++ b/.git-blame-ignore-revs
@@ -1,3 +1,3 @@
 # .git-blame-ignore-revs
 # Add trailing commas to meet "trailingComma": "all" rule
-2bafb400aedadca3391565dd5c84e19400d67467
+9287cd7ad557150b4900e010c1e87b189df2eb90

--- a/.git-blame-ignore-revs
+++ b/.git-blame-ignore-revs
@@ -1,0 +1,3 @@
+# .git-blame-ignore-revs
+# Add trailing commas to meet "trailingComma": "all" rule
+2bafb400aedadca3391565dd5c84e19400d67467

--- a/.gitconfig
+++ b/.gitconfig
@@ -1,0 +1,2 @@
+[blame]
+  ignoreRevsFile = .git-blame-ignore-revs

--- a/scripts/postinstall.sh
+++ b/scripts/postinstall.sh
@@ -17,3 +17,6 @@ if [ "$LOCK_HASH" != "$LOCK_HASH_AFTER" ]; then
 else
   echo "yarn-minify did not modify the yarn.lock file"
 fi
+
+# Add web's git config to the local path in an idempotent way
+git config --local include.path '../.gitconfig'


### PR DESCRIPTION
## Description

A fast follow on from https://github.com/shapeshift/web/pull/1437, this PR sets up a `.git-blame-ignore-revs` so that formatting commits are ignored in git blame on both GibHub, locally, and in IDEs

- A `.git-blame-ignore-revs` file has been implemented, with the lint commit ignored - this ensures the lint commit is automatically ignored when using git blame on GitHub. 
- A `.gitconfig` file is added which allows IDEs (tested on WebStorm and VSCode) to respect all skipped commits
- `postinstall.sh` has been updated to automatically use the `.gitconfig` locally once `yarn` / `yarn install` is run

It also works locally by using `git blame --ignore-revs-file .git-blame-ignore-revs`.

For more information on this feature, please see here: https://docs.github.com/en/repositories/working-with-files/using-files/viewing-a-file#ignore-commits-in-the-blame-view

## Notice

<!-- Before submitting a pull request, please make sure you have answered the following: -->

- [x] Have you followed the guidelines in our [Contributing]('https://github.com/shapeshift/web/CONTRIBUTING.md) guide?
- [x] Have you checked to ensure there aren't other open [Pull Requests](https://github.com/shapeshift/web/pulls) for the same update/change?

## Pull Request Type

- [ ] :bug: Bug fix (Non-breaking Change: Fixes an issue)
- [x] :hammer_and_wrench: Chore (Non-breaking Change: Doc updates, pkg upgrades, typos, etc..)
- [ ] :nail_care: New Feature (Breaking/Non-breaking Change)

## Issue (if applicable)

N/A

## Risk

N/A

## Testing

N/A

## Screenshots (if applicable)

Example showing the lint commit is successfully ignored.

<img width="372" alt="Screen Shot 2022-04-08 at 5 22 41 pm" src="https://user-images.githubusercontent.com/97164662/162385121-89816baf-ddd9-4f40-b0f0-6aa48cec75fb.png">