### PR TITLE
fix: move the percents at the top of the vstack on cosmos

### DIFF
--- a/src/plugins/cosmos/components/modals/Staking/views/Stake.tsx
+++ b/src/plugins/cosmos/components/modals/Staking/views/Stake.tsx
@@ -174,6 +174,7 @@ export const Stake = ({ assetId, apr, validatorAddress }: StakeProps) => {
             divider={<Divider />}
             spacing={0}
           >
+            <PercentOptionsRow onPercentClick={handlePercentClick} percent={percent} />
             <StakingInput
               height='40px'
               width='100%'
@@ -186,7 +187,6 @@ export const Stake = ({ assetId, apr, validatorAddress }: StakeProps) => {
               onInputChange={handleInputChange}
               control={control}
             />
-            <PercentOptionsRow onPercentClick={handlePercentClick} percent={percent} />
             <Box width='100%' pb='12px'>
               <EstimatedReturnsRow
                 px={4}

--- a/src/plugins/cosmos/components/modals/Staking/views/Unstake.tsx
+++ b/src/plugins/cosmos/components/modals/Staking/views/Unstake.tsx
@@ -194,6 +194,11 @@ export const Unstake = ({ assetId, apr, accountSpecifier, validatorAddress }: Un
               mt='8px'
               mb='8px'
             >
+              <PercentOptionsRow
+                width='100%'
+                onPercentClick={handlePercentClick}
+                percent={percent}
+              />
               <StakingInput
                 height='40px'
                 width='100%'
@@ -205,11 +210,6 @@ export const Unstake = ({ assetId, apr, accountSpecifier, validatorAddress }: Un
                 onInputToggle={handleInputToggle}
                 onInputChange={handleInputChange}
                 control={control}
-              />
-              <PercentOptionsRow
-                width='100%'
-                onPercentClick={handlePercentClick}
-                percent={percent}
               />
             </VStack>
           </FormControl>


### PR DESCRIPTION
## Description
For consistency with yearn and foxy, percents in the VStack of cosmos should be at the top of the stack
<!-- Please describe your changes -->

## Notice

<!-- Before submitting a pull request, please make sure you have answered the following: -->

- [x] Have you followed the guidelines in our [Contributing]('https://github.com/shapeshift/web/CONTRIBUTING.md) guide?
- [x] Have you checked to ensure there aren't other open [Pull Requests](https://github.com/shapeshift/web/pulls) for the same update/change?

## Pull Request Type

- [x] :bug: Bug fix (Non-breaking Change: Fixes an issue)
- [ ] :hammer_and_wrench: Chore (Non-breaking Change: Doc updates, pkg upgrades, typos, etc..)
- [ ] :nail_care: New Feature (Breaking/Non-breaking Change)

## Risk
None
<!-----------------------------------------------------------------------------
Outline the scope of your changes and the risk associated with them. You must use your discretion as an engineer to determine the potential impact of your changes.

E.g. an upgrade to `hdwallet` or core state management would be considered higher risk, and might require a full regression test. UI or isolated view changes, or something behind a feature flag may have near zero risk. Small bug fixes might require testing isolated to the specific fix.
------------------------------------------------------------------------------>

## Testing
- Go on cosmos staking modal
- Check on Stake/Unstake if the percents are on the top of the stack (see screenshots)
<!-----------------------------------------------------------------------------
If your testing steps are technical, outline steps for an engineer to verify.

If your testing steps are functional, please provide a full guide with any features requiring special attention for operations to test your branch in the preview environment.
------------------------------------------------------------------------------>

## Screenshots (if applicable)
![image](https://user-images.githubusercontent.com/14963751/163234539-546a3a1f-a0d9-4361-b0c7-92376e39c544.png)
![image](https://user-images.githubusercontent.com/14963751/163234582-8ac7a832-4666-4462-beee-ec52caf4ca87.png)
