### PR TITLE
feat: plugin conditional compilation

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -30,3 +30,5 @@ yarn-error.log*
 # idea
 *.iml
 .idea/
+
+/src/plugins/active_generated.ts

--- a/package.json
+++ b/package.json
@@ -235,6 +235,7 @@
     "storybook-dark-mode": "^1.0.9",
     "ts-jest": "^27.1.5",
     "ts-node": "^10.8.0",
+    "type-fest": "^2.13.0",
     "typescript": "^4.6.2",
     "val-loader": "^4.0.0",
     "web3-utils": "^1.5.2",

--- a/react-app-rewired/env.ts
+++ b/react-app-rewired/env.ts
@@ -1,0 +1,44 @@
+import * as fs from 'fs'
+import { uniq } from 'lodash'
+import * as path from 'path'
+
+import { getActivePluginNames } from './plugins'
+
+const buildPath = path.resolve(__dirname, '../')
+
+function getConfigKeysViaKludgyHack(path: string) {
+  return Array.from(
+    fs.readFileSync(path, { encoding: 'utf-8' }).matchAll(/REACT_APP_[A-Z0-9_]+/g),
+  ).map(x => x[0])
+}
+
+function* generateBaseConfigKeys(dir: string): Generator<string, void, undefined> {
+  for (const dirent of fs.readdirSync(dir, { withFileTypes: true })) {
+    const subpath = path.join(dir, dirent.name)
+    if (dirent.isDirectory()) {
+      yield* generateBaseConfigKeys(subpath)
+      continue
+    }
+    yield* getConfigKeysViaKludgyHack(subpath)
+    // yield* Object.keys(require(subpath).default)
+  }
+}
+
+function getPluginConfigKeys(name: string) {
+  const pluginConfigPath = path.join(buildPath, 'src/plugins', name, 'config.ts')
+  return getConfigKeysViaKludgyHack(pluginConfigPath)
+  // return Object.keys(require(pluginConfigPath).validators)
+}
+
+function* generateConfigKeys() {
+  yield* generateBaseConfigKeys(path.join(buildPath, 'src/config/validators'))
+  for (const pluginName of getActivePluginNames()) {
+    yield* getPluginConfigKeys(pluginName)
+  }
+}
+
+export function getConfigKeys() {
+  const out = uniq(Array.from(generateConfigKeys()).sort())
+  console.info(`Config keys:`, out)
+  return out
+}

--- a/react-app-rewired/plugins.ts
+++ b/react-app-rewired/plugins.ts
@@ -1,0 +1,27 @@
+import * as fs from 'fs'
+import { memoize } from 'lodash'
+import * as path from 'path'
+import type { ScreamingSnakeCase } from 'type-fest'
+
+function toScreamingSnakeCase<T extends string>(x: T): ScreamingSnakeCase<T> {
+  return x.replace(/[A-Z]/g, x => `_${x.toLowerCase()}`).toUpperCase() as ScreamingSnakeCase<T>
+}
+
+export const getActivePluginNames = memoize(() => {
+  const out: string[] = []
+  const pluginPath = path.resolve(__dirname, '../src/plugins')
+  for (const pluginDirEnt of fs.readdirSync(pluginPath, { withFileTypes: true })) {
+    if (!pluginDirEnt.isDirectory()) continue
+    const manifestPath = path.join(pluginPath, pluginDirEnt.name, 'manifest.json')
+    const disabledByDefault = fs.existsSync(manifestPath)
+      ? JSON.parse(fs.readFileSync(manifestPath).toString('utf-8')).disabledByDefault ?? false
+      : false
+    const pluginNameEnvVar = `PLUGIN_${toScreamingSnakeCase(pluginDirEnt.name)}` as const
+    const enabled =
+      process.env[pluginNameEnvVar] === 'true' ||
+      (!disabledByDefault && process.env[pluginNameEnvVar] !== 'false')
+    if (enabled) out.push(pluginDirEnt.name)
+  }
+  console.info('Active plugins:', out)
+  return out
+})

--- a/src/context/PluginProvider/PluginProvider.tsx
+++ b/src/context/PluginProvider/PluginProvider.tsx
@@ -1,7 +1,7 @@
 import { ChainId } from '@shapeshiftoss/caip'
 import { ChainAdapter, ChainAdapterManager } from '@shapeshiftoss/chain-adapters'
 import { KnownChainIds } from '@shapeshiftoss/types'
-import { Plugin, PluginManager } from 'plugins'
+import { Plugin, PluginManager, registerPlugins } from 'plugins'
 import React, { createContext, useContext, useEffect, useMemo, useRef, useState } from 'react'
 import { useSelector } from 'react-redux'
 import { Route } from 'Routes/helpers'
@@ -20,8 +20,6 @@ type PluginProviderContextProps = {
   supportedChains: ChainId[]
   routes: Route[]
 }
-
-const activePlugins = ['bitcoin', 'cosmos', 'ethereum', 'foxPage', 'osmosis']
 
 // don't export me, access me through the getter
 let _chainAdapterManager: ChainAdapterManager | undefined
@@ -60,19 +58,9 @@ export const PluginProvider = ({ children }: PluginProviderProps): JSX.Element =
 
   useEffect(() => {
     ;(async () => {
-      pluginManager.clear()
-
-      for (const plugin of activePlugins) {
-        try {
-          pluginManager.register(await import(`../../plugins/${plugin}/index.tsx`))
-        } catch (e) {
-          moduleLogger.error(e, { fn: 'register' }, 'Register Plugins')
-        }
-      }
-
+      await registerPlugins()
       const plugins = pluginManager.entries()
       setPlugins(plugins)
-      moduleLogger.debug({ plugins }, 'Plugins Registration Completed')
     })()
   }, [pluginManager])
 

