### PR TITLE
fix: encode assetId in <ConnectWallet />

### DIFF
--- a/src/pages/ConnectWallet/ConnectWallet.tsx
+++ b/src/pages/ConnectWallet/ConnectWallet.tsx
@@ -9,6 +9,7 @@ import { Vault } from '@shapeshiftoss/hdwallet-native-vault'
 import { Dispatch, useEffect } from 'react'
 import { isFirefox } from 'react-device-detect'
 import { useTranslate } from 'react-polyglot'
+import { generatePath, matchPath } from 'react-router-dom'
 import { useHistory } from 'react-router-dom'
 import Orbs from 'assets/orbs.svg'
 import OrbsStatic from 'assets/orbs-static.png'
@@ -68,7 +69,19 @@ export const ConnectWallet = () => {
   const translate = useTranslate()
   const query = useQuery<{ returnUrl: string }>()
   useEffect(() => {
-    hasWallet && history.push(query?.returnUrl ? query.returnUrl : '/dashboard')
+    const match = matchPath<{ accountId?: string; chainId?: string; assetSubId?: string }>(
+      query.returnUrl,
+      {
+        path: '/accounts/:accountId/:chainId/:assetSubId',
+      },
+    )
+    const path = match
+      ? generatePath('/accounts/:accountId/:assetId', {
+          accountId: match?.params?.accountId ?? '',
+          assetId: `${match?.params?.chainId ?? ''}/${match?.params?.assetSubId ?? ''}`,
+        })
+      : query?.returnUrl
+    hasWallet && history.push(path ?? '/dashboard')
     // Programmatic login for Cypress tests
     // The first `!state.isConnected` filters any re-render if the wallet is already connected.
     if (isCypressTest && !state.isConnected) {

--- a/src/pages/ConnectWallet/ConnectWallet.tsx
+++ b/src/pages/ConnectWallet/ConnectWallet.tsx
@@ -69,6 +69,7 @@ export const ConnectWallet = () => {
   const translate = useTranslate()
   const query = useQuery<{ returnUrl: string }>()
   useEffect(() => {
+    // This handles reloading an asset's account page on Native/KeepKey. Without this, routing will break.
     // /:accountId/:assetId really is /:accountId/:chainId/:assetSubId e.g /accounts/eip155:1:0xmyPubKey/eip155:1/erc20:0xa0b86991c6218b36c1d19d4a2e9eb0ce3606eb48
     // The (/:chainId/:assetSubId) part is URI encoded as one entity in the regular app flow in <AssetAccountRow />, using generatePath()
     // This applies a similar logic here, that works with history.push()

--- a/src/pages/ConnectWallet/ConnectWallet.tsx
+++ b/src/pages/ConnectWallet/ConnectWallet.tsx
@@ -69,6 +69,9 @@ export const ConnectWallet = () => {
   const translate = useTranslate()
   const query = useQuery<{ returnUrl: string }>()
   useEffect(() => {
+    // /:accountId/:assetId really is /:accountId/:chainId/:assetSubId e.g /accounts/eip155:1:0xmyPubKey/eip155:1/erc20:0xa0b86991c6218b36c1d19d4a2e9eb0ce3606eb48
+    // The (/:chainId/:assetSubId) part is URI encoded as one entity in the regular app flow in <AssetAccountRow />, using generatePath()
+    // This applies a similar logic here, that works with history.push()
     const match = matchPath<{ accountId?: string; chainId?: string; assetSubId?: string }>(
       query.returnUrl,
       {


### PR DESCRIPTION
## Description

This PR fixes KeepKey/native wallet reconnect on an asset's account page by properly encoding the URI of the `assetId` part in `/:accountId/:assetId/` when reconnecting wallet and pushing the `returnUrl`:
https://github.com/shapeshift/web/blob/495260f2a7dbd6b4df2a86f7fed2cd3463e56b67/src/pages/ConnectWallet/ConnectWallet.tsx#L71

The bug that we currently have where reloading an asset page in Native/KeepKey redirects to Dashboard is caused by the fact that `/:accountId/:assetId` really is `/:accountId/:chainId/:assetSubId`, however, the `/:chainId/:assetSubId` part is URI encoded as one entity in the regular app flow when we route to `<AccountAsset />` in `<AssetAccountRow />`, using `generatePath()`:
https://github.com/shapeshift/web/blob/47da0e056eefce23c7d7f85b242c946d902d89e7/src/components/AssetAccounts/AssetAccountRow.tsx#L61-L64

This allows the app to understand this part as a single `accountId` part. However, when pushing the `returnUrl`, we don't encode the URL, which produces this discrepancy between the working routing in the regular app flow and in the reconnect flow. 

This PR solves it by extracting the `/:accountId/:chainId/:assetSubId` params, and reconstructing a path with `/:accountId/:encodedAssetId` when pushing history in `<ConnectWallet />`

## Notice

<!-- Before submitting a pull request, please make sure you have answered the following: -->

- [x] Have you followed the guidelines in our [Contributing]('https://github.com/shapeshift/web/CONTRIBUTING.md) guide?
- [x] Have you checked to ensure there aren't other open [Pull Requests](https://github.com/shapeshift/web/pulls) for the same update/change?

## Pull Request Type

- [x] :bug: Bug fix (Non-breaking Change: Fixes an issue)
- [ ] :hammer_and_wrench: Chore (Non-breaking Change: Doc updates, pkg upgrades, typos, etc..)
- [ ] :nail_care: New Feature (Breaking/Non-breaking Change)

## Issue (if applicable)

closes #1657

## Risk

In theory, this has the potential to produce regressions on every single reconnect route.
In practice, the logic here monkey patches the `/:accountId/:chainId/:assetSubId` route specifically. I tested other routes and found no regressions.

## Testing

- Connect with native/KK
- Go to any asset's account page
- Refresh the page
- The page should refresh on the same account page

## Screenshots (if applicable)
