### PR TITLE
fix: modify broken link-packages script

### DIFF
--- a/scripts/link-packages.sh
+++ b/scripts/link-packages.sh
@@ -1,2 +1,2 @@
 #!/bin/bash
-grep -oE '@shapeshiftoss\/[a-z-]*' package.json | grep -v hdwallet | xargs yarn link
+grep -oE '@shapeshiftoss\/[a-z-]*' package.json | grep -v -e hdwallet -e web | xargs yarn link


### PR DESCRIPTION
## Description

Small fix to make the `yarn link-packages` command usable again

## Notice

<!-- Before submitting a pull request, please make sure you have answered the following: -->

- [x] Have you followed the guidelines in our [Contributing]('https://github.com/shapeshift/web/CONTRIBUTING.md) guide?
- [ ] Have you checked to ensure there aren't other open [Pull Requests](https://github.com/shapeshift/web/pulls) for the same update/change?

## Pull Request Type

- [x] :bug: Bug fix (Non-breaking Change: Fixes an issue)
- [ ] :hammer_and_wrench: Chore (Non-breaking Change: Doc updates, pkg upgrades, typos, etc..)
- [ ] :nail_care: New Feature (Breaking/Non-breaking Change)

## Risk

None

## Testing

1.) From project root, run `yarn link-packages`
2.) ?
3.) Profit

## Screenshots (if applicable)
