### PR TITLE
feat: confirm password for wallet creation flow

### DIFF
--- a/cypress/integration/login_spec.ts
+++ b/cypress/integration/login_spec.ts
@@ -49,6 +49,7 @@ describe('The Dashboard', () => {
     cy.getBySel('wallet-native-seed-submit-button').click()
     cy.getBySel('wallet-native-set-name-input').type('cypress-test')
     cy.getBySel('wallet-native-password-input').type(password)
+    cy.getBySel('wallet-native-confirmPassword-input').type(password)
     cy.getBySel('wallet-native-password-submit-button').click()
 
     cy.url().should('equal', `${baseUrl}dashboard`)

--- a/src/assets/translations/en/main.json
+++ b/src/assets/translations/en/main.json
@@ -483,7 +483,7 @@
         "show": "Show password",
         "hide": "Hide password",
         "error": {
-          "invalid": "Your passwords don't match",
+          "invalid": "Password must match",
           "required": "Password confirmation is required",
           "length": "Your password must be at least %{length} characters",
           "maxLength": "Nickname must be %{length} characters maximum"

--- a/src/assets/translations/en/main.json
+++ b/src/assets/translations/en/main.json
@@ -474,6 +474,20 @@
           "length": "Your password must be at least %{length} characters",
           "maxLength": "Nickname must be %{length} characters maximum"
         }
+      },
+      "confirmPassword": {
+        "header": "Confirm Your Password",
+        "walletName": "Wallet nickname (optional)",
+        "body": "Confirm your password to decrypt your wallet",
+        "placeholder": "Confirm Password",
+        "show": "Show password",
+        "hide": "Hide password",
+        "error": {
+          "invalid": "Your passwords don't match",
+          "required": "Password confirmation is required",
+          "length": "Your password must be at least %{length} characters",
+          "maxLength": "Nickname must be %{length} characters maximum"
+        }
       }
     },
     "stake": {

--- a/src/context/WalletProvider/NativeWallet/components/NativePassword.tsx
+++ b/src/context/WalletProvider/NativeWallet/components/NativePassword.tsx
@@ -42,8 +42,11 @@ export const NativePassword = ({ history, location }: NativeSetupProps) => {
     setError,
     handleSubmit,
     register,
+    watch,
     formState: { errors, isSubmitting },
   } = useForm({ mode: 'onChange', shouldUnregister: true })
+
+  const watchPassword = watch('password')
 
   return (
     <>
@@ -98,13 +101,43 @@ export const NativePassword = ({ history, location }: NativeSetupProps) => {
             </InputGroup>
             <FormErrorMessage>{errors?.password?.message}</FormErrorMessage>
           </FormControl>
+          <FormControl mb={6} isInvalid={errors.confirmPassword}>
+            <InputGroup size='lg' variant='filled'>
+              <Input
+                {...register('confirmPassword', {
+                  required: translate('modals.shapeShift.confirmPassword.error.required'),
+                  validate: value =>
+                    value === watchPassword ||
+                    translate('modals.shapeShift.confirmPassword.error.invalid'),
+                })}
+                pr='4.5rem'
+                type={showPw ? 'text' : 'confirmPassword'}
+                placeholder={translate('modals.shapeShift.confirmPassword.placeholder')}
+                autoComplete={'confirmPassword'}
+                id='confirmPassword'
+                data-test='wallet-native-confirmPassword-input'
+              />
+              <InputRightElement>
+                <IconButton
+                  aria-label={translate(
+                    `modals.shapeShift.confirmPassword.${showPw ? 'hide' : 'show'}`,
+                  )}
+                  h='1.75rem'
+                  size='sm'
+                  onClick={handleShowClick}
+                  icon={!showPw ? <FaEye /> : <FaEyeSlash />}
+                />
+              </InputRightElement>
+            </InputGroup>
+            <FormErrorMessage>{errors?.confirmPassword?.message}</FormErrorMessage>
+          </FormControl>
           <Button
             colorScheme='blue'
             size='lg'
             isFullWidth
             type='submit'
             isLoading={isSubmitting}
-            isDisabled={errors.name}
+            isDisabled={errors.name || errors.password || errors.confirmPassword}
             data-test='wallet-native-password-submit-button'
           >
             <Text translation={'walletProvider.shapeShift.password.button'} />

--- a/src/context/WalletProvider/NativeWallet/components/NativePassword.tsx
+++ b/src/context/WalletProvider/NativeWallet/components/NativePassword.tsx
@@ -20,8 +20,10 @@ import { NativeSetupProps } from '../types'
 export const NativePassword = ({ history, location }: NativeSetupProps) => {
   const translate = useTranslate()
   const [showPw, setShowPw] = useState<boolean>(false)
+  const [showConfirmPw, setShowConfirmPw] = useState<boolean>(false)
 
-  const handleShowClick = () => setShowPw(!showPw)
+  const handleShowPwClick = () => setShowPw(!showPw)
+  const handleShowConfirmPwClick = () => setShowConfirmPw(state => !state)
   const onSubmit = async (values: FieldValues) => {
     try {
       const vault = location.state.vault
@@ -94,7 +96,7 @@ export const NativePassword = ({ history, location }: NativeSetupProps) => {
                   aria-label={translate(`modals.shapeShift.password.${showPw ? 'hide' : 'show'}`)}
                   h='1.75rem'
                   size='sm'
-                  onClick={handleShowClick}
+                  onClick={handleShowPwClick}
                   icon={!showPw ? <FaEye /> : <FaEyeSlash />}
                 />
               </InputRightElement>
@@ -111,7 +113,7 @@ export const NativePassword = ({ history, location }: NativeSetupProps) => {
                     translate('modals.shapeShift.confirmPassword.error.invalid'),
                 })}
                 pr='4.5rem'
-                type={showPw ? 'text' : 'confirmPassword'}
+                type={showConfirmPw ? 'text' : 'password'}
                 placeholder={translate('modals.shapeShift.confirmPassword.placeholder')}
                 autoComplete={'confirmPassword'}
                 id='confirmPassword'
@@ -120,12 +122,12 @@ export const NativePassword = ({ history, location }: NativeSetupProps) => {
               <InputRightElement>
                 <IconButton
                   aria-label={translate(
-                    `modals.shapeShift.confirmPassword.${showPw ? 'hide' : 'show'}`,
+                    `modals.shapeShift.confirmPassword.${showConfirmPw ? 'hide' : 'show'}`,
                   )}
                   h='1.75rem'
                   size='sm'
-                  onClick={handleShowClick}
-                  icon={!showPw ? <FaEye /> : <FaEyeSlash />}
+                  onClick={handleShowConfirmPwClick}
+                  icon={!showConfirmPw ? <FaEye /> : <FaEyeSlash />}
                 />
               </InputRightElement>
             </InputGroup>


### PR DESCRIPTION
## Description

Added password confirmation for the wallet creation flow to improve UX and secure their password

## Notice

<!-- Before submitting a pull request, please make sure you have answered the following: -->

- [x] Have you followed the guidelines in our [Contributing]('https://github.com/shapeshift/web/CONTRIBUTING.md) guide?
- [x] Have you checked to ensure there aren't other open [Pull Requests](https://github.com/shapeshift/web/pulls) for the same update/change?

## Pull Request Type

- [ ] :bug: Bug fix (Non-breaking Change: Fixes an issue)
- [ ] :hammer_and_wrench: Chore (Non-breaking Change: Doc updates, pkg upgrades, typos, etc..)
- [x] :nail_care: New Feature (Breaking/Non-breaking Change)

## Issue (if applicable)

Closes https://github.com/shapeshift/web/issues/1919

## Risk

N/A

## Testing

- Go to the home page of the web application (Log out from the dashboard if you are logged in)
- Try creating a new shapeshift wallet or a native one

## Screenshots (if applicable)

![Screenshot from 2022-06-02 23-17-08](https://user-images.githubusercontent.com/61096193/171694360-4cd081d1-421f-4a7d-aa7e-a0873e5deef8.png)

![Screenshot from 2022-06-02 23-17-24](https://user-images.githubusercontent.com/61096193/171694371-1b8b63bc-03e9-4d7c-9efb-efe4fd50d926.png)

![Screenshot from 2022-06-02 23-17-41](https://user-images.githubusercontent.com/61096193/171694382-545e0333-840c-47c8-bded-9c5372747665.png)

![Screenshot from 2022-06-02 23-17-50](https://user-images.githubusercontent.com/61096193/171694388-32e480bc-45d7-4533-96d4-ea9d10ea54c8.png)

