### PR TITLE
fix: handle avalanche feature flag for supported chains

### DIFF
--- a/package.json
+++ b/package.json
@@ -105,7 +105,7 @@
     "@shapeshiftoss/logger": "^1.1.2",
     "@shapeshiftoss/market-service": "^6.4.1",
     "@shapeshiftoss/swapper": "^7.8.1",
-    "@shapeshiftoss/types": "^6.2.0",
+    "@shapeshiftoss/types": "^6.3.0",
     "@shapeshiftoss/unchained-client": "^9.0.2",
     "@uniswap/sdk": "^3.0.3",
     "@unstoppabledomains/resolution": "^7.1.4",

--- a/src/context/AppProvider/AppContext.tsx
+++ b/src/context/AppProvider/AppContext.tsx
@@ -123,7 +123,7 @@ export const AppProvider = ({ children }: { children: React.ReactNode }) => {
 
         for (const chainId of supportedChains) {
           const adapter = chainAdapterManager.get(chainId)
-          if (!adapter) return
+          if (!adapter) continue
 
           switch (chainId) {
             case ethChainId: {

--- a/src/context/PluginProvider/PluginProvider.tsx
+++ b/src/context/PluginProvider/PluginProvider.tsx
@@ -129,18 +129,18 @@ export const PluginProvider = ({ children }: PluginProviderProps): JSX.Element =
 
     setRoutes(pluginRoutes)
 
-    const chainIdFilter: Array<string> = []
+    const omittedChainIds: Array<string> = []
 
     if (!featureFlags.Osmosis) {
-      chainIdFilter.push(KnownChainIds.OsmosisMainnet)
+      omittedChainIds.push(KnownChainIds.OsmosisMainnet)
     }
 
     if (!featureFlags.Avalanche) {
-      chainIdFilter.push(KnownChainIds.AvalancheMainnet)
+      omittedChainIds.push(KnownChainIds.AvalancheMainnet)
     }
 
     const _supportedChains = Object.values<ChainId>(KnownChainIds).filter(
-      chainId => !chainIdFilter.includes(chainId),
+      chainId => !omittedChainIds.includes(chainId),
     )
 
     moduleLogger.trace({ supportedChains: _supportedChains }, 'Setting supportedChains')

--- a/src/context/PluginProvider/PluginProvider.tsx
+++ b/src/context/PluginProvider/PluginProvider.tsx
@@ -128,11 +128,21 @@ export const PluginProvider = ({ children }: PluginProviderProps): JSX.Element =
     )
 
     setRoutes(pluginRoutes)
-    const knownChainIds = featureFlags.Osmosis
-      ? Object.values(KnownChainIds)
-      : Object.values(KnownChainIds).filter(chainId => chainId !== KnownChainIds.OsmosisMainnet)
 
-    const _supportedChains = Object.values(knownChainIds) as ChainId[]
+    const chainIdFilter: Array<string> = []
+
+    if (!featureFlags.Osmosis) {
+      chainIdFilter.push(KnownChainIds.OsmosisMainnet)
+    }
+
+    if (!featureFlags.Avalanche) {
+      chainIdFilter.push(KnownChainIds.AvalancheMainnet)
+    }
+
+    const _supportedChains = Object.values<ChainId>(KnownChainIds).filter(
+      chainId => !chainIdFilter.includes(chainId),
+    )
+
     moduleLogger.trace({ supportedChains: _supportedChains }, 'Setting supportedChains')
     setSupportedChains(_supportedChains)
   }, [chainAdapterManager, featureFlags, plugins, pluginManager])

--- a/yarn.lock
+++ b/yarn.lock
@@ -4039,10 +4039,10 @@
   resolved "https://registry.yarnpkg.com/@shapeshiftoss/types/-/types-3.1.3.tgz#26b1d626d2b342b107e2ea538b5aedb0bee896ab"
   integrity sha512-Nhrs8gQelmsFAQQHTEq8TS3wueBKqjBf0pX6VxOiIQyasordSHQT4Di6WQOL1NWhciYptJ2nHPbarmhKOD63Eg==
 
-"@shapeshiftoss/types@^6.2.0":
-  version "6.2.0"
-  resolved "https://registry.yarnpkg.com/@shapeshiftoss/types/-/types-6.2.0.tgz#305ce90537b9453462d5c36f2df8244f1e2a7da4"
-  integrity sha512-ORWtYWsyZBUrf4ZPc2wdPAs8zNVmb0xLU5W4Ol2K3lqmvcsuGjiwQF+IStazrE4444E7lrh18inveKF3wBIugg==
+"@shapeshiftoss/types@^6.3.0":
+  version "6.3.0"
+  resolved "https://registry.yarnpkg.com/@shapeshiftoss/types/-/types-6.3.0.tgz#4328ae23af12ad34e2dba7ea2f2f7b91426a218c"
+  integrity sha512-1P38a4MWA3r5ueR3szTN8Z3b/VjhZfPl8ha/kzeaU03yWR5PCn4nj/xThFB/v53ruQYLyQZcqokz6VHLCOmnDw==
 
 "@shapeshiftoss/unchained-client@^9.0.2":
   version "9.0.2"

--- a/yarn.lock
+++ b/yarn.lock
@@ -3831,17 +3831,7 @@
     web-encoding "^1.1.0"
     wif "^2.0.6"
 
-"@shapeshiftoss/hdwallet-core@1.23.0", "@shapeshiftoss/hdwallet-core@latest":
-  version "1.23.0"
-  resolved "https://registry.yarnpkg.com/@shapeshiftoss/hdwallet-core/-/hdwallet-core-1.23.0.tgz#8e7552b684d9c4600381cf3131c9d304df4b169a"
-  integrity sha512-CP0ysBeyRMtjx1OTSj+EmuhYWeh3YGxrbobj7HZDYYl8kHyUseJTTQ3s42ezS1AfXkDf/YidKDxa7p6+v7/0sw==
-  dependencies:
-    eventemitter2 "^5.0.1"
-    lodash "^4.17.21"
-    rxjs "^6.4.0"
-    type-assertions "^1.1.0"
-
-"@shapeshiftoss/hdwallet-core@1.24.0", "@shapeshiftoss/hdwallet-core@^1.24.0":
+"@shapeshiftoss/hdwallet-core@1.24.0", "@shapeshiftoss/hdwallet-core@^1.24.0", "@shapeshiftoss/hdwallet-core@latest":
   version "1.24.0"
   resolved "https://registry.yarnpkg.com/@shapeshiftoss/hdwallet-core/-/hdwallet-core-1.24.0.tgz#3a3c1b527d885b062f55cc4802da8e5c2600236a"
   integrity sha512-2uL8hA9sQlNHNzZ73VjVskSjwI+YzyZ5w+wDqiftu1R7p7OEw7t0A375miLA0+tYQTMShGmzMosbErCBCPwYqg==


### PR DESCRIPTION
## Description

- Honor avalanche feature flag when filtering `supportedChains` based on `KnownChainIds`
- Handle missing chain adapter more gracefully

## Notice

<!-- Before submitting a pull request, please make sure you have answered the following: -->

- [x] Have you followed the guidelines in our [Contributing]('https://github.com/shapeshift/web/CONTRIBUTING.md) guide?
- [x] Have you checked to ensure there aren't other open [Pull Requests](https://github.com/shapeshift/web/pulls) for the same update/change?

## Pull Request Type

- [x] :bug: Bug fix (Non-breaking Change: Fixes an issue)
- [ ] :hammer_and_wrench: Chore (Non-breaking Change: Doc updates, pkg upgrades, typos, etc..)
- [ ] :nail_care: New Feature (Breaking/Non-breaking Change)

## Issue (if applicable)

<!-----------------------------------------------------------------------------
If applicable, please link to the github issue and put `closes #XXXX` in your comment to auto-close the issue that your PR fixes.
------------------------------------------------------------------------------>

## Risk

Low

## Testing

Dashboard should now load against `@shapeshiftoss/typesv6.3.0`

## Screenshots (if applicable)
