### PR TITLE
fix: tighten onMissingKey checks

### DIFF
--- a/src/context/I18nProvider/I18nProvider.tsx
+++ b/src/context/I18nProvider/I18nProvider.tsx
@@ -10,7 +10,7 @@ export const I18nProvider = ({ children }: { children: React.ReactNode }) => {
   const messages = translations[locale]
   const onMissingKey = (key: string, substitutions?: InterpolationOptions) => {
     const translation = get(translations['en'], key)
-    return translation ? transformPhrase(translation, substitutions) : key
+    return typeof translation === 'string' ? transformPhrase(translation, substitutions) : key
   }
   return (
     <I18n locale={locale} messages={messages} allowMissing={true} onMissingKey={onMissingKey}>


### PR DESCRIPTION
## Description

This tightens the `onMissingKey` check in case the translation key is a valid key, but isn't a string e.g an object containing more translation keys.

## Notice

<!-- Before submitting a pull request, please make sure you have answered the following: -->

- [x] Have you followed the guidelines in our [Contributing]('https://github.com/shapeshift/web/CONTRIBUTING.md) guide?
- [x] Have you checked to ensure there aren't other open [Pull Requests](https://github.com/shapeshift/web/pulls) for the same update/change?

## Pull Request Type

- [x] :bug: Bug fix (Non-breaking Change: Fixes an issue)
- [ ] :hammer_and_wrench: Chore (Non-breaking Change: Doc updates, pkg upgrades, typos, etc..)
- [ ] :nail_care: New Feature (Breaking/Non-breaking Change)

## Issue (if applicable)

N/A

## Risk

N/A

## Testing

- Translations are still working
- Change a translation property to be an `Record<string, string>` object of translations instead of a key. The app shouldn't crash, no error should be thrown and the raw translation key should be shown.

## Screenshots (if applicable)
