### PR TITLE
fix: `handleInputChange` rugging last invocation response

### DIFF
--- a/src/components/Modals/Send/hooks/useSendDetails/useSendDetails.tsx
+++ b/src/components/Modals/Send/hooks/useSendDetails/useSendDetails.tsx
@@ -167,7 +167,7 @@ export const useSendDetails = (): UseSendDetailsReturnType => {
     }
   }, [accountSpecifier, chainAdapterManager, contractAddress, getValues, wallet])
 
-  const debouncedEstimateFormFees = useMemo(() => {
+  const debouncedSetEstimatedFormFees = useMemo(() => {
     return debounce(
       async () => {
         const estimatedFees = await estimateFormFees()
@@ -232,12 +232,12 @@ export const useSendDetails = (): UseSendDetailsReturnType => {
     setValue,
   ])
 
-  // Stop calls to debouncedEstimateFormFees on unmount
+  // Stop calls to debouncedSetEstimatedFormFees on unmount
   useEffect(() => {
     return () => {
-      debouncedEstimateFormFees.cancel()
+      debouncedSetEstimatedFormFees.cancel()
     }
-  }, [debouncedEstimateFormFees])
+  }, [debouncedSetEstimatedFormFees])
 
   const handleNextClick = async () => {
     history.push(SendRoutes.Confirm)
@@ -409,7 +409,7 @@ export const useSendDetails = (): UseSendDetailsReturnType => {
       try {
         if (inputValue === '') {
           // Cancel any pending requests
-          debouncedEstimateFormFees.cancel()
+          debouncedSetEstimatedFormFees.cancel()
           // Don't show an error message when the input is empty
           setValue(SendFormFields.AmountFieldError, '')
           // Set value of the other input to an empty string as well
@@ -430,7 +430,7 @@ export const useSendDetails = (): UseSendDetailsReturnType => {
         await (async () => {
           try {
             setLoading(true)
-            await debouncedEstimateFormFees()
+            await debouncedSetEstimatedFormFees()
           } catch (e) {
             throw new Error('common.insufficientFunds')
           } finally {


### PR DESCRIPTION
## Description

Our fee estimate debouncing mechanism added in https://github.com/shapeshift/web/pull/1835 gets rugged by `handleInputChange`. 

Whilst the calls to `estimateFormFees` will debounce as expected, the logic inside `handleInputChange` is not debounced and will set `estimatedFees` before the final invocation of the debouncer is resolved.

When sending on Avalanche this resulted in a `gasLimit` that was too low, leading to failed transactions.

## Notice

- [x] Have you followed the guidelines in our [Contributing]('https://github.com/shapeshift/web/CONTRIBUTING.md) guide?
- [x] Have you checked to ensure there aren't other open [Pull Requests](https://github.com/shapeshift/web/pulls) for the same update/change?

## Pull Request Type

- [x] :bug: Bug fix (Non-breaking Change: Fixes an issue)
- [ ] :hammer_and_wrench: Chore (Non-breaking Change: Doc updates, pkg upgrades, typos, etc..)
- [ ] :nail_care: New Feature (Breaking/Non-breaking Change)

## Issue (if applicable)

Closes https://github.com/shapeshift/web/issues/2200

## Risk

Small and limited to send functionality, but we should ensure sends still work as expected across chains.

## Testing

Replicating this bug requires sending on a chain that has a different `gasFee` when sending a value of `0` vs sending non-zero.

## Screenshots (if applicable)

When typing `0.03` the final `gasLimit` is `30584`, which is what we want, and is used in `buildSendTransaction`.

<img width="1237" alt="Screen Shot 2022-07-22 at 4 31 26 pm" src="https://user-images.githubusercontent.com/97164662/180377564-df84791c-8182-4905-ab79-10d48e84a327.png">

