### PR TITLE
fix: send input handler check

### DIFF
--- a/src/components/Modals/Send/hooks/useSendDetails/useSendDetails.test.tsx
+++ b/src/components/Modals/Send/hooks/useSendDetails/useSendDetails.test.tsx
@@ -18,6 +18,7 @@ import {
   selectPortfolioFiatBalanceByFilter,
 } from 'state/slices/selectors'
 
+import { SendFormFields } from '../../SendCommon'
 import { useSendDetails } from './useSendDetails'
 
 jest.mock('@shapeshiftoss/market-service', () => ({
@@ -208,7 +209,7 @@ describe('useSendDetails', () => {
 
       result.current.handleInputChange('0')
       jest.advanceTimersByTime(1500) // handleInputChange is now debounced for 1 second
-      expect(setValue).toHaveBeenCalledWith('fiatAmount', '0')
+      expect(setValue).toHaveBeenCalledWith(SendFormFields.AmountFieldError, '')
       setValue.mockClear()
     })
     jest.useRealTimers()

--- a/src/components/Modals/Send/hooks/useSendDetails/useSendDetails.tsx
+++ b/src/components/Modals/Send/hooks/useSendDetails/useSendDetails.tsx
@@ -330,8 +330,8 @@ export const useSendDetails = (): UseSendDetailsReturnType => {
         fieldName !== SendFormFields.FiatAmount
           ? SendFormFields.FiatAmount
           : SendFormFields.CryptoAmount
-      if (inputValue === '') {
-        // Don't show an error message when the input is empty
+      if (inputValue === '' || Number(inputValue) === 0) {
+        // Don't show an error message when the input is empty or zero
         setValue(SendFormFields.AmountFieldError, '')
         setLoading(false)
         // Set value of the other input to an empty string as well


### PR DESCRIPTION
## Description

Adds a check to the input handler to test if the input is equivalent to zero preventing gas estimate calls to be made that would cost less given value is zero.

## Notice

- [x] Have you followed the guidelines in our [Contributing]('https://github.com/shapeshift/web/CONTRIBUTING.md) guide?
- [x] Have you checked to ensure there aren't other open [Pull Requests](https://github.com/shapeshift/web/pulls) for the same update/change?

## Pull Request Type

- [x] :bug: Bug fix (Non-breaking Change: Fixes an issue)
- [ ] :hammer_and_wrench: Chore (Non-breaking Change: Doc updates, pkg upgrades, typos, etc..)
- [ ] :nail_care: New Feature (Breaking/Non-breaking Change)

## Issue (if applicable)

closes #1780 

## Risk

Related: Questioning the `leading` option on the debounce method found in [useSendDetails.tsx](https://github.com/shapeshift/web/blob/ddb2c5af32dfae645c9c67e4e1ff87179b0bff02/src/components/Modals/Send/hooks/useSendDetails/useSendDetails.tsx#L385). @0xApotheosis We can save an API call by removing the leading option; What is the reasoning behind always making a request on the first input?

## Testing

1. Go to assets
2. Click ETH
3. Click `Send` in top right
4. Use the referenced address in the issue for `Send to`: `0x8f5df2d1045543d2e1a4be1879cabde24b81d2b9`
5. Click `Next`
6. Type `0.001` or something with even more zeroes like `0.0000001`

## Screenshots (if applicable)