--- a/src/plugins/index.ts
+++ b/src/plugins/index.ts
@@ -1,10 +1,14 @@
 import { ChainId } from '@shapeshiftoss/caip'
 import { ChainAdapter } from '@shapeshiftoss/chain-adapters'
+import { ChainTypes } from '@shapeshiftoss/types'
+import { logger } from 'lib/logger'
 import { FeatureFlags } from 'state/slices/preferencesSlice/preferencesSlice'
 
 import { Route } from '../Routes/helpers'
 
-const activePlugins = ['bitcoin', 'cosmos', 'ethereum', 'osmosis']
+const moduleLogger = logger.child({ namespace: ['PluginManager'] })
+
+const activePlugins = ['bitcoin', 'cosmos', 'ethereum', 'foxPage', 'osmosis']
 
 export type Plugins = [chainId: string, chain: Plugin][]
 export type RegistrablePlugin = { register: () => Plugins }
@@ -14,7 +18,7 @@ export interface Plugin {
   icon?: JSX.Element
   featureFlag?: keyof FeatureFlags
   providers?: {
-    chainAdapters?: Array<[ChainId, () => ChainAdapter<ChainId>]>
+    chainAdapters?: Array<[ChainId, () => ChainAdapter<ChainTypes>]>
   }
   routes?: Route[]
 }
@@ -35,6 +39,10 @@ export class PluginManager {
     }
   }
 
+  keys(): string[] {
+    return [...this.#pluginManager.keys()]
+  }
+
   entries(): [string, Plugin][] {
     return [...this.#pluginManager.entries()]
   }
@@ -44,10 +52,20 @@ export class PluginManager {
 // if we need to support features that require re-rendering. Currently we do not.
 export const pluginManager = new PluginManager()
 
-export const registerPlugins = async () => {
+export async function registerPlugins() {
   pluginManager.clear()
 
   for (const plugin of activePlugins) {
-    pluginManager.register(await import(`./${plugin}/index.tsx`))
+    try {
+      pluginManager.register(await import(`./${plugin}/index.tsx`))
+      moduleLogger.trace({ fn: 'registerPlugins', pluginManager, plugin }, 'Registered Plugin')
+    } catch (e) {
+      moduleLogger.error(e, { fn: 'registerPlugins', pluginManager }, 'Register Plugins')
+    }
   }
+
+  moduleLogger.debug(
+    { pluginManager, plugins: pluginManager.keys() },
+    'Plugins Registration Completed',
+  )
 }

--- a/yarn.lock
+++ b/yarn.lock
@@ -20798,6 +20798,11 @@ type-fest@^1.2.2:
   resolved "https://registry.yarnpkg.com/type-fest/-/type-fest-1.4.0.tgz#e9fb813fe3bf1744ec359d55d1affefa76f14be1"
   integrity sha512-yGSza74xk0UG8k+pLh5oeoYirvIiWo5t0/o3zHHAO2tRDiZcxWP7fywNlXhqb6/r6sWvwi+RsyQMWhVLe4BVuA==
 
+type-fest@^2.13.0:
+  version "2.13.0"
+  resolved "https://registry.yarnpkg.com/type-fest/-/type-fest-2.13.0.tgz#d1ecee38af29eb2e863b22299a3d68ef30d2abfb"
+  integrity sha512-lPfAm42MxE4/456+QyIaaVBAwgpJb6xZ8PRu09utnhPdWwcyj9vgy6Sq0Z5yNbJ21EdxB5dRU/Qg8bsyAMtlcw==
+
 type-is@~1.6.18:
   version "1.6.18"
   resolved "https://registry.yarnpkg.com/type-is/-/type-is-1.6.18.tgz#4e552cd05df09467dcbc4ef739de89f2cf37c131"


### PR DESCRIPTION
## Description

Based on #1994.

Adds support for conditional compilation of plugins. Any plugin may be explicitly excluded from a build by setting an env var `PLUGIN_FOO=false`. Plugins may declare themselves as `disabledByDefault` (i.e. the upcoming Pendo plugin), in which case they are not included in a build unless the env var `PLUGIN_FOO=true` is set.

Conditional compilation is achieved by code-generation to satisfy Webpack's need to understand dynamic imports at compile time. A TypeScript file, `src/plugins/active_generated.ts`, is generated at the beginning of the build; this file includes explicit `import('./foo')` statements for all active plugins, preventing Webpack from seeing an `import()` it doesn't understand. (Fun fact -- if it does see an import without a string literal, you don't get an explicit error... it just attempts to compile every single file separately -- including the unit tests! -- just in case they might get imported at runtime, tripling the number of build artifacts and throwing all sorts of interesting errors.)

## Notice

<!-- Before submitting a pull request, please make sure you have answered the following: -->

- [x] Have you followed the guidelines in our [Contributing]('https://github.com/shapeshift/web/CONTRIBUTING.md) guide?
- [x] Have you checked to ensure there aren't other open [Pull Requests](https://github.com/shapeshift/web/pulls) for the same update/change?

## Pull Request Type

- [ ] :bug: Bug fix (Non-breaking Change: Fixes an issue)
- [ ] :hammer_and_wrench: Chore (Non-breaking Change: Doc updates, pkg upgrades, typos, etc..)
- [x] :nail_care: New Feature (Breaking/Non-breaking Change)

## Issue (if applicable)

Closes #1998.

## Risk

TBD.

## Testing

TBD.
