### PR TITLE
fix: keepkey recovery flow cancel and close events

### DIFF
--- a/src/context/WalletProvider/KeepKey/components/RecoverySentence.tsx
+++ b/src/context/WalletProvider/KeepKey/components/RecoverySentence.tsx
@@ -2,8 +2,10 @@ import { Alert, AlertIcon, Flex, useColorModeValue } from '@chakra-ui/react'
 import { ModalBody, ModalHeader } from '@chakra-ui/react'
 import { AwaitKeepKey } from 'components/Layout/Header/NavBar/KeepKey/AwaitKeepKey'
 import { Text } from 'components/Text'
+import { useKeepKeyCancel } from 'context/WalletProvider/KeepKey/hooks/useKeepKeyCancel'
 
 export const KeepKeyRecoverySentence = () => {
+  const handleCancel = useKeepKeyCancel()
   const yellowShade = useColorModeValue('yellow.500', 'yellow.200')
 
   return (
@@ -22,6 +24,7 @@ export const KeepKeyRecoverySentence = () => {
         </Alert>
       </ModalBody>
       <AwaitKeepKey
+        onCancel={handleCancel}
         translation={'modals.keepKey.recoverySentence.awaitingButtonPress'}
         pl={6}
         pr={6}

--- a/src/context/WalletProvider/KeepKey/components/RecoverySentenceEntry.tsx
+++ b/src/context/WalletProvider/KeepKey/components/RecoverySentenceEntry.tsx
@@ -18,6 +18,7 @@ import { useHistory } from 'react-router-dom'
 import { AwaitKeepKey } from 'components/Layout/Header/NavBar/KeepKey/AwaitKeepKey'
 import { RawText, Text } from 'components/Text'
 import { inputValuesReducer, isLetter, isValidInput } from 'context/WalletProvider/KeepKey/helpers'
+import { useKeepKeyCancel } from 'context/WalletProvider/KeepKey/hooks/useKeepKeyCancel'
 import { KeepKeyRoutes } from 'context/WalletProvider/routes'
 import { useWallet } from 'hooks/useWallet/useWallet'
 
@@ -37,6 +38,7 @@ export const KeepKeyRecoverySentenceEntry = () => {
     },
   } = useWallet()
   const history = useHistory()
+  const handleCancel = useKeepKeyCancel()
   const [wordEntropy, setWordEntropy] = useState<12 | 18 | 24>(12)
   const [characterInputValues, setCharacterInputValues] = useState(
     Object.seal(new Array<string | undefined>(maxInputLength).fill(undefined)),
@@ -186,8 +188,6 @@ export const KeepKeyRecoverySentenceEntry = () => {
     }
   }
 
-  const onCancel = () => history.goBack()
-
   const pinInputFieldProps: PinInputFieldProps = useMemo(
     () => ({
       background: inputBackgroundColor,
@@ -207,7 +207,7 @@ export const KeepKeyRecoverySentenceEntry = () => {
         <Text color='gray.500' translation={'modals.keepKey.recoverySentenceEntry.body'} mb={4} />
         <AwaitKeepKey
           translation='modals.keepKey.recoverySentenceEntry.awaitingButtonPress'
-          onCancel={onCancel}
+          onCancel={handleCancel}
         >
           <HStack justifyContent='space-between'>
             {wordEntropyCircle}

--- a/src/context/WalletProvider/KeepKey/hooks/useKeepKeyCancel.ts
+++ b/src/context/WalletProvider/KeepKey/hooks/useKeepKeyCancel.ts
@@ -1,0 +1,36 @@
+import { useToast } from '@chakra-ui/react'
+import { useCallback } from 'react'
+import { useTranslate } from 'react-polyglot'
+import { useHistory } from 'react-router-dom'
+import { WalletActions } from 'context/WalletProvider/actions'
+import { useWallet } from 'hooks/useWallet/useWallet'
+
+export const useKeepKeyCancel = () => {
+  const history = useHistory()
+  const toast = useToast()
+  const translate = useTranslate()
+  const {
+    state: { wallet },
+    dispatch,
+  } = useWallet()
+
+  const cancelWalletRequests = useCallback(async () => {
+    await wallet?.cancel().catch(e => {
+      console.error(e)
+      toast({
+        title: translate('common.error'),
+        description: e?.message ?? translate('common.somethingWentWrong'),
+        status: 'error',
+        isClosable: true,
+      })
+    })
+  }, [toast, translate, wallet])
+
+  const handleCancel = async () => {
+    history.replace('/')
+    dispatch({ type: WalletActions.SET_INITIAL_ROUTE, payload: '' })
+    await cancelWalletRequests()
+  }
+
+  return handleCancel
+}

--- a/src/context/WalletProvider/KeepKey/hooks/useKeepKeyCancel.ts
+++ b/src/context/WalletProvider/KeepKey/hooks/useKeepKeyCancel.ts
@@ -14,7 +14,7 @@ export const useKeepKeyCancel = () => {
     dispatch,
   } = useWallet()
 
-  const cancelWalletRequests = useCallback(async () => {
+  const cancelWalletRequest = useCallback(async () => {
     await wallet?.cancel().catch(e => {
       console.error(e)
       toast({
@@ -29,7 +29,7 @@ export const useKeepKeyCancel = () => {
   const handleCancel = async () => {
     history.replace('/')
     dispatch({ type: WalletActions.SET_INITIAL_ROUTE, payload: '' })
-    await cancelWalletRequests()
+    await cancelWalletRequest()
   }
 
   return handleCancel

--- a/src/context/WalletProvider/KeepKey/hooks/useKeepKeyEventHandler.ts
+++ b/src/context/WalletProvider/KeepKey/hooks/useKeepKeyEventHandler.ts
@@ -174,6 +174,11 @@ export const useKeepKeyEventHandler = (
         if (id === state.walletInfo?.deviceId) {
           dispatch({ type: WalletActions.SET_IS_CONNECTED, payload: false })
         }
+        if (modal) {
+          dispatch({ type: WalletActions.SET_WALLET_MODAL, payload: false })
+          dispatch({ type: WalletActions.SET_INITIAL_ROUTE, payload: '' })
+          dispatch({ type: WalletActions.SET_WALLET_MODAL, payload: true })
+        }
       } catch (e) {
         console.error('Device Disconnect Error:', e)
       }

--- a/src/context/WalletProvider/KeepKey/hooks/useKeepKeyEventHandler.ts
+++ b/src/context/WalletProvider/KeepKey/hooks/useKeepKeyEventHandler.ts
@@ -175,8 +175,8 @@ export const useKeepKeyEventHandler = (
           dispatch({ type: WalletActions.SET_IS_CONNECTED, payload: false })
         }
         if (modal) {
+          // Little trick to send the user back to the wallet select route
           dispatch({ type: WalletActions.SET_WALLET_MODAL, payload: false })
-          dispatch({ type: WalletActions.SET_INITIAL_ROUTE, payload: '' })
           dispatch({ type: WalletActions.SET_WALLET_MODAL, payload: true })
         }
       } catch (e) {


### PR DESCRIPTION
## Description
- I added a new hook: `useKeepKeyCancel` used to cancel the wallet + get back to the wallet select route
- It's used by the `AwaitKeepKey` component in both `RecoverySentence` and `RecoverySentenceEntry`
- In case the user unplug the keepkey, it opens and close the modal in order to be redirected to the `SelectModal` view

<!-- Please describe your changes -->

## Notice

<!-- Before submitting a pull request, please make sure you have answered the following: -->

- [x] Have you followed the guidelines in our [Contributing]('https://github.com/shapeshift/web/CONTRIBUTING.md) guide?
- [x] Have you checked to ensure there aren't other open [Pull Requests](https://github.com/shapeshift/web/pulls) for the same update/change?

## Pull Request Type

- [x] :bug: Bug fix (Non-breaking Change: Fixes an issue)
- [ ] :hammer_and_wrench: Chore (Non-breaking Change: Doc updates, pkg upgrades, typos, etc..)
- [ ] :nail_care: New Feature (Breaking/Non-breaking Change)

## Issue (if applicable)
closes #1614
partially addresses #1610
<!-----------------------------------------------------------------------------
If applicable, please link to the github issue and put `closes #XXXX` in your comment to auto-close the issue that your PR fixes.
------------------------------------------------------------------------------>

## Risk
KeepKey flow could be buggy
<!-----------------------------------------------------------------------------
Outline the scope of your changes and the risk associated with them. You must use your discretion as an engineer to determine the potential impact of your changes.

E.g. an upgrade to `hdwallet` or core state management would be considered higher risk, and might require a full regression test. UI or isolated view changes, or something behind a feature flag may have near zero risk. Small bug fixes might require testing isolated to the specific fix.
------------------------------------------------------------------------------>

## Testing
- Wipe your keepkey
- Try to recover it, click on cancel when you can, you should be redirected to the SelectModal

- Try to initialize it, click on cancel it's waiting for a keepkey button press, you should be redirected to the SelectModal view

- Try to go anywhere in the workflow, unplug the keepkey from your computer, you should be redirected to the SelectModal view


<!-----------------------------------------------------------------------------
If your testing steps are technical, outline steps for an engineer to verify.

If your testing steps are functional, please provide a full guide with any features requiring special attention for operations to test your branch in the preview environment.
------------------------------------------------------------------------------>

## Screenshots (if applicable)
