### PR TITLE
fix: change calls to "getSupportedChains()" to use "PluginManager.supportedChains"

### DIFF
--- a/src/context/PortfolioProvider/PortfolioContext.tsx
+++ b/src/context/PortfolioProvider/PortfolioContext.tsx
@@ -17,7 +17,7 @@ import head from 'lodash/head'
 import isEmpty from 'lodash/isEmpty'
 import React, { useCallback, useEffect, useState } from 'react'
 import { useDispatch, useSelector } from 'react-redux'
-import { useChainAdapters } from 'context/PluginProvider/PluginProvider'
+import { usePlugins } from 'context/PluginProvider/PluginProvider'
 import { useWallet } from 'hooks/useWallet/useWallet'
 import {
   AccountSpecifierMap,
@@ -53,7 +53,7 @@ import { deserializeUniqueTxId } from 'state/slices/txHistorySlice/utils'
  */
 export const PortfolioProvider = ({ children }: { children: React.ReactNode }) => {
   const dispatch = useDispatch()
-  const chainAdapter = useChainAdapters()
+  const { chainAdapterManager, supportedChains } = usePlugins()
   const {
     state: { wallet },
   } = useWallet()
@@ -106,11 +106,10 @@ export const PortfolioProvider = ({ children }: { children: React.ReactNode }) =
     if (isEmpty(assetsById)) return
     ;(async () => {
       try {
-        const supportedChains = chainAdapter.getSupportedChains()
         const acc: AccountSpecifierMap[] = []
 
         for (const chain of supportedChains) {
-          const adapter = chainAdapter.byChain(chain)
+          const adapter = chainAdapterManager.byChain(chain)
 
           switch (chain) {
             // TODO: Handle Cosmos ChainType here
@@ -181,7 +180,7 @@ export const PortfolioProvider = ({ children }: { children: React.ReactNode }) =
         console.error('useAccountSpecifiers:getAccountSpecifiers:Error', e)
       }
     })()
-  }, [assetsById, chainAdapter, dispatch, wallet])
+  }, [assetsById, chainAdapterManager, dispatch, wallet, supportedChains])
 
   const txIds = useSelector(selectTxIds)
   const txsById = useSelector(selectTxs)

--- a/src/context/TransactionsProvider/TransactionsProvider.tsx
+++ b/src/context/TransactionsProvider/TransactionsProvider.tsx
@@ -3,7 +3,7 @@ import { utxoAccountParams } from '@shapeshiftoss/chain-adapters'
 import isEmpty from 'lodash/isEmpty'
 import React, { useCallback, useEffect } from 'react'
 import { useDispatch, useSelector } from 'react-redux'
-import { useChainAdapters } from 'context/PluginProvider/PluginProvider'
+import { usePlugins } from 'context/PluginProvider/PluginProvider'
 import { useWallet } from 'hooks/useWallet/useWallet'
 import { walletSupportChain } from 'hooks/useWalletSupportsChain/useWalletSupportsChain'
 import { AccountSpecifierMap } from 'state/slices/accountSpecifiersSlice/accountSpecifiersSlice'
@@ -29,7 +29,7 @@ export const TransactionsProvider = ({ children }: TransactionsProviderProps): J
   const {
     state: { wallet, walletInfo },
   } = useWallet()
-  const chainAdapter = useChainAdapters()
+  const { chainAdapterManager, supportedChains } = usePlugins()
   const assets = useSelector(selectAssets)
   const portfolioAssetIds = useSelector(selectPortfolioAssetIds)
   const accountSpecifiers = useSelector(selectAccountSpecifiers)
