### PR TITLE
chore: remove proxy endpoint

### DIFF
--- a/react-app-rewired/headers/csps/bridges/axelar.ts
+++ b/react-app-rewired/headers/csps/bridges/axelar.ts
@@ -5,7 +5,6 @@ export const csp: Csp = {
     'https://api.gmp.axelarscan.io',
     'https://nest-server-mainnet.axelar.dev',
     'wss://nest-server-mainnet.axelar.dev',
-    // https://axelar-lcd.quickapi.com does not correctly return CORS headers. A proxy was made to add them.
-    'https://9bo26t9rjb.execute-api.ap-southeast-2.amazonaws.com/apotheosis',
+    'https://axelar-lcd.quickapi.com/',
   ],
 }

--- a/src/components/Bridge/BridgeRoutes/Confirm.tsx
+++ b/src/components/Bridge/BridgeRoutes/Confirm.tsx
@@ -96,7 +96,7 @@ export const Confirm: React.FC<SelectAssetProps> = ({ history }) => {
     ;(async () => {
       try {
         // We can't use axelarQuerySdk.getTransferFee() because of a CORS issue with the SDK
-        const baseUrl = 'https://9bo26t9rjb.execute-api.ap-southeast-2.amazonaws.com/apotheosis'
+        const baseUrl = 'https://axelar-lcd.quickapi.com/axelar/nexus/v1beta1/transfer_fee'
         const requestUrl = `${baseUrl}?source_chain=${sourceChainName}&destination_chain=${destinationChainName}&amount=${cryptoAmount}${assetDenom}`
         const {
           data: {


### PR DESCRIPTION
## Description

When I did the Axelar demo the quote endpoint did not return CORS headers, so I made a passthrough proxy API (`https://9bo26t9rjb.execute-api.ap-southeast-2.amazonaws.com/apotheosis`) to add the needed headers.

I've been in touch with their team and they've now added the needed headers to the URL response, and we can now use it directly.

Note though that we still can't use their APK until they update the SDK's REST service to include the needed headers. I've reached out to them about this, too.

## Notice

- [x] Have you followed the guidelines in our [Contributing]('https://github.com/shapeshift/web/CONTRIBUTING.md) guide?
- [x] Have you checked to ensure there aren't other open [Pull Requests](https://github.com/shapeshift/web/pulls) for the same update/change?

## Pull Request Type

- [ ] :bug: Bug fix (Non-breaking Change: Fixes an issue)
- [x] :hammer_and_wrench: Chore (Non-breaking Change: Doc updates, pkg upgrades, typos, etc..)
- [ ] :nail_care: New Feature (Breaking/Non-breaking Change)

## Issue (if applicable)

Relates to https://github.com/shapeshift/web/issues/2347.

## Risk

Minimal.

## Testing

The bridge should still be able to get quotes.

## Screenshots (if applicable)

N/A