### PR TITLE
feat: rehydrate dayjs locale settings on app reload

### DIFF
--- a/src/context/AppProvider/AppContext.tsx
+++ b/src/context/AppProvider/AppContext.tsx
@@ -56,6 +56,7 @@ import {
   selectPortfolioAccounts,
   selectPortfolioAssetIds,
   selectSelectedCurrency,
+  selectSelectedLocale,
   selectTxHistoryStatus,
 } from 'state/slices/selectors'
 import { txHistory, txHistoryApi } from 'state/slices/txHistorySlice/txHistorySlice'
@@ -104,6 +105,11 @@ export const AppProvider = ({ children }: { children: React.ReactNode }) => {
   // this is needed to sort assets by market cap
   // and covers most assets users will have
   useFindAllQuery()
+
+  const selectedLocale = useAppSelector(selectSelectedLocale)
+  useEffect(() => {
+    require(`dayjs/locale/${selectedLocale}.js`)
+  }, [selectedLocale])
 
   /**
    * handle wallet disconnect/switch logic

--- a/src/state/slices/preferencesSlice/preferencesSlice.ts
+++ b/src/state/slices/preferencesSlice/preferencesSlice.ts
@@ -69,8 +69,6 @@ export const preferences = createSlice({
       state.featureFlags[payload.flag] = payload.value
     },
     setSelectedLocale(state, { payload }: { payload: { locale: string } }) {
-      require(`dayjs/locale/${payload.locale}.js`)
-
       state.selectedLocale = payload.locale
     },
     setSelectedCurrency(state, { payload }: { payload: { currency: SupportedFiatCurrencies } }) {


### PR DESCRIPTION
## Description

This makes sure we rehydrate the dayjs language settings on app rehydrate, so that reloading the app keeps the date format of the selected locale.

## Notice

<!-- Before submitting a pull request, please make sure you have answered the following: -->

- [x] Have you followed the guidelines in our [Contributing]('https://github.com/shapeshift/web/CONTRIBUTING.md) guide?
- [x] Have you checked to ensure there aren't other open [Pull Requests](https://github.com/shapeshift/web/pulls) for the same update/change?

## Pull Request Type

- [x] :bug: Bug fix (Non-breaking Change: Fixes an issue)
- [ ] :hammer_and_wrench: Chore (Non-breaking Change: Doc updates, pkg upgrades, typos, etc..)
- [ ] :nail_care: New Feature (Breaking/Non-breaking Change)

## Issue (if applicable)

- closes https://github.com/shapeshift/web/issues/2467

## Risk

- This lives in `<AppContext />` which is already bloated and fragile, should it live somewhere else?

## Testing

- Select a language
- Reloading the app should keep the date format
- Changing the selected language should update the date format
- Accessing a language through `?lang=<language>` (either through a new, or appended to the same tab's URL) queryparam should update the date format

## Screenshots (if applicable)
