### PR TITLE
chore: simplify balance charts

### DIFF
--- a/src/hooks/useBalanceChartData/cosmosUtils.test.ts
+++ b/src/hooks/useBalanceChartData/cosmosUtils.test.ts
@@ -1,7 +1,7 @@
 import { merge } from 'lodash'
 import { Tx } from 'state/slices/txHistorySlice/txHistorySlice'
 
-import { includeTransaction } from './cosmosUtils'
+import { excludeTransaction } from './cosmosUtils'
 
 const mockTx = (obj?: { parser?: string; method?: string }) =>
   ({
@@ -15,15 +15,15 @@ const mockTx = (obj?: { parser?: string; method?: string }) =>
   } as Tx)
 
 describe('cosmosUtils', () => {
-  describe('includeTransaction', () => {
+  describe('excludeTransaction', () => {
     it.each([[undefined], [{ method: 'begin_unbonding' }]])('should return false for %O', args => {
-      expect(includeTransaction(mockTx(args))).toBe(false)
+      expect(excludeTransaction(mockTx(args))).toBe(true)
     })
 
     it.each([[{ parser: 'bitcoin' }], [{ method: 'normal_tx' }]])(
       'should return true for %O',
       args => {
-        expect(includeTransaction(mockTx(args))).toBe(true)
+        expect(excludeTransaction(mockTx(args))).toBe(false)
       },
     )
   })

--- a/src/hooks/useBalanceChartData/cosmosUtils.ts
+++ b/src/hooks/useBalanceChartData/cosmosUtils.ts
@@ -1,14 +1,8 @@
-import { ASSET_REFERENCE, cosmosChainId, toAssetId } from '@shapeshiftoss/caip'
+import { cosmosAssetId } from '@shapeshiftoss/caip'
 import { bnOrZero } from 'lib/bignumber/bignumber'
 import { Tx } from 'state/slices/txHistorySlice/txHistorySlice'
 
 import { Bucket } from './useBalanceChartData'
-
-const cosmosAssetId = toAssetId({
-  chainId: cosmosChainId,
-  assetNamespace: 'slip44',
-  assetReference: ASSET_REFERENCE.Cosmos,
-})
 
 export const includeTransaction = (tx: Tx): boolean =>
   tx.data?.parser !== 'cosmos' ||

--- a/src/hooks/useBalanceChartData/cosmosUtils.ts
+++ b/src/hooks/useBalanceChartData/cosmosUtils.ts
@@ -1,12 +1,14 @@
 import { Tx } from 'state/slices/txHistorySlice/txHistorySlice'
 
-export const includeTransaction = (tx: Tx): boolean =>
-  tx.data?.parser !== 'cosmos' ||
-  !(
-    tx?.data.method === 'delegate' ||
-    tx?.data.method === 'begin_unbonding' ||
-    tx?.data.method === 'withdraw_delegator_reward' ||
-    tx?.data.method === 'begin_redelegate' ||
-    tx?.data.method === 'cancel_unbond' ||
-    tx?.data.method === 'set_withdraw_address'
+export const excludeTransaction = (tx: Tx): boolean =>
+  !Boolean(
+    tx.data?.parser !== 'cosmos' ||
+      !(
+        tx?.data.method === 'delegate' ||
+        tx?.data.method === 'begin_unbonding' ||
+        tx?.data.method === 'withdraw_delegator_reward' ||
+        tx?.data.method === 'begin_redelegate' ||
+        tx?.data.method === 'cancel_unbond' ||
+        tx?.data.method === 'set_withdraw_address'
+      ),
   )

--- a/src/hooks/useBalanceChartData/cosmosUtils.ts
+++ b/src/hooks/useBalanceChartData/cosmosUtils.ts
@@ -1,14 +1,13 @@
 import { Tx } from 'state/slices/txHistorySlice/txHistorySlice'
 
 export const excludeTransaction = (tx: Tx): boolean =>
-  !Boolean(
-    tx.data?.parser !== 'cosmos' ||
-      !(
-        tx?.data.method === 'delegate' ||
-        tx?.data.method === 'begin_unbonding' ||
-        tx?.data.method === 'withdraw_delegator_reward' ||
-        tx?.data.method === 'begin_redelegate' ||
-        tx?.data.method === 'cancel_unbond' ||
-        tx?.data.method === 'set_withdraw_address'
-      ),
+  Boolean(
+    tx.data &&
+      tx.data.parser === 'cosmos' &&
+      (tx.data.method === 'delegate' ||
+        tx.data.method === 'begin_unbonding' ||
+        tx.data.method === 'withdraw_delegator_reward' ||
+        tx.data.method === 'begin_redelegate' ||
+        tx.data.method === 'cancel_unbond' ||
+        tx.data.method === 'set_withdraw_address'),
   )

--- a/src/hooks/useBalanceChartData/cosmosUtils.ts
+++ b/src/hooks/useBalanceChartData/cosmosUtils.ts
@@ -5,5 +5,6 @@ export const includeTransaction = (tx: Tx): boolean =>
   !(
     tx?.data.method === 'delegate' ||
     tx?.data.method === 'begin_unbonding' ||
-    tx?.data.method === 'withdraw_delegator_reward'
+    tx?.data.method === 'withdraw_delegator_reward' ||
+    tx?.data.method === 'begin_redelegate'
   )

--- a/src/hooks/useBalanceChartData/cosmosUtils.ts
+++ b/src/hooks/useBalanceChartData/cosmosUtils.ts
@@ -6,5 +6,7 @@ export const includeTransaction = (tx: Tx): boolean =>
     tx?.data.method === 'delegate' ||
     tx?.data.method === 'begin_unbonding' ||
     tx?.data.method === 'withdraw_delegator_reward' ||
-    tx?.data.method === 'begin_redelegate'
+    tx?.data.method === 'begin_redelegate' ||
+    tx?.data.method === 'cancel_unbond' ||
+    tx?.data.method === 'set_withdraw_address'
   )

--- a/src/hooks/useBalanceChartData/cosmosUtils.ts
+++ b/src/hooks/useBalanceChartData/cosmosUtils.ts
@@ -1,26 +1,5 @@
-import { cosmosAssetId } from '@shapeshiftoss/caip'
-import { bnOrZero } from 'lib/bignumber/bignumber'
 import { Tx } from 'state/slices/txHistorySlice/txHistorySlice'
-
-import { Bucket } from './useBalanceChartData'
 
 export const includeTransaction = (tx: Tx): boolean =>
   tx.data?.parser !== 'cosmos' ||
   !(tx?.data.method === 'delegate' || tx?.data.method === 'begin_unbonding')
-
-export const includeStakedBalance = (
-  startingBucket: Bucket,
-  totalCosmosStaked: string,
-  assetIds: string[],
-) => {
-  const newStartingBucket = { ...startingBucket }
-
-  if (assetIds.includes(cosmosAssetId)) {
-    newStartingBucket.balance.crypto[cosmosAssetId] = newStartingBucket.balance.crypto[
-      cosmosAssetId
-    ]
-      ? newStartingBucket.balance.crypto[cosmosAssetId].plus(totalCosmosStaked)
-      : bnOrZero(totalCosmosStaked)
-  }
-  return newStartingBucket
-}

--- a/src/hooks/useBalanceChartData/cosmosUtils.ts
+++ b/src/hooks/useBalanceChartData/cosmosUtils.ts
@@ -2,4 +2,8 @@ import { Tx } from 'state/slices/txHistorySlice/txHistorySlice'
 
 export const includeTransaction = (tx: Tx): boolean =>
   tx.data?.parser !== 'cosmos' ||
-  !(tx?.data.method === 'delegate' || tx?.data.method === 'begin_unbonding')
+  !(
+    tx?.data.method === 'delegate' ||
+    tx?.data.method === 'begin_unbonding' ||
+    tx?.data.method === 'withdraw_delegator_reward'
+  )

--- a/src/hooks/useBalanceChartData/useBalanceChartData.test.ts
+++ b/src/hooks/useBalanceChartData/useBalanceChartData.test.ts
@@ -113,7 +113,6 @@ describe('calculateBucketPrices', () => {
       cryptoPriceHistoryData,
       fiatPriceHistoryData,
       portfolioAssets,
-      delegationTotal: '0',
     })
 
     expect(calculatedBuckets[0].balance.crypto[foxAssetId].toFixed(0)).toEqual(value)
@@ -146,7 +145,6 @@ describe('calculateBucketPrices', () => {
       cryptoPriceHistoryData,
       fiatPriceHistoryData,
       portfolioAssets,
-      delegationTotal: '0',
     })
     expect(calculatedBuckets[0].balance.crypto[ethAssetId].toNumber()).toEqual(0)
   })

--- a/src/hooks/useBalanceChartData/useBalanceChartData.ts
+++ b/src/hooks/useBalanceChartData/useBalanceChartData.ts
@@ -33,13 +33,13 @@ import {
   selectFiatPriceHistoryTimeframe,
   selectPortfolioAssets,
   selectPriceHistoriesLoadingByAssetTimeframe,
+  selectRebasesByFilter,
+  selectTxHistoryStatus,
   selectTxsByFilter,
 } from 'state/slices/selectors'
-import { selectRebasesByFilter } from 'state/slices/txHistorySlice/selectors'
 import { Tx } from 'state/slices/txHistorySlice/txHistorySlice'
 import { useAppSelector } from 'state/store'
 
-import { selectTxHistoryStatus } from './../../state/slices/txHistorySlice/selectors'
 import { includeTransaction } from './cosmosUtils'
 
 const moduleLogger = logger.child({ namespace: ['useBalanceChartData'] })
@@ -328,15 +328,6 @@ export const useBalanceChartData: UseBalanceChartData = args => {
   // rebasing token balances can be adjusted by rebase events rather than txs
   // and we need to account for this in charts
   const rebases = useAppSelector(state => selectRebasesByFilter(state, txFilter))
-
-  // the portfolio page is simple - consider all txs and all portfolio asset ids
-  // across all accounts - just don't filter for accounts
-
-  // there are a few different situations for
-  // - top level asset pages - zero or more account ids
-  // - an asset account page, e.g. show me the eth for 0xfoo - a single account id
-  // - an account asset page, e.g. show me the fox for 0xbar - a single account id
-  // this may seem complicated, but we just need txs filtered by account ids
 
   // kick off requests for all the price histories we need
   useFetchPriceHistories({ assetIds, timeframe })

--- a/src/hooks/useBalanceChartData/useBalanceChartData.ts
+++ b/src/hooks/useBalanceChartData/useBalanceChartData.ts
@@ -1,6 +1,6 @@
-import { AssetId } from '@shapeshiftoss/caip'
+import { AssetId, CHAIN_NAMESPACE, fromChainId } from '@shapeshiftoss/caip'
 import { RebaseHistory } from '@shapeshiftoss/investor-foxy'
-import { HistoryData, HistoryTimeframe, KnownChainIds } from '@shapeshiftoss/types'
+import { HistoryData, HistoryTimeframe } from '@shapeshiftoss/types'
 import { TransferType, TxStatus } from '@shapeshiftoss/unchained-client'
 import { BigNumber } from 'bignumber.js'
 import dayjs from 'dayjs'
@@ -222,10 +222,9 @@ export const calculateBucketPrices: CalculateBucketPrices = args => {
     // if we have txs in this bucket, adjust the crypto balance in each bucket
     txs.forEach(tx => {
       if (tx.fee && assetIds.includes(tx.fee.assetId)) {
-        // balance history being built in descending order, so fee means we had more before
-        // TODO(0xdef1cafe): this is awful but gets us out of trouble
-        // NOTE: related to utxo balance tracking, just ignoring bitcoin for now as our only utxo chain support
-        if (tx.chain !== KnownChainIds.BitcoinMainnet) {
+        // don't count fees for UTXO chains
+        if (fromChainId(tx.chain).chainNamespace !== CHAIN_NAMESPACE.Bitcoin) {
+          // balance history being built in descending order, so fee means we had more before
           bucket.balance.crypto[tx.fee.assetId] = bucket.balance.crypto[tx.fee.assetId].plus(
             bnOrZero(tx.fee.value),
           )

--- a/src/hooks/useBalanceChartData/useBalanceChartData.ts
+++ b/src/hooks/useBalanceChartData/useBalanceChartData.ts
@@ -40,7 +40,7 @@ import {
 import { Tx } from 'state/slices/txHistorySlice/txHistorySlice'
 import { useAppSelector } from 'state/store'
 
-import { includeTransaction } from './cosmosUtils'
+import { excludeTransaction } from './cosmosUtils'
 
 const moduleLogger = logger.child({ namespace: ['useBalanceChartData'] })
 
@@ -231,14 +231,14 @@ export const calculateBucketPrices: CalculateBucketPrices = args => {
         }
       }
 
-      // Identify Special cases where we should not include cosmos delegate/undelegate txs in chart balance
-      const includeTx = includeTransaction(tx)
+      // Identify Special cases where we should exclude cosmos delegate/undelegate/claim txs in chart balance
+      const excludeTx = excludeTransaction(tx)
 
       tx.transfers.forEach(transfer => {
         const asset = transfer.assetId
 
         if (!assetIds.includes(asset)) return
-        if (!includeTx) return
+        if (excludeTx) return
         if (tx.status === TxStatus.Failed) return
 
         const bucketValue = bnOrZero(bucket.balance.crypto[asset])

--- a/src/hooks/useBalanceChartData/useBalanceChartData.ts
+++ b/src/hooks/useBalanceChartData/useBalanceChartData.ts
@@ -29,11 +29,11 @@ import {
 import {
   selectAccountSpecifiers,
   selectAssets,
+  selectBalanceChartCryptoBalancesByAccountIdAboveThreshold,
   selectCryptoPriceHistoryTimeframe,
   selectFiatPriceHistoriesLoadingByTimeframe,
   selectFiatPriceHistoryTimeframe,
   selectPortfolioAssets,
-  selectPortfolioCryptoBalancesByAccountIdAboveThreshold,
   selectPriceHistoriesLoadingByAssetTimeframe,
   selectTotalStakingDelegationCryptoByAccountSpecifier,
   selectTxsByFilter,
@@ -328,9 +328,9 @@ export const useBalanceChartData: UseBalanceChartData = args => {
   const accountIds = useMemo(() => (accountId ? [accountId] : []), [accountId])
   const [balanceChartDataLoading, setBalanceChartDataLoading] = useState(true)
   const [balanceChartData, setBalanceChartData] = useState<HistoryData[]>([])
-  // dummy assetId - we're only filtering on account
+
   const balances = useAppSelector(state =>
-    selectPortfolioCryptoBalancesByAccountIdAboveThreshold(state, accountId),
+    selectBalanceChartCryptoBalancesByAccountIdAboveThreshold(state, accountId),
   )
 
   // Get total delegation

--- a/src/state/slices/portfolioSlice/portfolioSliceCommon.ts
+++ b/src/state/slices/portfolioSlice/portfolioSliceCommon.ts
@@ -31,15 +31,17 @@ export type Staking = {
   rewards: cosmos.Reward[]
 }
 
+type StakingDataParsedByAccountSpecifier = Record<string, Staking>
+export type StakingDataByValidatorId = Record<PubKey, StakingDataParsedByAccountSpecifier>
+
 export type PortfolioAccount = {
   /** The asset ids belonging to an account */
   assetIds: AssetId[]
   /** The list of validators this account is delegated to */
   validatorIds?: PubKey[]
   /** The staking data for per validator, so we can do a join from validatorDataSlice */
-  stakingDataByValidatorId?: Record<PubKey, StakingDataParsedByAccountSpecifier>
+  stakingDataByValidatorId?: StakingDataByValidatorId
 }
-type StakingDataParsedByAccountSpecifier = Record<string, Staking>
 
 export type PortfolioAccounts = {
   byId: {

--- a/src/state/slices/portfolioSlice/portfolioSliceCommon.ts
+++ b/src/state/slices/portfolioSlice/portfolioSliceCommon.ts
@@ -31,7 +31,7 @@ export type Staking = {
   rewards: cosmos.Reward[]
 }
 
-type StakingDataParsedByAccountSpecifier = Record<string, Staking>
+type StakingDataParsedByAccountSpecifier = Record<AccountSpecifier, Staking>
 export type StakingDataByValidatorId = Record<PubKey, StakingDataParsedByAccountSpecifier>
 
 export type PortfolioAccount = {

--- a/src/state/slices/portfolioSlice/selectors.ts
+++ b/src/state/slices/portfolioSlice/selectors.ts
@@ -370,14 +370,6 @@ export const selectStakingDataByAccountSpecifier = createSelector(
   },
 )
 
-export const selectAllStakingDataByValidator = createSelector(
-  selectPortfolioAccounts,
-  selectAccountSpecifierParamFromFilter,
-  (portfolioAccounts, accountSpecifier) => {
-    return portfolioAccounts?.[accountSpecifier]?.stakingDataByValidatorId
-  },
-)
-
 export const selectTotalStakingDelegationCryptoByAccountSpecifier = createDeepEqualOutputSelector(
   selectStakingDataByAccountSpecifier,
   selectAssetIdParamFromFilter,
@@ -849,7 +841,7 @@ export const selectDelegationCryptoAmountByAssetIdAndValidator = createSelector(
 )
 
 export const selectUnbondingEntriesByAccountSpecifier = createDeepEqualOutputSelector(
-  selectAllStakingDataByValidator,
+  selectStakingDataByAccountSpecifier,
   selectValidatorAddressParamFromFilter,
   selectAssetIdParamFromFilter,
   (stakingDataByValidator, validatorAddress, assetId): cosmos.UndelegationEntry[] => {
@@ -920,7 +912,7 @@ export const selectValidatorIds = createDeepEqualOutputSelector(
 export const selectStakingOpportunitiesDataFull = createDeepEqualOutputSelector(
   selectValidatorIds,
   selectValidators,
-  selectAllStakingDataByValidator,
+  selectStakingDataByAccountSpecifier,
   selectAssetIdParamFromFilter,
   (validatorIds, validatorsData, stakingDataByValidator, assetId): OpportunitiesDataFull[] =>
     validatorIds.map(validatorId => {

--- a/src/state/slices/validatorDataSlice/validatorDataSlice.ts
+++ b/src/state/slices/validatorDataSlice/validatorDataSlice.ts
@@ -1,12 +1,11 @@
 import { createSlice } from '@reduxjs/toolkit'
 import { createApi, fetchBaseQuery } from '@reduxjs/toolkit/query/react'
-import { ChainId } from '@shapeshiftoss/caip'
+import { ChainId, osmosisAssetId } from '@shapeshiftoss/caip'
 import { cosmos } from '@shapeshiftoss/chain-adapters'
 import {
   isCosmosChainId,
   isOsmosisChainId,
 } from 'plugins/cosmos/components/modals/Staking/StakingCommon'
-// @ts-ignore this will fail at 'file differs in casing' error
 import { getChainAdapterManager } from 'context/PluginProvider/chainAdapterSingleton'
 import { logger } from 'lib/logger'
 import {
@@ -15,12 +14,16 @@ import {
 } from 'state/slices/validatorDataSlice/constants'
 
 import { PortfolioAccounts } from '../portfolioSlice/portfolioSliceCommon'
+import { cosmosAssetId } from './../../../test/mocks/accounts'
 
 const moduleLogger = logger.child({ namespace: ['validatorDataSlice'] })
 
 export type PubKey = string
 
 type SingleValidatorDataArgs = { accountSpecifier: string; chainId: ChainId }
+
+// assets that can be staked to validators
+export const VALIDATOR_STAKABLE_ASSET_IDS = [cosmosAssetId, osmosisAssetId]
 
 export type Validators = {
   validators: cosmos.Validator[]

--- a/src/state/slices/validatorDataSlice/validatorDataSlice.ts
+++ b/src/state/slices/validatorDataSlice/validatorDataSlice.ts
@@ -1,11 +1,12 @@
 import { createSlice } from '@reduxjs/toolkit'
 import { createApi, fetchBaseQuery } from '@reduxjs/toolkit/query/react'
-import { ChainId, osmosisAssetId } from '@shapeshiftoss/caip'
+import { ChainId } from '@shapeshiftoss/caip'
 import { cosmos } from '@shapeshiftoss/chain-adapters'
 import {
   isCosmosChainId,
   isOsmosisChainId,
 } from 'plugins/cosmos/components/modals/Staking/StakingCommon'
+// @ts-ignore this will fail at 'file differs in casing' error
 import { getChainAdapterManager } from 'context/PluginProvider/chainAdapterSingleton'
 import { logger } from 'lib/logger'
 import {
@@ -14,16 +15,12 @@ import {
 } from 'state/slices/validatorDataSlice/constants'
 
 import { PortfolioAccounts } from '../portfolioSlice/portfolioSliceCommon'
-import { cosmosAssetId } from './../../../test/mocks/accounts'
 
 const moduleLogger = logger.child({ namespace: ['validatorDataSlice'] })
 
 export type PubKey = string
 
 type SingleValidatorDataArgs = { accountSpecifier: string; chainId: ChainId }
-
-// assets that can be staked to validators
-export const VALIDATOR_STAKABLE_ASSET_IDS = [cosmosAssetId, osmosisAssetId]
 
 export type Validators = {
   validators: cosmos.Validator[]


### PR DESCRIPTION
## Description

<!-- Please describe your changes -->

* there was cosmos specific asset logic stinking up the balance chart. this moves it out to the selector layer and generalizes it to support all assets capable of delegation, and includes delegation, redelegation, and pending redelegation balances.
* balance charts should be faster on initial load as we no longer debounce to guess when tx history is loaded - we now know as we fetch historical tx's restfully and set a loaded state on completion
* this cleanup gets the balance charts in a better place to be turned into rainbows.

TODO

* [ ] figure out cosmos residual balance - **not a regression on this PR**

## Notice

<!-- Before submitting a pull request, please make sure you have answered the following: -->

- [x] Have you followed the guidelines in our [Contributing]('https://github.com/shapeshift/web/CONTRIBUTING.md) guide?
- [x] Have you checked to ensure there aren't other open [Pull Requests](https://github.com/shapeshift/web/pulls) for the same update/change?

## Pull Request Type

- [x] :bug: Bug fix (Non-breaking Change: Fixes an issue)
- [x] :hammer_and_wrench: Chore (Non-breaking Change: Doc updates, pkg upgrades, typos, etc..)
- [ ] :nail_care: New Feature (Breaking/Non-breaking Change)

## Issue (if applicable)

closes #1874 

<!-----------------------------------------------------------------------------
If applicable, please link to the github issue and put `closes #XXXX` in your comment to auto-close the issue that your PR fixes.
------------------------------------------------------------------------------>

## Risk

<!-----------------------------------------------------------------------------
Outline the scope of your changes and the risk associated with them. You must use your discretion as an engineer to determine the potential impact of your changes.

E.g. an upgrade to `hdwallet` or core state management would be considered higher risk, and might require a full regression test. UI or isolated view changes, or something behind a feature flag may have near zero risk. Small bug fixes might require testing isolated to the specific fix.
------------------------------------------------------------------------------>

this should actually fix the disparity between the right hand side of the charts and the total portfolio balance displayed. they still use different logic to calculate the same total but this can be unified in an additional PR.

## Testing

<!-----------------------------------------------------------------------------
If your testing steps are technical, outline steps for an engineer to verify.

If your testing steps are functional, please provide a full guide with any features requiring special attention for operations to test your branch in the preview environment.
------------------------------------------------------------------------------>

* a general regression of balance charts
* **please test with native wallet including new UTXO coins (DOGE/BCH/LTC)** - these previous would have gone to negative balances
* specific regression test of accounts with delegated, pending undelegations, and redelegations would be most useful

## Screenshots (if applicable)

* no specific user facing changes, charts aesthetically should look the same but
  * show correct data including all delegations, pending undelegations, and redelegations.
  * not go negative in the past for UTXO coins
