### PR TITLE
feat: consistent APR with fox-farming

### DIFF
--- a/src/pages/Defi/views/StakingVaults.tsx
+++ b/src/pages/Defi/views/StakingVaults.tsx
@@ -9,6 +9,7 @@ import {
   useColorModeValue,
 } from '@chakra-ui/react'
 import { useFarmingApr } from 'plugins/foxPage/hooks/useFarmingApr'
+import { useLpApr } from 'plugins/foxPage/hooks/useLpApr'
 import { useTranslate } from 'react-polyglot'
 import { Amount } from 'components/Amount/Amount'
 import { AssetIcon } from 'components/AssetIcon'
@@ -16,6 +17,7 @@ import { Card } from 'components/Card/Card'
 import { Main } from 'components/Layout/Main'
 import { AllEarnOpportunities } from 'components/StakingVaults/AllEarnOpportunities'
 import { RawText } from 'components/Text'
+import { bnOrZero } from 'lib/bignumber/bignumber'
 import { selectAssetById } from 'state/slices/selectors'
 import { useAppSelector } from 'state/store'
 
@@ -31,6 +33,7 @@ const DefiHeader = () => {
 const FoxFarmCTA = () => {
   const translate = useTranslate()
   const { farmingAprV4, isFarmingAprV4Loaded } = useFarmingApr()
+  const { lpApr, isLpAprLoaded } = useLpApr()
   const ethAsset = useAppSelector(state => selectAssetById(state, 'eip155:1/slip44:60'))
   const foxAsset = useAppSelector(state =>
     selectAssetById(state, 'eip155:1/erc20:0xc770eefad204b5180df6a14ee197d99d808ee52d'),
@@ -65,8 +68,15 @@ const FoxFarmCTA = () => {
           <CText ml='5' fontWeight='normal' fontSize={{ base: 'md', md: 'lg' }}>
             {translate('defi.clickHereToEarn')}
             <span> </span>
-            <Skeleton display='inline-block' isLoaded={isFarmingAprV4Loaded}>
-              <Amount.Percent as='span' value={farmingAprV4 ?? ''} />
+            <Skeleton display='inline-block' isLoaded={isFarmingAprV4Loaded && isLpAprLoaded}>
+              <Amount.Percent
+                as='span'
+                value={
+                  bnOrZero(farmingAprV4)
+                    .plus(lpApr ?? 0)
+                    .toString() ?? ''
+                }
+              />
             </Skeleton>
             {translate('defi.byFarming')}
           </CText>

--- a/src/pages/Defi/views/StakingVaults.tsx
+++ b/src/pages/Defi/views/StakingVaults.tsx
@@ -71,11 +71,9 @@ const FoxFarmCTA = () => {
             <Skeleton display='inline-block' isLoaded={isFarmingAprV4Loaded && isLpAprLoaded}>
               <Amount.Percent
                 as='span'
-                value={
-                  bnOrZero(farmingAprV4)
-                    .plus(lpApr ?? 0)
-                    .toString() ?? ''
-                }
+                value={bnOrZero(farmingAprV4)
+                  .plus(lpApr ?? 0)
+                  .toString()}
               />
             </Skeleton>
             {translate('defi.byFarming')}

--- a/src/plugins/foxPage/hooks/useLpApr.ts
+++ b/src/plugins/foxPage/hooks/useLpApr.ts
@@ -27,7 +27,7 @@ const fetchPairData = memoize(
 
 export const useLpApr = () => {
   const [lpApr, setLpApr] = useState<string | null>(null)
-  const [loaded, setLoaded] = useState(false)
+  const [isLpAprLoaded, setIsLpAprLoaded] = useState(false)
   const blockNumber = useCurrentBlockNumber()
 
   const liquidityContractAddress = UNIV2_WETH_FOX_POOL_ADDRESS
@@ -53,9 +53,9 @@ export const useLpApr = () => {
         uniswapLPContract,
       })
       setLpApr(bnOrZero(apr).div(100).toString())
-      setLoaded(true)
+      setIsLpAprLoaded(true)
     })()
   }, [blockNumber, uniswapLPContract])
 
-  return { loaded, lpApr }
+  return { isLpAprLoaded, lpApr }
 }

--- a/src/plugins/foxPage/hooks/useOtherOpportunities.ts
+++ b/src/plugins/foxPage/hooks/useOtherOpportunities.ts
@@ -3,12 +3,13 @@ import { foxEthLpOpportunityName } from 'features/defi/providers/fox-eth-lp/cons
 import { useFarmingApr } from 'plugins/foxPage/hooks/useFarmingApr'
 import { useLpApr } from 'plugins/foxPage/hooks/useLpApr'
 import { useMemo } from 'react'
+import { bnOrZero } from 'lib/bignumber/bignumber'
 
 import { FOX_ASSET_ID, FOXY_ASSET_ID, OpportunitiesBucket, OpportunityTypes } from '../FoxCommon'
 
 export const useOtherOpportunities = (assetId: AssetId) => {
   const { farmingAprV4, isFarmingAprV4Loaded } = useFarmingApr()
-  const { lpApr, loaded: isLpAprLoaded } = useLpApr()
+  const { lpApr, isLpAprLoaded } = useLpApr()
 
   const otherOpportunities = useMemo(() => {
     const opportunities: Record<AssetId, OpportunitiesBucket[]> = {
@@ -35,8 +36,13 @@ export const useOtherOpportunities = (assetId: AssetId) => {
           opportunities: [
             {
               title: 'ETH-FOX UNI V4 Farm',
-              isLoaded: isFarmingAprV4Loaded,
-              apy: isFarmingAprV4Loaded ? farmingAprV4 : null,
+              isLoaded: isFarmingAprV4Loaded && isLpAprLoaded,
+              apy:
+                isFarmingAprV4Loaded && isLpAprLoaded
+                  ? bnOrZero(farmingAprV4)
+                      .plus(lpApr ?? 0)
+                      .toString()
+                  : null,
               link: 'https://fox.shapeshift.com/fox-farming/liquidity/0x470e8de2ebaef52014a47cb5e6af86884947f08c/staking/0x24fd7fb95dc742e23dc3829d3e656feeb5f67fa0/get-started',
               icons: [
                 'https://assets.coincap.io/assets/icons/eth@2x.png',


### PR DESCRIPTION
## Description

This brings a consistent APR with the https://fox.shapeshift.com/fox-farming page.

The APR displayed from farming is now Farming APR (yield from farming) + LP APR (yield from LP token fees), the same as in the fox-farming page. Confirmed by product this was the original intent on the fox-farming page and the one we want here as well. 

## Notice

<!-- Before submitting a pull request, please make sure you have answered the following: -->

- [x] Have you followed the guidelines in our [Contributing]('https://github.com/shapeshift/web/CONTRIBUTING.md) guide?
- [x] Have you checked to ensure there aren't other open [Pull Requests](https://github.com/shapeshift/web/pulls) for the same update/change?

## Pull Request Type

- [ ] :bug: Bug fix (Non-breaking Change: Fixes an issue)
- [ ] :hammer_and_wrench: Chore (Non-breaking Change: Doc updates, pkg upgrades, typos, etc..)
- [x] :nail_care: New Feature (Breaking/Non-breaking Change)

## Issue (if applicable)

- closes https://github.com/shapeshift/web/issues/2379

## Risk

- Possibly more Infura requests - keep an eye on these.

## Testing

- Go to Fox Page
- Farming APR should match the one in https://fox.shapeshift.com/fox-farming

- Go to DeFi earn tab
- CTA APR should match the one in https://fox.shapeshift.com/fox-farming

## Screenshots (if applicable)

<img width="920" alt="image" src="https://user-images.githubusercontent.com/17035424/184175723-ce5c05f2-9b1d-4009-8b10-9a87bce5fc23.png">
<img width="784" alt="image" src="https://user-images.githubusercontent.com/17035424/184175745-1c3db004-f543-4f86-ad03-baa735f6aacf.png">
<img width="728" alt="image" src="https://user-images.githubusercontent.com/17035424/184175815-79b7359a-6277-41dd-8fb8-8152c1739638.png">
