### PR TITLE
chore: change FOXY_APY config to 'num' instead of 'str'

### DIFF
--- a/sample.env
+++ b/sample.env
@@ -18,7 +18,7 @@ REACT_APP_FEATURE_FOXY_INVESTOR=false
 REACT_APP_FEATURE_PLUGIN_BITCOIN=false
 REACT_APP_REDUX_LOGGING=false
 REACT_APP_FEATURE_KEEPKEY_SETTINGS=false
-REACT_APP_FOXY_APY=.13
+REACT_APP_FOXY_APY=0.15
 
 REACT_APP_GEM_COINIFY_SUPPORTED_COINS=https://api.gem.co/institutions/coinify/supported_currencies
 REACT_APP_GEM_WYRE_SUPPORTED_COINS=https://api.gem.co/institutions/wyre/supported_currencies

--- a/src/config.ts
+++ b/src/config.ts
@@ -3,7 +3,7 @@ import { bool } from 'envalid'
 
 import env from './env'
 
-const { cleanEnv, str, url } = envalid
+const { cleanEnv, str, url, num } = envalid
 
 // add validators for each .env variable
 // note env vars must be prefixed with REACT_APP_
@@ -28,7 +28,7 @@ const validators = {
   REACT_APP_GEM_ASSET_LOGO: url(),
   REACT_APP_GEM_ENV: str(),
   REACT_APP_GEM_API_KEY: str(),
-  REACT_APP_FOXY_APY: str(),
+  REACT_APP_FOXY_APY: num({ default: 0.15 }),
   REACT_APP_FEATURE_YEARN: bool({ default: true }),
   REACT_APP_FEATURE_COSMOS_INVESTOR: bool({ default: false }),
   REACT_APP_FEATURE_PLUGIN_BITCOIN: bool({ default: false }),

--- a/src/pages/Defi/hooks/useFoxyBalances.tsx
+++ b/src/pages/Defi/hooks/useFoxyBalances.tsx
@@ -121,7 +121,7 @@ export function useFoxyBalances(): UseFoxyBalancesReturn {
 
         // remove when Tokemak has api to get real apy
         for (const key in foxyOpportunities) {
-          foxyOpportunities[key].apy = getConfig().REACT_APP_FOXY_APY
+          foxyOpportunities[key].apy = bnOrZero(getConfig().REACT_APP_FOXY_APY).toString()
         }
 
         setOpportunites(foxyOpportunities)


### PR DESCRIPTION
## Description

chore: change `REACT_APP_FOXY_APY` config to `num` instead of `str` and set a default value of `0.15`.

This will make sure that any value we put in the environment variable is at least a valid number

## Notice

<!-- Before submitting a pull request, please make sure you have answered the following: -->

- [X] Have you followed the guidelines in our [Contributing]('https://github.com/shapeshift/web/CONTRIBUTING.md) guide?
- [X] Have you checked to ensure there aren't other open [Pull Requests](https://github.com/shapeshift/web/pulls) for the same update/change?

## Pull Request Type

- [ ] :bug: Bug fix (Non-breaking Change: Fixes an issue)
- [X] :hammer_and_wrench: Chore (Non-breaking Change: Doc updates, pkg upgrades, typos, etc..)
- [ ] :nail_care: New Feature (Breaking/Non-breaking Change)

## Issue (if applicable)

N/A

## Risk

Very very low. It actually reduces risk by catching mistakes in the environment variable.

## Testing

Best to test locally. 
1. In `.env` add `REACT_APP_FOXY_APY`
2. Set the value to a valid number
3. Start the app `yarn dev`
4. Change the value to not a number
5. Start the app

## Screenshots (if applicable)
![image](https://user-images.githubusercontent.com/1958266/163252167-c9fdf665-e54f-44fe-b801-70918d81e91a.png)
