### PR TITLE
fix(fiatRamps): monkey patch missing AVAX asset name and icon

### DIFF
--- a/src/components/Modals/FiatRamps/hooks/useFiatRampCurrencyList.ts
+++ b/src/components/Modals/FiatRamps/hooks/useFiatRampCurrencyList.ts
@@ -1,3 +1,4 @@
+import { avalancheAssetId } from '@shapeshiftoss/caip'
 import { useCallback, useEffect, useState } from 'react'
 import { useWallet } from 'hooks/useWallet/useWallet'
 import { bnOrZero } from 'lib/bignumber/bignumber'
@@ -73,6 +74,15 @@ export const useFiatRampCurrencyList = (fiatRampProvider: FiatRamp) => {
             if (!reduxAsset) {
               return {
                 ...asset,
+                symbol: asset.symbol.toUpperCase(),
+                // TODO: Monkey patch, remove after REACT_APP_FEATURE_AVALANCHE is enabled/removed
+                ...(asset.assetId === avalancheAssetId
+                  ? {
+                      name: 'Avalanche',
+                      imageUrl:
+                        'https://rawcdn.githack.com/trustwallet/assets/32e51d582a890b3dd3135fe3ee7c20c2fd699a6d/blockchains/avalanchec/info/logo.png',
+                    }
+                  : {}),
                 disabled: true,
               }
             }


### PR DESCRIPTION
## Description

This PR:

- monkey patches the AVAX buy asset and gives it a name and `imageUrl` properties in the `if (!reduxAsset)` branch, since with the `REACT_APP_FEATURE_AVALANCHE` flag off, it doesn't exist in the assets slice
- uppercases the `symbol` property in this same branch, since it comes lowercased for all assets

## Notice

<!-- Before submitting a pull request, please make sure you have answered the following: -->

- [x] Have you followed the guidelines in our [Contributing]('https://github.com/shapeshift/web/CONTRIBUTING.md) guide?
- [x] Have you checked to ensure there aren't other open [Pull Requests](https://github.com/shapeshift/web/pulls) for the same update/change?

## Pull Request Type

- [x] :bug: Bug fix (Non-breaking Change: Fixes an issue)
- [ ] :hammer_and_wrench: Chore (Non-breaking Change: Doc updates, pkg upgrades, typos, etc..)
- [ ] :nail_care: New Feature (Breaking/Non-breaking Change)

## Issue (if applicable)

N/A

## Risk

None, the `addSellPropertiesAndSort` method doesn't have an `if (!reduxAsset)` branch so such monkey patches should be all we need to support assets not in the assets slice.

## Testing

- Avalanche asset should be displaying the same with the flag on and off

## Screenshots (if applicable)


Develop:

![image](https://user-images.githubusercontent.com/17035424/184636341-4fcbec22-a7d7-4aef-8913-a35431264e71.png)

This diff:

<img width="464" alt="image" src="https://user-images.githubusercontent.com/17035424/184636398-cc4b6b0e-21fc-46fb-93a0-12b71a974340.png">
