### PR TITLE
fix: use the correct fee symbol in send modal

### DIFF
--- a/src/components/Modals/Send/TxFeeRadioGroup.tsx
+++ b/src/components/Modals/Send/TxFeeRadioGroup.tsx
@@ -1,9 +1,10 @@
 import { Box, Button, ButtonGroup, Radio, Spinner, useColorModeValue } from '@chakra-ui/react'
-import { fromAssetId } from '@shapeshiftoss/caip'
 import { FeeDataKey } from '@shapeshiftoss/chain-adapters'
 import { useController, useFormContext, useWatch } from 'react-hook-form'
 import { Amount } from 'components/Amount/Amount'
 import { Text } from 'components/Text'
+import { selectFeeAssetById } from 'state/slices/selectors'
+import { useAppSelector } from 'state/store'
 
 import type { SendInput } from './Form'
 import { SendFormFields } from './SendCommon'
@@ -51,6 +52,7 @@ export const TxFeeRadioGroup = ({ fees }: TxFeeRadioGroupProps) => {
   const activeFee = useWatch<SendInput, SendFormFields.FeeType>({ name: SendFormFields.FeeType })
   const bg = useColorModeValue('gray.50', 'gray.850')
   const borderColor = useColorModeValue('gray.100', 'gray.750')
+  const feeAsset = useAppSelector(state => selectFeeAssetById(state, asset.assetId))
 
   if (!fees) {
     return (
@@ -83,7 +85,6 @@ export const TxFeeRadioGroup = ({ fees }: TxFeeRadioGroupProps) => {
         const current = fees[key]
         const color = getFeeColor(key)
         const translation = getFeeTranslation(key)
-        const { assetReference } = fromAssetId(asset.assetId)
 
         return (
           <Button
@@ -112,7 +113,7 @@ export const TxFeeRadioGroup = ({ fees }: TxFeeRadioGroupProps) => {
               fontSize='sm'
               fontWeight='normal'
               maximumFractionDigits={6}
-              symbol={assetReference ? 'ETH' : asset.symbol}
+              symbol={feeAsset.symbol}
               value={current.txFee}
             />
             <Amount.Fiat


### PR DESCRIPTION
## Description

There was bad logic for determining the fee symbol. Replace with `selectFeeAssetById` selector.

## Notice

<!-- Before submitting a pull request, please make sure you have answered the following: -->

- [x] Have you followed the guidelines in our [Contributing]('https://github.com/shapeshift/web/CONTRIBUTING.md) guide?
- [x] Have you checked to ensure there aren't other open [Pull Requests](https://github.com/shapeshift/web/pulls) for the same update/change?

## Pull Request Type

- [x] :bug: Bug fix (Non-breaking Change: Fixes an issue)
- [ ] :hammer_and_wrench: Chore (Non-breaking Change: Doc updates, pkg upgrades, typos, etc..)
- [ ] :nail_care: New Feature (Breaking/Non-breaking Change)

## Issue (if applicable)

<!-----------------------------------------------------------------------------
If applicable, please link to the github issue and put `closes #XXXX` in your comment to auto-close the issue that your PR fixes.
------------------------------------------------------------------------------>

## Risk

Low

## Testing

Ensure the correct fee asset shows on the confirm send modal
- Ethereum/ERC20s: `ETH`
- Bitcoin: `BTC`
- Cosmos: `ATOM`

## Screenshots (if applicable)

Before:

- Bitcoin
![image](https://user-images.githubusercontent.com/35275952/178801406-bcf2eca9-d8bc-442b-9915-a15e602ef2d6.png)

- Cosmos
![image](https://user-images.githubusercontent.com/35275952/178801304-3b26e296-37ba-4419-868d-206a9e1dff6f.png)

After:

- Bitcoin
![image](https://user-images.githubusercontent.com/35275952/178801145-78c22cab-bd97-4f4b-91da-e30715f5e7c2.png)

- Cosmos
![image](https://user-images.githubusercontent.com/35275952/178800966-fda220f5-fdec-49a9-b926-d9cc70c384ab.png)
