### PR TITLE
fix: uncaught type errors in Trade component

### DIFF
--- a/src/components/AssetSearch/AssetSearch.tsx
+++ b/src/components/AssetSearch/AssetSearch.tsx
@@ -4,10 +4,15 @@ import { Asset } from '@shapeshiftoss/types'
 import { FormEvent, useEffect, useMemo, useState } from 'react'
 import { useForm } from 'react-hook-form'
 import { useSelector } from 'react-redux'
+import { logger } from 'lib/logger'
 import { selectAssetsByMarketCap } from 'state/slices/selectors'
 
 import { AssetList } from './AssetList'
 import { filterAssetsBySearchTerm } from './helpers/filterAssetsBySearchTerm/filterAssetsBySearchTerm'
+
+const moduleLogger = logger.child({
+  namespace: ['AssetSearch'],
+})
 
 type AssetSearchProps = {
   onClick: (asset: any) => void
@@ -33,6 +38,8 @@ export const AssetSearch = ({ onClick, filterBy }: AssetSearchProps) => {
       setFilteredAssets(
         searching ? filterAssetsBySearchTerm(searchString, currentAssets) : currentAssets,
       )
+    } else {
+      moduleLogger.error('currentAssets not defined')
     }
     // eslint-disable-next-line react-hooks/exhaustive-deps
   }, [searchString])

