### PR TITLE
feat: cosmos defi UI part 3: modals routing

### DIFF
--- a/src/components/Delegate/StakingOpportunities.tsx
+++ b/src/components/Delegate/StakingOpportunities.tsx
@@ -1,20 +1,21 @@
 import { ArrowForwardIcon } from '@chakra-ui/icons'
 import { Box, Button, Flex, HStack, Skeleton, Tag, TagLabel } from '@chakra-ui/react'
-import { AssetId, ChainId } from '@shapeshiftoss/caip'
+import { AssetId, ChainId, fromAssetId } from '@shapeshiftoss/caip'
+import { chainIdToLabel } from 'features/defi/helpers/utils'
 import { AprTag } from 'plugins/cosmos/components/AprTag/AprTag'
 import {
   isCosmosChainId,
   isOsmosisChainId,
 } from 'plugins/cosmos/components/modals/Staking/StakingCommon'
+import qs from 'qs'
 import { useMemo } from 'react'
-import { NavLink } from 'react-router-dom'
+import { NavLink, useHistory } from 'react-router-dom'
 import { Row } from 'react-table'
 import { Amount } from 'components/Amount/Amount'
 import { AssetIcon } from 'components/AssetIcon'
 import { Card } from 'components/Card/Card'
 import { ReactTable } from 'components/ReactTable/ReactTable'
 import { RawText, Text } from 'components/Text'
