### PR TITLE
fix: don't unmount/remount private routes on route change

### DIFF
--- a/src/Routes/Routes.tsx
+++ b/src/Routes/Routes.tsx
@@ -70,10 +70,10 @@ export const Routes = () => {
           ) : null
         }}
       </Route>
-      {appRoutes.map((route, index) => {
+      {appRoutes.map(route => {
         const MainComponent = route.main
         return (
-          <PrivateRoute key={index} path={route.path} exact hasWallet={hasWallet}>
+          <PrivateRoute path={route.path} exact hasWallet={hasWallet}>
             <Layout>{MainComponent && <MainComponent />}</Layout>
           </PrivateRoute>
         )

--- a/src/components/Layout/Header/NavBar/WalletConnectedMenu.tsx
+++ b/src/components/Layout/Header/NavBar/WalletConnectedMenu.tsx
@@ -77,15 +77,10 @@ export const WalletConnectedMenu = ({
             <ConnectedMenu />
           </SubMenuContainer>
         </Route>
-        {connectedWalletMenuRoutes?.map((route, index) => {
+        {connectedWalletMenuRoutes?.map(route => {
           const Component = route.component
           return !Component ? null : (
-            <Route
-              exact
-              key={index}
-              path={route.path}
-              render={routeProps => <Component {...routeProps} />}
-            />
+            <Route exact path={route.path} render={routeProps => <Component {...routeProps} />} />
           )
         })}
       </Switch>

--- a/src/context/WalletProvider/WalletViewsSwitch.tsx
+++ b/src/context/WalletProvider/WalletViewsSwitch.tsx
@@ -99,12 +99,11 @@ export const WalletViewsSwitch = () => {
             <SlideTransition key={location.key}>
               <Switch key={location.pathname} location={location}>
                 {type &&
-                  SUPPORTED_WALLETS[type].routes.map((route, index) => {
+                  SUPPORTED_WALLETS[type].routes.map(route => {
                     const Component = route.component
                     return !Component ? null : (
                       <Route
                         exact
-                        key={index}
                         path={route.path}
                         render={routeProps => <Component {...routeProps} />}
                       />


### PR DESCRIPTION
## Description

This both improves performance and fixes a bug related to the whole layout tree unmounting and remounting on route change.

The `key` prop is used by react, and by extension by react-router as a react library, to uniquely identify components.
By giving a different `key` prop to `appRoute` outer component on each `appRoutes` iteration, we're effectively telling react "this is a whole new component` which is not true, we are effectively mapping over what is the exact same component, only rendering a different `{children}` prop which will cause the whole `<Layout />` JSX tree to rerender.

This currently causes some re-renders producing unwanted behaviors, such as, but most likely not related to the `<WalletButton />` flicker spotted by @reallybeard on route change.

Fixed by **not** providing a key to the mapped components.

## Notice

<!-- Before submitting a pull request, please make sure you have answered the following: -->

- [x] Have you followed the guidelines in our [Contributing]('https://github.com/shapeshift/web/CONTRIBUTING.md) guide?
- [x] Have you checked to ensure there aren't other open [Pull Requests](https://github.com/shapeshift/web/pulls) for the same update/change?

## Pull Request Type

- [x] :bug: Bug fix (Non-breaking Change: Fixes an issue)
- [ ] :hammer_and_wrench: Chore (Non-breaking Change: Doc updates, pkg upgrades, typos, etc..)
- [ ] :nail_care: New Feature (Breaking/Non-breaking Change)

## Issue (if applicable)

N/A

## Risk

Monitor performance, in theory it should be improved.

## Testing

- Switching routes should still work
- The wallet label flicker on route change should be fixed

## Screenshots (if applicable)
