### PR TITLE
fix: outline is dark on connect wallet

### DIFF
--- a/src/pages/ConnectWallet/ConnectWallet.tsx
+++ b/src/pages/ConnectWallet/ConnectWallet.tsx
@@ -122,9 +122,9 @@ export const ConnectWallet = () => {
                 fontSize={{ base: '6xl', lg: '8xl' }}
                 mb={6}
               >
-                <RawText color='white' fontWeight='light' lineHeight='1'>
+                <RawText color='white' fontWeight='light' lineHeight='1' userSelect={'none'}>
                   {translate('connectWalletPage.exploreThe')}{' '}
-                  <RawText color='white' fontWeight='bold' as='span' userSelect={'none'}>
+                  <RawText color='white' fontWeight='bold' as='span'>
                     {translate('connectWalletPage.defiUniverse')}
                   </RawText>
                 </RawText>
@@ -165,7 +165,6 @@ export const ConnectWallet = () => {
                   size='lg'
                   zIndex={1}
                   variant='outline'
-                  colorScheme='white'
                   onClick={connectDemo}
                   isLoading={state.isLoadingLocalWallet}
                 >


### PR DESCRIPTION
## Description

- Fix the outline button on the connect wallet when in light mode
- Make the entire header on the connect wallet screen un-selectable

## Notice

<!-- Before submitting a pull request, please make sure you have answered the following: -->

- [x] Have you followed the guidelines in our [Contributing]('https://github.com/shapeshift/web/CONTRIBUTING.md) guide?
- [x] Have you checked to ensure there aren't other open [Pull Requests](https://github.com/shapeshift/web/pulls) for the same update/change?

## Pull Request Type

- [x] :bug: Bug fix (Non-breaking Change: Fixes an issue)
- [ ] :hammer_and_wrench: Chore (Non-breaking Change: Doc updates, pkg upgrades, typos, etc..)
- [ ] :nail_care: New Feature (Breaking/Non-breaking Change)

## Issue (if applicable)

n/a

## Risk

n/a

## Testing

When on the connect wallet screen, in light mode the button should be white

## Screenshots (if applicable)
![Screen Shot 2022-08-23 at 11 09 13 AM](https://user-images.githubusercontent.com/89934888/186207940-521670de-5adc-468f-ba6f-91d0cd98b0b0.png)

