### PR TITLE
fix: collapse drawer when menu item is clicked

### DIFF
--- a/src/components/Layout/Header/Header.tsx
+++ b/src/components/Layout/Header/Header.tsx
@@ -20,7 +20,7 @@ import { UserMenu } from './NavBar/UserMenu'
 import { SideNavContent } from './SideNavContent'
 
 export const Header = () => {
-  const { onToggle, isOpen, onClose } = useDisclosure({ id: 'navDrawer' })
+  const { onToggle, isOpen, onClose } = useDisclosure()
   const history = useHistory()
   const bg = useColorModeValue('white', 'gray.800')
   const borderColor = useColorModeValue('gray.100', 'gray.750')

--- a/src/components/Layout/Header/Header.tsx
+++ b/src/components/Layout/Header/Header.tsx
@@ -20,7 +20,7 @@ import { UserMenu } from './NavBar/UserMenu'
 import { SideNavContent } from './SideNavContent'
 
 export const Header = () => {
-  const { onToggle, isOpen, onClose } = useDisclosure()
+  const { onToggle, isOpen, onClose } = useDisclosure({ id: 'navDrawer' })
   const history = useHistory()
   const bg = useColorModeValue('white', 'gray.800')
   const borderColor = useColorModeValue('gray.100', 'gray.750')
@@ -94,7 +94,7 @@ export const Header = () => {
       <Drawer isOpen={isOpen} onClose={onClose} placement='left'>
         <DrawerOverlay />
         <DrawerContent>
-          <SideNavContent />
+          <SideNavContent onClose={onClose} />
         </DrawerContent>
       </Drawer>
     </>

--- a/src/components/Layout/Header/NavBar/UserMenu.tsx
+++ b/src/components/Layout/Header/NavBar/UserMenu.tsx
@@ -128,11 +128,12 @@ const WalletButton: FC<WalletButtonProps> = ({
   )
 }
 
-export const UserMenu = () => {
+export const UserMenu: React.FC<{ onClick?: () => void }> = ({ onClick }) => {
   const { state, dispatch, disconnect } = useWallet()
   const { isConnected, walletInfo, type } = state
   const hasWallet = Boolean(walletInfo?.deviceId)
   const handleConnect = () => {
+    onClick && onClick()
     dispatch({ type: WalletActions.SET_WALLET_MODAL, payload: true })
   }
 

--- a/src/components/Layout/Header/SideNavContent.tsx
+++ b/src/components/Layout/Header/SideNavContent.tsx
@@ -38,7 +38,7 @@ export const SideNavContent = ({ isCompact, onClose }: HeaderContentProps) => {
       {!isLargerThanMd && (
         <>
           <Flex width='full'>
-            <UserMenu onClick={() => handleClick} />
+            <UserMenu onClick={() => handleClick()} />
           </Flex>
           <Flex width='full' mt={4}>
             <FiatRamps />

--- a/src/components/Layout/Header/SideNavContent.tsx
+++ b/src/components/Layout/Header/SideNavContent.tsx
@@ -64,7 +64,7 @@ export const SideNavContent = ({ isCompact, onClose }: HeaderContentProps) => {
           as={Link}
           justifyContent='flex-start'
           variant='ghost'
-          onClick={() => handleClick}
+          onClick={() => handleClick()}
           label={translate('common.submitFeedback')}
           isExternal
           href='https://shapeshift.notion.site/Submit-Feedback-or-a-Feature-Request-af48a25fea574da4a05a980c347c055b'

--- a/src/components/Layout/Header/SideNavContent.tsx
+++ b/src/components/Layout/Header/SideNavContent.tsx
@@ -12,12 +12,18 @@ import { UserMenu } from './NavBar/UserMenu'
 
 type HeaderContentProps = {
   isCompact?: boolean
+  onClose?: () => void
 } & FlexProps
 
-export const SideNavContent = ({ isCompact }: HeaderContentProps) => {
+export const SideNavContent = ({ isCompact, onClose }: HeaderContentProps) => {
   const translate = useTranslate()
   const [isLargerThanMd] = useMediaQuery(`(min-width: ${breakpoints['md']})`)
   const { settings } = useModal()
+
+  const handleClick = (onClick?: () => void) => {
+    onClose && onClose()
+    onClick && onClick()
+  }
 
   return (
     <Flex
@@ -32,7 +38,7 @@ export const SideNavContent = ({ isCompact }: HeaderContentProps) => {
       {!isLargerThanMd && (
         <>
           <Flex width='full'>
-            <UserMenu />
+            <UserMenu onClick={() => handleClick} />
           </Flex>
           <Flex width='full' mt={4}>
             <FiatRamps />
@@ -48,7 +54,7 @@ export const SideNavContent = ({ isCompact }: HeaderContentProps) => {
         <MainNavLink
           variant='ghost'
           isCompact={isCompact}
-          onClick={() => settings.open({})}
+          onClick={() => handleClick(() => settings.open({}))}
           label={translate('common.settings')}
           leftIcon={<SettingsIcon />}
         />
@@ -58,6 +64,7 @@ export const SideNavContent = ({ isCompact }: HeaderContentProps) => {
           as={Link}
           justifyContent='flex-start'
           variant='ghost'
+          onClick={() => handleClick}
           label={translate('common.submitFeedback')}
           isExternal
           href='https://shapeshift.notion.site/Submit-Feedback-or-a-Feature-Request-af48a25fea574da4a05a980c347c055b'


### PR DESCRIPTION
## Description

- when the drawer is open its trapping focus so we need to collapse it whenever you click on a menu item
- Pass down the onClose from the useDisclosure
- Add a helper handleClick function that fires the onClose and the onClick

## Notice

<!-- Before submitting a pull request, please make sure you have answered the following: -->

- [x] Have you followed the guidelines in our [Contributing]('https://github.com/shapeshift/web/CONTRIBUTING.md) guide?
- [x] Have you checked to ensure there aren't other open [Pull Requests](https://github.com/shapeshift/web/pulls) for the same update/change?

## Pull Request Type

- [x] :bug: Bug fix (Non-breaking Change: Fixes an issue)
- [ ] :hammer_and_wrench: Chore (Non-breaking Change: Doc updates, pkg upgrades, typos, etc..)
- [ ] :nail_care: New Feature (Breaking/Non-breaking Change)

## Issue (if applicable)

closes #1400 

## Risk

Small risk

## Testing

Click on a switch wallet or submit feedback/settings the drawer should collapse giving focus to whatever menu you just clicked.

## Screenshots (if applicable)
