### PR TITLE
fix: foxy and yearn AssetChart delegation balance

### DIFF
--- a/src/components/AssetHeader/AssetChart.tsx
+++ b/src/components/AssetHeader/AssetChart.tsx
@@ -28,6 +28,7 @@ import { PriceChart } from 'components/PriceChart/PriceChart'
 import { RawText, Text } from 'components/Text'
 import { useLocaleFormatter } from 'hooks/useLocaleFormatter/useLocaleFormatter'
 import { bnOrZero } from 'lib/bignumber/bignumber'
+import { useEarnBalances } from 'pages/Defi/hooks/useEarnBalances'
 import { AccountSpecifier } from 'state/slices/accountSpecifiersSlice/accountSpecifiersSlice'
 import {
   selectTotalCryptoBalanceWithDelegations,
@@ -37,7 +38,6 @@ import {
   selectAssetById,
   selectFirstAccountSpecifierByChainId,
   selectMarketDataById,
-  selectTotalStakingDelegationCryptoByFilter,
 } from 'state/slices/selectors'
 import { useAppSelector } from 'state/store'
 
@@ -83,9 +83,11 @@ export const AssetChart = ({ accountId, assetId, isLoaded }: AssetChartProps) =>
     selectTotalCryptoBalanceWithDelegations(state, filter),
   )
 
-  const delegationBalance = useAppSelector(state =>
-    selectTotalStakingDelegationCryptoByFilter(state, filter),
-  )
+  const earnBalances = useEarnBalances()
+  const delegationBalance = useMemo(() => {
+    const assetEarnBalance = earnBalances.opportunities.find(balance => balance.assetId === assetId)
+    return assetEarnBalance?.cryptoAmount
+  }, [assetId, earnBalances.opportunities])
 
   useEffect(() => {
     if (bnOrZero(fiatBalanceWithDelegations).gt(0)) {

--- a/src/components/AssetHeader/AssetChart.tsx
+++ b/src/components/AssetHeader/AssetChart.tsx
@@ -86,7 +86,7 @@ export const AssetChart = ({ accountId, assetId, isLoaded }: AssetChartProps) =>
   const earnBalances = useEarnBalances()
   const delegationBalance = useMemo(() => {
     const assetEarnBalance = earnBalances.opportunities.find(balance => balance.assetId === assetId)
-    return assetEarnBalance?.cryptoAmount
+    return assetEarnBalance?.cryptoAmount ?? '0'
   }, [assetId, earnBalances.opportunities])
 
   useEffect(() => {


### PR DESCRIPTION
## Description

This adds the staked amount in asset charts for Yearn/Foxy staking types.

## Notice

<!-- Before submitting a pull request, please make sure you have answered the following: -->

- [x] Have you followed the guidelines in our [Contributing]('https://github.com/shapeshift/web/CONTRIBUTING.md) guide?
- [ ] Have you checked to ensure there aren't other open [Pull Requests](https://github.com/shapeshift/web/pulls) for the same update/change?

## Pull Request Type

- [x] :bug: Bug fix (Non-breaking Change: Fixes an issue)
- [ ] :hammer_and_wrench: Chore (Non-breaking Change: Doc updates, pkg upgrades, typos, etc..)
- [ ] :nail_care: New Feature (Breaking/Non-breaking Change)

## Issue (if applicable)

closes https://github.com/shapeshift/web/issues/1645
<!-----------------------------------------------------------------------------
If applicable, please link to the github issue and put `closes #XXXX` in your comment to auto-close the issue that your PR fixes.
------------------------------------------------------------------------------>

## Risk

N/A
<!-----------------------------------------------------------------------------
Outline the scope of your changes and the risk associated with them. You must use your discretion as an engineer to determine the potential impact of your changes.

E.g. an upgrade to `hdwallet` or core state management would be considered higher risk, and might require a full regression test. UI or isolated view changes, or something behind a feature flag may have near zero risk. Small bug fixes might require testing isolated to the specific fix.
------------------------------------------------------------------------------>

## Testing

- Staked amount should be displayed in asset chart for yearn/foxy active staking
- No regressions exist in case of no active amount
- No regressions exist for Cosmos staking in asset chart

## Screenshots (if applicable)

<img width="882" alt="image" src="https://user-images.githubusercontent.com/17035424/167630933-be69cfd0-00dc-421d-ad87-d60d5fad5066.png">
<img width="866" alt="image" src="https://user-images.githubusercontent.com/17035424/167631011-adf89dd4-21a4-450e-b80e-104c1eb530e8.png">
<img width="879" alt="image" src="https://user-images.githubusercontent.com/17035424/167631155-25fd982e-ff1d-47a7-9cba-2de992a9ab35.png">
