### PR TITLE
feat: add lib instructions to fiat ramps docs

### DIFF
--- a/src/components/Modals/FiatRamps/fiat-ramps.md
+++ b/src/components/Modals/FiatRamps/fiat-ramps.md
@@ -11,23 +11,22 @@ Generally to add a new fiat ramp provider, you should complement `SupportedFiatR
 - The new provider should have a `onSubmit` property for passing the data to the provider API.
 - `isImplemeted` field is used to show whether the provider is ready to use or a `coming soon` text should be shown instead.
 
-You will also need to add a two way mapping from ShapeShift AssetId <> ramp ticker / ID in the `@shapeshiftoss/caip` package, located in [lib](https://github.com/shapeshift/lib).
+You will also need to add a two-way mapping from ShapeShift AssetId <> ramp ticker / ID in the `@shapeshiftoss/caip` package, located in [lib](https://github.com/shapeshift/lib).
 Refer to the README in that repo to work with lib packages locally.
 
 This mapping serves two purposes:
 - have a source of truth for the intersection of the assets ShapeShift and the ramp support
-- be able to convert from our internal [`AssetId`](https://github.com/shapeshift/lib/tree/main/packages/caip#assetid-caip19---asset-type-and-asset-id-specification)s to the ramp's ticker / ID so we can build the payload/link to the ramp
+- be able to convert from our internal [`AssetId`](https://github.com/shapeshift/lib/tree/main/packages/caip#assetid-caip19---asset-type-and-asset-id-specification)s to the ramp's ticker / ID, so we can build the payload/link to the ramp
 
 See these commits for reference:
 - [Banxa mapping](https://github.com/shapeshift/lib/commit/f24f9d800041534ae45a5196bb2030bba5f5864a)
 - [Gem mapping](https://github.com/shapeshift/lib/commit/78a8f14b82330239555ad544121ea956dd6ca8be)
-- [Coinbase mapping](https://github.com/shapeshift/lib/commit/fb2cc5aafe74ac33d896f130952b4dcbfbf98e4a) (unused in web)
+- [Coinbase mapping](https://github.com/shapeshift/lib/commit/fb2cc5aafe74ac33d896f130952b4dcbfbf98e4a) (unused in [web](https://github.com/shapeshift/web))
 - [OnJuno mapping](https://github.com/shapeshift/lib/commit/5fade1f998cc6224dd2cb5d076f26a4c485b649a)
 
 You can copy any of these commits, located in lib's [packages/caip/src/adapters](https://github.com/shapeshift/lib/tree/main/packages/caip/src/adapters) directory (Banxa, Gem, Coinbase or JunoPay are all fiat ramp adapters there) and adapt it to the ramp you're integrating.
 
 Refer to the documentation of the ramp you're integrating to find out the ID of the assets you're adding in this mapping.
-
 
 ### NOTE
 This whole structure is based on the assumption that user only should choose a provider and select an asset to buy or sell. with the same flow for any given provider. if a new provider needs extra steps to be implemented, a connect-wallet-like approach should be implemented.

--- a/src/components/Modals/FiatRamps/fiat-ramps.md
+++ b/src/components/Modals/FiatRamps/fiat-ramps.md
@@ -11,6 +11,23 @@ Generally to add a new fiat ramp provider, you should complement `SupportedFiatR
 - The new provider should have a `onSubmit` property for passing the data to the provider API.
 - `isImplemeted` field is used to show whether the provider is ready to use or a `coming soon` text should be shown instead.
 
