### PR TITLE
fix: unrug Tx history swapper info

### DIFF
--- a/package.json
+++ b/package.json
@@ -87,7 +87,7 @@
     "@reduxjs/toolkit": "^1.8.2",
     "@shapeshiftoss/asset-service": "^7.2.0",
     "@shapeshiftoss/caip": "^6.12.0",
-    "@shapeshiftoss/chain-adapters": "^7.15.0",
+    "@shapeshiftoss/chain-adapters": "^7.15.1",
     "@shapeshiftoss/errors": "^1.1.2",
     "@shapeshiftoss/hdwallet-core": "^1.29.0",
     "@shapeshiftoss/hdwallet-keepkey": "^1.29.0",

--- a/yarn.lock
+++ b/yarn.lock
@@ -3762,10 +3762,10 @@
   resolved "https://registry.yarnpkg.com/@shapeshiftoss/caip/-/caip-6.12.0.tgz#4ce600784138ecbdda738ca70a0eb67656341f30"
   integrity sha512-bo365eAYXOAJZh7fOEMhl32Mw89+u57bGwQM0mUe7EWlb87t9PMd22NaPFP3/rmuv8Vbi4OXU7ntjPUqZQeDiQ==
 
-"@shapeshiftoss/chain-adapters@^7.15.0":
-  version "7.15.0"
-  resolved "https://registry.yarnpkg.com/@shapeshiftoss/chain-adapters/-/chain-adapters-7.15.0.tgz#97ae53e16cdabf9ca24b98ca1c2e9c24cd7a1d89"
-  integrity sha512-9/wuvCUKhx7HDkI6WTHqimb4NqNEvfixiUyA3sgYOoqQOtc7Dzto0uPc5kukTxZPriFC5XL7hUSFvP7ztTQY3A==
+"@shapeshiftoss/chain-adapters@^7.15.1":
+  version "7.15.1"
+  resolved "https://registry.yarnpkg.com/@shapeshiftoss/chain-adapters/-/chain-adapters-7.15.1.tgz#94cbba9de99ab1c3cd628c1978bb75501e7f29c2"
+  integrity sha512-os2zvH4Fi3rSoAdrQHTMFLw33rEzeBTfgShDLEqiFTWXYQetwgN75Z2LHzGT37G4D97jt6PsdWdMHXBgCxhgpQ==
   dependencies:
     axios "^0.26.1"
     bech32 "^2.0.0"


### PR DESCRIPTION
## Description

Bump `@shapeshiftoss/chain-adapters` from v7.15.0 to v7.15.1, which implements https://github.com/shapeshift/lib/pull/950

#### Original description from the lib PR

Makes Tx history great again after types refactor in https://github.com/shapeshift/lib/commit/944c8d12dc8380734fe197a8c7555c9c1ce903f7

Before:

<img width="363" alt="image" src="https://user-images.githubusercontent.com/17035424/183296169-084cd356-1315-4451-b1d8-1bc453dc6054.png">


After:

<img width="369" alt="image" src="https://user-images.githubusercontent.com/17035424/183296074-23c6447f-9a99-4ada-b556-b9b462549cd7.png">

## Notice

<!-- Before submitting a pull request, please make sure you have answered the following: -->

- [x] Have you followed the guidelines in our [Contributing]('https://github.com/shapeshift/web/CONTRIBUTING.md) guide?
- [x] Have you checked to ensure there aren't other open [Pull Requests](https://github.com/shapeshift/web/pulls) for the same update/change?

## Pull Request Type

- [x] :bug: Bug fix (Non-breaking Change: Fixes an issue)
- [ ] :hammer_and_wrench: Chore (Non-breaking Change: Doc updates, pkg upgrades, typos, etc..)
- [ ] :nail_care: New Feature (Breaking/Non-breaking Change)

## Issue (if applicable)

N/A

## Risk

None - already tested with linked lib by @0xApotheosis and myself, retested before opening the PR as a sanity check

## Testing

- Tx history should be great again 

## Screenshots (if applicable)
