### PR TITLE
chore: use `REACT_APP_KEEPKEY_VERSIONS_URL` in `headers.js`

### DIFF
--- a/headers.js
+++ b/headers.js
@@ -7,8 +7,7 @@ const cspMeta = Object.entries({
     "'self'",
     'data:',
     // Explicitly whitelist our KeepKey versions file
-    // TODO: File manually added to IPFS - we need to instead add it to version control and use a persistent URL.
-    'https://bafybeied24gc2ipvlxdbs4v676dwho2l5aafmngrleic3do2czdvgb546u.ipfs.dweb.link/keepKey.json',
+    process.env.REACT_APP_KEEPKEY_VERSIONS_URL,
     // @shapeshiftoss/swapper@1.15.0: https://github.com/shapeshift/lib/blob/f833ac7f8c70dee801eaa24525336ca6992e5903/packages/swapper/src/swappers/zrx/utils/zrxService.ts#L4
     'https://api.0x.org',
     // @shapeshiftoss/chain-adapters@1.22.1: https://github.com/shapeshift/lib/blob/476550629be9485bfc089decc4df85456968464a/packages/chain-adapters/src/ethereum/EthereumChainAdapter.ts#L226

--- a/headers.js
+++ b/headers.js
@@ -6,8 +6,6 @@ const cspMeta = Object.entries({
   'connect-src': [
     "'self'",
     'data:',
-    // Explicitly whitelist our KeepKey versions file
-    process.env.REACT_APP_KEEPKEY_VERSIONS_URL,
     // @shapeshiftoss/swapper@1.15.0: https://github.com/shapeshift/lib/blob/f833ac7f8c70dee801eaa24525336ca6992e5903/packages/swapper/src/swappers/zrx/utils/zrxService.ts#L4
     'https://api.0x.org',
     // @shapeshiftoss/chain-adapters@1.22.1: https://github.com/shapeshift/lib/blob/476550629be9485bfc089decc4df85456968464a/packages/chain-adapters/src/ethereum/EthereumChainAdapter.ts#L226
@@ -55,6 +53,8 @@ const cspMeta = Object.entries({
     process.env.REACT_APP_UNCHAINED_BITCOIN_WS_URL,
     process.env.REACT_APP_UNCHAINED_COSMOS_HTTP_URL,
     process.env.REACT_APP_UNCHAINED_COSMOS_WS_URL,
+    // Explicitly whitelist our KeepKey versions file
+    process.env.REACT_APP_KEEPKEY_VERSIONS_URL,
   ],
   'frame-src': ['https://fwd.metamask.io/', 'https://widget.portis.io'],
   'img-src': [

--- a/sample.env
+++ b/sample.env
@@ -12,7 +12,7 @@ REACT_APP_UNCHAINED_COSMOS_HTTP_URL=https://dev-api.cosmos.shapeshift.com
 REACT_APP_UNCHAINED_COSMOS_WS_URL=wss://dev-api.cosmos.shapeshift.com
 REACT_APP_PORTIS_DAPP_ID=8609e6a8-e0dc-45e6-a0ad-edde63a4cdda
 REACT_APP_ETHEREUM_NODE_URL=https://mainnet.infura.io/v3/d734c7eebcdf400185d7eb67322a7e57
-REACT_APP_KEEPKEY_VERSIONS_URL=https://bafybeied24gc2ipvlxdbs4v676dwho2l5aafmngrleic3do2czdvgb546u.ipfs.dweb.link/keepKey.json
+REACT_APP_KEEPKEY_VERSIONS_URL=https://static.shapeshift.com/firmware/releases.json
 
 REACT_APP_FEATURE_COSMOS_INVESTOR=false
 REACT_APP_FEATURE_FOXY_INVESTOR=false

--- a/sample.env
+++ b/sample.env
@@ -12,6 +12,7 @@ REACT_APP_UNCHAINED_COSMOS_HTTP_URL=https://dev-api.cosmos.shapeshift.com
 REACT_APP_UNCHAINED_COSMOS_WS_URL=wss://dev-api.cosmos.shapeshift.com
 REACT_APP_PORTIS_DAPP_ID=8609e6a8-e0dc-45e6-a0ad-edde63a4cdda
 REACT_APP_ETHEREUM_NODE_URL=https://mainnet.infura.io/v3/d734c7eebcdf400185d7eb67322a7e57
+REACT_APP_KEEPKEY_VERSIONS_URL=https://bafybeied24gc2ipvlxdbs4v676dwho2l5aafmngrleic3do2czdvgb546u.ipfs.dweb.link/keepKey.json
 
 REACT_APP_FEATURE_COSMOS_INVESTOR=false
 REACT_APP_FEATURE_FOXY_INVESTOR=false

--- a/src/config.ts
+++ b/src/config.ts
@@ -18,10 +18,7 @@ const validators = {
   // TODO:
   //  Version control data and use a persistent URL
   //  so we don't need to update whenever new KeepKey firmware/bootloader is released.
-  REACT_APP_KEEPKEY_VERSIONS_URL: url({
-    default:
-      'https://bafybeied24gc2ipvlxdbs4v676dwho2l5aafmngrleic3do2czdvgb546u.ipfs.dweb.link/keepKey.json',
-  }),
+  REACT_APP_KEEPKEY_VERSIONS_URL: url(),
   REACT_APP_PORTIS_DAPP_ID: str({ devDefault: 'fakePortisId' }),
   REACT_APP_GEM_COINIFY_SUPPORTED_COINS: url(),
   REACT_APP_GEM_WYRE_SUPPORTED_COINS: url(),


### PR DESCRIPTION
## Description

Ensure our headers are in sync with the KeepKey versions URL.

## Notice

<!-- Before submitting a pull request, please make sure you have answered the following: -->

- [x] Have you followed the guidelines in our [Contributing]('https://github.com/shapeshift/web/CONTRIBUTING.md) guide?
- [x] Have you checked to ensure there aren't other open [Pull Requests](https://github.com/shapeshift/web/pulls) for the same update/change?

## Pull Request Type

- [ ] :bug: Bug fix (Non-breaking Change: Fixes an issue)
- [x] :hammer_and_wrench: Chore (Non-breaking Change: Doc updates, pkg upgrades, typos, etc..)
- [ ] :nail_care: New Feature (Breaking/Non-breaking Change)

## Issue (if applicable)

Closes https://github.com/shapeshift/web/issues/1453

## Risk

`REACT_APP_KEEPKEY_VERSIONS_URL` needs to be added and set to `https://bafybeied24gc2ipvlxdbs4v676dwho2l5aafmngrleic3do2czdvgb546u.ipfs.dweb.link/keepKey.json` before this is deployed, else the KeepKey version in the settings menu won't load.

## Testing

KeepKey settings should load correctly when the `REACT_APP_KEEPKEY_VERSIONS_URL` environment variable is set.

## Screenshots (if applicable)

<img width="288" alt="Screen Shot 2022-04-15 at 9 10 57 am" src="https://user-images.githubusercontent.com/97164662/163491795-71c84bd7-5eb9-4b3e-8376-10f4ae0a1d05.png">
