### PR TITLE
bug: fix banner padding

### DIFF
--- a/src/components/Layout/Header/Header.tsx
+++ b/src/components/Layout/Header/Header.tsx
@@ -69,8 +69,8 @@ export const Header = () => {
           <Box
             bg='blue.500'
             width='full'
-            paddingTop='calc(1rem + env(safe-area-inset-top))'
-            paddingBottom={{ base: '1rem', md: 0 }}
+            paddingTop={{ base: 'calc(0.5rem + env(safe-area-inset-top))', md: 0 }}
+            paddingBottom={{ base: '0.5rem', md: 0 }}
             minHeight='2.5rem'
             fontSize={{ base: 'sm', md: 'md' }}
             as='button'


### PR DESCRIPTION
## Description

Adjust padding to only show up on mobile for the connect banner

## Notice

<!-- Before submitting a pull request, please make sure you have answered the following: -->

- [x] Have you followed the guidelines in our [Contributing]('https://github.com/shapeshift/web/CONTRIBUTING.md) guide?
- [x] Have you checked to ensure there aren't other open [Pull Requests](https://github.com/shapeshift/web/pulls) for the same update/change?

## Pull Request Type

- [x] :bug: Bug fix (Non-breaking Change: Fixes an issue)
- [ ] :hammer_and_wrench: Chore (Non-breaking Change: Doc updates, pkg upgrades, typos, etc..)
- [ ] :nail_care: New Feature (Breaking/Non-breaking Change)

## Issue (if applicable)

<!-----------------------------------------------------------------------------
If applicable, please link to the github issue and put `closes #XXXX` in your comment to auto-close the issue that your PR fixes.
------------------------------------------------------------------------------>

## Risk

no risk

## Testing

make sure the padding looks correct on desktop and mobile

## Screenshots (if applicable)
