### PR TITLE
fix: close login modal when native wallet is already initialized

### DIFF
--- a/src/context/WalletProvider/NativeWallet/components/NativeLoad.tsx
+++ b/src/context/WalletProvider/NativeWallet/components/NativeLoad.tsx
@@ -80,16 +80,19 @@ export const NativeLoad = ({ history }: RouteComponentProps) => {
           // after the wallet has been decrypted. If we set it now, `getPublicKeys` calls will
           // return null, and we don't have a retry mechanism
           await wallet.initialize()
+          // If the wallet is not initialized, it means that the password need to be entered
+          // so we have to redirect to the enter-password view
+          history.push('/native/enter-password', { deviceId })
         } else {
           dispatch({
             type: WalletActions.SET_WALLET,
             payload: { wallet, name, icon, deviceId, meta: { label: item.name } },
           })
           dispatch({ type: WalletActions.SET_IS_CONNECTED, payload: true })
+          // The wallet is already initialized so we can close the modal
+          dispatch({ type: WalletActions.SET_WALLET_MODAL, payload: false })
         }
-        history.push('/native/enter-password', { deviceId })
-        // Always close the modal after trying to pair the wallet
-        // dispatch({ type: WalletActions.SET_WALLET_MODAL, payload: false })
+
         setLocalWalletTypeAndDeviceId(KeyManager.Native, deviceId)
         setLocalNativeWalletName(item.name)
       } catch (e) {


### PR DESCRIPTION
## Description
- If you already logged in a native wallet, the wallet is already initialized and you don't need to enter your password again
- So I just closed the modal in case the wallet is already initialized, if it's not, then it will redirect you to the `enter-password` route

More info on https://github.com/shapeshift/web/issues/1684#issuecomment-1139718910
<!-- Please describe your changes -->

## Notice

<!-- Before submitting a pull request, please make sure you have answered the following: -->

- [x] Have you followed the guidelines in our [Contributing]('https://github.com/shapeshift/web/CONTRIBUTING.md) guide?
- [x] Have you checked to ensure there aren't other open [Pull Requests](https://github.com/shapeshift/web/pulls) for the same update/change?

## Pull Request Type

- [x] :bug: Bug fix (Non-breaking Change: Fixes an issue)
- [ ] :hammer_and_wrench: Chore (Non-breaking Change: Doc updates, pkg upgrades, typos, etc..)
- [ ] :nail_care: New Feature (Breaking/Non-breaking Change)

## Issue (if applicable)
closes #1684
<!-----------------------------------------------------------------------------
If applicable, please link to the github issue and put `closes #XXXX` in your comment to auto-close the issue that your PR fixes.
------------------------------------------------------------------------------>

## Risk
No real risk tbh
<!-----------------------------------------------------------------------------
Outline the scope of your changes and the risk associated with them. You must use your discretion as an engineer to determine the potential impact of your changes.

E.g. an upgrade to `hdwallet` or core state management would be considered higher risk, and might require a full regression test. UI or isolated view changes, or something behind a feature flag may have near zero risk. Small bug fixes might require testing isolated to the specific fix.
------------------------------------------------------------------------------>

## Testing
- Open the app
- Connect to a native wallet
- Connect to any other provider, or even another native wallet
- Try to connect to the first native wallet, it shouldn't prompt the enter-password view
<!-----------------------------------------------------------------------------
If your testing steps are technical, outline steps for an engineer to verify.

If your testing steps are functional, please provide a full guide with any features requiring special attention for operations to test your branch in the preview environment.
------------------------------------------------------------------------------>

## Screenshots (if applicable)
