### PR TITLE
feat: bump @shapeshiftoss/market-service to latest

### DIFF
--- a/package.json
+++ b/package.json
@@ -103,7 +103,7 @@
     "@shapeshiftoss/investor-foxy": "^4.0.2",
     "@shapeshiftoss/investor-yearn": "^4.0.2",
     "@shapeshiftoss/logger": "^1.1.2",
-    "@shapeshiftoss/market-service": "^6.3.0",
+    "@shapeshiftoss/market-service": "^6.4.0",
     "@shapeshiftoss/swapper": "^7.6.0",
     "@shapeshiftoss/types": "^6.2.0",
     "@shapeshiftoss/unchained-client": "^9.0.1",

--- a/yarn.lock
+++ b/yarn.lock
@@ -4012,10 +4012,10 @@
   resolved "https://registry.yarnpkg.com/@shapeshiftoss/logger/-/logger-1.1.2.tgz#abbcc087387823448f8ea404722aab44048460a2"
   integrity sha512-6P3lM5aCjQse1NoPMgniXJvz0ccEcBisyHmu+q45eyStD7qap3S953esc+l9e9cjWGNuO48+97tQh8tkfY0Wsg==
 
-"@shapeshiftoss/market-service@^6.3.0":
-  version "6.3.0"
-  resolved "https://registry.yarnpkg.com/@shapeshiftoss/market-service/-/market-service-6.3.0.tgz#5c025fab9f352c0512f6bdec3f35a7ebb650e206"
-  integrity sha512-7J8+/h2sU7jJB8e49uABSQPOxtd577VOlIXnx9dPlkc0J4prMzgo/+E/pVz5UdzO6IrPL8HhW0Z77mmb0kkoKw==
+"@shapeshiftoss/market-service@^6.4.0":
+  version "6.4.0"
+  resolved "https://registry.yarnpkg.com/@shapeshiftoss/market-service/-/market-service-6.4.0.tgz#6f6b929bf4cddb863118a571b3aad7755b72f26a"
+  integrity sha512-lcpVhsC3dOYqcWIavMh5Aznx6Jc3vCuGVqO5LVaLNgHSEFbJqwvi+dpoBpz216BVX5NXsH0r68530rLD2M79uA==
   dependencies:
     "@ethersproject/providers" "^5.5.3"
     "@yfi/sdk" "^1.0.30"


### PR DESCRIPTION
## Description

This bumps `@shapeshiftoss/market-service` to v6.4.0 and fixes the discrepancy in FOX/FOXy market data.

Release notes:
https://github.com/shapeshift/lib/releases/tag/%40shapeshiftoss%2Fmarket-service-v6.4.0

## Notice

<!-- Before submitting a pull request, please make sure you have answered the following: -->

- [x] Have you followed the guidelines in our [Contributing]('https://github.com/shapeshift/web/CONTRIBUTING.md) guide?
- [x] Have you checked to ensure there aren't other open [Pull Requests](https://github.com/shapeshift/web/pulls) for the same update/change?

## Pull Request Type

- [ ] :bug: Bug fix (Non-breaking Change: Fixes an issue)
- [ ] :hammer_and_wrench: Chore (Non-breaking Change: Doc updates, pkg upgrades, typos, etc..)
- [x] :nail_care: New Feature (Breaking/Non-breaking Change)

## Issue (if applicable)

closes #2024

## Risk

None. This uses FOX market data for FOXy, if there is any regression, this would mean we have bigger problems in getting Coingecko market data for ERC20s.

## Testing

- FOX and FOXy price charts should show the same values
- FOXy market data data for price and day change should be the same for FOX and FOXy in accounts/assets pages as well as in FOX page

## Screenshots (if applicable)

<img width="1268" alt="image" src="https://user-images.githubusercontent.com/17035424/176276483-442c4953-844a-4933-b521-c10c2b98af0f.png">
<img width="1259" alt="image" src="https://user-images.githubusercontent.com/17035424/176276572-58d240d1-526a-4014-837f-42a1a819ff49.png">
