### PR TITLE
feat: add a governance fetching service

### DIFF
--- a/src/assets/translations/en/main.json
+++ b/src/assets/translations/en/main.json
@@ -995,6 +995,8 @@
       "balance": "Balance",
       "getStarted": "Get Started",
       "currentPrice": "Current Price"
+      "governanceTitle": "Governance",
+      "seeAllProposals": "See All Proposals"
     }
   }
 }

--- a/src/assets/translations/en/main.json
+++ b/src/assets/translations/en/main.json
@@ -994,7 +994,7 @@
       "currentApy": "Current APY",
       "balance": "Balance",
       "getStarted": "Get Started",
-      "currentPrice": "Current Price"
+      "currentPrice": "Current Price",
       "governanceTitle": "Governance",
       "seeAllProposals": "See All Proposals"
     }

--- a/src/plugins/foxPage/hooks/getGovernanceData.ts
+++ b/src/plugins/foxPage/hooks/getGovernanceData.ts
@@ -1,0 +1,63 @@
+import axios from 'axios'
+import { useEffect, useState } from 'react'
+import { bnOrZero } from 'lib/bignumber/bignumber'
+
+type BoardroomGovernanceData = Array<{
+  currentState: string
+  title: string
+  choices: Array<string>
+  results: Array<{ total: number; choice: number }>
+  refId: string
+}>
+
+const BOARDROOM_API_BASE_URL = 'https://api.boardroom.info/v1/protocols/shapeshift'
+export const BOARDROOM_APP_BASE_URL = 'https://boardroom.io/shapeshift'
+
+const parseGovernanceData = (governanceData: BoardroomGovernanceData) => {
+  const activeProposals = governanceData.filter(data => data.currentState === 'active')
+  const proposals = activeProposals.length ? activeProposals : [governanceData[0]]
+
+  return proposals.map(({ title, choices, results, refId }) => {
+    const totalResults = results.reduce((acc, currentResult) => {
+      acc = acc.plus(currentResult.total)
+      return acc
+    }, bnOrZero('0'))
+
+    return {
+      refId,
+      title,
+      choices,
+      results: results.map(result => ({
+        absolute: result.total,
+        percent: bnOrZero(result.total).div(totalResults).toString(),
+      })),
+    }
+  })
+}
+
+export const useGetGovernanceData = () => {
+  const [data, setData] = useState<ReturnType<typeof parseGovernanceData>>([])
+  const [error, setError] = useState<any>()
+  const [loaded, setLoaded] = useState<boolean>(false)
+
+  useEffect(() => {
+    const loadGovernanceData = async () => {
+      try {
+        const response = await axios.get<{ data: BoardroomGovernanceData }>(
+          `${BOARDROOM_API_BASE_URL}/proposals`,
+        )
+        const governanceData = response?.data?.data
+        const parsedGovernanceData = parseGovernanceData(governanceData)
+        setData(parsedGovernanceData)
+      } catch (e) {
+        setError(e)
+      } finally {
+        setLoaded(true)
+      }
+    }
+
+    loadGovernanceData()
+  }, [])
+
+  return { data, error, loaded }
+}


### PR DESCRIPTION
## Description

This adds a service (hook) fetching the governance data.
This doesn't add the governance component yet, although the wired up component is already available in the `foxpage-governance` branch https://github.com/shapeshift/web/commit/18083d9a479eab7dcc04a4482198a958c7ac5a1a
Wire up will be about committing the aforementioned component used as app code.

## Notice

<!-- Before submitting a pull request, please make sure you have answered the following: -->

- [x] Have you followed the guidelines in our [Contributing]('https://github.com/shapeshift/web/CONTRIBUTING.md) guide?
- [x] Have you checked to ensure there aren't other open [Pull Requests](https://github.com/shapeshift/web/pulls) for the same update/change?

## Pull Request Type

- [ ] :bug: Bug fix (Non-breaking Change: Fixes an issue)
- [ ] :hammer_and_wrench: Chore (Non-breaking Change: Doc updates, pkg upgrades, typos, etc..)
- [x] :nail_care: New Feature (Breaking/Non-breaking Change)

## Issue (if applicable)

Partially tackles #1828

## Risk

N/A

## Testing

- Run FoxPage Layout story on storybook
- The last governance proposal should be shown, with working links in title and "See all proposals"


## Screenshots (if applicable)

<img width="1001" alt="image" src="https://user-images.githubusercontent.com/17035424/170102867-50d4a144-af5e-411d-b6cf-93d46d153969.png">