### PR TITLE
fix: correct osmo explorer link

### DIFF
--- a/src/components/Trade/TradeConfirm/TradeConfirm.tsx
+++ b/src/components/Trade/TradeConfirm/TradeConfirm.tsx
@@ -146,13 +146,13 @@ export const TradeConfirm = ({ history }: RouterProps) => {
   const txLink = useMemo(() => {
     switch (trade.sources[0].name) {
       case 'Osmosis':
-        return `${osmosisAsset?.explorerTxLink}${buyTxid}`
+        return `${osmosisAsset?.explorerTxLink}${sellTxid}`
       case 'CowSwap':
         return `https://explorer.cow.fi/orders/${sellTxid}`
       default:
         return `${trade.sellAsset?.explorerTxLink}${sellTxid}`
     }
-  }, [trade, sellTxid, osmosisAsset, buyTxid])
+  }, [trade, sellTxid, osmosisAsset])
 
   return (
     <SlideTransition>


### PR DESCRIPTION
## Description

use sell asset explorer link as buy asset does not always exist right away.

## Notice

<!-- Before submitting a pull request, please make sure you have answered the following: -->

- [x] Have you followed the guidelines in our [Contributing]('https://github.com/shapeshift/web/CONTRIBUTING.md) guide?
- [x] Have you checked to ensure there aren't other open [Pull Requests](https://github.com/shapeshift/web/pulls) for the same update/change?

## Pull Request Type

- [x] :bug: Bug fix (Non-breaking Change: Fixes an issue)
- [ ] :hammer_and_wrench: Chore (Non-breaking Change: Doc updates, pkg upgrades, typos, etc..)
- [ ] :nail_care: New Feature (Breaking/Non-breaking Change)

## Risk

no risk

## Testing

do osmo -> atom trade or vice versa and when explorer link appears it should go to the osmosis "trade" transaction

