### PR TITLE
fix: don't claim fractions of uatom

### DIFF
--- a/src/plugins/cosmos/components/modals/Staking/views/Overview.tsx
+++ b/src/plugins/cosmos/components/modals/Staking/views/Overview.tsx
@@ -114,7 +114,9 @@ export const Overview: React.FC<StakedProps> = ({
                   <ClaimButton
                     assetId={assetId}
                     validatorAddress={validatorAddress}
-                    isDisabled={bnOrZero(rewardsAmount).isZero()}
+                    // We're getting fractions of uatom as rewards, but at protocol-level, it is actually impossible to claim these
+                    // Any amount that's less than 1 uatom effectively means no rewards
+                    isDisabled={bnOrZero(rewardsAmount).lt(1)}
                   />
                 )}
               />


### PR DESCRIPTION
## Description

Currently, we can claim less than 1 uatom (0.000001 ATOM), since unchained returns such amounts as rewards.
However, such amounts are not possible to represent at protocol-level, and when trying to send Txs for claiming fractions of uatom, no rewards will effectively be claimed.

This tightens the check for disabling the claim button by disabling it if the rewards amount are lower than 1 (uatom) vs. equal to zero currently.

## Notice

<!-- Before submitting a pull request, please make sure you have answered the following: -->

- [x] Have you followed the guidelines in our [Contributing]('https://github.com/shapeshift/web/CONTRIBUTING.md) guide?
- [x] Have you checked to ensure there aren't other open [Pull Requests](https://github.com/shapeshift/web/pulls) for the same update/change?

## Pull Request Type

- [x] :bug: Bug fix (Non-breaking Change: Fixes an issue)
- [ ] :hammer_and_wrench: Chore (Non-breaking Change: Doc updates, pkg upgrades, typos, etc..)
- [ ] :nail_care: New Feature (Breaking/Non-breaking Change)

## Issue (if applicable)

N/A

## Risk

N/A

## Testing

- Claim rewards
- A few minutes later, try to claim again (on unchained, rewards should then be equal to 0.0x atom)
- The claim button should be disabled

## Screenshots (if applicable)

<img width="400" alt="image" src="https://user-images.githubusercontent.com/17035424/163290285-77913364-2314-49ee-ab25-6ceb8a0bdb75.png">