### PR TITLE
fix: missing cosmos earn balance

### DIFF
--- a/src/pages/Defi/views/Overview.tsx
+++ b/src/pages/Defi/views/Overview.tsx
@@ -2,7 +2,7 @@ import { Box, Divider, Heading, Stack } from '@chakra-ui/react'
 import { useTranslate } from 'react-polyglot'
 import { useSelector } from 'react-redux'
 import { Main } from 'components/Layout/Main'
-import { selectPortfolioTotalFiatBalance } from 'state/slices/selectors'
+import { selectPortfolioTotalFiatBalanceWithDelegations } from 'state/slices/selectors'
 
 import { OpportunityCardList } from '../components/OpportunityCardList'
 import { OverviewHeader } from '../components/OverviewHeader'
@@ -19,7 +19,7 @@ const DefiHeader = () => {
 
 export const Overview = () => {
   const balances = useEarnBalances()
-  const walletBalance = useSelector(selectPortfolioTotalFiatBalance)
+  const walletBalance = useSelector(selectPortfolioTotalFiatBalanceWithDelegations)
   return (
     <Main titleComponent={<DefiHeader />}>
       <OverviewHeader earnBalance={balances} walletBalance={walletBalance} />


### PR DESCRIPTION
## Description

Cosmos staking balance was missing from balance and networth displayed on defi overview page, this is a simple fix to add it back.

## Notice

<!-- Before submitting a pull request, please make sure you have answered the following: -->

- [X] Have you followed the guidelines in our [Contributing]('https://github.com/shapeshift/web/CONTRIBUTING.md) guide?
- [X] Have you checked to ensure there aren't other open [Pull Requests](https://github.com/shapeshift/web/pulls) for the same update/change?

## Pull Request Type

- [X] :bug: Bug fix (Non-breaking Change: Fixes an issue)
- [ ] :hammer_and_wrench: Chore (Non-breaking Change: Doc updates, pkg upgrades, typos, etc..)
- [ ] :nail_care: New Feature (Breaking/Non-breaking Change)

## Issue (if applicable)

https://github.com/shapeshift/web/issues/1491

## Risk

No risk

## Testing

Having multiple earn sources (yearn, foxy, cosmos)
Navigate to defi overview page
Verify total earn / wallet balance and networth are correct

## Screenshots (if applicable)

![opp_cards](https://user-images.githubusercontent.com/5720927/163567030-aed573a3-c2d5-4f10-98df-033aa4748ae3.png)

![portfolio](https://user-images.githubusercontent.com/5720927/163567045-00e1e8ee-3c92-451d-ac69-0d8821f40264.png)


