### PR TITLE
chore: remove unnecessary passing of wallet into useswaper functions

### DIFF
--- a/src/components/Approval/Approval.tsx
+++ b/src/components/Approval/Approval.tsx
@@ -43,7 +43,7 @@ export const Approval = () => {
     number: { toCrypto, toFiat },
   } = useLocaleFormatter({ fiatType: 'USD' })
   const {
-    state: { wallet, isConnected },
+    state: { isConnected },
     dispatch,
   } = useWallet()
   const { showErrorToast } = useErrorHandler()
@@ -53,7 +53,6 @@ export const Approval = () => {
 
   const approve = async () => {
     try {
-      if (!wallet) return
       if (!isConnected) {
         /**
          * call history.goBack() to reset current form state
@@ -66,14 +65,14 @@ export const Approval = () => {
       const fnLogger = logger.child({ name: 'approve' })
       fnLogger.trace('Attempting Approval...')
 
-      const txId = await approveInfinite(wallet)
+      const txId = await approveInfinite()
 
       setApprovalTxId(txId)
 
       approvalInterval.current = setInterval(async () => {
         fnLogger.trace({ fn: 'checkApprovalNeeded' }, 'Checking Approval Needed...')
         try {
-          const approvalNeeded = await checkApprovalNeeded(wallet)
+          const approvalNeeded = await checkApprovalNeeded()
           if (approvalNeeded) return
         } catch (e) {
           showErrorToast(e)
@@ -83,7 +82,6 @@ export const Approval = () => {
         approvalInterval.current && clearInterval(approvalInterval.current)
 
         await updateTrade({
-          wallet,
           sellAsset: quote?.sellAsset,
           buyAsset: quote?.buyAsset,
           amount: quote?.sellAmount,

--- a/src/components/Trade/TradeConfirm/TradeConfirm.tsx
+++ b/src/components/Trade/TradeConfirm/TradeConfirm.tsx
@@ -47,7 +47,7 @@ export const TradeConfirm = ({ history }: RouterProps) => {
     number: { toFiat },
   } = useLocaleFormatter({ fiatType: 'USD' })
   const {
-    state: { wallet, isConnected },
+    state: { isConnected },
     dispatch,
   } = useWallet()
   const { chainId } = trade.sellAsset
@@ -65,7 +65,6 @@ export const TradeConfirm = ({ history }: RouterProps) => {
 
   const onSubmit = async () => {
     try {
-      if (!wallet) return
       if (!isConnected) {
         /**
          * call handleBack to reset current form state
@@ -76,7 +75,7 @@ export const TradeConfirm = ({ history }: RouterProps) => {
         return
       }
 
-      const result = await executeQuote({ wallet })
+      const result = await executeQuote()
 
       // Poll until we have a "buy" txid
       // This means the trade is just about finished

--- a/src/components/Trade/TradeInput.tsx
+++ b/src/components/Trade/TradeInput.tsx
@@ -99,7 +99,7 @@ export const TradeInput = ({ history }: RouterProps) => {
     }
 
     try {
-      const approvalNeeded = await checkApprovalNeeded(wallet)
+      const approvalNeeded = await checkApprovalNeeded()
       if (approvalNeeded) {
         history.push({
           pathname: TradeRoutePaths.Approval,
@@ -110,7 +110,6 @@ export const TradeInput = ({ history }: RouterProps) => {
         return
       }
       await updateTrade({
-        wallet,
         sellAsset: quote?.sellAsset,
         buyAsset: quote?.buyAsset,
         amount: quote?.sellAmount,
@@ -137,7 +136,6 @@ export const TradeInput = ({ history }: RouterProps) => {
         'Getting Send Max Amount...',
       )
       const maxSendAmount = await getSendMaxAmount({
-        wallet,
         sellAsset: sellTradeAsset.asset,
         buyAsset: buyTradeAsset.asset,
         feeAsset,

--- a/src/components/Trade/TradeInput.tsx
+++ b/src/components/Trade/TradeInput.tsx
@@ -80,7 +80,6 @@ export const TradeInput = ({ history }: RouterProps) => {
     .gte(0)
 
   const onSubmit = async () => {
-    if (!wallet) return
     if (!(quote?.sellAsset && quote?.buyAsset && quote.sellAmount)) return
 
     const minSellAmount = toBaseUnit(quote.minimum, quote.sellAsset.precision)
@@ -121,7 +120,7 @@ export const TradeInput = ({ history }: RouterProps) => {
   }
 
   const onSetMaxTrade = async () => {
-    if (!(wallet && sellTradeAsset?.asset && buyTradeAsset?.asset)) return
+    if (!(sellTradeAsset?.asset && buyTradeAsset?.asset)) return
     const fnLogger = moduleLogger.child({ namespace: ['onSwapMax'] })
 
     try {

--- a/src/components/Trade/hooks/useSwapper/useSwapper.test.tsx
+++ b/src/components/Trade/hooks/useSwapper/useSwapper.test.tsx
@@ -9,6 +9,7 @@ import { ETH, ETHCHAIN_QUOTE, ETHCHAIN_QUOTE_FEES, FOX, USDC, WETH } from 'test/
 import { TestProviders } from 'test/TestProviders'
 import { TradeAmountInputField, TradeAsset } from 'components/Trade/types'
 import { useChainAdapters } from 'context/PluginProvider/PluginProvider'
+import { useWallet } from 'hooks/useWallet/useWallet'
 
 import { useSwapper } from './useSwapper'
 
@@ -16,6 +17,7 @@ jest.mock('lib/web3-instance')
 jest.mock('react-hook-form')
 jest.mock('lodash/debounce')
 jest.mock('@shapeshiftoss/swapper')
+jest.mock('hooks/useWallet/useWallet')
 jest.mock('context/PluginProvider/PluginProvider')
 jest.mock('react-redux', () => ({
   ...jest.requireActual('react-redux'),
@@ -106,6 +108,11 @@ describe('useSwapper', () => {
           [KnownChainIds.EthereumMainnet, {}],
         ]),
     )
+    ;(useWallet as jest.Mock<unknown>).mockImplementation(() => ({
+      state: {
+        wallet: {},
+      },
+    }))
   })
   it('approves infinite', async () => {
     const { result } = setup()

--- a/src/components/Trade/hooks/useSwapper/useSwapper.test.tsx
+++ b/src/components/Trade/hooks/useSwapper/useSwapper.test.tsx
@@ -108,19 +108,19 @@ describe('useSwapper', () => {
     )
   })
   it('approves infinite', async () => {
-    const { result, wallet } = setup()
-    const txid = await result.current.approveInfinite(wallet)
+    const { result } = setup()
+    const txid = await result.current.approveInfinite()
     expect(txid).toBe('0x023423093248420937')
   })
   it('gets approval needed', async () => {
-    const { result, wallet } = setup()
-    const approvalNeeded = await result.current.checkApprovalNeeded(wallet)
+    const { result } = setup()
+    const approvalNeeded = await result.current.checkApprovalNeeded()
     expect(approvalNeeded).toBe(false)
   })
   it('returns true when approval is needed', async () => {
-    const { result, wallet } = setup({ approvalNeededBoolean: true })
+    const { result } = setup({ approvalNeededBoolean: true })
 
-    const approvalNeeded = await result.current.checkApprovalNeeded(wallet)
+    const approvalNeeded = await result.current.checkApprovalNeeded()
     expect(approvalNeeded).toBe(true)
   })
   it('gets default pair', () => {


### PR DESCRIPTION
## Description

We will need wallet in a couple more swapper calls for thorchain trading

This adds useWallet() to useSwapper() so we dont have to pass it through everywhere and can dismantle some of the spaghetti

## Notice


- [x] Have you followed the guidelines in our [Contributing]('https://github.com/shapeshift/web/CONTRIBUTING.md) guide?
- [x] Have you checked to ensure there aren't other open [Pull Requests](https://github.com/shapeshift/web/pulls) for the same update/change?

## Pull Request Type

- [ ] :bug: Bug fix (Non-breaking Change: Fixes an issue)
- [x] :hammer_and_wrench: Chore (Non-breaking Change: Doc updates, pkg upgrades, typos, etc..)
- [ ] :nail_care: New Feature (Breaking/Non-breaking Change)

## Issue (if applicable)

<!-----------------------------------------------------------------------------
If applicable, please link to the github issue and put `closes #XXXX` in your comment to auto-close the issue that your PR fixes.
------------------------------------------------------------------------------>

## Risk

low risk swapper changes

## Testing

make sure swaps still work
