### PR TITLE
fix: avoid displaying asset description collapse button if the description is small

### DIFF
--- a/src/components/AssetHeader/AssetDescription.tsx
+++ b/src/components/AssetHeader/AssetDescription.tsx
@@ -1,6 +1,6 @@
-import { Button, Collapse, Skeleton, SkeletonText } from '@chakra-ui/react'
+import { Box, Button, Collapse, Skeleton, SkeletonText } from '@chakra-ui/react'
 import { AssetId } from '@shapeshiftoss/caip'
-import { useState } from 'react'
+import { useRef, useState } from 'react'
 import { useTranslate } from 'react-polyglot'
 import { Card } from 'components/Card/Card'
 import { ParsedHtml } from 'components/ParsedHtml/ParsedHtml'
@@ -14,14 +14,24 @@ type AssetDescriptionProps = {
   assetId: AssetId
 }
 
+const DESCRIPTION_DEFAULT_HEIGHT = 75
+
 export const AssetDescription = ({ assetId }: AssetDescriptionProps) => {
   const translate = useTranslate()
   const [showDescription, setShowDescription] = useState(false)
+  const descriptionEl = useRef<HTMLDivElement | null>(null)
   const handleToggle = () => setShowDescription(!showDescription)
   const asset = useAppSelector(state => selectAssetById(state, assetId))
   const { name, description, isTrustedDescription } = asset || {}
   const query = useGetAssetDescriptionQuery(assetId)
   const isLoaded = !query.isLoading
+
+  // If the height of the description is higher than the collapse element when it's closed
+  // we should display the Show More button
+  const shouldDisplayToggleButton =
+    descriptionEl?.current?.clientHeight &&
+    descriptionEl.current.clientHeight > DESCRIPTION_DEFAULT_HEIGHT
+
   if (!description || !isLoaded) return null
   return (
     <Card>
@@ -31,21 +41,25 @@ export const AssetDescription = ({ assetId }: AssetDescriptionProps) => {
             {translate('assets.assetDetails.assetHeader.aboutAsset', { asset: name })}
           </Card.Heading>
         </Skeleton>
-        <Collapse startingHeight={70} in={showDescription}>
-          <SkeletonText isLoaded={isLoaded} noOfLines={4} spacing={2} skeletonHeight='20px'>
-            {isTrustedDescription && (
-              <ParsedHtml color='gray.500' innerHtml={markdownLinkToHTML(description)} />
-            )}
-            {!isTrustedDescription && (
-              <SanitizedHtml color='gray.500' dirtyHtml={markdownLinkToHTML(description)} />
-            )}
-          </SkeletonText>
+        <Collapse startingHeight={DESCRIPTION_DEFAULT_HEIGHT} in={showDescription}>
+          <Box ref={descriptionEl}>
+            <SkeletonText isLoaded={isLoaded} noOfLines={4} spacing={2} skeletonHeight='20px'>
+              {isTrustedDescription && (
+                <ParsedHtml color='gray.500' innerHtml={markdownLinkToHTML(description)} />
+              )}
+              {!isTrustedDescription && (
+                <SanitizedHtml color='gray.500' dirtyHtml={markdownLinkToHTML(description)} />
+              )}
+            </SkeletonText>
+          </Box>
         </Collapse>
-        <Button size='sm' onClick={handleToggle} mt='1rem'>
-          {showDescription
-            ? translate('assets.assetDetails.assetDescription.showLess')
-            : translate('assets.assetDetails.assetDescription.showMore')}
-        </Button>
+        {shouldDisplayToggleButton && (
+          <Button size='sm' onClick={handleToggle} mt='1rem'>
+            {showDescription
+              ? translate('assets.assetDetails.assetDescription.showLess')
+              : translate('assets.assetDetails.assetDescription.showMore')}
+          </Button>
+        )}
       </Card.Footer>
     </Card>
   )

--- a/src/components/AssetHeader/AssetDescription.tsx
+++ b/src/components/AssetHeader/AssetDescription.tsx
@@ -1,6 +1,6 @@
 import { Box, Button, Collapse, Skeleton, SkeletonText } from '@chakra-ui/react'
 import { AssetId } from '@shapeshiftoss/caip'
-import { useRef, useState } from 'react'
+import { useEffect, useRef, useState } from 'react'
 import { useTranslate } from 'react-polyglot'
 import { Card } from 'components/Card/Card'
 import { ParsedHtml } from 'components/ParsedHtml/ParsedHtml'
@@ -19,6 +19,7 @@ const DESCRIPTION_DEFAULT_HEIGHT = 75
 export const AssetDescription = ({ assetId }: AssetDescriptionProps) => {
   const translate = useTranslate()
   const [showDescription, setShowDescription] = useState(false)
+  const [shouldDisplayToggleButton, setShouldDisplayToggleButton] = useState(true)
   const descriptionEl = useRef<HTMLDivElement | null>(null)
   const handleToggle = () => setShowDescription(!showDescription)
   const asset = useAppSelector(state => selectAssetById(state, assetId))
@@ -28,11 +29,14 @@ export const AssetDescription = ({ assetId }: AssetDescriptionProps) => {
 
   // If the height of the description is higher than the collapse element when it's closed
   // we should display the Show More button
-  const shouldDisplayToggleButton =
-    descriptionEl?.current?.clientHeight &&
-    descriptionEl.current.clientHeight > DESCRIPTION_DEFAULT_HEIGHT
+  useEffect(() => {
+    setShouldDisplayToggleButton(
+      (descriptionEl?.current?.clientHeight ?? 0) > DESCRIPTION_DEFAULT_HEIGHT,
+    )
+  }, [descriptionEl?.current?.clientHeight, description])
 
   if (!description || !isLoaded) return null
+
   return (
     <Card>
       <Card.Footer>


### PR DESCRIPTION
## Description
For example on `DAI`, the `Show More` button is displayed but the description isn't higher than the collapse.
To fix this, I increased a bit the default height of the description collapse component as 3 lines are a bit higher than 70.
Then I used a ref in order to check the height of the description, if it's higher than the default height of the collapse, we can display the button because it means that the description is longer than the space allowed
I used a useEffect and a setState to trigger the condition again in case the description or the ref element is not set yet

This is the best solution I could find because if we choose to trim the text and add some dots, it will add a lot of complexity (because the description contains some HTML elements, you can trim inside an HTML element syntax and it will be buggy, we would need to handle all these edge cases...)
<!-- Please describe your changes -->

## Notice

<!-- Before submitting a pull request, please make sure you have answered the following: -->

- [x] Have you followed the guidelines in our [Contributing]('https://github.com/shapeshift/web/CONTRIBUTING.md) guide?
- [x] Have you checked to ensure there aren't other open [Pull Requests](https://github.com/shapeshift/web/pulls) for the same update/change?

## Pull Request Type

- [x] :bug: Bug fix (Non-breaking Change: Fixes an issue)
- [ ] :hammer_and_wrench: Chore (Non-breaking Change: Doc updates, pkg upgrades, typos, etc..)
- [ ] :nail_care: New Feature (Breaking/Non-breaking Change)

## Issue (if applicable)
closes #1806
<!-----------------------------------------------------------------------------
If applicable, please link to the github issue and put `closes #XXXX` in your comment to auto-close the issue that your PR fixes.
------------------------------------------------------------------------------>

## Risk
- It could probably break the description toggler
<!-----------------------------------------------------------------------------
Outline the scope of your changes and the risk associated with them. You must use your discretion as an engineer to determine the potential impact of your changes.

E.g. an upgrade to `hdwallet` or core state management would be considered higher risk, and might require a full regression test. UI or isolated view changes, or something behind a feature flag may have near zero risk. Small bug fixes might require testing isolated to the specific fix.
------------------------------------------------------------------------------>

## Testing
- Go to Ethereum Asset page, see if the `Show More` button is shown inside the description component
- Go to DAI Asset page, see if the `Show More` button is correctly hidden in the description component
<!-----------------------------------------------------------------------------
If your testing steps are technical, outline steps for an engineer to verify.

If your testing steps are functional, please provide a full guide with any features requiring special attention for operations to test your branch in the preview environment.
------------------------------------------------------------------------------>

## Screenshots (if applicable)
<img width="359" alt="image" src="https://user-images.githubusercontent.com/14963751/168839350-6c3ab70d-cfe2-4ccc-89ce-8c6d2f29bf45.png">
<img width="362" alt="image" src="https://user-images.githubusercontent.com/14963751/168839425-632f1800-c545-448d-ad65-1eeffc96c56d.png">