-import { useModal } from 'hooks/useModal/useModal'
 import { bnOrZero } from 'lib/bignumber/bignumber'
 import {
   OpportunitiesDataFull,
@@ -69,6 +70,7 @@ export const ValidatorName = ({
 }
 
 export const StakingOpportunities = ({ assetId }: StakingOpportunitiesProps) => {
+  const history = useHistory()
   const asset = useAppSelector(state => selectAssetById(state, assetId))
   const marketData = useAppSelector(state => selectMarketDataById(state, assetId))
 
@@ -85,12 +87,19 @@ export const StakingOpportunities = ({ assetId }: StakingOpportunitiesProps) => 
   )
 
   const rows = stakingOpportunitiesData
-  const { cosmosStaking } = useModal()
 
   const handleClick = (values: Row<OpportunitiesDataFull>) => {
-    cosmosStaking.open({
-      assetId,
-      validatorAddress: values.original.address,
+    const { chainId, assetReference } = fromAssetId(assetId)
+    const provider = chainIdToLabel(chainId)
+    history.push({
+      pathname: '/defi',
+      search: qs.stringify({
+        provider,
+        chainId,
+        contractAddress: values.original.address,
+        assetReference,
+        modal: 'overview',
+      }),
     })
   }
 

--- a/src/components/Delegate/StakingOpportunities.tsx
+++ b/src/components/Delegate/StakingOpportunities.tsx
@@ -92,7 +92,6 @@ export const StakingOpportunities = ({ assetId }: StakingOpportunitiesProps) => 
     const { chainId, assetReference } = fromAssetId(assetId)
     const provider = chainIdToLabel(chainId)
     history.push({
-      pathname: '/defi',
       search: qs.stringify({
         provider,
         chainId,

--- a/src/components/Delegate/StakingOpportunities.tsx
+++ b/src/components/Delegate/StakingOpportunities.tsx
@@ -8,7 +8,7 @@ import {
   isOsmosisChainId,
 } from 'plugins/cosmos/components/modals/Staking/StakingCommon'
 import qs from 'qs'
-import { useMemo } from 'react'
+import { useCallback, useMemo } from 'react'
 import { NavLink, useHistory } from 'react-router-dom'
 import { Row } from 'react-table'
 import { Amount } from 'components/Amount/Amount'
@@ -88,19 +88,22 @@ export const StakingOpportunities = ({ assetId }: StakingOpportunitiesProps) => 
 
   const rows = stakingOpportunitiesData
 
-  const handleClick = (values: Row<OpportunitiesDataFull>) => {
-    const { chainId, assetReference } = fromAssetId(assetId)
-    const provider = chainIdToLabel(chainId)
-    history.push({
-      search: qs.stringify({
-        provider,
-        chainId,
-        contractAddress: values.original.address,
-        assetReference,
-        modal: 'overview',
-      }),
-    })
-  }
+  const handleClick = useCallback(
+    (values: Row<OpportunitiesDataFull>) => {
+      const { chainId, assetReference } = fromAssetId(assetId)
+      const provider = chainIdToLabel(chainId)
+      history.push({
+        search: qs.stringify({
+          provider,
+          chainId,
+          contractAddress: values.original.address,
+          assetReference,
+          modal: 'overview',
+        }),
+      })
+    },
+    [assetId, history],
+  )
 
   const columns = useMemo(
     () => [

--- a/src/components/StakingVaults/AllEarnOpportunities.tsx
+++ b/src/components/StakingVaults/AllEarnOpportunities.tsx
@@ -4,10 +4,6 @@ import {
   EarnOpportunityType,
   useNormalizeOpportunities,
 } from 'features/defi/helpers/normalizeOpportunity'
-import {
-  isCosmosChainId,
-  isOsmosisChainId,
-} from 'plugins/cosmos/components/modals/Staking/StakingCommon'
 import qs from 'qs'
 import { useCallback, useMemo } from 'react'
 import { useHistory, useLocation } from 'react-router'
@@ -15,7 +11,6 @@ import { Card } from 'components/Card/Card'
 import { Text } from 'components/Text'
 import { WalletActions } from 'context/WalletProvider/actions'
 import { DemoConfig } from 'context/WalletProvider/DemoWallet/config'
-import { useModal } from 'hooks/useModal/useModal'
 import { useSortedYearnVaults } from 'hooks/useSortedYearnVaults/useSortedYearnVaults'
 import { useWallet } from 'hooks/useWallet/useWallet'
 import { useCosmosSdkStakingBalances } from 'pages/Defi/hooks/useCosmosSdkStakingBalances'
@@ -41,7 +36,6 @@ export const AllEarnOpportunities = () => {
     useCosmosSdkStakingBalances({
       assetId: osmosisAssetId,
     })
-  const { cosmosStaking } = useModal()
 
   const allRows = useNormalizeOpportunities({
     vaultArray: sortedVaults,
@@ -58,15 +52,6 @@ export const AllEarnOpportunities = () => {
       const { assetReference } = fromAssetId(assetId)
       if (!isConnected && walletInfo?.deviceId !== DemoConfig.name) {
         dispatch({ type: WalletActions.SET_WALLET_MODAL, payload: true })
-        return
-      }
-
-      if (isCosmosChainId(chainId) || isOsmosisChainId(chainId)) {
-        cosmosStaking.open({
-          assetId,
-          validatorAddress: contractAddress,
-        })
-
         return
       }
 

--- a/src/pages/Defi/components/OpportunityCard.tsx
+++ b/src/pages/Defi/components/OpportunityCard.tsx
@@ -23,7 +23,6 @@ import { AssetIcon } from 'components/AssetIcon'
 import { Card } from 'components/Card/Card'
 import { RawText, Text } from 'components/Text'
 import { WalletActions } from 'context/WalletProvider/actions'
-import { useModal } from 'hooks/useModal/useModal'
 import { useWallet } from 'hooks/useWallet/useWallet'
 import { AssetsById } from 'state/slices/assetsSlice/assetsSlice'
 import { selectAssetById, selectAssets } from 'state/slices/selectors'
@@ -59,7 +58,6 @@ export const OpportunityCard = ({
   const history = useHistory()
   const bgHover = useColorModeValue('gray.100', 'gray.700')
   const asset = useAppSelector(state => selectAssetById(state, assetId))
-  const { cosmosStaking } = useModal()
   const { assetReference } = fromAssetId(assetId)
 
   const assets = useAppSelector(selectAssets)
@@ -71,14 +69,6 @@ export const OpportunityCard = ({
 
   const handleClick = () => {
     if (isConnected) {
-      if (isCosmosChainId(chainId) || isOsmosisChainId(chainId)) {
-        cosmosStaking.open({
-          assetId,
-          validatorAddress: contractAddress,
-        })
-        return
-      }
-
       history.push({
         pathname: '/defi',
         search: qs.stringify({


### PR DESCRIPTION
## Description

This wires up the new Cosmos DeFi UI components.

## Notice

<!-- Before submitting a pull request, please make sure you have answered the following: -->

- [x] Have you followed the guidelines in our [Contributing]('https://github.com/shapeshift/web/CONTRIBUTING.md) guide?
- [x] Have you checked to ensure there aren't other open [Pull Requests](https://github.com/shapeshift/web/pulls) for the same update/change?

## Pull Request Type

- [ ] :bug: Bug fix (Non-breaking Change: Fixes an issue)
- [ ] :hammer_and_wrench: Chore (Non-breaking Change: Doc updates, pkg upgrades, typos, etc..)
- [x] :nail_care: New Feature (Breaking/Non-breaking Change)

## Issue (if applicable)

partially tackles https://github.com/shapeshift/web/issues/2219

## Risk

- This is a wire-up issue. I've tested in the various places that the old UI isn't opened (this would be caught by tsc) but operations should test that the routing works for all consumers of Cosmos staking modals. 

## Testing

- See risks. 

## Screenshots (if applicable)

<img width="535" alt="image" src="https://user-images.githubusercontent.com/17035424/181643813-61926faf-e28a-4fce-ab66-961b3b5f1ae1.png">
<img width="533" alt="image" src="https://user-images.githubusercontent.com/17035424/181645261-c8387fab-1d7e-4220-9389-0c571f1e3629.png">
<img width="541" alt="image" src="https://user-images.githubusercontent.com/17035424/181645676-439e9b9c-bdbe-4b6f-9f5d-04f094e9a619.png">
<img width="538" alt="image" src="https://user-images.githubusercontent.com/17035424/181645789-2edcfdf2-2acb-4f1d-82f3-3c35e8bc944b.png">
<img width="543" alt="image" src="https://user-images.githubusercontent.com/17035424/181645994-abcc3cd7-a963-4451-a008-5785f5d44331.png">

<img width="540" alt="image" src="https://user-images.githubusercontent.com/17035424/181646024-4128f528-c7ce-47c6-8ba7-0bb883fb0241.png">
<img width="525" alt="image" src="https://user-images.githubusercontent.com/17035424/181646049-7c5c0406-aa9e-45c4-8ec1-f53a9f047f40.png">

<img width="527" alt="image" src="https://user-images.githubusercontent.com/17035424/181646124-46710d9a-8ab2-4bbf-b687-17dfdb074ab3.png">
<img width="528" alt="image" src="https://user-images.githubusercontent.com/17035424/181646282-af3b9ce8-505b-4897-a2f0-b1b91f830759.png">
<img width="540" alt="image" src="https://user-images.githubusercontent.com/17035424/181646331-874201cc-10d7-4e5b-9c53-c4bcd5acbd00.png">

<img width="525" alt="image" src="https://user-images.githubusercontent.com/17035424/181646570-acdec2f2-3a4f-40c1-9d19-ecc224b78a45.png">
<img width="523" alt="image" src="https://user-images.githubusercontent.com/17035424/181646584-ee81e136-9239-4a35-865b-a4e44471b063.png">
<img width="465" alt="image" src="https://user-images.githubusercontent.com/17035424/181646623-3a84974c-a7ca-4029-8a35-1e5e8b609993.png">