### PR TITLE
feat(Cypress): add Apple Silicon support & use v4 CI action

### DIFF
--- a/.github/workflows/bootstrap.yml
+++ b/.github/workflows/bootstrap.yml
@@ -47,7 +47,7 @@ jobs:
             ${{ runner.os }}-node-modules-${{ github.ref }}-
 
       - name: Install Cypress & Build Project
-        uses: cypress-io/github-action@v3
+        uses: cypress-io/github-action@v4
         with:
           # Disable running of tests within install job
           runTests: false

--- a/.github/workflows/pr-cypress.yml
+++ b/.github/workflows/pr-cypress.yml
@@ -97,7 +97,7 @@ jobs:
       # closer reflect Github runner resources.
       # @see https://docs.github.com/en/actions/using-github-hosted-runners/about-github-hosted-runners#supported-runners-and-hardware-resources
       - name: Cypress Run
-        uses: cypress-io/github-action@v3
+        uses: cypress-io/github-action@v4
         with:
           record: true
           start: yarn dev:silent

--- a/package.json
+++ b/package.json
@@ -215,7 +215,7 @@
     "@types/redux-logger": "^3.0.9",
     "@types/ssri": "^7.1.1",
     "circular-dependency-plugin": "^5.2.2",
-    "cypress": "10.1.0",
+    "cypress": "10.2.0",
     "eslint-config-prettier": "^8.3.0",
     "eslint-plugin-cypress": "^2.12.1",
     "eslint-plugin-prettier": "^4.0.0",

--- a/yarn.lock
+++ b/yarn.lock
@@ -9523,10 +9523,10 @@ cyclist@^1.0.1:
   resolved "https://registry.yarnpkg.com/cyclist/-/cyclist-1.0.1.tgz#596e9698fd0c80e12038c2b82d6eb1b35b6224d9"
   integrity sha1-WW6WmP0MgOEgOMK4LW6xs1tiJNk=
 
-cypress@10.1.0:
-  version "10.1.0"
-  resolved "https://registry.yarnpkg.com/cypress/-/cypress-10.1.0.tgz#6514a26c721822a02bc194e9a7f72c3142aea174"
-  integrity sha512-aQ4JVZVib4Xd9FZW8IRZfKelUvqF4y5A+oUbNvn8TlsBmEfIg3m5Xd6Mt6PVU/jHiVJ9Psl905B3ZPnrDcmyuQ==
+cypress@10.2.0:
+  version "10.2.0"
+  resolved "https://registry.yarnpkg.com/cypress/-/cypress-10.2.0.tgz#ca078abfceb13be2a33cbba6e0e80ded770f542a"
+  integrity sha512-+i9lY5ENlfi2mJwsggzR+XASOIgMd7S/Gd3/13NCpv596n3YSplMAueBTIxNLcxDpTcIksp+9pM3UaDrJDpFqA==
   dependencies:
     "@cypress/request" "^2.88.10"
     "@cypress/xvfb" "^1.2.4"


### PR DESCRIPTION
## Description

- Use V4 Cypress action to better handle Cypress 10 in our CI pipeline: https://github.com/cypress-io/github-action/releases
- Minor bump Cypress package to 10.2.0, which adds native support for Apple Silicon - running Cypress locally is now super quick on supported machines 🚀 

## Notice

<!-- Before submitting a pull request, please make sure you have answered the following: -->

- [x] Have you followed the guidelines in our [Contributing]('https://github.com/shapeshift/web/CONTRIBUTING.md) guide?
- [x] Have you checked to ensure there aren't other open [Pull Requests](https://github.com/shapeshift/web/pulls) for the same update/change?

## Pull Request Type

- [ ] :bug: Bug fix (Non-breaking Change: Fixes an issue)
- [ ] :hammer_and_wrench: Chore (Non-breaking Change: Doc updates, pkg upgrades, typos, etc..)
- [x] :nail_care: New Feature (Breaking/Non-breaking Change)

## Issue (if applicable)

N/A

## Risk

Minimal, as changes only affect CI/Cypress.

## Testing

- CI should pass
- `yarn test:cypress` should work as expected (and be significantly faster if you're on an M1/M2 machine!)

## Screenshots (if applicable)

N/A