### PR TITLE
fix(foxPage): fox assets <MenuList /> zIndex

### DIFF
--- a/src/plugins/foxPage/foxPage.tsx
+++ b/src/plugins/foxPage/foxPage.tsx
@@ -197,7 +197,7 @@ export const FoxPage = () => {
                       />
                     )}
                   </MenuButton>
-                  <MenuList>
+                  <MenuList zIndex={3}>
                     {assets.map((asset, index) => (
                       <MenuItem key={asset.assetId} onClick={() => handleTabClick(asset.assetId)}>
                         <FoxTab


### PR DESCRIPTION
## Description

This adds a `zIndex` prop to the `<MenuList />` rendering the Fox Page asset tab selection, fixing the main opportunity icon that's currently on top of it because of some higher z-index value.

## Notice

<!-- Before submitting a pull request, please make sure you have answered the following: -->

- [x] Have you followed the guidelines in our [Contributing]('https://github.com/shapeshift/web/CONTRIBUTING.md) guide?
- [x] Have you checked to ensure there aren't other open [Pull Requests](https://github.com/shapeshift/web/pulls) for the same update/change?

## Pull Request Type

- [x] :bug: Bug fix (Non-breaking Change: Fixes an issue)
- [ ] :hammer_and_wrench: Chore (Non-breaking Change: Doc updates, pkg upgrades, typos, etc..)
- [ ] :nail_care: New Feature (Breaking/Non-breaking Change)

## Issue (if applicable)

closes https://github.com/shapeshift/web/issues/2205

## Risk

None.

## Testing

- Open the Fox Page tab selection on mobile
- The main opportunity icon should not be on top of the menu

## Screenshots (if applicable)

<img width="506" alt="image" src="https://user-images.githubusercontent.com/17035424/180453725-f405a6b3-4f87-4734-80d6-302b8058ad40.png">