### PR TITLE
fix: include undelegations in total fiat balance

### DIFF
--- a/src/pages/Dashboard/Portfolio.tsx
+++ b/src/pages/Dashboard/Portfolio.tsx
@@ -10,7 +10,7 @@ import { DEFAULT_HISTORY_TIMEFRAME } from 'context/AppProvider/AppContext'
 import {
   selectPortfolioAssetIds,
   selectPortfolioLoading,
-  selectPortfolioTotalFiatBalanceWithDelegations,
+  selectPortfolioTotalFiatBalanceWithStakingData,
 } from 'state/slices/selectors'
 
 import { AccountTable } from './components/AccountList/AccountTable'
@@ -20,7 +20,7 @@ export const Portfolio = () => {
   const [percentChange, setPercentChange] = useState(0)
 
   const assetIds = useSelector(selectPortfolioAssetIds)
-  const totalBalance = useSelector(selectPortfolioTotalFiatBalanceWithDelegations)
+  const totalBalance = useSelector(selectPortfolioTotalFiatBalanceWithStakingData)
 
   const loading = useSelector(selectPortfolioLoading)
   const isLoaded = !loading

--- a/src/pages/Defi/views/Overview.tsx
+++ b/src/pages/Defi/views/Overview.tsx
@@ -2,7 +2,7 @@ import { Box, Divider, Heading, Stack } from '@chakra-ui/react'
 import { useTranslate } from 'react-polyglot'
 import { useSelector } from 'react-redux'
 import { Main } from 'components/Layout/Main'
-import { selectPortfolioTotalFiatBalanceWithDelegations } from 'state/slices/selectors'
+import { selectPortfolioTotalFiatBalanceWithStakingData } from 'state/slices/selectors'
 
 import { OpportunityCardList } from '../components/OpportunityCardList'
 import { OverviewHeader } from '../components/OverviewHeader'
@@ -19,7 +19,7 @@ const DefiHeader = () => {
 
 export const Overview = () => {
   const balances = useEarnBalances()
-  const walletBalance = useSelector(selectPortfolioTotalFiatBalanceWithDelegations)
+  const walletBalance = useSelector(selectPortfolioTotalFiatBalanceWithStakingData)
   return (
     <Main titleComponent={<DefiHeader />}>
       <OverviewHeader earnBalance={balances} walletBalance={walletBalance} />


### PR DESCRIPTION
## Description

This includes undelegations in the derived total fiat balance (which includes staking data).

The total balance is currently incorrect, as it is not accounting for undelegations. 
Accidentally fixes the DeFi section values: the fact that the DeFi wallet balance is negative / net worth is incorrect is actually a consequence of the incorrect total fiat balance, rather than a bug in itself.

## Notice

<!-- Before submitting a pull request, please make sure you have answered the following: -->

- [x] Have you followed the guidelines in our [Contributing]('https://github.com/shapeshift/web/CONTRIBUTING.md) guide?
- [x] Have you checked to ensure there aren't other open [Pull Requests](https://github.com/shapeshift/web/pulls) for the same update/change?

## Pull Request Type

- [x] :bug: Bug fix (Non-breaking Change: Fixes an issue)
- [ ] :hammer_and_wrench: Chore (Non-breaking Change: Doc updates, pkg upgrades, typos, etc..)
- [ ] :nail_care: New Feature (Breaking/Non-breaking Change)

## Issue (if applicable)

- closes #2112

## Risk

Isolated to portfolio balances / DeFi overview, for wallets supporting IBC staking.

## Testing

- Undelegate some ATOM, so that wallet ((wallet fiat balance + delegated assets fiat balance) - undelegated assets fiat balance) is negative
- The DeFi section "Net worth" should show the total of wallet fiat balance + delegated assets fiat balance + undelegated assets fiat balance
- The DeFi section "Wallet Balance" shouldn't show a negative number
- The portfolio balance for ATOM should include the unstaked balance
- The aforementioned flow should work with both Osmosis flag on and off

## Screenshots (if applicable)

<img width="1314" alt="image" src="https://user-images.githubusercontent.com/17035424/177603374-6ab6e98c-6a20-462f-9400-fe9c56a4511f.png">

