### PR TITLE
chore: lock caip package

### DIFF
--- a/package.json
+++ b/package.json
@@ -15,7 +15,7 @@
     "@metamask/detect-provider": "^1.2.0",
     "@reduxjs/toolkit": "^1.8.0",
     "@shapeshiftoss/asset-service": "^2.4.5",
-    "@shapeshiftoss/caip": "^2.4.0",
+    "@shapeshiftoss/caip": "2.5.0",
     "@shapeshiftoss/chain-adapters": "^2.15.0",
     "@shapeshiftoss/hdwallet-core": "^1.21.1",
     "@shapeshiftoss/hdwallet-keepkey": "^1.21.1",

--- a/yarn.lock
+++ b/yarn.lock
@@ -3831,10 +3831,10 @@
     tsoa "^3.4.0"
     ws "^8.3.0"
 
-"@shapeshiftoss/caip@^2.0.0", "@shapeshiftoss/caip@^2.4.0":
-  version "2.4.0"
-  resolved "https://registry.yarnpkg.com/@shapeshiftoss/caip/-/caip-2.4.0.tgz#86ed9e82c31bea733a42f8475f4d6ad3057be859"
-  integrity sha512-mtj8DPscA+W+zn8fBQGfHMiT+yj0fp00/v46DDPuk1xu2vWrtTZ/HLEPGKwHadJP0chYjHE/r3t5P9CSQ5XKrA==
+"@shapeshiftoss/caip@2.5.0", "@shapeshiftoss/caip@^2.0.0":
+  version "2.5.0"
+  resolved "https://registry.yarnpkg.com/@shapeshiftoss/caip/-/caip-2.5.0.tgz#f82f0fb16267d1bcfa80e31fd2708c89adbfda3a"
+  integrity sha512-CWL50ctseRvPWM1AdydZZ2yAjN/46e29xUwikVTXycbyNKV445i3I50iScjNfmNOUNM5u9Mq67FGsiDhvpNZOw==
 
 "@shapeshiftoss/chain-adapters@^2.15.0":
   version "2.15.0"


### PR DESCRIPTION
## Description

The CAIP package change, https://github.com/shapeshift/lib/pull/625, was published as a patch release (`2.5.1`), but it should have been a major version bump - `develop` is partially broken due to this.

This PR locks `@shapeshiftoss/caip` to `2.5.0`, the last non-breaking version of the package.

## Notice

- [x] Have you followed the guidelines in our [Contributing]('https://github.com/shapeshift/web/CONTRIBUTING.md) guide?
- [x] Have you checked to ensure there aren't other open [Pull Requests](https://github.com/shapeshift/web/pulls) for the same update/change?

## Pull Request Type

- [x] :bug: Bug fix (Non-breaking Change: Fixes an issue)
- [ ] :hammer_and_wrench: Chore (Non-breaking Change: Doc updates, pkg upgrades, typos, etc..)
- [ ] :nail_care: New Feature (Breaking/Non-breaking Change)

## Issue (if applicable)

N/A

## Risk

Minimal.

## Testing

`yarn build` should execute with no errors.

## Screenshots (if applicable)

N/A