### PR TITLE
fix(TradeInput): max ETH Trade bug covering gas

### DIFF
--- a/src/components/Trade/TradeInput.tsx
+++ b/src/components/Trade/TradeInput.tsx
@@ -130,7 +130,13 @@ export const TradeInput = ({ history }: RouterProps) => {
     if (!wallet) return
     try {
       setIsSendMaxLoading(true)
-      const maxSendAmount = await getSendMaxAmount({ wallet, sellAsset, buyAsset })
+      const maxSendAmount = await getSendMaxAmount({
+        wallet,
+        sellAsset,
+        buyAsset,
+        feeAsset,
+        estimatedGasFees,
+      })
       const action = TradeActions.SELL
       const currentSellAsset = getValues('sellAsset')
       const currentBuyAsset = getValues('buyAsset')


### PR DESCRIPTION
## Description

Fixed error affecting the Max option while trading ETH to include gas fees, moved gas estimation to be included before value is populated in input.


## Notice

<!-- Before submitting a pull request, please make sure you have answered the following: -->

- [x] Have you followed the guidelines in our [Contributing]('https://github.com/shapeshift/web/CONTRIBUTING.md) guide?
- [x] Have you checked to ensure there aren't other open [Pull Requests](https://github.com/shapeshift/web/pulls) for the same update/change?

## Pull Request Type

- [x] :bug: Bug fix (Non-breaking Change: Fixes an issue)
- [ ] :hammer_and_wrench: Chore (Non-breaking Change: Doc updates, pkg upgrades, typos, etc..)
- [ ] :nail_care: New Feature (Breaking/Non-breaking Change)

## Issue (if applicable)

closes #1280 
<!-----------------------------------------------------------------------------
If applicable, please link to the github issue and put `closes #XXXX` in your comment to auto-close the issue that your PR fixes.
------------------------------------------------------------------------------>

## Risk

<!-----------------------------------------------------------------------------
Outline the scope of your changes and the risk associated with them. You must use your discretion as an engineer to determine the potential impact of your changes.

E.g. an upgrade to `hdwallet` or core state management would be considered higher risk, and might require a full regression test. UI or isolated view changes, or something behind a feature flag may have near zero risk. Small bug fixes might require testing isolated to the specific fix.
------------------------------------------------------------------------------>

To risks that I'm aware of.

## Testing

<!-----------------------------------------------------------------------------
If your testing steps are technical, outline steps for an engineer to verify.

If your testing steps are functional, please provide a full guide with any features requiring special attention for operations to test your branch in the preview environment.
------------------------------------------------------------------------------>
(Tested using MetaMask on ETH Mainnet
1. Go to the trade widget toward the upper left hand side of the screen.
2. With ETH selected as the input asset, click the max send button.

## Screenshots (if applicable)
https://user-images.githubusercontent.com/14836056/164548521-7d553bb8-f214-4071-a81b-8f086de1d9fa.mov