### PR TITLE
fix: refactor getsendmaxamount

### DIFF
--- a/src/components/Trade/TradeInput.tsx
+++ b/src/components/Trade/TradeInput.tsx
@@ -135,7 +135,6 @@ export const TradeInput = ({ history }: RouterProps) => {
         sellAsset,
         buyAsset,
         feeAsset,
-        estimatedGasFees,
       })
       const action = TradeActions.SELL
       const currentSellAsset = getValues('sellAsset')

--- a/src/components/Trade/hooks/useSwapper/useSwapper.ts
+++ b/src/components/Trade/hooks/useSwapper/useSwapper.ts
@@ -91,10 +91,9 @@ export const useSwapper = () => {
     return swapper.getDefaultPair()
   }, [swapperManager, bestSwapperType])
 
-  const sellAssetBalance =
-    useAppSelector(state =>
-      selectPortfolioCryptoBalanceByAssetId(state, sellAsset?.currency?.caip19),
-    ) ?? '0'
+  const sellAssetBalance = useAppSelector(state =>
+    selectPortfolioCryptoBalanceByAssetId(state, sellAsset?.currency?.caip19),
+  )
 
   const getSendMaxAmount = async ({
     wallet,
@@ -117,9 +116,10 @@ export const useSwapper = () => {
       wallet,
     )
 
+    // Only subtract fee if sell asset is the see asset
     const isFeeAsset = feeAsset.caip19 === sellAsset.currency.caip19
     // Pad fee because estimations can be wrong
-    const feePadded = bnOrZero(maximumQuote?.feeData?.fee).times(1.1)
+    const feePadded = bnOrZero(maximumQuote?.feeData?.fee)
     const maxAmount = fromBaseUnit(
       bnOrZero(sellAssetBalance)
         .minus(isFeeAsset ? feePadded : 0)

--- a/src/components/Trade/hooks/useSwapper/useSwapper.ts
+++ b/src/components/Trade/hooks/useSwapper/useSwapper.ts
@@ -120,6 +120,8 @@ export const useSwapper = () => {
     const isFeeAsset = feeAsset.caip19 === sellAsset.currency.caip19
     // Pad fee because estimations can be wrong
     const feePadded = bnOrZero(maximumQuote?.feeData?.fee)
+    // sell asset balance minus expected fee = maxTradeAmount
+    // only subtract if sell asset is fee asset
     const maxAmount = fromBaseUnit(
       bnOrZero(sellAssetBalance)
         .minus(isFeeAsset ? feePadded : 0)

--- a/src/components/Trade/hooks/useSwapper/useSwapper.ts
+++ b/src/components/Trade/hooks/useSwapper/useSwapper.ts
@@ -91,7 +91,7 @@ export const useSwapper = () => {
     return swapper.getDefaultPair()
   }, [swapperManager, bestSwapperType])
 
-  const balance =
+  const sellAssetBalance =
     useAppSelector(state =>
       selectPortfolioCryptoBalanceByAssetId(state, sellAsset?.currency?.caip19),
     ) ?? '0'
@@ -112,7 +112,7 @@ export const useSwapper = () => {
       {
         sellAsset: sellAsset.currency,
         buyAsset: buyAsset.currency,
-        sellAmount: balance,
+        sellAmount: sellAssetBalance,
       },
       wallet,
     )
@@ -121,7 +121,7 @@ export const useSwapper = () => {
     // Pad fee because estimations can be wrong
     const feePadded = bnOrZero(maximumQuote?.feeData?.fee).times(1.1)
     const maxAmount = fromBaseUnit(
-      bnOrZero(balance)
+      bnOrZero(sellAssetBalance)
         .minus(isFeeAsset ? feePadded : 0)
         .toString(),
       sellAsset.currency.precision,

--- a/src/state/slices/portfolioSlice/selectors.ts
+++ b/src/state/slices/portfolioSlice/selectors.ts
@@ -201,7 +201,7 @@ export const selectPortfolioFiatBalanceByFilter = createSelector(
 export const selectPortfolioCryptoBalanceByAssetId = createSelector(
   selectPortfolioAssetBalances,
   selectAssetIdParam,
-  (byId, assetId): string => byId[assetId],
+  (byId, assetId): string => byId[assetId] ?? 0,
 )
 
 export const selectPortfolioCryptoHumanBalanceByFilter = createSelector(


### PR DESCRIPTION
## Description

Greatly simplify getSendMaxAmount() to be not use swapper.getSendMaxAmount().

It is now: `sendAssetBalance - estimatedFeePadded` and very easy to understand compared to before

This is basically the same logic but previously it was doing it a crazy spaghetti-code fashion passing tons of unneccessary data all over the place.

We can now remove getSendMaxAmount() from swapper which helps keep things loosely coupled and clean.

## Notice

- [x] Have you followed the guidelines in our [Contributing]('https://github.com/shapeshift/web/CONTRIBUTING.md) guide?
- [x] Have you checked to ensure there aren't other open [Pull Requests](https://github.com/shapeshift/web/pulls) for the same update/change?

## Pull Request Type

- [x] :bug: Bug fix (Non-breaking Change: Fixes an issue)
- [ ] :hammer_and_wrench: Chore (Non-breaking Change: Doc updates, pkg upgrades, typos, etc..)
- [ ] :nail_care: New Feature (Breaking/Non-breaking Change)

## Risk

Sendmax could not work correctly

## Testing

Test that sendmax still works for trades.
