### PR TITLE
feat: fox lp icons changed to a pair of fox and eth

### DIFF
--- a/src/components/DeFi/components/AssetInput.tsx
+++ b/src/components/DeFi/components/AssetInput.tsx
@@ -8,6 +8,7 @@ import {
   Stack,
   useColorModeValue,
 } from '@chakra-ui/react'
+import { PairIcons } from 'features/defi/components/PairIcons/PairIcons'
 import { PropsWithChildren, useRef, useState } from 'react'
 import { FieldError } from 'react-hook-form'
 import NumberFormat from 'react-number-format'
@@ -51,6 +52,7 @@ export type AssetInputProps = {
   fiatBalance?: string
   errors?: FieldError
   percentOptions: number[]
+  icons?: string[]
 } & PropsWithChildren
 
 export const AssetInput: React.FC<AssetInputProps> = ({
@@ -67,6 +69,7 @@ export const AssetInput: React.FC<AssetInputProps> = ({
   fiatBalance,
   errors,
   percentOptions = [0.25, 0.5, 0.75, 1],
+  icons,
   children,
 }) => {
   const {
@@ -95,7 +98,9 @@ export const AssetInput: React.FC<AssetInputProps> = ({
           onClick={onAssetClick}
           size='sm'
           variant={onAssetClick ? 'solid' : 'read-only'}
-          leftIcon={<AssetIcon src={assetIcon} size='xs' />}
+          leftIcon={
+            icons ? <PairIcons icons={icons} isSmall /> : <AssetIcon src={assetIcon} size='xs' />
+          }
           rightIcon={onAssetClick && <ChevronDownIcon />}
         >
           {assetSymbol}

--- a/src/features/defi/components/Deposit/PairDeposit.tsx
+++ b/src/features/defi/components/Deposit/PairDeposit.tsx
@@ -13,6 +13,8 @@ import { Row } from 'components/Row/Row'
 import { Text } from 'components/Text'
 import { bnOrZero } from 'lib/bignumber/bignumber'
 
+import { PairIcons } from '../PairIcons/PairIcons'
+
 type DepositProps = {
   asset1: Asset
   asset2: Asset
@@ -44,6 +46,7 @@ type DepositProps = {
   onBack?(): void
   onCancel(): void
   syncPair?: boolean
+  icons?: string[]
 }
 
 enum Field {
@@ -79,6 +82,7 @@ export const PairDeposit = ({
   onContinue,
   percentOptions,
   syncPair = true,
+  icons,
 }: DepositProps) => {
   const translate = useTranslate()
   const green = useColorModeValue('green.500', 'green.200')
@@ -238,7 +242,11 @@ export const PairDeposit = ({
               <Stack textAlign='right' spacing={0}>
                 <Amount.Fiat value={fiatYield} fontWeight='bold' lineHeight='1' mb={1} />
                 <Stack alignItems='flex-end'>
-                  <AssetIcon size='xs' src={destAsset.icon} />
+                  {icons ? (
+                    <PairIcons icons={icons} isSmall />
+                  ) : (
+                    <AssetIcon size='xs' src={destAsset.icon} />
+                  )}
                 </Stack>
               </Stack>
             </Row.Value>

--- a/src/features/defi/components/Overview/Overview.tsx
+++ b/src/features/defi/components/Overview/Overview.tsx
@@ -20,6 +20,7 @@ import { AssetIcon } from 'components/AssetIcon'
 import { RawText, Text } from 'components/Text'
 
 import { DefiActionButtonProps, DefiActionButtons } from '../DefiActionButtons'
+import { PairIcons } from '../PairIcons/PairIcons'
 
 type AssetWithBalance = {
   cryptoBalance: string
@@ -36,6 +37,7 @@ type OverviewProps = {
   provider: string
   tvl?: string
   apy?: string
+  icons?: string[]
 } & DefiActionButtonProps &
   PropsWithChildren
 
@@ -48,6 +50,7 @@ export const Overview: React.FC<OverviewProps> = ({
   provider,
   tvl,
   apy,
+  icons,
   description,
   menu,
   children,
@@ -92,7 +95,7 @@ export const Overview: React.FC<OverviewProps> = ({
           <Stack p={8} spacing={6}>
             <Stack direction='row' alignItems='center' justifyContent='space-between'>
               <Stack direction='row' alignItems='center' spacing={2}>
-                <AssetIcon src={asset.icon} size='md' />
+                {icons ? <PairIcons icons={icons} /> : <AssetIcon src={asset.icon} size='md' />}
                 <Stack spacing={0}>
                   <RawText fontSize='lg' lineHeight='shorter'>
                     {name}

--- a/src/features/defi/components/PairIcons/PairIcons.tsx
+++ b/src/features/defi/components/PairIcons/PairIcons.tsx
@@ -1,0 +1,15 @@
+import { Flex, useColorModeValue } from '@chakra-ui/react'
+import { AssetIcon } from 'components/AssetIcon'
+
+export const PairIcons = ({ icons, isSmall }: { icons: Array<string>; isSmall?: boolean }) => {
+  const boxHeight = isSmall ? '38px' : '46px'
+  const assetBoxSize = isSmall ? '5' : '6'
+  const bg = useColorModeValue('gray.200', 'gray.700')
+  return (
+    <Flex flexDirection='row' alignItems='center' bg={bg} p={1} borderRadius={8} h={boxHeight}>
+      {icons.map((iconSrc, i) => (
+        <AssetIcon key={iconSrc} src={iconSrc} boxSize={assetBoxSize} ml={i === 0 ? '0' : '-2.5'} />
+      ))}
+    </Flex>
+  )
+}

--- a/src/features/defi/components/TxStatus/PairIcons.tsx
+++ b/src/features/defi/components/TxStatus/PairIcons.tsx
@@ -1,0 +1,12 @@
+import { Flex } from '@chakra-ui/react'
+import { AssetIcon } from 'components/AssetIcon'
+
+export const PairIcons = ({ icons }: { icons: Array<string> }) => {
+  return (
+    <Flex flexDirection='row' alignItems='center' p={1} borderRadius={8}>
+      {icons.map((iconSrc, i) => (
+        <AssetIcon key={iconSrc} src={iconSrc} boxSize='8' ml={i === 0 ? '0' : '-1.5'} />
+      ))}
+    </Flex>
+  )
+}

--- a/src/features/defi/components/TxStatus/TxStatus.tsx
+++ b/src/features/defi/components/TxStatus/TxStatus.tsx
@@ -1,10 +1,12 @@
 import { ChevronDownIcon, ChevronRightIcon } from '@chakra-ui/icons'
 import {
+  Box,
   Button,
   Circle,
   CircularProgressLabel,
   Collapse,
   Divider,
+  Flex,
   Stack,
   useColorModeValue,
   useDisclosure,
@@ -13,6 +15,8 @@ import React from 'react'
 import { useTranslate } from 'react-polyglot'
 import { CircularProgress } from 'components/CircularProgress/CircularProgress'
 import { RawText, Text } from 'components/Text'
+
+import { PairIcons } from './PairIcons'
 
 type Status =
   | 'modals.status.header.pending'
@@ -28,6 +32,7 @@ type TxStatusProps = {
   statusBg?: string
   statusBody?: string
   continueText: string
+  pairIcons?: string[]
   children?: React.ReactNode
 }
 
@@ -36,6 +41,7 @@ export const TxStatus = ({
   loading,
   statusText,
   statusIcon,
+  pairIcons,
   statusBody,
   continueText,
   statusBg,
@@ -47,11 +53,37 @@ export const TxStatus = ({
   return (
     <Stack width='full' spacing={0} borderColor={borderColor} divider={<Divider />}>
       <Stack textAlign='center' spacing={6} p={6} alignItems='center'>
-        <Circle bg={statusBg}>
-          <CircularProgress isIndeterminate={loading}>
-            <CircularProgressLabel>{statusIcon}</CircularProgressLabel>
-          </CircularProgress>
-        </Circle>
+        {pairIcons ? (
+          <Flex position='relative' justifyContent='center' alignItems='center'>
+            <Flex
+              pl={2}
+              borderWidth='1px'
+              borderColor={borderColor}
+              borderRadius='3xl'
+              alignItems='center'
+              justifyContent='space-between'
+              w='110px'
+            >
+              {loading ? (
+                <CircularProgress size={6} />
+              ) : (
+                <Circle size={6} bg={statusBg}>
+                  {statusIcon}
+                </Circle>
+              )}
+              <PairIcons icons={pairIcons} />
+            </Flex>
+            <Box position='absolute' transform='scale(1.5)' filter='blur(20px)' opacity='0.5'>
+              <PairIcons icons={pairIcons} />
+            </Box>
+          </Flex>
+        ) : (
+          <Circle bg={statusBg}>
+            <CircularProgress isIndeterminate={loading}>
+              <CircularProgressLabel>{statusIcon}</CircularProgressLabel>
+            </CircularProgress>
+          </Circle>
+        )}
         <Stack>
           <Text translation={statusText} fontSize='xl' />
           {statusBody && <RawText color='gray.500'>{statusBody}</RawText>}

--- a/src/features/defi/components/Withdraw/Withdraw.tsx
+++ b/src/features/defi/components/Withdraw/Withdraw.tsx
@@ -65,6 +65,7 @@ type WithdrawProps = {
   onContinue(values: FieldValues): void
   onCancel(): void
   onInputChange?: (value: string, isFiat?: boolean) => void
+  icons?: string[]
 } & PropsWithChildren
 
 export enum Field {
@@ -97,6 +98,7 @@ export const Withdraw: React.FC<WithdrawProps> = ({
   percentOptions,
   children,
   onInputChange,
+  icons,
 }) => {
   const translate = useTranslate()
   const {
@@ -174,6 +176,7 @@ export const Withdraw: React.FC<WithdrawProps> = ({
           onMaxClick={value => handlePercentClick(value)}
           percentOptions={percentOptions}
           isReadOnly={disableInput}
+          icons={icons}
         />
       </FormField>
       {children}

--- a/src/features/defi/providers/fox-eth-lp/components/FoxEthLpManager/Deposit/components/Deposit.tsx
+++ b/src/features/defi/providers/fox-eth-lp/components/FoxEthLpManager/Deposit/components/Deposit.tsx
@@ -176,6 +176,7 @@ export const Deposit: React.FC<StepComponentProps> = ({ onNext }) => {
     <PairDeposit
       asset1={foxAsset}
       asset2={ethAsset}
+      icons={opportunity?.icons}
       destAsset={asset}
       apy={opportunity?.apy?.toString() ?? ''}
       cryptoAmountAvailable1={foxCryptoAmountAvailable.toPrecision()}

--- a/src/features/defi/providers/fox-eth-lp/components/FoxEthLpManager/Deposit/components/Status.tsx
+++ b/src/features/defi/providers/fox-eth-lp/components/FoxEthLpManager/Deposit/components/Status.tsx
@@ -47,7 +47,6 @@ export const Status = () => {
     assetNamespace: 'slip44',
     assetReference: ASSET_REFERENCE.Ethereum,
   })
-  const lpAsset = useAppSelector(state => selectAssetById(state, opportunity.assetId))
   const foxAsset = useAppSelector(state => selectAssetById(state, foxAssetId))
   const ethAsset = useAppSelector(state => selectAssetById(state, ethAssetId))
 
@@ -101,7 +100,7 @@ export const Status = () => {
       case 'success':
         return {
           statusText: StatusTextEnum.success,
-          statusIcon: <CheckIcon color='white' />,
+          statusIcon: <CheckIcon color='gray.900' fontSize='xs' />,
           statusBody: translate('modals.deposit.status.success', {
             opportunity: `FOX/ETH LP`,
           }),
@@ -110,13 +109,13 @@ export const Status = () => {
       case 'failed':
         return {
           statusText: StatusTextEnum.failed,
-          statusIcon: <CloseIcon color='white' />,
+          statusIcon: <CloseIcon color='gray.900' fontSize='xs' />,
           statusBody: translate('modals.deposit.status.failed'),
           statusBg: 'red.500',
         }
       default:
         return {
-          statusIcon: <AssetIcon size='xs' src={lpAsset?.icon} />,
+          statusIcon: null,
           statusText: StatusTextEnum.pending,
           statusBody: translate('modals.deposit.status.pending'),
           statusBg: 'transparent',
@@ -134,6 +133,7 @@ export const Status = () => {
       statusBody={statusBody}
       statusBg={statusBg}
       continueText='modals.status.position'
+      pairIcons={opportunity.icons}
     >
       <Summary spacing={0} mx={6} mb={4}>
         <Row variant='vert-gutter'>

--- a/src/features/defi/providers/fox-eth-lp/components/FoxEthLpManager/Overview/FoxEthLpOverview.tsx
+++ b/src/features/defi/providers/fox-eth-lp/components/FoxEthLpManager/Overview/FoxEthLpOverview.tsx
@@ -34,6 +34,7 @@ export const FoxEthLpOverview = () => {
   return (
     <Overview
       asset={lpAsset}
+      icons={opportunity.icons}
       name={foxEthLpOpportunityName}
       opportunityFiatBalance={opportunity.fiatAmount}
       underlyingAssets={[

--- a/src/features/defi/providers/fox-eth-lp/components/FoxEthLpManager/Withdraw/components/Confirm.tsx
+++ b/src/features/defi/providers/fox-eth-lp/components/FoxEthLpManager/Withdraw/components/Confirm.tsx
@@ -2,6 +2,7 @@ import { Alert, AlertIcon, Box, Stack } from '@chakra-ui/react'
 import { ethAssetId } from '@shapeshiftoss/caip'
 import { supportsETH } from '@shapeshiftoss/hdwallet-core'
 import { Confirm as ReusableConfirm } from 'features/defi/components/Confirm/Confirm'
+import { PairIcons } from 'features/defi/components/PairIcons/PairIcons'
 import { Summary } from 'features/defi/components/Summary'
 import { DefiStep } from 'features/defi/contexts/DefiManagerProvider/DefiCommon'
 import { foxAssetId, foxEthLpAssetId } from 'features/defi/providers/fox-eth-lp/constants'
@@ -15,6 +16,7 @@ import { Row } from 'components/Row/Row'
 import { RawText, Text } from 'components/Text'
 import { useWallet } from 'hooks/useWallet/useWallet'
 import { bnOrZero } from 'lib/bignumber/bignumber'
+import { useFoxEthLpBalances } from 'pages/Defi/hooks/useFoxEthLpBalances'
 import {
   selectAssetById,
   selectMarketDataById,
@@ -28,7 +30,7 @@ import { WithdrawContext } from '../WithdrawContext'
 export const Confirm = ({ onNext }: StepComponentProps) => {
   const { state, dispatch } = useContext(WithdrawContext)
   const translate = useTranslate()
-  const opportunity = state?.opportunity
+  const { opportunity } = useFoxEthLpBalances()
   const { removeLiquidity } = useFoxEthLiquidityPool()
 
   const ethAsset = useAppSelector(state => selectAssetById(state, ethAssetId))
@@ -89,7 +91,7 @@ export const Confirm = ({ onNext }: StepComponentProps) => {
           </Row.Label>
           <Row px={0} fontWeight='medium'>
             <Stack direction='row' alignItems='center'>
-              <AssetIcon size='xs' src={lpAsset.icon} />
+              <PairIcons icons={opportunity.icons!} isSmall />
               <RawText>{lpAsset.name}</RawText>
             </Stack>
             <Row.Value>

--- a/src/features/defi/providers/fox-eth-lp/components/FoxEthLpManager/Withdraw/components/Status.tsx
+++ b/src/features/defi/providers/fox-eth-lp/components/FoxEthLpManager/Withdraw/components/Status.tsx
@@ -3,6 +3,7 @@ import { Box, Button, Link, Stack } from '@chakra-ui/react'
 import { ethAssetId } from '@shapeshiftoss/caip'
 import { ChainAdapter } from '@shapeshiftoss/chain-adapters'
 import { KnownChainIds } from '@shapeshiftoss/types'
+import { PairIcons } from 'features/defi/components/PairIcons/PairIcons'
 import { Summary } from 'features/defi/components/Summary'
 import { TxStatus } from 'features/defi/components/TxStatus/TxStatus'
 import { DefiParams, DefiQueryParams } from 'features/defi/contexts/DefiManagerProvider/DefiCommon'
@@ -18,6 +19,7 @@ import { getChainAdapterManager } from 'context/PluginProvider/chainAdapterSingl
 import { useBrowserRouter } from 'hooks/useBrowserRouter/useBrowserRouter'
 import { useWallet } from 'hooks/useWallet/useWallet'
 import { bnOrZero } from 'lib/bignumber/bignumber'
+import { useFoxEthLpBalances } from 'pages/Defi/hooks/useFoxEthLpBalances'
 import {
   selectAssetById,
   selectFirstAccountSpecifierByChainId,
@@ -36,6 +38,7 @@ export const Status = () => {
   const { state, dispatch } = useContext(WithdrawContext)
   const { query, history: browserHistory } = useBrowserRouter<DefiQueryParams, DefiParams>()
   const { chainId } = query
+  const { opportunity } = useFoxEthLpBalances()
   const {
     state: { wallet },
   } = useWallet()
@@ -94,7 +97,7 @@ export const Status = () => {
       case 'success':
         return {
           statusText: StatusTextEnum.success,
-          statusIcon: <CheckIcon color='white' />,
+          statusIcon: <CheckIcon color='gray.900' fontSize='xs' />,
           statusBg: 'green.500',
           statusBody: translate('modals.withdraw.status.success', {
             opportunity: lpAsset.symbol,
@@ -103,13 +106,13 @@ export const Status = () => {
       case 'failed':
         return {
           statusText: StatusTextEnum.failed,
-          statusIcon: <CloseIcon color='white' />,
+          statusIcon: <CloseIcon color='gray.900' fontSize='xs' />,
           statusBg: 'red.500',
           statusBody: translate('modals.withdraw.status.failed'),
         }
       default:
         return {
-          statusIcon: <AssetIcon size='xs' src={lpAsset.icon} />,
+          statusIcon: null,
           statusText: StatusTextEnum.pending,
           statusBg: 'transparent',
           statusBody: translate('modals.withdraw.status.pending'),
@@ -127,6 +130,7 @@ export const Status = () => {
       statusIcon={statusIcon}
       statusBg={statusBg}
       statusBody={statusBody}
+      pairIcons={opportunity.icons}
     >
       <Summary spacing={0} mx={6} mb={4}>
         <Row variant='vertical' p={4}>
@@ -135,7 +139,7 @@ export const Status = () => {
           </Row.Label>
           <Row px={0} fontWeight='medium'>
             <Stack direction='row' alignItems='center'>
-              <AssetIcon size='xs' src={lpAsset.icon} />
+              <PairIcons icons={opportunity.icons!} isSmall />
               <RawText>{lpAsset.name}</RawText>
             </Stack>
             <Row.Value>

--- a/src/features/defi/providers/fox-eth-lp/components/FoxEthLpManager/Withdraw/components/Withdraw.tsx
+++ b/src/features/defi/providers/fox-eth-lp/components/FoxEthLpManager/Withdraw/components/Withdraw.tsx
@@ -156,6 +156,7 @@ export const Withdraw: React.FC<StepComponentProps> = ({ onNext }) => {
     <FormProvider {...methods}>
       <ReusableWithdraw
         asset={asset}
+        icons={opportunity.icons}
         cryptoAmountAvailable={cryptoAmountAvailable.toPrecision()}
         cryptoInputValidation={{
           required: true,


### PR DESCRIPTION
## Description

- Adds support for pair icons across the Defi components for future usage
- Changed Uniswap icons with fox+eth

## Notice

<!-- Before submitting a pull request, please make sure you have answered the following: -->

- [x] Have you followed the guidelines in our [Contributing]('https://github.com/shapeshift/web/CONTRIBUTING.md) guide?
- [x] Have you checked to ensure there aren't other open [Pull Requests](https://github.com/shapeshift/web/pulls) for the same update/change?

## Pull Request Type

- [ ] :bug: Bug fix (Non-breaking Change: Fixes an issue)
- [ ] :hammer_and_wrench: Chore (Non-breaking Change: Doc updates, pkg upgrades, typos, etc..)
- [x] :nail_care: New Feature (Breaking/Non-breaking Change)

## Issue (if applicable)

closes #2391 

## Risk

none

## Screenshots (if applicable)
<img width="470" alt="Screen Shot 2022-08-11 at 13 44 48" src="https://user-images.githubusercontent.com/20498757/184103828-42e4aa4b-bae0-47d2-98df-ccfe20e3814b.png">
<img width="480" alt="Screen Shot 2022-08-11 at 13 45 00" src="https://user-images.githubusercontent.com/20498757/184103841-71dbac75-2336-4412-9a73-2d20338d190b.png">

<img width="487" alt="Screen Shot 2022-08-11 at 13 58 40" src="https://user-images.githubusercontent.com/20498757/184104283-561f0919-36ec-47a0-82dc-4f30cfb623f1.png">

<img width="477" alt="Screen Shot 2022-08-11 at 13 59 59" src="https://user-images.githubusercontent.com/20498757/184104467-ba0d6a3f-992f-4587-8559-11d26815506c.png">
