### PR TITLE
feat: show app updated toast when env vars change #1309

### DIFF
--- a/src/hooks/useHasAppUpdated/useHasAppUpdated.test.ts
+++ b/src/hooks/useHasAppUpdated/useHasAppUpdated.test.ts
@@ -1,0 +1,78 @@
+import { act, renderHook } from '@testing-library/react-hooks'
+import axios from 'axios'
+
+import { useHasAppUpdated } from './useHasAppUpdated'
+
+jest.mock('axios')
+const mockAxios = axios as jest.Mocked<typeof axios>
+
+describe('useHasAppUpdated', () => {
+  afterEach(() => {
+    jest.resetAllMocks()
+    jest.clearAllTimers()
+  })
+  afterAll(() => {
+    jest.resetAllMocks()
+    jest.clearAllTimers()
+    jest.useRealTimers()
+  })
+
+  const APP_UPDATE_CHECK_INTERVAL = 1000 * 60
+
+  it('should return false when env.json/asset-manifest.json is not updated', async () => {
+    jest.useFakeTimers('legacy')
+    jest.spyOn(window, 'setInterval')
+
+    mockAxios.get.mockImplementation((url: string) => {
+      return Promise.resolve({ data: {} })
+    })
+
+    const { result } = renderHook(() => useHasAppUpdated())
+    expect(result.current).toBe(false)
+  })
+
+  it('should return true when env.json is updated', async () => {
+    jest.useFakeTimers('legacy')
+    jest.spyOn(window, 'setInterval')
+
+    mockAxios.get.mockImplementation((url: string) => {
+      return Promise.resolve({ data: {} })
+    })
+
+    const { result, waitForNextUpdate } = renderHook(() => useHasAppUpdated())
+
+    act(() => {
+      jest.advanceTimersByTime(APP_UPDATE_CHECK_INTERVAL)
+    })
+
+    mockAxios.get.mockImplementationOnce((url: string) => {
+      if (url.includes('env.json')) return Promise.resolve({ data: { change: true } })
+      else return Promise.resolve({ data: {} })
+    })
+
+    await waitForNextUpdate()
+    expect(result.current).toBe(true)
+  })
+
+  it('should return true when asset-manifest.json is updated', async () => {
+    jest.useFakeTimers('legacy')
+    jest.spyOn(window, 'setInterval')
+    mockAxios.get.mockImplementation((url: string) => {
+      return Promise.resolve({ data: {} })
+    })
+
+    const { result, waitForNextUpdate } = renderHook(() => useHasAppUpdated())
+
+    act(() => {
+      jest.advanceTimersByTime(APP_UPDATE_CHECK_INTERVAL)
+    })
+
+    mockAxios.get.mockImplementationOnce((url: string) => {
+      if (url.includes('asset-manifest.json')) return Promise.resolve({ data: { change: true } })
+      else return Promise.resolve({ data: {} })
+    })
+
+    await waitForNextUpdate()
+    expect(result.current).toBe(true)
+  })
+})

--- a/src/hooks/useHasAppUpdated/useHasAppUpdated.ts
+++ b/src/hooks/useHasAppUpdated/useHasAppUpdated.ts
@@ -19,7 +19,7 @@ export const useHasAppUpdated = () => {
     }
   }
 
