### PR TITLE
feat(cosmos): maxApr -> apr

### DIFF
--- a/src/assets/translations/en/main.json
+++ b/src/assets/translations/en/main.json
@@ -155,7 +155,7 @@
         }
       },
       "getStarted": {
-        "header": "Stake your %{assetName} to earn up to %{maxApr}% APR*",
+        "header": "Stake your %{assetName} to earn %{apr}% APR*",
         "body": "Staking is the process of holding funds in a cryptocurrency wallet to support the operations of a blockchain network and, in return, holders are rewarded for their contribution.",
         "userProtectionInfo": "*Returns are estimated and fluctuate with market conditions.",
         "cta": {

--- a/src/assets/translations/es/main.json
+++ b/src/assets/translations/es/main.json
@@ -153,7 +153,7 @@
         }
       },
       "getStarted": {
-        "header": "Stake su %{assetName} para ganar hasta %{maxApr}% APR*",
+        "header": "Stake su %{assetName} para ganar %{apr}% APR*",
         "body": "El staking es el proceso de mantener fondos en una billetera de criptomonedas para respaldar las operaciones de una blockchain, a cambio, los titulares son recompensados por su contribución.",
         "userProtectionInfo": "*Los rendimientos son estimados y fluctúan con las condiciones del mercado.",
         "cta": {

--- a/src/assets/translations/fr/main.json
+++ b/src/assets/translations/fr/main.json
@@ -153,7 +153,7 @@
         }
       },
       "getStarted": {
-        "header": "Misez votre %{assetName} pour gagner jusqu'à %{maxApr}% d'APR*",
+        "header": "Misez votre %{assetName} pour gagner %{apr}% d'APR*",
         "body": "La mise est le processus consistant à détenir des fonds dans un porte-monnaie de crypto-monnaies pour soutenir les opérations d'un réseau blockchain et, en retour, les détenteurs sont récompensés pour leur contribution.",
         "userProtectionInfo": "*Les rendements sont estimés et fluctuent en fonction des conditions du marché.",
         "cta": {

--- a/src/assets/translations/id/main.json
+++ b/src/assets/translations/id/main.json
@@ -147,7 +147,7 @@
         }
       },
       "getStarted": {
-        "header": "Stake %{assetName} Anda untuk mendapatkan hingga %{maxApr}% APR*",
+        "header": "Stake %{assetName} Anda untuk mendapatkan %{apr}% APR*",
         "body": "Staking adalah proses menyimpan dana di dompet cryptocurrency untuk mendukung operasi jaringan blockchain dan, sebagai imbalannya, pemegang diberi imbalan atas kontribusi mereka.",
         "userProtectionInfo": "*Pengembalian diperkirakan dan berfluktuasi dengan kondisi pasar.",
         "cta": {
@@ -263,7 +263,7 @@
     },
     "viewOnChain": "Lihat di rantai",
     "getStarted": {
-      "header": "Stake %{assetName} Anda untuk mendapatkan hingga %{maxApr}% APR*",
+      "header": "Stake %{assetName} Anda untuk mendapatkan hingga %{apr}% APR*",
       "body": "Staking adalah proses menyimpan dana di dompet cryptocurrency untuk mendukung operasi jaringan blockchain dan, sebagai imbalannya, pemegang diberi imbalan atas kontribusi mereka..",
       "userProtectionInfo": "*Pengembalian diperkirakan dan berfluktuasi dengan kondisi pasar.",
       "cta": {

--- a/src/assets/translations/ko/main.json
+++ b/src/assets/translations/ko/main.json
@@ -148,7 +148,7 @@
         }
       },
       "getStarted": {
-        "header": "%{assetName} 스테이킹하여 최대 %{maxApr}% APR*을 받으세요.",
+        "header": "%{assetName} 스테이킹하여 최대 %{apr}% APR*을 받으세요.",
         "body": "스테이킹은 블록체인 네트워크 운영을 지원하기 위해 암호화폐 지갑에 자금을 보유하는 과정이며, 그 대가로 보유자는 기여에 대한 보상을 받습니다.",
         "userProtectionInfo": "*수익은 추정된 것으로 시장 상황에 따라 변동됩니다.",
         "cta": {

--- a/src/assets/translations/pt/main.json
+++ b/src/assets/translations/pt/main.json
@@ -153,7 +153,7 @@
         }
       },
       "getStarted": {
-        "header": "Deposite seu %{assetName} para ganhar até %{maxApr}% APR*",
+        "header": "Deposite seu %{assetName} para ganhar %{apr}% APR*",
         "body": "Staking é o processo de manter fundos em uma carteira de criptomoedas para apoiar as operações de uma rede blockchain e, em troca, os detentores são recompensados por sua contribuição.",
         "userProtectionInfo": "*Os retornos são estimados e variam de acordo com as condições de mercado.",
         "cta": {

--- a/src/assets/translations/zh/main.json
+++ b/src/assets/translations/zh/main.json
@@ -147,7 +147,7 @@
         }
       },
       "getStarted": {
-        "header": "质押您的 %{assetName} 最高可赚取 %{maxApr}% 年利率*",
+        "header": "质押您的 %{assetName} 最高可赚取 %{apr}% 年利率*",
         "body": "质押是在加密货币钱包中持有资金以支持区块链网络运营的过程，作为回报，质押者的贡献会得到回报。",
         "userProtectionInfo": "*回报率是预估的，会随着市场情况而波动。",
         "cta": {


### PR DESCRIPTION
## Description

This changes the static max APR to a dynamic one in the "Get Started" cosmos SDK (CosmosHub/Osmosis) component.
It also removes the "up to" terminology in all translations using the latin alphabet.

## Notice

<!-- Before submitting a pull request, please make sure you have answered the following: -->

- [x] Have you followed the guidelines in our [Contributing]('https://github.com/shapeshift/web/CONTRIBUTING.md) guide?
- [x] Have you checked to ensure there aren't other open [Pull Requests](https://github.com/shapeshift/web/pulls) for the same update/change?

## Pull Request Type

- [ ] :bug: Bug fix (Non-breaking Change: Fixes an issue)
- [ ] :hammer_and_wrench: Chore (Non-breaking Change: Doc updates, pkg upgrades, typos, etc..)
- [x] :nail_care: New Feature (Breaking/Non-breaking Change)

## Issue (if applicable)

closes https://github.com/shapeshift/web/issues/2102

## Risk

N/A

## Testing

- If there is no active ATOM staking for the current account, the "Get Started" component should show "Earn X APY" where X is the current chain APY, similar to e.g the ShapeShift Staking Opportunities default validator row
- If there is no active OSMO staking for the current account, the "Get Started" component should show "Earn X APY" where X is the current chain APY, similar to e.g the TaxiStake Staking Opportunities default validator row

## Screenshots (if applicable)

<img width="461" alt="image" src="https://user-images.githubusercontent.com/17035424/178024640-5d88ba1d-556b-4d80-96e8-21cee872de3b.png">
<img width="461" alt="image" src="https://user-images.githubusercontent.com/17035424/178024780-26ca6ba7-4e45-4556-b12d-852d8aed482f.png">