### PR TITLE
fix: fox modal opening from defi and earn opportunity

### DIFF
--- a/src/components/StakingVaults/EarnOpportunities.tsx
+++ b/src/components/StakingVaults/EarnOpportunities.tsx
@@ -55,13 +55,15 @@ export const EarnOpportunities = ({ assetId: caip19 }: EarnOpportunitiesProps) =
       return
     }
 
-    const pathName =
+    // TODO remove this condition once staking modals are unified
+    // Currently vault staking modals do not have overview tab
+    const pathname =
       type === DefiType.TokenStaking
         ? `/defi/${type}/${provider}/overview`
         : `/defi/${type}/${provider}/deposit`
 
     history.push({
-      pathname: pathName,
+      pathname,
       search: qs.stringify({
         chain,
         contractAddress,

--- a/src/components/StakingVaults/EarnOpportunities.tsx
+++ b/src/components/StakingVaults/EarnOpportunities.tsx
@@ -1,6 +1,7 @@
 import { ArrowForwardIcon } from '@chakra-ui/icons'
 import { Box, Button, HStack } from '@chakra-ui/react'
 import { AssetId } from '@shapeshiftoss/caip'
+import { DefiType } from 'features/defi/contexts/DefiManagerProvider/DefiCommon'
 import {
   EarnOpportunityType,
   useNormalizeOpportunities,
@@ -54,8 +55,13 @@ export const EarnOpportunities = ({ assetId: caip19 }: EarnOpportunitiesProps) =
       return
     }
 
+    const pathName =
+      type === DefiType.TokenStaking
+        ? `/defi/${type}/${provider}/overview`
+        : `/defi/${type}/${provider}/deposit`
+
     history.push({
-      pathname: `/defi/${type}/${provider}/deposit`,
+      pathname: pathName,
       search: qs.stringify({
         chain,
         contractAddress,

--- a/src/pages/Defi/components/OpportunityCard.tsx
+++ b/src/pages/Defi/components/OpportunityCard.tsx
@@ -66,13 +66,15 @@ export const OpportunityCard = ({
         return
       }
 
-      const pathName =
+      // TODO remove this condition once staking modals are unified
+      // Currently vault staking modals do not have overview tab
+      const pathname =
         type === DefiType.TokenStaking
           ? `/defi/${type}/${provider}/overview`
           : `/defi/${type}/${provider}/withdraw`
 
       history.push({
-        pathname: pathName,
+        pathname,
         search: qs.stringify({
           chain,
           contractAddress,

--- a/src/pages/Defi/components/OpportunityCard.tsx
+++ b/src/pages/Defi/components/OpportunityCard.tsx
@@ -11,6 +11,7 @@ import {
   useColorModeValue,
 } from '@chakra-ui/react'
 import { ChainTypes } from '@shapeshiftoss/types'
+import { DefiType } from 'features/defi/contexts/DefiManagerProvider/DefiCommon'
 import { EarnOpportunityType } from 'features/defi/helpers/normalizeOpportunity'
 import qs from 'qs'
 import { useHistory, useLocation } from 'react-router'
@@ -64,8 +65,14 @@ export const OpportunityCard = ({
         })
         return
       }
+
+      const pathName =
+        type === DefiType.TokenStaking
+          ? `/defi/${type}/${provider}/overview`
+          : `/defi/${type}/${provider}/withdraw`
+
       history.push({
-        pathname: `/defi/${type}/${provider}/withdraw`,
+        pathname: pathName,
         search: qs.stringify({
           chain,
           contractAddress,


### PR DESCRIPTION
## Description

Fixes fox modal opening in "withdraw" or "deposit" tab instead of "overview".
This behaviour was present from defi page and asset page.
This raises the question of consistency with yearn vaults (modal is still opening in deposit / withdraw page depending on where you are calling it from)

## Notice

<!-- Before submitting a pull request, please make sure you have answered the following: -->

- [ ] Have you followed the guidelines in our [Contributing]('https://github.com/shapeshift/web/CONTRIBUTING.md) guide?
- [ ] Have you checked to ensure there aren't other open [Pull Requests](https://github.com/shapeshift/web/pulls) for the same update/change?

## Pull Request Type

- [X] :bug: Bug fix (Non-breaking Change: Fixes an issue)
- [ ] :hammer_and_wrench: Chore (Non-breaking Change: Doc updates, pkg upgrades, typos, etc..)
- [ ] :nail_care: New Feature (Breaking/Non-breaking Change)

## Issue (if applicable)

https://github.com/shapeshift/web/issues/1656

## Risk

There is a risk of affecting yearn vaults modal opening, I tested it and there is no regression.

## Testing

- Go to fox asset page
- Click on foxy opportunity
- Verify the modal is opened in overview tab

- Go to defi page (+ have some fox staked in foxy)
- Click on foxy opportunity
- Verify the modal is opened in overview tab

## Screenshots (if applicable)

![foxy_defi_modal](https://user-images.githubusercontent.com/5720927/167372623-dfa9efbf-c392-487e-a51c-6ad5ddc4fb40.png)

![defi_yearn](https://user-images.githubusercontent.com/5720927/167372655-e2ca8fc0-9d9f-46b3-88d1-ad5a325b81a4.png)

![earnopp_fox_modal](https://user-images.githubusercontent.com/5720927/167372673-e63cc449-f288-465d-89a7-fae32c70bada.png)

