### PR TITLE
chore: add error handling hook (swapper)

### DIFF
--- a/src/assets/translations/en/main.json
+++ b/src/assets/translations/en/main.json
@@ -379,6 +379,12 @@
       "depositAddressRequired": "Cannot execute an ETH quote without a DEX address",
       "sellAssetNetworkAndSymbolRequired": "Both asset network and symbol are required to execute a quote",
       "hdwalletInvalidConfig": "An error occurred communicating with your hardware wallet",
+      "allowanceRequiredFailed": "An error occurred getting approving the allowance required to trade.",
+      "checkApprovalNeededFailed": "An error occurred checking the approval for your trade.",
+      "approveInfiniteFailed": "An error occurred approving your trade.",
+      "buildTradeFailed": "An error occurred building your trade.",
+      "executeTradeFailed": "An error occurred executing your trade.",
+      "unsupportedPair": "This trading pair is not currently supported.",
       "signing": {
         "failed": "An error occurred signing the transaction",
         "required": "A signed transaction is required"

--- a/src/assets/translations/en/main.json
+++ b/src/assets/translations/en/main.json
@@ -58,7 +58,8 @@
     "login": "Log In",
     "verify": "Verify",
     "notRobot": "I am not a Robot",
-    "skip": "Skip"
+    "skip": "Skip",
+    "generalError": "An error has occured"
   },
   "updateToast": {
     "body": "A new version of the app is available",
@@ -388,7 +389,8 @@
       "signing": {
         "failed": "An error occurred signing the transaction",
         "required": "A signed transaction is required"
-      }
+      },
+      "generalError": "A trade error has occured"
     }
   },
   "modals": {

--- a/src/assets/translations/en/main.json
+++ b/src/assets/translations/en/main.json
@@ -384,8 +384,11 @@
       "checkApprovalNeededFailed": "An error occurred checking the approval for your trade.",
       "approveInfiniteFailed": "An error occurred approving your trade.",
       "buildTradeFailed": "An error occurred building your trade.",
+      "grantAllowanceFailed": "An error occurred granting allowance.",
+      "minMaxError": "An error occured getting min / max trade amount",
       "executeTradeFailed": "An error occurred executing your trade.",
       "unsupportedPair": "This trading pair is not currently supported.",
+      "rateError": "An error occured getting trade rates",
       "signing": {
         "failed": "An error occurred signing the transaction",
         "required": "A signed transaction is required"

--- a/src/components/Approval/Approval.tsx
+++ b/src/components/Approval/Approval.tsx
@@ -1,18 +1,18 @@
-import { Button, Divider, Flex, Image, Link, SkeletonCircle, useToast } from '@chakra-ui/react'
+import { Button, Divider, Flex, Image, Link, SkeletonCircle } from '@chakra-ui/react'
 import { SupportedChainIds } from '@shapeshiftoss/types'
 import { useEffect, useRef, useState } from 'react'
 import { CountdownCircleTimer } from 'react-countdown-circle-timer'
 import { useFormContext } from 'react-hook-form'
-import { useTranslate } from 'react-polyglot'
 import { useHistory, useLocation } from 'react-router-dom'
 import { Card } from 'components/Card/Card'
 import { MiddleEllipsis } from 'components/MiddleEllipsis/MiddleEllipsis'
 import { Row } from 'components/Row/Row'
 import { SlideTransition } from 'components/SlideTransition'
 import { RawText, Text } from 'components/Text'
-import { TRADE_ERRORS, useSwapper } from 'components/Trade/hooks/useSwapper/useSwapper'
+import { useSwapper } from 'components/Trade/hooks/useSwapper/useSwapper'
 import { TradeRoutePaths, TradeState } from 'components/Trade/types'
 import { WalletActions } from 'context/WalletProvider/actions'
+import { useErrorHandler } from 'hooks/useErrorToast/useErrorToast'
 import { useLocaleFormatter } from 'hooks/useLocaleFormatter/useLocaleFormatter'
 import { useWallet } from 'hooks/useWallet/useWallet'
 import { bnOrZero } from 'lib/bignumber/bignumber'
@@ -31,8 +31,6 @@ export const Approval = () => {
   const history = useHistory()
   const location = useLocation<ApprovalParams>()
   const approvalInterval: { current: NodeJS.Timeout | undefined } = useRef()
-  const toast = useToast()
-  const translate = useTranslate()
   const [approvalTxId, setApprovalTxId] = useState<string>()
   const { fiatRate } = location.state
 
@@ -49,71 +47,54 @@ export const Approval = () => {
     state: { wallet, isConnected },
     dispatch,
   } = useWallet()
+  const { showErrorToast } = useErrorHandler()
   const { quote, fees } = getValues()
   const fee = fees?.chainSpecific?.approvalFee
   const symbol = quote?.sellAsset?.symbol
 
   const approve = async () => {
-    if (!wallet) return
-    if (!isConnected) {
-      /**
-       * call history.goBack() to reset current form state
-       * before opening the connect wallet modal.
-       */
-      history.goBack()
-      dispatch({ type: WalletActions.SET_WALLET_MODAL, payload: true })
-      return
-    }
-    const fnLogger = logger.child({ name: 'approve' })
-    fnLogger.trace('Attempting Approval...')
-
-    let txId
     try {
-      txId = await approveInfinite(wallet)
-    } catch (e) {
-      fnLogger.error(e, 'Approval Failed')
-      // TODO: (ryankk) this toast is currently assuming that the error is 'Not enough eth for tx fee' because we don't
-      // get the full error response back from unchained (we get a 500 error). We can make this more precise by returning
-      // the full error returned from unchained.
-      handleToast(translate(TRADE_ERRORS.NOT_ENOUGH_ETH))
-    }
-
-    if (!txId) return
-    setApprovalTxId(txId)
-
-    approvalInterval.current = setInterval(async () => {
-      fnLogger.trace({ fn: 'checkApprovalNeeded' }, 'Checking Approval Needed...')
-      try {
-        const approvalNeeded = await checkApprovalNeeded(wallet)
-        if (approvalNeeded) return
-      } catch (e) {
-        fnLogger.error(e, { fn: 'checkApprovalNeeded' }, 'Check Approval Needed Failed')
-        handleToast()
-        approvalInterval.current && clearInterval(approvalInterval.current)
-        return history.push(TradeRoutePaths.Input)
+      if (!wallet) return
+      if (!isConnected) {
+        /**
+         * call history.goBack() to reset current form state
+         * before opening the connect wallet modal.
+         */
+        history.goBack()
+        dispatch({ type: WalletActions.SET_WALLET_MODAL, payload: true })
+        return
       }
-      approvalInterval.current && clearInterval(approvalInterval.current)
+      const fnLogger = logger.child({ name: 'approve' })
+      fnLogger.trace('Attempting Approval...')
 
-      await updateTrade({
-        wallet,
-        sellAsset: quote?.sellAsset,
-        buyAsset: quote?.buyAsset,
-        amount: quote?.sellAmount,
-      })
+      const txId = await approveInfinite(wallet)
 
-      history.push({ pathname: TradeRoutePaths.Confirm, state: { fiatRate } })
-    }, 5000)
-  }
+      setApprovalTxId(txId)
 
-  const handleToast = (description: string = '') => {
-    toast({
-      title: translate(TRADE_ERRORS.TITLE),
-      description,
-      status: 'error',
-      duration: 9000,
-      isClosable: true,
-      position: 'top-right',
-    })
+      approvalInterval.current = setInterval(async () => {
+        fnLogger.trace({ fn: 'checkApprovalNeeded' }, 'Checking Approval Needed...')
+        try {
+          const approvalNeeded = await checkApprovalNeeded(wallet)
+          if (approvalNeeded) return
+        } catch (e) {
+          showErrorToast(e)
+          approvalInterval.current && clearInterval(approvalInterval.current)
+          return history.push(TradeRoutePaths.Input)
+        }
+        approvalInterval.current && clearInterval(approvalInterval.current)
+
+        await updateTrade({
+          wallet,
+          sellAsset: quote?.sellAsset,
+          buyAsset: quote?.buyAsset,
+          amount: quote?.sellAmount,
+        })
+
+        history.push({ pathname: TradeRoutePaths.Confirm, state: { fiatRate } })
+      }, 5000)
+    } catch (e) {
+      showErrorToast(e)
+    }
   }
 
   useEffect(() => {

--- a/src/components/Trade/TradeConfirm/TradeConfirm.tsx
+++ b/src/components/Trade/TradeConfirm/TradeConfirm.tsx
@@ -1,4 +1,4 @@
-import { Box, Button, Divider, Link, Stack, useToast } from '@chakra-ui/react'
+import { Box, Button, Divider, Link, Stack } from '@chakra-ui/react'
 import { ASSET_REFERENCE, toAssetId } from '@shapeshiftoss/caip'
 import { NetworkTypes, SupportedChainIds } from '@shapeshiftoss/types'
 import { useState } from 'react'
@@ -10,8 +10,9 @@ import { HelperTooltip } from 'components/HelperTooltip/HelperTooltip'
 import { Row } from 'components/Row/Row'
 import { SlideTransition } from 'components/SlideTransition'
 import { RawText, Text } from 'components/Text'
-import { TRADE_ERRORS, useSwapper } from 'components/Trade/hooks/useSwapper/useSwapper'
+import { useSwapper } from 'components/Trade/hooks/useSwapper/useSwapper'
 import { WalletActions } from 'context/WalletProvider/actions'
+import { useErrorHandler } from 'hooks/useErrorToast/useErrorToast'
 import { useLocaleFormatter } from 'hooks/useLocaleFormatter/useLocaleFormatter'
 import { useWallet } from 'hooks/useWallet/useWallet'
 import { bnOrZero } from 'lib/bignumber/bignumber'
@@ -34,7 +35,6 @@ export const TradeConfirm = ({ history }: RouterProps) => {
     handleSubmit,
     formState: { isSubmitting },
   } = useFormContext<TradeState<SupportedChainIds>>()
-  const toast = useToast()
   const translate = useTranslate()
   const { trade, fees, sellAssetFiatRate } = getValues()
   const { executeQuote, reset } = useSwapper()
@@ -60,33 +60,28 @@ export const TradeConfirm = ({ history }: RouterProps) => {
 
   const status = useAppSelector(state => selectLastTxStatusByAssetId(state, assetId))
 
+  const { showErrorToast } = useErrorHandler()
+
   const onSubmit = async () => {
-    if (!wallet) return
-    if (!isConnected) {
-      /**
-       * call handleBack to reset current form state
-       * before opening the connect wallet modal.
-       */
-      handleBack()
-      dispatch({ type: WalletActions.SET_WALLET_MODAL, payload: true })
-      return
-    }
     try {
+      if (!wallet) return
+      if (!isConnected) {
+        /**
+         * call handleBack to reset current form state
+         * before opening the connect wallet modal.
+         */
+        handleBack()
+        dispatch({ type: WalletActions.SET_WALLET_MODAL, payload: true })
+        return
+      }
+
       const result = await executeQuote({ wallet })
       const transactionId = result?.txid
       if (transactionId) {
         setTxid(transactionId)
       }
-    } catch (err) {
-      console.error(`TradeConfirm:onSubmit - ${err}`)
-      toast({
-        title: translate('trade.errors.title'),
-        description: translate(TRADE_ERRORS.DEX_TRADE_FAILED),
-        status: 'error',
-        duration: 9000,
-        isClosable: true,
-        position: 'top-right',
-      })
+    } catch (e) {
+      showErrorToast(e)
     }
   }
 

--- a/src/components/Trade/TradeInput.tsx
+++ b/src/components/Trade/TradeInput.tsx
@@ -148,7 +148,6 @@ export const TradeInput = ({ history }: RouterProps) => {
         action: TradeAmountInputField.SELL,
         amount: maxSendAmount,
       })
-      throw new Error('e')
     } catch (e) {
       showErrorToast(e)
     } finally {

--- a/src/components/Trade/TradeInput.tsx
+++ b/src/components/Trade/TradeInput.tsx
@@ -13,7 +13,7 @@ import { SlideTransition } from 'components/SlideTransition'
 import { RawText, Text } from 'components/Text'
 import { TokenButton } from 'components/TokenRow/TokenButton'
 import { TokenRow } from 'components/TokenRow/TokenRow'
-import { TRADE_ERRORS, useSwapper } from 'components/Trade/hooks/useSwapper/useSwapper'
+import { useSwapper } from 'components/Trade/hooks/useSwapper/useSwapper'
 import { useErrorHandler } from 'hooks/useErrorToast/useErrorToast'
 import { useLocaleFormatter } from 'hooks/useLocaleFormatter/useLocaleFormatter'
 import { useWallet } from 'hooks/useWallet/useWallet'
@@ -112,8 +112,8 @@ export const TradeInput = ({ history }: RouterProps) => {
         amount: quote?.sellAmount,
       })
       history.push({ pathname: TradeRoutePaths.Confirm, state: { fiatRate: feeAssetFiatRate } })
-    } catch (err) {
-      showErrorToast(err)
+    } catch (e) {
+      showErrorToast(e)
     }
   }
 
@@ -141,8 +141,6 @@ export const TradeInput = ({ history }: RouterProps) => {
       const currentSellAsset = getValues('sellAsset')
       const currentBuyAsset = getValues('buyAsset')
 
-      if (!maxSendAmount) return
-
       updateQuote({
         sellAsset: currentSellAsset.asset,
         buyAsset: currentBuyAsset.asset,
@@ -150,37 +148,31 @@ export const TradeInput = ({ history }: RouterProps) => {
         action: TradeAmountInputField.SELL,
         amount: maxSendAmount,
       })
+      throw new Error('e')
     } catch (e) {
-      fnLogger.error(e, 'Building Quote Failed')
-      handleToast(translate(TRADE_ERRORS.QUOTE_FAILED))
+      showErrorToast(e)
     } finally {
       setIsSendMaxLoading(false)
     }
   }
 
-  const handleToast = (description: string) => {
-    toast({
-      description,
-      status: 'error',
-      duration: 9000,
-      isClosable: true,
-      position: 'top-right',
-    })
-  }
-
   const toggleAssets = () => {
-    const currentSellAsset = getValues('sellAsset')
-    const currentBuyAsset = getValues('buyAsset')
-    setValue('sellAsset', currentBuyAsset)
-    setValue('buyAsset', currentSellAsset)
-    updateQuote({
-      forceQuote: true,
-      amount: bnOrZero(currentBuyAsset.amount).toString(),
-      sellAsset: currentBuyAsset.asset,
-      buyAsset: currentSellAsset.asset,
-      feeAsset,
-      action: TradeAmountInputField.SELL,
-    })
+    try {
+      const currentSellAsset = getValues('sellAsset')
+      const currentBuyAsset = getValues('buyAsset')
+      setValue('sellAsset', currentBuyAsset)
+      setValue('buyAsset', currentSellAsset)
+      updateQuote({
+        forceQuote: true,
+        amount: bnOrZero(currentBuyAsset.amount).toString(),
+        sellAsset: currentBuyAsset.asset,
+        buyAsset: currentSellAsset.asset,
+        feeAsset,
+        action: TradeAmountInputField.SELL,
+      })
+    } catch (e) {
+      showErrorToast(e)
+    }
   }
 
   const getTranslationKey = () => {

--- a/src/components/Trade/hooks/useSwapper/useSwapper.ts
+++ b/src/components/Trade/hooks/useSwapper/useSwapper.ts
@@ -5,12 +5,11 @@ import { Asset, ExecQuoteOutput, SupportedChainIds, SwapperType } from '@shapesh
 import debounce from 'lodash/debounce'
 import { useCallback, useRef, useState } from 'react'
 import { useFormContext, useWatch } from 'react-hook-form'
-import { useTranslate } from 'react-polyglot'
 import { useSelector } from 'react-redux'
 import { BuildQuoteTxOutput, TradeAmountInputField, TradeAsset } from 'components/Trade/types'
 import { useChainAdapters } from 'context/PluginProvider/PluginProvider'
 import { bn, bnOrZero } from 'lib/bignumber/bignumber'
-import { fromBaseUnit, toBaseUnit } from 'lib/math'
+import { fromBaseUnit } from 'lib/math'
 import { getWeb3Instance } from 'lib/web3-instance'
 import {
   selectAssetIds,
@@ -42,7 +41,6 @@ export enum TRADE_ERRORS {
 
 export const useSwapper = () => {
   const { setValue } = useFormContext()
-  const translate = useTranslate()
   const [quote, sellTradeAsset, trade] = useWatch({
     name: ['quote', 'sellAsset', 'trade'],
   }) as [
@@ -137,16 +135,6 @@ export const useSwapper = () => {
       buyAssetId: buyAsset.assetId,
       sellAssetId: sellAsset.assetId,
     })
-
-    const minSellAmount = toBaseUnit(quote.minimum, sellAsset.precision)
-
-    if (bnOrZero(amount).lt(minSellAmount)) {
-      return {
-        success: false,
-        statusReason: translate(TRADE_ERRORS.AMOUNT_TO_SMALL, { minLimit: quote.minimum }),
-      }
-    }
-
     const result = await swapper?.buildTrade({
       sellAmount: amount,
       sellAsset,

--- a/src/components/Trade/hooks/useSwapper/useSwapper.ts
+++ b/src/components/Trade/hooks/useSwapper/useSwapper.ts
@@ -8,6 +8,7 @@ import { useFormContext, useWatch } from 'react-hook-form'
 import { useSelector } from 'react-redux'
 import { BuildQuoteTxOutput, TradeAmountInputField, TradeAsset } from 'components/Trade/types'
 import { useChainAdapters } from 'context/PluginProvider/PluginProvider'
+import { useErrorHandler } from 'hooks/useErrorToast/useErrorToast'
 import { bn, bnOrZero } from 'lib/bignumber/bignumber'
 import { fromBaseUnit } from 'lib/math'
 import { getWeb3Instance } from 'lib/web3-instance'
@@ -94,6 +95,8 @@ export const useSwapper = () => {
   const feeAsset = useAppSelector(state =>
     selectFeeAssetById(state, sellTradeAsset?.asset.assetId ?? 'eip155:1/slip44:60'),
   )
+
+  const { showErrorToast } = useErrorHandler()
 
   const getSendMaxAmount = async ({
     sellAsset,
@@ -205,6 +208,7 @@ export const useSwapper = () => {
         setValue('buyAsset.amount', fromBaseUnit(buyAmount, buyAsset.precision)) // Buy asset input field amount
         setValue('sellAsset.amount', fromBaseUnit(sellAmount, sellAsset.precision)) // Sell asset input field amount
       } catch (e) {
+        showErrorToast(e)
         console.error(e)
       }
     }, debounceTime),

--- a/src/components/Trade/hooks/useSwapper/useSwapper.ts
+++ b/src/components/Trade/hooks/useSwapper/useSwapper.ts
@@ -32,14 +32,6 @@ type GetQuoteInput = {
   forceQuote?: boolean
 }
 
-export enum TRADE_ERRORS {
-  TITLE = 'trade.errors.title',
-  NOT_ENOUGH_ETH = 'trade.errors.notEnoughEth',
-  AMOUNT_TO_SMALL = 'trade.errors.amountToSmall',
-  DEX_TRADE_FAILED = 'trade.errors.dexTradeFailed',
-  QUOTE_FAILED = 'trade.errors.quoteFailed',
-}
-
 export const useSwapper = () => {
   const { setValue } = useFormContext()
   const [quote, sellTradeAsset, trade] = useWatch({

--- a/src/components/Trade/hooks/useSwapper/useSwapper.ts
+++ b/src/components/Trade/hooks/useSwapper/useSwapper.ts
@@ -209,7 +209,6 @@ export const useSwapper = () => {
         setValue('sellAsset.amount', fromBaseUnit(sellAmount, sellAsset.precision)) // Sell asset input field amount
       } catch (e) {
         showErrorToast(e)
-        console.error(e)
       }
     }, debounceTime),
   )

--- a/src/components/Trade/hooks/useSwapperErrors/useSwapperErrors.ts
+++ b/src/components/Trade/hooks/useSwapperErrors/useSwapperErrors.ts
@@ -1,0 +1,51 @@
+import { SwapErrorTypes, SwapError } from '@shapeshiftoss/swapper'
+import { useToast } from '@chakra-ui/react'
+import { useTranslate } from 'react-polyglot'
+import { logger } from 'lib/logger'
+
+// TODO(ryankk): We probably need to remove some of the messages in 'translations/en/main.json' under 'trade.errors',
+// there are a lot that are unused.
+const SwapErrorMap = {
+  [SwapErrorTypes.ALLOWANCE_REQUIRED_FAILED]: 'trade.errors.allowanceRequiredFailed',
+  [SwapErrorTypes.CHECK_APPROVAL_FAILED]: 'trade.errors.checkApprovalNeededFailed',
+  [SwapErrorTypes.APPROVE_INFINITE_FAILED]: 'trade.errors.approveInfiniteFailed',
+  [SwapErrorTypes.BUILD_TRADE_FAILED]: 'trade.errors.buildTradeFailed',
+  [SwapErrorTypes.EXECUTE_TRADE_FAILED]: 'trade.errors.executeTradeFailed',
+  [SwapErrorTypes.GRANT_ALLOWANCE_FAILED]: 'trade.errors.buildTradeFailed',
+  [SwapErrorTypes.MANAGER_ERROR]: 'trade.errors.buildTradeFailed',
+  [SwapErrorTypes.MIN_MAX_FAILED]: 'trade.errors.buildTradeFailed',
+  [SwapErrorTypes.SIGN_AND_BROADCAST_FAILED]: 'trade.errors.broadcastFailed',
+  [SwapErrorTypes.TRADE_QUOTE_FAILED]: 'trade.errors.quoteFailed',
+  [SwapErrorTypes.UNSUPPORTED_PAIR]: 'trade.errors.unsupportedPair',
+  [SwapErrorTypes.USD_RATE_FAILED]: 'trade.errors.buildTradeFailed',
+  [SwapErrorTypes.UNSUPPORTED_CHAIN]: 'trade.errors.unsupportedPair',
+  [SwapErrorTypes.VALIDATION_FAILED]: 'trade.errors.buildTradeFailed',
+  [SwapErrorTypes.RESPONSE_ERROR]: 'trade.errors.buildTradeFailed'
+}
+
+const moduleLogger = logger.child({ namespace: ['Swapper'] })
+
+export const useSwapperErrors = () => {
+  const toast = useToast()
+  const translate = useTranslate()
+
+  const handleSwapErrors = (error: SwapError | Error) => {
+    const translation =
+      error instanceof SwapError ? SwapErrorMap[error.code] : 'trade.errors.quoteFailed' // is this a good default?
+
+    moduleLogger.error(error)
+
+    toast({
+      title: translate('trade.errors.title'),
+      description: translate(translation),
+      status: 'error',
+      duration: 9000,
+      isClosable: true,
+      position: 'top-right'
+    })
+  }
+
+  return {
+    handleSwapErrors
+  }
+}

--- a/src/hooks/useErrorToast/useErrorToast.ts
+++ b/src/hooks/useErrorToast/useErrorToast.ts
@@ -1,11 +1,10 @@
-// TODO dont make this specific to swapper
-
 import { useToast } from '@chakra-ui/react'
 import { SwapErrorTypes } from '@shapeshiftoss/swapper'
 import { get, isError } from 'lodash'
 import { useTranslate } from 'react-polyglot'
 import { logger } from 'lib/logger'
 
+// TODO support more error types (non swapper errors)
 const ErrorTranslationMap: Record<string, string> = {
   [SwapErrorTypes.ALLOWANCE_REQUIRED_FAILED]: 'trade.errors.allowanceRequiredFailed',
   [SwapErrorTypes.CHECK_APPROVAL_FAILED]: 'trade.errors.checkApprovalNeededFailed',
@@ -24,12 +23,11 @@ const ErrorTranslationMap: Record<string, string> = {
   [SwapErrorTypes.RESPONSE_ERROR]: 'trade.errors.buildTradeFailed',
 }
 
-// TODO support more error types (non swapper errors)
 const getTranslationFromError = (error: unknown) => {
   if (isError(error)) {
-    return ErrorTranslationMap[get(error, 'code')] ?? 'trade.errors.quoteFailed' // use something better than quoteFailed
+    return ErrorTranslationMap[get(error, 'code')] ?? 'trade.errors.generalError'
   }
-  return 'trade.errors.quoteFailed' // generic error here (not trade)
+  return 'common.generalError'
 }
 
 const moduleLogger = logger.child({ namespace: ['Swapper'] })

--- a/src/hooks/useErrorToast/useErrorToast.ts
+++ b/src/hooks/useErrorToast/useErrorToast.ts
@@ -30,7 +30,7 @@ const getTranslationFromError = (error: unknown) => {
   return 'common.generalError'
 }
 
-const moduleLogger = logger.child({ namespace: ['Swapper'] })
+const moduleLogger = logger.child({ namespace: ['Error'] })
 
 export const useErrorHandler = () => {
   const toast = useToast()

--- a/src/hooks/useErrorToast/useErrorToast.ts
+++ b/src/hooks/useErrorToast/useErrorToast.ts
@@ -11,16 +11,16 @@ const ErrorTranslationMap: Record<string, string> = {
   [SwapErrorTypes.APPROVE_INFINITE_FAILED]: 'trade.errors.approveInfiniteFailed',
   [SwapErrorTypes.BUILD_TRADE_FAILED]: 'trade.errors.buildTradeFailed',
   [SwapErrorTypes.EXECUTE_TRADE_FAILED]: 'trade.errors.executeTradeFailed',
-  [SwapErrorTypes.GRANT_ALLOWANCE_FAILED]: 'trade.errors.buildTradeFailed',
-  [SwapErrorTypes.MANAGER_ERROR]: 'trade.errors.buildTradeFailed',
-  [SwapErrorTypes.MIN_MAX_FAILED]: 'trade.errors.buildTradeFailed',
+  [SwapErrorTypes.GRANT_ALLOWANCE_FAILED]: 'trade.errors.grantAllowanceFailed',
+  [SwapErrorTypes.MANAGER_ERROR]: 'trade.errors.generalError',
+  [SwapErrorTypes.MIN_MAX_FAILED]: 'trade.errors.minMaxError',
   [SwapErrorTypes.SIGN_AND_BROADCAST_FAILED]: 'trade.errors.broadcastFailed',
   [SwapErrorTypes.TRADE_QUOTE_FAILED]: 'trade.errors.quoteFailed',
   [SwapErrorTypes.UNSUPPORTED_PAIR]: 'trade.errors.unsupportedPair',
-  [SwapErrorTypes.USD_RATE_FAILED]: 'trade.errors.buildTradeFailed',
+  [SwapErrorTypes.USD_RATE_FAILED]: 'trade.errors.rateError',
   [SwapErrorTypes.UNSUPPORTED_CHAIN]: 'trade.errors.unsupportedPair',
-  [SwapErrorTypes.VALIDATION_FAILED]: 'trade.errors.buildTradeFailed',
-  [SwapErrorTypes.RESPONSE_ERROR]: 'trade.errors.buildTradeFailed',
+  [SwapErrorTypes.VALIDATION_FAILED]: 'trade.errors.generalError',
+  [SwapErrorTypes.RESPONSE_ERROR]: 'trade.errors.generalError',
 }
 
 const getTranslationFromError = (error: unknown) => {

--- a/src/hooks/useErrorToast/useErrorToast.ts
+++ b/src/hooks/useErrorToast/useErrorToast.ts
@@ -25,7 +25,7 @@ const ErrorTranslationMap: Record<string, string> = {
 
 const getTranslationFromError = (error: unknown) => {
   if (isError(error)) {
-    return ErrorTranslationMap[get(error, 'code')] ?? 'trade.errors.generalError'
+    return ErrorTranslationMap[get(error, 'code')] ?? 'common.generalError'
   }
   return 'common.generalError'
 }


### PR DESCRIPTION
## Description

Add `showErrorToast()` utility to translate and display known errors. Currently only handles swapper errors with translations but can easily be expanded.

Replace existing swap error handling to use showErrorToast(e)

## Notice

<!-- Before submitting a pull request, please make sure you have answered the following: -->

- [x] Have you followed the guidelines in our [Contributing]('https://github.com/shapeshift/web/CONTRIBUTING.md) guide?
- [x] Have you checked to ensure there aren't other open [Pull Requests](https://github.com/shapeshift/web/pulls) for the same update/change?

## Pull Request Type

- [ ] :bug: Bug fix (Non-breaking Change: Fixes an issue)
- [x] :hammer_and_wrench: Chore (Non-breaking Change: Doc updates, pkg upgrades, typos, etc..)
- [ ] :nail_care: New Feature (Breaking/Non-breaking Change)

## Issue (if applicable)

<!-----------------------------------------------------------------------------
If applicable, please link to the github issue and put `closes #XXXX` in your comment to auto-close the issue that your PR fixes.
------------------------------------------------------------------------------>

## Risk

Low risk. Nothing should change from a user perspective just how we handle errors under the hood

## Testing

Nothing should change from a user perspective. Test that swaps still work

## Screenshots (if applicable)

This screenshot should never happen under normal circumstances but is an example of what an error will look like to the user.

<img width="572" alt="Screen Shot 2022-05-19 at 3 05 25 PM" src="https://user-images.githubusercontent.com/6187559/169404563-bafc505b-8dae-4f28-8192-9a893a2b894a.png">

Error logs example:
<img width="730" alt="Screen Shot 2022-05-19 at 3 53 35 PM" src="https://user-images.githubusercontent.com/6187559/169410882-cea09262-c187-4671-a13f-1b6a57b938f5.png">


