### PR TITLE
feat: Restful TxHistory and websocket updates for BTC/ETH

### DIFF
--- a/src/context/TransactionsProvider/TransactionsProvider.tsx
+++ b/src/context/TransactionsProvider/TransactionsProvider.tsx
@@ -1,27 +1,25 @@
-import { ChainId, chainIdToFeeAssetId, cosmosChainId } from '@shapeshiftoss/caip'
+import { chainIdToFeeAssetId, cosmosChainId, fromAccountId } from '@shapeshiftoss/caip'
 import { utxoAccountParams } from '@shapeshiftoss/chain-adapters'
+import { TxStatus } from '@shapeshiftoss/types/dist/chain-adapters'
 import isEmpty from 'lodash/isEmpty'
-import size from 'lodash/size'
-import React, { useCallback, useEffect, useState } from 'react'
+import React, { useEffect, useState } from 'react'
 import { useDispatch, useSelector } from 'react-redux'
 import { usePlugins } from 'context/PluginProvider/PluginProvider'
 import { useWallet } from 'hooks/useWallet/useWallet'
 import { walletSupportsChain } from 'hooks/useWalletSupportsChain/useWalletSupportsChain'
 import { logger } from 'lib/logger'
 import { AccountSpecifierMap } from 'state/slices/accountSpecifiersSlice/accountSpecifiersSlice'
+import { portfolioApi } from 'state/slices/portfolioSlice/portfolioSlice'
 import {
   selectAccountIdByAddress,
   selectAccountSpecifiers,
   selectAssets,
   selectIsPortfolioLoaded,
-  selectPortfolioAccounts,
   selectPortfolioAssetIds,
 } from 'state/slices/selectors'
-import { txHistoryApi } from 'state/slices/txHistorySlice/txHistorySlice'
 import { txHistory } from 'state/slices/txHistorySlice/txHistorySlice'
-import { SHAPESHIFT_VALIDATOR_ADDRESS } from 'state/slices/validatorDataSlice/const'
 import { validatorDataApi } from 'state/slices/validatorDataSlice/validatorDataSlice'
-import { store, useAppSelector } from 'state/store'
+import { store } from 'state/store'
 
 const moduleLogger = logger.child({ namespace: ['TransactionsProvider'] })
 
@@ -41,33 +39,20 @@ export const TransactionsProvider = ({ children }: TransactionsProviderProps): J
   const accountSpecifiers = useSelector(selectAccountSpecifiers)
   const isPortfolioLoaded = useSelector(selectIsPortfolioLoaded)
 
-  const getAccountSpecifiersByChainId = useCallback(
-    (chainId: ChainId): AccountSpecifierMap[] => {
-      return accountSpecifiers.reduce<AccountSpecifierMap[]>((acc, cur) => {
-        const [_chainId, accountSpecifier] = Object.entries(cur)[0]
-        if (_chainId !== chainId) return acc
-        return acc.concat({ [chainId]: accountSpecifier })
-      }, [])
-    },
-    [accountSpecifiers],
-  )
-
   /**
-   * tx history unsubscribe and cleanup logic
+   * unsubscribe and cleanup logic
    */
   useEffect(() => {
     // account specifiers changing will trigger this effect
     // we've disconnected/switched a wallet, unsubscribe from tx history and clear tx history
     if (!isSubscribed) return
-    moduleLogger.info('unsubscribing from tx history')
+    moduleLogger.info('unsubscribing txs')
     supportedChains.forEach(chain => chainAdapterManager.byChain(chain).unsubscribeTxs())
     dispatch(txHistory.actions.clear())
     setIsSubscribed(false)
     // setting isSubscribed to false will trigger this effect
     // eslint-disable-next-line react-hooks/exhaustive-deps
   }, [accountSpecifiers, dispatch, chainAdapterManager, supportedChains])
