### PR TITLE
feat: add new welcome modal for mobile users

### DIFF
--- a/src/assets/translations/en/main.json
+++ b/src/assets/translations/en/main.json
@@ -806,6 +806,19 @@
         "ILS": "Israeli Shekel",
         "IDR": "Indonesian Rupiah"
       }
+    },
+    "mobileWelcome": {
+      "success": {
+        "header": "Your wallet has been imported!",
+        "body": "Welcome to the new ShapeShift App.",
+        "primaryCta": "Continue"
+      },
+      "notice": {
+        "header": "Login with email is being deprecated. Backup your wallet now!",
+        "body": "If you ever lose access to your device, you need your secret recovery phrase to recover your funds.",
+        "primaryCta": "Get Secret Recovery Phrase",
+        "secondaryCta": "I already know my secret recovery phrase"
+      }
     }
   },
   "walletProvider": {

--- a/src/components/Layout/Header/Header.tsx
+++ b/src/components/Layout/Header/Header.tsx
@@ -1,7 +1,6 @@
 import { HamburgerIcon, InfoIcon } from '@chakra-ui/icons'
 import {
   Box,
-  Button,
   Drawer,
   DrawerContent,
   DrawerOverlay,

--- a/src/components/Layout/Header/Header.tsx
+++ b/src/components/Layout/Header/Header.tsx
@@ -1,6 +1,7 @@
 import { HamburgerIcon, InfoIcon } from '@chakra-ui/icons'
 import {
   Box,
+  Button,
   Drawer,
   DrawerContent,
   DrawerOverlay,

--- a/src/components/Layout/Header/NavBar/Native/BackupPassphraseModal/BackupPassphraseInfo.tsx
+++ b/src/components/Layout/Header/NavBar/Native/BackupPassphraseModal/BackupPassphraseInfo.tsx
@@ -22,6 +22,7 @@ import { useTranslate } from 'react-polyglot'
 import { useHistory } from 'react-router'
 import { SlideTransition } from 'components/SlideTransition'
 import { Text } from 'components/Text'
+import { useModal } from 'hooks/useModal/useModal'
 import { logger } from 'lib/logger'
 
 import { BackupPassphraseRoutes } from './BackupPassphraseCommon'
@@ -33,6 +34,11 @@ const moduleLogger = logger.child({
 export const BackupPassphraseInfo = ({ vault }: { vault: Vault | null }) => {
   const translate = useTranslate()
   const history = useHistory()
+  const {
+    backupNativePassphrase: {
+      props: { preventClose },
+    },
+  } = useModal()
   const [revealed, setRevealed] = useState<boolean>(false)
   const handleShow = () => {
     setRevealed(!revealed)
@@ -95,7 +101,7 @@ export const BackupPassphraseInfo = ({ vault }: { vault: Vault | null }) => {
       <ModalHeader pt={4}>
         <Text translation={'modals.shapeShift.backupPassphrase.info.title'} />
       </ModalHeader>
-      <ModalCloseButton />
+      {!preventClose && <ModalCloseButton />}
       <ModalBody>
         <Text
           color='gray.500'

--- a/src/components/Layout/Header/NavBar/Native/BackupPassphraseModal/BackupPassphraseModal.tsx
+++ b/src/components/Layout/Header/NavBar/Native/BackupPassphraseModal/BackupPassphraseModal.tsx
@@ -14,7 +14,11 @@ export const entries = [
   BackupPassphraseRoutes.Success,
 ]
 
-export const BackupPassphraseModal = () => {
+type BackupPassphraseModalProps = {
+  preventClose?: boolean
+}
+
+export const BackupPassphraseModal: React.FC<BackupPassphraseModalProps> = ({ preventClose }) => {
   const [vault, setVault] = useState<Vault | null>(null)
   const { backupNativePassphrase } = useModal()
   const { close, isOpen } = backupNativePassphrase
@@ -25,7 +29,13 @@ export const BackupPassphraseModal = () => {
   }
 
   return (
-    <Modal isCentered closeOnOverlayClick closeOnEsc isOpen={isOpen} onClose={handleClose}>
+    <Modal
+      isCentered
+      closeOnOverlayClick={!preventClose}
+      closeOnEsc={!preventClose}
+      isOpen={isOpen}
+      onClose={handleClose}
+    >
       <ModalOverlay />
       <ModalContent justifyContent='center' px={3} pt={3} pb={6}>
         <MemoryRouter initialEntries={entries}>

--- a/src/components/Layout/Header/NavBar/Native/BackupPassphraseModal/BackupPassphrasePassword.tsx
+++ b/src/components/Layout/Header/NavBar/Native/BackupPassphraseModal/BackupPassphrasePassword.tsx
@@ -21,6 +21,7 @@ import { IconCircle } from 'components/IconCircle'
 import { SlideTransition } from 'components/SlideTransition'
 import { RawText, Text } from 'components/Text'
 import { NativeWalletValues } from 'context/WalletProvider/NativeWallet/types'
+import { useModal } from 'hooks/useModal/useModal'
 import { useWallet } from 'hooks/useWallet/useWallet'
 
 import { BackupPassphraseRoutes } from './BackupPassphraseCommon'
@@ -30,6 +31,11 @@ export const BackupPassphrasePassword = ({ setVault }: { setVault: (vault: Vault
   const { state } = useWallet()
   const { walletInfo } = state
   const history = useHistory()
+  const {
+    backupNativePassphrase: {
+      props: { preventClose },
+    },
+  } = useModal()
 
   const [showPw, setShowPw] = useState<boolean>(false)
 
@@ -64,7 +70,7 @@ export const BackupPassphrasePassword = ({ setVault }: { setVault: (vault: Vault
       <ModalHeader>
         <Text translation={'modals.shapeShift.backupPassphrase.enterPassword'} />
       </ModalHeader>
-      <ModalCloseButton />
+      {!preventClose && <ModalCloseButton />}
       <ModalBody>
         <Button
           px={4}

--- a/src/components/Layout/Header/NavBar/Native/BackupPassphraseModal/BackupPassphraseTest.tsx
+++ b/src/components/Layout/Header/NavBar/Native/BackupPassphraseModal/BackupPassphraseTest.tsx
@@ -23,6 +23,7 @@ import { useTranslate } from 'react-polyglot'
 import { useHistory } from 'react-router'
 import { SlideTransition } from 'components/SlideTransition'
 import { RawText, Text } from 'components/Text'
+import { useModal } from 'hooks/useModal/useModal'
 
 import { BackupPassphraseRoutes } from './BackupPassphraseCommon'
 
@@ -44,6 +45,11 @@ type TestState = {
 export const BackupPassphraseTest = ({ vault }: { vault: Vault | null }) => {
   const translate = useTranslate()
   const history = useHistory()
+  const {
+    backupNativePassphrase: {
+      props: { preventClose },
+    },
+  } = useModal()
   const [testState, setTestState] = useState<TestState | null>(null)
   const [testCount, setTestCount] = useState<number>(0)
   const [revoker] = useState(new (Revocable(class {}))())
@@ -126,7 +132,7 @@ export const BackupPassphraseTest = ({ vault }: { vault: Vault | null }) => {
       <ModalHeader pt={4}>
         <Text translation={'modals.shapeShift.backupPassphrase.testTitle'} />
       </ModalHeader>
-      <ModalCloseButton />
+      {!preventClose && <ModalCloseButton />}
       <ModalBody>
         <RawText>
           <Text

--- a/src/components/Modals/MobileWelcome/MobileWelcomeModal.tsx
+++ b/src/components/Modals/MobileWelcome/MobileWelcomeModal.tsx
@@ -8,11 +8,7 @@ import { Notice } from './views/Notice'
 
 export const MobileWelcomeModal = () => {
   const { mobileWelcomeModal } = useModal()
-  const { close, isOpen } = mobileWelcomeModal
-
-  const handleClose = () => {
-    close()
-  }
+  const { close: handleClose, isOpen } = mobileWelcomeModal
 
   return (
     <Modal
@@ -26,17 +22,15 @@ export const MobileWelcomeModal = () => {
       <ModalContent justifyContent='center' px={3} pt={3} pb={6}>
         <MemoryRouter>
           <Route>
-            {({ location }) => {
-              return (
-                <AnimatePresence exitBeforeEnter initial={false}>
-                  <Switch key={location.key} location={location}>
-                    <Route path='/success' component={ImportSuccess} />
-                    <Route path='/notice' component={Notice} />
-                    <Redirect exact from='/' to='/success' />
-                  </Switch>
-                </AnimatePresence>
-              )
-            }}
+            {({ location }) => (
+              <AnimatePresence exitBeforeEnter initial={false}>
+                <Switch key={location.key} location={location}>
+                  <Route path='/success' component={ImportSuccess} />
+                  <Route path='/notice' component={Notice} />
+                  <Redirect exact from='/' to='/success' />
+                </Switch>
+              </AnimatePresence>
+            )}
           </Route>
         </MemoryRouter>
       </ModalContent>

--- a/src/components/Modals/MobileWelcome/MobileWelcomeModal.tsx
+++ b/src/components/Modals/MobileWelcome/MobileWelcomeModal.tsx
@@ -1,0 +1,45 @@
+import { Modal, ModalContent, ModalOverlay } from '@chakra-ui/react'
+import { AnimatePresence } from 'framer-motion'
+import { MemoryRouter, Redirect, Route, Switch } from 'react-router'
+import { useModal } from 'hooks/useModal/useModal'
+
+import { ImportSuccess } from './views/ImportSuccess'
+import { Notice } from './views/Notice'
+
+export const MobileWelcomeModal = () => {
+  const { mobileWelcomeModal } = useModal()
+  const { close, isOpen } = mobileWelcomeModal
+
+  const handleClose = () => {
+    close()
+  }
+
+  return (
+    <Modal
+      isCentered
+      closeOnOverlayClick={false}
+      closeOnEsc={false}
+      isOpen={isOpen}
+      onClose={handleClose}
+    >
+      <ModalOverlay />
+      <ModalContent justifyContent='center' px={3} pt={3} pb={6}>
+        <MemoryRouter>
+          <Route>
+            {({ location }) => {
+              return (
+                <AnimatePresence exitBeforeEnter initial={false}>
+                  <Switch key={location.key} location={location}>
+                    <Route path='/success' component={ImportSuccess} />
+                    <Route path='/notice' component={Notice} />
+                    <Redirect exact from='/' to='/success' />
+                  </Switch>
+                </AnimatePresence>
+              )
+            }}
+          </Route>
+        </MemoryRouter>
+      </ModalContent>
+    </Modal>
+  )
+}

--- a/src/components/Modals/MobileWelcome/views/ImportSuccess.tsx
+++ b/src/components/Modals/MobileWelcome/views/ImportSuccess.tsx
@@ -1,0 +1,39 @@
+import { ArrowForwardIcon, CheckCircleIcon } from '@chakra-ui/icons'
+import { Button, ModalBody, ModalFooter, Stack } from '@chakra-ui/react'
+import { useTranslate } from 'react-polyglot'
+import { useHistory } from 'react-router'
+import { SlideTransition } from 'components/SlideTransition'
+import { Text } from 'components/Text'
+
+export const ImportSuccess = () => {
+  const history = useHistory()
+  const translate = useTranslate()
+  return (
+    <SlideTransition>
+      <ModalBody>
+        <Stack justifyContent='center' alignItems='center' spacing={4} py={10}>
+          <CheckCircleIcon boxSize='12' color='green.500' />
+          <Stack spacing={0} textAlign='center'>
+            <Text
+              fontSize='lg'
+              fontWeight='bold'
+              translation='modals.mobileWelcome.success.header'
+            />
+            <Text color='gray.500' translation='modals.mobileWelcome.success.body' />
+          </Stack>
+        </Stack>
+      </ModalBody>
+      <ModalFooter flexDir='column'>
+        <Button
+          width='full'
+          size='lg'
+          colorScheme='blue'
+          onClick={() => history.push('/notice')}
+          rightIcon={<ArrowForwardIcon />}
+        >
+          {translate('modals.mobileWelcome.success.primaryCta')}
+        </Button>
+      </ModalFooter>
+    </SlideTransition>
+  )
+}

--- a/src/components/Modals/MobileWelcome/views/ImportSuccess.tsx
+++ b/src/components/Modals/MobileWelcome/views/ImportSuccess.tsx
@@ -1,5 +1,6 @@
 import { ArrowForwardIcon, CheckCircleIcon } from '@chakra-ui/icons'
 import { Button, ModalBody, ModalFooter, Stack } from '@chakra-ui/react'
+import { useCallback } from 'react'
 import { useTranslate } from 'react-polyglot'
 import { useHistory } from 'react-router'
 import { SlideTransition } from 'components/SlideTransition'
@@ -8,6 +9,9 @@ import { Text } from 'components/Text'
 export const ImportSuccess = () => {
   const history = useHistory()
   const translate = useTranslate()
+  
+  const handleContinueClick = useCallback(() => history.push('/notice'), [history])
+  
   return (
     <SlideTransition>
       <ModalBody>
@@ -28,7 +32,7 @@ export const ImportSuccess = () => {
           width='full'
           size='lg'
           colorScheme='blue'
-          onClick={() => history.push('/notice')}
+          onClick={handleContinueClick}
           rightIcon={<ArrowForwardIcon />}
         >
           {translate('modals.mobileWelcome.success.primaryCta')}

--- a/src/components/Modals/MobileWelcome/views/Notice.tsx
+++ b/src/components/Modals/MobileWelcome/views/Notice.tsx
@@ -1,0 +1,56 @@
+import { ArrowForwardIcon, WarningTwoIcon } from '@chakra-ui/icons'
+import { Box, Button, ModalBody, ModalFooter, Stack, useColorModeValue } from '@chakra-ui/react'
+import { useTranslate } from 'react-polyglot'
+import { AccountsIcon } from 'components/Icons/Accounts'
+import { SlideTransition } from 'components/SlideTransition'
+import { Text } from 'components/Text'
+import { useModal } from 'hooks/useModal/useModal'
+
+export const Notice = () => {
+  const translate = useTranslate()
+  const iconColor = useColorModeValue('gray.200', 'gray.700')
+  const {
+    mobileWelcomeModal: { close },
+    backupNativePassphrase: { open },
+  } = useModal()
+
+  const handleRecoveryClick = () => {
+    close()
+    open({ preventClose: true })
+  }
+  return (
+    <SlideTransition>
+      <ModalBody>
+        <Stack justifyContent='center' alignItems='center' spacing={4} py={6}>
+          <Box position='relative'>
+            <AccountsIcon boxSize='16' color={iconColor} />
+            <WarningTwoIcon boxSize='6' color='yellow.300' position='absolute' right={-4} top={2} />
+          </Box>
+
+          <Stack textAlign='center' spacing={2}>
+            <Text
+              fontSize='lg'
+              fontWeight='bold'
+              translation='modals.mobileWelcome.notice.header'
+            />
+            <Text color='gray.500' translation='modals.mobileWelcome.notice.body' />
+          </Stack>
+        </Stack>
+      </ModalBody>
+      <ModalFooter flexDir='column' gap={2}>
+        <Button
+          width='full'
+          size='lg'
+          colorScheme='blue'
+          onClick={handleRecoveryClick}
+          rightIcon={<ArrowForwardIcon />}
+        >
+          {translate('modals.mobileWelcome.notice.primaryCta')}
+        </Button>
+        <Button width='full' colorScheme='blue' variant='ghost' onClick={() => close()}>
+          {translate('modals.mobileWelcome.notice.secondaryCta')}
+        </Button>
+      </ModalFooter>
+    </SlideTransition>
+  )
+}

--- a/src/components/Modals/MobileWelcome/views/Notice.tsx
+++ b/src/components/Modals/MobileWelcome/views/Notice.tsx
@@ -10,12 +10,12 @@ export const Notice = () => {
   const translate = useTranslate()
   const iconColor = useColorModeValue('gray.200', 'gray.700')
   const {
-    mobileWelcomeModal: { close },
+    mobileWelcomeModal: { close: handleClose },
     backupNativePassphrase: { open },
   } = useModal()
 
   const handleRecoveryClick = () => {
-    close()
+    handleClose()
     open({ preventClose: true })
   }
   return (
@@ -47,7 +47,7 @@ export const Notice = () => {
         >
           {translate('modals.mobileWelcome.notice.primaryCta')}
         </Button>
-        <Button width='full' colorScheme='blue' variant='ghost' onClick={() => close()}>
+        <Button width='full' colorScheme='blue' variant='ghost' onClick={handleClose}>
           {translate('modals.mobileWelcome.notice.secondaryCta')}
         </Button>
       </ModalFooter>

--- a/src/context/ModalProvider/ModalProvider.tsx
+++ b/src/context/ModalProvider/ModalProvider.tsx
@@ -5,6 +5,7 @@ import React, { useMemo, useReducer } from 'react'
 import { WipeModal } from 'components/Layout/Header/NavBar/KeepKey/Modals/Wipe'
 import { BackupPassphraseModal } from 'components/Layout/Header/NavBar/Native/BackupPassphraseModal/BackupPassphraseModal'
 import { FiatRampsModal } from 'components/Modals/FiatRamps/FiatRamps'
+import { MobileWelcomeModal } from 'components/Modals/MobileWelcome/MobileWelcomeModal'
 import { ReceiveModal } from 'components/Modals/Receive/Receive'
 import { SendModal } from 'components/Modals/Send/Send'
 import { SettingsModal } from 'components/Modals/Settings/Settings'
@@ -22,6 +23,7 @@ const MODALS = {
   keepKeyWipe: WipeModal,
   consentOptin: OptInModal,
   backupNativePassphrase: BackupPassphraseModal,
+  mobileWelcomeModal: MobileWelcomeModal,
 }
 
 // state


### PR DESCRIPTION
## Description

Add the new welcome modal UI for mobile users that prompts them to backup their wallet.

You have to manually trigger the modal to see it right now. Follow up PR will be done to trigger the modal.

## Notice

<!-- Before submitting a pull request, please make sure you have answered the following: -->

- [x] Have you followed the guidelines in our [Contributing]('https://github.com/shapeshift/web/CONTRIBUTING.md) guide?
- [x] Have you checked to ensure there aren't other open [Pull Requests](https://github.com/shapeshift/web/pulls) for the same update/change?

## Pull Request Type

- [ ] :bug: Bug fix (Non-breaking Change: Fixes an issue)
- [ ] :hammer_and_wrench: Chore (Non-breaking Change: Doc updates, pkg upgrades, typos, etc..)
- [x] :nail_care: New Feature (Breaking/Non-breaking Change)

## Issue (if applicable)

https://github.com/shapeshift/mobile-app/issues/39

## Risk

Very small risk to the backup my wallet modal, I adjusted some logic to not allow mobile users to exit.

## Testing

Make sure you can backup your wallet as normal, and close out of the modal freely.

### Engineering

Use the modal context to trigger the `mobileWelcomeModal` modal

### Operations

Make sure you can backup your wallet as normal, and close out of the modal freely.

## Screenshots (if applicable)
![Screen Shot 2022-08-26 at 2 06 36 AM](https://user-images.githubusercontent.com/89934888/186843976-0f288380-849a-418b-ab69-4f1ae6a7a964.png)
![Screen Shot 2022-08-26 at 2 06 39 AM](https://user-images.githubusercontent.com/89934888/186844000-08f8f483-b52a-4982-b4c3-aedbaab46fc5.png)

