### PR TITLE
chore: unchained-client v9.2.0

### DIFF
--- a/package.json
+++ b/package.json
@@ -106,7 +106,7 @@
     "@shapeshiftoss/market-service": "^6.4.1",
     "@shapeshiftoss/swapper": "^8.1.0",
     "@shapeshiftoss/types": "^7.0.0",
-    "@shapeshiftoss/unchained-client": "^9.1.1",
+    "@shapeshiftoss/unchained-client": "^9.2.0",
     "@uniswap/sdk": "^3.0.3",
     "@unstoppabledomains/resolution": "^7.1.4",
     "@visx/axis": "^2.10.0",

--- a/yarn.lock
+++ b/yarn.lock
@@ -4044,10 +4044,10 @@
   resolved "https://registry.yarnpkg.com/@shapeshiftoss/types/-/types-7.0.0.tgz#8d09b1dda5d68839cdfe5d1588295eb0ac6cb163"
   integrity sha512-hUUfjQwWX82XRClDvPm0VNgJfSsN5d5yAU9WR5RChfvN76G0N6DcU1VYqpXK8oGW9C0z/1fqgK4XBKLRmIQNFg==
 
-"@shapeshiftoss/unchained-client@^9.1.1":
-  version "9.1.1"
-  resolved "https://registry.yarnpkg.com/@shapeshiftoss/unchained-client/-/unchained-client-9.1.1.tgz#06e0ab1e2a0ce65628fac5feceade6f420650297"
-  integrity sha512-Y8gLv+zKJN9B5otaEUi9LmXtSXq5ILfZTilH8Z2x+fQIxUp1tmL5ger5dgXbRgquGaBvyXBsJhOXRO9Mr6S8Hw==
+"@shapeshiftoss/unchained-client@^9.2.0":
+  version "9.2.0"
+  resolved "https://registry.yarnpkg.com/@shapeshiftoss/unchained-client/-/unchained-client-9.2.0.tgz#6f1e69edd67fddcf81a624b2cc4bb353e72dde69"
+  integrity sha512-bvuoCygMOa4EINVK8FRW3CE9a0bbB1PsytI6HUNrtgtr7mOdO98aPGvrlTwathqdQzbdpPfJM08j86QXKvyBpg==
   dependencies:
     "@yfi/sdk" "^1.0.30"
     bignumber.js "^9.0.2"


### PR DESCRIPTION
## Description

Bump unchained-client to v9.2.0 which includes automatic websocket reconnect logic

## Notice

<!-- Before submitting a pull request, please make sure you have answered the following: -->

- [x] Have you followed the guidelines in our [Contributing]('https://github.com/shapeshift/web/CONTRIBUTING.md) guide?
- [x] Have you checked to ensure there aren't other open [Pull Requests](https://github.com/shapeshift/web/pulls) for the same update/change?

## Pull Request Type

- [ ] :bug: Bug fix (Non-breaking Change: Fixes an issue)
- [x] :hammer_and_wrench: Chore (Non-breaking Change: Doc updates, pkg upgrades, typos, etc..)
- [ ] :nail_care: New Feature (Breaking/Non-breaking Change)

## Issue (if applicable)

<!-----------------------------------------------------------------------------
If applicable, please link to the github issue and put `closes #XXXX` in your comment to auto-close the issue that your PR fixes.
------------------------------------------------------------------------------>

## Risk

- Medium: websocket client logic moved around and reworked some which does have the possibility for a missed edge case

## Testing

- Keep an eye on the network tab (filter by WS) and make sure you always see a `pending` connection to each chain supported

## Screenshots (if applicable)

- active (pending) websocket connections
![image](https://user-images.githubusercontent.com/35275952/178599206-ce8f6f14-d07f-476f-9e36-83b66a85bf1d.png)

- reconnect scenario: you can see one set of connections was only open for ~1min, but there is still a live set showing pending which shows the reconnect logic working
![image](https://user-images.githubusercontent.com/35275952/178605404-528cccda-e919-4ffb-b99b-24c6747072f1.png)
