### PR TITLE
feat(swapper): limit crypto protocol fee to 6 decimal places

### DIFF
--- a/src/components/Trade/TradeConfirm/TradeConfirm.tsx
+++ b/src/components/Trade/TradeConfirm/TradeConfirm.tsx
@@ -213,6 +213,7 @@ export const TradeConfirm = ({ history }: RouterProps) => {
                   <Row.Value>
                     {bn(trade.feeAmountInSellToken)
                       .div(bn(10).pow(trade.sellAsset.precision))
+                      .decimalPlaces(6)
                       .toString()}{' '}
                     ≃{' '}
                     {toFiat(


### PR DESCRIPTION
## Description

This limits the decimal places of the swapper protocol fee to 6 decimal places to avoid rugging the UI.

## Notice

<!-- Before submitting a pull request, please make sure you have answered the following: -->

- [x] Have you followed the guidelines in our [Contributing]('https://github.com/shapeshift/web/CONTRIBUTING.md) guide?
- [x] Have you checked to ensure there aren't other open [Pull Requests](https://github.com/shapeshift/web/pulls) for the same update/change?

## Pull Request Type

- [ ] :bug: Bug fix (Non-breaking Change: Fixes an issue)
- [ ] :hammer_and_wrench: Chore (Non-breaking Change: Doc updates, pkg upgrades, typos, etc..)
- [x] :nail_care: New Feature (Breaking/Non-breaking Change)

## Issue (if applicable)

N/A

## Risk

None

## Testing

- Input some amount/pair to be swapped with CoW
- The protocol fee should have a maximum of 6 decimal places

## Screenshots (if applicable)

Develop:

<img width="403" alt="image" src="https://user-images.githubusercontent.com/17035424/184732572-b4829fe9-ba4c-4228-b1b1-753604f41e3a.png">

This diff:

<img width="410" alt="image" src="https://user-images.githubusercontent.com/17035424/184732294-22e5a2dc-8adb-4593-80e8-988d45a859c6.png">