### PR TITLE
feat: reduce tx page size for Avalanche

### DIFF
--- a/src/state/slices/txHistorySlice/txHistorySlice.ts
+++ b/src/state/slices/txHistorySlice/txHistorySlice.ts
@@ -337,6 +337,13 @@ export const txHistoryApi = createApi({
               const pageSize = (() => {
                 switch (chainId) {
                   case KnownChainIds.AvalancheMainnet:
+                    /**
+                     * as of writing, the data source upstream from unchained can choke and timeout
+                     * on a page size of 100 for avalanche tx history.
+                     *
+                     * using a larger number of smaller requests is a stopgap to prevent timeouts
+                     * until we can address the root cause upstream.
+                     */
                     return 10
                   default:
                     return 100

--- a/src/state/slices/txHistorySlice/txHistorySlice.ts
+++ b/src/state/slices/txHistorySlice/txHistorySlice.ts
@@ -334,13 +334,22 @@ export const txHistoryApi = createApi({
                   },
                 }
 
+              const pageSize = (() => {
+                switch (chainId) {
+                  case KnownChainIds.AvalancheMainnet:
+                    return 10
+                  default:
+                    return 100
+                }
+              })()
+
               let currentCursor: string = ''
               try {
                 do {
                   const { cursor, transactions } = await adapter.getTxHistory({
                     cursor: currentCursor,
                     pubkey,
-                    pageSize: 100,
+                    pageSize,
                   })
 
                   currentCursor = cursor


### PR DESCRIPTION
## Description

Reduces the page size for TX requests to the Avalanche node from `100` to `10`.

## Notice

- [x] Have you followed the guidelines in our [Contributing]('https://github.com/shapeshift/web/CONTRIBUTING.md) guide?
- [x] Have you checked to ensure there aren't other open [Pull Requests](https://github.com/shapeshift/web/pulls) for the same update/change?

## Pull Request Type

- [ ] :bug: Bug fix (Non-breaking Change: Fixes an issue)
- [ ] :hammer_and_wrench: Chore (Non-breaking Change: Doc updates, pkg upgrades, typos, etc..)
- [x] :nail_care: New Feature (Breaking/Non-breaking Change)

## Issue (if applicable)

Closes https://github.com/shapeshift/web/issues/2231

## Risk

Minimal - more requests will be made addresses with a large numbers of Avalanche transactions.

## Testing

1. Enable Avalanche feature flag
2. Load the transaction history page
3. Note that the `pageSize` query param for Avalanche transaction requests is `10`, and Ethereum transaction requests is still `100`.

## Screenshots (if applicable)

<img width="322" alt="Screen Shot 2022-07-27 at 3 39 53 pm" src="https://user-images.githubusercontent.com/97164662/181169728-686f71c5-c666-4661-beb6-8386f7812ee7.png">