### PR TITLE
fix: fix hdwallet-core dependency resolution

### DIFF
--- a/package.json
+++ b/package.json
@@ -64,9 +64,6 @@
       "last 1 safari version"
     ]
   },
-  "resolutions": {
-    "@shapeshiftoss/hdwallet-core": "1.25.0"
-  },
   "config-overrides-path": "react-app-rewired.config.js",
   "fork-ts-checker": {
     "typescript": {

--- a/yarn.lock
+++ b/yarn.lock
@@ -3795,17 +3795,7 @@
     web-encoding "^1.1.0"
     wif "^2.0.6"
 
-"@shapeshiftoss/hdwallet-core@1.25.0", "@shapeshiftoss/hdwallet-core@latest":
-  version "1.25.0"
-  resolved "https://registry.yarnpkg.com/@shapeshiftoss/hdwallet-core/-/hdwallet-core-1.25.0.tgz#97b4e29f124ef6600f182af33e620b10bb4b0e60"
-  integrity sha512-o4o9ww4ux7NmoBIjT3AlP6gmxKzRHvyfxpkVGuaM5bHuPa44GItO5duZwK9s38QqC0EX4z8USG1/44E2e+YaXw==
-  dependencies:
-    eventemitter2 "^5.0.1"
-    lodash "^4.17.21"
-    rxjs "^6.4.0"
-    type-assertions "^1.1.0"
-
-"@shapeshiftoss/hdwallet-core@1.27.0", "@shapeshiftoss/hdwallet-core@^1.27.0":
+"@shapeshiftoss/hdwallet-core@1.27.0", "@shapeshiftoss/hdwallet-core@^1.27.0", "@shapeshiftoss/hdwallet-core@latest":
   version "1.27.0"
   resolved "https://registry.yarnpkg.com/@shapeshiftoss/hdwallet-core/-/hdwallet-core-1.27.0.tgz#63ab356040f00980fbbc5d60435a7a8ea697fc7b"
   integrity sha512-NmucwcYTB3uq2SmsWK6rg+bywpDDn6CFAiiYkDR52CxSxxfKSWNkV0Pq+ZeHTvd5NZ9VGL2fft4WXGMjQ0fyzA==


### PR DESCRIPTION
## Description

fix: fix hdwallet-core dependency resolution

in `package.json` right now we're forcing the resolution of hdwallet-core version to 1.25 which is causing many duplicates of the dependency to be installed.

## Notice

<!-- Before submitting a pull request, please make sure you have answered the following: -->

- [X] Have you followed the guidelines in our [Contributing]('https://github.com/shapeshift/web/CONTRIBUTING.md) guide?
- [X] Have you checked to ensure there aren't other open [Pull Requests](https://github.com/shapeshift/web/pulls) for the same update/change?

## Pull Request Type

- [X] :bug: Bug fix (Non-breaking Change: Fixes an issue)
- [] :hammer_and_wrench: Chore (Non-breaking Change: Doc updates, pkg upgrades, typos, etc..)
- [ ] :nail_care: New Feature (Breaking/Non-breaking Change)

## Issue (if applicable)
N/A
## Risk
N/A
## Testing
Wallets
## Screenshots (if applicable)
before
```
=> Found "@shapeshiftoss/hdwallet-core@1.27.0"
info Has been hoisted to "@shapeshiftoss/hdwallet-core"
info This module exists because it's specified in "dependencies".
info Disk size without dependencies: "444KB"
info Disk size with unique dependencies: "22.47MB"
info Disk size with transitive dependencies: "22.55MB"
info Number of shared dependencies: 5
=> Found "@shapeshiftoss/hdwallet-keepkey#@shapeshiftoss/hdwallet-core@1.25.0"
info This module exists because "@shapeshiftoss#hdwallet-keepkey" depends on it.
info Disk size without dependencies: "444KB"
info Disk size with unique dependencies: "22.47MB"
info Disk size with transitive dependencies: "22.55MB"
info Number of shared dependencies: 5
=> Found "@shapeshiftoss/hdwallet-keepkey-webusb#@shapeshiftoss/hdwallet-core@1.25.0"
info This module exists because "@shapeshiftoss#hdwallet-keepkey-webusb" depends on it.
info Disk size without dependencies: "444KB"
info Disk size with unique dependencies: "22.47MB"
info Disk size with transitive dependencies: "22.55MB"
info Number of shared dependencies: 5
=> Found "@shapeshiftoss/hdwallet-keplr#@shapeshiftoss/hdwallet-core@1.25.0"
info This module exists because "@shapeshiftoss#hdwallet-keplr" depends on it.
info Disk size without dependencies: "444KB"
info Disk size with unique dependencies: "22.47MB"
info Disk size with transitive dependencies: "22.55MB"
info Number of shared dependencies: 5
... (for all other wallets)
```
after
```
=> Found "@shapeshiftoss/hdwallet-core@1.27.0"
info Has been hoisted to "@shapeshiftoss/hdwallet-core"
info Reasons this module exists
   - Specified in "dependencies"
   - Hoisted from "@shapeshiftoss#hdwallet-keepkey#@shapeshiftoss#hdwallet-core"
   - Hoisted from "@shapeshiftoss#hdwallet-keepkey-webusb#@shapeshiftoss#hdwallet-core"
   - Hoisted from "@shapeshiftoss#hdwallet-keplr#@shapeshiftoss#hdwallet-core"
   - Hoisted from "@shapeshiftoss#hdwallet-metamask#@shapeshiftoss#hdwallet-core"
   - Hoisted from "@shapeshiftoss#hdwallet-native#@shapeshiftoss#hdwallet-core"
   - Hoisted from "@shapeshiftoss#hdwallet-portis#@shapeshiftoss#hdwallet-core"
   - Hoisted from "@shapeshiftoss#hdwallet-tallyho#@shapeshiftoss#hdwallet-core"
   - Hoisted from "@shapeshiftoss#hdwallet-walletconnect#@shapeshiftoss#hdwallet-core"
   - Hoisted from "@shapeshiftoss#hdwallet-xdefi#@shapeshiftoss#hdwallet-core"
   - Hoisted from "@shapeshiftoss#hdwallet-native#tendermint-tx-builder#@shapeshiftoss#hdwallet-core"
info Disk size without dependencies: "444KB"
info Disk size with unique dependencies: "22.47MB"
info Disk size with transitive dependencies: "22.55MB"
info Number of shared dependencies: 5
```
