### PR TITLE
fix: remove useGetStakingDataQuery

### DIFF
--- a/src/state/slices/stakingDataSlice/stakingDataSlice.ts
+++ b/src/state/slices/stakingDataSlice/stakingDataSlice.ts
@@ -213,5 +213,3 @@ export const stakingDataApi = createApi({
     }),
   }),
 })
-
-export const { useGetStakingDataQuery } = stakingDataApi


### PR DESCRIPTION
## Description

re: https://github.com/shapeshift/web/commit/3b9ff1c67b62d3641d3833c305d11a574c818cdb#r70988022

This removes the `useGetStakingDataQuery` hook that was exported in 3b9ff1c67b62d3641d3833c305d11a574c818cdb and its usage. Since hooks can't be called conditionally, the usage in `useBalanceChartData` calls the staking data RTK query a first time with an empty `''` string as `accountSpecifier`:
https://github.com/shapeshift/web/blob/3b9ff1c67b62d3641d3833c305d11a574c818cdb/src/hooks/useBalanceChartData/useBalanceChartData.ts#L351

This produces a `fromCAIP10: invalid caip10` error at this line:

https://github.com/shapeshift/web/blob/013226910fbdddb5bc96a691e3506f6b22eea597/src/state/slices/stakingDataSlice/stakingDataSlice.ts#L115

## Notice

<!-- Before submitting a pull request, please make sure you have answered the following: -->

- [x] Have you followed the guidelines in our [Contributing]('https://github.com/shapeshift/web/CONTRIBUTING.md) guide?
- [x] Have you checked to ensure there aren't other open [Pull Requests](https://github.com/shapeshift/web/pulls) for the same update/change?

## Pull Request Type

- [x] :bug: Bug fix (Non-breaking Change: Fixes an issue)
- [ ] :hammer_and_wrench: Chore (Non-breaking Change: Doc updates, pkg upgrades, typos, etc..)
- [ ] :nail_care: New Feature (Breaking/Non-breaking Change)

## Issue (if applicable)

N/A

## Risk

N/A

## Testing

- Balance charts with Cosmos staking data shouldn't regress
- No `Error fetching staking data for ` error is thrown in the console.

## Screenshots (if applicable)
