### PR TITLE
feat: error on fiat balance lower than fiat-ramp provider minimum usd

### DIFF
--- a/src/assets/translations/main.json
+++ b/src/assets/translations/main.json
@@ -99,7 +99,8 @@
     "selectAnAssetToSell": "Select an asset to sell",
     "fundsTo": "Funds will be sent to",
     "fundsFrom": "Funds will be sent from",
-    "headerLabel": "Buy/Sell Crypto"
+    "headerLabel": "Buy/Sell Crypto",
+    "lowBalanceError": "Minimum amount to sell $%{amount}"
   },
   "connectWalletPage": {
     "shapeshift": "ShapeShift",

--- a/src/assets/translations/main.json
+++ b/src/assets/translations/main.json
@@ -100,7 +100,7 @@
     "fundsTo": "Funds will be sent to",
     "fundsFrom": "Funds will be sent from",
     "headerLabel": "Buy/Sell Crypto",
-    "lowBalanceError": "Minimum amount to sell $%{amount}"
+    "insufficientCryptoAmountToSell": "Minimum amount to sell $%{amount}"
   },
   "connectWalletPage": {
     "shapeshift": "ShapeShift",

--- a/src/components/Modals/FiatRamps/FiatRampsCommon.ts
+++ b/src/components/Modals/FiatRamps/FiatRampsCommon.ts
@@ -16,6 +16,7 @@ export type FiatRampAsset = {
   symbol: string
   imageUrl?: string
   disabled?: boolean
+  isBelowTheMinimumUsdAmountWhenSelling?: boolean
 } & (
   | {
       cryptoBalance: BigNumber

--- a/src/components/Modals/FiatRamps/FiatRampsCommon.ts
+++ b/src/components/Modals/FiatRamps/FiatRampsCommon.ts
@@ -16,7 +16,7 @@ export type FiatRampAsset = {
   symbol: string
   imageUrl?: string
   disabled?: boolean
-  isBelowTheMinimumUsdAmountWhenSelling?: boolean
+  isBelowSellThreshold?: boolean
 } & (
   | {
       cryptoBalance: BigNumber

--- a/src/components/Modals/FiatRamps/config.ts
+++ b/src/components/Modals/FiatRamps/config.ts
@@ -20,6 +20,7 @@ export interface SupportedFiatRampConfig {
   isImplemented: boolean
   getBuyAndSellList: () => Promise<[FiatRampAsset[], FiatRampAsset[]]>
   onSubmit: (action: FiatRampAction, asset: string, address: string) => void
+  minimumUsdAmountWhenSelling?: number
 }
 
 export enum FiatRamp {
@@ -46,6 +47,7 @@ export const supportedFiatRamps: SupportedFiatRamp = {
       window.open(gemPartnerUrl, '_blank')?.focus()
     },
     isImplemented: true,
+    minimumUsdAmountWhenSelling: 5,
   },
   [FiatRamp.OnJuno]: {
     label: 'fiatRamps.onJuno',

--- a/src/components/Modals/FiatRamps/config.ts
+++ b/src/components/Modals/FiatRamps/config.ts
@@ -20,7 +20,7 @@ export interface SupportedFiatRampConfig {
   isImplemented: boolean
   getBuyAndSellList: () => Promise<[FiatRampAsset[], FiatRampAsset[]]>
   onSubmit: (action: FiatRampAction, asset: string, address: string) => void
-  minimumUsdAmountWhenSelling?: number
+  minimumSellThreshold?: number
 }
 
 export enum FiatRamp {
@@ -47,7 +47,7 @@ export const supportedFiatRamps: SupportedFiatRamp = {
       window.open(gemPartnerUrl, '_blank')?.focus()
     },
     isImplemented: true,
-    minimumUsdAmountWhenSelling: 5,
+    minimumSellThreshold: 5,
   },
   [FiatRamp.OnJuno]: {
     label: 'fiatRamps.onJuno',

--- a/src/components/Modals/FiatRamps/hooks/useFiatRampCurrencyList.ts
+++ b/src/components/Modals/FiatRamps/hooks/useFiatRampCurrencyList.ts
@@ -26,13 +26,20 @@ export const useFiatRampCurrencyList = (fiatRampProvider: FiatRamp) => {
         .filter(asset => Object.keys(balances).includes(asset.assetId))
         .map(asset => {
           const reduxAsset = reduxAssets[asset.assetId]
+          const fiatBalance = bnOrZero(balances?.[asset.assetId]?.fiat)
+          const fiatRampMinimumUsdAmountWhenSelling = bnOrZero(
+            supportedFiatRamps[fiatRampProvider].minimumUsdAmountWhenSelling ?? 0,
+          )
           return {
             ...asset,
             name: reduxAsset.name,
             symbol: reduxAsset.symbol,
             disabled: !isAssetSupportedByWallet(asset?.assetId ?? '', wallet),
             cryptoBalance: bnOrZero(balances?.[asset.assetId]?.crypto),
-            fiatBalance: bnOrZero(balances?.[asset.assetId]?.fiat),
+            fiatBalance,
+            isBelowTheMinimumUsdAmountWhenSelling: fiatBalance.lt(
+              fiatRampMinimumUsdAmountWhenSelling,
+            ),
           }
         })
         .sort((a, b) =>
@@ -41,7 +48,7 @@ export const useFiatRampCurrencyList = (fiatRampProvider: FiatRamp) => {
             : a.name.localeCompare(b.name),
         )
     },
-    [balances, reduxAssets, wallet],
+    [balances, fiatRampProvider, reduxAssets, wallet],
   )
 
   const addBuyPropertiesAndSort = useCallback(

--- a/src/components/Modals/FiatRamps/hooks/useFiatRampCurrencyList.ts
+++ b/src/components/Modals/FiatRamps/hooks/useFiatRampCurrencyList.ts
@@ -27,8 +27,8 @@ export const useFiatRampCurrencyList = (fiatRampProvider: FiatRamp) => {
         .map(asset => {
           const reduxAsset = reduxAssets[asset.assetId]
           const fiatBalance = bnOrZero(balances?.[asset.assetId]?.fiat)
-          const fiatRampMinimumUsdAmountWhenSelling = bnOrZero(
-            supportedFiatRamps[fiatRampProvider].minimumUsdAmountWhenSelling ?? 0,
+          const minimumSellThreshold = bnOrZero(
+            supportedFiatRamps[fiatRampProvider].minimumSellThreshold ?? 0,
           )
           return {
             ...asset,
@@ -37,9 +37,7 @@ export const useFiatRampCurrencyList = (fiatRampProvider: FiatRamp) => {
             disabled: !isAssetSupportedByWallet(asset?.assetId ?? '', wallet),
             cryptoBalance: bnOrZero(balances?.[asset.assetId]?.crypto),
             fiatBalance,
-            isBelowTheMinimumUsdAmountWhenSelling: fiatBalance.lt(
-              fiatRampMinimumUsdAmountWhenSelling,
-            ),
+            isBelowSellThreshold: fiatBalance.lt(minimumSellThreshold),
           }
         })
         .sort((a, b) =>

--- a/src/components/Modals/FiatRamps/views/Overview.tsx
+++ b/src/components/Modals/FiatRamps/views/Overview.tsx
@@ -238,7 +238,7 @@ export const Overview: React.FC<OverviewProps> = ({
             <Text
               translation={[
                 'fiatRamps.insufficientCryptoAmountToSell',
-                { amount: supportedFiatRamps[fiatRampProvider].minimumUsdAmountWhenSelling },
+                { amount: supportedFiatRamps[fiatRampProvider].minimumSellThreshold },
               ]}
             />
           </Alert>

--- a/src/components/Modals/FiatRamps/views/Overview.tsx
+++ b/src/components/Modals/FiatRamps/views/Overview.tsx
@@ -1,5 +1,7 @@
 import { CheckIcon, ChevronRightIcon, CopyIcon, ViewIcon } from '@chakra-ui/icons'
 import {
+  Alert,
+  AlertIcon,
   Box,
   Button,
   Flex,
@@ -230,11 +232,22 @@ export const Overview: React.FC<OverviewProps> = ({
             </InputGroup>
           </Flex>
         )}
+        {selectedAsset?.isBelowTheMinimumUsdAmountWhenSelling && (
+          <Alert status='error'>
+            <AlertIcon />
+            <Text
+              translation={[
+                'fiatRamps.lowBalanceError',
+                { amount: supportedFiatRamps[fiatRampProvider].minimumUsdAmountWhenSelling },
+              ]}
+            />
+          </Alert>
+        )}
         <Button
           width='full'
           size='lg'
           colorScheme='blue'
-          disabled={!selectedAsset}
+          disabled={!selectedAsset || selectedAsset?.isBelowTheMinimumUsdAmountWhenSelling}
           mt='25px'
           onClick={() =>
             supportedFiatRamps[fiatRampProvider].onSubmit(

--- a/src/components/Modals/FiatRamps/views/Overview.tsx
+++ b/src/components/Modals/FiatRamps/views/Overview.tsx
@@ -233,7 +233,7 @@ export const Overview: React.FC<OverviewProps> = ({
           </Flex>
         )}
         {selectedAsset?.isBelowSellThreshold && (
-          <Alert status='error'>
+          <Alert status='error' variant={'solid'}>
             <AlertIcon />
             <Text
               translation={[

--- a/src/components/Modals/FiatRamps/views/Overview.tsx
+++ b/src/components/Modals/FiatRamps/views/Overview.tsx
@@ -232,12 +232,12 @@ export const Overview: React.FC<OverviewProps> = ({
             </InputGroup>
           </Flex>
         )}
-        {selectedAsset?.isBelowTheMinimumUsdAmountWhenSelling && (
+        {selectedAsset?.isBelowSellThreshold && (
           <Alert status='error'>
             <AlertIcon />
             <Text
               translation={[
-                'fiatRamps.lowBalanceError',
+                'fiatRamps.insufficientCryptoAmountToSell',
                 { amount: supportedFiatRamps[fiatRampProvider].minimumUsdAmountWhenSelling },
               ]}
             />
@@ -247,7 +247,7 @@ export const Overview: React.FC<OverviewProps> = ({
           width='full'
           size='lg'
           colorScheme='blue'
-          disabled={!selectedAsset || selectedAsset?.isBelowTheMinimumUsdAmountWhenSelling}
+          disabled={!selectedAsset || selectedAsset?.isBelowSellThreshold}
           mt='25px'
           onClick={() =>
             supportedFiatRamps[fiatRampProvider].onSubmit(


### PR DESCRIPTION
## Description

Show an error when the fiat balance of an asset is lower than the fiat-ramp provider minimum USD amount for selling.

## Notice

<!-- Before submitting a pull request, please make sure you have answered the following: -->

- [x] Have you followed the guidelines in our [Contributing]('https://github.com/shapeshift/web/CONTRIBUTING.md) guide?
- [x] Have you checked to ensure there aren't other open [Pull Requests](https://github.com/shapeshift/web/pulls) for the same update/change?

## Pull Request Type

- [ ] :bug: Bug fix (Non-breaking Change: Fixes an issue)
- [ ] :hammer_and_wrench: Chore (Non-breaking Change: Doc updates, pkg upgrades, typos, etc..)
- [x] :nail_care: New Feature (Breaking/Non-breaking Change)

## Issue (if applicable)
closes #1186 

## Risk

none

## Testing

open up the buy/sell modal, select GEM, and choose an asset to sell which has a fiat value lower than $5. you should not be able to continue.

## Screenshots (if applicable)
<img width="421" alt="sell-minimum" src="https://user-images.githubusercontent.com/20498757/165081254-d4130812-e357-4d25-9322-cda63baa7093.png">
<img width="428" alt="sell-minimum-light" src="https://user-images.githubusercontent.com/20498757/165086196-aebd0ef8-5a48-4e37-99af-6bf0e4925ebb.png">

