### PR TITLE
fix: replace ZrxExecuteQuote with ZrxExecuteTrade

### DIFF
--- a/src/components/Trade/TradeConfirm/TradeConfirm.tsx
+++ b/src/components/Trade/TradeConfirm/TradeConfirm.tsx
@@ -62,11 +62,11 @@ export const TradeConfirm = ({ history }: RouterProps) => {
 
   // Parametrized errors cannot simply be matched with === since their param(s) might vary
   const PARAMETRIZED_ERRORS_TO_TRADE_ERRORS = {
-    'ZrxExecuteQuote - signAndBroadcastTransaction error': TRADE_ERRORS.TRANSACTION_REJECTED,
-    'ZrxExecuteQuote - Signed transaction is required': TRADE_ERRORS.SIGNING_REQUIRED,
-    'ZrxExecuteQuote - broadcastTransaction error': TRADE_ERRORS.BROADCAST_FAILED,
-    'ZrxExecuteQuote - invalid HDWallet config': TRADE_ERRORS.HDWALLET_INVALID_CONFIG,
-    'ZrxExecuteQuote - signTransaction error': TRADE_ERRORS.SIGNING_FAILED,
+    'ZrxExecuteTrade - signAndBroadcastTransaction error': TRADE_ERRORS.TRANSACTION_REJECTED,
+    'ZrxExecuteTrade - Signed transaction is required': TRADE_ERRORS.SIGNING_REQUIRED,
+    'ZrxExecuteTrade - broadcastTransaction error': TRADE_ERRORS.BROADCAST_FAILED,
+    'ZrxExecuteTrade - invalid HDWallet config': TRADE_ERRORS.HDWALLET_INVALID_CONFIG,
+    'ZrxExecuteTrade - signTransaction error': TRADE_ERRORS.SIGNING_FAILED,
   } as const
 
   const getParametrizedErrorMessageOrDefault = (
@@ -102,23 +102,23 @@ export const TradeConfirm = ({ history }: RouterProps) => {
       console.error(`TradeConfirm:onSubmit - ${err}`)
       let errorMessage
       switch ((err as ZrxError).message) {
-        case 'ZrxSwapper:ZrxExecuteQuote Cannot execute a failed quote': {
+        case 'ZrxSwapper:ZrxExecuteTrade Cannot execute a failed quote': {
           errorMessage = TRADE_ERRORS.FAILED_QUOTE_EXECUTED
           break
         }
-        case 'ZrxSwapper:ZrxExecuteQuote sellAssetAccountId is required': {
+        case 'ZrxSwapper:ZrxExecuteTrade sellAssetAccountId is required': {
           errorMessage = TRADE_ERRORS.SELL_ASSET_REQUIRED
           break
         }
-        case 'ZrxSwapper:ZrxExecuteQuote sellAmount is required': {
+        case 'ZrxSwapper:ZrxExecuteTrade sellAmount is required': {
           errorMessage = TRADE_ERRORS.SELL_AMOUNT_REQUIRED
           break
         }
-        case 'ZrxSwapper:ZrxExecuteQuote depositAddress is required': {
+        case 'ZrxSwapper:ZrxExecuteTrade depositAddress is required': {
           errorMessage = TRADE_ERRORS.DEPOSIT_ADDRESS_REQUIRED
           break
         }
-        case 'ZrxSwapper:ZrxExecuteQuote sellAssetNetwork and sellAssetSymbol are required': {
+        case 'ZrxSwapper:ZrxExecuteTrade sellAssetNetwork and sellAssetSymbol are required': {
           errorMessage = TRADE_ERRORS.SELL_ASSET_NETWORK_AND_SYMBOL_REQUIRED
           break
         }


### PR DESCRIPTION
## Description

During swapper refactor, `ZrxExecuteQuote` was renamed to `ZrxExecuteTrade` but we didn't update the error-handling to support this new naming:

https://github.com/shapeshift/web/blob/fd67442e47da2136ddf7148fa3549c330a1b89e5/src/components/Trade/TradeConfirm/TradeConfirm.tsx#L64-L70

This brings back proper error-handling. 

## Notice

<!-- Before submitting a pull request, please make sure you have answered the following: -->

- [x] Have you followed the guidelines in our [Contributing]('https://github.com/shapeshift/web/CONTRIBUTING.md) guide?
- [x] Have you checked to ensure there aren't other open [Pull Requests](https://github.com/shapeshift/web/pulls) for the same update/change?

## Pull Request Type

- [ ] :bug: Bug fix (Non-breaking Change: Fixes an issue)
- [ ] :hammer_and_wrench: Chore (Non-breaking Change: Doc updates, pkg upgrades, typos, etc..)
- [ ] :nail_care: New Feature (Breaking/Non-breaking Change)

## Issue (if applicable)

closes #1775

## Risk

N/A, this is just making it consistent with the previous implementation.

## Testing

- Make a trade all the way to the MetaMask confirmation popup
- Reject Tx
- "User rejected the transaction" toast should be displayed

## Screenshots (if applicable)

<img width="343" alt="image" src="https://user-images.githubusercontent.com/17035424/168177990-d7d59ab3-1426-4b29-a826-1cf712e4664d.png">