### PR TITLE
feat: client-side cowswap Tx fees parsing

### DIFF
--- a/src/components/TransactionHistoryRows/TransactionTrade.tsx
+++ b/src/components/TransactionHistoryRows/TransactionTrade.tsx
@@ -66,7 +66,7 @@ export const TransactionTrade = ({
               <Row title='transactionType'>
                 <Text value={txDetails.tx.trade.type} />
               </Row>
-              <Row title='fee'>
+              <Row title='fees'>
                 <Text value={tradeFees} />
               </Row>
             </>

--- a/src/components/TransactionHistoryRows/TransactionTrade.tsx
+++ b/src/components/TransactionHistoryRows/TransactionTrade.tsx
@@ -66,7 +66,7 @@ export const TransactionTrade = ({
               <Row title='transactionType'>
                 <Text value={txDetails.tx.trade.type} />
               </Row>
-              <Row title='fees'>
+              <Row title='fee'>
                 <Text value={tradeFees} />
               </Row>
             </>

--- a/src/components/TransactionHistoryRows/TransactionTrade.tsx
+++ b/src/components/TransactionHistoryRows/TransactionTrade.tsx
@@ -1,3 +1,4 @@
+import { useTradeFees } from './hooks'
 import { Amount } from './TransactionDetails/Amount'
 import { TransactionDetailsContainer } from './TransactionDetails/Container'
 import { Row } from './TransactionDetails/Row'
@@ -21,6 +22,9 @@ export const TransactionTrade = ({
   let assets = []
   if (txDetails.sellAsset) assets.push(parseRelevantAssetFromTx(txDetails, AssetTypes.Source))
   if (txDetails.buyAsset) assets.push(parseRelevantAssetFromTx(txDetails, AssetTypes.Destination))
+
+  const { tradeFees } = useTradeFees({ txDetails })
+
   return (
     <>
       <TransactionGenericRow
@@ -58,9 +62,14 @@ export const TransactionTrade = ({
             </Row>
           )}
           {txDetails.tx.trade && (
-            <Row title='transactionType'>
-              <Text value={txDetails.tx.trade.type} />
-            </Row>
+            <>
+              <Row title='transactionType'>
+                <Text value={txDetails.tx.trade.type} />
+              </Row>
+              <Row title='fee'>
+                <Text value={tradeFees} />
+              </Row>
+            </>
           )}
         </TxGrid>
       </TransactionDetailsContainer>

--- a/src/components/TransactionHistoryRows/TransactionTrade.tsx
+++ b/src/components/TransactionHistoryRows/TransactionTrade.tsx
@@ -1,5 +1,7 @@
+import { Amount } from 'components/Amount/Amount'
+
 import { useTradeFees } from './hooks'
-import { Amount } from './TransactionDetails/Amount'
+import { Amount as TransactionAmount } from './TransactionDetails/Amount'
 import { TransactionDetailsContainer } from './TransactionDetails/Container'
 import { Row } from './TransactionDetails/Row'
 import { Status } from './TransactionDetails/Status'
@@ -49,7 +51,7 @@ export const TransactionTrade = ({
           </Row>
           {txDetails.feeAsset && (
             <Row title='minerFee'>
-              <Amount
+              <TransactionAmount
                 value={txDetails.tx.fee?.value ?? '0'}
                 precision={txDetails.feeAsset.precision}
                 symbol={txDetails.feeAsset.symbol}
@@ -62,14 +64,14 @@ export const TransactionTrade = ({
             </Row>
           )}
           {txDetails.tx.trade && (
-            <>
-              <Row title='transactionType'>
-                <Text value={txDetails.tx.trade.type} />
-              </Row>
-              <Row title='fee'>
-                <Text value={tradeFees} />
-              </Row>
-            </>
+            <Row title='transactionType'>
+              <Text value={txDetails.tx.trade.type} />
+            </Row>
+          )}
+          {txDetails.tx.trade && txDetails.sellAsset && tradeFees && (
+            <Row title='fee'>
+              <Amount.Crypto value={tradeFees} symbol={txDetails.sellAsset.symbol} />
+            </Row>
           )}
         </TxGrid>
       </TransactionDetailsContainer>

--- a/src/components/TransactionHistoryRows/hooks.tsx
+++ b/src/components/TransactionHistoryRows/hooks.tsx
@@ -57,7 +57,7 @@ export const useTradeFees = ({ txDetails }: { txDetails: TxDetails }) => {
     const tradeFees = getTradeFees({
       sellAsset,
       buyAsset,
-      blockTime: dayjs(txDetails.tx.blockTime * 1000).valueOf(),
+      blockTime: dayjs(txDetails.tx.blockTime * 1000).valueOf(), // unchained uses seconds
       sellAmount: txDetails.sellTransfer.value,
       buyAmount: txDetails.buyTransfer.value,
       cryptoPriceHistoryData,

--- a/src/components/TransactionHistoryRows/hooks.tsx
+++ b/src/components/TransactionHistoryRows/hooks.tsx
@@ -30,8 +30,6 @@ export const useTradeFees = ({ txDetails }: { txDetails: TxDetails }) => {
   useEffect(() => {
     if (
       !(
-        buyAsset &&
-        sellAsset &&
         txDetails?.tx?.trade &&
         txDetails.sellAsset &&
         txDetails.buyAsset &&

--- a/src/components/TransactionHistoryRows/hooks.tsx
+++ b/src/components/TransactionHistoryRows/hooks.tsx
@@ -1,0 +1,74 @@
+import { HistoryTimeframe } from '@shapeshiftoss/types'
+import { Dex } from '@shapeshiftoss/unchained-client'
+import dayjs from 'dayjs'
+import { useEffect, useState } from 'react'
+import { useDispatch } from 'react-redux'
+import { TxDetails } from 'hooks/useTxDetails/useTxDetails'
+import { marketApi } from 'state/slices/marketDataSlice/marketDataSlice'
+import { selectAssetById, selectCryptoPriceHistoryTimeframe } from 'state/slices/selectors'
+import { useAppSelector } from 'state/store'
+
+import { getTradeFees } from './utils'
+
+export const useTradeFees = ({ txDetails }: { txDetails: TxDetails }) => {
+  const [tradeFees, setTradeFees] = useState<string>('')
+
+  const dispatch = useDispatch()
+  const cryptoPriceHistoryData = useAppSelector(state =>
+    selectCryptoPriceHistoryTimeframe(state, HistoryTimeframe.ALL),
+  )
+
+  const buyAsset = useAppSelector(state =>
+    selectAssetById(state, txDetails.buyAsset?.assetId ?? ''),
+  )
+  const sellAsset = useAppSelector(state =>
+    selectAssetById(state, txDetails.sellAsset?.assetId ?? ''),
+  )
+
+  const { findPriceHistoryByAssetId } = marketApi.endpoints
+
+  useEffect(() => {
+    if (
+      !(
+        txDetails?.tx?.trade &&
+        txDetails.sellAsset &&
+        txDetails.buyAsset &&
+        txDetails.sellTransfer &&
+        txDetails.buyTransfer
+      )
+    )
+      return
+    if (txDetails.tx.trade.dexName !== Dex.CowSwap) return
+
+    if (!Object.keys(cryptoPriceHistoryData).length) {
+      const [sellAssetId, buyAssetId] = [txDetails.sellAsset.assetId, txDetails.buyAsset.assetId]
+
+      // Fetch / use cached price history by assetId
+      ;[sellAssetId, buyAssetId].forEach(assetId => {
+        dispatch(findPriceHistoryByAssetId.initiate({ assetId, timeframe: HistoryTimeframe.ALL }))
+      })
+    }
+
+    const tradeFees = getTradeFees({
+      sellAsset,
+      buyAsset,
+      blockTime: dayjs(txDetails.tx.blockTime * 1000).valueOf(),
+      sellAmount: txDetails.sellTransfer.value,
+      buyAmount: txDetails.buyTransfer.value,
+      cryptoPriceHistoryData,
+    })
+
+    setTradeFees(tradeFees)
+  }, [
+    dispatch,
+    buyAsset,
+    sellAsset,
+    cryptoPriceHistoryData,
+    findPriceHistoryByAssetId,
+    txDetails.buyAsset,
+    txDetails,
+    txDetails.sellTransfer,
+  ])
+
+  return { tradeFees }
+}

--- a/src/components/TransactionHistoryRows/hooks.tsx
+++ b/src/components/TransactionHistoryRows/hooks.tsx
@@ -11,7 +11,7 @@ import { useAppSelector } from 'state/store'
 import { getTradeFees } from './utils'
 
 export const useTradeFees = ({ txDetails }: { txDetails: TxDetails }) => {
-  const [tradeFees, setTradeFees] = useState<string>('')
+  const [tradeFees, setTradeFees] = useState<string | null>(null)
 
   const dispatch = useDispatch()
   const cryptoPriceHistoryData = useAppSelector(state =>

--- a/src/components/TransactionHistoryRows/hooks.tsx
+++ b/src/components/TransactionHistoryRows/hooks.tsx
@@ -40,7 +40,12 @@ export const useTradeFees = ({ txDetails }: { txDetails: TxDetails }) => {
       return
     if (txDetails.tx.trade.dexName !== Dex.CowSwap) return
 
-    if (!Object.keys(cryptoPriceHistoryData).length) {
+    if (
+      !(
+        cryptoPriceHistoryData[txDetails.buyAsset.assetId] &&
+        cryptoPriceHistoryData[txDetails.sellAsset.assetId]
+      )
+    ) {
       const [sellAssetId, buyAssetId] = [txDetails.sellAsset.assetId, txDetails.buyAsset.assetId]
 
       // Fetch / use cached price history by assetId

--- a/src/components/TransactionHistoryRows/hooks.tsx
+++ b/src/components/TransactionHistoryRows/hooks.tsx
@@ -30,6 +30,8 @@ export const useTradeFees = ({ txDetails }: { txDetails: TxDetails }) => {
   useEffect(() => {
     if (
       !(
+        buyAsset &&
+        sellAsset &&
         txDetails?.tx?.trade &&
         txDetails.sellAsset &&
         txDetails.buyAsset &&

--- a/src/components/TransactionHistoryRows/utils.ts
+++ b/src/components/TransactionHistoryRows/utils.ts
@@ -84,7 +84,7 @@ export const getTradeFees = memoize(
     const sellAssetPriceHistoryData = cryptoPriceHistoryData[sellAsset.assetId]
     const buyAssetPriceHistoryData = cryptoPriceHistoryData[buyAsset.assetId]
 
-    if (!sellAssetPriceHistoryData || !buyAssetPriceHistoryData) return ''
+    if (!sellAssetPriceHistoryData || !buyAssetPriceHistoryData) return null
 
     const sellAssetPriceAtDate = priceAtDate({
       date: blockTime,
@@ -106,6 +106,6 @@ export const getTradeFees = memoize(
 
     const sellTokenFee = sellAmountFiat.minus(buyAmountFiat).div(sellAssetPriceAtDate)
 
-    return `${sellTokenFee.toString()} ${sellAsset.symbol}`
+    return sellTokenFee.toString()
   },
 )

--- a/src/components/TransactionHistoryRows/utils.ts
+++ b/src/components/TransactionHistoryRows/utils.ts
@@ -96,6 +96,8 @@ export const getTradeFees = memoize(
       priceHistoryData: buyAssetPriceHistoryData,
     })
 
+    if (bn(sellAssetPriceAtDate).isZero() || bn(buyAssetPriceAtDate).isZero()) return null
+
     const sellAmountFiat = bnOrZero(sellAmount)
       .div(bn(10).pow(sellAsset.precision))
       .times(bnOrZero(sellAssetPriceAtDate))

--- a/src/components/TransactionHistoryRows/utils.ts
+++ b/src/components/TransactionHistoryRows/utils.ts
@@ -1,5 +1,10 @@
+import { Asset } from '@shapeshiftoss/asset-service'
 import { cosmos, evm, TransactionMetadata } from '@shapeshiftoss/chain-adapters'
+import { bnOrZero } from '@shapeshiftoss/investor-foxy'
+import { memoize } from 'lodash'
 import { TxDetails } from 'hooks/useTxDetails/useTxDetails'
+import { priceAtDate } from 'lib/charts'
+import { PriceHistoryData } from 'state/slices/marketDataSlice/marketDataSlice'
 
 export enum AssetTypes {
   Source = 'source',
@@ -58,3 +63,49 @@ export const parseRelevantAssetFromTx = (txDetails: TxDetails, assetType: AssetT
       }
   }
 }
+
+type GetTradeFeesInput = {
+  buyAsset: Asset
+  sellAsset: Asset
+  buyAmount: string
+  sellAmount: string
+  blockTime: number
+  cryptoPriceHistoryData: PriceHistoryData
+}
+export const getTradeFees = memoize(
+  ({
+    sellAsset,
+    buyAsset,
+    buyAmount,
+    sellAmount,
+    blockTime,
+    cryptoPriceHistoryData,
+  }: GetTradeFeesInput) => {
+    const sellAssetPriceHistoryData = cryptoPriceHistoryData[sellAsset.assetId]
+    const buyAssetPriceHistoryData = cryptoPriceHistoryData[buyAsset.assetId]
+
+    if (!sellAssetPriceHistoryData || !buyAssetPriceHistoryData) return ''
+
+    const sellAssetPriceAtDate = priceAtDate({
+      date: blockTime,
+      priceHistoryData: sellAssetPriceHistoryData,
+    })
+
+    const buyAssetPriceAtDate = priceAtDate({
+      date: blockTime,
+      priceHistoryData: buyAssetPriceHistoryData,
+    })
+
+    const sellAmountFiat = bnOrZero(sellAmount)
+      .div(`1e+${sellAsset.precision}`)
+      .times(bnOrZero(sellAssetPriceAtDate))
+
+    const buyAmountFiat = bnOrZero(buyAmount)
+      .div(`1e+${buyAsset.precision}`)
+      .times(bnOrZero(buyAssetPriceAtDate))
+
+    const sellTokenFee = sellAmountFiat.minus(buyAmountFiat).div(sellAssetPriceAtDate)
+
+    return `${sellTokenFee.toString()} ${sellAsset.symbol}`
+  },
+)

--- a/src/components/TransactionHistoryRows/utils.ts
+++ b/src/components/TransactionHistoryRows/utils.ts
@@ -1,8 +1,8 @@
 import { Asset } from '@shapeshiftoss/asset-service'
 import { cosmos, evm, TransactionMetadata } from '@shapeshiftoss/chain-adapters'
-import { bnOrZero } from '@shapeshiftoss/investor-foxy'
 import { memoize } from 'lodash'
 import { TxDetails } from 'hooks/useTxDetails/useTxDetails'
+import { bn, bnOrZero } from 'lib/bignumber/bignumber'
 import { priceAtDate } from 'lib/charts'
 import { PriceHistoryData } from 'state/slices/marketDataSlice/marketDataSlice'
 
@@ -97,11 +97,11 @@ export const getTradeFees = memoize(
     })
 
     const sellAmountFiat = bnOrZero(sellAmount)
-      .div(`1e+${sellAsset.precision}`)
+      .div(bn(10).pow(sellAsset.precision))
       .times(bnOrZero(sellAssetPriceAtDate))
 
     const buyAmountFiat = bnOrZero(buyAmount)
-      .div(`1e+${buyAsset.precision}`)
+      .div(bn(10).pow(buyAsset.precision))
       .times(bnOrZero(buyAssetPriceAtDate))
 
     const sellTokenFee = sellAmountFiat.minus(buyAmountFiat).div(sellAssetPriceAtDate)


### PR DESCRIPTION
## Description

This parses fees using market data for Cow Swaps.

They are not expected to be 100% accurate, but it should give us enough confidence to display fees without resorting to using Cow.fi subgraph or parsing Tx events ourselves in unchained.

## Notice

<!-- Before submitting a pull request, please make sure you have answered the following: -->

- [x] Have you followed the guidelines in our [Contributing]('https://github.com/shapeshift/web/CONTRIBUTING.md) guide?
- [x] Have you checked to ensure there aren't other open [Pull Requests](https://github.com/shapeshift/web/pulls) for the same update/change?

## Pull Request Type

- [ ] :bug: Bug fix (Non-breaking Change: Fixes an issue)
- [ ] :hammer_and_wrench: Chore (Non-breaking Change: Doc updates, pkg upgrades, typos, etc..)
- [x] :nail_care: New Feature (Breaking/Non-breaking Change)

## Issue (if applicable)

- closes https://github.com/shapeshift/web/issues/2279

## Risk

- This should show no regression for non-cow Txs 

<!-----------------------------------------------------------------------------
Outline the scope of your changes and the risk associated with them. You must use your discretion as an engineer to determine the potential impact of your changes.

E.g. an upgrade to `hdwallet` or core state management would be considered higher risk, and might require a full regression test. UI or isolated view changes, or something behind a feature flag may have near zero risk. Small bug fixes might require testing isolated to the specific fix.
------------------------------------------------------------------------------>

## Testing

- CowSwap trades should show fees in sell token under

## Screenshots (if applicable)

<img width="1245" alt="image" src="https://user-images.githubusercontent.com/17035424/183731017-f23a394e-9ff0-4927-8609-52dc07aa52a4.png">
<img width="900" alt="image" src="https://user-images.githubusercontent.com/17035424/183731100-7fd02406-f2d5-4c32-aa2e-69c957b85be1.png">

<img width="1258" alt="image" src="https://user-images.githubusercontent.com/17035424/183731237-4352c95a-97bc-45c3-aa1c-047ae3894760.png">
<img width="911" alt="image" src="https://user-images.githubusercontent.com/17035424/183731489-8f95f209-ead3-47e5-863a-b07525cfaddb.png">

<img width="1251" alt="image" src="https://user-images.githubusercontent.com/17035424/183731810-37213a80-f551-4559-9728-6e315fefdd9c.png">
<img width="832" alt="image" src="https://user-images.githubusercontent.com/17035424/183731918-a68e90c9-b5b7-4b1b-b511-8dc801a2a0cc.png">