### PR TITLE
feat: reword trade.errors.rateError

### DIFF
--- a/src/assets/translations/en/main.json
+++ b/src/assets/translations/en/main.json
@@ -463,7 +463,7 @@
       "executeTradeFailed": "An error occurred executing your trade.",
       "unsupportedPair": "This trading pair is not currently supported.",
       "unsupportedChain": "This chain is not currently supported.",
-      "rateError": "An error occurred getting trade rates",
+      "rateError": "We're not able to get a quote for this pair",
       "signing": {
         "failed": "An error occurred signing the transaction",
         "required": "A signed transaction is required"


### PR DESCRIPTION
## Description

This rewords `trade.errors.rateError` from `trade.errors.rateError` to `We're not able to get a quote for this pair`

## Notice

<!-- Before submitting a pull request, please make sure you have answered the following: -->

- [ ] Have you followed the guidelines in our [Contributing]('https://github.com/shapeshift/web/CONTRIBUTING.md) guide?
- [x] Have you checked to ensure there aren't other open [Pull Requests](https://github.com/shapeshift/web/pulls) for the same update/change?

## Pull Request Type

- [ ] :bug: Bug fix (Non-breaking Change: Fixes an issue)
- [ ] :hammer_and_wrench: Chore (Non-breaking Change: Doc updates, pkg upgrades, typos, etc..)
- [x] :nail_care: New Feature (Breaking/Non-breaking Change)

## Issue (if applicable)

- closes https://github.com/shapeshift/web/issues/2179

<!-----------------------------------------------------------------------------
If applicable, please link to the github issue and put `closes #XXXX` in your comment to auto-close the issue that your PR fixes.
------------------------------------------------------------------------------>

## Risk

None

## Testing

- Get to an errored swapper state by inputting an invalid pair e.g USDC/yvDAI
- The error toast should display `We're not able to get a quote for this pair`

## Screenshots (if applicable)

<img width="391" alt="image" src="https://user-images.githubusercontent.com/17035424/184458356-0086fb2a-18e5-4fa6-9255-0fdf18f4d50e.png">
