### PR TITLE
feat: show that label entry is optional

### DIFF
--- a/src/assets/translations/main.json
+++ b/src/assets/translations/main.json
@@ -385,9 +385,11 @@
         "button": "Submit Passphrase"
       },
       "label": {
-        "header": "Label Your KeepKey",
+        "header": "Label Your KeepKey (optional)",
         "body": "Labeling each of your devices allows you to easily distinguish one from the other.",
-        "button": "Set Label"
+        "setLabelButton": "Set Label",
+        "skipLabelButton": "Skip",
+        "placeholder": "Optional"
       },
       "recoverySettings": {
         "header": "Recover Your Wallet",

--- a/src/context/WalletProvider/KeepKey/components/Label.tsx
+++ b/src/context/WalletProvider/KeepKey/components/Label.tsx
@@ -1,7 +1,7 @@
 import { Button, Input, ModalBody, ModalHeader } from '@chakra-ui/react'
 import { useToast } from '@chakra-ui/toast'
 import { RecoverDevice, ResetDevice } from '@shapeshiftoss/hdwallet-core'
-import { useRef, useState } from 'react'
+import { useState } from 'react'
 import { useTranslate } from 'react-polyglot'
 import { Text } from 'components/Text'
 import { VALID_ENTROPY_NUMBERS } from 'context/WalletProvider/KeepKey/components/RecoverySettings'
@@ -26,11 +26,10 @@ export const KeepKeyLabel = () => {
   } = useWallet()
   const toast = useToast()
   const translate = useTranslate()
-  const inputRef = useRef<HTMLInputElement | null>(null)
+  const [label, setLabel] = useState('')
 
   const handleInitializeSubmit = async () => {
     setLoading(true)
-    const label = inputRef.current?.value
     const resetMessage: ResetDevice = { label: label ?? '', pin: true }
     setDeviceState({ awaitingDeviceInteraction: true })
     await wallet?.reset(resetMessage).catch(e => {
@@ -46,7 +45,6 @@ export const KeepKeyLabel = () => {
 
   const handleRecoverSubmit = async () => {
     setLoading(true)
-    const label = inputRef.current?.value
     setDeviceState({ awaitingDeviceInteraction: true })
     const recoverParams: RecoverDevice = {
       entropy: parseIntToEntropy(recoveryEntropy),
@@ -73,7 +71,16 @@ export const KeepKeyLabel = () => {
       </ModalHeader>
       <ModalBody>
         <Text color='gray.500' translation={'modals.keepKey.label.body'} mb={4} />
-        <Input type='text' ref={inputRef} size='lg' variant='filled' mt={3} mb={6} />
+        <Input
+          type='text'
+          value={label}
+          placeholder={translate('modals.keepKey.label.placeholder')}
+          onChange={e => setLabel(e.target.value)}
+          size='lg'
+          variant='filled'
+          mt={3}
+          mb={6}
+        />
         <Button
           isFullWidth
           size='lg'
@@ -82,7 +89,11 @@ export const KeepKeyLabel = () => {
           disabled={loading}
           mb={3}
         >
-          <Text translation={'modals.keepKey.label.button'} />
+          <Text
+            translation={
+              label ? 'modals.keepKey.label.setLabelButton' : 'modals.keepKey.label.skipLabelButton'
+            }
+          />
         </Button>
       </ModalBody>
     </>


### PR DESCRIPTION
## Description

"Setting a label is optional and this should be communicated to the user somehow".

- Adds "optional" placeholder and header copy
- Sets button copy to "Skip" when no label has been entered

## Notice

- [x] Have you followed the guidelines in our [Contributing]('https://github.com/shapeshift/web/CONTRIBUTING.md) guide?
- [x] Have you checked to ensure there aren't other open [Pull Requests](https://github.com/shapeshift/web/pulls) for the same update/change?

## Pull Request Type

- [ ] :bug: Bug fix (Non-breaking Change: Fixes an issue)
- [ ] :hammer_and_wrench: Chore (Non-breaking Change: Doc updates, pkg upgrades, typos, etc..)
- [x] :nail_care: New Feature (Breaking/Non-breaking Change)

## Issue (if applicable)

Closes https://github.com/shapeshift/web/issues/1611

## Risk

Minimal - cosmetic changes only.

## Testing

Initialise or recover a KeepKey and set a label, or not, via the Label modal.

## Screenshots (if applicable)

<img width="428" alt="Screen Shot 2022-04-28 at 7 44 54 pm" src="https://user-images.githubusercontent.com/97164662/165727762-556895f0-8a81-477c-a40e-26962654e6d7.png">
<img width="426" alt="Screen Shot 2022-04-28 at 7 45 03 pm" src="https://user-images.githubusercontent.com/97164662/165727773-e671025a-4ffc-4ac8-ade4-dce8ca75dc0b.png">

