### PR TITLE
chore: remove unused transactionRow interpolation variable

### DIFF
--- a/src/assets/translations/de/main.json
+++ b/src/assets/translations/de/main.json
@@ -348,7 +348,7 @@
     "clickToConnect": "Klicken Sie hier, um eine Wallet zu verbinden"
   },
   "transactionRow": {
-    "send": "gesendet",
+    "send": "Gesendet",
     "receive": "Erhalten",
     "moreDetails": "Mehr Details",
     "date": "Datum",

--- a/src/assets/translations/de/main.json
+++ b/src/assets/translations/de/main.json
@@ -348,8 +348,8 @@
     "clickToConnect": "Klicken Sie hier, um eine Wallet zu verbinden"
   },
   "transactionRow": {
-    "send": "%{symbol} gesendet",
-    "receive": "Erhalten %{symbol}",
+    "send": "gesendet",
+    "receive": "Erhalten",
     "moreDetails": "Mehr Details",
     "date": "Datum",
     "txid": "Transaktions ID",

--- a/src/assets/translations/en/main.json
+++ b/src/assets/translations/en/main.json
@@ -357,8 +357,8 @@
     "explore": "Explore"
   },
   "transactionRow": {
-    "send": "Sent %{symbol}",
-    "receive": "Received %{symbol}",
+    "send": "Sent",
+    "receive": "Received",
     "moreDetails": "More Details",
     "date": "Date",
     "txid": "Transaction ID",

--- a/src/assets/translations/es/main.json
+++ b/src/assets/translations/es/main.json
@@ -348,8 +348,8 @@
     "clickToConnect": "Haga clic para conectar una billetera"
   },
   "transactionRow": {
-    "send": "Enviado %{symbol}",
-    "receive": "Recibido %{symbol}",
+    "send": "Enviado",
+    "receive": "Recibido",
     "moreDetails": "Más Detalles",
     "date": "Fecha",
     "txid": "ID Transacción",

--- a/src/assets/translations/fr/main.json
+++ b/src/assets/translations/fr/main.json
@@ -348,8 +348,8 @@
     "clickToConnect": "Cliquez pour connecter un porte-monnaie"
   },
   "transactionRow": {
-    "send": "envoyé",
-    "receive": "reçu",
+    "send": "Envoyé",
+    "receive": "Reçu",
     "moreDetails": "Plus de détails",
     "date": "Date",
     "txid": "ID de transaction",

--- a/src/assets/translations/fr/main.json
+++ b/src/assets/translations/fr/main.json
@@ -348,8 +348,8 @@
     "clickToConnect": "Cliquez pour connecter un porte-monnaie"
   },
   "transactionRow": {
-    "send": "%{symbol} envoyés",
-    "receive": "%{symbol} reçus",
+    "send": "envoyé",
+    "receive": "reçu",
     "moreDetails": "Plus de détails",
     "date": "Date",
     "txid": "ID de transaction",

--- a/src/assets/translations/id/main.json
+++ b/src/assets/translations/id/main.json
@@ -280,8 +280,8 @@
     "featureFlags": "Fitur Bendera"
   },
   "transactionRow": {
-    "send": "Kirim %{symbol}",
-    "receive": "Menerima %{symbol}",
+    "send": "Kirim",
+    "receive": "Menerima",
     "moreDetails": "Lebih Detail",
     "date": "Tanggal",
     "txid": "ID Transaksi",

--- a/src/assets/translations/ko/main.json
+++ b/src/assets/translations/ko/main.json
@@ -276,8 +276,8 @@
     "clickToConnect": "여기를 눌러 지갑 연결하기"
   },
   "transactionRow": {
-    "send": "%{symbol} 송신",
-    "receive": "%{symbol} 수신",
+    "send": "송신",
+    "receive": "수신",
     "moreDetails": "자세한 정보",
     "date": "날짜",
     "txid": "거래 아이디",

--- a/src/assets/translations/pt/main.json
+++ b/src/assets/translations/pt/main.json
@@ -348,8 +348,8 @@
     "clickToConnect": "Clique para conectar uma carteira"
   },
   "transactionRow": {
-    "send": "Enviado %{symbol}",
-    "receive": "Recebido %{symbol}",
+    "send": "Enviado",
+    "receive": "Recebido",
     "moreDetails": "Mais Detalhes",
     "date": "Data",
     "txid": "ID da Transação",

--- a/src/assets/translations/ru/main.json
+++ b/src/assets/translations/ru/main.json
@@ -126,8 +126,8 @@
     "foxToken": "FOX возможности"
   },
   "transactionRow": {
-    "send": "Отправлено %{symbol}",
-    "receive": "Получено %{symbol}",
+    "send": "Отправлено",
+    "receive": "Получено",
     "moreDetails": "Больше информации",
     "date": "Дата",
     "txid": "ID транзакции",

--- a/src/assets/translations/zh/main.json
+++ b/src/assets/translations/zh/main.json
@@ -271,8 +271,8 @@
     "featureFlags": "功能开关标志"
   },
   "transactionRow": {
-    "send": "已发送%{symbol}",
-    "receive": "已收到%{symbol}",
+    "send": "已发送",
+    "receive": "已收到",
     "moreDetails": "查看详情",
     "date": "日期",
     "txid": "交易 ID",

--- a/src/components/TransactionHistoryRows/TransactionGenericRow.tsx
+++ b/src/components/TransactionHistoryRows/TransactionGenericRow.tsx
@@ -150,9 +150,7 @@ export const TransactionGenericRow = ({
               <Text
                 fontWeight='bold'
                 flex={1}
-                translation={
-                  title ? title : [`transactionRow.${type.toLowerCase()}`, { symbol: '' }]
-                }
+                translation={title ? title : `transactionRow.${type.toLowerCase()}`}
               />
               <TransactionTime blockTime={blockTime} format={dateFormat} />
             </Stack>


### PR DESCRIPTION
## Description

Removes an unused interpolation variable, confirmed by product we will never use it - see linked issue.

## Notice

<!-- Before submitting a pull request, please make sure you have answered the following: -->

- [x] Have you followed the guidelines in our [Contributing]('https://github.com/shapeshift/web/CONTRIBUTING.md) guide?
- [x] Have you checked to ensure there aren't other open [Pull Requests](https://github.com/shapeshift/web/pulls) for the same update/change?

## Pull Request Type

- [ ] :bug: Bug fix (Non-breaking Change: Fixes an issue)
- [x] :hammer_and_wrench: Chore (Non-breaking Change: Doc updates, pkg upgrades, typos, etc..)
- [ ] :nail_care: New Feature (Breaking/Non-breaking Change)

## Issue (if applicable)

closes #2524

## Risk

None, this is a chore - the interpolation variable was previously unused

## Testing

- CI is happy

## Screenshots (if applicable)
