### PR TITLE
chore(defi): no div(`1e+${asset.precision}`)

### DIFF
--- a/src/features/defi/providers/fox-eth-lp/components/FoxEthLpManager/Deposit/components/Approve.tsx
+++ b/src/features/defi/providers/fox-eth-lp/components/FoxEthLpManager/Deposit/components/Approve.tsx
@@ -9,7 +9,7 @@ import { FOX_TOKEN_CONTRACT_ADDRESS } from 'plugins/foxPage/const'
 import { useContext } from 'react'
 import { useTranslate } from 'react-polyglot'
 import { useWallet } from 'hooks/useWallet/useWallet'
-import { bnOrZero } from 'lib/bignumber/bignumber'
+import { bn, bnOrZero } from 'lib/bignumber/bignumber'
 import { logger } from 'lib/logger'
 import { poll } from 'lib/poll/poll'
 import { selectAssetById, selectMarketDataById } from 'state/slices/selectors'
@@ -53,7 +53,7 @@ export const Approve: React.FC<FoxEthLpApproveProps> = ({ onNext }) => {
       await poll({
         fn: () => allowance(),
         validate: (result: string) => {
-          const allowance = bnOrZero(result).div(`1e+${foxAsset.precision}`)
+          const allowance = bnOrZero(result).div(bn(10).pow(foxAsset.precision))
           return bnOrZero(allowance).gte(bnOrZero(state.deposit.foxCryptoAmount))
         },
         interval: 15000,
@@ -66,7 +66,7 @@ export const Approve: React.FC<FoxEthLpApproveProps> = ({ onNext }) => {
       )
       if (!gasData) return
       const estimatedGasCrypto = bnOrZero(gasData.average.txFee)
-        .div(`1e${feeAsset.precision}`)
+        .div(bn(10).pow(feeAsset.precision))
         .toPrecision()
       dispatch({
         type: FoxEthLpDepositActionType.SET_DEPOSIT,

--- a/src/features/defi/providers/fox-eth-lp/components/FoxEthLpManager/Deposit/components/Deposit.tsx
+++ b/src/features/defi/providers/fox-eth-lp/components/FoxEthLpManager/Deposit/components/Deposit.tsx
@@ -15,7 +15,7 @@ import { useTranslate } from 'react-polyglot'
 import { useHistory } from 'react-router-dom'
 import { StepComponentProps } from 'components/DeFi/components/Steps'
 import { useBrowserRouter } from 'hooks/useBrowserRouter/useBrowserRouter'
-import { bnOrZero } from 'lib/bignumber/bignumber'
+import { bn, bnOrZero } from 'lib/bignumber/bignumber'
 import { logger } from 'lib/logger'
 import {
   selectAssetById,
@@ -63,7 +63,7 @@ export const Deposit: React.FC<StepComponentProps> = ({ onNext }) => {
     try {
       const gasData = await getDepositGasData(deposit.cryptoAmount1, deposit.cryptoAmount2)
       if (!gasData) return
-      return bnOrZero(gasData.average.txFee).div(`1e${ethAsset.precision}`).toPrecision()
+      return bnOrZero(gasData.average.txFee).div(bn(10).pow(ethAsset.precision)).toPrecision()
     } catch (error) {
       moduleLogger.error(
         { fn: 'getDepositGasEstimate', error },
@@ -94,7 +94,7 @@ export const Deposit: React.FC<StepComponentProps> = ({ onNext }) => {
     try {
       // Check if approval is required for user address
       const lpAllowance = await allowance()
-      const allowanceAmount = bnOrZero(lpAllowance).div(`1e+${foxAsset.precision}`)
+      const allowanceAmount = bnOrZero(lpAllowance).div(bn(10).pow(foxAsset.precision))
 
       // Skip approval step if user allowance is greater than or equal requested deposit amount
       if (allowanceAmount.gte(bnOrZero(formValues.cryptoAmount1))) {
@@ -113,7 +113,7 @@ export const Deposit: React.FC<StepComponentProps> = ({ onNext }) => {
           type: FoxEthLpDepositActionType.SET_APPROVE,
           payload: {
             estimatedGasCrypto: bnOrZero(estimatedGasCrypto.average.txFee)
-              .div(`1e${ethAsset.precision}`)
+              .div(bn(10).pow(ethAsset.precision))
               .toPrecision(),
           },
         })
@@ -157,9 +157,9 @@ export const Deposit: React.FC<StepComponentProps> = ({ onNext }) => {
     return hasValidBalance || 'common.insufficientFunds'
   }
 
-  const foxCryptoAmountAvailable = bnOrZero(foxBalance).div(`1e${foxAsset.precision}`)
+  const foxCryptoAmountAvailable = bnOrZero(foxBalance).div(bn(10).pow(foxAsset.precision))
   const foxFiatAmountAvailable = bnOrZero(foxCryptoAmountAvailable).times(foxMarketData.price)
-  const ethCryptoAmountAvailable = bnOrZero(ethBalance).div(`1e${ethAsset.precision}`)
+  const ethCryptoAmountAvailable = bnOrZero(ethBalance).div(bn(10).pow(ethAsset.precision))
   const ethFiatAmountAvailable = bnOrZero(ethCryptoAmountAvailable).times(ethMarketData.price)
 
   const handleBack = () => {

--- a/src/features/defi/providers/fox-eth-lp/components/FoxEthLpManager/Withdraw/components/Approve.tsx
+++ b/src/features/defi/providers/fox-eth-lp/components/FoxEthLpManager/Withdraw/components/Approve.tsx
@@ -11,7 +11,7 @@ import { useFoxEthLiquidityPool } from 'features/defi/providers/fox-eth-lp/hooks
 import { useContext } from 'react'
 import { useTranslate } from 'react-polyglot'
 import { useWallet } from 'hooks/useWallet/useWallet'
-import { bnOrZero } from 'lib/bignumber/bignumber'
+import { bn, bnOrZero } from 'lib/bignumber/bignumber'
 import { logger } from 'lib/logger'
 import { poll } from 'lib/poll/poll'
 import { selectAssetById, selectMarketDataById } from 'state/slices/selectors'
@@ -55,7 +55,7 @@ export const Approve: React.FC<FoxEthLpApproveProps> = ({ onNext }) => {
       await poll({
         fn: () => allowance(true),
         validate: (result: string) => {
-          const allowance = bnOrZero(result).div(`1e+${foxAsset.precision}`)
+          const allowance = bnOrZero(result).div(bn(10).pow(foxAsset.precision))
           return bnOrZero(allowance).gte(bnOrZero(state.withdraw.lpAmount))
         },
         interval: 15000,
@@ -69,7 +69,7 @@ export const Approve: React.FC<FoxEthLpApproveProps> = ({ onNext }) => {
       )
       if (!gasData) return
       const estimatedGasCrypto = bnOrZero(gasData.average.txFee)
-        .div(`1e${feeAsset.precision}`)
+        .div(bn(10).pow(feeAsset.precision))
         .toPrecision()
       dispatch({
         type: FoxEthLpWithdrawActionType.SET_WITHDRAW,

--- a/src/features/defi/providers/fox-eth-lp/components/FoxEthLpManager/Withdraw/components/Withdraw.tsx
+++ b/src/features/defi/providers/fox-eth-lp/components/FoxEthLpManager/Withdraw/components/Withdraw.tsx
@@ -61,7 +61,7 @@ export const Withdraw: React.FC<StepComponentProps> = ({ onNext }) => {
   const balance = useAppSelector(state =>
     selectPortfolioCryptoBalanceByAssetId(state, { assetId: opportunity.assetId }),
   )
-  const cryptoAmountAvailable = bnOrZero(balance).div(bn(10).pow(asset.precision))
+  const cryptoAmountAvailable = bnOrZero(balance).div(bn(10).pow(asset?.precision))
 
   if (!state || !dispatch) return null
 

--- a/src/features/defi/providers/fox-eth-lp/components/FoxEthLpManager/Withdraw/components/Withdraw.tsx
+++ b/src/features/defi/providers/fox-eth-lp/components/FoxEthLpManager/Withdraw/components/Withdraw.tsx
@@ -18,7 +18,7 @@ import { StepComponentProps } from 'components/DeFi/components/Steps'
 import { Text } from 'components/Text'
 import { useFoxEth } from 'context/FoxEthProvider/FoxEthProvider'
 import { useBrowserRouter } from 'hooks/useBrowserRouter/useBrowserRouter'
-import { bnOrZero } from 'lib/bignumber/bignumber'
+import { bn, bnOrZero } from 'lib/bignumber/bignumber'
 import {
   selectAssetById,
   selectMarketDataById,
@@ -61,7 +61,7 @@ export const Withdraw: React.FC<StepComponentProps> = ({ onNext }) => {
   const balance = useAppSelector(state =>
     selectPortfolioCryptoBalanceByAssetId(state, { assetId: opportunity.assetId }),
   )
-  const cryptoAmountAvailable = bnOrZero(balance).div(`1e+${asset?.precision}`)
+  const cryptoAmountAvailable = bnOrZero(balance).div(bn(10).pow(asset.precision))
 
   if (!state || !dispatch) return null
 
@@ -69,7 +69,7 @@ export const Withdraw: React.FC<StepComponentProps> = ({ onNext }) => {
     try {
       const fee = await getWithdrawGasData(withdraw.cryptoAmount, foxAmount, ethAmount)
       if (!fee) return
-      return bnOrZero(fee.average.txFee).div(`1e${ethAsset.precision}`).toPrecision()
+      return bnOrZero(fee.average.txFee).div(bn(10).pow(ethAsset.precision)).toPrecision()
     } catch (error) {
       // TODO: handle client side errors maybe add a toast?
       console.error('FoxEthLpWithdraw:getWithdrawGasEstimate error:', error)
@@ -107,7 +107,7 @@ export const Withdraw: React.FC<StepComponentProps> = ({ onNext }) => {
         type: FoxEthLpWithdrawActionType.SET_APPROVE,
         payload: {
           estimatedGasCrypto: bnOrZero(estimatedGasCrypto.average.txFee)
-            .div(`1e${ethAsset.precision}`)
+            .div(bn(10).pow(ethAsset.precision))
             .toPrecision(),
         },
       })

--- a/src/features/defi/providers/fox-farming/components/FoxFarmingManager/Deposit/components/Approve.tsx
+++ b/src/features/defi/providers/fox-farming/components/FoxFarmingManager/Deposit/components/Approve.tsx
@@ -12,7 +12,7 @@ import { useContext } from 'react'
 import { useTranslate } from 'react-polyglot'
 import { useBrowserRouter } from 'hooks/useBrowserRouter/useBrowserRouter'
 import { useWallet } from 'hooks/useWallet/useWallet'
-import { bnOrZero } from 'lib/bignumber/bignumber'
+import { bn, bnOrZero } from 'lib/bignumber/bignumber'
 import { logger } from 'lib/logger'
 import { poll } from 'lib/poll/poll'
 import { selectAssetById, selectMarketDataById } from 'state/slices/selectors'
@@ -65,7 +65,7 @@ export const Approve: React.FC<FoxFarmingApproveProps> = ({ onNext }) => {
       await poll({
         fn: () => allowance(),
         validate: (result: string) => {
-          const allowance = bnOrZero(result).div(`1e+${asset.precision}`)
+          const allowance = bnOrZero(result).div(bn(10).pow(asset.precision))
           return bnOrZero(allowance).gte(bnOrZero(state.deposit.cryptoAmount))
         },
         interval: 15000,
@@ -75,7 +75,7 @@ export const Approve: React.FC<FoxFarmingApproveProps> = ({ onNext }) => {
       const gasData = await getStakeGasData(state.deposit.cryptoAmount)
       if (!gasData) return
       const estimatedGasCrypto = bnOrZero(gasData.average.txFee)
-        .div(`1e${feeAsset.precision}`)
+        .div(bn(10).pow(feeAsset.precision))
         .toPrecision()
       dispatch({
         type: FoxFarmingDepositActionType.SET_DEPOSIT,

--- a/src/features/defi/providers/fox-farming/components/FoxFarmingManager/Deposit/components/Deposit.tsx
+++ b/src/features/defi/providers/fox-farming/components/FoxFarmingManager/Deposit/components/Deposit.tsx
@@ -16,7 +16,7 @@ import { useTranslate } from 'react-polyglot'
 import { useHistory } from 'react-router-dom'
 import { StepComponentProps } from 'components/DeFi/components/Steps'
 import { useBrowserRouter } from 'hooks/useBrowserRouter/useBrowserRouter'
-import { bnOrZero } from 'lib/bignumber/bignumber'
+import { bn, bnOrZero } from 'lib/bignumber/bignumber'
 import { logger } from 'lib/logger'
 import { selectAssetById, selectPortfolioCryptoBalanceByAssetId } from 'state/slices/selectors'
 import { useAppSelector } from 'state/store'
@@ -77,7 +77,7 @@ export const Deposit: React.FC<StepComponentProps> = ({ onNext }) => {
         try {
           const gasData = await getStakeGasData(deposit.cryptoAmount)
           if (!gasData) return
-          return bnOrZero(gasData.average.txFee).div(`1e${ethAsset.precision}`).toPrecision()
+          return bnOrZero(gasData.average.txFee).div(bn(10).pow(ethAsset.precision)).toPrecision()
         } catch (error) {
           moduleLogger.error(
             { fn: 'getDepositGasEstimate', error },
@@ -98,7 +98,7 @@ export const Deposit: React.FC<StepComponentProps> = ({ onNext }) => {
       try {
         // Check if approval is required for user address
         const _allowance = await foxFarmingAllowance()
-        const allowance = bnOrZero(_allowance).div(`1e+${asset.precision}`)
+        const allowance = bnOrZero(_allowance).div(bn(10).pow(asset.precision))
 
         // Skip approval step if user allowance is greater than or equal requested deposit amount
         if (allowance.gte(formValues.cryptoAmount)) {
@@ -117,7 +117,7 @@ export const Deposit: React.FC<StepComponentProps> = ({ onNext }) => {
             type: FoxFarmingDepositActionType.SET_APPROVE,
             payload: {
               estimatedGasCrypto: bnOrZero(estimatedGasCrypto.average.txFee)
-                .div(`1e${ethAsset.precision}`)
+                .div(bn(10).pow(ethAsset.precision))
                 .toPrecision(),
             },
           })
@@ -156,7 +156,7 @@ export const Deposit: React.FC<StepComponentProps> = ({ onNext }) => {
   const handleCancel = browserHistory.goBack
 
   const validateCryptoAmount = (value: string) => {
-    const crypto = bnOrZero(balance).div(`1e+${asset.precision}`)
+    const crypto = bnOrZero(balance).div(bn(10).pow(asset.precision))
     const _value = bnOrZero(value)
     const hasValidBalance = crypto.gt(0) && _value.gt(0) && crypto.gte(value)
     if (_value.isEqualTo(0)) return ''
@@ -164,7 +164,7 @@ export const Deposit: React.FC<StepComponentProps> = ({ onNext }) => {
   }
 
   const validateFiatAmount = (value: string) => {
-    const crypto = bnOrZero(balance).div(`1e+${asset.precision}`)
+    const crypto = bnOrZero(balance).div(bn(10).pow(asset.precision))
     const fiat = crypto.times(marketData.price)
     const _value = bnOrZero(value)
     const hasValidBalance = fiat.gt(0) && _value.gt(0) && fiat.gte(value)
@@ -172,7 +172,7 @@ export const Deposit: React.FC<StepComponentProps> = ({ onNext }) => {
     return hasValidBalance || 'common.insufficientFunds'
   }
 
-  const cryptoAmountAvailable = bnOrZero(balance).div(`1e${asset.precision}`)
+  const cryptoAmountAvailable = bnOrZero(balance).div(bn(10).pow(asset.precision))
   const fiatAmountAvailable = bnOrZero(cryptoAmountAvailable).times(marketData.price)
 
   const handleBack = () => {

--- a/src/features/defi/providers/fox-farming/components/FoxFarmingManager/Withdraw/components/Approve.tsx
+++ b/src/features/defi/providers/fox-farming/components/FoxFarmingManager/Withdraw/components/Approve.tsx
@@ -14,7 +14,7 @@ import { useTranslate } from 'react-polyglot'
 import { StepComponentProps } from 'components/DeFi/components/Steps'
 import { useBrowserRouter } from 'hooks/useBrowserRouter/useBrowserRouter'
 import { useWallet } from 'hooks/useWallet/useWallet'
-import { bnOrZero } from 'lib/bignumber/bignumber'
+import { bn, bnOrZero } from 'lib/bignumber/bignumber'
 import { logger } from 'lib/logger'
 import { poll } from 'lib/poll/poll'
 import { selectAssetById, selectMarketDataById } from 'state/slices/selectors'
@@ -69,7 +69,7 @@ export const Approve = ({ onNext }: StepComponentProps) => {
       await poll({
         fn: () => allowance(),
         validate: (result: string) => {
-          const allowance = bnOrZero(result).div(`1e+${asset.precision}`)
+          const allowance = bnOrZero(result).div(bn(10).pow(asset.precision))
           return bnOrZero(allowance).gte(bnOrZero(state.withdraw.lpAmount))
         },
         interval: 15000,
@@ -79,7 +79,7 @@ export const Approve = ({ onNext }: StepComponentProps) => {
       const gasData = await getUnstakeGasData(state.withdraw.lpAmount, state.withdraw.isExiting)
       if (!gasData) return
       const estimatedGasCrypto = bnOrZero(gasData.average.txFee)
-        .div(`1e${feeAsset.precision}`)
+        .div(bn(10).pow(feeAsset.precision))
         .toPrecision()
       dispatch({
         type: FoxFarmingWithdrawActionType.SET_WITHDRAW,

--- a/src/features/defi/providers/fox-farming/components/FoxFarmingManager/Withdraw/components/Withdraw.tsx
+++ b/src/features/defi/providers/fox-farming/components/FoxFarmingManager/Withdraw/components/Withdraw.tsx
@@ -14,7 +14,7 @@ import { useContext, useState } from 'react'
 import { FormProvider, useForm } from 'react-hook-form'
 import { StepComponentProps } from 'components/DeFi/components/Steps'
 import { useBrowserRouter } from 'hooks/useBrowserRouter/useBrowserRouter'
-import { bnOrZero } from 'lib/bignumber/bignumber'
+import { bn, bnOrZero } from 'lib/bignumber/bignumber'
 import { selectAssetById } from 'state/slices/selectors'
 import { useAppSelector } from 'state/store'
 
@@ -45,7 +45,7 @@ export const Withdraw: React.FC<StepComponentProps> = ({ onNext }) => {
     try {
       const fee = await getUnstakeGasData(withdraw.cryptoAmount, isExiting)
       if (!fee) return
-      return bnOrZero(fee.average.txFee).div(`1e${ethAsset.precision}`).toPrecision()
+      return bnOrZero(fee.average.txFee).div(bn(10).pow(ethAsset.precision)).toPrecision()
     } catch (error) {
       // TODO: handle client side errors maybe add a toast?
       console.error('FoxFarmingWithdraw:getWithdrawGasEstimate error:', error)
@@ -61,9 +61,9 @@ export const Withdraw: React.FC<StepComponentProps> = ({ onNext }) => {
       payload: { lpAmount: formValues.cryptoAmount, isExiting },
     })
     const lpAllowance = await allowance()
-    const allowanceAmount = bnOrZero(lpAllowance).div(`1e+${asset.precision}`)
+    const allowanceAmount = bnOrZero(lpAllowance).div(bn(10).pow(asset.precision))
 
-    // Skip approval step if user allowance is greater than requested deposit amount
+    // Skip approval step if user allowance is greater than or equal requested deposit amount
     if (allowanceAmount.gte(bnOrZero(formValues.cryptoAmount))) {
       const estimatedGasCrypto = await getWithdrawGasEstimate(formValues)
       if (!estimatedGasCrypto) {
@@ -83,7 +83,7 @@ export const Withdraw: React.FC<StepComponentProps> = ({ onNext }) => {
         type: FoxFarmingWithdrawActionType.SET_APPROVE,
         payload: {
           estimatedGasCrypto: bnOrZero(estimatedGasCrypto.average.txFee)
-            .div(`1e${ethAsset.precision}`)
+            .div(bn(10).pow(asset.precision))
             .toPrecision(),
         },
       })

--- a/src/features/defi/providers/fox-farming/components/FoxFarmingManager/Withdraw/components/Withdraw.tsx
+++ b/src/features/defi/providers/fox-farming/components/FoxFarmingManager/Withdraw/components/Withdraw.tsx
@@ -83,7 +83,7 @@ export const Withdraw: React.FC<StepComponentProps> = ({ onNext }) => {
         type: FoxFarmingWithdrawActionType.SET_APPROVE,
         payload: {
           estimatedGasCrypto: bnOrZero(estimatedGasCrypto.average.txFee)
-            .div(bn(10).pow(asset.precision))
+            .div(bn(10).pow(ethAsset.precision))
             .toPrecision(),
         },
       })

--- a/src/features/defi/providers/foxy/components/FoxyManager/Deposit/components/Approve.tsx
+++ b/src/features/defi/providers/foxy/components/FoxyManager/Deposit/components/Approve.tsx
@@ -15,7 +15,7 @@ import { useHistory } from 'react-router-dom'
 import { StepComponentProps } from 'components/DeFi/components/Steps'
 import { useBrowserRouter } from 'hooks/useBrowserRouter/useBrowserRouter'
 import { useWallet } from 'hooks/useWallet/useWallet'
-import { bnOrZero } from 'lib/bignumber/bignumber'
+import { bn, bnOrZero } from 'lib/bignumber/bignumber'
 import { logger } from 'lib/logger'
 import { poll } from 'lib/poll/poll'
 import { selectAssetById, selectMarketDataById } from 'state/slices/selectors'
@@ -100,7 +100,7 @@ export const Approve: React.FC<StepComponentProps> = ({ onNext }) => {
             userAddress: state.userAddress!,
           }),
         validate: (result: string) => {
-          const allowance = bnOrZero(result).div(`1e+${asset.precision}`)
+          const allowance = bnOrZero(result).div(bn(10).pow(asset.precision))
           return bnOrZero(allowance).gte(state.deposit.cryptoAmount)
         },
         interval: 15000,
@@ -133,11 +133,11 @@ export const Approve: React.FC<StepComponentProps> = ({ onNext }) => {
       asset={asset}
       feeAsset={feeAsset}
       cryptoEstimatedGasFee={bnOrZero(state.approve.estimatedGasCrypto)
-        .div(`1e+${feeAsset.precision}`)
+        .div(bn(10).pow(feeAsset.precision))
         .toFixed(5)}
       disableAction
       fiatEstimatedGasFee={bnOrZero(state.approve.estimatedGasCrypto)
-        .div(`1e+${feeAsset.precision}`)
+        .div(bn(10).pow(feeAsset.precision))
         .times(feeMarketData.price)
         .toFixed(2)}
       loading={state.loading}

--- a/src/features/defi/providers/foxy/components/FoxyManager/Deposit/components/Deposit.tsx
+++ b/src/features/defi/providers/foxy/components/FoxyManager/Deposit/components/Deposit.tsx
@@ -12,7 +12,7 @@ import { useTranslate } from 'react-polyglot'
 import { useHistory } from 'react-router-dom'
 import { StepComponentProps } from 'components/DeFi/components/Steps'
 import { useBrowserRouter } from 'hooks/useBrowserRouter/useBrowserRouter'
-import { BigNumber, bnOrZero } from 'lib/bignumber/bignumber'
+import { BigNumber, bn, bnOrZero } from 'lib/bignumber/bignumber'
 import { logger } from 'lib/logger'
 import {
   selectAssetById,
@@ -116,7 +116,7 @@ export const Deposit: React.FC<StepComponentProps> = ({ onNext }) => {
           contractAddress,
           userAddress: state.userAddress,
         })
-        const allowance = bnOrZero(_allowance).div(`1e+${asset.precision}`)
+        const allowance = bnOrZero(_allowance).div(bn(10).pow(asset.precision))
 
         // Skip approval step if user allowance is greater than or equal requested deposit amount
         if (allowance.gte(formValues.cryptoAmount)) {
@@ -167,7 +167,7 @@ export const Deposit: React.FC<StepComponentProps> = ({ onNext }) => {
   const handleCancel = history.goBack
 
   const validateCryptoAmount = (value: string) => {
-    const crypto = bnOrZero(balance).div(`1e+${asset.precision}`)
+    const crypto = bnOrZero(balance).div(bn(10).pow(asset.precision))
     const _value = bnOrZero(value)
     const hasValidBalance = crypto.gt(0) && _value.gt(0) && crypto.gte(value)
     if (_value.isEqualTo(0)) return ''
@@ -175,7 +175,7 @@ export const Deposit: React.FC<StepComponentProps> = ({ onNext }) => {
   }
 
   const validateFiatAmount = (value: string) => {
-    const crypto = bnOrZero(balance).div(`1e+${asset.precision}`)
+    const crypto = bnOrZero(balance).div(bn(10).pow(asset.precision))
     const fiat = crypto.times(marketData.price)
     const _value = bnOrZero(value)
     const hasValidBalance = fiat.gt(0) && _value.gt(0) && fiat.gte(value)
@@ -183,7 +183,7 @@ export const Deposit: React.FC<StepComponentProps> = ({ onNext }) => {
     return hasValidBalance || 'common.insufficientFunds'
   }
 
-  const cryptoAmountAvailable = bnOrZero(balance).div(`1e${asset.precision}`)
+  const cryptoAmountAvailable = bnOrZero(balance).div(bn(10).pow(asset.precision))
   const fiatAmountAvailable = bnOrZero(cryptoAmountAvailable).times(marketData.price)
 
   return (

--- a/src/features/defi/providers/foxy/components/FoxyManager/Withdraw/components/Approve.tsx
+++ b/src/features/defi/providers/foxy/components/FoxyManager/Withdraw/components/Approve.tsx
@@ -107,7 +107,7 @@ export const Approve = ({ onNext }: StepComponentProps) => {
             userAddress: state.userAddress!,
           }),
         validate: (result: string) => {
-          const allowance = bnOrZero(bn(result).div(`1e+${asset.precision}`))
+          const allowance = bnOrZero(bn(result).div(bn(10).pow(asset.precision)))
           return bnOrZero(allowance).gte(state.withdraw.cryptoAmount)
         },
         interval: 15000,
@@ -139,11 +139,11 @@ export const Approve = ({ onNext }: StepComponentProps) => {
       asset={asset}
       feeAsset={feeAsset}
       cryptoEstimatedGasFee={bnOrZero(state.approve.estimatedGasCrypto)
-        .div(`1e+${feeAsset.precision}`)
+        .div(bn(10).pow(feeAsset.precision))
         .toFixed(5)}
       disableAction
       fiatEstimatedGasFee={bnOrZero(state.approve.estimatedGasCrypto)
-        .div(`1e+${feeAsset.precision}`)
+        .div(bn(10).pow(feeAsset.precision))
         .times(feeMarketData.price)
         .toFixed(2)}
       loading={state.loading}

--- a/src/features/defi/providers/foxy/components/FoxyManager/Withdraw/components/Withdraw.tsx
+++ b/src/features/defi/providers/foxy/components/FoxyManager/Withdraw/components/Withdraw.tsx
@@ -70,7 +70,7 @@ export const Withdraw: React.FC<StepComponentProps> = ({ onNext }) => {
   // user info
   const balance = useAppSelector(state => selectPortfolioCryptoBalanceByAssetId(state, { assetId }))
 
-  const cryptoAmountAvailable = bnOrZero(bn(balance).div(`1e+${asset?.precision}`))
+  const cryptoAmountAvailable = bnOrZero(bn(balance).div(bn(10).pow(asset.precision)))
   const fiatAmountAvailable = bnOrZero(bn(cryptoAmountAvailable).times(bnOrZero(marketData?.price)))
 
   const handlePercentClick = useCallback(
@@ -169,7 +169,7 @@ export const Withdraw: React.FC<StepComponentProps> = ({ onNext }) => {
           userAddress: state.userAddress,
         })
 
-        const allowance = bnOrZero(bn(_allowance).div(`1e+${asset.precision}`))
+        const allowance = bnOrZero(bn(_allowance).div(bn(10).pow(asset.precision)))
 
         // Skip approval step if user allowance is greater than or equal requested deposit amount
         if (allowance.gte(formValues.cryptoAmount)) {
@@ -229,7 +229,7 @@ export const Withdraw: React.FC<StepComponentProps> = ({ onNext }) => {
   }
 
   const validateCryptoAmount = (value: string) => {
-    const crypto = bnOrZero(bn(balance).div(`1e+${asset.precision}`))
+    const crypto = bnOrZero(bn(balance).div(bn(10).pow(asset.precision)))
     const _value = bnOrZero(value)
     const hasValidBalance = crypto.gt(0) && _value.gt(0) && crypto.gte(value)
     if (_value.isEqualTo(0)) return ''
@@ -237,7 +237,7 @@ export const Withdraw: React.FC<StepComponentProps> = ({ onNext }) => {
   }
 
   const validateFiatAmount = (value: string) => {
-    const crypto = bnOrZero(bn(balance).div(`1e+${asset.precision}`))
+    const crypto = bnOrZero(bn(balance).div(bn(10).pow(asset.precision)))
     const fiat = crypto.times(bnOrZero(marketData?.price))
     const _value = bnOrZero(value)
     const hasValidBalance = fiat.gt(0) && _value.gt(0) && fiat.gte(value)

--- a/src/features/defi/providers/foxy/components/FoxyManager/Withdraw/components/Withdraw.tsx
+++ b/src/features/defi/providers/foxy/components/FoxyManager/Withdraw/components/Withdraw.tsx
@@ -70,7 +70,7 @@ export const Withdraw: React.FC<StepComponentProps> = ({ onNext }) => {
   // user info
   const balance = useAppSelector(state => selectPortfolioCryptoBalanceByAssetId(state, { assetId }))
 
-  const cryptoAmountAvailable = bnOrZero(bn(balance).div(bn(10).pow(asset.precision)))
+  const cryptoAmountAvailable = bnOrZero(bn(balance).div(bn(10).pow(asset?.precision)))
   const fiatAmountAvailable = bnOrZero(bn(cryptoAmountAvailable).times(bnOrZero(marketData?.price)))
 
   const handlePercentClick = useCallback(

--- a/src/features/defi/providers/yearn/components/YearnManager/Deposit/components/Approve.tsx
+++ b/src/features/defi/providers/yearn/components/YearnManager/Deposit/components/Approve.tsx
@@ -14,7 +14,7 @@ import { useContext } from 'react'
 import { useTranslate } from 'react-polyglot'
 import { useBrowserRouter } from 'hooks/useBrowserRouter/useBrowserRouter'
 import { useWallet } from 'hooks/useWallet/useWallet'
-import { bnOrZero } from 'lib/bignumber/bignumber'
+import { bn, bnOrZero } from 'lib/bignumber/bignumber'
 import { logger } from 'lib/logger'
 import { poll } from 'lib/poll/poll'
 import { selectAssetById, selectMarketDataById } from 'state/slices/selectors'
@@ -117,7 +117,7 @@ export const Approve: React.FC<YearnApproveProps> = ({ onNext }) => {
       await poll({
         fn: () => yearnOpportunity.allowance(address),
         validate: (result: string) => {
-          const allowance = bnOrZero(result).div(`1e+${asset.precision}`)
+          const allowance = bnOrZero(result).div(bn(10).pow(asset.precision))
           return bnOrZero(allowance).gte(state.deposit.cryptoAmount)
         },
         interval: 15000,
@@ -150,11 +150,11 @@ export const Approve: React.FC<YearnApproveProps> = ({ onNext }) => {
       asset={asset}
       feeAsset={feeAsset}
       cryptoEstimatedGasFee={bnOrZero(state.approve.estimatedGasCrypto)
-        .div(`1e+${feeAsset.precision}`)
+        .div(bn(10).pow(feeAsset.precision))
         .toFixed(5)}
       disableAction
       fiatEstimatedGasFee={bnOrZero(state.approve.estimatedGasCrypto)
-        .div(`1e+${feeAsset.precision}`)
+        .div(bn(10).pow(feeAsset.precision))
         .times(feeMarketData.price)
         .toFixed(2)}
       loading={state.loading}

--- a/src/features/defi/providers/yearn/components/YearnManager/Deposit/components/Deposit.tsx
+++ b/src/features/defi/providers/yearn/components/YearnManager/Deposit/components/Deposit.tsx
@@ -14,7 +14,7 @@ import { useTranslate } from 'react-polyglot'
 import { useHistory } from 'react-router-dom'
 import { StepComponentProps } from 'components/DeFi/components/Steps'
 import { useBrowserRouter } from 'hooks/useBrowserRouter/useBrowserRouter'
-import { bnOrZero } from 'lib/bignumber/bignumber'
+import { bn, bnOrZero } from 'lib/bignumber/bignumber'
 import { logger } from 'lib/logger'
 import {
   selectAssetById,
@@ -118,7 +118,7 @@ export const Deposit: React.FC<StepComponentProps> = ({ onNext }) => {
         )
         if (!yearnOpportunity) throw new Error('No opportunity')
         const _allowance = await yearnOpportunity.allowance(state.userAddress)
-        const allowance = bnOrZero(_allowance).div(`1e+${asset.precision}`)
+        const allowance = bnOrZero(_allowance).div(bn(10).pow(asset.precision))
 
         // Skip approval step if user allowance is greater than or equal requested deposit amount
         if (allowance.gte(formValues.cryptoAmount)) {
@@ -169,7 +169,7 @@ export const Deposit: React.FC<StepComponentProps> = ({ onNext }) => {
   const handleCancel = browserHistory.goBack
 
   const validateCryptoAmount = (value: string) => {
-    const crypto = bnOrZero(balance).div(`1e+${asset.precision}`)
+    const crypto = bnOrZero(balance).div(bn(10).pow(asset.precision))
     const _value = bnOrZero(value)
     const hasValidBalance = crypto.gt(0) && _value.gt(0) && crypto.gte(value)
     if (_value.isEqualTo(0)) return ''
@@ -177,7 +177,7 @@ export const Deposit: React.FC<StepComponentProps> = ({ onNext }) => {
   }
 
   const validateFiatAmount = (value: string) => {
-    const crypto = bnOrZero(balance).div(`1e+${asset.precision}`)
+    const crypto = bnOrZero(balance).div(bn(10).pow(asset.precision))
     const fiat = crypto.times(marketData.price)
     const _value = bnOrZero(value)
     const hasValidBalance = fiat.gt(0) && _value.gt(0) && fiat.gte(value)
@@ -185,7 +185,7 @@ export const Deposit: React.FC<StepComponentProps> = ({ onNext }) => {
     return hasValidBalance || 'common.insufficientFunds'
   }
 
-  const cryptoAmountAvailable = bnOrZero(balance).div(`1e${asset.precision}`)
+  const cryptoAmountAvailable = bnOrZero(balance).div(bn(10).pow(asset.precision))
   const fiatAmountAvailable = bnOrZero(cryptoAmountAvailable).times(marketData.price)
 
   const handleBack = () => {


### PR DESCRIPTION
## Description

Some housekeeping done while working on the original PR (https://github.com/shapeshift/web/pull/2473) - as a separate PR to keep things atomic.

## Notice

<!-- Before submitting a pull request, please make sure you have answered the following: -->

- [x] Have you followed the guidelines in our [Contributing]('https://github.com/shapeshift/web/CONTRIBUTING.md) guide?
- [x] Have you checked to ensure there aren't other open [Pull Requests](https://github.com/shapeshift/web/pulls) for the same update/change?

## Pull Request Type

- [ ] :bug: Bug fix (Non-breaking Change: Fixes an issue)
- [x] :hammer_and_wrench: Chore (Non-breaking Change: Doc updates, pkg upgrades, typos, etc..)
- [ ] :nail_care: New Feature (Breaking/Non-breaking Change)

## Issue (if applicable)

- Related to https://github.com/shapeshift/web/issues/2461
- Related to https://github.com/shapeshift/web/issues/2434

## Risk

None, double check that the hunks are correct. The diff might look a bit off in some places because of git shenanigans and manual hunk edits, but if you patch this diff in your editor of choice (and most likely after restack/rebase), it will look good.

## Testing

- CI is happy
- DeFi opportunities are happy (tested as part of https://github.com/shapeshift/web/pull/2473)

## Screenshots (if applicable)
