### PR TITLE
fix: default pair for unsupported assets

### DIFF
--- a/package.json
+++ b/package.json
@@ -29,7 +29,7 @@
     "@shapeshiftoss/investor-yearn": "^2.0.0",
     "@shapeshiftoss/logger": "^1.1.2",
     "@shapeshiftoss/market-service": "^4.0.0",
-    "@shapeshiftoss/swapper": "^5.0.0",
+    "@shapeshiftoss/swapper": "^5.1.1",
     "@shapeshiftoss/types": "^4.1.0",
     "@shapeshiftoss/unchained-client": "^8.0.0",
     "@visx/axis": "^2.6.0",

--- a/package.json
+++ b/package.json
@@ -15,7 +15,7 @@
     "@metamask/detect-provider": "^1.2.0",
     "@reduxjs/toolkit": "^1.8.0",
     "@shapeshiftoss/asset-service": "^4.1.0",
-    "@shapeshiftoss/caip": "^4.0.0",
+    "@shapeshiftoss/caip": "^4.0.1",
     "@shapeshiftoss/chain-adapters": "^4.0.0",
     "@shapeshiftoss/errors": "^1.1.1",
     "@shapeshiftoss/hdwallet-core": "^1.21.2",

--- a/src/components/Trade/TradeInput.tsx
+++ b/src/components/Trade/TradeInput.tsx
@@ -56,7 +56,7 @@ export const TradeInput = ({ history }: RouterProps) => {
   )
   const hasValidTradeBalance = bnOrZero(sellAssetBalance).gte(bnOrZero(sellTradeAsset?.amount))
   const hasValidBalance = bnOrZero(sellAssetBalance).gt(0)
-  const hasValidSellAmount = bnOrZero(sellTradeAsset.amount).gt(0)
+  const hasValidSellAmount = bnOrZero(sellTradeAsset?.amount).gt(0)
 
   const feeAssetBalance = useAppSelector(state =>
     feeAsset

--- a/src/components/Trade/hooks/useSwapper/useSwapper.ts
+++ b/src/components/Trade/hooks/useSwapper/useSwapper.ts
@@ -130,7 +130,10 @@ export const useSwapper = () => {
       buyAssetId: buyAsset.assetId,
       sellAssetId: sellAsset.assetId,
     })
-    const result = await swapper?.buildTrade({
+
+    if (!swapper) throw new Error('no swapper available')
+
+    const result = await swapper.buildTrade({
       sellAmount: amount,
       sellAsset,
       buyAsset,
@@ -153,6 +156,7 @@ export const useSwapper = () => {
       buyAssetId: trade.buyAsset.assetId,
       sellAssetId: trade.sellAsset.assetId,
     })
+    if (!swapper) throw new Error('no swapper available')
     return swapper.executeTrade({ trade, wallet })
   }
 
@@ -163,6 +167,8 @@ export const useSwapper = () => {
           buyAssetId: buyAsset.assetId,
           sellAssetId: sellAsset.assetId,
         })
+
+        if (!swapper) throw new Error('no swapper available')
 
         const { getUsdRate } = swapper
 
@@ -265,6 +271,8 @@ export const useSwapper = () => {
       buyAssetId: quote.buyAsset.assetId,
       sellAssetId: quote.sellAsset.assetId,
     })
+
+    if (!swapper) throw new Error('no swapper available')
     const { approvalNeeded } = await swapper.approvalNeeded({ quote, wallet })
     return approvalNeeded
   }
@@ -274,6 +282,8 @@ export const useSwapper = () => {
       buyAssetId: quote.buyAsset.assetId,
       sellAssetId: quote.sellAsset.assetId,
     })
+
+    if (!swapper) throw new Error('no swapper available')
     const txid = await swapper.approveInfinite({ quote, wallet })
     return txid
   }

