### PR TITLE
chore: avoid possible lockfile changes in CI

### DIFF
--- a/scripts/postinstall.sh
+++ b/scripts/postinstall.sh
@@ -13,7 +13,7 @@ LOCK_HASH_AFTER=$($COMMAND yarn.lock | cut -d ' ' -f 1)
 echo "Checking if yarn.lock has changed: [$LOCK_HASH] vs [$LOCK_HASH_AFTER]"
 if [ "$LOCK_HASH" != "$LOCK_HASH_AFTER" ]; then
   echo "yarn-minify changed the yarn.lock file. Running yarn again..."
-  yarn
+  yarn install --frozen-lockfile
 else
   echo "yarn-minify did not modify the yarn.lock file"
 fi


### PR DESCRIPTION
## Description

CI is supposed to install yarn packages with `--frozen-lockfile` set, but that's somewhat undercut if it might be (under freak circumstances) immediately re-run without that option by `postinstall.sh`. Unconditionally using the safe behavior would also mean rejecting any breaking lockfile changes `yarn-minify` might possibly make.

## Notice

<!-- Before submitting a pull request, please make sure you have answered the following: -->

- [x] Have you followed the guidelines in our [Contributing]('https://github.com/shapeshift/web/CONTRIBUTING.md) guide?
- [x] Have you checked to ensure there aren't other open [Pull Requests](https://github.com/shapeshift/web/pulls) for the same update/change?

## Pull Request Type

- [ ] :bug: Bug fix (Non-breaking Change: Fixes an issue)
- [x] :hammer_and_wrench: Chore (Non-breaking Change: Doc updates, pkg upgrades, typos, etc..)
- [ ] :nail_care: New Feature (Breaking/Non-breaking Change)

## Risk

_De minimis._

## Testing

None required.
