### PR TITLE
chore(cypress): ignore Yearn errors

### DIFF
--- a/cypress/support/e2e.ts
+++ b/cypress/support/e2e.ts
@@ -1,1 +1,8 @@
 import './commands'
+
+Cypress.on('uncaught:exception', err => {
+  // Returning false here prevents Cypress from failing the test
+
+  // We are getting rugged by responses from Yearn, which is breaking Cypress. Ignore these exceptions.
+  if (err.message.includes('hex data is odd-length')) return false
+})


### PR DESCRIPTION
## Description

Cypress is getting rugged by an exception that occurs when we get rate-limited by Yearn, which occurs when Cypress is run.

We can't even record the Yearn responses without being `403`ed.

This PR creates a pattern for ignoring uncaught errors in Cypress, and ignores the current uncaught exception.

## Notice

- [x] Have you followed the guidelines in our [Contributing]('https://github.com/shapeshift/web/CONTRIBUTING.md) guide?
- [x] Have you checked to ensure there aren't other open [Pull Requests](https://github.com/shapeshift/web/pulls) for the same update/change?

## Pull Request Type

- [ ] :bug: Bug fix (Non-breaking Change: Fixes an issue)
- [x] :hammer_and_wrench: Chore (Non-breaking Change: Doc updates, pkg upgrades, typos, etc..)
- [ ] :nail_care: New Feature (Breaking/Non-breaking Change)

## Issue (if applicable)

N/A

## Risk

Minimal - only touches Cypress configuration.

## Testing

Should fix CI failures.

## Screenshots (if applicable)

N/A