### PR TITLE
feat(defi providers): add callbacks to event handlers

### DIFF
--- a/src/features/defi/providers/cosmos/components/CosmosManager/Deposit/components/Status.tsx
+++ b/src/features/defi/providers/cosmos/components/CosmosManager/Deposit/components/Status.tsx
@@ -4,7 +4,7 @@ import { toAssetId } from '@shapeshiftoss/caip'
 import { Summary } from 'features/defi/components/Summary'
 import { TxStatus } from 'features/defi/components/TxStatus/TxStatus'
 import { DefiParams, DefiQueryParams } from 'features/defi/contexts/DefiManagerProvider/DefiCommon'
-import { useContext } from 'react'
+import { useCallback, useContext } from 'react'
 import { useTranslate } from 'react-polyglot'
 import { useHistory } from 'react-router-dom'
 import { Amount } from 'components/Amount/Amount'
@@ -29,9 +29,9 @@ export const Status = () => {
 
   const asset = useAppSelector(state => selectAssetById(state, assetId))
 
-  const handleViewPosition = () => {
+  const handleViewPosition = useCallback(() => {
     browserHistory.push('/defi')
-  }
+  }, [browserHistory])
 
   const handleCancel = history.goBack
 

--- a/src/features/defi/providers/foxy/components/FoxyManager/Deposit/components/Deposit.tsx
+++ b/src/features/defi/providers/foxy/components/FoxyManager/Deposit/components/Deposit.tsx
@@ -49,7 +49,7 @@ export const Deposit: React.FC<StepComponentProps> = ({ onNext }) => {
 
   const handleContinue = useCallback(
     async (formValues: DepositValues) => {
-      if (!(state && dispatch)) return
+      if (!(state && state.userAddress?.length && dispatch && api)) return
 
       const getApproveGasEstimate = async () => {
         if (!state.userAddress || !assetReference || !api) return

--- a/src/features/defi/providers/foxy/components/FoxyManager/Deposit/components/Deposit.tsx
+++ b/src/features/defi/providers/foxy/components/FoxyManager/Deposit/components/Deposit.tsx
@@ -7,7 +7,7 @@ import {
   DefiStep,
 } from 'features/defi/contexts/DefiManagerProvider/DefiCommon'
 import { useFoxy } from 'features/defi/contexts/FoxyProvider/FoxyProvider'
-import { useContext, useMemo } from 'react'
+import { useCallback, useContext, useMemo } from 'react'
 import { useTranslate } from 'react-polyglot'
 import { useHistory } from 'react-router-dom'
 import { StepComponentProps } from 'components/DeFi/components/Steps'
@@ -47,105 +47,122 @@ export const Deposit: React.FC<StepComponentProps> = ({ onNext }) => {
   // notify
   const toast = useToast()
 
-  if (!state || !dispatch) return null
+  const handleContinue = useCallback(
+    async (formValues: DepositValues) => {
+      if (!(state && dispatch)) return
 
-  const getDepositGasEstimate = async (deposit: DepositValues) => {
-    if (!state.userAddress || !assetReference || !api) return
-    try {
-      const [gasLimit, gasPrice] = await Promise.all([
-        api.estimateDepositGas({
+      const getApproveGasEstimate = async () => {
+        if (!state.userAddress || !assetReference || !api) return
+        try {
+          const [gasLimit, gasPrice] = await Promise.all([
+            api.estimateApproveGas({
+              tokenContractAddress: assetReference,
+              contractAddress,
+              userAddress: state.userAddress,
+            }),
+            api.getGasPrice(),
+          ])
+          return bnOrZero(gasPrice).times(gasLimit).toFixed(0)
+        } catch (error) {
+          moduleLogger.error(
+            { fn: 'getApproveEstimate', error },
+            'Error getting approval gas estimate',
+          )
+          toast({
+            position: 'top-right',
+            description: translate('common.somethingWentWrongBody'),
+            title: translate('common.somethingWentWrong'),
+            status: 'error',
+          })
+        }
+      }
+
+      const getDepositGasEstimate = async (deposit: DepositValues) => {
+        if (!state.userAddress || !assetReference || !api) return
+        try {
+          const [gasLimit, gasPrice] = await Promise.all([
+            api.estimateDepositGas({
+              tokenContractAddress: assetReference,
+              contractAddress,
+              amountDesired: bnOrZero(deposit.cryptoAmount)
+                .times(`1e+${asset.precision}`)
+                .decimalPlaces(0),
+              userAddress: state.userAddress,
+            }),
+            api.getGasPrice(),
+          ])
+          return bnOrZero(gasPrice).times(gasLimit).toFixed(0)
+        } catch (error) {
+          moduleLogger.error(
+            { fn: 'getDepositGasEstimate', error },
+            'Error getting deposit gas estimate',
+          )
+          toast({
+            position: 'top-right',
+            description: translate('common.somethingWentWrongBody'),
+            title: translate('common.somethingWentWrong'),
+            status: 'error',
+          })
+        }
+      }
+
+      // set deposit state for future use
+      dispatch({ type: FoxyDepositActionType.SET_DEPOSIT, payload: formValues })
+      dispatch({ type: FoxyDepositActionType.SET_LOADING, payload: true })
+      try {
+        // Check is approval is required for user address
+        const _allowance = await api.allowance({
           tokenContractAddress: assetReference,
           contractAddress,
-          amountDesired: bnOrZero(deposit.cryptoAmount)
-            .times(`1e+${asset.precision}`)
-            .decimalPlaces(0),
           userAddress: state.userAddress,
-        }),
-        api.getGasPrice(),
-      ])
-      return bnOrZero(gasPrice).times(gasLimit).toFixed(0)
-    } catch (error) {
-      moduleLogger.error(
-        { fn: 'getDepositGasEstimate', error },
-        'Error getting deposit gas estimate',
-      )
-      toast({
-        position: 'top-right',
-        description: translate('common.somethingWentWrongBody'),
-        title: translate('common.somethingWentWrong'),
-        status: 'error',
-      })
-    }
-  }
-
-  const getApproveGasEstimate = async () => {
-    if (!state.userAddress || !assetReference || !api) return
-    try {
-      const [gasLimit, gasPrice] = await Promise.all([
-        api.estimateApproveGas({
-          tokenContractAddress: assetReference,
-          contractAddress,
-          userAddress: state.userAddress,
-        }),
-        api.getGasPrice(),
-      ])
-      return bnOrZero(gasPrice).times(gasLimit).toFixed(0)
-    } catch (error) {
-      moduleLogger.error({ fn: 'getApproveEstimate', error }, 'Error getting approval gas estimate')
-      toast({
-        position: 'top-right',
-        description: translate('common.somethingWentWrongBody'),
-        title: translate('common.somethingWentWrong'),
-        status: 'error',
-      })
-    }
-  }
-
-  const handleContinue = async (formValues: DepositValues) => {
-    if (!state.userAddress || !api) return
-    // set deposit state for future use
-    dispatch({ type: FoxyDepositActionType.SET_DEPOSIT, payload: formValues })
-    dispatch({ type: FoxyDepositActionType.SET_LOADING, payload: true })
-    try {
-      // Check is approval is required for user address
-      const _allowance = await api.allowance({
-        tokenContractAddress: assetReference,
-        contractAddress,
-        userAddress: state.userAddress,
-      })
-      const allowance = bnOrZero(_allowance).div(`1e+${asset.precision}`)
-
-      // Skip approval step if user allowance is greater than requested deposit amount
-      if (allowance.gt(formValues.cryptoAmount)) {
-        const estimatedGasCrypto = await getDepositGasEstimate(formValues)
-        if (!estimatedGasCrypto) return
-        dispatch({
-          type: FoxyDepositActionType.SET_DEPOSIT,
-          payload: { estimatedGasCrypto },
         })
-        onNext(DefiStep.Confirm)
-        dispatch({ type: FoxyDepositActionType.SET_LOADING, payload: false })
-      } else {
-        const estimatedGasCrypto = await getApproveGasEstimate()
-        if (!estimatedGasCrypto) return
-        dispatch({
-          type: FoxyDepositActionType.SET_APPROVE,
-          payload: { estimatedGasCrypto },
+        const allowance = bnOrZero(_allowance).div(`1e+${asset.precision}`)
+
+        // Skip approval step if user allowance is greater than requested deposit amount
+        if (allowance.gt(formValues.cryptoAmount)) {
+          const estimatedGasCrypto = await getDepositGasEstimate(formValues)
+          if (!estimatedGasCrypto) return
+          dispatch({
+            type: FoxyDepositActionType.SET_DEPOSIT,
+            payload: { estimatedGasCrypto },
+          })
+          onNext(DefiStep.Confirm)
+          dispatch({ type: FoxyDepositActionType.SET_LOADING, payload: false })
+        } else {
+          const estimatedGasCrypto = await getApproveGasEstimate()
+          if (!estimatedGasCrypto) return
+          dispatch({
+            type: FoxyDepositActionType.SET_APPROVE,
+            payload: { estimatedGasCrypto },
+          })
+          onNext(DefiStep.Approve)
+          dispatch({ type: FoxyDepositActionType.SET_LOADING, payload: false })
+        }
+      } catch (error) {
+        moduleLogger.error({ fn: 'handleContinue', error }, 'Error on continue')
+        toast({
+          position: 'top-right',
+          description: translate('common.somethingWentWrongBody'),
+          title: translate('common.somethingWentWrong'),
+          status: 'error',
         })
-        onNext(DefiStep.Approve)
         dispatch({ type: FoxyDepositActionType.SET_LOADING, payload: false })
       }
-    } catch (error) {
-      moduleLogger.error({ fn: 'handleContinue', error }, 'Error on continue')
-      toast({
-        position: 'top-right',
-        description: translate('common.somethingWentWrongBody'),
-        title: translate('common.somethingWentWrong'),
-        status: 'error',
-      })
-      dispatch({ type: FoxyDepositActionType.SET_LOADING, payload: false })
-    }
-  }
+    },
+    [
+      api,
+      asset.precision,
+      assetReference,
+      contractAddress,
+      dispatch,
+      onNext,
+      state,
+      toast,
+      translate,
+    ],
+  )
+
+  if (!state || !dispatch) return null
 
   const handleCancel = history.goBack
 

--- a/src/features/defi/providers/foxy/components/FoxyManager/Deposit/components/Status.tsx
+++ b/src/features/defi/providers/foxy/components/FoxyManager/Deposit/components/Status.tsx
@@ -4,7 +4,7 @@ import { ASSET_REFERENCE, toAssetId } from '@shapeshiftoss/caip'
 import { Summary } from 'features/defi/components/Summary'
 import { TxStatus } from 'features/defi/components/TxStatus/TxStatus'
 import { DefiParams, DefiQueryParams } from 'features/defi/contexts/DefiManagerProvider/DefiCommon'
-import { useContext } from 'react'
+import { useCallback, useContext } from 'react'
 import { useTranslate } from 'react-polyglot'
 import { useHistory } from 'react-router-dom'
 import { Amount } from 'components/Amount/Amount'
@@ -37,9 +37,9 @@ export const Status = () => {
   const feeAsset = useAppSelector(state => selectAssetById(state, feeAssetId))
   const feeMarketData = useAppSelector(state => selectMarketDataById(state, feeAssetId))
 
-  const handleViewPosition = () => {
+  const handleViewPosition = useCallback(() => {
     browserHistory.push('/defi')
-  }
+  }, [browserHistory])
 
   const handleCancel = history.goBack
 

--- a/src/features/defi/providers/foxy/components/FoxyManager/Withdraw/components/Status.tsx
+++ b/src/features/defi/providers/foxy/components/FoxyManager/Withdraw/components/Status.tsx
@@ -5,7 +5,7 @@ import { WithdrawType } from '@shapeshiftoss/types'
 import { Summary } from 'features/defi/components/Summary'
 import { TxStatus } from 'features/defi/components/TxStatus/TxStatus'
 import { DefiParams, DefiQueryParams } from 'features/defi/contexts/DefiManagerProvider/DefiCommon'
-import { useContext, useMemo } from 'react'
+import { useCallback, useContext, useMemo } from 'react'
 import { useTranslate } from 'react-polyglot'
 import { Amount } from 'components/Amount/Amount'
 import { AssetIcon } from 'components/AssetIcon'
@@ -56,9 +56,9 @@ export const Status = () => {
 
   if (!state || !dispatch) return null
 
-  const handleViewPosition = () => {
+  const handleViewPosition = useCallback(() => {
     browserHistory.push('/defi')
-  }
+  }, [browserHistory])
 
   const handleCancel = () => {
     browserHistory.goBack()

--- a/src/features/defi/providers/foxy/components/FoxyManager/Withdraw/components/Status.tsx
+++ b/src/features/defi/providers/foxy/components/FoxyManager/Withdraw/components/Status.tsx
@@ -54,11 +54,11 @@ export const Status = () => {
       : '0'
   }, [state?.withdraw.withdrawType, state?.withdraw.cryptoAmount, state?.foxyFeePercentage])
 
-  if (!state || !dispatch) return null
-
   const handleViewPosition = useCallback(() => {
     browserHistory.push('/defi')
   }, [browserHistory])
+
+  if (!state || !dispatch) return null
 
   const handleCancel = () => {
     browserHistory.goBack()

--- a/src/features/defi/providers/yearn/components/YearnManager/Deposit/components/Status.tsx
+++ b/src/features/defi/providers/yearn/components/YearnManager/Deposit/components/Status.tsx
@@ -68,7 +68,7 @@ export const Status = () => {
 
   const handleViewPosition = useCallback(() => {
     browserHistory.push('/defi')
-  }, [[browserHistory]])
+  }, [browserHistory])
 
   const handleCancel = () => {
     browserHistory.goBack()

--- a/src/features/defi/providers/yearn/components/YearnManager/Deposit/components/Status.tsx
+++ b/src/features/defi/providers/yearn/components/YearnManager/Deposit/components/Status.tsx
@@ -4,7 +4,7 @@ import { ASSET_REFERENCE, toAssetId } from '@shapeshiftoss/caip'
 import { Summary } from 'features/defi/components/Summary'
 import { TxStatus } from 'features/defi/components/TxStatus/TxStatus'
 import { DefiParams, DefiQueryParams } from 'features/defi/contexts/DefiManagerProvider/DefiCommon'
-import { useContext, useEffect, useMemo } from 'react'
+import { useCallback, useContext, useEffect, useMemo } from 'react'
 import { useTranslate } from 'react-polyglot'
 import { Amount } from 'components/Amount/Amount'
 import { AssetIcon } from 'components/AssetIcon'
@@ -66,9 +66,9 @@ export const Status = () => {
     }
   }, [confirmedTransaction, dispatch])
 
-  const handleViewPosition = () => {
+  const handleViewPosition = useCallback(() => {
     browserHistory.push('/defi')
-  }
+  }, [[browserHistory]])
 
   const handleCancel = () => {
     browserHistory.goBack()

--- a/src/features/defi/providers/yearn/components/YearnManager/Withdraw/components/Status.tsx
+++ b/src/features/defi/providers/yearn/components/YearnManager/Withdraw/components/Status.tsx
@@ -4,7 +4,7 @@ import { ASSET_REFERENCE, toAssetId } from '@shapeshiftoss/caip'
 import { Summary } from 'features/defi/components/Summary'
 import { TxStatus } from 'features/defi/components/TxStatus/TxStatus'
 import { DefiParams, DefiQueryParams } from 'features/defi/contexts/DefiManagerProvider/DefiCommon'
-import { useContext, useEffect, useMemo } from 'react'
+import { useCallback, useContext, useEffect, useMemo } from 'react'
 import { useTranslate } from 'react-polyglot'
 import { Amount } from 'components/Amount/Amount'
 import { AssetIcon } from 'components/AssetIcon'
@@ -75,13 +75,13 @@ export const Status = () => {
     }
   }, [confirmedTransaction, dispatch])
 
-  const handleViewPosition = () => {
+  const handleViewPosition = useCallback(() => {
     browserHistory.push('/defi')
-  }
+  }, [browserHistory])
 
-  const handleCancel = () => {
+  const handleCancel = useCallback(() => {
     browserHistory.goBack()
-  }
+  }, [browserHistory])
 
   if (!state) return null
 


### PR DESCRIPTION
## Description

This wraps DeFi provider event handlers in callbacks, giving us referentially stable callbacks.

## Notice

<!-- Before submitting a pull request, please make sure you have answered the following: -->

- [x] Have you followed the guidelines in our [Contributing]('https://github.com/shapeshift/web/CONTRIBUTING.md) guide?
- [x] Have you checked to ensure there aren't other open [Pull Requests](https://github.com/shapeshift/web/pulls) for the same update/change?

## Pull Request Type

- [ ] :bug: Bug fix (Non-breaking Change: Fixes an issue)
- [ ] :hammer_and_wrench: Chore (Non-breaking Change: Doc updates, pkg upgrades, typos, etc..)
- [x] :nail_care: New Feature (Breaking/Non-breaking Change)

## Issue (if applicable)

None - housekeeping

## Risk

Low. This in theory should just give us referentially stable callbacks vs. unstable ones currently.

## Testing


- General regression test of DeFi providers - can be done with Keplr/Metamask with no need to actually broadcast a Tx.

## Screenshots (if applicable)
