### PR TITLE
feat: add ShapeShift DAO advanced features memo

### DIFF
--- a/src/plugins/cosmos/hooks/useStakingAction/useStakingAction.tsx
+++ b/src/plugins/cosmos/hooks/useStakingAction/useStakingAction.tsx
@@ -3,6 +3,7 @@ import { Asset, chainAdapters, ChainTypes } from '@shapeshiftoss/types'
 import { StakingAction } from 'plugins/cosmos/components/modals/Staking/StakingCommon'
 import { useChainAdapters } from 'context/PluginProvider/PluginProvider'
 import { useWallet } from 'hooks/useWallet/useWallet'
+import { SHAPESHIFT_VALIDATOR_ADDRESS } from 'state/slices/validatorDataSlice/const'
 
 type StakingInput =
   | {
@@ -35,6 +36,8 @@ export const useStakingAction = () => {
         let result
 
         const { chainSpecific, validator, action, value } = data
+        const memo = validator === SHAPESHIFT_VALIDATOR_ADDRESS ? 'Delegated with ShapeShift' : ''
+
         if (adapterType === ChainTypes.Cosmos) {
           switch (action) {
             case StakingAction.Claim: {
@@ -44,6 +47,7 @@ export const useStakingAction = () => {
                 wallet,
                 validator,
                 chainSpecific,
+                memo,
               })
               break
             }
@@ -53,6 +57,7 @@ export const useStakingAction = () => {
                 validator,
                 value,
                 chainSpecific,
+                memo,
               })
               break
             }
@@ -62,6 +67,7 @@ export const useStakingAction = () => {
                 validator,
                 value,
                 chainSpecific,
+                memo,
               })
               break
             }


### PR DESCRIPTION
## Description

This adds a memo for advanced features Txs **to the Shapeshift DAO validator only**. 

## Notice

<!-- Before submitting a pull request, please make sure you have answered the following: -->

- [x] Have you followed the guidelines in our [Contributing]('https://github.com/shapeshift/web/CONTRIBUTING.md) guide?
- [x] Have you checked to ensure there aren't other open [Pull Requests](https://github.com/shapeshift/web/pulls) for the same update/change?

## Pull Request Type

- [ ] :bug: Bug fix (Non-breaking Change: Fixes an issue)
- [ ] :hammer_and_wrench: Chore (Non-breaking Change: Doc updates, pkg upgrades, typos, etc..)
- [x] :nail_care: New Feature (Breaking/Non-breaking Change)

## Issue (if applicable)

closes #1904

## Risk

N/A

## Testing

- Broadcast any Cosmos staking Tx to the ShapeShift validator. Open Tx in explorer, the memo should be `Delegated with ShapeShift`
- Broadcast any other Cosmos staking Tx. Open Tx in explorer, the memo should be empty 

## Screenshots (if applicable)

Cosmostation Tx:

<img width="733" alt="image" src="https://user-images.githubusercontent.com/17035424/170738155-229da55c-d955-4fca-a9b0-0b8120411ec9.png">

ShapeShift DAO Tx:

<img width="701" alt="image" src="https://user-images.githubusercontent.com/17035424/170738586-032eedae-80d4-4f38-b42f-99a4e70c9a83.png">