### PR TITLE
fix: osmo cosmo urls reversed

### DIFF
--- a/.env.base
+++ b/.env.base
@@ -33,8 +33,8 @@ REACT_APP_COWSWAP_HTTP_URL=https://api.cow.fi/mainnet/api
 REACT_APP_MIDGARD_URL=https://midgard.thorswap.net/v2
 
 # nodes
-REACT_APP_OSMOSIS_NODE_URL=https://cosmoshub-4--lcd--full.datahub.figment.io/apikey/14c056a2415b6e0d2b9f55985214f3f1/
-REACT_APP_COSMOS_NODE_URL=https://osmosis-1--lcd--full.datahub.figment.io/apikey/14c056a2415b6e0d2b9f55985214f3f1/
+REACT_APP_COSMOS_NODE_URL=https://cosmoshub-4--lcd--full.datahub.figment.io/apikey/14c056a2415b6e0d2b9f55985214f3f1/
+REACT_APP_OSMOSIS_NODE_URL=https://osmosis-1--lcd--full.datahub.figment.io/apikey/14c056a2415b6e0d2b9f55985214f3f1/
 REACT_APP_ALCHEMY_POLYGON_URL=https://polygon-mainnet.g.alchemy.com/v2/458rwsHQDajSOTCdC5AACXQUMYrllacR
 REACT_APP_ETHEREUM_NODE_URL=https://mainnet.infura.io/v3/71acfee9f8544347a4676bd8affa26b8
 REACT_APP_AVALANCHE_NODE_URL=https://api.avax.network/ext/bc/C/rpc

--- a/package.json
+++ b/package.json
@@ -104,7 +104,7 @@
     "@shapeshiftoss/investor-yearn": "^4.1.0",
     "@shapeshiftoss/logger": "^1.1.2",
     "@shapeshiftoss/market-service": "^6.5.0",
-    "@shapeshiftoss/swapper": "^9.17.0",
+    "@shapeshiftoss/swapper": "^9.17.1",
     "@shapeshiftoss/types": "^8.2.0",
     "@shapeshiftoss/unchained-client": "^9.9.0",
     "@uniswap/sdk": "^3.0.3",

--- a/yarn.lock
+++ b/yarn.lock
@@ -4038,10 +4038,10 @@
     google-protobuf "^3.17.0"
     long "^4.0.0"
 
-"@shapeshiftoss/swapper@^9.17.0":
-  version "9.17.0"
-  resolved "https://registry.yarnpkg.com/@shapeshiftoss/swapper/-/swapper-9.17.0.tgz#e8e68b862a7aa6f6eda1c7be77ab4619f73455a9"
-  integrity sha512-nG+0IWjl7puuYsvHRd+jT6p58J+U+WodWmq/r/qFLQreZzed+wYH1OZuGaHkT1j/mF+vrpJa//G7Js0cmEoGFw==
+"@shapeshiftoss/swapper@^9.17.1":
+  version "9.17.1"
+  resolved "https://registry.yarnpkg.com/@shapeshiftoss/swapper/-/swapper-9.17.1.tgz#c4bd8ddb0d0df5a49ce21cc50cd12d240142d6ff"
+  integrity sha512-FwfSN3a2BX/YhUGHrrivybipt9zHtIatbBxlWxO/A7pSB+kPx6WOvb84vWYnID3v5Fqn/j6WyBDju+H6QjDNww==
   dependencies:
     axios "^0.26.1"
     bignumber.js "^9.0.2"


### PR DESCRIPTION
## Description

Osmosis and cosmos node urls were reversed, breaking osmosis swapping. Swapping is now working again with this pr

## Notice

<!-- Before submitting a pull request, please make sure you have answered the following: -->

- [x] Have you followed the guidelines in our [Contributing]('https://github.com/shapeshift/web/CONTRIBUTING.md) guide?
- [x] Have you checked to ensure there aren't other open [Pull Requests](https://github.com/shapeshift/web/pulls) for the same update/change?

## Pull Request Type

- [x] :bug: Bug fix (Non-breaking Change: Fixes an issue)
- [ ] :hammer_and_wrench: Chore (Non-breaking Change: Doc updates, pkg upgrades, typos, etc..)
- [ ] :nail_care: New Feature (Breaking/Non-breaking Change)

## Risk

none. fixes incorrect osmosis & cosmos urls

## Testing

1) Enable osmosis trading feature flag
2) Perform an atom -> osmosis  (or vice versa)  swap and see that it completes with no errors

### Engineering

see testing section

### Operations

see testing section
