### PR TITLE
chore: rename <MiddleEllipsis /> address prop to value

### DIFF
--- a/src/components/Approval/Approval.tsx
+++ b/src/components/Approval/Approval.tsx
@@ -191,7 +191,7 @@ export const Approval = () => {
                       color='blue.500'
                       href={`${quote?.sellAsset?.explorerTxLink}${approvalTxId}`}
                     >
-                      <MiddleEllipsis address={approvalTxId} />
+                      <MiddleEllipsis value={approvalTxId} />
                     </Link>
                   </Row.Value>
                 </Row>

--- a/src/components/Bridge/BridgeRoutes/Status.tsx
+++ b/src/components/Bridge/BridgeRoutes/Status.tsx
@@ -202,7 +202,7 @@ export const Status = () => {
                   <Row variant='gutter'>
                     <Row.Label>{translate('bridge.receiveAddress')}</Row.Label>
                     <Row.Value>
-                      <MiddleEllipsis address={receiveAddress ?? ''} />
+                      <MiddleEllipsis value={receiveAddress ?? ''} />
                     </Row.Value>
                   </Row>
                   <Row variant='gutter'>

--- a/src/components/Bridge/components/EditableAddress.tsx
+++ b/src/components/Bridge/components/EditableAddress.tsx
@@ -23,7 +23,7 @@ const EditControls: React.FC<{ value: string }> = ({ value }) => {
     </ButtonGroup>
   ) : (
     <Stack direction='row'>
-      <MiddleEllipsis address={value} />
+      <MiddleEllipsis value={value} />
       <IconButton
         size='sm'
         aria-label='Edit Address'

--- a/src/components/Layout/Header/NavBar/UserMenu.tsx
+++ b/src/components/Layout/Header/NavBar/UserMenu.tsx
@@ -118,7 +118,7 @@ const WalletButton: FC<WalletButtonProps> = ({
             pr='2'
             shouldShorten={shouldShorten}
             bgColor={bgColor}
-            address={walletLabel}
+            value={walletLabel}
           />
         ) : (
           <RawText>{walletInfo?.name}</RawText>

--- a/src/components/MiddleEllipsis/MiddleEllipsis.tsx
+++ b/src/components/MiddleEllipsis/MiddleEllipsis.tsx
@@ -2,14 +2,14 @@ import { Flex, FlexProps } from '@chakra-ui/react'
 import { firstFourLastFour } from 'state/slices/portfolioSlice/utils'
 
 type MiddleEllipsisProps = {
-  address: string
+  value: string
   shouldShorten?: boolean
 } & FlexProps
 
-export const MiddleEllipsis = ({ address, shouldShorten = true, ...rest }: MiddleEllipsisProps) => {
+export const MiddleEllipsis = ({ value, shouldShorten = true, ...rest }: MiddleEllipsisProps) => {
   return (
     <Flex alignItems='center' whiteSpace='nowrap' {...rest}>
-      <span style={{ lineHeight: 1 }}>{shouldShorten ? firstFourLastFour(address) : address}</span>
+      <span style={{ lineHeight: 1 }}>{shouldShorten ? firstFourLastFour(value) : value}</span>
     </Flex>
   )
 }

--- a/src/components/Modals/Receive/ReceiveInfo.tsx
+++ b/src/components/Modals/Receive/ReceiveInfo.tsx
@@ -191,7 +191,7 @@ export const ReceiveInfo = ({ asset, accountId }: ReceivePropsType) => {
                       _active={{ color: 'blue.800' }}
                       cursor='pointer'
                     >
-                      <MiddleEllipsis address={receiveAddress} data-test='receive-address-label' />
+                      <MiddleEllipsis value={receiveAddress} data-test='receive-address-label' />
                     </Flex>
                   </Skeleton>
                 </Card.Body>

--- a/src/components/Modals/Send/views/Confirm.tsx
+++ b/src/components/Modals/Send/views/Confirm.tsx
@@ -94,7 +94,7 @@ export const Confirm = () => {
               <Text translation={'modals.send.confirm.sendTo'} />
             </Row.Label>
             <Row.Value>
-              {vanityAddress ? vanityAddress : <MiddleEllipsis address={address} />}
+              {vanityAddress ? vanityAddress : <MiddleEllipsis value={address} />}
             </Row.Value>
           </Row>
           <FormControl mt={4}>

--- a/src/components/TransactionHistoryRows/TransactionDetails/Address.tsx
+++ b/src/components/TransactionHistoryRows/TransactionDetails/Address.tsx
@@ -26,8 +26,8 @@ export const Address = ({
       _hover={{ bg: 'transparent' }}
       fontSize='inherit'
     >
-      <MiddleEllipsis address={ens || address} />
+      <MiddleEllipsis value={ens || address} />
     </Button>
   ) : (
-    <MiddleEllipsis address={ens || address} />
+    <MiddleEllipsis value={ens || address} />
   )

--- a/src/components/TransactionHistoryRows/TransactionLink.tsx
+++ b/src/components/TransactionHistoryRows/TransactionLink.tsx
@@ -25,6 +25,6 @@ export const TransactionLink = ({
     display='flex'
     alignItems='center'
   >
-    <MiddleEllipsis address={txid} />
+    <MiddleEllipsis value={txid} />
   </Button>
 )

--- a/src/features/defi/providers/cosmos/components/CosmosManager/Claim/ClaimConfirm.tsx
+++ b/src/features/defi/providers/cosmos/components/CosmosManager/Claim/ClaimConfirm.tsx
@@ -167,7 +167,7 @@ export const ClaimConfirm = ({
                   color='blue.500'
                   href={`${asset?.explorerAddressLink}${userAddress}`}
                 >
-                  <MiddleEllipsis address={userAddress} />
+                  <MiddleEllipsis value={userAddress} />
                 </Link>
               </Skeleton>
             </Row.Value>

--- a/src/features/defi/providers/cosmos/components/CosmosManager/Claim/ClaimStatus.tsx
+++ b/src/features/defi/providers/cosmos/components/CosmosManager/Claim/ClaimStatus.tsx
@@ -128,7 +128,7 @@ export const ClaimStatus = () => {
               <Row.Label>{translate('modals.status.transactionId')}</Row.Label>
               <Row.Value>
                 <Link isExternal color='blue.500' href={`${asset?.explorerTxLink}${txid}`}>
-                  <MiddleEllipsis address={txid} />
+                  <MiddleEllipsis value={txid} />
                 </Link>
               </Row.Value>
             </Row>
@@ -150,7 +150,7 @@ export const ClaimStatus = () => {
                 color='blue.500'
                 href={`${asset?.explorerAddressLink}${userAddress}`}
               >
-                <MiddleEllipsis address={userAddress} />
+                <MiddleEllipsis value={userAddress} />
               </Link>
             </Row.Value>
           </Row>

--- a/src/features/defi/providers/cosmos/components/CosmosManager/Withdraw/components/Status.tsx
+++ b/src/features/defi/providers/cosmos/components/CosmosManager/Withdraw/components/Status.tsx
@@ -108,7 +108,7 @@ export const Status = () => {
             <Text translation='modals.confirm.withdrawTo' />
           </Row.Label>
           <Row.Value fontWeight='bold'>
-            <MiddleEllipsis address={state.userAddress || ''} />
+            <MiddleEllipsis value={state.userAddress || ''} />
           </Row.Value>
         </Row>
         {state.txid && (

--- a/src/features/defi/providers/fox-farming/components/FoxFarmingManager/Overview/Claim/ClaimConfirm.tsx
+++ b/src/features/defi/providers/fox-farming/components/FoxFarmingManager/Overview/Claim/ClaimConfirm.tsx
@@ -172,7 +172,7 @@ export const ClaimConfirm = ({
                   color='blue.500'
                   href={`${asset?.explorerAddressLink}${userAddress}`}
                 >
-                  <MiddleEllipsis address={userAddress} />
+                  <MiddleEllipsis value={userAddress} />
                 </Link>
               </Skeleton>
             </Row.Value>

--- a/src/features/defi/providers/fox-farming/components/FoxFarmingManager/Overview/Claim/ClaimStatus.tsx
+++ b/src/features/defi/providers/fox-farming/components/FoxFarmingManager/Overview/Claim/ClaimStatus.tsx
@@ -138,7 +138,7 @@ export const ClaimStatus = () => {
             <Row.Label>{translate('modals.status.transactionId')}</Row.Label>
             <Row.Value>
               <Link isExternal color='blue.500' href={`${asset?.explorerTxLink}${txid}`}>
-                <MiddleEllipsis address={txid} />
+                <MiddleEllipsis value={txid} />
               </Link>
             </Row.Value>
           </Row>
@@ -156,7 +156,7 @@ export const ClaimStatus = () => {
                 color='blue.500'
                 href={`${asset?.explorerAddressLink}${userAddress}`}
               >
-                <MiddleEllipsis address={userAddress} />
+                <MiddleEllipsis value={userAddress} />
               </Link>
             </Row.Value>
           </Row>

--- a/src/features/defi/providers/foxy/components/FoxyManager/Overview/Claim/ClaimConfirm.tsx
+++ b/src/features/defi/providers/foxy/components/FoxyManager/Overview/Claim/ClaimConfirm.tsx
@@ -165,7 +165,7 @@ export const ClaimConfirm = ({
                   color='blue.500'
                   href={`${asset?.explorerAddressLink}${userAddress}`}
                 >
-                  <MiddleEllipsis address={userAddress} />
+                  <MiddleEllipsis value={userAddress} />
                 </Link>
               </Skeleton>
             </Row.Value>

--- a/src/features/defi/providers/foxy/components/FoxyManager/Overview/Claim/ClaimStatus.tsx
+++ b/src/features/defi/providers/foxy/components/FoxyManager/Overview/Claim/ClaimStatus.tsx
@@ -148,7 +148,7 @@ export const ClaimStatus = () => {
             <Row.Label>{translate('modals.status.transactionId')}</Row.Label>
             <Row.Value>
               <Link isExternal color='blue.500' href={`${asset?.explorerTxLink}${txid}`}>
-                <MiddleEllipsis address={txid} />
+                <MiddleEllipsis value={txid} />
               </Link>
             </Row.Value>
           </Row>
@@ -169,7 +169,7 @@ export const ClaimStatus = () => {
                 color='blue.500'
                 href={`${asset?.explorerAddressLink}${userAddress}`}
               >
-                <MiddleEllipsis address={userAddress} />
+                <MiddleEllipsis value={userAddress} />
               </Link>
             </Row.Value>
           </Row>

--- a/src/features/defi/providers/foxy/components/FoxyManager/Withdraw/components/Status.tsx
+++ b/src/features/defi/providers/foxy/components/FoxyManager/Withdraw/components/Status.tsx
@@ -129,7 +129,7 @@ export const Status = () => {
             <Text translation='modals.confirm.withdrawTo' />
           </Row.Label>
           <Row.Value fontWeight='bold'>
-            <MiddleEllipsis address={state.userAddress || ''} />
+            <MiddleEllipsis value={state.userAddress || ''} />
           </Row.Value>
         </Row>
         <Row variant='gutter'>

--- a/src/plugins/cosmos/components/modals/Send/views/Confirm.tsx
+++ b/src/plugins/cosmos/components/modals/Send/views/Confirm.tsx
@@ -86,7 +86,7 @@ export const Confirm = () => {
               <Text translation={'modals.send.confirm.sendTo'} />
             </Row.Label>
             <Row.Value>
-              <MiddleEllipsis address={address} />
+              <MiddleEllipsis value={address} />
             </Row.Value>
           </Row>
           <Row>


### PR DESCRIPTION
## Description

Housekeeping PR, the current `address` prop is wrong, what we pass as `address` can be an address, wallet label, or NS domain name.
Additionally, this is namespaced under `components` and could be used for anything not address/domain/wallet label related.

## Notice

<!-- Before submitting a pull request, please make sure you have answered the following: -->

- [x] Have you followed the guidelines in our [Contributing]('https://github.com/shapeshift/web/CONTRIBUTING.md) guide?
- [x] Have you checked to ensure there aren't other open [Pull Requests](https://github.com/shapeshift/web/pulls) for the same update/change?

## Pull Request Type

- [ ] :bug: Bug fix (Non-breaking Change: Fixes an issue)
- [x] :hammer_and_wrench: Chore (Non-breaking Change: Doc updates, pkg upgrades, typos, etc..)
- [ ] :nail_care: New Feature (Breaking/Non-breaking Change)

## Issue (if applicable)

N/A

## Risk

None

## Testing

- `tsc` is happy

## Screenshots (if applicable)
