### PR TITLE
feat: cosmos defi UI part 5: use full balance for 100% handlePercentClick option

### DIFF
--- a/src/features/defi/components/Deposit/Deposit.tsx
+++ b/src/features/defi/components/Deposit/Deposit.tsx
@@ -2,6 +2,7 @@ import { Button, Stack, useColorModeValue } from '@chakra-ui/react'
 import { Asset } from '@shapeshiftoss/asset-service'
 import { MarketData } from '@shapeshiftoss/types'
 import get from 'lodash/get'
+import { useCallback } from 'react'
 import { ControllerProps, useController, useForm, useWatch } from 'react-hook-form'
 import { useTranslate } from 'react-polyglot'
 import { Amount } from 'components/Amount/Amount'
@@ -114,19 +115,22 @@ export const Deposit = ({
     }
   }
 
-  const handlePercentClick = (percent: number) => {
-    const cryptoAmount =
-      percent === 1
-        ? cryptoAmountAvailable
-        : bnOrZero(cryptoAmountAvailable).times(percent).precision(asset.precision)
-    const fiatAmount = bnOrZero(cryptoAmount).times(marketData.price)
-    setValue(Field.FiatAmount, fiatAmount.toString(), {
-      shouldValidate: true,
-    })
-    setValue(Field.CryptoAmount, cryptoAmount.toString(), {
-      shouldValidate: true,
-    })
-  }
+  const handlePercentClick = useCallback(
+    (percent: number) => {
+      const cryptoAmount =
+        percent === 1
+          ? cryptoAmountAvailable
+          : bnOrZero(cryptoAmountAvailable).times(percent).precision(asset.precision)
+      const fiatAmount = bnOrZero(cryptoAmount).times(marketData.price)
+      setValue(Field.FiatAmount, fiatAmount.toString(), {
+        shouldValidate: true,
+      })
+      setValue(Field.CryptoAmount, cryptoAmount.toString(), {
+        shouldValidate: true,
+      })
+    },
+    [asset.precision, cryptoAmountAvailable, marketData.price, setValue],
+  )
 
   const onSubmit = (values: DepositValues) => {
     onContinue(values)

--- a/src/features/defi/components/Deposit/Deposit.tsx
+++ b/src/features/defi/components/Deposit/Deposit.tsx
@@ -115,7 +115,10 @@ export const Deposit = ({
   }
 
   const handlePercentClick = (percent: number) => {
-    const cryptoAmount = bnOrZero(cryptoAmountAvailable).times(percent)
+    const cryptoAmount =
+      percent === 1
+        ? cryptoAmountAvailable
+        : bnOrZero(cryptoAmountAvailable).times(percent).precision(asset.precision)
     const fiatAmount = bnOrZero(cryptoAmount).times(marketData.price)
     setValue(Field.FiatAmount, fiatAmount.toString(), {
       shouldValidate: true,


### PR DESCRIPTION
## Description

This uses the full wallet balance in `handlePercentClick`, when the 100% option is selected. This applies to all DeFi
consumers of this method, not only Cosmos. TODO copy description from 2233

## Notice

<!-- Before submitting a pull request, please make sure you have answered the following: -->

- [x] Have you followed the guidelines in our [Contributing]('https://github.com/shapeshift/web/CONTRIBUTING.md) guide?
- [x] Have you checked to ensure there aren't other open [Pull Requests](https://github.com/shapeshift/web/pulls) for the same update/change?

## Pull Request Type

- [ ] :bug: Bug fix (Non-breaking Change: Fixes an issue)
- [ ] :hammer_and_wrench: Chore (Non-breaking Change: Doc updates, pkg upgrades, typos, etc..)
- [x] :nail_care: New Feature (Breaking/Non-breaking Change)

## Issue (if applicable)

partially tackles https://github.com/shapeshift/web/issues/2219

## Risk

None, this actually returns the actual wallet balance vs. a possibly off computation before that would result in insufficient balance state in some cases.

## Testing

- 100% selection across all DeFi opportunities (Yearn/Foxy as well as this new Cosmos one) should select 100% of the wallet balance for said asset.