### PR TITLE
fix: avoid infinite render

### DIFF
--- a/src/context/WalletProvider/WalletViewsSwitch.tsx
+++ b/src/context/WalletProvider/WalletViewsSwitch.tsx
@@ -59,6 +59,10 @@ export const WalletViewsSwitch = () => {
     await cancelWalletRequests()
   }
 
+  const onContinue = useCallback(() => {
+    history.push('/select')
+  }, [history])
+
   useEffect(() => {
     if (initialRoute) {
       history.push(initialRoute)
@@ -107,10 +111,7 @@ export const WalletViewsSwitch = () => {
                   })}
 
                 <Route path={'/select'} children={() => <SelectModal />} />
-                <Route
-                  path={'/'}
-                  children={() => <OptInModalBody onContinue={() => history.push('/select')} />}
-                />
+                <Route path={'/'} children={() => <OptInModalBody onContinue={onContinue} />} />
               </Switch>
             </SlideTransition>
           </AnimatePresence>


### PR DESCRIPTION
## Description

Wrap `onContinue` in a `useCallback` to avoid an infinite loop caused by `history` changing.

## Notice

<!-- Before submitting a pull request, please make sure you have answered the following: -->

- [x] Have you followed the guidelines in our [Contributing]('https://github.com/shapeshift/web/CONTRIBUTING.md) guide?
- [x] Have you checked to ensure there aren't other open [Pull Requests](https://github.com/shapeshift/web/pulls) for the same update/change?

## Pull Request Type

- [x] :bug: Bug fix (Non-breaking Change: Fixes an issue)
- [ ] :hammer_and_wrench: Chore (Non-breaking Change: Doc updates, pkg upgrades, typos, etc..)
- [ ] :nail_care: New Feature (Breaking/Non-breaking Change)

## Issue (if applicable)

N/A

## Risk

Small, though this does touch wallet switching.

## Testing

- Switching wallets should work
- Switching to a KeepKey should work
- No "maximum call depth exceeded" error should show in the console

## Screenshots (if applicable)

N/A