### PR TITLE
chore: replace hard coded fee asset

### DIFF
--- a/src/components/Trade/hooks/useTradeRoutes/useTradeRoutes.test.tsx
+++ b/src/components/Trade/hooks/useTradeRoutes/useTradeRoutes.test.tsx
@@ -21,6 +21,9 @@ jest.mock('state/slices/selectors', () => ({
     'eip155:1/slip44:60': mockETH,
     'eip155:1/erc20:0xc770eefad204b5180df6a14ee197d99d808ee52d': mockFOX,
   }),
+  selectAssetById: () => ({
+    'eip155:1/slip44:60': mockETH,
+  }),
 }))
 
 function setup({ buyAmount, sellAmount }: { buyAmount?: string; sellAmount?: string }) {

--- a/src/components/Trade/hooks/useTradeRoutes/useTradeRoutes.ts
+++ b/src/components/Trade/hooks/useTradeRoutes/useTradeRoutes.ts
@@ -23,7 +23,7 @@ export const useTradeRoutes = (
   const { updateQuote, getDefaultPair, swapperManager } = useSwapper()
   const buyTradeAsset = getValues('buyAsset')
   const sellTradeAsset = getValues('sellAsset')
-  const feeAssetId = chainIdToFeeAssetId(sellTradeAsset.asset.chainId)
+  const feeAssetId = chainIdToFeeAssetId(sellTradeAsset?.asset?.chainId ?? 'eip155:1')
   const feeAsset = useAppSelector(state => selectAssetById(state, feeAssetId))
   const assets = useSelector(selectAssets)
 

--- a/src/components/Trade/hooks/useTradeRoutes/useTradeRoutes.ts
+++ b/src/components/Trade/hooks/useTradeRoutes/useTradeRoutes.ts
@@ -1,4 +1,4 @@
-import { AssetId } from '@shapeshiftoss/caip'
+import { AssetId, chainIdToFeeAssetId } from '@shapeshiftoss/caip'
 import { Asset, SupportedChainIds } from '@shapeshiftoss/types'
 import isEmpty from 'lodash/isEmpty'
 import { useCallback, useEffect } from 'react'
@@ -7,11 +7,10 @@ import { useSelector } from 'react-redux'
 import { useHistory } from 'react-router-dom'
 import { TradeAmountInputField, TradeRoutePaths, TradeState } from 'components/Trade/types'
 import { bnOrZero } from 'lib/bignumber/bignumber'
-import { selectAssets } from 'state/slices/selectors'
+import { selectAssetById, selectAssets } from 'state/slices/selectors'
+import { useAppSelector } from 'state/store'
 
 import { useSwapper } from '../useSwapper/useSwapper'
-
-const ETHEREUM_ASSET_ID = 'eip155:1/slip44:60'
 
 export const useTradeRoutes = (
   routeBuyAssetId?: AssetId,
@@ -24,8 +23,9 @@ export const useTradeRoutes = (
   const { updateQuote, getDefaultPair, swapperManager } = useSwapper()
   const buyTradeAsset = getValues('buyAsset')
   const sellTradeAsset = getValues('sellAsset')
+  const feeAssetId = chainIdToFeeAssetId(sellTradeAsset.asset.chainId)
+  const feeAsset = useAppSelector(state => selectAssetById(state, feeAssetId))
   const assets = useSelector(selectAssets)
-  const feeAsset = assets[ETHEREUM_ASSET_ID]
 
   const setDefaultAssets = useCallback(async () => {
     // wait for assets to be loaded


### PR DESCRIPTION
## Description

Replace hard coded ETH feeAsset to become dynamic based on chain id.

## Notice

<!-- Before submitting a pull request, please make sure you have answered the following: -->

- [x] Have you followed the guidelines in our [Contributing]('https://github.com/shapeshift/web/CONTRIBUTING.md) guide?
- [x] Have you checked to ensure there aren't other open [Pull Requests](https://github.com/shapeshift/web/pulls) for the same update/change?

## Pull Request Type

- [ ] :bug: Bug fix (Non-breaking Change: Fixes an issue)
- [x] :hammer_and_wrench: Chore (Non-breaking Change: Doc updates, pkg upgrades, typos, etc..)
- [ ] :nail_care: New Feature (Breaking/Non-breaking Change)

## Issue (if applicable)

closes #1728 (this closes out the last comment that was apart of this work)

## Risk

Updating a trade on load could be broken if we don't support a specific chain for an asset, but given the assets are hard coded to chains we support this should not happen.

## Testing

Checking if an initial trade quote is supplied on load of the application.

## Screenshots (if applicable)
