### PR TITLE
fix: fox page memoization improvements

### DIFF
--- a/src/plugins/foxPage/hooks/useCurrentBlockNumber.ts
+++ b/src/plugins/foxPage/hooks/useCurrentBlockNumber.ts
@@ -2,26 +2,19 @@ import { useEffect, useState } from 'react'
 
 import { getEthersProvider } from '../utils'
 
+const web3Provider = getEthersProvider()
+
 export const useCurrentBlockNumber = () => {
   const [block, setBlock] = useState<number | null>(null)
 
-  // attach/detach listeners
   useEffect(() => {
-    const web3Provider = getEthersProvider()
-    if (!web3Provider) return
-
-    setBlock(null)
+    if (!web3Provider || block) return
 
     web3Provider
       .getBlockNumber()
       .then(setBlock)
       .catch(error => console.error(`Failed to get block number for chainId:`, error))
-
-    web3Provider.on('block', setBlock)
-    return () => {
-      web3Provider.off('block', setBlock)
-    }
-  }, [])
+  }, [block])
 
   return block
 }

--- a/src/plugins/foxPage/hooks/useFarmingApr.ts
+++ b/src/plugins/foxPage/hooks/useFarmingApr.ts
@@ -14,8 +14,9 @@ import farmingAbi from '../farmingAbi.json'
 import { getEthersProvider, rewardRatePerToken } from '../utils'
 import { useCurrentBlockNumber } from './useCurrentBlockNumber'
 
+const ethersProvider = getEthersProvider()
+
 export const useFarmingApr = () => {
-  const ethersProvider = getEthersProvider()
   const [farmingApr, setFarmingApr] = useState<string | null>(null)
   const [loaded, setLoaded] = useState(false)
   const blockNumber = useCurrentBlockNumber()
@@ -23,15 +24,14 @@ export const useFarmingApr = () => {
   const liquidityContractAddress = UNISWAP_V2_WETH_FOX_POOL_ADDRESS
   const uniswapLPContract = useMemo(
     () => new Contract(liquidityContractAddress, IUniswapV2Pair.abi, ethersProvider),
-    [liquidityContractAddress, ethersProvider],
+    [liquidityContractAddress],
   )
   const farmingRewardsContract = useMemo(
     () => new Contract(UNISWAP_V2_WETH_FOX_FARMING_REWARDS_ADDRESS, farmingAbi, ethersProvider),
-    [ethersProvider],
+    [],
   )
 
   useEffect(() => {
-    const ethersProvider = getEthersProvider()
     if (
       !ethersProvider ||
       !Fetcher ||


### PR DESCRIPTION
## Description

This PR:

- Instantiates ethers providers outside of hooks
- Makes sure that the underlying provider in `getEthersProvider` doesn't get re-instantiated
- Memoizes `fetchPairData`, `calculateAPRFromToken0`, `getTotalLpSupply` and `getRewardsRate`
- Removes the `web3Provider.on('block')` event listeners that use polling

This drastically reduces the number of Infura calls, but should be considered a naive patch for now. Quoting @0xdef1cafe:
> hooks are not singletons

Following this will be a PR creating a shared context for the current hooks to live in (whether that's as a simple singleton, a cached service, a RTK query or a React context is an implementation details) so that they, and their underlying XHRs don't get fired multiple times

Another PR will be coming along, abstracting away the logic from `useFoxyBalances` in a similar manner, since that hook accounts for most of the superfluous network calls remaining.

## Notice

<!-- Before submitting a pull request, please make sure you have answered the following: -->

- [x] Have you followed the guidelines in our [Contributing]('https://github.com/shapeshift/web/CONTRIBUTING.md) guide?
- [x] Have you checked to ensure there aren't other open [Pull Requests](https://github.com/shapeshift/web/pulls) for the same update/change?

## Pull Request Type

- [x] :bug: Bug fix (Non-breaking Change: Fixes an issue)
- [ ] :hammer_and_wrench: Chore (Non-breaking Change: Doc updates, pkg upgrades, typos, etc..)
- [ ] :nail_care: New Feature (Breaking/Non-breaking Change)

## Issue (if applicable)

N/A

## Risk

Contained to Fox Page. I tested it out and found no regressions.

## Testing

- Fox Page APYs should still be working

## Screenshots (if applicable)
