### PR TITLE
feat: add parseGovernanceData tests

### DIFF
--- a/src/plugins/foxPage/hooks/getGovernanceData.test.ts
+++ b/src/plugins/foxPage/hooks/getGovernanceData.test.ts
@@ -1,40 +1,15 @@
-import { parseGovernanceData } from './getGovernanceData'
+import { BoardroomGovernanceResult, parseGovernanceData } from './getGovernanceData'
 
-const EMPTY_RESULTS_PROPOSAL = {
+const EMPTY_RESULTS_PROPOSAL: BoardroomGovernanceResult = {
   refId: 'refId1',
-  id: 'id1',
   title: 'Proposal 1',
-  content: 'Content 1',
-  protocol: 'shapeshift',
-  adapter: 'default',
-  proposer: '0x9Fca79Fb30aa631a82312A7a34d0f05359C626ad',
-  totalVotes: 5,
-  blockNumber: 14963724,
-  externalUrl: 'https://snapshot.org/#/shapeshiftdao.eth/proposal/id1',
-  startTime: { timestamp: 1655239110 },
-  endTime: { timestamp: 1655498315 },
-  startTimestamp: '1655239110',
-  endTimestamp: '1655498315',
   currentState: 'active',
   choices: ['YES', 'NO'],
   results: [],
-  events: [],
 }
-const PARTIAL_RESULTS_PROPOSAL = {
+const PARTIAL_RESULTS_PROPOSAL: BoardroomGovernanceResult = {
   refId: 'refId2',
-  id: 'id2',
   title: 'Proposal 2',
-  content: 'Content 2',
-  protocol: 'shapeshift',
-  adapter: 'default',
-  proposer: '0x9Fca79Fb30aa631a82312A7a34d0f05359C626ad',
-  totalVotes: 5,
-  blockNumber: 14963724,
-  externalUrl: 'https://snapshot.org/#/shapeshiftdao.eth/proposal/id2',
-  startTime: { timestamp: 1655239110 },
-  endTime: { timestamp: 1655498315 },
-  startTimestamp: '1655239110',
-  endTimestamp: '1655498315',
   currentState: 'active',
   choices: ['YES', 'NO'],
   results: [
@@ -43,24 +18,11 @@ const PARTIAL_RESULTS_PROPOSAL = {
       choice: 0,
     },
   ],
-  events: [],
 }
 
-const ALL_RESULTS_PROPOSAL = {
+const ALL_RESULTS_PROPOSAL: BoardroomGovernanceResult = {
   refId: 'refId3',
-  id: 'id3',
   title: 'Proposal 3',
-  content: 'Content 3',
-  protocol: 'shapeshift',
-  adapter: 'default',
-  proposer: '0x82c6b4E75Ef8A3669359F7368266FF8F7C719D93',
-  totalVotes: 48,
-  blockNumber: 14896948,
-  externalUrl: 'https://snapshot.org/#/shapeshiftdao.eth/proposal/id3',
-  startTime: { timestamp: 1654256993 },
-  endTime: { timestamp: 1654516193 },
-  startTimestamp: '1654256993',
-  endTimestamp: '1654516193',
   currentState: 'closed',
   choices: ['Yes (For)', 'No (Against)'],
   results: [
@@ -73,28 +35,11 @@ const ALL_RESULTS_PROPOSAL = {
       choice: 1,
     },
   ],
-  events: [],
 }
 
-const INACTIVE_PROPOSAL = {
+const INACTIVE_PROPOSAL: BoardroomGovernanceResult = {
   refId: 'refId4',
-  id: 'id4',
   title: 'Proposal 4',
-  content: 'Content 4',
-  protocol: 'shapeshift',
-  adapter: 'default',
-  proposer: '0x9304b785e517b8644fCf6F2a12dD05877BC035E2',
-  totalVotes: 65,
-  blockNumber: 14310669,
-  externalUrl: 'https://snapshot.org/#/shapeshiftdao.eth/proposal/id4',
-  startTime: {
-    timestamp: 1646269200,
-  },
-  endTime: {
-    timestamp: 1646960400,
-  },
-  startTimestamp: '1646269200',
-  endTimestamp: '1646960400',
   currentState: 'closed',
   choices: ['For', 'Against'],
   results: [
@@ -103,28 +48,11 @@ const INACTIVE_PROPOSAL = {
       choice: 0,
     },
   ],
-  events: [],
 }
 
-const INACTIVE_PROPOSAL_TWO = {
+const INACTIVE_PROPOSAL_TWO: BoardroomGovernanceResult = {
   refId: 'refId5',
-  id: 'id5',
   title: 'Proposal 5',
-  content: 'Content 5',
-  protocol: 'shapeshift',
-  adapter: 'default',
-  proposer: '0x9304b785e517b8644fCf6F2a12dD05877BC035E2',
-  totalVotes: 65,
-  blockNumber: 14310669,
-  externalUrl: 'https://snapshot.org/#/shapeshiftdao.eth/proposal/id5',
-  startTime: {
-    timestamp: 1646269200,
-  },
-  endTime: {
-    timestamp: 1646960400,
-  },
-  startTimestamp: '1646269200',
-  endTimestamp: '1646960400',
   currentState: 'closed',
   choices: ['For', 'Against'],
   results: [
@@ -133,7 +61,6 @@ const INACTIVE_PROPOSAL_TWO = {
       choice: 0,
     },
   ],
-  events: [],
 }
 
 describe('parseGovernanceData', () => {

--- a/src/plugins/foxPage/hooks/getGovernanceData.test.ts
+++ b/src/plugins/foxPage/hooks/getGovernanceData.test.ts
@@ -75,6 +75,67 @@ const ALL_RESULTS_PROPOSAL = {
   ],
   events: [],
 }
+
+const INACTIVE_PROPOSAL = {
+  refId: 'refId4',
+  id: 'id4',
+  title: 'Proposal 4',
+  content: 'Content 4',
+  protocol: 'shapeshift',
+  adapter: 'default',
+  proposer: '0x9304b785e517b8644fCf6F2a12dD05877BC035E2',
+  totalVotes: 65,
+  blockNumber: 14310669,
+  externalUrl: 'https://snapshot.org/#/shapeshiftdao.eth/proposal/id4',
+  startTime: {
+    timestamp: 1646269200,
+  },
+  endTime: {
+    timestamp: 1646960400,
+  },
+  startTimestamp: '1646269200',
+  endTimestamp: '1646960400',
+  currentState: 'closed',
+  choices: ['For', 'Against'],
+  results: [
+    {
+      total: 5876468,
+      choice: 0,
+    },
+  ],
+  events: [],
+}
+
+const INACTIVE_PROPOSAL_TWO = {
+  refId: 'refId5',
+  id: 'id5',
+  title: 'Proposal 5',
+  content: 'Content 5',
+  protocol: 'shapeshift',
+  adapter: 'default',
+  proposer: '0x9304b785e517b8644fCf6F2a12dD05877BC035E2',
+  totalVotes: 65,
+  blockNumber: 14310669,
+  externalUrl: 'https://snapshot.org/#/shapeshiftdao.eth/proposal/id5',
+  startTime: {
+    timestamp: 1646269200,
+  },
+  endTime: {
+    timestamp: 1646960400,
+  },
+  startTimestamp: '1646269200',
+  endTimestamp: '1646960400',
+  currentState: 'closed',
+  choices: ['For', 'Against'],
+  results: [
+    {
+      total: 5876468,
+      choice: 0,
+    },
+  ],
+  events: [],
+}
+
 describe('parseGovernanceData', () => {
   const ZERO_RESULT = {
     absolute: '0',
@@ -111,6 +172,30 @@ describe('parseGovernanceData', () => {
     expect(parsedData[0].results[1]).toMatchObject({
       absolute: '200',
       percent: '0.00004851137391608915',
+    })
+  })
+  it('builds a parsed response with the latest inactive proposal if all inactive', () => {
+    const data = [INACTIVE_PROPOSAL, INACTIVE_PROPOSAL_TWO, ALL_RESULTS_PROPOSAL]
+    const parsedData = parseGovernanceData(data)
+    expect(parsedData).toHaveLength(1)
+    expect(parsedData[0].results).toHaveLength(2)
+    expect(parsedData[0].refId).toEqual(INACTIVE_PROPOSAL.refId)
+    expect(parsedData[0].results[0]).toMatchObject({
+      absolute: '5876468',
+      percent: '1',
+    })
+  })
+  it('builds a parsed response with all active proposals', () => {
+    const data = [EMPTY_RESULTS_PROPOSAL, PARTIAL_RESULTS_PROPOSAL]
+    const parsedData = parseGovernanceData(data)
+    expect(parsedData).toHaveLength(2)
+    expect(parsedData[0].results).toHaveLength(2)
+    expect(parsedData[0].refId).toEqual(EMPTY_RESULTS_PROPOSAL.refId)
+    expect(parsedData[1].refId).toEqual(PARTIAL_RESULTS_PROPOSAL.refId)
+    expect(parsedData[0].results[0]).toMatchObject(ZERO_RESULT)
+    expect(parsedData[1].results[0]).toMatchObject({
+      absolute: '362512.22',
+      percent: '1',
     })
   })
 })

--- a/src/plugins/foxPage/hooks/getGovernanceData.test.ts
+++ b/src/plugins/foxPage/hooks/getGovernanceData.test.ts
@@ -1,0 +1,116 @@
+import { parseGovernanceData } from './getGovernanceData'
+
+const EMPTY_RESULTS_PROPOSAL = {
+  refId: 'refId1',
+  id: 'id1',
+  title: 'Proposal 1',
+  content: 'Content 1',
+  protocol: 'shapeshift',
+  adapter: 'default',
+  proposer: '0x9Fca79Fb30aa631a82312A7a34d0f05359C626ad',
+  totalVotes: 5,
+  blockNumber: 14963724,
+  externalUrl: 'https://snapshot.org/#/shapeshiftdao.eth/proposal/id1',
+  startTime: { timestamp: 1655239110 },
+  endTime: { timestamp: 1655498315 },
+  startTimestamp: '1655239110',
+  endTimestamp: '1655498315',
+  currentState: 'active',
+  choices: ['YES', 'NO'],
+  results: [],
+  events: [],
+}
+const PARTIAL_RESULTS_PROPOSAL = {
+  refId: 'refId2',
+  id: 'id2',
+  title: 'Proposal 2',
+  content: 'Content 2',
+  protocol: 'shapeshift',
+  adapter: 'default',
+  proposer: '0x9Fca79Fb30aa631a82312A7a34d0f05359C626ad',
+  totalVotes: 5,
+  blockNumber: 14963724,
+  externalUrl: 'https://snapshot.org/#/shapeshiftdao.eth/proposal/id2',
+  startTime: { timestamp: 1655239110 },
+  endTime: { timestamp: 1655498315 },
+  startTimestamp: '1655239110',
+  endTimestamp: '1655498315',
+  currentState: 'active',
+  choices: ['YES', 'NO'],
+  results: [
+    {
+      total: 362512.22,
+      choice: 0,
+    },
+  ],
+  events: [],
+}
+
+const ALL_RESULTS_PROPOSAL = {
+  refId: 'refId3',
+  id: 'id3',
+  title: 'Proposal 3',
+  content: 'Content 3',
+  protocol: 'shapeshift',
+  adapter: 'default',
+  proposer: '0x82c6b4E75Ef8A3669359F7368266FF8F7C719D93',
+  totalVotes: 48,
+  blockNumber: 14896948,
+  externalUrl: 'https://snapshot.org/#/shapeshiftdao.eth/proposal/id3',
+  startTime: { timestamp: 1654256993 },
+  endTime: { timestamp: 1654516193 },
+  startTimestamp: '1654256993',
+  endTimestamp: '1654516193',
+  currentState: 'closed',
+  choices: ['Yes (For)', 'No (Against)'],
+  results: [
+    {
+      total: 4122544.5,
+      choice: 0,
+    },
+    {
+      total: 200,
+      choice: 1,
+    },
+  ],
+  events: [],
+}
+describe('parseGovernanceData', () => {
+  const ZERO_RESULT = {
+    absolute: '0',
+    percent: '0',
+  }
+  it('populates and zeros out boardroom response with no results', () => {
+    const data = [EMPTY_RESULTS_PROPOSAL]
+    const parsedData = parseGovernanceData(data)
+    expect(parsedData).toHaveLength(1)
+    expect(parsedData[0].results).toHaveLength(2)
+    expect(parsedData[0].results[0]).toMatchObject(ZERO_RESULT)
+    expect(parsedData[0].results[1]).toMatchObject(ZERO_RESULT)
+  })
+  it('populates and zeros out the missing result items of a boardroom response with partial results', () => {
+    const data = [PARTIAL_RESULTS_PROPOSAL]
+    const parsedData = parseGovernanceData(data)
+    expect(parsedData).toHaveLength(1)
+    expect(parsedData[0].results).toHaveLength(2)
+    expect(parsedData[0].results[0]).toMatchObject({
+      absolute: '362512.22',
+      percent: '1',
+    })
+    expect(parsedData[0].results[1]).toMatchObject(ZERO_RESULT)
+  })
+  it('parses a boardroom response with results for all choices', () => {
+    const data = [ALL_RESULTS_PROPOSAL]
+    const parsedData = parseGovernanceData(data)
+    expect(parsedData).toHaveLength(1)
+    expect(parsedData[0].results).toHaveLength(2)
+    expect(parsedData[0].results[0]).toMatchObject({
+      absolute: '4122544.5',
+      percent: '0.99995148862608391085',
+    })
+    expect(parsedData[0].results[1]).toMatchObject({
+      absolute: '200',
+      percent: '0.00004851137391608915',
+    })
+  })
+})

--- a/src/plugins/foxPage/hooks/getGovernanceData.ts
+++ b/src/plugins/foxPage/hooks/getGovernanceData.ts
@@ -13,7 +13,7 @@ type BoardroomGovernanceData = Array<{
 
 const BOARDROOM_API_BASE_URL = getConfig().REACT_APP_BOARDROOM_API_BASE_URL
 
-const parseGovernanceData = (governanceData: BoardroomGovernanceData) => {
+export const parseGovernanceData = (governanceData: BoardroomGovernanceData) => {
   const activeProposals = governanceData.filter(data => data.currentState === 'active')
   const proposals = activeProposals.length ? activeProposals : [governanceData[0]]
 
@@ -28,7 +28,7 @@ const parseGovernanceData = (governanceData: BoardroomGovernanceData) => {
       title,
       choices,
       results: choices.map((_, i) => ({
-        absolute: results[i] ? results[i].total : 0,
+        absolute: bnOrZero(results[i]?.total).toString(),
         percent: results[i] ? bnOrZero(results[i].total).div(totalResults).toString() : '0',
       })),
     }

--- a/src/plugins/foxPage/hooks/getGovernanceData.ts
+++ b/src/plugins/foxPage/hooks/getGovernanceData.ts
@@ -3,17 +3,30 @@ import { getConfig } from 'config'
 import { useEffect, useState } from 'react'
 import { bnOrZero } from 'lib/bignumber/bignumber'
 
-type BoardroomGovernanceData = Array<{
+// Non-exhaustive typings. We do not want to keep this a 1/1 mapping to an external API
+export type BoardroomGovernanceResult = {
   currentState: string
   title: string
   choices: Array<string>
   results: Array<{ total: number; choice: number }>
   refId: string
-}>
+}
+
+export type ParsedBoardroomGovernanceResult = {
+  refId: string
+  title: string
+  choices: string[]
+  results: Array<{
+    absolute: string
+    percent: string
+  }>
+}
 
 const BOARDROOM_API_BASE_URL = getConfig().REACT_APP_BOARDROOM_API_BASE_URL
 
-export const parseGovernanceData = (governanceData: BoardroomGovernanceData) => {
+export const parseGovernanceData = (
+  governanceData: BoardroomGovernanceResult[],
+): ParsedBoardroomGovernanceResult[] => {
   const activeProposals = governanceData.filter(data => data.currentState === 'active')
   const proposals = activeProposals.length ? activeProposals : [governanceData[0]]
 
@@ -43,7 +56,7 @@ export const useGetGovernanceData = () => {
   useEffect(() => {
     const loadGovernanceData = async () => {
       try {
-        const response = await axios.get<{ data: BoardroomGovernanceData }>(
+        const response = await axios.get<{ data: BoardroomGovernanceResult[] }>(
           `${BOARDROOM_API_BASE_URL}proposals`,
         )
         const governanceData = response?.data?.data


### PR DESCRIPTION
## Description

This adds tests for the `parseGovernanceData` function.
Also changes the `absolute` property to be a string for consistency and adds stylistic changes, see below.

- test the parsing of full/partial/empty results
- test the parsing of fallback latest proposal/active proposals
- parse to an `absolute` result property as a string for consistency
- use optional chaining when falling back to zero for `absolute`
- add types for a single Boardroom parsed result and use it as a `ParsedBoardroomGovernanceResult[]` return type for `parseGovernanceData`

## Notice

<!-- Before submitting a pull request, please make sure you have answered the following: -->

- [x] Have you followed the guidelines in our [Contributing]('https://github.com/shapeshift/web/CONTRIBUTING.md) guide?
- [x] Have you checked to ensure there aren't other open [Pull Requests](https://github.com/shapeshift/web/pulls) for the same update/change?

## Pull Request Type

- [ ] :bug: Bug fix (Non-breaking Change: Fixes an issue)
- [ ] :hammer_and_wrench: Chore (Non-breaking Change: Doc updates, pkg upgrades, typos, etc..)
- [x] :nail_care: New Feature (Breaking/Non-breaking Change)

## Issue (if applicable)

N/A

## Risk

None, this only adds tests cases/stylistic changes, and improves typings.

## Testing

- Governance data should still be working with no regressions

## Screenshots (if applicable)
