### PR TITLE
fix: display default osmo validator for KK

### DIFF
--- a/src/components/StakingVaults/AllEarnOpportunities.tsx
+++ b/src/components/StakingVaults/AllEarnOpportunities.tsx
@@ -41,7 +41,7 @@ export const AllEarnOpportunities = () => {
   const { cosmosSdkStakingOpportunities: osmosisStakingOpportunities } =
     useCosmosSdkStakingBalances({
       assetId: osmosisAssetId,
-      supportsCosmosSdk: wallet ? supportsOsmosis(wallet) : undefined,
+      supportsCosmosSdk: wallet ? Boolean(supportsOsmosis(wallet)) : undefined,
     })
   const featureFlags = useAppSelector(selectFeatureFlags)
   const allRows = useNormalizeOpportunities({

--- a/src/pages/Defi/hooks/useCosmosSdkStakingBalances.tsx
+++ b/src/pages/Defi/hooks/useCosmosSdkStakingBalances.tsx
@@ -1,4 +1,4 @@
-import { AssetId, ChainId, cosmosChainId, fromAssetId, osmosisChainId } from '@shapeshiftoss/caip'
+import { AssetId, ChainId } from '@shapeshiftoss/caip'
 import { cosmos } from '@shapeshiftoss/unchained-client'
 import { useMemo } from 'react'
 import { BigNumber, bn, bnOrZero } from 'lib/bignumber/bignumber'
@@ -9,10 +9,7 @@ import {
   selectMarketDataById,
   selectStakingOpportunitiesDataFull,
 } from 'state/slices/selectors'
-import {
-  EMPTY_COSMOS_ADDRESS,
-  EMPTY_OSMOSIS_ADDRESS,
-} from 'state/slices/validatorDataSlice/constants'
+import { getDefaultValidatorAddressFromAssetId } from 'state/slices/validatorDataSlice/utils'
 import { useAppSelector } from 'state/store'
 
 type UseCosmosStakingBalancesProps = {
@@ -51,25 +48,10 @@ export function useCosmosSdkStakingBalances({
     selectFirstAccountSpecifierByChainId(state, asset?.chainId),
   )
 
-  // Default account specifiers to fetch Cosmos SDK staking data without any cosmos account
-  // Created and private key burned, guaranteed to be empty
-  const defaultCosmosAccountSpecifier = `${cosmosChainId}:${EMPTY_COSMOS_ADDRESS}`
-  const defaultOsmosisAccountSpecifier = `${osmosisChainId}:${EMPTY_OSMOSIS_ADDRESS}`
-  const { chainId } = fromAssetId(assetId)
-
-  const defaultAccountSpecifier = (() => {
-    if (supportsCosmosSdk) return ''
-
-    switch (chainId) {
-      case cosmosChainId:
-        return defaultCosmosAccountSpecifier
-      case osmosisChainId:
-        return defaultOsmosisAccountSpecifier
-      default:
-        return ''
-    }
-  })()
-
+  const defaultAccountSpecifier = useMemo(
+    () => getDefaultValidatorAddressFromAssetId(assetId),
+    [assetId],
+  )
   const stakingOpportunities = useAppSelector(state =>
     selectStakingOpportunitiesDataFull(state, {
       accountSpecifier: supportsCosmosSdk ? accountSpecifier : defaultAccountSpecifier,


### PR DESCRIPTION
## Description

This fixes the default validator not being displayed for KK.

## Notice

<!-- Before submitting a pull request, please make sure you have answered the following: -->

- [x] Have you followed the guidelines in our [Contributing]('https://github.com/shapeshift/web/CONTRIBUTING.md) guide?
- [x] Have you checked to ensure there aren't other open [Pull Requests](https://github.com/shapeshift/web/pulls) for the same update/change?

## Pull Request Type

- [x] :bug: Bug fix (Non-breaking Change: Fixes an issue)
- [ ] :hammer_and_wrench: Chore (Non-breaking Change: Doc updates, pkg upgrades, typos, etc..)
- [ ] :nail_care: New Feature (Breaking/Non-breaking Change)

## Issue (if applicable)

Relates to https://github.com/shapeshift/web/issues/2500

## Risk

N/A

## Testing

- Enable the `Osmosis` flag
- Connect a KK
- The default Osmosis validator should be displayed

## Screenshots (if applicable)

<img width="1032" alt="image" src="https://user-images.githubusercontent.com/17035424/186738181-2cd840a3-67d6-438a-97ed-57f697322462.png">
