### PR TITLE
feat(cosmos): force refetch at stakingDataSlice-level

### DIFF
--- a/src/context/PortfolioProvider/PortfolioContext.tsx
+++ b/src/context/PortfolioProvider/PortfolioContext.tsx
@@ -217,10 +217,7 @@ export const PortfolioProvider = ({ children }: { children: React.ReactNode }) =
       if (!txAccountSpecifier.length) return
 
       dispatch(
-        stakingDataApi.endpoints.getStakingData.initiate(
-          { accountSpecifier: txAccountSpecifier },
-          { forceRefetch: true },
-        ),
+        stakingDataApi.endpoints.getStakingData.initiate({ accountSpecifier: txAccountSpecifier }),
       )
     },
     [dispatch],

--- a/src/hooks/useBalanceChartData/useBalanceChartData.ts
+++ b/src/hooks/useBalanceChartData/useBalanceChartData.ts
@@ -37,10 +37,10 @@ import {
   selectTxsByFilter,
 } from 'state/slices/selectors'
 import { selectTotalStakingDelegationCryptoByAccountSpecifier } from 'state/slices/stakingDataSlice/selectors'
-import { stakingDataApi } from 'state/slices/stakingDataSlice/stakingDataSlice'
+import { useGetStakingDataQuery } from 'state/slices/stakingDataSlice/stakingDataSlice'
 import { selectRebasesByFilter } from 'state/slices/txHistorySlice/selectors'
 import { Tx } from 'state/slices/txHistorySlice/txHistorySlice'
-import { useAppDispatch, useAppSelector } from 'state/store'
+import { useAppSelector } from 'state/store'
 
 import { includeStakedBalance, includeTransaction } from './cosmosUtils'
 