-  // 'asset-manifest.json' keeps track of latest minified built files.
+  // 'asset-manifest.json' keeps track of the latest minified built files.
   // interpolated with a dummy query param to bypass the browser cache.
   const assetManifestUrl = `/asset-manifest.json?${new Date().valueOf()}`
   const storeMainManifestJs = async () => {

--- a/src/hooks/useHasAppUpdated/useHasAppUpdated.ts
+++ b/src/hooks/useHasAppUpdated/useHasAppUpdated.ts
@@ -7,7 +7,7 @@ const APP_UPDATE_CHECK_INTERVAL = 1000 * 60
 
 export const useHasAppUpdated = () => {
   const [hasUpdated, setHasUpdated] = useState(false)
-  const [initialManifestMainJs, setManifestMainJs] = useState(null)
+  const [initialManifestMainJs, setInitialManifestMainJs] = useState(null)
   const [initialEnvMainJs, setInitialEnvMainJs] = useState(null)
 
   const fetchData = async (url: string) => {

--- a/src/hooks/useHasAppUpdated/useHasAppUpdated.ts
+++ b/src/hooks/useHasAppUpdated/useHasAppUpdated.ts
@@ -1,7 +1,7 @@
 import { useInterval } from '@chakra-ui/hooks'
 import axios from 'axios'
 import isEqual from 'lodash/isEqual'
-import { useMemo, useState } from 'react'
+import { useCallback, useState } from 'react'
 
 const APP_UPDATE_CHECK_INTERVAL = 1000 * 60
 
@@ -24,17 +24,17 @@ export const useHasAppUpdated = () => {
   const assetManifestUrl = `/asset-manifest.json?${new Date().valueOf()}`
   const storeMainManifestJs = async () => {
     const manifestMainJs = await fetchData(assetManifestUrl)
-    setManifestMainJs(manifestMainJs)
+    setInitialManifestMainJs(manifestMainJs)
   }
-  useMemo(storeMainManifestJs, [])
+  useCallback(storeMainManifestJs, [])
 
   // interpolated with a dummy query param to bypass the browser cache.
   const envUrl = `/env.json?${new Date().valueOf()}`
   const storeMainEnvJs = async () => {
     const envMainJs = await fetchData(envUrl)
-    setEnvMainJs(envMainJs)
+    setInitialEnvMainJs(envMainJs)
   }
-  useMemo(storeMainEnvJs, [])
+  useCallback(storeMainEnvJs, [])
 
   useInterval(async () => {
     const [currentManifestJs, currentEnvJs] = await Promise.all([
@@ -45,8 +45,8 @@ export const useHasAppUpdated = () => {
     const isExactAssetManifest = isEqual(initialManifestMainJs, currentManifestJs)
     const isExactEnv = isEqual(initialEnvMainJs, currentEnvJs)
 
-    const eitherhasChanged = !isExactAssetManifest || !isExactEnv
-    eitherhasChanged ? setHasUpdated(true) : setHasUpdated(false)
+    const eitherHasChanged = !isExactAssetManifest || !isExactEnv
+    eitherHasChanged ? setHasUpdated(true) : setHasUpdated(false)
   }, APP_UPDATE_CHECK_INTERVAL)
 
   return hasUpdated

--- a/src/hooks/useHasAppUpdated/useHasAppUpdated.ts
+++ b/src/hooks/useHasAppUpdated/useHasAppUpdated.ts
@@ -8,7 +8,7 @@ const APP_UPDATE_CHECK_INTERVAL = 1000 * 60
 export const useHasAppUpdated = () => {
   const [hasUpdated, setHasUpdated] = useState(false)
   const [initialManifestMainJs, setManifestMainJs] = useState(null)
-  const [initialEnvMainJs, setEnvMainJs] = useState(null)
+  const [initialEnvMainJs, setInitialEnvMainJs] = useState(null)
 
   const fetchData = async (url: string) => {
     try {

--- a/src/hooks/useHasAppUpdated/useHasAppUpdated.ts
+++ b/src/hooks/useHasAppUpdated/useHasAppUpdated.ts
@@ -26,7 +26,7 @@ export const useHasAppUpdated = () => {
     const manifestMainJs = await fetchData(assetManifestUrl)
     setInitialManifestMainJs(manifestMainJs)
   }
-  useCallback(storeMainManifestJs, [])
+  useCallback(storeMainManifestJs, [assetManifestUrl])
 
   // interpolated with a dummy query param to bypass the browser cache.
   const envUrl = `/env.json?${new Date().valueOf()}`
@@ -34,7 +34,7 @@ export const useHasAppUpdated = () => {
     const envMainJs = await fetchData(envUrl)
     setInitialEnvMainJs(envMainJs)
   }
-  useCallback(storeMainEnvJs, [])
+  useCallback(storeMainEnvJs, [envUrl])
 
   useInterval(async () => {
     const [currentManifestJs, currentEnvJs] = await Promise.all([


### PR DESCRIPTION
## Description

Refactored [https://github.com/shapeshift/web/blob/develop/src/hooks/useHasAppUpdated/useHasAppUpdated.ts](https://github.com/shapeshift/web/blob/develop/src/hooks/useHasAppUpdated/useHasAppUpdated.ts) to poll `/env.json` for changes and sets a flag when either change.

`useHasAppUpdated` hook now polls both `/env.json` and `/asset-manifest.json` for changes and returns `true` when either change.

## Notice

<!-- Before submitting a pull request, please make sure you have answered the following: -->

- [X] Have you followed the guidelines in our [Contributing]('https://github.com/shapeshift/web/CONTRIBUTING.md) guide?
- [X] Have you checked to ensure there aren't other open [Pull Requests](https://github.com/shapeshift/web/pulls) for the same update/change?

## Pull Request Type

- [ ] :bug: Bug fix (Non-breaking Change: Fixes an issue)
- [ ] :hammer_and_wrench: Chore (Non-breaking Change: Doc updates, pkg upgrades, typos, etc..)
- [X] :nail_care: New Feature (Breaking/Non-breaking Change)

## Issue (if applicable)
Closes #1309

## Risk
zero risk

## Testing
`useHasAppUpdated` hook benefits less from testing due to the nature of the internals of the hook. 
Reasons `useHasAppUpdated` benefits less from `unit` testing:

1. `useHasAppUpdated` implementation relies on the [useInterval](https://codesandbox.io/s/pyd7r?file=/src/use-interval.ts) hook due to `jest` failing to register timer when using `jest.useFakeTimers()`
[see a related Stack Overflow question](https://stackoverflow.com/questions/66366502/testing-useinterval-hook-with-jest-does-not-register-timer)

Testing `useHasAppUpdated` requires technical/manual test as follows:

### steps for manually testing
1. Build the project to generate production build:
```bash
yarn build
```
3. Install serve (a local test HTTP server) [serve](https://www.npmjs.com/package/serve)
```bash
#install serve globally
yarn global add serve
```
4. Serve the `build/` folder
```bash
server -s build/
```
![served-build](https://user-images.githubusercontent.com/37052032/162972594-7bf9c9a0-96c8-4120-a1c6-47fab75ce3fa.png)
5. Visit the page  at http://locahost:3000 
![dashboard](https://user-images.githubusercontent.com/37052032/162973136-8fceacde-15b7-4aef-af54-9c75479ac244.png)

6.  Make any changes to `build/env.json` and/or `build/asset-manifest.json`, to mimic and update to the `env.json` vars or `asset-manifest.json`:
`build/env.json`
![edit-env-json](https://user-images.githubusercontent.com/37052032/162973707-a070dc7a-3154-4972-bf10-2a0c45708678.png)
`build/asset-manifest.json`
![edit-asset-manifest](https://user-images.githubusercontent.com/37052032/162973961-4ef30c28-a993-4648-8417-3b864457412b.png)

7. Viewing the app at http://localhost:3000, After, `60` seconds a notification is deployed due to the changes:

![toast-shown-highlighted](https://user-images.githubusercontent.com/37052032/162974785-f593b39a-82ce-41bb-b2a2-5c76908056fc.png)



## Screenshots (if applicable)
