### PR TITLE
fix: bad check for supported chain in get quote

### DIFF
--- a/src/components/Trade/hooks/useSwapper/useSwapper.ts
+++ b/src/components/Trade/hooks/useSwapper/useSwapper.ts
@@ -1,4 +1,4 @@
-import { ChainId } from '@shapeshiftoss/caip'
+import { btcChainId, ChainId } from '@shapeshiftoss/caip'
 import { ethereum } from '@shapeshiftoss/chain-adapters'
 import {
   QuoteFeeData,
@@ -250,7 +250,7 @@ export const useSwapper = () => {
               sellAssetAccountNumber: 0,
               wallet,
             })
-          } else if (sellAsset.chainId === 'bip122:000000000019d6689c085ae165831e93') {
+          } else if (sellAsset.chainId === btcChainId) {
             // TODO do bitcoin specific trade quote including `bip44Params`, `accountType` and `wallet`
             // They will need to have selected an accountType from a modal if bitcoin
             throw new Error('bitcoin unsupported')

--- a/src/components/Trade/hooks/useSwapper/useSwapper.ts
+++ b/src/components/Trade/hooks/useSwapper/useSwapper.ts
@@ -250,7 +250,7 @@ export const useSwapper = () => {
               sellAssetAccountNumber: 0,
               wallet,
             })
-          } else if ('bip122:000000000019d6689c085ae165831e93') {
+          } else if (sellAsset.chainId === 'bip122:000000000019d6689c085ae165831e93') {
             // TODO do bitcoin specific trade quote including `bip44Params`, `accountType` and `wallet`
             // They will need to have selected an accountType from a modal if bitcoin
             throw new Error('bitcoin unsupported')


### PR DESCRIPTION
## Description

This fixes a bug getting quotes for swapper pairs where it was always saying "bitcoin unsupported" if it hit the else

## Notice

<!-- Before submitting a pull request, please make sure you have answered the following: -->

- [ ] Have you followed the guidelines in our [Contributing]('https://github.com/shapeshift/web/CONTRIBUTING.md) guide?
- [ ] Have you checked to ensure there aren't other open [Pull Requests](https://github.com/shapeshift/web/pulls) for the same update/change?

## Pull Request Type

- [ ] :bug: Bug fix (Non-breaking Change: Fixes an issue)
- [ ] :hammer_and_wrench: Chore (Non-breaking Change: Doc updates, pkg upgrades, typos, etc..)
- [ ] :nail_care: New Feature (Breaking/Non-breaking Change)

## Issue (if applicable)

<!-----------------------------------------------------------------------------
If applicable, please link to the github issue and put `closes #XXXX` in your comment to auto-close the issue that your PR fixes.
------------------------------------------------------------------------------>

## Risk

no risk. fixes stuff

## Testing

no risk. make sure swapper works

## Screenshots (if applicable)
