### PR TITLE
feat: use serializable `GetTradeQuoteInput` args

### DIFF
--- a/package.json
+++ b/package.json
@@ -104,7 +104,7 @@
     "@shapeshiftoss/investor-yearn": "^4.1.0",
     "@shapeshiftoss/logger": "^1.1.2",
     "@shapeshiftoss/market-service": "^6.5.0",
-    "@shapeshiftoss/swapper": "^9.16.2",
+    "@shapeshiftoss/swapper": "^9.17.0",
     "@shapeshiftoss/types": "^8.2.0",
     "@shapeshiftoss/unchained-client": "^9.9.0",
     "@uniswap/sdk": "^3.0.3",

--- a/yarn.lock
+++ b/yarn.lock
@@ -4038,10 +4038,10 @@
     google-protobuf "^3.17.0"
     long "^4.0.0"
 
-"@shapeshiftoss/swapper@^9.16.2":
-  version "9.16.2"
-  resolved "https://registry.yarnpkg.com/@shapeshiftoss/swapper/-/swapper-9.16.2.tgz#52d1b1667f2f6a5efedd5c1400a31dd1c96cde47"
-  integrity sha512-LEH1tBP1ZvVNrhZlaEyXlyM7SLavg4CbwQHV3WSu8VRz92dEQvtVLLWp/AWnWuLWP+8Duayj4hTwjTRyQs1Yfg==
+"@shapeshiftoss/swapper@^9.17.0":
+  version "9.17.0"
+  resolved "https://registry.yarnpkg.com/@shapeshiftoss/swapper/-/swapper-9.17.0.tgz#e8e68b862a7aa6f6eda1c7be77ab4619f73455a9"
+  integrity sha512-nG+0IWjl7puuYsvHRd+jT6p58J+U+WodWmq/r/qFLQreZzed+wYH1OZuGaHkT1j/mF+vrpJa//G7Js0cmEoGFw==
   dependencies:
     axios "^0.26.1"
     bignumber.js "^9.0.2"


### PR DESCRIPTION
## Description

Supports the serialization of `GetTradeQuoteInput` type args made in https://github.com/shapeshift/lib/pull/989.

TODO: bump the swapper package to the new major version once it is published, and open this PR for review.

## Notice

- [x] Have you followed the guidelines in our [Contributing]('https://github.com/shapeshift/web/CONTRIBUTING.md) guide?
- [x] Have you checked to ensure there aren't other open [Pull Requests](https://github.com/shapeshift/web/pulls) for the same update/change?

## Pull Request Type

- [ ] :bug: Bug fix (Non-breaking Change: Fixes an issue)
- [ ] :hammer_and_wrench: Chore (Non-breaking Change: Doc updates, pkg upgrades, typos, etc..)
- [x] :nail_care: New Feature (Breaking/Non-breaking Change)

## Issue (if applicable)

Contributes to https://github.com/shapeshift/web/issues/2556

## Risk

Thor trade quote logic touched - there is a risk of regression here.

## Testing

Ensure quotes for Thor still work as expected.

## Screenshots (if applicable)

N/A