### PR TITLE
fix: osmo validator to shapeshift

### DIFF
--- a/package.json
+++ b/package.json
@@ -103,7 +103,7 @@
     "@shapeshiftoss/investor-yearn": "^4.0.6",
     "@shapeshiftoss/logger": "^1.1.2",
     "@shapeshiftoss/market-service": "^6.4.5",
-    "@shapeshiftoss/swapper": "^9.2.2",
+    "@shapeshiftoss/swapper": "^9.3.1",
     "@shapeshiftoss/types": "^8.1.0",
     "@shapeshiftoss/unchained-client": "^9.5.0",
     "@uniswap/sdk": "^3.0.3",

--- a/src/state/slices/validatorDataSlice/constants.ts
+++ b/src/state/slices/validatorDataSlice/constants.ts
@@ -1,4 +1,4 @@
 export const SHAPESHIFT_COSMOS_VALIDATOR_ADDRESS =
   'cosmosvaloper199mlc7fr6ll5t54w7tts7f4s0cvnqgc59nmuxf'
 export const SHAPESHIFT_OSMOSIS_VALIDATOR_ADDRESS =
-  'osmovaloper1vkfmegxrsveefn2wmudh7apxuzu2n77654ad62'
+  'osmovaloper1xf9zpq5kpxks49cg606tzd8qstaykxgt2vs0d5'

--- a/yarn.lock
+++ b/yarn.lock
@@ -4003,10 +4003,10 @@
     google-protobuf "^3.17.0"
     long "^4.0.0"
 
-"@shapeshiftoss/swapper@^9.2.2":
-  version "9.2.2"
-  resolved "https://registry.yarnpkg.com/@shapeshiftoss/swapper/-/swapper-9.2.2.tgz#0cde02846805baaf25a6a99602188b16e7c4e12c"
-  integrity sha512-f4F+IUHvUXUXwXIVCt4pnNy0Qd6kGkm8QFEaydBJUvJBe7GhPwDnPjGEjvTGOpTegO6q10BOtsWFoAlcAsgt7g==
+"@shapeshiftoss/swapper@^9.3.1":
+  version "9.3.1"
+  resolved "https://registry.yarnpkg.com/@shapeshiftoss/swapper/-/swapper-9.3.1.tgz#b912a476fa4a21c25d70827ec0822869b51e0e56"
+  integrity sha512-pMzQyuQwCQZS9MeyYtBkHVMCAObbs04wJw2GtO5Lwe5N8JoPeSXTwz3063Pihmk33S9tbNU0XXPN8X4lb/FpQw==
   dependencies:
     axios "^0.26.1"
     bignumber.js "^9.0.2"


### PR DESCRIPTION
## Description

Update osmo validator to shapeshift instead from taxistake.

Update to latest swapper (affiliate fee)

## Notice

<!-- Before submitting a pull request, please make sure you have answered the following: -->

- [x] Have you followed the guidelines in our [Contributing]('https://github.com/shapeshift/web/CONTRIBUTING.md) guide?
- [x] Have you checked to ensure there aren't other open [Pull Requests](https://github.com/shapeshift/web/pulls) for the same update/change?

## Pull Request Type

- [x] :bug: Bug fix (Non-breaking Change: Fixes an issue)
- [ ] :hammer_and_wrench: Chore (Non-breaking Change: Doc updates, pkg upgrades, typos, etc..)
- [ ] :nail_care: New Feature (Breaking/Non-breaking Change)

## Issue (if applicable)

<!-----------------------------------------------------------------------------
If applicable, please link to the github issue and put `closes #XXXX` in your comment to auto-close the issue that your PR fixes.
------------------------------------------------------------------------------>

## Risk

Low risk. use different default validator

## Testing

test osmo staking

