### PR TITLE
chore: remove useless swapper error handling in web

### DIFF
--- a/src/components/Trade/hooks/useSwapper/useSwapper.ts
+++ b/src/components/Trade/hooks/useSwapper/useSwapper.ts
@@ -189,33 +189,16 @@ export const useSwapper = () => {
       wallet,
       sendMax: true,
     })
-
     if (result?.success) {
       setFees(result, sellAsset)
       setValue('trade', result)
-      return result
     } else {
-      // TODO: (ryankk) Post bounty, these need to be revisited so the error messages can be more accurate.
-      switch (result.statusReason) {
-        case 'Gas estimation failed':
-          return {
-            success: false,
-            statusReason: translate(TRADE_ERRORS.INSUFFICIENT_FUNDS),
-          }
-        case 'Insufficient funds for transaction':
-          return {
-            success: false,
-            statusReason: translate(TRADE_ERRORS.INSUFFICIENT_FUNDS_FOR_AMOUNT, {
-              symbol: sellAsset.symbol,
-            }),
-          }
-        default:
-          return {
-            success: false,
-            statusReason: translate(TRADE_ERRORS.QUOTE_FAILED),
-          }
+      return {
+        success: false,
+        statusReason: translate(TRADE_ERRORS.QUOTE_FAILED),
       }
     }
+    return result
   }
 
   const executeQuote = async ({

--- a/src/components/Trade/hooks/useSwapper/useSwapper.ts
+++ b/src/components/Trade/hooks/useSwapper/useSwapper.ts
@@ -192,13 +192,13 @@ export const useSwapper = () => {
     if (result?.success) {
       setFees(result, sellAsset)
       setValue('trade', result)
+      return result
     } else {
       return {
         success: false,
         statusReason: translate(TRADE_ERRORS.QUOTE_FAILED),
       }
     }
-    return result
   }
 
   const executeQuote = async ({


### PR DESCRIPTION
## Description

The existing swapper error handling isn't useful very useful in catching and displaying errors.

This PR removes the existing swapper error handling logic to the bare minimum.

We will follow up with more robust swapper error handling once this PR is merged: https://github.com/shapeshift/lib/pull/632

## Notice

- [ ] Have you followed the guidelines in our [Contributing]('https://github.com/shapeshift/web/CONTRIBUTING.md) guide?
- [ ] Have you checked to ensure there aren't other open [Pull Requests](https://github.com/shapeshift/web/pulls) for the same update/change?

## Pull Request Type

- [ ] :bug: Bug fix (Non-breaking Change: Fixes an issue)
- [ ] :hammer_and_wrench: Chore (Non-breaking Change: Doc updates, pkg upgrades, typos, etc..)
- [ ] :nail_care: New Feature (Breaking/Non-breaking Change)

## Issue (if applicable)

<!-----------------------------------------------------------------------------
If applicable, please link to the github issue and put `closes #XXXX` in your comment to auto-close the issue that your PR fixes.
------------------------------------------------------------------------------>

## Risk

very low. errors from swapper are still caught and displayed in a toast in the same way.

## Testing

make sure swaps still work- there are no user facing changes, just simplify the error handling