### PR TITLE
feat: cosmos defi UI part 1: Cosmos DeFi provider

### DIFF
--- a/src/assets/translations/en/main.json
+++ b/src/assets/translations/en/main.json
@@ -300,6 +300,9 @@
       },
       "confirm": {
         "title": "Confirm"
+      },
+      "status": {
+        "title": "Status"
       }
     }
   },

--- a/src/features/defi/components/Deposit/Deposit.tsx
+++ b/src/features/defi/components/Deposit/Deposit.tsx
@@ -36,7 +36,7 @@ type DepositProps = {
   onCancel(): void
 }
 
-enum Field {
+export enum Field {
   FiatAmount = 'fiatAmount',
   CryptoAmount = 'cryptoAmount',
   Slippage = 'slippage',

--- a/src/features/defi/contexts/DefiManagerProvider/DefiCommon.ts
+++ b/src/features/defi/contexts/DefiManagerProvider/DefiCommon.ts
@@ -11,6 +11,8 @@ export enum DefiType {
 export enum DefiProvider {
   Yearn = 'yearn',
   ShapeShift = 'ShapeShift',
+  Cosmos = 'Cosmos',
+  Osmosis = 'Osmosis',
 }
 
 export enum DefiAction {

--- a/src/features/defi/contexts/DefiManagerProvider/DefiManagerProvider.tsx
+++ b/src/features/defi/contexts/DefiManagerProvider/DefiManagerProvider.tsx
@@ -4,6 +4,7 @@ import React, { useMemo } from 'react'
 import { useBrowserRouter } from 'hooks/useBrowserRouter/useBrowserRouter'
 
 import { DefiModal } from '../../components/DefiModal/DefiModal'
+import { CosmosManager } from '../../providers/cosmos/components/CosmosManager/CosmosManager'
 import { FoxyManager } from '../../providers/foxy/components/FoxyManager/FoxyManager'
 import { YearnManager } from '../../providers/yearn/components/YearnManager/YearnManager'
 import {
@@ -19,6 +20,8 @@ const DefiManagerContext = React.createContext<DefiManagerContextProps | null>(n
 const DefiModules = {
   [DefiProvider.Yearn]: YearnManager,
   [DefiProvider.ShapeShift]: FoxyManager,
+  [DefiProvider.Cosmos]: CosmosManager,
+  [DefiProvider.Osmosis]: CosmosManager,
 }
 
 /*

--- a/src/features/defi/providers/cosmos/components/CosmosManager/Claim/ClaimConfirm.tsx
+++ b/src/features/defi/providers/cosmos/components/CosmosManager/Claim/ClaimConfirm.tsx
@@ -1,0 +1,211 @@
+import {
+  Button,
+  Link,
+  ModalBody,
+  ModalFooter,
+  Skeleton,
+  SkeletonText,
+  Stack,
+  useToast,
+} from '@chakra-ui/react'
+import { ASSET_REFERENCE, AssetId, ChainId, toAssetId } from '@shapeshiftoss/caip'
+import { cosmossdk } from '@shapeshiftoss/chain-adapters'
+import { StakingAction } from 'plugins/cosmos/components/modals/Staking/StakingCommon'
+import { useStakingAction } from 'plugins/cosmos/hooks/useStakingAction/useStakingAction'
+import { getStakingFees } from 'plugins/cosmos/utils'
+import { useEffect, useState } from 'react'
+import { useTranslate } from 'react-polyglot'
+import { useHistory } from 'react-router'
+import { Amount } from 'components/Amount/Amount'
+import { AssetIcon } from 'components/AssetIcon'
+import { MiddleEllipsis } from 'components/MiddleEllipsis/MiddleEllipsis'
+import { Row } from 'components/Row/Row'
+import { SlideTransition } from 'components/SlideTransition'
+import { Text } from 'components/Text'
+import { getChainAdapterManager } from 'context/PluginProvider/chainAdapterSingleton'
+import { useWallet } from 'hooks/useWallet/useWallet'
+import { bnOrZero } from 'lib/bignumber/bignumber'
+import { selectAssetById, selectMarketDataById } from 'state/slices/selectors'
+import { useAppSelector } from 'state/store'
+
+type ClaimConfirmProps = {
+  assetId: AssetId
+  amount?: string
+  contractAddress: string
+  chainId: ChainId
+  onBack: () => void
+}
+
+export const ClaimConfirm = ({
+  assetId,
+  amount,
+  contractAddress,
+  chainId,
+  onBack,
+}: ClaimConfirmProps) => {
+  const [userAddress, setUserAddress] = useState<string>('')
+  const [estimatedGas, setEstimatedGas] = useState<string>('0')
+  const [loading, setLoading] = useState<boolean>(false)
+  const chainAdapterManager = getChainAdapterManager()
+  const { state: walletState } = useWallet()
+  const translate = useTranslate()
+  const claimAmount = bnOrZero(amount).toString()
+  const history = useHistory()
+
+  // Asset Info
+  const asset = useAppSelector(state => selectAssetById(state, assetId))
+  const feeAssetId = toAssetId({
+    chainId,
+    assetNamespace: 'slip44',
+    assetReference: ASSET_REFERENCE.Cosmos, // TODO: Programmatic
+  })
+  const feeAsset = useAppSelector(state => selectAssetById(state, feeAssetId))
+  const feeMarketData = useAppSelector(state => selectMarketDataById(state, feeAssetId))
+
+  const toast = useToast()
+
+  const { handleStakingAction } = useStakingAction()
+
+  const handleConfirm = async () => {
+    if (!walletState.wallet || !contractAddress || !userAddress) return
+    setLoading(true)
+
+    const { gasLimit, gasPrice } = await getStakingFees(asset, feeMarketData.price)
+
+    try {
+      const broadcastTxId = await handleStakingAction({
+        asset,
+        validator: contractAddress,
+        chainSpecific: {
+          gas: gasLimit,
+          fee: bnOrZero(gasPrice).times(`1e+${asset?.precision}`).toString(),
+        },
+        value: bnOrZero(claimAmount).times(`1e+${asset.precision}`).toString(),
+        action: StakingAction.Claim,
+      })
+      history.push('/status', {
+        txid: broadcastTxId,
+        assetId,
+        amount,
+        userAddress,
+        estimatedGas,
+        chainId,
+      })
+    } catch (error) {
+      console.error('ClaimWithdraw:handleConfirm error', error)
+      toast({
+        position: 'top-right',
+        description: translate('common.transactionFailedBody'),
+        title: translate('common.transactionFailed'),
+        status: 'error',
+      })
+    } finally {
+      setLoading(false)
+    }
+  }
+
+  useEffect(() => {
+    ;(async () => {
+      try {
+        if (!walletState.wallet) return
+
+        const { gasLimit, gasPrice } = await getStakingFees(asset, feeMarketData.price)
+
+        const chainAdapter = chainAdapterManager.get(chainId) as unknown as
+          | cosmossdk.cosmos.ChainAdapter
+          | cosmossdk.osmosis.ChainAdapter
+        const userAddress = await chainAdapter.getAddress({ wallet: walletState.wallet })
+        setUserAddress(userAddress)
+        const gasEstimate = bnOrZero(gasPrice).times(gasLimit).toFixed(0)
+        setEstimatedGas(gasEstimate)
+      } catch (error) {
+        // TODO: handle client side errors
+        console.error('CosmosClaim error:', error)
+      }
+    })()
+  }, [
+    chainId,
+    asset,
+    chainAdapterManager,
+    contractAddress,
+    feeAsset.precision,
+    feeMarketData.price,
+    walletState.wallet,
+  ])
+
+  return (
+    <SlideTransition>
+      <ModalBody>
+        <Stack alignItems='center' justifyContent='center' py={8}>
+          <Text color='gray.500' translation='defi.modals.claim.claimAmount' />
+          <Stack direction='row' alignItems='center' justifyContent='center'>
+            <AssetIcon boxSize='10' src={asset.icon} />
+            <Amount.Crypto
+              fontSize='3xl'
+              fontWeight='medium'
+              value={bnOrZero(claimAmount).div(`1e+${asset.precision}`).toString()}
+              symbol={asset?.symbol}
+            />
+          </Stack>
+        </Stack>
+      </ModalBody>
+      <ModalFooter flexDir='column'>
+        <Stack width='full' spacing={6}>
+          <Row>
+            <Row.Label>
+              <Text translation='defi.modals.claim.claimToAddress' />
+            </Row.Label>
+            <Row.Value>
+              <Skeleton minWidth='100px' isLoaded={!!userAddress}>
+                <Link
+                  isExternal
+                  color='blue.500'
+                  href={`${asset?.explorerAddressLink}${userAddress}`}
+                >
+                  <MiddleEllipsis address={userAddress} />
+                </Link>
+              </Skeleton>
+            </Row.Value>
+          </Row>
+          <Row>
+            <Row.Label>
+              <Text translation='common.estimatedGas' />
+            </Row.Label>
+            <Row.Value>
+              <SkeletonText
+                noOfLines={2}
+                isLoaded={!!bnOrZero(estimatedGas).gt(0)}
+                fontSize='md'
+                display='flex'
+                flexDir='column'
+                alignItems='flex-end'
+              >
+                <Stack textAlign='right' spacing={0}>
+                  <Amount.Fiat
+                    value={bnOrZero(estimatedGas)
+                      .div(`1e+${feeAsset.precision}`)
+                      .times(feeMarketData.price)
+                      .toFixed(2)}
+                  />
+                  <Amount.Crypto
+                    color='gray.500'
+                    value={bnOrZero(estimatedGas).div(`1e+${feeAsset.precision}`).toFixed(5)}
+                    symbol={feeAsset.symbol}
+                  />
+                </Stack>
+              </SkeletonText>
+            </Row.Value>
+          </Row>
+          <Stack direction='row' width='full' justifyContent='space-between'>
+            <Button size='lg' onClick={onBack}>
+              {translate('common.cancel')}
+            </Button>
+            <Button size='lg' colorScheme='blue' onClick={handleConfirm} isLoading={loading}>
+              {translate('defi.modals.claim.confirmClaim')}
+            </Button>
+          </Stack>
+        </Stack>
+      </ModalFooter>
+    </SlideTransition>
+  )
+}

--- a/src/features/defi/providers/cosmos/components/CosmosManager/Claim/ClaimRoutes.tsx
+++ b/src/features/defi/providers/cosmos/components/CosmosManager/Claim/ClaimRoutes.tsx
@@ -6,10 +6,7 @@ import { Route, Switch, useLocation } from 'react-router'
 import { RouteSteps } from 'components/RouteSteps/RouteSteps'
 import { SlideTransition } from 'components/SlideTransition'
 import { useBrowserRouter } from 'hooks/useBrowserRouter/useBrowserRouter'
-import {
-  MergedActiveStakingOpportunity,
-  useCosmosSdkStakingBalances,
-} from 'pages/Defi/hooks/useCosmosSdkStakingBalances'
+import { useCosmosSdkStakingBalances } from 'pages/Defi/hooks/useCosmosSdkStakingBalances'
 
 import { ClaimConfirm } from './ClaimConfirm'
 import { ClaimStatus } from './ClaimStatus'

--- a/src/features/defi/providers/cosmos/components/CosmosManager/Claim/ClaimRoutes.tsx
+++ b/src/features/defi/providers/cosmos/components/CosmosManager/Claim/ClaimRoutes.tsx
@@ -1,0 +1,70 @@
+import { toAssetId } from '@shapeshiftoss/caip'
+import { DefiParams, DefiQueryParams } from 'features/defi/contexts/DefiManagerProvider/DefiCommon'
+import { AnimatePresence } from 'framer-motion'
+import { useMemo } from 'react'
+import { Route, Switch, useLocation } from 'react-router'
+import { RouteSteps } from 'components/RouteSteps/RouteSteps'
+import { SlideTransition } from 'components/SlideTransition'
+import { useBrowserRouter } from 'hooks/useBrowserRouter/useBrowserRouter'
+import {
+  MergedActiveStakingOpportunity,
+  useCosmosSdkStakingBalances,
+} from 'pages/Defi/hooks/useCosmosSdkStakingBalances'
+
+import { ClaimConfirm } from './ClaimConfirm'
+import { ClaimStatus } from './ClaimStatus'
+
+enum OverviewPath {
+  Claim = '/',
+  ClaimStatus = '/status',
+}
+
+export const routes = [
+  { step: 0, path: OverviewPath.Claim, label: 'Confirm' },
+  { step: 1, path: OverviewPath.ClaimStatus, label: 'Status' },
+]
+
+type ClaimRouteProps = {
+  onBack: () => void
+}
+
+export const ClaimRoutes = ({ onBack }: ClaimRouteProps) => {
+  const { query } = useBrowserRouter<DefiQueryParams, DefiParams>()
+  const { contractAddress, assetReference, chainId } = query
+  const assetNamespace = 'slip44'
+  const stakingAssetId = toAssetId({
+    chainId,
+    assetNamespace,
+    assetReference,
+  })
+
+  const opportunities = useCosmosSdkStakingBalances({ assetId: stakingAssetId })
+  const opportunity = useMemo(
+    () =>
+      opportunities?.cosmosSdkStakingOpportunities?.find(
+        opportunity => opportunity.address === contractAddress,
+      ) ?? {},
+    [opportunities, contractAddress],
+  ) as MergedActiveStakingOpportunity
+  const location = useLocation()
+
+  return (
+    <SlideTransition>
+      <RouteSteps routes={routes} location={location} pt={4} />
+      <AnimatePresence exitBeforeEnter initial={false}>
+        <Switch location={location} key={location.key}>
+          <Route exact path='/'>
+            <ClaimConfirm
+              assetId={stakingAssetId}
+              chainId={chainId}
+              contractAddress={contractAddress}
+              onBack={onBack}
+              amount={opportunity.rewards}
+            />
+          </Route>
+          <Route exact path='/status' component={ClaimStatus} />
+        </Switch>
+      </AnimatePresence>
+    </SlideTransition>
+  )
+}

--- a/src/features/defi/providers/cosmos/components/CosmosManager/Claim/ClaimRoutes.tsx
+++ b/src/features/defi/providers/cosmos/components/CosmosManager/Claim/ClaimRoutes.tsx
@@ -43,10 +43,11 @@ export const ClaimRoutes = ({ onBack }: ClaimRouteProps) => {
     () =>
       opportunities?.cosmosSdkStakingOpportunities?.find(
         opportunity => opportunity.address === contractAddress,
-      ) ?? {},
+      ),
     [opportunities, contractAddress],
-  ) as MergedActiveStakingOpportunity
+  )
   const location = useLocation()
+  if (!opportunity) return null
 
   return (
     <SlideTransition>

--- a/src/features/defi/providers/cosmos/components/CosmosManager/Claim/ClaimStatus.tsx
+++ b/src/features/defi/providers/cosmos/components/CosmosManager/Claim/ClaimStatus.tsx
@@ -1,0 +1,160 @@
+import { Box, Button, Center, Link, ModalBody, ModalFooter, Stack } from '@chakra-ui/react'
+import { AssetId, ChainId } from '@shapeshiftoss/caip'
+import { useEffect, useState } from 'react'
+import { FaCheck, FaTimes } from 'react-icons/fa'
+import { useTranslate } from 'react-polyglot'
+import { useLocation } from 'react-router'
+import { Amount } from 'components/Amount/Amount'
+import { AssetIcon } from 'components/AssetIcon'
+import { CircularProgress } from 'components/CircularProgress/CircularProgress'
+import { IconCircle } from 'components/IconCircle'
+import { MiddleEllipsis } from 'components/MiddleEllipsis/MiddleEllipsis'
+import { Row } from 'components/Row/Row'
+import { SlideTransition } from 'components/SlideTransition'
+import { RawText } from 'components/Text'
+import { useBrowserRouter } from 'hooks/useBrowserRouter/useBrowserRouter'
+import { bnOrZero } from 'lib/bignumber/bignumber'
+import { selectAssetById } from 'state/slices/selectors'
+import { useAppSelector } from 'state/store'
+
+interface ClaimStatusState {
+  txid: string
+  assetId: AssetId
+  amount: string
+  userAddress: string
+  estimatedGas: string
+  usedGasFee?: string
+  status: string
+  chainId: ChainId
+}
+
+enum TxStatus {
+  PENDING = 'pending',
+  SUCCESS = 'success',
+  FAILED = 'failed',
+}
+
+type ClaimState = {
+  txStatus: TxStatus
+  usedGasFee?: string
+}
+
+const StatusInfo = {
+  [TxStatus.PENDING]: {
+    text: 'defi.broadcastingTransaction',
+    color: 'blue.500',
+  },
+  [TxStatus.SUCCESS]: {
+    text: 'defi.transactionComplete',
+    color: 'green.500',
+    icon: <FaCheck />,
+  },
+  [TxStatus.FAILED]: {
+    text: 'defi.transactionFailed',
+    color: 'red.500',
+    icon: <FaTimes />,
+  },
+}
+
+export const ClaimStatus = () => {
+  const { history: browserHistory } = useBrowserRouter()
+  const translate = useTranslate()
+  const {
+    state: { txid, amount, assetId, userAddress },
+  } = useLocation<ClaimStatusState>()
+  const [state, setState] = useState<ClaimState>({
+    txStatus: TxStatus.PENDING,
+  })
+
+  // Asset Info
+  const asset = useAppSelector(state => selectAssetById(state, assetId)) // TODO: diff denom for rewards
+
+  useEffect(() => {
+    ;(async () => {
+      if (!txid) return
+      try {
+        setState({
+          ...state,
+          txStatus: txid ? TxStatus.SUCCESS : TxStatus.FAILED,
+        })
+      } catch (error) {
+        console.error('CosmosClaim:useEffect error:', error)
+        setState({
+          ...state,
+          txStatus: TxStatus.FAILED,
+        })
+      }
+    })()
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, [])
+
+  return (
+    <SlideTransition>
+      <ModalBody>
+        <Center py={8} flexDirection='column'>
+          <CircularProgress
+            size='24'
+            position='relative'
+            thickness='4px'
+            isIndeterminate={state.txStatus === TxStatus.PENDING}
+          >
+            <Box position='absolute' top='50%' left='50%' transform='translate(-50%, -50%)'>
+              {state.txStatus === TxStatus.PENDING ? (
+                <AssetIcon src={asset?.icon} boxSize='16' />
+              ) : (
+                <IconCircle bg={StatusInfo[state.txStatus].color} boxSize='16' color='white'>
+                  {StatusInfo[state.txStatus].icon}
+                </IconCircle>
+              )}
+            </Box>
+          </CircularProgress>
+          <RawText mt={6} fontWeight='medium'>
+            {translate(
+              state.txStatus === TxStatus.PENDING
+                ? 'defi.broadcastingTransaction'
+                : 'defi.transactionComplete',
+            )}
+          </RawText>
+        </Center>
+      </ModalBody>
+      <ModalFooter>
+        <Stack width='full' spacing={4}>
+          {txid && (
+            <Row>
+              <Row.Label>{translate('modals.status.transactionId')}</Row.Label>
+              <Row.Value>
+                <Link isExternal color='blue.500' href={`${asset?.explorerTxLink}${txid}`}>
+                  <MiddleEllipsis address={txid} />
+                </Link>
+              </Row.Value>
+            </Row>
+          )}
+          <Row>
+            <Row.Label>{translate('defi.modals.claim.claimAmount')}</Row.Label>
+            <Row.Value>
+              <Amount.Crypto
+                value={bnOrZero(amount).div(`1e+${asset.precision}`).toString()}
+                symbol={asset?.symbol}
+              />
+            </Row.Value>
+          </Row>
+          <Row>
+            <Row.Label>{translate('defi.modals.claim.claimToAddress')}</Row.Label>
+            <Row.Value>
+              <Link
+                isExternal
+                color='blue.500'
+                href={`${asset?.explorerAddressLink}${userAddress}`}
+              >
+                <MiddleEllipsis address={userAddress} />
+              </Link>
+            </Row.Value>
+          </Row>
+          <Button width='full' size='lg' onClick={() => browserHistory.goBack()}>
+            {translate('common.close')}
+          </Button>
+        </Stack>
+      </ModalFooter>
+    </SlideTransition>
+  )
+}

--- a/src/features/defi/providers/cosmos/components/CosmosManager/Claim/CosmosClaim.tsx
+++ b/src/features/defi/providers/cosmos/components/CosmosManager/Claim/CosmosClaim.tsx
@@ -1,0 +1,59 @@
+import { toAssetId } from '@shapeshiftoss/caip'
+import { DefiModalContent } from 'features/defi/components/DefiModal/DefiModalContent'
+import { DefiModalHeader } from 'features/defi/components/DefiModal/DefiModalHeader'
+import {
+  DefiAction,
+  DefiParams,
+  DefiQueryParams,
+} from 'features/defi/contexts/DefiManagerProvider/DefiCommon'
+import qs from 'qs'
+import { useTranslate } from 'react-polyglot'
+import { MemoryRouter } from 'react-router'
+import { SlideTransition } from 'components/SlideTransition'
+import { useBrowserRouter } from 'hooks/useBrowserRouter/useBrowserRouter'
+import { selectAssetById } from 'state/slices/selectors'
+import { useAppSelector } from 'state/store'
+
+import { ClaimRoutes } from './ClaimRoutes'
+
+export const CosmosClaim = () => {
+  const { query, history, location } = useBrowserRouter<DefiQueryParams, DefiParams>()
+  const { chainId, assetReference } = query
+
+  const assetNamespace = 'slip44' // TODO: add to query, why do we hardcode this?
+  // Asset info
+  const assetId = toAssetId({
+    chainId,
+    assetNamespace,
+    assetReference, // TODO: handle multiple denoms
+  })
+  const asset = useAppSelector(state => selectAssetById(state, assetId))
+
+  const translate = useTranslate()
+
+  const handleBack = () => {
+    history.push({
+      pathname: location.pathname,
+      search: qs.stringify({
+        ...query,
+        modal: DefiAction.Overview,
+      }),
+    })
+  }
+
+  return (
+    <DefiModalContent>
+      <DefiModalHeader
+        onBack={handleBack}
+        title={translate('defi.modals.claim.claimYour', {
+          opportunity: `${asset.name}`,
+        })}
+      />
+      <SlideTransition>
+        <MemoryRouter>
+          <ClaimRoutes onBack={handleBack} />
+        </MemoryRouter>
+      </SlideTransition>
+    </DefiModalContent>
+  )
+}

--- a/src/features/defi/providers/cosmos/components/CosmosManager/CosmosManager.tsx
+++ b/src/features/defi/providers/cosmos/components/CosmosManager/CosmosManager.tsx
@@ -1,0 +1,53 @@
+import {
+  DefiAction,
+  DefiParams,
+  DefiQueryParams,
+} from 'features/defi/contexts/DefiManagerProvider/DefiCommon'
+import { AnimatePresence } from 'framer-motion'
+import { SlideTransition } from 'components/SlideTransition'
+import { useBrowserRouter } from 'hooks/useBrowserRouter/useBrowserRouter'
+
+import { CosmosClaim } from './Claim/CosmosClaim'
+import { CosmosDeposit } from './Deposit/CosmosDeposit'
+import { CosmosLearnMore } from './LearnMore/CosmosLearnMore'
+import { CosmosOverview } from './Overview/CosmosOverview'
+import { CosmosWithdraw } from './Withdraw/CosmosWithdraw'
+
+export const CosmosManager = () => {
+  const { query, history: browserHistory } = useBrowserRouter<DefiQueryParams, DefiParams>()
+  const { modal } = query
+  const handleCancel = () => {
+    browserHistory.goBack()
+  }
+
+  return (
+    <AnimatePresence exitBeforeEnter initial={false}>
+      {modal === DefiAction.GetStarted && (
+        <SlideTransition key={DefiAction.Overview}>
+          <CosmosLearnMore onClose={handleCancel} />
+        </SlideTransition>
+      )}
+
+      {modal === DefiAction.Overview && (
+        <SlideTransition key={DefiAction.Overview}>
+          <CosmosOverview />
+        </SlideTransition>
+      )}
+      {modal === DefiAction.Deposit && (
+        <SlideTransition key={DefiAction.Deposit}>
+          <CosmosDeposit />
+        </SlideTransition>
+      )}
+      {modal === DefiAction.Withdraw && (
+        <SlideTransition key={DefiAction.Withdraw}>
+          <CosmosWithdraw />
+        </SlideTransition>
+      )}
+      {modal === DefiAction.Claim && (
+        <SlideTransition key={DefiAction.Claim}>
+          <CosmosClaim />
+        </SlideTransition>
+      )}
+    </AnimatePresence>
+  )
+}

--- a/src/features/defi/providers/cosmos/components/CosmosManager/Deposit/CosmosDeposit.tsx
+++ b/src/features/defi/providers/cosmos/components/CosmosManager/Deposit/CosmosDeposit.tsx
@@ -1,0 +1,135 @@
+import { Center } from '@chakra-ui/react'
+import { toAssetId } from '@shapeshiftoss/caip'
+import { DefiModalContent } from 'features/defi/components/DefiModal/DefiModalContent'
+import { DefiModalHeader } from 'features/defi/components/DefiModal/DefiModalHeader'
+import {
+  DefiAction,
+  DefiParams,
+  DefiQueryParams,
+  DefiStep,
+} from 'features/defi/contexts/DefiManagerProvider/DefiCommon'
+import qs from 'qs'
+import { useEffect, useMemo, useReducer } from 'react'
+import { useTranslate } from 'react-polyglot'
+import { useSelector } from 'react-redux'
+import { CircularProgress } from 'components/CircularProgress/CircularProgress'
+import { DefiStepProps, Steps } from 'components/DeFi/components/Steps'
+import { getChainAdapterManager } from 'context/PluginProvider/chainAdapterSingleton'
+import { useBrowserRouter } from 'hooks/useBrowserRouter/useBrowserRouter'
+import { useWallet } from 'hooks/useWallet/useWallet'
+import { bnOrZero } from 'lib/bignumber/bignumber'
+import { useCosmosSdkStakingBalances } from 'pages/Defi/hooks/useCosmosSdkStakingBalances'
+import {
+  selectAssetById,
+  selectMarketDataById,
+  selectPortfolioLoading,
+  selectValidatorByAddress,
+} from 'state/slices/selectors'
+import { useAppSelector } from 'state/store'
+
+import { Confirm } from './components/Confirm'
+import { Deposit } from './components/Deposit'
+import { Status } from './components/Status'
+import { CosmosDepositActionType } from './DepositCommon'
+import { DepositContext } from './DepositContext'
+import { initialState, reducer } from './DepositReducer'
+
+export const CosmosDeposit = () => {
+  const translate = useTranslate()
+  const [state, dispatch] = useReducer(reducer, initialState)
+  const { query, history, location } = useBrowserRouter<DefiQueryParams, DefiParams>()
+  const { chainId, contractAddress, assetReference } = query
+  const assetNamespace = 'slip44'
+  const assetId = toAssetId({ chainId, assetNamespace, assetReference })
+
+  const asset = useAppSelector(state => selectAssetById(state, assetId))
+  const marketData = useAppSelector(state => selectMarketDataById(state, assetId))
+
+  // user info
+  const { state: walletState } = useWallet()
+  const loading = useSelector(selectPortfolioLoading)
+
+  const validatorData = useAppSelector(state => selectValidatorByAddress(state, contractAddress))
+
+  const apr = useMemo(() => bnOrZero(validatorData?.apr).toString(), [validatorData])
+
+  const opportunities = useCosmosSdkStakingBalances({ assetId })
+  const cosmosOpportunity = useMemo(
+    () =>
+      opportunities?.cosmosSdkStakingOpportunities?.find(
+        opportunity => opportunity.address === contractAddress,
+      ),
+    [opportunities, contractAddress],
+  )
+  useEffect(() => {
+    ;(async () => {
+      try {
+        if (!cosmosOpportunity) return
+
+        const chainAdapterManager = getChainAdapterManager()
+        const chainAdapter = chainAdapterManager.get(chainId)
+        if (!(walletState.wallet && contractAddress && chainAdapter && apr)) return
+
+        const address = await chainAdapter.getAddress({ wallet: walletState.wallet })
+
+        dispatch({ type: CosmosDepositActionType.SET_USER_ADDRESS, payload: address })
+        dispatch({
+          type: CosmosDepositActionType.SET_OPPORTUNITY,
+          payload: { ...cosmosOpportunity },
+        })
+      } catch (error) {
+        // TODO: handle client side errors
+        console.error('CosmosDeposit error:', error)
+      }
+    })()
+  }, [chainId, cosmosOpportunity, apr, contractAddress, walletState.wallet])
+
+  const handleBack = () => {
+    history.push({
+      pathname: location.pathname,
+      search: qs.stringify({
+        ...query,
+        modal: DefiAction.Overview,
+      }),
+    })
+  }
+
+  const StepConfig: DefiStepProps = useMemo(() => {
+    return {
+      [DefiStep.Info]: {
+        label: translate('defi.steps.deposit.info.title'),
+        description: translate('defi.steps.deposit.info.description', { asset: asset.symbol }),
+        component: Deposit,
+      },
+      [DefiStep.Confirm]: {
+        label: translate('defi.steps.confirm.title'),
+        component: Confirm,
+      },
+      [DefiStep.Status]: {
+        label: 'Status',
+        component: Status,
+      },
+    }
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, [asset.symbol])
+
+  if (loading || !asset || !marketData) {
+    return (
+      <Center minW='350px' minH='350px'>
+        <CircularProgress />
+      </Center>
+    )
+  }
+
+  return (
+    <DepositContext.Provider value={{ state, dispatch }}>
+      <DefiModalContent>
+        <DefiModalHeader
+          onBack={handleBack}
+          title={translate('modals.stake.stakeYour', { opportunity: `${asset.symbol}` })}
+        />
+        <Steps steps={StepConfig} />
+      </DefiModalContent>
+    </DepositContext.Provider>
+  )
+}

--- a/src/features/defi/providers/cosmos/components/CosmosManager/Deposit/DepositCommon.ts
+++ b/src/features/defi/providers/cosmos/components/CosmosManager/Deposit/DepositCommon.ts
@@ -1,0 +1,75 @@
+import { ChainId } from '@shapeshiftoss/caip'
+import { DepositValues, Field as DepositField } from 'features/defi/components/Deposit/Deposit'
+import { DefiType } from 'features/defi/contexts/DefiManagerProvider/DefiCommon'
+import { BigNumber } from 'lib/bignumber/bignumber'
+import { MergedActiveStakingOpportunity } from 'pages/Defi/hooks/useCosmosSdkStakingBalances'
+
+type SupportedCosmosOpportunity = {
+  type: DefiType
+  provider: string
+  version: string
+  stakingToken: string
+  chain: ChainId
+  tvl: BigNumber
+  apr: string
+  expired: boolean
+}
+
+type EstimatedGas = {
+  estimatedGasCrypto?: string
+}
+
+type CosmosDepositValues = Omit<DepositValues, DepositField.Slippage> &
+  EstimatedGas & {
+    txStatus: string
+    usedGasFee: string // TODO: remove this property?
+  }
+
+export type CosmosDepositState = {
+  cosmosOpportunity: SupportedCosmosOpportunity
+  userAddress: string | null
+  deposit: CosmosDepositValues
+  loading: boolean
+  pricePerShare: string
+  txid: string | null
+}
+
+export enum CosmosDepositActionType {
+  SET_OPPORTUNITY = 'SET_OPPORTUNITY',
+  SET_USER_ADDRESS = 'SET_USER_ADDRESS',
+  SET_DEPOSIT = 'SET_DEPOSIT',
+  SET_LOADING = 'SET_LOADING',
+  SET_TXID = 'SET_TXID',
+}
+
+type SetCosmosOpportunitiesAction = {
+  type: CosmosDepositActionType.SET_OPPORTUNITY
+  payload: Partial<MergedActiveStakingOpportunity> | null
+}
+
+type SetDeposit = {
+  type: CosmosDepositActionType.SET_DEPOSIT
+  payload: Partial<CosmosDepositValues>
+}
+
+type SetUserAddress = {
+  type: CosmosDepositActionType.SET_USER_ADDRESS
+  payload: string
+}
+
+type SetLoading = {
+  type: CosmosDepositActionType.SET_LOADING
+  payload: boolean
+}
+
+type SetTxid = {
+  type: CosmosDepositActionType.SET_TXID
+  payload: string
+}
+
+export type CosmosDepositActions =
+  | SetCosmosOpportunitiesAction
+  | SetDeposit
+  | SetUserAddress
+  | SetLoading
+  | SetTxid

--- a/src/features/defi/providers/cosmos/components/CosmosManager/Deposit/DepositContext.ts
+++ b/src/features/defi/providers/cosmos/components/CosmosManager/Deposit/DepositContext.ts
@@ -1,0 +1,10 @@
+import { createContext } from 'react'
+
+import { CosmosDepositActions, CosmosDepositState } from './DepositCommon'
+
+export interface IDepositContext {
+  state: CosmosDepositState | null
+  dispatch: React.Dispatch<CosmosDepositActions> | null
+}
+
+export const DepositContext = createContext<IDepositContext>({ state: null, dispatch: null })

--- a/src/features/defi/providers/cosmos/components/CosmosManager/Deposit/DepositReducer.ts
+++ b/src/features/defi/providers/cosmos/components/CosmosManager/Deposit/DepositReducer.ts
@@ -1,0 +1,55 @@
+import { KnownChainIds } from '@shapeshiftoss/types'
+import { DefiType } from 'features/defi/contexts/DefiManagerProvider/DefiCommon'
+import { bn, bnOrZero } from 'lib/bignumber/bignumber'
+
+import { CosmosDepositActions, CosmosDepositActionType, CosmosDepositState } from './DepositCommon'
+
+export const initialState: CosmosDepositState = {
+  txid: null,
+  cosmosOpportunity: {
+    stakingToken: '',
+    provider: '',
+    chain: KnownChainIds.CosmosMainnet,
+    type: DefiType.TokenStaking,
+    expired: false,
+    version: '',
+    tvl: bn(0),
+    apr: '',
+  },
+  userAddress: null,
+  loading: false,
+  pricePerShare: '',
+  deposit: {
+    fiatAmount: '',
+    cryptoAmount: '',
+    txStatus: 'pending',
+    usedGasFee: '',
+  },
+}
+
+export const reducer = (
+  state: CosmosDepositState,
+  action: CosmosDepositActions,
+): CosmosDepositState => {
+  switch (action.type) {
+    case CosmosDepositActionType.SET_OPPORTUNITY:
+      return {
+        ...state,
+        cosmosOpportunity: {
+          ...state.cosmosOpportunity,
+          ...action.payload,
+          tvl: bnOrZero(action.payload?.tvl),
+        },
+      }
+    case CosmosDepositActionType.SET_DEPOSIT:
+      return { ...state, deposit: { ...state.deposit, ...action.payload } }
+    case CosmosDepositActionType.SET_USER_ADDRESS:
+      return { ...state, userAddress: action.payload }
+    case CosmosDepositActionType.SET_LOADING:
+      return { ...state, loading: action.payload }
+    case CosmosDepositActionType.SET_TXID:
+      return { ...state, txid: action.payload }
+    default:
+      return state
+  }
+}

--- a/src/features/defi/providers/cosmos/components/CosmosManager/Deposit/components/Confirm.tsx
+++ b/src/features/defi/providers/cosmos/components/CosmosManager/Deposit/components/Confirm.tsx
@@ -1,0 +1,172 @@
+import { Alert, AlertIcon, Box, Stack, useToast } from '@chakra-ui/react'
+import { ASSET_REFERENCE, toAssetId } from '@shapeshiftoss/caip'
+import { Confirm as ReusableConfirm } from 'features/defi/components/Confirm/Confirm'
+import { Summary } from 'features/defi/components/Summary'
+import {
+  DefiParams,
+  DefiQueryParams,
+  DefiStep,
+} from 'features/defi/contexts/DefiManagerProvider/DefiCommon'
+import { StakingAction } from 'plugins/cosmos/components/modals/Staking/StakingCommon'
+import { useStakingAction } from 'plugins/cosmos/hooks/useStakingAction/useStakingAction'
+import { getStakingFees } from 'plugins/cosmos/utils'
+import { useContext } from 'react'
+import { useTranslate } from 'react-polyglot'
+import { Amount } from 'components/Amount/Amount'
+import { AssetIcon } from 'components/AssetIcon'
+import { StepComponentProps } from 'components/DeFi/components/Steps'
+import { Row } from 'components/Row/Row'
+import { RawText, Text } from 'components/Text'
+import { useBrowserRouter } from 'hooks/useBrowserRouter/useBrowserRouter'
+import { useWallet } from 'hooks/useWallet/useWallet'
+import { bnOrZero } from 'lib/bignumber/bignumber'
+import {
+  selectAssetById,
+  selectMarketDataById,
+  selectPortfolioCryptoHumanBalanceByAssetId,
+} from 'state/slices/selectors'
+import { useAppSelector } from 'state/store'
+
+import { CosmosDepositActionType } from '../DepositCommon'
+import { DepositContext } from '../DepositContext'
+
+export const Confirm = ({ onNext }: StepComponentProps) => {
+  const { state, dispatch } = useContext(DepositContext)
+  const translate = useTranslate()
+  const { query } = useBrowserRouter<DefiQueryParams, DefiParams>()
+  const { chainId, contractAddress, assetReference } = query
+  const assetNamespace = 'slip44'
+  const assetId = toAssetId({ chainId, assetNamespace, assetReference })
+  const feeAssetId = toAssetId({
+    chainId,
+    assetNamespace: 'slip44',
+    assetReference: ASSET_REFERENCE.Cosmos,
+  })
+
+  const asset = useAppSelector(state => selectAssetById(state, assetId))
+  const feeAsset = useAppSelector(state => selectAssetById(state, feeAssetId))
+  const feeMarketData = useAppSelector(state => selectMarketDataById(state, feeAssetId))
+
+  // user info
+  const { state: walletState } = useWallet()
+
+  // notify
+  const toast = useToast()
+
+  const feeAssetBalance = useAppSelector(state =>
+    selectPortfolioCryptoHumanBalanceByAssetId(state, { assetId: feeAsset?.assetId ?? '' }),
+  )
+
+  const marketData = useAppSelector(state => selectMarketDataById(state, assetId))
+
+  const { handleStakingAction } = useStakingAction()
+
+  if (!state || !dispatch) return null
+
+  const handleDeposit = async () => {
+    if (!state.userAddress || !assetReference || !walletState.wallet) return
+    dispatch({ type: CosmosDepositActionType.SET_LOADING, payload: true })
+
+    const { gasLimit, gasPrice } = await getStakingFees(asset, marketData.price)
+
+    try {
+      const broadcastTxId = await handleStakingAction({
+        asset,
+        validator: contractAddress,
+        chainSpecific: {
+          gas: gasLimit,
+          fee: bnOrZero(gasPrice).times(`1e+${asset?.precision}`).toString(),
+        },
+        value: bnOrZero(state.deposit.cryptoAmount).times(`1e+${asset.precision}`).toString(),
+        action: StakingAction.Stake,
+      })
+
+      dispatch({
+        type: CosmosDepositActionType.SET_DEPOSIT,
+        payload: {
+          txStatus: broadcastTxId?.length ? 'success' : 'failed',
+        },
+      })
+
+      if (!broadcastTxId) {
+        throw new Error() // TODO:
+      }
+
+      dispatch({ type: CosmosDepositActionType.SET_TXID, payload: broadcastTxId })
+    } catch (error) {
+      console.error('CosmosDeposit:handleDeposit error', error)
+      toast({
+        position: 'top-right',
+        description: translate('common.transactionFailedBody'),
+        title: translate('common.transactionFailed'),
+        status: 'error',
+      })
+    } finally {
+      onNext(DefiStep.Status)
+      dispatch({ type: CosmosDepositActionType.SET_LOADING, payload: false })
+    }
+  }
+
+  const hasEnoughBalanceForGas = bnOrZero(feeAssetBalance).gte(
+    bnOrZero(state.deposit.cryptoAmount).plus(
+      bnOrZero(state.deposit.estimatedGasCrypto).div(`1e+${feeAsset.precision}`),
+    ),
+  )
+
+  return (
+    <ReusableConfirm
+      onCancel={() => onNext(DefiStep.Info)}
+      onConfirm={handleDeposit}
+      loading={state.loading}
+      loadingText={translate('common.confirm')}
+      isDisabled={!hasEnoughBalanceForGas}
+      headerText='modals.confirm.deposit.header'
+    >
+      <Summary>
+        <Row variant='vertical' p={4}>
+          <Row.Label>
+            <Text translation='modals.confirm.amountToStake' />
+          </Row.Label>
+          <Row px={0} fontWeight='medium'>
+            <Stack direction='row' alignItems='center'>
+              <AssetIcon size='xs' src={asset.icon} />
+              <RawText>{asset.name}</RawText>
+            </Stack>
+            <Row.Value>
+              <Amount.Crypto value={state.deposit.cryptoAmount} symbol={asset.symbol} />
+            </Row.Value>
+          </Row>
+        </Row>
+        <Row p={4}>
+          <Row.Label>
+            <Text translation='modals.confirm.estimatedGas' />
+          </Row.Label>
+          <Row.Value>
+            <Box textAlign='right'>
+              <Amount.Fiat
+                fontWeight='bold'
+                value={bnOrZero(state.deposit.estimatedGasCrypto)
+                  .div(`1e+${feeAsset.precision}`)
+                  .times(feeMarketData.price)
+                  .toFixed(2)}
+              />
+              <Amount.Crypto
+                color='gray.500'
+                value={bnOrZero(state.deposit.estimatedGasCrypto)
+                  .div(`1e+${feeAsset.precision}`)
+                  .toFixed(5)}
+                symbol={feeAsset.symbol}
+              />
+            </Box>
+          </Row.Value>
+        </Row>
+      </Summary>
+      {!hasEnoughBalanceForGas && (
+        <Alert status='error' borderRadius='lg'>
+          <AlertIcon />
+          <Text translation={['modals.confirm.notEnoughGas', { assetSymbol: feeAsset.symbol }]} />
+        </Alert>
+      )}
+    </ReusableConfirm>
+  )
+}

--- a/src/features/defi/providers/cosmos/components/CosmosManager/Deposit/components/Deposit.tsx
+++ b/src/features/defi/providers/cosmos/components/CosmosManager/Deposit/components/Deposit.tsx
@@ -1,0 +1,142 @@
+import { useToast } from '@chakra-ui/react'
+import { toAssetId } from '@shapeshiftoss/caip'
+import { Deposit as ReusableDeposit, DepositValues } from 'features/defi/components/Deposit/Deposit'
+import {
+  DefiParams,
+  DefiQueryParams,
+  DefiStep,
+} from 'features/defi/contexts/DefiManagerProvider/DefiCommon'
+import { getStakingFees } from 'plugins/cosmos/utils'
+import { useContext, useMemo } from 'react'
+import { useTranslate } from 'react-polyglot'
+import { useHistory } from 'react-router-dom'
+import { StepComponentProps } from 'components/DeFi/components/Steps'
+import { useBrowserRouter } from 'hooks/useBrowserRouter/useBrowserRouter'
+import { BigNumber, bnOrZero } from 'lib/bignumber/bignumber'
+import { logger } from 'lib/logger'
+import {
+  selectAssetById,
+  selectMarketDataById,
+  selectPortfolioCryptoBalanceByAssetId,
+} from 'state/slices/selectors'
+import { useAppSelector } from 'state/store'
+
+import { CosmosDepositActionType } from '../DepositCommon'
+import { DepositContext } from '../DepositContext'
+
+const moduleLogger = logger.child({ namespace: ['CosmosDeposit:Deposit'] })
+
+export const Deposit: React.FC<StepComponentProps> = ({ onNext }) => {
+  const { state, dispatch } = useContext(DepositContext)
+  const history = useHistory()
+  const translate = useTranslate()
+  const { query } = useBrowserRouter<DefiQueryParams, DefiParams>()
+  const { chainId, assetReference } = query
+  const assetNamespace = 'slip44'
+  const assetId = toAssetId({ chainId, assetNamespace, assetReference })
+
+  const asset = useAppSelector(state => selectAssetById(state, assetId))
+  const marketData = useAppSelector(state => selectMarketDataById(state, assetId))
+
+  const opportunity = useMemo(() => state?.cosmosOpportunity, [state])
+
+  // user info
+  const balance = useAppSelector(state => selectPortfolioCryptoBalanceByAssetId(state, { assetId }))
+
+  // notify
+  const toast = useToast()
+
+  if (!state || !dispatch) return null
+
+  const getStakingGasEstimate = async () => {
+    if (!state.userAddress || !assetReference) return
+
+    const { gasLimit, gasPrice } = await getStakingFees(asset, marketData.price)
+
+    try {
+      return bnOrZero(gasPrice).times(gasLimit).toFixed(0)
+    } catch (error) {
+      moduleLogger.error(
+        { fn: 'getStakingGasEstimate', error },
+        'Error getting deposit gas estimate',
+      )
+      toast({
+        position: 'top-right',
+        description: translate('common.somethingWentWrongBody'),
+        title: translate('common.somethingWentWrong'),
+        status: 'error',
+      })
+    }
+  }
+
+  const handleContinue = async (formValues: DepositValues) => {
+    if (!state.userAddress) return
+    // set deposit state for future use
+    dispatch({ type: CosmosDepositActionType.SET_DEPOSIT, payload: formValues })
+    dispatch({ type: CosmosDepositActionType.SET_LOADING, payload: true })
+    try {
+      const estimatedGasCrypto = await getStakingGasEstimate()
+      if (!estimatedGasCrypto) return
+      dispatch({
+        type: CosmosDepositActionType.SET_DEPOSIT,
+        payload: { estimatedGasCrypto },
+      })
+      onNext(DefiStep.Confirm)
+      dispatch({ type: CosmosDepositActionType.SET_LOADING, payload: false })
+    } catch (error) {
+      moduleLogger.error({ fn: 'handleContinue', error }, 'Error on continue')
+      toast({
+        position: 'top-right',
+        description: translate('common.somethingWentWrongBody'),
+        title: translate('common.somethingWentWrong'),
+        status: 'error',
+      })
+      dispatch({ type: CosmosDepositActionType.SET_LOADING, payload: false })
+    }
+  }
+
+  const handleCancel = history.goBack
+
+  const validateCryptoAmount = (value: string) => {
+    const crypto = bnOrZero(balance).div(`1e+${asset.precision}`)
+    const _value = bnOrZero(value)
+    const hasValidBalance = crypto.gt(0) && _value.gt(0) && crypto.gte(value)
+    if (_value.isEqualTo(0)) return ''
+    return hasValidBalance || 'common.insufficientFunds'
+  }
+
+  const validateFiatAmount = (value: string) => {
+    const crypto = bnOrZero(balance).div(`1e+${asset.precision}`)
+    const fiat = crypto.times(marketData.price)
+    const _value = bnOrZero(value)
+    const hasValidBalance = fiat.gt(0) && _value.gt(0) && fiat.gte(value)
+    if (_value.isEqualTo(0)) return ''
+    return hasValidBalance || 'common.insufficientFunds'
+  }
+
+  const cryptoAmountAvailable = bnOrZero(balance).div(`1e${asset.precision}`)
+  const fiatAmountAvailable = bnOrZero(cryptoAmountAvailable).times(marketData.price)
+
+  return (
+    <ReusableDeposit
+      asset={asset}
+      isLoading={state.loading}
+      apy={String(opportunity?.apr)}
+      cryptoAmountAvailable={cryptoAmountAvailable.toPrecision()}
+      cryptoInputValidation={{
+        required: true,
+        validate: { validateCryptoAmount },
+      }}
+      fiatAmountAvailable={fiatAmountAvailable.toFixed(2, BigNumber.ROUND_DOWN)}
+      fiatInputValidation={{
+        required: true,
+        validate: { validateFiatAmount },
+      }}
+      marketData={marketData}
+      onCancel={handleCancel}
+      onContinue={handleContinue}
+      percentOptions={[0.25, 0.5, 0.75, 1]}
+      enableSlippage={false}
+    />
+  )
+}

--- a/src/features/defi/providers/cosmos/components/CosmosManager/Deposit/components/Status.tsx
+++ b/src/features/defi/providers/cosmos/components/CosmosManager/Deposit/components/Status.tsx
@@ -1,0 +1,112 @@
+import { CheckIcon, CloseIcon, ExternalLinkIcon } from '@chakra-ui/icons'
+import { Button, Link, Stack } from '@chakra-ui/react'
+import { toAssetId } from '@shapeshiftoss/caip'
+import { Summary } from 'features/defi/components/Summary'
+import { TxStatus } from 'features/defi/components/TxStatus/TxStatus'
+import { DefiParams, DefiQueryParams } from 'features/defi/contexts/DefiManagerProvider/DefiCommon'
+import { useContext } from 'react'
+import { useTranslate } from 'react-polyglot'
+import { useHistory } from 'react-router-dom'
+import { Amount } from 'components/Amount/Amount'
+import { AssetIcon } from 'components/AssetIcon'
+import { StatusTextEnum } from 'components/RouteSteps/RouteSteps'
+import { Row } from 'components/Row/Row'
+import { RawText, Text } from 'components/Text'
+import { useBrowserRouter } from 'hooks/useBrowserRouter/useBrowserRouter'
+import { selectAssetById } from 'state/slices/selectors'
+import { useAppSelector } from 'state/store'
+
+import { DepositContext } from '../DepositContext'
+
+export const Status = () => {
+  const translate = useTranslate()
+  const { state } = useContext(DepositContext)
+  const history = useHistory()
+  const { query, history: browserHistory } = useBrowserRouter<DefiQueryParams, DefiParams>()
+  const { chainId, assetReference } = query
+  const assetNamespace = 'slip44'
+  const assetId = toAssetId({ chainId, assetNamespace, assetReference })
+
+  const asset = useAppSelector(state => selectAssetById(state, assetId))
+
+  const handleViewPosition = () => {
+    browserHistory.push('/defi')
+  }
+
+  const handleCancel = history.goBack
+
+  if (!state) return null
+
+  const { statusIcon, statusText, statusBg, statusBody } = (() => {
+    switch (state.deposit.txStatus) {
+      case 'success':
+        return {
+          statusText: StatusTextEnum.success,
+          statusIcon: <CheckIcon color='white' />,
+          statusBody: translate('modals.deposit.status.success', {
+            opportunity: asset.name,
+          }),
+          statusBg: 'green.500',
+        }
+      case 'failed':
+        return {
+          statusText: StatusTextEnum.failed,
+          statusIcon: <CloseIcon color='white' />,
+          statusBody: translate('modals.deposit.status.failed'),
+          statusBg: 'red.500',
+        }
+      default:
+        return {
+          statusIcon: <AssetIcon size='xs' src={asset?.icon} />,
+          statusText: StatusTextEnum.pending,
+          statusBody: translate('modals.deposit.status.pending'),
+          statusBg: 'transparent',
+        }
+    }
+  })()
+
+  return (
+    <TxStatus
+      onClose={handleCancel}
+      onContinue={state.deposit.txStatus === 'success' ? handleViewPosition : undefined}
+      loading={!['success', 'failed'].includes(state.deposit.txStatus)}
+      statusText={statusText}
+      statusIcon={statusIcon}
+      statusBg={statusBg}
+      statusBody={statusBody}
+      continueText='modals.status.position'
+    >
+      <Summary>
+        <Row variant='vertical' p={4}>
+          <Row.Label>
+            <Text translation='modals.confirm.amountToStake' />
+          </Row.Label>
+          <Row px={0} fontWeight='medium'>
+            <Stack direction='row' alignItems='center'>
+              <AssetIcon size='xs' src={asset.icon} />
+              <RawText>{asset.name}</RawText>
+            </Stack>
+            <Row.Value>
+              <Amount.Crypto value={state.deposit.cryptoAmount} symbol={asset.symbol} />
+            </Row.Value>
+          </Row>
+        </Row>
+        {state.deposit.txStatus === 'success' && (
+          <Row variant='gutter'>
+            <Button
+              as={Link}
+              width='full'
+              isExternal
+              variant='ghost-filled'
+              colorScheme='green'
+              rightIcon={<ExternalLinkIcon />}
+              href={`${asset.explorerTxLink}/${state.txid}`}
+            >
+              {translate('defi.viewOnChain')}
+            </Button>
+          </Row>
+        )}
+      </Summary>
+    </TxStatus>
+  )
+}

--- a/src/features/defi/providers/cosmos/components/CosmosManager/LearnMore/CosmosLearnMore.tsx
+++ b/src/features/defi/providers/cosmos/components/CosmosManager/LearnMore/CosmosLearnMore.tsx
@@ -1,0 +1,155 @@
+import { ArrowBackIcon } from '@chakra-ui/icons'
+import { Box, Flex } from '@chakra-ui/layout'
+import { Button, IconButton } from '@chakra-ui/react'
+import { toAssetId } from '@shapeshiftoss/caip'
+import { useSteps } from 'chakra-ui-steps'
+import { DefiParams, DefiQueryParams } from 'features/defi/contexts/DefiManagerProvider/DefiCommon'
+import { DefiModalHeader } from 'plugins/cosmos/components/DefiModalHeader/DefiModalHeader'
+import { assetIdToUnbondingDays } from 'plugins/cosmos/components/modals/Staking/StakingCommon'
+import { useMemo } from 'react'
+import { useHistory } from 'react-router-dom'
+import rewards from 'assets/rewards.svg'
+import risk from 'assets/risk.svg'
+import withdraw from 'assets/withdraw.svg'
+import { CarouselDots } from 'components/CarouselDots/CarouselDots'
+import { SlideTransition } from 'components/SlideTransition'
+import { Text } from 'components/Text'
+import { useBrowserRouter } from 'hooks/useBrowserRouter/useBrowserRouter'
+import { selectAssetNameById } from 'state/slices/selectors'
+import { useAppSelector } from 'state/store'
+
+const STEP_TO_ELEMENTS_MAPPING = [
+  {
+    bodies: [
+      'defi.modals.learnMore.bodies.rateFluctuationInfo',
+      'defi.modals.learnMore.bodies.amountStakingInfo',
+      'defi.modals.learnMore.bodies.withdrawInfo',
+    ],
+    header: 'defi.modals.learnMore.headers.aboutStakingRewards',
+    headerImageSrc: rewards,
+  },
+  {
+    bodies: ['defi.modals.learnMore.bodies.unbondingInfo'],
+    header: 'defi.modals.learnMore.headers.unstaking',
+    headerImageSrc: withdraw,
+  },
+  {
+    bodies: [
+      'defi.modals.learnMore.bodies.slashingInfo',
+      'defi.modals.learnMore.bodies.partnerInfo',
+    ],
+    header: 'defi.modals.learnMore.headers.risks',
+    headerImageSrc: risk,
+  },
+]
+
+type LearnMoreProps = {
+  onClose: () => void
+}
+
+export const CosmosLearnMore = ({ onClose }: LearnMoreProps) => {
+  const history = useHistory()
+
+  const { query } = useBrowserRouter<DefiQueryParams, DefiParams>()
+  const { chainId, assetReference } = query
+  const assetNamespace = 'slip44'
+
+  const assetId = toAssetId({ chainId, assetNamespace, assetReference })
+
+  const assetName = useAppSelector(state => selectAssetNameById(state, assetId))
+  const unbondingDays = useMemo(() => assetIdToUnbondingDays(assetId), [assetId])
+
+  const { nextStep, prevStep, setStep, activeStep } = useSteps({
+    initialStep: 1,
+  })
+
+  const stepsLength = Object.keys(STEP_TO_ELEMENTS_MAPPING).length
+  const isFirstStep = activeStep === 1
+  const isLastStep = activeStep === stepsLength
+
+  const handleNextOrCloseClick = () => {
+    if (isLastStep) return onClose()
+
+    nextStep()
+  }
+
+  const handlePrevClick = () => {
+    if (isFirstStep) {
+      return history.goBack()
+    }
+
+    prevStep()
+  }
+
+  const currentElement = STEP_TO_ELEMENTS_MAPPING[activeStep - 1]
+
+  return (
+    <>
+      <IconButton
+        variant='ghost'
+        icon={<ArrowBackIcon />}
+        aria-label={'common.back'}
+        position='absolute'
+        top={2}
+        left={3}
+        fontSize='xl'
+        size='sm'
+        onClick={handlePrevClick}
+      />
+      <Box pt='36px' pb='20px' px='24px'>
+        <Flex
+          direction='column'
+          maxWidth='395px'
+          height='520px'
+          alignItems='center'
+          justifyContent='space-between'
+        >
+          <SlideTransition key={activeStep}>
+            <Flex direction='column' alignItems='center'>
+              <DefiModalHeader
+                headerImageSrc={currentElement.headerImageSrc}
+                headerText={[currentElement.header, { assetName }]}
+                headerImageMaxWidth={120}
+              />
+              <Box>
+                <Flex direction='column'>
+                  {currentElement.bodies.map((body, i) => (
+                    <Box textAlign='left' key={i} mb='18px'>
+                      <Text
+                        translation={[body, { assetName, unbondingDays }]}
+                        color='gray.500'
+                        fontWeight='semibold'
+                        fontSize='15px'
+                      />
+                    </Box>
+                  ))}
+                </Flex>
+              </Box>
+            </Flex>
+          </SlideTransition>
+          <Flex width='100%' direction='column' justifyContent='center' alignItems='center'>
+            <Box width='100%'>
+              <Button
+                size='lg'
+                zIndex={1}
+                width='100%'
+                colorScheme='blue'
+                mb='20px'
+                onClick={handleNextOrCloseClick}
+              >
+                <Text
+                  translation={
+                    isLastStep ? 'defi.modals.learnMore.close' : 'defi.modals.learnMore.next'
+                  }
+                />
+              </Button>
+            </Box>
+            <Box width='46px'>
+              <CarouselDots length={stepsLength} activeIndex={activeStep} onClick={setStep} />
+            </Box>
+          </Flex>
+        </Flex>
+      </Box>
+    </>
+  )
+}

--- a/src/features/defi/providers/cosmos/components/CosmosManager/Overview/CosmosEmpty.tsx
+++ b/src/features/defi/providers/cosmos/components/CosmosManager/Overview/CosmosEmpty.tsx
@@ -1,0 +1,45 @@
+import { Button, Skeleton, Stack, Text as CText, VStack } from '@chakra-ui/react'
+import { Asset } from '@shapeshiftoss/asset-service'
+import { DefiModalContent } from 'features/defi/components/DefiModal/DefiModalContent'
+import { EmptyOverview } from 'features/defi/components/EmptyOverview/EmptyOverview'
+import { Amount } from 'components/Amount/Amount'
+import { Text } from 'components/Text'
+
+type CosmosEmptyProps = {
+  assets: Asset[]
+  apy: string | undefined
+  onStakeClick?: () => void
+  onLearnMoreClick?: () => void
+}
+
+export const CosmosEmpty = ({ assets, apy, onStakeClick, onLearnMoreClick }: CosmosEmptyProps) => {
+  const [stakingAsset] = assets // TODO: Handle different denom rewards
+  return (
+    <DefiModalContent>
+      <EmptyOverview
+        assets={assets}
+        footer={
+          <VStack spacing={4} align='center' width='100%'>
+            <Button width='full' colorScheme='blue' onClick={onStakeClick}>
+              <Text translation={'defi.modals.cosmosOverview.cta'} />
+            </Button>
+            <Button width='full' colorScheme='blue' onClick={onLearnMoreClick}>
+              <Text translation={'defi.modals.cosmosOverview.learnMore'} />
+            </Button>
+          </VStack>
+        }
+      >
+        <Stack direction='row' spacing={1} justifyContent='center' mb={4}>
+          <Text translation={['defi.modals.getStarted.header', { assetName: stakingAsset.name }]} />
+          <CText color='green.500'>
+            <Skeleton isLoaded={Boolean(apy)}>
+              <Amount.Percent value={apy ?? ''} suffix='APR' />
+            </Skeleton>
+          </CText>
+        </Stack>
+        <Text color='gray.500' translation='defi.modals.getStarted.body' />
+        <Text color='gray.500' translation='defi.modals.getStarted.userProtectionInfo' />
+      </EmptyOverview>
+    </DefiModalContent>
+  )
+}

--- a/src/features/defi/providers/cosmos/components/CosmosManager/Overview/CosmosOverview.tsx
+++ b/src/features/defi/providers/cosmos/components/CosmosManager/Overview/CosmosOverview.tsx
@@ -1,0 +1,185 @@
+import { ArrowDownIcon, ArrowUpIcon } from '@chakra-ui/icons'
+import { Center } from '@chakra-ui/react'
+import { toAssetId } from '@shapeshiftoss/caip'
+import { DefiModalContent } from 'features/defi/components/DefiModal/DefiModalContent'
+import { Overview } from 'features/defi/components/Overview/Overview'
+import {
+  DefiAction,
+  DefiParams,
+  DefiQueryParams,
+} from 'features/defi/contexts/DefiManagerProvider/DefiCommon'
+import {
+  isCosmosAssetId,
+  isOsmosisAssetId,
+} from 'plugins/cosmos/components/modals/Staking/StakingCommon'
+import qs from 'qs'
+import { useMemo } from 'react'
+import { FaGift } from 'react-icons/fa'
+import { useTranslate } from 'react-polyglot'
+import { CircularProgress } from 'components/CircularProgress/CircularProgress'
+import { useBrowserRouter } from 'hooks/useBrowserRouter/useBrowserRouter'
+import { bnOrZero } from 'lib/bignumber/bignumber'
+import {
+  MergedActiveStakingOpportunity,
+  useCosmosSdkStakingBalances,
+} from 'pages/Defi/hooks/useCosmosSdkStakingBalances'
+import { useGetAssetDescriptionQuery } from 'state/slices/assetsSlice/assetsSlice'
+import {
+  selectAssetById,
+  selectFirstAccountSpecifierByChainId,
+  selectMarketDataById,
+  selectSelectedLocale,
+  selectTotalBondingsBalanceByAssetId,
+  selectValidatorByAddress,
+} from 'state/slices/selectors'
+import {
+  SHAPESHIFT_COSMOS_VALIDATOR_ADDRESS,
+  SHAPESHIFT_OSMOSIS_VALIDATOR_ADDRESS,
+} from 'state/slices/validatorDataSlice/constants'
+import { useAppSelector } from 'state/store'
+
+import { CosmosEmpty } from './CosmosEmpty'
+import { WithdrawCard } from './WithdrawCard'
+
+export const CosmosOverview = () => {
+  const translate = useTranslate()
+  const { query, history, location } = useBrowserRouter<DefiQueryParams, DefiParams>()
+  const { chainId, contractAddress, assetReference } = query
+
+  const assetNamespace = 'slip44'
+  const stakingAssetId = toAssetId({
+    chainId,
+    assetNamespace,
+    assetReference,
+  })
+
+  const opportunities = useCosmosSdkStakingBalances({ assetId: stakingAssetId })
+
+  const opportunity = useMemo(
+    () =>
+      opportunities?.cosmosSdkStakingOpportunities?.find(
+        opportunity => opportunity.address === contractAddress,
+      ) ?? {},
+    [opportunities, contractAddress],
+  ) as MergedActiveStakingOpportunity
+
+  const loaded = useMemo(() => opportunity.isLoaded, [opportunity.isLoaded])
+
+  const stakingAsset = useAppSelector(state => selectAssetById(state, stakingAssetId))
+
+  const accountSpecifier = useAppSelector(state =>
+    selectFirstAccountSpecifierByChainId(state, stakingAsset?.chainId),
+  )
+
+  const totalBondings = useAppSelector(state =>
+    selectTotalBondingsBalanceByAssetId(state, {
+      accountSpecifier,
+      validatorAddress: contractAddress,
+      assetId: stakingAsset.assetId,
+    }),
+  )
+
+  const marketData = useAppSelector(state => selectMarketDataById(state, stakingAssetId))
+  const cryptoAmountAvailable = bnOrZero(totalBondings).div(`1e${stakingAsset.precision}`)
+  const fiatAmountAvailable = bnOrZero(cryptoAmountAvailable).times(marketData.price)
+  const hasClaim = bnOrZero(opportunity.rewards).gt(0)
+  const claimDisabled = !hasClaim
+
+  const selectedLocale = useAppSelector(selectSelectedLocale)
+  const descriptionQuery = useGetAssetDescriptionQuery({ assetId: stakingAssetId, selectedLocale })
+
+  const defaultValidatorAddress = useMemo(() => {
+    if (isCosmosAssetId(stakingAssetId)) return SHAPESHIFT_COSMOS_VALIDATOR_ADDRESS
+    if (isOsmosisAssetId(stakingAssetId)) return SHAPESHIFT_OSMOSIS_VALIDATOR_ADDRESS
+
+    return ''
+  }, [stakingAssetId])
+  const validatorData = useAppSelector(state =>
+    selectValidatorByAddress(state, defaultValidatorAddress),
+  )
+
+  const apr = useMemo(() => bnOrZero(validatorData?.apr).toString(), [validatorData])
+
+  if (!loaded || !opportunity) {
+    return (
+      <DefiModalContent>
+        <Center minW='350px' minH='350px'>
+          <CircularProgress isIndeterminate />
+        </Center>
+      </DefiModalContent>
+    )
+  }
+
+  if (bnOrZero(totalBondings).eq(0)) {
+    return (
+      <CosmosEmpty
+        assets={[stakingAsset]}
+        apy={apr ?? ''}
+        onStakeClick={() =>
+          history.push({
+            pathname: location.pathname,
+            search: qs.stringify({
+              ...query,
+              modal: DefiAction.Deposit,
+            }),
+          })
+        }
+        onLearnMoreClick={() =>
+          history.push({
+            pathname: location.pathname,
+            search: qs.stringify({
+              ...query,
+              modal: DefiAction.GetStarted,
+            }),
+          })
+        }
+      />
+    )
+  }
+
+  return (
+    <Overview
+      asset={stakingAsset}
+      name={opportunity.moniker}
+      opportunityFiatBalance={fiatAmountAvailable.toFixed(2)}
+      underlyingAssets={[
+        {
+          ...stakingAsset,
+          cryptoBalance: cryptoAmountAvailable.toFixed(stakingAsset.precision),
+          allocationPercentage: '1',
+        },
+      ]}
+      provider={`${stakingAsset.name} Staking`}
+      menu={[
+        {
+          label: 'common.deposit',
+          icon: <ArrowUpIcon />,
+          action: DefiAction.Deposit,
+        },
+        {
+          label: 'common.withdraw',
+          icon: <ArrowDownIcon />,
+          action: DefiAction.Withdraw,
+        },
+        {
+          label: 'common.claim',
+          icon: <FaGift />,
+          action: DefiAction.Claim,
+          variant: 'ghost-filled',
+          colorScheme: 'green',
+          isDisabled: claimDisabled,
+          toolTip: translate('defi.modals.overview.noWithdrawals'),
+        },
+      ]}
+      description={{
+        description: stakingAsset.description,
+        isLoaded: !descriptionQuery.isLoading,
+        isTrustedDescription: stakingAsset.isTrustedDescription,
+      }}
+      tvl={bnOrZero(opportunity.tvl).toFixed(2)}
+      apy={apr?.toString()}
+    >
+      <WithdrawCard asset={stakingAsset} />
+    </Overview>
+  )
+}

--- a/src/features/defi/providers/cosmos/components/CosmosManager/Overview/CosmosOverview.tsx
+++ b/src/features/defi/providers/cosmos/components/CosmosManager/Overview/CosmosOverview.tsx
@@ -19,10 +19,7 @@ import { useTranslate } from 'react-polyglot'
 import { CircularProgress } from 'components/CircularProgress/CircularProgress'
 import { useBrowserRouter } from 'hooks/useBrowserRouter/useBrowserRouter'
 import { bnOrZero } from 'lib/bignumber/bignumber'
-import {
-  MergedActiveStakingOpportunity,
-  useCosmosSdkStakingBalances,
-} from 'pages/Defi/hooks/useCosmosSdkStakingBalances'
+import { useCosmosSdkStakingBalances } from 'pages/Defi/hooks/useCosmosSdkStakingBalances'
 import { useGetAssetDescriptionQuery } from 'state/slices/assetsSlice/assetsSlice'
 import {
   selectAssetById,
@@ -59,11 +56,11 @@ export const CosmosOverview = () => {
     () =>
       opportunities?.cosmosSdkStakingOpportunities?.find(
         opportunity => opportunity.address === contractAddress,
-      ) ?? {},
+      ),
     [opportunities, contractAddress],
-  ) as MergedActiveStakingOpportunity
+  )
 
-  const loaded = useMemo(() => opportunity.isLoaded, [opportunity.isLoaded])
+  const loaded = useMemo(() => opportunity?.isLoaded, [opportunity?.isLoaded])
 
   const stakingAsset = useAppSelector(state => selectAssetById(state, stakingAssetId))
 
@@ -82,8 +79,6 @@ export const CosmosOverview = () => {
   const marketData = useAppSelector(state => selectMarketDataById(state, stakingAssetId))
   const cryptoAmountAvailable = bnOrZero(totalBondings).div(`1e${stakingAsset.precision}`)
   const fiatAmountAvailable = bnOrZero(cryptoAmountAvailable).times(marketData.price)
-  const hasClaim = bnOrZero(opportunity.rewards).gt(0)
-  const claimDisabled = !hasClaim
 
   const selectedLocale = useAppSelector(selectSelectedLocale)
   const descriptionQuery = useGetAssetDescriptionQuery({ assetId: stakingAssetId, selectedLocale })
@@ -99,6 +94,11 @@ export const CosmosOverview = () => {
   )
 
   const apr = useMemo(() => bnOrZero(validatorData?.apr).toString(), [validatorData])
+
+  if (!opportunity) return null
+
+  const hasClaim = bnOrZero(opportunity?.rewards).gt(0)
+  const claimDisabled = !hasClaim
 
   if (!loaded || !opportunity) {
     return (

--- a/src/features/defi/providers/cosmos/components/CosmosManager/Overview/WithdrawCard.tsx
+++ b/src/features/defi/providers/cosmos/components/CosmosManager/Overview/WithdrawCard.tsx
@@ -1,0 +1,97 @@
+import { Button, Stack, useColorModeValue } from '@chakra-ui/react'
+import { Asset } from '@shapeshiftoss/asset-service'
+import dayjs from 'dayjs'
+import { DefiParams, DefiQueryParams } from 'features/defi/contexts/DefiManagerProvider/DefiCommon'
+import { useMemo } from 'react'
+import { FaArrowDown } from 'react-icons/fa'
+import { Amount } from 'components/Amount/Amount'
+import { IconCircle } from 'components/IconCircle'
+import { Text } from 'components/Text'
+import { useBrowserRouter } from 'hooks/useBrowserRouter/useBrowserRouter'
+import { bnOrZero } from 'lib/bignumber/bignumber'
+import {
+  selectFirstAccountSpecifierByChainId,
+  selectUnbondingEntriesByAccountSpecifier,
+} from 'state/slices/selectors'
+import { useAppSelector } from 'state/store'
+
+type WithdrawCardProps = {
+  asset: Asset
+}
+
+export const WithdrawCard = ({ asset }: WithdrawCardProps) => {
+  const { query } = useBrowserRouter<DefiQueryParams, DefiParams>()
+  const { contractAddress } = query
+
+  const accountSpecifier = useAppSelector(state =>
+    selectFirstAccountSpecifierByChainId(state, asset?.chainId),
+  )
+
+  const undelegationEntries = useAppSelector(state =>
+    selectUnbondingEntriesByAccountSpecifier(state, {
+      accountSpecifier,
+      validatorAddress: contractAddress,
+      assetId: asset.assetId,
+    }),
+  )
+
+  const hasClaim = useMemo(() => Boolean(undelegationEntries.length), [undelegationEntries])
+  const textColor = useColorModeValue('black', 'white')
+
+  return (
+    <Stack px={8} py={6}>
+      <Text fontWeight='medium' translation='defi.modals.cosmosOverview.withdrawals' />
+      {!hasClaim ? (
+        <Text color='gray.500' translation='defi.modals.cosmosOverview.emptyWithdraws' />
+      ) : (
+        undelegationEntries.map(({ amount, completionTime }) => {
+          return (
+            <Button
+              variant='input'
+              _hover={{ cursor: 'auto', borderRadius: 'auto', borderColor: 'auto' }}
+              _active={{ cursor: 'auto', borderRadius: 'auto', borderColor: 'auto' }}
+              width='full'
+              maxHeight='auto'
+              height='auto'
+              alignItems='center'
+              justifyContent='flex-start'
+              textAlign='left'
+              py={2}
+              leftIcon={
+                <IconCircle>
+                  <FaArrowDown />
+                </IconCircle>
+              }
+            >
+              <Stack spacing={0}>
+                <Text color={textColor} translation='common.withdrawal' />
+                <Text
+                  color={'yellow.200'}
+                  fontWeight='normal'
+                  lineHeight='shorter'
+                  translation={'common.pending'}
+                />
+              </Stack>
+              <Stack spacing={0} ml='auto' textAlign='right'>
+                <Amount.Crypto
+                  color={textColor}
+                  value={bnOrZero(amount).div(`1e+${asset.precision}`).toString()}
+                  symbol={asset.symbol}
+                  maximumFractionDigits={asset.precision}
+                />
+                <Text
+                  fontWeight='normal'
+                  lineHeight='shorter'
+                  translation={[
+                    'defi.modals.cosmosOverview.availableDate',
+                    { date: dayjs().to(dayjs.unix(completionTime)) },
+                  ]}
+                />
+              </Stack>
+            </Button>
+          )
+        })
+      )}
+    </Stack>
+  )
+}

--- a/src/features/defi/providers/cosmos/components/CosmosManager/Overview/WithdrawCard.tsx
+++ b/src/features/defi/providers/cosmos/components/CosmosManager/Overview/WithdrawCard.tsx
@@ -38,59 +38,65 @@ export const WithdrawCard = ({ asset }: WithdrawCardProps) => {
   const hasClaim = useMemo(() => Boolean(undelegationEntries.length), [undelegationEntries])
   const textColor = useColorModeValue('black', 'white')
 
+  const undelegationNodes = useMemo(
+    () =>
+      undelegationEntries.map(({ amount, completionTime }) => {
+        return (
+          <Button
+            variant='input'
+            _hover={{ cursor: 'auto', borderRadius: 'auto', borderColor: 'auto' }}
+            _active={{ cursor: 'auto', borderRadius: 'auto', borderColor: 'auto' }}
+            width='full'
+            maxHeight='auto'
+            height='auto'
+            alignItems='center'
+            justifyContent='flex-start'
+            textAlign='left'
+            py={2}
+            leftIcon={
+              <IconCircle>
+                <FaArrowDown />
+              </IconCircle>
+            }
+          >
+            <Stack spacing={0}>
+              <Text color={textColor} translation='common.withdrawal' />
+              <Text
+                color={'yellow.200'}
+                fontWeight='normal'
+                lineHeight='shorter'
+                translation={'common.pending'}
+              />
+            </Stack>
+            <Stack spacing={0} ml='auto' textAlign='right'>
+              <Amount.Crypto
+                color={textColor}
+                value={bnOrZero(amount).div(`1e+${asset.precision}`).toString()}
+                symbol={asset.symbol}
+                maximumFractionDigits={asset.precision}
+              />
+              <Text
+                fontWeight='normal'
+                lineHeight='shorter'
+                translation={[
+                  'defi.modals.cosmosOverview.availableDate',
+                  { date: dayjs().to(dayjs.unix(completionTime)) },
+                ]}
+              />
+            </Stack>
+          </Button>
+        )
+      }),
+    [asset.precision, asset.symbol, textColor, undelegationEntries],
+  )
+
   return (
     <Stack px={8} py={6}>
       <Text fontWeight='medium' translation='defi.modals.cosmosOverview.withdrawals' />
       {!hasClaim ? (
         <Text color='gray.500' translation='defi.modals.cosmosOverview.emptyWithdraws' />
       ) : (
-        undelegationEntries.map(({ amount, completionTime }) => {
-          return (
-            <Button
-              variant='input'
-              _hover={{ cursor: 'auto', borderRadius: 'auto', borderColor: 'auto' }}
-              _active={{ cursor: 'auto', borderRadius: 'auto', borderColor: 'auto' }}
-              width='full'
-              maxHeight='auto'
-              height='auto'
-              alignItems='center'
-              justifyContent='flex-start'
-              textAlign='left'
-              py={2}
-              leftIcon={
-                <IconCircle>
-                  <FaArrowDown />
-                </IconCircle>
-              }
-            >
-              <Stack spacing={0}>
-                <Text color={textColor} translation='common.withdrawal' />
-                <Text
-                  color={'yellow.200'}
-                  fontWeight='normal'
-                  lineHeight='shorter'
-                  translation={'common.pending'}
-                />
-              </Stack>
-              <Stack spacing={0} ml='auto' textAlign='right'>
-                <Amount.Crypto
-                  color={textColor}
-                  value={bnOrZero(amount).div(`1e+${asset.precision}`).toString()}
-                  symbol={asset.symbol}
-                  maximumFractionDigits={asset.precision}
-                />
-                <Text
-                  fontWeight='normal'
-                  lineHeight='shorter'
-                  translation={[
-                    'defi.modals.cosmosOverview.availableDate',
-                    { date: dayjs().to(dayjs.unix(completionTime)) },
-                  ]}
-                />
-              </Stack>
-            </Button>
-          )
-        })
+        undelegationNodes
       )}
     </Stack>
   )

--- a/src/features/defi/providers/cosmos/components/CosmosManager/Withdraw/CosmosWithdraw.tsx
+++ b/src/features/defi/providers/cosmos/components/CosmosManager/Withdraw/CosmosWithdraw.tsx
@@ -1,0 +1,148 @@
+import { Center } from '@chakra-ui/react'
+import { toAssetId } from '@shapeshiftoss/caip'
+import { DefiModalContent } from 'features/defi/components/DefiModal/DefiModalContent'
+import { DefiModalHeader } from 'features/defi/components/DefiModal/DefiModalHeader'
+import {
+  DefiAction,
+  DefiParams,
+  DefiQueryParams,
+  DefiStep,
+} from 'features/defi/contexts/DefiManagerProvider/DefiCommon'
+import qs from 'qs'
+import { useEffect, useMemo, useReducer } from 'react'
+import { useTranslate } from 'react-polyglot'
+import { CircularProgress } from 'components/CircularProgress/CircularProgress'
+import { DefiStepProps, Steps } from 'components/DeFi/components/Steps'
+import { getChainAdapterManager } from 'context/PluginProvider/chainAdapterSingleton'
+import { useBrowserRouter } from 'hooks/useBrowserRouter/useBrowserRouter'
+import { useWallet } from 'hooks/useWallet/useWallet'
+import {
+  MergedActiveStakingOpportunity,
+  useCosmosSdkStakingBalances,
+} from 'pages/Defi/hooks/useCosmosSdkStakingBalances'
+import { selectAssetById, selectMarketDataById } from 'state/slices/selectors'
+import { useAppSelector } from 'state/store'
+
+import { Confirm } from './components/Confirm'
+import { Status } from './components/Status'
+import { Withdraw } from './components/Withdraw'
+import { CosmosWithdrawActionType } from './WithdrawCommon'
+import { WithdrawContext } from './WithdrawContext'
+import { initialState, reducer } from './WithdrawReducer'
+
+export const CosmosWithdraw = () => {
+  const translate = useTranslate()
+  const [state, dispatch] = useReducer(reducer, initialState)
+  const { query, history, location } = useBrowserRouter<DefiQueryParams, DefiParams>()
+  const { chainId, contractAddress, assetReference } = query
+
+  const assetNamespace = 'slip44' // TODO: add to query, why do we hardcode this?
+  // Asset info
+  const assetId = toAssetId({
+    chainId,
+    assetNamespace,
+    assetReference, // TODO: handle multiple denoms
+  })
+  const underlyingAssetId = toAssetId({
+    // TODO: Underlying asset is the same as the staked asset for now, handle multiple denoms
+    chainId,
+    assetNamespace,
+    assetReference,
+  })
+  const asset = useAppSelector(state => selectAssetById(state, assetId))
+  const underlyingAsset = useAppSelector(state => selectAssetById(state, underlyingAssetId))
+  const marketData = useAppSelector(state => selectMarketDataById(state, assetId))
+  const feeAssetId = toAssetId({
+    chainId,
+    assetNamespace,
+    assetReference,
+  })
+  const feeMarketData = useAppSelector(state => selectMarketDataById(state, feeAssetId))
+
+  // user info
+  const chainAdapterManager = getChainAdapterManager()
+  const chainAdapter = chainAdapterManager.get(chainId)
+  const { state: walletState } = useWallet()
+
+  const opportunities = useCosmosSdkStakingBalances({ assetId })
+  const cosmosOpportunity = useMemo(
+    () =>
+      opportunities?.cosmosSdkStakingOpportunities?.find(
+        opportunity => opportunity.address === contractAddress,
+      ) ?? {},
+    [opportunities, contractAddress],
+  ) as unknown as MergedActiveStakingOpportunity // TODO: remove casting
+
+  useEffect(() => {
+    ;(async () => {
+      try {
+        if (!(walletState.wallet && contractAddress && chainAdapter)) return
+        const address = await chainAdapter.getAddress({ wallet: walletState.wallet })
+
+        dispatch({
+          type: CosmosWithdrawActionType.SET_USER_ADDRESS,
+          payload: address,
+        })
+        dispatch({
+          type: CosmosWithdrawActionType.SET_OPPORTUNITY,
+          payload: { ...cosmosOpportunity },
+        })
+      } catch (error) {
+        // TODO: handle client side errors
+        console.error('CosmosWithdraw error:', error)
+      }
+    })()
+  }, [cosmosOpportunity, chainAdapter, contractAddress, walletState.wallet])
+
+  const StepConfig: DefiStepProps = useMemo(() => {
+    return {
+      [DefiStep.Info]: {
+        label: translate('defi.steps.withdraw.info.title'),
+        description: translate('defi.steps.withdraw.info.yieldyDescription', {
+          asset: underlyingAsset?.symbol ?? '',
+        }),
+        component: Withdraw,
+      },
+      [DefiStep.Confirm]: {
+        label: translate('defi.steps.confirm.title'),
+        component: Confirm,
+      },
+      [DefiStep.Status]: {
+        label: 'Status',
+        component: Status,
+      },
+    }
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, [underlyingAsset?.symbol])
+
+  const handleBack = () => {
+    history.push({
+      pathname: location.pathname,
+      search: qs.stringify({
+        ...query,
+        modal: DefiAction.Overview,
+      }),
+    })
+  }
+
+  if (!cosmosOpportunity?.isLoaded || !asset || !marketData || !feeMarketData)
+    return (
+      <Center minW='350px' minH='350px'>
+        <CircularProgress />
+      </Center>
+    )
+
+  return (
+    <WithdrawContext.Provider value={{ state, dispatch }}>
+      <DefiModalContent>
+        <DefiModalHeader
+          onBack={handleBack}
+          title={translate('modals.withdraw.unstakeYour', {
+            opportunity: `${underlyingAsset.symbol}`,
+          })}
+        />
+        <Steps steps={StepConfig} />
+      </DefiModalContent>
+    </WithdrawContext.Provider>
+  )
+}

--- a/src/features/defi/providers/cosmos/components/CosmosManager/Withdraw/CosmosWithdraw.tsx
+++ b/src/features/defi/providers/cosmos/components/CosmosManager/Withdraw/CosmosWithdraw.tsx
@@ -108,7 +108,7 @@ export const CosmosWithdraw = () => {
         component: Confirm,
       },
       [DefiStep.Status]: {
-        label: 'Status',
+        label: translate('defi.steps.status.title'),
         component: Status,
       },
     }

--- a/src/features/defi/providers/cosmos/components/CosmosManager/Withdraw/WithdrawCommon.ts
+++ b/src/features/defi/providers/cosmos/components/CosmosManager/Withdraw/WithdrawCommon.ts
@@ -1,0 +1,76 @@
+import { ChainId } from '@shapeshiftoss/caip'
+import { WithdrawType } from '@shapeshiftoss/types'
+import { Field as WithdrawField, WithdrawValues } from 'features/defi/components/Withdraw/Withdraw'
+import { DefiType } from 'features/defi/contexts/DefiManagerProvider/DefiCommon'
+import { BigNumber } from 'lib/bignumber/bignumber'
+import { MergedActiveStakingOpportunity } from 'pages/Defi/hooks/useCosmosSdkStakingBalances'
+
+type SupportedCosmosOpportunity = {
+  type: DefiType
+  provider: string
+  version: string
+  contractAddress: string
+  stakingToken: string
+  chain: ChainId
+  tvl: BigNumber
+  expired: boolean
+}
+
+type EstimatedGas = {
+  estimatedGasCrypto?: string
+}
+
+type CosmosWithdrawValues = Omit<WithdrawValues, WithdrawField.Slippage> &
+  EstimatedGas & {
+    txStatus: string
+    usedGasFee: string
+    withdrawType: WithdrawType
+  }
+
+export type CosmosWithdrawState = {
+  cosmosOpportunity: SupportedCosmosOpportunity
+  userAddress: string | null
+  withdraw: CosmosWithdrawValues
+  loading: boolean
+  txid: string | null
+}
+export enum CosmosWithdrawActionType {
+  SET_OPPORTUNITY = 'SET_OPPORTUNITY',
+  SET_USER_ADDRESS = 'SET_USER_ADDRESS',
+  SET_WITHDRAW = 'SET_WITHDRAW',
+  SET_LOADING = 'SET_LOADING',
+  SET_TXID = 'SET_TXID',
+  SET_TX_STATUS = 'SET_TX_STATUS',
+}
+
+type SetVaultAction = {
+  type: CosmosWithdrawActionType.SET_OPPORTUNITY
+  payload: MergedActiveStakingOpportunity
+}
+
+type SetWithdraw = {
+  type: CosmosWithdrawActionType.SET_WITHDRAW
+  payload: Partial<CosmosWithdrawValues>
+}
+
+type SetUserAddress = {
+  type: CosmosWithdrawActionType.SET_USER_ADDRESS
+  payload: string
+}
+
+type SetLoading = {
+  type: CosmosWithdrawActionType.SET_LOADING
+  payload: boolean
+}
+
+type SetTxid = {
+  type: CosmosWithdrawActionType.SET_TXID
+  payload: string
+}
+
+export type CosmosWithdrawActions =
+  | SetVaultAction
+  | SetWithdraw
+  | SetUserAddress
+  | SetLoading
+  | SetTxid

--- a/src/features/defi/providers/cosmos/components/CosmosManager/Withdraw/WithdrawContext.ts
+++ b/src/features/defi/providers/cosmos/components/CosmosManager/Withdraw/WithdrawContext.ts
@@ -1,0 +1,10 @@
+import { createContext } from 'react'
+
+import { CosmosWithdrawActions, CosmosWithdrawState } from './WithdrawCommon'
+
+interface IWithdrawContext {
+  state: CosmosWithdrawState | null
+  dispatch: React.Dispatch<CosmosWithdrawActions> | null
+}
+
+export const WithdrawContext = createContext<IWithdrawContext>({ state: null, dispatch: null })

--- a/src/features/defi/providers/cosmos/components/CosmosManager/Withdraw/WithdrawReducer.ts
+++ b/src/features/defi/providers/cosmos/components/CosmosManager/Withdraw/WithdrawReducer.ts
@@ -1,0 +1,49 @@
+import { KnownChainIds, WithdrawType } from '@shapeshiftoss/types'
+import { DefiType } from 'features/defi/contexts/DefiManagerProvider/DefiCommon'
+import { bnOrZero } from 'lib/bignumber/bignumber'
+
+import {
+  CosmosWithdrawActions,
+  CosmosWithdrawActionType,
+  CosmosWithdrawState,
+} from './WithdrawCommon'
+
+export const initialState: CosmosWithdrawState = {
+  txid: null,
+  cosmosOpportunity: {
+    contractAddress: '',
+    stakingToken: '',
+    provider: '',
+    chain: KnownChainIds.CosmosMainnet,
+    type: DefiType.TokenStaking,
+    expired: false,
+    version: '',
+    tvl: bnOrZero(0),
+  },
+  userAddress: null,
+  loading: false,
+  withdraw: {
+    fiatAmount: '',
+    cryptoAmount: '',
+    txStatus: 'pending',
+    usedGasFee: '',
+    withdrawType: WithdrawType.DELAYED,
+  },
+}
+
+export const reducer = (state: CosmosWithdrawState, action: CosmosWithdrawActions) => {
+  switch (action.type) {
+    case CosmosWithdrawActionType.SET_OPPORTUNITY:
+      return { ...state, CosmosOpportunity: { ...state.cosmosOpportunity, ...action.payload } }
+    case CosmosWithdrawActionType.SET_WITHDRAW:
+      return { ...state, withdraw: { ...state.withdraw, ...action.payload } }
+    case CosmosWithdrawActionType.SET_USER_ADDRESS:
+      return { ...state, userAddress: action.payload }
+    case CosmosWithdrawActionType.SET_LOADING:
+      return { ...state, loading: action.payload }
+    case CosmosWithdrawActionType.SET_TXID:
+      return { ...state, txid: action.payload }
+    default:
+      return state
+  }
+}

--- a/src/features/defi/providers/cosmos/components/CosmosManager/Withdraw/components/Status.tsx
+++ b/src/features/defi/providers/cosmos/components/CosmosManager/Withdraw/components/Status.tsx
@@ -1,0 +1,132 @@
+import { CheckIcon, CloseIcon, ExternalLinkIcon } from '@chakra-ui/icons'
+import { Button, Link, Stack } from '@chakra-ui/react'
+import { toAssetId } from '@shapeshiftoss/caip'
+import { Summary } from 'features/defi/components/Summary'
+import { TxStatus } from 'features/defi/components/TxStatus/TxStatus'
+import { DefiParams, DefiQueryParams } from 'features/defi/contexts/DefiManagerProvider/DefiCommon'
+import { useContext } from 'react'
+import { useTranslate } from 'react-polyglot'
+import { Amount } from 'components/Amount/Amount'
+import { AssetIcon } from 'components/AssetIcon'
+import { MiddleEllipsis } from 'components/MiddleEllipsis/MiddleEllipsis'
+import { StatusTextEnum } from 'components/RouteSteps/RouteSteps'
+import { Row } from 'components/Row/Row'
+import { RawText, Text } from 'components/Text'
+import { useBrowserRouter } from 'hooks/useBrowserRouter/useBrowserRouter'
+import { selectAssetById } from 'state/slices/selectors'
+import { useAppSelector } from 'state/store'
+
+import { WithdrawContext } from '../WithdrawContext'
+
+export const Status = () => {
+  const { state, dispatch } = useContext(WithdrawContext)
+  const translate = useTranslate()
+  const { query, history: browserHistory } = useBrowserRouter<DefiQueryParams, DefiParams>()
+  const { chainId, assetReference } = query
+
+  const assetNamespace = 'slip44'
+  // Asset info
+  const underlyingAssetId = toAssetId({
+    chainId,
+    assetNamespace,
+    assetReference,
+  })
+  const underlyingAsset = useAppSelector(state => selectAssetById(state, underlyingAssetId))
+  const assetId = toAssetId({
+    chainId,
+    assetNamespace,
+    assetReference,
+  })
+  const asset = useAppSelector(state => selectAssetById(state, assetId))
+
+  if (!state || !dispatch) return null
+
+  const handleViewPosition = () => {
+    browserHistory.push('/defi')
+  }
+
+  const handleCancel = () => {
+    browserHistory.goBack()
+  }
+
+  const { statusIcon, statusText, statusBg, statusBody } = (() => {
+    switch (state.withdraw.txStatus) {
+      case 'success':
+        return {
+          statusText: StatusTextEnum.success,
+          statusIcon: <CheckIcon color='white' />,
+          statusBg: 'green.500',
+          statusBody: translate('modals.withdraw.status.success', {
+            opportunity: `${underlyingAsset.symbol} Vault`,
+          }),
+        }
+      case 'failed':
+        return {
+          statusText: StatusTextEnum.failed,
+          statusIcon: <CloseIcon color='white' />,
+          statusBg: 'red.500',
+          statusBody: translate('modals.withdraw.status.failed'),
+        }
+      default:
+        return {
+          statusIcon: <AssetIcon size='xs' src={asset?.icon} />,
+          statusText: StatusTextEnum.pending,
+          statusBg: 'transparent',
+          statusBody: translate('modals.withdraw.status.pending'),
+        }
+    }
+  })()
+
+  return (
+    <TxStatus
+      onClose={handleCancel}
+      onContinue={state.withdraw.txStatus === 'success' ? handleViewPosition : undefined}
+      loading={!['success', 'failed'].includes(state.withdraw.txStatus)}
+      continueText='modals.status.position'
+      statusText={statusText}
+      statusBg={statusBg}
+      statusIcon={statusIcon}
+      statusBody={statusBody}
+    >
+      <Summary spacing={0} mx={6} mb={4}>
+        <Row variant='vert-gutter'>
+          <Row.Label>
+            <Text translation='modals.confirm.amountToWithdraw' />
+          </Row.Label>
+          <Row px={0} fontWeight='medium'>
+            <Stack direction='row' alignItems='center'>
+              <AssetIcon size='xs' src={underlyingAsset.icon} />
+              <RawText>{underlyingAsset.name}</RawText>
+            </Stack>
+            <Row.Value>
+              <Amount.Crypto value={state.withdraw.cryptoAmount} symbol={underlyingAsset.symbol} />
+            </Row.Value>
+          </Row>
+        </Row>
+        <Row variant='gutter'>
+          <Row.Label>
+            <Text translation='modals.confirm.withdrawTo' />
+          </Row.Label>
+          <Row.Value fontWeight='bold'>
+            <MiddleEllipsis address={state.userAddress || ''} />
+          </Row.Value>
+        </Row>
+        {state.txid && (
+          <Row variant='gutter'>
+            <Button
+              as={Link}
+              width='full'
+              isExternal
+              variant='ghost-filled'
+              colorScheme='green'
+              rightIcon={<ExternalLinkIcon />}
+              href={`${asset.explorerTxLink}/${state.txid}`}
+            >
+              {translate('defi.viewOnChain')}
+            </Button>
+          </Row>
+        )}
+      </Summary>
+    </TxStatus>
+  )
+}

--- a/src/features/defi/providers/cosmos/components/CosmosManager/Withdraw/components/Withdraw.tsx
+++ b/src/features/defi/providers/cosmos/components/CosmosManager/Withdraw/components/Withdraw.tsx
@@ -1,0 +1,208 @@
+import { useToast } from '@chakra-ui/react'
+import { toAssetId } from '@shapeshiftoss/caip'
+import { WithdrawType } from '@shapeshiftoss/types'
+import {
+  Field,
+  Withdraw as ReusableWithdraw,
+  WithdrawValues,
+} from 'features/defi/components/Withdraw/Withdraw'
+import {
+  DefiParams,
+  DefiQueryParams,
+  DefiStep,
+} from 'features/defi/contexts/DefiManagerProvider/DefiCommon'
+import { getStakingFees } from 'plugins/cosmos/utils'
+import { useContext } from 'react'
+import { FormProvider, useForm } from 'react-hook-form'
+import { useTranslate } from 'react-polyglot'
+import { StepComponentProps } from 'components/DeFi/components/Steps'
+import { useBrowserRouter } from 'hooks/useBrowserRouter/useBrowserRouter'
+import { BigNumber, bn, bnOrZero } from 'lib/bignumber/bignumber'
+import { logger } from 'lib/logger'
+import {
+  selectAssetById,
+  selectDelegationCryptoAmountByAssetIdAndValidator,
+  selectFirstAccountSpecifierByChainId,
+  selectMarketDataById,
+} from 'state/slices/selectors'
+import { useAppSelector } from 'state/store'
+
+import { CosmosWithdrawActionType } from '../WithdrawCommon'
+import { WithdrawContext } from '../WithdrawContext'
+
+export type CosmosWithdrawValues = {
+  [Field.WithdrawType]: WithdrawType
+} & WithdrawValues
+
+const moduleLogger = logger.child({ namespace: ['CosmosWithdraw:Withdraw'] })
+
+export const Withdraw: React.FC<StepComponentProps> = ({ onNext }) => {
+  const { state, dispatch } = useContext(WithdrawContext)
+  const translate = useTranslate()
+  const { query, history: browserHistory } = useBrowserRouter<DefiQueryParams, DefiParams>()
+  const { chainId, assetReference, contractAddress } = query
+  const toast = useToast()
+
+  const methods = useForm<CosmosWithdrawValues>({ mode: 'onChange' })
+  const { setValue, watch } = methods
+
+  const withdrawTypeValue = watch(Field.WithdrawType)
+
+  const assetNamespace = 'slip44' // TODO: add to query, why do we hardcode this?
+  // Reward Asset info
+  const assetId = toAssetId({
+    chainId,
+    assetNamespace,
+    assetReference, // TODO: different denom asset reference
+  })
+  const asset = useAppSelector(state => selectAssetById(state, assetId))
+  const marketData = useAppSelector(state => selectMarketDataById(state, assetId))
+
+  // Staking Asset Info
+  const stakingAssetId = toAssetId({
+    chainId,
+    assetNamespace,
+    assetReference,
+  })
+  const stakingAsset = useAppSelector(state => selectAssetById(state, stakingAssetId))
+
+  const accountSpecifier = useAppSelector(state =>
+    selectFirstAccountSpecifierByChainId(state, asset?.chainId),
+  )
+
+  const cryptoStakeBalance = useAppSelector(state =>
+    selectDelegationCryptoAmountByAssetIdAndValidator(state, {
+      accountSpecifier,
+      validatorAddress: contractAddress,
+      assetId,
+    }),
+  )
+  const cryptoStakeBalanceHuman = bnOrZero(cryptoStakeBalance).div(`1e+${asset?.precision}`)
+
+  const fiatStakeAmountHuman = cryptoStakeBalanceHuman.times(bnOrZero(marketData.price)).toString()
+
+  if (!state || !dispatch) return null
+
+  const getWithdrawGasEstimate = async () => {
+    if (!state.userAddress) return
+
+    const { gasLimit, gasPrice } = await getStakingFees(asset, marketData.price)
+
+    try {
+      return bnOrZero(gasPrice).times(gasLimit).toFixed(0)
+    } catch (error) {
+      moduleLogger.error(
+        { fn: 'getWithdrawGasEstimate', error },
+        'Error getting deposit gas estimate',
+      )
+      const fundsError =
+        error instanceof Error && error.message.includes('Not enough funds in reserve')
+      toast({
+        position: 'top-right',
+        description: fundsError
+          ? translate('defi.notEnoughFundsInReserve')
+          : translate('common.somethingWentWrong'),
+        title: translate('common.somethingWentWrong'),
+        status: 'error',
+      })
+    }
+  }
+
+  const handleContinue = async (formValues: CosmosWithdrawValues) => {
+    if (!state.userAddress) return
+    // set withdraw state for future use
+    dispatch({
+      type: CosmosWithdrawActionType.SET_WITHDRAW,
+      payload: formValues,
+    })
+    dispatch({
+      type: CosmosWithdrawActionType.SET_LOADING,
+      payload: true,
+    })
+    try {
+      const estimatedGasCrypto = await getWithdrawGasEstimate()
+
+      if (!estimatedGasCrypto) return
+      dispatch({
+        type: CosmosWithdrawActionType.SET_WITHDRAW,
+        payload: { estimatedGasCrypto },
+      })
+      onNext(DefiStep.Confirm)
+      dispatch({
+        type: CosmosWithdrawActionType.SET_LOADING,
+        payload: false,
+      })
+    } catch (error) {
+      moduleLogger.error({ fn: 'handleContinue', error }, 'Error with withdraw')
+      dispatch({
+        type: CosmosWithdrawActionType.SET_LOADING,
+        payload: false,
+      })
+      toast({
+        position: 'top-right',
+        description: translate('common.somethingWentWrongBody'),
+        title: translate('common.somethingWentWrong'),
+        status: 'error',
+      })
+    }
+  }
+
+  const handleCancel = () => {
+    browserHistory.goBack()
+  }
+
+  const handlePercentClick = (percent: number) => {
+    const cryptoAmount = bnOrZero(cryptoStakeBalanceHuman)
+      .times(percent)
+      .dp(asset.precision, BigNumber.ROUND_DOWN)
+    const fiatAmount = bnOrZero(cryptoAmount).times(marketData.price)
+    setValue(Field.FiatAmount, fiatAmount.toString(), {
+      shouldValidate: true,
+    })
+    setValue(Field.CryptoAmount, cryptoAmount.toString(), {
+      shouldValidate: true,
+    })
+  }
+
+  const validateCryptoAmount = (value: string) => {
+    const crypto = bnOrZero(bn(cryptoStakeBalance).div(`1e+${asset.precision}`))
+    const _value = bnOrZero(value)
+    const hasValidBalance = crypto.gt(0) && _value.gt(0) && crypto.gte(value)
+    if (_value.isEqualTo(0)) return ''
+    return hasValidBalance || 'common.insufficientFunds'
+  }
+
+  const validateFiatAmount = (value: string) => {
+    const crypto = bnOrZero(bn(cryptoStakeBalance).div(`1e+${asset.precision}`))
+    const fiat = crypto.times(bnOrZero(marketData?.price))
+    const _value = bnOrZero(value)
+    const hasValidBalance = fiat.gt(0) && _value.gt(0) && fiat.gte(value)
+    if (_value.isEqualTo(0)) return ''
+    return hasValidBalance || 'common.insufficientFunds'
+  }
+
+  return (
+    <FormProvider {...methods}>
+      <ReusableWithdraw
+        asset={stakingAsset}
+        cryptoAmountAvailable={cryptoStakeBalanceHuman.toString()}
+        cryptoInputValidation={{
+          required: true,
+          validate: { validateCryptoAmount },
+        }}
+        fiatAmountAvailable={fiatStakeAmountHuman.toString()}
+        fiatInputValidation={{
+          required: true,
+          validate: { validateFiatAmount },
+        }}
+        marketData={marketData}
+        onCancel={handleCancel}
+        onContinue={handleContinue}
+        isLoading={state.loading}
+        handlePercentClick={handlePercentClick}
+        disableInput={withdrawTypeValue === WithdrawType.INSTANT}
+        percentOptions={[0.25, 0.5, 0.75, 1]}
+      />
+    </FormProvider>
+  )
+}

--- a/src/features/defi/providers/cosmos/components/CosmosManager/Withdraw/components/WithdrawType.tsx
+++ b/src/features/defi/providers/cosmos/components/CosmosManager/Withdraw/components/WithdrawType.tsx
@@ -1,0 +1,97 @@
+import { Button, ButtonGroup, Stack } from '@chakra-ui/react'
+import { Asset } from '@shapeshiftoss/asset-service'
+import { WithdrawType } from '@shapeshiftoss/types'
+import { useMemo } from 'react'
+import { useController, useFormContext } from 'react-hook-form'
+import { useTranslate } from 'react-polyglot'
+import { Amount } from 'components/Amount/Amount'
+import { FormField } from 'components/DeFi/components/FormField'
+import { Row } from 'components/Row/Row'
+import { RawText } from 'components/Text'
+import { bn, bnOrZero } from 'lib/bignumber/bignumber'
+
+type WithdrawTypeProps = {
+  asset: Asset
+  handlePercentClick: (arg: number) => void
+  feePercentage: string
+}
+
+export const WithdrawTypeField: React.FC<WithdrawTypeProps> = ({
+  handlePercentClick,
+  asset,
+  feePercentage,
+}) => {
+  const { control, watch } = useFormContext()
+  const translate = useTranslate()
+  const { field: withdrawType } = useController({
+    name: 'withdrawType',
+    control,
+    defaultValue: WithdrawType.DELAYED,
+  })
+
+  const cryptoAmount = watch('cryptoAmount')
+
+  const handleClick = (value: WithdrawType) => {
+    if (value === WithdrawType.INSTANT) {
+      withdrawType.onChange(WithdrawType.INSTANT)
+      handlePercentClick(1)
+    } else {
+      withdrawType.onChange(WithdrawType.DELAYED)
+    }
+  }
+
+  const withdrawalFee = useMemo(() => {
+    return withdrawType.value === WithdrawType.INSTANT
+      ? bnOrZero(bn(cryptoAmount).times(feePercentage)).toString()
+      : '0'
+  }, [cryptoAmount, feePercentage, withdrawType.value])
+
+  return (
+    <>
+      <FormField label={translate('modals.withdraw.withdrawType')}>
+        <ButtonGroup colorScheme='blue' width='full' variant='input'>
+          <Button
+            width='full'
+            flexDir='column'
+            height='auto'
+            py={4}
+            onClick={() => handleClick(WithdrawType.INSTANT)}
+            isActive={withdrawType.value === WithdrawType.INSTANT}
+          >
+            <Stack alignItems='center' spacing={1}>
+              <RawText>{translate('modals.withdraw.instant')}</RawText>
+              <RawText color='gray.500' fontSize='sm'>
+                {translate('modals.withdraw.fee', {
+                  fee: bnOrZero(feePercentage).times(100) ?? '0',
+                  symbol: asset.symbol,
+                })}
+              </RawText>
+            </Stack>
+          </Button>
+          <Button
+            width='full'
+            flexDir='column'
+            height='auto'
+            onClick={() => handleClick(WithdrawType.DELAYED)}
+            isActive={withdrawType.value === WithdrawType.DELAYED}
+          >
+            <Stack alignItems='center' spacing={1}>
+              <RawText>{translate('modals.withdraw.delayed')}</RawText>
+              <RawText color='gray.500' fontSize='sm'>
+                {translate('modals.withdraw.noFee', {
+                  symbol: asset.symbol,
+                })}
+              </RawText>
+            </Stack>
+          </Button>
+        </ButtonGroup>
+      </FormField>
+      <Row>
+        <Row.Label>{translate('modals.withdraw.withdrawalFee')}</Row.Label>
+        <Row.Value>
+          <Amount.Crypto value={withdrawalFee} symbol={asset.symbol} />
+        </Row.Value>
+      </Row>
+    </>
+  )
+}

--- a/src/plugins/cosmos/utils.ts
+++ b/src/plugins/cosmos/utils.ts
@@ -1,5 +1,8 @@
-import { cosmos, FeeDataEstimate, FeeDataKey } from '@shapeshiftoss/chain-adapters'
+import { Asset } from '@shapeshiftoss/asset-service'
+import { fromAssetId } from '@shapeshiftoss/caip'
+import { cosmos, cosmossdk, FeeDataEstimate, FeeDataKey } from '@shapeshiftoss/chain-adapters'
 import { KnownChainIds } from '@shapeshiftoss/types'
+import { getChainAdapterManager } from 'context/PluginProvider/chainAdapterSingleton'
 import { bnOrZero } from 'lib/bignumber/bignumber'
 
 export type FeePriceValueHuman = {
@@ -48,4 +51,63 @@ export const getFormFees = (
     acc[key] = { txFee, fiatFee, chainSpecific }
     return acc
   }, initialFees)
+}
+
+// TODO: Remove the old implementation and rename me to getFormFees before landing
+export const getStakingFees = async (asset: Asset, fiatRate: string) => {
+  // We don't use all of these fields for the return value but this is our standard FeeDataEstimate fees, for consistency
+  const initialFees = {
+    slow: {
+      fiatFee: '',
+      txFee: '',
+      chainSpecific: {
+        gasLimit: '',
+      },
+    },
+    average: {
+      fiatFee: '',
+      txFee: '',
+      chainSpecific: {
+        gasLimit: '',
+      },
+    },
+    fast: {
+      fiatFee: '',
+      txFee: '',
+      chainSpecific: {
+        gasLimit: '',
+      },
+    },
+  }
+
+  const chainAdapterManager = getChainAdapterManager()
+  const adapter = chainAdapterManager.get(fromAssetId(asset.assetId).chainId) as unknown as
+    | cosmossdk.cosmos.ChainAdapter
+    | cosmossdk.osmosis.ChainAdapter
+
+  const feeData = await adapter.getFeeData({})
+
+  if (!adapter)
+    return {
+      gasLimit: initialFees.average.chainSpecific.gasLimit,
+      gasPrice: initialFees.average.txFee,
+    }
+
+  const adapterFees = (Object.keys(feeData) as FeeDataKey[]).reduce<FeePrice>(
+    (acc: any, key: FeeDataKey) => {
+      const chainSpecific = feeData[key].chainSpecific
+      const txFee = bnOrZero(feeData[key].txFee)
+        .dividedBy(bnOrZero(`1e+${asset.precision}`))
+        .toPrecision()
+      const fiatFee = bnOrZero(txFee).times(fiatRate).toPrecision()
+      acc[key] = { txFee, fiatFee, chainSpecific }
+      return acc
+    },
+    initialFees,
+  )
+
+  return {
+    gasLimit: adapterFees.average.chainSpecific.gasLimit,
+    gasPrice: adapterFees.average.txFee,
+  }
 }


### PR DESCRIPTION
## Description

This adds a new provider for Cosmos staking. Included in this PR:

- Staking
- Unstaking
- Claim
- Display of TVL, APY, staked balance/current active unbondings list in the modal
- Get Started / Learn More modal

This does **not**:

- wire the implementation just yet, this is done in https://github.com/shapeshift/web/pull/2295
- fix the current issues with the existing implementation WRT subtracting gas fees from the percentage estimation. This was originally intended in https://github.com/shapeshift/web/pull/1703 and will be following this PR, with a systematic, optional gas fee subtraction for all DeFi modals

## Notice

<!-- Before submitting a pull request, please make sure you have answered the following: -->

- [x] Have you followed the guidelines in our [Contributing]('https://github.com/shapeshift/web/CONTRIBUTING.md) guide?
- [x] Have you checked to ensure there aren't other open [Pull Requests](https://github.com/shapeshift/web/pulls) for the same update/change?

## Pull Request Type

- [ ] :bug: Bug fix (Non-breaking Change: Fixes an issue)
- [ ] :hammer_and_wrench: Chore (Non-breaking Change: Doc updates, pkg upgrades, typos, etc..)
- [x] :nail_care: New Feature (Breaking/Non-breaking Change)

## Issue (if applicable)

partially tackles https://github.com/shapeshift/web/issues/2219

## Risk

- None in this PR. This does not route the provider yet.

## Testing

- Current Cosmos DeFi modals should still open with no regressions

## Screenshots (if applicable)

<img width="535" alt="image" src="https://user-images.githubusercontent.com/17035424/181643813-61926faf-e28a-4fce-ab66-961b3b5f1ae1.png">
<img width="533" alt="image" src="https://user-images.githubusercontent.com/17035424/181645261-c8387fab-1d7e-4220-9389-0c571f1e3629.png">
<img width="541" alt="image" src="https://user-images.githubusercontent.com/17035424/181645676-439e9b9c-bdbe-4b6f-9f5d-04f094e9a619.png">
<img width="538" alt="image" src="https://user-images.githubusercontent.com/17035424/181645789-2edcfdf2-2acb-4f1d-82f3-3c35e8bc944b.png">
<img width="543" alt="image" src="https://user-images.githubusercontent.com/17035424/181645994-abcc3cd7-a963-4451-a008-5785f5d44331.png">

<img width="540" alt="image" src="https://user-images.githubusercontent.com/17035424/181646024-4128f528-c7ce-47c6-8ba7-0bb883fb0241.png">
<img width="525" alt="image" src="https://user-images.githubusercontent.com/17035424/181646049-7c5c0406-aa9e-45c4-8ec1-f53a9f047f40.png">

<img width="527" alt="image" src="https://user-images.githubusercontent.com/17035424/181646124-46710d9a-8ab2-4bbf-b687-17dfdb074ab3.png">
<img width="528" alt="image" src="https://user-images.githubusercontent.com/17035424/181646282-af3b9ce8-505b-4897-a2f0-b1b91f830759.png">
<img width="540" alt="image" src="https://user-images.githubusercontent.com/17035424/181646331-874201cc-10d7-4e5b-9c53-c4bcd5acbd00.png">

<img width="525" alt="image" src="https://user-images.githubusercontent.com/17035424/181646570-acdec2f2-3a4f-40c1-9d19-ecc224b78a45.png">
<img width="523" alt="image" src="https://user-images.githubusercontent.com/17035424/181646584-ee81e136-9239-4a35-865b-a4e44471b063.png">
<img width="465" alt="image" src="https://user-images.githubusercontent.com/17035424/181646623-3a84974c-a7ca-4029-8a35-1e5e8b609993.png">