### PR TITLE
feat(banxa): support USDC and USDT sell orders

### DIFF
--- a/src/components/Modals/FiatRamps/config.ts
+++ b/src/components/Modals/FiatRamps/config.ts
@@ -81,10 +81,6 @@ export const supportedFiatRamps: SupportedFiatRamp = {
     supportsSell: true,
     getBuyAndSellList: async () => {
       const buyAssets = getBanxaAssets()
-      /**
-       * https://discord.com/channels/554694662431178782/972197500305948803/973110904382169118
-       * banxa only supports btc sells for now
-       */
       const sellAssets = buyAssets.filter(a =>
         [btcAssetId, usdcAssetId, usdtAssetId].includes(a.assetId),
       )

--- a/src/components/Modals/FiatRamps/config.ts
+++ b/src/components/Modals/FiatRamps/config.ts
@@ -24,6 +24,9 @@ const moduleLogger = logger.child({
   namespace: ['Modals', 'FiatRamps', 'config'],
 })
 
+export const usdcAssetId: AssetId = 'eip155:1/erc20:0xa0b86991c6218b36c1d19d4a2e9eb0ce3606eb48'
+export const usdtAssetId: AssetId = 'eip155:1/erc20:0xdac17f958d2ee523a2206206994597c13d831ec7'
+
 export interface SupportedFiatRampConfig {
   // key of translation jsons, will be used to show the provider name in the list
   label: string
@@ -82,7 +85,9 @@ export const supportedFiatRamps: SupportedFiatRamp = {
        * https://discord.com/channels/554694662431178782/972197500305948803/973110904382169118
        * banxa only supports btc sells for now
        */
-      const sellAssets = buyAssets.filter(a => a.assetId === btcAssetId)
+      const sellAssets = buyAssets.filter(a =>
+        [btcAssetId, usdcAssetId, usdtAssetId].includes(a.assetId),
+      )
       return [buyAssets, sellAssets]
     },
     onSubmit: (action: FiatRampAction, assetId: AssetId, address: string) => {


### PR DESCRIPTION
## Description

This adds support for the newly supported USDC and USDT stablecoins for Banxa sell orders.

## Notice

<!-- Before submitting a pull request, please make sure you have answered the following: -->

- [x] Have you followed the guidelines in our [Contributing]('https://github.com/shapeshift/web/CONTRIBUTING.md) guide?
- [x] Have you checked to ensure there aren't other open [Pull Requests](https://github.com/shapeshift/web/pulls) for the same update/change?

## Pull Request Type

- [ ] :bug: Bug fix (Non-breaking Change: Fixes an issue)
- [ ] :hammer_and_wrench: Chore (Non-breaking Change: Doc updates, pkg upgrades, typos, etc..)
- [x] :nail_care: New Feature (Breaking/Non-breaking Change)

## Issue (if applicable)

N/A

## Risk

None, this is just adding some new supported sell assets, for Banxa only

## Testing

- Have 50$+ of USDC/USDT in your wallet, or monkey-patch this line to `disabled={false}`:
https://github.com/shapeshift/web/blob/8770737be7fe61363970659bfaf51d76c1361377/src/components/Modals/FiatRamps/views/Overview.tsx#L250
- Go to Banxa ramp option's sell tab
- USDC and USDT should be available as sell assets
- Banxa partner tab should open with USDC/USDT populated

## Screenshots (if applicable)

<img width="452" alt="image" src="https://user-images.githubusercontent.com/17035424/179216827-e9857009-2a11-41ec-8673-8481a362125b.png">
<img width="624" alt="image" src="https://user-images.githubusercontent.com/17035424/179216915-9bd640c5-2cb4-4338-9967-6369c9f4908a.png">
<img width="606" alt="image" src="https://user-images.githubusercontent.com/17035424/179216965-2c56eca7-660e-469d-819d-8e9416004793.png">