### PR TITLE
fix: entropy constant regression

### DIFF
--- a/src/context/WalletProvider/KeepKey/components/RecoverySettings.tsx
+++ b/src/context/WalletProvider/KeepKey/components/RecoverySettings.tsx
@@ -17,7 +17,7 @@ import { KeepKeyRoutes } from 'context/WalletProvider/routes'
 import { useWallet } from 'hooks/useWallet/useWallet'
 
 export const VALID_ENTROPY_NUMBERS = [128, 192, 256] as const
-export const VALID_ENTROPY = VALID_ENTROPY_NUMBERS.map(toString)
+export const VALID_ENTROPY = VALID_ENTROPY_NUMBERS.map(entropy => entropy.toString())
 export type Entropy = typeof VALID_ENTROPY[number]
 
 export const sentenceLength = Object.freeze({


### PR DESCRIPTION
## Description

I caused a regression to the word entropy constant in a refactor: https://github.com/shapeshift/web/pull/1561/commits/d3474e4092cca0e2baad79bcc6fb05f1aba5d710

This PR fixes that regression.

## Notice

<!-- Before submitting a pull request, please make sure you have answered the following: -->

- [x] Have you followed the guidelines in our [Contributing]('https://github.com/shapeshift/web/CONTRIBUTING.md) guide?
- [x] Have you checked to ensure there aren't other open [Pull Requests](https://github.com/shapeshift/web/pulls) for the same update/change?

## Pull Request Type

- [x] :bug: Bug fix (Non-breaking Change: Fixes an issue)
- [ ] :hammer_and_wrench: Chore (Non-breaking Change: Doc updates, pkg upgrades, typos, etc..)
- [ ] :nail_care: New Feature (Breaking/Non-breaking Change)

## Issue (if applicable)

N/A

## Risk

Things should be strictly better!

## Testing

You can now correctly select the recovery word entropy again.

## Screenshots (if applicable)

N/A
