### PR TITLE
fix: modals.withdraw.status.failed translation

### DIFF
--- a/src/assets/translations/en/main.json
+++ b/src/assets/translations/en/main.json
@@ -626,7 +626,7 @@
       "status": {
         "pending": "Your transaction has been broadcast and is pending confirmation.",
         "success": "You have successfully withdrawn from %{opportunity}.",
-        "failed": "There was an issue with your deposit."
+        "failed": "There was an issue with your withdraw."
       },
       "info": {
         "delayed": "The delayed withdrawal has two transactions:",


### PR DESCRIPTION
## Description

Currently, the `failed` translation in `modals.withdraw.status` uses the `deposit` word instead of `withdraw` 

## Notice

<!-- Before submitting a pull request, please make sure you have answered the following: -->

- [x] Have you followed the guidelines in our [Contributing]('https://github.com/shapeshift/web/CONTRIBUTING.md) guide?
- [x] Have you checked to ensure there aren't other open [Pull Requests](https://github.com/shapeshift/web/pulls) for the same update/change?

## Pull Request Type

- [x] :bug: Bug fix (Non-breaking Change: Fixes an issue)
- [ ] :hammer_and_wrench: Chore (Non-breaking Change: Doc updates, pkg upgrades, typos, etc..)
- [ ] :nail_care: New Feature (Breaking/Non-breaking Change)

## Issue (if applicable)

N/A

## Risk

None.

## Testing

- Applies to Foxy and Yearn failed witthdraws, which might be a tricky state to get to

## Screenshots (if applicable)
