### PR TITLE
refactor: rename `selectAssetByCAIP19` to `selectAssetById`

### DIFF
--- a/src/components/AccountAssets/AccountAssets.tsx
+++ b/src/components/AccountAssets/AccountAssets.tsx
@@ -2,7 +2,7 @@ import { AssetId } from '@shapeshiftoss/caip'
 import { Text } from 'components/Text'
 import { AccountSpecifier } from 'state/slices/accountSpecifiersSlice/accountSpecifiersSlice'
 import {
-  selectAssetByCAIP19,
+  selectAssetByAssetId,
   selectPortfolioAssetIdsByAccountIdExcludeFeeAsset,
 } from 'state/slices/selectors'
 import { useAppSelector } from 'state/store'
@@ -19,7 +19,7 @@ export const AccountAssets = ({ assetId, accountId }: AccountAssetsProps) => {
   const assetIds = useAppSelector(state =>
     selectPortfolioAssetIdsByAccountIdExcludeFeeAsset(state, accountId),
   )
-  const asset = useAppSelector(state => selectAssetByCAIP19(state, assetId))
+  const asset = useAppSelector(state => selectAssetByAssetId(state, assetId))
 
   // @TODO: This filters for ETH to not show tokens component on tokens
   if (asset.tokenId || assetIds.length === 0) return null

--- a/src/components/AccountAssets/AccountAssets.tsx
+++ b/src/components/AccountAssets/AccountAssets.tsx
@@ -2,7 +2,7 @@ import { AssetId } from '@shapeshiftoss/caip'
 import { Text } from 'components/Text'
 import { AccountSpecifier } from 'state/slices/accountSpecifiersSlice/accountSpecifiersSlice'
 import {
-  selectAssetByAssetId,
+  selectAssetById,
   selectPortfolioAssetIdsByAccountIdExcludeFeeAsset,
 } from 'state/slices/selectors'
 import { useAppSelector } from 'state/store'
@@ -19,7 +19,7 @@ export const AccountAssets = ({ assetId, accountId }: AccountAssetsProps) => {
   const assetIds = useAppSelector(state =>
     selectPortfolioAssetIdsByAccountIdExcludeFeeAsset(state, accountId),
   )
-  const asset = useAppSelector(state => selectAssetByAssetId(state, assetId))
+  const asset = useAppSelector(state => selectAssetById(state, assetId))
 
   // @TODO: This filters for ETH to not show tokens component on tokens
   if (asset.tokenId || assetIds.length === 0) return null

--- a/src/components/AccountRow/AccountRow.tsx
+++ b/src/components/AccountRow/AccountRow.tsx
@@ -6,7 +6,7 @@ import { Amount } from 'components/Amount/Amount'
 import { AssetIcon } from 'components/AssetIcon'
 import { RawText } from 'components/Text'
 import {
-  selectAssetByAssetId,
+  selectAssetById,
   selectMarketDataById,
   selectPortfolioCryptoHumanBalanceByAssetId,
   selectPortfolioFiatBalanceByAssetId,
@@ -25,7 +25,7 @@ export const AccountRow = ({ allocationValue, assetId, ...rest }: AccountRowArgs
   const rowHover = useColorModeValue('gray.100', 'gray.750')
   const url = useMemo(() => (assetId ? `/assets/${assetId}` : ''), [assetId])
 
-  const asset = useAppSelector(state => selectAssetByAssetId(state, assetId))
+  const asset = useAppSelector(state => selectAssetById(state, assetId))
   const marketData = useAppSelector(state => selectMarketDataById(state, assetId))
   const cryptoValue = useAppSelector(state =>
     selectPortfolioCryptoHumanBalanceByAssetId(state, assetId),

--- a/src/components/AccountRow/AccountRow.tsx
+++ b/src/components/AccountRow/AccountRow.tsx
@@ -6,7 +6,7 @@ import { Amount } from 'components/Amount/Amount'
 import { AssetIcon } from 'components/AssetIcon'
 import { RawText } from 'components/Text'
 import {
-  selectAssetByCAIP19,
+  selectAssetByAssetId,
   selectMarketDataById,
   selectPortfolioCryptoHumanBalanceByAssetId,
   selectPortfolioFiatBalanceByAssetId,
@@ -25,7 +25,7 @@ export const AccountRow = ({ allocationValue, assetId, ...rest }: AccountRowArgs
   const rowHover = useColorModeValue('gray.100', 'gray.750')
   const url = useMemo(() => (assetId ? `/assets/${assetId}` : ''), [assetId])
 
-  const asset = useAppSelector(state => selectAssetByCAIP19(state, assetId))
+  const asset = useAppSelector(state => selectAssetByAssetId(state, assetId))
   const marketData = useAppSelector(state => selectMarketDataById(state, assetId))
   const cryptoValue = useAppSelector(state =>
     selectPortfolioCryptoHumanBalanceByAssetId(state, assetId),

--- a/src/components/AssetAccounts/AssetAccountRow.tsx
+++ b/src/components/AssetAccounts/AssetAccountRow.tsx
@@ -18,7 +18,7 @@ import { RawText } from 'components/Text'
 import { AccountSpecifier } from 'state/slices/accountSpecifiersSlice/accountSpecifiersSlice'
 import { accountIdToFeeAssetId, accountIdToLabel } from 'state/slices/portfolioSlice/utils'
 import {
-  selectAssetByAssetId,
+  selectAssetById,
   selectPortfolioAllocationPercentByFilter,
   selectTotalCryptoBalanceWithDelegations,
   selectTotalFiatBalanceWithDelegations,
@@ -48,8 +48,8 @@ export const AssetAccountRow = ({
   const [isLargerThanMd] = useMediaQuery(`(min-width: ${breakpoints['md']})`)
   const feeAssetId = accountIdToFeeAssetId(accountId)
   const rowAssetId = assetId ? assetId : feeAssetId
-  const asset = useAppSelector(state => selectAssetByAssetId(state, rowAssetId))
-  const feeAsset = useAppSelector(state => selectAssetByAssetId(state, feeAssetId))
+  const asset = useAppSelector(state => selectAssetById(state, rowAssetId))
+  const feeAsset = useAppSelector(state => selectAssetById(state, feeAssetId))
   const filter = useMemo(() => ({ assetId: rowAssetId, accountId }), [rowAssetId, accountId])
   const fiatBalance = useAppSelector(state => selectTotalFiatBalanceWithDelegations(state, filter))
   const cryptoHumanBalance = useAppSelector(state =>

--- a/src/components/AssetAccounts/AssetAccountRow.tsx
+++ b/src/components/AssetAccounts/AssetAccountRow.tsx
@@ -18,7 +18,7 @@ import { RawText } from 'components/Text'
 import { AccountSpecifier } from 'state/slices/accountSpecifiersSlice/accountSpecifiersSlice'
 import { accountIdToFeeAssetId, accountIdToLabel } from 'state/slices/portfolioSlice/utils'
 import {
-  selectAssetByCAIP19,
+  selectAssetByAssetId,
   selectPortfolioAllocationPercentByFilter,
   selectTotalCryptoBalanceWithDelegations,
   selectTotalFiatBalanceWithDelegations,
@@ -48,8 +48,8 @@ export const AssetAccountRow = ({
   const [isLargerThanMd] = useMediaQuery(`(min-width: ${breakpoints['md']})`)
   const feeAssetId = accountIdToFeeAssetId(accountId)
   const rowAssetId = assetId ? assetId : feeAssetId
-  const asset = useAppSelector(state => selectAssetByCAIP19(state, rowAssetId))
-  const feeAsset = useAppSelector(state => selectAssetByCAIP19(state, feeAssetId))
+  const asset = useAppSelector(state => selectAssetByAssetId(state, rowAssetId))
+  const feeAsset = useAppSelector(state => selectAssetByAssetId(state, feeAssetId))
   const filter = useMemo(() => ({ assetId: rowAssetId, accountId }), [rowAssetId, accountId])
   const fiatBalance = useAppSelector(state => selectTotalFiatBalanceWithDelegations(state, filter))
   const cryptoHumanBalance = useAppSelector(state =>

--- a/src/components/AssetHeader/AccountLabel.tsx
+++ b/src/components/AssetHeader/AccountLabel.tsx
@@ -2,13 +2,13 @@ import { HStack, Tag, TagLabel } from '@chakra-ui/react'
 import { RawText } from 'components/Text'
 import { AccountSpecifier } from 'state/slices/accountSpecifiersSlice/accountSpecifiersSlice'
 import { accountIdToFeeAssetId, accountIdToLabel } from 'state/slices/portfolioSlice/utils'
-import { selectAssetByAssetId } from 'state/slices/selectors'
+import { selectAssetById } from 'state/slices/selectors'
 import { useAppSelector } from 'state/store'
 
 export const AccountLabel = ({ accountId }: { accountId: AccountSpecifier }) => {
   const label = accountId ? accountIdToLabel(accountId) : null
   const feeAssetId = accountIdToFeeAssetId(accountId)
-  const feeAsset = useAppSelector(state => selectAssetByAssetId(state, feeAssetId))
+  const feeAsset = useAppSelector(state => selectAssetById(state, feeAssetId))
   return (
     <HStack fontSize='small' spacing={1}>
       <RawText>{feeAsset.name}</RawText>

--- a/src/components/AssetHeader/AccountLabel.tsx
+++ b/src/components/AssetHeader/AccountLabel.tsx
@@ -2,13 +2,13 @@ import { HStack, Tag, TagLabel } from '@chakra-ui/react'
 import { RawText } from 'components/Text'
 import { AccountSpecifier } from 'state/slices/accountSpecifiersSlice/accountSpecifiersSlice'
 import { accountIdToFeeAssetId, accountIdToLabel } from 'state/slices/portfolioSlice/utils'
-import { selectAssetByCAIP19 } from 'state/slices/selectors'
+import { selectAssetByAssetId } from 'state/slices/selectors'
 import { useAppSelector } from 'state/store'
 
 export const AccountLabel = ({ accountId }: { accountId: AccountSpecifier }) => {
   const label = accountId ? accountIdToLabel(accountId) : null
   const feeAssetId = accountIdToFeeAssetId(accountId)
-  const feeAsset = useAppSelector(state => selectAssetByCAIP19(state, feeAssetId))
+  const feeAsset = useAppSelector(state => selectAssetByAssetId(state, feeAssetId))
   return (
     <HStack fontSize='small' spacing={1}>
       <RawText>{feeAsset.name}</RawText>

--- a/src/components/AssetHeader/AssetActions.tsx
+++ b/src/components/AssetHeader/AssetActions.tsx
@@ -7,7 +7,7 @@ import { WalletActions } from 'context/WalletProvider/actions'
 import { useModal } from 'hooks/useModal/useModal'
 import { useWallet } from 'hooks/useWallet/useWallet'
 import { AccountSpecifier } from 'state/slices/accountSpecifiersSlice/accountSpecifiersSlice'
-import { selectAssetByCAIP19 } from 'state/slices/selectors'
+import { selectAssetByAssetId } from 'state/slices/selectors'
 import { useAppSelector } from 'state/store'
 
 type AssetActionProps = {
@@ -24,7 +24,7 @@ export const AssetActions = ({ isLoaded, assetId, accountId, cryptoBalance }: As
     state: { isConnected },
     dispatch,
   } = useWallet()
-  const asset = useAppSelector(state => selectAssetByCAIP19(state, assetId))
+  const asset = useAppSelector(state => selectAssetByAssetId(state, assetId))
 
   const handleWalletModalOpen = () =>
     dispatch({ type: WalletActions.SET_WALLET_MODAL, payload: true })

--- a/src/components/AssetHeader/AssetActions.tsx
+++ b/src/components/AssetHeader/AssetActions.tsx
@@ -7,7 +7,7 @@ import { WalletActions } from 'context/WalletProvider/actions'
 import { useModal } from 'hooks/useModal/useModal'
 import { useWallet } from 'hooks/useWallet/useWallet'
 import { AccountSpecifier } from 'state/slices/accountSpecifiersSlice/accountSpecifiersSlice'
-import { selectAssetByAssetId } from 'state/slices/selectors'
+import { selectAssetById } from 'state/slices/selectors'
 import { useAppSelector } from 'state/store'
 
 type AssetActionProps = {
@@ -24,7 +24,7 @@ export const AssetActions = ({ isLoaded, assetId, accountId, cryptoBalance }: As
     state: { isConnected },
     dispatch,
   } = useWallet()
-  const asset = useAppSelector(state => selectAssetByAssetId(state, assetId))
+  const asset = useAppSelector(state => selectAssetById(state, assetId))
 
   const handleWalletModalOpen = () =>
     dispatch({ type: WalletActions.SET_WALLET_MODAL, payload: true })

--- a/src/components/AssetHeader/AssetChart.tsx
+++ b/src/components/AssetHeader/AssetChart.tsx
@@ -34,7 +34,7 @@ import {
   selectTotalFiatBalanceWithDelegations,
 } from 'state/slices/portfolioSlice/selectors'
 import {
-  selectAssetByAssetId,
+  selectAssetById,
   selectMarketDataById,
   selectTotalStakingDelegationCryptoByFilter,
 } from 'state/slices/selectors'
@@ -60,7 +60,7 @@ export const AssetChart = ({ accountId, assetId, isLoaded }: AssetChartProps) =>
   const alertIconColor = useColorModeValue('blue.500', 'blue.200')
   const [timeframe, setTimeframe] = useState(HistoryTimeframe.DAY)
   const assetIds = useMemo(() => [assetId].filter(Boolean), [assetId])
-  const asset = useAppSelector(state => selectAssetByAssetId(state, assetId))
+  const asset = useAppSelector(state => selectAssetById(state, assetId))
   const marketData = useAppSelector(state => selectMarketDataById(state, assetId))
   const { price } = marketData || {}
   const assetPrice = toFiat(price) ?? 0

--- a/src/components/AssetHeader/AssetChart.tsx
+++ b/src/components/AssetHeader/AssetChart.tsx
@@ -34,7 +34,7 @@ import {
   selectTotalFiatBalanceWithDelegations,
 } from 'state/slices/portfolioSlice/selectors'
 import {
-  selectAssetByCAIP19,
+  selectAssetByAssetId,
   selectMarketDataById,
   selectTotalStakingDelegationCryptoByFilter,
 } from 'state/slices/selectors'
@@ -60,7 +60,7 @@ export const AssetChart = ({ accountId, assetId, isLoaded }: AssetChartProps) =>
   const alertIconColor = useColorModeValue('blue.500', 'blue.200')
   const [timeframe, setTimeframe] = useState(HistoryTimeframe.DAY)
   const assetIds = useMemo(() => [assetId].filter(Boolean), [assetId])
-  const asset = useAppSelector(state => selectAssetByCAIP19(state, assetId))
+  const asset = useAppSelector(state => selectAssetByAssetId(state, assetId))
   const marketData = useAppSelector(state => selectMarketDataById(state, assetId))
   const { price } = marketData || {}
   const assetPrice = toFiat(price) ?? 0

--- a/src/components/AssetHeader/AssetDescription.tsx
+++ b/src/components/AssetHeader/AssetDescription.tsx
@@ -7,7 +7,7 @@ import { ParsedHtml } from 'components/ParsedHtml/ParsedHtml'
 import { SanitizedHtml } from 'components/SanitizedHtml/SanitizedHtml'
 import { markdownLinkToHTML } from 'lib/utils'
 import { useGetAssetDescriptionQuery } from 'state/slices/assetsSlice/assetsSlice'
-import { selectAssetByCAIP19 } from 'state/slices/selectors'
+import { selectAssetByAssetId } from 'state/slices/selectors'
 import { useAppSelector } from 'state/store'
 
 type AssetDescriptionProps = {
@@ -18,7 +18,7 @@ export const AssetDescription = ({ assetId }: AssetDescriptionProps) => {
   const translate = useTranslate()
   const [showDescription, setShowDescription] = useState(false)
   const handleToggle = () => setShowDescription(!showDescription)
-  const asset = useAppSelector(state => selectAssetByCAIP19(state, assetId))
+  const asset = useAppSelector(state => selectAssetByAssetId(state, assetId))
   const { name, description, isTrustedDescription } = asset || {}
   const query = useGetAssetDescriptionQuery(assetId)
   const isLoaded = !query.isLoading

--- a/src/components/AssetHeader/AssetDescription.tsx
+++ b/src/components/AssetHeader/AssetDescription.tsx
@@ -7,7 +7,7 @@ import { ParsedHtml } from 'components/ParsedHtml/ParsedHtml'
 import { SanitizedHtml } from 'components/SanitizedHtml/SanitizedHtml'
 import { markdownLinkToHTML } from 'lib/utils'
 import { useGetAssetDescriptionQuery } from 'state/slices/assetsSlice/assetsSlice'
-import { selectAssetByAssetId } from 'state/slices/selectors'
+import { selectAssetById } from 'state/slices/selectors'
 import { useAppSelector } from 'state/store'
 
 type AssetDescriptionProps = {
@@ -18,7 +18,7 @@ export const AssetDescription = ({ assetId }: AssetDescriptionProps) => {
   const translate = useTranslate()
   const [showDescription, setShowDescription] = useState(false)
   const handleToggle = () => setShowDescription(!showDescription)
-  const asset = useAppSelector(state => selectAssetByAssetId(state, assetId))
+  const asset = useAppSelector(state => selectAssetById(state, assetId))
   const { name, description, isTrustedDescription } = asset || {}
   const query = useGetAssetDescriptionQuery(assetId)
   const isLoaded = !query.isLoading

--- a/src/components/AssetHeader/AssetHeader.tsx
+++ b/src/components/AssetHeader/AssetHeader.tsx
@@ -6,7 +6,7 @@ import { useWalletSupportsChain } from 'hooks/useWalletSupportsChain/useWalletSu
 import { AccountSpecifier } from 'state/slices/accountSpecifiersSlice/accountSpecifiersSlice'
 import {
   selectAccountIdsByAssetId,
-  selectAssetByCAIP19,
+  selectAssetByAssetId,
   selectMarketDataById,
   selectPortfolioCryptoHumanBalanceByFilter,
 } from 'state/slices/selectors'
@@ -20,7 +20,7 @@ type AssetHeaderProps = {
 }
 
 export const AssetHeader: React.FC<AssetHeaderProps> = ({ assetId, accountId }) => {
-  const asset = useAppSelector(state => selectAssetByCAIP19(state, assetId))
+  const asset = useAppSelector(state => selectAssetByAssetId(state, assetId))
   const chainId = asset.caip2
   const marketData = useAppSelector(state => selectMarketDataById(state, assetId))
   const accountIds = useAppSelector(state => selectAccountIdsByAssetId(state, assetId))

--- a/src/components/AssetHeader/AssetHeader.tsx
+++ b/src/components/AssetHeader/AssetHeader.tsx
@@ -6,7 +6,7 @@ import { useWalletSupportsChain } from 'hooks/useWalletSupportsChain/useWalletSu
 import { AccountSpecifier } from 'state/slices/accountSpecifiersSlice/accountSpecifiersSlice'
 import {
   selectAccountIdsByAssetId,
-  selectAssetByAssetId,
+  selectAssetById,
   selectMarketDataById,
   selectPortfolioCryptoHumanBalanceByFilter,
 } from 'state/slices/selectors'
@@ -20,7 +20,7 @@ type AssetHeaderProps = {
 }
 
 export const AssetHeader: React.FC<AssetHeaderProps> = ({ assetId, accountId }) => {
-  const asset = useAppSelector(state => selectAssetByAssetId(state, assetId))
+  const asset = useAppSelector(state => selectAssetById(state, assetId))
   const chainId = asset.caip2
   const marketData = useAppSelector(state => selectMarketDataById(state, assetId))
   const accountIds = useAppSelector(state => selectAccountIdsByAssetId(state, assetId))

--- a/src/components/Breadcrumbs/Breadcrumbs.tsx
+++ b/src/components/Breadcrumbs/Breadcrumbs.tsx
@@ -2,7 +2,7 @@ import { Breadcrumb, BreadcrumbItem, BreadcrumbLink } from '@chakra-ui/react'
 import withBreadcrumbs, { BreadcrumbsRoute } from 'react-router-breadcrumbs-hoc'
 import { Link } from 'react-router-dom'
 import { AccountLabel } from 'components/AssetHeader/AccountLabel'
-import { selectAssetByAssetId } from 'state/slices/selectors'
+import { selectAssetById } from 'state/slices/selectors'
 import { useAppSelector } from 'state/store'
 
 const GetAccountName = (props: any) => {
@@ -23,7 +23,7 @@ const GetAssetName = (props: any) => {
   } = props
 
   const assetId = assetIdParam ? decodeURIComponent(assetIdParam) : `${chainId}/${assetSubId}`
-  const asset = useAppSelector(state => selectAssetByAssetId(state, assetId))
+  const asset = useAppSelector(state => selectAssetById(state, assetId))
   return <>{asset?.name}</>
 }
 

--- a/src/components/Breadcrumbs/Breadcrumbs.tsx
+++ b/src/components/Breadcrumbs/Breadcrumbs.tsx
@@ -2,7 +2,7 @@ import { Breadcrumb, BreadcrumbItem, BreadcrumbLink } from '@chakra-ui/react'
 import withBreadcrumbs, { BreadcrumbsRoute } from 'react-router-breadcrumbs-hoc'
 import { Link } from 'react-router-dom'
 import { AccountLabel } from 'components/AssetHeader/AccountLabel'
-import { selectAssetByCAIP19 } from 'state/slices/selectors'
+import { selectAssetByAssetId } from 'state/slices/selectors'
 import { useAppSelector } from 'state/store'
 
 const GetAccountName = (props: any) => {
@@ -23,7 +23,7 @@ const GetAssetName = (props: any) => {
   } = props
 
   const assetId = assetIdParam ? decodeURIComponent(assetIdParam) : `${chainId}/${assetSubId}`
-  const asset = useAppSelector(state => selectAssetByCAIP19(state, assetId))
+  const asset = useAppSelector(state => selectAssetByAssetId(state, assetId))
   return <>{asset?.name}</>
 }
 

--- a/src/components/Delegate/StakingOpportunities.tsx
+++ b/src/components/Delegate/StakingOpportunities.tsx
@@ -22,7 +22,7 @@ import { RawText, Text } from 'components/Text'
 import { useModal } from 'hooks/useModal/useModal'
 import { bnOrZero } from 'lib/bignumber/bignumber'
 import { useCosmosStakingBalances } from 'pages/Defi/hooks/useCosmosStakingBalances'
-import { selectAssetByAssetId, selectMarketDataById } from 'state/slices/selectors'
+import { selectAssetById, selectMarketDataById } from 'state/slices/selectors'
 import { ActiveStakingOpportunity } from 'state/slices/stakingDataSlice/selectors'
 import { useAppSelector } from 'state/store'
 
@@ -62,7 +62,7 @@ export const ValidatorName = ({ moniker, isStaking, validatorAddress }: Validato
 }
 
 export const StakingOpportunities = ({ assetId }: StakingOpportunitiesProps) => {
-  const asset = useAppSelector(state => selectAssetByAssetId(state, assetId))
+  const asset = useAppSelector(state => selectAssetById(state, assetId))
   const marketData = useAppSelector(state => selectMarketDataById(state, assetId))
 
   const { activeStakingOpportunities, stakingOpportunities, isLoaded } = useCosmosStakingBalances({

--- a/src/components/Delegate/StakingOpportunities.tsx
+++ b/src/components/Delegate/StakingOpportunities.tsx
@@ -22,7 +22,7 @@ import { RawText, Text } from 'components/Text'
 import { useModal } from 'hooks/useModal/useModal'
 import { bnOrZero } from 'lib/bignumber/bignumber'
 import { useCosmosStakingBalances } from 'pages/Defi/hooks/useCosmosStakingBalances'
-import { selectAssetByCAIP19, selectMarketDataById } from 'state/slices/selectors'
+import { selectAssetByAssetId, selectMarketDataById } from 'state/slices/selectors'
 import { ActiveStakingOpportunity } from 'state/slices/stakingDataSlice/selectors'
 import { useAppSelector } from 'state/store'
 
@@ -62,7 +62,7 @@ export const ValidatorName = ({ moniker, isStaking, validatorAddress }: Validato
 }
 
 export const StakingOpportunities = ({ assetId }: StakingOpportunitiesProps) => {
-  const asset = useAppSelector(state => selectAssetByCAIP19(state, assetId))
+  const asset = useAppSelector(state => selectAssetByAssetId(state, assetId))
   const marketData = useAppSelector(state => selectMarketDataById(state, assetId))
 
   const { activeStakingOpportunities, stakingOpportunities, isLoaded } = useCosmosStakingBalances({

--- a/src/components/Modals/Send/hooks/useSendFees/useSendFees.test.tsx
+++ b/src/components/Modals/Send/hooks/useSendFees/useSendFees.test.tsx
@@ -12,7 +12,7 @@ jest.mock('react-hook-form')
 jest.mock('hooks/useWallet/useWallet')
 jest.mock('state/slices/selectors', () => ({
   ...jest.requireActual('state/slices/selectors'),
-  selectAssetByCAIP19: (_state: ReduxState, _id: AssetId) => mockEthAsset,
+  selectAssetByAssetId: (_state: ReduxState, _id: AssetId) => mockEthAsset,
   selectFeeAssetById: (_state: ReduxState, _id: AssetId) => mockEthAsset,
   selectMarketDataById: () => mockEthAsset,
 }))

--- a/src/components/Modals/Send/hooks/useSendFees/useSendFees.test.tsx
+++ b/src/components/Modals/Send/hooks/useSendFees/useSendFees.test.tsx
@@ -12,7 +12,7 @@ jest.mock('react-hook-form')
 jest.mock('hooks/useWallet/useWallet')
 jest.mock('state/slices/selectors', () => ({
   ...jest.requireActual('state/slices/selectors'),
-  selectAssetByAssetId: (_state: ReduxState, _id: AssetId) => mockEthAsset,
+  selectAssetById: (_state: ReduxState, _id: AssetId) => mockEthAsset,
   selectFeeAssetById: (_state: ReduxState, _id: AssetId) => mockEthAsset,
   selectMarketDataById: () => mockEthAsset,
 }))

--- a/src/components/SelectAssets/SelectAccount.tsx
+++ b/src/components/SelectAssets/SelectAccount.tsx
@@ -7,7 +7,7 @@ import { useHistory, useLocation } from 'react-router'
 import { AssetAccountRow } from 'components/AssetAccounts/AssetAccountRow'
 import { SlideTransition } from 'components/SlideTransition'
 import { AccountSpecifier } from 'state/slices/accountSpecifiersSlice/accountSpecifiersSlice'
-import { selectAccountIdsByAssetId, selectAssetByCAIP19 } from 'state/slices/selectors'
+import { selectAccountIdsByAssetId, selectAssetByAssetId } from 'state/slices/selectors'
 import { useAppSelector } from 'state/store'
 
 import { SelectAssetRoutes } from './SelectAssetCommon'
@@ -27,7 +27,7 @@ export const SelectAccount = ({ onClick, ...rest }: SelectAccountProps) => {
   const accountIds = useAppSelector(state =>
     selectAccountIdsByAssetId(state, location.state.assetId),
   )
-  const asset = useAppSelector(state => selectAssetByCAIP19(state, location.state.assetId))
+  const asset = useAppSelector(state => selectAssetByAssetId(state, location.state.assetId))
   return (
     <SlideTransition>
       <ModalHeader textAlign='center' display='grid' gridTemplateColumns='32px 1fr 32px' px={2}>

--- a/src/components/SelectAssets/SelectAccount.tsx
+++ b/src/components/SelectAssets/SelectAccount.tsx
@@ -7,7 +7,7 @@ import { useHistory, useLocation } from 'react-router'
 import { AssetAccountRow } from 'components/AssetAccounts/AssetAccountRow'
 import { SlideTransition } from 'components/SlideTransition'
 import { AccountSpecifier } from 'state/slices/accountSpecifiersSlice/accountSpecifiersSlice'
-import { selectAccountIdsByAssetId, selectAssetByAssetId } from 'state/slices/selectors'
+import { selectAccountIdsByAssetId, selectAssetById } from 'state/slices/selectors'
 import { useAppSelector } from 'state/store'
 
 import { SelectAssetRoutes } from './SelectAssetCommon'
@@ -27,7 +27,7 @@ export const SelectAccount = ({ onClick, ...rest }: SelectAccountProps) => {
   const accountIds = useAppSelector(state =>
     selectAccountIdsByAssetId(state, location.state.assetId),
   )
-  const asset = useAppSelector(state => selectAssetByAssetId(state, location.state.assetId))
+  const asset = useAppSelector(state => selectAssetById(state, location.state.assetId))
   return (
     <SlideTransition>
       <ModalHeader textAlign='center' display='grid' gridTemplateColumns='32px 1fr 32px' px={2}>

--- a/src/components/StakingVaults/AssetTeaser.tsx
+++ b/src/components/StakingVaults/AssetTeaser.tsx
@@ -17,11 +17,11 @@ import { Link } from 'react-router-dom'
 import { AssetIcon } from 'components/AssetIcon'
 import { RawText, Text } from 'components/Text'
 import { useGetAssetDescriptionQuery } from 'state/slices/assetsSlice/assetsSlice'
-import { selectAssetByAssetId } from 'state/slices/selectors'
+import { selectAssetById } from 'state/slices/selectors'
 import { useAppSelector } from 'state/store'
 
 export const AssetTeaser = ({ assetId }: { assetId: AssetId }) => {
-  const asset = useAppSelector(state => selectAssetByAssetId(state, assetId))
+  const asset = useAppSelector(state => selectAssetById(state, assetId))
   const { description, icon, name } = asset || {}
   const { isLoading } = useGetAssetDescriptionQuery(assetId, { skip: !!description })
   const url = useMemo(() => (assetId ? `/assets/${assetId}` : ''), [assetId])

--- a/src/components/StakingVaults/AssetTeaser.tsx
+++ b/src/components/StakingVaults/AssetTeaser.tsx
@@ -17,11 +17,11 @@ import { Link } from 'react-router-dom'
 import { AssetIcon } from 'components/AssetIcon'
 import { RawText, Text } from 'components/Text'
 import { useGetAssetDescriptionQuery } from 'state/slices/assetsSlice/assetsSlice'
-import { selectAssetByCAIP19 } from 'state/slices/selectors'
+import { selectAssetByAssetId } from 'state/slices/selectors'
 import { useAppSelector } from 'state/store'
 
 export const AssetTeaser = ({ assetId }: { assetId: AssetId }) => {
-  const asset = useAppSelector(state => selectAssetByCAIP19(state, assetId))
+  const asset = useAppSelector(state => selectAssetByAssetId(state, assetId))
   const { description, icon, name } = asset || {}
   const { isLoading } = useGetAssetDescriptionQuery(assetId, { skip: !!description })
   const url = useMemo(() => (assetId ? `/assets/${assetId}` : ''), [assetId])

--- a/src/components/StakingVaults/Cells.tsx
+++ b/src/components/StakingVaults/Cells.tsx
@@ -15,7 +15,7 @@ import { useState } from 'react'
 import { FaInfoCircle } from 'react-icons/fa'
 import { AssetIcon } from 'components/AssetIcon'
 import { RawText } from 'components/Text'
-import { selectAssetByAssetId } from 'state/slices/selectors'
+import { selectAssetById } from 'state/slices/selectors'
 import { useAppSelector } from 'state/store'
 
 import { AssetTeaser } from './AssetTeaser'
@@ -57,7 +57,7 @@ export const AssetCell = ({
   const linkColor = useColorModeValue('black', 'white')
   const debouncedHandleMouseEnter = debounce(() => setShowPopover(true), 100)
   const handleOnMouseLeave = debouncedHandleMouseEnter.cancel
-  const asset = useAppSelector(state => selectAssetByAssetId(state, assetId))
+  const asset = useAppSelector(state => selectAssetById(state, assetId))
 
   if (!asset) return null
 

--- a/src/components/StakingVaults/Cells.tsx
+++ b/src/components/StakingVaults/Cells.tsx
@@ -15,7 +15,7 @@ import { useState } from 'react'
 import { FaInfoCircle } from 'react-icons/fa'
 import { AssetIcon } from 'components/AssetIcon'
 import { RawText } from 'components/Text'
-import { selectAssetByCAIP19 } from 'state/slices/selectors'
+import { selectAssetByAssetId } from 'state/slices/selectors'
 import { useAppSelector } from 'state/store'
 
 import { AssetTeaser } from './AssetTeaser'
@@ -57,7 +57,7 @@ export const AssetCell = ({
   const linkColor = useColorModeValue('black', 'white')
   const debouncedHandleMouseEnter = debounce(() => setShowPopover(true), 100)
   const handleOnMouseLeave = debouncedHandleMouseEnter.cancel
-  const asset = useAppSelector(state => selectAssetByCAIP19(state, assetId))
+  const asset = useAppSelector(state => selectAssetByAssetId(state, assetId))
 
   if (!asset) return null
 

--- a/src/components/StakingVaults/EarnOpportunities.tsx
+++ b/src/components/StakingVaults/EarnOpportunities.tsx
@@ -14,7 +14,7 @@ import { useWallet } from 'hooks/useWallet/useWallet'
 import { useYearnVaults } from 'hooks/useYearnVaults/useYearnVaults'
 import { useFoxyBalances } from 'pages/Defi/hooks/useFoxyBalances'
 import { AccountSpecifier } from 'state/slices/portfolioSlice/portfolioSliceCommon'
-import { selectAssetByAssetId, selectFeatureFlag } from 'state/slices/selectors'
+import { selectAssetById, selectFeatureFlag } from 'state/slices/selectors'
 import { useAppSelector } from 'state/store'
 
 import { StakingTable } from './StakingTable'
@@ -33,7 +33,7 @@ export const EarnOpportunities = ({ assetId: caip19 }: EarnOpportunitiesProps) =
     state: { isConnected },
     dispatch,
   } = useWallet()
-  const asset = useAppSelector(state => selectAssetByAssetId(state, caip19))
+  const asset = useAppSelector(state => selectAssetById(state, caip19))
   const foxyInvestorFeatureFlag = useAppSelector(state => selectFeatureFlag(state, 'FoxyInvestor'))
   const vaults = useYearnVaults()
   const { opportunities } = useFoxyBalances()

--- a/src/components/StakingVaults/EarnOpportunities.tsx
+++ b/src/components/StakingVaults/EarnOpportunities.tsx
@@ -14,7 +14,7 @@ import { useWallet } from 'hooks/useWallet/useWallet'
 import { useYearnVaults } from 'hooks/useYearnVaults/useYearnVaults'
 import { useFoxyBalances } from 'pages/Defi/hooks/useFoxyBalances'
 import { AccountSpecifier } from 'state/slices/portfolioSlice/portfolioSliceCommon'
-import { selectAssetByCAIP19, selectFeatureFlag } from 'state/slices/selectors'
+import { selectAssetByAssetId, selectFeatureFlag } from 'state/slices/selectors'
 import { useAppSelector } from 'state/store'
 
 import { StakingTable } from './StakingTable'
@@ -33,7 +33,7 @@ export const EarnOpportunities = ({ assetId: caip19 }: EarnOpportunitiesProps) =
     state: { isConnected },
     dispatch,
   } = useWallet()
-  const asset = useAppSelector(state => selectAssetByCAIP19(state, caip19))
+  const asset = useAppSelector(state => selectAssetByAssetId(state, caip19))
   const foxyInvestorFeatureFlag = useAppSelector(state => selectFeatureFlag(state, 'FoxyInvestor'))
   const vaults = useYearnVaults()
   const { opportunities } = useFoxyBalances()

--- a/src/components/Trade/TradeInput.tsx
+++ b/src/components/Trade/TradeInput.tsx
@@ -25,7 +25,7 @@ import { useWallet } from 'hooks/useWallet/useWallet'
 import { bnOrZero } from 'lib/bignumber/bignumber'
 import { firstNonZeroDecimal } from 'lib/math'
 import {
-  selectAssetByAssetId,
+  selectAssetById,
   selectFeeAssetById,
   selectPortfolioCryptoHumanBalanceByAssetId,
 } from 'state/slices/selectors'
@@ -71,7 +71,7 @@ export const TradeInput = ({ history }: RouterProps) => {
   const feeAsset = useAppSelector(state =>
     sellAsset
       ? selectFeeAssetById(state, sellAsset?.currency?.caip19)
-      : selectAssetByAssetId(state, 'eip155:1/slip44:60'),
+      : selectAssetById(state, 'eip155:1/slip44:60'),
   )
   const feeAssetBalance = useAppSelector(state =>
     feeAsset ? selectPortfolioCryptoHumanBalanceByAssetId(state, feeAsset?.caip19) : null,

--- a/src/components/Trade/TradeInput.tsx
+++ b/src/components/Trade/TradeInput.tsx
@@ -25,7 +25,7 @@ import { useWallet } from 'hooks/useWallet/useWallet'
 import { bnOrZero } from 'lib/bignumber/bignumber'
 import { firstNonZeroDecimal } from 'lib/math'
 import {
-  selectAssetByCAIP19,
+  selectAssetByAssetId,
   selectFeeAssetById,
   selectPortfolioCryptoHumanBalanceByAssetId,
 } from 'state/slices/selectors'
@@ -71,7 +71,7 @@ export const TradeInput = ({ history }: RouterProps) => {
   const feeAsset = useAppSelector(state =>
     sellAsset
       ? selectFeeAssetById(state, sellAsset?.currency?.caip19)
-      : selectAssetByCAIP19(state, 'eip155:1/slip44:60'),
+      : selectAssetByAssetId(state, 'eip155:1/slip44:60'),
   )
   const feeAssetBalance = useAppSelector(state =>
     feeAsset ? selectPortfolioCryptoHumanBalanceByAssetId(state, feeAsset?.caip19) : null,

--- a/src/components/TransactionHistory/AssetTransactionHistory.tsx
+++ b/src/components/TransactionHistory/AssetTransactionHistory.tsx
@@ -8,7 +8,7 @@ import { useWalletSupportsChain } from 'hooks/useWalletSupportsChain/useWalletSu
 import { AccountSpecifier } from 'state/slices/accountSpecifiersSlice/accountSpecifiersSlice'
 import {
   selectAccountIdsByAssetId,
-  selectAssetByAssetId,
+  selectAssetById,
   selectTxIdsByFilter,
 } from 'state/slices/selectors'
 import { useAppSelector } from 'state/store'
@@ -31,7 +31,7 @@ export const AssetTransactionHistory: React.FC<AssetTransactionHistoryProps> = (
     state: { wallet },
   } = useWallet()
 
-  const asset = useAppSelector(state => selectAssetByAssetId(state, assetId))
+  const asset = useAppSelector(state => selectAssetById(state, assetId))
   const chainId = asset.caip2
   const accountIds = useAppSelector(state => selectAccountIdsByAssetId(state, assetId))
   const filter = useMemo(

--- a/src/components/TransactionHistory/AssetTransactionHistory.tsx
+++ b/src/components/TransactionHistory/AssetTransactionHistory.tsx
@@ -8,7 +8,7 @@ import { useWalletSupportsChain } from 'hooks/useWalletSupportsChain/useWalletSu
 import { AccountSpecifier } from 'state/slices/accountSpecifiersSlice/accountSpecifiersSlice'
 import {
   selectAccountIdsByAssetId,
-  selectAssetByCAIP19,
+  selectAssetByAssetId,
   selectTxIdsByFilter,
 } from 'state/slices/selectors'
 import { useAppSelector } from 'state/store'
@@ -31,7 +31,7 @@ export const AssetTransactionHistory: React.FC<AssetTransactionHistoryProps> = (
     state: { wallet },
   } = useWallet()
 
-  const asset = useAppSelector(state => selectAssetByCAIP19(state, assetId))
+  const asset = useAppSelector(state => selectAssetByAssetId(state, assetId))
   const chainId = asset.caip2
   const accountIds = useAppSelector(state => selectAccountIdsByAssetId(state, assetId))
   const filter = useMemo(

--- a/src/components/TransactionHistory/TransactionsGroupByDate.tsx
+++ b/src/components/TransactionHistory/TransactionsGroupByDate.tsx
@@ -6,7 +6,7 @@ import { TransactionDate } from 'components/TransactionHistoryRows/TransactionDa
 import { TransactionRow } from 'components/TransactionHistoryRows/TransactionRow'
 import { useResizeObserver } from 'hooks/useResizeObserver/useResizeObserver'
 import { MatchParams } from 'pages/Assets/Asset'
-import { selectAssetByAssetId, selectTxDateByIds } from 'state/slices/selectors'
+import { selectAssetById, selectTxDateByIds } from 'state/slices/selectors'
 import { TxId } from 'state/slices/txHistorySlice/txHistorySlice'
 import { useAppSelector } from 'state/store'
 
@@ -26,7 +26,7 @@ export const TransactionsGroupByDate: React.FC<TransactionsGroupByDateProps> = (
 }) => {
   const params = useParams<MatchParams>()
   const assetId = `${params.chainId}/${params.assetSubId}`
-  const asset = useAppSelector(state => selectAssetByAssetId(state, assetId))
+  const asset = useAppSelector(state => selectAssetById(state, assetId))
 
   const { setNode, entry } = useResizeObserver()
   const transactions = useAppSelector(state => selectTxDateByIds(state, txIds))

--- a/src/components/TransactionHistory/TransactionsGroupByDate.tsx
+++ b/src/components/TransactionHistory/TransactionsGroupByDate.tsx
@@ -6,7 +6,7 @@ import { TransactionDate } from 'components/TransactionHistoryRows/TransactionDa
 import { TransactionRow } from 'components/TransactionHistoryRows/TransactionRow'
 import { useResizeObserver } from 'hooks/useResizeObserver/useResizeObserver'
 import { MatchParams } from 'pages/Assets/Asset'
-import { selectAssetByCAIP19, selectTxDateByIds } from 'state/slices/selectors'
+import { selectAssetByAssetId, selectTxDateByIds } from 'state/slices/selectors'
 import { TxId } from 'state/slices/txHistorySlice/txHistorySlice'
 import { useAppSelector } from 'state/store'
 
@@ -26,7 +26,7 @@ export const TransactionsGroupByDate: React.FC<TransactionsGroupByDateProps> = (
 }) => {
   const params = useParams<MatchParams>()
   const assetId = `${params.chainId}/${params.assetSubId}`
-  const asset = useAppSelector(state => selectAssetByCAIP19(state, assetId))
+  const asset = useAppSelector(state => selectAssetByAssetId(state, assetId))
 
   const { setNode, entry } = useResizeObserver()
   const transactions = useAppSelector(state => selectTxDateByIds(state, txIds))

--- a/src/components/TransactionHistoryRows/TransactionDetails/TransferCol.tsx
+++ b/src/components/TransactionHistoryRows/TransactionDetails/TransferCol.tsx
@@ -1,7 +1,7 @@
 import { Stack, useColorModeValue } from '@chakra-ui/react'
 import { TxTransfer } from '@shapeshiftoss/types/dist/chain-adapters'
 import { AssetIcon } from 'components/AssetIcon'
-import { selectAssetByAssetId } from 'state/slices/assetsSlice/selectors'
+import { selectAssetById } from 'state/slices/assetsSlice/selectors'
 import { useAppSelector } from 'state/store'
 
 import { Address } from './Address'
@@ -13,7 +13,7 @@ type TransferColumnProps = {
 } & TxTransfer
 
 export const TransferColumn = (transfer: TransferColumnProps) => {
-  const asset = useAppSelector(state => selectAssetByAssetId(state, transfer.caip19))
+  const asset = useAppSelector(state => selectAssetById(state, transfer.caip19))
   const bgColor = useColorModeValue('white', 'whiteAlpha.100')
   return (
     <Stack

--- a/src/components/TransactionHistoryRows/TransactionDetails/TransferCol.tsx
+++ b/src/components/TransactionHistoryRows/TransactionDetails/TransferCol.tsx
@@ -1,7 +1,7 @@
 import { Stack, useColorModeValue } from '@chakra-ui/react'
 import { TxTransfer } from '@shapeshiftoss/types/dist/chain-adapters'
 import { AssetIcon } from 'components/AssetIcon'
-import { selectAssetByCAIP19 } from 'state/slices/assetsSlice/selectors'
+import { selectAssetByAssetId } from 'state/slices/assetsSlice/selectors'
 import { useAppSelector } from 'state/store'
 
 import { Address } from './Address'
@@ -13,7 +13,7 @@ type TransferColumnProps = {
 } & TxTransfer
 
 export const TransferColumn = (transfer: TransferColumnProps) => {
-  const asset = useAppSelector(state => selectAssetByCAIP19(state, transfer.caip19))
+  const asset = useAppSelector(state => selectAssetByAssetId(state, transfer.caip19))
   const bgColor = useColorModeValue('white', 'whiteAlpha.100')
   return (
     <Stack

--- a/src/components/Transactions/AllTransactions.tsx
+++ b/src/components/Transactions/AllTransactions.tsx
@@ -12,7 +12,7 @@ import { useWalletSupportsChain } from 'hooks/useWalletSupportsChain/useWalletSu
 import { AccountSpecifier } from 'state/slices/accountSpecifiersSlice/accountSpecifiersSlice'
 import {
   selectAccountIdsByAssetId,
-  selectAssetByAssetId,
+  selectAssetById,
   selectTxIdsByFilter,
 } from 'state/slices/selectors'
 import { useAppSelector } from 'state/store'
@@ -26,7 +26,7 @@ export const AllTransactions: React.FC<AssetTransactionProps> = ({ assetId, acco
   const {
     state: { wallet },
   } = useWallet()
-  const asset = useAppSelector(state => selectAssetByAssetId(state, assetId))
+  const asset = useAppSelector(state => selectAssetById(state, assetId))
   const chainId = asset.caip2
   const accountIds = useAppSelector(state => selectAccountIdsByAssetId(state, assetId))
   const filter = useMemo(

--- a/src/components/Transactions/AllTransactions.tsx
+++ b/src/components/Transactions/AllTransactions.tsx
@@ -12,7 +12,7 @@ import { useWalletSupportsChain } from 'hooks/useWalletSupportsChain/useWalletSu
 import { AccountSpecifier } from 'state/slices/accountSpecifiersSlice/accountSpecifiersSlice'
 import {
   selectAccountIdsByAssetId,
-  selectAssetByCAIP19,
+  selectAssetByAssetId,
   selectTxIdsByFilter,
 } from 'state/slices/selectors'
 import { useAppSelector } from 'state/store'
@@ -26,7 +26,7 @@ export const AllTransactions: React.FC<AssetTransactionProps> = ({ assetId, acco
   const {
     state: { wallet },
   } = useWallet()
-  const asset = useAppSelector(state => selectAssetByCAIP19(state, assetId))
+  const asset = useAppSelector(state => selectAssetByAssetId(state, assetId))
   const chainId = asset.caip2
   const accountIds = useAppSelector(state => selectAccountIdsByAssetId(state, assetId))
   const filter = useMemo(

--- a/src/components/UnderlyingToken.tsx
+++ b/src/components/UnderlyingToken.tsx
@@ -11,7 +11,7 @@ import { Text } from 'components/Text'
 import { useWallet } from 'hooks/useWallet/useWallet'
 import { useYearnVaults } from 'hooks/useYearnVaults/useYearnVaults'
 import { AccountSpecifier } from 'state/slices/accountSpecifiersSlice/accountSpecifiersSlice'
-import { selectAssetByAssetId } from 'state/slices/selectors'
+import { selectAssetById } from 'state/slices/selectors'
 import { useAppSelector } from 'state/store'
 
 type UnderlyingTokenProps = {
@@ -27,7 +27,7 @@ export const UnderlyingToken = ({ assetId, accountId }: UnderlyingTokenProps) =>
   const vaults: SupportedYearnVault[] = useYearnVaults()
 
   // Get asset from caip19
-  const asset = useAppSelector(state => selectAssetByAssetId(state, assetId))
+  const asset = useAppSelector(state => selectAssetById(state, assetId))
 
   const {
     state: { wallet },

--- a/src/components/UnderlyingToken.tsx
+++ b/src/components/UnderlyingToken.tsx
@@ -11,7 +11,7 @@ import { Text } from 'components/Text'
 import { useWallet } from 'hooks/useWallet/useWallet'
 import { useYearnVaults } from 'hooks/useYearnVaults/useYearnVaults'
 import { AccountSpecifier } from 'state/slices/accountSpecifiersSlice/accountSpecifiersSlice'
-import { selectAssetByCAIP19 } from 'state/slices/selectors'
+import { selectAssetByAssetId } from 'state/slices/selectors'
 import { useAppSelector } from 'state/store'
 
 type UnderlyingTokenProps = {
@@ -27,7 +27,7 @@ export const UnderlyingToken = ({ assetId, accountId }: UnderlyingTokenProps) =>
   const vaults: SupportedYearnVault[] = useYearnVaults()
 
   // Get asset from caip19
-  const asset = useAppSelector(state => selectAssetByCAIP19(state, assetId))
+  const asset = useAppSelector(state => selectAssetByAssetId(state, assetId))
 
   const {
     state: { wallet },

--- a/src/features/defi/providers/foxy/components/FoxyManager/Deposit/FoxyDeposit.tsx
+++ b/src/features/defi/providers/foxy/components/FoxyManager/Deposit/FoxyDeposit.tsx
@@ -17,7 +17,7 @@ import { useWallet } from 'hooks/useWallet/useWallet'
 import { bnOrZero } from 'lib/bignumber/bignumber'
 import { marketApi } from 'state/slices/marketDataSlice/marketDataSlice'
 import {
-  selectAssetByCAIP19,
+  selectAssetByAssetId,
   selectMarketDataById,
   selectPortfolioLoading,
 } from 'state/slices/selectors'
@@ -47,7 +47,7 @@ export const FoxyDeposit = ({ api }: FoxyDepositProps) => {
   const assetNamespace = AssetNamespace.ERC20
   const assetId = caip19.toCAIP19({ chain, network, assetNamespace, assetReference: tokenId })
 
-  const asset = useAppSelector(state => selectAssetByCAIP19(state, assetId))
+  const asset = useAppSelector(state => selectAssetByAssetId(state, assetId))
   const marketData = useAppSelector(state => selectMarketDataById(state, assetId))
   if (!marketData) appDispatch(marketApi.endpoints.findByCaip19.initiate(assetId))
 

--- a/src/features/defi/providers/foxy/components/FoxyManager/Deposit/FoxyDeposit.tsx
+++ b/src/features/defi/providers/foxy/components/FoxyManager/Deposit/FoxyDeposit.tsx
@@ -17,7 +17,7 @@ import { useWallet } from 'hooks/useWallet/useWallet'
 import { bnOrZero } from 'lib/bignumber/bignumber'
 import { marketApi } from 'state/slices/marketDataSlice/marketDataSlice'
 import {
-  selectAssetByAssetId,
+  selectAssetById,
   selectMarketDataById,
   selectPortfolioLoading,
 } from 'state/slices/selectors'
@@ -47,7 +47,7 @@ export const FoxyDeposit = ({ api }: FoxyDepositProps) => {
   const assetNamespace = AssetNamespace.ERC20
   const assetId = caip19.toCAIP19({ chain, network, assetNamespace, assetReference: tokenId })
 
-  const asset = useAppSelector(state => selectAssetByAssetId(state, assetId))
+  const asset = useAppSelector(state => selectAssetById(state, assetId))
   const marketData = useAppSelector(state => selectMarketDataById(state, assetId))
   if (!marketData) appDispatch(marketApi.endpoints.findByCaip19.initiate(assetId))
 

--- a/src/features/defi/providers/foxy/components/FoxyManager/Deposit/components/Approve.tsx
+++ b/src/features/defi/providers/foxy/components/FoxyManager/Deposit/components/Approve.tsx
@@ -14,7 +14,7 @@ import { useWallet } from 'hooks/useWallet/useWallet'
 import { bnOrZero } from 'lib/bignumber/bignumber'
 import { poll } from 'lib/poll/poll'
 import { marketApi } from 'state/slices/marketDataSlice/marketDataSlice'
-import { selectAssetByCAIP19, selectMarketDataById } from 'state/slices/selectors'
+import { selectAssetByAssetId, selectMarketDataById } from 'state/slices/selectors'
 import { useAppDispatch, useAppSelector } from 'state/store'
 
 import { DepositPath } from '../DepositCommon'
@@ -45,10 +45,10 @@ export const Approve = ({ api, getDepositGasEstimate }: FoxyApproveProps) => {
     assetReference: AssetReference.Ethereum,
   })
 
-  const asset = useAppSelector(state => selectAssetByCAIP19(state, assetId))
+  const asset = useAppSelector(state => selectAssetByAssetId(state, assetId))
   const marketData = useAppSelector(state => selectMarketDataById(state, assetId))
   if (!marketData) appDispatch(marketApi.endpoints.findByCaip19.initiate(assetId))
-  const feeAsset = useAppSelector(state => selectAssetByCAIP19(state, feeAssetId))
+  const feeAsset = useAppSelector(state => selectAssetByAssetId(state, feeAssetId))
   const feeMarketData = useAppSelector(state => selectMarketDataById(state, feeAssetId))
 
   // user info

--- a/src/features/defi/providers/foxy/components/FoxyManager/Deposit/components/Approve.tsx
+++ b/src/features/defi/providers/foxy/components/FoxyManager/Deposit/components/Approve.tsx
@@ -14,7 +14,7 @@ import { useWallet } from 'hooks/useWallet/useWallet'
 import { bnOrZero } from 'lib/bignumber/bignumber'
 import { poll } from 'lib/poll/poll'
 import { marketApi } from 'state/slices/marketDataSlice/marketDataSlice'
-import { selectAssetByAssetId, selectMarketDataById } from 'state/slices/selectors'
+import { selectAssetById, selectMarketDataById } from 'state/slices/selectors'
 import { useAppDispatch, useAppSelector } from 'state/store'
 
 import { DepositPath } from '../DepositCommon'
@@ -45,10 +45,10 @@ export const Approve = ({ api, getDepositGasEstimate }: FoxyApproveProps) => {
     assetReference: AssetReference.Ethereum,
   })
 
-  const asset = useAppSelector(state => selectAssetByAssetId(state, assetId))
+  const asset = useAppSelector(state => selectAssetById(state, assetId))
   const marketData = useAppSelector(state => selectMarketDataById(state, assetId))
   if (!marketData) appDispatch(marketApi.endpoints.findByCaip19.initiate(assetId))
-  const feeAsset = useAppSelector(state => selectAssetByAssetId(state, feeAssetId))
+  const feeAsset = useAppSelector(state => selectAssetById(state, feeAssetId))
   const feeMarketData = useAppSelector(state => selectMarketDataById(state, feeAssetId))
 
   // user info

--- a/src/features/defi/providers/foxy/components/FoxyManager/Deposit/components/Confirm.tsx
+++ b/src/features/defi/providers/foxy/components/FoxyManager/Deposit/components/Confirm.tsx
@@ -18,7 +18,7 @@ import { useWallet } from 'hooks/useWallet/useWallet'
 import { bnOrZero } from 'lib/bignumber/bignumber'
 import { poll } from 'lib/poll/poll'
 import { marketApi } from 'state/slices/marketDataSlice/marketDataSlice'
-import { selectAssetByAssetId, selectMarketDataById } from 'state/slices/selectors'
+import { selectAssetById, selectMarketDataById } from 'state/slices/selectors'
 import { useAppDispatch, useAppSelector } from 'state/store'
 
 import { DepositPath } from '../DepositCommon'
@@ -47,10 +47,10 @@ export const Confirm = ({ api, apy }: FoxyConfirmProps) => {
     assetReference: AssetReference.Ethereum,
   })
 
-  const asset = useAppSelector(state => selectAssetByAssetId(state, assetId))
+  const asset = useAppSelector(state => selectAssetById(state, assetId))
   const marketData = useAppSelector(state => selectMarketDataById(state, assetId))
   if (!marketData) appDispatch(marketApi.endpoints.findByCaip19.initiate(assetId))
-  const feeAsset = useAppSelector(state => selectAssetByAssetId(state, feeAssetId))
+  const feeAsset = useAppSelector(state => selectAssetById(state, feeAssetId))
   const feeMarketData = useAppSelector(state => selectMarketDataById(state, feeAssetId))
   const contractAssetId = caip19.toCAIP19({
     chain,
@@ -58,7 +58,7 @@ export const Confirm = ({ api, apy }: FoxyConfirmProps) => {
     assetNamespace,
     assetReference: rewardId,
   })
-  const contractAsset = useAppSelector(state => selectAssetByAssetId(state, contractAssetId))
+  const contractAsset = useAppSelector(state => selectAssetById(state, contractAssetId))
 
   // user info
   const { state: walletState } = useWallet()

--- a/src/features/defi/providers/foxy/components/FoxyManager/Deposit/components/Confirm.tsx
+++ b/src/features/defi/providers/foxy/components/FoxyManager/Deposit/components/Confirm.tsx
@@ -18,7 +18,7 @@ import { useWallet } from 'hooks/useWallet/useWallet'
 import { bnOrZero } from 'lib/bignumber/bignumber'
 import { poll } from 'lib/poll/poll'
 import { marketApi } from 'state/slices/marketDataSlice/marketDataSlice'
-import { selectAssetByCAIP19, selectMarketDataById } from 'state/slices/selectors'
+import { selectAssetByAssetId, selectMarketDataById } from 'state/slices/selectors'
 import { useAppDispatch, useAppSelector } from 'state/store'
 
 import { DepositPath } from '../DepositCommon'
@@ -47,10 +47,10 @@ export const Confirm = ({ api, apy }: FoxyConfirmProps) => {
     assetReference: AssetReference.Ethereum,
   })
 
-  const asset = useAppSelector(state => selectAssetByCAIP19(state, assetId))
+  const asset = useAppSelector(state => selectAssetByAssetId(state, assetId))
   const marketData = useAppSelector(state => selectMarketDataById(state, assetId))
   if (!marketData) appDispatch(marketApi.endpoints.findByCaip19.initiate(assetId))
-  const feeAsset = useAppSelector(state => selectAssetByCAIP19(state, feeAssetId))
+  const feeAsset = useAppSelector(state => selectAssetByAssetId(state, feeAssetId))
   const feeMarketData = useAppSelector(state => selectMarketDataById(state, feeAssetId))
   const contractAssetId = caip19.toCAIP19({
     chain,
@@ -58,7 +58,7 @@ export const Confirm = ({ api, apy }: FoxyConfirmProps) => {
     assetNamespace,
     assetReference: rewardId,
   })
-  const contractAsset = useAppSelector(state => selectAssetByCAIP19(state, contractAssetId))
+  const contractAsset = useAppSelector(state => selectAssetByAssetId(state, contractAssetId))
 
   // user info
   const { state: walletState } = useWallet()

--- a/src/features/defi/providers/foxy/components/FoxyManager/Deposit/components/Deposit.tsx
+++ b/src/features/defi/providers/foxy/components/FoxyManager/Deposit/components/Deposit.tsx
@@ -11,7 +11,7 @@ import { useBrowserRouter } from 'hooks/useBrowserRouter/useBrowserRouter'
 import { bnOrZero } from 'lib/bignumber/bignumber'
 import { marketApi } from 'state/slices/marketDataSlice/marketDataSlice'
 import {
-  selectAssetByCAIP19,
+  selectAssetByAssetId,
   selectMarketDataById,
   selectPortfolioCryptoBalanceByAssetId,
 } from 'state/slices/selectors'
@@ -38,7 +38,7 @@ export const Deposit = ({ api, apy, getDepositGasEstimate }: FoxyDepositProps) =
   const assetNamespace = AssetNamespace.ERC20
   const assetId = caip19.toCAIP19({ chain, network, assetNamespace, assetReference: tokenId })
 
-  const asset = useAppSelector(state => selectAssetByCAIP19(state, assetId))
+  const asset = useAppSelector(state => selectAssetByAssetId(state, assetId))
   const marketData = useAppSelector(state => selectMarketDataById(state, assetId))
   if (!marketData) appDispatch(marketApi.endpoints.findByCaip19.initiate(assetId))
 

--- a/src/features/defi/providers/foxy/components/FoxyManager/Deposit/components/Deposit.tsx
+++ b/src/features/defi/providers/foxy/components/FoxyManager/Deposit/components/Deposit.tsx
@@ -11,7 +11,7 @@ import { useBrowserRouter } from 'hooks/useBrowserRouter/useBrowserRouter'
 import { bnOrZero } from 'lib/bignumber/bignumber'
 import { marketApi } from 'state/slices/marketDataSlice/marketDataSlice'
 import {
-  selectAssetByAssetId,
+  selectAssetById,
   selectMarketDataById,
   selectPortfolioCryptoBalanceByAssetId,
 } from 'state/slices/selectors'
@@ -38,7 +38,7 @@ export const Deposit = ({ api, apy, getDepositGasEstimate }: FoxyDepositProps) =
   const assetNamespace = AssetNamespace.ERC20
   const assetId = caip19.toCAIP19({ chain, network, assetNamespace, assetReference: tokenId })
 
-  const asset = useAppSelector(state => selectAssetByAssetId(state, assetId))
+  const asset = useAppSelector(state => selectAssetById(state, assetId))
   const marketData = useAppSelector(state => selectMarketDataById(state, assetId))
   if (!marketData) appDispatch(marketApi.endpoints.findByCaip19.initiate(assetId))
 

--- a/src/features/defi/providers/foxy/components/FoxyManager/Deposit/components/Status.tsx
+++ b/src/features/defi/providers/foxy/components/FoxyManager/Deposit/components/Status.tsx
@@ -15,7 +15,7 @@ import { Text } from 'components/Text'
 import { useBrowserRouter } from 'hooks/useBrowserRouter/useBrowserRouter'
 import { bnOrZero } from 'lib/bignumber/bignumber'
 import { marketApi } from 'state/slices/marketDataSlice/marketDataSlice'
-import { selectAssetByAssetId, selectMarketDataById } from 'state/slices/selectors'
+import { selectAssetById, selectMarketDataById } from 'state/slices/selectors'
 import { useAppDispatch, useAppSelector } from 'state/store'
 
 import { DepositContext } from '../DepositContext'
@@ -42,10 +42,10 @@ export const Status = ({ api, apy }: FoxyStatusProps) => {
     assetReference: AssetReference.Ethereum,
   })
 
-  const asset = useAppSelector(state => selectAssetByAssetId(state, assetId))
+  const asset = useAppSelector(state => selectAssetById(state, assetId))
   const marketData = useAppSelector(state => selectMarketDataById(state, assetId))
   if (!marketData) appDispatch(marketApi.endpoints.findByCaip19.initiate(assetId))
-  const feeAsset = useAppSelector(state => selectAssetByAssetId(state, feeAssetId))
+  const feeAsset = useAppSelector(state => selectAssetById(state, feeAssetId))
   const feeMarketData = useAppSelector(state => selectMarketDataById(state, feeAssetId))
   const contractAssetId = caip19.toCAIP19({
     chain,
@@ -53,7 +53,7 @@ export const Status = ({ api, apy }: FoxyStatusProps) => {
     assetNamespace,
     assetReference: rewardId,
   })
-  const contractAsset = useAppSelector(state => selectAssetByAssetId(state, contractAssetId))
+  const contractAsset = useAppSelector(state => selectAssetById(state, contractAssetId))
 
   const handleViewPosition = () => {
     browserHistory.push('/defi')

--- a/src/features/defi/providers/foxy/components/FoxyManager/Deposit/components/Status.tsx
+++ b/src/features/defi/providers/foxy/components/FoxyManager/Deposit/components/Status.tsx
@@ -15,7 +15,7 @@ import { Text } from 'components/Text'
 import { useBrowserRouter } from 'hooks/useBrowserRouter/useBrowserRouter'
 import { bnOrZero } from 'lib/bignumber/bignumber'
 import { marketApi } from 'state/slices/marketDataSlice/marketDataSlice'
-import { selectAssetByCAIP19, selectMarketDataById } from 'state/slices/selectors'
+import { selectAssetByAssetId, selectMarketDataById } from 'state/slices/selectors'
 import { useAppDispatch, useAppSelector } from 'state/store'
 
 import { DepositContext } from '../DepositContext'
@@ -42,10 +42,10 @@ export const Status = ({ api, apy }: FoxyStatusProps) => {
     assetReference: AssetReference.Ethereum,
   })
 
-  const asset = useAppSelector(state => selectAssetByCAIP19(state, assetId))
+  const asset = useAppSelector(state => selectAssetByAssetId(state, assetId))
   const marketData = useAppSelector(state => selectMarketDataById(state, assetId))
   if (!marketData) appDispatch(marketApi.endpoints.findByCaip19.initiate(assetId))
-  const feeAsset = useAppSelector(state => selectAssetByCAIP19(state, feeAssetId))
+  const feeAsset = useAppSelector(state => selectAssetByAssetId(state, feeAssetId))
   const feeMarketData = useAppSelector(state => selectMarketDataById(state, feeAssetId))
   const contractAssetId = caip19.toCAIP19({
     chain,
@@ -53,7 +53,7 @@ export const Status = ({ api, apy }: FoxyStatusProps) => {
     assetNamespace,
     assetReference: rewardId,
   })
-  const contractAsset = useAppSelector(state => selectAssetByCAIP19(state, contractAssetId))
+  const contractAsset = useAppSelector(state => selectAssetByAssetId(state, contractAssetId))
 
   const handleViewPosition = () => {
     browserHistory.push('/defi')

--- a/src/features/defi/providers/foxy/components/FoxyManager/Overview/Claim/ClaimConfirm.tsx
+++ b/src/features/defi/providers/foxy/components/FoxyManager/Overview/Claim/ClaimConfirm.tsx
@@ -23,7 +23,7 @@ import { SlideTransition } from 'components/SlideTransition'
 import { Text } from 'components/Text'
 import { useChainAdapters } from 'context/PluginProvider/PluginProvider'
 import { useWallet } from 'hooks/useWallet/useWallet'
-import { selectAssetByCAIP19, selectMarketDataById } from 'state/slices/selectors'
+import { selectAssetByAssetId, selectMarketDataById } from 'state/slices/selectors'
 import { useAppSelector } from 'state/store'
 
 type ClaimConfirmProps = {
@@ -53,14 +53,14 @@ export const ClaimConfirm = ({
 
   // Asset Info
   const network = NetworkTypes.MAINNET
-  const asset = useAppSelector(state => selectAssetByCAIP19(state, assetId))
+  const asset = useAppSelector(state => selectAssetByAssetId(state, assetId))
   const feeAssetCAIP19 = caip19.toCAIP19({
     chain,
     network,
     assetNamespace: AssetNamespace.Slip44,
     assetReference: AssetReference.Ethereum,
   })
-  const feeAsset = useAppSelector(state => selectAssetByCAIP19(state, feeAssetCAIP19))
+  const feeAsset = useAppSelector(state => selectAssetByAssetId(state, feeAssetCAIP19))
   const feeMarketData = useAppSelector(state => selectMarketDataById(state, feeAssetCAIP19))
 
   const toast = useToast()

--- a/src/features/defi/providers/foxy/components/FoxyManager/Overview/Claim/ClaimConfirm.tsx
+++ b/src/features/defi/providers/foxy/components/FoxyManager/Overview/Claim/ClaimConfirm.tsx
@@ -23,7 +23,7 @@ import { SlideTransition } from 'components/SlideTransition'
 import { Text } from 'components/Text'
 import { useChainAdapters } from 'context/PluginProvider/PluginProvider'
 import { useWallet } from 'hooks/useWallet/useWallet'
-import { selectAssetByAssetId, selectMarketDataById } from 'state/slices/selectors'
+import { selectAssetById, selectMarketDataById } from 'state/slices/selectors'
 import { useAppSelector } from 'state/store'
 
 type ClaimConfirmProps = {
@@ -53,14 +53,14 @@ export const ClaimConfirm = ({
 
   // Asset Info
   const network = NetworkTypes.MAINNET
-  const asset = useAppSelector(state => selectAssetByAssetId(state, assetId))
+  const asset = useAppSelector(state => selectAssetById(state, assetId))
   const feeAssetCAIP19 = caip19.toCAIP19({
     chain,
     network,
     assetNamespace: AssetNamespace.Slip44,
     assetReference: AssetReference.Ethereum,
   })
-  const feeAsset = useAppSelector(state => selectAssetByAssetId(state, feeAssetCAIP19))
+  const feeAsset = useAppSelector(state => selectAssetById(state, feeAssetCAIP19))
   const feeMarketData = useAppSelector(state => selectMarketDataById(state, feeAssetCAIP19))
 
   const toast = useToast()

--- a/src/features/defi/providers/foxy/components/FoxyManager/Overview/Claim/ClaimStatus.tsx
+++ b/src/features/defi/providers/foxy/components/FoxyManager/Overview/Claim/ClaimStatus.tsx
@@ -19,7 +19,7 @@ import { SlideTransition } from 'components/SlideTransition'
 import { RawText } from 'components/Text'
 import { useBrowserRouter } from 'hooks/useBrowserRouter/useBrowserRouter'
 import { poll } from 'lib/poll/poll'
-import { selectAssetByCAIP19, selectMarketDataById } from 'state/slices/selectors'
+import { selectAssetByAssetId, selectMarketDataById } from 'state/slices/selectors'
 import { useAppSelector } from 'state/store'
 
 interface ClaimStatusState {
@@ -74,14 +74,14 @@ export const ClaimStatus = () => {
 
   // Asset Info
   const network = NetworkTypes.MAINNET
-  const asset = useAppSelector(state => selectAssetByCAIP19(state, assetId))
+  const asset = useAppSelector(state => selectAssetByAssetId(state, assetId))
   const feeAssetCAIP19 = caip19.toCAIP19({
     chain,
     network,
     assetNamespace: AssetNamespace.Slip44,
     assetReference: AssetReference.Ethereum,
   })
-  const feeAsset = useAppSelector(state => selectAssetByCAIP19(state, feeAssetCAIP19))
+  const feeAsset = useAppSelector(state => selectAssetByAssetId(state, feeAssetCAIP19))
   const feeMarketData = useAppSelector(state => selectMarketDataById(state, feeAssetCAIP19))
 
   useEffect(() => {

--- a/src/features/defi/providers/foxy/components/FoxyManager/Overview/Claim/ClaimStatus.tsx
+++ b/src/features/defi/providers/foxy/components/FoxyManager/Overview/Claim/ClaimStatus.tsx
@@ -19,7 +19,7 @@ import { SlideTransition } from 'components/SlideTransition'
 import { RawText } from 'components/Text'
 import { useBrowserRouter } from 'hooks/useBrowserRouter/useBrowserRouter'
 import { poll } from 'lib/poll/poll'
-import { selectAssetByAssetId, selectMarketDataById } from 'state/slices/selectors'
+import { selectAssetById, selectMarketDataById } from 'state/slices/selectors'
 import { useAppSelector } from 'state/store'
 
 interface ClaimStatusState {
@@ -74,14 +74,14 @@ export const ClaimStatus = () => {
 
   // Asset Info
   const network = NetworkTypes.MAINNET
-  const asset = useAppSelector(state => selectAssetByAssetId(state, assetId))
+  const asset = useAppSelector(state => selectAssetById(state, assetId))
   const feeAssetCAIP19 = caip19.toCAIP19({
     chain,
     network,
     assetNamespace: AssetNamespace.Slip44,
     assetReference: AssetReference.Ethereum,
   })
-  const feeAsset = useAppSelector(state => selectAssetByAssetId(state, feeAssetCAIP19))
+  const feeAsset = useAppSelector(state => selectAssetById(state, feeAssetCAIP19))
   const feeMarketData = useAppSelector(state => selectMarketDataById(state, feeAssetCAIP19))
 
   useEffect(() => {

--- a/src/features/defi/providers/foxy/components/FoxyManager/Overview/FoxyDetails.tsx
+++ b/src/features/defi/providers/foxy/components/FoxyManager/Overview/FoxyDetails.tsx
@@ -11,7 +11,7 @@ import { Text } from 'components/Text'
 import { useBrowserRouter } from 'hooks/useBrowserRouter/useBrowserRouter'
 import { bnOrZero } from 'lib/bignumber/bignumber'
 import { useFoxyBalances } from 'pages/Defi/hooks/useFoxyBalances'
-import { selectAssetByCAIP19 } from 'state/slices/selectors'
+import { selectAssetByAssetId } from 'state/slices/selectors'
 import { useAppSelector } from 'state/store'
 
 import { FoxyEmpty } from './FoxyEmpty'
@@ -44,14 +44,14 @@ export const FoxyDetails = ({ api }: FoxyDetailsProps) => {
     assetNamespace,
     assetReference: tokenId,
   })
-  const stakingAsset = useAppSelector(state => selectAssetByCAIP19(state, stakingAssetCAIP19))
+  const stakingAsset = useAppSelector(state => selectAssetByAssetId(state, stakingAssetCAIP19))
   const rewardAssetCAIP19 = caip19.toCAIP19({
     chain,
     network,
     assetNamespace,
     assetReference: rewardId,
   })
-  const rewardAsset = useAppSelector(state => selectAssetByCAIP19(state, rewardAssetCAIP19))
+  const rewardAsset = useAppSelector(state => selectAssetByAssetId(state, rewardAssetCAIP19))
   const apy = bnOrZero(opportunity?.apy).times(100).toString()
   if (loading || !opportunity) {
     return (

--- a/src/features/defi/providers/foxy/components/FoxyManager/Overview/FoxyDetails.tsx
+++ b/src/features/defi/providers/foxy/components/FoxyManager/Overview/FoxyDetails.tsx
@@ -11,7 +11,7 @@ import { Text } from 'components/Text'
 import { useBrowserRouter } from 'hooks/useBrowserRouter/useBrowserRouter'
 import { bnOrZero } from 'lib/bignumber/bignumber'
 import { useFoxyBalances } from 'pages/Defi/hooks/useFoxyBalances'
-import { selectAssetByAssetId } from 'state/slices/selectors'
+import { selectAssetById } from 'state/slices/selectors'
 import { useAppSelector } from 'state/store'
 
 import { FoxyEmpty } from './FoxyEmpty'
@@ -44,14 +44,14 @@ export const FoxyDetails = ({ api }: FoxyDetailsProps) => {
     assetNamespace,
     assetReference: tokenId,
   })
-  const stakingAsset = useAppSelector(state => selectAssetByAssetId(state, stakingAssetCAIP19))
+  const stakingAsset = useAppSelector(state => selectAssetById(state, stakingAssetCAIP19))
   const rewardAssetCAIP19 = caip19.toCAIP19({
     chain,
     network,
     assetNamespace,
     assetReference: rewardId,
   })
-  const rewardAsset = useAppSelector(state => selectAssetByAssetId(state, rewardAssetCAIP19))
+  const rewardAsset = useAppSelector(state => selectAssetById(state, rewardAssetCAIP19))
   const apy = bnOrZero(opportunity?.apy).times(100).toString()
   if (loading || !opportunity) {
     return (

--- a/src/features/defi/providers/foxy/components/FoxyManager/Withdraw/FoxyWithdraw.tsx
+++ b/src/features/defi/providers/foxy/components/FoxyManager/Withdraw/FoxyWithdraw.tsx
@@ -17,7 +17,7 @@ import { useWallet } from 'hooks/useWallet/useWallet'
 import { bn, bnOrZero } from 'lib/bignumber/bignumber'
 import { marketApi } from 'state/slices/marketDataSlice/marketDataSlice'
 import {
-  selectAssetByCAIP19,
+  selectAssetByAssetId,
   selectMarketDataById,
   selectPortfolioLoading,
 } from 'state/slices/selectors'
@@ -53,7 +53,7 @@ export const FoxyWithdraw = ({ api }: FoxyWithdrawProps) => {
     assetNamespace,
     assetReference: rewardId,
   })
-  const asset = useAppSelector(state => selectAssetByCAIP19(state, assetCAIP19))
+  const asset = useAppSelector(state => selectAssetByAssetId(state, assetCAIP19))
   const marketData = useAppSelector(state => selectMarketDataById(state, assetCAIP19))
   if (!marketData) appDispatch(marketApi.endpoints.findByCaip19.initiate(assetCAIP19))
   const feeAssetCAIP19 = caip19.toCAIP19({

--- a/src/features/defi/providers/foxy/components/FoxyManager/Withdraw/FoxyWithdraw.tsx
+++ b/src/features/defi/providers/foxy/components/FoxyManager/Withdraw/FoxyWithdraw.tsx
@@ -17,7 +17,7 @@ import { useWallet } from 'hooks/useWallet/useWallet'
 import { bn, bnOrZero } from 'lib/bignumber/bignumber'
 import { marketApi } from 'state/slices/marketDataSlice/marketDataSlice'
 import {
-  selectAssetByAssetId,
+  selectAssetById,
   selectMarketDataById,
   selectPortfolioLoading,
 } from 'state/slices/selectors'
@@ -53,7 +53,7 @@ export const FoxyWithdraw = ({ api }: FoxyWithdrawProps) => {
     assetNamespace,
     assetReference: rewardId,
   })
-  const asset = useAppSelector(state => selectAssetByAssetId(state, assetCAIP19))
+  const asset = useAppSelector(state => selectAssetById(state, assetCAIP19))
   const marketData = useAppSelector(state => selectMarketDataById(state, assetCAIP19))
   if (!marketData) appDispatch(marketApi.endpoints.findByCaip19.initiate(assetCAIP19))
   const feeAssetCAIP19 = caip19.toCAIP19({

--- a/src/features/defi/providers/foxy/components/FoxyManager/Withdraw/components/Approve.tsx
+++ b/src/features/defi/providers/foxy/components/FoxyManager/Withdraw/components/Approve.tsx
@@ -14,7 +14,7 @@ import { useWallet } from 'hooks/useWallet/useWallet'
 import { bn, bnOrZero } from 'lib/bignumber/bignumber'
 import { poll } from 'lib/poll/poll'
 import { marketApi } from 'state/slices/marketDataSlice/marketDataSlice'
-import { selectAssetByAssetId, selectMarketDataById } from 'state/slices/selectors'
+import { selectAssetById, selectMarketDataById } from 'state/slices/selectors'
 import { useAppDispatch, useAppSelector } from 'state/store'
 
 import { WithdrawPath } from '../WithdrawCommon'
@@ -45,7 +45,7 @@ export const Approve = ({ api, getWithdrawGasEstimate }: FoxyApproveProps) => {
     assetNamespace,
     assetReference: rewardId,
   })
-  const asset = useAppSelector(state => selectAssetByAssetId(state, assetCAIP19))
+  const asset = useAppSelector(state => selectAssetById(state, assetCAIP19))
   const marketData = useAppSelector(state => selectMarketDataById(state, assetCAIP19))
   if (!marketData) appDispatch(marketApi.endpoints.findByCaip19.initiate(assetCAIP19))
   const feeAssetCAIP19 = caip19.toCAIP19({
@@ -54,7 +54,7 @@ export const Approve = ({ api, getWithdrawGasEstimate }: FoxyApproveProps) => {
     assetNamespace: AssetNamespace.Slip44,
     assetReference: AssetReference.Ethereum,
   })
-  const feeAsset = useAppSelector(state => selectAssetByAssetId(state, feeAssetCAIP19))
+  const feeAsset = useAppSelector(state => selectAssetById(state, feeAssetCAIP19))
   const feeMarketData = useAppSelector(state => selectMarketDataById(state, feeAssetCAIP19))
 
   // user info

--- a/src/features/defi/providers/foxy/components/FoxyManager/Withdraw/components/Approve.tsx
+++ b/src/features/defi/providers/foxy/components/FoxyManager/Withdraw/components/Approve.tsx
@@ -14,7 +14,7 @@ import { useWallet } from 'hooks/useWallet/useWallet'
 import { bn, bnOrZero } from 'lib/bignumber/bignumber'
 import { poll } from 'lib/poll/poll'
 import { marketApi } from 'state/slices/marketDataSlice/marketDataSlice'
-import { selectAssetByCAIP19, selectMarketDataById } from 'state/slices/selectors'
+import { selectAssetByAssetId, selectMarketDataById } from 'state/slices/selectors'
 import { useAppDispatch, useAppSelector } from 'state/store'
 
 import { WithdrawPath } from '../WithdrawCommon'
@@ -45,7 +45,7 @@ export const Approve = ({ api, getWithdrawGasEstimate }: FoxyApproveProps) => {
     assetNamespace,
     assetReference: rewardId,
   })
-  const asset = useAppSelector(state => selectAssetByCAIP19(state, assetCAIP19))
+  const asset = useAppSelector(state => selectAssetByAssetId(state, assetCAIP19))
   const marketData = useAppSelector(state => selectMarketDataById(state, assetCAIP19))
   if (!marketData) appDispatch(marketApi.endpoints.findByCaip19.initiate(assetCAIP19))
   const feeAssetCAIP19 = caip19.toCAIP19({
@@ -54,7 +54,7 @@ export const Approve = ({ api, getWithdrawGasEstimate }: FoxyApproveProps) => {
     assetNamespace: AssetNamespace.Slip44,
     assetReference: AssetReference.Ethereum,
   })
-  const feeAsset = useAppSelector(state => selectAssetByCAIP19(state, feeAssetCAIP19))
+  const feeAsset = useAppSelector(state => selectAssetByAssetId(state, feeAssetCAIP19))
   const feeMarketData = useAppSelector(state => selectMarketDataById(state, feeAssetCAIP19))
 
   // user info

--- a/src/features/defi/providers/foxy/components/FoxyManager/Withdraw/components/Confirm.tsx
+++ b/src/features/defi/providers/foxy/components/FoxyManager/Withdraw/components/Confirm.tsx
@@ -18,7 +18,7 @@ import { useWallet } from 'hooks/useWallet/useWallet'
 import { bn, bnOrZero } from 'lib/bignumber/bignumber'
 import { poll } from 'lib/poll/poll'
 import { marketApi } from 'state/slices/marketDataSlice/marketDataSlice'
-import { selectAssetByAssetId, selectMarketDataById } from 'state/slices/selectors'
+import { selectAssetById, selectMarketDataById } from 'state/slices/selectors'
 import { useAppDispatch, useAppSelector } from 'state/store'
 
 import { FoxyWithdrawActionType, WithdrawPath } from '../WithdrawCommon'
@@ -45,16 +45,14 @@ export const Confirm = ({ api }: FoxyConfirmProps) => {
     assetNamespace,
     assetReference: tokenId,
   })
-  const underlyingAsset = useAppSelector(state =>
-    selectAssetByAssetId(state, underlyingAssetCAIP19),
-  )
+  const underlyingAsset = useAppSelector(state => selectAssetById(state, underlyingAssetCAIP19))
   const assetCAIP19 = caip19.toCAIP19({
     chain,
     network,
     assetNamespace,
     assetReference: rewardId,
   })
-  const asset = useAppSelector(state => selectAssetByAssetId(state, assetCAIP19))
+  const asset = useAppSelector(state => selectAssetById(state, assetCAIP19))
   const marketData = useAppSelector(state => selectMarketDataById(state, assetCAIP19))
   if (!marketData) appDispatch(marketApi.endpoints.findByCaip19.initiate(assetCAIP19))
   const feeAssetCAIP19 = caip19.toCAIP19({
@@ -63,7 +61,7 @@ export const Confirm = ({ api }: FoxyConfirmProps) => {
     assetNamespace: AssetNamespace.Slip44,
     assetReference: AssetReference.Ethereum,
   })
-  const feeAsset = useAppSelector(state => selectAssetByAssetId(state, feeAssetCAIP19))
+  const feeAsset = useAppSelector(state => selectAssetById(state, feeAssetCAIP19))
   const feeMarketData = useAppSelector(state => selectMarketDataById(state, feeAssetCAIP19))
 
   // user info

--- a/src/features/defi/providers/foxy/components/FoxyManager/Withdraw/components/Confirm.tsx
+++ b/src/features/defi/providers/foxy/components/FoxyManager/Withdraw/components/Confirm.tsx
@@ -18,7 +18,7 @@ import { useWallet } from 'hooks/useWallet/useWallet'
 import { bn, bnOrZero } from 'lib/bignumber/bignumber'
 import { poll } from 'lib/poll/poll'
 import { marketApi } from 'state/slices/marketDataSlice/marketDataSlice'
-import { selectAssetByCAIP19, selectMarketDataById } from 'state/slices/selectors'
+import { selectAssetByAssetId, selectMarketDataById } from 'state/slices/selectors'
 import { useAppDispatch, useAppSelector } from 'state/store'
 
 import { FoxyWithdrawActionType, WithdrawPath } from '../WithdrawCommon'
@@ -45,14 +45,16 @@ export const Confirm = ({ api }: FoxyConfirmProps) => {
     assetNamespace,
     assetReference: tokenId,
   })
-  const underlyingAsset = useAppSelector(state => selectAssetByCAIP19(state, underlyingAssetCAIP19))
+  const underlyingAsset = useAppSelector(state =>
+    selectAssetByAssetId(state, underlyingAssetCAIP19),
+  )
   const assetCAIP19 = caip19.toCAIP19({
     chain,
     network,
     assetNamespace,
     assetReference: rewardId,
   })
-  const asset = useAppSelector(state => selectAssetByCAIP19(state, assetCAIP19))
+  const asset = useAppSelector(state => selectAssetByAssetId(state, assetCAIP19))
   const marketData = useAppSelector(state => selectMarketDataById(state, assetCAIP19))
   if (!marketData) appDispatch(marketApi.endpoints.findByCaip19.initiate(assetCAIP19))
   const feeAssetCAIP19 = caip19.toCAIP19({
@@ -61,7 +63,7 @@ export const Confirm = ({ api }: FoxyConfirmProps) => {
     assetNamespace: AssetNamespace.Slip44,
     assetReference: AssetReference.Ethereum,
   })
-  const feeAsset = useAppSelector(state => selectAssetByCAIP19(state, feeAssetCAIP19))
+  const feeAsset = useAppSelector(state => selectAssetByAssetId(state, feeAssetCAIP19))
   const feeMarketData = useAppSelector(state => selectMarketDataById(state, feeAssetCAIP19))
 
   // user info

--- a/src/features/defi/providers/foxy/components/FoxyManager/Withdraw/components/Status.tsx
+++ b/src/features/defi/providers/foxy/components/FoxyManager/Withdraw/components/Status.tsx
@@ -14,7 +14,7 @@ import { Text } from 'components/Text'
 import { useBrowserRouter } from 'hooks/useBrowserRouter/useBrowserRouter'
 import { bn, bnOrZero } from 'lib/bignumber/bignumber'
 import { marketApi } from 'state/slices/marketDataSlice/marketDataSlice'
-import { selectAssetByAssetId, selectMarketDataById } from 'state/slices/selectors'
+import { selectAssetById, selectMarketDataById } from 'state/slices/selectors'
 import { useAppDispatch, useAppSelector } from 'state/store'
 
 import { WithdrawContext } from '../WithdrawContext'
@@ -39,16 +39,14 @@ export const Status = ({ api }: FoxyStatusProps) => {
     assetNamespace,
     assetReference: tokenId,
   })
-  const underlyingAsset = useAppSelector(state =>
-    selectAssetByAssetId(state, underlyingAssetCAIP19),
-  )
+  const underlyingAsset = useAppSelector(state => selectAssetById(state, underlyingAssetCAIP19))
   const assetCAIP19 = caip19.toCAIP19({
     chain,
     network,
     assetNamespace,
     assetReference: rewardId,
   })
-  const asset = useAppSelector(state => selectAssetByAssetId(state, assetCAIP19))
+  const asset = useAppSelector(state => selectAssetById(state, assetCAIP19))
   const marketData = useAppSelector(state => selectMarketDataById(state, assetCAIP19))
   if (!marketData) appDispatch(marketApi.endpoints.findByCaip19.initiate(assetCAIP19))
   const feeAssetCAIP19 = caip19.toCAIP19({
@@ -57,7 +55,7 @@ export const Status = ({ api }: FoxyStatusProps) => {
     assetNamespace: AssetNamespace.Slip44,
     assetReference: AssetReference.Ethereum,
   })
-  const feeAsset = useAppSelector(state => selectAssetByAssetId(state, feeAssetCAIP19))
+  const feeAsset = useAppSelector(state => selectAssetById(state, feeAssetCAIP19))
   const feeMarketData = useAppSelector(state => selectMarketDataById(state, feeAssetCAIP19))
 
   const withdrawalFee = useMemo(() => {

--- a/src/features/defi/providers/foxy/components/FoxyManager/Withdraw/components/Status.tsx
+++ b/src/features/defi/providers/foxy/components/FoxyManager/Withdraw/components/Status.tsx
@@ -14,7 +14,7 @@ import { Text } from 'components/Text'
 import { useBrowserRouter } from 'hooks/useBrowserRouter/useBrowserRouter'
 import { bn, bnOrZero } from 'lib/bignumber/bignumber'
 import { marketApi } from 'state/slices/marketDataSlice/marketDataSlice'
-import { selectAssetByCAIP19, selectMarketDataById } from 'state/slices/selectors'
+import { selectAssetByAssetId, selectMarketDataById } from 'state/slices/selectors'
 import { useAppDispatch, useAppSelector } from 'state/store'
 
 import { WithdrawContext } from '../WithdrawContext'
@@ -39,14 +39,16 @@ export const Status = ({ api }: FoxyStatusProps) => {
     assetNamespace,
     assetReference: tokenId,
   })
-  const underlyingAsset = useAppSelector(state => selectAssetByCAIP19(state, underlyingAssetCAIP19))
+  const underlyingAsset = useAppSelector(state =>
+    selectAssetByAssetId(state, underlyingAssetCAIP19),
+  )
   const assetCAIP19 = caip19.toCAIP19({
     chain,
     network,
     assetNamespace,
     assetReference: rewardId,
   })
-  const asset = useAppSelector(state => selectAssetByCAIP19(state, assetCAIP19))
+  const asset = useAppSelector(state => selectAssetByAssetId(state, assetCAIP19))
   const marketData = useAppSelector(state => selectMarketDataById(state, assetCAIP19))
   if (!marketData) appDispatch(marketApi.endpoints.findByCaip19.initiate(assetCAIP19))
   const feeAssetCAIP19 = caip19.toCAIP19({
@@ -55,7 +57,7 @@ export const Status = ({ api }: FoxyStatusProps) => {
     assetNamespace: AssetNamespace.Slip44,
     assetReference: AssetReference.Ethereum,
   })
-  const feeAsset = useAppSelector(state => selectAssetByCAIP19(state, feeAssetCAIP19))
+  const feeAsset = useAppSelector(state => selectAssetByAssetId(state, feeAssetCAIP19))
   const feeMarketData = useAppSelector(state => selectMarketDataById(state, feeAssetCAIP19))
 
   const withdrawalFee = useMemo(() => {

--- a/src/features/defi/providers/foxy/components/FoxyManager/Withdraw/components/Withdraw.tsx
+++ b/src/features/defi/providers/foxy/components/FoxyManager/Withdraw/components/Withdraw.tsx
@@ -18,7 +18,7 @@ import { useBrowserRouter } from 'hooks/useBrowserRouter/useBrowserRouter'
 import { bn, bnOrZero } from 'lib/bignumber/bignumber'
 import { marketApi } from 'state/slices/marketDataSlice/marketDataSlice'
 import {
-  selectAssetByAssetId,
+  selectAssetById,
   selectMarketDataById,
   selectPortfolioCryptoBalanceByAssetId,
 } from 'state/slices/selectors'
@@ -50,7 +50,7 @@ export const Withdraw = ({ api, getWithdrawGasEstimate }: FoxyWithdrawProps) => 
     assetNamespace,
     assetReference: rewardId,
   })
-  const asset = useAppSelector(state => selectAssetByAssetId(state, assetCAIP19))
+  const asset = useAppSelector(state => selectAssetById(state, assetCAIP19))
   const marketData = useAppSelector(state => selectMarketDataById(state, assetCAIP19))
   if (!marketData) appDispatch(marketApi.endpoints.findByCaip19.initiate(assetCAIP19))
 

--- a/src/features/defi/providers/foxy/components/FoxyManager/Withdraw/components/Withdraw.tsx
+++ b/src/features/defi/providers/foxy/components/FoxyManager/Withdraw/components/Withdraw.tsx
@@ -18,7 +18,7 @@ import { useBrowserRouter } from 'hooks/useBrowserRouter/useBrowserRouter'
 import { bn, bnOrZero } from 'lib/bignumber/bignumber'
 import { marketApi } from 'state/slices/marketDataSlice/marketDataSlice'
 import {
-  selectAssetByCAIP19,
+  selectAssetByAssetId,
   selectMarketDataById,
   selectPortfolioCryptoBalanceByAssetId,
 } from 'state/slices/selectors'
@@ -50,7 +50,7 @@ export const Withdraw = ({ api, getWithdrawGasEstimate }: FoxyWithdrawProps) => 
     assetNamespace,
     assetReference: rewardId,
   })
-  const asset = useAppSelector(state => selectAssetByCAIP19(state, assetCAIP19))
+  const asset = useAppSelector(state => selectAssetByAssetId(state, assetCAIP19))
   const marketData = useAppSelector(state => selectMarketDataById(state, assetCAIP19))
   if (!marketData) appDispatch(marketApi.endpoints.findByCaip19.initiate(assetCAIP19))
 

--- a/src/features/defi/providers/yearn/components/YearnManager/Deposit/YearnDeposit.tsx
+++ b/src/features/defi/providers/yearn/components/YearnManager/Deposit/YearnDeposit.tsx
@@ -17,7 +17,7 @@ import { useWallet } from 'hooks/useWallet/useWallet'
 import { bnOrZero } from 'lib/bignumber/bignumber'
 import { marketApi } from 'state/slices/marketDataSlice/marketDataSlice'
 import {
-  selectAssetByCAIP19,
+  selectAssetByAssetId,
   selectMarketDataById,
   selectPortfolioLoading,
 } from 'state/slices/selectors'
@@ -47,7 +47,7 @@ export const YearnDeposit = ({ api }: YearnDepositProps) => {
   const network = NetworkTypes.MAINNET
   const assetNamespace = AssetNamespace.ERC20
   const assetCAIP19 = caip19.toCAIP19({ chain, network, assetNamespace, assetReference: tokenId })
-  const asset = useAppSelector(state => selectAssetByCAIP19(state, assetCAIP19))
+  const asset = useAppSelector(state => selectAssetByAssetId(state, assetCAIP19))
   const marketData = useAppSelector(state => selectMarketDataById(state, assetCAIP19))
   if (!marketData) appDispatch(marketApi.endpoints.findByCaip19.initiate(assetCAIP19))
 

--- a/src/features/defi/providers/yearn/components/YearnManager/Deposit/YearnDeposit.tsx
+++ b/src/features/defi/providers/yearn/components/YearnManager/Deposit/YearnDeposit.tsx
@@ -17,7 +17,7 @@ import { useWallet } from 'hooks/useWallet/useWallet'
 import { bnOrZero } from 'lib/bignumber/bignumber'
 import { marketApi } from 'state/slices/marketDataSlice/marketDataSlice'
 import {
-  selectAssetByAssetId,
+  selectAssetById,
   selectMarketDataById,
   selectPortfolioLoading,
 } from 'state/slices/selectors'
@@ -47,7 +47,7 @@ export const YearnDeposit = ({ api }: YearnDepositProps) => {
   const network = NetworkTypes.MAINNET
   const assetNamespace = AssetNamespace.ERC20
   const assetCAIP19 = caip19.toCAIP19({ chain, network, assetNamespace, assetReference: tokenId })
-  const asset = useAppSelector(state => selectAssetByAssetId(state, assetCAIP19))
+  const asset = useAppSelector(state => selectAssetById(state, assetCAIP19))
   const marketData = useAppSelector(state => selectMarketDataById(state, assetCAIP19))
   if (!marketData) appDispatch(marketApi.endpoints.findByCaip19.initiate(assetCAIP19))
 

--- a/src/features/defi/providers/yearn/components/YearnManager/Deposit/components/Approve.tsx
+++ b/src/features/defi/providers/yearn/components/YearnManager/Deposit/components/Approve.tsx
@@ -14,7 +14,7 @@ import { useWallet } from 'hooks/useWallet/useWallet'
 import { bnOrZero } from 'lib/bignumber/bignumber'
 import { poll } from 'lib/poll/poll'
 import { marketApi } from 'state/slices/marketDataSlice/marketDataSlice'
-import { selectAssetByAssetId, selectMarketDataById } from 'state/slices/selectors'
+import { selectAssetById, selectMarketDataById } from 'state/slices/selectors'
 import { useAppDispatch, useAppSelector } from 'state/store'
 
 import { DepositPath, YearnDepositActionType } from '../DepositCommon'
@@ -43,10 +43,10 @@ export const Approve = ({ api, getDepositGasEstimate }: YearnApproveProps) => {
     assetNamespace: AssetNamespace.Slip44,
     assetReference: AssetReference.Ethereum,
   })
-  const asset = useAppSelector(state => selectAssetByAssetId(state, assetCAIP19))
+  const asset = useAppSelector(state => selectAssetById(state, assetCAIP19))
   const marketData = useAppSelector(state => selectMarketDataById(state, assetCAIP19))
   if (!marketData) appDispatch(marketApi.endpoints.findByCaip19.initiate(assetCAIP19))
-  const feeAsset = useAppSelector(state => selectAssetByAssetId(state, feeAssetCAIP19))
+  const feeAsset = useAppSelector(state => selectAssetById(state, feeAssetCAIP19))
   const feeMarketData = useAppSelector(state => selectMarketDataById(state, feeAssetCAIP19))
 
   // user info

--- a/src/features/defi/providers/yearn/components/YearnManager/Deposit/components/Approve.tsx
+++ b/src/features/defi/providers/yearn/components/YearnManager/Deposit/components/Approve.tsx
@@ -14,7 +14,7 @@ import { useWallet } from 'hooks/useWallet/useWallet'
 import { bnOrZero } from 'lib/bignumber/bignumber'
 import { poll } from 'lib/poll/poll'
 import { marketApi } from 'state/slices/marketDataSlice/marketDataSlice'
-import { selectAssetByCAIP19, selectMarketDataById } from 'state/slices/selectors'
+import { selectAssetByAssetId, selectMarketDataById } from 'state/slices/selectors'
 import { useAppDispatch, useAppSelector } from 'state/store'
 
 import { DepositPath, YearnDepositActionType } from '../DepositCommon'
@@ -43,10 +43,10 @@ export const Approve = ({ api, getDepositGasEstimate }: YearnApproveProps) => {
     assetNamespace: AssetNamespace.Slip44,
     assetReference: AssetReference.Ethereum,
   })
-  const asset = useAppSelector(state => selectAssetByCAIP19(state, assetCAIP19))
+  const asset = useAppSelector(state => selectAssetByAssetId(state, assetCAIP19))
   const marketData = useAppSelector(state => selectMarketDataById(state, assetCAIP19))
   if (!marketData) appDispatch(marketApi.endpoints.findByCaip19.initiate(assetCAIP19))
-  const feeAsset = useAppSelector(state => selectAssetByCAIP19(state, feeAssetCAIP19))
+  const feeAsset = useAppSelector(state => selectAssetByAssetId(state, feeAssetCAIP19))
   const feeMarketData = useAppSelector(state => selectMarketDataById(state, feeAssetCAIP19))
 
   // user info

--- a/src/features/defi/providers/yearn/components/YearnManager/Deposit/components/Confirm.tsx
+++ b/src/features/defi/providers/yearn/components/YearnManager/Deposit/components/Confirm.tsx
@@ -18,7 +18,7 @@ import { useWallet } from 'hooks/useWallet/useWallet'
 import { bnOrZero } from 'lib/bignumber/bignumber'
 import { poll } from 'lib/poll/poll'
 import { marketApi } from 'state/slices/marketDataSlice/marketDataSlice'
-import { selectAssetByCAIP19, selectMarketDataById } from 'state/slices/selectors'
+import { selectAssetByAssetId, selectMarketDataById } from 'state/slices/selectors'
 import { useAppDispatch, useAppSelector } from 'state/store'
 
 import { DepositPath, YearnDepositActionType } from '../DepositCommon'
@@ -45,10 +45,10 @@ export const Confirm = ({ api }: YearnConfirmProps) => {
     assetNamespace: AssetNamespace.Slip44,
     assetReference: AssetReference.Ethereum,
   })
-  const asset = useAppSelector(state => selectAssetByCAIP19(state, assetCAIP19))
+  const asset = useAppSelector(state => selectAssetByAssetId(state, assetCAIP19))
   const marketData = useAppSelector(state => selectMarketDataById(state, assetCAIP19))
   if (!marketData) appDispatch(marketApi.endpoints.findByCaip19.initiate(assetCAIP19))
-  const feeAsset = useAppSelector(state => selectAssetByCAIP19(state, feeAssetCAIP19))
+  const feeAsset = useAppSelector(state => selectAssetByAssetId(state, feeAssetCAIP19))
   const feeMarketData = useAppSelector(state => selectMarketDataById(state, feeAssetCAIP19))
   const vaultCAIP19 = caip19.toCAIP19({
     chain,
@@ -56,7 +56,7 @@ export const Confirm = ({ api }: YearnConfirmProps) => {
     assetNamespace,
     assetReference: vaultAddress,
   })
-  const vaultAsset = useAppSelector(state => selectAssetByCAIP19(state, vaultCAIP19))
+  const vaultAsset = useAppSelector(state => selectAssetByAssetId(state, vaultCAIP19))
 
   // user info
   const { state: walletState } = useWallet()

--- a/src/features/defi/providers/yearn/components/YearnManager/Deposit/components/Confirm.tsx
+++ b/src/features/defi/providers/yearn/components/YearnManager/Deposit/components/Confirm.tsx
@@ -18,7 +18,7 @@ import { useWallet } from 'hooks/useWallet/useWallet'
 import { bnOrZero } from 'lib/bignumber/bignumber'
 import { poll } from 'lib/poll/poll'
 import { marketApi } from 'state/slices/marketDataSlice/marketDataSlice'
-import { selectAssetByAssetId, selectMarketDataById } from 'state/slices/selectors'
+import { selectAssetById, selectMarketDataById } from 'state/slices/selectors'
 import { useAppDispatch, useAppSelector } from 'state/store'
 
 import { DepositPath, YearnDepositActionType } from '../DepositCommon'
@@ -45,10 +45,10 @@ export const Confirm = ({ api }: YearnConfirmProps) => {
     assetNamespace: AssetNamespace.Slip44,
     assetReference: AssetReference.Ethereum,
   })
-  const asset = useAppSelector(state => selectAssetByAssetId(state, assetCAIP19))
+  const asset = useAppSelector(state => selectAssetById(state, assetCAIP19))
   const marketData = useAppSelector(state => selectMarketDataById(state, assetCAIP19))
   if (!marketData) appDispatch(marketApi.endpoints.findByCaip19.initiate(assetCAIP19))
-  const feeAsset = useAppSelector(state => selectAssetByAssetId(state, feeAssetCAIP19))
+  const feeAsset = useAppSelector(state => selectAssetById(state, feeAssetCAIP19))
   const feeMarketData = useAppSelector(state => selectMarketDataById(state, feeAssetCAIP19))
   const vaultCAIP19 = caip19.toCAIP19({
     chain,
@@ -56,7 +56,7 @@ export const Confirm = ({ api }: YearnConfirmProps) => {
     assetNamespace,
     assetReference: vaultAddress,
   })
-  const vaultAsset = useAppSelector(state => selectAssetByAssetId(state, vaultCAIP19))
+  const vaultAsset = useAppSelector(state => selectAssetById(state, vaultCAIP19))
 
   // user info
   const { state: walletState } = useWallet()

--- a/src/features/defi/providers/yearn/components/YearnManager/Deposit/components/Deposit.tsx
+++ b/src/features/defi/providers/yearn/components/YearnManager/Deposit/components/Deposit.tsx
@@ -11,7 +11,7 @@ import { useBrowserRouter } from 'hooks/useBrowserRouter/useBrowserRouter'
 import { bnOrZero } from 'lib/bignumber/bignumber'
 import { marketApi } from 'state/slices/marketDataSlice/marketDataSlice'
 import {
-  selectAssetByCAIP19,
+  selectAssetByAssetId,
   selectMarketDataById,
   selectPortfolioCryptoBalanceByAssetId,
 } from 'state/slices/selectors'
@@ -37,7 +37,7 @@ export const Deposit = ({ api, apy, getDepositGasEstimate }: YearnDepositProps) 
   const network = NetworkTypes.MAINNET
   const assetNamespace = AssetNamespace.ERC20
   const assetCAIP19 = caip19.toCAIP19({ chain, network, assetNamespace, assetReference: tokenId })
-  const asset = useAppSelector(state => selectAssetByCAIP19(state, assetCAIP19))
+  const asset = useAppSelector(state => selectAssetByAssetId(state, assetCAIP19))
   const marketData = useAppSelector(state => selectMarketDataById(state, assetCAIP19))
   if (!marketData) appDispatch(marketApi.endpoints.findByCaip19.initiate(assetCAIP19))
 

--- a/src/features/defi/providers/yearn/components/YearnManager/Deposit/components/Deposit.tsx
+++ b/src/features/defi/providers/yearn/components/YearnManager/Deposit/components/Deposit.tsx
@@ -11,7 +11,7 @@ import { useBrowserRouter } from 'hooks/useBrowserRouter/useBrowserRouter'
 import { bnOrZero } from 'lib/bignumber/bignumber'
 import { marketApi } from 'state/slices/marketDataSlice/marketDataSlice'
 import {
-  selectAssetByAssetId,
+  selectAssetById,
   selectMarketDataById,
   selectPortfolioCryptoBalanceByAssetId,
 } from 'state/slices/selectors'
@@ -37,7 +37,7 @@ export const Deposit = ({ api, apy, getDepositGasEstimate }: YearnDepositProps) 
   const network = NetworkTypes.MAINNET
   const assetNamespace = AssetNamespace.ERC20
   const assetCAIP19 = caip19.toCAIP19({ chain, network, assetNamespace, assetReference: tokenId })
-  const asset = useAppSelector(state => selectAssetByAssetId(state, assetCAIP19))
+  const asset = useAppSelector(state => selectAssetById(state, assetCAIP19))
   const marketData = useAppSelector(state => selectMarketDataById(state, assetCAIP19))
   if (!marketData) appDispatch(marketApi.endpoints.findByCaip19.initiate(assetCAIP19))
 

--- a/src/features/defi/providers/yearn/components/YearnManager/Deposit/components/Status.tsx
+++ b/src/features/defi/providers/yearn/components/YearnManager/Deposit/components/Status.tsx
@@ -13,7 +13,7 @@ import { Text } from 'components/Text'
 import { useBrowserRouter } from 'hooks/useBrowserRouter/useBrowserRouter'
 import { bnOrZero } from 'lib/bignumber/bignumber'
 import { marketApi } from 'state/slices/marketDataSlice/marketDataSlice'
-import { selectAssetByCAIP19, selectMarketDataById } from 'state/slices/selectors'
+import { selectAssetByAssetId, selectMarketDataById } from 'state/slices/selectors'
 import { useAppDispatch, useAppSelector } from 'state/store'
 
 import { DepositContext } from '../DepositContext'
@@ -33,10 +33,10 @@ export const Status = () => {
     assetNamespace: AssetNamespace.Slip44,
     assetReference: AssetReference.Ethereum,
   })
-  const asset = useAppSelector(state => selectAssetByCAIP19(state, assetCAIP19))
+  const asset = useAppSelector(state => selectAssetByAssetId(state, assetCAIP19))
   const marketData = useAppSelector(state => selectMarketDataById(state, assetCAIP19))
   if (!marketData) appDispatch(marketApi.endpoints.findByCaip19.initiate(assetCAIP19))
-  const feeAsset = useAppSelector(state => selectAssetByCAIP19(state, feeAssetCAIP19))
+  const feeAsset = useAppSelector(state => selectAssetByAssetId(state, feeAssetCAIP19))
   const feeMarketData = useAppSelector(state => selectMarketDataById(state, feeAssetCAIP19))
   const vaultCAIP19 = caip19.toCAIP19({
     chain,
@@ -44,7 +44,7 @@ export const Status = () => {
     assetNamespace,
     assetReference: vaultAddress,
   })
-  const vaultAsset = useAppSelector(state => selectAssetByCAIP19(state, vaultCAIP19))
+  const vaultAsset = useAppSelector(state => selectAssetByAssetId(state, vaultCAIP19))
 
   const handleViewPosition = () => {
     browserHistory.push('/defi')

--- a/src/features/defi/providers/yearn/components/YearnManager/Deposit/components/Status.tsx
+++ b/src/features/defi/providers/yearn/components/YearnManager/Deposit/components/Status.tsx
@@ -13,7 +13,7 @@ import { Text } from 'components/Text'
 import { useBrowserRouter } from 'hooks/useBrowserRouter/useBrowserRouter'
 import { bnOrZero } from 'lib/bignumber/bignumber'
 import { marketApi } from 'state/slices/marketDataSlice/marketDataSlice'
-import { selectAssetByAssetId, selectMarketDataById } from 'state/slices/selectors'
+import { selectAssetById, selectMarketDataById } from 'state/slices/selectors'
 import { useAppDispatch, useAppSelector } from 'state/store'
 
 import { DepositContext } from '../DepositContext'
@@ -33,10 +33,10 @@ export const Status = () => {
     assetNamespace: AssetNamespace.Slip44,
     assetReference: AssetReference.Ethereum,
   })
-  const asset = useAppSelector(state => selectAssetByAssetId(state, assetCAIP19))
+  const asset = useAppSelector(state => selectAssetById(state, assetCAIP19))
   const marketData = useAppSelector(state => selectMarketDataById(state, assetCAIP19))
   if (!marketData) appDispatch(marketApi.endpoints.findByCaip19.initiate(assetCAIP19))
-  const feeAsset = useAppSelector(state => selectAssetByAssetId(state, feeAssetCAIP19))
+  const feeAsset = useAppSelector(state => selectAssetById(state, feeAssetCAIP19))
   const feeMarketData = useAppSelector(state => selectMarketDataById(state, feeAssetCAIP19))
   const vaultCAIP19 = caip19.toCAIP19({
     chain,
@@ -44,7 +44,7 @@ export const Status = () => {
     assetNamespace,
     assetReference: vaultAddress,
   })
-  const vaultAsset = useAppSelector(state => selectAssetByAssetId(state, vaultCAIP19))
+  const vaultAsset = useAppSelector(state => selectAssetById(state, vaultCAIP19))
 
   const handleViewPosition = () => {
     browserHistory.push('/defi')

--- a/src/features/defi/providers/yearn/components/YearnManager/Withdraw/YearnWithdraw.tsx
+++ b/src/features/defi/providers/yearn/components/YearnManager/Withdraw/YearnWithdraw.tsx
@@ -13,7 +13,7 @@ import { useChainAdapters } from 'context/PluginProvider/PluginProvider'
 import { useBrowserRouter } from 'hooks/useBrowserRouter/useBrowserRouter'
 import { useWallet } from 'hooks/useWallet/useWallet'
 import {
-  selectAssetByCAIP19,
+  selectAssetByAssetId,
   selectMarketDataById,
   selectPortfolioLoading,
 } from 'state/slices/selectors'
@@ -51,7 +51,7 @@ export const YearnWithdraw = ({ api }: YearnWithdrawProps) => {
     assetNamespace,
     assetReference: vaultAddress,
   })
-  const asset = useAppSelector(state => selectAssetByCAIP19(state, assetCAIP19))
+  const asset = useAppSelector(state => selectAssetByAssetId(state, assetCAIP19))
   const marketData = useAppSelector(state => selectMarketDataById(state, underlyingAssetCAIP19))
 
   // user info

--- a/src/features/defi/providers/yearn/components/YearnManager/Withdraw/YearnWithdraw.tsx
+++ b/src/features/defi/providers/yearn/components/YearnManager/Withdraw/YearnWithdraw.tsx
@@ -13,7 +13,7 @@ import { useChainAdapters } from 'context/PluginProvider/PluginProvider'
 import { useBrowserRouter } from 'hooks/useBrowserRouter/useBrowserRouter'
 import { useWallet } from 'hooks/useWallet/useWallet'
 import {
-  selectAssetByAssetId,
+  selectAssetById,
   selectMarketDataById,
   selectPortfolioLoading,
 } from 'state/slices/selectors'
@@ -51,7 +51,7 @@ export const YearnWithdraw = ({ api }: YearnWithdrawProps) => {
     assetNamespace,
     assetReference: vaultAddress,
   })
-  const asset = useAppSelector(state => selectAssetByAssetId(state, assetCAIP19))
+  const asset = useAppSelector(state => selectAssetById(state, assetCAIP19))
   const marketData = useAppSelector(state => selectMarketDataById(state, underlyingAssetCAIP19))
 
   // user info

--- a/src/features/defi/providers/yearn/components/YearnManager/Withdraw/components/Confirm.tsx
+++ b/src/features/defi/providers/yearn/components/YearnManager/Withdraw/components/Confirm.tsx
@@ -17,7 +17,7 @@ import { useBrowserRouter } from 'hooks/useBrowserRouter/useBrowserRouter'
 import { useWallet } from 'hooks/useWallet/useWallet'
 import { bnOrZero } from 'lib/bignumber/bignumber'
 import { poll } from 'lib/poll/poll'
-import { selectAssetByCAIP19, selectMarketDataById } from 'state/slices/selectors'
+import { selectAssetByAssetId, selectMarketDataById } from 'state/slices/selectors'
 import { useAppSelector } from 'state/store'
 
 import { WithdrawPath, YearnWithdrawActionType } from '../WithdrawCommon'
@@ -43,21 +43,23 @@ export const Confirm = ({ api }: YearnConfirmProps) => {
     assetNamespace,
     assetReference: tokenId,
   })
-  const underlyingAsset = useAppSelector(state => selectAssetByCAIP19(state, underlyingAssetCAIP19))
+  const underlyingAsset = useAppSelector(state =>
+    selectAssetByAssetId(state, underlyingAssetCAIP19),
+  )
   const assetCAIP19 = caip19.toCAIP19({
     chain,
     network,
     assetNamespace,
     assetReference: vaultAddress,
   })
-  const asset = useAppSelector(state => selectAssetByCAIP19(state, assetCAIP19))
+  const asset = useAppSelector(state => selectAssetByAssetId(state, assetCAIP19))
   const feeAssetCAIP19 = caip19.toCAIP19({
     chain,
     network,
     assetNamespace: AssetNamespace.Slip44,
     assetReference: AssetReference.Ethereum,
   })
-  const feeAsset = useAppSelector(state => selectAssetByCAIP19(state, feeAssetCAIP19))
+  const feeAsset = useAppSelector(state => selectAssetByAssetId(state, feeAssetCAIP19))
   const feeMarketData = useAppSelector(state => selectMarketDataById(state, feeAssetCAIP19))
 
   // user info

--- a/src/features/defi/providers/yearn/components/YearnManager/Withdraw/components/Confirm.tsx
+++ b/src/features/defi/providers/yearn/components/YearnManager/Withdraw/components/Confirm.tsx
@@ -17,7 +17,7 @@ import { useBrowserRouter } from 'hooks/useBrowserRouter/useBrowserRouter'
 import { useWallet } from 'hooks/useWallet/useWallet'
 import { bnOrZero } from 'lib/bignumber/bignumber'
 import { poll } from 'lib/poll/poll'
-import { selectAssetByAssetId, selectMarketDataById } from 'state/slices/selectors'
+import { selectAssetById, selectMarketDataById } from 'state/slices/selectors'
 import { useAppSelector } from 'state/store'
 
 import { WithdrawPath, YearnWithdrawActionType } from '../WithdrawCommon'
@@ -43,23 +43,21 @@ export const Confirm = ({ api }: YearnConfirmProps) => {
     assetNamespace,
     assetReference: tokenId,
   })
-  const underlyingAsset = useAppSelector(state =>
-    selectAssetByAssetId(state, underlyingAssetCAIP19),
-  )
+  const underlyingAsset = useAppSelector(state => selectAssetById(state, underlyingAssetCAIP19))
   const assetCAIP19 = caip19.toCAIP19({
     chain,
     network,
     assetNamespace,
     assetReference: vaultAddress,
   })
-  const asset = useAppSelector(state => selectAssetByAssetId(state, assetCAIP19))
+  const asset = useAppSelector(state => selectAssetById(state, assetCAIP19))
   const feeAssetCAIP19 = caip19.toCAIP19({
     chain,
     network,
     assetNamespace: AssetNamespace.Slip44,
     assetReference: AssetReference.Ethereum,
   })
-  const feeAsset = useAppSelector(state => selectAssetByAssetId(state, feeAssetCAIP19))
+  const feeAsset = useAppSelector(state => selectAssetById(state, feeAssetCAIP19))
   const feeMarketData = useAppSelector(state => selectMarketDataById(state, feeAssetCAIP19))
 
   // user info

--- a/src/features/defi/providers/yearn/components/YearnManager/Withdraw/components/Status.tsx
+++ b/src/features/defi/providers/yearn/components/YearnManager/Withdraw/components/Status.tsx
@@ -12,7 +12,7 @@ import { Row } from 'components/Row/Row'
 import { Text } from 'components/Text'
 import { useBrowserRouter } from 'hooks/useBrowserRouter/useBrowserRouter'
 import { bnOrZero } from 'lib/bignumber/bignumber'
-import { selectAssetByAssetId, selectMarketDataById } from 'state/slices/selectors'
+import { selectAssetById, selectMarketDataById } from 'state/slices/selectors'
 import { useAppSelector } from 'state/store'
 
 import { WithdrawContext } from '../WithdrawContext'
@@ -31,23 +31,21 @@ export const Status = () => {
     assetNamespace,
     assetReference: tokenId,
   })
-  const underlyingAsset = useAppSelector(state =>
-    selectAssetByAssetId(state, underlyingAssetCAIP19),
-  )
+  const underlyingAsset = useAppSelector(state => selectAssetById(state, underlyingAssetCAIP19))
   const assetCAIP19 = caip19.toCAIP19({
     chain,
     network,
     assetNamespace,
     assetReference: vaultAddress,
   })
-  const asset = useAppSelector(state => selectAssetByAssetId(state, assetCAIP19))
+  const asset = useAppSelector(state => selectAssetById(state, assetCAIP19))
   const feeAssetCAIP19 = caip19.toCAIP19({
     chain,
     network,
     assetNamespace: AssetNamespace.Slip44,
     assetReference: AssetReference.Ethereum,
   })
-  const feeAsset = useAppSelector(state => selectAssetByAssetId(state, feeAssetCAIP19))
+  const feeAsset = useAppSelector(state => selectAssetById(state, feeAssetCAIP19))
   const feeMarketData = useAppSelector(state => selectMarketDataById(state, feeAssetCAIP19))
 
   const handleViewPosition = () => {

--- a/src/features/defi/providers/yearn/components/YearnManager/Withdraw/components/Status.tsx
+++ b/src/features/defi/providers/yearn/components/YearnManager/Withdraw/components/Status.tsx
@@ -12,7 +12,7 @@ import { Row } from 'components/Row/Row'
 import { Text } from 'components/Text'
 import { useBrowserRouter } from 'hooks/useBrowserRouter/useBrowserRouter'
 import { bnOrZero } from 'lib/bignumber/bignumber'
-import { selectAssetByCAIP19, selectMarketDataById } from 'state/slices/selectors'
+import { selectAssetByAssetId, selectMarketDataById } from 'state/slices/selectors'
 import { useAppSelector } from 'state/store'
 
 import { WithdrawContext } from '../WithdrawContext'
@@ -31,21 +31,23 @@ export const Status = () => {
     assetNamespace,
     assetReference: tokenId,
   })
-  const underlyingAsset = useAppSelector(state => selectAssetByCAIP19(state, underlyingAssetCAIP19))
+  const underlyingAsset = useAppSelector(state =>
+    selectAssetByAssetId(state, underlyingAssetCAIP19),
+  )
   const assetCAIP19 = caip19.toCAIP19({
     chain,
     network,
     assetNamespace,
     assetReference: vaultAddress,
   })
-  const asset = useAppSelector(state => selectAssetByCAIP19(state, assetCAIP19))
+  const asset = useAppSelector(state => selectAssetByAssetId(state, assetCAIP19))
   const feeAssetCAIP19 = caip19.toCAIP19({
     chain,
     network,
     assetNamespace: AssetNamespace.Slip44,
     assetReference: AssetReference.Ethereum,
   })
-  const feeAsset = useAppSelector(state => selectAssetByCAIP19(state, feeAssetCAIP19))
+  const feeAsset = useAppSelector(state => selectAssetByAssetId(state, feeAssetCAIP19))
   const feeMarketData = useAppSelector(state => selectMarketDataById(state, feeAssetCAIP19))
 
   const handleViewPosition = () => {

--- a/src/features/defi/providers/yearn/components/YearnManager/Withdraw/components/Withdraw.tsx
+++ b/src/features/defi/providers/yearn/components/YearnManager/Withdraw/components/Withdraw.tsx
@@ -11,7 +11,7 @@ import { useHistory } from 'react-router-dom'
 import { useBrowserRouter } from 'hooks/useBrowserRouter/useBrowserRouter'
 import { bnOrZero } from 'lib/bignumber/bignumber'
 import {
-  selectAssetByCAIP19,
+  selectAssetByAssetId,
   selectMarketDataById,
   selectPortfolioCryptoBalanceByAssetId,
 } from 'state/slices/selectors'
@@ -45,7 +45,7 @@ export const Withdraw = ({ api }: YearnWithdrawProps) => {
     assetNamespace,
     assetReference: vaultAddress,
   })
-  const asset = useAppSelector(state => selectAssetByCAIP19(state, assetCAIP19))
+  const asset = useAppSelector(state => selectAssetByAssetId(state, assetCAIP19))
   const marketData = useAppSelector(state => selectMarketDataById(state, underlyingAssetCAIP19))
 
   // user info

--- a/src/features/defi/providers/yearn/components/YearnManager/Withdraw/components/Withdraw.tsx
+++ b/src/features/defi/providers/yearn/components/YearnManager/Withdraw/components/Withdraw.tsx
@@ -11,7 +11,7 @@ import { useHistory } from 'react-router-dom'
 import { useBrowserRouter } from 'hooks/useBrowserRouter/useBrowserRouter'
 import { bnOrZero } from 'lib/bignumber/bignumber'
 import {
-  selectAssetByAssetId,
+  selectAssetById,
   selectMarketDataById,
   selectPortfolioCryptoBalanceByAssetId,
 } from 'state/slices/selectors'
@@ -45,7 +45,7 @@ export const Withdraw = ({ api }: YearnWithdrawProps) => {
     assetNamespace,
     assetReference: vaultAddress,
   })
-  const asset = useAppSelector(state => selectAssetByAssetId(state, assetCAIP19))
+  const asset = useAppSelector(state => selectAssetById(state, assetCAIP19))
   const marketData = useAppSelector(state => selectMarketDataById(state, underlyingAssetCAIP19))
 
   // user info

--- a/src/hooks/useTxDetails/useTxDetails.ts
+++ b/src/hooks/useTxDetails/useTxDetails.ts
@@ -3,7 +3,7 @@ import { useEffect, useState } from 'react'
 import { ensReverseLookup } from 'lib/ens'
 import { ReduxState } from 'state/reducer'
 import {
-  selectAssetByAssetId,
+  selectAssetById,
   selectFeeAssetByChainId,
   selectMarketDataById,
   selectTxById,
@@ -114,14 +114,14 @@ export const useTxDetails = (txId: string, activeAsset?: Asset): TxDetails => {
   })()
 
   const standardAsset = useAppSelector((state: ReduxState) =>
-    selectAssetByAssetId(state, standardTx?.caip19 ?? ''),
+    selectAssetById(state, standardTx?.caip19 ?? ''),
   )
 
   // stables need precision of eth (18) rather than 10
   const defaultFeeAsset = useAppSelector(state => selectFeeAssetByChainId(state, tx.caip2))
-  const feeAsset = useAppSelector(state => selectAssetByAssetId(state, tx.fee?.caip19 ?? ''))
-  const buyAsset = useAppSelector(state => selectAssetByAssetId(state, buyTransfer?.caip19 ?? ''))
-  const sellAsset = useAppSelector(state => selectAssetByAssetId(state, sellTransfer?.caip19 ?? ''))
+  const feeAsset = useAppSelector(state => selectAssetById(state, tx.fee?.caip19 ?? ''))
+  const buyAsset = useAppSelector(state => selectAssetById(state, buyTransfer?.caip19 ?? ''))
+  const sellAsset = useAppSelector(state => selectAssetById(state, sellTransfer?.caip19 ?? ''))
   const tradeAsset = activeAsset?.symbol === sellAsset?.symbol ? sellAsset : buyAsset
   const sourceMarketData = useAppSelector(state =>
     selectMarketDataById(state, sellTransfer?.caip19 ?? ''),

--- a/src/hooks/useTxDetails/useTxDetails.ts
+++ b/src/hooks/useTxDetails/useTxDetails.ts
@@ -3,7 +3,7 @@ import { useEffect, useState } from 'react'
 import { ensReverseLookup } from 'lib/ens'
 import { ReduxState } from 'state/reducer'
 import {
-  selectAssetByCAIP19,
+  selectAssetByAssetId,
   selectFeeAssetByChainId,
   selectMarketDataById,
   selectTxById,
@@ -114,14 +114,14 @@ export const useTxDetails = (txId: string, activeAsset?: Asset): TxDetails => {
   })()
 
   const standardAsset = useAppSelector((state: ReduxState) =>
-    selectAssetByCAIP19(state, standardTx?.caip19 ?? ''),
+    selectAssetByAssetId(state, standardTx?.caip19 ?? ''),
   )
 
   // stables need precision of eth (18) rather than 10
   const defaultFeeAsset = useAppSelector(state => selectFeeAssetByChainId(state, tx.caip2))
-  const feeAsset = useAppSelector(state => selectAssetByCAIP19(state, tx.fee?.caip19 ?? ''))
-  const buyAsset = useAppSelector(state => selectAssetByCAIP19(state, buyTransfer?.caip19 ?? ''))
-  const sellAsset = useAppSelector(state => selectAssetByCAIP19(state, sellTransfer?.caip19 ?? ''))
+  const feeAsset = useAppSelector(state => selectAssetByAssetId(state, tx.fee?.caip19 ?? ''))
+  const buyAsset = useAppSelector(state => selectAssetByAssetId(state, buyTransfer?.caip19 ?? ''))
+  const sellAsset = useAppSelector(state => selectAssetByAssetId(state, sellTransfer?.caip19 ?? ''))
   const tradeAsset = activeAsset?.symbol === sellAsset?.symbol ? sellAsset : buyAsset
   const sourceMarketData = useAppSelector(state =>
     selectMarketDataById(state, sellTransfer?.caip19 ?? ''),

--- a/src/pages/Accounts/Account.tsx
+++ b/src/pages/Accounts/Account.tsx
@@ -3,7 +3,7 @@ import { Route } from 'Routes/helpers'
 import { AssetAccountDetails } from 'components/AssetAccountDetails'
 import { AccountSpecifier } from 'state/slices/accountSpecifiersSlice/accountSpecifiersSlice'
 import { accountIdToFeeAssetId } from 'state/slices/portfolioSlice/utils'
-import { selectAssetByCAIP19 } from 'state/slices/selectors'
+import { selectAssetByAssetId } from 'state/slices/selectors'
 import { useAppSelector } from 'state/store'
 
 export type MatchParams = {
@@ -15,7 +15,7 @@ export const Account = ({ route }: { route?: Route }) => {
   const { accountId } = useParams<MatchParams>()
   const parsedAccountId = decodeURIComponent(accountId)
   const feeAssetId = accountIdToFeeAssetId(parsedAccountId)
-  const feeAsset = useAppSelector(state => selectAssetByCAIP19(state, feeAssetId))
+  const feeAsset = useAppSelector(state => selectAssetByAssetId(state, feeAssetId))
 
   return (
     feeAsset && (

--- a/src/pages/Accounts/Account.tsx
+++ b/src/pages/Accounts/Account.tsx
@@ -3,7 +3,7 @@ import { Route } from 'Routes/helpers'
 import { AssetAccountDetails } from 'components/AssetAccountDetails'
 import { AccountSpecifier } from 'state/slices/accountSpecifiersSlice/accountSpecifiersSlice'
 import { accountIdToFeeAssetId } from 'state/slices/portfolioSlice/utils'
-import { selectAssetByAssetId } from 'state/slices/selectors'
+import { selectAssetById } from 'state/slices/selectors'
 import { useAppSelector } from 'state/store'
 
 export type MatchParams = {
@@ -15,7 +15,7 @@ export const Account = ({ route }: { route?: Route }) => {
   const { accountId } = useParams<MatchParams>()
   const parsedAccountId = decodeURIComponent(accountId)
   const feeAssetId = accountIdToFeeAssetId(parsedAccountId)
-  const feeAsset = useAppSelector(state => selectAssetByAssetId(state, feeAssetId))
+  const feeAsset = useAppSelector(state => selectAssetById(state, feeAssetId))
 
   return (
     feeAsset && (

--- a/src/pages/Accounts/AccountToken/AccountTokenTxHistory.tsx
+++ b/src/pages/Accounts/AccountToken/AccountTokenTxHistory.tsx
@@ -2,7 +2,7 @@ import { useParams } from 'react-router-dom'
 import { AssetHeader } from 'components/AssetHeader/AssetHeader'
 import { Main } from 'components/Layout/Main'
 import { AssetTransactionHistory } from 'components/TransactionHistory/AssetTransactionHistory'
-import { selectAssetByCAIP19 } from 'state/slices/assetsSlice/selectors'
+import { selectAssetByAssetId } from 'state/slices/assetsSlice/selectors'
 import { useAppSelector } from 'state/store'
 
 import { MatchParams } from './AccountToken'
@@ -10,7 +10,7 @@ import { MatchParams } from './AccountToken'
 export const AccountTokenTxHistory: React.FC = () => {
   const { accountId, assetId } = useParams<MatchParams>()
   const assetIdParam = decodeURIComponent(assetId)
-  const asset = useAppSelector(state => selectAssetByCAIP19(state, assetIdParam))
+  const asset = useAppSelector(state => selectAssetByAssetId(state, assetIdParam))
   return !asset ? null : (
     <Main titleComponent={<AssetHeader assetId={assetIdParam} accountId={accountId} />}>
       <AssetTransactionHistory

--- a/src/pages/Accounts/AccountToken/AccountTokenTxHistory.tsx
+++ b/src/pages/Accounts/AccountToken/AccountTokenTxHistory.tsx
@@ -2,7 +2,7 @@ import { useParams } from 'react-router-dom'
 import { AssetHeader } from 'components/AssetHeader/AssetHeader'
 import { Main } from 'components/Layout/Main'
 import { AssetTransactionHistory } from 'components/TransactionHistory/AssetTransactionHistory'
-import { selectAssetByAssetId } from 'state/slices/assetsSlice/selectors'
+import { selectAssetById } from 'state/slices/assetsSlice/selectors'
 import { useAppSelector } from 'state/store'
 
 import { MatchParams } from './AccountToken'
@@ -10,7 +10,7 @@ import { MatchParams } from './AccountToken'
 export const AccountTokenTxHistory: React.FC = () => {
   const { accountId, assetId } = useParams<MatchParams>()
   const assetIdParam = decodeURIComponent(assetId)
-  const asset = useAppSelector(state => selectAssetByAssetId(state, assetIdParam))
+  const asset = useAppSelector(state => selectAssetById(state, assetIdParam))
   return !asset ? null : (
     <Main titleComponent={<AssetHeader assetId={assetIdParam} accountId={accountId} />}>
       <AssetTransactionHistory

--- a/src/pages/Accounts/AccountTxHistory.tsx
+++ b/src/pages/Accounts/AccountTxHistory.tsx
@@ -3,7 +3,7 @@ import { AssetHeader } from 'components/AssetHeader/AssetHeader'
 import { Main } from 'components/Layout/Main'
 import { AssetTransactionHistory } from 'components/TransactionHistory/AssetTransactionHistory'
 import { accountIdToFeeAssetId } from 'state/slices/portfolioSlice/utils'
-import { selectAssetByAssetId } from 'state/slices/selectors'
+import { selectAssetById } from 'state/slices/selectors'
 import { useAppSelector } from 'state/store'
 
 import { MatchParams } from './Account'
@@ -12,7 +12,7 @@ export const AccountTxHistory: React.FC = () => {
   const { accountId } = useParams<MatchParams>()
   const parsedAccountId = decodeURIComponent(accountId)
   const feeAssetId = accountIdToFeeAssetId(parsedAccountId)
-  const feeAsset = useAppSelector(state => selectAssetByAssetId(state, feeAssetId))
+  const feeAsset = useAppSelector(state => selectAssetById(state, feeAssetId))
   return !feeAsset ? null : (
     <Main titleComponent={<AssetHeader assetId={feeAssetId} accountId={accountId} />}>
       <AssetTransactionHistory assetId={feeAssetId} accountId={accountId} useCompactMode={false} />

--- a/src/pages/Accounts/AccountTxHistory.tsx
+++ b/src/pages/Accounts/AccountTxHistory.tsx
@@ -3,7 +3,7 @@ import { AssetHeader } from 'components/AssetHeader/AssetHeader'
 import { Main } from 'components/Layout/Main'
 import { AssetTransactionHistory } from 'components/TransactionHistory/AssetTransactionHistory'
 import { accountIdToFeeAssetId } from 'state/slices/portfolioSlice/utils'
-import { selectAssetByCAIP19 } from 'state/slices/selectors'
+import { selectAssetByAssetId } from 'state/slices/selectors'
 import { useAppSelector } from 'state/store'
 
 import { MatchParams } from './Account'
@@ -12,7 +12,7 @@ export const AccountTxHistory: React.FC = () => {
   const { accountId } = useParams<MatchParams>()
   const parsedAccountId = decodeURIComponent(accountId)
   const feeAssetId = accountIdToFeeAssetId(parsedAccountId)
-  const feeAsset = useAppSelector(state => selectAssetByCAIP19(state, feeAssetId))
+  const feeAsset = useAppSelector(state => selectAssetByAssetId(state, feeAssetId))
   return !feeAsset ? null : (
     <Main titleComponent={<AssetHeader assetId={feeAssetId} accountId={accountId} />}>
       <AssetTransactionHistory assetId={feeAssetId} accountId={accountId} useCompactMode={false} />

--- a/src/pages/Assets/Asset.tsx
+++ b/src/pages/Assets/Asset.tsx
@@ -6,7 +6,7 @@ import { AssetAccountDetails } from 'components/AssetAccountDetails'
 import { Page } from 'components/Layout/Page'
 import { marketApi } from 'state/slices/marketDataSlice/marketDataSlice'
 import {
-  selectAssetByCAIP19,
+  selectAssetByAssetId,
   selectMarketDataById,
   selectMarketDataLoadingById,
 } from 'state/slices/selectors'
@@ -23,7 +23,7 @@ export const useAsset = () => {
 
   const params = useParams<MatchParams>()
   const assetId = `${params.chainId}/${params.assetSubId}`
-  const asset = useAppSelector(state => selectAssetByCAIP19(state, assetId))
+  const asset = useAppSelector(state => selectAssetByAssetId(state, assetId))
   const marketData = useAppSelector(state => selectMarketDataById(state, assetId))
 
   // Many, but not all, assets are initialized with market data on app load. This dispatch will

--- a/src/pages/Assets/Asset.tsx
+++ b/src/pages/Assets/Asset.tsx
@@ -6,7 +6,7 @@ import { AssetAccountDetails } from 'components/AssetAccountDetails'
 import { Page } from 'components/Layout/Page'
 import { marketApi } from 'state/slices/marketDataSlice/marketDataSlice'
 import {
-  selectAssetByAssetId,
+  selectAssetById,
   selectMarketDataById,
   selectMarketDataLoadingById,
 } from 'state/slices/selectors'
@@ -23,7 +23,7 @@ export const useAsset = () => {
 
   const params = useParams<MatchParams>()
   const assetId = `${params.chainId}/${params.assetSubId}`
-  const asset = useAppSelector(state => selectAssetByAssetId(state, assetId))
+  const asset = useAppSelector(state => selectAssetById(state, assetId))
   const marketData = useAppSelector(state => selectMarketDataById(state, assetId))
 
   // Many, but not all, assets are initialized with market data on app load. This dispatch will

--- a/src/pages/Defi/components/OpportunityCard.tsx
+++ b/src/pages/Defi/components/OpportunityCard.tsx
@@ -21,7 +21,7 @@ import { RawText, Text } from 'components/Text'
 import { WalletActions } from 'context/WalletProvider/actions'
 import { useModal } from 'hooks/useModal/useModal'
 import { useWallet } from 'hooks/useWallet/useWallet'
-import { selectAssetByCAIP19 } from 'state/slices/selectors'
+import { selectAssetByAssetId } from 'state/slices/selectors'
 import { useAppSelector } from 'state/store'
 
 type OpportunityCardProps = {
@@ -46,7 +46,7 @@ export const OpportunityCard = ({
   const history = useHistory()
   const location = useLocation()
   const bgHover = useColorModeValue('gray.100', 'gray.700')
-  const asset = useAppSelector(state => selectAssetByCAIP19(state, assetId))
+  const asset = useAppSelector(state => selectAssetByAssetId(state, assetId))
   const { cosmosStaking } = useModal()
   const isCosmosStaking = chain === ChainTypes.Cosmos
 

--- a/src/pages/Defi/components/OpportunityCard.tsx
+++ b/src/pages/Defi/components/OpportunityCard.tsx
@@ -21,7 +21,7 @@ import { RawText, Text } from 'components/Text'
 import { WalletActions } from 'context/WalletProvider/actions'
 import { useModal } from 'hooks/useModal/useModal'
 import { useWallet } from 'hooks/useWallet/useWallet'
-import { selectAssetByAssetId } from 'state/slices/selectors'
+import { selectAssetById } from 'state/slices/selectors'
 import { useAppSelector } from 'state/store'
 
 type OpportunityCardProps = {
@@ -46,7 +46,7 @@ export const OpportunityCard = ({
   const history = useHistory()
   const location = useLocation()
   const bgHover = useColorModeValue('gray.100', 'gray.700')
-  const asset = useAppSelector(state => selectAssetByAssetId(state, assetId))
+  const asset = useAppSelector(state => selectAssetById(state, assetId))
   const { cosmosStaking } = useModal()
   const isCosmosStaking = chain === ChainTypes.Cosmos
 

--- a/src/pages/Defi/hooks/useCosmosStakingBalances.tsx
+++ b/src/pages/Defi/hooks/useCosmosStakingBalances.tsx
@@ -4,7 +4,7 @@ import { useEffect, useMemo } from 'react'
 import { BigNumber, bnOrZero } from 'lib/bignumber/bignumber'
 import {
   selectAccountSpecifier,
-  selectAssetByCAIP19,
+  selectAssetByAssetId,
   selectMarketDataById,
 } from 'state/slices/selectors'
 import {
@@ -53,7 +53,7 @@ export function useCosmosStakingBalances({
   const isValidatorDataLoaded = useAppSelector(selectValidatorIsLoaded)
   const isLoaded = isStakingDataLoaded && isValidatorDataLoaded
   const marketData = useAppSelector(state => selectMarketDataById(state, assetId))
-  const asset = useAppSelector(state => selectAssetByCAIP19(state, assetId))
+  const asset = useAppSelector(state => selectAssetByAssetId(state, assetId))
   const dispatch = useAppDispatch()
 
   const accountSpecifiers = useAppSelector(state => selectAccountSpecifier(state, asset?.caip2))

--- a/src/pages/Defi/hooks/useCosmosStakingBalances.tsx
+++ b/src/pages/Defi/hooks/useCosmosStakingBalances.tsx
@@ -4,7 +4,7 @@ import { useEffect, useMemo } from 'react'
 import { BigNumber, bnOrZero } from 'lib/bignumber/bignumber'
 import {
   selectAccountSpecifier,
-  selectAssetByAssetId,
+  selectAssetById,
   selectMarketDataById,
 } from 'state/slices/selectors'
 import {
@@ -53,7 +53,7 @@ export function useCosmosStakingBalances({
   const isValidatorDataLoaded = useAppSelector(selectValidatorIsLoaded)
   const isLoaded = isStakingDataLoaded && isValidatorDataLoaded
   const marketData = useAppSelector(state => selectMarketDataById(state, assetId))
-  const asset = useAppSelector(state => selectAssetByAssetId(state, assetId))
+  const asset = useAppSelector(state => selectAssetById(state, assetId))
   const dispatch = useAppDispatch()
 
   const accountSpecifiers = useAppSelector(state => selectAccountSpecifier(state, asset?.caip2))

--- a/src/plugins/cosmos/CosmosAccount.tsx
+++ b/src/plugins/cosmos/CosmosAccount.tsx
@@ -1,7 +1,7 @@
 import { AssetId } from '@shapeshiftoss/caip'
 import { useParams } from 'react-router-dom'
 import { accountIdToFeeAssetId } from 'state/slices/portfolioSlice/utils'
-import { selectAssetByCAIP19 } from 'state/slices/selectors'
+import { selectAssetByAssetId } from 'state/slices/selectors'
 import { useAppSelector } from 'state/store'
 
 import { CosmosAssetAccountDetails } from './CosmosAssetAccountDetails'
@@ -16,7 +16,7 @@ export const CosmosAccount = () => {
   const accountId = `cosmos:${accountSubId}`
   const parsedAccountId = decodeURIComponent(accountId)
   const feeAssetId = accountIdToFeeAssetId(parsedAccountId)
-  const feeAsset = useAppSelector(state => selectAssetByCAIP19(state, feeAssetId))
+  const feeAsset = useAppSelector(state => selectAssetByAssetId(state, feeAssetId))
 
   return feeAsset && <CosmosAssetAccountDetails assetId={feeAsset.caip19} accountId={accountId} />
 }

--- a/src/plugins/cosmos/CosmosAccount.tsx
+++ b/src/plugins/cosmos/CosmosAccount.tsx
@@ -1,7 +1,7 @@
 import { AssetId } from '@shapeshiftoss/caip'
 import { useParams } from 'react-router-dom'
 import { accountIdToFeeAssetId } from 'state/slices/portfolioSlice/utils'
-import { selectAssetByAssetId } from 'state/slices/selectors'
+import { selectAssetById } from 'state/slices/selectors'
 import { useAppSelector } from 'state/store'
 
 import { CosmosAssetAccountDetails } from './CosmosAssetAccountDetails'
@@ -16,7 +16,7 @@ export const CosmosAccount = () => {
   const accountId = `cosmos:${accountSubId}`
   const parsedAccountId = decodeURIComponent(accountId)
   const feeAssetId = accountIdToFeeAssetId(parsedAccountId)
-  const feeAsset = useAppSelector(state => selectAssetByAssetId(state, feeAssetId))
+  const feeAsset = useAppSelector(state => selectAssetById(state, feeAssetId))
 
   return feeAsset && <CosmosAssetAccountDetails assetId={feeAsset.caip19} accountId={accountId} />
 }

--- a/src/plugins/cosmos/CosmosAccountTxHistory.tsx
+++ b/src/plugins/cosmos/CosmosAccountTxHistory.tsx
@@ -3,7 +3,7 @@ import { AssetHeader } from 'components/AssetHeader/AssetHeader'
 import { Main } from 'components/Layout/Main'
 import { AssetTransactionHistory } from 'components/TransactionHistory/AssetTransactionHistory'
 import { accountIdToFeeAssetId } from 'state/slices/portfolioSlice/utils'
-import { selectAssetByCAIP19 } from 'state/slices/selectors'
+import { selectAssetByAssetId } from 'state/slices/selectors'
 import { useAppSelector } from 'state/store'
 
 import { MatchParams } from './CosmosAccount'
@@ -13,7 +13,7 @@ export const CosmosAccountTxHistory: React.FC = () => {
   const accountId = `cosmos:${accountSubId}`
   const parsedAccountId = decodeURIComponent(accountId)
   const feeAssetId = accountIdToFeeAssetId(parsedAccountId)
-  const feeAsset = useAppSelector(state => selectAssetByCAIP19(state, feeAssetId))
+  const feeAsset = useAppSelector(state => selectAssetByAssetId(state, feeAssetId))
   return !feeAsset ? null : (
     <Main titleComponent={<AssetHeader assetId={feeAssetId} accountId={accountId} />}>
       <AssetTransactionHistory assetId={feeAssetId} accountId={accountId} useCompactMode={false} />

--- a/src/plugins/cosmos/CosmosAccountTxHistory.tsx
+++ b/src/plugins/cosmos/CosmosAccountTxHistory.tsx
@@ -3,7 +3,7 @@ import { AssetHeader } from 'components/AssetHeader/AssetHeader'
 import { Main } from 'components/Layout/Main'
 import { AssetTransactionHistory } from 'components/TransactionHistory/AssetTransactionHistory'
 import { accountIdToFeeAssetId } from 'state/slices/portfolioSlice/utils'
-import { selectAssetByAssetId } from 'state/slices/selectors'
+import { selectAssetById } from 'state/slices/selectors'
 import { useAppSelector } from 'state/store'
 
 import { MatchParams } from './CosmosAccount'
@@ -13,7 +13,7 @@ export const CosmosAccountTxHistory: React.FC = () => {
   const accountId = `cosmos:${accountSubId}`
   const parsedAccountId = decodeURIComponent(accountId)
   const feeAssetId = accountIdToFeeAssetId(parsedAccountId)
-  const feeAsset = useAppSelector(state => selectAssetByAssetId(state, feeAssetId))
+  const feeAsset = useAppSelector(state => selectAssetById(state, feeAssetId))
   return !feeAsset ? null : (
     <Main titleComponent={<AssetHeader assetId={feeAssetId} accountId={accountId} />}>
       <AssetTransactionHistory assetId={feeAssetId} accountId={accountId} useCompactMode={false} />

--- a/src/plugins/cosmos/CosmosAsset.tsx
+++ b/src/plugins/cosmos/CosmosAsset.tsx
@@ -4,7 +4,7 @@ import { Page } from 'components/Layout/Page'
 import { LoadingAsset } from 'pages/Assets/LoadingAsset'
 import { marketApi } from 'state/slices/marketDataSlice/marketDataSlice'
 import {
-  selectAssetByCAIP19,
+  selectAssetByAssetId,
   selectMarketDataById,
   selectMarketDataLoadingById,
 } from 'state/slices/selectors'
@@ -22,7 +22,7 @@ export const CosmosAsset = () => {
 
   const { chainRef, assetSubId } = useParams<MatchParams>()
   const assetId = `cosmos:${chainRef}/${assetSubId}`
-  const asset = useAppSelector(state => selectAssetByCAIP19(state, assetId))
+  const asset = useAppSelector(state => selectAssetByAssetId(state, assetId))
   const marketData = useAppSelector(state => selectMarketDataById(state, assetId))
 
   if (!marketData) dispatch(marketApi.endpoints.findByCaip19.initiate(assetId))

--- a/src/plugins/cosmos/CosmosAsset.tsx
+++ b/src/plugins/cosmos/CosmosAsset.tsx
@@ -4,7 +4,7 @@ import { Page } from 'components/Layout/Page'
 import { LoadingAsset } from 'pages/Assets/LoadingAsset'
 import { marketApi } from 'state/slices/marketDataSlice/marketDataSlice'
 import {
-  selectAssetByAssetId,
+  selectAssetById,
   selectMarketDataById,
   selectMarketDataLoadingById,
 } from 'state/slices/selectors'
@@ -22,7 +22,7 @@ export const CosmosAsset = () => {
 
   const { chainRef, assetSubId } = useParams<MatchParams>()
   const assetId = `cosmos:${chainRef}/${assetSubId}`
-  const asset = useAppSelector(state => selectAssetByAssetId(state, assetId))
+  const asset = useAppSelector(state => selectAssetById(state, assetId))
   const marketData = useAppSelector(state => selectMarketDataById(state, assetId))
 
   if (!marketData) dispatch(marketApi.endpoints.findByCaip19.initiate(assetId))

--- a/src/plugins/cosmos/components/modals/GetStarted/views/GetStarted.tsx
+++ b/src/plugins/cosmos/components/modals/GetStarted/views/GetStarted.tsx
@@ -7,7 +7,7 @@ import { useHistory, useLocation } from 'react-router-dom'
 import osmosis from 'assets/osmosis.svg'
 import { Text } from 'components/Text'
 import { useModal } from 'hooks/useModal/useModal'
-import { selectAssetByAssetId } from 'state/slices/selectors'
+import { selectAssetById } from 'state/slices/selectors'
 import { useAppSelector } from 'state/store'
 
 type GetStartedProps = {
@@ -40,7 +40,7 @@ export const GetStarted = ({ assetId }: GetStartedProps) => {
     cosmosGetStarted.close()
   }
 
-  const asset = useAppSelector(state => selectAssetByAssetId(state, assetId))
+  const asset = useAppSelector(state => selectAssetById(state, assetId))
   const maxApr = ASSET_ID_TO_MAX_APR[assetId]
 
   return (

--- a/src/plugins/cosmos/components/modals/GetStarted/views/GetStarted.tsx
+++ b/src/plugins/cosmos/components/modals/GetStarted/views/GetStarted.tsx
@@ -7,7 +7,7 @@ import { useHistory, useLocation } from 'react-router-dom'
 import osmosis from 'assets/osmosis.svg'
 import { Text } from 'components/Text'
 import { useModal } from 'hooks/useModal/useModal'
-import { selectAssetByCAIP19 } from 'state/slices/selectors'
+import { selectAssetByAssetId } from 'state/slices/selectors'
 import { useAppSelector } from 'state/store'
 
 type GetStartedProps = {
@@ -40,7 +40,7 @@ export const GetStarted = ({ assetId }: GetStartedProps) => {
     cosmosGetStarted.close()
   }
 
-  const asset = useAppSelector(state => selectAssetByCAIP19(state, assetId))
+  const asset = useAppSelector(state => selectAssetByAssetId(state, assetId))
   const maxApr = ASSET_ID_TO_MAX_APR[assetId]
 
   return (

--- a/src/plugins/cosmos/components/modals/Staking/Staking.tsx
+++ b/src/plugins/cosmos/components/modals/Staking/Staking.tsx
@@ -13,7 +13,7 @@ import { useRef } from 'react'
 import { useTranslate } from 'react-polyglot'
 import { matchPath, MemoryRouter, Route, Switch, useLocation } from 'react-router-dom'
 import { RouteSteps } from 'components/RouteSteps/RouteSteps'
-import { selectAccountSpecifier, selectAssetByAssetId } from 'state/slices/selectors'
+import { selectAccountSpecifier, selectAssetById } from 'state/slices/selectors'
 import { useAppSelector } from 'state/store'
 
 import { StakeFormManager } from './forms/StakeFormManager'
@@ -73,7 +73,7 @@ const StakingModalContent = ({ assetId, validatorAddress }: StakingModalProps) =
 
   const initialRef = useRef<HTMLInputElement>(null)
 
-  const asset = useAppSelector(state => selectAssetByAssetId(state, assetId))
+  const asset = useAppSelector(state => selectAssetById(state, assetId))
   const accountSpecifiersForChainId = useAppSelector(state =>
     selectAccountSpecifier(state, asset?.caip2),
   )

--- a/src/plugins/cosmos/components/modals/Staking/Staking.tsx
+++ b/src/plugins/cosmos/components/modals/Staking/Staking.tsx
@@ -13,7 +13,7 @@ import { useRef } from 'react'
 import { useTranslate } from 'react-polyglot'
 import { matchPath, MemoryRouter, Route, Switch, useLocation } from 'react-router-dom'
 import { RouteSteps } from 'components/RouteSteps/RouteSteps'
-import { selectAccountSpecifier, selectAssetByCAIP19 } from 'state/slices/selectors'
+import { selectAccountSpecifier, selectAssetByAssetId } from 'state/slices/selectors'
 import { useAppSelector } from 'state/store'
 
 import { StakeFormManager } from './forms/StakeFormManager'
@@ -73,7 +73,7 @@ const StakingModalContent = ({ assetId, validatorAddress }: StakingModalProps) =
 
   const initialRef = useRef<HTMLInputElement>(null)
 
-  const asset = useAppSelector(state => selectAssetByCAIP19(state, assetId))
+  const asset = useAppSelector(state => selectAssetByAssetId(state, assetId))
   const accountSpecifiersForChainId = useAppSelector(state =>
     selectAccountSpecifier(state, asset?.caip2),
   )

--- a/src/plugins/cosmos/components/modals/Staking/views/ClaimBroadcast.tsx
+++ b/src/plugins/cosmos/components/modals/Staking/views/ClaimBroadcast.tsx
@@ -16,7 +16,7 @@ import { MiddleEllipsis } from 'components/MiddleEllipsis/MiddleEllipsis'
 import { SlideTransition } from 'components/SlideTransition'
 import { Text } from 'components/Text'
 import { bnOrZero } from 'lib/bignumber/bignumber'
-import { selectAssetByCAIP19, selectMarketDataById } from 'state/slices/selectors'
+import { selectAssetByAssetId, selectMarketDataById } from 'state/slices/selectors'
 import { useAppSelector } from 'state/store'
 
 type ClaimBroadcastProps = {
@@ -43,7 +43,7 @@ export const ClaimBroadcast = ({ assetId, validatorAddress, onClose }: ClaimBroa
   const { control } = methods
   const { txFee, fiatFee, gasLimit, cryptoAmount } = useWatch({ control })
 
-  const asset = useAppSelector(state => selectAssetByCAIP19(state, assetId))
+  const asset = useAppSelector(state => selectAssetByAssetId(state, assetId))
   const marketData = useAppSelector(state => selectMarketDataById(state, assetId))
 
   // TODO(gomes): This currently fires the broadcat once on component mount. Move this to something like useFormSend

--- a/src/plugins/cosmos/components/modals/Staking/views/ClaimBroadcast.tsx
+++ b/src/plugins/cosmos/components/modals/Staking/views/ClaimBroadcast.tsx
@@ -16,7 +16,7 @@ import { MiddleEllipsis } from 'components/MiddleEllipsis/MiddleEllipsis'
 import { SlideTransition } from 'components/SlideTransition'
 import { Text } from 'components/Text'
 import { bnOrZero } from 'lib/bignumber/bignumber'
-import { selectAssetByAssetId, selectMarketDataById } from 'state/slices/selectors'
+import { selectAssetById, selectMarketDataById } from 'state/slices/selectors'
 import { useAppSelector } from 'state/store'
 
 type ClaimBroadcastProps = {
@@ -43,7 +43,7 @@ export const ClaimBroadcast = ({ assetId, validatorAddress, onClose }: ClaimBroa
   const { control } = methods
   const { txFee, fiatFee, gasLimit, cryptoAmount } = useWatch({ control })
 
-  const asset = useAppSelector(state => selectAssetByAssetId(state, assetId))
+  const asset = useAppSelector(state => selectAssetById(state, assetId))
   const marketData = useAppSelector(state => selectMarketDataById(state, assetId))
 
   // TODO(gomes): This currently fires the broadcat once on component mount. Move this to something like useFormSend

--- a/src/plugins/cosmos/components/modals/Staking/views/ClaimConfirm.tsx
+++ b/src/plugins/cosmos/components/modals/Staking/views/ClaimConfirm.tsx
@@ -30,7 +30,7 @@ import { useChainAdapters } from 'context/PluginProvider/PluginProvider'
 import { useModal } from 'hooks/useModal/useModal'
 import { useWallet } from 'hooks/useWallet/useWallet'
 import {
-  selectAssetByCAIP19,
+  selectAssetByAssetId,
   selectMarketDataById,
   selectPortfolioCryptoBalanceByAssetId,
   selectRewardsAmountByAssetId,
@@ -54,7 +54,7 @@ export const ClaimConfirm = ({
   const activeFee = useWatch<ConfirmFormInput, ConfirmFormFields.FeeType>({
     name: ConfirmFormFields.FeeType,
   })
-  const asset = useAppSelector(state => selectAssetByCAIP19(state, assetId))
+  const asset = useAppSelector(state => selectAssetByAssetId(state, assetId))
   const balance = useAppSelector(state => selectPortfolioCryptoBalanceByAssetId(state, assetId))
   const cryptoBalanceHuman = bnOrZero(balance).div(`1e+${asset?.precision}`)
 

--- a/src/plugins/cosmos/components/modals/Staking/views/ClaimConfirm.tsx
+++ b/src/plugins/cosmos/components/modals/Staking/views/ClaimConfirm.tsx
@@ -30,7 +30,7 @@ import { useChainAdapters } from 'context/PluginProvider/PluginProvider'
 import { useModal } from 'hooks/useModal/useModal'
 import { useWallet } from 'hooks/useWallet/useWallet'
 import {
-  selectAssetByAssetId,
+  selectAssetById,
   selectMarketDataById,
   selectPortfolioCryptoBalanceByAssetId,
   selectRewardsAmountByAssetId,
@@ -54,7 +54,7 @@ export const ClaimConfirm = ({
   const activeFee = useWatch<ConfirmFormInput, ConfirmFormFields.FeeType>({
     name: ConfirmFormFields.FeeType,
   })
-  const asset = useAppSelector(state => selectAssetByAssetId(state, assetId))
+  const asset = useAppSelector(state => selectAssetById(state, assetId))
   const balance = useAppSelector(state => selectPortfolioCryptoBalanceByAssetId(state, assetId))
   const cryptoBalanceHuman = bnOrZero(balance).div(`1e+${asset?.precision}`)
 

--- a/src/plugins/cosmos/components/modals/Staking/views/Overview.tsx
+++ b/src/plugins/cosmos/components/modals/Staking/views/Overview.tsx
@@ -9,7 +9,7 @@ import { UnbondingRow } from 'plugins/cosmos/components/UnbondingRow/UnbondingRo
 import { useEffect } from 'react'
 import { Text } from 'components/Text'
 import { bnOrZero } from 'lib/bignumber/bignumber'
-import { selectAssetByCAIP19, selectMarketDataById } from 'state/slices/selectors'
+import { selectAssetByAssetId, selectMarketDataById } from 'state/slices/selectors'
 import {
   selectAllUnbondingsEntriesByAssetIdAndValidator,
   selectRewardsAmountByAssetId,
@@ -32,7 +32,7 @@ export const Overview: React.FC<StakedProps> = ({
   accountSpecifier,
 }) => {
   const isLoaded = useAppSelector(selectStakingDataIsLoaded)
-  const asset = useAppSelector(state => selectAssetByCAIP19(state, assetId))
+  const asset = useAppSelector(state => selectAssetByAssetId(state, assetId))
   const marketData = useAppSelector(state => selectMarketDataById(state, assetId))
 
   const dispatch = useAppDispatch()

--- a/src/plugins/cosmos/components/modals/Staking/views/Overview.tsx
+++ b/src/plugins/cosmos/components/modals/Staking/views/Overview.tsx
@@ -9,7 +9,7 @@ import { UnbondingRow } from 'plugins/cosmos/components/UnbondingRow/UnbondingRo
 import { useEffect } from 'react'
 import { Text } from 'components/Text'
 import { bnOrZero } from 'lib/bignumber/bignumber'
-import { selectAssetByAssetId, selectMarketDataById } from 'state/slices/selectors'
+import { selectAssetById, selectMarketDataById } from 'state/slices/selectors'
 import {
   selectAllUnbondingsEntriesByAssetIdAndValidator,
   selectRewardsAmountByAssetId,
@@ -32,7 +32,7 @@ export const Overview: React.FC<StakedProps> = ({
   accountSpecifier,
 }) => {
   const isLoaded = useAppSelector(selectStakingDataIsLoaded)
-  const asset = useAppSelector(state => selectAssetByAssetId(state, assetId))
+  const asset = useAppSelector(state => selectAssetById(state, assetId))
   const marketData = useAppSelector(state => selectMarketDataById(state, assetId))
 
   const dispatch = useAppDispatch()

--- a/src/plugins/cosmos/components/modals/Staking/views/Stake.tsx
+++ b/src/plugins/cosmos/components/modals/Staking/views/Stake.tsx
@@ -26,7 +26,7 @@ import { Text } from 'components/Text'
 import { useModal } from 'hooks/useModal/useModal'
 import { BigNumber, bnOrZero } from 'lib/bignumber/bignumber'
 import {
-  selectAssetByAssetId,
+  selectAssetById,
   selectMarketDataById,
   selectPortfolioCryptoBalanceByAssetId,
 } from 'state/slices/selectors'
@@ -53,7 +53,7 @@ export const Stake = ({ assetId, apr, validatorAddress }: StakeProps) => {
     setValue,
   } = useFormContext<StakingValues>()
 
-  const asset = useAppSelector(state => selectAssetByAssetId(state, assetId))
+  const asset = useAppSelector(state => selectAssetById(state, assetId))
 
   const marketData = useAppSelector(state => selectMarketDataById(state, assetId))
   const balance = useAppSelector(state => selectPortfolioCryptoBalanceByAssetId(state, assetId))

--- a/src/plugins/cosmos/components/modals/Staking/views/Stake.tsx
+++ b/src/plugins/cosmos/components/modals/Staking/views/Stake.tsx
@@ -26,7 +26,7 @@ import { Text } from 'components/Text'
 import { useModal } from 'hooks/useModal/useModal'
 import { BigNumber, bnOrZero } from 'lib/bignumber/bignumber'
 import {
-  selectAssetByCAIP19,
+  selectAssetByAssetId,
   selectMarketDataById,
   selectPortfolioCryptoBalanceByAssetId,
 } from 'state/slices/selectors'
@@ -53,7 +53,7 @@ export const Stake = ({ assetId, apr, validatorAddress }: StakeProps) => {
     setValue,
   } = useFormContext<StakingValues>()
 
-  const asset = useAppSelector(state => selectAssetByCAIP19(state, assetId))
+  const asset = useAppSelector(state => selectAssetByAssetId(state, assetId))
 
   const marketData = useAppSelector(state => selectMarketDataById(state, assetId))
   const balance = useAppSelector(state => selectPortfolioCryptoBalanceByAssetId(state, assetId))

--- a/src/plugins/cosmos/components/modals/Staking/views/StakeBroadcast.tsx
+++ b/src/plugins/cosmos/components/modals/Staking/views/StakeBroadcast.tsx
@@ -13,7 +13,7 @@ import { SlideTransition } from 'components/SlideTransition'
 import { Text } from 'components/Text'
 import { bnOrZero } from 'lib/bignumber/bignumber'
 import {
-  selectAssetByCAIP19,
+  selectAssetByAssetId,
   selectMarketDataById,
   selectSingleValidator,
 } from 'state/slices/selectors'
@@ -50,7 +50,7 @@ export const StakeBroadcast = ({
   const [broadcasted, setBroadcasted] = useState(false)
   const [txId, setTxId] = useState<string | null>(null)
 
-  const asset = useAppSelector(state => selectAssetByCAIP19(state, assetId))
+  const asset = useAppSelector(state => selectAssetByAssetId(state, assetId))
 
   const { handleStakingAction } = useStakingAction()
   const marketData = useAppSelector(state => selectMarketDataById(state, assetId))

--- a/src/plugins/cosmos/components/modals/Staking/views/StakeBroadcast.tsx
+++ b/src/plugins/cosmos/components/modals/Staking/views/StakeBroadcast.tsx
@@ -13,7 +13,7 @@ import { SlideTransition } from 'components/SlideTransition'
 import { Text } from 'components/Text'
 import { bnOrZero } from 'lib/bignumber/bignumber'
 import {
-  selectAssetByAssetId,
+  selectAssetById,
   selectMarketDataById,
   selectSingleValidator,
 } from 'state/slices/selectors'
@@ -50,7 +50,7 @@ export const StakeBroadcast = ({
   const [broadcasted, setBroadcasted] = useState(false)
   const [txId, setTxId] = useState<string | null>(null)
 
-  const asset = useAppSelector(state => selectAssetByAssetId(state, assetId))
+  const asset = useAppSelector(state => selectAssetById(state, assetId))
 
   const { handleStakingAction } = useStakingAction()
   const marketData = useAppSelector(state => selectMarketDataById(state, assetId))

--- a/src/plugins/cosmos/components/modals/Staking/views/StakeConfirm.tsx
+++ b/src/plugins/cosmos/components/modals/Staking/views/StakeConfirm.tsx
@@ -31,7 +31,7 @@ import { useChainAdapters } from 'context/PluginProvider/PluginProvider'
 import { useWallet } from 'hooks/useWallet/useWallet'
 import { bnOrZero } from 'lib/bignumber/bignumber'
 import {
-  selectAssetByCAIP19,
+  selectAssetByAssetId,
   selectMarketDataById,
   selectPortfolioCryptoBalanceByAssetId,
   selectSingleValidator,
@@ -67,7 +67,7 @@ export const StakeConfirm = ({
   const activeFee = useWatch<ConfirmFormInput, ConfirmFormFields.FeeType>({
     name: ConfirmFormFields.FeeType,
   })
-  const asset = useAppSelector(state => selectAssetByCAIP19(state, assetId))
+  const asset = useAppSelector(state => selectAssetByAssetId(state, assetId))
   const marketData = useAppSelector(state => selectMarketDataById(state, assetId))
   const validatorInfo = useAppSelector(state =>
     selectSingleValidator(state, accountSpecifier, validatorAddress),

--- a/src/plugins/cosmos/components/modals/Staking/views/StakeConfirm.tsx
+++ b/src/plugins/cosmos/components/modals/Staking/views/StakeConfirm.tsx
@@ -31,7 +31,7 @@ import { useChainAdapters } from 'context/PluginProvider/PluginProvider'
 import { useWallet } from 'hooks/useWallet/useWallet'
 import { bnOrZero } from 'lib/bignumber/bignumber'
 import {
-  selectAssetByAssetId,
+  selectAssetById,
   selectMarketDataById,
   selectPortfolioCryptoBalanceByAssetId,
   selectSingleValidator,
@@ -67,7 +67,7 @@ export const StakeConfirm = ({
   const activeFee = useWatch<ConfirmFormInput, ConfirmFormFields.FeeType>({
     name: ConfirmFormFields.FeeType,
   })
-  const asset = useAppSelector(state => selectAssetByAssetId(state, assetId))
+  const asset = useAppSelector(state => selectAssetById(state, assetId))
   const marketData = useAppSelector(state => selectMarketDataById(state, assetId))
   const validatorInfo = useAppSelector(state =>
     selectSingleValidator(state, accountSpecifier, validatorAddress),

--- a/src/plugins/cosmos/components/modals/Staking/views/Unstake.tsx
+++ b/src/plugins/cosmos/components/modals/Staking/views/Unstake.tsx
@@ -23,7 +23,7 @@ import { Text } from 'components/Text'
 import { useModal } from 'hooks/useModal/useModal'
 import { BigNumber, bnOrZero } from 'lib/bignumber/bignumber'
 import {
-  selectAssetByAssetId,
+  selectAssetById,
   selectDelegationCryptoAmountByAssetIdAndValidator,
   selectMarketDataById,
 } from 'state/slices/selectors'
@@ -56,7 +56,7 @@ export const Unstake = ({ assetId, apr, accountSpecifier, validatorAddress }: Un
 
   const values = useWatch({ control })
 
-  const asset = useAppSelector(state => selectAssetByAssetId(state, assetId))
+  const asset = useAppSelector(state => selectAssetById(state, assetId))
   const marketData = useAppSelector(state => selectMarketDataById(state, assetId))
   const cryptoStakeBalance = useAppSelector(state =>
     selectDelegationCryptoAmountByAssetIdAndValidator(

--- a/src/plugins/cosmos/components/modals/Staking/views/Unstake.tsx
+++ b/src/plugins/cosmos/components/modals/Staking/views/Unstake.tsx
@@ -23,7 +23,7 @@ import { Text } from 'components/Text'
 import { useModal } from 'hooks/useModal/useModal'
 import { BigNumber, bnOrZero } from 'lib/bignumber/bignumber'
 import {
-  selectAssetByCAIP19,
+  selectAssetByAssetId,
   selectDelegationCryptoAmountByAssetIdAndValidator,
   selectMarketDataById,
 } from 'state/slices/selectors'
@@ -56,7 +56,7 @@ export const Unstake = ({ assetId, apr, accountSpecifier, validatorAddress }: Un
 
   const values = useWatch({ control })
 
-  const asset = useAppSelector(state => selectAssetByCAIP19(state, assetId))
+  const asset = useAppSelector(state => selectAssetByAssetId(state, assetId))
   const marketData = useAppSelector(state => selectMarketDataById(state, assetId))
   const cryptoStakeBalance = useAppSelector(state =>
     selectDelegationCryptoAmountByAssetIdAndValidator(

--- a/src/plugins/cosmos/components/modals/Staking/views/UnstakeBroadcast.tsx
+++ b/src/plugins/cosmos/components/modals/Staking/views/UnstakeBroadcast.tsx
@@ -12,7 +12,7 @@ import { MiddleEllipsis } from 'components/MiddleEllipsis/MiddleEllipsis'
 import { SlideTransition } from 'components/SlideTransition'
 import { Text } from 'components/Text'
 import {
-  selectAssetByCAIP19,
+  selectAssetByAssetId,
   selectMarketDataById,
   selectSingleValidator,
 } from 'state/slices/selectors'
@@ -37,7 +37,7 @@ export const UnstakeBroadcast = ({
   const [broadcasted, setBroadcasted] = useState(false)
   const [txId, setTxId] = useState<string | null>(null)
 
-  const asset = useAppSelector(state => selectAssetByCAIP19(state, assetId))
+  const asset = useAppSelector(state => selectAssetByAssetId(state, assetId))
   const marketData = useAppSelector(state => selectMarketDataById(state, assetId))
   const validatorInfo = useAppSelector(state =>
     selectSingleValidator(state, accountSpecifier, validatorAddress),

--- a/src/plugins/cosmos/components/modals/Staking/views/UnstakeBroadcast.tsx
+++ b/src/plugins/cosmos/components/modals/Staking/views/UnstakeBroadcast.tsx
@@ -12,7 +12,7 @@ import { MiddleEllipsis } from 'components/MiddleEllipsis/MiddleEllipsis'
 import { SlideTransition } from 'components/SlideTransition'
 import { Text } from 'components/Text'
 import {
-  selectAssetByAssetId,
+  selectAssetById,
   selectMarketDataById,
   selectSingleValidator,
 } from 'state/slices/selectors'
@@ -37,7 +37,7 @@ export const UnstakeBroadcast = ({
   const [broadcasted, setBroadcasted] = useState(false)
   const [txId, setTxId] = useState<string | null>(null)
 
-  const asset = useAppSelector(state => selectAssetByAssetId(state, assetId))
+  const asset = useAppSelector(state => selectAssetById(state, assetId))
   const marketData = useAppSelector(state => selectMarketDataById(state, assetId))
   const validatorInfo = useAppSelector(state =>
     selectSingleValidator(state, accountSpecifier, validatorAddress),

--- a/src/plugins/cosmos/components/modals/Staking/views/UnstakeConfirm.tsx
+++ b/src/plugins/cosmos/components/modals/Staking/views/UnstakeConfirm.tsx
@@ -31,7 +31,7 @@ import { Text } from 'components/Text'
 import { useChainAdapters } from 'context/PluginProvider/PluginProvider'
 import { useWallet } from 'hooks/useWallet/useWallet'
 import {
-  selectAssetByCAIP19,
+  selectAssetByAssetId,
   selectMarketDataById,
   selectPortfolioCryptoBalanceByAssetId,
   selectSingleValidator,
@@ -69,7 +69,7 @@ export const UnstakeConfirm = ({
     state: { wallet },
   } = useWallet()
 
-  const asset = useAppSelector(state => selectAssetByCAIP19(state, assetId))
+  const asset = useAppSelector(state => selectAssetByAssetId(state, assetId))
   const marketData = useAppSelector(state => selectMarketDataById(state, assetId))
   const chainAdapterManager = useChainAdapters()
   const adapter = chainAdapterManager.byChain(asset.chain) as CosmosChainAdapter

--- a/src/plugins/cosmos/components/modals/Staking/views/UnstakeConfirm.tsx
+++ b/src/plugins/cosmos/components/modals/Staking/views/UnstakeConfirm.tsx
@@ -31,7 +31,7 @@ import { Text } from 'components/Text'
 import { useChainAdapters } from 'context/PluginProvider/PluginProvider'
 import { useWallet } from 'hooks/useWallet/useWallet'
 import {
-  selectAssetByAssetId,
+  selectAssetById,
   selectMarketDataById,
   selectPortfolioCryptoBalanceByAssetId,
   selectSingleValidator,
@@ -69,7 +69,7 @@ export const UnstakeConfirm = ({
     state: { wallet },
   } = useWallet()
 
-  const asset = useAppSelector(state => selectAssetByAssetId(state, assetId))
+  const asset = useAppSelector(state => selectAssetById(state, assetId))
   const marketData = useAppSelector(state => selectMarketDataById(state, assetId))
   const chainAdapterManager = useChainAdapters()
   const adapter = chainAdapterManager.byChain(asset.chain) as CosmosChainAdapter

--- a/src/state/slices/assetsSlice/selectors.ts
+++ b/src/state/slices/assetsSlice/selectors.ts
@@ -15,13 +15,13 @@ import { ReduxState } from 'state/reducer'
 import { createDeepEqualOutputSelector } from 'state/selector-utils'
 import { selectMarketDataIds } from 'state/slices/marketDataSlice/selectors'
 
-export const selectAssetByAssetId = createCachedSelector(
+export const selectAssetById = createCachedSelector(
   (state: ReduxState) => state.assets.byId,
   (_state: ReduxState, assetId: AssetId) => assetId,
   (byId, assetId) => byId[assetId] || undefined,
 )((_state: ReduxState, assetId: AssetId | undefined): AssetId => assetId ?? 'undefined')
 
-export const selectAssetNameById = createSelector(selectAssetByAssetId, asset =>
+export const selectAssetNameById = createSelector(selectAssetById, asset =>
   asset ? asset.name : undefined,
 )
 

--- a/src/state/slices/assetsSlice/selectors.ts
+++ b/src/state/slices/assetsSlice/selectors.ts
@@ -15,13 +15,13 @@ import { ReduxState } from 'state/reducer'
 import { createDeepEqualOutputSelector } from 'state/selector-utils'
 import { selectMarketDataIds } from 'state/slices/marketDataSlice/selectors'
 
-export const selectAssetByCAIP19 = createCachedSelector(
+export const selectAssetByAssetId = createCachedSelector(
   (state: ReduxState) => state.assets.byId,
   (_state: ReduxState, CAIP19: AssetId) => CAIP19,
   (byId, CAIP19) => byId[CAIP19] || undefined,
 )((_state: ReduxState, assetId: AssetId | undefined): AssetId => assetId ?? 'undefined')
 
-export const selectAssetNameById = createSelector(selectAssetByCAIP19, asset =>
+export const selectAssetNameById = createSelector(selectAssetByAssetId, asset =>
   asset ? asset.name : undefined,
 )
 

--- a/src/state/slices/assetsSlice/selectors.ts
+++ b/src/state/slices/assetsSlice/selectors.ts
@@ -17,8 +17,8 @@ import { selectMarketDataIds } from 'state/slices/marketDataSlice/selectors'
 
 export const selectAssetByAssetId = createCachedSelector(
   (state: ReduxState) => state.assets.byId,
-  (_state: ReduxState, CAIP19: AssetId) => CAIP19,
-  (byId, CAIP19) => byId[CAIP19] || undefined,
+  (_state: ReduxState, assetId: AssetId) => assetId,
+  (byId, assetId) => byId[assetId] || undefined,
 )((_state: ReduxState, assetId: AssetId | undefined): AssetId => assetId ?? 'undefined')
 
 export const selectAssetNameById = createSelector(selectAssetByAssetId, asset =>


### PR DESCRIPTION
## Description

Rename all instances of `selectAssetByCAIP19` to `selectAssetById`.

## Notice

<!-- Before submitting a pull request, please make sure you have answered the following: -->

- [x] Have you followed the guidelines in our [Contributing]('https://github.com/shapeshift/web/CONTRIBUTING.md) guide?
- [x] Have you checked to ensure there aren't other open [Pull Requests](https://github.com/shapeshift/web/pulls) for the same update/change?

## Pull Request Type

- [ ] :bug: Bug fix (Non-breaking Change: Fixes an issue)
- [x] :hammer_and_wrench: Chore (Non-breaking Change: Doc updates, pkg upgrades, typos, etc..)
- [ ] :nail_care: New Feature (Breaking/Non-breaking Change)

## Issue (if applicable)

Contributes to https://github.com/shapeshift/web/issues/1629

## Risk

Minimal - rename only.

## Testing

Everything should work is it did before.

## Screenshots (if applicable)

N/A