### PR TITLE
fix: don't show 'exponentiated' icons for fee assets/acccounts on account page

### DIFF
--- a/src/components/AssetAccounts/AssetAccountRow.tsx
+++ b/src/components/AssetAccounts/AssetAccountRow.tsx
@@ -111,7 +111,7 @@ export const AssetAccountRow = ({
           <AssetIcon src={asset?.icon} boxSize='30px' mr={2} />
         </Box>
         <Flex flexDir='column' ml={2} maxWidth='100%'>
-          {assetReference && (
+          {assetNamespace !== 'slip44' && (
             <RawText fontWeight='bold' color='gray.500' fontSize='sm'>
               {feeAsset.name}
             </RawText>

--- a/src/components/AssetAccounts/AssetAccountRow.tsx
+++ b/src/components/AssetAccounts/AssetAccountRow.tsx
@@ -54,7 +54,7 @@ export const AssetAccountRow = ({
   const accountSpecifier = useAppSelector(state =>
     selectFirstAccountSpecifierByChainId(state, asset?.chainId),
   )
-  const { assetReference } = fromAssetId(asset.assetId)
+  const { assetReference, assetNamespace } = fromAssetId(asset.assetId)
 
   const filter = useMemo(
     () => ({ assetId: rowAssetId, accountId, accountSpecifier }),
@@ -96,7 +96,8 @@ export const AssetAccountRow = ({
     >
       <Flex alignItems='center'>
         <Box position='relative'>
-          {assetReference && (
+          {/** don't show "exponentiated" asset icons for fee assets */}
+          {assetNamespace !== 'slip44' && (
             <AssetIcon
               src={feeAsset.icon}
               right={0}


### PR DESCRIPTION
## Description

<!-- Please describe your changes -->

fixes a small regression noticed by product

* we should only show the fee asset "exponentiated" icon on tokens
* we should only show the chain name label above tokens, not on top level accounts

all fee/account assets have an assetNamespace of `slip44` - if it's not this it's some type of token
on the given chain

## Notice

<!-- Before submitting a pull request, please make sure you have answered the following: -->

- [x] Have you followed the guidelines in our [Contributing]('https://github.com/shapeshift/web/CONTRIBUTING.md) guide?
- [x] Have you checked to ensure there aren't other open [Pull Requests](https://github.com/shapeshift/web/pulls) for the same update/change?

## Pull Request Type

- [x] :bug: Bug fix (Non-breaking Change: Fixes an issue)
- [ ] :hammer_and_wrench: Chore (Non-breaking Change: Doc updates, pkg upgrades, typos, etc..)
- [ ] :nail_care: New Feature (Breaking/Non-breaking Change)

## Issue (if applicable)

<!-----------------------------------------------------------------------------
If applicable, please link to the github issue and put `closes #XXXX` in your comment to auto-close the issue that your PR fixes.
------------------------------------------------------------------------------>

n/a - noticed by product

## Risk

<!-----------------------------------------------------------------------------
Outline the scope of your changes and the risk associated with them. You must use your discretion as an engineer to determine the potential impact of your changes.

E.g. an upgrade to `hdwallet` or core state management would be considered higher risk, and might require a full regression test. UI or isolated view changes, or something behind a feature flag may have near zero risk. Small bug fixes might require testing isolated to the specific fix.
------------------------------------------------------------------------------>

other icon may render incorrectly

## Testing

<!-----------------------------------------------------------------------------
If your testing steps are technical, outline steps for an engineer to verify.

If your testing steps are functional, please provide a full guide with any features requiring special attention for operations to test your branch in the preview environment.
------------------------------------------------------------------------------>

account page shouldn't show a little fee asset icon to the top right of accounts - they should only
appear for tokens


## Screenshots (if applicable)

before - BTC incorrectly showing small BTC icon on top right

<img width="378" alt="image" src="https://user-images.githubusercontent.com/88504456/180459741-882aec7c-ba9d-4eff-b8b4-592719dee795.png">

after - small icons of fee asset on top right for tokens, not on top level accounts (BTC)

<img width="756" alt="image" src="https://user-images.githubusercontent.com/88504456/180460868-6f5aa699-656f-46e6-a106-4cc0355d2cba.png">
