### PR TITLE
feat: enforce react-hooks/exhaustive deps

### DIFF
--- a/.eslintrc
+++ b/.eslintrc
@@ -74,6 +74,7 @@
       }
     ],
     "object-shorthand": "error",
-    "eqeqeq": "error"
+    "eqeqeq": "error",
+    "react-hooks/exhaustive-deps": "error"
   }
 }


### PR DESCRIPTION
## Description

This enforces the react-hooks/exhaustive-deps rule, which we usually skip with eslint-disable-next-line directives when needed, so we are safe with erroring vs. emitting warnings.

## Notice

<!-- Before submitting a pull request, please make sure you have answered the following: -->

- [x] Have you followed the guidelines in our [Contributing]('https://github.com/shapeshift/web/CONTRIBUTING.md) guide?
- [x] Have you checked to ensure there aren't other open [Pull Requests](https://github.com/shapeshift/web/pulls) for the same update/change?

## Pull Request Type

- [ ] :bug: Bug fix (Non-breaking Change: Fixes an issue)
- [ ] :hammer_and_wrench: Chore (Non-breaking Change: Doc updates, pkg upgrades, typos, etc..)
- [x] :nail_care: New Feature (Breaking/Non-breaking Change)

## Issue (if applicable)

N/A

## Risk

None

## Testing

- Add some unused dependency in a useEffect() or useMemo() deps array
- `yarn lint` should not be happy

## Screenshots (if applicable)

develop:

<img width="858" alt="image" src="https://user-images.githubusercontent.com/17035424/182344292-a607f495-4c05-43b9-b514-25590ea3cd54.png">


This diff:

<img width="848" alt="image" src="https://user-images.githubusercontent.com/17035424/182344442-2b6a548f-85e6-44ea-97f7-3f03e923818b.png">