### PR TITLE
feat: abstract isDemoWallet into useWallet().state

### DIFF
--- a/src/Routes/Routes.tsx
+++ b/src/Routes/Routes.tsx
@@ -1,7 +1,6 @@
 import { useEffect, useState } from 'react'
 import { matchPath, Redirect, Route, Switch, useLocation } from 'react-router-dom'
 import { Layout } from 'components/Layout/Layout'
-import { DemoConfig } from 'context/WalletProvider/DemoWallet/config'
 import { useBrowserRouter } from 'hooks/useBrowserRouter/useBrowserRouter'
 import { useWallet } from 'hooks/useWallet/useWallet'
 import { ConnectWallet } from 'pages/ConnectWallet/ConnectWallet'
@@ -32,14 +31,12 @@ export const Routes = () => {
     if (!matchDemoPath && shouldRedirectDemoRoute) return setShouldRedirectDemoRoute(false)
     if (!matchDemoPath || state.isLoadingLocalWallet) return
 
-    state.walletInfo?.deviceId === DemoConfig.name
-      ? setShouldRedirectDemoRoute(true)
-      : connectDemo()
+    state.isDemoWallet ? setShouldRedirectDemoRoute(true) : connectDemo()
   }, [
     matchDemoPath,
     shouldRedirectDemoRoute,
     location.pathname,
-    state.walletInfo?.deviceId,
+    state.isDemoWallet,
     state.isLoadingLocalWallet,
     connectDemo,
   ])

--- a/src/components/Layout/Header/Header.tsx
+++ b/src/components/Layout/Header/Header.tsx
@@ -15,7 +15,6 @@ import { Link, useHistory } from 'react-router-dom'
 import { FoxIcon } from 'components/Icons/FoxIcon'
 import { Text } from 'components/Text'
 import { WalletActions } from 'context/WalletProvider/actions'
-import { DemoConfig } from 'context/WalletProvider/DemoWallet/config'
 import { useWallet } from 'hooks/useWallet/useWallet'
 
 import { AutoCompleteSearch } from './AutoCompleteSearch/AutoCompleteSearch'
@@ -30,7 +29,7 @@ export const Header = () => {
   const bg = useColorModeValue('white', 'gray.800')
   const borderColor = useColorModeValue('gray.100', 'gray.750')
   const {
-    state: { walletInfo },
+    state: { isDemoWallet },
     dispatch,
   } = useWallet()
 
@@ -53,7 +52,6 @@ export const Header = () => {
   }, [handleKeyPress])
 
   const handleBannerClick = () => dispatch({ type: WalletActions.SET_WALLET_MODAL, payload: true })