--- a/src/components/Trade/hooks/useTradeRoutes/useTradeRoutes.test.tsx
+++ b/src/components/Trade/hooks/useTradeRoutes/useTradeRoutes.test.tsx
@@ -96,7 +96,7 @@ describe('useTradeRoutes', () => {
     const { result, setValue, updateQuote } = setup({ sellAmount: '234' })
     await result.current.handleBuyClick(mockFOX)
     expect(setValue).toHaveBeenCalledWith('buyAsset.asset', mockFOX)
-    expect(setValue).toHaveBeenCalledWith('sellAsset.asset', mockETH)
+    expect(setValue).toHaveBeenCalledWith('sellAsset.asset', WETH)
     expect(updateQuote).toHaveBeenCalled()
   })
   it('swaps when same asset on buy click', async () => {

--- a/src/components/Trade/hooks/useTradeRoutes/useTradeRoutes.test.tsx
+++ b/src/components/Trade/hooks/useTradeRoutes/useTradeRoutes.test.tsx
@@ -1,4 +1,3 @@
-import { SwapperType } from '@shapeshiftoss/types'
 import { renderHook } from '@testing-library/react-hooks'
 import { useFormContext, useWatch } from 'react-hook-form'
 import { ETH as mockETH, FOX as mockFOX, WETH } from 'test/constants'

--- a/src/components/Trade/hooks/useTradeRoutes/useTradeRoutes.test.tsx
+++ b/src/components/Trade/hooks/useTradeRoutes/useTradeRoutes.test.tsx
@@ -1,4 +1,3 @@
-import { SwapperManager } from '@shapeshiftoss/swapper'
 import { SwapperType } from '@shapeshiftoss/types'
 import { renderHook } from '@testing-library/react-hooks'
 import { useFormContext, useWatch } from 'react-hook-form'
@@ -31,10 +30,11 @@ function setup({ buyAmount, sellAmount }: { buyAmount?: string; sellAmount?: str
   ;(useWatch as jest.Mock<unknown>).mockImplementation(() => [{}, {}])
   ;(useSwapper as jest.Mock<unknown>).mockImplementation(() => ({
     updateQuote,
-    getBestSwapper: () => SwapperType.Zrx,
     getDefaultPair: () => [mockETH.assetId, mockFOX.assetId],
+    swapperManager: {
+      getBestSwapper: jest.fn(),
+    },
   }))
-  ;(SwapperManager as jest.Mock<unknown>).mockImplementation(() => ({}))
   ;(useFormContext as jest.Mock<unknown>).mockImplementation(() => ({
     setValue,
     getValues: jest.fn((search: string) => {

--- a/src/components/Trade/hooks/useTradeRoutes/useTradeRoutes.test.tsx
+++ b/src/components/Trade/hooks/useTradeRoutes/useTradeRoutes.test.tsx
@@ -1,3 +1,4 @@
+import { SwapperManager } from '@shapeshiftoss/swapper'
 import { SwapperType } from '@shapeshiftoss/types'
 import { renderHook } from '@testing-library/react-hooks'
 import { useFormContext, useWatch } from 'react-hook-form'
@@ -16,6 +17,7 @@ jest.mock('react-router-dom', () => ({
 jest.mock('lib/web3-instance')
 jest.mock('react-hook-form')
 jest.mock('../useSwapper/useSwapper')
+jest.mock('@shapeshiftoss/swapper')
 jest.mock('state/slices/selectors', () => ({
   selectAssets: () => ({
     'eip155:1/slip44:60': mockETH,
@@ -32,6 +34,7 @@ function setup({ buyAmount, sellAmount }: { buyAmount?: string; sellAmount?: str
     getBestSwapper: () => SwapperType.Zrx,
     getDefaultPair: () => [mockETH.assetId, mockFOX.assetId],
   }))
+  ;(SwapperManager as jest.Mock<unknown>).mockImplementation(() => ({}))
   ;(useFormContext as jest.Mock<unknown>).mockImplementation(() => ({
     setValue,
     getValues: jest.fn((search: string) => {

--- a/src/components/Trade/hooks/useTradeRoutes/useTradeRoutes.ts
+++ b/src/components/Trade/hooks/useTradeRoutes/useTradeRoutes.ts
@@ -43,7 +43,8 @@ export const useTradeRoutes = (
       })
 
       let isSupportedPair = false
-      // check pair is valid
+      // TODO update swapper to have an official way to validate a pair is supported.
+      // This works for now
       try {
         if (bestSwapper) {
           await bestSwapper.getUsdRate({ ...assets[buyAssetToCheck] })

--- a/src/components/Trade/hooks/useTradeRoutes/useTradeRoutes.ts
+++ b/src/components/Trade/hooks/useTradeRoutes/useTradeRoutes.ts
@@ -46,6 +46,7 @@ export const useTradeRoutes = (
       // check pair is valid
       try {
         if (bestSwapper) {
+          await bestSwapper.getUsdRate({ ...assets[buyAssetToCheck] })
           isSupportedPair = true
         }
       } catch (e) {}

--- a/src/components/Trade/hooks/useTradeRoutes/useTradeRoutes.ts
+++ b/src/components/Trade/hooks/useTradeRoutes/useTradeRoutes.ts
@@ -1,5 +1,4 @@
 import { AssetId } from '@shapeshiftoss/caip'
-import { SwapperManager } from '@shapeshiftoss/swapper'
 import { Asset, SupportedChainIds } from '@shapeshiftoss/types'
 import isEmpty from 'lodash/isEmpty'
 import { useCallback, useEffect } from 'react'
@@ -13,7 +12,6 @@ import { selectAssets } from 'state/slices/selectors'
 import { useSwapper } from '../useSwapper/useSwapper'
 
 const ETHEREUM_ASSET_ID = 'eip155:1/slip44:60'
-const swapperManager = new SwapperManager()
 
 export const useTradeRoutes = (
   selectedBuyAssetId?: AssetId,
@@ -23,7 +21,7 @@ export const useTradeRoutes = (
 } => {
   const history = useHistory()
   const { getValues, setValue } = useFormContext<TradeState<SupportedChainIds>>()
-  const { updateQuote, getDefaultPair } = useSwapper()
+  const { updateQuote, getDefaultPair, swapperManager } = useSwapper()
   const buyTradeAsset = getValues('buyAsset')
   const sellTradeAsset = getValues('sellAsset')
   const assets = useSelector(selectAssets)
@@ -37,10 +35,10 @@ export const useTradeRoutes = (
       const [defaultSellAssetId, defaultBuyAssetId] = getDefaultPair()
       const sellAsset = assets[defaultSellAssetId]
 
-      const buyAssetToCheck = selectedBuyAssetId ?? defaultBuyAssetId
+      const buyAssetToCheckId = selectedBuyAssetId ?? defaultBuyAssetId
 
       const bestSwapper = await swapperManager.getBestSwapper({
-        buyAssetId: buyAssetToCheck,
+        buyAssetId: buyAssetToCheckId,
         sellAssetId: defaultSellAssetId,
       })
 
@@ -49,12 +47,12 @@ export const useTradeRoutes = (
       // This works for now
       try {
         if (bestSwapper) {
-          await bestSwapper.getUsdRate({ ...assets[buyAssetToCheck] })
+          await bestSwapper.getUsdRate({ ...assets[buyAssetToCheckId] })
           isSupportedPair = true
         }
       } catch (e) {}
 
-      const buyAssetId = isSupportedPair ? buyAssetToCheck : defaultBuyAssetId
+      const buyAssetId = isSupportedPair ? buyAssetToCheckId : defaultBuyAssetId
 
       const buyAsset = assets[buyAssetId]
 

--- a/src/components/Trade/hooks/useTradeRoutes/useTradeRoutes.ts
+++ b/src/components/Trade/hooks/useTradeRoutes/useTradeRoutes.ts
@@ -35,7 +35,11 @@ export const useTradeRoutes = (
       const [defaultSellAssetId, defaultBuyAssetId] = getDefaultPair()
       const sellAsset = assets[defaultSellAssetId]
 
-      const buyAssetToCheckId = selectedBuyAssetId ?? defaultBuyAssetId
+      let preBuyAssetToCheckId = selectedBuyAssetId ?? defaultBuyAssetId
+
+      // make sure the same buy and sell assets arent selected
+      const buyAssetToCheckId =
+        preBuyAssetToCheckId === defaultSellAssetId ? defaultBuyAssetId : preBuyAssetToCheckId
 
       const bestSwapper = await swapperManager.getBestSwapper({
         buyAssetId: buyAssetToCheckId,

--- a/src/components/Trade/hooks/useTradeRoutes/useTradeRoutes.ts
+++ b/src/components/Trade/hooks/useTradeRoutes/useTradeRoutes.ts
@@ -46,7 +46,7 @@ export const useTradeRoutes = (
 
       const supportedBuyAssetId = isSupportedPair ? buyAssetId : defaultBuyAssetId
 
-      const buyAsset = assets[supportedBuyAssetId as string]
+      const buyAsset = assets[supportedBuyAssetId]
 
       if (sellAsset && buyAsset) {
         setValue('buyAsset.asset', buyAsset)

--- a/src/components/Trade/hooks/useTradeRoutes/useTradeRoutes.ts
+++ b/src/components/Trade/hooks/useTradeRoutes/useTradeRoutes.ts
@@ -1,4 +1,5 @@
 import { AssetId } from '@shapeshiftoss/caip'
+import { SwapperManager } from '@shapeshiftoss/swapper'
 import { Asset, SupportedChainIds } from '@shapeshiftoss/types'
 import isEmpty from 'lodash/isEmpty'
 import { useCallback, useEffect } from 'react'
@@ -12,6 +13,7 @@ import { selectAssets } from 'state/slices/selectors'
 import { useSwapper } from '../useSwapper/useSwapper'
 
 const ETHEREUM_ASSET_ID = 'eip155:1/slip44:60'
+const swapperManager = new SwapperManager()
 
 export const useTradeRoutes = (
   selectedBuyAssetId?: AssetId,
@@ -21,7 +23,7 @@ export const useTradeRoutes = (
 } => {
   const history = useHistory()
   const { getValues, setValue } = useFormContext<TradeState<SupportedChainIds>>()
-  const { updateQuote, getDefaultPair, swapperManager } = useSwapper()
+  const { updateQuote, getDefaultPair } = useSwapper()
   const buyTradeAsset = getValues('buyAsset')
   const sellTradeAsset = getValues('sellAsset')
   const assets = useSelector(selectAssets)

--- a/src/components/Trade/hooks/useTradeRoutes/useTradeRoutes.ts
+++ b/src/components/Trade/hooks/useTradeRoutes/useTradeRoutes.ts
@@ -14,7 +14,7 @@ import { useSwapper } from '../useSwapper/useSwapper'
 const ETHEREUM_ASSET_ID = 'eip155:1/slip44:60'
 
 export const useTradeRoutes = (
-  selectedBuyAssetId?: AssetId,
+  routeBuyAssetId?: AssetId,
 ): {
   handleSellClick: (asset: Asset) => Promise<void>
   handleBuyClick: (asset: Asset) => Promise<void>
@@ -35,7 +35,7 @@ export const useTradeRoutes = (
       const [defaultSellAssetId, defaultBuyAssetId] = getDefaultPair()
       const sellAsset = assets[defaultSellAssetId]
 
-      let preBuyAssetToCheckId = selectedBuyAssetId ?? defaultBuyAssetId
+      const preBuyAssetToCheckId = routeBuyAssetId ?? defaultBuyAssetId
 
       // make sure the same buy and sell assets arent selected
       const buyAssetToCheckId =
@@ -46,15 +46,17 @@ export const useTradeRoutes = (
         sellAssetId: defaultSellAssetId,
       })
 
-      let isSupportedPair = false
       // TODO update swapper to have an official way to validate a pair is supported.
       // This works for now
-      try {
-        if (bestSwapper) {
-          await bestSwapper.getUsdRate({ ...assets[buyAssetToCheckId] })
-          isSupportedPair = true
-        }
-      } catch (e) {}
+      const isSupportedPair = await (async () => {
+        try {
+          if (bestSwapper) {
+            await bestSwapper.getUsdRate({ ...assets[buyAssetToCheckId] })
+            return true
+          }
+        } catch (e) {}
+        return false
+      })()
 
       const buyAssetId = isSupportedPair ? buyAssetToCheckId : defaultBuyAssetId
 
@@ -75,7 +77,7 @@ export const useTradeRoutes = (
     } catch (e) {
       console.warn(e)
     }
-  }, [assets, feeAsset, getDefaultPair, selectedBuyAssetId, setValue, swapperManager, updateQuote])
+  }, [assets, feeAsset, getDefaultPair, routeBuyAssetId, setValue, swapperManager, updateQuote])
 
   useEffect(() => {
     setDefaultAssets()

--- a/src/components/Trade/hooks/useTradeRoutes/useTradeRoutes.ts
+++ b/src/components/Trade/hooks/useTradeRoutes/useTradeRoutes.ts
@@ -81,7 +81,7 @@ export const useTradeRoutes = (
 
   useEffect(() => {
     setDefaultAssets()
-  }, [assets, feeAsset]) // eslint-disable-line react-hooks/exhaustive-deps
+  }, [assets, feeAsset, routeBuyAssetId]) // eslint-disable-line react-hooks/exhaustive-deps
 
   const handleSellClick = useCallback(
     async (asset: Asset) => {

--- a/src/components/Trade/hooks/useTradeRoutes/useTradeRoutes.ts
+++ b/src/components/Trade/hooks/useTradeRoutes/useTradeRoutes.ts
@@ -1,5 +1,4 @@
 import { AssetId } from '@shapeshiftoss/caip'
-import { SwapperManager } from '@shapeshiftoss/swapper'
 import { Asset, SupportedChainIds } from '@shapeshiftoss/types'
 import isEmpty from 'lodash/isEmpty'
 import { useCallback, useEffect } from 'react'

--- a/yarn.lock
+++ b/yarn.lock
@@ -4061,9 +4061,9 @@
     long "^4.0.0"
 
 "@shapeshiftoss/swapper@^5.0.0":
-  version "5.0.1"
-  resolved "https://registry.yarnpkg.com/@shapeshiftoss/swapper/-/swapper-5.0.1.tgz#434f54d7babd12cd7569cb36cd7796d23448e0cb"
-  integrity sha512-7NiRF322Pd03GwkF1X8KG02OHjDXgoTEyYdYaF0gK2QDOBnBMWGNqHJe0iW71wzLRS1nSpNYytobod8cvhan1g==
+  version "5.1.1"
+  resolved "https://registry.yarnpkg.com/@shapeshiftoss/swapper/-/swapper-5.1.1.tgz#3e9cee411b9179a8efe77a6442bfb1761acb3e0e"
+  integrity sha512-tJ9VnoyxPaGE19TV+FYb2a5yEumK8PZ53o30b2A+Fg7mNjzjdlmZNbCh6VAveGminu6r3uqODJ6jKgkdnSTKjA==
   dependencies:
     axios "^0.26.0"
     bignumber.js "^9.0.1"
@@ -11703,9 +11703,9 @@ follow-redirects@1.5.10:
     debug "=3.1.0"
 
 follow-redirects@^1.0.0, follow-redirects@^1.10.0, follow-redirects@^1.14.0, follow-redirects@^1.14.8:
-  version "1.14.9"
-  resolved "https://registry.yarnpkg.com/follow-redirects/-/follow-redirects-1.14.9.tgz#dd4ea157de7bfaf9ea9b3fbd85aa16951f78d8d7"
-  integrity sha512-MQDfihBQYMcyy5dhRDJUHcw7lb2Pv/TuE6xP1vyraLukNDHKbDxDNaOE3NbCAdKQApno+GPRyo1YAp89yCjK4w==
+  version "1.15.0"
+  resolved "https://registry.yarnpkg.com/follow-redirects/-/follow-redirects-1.15.0.tgz#06441868281c86d0dda4ad8bdaead2d02dca89d4"
+  integrity sha512-aExlJShTV4qOUOL7yF1U5tvLCB0xQuudbf6toyYA0E/acBNw71mvjFTnLaRp50aQaYocMR0a/RMMBIHeZnGyjQ==
 
 for-in@^1.0.2:
   version "1.0.2"

--- a/yarn.lock
+++ b/yarn.lock
@@ -4060,7 +4060,7 @@
     google-protobuf "^3.17.0"
     long "^4.0.0"
 
-"@shapeshiftoss/swapper@^5.0.0":
+"@shapeshiftoss/swapper@^5.1.1":
   version "5.1.1"
   resolved "https://registry.yarnpkg.com/@shapeshiftoss/swapper/-/swapper-5.1.1.tgz#3e9cee411b9179a8efe77a6442bfb1761acb3e0e"
   integrity sha512-tJ9VnoyxPaGE19TV+FYb2a5yEumK8PZ53o30b2A+Fg7mNjzjdlmZNbCh6VAveGminu6r3uqODJ6jKgkdnSTKjA==

--- a/yarn.lock
+++ b/yarn.lock
@@ -3831,10 +3831,10 @@
     tsoa "^3.4.0"
     ws "^8.3.0"
 
-"@shapeshiftoss/caip@^4.0.0":
-  version "4.0.0"
-  resolved "https://registry.yarnpkg.com/@shapeshiftoss/caip/-/caip-4.0.0.tgz#8d854a17dcfac3354f860322795bd52dff0886b4"
-  integrity sha512-RQrcjneQ9HbirBrFE8AH6aM5uSw0MudYeamYR66rtzvZnaOpIc2t8dwHLqgQ0Y/DVi2XGyN6jQkcdjcMi64ERA==
+"@shapeshiftoss/caip@^4.0.1":
+  version "4.0.1"
+  resolved "https://registry.yarnpkg.com/@shapeshiftoss/caip/-/caip-4.0.1.tgz#e1afdfafd540769c2d9ee9c2236fbbf4136467f6"
+  integrity sha512-kwb2S3QUKLJ5lPhumi6FYm1x9/bhzjJqPVR4NvEqU6kQgE03Ovf4zVT6FWxWPqcqNGK6w4DJIsmvy2YBRmdCEQ==
 
 "@shapeshiftoss/chain-adapters@^4.0.0":
   version "4.0.1"


### PR DESCRIPTION
## Description

Buy asset on the default pair defaults to whatever page the user is on. Some assets (foxy) are unsupported by the swapper and cause problems when visiting those pages.

We now check to make sure we can support the pair and default to fox otherwise

Also check to make sure swapper exists before making swapper calls

## Notice

- [ ] Have you followed the guidelines in our [Contributing]('https://github.com/shapeshift/web/CONTRIBUTING.md) guide?
- [ ] Have you checked to ensure there aren't other open [Pull Requests](https://github.com/shapeshift/web/pulls) for the same update/change?

## Pull Request Type

- [ ] :bug: Bug fix (Non-breaking Change: Fixes an issue)
- [ ] :hammer_and_wrench: Chore (Non-breaking Change: Doc updates, pkg upgrades, typos, etc..)
- [ ] :nail_care: New Feature (Breaking/Non-breaking Change)

## Risk

Low risk, fixes foxy asset page

## Testing

Go to foxy page and see that trade area isnt forever loading a quote.

## Screenshots (if applicable)
![Screen Shot 2022-05-20 at 10 41 25 AM](https://user-images.githubusercontent.com/6187559/169573985-bf50818e-57cc-41cd-8f32-2c6de5a32a64.png)


