### PR TITLE
fix: use correct `from` account in handleSendMax

### DIFF
--- a/src/components/Modals/Send/hooks/useSendDetails/useSendDetails.tsx
+++ b/src/components/Modals/Send/hooks/useSendDetails/useSendDetails.tsx
@@ -205,7 +205,6 @@ export const useSendDetails = (): UseSendDetailsReturnType => {
 
       try {
         const { chainId, account } = fromAccountId(accountSpecifier)
-        fnLogger.error({ chainId, account, accountSpecifier }, 'debug')
         const { fastFee, adapterFees } = await (async () => {
           switch (chainId) {
             case KnownChainIds.CosmosMainnet: {
@@ -228,7 +227,7 @@ export const useSendDetails = (): UseSendDetailsReturnType => {
               const adapterFees = await ethAdapter.getFeeData({
                 to,
                 value,
-                chainSpecific: { contractAddress, from: accountSpecifier },
+                chainSpecific: { contractAddress, from: account },
                 sendMax: true,
               })
               const fastFee = adapterFees.fast.txFee
@@ -244,7 +243,7 @@ export const useSendDetails = (): UseSendDetailsReturnType => {
               const adapterFees = await btcAdapter.getFeeData({
                 to,
                 value,
-                chainSpecific: { pubkey: accountSpecifier },
+                chainSpecific: { pubkey: account },
                 sendMax: true,
               })
               const fastFee = adapterFees.fast.txFee


### PR DESCRIPTION
## Description

This uses the correct accounts for sends:

- `fromAccountId(accountSpecifier).account` for Cosmos SDK
- `fromAccountId(accountSpecifier).account` for Bitcoin

It also removes a `fnLogger.error` call that was throwing and breaking the flow.

## Notice

<!-- Before submitting a pull request, please make sure you have answered the following: -->

- [x] Have you followed the guidelines in our [Contributing]('https://github.com/shapeshift/web/CONTRIBUTING.md) guide?
- [x] Have you checked to ensure there aren't other open [Pull Requests](https://github.com/shapeshift/web/pulls) for the same update/change?

## Pull Request Type

- [x] :bug: Bug fix (Non-breaking Change: Fixes an issue)
- [ ] :hammer_and_wrench: Chore (Non-breaking Change: Doc updates, pkg upgrades, typos, etc..)
- [ ] :nail_care: New Feature (Breaking/Non-breaking Change)

## Issue (if applicable)

- Related to #1570

## Risk

- Sends and max sends could still be broken. I have tested max/sends across BTC/ETH/ERC20s/Cosmos as well as stake/unstake/claim on Cosmos SDK.

## Testing

- Sends should work across BTC/ETH/ERC20s/ATOM
- Receive should work across BTC/ETH/ERC20s/ATOM
- Cosmos advanced features should show no regressions

## Screenshots (if applicable)

<img width="468" alt="image" src="https://user-images.githubusercontent.com/17035424/174127558-f6fa0dba-7171-477e-9178-8fc06d9946e0.png">
<img width="476" alt="image" src="https://user-images.githubusercontent.com/17035424/174128414-8ffe828e-49a1-4b04-b625-ff49e6f329e9.png">
<img width="471" alt="image" src="https://user-images.githubusercontent.com/17035424/174128467-3e5a1aff-0294-4001-a7d1-d23792c094a9.png">
<img width="475" alt="image" src="https://user-images.githubusercontent.com/17035424/174128516-a9d7c1b7-0dd0-4e94-800b-0b5894a45bcf.png">