-  const isDemo = walletInfo?.deviceId === DemoConfig.name
 
   return (
     <>
@@ -64,9 +62,9 @@ export const Header = () => {
         position='sticky'
         zIndex='banner'
         top={0}
-        paddingTop={{ base: isDemo ? 0 : 'env(safe-area-inset-top)', md: 0 }}
+        paddingTop={{ base: isDemoWallet ? 0 : 'env(safe-area-inset-top)', md: 0 }}
       >
-        {isDemo && (
+        {isDemoWallet && (
           <Box
             bg='blue.500'
             width='full'

--- a/src/components/Layout/Header/NavBar/UserMenu.tsx
+++ b/src/components/Layout/Header/NavBar/UserMenu.tsx
@@ -11,7 +11,6 @@ import { WalletImage } from 'components/Layout/Header/NavBar/WalletImage'
 import { MiddleEllipsis } from 'components/MiddleEllipsis/MiddleEllipsis'
 import { RawText, Text } from 'components/Text'
 import { WalletActions } from 'context/WalletProvider/actions'
-import { DemoConfig } from 'context/WalletProvider/DemoWallet/config'
 import type { InitialState } from 'context/WalletProvider/WalletProvider'
 import { useWallet } from 'hooks/useWallet/useWallet'
 import { ensReverseLookup } from 'lib/address/ens'
@@ -55,12 +54,14 @@ export const WalletConnected = (props: WalletConnectedProps) => {
 
 type WalletButtonProps = {
   isConnected: boolean
+  isDemoWallet: boolean
   isLoadingLocalWallet: boolean
   onConnect: () => void
 } & Pick<InitialState, 'walletInfo'>
 
 const WalletButton: FC<WalletButtonProps> = ({
   isConnected,
+  isDemoWallet,
   walletInfo,
   onConnect,
   isLoadingLocalWallet,
@@ -99,7 +100,7 @@ const WalletButton: FC<WalletButtonProps> = ({
       isLoading={isLoadingLocalWallet}
       leftIcon={
         <HStack>
-          {!(isConnected || walletInfo?.deviceId === DemoConfig.name) && (
+          {!(isConnected || isDemoWallet) && (
             <WarningTwoIcon ml={2} w={3} h={3} color='yellow.500' />
           )}
           <WalletImage walletInfo={walletInfo} />
@@ -132,7 +133,7 @@ const WalletButton: FC<WalletButtonProps> = ({
 
 export const UserMenu: React.FC<{ onClick?: () => void }> = ({ onClick }) => {
   const { state, dispatch, disconnect } = useWallet()
-  const { isConnected, walletInfo, type, isLocked } = state
+  const { isConnected, isDemoWallet, walletInfo, type, isLocked } = state
 
   if (isLocked) disconnect()
   const hasWallet = Boolean(walletInfo?.deviceId)
@@ -146,6 +147,7 @@ export const UserMenu: React.FC<{ onClick?: () => void }> = ({ onClick }) => {
         onConnect={handleConnect}
         walletInfo={walletInfo}
         isConnected={isConnected}
+        isDemoWallet={isDemoWallet}
         isLoadingLocalWallet={state.isLoadingLocalWallet}
       />
       <Menu>
@@ -164,7 +166,7 @@ export const UserMenu: React.FC<{ onClick?: () => void }> = ({ onClick }) => {
         >
           {hasWallet ? (
             <WalletConnected
-              isConnected={isConnected || walletInfo?.deviceId === DemoConfig.name}
+              isConnected={isConnected || isDemoWallet}
               walletInfo={walletInfo}
               onDisconnect={disconnect}
               onSwitchProvider={handleConnect}

--- a/src/components/Layout/Header/SideNav.tsx
+++ b/src/components/Layout/Header/SideNav.tsx
@@ -1,5 +1,4 @@
 import { chakra, useColorModeValue } from '@chakra-ui/react'
-import { DemoConfig } from 'context/WalletProvider/DemoWallet/config'
 import { useWallet } from 'hooks/useWallet/useWallet'
 
 import { SideNavContent } from './SideNavContent'
@@ -8,9 +7,9 @@ export const SideNav = () => {
   const bg = useColorModeValue('white', 'gray.850')
   const borderColor = useColorModeValue('gray.100', 'gray.750')
   const {
-    state: { walletInfo },
+    state: { isDemoWallet },
   } = useWallet()
-  const top = walletInfo?.deviceId === DemoConfig.name ? '7rem' : '4.5rem'
+  const top = isDemoWallet ? '7rem' : '4.5rem'
   return (
     <>
       <chakra.header

--- a/src/components/Layout/PageTransition.tsx
+++ b/src/components/Layout/PageTransition.tsx
@@ -1,6 +1,5 @@
 import { useMediaQuery } from '@chakra-ui/media-query'
 import { HTMLMotionProps, motion } from 'framer-motion'
-import { DemoConfig } from 'context/WalletProvider/DemoWallet/config'
 import { useWallet } from 'hooks/useWallet/useWallet'
 import { breakpoints } from 'theme/theme'
 
@@ -8,9 +7,7 @@ export const PageTransition: React.FC<HTMLMotionProps<'div'>> = props => {
   const [isLargerThanMd] = useMediaQuery(`(min-width: ${breakpoints['md']})`, { ssr: false })
   const walletContext = useWallet()
   const minHeight = isLargerThanMd
-    ? `calc(100vh - ${
-        walletContext?.state?.walletInfo?.deviceId === DemoConfig.name ? '7rem' : '4.5rem'
-      })`
+    ? `calc(100vh - ${walletContext?.state?.isDemoWallet ? '7rem' : '4.5rem'})`
     : 'auto'
 
   return (

--- a/src/components/StakingVaults/AllEarnOpportunities.tsx
+++ b/src/components/StakingVaults/AllEarnOpportunities.tsx
@@ -10,7 +10,6 @@ import { useHistory, useLocation } from 'react-router'
 import { Card } from 'components/Card/Card'
 import { Text } from 'components/Text'
 import { WalletActions } from 'context/WalletProvider/actions'
-import { DemoConfig } from 'context/WalletProvider/DemoWallet/config'
 import { useSortedYearnVaults } from 'hooks/useSortedYearnVaults/useSortedYearnVaults'
 import { useWallet } from 'hooks/useWallet/useWallet'
 import { useCosmosSdkStakingBalances } from 'pages/Defi/hooks/useCosmosSdkStakingBalances'
@@ -25,7 +24,7 @@ export const AllEarnOpportunities = () => {
   const history = useHistory()
   const location = useLocation()
   const {
-    state: { isConnected, walletInfo },
+    state: { isConnected, isDemoWallet },
     dispatch,
   } = useWallet()
   const sortedVaults = useSortedYearnVaults()
@@ -55,7 +54,7 @@ export const AllEarnOpportunities = () => {
     (opportunity: EarnOpportunityType) => {
       const { provider, contractAddress, chainId, rewardAddress, assetId } = opportunity
       const { assetReference } = fromAssetId(assetId)
-      if (!isConnected && walletInfo?.deviceId !== DemoConfig.name) {
+      if (!isConnected && isDemoWallet) {
         dispatch({ type: WalletActions.SET_WALLET_MODAL, payload: true })
         return
       }

--- a/src/context/WalletProvider/WalletProvider.tsx
+++ b/src/context/WalletProvider/WalletProvider.tsx
@@ -75,6 +75,7 @@ export interface InitialState {
   initialRoute: string | null
   walletInfo: WalletInfo | null
   isConnected: boolean
+  isDemoWallet: boolean
   isLocked: boolean
   modal: boolean
   isLoadingLocalWallet: boolean
@@ -92,6 +93,7 @@ const initialState: InitialState = {
   initialRoute: null,
   walletInfo: null,
   isConnected: false,
+  isDemoWallet: false,
   isLocked: false,
   modal: false,
   isLoadingLocalWallet: false,
@@ -119,6 +121,8 @@ const reducer = (state: InitialState, action: ActionTypes) => {
           },
         },
       }
+    case WalletActions.SET_IS_DEMO_WALLET:
+      return { ...state, isDemoWallet: action.payload }
     case WalletActions.SET_IS_CONNECTED:
       return { ...state, isConnected: action.payload }
     case WalletActions.SET_IS_LOCKED:
@@ -583,6 +587,7 @@ export const WalletProvider = ({ children }: { children: React.ReactNode }): JSX
         meta: { label: name },
       },
     })
+    dispatch({ type: WalletActions.SET_IS_DEMO_WALLET, payload: true })
     dispatch({ type: WalletActions.SET_IS_CONNECTED, payload: false })
     dispatch({ type: WalletActions.SET_LOCAL_WALLET_LOADING, payload: false })
   }, [state.keyring])

--- a/src/context/WalletProvider/WalletProvider.tsx
+++ b/src/context/WalletProvider/WalletProvider.tsx
@@ -587,9 +587,9 @@ export const WalletProvider = ({ children }: { children: React.ReactNode }): JSX
         meta: { label: name },
       },
     })
-    dispatch({ type: WalletActions.SET_IS_DEMO_WALLET, payload: true })
     dispatch({ type: WalletActions.SET_IS_CONNECTED, payload: false })
     dispatch({ type: WalletActions.SET_LOCAL_WALLET_LOADING, payload: false })
+    dispatch({ type: WalletActions.SET_IS_DEMO_WALLET, payload: true })
   }, [state.keyring])
 
   const create = useCallback(async (type: KeyManager) => {

--- a/src/context/WalletProvider/actions.ts
+++ b/src/context/WalletProvider/actions.ts
@@ -12,6 +12,7 @@ export enum WalletActions {
   SET_CONNECTOR_TYPE = 'SET_CONNECTOR_TYPE',
   SET_INITIAL_ROUTE = 'SET_INITIAL_ROUTE',
   SET_IS_CONNECTED = 'SET_IS_CONNECTED',
+  SET_IS_DEMO_WALLET = 'SET_IS_DEMO_WALLET',
   SET_IS_LOCKED = 'SET_IS_LOCKED',
   SET_WALLET_MODAL = 'SET_WALLET_MODAL',
   RESET_STATE = 'RESET_STATE',
@@ -39,6 +40,7 @@ export type ActionTypes =
       }
     }
   | { type: WalletActions.SET_IS_CONNECTED; payload: boolean }
+  | { type: WalletActions.SET_IS_DEMO_WALLET; payload: boolean }
   | { type: WalletActions.SET_IS_LOCKED; payload: boolean }
   | { type: WalletActions.SET_CONNECTOR_TYPE; payload: KeyManager }
   | { type: WalletActions.SET_INITIAL_ROUTE; payload: string }


### PR DESCRIPTION
## Description

This abstracts the demo wallet feature detection into a `isDemoWallet` field into `WalletProvider` state, to be consumed as `state.isDemoWallet` from `useWallet()`.

As we are adding more demo wallet logic, this will reduce the room for errors.

## Notice

<!-- Before submitting a pull request, please make sure you have answered the following: -->

- [x] Have you followed the guidelines in our [Contributing]('https://github.com/shapeshift/web/CONTRIBUTING.md) guide?
- [x] Have you checked to ensure there aren't other open [Pull Requests](https://github.com/shapeshift/web/pulls) for the same update/change?

## Pull Request Type

- [ ] :bug: Bug fix (Non-breaking Change: Fixes an issue)
- [ ] :hammer_and_wrench: Chore (Non-breaking Change: Doc updates, pkg upgrades, typos, etc..)
- [x] :nail_care: New Feature (Breaking/Non-breaking Change)

## Issue (if applicable)

N/A

## Risk

All the places this diff touches could theoretically show regressions:

- User Menu
- Side Nav
- Transitions
- DeFi Earn tab
- /demo routing 

## Testing

- Deep linking to demo wallet still works
- All the aforementioned places still work with demo wallet 

## Screenshots (if applicable)
