### PR TITLE
fix(cosmos): additional safeguards against staking data overfetching

### DIFF
--- a/src/hooks/useBalanceChartData/useBalanceChartData.ts
+++ b/src/hooks/useBalanceChartData/useBalanceChartData.ts
@@ -36,7 +36,10 @@ import {
   selectPriceHistoryTimeframe,
   selectTxsByFilter,
 } from 'state/slices/selectors'
-import { selectTotalStakingDelegationCryptoByAccountSpecifier } from 'state/slices/stakingDataSlice/selectors'
+import {
+  selectStakingDataIsLoaded,
+  selectTotalStakingDelegationCryptoByAccountSpecifier,
+} from 'state/slices/stakingDataSlice/selectors'
 import { stakingDataApi } from 'state/slices/stakingDataSlice/stakingDataSlice'
 import { selectRebasesByFilter } from 'state/slices/txHistorySlice/selectors'
 import { Tx } from 'state/slices/txHistorySlice/txHistorySlice'
@@ -322,6 +325,7 @@ type UseBalanceChartData = (args: UseBalanceChartDataArgs) => UseBalanceChartDat
 */
 export const useBalanceChartData: UseBalanceChartData = args => {
   const { assetIds, accountId, timeframe } = args
+  const isStakingDataLoaded = useAppSelector(selectStakingDataIsLoaded)
   const dispatch = useAppDispatch()
   const accountIds = useMemo(() => (accountId ? [accountId] : []), [accountId])
   const [balanceChartDataLoading, setBalanceChartDataLoading] = useState(true)
@@ -352,7 +356,7 @@ export const useBalanceChartData: UseBalanceChartData = args => {
   // load staking data to redux state
   useEffect(() => {
     ;(async () => {
-      if (!cosmosCaip10?.length) return
+      if (!cosmosCaip10?.length || isStakingDataLoaded) return
 
       dispatch(
         stakingDataApi.endpoints.getStakingData.initiate(
@@ -361,7 +365,7 @@ export const useBalanceChartData: UseBalanceChartData = args => {
         ),
       )
     })()
-  }, [dispatch, cosmosCaip10])
+  }, [dispatch, cosmosCaip10, isStakingDataLoaded])
 
   const delegationTotal = useAppSelector(state =>
     selectTotalStakingDelegationCryptoByAccountSpecifier(state, cosmosCaip10),


### PR DESCRIPTION
## Description

This adds an additional useEffect `isStakingDataLoaded` dep on `useBalanceChartsData` and early return if true, to safeguard against overfetching.

Currently, when going from account page to asset page, as well as when going from any route to dashboard, the app fires requests to unchained for Cosmos account, while we should only fetch on app load and subsequent Txs.

### Notes

This is adding additional logic that we need with the current architecture, but all component/hooks-level logic will most likely eventually be removed entirely as part of #1454 - as only the `PortfolioContext` and `TransactionsProvider` should really need to be concerned about fetching what we currently define as "staking data".

## Notice

<!-- Before submitting a pull request, please make sure you have answered the following: -->

- [x] Have you followed the guidelines in our [Contributing]('https://github.com/shapeshift/web/CONTRIBUTING.md) guide?
- [x] Have you checked to ensure there aren't other open [Pull Requests](https://github.com/shapeshift/web/pulls) for the same update/change?

## Pull Request Type

- [x] :bug: Bug fix (Non-breaking Change: Fixes an issue)
- [ ] :hammer_and_wrench: Chore (Non-breaking Change: Doc updates, pkg upgrades, typos, etc..)
- [ ] :nail_care: New Feature (Breaking/Non-breaking Change)

## Issue (if applicable)

<!-----------------------------------------------------------------------------
If applicable, please link to the github issue and put `closes #XXXX` in your comment to auto-close the issue that your PR fixes.
------------------------------------------------------------------------------>

## Risk

<!-----------------------------------------------------------------------------
Outline the scope of your changes and the risk associated with them. You must use your discretion as an engineer to determine the potential impact of your changes.

E.g. an upgrade to `hdwallet` or core state management would be considered higher risk, and might require a full regression test. UI or isolated view changes, or something behind a feature flag may have near zero risk. Small bug fixes might require testing isolated to the specific fix.
------------------------------------------------------------------------------>

## Testing

- Open Chrome DevTools or similar on the Network tab
- Go to cosmos asset page and wait for the initial Txs to finish loading from websocket ("Transaction History" skeleton should have disappeared and Tx history fully loaded there)
- Go to Cosmos account page -> no new request should be made to unchained Cosmos account endpoint
- Go to Dashboard -> no new request should be made to unchained Cosmos account endpoint
- Click your browser previous page button to go back to Cosmos account page -> no new request should be made to unchained Cosmos account endpoint

## Screenshots (if applicable)
