### PR TITLE
fix: detect ETH support in fox LP/farming provider/hooks

### DIFF
--- a/src/context/FoxEthProvider/FoxEthProvider.tsx
+++ b/src/context/FoxEthProvider/FoxEthProvider.tsx
@@ -1,5 +1,6 @@
 import { ethAssetId, ethChainId } from '@shapeshiftoss/caip'
 import { ChainAdapter } from '@shapeshiftoss/chain-adapters'
+import { supportsETH } from '@shapeshiftoss/hdwallet-core'
 import { KnownChainIds } from '@shapeshiftoss/types'
 import { TxStatus } from '@shapeshiftoss/unchained-client'
 import { DefiProvider, DefiType } from 'features/defi/contexts/DefiManagerProvider/DefiCommon'
@@ -134,6 +135,7 @@ export const FoxEthProvider = ({ children }: FoxEthProviderProps) => {
   useEffect(() => {
     if (wallet && adapter) {
       ;(async () => {
+        if (!supportsETH(wallet)) return
         const address = await adapter.getAddress({ wallet })
         setConnectedWalletEthAddress(address)
       })()

--- a/src/features/defi/providers/fox-eth-lp/hooks/useFoxEthLiquidityPool.ts
+++ b/src/features/defi/providers/fox-eth-lp/hooks/useFoxEthLiquidityPool.ts
@@ -60,6 +60,7 @@ export const useFoxEthLiquidityPool = () => {
   useEffect(() => {
     if (wallet && adapter) {
       ;(async () => {
+        if (!supportsETH(wallet)) return
         const address = await adapter.getAddress({ wallet })
         setConnectedWalletEthAddress(address)
       })()

--- a/src/features/defi/providers/fox-farming/hooks/useFoxFarming.ts
+++ b/src/features/defi/providers/fox-farming/hooks/useFoxFarming.ts
@@ -49,6 +49,7 @@ export const useFoxFarming = (contractAddress: string) => {
   useEffect(() => {
     if (wallet && adapter) {
       ;(async () => {
+        if (!supportsETH(wallet)) return
         const address = await adapter.getAddress({ wallet })
         setConnectedWalletEthAddress(address)
       })()


### PR DESCRIPTION
## Description

This properly narrows down ETH support and avoids calling `EthereumChainAdapter` methods with a non-Ethereum-supporting wallet.

## Notice

<!-- Before submitting a pull request, please make sure you have answered the following: -->

- [x] Have you followed the guidelines in our [Contributing]('https://github.com/shapeshift/web/CONTRIBUTING.md) guide?
- [x] Have you checked to ensure there aren't other open [Pull Requests](https://github.com/shapeshift/web/pulls) for the same update/change?

## Pull Request Type

- [x] :bug: Bug fix (Non-breaking Change: Fixes an issue)
- [ ] :hammer_and_wrench: Chore (Non-breaking Change: Doc updates, pkg upgrades, typos, etc..)
- [ ] :nail_care: New Feature (Breaking/Non-breaking Change)

## Issue (if applicable)

Closes https://github.com/shapeshift/web/issues/2495

## Risk

N/A

## Testing

- Connect Keplr wallet
- No `wallet.ethGetaddress is not a function` errors are present in the console

## Screenshots (if applicable)
