### PR TITLE
feat: revert of the revert of "fix: interpolation on english fallback…

### DIFF
--- a/src/context/I18nProvider/I18nProvider.tsx
+++ b/src/context/I18nProvider/I18nProvider.tsx
@@ -1,4 +1,5 @@
 import get from 'lodash/get'
+import { InterpolationOptions, transformPhrase } from 'node-polyglot'
 import { I18n } from 'react-polyglot'
 import { translations } from 'assets/translations'
 import { selectSelectedLocale } from 'state/slices/selectors'
@@ -7,7 +8,10 @@ import { useAppSelector } from 'state/store'
 export const I18nProvider = ({ children }: { children: React.ReactNode }) => {
   const locale: string = useAppSelector(selectSelectedLocale)
   const messages = translations[locale]
-  const onMissingKey = (key: string) => get(translations['en'], key)
+  const onMissingKey = (key: string, substitutions?: InterpolationOptions) => {
+    const translation = get(translations['en'], key)
+    return translation ? transformPhrase(translation, substitutions) : key
+  }
   return (
     <I18n locale={locale} messages={messages} allowMissing={true} onMissingKey={onMissingKey}>
       {children}


### PR DESCRIPTION
… (#1858)"

This reverts commit 631f032491a1347fd83f33f36e2f3bb05dafe3d1.

In addition to the original commit handling substitutions on missing translations that fallback to English, this also returns the original translation key in case of non-existing translation entry for it, the same as node-polyglot/react-polyglot would do natively.

## Description

This handles interpolations on missing translation strings that fallback to English
- Uses subtitutions object to construct a properly interpolated string
- If no entry is available for said translation, falls back to the raw translation key

## Notice

<!-- Before submitting a pull request, please make sure you have answered the following: -->

- [x] Have you followed the guidelines in our [Contributing]('https://github.com/shapeshift/web/CONTRIBUTING.md) guide?
- [x] Have you checked to ensure there aren't other open [Pull Requests](https://github.com/shapeshift/web/pulls) for the same update/change?

## Pull Request Type

- [ ] :bug: Bug fix (Non-breaking Change: Fixes an issue)
- [ ] :hammer_and_wrench: Chore (Non-breaking Change: Doc updates, pkg upgrades, typos, etc..)
- [x] :nail_care: New Feature (Breaking/Non-breaking Change)

## Issue (if applicable)

closes #1857

## Risk

None, fixes the missing interpolations while bringing back the original polyglot behavior and avoiding the whole app crashing on missing ones.

## Testing

### Happy Path with substitutions

- Switch to Russian language
- Try one of the untranslated keys from the issue (Cosmos Get Started / ETH-FOX CTA)
- Substitutions should be made and the same text should be rendered as with English translations

### Happy Path without substitutions

- Translations without substitutions should still work the same way as before

### Sad Path without substitutions

- The original translation string should be shown

## Screenshots (if applicable)

<img width="485" alt="image" src="https://user-images.githubusercontent.com/17035424/170291091-ed074da1-53fe-43c9-a8e9-683664dc310b.png">
<img width="446" alt="image" src="https://user-images.githubusercontent.com/17035424/169590288-1b1b1d61-59f2-4585-b99b-f498bf0c64b8.png">
<img width="765" alt="image" src="https://user-images.githubusercontent.com/17035424/169590354-6966ebf3-98df-4192-8ba4-b71ca7e2ee49.png">