### PR TITLE
feat: add <Governance /> component

### DIFF
--- a/src/plugins/foxPage/components/Governance.tsx
+++ b/src/plugins/foxPage/components/Governance.tsx
@@ -1,0 +1,85 @@
+import { Badge, Box, Flex } from '@chakra-ui/layout'
+import { Link, Progress, Text as CText, useColorModeValue } from '@chakra-ui/react'
+import { useTranslate } from 'react-polyglot'
+import { Amount } from 'components/Amount/Amount'
+import { Card } from 'components/Card/Card'
+import { Text } from 'components/Text/Text'
+
+export const Governance = () => {
+  const translate = useTranslate()
+  const linkColor = useColorModeValue('blue.500', 'blue.200')
+
+  return (
+    <Card display='block' width='full'>
+      <Card.Header>
+        <Flex flexDirection='row' justifyContent='space-between' alignItems='center' mb={2}>
+          <CText fontWeight='bold' color='inherit'>
+            {translate('plugins.foxPage.governanceTitle')}
+          </CText>
+          <Link isExternal href={'#'} fontWeight='semibold' color={linkColor}>
+            <Text translation='plugins.foxPage.seeAllProposals' />
+          </Link>
+        </Flex>
+        <Text
+          translation='Lorem ipsum dolor sit amet, consectetur adipiscing elit. Ut eget elit faucibus'
+          color='gray.500'
+        />
+      </Card.Header>
+      <Card.Body>
+        <Box>
+          <Link
+            isExternal
+            href={'#'}
+            fontWeight='semibold'
+            color={linkColor}
+            mb={4}
+            display='inline-block'
+          >
+            <Text translation='[SCP-71] Proposal to Create the KeepKey Workstream' />
+          </Link>
+          <Box mb={4}>
+            <Flex justifyContent='space-between' mb={2}>
+              <Text translation='plugins.foxPage.for' fontWeight='semibold' />
+
+              <Flex>
+                <Text translation='2,934,283' fontWeight='semibold' mr={2} />
+                <Badge
+                  colorScheme='blue'
+                  display='flex'
+                  alignItems='center'
+                  px={2}
+                  py={'2px'}
+                  borderRadius='md'
+                >
+                  <Amount.Percent value={'0.6698'} fontWeight='normal' />
+                </Badge>
+              </Flex>
+            </Flex>
+            <Progress value={66.98} height={1} colorScheme='green' />
+          </Box>
+
+          <Box mb={4}>
+            <Flex justifyContent='space-between' mb={2}>
+              <Text translation='plugins.foxPage.against' fontWeight='semibold' />
+
+              <Flex>
+                <Text translation='1,446,828' fontWeight='semibold' mr={2} />
+                <Badge
+                  colorScheme='blue'
+                  display='flex'
+                  alignItems='center'
+                  px={2}
+                  py={'2px'}
+                  borderRadius='md'
+                >
+                  <Amount.Percent value={'0.3302'} fontWeight='normal' />
+                </Badge>
+              </Flex>
+            </Flex>
+            <Progress value={33.02} height={1} colorScheme='green' />
+          </Box>
+        </Box>
+      </Card.Body>
+    </Card>
+  )
+}