--- a/src/components/AssetSearch/AssetSearch.tsx
+++ b/src/components/AssetSearch/AssetSearch.tsx
@@ -11,7 +11,7 @@ import { filterAssetsBySearchTerm } from './helpers/filterAssetsBySearchTerm/fil
 
 type AssetSearchProps = {
   onClick: (asset: any) => void
-  filterBy?: (asset: Asset[]) => Asset[]
+  filterBy?: (asset: Asset[]) => Asset[] | undefined
 }
 
 export const AssetSearch = ({ onClick, filterBy }: AssetSearchProps) => {
@@ -29,11 +29,15 @@ export const AssetSearch = ({ onClick, filterBy }: AssetSearchProps) => {
   const searching = useMemo(() => searchString.length > 0, [searchString])
 
   useEffect(() => {
-    setFilteredAssets(
-      searching ? filterAssetsBySearchTerm(searchString, currentAssets) : currentAssets,
-    )
+    if (currentAssets) {
+      setFilteredAssets(
+        searching ? filterAssetsBySearchTerm(searchString, currentAssets) : currentAssets,
+      )
+    }
     // eslint-disable-next-line react-hooks/exhaustive-deps
   }, [searchString])
+
+  const listAssets = searching ? filteredAssets : currentAssets
 
   return (
     <>
@@ -57,13 +61,11 @@ export const AssetSearch = ({ onClick, filterBy }: AssetSearchProps) => {
           />
         </InputGroup>
       </Box>
-      <Box flex={1}>
-        <AssetList
-          mb='10'
-          assets={searching ? filteredAssets : currentAssets}
-          handleClick={onClick}
-        />
-      </Box>
+      {listAssets && (
+        <Box flex={1}>
+          <AssetList mb='10' assets={listAssets} handleClick={onClick} />
+        </Box>
+      )}
     </>
   )
 }

--- a/src/components/Trade/SelectAsset.tsx
+++ b/src/components/Trade/SelectAsset.tsx
@@ -10,7 +10,7 @@ import { WithBackButton } from './WithBackButton'
 
 type SelectAssetProps = {
   onClick: (asset: Asset) => void
-  filterBy: (assets: Asset[]) => Asset[]
+  filterBy: (assets: Asset[]) => Asset[] | undefined
 } & RouteComponentProps
 
 export const SelectAsset: React.FC<SelectAssetProps> = ({ onClick, history, filterBy }) => {

--- a/src/components/Trade/TradeInput.tsx
+++ b/src/components/Trade/TradeInput.tsx
@@ -286,8 +286,8 @@ export const TradeInput = ({ history }: RouterProps) => {
                 inputLeftElement={
                   <TokenButton
                     onClick={() => history.push(TradeRoutePaths.SellSelect)}
-                    logo={sellTradeAsset?.asset?.icon ?? ''} // FIXME
-                    symbol={sellTradeAsset?.asset?.symbol ?? ''} // FIXME
+                    logo={sellTradeAsset?.asset?.icon ?? ''}
+                    symbol={sellTradeAsset?.asset?.symbol ?? ''}
                     data-test='token-row-sell-token-button'
                   />
                 }
@@ -358,8 +358,8 @@ export const TradeInput = ({ history }: RouterProps) => {
                 inputLeftElement={
                   <TokenButton
                     onClick={() => history.push(TradeRoutePaths.BuySelect)}
-                    logo={buyTradeAsset?.asset?.icon || ''} // FIXME
-                    symbol={buyTradeAsset?.asset?.symbol || ''} // FIXME
+                    logo={buyTradeAsset?.asset?.icon || ''}
+                    symbol={buyTradeAsset?.asset?.symbol || ''}
                     data-test='token-row-buy-token-button'
                   />
                 }

--- a/src/components/Trade/TradeInput.tsx
+++ b/src/components/Trade/TradeInput.tsx
@@ -43,12 +43,7 @@ export const TradeInput = ({ history }: RouterProps) => {
   const [isSendMaxLoading, setIsSendMaxLoading] = useState<boolean>(false)
   const [quote, feeAssetFiatRate, buyTradeAsset, sellTradeAsset] = useWatch({
     name: ['quote', 'feeAssetFiatRate', 'buyAsset', 'sellAsset'],
-  }) as [
-    TS['quote'],
-    TS['feeAssetFiatRate'],
-    TS['buyAsset'] | undefined,
-    TS['sellAsset'] | undefined,
-  ]
+  }) as [TS['quote'], TS['feeAssetFiatRate'], TS['buyAsset'], TS['sellAsset']]
   const { updateQuote, checkApprovalNeeded, getSendMaxAmount, updateTrade, feeAsset } = useSwapper()
   const toast = useToast()
   const translate = useTranslate()
@@ -127,7 +122,7 @@ export const TradeInput = ({ history }: RouterProps) => {
   }
 
   const onSetMaxTrade = async () => {
-    if (!(wallet && sellTradeAsset && buyTradeAsset)) return
+    if (!(wallet && sellTradeAsset?.asset && buyTradeAsset?.asset)) return
     const fnLogger = moduleLogger.child({ namespace: ['onSwapMax'] })
 
     try {
@@ -150,7 +145,7 @@ export const TradeInput = ({ history }: RouterProps) => {
       const currentSellAsset = getValues('sellAsset')
       const currentBuyAsset = getValues('buyAsset')
 
-      if (sellTradeAsset && buyTradeAsset) {
+      if (currentSellAsset?.asset && currentBuyAsset?.asset) {
         await updateQuote({
           sellAsset: currentSellAsset.asset,
           buyAsset: currentBuyAsset.asset,
@@ -162,8 +157,8 @@ export const TradeInput = ({ history }: RouterProps) => {
         fnLogger.error(
           {
             fn: 'getSendMaxAmount',
-            sellAsset: sellTradeAsset?.asset,
-            buyAsset: buyTradeAsset?.asset,
+            sellAsset: currentBuyAsset?.asset,
+            buyAsset: currentBuyAsset?.asset,
             feeAsset,
           },
           'Invalid assets',
@@ -181,6 +176,7 @@ export const TradeInput = ({ history }: RouterProps) => {
     try {
       const currentSellAsset = getValues('sellAsset')
       const currentBuyAsset = getValues('buyAsset')
+      if (!(currentSellAsset?.asset && currentBuyAsset?.asset)) return
       setValue('sellAsset', currentBuyAsset)
       setValue('buyAsset', currentSellAsset)
       updateQuote({
@@ -244,7 +240,7 @@ export const TradeInput = ({ history }: RouterProps) => {
                     isNumericString={true}
                     onValueChange={e => {
                       onChange(e.value)
-                      if (e.value !== value && sellTradeAsset && buyTradeAsset) {
+                      if (e.value !== value && sellTradeAsset?.asset && buyTradeAsset?.asset) {
                         updateQuote({
                           amount: e.value,
                           sellAsset: sellTradeAsset.asset,
@@ -275,7 +271,7 @@ export const TradeInput = ({ history }: RouterProps) => {
                 disabled={isSendMaxLoading}
                 rules={{ required: true }}
                 onInputChange={(amount: string) => {
-                  if (sellTradeAsset && buyTradeAsset) {
+                  if (sellTradeAsset?.asset && buyTradeAsset?.asset) {
                     updateQuote({
                       amount,
                       sellAsset: sellTradeAsset.asset,
@@ -357,7 +353,7 @@ export const TradeInput = ({ history }: RouterProps) => {
                 disabled={isSendMaxLoading}
                 rules={{ required: true }}
                 onInputChange={(amount: string) => {
-                  if (sellTradeAsset && buyTradeAsset) {
+                  if (sellTradeAsset?.asset && buyTradeAsset?.asset) {
                     updateQuote({
                       amount,
                       sellAsset: sellTradeAsset.asset,

--- a/src/components/Trade/hooks/useSwapper/useSwapper.ts
+++ b/src/components/Trade/hooks/useSwapper/useSwapper.ts
@@ -46,7 +46,7 @@ export const useSwapper = () => {
     name: ['quote', 'sellAsset', 'trade'],
   }) as [
     TradeQuote<SupportedChainIds> & Trade<SupportedChainIds>,
-    TradeAsset,
+    TradeAsset | undefined,
     Trade<SupportedChainIds>,
   ]
   const adapterManager = useChainAdapters()
@@ -72,13 +72,16 @@ export const useSwapper = () => {
   )
 
   const getSupportedBuyAssetsFromSellAsset = useCallback(
-    (assets: Asset[]): Asset[] => {
+    (assets: Asset[]): Asset[] | undefined => {
+      const sellAssetId = sellTradeAsset?.asset?.assetId
       const assetIds = assets.map(asset => asset.assetId)
-      const supportedBuyAssetIds = swapperManager.getSupportedBuyAssetIdsFromSellId({
-        assetIds,
-        sellAssetId: sellTradeAsset?.asset.assetId,
-      })
-      return filterAssetsByIds(assets, supportedBuyAssetIds)
+      const supportedBuyAssetIds = sellAssetId
+        ? swapperManager.getSupportedBuyAssetIdsFromSellId({
+            assetIds,
+            sellAssetId,
+          })
+        : undefined
+      return supportedBuyAssetIds ? filterAssetsByIds(assets, supportedBuyAssetIds) : undefined
     },
     [swapperManager, sellTradeAsset],
   )
@@ -89,11 +92,11 @@ export const useSwapper = () => {
   }, [])
 
   const sellAssetBalance = useAppSelector(state =>
-    selectPortfolioCryptoBalanceByAssetId(state, { assetId: sellTradeAsset?.asset.assetId }),
+    selectPortfolioCryptoBalanceByAssetId(state, { assetId: sellTradeAsset?.asset?.assetId ?? '' }),
   )
 
   const feeAsset = useAppSelector(state =>
-    selectFeeAssetById(state, sellTradeAsset?.asset.assetId ?? 'eip155:1/slip44:60'),
+    selectFeeAssetById(state, sellTradeAsset?.asset?.assetId ?? 'eip155:1/slip44:60'),
   )
 
   const { showErrorToast } = useErrorHandler()

--- a/src/components/Trade/hooks/useTradeRoutes/useTradeRoutes.ts
+++ b/src/components/Trade/hooks/useTradeRoutes/useTradeRoutes.ts
@@ -65,7 +65,7 @@ export const useTradeRoutes = (
       if (sellAsset && buyAsset) {
         setValue('buyAsset.asset', buyAsset)
         setValue('sellAsset.asset', sellAsset)
-        updateQuote({
+        await updateQuote({
           forceQuote: true,
           amount: '0',
           sellAsset,
@@ -90,21 +90,23 @@ export const useTradeRoutes = (
         const previousBuyAsset = { ...getValues('buyAsset') }
 
         // Handle scenario where same asset is selected for buy and sell
-        if (asset.assetId === previousBuyAsset?.asset.assetId) {
+        if (asset.assetId === previousBuyAsset?.asset?.assetId) {
           setValue('sellAsset.asset', asset)
           setValue('buyAsset.asset', previousSellAsset.asset)
         } else {
           setValue('sellAsset.asset', asset)
           setValue('buyAsset.asset', buyTradeAsset?.asset)
         }
-        updateQuote({
-          forceQuote: true,
-          amount: bnOrZero(sellTradeAsset?.amount).toString(),
-          sellAsset: asset,
-          buyAsset: buyTradeAsset?.asset,
-          feeAsset,
-          action: TradeAmountInputField.SELL,
-        })
+        if (sellTradeAsset?.asset && buyTradeAsset?.asset) {
+          await updateQuote({
+            forceQuote: true,
+            amount: bnOrZero(sellTradeAsset.amount).toString(),
+            sellAsset: asset,
+            buyAsset: buyTradeAsset.asset,
+            feeAsset,
+            action: TradeAmountInputField.SELL,
+          })
+        }
       } catch (e) {
         console.warn(e)
       } finally {
@@ -113,11 +115,12 @@ export const useTradeRoutes = (
     },
     [
       getValues,
-      updateQuote,
+      sellTradeAsset?.asset,
       sellTradeAsset?.amount,
       buyTradeAsset?.asset,
-      feeAsset,
       setValue,
+      updateQuote,
+      feeAsset,
       history,
     ],
   )
@@ -129,7 +132,7 @@ export const useTradeRoutes = (
         const previousBuyAsset = { ...getValues('buyAsset') }
 
         // Handle scenario where same asset is selected for buy and sell
-        if (asset.assetId === previousSellAsset?.asset.assetId) {
+        if (asset.assetId === previousSellAsset?.asset?.assetId) {
           setValue('buyAsset.asset', asset)
           setValue('sellAsset.asset', previousBuyAsset.asset)
         } else {
@@ -137,14 +140,16 @@ export const useTradeRoutes = (
           setValue('sellAsset.asset', sellTradeAsset?.asset)
         }
 
-        updateQuote({
-          forceQuote: true,
-          amount: bnOrZero(buyTradeAsset?.amount).toString(),
-          sellAsset: sellTradeAsset?.asset,
-          buyAsset: asset,
-          feeAsset,
-          action: TradeAmountInputField.SELL,
-        })
+        if (sellTradeAsset?.asset && buyTradeAsset?.asset) {
+          await updateQuote({
+            forceQuote: true,
+            amount: bnOrZero(buyTradeAsset.amount).toString(),
+            sellAsset: sellTradeAsset.asset,
+            buyAsset: asset,
+            feeAsset,
+            action: TradeAmountInputField.SELL,
+          })
+        }
       } catch (e) {
         console.warn(e)
       } finally {

--- a/src/components/Trade/types.ts
+++ b/src/components/Trade/types.ts
@@ -23,9 +23,9 @@ export type BuildQuoteTxOutput = {
 }
 
 export type TradeState<C extends SupportedChainIds> = {
-  sellAsset: TradeAsset
-  buyAsset: TradeAsset
-  fiatSellAmount: string
+  sellAsset: TradeAsset | undefined
+  buyAsset: TradeAsset | undefined
+  fiatSellAmount: string | undefined
   sellAssetFiatRate: string
   feeAssetFiatRate: string
   fees?: QuoteFeeData<C>

--- a/src/components/Trade/types.ts
+++ b/src/components/Trade/types.ts
@@ -9,7 +9,7 @@ export enum TradeAmountInputField {
 }
 
 export type TradeAsset = {
-  asset: Asset
+  asset?: Asset
   amount?: string
 }
 


### PR DESCRIPTION
## Description

Fixes the uncaught type errors that occur in `useSwapper.ts` and `TradeInput.tsx` on unhandled network request failures by updating the types to correctly reflect that `TradeState` and `TradeAsset` properties can be `undefined`.

Also adds some missing `await`s.

<img width="914" alt="Screen Shot 2022-06-05 at 9 38 30 am" src="https://user-images.githubusercontent.com/97164662/172036418-cdcf453d-6c11-4311-86f8-834c6df612ce.png">

<img width="910" alt="Screen Shot 2022-06-05 at 11 20 04 am" src="https://user-images.githubusercontent.com/97164662/172036423-d52993cf-cf20-4498-9620-5c501e2c70eb.png">

## Notice

- [x] Have you followed the guidelines in our [Contributing]('https://github.com/shapeshift/web/CONTRIBUTING.md) guide?
- [x] Have you checked to ensure there aren't other open [Pull Requests](https://github.com/shapeshift/web/pulls) for the same update/change?

## Pull Request Type

- [x] :bug: Bug fix (Non-breaking Change: Fixes an issue)
- [ ] :hammer_and_wrench: Chore (Non-breaking Change: Doc updates, pkg upgrades, typos, etc..)
- [ ] :nail_care: New Feature (Breaking/Non-breaking Change)

## Issue (if applicable)

Closes https://github.com/shapeshift/web/issues/1945

## Risk

This is a refactor, so no changes to behaviour are expected, though we should check for regressions.

## Testing

Confirm that the trade component still works as expected.

## Screenshots (if applicable)

N/A

