### PR TITLE
feat: more fox page tweaks (2)

### DIFF
--- a/src/assets/translations/en/main.json
+++ b/src/assets/translations/en/main.json
@@ -1107,12 +1107,16 @@
       "currentApy": "Current APY",
       "balance": "Balance",
       "getStarted": "Get Started",
+      "manage": "Manage",
       "currentPrice": "Current Price",
       "tradingUnavailable": "%{assetSymbol} is not yet tradeable on ShapeShift. You can trade %{assetSymbol} on ElasticSwap.",
       "tradeOnElasticSwap": "Trade %{assetSymbol} on ElasticSwap",
-      "otherOpportunitiesTitle": "Opportunities",
+      "otherOpportunitiesTitle": {
+        "FOX": "Other Opportunities",
+        "FOXy": "Opportunities"
+      },
       "otherOpportunitiesDescription": {
-        "FOX": "Get cagey with your FOX investment strategies! Explore the many opportunities for providing liquidity, farming for yield, lending and borrowing. Click the “Get Started” links below to visit the external sites of interest to learn more—and put your FOX to work for you.",
+        "FOX": "Explore the many opportunities for providing liquidity, farming for yield, lending and borrowing. Click the “Get Started” links below to visit the external sites of interest to learn more—and put your FOX to work for you.",
         "FOXy": "Quickly and easily purchase FOXy, the industry’s first DAO rebasing token that offers both yield and profit rewards."
       },
       "liquidityPools": "Liquidity Pools",

--- a/src/plugins/foxPage/components/MainOpportunity.tsx
+++ b/src/plugins/foxPage/components/MainOpportunity.tsx
@@ -5,6 +5,8 @@ import { Amount } from 'components/Amount/Amount'
 import { AssetIcon } from 'components/AssetIcon'
 import { Card } from 'components/Card/Card'
 import { Text } from 'components/Text/Text'
+import { bnOrZero } from 'lib/bignumber/bignumber'
+import { useFoxyBalances } from 'pages/Defi/hooks/useFoxyBalances'
 import { selectAssetById } from 'state/slices/selectors'
 import { useAppSelector } from 'state/store'
 
