### PR TITLE
fix: remove isOpen state and use chevron down icon

### DIFF
--- a/src/components/Layout/Header/NavBar/UserMenu.tsx
+++ b/src/components/Layout/Header/NavBar/UserMenu.tsx
@@ -1,4 +1,4 @@
-import { ChevronDownIcon, ChevronRightIcon, WarningTwoIcon } from '@chakra-ui/icons'
+import { ChevronDownIcon, WarningTwoIcon } from '@chakra-ui/icons'
 import { Menu, MenuButton, MenuGroup, MenuItem, MenuList } from '@chakra-ui/menu'
 import { Button, ButtonGroup, Flex, HStack, IconButton, useColorModeValue } from '@chakra-ui/react'
 import { FC, useEffect, useState } from 'react'
@@ -23,7 +23,7 @@ const NoWallet = ({ onClick }: { onClick: () => void }) => {
     <MenuGroup title={translate('common.noWallet')} ml={3} color='gray.500'>
       <MenuItem onClick={onClick} alignItems='center' justifyContent='space-between'>
         {translate('common.connectWallet')}
-        <ChevronRightIcon />
+        <ChevronDownIcon />
       </MenuItem>
     </MenuGroup>
   )
@@ -138,8 +138,6 @@ export const UserMenu: React.FC<{ onClick?: () => void }> = ({ onClick }) => {
     onClick && onClick()
     dispatch({ type: WalletActions.SET_WALLET_MODAL, payload: true })
   }
-  const [isOpen, setIsOpen] = useState(false)
-
   return (
     <ButtonGroup>
       <WalletButton
@@ -152,8 +150,7 @@ export const UserMenu: React.FC<{ onClick?: () => void }> = ({ onClick }) => {
         <MenuButton
           as={IconButton}
           aria-label='Open wallet dropdown menu'
-          onClick={() => setIsOpen(!isOpen)}
-          icon={isOpen ? <ChevronDownIcon /> : <ChevronRightIcon />}
+          icon={<ChevronDownIcon />}
           data-test='navigation-wallet-dropdown-button'
         />
         <MenuList


### PR DESCRIPTION
## Description

This fixes the wrong icon being shown on outside `<UserMenu />` click by always showing the `<ChevronDown />` icon and as a result, removes the `isOpen` state, which was a previous hack not accounting for outside click.

## Notice

<!-- Before submitting a pull request, please make sure you have answered the following: -->

- [x] Have you followed the guidelines in our [Contributing]('https://github.com/shapeshift/web/CONTRIBUTING.md) guide?
- [x] Have you checked to ensure there aren't other open [Pull Requests](https://github.com/shapeshift/web/pulls) for the same update/change?

## Pull Request Type

- [x] :bug: Bug fix (Non-breaking Change: Fixes an issue)
- [ ] :hammer_and_wrench: Chore (Non-breaking Change: Doc updates, pkg upgrades, typos, etc..)
- [ ] :nail_care: New Feature (Breaking/Non-breaking Change)

## Issue (if applicable)

closes #1807

## Risk

None that I'm aware of. This removes any open/closed state so it should give us more confidence.

## Testing

- Go to Dashboard with a connected wallet
- Notice how the icon that shows the user menu is a chevron down icon
- Click on the icon, the user menu opens and the icon should stay as a chevron down
- Click again, the user menu closes and the icon should stay as a chevron down icon
- Proceed again but this time closing the user menu by outside clicking it, it should stay as a chevron down icon

## Screenshots (if applicable)
