### PR TITLE
fix: updated captcha form error to fix path to translation and give a…

### DIFF
--- a/src/assets/translations/en/main.json
+++ b/src/assets/translations/en/main.json
@@ -941,6 +941,7 @@
         "emailRequired": "Email is required",
         "invalidEmail": "Email is invalid",
         "invalidCaptcha": "Captcha is invalid",
+        "captchaRequired": "Captcha is required",
         "tooManyAttempts": "Too many attempts, please try again later.",
         "invalidLogin": "Invalid login",
         "noWallet": "Could not find a ShapeShift Native wallet for your login. If you feel this message is in error, please contact ShapeShift support.",

--- a/src/assets/translations/es/main.json
+++ b/src/assets/translations/es/main.json
@@ -831,6 +831,7 @@
         "emailRequired": "Correo Electronico es requerido",
         "invalidEmail": "Correo Electrónico es invalido",
         "invalidCaptcha": "El Captcha no es válido",
+        "captchaRequired": "Se requiere captcha",
         "invalidLogin": "Ingreso invalido",
         "noWallet": "No se pudo encontrar una billetera nativa de ShapeShift para su inicio de sesión. Si cree que este mensaje es un error, comuníquese con el soporte de ShapeShift.",
         "decryptionError": "Algo salió mal al descifrar su billetera.",

--- a/src/assets/translations/fr/main.json
+++ b/src/assets/translations/fr/main.json
@@ -821,6 +821,7 @@
         "emailRequired": "L'adresse de courriel est requise",
         "invalidEmail": "L'adresse de courriel est invalide",
         "invalidCaptcha": "Le Capcha est invalide",
+        "captchaRequired": "Le Capcha est requis",
         "invalidLogin": "Identification invalide",
         "noWallet": "Impossible de trouver un porte-monnaie ShapeShift Natif pour votre connexion. Si vous pensez que ce message est une erreur, veuillez contacter le support ShapeShift.",
         "decryptionError": "Une erreur s'est produite lors du décryptage de votre porte-monnaie.",

--- a/src/assets/translations/id/main.json
+++ b/src/assets/translations/id/main.json
@@ -836,6 +836,7 @@
         "emailRequired": "Email diperlukan ",
         "invalidEmail": "Email tidak valid",
         "invalidCaptcha": "Captcha tidak valid",
+        "captchaRequired": "Captcha diperlukan",
         "invalidLogin": "Invalid login",
         "noWallet": "Tidak dapat menemukan dompet ShapeShift Asli untuk login Anda. Jika Anda merasa pesan ini salah, silakan hubungi dukungan ShapeShift.",
         "decryptionError": "Terjadi kesalahan saat mendekripsi dompet Anda.",

--- a/src/assets/translations/ko/main.json
+++ b/src/assets/translations/ko/main.json
@@ -831,6 +831,7 @@
         "emailRequired": "이메일 입력이 필요합니다",
         "invalidEmail": "올바른 이메일이 아닙니다",
         "invalidCaptcha": "올바른 Captcha가 아닙니다",
+        "captchaRequired": "보안문자가 필요합니다",
         "invalidLogin": "로그인 실패",
         "noWallet": "로그인을 하기 위한 ShapeShift 기본 지갑을 찾을 수 없습니다. 이 안내에 오류가 있다고 생각하시면 ShapeShift 고객 지원 센터에 문의해주세요.",
         "decryptionError": "지갑을 복호화하는 중에 오류가 발생하였습니다.",

--- a/src/assets/translations/pt/main.json
+++ b/src/assets/translations/pt/main.json
@@ -827,6 +827,7 @@
         "emailRequired": "O e-mail é obrigatório",
         "invalidEmail": "Email inválido",
         "invalidCaptcha": "Captcha inválido",
+        "captchaRequired": "Captcha é obrigatório",
         "invalidLogin": "Login inválido",
         "noWallet": "Não foi possível encontrar uma carteira ShapeShift Native para o seu login. Se você achar que esta mensagem está errada, entre em contato com o suporte da ShapeShift.",
         "decryptionError": "Algo deu errado ao descriptografar sua carteira.",

--- a/src/assets/translations/zh/main.json
+++ b/src/assets/translations/zh/main.json
@@ -827,6 +827,7 @@
         "emailRequired": "电子邮件是必需的",
         "invalidEmail": "电子邮件不可用",
         "invalidCaptcha": "验证码不可用",
