### PR TITLE
feat: revert the revert of "chore: remove unneeded market fetch (#1808)"

### DIFF
--- a/headers.js
+++ b/headers.js
@@ -80,6 +80,7 @@ const cspMeta = Object.entries({
     'https://raw.githack.com/shapeshift/lib/',
     'https://raw.githubusercontent.com/shapeshift/lib/',
     'https://raw.githubusercontent.com/cosmostation/',
+    'https://raw.githubusercontent.com/cosmos/chain-registry/',
   ],
   'script-src': [
     "'self'",

--- a/src/context/AppProvider/AppContext.tsx
+++ b/src/context/AppProvider/AppContext.tsx
@@ -18,8 +18,8 @@ import head from 'lodash/head'
 import isEmpty from 'lodash/isEmpty'
 import React, { useCallback, useEffect, useState } from 'react'
 import { useDispatch, useSelector } from 'react-redux'
-import { matchPath, useLocation } from 'react-router'
 import { usePlugins } from 'context/PluginProvider/PluginProvider'
+import { useRouteAssetId } from 'hooks/useRouteAssetId/useRouteAssetId'
 import { useWallet } from 'hooks/useWallet/useWallet'
 import { logger } from 'lib/logger'
 import {
@@ -68,7 +68,7 @@ export const AppProvider = ({ children }: { children: React.ReactNode }) => {
   } = useWallet()
   const assetsById = useSelector(selectAssets)
   const assetIds = useSelector(selectAssetIds)
-  const location = useLocation()
+  const routeAssetId = useRouteAssetId()
 
   // keep track of pending tx ids, so we can refetch the portfolio when they confirm
   const [pendingTxIds, setPendingTxIds] = useState<Set<TxId>>(new Set<TxId>())
@@ -330,16 +330,13 @@ export const AppProvider = ({ children }: { children: React.ReactNode }) => {
   }, [portfolioAssetIds, setMarketDataIntervalId, dispatch])
 
   // market data single-asset fetch, will use cached version if available
+  // This uses the assetId from /assets route
   useEffect(() => {
-    const assetIdPathMatch = matchPath<{ chainId: string; assetSubId: string }>(location.pathname, {
-      path: '/assets/:chainId/:assetSubId',
-    })
-    if (!assetIdPathMatch?.params) return
+    // early return for routes that don't contain an assetId, no need to refetch marketData granularly
+    if (!routeAssetId) return
 
-    const { chainId, assetSubId } = assetIdPathMatch.params
-    const assetId = `${chainId}/${assetSubId}`
-    dispatch(marketApi.endpoints.findByAssetId.initiate(assetId))
-  }, [dispatch, location.pathname])
+    dispatch(marketApi.endpoints.findByAssetId.initiate(routeAssetId))
+  }, [dispatch, routeAssetId])
 
   // If the assets aren't loaded, then the app isn't ready to render
   // This fixes issues with refreshes on pages that expect assets to already exist

--- a/src/features/defi/providers/foxy/components/FoxyManager/Deposit/FoxyDeposit.tsx
+++ b/src/features/defi/providers/foxy/components/FoxyManager/Deposit/FoxyDeposit.tsx
@@ -15,13 +15,12 @@ import { useChainAdapters } from 'context/PluginProvider/PluginProvider'
 import { useBrowserRouter } from 'hooks/useBrowserRouter/useBrowserRouter'
 import { useWallet } from 'hooks/useWallet/useWallet'
 import { bnOrZero } from 'lib/bignumber/bignumber'
-import { marketApi } from 'state/slices/marketDataSlice/marketDataSlice'
 import {
   selectAssetById,
   selectMarketDataById,
   selectPortfolioLoading,
 } from 'state/slices/selectors'
-import { useAppDispatch, useAppSelector } from 'state/store'
+import { useAppSelector } from 'state/store'
 
 import { Approve } from './components/Approve'
 import { Confirm } from './components/Confirm'
