### PR TITLE
fix: use `feeAsset.assetId` for `nativeAssetBalance`

### DIFF
--- a/src/components/Modals/Send/hooks/useSendDetails/useSendDetails.tsx
+++ b/src/components/Modals/Send/hooks/useSendDetails/useSendDetails.tsx
@@ -84,8 +84,11 @@ export const useSendDetails = (): UseSendDetailsReturnType => {
   )
 
   const nativeAssetBalance = bnOrZero(
-    useAppSelector(state => selectPortfolioCryptoBalanceByFilter(state, { assetId, accountId })),
+    useAppSelector(state =>
+      selectPortfolioCryptoBalanceByFilter(state, { assetId: feeAsset.assetId, accountId }),
+    ),
   )
+
   const chainAdapterManager = useChainAdapters()
   const {
     state: { wallet },


### PR DESCRIPTION
## Description

use `feeAsset.assetId` for `nativeAssetBalance`

## Notice

<!-- Before submitting a pull request, please make sure you have answered the following: -->

- [x] Have you followed the guidelines in our [Contributing]('https://github.com/shapeshift/web/CONTRIBUTING.md) guide?
- [x] Have you checked to ensure there aren't other open [Pull Requests](https://github.com/shapeshift/web/pulls) for the same update/change?

## Pull Request Type

- [x] :bug: Bug fix (Non-breaking Change: Fixes an issue)
- [ ] :hammer_and_wrench: Chore (Non-breaking Change: Doc updates, pkg upgrades, typos, etc..)
- [ ] :nail_care: New Feature (Breaking/Non-breaking Change)

## Issue (if applicable)

NA

## Risk

Fixes broken caip19 -> assetId change. No risk.

## Testing

Validate the ability to send all ERC20 tokens now that ETH is being used as the native asset balance to check for enough to cover for fees

## Screenshots (if applicable)

Production:
![image](https://user-images.githubusercontent.com/35275952/167174354-b3d79588-50e2-4b92-938d-387d8839ca25.png)

Local Change:
![image](https://user-images.githubusercontent.com/35275952/167174259-a9ccb1ac-7783-4bb2-b8d6-3a1e51413798.png)