### PR TITLE
fix: show when lr is empty + disable input when instant unstake

### DIFF
--- a/src/assets/translations/main.json
+++ b/src/assets/translations/main.json
@@ -189,6 +189,7 @@
     "broadcastingTransaction": "Broadcasting Transaction",
     "transactionComplete": "Transaction Complete",
     "transactionFailed": "Transaction Failed",
+    "notEnoughFundsInReserve": "Not enough funds in liquidity reserve contract",
     "validator": "Validator",
     "validatorMoniker":"%{moniker} Validator",
     "stakedAmount": "Staked Amount",

--- a/src/features/defi/components/Withdraw/Withdraw.tsx
+++ b/src/features/defi/components/Withdraw/Withdraw.tsx
@@ -388,6 +388,7 @@ export const Withdraw: React.FC<WithdrawProps> = ({
                           inputMode='decimal'
                           thousandSeparator={localeParts.group}
                           value={value}
+                          disabled={values.withdrawType === WithdrawType.INSTANT}
                           onChange={e => {
                             onChange(amountRef.current)
                             handleInputChange(amountRef.current as string)

--- a/src/features/defi/providers/foxy/components/FoxyManager/Withdraw/FoxyWithdraw.tsx
+++ b/src/features/defi/providers/foxy/components/FoxyManager/Withdraw/FoxyWithdraw.tsx
@@ -120,14 +120,21 @@ export const FoxyWithdraw = ({ api }: FoxyWithdrawProps) => {
       const returVal = bnOrZero(bn(gasPrice).times(gasLimit)).toFixed(0)
       return returVal
     } catch (error) {
-      // TODO: handle client side errors maybe add a toast?
-      console.error('FoxyWithdraw:getWithdrawGasEstimate error:', error)
-      toast({
-        position: 'top-right',
-        description: translate('common.somethingWentWrongBody'),
-        title: translate('common.somethingWentWrong'),
-        status: 'error',
-      })
+      if (error instanceof Error && error.message.includes('Not enough funds in reserve')) {
+        toast({
+          position: 'top-right',
+          description: translate('defi.notEnoughFundsInReserve'),
+          title: translate('common.somethingWentWrong'),
+          status: 'error',
+        })
+      } else {
+        toast({
+          position: 'top-right',
+          description: translate('common.somethingWentWrong'),
+          title: translate('common.somethingWentWrong'),
+          status: 'error',
+        })
+      }
     }
   }
 

--- a/src/features/defi/providers/foxy/components/FoxyManager/Withdraw/FoxyWithdraw.tsx
+++ b/src/features/defi/providers/foxy/components/FoxyManager/Withdraw/FoxyWithdraw.tsx
@@ -120,6 +120,7 @@ export const FoxyWithdraw = ({ api }: FoxyWithdrawProps) => {
       const returVal = bnOrZero(bn(gasPrice).times(gasLimit)).toFixed(0)
       return returVal
     } catch (error) {
+      console.error('FoxyWithdraw:getWithdrawGasEstimate error:', error)
       if (error instanceof Error && error.message.includes('Not enough funds in reserve')) {
         toast({
           position: 'top-right',

--- a/src/features/defi/providers/foxy/components/FoxyManager/Withdraw/FoxyWithdraw.tsx
+++ b/src/features/defi/providers/foxy/components/FoxyManager/Withdraw/FoxyWithdraw.tsx
@@ -121,21 +121,16 @@ export const FoxyWithdraw = ({ api }: FoxyWithdrawProps) => {
       return returVal
     } catch (error) {
       console.error('FoxyWithdraw:getWithdrawGasEstimate error:', error)
-      if (error instanceof Error && error.message.includes('Not enough funds in reserve')) {
-        toast({
-          position: 'top-right',
-          description: translate('defi.notEnoughFundsInReserve'),
-          title: translate('common.somethingWentWrong'),
-          status: 'error',
-        })
-      } else {
-        toast({
-          position: 'top-right',
-          description: translate('common.somethingWentWrong'),
-          title: translate('common.somethingWentWrong'),
-          status: 'error',
-        })
-      }
+      const fundsError =
+        error instanceof Error && error.message.includes('Not enough funds in reserve')
+      toast({
+        position: 'top-right',
+        description: fundsError
+          ? translate('defi.notEnoughFundsInReserve')
+          : translate('common.somethingWentWrong'),
+        title: translate('common.somethingWentWrong'),
+        status: 'error',
+      })
     }
   }
 


### PR DESCRIPTION
## Description

Instant shouldn't allow amount to be changed + show better error when reserve is empty.

These were comments from product

## Notice

<!-- Before submitting a pull request, please make sure you have answered the following: -->

- [x] Have you followed the guidelines in our [Contributing]('https://github.com/shapeshift/web/CONTRIBUTING.md) guide?
- [x] Have you checked to ensure there aren't other open [Pull Requests](https://github.com/shapeshift/web/pulls) for the same update/change?

## Pull Request Type

- [x] :bug: Bug fix (Non-breaking Change: Fixes an issue)
- [ ] :hammer_and_wrench: Chore (Non-breaking Change: Doc updates, pkg upgrades, typos, etc..)
- [ ] :nail_care: New Feature (Breaking/Non-breaking Change)

## Issue (if applicable)

<!-----------------------------------------------------------------------------
If applicable, please link to the github issue and put `closes #XXXX` in your comment to auto-close the issue that your PR fixes.
------------------------------------------------------------------------------>

## Risk

<!-----------------------------------------------------------------------------
Outline the scope of your changes and the risk associated with them. You must use your discretion as an engineer to determine the potential impact of your changes.

E.g. an upgrade to `hdwallet` or core state management would be considered higher risk, and might require a full regression test. UI or isolated view changes, or something behind a feature flag may have near zero risk. Small bug fixes might require testing isolated to the specific fix.
------------------------------------------------------------------------------>

## Testing

<!-----------------------------------------------------------------------------
If your testing steps are technical, outline steps for an engineer to verify.

If your testing steps are functional, please provide a full guide with any features requiring special attention for operations to test your branch in the preview environment.
------------------------------------------------------------------------------>

## Screenshots (if applicable)
