### PR TITLE
fix: get rate on refresh

### DIFF
--- a/src/components/Trade/hooks/useSwapper/useSwapper.ts
+++ b/src/components/Trade/hooks/useSwapper/useSwapper.ts
@@ -274,26 +274,22 @@ export const useSwapper = () => {
     }, debounceTime),
   )
 
-  const updateQuote = async ({
-    amount,
-    sellAsset,
-    buyAsset,
-    feeAsset,
-    action,
-    forceQuote,
-  }: GetQuoteInput) => {
-    if (!wallet) return
-    if (!forceQuote && bnOrZero(amount).isZero()) return
-    setValue('quote', undefined)
-    await updateQuoteDebounced.current({
-      amount,
-      feeAsset,
-      sellAsset,
-      action,
-      buyAsset,
-      wallet,
-    })
-  }
+  const updateQuote = useCallback(
+    async ({ amount, sellAsset, buyAsset, feeAsset, action, forceQuote }: GetQuoteInput) => {
+      if (!wallet) return
+      if (!forceQuote && bnOrZero(amount).isZero()) return
+      setValue('quote', undefined)
+      await updateQuoteDebounced.current({
+        amount,
+        feeAsset,
+        sellAsset,
+        action,
+        buyAsset,
+        wallet,
+      })
+    },
+    [setValue, wallet],
+  )
 
   const setFees = async (
     trade: Trade<KnownChainIds> | TradeQuote<KnownChainIds>,

--- a/src/components/Trade/hooks/useTradeRoutes/useTradeRoutes.test.tsx
+++ b/src/components/Trade/hooks/useTradeRoutes/useTradeRoutes.test.tsx
@@ -15,6 +15,11 @@ jest.mock('react-router-dom', () => ({
 jest.mock('lib/web3-instance')
 jest.mock('react-hook-form')
 jest.mock('../useSwapper/useSwapper')
+jest.mock('hooks/useWallet/useWallet', () => ({
+  useWallet: () => ({
+    state: { wallet: {} },
+  }),
+}))
 jest.mock('@shapeshiftoss/swapper')
 jest.mock('state/slices/selectors', () => ({
   selectAssets: () => ({

--- a/src/components/Trade/hooks/useTradeRoutes/useTradeRoutes.ts
+++ b/src/components/Trade/hooks/useTradeRoutes/useTradeRoutes.ts
@@ -6,6 +6,7 @@ import { useFormContext } from 'react-hook-form'
 import { useSelector } from 'react-redux'
 import { useHistory } from 'react-router-dom'
 import { TradeAmountInputField, TradeRoutePaths, TradeState } from 'components/Trade/types'
+import { useWallet } from 'hooks/useWallet/useWallet'
 import { bnOrZero } from 'lib/bignumber/bignumber'
 import { selectAssetById, selectAssets } from 'state/slices/selectors'
 import { useAppSelector } from 'state/store'
@@ -26,6 +27,9 @@ export const useTradeRoutes = (
   const feeAssetId = chainIdToFeeAssetId(sellTradeAsset?.asset?.chainId ?? 'eip155:1')
   const feeAsset = useAppSelector(state => selectAssetById(state, feeAssetId))
   const assets = useSelector(selectAssets)
+  const {
+    state: { wallet },
+  } = useWallet()
 
   const setDefaultAssets = useCallback(async () => {
     // wait for assets to be loaded
@@ -81,7 +85,7 @@ export const useTradeRoutes = (
 
   useEffect(() => {
     setDefaultAssets()
-  }, [assets, routeBuyAssetId]) // eslint-disable-line react-hooks/exhaustive-deps
+  }, [assets, routeBuyAssetId, wallet, setDefaultAssets])
 
   const handleSellClick = useCallback(
     async (asset: Asset) => {


### PR DESCRIPTION
## Description

Whenever the Dashboard is refreshed a race condition with `useWallet` prevents a quote from loading, and we end up with `Searching for best rate...` until the swapper state is changed by the user.

<img width="399" alt="Screen Shot 2022-07-05 at 9 47 48 am" src="https://user-images.githubusercontent.com/97164662/177230774-02cfa9d3-360d-4c74-92bb-0f0a08bee6ff.png">

This PR fixes the bug, and wraps `updateQuote` in `useCallback` as a performance optimisation.

## Notice

<!-- Before submitting a pull request, please make sure you have answered the following: -->

- [x] Have you followed the guidelines in our [Contributing]('https://github.com/shapeshift/web/CONTRIBUTING.md) guide?
- [x] Have you checked to ensure there aren't other open [Pull Requests](https://github.com/shapeshift/web/pulls) for the same update/change?

## Pull Request Type

- [x] :bug: Bug fix (Non-breaking Change: Fixes an issue)
- [ ] :hammer_and_wrench: Chore (Non-breaking Change: Doc updates, pkg upgrades, typos, etc..)
- [ ] :nail_care: New Feature (Breaking/Non-breaking Change)

## Issue (if applicable)

N/A

## Risk

Minimal - a small change to the swapper.

## Testing

- When refreshing the dashboard we should get a quote for the trade assets
- The swapper should have no regressions

## Screenshots (if applicable)

<img width="400" alt="Screen Shot 2022-07-05 at 10 39 49 am" src="https://user-images.githubusercontent.com/97164662/177230903-8bd494cc-9835-4923-af1d-0dbcfeeca492.png">