### PR TITLE
feat(swapper): add toast for invalid trading types

### DIFF
--- a/package.json
+++ b/package.json
@@ -104,7 +104,7 @@
     "@shapeshiftoss/investor-yearn": "^4.0.3",
     "@shapeshiftoss/logger": "^1.1.2",
     "@shapeshiftoss/market-service": "^6.4.1",
-    "@shapeshiftoss/swapper": "^8.3.0",
+    "@shapeshiftoss/swapper": "^8.4.0",
     "@shapeshiftoss/types": "^7.0.0",
     "@shapeshiftoss/unchained-client": "^9.2.0",
     "@uniswap/sdk": "^3.0.3",

--- a/src/assets/translations/en/main.json
+++ b/src/assets/translations/en/main.json
@@ -383,6 +383,7 @@
       "insufficientFundsForLimit": "Insufficient funds. The minimum trade amount for this pair is %{minLimit}",
       "insufficientFundsForAmount": "Insufficient funds. Your %{symbol} balance is less than the selected amount",
       "invalidTradePair": "Invalid trade pair: %{sellAssetName} and %{buyAssetName}",
+      "invalidTradePairBtnText": "Invalid Trade Pair",
       "noLiquidityError": "Not enough liquidity available",
       "overMaxSlippage": "This trade would result in over %{slippagePercentage}% slippage. Please trade a lower amount for a better price",
       "balanceToLow": "Balance too low. The minimum trade amount for this pair is %{minLimit}",

--- a/src/assets/translations/en/main.json
+++ b/src/assets/translations/en/main.json
@@ -382,6 +382,7 @@
       "broadcastFailed": "An error occurred while broadcasting the transaction",
       "insufficientFundsForLimit": "Insufficient funds. The minimum trade amount for this pair is %{minLimit}",
       "insufficientFundsForAmount": "Insufficient funds. Your %{symbol} balance is less than the selected amount",
+      "invalidTradePair": "Invalid trade pair: %{sellAssetName} and %{buyAssetName}",
       "noLiquidityError": "Not enough liquidity available",
       "overMaxSlippage": "This trade would result in over %{slippagePercentage}% slippage. Please trade a lower amount for a better price",
       "balanceToLow": "Balance too low. The minimum trade amount for this pair is %{minLimit}",

--- a/src/components/Trade/TradeInput.tsx
+++ b/src/components/Trade/TradeInput.tsx
@@ -194,6 +194,10 @@ export const TradeInput = ({ history }: RouterProps) => {
       return 'common.connectWallet'
     }
 
+    if (errors.quote) {
+      return 'trade.errors.invalidTradePairBtnText'
+    }
+
     if (isValid && !hasValidTradeBalance) {
       return 'common.insufficientFunds'
     }
@@ -368,6 +372,7 @@ export const TradeInput = ({ history }: RouterProps) => {
               size='lg'
               width='full'
               colorScheme={
+                errors.quote ||
                 error ||
                 (isValid &&
                   (!hasEnoughBalanceForGas || !hasValidTradeBalance) &&
@@ -383,7 +388,8 @@ export const TradeInput = ({ history }: RouterProps) => {
                 !hasValidTradeBalance ||
                 !hasEnoughBalanceForGas ||
                 !quote ||
-                !hasValidSellAmount
+                !hasValidSellAmount ||
+                !!errors.quote
               }
               style={{
                 whiteSpace: 'normal',

--- a/src/components/Trade/hooks/useSwapper/useSwapper.ts
+++ b/src/components/Trade/hooks/useSwapper/useSwapper.ts
@@ -401,8 +401,8 @@ export const useSwapper = () => {
         sellAssetId: sellAsset.assetId,
       })
 
+      // we assume that if we do not have a swapper returned, it is not a valid trade pair
       if (!swapper) {
-        // we assume that if we do not have a swapper returned, it is not a valid trade pair
         setError('quote', { message: 'trade.errors.invalidTradePairBtnText' })
         return toast({
           title: translate('trade.errors.title'),

--- a/yarn.lock
+++ b/yarn.lock
@@ -4024,10 +4024,10 @@
     google-protobuf "^3.17.0"
     long "^4.0.0"
 
-"@shapeshiftoss/swapper@^8.3.0":
-  version "8.3.0"
-  resolved "https://registry.yarnpkg.com/@shapeshiftoss/swapper/-/swapper-8.3.0.tgz#6bfdf8538b25dc632ecceb034f95c9ccec16602f"
-  integrity sha512-xQIa9nxYtRNNVYaXiY7SCV/5dSO1LwFH3WTSD9i6w01o9oLpGmzTyi25xQfQNdn5JFhBv62Tb0EK58O8Fvx91A==
+"@shapeshiftoss/swapper@^8.4.0":
+  version "8.4.0"
+  resolved "https://registry.yarnpkg.com/@shapeshiftoss/swapper/-/swapper-8.4.0.tgz#45b5aa0ed39bcdfb6749c23ba0136d20c8343629"
+  integrity sha512-ZtP1SuWkiu9B4Zy3Md1VjItAPNqrUcl2oLCb/cr0DiROj5Yw5r8Wg1p6nkfn6Kqeh3SC0LOdSRhMufgQRLbLGA==
   dependencies:
     axios "^0.26.1"
     bignumber.js "^9.0.2"


### PR DESCRIPTION
## Description

Add toast for invalid trade pairs.
- When a user is selecting assets to trade, a state where two trading assets that are not supported by any current swappers can happen. In that situation, we assume that if a swapper is NOT returned, the two assets are not supported by any current swappers.

## Notice

<!-- Before submitting a pull request, please make sure you have answered the following: -->

- [x] Have you followed the guidelines in our [Contributing]('https://github.com/shapeshift/web/CONTRIBUTING.md) guide?
- [x] Have you checked to ensure there aren't other open [Pull Requests](https://github.com/shapeshift/web/pulls) for the same update/change?

## Pull Request Type

- [ ] :bug: Bug fix (Non-breaking Change: Fixes an issue)
- [ ] :hammer_and_wrench: Chore (Non-breaking Change: Doc updates, pkg upgrades, typos, etc..)
- [x] :nail_care: New Feature (Breaking/Non-breaking Change)

## Issue (if applicable)
closes #2152 

## Risk
- This is a very minimal risk, given it just expands on the current logic of how to handle a best swapper not being returned.

## Testing
- With the thorchain feature flag turned on (locally, you currently have to hard code the `REACT_APP_FEATURE_THOR` const to `true` inside of `.env`), choose `BTC` (or some asset that is supported by thorchain) for the buy asset. With `ETH` as the sell asset and `BTC` as the buy asset, change the buy asset to something that is not supported by Thochain (shiba Inu). You should see the toast that states this is not a valid trading pair.


## Screenshots (if applicable)
