### PR TITLE
fix: add missing translation entries for WETH parser

### DIFF
--- a/src/assets/translations/en/main.json
+++ b/src/assets/translations/en/main.json
@@ -315,6 +315,12 @@
     "amount": "Amount",
     "for": "for",
     "parser": {
+      "weth": {
+        "deposit": "Deposit",
+        "approve": "Approve",
+        "withdraw": "Withdraw",
+        "receive": "Receive"
+      },
       "yearn": {
         "deposit": "Deposit",
         "approve": "Approve",

--- a/src/assets/translations/es/main.json
+++ b/src/assets/translations/es/main.json
@@ -304,6 +304,12 @@
     "amount": "Cantidad",
     "for": "para",
     "parser": {
+      "weth": {
+        "deposit": "Depositar",
+        "approve": "Aprobar",
+        "withdraw": "Retirar",
+        "receive": "Recibir"
+      },
       "yearn": {
         "deposit": "Depositar",
         "approve": "Aprobar",

--- a/src/assets/translations/id/main.json
+++ b/src/assets/translations/id/main.json
@@ -313,6 +313,12 @@
     "amount": "Jumlah",
     "for": "Untuk",
     "parser": {
+      "weth": {
+        "deposit": "Deposit",
+        "approve": "Menyetujui",
+        "withdraw": "Penarikan ",
+        "receive": "Menerima"
+      },
       "yearn": {
         "deposit": "Deposit",
         "approve": "Menyetujui",

--- a/src/assets/translations/ko/main.json
+++ b/src/assets/translations/ko/main.json
@@ -304,6 +304,12 @@
     "amount": "거래량",
     "for": "for",
     "parser": {
+      "weth": {
+        "deposit": "자산 입금",
+        "approve": "승인하기",
+        "withdraw": "자산 출금",
+        "receive": "받음"
+      },
       "yearn": {
         "deposit": "자산 입금",
         "approve": "승인하기",

--- a/src/assets/translations/pt/main.json
+++ b/src/assets/translations/pt/main.json
@@ -304,6 +304,12 @@
     "amount": "Montante",
     "for": "Por",
     "parser": {
+      "weth": {
+        "deposit": "Depósito",
+        "approve": "Aprovar",
+        "withdraw": "Retirar",
+        "receive": "Receber"
+      },
       "yearn": {
         "deposit": "Depósito",
         "approve": "Aprovar",

--- a/src/assets/translations/zh/main.json
+++ b/src/assets/translations/zh/main.json
@@ -304,6 +304,12 @@
     "amount": "金额",
     "for": "为了",
     "parser": {
+      "weth": {
+        "deposit": "存款",
+        "approve": "批准",
+        "withdraw": "取款",
+        "receive": "收到"
+      },
       "yearn": {
         "deposit": "存款",
         "approve": "批准",


### PR DESCRIPTION
## Description

This adds the missing weth parser translations entries, that currently result in WETH Txs defaulting to the raw translation string.

Checked against the unchained weth parser implementation:
https://github.com/shapeshift/lib/blob/0ed73a884dd2088fe704a4114c57f7787ad36dc3/packages/unchained-client/src/ethereum/parser/weth.ts#L24-L27

For ZRX, we don't actually need to add any new translations for it as this is already handled by the `<TransactionTrade />` component, vs. `<TransactionContract />` for the unhandled WETH Txs.


## Notice

<!-- Before submitting a pull request, please make sure you have answered the following: -->

- [x] Have you followed the guidelines in our [Contributing]('https://github.com/shapeshift/web/CONTRIBUTING.md) guide?
- [x] Have you checked to ensure there aren't other open [Pull Requests](https://github.com/shapeshift/web/pulls) for the same update/change?

## Pull Request Type

- [x] :bug: Bug fix (Non-breaking Change: Fixes an issue)
- [ ] :hammer_and_wrench: Chore (Non-breaking Change: Doc updates, pkg upgrades, typos, etc..)
- [ ] :nail_care: New Feature (Breaking/Non-breaking Change)

## Issue (if applicable)

closes #1881

## Risk

None, this is just copying the `yearn` parser translations into weth.

## Testing

<!-----------------------------------------------------------------------------
If your testing steps are technical, outline steps for an engineer to verify.

If your testing steps are functional, please provide a full guide with any features requiring special attention for operations to test your branch in the preview environment.
------------------------------------------------------------------------------>

## Screenshots (if applicable)

<img width="430" alt="image" src="https://user-images.githubusercontent.com/17035424/170299850-38218a88-1353-4140-8abf-6ada5b62faea.png">