### PR TITLE
feat: use Cow Protocol Explorer URL

### DIFF
--- a/package.json
+++ b/package.json
@@ -104,7 +104,7 @@
     "@shapeshiftoss/investor-yearn": "^4.0.7",
     "@shapeshiftoss/logger": "^1.1.2",
     "@shapeshiftoss/market-service": "^6.5.0",
-    "@shapeshiftoss/swapper": "^9.9.1",
+    "@shapeshiftoss/swapper": "^9.11.0",
     "@shapeshiftoss/types": "^8.2.0",
     "@shapeshiftoss/unchained-client": "^9.8.1",
     "@uniswap/sdk": "^3.0.3",

--- a/src/components/Trade/TradeConfirm/TradeConfirm.tsx
+++ b/src/components/Trade/TradeConfirm/TradeConfirm.tsx
@@ -141,10 +141,13 @@ export const TradeConfirm = ({ history }: RouterProps) => {
     gasFeeToTradeRatioPercentage > gasFeeToTradeRatioPercentageThreshold
 
   const txLink = useMemo(() => {
-    if (trade.sources[0].name === 'Osmosis') {
-      return `${osmosisAsset?.explorerTxLink}${txid}`
-    } else {
-      return `${trade.sellAsset?.explorerTxLink}${txid}`
+    switch (trade.sources[0].name) {
+      case 'Osmosis':
+        return `${osmosisAsset?.explorerTxLink}${txid}`
+      case 'CowSwap':
+        return `https://explorer.cow.fi/orders/${txid}`
+      default:
+        return `${trade.sellAsset?.explorerTxLink}${txid}`
     }
   }, [trade, osmosisAsset, txid])
 

--- a/yarn.lock
+++ b/yarn.lock
@@ -4026,10 +4026,10 @@
     google-protobuf "^3.17.0"
     long "^4.0.0"
 
-"@shapeshiftoss/swapper@^9.9.1":
-  version "9.10.1"
-  resolved "https://registry.yarnpkg.com/@shapeshiftoss/swapper/-/swapper-9.10.1.tgz#7103146bedc77478ac122883ac33033cfb2198b2"
-  integrity sha512-BIt7b2IFrkGu5ApbKdUayO7Cn6fWiXfBaDqRh3cK6f0ZRMsMQ3gudluKYnIo+qujeZTtH5Iwb2FgXFfjPG42Zw==
+"@shapeshiftoss/swapper@^9.11.0":
+  version "9.11.0"
+  resolved "https://registry.yarnpkg.com/@shapeshiftoss/swapper/-/swapper-9.11.0.tgz#ab7910ea3ae3ca3bd3245b94cd59e24b94b82f7c"
+  integrity sha512-gMfGikYfYPMGs2h81zK1TVEbqzfNVhTTICL//ALCSmip9VGPpl4mDfG1egnQ/ls5fupc1oOmfjRkue/97hVglA==
   dependencies:
     axios "^0.26.1"
     bignumber.js "^9.0.2"


### PR DESCRIPTION
## Description

Uses the Cow Protocol Explorer as the `txLink`, which forms the URL for the "View Transaction" link on the `TradeConfirm` component.

Example of a generated transaction link: https://explorer.cow.fi/orders/0xafcf8125f2bc673056a40d4fd37983d3053b0428c4ab079ee0cffdf92df4ecfec2090e54b0db09a1515f203aea6ed62a115548ec62f49e5a

This can be merged beforehand, but it requires https://github.com/shapeshift/lib/pull/964 to be linked before it can be tested, as currently the `sellTxid` is returning as an empty string from `CowSwapper`.

## Notice

- [x] Have you followed the guidelines in our [Contributing]('https://github.com/shapeshift/web/CONTRIBUTING.md) guide?
- [x] Have you checked to ensure there aren't other open [Pull Requests](https://github.com/shapeshift/web/pulls) for the same update/change?

## Pull Request Type

- [ ] :bug: Bug fix (Non-breaking Change: Fixes an issue)
- [ ] :hammer_and_wrench: Chore (Non-breaking Change: Doc updates, pkg upgrades, typos, etc..)
- [x] :nail_care: New Feature (Breaking/Non-breaking Change)

## Issue (if applicable)

Closes https://github.com/shapeshift/web/issues/2363

## Risk

Minimal.

## Testing

Once a swap is complete using CowSwap, the `TradeConfirm` component should correctly link to the Cow Protocol Explorer.

## Screenshots (if applicable)

<img width="404" alt="Screen Shot 2022-08-11 at 3 48 15 pm" src="https://user-images.githubusercontent.com/97164662/184072196-d63e1b9e-c71f-40db-82b1-35c58053a3b9.png">
