### PR TITLE
chore: initialize swappers

### DIFF
--- a/.github/workflows/bootstrap.yml
+++ b/.github/workflows/bootstrap.yml
@@ -19,6 +19,7 @@ jobs:
       REACT_APP_ETHEREUM_NODE_URL: https://mainnet.infura.io/v3/d734c7eebcdf400185d7eb67322a7e57
       REACT_APP_WALLET_MIGRATION_URL: https://axiom-wallet-migration-api.megacluster.stage.chiefhappinessofficerellie.org/api/migrate
       REACT_APP_FRIENDLY_CAPTCHA_SITE_KEY: FCMM7AFC0S6A8NUK
+      REACT_APP_MIDGARD_URL: https://midgard.thorchain.info/v2
     steps:
       - name: Checkout
         uses: actions/checkout@v3

--- a/.github/workflows/pr-cypress.yml
+++ b/.github/workflows/pr-cypress.yml
@@ -20,6 +20,7 @@ env:
   REACT_APP_ETHEREUM_NODE_URL: https://mainnet.infura.io/v3/d734c7eebcdf400185d7eb67322a7e57
   REACT_APP_WALLET_MIGRATION_URL: https://axiom-wallet-migration-api.megacluster.stage.chiefhappinessofficerellie.org/api/migrate
   REACT_APP_FRIENDLY_CAPTCHA_SITE_KEY: FCMM7AFC0S6A8NUK
+  REACT_APP_MIDGARD_URL: https://midgard.thorchain.info/v2
 
   REACT_APP_GEM_ASSET_LOGO: https://gem-widgets-assets.s3-us-west-2.amazonaws.com/currencies/crypto/
   REACT_APP_GEM_API_KEY: bb4164a72246dae1e03010d664d6cdae4e19b2554de02e3bf6c3cd30aa7e359e

--- a/.github/workflows/pr.yml
+++ b/.github/workflows/pr.yml
@@ -19,6 +19,7 @@ jobs:
       REACT_APP_WALLET_MIGRATION_URL: https://axiom-wallet-migration-api.megacluster.stage.chiefhappinessofficerellie.org/api/migrate
       REACT_APP_FRIENDLY_CAPTCHA_SITE_KEY: FCMM7AFC0S6A8NUK
       REACT_APP_KEEPKEY_VERSIONS_URL: https://ipfs.io/ipns/k51qzi5uqu5dlbggjzdpw8ya206zkcdmd1gmg77oqdmuhs899bgfv43lzhd5er/releases.json
+      REACT_APP_KEEPKEY_VERSIONS_URL: https://midgard.thorchain.info/v2
 
       REACT_APP_COINBASE_SUPPORTED_COINS: https://api.pro.coinbase.com/currencies
       REACT_APP_COINBASE_PAY_APP_ID: 1dbd2a0b94

--- a/.github/workflows/pr.yml
+++ b/.github/workflows/pr.yml
@@ -19,7 +19,7 @@ jobs:
       REACT_APP_WALLET_MIGRATION_URL: https://axiom-wallet-migration-api.megacluster.stage.chiefhappinessofficerellie.org/api/migrate
       REACT_APP_FRIENDLY_CAPTCHA_SITE_KEY: FCMM7AFC0S6A8NUK
       REACT_APP_KEEPKEY_VERSIONS_URL: https://ipfs.io/ipns/k51qzi5uqu5dlbggjzdpw8ya206zkcdmd1gmg77oqdmuhs899bgfv43lzhd5er/releases.json
-      REACT_APP_KEEPKEY_VERSIONS_URL: https://midgard.thorchain.info/v2
+      REACT_APP_MIDGARD_URL: https://midgard.thorchain.info/v2
 
       REACT_APP_COINBASE_SUPPORTED_COINS: https://api.pro.coinbase.com/currencies
       REACT_APP_COINBASE_PAY_APP_ID: 1dbd2a0b94

