### PR TITLE
fix: wallet, portfolio and tx management

### DIFF
--- a/src/AppProviders.tsx
+++ b/src/AppProviders.tsx
@@ -36,13 +36,13 @@ export function AppProviders({ children }: ProvidersProps) {
                   <WalletProvider>
                     <KeepKeyProvider>
                       <ModalProvider>
-                        <PortfolioProvider>
-                          <MarketDataProvider>
-                            <TransactionsProvider>
+                        <TransactionsProvider>
+                          <PortfolioProvider>
+                            <MarketDataProvider>
                               <DefiManagerProvider>{children}</DefiManagerProvider>
-                            </TransactionsProvider>
-                          </MarketDataProvider>
-                        </PortfolioProvider>
+                            </MarketDataProvider>
+                          </PortfolioProvider>
+                        </TransactionsProvider>
                       </ModalProvider>
                     </KeepKeyProvider>
                   </WalletProvider>

--- a/src/AppProviders.tsx
+++ b/src/AppProviders.tsx
@@ -5,12 +5,12 @@ import { Provider as ReduxProvider } from 'react-redux'
 import { HashRouter } from 'react-router-dom'
 import { PersistGate } from 'redux-persist/integration/react'
 import { ScrollToTop } from 'Routes/ScrollToTop'
+import { AppProvider } from 'context/AppProvider/AppContext'
 import { BrowserRouterProvider } from 'context/BrowserRouterProvider/BrowserRouterProvider'
 import { I18nProvider } from 'context/I18nProvider/I18nProvider'
 import { MarketDataProvider } from 'context/MarketDataProvider/MarketDataProvider'
 import { ModalProvider } from 'context/ModalProvider/ModalProvider'
 import { PluginProvider } from 'context/PluginProvider/PluginProvider'
-import { PortfolioProvider } from 'context/PortfolioProvider/PortfolioContext'
 import { TransactionsProvider } from 'context/TransactionsProvider/TransactionsProvider'
 import { KeepKeyProvider } from 'context/WalletProvider/KeepKeyProvider'
 import { WalletProvider } from 'context/WalletProvider/WalletProvider'
@@ -37,11 +37,11 @@ export function AppProviders({ children }: ProvidersProps) {
                     <KeepKeyProvider>
                       <ModalProvider>
                         <TransactionsProvider>
-                          <PortfolioProvider>
+                          <AppProvider>
                             <MarketDataProvider>
                               <DefiManagerProvider>{children}</DefiManagerProvider>
                             </MarketDataProvider>
-                          </PortfolioProvider>
+                          </AppProvider>
                         </TransactionsProvider>
                       </ModalProvider>
                     </KeepKeyProvider>

--- a/src/context/AppProvider/AppContext.tsx
+++ b/src/context/AppProvider/AppContext.tsx
@@ -96,8 +96,8 @@ export const AppProvider = ({ children }: { children: React.ReactNode }) => {
     const switched = Boolean(wallet && !isEmpty(accountSpecifiersList))
     const disconnected = !wallet
     // TODO(0xdef1cafe): keep this - change to structured debug logging
-    switched && console.info('PortfolioContext: wallet switched')
-    disconnected && console.info('PortfolioContext: wallet disconnected')
+    switched && console.info('AppContext: wallet switched')
+    disconnected && console.info('AppContext: wallet disconnected')
     if (switched || disconnected) {
       dispatch(accountSpecifiers.actions.clear())
       dispatch(portfolio.actions.clear())

--- a/src/context/AppProvider/AppContext.tsx
+++ b/src/context/AppProvider/AppContext.tsx
@@ -51,7 +51,7 @@ import { deserializeUniqueTxId } from 'state/slices/txHistorySlice/utils'
  * for some time as reselect does a really good job of memoizing things
  *
  */
-export const PortfolioProvider = ({ children }: { children: React.ReactNode }) => {
+export const AppProvider = ({ children }: { children: React.ReactNode }) => {
   const dispatch = useDispatch()
   const { chainAdapterManager, supportedChains } = usePlugins()
   const {

--- a/src/context/PluginProvider/PluginProvider.tsx
+++ b/src/context/PluginProvider/PluginProvider.tsx
@@ -105,7 +105,8 @@ export const PluginProvider = ({ children }: PluginProviderProps): JSX.Element =
       {
         add: chain => {
           const factory = newChainAdapters[chain]
-          console.info('adding chain', chain)
+          // TODO(0xdef1cafe): leave this here, change to debug logging
+          console.info('PluginProvider: adding chain', chain)
           if (factory) getChainAdapters().addChain(chain, factory)
         },
         remove: chain => {
@@ -116,7 +117,8 @@ export const PluginProvider = ({ children }: PluginProviderProps): JSX.Element =
     )
 
     setRoutes(pluginRoutes)
-    console.info('setting supported chains')
+    // TODO(0xdef1cafe): leave this here, change to debug logging
+    console.info('PluginProvider: setting supported chains')
     setSupportedChains(getChainAdapters().getSupportedChains())
   }, [chainAdapterManager, featureFlags, plugins, pluginManager])
 

--- a/src/context/PluginProvider/PluginProvider.tsx
+++ b/src/context/PluginProvider/PluginProvider.tsx
@@ -50,10 +50,10 @@ export const PluginProvider = ({ children }: PluginProviderProps): JSX.Element =
   const chainAdapterManagerRef = useRef<ChainAdapterManager>(getChainAdapters())
 
   // a memoized version of the current version of the ref to be made available on the context
-  const chainAdapterManager = useMemo(
-    () => chainAdapterManagerRef.current,
-    [chainAdapterManagerRef],
-  )
+  const chainAdapterManager = useMemo(() => {
+    console.info('cam ref')
+    return chainAdapterManagerRef.current
+  }, [chainAdapterManagerRef])
 
   useEffect(() => {
     ;(async () => {

--- a/src/context/PluginProvider/PluginProvider.tsx
+++ b/src/context/PluginProvider/PluginProvider.tsx
@@ -105,6 +105,7 @@ export const PluginProvider = ({ children }: PluginProviderProps): JSX.Element =
       {
         add: chain => {
           const factory = newChainAdapters[chain]
+          console.info('adding chain', chain)
           if (factory) getChainAdapters().addChain(chain, factory)
         },
         remove: chain => {
@@ -115,6 +116,7 @@ export const PluginProvider = ({ children }: PluginProviderProps): JSX.Element =
     )
 
     setRoutes(pluginRoutes)
+    console.info('setting supported chains')
     setSupportedChains(getChainAdapters().getSupportedChains())
   }, [chainAdapterManager, featureFlags, plugins, pluginManager])
 

--- a/src/context/PluginProvider/PluginProvider.tsx
+++ b/src/context/PluginProvider/PluginProvider.tsx
@@ -50,10 +50,10 @@ export const PluginProvider = ({ children }: PluginProviderProps): JSX.Element =
   const chainAdapterManagerRef = useRef<ChainAdapterManager>(getChainAdapters())
 
   // a memoized version of the current version of the ref to be made available on the context
-  const chainAdapterManager = useMemo(() => {
-    console.info('cam ref')
-    return chainAdapterManagerRef.current
-  }, [chainAdapterManagerRef])
+  const chainAdapterManager = useMemo(
+    () => chainAdapterManagerRef.current,
+    [chainAdapterManagerRef],
+  )
 
   useEffect(() => {
     ;(async () => {

--- a/src/context/PortfolioProvider/PortfolioContext.tsx
+++ b/src/context/PortfolioProvider/PortfolioContext.tsx
@@ -90,12 +90,14 @@ export const PortfolioProvider = ({ children }: { children: React.ReactNode }) =
    * handle wallet disconnect/switch logic
    */
   useEffect(() => {
-    // if we have account specifiers, but not a wallet, it means we've disconnected/switched wallets
-    // and need to clear the account specifiers
-    const disconnected = !wallet
+    // if we have a wallet and changed account specifiers, we have switched wallets
+    // NOTE! - the wallet will change before the account specifiers does, so clearing here is valid
+    // check the console logs in the browser for the ordering of actions to verify this logic
     const switched = Boolean(wallet && !isEmpty(accountSpecifiersList))
-    disconnected && console.info('PortfolioContext: wallet disconnected')
+    const disconnected = !wallet
+    // TODO(0xdef1cafe): keep this - change to structured debug logging
     switched && console.info('PortfolioContext: wallet switched')
+    disconnected && console.info('PortfolioContext: wallet disconnected')
     if (switched || disconnected) {
       dispatch(accountSpecifiers.actions.clear())
       dispatch(portfolio.actions.clear())

--- a/src/context/PortfolioProvider/PortfolioContext.tsx
+++ b/src/context/PortfolioProvider/PortfolioContext.tsx
@@ -15,6 +15,7 @@ import { ChainTypes, NetworkTypes } from '@shapeshiftoss/types'
 import difference from 'lodash/difference'
 import head from 'lodash/head'
 import isEmpty from 'lodash/isEmpty'
+import isEqual from 'lodash/isEqual'
 import React, { useCallback, useEffect, useState } from 'react'
 import { useDispatch, useSelector } from 'react-redux'
 import { usePlugins } from 'context/PluginProvider/PluginProvider'
@@ -182,7 +183,8 @@ export const PortfolioProvider = ({ children }: { children: React.ReactNode }) =
         }
 
         console.info('dispatching account specifiers set action')
-        dispatch(accountSpecifiers.actions.setAccountSpecifiers(acc))
+        !isEqual(accountSpecifiers, acc) &&
+          dispatch(accountSpecifiers.actions.setAccountSpecifiers(acc))
       } catch (e) {
         console.error('useAccountSpecifiers:getAccountSpecifiers:Error', e)
       }

--- a/src/context/PortfolioProvider/PortfolioContext.tsx
+++ b/src/context/PortfolioProvider/PortfolioContext.tsx
@@ -194,9 +194,6 @@ export const PortfolioProvider = ({ children }: { children: React.ReactNode }) =
         console.error('useAccountSpecifiers:getAccountSpecifiers:Error', e)
       }
     })()
-
-    // accountSpecifiersList is set by this hook, so don't create infinite loop
-    // eslint-disable-next-line react-hooks/exhaustive-deps
   }, [assetsById, chainAdapterManager, dispatch, wallet, supportedChains])
 
   const txIds = useSelector(selectTxIds)

--- a/src/context/TransactionsProvider/TransactionsProvider.tsx
+++ b/src/context/TransactionsProvider/TransactionsProvider.tsx
@@ -8,6 +8,7 @@ import { useWallet } from 'hooks/useWallet/useWallet'
 import { walletSupportChain } from 'hooks/useWalletSupportsChain/useWalletSupportsChain'
 import { AccountSpecifierMap } from 'state/slices/accountSpecifiersSlice/accountSpecifiersSlice'
 import { supportedAccountTypes } from 'state/slices/portfolioSlice/portfolioSliceCommon'
+import { chainIdToFeeAssetId } from 'state/slices/portfolioSlice/utils'
 import {
   selectAccountIdByAddress,
   selectAccountSpecifiers,
@@ -60,12 +61,9 @@ export const TransactionsProvider = ({ children }: TransactionsProviderProps): J
         const chainId = adapter.getCaip2()
         if (!walletSupportChain({ chainId, wallet })) continue
 
-        const asset = Object.values(assets).find(asset => asset.caip2 === chainId)
-        if (!asset) {
-          throw new Error(`asset not found for chain ${chain}`)
-        }
-
-        const accountTypes = supportedAccountTypes[chain] ?? [undefined]
+        // assets are known to be defined at this point - if we don't have the fee asset we have bigger problems
+        const asset = assets[chainIdToFeeAssetId(chainId)]
+        const accountTypes = supportedAccountTypes[chain]
 
         // TODO(0xdef1cafe) - once we have restful tx history for all coinstacks
         // this state machine should be removed, and managed by the txHistory RTK query api

--- a/src/context/TransactionsProvider/TransactionsProvider.tsx
+++ b/src/context/TransactionsProvider/TransactionsProvider.tsx
@@ -55,8 +55,9 @@ export const TransactionsProvider = ({ children }: TransactionsProviderProps): J
    * tx history unsubscribe and cleanup logic
    */
   useEffect(() => {
+    // account specifiers changing will trigger this effect
     // we've disconnected/switched a wallet, unsubscribe from tx history and clear tx history
-    if (!isPortfolioLoaded && txIds.length) {
+    if (txIds.length) {
       console.info('TransactionsProvider: unsubscribing from tx history')
       supportedChains.forEach(chain => chainAdapterManager.byChain(chain).unsubscribeTxs())
       setIsSubscribed(false)
@@ -64,7 +65,7 @@ export const TransactionsProvider = ({ children }: TransactionsProviderProps): J
     }
     // txIds are changed by this effect, don't cause infinite loop
     // eslint-disable-next-line react-hooks/exhaustive-deps
-  }, [isPortfolioLoaded, accountSpecifiers, chainAdapterManager, supportedChains])
+  }, [accountSpecifiers, dispatch, chainAdapterManager, supportedChains])
 
   /**
    * tx history subscription logic

--- a/src/context/TransactionsProvider/TransactionsProvider.tsx
+++ b/src/context/TransactionsProvider/TransactionsProvider.tsx
@@ -57,13 +57,12 @@ export const TransactionsProvider = ({ children }: TransactionsProviderProps): J
   useEffect(() => {
     // account specifiers changing will trigger this effect
     // we've disconnected/switched a wallet, unsubscribe from tx history and clear tx history
-    if (txIds.length) {
-      console.info('TransactionsProvider: unsubscribing from tx history')
-      supportedChains.forEach(chain => chainAdapterManager.byChain(chain).unsubscribeTxs())
-      setIsSubscribed(false)
-      dispatch(txHistory.actions.clear())
-    }
-    // txIds are changed by this effect, don't cause infinite loop
+    if (!isSubscribed) return
+    console.info('TransactionsProvider: unsubscribing from tx history')
+    supportedChains.forEach(chain => chainAdapterManager.byChain(chain).unsubscribeTxs())
+    dispatch(txHistory.actions.clear())
+    setIsSubscribed(false)
+    // setting isSubscribed to false will trigger this effect
     // eslint-disable-next-line react-hooks/exhaustive-deps
   }, [accountSpecifiers, dispatch, chainAdapterManager, supportedChains])
 

--- a/src/context/TransactionsProvider/TransactionsProvider.tsx
+++ b/src/context/TransactionsProvider/TransactionsProvider.tsx
@@ -12,6 +12,7 @@ import {
   selectAccountIdByAddress,
   selectAccountSpecifiers,
   selectAssets,
+  selectIsPortfolioLoaded,
   selectPortfolioAssetIds,
   selectTxHistoryStatus,
   selectTxIds,
@@ -47,9 +48,12 @@ export const TransactionsProvider = ({ children }: TransactionsProviderProps): J
     [accountSpecifiers],
   )
 
+  const isPortfolioLoaded = useSelector(selectIsPortfolioLoaded)
+
   useEffect(() => {
     if (!wallet) return
     if (isEmpty(assets)) return
+    if (!isPortfolioLoaded) return
     ;(async () => {
       for (const chain of supportedChains) {
         const adapter = chainAdapterManager.byChain(chain)
@@ -130,6 +134,7 @@ export const TransactionsProvider = ({ children }: TransactionsProviderProps): J
       })
     }
   }, [
+    isPortfolioLoaded,
     assets,
     dispatch,
     walletInfo?.deviceId,

--- a/src/context/TransactionsProvider/TransactionsProvider.tsx
+++ b/src/context/TransactionsProvider/TransactionsProvider.tsx
@@ -122,6 +122,7 @@ export const TransactionsProvider = ({ children }: TransactionsProviderProps): J
     })()
 
     return () => {
+      console.trace()
       console.info('clearing tx history')
       dispatch(txHistory.actions.clear())
       supportedChains.forEach(chain => {

--- a/src/context/TransactionsProvider/TransactionsProvider.tsx
+++ b/src/context/TransactionsProvider/TransactionsProvider.tsx
@@ -73,6 +73,7 @@ export const TransactionsProvider = ({ children }: TransactionsProviderProps): J
         for await (const accountType of accountTypes) {
           const accountParams = accountType ? utxoAccountParams(asset, accountType, 0) : {}
           try {
+            console.info('subscribing txs for', chainId, accountType)
             await adapter.subscribeTxs(
               { wallet, accountType, ...accountParams },
               msg => {
@@ -123,6 +124,7 @@ export const TransactionsProvider = ({ children }: TransactionsProviderProps): J
     })()
 
     return () => {
+      console.info('clearing tx history')
       dispatch(txHistory.actions.clear())
       supportedChains.forEach(chain => {
         try {

--- a/src/context/TransactionsProvider/TransactionsProvider.tsx
+++ b/src/context/TransactionsProvider/TransactionsProvider.tsx
@@ -74,7 +74,6 @@ export const TransactionsProvider = ({ children }: TransactionsProviderProps): J
     if (!wallet) return
     if (isEmpty(assets)) return
     if (!isPortfolioLoaded) return // wait for all chain portfolios to be loaded before subscribing
-    if (isEmpty(accountSpecifiers)) return // don't subscribe if we don't have accountSpecifiers
     if (isSubscribed) return // don't resubscribe
     ;(async () =>
       Promise.all(

--- a/src/hooks/useWalletSupportsChain/useWalletSupportsChain.ts
+++ b/src/hooks/useWalletSupportsChain/useWalletSupportsChain.ts
@@ -12,7 +12,7 @@ type UseWalletSupportsChainArgs = { chainId: CAIP2; wallet: HDWallet | null }
 type UseWalletSupportsChain = (args: UseWalletSupportsChainArgs) => boolean
 
 // use outside react
-export const walletSupportChain: UseWalletSupportsChain = ({ chainId, wallet }) => {
+export const walletSupportsChain: UseWalletSupportsChain = ({ chainId, wallet }) => {
   if (!wallet) return false
   const ethCAIP2 = caip2.toCAIP2({ chain: ChainTypes.Ethereum, network: NetworkTypes.MAINNET })
   const btcCAIP2 = caip2.toCAIP2({ chain: ChainTypes.Bitcoin, network: NetworkTypes.MAINNET })
@@ -46,4 +46,4 @@ export const walletSupportChain: UseWalletSupportsChain = ({ chainId, wallet }) 
 }
 
 // TODO(0xdef1cafe): this whole thing should belong in chain adapters
-export const useWalletSupportsChain: UseWalletSupportsChain = args => walletSupportChain(args)
+export const useWalletSupportsChain: UseWalletSupportsChain = args => walletSupportsChain(args)

--- a/src/state/slices/accountSpecifiersSlice/accountSpecifiersSlice.ts
+++ b/src/state/slices/accountSpecifiersSlice/accountSpecifiersSlice.ts
@@ -1,5 +1,6 @@
 import { createSlice } from '@reduxjs/toolkit'
 import { CAIP2 } from '@shapeshiftoss/caip'
+import isEqual from 'lodash/isEqual'
 
 // an account specifier is an x/y/zpub, or eth public key
 // as consumed by unchained, note this is *not* a CAIP10
@@ -19,8 +20,14 @@ export const accountSpecifiers = createSlice({
   name: 'accountSpecifiers',
   initialState: getInitialState(),
   reducers: {
-    clear: getInitialState,
+    clear: () => {
+      console.info('accountSpecifiersSlice: clearing account specifiers')
+      return getInitialState()
+    },
     setAccountSpecifiers(state, { payload }: { payload: AccountSpecifierMap[] }) {
+      // don't set to exactly the same thing and cause renders
+      if (isEqual(state.accountSpecifiers, payload)) return
+      console.info('accountSpecifiersSlice: dispatching account specifiers set action')
       state.accountSpecifiers = payload
     },
   },

--- a/src/state/slices/accountSpecifiersSlice/selectors.ts
+++ b/src/state/slices/accountSpecifiersSlice/selectors.ts
@@ -1,8 +1,12 @@
 import { CAIP2 } from '@shapeshiftoss/caip'
 import { ReduxState } from 'state/reducer'
 
-export const selectAccountSpecifiers = (state: ReduxState) =>
-  state.accountSpecifiers.accountSpecifiers
+import { createDeepEqualOutputSelector } from './../../selector-utils'
+
+export const selectAccountSpecifiers = createDeepEqualOutputSelector(
+  (state: ReduxState) => state.accountSpecifiers.accountSpecifiers,
+  accountSpecifiers => accountSpecifiers,
+)
 
 // returns an array of the full `caip2:pubkeyish` type, as used in URLs for account pages
 export const selectAccountSpecifierStrings = (state: ReduxState) =>

--- a/src/state/slices/assetsSlice/selectors.ts
+++ b/src/state/slices/assetsSlice/selectors.ts
@@ -4,6 +4,7 @@ import { Asset, ChainTypes, NetworkTypes } from '@shapeshiftoss/types'
 import cloneDeep from 'lodash/cloneDeep'
 import sortBy from 'lodash/sortBy'
 import { ReduxState } from 'state/reducer'
+import { createDeepEqualOutputSelector } from 'state/selector-utils'
 import { selectMarketDataIds } from 'state/slices/marketDataSlice/selectors'
 
 export const selectAssetByCAIP19 = createSelector(
@@ -16,7 +17,10 @@ export const selectAssetNameById = createSelector(selectAssetByCAIP19, asset =>
   asset ? asset.name : undefined,
 )
 
-export const selectAssets = (state: ReduxState) => state.assets.byId
+export const selectAssets = createDeepEqualOutputSelector(
+  (state: ReduxState) => state.assets.byId,
+  byId => byId,
+)
 export const selectAssetIds = (state: ReduxState) => state.assets.ids
 
 export const selectAssetsByMarketCap = createSelector(

--- a/src/state/slices/portfolioSlice/portfolioSlice.test.ts
+++ b/src/state/slices/portfolioSlice/portfolioSlice.test.ts
@@ -43,6 +43,8 @@ import {
 } from './selectors'
 
 describe('portfolioSlice', () => {
+  const consoleInfoSpy = jest.spyOn(console, 'info').mockImplementation(() => void 0)
+  afterAll(() => consoleInfoSpy.mockRestore())
   describe('reducers', () => {
     describe('upsertPortfolio', () => {
       describe('ethereum', () => {

--- a/src/state/slices/portfolioSlice/portfolioSlice.ts
+++ b/src/state/slices/portfolioSlice/portfolioSlice.ts
@@ -15,7 +15,10 @@ export const portfolio = createSlice({
   name: 'portfolio',
   initialState,
   reducers: {
-    clear: () => initialState,
+    clear: () => {
+      console.info('portfolioSlice: clearing portfolio')
+      return initialState
+    },
     upsertPortfolio: (state, { payload }: { payload: Portfolio }) => {
       // upsert all
       state.accounts.byId = { ...state.accounts.byId, ...payload.accounts.byId }

--- a/src/state/slices/portfolioSlice/portfolioSlice.ts
+++ b/src/state/slices/portfolioSlice/portfolioSlice.ts
@@ -20,6 +20,7 @@ export const portfolio = createSlice({
       return initialState
     },
     upsertPortfolio: (state, { payload }: { payload: Portfolio }) => {
+      console.info('portfolioSlice: upserting portfolio')
       // upsert all
       state.accounts.byId = { ...state.accounts.byId, ...payload.accounts.byId }
       const accountIds = Array.from(new Set([...state.accounts.ids, ...payload.accounts.ids]))

--- a/src/state/slices/portfolioSlice/portfolioSliceCommon.ts
+++ b/src/state/slices/portfolioSlice/portfolioSliceCommon.ts
@@ -8,6 +8,9 @@ export const supportedAccountTypes = {
     UtxoAccountType.SegwitP2sh,
     UtxoAccountType.P2pkh,
   ],
+  // this looks funky, but we need a non zero length array to map over
+  // where we consume it - it either looks weird here or in the consumption
+  // so...  ¯\_(ツ)_/¯
   [ChainTypes.Ethereum]: [undefined],
   [ChainTypes.Cosmos]: [undefined],
   [ChainTypes.Osmosis]: [undefined],

--- a/src/state/slices/portfolioSlice/portfolioSliceCommon.ts
+++ b/src/state/slices/portfolioSlice/portfolioSliceCommon.ts
@@ -8,9 +8,9 @@ export const supportedAccountTypes = {
     UtxoAccountType.SegwitP2sh,
     UtxoAccountType.P2pkh,
   ],
-  [ChainTypes.Ethereum]: undefined,
-  [ChainTypes.Cosmos]: undefined,
-  [ChainTypes.Osmosis]: undefined,
+  [ChainTypes.Ethereum]: [undefined],
+  [ChainTypes.Cosmos]: [undefined],
+  [ChainTypes.Osmosis]: [undefined],
 }
 
 /*

--- a/src/state/slices/portfolioSlice/selectors.test.ts
+++ b/src/state/slices/portfolioSlice/selectors.test.ts
@@ -1,0 +1,73 @@
+import { btcCaip2, btcCaip19, ethCaip2, ethCaip19 } from 'test/mocks/accounts'
+import { mockStore } from 'test/mocks/store'
+import { ReduxState } from 'state/reducer'
+
+import { selectIsPortfolioLoaded } from './selectors'
+
+jest.mock('../selectors', () => {
+  return {
+    ...jest.requireActual('./selectors'),
+    selectAccountSpecifiers: jest.mock,
+  }
+})
+
+describe('selectIsPortfolioLoaded', () => {
+  it('should return false for empty account specifiers', () => {
+    const thisMockStore: ReduxState = {
+      ...mockStore,
+      accountSpecifiers: {
+        accountSpecifiers: [],
+      },
+      portfolio: {
+        ...mockStore.portfolio,
+        assetBalances: {
+          byId: {},
+          ids: [],
+        },
+      },
+    }
+    const result = selectIsPortfolioLoaded(thisMockStore)
+    expect(result).toBeFalsy()
+  })
+
+  it('should return false if partially loaded', () => {
+    const thisMockStore: ReduxState = {
+      ...mockStore,
+      accountSpecifiers: {
+        accountSpecifiers: [{ [ethCaip2]: 'foo' }, { [btcCaip2]: 'bar' }],
+      },
+      portfolio: {
+        ...mockStore.portfolio,
+        assetBalances: {
+          byId: {
+            [ethCaip19]: '',
+          },
+          ids: [ethCaip19],
+        },
+      },
+    }
+    const result = selectIsPortfolioLoaded(thisMockStore)
+    expect(result).toBeFalsy()
+  })
+
+  it('should return true if fully loaded', () => {
+    const thisMockStore: ReduxState = {
+      ...mockStore,
+      accountSpecifiers: {
+        accountSpecifiers: [{ [ethCaip2]: 'foo' }, { [btcCaip2]: 'bar' }],
+      },
+      portfolio: {
+        ...mockStore.portfolio,
+        assetBalances: {
+          byId: {
+            [ethCaip19]: '',
+            [btcCaip19]: '',
+          },
+          ids: [ethCaip19, btcCaip19],
+        },
+      },
+    }
+    const result = selectIsPortfolioLoaded(thisMockStore)
+    expect(result).toBeTruthy()
+  })
+})

--- a/src/state/slices/portfolioSlice/selectors.ts
+++ b/src/state/slices/portfolioSlice/selectors.ts
@@ -1,7 +1,14 @@
 import { createSelector } from '@reduxjs/toolkit'
 import { CAIP10, CAIP19 } from '@shapeshiftoss/caip'
 import { Asset } from '@shapeshiftoss/types'
+import difference from 'lodash/difference'
+import flow from 'lodash/flow'
+import head from 'lodash/head'
+import keys from 'lodash/keys'
+import map from 'lodash/map'
+import size from 'lodash/size'
 import toLower from 'lodash/toLower'
+import uniq from 'lodash/uniq'
 import { bn, bnOrZero } from 'lib/bignumber/bignumber'
 import { fromBaseUnit } from 'lib/math'
 import { ReduxState } from 'state/reducer'
@@ -15,6 +22,7 @@ import {
 } from 'state/slices/stakingDataSlice/selectors'
 
 import { AccountSpecifier } from '../accountSpecifiersSlice/accountSpecifiersSlice'
+import { selectAccountSpecifiers } from './../accountSpecifiersSlice/selectors'
 import {
   PortfolioAccountBalances,
   PortfolioAccountSpecifiers,
@@ -23,6 +31,7 @@ import {
   PortfolioBalancesById,
 } from './portfolioSliceCommon'
 import {
+  assetIdtoChainId,
   findAccountsByAssetId,
   makeBalancesByChainBucketsFlattened,
   makeSortedAccountBalances,
@@ -47,6 +56,20 @@ export const selectAccountIds = (state: ReduxState): PortfolioAccountSpecifiers[
 export const selectPortfolioAccountBalances = (
   state: ReduxState,
 ): PortfolioAccountBalances['byId'] => state.portfolio.accountBalances.byId
+
+export const selectIsPortfolioLoaded = createSelector(
+  selectAccountSpecifiers,
+  selectPortfolioAssetIds,
+  (accountSpecifiers, portfolioAssetIds) => {
+    if (!accountSpecifiers.length) return false
+    return !size(
+      difference(
+        uniq(map(accountSpecifiers, flow([keys, head]))),
+        uniq(map(portfolioAssetIds, assetIdtoChainId)),
+      ),
+    )
+  },
+)
 
 export const selectPortfolioFiatBalances = createSelector(
   selectAssets,

--- a/src/state/slices/portfolioSlice/selectors.ts
+++ b/src/state/slices/portfolioSlice/selectors.ts
@@ -62,6 +62,13 @@ export const selectIsPortfolioLoaded = createSelector(
   selectPortfolioAssetIds,
   (accountSpecifiers, portfolioAssetIds) => {
     if (!accountSpecifiers.length) return false
+    /**
+     * for a given wallet - we can support 1 to n chains
+     * PortfolioContext ensures we will have a portfolioAssetId for each chain's fee asset
+     * until the portfolioAssetIds includes supported chains fee assets, it's not fully loaded
+     * the golf below ensures that's the case
+     */
+
     return !size(
       difference(
         uniq(map(accountSpecifiers, flow([keys, head]))),

--- a/src/state/slices/portfolioSlice/selectors.ts
+++ b/src/state/slices/portfolioSlice/selectors.ts
@@ -64,7 +64,7 @@ export const selectIsPortfolioLoaded = createSelector(
     if (!accountSpecifiers.length) return false
     /**
      * for a given wallet - we can support 1 to n chains
-     * PortfolioContext ensures we will have a portfolioAssetId for each chain's fee asset
+     * AppContext ensures we will have a portfolioAssetId for each chain's fee asset
      * until the portfolioAssetIds includes supported chains fee assets, it's not fully loaded
      * the golf below ensures that's the case
      */

--- a/src/state/slices/portfolioSlice/utils.ts
+++ b/src/state/slices/portfolioSlice/utils.ts
@@ -95,9 +95,11 @@ export const accountIdToLabel = (accountId: AccountSpecifier): string => {
   }
 }
 
+export const chainIdToFeeAssetId = (chainId: CAIP2): CAIP19 => caip2toCaip19[chainId]
+
 // note - this is not really a selector, more of a util
-export const accountIdToFeeAssetId = (accountId: AccountSpecifier) =>
-  caip2toCaip19[accountIdToChainId(accountId)]
+export const accountIdToFeeAssetId = (accountId: AccountSpecifier): CAIP19 =>
+  chainIdToFeeAssetId(accountIdToChainId(accountId))
 
 export const accountIdToAccountType = (accountId: AccountSpecifier): UtxoAccountType | null => {
   const pubkeyVariant = last(accountId.split(':'))

--- a/src/state/slices/stakingDataSlice/stakingDataSlice.test.ts
+++ b/src/state/slices/stakingDataSlice/stakingDataSlice.test.ts
@@ -28,9 +28,11 @@ const cosmosAssetId = 'cosmos:cosmoshub-4/slip44:118'
 const SHAPESHIFT_VALIDATOR_ADDRESS = 'cosmosvaloper199mlc7fr6ll5t54w7tts7f4s0cvnqgc59nmuxf'
 
 describe('stakingDataSlice', () => {
+  const consoleInfoSpy = jest.spyOn(console, 'info').mockImplementation(() => void 0)
   beforeEach(() => {
     clearState()
   })
+  afterAll(() => consoleInfoSpy.mockRestore())
 
   it('returns uninitialized properties for initialState', async () => {
     expect(store.getState().stakingData).toEqual({

--- a/src/state/slices/txHistorySlice/txHistorySlice.test.ts
+++ b/src/state/slices/txHistorySlice/txHistorySlice.test.ts
@@ -9,9 +9,11 @@ import { RebasesState, TxHistory, txHistory, TxsState } from './txHistorySlice'
 import { makeUniqueTxId } from './utils'
 
 describe('txHistorySlice', () => {
+  const consoleInfoSpy = jest.spyOn(console, 'info').mockImplementation(() => void 0)
   beforeAll(() => {
     jest.resetModules()
   })
+  afterAll(() => consoleInfoSpy.mockRestore())
 
   it('returns empty object for initialState', async () => {
     expect(store.getState().txHistory).toEqual({

--- a/src/state/slices/txHistorySlice/txHistorySlice.ts
+++ b/src/state/slices/txHistorySlice/txHistorySlice.ts
@@ -220,7 +220,10 @@ export const txHistory = createSlice({
   name: 'txHistory',
   initialState,
   reducers: {
-    clear: () => initialState,
+    clear: () => {
+      console.info('txHistorySlice: clearing tx history')
+      return initialState
+    },
     setStatus: (state, { payload }: TxHistoryStatusPayload) => {
       state.txs.status = payload
     },


### PR DESCRIPTION
## Description

<!-- Please describe your changes -->

**please note - this is only 200 lines but extremely terse, fragile, and core business logic in the app**

we're currently subscribing to txs multiple times and unsubbing multiple times - this was identified symptomatically while cosmos staking was being tested and uncovered more serious issues.

this PR solidifies how we manage wallet connection/switching/disconnection, to ensure we don't have any websocket related issues with the tx history, and also ensure we clear the portfolio when a wallet is disconnected/swapped.

* fixes bug where we'd reset account specifiers and unsub transactions every time we navigated to an account page
* changes the order of the transaction and portfolio providers for more logical order of actions (see console logging for the result)
* adds debugging logic that needs to stay in plugin manager, account specifiers, portfolio, and tx history slicers/reducers, so we can identify if changes in future cause regressions
* handle and heavily comment wallet switching/disconnection logic in portfolio
* adds state machine to track tx subscription state, as we can't get this state from chain adapters
* correctly unsubscribes and clears tx history on wallet switch/disconnect
* changes the tx subscription logic to wait for all accounts to be loaded from all chains, before subscribing to txs, as otherwise we'd subscribe multiple times
* changes the tx subscription logic from `for await (chain of chains)` to `await Promise.all` so all chains subscribe simultaneously - as a result txs load significantly faster
* lowers tx history loading "guess" delay from 10s to 5s as we now subscribe concurrently
* removes unsubscribe tx history logic from hook and manages separately with logging
* fixes typo in `walletSupportsChain` function
* memoizes several selectors to prevent unnecessary triggers of effect logic
* adds a `selectIsPortfolioLoaded` function with some pretty terse logic required to know when to subscribe to txs
* simplifies and consolidates some portfolio utility functions

this also highlights the need for a few things in chain adapters

* we need a function `getWalletSupportedChains(wallet: HDWallet) => CAIP2[]`
* we need a function `getSupportChainIds() => CAIP2[]`
* we need a function `getSubscriptions() => string[]` to query the current state of subscribe websockets

## Notice

<!-- Before submitting a pull request, please make sure you have answered the following: -->

- [x] Have you followed the guidelines in our [Contributing]('https://github.com/shapeshift/web/CONTRIBUTING.md) guide?
- [x] Have you checked to ensure there aren't other open [Pull Requests](https://github.com/shapeshift/web/pulls) for the same update/change?

## Pull Request Type

- [x] :bug: Bug fix (Non-breaking Change: Fixes an issue)
- [x] :hammer_and_wrench: Chore (Non-breaking Change: Doc updates, pkg upgrades, typos, etc..)
- [ ] :nail_care: New Feature (Breaking/Non-breaking Change)

## Issue (if applicable)

<!-----------------------------------------------------------------------------
If applicable, please link to the github issue and put `closes #XXXX` in your comment to auto-close the issue that your PR fixes.
------------------------------------------------------------------------------>

n/a - fixes technical regression/core engineering

## Risk

<!-----------------------------------------------------------------------------
Outline the scope of your changes and the risk associated with them. You must use your discretion as an engineer to determine the potential impact of your changes.

E.g. an upgrade to `hdwallet` or core state management would be considered higher risk, and might require a full regression test. UI or isolated view changes, or something behind a feature flag may have near zero risk. Small bug fixes might require testing isolated to the specific fix.
------------------------------------------------------------------------------>

this makes significant changes to the portfolio and transactions provider. i've tested extensively but encourage reviewers to test this locally with the console open. watch the websockets and console as you connect, switch, disconnect wallets. try and break this as much as possible.

open to a huge amount of scrutiny here - but i'm confident this is much better than before.

## Testing

<!-----------------------------------------------------------------------------
If your testing steps are technical, outline steps for an engineer to verify.

If your testing steps are functional, please provide a full guide with any features requiring special attention for operations to test your branch in the preview environment.
------------------------------------------------------------------------------>

operations - please connect/switch/disconnect wallets and report any abnormal behaviour.
engineering - review in person or rip me a new one here.

## Screenshots (if applicable)

no user facing changes - should fix bugs where we were erroneously unsubscribing from transaction history.