### PR TITLE
refactor: improve plugin api

### DIFF
--- a/package.json
+++ b/package.json
@@ -235,6 +235,7 @@
     "storybook-dark-mode": "^1.0.9",
     "ts-jest": "^27.1.5",
     "ts-node": "^10.8.0",
+    "type-fest": "^2.13.0",
     "typescript": "^4.6.2",
     "val-loader": "^4.0.0",
     "web3-utils": "^1.5.2",

--- a/src/plugins/active.ts
+++ b/src/plugins/active.ts
@@ -1,0 +1,13 @@
+import * as bitcoin from './bitcoin'
+import * as cosmos from './cosmos'
+import * as ethereum from './ethereum'
+import * as foxPage from './foxPage'
+import * as osmosis from './osmosis'
+
+export const activePlugins = Object.freeze({
+  bitcoin,
+  cosmos,
+  ethereum,
+  foxPage,
+  osmosis,
+})

--- a/src/plugins/bitcoin/index.test.tsx
+++ b/src/plugins/bitcoin/index.test.tsx
@@ -1,0 +1,25 @@
+// import type { bitcoin } from '@shapeshiftoss/chain-adapters'
+import type { KnownChainIds } from '@shapeshiftoss/types'
+import * as ta from 'type-assertions'
+
+import {
+  // PluginChainAdapter,
+  PluginChainId,
+  RegistrablePlugin,
+  RegistrablePluginPluginType,
+} from '../types'
+
+type ThisRegistrablePlugin = typeof import('.')
+type ThisPlugin = RegistrablePluginPluginType<ThisRegistrablePlugin>
+
+describe('bitcoin plugin', () => {
+  it('has the correct types', async () => {
+    ta.assert<ta.Extends<ThisRegistrablePlugin, RegistrablePlugin>>()
+    ta.assert<ta.Equal<PluginChainId<ThisPlugin>, KnownChainIds.BitcoinMainnet>>()
+    //TODO: Uncomment when concrete type is returned from plugin
+    // ta.assert<ta.Equal<PluginChainAdapter<ThisPlugin>, bitcoin.ChainAdapter>>()
+
+    // ta.assert() is checked at compile time, not runtime. This do-nothing expect() is included simply to pacify jest.
+    expect(() => ta.assert<true>()).not.toThrow()
+  })
+})

--- a/src/plugins/bitcoin/index.tsx
+++ b/src/plugins/bitcoin/index.tsx
@@ -1,40 +1,31 @@
-import { ChainId } from '@shapeshiftoss/caip'
-import { bitcoin, ChainAdapter } from '@shapeshiftoss/chain-adapters'
+import type { ChainId } from '@shapeshiftoss/caip'
+import { type ChainAdapter, bitcoin } from '@shapeshiftoss/chain-adapters'
 import { KnownChainIds } from '@shapeshiftoss/types'
 import * as unchained from '@shapeshiftoss/unchained-client'
 import { getConfig } from 'config'
-import { Plugins } from 'plugins'
 