@@ -50,10 +50,9 @@ export const TransactionsProvider = ({ children }: TransactionsProviderProps): J
   useEffect(() => {
     if (!wallet) return
     if (isEmpty(assets)) return
-    const supportedChains = chainAdapter.getSupportedChains()
     ;(async () => {
       for (const chain of supportedChains) {
-        const adapter = chainAdapter.byChain(chain)
+        const adapter = chainAdapterManager.byChain(chain)
         const chainId = adapter.getCaip2()
         if (!walletSupportChain({ chainId, wallet })) continue
 
@@ -123,7 +122,7 @@ export const TransactionsProvider = ({ children }: TransactionsProviderProps): J
       dispatch(txHistory.actions.clear())
       supportedChains.forEach(chain => {
         try {
-          const adapter = chainAdapter.byChain(chain)
+          const adapter = chainAdapterManager.byChain(chain)
           adapter.unsubscribeTxs()
         } catch (e) {
           console.error('TransactionsProvider: Error unsubscribing from transaction history', e)
@@ -135,7 +134,8 @@ export const TransactionsProvider = ({ children }: TransactionsProviderProps): J
     dispatch,
     walletInfo?.deviceId,
     wallet,
-    chainAdapter,
+    chainAdapterManager,
+    supportedChains,
     accountSpecifiers,
     getAccountSpecifiersByChainId,
     portfolioAssetIds,

--- a/src/features/defi/contexts/FoxyProvider/FoxyProvider.tsx
+++ b/src/features/defi/contexts/FoxyProvider/FoxyProvider.tsx
@@ -2,7 +2,7 @@ import { foxyAddresses, FoxyApi } from '@shapeshiftoss/investor-foxy'
 import { ChainTypes } from '@shapeshiftoss/types'
 import { getConfig } from 'config'
 import React, { useContext, useEffect, useState } from 'react'
-import { useChainAdapters } from 'context/PluginProvider/PluginProvider'
+import { usePlugins } from 'context/PluginProvider/PluginProvider'
 import { selectFeatureFlag } from 'state/slices/selectors'
 import { useAppSelector } from 'state/store'
 
@@ -23,17 +23,16 @@ export const FoxyProvider: React.FC = ({ children }) => {
   const [foxy, setFoxy] = useState<FoxyApi | null>(null)
   const [loading, setLoading] = useState<boolean>(false)
   const foxyInvestorFeatureFlag = useAppSelector(state => selectFeatureFlag(state, 'FoxyInvestor'))
-  const adapters = useChainAdapters()
-  const numSupportedChainAdapters = adapters.getSupportedChains().length
+  const { supportedChains, chainAdapterManager } = usePlugins()
 
   useEffect(() => {
     ;(async () => {
       try {
         if (!foxyInvestorFeatureFlag) return
-        if (!adapters.getSupportedChains().includes(ChainTypes.Ethereum)) return
+        if (!supportedChains.includes(ChainTypes.Ethereum)) return
         setLoading(true)
         const api = new FoxyApi({
-          adapter: adapters.byChain(ChainTypes.Ethereum),
+          adapter: chainAdapterManager.byChain(ChainTypes.Ethereum),
           providerUrl: getConfig().REACT_APP_ETHEREUM_NODE_URL,
           foxyAddresses: foxyAddresses,
         })
@@ -44,7 +43,7 @@ export const FoxyProvider: React.FC = ({ children }) => {
         setLoading(false)
       }
     })()
-  }, [adapters, foxyInvestorFeatureFlag, numSupportedChainAdapters])
+  }, [chainAdapterManager, foxyInvestorFeatureFlag, supportedChains])
 
   return <FoxyContext.Provider value={{ foxy, loading }}>{children}</FoxyContext.Provider>
 }

--- a/src/features/defi/contexts/YearnProvider/YearnProvider.tsx
+++ b/src/features/defi/contexts/YearnProvider/YearnProvider.tsx
@@ -2,7 +2,7 @@ import { YearnVaultApi } from '@shapeshiftoss/investor-yearn'
 import { ChainTypes } from '@shapeshiftoss/types'
 import { getConfig } from 'config'
 import React, { useContext, useEffect, useState } from 'react'
-import { useChainAdapters } from 'context/PluginProvider/PluginProvider'
+import { usePlugins } from 'context/PluginProvider/PluginProvider'
 
 type YearnContextProps = {
   loading: boolean
@@ -20,16 +20,15 @@ export const useYearn = () => {
 export const YearnProvider: React.FC = ({ children }) => {
   const [yearn, setYearn] = useState<YearnVaultApi | null>(null)
   const [loading, setLoading] = useState<boolean>(false)
-  const adapters = useChainAdapters()
-  const numSupportedChainAdapters = adapters.getSupportedChains().length
+  const { chainAdapterManager, supportedChains } = usePlugins()
 
   useEffect(() => {
     ;(async () => {
       try {
-        if (!adapters.getSupportedChains().includes(ChainTypes.Ethereum)) return
+        if (!chainAdapterManager.getSupportedChains().includes(ChainTypes.Ethereum)) return
         setLoading(true)
         const api = new YearnVaultApi({
-          adapter: adapters.byChain(ChainTypes.Ethereum),
+          adapter: chainAdapterManager.byChain(ChainTypes.Ethereum),
           providerUrl: getConfig().REACT_APP_ETHEREUM_NODE_URL,
         })
         await api.initialize()
@@ -40,7 +39,7 @@ export const YearnProvider: React.FC = ({ children }) => {
         setLoading(false)
       }
     })()
-  }, [adapters, numSupportedChainAdapters])
+  }, [chainAdapterManager, supportedChains])
 
   return <YearnContext.Provider value={{ yearn, loading }}>{children}</YearnContext.Provider>
 }


### PR DESCRIPTION
## Description

fix: change calls to `getSupportedChains()` to use `PluginManager.supportedChains`

`supportedChains` is a reactive state variable so it will cause re-renders when it changes

using `adapters.getSupportedChains()` isn't reactive.

## Notice

<!-- Before submitting a pull request, please make sure you have answered the following: -->

- [X] Have you followed the guidelines in our [Contributing]('https://github.com/shapeshift/web/CONTRIBUTING.md) guide?
- [X] Have you checked to ensure there aren't other open [Pull Requests](https://github.com/shapeshift/web/pulls) for the same update/change?

## Pull Request Type

- [X] :bug: Bug fix (Non-breaking Change: Fixes an issue)
- [ ] :hammer_and_wrench: Chore (Non-breaking Change: Doc updates, pkg upgrades, typos, etc..)
- [ ] :nail_care: New Feature (Breaking/Non-breaking Change)

## Issue (if applicable)

No issue, but prevents an issue if we have a feature flag that toggles support for a chain adapter (such as adding a new chain like Osmosis).

Also changes the code to be consistent in how we check if a chain is supported

## Risk

There shouldn't be any risk right now until we add a new chain plugin with a feature flag

## Testing

That that the following load correctly:
1. Portfolio
2. Transaction history
3. Foxy
4. Yearn

## Screenshots (if applicable)
