### PR TITLE
feat: improve useFoxyBalances loading state

### DIFF
--- a/src/pages/Defi/hooks/useFoxyBalances.tsx
+++ b/src/pages/Defi/hooks/useFoxyBalances.tsx
@@ -104,7 +104,7 @@ async function getFoxyOpportunities(
 }
 
 export function useFoxyBalances(): UseFoxyBalancesReturn {
-  const [loading, setLoading] = useState(false)
+  const [loading, setLoading] = useState(true)
   const [opportunities, setOpportunities] = useState<Record<string, FoxyOpportunity>>({})
   const marketData = useSelector(selectMarketData)
   const assets = useSelector(selectAssets)
@@ -123,9 +123,11 @@ export function useFoxyBalances(): UseFoxyBalancesReturn {
   const supportsEthereumChain = useWalletSupportsChain({ chainId: ethChainId, wallet })
 
   useEffect(() => {
-    if (!wallet || !supportsEthereumChain || !foxy || !foxyApr) return
+    if (!wallet || !supportsEthereumChain || !foxy || !foxyApr) {
+      setLoading(false)
+      return
+    }
     ;(async () => {
-      setLoading(true)
       try {
         const chainAdapter = await chainAdapterManager.byChainId('eip155:1')
         const userAddress = await chainAdapter.getAddress({ wallet })

--- a/src/plugins/foxPage/components/MainOpportunity.tsx
+++ b/src/plugins/foxPage/components/MainOpportunity.tsx
@@ -74,7 +74,7 @@ export const MainOpportunity = ({
               {balance}
             </CText>
           </Box>
-          <Skeleton isLoaded={isFoxyBalancesLoading === false}>
+          <Skeleton isLoaded={!isFoxyBalancesLoading}>
             <Box alignSelf='center'>
               <Button onClick={onClick} colorScheme={'blue'}>
                 <CText>


### PR DESCRIPTION
## Description

This PR sets the `loading` state field of the `useFoxyBalances` hook to be initially true.

It makes the loading state more reliable and fixes a flash of loading state in presentational components relying on `!(useFoxyBalances().loading)` consumption to render a `<Skeleton />`, which currently render the component, then a `<Skeleton />`, then the component again.

## Notice

<!-- Before submitting a pull request, please make sure you have answered the following: -->

- [x] Have you followed the guidelines in our [Contributing]('https://github.com/shapeshift/web/CONTRIBUTING.md) guide?
- [x] Have you checked to ensure there aren't other open [Pull Requests](https://github.com/shapeshift/web/pulls) for the same update/change?

## Pull Request Type

- [ ] :bug: Bug fix (Non-breaking Change: Fixes an issue)
- [ ] :hammer_and_wrench: Chore (Non-breaking Change: Doc updates, pkg upgrades, typos, etc..)
- [x] :nail_care: New Feature (Breaking/Non-breaking Change)

## Issue (if applicable)

N/A

## Risk

Components/hooks using `useFoxyBalances` could regress because of this. Tested across the DeFi section and didn't notice regressions.

## Testing

- There should be no regression in the loading of DeFi opportunities

## Screenshots (if applicable)
