### PR TITLE
fix: cosmos staking ToS link

### DIFF
--- a/src/pages/ConnectWallet/ConnectWallet.tsx
+++ b/src/pages/ConnectWallet/ConnectWallet.tsx
@@ -107,7 +107,7 @@ export const ConnectWallet = () => {
             </Badge>
           </Flex>
           <Flex width='full' alignItems='center' justifyContent='center' gap={8}>
-            <Link href='/legal/terms-of-service'>
+            <Link href='/#/legal/terms-of-service'>
               <Text color='gray.500' translation='common.terms' />
             </Link>
             <Link href='/#/legal/privacy-policy'>

--- a/src/pages/ConnectWallet/ConnectWallet.tsx
+++ b/src/pages/ConnectWallet/ConnectWallet.tsx
@@ -110,7 +110,7 @@ export const ConnectWallet = () => {
             <Link href='/legal/terms-of-service'>
               <Text color='gray.500' translation='common.terms' />
             </Link>
-            <Link href='/legal/privacy-policy'>
+            <Link href='/#/legal/privacy-policy'>
               <Text color='gray.500' translation='common.privacy' />
             </Link>
           </Flex>

--- a/src/plugins/cosmos/components/modals/Staking/views/Stake.tsx
+++ b/src/plugins/cosmos/components/modals/Staking/views/Stake.tsx
@@ -23,6 +23,7 @@ import { useTranslate } from 'react-polyglot'
 import { useHistory } from 'react-router-dom'
 import { SlideTransition } from 'components/SlideTransition'
 import { Text } from 'components/Text'
+import { useModal } from 'hooks/useModal/useModal'
 import { BigNumber, bnOrZero } from 'lib/bignumber/bignumber'
 import {
   selectAssetByCAIP19,
@@ -70,6 +71,8 @@ export const Stake = ({ assetId, apr, validatorAddress }: StakeProps) => {
   const borderColor = useColorModeValue('gray.100', 'gray.750')
 
   const memoryHistory = useHistory()
+
+  const { cosmosStaking } = useModal()
 
   const onSubmit = (_: any) => {
     memoryHistory.push(StakingPath.Confirm, {
@@ -214,7 +217,12 @@ export const Stake = ({ assetId, apr, validatorAddress }: StakeProps) => {
               {`${translate('defi.modals.staking.risks')}`}
             </Link>
             {` ${translate('defi.modals.staking.ofParticipating')} `}
-            <Link color={'blue.200'} fontWeight='bold' target='_blank' href='/legal/privacy-policy'>
+            <Link
+              color={'blue.200'}
+              fontWeight='bold'
+              href='/#/legal/privacy-policy'
+              onClick={cosmosStaking.close}
+            >
               {`${translate('defi.modals.staking.terms')}.`}
             </Link>
           </CText>


### PR DESCRIPTION
## Description

This fixes the "terms" link in cosmos staking modal

## Notice

<!-- Before submitting a pull request, please make sure you have answered the following: -->

- [x] Have you followed the guidelines in our [Contributing]('https://github.com/shapeshift/web/CONTRIBUTING.md) guide?
- [x] Have you checked to ensure there aren't other open [Pull Requests](https://github.com/shapeshift/web/pulls) for the same update/change?

## Pull Request Type

- [x] :bug: Bug fix (Non-breaking Change: Fixes an issue)
- [ ] :hammer_and_wrench: Chore (Non-breaking Change: Doc updates, pkg upgrades, typos, etc..)
- [ ] :nail_care: New Feature (Breaking/Non-breaking Change)

## Issue (if applicable)

closes #1559

## Risk

N/A

## Testing

- Go to Cosmos Staking modal
- Click the `terms` link
- Terms and conditions should open in new tab

## Screenshots (if applicable)
