### PR TITLE
fix(pendo): selectively fire `onContinue`

### DIFF
--- a/src/context/WalletProvider/WalletViewsSwitch.tsx
+++ b/src/context/WalletProvider/WalletViewsSwitch.tsx
@@ -60,6 +60,7 @@ export const WalletViewsSwitch = () => {
   }
 
   const onContinue = useCallback(() => {
+    // Without this check we'll fire again once a KeepKey initializes and ask the user to select a wallet again
     if (!initialRoute || initialRoute === '/') history.push('/select')
   }, [history, initialRoute])
 

--- a/src/context/WalletProvider/WalletViewsSwitch.tsx
+++ b/src/context/WalletProvider/WalletViewsSwitch.tsx
@@ -60,8 +60,8 @@ export const WalletViewsSwitch = () => {
   }
 
   const onContinue = useCallback(() => {
-    history.push('/select')
-  }, [history])
+    if (!initialRoute) history.push('/select')
+  }, [history, initialRoute])
 
   useEffect(() => {
     if (initialRoute) {

--- a/src/context/WalletProvider/WalletViewsSwitch.tsx
+++ b/src/context/WalletProvider/WalletViewsSwitch.tsx
@@ -60,7 +60,7 @@ export const WalletViewsSwitch = () => {
   }
 
   const onContinue = useCallback(() => {
-    if (!initialRoute) history.push('/select')
+    if (!initialRoute || initialRoute === '/') history.push('/select')
   }, [history, initialRoute])
 
   useEffect(() => {


### PR DESCRIPTION
## Description

The call of `onContinue` on the following line: https://github.com/shapeshift/web/blob/4231c5b249372a6a25c486246774d79891993561/src/plugins/pendo/components/OptInModal/OptInModalBody.tsx#L43 

is firing after the `/keepkey/enter-pin` route is entered because `WalletProvider` re-renders (with `WalletViewsSwitch` as one of it's grandchildren) at this time (this side effect is a code smell, but not one intending to be addressed in this PR).

We only want to run the logic in `OptInModalBody` when the user is attempting to connect or switch to a wallet (not when a state change causes a re-render of `WalletProvider`).

This PR updates the `onContinue` callback so that it only fires when we are selecting a wallet.

## Notice

<!-- Before submitting a pull request, please make sure you have answered the following: -->

- [x] Have you followed the guidelines in our [Contributing]('https://github.com/shapeshift/web/CONTRIBUTING.md) guide?
- [x] Have you checked to ensure there aren't other open [Pull Requests](https://github.com/shapeshift/web/pulls) for the same update/change?

## Pull Request Type

- [x] :bug: Bug fix (Non-breaking Change: Fixes an issue)
- [ ] :hammer_and_wrench: Chore (Non-breaking Change: Doc updates, pkg upgrades, typos, etc..)
- [ ] :nail_care: New Feature (Breaking/Non-breaking Change)

## Issue (if applicable)

Closes https://github.com/shapeshift/web/issues/2186

## Risk

Some: selecting and changing wallets should be tested thoroughly.

## Testing

Connect to a newly connected KeepKey that has a PIN. The wallet should connect immediately, rather than needing to be selected twice.

## Screenshots (if applicable)

N/A