### PR TITLE
fix: catch foxy opportunity failure

### DIFF
--- a/src/pages/Defi/hooks/useFoxyBalances.tsx
+++ b/src/pages/Defi/hooks/useFoxyBalances.tsx
@@ -8,6 +8,7 @@ import { useSelector } from 'react-redux'
 import { useChainAdapters } from 'context/PluginProvider/PluginProvider'
 import { useWallet } from 'hooks/useWallet/useWallet'
 import { BigNumber, bn, bnOrZero } from 'lib/bignumber/bignumber'
+import { logger } from 'lib/logger'
 import { PortfolioBalancesById } from 'state/slices/portfolioSlice/portfolioSliceCommon'
 import {
   selectAssets,
@@ -45,57 +46,65 @@ export type UseFoxyBalancesReturn = {
   loading: boolean
 }
 
+const moduleLogger = logger.child({
+  namespace: ['DeFi', 'Hooks', 'UseFoxyBalances'],
+})
+
 async function getFoxyOpportunities(
   balances: PortfolioBalancesById,
   api: FoxyApi,
   userAddress: string,
 ) {
   const acc: Record<string, FoxyOpportunity> = {}
-  const opps = await api.getFoxyOpportunities()
-  for (let index = 0; index < opps.length; index++) {
-    // TODO: assetIds in vaults
-    const opportunity = opps[index]
-    const withdrawInfo = await api.getWithdrawInfo({
-      contractAddress: opportunity.contractAddress,
-      userAddress,
-    })
-    const rewardTokenAssetId = toAssetId({
-      chain: opportunity.chain,
-      network: NetworkTypes.MAINNET,
-      assetNamespace: 'erc20',
-      assetReference: opportunity.rewardToken,
-    })
-    const contractAssetId = toAssetId({
-      chain: opportunity.chain,
-      network: NetworkTypes.MAINNET,
-      assetNamespace: 'erc20',
-      assetReference: opportunity.contractAddress,
-    })
-    const tokenAssetId = toAssetId({
-      chain: opportunity.chain,
-      network: NetworkTypes.MAINNET,
-      assetNamespace: 'erc20',
-      assetReference: opportunity.stakingToken,
-    })
-    const balance = balances[rewardTokenAssetId]
+  try {
+    const opportunities = await api.getFoxyOpportunities()
+    for (let index = 0; index < opportunities.length; index++) {
+      // TODO: assetIds in vaults
+      const opportunity = opportunities[index]
+      const withdrawInfo = await api.getWithdrawInfo({
+        contractAddress: opportunity.contractAddress,
+        userAddress,
+      })
+      const rewardTokenAssetId = toAssetId({
+        chain: opportunity.chain,
+        network: NetworkTypes.MAINNET,
+        assetNamespace: 'erc20',
+        assetReference: opportunity.rewardToken,
+      })
+      const contractAssetId = toAssetId({
+        chain: opportunity.chain,
+        network: NetworkTypes.MAINNET,
+        assetNamespace: 'erc20',
+        assetReference: opportunity.contractAddress,
+      })
+      const tokenAssetId = toAssetId({
+        chain: opportunity.chain,
+        network: NetworkTypes.MAINNET,
+        assetNamespace: 'erc20',
+        assetReference: opportunity.stakingToken,
+      })
+      const balance = balances[rewardTokenAssetId]
 
-    const pricePerShare = api.pricePerShare()
-    acc[opportunity.contractAddress] = {
-      ...opportunity,
-      balance: bnOrZero(balance).toString(),
-      contractAssetId,
-      tokenAssetId,
-      rewardTokenAssetId,
-      pricePerShare: bnOrZero(pricePerShare),
-      withdrawInfo,
+      const pricePerShare = api.pricePerShare()
+      acc[opportunity.contractAddress] = {
+        ...opportunity,
+        balance: bnOrZero(balance).toString(),
+        contractAssetId,
+        tokenAssetId,
+        rewardTokenAssetId,
+        pricePerShare: bnOrZero(pricePerShare),
+        withdrawInfo,
+      }
     }
+    return acc
+  } catch (e) {
+    moduleLogger.error(e, { fn: 'getFoxyOpportunities' }, 'Error getting opportunities')
   }
-  return acc
 }
 
 export function useFoxyBalances(): UseFoxyBalancesReturn {
   const [loading, setLoading] = useState(false)
-  const [opportunities, setOpportunites] = useState<Record<string, FoxyOpportunity>>({})
+  const [opportunities, setOpportunities] = useState<Record<string, FoxyOpportunity>>({})
   const marketData = useSelector(selectMarketData)
   const assets = useSelector(selectAssets)
 
@@ -117,13 +126,14 @@ export function useFoxyBalances(): UseFoxyBalancesReturn {
         const chainAdapter = await chainAdapterManager.byChainId('eip155:1')
         const userAddress = await chainAdapter.getAddress({ wallet })
         const foxyOpportunities = await getFoxyOpportunities(balances, foxy, userAddress)
+        if (!foxyOpportunities) return
 
         // remove when Tokemak has api to get real apy
         for (const key in foxyOpportunities) {
           foxyOpportunities[key].apy = bnOrZero(getConfig().REACT_APP_FOXY_APY).toString()
         }
 
-        setOpportunites(foxyOpportunities)
+        setOpportunities(foxyOpportunities)
       } catch (error) {
         console.error('error', error)
       } finally {


### PR DESCRIPTION
## Description

`getFoxyOpportunities()` in [packages/investor-foxy/src/api/api.ts](https://github.com/shapeshift/lib/blob/d595252f267baddd5ea47a555a2c815d0b424cf2/packages/investor-foxy/src/api/api.ts#L197) throws on request failure, which happens somewhat often.

We call it in `web` in `getFoxyOpportunities()`, `src/pages/Defi/hooks/useFoxyBalances.tsx`, but don't gracefully handle failures - this was caught by Cypress, which was intermittently throwing in CI, e.g. https://github.com/shapeshift/web/runs/6551637054?check_suite_focus=true

This PR updates `getFoxyOpportunities()` to handle failures.

<img width="905" alt="Screen Shot 2022-05-26 at 3 27 16 pm" src="https://user-images.githubusercontent.com/97164662/170423288-285ca914-0c01-42fe-8139-3a63b988ef0d.png">


## Notice

<!-- Before submitting a pull request, please make sure you have answered the following: -->

- [x] Have you followed the guidelines in our [Contributing]('https://github.com/shapeshift/web/CONTRIBUTING.md) guide?
- [x] Have you checked to ensure there aren't other open [Pull Requests](https://github.com/shapeshift/web/pulls) for the same update/change?

## Pull Request Type

- [x] :bug: Bug fix (Non-breaking Change: Fixes an issue)
- [ ] :hammer_and_wrench: Chore (Non-breaking Change: Doc updates, pkg upgrades, typos, etc..)
- [ ] :nail_care: New Feature (Breaking/Non-breaking Change)

## Issue (if applicable)

N/A

## Risk

Minimal.

## Testing

No regressions expected - FOXy opportunities should work as expected.

## Screenshots (if applicable)

Uncaught error

<img width="678" alt="Screen Shot 2022-05-26 at 2 33 56 pm" src="https://user-images.githubusercontent.com/97164662/170423557-82951c07-796a-4b73-9227-250f1252505b.png">

