### PR TITLE
fix: add additional path for cosmos plugin account page

### DIFF
--- a/src/components/Breadcrumbs/Breadcrumbs.tsx
+++ b/src/components/Breadcrumbs/Breadcrumbs.tsx
@@ -8,10 +8,11 @@ import { useAppSelector } from 'state/store'
 const GetAccountName = (props: any) => {
   const {
     match: {
-      params: { accountId },
+      params: { accountId, tab },
     },
   } = props
-  return <AccountLabel accountId={accountId} />
+
+  return tab ? <>{tab}</> : <AccountLabel accountId={accountId} />
 }
 
 const GetAssetName = (props: any) => {
@@ -27,6 +28,7 @@ const GetAssetName = (props: any) => {
 
 const routes: BreadcrumbsRoute[] = [
   { path: '/accounts/:accountId', breadcrumb: GetAccountName },
+  { path: '/accounts/:accountId/:tab', breadcrumb: GetAccountName },
   { path: '/accounts/:accountId/:assetId', breadcrumb: GetAssetName },
   { path: '/assets/:chainId/:assetSubId', breadcrumb: GetAssetName },
 ]

--- a/src/components/Breadcrumbs/Breadcrumbs.tsx
+++ b/src/components/Breadcrumbs/Breadcrumbs.tsx
@@ -8,11 +8,11 @@ import { useAppSelector } from 'state/store'
 const GetAccountName = (props: any) => {
   const {
     match: {
-      params: { accountId, tab },
+      params: { accountId },
     },
   } = props
 
-  return tab ? <>{tab}</> : <AccountLabel accountId={accountId} />
+  return <AccountLabel accountId={accountId} />
 }
 
 const GetAssetName = (props: any) => {
@@ -21,6 +21,7 @@ const GetAssetName = (props: any) => {
       params: { chainId, assetSubId, assetId: assetIdParam },
     },
   } = props
+
   const assetId = assetIdParam ? decodeURIComponent(assetIdParam) : `${chainId}/${assetSubId}`
   const asset = useAppSelector(state => selectAssetByCAIP19(state, assetId))
   return <>{asset?.name}</>
@@ -28,7 +29,6 @@ const GetAssetName = (props: any) => {
 
 const routes: BreadcrumbsRoute[] = [
   { path: '/accounts/:accountId', breadcrumb: GetAccountName },
-  { path: '/accounts/:accountId/:tab', breadcrumb: GetAccountName },
   { path: '/accounts/:accountId/:assetId', breadcrumb: GetAssetName },
   { path: '/assets/:chainId/:assetSubId', breadcrumb: GetAssetName },
 ]

--- a/src/plugins/cosmos/index.tsx
+++ b/src/plugins/cosmos/index.tsx
@@ -79,6 +79,25 @@ export function register(): Plugins {
               },
             ],
           },
+          {
+            path: '/accounts/cosmos::accountSubId',
+            label: '',
+            hide: true,
+            main: null,
+            icon: <AssetIcon src='https://assets.coincap.io/assets/icons/atom@2x.png' />,
+            routes: [
+              {
+                path: '/',
+                label: 'navBar.overview',
+                main: () => <CosmosAccount />,
+              },
+              {
+                path: '/transactions',
+                label: 'navBar.transactions',
+                main: () => <CosmosAccountTxHistory />,
+              },
+            ],
+          },
         ],
       },
     ],

--- a/src/plugins/cosmos/index.tsx
+++ b/src/plugins/cosmos/index.tsx
@@ -61,7 +61,7 @@ export function register(): Plugins {
             ],
           },
           {
-            path: '/accounts/cosmos::accountSubId/:assetId',
+            path: '/accounts/cosmos::accountSubId',
             label: '',
             hide: true,
             main: null,
@@ -80,7 +80,7 @@ export function register(): Plugins {
             ],
           },
           {
-            path: '/accounts/cosmos::accountSubId',
+            path: '/accounts/cosmos::accountSubId/:assetId',
             label: '',
             hide: true,
             main: null,


### PR DESCRIPTION
## Description

- Add additional path pattern matching for cosmos `Account` page. When navigating from the `Accounts` page (all accounts for a user) to a specific account (ie cosmos account page), the url path is `/accounts/:accountId` instead of  `/accounts/:accountId/:assetId`, which is used when navigating from an `Asset` page to an `Account` page. 

## Notice

<!-- Before submitting a pull request, please make sure you have answered the following: -->

- [x] Have you followed the guidelines in our [Contributing]('https://github.com/shapeshift/web/CONTRIBUTING.md) guide?
- [x] Have you checked to ensure there aren't other open [Pull Requests](https://github.com/shapeshift/web/pulls) for the same update/change?

## Pull Request Type

- [x] :bug: Bug fix (Non-breaking Change: Fixes an issue)
- [ ] :hammer_and_wrench: Chore (Non-breaking Change: Doc updates, pkg upgrades, typos, etc..)
- [ ] :nail_care: New Feature (Breaking/Non-breaking Change)

## Issue (if applicable)

Closes [Cosmos showing wrong Account page](https://github.com/shapeshift/web/issues/1468) #1468 

<!-----------------------------------------------------------------------------
If applicable, please link to the github issue and put `closes #XXXX` in your comment to auto-close the issue that your PR fixes.
------------------------------------------------------------------------------>

## Risk

- The risk with this PR is small, given the pattern matching with the path is only associated with cosmos, but it could affect other assets. I've done enough testing to make sure it wasn't affecting any assets that I could currently test, which are BTC, ETH, and ERC20s.

<!-----------------------------------------------------------------------------
Outline the scope of your changes and the risk associated with them. You must use your discretion as an engineer to determine the potential impact of your changes.

E.g. an upgrade to `hdwallet` or core state management would be considered higher risk, and might require a full regression test. UI or isolated view changes, or something behind a feature flag may have near zero risk. Small bug fixes might require testing isolated to the specific fix.
------------------------------------------------------------------------------>

## Testing

- Navigate to the `Account` page
- Select `Cosmos`
- You should see the cosmos account page with the `Staking` section.

<!-----------------------------------------------------------------------------
If your testing steps are technical, outline steps for an engineer to verify.

If your testing steps are functional, please provide a full guide with any features requiring special attention for operations to test your branch in the preview environment.
------------------------------------------------------------------------------>

## Screenshots (if applicable)