-export function register(): Plugins {
-  return [
-    [
-      'bitcoinChainAdapter',
-      {
-        name: 'bitcoinChainAdapter',
-        providers: {
-          chainAdapters: [
-            [
-              KnownChainIds.BitcoinMainnet,
-              () => {
-                const http = new unchained.bitcoin.V1Api(
-                  new unchained.bitcoin.Configuration({
-                    basePath: getConfig().REACT_APP_UNCHAINED_BITCOIN_HTTP_URL,
-                  }),
-                )
+export function register() {
+  return {
+    providers: {
+      chainAdapters: {
+        [KnownChainIds.BitcoinMainnet]: () => {
+          const http = new unchained.bitcoin.V1Api(
+            new unchained.bitcoin.Configuration({
+              basePath: getConfig().REACT_APP_UNCHAINED_BITCOIN_HTTP_URL,
+            }),
+          )
 
-                const ws = new unchained.ws.Client<unchained.bitcoin.BitcoinTx>(
-                  getConfig().REACT_APP_UNCHAINED_BITCOIN_WS_URL,
-                )
+          const ws = new unchained.ws.Client<unchained.bitcoin.BitcoinTx>(
+            getConfig().REACT_APP_UNCHAINED_BITCOIN_WS_URL,
+          )
 
-                return new bitcoin.ChainAdapter({
-                  providers: { http, ws },
-                  coinName: 'Bitcoin',
-                }) as unknown as ChainAdapter<ChainId> // FIXME: this is silly
-              },
-            ],
-          ],
+          return new bitcoin.ChainAdapter({
+            providers: { http, ws },
+            coinName: 'Bitcoin',
+          }) as unknown as ChainAdapter<ChainId> // FIXME: this is silly
+          //TODO: When addressing the above, uncomment the matching test in ./index.test.tsx
         },
       },
-    ],
-  ]
+    },
+  } as const
 }

--- a/src/plugins/cosmos/index.test.tsx
+++ b/src/plugins/cosmos/index.test.tsx
@@ -1,0 +1,25 @@
+// import type { cosmossdk } from '@shapeshiftoss/chain-adapters'
+import type { KnownChainIds } from '@shapeshiftoss/types'
+import * as ta from 'type-assertions'
+
+import {
+  // PluginChainAdapter,
+  PluginChainId,
+  RegistrablePlugin,
+  RegistrablePluginPluginType,
+} from '../types'
+
+type ThisRegistrablePlugin = typeof import('.')
+type ThisPlugin = RegistrablePluginPluginType<ThisRegistrablePlugin>
+
+describe('cosmos plugin', () => {
+  it('has the correct types', async () => {
+    ta.assert<ta.Extends<ThisRegistrablePlugin, RegistrablePlugin>>()
+    ta.assert<ta.Equal<PluginChainId<ThisPlugin>, KnownChainIds.CosmosMainnet>>()
+    //TODO: Uncomment when concrete type is returned from plugin
+    // ta.assert<ta.Equal<PluginChainAdapter<ThisPlugin>, cosmossdk.cosmos.ChainAdapter>>()
+
+    // ta.assert() is checked at compile time, not runtime. This do-nothing expect() is included simply to pacify jest.
+    expect(() => ta.assert<true>()).not.toThrow()
+  })
+})

--- a/src/plugins/cosmos/index.tsx
+++ b/src/plugins/cosmos/index.tsx
@@ -1,9 +1,8 @@
-import { ChainId } from '@shapeshiftoss/caip'
-import { ChainAdapter, cosmossdk } from '@shapeshiftoss/chain-adapters'
+import type { ChainId } from '@shapeshiftoss/caip'
+import { type ChainAdapter, cosmossdk } from '@shapeshiftoss/chain-adapters'
 import { KnownChainIds } from '@shapeshiftoss/types'
 import * as unchained from '@shapeshiftoss/unchained-client'
 import { getConfig } from 'config'
-import { Plugins } from 'plugins'
 import { AssetIcon } from 'components/AssetIcon'
 
 import { CosmosAccount } from './CosmosAccount'
@@ -11,96 +10,88 @@ import { CosmosAccountTxHistory } from './CosmosAccountTxHistory'
 import { CosmosAsset } from './CosmosAsset'
 import { CosmosAssetTxHistory } from './CosmostAssetTxHistory'
 
-export function register(): Plugins {
-  return [
-    [
-      'cosmos:cosmoshub-4',
-      {
-        name: 'plugins.cosmos.navBar',
-        icon: <AssetIcon src='https://assets.coincap.io/assets/icons/atom@2x.png' />,
-        providers: {
-          chainAdapters: [
-            [
-              KnownChainIds.CosmosMainnet,
-              () => {
-                const http = new unchained.cosmos.V1Api(
-                  new unchained.cosmos.Configuration({
-                    basePath: getConfig().REACT_APP_UNCHAINED_COSMOS_HTTP_URL,
-                  }),
-                )
+export function register() {
+  return {
+    icon: <AssetIcon src='https://assets.coincap.io/assets/icons/atom@2x.png' />,
+    providers: {
+      chainAdapters: {
+        [KnownChainIds.CosmosMainnet]: () => {
+          const http = new unchained.cosmos.V1Api(
+            new unchained.cosmos.Configuration({
+              basePath: getConfig().REACT_APP_UNCHAINED_COSMOS_HTTP_URL,
+            }),
+          )
 
-                const ws = new unchained.ws.Client<unchained.cosmos.Tx>(
-                  getConfig().REACT_APP_UNCHAINED_COSMOS_WS_URL,
-                )
+          const ws = new unchained.ws.Client<unchained.cosmos.Tx>(
+            getConfig().REACT_APP_UNCHAINED_COSMOS_WS_URL,
+          )
 
-                return new cosmossdk.cosmos.ChainAdapter({
-                  providers: { http, ws },
-                  coinName: 'Cosmos',
-                }) as unknown as ChainAdapter<ChainId> // FIXME: this is silly
-              },
-            ],
-          ],
+          return new cosmossdk.cosmos.ChainAdapter({
+            providers: { http, ws },
+            coinName: 'Cosmos',
+          }) as unknown as ChainAdapter<ChainId> // FIXME: this is silly
+          //TODO: When addressing the above, uncomment the matching test in ./index.test.tsx
         },
+      },
+    },
+    routes: [
+      {
+        path: '/assets/cosmos::chainRef/:assetSubId',
+        hide: true,
+        label: '',
+        main: null,
+        icon: <AssetIcon src='https://assets.coincap.io/assets/icons/atom@2x.png' />,
         routes: [
           {
-            path: '/assets/cosmos::chainRef/:assetSubId',
-            hide: true,
-            label: '',
-            main: null,
-            icon: <AssetIcon src='https://assets.coincap.io/assets/icons/atom@2x.png' />,
-            routes: [
-              {
-                path: '/',
-                label: 'navBar.overview',
-                main: () => <CosmosAsset />,
-              },
-              {
-                path: '/transactions',
-                label: 'navBar.transactions',
-                main: () => <CosmosAssetTxHistory />,
-              },
-            ],
+            path: '/',
+            label: 'navBar.overview',
+            main: () => <CosmosAsset />,
           },
           {
-            path: '/accounts/cosmos::accountSubId',
-            label: '',
-            hide: true,
-            main: null,
-            icon: <AssetIcon src='https://assets.coincap.io/assets/icons/atom@2x.png' />,
-            routes: [
-              {
-                path: '/',
-                label: 'navBar.overview',
-                main: () => <CosmosAccount />,
-              },
-              {
-                path: '/transactions',
-                label: 'navBar.transactions',
-                main: () => <CosmosAccountTxHistory />,
-              },
-            ],
+            path: '/transactions',
+            label: 'navBar.transactions',
+            main: () => <CosmosAssetTxHistory />,
+          },
+        ],
+      },
+      {
+        path: '/accounts/cosmos::accountSubId',
+        label: '',
+        hide: true,
+        main: null,
+        icon: <AssetIcon src='https://assets.coincap.io/assets/icons/atom@2x.png' />,
+        routes: [
+          {
+            path: '/',
+            label: 'navBar.overview',
+            main: () => <CosmosAccount />,
           },
           {
-            path: '/accounts/cosmos::accountSubId/:assetId',
-            label: '',
-            hide: true,
-            main: null,
-            icon: <AssetIcon src='https://assets.coincap.io/assets/icons/atom@2x.png' />,
-            routes: [
-              {
-                path: '/',
-                label: 'navBar.overview',
-                main: () => <CosmosAccount />,
-              },
-              {
-                path: '/transactions',
-                label: 'navBar.transactions',
-                main: () => <CosmosAccountTxHistory />,
-              },
-            ],
+            path: '/transactions',
+            label: 'navBar.transactions',
+            main: () => <CosmosAccountTxHistory />,
+          },
+        ],
+      },
+      {
+        path: '/accounts/cosmos::accountSubId/:assetId',
+        label: '',
+        hide: true,
+        main: null,
+        icon: <AssetIcon src='https://assets.coincap.io/assets/icons/atom@2x.png' />,
+        routes: [
+          {
+            path: '/',
+            label: 'navBar.overview',
+            main: () => <CosmosAccount />,
+          },
+          {
+            path: '/transactions',
+            label: 'navBar.transactions',
+            main: () => <CosmosAccountTxHistory />,
           },
         ],
       },
     ],
-  ]
+  } as const
 }

--- a/src/plugins/ethereum/index.test.tsx
+++ b/src/plugins/ethereum/index.test.tsx
@@ -1,0 +1,25 @@
+// import type { ethereum } from '@shapeshiftoss/chain-adapters'
+import type { KnownChainIds } from '@shapeshiftoss/types'
+import * as ta from 'type-assertions'
+
+import {
+  // PluginChainAdapter,
+  PluginChainId,
+  RegistrablePlugin,
+  RegistrablePluginPluginType,
+} from '../types'
+
+type ThisRegistrablePlugin = typeof import('.')
+type ThisPlugin = RegistrablePluginPluginType<ThisRegistrablePlugin>
+
+describe('ethereum plugin', () => {
+  it('has the correct types', async () => {
+    ta.assert<ta.Extends<ThisRegistrablePlugin, RegistrablePlugin>>()
+    ta.assert<ta.Equal<PluginChainId<ThisPlugin>, KnownChainIds.EthereumMainnet>>()
+    //TODO: Uncomment when concrete type is returned from plugin
+    // ta.assert<ta.Equal<PluginChainAdapter<ThisPlugin>, ethereum.ChainAdapter>>()
+
+    // ta.assert() is checked at compile time, not runtime. This do-nothing expect() is included simply to pacify jest.
+    expect(() => ta.assert<true>()).not.toThrow()
+  })
+})

--- a/src/plugins/ethereum/index.tsx
+++ b/src/plugins/ethereum/index.tsx
@@ -1,40 +1,31 @@
-import { ChainId } from '@shapeshiftoss/caip'
-import { ChainAdapter, ethereum } from '@shapeshiftoss/chain-adapters'
+import type { ChainId } from '@shapeshiftoss/caip'
+import { type ChainAdapter, ethereum } from '@shapeshiftoss/chain-adapters'
 import { KnownChainIds } from '@shapeshiftoss/types'
 import * as unchained from '@shapeshiftoss/unchained-client'
 import { getConfig } from 'config'
-import { Plugins } from 'plugins'
 
-export function register(): Plugins {
-  return [
-    [
-      'ethereumChainAdapter',
-      {
-        name: 'ethereumChainAdapter',
-        providers: {
-          chainAdapters: [
-            [
-              KnownChainIds.EthereumMainnet,
-              () => {
-                const http = new unchained.ethereum.V1Api(
-                  new unchained.ethereum.Configuration({
-                    basePath: getConfig().REACT_APP_UNCHAINED_ETHEREUM_HTTP_URL,
-                  }),
-                )
+export function register() {
+  return {
+    providers: {
+      chainAdapters: {
+        [KnownChainIds.EthereumMainnet]: () => {
+          const http = new unchained.ethereum.V1Api(
+            new unchained.ethereum.Configuration({
+              basePath: getConfig().REACT_APP_UNCHAINED_ETHEREUM_HTTP_URL,
+            }),
+          )
 
-                const ws = new unchained.ws.Client<unchained.ethereum.EthereumTx>(
-                  getConfig().REACT_APP_UNCHAINED_ETHEREUM_WS_URL,
-                )
+          const ws = new unchained.ws.Client<unchained.ethereum.EthereumTx>(
+            getConfig().REACT_APP_UNCHAINED_ETHEREUM_WS_URL,
+          )
 
-                return new ethereum.ChainAdapter({
-                  providers: { http, ws },
-                  rpcUrl: getConfig().REACT_APP_ETHEREUM_NODE_URL,
-                }) as unknown as ChainAdapter<ChainId> // FIXME: this is silly
-              },
-            ],
-          ],
+          return new ethereum.ChainAdapter({
+            providers: { http, ws },
+            rpcUrl: getConfig().REACT_APP_ETHEREUM_NODE_URL,
+          }) as unknown as ChainAdapter<ChainId> // FIXME: this is silly
+          //TODO: When addressing the above, uncomment the matching test in ./index.test.tsx
         },
       },
-    ],
-  ]
+    },
+  } as const
 }

--- a/src/plugins/foxPage/index.test.tsx
+++ b/src/plugins/foxPage/index.test.tsx
@@ -1,0 +1,22 @@
+import * as ta from 'type-assertions'
+
+import {
+  PluginChainAdapter,
+  PluginChainId,
+  RegistrablePlugin,
+  RegistrablePluginPluginType,
+} from '../types'
+
+type ThisRegistrablePlugin = typeof import('.')
+type ThisPlugin = RegistrablePluginPluginType<ThisRegistrablePlugin>
+
+describe('foxPage plugin', () => {
+  it('has the correct types', async () => {
+    ta.assert<ta.Extends<ThisRegistrablePlugin, RegistrablePlugin>>()
+    ta.assert<ta.Equal<PluginChainId<ThisPlugin>, never>>()
+    ta.assert<ta.Equal<PluginChainAdapter<ThisPlugin>, never>>()
+
+    // ta.assert() is checked at compile time, not runtime. This do-nothing expect() is included simply to pacify jest.
+    expect(() => ta.assert<true>()).not.toThrow()
+  })
+})

--- a/src/plugins/foxPage/index.tsx
+++ b/src/plugins/foxPage/index.tsx
@@ -1,36 +1,29 @@
-import { Plugins } from 'plugins'
 import { FoxIcon } from 'components/Icons/FoxIcon'
 
 import { FoxPage } from './foxPage'
 
-export function register(): Plugins {
-  return [
-    [
-      'foxPage',
+export function register() {
+  return {
+    icon: <FoxIcon />,
+    routes: [
       {
-        name: 'foxPage',
+        path: '/fox',
+        label: 'navBar.foxToken',
+        main: () => <FoxPage />,
         icon: <FoxIcon />,
         routes: [
           {
             path: '/fox',
             label: 'navBar.foxToken',
             main: () => <FoxPage />,
-            icon: <FoxIcon />,
-            routes: [
-              {
-                path: '/fox',
-                label: 'navBar.foxToken',
-                main: () => <FoxPage />,
-              },
-              {
-                path: '/foxy',
-                label: 'navBar.foxToken',
-                main: () => <FoxPage />,
-              },
-            ],
+          },
+          {
+            path: '/foxy',
+            label: 'navBar.foxToken',
+            main: () => <FoxPage />,
           },
         ],
       },
     ],
-  ]
+  } as const
 }

--- a/src/plugins/index.test.ts
+++ b/src/plugins/index.test.ts
@@ -1,0 +1,21 @@
+import type { KnownChainIds } from '@shapeshiftoss/types'
+import * as ta from 'type-assertions'
+
+import type { ActivePlugin, PluginChainId } from './types'
+
+describe('the set of active plugins', () => {
+  it('provides all required types of ChainAdapte', async () => {
+    ta.assert<
+      ta.Extends<
+        | KnownChainIds.BitcoinMainnet
+        | KnownChainIds.CosmosMainnet
+        | KnownChainIds.EthereumMainnet
+        | KnownChainIds.OsmosisMainnet,
+        PluginChainId<ActivePlugin>
+      >
+    >()
+
+    // ta.assert() is checked at compile time, not runtime. This do-nothing expect() is included simply to pacify jest.
+    expect(() => ta.assert<true>()).not.toThrow()
+  })
+})

--- a/src/plugins/osmosis/index.test.tsx
+++ b/src/plugins/osmosis/index.test.tsx
@@ -1,0 +1,25 @@
+// import type { cosmossdk } from '@shapeshiftoss/chain-adapters'
+import type { KnownChainIds } from '@shapeshiftoss/types'
+import * as ta from 'type-assertions'
+
+import type {
+  // PluginChainAdapter,
+  PluginChainId,
+  RegistrablePlugin,
+  RegistrablePluginPluginType,
+} from '../types'
+
+type ThisRegistrablePlugin = typeof import('.')
+type ThisPlugin = RegistrablePluginPluginType<ThisRegistrablePlugin>
+
+describe('osmosis plugin', () => {
+  it('has the correct types', async () => {
+    ta.assert<ta.Extends<ThisRegistrablePlugin, RegistrablePlugin>>()
+    ta.assert<ta.Equal<PluginChainId<ThisPlugin>, KnownChainIds.OsmosisMainnet>>()
+    //TODO: Uncomment when concrete type is returned from plugin
+    // ta.assert<ta.Equal<PluginChainAdapter<ThisPlugin>, cosmossdk.osmosis.ChainAdapter>>()
+
+    // ta.assert() is checked at compile time, not runtime. This do-nothing expect() is included simply to pacify jest.
+    expect(() => ta.assert<true>()).not.toThrow()
+  })
+})

--- a/src/plugins/osmosis/index.tsx
+++ b/src/plugins/osmosis/index.tsx
@@ -1,41 +1,32 @@
-import { ChainId } from '@shapeshiftoss/caip'
-import { ChainAdapter, cosmossdk } from '@shapeshiftoss/chain-adapters'
+import type { ChainId } from '@shapeshiftoss/caip'
+import { type ChainAdapter, cosmossdk } from '@shapeshiftoss/chain-adapters'
 import { KnownChainIds } from '@shapeshiftoss/types'
 import * as unchained from '@shapeshiftoss/unchained-client'
 import { getConfig } from 'config'
-import { Plugins } from 'plugins'
 
-export function register(): Plugins {
-  return [
-    [
-      'osmosisChainAdapter',
-      {
-        name: 'osmosisChainAdapter',
-        featureFlag: 'Osmosis',
-        providers: {
-          chainAdapters: [
-            [
-              KnownChainIds.OsmosisMainnet,
-              () => {
-                const http = new unchained.osmosis.V1Api(
-                  new unchained.osmosis.Configuration({
-                    basePath: getConfig().REACT_APP_UNCHAINED_OSMOSIS_HTTP_URL,
-                  }),
-                )
+export function register() {
+  return {
+    featureFlag: 'Osmosis' as const,
+    providers: {
+      chainAdapters: {
+        [KnownChainIds.OsmosisMainnet]: () => {
+          const http = new unchained.osmosis.V1Api(
+            new unchained.osmosis.Configuration({
+              basePath: getConfig().REACT_APP_UNCHAINED_OSMOSIS_HTTP_URL,
+            }),
+          )
 
-                const ws = new unchained.ws.Client<unchained.osmosis.Tx>(
-                  getConfig().REACT_APP_UNCHAINED_OSMOSIS_WS_URL,
-                )
+          const ws = new unchained.ws.Client<unchained.osmosis.Tx>(
+            getConfig().REACT_APP_UNCHAINED_OSMOSIS_WS_URL,
+          )
 
-                return new cosmossdk.osmosis.ChainAdapter({
-                  providers: { http, ws },
-                  coinName: 'Osmosis',
-                }) as unknown as ChainAdapter<ChainId> // FIXME: this is silly
-              },
-            ],
-          ],
+          return new cosmossdk.osmosis.ChainAdapter({
+            providers: { http, ws },
+            coinName: 'Osmosis',
+          }) as unknown as ChainAdapter<ChainId> // FIXME: this is silly
+          //TODO: When addressing the above, uncomment the matching test in ./index.test.tsx
         },
       },
-    ],
-  ]
+    },
+  } as const
 }

--- a/src/plugins/types.ts
+++ b/src/plugins/types.ts
@@ -1,0 +1,62 @@
+import type { ChainId } from '@shapeshiftoss/caip'
+import type { ChainAdapter } from '@shapeshiftoss/chain-adapters'
+import type { Get, ReadonlyDeep, ValueOf } from 'type-fest'
+import type { FeatureFlags } from 'state/slices/preferencesSlice/preferencesSlice'
+
+import type { Route } from '../Routes/helpers'
+import type { activePlugins } from './active'
+
+/**
+ * We need plugins to be able to export (a register function that returns) a narrow (i.e. non-widened) type. The simplest
+ * way to do this is for them to use "as const", but that will also turn the value Readonly and cause TypeScript to throw
+ * a fit. As a workaround, we explicitly ask for the Readonly version here so plugins can use "as const".
+ */
+type PluginBase = ReadonlyDeep<{
+  icon?: JSX.Element
+  featureFlag?: keyof FeatureFlags
+  providers?: {
+    chainAdapters?: Partial<Record<ChainId, () => ChainAdapter<ChainId>>>
+  }
+  routes?: Route[]
+}>
+export type Plugin<T extends PluginBase = PluginBase> = T
+
+export type RegistrablePlugin<T extends Plugin = Plugin> = { register: () => T }
+
+/**
+ * Given a union of RegistrablePlugin types, gets the union of the Plugin types created on registration.
+ */
+export type RegistrablePluginPluginType<T extends RegistrablePlugin<any>> =
+  T extends RegistrablePlugin<infer R> ? R : never
+
+/**
+ * Given a union of Plugin types, gets the union of all the types of ChainAdapter they provide.
+ */
+export type PluginChainAdapter<T extends Plugin> = T extends unknown
+  ? ReturnType<Extract<ValueOf<Get<T, 'providers.chainAdapters'>>, (...args: any) => any>>
+  : never
+
+/**
+ * Given a union of Plugin types, gets the union of all the ChainIds they provide ChainAdapters for.
+ */
+export type PluginChainId<T extends Plugin> = T extends unknown
+  ? keyof Get<T, 'providers.chainAdapters'>
+  : never
+
+/**
+ * Union of the types of all active registrable plugins (i.e. `typeof import('./foo') | typeof import('./bar')`)
+ */
+export type ActiveRegistrablePlugin = ValueOf<typeof activePlugins>
+
+/**
+ * Union of all the possible types of Plugin you might get by calling register() on an active RegistrablePlugin
+ */
+export type ActivePlugin = ReturnType<ActiveRegistrablePlugin['register']>
+
+/**
+ * Given a ChainId, gets the specific Plugin which provides a matching ChainAdapter
+ */
+export type ActivePluginForChainId<T extends PluginChainId<ActivePlugin>> = Extract<
+  ActivePlugin,
+  { providers: { chainAdapters: Record<T, unknown> } }
+>

--- a/yarn.lock
+++ b/yarn.lock
@@ -20798,6 +20798,11 @@ type-fest@^1.2.2:
   resolved "https://registry.yarnpkg.com/type-fest/-/type-fest-1.4.0.tgz#e9fb813fe3bf1744ec359d55d1affefa76f14be1"
   integrity sha512-yGSza74xk0UG8k+pLh5oeoYirvIiWo5t0/o3zHHAO2tRDiZcxWP7fywNlXhqb6/r6sWvwi+RsyQMWhVLe4BVuA==
 
+type-fest@^2.13.0:
+  version "2.13.0"
+  resolved "https://registry.yarnpkg.com/type-fest/-/type-fest-2.13.0.tgz#d1ecee38af29eb2e863b22299a3d68ef30d2abfb"
+  integrity sha512-lPfAm42MxE4/456+QyIaaVBAwgpJb6xZ8PRu09utnhPdWwcyj9vgy6Sq0Z5yNbJ21EdxB5dRU/Qg8bsyAMtlcw==
+
 type-is@~1.6.18:
   version "1.6.18"
   resolved "https://registry.yarnpkg.com/type-is/-/type-is-1.6.18.tgz#4e552cd05df09467dcbc4ef739de89f2cf37c131"


### PR DESCRIPTION
## Description

Based on #2047.

Improves the plugin API in preparation for adding the new Pendo plugin. In particular, improves handling of static types, and adds compile-time tests using the `type-assertions` library.

## Notice

<!-- Before submitting a pull request, please make sure you have answered the following: -->

- [ ] Have you followed the guidelines in our [Contributing]('https://github.com/shapeshift/web/CONTRIBUTING.md) guide?
- [ ] Have you checked to ensure there aren't other open [Pull Requests](https://github.com/shapeshift/web/pulls) for the same update/change?

## Pull Request Type

- [ ] :bug: Bug fix (Non-breaking Change: Fixes an issue)
- [x] :hammer_and_wrench: Chore (Non-breaking Change: Doc updates, pkg upgrades, typos, etc..)
- [x] :nail_care: New Feature (Breaking/Non-breaking Change)

## Risk

No change to runtime behavior, so if CI passes we're pretty safe.

## Testing

- [ ] Verify CI passes.

