### PR TITLE
fix: add inset top for mobile

### DIFF
--- a/src/components/Layout/Header/Header.tsx
+++ b/src/components/Layout/Header/Header.tsx
@@ -125,7 +125,7 @@ export const Header = () => {
       </Flex>
       <Drawer isOpen={isOpen} onClose={onClose} placement='left'>
         <DrawerOverlay />
-        <DrawerContent>
+        <DrawerContent paddingTop='env(safe-area-inset-top)'>
           <SideNavContent onClose={onClose} />
         </DrawerContent>
       </Drawer>


### PR DESCRIPTION
## Description

Need to account for the status bar on mobile devices when running in PWA or the new mobile app.

## Notice

<!-- Before submitting a pull request, please make sure you have answered the following: -->

- [x] Have you followed the guidelines in our [Contributing]('https://github.com/shapeshift/web/CONTRIBUTING.md) guide?
- [x] Have you checked to ensure there aren't other open [Pull Requests](https://github.com/shapeshift/web/pulls) for the same update/change?

## Pull Request Type

- [x] :bug: Bug fix (Non-breaking Change: Fixes an issue)
- [ ] :hammer_and_wrench: Chore (Non-breaking Change: Doc updates, pkg upgrades, typos, etc..)
- [ ] :nail_care: New Feature (Breaking/Non-breaking Change)

## Issue (if applicable)

N/A

## Risk

None

## Testing

n/a

## Screenshots (if applicable)
