### PR TITLE
chore: remove duplicate /connect-wallet route

### DIFF
--- a/src/Routes/Routes.tsx
+++ b/src/Routes/Routes.tsx
@@ -35,9 +35,6 @@ export const Routes = () => {
       <Route path='/connect-wallet'>
         <ConnectWallet />
       </Route>
-      <Route path='/connect-wallet'>
-        <ConnectWallet />
-      </Route>
       <Route path={'/legal/terms-of-service'}>
         <Layout>
           <TermsOfService />


### PR DESCRIPTION
## Description

This removes the duplicate /connect-wallet route:

https://github.com/shapeshift/web/blob/8f975ac6f1315f96c6666c9e1721230fdfa9fbff/src/Routes/Routes.tsx#L35-L40

## Notice

<!-- Before submitting a pull request, please make sure you have answered the following: -->

- [x] Have you followed the guidelines in our [Contributing]('https://github.com/shapeshift/web/CONTRIBUTING.md) guide?
- [x] Have you checked to ensure there aren't other open [Pull Requests](https://github.com/shapeshift/web/pulls) for the same update/change?

## Pull Request Type

- [ ] :bug: Bug fix (Non-breaking Change: Fixes an issue)
- [x] :hammer_and_wrench: Chore (Non-breaking Change: Doc updates, pkg upgrades, typos, etc..)
- [ ] :nail_care: New Feature (Breaking/Non-breaking Change)

## Issue (if applicable)

N/A

## Risk

None, currently we route to the first route and the second does nothing.

## Testing

- The "Connect wallet" page shows no regressions
- Reconnecting wallet modal shows no regressions

## Screenshots (if applicable)
