### PR TITLE
fix: explorer links

### DIFF
--- a/src/components/Trade/TradeConfirm/TradeConfirm.tsx
+++ b/src/components/Trade/TradeConfirm/TradeConfirm.tsx
@@ -101,8 +101,8 @@ export const TradeConfirm = ({ history }: RouterProps) => {
       })
 
       if (txs.e) throw txs.e
-      if (!txs?.buyTxid) throw new Error('No buyTxid from getTradeTxs')
-      setTxid(txs.buyTxid)
+      if (!txs?.sellTxid) throw new Error('No sellTxid from getTradeTxs')
+      setTxid(txs.sellTxid)
     } catch (e) {
       showErrorToast(e)
       reset()
@@ -141,7 +141,7 @@ export const TradeConfirm = ({ history }: RouterProps) => {
     gasFeeToTradeRatioPercentage > gasFeeToTradeRatioPercentageThreshold
 
   const txLink = useMemo(() => {
-    if (fromChainId(trade.sellAsset.chainId).chainNamespace === CHAIN_NAMESPACE.Cosmos) {
+    if (trade.sources[0].name === 'Osmosis') {
       return `${osmosisAsset?.explorerTxLink}${txid}`
     } else {
       return `${trade.sellAsset?.explorerTxLink}${txid}`

--- a/src/components/Trade/TradeConfirm/TradeConfirm.tsx
+++ b/src/components/Trade/TradeConfirm/TradeConfirm.tsx
@@ -1,6 +1,6 @@
 import { WarningTwoIcon } from '@chakra-ui/icons'
 import { Box, Button, Divider, Flex, Link, Stack } from '@chakra-ui/react'
-import { CHAIN_NAMESPACE, fromChainId, osmosisAssetId } from '@shapeshiftoss/caip'
+import { osmosisAssetId } from '@shapeshiftoss/caip'
 import { TradeTxs } from '@shapeshiftoss/swapper'
 import { KnownChainIds } from '@shapeshiftoss/types'
 import { TxStatus } from '@shapeshiftoss/unchained-client'


### PR DESCRIPTION
## Description

1) set txid to sell asset txid instead of buyAsset. The explorer link logic expects a sell asset

2) Fix osmo-specific explorer link logic. It was setting the explorer link to osmosis for all trades out of a cosmos-sdk chain. This was causing problems for thorchain swaps 

## Notice

<!-- Before submitting a pull request, please make sure you have answered the following: -->

- [x] Have you followed the guidelines in our [Contributing]('https://github.com/shapeshift/web/CONTRIBUTING.md) guide?
- [x] Have you checked to ensure there aren't other open [Pull Requests](https://github.com/shapeshift/web/pulls) for the same update/change?

## Pull Request Type

- [x] :bug: Bug fix (Non-breaking Change: Fixes an issue)
- [ ] :hammer_and_wrench: Chore (Non-breaking Change: Doc updates, pkg upgrades, typos, etc..)
- [ ] :nail_care: New Feature (Breaking/Non-breaking Change)

## Issue (if applicable)

https://github.com/shapeshift/web/issues/2339

## Risk

low risk. fixes incorrect explorer link logic


## Testing

Do a swap into bch. see that explorer link is correct
