### PR TITLE
fix: remove feeasset from dep array

### DIFF
--- a/src/components/Trade/hooks/useTradeRoutes/useTradeRoutes.ts
+++ b/src/components/Trade/hooks/useTradeRoutes/useTradeRoutes.ts
@@ -81,7 +81,7 @@ export const useTradeRoutes = (
 
   useEffect(() => {
     setDefaultAssets()
-  }, [assets, feeAsset, routeBuyAssetId]) // eslint-disable-line react-hooks/exhaustive-deps
+  }, [assets, routeBuyAssetId]) // eslint-disable-line react-hooks/exhaustive-deps
 
   const handleSellClick = useCallback(
     async (asset: Asset) => {


### PR DESCRIPTION
## Description

Trade FeeAsset did not belong in the dependency array for setting default pair

It doesnt matter right now because its always eth and never changes but this was causing problems when adding swappers that support other chains

## Notice

<!-- Before submitting a pull request, please make sure you have answered the following: -->

- [x] Have you followed the guidelines in our [Contributing]('https://github.com/shapeshift/web/CONTRIBUTING.md) guide?
- [x] Have you checked to ensure there aren't other open [Pull Requests](https://github.com/shapeshift/web/pulls) for the same update/change?

## Pull Request Type

- [x] :bug: Bug fix (Non-breaking Change: Fixes an issue)
- [ ] :hammer_and_wrench: Chore (Non-breaking Change: Doc updates, pkg upgrades, typos, etc..)
- [ ] :nail_care: New Feature (Breaking/Non-breaking Change)

## Risk

Low risk. fixes issue with thorchain that isnt merged yet

## Testing

Nothing should be different from a user perspective. Check that trades still work