+You will also need to add a two way mapping from ShapeShift AssetId <> ramp ticker / ID in the `@shapeshiftoss/caip`, located in [lib](https://github.com/shapeshift/lib).
+Refer to the README in that repo to work with lib packages locally.
+
+This mapping serves multiple purposes:
+- have a source of truth for the intersection of the assets ShapeShift and the ramp support
+- be able to convert from our internal [`AssetId`](https://github.com/shapeshift/lib/tree/main/packages/caip#assetid-caip19---asset-type-and-asset-id-specification)s to the ramp's ticker / ID so we can build the payload/link to the ramp.
+
+See these commits for reference:
+- [Banxa mapping](https://github.com/shapeshift/lib/commit/f24f9d800041534ae45a5196bb2030bba5f5864a)
+- [Gem mapping](https://github.com/shapeshift/lib/commit/78a8f14b82330239555ad544121ea956dd6ca8be)
+- [Coinbase mapping](https://github.com/shapeshift/lib/commit/fb2cc5aafe74ac33d896f130952b4dcbfbf98e4a) (unused in web)
+- [OnJuno mapping](https://github.com/shapeshift/lib/commit/5fade1f998cc6224dd2cb5d076f26a4c485b649a)
+
+You can copy any of these commits, located in lib's [packages/caip/src/adapters](https://github.com/shapeshift/lib/tree/main/packages/caip/src/adapters) directory (Banxa, Gem, Coinbase or JunoPay are all fiat ramp adapters there) and adapt it to the ramp you're integrating.
+
+Refer to the documentation of the ramp you're integrating to find out the ID of the assets you're adding in this mapping.
+
 
 ### NOTE
 This whole structure is based on the assumption that user only should choose a provider and select an asset to buy or sell. with the same flow for any given provider. if a new provider needs extra steps to be implemented, a connect-wallet-like approach should be implemented.

--- a/src/components/Modals/FiatRamps/fiat-ramps.md
+++ b/src/components/Modals/FiatRamps/fiat-ramps.md
@@ -11,7 +11,7 @@ Generally to add a new fiat ramp provider, you should complement `SupportedFiatR
 - The new provider should have a `onSubmit` property for passing the data to the provider API.
 - `isImplemeted` field is used to show whether the provider is ready to use or a `coming soon` text should be shown instead.
 
-You will also need to add a two way mapping from ShapeShift AssetId <> ramp ticker / ID in the `@shapeshiftoss/caip`, located in [lib](https://github.com/shapeshift/lib).
+You will also need to add a two way mapping from ShapeShift AssetId <> ramp ticker / ID in the `@shapeshiftoss/caip` package, located in [lib](https://github.com/shapeshift/lib).
 Refer to the README in that repo to work with lib packages locally.
 
 This mapping serves multiple purposes:

--- a/src/components/Modals/FiatRamps/fiat-ramps.md
+++ b/src/components/Modals/FiatRamps/fiat-ramps.md
@@ -14,7 +14,7 @@ Generally to add a new fiat ramp provider, you should complement `SupportedFiatR
 You will also need to add a two way mapping from ShapeShift AssetId <> ramp ticker / ID in the `@shapeshiftoss/caip` package, located in [lib](https://github.com/shapeshift/lib).
 Refer to the README in that repo to work with lib packages locally.
 
-This mapping serves multiple purposes:
+This mapping serves two purposes:
 - have a source of truth for the intersection of the assets ShapeShift and the ramp support
 - be able to convert from our internal [`AssetId`](https://github.com/shapeshift/lib/tree/main/packages/caip#assetid-caip19---asset-type-and-asset-id-specification)s to the ramp's ticker / ID so we can build the payload/link to the ramp.
 

--- a/src/components/Modals/FiatRamps/fiat-ramps.md
+++ b/src/components/Modals/FiatRamps/fiat-ramps.md
@@ -16,7 +16,7 @@ Refer to the README in that repo to work with lib packages locally.
 
 This mapping serves two purposes:
 - have a source of truth for the intersection of the assets ShapeShift and the ramp support
-- be able to convert from our internal [`AssetId`](https://github.com/shapeshift/lib/tree/main/packages/caip#assetid-caip19---asset-type-and-asset-id-specification)s to the ramp's ticker / ID so we can build the payload/link to the ramp.
+- be able to convert from our internal [`AssetId`](https://github.com/shapeshift/lib/tree/main/packages/caip#assetid-caip19---asset-type-and-asset-id-specification)s to the ramp's ticker / ID so we can build the payload/link to the ramp
 
 See these commits for reference:
 - [Banxa mapping](https://github.com/shapeshift/lib/commit/f24f9d800041534ae45a5196bb2030bba5f5864a)


### PR DESCRIPTION
## Description

This adds instructions on how to add CAIP adapter mappings for the fiat ramp abstraction 

## Notice

<!-- Before submitting a pull request, please make sure you have answered the following: -->

- [x] Have you followed the guidelines in our [Contributing]('https://github.com/shapeshift/web/CONTRIBUTING.md) guide?
- [x] Have you checked to ensure there aren't other open [Pull Requests](https://github.com/shapeshift/web/pulls) for the same update/change?

## Pull Request Type

- [ ] :bug: Bug fix (Non-breaking Change: Fixes an issue)
- [ ] :hammer_and_wrench: Chore (Non-breaking Change: Doc updates, pkg upgrades, typos, etc..)
- [x] :nail_care: New Feature (Breaking/Non-breaking Change)

## Issue (if applicable)

N/A

## Risk

None, just diffes a markdown file

## Testing

- Instructions are clear

## Screenshots (if applicable)
