### PR TITLE
refactor: invert noBackButton to showBackButton

### DIFF
--- a/src/context/WalletProvider/WalletProvider.tsx
+++ b/src/context/WalletProvider/WalletProvider.tsx
@@ -42,7 +42,7 @@ export interface InitialState {
   modal: boolean
   isLoadingLocalWallet: boolean
   deviceId: string
-  noBackButton: boolean
+  showBackButton: boolean
   keepKeyPinRequestType: PinMatrixRequestType | null
   awaitingDeviceInteraction: boolean
   lastDeviceInteractionStatus: Outcome
@@ -59,7 +59,7 @@ const initialState: InitialState = {
   modal: false,
   isLoadingLocalWallet: false,
   deviceId: '',
-  noBackButton: false,
+  showBackButton: true,
   keepKeyPinRequestType: null,
   awaitingDeviceInteraction: false,
   lastDeviceInteractionStatus: undefined,
@@ -100,7 +100,7 @@ const reducer = (state: InitialState, action: ActionTypes) => {
       if (!action.payload && state.modal) {
         newState.initialRoute = '/'
         newState.isLoadingLocalWallet = false
-        newState.noBackButton = false
+        newState.showBackButton = true
         newState.keepKeyPinRequestType = null
       }
       return newState
@@ -109,7 +109,7 @@ const reducer = (state: InitialState, action: ActionTypes) => {
         ...state,
         modal: action.payload.modal,
         type: KeyManager.Native,
-        noBackButton: state.isLoadingLocalWallet,
+        showBackButton: !state.isLoadingLocalWallet,
         deviceId: action.payload.deviceId,
         initialRoute: '/native/enter-password',
       }
@@ -118,7 +118,7 @@ const reducer = (state: InitialState, action: ActionTypes) => {
         ...state,
         modal: true,
         type: KeyManager.KeepKey,
-        noBackButton: true,
+        showBackButton: false,
         deviceId: action.payload.deviceId,
         keepKeyPinRequestType: action.payload.pinRequestType ?? null,
         initialRoute: '/keepkey/enter-pin',
@@ -128,7 +128,7 @@ const reducer = (state: InitialState, action: ActionTypes) => {
         ...state,
         modal: true,
         type: KeyManager.KeepKey,
-        noBackButton: true,
+        showBackButton: false,
         deviceId: action.payload.deviceId,
         initialRoute: '/keepkey/passphrase',
       }
@@ -151,7 +151,7 @@ const reducer = (state: InitialState, action: ActionTypes) => {
         type: null,
         initialRoute: null,
         isLoadingLocalWallet: false,
-        noBackButton: false,
+        showBackButton: true,
         keepKeyPinRequestType: null,
         awaitingDeviceInteraction: false,
         lastDeviceInteractionStatus: undefined,

--- a/src/context/WalletProvider/WalletViewsSwitch.tsx
+++ b/src/context/WalletProvider/WalletViewsSwitch.tsx
@@ -73,7 +73,7 @@ export const WalletViewsSwitch = () => {
         <ModalOverlay />
         <ModalContent justifyContent='center' px={3} pt={3} pb={6}>
           <Flex justifyContent='space-between' alignItems='center' position='relative'>
-            {!match?.isExact && !state.noBackButton && (
+            {!match?.isExact && state.showBackButton && (
               <IconButton
                 icon={<ArrowBackIcon />}
                 aria-label='Back'


### PR DESCRIPTION
## Description

The `noBackButton` button property has a negative name, which is confusing.

This PR renames it to `showBackButton` and inverts all related logic.

## Notice

<!-- Before submitting a pull request, please make sure you have answered the following: -->

- [x] Have you followed the guidelines in our [Contributing]('https://github.com/shapeshift/web/CONTRIBUTING.md) guide?
- [x] Have you checked to ensure there aren't other open [Pull Requests](https://github.com/shapeshift/web/pulls) for the same update/change?

## Pull Request Type

- [ ] :bug: Bug fix (Non-breaking Change: Fixes an issue)
- [x] :hammer_and_wrench: Chore (Non-breaking Change: Doc updates, pkg upgrades, typos, etc..)
- [ ] :nail_care: New Feature (Breaking/Non-breaking Change)

## Issue (if applicable)

N/A

## Risk

N/A

## Testing

N/A

## Screenshots (if applicable)

N/A
