### PR TITLE
fix: about section collapse

### DIFF
--- a/src/components/AssetHeader/AssetDescription.tsx
+++ b/src/components/AssetHeader/AssetDescription.tsx
@@ -1,6 +1,6 @@
 import { Box, Button, Collapse, Skeleton, SkeletonText } from '@chakra-ui/react'
 import { AssetId } from '@shapeshiftoss/caip'
-import { useEffect, useRef, useState } from 'react'
+import { useEffect, useLayoutEffect, useRef, useState } from 'react'
 import { useTranslate } from 'react-polyglot'
 import { Card } from 'components/Card/Card'
 import { ParsedHtml } from 'components/ParsedHtml/ParsedHtml'
@@ -26,6 +26,11 @@ export const AssetDescription = ({ assetId }: AssetDescriptionProps) => {
   const { name, description, isTrustedDescription } = asset || {}
   const query = useGetAssetDescriptionQuery(assetId)
   const isLoaded = !query.isLoading
+
+  // Collapse about section any time description changes
+  useLayoutEffect(() => {
+    setShowDescription(false)
+  }, [description])
 
   // If the height of the description is higher than the collapse element when it's closed
   // we should display the Show More button

--- a/src/components/AssetHeader/AssetDescription.tsx
+++ b/src/components/AssetHeader/AssetDescription.tsx
@@ -28,7 +28,7 @@ export const AssetDescription = ({ assetId }: AssetDescriptionProps) => {
   const isLoaded = !query.isLoading
 
   // Collapse about section any time description changes
-  useLayoutEffect(() => {
+  useEffect(() => {
     setShowDescription(false)
   }, [description])
 

--- a/src/components/AssetHeader/AssetDescription.tsx
+++ b/src/components/AssetHeader/AssetDescription.tsx
@@ -1,6 +1,6 @@
 import { Box, Button, Collapse, Skeleton, SkeletonText } from '@chakra-ui/react'
 import { AssetId } from '@shapeshiftoss/caip'
-import { useEffect, useLayoutEffect, useRef, useState } from 'react'
+import { useEffect, useRef, useState } from 'react'
 import { useTranslate } from 'react-polyglot'
 import { Card } from 'components/Card/Card'
 import { ParsedHtml } from 'components/ParsedHtml/ParsedHtml'


### PR DESCRIPTION
## Description

Collapses "About" section for assets when description changes.

## Notice

- [x] Have you followed the guidelines in our [Contributing]('https://github.com/shapeshift/web/CONTRIBUTING.md) guide?
- [x] Have you checked to ensure there aren't other open [Pull Requests](https://github.com/shapeshift/web/pulls) for the same update/change?

## Pull Request Type

- [x] :bug: Bug fix (Non-breaking Change: Fixes an issue)
- [ ] :hammer_and_wrench: Chore (Non-breaking Change: Doc updates, pkg upgrades, typos, etc..)
- [ ] :nail_care: New Feature (Breaking/Non-breaking Change)

## Issue (if applicable)

 closes #1826

## Risk

Collapsing on any description change may be too broad.

## Testing

Follow video found in [issue #1826](https://github.com/shapeshift/web/issues/1826)

## Screenshots (if applicable)
