### PR TITLE
feat: show order routing protocol in confirm trade modal

### DIFF
--- a/src/components/Trade/TradeConfirm/TradeConfirm.tsx
+++ b/src/components/Trade/TradeConfirm/TradeConfirm.tsx
@@ -163,6 +163,9 @@ export const TradeConfirm = ({ history }: RouterProps) => {
                   <RawText>{`1 ${trade.sellAsset.symbol} = ${firstNonZeroDecimal(
                     bnOrZero(trade?.rate),
                   )} ${trade?.buyAsset?.symbol}`}</RawText>
+                  {!!fees?.tradeFeeSource && (
+                    <RawText color="gray.500">@{fees?.tradeFeeSource}</RawText>
+                  )}
                 </Box>
               </Row>
               <Row>
@@ -180,10 +183,7 @@ export const TradeConfirm = ({ history }: RouterProps) => {
                 <HelperTooltip label={translate('trade.tooltip.shapeshiftFee')}>
                   <Row.Label>
                     <Text
-                      translation={[
-                        'trade.tradeFeeSource',
-                        { tradeFeeSource: fees?.tradeFeeSource ?? 'Trade' },
-                      ]}
+                      translation={['trade.tradeFeeSource', { tradeFeeSource: 'ShapeShift' }]}
                     />
                   </Row.Label>
                 </HelperTooltip>

--- a/src/components/Trade/TradeConfirm/TradeConfirm.tsx
+++ b/src/components/Trade/TradeConfirm/TradeConfirm.tsx
@@ -164,7 +164,7 @@ export const TradeConfirm = ({ history }: RouterProps) => {
                     bnOrZero(trade?.rate),
                   )} ${trade?.buyAsset?.symbol}`}</RawText>
                   {!!fees?.tradeFeeSource && (
-                    <RawText color="gray.500">@{fees?.tradeFeeSource}</RawText>
+                    <RawText color='gray.500'>@{fees?.tradeFeeSource}</RawText>
                   )}
                 </Box>
               </Row>


### PR DESCRIPTION
## Description

Added order routing protocol information in confirm trade modal

## Notice

<!-- Before submitting a pull request, please make sure you have answered the following: -->

- [x] Have you followed the guidelines in our [Contributing]('https://github.com/shapeshift/web/CONTRIBUTING.md) guide?
- [x] Have you checked to ensure there aren't other open [Pull Requests](https://github.com/shapeshift/web/pulls) for the same update/change?

## Pull Request Type

- [ ] :bug: Bug fix (Non-breaking Change: Fixes an issue)
- [ ] :hammer_and_wrench: Chore (Non-breaking Change: Doc updates, pkg upgrades, typos, etc..)
- [x] :nail_care: New Feature (Breaking/Non-breaking Change)

## Issue (if applicable)

closes #2174

## Risk

N/A

## Testing

- Login to the app
- Initiate a trade preview

## Screenshots (if applicable)

Before

![Screenshot from 2022-07-19 01-49-13](https://user-images.githubusercontent.com/61096193/179610035-94bf25a8-e220-4212-b692-2f509f267705.png)

After

![Screenshot from 2022-07-19 01-46-17](https://user-images.githubusercontent.com/61096193/179610055-5f643cfc-ea25-4ef1-847f-7f8ed34e6708.png)


