### PR TITLE
fix: onramp undefined assetId

### DIFF
--- a/src/components/Modals/FiatRamps/views/Overview.tsx
+++ b/src/components/Modals/FiatRamps/views/Overview.tsx
@@ -112,7 +112,9 @@ export const Overview: React.FC<OverviewProps> = ({
   useEffect(() => {
     if (!wallet) return
     supportsAddressVerifying && setSupportsAddressVerifying(true)
-    setChainId(fromAssetId(selectedAsset?.assetId ?? '').chainId ?? ethChainId)
+    const maybeAssetId = selectedAsset?.assetId
+    const chainId = maybeAssetId ? fromAssetId(maybeAssetId).chainId : ethChainId
+    setChainId(chainId)
     // supportsAddressVerifying will cause infinite loop
     // eslint-disable-next-line react-hooks/exhaustive-deps
   }, [selectedAsset, setChainId, setSupportsAddressVerifying, wallet])


### PR DESCRIPTION
## Description

We refactored `Overview.tsx` in https://github.com/shapeshift/web/pull/2188 to use the helpers in `@shapeshiftoss/caip`.

The behaviour changed slightly as the CAIP helpers will throw if the input is invalid, rather than silently failing.

This PR ensures we have an `assetId` before calling `fromAssetId`.

## Notice

- [x] Have you followed the guidelines in our [Contributing]('https://github.com/shapeshift/web/CONTRIBUTING.md) guide?
- [x] Have you checked to ensure there aren't other open [Pull Requests](https://github.com/shapeshift/web/pulls) for the same update/change?

## Pull Request Type

- [x] :bug: Bug fix (Non-breaking Change: Fixes an issue)
- [ ] :hammer_and_wrench: Chore (Non-breaking Change: Doc updates, pkg upgrades, typos, etc..)
- [ ] :nail_care: New Feature (Breaking/Non-breaking Change)

## Issue (if applicable)

N/A

## Risk

Minimal.

## Testing

1. Click buy/sell crypto
2. Pick a fiat ramp provider
3. Should not whitescreen

## Screenshots (if applicable)

N/A