### PR TITLE
fix: keepKey modal

### DIFF
--- a/src/assets/translations/en/main.json
+++ b/src/assets/translations/en/main.json
@@ -507,8 +507,8 @@
         "awaitingButtonPress": "Follow the steps on your KeepKey to view your Recovery Sentence. Write it down!"
       },
       "wiped": {
-        "header": "KeepKey Wiped Successfully",
-        "body": "You have successfully reset your KeepKey to factory defaults. You can now restore using an existing recovery seed, or create a new wallet.",
+        "header": "Get Started with KeepKey",
+        "body": "Your KeepKey is set to factory default settings. Create a new wallet, or restore a wallet using your secret recovery phrase",
         "createButton": "Create a New Wallet",
         "recoverButton": "Recover Wallet"
       },

--- a/src/assets/translations/en/main.json
+++ b/src/assets/translations/en/main.json
@@ -506,7 +506,7 @@
         "infoSecond": "Never share your recovery sentence, it grants access to all of your funds.",
         "awaitingButtonPress": "Follow the steps on your KeepKey to view your Recovery Sentence. Write it down!"
       },
-      "wiped": {
+      "factoryState": {
         "header": "Get Started with KeepKey",
         "body": "Your KeepKey is set to factory default settings. Create a new wallet, or restore a wallet using your secret recovery phrase",
         "createButton": "Create a New Wallet",

--- a/src/assets/translations/es/main.json
+++ b/src/assets/translations/es/main.json
@@ -464,7 +464,7 @@
         "infoSecond": "Nunca comparta su frase de recuperación, otorgara acceso a todos sus fondos.",
         "awaitingButtonPress": "Siga los pasos en su KeepKey para ver su sentencia de recuperación. ¡Escríbelo!"
       },
-      "wiped": {
+      "factoryState": {
         "header": "KeepKey borrado con éxito",
         "body": "Ha restablecido con éxito su KeepKey a los valores de fábrica predeterminados. Ahora puede restaurar utilizando una frase semilla de recuperación existente o crear una nueva billetera.",
         "createButton": "Crear una nueva billetera",

--- a/src/assets/translations/es/main.json
+++ b/src/assets/translations/es/main.json
@@ -464,12 +464,6 @@
         "infoSecond": "Nunca comparta su frase de recuperación, otorgara acceso a todos sus fondos.",
         "awaitingButtonPress": "Siga los pasos en su KeepKey para ver su sentencia de recuperación. ¡Escríbelo!"
       },
-      "factoryState": {
-        "header": "KeepKey borrado con éxito",
-        "body": "Ha restablecido con éxito su KeepKey a los valores de fábrica predeterminados. Ahora puede restaurar utilizando una frase semilla de recuperación existente o crear una nueva billetera.",
-        "createButton": "Crear una nueva billetera",
-        "recoverButton": "Recuperar billetera"
-      },
       "recoverySentenceEntry": {
         "header": "Ingrese su Oración de Recuperación",
         "body": "Usando la leyenda codificada del teclado en su KeepKey, ingrese las primeras 4 letras de cada palabra. Si hay menos de 4 letras en la palabra, presione Enter, presione la barra espaciadora o haga clic en Siguiente cuando haya terminado de escribir.",

--- a/src/assets/translations/fr/main.json
+++ b/src/assets/translations/fr/main.json
@@ -463,12 +463,6 @@
         "infoSecond": "Ne partagez jamais votre phrase de récupération, elle donne accès à tous vos fonds.",
         "awaitingButtonPress": "Suivez les étapes sur votre KeepKey pour afficher votre phrase de récupération. Écrivez-la !"
       },
-      "factoryState": {
-        "header": "KeepKey effacé avec succès",
-        "body": "Vous avez réinitialisé avec succès votre KeepKey avec les paramètres d'usine. Vous pouvez maintenant le restaurer à l'aide d'une phrase de récupération existante ou créer un nouveau porte-monnaie.",
-        "createButton": "Créer un nouveau porte-monnaie",
-        "recoverButton": "Récupérer le porte-monnaie"
-      },
       "recoverySentenceEntry": {
         "header": "Entrez votre phrase de récupération",
         "body": "À l'aide de la légende du clavier brouillé sur votre KeepKey, entrez les 4 premières lettres de chaque mot. S'il y a moins de 4 lettres dans le mot, appuyez sur Entrée, appuyez sur la barre d'espace ou cliquez sur Suivant lorsque vous avez fini de l'entrer.",

--- a/src/assets/translations/fr/main.json
+++ b/src/assets/translations/fr/main.json
@@ -463,7 +463,7 @@
         "infoSecond": "Ne partagez jamais votre phrase de récupération, elle donne accès à tous vos fonds.",
         "awaitingButtonPress": "Suivez les étapes sur votre KeepKey pour afficher votre phrase de récupération. Écrivez-la !"
       },
-      "wiped": {
+      "factoryState": {
         "header": "KeepKey effacé avec succès",
         "body": "Vous avez réinitialisé avec succès votre KeepKey avec les paramètres d'usine. Vous pouvez maintenant le restaurer à l'aide d'une phrase de récupération existante ou créer un nouveau porte-monnaie.",
         "createButton": "Créer un nouveau porte-monnaie",

--- a/src/assets/translations/id/main.json
+++ b/src/assets/translations/id/main.json
@@ -408,7 +408,7 @@
         "infoSecond": "Jangan pernah membagikan hukuman pemulihan Anda, itu memberikan akses ke semua dana Anda.",
         "awaitingButtonPress": "Ikuti langkah-langkah di KeepKey Anda untuk melihat Kalimat Pemulihan Anda. Tuliskan!"
       },
-      "wiped": {
+      "factoryState": {
         "header": "KeepKey Berhasil Dihapus",
         "body": "Anda telah berhasil mengatur ulang KeepKey Anda ke default pabrik. Anda sekarang dapat memulihkan menggunakan benih pemulihan yang ada, atau membuat dompet baru.",
         "createButton": "Buat Dompet Baru",

--- a/src/assets/translations/id/main.json
+++ b/src/assets/translations/id/main.json
@@ -408,12 +408,6 @@
         "infoSecond": "Jangan pernah membagikan hukuman pemulihan Anda, itu memberikan akses ke semua dana Anda.",
         "awaitingButtonPress": "Ikuti langkah-langkah di KeepKey Anda untuk melihat Kalimat Pemulihan Anda. Tuliskan!"
       },
-      "factoryState": {
-        "header": "KeepKey Berhasil Dihapus",
-        "body": "Anda telah berhasil mengatur ulang KeepKey Anda ke default pabrik. Anda sekarang dapat memulihkan menggunakan benih pemulihan yang ada, atau membuat dompet baru.",
-        "createButton": "Buat Dompet Baru",
-        "recoverButton": "Pulihkan Dompet"
-      },
       "recoverySentenceEntry": {
         "header": "Masukkan Kalimat Pemulihan Anda",
         "body": "Dengan menggunakan legenda keyboard yang diacak di KeepKey Anda, masukkan 4 huruf pertama dari setiap kata. Jika ada kurang dari 4 huruf dalam kata, tekan Enter, tekan spasi, atau klik berikutnya setelah Anda selesai mengetik.",

--- a/src/assets/translations/ko/main.json
+++ b/src/assets/translations/ko/main.json
@@ -421,12 +421,6 @@
         "infoSecond": "이 복구 문장을 통해서 당신이 KeepKey에 보유한 모든 자산에 접근할 수 있습니다. 이 복구 문장은 '절대' 다른 어디에도 공유하지 마세요.",
         "awaitingButtonPress": "KeepKey의 단계에 따라 복구 문장을 확인하시고, 반드시 따로 적어두세요."
       },
-      "factoryState": {
-        "header": "KeepKey 초기화 성공",
-        "body": "KeepKey의 공장 초기화가 완료되었습니다. 이제, KeepKey에 기존의 복구 시드를 사용하여 복원하거나, 새 지갑을 만들 수 있습니다.",
-        "createButton": "새 지갑 만들기",
-        "recoverButton": "지갑 복구"
-      },
       "recoverySentenceEntry": {
         "header": "복구 문장을 입력해주세요",
         "body": "KeepKey에 있는 스크램블 키보드를 사용해, 각 단어의 앞 4글자를 입력해주세요. 단어가 4글자보다 적다면, 엔터를 입력하고 스페이스 바를 눌러주세요. 입력이 완료되었으면 '다음'을 클릭해주세요.",

--- a/src/assets/translations/ko/main.json
+++ b/src/assets/translations/ko/main.json
@@ -421,7 +421,7 @@
         "infoSecond": "이 복구 문장을 통해서 당신이 KeepKey에 보유한 모든 자산에 접근할 수 있습니다. 이 복구 문장은 '절대' 다른 어디에도 공유하지 마세요.",
         "awaitingButtonPress": "KeepKey의 단계에 따라 복구 문장을 확인하시고, 반드시 따로 적어두세요."
       },
-      "wiped": {
+      "factoryState": {
         "header": "KeepKey 초기화 성공",
         "body": "KeepKey의 공장 초기화가 완료되었습니다. 이제, KeepKey에 기존의 복구 시드를 사용하여 복원하거나, 새 지갑을 만들 수 있습니다.",
         "createButton": "새 지갑 만들기",

--- a/src/assets/translations/pt/main.json
+++ b/src/assets/translations/pt/main.json
@@ -463,12 +463,6 @@
         "infoSecond": "Nunca compartilhe sua frase de recuperação, ela concede acesso a todos os seus fundos.",
         "awaitingButtonPress": "Siga as etapas em sua KeepKey para visualizar sua frase de recuperação. Não se esqueça de anotá-la. "
       },
-      "factoryState": {
-        "header": "KeepKey apagada com sucesso",
-        "body": "Você redefiniu com sucesso sua KeepKey para os padrões de fábrica. Agora você pode restaurar usando uma frase de recuperação existente ou criar uma nova carteira.",
-        "createButton": "Criar uma nova carteira",
-        "recoverButton": "Recuperar carteira"
-      },
       "recoverySentenceEntry": {
         "header": "Digite sua frase de recuperação",
         "body": "Use a legenda embaralhada do teclado em sua KeepKey, digite as primeiras 4 letras de cada palavra. Se houver menos de 4 letras na palavra, pressione Enter, pressione a barra de espaço ou clique em próximo quando terminar de digitar.",

--- a/src/assets/translations/pt/main.json
+++ b/src/assets/translations/pt/main.json
@@ -463,7 +463,7 @@
         "infoSecond": "Nunca compartilhe sua frase de recuperação, ela concede acesso a todos os seus fundos.",
         "awaitingButtonPress": "Siga as etapas em sua KeepKey para visualizar sua frase de recuperação. Não se esqueça de anotá-la. "
       },
-      "wiped": {
+      "factoryState": {
         "header": "KeepKey apagada com sucesso",
         "body": "Você redefiniu com sucesso sua KeepKey para os padrões de fábrica. Agora você pode restaurar usando uma frase de recuperação existente ou criar uma nova carteira.",
         "createButton": "Criar uma nova carteira",

--- a/src/assets/translations/zh/main.json
+++ b/src/assets/translations/zh/main.json
@@ -399,7 +399,7 @@
         "infoSecond": "永远不要告诉别人你的恢复短语，这能让拥有者动用你的所有的资金。",
         "awaitingButtonPress": "按照KeepKey上的步骤查看您的恢复短语。写下来！"
       },
-      "wiped": {
+      "factoryState": {
         "header": "KeepKey已成功擦除",
         "body": "你已成功将KeepKey重置为出厂默认设置。现在，你可以使用现有恢复助记词进行还原，也可以创建一个新的钱包。",
         "createButton": "创建一个新的钱包",

--- a/src/assets/translations/zh/main.json
+++ b/src/assets/translations/zh/main.json
@@ -399,12 +399,6 @@
         "infoSecond": "永远不要告诉别人你的恢复短语，这能让拥有者动用你的所有的资金。",
         "awaitingButtonPress": "按照KeepKey上的步骤查看您的恢复短语。写下来！"
       },
-      "factoryState": {
-        "header": "KeepKey已成功擦除",
-        "body": "你已成功将KeepKey重置为出厂默认设置。现在，你可以使用现有恢复助记词进行还原，也可以创建一个新的钱包。",
-        "createButton": "创建一个新的钱包",
-        "recoverButton": "找回钱包"
-      },
       "recoverySentenceEntry": {
         "header": "输入您的恢复短语",
         "body": "使用你的KeepKey上的加密键盘图例，输入每个单词的前4个字母。如果单词中少于4个字母，按Enter键，按空格键，或者在输入完成后单击next。",

--- a/src/context/WalletProvider/KeepKey/components/FactoryState.tsx
+++ b/src/context/WalletProvider/KeepKey/components/FactoryState.tsx
@@ -6,7 +6,7 @@ import { Text } from 'components/Text'
 import { KeepKeyRoutes } from 'context/WalletProvider/routes'
 import { useWallet } from 'hooks/useWallet/useWallet'
 
-export const WipedSuccessfully = () => {
+export const FactoryState = () => {
   const [loading, setLoading] = useState(false)
   const history = useHistory()
   const { setDeviceState } = useWallet()
@@ -32,11 +32,11 @@ export const WipedSuccessfully = () => {
       <ModalHeader>
         <Flex alignItems='center'>
           <CheckCircleIcon color='green.400' mr={3} />
-          <Text translation={'modals.keepKey.wiped.header'} />
+          <Text translation={'modals.keepKey.factoryState.header'} />
         </Flex>
       </ModalHeader>
       <ModalBody>
-        <Text color='gray.500' translation={'modals.keepKey.wiped.body'} mb={4} />
+        <Text color='gray.500' translation={'modals.keepKey.factoryState.body'} mb={4} />
         <Button
           width='full'
           size='lg'
@@ -45,7 +45,7 @@ export const WipedSuccessfully = () => {
           disabled={loading}
           mb={3}
         >
-          <Text translation={'modals.keepKey.wiped.createButton'} />
+          <Text translation={'modals.keepKey.factoryState.createButton'} />
         </Button>
         <Button
           width='full'
@@ -55,7 +55,7 @@ export const WipedSuccessfully = () => {
           variant='outline'
           border='none'
         >
-          <Text translation={'modals.keepKey.wiped.recoverButton'} />
+          <Text translation={'modals.keepKey.factoryState.recoverButton'} />
         </Button>
       </ModalBody>
     </>

--- a/src/context/WalletProvider/WalletProvider.tsx
+++ b/src/context/WalletProvider/WalletProvider.tsx
@@ -218,7 +218,7 @@ const reducer = (state: InitialState, action: ActionTypes) => {
         type: KeyManager.KeepKey,
         deviceId: action.payload.deviceId,
         onCloseRoute: '/connect-wallet',
-        initialRoute: KeepKeyRoutes.WipeSuccessful,
+        initialRoute: KeepKeyRoutes.FactoryState,
       }
     case WalletActions.OPEN_KEEPKEY_RECOVERY:
       return {

--- a/src/context/WalletProvider/WalletProvider.tsx
+++ b/src/context/WalletProvider/WalletProvider.tsx
@@ -73,6 +73,7 @@ export interface InitialState {
   wallet: HDWallet | null
   type: KeyManager | null
   initialRoute: string | null
+  onCloseRoute: string
   walletInfo: WalletInfo | null
   isConnected: boolean
   isDemoWallet: boolean
@@ -91,6 +92,7 @@ const initialState: InitialState = {
   wallet: null,
   type: null,
   initialRoute: null,
+  onCloseRoute: '/',
   walletInfo: null,
   isConnected: false,
   isDemoWallet: false,
@@ -212,8 +214,10 @@ const reducer = (state: InitialState, action: ActionTypes) => {
       return {
         ...state,
         modal: true,
+        showBackButton: false,
         type: KeyManager.KeepKey,
         deviceId: action.payload.deviceId,
+        onCloseRoute: '/connect-wallet',
         initialRoute: KeepKeyRoutes.WipeSuccessful,
       }
     case WalletActions.OPEN_KEEPKEY_RECOVERY:

--- a/src/context/WalletProvider/WalletProvider.tsx
+++ b/src/context/WalletProvider/WalletProvider.tsx
@@ -73,7 +73,7 @@ export interface InitialState {
   wallet: HDWallet | null
   type: KeyManager | null
   initialRoute: string | null
-  onCloseRoute: string
+  shouldResetOnClose: boolean
   walletInfo: WalletInfo | null
   isConnected: boolean
   isDemoWallet: boolean
@@ -92,7 +92,7 @@ const initialState: InitialState = {
   wallet: null,
   type: null,
   initialRoute: null,
-  onCloseRoute: '/',
+  shouldResetOnClose: false,
   walletInfo: null,
   isConnected: false,
   isDemoWallet: false,
@@ -217,7 +217,7 @@ const reducer = (state: InitialState, action: ActionTypes) => {
         showBackButton: false,
         type: KeyManager.KeepKey,
         deviceId: action.payload.deviceId,
-        onCloseRoute: '/connect-wallet',
+        shouldResetOnClose: true,
         initialRoute: KeepKeyRoutes.FactoryState,
       }
     case WalletActions.OPEN_KEEPKEY_RECOVERY:

--- a/src/context/WalletProvider/WalletViewsSwitch.tsx
+++ b/src/context/WalletProvider/WalletViewsSwitch.tsx
@@ -27,7 +27,7 @@ export const WalletViewsSwitch = () => {
   const translate = useTranslate()
   const match = useRouteMatch('/')
   const {
-    state: { wallet, modal, showBackButton, initialRoute, type },
+    state: { wallet, modal, showBackButton, initialRoute, onCloseRoute = '/', type },
     dispatch,
   } = useWallet()
 
@@ -44,7 +44,7 @@ export const WalletViewsSwitch = () => {
   }, [toast, translate, wallet])
 
   const onClose = async () => {
-    history.replace('/')
+    history.replace(onCloseRoute)
     dispatch({ type: WalletActions.SET_WALLET_MODAL, payload: false })
     await cancelWalletRequests()
   }

--- a/src/context/WalletProvider/WalletViewsSwitch.tsx
+++ b/src/context/WalletProvider/WalletViewsSwitch.tsx
@@ -27,7 +27,7 @@ export const WalletViewsSwitch = () => {
   const translate = useTranslate()
   const match = useRouteMatch('/')
   const {
-    state: { wallet, modal, showBackButton, initialRoute, onCloseRoute = '/', type },
+    state: { wallet, modal, showBackButton, initialRoute, onCloseRoute, type },
     dispatch,
   } = useWallet()
 

--- a/src/context/WalletProvider/WalletViewsSwitch.tsx
+++ b/src/context/WalletProvider/WalletViewsSwitch.tsx
@@ -27,7 +27,7 @@ export const WalletViewsSwitch = () => {
   const translate = useTranslate()
   const match = useRouteMatch('/')
   const {
-    state: { wallet, modal, showBackButton, initialRoute, onCloseRoute, type },
+    state: { wallet, modal, showBackButton, initialRoute, shouldResetOnClose, type },
     dispatch,
   } = useWallet()
 
@@ -44,8 +44,12 @@ export const WalletViewsSwitch = () => {
   }, [toast, translate, wallet])
 
   const onClose = async () => {
-    history.replace(onCloseRoute)
-    dispatch({ type: WalletActions.SET_WALLET_MODAL, payload: false })
+    history.replace('/')
+    if (shouldResetOnClose) {
+      dispatch({ type: WalletActions.RESET_STATE })
+    } else {
+      dispatch({ type: WalletActions.SET_WALLET_MODAL, payload: false })
+    }
     await cancelWalletRequests()
   }
 

--- a/src/context/WalletProvider/config.ts
+++ b/src/context/WalletProvider/config.ts
@@ -1,12 +1,12 @@
 import { ComponentWithAs, IconProps } from '@chakra-ui/react'
 import { RouteProps } from 'react-router-dom'
+import { FactoryState } from 'context/WalletProvider/KeepKey/components/FactoryState'
 import { KeepKeyLabel } from 'context/WalletProvider/KeepKey/components/Label'
 import { KeepKeyRecoverySentence } from 'context/WalletProvider/KeepKey/components/RecoverySentence'
 import { KeepKeyRecoverySentenceEntry } from 'context/WalletProvider/KeepKey/components/RecoverySentenceEntry'
 import { KeepKeyRecoverySentenceInvalid } from 'context/WalletProvider/KeepKey/components/RecoverySentenceInvalid'
 import { KeepKeyRecoverySettings } from 'context/WalletProvider/KeepKey/components/RecoverySettings'
 import { RecoverySettingUp } from 'context/WalletProvider/KeepKey/components/RecoverySettingUp'
-import { WipedSuccessfully } from 'context/WalletProvider/KeepKey/components/WipedSuccessfully'
 import { KeepKeyRoutes } from 'context/WalletProvider/routes'
 
 import { DemoConfig } from './DemoWallet/config'
@@ -79,7 +79,7 @@ export const SUPPORTED_WALLETS: Record<KeyManager, SupportedWalletInfo> = {
       { path: KeepKeyRoutes.Success, component: KeepKeySuccess },
       { path: KeepKeyRoutes.Pin, component: KeepKeyPin },
       { path: KeepKeyRoutes.Passphrase, component: KeepKeyPassphrase },
-      { path: KeepKeyRoutes.WipeSuccessful, component: WipedSuccessfully },
+      { path: KeepKeyRoutes.WipeSuccessful, component: FactoryState },
       { path: KeepKeyRoutes.NewLabel, component: KeepKeyLabel },
       { path: KeepKeyRoutes.NewRecoverySentence, component: KeepKeyRecoverySentence },
       { path: KeepKeyRoutes.RecoverySentenceEntry, component: KeepKeyRecoverySentenceEntry },

--- a/src/context/WalletProvider/config.ts
+++ b/src/context/WalletProvider/config.ts
@@ -79,7 +79,7 @@ export const SUPPORTED_WALLETS: Record<KeyManager, SupportedWalletInfo> = {
       { path: KeepKeyRoutes.Success, component: KeepKeySuccess },
       { path: KeepKeyRoutes.Pin, component: KeepKeyPin },
       { path: KeepKeyRoutes.Passphrase, component: KeepKeyPassphrase },
-      { path: KeepKeyRoutes.WipeSuccessful, component: FactoryState },
+      { path: KeepKeyRoutes.FactoryState, component: FactoryState },
       { path: KeepKeyRoutes.NewLabel, component: KeepKeyLabel },
       { path: KeepKeyRoutes.NewRecoverySentence, component: KeepKeyRecoverySentence },
       { path: KeepKeyRoutes.RecoverySentenceEntry, component: KeepKeyRecoverySentenceEntry },

--- a/src/context/WalletProvider/routes.ts
+++ b/src/context/WalletProvider/routes.ts
@@ -1,5 +1,5 @@
 export enum KeepKeyRoutes {
-  WipeSuccessful = '/keepkey/new',
+  FactoryState = '/keepkey/new',
   Connect = '/keepkey/connect',
   Success = '/keepkey/success',
   Passphrase = '/keepkey/passphrase',


### PR DESCRIPTION
## Description
Multiple fixes to KeepKey reset modal:
 - modified header & inner text
 - removed "back" button
 - added redirect on modal close

<!-- Please describe your changes -->

## Notice

<!-- Before submitting a pull request, please make sure you have answered the following: -->

- [x] Have you followed the guidelines in our [Contributing]('https://github.com/shapeshift/web/CONTRIBUTING.md) guide?
- [x] Have you checked to ensure there aren't other open [Pull Requests](https://github.com/shapeshift/web/pulls) for the same update/change?

## Pull Request Type

- [x] :bug: Bug fix (Non-breaking Change: Fixes an issue)
- [ ] :hammer_and_wrench: Chore (Non-breaking Change: Doc updates, pkg upgrades, typos, etc..)
- [ ] :nail_care: New Feature (Breaking/Non-breaking Change)

## Issue (if applicable)
Closes #1609 
<!-----------------------------------------------------------------------------
If applicable, please link to the github issue and put `closes #XXXX` in your comment to auto-close the issue that your PR fixes.
------------------------------------------------------------------------------>

## Risk
Zero
<!-----------------------------------------------------------------------------
Outline the scope of your changes and the risk associated with them. You must use your discretion as an engineer to determine the potential impact of your changes.

E.g. an upgrade to `hdwallet` or core state management would be considered higher risk, and might require a full regression test. UI or isolated view changes, or something behind a feature flag may have near zero risk. Small bug fixes might require testing isolated to the specific fix.
------------------------------------------------------------------------------>

## Testing

According to the comment https://github.com/shapeshift/web/issues/1609#issuecomment-1112649156

Modal after resetting KeepKey/adding a new one should have:
title: "Get Started with KeepKey"
text: "Your KeepKey is set to factory default settings. Create a new wallet, or restore a wallet using your secret recovery phrase"

Also, it shouldn't have 'back' button in the header of modal, and closing the modal should redirect to '/connect-wallet' page


<!-----------------------------------------------------------------------------
If your testing steps are technical, outline steps for an engineer to verify.

If your testing steps are functional, please provide a full guide with any features requiring special attention for operations to test your branch in the preview environment.
------------------------------------------------------------------------------>

## Screenshots (if applicable)
