### PR TITLE
chore: use bn where appropriate

### DIFF
--- a/src/features/defi/providers/foxy/components/FoxyManager/Deposit/DepositReducer.ts
+++ b/src/features/defi/providers/foxy/components/FoxyManager/Deposit/DepositReducer.ts
@@ -1,7 +1,7 @@
 import { DefiType } from '@shapeshiftoss/investor-foxy'
 import { ChainTypes } from '@shapeshiftoss/types'
 import { getConfig } from 'config'
-import { bnOrZero } from 'lib/bignumber/bignumber'
+import { bn, bnOrZero } from 'lib/bignumber/bignumber'
 
 import { FoxyDepositActions, FoxyDepositActionType, FoxyDepositState } from './DepositCommon'
 
@@ -16,7 +16,7 @@ export const initialState: FoxyDepositState = {
     expired: false,
     version: '',
     rewardToken: '',
-    tvl: bnOrZero(0),
+    tvl: bn(0),
     apy: '',
   },
   userAddress: null,

--- a/src/pages/Defi/hooks/useCosmosStakingBalances.tsx
+++ b/src/pages/Defi/hooks/useCosmosStakingBalances.tsx
@@ -1,7 +1,7 @@
 import { AssetId } from '@shapeshiftoss/caip'
 import { chainAdapters, ChainTypes } from '@shapeshiftoss/types'
 import { useMemo } from 'react'
-import { BigNumber, bnOrZero } from 'lib/bignumber/bignumber'
+import { BigNumber, bn, bnOrZero } from 'lib/bignumber/bignumber'
 import {
   ActiveStakingOpportunity,
   selectAssetById,
@@ -85,7 +85,7 @@ export function useCosmosStakingBalances({
         (acc: BigNumber, opportunity: MergedActiveStakingOpportunity) => {
           return acc.plus(bnOrZero(opportunity.fiatAmount))
         },
-        bnOrZero(0),
+        bn(0),
       ),
     [mergedActiveStakingOpportunities],
   )

--- a/src/pages/Defi/hooks/useFoxyBalances.tsx
+++ b/src/pages/Defi/hooks/useFoxyBalances.tsx
@@ -7,7 +7,7 @@ import { useCallback, useEffect, useMemo, useState } from 'react'
 import { useSelector } from 'react-redux'
 import { useChainAdapters } from 'context/PluginProvider/PluginProvider'
 import { useWallet } from 'hooks/useWallet/useWallet'
-import { BigNumber, bnOrZero } from 'lib/bignumber/bignumber'
+import { BigNumber, bn, bnOrZero } from 'lib/bignumber/bignumber'
 import { PortfolioBalancesById } from 'state/slices/portfolioSlice/portfolioSliceCommon'
 import {
   selectAssets,
@@ -150,7 +150,7 @@ export function useFoxyBalances(): UseFoxyBalancesReturn {
       Object.values(opportunities).reduce((acc: BigNumber, opportunity: FoxyOpportunity) => {
         const amount = makeFiatAmount(opportunity)
         return acc.plus(bnOrZero(amount))
-      }, bnOrZero(0)),
+      }, bn(0)),
     [makeFiatAmount, opportunities],
   )
 

--- a/src/pages/Defi/hooks/useVaultBalances.tsx
+++ b/src/pages/Defi/hooks/useVaultBalances.tsx
@@ -9,7 +9,7 @@ import { useYearn } from 'features/defi/contexts/YearnProvider/YearnProvider'
 import { useCallback, useEffect, useMemo, useState } from 'react'
 import { useDispatch, useSelector } from 'react-redux'
 import { useWallet } from 'hooks/useWallet/useWallet'
-import { BigNumber, bnOrZero } from 'lib/bignumber/bignumber'
+import { BigNumber, bn, bnOrZero } from 'lib/bignumber/bignumber'
 import { PortfolioBalancesById } from 'state/slices/portfolioSlice/portfolioSliceCommon'
 import {
   selectAssets,
@@ -116,7 +116,7 @@ export function useVaultBalances(): UseVaultBalancesReturn {
       Object.values(vaults).reduce((acc: BigNumber, vault: EarnVault) => {
         const amount = makeVaultFiatAmount(vault)
         return acc.plus(bnOrZero(amount))
-      }, bnOrZero(0)),
+      }, bn(0)),
     [makeVaultFiatAmount, vaults],
   )
 

--- a/src/plugins/cosmos/components/modals/Send/hooks/useFormSend/useFormSend.tsx
+++ b/src/plugins/cosmos/components/modals/Send/hooks/useFormSend/useFormSend.tsx
@@ -6,7 +6,7 @@ import { useTranslate } from 'react-polyglot'
 import { useChainAdapters } from 'context/PluginProvider/PluginProvider'
 import { useModal } from 'hooks/useModal/useModal'
 import { useWallet } from 'hooks/useWallet/useWallet'
-import { bnOrZero } from 'lib/bignumber/bignumber'
+import { bn, bnOrZero } from 'lib/bignumber/bignumber'
 
 import { SendInput } from '../../Form'
 
@@ -24,7 +24,7 @@ export const useFormSend = () => {
       try {
         const adapter = chainAdapterManager.byChain(data.asset.chain)
         const value = bnOrZero(data.cryptoAmount)
-          .times(bnOrZero(10).exponentiatedBy(data.asset.precision))
+          .times(bn(10).exponentiatedBy(data.asset.precision))
           .toFixed(0)
 
         const adapterType = adapter.getType()

--- a/src/test/mocks/vaults.ts
+++ b/src/test/mocks/vaults.ts
@@ -1,4 +1,4 @@
-import { bnOrZero } from '@shapeshiftoss/chain-adapters'
+import { bn } from '@shapeshiftoss/chain-adapters'
 import { ChainTypes } from '@shapeshiftoss/types'
 import { YearnVaultWithApyAndTvl } from 'hooks/useVaultWithoutBalance/useVaultWithoutBalance'
 import { MergedEarnVault } from 'pages/Defi/hooks/useVaultBalances'
@@ -89,6 +89,6 @@ export const mockVaultWithBalance = (obj?: {
   type: '',
   vaultCaip19: '',
   tokenCaip19: '',
-  pricePerShare: bnOrZero(0),
+  pricePerShare: bn(0),
   ...obj,
 })


### PR DESCRIPTION
## Description

We use `bnOrZero` in places we shouldn't.

This PR removes this pattern to stop it from propagating.

## Notice

- [x] Have you followed the guidelines in our [Contributing]('https://github.com/shapeshift/web/CONTRIBUTING.md) guide?
- [x] Have you checked to ensure there aren't other open [Pull Requests](https://github.com/shapeshift/web/pulls) for the same update/change?

## Pull Request Type

- [ ] :bug: Bug fix (Non-breaking Change: Fixes an issue)
- [x] :hammer_and_wrench: Chore (Non-breaking Change: Doc updates, pkg upgrades, typos, etc..)
- [ ] :nail_care: New Feature (Breaking/Non-breaking Change)

## Issue (if applicable)

N/A

## Risk

Minimal.

## Testing

Everything should work as it does now.

## Screenshots (if applicable)

N/A
