### PR TITLE
feat(build): generate list of active plugins at compile time

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,5 +1,8 @@
 # See https://help.github.com/articles/ignoring-files/ for more about ignoring files.
 
+# conditional compilation
+src/plugins/active_generated.ts
+
 # dependencies
 /node_modules
 /.pnp

--- a/react-app-rewired/index.ts
+++ b/react-app-rewired/index.ts
@@ -11,6 +11,7 @@ import * as webpack from 'webpack'
 import { SubresourceIntegrityPlugin } from 'webpack-subresource-integrity'
 
 import { cspMeta, headers, serializeCsp } from './headers'
+import { getActivePluginNames } from './plugins'
 import { progressPlugin } from './progress'
 
 type DevServerConfigFunction = (
@@ -321,6 +322,13 @@ const reactAppRewireConfig = {
           }
         : {},
     )
+
+    const activePluginNames = getActivePluginNames().sort()
+    const activePluginScript = `export async function getActivePlugins() {\n  return await Promise.all([\n${activePluginNames
+      .map(x => `    import('./${x}'),`)
+      .join('\n')}\n  ])\n}\n`
+
+    fs.writeFileSync(path.join(buildPath, 'src/plugins/active_generated.ts'), activePluginScript)
 
     return config
   },

--- a/react-app-rewired/plugins.ts
+++ b/react-app-rewired/plugins.ts
@@ -1,0 +1,16 @@
+import * as fs from 'fs'
+import { memoize } from 'lodash'
+import * as path from 'path'
+
+const excludedPluginNames = process.env.EXCLUDED_PLUGINS?.split(',') ?? []
+
+export const getActivePluginNames = memoize(() => {
+  const out: string[] = []
+  const pluginPath = path.resolve(__dirname, '../src/plugins')
+  for (const pluginDirEnt of fs.readdirSync(pluginPath, { withFileTypes: true })) {
+    if (!pluginDirEnt.isDirectory()) continue
+    if (!excludedPluginNames.includes(pluginDirEnt.name)) out.push(pluginDirEnt.name)
+  }
+  console.info('Active plugins:', out)
+  return out
+})

--- a/sample.env
+++ b/sample.env
@@ -5,6 +5,7 @@
 # REACT_APP_UNCHAINED_BITCOIN_WS_URL=ws://api.bitcoin.localhost
 # connect to dev cluster
 
+EXCLUDED_PLUGINS=analytics
 REACT_APP_LOG_LEVEL=debug
 
 REACT_APP_UNCHAINED_ETHEREUM_HTTP_URL=https://dev-api.ethereum.shapeshift.com

--- a/src/plugins/analytics/index.tsx
+++ b/src/plugins/analytics/index.tsx
@@ -1,0 +1,5 @@
+import { Plugins } from '../index'
+
+export function register(): Plugins {
+  return [['analytics', { name: 'Pendo Analytics' }]]
+}


### PR DESCRIPTION
## Description

feat(build): generate list of active plugins at compile time

This adds a step the webpack build to allow us to statically compile in the plugins we want and exclude any that we don't.

## Notice

<!-- Before submitting a pull request, please make sure you have answered the following: -->

- [X] Have you followed the guidelines in our [Contributing]('https://github.com/shapeshift/web/CONTRIBUTING.md) guide?
- [X] Have you checked to ensure there aren't other open [Pull Requests](https://github.com/shapeshift/web/pulls) for the same update/change?

## Pull Request Type

- [ ] :bug: Bug fix (Non-breaking Change: Fixes an issue)
- [ ] :hammer_and_wrench: Chore (Non-breaking Change: Doc updates, pkg upgrades, typos, etc..)
- [X] :nail_care: New Feature (Breaking/Non-breaking Change)

## Issue (if applicable)

closes #1998 

## Risk

`yarn type-check` will only work right now after running `yarn dev` or `yarn build` to generate the plugin file. We can improve this later.

## Testing
1. Build should work without any changes
2. Add `EXCLUDED_PLUGINS=analytics` to `.env` and run `yarn build` again. The output code should not have the `OptInModal` included.

## Screenshots (if applicable)
