### PR TITLE
fix: remove default validator in `<StakeBroadcast />` and use validator…

### DIFF
--- a/src/plugins/cosmos/components/modals/Staking/views/StakeBroadcast.tsx
+++ b/src/plugins/cosmos/components/modals/Staking/views/StakeBroadcast.tsx
@@ -39,8 +39,6 @@ function calculateYearlyYield(apy: string, amount: string = '') {
   return bnOrZero(amount).times(apy).toString()
 }
 
-const DEFAULT_VALIDATOR_NAME = 'Shapeshift Validator'
-
 export const StakeBroadcast = ({
   assetId,
   accountSpecifier,
@@ -130,8 +128,12 @@ export const StakeBroadcast = ({
               <InfoOutlineIcon />
             </Tooltip>
           </CText>
-          <Link color={'blue.200'} target='_blank' href='#'>
-            {DEFAULT_VALIDATOR_NAME}
+          <Link
+            color={'blue.200'}
+            target='_blank'
+            href={`https://www.mintscan.io/cosmos/validators/${validatorAddress}`}
+          >
+            {validatorInfo.moniker}
           </Link>
         </Flex>
         <Flex width='100%' mb='35px' justifyContent='space-between'>

--- a/src/plugins/cosmos/components/modals/Staking/views/UnstakeBroadcast.tsx
+++ b/src/plugins/cosmos/components/modals/Staking/views/UnstakeBroadcast.tsx
@@ -112,7 +112,13 @@ export const UnstakeBroadcast = ({
               <InfoOutlineIcon />
             </Tooltip>
           </CText>
-          <CText color='blue.300'>{validatorInfo?.moniker}</CText>
+          <Link
+            color={'blue.200'}
+            target='_blank'
+            href={`https://www.mintscan.io/cosmos/validators/${validatorAddress}`}
+          >
+            {validatorInfo.moniker}
+          </Link>
         </Flex>
 
         <Flex width='100%' mb='35px' justifyContent='space-between'>


### PR DESCRIPTION
… link in `<UnstakeBroadcast />`

## Description

- removes the default validator in `<StakeBroadcast />` (currently, the default validator will always be shown) and add missing validator link
- add missing validator link on `<UnstakeBroadcast />`

## Notice

<!-- Before submitting a pull request, please make sure you have answered the following: -->

- [x] Have you followed the guidelines in our [Contributing]('https://github.com/shapeshift/web/CONTRIBUTING.md) guide?
- [x] Have you checked to ensure there aren't other open [Pull Requests](https://github.com/shapeshift/web/pulls) for the same update/change?

## Pull Request Type

- [x] :bug: Bug fix (Non-breaking Change: Fixes an issue)
- [ ] :hammer_and_wrench: Chore (Non-breaking Change: Doc updates, pkg upgrades, typos, etc..)
- [ ] :nail_care: New Feature (Breaking/Non-breaking Change)

## Issue (if applicable)

N/A

## Risk

N/A

## Testing

- The current chosen validator should be used in `<StakeBroadcast />` vs. ShapeShift Validator currently. The validator should be a link vs. text currently
- In `<UnstakeBroadcast />`, the validator should be a link vs. text currently


## Screenshots (if applicable)
