### PR TITLE
fix: add spacing to yat banner on send modal

### DIFF
--- a/src/components/Modals/Send/views/Address.tsx
+++ b/src/components/Modals/Send/views/Address.tsx
@@ -93,6 +93,7 @@ export const Address = () => {
             }}
           />
         </FormControl>
+        {isYatFeatureEnabled && <YatBanner mt={6} />}
       </ModalBody>
       <ModalFooter {...(isYatFeatureEnabled && { display: 'flex', flexDir: 'column' })}>
         <Stack flex={1} {...(isYatFeatureEnabled && { w: 'full' })}>
@@ -111,7 +112,6 @@ export const Address = () => {
             <Text translation='common.cancel' />
           </Button>
         </Stack>
-        {isYatFeatureEnabled && <YatBanner />}
       </ModalFooter>
     </SlideTransition>
   )


### PR DESCRIPTION
## Description

- Fix spacing on the send modal

## Notice

<!-- Before submitting a pull request, please make sure you have answered the following: -->

- [x] Have you followed the guidelines in our [Contributing]('https://github.com/shapeshift/web/CONTRIBUTING.md) guide?
- [x] Have you checked to ensure there aren't other open [Pull Requests](https://github.com/shapeshift/web/pulls) for the same update/change?

## Pull Request Type

- [x] :bug: Bug fix (Non-breaking Change: Fixes an issue)
- [ ] :hammer_and_wrench: Chore (Non-breaking Change: Doc updates, pkg upgrades, typos, etc..)
- [ ] :nail_care: New Feature (Breaking/Non-breaking Change)

## Issue (if applicable)

<!-----------------------------------------------------------------------------
If applicable, please link to the github issue and put `closes #XXXX` in your comment to auto-close the issue that your PR fixes.
------------------------------------------------------------------------------>

## Risk

n/a

## Testing

n/a

## Screenshots (if applicable)
![Screen Shot 2022-08-24 at 5 06 38 PM](https://user-images.githubusercontent.com/89934888/186532133-1fa4a7f8-3c3d-4639-b5c7-c90814fec4a5.png)
