### PR TITLE
fix: get asset icon from redux assets if asset src not provided

### DIFF
--- a/src/components/AssetIcon.tsx
+++ b/src/components/AssetIcon.tsx
@@ -5,26 +5,29 @@ import {
   useColorModeValue,
   useMultiStyleConfig,
 } from '@chakra-ui/react'
+import { selectAssetById } from 'state/slices/selectors'
+import { useAppSelector } from 'state/store'
 
 import { FoxIcon } from './Icons/FoxIcon'
 
 type AssetIconProps = {
-  symbol?: string
+  assetId?: string
 } & AvatarProps
 
 // @TODO: this will be replaced with whatever we do for icons later
 
 // The icon prop is used as the placeholder while the icon loads, or if it fails to load.
 
-// Either src or symbol can be passed, if both are passed src takes precedence
-export const AssetIcon = ({ symbol, src, ...rest }: AssetIconProps) => {
+// Either src or assetId can be passed, if both are passed src takes precedence
+export const AssetIcon = ({ assetId, src, ...rest }: AssetIconProps) => {
   const assetIconBg = useColorModeValue('gray.200', 'gray.700')
   const assetIconColor = useColorModeValue('gray.500', 'gray.500')
+  const asset = useAppSelector(state => selectAssetById(state, assetId ?? ''))
 
-  if (!src && !symbol) {
+  if (!assetId && !src) {
     return null
   }
-  const imgSrc = src ? src : `https://static.coincap.io/assets/icons/256/${symbol}.png`
+  const imgSrc = src ?? asset?.icon
   return (
     <Avatar
       src={imgSrc}

--- a/src/components/Modals/FiatRamps/components/AssetSearch/AssetRow.tsx
+++ b/src/components/Modals/FiatRamps/components/AssetSearch/AssetRow.tsx
@@ -26,7 +26,7 @@ export const AssetRow: React.FC<ListChildComponentProps> = ({ data, index, style
       }}
     >
       <Box style={{ display: 'flex', flexDirection: 'row' }}>
-        <AssetIcon src={asset.imageUrl} symbol={asset.symbol.toLowerCase()} boxSize='24px' mr={4} />
+        <AssetIcon src={asset.imageUrl} assetId={asset.assetId} boxSize='24px' mr={4} />
         <Box textAlign='left'>
           <Text lineHeight={1}>{asset.name}</Text>
           <Text fontWeight='normal' fontSize='sm' color={color}>

--- a/src/components/Modals/FiatRamps/views/Overview.tsx
+++ b/src/components/Modals/FiatRamps/views/Overview.tsx
@@ -219,11 +219,7 @@ export const Overview: React.FC<OverviewProps> = ({
         >
           {selectedAsset ? (
             <Flex alignItems='center'>
-              <AssetIcon
-                src={selectedAsset.imageUrl}
-                symbol={selectedAsset.symbol.toLowerCase()}
-                mr={4}
-              />
+              <AssetIcon src={selectedAsset.imageUrl} assetId={selectedAsset.assetId} mr={4} />
               <Box textAlign='left'>
                 <RawText lineHeight={1}>{selectedAsset.name}</RawText>
                 <RawText fontWeight='normal' fontSize='sm' color='gray.500'>


### PR DESCRIPTION
## Description

This PR removes the hardcoded `coincap` asset images in `<AssetIcon />`. fallback to redux asset icon if `src` not provided.

## Notice

<!-- Before submitting a pull request, please make sure you have answered the following: -->

- [x] Have you followed the guidelines in our [Contributing]('https://github.com/shapeshift/web/CONTRIBUTING.md) guide?
- [x] Have you checked to ensure there aren't other open [Pull Requests](https://github.com/shapeshift/web/pulls) for the same update/change?

## Pull Request Type

- [x] :bug: Bug fix (Non-breaking Change: Fixes an issue)
- [ ] :hammer_and_wrench: Chore (Non-breaking Change: Doc updates, pkg upgrades, typos, etc..)
- [ ] :nail_care: New Feature (Breaking/Non-breaking Change)

## Issue (if applicable)

closes #2409

## Risk

none

## Testing

open up buy/sell modal, assets should have icons the same as the app

## Screenshots (if applicable)
<img width="440" alt="Screen Shot 2022-08-15" src="https://user-images.githubusercontent.com/20498757/184602554-da5f2888-b606-4d85-a9d5-acbb052e8466.png">

