### PR TITLE
feat: add visitor id to the flags page

### DIFF
--- a/src/pages/Flags/Debugging.tsx
+++ b/src/pages/Flags/Debugging.tsx
@@ -84,7 +84,7 @@ export const Debugging = () => {
           </Row>
         </Card.Body>
         <Card.Footer>
-          <Button onClick={() => window.location.reload()} colorScheme='blue'>
+          <Button onClick={window.location.reload} colorScheme='blue'>
             Reload
           </Button>
         </Card.Footer>

--- a/src/pages/Flags/Debugging.tsx
+++ b/src/pages/Flags/Debugging.tsx
@@ -21,7 +21,8 @@ export const Debugging = () => {
 
   const handleCopyClick = async () => {
     try {
-      await navigator.clipboard.writeText(visitorId ?? '')
+      if (!visitorId) throw new Error()
+      await navigator.clipboard.writeText(visitorId)
       alert('Visitor ID copied!')
     } catch (e) {
       alert('Something went wrong')

--- a/src/pages/Flags/Debugging.tsx
+++ b/src/pages/Flags/Debugging.tsx
@@ -72,7 +72,7 @@ export const Debugging = () => {
           </Row>
           <Row alignItems='center'>
             <Row.Label>Pendo visitor ID</Row.Label>
-            <Row.Value display='flex' gap={4}>
+            <Row.Value display='flex' gap={4} alignItems='center'>
               <RawText>{visitorId}</RawText>
               <IconButton
                 aria-label='Copy'

--- a/src/pages/Flags/Debugging.tsx
+++ b/src/pages/Flags/Debugging.tsx
@@ -1,8 +1,6 @@
 import { ChevronDownIcon, CopyIcon } from '@chakra-ui/icons'
 import {
   Button,
-  Heading,
-  HStack,
   IconButton,
   Menu,
   MenuButton,

--- a/src/pages/Flags/Debugging.tsx
+++ b/src/pages/Flags/Debugging.tsx
@@ -1,8 +1,9 @@
-import { ChevronDownIcon } from '@chakra-ui/icons'
+import { ChevronDownIcon, CopyIcon } from '@chakra-ui/icons'
 import {
   Button,
   Heading,
   HStack,
+  IconButton,
   Menu,
   MenuButton,
   MenuItemOption,
@@ -10,19 +11,40 @@ import {
   MenuOptionGroup,
   Stack,
 } from '@chakra-ui/react'
-import { useState } from 'react'
+import { useEffect, useState } from 'react'
 import { Card } from 'components/Card/Card'
 import { Row } from 'components/Row/Row'
+import { RawText } from 'components/Text'
 import { getLogLevel, saveLogLevel } from 'lib/logger'
 
 export const Debugging = () => {
   const [logLevel, setLogLevel] = useState(getLogLevel())
+  const [visitorId, setVisitorId] = useState<string | null>(null)
+
+  const handleCopyClick = async () => {
+    try {
+      await navigator.clipboard.writeText(visitorId ?? '')
+      alert('Visitor ID copied!')
+    } catch (e) {
+      alert('Something went wrong')
+    }
+  }
+
+  useEffect(() => {
+    const pendoData = window.localStorage.getItem('visitorData')
+    if (pendoData) {
+      const value = JSON.parse(pendoData)
+      setVisitorId(value.visitorId.id)
+    }
+  }, [])
 
   return (
-    <Stack my={8} spacing={4}>
-      <Heading>Debugging</Heading>
+    <Stack my={8} spacing={4} flex={1}>
       <Card>
-        <Card.Body>
+        <Card.Header>
+          <Card.Heading>Debugging</Card.Heading>
+        </Card.Header>
+        <Card.Body as={Stack}>
           <Row alignItems='center'>
             <Row.Label>Log Level</Row.Label>
             <Row.Value>
@@ -50,14 +72,25 @@ export const Debugging = () => {
               </Menu>
             </Row.Value>
           </Row>
+          <Row alignItems='center'>
+            <Row.Label>Pendo visitor ID</Row.Label>
+            <Row.Value>
+              <RawText>{visitorId}</RawText>
+              <IconButton
+                aria-label='Copy'
+                size='sm'
+                icon={<CopyIcon />}
+                onClick={handleCopyClick}
+              />
+            </Row.Value>
+          </Row>
         </Card.Body>
+        <Card.Footer>
+          <Button onClick={() => window.location.reload()} colorScheme='blue'>
+            Reload
+          </Button>
+        </Card.Footer>
       </Card>
-
-      <HStack width='full'>
-        <Button onClick={() => window.location.reload()} colorScheme='blue'>
-          Reload
-        </Button>
-      </HStack>
     </Stack>
   )
 }

--- a/src/pages/Flags/Debugging.tsx
+++ b/src/pages/Flags/Debugging.tsx
@@ -72,7 +72,7 @@ export const Debugging = () => {
           </Row>
           <Row alignItems='center'>
             <Row.Label>Pendo visitor ID</Row.Label>
-            <Row.Value>
+            <Row.Value display='flex' gap={4}>
               <RawText>{visitorId}</RawText>
               <IconButton
                 aria-label='Copy'

--- a/src/pages/Flags/Flags.tsx
+++ b/src/pages/Flags/Flags.tsx
@@ -1,21 +1,10 @@
 import { Alert } from '@chakra-ui/alert'
-import { CopyIcon } from '@chakra-ui/icons'
-import {
-  AlertIcon,
-  Button,
-  Heading,
-  HStack,
-  IconButton,
-  Stack,
-  StackDivider,
-} from '@chakra-ui/react'
-import { Summary } from 'features/defi/components/Summary'
-import { useEffect, useState } from 'react'
+import { AlertIcon, Button, Heading, HStack, Stack, StackDivider } from '@chakra-ui/react'
+import { useState } from 'react'
 import { useDispatch } from 'react-redux'
 import { useHistory } from 'react-router-dom'
 import { Card } from 'components/Card/Card'
 import { Main } from 'components/Layout/Main'
-import { Row } from 'components/Row/Row'
 import { RawText } from 'components/Text'
 import { Debugging } from 'pages/Flags/Debugging'
 import { slices } from 'state/reducer'
@@ -45,7 +34,6 @@ export const Flags = () => {
   const dispatch = useDispatch<AppDispatch>()
   const featureFlags = useAppSelector(selectFeatureFlags)
   const [error, setError] = useState<string | null>(null)
-  const [visitorId, setVisitorId] = useState<string | null>(null)
 
   const handleApply = async () => {
     try {
@@ -68,22 +56,6 @@ export const Flags = () => {
       setError(String((e as Error)?.message))
     }
   }
-
-  const handleCopyClick = async () => {
-    try {
-      await navigator.clipboard.writeText(visitorId ?? '')
-      alert('Visitor ID copied!')
-    } catch (e) {
-      alert('Something went wrong')
-    }
-  }
-  useEffect(() => {
-    const pendoData = window.localStorage.getItem('visitorData')
-    if (pendoData) {
-      const value = JSON.parse(pendoData)
-      setVisitorId(value.visitorId.id)
-    }
-  }, [])
 
   return (
     <Main titleComponent={<FlagHeader />}>

--- a/src/pages/Flags/Flags.tsx
+++ b/src/pages/Flags/Flags.tsx
@@ -1,10 +1,21 @@
 import { Alert } from '@chakra-ui/alert'
-import { AlertIcon, Button, Heading, HStack, Stack, StackDivider } from '@chakra-ui/react'
-import { useState } from 'react'
+import { CopyIcon } from '@chakra-ui/icons'
+import {
+  AlertIcon,
+  Button,
+  Heading,
+  HStack,
+  IconButton,
+  Stack,
+  StackDivider,
+} from '@chakra-ui/react'
+import { Summary } from 'features/defi/components/Summary'
+import { useEffect, useState } from 'react'
 import { useDispatch } from 'react-redux'
 import { useHistory } from 'react-router-dom'
 import { Card } from 'components/Card/Card'
 import { Main } from 'components/Layout/Main'
+import { Row } from 'components/Row/Row'
 import { RawText } from 'components/Text'
 import { Debugging } from 'pages/Flags/Debugging'
 import { slices } from 'state/reducer'
@@ -34,6 +45,7 @@ export const Flags = () => {
   const dispatch = useDispatch<AppDispatch>()
   const featureFlags = useAppSelector(selectFeatureFlags)
   const [error, setError] = useState<string | null>(null)
+  const [visitorId, setVisitorId] = useState<string | null>(null)
 
   const handleApply = async () => {
     try {
@@ -57,27 +69,45 @@ export const Flags = () => {
     }
   }
 
+  const handleCopyClick = async () => {
+    try {
+      await navigator.clipboard.writeText(visitorId ?? '')
+      alert('Visitor ID copied!')
+    } catch (e) {
+      alert('Something went wrong')
+    }
+  }
+  useEffect(() => {
+    const pendoData = window.localStorage.getItem('visitorData')
+    if (pendoData) {
+      const value = JSON.parse(pendoData)
+      setVisitorId(value.visitorId.id)
+    }
+  }, [])
+
   return (
     <Main titleComponent={<FlagHeader />}>
-      <Card>
-        <Card.Body>
-          <Stack divider={<StackDivider />}>
-            {Object.keys(featureFlags).map((flag, idx) => (
-              <FlagRow key={idx} flag={flag as keyof FeatureFlags} />
-            ))}
-          </Stack>
-        </Card.Body>
-      </Card>
+      <Stack direction={{ base: 'column', md: 'row' }} spacing={6}>
+        <Card flex={1}>
+          <Card.Body>
+            <Stack divider={<StackDivider />}>
+              {Object.keys(featureFlags).map((flag, idx) => (
+                <FlagRow key={idx} flag={flag as keyof FeatureFlags} />
+              ))}
+            </Stack>
+          </Card.Body>
+          <Card.Footer>
+            <HStack my={4} width='full'>
+              <Button onClick={handleApply} colorScheme='blue'>
+                Apply
+              </Button>
+              <Button onClick={handleResetPrefs}>Reset Flags to Default</Button>
+            </HStack>
+          </Card.Footer>
+        </Card>
 
-      <HStack my={4} width='full'>
-        <Button onClick={handleApply} colorScheme='blue'>
-          Apply
-        </Button>
-        <Button onClick={handleResetPrefs}>Reset Flags to Default</Button>
-      </HStack>
-
-      <Debugging />
-
+        <Debugging />
+      </Stack>
       {error && (
         <Alert status='error'>
           <AlertIcon />


### PR DESCRIPTION
## Description

Need an easy way for people to grab their visitor ID that are helping us test.

## Notice

<!-- Before submitting a pull request, please make sure you have answered the following: -->

- [x] Have you followed the guidelines in our [Contributing]('https://github.com/shapeshift/web/CONTRIBUTING.md) guide?
- [x] Have you checked to ensure there aren't other open [Pull Requests](https://github.com/shapeshift/web/pulls) for the same update/change?

## Pull Request Type

- [ ] :bug: Bug fix (Non-breaking Change: Fixes an issue)
- [ ] :hammer_and_wrench: Chore (Non-breaking Change: Doc updates, pkg upgrades, typos, etc..)
- [x] :nail_care: New Feature (Breaking/Non-breaking Change)

## Issue (if applicable)

<!-----------------------------------------------------------------------------
If applicable, please link to the github issue and put `closes #XXXX` in your comment to auto-close the issue that your PR fixes.
------------------------------------------------------------------------------>

## Risk

This a hidden page so not real risk.

## Testing

Going to the flags page you will see your visitor ID and be able to copy it.

## Screenshots (if applicable)
![Screen Shot 2022-08-25 at 4 12 52 PM](https://user-images.githubusercontent.com/89934888/186769866-7d1789d8-5094-4832-b630-760f217ca831.png)