-
-  const portfolioAccounts = useAppSelector(state => selectPortfolioAccounts(state))
 
   /**
    * tx history subscription logic
@@ -86,26 +71,50 @@ export const TransactionsProvider = ({ children }: TransactionsProviderProps): J
           })
           .map(async chain => {
             const adapter = chainAdapterManager.byChain(chain)
-            // this looks funky, but we need a non zero length array to map over
-            const supportedAccountTypes = adapter.getSupportedAccountTypes?.() ?? [undefined]
             const chainId = adapter.getChainId()
 
             // assets are known to be defined at this point - if we don't have the fee asset we have bigger problems
             const asset = assets[chainIdToFeeAssetId(chainId)]
 
+            // subscribe to new transactions for all supported accounts
             try {
+              // account types are only supported for utxo chains, default to undefined if no accountTypes are supported
+              const supportedAccountTypes = adapter.getSupportedAccountTypes?.() ?? [undefined]
+
               await Promise.all(
                 supportedAccountTypes.map(async accountType => {
-                  const accountParams = accountType ? utxoAccountParams(asset, accountType, 0) : {}
                   moduleLogger.info({ chainId, accountType }, 'subscribing txs')
+
+                  const accountParams = accountType ? utxoAccountParams(asset, accountType, 0) : {}
+
                   return adapter.subscribeTxs(
                     { wallet, accountType, ...accountParams },
                     msg => {
-                      const accountSpecifier = `${msg.chainId}:${msg.address}`
                       const state = store.getState()
                       const accountId = selectAccountIdByAddress(state, {
-                        accountSpecifier,
+                        accountSpecifier: `${msg.chainId}:${msg.address}`,
                       })
+
+                      const { getAccount } = portfolioApi.endpoints
+                      const { getValidatorData } = validatorDataApi.endpoints
+
+                      // refetch validator data on new txs in case TVL or APR has changed
+                      if (msg.chainId === cosmosChainId) {
+                        dispatch(getValidatorData.initiate({ accountSpecifier: accountId }))
+                      }
+
+                      // refetch account on non pending txs
+                      // this catches Failed and Unknown status as well in case they caused account changes
+                      if (msg.status !== TxStatus.Pending) {
+                        const { account } = fromAccountId(accountId)
+                        const accountSpecifierMap: AccountSpecifierMap = {
+                          [msg.chainId]: account,
+                        }
+                        dispatch(
+                          getAccount.initiate({ accountSpecifierMap }, { forceRefetch: true }),
+                        )
+                      }
+
                       dispatch(
                         txHistory.actions.onMessage({
                           message: { ...msg, accountType },
@@ -117,49 +126,13 @@ export const TransactionsProvider = ({ children }: TransactionsProviderProps): J
                   )
                 }),
               )
+
               // manage subscription state - we can't request this from chain adapters,
               // and need this to prevent resubscribing when switching wallets
               setIsSubscribed(true)
             } catch (e: unknown) {
               moduleLogger.error(e, { chain }, 'Error subscribing to transaction history for chain')
             }
-            // RESTfully fetch all tx and rebase history for this chain.
-            getAccountSpecifiersByChainId(chainId).forEach(accountSpecifierMap => {
-              if (accountSpecifierMap[cosmosChainId]) {
-                const cosmosAccountSpecifier = accountSpecifierMap[cosmosChainId]
-                const cosmosPortfolioAccount =
-                  portfolioAccounts[`${cosmosChainId}:${cosmosAccountSpecifier}`]
-                if (cosmosPortfolioAccount) {
-                  const validatorIds = size(cosmosPortfolioAccount.validatorIds)
-                    ? cosmosPortfolioAccount.validatorIds
-                    : [SHAPESHIFT_VALIDATOR_ADDRESS]
-                  validatorIds?.forEach(validatorAddress => {
-                    dispatch(
-                      validatorDataApi.endpoints.getValidatorData.initiate({
-                        validatorAddress,
-                      }),
-                    )
-                  })
-                }
-              }
-              const { getAllTxHistory, getFoxyRebaseHistoryByAccountId } = txHistoryApi.endpoints
-              const options = { forceRefetch: true }
-              dispatch(getAllTxHistory.initiate({ accountSpecifierMap }, options))
-
-              /**
-               * foxy rebase history is most closely linked to transactions.
-               * unfortunately, we have to call this for a specific asset here
-               * because we need it for the dashboard balance chart
-               *
-               * if you're reading this and are about to add another rebase token here,
-               * stop, and make a getRebaseHistoryByAccountId that takes
-               * an accountId and assetId[] in the txHistoryApi
-               */
-
-              // fetch all rebase history for FOXy
-              const payload = { accountSpecifierMap, portfolioAssetIds }
-              dispatch(getFoxyRebaseHistoryByAccountId.initiate(payload, options))
-            })
           }),
       ))()
     // assets causes unnecessary renders, but doesn't actually change
@@ -173,7 +146,6 @@ export const TransactionsProvider = ({ children }: TransactionsProviderProps): J
     chainAdapterManager,
     supportedChains,
     accountSpecifiers,
-    getAccountSpecifiersByChainId,
     portfolioAssetIds,
   ])
 

--- a/src/plugins/bitcoin/index.tsx
+++ b/src/plugins/bitcoin/index.tsx
@@ -21,7 +21,7 @@ export function register(): Plugins {
                   }),
                 )
 
