### PR TITLE
fix: staking ToS link - open in a new tab

### DIFF
--- a/src/plugins/cosmos/components/modals/Staking/views/Stake.tsx
+++ b/src/plugins/cosmos/components/modals/Staking/views/Stake.tsx
@@ -220,6 +220,7 @@ export const Stake = ({ assetId, apr, validatorAddress }: StakeProps) => {
             <Link
               color={'blue.200'}
               fontWeight='bold'
+              target='_blank'
               href='/#/legal/privacy-policy'
               onClick={cosmosStaking.close}
             >


### PR DESCRIPTION
## Description

This opens the ToS link in staking modal in a new tab.

## Notice

<!-- Before submitting a pull request, please make sure you have answered the following: -->

- [x] Have you followed the guidelines in our [Contributing]('https://github.com/shapeshift/web/CONTRIBUTING.md) guide?
- [x] Have you checked to ensure there aren't other open [Pull Requests](https://github.com/shapeshift/web/pulls) for the same update/change?

## Pull Request Type

- [x] :bug: Bug fix (Non-breaking Change: Fixes an issue)
- [ ] :hammer_and_wrench: Chore (Non-breaking Change: Doc updates, pkg upgrades, typos, etc..)
- [] :nail_care: New Feature (Breaking/Non-breaking Change)

## Issue (if applicable)

#1559

## Risk

The "Enter your password" modal is shown, which is not the best UX. 

## Testing

- Go to staking modal
- Click the `terms` link
- It should open in a new tab 

## Screenshots (if applicable)
