### PR TITLE
fix: remove duplicate native wallet logic

### DIFF
--- a/src/context/WalletProvider/NativeWallet/components/NativeLoad.tsx
+++ b/src/context/WalletProvider/NativeWallet/components/NativeLoad.tsx
@@ -80,9 +80,6 @@ export const NativeLoad = ({ history }: RouteComponentProps) => {
           // after the wallet has been decrypted. If we set it now, `getPublicKeys` calls will
           // return null, and we don't have a retry mechanism
           await wallet.initialize()
-          // If the wallet is not initialized, it means that the password need to be entered
-          // so we have to redirect to the enter-password view
-          history.push('/native/enter-password', { deviceId })
         } else {
           dispatch({
             type: WalletActions.SET_WALLET,


### PR DESCRIPTION
## Description

This removes some duplicate logic on the native wallet initialization.

Currently, we route to the `/native/enter-password` route. This is already handled by the `useNativeEventHandler` hook using events handling:

https://github.com/shapeshift/web/blob/f7f4e955a4410e8d7065c3f9fa071bf00f97858e/src/context/WalletProvider/NativeWallet/hooks/useNativeEventHandler.ts#L22

As a result, the duplicate `history.push` calls are causing duplicate `/native/enter-password` entries which are the root cause of https://github.com/shapeshift/web/issues/2215

The original logic was added in 76a762a88 and became duplicate after f4e25935d
## Notice

<!-- Before submitting a pull request, please make sure you have answered the following: -->

- [x] Have you followed the guidelines in our [Contributing]('https://github.com/shapeshift/web/CONTRIBUTING.md) guide?
- [x] Have you checked to ensure there aren't other open [Pull Requests](https://github.com/shapeshift/web/pulls) for the same update/change?

## Pull Request Type

- [x] :bug: Bug fix (Non-breaking Change: Fixes an issue)
- [ ] :hammer_and_wrench: Chore (Non-breaking Change: Doc updates, pkg upgrades, typos, etc..)
- [ ] :nail_care: New Feature (Breaking/Non-breaking Change)

## Issue (if applicable)

closes https://github.com/shapeshift/web/issues/2215

## Risk

That has potential risk on the native wallet initialization feature. Effectively, tested out the whole flow and didn't find any regressions (connect/reconnect/vault switch).

## Testing

- Regression test the native wallet - it should show no regressions

- Open the select wallet modal
- Select native and go to the password input step
- Clicking back should route you back to the previous step


## Screenshots (if applicable)
