### PR TITLE
feat(foxPage): disable FOX borrowing and lending

### DIFF
--- a/src/plugins/foxPage/FoxCommon.ts
+++ b/src/plugins/foxPage/FoxCommon.ts
@@ -16,6 +16,7 @@ export type ExternalOpportunity = {
   link: string
   icons: string[]
   isLoaded?: boolean
+  isDisabled?: boolean
 }
 
 export type OpportunitiesBucket = {

--- a/src/plugins/foxPage/components/OtherOpportunities/OtherOpportunities.tsx
+++ b/src/plugins/foxPage/components/OtherOpportunities/OtherOpportunities.tsx
@@ -29,7 +29,8 @@ export const OtherOpportunities: React.FC<OtherOpportunitiesProps> = ({
         <Accordion mx={-6} defaultIndex={[0]} allowToggle allowMultiple>
           {opportunities.map(opportunitiesBucket => {
             const { opportunities } = opportunitiesBucket
-            if (!opportunities.length) return null
+            if (!opportunities.length || opportunities.every(opportunity => opportunity.isDisabled))
+              return null
 
             return (
               <FoxOtherOpportunityPanel

--- a/src/plugins/foxPage/hooks/useOtherOpportunities.ts
+++ b/src/plugins/foxPage/hooks/useOtherOpportunities.ts
@@ -4,12 +4,10 @@ import { useLpApr } from 'plugins/foxPage/hooks/useLpApr'
 import { useMemo } from 'react'
 
 import { FOX_ASSET_ID, FOXY_ASSET_ID, OpportunitiesBucket, OpportunityTypes } from '../FoxCommon'
-import { useFoxyApr } from './useFoxyApr'
 
 export const useOtherOpportunities = (assetId: AssetId) => {
   const { farmingApr, loaded: isFarmingAprLoaded } = useFarmingApr()
   const { lpApr, loaded: isLpAprLoaded } = useLpApr()
-  const { foxyApr, loaded: isFoxyAprLoaded } = useFoxyApr()
 
   const otherOpportunities = useMemo(() => {
     const opportunities: Record<AssetId, OpportunitiesBucket[]> = {
@@ -52,10 +50,11 @@ export const useOtherOpportunities = (assetId: AssetId) => {
           opportunities: [
             {
               title: 'FOX',
-              isLoaded: isFoxyAprLoaded,
-              apy: isFoxyAprLoaded ? foxyApr : foxyApr,
-              link: 'https://www.tokemak.xyz/',
+              isLoaded: true,
+              apy: null,
+              link: 'https://app.rari.capital/fuse/pool/79',
               icons: ['https://assets.coincap.io/assets/icons/fox@2x.png'],
+              isDisabled: true,
             },
           ],
         },
@@ -80,7 +79,7 @@ export const useOtherOpportunities = (assetId: AssetId) => {
     }
 
     return opportunities[assetId]
-  }, [lpApr, foxyApr, farmingApr, assetId, isLpAprLoaded, isFoxyAprLoaded, isFarmingAprLoaded])
+  }, [lpApr, farmingApr, assetId, isLpAprLoaded, isFarmingAprLoaded])
 
   return otherOpportunities
 }


### PR DESCRIPTION
## Description

This disables the "Borrowing and Lending" section.

~~Also modifies the Tokemak Borrowing and Lending opportunity to be a Rari opportunity, so we can easily re-enable it by deleting the `isDisabled: true` line, if we need to.~~ Done in https://github.com/shapeshift/web/pull/2063

## Notice

<!-- Before submitting a pull request, please make sure you have answered the following: -->

- [x] Have you followed the guidelines in our [Contributing]('https://github.com/shapeshift/web/CONTRIBUTING.md) guide?
- [x] Have you checked to ensure there aren't other open [Pull Requests](https://github.com/shapeshift/web/pulls) for the same update/change?

## Pull Request Type

- [ ] :bug: Bug fix (Non-breaking Change: Fixes an issue)
- [ ] :hammer_and_wrench: Chore (Non-breaking Change: Doc updates, pkg upgrades, typos, etc..)
- [x] :nail_care: New Feature (Breaking/Non-breaking Change)

## Issue (if applicable)

closes #2060

## Risk

None

## Testing

The "Borrowing and Lending" section should be hidden for FOX.

## Screenshots (if applicable)

<img width="737" alt="image" src="https://user-images.githubusercontent.com/17035424/174448253-62213ca8-6178-4514-b845-7ae06de0c092.png">