### PR TITLE
fix: buy or sell modal overflow issue on mobile

### DIFF
--- a/src/components/Modals/FiatRamps/views/RampsList.tsx
+++ b/src/components/Modals/FiatRamps/views/RampsList.tsx
@@ -57,7 +57,7 @@ export const RampsList: React.FC<RampsListProps> = ({ setFiatRampProvider }) => 
                   <Text translation={fiatRampConfig.info ?? ''} />
                 </Box>
               </Flex>
-              <Box>
+              <Box display={['none', 'block']}>
                 <Tag colorScheme='green' mr={2}>
                   <Text translation='fiatRamps.buy' style={{ textTransform: 'uppercase' }} />
                 </Tag>

--- a/src/components/Modals/FiatRamps/views/RampsList.tsx
+++ b/src/components/Modals/FiatRamps/views/RampsList.tsx
@@ -42,7 +42,14 @@ export const RampsList: React.FC<RampsListProps> = ({ setFiatRampProvider }) => 
             }}
             rightIcon={<ChevronRightIcon boxSize={6} />}
           >
-            <Flex flex={1} flexDirection='row' justifyContent='space-between' alignItems='center'>
+            <Flex
+              flex={1}
+              flexDirection={['column', 'row']}
+              justifyContent='space-between'
+              alignItems={['baseline', 'center']}
+              gap={['1em', 0]}
+              width='100%'
+            >
               <Flex flexDirection='row' justifyContent='center' alignItems='center'>
                 <AssetIcon src={fiatRampConfig.logo} />
                 <Box textAlign='left' ml={2}>
@@ -72,9 +79,15 @@ export const RampsList: React.FC<RampsListProps> = ({ setFiatRampProvider }) => 
             fontWeight='normal'
             py={2}
           >
-            <Flex flexDirection='row' justifyContent='center' alignItems='center'>
+            <Flex
+              flexDirection='row'
+              justifyContent='flex-start'
+              alignItems='center'
+              gap={['1em', 0]}
+              width='100%'
+            >
               <AssetIcon src={fiatRampConfig.logo} />
-              <Box textAlign='left' ml={2}>
+              <Box textAlign='left' ml={[0, 2]}>
                 <Text fontWeight='bold' translation={fiatRampConfig.label} />
                 <Text translation='fiatRamps.comingSoon' />
               </Box>
@@ -88,7 +101,7 @@ export const RampsList: React.FC<RampsListProps> = ({ setFiatRampProvider }) => 
   }, [banxaFiatRampFeatureFlag, history, setFiatRampProvider])
 
   return (
-    <Flex justifyContent='center' alignItems='center' width={'32rem'}>
+    <Flex justifyContent='center' alignItems='center' width={['100%', '32rem']}>
       <Card boxShadow='none' borderWidth={0}>
         <Card.Header>
           <Card.Heading>

--- a/src/components/Modals/FiatRamps/views/RampsList.tsx
+++ b/src/components/Modals/FiatRamps/views/RampsList.tsx
@@ -79,15 +79,9 @@ export const RampsList: React.FC<RampsListProps> = ({ setFiatRampProvider }) => 
             fontWeight='normal'
             py={2}
           >
-            <Flex
-              flexDirection='row'
-              justifyContent='flex-start'
-              alignItems='center'
-              gap={['1em', 0]}
-              width='100%'
-            >
+            <Flex flexDirection='row' justifyContent='flex-start' alignItems='center' width='100%'>
               <AssetIcon src={fiatRampConfig.logo} />
-              <Box textAlign='left' ml={[0, 2]}>
+              <Box textAlign='left' ml={2}>
                 <Text fontWeight='bold' translation={fiatRampConfig.label} />
                 <Text translation='fiatRamps.comingSoon' />
               </Box>


### PR DESCRIPTION
## Description

Fixed buy or sell modal overflow issue on mobile devices

## Notice

- [x] Have you followed the guidelines in our [Contributing]('https://github.com/shapeshift/web/CONTRIBUTING.md) guide?
- [x] Have you checked to ensure there aren't other open [Pull Requests](https://github.com/shapeshift/web/pulls) for the same update/change?

## Pull Request Type

- [x] :bug: Bug fix (Non-breaking Change: Fixes an issue)
- [ ] :hammer_and_wrench: Chore (Non-breaking Change: Doc updates, pkg upgrades, typos, etc..)
- [ ] :nail_care: New Feature (Breaking/Non-breaking Change)

## Issue (if applicable)

closes #1804 

## Risk

N/A

## Testing

- Open dev server
- Login
- Click on buy / sell crypto from the nav

## Screenshots (if applicable)

![Screenshot from 2022-05-31 21-16-09](https://user-images.githubusercontent.com/61096193/171215624-ba34de9c-ae45-4284-a901-0a37b47399e5.png)

