### PR TITLE
fix: reset trade amount to fiat amount when they toggle assets

### DIFF
--- a/src/components/Trade/hooks/useTradeRoutes/useTradeRoutes.ts
+++ b/src/components/Trade/hooks/useTradeRoutes/useTradeRoutes.ts
@@ -7,7 +7,6 @@ import { useSelector } from 'react-redux'
 import { useHistory } from 'react-router-dom'
 import { TradeAmountInputField, TradeRoutePaths, TradeState } from 'components/Trade/types'
 import { useWallet } from 'hooks/useWallet/useWallet'
-import { bnOrZero } from 'lib/bignumber/bignumber'
 import { selectAssetById, selectAssets } from 'state/slices/selectors'
 import { useAppSelector } from 'state/store'
 
@@ -115,13 +114,14 @@ export const useTradeRoutes = (
           setValue('buyAsset.asset', buyTradeAsset?.asset)
         }
         if (sellTradeAsset?.asset && buyTradeAsset?.asset) {
+          const fiatSellAmount = getValues('fiatSellAmount') ?? '0'
           await updateQuote({
             forceQuote: true,
-            amount: bnOrZero(sellTradeAsset.amount).toString(),
+            amount: fiatSellAmount,
             sellAsset: asset,
             buyAsset: buyTradeAsset.asset,
             feeAsset,
-            action: TradeAmountInputField.SELL,
+            action: TradeAmountInputField.FIAT,
           })
         }
       } catch (e) {
@@ -130,16 +130,7 @@ export const useTradeRoutes = (
         history.push(TradeRoutePaths.Input)
       }
     },
-    [
-      getValues,
-      sellTradeAsset?.asset,
-      sellTradeAsset?.amount,
-      buyTradeAsset?.asset,
-      setValue,
-      updateQuote,
-      feeAsset,
-      history,
-    ],
+    [getValues, sellTradeAsset, buyTradeAsset, setValue, updateQuote, feeAsset, history],
   )
 
   const handleBuyClick = useCallback(
@@ -158,13 +149,14 @@ export const useTradeRoutes = (
         }
 
         if (sellTradeAsset?.asset && buyTradeAsset?.asset) {
+          const fiatSellAmount = getValues('fiatSellAmount') ?? '0'
           await updateQuote({
             forceQuote: true,
-            amount: bnOrZero(buyTradeAsset.amount).toString(),
+            amount: fiatSellAmount,
             sellAsset: sellTradeAsset.asset,
             buyAsset: asset,
             feeAsset,
-            action: TradeAmountInputField.SELL,
+            action: TradeAmountInputField.FIAT,
           })
         }
       } catch (e) {


### PR DESCRIPTION
## Description

When they changed their buy or sell asset it was incorrectly trying to recalculate amounts using the previous sell asset value and the newly selected sell asset.

- Now it updates recalculates new amounts based on the current trade FIAT amount.

- Also fix dependency array for handleSellClick


## Notice

<!-- Before submitting a pull request, please make sure you have answered the following: -->

- [x] Have you followed the guidelines in our [Contributing]('https://github.com/shapeshift/web/CONTRIBUTING.md) guide?
- [x] Have you checked to ensure there aren't other open [Pull Requests](https://github.com/shapeshift/web/pulls) for the same update/change?

## Pull Request Type

- [x] :bug: Bug fix (Non-breaking Change: Fixes an issue)
- [ ] :hammer_and_wrench: Chore (Non-breaking Change: Doc updates, pkg upgrades, typos, etc..)
- [ ] :nail_care: New Feature (Breaking/Non-breaking Change)

## Issue (if applicable)



## Risk

Low risk bug fix

## Testing

See that switching the buy or sell asset does not mess up the amounts previously entered

## Screenshots (if applicable)
