### PR TITLE
fix: warning/error spew

### DIFF
--- a/src/components/AssetIcon.tsx
+++ b/src/components/AssetIcon.tsx
@@ -12,12 +12,18 @@ type AssetIconProps = {
 
 // Either src or symbol can be passed, if both are passed src takes precedence
 export const AssetIcon = ({ symbol, src, ...rest }: AssetIconProps) => {
+  const assetIconBg = useColorModeValue('gray.200', 'gray.700')
+  const assetIconColor = useColorModeValue('gray.500', 'gray.500')
+
+  if (!src && !symbol) {
+    return null
+  }
   const imgSrc = src ? src : `https://static.coincap.io/assets/icons/256/${symbol}.png`
   return (
     <Avatar
       src={imgSrc}
-      bg={useColorModeValue('gray.200', 'gray.700')}
-      icon={<FoxIcon boxSize='16px' color={useColorModeValue('gray.500', 'gray.500')} />}
+      bg={assetIconBg}
+      icon={<FoxIcon boxSize='16px' color={assetIconColor} />}
       {...rest}
     />
   )

--- a/src/components/Icons/KeplrIcon.tsx
+++ b/src/components/Icons/KeplrIcon.tsx
@@ -18,8 +18,8 @@ export const KeplrIcon = createIcon({
           gradientTransform='translate(0.908673,0.109586),rotate(140.172042),scale(1.000000,1.206725),translate(-0.908673,-0.109586)'
           id='radialGradient-1'
         >
-          <stop stop-color='#2F80F2' offset='0%'></stop>
-          <stop stop-color='#A942B5' offset='99.9656883%'></stop>
+          <stop stopColor='#2F80F2' offset='0%'></stop>
+          <stop stopColor='#A942B5' offset='99.9656883%'></stop>
         </radialGradient>
         <radialGradient
           cx='0%'
@@ -30,8 +30,8 @@ export const KeplrIcon = createIcon({
           gradientTransform='translate(0.000000,0.021481),rotate(46.320810),scale(1.000000,1.047856),translate(-0.000000,-0.021481)'
           id='radialGradient-2'
         >
-          <stop stop-color='#45F9DE' offset='0%'></stop>
-          <stop stop-color='#A942B5' stop-opacity='0' offset='100%'></stop>
+          <stop stopColor='#45F9DE' offset='0%'></stop>
+          <stop stopColor='#A942B5' stopOpacity='0' offset='100%'></stop>
         </radialGradient>
         <radialGradient
           cx='100%'
@@ -42,9 +42,9 @@ export const KeplrIcon = createIcon({
           gradientTransform='translate(1.000000,1.000000),rotate(180.000000),scale(1.000000,0.514961),translate(-1.000000,-1.000000)'
           id='radialGradient-3'
         >
-          <stop stop-color='#E957C5' offset='0%'></stop>
-          <stop stop-color='#AC43B6' stop-opacity='0.0437004098' offset='100%'></stop>
-          <stop stop-color='#A942B5' stop-opacity='0' offset='100%'></stop>
+          <stop stopColor='#E957C5' offset='0%'></stop>
+          <stop stopColor='#AC43B6' stopOpacity='0.0437004098' offset='100%'></stop>
+          <stop stopColor='#A942B5' stopOpacity='0' offset='100%'></stop>
         </radialGradient>
         <radialGradient
           cx='50%'
@@ -55,15 +55,15 @@ export const KeplrIcon = createIcon({
           gradientTransform='translate(0.500000,0.500000),rotate(119.937813),scale(1.000000,1.499193),translate(-0.500000,-0.500000)'
           id='radialGradient-4'
         >
-          <stop stop-color='#000000' stop-opacity='0.184877622' offset='0%'></stop>
-          <stop stop-color='#101010' offset='100%'></stop>
+          <stop stopColor='#000000' stopOpacity='0.184877622' offset='0%'></stop>
+          <stop stopColor='#101010' offset='100%'></stop>
         </radialGradient>
         <linearGradient x1='94.2375438%' y1='58.966132%' x2='0%' y2='0%' id='linearGradient-5'>
-          <stop stop-color='#FFFFFF' stop-opacity='0.184877622' offset='0%'></stop>
-          <stop stop-color='#FFFFFF' offset='100%'></stop>
+          <stop stopColor='#FFFFFF' stopOpacity='0.184877622' offset='0%'></stop>
+          <stop stopColor='#FFFFFF' offset='100%'></stop>
         </linearGradient>
       </defs>
-      <g id='Artboard-Copy-6' stroke='none' stroke-width='1' fill='none' fill-rule='evenodd'>
+      <g id='Artboard-Copy-6' stroke='none' strokeWidth='1' fill='none' fillRule='evenodd'>
         <g id='Group'>
           <rect
             id='Rectangle'
@@ -76,7 +76,7 @@ export const KeplrIcon = createIcon({
           ></rect>
           <rect
             id='Rectangle-Copy-2'
-            fill-opacity='0.57'
+            fillOpacity='0.57'
             fill='url(#radialGradient-2)'
             x='0'
             y='0'
@@ -86,7 +86,7 @@ export const KeplrIcon = createIcon({
           ></rect>
           <rect
             id='Rectangle-Copy-3'
-            fill-opacity='0.68'
+            fillOpacity='0.68'
             fill='url(#radialGradient-3)'
             x='0'
             y='0'
@@ -96,7 +96,7 @@ export const KeplrIcon = createIcon({
           ></rect>
           <rect
             id='Rectangle-Copy'
-            fill-opacity='0.08'
+            fillOpacity='0.08'
             fill='url(#radialGradient-4)'
             x='0'
             y='0'
@@ -106,7 +106,7 @@ export const KeplrIcon = createIcon({
           ></rect>
           <rect
             id='Rectangle-Copy-4'
-            fill-opacity='0.03'
+            fillOpacity='0.03'
             fill='url(#linearGradient-5)'
             x='0'
             y='0'
@@ -118,7 +118,7 @@ export const KeplrIcon = createIcon({
         <polygon
           id='K'
           fill='#FFFFFF'
-          fill-rule='nonzero'
+          fillRule='nonzero'
           points='70.4 170 70.4 108 129 170 161.6 170 161.6 168.4 94.2 97.8 156.4 30.8 156.4 30 123.6 30 70.4 89.2 70.4 30 44 30 44 170'
         ></polygon>
       </g>

--- a/src/pages/Defi/components/OpportunityCardList.tsx
+++ b/src/pages/Defi/components/OpportunityCardList.tsx
@@ -39,9 +39,14 @@ export const OpportunityCardList = ({ balances }: { balances: UseEarnBalancesRet
         gridTemplateColumns={{ base: 'repeat(1, 1fr)', lg: 'repeat(3, 1fr)' }}
         gridGap={6}
       >
-        {activeOpportunities.map(opportunity => {
-          return <OpportunityCard key={opportunity.assetId} {...opportunity} />
-        })}
+        {activeOpportunities.map((opportunity, i) => (
+          // https://reactjs.org/docs/lists-and-keys.html
+          // Indexes as keys are fine under the right conditions (no permutations, additions only to the end of the array) which is the case here
+          // We initially have all the opportunities, but only set them as loaded when all the data for them is loaded
+          // The only unique identifier we have is `opportunity.contractAddress`, which we can't use because of the internals of <Skeleton />
+          // which will use undefined as keys while the data is loading
+          <OpportunityCard key={i} {...opportunity} />
+        ))}
       </SimpleGrid>
       {activeOpportunities.length === 0 && (
         <Card textAlign='center' py={6} boxShadow='none'>

--- a/src/pages/Defi/hooks/useFoxyBalances.tsx
+++ b/src/pages/Defi/hooks/useFoxyBalances.tsx
@@ -1,4 +1,4 @@
-import { AssetId, ChainId, toAssetId } from '@shapeshiftoss/caip'
+import { AssetId, ChainId, ethChainId, toAssetId } from '@shapeshiftoss/caip'
 import { DefiType, FoxyApi, WithdrawInfo } from '@shapeshiftoss/investor-foxy'
 import { getConfig } from 'config'
 import { useFoxy } from 'features/defi/contexts/FoxyProvider/FoxyProvider'
@@ -6,6 +6,7 @@ import { useCallback, useEffect, useMemo, useState } from 'react'
 import { useSelector } from 'react-redux'
 import { useChainAdapters } from 'context/PluginProvider/PluginProvider'
 import { useWallet } from 'hooks/useWallet/useWallet'
+import { useWalletSupportsChain } from 'hooks/useWalletSupportsChain/useWalletSupportsChain'
 import { BigNumber, bn, bnOrZero } from 'lib/bignumber/bignumber'
 import { logger } from 'lib/logger'
 import { chainTypeToMainnetChainId } from 'lib/utils'
@@ -116,8 +117,10 @@ export function useFoxyBalances(): UseFoxyBalancesReturn {
   const balances = useSelector(selectPortfolioAssetBalances)
   const balancesLoading = useSelector(selectPortfolioLoading)
 
+  const supportsEthereumChain = useWalletSupportsChain({ chainId: ethChainId, wallet })
+
   useEffect(() => {
-    if (!wallet || !foxy) return
+    if (!wallet || !supportsEthereumChain || !foxy) return
     ;(async () => {
       setLoading(true)
       try {
@@ -138,7 +141,15 @@ export function useFoxyBalances(): UseFoxyBalancesReturn {
         setLoading(false)
       }
     })()
-  }, [wallet, foxyLoading, foxy, balances, balancesLoading, chainAdapterManager])
+  }, [
+    wallet,
+    foxyLoading,
+    foxy,
+    balances,
+    balancesLoading,
+    chainAdapterManager,
+    supportsEthereumChain,
+  ])
 
   const makeFiatAmount = useCallback(
     (opportunity: FoxyOpportunity) => {

--- a/src/plugins/cosmos/components/AssetClaimCard/AssetClaimCard.tsx
+++ b/src/plugins/cosmos/components/AssetClaimCard/AssetClaimCard.tsx
@@ -44,13 +44,11 @@ export const AssetClaimCard = ({
                 symbol={assetSymbol}
                 value={cryptoRewardsAmount.toPrecision()}
               />
-              (
               <Amount.Fiat
                 color='gray.500'
                 lineHeight='1'
                 value={cryptoRewardsAmount.times(fiatRate).toPrecision()}
               />
-              )
             </CText>
           </Box>
         </Flex>


### PR DESCRIPTION
## Description

This tackles most of the current warnings and errors in the build.

- add checks in `AssetIcon />` to early return null in case there is no `src` nor `symbol` props (during `sellTradeAsset` load)
- camelCases `≤KeplrIcon />` class attributes
- use unique keys in the mapped over `<OpportunityCard />`s in `<OpportunityCardList />
- check for Ethereum chain support in `useFoxyBalances` hook (the newly added Keplr wallet only supports IBC chain, meaning the DeFi section currently throws on `chainAdapter.getAddress({ wallet })` call since the instantiated `ChainAdapter` is an `EthereumChainAdapter`

## Notice

<!-- Before submitting a pull request, please make sure you have answered the following: -->

- [x] Have you followed the guidelines in our [Contributing]('https://github.com/shapeshift/web/CONTRIBUTING.md) guide?
- [x] Have you checked to ensure there aren't other open [Pull Requests](https://github.com/shapeshift/web/pulls) for the same update/change?

## Pull Request Type

- [x] :bug: Bug fix (Non-breaking Change: Fixes an issue)
- [ ] :hammer_and_wrench: Chore (Non-breaking Change: Doc updates, pkg upgrades, typos, etc..)
- [ ] :nail_care: New Feature (Breaking/Non-breaking Change)

## Issue (if applicable)

N/A

## Risk

The only potential risk is on FOXy balances, which I've regression tested and is still working fine on MetaMask

## Testing

- asset icons (including Keplr icon) should still be shown across the app
- FOXy balances should still work on all wallets supporting it (i.e not Keplr)

## Screenshots (if applicable)