@@ -28,6 +30,9 @@ export const MainOpportunity = ({
   const translate = useTranslate()
 
   const selectedAsset = useAppSelector(state => selectAssetById(state, assetId))
+
+  const { opportunities: foxyOpportunities, loading: isFoxyBalancesLoading } = useFoxyBalances()
+  const hasActiveStaking = bnOrZero(foxyOpportunities?.[0]?.balance).gt(0)
 
   return (
     <Card display='block' width='full'>
@@ -69,11 +74,17 @@ export const MainOpportunity = ({
               {balance}
             </CText>
           </Box>
-          <Box alignSelf='center'>
-            <Button onClick={onClick} colorScheme={'blue'}>
-              <CText>{translate('plugins.foxPage.getStarted')}</CText>
-            </Button>
-          </Box>
+          <Skeleton isLoaded={isFoxyBalancesLoading === false}>
+            <Box alignSelf='center'>
+              <Button onClick={onClick} colorScheme={'blue'}>
+                <CText>
+                  {translate(
+                    hasActiveStaking ? 'plugins.foxPage.manage' : 'plugins.foxPage.getStarted',
+                  )}
+                </CText>
+              </Button>
+            </Box>
+          </Skeleton>
         </Flex>
       </Card.Body>
     </Card>

--- a/src/plugins/foxPage/components/OtherOpportunities/OtherOpportunities.tsx
+++ b/src/plugins/foxPage/components/OtherOpportunities/OtherOpportunities.tsx
@@ -1,30 +1,27 @@
 import { Flex } from '@chakra-ui/layout'
-import { Accordion, Text as CText } from '@chakra-ui/react'
+import { Accordion } from '@chakra-ui/react'
 import { OpportunitiesBucket } from 'plugins/foxPage/FoxCommon'
-import { useTranslate } from 'react-polyglot'
 import { Card } from 'components/Card/Card'
 import { Text } from 'components/Text/Text'
 
 import { FoxOtherOpportunityPanel } from './FoxOtherOpportunityPanel'
 
 type OtherOpportunitiesProps = {
+  title: string
   description: string
   opportunities: OpportunitiesBucket[]
 }
 
 export const OtherOpportunities: React.FC<OtherOpportunitiesProps> = ({
+  title,
   description,
   opportunities,
 }) => {
-  const translate = useTranslate()
-
   return (
     <Card display='block' width='full' borderRadius={8}>
       <Card.Header pb={0}>
         <Flex flexDirection='row' alignItems='center' mb={2}>
-          <CText fontWeight='bold' color='inherit'>
-            {translate('plugins.foxPage.otherOpportunitiesTitle')}
-          </CText>
+          <Text translation={title} fontWeight='bold' color='inherit' />
         </Flex>
         <Text translation={description} color='gray.500' />
       </Card.Header>

--- a/src/plugins/foxPage/foxPage.tsx
+++ b/src/plugins/foxPage/foxPage.tsx
@@ -242,6 +242,7 @@ export const FoxPage = () => {
                 />
 
                 <OtherOpportunities
+                  title={`plugins.foxPage.otherOpportunitiesTitle.${selectedAsset.symbol}`}
                   description={`plugins.foxPage.otherOpportunitiesDescription.${selectedAsset.symbol}`}
                   opportunities={otherOpportunities}
                 />
@@ -264,6 +265,7 @@ export const FoxPage = () => {
             >
               <Stack spacing={4} flex='1 1 0%' width='full'>
                 <OtherOpportunities
+                  title={`plugins.foxPage.otherOpportunitiesTitle.${selectedAsset.symbol}`}
                   description={`plugins.foxPage.otherOpportunitiesDescription.${selectedAsset.symbol}`}
                   opportunities={otherOpportunities}
                 />


### PR DESCRIPTION
## Description

The return of the Fox Page tweaks. 

This:

- adds programmatic title to the other opportunities component ("Other Opportunities" for FOX, "Opportunities" for FOXy since there is no main opportunity)
- remove the `Get cagey ...` sentance for FOX other opportunities description
- displays a "Manage" button for the FOX staking component in case there is an active staking  

## Notice

<!-- Before submitting a pull request, please make sure you have answered the following: -->

- [x] Have you followed the guidelines in our [Contributing]('https://github.com/shapeshift/web/CONTRIBUTING.md) guide?
- [x] Have you checked to ensure there aren't other open [Pull Requests](https://github.com/shapeshift/web/pulls) for the same update/change?

## Pull Request Type

- [ ] :bug: Bug fix (Non-breaking Change: Fixes an issue)
- [ ] :hammer_and_wrench: Chore (Non-breaking Change: Doc updates, pkg upgrades, typos, etc..)
- [x] :nail_care: New Feature (Breaking/Non-breaking Change)

## Issue (if applicable)

N/A

## Risk

N/A, isolated

## Testing

- Other Opportunities component should show "Other Opportunities" for FOX, but only "Opportunities" for FOXy
- `Get cagey ...` sentance should be removed from FOX other opportunities description
-  FOXy staking component button should be displaying "Manage" in case there is an active staking , "Get Started" otherwise

## Screenshots (if applicable)

<img width="742" alt="image" src="https://user-images.githubusercontent.com/17035424/172709132-7c7bc2a0-c26a-4b04-9c46-c1958588048f.png">
<img width="737" alt="image" src="https://user-images.githubusercontent.com/17035424/172710217-9d9afd0a-254e-411b-af12-0c395b53ef09.png">
<img width="740" alt="image" src="https://user-images.githubusercontent.com/17035424/172710851-0e72f00b-642f-4ad3-9ecb-b7839975b1d3.png">
<img width="757" alt="image" src="https://user-images.githubusercontent.com/17035424/172712448-236315de-6ed5-498c-afb5-fbc1d1bec8ba.png">