### PR TITLE
chore: don't call hdwallet adapter.initialize if it's not there

### DIFF
--- a/src/context/WalletProvider/WalletProvider.tsx
+++ b/src/context/WalletProvider/WalletProvider.tsx
@@ -327,7 +327,7 @@ export const WalletProvider = ({ children }: { children: React.ReactNode }): JSX
                 : undefined
             const adapter = SUPPORTED_WALLETS[wallet].adapter.useKeyring(state.keyring, options)
             // useKeyring returns the instance of the adapter. We'll keep it for future reference.
-            await adapter.initialize()
+            await adapter.initialize?.()
             adapters.set(wallet, adapter)
           } catch (e) {
             console.error('Error initializing HDWallet adapters', e)


### PR DESCRIPTION
## Description

Many `hdwallet-*` adapters don't do anything useful on `adapter.initialize()`, but because it's part of the exported API every new hdwallet implementation still has to cut-n-paste a boilerplate implementation. Making this call optional will allow us to consider removing `adapter.initialize()` from the upstream API and nuking all the boilerplate, which should make implementing new wallets (xdefi, tally, keplr, etc) a bit easier.

## Notice

<!-- Before submitting a pull request, please make sure you have answered the following: -->

- [x] Have you followed the guidelines in our [Contributing]('https://github.com/shapeshift/web/CONTRIBUTING.md) guide?
- [x] Have you checked to ensure there aren't other open [Pull Requests](https://github.com/shapeshift/web/pulls) for the same update/change?

## Pull Request Type

- [ ] :bug: Bug fix (Non-breaking Change: Fixes an issue)
- [x] :hammer_and_wrench: Chore (Non-breaking Change: Doc updates, pkg upgrades, typos, etc..)
- [ ] :nail_care: New Feature (Breaking/Non-breaking Change)

## Risk

_De minimis._

## Testing

None required.