### PR TITLE
feat: auto enable pendo for mobile app

### DIFF
--- a/src/components/LoadingBody.tsx
+++ b/src/components/LoadingBody.tsx
@@ -1,0 +1,22 @@
+import { Center } from '@chakra-ui/react'
+import { PropsWithChildren } from 'react'
+
+import { CircularProgress } from './CircularProgress/CircularProgress'
+
+type LoadingBodyProps = {
+  isLoaded?: boolean
+} & PropsWithChildren
+
+export const LoadingBody: React.FC<LoadingBodyProps> = ({ isLoaded, children }) => {
+  return (
+    <>
+      {isLoaded ? (
+        children
+      ) : (
+        <Center minHeight='24'>
+          <CircularProgress />
+        </Center>
+      )}
+    </>
+  )
+}

--- a/src/lib/globals.ts
+++ b/src/lib/globals.ts
@@ -4,4 +4,4 @@ declare global {
   }
 }
 
-export const isMobile = true
+export const isMobile = Boolean(window.isShapeShiftMobile)

--- a/src/lib/globals.ts
+++ b/src/lib/globals.ts
@@ -4,4 +4,4 @@ declare global {
   }
 }
 
-export const isMobile = Boolean(window.isShapeShiftMobile)
+export const isMobile = true

--- a/src/plugins/pendo/components/OptInModal/OptInModal.tsx
+++ b/src/plugins/pendo/components/OptInModal/OptInModal.tsx
@@ -34,6 +34,9 @@ export const OptInModal: React.FC = () => {
     moduleLogger.trace({ consent }, 'Consent Check')
     if (isMobile || consent) {
       // Auto launch if mobile or if they have consented
+      if (isMobile && !consent) {
+        VisitorDataManager.recordConsent(CONSENT_TAG, true)
+      }
       launch()
     } else if (!consent && !isOpen && hasWallet) {
       moduleLogger.debug({ consent }, 'Showing consent modal')

--- a/src/plugins/pendo/components/OptInModal/OptInModal.tsx
+++ b/src/plugins/pendo/components/OptInModal/OptInModal.tsx
@@ -7,6 +7,7 @@ import { VisitorDataManager } from 'plugins/pendo/visitorData'
 import { useEffect } from 'react'
 import { useFeatureFlag } from 'hooks/useFeatureFlag/useFeatureFlag'
 import { useWallet } from 'hooks/useWallet/useWallet'
+import { isMobile } from 'lib/globals'
 import { logger } from 'lib/logger'
 
 const moduleLogger = logger.child({ namespace: ['Plugins', 'Pendo', 'OptInModal'] })
@@ -31,11 +32,12 @@ export const OptInModal: React.FC = () => {
     const CONSENT_TAG = `pendo_${getConfig().REACT_APP_PENDO_CONSENT_VERSION}`
     const consent = VisitorDataManager.checkConsent(CONSENT_TAG)
     moduleLogger.trace({ consent }, 'Consent Check')
-    if (typeof consent === 'undefined' && !isOpen && hasWallet) {
+    if (isMobile || consent) {
+      // Auto launch if mobile or if they have consented
+      launch()
+    } else if (!consent && !isOpen && hasWallet) {
       moduleLogger.debug({ consent }, 'Showing consent modal')
       onOpen()
-    } else if (consent === true) {
-      launch() // launch is memoized so it'll only run once
     }
   }, [enabled, hasWallet, isOpen, onOpen])
 

--- a/src/plugins/pendo/components/OptInModal/OptInModalBody.tsx
+++ b/src/plugins/pendo/components/OptInModal/OptInModalBody.tsx
@@ -15,6 +15,7 @@ import { useEffect } from 'react'
 import { IoMdCheckmark, IoMdClose } from 'react-icons/io'
 import { Text } from 'components/Text'
 import { useFeatureFlag } from 'hooks/useFeatureFlag/useFeatureFlag'
+import { isMobile } from 'lib/globals'
 import { logger } from 'lib/logger'
 
 import { OptInIcon } from './OptInIcon'
@@ -37,9 +38,10 @@ export const OptInModalBody: React.FC<OptInModalProps> = ({ onContinue }) => {
 
   useEffect(() => {
     if (!enabled) onContinue()
-    if (typeof consent === 'boolean') {
+    // Auto launch if mobile or if they have consented
+    if (consent || isMobile) {
       moduleLogger.trace({ consent }, 'User has selected their consent')
-      if (consent) launch()
+      launch()
       onContinue()
     }
   }, [consent, enabled, onContinue])

--- a/src/plugins/pendo/components/OptInModal/OptInModalBody.tsx
+++ b/src/plugins/pendo/components/OptInModal/OptInModalBody.tsx
@@ -53,11 +53,17 @@ export const OptInModalBody: React.FC<OptInModalProps> = ({ onContinue }) => {
   const handleConfirm = async () => {
     moduleLogger.trace({ fn: 'handleConfirm' }, 'Confirmed')
     VisitorDataManager.recordConsent(CONSENT_TAG, true)
+    // Duplicate logic as in the useEffect above but DON'T remove it
+    // consent is not reactive and it won't update and do what you'd expect by moving the following lines in a useEffect()
     launch()
     onContinue()
   }
 
   return enabled ? (
+    // If we haven't recorded user consent, <LoadingBody /> will render children
+    // This looks wrong, but this route actually gets rendered once
+    // If we have a consent, we push another route
+    // Else, we also push another route, recording consent in case of mobile users
     <LoadingBody isLoaded={!consent}>
       <ModalBody py={8}>
         <OptInIcon mb={4} />

--- a/src/plugins/pendo/components/OptInModal/OptInModalBody.tsx
+++ b/src/plugins/pendo/components/OptInModal/OptInModalBody.tsx
@@ -35,8 +35,7 @@ export const OptInModalBody: React.FC<OptInModalProps> = ({ onContinue }) => {
   const borderColor = useColorModeValue('gray.100', 'gray.750')
 
   const CONSENT_TAG = `pendo_${getConfig().REACT_APP_PENDO_CONSENT_VERSION}`
-  // eslint-disable-next-line react-hooks/exhaustive-deps
-  const consent = useMemo(() => VisitorDataManager.checkConsent(CONSENT_TAG), [])
+  const consent = useMemo(() => VisitorDataManager.checkConsent(CONSENT_TAG), [CONSENT_TAG])
 
   useEffect(() => {
     if (!enabled) onContinue()

--- a/src/plugins/pendo/components/OptInModal/OptInModalBody.tsx
+++ b/src/plugins/pendo/components/OptInModal/OptInModalBody.tsx
@@ -58,7 +58,7 @@ export const OptInModalBody: React.FC<OptInModalProps> = ({ onContinue }) => {
   }
 
   return enabled ? (
-    <LoadingBody isLoaded={consent}>
+    <LoadingBody isLoaded={!consent}>
       <ModalBody py={8}>
         <OptInIcon mb={4} />
         <Text

--- a/src/plugins/pendo/components/OptInModal/OptInModalBody.tsx
+++ b/src/plugins/pendo/components/OptInModal/OptInModalBody.tsx
@@ -58,7 +58,7 @@ export const OptInModalBody: React.FC<OptInModalProps> = ({ onContinue }) => {
   }
 
   return enabled ? (
-    <LoadingBody isLoaded={typeof consent !== 'boolean'}>
+    <LoadingBody isLoaded={consent}>
       <ModalBody py={8}>
         <OptInIcon mb={4} />
         <Text


### PR DESCRIPTION
## Description

- For the mobile app we will be running pendo by default, check the `isMobile` global var if its true --- launch pendo.

## Notice

<!-- Before submitting a pull request, please make sure you have answered the following: -->

- [x] Have you followed the guidelines in our [Contributing]('https://github.com/shapeshift/web/CONTRIBUTING.md) guide?
- [x] Have you checked to ensure there aren't other open [Pull Requests](https://github.com/shapeshift/web/pulls) for the same update/change?

## Pull Request Type

- [ ] :bug: Bug fix (Non-breaking Change: Fixes an issue)
- [ ] :hammer_and_wrench: Chore (Non-breaking Change: Doc updates, pkg upgrades, typos, etc..)
- [x] :nail_care: New Feature (Breaking/Non-breaking Change)

## Issue (if applicable)

https://github.com/shapeshift/mobile-app/issues/38


## Risk

Small risk that pendo modal doesn't launch correctly

## Testing

Test the pendo modal is launched on web browsers as normal

### Engineering

Can't really test locally.

### Operations

Go to the fleak build, and confirm that you still see the consent modal for pendo.

## Screenshots (if applicable)
