### PR TITLE
chore: update makeUniqueTxId signature

### DIFF
--- a/src/state/slices/txHistorySlice/txHistorySlice.test.ts
+++ b/src/state/slices/txHistorySlice/txHistorySlice.test.ts
@@ -46,7 +46,9 @@ describe('txHistorySlice', () => {
       const ethChainId = EthSend.chainId
       const accountSpecifier = `${ethChainId}:0xdef1cafe`
       // expected transaction order
-      const expected = map(transactions, tx => makeUniqueTxId(tx, accountSpecifier))
+      const expected = map(transactions, tx =>
+        makeUniqueTxId(accountSpecifier, tx.txid, tx.address),
+      )
 
       store.dispatch(txHistory.actions.clear())
 
@@ -90,10 +92,14 @@ describe('txHistorySlice', () => {
 
       // eth data exists
       expect(
-        store.getState().txHistory.txs.byId[makeUniqueTxId(EthSend, ethAccountSpecifier)],
+        store.getState().txHistory.txs.byId[
+          makeUniqueTxId(ethAccountSpecifier, EthSend.txid, EthSend.address)
+        ],
       ).toEqual(EthSend)
       expect(
-        store.getState().txHistory.txs.byId[makeUniqueTxId(EthReceive, ethAccountSpecifier)],
+        store.getState().txHistory.txs.byId[
+          makeUniqueTxId(ethAccountSpecifier, EthReceive.txid, EthReceive.address)
+        ],
       ).toEqual(EthReceive)
 
       const segwitNativeAccountSpecifier = `${BtcSend.chainId}:zpub`
@@ -129,10 +135,14 @@ describe('txHistorySlice', () => {
 
       // btc data exists
       expect(
-        store.getState().txHistory.txs.byId[makeUniqueTxId(BtcSend, segwitNativeAccountSpecifier)],
+        store.getState().txHistory.txs.byId[
+          makeUniqueTxId(segwitNativeAccountSpecifier, BtcSend.txid, BtcSend.address)
+        ],
       ).toEqual(BtcSend)
       expect(
-        store.getState().txHistory.txs.byId[makeUniqueTxId(BtcSendSegwit, segwitAccountSpecifier)],
+        store.getState().txHistory.txs.byId[
+          makeUniqueTxId(segwitAccountSpecifier, BtcSendSegwit.txid, BtcSendSegwit.address)
+        ],
       ).toEqual(BtcSendSegwit)
     })
 
@@ -147,15 +157,18 @@ describe('txHistorySlice', () => {
       )
 
       expect(
-        store.getState().txHistory.txs.byId[makeUniqueTxId(EthReceivePending, ethAccountSpecifier)]
-          .status,
+        store.getState().txHistory.txs.byId[
+          makeUniqueTxId(ethAccountSpecifier, EthReceivePending.txid, EthReceivePending.address)
+        ].status,
       ).toBe(chainAdapters.TxStatus.Pending)
 
       store.dispatch(
         txHistory.actions.onMessage({ message: EthReceive, accountSpecifier: ethAccountSpecifier }),
       )
       expect(
-        store.getState().txHistory.txs.byId[makeUniqueTxId(EthReceive, ethAccountSpecifier)].status,
+        store.getState().txHistory.txs.byId[
+          makeUniqueTxId(ethAccountSpecifier, EthReceive.txid, EthReceive.address)
+        ].status,
       ).toBe(chainAdapters.TxStatus.Confirmed)
     })
 
@@ -191,16 +204,16 @@ describe('txHistorySlice', () => {
       )
 
       expect(store.getState().txHistory.txs.byAccountId[ethAccountSpecifier]).toStrictEqual([
-        makeUniqueTxId(EthSend, ethAccountSpecifier),
-        makeUniqueTxId(EthReceive, ethAccountSpecifier),
+        makeUniqueTxId(ethAccountSpecifier, EthSend.txid, EthSend.address),
+        makeUniqueTxId(ethAccountSpecifier, EthReceive.txid, EthReceive.address),
       ])
 
       expect(
         store.getState().txHistory.txs.byAccountId[segwitNativeAccountSpecifier],
-      ).toStrictEqual([makeUniqueTxId(BtcSend, segwitNativeAccountSpecifier)])
+      ).toStrictEqual([makeUniqueTxId(segwitNativeAccountSpecifier, BtcSend.txid, BtcSend.address)])
 
       expect(store.getState().txHistory.txs.byAccountId[segwitAccountSpecifier]).toStrictEqual([
-        makeUniqueTxId(BtcSendSegwit, segwitAccountSpecifier),
+        makeUniqueTxId(segwitAccountSpecifier, BtcSendSegwit.txid, BtcSendSegwit.address),
       ])
     })
   })