@@ -322,7 +322,6 @@ type UseBalanceChartData = (args: UseBalanceChartDataArgs) => UseBalanceChartDat
 */
 export const useBalanceChartData: UseBalanceChartData = args => {
   const { assetIds, accountId, timeframe } = args
-  const dispatch = useAppDispatch()
   const accountIds = useMemo(() => (accountId ? [accountId] : []), [accountId])
   const [balanceChartDataLoading, setBalanceChartDataLoading] = useState(true)
   const [balanceChartData, setBalanceChartData] = useState<HistoryData[]>([])
@@ -349,19 +348,7 @@ export const useBalanceChartData: UseBalanceChartData = args => {
   // TODO(ryankk): this needs to be removed once staking data is keyed by accountSpecifier instead of caip10
   const cosmosCaip10 = account ? caip10.toCAIP10({ caip2: cosmosCaip2, account }) : ''
 
-  // load staking data to redux state
-  useEffect(() => {
-    ;(async () => {
-      if (!cosmosCaip10?.length) return
-
-      dispatch(
-        stakingDataApi.endpoints.getStakingData.initiate(
-          { accountSpecifier: cosmosCaip10 },
-          { forceRefetch: true },
-        ),
-      )
-    })()
-  }, [dispatch, cosmosCaip10])
+  useGetStakingDataQuery({ accountSpecifier: cosmosCaip10 }, { skip: !cosmosCaip10?.length })
 
   const delegationTotal = useAppSelector(state =>
     selectTotalStakingDelegationCryptoByAccountSpecifier(state, cosmosCaip10),

--- a/src/plugins/cosmos/components/modals/Staking/views/Overview.tsx
+++ b/src/plugins/cosmos/components/modals/Staking/views/Overview.tsx
@@ -6,7 +6,6 @@ import { AssetClaimCard } from 'plugins/cosmos/components/AssetClaimCard/AssetCl
 import { ClaimButton } from 'plugins/cosmos/components/ClaimButton/ClaimButton'
 import { StakedRow } from 'plugins/cosmos/components/StakedRow/StakedRow'
 import { UnbondingRow } from 'plugins/cosmos/components/UnbondingRow/UnbondingRow'
-import { useEffect } from 'react'
 import { Text } from 'components/Text'
 import { bnOrZero } from 'lib/bignumber/bignumber'
 import { selectAssetByCAIP19, selectMarketDataById } from 'state/slices/selectors'
@@ -17,7 +16,7 @@ import {
   selectStakingDataIsLoaded,
   selectTotalBondingsBalanceByAssetId,
 } from 'state/slices/stakingDataSlice/selectors'
-import { stakingDataApi } from 'state/slices/stakingDataSlice/stakingDataSlice'
+import { useGetStakingDataQuery } from 'state/slices/stakingDataSlice/stakingDataSlice'
 import { useAppDispatch, useAppSelector } from 'state/store'
 
 type StakedProps = {
@@ -35,20 +34,7 @@ export const Overview: React.FC<StakedProps> = ({
   const asset = useAppSelector(state => selectAssetByCAIP19(state, assetId))
   const marketData = useAppSelector(state => selectMarketDataById(state, assetId))
 
-  const dispatch = useAppDispatch()
-
-  useEffect(() => {
-    ;(async () => {
-      if (!accountSpecifier.length || isLoaded) return
-
-      dispatch(
-        stakingDataApi.endpoints.getStakingData.initiate(
-          { accountSpecifier },
-          { forceRefetch: true },
-        ),
-      )
-    })()
-  }, [accountSpecifier, isLoaded, dispatch])
+  useGetStakingDataQuery({ accountSpecifier }, { skip: !accountSpecifier.length || isLoaded })
 
   const validatorInfo = useAppSelector(state =>
     selectSingleValidator(state, accountSpecifier, validatorAddress),

--- a/src/plugins/cosmos/components/modals/Staking/views/Overview.tsx
+++ b/src/plugins/cosmos/components/modals/Staking/views/Overview.tsx
@@ -17,7 +17,7 @@ import {
   selectTotalBondingsBalanceByAssetId,
 } from 'state/slices/stakingDataSlice/selectors'
 import { useGetStakingDataQuery } from 'state/slices/stakingDataSlice/stakingDataSlice'
-import { useAppDispatch, useAppSelector } from 'state/store'
+import { useAppSelector } from 'state/store'
 
 type StakedProps = {
   assetId: CAIP19

--- a/src/state/slices/stakingDataSlice/stakingDataSlice.ts
+++ b/src/state/slices/stakingDataSlice/stakingDataSlice.ts
@@ -108,6 +108,7 @@ export const stakingDataApi = createApi({
   baseQuery: fetchBaseQuery({ baseUrl: '/' }),
   // refetch if network connection is dropped, useful for mobile
   refetchOnReconnect: true,
+  refetchOnMountOrArgChange: true,
   endpoints: build => ({
     getStakingData: build.query<Staking, AllStakingDataArgs>({
       queryFn: async ({ accountSpecifier }, { dispatch }) => {
@@ -224,3 +225,5 @@ export const stakingDataApi = createApi({
     }),
   }),
 })
+
+export const { useGetStakingDataQuery, useGetAllValidatorsDataQuery } = stakingDataApi


### PR DESCRIPTION
## Description

This PR
- adds force refetch of the staking/validators-data at query-level with [refetchOnMountOrArgChange](https://redux-toolkit.js.org/rtk-query/api/createApi#refetchonmountorargchange). Since we always want to have fresh data, there is no need for us to explicitly dispatch an initiate endpoint action with `forceRefetch: true` everywhere. According to [RTK docs entry for `refetchOnMountOrArgChange`](https://redux-toolkit.js.org/rtk-query/api/createApi#refetchonmountorargchange):
  > Defaults to false. This setting allows you to control whether if a cached result is already available RTK Query will only serve a cached result, or if it should refetch when set to true or if an adequate amount of time has passed since the last successful query result.
- uses RTK hooks everywhere it is possible to not break the rules of hooks (i.e not inside a callback, and not called in the context of a loop closure)
- uses the `skip` option ([docs](https://redux-toolkit.js.org/rtk-query/usage/queries#query-hook-options)) to skip fetching instead of the current `useEffect`:
  > skip - Allows a query to 'skip' running for that render. Defaults to false
- wraps the Rewards and Stake Amount rows of `<StakingOpportunities />` in a skeleton, since these refresh on staking data change

## Notice

<!-- Before submitting a pull request, please make sure you have answered the following: -->

- [x] Have you followed the guidelines in our [Contributing]('https://github.com/shapeshift/web/CONTRIBUTING.md) guide?
- [x] Have you checked to ensure there aren't other open [Pull Requests](https://github.com/shapeshift/web/pulls) for the same update/change?

## Pull Request Type

- [ ] :bug: Bug fix (Non-breaking Change: Fixes an issue)
- [ ] :hammer_and_wrench: Chore (Non-breaking Change: Doc updates, pkg upgrades, typos, etc..)
- [x] :nail_care: New Feature (Breaking/Non-breaking Change)

## Issue (if applicable)

<!-----------------------------------------------------------------------------
If applicable, please link to the github issue and put `closes #XXXX` in your comment to auto-close the issue that your PR fixes.
------------------------------------------------------------------------------>

## Risk

This touches the RTK queries fire. We should regression test this to make sure that they still fetch and re-fetch the same way as they do currently (tested locally, and I didn't see any regression. The requests fire similarly as they do in develop, and we do not send additional ones compared to develop).

## Testing

- Stake, claim, unclaim, or send some ATOM
- The app should still refetch the relevant amounts and re-render

## Screenshots (if applicable)

<img width="788" alt="image" src="https://user-images.githubusercontent.com/17035424/162988483-8ae9a5cb-3cdc-4292-8a5e-a2ab7e12362c.png">