### PR TITLE
fix: fox page warnings

### DIFF
--- a/src/plugins/foxPage/components/FoxTab.stories.tsx
+++ b/src/plugins/foxPage/components/FoxTab.stories.tsx
@@ -34,7 +34,6 @@ export const FoxPageTabs: Story = () => (
         <FoxTab
           assetIcon={fox.icon}
           assetSymbol={fox.symbol}
-          isSelected={true}
           cryptoAmount={'3000'}
           fiatAmount={'1000'}
           onClick={() => {}}

--- a/src/plugins/foxPage/components/FoxTab.tsx
+++ b/src/plugins/foxPage/components/FoxTab.tsx
@@ -9,7 +9,6 @@ type FoxTabProps = {
   assetSymbol: string
   fiatAmount: string
   cryptoAmount: string
-  isSelected?: boolean
   onClick?: () => void
 } & TabProps
 
@@ -18,11 +17,11 @@ export const FoxTab: React.FC<FoxTabProps> = ({
   assetSymbol,
   fiatAmount,
   cryptoAmount,
-  isSelected,
   onClick,
   ...props
 }) => {
   const bgHover = useColorModeValue('gray.100', 'gray.750')
+  const { isSelected, ...otherProps } = props
 
   return (
     <Tab
@@ -39,9 +38,8 @@ export const FoxTab: React.FC<FoxTabProps> = ({
       _hover={{ textDecoration: 'none', bg: { base: 'none', md: bgHover } }}
       textAlign='left'
       p={0}
-      isSelected={isSelected}
       onClick={onClick}
-      {...props}
+      {...otherProps}
     >
       <Card display='block' bg='none' border='none' boxShadow='none' p={0} width='full'>
         <Card.Body

--- a/src/plugins/foxPage/components/FoxTab.tsx
+++ b/src/plugins/foxPage/components/FoxTab.tsx
@@ -21,7 +21,6 @@ export const FoxTab: React.FC<FoxTabProps> = ({
   ...props
 }) => {
   const bgHover = useColorModeValue('gray.100', 'gray.750')
-  const { isSelected, ...otherProps } = props
 
   return (
     <Tab
@@ -39,7 +38,7 @@ export const FoxTab: React.FC<FoxTabProps> = ({
       textAlign='left'
       p={0}
       onClick={onClick}
-      {...otherProps}
+      {...props}
     >
       <Card display='block' bg='none' border='none' boxShadow='none' p={0} width='full'>
         <Card.Body

--- a/src/plugins/foxPage/components/Layout.stories.tsx
+++ b/src/plugins/foxPage/components/Layout.stories.tsx
@@ -77,7 +77,6 @@ export const FoxLayout: Story = () => {
                 <FoxTab
                   assetSymbol={mockAsset.symbol}
                   assetIcon={mockAsset.icon}
-                  isSelected={true}
                   cryptoAmount={'3000'}
                   fiatAmount={'1000'}
                   onClick={() => {

--- a/src/plugins/foxPage/foxPage.tsx
+++ b/src/plugins/foxPage/foxPage.tsx
@@ -133,9 +133,9 @@ export const FoxPage = (props: FoxPageProps) => {
             {isLargerThanMd &&
               assets.map((asset, index) => (
                 <FoxTab
+                  key={index}
                   assetSymbol={asset.symbol}
                   assetIcon={asset.icon}
-                  isSelected={props.activeAssetId === asset.assetId}
                   cryptoAmount={cryptoBalances[index]}
                   fiatAmount={fiatBalances[index]}
                   onClick={() => handleTabClick(asset.assetId)}
@@ -164,11 +164,10 @@ export const FoxPage = (props: FoxPageProps) => {
                   </MenuButton>
                   <MenuList>
                     {assets.map((asset, index) => (
-                      <MenuItem onClick={() => handleTabClick(asset.assetId)}>
+                      <MenuItem key={index} onClick={() => handleTabClick(asset.assetId)}>
                         <FoxTab
                           assetSymbol={asset.symbol}
                           assetIcon={asset.icon}
-                          isSelected={asset.assetId === props.activeAssetId}
                           cryptoAmount={cryptoBalances[index]}
                           fiatAmount={fiatBalances[index]}
                           as={Box}

--- a/src/plugins/foxPage/foxPage.tsx
+++ b/src/plugins/foxPage/foxPage.tsx
@@ -133,7 +133,7 @@ export const FoxPage = (props: FoxPageProps) => {
             {isLargerThanMd &&
               assets.map((asset, index) => (
                 <FoxTab
-                  key={index}
+                  key={asset.assetId}
                   assetSymbol={asset.symbol}
                   assetIcon={asset.icon}
                   cryptoAmount={cryptoBalances[index]}
@@ -164,7 +164,7 @@ export const FoxPage = (props: FoxPageProps) => {
                   </MenuButton>
                   <MenuList>
                     {assets.map((asset, index) => (
-                      <MenuItem key={index} onClick={() => handleTabClick(asset.assetId)}>
+                      <MenuItem key={asset.assetId} onClick={() => handleTabClick(asset.assetId)}>
                         <FoxTab
                           assetSymbol={asset.symbol}
                           assetIcon={asset.icon}


### PR DESCRIPTION
## Description

Fixes 2 warnings related to recent fox page code.

Existing warnings for fox page on develop branch are :
![warning1](https://user-images.githubusercontent.com/97164662/170638645-8fc6d034-0978-44d3-98e4-09106bdf14b8.png)
![warning2](https://user-images.githubusercontent.com/97164662/170638700-726f802f-d9fd-4058-a595-5fdfa3639574.png)

## Notice

<!-- Before submitting a pull request, please make sure you have answered the following: -->

- [X] Have you followed the guidelines in our [Contributing]('https://github.com/shapeshift/web/CONTRIBUTING.md) guide?
- [X] Have you checked to ensure there aren't other open [Pull Requests](https://github.com/shapeshift/web/pulls) for the same update/change?

## Pull Request Type

- [X] :bug: Bug fix (Non-breaking Change: Fixes an issue)
- [ ] :hammer_and_wrench: Chore (Non-breaking Change: Doc updates, pkg upgrades, typos, etc..)
- [ ] :nail_care: New Feature (Breaking/Non-breaking Change)

## Issue (if applicable)

Coming from review comment https://github.com/shapeshift/web/pull/1879#pullrequestreview-987068820
<!-----------------------------------------------------------------------------
If applicable, please link to the github issue and put `closes #XXXX` in your comment to auto-close the issue that your PR fixes.
------------------------------------------------------------------------------>

## Risk

Risk is the change of tab on fox page is not working properly anymore. I tested it and it's working fine.
<!-----------------------------------------------------------------------------
Outline the scope of your changes and the risk associated with them. You must use your discretion as an engineer to determine the potential impact of your changes.

E.g. an upgrade to `hdwallet` or core state management would be considered higher risk, and might require a full regression test. UI or isolated view changes, or something behind a feature flag may have near zero risk. Small bug fixes might require testing isolated to the specific fix.
------------------------------------------------------------------------------>

## Testing

- Go to fox page
- Verify tab change is still working fine
- No more warnings related to fox page in console

<!-----------------------------------------------------------------------------
If your testing steps are technical, outline steps for an engineer to verify.

If your testing steps are functional, please provide a full guide with any features requiring special attention for operations to test your branch in the preview environment.
------------------------------------------------------------------------------>

## Screenshots (if applicable)

![fox](https://user-images.githubusercontent.com/5720927/170988271-ab8ce333-7fd8-4420-8237-b9f5b34eef32.png)

![foxy](https://user-images.githubusercontent.com/5720927/170988288-b2204060-9f11-4a37-a5d3-736b4bbe1b86.png)

