### PR TITLE
feat(defi providers): remove react-hooks/exhaustive-deps directives

### DIFF
--- a/src/features/defi/providers/cosmos/components/CosmosManager/Claim/ClaimStatus.tsx
+++ b/src/features/defi/providers/cosmos/components/CosmosManager/Claim/ClaimStatus.tsx
@@ -90,8 +90,7 @@ export const ClaimStatus = () => {
         })
       }
     })()
-    // eslint-disable-next-line react-hooks/exhaustive-deps
-  }, [])
+  }, [state, txid])
 
   return (
     <SlideTransition>

--- a/src/features/defi/providers/cosmos/components/CosmosManager/Deposit/CosmosDeposit.tsx
+++ b/src/features/defi/providers/cosmos/components/CosmosManager/Deposit/CosmosDeposit.tsx
@@ -115,8 +115,7 @@ export const CosmosDeposit = () => {
         component: Status,
       },
     }
-    // eslint-disable-next-line react-hooks/exhaustive-deps
-  }, [asset.symbol])
+  }, [asset.symbol, translate])
 
   if (loading || !asset || !marketData) {
     return (

--- a/src/features/defi/providers/cosmos/components/CosmosManager/Withdraw/CosmosWithdraw.tsx
+++ b/src/features/defi/providers/cosmos/components/CosmosManager/Withdraw/CosmosWithdraw.tsx
@@ -117,8 +117,7 @@ export const CosmosWithdraw = () => {
         component: Status,
       },
     }
-    // eslint-disable-next-line react-hooks/exhaustive-deps
-  }, [underlyingAsset?.symbol])
+  }, [translate, underlyingAsset?.symbol])
 
   const handleBack = () => {
     history.push({

--- a/src/features/defi/providers/cosmos/components/CosmosManager/Withdraw/components/Status.tsx
+++ b/src/features/defi/providers/cosmos/components/CosmosManager/Withdraw/components/Status.tsx
@@ -4,7 +4,7 @@ import { toAssetId } from '@shapeshiftoss/caip'
 import { Summary } from 'features/defi/components/Summary'
 import { TxStatus } from 'features/defi/components/TxStatus/TxStatus'
 import { DefiParams, DefiQueryParams } from 'features/defi/contexts/DefiManagerProvider/DefiCommon'
-import { useContext } from 'react'
+import { useCallback, useContext } from 'react'
 import { useTranslate } from 'react-polyglot'
 import { Amount } from 'components/Amount/Amount'
 import { AssetIcon } from 'components/AssetIcon'
@@ -39,15 +39,15 @@ export const Status = () => {
   })
   const asset = useAppSelector(state => selectAssetById(state, assetId))
 
-  if (!state || !dispatch) return null
-
-  const handleViewPosition = () => {
+  const handleViewPosition = useCallback(() => {
     browserHistory.push('/defi')
-  }
+  }, [browserHistory])
 
-  const handleCancel = () => {
+  const handleCancel = useCallback(() => {
     browserHistory.goBack()
-  }
+  }, [browserHistory])
+
+  if (!state || !dispatch) return null
 
   const { statusIcon, statusText, statusBg, statusBody } = (() => {
     switch (state.withdraw.txStatus) {

--- a/src/features/defi/providers/foxy/components/FoxyManager/Deposit/FoxyDeposit.tsx
+++ b/src/features/defi/providers/foxy/components/FoxyManager/Deposit/FoxyDeposit.tsx
@@ -110,8 +110,7 @@ export const FoxyDeposit = () => {
         component: Status,
       },
     }
-    // eslint-disable-next-line react-hooks/exhaustive-deps
-  }, [asset.symbol])
+  }, [translate, asset.symbol])
 
   if (loading || !asset || !marketData) {
     return (

--- a/src/features/defi/providers/foxy/components/FoxyManager/Overview/Claim/ClaimStatus.tsx
+++ b/src/features/defi/providers/foxy/components/FoxyManager/Overview/Claim/ClaimStatus.tsx
@@ -111,8 +111,7 @@ export const ClaimStatus = () => {
         })
       }
     })()
-    // eslint-disable-next-line react-hooks/exhaustive-deps
-  }, [])
+  }, [estimatedGas, foxy, state, txid])
 
   return (
     <SlideTransition>

--- a/src/features/defi/providers/foxy/components/FoxyManager/Withdraw/FoxyWithdraw.tsx
+++ b/src/features/defi/providers/foxy/components/FoxyManager/Withdraw/FoxyWithdraw.tsx
@@ -129,8 +129,7 @@ export const FoxyWithdraw = () => {
         component: Status,
       },
     }
-    // eslint-disable-next-line react-hooks/exhaustive-deps
-  }, [underlyingAsset.symbol])
+  }, [translate, underlyingAsset.symbol])
 
   const handleBack = () => {
     history.push({

--- a/src/features/defi/providers/yearn/components/YearnManager/Deposit/YearnDeposit.tsx
+++ b/src/features/defi/providers/yearn/components/YearnManager/Deposit/YearnDeposit.tsx
@@ -115,8 +115,7 @@ export const YearnDeposit = () => {
         component: Status,
       },
     }
-    // eslint-disable-next-line react-hooks/exhaustive-deps
-  }, [asset.symbol])
+  }, [asset.symbol, translate])
 
   if (loading || !asset || !marketData || !api) {
     return (

--- a/src/features/defi/providers/yearn/components/YearnManager/Withdraw/YearnWithdraw.tsx
+++ b/src/features/defi/providers/yearn/components/YearnManager/Withdraw/YearnWithdraw.tsx
@@ -123,9 +123,7 @@ export const YearnWithdraw = () => {
         component: Status,
       },
     }
-    // We only need this to update on symbol change
-    // eslint-disable-next-line react-hooks/exhaustive-deps
-  }, [underlyingAsset.symbol])
+  }, [translate, underlyingAsset.symbol])
 
   if (loading || !asset || !marketData)
     return (


### PR DESCRIPTION
## Description

This removes the `react-hooks/exhaustive-deps` directives across DeFi UI providers. We should be safe, and even safer, using the dependencies that are currently skipped.

## Notice

<!-- Before submitting a pull request, please make sure you have answered the following: -->

- [x] Have you followed the guidelines in our [Contributing]('https://github.com/shapeshift/web/CONTRIBUTING.md) guide?
- [x] Have you checked to ensure there aren't other open [Pull Requests](https://github.com/shapeshift/web/pulls) for the same update/change?

## Pull Request Type

- [ ] :bug: Bug fix (Non-breaking Change: Fixes an issue)
- [ ] :hammer_and_wrench: Chore (Non-breaking Change: Doc updates, pkg upgrades, typos, etc..)
- [x] :nail_care: New Feature (Breaking/Non-breaking Change)

## Issue (if applicable)

N/A - housekeeping

## Risk

Low. They could be unexpected runs with the added dependencies, but effectively, the dependencies we react on are either effectively stable, or dependencies we actually **want** to react on.

## Testing

- General regression test of DeFi providers - can be done with Keplr/Metamask with no need to actually broadcast a Tx.

## Screenshots (if applicable)
