### PR TITLE
feat: add config to check if app is running in mobile

### DIFF
--- a/src/config.ts
+++ b/src/config.ts
@@ -85,12 +85,5 @@ function reporter<T>({ errors }: envalid.ReporterOptions<T>) {
 }
 
 export const getConfig = memoize(() =>
-  Object.freeze(
-    merge(
-      { ...cleanEnv(env, validators, { reporter }) },
-      {
-        isMobile: Boolean((globalThis as any).isShapeShiftMobile),
-      },
-    ),
-  ),
+  Object.freeze(merge({ ...cleanEnv(env, validators, { reporter }) })),
 )

--- a/src/config.ts
+++ b/src/config.ts
@@ -85,5 +85,12 @@ function reporter<T>({ errors }: envalid.ReporterOptions<T>) {
 }
 
 export const getConfig = memoize(() =>
-  Object.freeze(merge({ ...cleanEnv(env, validators, { reporter }) })),
+  Object.freeze(
+    merge(
+      { ...cleanEnv(env, validators, { reporter }) },
+      {
+        isMobile: Boolean((globalThis as any).isShapeShiftMobile),
+      },
+    ),
+  ),
 )

--- a/src/config.ts
+++ b/src/config.ts
@@ -2,7 +2,6 @@ import * as envalid from 'envalid'
 import { bool } from 'envalid'
 import forEach from 'lodash/forEach'
 import memoize from 'lodash/memoize'
-import merge from 'lodash/merge'
 
 import env from './env'
 
@@ -85,5 +84,5 @@ function reporter<T>({ errors }: envalid.ReporterOptions<T>) {
 }
 
 export const getConfig = memoize(() =>
-  Object.freeze(merge({ ...cleanEnv(env, validators, { reporter }) })),
+  Object.freeze({ ...cleanEnv(env, validators, { reporter }) }),
 )

--- a/src/lib/globals.ts
+++ b/src/lib/globals.ts
@@ -1,0 +1,7 @@
+declare global {
+  interface Window {
+    isShapeShiftMobile: true | undefined
+  }
+}
+
+export const isMobile = Boolean(window.isShapeShiftMobile)


### PR DESCRIPTION
## Description

The `globalThis.isShapeShiftMobile` will be set to true via injected JavaScript from the new mobile app.

I've verified that the injected JavaScript runs before `config.ts` and returns true. This config variable can be used in the future to show different content as needed (such as a different wallet flow for the mobile app).

## Notice

<!-- Before submitting a pull request, please make sure you have answered the following: -->

- [X] Have you followed the guidelines in our [Contributing]('https://github.com/shapeshift/web/CONTRIBUTING.md) guide?
- [X] Have you checked to ensure there aren't other open [Pull Requests](https://github.com/shapeshift/web/pulls) for the same update/change?

## Pull Request Type

- [ ] :bug: Bug fix (Non-breaking Change: Fixes an issue)
- [ ] :hammer_and_wrench: Chore (Non-breaking Change: Doc updates, pkg upgrades, typos, etc..)
- [X] :nail_care: New Feature (Breaking/Non-breaking Change)

## Issue (if applicable)
N/A
## Risk
None. The worst case is that `isMobile` reports `false` when it should report `true`.
## Testing
Requires new mobile app for testing
## Screenshots (if applicable)
Mobile
![image](https://user-images.githubusercontent.com/1958266/182079555-36e55a7f-0ed4-48df-a605-de4f2c5c4ea4.png)

Desktop
![image](https://user-images.githubusercontent.com/1958266/182079698-80b5b9cf-0061-4ded-b518-5d4ab088bffe.png)
