### PR TITLE
fix: cosmos balance on asset and account pages

### DIFF
--- a/src/components/AssetAccounts/AssetAccountRow.tsx
+++ b/src/components/AssetAccounts/AssetAccountRow.tsx
@@ -20,8 +20,8 @@ import { accountIdToFeeAssetId, accountIdToLabel } from 'state/slices/portfolioS
 import {
   selectAssetByCAIP19,
   selectPortfolioAllocationPercentByFilter,
-  selectPortfolioCryptoHumanBalanceByFilter,
-  selectPortfolioFiatBalanceByFilter,
+  selectTotalCryptoBalanceWithDelegations,
+  selectTotalFiatBalanceWithDelegations,
 } from 'state/slices/selectors'
 import { useAppSelector } from 'state/store'
 import { breakpoints } from 'theme/theme'
@@ -51,9 +51,9 @@ export const AssetAccountRow = ({
   const asset = useAppSelector(state => selectAssetByCAIP19(state, rowAssetId))
   const feeAsset = useAppSelector(state => selectAssetByCAIP19(state, feeAssetId))
   const filter = useMemo(() => ({ assetId: rowAssetId, accountId }), [rowAssetId, accountId])
-  const fiatBalance = useAppSelector(state => selectPortfolioFiatBalanceByFilter(state, filter))
+  const fiatBalance = useAppSelector(state => selectTotalFiatBalanceWithDelegations(state, filter))
   const cryptoHumanBalance = useAppSelector(state =>
-    selectPortfolioCryptoHumanBalanceByFilter(state, filter),
+    selectTotalCryptoBalanceWithDelegations(state, filter),
   )
   const allocation = useAppSelector(state =>
     selectPortfolioAllocationPercentByFilter(state, { accountId, assetId: rowAssetId }),

--- a/src/components/AssetHeader/AssetChart.tsx
+++ b/src/components/AssetHeader/AssetChart.tsx
@@ -135,7 +135,7 @@ export const AssetChart = ({ accountId, assetId, isLoaded }: AssetChartProps) =>
               </Stat>
             )}
           </StatGroup>
-          {bnOrZero(delegationBalance).gt(0) && (
+          {bnOrZero(delegationBalance).gt(0) && view === View.Balance && (
             <Flex mt={4}>
               <Alert
                 as={Stack}

--- a/src/state/slices/portfolioSlice/portfolioSlice.test.ts
+++ b/src/state/slices/portfolioSlice/portfolioSlice.test.ts
@@ -3,12 +3,14 @@ import {
   btcAddresses,
   btcCaip10s,
   btcPubKeys,
+  cosmosCaip19,
   ethCaip10s,
   ethCaip19,
   ethPubKeys,
   foxCaip19,
   mockBtcAccount,
   mockBtcAddress,
+  mockCosmosAccount,
   mockEthAccount,
   mockETHandBTCAccounts,
   mockEthToken,
@@ -19,13 +21,15 @@ import {
   yvusdcCaip19,
   zeroCaip19,
 } from 'test/mocks/accounts'
-import { mockAssetState } from 'test/mocks/assets'
+import { cosmos, mockAssetState } from 'test/mocks/assets'
 import { mockMarketData } from 'test/mocks/marketData'
 import { mockUpsertPortfolio } from 'test/mocks/portfolio'
+import { mockStakingData, mockStakingDataWithOnlyUndelegations } from 'test/mocks/stakingData'
 import { createStore } from 'state/store'
 
 import { assets as assetsSlice } from '../assetsSlice/assetsSlice'
 import { marketData as marketDataSlice } from '../marketDataSlice/marketDataSlice'
+import { stakingData as stakingDataSlice } from '../stakingDataSlice/stakingDataSlice'
 import { portfolio as portfolioSlice } from './portfolioSlice'
 import {
   selectAccountIdByAddress,
@@ -40,6 +44,7 @@ import {
   selectPortfolioFiatAccountBalances,
   selectPortfolioFiatBalanceByFilter,
   selectPortfolioTotalFiatBalanceByAccount,
+  selectTotalFiatBalanceWithDelegations,
 } from './selectors'
 
 describe('portfolioSlice', () => {
@@ -771,6 +776,134 @@ describe('portfolioSlice', () => {
       it('should return correct portfolio rows in case of 100% allocation on one asset', () => {
         const result = selectPortfolioAccountRows(state)
         expect(result).toMatchSnapshot()
+      })
+    })
+
+    describe('selectTotalFiatBalanceWithDelegations', () => {
+      const cosmosAccountSpecifier: string =
+        'cosmos:cosmoshub-4:cosmos1wc4rv7dv8lafv38s50pfp5qsgv7eknetyml669'
+
+      it('should return correct fiat balance in case there are delegations, undelegations and asset balance', () => {
+        const store = createStore()
+        const assetData = mockAssetState({
+          byId: {
+            [cosmos.caip19]: cosmos,
+          },
+          ids: [cosmos.caip19],
+        })
+        store.dispatch(assetsSlice.actions.setAssets(assetData))
+
+        const cosmosMarketData = mockMarketData({ price: '77.55' })
+        store.dispatch(
+          marketDataSlice.actions.setMarketData({
+            [cosmos.caip19]: cosmosMarketData,
+          }),
+        )
+
+        const cosmosAccount = mockCosmosAccount()
+
+        store.dispatch(
+          portfolioSlice.actions.upsertPortfolio(
+            mockUpsertPortfolio([cosmosAccount], [cosmosCaip19]),
+          ),
+        )
+
+        store.dispatch(
+          stakingDataSlice.actions.upsertStakingData({
+            accountSpecifier: cosmosAccountSpecifier,
+            stakingData: mockStakingData,
+          }),
+        )
+
+        const result = selectTotalFiatBalanceWithDelegations(store.getState(), {
+          assetId: cosmosCaip19,
+          accountId: cosmosAccountSpecifier,
+        })
+        expect(result).toEqual('1.25002845')
+      })
+
+      it('should return correct fiat balance in case there are delegations and undelegations but no asset balance', () => {
+        const store = createStore()
+        const assetData = mockAssetState({
+          byId: {
+            [cosmos.caip19]: cosmos,
+          },
+          ids: [cosmos.caip19],
+        })
+        store.dispatch(assetsSlice.actions.setAssets(assetData))
+
+        const cosmosMarketData = mockMarketData({ price: '77.55' })
+        store.dispatch(
+          marketDataSlice.actions.setMarketData({
+            [cosmos.caip19]: cosmosMarketData,
+          }),
+        )
+        store.dispatch(
+          stakingDataSlice.actions.upsertStakingData({
+            accountSpecifier: cosmosAccountSpecifier,
+            stakingData: mockStakingData,
+          }),
+        )
+
+        const result = selectTotalFiatBalanceWithDelegations(store.getState(), {
+          assetId: cosmosCaip19,
+          accountId: cosmosAccountSpecifier,
+        })
+        expect(result).toEqual('1.17247845')
+      })
+
+      it('should return non zero fiat balance in case there are only undelegations', () => {
+        const store = createStore()
+        const assetData = mockAssetState({
+          byId: {
+            [cosmos.caip19]: cosmos,
+          },
+          ids: [cosmos.caip19],
+        })
+        store.dispatch(assetsSlice.actions.setAssets(assetData))
+
+        const cosmosMarketData = mockMarketData({ price: '77.55' })
+        store.dispatch(
+          marketDataSlice.actions.setMarketData({
+            [cosmos.caip19]: cosmosMarketData,
+          }),
+        )
+        store.dispatch(
+          stakingDataSlice.actions.upsertStakingData({
+            accountSpecifier: cosmosAccountSpecifier,
+            stakingData: mockStakingDataWithOnlyUndelegations,
+          }),
+        )
+
+        const result = selectTotalFiatBalanceWithDelegations(store.getState(), {
+          assetId: cosmosCaip19,
+          accountId: cosmosAccountSpecifier,
+        })
+        expect(result).toEqual('0.0271425')
+      })
+
+      it('should return zero fiat balance in case there are no delegations nor asset balance', () => {
+        const store = createStore()
+        const assetData = mockAssetState({
+          byId: {
+            [cosmos.caip19]: cosmos,
+          },
+          ids: [cosmos.caip19],
+        })
+        store.dispatch(assetsSlice.actions.setAssets(assetData))
+
+        const cosmosMarketData = mockMarketData({ price: '77.55' })
+        store.dispatch(
+          marketDataSlice.actions.setMarketData({
+            [cosmos.caip19]: cosmosMarketData,
+          }),
+        )
+
+        const result = selectTotalFiatBalanceWithDelegations(store.getState(), {
+          assetId: cosmosCaip19,
+          accountId: cosmosAccountSpecifier,
+        })
+        expect(result).toEqual('0')
       })
     })
   })

--- a/src/state/slices/stakingDataSlice/selectors.ts
+++ b/src/state/slices/stakingDataSlice/selectors.ts
@@ -81,8 +81,8 @@ export const selectStakingDataByFilter = createSelector(
   selectAssetIdParamFromFilterOptional,
   selectAccountIdParamFromFilterOptional,
   (stakingData, _, accountId) => {
-    if (!accountId) return null
-    return stakingData.byAccountSpecifier[accountId] || null
+    if (!accountId) return Object.values(stakingData.byAccountSpecifier)
+    return [stakingData.byAccountSpecifier[accountId]] || null
   },
 )
 
@@ -110,8 +110,27 @@ export const selectTotalStakingDelegationCryptoByFilter = createSelector(
   // In the future there may be chains that support rewards in multiple denoms and this will need to be parsed differently
   (stakingData, assetId, _, assets) => {
     const amount = reduce(
-      stakingData?.delegations,
-      (acc, delegation) => acc.plus(bnOrZero(delegation.amount)),
+      stakingData,
+      (acc, singleStakingData) => {
+        const amountDelegations = reduce(
+          singleStakingData?.delegations,
+          (acc, delegation) => acc.plus(bnOrZero(delegation.amount)),
+          bn(0),
+        )
+
+        const amountUndelegations = reduce(
+          singleStakingData?.undelegations,
+          (acc, undelegation) => {
+            undelegation.entries.forEach(undelegationEntry => {
+              acc = acc.plus(bnOrZero(undelegationEntry.amount))
+            })
+            return acc
+          },
+          bn(0),
+        )
+
+        return acc.plus(amountDelegations).plus(amountUndelegations)
+      },
       bn(0),
     )
 

--- a/src/state/slices/stakingDataSlice/selectors.ts
+++ b/src/state/slices/stakingDataSlice/selectors.ts
@@ -14,7 +14,7 @@ import { selectMarketData } from 'state/slices/marketDataSlice/selectors'
 import { accountIdToFeeAssetId } from 'state/slices/portfolioSlice/utils'
 
 import { AccountSpecifier } from '../accountSpecifiersSlice/accountSpecifiersSlice'
-import { PubKey } from './stakingDataSlice'
+import { PubKey, Staking } from './stakingDataSlice'
 export type ActiveStakingOpportunity = {
   address: PubKey
   moniker: string
@@ -76,11 +76,11 @@ export const selectStakingDataByAccountSpecifier = createSelector(
   },
 )
 
-export const selectStakingDataByFilter = createSelector(
+export const selectStakingDataByFilter = createDeepEqualOutputSelector(
   selectStakingData,
   selectAssetIdParamFromFilterOptional,
   selectAccountIdParamFromFilterOptional,
-  (stakingData, _, accountId) => {
+  (stakingData, _, accountId): Staking[] => {
     if (!accountId) return Object.values(stakingData.byAccountSpecifier)
     return [stakingData.byAccountSpecifier[accountId]] || null
   },

--- a/src/test/mocks/accounts.ts
+++ b/src/test/mocks/accounts.ts
@@ -15,6 +15,9 @@ export const unknown3Caip19 = 'eip155:1/erc20:0xecd18dbba2987608c094ed552fef3924
 export const btcCaip2 = 'bip122:000000000019d6689c085ae165831e93'
 export const btcCaip19 = 'bip122:000000000019d6689c085ae165831e93/slip44:0'
 
+export const cosmosCaip2 = 'cosmos:cosmoshub-4'
+export const cosmosCaip19 = 'cosmos:cosmoshub-4/slip44:118'
+
 export const assetIds = [ethCaip19, foxCaip19, usdcCaip19, yvusdcCaip19, zeroCaip19]
 
 export const btcCaip10s = Object.freeze([
@@ -49,6 +52,8 @@ export const btcAddresses = Object.freeze([
   'bc1q4cqvc3ul562uuz358y77hmqhlfex8jhvfzzek8',
 ])
 
+export const cosmosPubKeys = Object.freeze(['cosmos1wc4rv7dv8lafv38s50pfp5qsgv7eknetyml669'])
+
 export const mockEthToken = (obj?: { balance?: string; caip19?: string }) => ({
   balance: '100',
   caip19: foxCaip19,
@@ -67,6 +72,27 @@ export const mockEthAccount = (obj?: Partial<chainAdapters.Account<ChainTypes.Et
         nonce: 1,
       },
       pubkey: ethPubKeys[0],
+    },
+    obj,
+  )
+
+export const mockCosmosAccount = (obj?: Partial<chainAdapters.Account<ChainTypes.Cosmos>>) =>
+  merge(
+    {},
+    {
+      balance: '1000',
+      caip2: cosmosCaip2,
+      caip19: cosmosCaip19,
+      chain: ChainTypes.Cosmos,
+      chainSpecific: {
+        sequence: '',
+        accountNumber: '',
+        delegations: [],
+        redelegations: [],
+        undelegations: [],
+        rewards: [],
+      },
+      pubkey: cosmosPubKeys[0],
     },
     obj,
   )

--- a/src/test/mocks/portfolio.ts
+++ b/src/test/mocks/portfolio.ts
@@ -3,13 +3,17 @@ import { accountToPortfolio } from 'state/slices/portfolioSlice/utils'
 
 // Creates a mock portfolio
 export const mockUpsertPortfolio = (
-  accounts: chainAdapters.Account<ChainTypes.Ethereum | ChainTypes.Bitcoin>[],
+  accounts: chainAdapters.Account<ChainTypes.Ethereum | ChainTypes.Bitcoin | ChainTypes.Cosmos>[],
   assetIds: string[],
 ) => {
   const portfolioAccounts = accounts.reduce(
     (
-      acc: { [k: string]: chainAdapters.Account<ChainTypes.Ethereum | ChainTypes.Bitcoin> },
-      account: chainAdapters.Account<ChainTypes.Ethereum | ChainTypes.Bitcoin>,
+      acc: {
+        [k: string]: chainAdapters.Account<
+          ChainTypes.Ethereum | ChainTypes.Bitcoin | ChainTypes.Cosmos
+        >
+      },
+      account: chainAdapters.Account<ChainTypes.Ethereum | ChainTypes.Bitcoin | ChainTypes.Cosmos>,
     ) => {
       acc[account.pubkey] = account
       return acc


### PR DESCRIPTION
## Description

This fixes the cosmos balance on asset and account pages which were different (staked amount not included).
This also removes the display of staked amount in case of price chart (now it is only showing the staked amount in case of balance chart).

It is possible there is still another bug, related to the cosmos balance displayed on dashboard. I preferred not to try to fix it since there is a big refactoring going on in https://github.com/shapeshift/web/pull/1479, the fix would probably be pretty ugly right now and hopefully more straightforward to do with the refactoring code.

## Notice

<!-- Before submitting a pull request, please make sure you have answered the following: -->

- [X] Have you followed the guidelines in our [Contributing]('https://github.com/shapeshift/web/CONTRIBUTING.md) guide?
- [X] Have you checked to ensure there aren't other open [Pull Requests](https://github.com/shapeshift/web/pulls) for the same update/change?

## Pull Request Type

- [X] :bug: Bug fix (Non-breaking Change: Fixes an issue)
- [ ] :hammer_and_wrench: Chore (Non-breaking Change: Doc updates, pkg upgrades, typos, etc..)
- [ ] :nail_care: New Feature (Breaking/Non-breaking Change)

## Issue (if applicable)

<!-----------------------------------------------------------------------------
If applicable, please link to the github issue and put `closes #XXXX` in your comment to auto-close the issue that your PR fixes.
------------------------------------------------------------------------------>
closes #1541

## Risk

<!-----------------------------------------------------------------------------
Outline the scope of your changes and the risk associated with them. You must use your discretion as an engineer to determine the potential impact of your changes.

E.g. an upgrade to `hdwallet` or core state management would be considered higher risk, and might require a full regression test. UI or isolated view changes, or something behind a feature flag may have near zero risk. Small bug fixes might require testing isolated to the specific fix.
------------------------------------------------------------------------------>

Code for one selector used widely on asset chart pages has been changed, so it is probably better to do some regression testing on differents assets for their asset chart.

## Testing

<!-----------------------------------------------------------------------------
If your testing steps are technical, outline steps for an engineer to verify.

If your testing steps are functional, please provide a full guide with any features requiring special attention for operations to test your branch in the preview environment.
------------------------------------------------------------------------------>

- Go to cosmos account and assets pages
- Verify balances and staked amount are the same
- Verify staked amount does not appear on price chart

## Screenshots (if applicable)

![accounts](https://user-images.githubusercontent.com/5720927/164513163-74725bc9-df06-4139-ae1f-e9eb661ecf92.png)

![account](https://user-images.githubusercontent.com/5720927/164513176-cc75c7e0-e98f-4bb1-b868-22951ea2a8f9.png)

![asset](https://user-images.githubusercontent.com/5720927/164513187-df1bcabb-343d-4f2e-93ca-338b5751e614.png)

