### PR TITLE
fix: unrug CI

### DIFF
--- a/cypress/support/e2e.ts
+++ b/cypress/support/e2e.ts
@@ -1,1 +1,8 @@
 import './commands'
+
+Cypress.on('uncaught:exception', err => {
+  // Returning false here prevents Cypress from failing the test
+
+  // We are getting rugged by responses from Yearn, which is breaking Cypress. Ignore these exceptions.
+  if (err.message.includes('hex data is odd-length')) return false
+})

--- a/package.json
+++ b/package.json
@@ -214,7 +214,7 @@
     "@types/redux-logger": "^3.0.9",
     "@types/ssri": "^7.1.1",
     "circular-dependency-plugin": "^5.2.2",
-    "cypress": "10.3.0",
+    "cypress": "^10.4.0",
     "eslint-config-prettier": "^8.3.0",
     "eslint-plugin-cypress": "^2.12.1",
     "eslint-plugin-prettier": "^4.0.0",

--- a/yarn.lock
+++ b/yarn.lock
@@ -9629,10 +9629,10 @@ cyclist@^1.0.1:
   resolved "https://registry.yarnpkg.com/cyclist/-/cyclist-1.0.1.tgz#596e9698fd0c80e12038c2b82d6eb1b35b6224d9"
   integrity sha1-WW6WmP0MgOEgOMK4LW6xs1tiJNk=
 
-cypress@10.3.0:
-  version "10.3.0"
-  resolved "https://registry.yarnpkg.com/cypress/-/cypress-10.3.0.tgz#fae8d32f0822fcfb938e79c7c31ef344794336ae"
-  integrity sha512-txkQWKzvBVnWdCuKs5Xc08gjpO89W2Dom2wpZgT9zWZT5jXxqPIxqP/NC1YArtkpmp3fN5HW8aDjYBizHLUFvg==
+cypress@^10.4.0:
+  version "10.4.0"
+  resolved "https://registry.yarnpkg.com/cypress/-/cypress-10.4.0.tgz#bb5b3b6588ad49eff172fecf5778cc0da2980e4e"
+  integrity sha512-OM7F8MRE01SHQRVVzunid1ZK1m90XTxYnl+7uZfIrB4CYqUDCrZEeSyCXzIbsS6qcaijVCAhqDL60SxG8N6hew==
   dependencies:
     "@cypress/request" "^2.88.10"
     "@cypress/xvfb" "^1.2.4"


### PR DESCRIPTION
## Description

**Update mock data**

Updates Cypress mock data to match our current array of requests.

**Ignore erroneous exception**

Cypress is getting rugged by an exception that occurs when we get rate-limited by Yearn, which occurs when Cypress is run. We can't even record the Yearn responses without being `403`ed.

This PR creates a pattern for ignoring uncaught errors in Cypress, and ignores the current uncaught exception.

**Cypress version bump**

Bumps Cypress to `10.4.0` and adds caret to allow minor version updates.

https://docs.cypress.io/guides/references/changelog#10-4-0

## Notice

- [x] Have you followed the guidelines in our [Contributing]('https://github.com/shapeshift/web/CONTRIBUTING.md) guide?
- [x] Have you checked to ensure there aren't other open [Pull Requests](https://github.com/shapeshift/web/pulls) for the same update/change?

## Pull Request Type

- [x] :bug: Bug fix (Non-breaking Change: Fixes an issue)
- [ ] :hammer_and_wrench: Chore (Non-breaking Change: Doc updates, pkg upgrades, typos, etc..)
- [ ] :nail_care: New Feature (Breaking/Non-breaking Change)

## Issue (if applicable)

N/A

## Risk

Minimal.

## Testing

CI should pass.

## Screenshots (if applicable)

N/A