### PR TITLE
feat(logger): add a simple logger without colors

### DIFF
--- a/src/lib/logger.ts
+++ b/src/lib/logger.ts
@@ -1,6 +1,7 @@
 // eslint-disable no-console
 import { Logger, LoggerFunction, LoggerOptions, LogLevel } from '@shapeshiftoss/logger'
 import { getConfig } from 'config'
+import { isMobile } from 'lib/globals'
 
 type LogStyle = {
   title: string
@@ -56,6 +57,24 @@ const browserLoggerFn: LoggerFunction = (level, data) => {
 }
 
 /**
+ * For use in the mobile app where colorized logging isn't supported
+ */
+const simpleLoggerFn: LoggerFunction = (level, data) => {
+  const consoleFn = level === LogLevel.TRACE ? LogLevel.DEBUG : level
+
+  const msg = data.error
+    ? `Error [Kind: ${data.error.kind}] ${data.error.message} `
+    : data._messages?.join(' ') || data.message
+
+  // eslint-disable-next-line no-console
+  console[consoleFn](
+    `${logStyles[level].icon} ${level}: [${data.namespace}] ${msg}\n`,
+    // In the webview, objects are rendered as "[object Object]" so we'll format it
+    require('util').inspect(data),
+  )
+}
+
+/**
  * Get the current log level configuration from local storage or from the environment
  *
  * We can't get the log level from the logger instance because it's stored in a private
@@ -75,7 +94,7 @@ export const getLogLevel = () => {
 export const createLogger = (opts?: LoggerOptions) => {
   const options = {
     name: 'App',
-    logFn: browserLoggerFn,
+    logFn: isMobile ? simpleLoggerFn : browserLoggerFn,
     level: getLogLevel(),
     ...opts,
   }


### PR DESCRIPTION
## Description

* add a new `simpleLoggerFn` in the global `logger` . This is for use in the mobile app where logs don't support CSS.
* default to `simpleLoggerFn` if `isMobile` is `true`

## Notice

<!-- Before submitting a pull request, please make sure you have answered the following: -->

- [X] Have you followed the guidelines in our [Contributing]('https://github.com/shapeshift/web/CONTRIBUTING.md) guide?
- [X] Have you checked to ensure there aren't other open [Pull Requests](https://github.com/shapeshift/web/pulls) for the same update/change?

## Pull Request Type

- [ ] :bug: Bug fix (Non-breaking Change: Fixes an issue)
- [ ] :hammer_and_wrench: Chore (Non-breaking Change: Doc updates, pkg upgrades, typos, etc..)
- [X] :nail_care: New Feature (Breaking/Non-breaking Change)

## Issue (if applicable)
N/A
## Risk
None
## Testing
1. Check the Dev Tools console and verify that logs are still being rendered in fancy colors

## Screenshots (if applicable)
![image](https://user-images.githubusercontent.com/1958266/183749848-ffaaf27e-c0aa-4cc0-acb2-45ec24d94c98.png)
