### PR TITLE
fix: correct FOXy icon URL

### DIFF
--- a/src/plugins/foxPage/components/FoxTab.stories.tsx
+++ b/src/plugins/foxPage/components/FoxTab.stories.tsx
@@ -27,7 +27,7 @@ export const FoxPageTabs: Story = () => (
           fiatAmount={'6000'}
           icons={[
             'https://assets.coincap.io/assets/icons/fox@2x.png',
-            'https://raw.githubusercontent.com/shapeshift/lib/main/packages/asset-service/src/generateAssetData/ethTokens/icons/foxy-icon.png',
+            'https://raw.githubusercontent.com/shapeshift/lib/main/packages/asset-service/src/generateAssetData/ethereum/icons/foxy-icon.png',
             'https://rawcdn.githack.com/trustwallet/assets/master/blockchains/ethereum/assets/0x03352D267951E96c6F7235037C5DFD2AB1466232/logo.png',
           ]}
         />

--- a/src/plugins/foxPage/hooks/useOtherOpportunities.ts
+++ b/src/plugins/foxPage/hooks/useOtherOpportunities.ts
@@ -71,7 +71,7 @@ export const useOtherOpportunities = (assetId: AssetId) => {
               apy: null,
               link: 'https://elasticswap.org/#/liquidity',
               icons: [
-                'https://raw.githubusercontent.com/shapeshift/lib/main/packages/asset-service/src/generateAssetData/ethTokens/icons/foxy-icon.png',
+                'https://raw.githubusercontent.com/shapeshift/lib/main/packages/asset-service/src/generateAssetData/ethereum/icons/foxy-icon.png',
               ],
             },
           ],

--- a/src/test/mocks/assets.ts
+++ b/src/test/mocks/assets.ts
@@ -86,7 +86,7 @@ export const foxy: Asset = {
   explorer: 'https://etherscan.io',
   explorerAddressLink: 'https://etherscan.io/address/',
   explorerTxLink: 'https://etherscan.io/tx/',
-  icon: 'https://raw.githubusercontent.com/shapeshift/lib/main/packages/asset-service/src/generateAssetData/ethTokens/icons/foxy-icon.png',
+  icon: 'https://raw.githubusercontent.com/shapeshift/lib/main/packages/asset-service/src/generateAssetData/ethereum/icons/foxy-icon.png',
   name: 'FOX Yieldy',
   precision: 18,
   symbol: 'FOXy',


### PR DESCRIPTION
## Description

This fixes the hardcoded FOXy asset's icon URL following https://github.com/shapeshift/lib/pull/790 - which is currently using the old /ethTokens path vs. /ethereum following this PR.

## Notice

<!-- Before submitting a pull request, please make sure you have answered the following: -->

- [x] Have you followed the guidelines in our [Contributing]('https://github.com/shapeshift/web/CONTRIBUTING.md) guide?
- [x] Have you checked to ensure there aren't other open [Pull Requests](https://github.com/shapeshift/web/pulls) for the same update/change?

## Pull Request Type

- [x] :bug: Bug fix (Non-breaking Change: Fixes an issue)
- [ ] :hammer_and_wrench: Chore (Non-breaking Change: Doc updates, pkg upgrades, typos, etc..)
- [ ] :nail_care: New Feature (Breaking/Non-breaking Change)

## Issue (if applicable)

https://github.com/shapeshift/lib/issues/807

## Risk

None

## Testing

- Go to FoxPage's FOXy tab
- In "Liquidity Pools", the FOXy icon should be shown

## Screenshots (if applicable)

<img width="743" alt="image" src="https://user-images.githubusercontent.com/17035424/174907863-75c1f35d-1719-48d8-b22f-53602febc428.png">