### PR TITLE
fix: bump chain-adapters version to fix KK showOnDevice issue

### DIFF
--- a/package.json
+++ b/package.json
@@ -88,7 +88,7 @@
     "@reduxjs/toolkit": "^1.8.0",
     "@shapeshiftoss/asset-service": "^6.3.1",
     "@shapeshiftoss/caip": "^6.3.0",
-    "@shapeshiftoss/chain-adapters": "^7.5.0",
+    "@shapeshiftoss/chain-adapters": "^7.6.0",
     "@shapeshiftoss/errors": "^1.1.2",
     "@shapeshiftoss/hdwallet-core": "^1.25.0",
     "@shapeshiftoss/hdwallet-keepkey": "^1.25.0",

--- a/yarn.lock
+++ b/yarn.lock
@@ -3780,10 +3780,10 @@
   resolved "https://registry.yarnpkg.com/@shapeshiftoss/caip/-/caip-6.3.0.tgz#8cec4f69767c190086e4f523be44ab65d93be829"
   integrity sha512-yeUUrBZSaIGrGad6K1uDABJDhUofkLpmGogRfD9+xxBbJi2a0Cs+o3bxi3cBaBTkC/Yk13T6g+k6fnD1iPJS8Q==
 
-"@shapeshiftoss/chain-adapters@^7.5.0":
-  version "7.5.0"
-  resolved "https://registry.yarnpkg.com/@shapeshiftoss/chain-adapters/-/chain-adapters-7.5.0.tgz#134b196362276ef4fd471463c3dc1bcde728d35e"
-  integrity sha512-uTXDQQtzM0W+EEXDcTGcVlCKIDYai18bHQ/9cn9x/thrxA3ImTu24/nhUbX0dlAcUSUv+wx3X0DHtRHSbnB5Dg==
+"@shapeshiftoss/chain-adapters@^7.6.0":
+  version "7.6.0"
+  resolved "https://registry.yarnpkg.com/@shapeshiftoss/chain-adapters/-/chain-adapters-7.6.0.tgz#e771422d3965621b81a3f5135c76dc0f7d82977d"
+  integrity sha512-/oa1j8Q4FfnPoCHJGdZHzwcAs7poHsCz77sXqAV3kCzfyvTNYS9IpzicSeLh6+4JoOuzAirHXKJGrydwi8u5wg==
   dependencies:
     axios "^0.26.1"
     bech32 "^2.0.0"


### PR DESCRIPTION
## Description

fix: bump chain-adapters version to fix KK showOnDevice issue

Fixes the issue with always showing the eth address on the KK when requesting the address from the device. This was due to a refactor in `chain-adapters`. The issue was fixed in the latest `chain-adapters`.

## Notice

<!-- Before submitting a pull request, please make sure you have answered the following: -->

- [X] Have you followed the guidelines in our [Contributing]('https://github.com/shapeshift/web/CONTRIBUTING.md) guide?
- [X] Have you checked to ensure there aren't other open [Pull Requests](https://github.com/shapeshift/web/pulls) for the same update/change?

## Pull Request Type

- [X] :bug: Bug fix (Non-breaking Change: Fixes an issue)
- [ ] :hammer_and_wrench: Chore (Non-breaking Change: Doc updates, pkg upgrades, typos, etc..)
- [ ] :nail_care: New Feature (Breaking/Non-breaking Change)

## Issue (if applicable)
closes #2150 
## Risk

## Testing
1. Connect Wallet -> KeepKey

## Screenshots (if applicable)
