### PR TITLE
fix: white-screen caused by undefined sellAsset

### DIFF
--- a/src/components/Trade/hooks/useSwapper/useSwapper.ts
+++ b/src/components/Trade/hooks/useSwapper/useSwapper.ts
@@ -104,7 +104,7 @@ export const useSwapper = () => {
       const assetIds = assets.map(asset => asset.assetId)
       const supportedBuyAssetIds = swapperManager.getSupportedBuyAssetIdsFromSellId({
         assetIds,
-        sellAssetId: sellAsset.currency.assetId,
+        sellAssetId: sellAsset?.currency?.assetId,
       })
       return filterAssetsByIds(assets, supportedBuyAssetIds)
     },


### PR DESCRIPTION
## Description

I tried to use the swapper in production today but got a white screen.

Seems we introduced a bug in https://github.com/shapeshift/web/pull/1626 with a missed optional chain.

When `defaultValue` is not defined, `useWatch` returns `undefined` on the first render because it is called before register, so our `sellAsset` needs optional chaining to access `assetId`.

## Notice

- [x] Have you followed the guidelines in our [Contributing]('https://github.com/shapeshift/web/CONTRIBUTING.md) guide?
- [x] Have you checked to ensure there aren't other open [Pull Requests](https://github.com/shapeshift/web/pulls) for the same update/change?

## Pull Request Type

- [x] :bug: Bug fix (Non-breaking Change: Fixes an issue)
- [ ] :hammer_and_wrench: Chore (Non-breaking Change: Doc updates, pkg upgrades, typos, etc..)
- [ ] :nail_care: New Feature (Breaking/Non-breaking Change)

## Issue (if applicable)

N/A

## Risk

Negligeble.

## Testing

Should be able to use swapper without white-screening.

## Screenshots (if applicable)
<img width="589" alt="Screen Shot 2022-05-04 at 4 02 31 pm" src="https://user-images.githubusercontent.com/97164662/166631454-f2bbceff-d676-4a68-bf34-cc0b9969743d.png">

<img width="730" alt="Screen Shot 2022-05-04 at 4 02 14 pm" src="https://user-images.githubusercontent.com/97164662/166631447-25ea2479-b0bd-474a-981f-4bd786ffb27a.png">

