### PR TITLE
chore: consume `unchained-client` Avalanche parser

### DIFF
--- a/package.json
+++ b/package.json
@@ -106,7 +106,7 @@
     "@shapeshiftoss/market-service": "^6.5.0",
     "@shapeshiftoss/swapper": "^9.9.0",
     "@shapeshiftoss/types": "^8.2.0",
-    "@shapeshiftoss/unchained-client": "^9.7.0",
+    "@shapeshiftoss/unchained-client": "^9.8.1",
     "@uniswap/sdk": "^3.0.3",
     "@unstoppabledomains/resolution": "^7.1.4",
     "@visx/axis": "^2.10.0",

--- a/yarn.lock
+++ b/yarn.lock
@@ -4047,10 +4047,10 @@
   resolved "https://registry.yarnpkg.com/@shapeshiftoss/types/-/types-8.2.0.tgz#9800dc9673f9ab7571d9d74c0d0d701a41efc942"
   integrity sha512-Khu5Byomu3d4Nb9XmqG50C1XyWe188vZ8v6laXQbqJEQkqbB9MQjZ/nQJDcMUeTfooPGGdJnFeyDKKX3WjwclQ==
 
-"@shapeshiftoss/unchained-client@^9.7.0":
-  version "9.7.0"
-  resolved "https://registry.yarnpkg.com/@shapeshiftoss/unchained-client/-/unchained-client-9.7.0.tgz#81834af2bcf882350de430df73f54935d290c33e"
-  integrity sha512-HfpVPkd78vVu27nTktS+ds/t78wlnGwWXAC2b+Q+PwhAVZEnTOr86C/Qf0ZBuRDuKYdYZBPNe69FDp97WhVMAg==
+"@shapeshiftoss/unchained-client@^9.8.1":
+  version "9.8.1"
+  resolved "https://registry.yarnpkg.com/@shapeshiftoss/unchained-client/-/unchained-client-9.8.1.tgz#17f40dc64358a5a7daa6a1c540775afc859f1e7c"
+  integrity sha512-RH3m1Lvbxql+RmowfePkcKamwEQ0QWKFJsMvRxSFyvZP5IDjxtM5vPkz9uMeP3D8/mqufhgn1Z5iQNpVzjwt7w==
   dependencies:
     "@yfi/sdk" "^1.0.30"
     bignumber.js "^9.0.2"


### PR DESCRIPTION
## Description

Bump `@shapeshiftoss/unchained-client` to consume the Avalanche parser changes made in https://github.com/shapeshift/lib/pull/952 and https://github.com/shapeshift/lib/pull/958.

## Notice

- [x] Have you followed the guidelines in our [Contributing]('https://github.com/shapeshift/web/CONTRIBUTING.md) guide?
- [x] Have you checked to ensure there aren't other open [Pull Requests](https://github.com/shapeshift/web/pulls) for the same update/change?

## Pull Request Type

- [ ] :bug: Bug fix (Non-breaking Change: Fixes an issue)
- [ ] :hammer_and_wrench: Chore (Non-breaking Change: Doc updates, pkg upgrades, typos, etc..)
- [x] :nail_care: New Feature (Breaking/Non-breaking Change)

## Issue (if applicable)

Gets https://github.com/shapeshift/lib/issues/951 into use.

## Risk

Minimal, only touches Avalanche parsing.

## Testing

As per https://github.com/shapeshift/lib/pull/952

## Screenshots (if applicable)

N/A