### PR TITLE
chore: comment flaky Cypress test on `trade-form-preview-button` element

### DIFF
--- a/cypress/integration/dashboard_spec.ts
+++ b/cypress/integration/dashboard_spec.ts
@@ -52,9 +52,10 @@ describe('The Dashboard', () => {
     cy.getBySel('token-row-sell-max-button').click()
     cy.waitForAllGetRequests()
     // TODO@0xApotheosis - this timeout won't be necessary once external request bounty complete
-    cy.get('[data-test=trade-form-preview-button]').contains('Insufficient Funds', {
-      timeout: 60000,
-    })
+    // This test has become flaky and is adding friction to CI - temporarily disabled.
+    // cy.get('[data-test=trade-form-preview-button]').contains('Insufficient Funds', {
+    //   timeout: 60000,
+    // })
     // TODO - We are now at the approval screen - test the rest of the flow
   })
 


### PR DESCRIPTION
## Description

We have non-deterministic behavior with the `trade-form-preview-button` element in Cypress, which is adding friction to the CI process.

Commenting this test until we have a fix for it.

## Notice

<!-- Before submitting a pull request, please make sure you have answered the following: -->

- [x] Have you followed the guidelines in our [Contributing]('https://github.com/shapeshift/web/CONTRIBUTING.md) guide?
- [x] Have you checked to ensure there aren't other open [Pull Requests](https://github.com/shapeshift/web/pulls) for the same update/change?

## Pull Request Type

- [x] :bug: Bug fix (Non-breaking Change: Fixes an issue)
- [ ] :hammer_and_wrench: Chore (Non-breaking Change: Doc updates, pkg upgrades, typos, etc..)
- [ ] :nail_care: New Feature (Breaking/Non-breaking Change)

## Issue (if applicable)

N/A

## Risk

Minimal.

## Testing

CI should pass.

## Screenshots (if applicable)

N/A