### PR TITLE
fix(foxPage): fox mainStakingTitle translation for french language

### DIFF
--- a/src/assets/translations/fr/main.json
+++ b/src/assets/translations/fr/main.json
@@ -1139,7 +1139,7 @@
       "buyAssetOnCoinbase": "Acheter du %{assetSymbol} sur Coinbase",
       "trade": "Échanger",
       "receive": "Recevoir",
-      "mainStakingTitle": "Mises de jetons %{assetName}",
+      "mainStakingTitle": "Mises de jetons %{assetSymbol}",
       "mainStakingDescription": "Mettez votre FOX au travail dans des contrats de mise unilatéraux pour gagner des récompenses FOX. (les FOX peuvent toujours être utilisés pour la gouvernance lorsqu'ils sont misés, mais autrement ils sont verrouillés dans le contrat durant la mise.)",
       "tvl": "TVL",
       "currentApy": "APY actuel",


### PR DESCRIPTION
## Description

Fixes a smallish little typo using the old `plugins.foxPage.mainStakingTitle` translation in https://github.com/shapeshift/web/commit/e47cdd9574f0d53591b6c17fa5a51212a35881cb - which should use `assetSymbol` as an interpolation variable

## Notice

<!-- Before submitting a pull request, please make sure you have answered the following: -->

- [x] Have you followed the guidelines in our [Contributing]('https://github.com/shapeshift/web/CONTRIBUTING.md) guide?
- [x] Have you checked to ensure there aren't other open [Pull Requests](https://github.com/shapeshift/web/pulls) for the same update/change?

## Pull Request Type

- [x] :bug: Bug fix (Non-breaking Change: Fixes an issue)
- [ ] :hammer_and_wrench: Chore (Non-breaking Change: Doc updates, pkg upgrades, typos, etc..)
- [ ] :nail_care: New Feature (Breaking/Non-breaking Change)

## Issue (if applicable)

N/A

## Risk

None.

## Testing

- Switch to French
- In the FOX opportunity, the main staking opportunity should display "Misez vos jetons FOX"

## Screenshots (if applicable)

<img width="738" alt="image" src="https://user-images.githubusercontent.com/17035424/180474416-9b8a8d85-6e1e-44b3-b73b-9b4eb2514635.png">