### PR TITLE
fix: double gas fee deduction

### DIFF
--- a/src/components/Trade/TradeInput.tsx
+++ b/src/components/Trade/TradeInput.tsx
@@ -86,7 +86,7 @@ export const TradeInput = ({ history }: RouterProps) => {
   const hasEnoughBalanceForGas = bnOrZero(feeAssetBalance)
     .minus(bnOrZero(estimatedGasFees))
     .minus(tradeDeduction)
-    .gt(0)
+    .gte(0)
 
   const onSubmit = async () => {
     if (!wallet) return

--- a/src/components/Trade/TradeInput.tsx
+++ b/src/components/Trade/TradeInput.tsx
@@ -130,12 +130,7 @@ export const TradeInput = ({ history }: RouterProps) => {
     if (!wallet) return
     try {
       setIsSendMaxLoading(true)
-      const maxSendAmount = await getSendMaxAmount({
-        wallet,
-        sellAsset,
-        buyAsset,
-        feeAsset,
-      })
+      const maxSendAmount = await getSendMaxAmount({ wallet, sellAsset, buyAsset })
       const action = TradeActions.SELL
       const currentSellAsset = getValues('sellAsset')
       const currentBuyAsset = getValues('buyAsset')

--- a/src/components/Trade/TradeInput.tsx
+++ b/src/components/Trade/TradeInput.tsx
@@ -130,7 +130,12 @@ export const TradeInput = ({ history }: RouterProps) => {
     if (!wallet) return
     try {
       setIsSendMaxLoading(true)
-      const maxSendAmount = await getSendMaxAmount({ wallet, sellAsset, buyAsset })
+      const maxSendAmount = await getSendMaxAmount({
+        wallet,
+        sellAsset,
+        buyAsset,
+        feeAsset,
+      })
       const action = TradeActions.SELL
       const currentSellAsset = getValues('sellAsset')
       const currentBuyAsset = getValues('buyAsset')

--- a/src/components/Trade/TradeInput.tsx
+++ b/src/components/Trade/TradeInput.tsx
@@ -80,7 +80,7 @@ export const TradeInput = ({ history }: RouterProps) => {
   // when trading from ETH, the value of TX in ETH is deducted
   const tradeDeduction =
     sellAsset && feeAsset && feeAsset.caip19 === sellAsset.currency.caip19
-      ? bnOrZero(estimatedGasFees).plus(bnOrZero(sellAsset.amount))
+      ? bnOrZero(sellAsset.amount)
       : bnOrZero(0)
 
   const hasEnoughBalanceForGas = bnOrZero(feeAssetBalance)

--- a/src/components/Trade/hooks/useSwapper/useSwapper.ts
+++ b/src/components/Trade/hooks/useSwapper/useSwapper.ts
@@ -93,12 +93,10 @@ export const useSwapper = () => {
     wallet,
     sellAsset,
     buyAsset,
-    feeAsset,
   }: {
     wallet: HDWallet
     sellAsset: TradeAsset
     buyAsset: TradeAsset
-    feeAsset: Asset | undefined
   }) => {
     const swapper = swapperManager.getSwapper(bestSwapperType)
     const { minimum: minimumAmount } = await swapper?.getMinMax({
@@ -119,21 +117,11 @@ export const useSwapper = () => {
 
     if (!minimumQuote) return
 
-    const { estimatedGasFees } = getValues()
-
-    // when trading from ETH, the estimated gas fee is deducted
-    const gasFeesDeduction =
-      sellAsset && feeAsset && feeAsset.caip19 === sellAsset.currency.caip19
-        ? bnOrZero(estimatedGasFees)
-        : bnOrZero(0)
-
-    const sendMaxAmount = bnOrZero(
-      await swapper.getSendMaxAmount({
-        wallet,
-        quote: minimumQuote,
-        sellAssetAccountId: '0', // TODO: remove hard coded accountId when multiple accounts are implemented
-      }),
-    ).minus(gasFeesDeduction)
+    const sendMaxAmount = await swapper.getSendMaxAmount({
+      wallet,
+      quote: minimumQuote,
+      sellAssetAccountId: '0', // TODO: remove hard coded accountId when multiple accounts are implemented
+    })
 
     const formattedMaxAmount = fromBaseUnit(sendMaxAmount, sellAsset.currency.precision)
 

--- a/src/components/Trade/hooks/useSwapper/useSwapper.ts
+++ b/src/components/Trade/hooks/useSwapper/useSwapper.ts
@@ -93,10 +93,12 @@ export const useSwapper = () => {
     wallet,
     sellAsset,
     buyAsset,
+    feeAsset,
   }: {
     wallet: HDWallet
     sellAsset: TradeAsset
     buyAsset: TradeAsset
+    feeAsset: Asset | undefined
   }) => {
     const swapper = swapperManager.getSwapper(bestSwapperType)
     const { minimum: minimumAmount } = await swapper?.getMinMax({
@@ -117,11 +119,21 @@ export const useSwapper = () => {
 
     if (!minimumQuote) return
 
-    const sendMaxAmount = await swapper.getSendMaxAmount({
-      wallet,
-      quote: minimumQuote,
-      sellAssetAccountId: '0', // TODO: remove hard coded accountId when multiple accounts are implemented
-    })
+    const { estimatedGasFees } = getValues()
+
+    // when trading from ETH, the estimated gas fee is deducted
+    const gasFeesDeduction =
+      sellAsset && feeAsset && feeAsset.caip19 === sellAsset.currency.caip19
+        ? bnOrZero(estimatedGasFees)
+        : bnOrZero(0)
+
+    const sendMaxAmount = bnOrZero(
+      await swapper.getSendMaxAmount({
+        wallet,
+        quote: minimumQuote,
+        sellAssetAccountId: '0', // TODO: remove hard coded accountId when multiple accounts are implemented
+      }),
+    ).minus(gasFeesDeduction)
 
     const formattedMaxAmount = fromBaseUnit(sendMaxAmount, sellAsset.currency.precision)
 


### PR DESCRIPTION
## Description

Fix double gas fee deduction. The gas fees are deducted here: https://github.com/shapeshift/web/blob/ddd08bad9526f8e67109ef4c49298ddf4d62686b/src/components/Trade/TradeInput.tsx#L86-L89
and the `estimatedGasFees` was also added to `tradeDeduction`, which resulted in double gas fee deduction in gas check.

## Notice

- [x] Have you followed the guidelines in our [Contributing]('https://github.com/shapeshift/web/CONTRIBUTING.md) guide?
- [x] Have you checked to ensure there aren't other open [Pull Requests](https://github.com/shapeshift/web/pulls) for the same update/change?

## Pull Request Type

- [x] :bug: Bug fix (Non-breaking Change: Fixes an issue)
- [ ] :hammer_and_wrench: Chore (Non-breaking Change: Doc updates, pkg upgrades, typos, etc..)
- [ ] :nail_care: New Feature (Breaking/Non-breaking Change)

## Risk
I don't think anyone would really want to trade all of their ETH for other ERC-20 token because they won't have gas for trading it back, but the same risk also applies now, if the gas fees increase. The above `tradeDeduction` comment says "when trading from ETH, the value of TX in ETH is deducted", and nothing about double fee deduction, so that's not the intended behavior.

## Testing

Try to trade `your all eth - estimated gas fee` for any other token, and you'll get "Not enough ETH to cover gas".
