### PR TITLE
fix: loading state and promise.all

### DIFF
--- a/src/components/Trade/TradeInput.tsx
+++ b/src/components/Trade/TradeInput.tsx
@@ -359,9 +359,14 @@ export const TradeInput = ({ history }: RouterProps) => {
                   ? 'red'
                   : 'blue'
               }
-              isLoading={isSubmitting || isSendMaxLoading || !quote}
+              isLoading={isSubmitting || isSendMaxLoading}
               isDisabled={
-                !isDirty || !isValid || !wallet || !hasValidTradeBalance || !hasEnoughBalanceForGas
+                !isDirty ||
+                !isValid ||
+                !wallet ||
+                !hasValidTradeBalance ||
+                !hasEnoughBalanceForGas ||
+                !quote
               }
               style={{
                 whiteSpace: 'normal',

--- a/src/components/Trade/TradeInput.tsx
+++ b/src/components/Trade/TradeInput.tsx
@@ -359,7 +359,7 @@ export const TradeInput = ({ history }: RouterProps) => {
                   ? 'red'
                   : 'blue'
               }
-              isLoading={isSubmitting || isSendMaxLoading}
+              isLoading={isSubmitting || isSendMaxLoading || !quote}
               isDisabled={
                 !isDirty || !isValid || !wallet || !hasValidTradeBalance || !hasEnoughBalanceForGas
               }

--- a/src/components/Trade/hooks/useSwapper/calculateAmounts.ts
+++ b/src/components/Trade/hooks/useSwapper/calculateAmounts.ts
@@ -17,18 +17,23 @@ export const calculateAmounts = async ({
   swapper: Swapper
   action: TradeAmountInputField
 }) => {
-  const sellAssetUsdRate = bnOrZero(
+  const sellAssetUsdRatePromise = bnOrZero(
     await swapper.getUsdRate({
       symbol: sellAsset.symbol,
       tokenId: sellAsset.tokenId,
     }),
   )
-  const buyAssetUsdRate = bnOrZero(
+  const buyAssetUsdRatePromise = bnOrZero(
     await swapper.getUsdRate({
       symbol: buyAsset.symbol,
       tokenId: buyAsset.tokenId,
     }),
   )
+
+  const [sellAssetUsdRate, buyAssetUsdRate] = await Promise.all([
+    sellAssetUsdRatePromise,
+    buyAssetUsdRatePromise,
+  ])
 
   const assetPriceRatio = buyAssetUsdRate.dividedBy(sellAssetUsdRate)
 

--- a/src/components/Trade/hooks/useSwapper/calculateAmounts.ts
+++ b/src/components/Trade/hooks/useSwapper/calculateAmounts.ts
@@ -17,25 +17,22 @@ export const calculateAmounts = async ({
   swapper: Swapper
   action: TradeAmountInputField
 }) => {
-  const sellAssetUsdRatePromise = bnOrZero(
-    await swapper.getUsdRate({
-      symbol: sellAsset.symbol,
-      tokenId: sellAsset.tokenId,
-    }),
-  )
-  const buyAssetUsdRatePromise = bnOrZero(
-    await swapper.getUsdRate({
-      symbol: buyAsset.symbol,
-      tokenId: buyAsset.tokenId,
-    }),
-  )
+  const sellAssetUsdRatePromise = swapper.getUsdRate({
+    symbol: sellAsset.symbol,
+    tokenId: sellAsset.tokenId,
+  })
+
+  const buyAssetUsdRatePromise = swapper.getUsdRate({
+    symbol: buyAsset.symbol,
+    tokenId: buyAsset.tokenId,
+  })
 
   const [sellAssetUsdRate, buyAssetUsdRate] = await Promise.all([
     sellAssetUsdRatePromise,
     buyAssetUsdRatePromise,
   ])
 
-  const assetPriceRatio = buyAssetUsdRate.dividedBy(sellAssetUsdRate)
+  const assetPriceRatio = bnOrZero(buyAssetUsdRate).dividedBy(sellAssetUsdRate)
 
   let sellAmount
   let buyAmount

--- a/src/components/Trade/hooks/useSwapper/calculateAmounts.ts
+++ b/src/components/Trade/hooks/useSwapper/calculateAmounts.ts
@@ -17,19 +17,12 @@ export const calculateAmounts = async ({
   swapper: Swapper
   action: TradeAmountInputField
 }) => {
-  const sellAssetUsdRatePromise = swapper.getUsdRate({
-    symbol: sellAsset.symbol,
-    tokenId: sellAsset.tokenId,
-  })
+  const { getUsdRate } = swapper
 
-  const buyAssetUsdRatePromise = swapper.getUsdRate({
-    symbol: buyAsset.symbol,
-    tokenId: buyAsset.tokenId,
-  })
-
+  // TODO(0xdef1cafe): error handling
   const [sellAssetUsdRate, buyAssetUsdRate] = await Promise.all([
-    sellAssetUsdRatePromise,
-    buyAssetUsdRatePromise,
+    getUsdRate({ ...sellAsset }),
+    getUsdRate({ ...buyAsset }),
   ])
 
   const assetPriceRatio = bnOrZero(buyAssetUsdRate).dividedBy(sellAssetUsdRate)


### PR DESCRIPTION
## Description

- Fixes swapper loading quote state
- Promise.all for slightly faster async quote load

## Notice

- [x] Have you followed the guidelines in our [Contributing]('https://github.com/shapeshift/web/CONTRIBUTING.md) guide?
- [x] Have you checked to ensure there aren't other open [Pull Requests](https://github.com/shapeshift/web/pulls) for the same update/change?

## Pull Request Type

- [x] :bug: Bug fix (Non-breaking Change: Fixes an issue)
- [ ] :hammer_and_wrench: Chore (Non-breaking Change: Doc updates, pkg upgrades, typos, etc..)
- [ ] :nail_care: New Feature (Breaking/Non-breaking Change)

## Issue (if applicable)

<!-----------------------------------------------------------------------------
If applicable, please link to the github issue and put `closes #XXXX` in your comment to auto-close the issue that your PR fixes.
------------------------------------------------------------------------------>

## Risk

very low

## Testing

test and see that the "Preview Trade" (submit) button is disabled while loading quote

## Screenshots (if applicable)

BEFORE:

<img width="457" alt="Screen Shot 2022-05-13 at 7 56 33 AM" src="https://user-images.githubusercontent.com/6187559/168299548-edb8aa88-3854-4017-bcc1-8fb7f000dee3.png">

AFTER:


<img width="440" alt="Screen Shot 2022-05-13 at 9 32 48 AM" src="https://user-images.githubusercontent.com/6187559/168317776-f78e4ef9-409f-449b-8aca-fbba60a03ed1.png">