--- a/react-app-rewired/headers/csps/defi/swappers/0x.ts
+++ b/react-app-rewired/headers/csps/defi/swappers/0x.ts
@@ -6,5 +6,7 @@ export const csp: Csp = {
     'https://api.0x.org',
     // @shapeshiftoss/chain-adapters@1.22.1: https://github.com/shapeshift/lib/blob/476550629be9485bfc089decc4df85456968464a/packages/chain-adapters/src/ethereum/EthereumChainAdapter.ts#L226
     'https://gas.api.0x.org',
+    // @shapeshiftoss/chain-adapters@1.22.1: https://github.com/shapeshift/lib/blob/476550629be9485bfc089decc4df85456968464a/packages/chain-adapters/src/ethereum/EthereumChainAdapter.ts#L226
+    'https://thor-midgard.cointainers.prod.chiefhappinessofficerellie.org',
   ],
 }

--- a/react-app-rewired/headers/csps/defi/swappers/0x.ts
+++ b/react-app-rewired/headers/csps/defi/swappers/0x.ts
@@ -6,7 +6,5 @@ export const csp: Csp = {
     'https://api.0x.org',
     // @shapeshiftoss/chain-adapters@1.22.1: https://github.com/shapeshift/lib/blob/476550629be9485bfc089decc4df85456968464a/packages/chain-adapters/src/ethereum/EthereumChainAdapter.ts#L226
     'https://gas.api.0x.org',
-    // @shapeshiftoss/chain-adapters@1.22.1: https://github.com/shapeshift/lib/blob/476550629be9485bfc089decc4df85456968464a/packages/chain-adapters/src/ethereum/EthereumChainAdapter.ts#L226
-    'https://thor-midgard.cointainers.prod.chiefhappinessofficerellie.org',
   ],
 }

--- a/react-app-rewired/headers/csps/defi/swappers/Thor.ts
+++ b/react-app-rewired/headers/csps/defi/swappers/Thor.ts
@@ -1,5 +1,5 @@
 import type { Csp } from '../../../types'
 
 export const csp: Csp = {
-  'connect-src': [process.env.REACT_APP_MIDGARD_URL!],
+  'connect-src': ['https://thor-midgard.cointainers.prod.chiefhappinessofficerellie.org'],
 }

--- a/react-app-rewired/headers/csps/defi/swappers/Thor.ts
+++ b/react-app-rewired/headers/csps/defi/swappers/Thor.ts
@@ -1,5 +1,6 @@
 import type { Csp } from '../../../types'
 
 export const csp: Csp = {
-  'connect-src': ['https://midgard.thorchain.info'],
+  // removes `/v2` from midgard url
+  'connect-src': [process.env.REACT_APP_MIDGARD_URL!.slice(0, -3)],
 }

--- a/react-app-rewired/headers/csps/defi/swappers/Thor.ts
+++ b/react-app-rewired/headers/csps/defi/swappers/Thor.ts
@@ -1,5 +1,5 @@
 import type { Csp } from '../../../types'
 
 export const csp: Csp = {
-  'connect-src': ['https://thor-midgard.cointainers.prod.chiefhappinessofficerellie.org'],
+  'connect-src': ['https://midgard.thorchain.info'],
 }

--- a/react-app-rewired/headers/csps/defi/swappers/Thor.ts
+++ b/react-app-rewired/headers/csps/defi/swappers/Thor.ts
@@ -2,5 +2,5 @@ import type { Csp } from '../../../types'
 
 export const csp: Csp = {
   // removes `/v2` from midgard url
-  'connect-src': [process.env.REACT_APP_MIDGARD_URL!.slice(0, -3)],
+  'connect-src': [String(process.env.REACT_APP_MIDGARD_URL).slice(0, -3)],
 }

--- a/react-app-rewired/headers/csps/defi/swappers/Thor.ts
+++ b/react-app-rewired/headers/csps/defi/swappers/Thor.ts
@@ -1,0 +1,5 @@
+import type { Csp } from '../../../types'
+
+export const csp: Csp = {
+  'connect-src': [process.env.REACT_APP_MIDGARD_URL!],
+}

