### PR TITLE
feat: handle language-switching queryparam

### DIFF
--- a/src/Routes/Routes.tsx
+++ b/src/Routes/Routes.tsx
@@ -33,7 +33,7 @@ export const Routes = () => {
   const { lang } = useQuery()
   const selectedLocale = useAppSelector(selectSelectedLocale)
   const matchDemoPath = matchPath<{ appRoute: string }>(location.pathname, {
-    path: ['/demo/:appRoute(.+)?', '/demo'],
+    path: ['/demo/:appRoute(.+)', '/demo'],
   })
 
   useEffect(() => {

--- a/src/Routes/Routes.tsx
+++ b/src/Routes/Routes.tsx
@@ -12,6 +12,8 @@ import { PrivacyPolicy } from 'pages/Legal/PrivacyPolicy'
 import { TermsOfService } from 'pages/Legal/TermsOfService'
 import { NotFound } from 'pages/NotFound/NotFound'
 import { preferences } from 'state/slices/preferencesSlice/preferencesSlice'
+import { selectSelectedLocale } from 'state/slices/selectors'
+import { useAppSelector } from 'state/store'
 
 import { PrivateRoute } from './PrivateRoute'
 
@@ -29,22 +31,23 @@ export const Routes = () => {
   const hasWallet = Boolean(state.walletInfo?.deviceId) || state.isLoadingLocalWallet
   const [shouldRedirectDemoRoute, setShouldRedirectDemoRoute] = useState(false)
   const { lang } = useQuery()
+  const selectedLocale = useAppSelector(selectSelectedLocale)
   const matchDemoPath = matchPath<{ appRoute: string }>(location.pathname, {
     path: ['/demo/:appRoute(.+)?', '/demo'],
   })
 
   useEffect(() => {
+    if (lang && LanguageTypeEnum[lang as LanguageTypeEnum] && selectedLocale !== lang) {
+      dispatch(preferences.actions.setSelectedLocale({ locale: lang }))
+    }
+  }, [lang, dispatch, selectedLocale])
+
+  useEffect(() => {
     if (!matchDemoPath && shouldRedirectDemoRoute) return setShouldRedirectDemoRoute(false)
     if (!matchDemoPath || state.isLoadingLocalWallet) return
 
-    if (lang && LanguageTypeEnum[lang as LanguageTypeEnum]) {
-      dispatch(preferences.actions.setSelectedLocale({ locale: lang }))
-    }
-
     state.isDemoWallet ? setShouldRedirectDemoRoute(true) : connectDemo()
   }, [
-    dispatch,
-    lang,
     matchDemoPath,
     shouldRedirectDemoRoute,
     location.pathname,


### PR DESCRIPTION
## Description

This allows switching the locale with a `lang` queryparam so we can deeplink to specific languages of the app.

## Notice

<!-- Before submitting a pull request, please make sure you have answered the following: -->

- [x] Have you followed the guidelines in our [Contributing]('https://github.com/shapeshift/web/CONTRIBUTING.md) guide?
- [x] Have you checked to ensure there aren't other open [Pull Requests](https://github.com/shapeshift/web/pulls) for the same update/change?

## Pull Request Type

- [ ] :bug: Bug fix (Non-breaking Change: Fixes an issue)
- [ ] :hammer_and_wrench: Chore (Non-breaking Change: Doc updates, pkg upgrades, typos, etc..)
- [x] :nail_care: New Feature (Breaking/Non-breaking Change)

## Issue (if applicable)

closes https://github.com/shapeshift/web/issues/2416

## Risk

More logic in the main routes handlers, but with the memoization from selector, and the early return from the `useEffect()` we should be 🛍️ 

## Testing

- On any of the app routes, add `?lang=<someSupportedLang>` e.g `http://localhost:3000/#/connect-wallet?returnUrl=/dashboard&lang=es`
- The app should automagically switch to said locale
- This should work for /demo routes
- This should work both when accessing said URL from the same tab, or when inputting it in a new tab

## Screenshots (if applicable)
