### PR TITLE
chore: remove unused types

### DIFF
--- a/src/components/Trade/hooks/useSwapper/useSwapper.ts
+++ b/src/components/Trade/hooks/useSwapper/useSwapper.ts
@@ -14,7 +14,7 @@ import debounce from 'lodash/debounce'
 import { useCallback, useRef, useState } from 'react'
 import { useFormContext, useWatch } from 'react-hook-form'
 import { useSelector } from 'react-redux'
-import { BuildQuoteTxOutput, TradeAmountInputField, TradeAsset } from 'components/Trade/types'
+import { TradeAmountInputField, TradeAsset } from 'components/Trade/types'
 import { useChainAdapters } from 'context/PluginProvider/PluginProvider'
 import { useErrorHandler } from 'hooks/useErrorToast/useErrorToast'
 import { bn, bnOrZero } from 'lib/bignumber/bignumber'
@@ -133,7 +133,7 @@ export const useSwapper = () => {
     sellAsset: Asset
     buyAsset: Asset
     amount: string
-  }): Promise<BuildQuoteTxOutput> => {
+  }): Promise<void> => {
     const swapper = await swapperManager.getBestSwapper({
       buyAssetId: buyAsset.assetId,
       sellAssetId: sellAsset.assetId,
@@ -152,7 +152,6 @@ export const useSwapper = () => {
     })
     setFees(result, sellAsset)
     setValue('trade', result)
-    return result
   }
 
   const getTradeTxs = async (tradeResult: TradeResult): Promise<TradeTxs> => {

--- a/src/components/Trade/types.ts
+++ b/src/components/Trade/types.ts
@@ -17,11 +17,6 @@ export type TradeProps = {
   defaultBuyAssetId: AssetId
 }
 
-export type BuildQuoteTxOutput = {
-  success: boolean
-  statusReason: string
-}
-
 export type TradeState<C extends SupportedChainIds> = {
   sellAsset: TradeAsset
   buyAsset: TradeAsset


### PR DESCRIPTION
## Description

Remove some unused types related to swapper. Removing this will allow us to safely remove "statusReason" and "success" from return values of swapper buildTrade() and getTradeQuote()

## Notice

- [ ] Have you followed the guidelines in our [Contributing]('https://github.com/shapeshift/web/CONTRIBUTING.md) guide?
- [ ] Have you checked to ensure there aren't other open [Pull Requests](https://github.com/shapeshift/web/pulls) for the same update/change?

## Pull Request Type

- [ ] :bug: Bug fix (Non-breaking Change: Fixes an issue)
- [ ] :hammer_and_wrench: Chore (Non-breaking Change: Doc updates, pkg upgrades, typos, etc..)
- [ ] :nail_care: New Feature (Breaking/Non-breaking Change)

## Issue (if applicable)

N/A

## Risk

no risk.

## Testing

Minimal testing needed - This is a very low risk PR removing types

## Screenshots (if applicable)
