### PR TITLE
feat: add service-worker

### DIFF
--- a/src/index.tsx
+++ b/src/index.tsx
@@ -7,6 +7,7 @@ import { reportWebVitals } from 'lib/reportWebVitals'
 
 import { App } from './App'
 import { AppProviders } from './AppProviders'
+import * as serviceWorkerRegistration from './serviceWorkerRegistration'
 
 ReactDOM.render(
   <React.StrictMode>
@@ -16,6 +17,8 @@ ReactDOM.render(
   </React.StrictMode>,
   document.getElementById('root'),
 )
+
+serviceWorkerRegistration.register()
 
 // If you want to start measuring performance in your app, pass a function
 // to log results (for example: reportWebVitals(console.log))

--- a/src/service-worker.ts
+++ b/src/service-worker.ts
@@ -1,0 +1,37 @@
+/// <reference lib="webworker" />
+declare const self: ServiceWorkerGlobalScope &
+  typeof globalThis & { __WB_MANIFEST: { revision: string | null; url: string } }
+
+export {}
+
+// create-react-app calls workbox-webpack-plugin.InjectManifest by default
+// and will throw an error if __WEB_MANIFEST isn't referenced in the service worker file
+// eslint-disable-next-line @typescript-eslint/no-unused-vars
+const manifest = self.__WB_MANIFEST
+
+self.addEventListener('activate', () => self.clients.claim())
+
+self.addEventListener('install', event => {
+  console.info('ServiceWorker:install', event)
+  event.waitUntil(
+    (async () => {
+      try {
+        console.info('ServiceWorker:install:skipWaiting')
+        await self.skipWaiting()
+      } catch (e) {
+        console.error('ServiceWorker:install:Error', e)
+      }
+    })(),
+  )
+})
+
+self.addEventListener('message', event => {
+  console.info('ServiceWorker:message', event)
+  if (event.data && event.data.type === 'SKIP_WAITING') {
+    self.skipWaiting()
+  }
+})
+
+self.addEventListener('fetch', event => {
+  console.info('ServiceWorker:fetch', event)
+})

--- a/src/service-worker.ts
+++ b/src/service-worker.ts
@@ -32,6 +32,4 @@ self.addEventListener('message', event => {
   }
 })
 
-self.addEventListener('fetch', event => {
-  console.info('ServiceWorker:fetch', event)
-})
+self.addEventListener('fetch', event => {})

