### PR TITLE
chore: trade status swapper agnostic

### DIFF
--- a/package.json
+++ b/package.json
@@ -30,7 +30,7 @@
     "@shapeshiftoss/investor-yearn": "^2.0.2",
     "@shapeshiftoss/logger": "^1.1.2",
     "@shapeshiftoss/market-service": "^4.2.2",
-    "@shapeshiftoss/swapper": "^5.1.5",
+    "@shapeshiftoss/swapper": "^5.2.3",
     "@shapeshiftoss/types": "^4.3.1",
     "@shapeshiftoss/unchained-client": "^8.3.4",
     "@visx/axis": "^2.6.0",

--- a/src/components/Trade/TradeConfirm/TradeConfirm.tsx
+++ b/src/components/Trade/TradeConfirm/TradeConfirm.tsx
@@ -37,7 +37,7 @@ export const TradeConfirm = ({ history }: RouterProps) => {
   } = useFormContext<TradeState<SupportedChainIds>>()
   const translate = useTranslate()
   const { trade, fees, sellAssetFiatRate } = getValues()
-  const { executeQuote, reset, checkTradeStatus } = useSwapper()
+  const { executeQuote, reset, getTradeTxs } = useSwapper()
   const location = useLocation<TradeConfirmParams>()
   const { fiatRate } = location.state
   const {
@@ -78,18 +78,18 @@ export const TradeConfirm = ({ history }: RouterProps) => {
 
       const result = await executeQuote({ wallet })
       console.log('executeQuote result', result)
-      const initialStatus = await checkTradeStatus(result)
+      const initialStatus = await getTradeTxs(result)
       if (initialStatus.buyTxid) {
         console.log('have txid immedietly')
         setTxid(initialStatus.buyTxid)
       } else {
         const interval = setInterval(async () => {
-          console.log('checking trade status on interval')
-          const status = await checkTradeStatus(result)
-          console.log('status1 is', status)
-          if (status.buyTxid) {
+          console.log('checking trade txs on interval')
+          const txs = await getTradeTxs(result)
+          console.log('txs is', txs)
+          if (txs.buyTxid) {
             console.log('setting the txid and clearing interval')
-            setTxid(status.buyTxid)
+            setTxid(txs.buyTxid)
             clearInterval(interval)
           }
         }, 1000 * 5 * 1) // refetch every 5 seconds

--- a/src/components/Trade/TradeConfirm/TradeConfirm.tsx
+++ b/src/components/Trade/TradeConfirm/TradeConfirm.tsx
@@ -81,12 +81,12 @@ export const TradeConfirm = ({ history }: RouterProps) => {
       // This means the trade is just about finished
       const txs = await poll({
         fn: () => getTradeTxs(result),
-        validate: (txs: TradeTxs) => txs.buyTxid,
+        validate: (txs: TradeTxs) => !!txs.buyTxid,
         interval: 10000, // 10 seconds
         maxAttempts: 300, // Lots of attempts because some trade are slow (thorchain to bitcoin)
       })
-      if (!txs) throw new Error('No txs from getTradeTxs')
-      setTxid(txs?.buyTxid)
+      if (!txs.buyTxid) throw new Error('No buyTxid from getTradeTxs')
+      setTxid(txs.buyTxid)
     } catch (e) {
       showErrorToast(e)
     }

--- a/src/components/Trade/TradeConfirm/TradeConfirm.tsx
+++ b/src/components/Trade/TradeConfirm/TradeConfirm.tsx
@@ -58,6 +58,9 @@ export const TradeConfirm = ({ history }: RouterProps) => {
   )
   const status = useAppSelector(state => selectTxStatusById(state, parsedTxId))
 
+  console.log('parsedTxId', parsedTxId)
+  console.log('status', status)
+
   const { showErrorToast } = useErrorHandler()
 
   const onSubmit = async () => {
@@ -74,18 +77,23 @@ export const TradeConfirm = ({ history }: RouterProps) => {
       }
 
       const result = await executeQuote({ wallet })
-
       console.log('executeQuote result', result)
-      const interval = setInterval(async () => {
-        console.log('checking trade status on interval')
-        const status = await checkTradeStatus(result)
-        console.log('status is', status)
-        if (status.buyTxid) {
-          console.log('setting the txid and clearing interval')
-          setTxid(status.buyTxid)
-          clearInterval(interval)
-        }
-      }, 1000 * 30 * 1) // refetch every 30 seconds
+      const initialStatus = await checkTradeStatus(result)
+      if (initialStatus.buyTxid) {
+        console.log('have txid immedietly')
+        setTxid(initialStatus.buyTxid)
+      } else {
+        const interval = setInterval(async () => {
+          console.log('checking trade status on interval')
+          const status = await checkTradeStatus(result)
+          console.log('status1 is', status)
+          if (status.buyTxid) {
+            console.log('setting the txid and clearing interval')
+            setTxid(status.buyTxid)
+            clearInterval(interval)
+          }
+        }, 1000 * 5 * 1) // refetch every 5 seconds
+      }
 
       // const transactionId = result?.txid
       // if (transactionId) {

--- a/src/components/Trade/hooks/useSwapper/useSwapper.ts
+++ b/src/components/Trade/hooks/useSwapper/useSwapper.ts
@@ -6,6 +6,7 @@ import {
   Trade,
   TradeQuote,
   TradeResult,
+  TradeStatus,
   ZrxSwapper,
 } from '@shapeshiftoss/swapper'
 import { Asset, SupportedChainIds, SwapperType } from '@shapeshiftoss/types'
@@ -152,6 +153,15 @@ export const useSwapper = () => {
     setFees(result, sellAsset)
     setValue('trade', result)
     return result
+  }
+
+  const checkTradeStatus = async (tradeResult: TradeResult): Promise<TradeStatus> => {
+    const swapper = await swapperManager.getBestSwapper({
+      buyAssetId: trade.buyAsset.assetId,
+      sellAssetId: trade.sellAsset.assetId,
+    })
+    if (!swapper) throw new Error('no swapper available')
+    return swapper.getTradeStatus(tradeResult)
   }
 
   const executeQuote = async ({ wallet }: { wallet: HDWallet }): Promise<TradeResult> => {
@@ -310,5 +320,6 @@ export const useSwapper = () => {
     getSendMaxAmount,
     reset,
     feeAsset,
+    checkTradeStatus,
   }
 }

--- a/src/components/Trade/hooks/useSwapper/useSwapper.ts
+++ b/src/components/Trade/hooks/useSwapper/useSwapper.ts
@@ -155,13 +155,13 @@ export const useSwapper = () => {
     return result
   }
 
-  const checkTradeStatus = async (tradeResult: TradeResult): Promise<TradeStatus> => {
+  const getTradeTxs = async (tradeResult: TradeResult): Promise<TradeStatus> => {
     const swapper = await swapperManager.getBestSwapper({
       buyAssetId: trade.buyAsset.assetId,
       sellAssetId: trade.sellAsset.assetId,
     })
     if (!swapper) throw new Error('no swapper available')
-    return swapper.getTradeStatus(tradeResult)
+    return swapper.getTradeTxs(tradeResult)
   }
 
   const executeQuote = async ({ wallet }: { wallet: HDWallet }): Promise<TradeResult> => {
@@ -320,6 +320,6 @@ export const useSwapper = () => {
     getSendMaxAmount,
     reset,
     feeAsset,
-    checkTradeStatus,
+    getTradeTxs,
   }
 }

--- a/src/components/Trade/hooks/useSwapper/useSwapper.ts
+++ b/src/components/Trade/hooks/useSwapper/useSwapper.ts
@@ -6,7 +6,7 @@ import {
   Trade,
   TradeQuote,
   TradeResult,
-  TradeStatus,
+  TradeTxs,
   ZrxSwapper,
 } from '@shapeshiftoss/swapper'
 import { Asset, SupportedChainIds, SwapperType } from '@shapeshiftoss/types'
@@ -155,7 +155,7 @@ export const useSwapper = () => {
     return result
   }
 
-  const getTradeTxs = async (tradeResult: TradeResult): Promise<TradeStatus> => {
+  const getTradeTxs = async (tradeResult: TradeResult): Promise<TradeTxs> => {
     const swapper = await swapperManager.getBestSwapper({
       buyAssetId: trade.buyAsset.assetId,
       sellAssetId: trade.sellAsset.assetId,

--- a/yarn.lock
+++ b/yarn.lock
@@ -4068,10 +4068,10 @@
     google-protobuf "^3.17.0"
     long "^4.0.0"
 
-"@shapeshiftoss/swapper@^5.1.5":
-  version "5.1.5"
-  resolved "https://registry.yarnpkg.com/@shapeshiftoss/swapper/-/swapper-5.1.5.tgz#be01518d9653595cc52831faaae4cc684e9e4407"
-  integrity sha512-x87f56gk1Vo8KiPPH/jT/zCK31XR+4I4xfISNZN489eOEimtIVTuIxXiR5CpsfNcDXulnqv67Tv1v8zcoJrWGg==
+"@shapeshiftoss/swapper@^5.2.3":
+  version "5.2.3"
+  resolved "https://registry.yarnpkg.com/@shapeshiftoss/swapper/-/swapper-5.2.3.tgz#062909c9280ea936c26a0335bb2a326a457b83a7"
+  integrity sha512-IhIixWt+fIY7qkPklRCXo7S8Lo43z0JXSiofWHrij263U9pYGTdOzfkf0gMjBR0F/I5dHbAOE5kg2BTWG0Wq6w==
   dependencies:
     axios "^0.26.0"
     bignumber.js "^9.0.1"


### PR DESCRIPTION
## Description

Make trade status swapper agnostic by using the new getTradeTxs() function to get incoming trade txid to determine if a trade has completed

## Notice

<!-- Before submitting a pull request, please make sure you have answered the following: -->

- [ ] Have you followed the guidelines in our [Contributing]('https://github.com/shapeshift/web/CONTRIBUTING.md) guide?
- [ ] Have you checked to ensure there aren't other open [Pull Requests](https://github.com/shapeshift/web/pulls) for the same update/change?

## Pull Request Type

- [ ] :bug: Bug fix (Non-breaking Change: Fixes an issue)
- [ ] :hammer_and_wrench: Chore (Non-breaking Change: Doc updates, pkg upgrades, typos, etc..)
- [ ] :nail_care: New Feature (Breaking/Non-breaking Change)

## Issue (if applicable)

https://github.com/shapeshift/lib/issues/704

## Risk

Verify that trades still show up as "pending" on the confirm screen before they show up as completed

## Testing

Low risk. Verify that trades still show up as "pending" on the confirm screen before they show up as completed

## Screenshots (if applicable)
