### PR TITLE
fix(mm/portis): delay `<AccountToken />` redirect until accountSpecifiers are loaded

### DIFF
--- a/src/pages/Accounts/AccountToken/AccountToken.tsx
+++ b/src/pages/Accounts/AccountToken/AccountToken.tsx
@@ -28,6 +28,7 @@ export const AccountToken = ({ route }: AccountTokenProps) => {
   const isCurrentAccountIdOwner = Boolean(
     accountSpecifierStrings.map(toLower).includes(toLower(accountId)),
   )
+  if (!accountSpecifierStrings.length) return null
   if (!isCurrentAccountIdOwner) return <Redirect to='/accounts' />
 
   const caip19 = assetId ? decodeURIComponent(assetId) : null


### PR DESCRIPTION
## Description

This fixes reloading accounts other than native token accounts, by waiting on `accountSpecifiers` to be populated in state before checking for `isCurrentAccountIdOwner` and redirecting if false:
https://github.com/shapeshift/web/blob/89e26b31f9e46638e9578544486edc663311954e/src/pages/Accounts/AccountToken/AccountToken.tsx#L31

## Notice

<!-- Before submitting a pull request, please make sure you have answered the following: -->

- [x] Have you followed the guidelines in our [Contributing]('https://github.com/shapeshift/web/CONTRIBUTING.md) guide?
- [x] Have you checked to ensure there aren't other open [Pull Requests](https://github.com/shapeshift/web/pulls) for the same update/change?

## Pull Request Type

- [x] :bug: Bug fix (Non-breaking Change: Fixes an issue)
- [ ] :hammer_and_wrench: Chore (Non-breaking Change: Doc updates, pkg upgrades, typos, etc..)
- [ ] :nail_care: New Feature (Breaking/Non-breaking Change)

## Issue (if applicable)

#1657

## Risk

N/A: if `accountSpecifiers` was ever empty for any reason other than them not being loaded, we'd have some bigger problem here than a regression from this line

## Testing

- Go to any non-native token page, which effectively means any ERC20
- Click on that asset's account
- Reload the page: The account page should reload properly

- There should be no regressions on native tokens pages - tested with ETH, ATOM, and all Bitcoin accounts

## Screenshots (if applicable)

N/A