### PR TITLE
fix(foxPage): defi modal history push

### DIFF
--- a/src/features/defi/providers/foxy/components/FoxyManager/FoxyCommon.ts
+++ b/src/features/defi/providers/foxy/components/FoxyManager/FoxyCommon.ts
@@ -1,5 +1,0 @@
-export enum FoxyPath {
-  Deposit = '/defi/token_staking/ShapeShift/deposit',
-  Withdraw = '/defi/token_staking/ShapeShift/withdraw',
-  Overview = `/defi/token_staking/ShapeShift/overview`,
-}

--- a/src/plugins/foxPage/components/AssetActions.tsx
+++ b/src/plugins/foxPage/components/AssetActions.tsx
@@ -13,7 +13,7 @@ import {
 } from '@chakra-ui/react'
 import { AssetId } from '@shapeshiftoss/caip'
 import { foxyAddresses } from '@shapeshiftoss/investor-foxy'
-import { FoxyPath } from 'features/defi/providers/foxy/components/FoxyManager/FoxyCommon'
+import { DefiProvider } from 'features/defi/contexts/DefiManagerProvider/DefiCommon'
 import qs from 'qs'
 import { useTranslate } from 'react-polyglot'
 import { useHistory, useLocation } from 'react-router'
@@ -39,8 +39,8 @@ const TradeFoxyElasticSwapUrl = `https://elasticswap.org/#/swap`
 
 export const AssetActions: React.FC<FoxTabProps> = ({ assetId }) => {
   const translate = useTranslate()
-  const history = useHistory()
   const location = useLocation()
+  const history = useHistory()
   const asset = useAppSelector(state => selectAssetById(state, assetId))
   const { description } = asset || {}
   const trimmedDescription = trimWithEndEllipsis(description, TrimmedDescriptionLength)
@@ -61,12 +61,14 @@ export const AssetActions: React.FC<FoxTabProps> = ({ assetId }) => {
 
   const onGetAssetClick = () => {
     history.push({
-      pathname: FoxyPath.Overview,
+      pathname: location.pathname,
       search: qs.stringify({
+        provider: DefiProvider.ShapeShift,
         chainId: asset.chainId,
         contractAddress: foxyAddresses[0].staking,
         assetReference: foxyAddresses[0].fox,
         rewardId: foxyAddresses[0].foxy,
+        modal: 'overview',
       }),
       state: { background: location },
     })

--- a/src/plugins/foxPage/foxPage.tsx
+++ b/src/plugins/foxPage/foxPage.tsx
@@ -17,7 +17,7 @@ import {
 } from '@chakra-ui/react'
 import { AssetId } from '@shapeshiftoss/caip'
 import { foxyAddresses } from '@shapeshiftoss/investor-foxy'
-import { FoxyPath } from 'features/defi/providers/foxy/components/FoxyManager/FoxyCommon'
+import { DefiProvider } from 'features/defi/contexts/DefiManagerProvider/DefiCommon'
 import qs from 'qs'
 import { useMemo } from 'react'
 import { useTranslate } from 'react-polyglot'
@@ -232,12 +232,14 @@ export const FoxPage = () => {
                   balance={cryptoBalances[selectedAssetIndex]}
                   onClick={() => {
                     history.push({
-                      pathname: FoxyPath.Overview,
+                      pathname: location.pathname,
                       search: qs.stringify({
+                        provider: DefiProvider.ShapeShift,
                         chainId: assetFoxy.chainId,
                         contractAddress: foxyAddresses[0].staking,
                         assetReference: foxyAddresses[0].fox,
                         rewardId: foxyAddresses[0].foxy,
+                        modal: 'overview',
                       }),
                       state: { background: location },
                     })

--- a/src/plugins/foxPage/utils/getFoxPageRouteAssetId.ts
+++ b/src/plugins/foxPage/utils/getFoxPageRouteAssetId.ts
@@ -1,10 +1,6 @@
-import { AssetId } from '@shapeshiftoss/caip'
+import { ethChainId, toAssetId } from '@shapeshiftoss/caip'
+import { foxyAddresses } from '@shapeshiftoss/investor-foxy'
 import { matchPath } from 'react-router'
-
-const FoxRoutePartToAssetId: Record<string, AssetId> = {
-  fox: 'eip155:1/erc20:0xc770eefad204b5180df6a14ee197d99d808ee52d',
-  foxy: 'eip155:1/erc20:0xdc49108ce5c57bc3408c3a5e95f3d864ec386ed3',
-}
 
 const FOX_PAGE_DEFAULT_ASSET = 'fox'
 
@@ -14,10 +10,18 @@ export const getFoxPageRouteAssetId = (pathname: string) => {
   })
 
   if (foxPageAssetIdPathMatch) {
-    const foxAsset = foxPageAssetIdPathMatch?.params?.foxAsset ?? FOX_PAGE_DEFAULT_ASSET
+    const foxAsset = (foxPageAssetIdPathMatch?.params?.foxAsset ?? FOX_PAGE_DEFAULT_ASSET) as
+      | 'fox'
+      | 'foxy'
 
-    if (FoxRoutePartToAssetId[foxAsset]) {
-      return FoxRoutePartToAssetId[foxAsset]
+    if (foxyAddresses[0][foxAsset]) {
+      const assetReference = foxyAddresses[0][foxAsset]
+
+      return toAssetId({
+        assetReference,
+        assetNamespace: 'erc20',
+        chainId: ethChainId,
+      })
     }
   }
 }

--- a/src/plugins/foxPage/utils/getFoxPageRouteAssetId.ts
+++ b/src/plugins/foxPage/utils/getFoxPageRouteAssetId.ts
@@ -5,14 +5,12 @@ import { matchPath } from 'react-router'
 const FOX_PAGE_DEFAULT_ASSET = 'fox'
 
 export const getFoxPageRouteAssetId = (pathname: string) => {
-  const foxPageAssetIdPathMatch = matchPath<{ foxAsset?: string }>(pathname, {
+  const foxPageAssetIdPathMatch = matchPath<{ foxAsset?: 'fox' | 'foxy' }>(pathname, {
     path: '/fox/:foxAsset?',
   })
 
   if (foxPageAssetIdPathMatch) {
-    const foxAsset = (foxPageAssetIdPathMatch?.params?.foxAsset ?? FOX_PAGE_DEFAULT_ASSET) as
-      | 'fox'
-      | 'foxy'
+    const foxAsset = foxPageAssetIdPathMatch?.params?.foxAsset ?? FOX_PAGE_DEFAULT_ASSET
 
     if (foxyAddresses[0][foxAsset]) {
       const assetReference = foxyAddresses[0][foxAsset]


### PR DESCRIPTION
## Description

This fixes the "Get FOXy" and "Get Started / Manage" links for the main FOXy opportunity in the Fox Page following the DeFi UI refactor.

Also does some housekeeping by cleaning up the now unused `FoxyCommon` module as well as refactoring the `getFoxPageRouteAssetId` to use `foxyAddresses` from `@shapeshiftoss/investor-foxy` for consistency.

## Notice

<!-- Before submitting a pull request, please make sure you have answered the following: -->

- [x] Have you followed the guidelines in our [Contributing]('https://github.com/shapeshift/web/CONTRIBUTING.md) guide?
- [x] Have you checked to ensure there aren't other open [Pull Requests](https://github.com/shapeshift/web/pulls) for the same update/change?

## Pull Request Type

- [x] :bug: Bug fix (Non-breaking Change: Fixes an issue)
- [ ] :hammer_and_wrench: Chore (Non-breaking Change: Doc updates, pkg upgrades, typos, etc..)
- [ ] :nail_care: New Feature (Breaking/Non-breaking Change)

## Issue (if applicable)

closes https://github.com/shapeshift/web/issues/2264

## Risk

Minimal, isolated to one specific part of the Fox Page.

## Testing

- In the FOXy tab of the Fox Page, "Get FOXy" should open the FOXy modal
- In the FOX tab of the Fox Page, "Get Started / Manage" should open the FOXy modal

## Screenshots (if applicable)

<img width="1223" alt="image" src="https://user-images.githubusercontent.com/17035424/181855126-39449ef3-f6c9-49cb-a35a-1ebc0d5d57bd.png">
<img width="1209" alt="image" src="https://user-images.githubusercontent.com/17035424/181855147-c938c7d3-1e6e-4288-a957-a190e8bdfb00.png">