@@ -39,7 +38,6 @@ export const FoxyDeposit = ({ api }: FoxyDepositProps) => {
   const [state, dispatch] = useReducer(reducer, initialState)
   const location = useLocation()
   const translate = useTranslate()
-  const appDispatch = useAppDispatch()
   const toast = useToast()
   const { query } = useBrowserRouter<DefiQueryParams, DefiParams>()
   const { chain, contractAddress, tokenId } = query
@@ -49,7 +47,6 @@ export const FoxyDeposit = ({ api }: FoxyDepositProps) => {
 
   const asset = useAppSelector(state => selectAssetById(state, assetId))
   const marketData = useAppSelector(state => selectMarketDataById(state, assetId))
-  if (!marketData) appDispatch(marketApi.endpoints.findByAssetId.initiate(assetId))
 
   // user info
   const chainAdapterManager = useChainAdapters()

--- a/src/features/defi/providers/foxy/components/FoxyManager/Deposit/components/Approve.tsx
+++ b/src/features/defi/providers/foxy/components/FoxyManager/Deposit/components/Approve.tsx
@@ -13,12 +13,10 @@ import { useBrowserRouter } from 'hooks/useBrowserRouter/useBrowserRouter'
 import { useWallet } from 'hooks/useWallet/useWallet'
 import { bnOrZero } from 'lib/bignumber/bignumber'
 import { poll } from 'lib/poll/poll'
-import { marketApi } from 'state/slices/marketDataSlice/marketDataSlice'
 import { selectAssetById, selectMarketDataById } from 'state/slices/selectors'
-import { useAppDispatch, useAppSelector } from 'state/store'
+import { useAppSelector } from 'state/store'
 
-import { DepositPath } from '../DepositCommon'
-import { FoxyDepositActionType } from '../DepositCommon'
+import { DepositPath, FoxyDepositActionType } from '../DepositCommon'
 import { DepositContext } from '../DepositContext'
 
 type FoxyApproveProps = {
@@ -29,7 +27,6 @@ type FoxyApproveProps = {
 export const Approve = ({ api, getDepositGasEstimate }: FoxyApproveProps) => {
   const { state, dispatch } = useContext(DepositContext)
   const history = useHistory()
-  const appDispatch = useAppDispatch()
   const translate = useTranslate()
   const toast = useToast()
   const { query } = useBrowserRouter<DefiQueryParams, DefiParams>()
@@ -46,8 +43,6 @@ export const Approve = ({ api, getDepositGasEstimate }: FoxyApproveProps) => {
   })
 
   const asset = useAppSelector(state => selectAssetById(state, assetId))
-  const marketData = useAppSelector(state => selectMarketDataById(state, assetId))
-  if (!marketData) appDispatch(marketApi.endpoints.findByAssetId.initiate(assetId))
   const feeAsset = useAppSelector(state => selectAssetById(state, feeAssetId))
   const feeMarketData = useAppSelector(state => selectMarketDataById(state, feeAssetId))
 

--- a/src/features/defi/providers/foxy/components/FoxyManager/Deposit/components/Confirm.tsx
+++ b/src/features/defi/providers/foxy/components/FoxyManager/Deposit/components/Confirm.tsx
@@ -17,12 +17,10 @@ import { useBrowserRouter } from 'hooks/useBrowserRouter/useBrowserRouter'
 import { useWallet } from 'hooks/useWallet/useWallet'
 import { bnOrZero } from 'lib/bignumber/bignumber'
 import { poll } from 'lib/poll/poll'
-import { marketApi } from 'state/slices/marketDataSlice/marketDataSlice'
 import { selectAssetById, selectMarketDataById } from 'state/slices/selectors'
-import { useAppDispatch, useAppSelector } from 'state/store'
+import { useAppSelector } from 'state/store'
 
-import { DepositPath } from '../DepositCommon'
-import { FoxyDepositActionType } from '../DepositCommon'
+import { DepositPath, FoxyDepositActionType } from '../DepositCommon'
 import { DepositContext } from '../DepositContext'
 
 type FoxyConfirmProps = {
@@ -33,7 +31,6 @@ type FoxyConfirmProps = {
 export const Confirm = ({ api, apy }: FoxyConfirmProps) => {
   const { state, dispatch } = useContext(DepositContext)
   const history = useHistory()
-  const appDispatch = useAppDispatch()
   const translate = useTranslate()
   const { query } = useBrowserRouter<DefiQueryParams, DefiParams>()
   const { chain, contractAddress, tokenId, rewardId } = query
@@ -49,7 +46,6 @@ export const Confirm = ({ api, apy }: FoxyConfirmProps) => {
 
   const asset = useAppSelector(state => selectAssetById(state, assetId))
   const marketData = useAppSelector(state => selectMarketDataById(state, assetId))
-  if (!marketData) appDispatch(marketApi.endpoints.findByAssetId.initiate(assetId))
   const feeAsset = useAppSelector(state => selectAssetById(state, feeAssetId))
   const feeMarketData = useAppSelector(state => selectMarketDataById(state, feeAssetId))
   const contractAssetId = toAssetId({

--- a/src/features/defi/providers/foxy/components/FoxyManager/Deposit/components/Deposit.tsx
+++ b/src/features/defi/providers/foxy/components/FoxyManager/Deposit/components/Deposit.tsx
@@ -9,16 +9,14 @@ import { useTranslate } from 'react-polyglot'
 import { useHistory } from 'react-router-dom'
 import { useBrowserRouter } from 'hooks/useBrowserRouter/useBrowserRouter'
 import { bnOrZero } from 'lib/bignumber/bignumber'
-import { marketApi } from 'state/slices/marketDataSlice/marketDataSlice'
 import {
   selectAssetById,
   selectMarketDataById,
   selectPortfolioCryptoBalanceByAssetId,
 } from 'state/slices/selectors'
-import { useAppDispatch, useAppSelector } from 'state/store'
+import { useAppSelector } from 'state/store'
 
-import { DepositPath } from '../DepositCommon'
-import { FoxyDepositActionType } from '../DepositCommon'
+import { DepositPath, FoxyDepositActionType } from '../DepositCommon'
 import { DepositContext } from '../DepositContext'
 
 type FoxyDepositProps = {
@@ -30,7 +28,6 @@ type FoxyDepositProps = {
 export const Deposit = ({ api, apy, getDepositGasEstimate }: FoxyDepositProps) => {
   const { state, dispatch } = useContext(DepositContext)
   const history = useHistory()
-  const appDispatch = useAppDispatch()
   const translate = useTranslate()
   const { query } = useBrowserRouter<DefiQueryParams, DefiParams>()
   const { chain, contractAddress, tokenId } = query
@@ -40,7 +37,6 @@ export const Deposit = ({ api, apy, getDepositGasEstimate }: FoxyDepositProps) =
 
   const asset = useAppSelector(state => selectAssetById(state, assetId))
   const marketData = useAppSelector(state => selectMarketDataById(state, assetId))
-  if (!marketData) appDispatch(marketApi.endpoints.findByAssetId.initiate(assetId))
 
   // user info
   const balance = useAppSelector(state => selectPortfolioCryptoBalanceByAssetId(state, { assetId }))

--- a/src/features/defi/providers/foxy/components/FoxyManager/Deposit/components/Status.tsx
+++ b/src/features/defi/providers/foxy/components/FoxyManager/Deposit/components/Status.tsx
@@ -14,9 +14,8 @@ import { Row } from 'components/Row/Row'
 import { Text } from 'components/Text'
 import { useBrowserRouter } from 'hooks/useBrowserRouter/useBrowserRouter'
 import { bnOrZero } from 'lib/bignumber/bignumber'
-import { marketApi } from 'state/slices/marketDataSlice/marketDataSlice'
 import { selectAssetById, selectMarketDataById } from 'state/slices/selectors'
-import { useAppDispatch, useAppSelector } from 'state/store'
+import { useAppSelector } from 'state/store'
 
 import { DepositContext } from '../DepositContext'
 
@@ -28,7 +27,6 @@ type FoxyStatusProps = {
 export const Status = ({ apy }: FoxyStatusProps) => {
   const { state } = useContext(DepositContext)
   const history = useHistory()
-  const appDispatch = useAppDispatch()
   const { query, history: browserHistory } = useBrowserRouter<DefiQueryParams, DefiParams>()
   const { chain, tokenId, rewardId } = query
   const network = NetworkTypes.MAINNET
@@ -44,7 +42,6 @@ export const Status = ({ apy }: FoxyStatusProps) => {
 
   const asset = useAppSelector(state => selectAssetById(state, assetId))
   const marketData = useAppSelector(state => selectMarketDataById(state, assetId))
-  if (!marketData) appDispatch(marketApi.endpoints.findByAssetId.initiate(assetId))
   const feeAsset = useAppSelector(state => selectAssetById(state, feeAssetId))
   const feeMarketData = useAppSelector(state => selectMarketDataById(state, feeAssetId))
   const contractAssetId = toAssetId({

--- a/src/features/defi/providers/foxy/components/FoxyManager/Withdraw/FoxyWithdraw.tsx
+++ b/src/features/defi/providers/foxy/components/FoxyManager/Withdraw/FoxyWithdraw.tsx
@@ -15,13 +15,12 @@ import { useChainAdapters } from 'context/PluginProvider/PluginProvider'
 import { useBrowserRouter } from 'hooks/useBrowserRouter/useBrowserRouter'
 import { useWallet } from 'hooks/useWallet/useWallet'
 import { bn, bnOrZero } from 'lib/bignumber/bignumber'
-import { marketApi } from 'state/slices/marketDataSlice/marketDataSlice'
 import {
   selectAssetById,
   selectMarketDataById,
   selectPortfolioLoading,
 } from 'state/slices/selectors'
-import { useAppDispatch, useAppSelector } from 'state/store'
+import { useAppSelector } from 'state/store'
 
 import { Approve } from './components/Approve'
 import { Confirm } from './components/Confirm'
@@ -39,7 +38,6 @@ export const FoxyWithdraw = ({ api }: FoxyWithdrawProps) => {
   const [state, dispatch] = useReducer(reducer, initialState)
   const location = useLocation()
   const translate = useTranslate()
-  const appDispatch = useAppDispatch()
   const { query } = useBrowserRouter<DefiQueryParams, DefiParams>()
   const { chain, contractAddress, rewardId } = query
   const toast = useToast()
@@ -55,7 +53,6 @@ export const FoxyWithdraw = ({ api }: FoxyWithdrawProps) => {
   })
   const asset = useAppSelector(state => selectAssetById(state, assetId))
   const marketData = useAppSelector(state => selectMarketDataById(state, assetId))
-  if (!marketData) appDispatch(marketApi.endpoints.findByAssetId.initiate(assetId))
   const feeAssetId = toAssetId({
     chain,
     network,

--- a/src/features/defi/providers/foxy/components/FoxyManager/Withdraw/components/Approve.tsx
+++ b/src/features/defi/providers/foxy/components/FoxyManager/Withdraw/components/Approve.tsx
@@ -13,12 +13,10 @@ import { useBrowserRouter } from 'hooks/useBrowserRouter/useBrowserRouter'
 import { useWallet } from 'hooks/useWallet/useWallet'
 import { bn, bnOrZero } from 'lib/bignumber/bignumber'
 import { poll } from 'lib/poll/poll'
-import { marketApi } from 'state/slices/marketDataSlice/marketDataSlice'
 import { selectAssetById, selectMarketDataById } from 'state/slices/selectors'
-import { useAppDispatch, useAppSelector } from 'state/store'
+import { useAppSelector } from 'state/store'
 
-import { WithdrawPath } from '../WithdrawCommon'
-import { FoxyWithdrawActionType } from '../WithdrawCommon'
+import { FoxyWithdrawActionType, WithdrawPath } from '../WithdrawCommon'
 import { WithdrawContext } from '../WithdrawContext'
 
 type FoxyApproveProps = {
@@ -30,7 +28,6 @@ export const Approve = ({ api, getWithdrawGasEstimate }: FoxyApproveProps) => {
   const { state, dispatch } = useContext(WithdrawContext)
   const history = useHistory()
   const translate = useTranslate()
-  const appDispatch = useAppDispatch()
   const alertText = useColorModeValue('blue.800', 'white')
   const { query } = useBrowserRouter<DefiQueryParams, DefiParams>()
   const { chain, contractAddress, rewardId } = query
@@ -46,8 +43,6 @@ export const Approve = ({ api, getWithdrawGasEstimate }: FoxyApproveProps) => {
     assetReference: rewardId,
   })
   const asset = useAppSelector(state => selectAssetById(state, assetId))
-  const marketData = useAppSelector(state => selectMarketDataById(state, assetId))
-  if (!marketData) appDispatch(marketApi.endpoints.findByAssetId.initiate(assetId))
   const feeAssetId = toAssetId({
     chain,
     network,

--- a/src/features/defi/providers/foxy/components/FoxyManager/Withdraw/components/Confirm.tsx
+++ b/src/features/defi/providers/foxy/components/FoxyManager/Withdraw/components/Confirm.tsx
@@ -17,9 +17,8 @@ import { useBrowserRouter } from 'hooks/useBrowserRouter/useBrowserRouter'
 import { useWallet } from 'hooks/useWallet/useWallet'
 import { bn, bnOrZero } from 'lib/bignumber/bignumber'
 import { poll } from 'lib/poll/poll'
-import { marketApi } from 'state/slices/marketDataSlice/marketDataSlice'
 import { selectAssetById, selectMarketDataById } from 'state/slices/selectors'
-import { useAppDispatch, useAppSelector } from 'state/store'
+import { useAppSelector } from 'state/store'
 
 import { FoxyWithdrawActionType, WithdrawPath } from '../WithdrawCommon'
 import { WithdrawContext } from '../WithdrawContext'
@@ -32,7 +31,6 @@ export const Confirm = ({ api }: FoxyConfirmProps) => {
   const { state, dispatch } = useContext(WithdrawContext)
   const history = useHistory()
   const translate = useTranslate()
-  const appDispatch = useAppDispatch()
   const { query } = useBrowserRouter<DefiQueryParams, DefiParams>()
   const { chain, contractAddress, tokenId, rewardId } = query
 
@@ -53,8 +51,6 @@ export const Confirm = ({ api }: FoxyConfirmProps) => {
     assetReference: rewardId,
   })
   const asset = useAppSelector(state => selectAssetById(state, assetId))
-  const marketData = useAppSelector(state => selectMarketDataById(state, assetId))
-  if (!marketData) appDispatch(marketApi.endpoints.findByAssetId.initiate(assetId))
   const feeAssetId = toAssetId({
     chain,
     network,

--- a/src/features/defi/providers/foxy/components/FoxyManager/Withdraw/components/Status.tsx
+++ b/src/features/defi/providers/foxy/components/FoxyManager/Withdraw/components/Status.tsx
@@ -12,15 +12,13 @@ import { Row } from 'components/Row/Row'
 import { Text } from 'components/Text'
 import { useBrowserRouter } from 'hooks/useBrowserRouter/useBrowserRouter'
 import { bn, bnOrZero } from 'lib/bignumber/bignumber'
-import { marketApi } from 'state/slices/marketDataSlice/marketDataSlice'
 import { selectAssetById, selectMarketDataById } from 'state/slices/selectors'
-import { useAppDispatch, useAppSelector } from 'state/store'
+import { useAppSelector } from 'state/store'
 
 import { WithdrawContext } from '../WithdrawContext'
 
 export const Status = () => {
   const { state, dispatch } = useContext(WithdrawContext)
-  const appDispatch = useAppDispatch()
   const { query, history: browserHistory } = useBrowserRouter<DefiQueryParams, DefiParams>()
   const { chain, tokenId, rewardId } = query
   const defaultStatusBg = useColorModeValue('white', 'gray.700')
@@ -42,8 +40,6 @@ export const Status = () => {
     assetReference: rewardId,
   })
   const asset = useAppSelector(state => selectAssetById(state, assetId))
-  const marketData = useAppSelector(state => selectMarketDataById(state, assetId))
-  if (!marketData) appDispatch(marketApi.endpoints.findByAssetId.initiate(assetId))
   const feeAssetId = toAssetId({
     chain,
     network,

--- a/src/features/defi/providers/foxy/components/FoxyManager/Withdraw/components/Withdraw.tsx
+++ b/src/features/defi/providers/foxy/components/FoxyManager/Withdraw/components/Withdraw.tsx
@@ -7,8 +7,7 @@ import {
   WithdrawValues,
 } from 'features/defi/components/Withdraw/Withdraw'
 import { DefiParams, DefiQueryParams } from 'features/defi/contexts/DefiManagerProvider/DefiCommon'
-import { useContext } from 'react'
-import { useMemo } from 'react'
+import { useContext, useMemo } from 'react'
 import { useTranslate } from 'react-polyglot'
 import { useHistory } from 'react-router-dom'
 import { Amount } from 'components/Amount/Amount'
@@ -16,13 +15,12 @@ import { Row } from 'components/Row/Row'
 import { Text } from 'components/Text'
 import { useBrowserRouter } from 'hooks/useBrowserRouter/useBrowserRouter'
 import { bn, bnOrZero } from 'lib/bignumber/bignumber'
-import { marketApi } from 'state/slices/marketDataSlice/marketDataSlice'
 import {
   selectAssetById,
   selectMarketDataById,
   selectPortfolioCryptoBalanceByAssetId,
 } from 'state/slices/selectors'
-import { useAppDispatch, useAppSelector } from 'state/store'
+import { useAppSelector } from 'state/store'
 
 import { FoxyWithdrawActionType, WithdrawPath } from '../WithdrawCommon'
 import { WithdrawContext } from '../WithdrawContext'
@@ -36,7 +34,6 @@ export const Withdraw = ({ api, getWithdrawGasEstimate }: FoxyWithdrawProps) => 
   const { state, dispatch } = useContext(WithdrawContext)
   const history = useHistory()
   const translate = useTranslate()
-  const appDispatch = useAppDispatch()
   const { query, history: browserHistory } = useBrowserRouter<DefiQueryParams, DefiParams>()
   const { chain, contractAddress, rewardId } = query
   const toast = useToast()
@@ -52,7 +49,6 @@ export const Withdraw = ({ api, getWithdrawGasEstimate }: FoxyWithdrawProps) => 
   })
   const asset = useAppSelector(state => selectAssetById(state, assetId))
   const marketData = useAppSelector(state => selectMarketDataById(state, assetId))
-  if (!marketData) appDispatch(marketApi.endpoints.findByAssetId.initiate(assetId))
 
   // user info
   const balance = useAppSelector(state => selectPortfolioCryptoBalanceByAssetId(state, { assetId }))

--- a/src/features/defi/providers/yearn/components/YearnManager/Deposit/YearnDeposit.tsx
+++ b/src/features/defi/providers/yearn/components/YearnManager/Deposit/YearnDeposit.tsx
@@ -15,13 +15,12 @@ import { useChainAdapters } from 'context/PluginProvider/PluginProvider'
 import { useBrowserRouter } from 'hooks/useBrowserRouter/useBrowserRouter'
 import { useWallet } from 'hooks/useWallet/useWallet'
 import { bnOrZero } from 'lib/bignumber/bignumber'
-import { marketApi } from 'state/slices/marketDataSlice/marketDataSlice'
 import {
   selectAssetById,
   selectMarketDataById,
   selectPortfolioLoading,
 } from 'state/slices/selectors'
-import { useAppDispatch, useAppSelector } from 'state/store'
+import { useAppSelector } from 'state/store'
 
 import { Approve } from './components/Approve'
 import { Confirm } from './components/Confirm'
@@ -40,7 +39,6 @@ export const YearnDeposit = ({ api }: YearnDepositProps) => {
   const location = useLocation()
   const translate = useTranslate()
   const toast = useToast()
-  const appDispatch = useAppDispatch()
   const { query } = useBrowserRouter<DefiQueryParams, DefiParams>()
   const { chain, contractAddress: vaultAddress, tokenId } = query
 
@@ -49,7 +47,6 @@ export const YearnDeposit = ({ api }: YearnDepositProps) => {
   const assetId = toAssetId({ chain, network, assetNamespace, assetReference: tokenId })
   const asset = useAppSelector(state => selectAssetById(state, assetId))
   const marketData = useAppSelector(state => selectMarketDataById(state, assetId))
-  if (!marketData) appDispatch(marketApi.endpoints.findByAssetId.initiate(assetId))
 
   // user info
   const chainAdapterManager = useChainAdapters()

--- a/src/features/defi/providers/yearn/components/YearnManager/Deposit/components/Approve.tsx
+++ b/src/features/defi/providers/yearn/components/YearnManager/Deposit/components/Approve.tsx
@@ -13,9 +13,8 @@ import { useBrowserRouter } from 'hooks/useBrowserRouter/useBrowserRouter'
 import { useWallet } from 'hooks/useWallet/useWallet'
 import { bnOrZero } from 'lib/bignumber/bignumber'
 import { poll } from 'lib/poll/poll'
-import { marketApi } from 'state/slices/marketDataSlice/marketDataSlice'
 import { selectAssetById, selectMarketDataById } from 'state/slices/selectors'
-import { useAppDispatch, useAppSelector } from 'state/store'
+import { useAppSelector } from 'state/store'
 
 import { DepositPath, YearnDepositActionType } from '../DepositCommon'
 import { DepositContext } from '../DepositContext'
@@ -28,7 +27,6 @@ type YearnApproveProps = {
 export const Approve = ({ api, getDepositGasEstimate }: YearnApproveProps) => {
   const { state, dispatch } = useContext(DepositContext)
   const history = useHistory()
-  const appDispatch = useAppDispatch()
   const translate = useTranslate()
   const { query } = useBrowserRouter<DefiQueryParams, DefiParams>()
   const { chain, tokenId } = query
@@ -44,8 +42,6 @@ export const Approve = ({ api, getDepositGasEstimate }: YearnApproveProps) => {
     assetReference: ASSET_REFERENCE.Ethereum,
   })
   const asset = useAppSelector(state => selectAssetById(state, assetId))
-  const marketData = useAppSelector(state => selectMarketDataById(state, assetId))
-  if (!marketData) appDispatch(marketApi.endpoints.findByAssetId.initiate(assetId))
   const feeAsset = useAppSelector(state => selectAssetById(state, feeAssetId))
   const feeMarketData = useAppSelector(state => selectMarketDataById(state, feeAssetId))
 

--- a/src/features/defi/providers/yearn/components/YearnManager/Deposit/components/Confirm.tsx
+++ b/src/features/defi/providers/yearn/components/YearnManager/Deposit/components/Confirm.tsx
@@ -17,9 +17,8 @@ import { useBrowserRouter } from 'hooks/useBrowserRouter/useBrowserRouter'
 import { useWallet } from 'hooks/useWallet/useWallet'
 import { bnOrZero } from 'lib/bignumber/bignumber'
 import { poll } from 'lib/poll/poll'
-import { marketApi } from 'state/slices/marketDataSlice/marketDataSlice'
 import { selectAssetById, selectMarketDataById } from 'state/slices/selectors'
-import { useAppDispatch, useAppSelector } from 'state/store'
+import { useAppSelector } from 'state/store'
 
 import { DepositPath, YearnDepositActionType } from '../DepositCommon'
 import { DepositContext } from '../DepositContext'
@@ -31,7 +30,6 @@ type YearnConfirmProps = {
 export const Confirm = ({ api }: YearnConfirmProps) => {
   const { state, dispatch } = useContext(DepositContext)
   const history = useHistory()
-  const appDispatch = useAppDispatch()
   const translate = useTranslate()
   const { query, history: browserHistory } = useBrowserRouter<DefiQueryParams, DefiParams>()
   const { chain, contractAddress: vaultAddress, tokenId } = query
@@ -47,7 +45,6 @@ export const Confirm = ({ api }: YearnConfirmProps) => {
   })
   const asset = useAppSelector(state => selectAssetById(state, assetId))
   const marketData = useAppSelector(state => selectMarketDataById(state, assetId))
-  if (!marketData) appDispatch(marketApi.endpoints.findByAssetId.initiate(assetId))
   const feeAsset = useAppSelector(state => selectAssetById(state, feeAssetId))
   const feeMarketData = useAppSelector(state => selectMarketDataById(state, feeAssetId))
   const vaultAssetId = toAssetId({

--- a/src/features/defi/providers/yearn/components/YearnManager/Deposit/components/Deposit.tsx
+++ b/src/features/defi/providers/yearn/components/YearnManager/Deposit/components/Deposit.tsx
@@ -9,13 +9,12 @@ import { useTranslate } from 'react-polyglot'
 import { useHistory } from 'react-router-dom'
 import { useBrowserRouter } from 'hooks/useBrowserRouter/useBrowserRouter'
 import { bnOrZero } from 'lib/bignumber/bignumber'
-import { marketApi } from 'state/slices/marketDataSlice/marketDataSlice'
 import {
   selectAssetById,
   selectMarketDataById,
   selectPortfolioCryptoBalanceByAssetId,
 } from 'state/slices/selectors'
-import { useAppDispatch, useAppSelector } from 'state/store'
+import { useAppSelector } from 'state/store'
 
 import { DepositPath, YearnDepositActionType } from '../DepositCommon'
 import { DepositContext } from '../DepositContext'
@@ -29,7 +28,6 @@ type YearnDepositProps = {
 export const Deposit = ({ api, apy, getDepositGasEstimate }: YearnDepositProps) => {
   const { state, dispatch } = useContext(DepositContext)
   const history = useHistory()
-  const appDispatch = useAppDispatch()
   const translate = useTranslate()
   const { query, history: browserHistory } = useBrowserRouter<DefiQueryParams, DefiParams>()
   const { chain, tokenId } = query
@@ -39,7 +37,6 @@ export const Deposit = ({ api, apy, getDepositGasEstimate }: YearnDepositProps) 
   const assetId = toAssetId({ chain, network, assetNamespace, assetReference: tokenId })
   const asset = useAppSelector(state => selectAssetById(state, assetId))
   const marketData = useAppSelector(state => selectMarketDataById(state, assetId))
-  if (!marketData) appDispatch(marketApi.endpoints.findByAssetId.initiate(assetId))
 
   // user info
   const balance = useAppSelector(state => selectPortfolioCryptoBalanceByAssetId(state, { assetId }))

--- a/src/features/defi/providers/yearn/components/YearnManager/Deposit/components/Status.tsx
+++ b/src/features/defi/providers/yearn/components/YearnManager/Deposit/components/Status.tsx
@@ -12,15 +12,13 @@ import { Row } from 'components/Row/Row'
 import { Text } from 'components/Text'
 import { useBrowserRouter } from 'hooks/useBrowserRouter/useBrowserRouter'
 import { bnOrZero } from 'lib/bignumber/bignumber'
-import { marketApi } from 'state/slices/marketDataSlice/marketDataSlice'
 import { selectAssetById, selectMarketDataById } from 'state/slices/selectors'
-import { useAppDispatch, useAppSelector } from 'state/store'
+import { useAppSelector } from 'state/store'
 
 import { DepositContext } from '../DepositContext'
 
 export const Status = () => {
   const { state } = useContext(DepositContext)
-  const appDispatch = useAppDispatch()
   const { query, history: browserHistory } = useBrowserRouter<DefiQueryParams, DefiParams>()
   const { chain, contractAddress: vaultAddress, tokenId } = query
 
@@ -35,7 +33,6 @@ export const Status = () => {
   })
   const asset = useAppSelector(state => selectAssetById(state, assetId))
   const marketData = useAppSelector(state => selectMarketDataById(state, assetId))
-  if (!marketData) appDispatch(marketApi.endpoints.findByAssetId.initiate(assetId))
   const feeAsset = useAppSelector(state => selectAssetById(state, feeAssetId))
   const feeMarketData = useAppSelector(state => selectMarketDataById(state, feeAssetId))
   const vaultAssetId = toAssetId({

--- a/src/hooks/useRouteAssetId/useRouteAssetId.ts
+++ b/src/hooks/useRouteAssetId/useRouteAssetId.ts
@@ -1,0 +1,24 @@
+import { AssetId } from '@shapeshiftoss/caip'
+import { useEffect, useState } from 'react'
+import { matchPath, useLocation } from 'react-router'
+
+export const useRouteAssetId = () => {
+  const location = useLocation()
+  const [assetId, setAssetId] = useState<AssetId | null>(null)
+
+  useEffect(() => {
+    // Extract the chainId and assetSubId parts from an /assets route, see src/Routes/RoutesCommon.tsx
+    const assetIdPathMatch = matchPath<{ chainId: string; assetSubId: string }>(location.pathname, {
+      path: '/assets/:chainId/:assetSubId',
+    })
+    if (!assetIdPathMatch?.params) return
+
+    const { chainId, assetSubId } = assetIdPathMatch.params
+
+    // Reconstitutes the assetId from valid matched params
+    const assetId = `${chainId}/${assetSubId}`
+    setAssetId(assetId)
+  }, [location.pathname])
+
+  return assetId
+}

--- a/src/plugins/cosmos/CosmosAsset.tsx
+++ b/src/plugins/cosmos/CosmosAsset.tsx
@@ -2,13 +2,8 @@ import { Flex } from '@chakra-ui/react'
 import { useParams } from 'react-router-dom'
 import { Page } from 'components/Layout/Page'
 import { LoadingAsset } from 'pages/Assets/LoadingAsset'
-import { marketApi } from 'state/slices/marketDataSlice/marketDataSlice'
-import {
-  selectAssetById,
-  selectMarketDataById,
-  selectMarketDataLoadingById,
-} from 'state/slices/selectors'
-import { useAppDispatch, useAppSelector } from 'state/store'
+import { selectAssetById, selectMarketDataLoadingById } from 'state/slices/selectors'
+import { useAppSelector } from 'state/store'
 
 import { CosmosAssetAccountDetails } from './CosmosAssetAccountDetails'
 
@@ -18,14 +13,9 @@ export type MatchParams = {
 }
 
 export const CosmosAsset = () => {
-  const dispatch = useAppDispatch()
-
   const { chainRef, assetSubId } = useParams<MatchParams>()
   const assetId = `cosmos:${chainRef}/${assetSubId}`
   const asset = useAppSelector(state => selectAssetById(state, assetId))
-  const marketData = useAppSelector(state => selectMarketDataById(state, assetId))
-
-  if (!marketData) dispatch(marketApi.endpoints.findByAssetId.initiate(assetId))
 
   const loading = useAppSelector(state => selectMarketDataLoadingById(state, assetId))
 


### PR DESCRIPTION
## Description

Reverts the revert of b7ca8078b93f0d24d2d75594bd1e9bd73f4eeb09

Brings back the XYZ on Osmosis assets, which were showing an infinite Skeleton loading as the request to get the Market data was never fetched for these.


## Notice

<!-- Before submitting a pull request, please make sure you have answered the following: -->

- [x] Have you followed the guidelines in our [Contributing]('https://github.com/shapeshift/web/CONTRIBUTING.md) guide?
- [x] Have you checked to ensure there aren't other open [Pull Requests](https://github.com/shapeshift/web/pulls) for the same update/change?

## Pull Request Type

- [ ] :bug: Bug fix (Non-breaking Change: Fixes an issue)
- [ ] :hammer_and_wrench: Chore (Non-breaking Change: Doc updates, pkg upgrades, typos, etc..)
- [x] :nail_care: New Feature (Breaking/Non-breaking Change)

## Issue (if applicable)

https://github.com/shapeshift/web/pull/1808

## Risk

This touches `<AppContext />` so as always with this, we should be very cautious, many things can break.
Effectively, there's two layers of `useEffect`s , each with their relevant protection, so the only risk is overfetching market data in `/assets/:chainId/:assetSubId` routes, which itself is mitigated by the fact that there's caching involved.

Tl;dr big risks, low effective risks

## Testing

- Go to Atom on Osmosis (or any XYZ on Osmosis asset)
- The asset page should load
- There should be no regression on other asset pages

## Screenshots (if applicable)

<img width="1275" alt="image" src="https://user-images.githubusercontent.com/17035424/169406881-487cb996-5c28-452a-b4d8-e0a58e1cf3fb.png">