--- a/sample.env
+++ b/sample.env
@@ -38,4 +38,4 @@ REACT_APP_BOARDROOM_APP_BASE_URL=https://boardroom.io/shapeshift/
 REACT_APP_COINBASE_PAY_APP_ID=1dbd2a0b94
 REACT_APP_COINBASE_SUPPORTED_COINS=https://api.pro.coinbase.com/currencies
 
-REACT_APP_MIDGARD_URL=https://thor-midgard.cointainers.prod.chiefhappinessofficerellie.org/v2
+REACT_APP_MIDGARD_URL=https://midgard.thorchain.info/v2

--- a/sample.env
+++ b/sample.env
@@ -38,4 +38,4 @@ REACT_APP_BOARDROOM_APP_BASE_URL=https://boardroom.io/shapeshift/
 REACT_APP_COINBASE_PAY_APP_ID=1dbd2a0b94
 REACT_APP_COINBASE_SUPPORTED_COINS=https://api.pro.coinbase.com/currencies
 
-REACT_APP_MIDGARD_URL=https://thor-midgard.cointainers.prod.chiefhappinessofficerellie.org
+REACT_APP_MIDGARD_URL=https://thor-midgard.cointainers.prod.chiefhappinessofficerellie.org/v2

--- a/sample.env
+++ b/sample.env
@@ -37,3 +37,5 @@ REACT_APP_BOARDROOM_APP_BASE_URL=https://boardroom.io/shapeshift/
 
 REACT_APP_COINBASE_PAY_APP_ID=1dbd2a0b94
 REACT_APP_COINBASE_SUPPORTED_COINS=https://api.pro.coinbase.com/currencies
+
+REACT_APP_MIDGARD_URL=https://thor-midgard.cointainers.prod.chiefhappinessofficerellie.org

--- a/sample.env
+++ b/sample.env
@@ -20,6 +20,7 @@ REACT_APP_ETHEREUM_NODE_URL=https://mainnet.infura.io/v3/d734c7eebcdf400185d7eb6
 REACT_APP_ALCHEMY_POLYGON_URL=https://polygon-mainnet.g.alchemy.com/v2/458rwsHQDajSOTCdC5AACXQUMYrllacR
 REACT_APP_KEEPKEY_VERSIONS_URL=https://raw.githack.com/keepkey/keepkey-updater/master/firmware/releases.json
 REACT_APP_WALLET_MIGRATION_URL=https://wallets.shapeshift.com/api/migrate
+REACT_APP_MIDGARD_URL=https://midgard.thorchain.info/v2
 
 REACT_APP_FRIENDLY_CAPTCHA_SITE_KEY=FCMM7AFC0S6A8NUK
 
@@ -38,4 +39,3 @@ REACT_APP_BOARDROOM_APP_BASE_URL=https://boardroom.io/shapeshift/
 REACT_APP_COINBASE_PAY_APP_ID=1dbd2a0b94
 REACT_APP_COINBASE_SUPPORTED_COINS=https://api.pro.coinbase.com/currencies
 
-REACT_APP_MIDGARD_URL=https://midgard.thorchain.info/v2

