### PR TITLE
fix: don't change assets when no input amounts

### DIFF
--- a/src/components/Trade/hooks/useTradeRoutes/useTradeRoutes.ts
+++ b/src/components/Trade/hooks/useTradeRoutes/useTradeRoutes.ts
@@ -101,11 +101,7 @@ export const useTradeRoutes = (
       const routeDefaultBuyAsset = assets[buyAssetId]
 
       // If we don't have a quote already, get one for the route's default assets
-      if (
-        routeDefaultSellAsset &&
-        routeDefaultBuyAsset &&
-        !(buyTradeAsset?.amount || sellTradeAsset?.amount)
-      ) {
+      if (routeDefaultSellAsset && routeDefaultBuyAsset && !(buyTradeAsset || sellTradeAsset)) {
         setValue('buyAsset.asset', routeDefaultBuyAsset)
         setValue('sellAsset.asset', routeDefaultSellAsset)
         await updateQuote({
@@ -123,13 +119,13 @@ export const useTradeRoutes = (
     }
   }, [
     assets,
-    buyTradeAsset?.amount,
+    buyTradeAsset,
     defaultBuyAssetId,
     defaultFeeAsset,
     defaultSellAssetId,
     routeBuyAssetId,
     selectedCurrencyToUsdRate,
-    sellTradeAsset?.amount,
+    sellTradeAsset,
     setValue,
     swapperManager,
     updateQuote,


### PR DESCRIPTION
## Description

We changed trade asset setting logic slightly in https://github.com/shapeshift/web/pull/2285 here: https://github.com/shapeshift/web/commit/92d3eb376bf6794448de73dfadabc72900446671#diff-62ce1d676340482a29d6dcef3d58bd421246f2b07ee978dc64ac7aca931af407L85

The effect is that if we have no amount in either the buy or sell input boxes the assets will reset:

```ts
setValue('buyAsset.asset', buyAsset)
setValue('sellAsset.asset', sellAsset)
```

What we really want is to only reset if we have no selected assets at all - this PR addresses that.

## Notice

- [x] Have you followed the guidelines in our [Contributing]('https://github.com/shapeshift/web/CONTRIBUTING.md) guide?
- [x] Have you checked to ensure there aren't other open [Pull Requests](https://github.com/shapeshift/web/pulls) for the same update/change?

## Pull Request Type

- [x] :bug: Bug fix (Non-breaking Change: Fixes an issue)
- [ ] :hammer_and_wrench: Chore (Non-breaking Change: Doc updates, pkg upgrades, typos, etc..)
- [ ] :nail_care: New Feature (Breaking/Non-breaking Change)

## Issue (if applicable)

Closes https://github.com/shapeshift/web/issues/2395, specifically comment https://github.com/shapeshift/web/issues/2395#issuecomment-1211399726

## Risk

Small, though this is a fragile part of the codebase 😬 

## Testing

Removing the input amounts for both the buy and sell assets should not reset the assets.

## Screenshots (if applicable)

<img width="397" alt="Screen Shot 2022-08-11 at 9 59 11 am" src="https://user-images.githubusercontent.com/97164662/184042906-1d1aa2f5-d40a-4ff0-8182-0ee06dd7988b.png">
