### PR TITLE
fix: dont continue to next screen on failure

### DIFF
--- a/src/components/Trade/TradeInput.tsx
+++ b/src/components/Trade/TradeInput.tsx
@@ -85,7 +85,10 @@ export const TradeInput = ({ history }: RouterProps) => {
         buyAsset: quote?.buyAsset,
         amount: quote?.sellAmount,
       })
-      if (!result?.success && result?.statusReason) handleToast(result.statusReason)
+      if (!result?.success && result?.statusReason) {
+        handleToast(result.statusReason)
+        return
+      }
       const approvalNeeded = await checkApprovalNeeded(wallet)
       if (approvalNeeded) {
         history.push({


### PR DESCRIPTION
## Description

Was not correctly returning early if there was as error.

This was noticed for and fixes the case of `sellAmount < minimumSellAmount`

## Notice

- [ ] Have you followed the guidelines in our [Contributing]('https://github.com/shapeshift/web/CONTRIBUTING.md) guide?
- [ ] Have you checked to ensure there aren't other open [Pull Requests](https://github.com/shapeshift/web/pulls) for the same update/change?

## Pull Request Type

- [ ] :bug: Bug fix (Non-breaking Change: Fixes an issue)
- [ ] :hammer_and_wrench: Chore (Non-breaking Change: Doc updates, pkg upgrades, typos, etc..)
- [ ] :nail_care: New Feature (Breaking/Non-breaking Change)


## Risk

almost no risk

## Testing

Enter a low amount (below $1) and see that it doesnt let you continue with the trade

## Screenshots (if applicable)

BEFORE:
![Screen Shot 2022-05-17 at 12 00 24 PM](https://user-images.githubusercontent.com/6187559/168925032-397d590e-7fc3-47d5-895e-ff976ac7f31a.png)

AFTER:
![Screen Shot 2022-05-17 at 4 43 45 PM](https://user-images.githubusercontent.com/6187559/168925047-cfd7da6b-2dcd-4fd5-a70e-2f97d38b8faf.png)




