### PR TITLE
fix: remove tab header when axelar is off

### DIFF
--- a/src/assets/translations/en/main.json
+++ b/src/assets/translations/en/main.json
@@ -430,6 +430,7 @@
     "noSupportedAssets": "No supported assets in portfolio."
   },
   "trade": {
+    "trade": "Trade",
     "allowance": "Allowance",
     "allowanceTooltip": "The amount you will grant the smart contract permission to use on your behalf.",
     "searchingRate": "Searching for best rate...",

--- a/src/components/Trade/TradeInput.tsx
+++ b/src/components/Trade/TradeInput.tsx
@@ -8,6 +8,7 @@ import { Controller, useFormContext, useWatch } from 'react-hook-form'
 import { FaArrowsAltV } from 'react-icons/fa'
 import NumberFormat from 'react-number-format'
 import { useTranslate } from 'react-polyglot'
+import { useSelector } from 'react-redux'
 import { RouterProps } from 'react-router-dom'
 import { Card } from 'components/Card/Card'
 import { FlexibleInputContainer } from 'components/FlexibleInputContainer/FlexibleInputContainer'
@@ -27,6 +28,7 @@ import { firstNonZeroDecimal, fromBaseUnit } from 'lib/math'
 import {
   selectAccountIdsByAssetId,
   selectAssetById,
+  selectFeatureFlags,
   selectFiatToUsdRate,
   selectFirstAccountSpecifierByChainId,
   selectHighestFiatBalanceAccountByAssetId,
@@ -54,6 +56,7 @@ export const TradeInput = ({ history }: RouterProps) => {
     number: { localeParts, toFiat },
   } = useLocaleFormatter()
   const [isSendMaxLoading, setIsSendMaxLoading] = useState<boolean>(false)
+  const { Axelar } = useSelector(selectFeatureFlags)
   const [
     quote,
     buyTradeAsset,
@@ -329,6 +332,14 @@ export const TradeInput = ({ history }: RouterProps) => {
     <SlideTransition>
       <Box as='form' onSubmit={handleSubmit(onSubmit)} mb={2}>
         <Card variant='unstyled'>
+          {!Axelar && (
+            <Card.Header>
+              <Card.Heading textAlign='center'>
+                <Text translation='trade.trade' />
+              </Card.Heading>
+            </Card.Header>
+          )}
+
           <Card.Body pb={0} px={0}>
             <FormControl isInvalid={!!errors.fiatSellAmount}>
               <Controller

--- a/src/pages/Dashboard/TradeCard.tsx
+++ b/src/pages/Dashboard/TradeCard.tsx
@@ -15,10 +15,13 @@ export const TradeCard = ({ defaultBuyAssetId }: TradeCardProps) => {
   return (
     <Card flex={1} variant='outline'>
       <Tabs isFitted variant='enclosed'>
-        <TabList>
-          <Tab>Trade</Tab>
-          {Axelar && <Tab>Bridge</Tab>}
-        </TabList>
+        {Axelar && (
+          <TabList>
+            <Tab>Trade</Tab>
+            <Tab>Bridge</Tab>
+          </TabList>
+        )}
+
         <TabPanels>
           <TabPanel py={4} px={6}>
             <Trade defaultBuyAssetId={defaultBuyAssetId} />


### PR DESCRIPTION
## Description

- Remove duplicate trade header

## Notice

<!-- Before submitting a pull request, please make sure you have answered the following: -->

- [x] Have you followed the guidelines in our [Contributing]('https://github.com/shapeshift/web/CONTRIBUTING.md) guide?
- [x] Have you checked to ensure there aren't other open [Pull Requests](https://github.com/shapeshift/web/pulls) for the same update/change?

## Pull Request Type

- [x] :bug: Bug fix (Non-breaking Change: Fixes an issue)
- [ ] :hammer_and_wrench: Chore (Non-breaking Change: Doc updates, pkg upgrades, typos, etc..)
- [ ] :nail_care: New Feature (Breaking/Non-breaking Change)

## Issue (if applicable)

closes #2558 

## Risk

No risk

## Testing

Going through a trade make sure there are not duplicate headers.

## Screenshots (if applicable)
![Screen Shot 2022-08-25 at 3 10 25 PM](https://user-images.githubusercontent.com/89934888/186759404-6cf2185c-f9dd-4c6d-8ecb-df37e1a78bb6.png)
![Screen Shot 2022-08-25 at 3 10 28 PM](https://user-images.githubusercontent.com/89934888/186759411-1fb683d0-7bb3-4305-bba9-c70cddc649e6.png)

