### PR TITLE
feat: localized asset descriptions

### DIFF
--- a/package.json
+++ b/package.json
@@ -86,7 +86,7 @@
     "@formatjs/intl-pluralrules": "^5.0.2",
     "@metamask/detect-provider": "^1.2.0",
     "@reduxjs/toolkit": "^1.8.0",
-    "@shapeshiftoss/asset-service": "^6.2.2",
+    "@shapeshiftoss/asset-service": "^6.3.0",
     "@shapeshiftoss/caip": "^6.2.1",
     "@shapeshiftoss/chain-adapters": "^7.2.1",
     "@shapeshiftoss/errors": "^1.1.2",

--- a/src/components/AssetHeader/AssetDescription.tsx
+++ b/src/components/AssetHeader/AssetDescription.tsx
@@ -7,7 +7,7 @@ import { ParsedHtml } from 'components/ParsedHtml/ParsedHtml'
 import { SanitizedHtml } from 'components/SanitizedHtml/SanitizedHtml'
 import { markdownLinkToHTML } from 'lib/utils'
 import { useGetAssetDescriptionQuery } from 'state/slices/assetsSlice/assetsSlice'
-import { selectAssetById } from 'state/slices/selectors'
+import { selectAssetById, selectSelectedLocale } from 'state/slices/selectors'
 import { useAppSelector } from 'state/store'
 
 type AssetDescriptionProps = {
@@ -24,7 +24,8 @@ export const AssetDescription = ({ assetId }: AssetDescriptionProps) => {
   const handleToggle = () => setShowDescription(!showDescription)
   const asset = useAppSelector(state => selectAssetById(state, assetId))
   const { name, description, isTrustedDescription } = asset || {}
-  const query = useGetAssetDescriptionQuery(assetId)
+  const selectedLocale = useAppSelector(selectSelectedLocale)
+  const query = useGetAssetDescriptionQuery({ assetId, selectedLocale })
   const isLoaded = !query.isLoading
 
   // Collapse about section any time description changes

--- a/src/components/StakingVaults/AssetTeaser.tsx
+++ b/src/components/StakingVaults/AssetTeaser.tsx
@@ -17,13 +17,17 @@ import { Link } from 'react-router-dom'
 import { AssetIcon } from 'components/AssetIcon'
 import { RawText, Text } from 'components/Text'
 import { useGetAssetDescriptionQuery } from 'state/slices/assetsSlice/assetsSlice'
-import { selectAssetById } from 'state/slices/selectors'
+import { selectAssetById, selectSelectedLocale } from 'state/slices/selectors'
 import { useAppSelector } from 'state/store'
 
 export const AssetTeaser = ({ assetId }: { assetId: AssetId }) => {
   const asset = useAppSelector(state => selectAssetById(state, assetId))
   const { description, icon, name } = asset || {}
-  const { isLoading } = useGetAssetDescriptionQuery(assetId, { skip: !!description })
+  const selectedLocale = useAppSelector(selectSelectedLocale)
+  const { isLoading } = useGetAssetDescriptionQuery(
+    { assetId, selectedLocale },
+    { skip: !!description },
+  )
   const url = useMemo(() => (assetId ? `/assets/${assetId}` : ''), [assetId])
   return (
     <Portal>

--- a/src/plugins/foxPage/foxPage.tsx
+++ b/src/plugins/foxPage/foxPage.tsx
@@ -31,7 +31,7 @@ import {
   selectTotalCryptoBalanceWithDelegations,
   selectTotalFiatBalanceWithDelegations,
 } from 'state/slices/portfolioSlice/selectors'
-import { selectAssetById } from 'state/slices/selectors'
+import { selectAssetById, selectSelectedLocale } from 'state/slices/selectors'
 import { selectFirstAccountSpecifierByChainId } from 'state/slices/selectors'
 import { useAppSelector } from 'state/store'
 import { breakpoints } from 'theme/theme'
@@ -131,8 +131,13 @@ export const FoxPage = () => {
     selectedAsset?.assetId === FOX_ASSET_ID
       ? FOX_DESCRIPTION // FOX has a custom description, other assets can use the asset-service one
       : selectedAsset?.description
+
+  const selectedLocale = useAppSelector(selectSelectedLocale)
   // TODO(gomes): Export a similar RTK select() query, consumed to determine wallet + staking balance loaded
-  const getAssetDescriptionQuery = useGetAssetDescriptionQuery(selectedAsset?.assetId)
+  const getAssetDescriptionQuery = useGetAssetDescriptionQuery({
+    assetId: selectedAsset?.assetId,
+    selectedLocale,
+  })
   const isAssetDescriptionLoaded = !getAssetDescriptionQuery.isLoading
 
   const handleTabClick = (assetId: AssetId) => {

--- a/src/state/slices/assetsSlice/assetsSlice.ts
+++ b/src/state/slices/assetsSlice/assetsSlice.ts
@@ -6,6 +6,7 @@ import { Asset } from '@shapeshiftoss/types'
 import cloneDeep from 'lodash/cloneDeep'
 import { ReduxState } from 'state/reducer'
 import { selectFeatureFlags } from 'state/slices/preferencesSlice/selectors'
+import { selectSelectedLocale } from 'state/slices/selectors'
 
 let service: AssetService | undefined = undefined
 
@@ -81,10 +82,11 @@ export const assetApi = createApi({
       queryFn: async (assetId, { getState }) => {
         const service = await getAssetService()
         // limitation of redux tookit https://redux-toolkit.js.org/rtk-query/api/createApi#queryfn
-        const { byId: byIdOriginal, ids } = (getState() as any).assets as AssetsState
+        const { byId: byIdOriginal, ids } = (getState() as ReduxState).assets as AssetsState
         const byId = cloneDeep(byIdOriginal)
+        const locale = selectSelectedLocale(getState() as ReduxState)
         try {
-          const { description, isTrusted } = await service.description(assetId)
+          const { description, isTrusted } = await service.description(assetId, locale)
           byId[assetId].description = description
           byId[assetId].isTrustedDescription = isTrusted
           const data = { byId, ids }

--- a/src/state/slices/assetsSlice/assetsSlice.ts
+++ b/src/state/slices/assetsSlice/assetsSlice.ts
@@ -81,7 +81,7 @@ export const assetApi = createApi({
       queryFn: async ({ assetId, selectedLocale }, { getState }) => {
         const service = await getAssetService()
         // limitation of redux tookit https://redux-toolkit.js.org/rtk-query/api/createApi#queryfn
-        const { byId: byIdOriginal, ids } = (getState() as ReduxState).assets as AssetsState
+        const { byId: byIdOriginal, ids } = (getState() as any).assets as AssetsState
         const byId = cloneDeep(byIdOriginal)
         try {
           const { description, isTrusted } = await service.description(assetId, selectedLocale)

--- a/src/state/slices/assetsSlice/assetsSlice.ts
+++ b/src/state/slices/assetsSlice/assetsSlice.ts
@@ -6,7 +6,6 @@ import { Asset } from '@shapeshiftoss/types'
 import cloneDeep from 'lodash/cloneDeep'
 import { ReduxState } from 'state/reducer'
 import { selectFeatureFlags } from 'state/slices/preferencesSlice/selectors'
-import { selectSelectedLocale } from 'state/slices/selectors'
 
 let service: AssetService | undefined = undefined
 
@@ -78,15 +77,14 @@ export const assetApi = createApi({
         data && dispatch(assets.actions.setAssets(data))
       },
     }),
-    getAssetDescription: build.query<AssetsState, AssetId>({
-      queryFn: async (assetId, { getState }) => {
+    getAssetDescription: build.query<AssetsState, { assetId: AssetId; selectedLocale: string }>({
+      queryFn: async ({ assetId, selectedLocale }, { getState }) => {
         const service = await getAssetService()
         // limitation of redux tookit https://redux-toolkit.js.org/rtk-query/api/createApi#queryfn
         const { byId: byIdOriginal, ids } = (getState() as ReduxState).assets as AssetsState
         const byId = cloneDeep(byIdOriginal)
-        const locale = selectSelectedLocale(getState() as ReduxState)
         try {
-          const { description, isTrusted } = await service.description(assetId, locale)
+          const { description, isTrusted } = await service.description(assetId, selectedLocale)
           byId[assetId].description = description
           byId[assetId].isTrustedDescription = isTrusted
           const data = { byId, ids }

--- a/yarn.lock
+++ b/yarn.lock
@@ -3737,15 +3737,16 @@
   resolved "https://registry.yarnpkg.com/@rushstack/eslint-patch/-/eslint-patch-1.1.0.tgz#7f698254aadf921e48dda8c0a6b304026b8a9323"
   integrity sha512-JLo+Y592QzIE+q7Dl2pMUtt4q8SKYI5jDrZxrozEQxnGVOyYE+GWK9eLkwTaeN9DDctlaRAQ3TBmzZ1qdLE30A==
 
-"@shapeshiftoss/asset-service@^6.2.2":
-  version "6.2.2"
-  resolved "https://registry.yarnpkg.com/@shapeshiftoss/asset-service/-/asset-service-6.2.2.tgz#692450e5aff2d7d0c8e2243c2aaabcdb1909b4ee"
-  integrity sha512-+Zftf6GsTUAfh1rya9L45Kfd2KzR9K1Sn9+HLhBeyghe16uixJYjQ/CoqT3tlRFvEaFpEZvULmPsCgyY1gfNaA==
+"@shapeshiftoss/asset-service@^6.3.0":
+  version "6.3.0"
+  resolved "https://registry.yarnpkg.com/@shapeshiftoss/asset-service/-/asset-service-6.3.0.tgz#3c6d04b87fcdd36d628d83cb2db3093f3fb3ed50"
+  integrity sha512-tL4oThqnRVqox2ZRdtoreVf1C4f4AAOkRWfZfZwF31EBDN3brIkI52RjzNb6RViKwVSuIMe2tEFgXVQkKfXdwA==
   dependencies:
     axios "^0.26.1"
     identicon.js "^2.3.3"
     js-pixel-fonts "^1.5.0"
     lodash "^4.17.21"
+    node-polyglot "^2.4.2"
 
 "@shapeshiftoss/bitcoinjs-lib@5.2.0-shapeshift.2":
   version "5.2.0-shapeshift.2"
@@ -15849,7 +15850,7 @@ node-libs-browser@^2.2.1:
     util "^0.11.0"
     vm-browserify "^1.0.1"
 
-node-polyglot@^2.4.0:
+node-polyglot@^2.4.0, node-polyglot@^2.4.2:
   version "2.4.2"
   resolved "https://registry.yarnpkg.com/node-polyglot/-/node-polyglot-2.4.2.tgz#e4876e6710b70dc00b1351a9a68de4af47a5d61d"
   integrity sha512-AgTVpQ32BQ5XPI+tFHJ9bCYxWwSLvtmEodX8ooftFhEuyCgBG6ijWulIVb7pH3THigtgvc9uLiPn0IO51KHpkg==


### PR DESCRIPTION
## Description

This uses localized asset descriptions from Coingecko / overriden descriptions.

Since the overriden localized descriptions have been duplicated from the English ones, and the Coingecko ones fallback to English if the localized description is an empty string, this should show no user changes in most cases, see:

https://api.coingecko.com/api/v3/coins/ethereum

## Notice

<!-- Before submitting a pull request, please make sure you have answered the following: -->

- [x] Have you followed the guidelines in our [Contributing]('https://github.com/shapeshift/web/CONTRIBUTING.md) guide?
- [x] Have you checked to ensure there aren't other open [Pull Requests](https://github.com/shapeshift/web/pulls) for the same update/change?

## Pull Request Type

- [ ] :bug: Bug fix (Non-breaking Change: Fixes an issue)
- [ ] :hammer_and_wrench: Chore (Non-breaking Change: Doc updates, pkg upgrades, typos, etc..)
- [x] :nail_care: New Feature (Breaking/Non-breaking Change)

## Issue (if applicable)

<!-----------------------------------------------------------------------------
If applicable, please link to the github issue and put `closes #XXXX` in your comment to auto-close the issue that your PR fixes.
------------------------------------------------------------------------------>

## Risk

This will fallback to English if the Coingecko/overriden description for the user selected locale is empty, so from a logic perspective it *should* carry no risks but asset descriptions should still be regression-tested across the app.

## Testing

- Go to Ethereum asset page with Chinese language set in preferences
- The asset description should show `Ethereum（以太坊）是一个平台和一种编程语…thereum（以太坊）的价格上涨超过50倍`
- Switch to Korean in preferences
- The asset description should show `이더리움(Ethereum/ETH)은 블록체인…정비로봇의 집을 청소하는 것도 가능해진다.`
- English and other languages should show no regressions

## Screenshots (if applicable)

<img width="399" alt="image" src="https://user-images.githubusercontent.com/17035424/176732027-f4ec837b-9b9d-44d0-aed9-0618aae9110d.png">
<img width="402" alt="image" src="https://user-images.githubusercontent.com/17035424/176732105-160d648e-fee7-46d5-890a-16afbb5a72af.png">