### PR TITLE
fix(cosmos): crypto amount validation fixes

### DIFF
--- a/src/plugins/cosmos/components/StakingInput/StakingInput.tsx
+++ b/src/plugins/cosmos/components/StakingInput/StakingInput.tsx
@@ -21,7 +21,6 @@ const cryptoInputValidation = {
   validate: {
     validateCryptoAmount: (cryptoAmount: string) => {
       if (bnOrZero(cryptoAmount).isZero()) return false
-      // TODO: Implement when we have cosmos/osmosis balance data
       return true
     },
   },

--- a/src/plugins/cosmos/components/StakingInput/StakingInput.tsx
+++ b/src/plugins/cosmos/components/StakingInput/StakingInput.tsx
@@ -19,10 +19,7 @@ type StakingInputProps = {
 const cryptoInputValidation = {
   required: true,
   validate: {
-    validateCryptoAmount: (cryptoAmount: string) => {
-      if (bnOrZero(cryptoAmount).isZero()) return false
-      return true
-    },
+    validateCryptoAmount: (cryptoAmount: string) => Boolean(bn(cryptoAmount).gt(0)),
   },
 }
 const fiatInputValidation = {

--- a/src/plugins/cosmos/components/StakingInput/StakingInput.tsx
+++ b/src/plugins/cosmos/components/StakingInput/StakingInput.tsx
@@ -28,11 +28,7 @@ const cryptoInputValidation = {
 const fiatInputValidation = {
   required: true,
   validate: {
-    validateFiatAmount: (fiatAmount: string) => {
-      if (bnOrZero(fiatAmount).isZero()) return false
-
-      return true
-    },
+    validateFiatAmount: (fiatAmount: string) => Boolean(bn(fiatAmount).gt(0)),
   },
 }
 const CryptoInput = (props: any) => (

--- a/src/plugins/cosmos/components/StakingInput/StakingInput.tsx
+++ b/src/plugins/cosmos/components/StakingInput/StakingInput.tsx
@@ -19,7 +19,8 @@ type StakingInputProps = {
 const cryptoInputValidation = {
   required: true,
   validate: {
-    validateCryptoAmount: (_: string) => {
+    validateCryptoAmount: (cryptoAmount: string) => {
+      if (bnOrZero(cryptoAmount).isZero()) return false
       // TODO: Implement when we have cosmos/osmosis balance data
       return true
     },
@@ -28,8 +29,9 @@ const cryptoInputValidation = {
 const fiatInputValidation = {
   required: true,
   validate: {
-    validateFiatAmount: (_: string) => {
-      // TODO: Implement when we have cosmos/osmosis balance data
+    validateFiatAmount: (fiatAmount: string) => {
+      if (bnOrZero(fiatAmount).isZero()) return false
+
       return true
     },
   },

--- a/src/plugins/cosmos/components/StakingInput/StakingInput.tsx
+++ b/src/plugins/cosmos/components/StakingInput/StakingInput.tsx
@@ -19,13 +19,13 @@ type StakingInputProps = {
 const cryptoInputValidation = {
   required: true,
   validate: {
-    validateCryptoAmount: (cryptoAmount: string) => Boolean(bn(cryptoAmount).gt(0)),
+    validateCryptoAmount: (cryptoAmount: string) => bnOrZero(cryptoAmount).gt(0),
   },
 }
 const fiatInputValidation = {
   required: true,
   validate: {
-    validateFiatAmount: (fiatAmount: string) => Boolean(bn(fiatAmount).gt(0)),
+    validateFiatAmount: (fiatAmount: string) => bnOrZero(fiatAmount).gt(0),
   },
 }
 const CryptoInput = (props: any) => (

--- a/src/plugins/cosmos/components/modals/Staking/views/Stake.tsx
+++ b/src/plugins/cosmos/components/modals/Staking/views/Stake.tsx
@@ -112,7 +112,9 @@ export const Stake = ({ assetId, apr, validatorAddress }: StakeProps) => {
       const cryptoAmount = bnOrZero(value).dp(asset.precision, BigNumber.ROUND_DOWN)
       const fiatAmount = bnOrZero(value).times(marketData.price)
       setValue(Field.FiatAmount, fiatAmount.toString(), { shouldValidate: true })
-      setValue(Field.CryptoAmount, cryptoAmount.toString(), { shouldValidate: true })
+      setValue(Field.CryptoAmount, value.length ? cryptoAmount.toString() : value, {
+        shouldValidate: true,
+      })
 
       if (cryptoAmount.gt(cryptoBalanceHuman)) {
         setValue(Field.AmountFieldError, 'common.insufficientFunds', { shouldValidate: true })

--- a/src/plugins/cosmos/components/modals/Staking/views/Unstake.tsx
+++ b/src/plugins/cosmos/components/modals/Staking/views/Unstake.tsx
@@ -121,7 +121,9 @@ export const Unstake = ({ assetId, apr, accountSpecifier, validatorAddress }: Un
       const cryptoAmount = bnOrZero(value).dp(asset.precision, BigNumber.ROUND_DOWN)
       const fiatAmount = bnOrZero(value).times(marketData.price)
       setValue(Field.FiatAmount, fiatAmount.toString(), { shouldValidate: true })
-      setValue(Field.CryptoAmount, cryptoAmount.toString(), { shouldValidate: true })
+      setValue(Field.CryptoAmount, value.length ? cryptoAmount.toString() : value, {
+        shouldValidate: true,
+      })
 
       if (cryptoAmount.gt(cryptoStakeBalanceHuman)) {
         setValue(Field.AmountFieldError, 'common.insufficientFunds', { shouldValidate: true })


### PR DESCRIPTION
## Description

- add validation on zero crypto/fiat amount
- fix removing a one-char input defaulting to zero

## Notice

<!-- Before submitting a pull request, please make sure you have answered the following: -->

- [x] Have you followed the guidelines in our [Contributing]('https://github.com/shapeshift/web/CONTRIBUTING.md) guide?
- [x] Have you checked to ensure there aren't other open [Pull Requests](https://github.com/shapeshift/web/pulls) for the same update/change?

## Pull Request Type

- [x] :bug: Bug fix (Non-breaking Change: Fixes an issue)
- [ ] :hammer_and_wrench: Chore (Non-breaking Change: Doc updates, pkg upgrades, typos, etc..)
- [ ] :nail_care: New Feature (Breaking/Non-breaking Change)

## Issue (if applicable)

N/A

## Risk

N/A

## Testing

- Continue button should be disable on cosmos stake/unstake with 0
- Pressing the delete key on a single digit in staking should bring back empty input

## Screenshots (if applicable)
