### PR TITLE
feat: switch DeFi section over to chainId entities

### DIFF
--- a/src/components/StakingVaults/AllEarnOpportunities.tsx
+++ b/src/components/StakingVaults/AllEarnOpportunities.tsx
@@ -1,4 +1,5 @@
 import { Box } from '@chakra-ui/react'
+import { cosmosChainId } from '@shapeshiftoss/caip'
 import {
   EarnOpportunityType,
   useNormalizeOpportunities,
@@ -48,8 +49,7 @@ export const AllEarnOpportunities = () => {
         return
       }
 
-      // TODO(gomes): when we find new home for "supported chainIds", use it here. Don't metastize supportedChainId imports from caip
-      if (chainId === 'cosmos:cosmoshub-4') {
+      if (chainId === cosmosChainId) {
         cosmosStaking.open({
           assetId,
           validatorAddress: contractAddress,

--- a/src/components/StakingVaults/AllEarnOpportunities.tsx
+++ b/src/components/StakingVaults/AllEarnOpportunities.tsx
@@ -1,5 +1,4 @@
 import { Box } from '@chakra-ui/react'
-import { ChainTypes } from '@shapeshiftoss/types'
 import {
   EarnOpportunityType,
   useNormalizeOpportunities,
@@ -42,14 +41,15 @@ export const AllEarnOpportunities = () => {
 
   const handleClick = useCallback(
     (opportunity: EarnOpportunityType) => {
-      const { type, provider, contractAddress, chain, tokenAddress, rewardAddress, assetId } =
+      const { type, provider, contractAddress, chainId, tokenAddress, rewardAddress, assetId } =
         opportunity
       if (!isConnected && walletInfo?.deviceId !== DemoConfig.name) {
         dispatch({ type: WalletActions.SET_WALLET_MODAL, payload: true })
         return
       }
 
-      if (chain === ChainTypes.Cosmos) {
+      // TODO(gomes): when we find new home for "supported chainIds", use it here. Don't metastize supportedChainId imports from caip
+      if (chainId === 'cosmos:cosmoshub-4') {
         cosmosStaking.open({
           assetId,
           validatorAddress: contractAddress,
@@ -61,7 +61,7 @@ export const AllEarnOpportunities = () => {
       history.push({
         pathname: `/defi/${type}/${provider}/overview`,
         search: qs.stringify({
-          chain,
+          chainId,
           contractAddress,
           tokenId: tokenAddress,
           rewardId: rewardAddress,

--- a/src/components/StakingVaults/EarnOpportunities.tsx
+++ b/src/components/StakingVaults/EarnOpportunities.tsx
@@ -46,7 +46,7 @@ export const EarnOpportunities = ({ assetId }: EarnOpportunitiesProps) => {
   }).filter(row => row.tokenAddress.toLowerCase() === asset.tokenId?.toLowerCase())
 
   const handleClick = (opportunity: EarnOpportunityType) => {
-    const { type, provider, contractAddress, chain, tokenAddress, rewardAddress } = opportunity
+    const { type, provider, contractAddress, chainId, tokenAddress, rewardAddress } = opportunity
     if (!isConnected) {
       dispatch({ type: WalletActions.SET_WALLET_MODAL, payload: true })
       return
@@ -62,7 +62,7 @@ export const EarnOpportunities = ({ assetId }: EarnOpportunitiesProps) => {
     history.push({
       pathname,
       search: qs.stringify({
-        chain,
+        chainId,
         contractAddress,
         tokenId: tokenAddress,
         rewardId: rewardAddress,

--- a/src/features/defi/contexts/DefiManagerProvider/DefiCommon.ts
+++ b/src/features/defi/contexts/DefiManagerProvider/DefiCommon.ts
@@ -1,4 +1,4 @@
-import { ChainTypes } from '@shapeshiftoss/types'
+import { ChainId } from '@shapeshiftoss/caip'
 
 export enum DefiType {
   Pool = 'pool',
@@ -27,7 +27,7 @@ export type DefiParams = {
 }
 
 export type DefiQueryParams = {
-  chain: ChainTypes
+  chainId: ChainId
   contractAddress: string
   tokenId: string
   rewardId: string

--- a/src/features/defi/helpers/__snapshots__/normalizeOpportunity.test.tsx.snap
+++ b/src/features/defi/helpers/__snapshots__/normalizeOpportunity.test.tsx.snap
@@ -5,7 +5,7 @@ Array [
   Object {
     "apy": "0.1528209855",
     "assetId": "cosmos:cosmoshub-4/slip44:118",
-    "chain": "cosmos",
+    "chainId": "cosmos:cosmoshub-4",
     "contractAddress": "cosmosvaloper199mlc7fr6ll5t54w7tts7f4s0cvnqgc59nmuxf",
     "cryptoAmount": "0.407785",
     "fiatAmount": "4.2",
@@ -22,7 +22,7 @@ Array [
   Object {
     "apy": "0.1546887975",
     "assetId": "cosmos:cosmoshub-4/slip44:118",
-    "chain": "cosmos",
+    "chainId": "cosmos:cosmoshub-4",
     "contractAddress": "cosmosvaloper1clpqr4nrk4khgkxj78fcwwh6dl3uw4epsluffn",
     "cryptoAmount": "0.013967",
     "fiatAmount": "0.24",

--- a/src/features/defi/helpers/normalizeOpportunity.test.tsx
+++ b/src/features/defi/helpers/normalizeOpportunity.test.tsx
@@ -1,4 +1,3 @@
-import { ChainTypes } from '@shapeshiftoss/types'
 import { renderHook } from '@testing-library/react-hooks'
 import { TestProviders } from 'test/TestProviders'
 import { MergedActiveStakingOpportunity } from 'pages/Defi/hooks/useCosmosStakingBalances'
@@ -23,7 +22,7 @@ const mockCosmosStakingOpportunities = [
     cryptoAmount: '0.407785',
     tvl: '21040543.6367982',
     fiatAmount: '4.2',
-    chain: ChainTypes.Cosmos,
+    chainId: 'cosmos:cosmoshub-4',
     assetId: 'cosmos:cosmoshub-4/slip44:118',
     tokenAddress: '118',
   },
@@ -39,7 +38,7 @@ const mockCosmosStakingOpportunities = [
     cryptoAmount: '0.013967',
     tvl: '63799889.014332',
     fiatAmount: '0.24',
-    chain: ChainTypes.Cosmos,
+    chainId: 'cosmos:cosmoshub-4',
     assetId: 'cosmos:cosmoshub-4/slip44:118',
     tokenAddress: '118',
   },

--- a/src/features/defi/helpers/normalizeOpportunity.test.tsx
+++ b/src/features/defi/helpers/normalizeOpportunity.test.tsx
@@ -1,3 +1,4 @@
+import { cosmosChainId } from '@shapeshiftoss/caip'
 import { renderHook } from '@testing-library/react-hooks'
 import { TestProviders } from 'test/TestProviders'
 import { MergedActiveStakingOpportunity } from 'pages/Defi/hooks/useCosmosStakingBalances'
@@ -22,7 +23,7 @@ const mockCosmosStakingOpportunities = [
     cryptoAmount: '0.407785',
     tvl: '21040543.6367982',
     fiatAmount: '4.2',
-    chainId: 'cosmos:cosmoshub-4',
+    chainId: cosmosChainId,
     assetId: 'cosmos:cosmoshub-4/slip44:118',
     tokenAddress: '118',
   },
@@ -38,7 +39,7 @@ const mockCosmosStakingOpportunities = [
     cryptoAmount: '0.013967',
     tvl: '63799889.014332',
     fiatAmount: '0.24',
-    chainId: 'cosmos:cosmoshub-4',
+    chainId: cosmosChainId,
     assetId: 'cosmos:cosmoshub-4/slip44:118',
     tokenAddress: '118',
   },

--- a/src/features/defi/helpers/normalizeOpportunity.tsx
+++ b/src/features/defi/helpers/normalizeOpportunity.tsx
@@ -1,6 +1,5 @@
-import { AssetId, toAssetId } from '@shapeshiftoss/caip'
+import { AssetId, ChainId, toAssetId } from '@shapeshiftoss/caip'
 import { SupportedYearnVault } from '@shapeshiftoss/investor-yearn'
-import { ChainTypes } from '@shapeshiftoss/types'
 import { USDC_PRECISION } from 'constants/UsdcPrecision'
 import { useTranslate } from 'react-polyglot'
 import { useSelector } from 'react-redux'
@@ -12,7 +11,7 @@ import { useVaultBalances } from 'pages/Defi/hooks/useVaultBalances'
 import { selectAssetIds } from 'state/slices/selectors'
 
 import { DefiType } from '../contexts/DefiManagerProvider/DefiCommon'
-import { chainTypeToLabel } from './utils'
+import { chainIdToLabel } from './utils'
 
 export type EarnOpportunityType = {
   type?: string
@@ -27,7 +26,7 @@ export type EarnOpportunityType = {
   fiatAmount: string
   cryptoAmount: string
   expired?: boolean
-  chain: ChainTypes
+  chainId: ChainId
   moniker?: string
   showAssetSymbol?: boolean
   isLoaded: boolean
@@ -62,7 +61,7 @@ const useTransformVault = (vaults: SupportedYearnVault[]): EarnOpportunityType[]
       tvl: bnOrZero(vault.underlyingTokenBalance.amountUsdc).div(`1e+${USDC_PRECISION}`).toString(),
       apy: vault.metadata.apy?.net_apy,
       expired: vault.expired,
-      chain: vault.chain,
+      chainId,
       assetId,
       fiatAmount,
       cryptoAmount,
@@ -101,7 +100,7 @@ const transformFoxy = (foxies: MergedFoxyOpportunity[]): EarnOpportunityType[] =
       tvl,
       apy,
       expired,
-      chain,
+      chainId,
       tokenAssetId: assetId,
       fiatAmount,
       cryptoAmount,
@@ -115,7 +114,7 @@ const transformFoxy = (foxies: MergedFoxyOpportunity[]): EarnOpportunityType[] =
       tvl: bnOrZero(tvl).toString(),
       apy,
       expired,
-      chain,
+      chainId,
       assetId,
       fiatAmount,
       cryptoAmount,
@@ -133,13 +132,13 @@ const useTransformCosmosStaking = (
     .map(staking => {
       return {
         type: DefiType.TokenStaking,
-        provider: chainTypeToLabel(staking.chain),
+        provider: chainIdToLabel(staking.chainId),
         contractAddress: staking.address,
         tokenAddress: staking.tokenAddress,
         rewardAddress: '',
         tvl: staking.tvl,
         apy: staking.apr,
-        chain: staking.chain,
+        chainId: staking.chainId,
         assetId: staking.assetId,
         fiatAmount: staking.fiatAmount ?? '',
         cryptoAmount: staking.cryptoAmount ?? '',

--- a/src/features/defi/helpers/utils.test.ts
+++ b/src/features/defi/helpers/utils.test.ts
@@ -1,16 +1,14 @@
-import { ChainTypes } from '@shapeshiftoss/types'
+import { chainIdToLabel } from './utils'
 
-import { chainTypeToLabel } from './utils'
-
-describe('chainTypeToLabel', () => {
+describe('chainIdToLabel', () => {
   it('can get label from chaintype', () => {
-    let result = chainTypeToLabel(ChainTypes.Cosmos)
+    let result = chainIdToLabel('cosmos:cosmoshub-4')
     expect(result).toEqual('Cosmos')
 
-    result = chainTypeToLabel(ChainTypes.Osmosis)
+    result = chainIdToLabel('cosmos:osmosis-1')
     expect(result).toEqual('Osmosis')
 
-    result = chainTypeToLabel(ChainTypes.Ethereum)
+    result = chainIdToLabel('eip155:1')
     expect(result).toEqual('')
   })
 })

--- a/src/features/defi/helpers/utils.test.ts
+++ b/src/features/defi/helpers/utils.test.ts
@@ -1,14 +1,16 @@
+import { cosmosChainId, ethChainId, osmosisChainId } from '@shapeshiftoss/caip'
+
 import { chainIdToLabel } from './utils'
 
 describe('chainIdToLabel', () => {
   it('can get label from chaintype', () => {
-    let result = chainIdToLabel('cosmos:cosmoshub-4')
+    let result = chainIdToLabel(cosmosChainId)
     expect(result).toEqual('Cosmos')
 
-    result = chainIdToLabel('cosmos:osmosis-1')
+    result = chainIdToLabel(osmosisChainId)
     expect(result).toEqual('Osmosis')
 
-    result = chainIdToLabel('eip155:1')
+    result = chainIdToLabel(ethChainId)
     expect(result).toEqual('')
   })
 })

--- a/src/features/defi/helpers/utils.ts
+++ b/src/features/defi/helpers/utils.ts
@@ -1,10 +1,11 @@
+import { cosmosChainId, osmosisChainId } from '@shapeshiftoss/caip'
 import { ChainId } from '@shapeshiftoss/caip'
 
 export const chainIdToLabel = (chainId: ChainId): string => {
   switch (chainId) {
-    case 'cosmos:cosmoshub-4':
+    case cosmosChainId:
       return 'Cosmos'
-    case 'cosmos:osmosis-1':
+    case osmosisChainId:
       return 'Osmosis'
     default: {
       return ''

--- a/src/features/defi/helpers/utils.ts
+++ b/src/features/defi/helpers/utils.ts
@@ -1,10 +1,10 @@
-import { ChainTypes } from '@shapeshiftoss/types'
+import { ChainId } from '@shapeshiftoss/caip'
 
-export const chainTypeToLabel = (chain: ChainTypes): string => {
-  switch (chain) {
-    case ChainTypes.Cosmos:
+export const chainIdToLabel = (chainId: ChainId): string => {
+  switch (chainId) {
+    case 'cosmos:cosmoshub-4':
       return 'Cosmos'
-    case ChainTypes.Osmosis:
+    case 'cosmos:osmosis-1':
       return 'Osmosis'
     default: {
       return ''

--- a/src/features/defi/providers/foxy/components/FoxyManager/Deposit/FoxyDeposit.tsx
+++ b/src/features/defi/providers/foxy/components/FoxyManager/Deposit/FoxyDeposit.tsx
@@ -1,5 +1,5 @@
 import { Center, Flex, useToast } from '@chakra-ui/react'
-import { toAssetId } from '@shapeshiftoss/caip'
+import { fromChainId, toAssetId } from '@shapeshiftoss/caip'
 import { FoxyApi } from '@shapeshiftoss/investor-foxy'
 import { DepositValues } from 'features/defi/components/Deposit/Deposit'
 import { DefiParams, DefiQueryParams } from 'features/defi/contexts/DefiManagerProvider/DefiCommon'
@@ -40,8 +40,7 @@ export const FoxyDeposit = ({ api }: FoxyDepositProps) => {
   const translate = useTranslate()
   const toast = useToast()
   const { query } = useBrowserRouter<DefiQueryParams, DefiParams>()
-  const { chain, contractAddress, tokenId } = query
-  const chainId = chainTypeToMainnetChainId(chain)
+  const { chainId, contractAddress, tokenId } = query
   const assetNamespace = 'erc20'
   const assetId = toAssetId({ chainId, assetNamespace, assetReference: tokenId })
 

--- a/src/features/defi/providers/foxy/components/FoxyManager/Deposit/FoxyDeposit.tsx
+++ b/src/features/defi/providers/foxy/components/FoxyManager/Deposit/FoxyDeposit.tsx
@@ -1,5 +1,5 @@
 import { Center, Flex, useToast } from '@chakra-ui/react'
-import { fromChainId, toAssetId } from '@shapeshiftoss/caip'
+import { toAssetId } from '@shapeshiftoss/caip'
 import { FoxyApi } from '@shapeshiftoss/investor-foxy'
 import { DepositValues } from 'features/defi/components/Deposit/Deposit'
 import { DefiParams, DefiQueryParams } from 'features/defi/contexts/DefiManagerProvider/DefiCommon'
@@ -14,7 +14,6 @@ import { useChainAdapters } from 'context/PluginProvider/PluginProvider'
 import { useBrowserRouter } from 'hooks/useBrowserRouter/useBrowserRouter'
 import { useWallet } from 'hooks/useWallet/useWallet'
 import { bnOrZero } from 'lib/bignumber/bignumber'
-import { chainTypeToMainnetChainId } from 'lib/utils'
 import {
   selectAssetById,
   selectMarketDataById,

--- a/src/features/defi/providers/foxy/components/FoxyManager/Deposit/components/Approve.tsx
+++ b/src/features/defi/providers/foxy/components/FoxyManager/Deposit/components/Approve.tsx
@@ -12,7 +12,6 @@ import { useBrowserRouter } from 'hooks/useBrowserRouter/useBrowserRouter'
 import { useWallet } from 'hooks/useWallet/useWallet'
 import { bnOrZero } from 'lib/bignumber/bignumber'
 import { poll } from 'lib/poll/poll'
-import { chainTypeToMainnetChainId } from 'lib/utils'
 import { selectAssetById, selectMarketDataById } from 'state/slices/selectors'
 import { useAppSelector } from 'state/store'
 
@@ -30,9 +29,8 @@ export const Approve = ({ api, getDepositGasEstimate }: FoxyApproveProps) => {
   const translate = useTranslate()
   const toast = useToast()
   const { query } = useBrowserRouter<DefiQueryParams, DefiParams>()
-  const { chain, contractAddress, tokenId } = query
+  const { chainId, contractAddress, tokenId } = query
   const alertText = useColorModeValue('blue.800', 'white')
-  const chainId = chainTypeToMainnetChainId(chain)
   const assetNamespace = 'erc20'
   const assetId = toAssetId({ chainId, assetNamespace, assetReference: tokenId })
   const feeAssetId = toAssetId({

--- a/src/features/defi/providers/foxy/components/FoxyManager/Deposit/components/Confirm.tsx
+++ b/src/features/defi/providers/foxy/components/FoxyManager/Deposit/components/Confirm.tsx
@@ -16,7 +16,6 @@ import { useBrowserRouter } from 'hooks/useBrowserRouter/useBrowserRouter'
 import { useWallet } from 'hooks/useWallet/useWallet'
 import { bnOrZero } from 'lib/bignumber/bignumber'
 import { poll } from 'lib/poll/poll'
-import { chainTypeToMainnetChainId } from 'lib/utils'
 import { selectAssetById, selectMarketDataById } from 'state/slices/selectors'
 import { useAppSelector } from 'state/store'
 
@@ -33,8 +32,7 @@ export const Confirm = ({ api, apy }: FoxyConfirmProps) => {
   const history = useHistory()
   const translate = useTranslate()
   const { query } = useBrowserRouter<DefiQueryParams, DefiParams>()
-  const { chain, contractAddress, tokenId, rewardId } = query
-  const chainId = chainTypeToMainnetChainId(chain)
+  const { chainId, contractAddress, tokenId, rewardId } = query
   const assetNamespace = 'erc20'
   const assetId = toAssetId({ chainId, assetNamespace, assetReference: tokenId })
   const feeAssetId = toAssetId({

--- a/src/features/defi/providers/foxy/components/FoxyManager/Deposit/components/Deposit.tsx
+++ b/src/features/defi/providers/foxy/components/FoxyManager/Deposit/components/Deposit.tsx
@@ -8,7 +8,6 @@ import { useTranslate } from 'react-polyglot'
 import { useHistory } from 'react-router-dom'
 import { useBrowserRouter } from 'hooks/useBrowserRouter/useBrowserRouter'
 import { bnOrZero } from 'lib/bignumber/bignumber'
-import { chainTypeToMainnetChainId } from 'lib/utils'
 import {
   selectAssetById,
   selectMarketDataById,
@@ -30,8 +29,7 @@ export const Deposit = ({ api, apy, getDepositGasEstimate }: FoxyDepositProps) =
   const history = useHistory()
   const translate = useTranslate()
   const { query } = useBrowserRouter<DefiQueryParams, DefiParams>()
-  const { chain, contractAddress, tokenId } = query
-  const chainId = chainTypeToMainnetChainId(chain)
+  const { chainId, contractAddress, tokenId } = query
   const assetNamespace = 'erc20'
   const assetId = toAssetId({ chainId, assetNamespace, assetReference: tokenId })
 

--- a/src/features/defi/providers/foxy/components/FoxyManager/Deposit/components/Status.tsx
+++ b/src/features/defi/providers/foxy/components/FoxyManager/Deposit/components/Status.tsx
@@ -13,7 +13,6 @@ import { Row } from 'components/Row/Row'
 import { Text } from 'components/Text'
 import { useBrowserRouter } from 'hooks/useBrowserRouter/useBrowserRouter'
 import { bnOrZero } from 'lib/bignumber/bignumber'
-import { chainTypeToMainnetChainId } from 'lib/utils'
 import { selectAssetById, selectMarketDataById } from 'state/slices/selectors'
 import { useAppSelector } from 'state/store'
 
@@ -28,8 +27,7 @@ export const Status = ({ apy }: FoxyStatusProps) => {
   const { state } = useContext(DepositContext)
   const history = useHistory()
   const { query, history: browserHistory } = useBrowserRouter<DefiQueryParams, DefiParams>()
-  const { chain, tokenId, rewardId } = query
-  const chainId = chainTypeToMainnetChainId(chain)
+  const { chainId, tokenId, rewardId } = query
   const assetNamespace = 'erc20'
   const defaultStatusBg = useColorModeValue('white', 'gray.700')
   const assetId = toAssetId({ chainId, assetNamespace, assetReference: tokenId })

--- a/src/features/defi/providers/foxy/components/FoxyManager/Overview/Claim/ClaimConfirm.tsx
+++ b/src/features/defi/providers/foxy/components/FoxyManager/Overview/Claim/ClaimConfirm.tsx
@@ -8,8 +8,7 @@ import {
   Stack,
   useToast,
 } from '@chakra-ui/react'
-import { ASSET_REFERENCE, AssetId, toAssetId } from '@shapeshiftoss/caip'
-import { ChainTypes } from '@shapeshiftoss/types'
+import { ASSET_REFERENCE, AssetId, ChainId, toAssetId } from '@shapeshiftoss/caip'
 import { useFoxy } from 'features/defi/contexts/FoxyProvider/FoxyProvider'
 import { useEffect, useState } from 'react'
 import { useTranslate } from 'react-polyglot'
@@ -23,7 +22,6 @@ import { Text } from 'components/Text'
 import { useChainAdapters } from 'context/PluginProvider/PluginProvider'
 import { useWallet } from 'hooks/useWallet/useWallet'
 import { bnOrZero } from 'lib/bignumber/bignumber'
-import { chainTypeToMainnetChainId } from 'lib/utils'
 import { selectAssetById, selectMarketDataById } from 'state/slices/selectors'
 import { useAppSelector } from 'state/store'
 
@@ -31,7 +29,7 @@ type ClaimConfirmProps = {
   assetId: AssetId
   amount?: string
   contractAddress: string
-  chain: ChainTypes
+  chainId: ChainId
   onBack: () => void
 }
 
@@ -39,7 +37,7 @@ export const ClaimConfirm = ({
   assetId,
   amount,
   contractAddress,
-  chain,
+  chainId,
   onBack,
 }: ClaimConfirmProps) => {
   const [userAddress, setUserAddress] = useState<string>('')
@@ -53,7 +51,6 @@ export const ClaimConfirm = ({
   const history = useHistory()
 
   // Asset Info
-  const chainId = chainTypeToMainnetChainId(chain)
   const asset = useAppSelector(state => selectAssetById(state, assetId))
   const feeAssetId = toAssetId({
     chainId,
@@ -81,7 +78,7 @@ export const ClaimConfirm = ({
         amount,
         userAddress,
         estimatedGas,
-        chain,
+        chainId,
       })
     } catch (error) {
       console.error('ClaimWithdraw:handleConfirm error', error)

--- a/src/features/defi/providers/foxy/components/FoxyManager/Overview/Claim/ClaimRoutes.tsx
+++ b/src/features/defi/providers/foxy/components/FoxyManager/Overview/Claim/ClaimRoutes.tsx
@@ -1,15 +1,10 @@
-<<<<<<< HEAD
-import { fromChainId, toAssetId } from '@shapeshiftoss/caip'
-=======
-import { fromChainId, toAssetId } from '@shapeshiftoss/caip'
->>>>>>> 23e5c817 (feat: DeFi chain -> chainId qs refactor)
+import { toAssetId } from '@shapeshiftoss/caip'
 import { DefiParams, DefiQueryParams } from 'features/defi/contexts/DefiManagerProvider/DefiCommon'
 import { AnimatePresence } from 'framer-motion'
 import { Route, Switch, useLocation } from 'react-router'
 import { RouteSteps } from 'components/RouteSteps/RouteSteps'
 import { SlideTransition } from 'components/SlideTransition'
 import { useBrowserRouter } from 'hooks/useBrowserRouter/useBrowserRouter'
-import { chainTypeToMainnetChainId } from 'lib/utils'
 import { useFoxyBalances } from 'pages/Defi/hooks/useFoxyBalances'
 
 import { ClaimConfirm } from './ClaimConfirm'
@@ -32,7 +27,7 @@ type ClaimRouteProps = {
 export const ClaimRoutes = ({ onBack }: ClaimRouteProps) => {
   const { query } = useBrowserRouter<DefiQueryParams, DefiParams>()
   const { contractAddress, tokenId, chainId } = query
-  const { chain } = fromChainId(chainId)
+
   const assetNamespace = 'erc20'
   const stakingAssetId = toAssetId({
     chainId,
@@ -51,7 +46,7 @@ export const ClaimRoutes = ({ onBack }: ClaimRouteProps) => {
           <Route exact path='/'>
             <ClaimConfirm
               assetId={stakingAssetId}
-              chain={chain}
+              chainId={chainId}
               contractAddress={contractAddress}
               onBack={onBack}
               amount={opportunity?.withdrawInfo.amount}

--- a/src/features/defi/providers/foxy/components/FoxyManager/Overview/Claim/ClaimRoutes.tsx
+++ b/src/features/defi/providers/foxy/components/FoxyManager/Overview/Claim/ClaimRoutes.tsx
@@ -1,4 +1,8 @@
-import { toAssetId } from '@shapeshiftoss/caip'
+<<<<<<< HEAD
+import { fromChainId, toAssetId } from '@shapeshiftoss/caip'
+=======
+import { fromChainId, toAssetId } from '@shapeshiftoss/caip'
+>>>>>>> 23e5c817 (feat: DeFi chain -> chainId qs refactor)
 import { DefiParams, DefiQueryParams } from 'features/defi/contexts/DefiManagerProvider/DefiCommon'
 import { AnimatePresence } from 'framer-motion'
 import { Route, Switch, useLocation } from 'react-router'
@@ -27,8 +31,8 @@ type ClaimRouteProps = {
 
 export const ClaimRoutes = ({ onBack }: ClaimRouteProps) => {
   const { query } = useBrowserRouter<DefiQueryParams, DefiParams>()
-  const { contractAddress, tokenId, chain } = query
-  const chainId = chainTypeToMainnetChainId(chain)
+  const { contractAddress, tokenId, chainId } = query
+  const { chain } = fromChainId(chainId)
   const assetNamespace = 'erc20'
   const stakingAssetId = toAssetId({
     chainId,

--- a/src/features/defi/providers/foxy/components/FoxyManager/Overview/Claim/ClaimStatus.tsx
+++ b/src/features/defi/providers/foxy/components/FoxyManager/Overview/Claim/ClaimStatus.tsx
@@ -1,6 +1,5 @@
 import { Box, Button, Center, Link, ModalBody, ModalFooter, Stack } from '@chakra-ui/react'
-import { ASSET_REFERENCE, AssetId, toAssetId } from '@shapeshiftoss/caip'
-import { ChainTypes } from '@shapeshiftoss/types'
+import { ASSET_REFERENCE, AssetId, ChainId, toAssetId } from '@shapeshiftoss/caip'
 import { useFoxy } from 'features/defi/contexts/FoxyProvider/FoxyProvider'
 import isNil from 'lodash/isNil'
 import { useEffect, useState } from 'react'
@@ -19,7 +18,6 @@ import { RawText } from 'components/Text'
 import { useBrowserRouter } from 'hooks/useBrowserRouter/useBrowserRouter'
 import { bnOrZero } from 'lib/bignumber/bignumber'
 import { poll } from 'lib/poll/poll'
-import { chainTypeToMainnetChainId } from 'lib/utils'
 import { selectAssetById, selectMarketDataById } from 'state/slices/selectors'
 import { useAppSelector } from 'state/store'
 
@@ -31,7 +29,7 @@ interface ClaimStatusState {
   estimatedGas: string
   usedGasFee?: string
   status: string
-  chain: ChainTypes
+  chainId: ChainId
 }
 
 enum TxStatus {
@@ -67,14 +65,13 @@ export const ClaimStatus = () => {
   const { foxy } = useFoxy()
   const translate = useTranslate()
   const {
-    state: { txid, amount, assetId, userAddress, estimatedGas, chain },
+    state: { txid, amount, assetId, userAddress, estimatedGas, chainId },
   } = useLocation<ClaimStatusState>()
   const [state, setState] = useState<ClaimState>({
     txStatus: TxStatus.PENDING,
   })
 
   // Asset Info
-  const chainId = chainTypeToMainnetChainId(chain)
   const asset = useAppSelector(state => selectAssetById(state, assetId))
   const feeAssetId = toAssetId({
     chainId,

--- a/src/features/defi/providers/foxy/components/FoxyManager/Overview/FoxyDetails.tsx
+++ b/src/features/defi/providers/foxy/components/FoxyManager/Overview/FoxyDetails.tsx
@@ -8,7 +8,6 @@ import { CircularProgress } from 'components/CircularProgress/CircularProgress'
 import { Text } from 'components/Text'
 import { useBrowserRouter } from 'hooks/useBrowserRouter/useBrowserRouter'
 import { bnOrZero } from 'lib/bignumber/bignumber'
-import { chainTypeToMainnetChainId } from 'lib/utils'
 import { useFoxyBalances } from 'pages/Defi/hooks/useFoxyBalances'
 import { selectAssetById } from 'state/slices/selectors'
 import { useAppSelector } from 'state/store'
@@ -27,11 +26,10 @@ export const FoxyDetails = () => {
     path: '/defi/:earnType/:provider/:action',
     exact: true,
   })
-  const { chain, contractAddress, tokenId, rewardId } = query
+  const { chainId, contractAddress, tokenId, rewardId } = query
   const opportunity = opportunities.find(e => e.contractAddress === contractAddress)
   const rewardBalance = bnOrZero(opportunity?.withdrawInfo.amount)
   const foxyBalance = bnOrZero(opportunity?.balance)
-  const chainId = chainTypeToMainnetChainId(chain)
   const assetNamespace = 'erc20'
   const stakingAssetId = toAssetId({
     chainId,

--- a/src/features/defi/providers/foxy/components/FoxyManager/Withdraw/FoxyWithdraw.tsx
+++ b/src/features/defi/providers/foxy/components/FoxyManager/Withdraw/FoxyWithdraw.tsx
@@ -15,7 +15,6 @@ import { useChainAdapters } from 'context/PluginProvider/PluginProvider'
 import { useBrowserRouter } from 'hooks/useBrowserRouter/useBrowserRouter'
 import { useWallet } from 'hooks/useWallet/useWallet'
 import { bn, bnOrZero } from 'lib/bignumber/bignumber'
-import { chainTypeToMainnetChainId } from 'lib/utils'
 import {
   selectAssetById,
   selectMarketDataById,
@@ -40,10 +39,9 @@ export const FoxyWithdraw = ({ api }: FoxyWithdrawProps) => {
   const location = useLocation()
   const translate = useTranslate()
   const { query } = useBrowserRouter<DefiQueryParams, DefiParams>()
-  const { chain, contractAddress, rewardId } = query
+  const { chainId, contractAddress, rewardId } = query
   const toast = useToast()
 
-  const chainId = chainTypeToMainnetChainId(chain)
   const assetNamespace = 'erc20'
   // Asset info
   const assetId = toAssetId({

--- a/src/features/defi/providers/foxy/components/FoxyManager/Withdraw/components/Approve.tsx
+++ b/src/features/defi/providers/foxy/components/FoxyManager/Withdraw/components/Approve.tsx
@@ -32,7 +32,6 @@ export const Approve = ({ api, getWithdrawGasEstimate }: FoxyApproveProps) => {
   const { chainId, contractAddress, rewardId } = query
   const toast = useToast()
 
-  const chainId = chainTypeToMainnetChainId(chain)
   const assetNamespace = 'erc20'
   // Asset info
   const assetId = toAssetId({

--- a/src/features/defi/providers/foxy/components/FoxyManager/Withdraw/components/Approve.tsx
+++ b/src/features/defi/providers/foxy/components/FoxyManager/Withdraw/components/Approve.tsx
@@ -12,7 +12,6 @@ import { useBrowserRouter } from 'hooks/useBrowserRouter/useBrowserRouter'
 import { useWallet } from 'hooks/useWallet/useWallet'
 import { bn, bnOrZero } from 'lib/bignumber/bignumber'
 import { poll } from 'lib/poll/poll'
-import { chainTypeToMainnetChainId } from 'lib/utils'
 import { selectAssetById, selectMarketDataById } from 'state/slices/selectors'
 import { useAppSelector } from 'state/store'
 
@@ -30,7 +29,7 @@ export const Approve = ({ api, getWithdrawGasEstimate }: FoxyApproveProps) => {
   const translate = useTranslate()
   const alertText = useColorModeValue('blue.800', 'white')
   const { query } = useBrowserRouter<DefiQueryParams, DefiParams>()
-  const { chain, contractAddress, rewardId } = query
+  const { chainId, contractAddress, rewardId } = query
   const toast = useToast()
 
   const chainId = chainTypeToMainnetChainId(chain)

--- a/src/features/defi/providers/foxy/components/FoxyManager/Withdraw/components/Confirm.tsx
+++ b/src/features/defi/providers/foxy/components/FoxyManager/Withdraw/components/Confirm.tsx
@@ -17,7 +17,6 @@ import { useBrowserRouter } from 'hooks/useBrowserRouter/useBrowserRouter'
 import { useWallet } from 'hooks/useWallet/useWallet'
 import { bn, bnOrZero } from 'lib/bignumber/bignumber'
 import { poll } from 'lib/poll/poll'
-import { chainTypeToMainnetChainId } from 'lib/utils'
 import { selectAssetById, selectMarketDataById } from 'state/slices/selectors'
 import { useAppSelector } from 'state/store'
 
@@ -33,7 +32,7 @@ export const Confirm = ({ api }: FoxyConfirmProps) => {
   const history = useHistory()
   const translate = useTranslate()
   const { query } = useBrowserRouter<DefiQueryParams, DefiParams>()
-  const { chain, contractAddress, tokenId, rewardId } = query
+  const { chainId, contractAddress, tokenId, rewardId } = query
 
   const chainId = chainTypeToMainnetChainId(chain)
   const assetNamespace = 'erc20'

--- a/src/features/defi/providers/foxy/components/FoxyManager/Withdraw/components/Confirm.tsx
+++ b/src/features/defi/providers/foxy/components/FoxyManager/Withdraw/components/Confirm.tsx
@@ -34,7 +34,6 @@ export const Confirm = ({ api }: FoxyConfirmProps) => {
   const { query } = useBrowserRouter<DefiQueryParams, DefiParams>()
   const { chainId, contractAddress, tokenId, rewardId } = query
 
-  const chainId = chainTypeToMainnetChainId(chain)
   const assetNamespace = 'erc20'
   // Asset info
   const underlyingAssetId = toAssetId({

--- a/src/features/defi/providers/foxy/components/FoxyManager/Withdraw/components/Status.tsx
+++ b/src/features/defi/providers/foxy/components/FoxyManager/Withdraw/components/Status.tsx
@@ -12,7 +12,6 @@ import { Row } from 'components/Row/Row'
 import { Text } from 'components/Text'
 import { useBrowserRouter } from 'hooks/useBrowserRouter/useBrowserRouter'
 import { bn, bnOrZero } from 'lib/bignumber/bignumber'
-import { chainTypeToMainnetChainId } from 'lib/utils'
 import { selectAssetById, selectMarketDataById } from 'state/slices/selectors'
 import { useAppSelector } from 'state/store'
 
@@ -21,10 +20,9 @@ import { WithdrawContext } from '../WithdrawContext'
 export const Status = () => {
   const { state, dispatch } = useContext(WithdrawContext)
   const { query, history: browserHistory } = useBrowserRouter<DefiQueryParams, DefiParams>()
-  const { chain, tokenId, rewardId } = query
+  const { chainId, tokenId, rewardId } = query
   const defaultStatusBg = useColorModeValue('white', 'gray.700')
 
-  const chainId = chainTypeToMainnetChainId(chain)
   const assetNamespace = 'erc20'
   // Asset info
   const underlyingAssetId = toAssetId({

--- a/src/features/defi/providers/foxy/components/FoxyManager/Withdraw/components/Withdraw.tsx
+++ b/src/features/defi/providers/foxy/components/FoxyManager/Withdraw/components/Withdraw.tsx
@@ -15,7 +15,6 @@ import { Row } from 'components/Row/Row'
 import { Text } from 'components/Text'
 import { useBrowserRouter } from 'hooks/useBrowserRouter/useBrowserRouter'
 import { bn, bnOrZero } from 'lib/bignumber/bignumber'
-import { chainTypeToMainnetChainId } from 'lib/utils'
 import {
   selectAssetById,
   selectMarketDataById,
@@ -36,10 +35,9 @@ export const Withdraw = ({ api, getWithdrawGasEstimate }: FoxyWithdrawProps) => 
   const history = useHistory()
   const translate = useTranslate()
   const { query, history: browserHistory } = useBrowserRouter<DefiQueryParams, DefiParams>()
-  const { chain, contractAddress, rewardId } = query
+  const { chainId, contractAddress, rewardId } = query
   const toast = useToast()
 
-  const chainId = chainTypeToMainnetChainId(chain)
   const assetNamespace = 'erc20'
   // Asset info
   const assetId = toAssetId({

--- a/src/features/defi/providers/yearn/components/YearnManager/Deposit/YearnDeposit.tsx
+++ b/src/features/defi/providers/yearn/components/YearnManager/Deposit/YearnDeposit.tsx
@@ -15,7 +15,6 @@ import { useChainAdapters } from 'context/PluginProvider/PluginProvider'
 import { useBrowserRouter } from 'hooks/useBrowserRouter/useBrowserRouter'
 import { useWallet } from 'hooks/useWallet/useWallet'
 import { bnOrZero } from 'lib/bignumber/bignumber'
-import { chainTypeToMainnetChainId } from 'lib/utils'
 import {
   selectAssetById,
   selectMarketDataById,
@@ -41,9 +40,8 @@ export const YearnDeposit = ({ api }: YearnDepositProps) => {
   const translate = useTranslate()
   const toast = useToast()
   const { query } = useBrowserRouter<DefiQueryParams, DefiParams>()
-  const { chain, contractAddress: vaultAddress, tokenId } = query
+  const { chainId, contractAddress: vaultAddress, tokenId } = query
 
-  const chainId = chainTypeToMainnetChainId(chain)
   const assetNamespace = 'erc20'
   const assetId = toAssetId({ chainId, assetNamespace, assetReference: tokenId })
   const asset = useAppSelector(state => selectAssetById(state, assetId))

--- a/src/features/defi/providers/yearn/components/YearnManager/Deposit/components/Approve.tsx
+++ b/src/features/defi/providers/yearn/components/YearnManager/Deposit/components/Approve.tsx
@@ -12,7 +12,6 @@ import { useBrowserRouter } from 'hooks/useBrowserRouter/useBrowserRouter'
 import { useWallet } from 'hooks/useWallet/useWallet'
 import { bnOrZero } from 'lib/bignumber/bignumber'
 import { poll } from 'lib/poll/poll'
-import { chainTypeToMainnetChainId } from 'lib/utils'
 import { selectAssetById, selectMarketDataById } from 'state/slices/selectors'
 import { useAppSelector } from 'state/store'
 
@@ -29,10 +28,9 @@ export const Approve = ({ api, getDepositGasEstimate }: YearnApproveProps) => {
   const history = useHistory()
   const translate = useTranslate()
   const { query } = useBrowserRouter<DefiQueryParams, DefiParams>()
-  const { chain, tokenId } = query
+  const { chainId, tokenId } = query
   const alertText = useColorModeValue('blue.800', 'white')
 
-  const chainId = chainTypeToMainnetChainId(chain)
   const assetNamespace = 'erc20'
   const assetId = toAssetId({ chainId, assetNamespace, assetReference: tokenId })
   const feeAssetId = toAssetId({

--- a/src/features/defi/providers/yearn/components/YearnManager/Deposit/components/Confirm.tsx
+++ b/src/features/defi/providers/yearn/components/YearnManager/Deposit/components/Confirm.tsx
@@ -16,7 +16,6 @@ import { useBrowserRouter } from 'hooks/useBrowserRouter/useBrowserRouter'
 import { useWallet } from 'hooks/useWallet/useWallet'
 import { bnOrZero } from 'lib/bignumber/bignumber'
 import { poll } from 'lib/poll/poll'
-import { chainTypeToMainnetChainId } from 'lib/utils'
 import { selectAssetById, selectMarketDataById } from 'state/slices/selectors'
 import { useAppSelector } from 'state/store'
 
@@ -32,9 +31,8 @@ export const Confirm = ({ api }: YearnConfirmProps) => {
   const history = useHistory()
   const translate = useTranslate()
   const { query, history: browserHistory } = useBrowserRouter<DefiQueryParams, DefiParams>()
-  const { chain, contractAddress: vaultAddress, tokenId } = query
+  const { chainId, contractAddress: vaultAddress, tokenId } = query
 
-  const chainId = chainTypeToMainnetChainId(chain)
   const assetNamespace = 'erc20'
   const assetId = toAssetId({ chainId, assetNamespace, assetReference: tokenId })
   const feeAssetId = toAssetId({

--- a/src/features/defi/providers/yearn/components/YearnManager/Deposit/components/Deposit.tsx
+++ b/src/features/defi/providers/yearn/components/YearnManager/Deposit/components/Deposit.tsx
@@ -8,7 +8,6 @@ import { useTranslate } from 'react-polyglot'
 import { useHistory } from 'react-router-dom'
 import { useBrowserRouter } from 'hooks/useBrowserRouter/useBrowserRouter'
 import { bnOrZero } from 'lib/bignumber/bignumber'
-import { chainTypeToMainnetChainId } from 'lib/utils'
 import {
   selectAssetById,
   selectMarketDataById,
@@ -30,9 +29,8 @@ export const Deposit = ({ api, apy, getDepositGasEstimate }: YearnDepositProps) 
   const history = useHistory()
   const translate = useTranslate()
   const { query, history: browserHistory } = useBrowserRouter<DefiQueryParams, DefiParams>()
-  const { chain, tokenId } = query
+  const { chainId, tokenId } = query
 
-  const chainId = chainTypeToMainnetChainId(chain)
   const assetNamespace = 'erc20'
   const assetId = toAssetId({ chainId, assetNamespace, assetReference: tokenId })
   const asset = useAppSelector(state => selectAssetById(state, assetId))

--- a/src/features/defi/providers/yearn/components/YearnManager/Deposit/components/Status.tsx
+++ b/src/features/defi/providers/yearn/components/YearnManager/Deposit/components/Status.tsx
@@ -11,7 +11,6 @@ import { Row } from 'components/Row/Row'
 import { Text } from 'components/Text'
 import { useBrowserRouter } from 'hooks/useBrowserRouter/useBrowserRouter'
 import { bnOrZero } from 'lib/bignumber/bignumber'
-import { chainTypeToMainnetChainId } from 'lib/utils'
 import { selectAssetById, selectMarketDataById } from 'state/slices/selectors'
 import { useAppSelector } from 'state/store'
 
@@ -20,9 +19,8 @@ import { DepositContext } from '../DepositContext'
 export const Status = () => {
   const { state } = useContext(DepositContext)
   const { query, history: browserHistory } = useBrowserRouter<DefiQueryParams, DefiParams>()
-  const { chain, contractAddress: vaultAddress, tokenId } = query
+  const { chainId, contractAddress: vaultAddress, tokenId } = query
 
-  const chainId = chainTypeToMainnetChainId(chain)
   const assetNamespace = 'erc20'
   const assetId = toAssetId({ chainId, assetNamespace, assetReference: tokenId })
   const feeAssetId = toAssetId({

--- a/src/features/defi/providers/yearn/components/YearnManager/Withdraw/YearnWithdraw.tsx
+++ b/src/features/defi/providers/yearn/components/YearnManager/Withdraw/YearnWithdraw.tsx
@@ -12,7 +12,6 @@ import { RouteSteps } from 'components/RouteSteps/RouteSteps'
 import { useChainAdapters } from 'context/PluginProvider/PluginProvider'
 import { useBrowserRouter } from 'hooks/useBrowserRouter/useBrowserRouter'
 import { useWallet } from 'hooks/useWallet/useWallet'
-import { chainTypeToMainnetChainId } from 'lib/utils'
 import {
   selectAssetById,
   selectMarketDataById,
@@ -35,9 +34,8 @@ export const YearnWithdraw = ({ api }: YearnWithdrawProps) => {
   const [state, dispatch] = useReducer(reducer, initialState)
   const location = useLocation()
   const { query } = useBrowserRouter<DefiQueryParams, DefiParams>()
-  const { chain, contractAddress: vaultAddress, tokenId } = query
+  const { chainId, contractAddress: vaultAddress, tokenId } = query
 
-  const chainId = chainTypeToMainnetChainId(chain)
   const assetNamespace = 'erc20'
   // Asset info
   const underlyingAssetId = toAssetId({

--- a/src/features/defi/providers/yearn/components/YearnManager/Withdraw/components/Confirm.tsx
+++ b/src/features/defi/providers/yearn/components/YearnManager/Withdraw/components/Confirm.tsx
@@ -16,7 +16,6 @@ import { useBrowserRouter } from 'hooks/useBrowserRouter/useBrowserRouter'
 import { useWallet } from 'hooks/useWallet/useWallet'
 import { bnOrZero } from 'lib/bignumber/bignumber'
 import { poll } from 'lib/poll/poll'
-import { chainTypeToMainnetChainId } from 'lib/utils'
 import { selectAssetById, selectMarketDataById } from 'state/slices/selectors'
 import { useAppSelector } from 'state/store'
 
@@ -32,9 +31,8 @@ export const Confirm = ({ api }: YearnConfirmProps) => {
   const translate = useTranslate()
   const history = useHistory()
   const { query, history: browserHistory } = useBrowserRouter<DefiQueryParams, DefiParams>()
-  const { chain, contractAddress: vaultAddress, tokenId } = query
+  const { chainId, contractAddress: vaultAddress, tokenId } = query
 
-  const chainId = chainTypeToMainnetChainId(chain)
   const assetNamespace = 'erc20'
   // Asset info
   const underlyingAssetId = toAssetId({

--- a/src/features/defi/providers/yearn/components/YearnManager/Withdraw/components/Status.tsx
+++ b/src/features/defi/providers/yearn/components/YearnManager/Withdraw/components/Status.tsx
@@ -11,7 +11,6 @@ import { Row } from 'components/Row/Row'
 import { Text } from 'components/Text'
 import { useBrowserRouter } from 'hooks/useBrowserRouter/useBrowserRouter'
 import { bnOrZero } from 'lib/bignumber/bignumber'
-import { chainTypeToMainnetChainId } from 'lib/utils'
 import { selectAssetById, selectMarketDataById } from 'state/slices/selectors'
 import { useAppSelector } from 'state/store'
 
@@ -20,9 +19,8 @@ import { WithdrawContext } from '../WithdrawContext'
 export const Status = () => {
   const { state } = useContext(WithdrawContext)
   const { query, history: browserHistory } = useBrowserRouter<DefiQueryParams, DefiParams>()
-  const { chain, contractAddress: vaultAddress, tokenId } = query
+  const { chainId, contractAddress: vaultAddress, tokenId } = query
 
-  const chainId = chainTypeToMainnetChainId(chain)
   const assetNamespace = 'erc20'
   // Asset info
   const underlyingAssetId = toAssetId({

--- a/src/features/defi/providers/yearn/components/YearnManager/Withdraw/components/Withdraw.tsx
+++ b/src/features/defi/providers/yearn/components/YearnManager/Withdraw/components/Withdraw.tsx
@@ -9,7 +9,6 @@ import { useContext } from 'react'
 import { useHistory } from 'react-router-dom'
 import { useBrowserRouter } from 'hooks/useBrowserRouter/useBrowserRouter'
 import { bnOrZero } from 'lib/bignumber/bignumber'
-import { chainTypeToMainnetChainId } from 'lib/utils'
 import {
   selectAssetById,
   selectMarketDataById,
@@ -28,9 +27,8 @@ export const Withdraw = ({ api }: YearnWithdrawProps) => {
   const { state, dispatch } = useContext(WithdrawContext)
   const history = useHistory()
   const { query, history: browserHistory } = useBrowserRouter<DefiQueryParams, DefiParams>()
-  const { chain, contractAddress: vaultAddress, tokenId } = query
+  const { chainId, contractAddress: vaultAddress, tokenId } = query
 
-  const chainId = chainTypeToMainnetChainId(chain)
   const assetNamespace = 'erc20'
   // Asset info
   const underlyingAssetId = toAssetId({

--- a/src/pages/Defi/components/OpportunityCard.tsx
+++ b/src/pages/Defi/components/OpportunityCard.tsx
@@ -10,6 +10,7 @@ import {
   StatNumber,
   useColorModeValue,
 } from '@chakra-ui/react'
+import { cosmosChainId } from '@shapeshiftoss/caip'
 import { DefiType } from 'features/defi/contexts/DefiManagerProvider/DefiCommon'
 import { EarnOpportunityType } from 'features/defi/helpers/normalizeOpportunity'
 import qs from 'qs'
@@ -48,8 +49,7 @@ export const OpportunityCard = ({
   const bgHover = useColorModeValue('gray.100', 'gray.700')
   const asset = useAppSelector(state => selectAssetById(state, assetId))
   const { cosmosStaking } = useModal()
-  // TODO(gomes): when we find new home for "supported chainIds", use it here. Don't metastize supportedChainId imports from caip
-  const isCosmosStaking = chainId === 'cosmos:cosmoshub-4'
+  const isCosmosStaking = chainId === cosmosChainId
 
   const {
     state: { isConnected },

--- a/src/pages/Defi/components/OpportunityCard.tsx
+++ b/src/pages/Defi/components/OpportunityCard.tsx
@@ -10,7 +10,6 @@ import {
   StatNumber,
   useColorModeValue,
 } from '@chakra-ui/react'
-import { ChainTypes } from '@shapeshiftoss/types'
 import { DefiType } from 'features/defi/contexts/DefiManagerProvider/DefiCommon'
 import { EarnOpportunityType } from 'features/defi/helpers/normalizeOpportunity'
 import qs from 'qs'
@@ -35,7 +34,7 @@ export const OpportunityCard = ({
   rewardAddress,
   contractAddress,
   provider,
-  chain,
+  chainId,
   isLoaded,
   apy,
   cryptoAmount,
@@ -49,7 +48,8 @@ export const OpportunityCard = ({
   const bgHover = useColorModeValue('gray.100', 'gray.700')
   const asset = useAppSelector(state => selectAssetById(state, assetId))
   const { cosmosStaking } = useModal()
-  const isCosmosStaking = chain === ChainTypes.Cosmos
+  // TODO(gomes): when we find new home for "supported chainIds", use it here. Don't metastize supportedChainId imports from caip
+  const isCosmosStaking = chainId === 'cosmos:cosmoshub-4'
 
   const {
     state: { isConnected },
@@ -76,7 +76,7 @@ export const OpportunityCard = ({
       history.push({
         pathname,
         search: qs.stringify({
-          chain,
+          chainId,
           contractAddress,
           tokenId: tokenAddress,
           rewardId: rewardAddress,

--- a/src/pages/Defi/hooks/__snapshots__/useCosmosStakingBalances.test.tsx.snap
+++ b/src/pages/Defi/hooks/__snapshots__/useCosmosStakingBalances.test.tsx.snap
@@ -4,7 +4,7 @@ exports[`useCosmosStakingBalances returns active and non active staking opportun
 Array [
   Object {
     "assetId": "cosmos:cosmoshub-4/slip44:118",
-    "chain": "cosmos",
+    "chainId": "cosmos:cosmoshub-4",
     "cryptoAmount": "0.000004",
     "fiatAmount": "0.00",
     "isLoaded": false,
@@ -17,7 +17,7 @@ Array [
     "address": "cosmosvaloper199mlc7fr6ll5t54w7tts7f4s0cvnqgc59nmuxf",
     "apr": "0.24",
     "assetId": "cosmos:cosmoshub-4/slip44:118",
-    "chain": "cosmos",
+    "chainId": "cosmos:cosmoshub-4",
     "commission": "0.100000000000000000",
     "cryptoAmount": "0.010115",
     "fiatAmount": "0.78",
@@ -31,7 +31,7 @@ Array [
   },
   Object {
     "assetId": "cosmos:cosmoshub-4/slip44:118",
-    "chain": "cosmos",
+    "chainId": "cosmos:cosmoshub-4",
     "cryptoAmount": "0.005",
     "fiatAmount": "0.39",
     "isLoaded": false,

--- a/src/pages/Defi/hooks/useCosmosStakingBalances.tsx
+++ b/src/pages/Defi/hooks/useCosmosStakingBalances.tsx
@@ -1,4 +1,4 @@
-import { AssetId } from '@shapeshiftoss/caip'
+import { AssetId, ChainId } from '@shapeshiftoss/caip'
 import { chainAdapters, ChainTypes } from '@shapeshiftoss/types'
 import { useMemo } from 'react'
 import { BigNumber, bn, bnOrZero } from 'lib/bignumber/bignumber'
@@ -24,7 +24,7 @@ export type MergedActiveStakingOpportunity = ActiveStakingOpportunity & {
   fiatAmount?: string
   tokenAddress: string
   assetId: AssetId
-  chain: ChainTypes
+  chainId: ChainId
   tvl: string
   isLoaded?: boolean
 }
@@ -32,7 +32,7 @@ export type MergedActiveStakingOpportunity = ActiveStakingOpportunity & {
 export type MergedStakingOpportunity = chainAdapters.cosmos.Validator & {
   tokenAddress: string
   assetId: AssetId
-  chain: ChainTypes
+  chainId: ChainTypes
   tvl: string
 }
 
@@ -71,7 +71,7 @@ export function useCosmosStakingBalances({
           .toString(),
         tvl,
         fiatAmount,
-        chain: asset.chain,
+        chainId: asset.chainId,
         assetId,
         tokenAddress: asset.slip44.toString(),
       }

--- a/src/pages/Defi/hooks/useFoxyBalances.tsx
+++ b/src/pages/Defi/hooks/useFoxyBalances.tsx
@@ -1,6 +1,5 @@
-import { AssetId, toAssetId } from '@shapeshiftoss/caip'
+import { AssetId, ChainId, toAssetId } from '@shapeshiftoss/caip'
 import { DefiType, FoxyApi, WithdrawInfo } from '@shapeshiftoss/investor-foxy'
-import { ChainTypes } from '@shapeshiftoss/types'
 import { getConfig } from 'config'
 import { useFoxy } from 'features/defi/contexts/FoxyProvider/FoxyProvider'
 import { useCallback, useEffect, useMemo, useState } from 'react'
@@ -25,7 +24,7 @@ export type FoxyOpportunity = {
   contractAddress: string
   rewardToken: string
   stakingToken: string
-  chain: ChainTypes
+  chainId: ChainId
   tvl?: BigNumber
   expired?: boolean
   apy?: string
@@ -86,6 +85,7 @@ async function getFoxyOpportunities(
       const pricePerShare = api.pricePerShare()
       acc[opportunity.contractAddress] = {
         ...opportunity,
+        chainId: chainTypeToMainnetChainId(opportunity.chain),
         balance: bnOrZero(balance).toString(),
         contractAssetId,
         tokenAssetId,

--- a/src/pages/Defi/hooks/useVaultBalances.tsx
+++ b/src/pages/Defi/hooks/useVaultBalances.tsx
@@ -44,6 +44,7 @@ async function getYearnVaults(balances: PortfolioBalancesById, yearn: YearnVault
       const pricePerShare = await yearn?.pricePerShare({ vaultAddress: vault.vaultAddress })
       acc[vault.vaultAddress] = {
         ...vault,
+        chainId: chainTypeToMainnetChainId(vault.chain),
         balance,
         vaultAssetId,
         tokenAssetId,


### PR DESCRIPTION
## Description

Currently, we consume `chainId`s vs. the deprecated `ChainType`s, following #1892
However, we are still heavily reliant on `chain` in the DeFi section core logic, which means that to consume them, we rely on `chainTypeToMainnetChainId` function for the conversion.
This updates the core logic of DeFi to use `chainId` instead of `chain` in most places where currently possible.

The next step will be for investor packages to export both object and types containing `chainId` as well, so we can remove the remaining calls.

## Notice

<!-- Before submitting a pull request, please make sure you have answered the following: -->

- [x] Have you followed the guidelines in our [Contributing]('https://github.com/shapeshift/web/CONTRIBUTING.md) guide?
- [x] Have you checked to ensure there aren't other open [Pull Requests](https://github.com/shapeshift/web/pulls) for the same update/change?

## Pull Request Type

- [ ] :bug: Bug fix (Non-breaking Change: Fixes an issue)
- [ ] :hammer_and_wrench: Chore (Non-breaking Change: Doc updates, pkg upgrades, typos, etc..)
- [x] :nail_care: New Feature (Breaking/Non-breaking Change)

## Issue (if applicable)

N/A

## Risk

This can potentially break the whole DeFi section. Did a regression testing of DeFi and all other places related to FOXy/Yearn and didn't find any regression.

## Testing

- CI should be happy
- DeFi section should show no regressions

## Screenshots (if applicable)
