### PR TITLE
chore: rename foxyBalancesApi -> foxyApi

### DIFF
--- a/react-app-rewired/headers/csps/plugins/foxPage.ts
+++ b/react-app-rewired/headers/csps/plugins/foxPage.ts
@@ -2,7 +2,7 @@ import type { Csp } from '../../types'
 
 export const csp: Csp = {
   'connect-src': [
-    // https://github.com/shapeshift/web/blob/c85fbdd27c360fc09cd8a2aaabec493f9c4e8b78/src/state/apis/foxy/foxyBalancesApi.ts#L21
+    // https://github.com/shapeshift/web/blob/c85fbdd27c360fc09cd8a2aaabec493f9c4e8b78/src/state/apis/foxy/foxyApi.ts#L21
     process.env.REACT_APP_TOKEMAK_STATS_URL!,
     // https://github.com/shapeshift/web/blob/965e5f3365e62f02f4cff3d0f78a020e0bf6b376/src/plugins/foxPage/hooks/getGovernanceData.ts#L47
     process.env.REACT_APP_BOARDROOM_API_BASE_URL!,

--- a/src/features/defi/helpers/normalizeOpportunity.tsx
+++ b/src/features/defi/helpers/normalizeOpportunity.tsx
@@ -5,7 +5,7 @@ import { useSelector } from 'react-redux'
 import { bnOrZero } from 'lib/bignumber/bignumber'
 import { MergedActiveStakingOpportunity } from 'pages/Defi/hooks/useCosmosSdkStakingBalances'
 import { useVaultBalances } from 'pages/Defi/hooks/useVaultBalances'
-import { MergedFoxyOpportunity } from 'state/apis/foxy/foxyBalancesApi'
+import { MergedFoxyOpportunity } from 'state/apis/foxy/foxyApi'
 import { selectAssetIds } from 'state/slices/selectors'
 
 import { DefiProvider, DefiType } from '../contexts/DefiManagerProvider/DefiCommon'

--- a/src/features/defi/providers/foxy/components/FoxyManager/Deposit/FoxyDeposit.tsx
+++ b/src/features/defi/providers/foxy/components/FoxyManager/Deposit/FoxyDeposit.tsx
@@ -20,7 +20,7 @@ import { getChainAdapterManager } from 'context/PluginProvider/chainAdapterSingl
 import { useBrowserRouter } from 'hooks/useBrowserRouter/useBrowserRouter'
 import { useWallet } from 'hooks/useWallet/useWallet'
 import { logger } from 'lib/logger'
-import { useGetFoxyAprQuery } from 'state/apis/foxy/foxyBalancesApi'
+import { useGetFoxyAprQuery } from 'state/apis/foxy/foxyApi'
 import {
   selectAssetById,
   selectMarketDataById,

--- a/src/pages/Defi/hooks/useFoxyBalances.tsx
+++ b/src/pages/Defi/hooks/useFoxyBalances.tsx
@@ -8,7 +8,7 @@ import {
   MergedFoxyOpportunity,
   useGetFoxyAprQuery,
   useGetFoxyBalancesQuery,
-} from 'state/apis/foxy/foxyBalancesApi'
+} from 'state/apis/foxy/foxyApi'
 
 export type UseFoxyBalancesReturn = {
   opportunities: MergedFoxyOpportunity[]

--- a/src/plugins/foxPage/foxPage.tsx
+++ b/src/plugins/foxPage/foxPage.tsx
@@ -26,7 +26,7 @@ import { AssetMarketData } from 'components/AssetHeader/AssetMarketData'
 import { useRouteAssetId } from 'hooks/useRouteAssetId/useRouteAssetId'
 import { bnOrZero } from 'lib/bignumber/bignumber'
 import { useFoxyBalances } from 'pages/Defi/hooks/useFoxyBalances'
-import { useGetFoxyAprQuery } from 'state/apis/foxy/foxyBalancesApi'
+import { useGetFoxyAprQuery } from 'state/apis/foxy/foxyApi'
 import { useGetAssetDescriptionQuery } from 'state/slices/assetsSlice/assetsSlice'
 import {
   selectTotalCryptoBalanceWithDelegations,

--- a/src/state/apis/foxy/foxyApi.ts
+++ b/src/state/apis/foxy/foxyApi.ts
@@ -232,7 +232,7 @@ export const foxyApi = createApi({
           console.error('error', error)
           return {
             error: {
-              error: `foxyApi Error`,
+              error: `getFoxyBalances Error`,
               status: 'CUSTOM_ERROR',
             },
           }

--- a/src/state/apis/foxy/foxyApi.ts
+++ b/src/state/apis/foxy/foxyApi.ts
@@ -177,9 +177,9 @@ async function getFoxyOpportunities(
   }
 }
 
-export const foxyBalancesApi = createApi({
+export const foxyApi = createApi({
   ...BASE_RTK_CREATE_API_CONFIG,
-  reducerPath: 'foxyBalancesApi',
+  reducerPath: 'foxyApi',
   endpoints: build => ({
     getFoxyBalances: build.query<GetFoxyBalancesOutput, GetFoxyBalancesInput>({
       queryFn: async ({ userAddress, foxyApr }, injected) => {
@@ -232,7 +232,7 @@ export const foxyBalancesApi = createApi({
           console.error('error', error)
           return {
             error: {
-              error: `foxyBalancesAPI Error`,
+              error: `foxyApi Error`,
               status: 'CUSTOM_ERROR',
             },
           }
@@ -294,4 +294,4 @@ export const foxyBalancesApi = createApi({
   }),
 })
 
-export const { useGetFoxyBalancesQuery, useGetFoxyAprQuery } = foxyBalancesApi
+export const { useGetFoxyBalancesQuery, useGetFoxyAprQuery } = foxyApi

--- a/src/state/reducer.ts
+++ b/src/state/reducer.ts
@@ -3,7 +3,7 @@ import localforage from 'localforage'
 import { persistReducer } from 'redux-persist'
 import { swapperApi } from 'state/apis/swapper/swapperApi'
 
-import { foxyBalancesApi } from './apis/foxy/foxyBalancesApi'
+import { foxyApi } from './apis/foxy/foxyApi'
 import { accountSpecifiers } from './slices/accountSpecifiersSlice/accountSpecifiersSlice'
 import { assetApi, assets } from './slices/assetsSlice/assetsSlice'
 import { marketApi, marketData } from './slices/marketDataSlice/marketDataSlice'
@@ -54,7 +54,7 @@ export const apiReducers = {
   [txHistoryApi.reducerPath]: txHistoryApi.reducer,
   [validatorDataApi.reducerPath]: validatorDataApi.reducer,
   [swapperApi.reducerPath]: swapperApi.reducer,
-  [foxyBalancesApi.reducerPath]: foxyBalancesApi.reducer,
+  [foxyApi.reducerPath]: foxyApi.reducer,
 }
 
 export const reducer = combineReducers({ ...sliceReducers, ...apiReducers })

--- a/src/state/store.ts
+++ b/src/state/store.ts
@@ -5,7 +5,7 @@ import { PERSIST, persistReducer, persistStore } from 'redux-persist'
 import { getStateWith, registerSelectors } from 'reselect-tools'
 import { swapperApi } from 'state/apis/swapper/swapperApi'
 
-import { foxyBalancesApi } from './apis/foxy/foxyBalancesApi'
+import { foxyApi } from './apis/foxy/foxyApi'
 import { apiSlices, reducer, ReduxState, slices } from './reducer'
 import { assetApi } from './slices/assetsSlice/assetsSlice'
 import { marketApi, marketData } from './slices/marketDataSlice/marketDataSlice'
@@ -26,7 +26,7 @@ const apiMiddleware = [
   assetApi.middleware,
   txHistoryApi.middleware,
   validatorDataApi.middleware,
-  foxyBalancesApi.middleware,
+  foxyApi.middleware,
   swapperApi.middleware,
 ]
 

--- a/src/test/mocks/store.ts
+++ b/src/test/mocks/store.ts
@@ -26,7 +26,7 @@ export const mockStore: ReduxState = {
   txHistoryApi: mockApiFactory('txHistoryApi' as const),
   validatorDataApi: mockApiFactory('validatorDataApi' as const),
   swapperApi: mockApiFactory('swapperApi' as const),
-  foxyBalancesApi: mockApiFactory('foxyBalancesApi' as const),
+  foxyApi: mockApiFactory('foxyApi' as const),
   portfolio: {
     accounts: {
       byId: {},


### PR DESCRIPTION
## Description

Rename the `foxyBalancesApi` module/slice to `foxyApi` following the addition of foxy APR RTK query in https://github.com/shapeshift/web/pull/2523

## Notice

<!-- Before submitting a pull request, please make sure you have answered the following: -->

- [x] Have you followed the guidelines in our [Contributing]('https://github.com/shapeshift/web/CONTRIBUTING.md) guide?
- [x] Have you checked to ensure there aren't other open [Pull Requests](https://github.com/shapeshift/web/pulls) for the same update/change?

## Pull Request Type

- [ ] :bug: Bug fix (Non-breaking Change: Fixes an issue)
-  [x] :hammer_and_wrench: Chore (Non-breaking Change: Doc updates, pkg upgrades, typos, etc..)
- [ ] :nail_care: New Feature (Breaking/Non-breaking Change)

## Issue (if applicable)

N/A

## Risk

None

## Testing

- CI is happy

## Screenshots (if applicable)
