### PR TITLE
chore: make sha256sums.sh follow symbolic links

### DIFF
--- a/scripts/sha256sums.sh
+++ b/scripts/sha256sums.sh
@@ -2,5 +2,5 @@
 
 rm -f ./build/SHA256SUMS
 TEMP=$(mktemp)
-find ./build -type f | xargs shasum -a 256 | sed -r 's/^([0-9a-f]{64}\s+)\.\/build\//\1/' | LC_ALL=C sort -k 2 | tee "$TEMP"
+find -L ./build -type f | xargs shasum -a 256 | sed -r 's/^([0-9a-f]{64}\s+)\.\/build\//\1/' | LC_ALL=C sort -k 2 | tee "$TEMP"
 mv "$TEMP" ./build/SHA256SUMS


### PR DESCRIPTION
## Description

Alpha's build process uses a symbolic link for the `/build` folder, which find does not traverse by default. This change will enable [web.patch](https://github.com/shapeshift/alpha/blob/main/web.patch) in alpha to be a little smaller.

## Notice

<!-- Before submitting a pull request, please make sure you have answered the following: -->

- [x] Have you followed the guidelines in our [Contributing]('https://github.com/shapeshift/web/CONTRIBUTING.md) guide?
- [x] Have you checked to ensure there aren't other open [Pull Requests](https://github.com/shapeshift/web/pulls) for the same update/change?

## Pull Request Type

- [ ] :bug: Bug fix (Non-breaking Change: Fixes an issue)
- [x] :hammer_and_wrench: Chore (Non-breaking Change: Doc updates, pkg upgrades, typos, etc..)
- [ ] :nail_care: New Feature (Breaking/Non-breaking Change)

## Risk

*De minimis.*

## Testing

Need to verify `find -L` works on mac.
