### PR TITLE
fix: add missing minLimit translation param

### DIFF
--- a/src/components/Trade/TradeInput.tsx
+++ b/src/components/Trade/TradeInput.tsx
@@ -85,7 +85,9 @@ export const TradeInput = ({ history }: RouterProps) => {
 
     if (bnOrZero(quote.sellAmount).lt(minSellAmount)) {
       toast({
-        description: translate('trade.errors.amountToSmall'),
+        description: translate('trade.errors.amountToSmall', {
+          minLimit: `${quote.minimum} ${quote.sellAsset.symbol}`,
+        }),
         status: 'error',
         duration: 9000,
         isClosable: true,


### PR DESCRIPTION
## Description

This adds the missing `minLimit` translation param in the trade component, that gets sent to the toast.
Currently, we're seeing the raw translation string instead of the minimum crypto sell amount.

## Notice

<!-- Before submitting a pull request, please make sure you have answered the following: -->

- [x] Have you followed the guidelines in our [Contributing]('https://github.com/shapeshift/web/CONTRIBUTING.md) guide?
- [x] Have you checked to ensure there aren't other open [Pull Requests](https://github.com/shapeshift/web/pulls) for the same update/change?

## Pull Request Type

- [x] :bug: Bug fix (Non-breaking Change: Fixes an issue)
- [ ] :hammer_and_wrench: Chore (Non-breaking Change: Doc updates, pkg upgrades, typos, etc..)
- [ ] :nail_care: New Feature (Breaking/Non-breaking Change)

## Issue (if applicable)

N/A

## Risk

None

## Testing

- Enter an amount to swap below the minimum sell amount
- Click "Preview Trade"
- The `Amount too small. The minimum trade amount for this pair is` toast should show the minimum crypto amount in a human-readable precision format of `<amount> <symbol>` 

## Screenshots (if applicable)

<img width="571" alt="image" src="https://user-images.githubusercontent.com/17035424/170373256-60c1220d-fc44-490e-9fbb-aaaa4c2ffdfb.png">