### PR TITLE
fix: yearn overview modal tvl

### DIFF
--- a/src/features/defi/providers/yearn/components/YearnManager/Overview/YearnOverview.tsx
+++ b/src/features/defi/providers/yearn/components/YearnManager/Overview/YearnOverview.tsx
@@ -2,6 +2,7 @@ import { ArrowDownIcon, ArrowUpIcon } from '@chakra-ui/icons'
 import { Center, useToast } from '@chakra-ui/react'
 import { toAssetId } from '@shapeshiftoss/caip'
 import { YearnOpportunity } from '@shapeshiftoss/investor-yearn'
+import { USDC_PRECISION } from 'constants/UsdcPrecision'
 import { Overview } from 'features/defi/components/Overview/Overview'
 import {
   DefiAction,
@@ -103,7 +104,7 @@ export const YearnOverview = () => {
         isLoaded: !descriptionQuery.isLoading,
         isTrustedDescription: underlyingToken.isTrustedDescription,
       }}
-      tvl={opportunity.tvl.balanceUsdc.toFixed(2)}
+      tvl={opportunity.tvl.balanceUsdc.div(`1e+${USDC_PRECISION}`).toString()}
       apy={opportunity.apy.toString()}
       menu={[
         {


### PR DESCRIPTION
## Description

This fixes the TVL in the yearn overview modal, which is currently using the raw TVL value and needs to be divided by a million

## Notice

<!-- Before submitting a pull request, please make sure you have answered the following: -->

- [x] Have you followed the guidelines in our [Contributing]('https://github.com/shapeshift/web/CONTRIBUTING.md) guide?
- [x] Have you checked to ensure there aren't other open [Pull Requests](https://github.com/shapeshift/web/pulls) for the same update/change?

## Pull Request Type

- [x] :bug: Bug fix (Non-breaking Change: Fixes an issue)
- [ ] :hammer_and_wrench: Chore (Non-breaking Change: Doc updates, pkg upgrades, typos, etc..)
- [ ] :nail_care: New Feature (Breaking/Non-breaking Change)

## Issue (if applicable)

N/A

## Risk

<!-----------------------------------------------------------------------------
Outline the scope of your changes and the risk associated with them. You must use your discretion as an engineer to determine the potential impact of your changes.

E.g. an upgrade to `hdwallet` or core state management would be considered higher risk, and might require a full regression test. UI or isolated view changes, or something behind a feature flag may have near zero risk. Small bug fixes might require testing isolated to the specific fix.
------------------------------------------------------------------------------>

## Testing

The TVL of Yearn opportunities rows should be the same as the one in the modal that opens on click.

## Screenshots (if applicable)

<img width="511" alt="image" src="https://user-images.githubusercontent.com/17035424/180835591-db93d5ba-2b31-41a6-bcaf-3e12eead80c0.png">
<img width="1125" alt="image" src="https://user-images.githubusercontent.com/17035424/180835725-16dced75-ba79-4c3f-9126-499bbc0dab38.png">