### PR TITLE
fix: dead click on same wallet selection after clicking back

### DIFF
--- a/src/context/WalletProvider/SelectModal.tsx
+++ b/src/context/WalletProvider/SelectModal.tsx
@@ -41,8 +41,8 @@ export const SelectModal = () => {
           {adapters &&
             // TODO: KeepKey adapter may fail due to the USB interface being in use by another tab
             // So not all of the supported wallets will have an initialized adapter
-            wallets.map(key => {
-              const option = SUPPORTED_WALLETS[key]
+            wallets.map(walletType => {
+              const option = SUPPORTED_WALLETS[walletType]
               const Icon = option.icon
               const activeWallet = walletInfo?.name === option.name
               // TODO: We can probably do better than a hardcoded ETH-only option for Walletconnect here.
@@ -55,19 +55,19 @@ export const SelectModal = () => {
 
               // some wallets (e.g. tally ho) do not exist on mobile
               if (isMobile && !option.mobileEnabled) return false
-              if (!walletConnectFeatureFlag && key === KeyManager.WalletConnect) return false
+              if (!walletConnectFeatureFlag && walletType === KeyManager.WalletConnect) return false
 
               return (
                 <Button
-                  key={key}
+                  key={walletType}
                   w='full'
                   size='md'
                   py={8}
                   isActive={activeWallet}
                   _active={{ bg: activeBg }}
                   justifyContent='space-between'
-                  onClick={() => connect(key)}
-                  data-test={`connect-wallet-${key}-button`}
+                  onClick={() => connect(walletType)}
+                  data-test={`connect-wallet-${walletType}-button`}
                 >
                   <Flex alignItems='flex-start' flexDir='column'>
                     <RawText fontWeight='semibold'>{option.name}</RawText>

--- a/src/context/WalletProvider/WalletViewsSwitch.tsx
+++ b/src/context/WalletProvider/WalletViewsSwitch.tsx
@@ -53,7 +53,7 @@ export const WalletViewsSwitch = () => {
     history.goBack()
     // If we're back at the select wallet modal, remove the initial route
     // otherwise clicking the button for the same wallet doesn't do anything
-    if (history.location.pathname === '/') {
+    if (history.location.pathname === '/select') {
       dispatch({ type: WalletActions.SET_INITIAL_ROUTE, payload: '' })
     }
     await cancelWalletRequests()


### PR DESCRIPTION
## Description

This fixes the dead click on a wallet select button, after selecting the same wallet and clicking back.

Additionally, renames the `key` variable in `<SelectModal />` to `walletType`, as the previous naming didn't make it obvious what was that variable referring to, and added friction to debugging.

## Notice

<!-- Before submitting a pull request, please make sure you have answered the following: -->

- [x] Have you followed the guidelines in our [Contributing]('https://github.com/shapeshift/web/CONTRIBUTING.md) guide?
- [x] Have you checked to ensure there aren't other open [Pull Requests](https://github.com/shapeshift/web/pulls) for the same update/change?

## Pull Request Type

- [x] :bug: Bug fix (Non-breaking Change: Fixes an issue)
- [ ] :hammer_and_wrench: Chore (Non-breaking Change: Doc updates, pkg upgrades, typos, etc..)
- [ ] :nail_care: New Feature (Breaking/Non-breaking Change)

## Issue (if applicable)

closes https://github.com/shapeshift/web/issues/2214

## Risk

There shouldn't be any, the previous check was checking for the `/` route, which looks like the intent was to refer to the initial wallet select route, but that route is actually `/select`. 

## Testing

- Open the wallet select modal
- Select a wallet
- Click the back button
- Clicking the same wallet button again should work

## Screenshots (if applicable)
