### PR TITLE
feat: bump @shapeshiftoss/chain-adapters to 7.4.1

### DIFF
--- a/package.json
+++ b/package.json
@@ -88,7 +88,7 @@
     "@reduxjs/toolkit": "^1.8.0",
     "@shapeshiftoss/asset-service": "^6.3.0",
     "@shapeshiftoss/caip": "^6.2.1",
-    "@shapeshiftoss/chain-adapters": "^7.2.1",
+    "@shapeshiftoss/chain-adapters": "^7.4.1",
     "@shapeshiftoss/errors": "^1.1.2",
     "@shapeshiftoss/hdwallet-core": "^1.24.0",
     "@shapeshiftoss/hdwallet-keepkey": "^1.24.0",

--- a/yarn.lock
+++ b/yarn.lock
@@ -3780,10 +3780,10 @@
   resolved "https://registry.yarnpkg.com/@shapeshiftoss/caip/-/caip-6.2.1.tgz#16e8e0d016c986dfa0f34c88254b803cc16009d7"
   integrity sha512-37R2TJVIOc3NZcgfZQn62ORzAvTzQhaxUrLjlGkPxDzNISk5YbmbOdMR+XvxOS11XrBjRhvtaV7vp1qz/t6z7g==
 
-"@shapeshiftoss/chain-adapters@^7.2.1":
-  version "7.2.1"
-  resolved "https://registry.yarnpkg.com/@shapeshiftoss/chain-adapters/-/chain-adapters-7.2.1.tgz#503cf03a20182a59c42a869985d48b7f638256e7"
-  integrity sha512-i5ruMmuZjLWh8Tw0k0rVz3NJVoFCU4LNS1wKbscKhKzTmpDfkmT/SfliTs0AC8XuaBPKaBW709fHNafRKHMpRw==
+"@shapeshiftoss/chain-adapters@^7.4.1":
+  version "7.4.1"
+  resolved "https://registry.yarnpkg.com/@shapeshiftoss/chain-adapters/-/chain-adapters-7.4.1.tgz#b2217dc4a05c4ef1a45364c8791ff65ddf872a8d"
+  integrity sha512-W3DGVhn4ib0bmCGlEADfSHuboiz3tCB9sr+XAS2cqojFmWSa+HtnG2LwkJYsaR8SxHH4FLioCu8yqaY+V3gmbw==
   dependencies:
     axios "^0.26.1"
     bech32 "^2.0.0"
@@ -3831,17 +3831,7 @@
     web-encoding "^1.1.0"
     wif "^2.0.6"
 
-"@shapeshiftoss/hdwallet-core@1.23.0", "@shapeshiftoss/hdwallet-core@latest":
-  version "1.23.0"
-  resolved "https://registry.yarnpkg.com/@shapeshiftoss/hdwallet-core/-/hdwallet-core-1.23.0.tgz#8e7552b684d9c4600381cf3131c9d304df4b169a"
-  integrity sha512-CP0ysBeyRMtjx1OTSj+EmuhYWeh3YGxrbobj7HZDYYl8kHyUseJTTQ3s42ezS1AfXkDf/YidKDxa7p6+v7/0sw==
-  dependencies:
-    eventemitter2 "^5.0.1"
-    lodash "^4.17.21"
-    rxjs "^6.4.0"
-    type-assertions "^1.1.0"
-
-"@shapeshiftoss/hdwallet-core@1.24.0", "@shapeshiftoss/hdwallet-core@^1.24.0":
+"@shapeshiftoss/hdwallet-core@1.24.0", "@shapeshiftoss/hdwallet-core@^1.24.0", "@shapeshiftoss/hdwallet-core@latest":
   version "1.24.0"
   resolved "https://registry.yarnpkg.com/@shapeshiftoss/hdwallet-core/-/hdwallet-core-1.24.0.tgz#3a3c1b527d885b062f55cc4802da8e5c2600236a"
   integrity sha512-2uL8hA9sQlNHNzZ73VjVskSjwI+YzyZ5w+wDqiftu1R7p7OEw7t0A375miLA0+tYQTMShGmzMosbErCBCPwYqg==


### PR DESCRIPTION
## Description

This bumps `@shapeshiftoss/chain-adapters` to latest.

Included releases:

https://github.com/shapeshift/lib/releases/tag/%40shapeshiftoss%2Fchain-adapters-v7.3.0
https://github.com/shapeshift/lib/releases/tag/%40shapeshiftoss%2Fchain-adapters-v7.4.0
https://github.com/shapeshift/lib/releases/tag/%40shapeshiftoss%2Fchain-adapters-v7.4.1

This:

- abstracts `EthereumChainAdapter` into `EVMBaseAdapter`
- adds `AvalancheChainAdapter`
- adds `getRpcUrl()` method to `EVMBaseAdapter`
- bumps the osmosis gas limit, which now broadcasts Osmosis unstake Txs successfully 

## Notice

<!-- Before submitting a pull request, please make sure you have answered the following: -->

- [x] Have you followed the guidelines in our [Contributing]('https://github.com/shapeshift/web/CONTRIBUTING.md) guide?
- [x] Have you checked to ensure there aren't other open [Pull Requests](https://github.com/shapeshift/web/pulls) for the same update/change?

## Pull Request Type

- [ ] :bug: Bug fix (Non-breaking Change: Fixes an issue)
- [ ] :hammer_and_wrench: Chore (Non-breaking Change: Doc updates, pkg upgrades, typos, etc..)
- [x] :nail_care: New Feature (Breaking/Non-breaking Change)

## Issue (if applicable)

N/A

## Risk

- Possible EthereumChainAdapter regressions

## Testing

- Ethereum features should still be working with no regressions

## Screenshots (if applicable)