--- a/src/serviceWorkerRegistration.ts
+++ b/src/serviceWorkerRegistration.ts
@@ -97,7 +97,6 @@ export function register(callbacks?: ServiceWorkerCallbacks) {
 
     window.addEventListener('load', () => {
       const swUrl = `${process.env.PUBLIC_URL}/service-worker.js`
-      debugger
       if (isLocalhost) {
         // This is running on localhost. Let's check if a service worker still exists or not.
         void checkValidServiceWorker(swUrl, callbacks)

--- a/src/serviceWorkerRegistration.ts
+++ b/src/serviceWorkerRegistration.ts
@@ -1,0 +1,114 @@
+// The service-worker doesn't load when use `yarn dev`. You need to do a
+// `yarn build && http-server build` and serve up the compiled output
+
+type ServiceWorkerCallbacks = {
+  onSuccess?: (registration: ServiceWorkerRegistration) => void
+  onUpdate?: (registration: ServiceWorkerRegistration) => void
+}
+
+const isLocalhost = Boolean(
+  window.location.hostname === 'localhost' ||
+    // [::1] is the IPv6 localhost address.
+    window.location.hostname === '[::1]' ||
+    // 127.0.0.0/8 are considered localhost for IPv4.
+    window.location.hostname.match(/^127(?:\.(?:25[0-5]|2[0-4][0-9]|[01]?[0-9][0-9]?)){3}$/),
+)
+
+// --- Internal Functions ---
+
+async function registerValidSW(swUrl: string, callbacks?: ServiceWorkerCallbacks) {
+  try {
+    const registration = await navigator.serviceWorker.register(swUrl)
+    registration.onupdatefound = () => {
+      const installingWorker = registration.installing
+      if (!installingWorker) return
+
+      installingWorker.onstatechange = () => {
+        if (installingWorker.state === 'installed') {
+          if (navigator.serviceWorker.controller) {
+            // At this point, the updated precached content has been fetched,
+            // but the previous service worker will still serve the older
+            // content until all client tabs are closed.
+            console.info('ServiceWorker:installed:onUpdate')
+            callbacks?.onUpdate?.(registration)
+          } else {
+            // At this point, everything has been precached.
+            console.info('ServiceWorker:installed:onSuccess')
+            callbacks?.onSuccess?.(registration)
+          }
+        }
+      }
+    }
+  } catch (e) {
+    console.error('ServiceWorker:registerValidSW:Error', e)
+  }
+}
+
+async function checkValidServiceWorker(swUrl: string, callbacks?: ServiceWorkerCallbacks) {
+  // Check if the service worker can be found. If it can't reload the page.
+  try {
+    const response = await fetch(swUrl, { headers: { 'Service-Worker': 'script' } })
+    // Ensure service worker exists, and that we really are getting a JS file.
+    const contentType = response.headers.get('content-type')
+    if (response.status === 404 || contentType?.indexOf('javascript') === -1) {
+      // No service worker found. Probably a different app. Reload the page.
+      const reg = await navigator.serviceWorker.ready
+      await reg.unregister()
+      window.location.reload()
+    } else {
+      // Service worker found. Proceed as normal.
+      await registerValidSW(swUrl, callbacks)
+    }
+  } catch (e) {
+    console.warn('ServiceWorker:checkValidServiceWorker - No internet connection found.')
+  }
+}
+
+// --- Exported Functions ---
+
+/**
+ * Unregister the service worker
+ */
+export async function unregister() {
+  if ('serviceWorker' in navigator) {
+    try {
+      const reg = await navigator.serviceWorker.ready
+      await reg.unregister()
+    } catch (e) {
+      console.error('ServiceWorker:unregister:Error', e)
+    }
+  }
+}
+
+/**
+ * Register the service worker
+ */
+export function register(callbacks?: ServiceWorkerCallbacks) {
+  // @TODO: process.env.NODE_ENV === 'production'
+  if ('serviceWorker' in navigator) {
+    const publicUrl = new URL(process.env.PUBLIC_URL, window.location.href)
+
+    if (publicUrl.origin !== window.location.origin) {
+      // Our service worker won't work if PUBLIC_URL is on a different origin
+      // from what our page is served on. This might happen if a CDN is used to
+      // serve assets; see https://github.com/facebook/create-react-app/issues/2374
+      return
+    }
+
+    window.addEventListener('load', () => {
+      const swUrl = `${process.env.PUBLIC_URL}/service-worker.js`
+      debugger
+      if (isLocalhost) {
+        // This is running on localhost. Let's check if a service worker still exists or not.
+        void checkValidServiceWorker(swUrl, callbacks)
+
+        // Add some additional logging to localhost, pointing developers to the
+        // service worker/PWA documentation.
+        navigator.serviceWorker.ready.then(() => console.info('ServiceWorker:ready'))
+      } else {
+        // Is not localhost. Just register service worker
+        void registerValidSW(swUrl, callbacks)
+      }
+    })
+  }
+}


### PR DESCRIPTION
## Description

feat: add service-worker

`create-react-app` already includes `workbox` for supporting service-workers for PWAs, so no change to the webpack config was required.

However, because `react-scripts` automatically calls `InjectManifest`, the `service-worker` file must include a reference to `__WB_MANIFEST` or the build will fail.  That manifest can be used for doing caching of assets but we're not doing that right now.

## Notice

<!-- Before submitting a pull request, please make sure you have answered the following: -->

- [X] Have you followed the guidelines in our [Contributing]('https://github.com/shapeshift/web/CONTRIBUTING.md) guide?
- [X] Have you checked to ensure there aren't other open [Pull Requests](https://github.com/shapeshift/web/pulls) for the same update/change?

## Pull Request Type

- [ ] :bug: Bug fix (Non-breaking Change: Fixes an issue)
- [ ] :hammer_and_wrench: Chore (Non-breaking Change: Doc updates, pkg upgrades, typos, etc..)
- [X] :nail_care: New Feature (Breaking/Non-breaking Change)

## Issue (if applicable)

closes #1545

## Risk

Low. The worst case is the service worker doesn't load but that won't cause anything else to stop working. It's possible there's a slight performance decrease when there are a lot of HTTP calls due to the logging of all service worker events.

## Testing

It's best to test this is an ephemeral environment.
1. Check the Console tab in Developer Tools.
2. Look for `ServiceWorker` log entries

## Screenshots (if applicable)
![image](https://user-images.githubusercontent.com/1958266/164559491-152b3044-d737-4183-ae1d-61487f2c0eaa.png)

### From the Fleek build:
![image](https://user-images.githubusercontent.com/1958266/164580665-d36c819f-c2a0-4105-ba8b-73c69480942e.png)
