### PR TITLE
fix: use correct type for execute quote

### DIFF
--- a/src/components/Trade/hooks/useSwapper/useSwapper.ts
+++ b/src/components/Trade/hooks/useSwapper/useSwapper.ts
@@ -1,7 +1,14 @@
 import { HDWallet } from '@shapeshiftoss/hdwallet-core'
 import { NativeHDWallet } from '@shapeshiftoss/hdwallet-native'
-import { QuoteFeeData, SwapperManager, Trade, TradeQuote, ZrxSwapper } from '@shapeshiftoss/swapper'
-import { Asset, ExecQuoteOutput, SupportedChainIds, SwapperType } from '@shapeshiftoss/types'
+import {
+  QuoteFeeData,
+  SwapperManager,
+  Trade,
+  TradeQuote,
+  TradeResult,
+  ZrxSwapper,
+} from '@shapeshiftoss/swapper'
+import { Asset, SupportedChainIds, SwapperType } from '@shapeshiftoss/types'
 import debounce from 'lodash/debounce'
 import { useCallback, useRef, useState } from 'react'
 import { useFormContext, useWatch } from 'react-hook-form'
@@ -147,11 +154,7 @@ export const useSwapper = () => {
     return result
   }
 
-  const executeQuote = async ({
-    wallet,
-  }: {
-    wallet: HDWallet
-  }): Promise<ExecQuoteOutput | undefined> => {
+  const executeQuote = async ({ wallet }: { wallet: HDWallet }): Promise<TradeResult> => {
     const swapper = await swapperManager.getBestSwapper({
       buyAssetId: trade.buyAsset.assetId,
       sellAssetId: trade.sellAsset.assetId,


### PR DESCRIPTION
## Description

We were using an old legacy type for execute quote. This uses the new correct one so we can remove the old one (they have the exact same fields)

## Notice

- [ ] Have you followed the guidelines in our [Contributing]('https://github.com/shapeshift/web/CONTRIBUTING.md) guide?
- [ ] Have you checked to ensure there aren't other open [Pull Requests](https://github.com/shapeshift/web/pulls) for the same update/change?

## Pull Request Type

- [ ] :bug: Bug fix (Non-breaking Change: Fixes an issue)
- [ ] :hammer_and_wrench: Chore (Non-breaking Change: Doc updates, pkg upgrades, typos, etc..)
- [ ] :nail_care: New Feature (Breaking/Non-breaking Change)


## Risk

no risk. type change

## Testing

Nothing is different from a user perspective.

## Screenshots (if applicable)
