### PR TITLE
fix(foxPage): add back `<AssetMarketData />` for FOXy

### DIFF
--- a/src/plugins/foxPage/foxPage.tsx
+++ b/src/plugins/foxPage/foxPage.tsx
@@ -238,6 +238,7 @@ export const FoxPage = () => {
               </Stack>
               <Stack flex='1 1 0%' width='full' maxWidth={{ base: 'full', lg: 'sm' }} spacing={4}>
                 <AssetActions assetId={FOXY_ASSET_ID} />
+                <AssetMarketData assetId={selectedAsset.assetId} />
                 <FoxChart assetId={FOXY_ASSET_ID} />
                 <TradeOpportunities
                   opportunities={assetsTradeOpportunitiesBuckets[FOXY_ASSET_ID]}


### PR DESCRIPTION
## Description

Adds back the `<AssetMarketData />` component for FOXy after it went away in https://github.com/shapeshift/web/pull/1840 mergefix

## Notice

<!-- Before submitting a pull request, please make sure you have answered the following: -->

- [x] Have you followed the guidelines in our [Contributing]('https://github.com/shapeshift/web/CONTRIBUTING.md) guide?
- [x] Have you checked to ensure there aren't other open [Pull Requests](https://github.com/shapeshift/web/pulls) for the same update/change?

## Pull Request Type

- [x] :bug: Bug fix (Non-breaking Change: Fixes an issue)
- [ ] :hammer_and_wrench: Chore (Non-breaking Change: Doc updates, pkg upgrades, typos, etc..)
- [ ] :nail_care: New Feature (Breaking/Non-breaking Change)

## Issue (if applicable)

https://github.com/shapeshift/web/issues/1771

## Risk

N/A

## Testing

- Market data should be shown for both FOX and FOXy in the Fox Page

## Screenshots (if applicable)

<img width="407" alt="image" src="https://user-images.githubusercontent.com/17035424/172243356-98806e7a-a031-4fff-8cd7-957962a0ac78.png">