### PR TITLE
feat: refresh trade quote every 30 seconds

### DIFF
--- a/src/components/Trade/TradeInput.tsx
+++ b/src/components/Trade/TradeInput.tsx
@@ -48,7 +48,14 @@ export const TradeInput = ({ history }: RouterProps) => {
   const [quote, buyTradeAsset, sellTradeAsset, feeAssetFiatRate] = useWatch({
     name: ['quote', 'buyAsset', 'sellAsset', 'feeAssetFiatRate'],
   }) as [TS['quote'], TS['buyAsset'], TS['sellAsset'], TS['feeAssetFiatRate']]
-  const { updateQuote, checkApprovalNeeded, getSendMaxAmount, updateTrade, feeAsset } = useSwapper()
+  const {
+    updateQuote,
+    checkApprovalNeeded,
+    getSendMaxAmount,
+    updateTrade,
+    feeAsset,
+    refreshQuote,
+  } = useSwapper()
   const toast = useToast()
   const translate = useTranslate()
   const selectedCurrencyToUsdRate = useAppSelector(selectFiatToUsdRate)
@@ -250,19 +257,7 @@ export const TradeInput = ({ history }: RouterProps) => {
   }, [selectedCurrencyToUsdRate])
 
   // Update the quote every 30 seconds
-  useInterval(async () => {
-    if (sellTradeAsset?.asset && buyTradeAsset?.asset) {
-      await updateQuote({
-        forceQuote: true,
-        amount: bnOrZero(sellTradeAsset.amount).toString(),
-        sellAsset: sellTradeAsset.asset,
-        buyAsset: buyTradeAsset.asset,
-        feeAsset,
-        action: TradeAmountInputField.SELL,
-        selectedCurrencyToUsdRate,
-      })
-    }
-  }, 1000 * 30) // 30 seconds
+  useInterval(async () => await refreshQuote(), 1000 * 30)
 
   return (
     <SlideTransition>

--- a/src/components/Trade/TradeInput.tsx
+++ b/src/components/Trade/TradeInput.tsx
@@ -15,6 +15,7 @@ import { TokenButton } from 'components/TokenRow/TokenButton'
 import { TokenRow } from 'components/TokenRow/TokenRow'
 import { useSwapper } from 'components/Trade/hooks/useSwapper/useSwapper'
 import { useErrorHandler } from 'hooks/useErrorToast/useErrorToast'
+import { useInterval } from 'hooks/useInterval/useInterval'
 import { useLocaleFormatter } from 'hooks/useLocaleFormatter/useLocaleFormatter'
 import { useWallet } from 'hooks/useWallet/useWallet'
 import { bnOrZero } from 'lib/bignumber/bignumber'
@@ -247,6 +248,21 @@ export const TradeInput = ({ history }: RouterProps) => {
     // only dependency of this hook is the fiat currency
     // eslint-disable-next-line react-hooks/exhaustive-deps
   }, [selectedCurrencyToUsdRate])
+
+  // Update the quote every 30 seconds
+  useInterval(async () => {
+    if (sellTradeAsset?.asset && buyTradeAsset?.asset) {
+      await updateQuote({
+        forceQuote: true,
+        amount: bnOrZero(sellTradeAsset.amount).toString(),
+        sellAsset: sellTradeAsset.asset,
+        buyAsset: buyTradeAsset.asset,
+        feeAsset,
+        action: TradeAmountInputField.SELL,
+        selectedCurrencyToUsdRate,
+      })
+    }
+  }, 1000 * 30) // 30 seconds
 
   return (
     <SlideTransition>

--- a/src/components/Trade/hooks/useSwapper/useSwapper.ts
+++ b/src/components/Trade/hooks/useSwapper/useSwapper.ts
@@ -64,6 +64,8 @@ type GetQuoteInput = {
   selectedCurrencyToUsdRate: BigNumber
 }
 
+let _getQuoteArgs: GetQuoteInput
+
 type DebouncedQuoteInput = {
   swapper: Swapper<ChainId>
   amount: string
@@ -510,15 +512,17 @@ export const useSwapper = () => {
   )
 
   const updateQuote = useCallback(
-    async ({
-      amount,
-      sellAsset,
-      buyAsset,
-      feeAsset,
-      action,
-      forceQuote,
-      selectedCurrencyToUsdRate,
-    }: GetQuoteInput) => {
+    async (args: GetQuoteInput) => {
+      _getQuoteArgs = args
+      const {
+        amount,
+        sellAsset,
+        buyAsset,
+        feeAsset,
+        action,
+        forceQuote,
+        selectedCurrencyToUsdRate,
+      } = args
       if (!wallet || !accountSpecifiersList.length) return
       if (!forceQuote && bnOrZero(amount).isZero()) return
       if (!Array.from(swapperManager.swappers.keys()).length) return
@@ -569,6 +573,10 @@ export const useSwapper = () => {
       translate,
     ],
   )
+
+  const refreshQuote = useCallback(async () => {
+    if (_getQuoteArgs) await updateQuote(_getQuoteArgs)
+  }, [updateQuote])
 
   const setFormFees = async ({
     trade,
@@ -673,6 +681,7 @@ export const useSwapper = () => {
     swapperManager,
     updateQuote,
     updateTrade,
+    refreshQuote,
     executeQuote,
     getSupportedBuyAssetsFromSellAsset,
     getSupportedSellableAssets,


### PR DESCRIPTION
## Description

Refreshes the trade quote every 30 seconds.

The simple implementation in https://github.com/shapeshift/web/commit/ea3b51c6a364cbebe726cefd147592fcb1093b80 won't fly because we need to remember the args used to get the last quote so we request a comparable one again.

`refreshQuote` added in https://github.com/shapeshift/web/commit/6c97e904d6b52bf3bc776c48491090b5d3c4e1d4 to reuse the last `GetQuoteInput` args called on _this_ instance of `useSwapper` on refresh.

## Notice

- [x] Have you followed the guidelines in our [Contributing]('https://github.com/shapeshift/web/CONTRIBUTING.md) guide?
- [x] Have you checked to ensure there aren't other open [Pull Requests](https://github.com/shapeshift/web/pulls) for the same update/change?

## Pull Request Type

- [ ] :bug: Bug fix (Non-breaking Change: Fixes an issue)
- [ ] :hammer_and_wrench: Chore (Non-breaking Change: Doc updates, pkg upgrades, typos, etc..)
- [x] :nail_care: New Feature (Breaking/Non-breaking Change)

## Issue (if applicable)

Closes https://github.com/shapeshift/web/issues/2361

## Risk

Small, though we want to make sure the refresh never overrides user-defined state.

## Testing

Get a quote, and notice it updates (refreshes) every 30 seconds.

## Screenshots (if applicable)

N/A