### PR TITLE
feat: consistent use of useRouteAssetId

### DIFF
--- a/src/components/TransactionHistory/TransactionsGroupByDate.tsx
+++ b/src/components/TransactionHistory/TransactionsGroupByDate.tsx
@@ -1,11 +1,10 @@
 import { Stack, StackDivider, useColorModeValue } from '@chakra-ui/react'
 import dayjs from 'dayjs'
 import { useMemo } from 'react'
-import { useParams } from 'react-router-dom'
 import { TransactionDate } from 'components/TransactionHistoryRows/TransactionDate'
 import { TransactionRow } from 'components/TransactionHistoryRows/TransactionRow'
 import { useResizeObserver } from 'hooks/useResizeObserver/useResizeObserver'
-import { MatchParams } from 'pages/Assets/Asset'
+import { useRouteAssetId } from 'hooks/useRouteAssetId/useRouteAssetId'
 import { selectAssetById, selectTxDateByIds } from 'state/slices/selectors'
 import { TxId } from 'state/slices/txHistorySlice/txHistorySlice'
 import { useAppSelector } from 'state/store'
@@ -24,8 +23,7 @@ export const TransactionsGroupByDate: React.FC<TransactionsGroupByDateProps> = (
   txIds,
   useCompactMode = false,
 }) => {
-  const params = useParams<MatchParams>()
-  const assetId = `${params.chainId}/${params.assetSubId}`
+  const assetId = useRouteAssetId()
   const asset = useAppSelector(state => selectAssetById(state, assetId))
 
   const { setNode, entry } = useResizeObserver()

--- a/src/hooks/useRouteAssetId/useRouteAssetId.ts
+++ b/src/hooks/useRouteAssetId/useRouteAssetId.ts
@@ -4,7 +4,7 @@ import { matchPath, useLocation } from 'react-router'
 
 export const useRouteAssetId = () => {
   const location = useLocation()
-  const [assetId, setAssetId] = useState<AssetId | null>(null)
+  const [assetId, setAssetId] = useState<AssetId>('')
 
   useEffect(() => {
     // Extract the chainId and assetSubId parts from an /assets route, see src/Routes/RoutesCommon.tsx

--- a/src/pages/Assets/Asset.tsx
+++ b/src/pages/Assets/Asset.tsx
@@ -1,18 +1,14 @@
-import type { ChainId } from '@shapeshiftoss/caip'
-import { useParams } from 'react-router-dom'
 import { Route } from 'Routes/helpers'
 import { AssetAccountDetails } from 'components/AssetAccountDetails'
+import { useRouteAssetId } from 'hooks/useRouteAssetId/useRouteAssetId'
 import { selectAssetById } from 'state/slices/selectors'
 import { useAppSelector } from 'state/store'
 
-export type MatchParams = {
-  chainId: ChainId
-  assetSubId: string
-}
-
 export const Asset = ({ route }: { route?: Route }) => {
-  const params = useParams<MatchParams>()
-  const assetId = `${params.chainId}/${params.assetSubId}`
+  const assetId = useRouteAssetId()
   const asset = useAppSelector(state => selectAssetById(state, assetId))
+
+  if (!asset) return null
+
   return <AssetAccountDetails assetId={asset.assetId} route={route} />
 }

--- a/src/pages/Assets/AssetTxHistory.tsx
+++ b/src/pages/Assets/AssetTxHistory.tsx
@@ -1,14 +1,11 @@
-import { useParams } from 'react-router-dom'
 import { AssetHeader } from 'components/AssetHeader/AssetHeader'
 import { Main } from 'components/Layout/Main'
 import { AssetTransactionHistory } from 'components/TransactionHistory/AssetTransactionHistory'
-
-import { MatchParams } from './Asset'
+import { useRouteAssetId } from 'hooks/useRouteAssetId/useRouteAssetId'
 
 export const AssetTxHistory: React.FC = () => {
-  const params = useParams<MatchParams>()
-  const assetId = `${params.chainId}/${params.assetSubId}`
-  if (!params.assetSubId && !params.chainId) return null
+  const assetId = useRouteAssetId()
+  if (!assetId) return null
 
   return (
     <Main titleComponent={<AssetHeader assetId={assetId} />}>

--- a/src/plugins/cosmos/CosmosAsset.tsx
+++ b/src/plugins/cosmos/CosmosAsset.tsx
@@ -1,23 +1,17 @@
 import { Flex } from '@chakra-ui/react'
-import { useParams } from 'react-router-dom'
 import { Page } from 'components/Layout/Page'
+import { useRouteAssetId } from 'hooks/useRouteAssetId/useRouteAssetId'
 import { LoadingAsset } from 'pages/Assets/LoadingAsset'
 import { selectAssetById, selectMarketDataLoadingById } from 'state/slices/selectors'
 import { useAppSelector } from 'state/store'
 
 import { CosmosAssetAccountDetails } from './CosmosAssetAccountDetails'
 
-export type MatchParams = {
-  assetSubId: string
-  chainRef: string
-}
-
 export const CosmosAsset = () => {
-  const { chainRef, assetSubId } = useParams<MatchParams>()
-  const assetId = `cosmos:${chainRef}/${assetSubId}`
+  const assetId = useRouteAssetId()
   const asset = useAppSelector(state => selectAssetById(state, assetId))
 
-  const loading = useAppSelector(state => selectMarketDataLoadingById(state, assetId))
+  const loading = useAppSelector(state => selectMarketDataLoadingById(state, assetId ?? ''))
 
   return !asset || loading ? (
     <Page key={asset?.assetId}>

--- a/src/plugins/cosmos/CosmostAssetTxHistory.tsx
+++ b/src/plugins/cosmos/CosmostAssetTxHistory.tsx
@@ -1,14 +1,11 @@
-import { useParams } from 'react-router-dom'
 import { AssetHeader } from 'components/AssetHeader/AssetHeader'
 import { Main } from 'components/Layout/Main'
 import { AssetTransactionHistory } from 'components/TransactionHistory/AssetTransactionHistory'
-
-import { MatchParams } from './CosmosAsset'
+import { useRouteAssetId } from 'hooks/useRouteAssetId/useRouteAssetId'
 
 export const CosmosAssetTxHistory: React.FC = () => {
-  const { chainRef, assetSubId } = useParams<MatchParams>()
-  const assetId = `cosmos:${chainRef}/${assetSubId}`
-  if (!assetSubId && !chainRef) return null
+  const assetId = useRouteAssetId()
+  if (!assetId) return null
 
   return (
     <Main titleComponent={<AssetHeader assetId={assetId} />}>


### PR DESCRIPTION
## Description

This uses the newly added `useRouteAssetId` hook consistently instead of de/serializing it from `chainId` and `assetSubId`. Also removes the now unused `MatchParams` types. 

https://github.com/shapeshift/web/blob/18a70b7ab1324595a4a1db4f7dabc834eda0c500/src/hooks/useRouteAssetId/useRouteAssetId.ts#L5-L24

## Note

This isn't updated in `<ConnectWallet />` yet, which has some custom decoding logic, see https://github.com/shapeshift/web/commit/a705b74e7ac38c89c714b83b63637259095cf596.
I'll add it there in a follow-up PR as it's potentially bug-prone and should be tested in isolation.

## Notice

<!-- Before submitting a pull request, please make sure you have answered the following: -->

- [x] Have you followed the guidelines in our [Contributing]('https://github.com/shapeshift/web/CONTRIBUTING.md) guide?
- [x] Have you checked to ensure there aren't other open [Pull Requests](https://github.com/shapeshift/web/pulls) for the same update/change?

## Pull Request Type

- [ ] :bug: Bug fix (Non-breaking Change: Fixes an issue)
- [ ] :hammer_and_wrench: Chore (Non-breaking Change: Doc updates, pkg upgrades, typos, etc..)
- [x] :nail_care: New Feature (Breaking/Non-breaking Change)

## Issue (if applicable)

N/A

## Risk

This has implications on Tx history (both the page and the right-side component) and Asset pages. Tested it out against previous implementation and we're getting the same `assetId`. 

## Testing

Tested on MM/Native/Portis

- Go to any asset page, it shouldn't produce any regression
- Go to Cosmos/IBC asset page, it shouldn't produce any regression
- Go to asset Tx history component and route, it shouldn't produce any regression
- Asset page breadcrumbs should show no regressions
- Reconnect KeepKey on an account/asset page should show no regressions (wasn't able to test it, but I didn't touch the code related to it, see Note section above)
- Tx history and asset loading states should show no regressions

## Screenshots (if applicable)
