### PR TITLE
feat(foxPage): display farming opportunities first

### DIFF
--- a/src/plugins/foxPage/hooks/useOtherOpportunities.ts
+++ b/src/plugins/foxPage/hooks/useOtherOpportunities.ts
@@ -15,22 +15,6 @@ export const useOtherOpportunities = (assetId: AssetId) => {
     const opportunities: Record<AssetId, OpportunitiesBucket[]> = {
       [FOX_ASSET_ID]: [
         {
-          type: OpportunityTypes.LiquidityPool,
-          title: 'plugins.foxPage.liquidityPools',
-          opportunities: [
-            {
-              title: foxEthLpOpportunityName,
-              isLoaded: isLpAprLoaded,
-              apy: isLpAprLoaded ? lpApr : null,
-              link: 'https://fox.shapeshift.com/fox-farming/liquidity/0x470e8de2ebaef52014a47cb5e6af86884947f08c/lp-add',
-              icons: [
-                'https://assets.coincap.io/assets/icons/eth@2x.png',
-                'https://assets.coincap.io/assets/icons/fox@2x.png',
-              ],
-            },
-          ],
-        },
-        {
           type: OpportunityTypes.Farming,
           title: 'plugins.foxPage.farming',
           opportunities: [
@@ -44,6 +28,22 @@ export const useOtherOpportunities = (assetId: AssetId) => {
                       .toString()
                   : null,
               link: 'https://fox.shapeshift.com/fox-farming/liquidity/0x470e8de2ebaef52014a47cb5e6af86884947f08c/staking/0x24fd7fb95dc742e23dc3829d3e656feeb5f67fa0/get-started',
+              icons: [
+                'https://assets.coincap.io/assets/icons/eth@2x.png',
+                'https://assets.coincap.io/assets/icons/fox@2x.png',
+              ],
+            },
+          ],
+        },
+        {
+          type: OpportunityTypes.LiquidityPool,
+          title: 'plugins.foxPage.liquidityPools',
+          opportunities: [
+            {
+              title: foxEthLpOpportunityName,
+              isLoaded: isLpAprLoaded,
+              apy: isLpAprLoaded ? lpApr : null,
+              link: 'https://fox.shapeshift.com/fox-farming/liquidity/0x470e8de2ebaef52014a47cb5e6af86884947f08c/lp-add',
               icons: [
                 'https://assets.coincap.io/assets/icons/eth@2x.png',
                 'https://assets.coincap.io/assets/icons/fox@2x.png',


### PR DESCRIPTION
## Description

This reorders the other opportunities of the Fox Page to show Fox Farming first. 

## Notice

<!-- Before submitting a pull request, please make sure you have answered the following: -->

- [x] Have you followed the guidelines in our [Contributing]('https://github.com/shapeshift/web/CONTRIBUTING.md) guide?
- [x] Have you checked to ensure there aren't other open [Pull Requests](https://github.com/shapeshift/web/pulls) for the same update/change?

## Pull Request Type

- [ ] :bug: Bug fix (Non-breaking Change: Fixes an issue)
- [ ] :hammer_and_wrench: Chore (Non-breaking Change: Doc updates, pkg upgrades, typos, etc..)
- [x] :nail_care: New Feature (Breaking/Non-breaking Change)

## Issue (if applicable)

- closes https://github.com/shapeshift/web/issues/2404

## Risk

- None, this just reorders things out

## Testing

- Farming opportunity for Fox tab in the Fox Page is displayed first

## Screenshots (if applicable)

<img width="986" alt="image" src="https://user-images.githubusercontent.com/17035424/184178185-a208c7c9-749a-4daa-9486-65c1cbbb94ac.png">
<img width="943" alt="image" src="https://user-images.githubusercontent.com/17035424/184178233-ab94ca76-e857-45da-81f9-326272cb3036.png">