--- a/src/plugins/foxPage/components/Governance.tsx
+++ b/src/plugins/foxPage/components/Governance.tsx
@@ -34,8 +34,8 @@ export const Governance = () => {
             color='gray.500'
           />
         </Card.Header>
-        {governanceData?.data.map(proposal => (
-          <Card.Body>
+        {governanceData?.data.map((proposal, i) => (
+          <Card.Body key={i}>
             <Box>
               <Link
                 isExternal
@@ -48,7 +48,7 @@ export const Governance = () => {
                 <CText>{proposal.title}</CText>
               </Link>
               {proposal.choices.map((choice, i) => (
-                <Box mb={4}>
+                <Box mb={4} key={i}>
                   <Flex justifyContent='space-between' mb={2}>
                     <CText fontWeight='semibold'>{choice}</CText>
 

--- a/src/plugins/foxPage/components/Governance.tsx
+++ b/src/plugins/foxPage/components/Governance.tsx
@@ -1,85 +1,80 @@
 import { Badge, Box, Flex } from '@chakra-ui/layout'
-import { Link, Progress, Text as CText, useColorModeValue } from '@chakra-ui/react'
+import { Link, Progress, Skeleton, Text as CText, useColorModeValue } from '@chakra-ui/react'
 import { useTranslate } from 'react-polyglot'
 import { Amount } from 'components/Amount/Amount'
 import { Card } from 'components/Card/Card'
 import { Text } from 'components/Text/Text'
 
+import { BOARDROOM_APP_BASE_URL, useGetGovernanceData } from '../hooks/getGovernanceData'
+
 export const Governance = () => {
   const translate = useTranslate()
   const linkColor = useColorModeValue('blue.500', 'blue.200')
+  const governanceData = useGetGovernanceData()
 
   return (
-    <Card display='block' width='full'>
-      <Card.Header>
-        <Flex flexDirection='row' justifyContent='space-between' alignItems='center' mb={2}>
-          <CText fontWeight='bold' color='inherit'>
-            {translate('plugins.foxPage.governanceTitle')}
-          </CText>
-          <Link isExternal href={'#'} fontWeight='semibold' color={linkColor}>
-            <Text translation='plugins.foxPage.seeAllProposals' />
-          </Link>
-        </Flex>
-        <Text
-          translation='Lorem ipsum dolor sit amet, consectetur adipiscing elit. Ut eget elit faucibus'
-          color='gray.500'
-        />
-      </Card.Header>
-      <Card.Body>
-        <Box>
-          <Link
-            isExternal
-            href={'#'}
-            fontWeight='semibold'
-            color={linkColor}
-            mb={4}
-            display='inline-block'
-          >
-            <Text translation='[SCP-71] Proposal to Create the KeepKey Workstream' />
-          </Link>
-          <Box mb={4}>
-            <Flex justifyContent='space-between' mb={2}>
-              <Text translation='plugins.foxPage.for' fontWeight='semibold' />
+    <Skeleton isLoaded={governanceData.loaded}>
+      <Card display='block' width='full'>
+        <Card.Header>
+          <Flex flexDirection='row' justifyContent='space-between' alignItems='center' mb={2}>
+            <CText fontWeight='bold' color='inherit'>
+              {translate('plugins.foxPage.governanceTitle')}
+            </CText>
+            <Link
+              isExternal
+              href={`${BOARDROOM_APP_BASE_URL}/proposals`}
+              fontWeight='semibold'
+              color={linkColor}
+            >
+              <Text translation='plugins.foxPage.seeAllProposals' />
+            </Link>
+          </Flex>
+          <Text
+            translation='Lorem ipsum dolor sit amet, consectetur adipiscing elit. Ut eget elit faucibus'
+            color='gray.500'
+          />
+        </Card.Header>
+        {governanceData?.data.map(proposal => (
+          <Card.Body>
+            <Box>
+              <Link
+                isExternal
+                href={`${BOARDROOM_APP_BASE_URL}/proposal/${proposal.refId}`}
+                fontWeight='semibold'
+                color={linkColor}
+                mb={4}
+                display='inline-block'
+              >
+                <CText>{proposal.title}</CText>
+              </Link>
+              {proposal.choices.map((choice, i) => (
+                <Box mb={4}>
+                  <Flex justifyContent='space-between' mb={2}>
+                    <CText fontWeight='semibold'>{choice}</CText>
 
-              <Flex>
-                <Text translation='2,934,283' fontWeight='semibold' mr={2} />
-                <Badge
-                  colorScheme='blue'
-                  display='flex'
-                  alignItems='center'
-                  px={2}
-                  py={'2px'}
-                  borderRadius='md'
-                >
-                  <Amount.Percent value={'0.6698'} fontWeight='normal' />
-                </Badge>
-              </Flex>
-            </Flex>
-            <Progress value={66.98} height={1} colorScheme='green' />
-          </Box>
-
-          <Box mb={4}>
-            <Flex justifyContent='space-between' mb={2}>
-              <Text translation='plugins.foxPage.against' fontWeight='semibold' />
-
-              <Flex>
-                <Text translation='1,446,828' fontWeight='semibold' mr={2} />
-                <Badge
-                  colorScheme='blue'
-                  display='flex'
-                  alignItems='center'
-                  px={2}
-                  py={'2px'}
-                  borderRadius='md'
-                >
-                  <Amount.Percent value={'0.3302'} fontWeight='normal' />
-                </Badge>
-              </Flex>
-            </Flex>
-            <Progress value={33.02} height={1} colorScheme='green' />
-          </Box>
-        </Box>
-      </Card.Body>
-    </Card>
+                    <Flex>
+                      <CText fontWeight='semibold' mr={2}>
+                        {proposal.results[i].absolute}
+                      </CText>
+                      <Badge
+                        colorScheme='blue'
+                        display='flex'
+                        alignItems='center'
+                        px={2}
+                        py={'2px'}
+                        borderRadius='md'
+                      >
+                        <Amount.Percent value={proposal.results[i].percent} fontWeight='normal' />
+                      </Badge>
+                    </Flex>
+                  </Flex>
+                  <Progress value={66.98} height={1} colorScheme='green' />
+                </Box>
+              ))}
+            </Box>
+          </Card.Body>
+        ))}
+      </Card>
+    </Skeleton>
   )
 }

--- a/src/plugins/foxPage/components/Layout.stories.tsx
+++ b/src/plugins/foxPage/components/Layout.stories.tsx
@@ -27,6 +27,7 @@ import { breakpoints } from 'theme/theme'
 import { AssetActions } from './AssetActions'
 import { FoxOpportunity } from './FoxOpportunity'
 import { FoxTab } from './FoxTab'
+import { Governance } from './Governance'
 import { Layout } from './Layout'
 import { OtherOpportunities } from './OtherOpportunities/OtherOpportunities'
 import { Total } from './Total'
@@ -169,6 +170,7 @@ export const FoxLayout: Story = () => {
                   onClick={() => null}
                 />
                 <OtherOpportunities description={'plugins.foxPage.otherOpportunitiesDescription'} />
+                <Governance />
               </Stack>
               <Stack flex='1 1 0%' width='full' maxWidth={{ base: 'full', xl: 'sm' }} spacing={4}>
                 <AssetActions


### PR DESCRIPTION
## Description

This adds the `<Governance />` component, wired up with the governance service.
This is not app code yet and is just used inside Storybook.

## Notice

<!-- Before submitting a pull request, please make sure you have answered the following: -->

- [x] Have you followed the guidelines in our [Contributing]('https://github.com/shapeshift/web/CONTRIBUTING.md) guide?
- [x] Have you checked to ensure there aren't other open [Pull Requests](https://github.com/shapeshift/web/pulls) for the same update/change?

## Pull Request Type

- [ ] :bug: Bug fix (Non-breaking Change: Fixes an issue)
- [ ] :hammer_and_wrench: Chore (Non-breaking Change: Doc updates, pkg upgrades, typos, etc..)
- [x] :nail_care: New Feature (Breaking/Non-breaking Change)

## Issue (if applicable)

closes #1825

## Risk

None, just a story

## Testing

- Open Storybook FoxPage Layout story
- A skeleton should be shown during governance data load
- Governance data should be shown matching Boardroom/Snapshot data after the data is loaded
- Links should be working 

## Screenshots (if applicable)

<img width="922" alt="image" src="https://user-images.githubusercontent.com/17035424/170598873-ca1e02a8-a20c-458f-a5ce-cc2385a29d5f.png">
<img width="908" alt="image" src="https://user-images.githubusercontent.com/17035424/170599046-c73daae5-c100-4296-a14b-d29bd29fb1af.png">