+        "captchaRequired": "验证码是必需的",
         "invalidLogin": "无效的登录",
         "noWallet": "找不到用于您登录的原生ShapeShift钱包。如果您觉得这条消息是错误的，请联系ShapeShift提供帮助。",
         "decryptionError": "在解密你的钱包时出了问题。",

--- a/src/context/WalletProvider/NativeWallet/components/LegacyLogin.tsx
+++ b/src/context/WalletProvider/NativeWallet/components/LegacyLogin.tsx
@@ -175,7 +175,7 @@ export const LegacyLogin = () => {
             <FormControl isInvalid={!captchaSolution} my={6}>
               <FriendlyCaptcha handleCaptcha={setCaptchaSolution} solution={captchaSolution} />
               <FormErrorMessage>
-                {translate('walletProvider.shapeShift.invalidCaptcha')}
+                {translate('walletProvider.shapeShift.legacy.captchaRequired')}
               </FormErrorMessage>
             </FormControl>
           </Box>
@@ -208,7 +208,7 @@ export const LegacyLogin = () => {
             <FormControl isInvalid={!captchaSolution} my={6}>
               <FriendlyCaptcha handleCaptcha={setCaptchaSolution} solution={captchaSolution} />
               <FormErrorMessage>
-                {translate('walletProvider.shapeShift.invalidCaptcha')}
+                {translate('walletProvider.shapeShift.legacy.captchaRequired')}
               </FormErrorMessage>
             </FormControl>
           </Box>


### PR DESCRIPTION
… better error of captcha required when login errors happen and solution is nulled out.

## Description

Fixes a bug of an invalid translation path and adds an error message for captcha required to prevent confusion from an invalid login. Sometimes the captcha requires the user to click to start verification, and the captcha is nulled out on invalid logins. So this error tells the user the captcha is required instead of it being invalid.
<!-- Please describe your changes -->

## Notice

<!-- Before submitting a pull request, please make sure you have answered the following: -->

- [x] Have you followed the guidelines in our [Contributing]('https://github.com/shapeshift/web/CONTRIBUTING.md) guide?
- [x] Have you checked to ensure there aren't other open [Pull Requests](https://github.com/shapeshift/web/pulls) for the same update/change?

## Pull Request Type

- [x] :bug: Bug fix (Non-breaking Change: Fixes an issue)
- [ ] :hammer_and_wrench: Chore (Non-breaking Change: Doc updates, pkg upgrades, typos, etc..)
- [ ] :nail_care: New Feature (Breaking/Non-breaking Change)

## Issue (if applicable)

closes #1968 
<!-----------------------------------------------------------------------------
If applicable, please link to the github issue and put `closes #XXXX` in your comment to auto-close the issue that your PR fixes.
------------------------------------------------------------------------------>

## Risk

Minimal risk to legacy login flow. Small risk of incorrect non-english translations. (I just used google translate)
<!-----------------------------------------------------------------------------
Outline the scope of your changes and the risk associated with them. You must use your discretion as an engineer to determine the potential impact of your changes.

E.g. an upgrade to `hdwallet` or core state management would be considered higher risk, and might require a full regression test. UI or isolated view changes, or something behind a feature flag may have near zero risk. Small bug fixes might require testing isolated to the specific fix.
------------------------------------------------------------------------------>

## Testing

To test. Try to login with invalid credentials. Once login fails, a message should show saying captcha required that will go away once captcha is re-completed. Sometimes captcha completes automatically, other times it requires a user click. Message should disappear once captcha is complete.
<!-----------------------------------------------------------------------------
If your testing steps are technical, outline steps for an engineer to verify.

If your testing steps are functional, please provide a full guide with any features requiring special attention for operations to test your branch in the preview environment.
------------------------------------------------------------------------------>

## Screenshots (if applicable)
<img width="393" alt="Screen Shot 2022-06-07 at 15 45 23" src="https://user-images.githubusercontent.com/88169003/172488468-56fc31f8-ab14-4dc4-8152-11b25ce1e779.png">
<img width="460" alt="Screen Shot 2022-06-07 at 15 45 40" src="https://user-images.githubusercontent.com/88169003/172488469-c1c8bde1-58f9-4eb3-b090-a76f67911418.png">