-                const ws = new unchained.ws.Client<unchained.Tx>(
+                const ws = new unchained.ws.Client<unchained.bitcoin.BitcoinTx>(
                   getConfig().REACT_APP_UNCHAINED_BITCOIN_WS_URL,
                 )
 

--- a/src/plugins/ethereum/index.tsx
+++ b/src/plugins/ethereum/index.tsx
@@ -21,11 +21,14 @@ export function register(): Plugins {
                   }),
                 )
 
-                const ws = new unchained.ws.Client<unchained.ethereum.ParsedTx>(
+                const ws = new unchained.ws.Client<unchained.ethereum.EthereumTx>(
                   getConfig().REACT_APP_UNCHAINED_ETHEREUM_WS_URL,
                 )
 
-                return new ethereum.ChainAdapter({ providers: { http, ws } })
+                return new ethereum.ChainAdapter({
+                  providers: { http, ws },
+                  rpcUrl: getConfig().REACT_APP_UNCHAINED_ETHEREUM_HTTP_URL,
+                })
               },
             ],
           ],

--- a/src/state/slices/portfolioSlice/portfolioSlice.ts
+++ b/src/state/slices/portfolioSlice/portfolioSlice.ts
@@ -99,6 +99,7 @@ export const portfolioApi = createApi({
           ChainId,
           string,
         ]
+
         // TODO(0xdef1cafe): chainAdapters.ChainId()
         const { chain } = fromChainId(chainId)
         try {

--- a/src/state/slices/txHistorySlice/utils.test.ts
+++ b/src/state/slices/txHistorySlice/utils.test.ts
@@ -1,6 +1,6 @@
 import { BtcSend, EthReceive, EthSend, FOXSend, yearnVaultDeposit } from 'test/mocks/txs'
 
-import { addToIndex, deserializeUniqueTxId, getRelatedAssetIds, makeUniqueTxId } from './utils'
+import { addToIndex, getRelatedAssetIds } from './utils'
 
 describe('txHistorySlice:utils', () => {
   describe('getRelatedAssetIds', () => {
@@ -59,20 +59,6 @@ describe('txHistorySlice:utils', () => {
 
     it('should maintain the sort order from the parent', () => {
       expect(addToIndex([2, 1, 3], [3], 1)).toStrictEqual([1, 3])
-    })
-  })
-
-  describe('deserializeUniqueTxId', () => {
-    it('can deserialize a txId', () => {
-      const ethChainId = EthSend.chainId
-      const accountSpecifier = `${ethChainId}:0xdef1cafe`
-      const txId = makeUniqueTxId(accountSpecifier, EthSend.txid, EthSend.address)
-
-      const { txAccountSpecifier, txid, txAddress } = deserializeUniqueTxId(txId)
-
-      expect(txAccountSpecifier).toEqual(accountSpecifier)
-      expect(txid).toEqual(EthSend.txid)
-      expect(txAddress).toEqual(EthSend.address.toLowerCase())
     })
   })
 })

--- a/src/state/slices/txHistorySlice/utils.ts
+++ b/src/state/slices/txHistorySlice/utils.ts
@@ -3,7 +3,7 @@ import intersection from 'lodash/intersection'
 import union from 'lodash/union'
 
 import { AccountSpecifier } from '../portfolioSlice/portfolioSliceCommon'
-import { Tx, TxId } from './txHistorySlice'
+import { Tx } from './txHistorySlice'
 
 export const getRelatedAssetIds = (tx: Tx): AssetId[] => {
   // we only want unique ids
@@ -50,10 +50,3 @@ export const makeUniqueTxId = (
   txId: Tx['txid'],
   txAddress: Tx['address'],
 ): string => [accountId, txId, txAddress.toLowerCase()].join(UNIQUE_TX_ID_DELIMITER)
-
-type DeserializeUniqueTxId = { txAccountSpecifier: string; txid: string; txAddress: string }
-
-export const deserializeUniqueTxId = (txId: TxId): DeserializeUniqueTxId => {
-  const [txAccountSpecifier, txid, txAddress] = txId.split(UNIQUE_TX_ID_DELIMITER)
-  return { txAccountSpecifier, txid, txAddress }
-}

--- a/src/state/slices/validatorDataSlice/validatorDataSlice.ts
+++ b/src/state/slices/validatorDataSlice/validatorDataSlice.ts
@@ -5,10 +5,16 @@ import { cosmossdk } from '@shapeshiftoss/chain-adapters'
 // @ts-ignore this will fail at 'file differs in casing' error
 import { chainAdapters } from '@shapeshiftoss/types'
 import { getChainAdapters } from 'context/PluginProvider/PluginProvider'
+import { logger } from 'lib/logger'
+import { SHAPESHIFT_VALIDATOR_ADDRESS } from 'state/slices/validatorDataSlice/const'
+
+import { PortfolioAccounts } from '../portfolioSlice/portfolioSliceCommon'
+
+const moduleLogger = logger.child({ namespace: ['validatorDataSlice'] })
 
 export type PubKey = string
 
-type SingleValidatorDataArgs = { validatorAddress: PubKey }
+type SingleValidatorDataArgs = { accountSpecifier: string }
 
 export type Validators = {
   validators: chainAdapters.cosmos.Validator[]
@@ -63,28 +69,48 @@ export const validatorDataApi = createApi({
   refetchOnReconnect: true,
   endpoints: build => ({
     getValidatorData: build.query<chainAdapters.cosmos.Validator, SingleValidatorDataArgs>({
-      queryFn: async ({ validatorAddress }, { dispatch }) => {
-        const chainAdapters = getChainAdapters()
-        const adapter = (await chainAdapters.byChainId(
-          cosmosChainId,
-        )) as cosmossdk.cosmos.ChainAdapter
-        try {
-          const data = await adapter.getValidator(validatorAddress)
-          dispatch(
-            validatorData.actions.upsertValidatorData({
-              validators: [data],
-            }),
-          )
-          return { data }
-        } catch (e) {
-          console.error('Error fetching single validator data', e)
-          return {
-            error: {
-              data: `Error fetching validator data`,
-              status: 500,
-            },
-          }
+      queryFn: async ({ accountSpecifier }, { dispatch, getState }) => {
+        // limitation of redux tookit https://redux-toolkit.js.org/rtk-query/api/createApi#queryfn
+        const { byId } = (getState() as any).portfolio.accounts as PortfolioAccounts
+
+        const portfolioAccount = byId[accountSpecifier]
+
+        if (!portfolioAccount) {
+          return { error: { data: `No portfolio data found for ${accountSpecifier}`, status: 404 } }
         }
+
+        const validatorIds = portfolioAccount.validatorIds?.length
+          ? portfolioAccount.validatorIds
+          : [SHAPESHIFT_VALIDATOR_ADDRESS]
+
+        const chainAdapters = getChainAdapters()
+        const adapter = chainAdapters.byChainId(cosmosChainId) as cosmossdk.cosmos.ChainAdapter
+
+        const validators = await Promise.allSettled(
+          validatorIds.map(async validatorId => {
+            try {
+              const data = await adapter.getValidator(validatorId)
+
+              dispatch(
+                validatorData.actions.upsertValidatorData({
+                  validators: [data],
+                }),
+              )
+            } catch (err) {
+              if (err instanceof Error) {
+                throw new Error(`failed to get data for validator: ${validatorId}: ${err.message}`)
+              }
+            }
+          }),
+        )
+
+        validators.forEach(promise => {
+          if (promise.status === 'rejected') {
+            moduleLogger.child({ fn: 'getValidatorData' }).warn(promise.reason)
+          }
+        })
+
+        return { data: {} as chainAdapters.cosmos.Validator }
       },
     }),
   }),


### PR DESCRIPTION
## Description

This updates bitcoin and ethereum to use the same restful tx history strategy and websocket only publishing newly confirmed or pending txs that is the new architectural standard introduced with cosmos.

## Notice

<!-- Before submitting a pull request, please make sure you have answered the following: -->

- [ ] Have you followed the guidelines in our [Contributing]('https://github.com/shapeshift/web/CONTRIBUTING.md) guide?
- [ ] Have you checked to ensure there aren't other open [Pull Requests](https://github.com/shapeshift/web/pulls) for the same update/change?

## Pull Request Type

- [ ] :bug: Bug fix (Non-breaking Change: Fixes an issue)
- [ ] :hammer_and_wrench: Chore (Non-breaking Change: Doc updates, pkg upgrades, typos, etc..)
- [ ] :nail_care: New Feature (Breaking/Non-breaking Change)

## Issue (if applicable)

N/A

## Risk

High Risk:

- Changes how tx history is fetched for ethereum and bitcoin
- Changes how we manage tx history loading state
- Refactors to cleanup wallet on connect logic to trigger fetching of txhistory, cosmos validator data, and foxy rebase history

## Testing

- Ensure tx history is accurate
- Ensure validators you have cosmos staked to are showing correctly
- Ensure foxy rebase history you have is showing correctly
- Ensure on transaction broadcast, you see pending tx updated in tx history list
- Ensure on confirmed tx you see the pending tx update to confirmed
- Ultimately the app should work as it did previously and likely a noticeable performance improvement

## Screenshots (if applicable)
