### PR TITLE
chore: don't reference specific env vars in cypress

### DIFF
--- a/cypress/plugins/index.ts
+++ b/cypress/plugins/index.ts
@@ -65,13 +65,9 @@ module.exports = async (on: any, config: any) => {
   }
 
   // Allow Cypress to see key Node environment variables via Cypress.env('some-variable')
-  config.env.REACT_APP_UNCHAINED_ETHEREUM_HTTP_URL =
-    process.env.REACT_APP_UNCHAINED_ETHEREUM_HTTP_URL
-  config.env.REACT_APP_UNCHAINED_ETHEREUM_WS_URL = process.env.REACT_APP_UNCHAINED_ETHEREUM_WS_URL
-  config.env.REACT_APP_UNCHAINED_BITCOIN_HTTP_URL = process.env.REACT_APP_UNCHAINED_BITCOIN_HTTP_URL
-  config.env.REACT_APP_UNCHAINED_BITCOIN_WS_URL = process.env.REACT_APP_UNCHAINED_BITCOIN_WS_URL
-  config.env.REACT_APP_PORTIS_DAPP_ID = process.env.REACT_APP_PORTIS_DAPP_ID
-  config.env.REACT_APP_ETHEREUM_NODE_URL = process.env.REACT_APP_ETHEREUM_NODE_URL
+  for (const [k, v] of Object.entries(process.env).filter(([k]) => k.startsWith('REACT_APP_'))) {
+    config.env[k] = v
+  }
 
   return config
 }


### PR DESCRIPTION
## Description

Cypress currently pulls in a hardcoded set of env vars; this removes the hardcoding to make things more flexible and maintainable.

## Notice

<!-- Before submitting a pull request, please make sure you have answered the following: -->

- [x] Have you followed the guidelines in our [Contributing]('https://github.com/shapeshift/web/CONTRIBUTING.md) guide?
- [x] Have you checked to ensure there aren't other open [Pull Requests](https://github.com/shapeshift/web/pulls) for the same update/change?

## Pull Request Type

- [x] :bug: Bug fix (Non-breaking Change: Fixes an issue)
- [x] :hammer_and_wrench: Chore (Non-breaking Change: Doc updates, pkg upgrades, typos, etc..)
- [ ] :nail_care: New Feature (Breaking/Non-breaking Change)

## Risk

Minimal.

## Testing

- [ ] CI turns green.
