### PR TITLE
fix: add explicit transactions route

### DIFF
--- a/src/components/Breadcrumbs/Breadcrumbs.tsx
+++ b/src/components/Breadcrumbs/Breadcrumbs.tsx
@@ -28,8 +28,14 @@ const GetAssetName = (props: any) => {
 }
 
 const routes: BreadcrumbsRoute[] = [
-  { path: '/accounts/:accountId', breadcrumb: GetAccountName },
-  { path: '/accounts/:accountId/:assetId', breadcrumb: GetAssetName },
+  {
+    path: '/accounts/:accountId',
+    breadcrumb: GetAccountName,
+    routes: [
+      { path: '/accounts/:accountId/transactions' },
+      { path: '/accounts/:accountId/:assetId', breadcrumb: GetAssetName },
+    ],
+  },
   { path: '/assets/:chainId/:assetSubId', breadcrumb: GetAssetName },
 ]
 


### PR DESCRIPTION
## Description

`react-router-breadcrumbs-hoc` confuses `transactions` path with `:assetId` and tries to render it as asset. Adding explicit `/accounts/:accountId/transactions` route solves this. I also did small refactoring of routes to make them more structured

## Notice

<!-- Before submitting a pull request, please make sure you have answered the following: -->

- [x] Have you followed the guidelines in our [Contributing]('https://github.com/shapeshift/web/CONTRIBUTING.md) guide?
- [x] Have you checked to ensure there aren't other open [Pull Requests](https://github.com/shapeshift/web/pulls) for the same update/change?

## Pull Request Type

- [x] :bug: Bug fix (Non-breaking Change: Fixes an issue)
- [ ] :hammer_and_wrench: Chore (Non-breaking Change: Doc updates, pkg upgrades, typos, etc..)
- [ ] :nail_care: New Feature (Breaking/Non-breaking Change)

## Issue (if applicable)

closes #1781 

## Risk

<!-----------------------------------------------------------------------------
Outline the scope of your changes and the risk associated with them. You must use your discretion as an engineer to determine the potential impact of your changes.

E.g. an upgrade to `hdwallet` or core state management would be considered higher risk, and might require a full regression test. UI or isolated view changes, or something behind a feature flag may have near zero risk. Small bug fixes might require testing isolated to the specific fix.
------------------------------------------------------------------------------>

## Testing

1. Log into app.shapeshift.com and connect to a wallet
2. Go to `Accounts` page and select account
3. Go to accounts transactions page

## Screenshots (if applicable)
![image](https://user-images.githubusercontent.com/101632255/169417680-96871b07-9a43-46b8-b0ef-06689e1e64dd.png)