--- a/src/components/Trade/hooks/useSwapper/useSwapper.ts
+++ b/src/components/Trade/hooks/useSwapper/useSwapper.ts
@@ -4,6 +4,7 @@ import {
   QuoteFeeData,
   Swapper,
   SwapperManager,
+  ThorchainSwapper,
   Trade,
   TradeQuote,
   TradeResult,
@@ -30,6 +31,7 @@ import {
 import { useAppSelector } from 'state/store'
 
 import { calculateAmounts } from './calculateAmounts'
+import { getConfig } from 'config'
 
 const debounceTime = 1000
 
@@ -62,14 +64,15 @@ export const useSwapper = () => {
 
     const web3 = getWeb3Instance()
 
+    const midgardUrl = getConfig().REACT_APP_MIDGARD_URL
     ;(async () => {
-      // const thorSwapper = new ThorchainSwapper({
-      //   midgardUrl: process.env.REACT_APP_MIDGARD_URL!,
-      //   adapterManager,
-      //   web3,
-      // })
-      // await thorSwapper.initialize()
-      // swapperManager.addSwapper(SwapperType.Thorchain, thorSwapper)
+      const thorSwapper = new ThorchainSwapper({
+        midgardUrl,
+        adapterManager,
+        web3,
+      })
+      await thorSwapper.initialize()
+      swapperManager.addSwapper(SwapperType.Thorchain, thorSwapper)
 
       const zrxSwapper = new ZrxSwapper({
         web3,

--- a/src/components/Trade/hooks/useSwapper/useSwapper.ts
+++ b/src/components/Trade/hooks/useSwapper/useSwapper.ts
@@ -64,15 +64,15 @@ export const useSwapper = () => {
 
     const web3 = getWeb3Instance()
 
-    const midgardUrl = getConfig().REACT_APP_MIDGARD_URL
     ;(async () => {
-      const thorSwapper = new ThorchainSwapper({
-        midgardUrl,
-        adapterManager,
-        web3,
-      })
-      await thorSwapper.initialize()
-      swapperManager.addSwapper(SwapperType.Thorchain, thorSwapper)
+      // const midgardUrl = getConfig().REACT_APP_MIDGARD_URL
+      // const thorSwapper = new ThorchainSwapper({
+      //   midgardUrl,
+      //   adapterManager,
+      //   web3,
+      // })
+      // await thorSwapper.initialize()
+      // swapperManager.addSwapper(SwapperType.Thorchain, thorSwapper)
 
       const zrxSwapper = new ZrxSwapper({
         web3,

--- a/src/components/Trade/hooks/useSwapper/useSwapper.ts
+++ b/src/components/Trade/hooks/useSwapper/useSwapper.ts
@@ -58,9 +58,8 @@ export const useSwapper = () => {
   })
 
   useEffect(() => {
-    if (!adapterManager || !swapperManager) {
-      return
-    }
+    if (!adapterManager || !swapperManager) return
+
     const web3 = getWeb3Instance()
 
     ;(async () => {

--- a/src/components/Trade/hooks/useSwapper/useSwapper.ts
+++ b/src/components/Trade/hooks/useSwapper/useSwapper.ts
@@ -4,7 +4,6 @@ import {
   QuoteFeeData,
   Swapper,
   SwapperManager,
-  ThorchainSwapper,
   Trade,
   TradeQuote,
   TradeResult,

--- a/src/components/Trade/hooks/useSwapper/useSwapper.ts
+++ b/src/components/Trade/hooks/useSwapper/useSwapper.ts
@@ -70,14 +70,14 @@ export const useSwapper = () => {
         adapter: adapterManager.get('eip155:1') as unknown as ethereum.ChainAdapter,
       })
 
-      const thorSwapper = new ThorchainSwapper({
-        midgardUrl: 'https://thor-midgard.cointainers.prod.chiefhappinessofficerellie.org/v2',
-        adapterManager,
-        web3,
-      })
+      // const thorSwapper = new ThorchainSwapper({
+      //   midgardUrl: 'https://thor-midgard.cointainers.prod.chiefhappinessofficerellie.org/v2',
+      //   adapterManager,
+      //   web3,
+      // })
       await zrxSwapper.initialize()
-      await thorSwapper.initialize()
-      swapperManager.addSwapper(SwapperType.Thorchain, thorSwapper)
+      // await thorSwapper.initialize()
+      // swapperManager.addSwapper(SwapperType.Thorchain, thorSwapper)
       swapperManager.addSwapper(SwapperType.Zrx, zrxSwapper)
     })()
   }, [adapterManager, swapperManager])

--- a/src/components/Trade/hooks/useSwapper/useSwapper.ts
+++ b/src/components/Trade/hooks/useSwapper/useSwapper.ts
@@ -64,19 +64,20 @@ export const useSwapper = () => {
     const web3 = getWeb3Instance()
 
     ;(async () => {
+      // const thorSwapper = new ThorchainSwapper({
+      //   midgardUrl: process.env.REACT_APP_MIDGARD_URL!,
+      //   adapterManager,
+      //   web3,
+      // })
+      // await thorSwapper.initialize()
+      // swapperManager.addSwapper(SwapperType.Thorchain, thorSwapper)
+
       const zrxSwapper = new ZrxSwapper({
         web3,
         adapter: adapterManager.get('eip155:1') as unknown as ethereum.ChainAdapter,
       })
 
-      // const thorSwapper = new ThorchainSwapper({
-      //   midgardUrl: 'https://thor-midgard.cointainers.prod.chiefhappinessofficerellie.org/v2',
-      //   adapterManager,
-      //   web3,
-      // })
       await zrxSwapper.initialize()
-      // await thorSwapper.initialize()
-      // swapperManager.addSwapper(SwapperType.Thorchain, thorSwapper)
       swapperManager.addSwapper(SwapperType.Zrx, zrxSwapper)
     })()
   }, [adapterManager, swapperManager])

--- a/src/components/Trade/hooks/useSwapper/useSwapper.ts
+++ b/src/components/Trade/hooks/useSwapper/useSwapper.ts
@@ -4,7 +4,6 @@ import {
   QuoteFeeData,
   Swapper,
   SwapperManager,
-  ThorchainSwapper,
   Trade,
   TradeQuote,
   TradeResult,
@@ -31,7 +30,6 @@ import {
 import { useAppSelector } from 'state/store'
 
 import { calculateAmounts } from './calculateAmounts'
-import { getConfig } from 'config'
 
 const debounceTime = 1000
 

--- a/src/config.ts
+++ b/src/config.ts
@@ -42,6 +42,9 @@ const validators = {
   REACT_APP_BOARDROOM_APP_BASE_URL: url({
     default: 'https://boardroom.io/shapeshift/',
   }),
+  REACT_APP_MIDGARD_URL: url({
+    default: 'https://thor-midgard.cointainers.prod.chiefhappinessofficerellie.org/v2',
+  }),
 }
 
 function reporter<T>({ errors }: envalid.ReporterOptions<T>) {

--- a/src/config.ts
+++ b/src/config.ts
@@ -43,7 +43,7 @@ const validators = {
     default: 'https://boardroom.io/shapeshift/',
   }),
   REACT_APP_MIDGARD_URL: url({
-    default: 'https://thor-midgard.cointainers.prod.chiefhappinessofficerellie.org/v2',
+    default: 'https://midgard.thorchain.info/v2',
   }),
 }
 


### PR DESCRIPTION
## Description

Swappers now must call the async function initialize() before being added to the manager.

## Notice


- [x] Have you followed the guidelines in our [Contributing]('https://github.com/shapeshift/web/CONTRIBUTING.md) guide?
- [x] Have you checked to ensure there aren't other open [Pull Requests](https://github.com/shapeshift/web/pulls) for the same update/change?

## Pull Request Type

- [ ] :bug: Bug fix (Non-breaking Change: Fixes an issue)
- [x] :hammer_and_wrench: Chore (Non-breaking Change: Doc updates, pkg upgrades, typos, etc..)
- [ ] :nail_care: New Feature (Breaking/Non-breaking Change)

## Issue (if applicable)

<!-----------------------------------------------------------------------------
If applicable, please link to the github issue and put `closes #XXXX` in your comment to auto-close the issue that your PR fixes.
------------------------------------------------------------------------------>

## Risk

low risk, changes how swappers initialize behind the scene

## Testing

Make sure swapping still works

## Screenshots (if applicable)
