### PR TITLE
fix: dont show green check before trade is confirmed

### DIFF
--- a/src/components/Trade/TradeConfirm/TradeConfirm.tsx
+++ b/src/components/Trade/TradeConfirm/TradeConfirm.tsx
@@ -165,7 +165,7 @@ export const TradeConfirm = ({ history }: RouterProps) => {
               tradeFiatAmount={tradeFiatAmount}
               trade={trade}
               mt={6}
-              status={status}
+              status={txid ? status : undefined}
             />
           </Card.Header>
           <Divider />


### PR DESCRIPTION
## Description

This reapplies the changes from https://github.com/shapeshift/web/pull/1378 and makes the trade step icon great again by not displaying trade completed state in the "Confirm and Trade" step.

## Notice

<!-- Before submitting a pull request, please make sure you have answered the following: -->

- [x] Have you followed the guidelines in our [Contributing]('https://github.com/shapeshift/web/CONTRIBUTING.md) guide?
- [x] Have you checked to ensure there aren't other open [Pull Requests](https://github.com/shapeshift/web/pulls) for the same update/change?

## Pull Request Type

- [x] :bug: Bug fix (Non-breaking Change: Fixes an issue)
- [ ] :hammer_and_wrench: Chore (Non-breaking Change: Doc updates, pkg upgrades, typos, etc..)
- [ ] :nail_care: New Feature (Breaking/Non-breaking Change)

## Issue (if applicable)

tackles #1747 partially but doesn't `close` it, since it's not fixing us needing to wait for the actual Tx confirmation status after broadcast

## Risk

None, just reverts back to the previous behavior 

## Testing

1. Make a swap up to the "Confirm and Trade" screen
2. Verify that the middle icon in the steps is shown as an arrow vs. a green check icon (test against develop)
3. No need to fully complete the swap, since this PR doesn't tackle our optimistic assumption of a confirmed Tx right after broadcast

## Screenshots (if applicable)
