### PR TITLE
chore: use AddressZero const from @ethersproject/constants

### DIFF
--- a/cypress/factories/0x/ethFoxRate.ts
+++ b/cypress/factories/0x/ethFoxRate.ts
@@ -1,3 +1,5 @@
+import { AddressZero } from '@ethersproject/constants'
+
 import { sources } from './sources'
 
 export const makeEthFoxRateResponse = () => {
@@ -16,7 +18,7 @@ export const makeEthFoxRateResponse = () => {
     sellTokenAddress: '0xeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeee',
     sellAmount: '89000000000000000000',
     sources,
-    allowanceTarget: '0x0000000000000000000000000000000000000000',
+    allowanceTarget: AddressZero,
     sellTokenToEthRate: '1',
     buyTokenToEthRate: '7846.55087491411914402',
   }

--- a/cypress/factories/0x/ethUsdcRate.ts
+++ b/cypress/factories/0x/ethUsdcRate.ts
@@ -1,5 +1,6 @@
-import { sources } from './sources'
+import { AddressZero } from '@ethersproject/constants'
 
+import { sources } from './sources'
 export const makeEthUsdcRateResponse = () => {
   return {
     chainId: 1,
@@ -16,7 +17,7 @@ export const makeEthUsdcRateResponse = () => {
     sellTokenAddress: '0xeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeee',
     sellAmount: '376837347525673',
     sources,
-    allowanceTarget: '0x0000000000000000000000000000000000000000',
+    allowanceTarget: AddressZero,
     sellTokenToEthRate: '1',
     buyTokenToEthRate: '2653.65836',
   }

--- a/src/lib/address/ens.ts
+++ b/src/lib/address/ens.ts
@@ -1,4 +1,5 @@
 import ENS, { getEnsAddress } from '@ensdomains/ensjs'
+import { AddressZero } from '@ethersproject/constants'
 import { CHAIN_REFERENCE } from '@shapeshiftoss/caip'
 import memoize from 'lodash/memoize'
 import { getWeb3Provider } from 'lib/web3-provider'
@@ -28,7 +29,7 @@ export const validateEnsDomain: ValidateVanityAddress = async ({ value }) =>
 export const ensLookup = memoize(async (domain: string): Promise<ResolveVanityAddressReturn> => {
   const ens = await getENS()
   const address = await ens.name(domain).getAddress()
-  if (address === '0x0000000000000000000000000000000000000000') return ''
+  if (address === AddressZero) return ''
   return address
 })
 

--- a/src/test/mocks/txs.ts
+++ b/src/test/mocks/txs.ts
@@ -1,3 +1,4 @@
+import { AddressZero } from '@ethersproject/constants'
 import { chainAdapters, ChainTypes, UtxoAccountType } from '@shapeshiftoss/types'
 import { Tx } from 'state/slices/txHistorySlice/txHistorySlice'
 
@@ -121,7 +122,7 @@ export const TradeTx: Tx = {
   transfers: [
     {
       assetId: 'eip155:1/erc20:0x5f18c75abdae578b483e5f43f12a39cf75b973a9',
-      from: '0x0000000000000000000000000000000000000000',
+      from: AddressZero,
       to: '0x934be745172066EDF795ffc5EA9F28f19b440c63',
       type: chainAdapters.TxType.Receive,
       value: '9178352',
@@ -325,7 +326,7 @@ export const yearnVaultDeposit: Tx = {
   transfers: [
     {
       assetId: 'eip155:1/erc20:0x5f18c75abdae578b483e5f43f12a39cf75b973a9',
-      from: '0x0000000000000000000000000000000000000000',
+      from: AddressZero,
       to: '0x934be745172066EDF795ffc5EA9F28f19b440c63',
       type: chainAdapters.TxType.Receive,
       value: '9178352',
@@ -424,7 +425,7 @@ export const createMockEthTxs = (account: string): Tx[] => {
       },
       {
         assetId: 'eip155:1/erc20:0xfbeb78a723b8087fd2ea7ef1afec93d35e8bed42',
-        from: '0x0000000000000000000000000000000000000000',
+        from: AddressZero,
         to: account,
         type: chainAdapters.TxType.Receive,
         value: '5481290118862792961',
@@ -450,7 +451,7 @@ export const createMockEthTxs = (account: string): Tx[] => {
       {
         assetId: 'eip155:1/erc20:0xfbeb78a723b8087fd2ea7ef1afec93d35e8bed42',
         from: account,
-        to: '0x0000000000000000000000000000000000000000',
+        to: AddressZero,
         type: chainAdapters.TxType.Send,
         value: '5481290118862792961',
       },
@@ -482,7 +483,7 @@ export const createMockEthTxs = (account: string): Tx[] => {
       {
         assetId: 'eip155:1/erc20:0x5f18c75abdae578b483e5f43f12a39cf75b973a9',
         from: '0x934be745172066EDF795ffc5EA9F28f19b440c63',
-        to: '0x0000000000000000000000000000000000000000',
+        to: AddressZero,
         type: chainAdapters.TxType.Send,
         value: '1000000',
       },
@@ -513,7 +514,7 @@ export const createMockEthTxs = (account: string): Tx[] => {
     transfers: [
       {
         assetId: 'eip155:1/erc20:0x5f18c75abdae578b483e5f43f12a39cf75b973a9',
-        from: '0x0000000000000000000000000000000000000000',
+        from: AddressZero,
         to: '0x934be745172066EDF795ffc5EA9F28f19b440c63',
         type: chainAdapters.TxType.Receive,
         value: '9178352',


### PR DESCRIPTION
## Description

This replaces all occurences of `0x0000000000000000000000000000000000000000` with imported `AddressZero` from ethers.js:

https://github.com/ethers-io/ethers.js/blob/a71f51825571d1ea0fa997c1352d5b4d85643416/packages/constants/src.ts/addresses.ts#L1

## Notice

<!-- Before submitting a pull request, please make sure you have answered the following: -->

- [x] Have you followed the guidelines in our [Contributing]('https://github.com/shapeshift/web/CONTRIBUTING.md) guide?
- [x] Have you checked to ensure there aren't other open [Pull Requests](https://github.com/shapeshift/web/pulls) for the same update/change?

## Pull Request Type

- [ ] :bug: Bug fix (Non-breaking Change: Fixes an issue)
- [x] :hammer_and_wrench: Chore (Non-breaking Change: Doc updates, pkg upgrades, typos, etc..)
- [ ] :nail_care: New Feature (Breaking/Non-breaking Change)

## Issue (if applicable)

N/A

## Risk

N/A, this is the same string

## Testing

N/A

## Screenshots (if applicable)
