### PR TITLE
fix: bitcoinChainAdapter reference was wrong

### DIFF
--- a/src/plugins/bitcoin/index.tsx
+++ b/src/plugins/bitcoin/index.tsx
@@ -16,7 +16,7 @@ export function register(): Plugins {
               ChainTypes.Bitcoin,
               () => {
                 const http = new unchained.bitcoin.V1Api(
-                  new unchained.ethereum.Configuration({
+                  new unchained.bitcoin.Configuration({
                     basePath: getConfig().REACT_APP_UNCHAINED_BITCOIN_HTTP_URL,
                   }),
                 )


### PR DESCRIPTION
## Description

fix: bitcoinChainAdapter reference was wrong

The code works because ethereum.Configuration and bitcoin.Configuration are the same code.

## Notice

<!-- Before submitting a pull request, please make sure you have answered the following: -->

- [X] Have you followed the guidelines in our [Contributing]('https://github.com/shapeshift/web/CONTRIBUTING.md) guide?
- [X] Have you checked to ensure there aren't other open [Pull Requests](https://github.com/shapeshift/web/pulls) for the same update/change?

## Pull Request Type

- [X] :bug: Bug fix (Non-breaking Change: Fixes an issue)
- [ ] :hammer_and_wrench: Chore (Non-breaking Change: Doc updates, pkg upgrades, typos, etc..)
- [ ] :nail_care: New Feature (Breaking/Non-breaking Change)

## Issue (if applicable)
N/A
## Risk
None
## Testing
Shouldn't change anything but would affect Bitcoin stuff?
## Screenshots (if applicable)
