### PR TITLE
refactor: tidy usage of `bnOrZero`

### DIFF
--- a/src/components/Modals/Send/hooks/useFormSend/useFormSend.tsx
+++ b/src/components/Modals/Send/hooks/useFormSend/useFormSend.tsx
@@ -17,7 +17,7 @@ import { getChainAdapterManager } from 'context/PluginProvider/chainAdapterSingl
 import { useEvm } from 'hooks/useEvm/useEvm'
 import { useModal } from 'hooks/useModal/useModal'
 import { useWallet } from 'hooks/useWallet/useWallet'
-import { bnOrZero } from 'lib/bignumber/bignumber'
+import { bn, bnOrZero } from 'lib/bignumber/bignumber'
 import { logger } from 'lib/logger'
 import { tokenOrUndefined } from 'lib/utils'
 import { accountIdToUtxoParams } from 'state/slices/portfolioSlice/utils'
@@ -43,7 +43,7 @@ export const useFormSend = () => {
         if (!adapter) throw new Error(`useFormSend: no adapter available for ${data.asset.chainId}`)
 
         const value = bnOrZero(data.cryptoAmount)
-          .times(bnOrZero(10).exponentiatedBy(data.asset.precision))
+          .times(bn(10).exponentiatedBy(data.asset.precision))
           .toFixed(0)
 
         const chainId = adapter.getChainId()

--- a/src/components/Modals/Send/utils.ts
+++ b/src/components/Modals/Send/utils.ts
@@ -8,7 +8,7 @@ import {
   UtxoChainId,
 } from '@shapeshiftoss/chain-adapters'
 import { getChainAdapterManager } from 'context/PluginProvider/chainAdapterSingleton'
-import { bnOrZero } from 'lib/bignumber/bignumber'
+import { bn, bnOrZero } from 'lib/bignumber/bignumber'
 
 export type EstimateFeesInput = {
   cryptoAmount: string
@@ -29,9 +29,7 @@ export const estimateFees = ({
 }: EstimateFeesInput): Promise<FeeDataEstimate<ChainId>> => {
   const chainAdapterManager = getChainAdapterManager()
   const { account } = fromAccountId(accountId)
-  const value = bnOrZero(cryptoAmount)
-    .times(bnOrZero(10).exponentiatedBy(asset.precision))
-    .toFixed(0)
+  const value = bnOrZero(cryptoAmount).times(bn(10).exponentiatedBy(asset.precision)).toFixed(0)
 
   const adapter = chainAdapterManager.get(asset.chainId)
   if (!adapter) throw new Error(`No adapter available for ${asset.chainId}`)

--- a/src/components/Trade/TradeInput.tsx
+++ b/src/components/Trade/TradeInput.tsx
@@ -20,7 +20,7 @@ import { ErrorTranslationMap, useErrorHandler } from 'hooks/useErrorToast/useErr
 import { useInterval } from 'hooks/useInterval/useInterval'
 import { useLocaleFormatter } from 'hooks/useLocaleFormatter/useLocaleFormatter'
 import { useWallet } from 'hooks/useWallet/useWallet'
-import { bnOrZero } from 'lib/bignumber/bignumber'
+import { bn, bnOrZero } from 'lib/bignumber/bignumber'
 import { logger } from 'lib/logger'
 import { firstNonZeroDecimal, fromBaseUnit } from 'lib/math'
 import {
@@ -83,9 +83,7 @@ export const TradeInput = ({ history }: RouterProps) => {
 
   // when trading from ETH, the value of TX in ETH is deducted
   const tradeDeduction =
-    feeAsset?.assetId === sellTradeAsset?.asset?.assetId
-      ? bnOrZero(sellTradeAsset.amount)
-      : bnOrZero(0)
+    feeAsset?.assetId === sellTradeAsset?.asset?.assetId ? bnOrZero(sellTradeAsset.amount) : bn(0)
 
   const hasEnoughBalanceForGas = bnOrZero(feeAssetBalance)
     .minus(fromBaseUnit(bnOrZero(quote?.feeData.fee), feeAsset?.precision))

--- a/src/features/defi/providers/cosmos/components/CosmosManager/Withdraw/WithdrawReducer.ts
+++ b/src/features/defi/providers/cosmos/components/CosmosManager/Withdraw/WithdrawReducer.ts
@@ -1,6 +1,6 @@
 import { KnownChainIds, WithdrawType } from '@shapeshiftoss/types'
 import { DefiType } from 'features/defi/contexts/DefiManagerProvider/DefiCommon'
-import { bnOrZero } from 'lib/bignumber/bignumber'
+import { bn } from 'lib/bignumber/bignumber'
 
 import {
   CosmosWithdrawActions,
@@ -18,7 +18,7 @@ export const initialState: CosmosWithdrawState = {
     type: DefiType.TokenStaking,
     expired: false,
     version: '',
-    tvl: bnOrZero(0),
+    tvl: bn(0),
   },
   userAddress: null,
   loading: false,

--- a/src/features/defi/providers/fox-eth-lp/hooks/useFoxEthLiquidityPool.ts
+++ b/src/features/defi/providers/fox-eth-lp/hooks/useFoxEthLiquidityPool.ts
@@ -16,7 +16,7 @@ import { useCallback, useEffect, useMemo, useState } from 'react'
 import { getChainAdapterManager } from 'context/PluginProvider/chainAdapterSingleton'
 import { useEvm } from 'hooks/useEvm/useEvm'
 import { useWallet } from 'hooks/useWallet/useWallet'
-import { bnOrZero } from 'lib/bignumber/bignumber'
+import { bn, bnOrZero } from 'lib/bignumber/bignumber'
 import { selectAssetById, selectMarketDataById } from 'state/slices/selectors'
 import { useAppSelector } from 'state/store'
 
@@ -37,7 +37,7 @@ function calculateSlippageMargin(amount: string | null, precision: number) {
   const percentage = 3
   const remainingPercentage = (100 - percentage) / 100
   return bnOrZero(amount)
-    .times(bnOrZero(10).exponentiatedBy(precision))
+    .times(bn(10).exponentiatedBy(precision))
     .times(bnOrZero(remainingPercentage))
     .decimalPlaces(0)
     .toFixed()
@@ -88,11 +88,11 @@ export const useFoxEthLiquidityPool = () => {
         if (!adapter)
           throw new Error(`addLiquidityEth: no adapter available for ${ethAsset.chainId}`)
         const value = bnOrZero(ethAmount)
-          .times(bnOrZero(10).exponentiatedBy(ethAsset.precision))
+          .times(bn(10).exponentiatedBy(ethAsset.precision))
           .toFixed(0)
         const data = uniswapRouterContract?.interface.encodeFunctionData('addLiquidityETH', [
           FOX_TOKEN_CONTRACT_ADDRESS,
-          bnOrZero(foxAmount).times(bnOrZero(10).exponentiatedBy(foxAsset.precision)).toFixed(0),
+          bnOrZero(foxAmount).times(bn(10).exponentiatedBy(foxAsset.precision)).toFixed(0),
           calculateSlippageMargin(foxAmount, foxAsset.precision),
           calculateSlippageMargin(ethAmount, ethAsset.precision),
           connectedWalletEthAddress,
@@ -191,7 +191,7 @@ export const useFoxEthLiquidityPool = () => {
           throw new Error(`addLiquidityEth: no adapter available for ${ethAsset.chainId}`)
         const data = uniswapRouterContract?.interface.encodeFunctionData('removeLiquidityETH', [
           FOX_TOKEN_CONTRACT_ADDRESS,
-          bnOrZero(lpAmount).times(bnOrZero(10).exponentiatedBy(lpAsset.precision)).toFixed(0),
+          bnOrZero(lpAmount).times(bn(10).exponentiatedBy(lpAsset.precision)).toFixed(0),
           calculateSlippageMargin(foxAmount, foxAsset.precision),
           calculateSlippageMargin(ethAmount, ethAsset.precision),
           connectedWalletEthAddress,
@@ -352,12 +352,10 @@ export const useFoxEthLiquidityPool = () => {
   const getDepositGasData = useCallback(
     async (foxAmount: string, ethAmount: string) => {
       if (!connectedWalletEthAddress || !uniswapRouterContract) return
-      const value = bnOrZero(ethAmount)
-        .times(bnOrZero(10).exponentiatedBy(ethAsset.precision))
-        .toFixed(0)
+      const value = bnOrZero(ethAmount).times(bn(10).exponentiatedBy(ethAsset.precision)).toFixed(0)
       const data = uniswapRouterContract.interface.encodeFunctionData('addLiquidityETH', [
         FOX_TOKEN_CONTRACT_ADDRESS,
-        bnOrZero(foxAmount).times(bnOrZero(10).exponentiatedBy(foxAsset.precision)).toFixed(0),
+        bnOrZero(foxAmount).times(bn(10).exponentiatedBy(foxAsset.precision)).toFixed(0),
         calculateSlippageMargin(foxAmount, foxAsset.precision),
         calculateSlippageMargin(ethAmount, ethAsset.precision),
         connectedWalletEthAddress,
@@ -387,7 +385,7 @@ export const useFoxEthLiquidityPool = () => {
       if (!connectedWalletEthAddress || !uniswapRouterContract) return
       const data = uniswapRouterContract.interface.encodeFunctionData('removeLiquidityETH', [
         FOX_TOKEN_CONTRACT_ADDRESS,
-        bnOrZero(lpAmount).times(bnOrZero(10).exponentiatedBy(lpAsset.precision)).toFixed(0),
+        bnOrZero(lpAmount).times(bn(10).exponentiatedBy(lpAsset.precision)).toFixed(0),
         calculateSlippageMargin(foxAmount, foxAsset.precision),
         calculateSlippageMargin(ethAmount, ethAsset.precision),
         connectedWalletEthAddress,

--- a/src/features/defi/providers/foxy/components/FoxyManager/Withdraw/WithdrawReducer.ts
+++ b/src/features/defi/providers/foxy/components/FoxyManager/Withdraw/WithdrawReducer.ts
@@ -1,6 +1,6 @@
 import { DefiType } from '@shapeshiftoss/investor-foxy'
 import { KnownChainIds, WithdrawType } from '@shapeshiftoss/types'
-import { bnOrZero } from 'lib/bignumber/bignumber'
+import { bn } from 'lib/bignumber/bignumber'
 
 import { FoxyWithdrawActions, FoxyWithdrawActionType, FoxyWithdrawState } from './WithdrawCommon'
 
@@ -15,7 +15,7 @@ export const initialState: FoxyWithdrawState = {
     expired: false,
     version: '',
     rewardToken: '',
-    tvl: bnOrZero(0),
+    tvl: bn(0),
     apy: '',
   },
   userAddress: null,

--- a/src/plugins/foxPage/utils.ts
+++ b/src/plugins/foxPage/utils.ts
@@ -3,7 +3,7 @@ import { ethChainId } from '@shapeshiftoss/caip'
 import { TokenAmount } from '@uniswap/sdk'
 import { providers } from 'ethers'
 import memoize from 'lodash/memoize'
-import { BN, bnOrZero } from 'lib/bignumber/bignumber'
+import { BN, bn, bnOrZero } from 'lib/bignumber/bignumber'
 import { logger } from 'lib/logger'
 import { getWeb3InstanceByChainId } from 'lib/web3-instance'
 
@@ -46,13 +46,13 @@ export const getToken0Volume24Hr = async ({
   )
 
   const token0SwapAmounts = events.map(event => {
-    if (!event?.args) return bnOrZero(0)
+    if (!event?.args) return bn(0)
     const { amount0In, amount0Out } = event.args
 
     return Number(amount0In)
       ? bnOrZero(amount0In.toString())
       : bnOrZero(amount0Out.toString())
-          .div(bnOrZero(1).minus(TRADING_FEE_RATE)) // Since these are outbound txs, this corrects the value to include trading fees taken out.
+          .div(bn(1).minus(TRADING_FEE_RATE)) // Since these are outbound txs, this corrects the value to include trading fees taken out.
           .decimalPlaces(0)
   })
 
@@ -79,7 +79,7 @@ export const calculateAPRFromToken0 = memoize(
 
     const token0PoolReservesEquivalent = bnOrZero(token0Reserves.toFixed())
       .times(2) // Double to get equivalent of both sides of pool
-      .times(bnOrZero(10).pow(token0Decimals))
+      .times(bn(10).pow(token0Decimals))
 
     const estimatedAPR = bnOrZero(token0Volume24Hr) // 24hr volume in terms of token0
       .div(token0PoolReservesEquivalent) // Total value (both sides) of pool reserves in terms of token0

--- a/src/state/slices/portfolioSlice/selectors.ts
+++ b/src/state/slices/portfolioSlice/selectors.ts
@@ -409,7 +409,7 @@ export const selectTotalStakingUndelegationCryptoByAccountSpecifier = createSele
         })
 
         return acc
-      }, bnOrZero(0))
+      }, bn(0))
       .toString()
 
     return amount
@@ -908,7 +908,7 @@ export const selectUnbondingCryptoAmountByAssetIdAndValidator = createDeepEqualO
     const unbondingCryptoAmountByAssetIdAndValidator = unbondingEntries
       .reduce((acc, current) => {
         return acc.plus(bnOrZero(current.amount))
-      }, bnOrZero(0))
+      }, bn(0))
       .toString()
 
     return unbondingCryptoAmountByAssetIdAndValidator
@@ -972,7 +972,7 @@ export const selectStakingOpportunitiesDataFull = createDeepEqualOutputSelector(
         .plus(
           undelegatedEntries.reduce<BN>(
             (acc, current) => acc.plus(bnOrZero(current.amount)),
-            bnOrZero(0),
+            bn(0),
           ),
         )
         .toString()


### PR DESCRIPTION
## Description

A refactor to use only use `bnOrZero` when we actually need it.

## Notice

- [x] Have you followed the guidelines in our [Contributing]('https://github.com/shapeshift/web/CONTRIBUTING.md) guide?
- [x] Have you checked to ensure there aren't other open [Pull Requests](https://github.com/shapeshift/web/pulls) for the same update/change?

## Pull Request Type

- [ ] :bug: Bug fix (Non-breaking Change: Fixes an issue)
- [x] :hammer_and_wrench: Chore (Non-breaking Change: Doc updates, pkg upgrades, typos, etc..)
- [ ] :nail_care: New Feature (Breaking/Non-breaking Change)

## Issue (if applicable)

N/A

## Risk

Minimal.

## Testing

CI should pass.

## Screenshots (if applicable)

N/A