### PR TITLE
feat: turn the wallet select into a grid

### DIFF
--- a/src/context/WalletProvider/SelectModal.tsx
+++ b/src/context/WalletProvider/SelectModal.tsx
@@ -1,15 +1,11 @@
 import { CheckCircleIcon } from '@chakra-ui/icons'
 import {
-  Avatar,
-  AvatarBadge,
   Button,
   Center,
   Flex,
   Grid,
   ModalBody,
   ModalHeader,
-  Stack,
-  Tag,
   useColorModeValue,
 } from '@chakra-ui/react'
 import { isMobile } from 'react-device-detect'

--- a/src/context/WalletProvider/SelectModal.tsx
+++ b/src/context/WalletProvider/SelectModal.tsx
@@ -1,4 +1,17 @@
-import { Button, Center, Flex, ModalBody, ModalHeader, Stack, Tag } from '@chakra-ui/react'
+import { CheckCircleIcon } from '@chakra-ui/icons'
+import {
+  Avatar,
+  AvatarBadge,
+  Button,
+  Center,
+  Flex,
+  Grid,
+  ModalBody,
+  ModalHeader,
+  Stack,
+  Tag,
+  useColorModeValue,
+} from '@chakra-ui/react'
 import { isMobile } from 'react-device-detect'
 import { useTranslate } from 'react-polyglot'
 import { RawText, Text } from 'components/Text'
@@ -15,6 +28,8 @@ export const SelectModal = () => {
   } = useWallet()
   const translate = useTranslate()
   const wallets = Object.values(KeyManager).filter(key => key !== KeyManager.Demo)
+  const greenColor = useColorModeValue('green.500', 'green.200')
+  const activeBg = useColorModeValue('gray.200', 'gray.900')
 
   return (
     <>
@@ -23,13 +38,14 @@ export const SelectModal = () => {
       </ModalHeader>
       <ModalBody>
         <Text mb={6} color='gray.500' translation={'walletProvider.selectModal.body'} />
-        <Stack mb={6}>
+        <Grid mb={6} gridTemplateColumns={{ base: '1fr', md: '1fr 1fr' }} gridGap={4}>
           {adapters &&
             // TODO: KeepKey adapter may fail due to the USB interface being in use by another tab
             // So not all of the supported wallets will have an initialized adapter
             wallets.map(key => {
               const option = SUPPORTED_WALLETS[key]
               const Icon = option.icon
+              const activeWallet = walletInfo?.name === option.name
 
               // some wallets (e.g. tally ho) do not exist on mobile
               if (isMobile && !option.mobileEnabled) return false
@@ -38,27 +54,31 @@ export const SelectModal = () => {
                 <Button
                   key={key}
                   w='full'
-                  size='lg'
+                  size='md'
                   py={8}
+                  isActive={activeWallet}
+                  _active={{ bg: activeBg }}
                   justifyContent='space-between'
                   onClick={() => connect(key)}
                   data-test={`connect-wallet-${key}-button`}
                 >
-                  <Flex alignItems='center'>
+                  <Flex alignItems='flex-start' flexDir='column'>
                     <RawText fontWeight='semibold'>{option.name}</RawText>
-                    {walletInfo?.name === option.name && (
-                      <Tag colorScheme='green' ml={2}>
-                        <Text translation='common.connected' />
-                      </Tag>
+                    {activeWallet && (
+                      <Text fontSize='xs' color='gray.500' translation='common.connected' />
                     )}
                   </Flex>
-                  <Center>
-                    <Icon height='30px' w='auto' />
+                  <Center width='25%'>
+                    {walletInfo?.name === option.name ? (
+                      <CheckCircleIcon color={greenColor} />
+                    ) : (
+                      <Icon height='24px' w='auto' />
+                    )}
                   </Center>
                 </Button>
               )
             })}
-        </Stack>
+        </Grid>
         <Flex direction={['column', 'row']} mt={2} justifyContent='center' alignItems='center'>
           <Text
             mb={[3]}


### PR DESCRIPTION
## Description

As we add more wallets, there is a need to update this style to be a grid.

## Notice

<!-- Before submitting a pull request, please make sure you have answered the following: -->

- [x] Have you followed the guidelines in our [Contributing]('https://github.com/shapeshift/web/CONTRIBUTING.md) guide?
- [x] Have you checked to ensure there aren't other open [Pull Requests](https://github.com/shapeshift/web/pulls) for the same update/change?

## Pull Request Type

- [ ] :bug: Bug fix (Non-breaking Change: Fixes an issue)
- [ ] :hammer_and_wrench: Chore (Non-breaking Change: Doc updates, pkg upgrades, typos, etc..)
- [x] :nail_care: New Feature (Breaking/Non-breaking Change)

## Issue (if applicable)

n/a

## Risk

No risk

## Testing

Make sure the wallets are selectable, on most screen sizes.

## Screenshots (if applicable)
![Screen Shot 2022-06-23 at 4 03 44 PM](https://user-images.githubusercontent.com/89934888/175399895-726731db-e36b-4b54-9cbb-583caac494c9.png)

