### PR TITLE
fix: remove validateDOMNesting foxPage errors

### DIFF
--- a/src/plugins/foxPage/components/MainOpportunity.tsx
+++ b/src/plugins/foxPage/components/MainOpportunity.tsx
@@ -57,9 +57,9 @@ export const MainOpportunity = ({
           <Box>
             <Text translation='plugins.foxPage.currentApy' color='gray.500' mb={1} />
             <Skeleton isLoaded={Boolean(apy)}>
-              <CText color='green.400' fontSize={'xl'}>
+              <Box color='green.400' fontSize={'xl'}>
                 <Amount.Percent value={apy} />
-              </CText>
+              </Box>
             </Skeleton>
           </Box>
           <Box>

--- a/src/plugins/foxPage/components/OtherOpportunities/FoxOtherOpportunityPanel.tsx
+++ b/src/plugins/foxPage/components/OtherOpportunities/FoxOtherOpportunityPanel.tsx
@@ -84,14 +84,14 @@ export const FoxOtherOpportunityPanel: React.FC<FoxOtherOpportunityPanelProps> =
             <Skeleton isLoaded={opportunity.isLoaded ? true : false} textAlign='center'>
               <Box>
                 <Text translation='plugins.foxPage.currentApy' color='gray.500' mb={1} />
-                <CText
+                <Box
                   color={opportunity.apy ? 'green.400' : undefined}
                   fontSize={'xl'}
                   fontWeight='semibold'
                   lineHeight='1'
                 >
                   {opportunity.apy ? <Amount.Percent value={opportunity.apy} /> : '--'}
-                </CText>
+                </Box>
               </Box>
             </Skeleton>
             <Box alignSelf='center' display={{ base: 'none', sm: 'block' }}>


### PR DESCRIPTION
## Description

This PR removes the console errors at `validateDOMNesting` on the Fox Page:

```
Warning: validateDOMNesting(...): <p> cannot appear as a descendant of <p>.
```

## Notice

<!-- Before submitting a pull request, please make sure you have answered the following: -->

- [x] Have you followed the guidelines in our [Contributing]('https://github.com/shapeshift/web/CONTRIBUTING.md) guide?
- [x] Have you checked to ensure there aren't other open [Pull Requests](https://github.com/shapeshift/web/pulls) for the same update/change?

## Pull Request Type

- [x] :bug: Bug fix (Non-breaking Change: Fixes an issue)
- [ ] :hammer_and_wrench: Chore (Non-breaking Change: Doc updates, pkg upgrades, typos, etc..)
- [ ] :nail_care: New Feature (Breaking/Non-breaking Change)

## Issue (if applicable)

N/A

## Risk

None, this is just semantic and makes the W3C validator as well as your browser very happy

## Testing

- FoxPage main/other opportunities should show no visual regressions

## Screenshots (if applicable)
