### PR TITLE
chore: do not strip data-test attributes

### DIFF
--- a/package.json
+++ b/package.json
@@ -190,7 +190,6 @@
     "@types/react-virtualized-auto-sizer": "^1.0.1",
     "@types/react-window": "^1.8.5",
     "@types/redux-logger": "^3.0.9",
-    "babel-plugin-react-remove-properties": "^0.3.0",
     "circular-dependency-plugin": "^5.2.2",
     "cypress": "9.6.0",
     "eslint-config-prettier": "^8.3.0",

--- a/react-app-rewired.config.js
+++ b/react-app-rewired.config.js
@@ -302,20 +302,6 @@ module.exports = {
         : {}
     )
 
-    // Remove data-test="" attributes from production builds
-    //
-    // data-test attributes are used as unique identifiers in Cypress integration and e2e tests.
-    // They aren't needed in production and
-    //   a) only bump up the bundle size, as well as
-    //   b) make it stupidly easy for potential bot authors
-    //      to automate site interactions.
-    //      (After all, that automation is what cypress tests do)
-    if (isProduction) {
-      const oneOfLoaders = config.module.rules.find(rule => Array.isArray(rule.oneOf))?.oneOf
-      const babelLoader = oneOfLoaders.find(rule => rule.loader?.includes('babel-loader'))
-      babelLoader.options.plugins.push(['react-remove-properties', { properties: ['data-test'] }])
-    }
-
     return config
   },
   devServer: configFunction => {

--- a/yarn.lock
+++ b/yarn.lock
@@ -7425,11 +7425,6 @@ babel-plugin-react-docgen@^4.1.0, babel-plugin-react-docgen@^4.2.1:
     lodash "^4.17.15"
     react-docgen "^5.0.0"
 
-babel-plugin-react-remove-properties@^0.3.0:
-  version "0.3.0"
-  resolved "https://registry.yarnpkg.com/babel-plugin-react-remove-properties/-/babel-plugin-react-remove-properties-0.3.0.tgz#7b623fb3c424b6efb4edc9b1ae4cc50e7154b87f"
-  integrity sha512-vbxegtXGyVcUkCvayLzftU95vuvpYFV85pRpeMpohMHeEY46Qe0VNWfkVVcCbaZ12CXHzDFOj0esumATcW83ng==
-
 babel-plugin-syntax-jsx@^6.18.0:
   version "6.18.0"
   resolved "https://registry.yarnpkg.com/babel-plugin-syntax-jsx/-/babel-plugin-syntax-jsx-6.18.0.tgz#0af32a9a6e13ca7a3fd5069e62d7b0f58d0d8946"


### PR DESCRIPTION
## Description

When initially implementing Cypress we stripped `data-test` attributes from the production build as a small optimisation.

With Pendo on the roadmap, we need to ensure these tags are included in the build so that Pendo can work effectively.

There is a relevant discussion on this started by @mrnerdhair here: https://github.com/shapeshift/web/discussions/1477
The general consensus was that this is a thing we want to do.

Noting that @GMSteuart suggested an alternative approach here: https://github.com/shapeshift/web/discussions/1477#discussioncomment-2665320, but in the interest of expediency I'm just stripping out the code that removes the tags for now.

## Notice

- [x] Have you followed the guidelines in our [Contributing]('https://github.com/shapeshift/web/CONTRIBUTING.md) guide?
- [x] Have you checked to ensure there aren't other open [Pull Requests](https://github.com/shapeshift/web/pulls) for the same update/change?

## Pull Request Type

- [ ] :bug: Bug fix (Non-breaking Change: Fixes an issue)
- [x] :hammer_and_wrench: Chore (Non-breaking Change: Doc updates, pkg upgrades, typos, etc..)
- [ ] :nail_care: New Feature (Breaking/Non-breaking Change)

## Issue (if applicable)

This relates to https://github.com/shapeshift/web/pull/1622, which closed https://github.com/shapeshift/web/issues/1551.

## Risk

Minimal.

## Testing

The production build should now have `data-test` attributes on relevant elements.

## Screenshots (if applicable)

N/A
