### PR TITLE
fix: set isDemoWallet to false on wallet connect

### DIFF
--- a/src/context/WalletProvider/KeepKey/components/Connect.tsx
+++ b/src/context/WalletProvider/KeepKey/components/Connect.tsx
@@ -88,6 +88,7 @@ export const KeepKeyConnect = () => {
           type: WalletActions.SET_WALLET,
           payload: { wallet, name: label, icon, deviceId, meta: { label } },
         })
+        dispatch({ type: WalletActions.SET_IS_DEMO_WALLET, payload: false })
         dispatch({ type: WalletActions.SET_IS_CONNECTED, payload: true })
         /**
          * The real deviceId of KeepKey wallet could be different from the

--- a/src/context/WalletProvider/KeepKey/hooks/useKeepKeyEventHandler.ts
+++ b/src/context/WalletProvider/KeepKey/hooks/useKeepKeyEventHandler.ts
@@ -199,6 +199,7 @@ export const useKeepKeyEventHandler = (
               icon: state.walletInfo.icon, // We're reconnecting the same wallet so we can reuse the walletInfo
             },
           })
+          dispatch({ type: WalletActions.SET_IS_DEMO_WALLET, payload: false })
           dispatch({ type: WalletActions.SET_IS_CONNECTED, payload: true })
         }
       } catch (e) {

--- a/src/context/WalletProvider/Keplr/components/Connect.tsx
+++ b/src/context/WalletProvider/Keplr/components/Connect.tsx
@@ -49,6 +49,7 @@ export const KeplrConnect = ({ history }: KeplrSetupProps) => {
           type: WalletActions.SET_WALLET,
           payload: { wallet, name, icon, deviceId },
         })
+        dispatch({ type: WalletActions.SET_IS_DEMO_WALLET, payload: false })
         dispatch({ type: WalletActions.SET_IS_CONNECTED, payload: true })
         setLocalWalletTypeAndDeviceId(KeyManager.Keplr, deviceId)
         dispatch({ type: WalletActions.SET_WALLET_MODAL, payload: false })

--- a/src/context/WalletProvider/MetaMask/components/Connect.tsx
+++ b/src/context/WalletProvider/MetaMask/components/Connect.tsx
@@ -85,6 +85,7 @@ export const MetaMaskConnect = ({ history }: MetaMaskSetupProps) => {
           type: WalletActions.SET_WALLET,
           payload: { wallet, name, icon, deviceId },
         })
+        dispatch({ type: WalletActions.SET_IS_DEMO_WALLET, payload: false })
         dispatch({ type: WalletActions.SET_IS_CONNECTED, payload: true })
         dispatch({ type: WalletActions.SET_IS_LOCKED, payload: isLocked })
         setLocalWalletTypeAndDeviceId(KeyManager.MetaMask, deviceId)

--- a/src/context/WalletProvider/NativeWallet/components/EnterPassword.tsx
+++ b/src/context/WalletProvider/NativeWallet/components/EnterPassword.tsx
@@ -63,6 +63,7 @@ export const EnterPassword = () => {
           meta: { label: vault.meta.get('name') as string },
         },
       })
+      dispatch({ type: WalletActions.SET_IS_DEMO_WALLET, payload: false })
       dispatch({ type: WalletActions.SET_IS_CONNECTED, payload: true })
       dispatch({ type: WalletActions.SET_LOCAL_WALLET_LOADING, payload: false })
       dispatch({ type: WalletActions.SET_WALLET_MODAL, payload: false })

--- a/src/context/WalletProvider/NativeWallet/components/NativeLoad.tsx
+++ b/src/context/WalletProvider/NativeWallet/components/NativeLoad.tsx
@@ -85,6 +85,7 @@ export const NativeLoad = ({ history }: RouteComponentProps) => {
             type: WalletActions.SET_WALLET,
             payload: { wallet, name, icon, deviceId, meta: { label: item.name } },
           })
+          dispatch({ type: WalletActions.SET_IS_DEMO_WALLET, payload: false })
           dispatch({ type: WalletActions.SET_IS_CONNECTED, payload: true })
           // The wallet is already initialized so we can close the modal
           dispatch({ type: WalletActions.SET_WALLET_MODAL, payload: false })

--- a/src/context/WalletProvider/NativeWallet/hooks/useNativeSuccess.ts
+++ b/src/context/WalletProvider/NativeWallet/hooks/useNativeSuccess.ts
@@ -45,6 +45,7 @@ export const useNativeSuccess = ({ vault }: UseNativeSuccessPropTypes) => {
             meta: { label: walletLabel },
           },
         })
+        dispatch({ type: WalletActions.SET_IS_DEMO_WALLET, payload: false })
         dispatch({ type: WalletActions.SET_IS_CONNECTED, payload: true })
         dispatch({ type: WalletActions.SET_WALLET_MODAL, payload: false })
         setLocalWalletTypeAndDeviceId(KeyManager.Native, deviceId)

--- a/src/context/WalletProvider/Portis/components/Connect.tsx
+++ b/src/context/WalletProvider/Portis/components/Connect.tsx
@@ -42,6 +42,7 @@ export const PortisConnect = ({ history }: PortisSetupProps) => {
           type: WalletActions.SET_WALLET,
           payload: { wallet, name, icon, deviceId: 'test' },
         })
+        dispatch({ type: WalletActions.SET_IS_DEMO_WALLET, payload: false })
         dispatch({ type: WalletActions.SET_IS_CONNECTED, payload: true })
         setLocalWalletTypeAndDeviceId(KeyManager.Portis, 'test')
         dispatch({ type: WalletActions.SET_WALLET_MODAL, payload: false })

--- a/src/context/WalletProvider/TallyHo/components/Connect.tsx
+++ b/src/context/WalletProvider/TallyHo/components/Connect.tsx
@@ -96,6 +96,7 @@ export const TallyHoConnect = ({ history }: TallyHoSetupProps) => {
           type: WalletActions.SET_WALLET,
           payload: { wallet, name, icon, deviceId },
         })
+        dispatch({ type: WalletActions.SET_IS_DEMO_WALLET, payload: false })
         dispatch({ type: WalletActions.SET_IS_CONNECTED, payload: true })
         setLocalWalletTypeAndDeviceId(KeyManager.TallyHo, deviceId)
         dispatch({ type: WalletActions.SET_WALLET_MODAL, payload: false })

--- a/src/context/WalletProvider/WalletConnect/components/Connect.tsx
+++ b/src/context/WalletProvider/WalletConnect/components/Connect.tsx
@@ -79,6 +79,7 @@ export const WalletConnectConnect = ({ history }: WalletConnectSetupProps) => {
           type: WalletActions.SET_WALLET,
           payload: { wallet, name, icon, deviceId },
         })
+        dispatch({ type: WalletActions.SET_IS_DEMO_WALLET, payload: false })
         dispatch({ type: WalletActions.SET_IS_CONNECTED, payload: true })
         setLocalWalletTypeAndDeviceId(KeyManager.WalletConnect, deviceId)
         dispatch({ type: WalletActions.SET_WALLET_MODAL, payload: false })

--- a/src/context/WalletProvider/XDEFI/components/Connect.tsx
+++ b/src/context/WalletProvider/XDEFI/components/Connect.tsx
@@ -75,6 +75,7 @@ export const XDEFIConnect = ({ history }: XDEFISetupProps) => {
           type: WalletActions.SET_WALLET,
           payload: { wallet, name, icon, deviceId },
         })
+        dispatch({ type: WalletActions.SET_IS_DEMO_WALLET, payload: false })
         dispatch({ type: WalletActions.SET_IS_CONNECTED, payload: true })
         setLocalWalletTypeAndDeviceId(KeyManager.XDefi, deviceId)
         dispatch({ type: WalletActions.SET_WALLET_MODAL, payload: false })


### PR DESCRIPTION
## Description

This properly sets `isDemoWallet` to false on wallet connect - making sure we avoid:

- the demo wallet banner hanging after wallet connection
- potentially other unwanted side effects from `isDemoWallet` staying set on wallet connect

## Notice

<!-- Before submitting a pull request, please make sure you have answered the following: -->

- [x] Have you followed the guidelines in our [Contributing]('https://github.com/shapeshift/web/CONTRIBUTING.md) guide?
- [x] Have you checked to ensure there aren't other open [Pull Requests](https://github.com/shapeshift/web/pulls) for the same update/change?

## Pull Request Type

- [x] :bug: Bug fix (Non-breaking Change: Fixes an issue)
- [ ] :hammer_and_wrench: Chore (Non-breaking Change: Doc updates, pkg upgrades, typos, etc..)
- [ ] :nail_care: New Feature (Breaking/Non-breaking Change)

## Issue (if applicable)

closes https://github.com/shapeshift/web/issues/2480

## Risk

N/A

## Testing

- Connect to demo wallet
- Open the wallet selection modal and connect any of our supported wallets
- The demo banner should disappear after connecting a wallet

## Screenshots (if applicable)