--- a/src/state/slices/txHistorySlice/txHistorySlice.ts
+++ b/src/state/slices/txHistorySlice/txHistorySlice.ts
@@ -127,7 +127,7 @@ const initialState: TxHistory = {
 
 const updateOrInsertTx = (txHistory: TxHistory, tx: Tx, accountSpecifier: AccountSpecifier) => {
   const { txs } = txHistory
-  const txid = makeUniqueTxId(tx, accountSpecifier)
+  const txid = makeUniqueTxId(accountSpecifier, tx.txid, tx.address)
 
   const isNew = !txs.byId[txid]
 
@@ -137,7 +137,9 @@ const updateOrInsertTx = (txHistory: TxHistory, tx: Tx, accountSpecifier: Accoun
   // add id to ordered set for new tx
   if (isNew) {
     const orderedTxs = orderBy(txs.byId, 'blockTime', ['desc'])
-    const index = orderedTxs.findIndex(tx => makeUniqueTxId(tx, accountSpecifier) === txid)
+    const index = orderedTxs.findIndex(
+      tx => makeUniqueTxId(accountSpecifier, tx.txid, tx.address) === txid,
+    )
     txs.ids.splice(index, 0, txid)
   }
 
@@ -147,7 +149,7 @@ const updateOrInsertTx = (txHistory: TxHistory, tx: Tx, accountSpecifier: Accoun
     txs.byAssetId[relatedAssetId] = addToIndex(
       txs.ids,
       txs.byAssetId[relatedAssetId],
-      makeUniqueTxId(tx, accountSpecifier),
+      makeUniqueTxId(accountSpecifier, tx.txid, tx.address),
     )
   })
 
@@ -155,7 +157,7 @@ const updateOrInsertTx = (txHistory: TxHistory, tx: Tx, accountSpecifier: Accoun
   txs.byAccountId[accountSpecifier] = addToIndex(
     txs.ids,
     txs.byAccountId[accountSpecifier],
-    makeUniqueTxId(tx, accountSpecifier),
+    makeUniqueTxId(accountSpecifier, tx.txid, tx.address),
   )
 
   // ^^^ redux toolkit uses the immer lib, which uses proxies under the hood

--- a/src/state/slices/txHistorySlice/utils.test.ts
+++ b/src/state/slices/txHistorySlice/utils.test.ts
@@ -66,7 +66,7 @@ describe('txHistorySlice:utils', () => {
     it('can deserialize a txId', () => {
       const ethChainId = EthSend.chainId
       const accountSpecifier = `${ethChainId}:0xdef1cafe`
-      const txId = makeUniqueTxId(EthSend, accountSpecifier)
+      const txId = makeUniqueTxId(accountSpecifier, EthSend.txid, EthSend.address)
 
       const { txAccountSpecifier, txid, txAddress } = deserializeUniqueTxId(txId)
 

--- a/src/state/slices/txHistorySlice/utils.ts
+++ b/src/state/slices/txHistorySlice/utils.ts
@@ -45,8 +45,11 @@ export const addToIndex = <T>(parentIndex: T[], childIndex: T[], newItem: T): T[
 
 // we can't use a hyphen as a delimiter, as it appears in the chain reference for cosmos
 export const UNIQUE_TX_ID_DELIMITER = '*'
-export const makeUniqueTxId = (tx: Tx, accountId: AccountSpecifier): string =>
-  [accountId, tx.txid, tx.address].join(UNIQUE_TX_ID_DELIMITER)
+export const makeUniqueTxId = (
+  accountId: AccountSpecifier,
+  txId: Tx['txid'],
+  txAddress: Tx['address'],
+): string => [accountId, txId, txAddress].join(UNIQUE_TX_ID_DELIMITER)
 
 type DeserializeUniqueTxId = { txAccountSpecifier: string; txid: string; txAddress: string }
 


### PR DESCRIPTION
## Description

This updates the signature of the `makeUniqueTxId` signature, to be able to support different parts separately.
The reason for that is we currently pass a `tx: Tx` and an `accountId: AccountSpecifier` params and then accesses `txid` and `address` from Tx, but following the swapper refactor and going forward, these two parts might be coming from multiple variables, not only from a single `Tx`.

This is needed for https://github.com/shapeshift/web/pull/1787 to avoid reinventing the serialization wheel. 

## Notice

<!-- Before submitting a pull request, please make sure you have answered the following: -->

- [x] Have you followed the guidelines in our [Contributing]('https://github.com/shapeshift/web/CONTRIBUTING.md) guide?
- [x] Have you checked to ensure there aren't other open [Pull Requests](https://github.com/shapeshift/web/pulls) for the same update/change?

## Pull Request Type

- [ ] :bug: Bug fix (Non-breaking Change: Fixes an issue)
- [x] :hammer_and_wrench: Chore (Non-breaking Change: Doc updates, pkg upgrades, typos, etc..)
- [ ] :nail_care: New Feature (Breaking/Non-breaking Change)

## Issue (if applicable)

N/A

## Risk

None, this just passes arguments directly instead of passing a `Tx` object and accessing its properties.

## Testing

Tests should still pass and CI should be happy

## Screenshots (if applicable)
