### PR TITLE
feat: cosmos defi UI part 4: fix selectRewardsByValidator selector

### DIFF
--- a/src/state/slices/portfolioSlice/selectors.ts
+++ b/src/state/slices/portfolioSlice/selectors.ts
@@ -884,6 +884,8 @@ export const selectRewardsByValidator = createDeepEqualOutputSelector(
   (allPortfolioAccounts, validatorAddress, accountSpecifier, assetId): string => {
     const cosmosAccount = allPortfolioAccounts?.[accountSpecifier]
 
+    if (!cosmosAccount) return '0'
+
     const rewards =
       cosmosAccount.stakingDataByValidatorId?.[validatorAddress]?.[assetId]?.rewards?.[0]?.amount ??
       '0'


### PR DESCRIPTION
## Description

Small portfolio selector safeguard in case no cosmos account is found for the passed accountSpecifier (if e.g `''` is passed as an accountSpecifier before they're loaded)

## Notice

<!-- Before submitting a pull request, please make sure you have answered the following: -->

- [x] Have you followed the guidelines in our [Contributing]('https://github.com/shapeshift/web/CONTRIBUTING.md) guide?
- [x] Have you checked to ensure there aren't other open [Pull Requests](https://github.com/shapeshift/web/pulls) for the same update/change?

## Pull Request Type

- [ ] :bug: Bug fix (Non-breaking Change: Fixes an issue)
- [ ] :hammer_and_wrench: Chore (Non-breaking Change: Doc updates, pkg upgrades, typos, etc..)
- [x] :nail_care: New Feature (Breaking/Non-breaking Change)

## Issue (if applicable)

partially tackles https://github.com/shapeshift/web/issues/2219

## Risk

None, this puts additional guards in place.

## Testing

- Cosmos rewards across DeFi section should still work