### PR TITLE
fix: hotfix osmo cosmo urls reversed

### DIFF
--- a/.env.base
+++ b/.env.base
@@ -33,8 +33,8 @@ REACT_APP_COWSWAP_HTTP_URL=https://api.cow.fi/mainnet/api
 REACT_APP_MIDGARD_URL=https://midgard.thorswap.net/v2
 
 # nodes
-REACT_APP_OSMOSIS_NODE_URL=https://cosmoshub-4--lcd--full.datahub.figment.io/apikey/14c056a2415b6e0d2b9f55985214f3f1/
-REACT_APP_COSMOS_NODE_URL=https://osmosis-1--lcd--full.datahub.figment.io/apikey/14c056a2415b6e0d2b9f55985214f3f1/
+REACT_APP_COSMOS_NODE_URL=https://cosmoshub-4--lcd--full.datahub.figment.io/apikey/14c056a2415b6e0d2b9f55985214f3f1/
+REACT_APP_OSMOSIS_NODE_URL=https://osmosis-1--lcd--full.datahub.figment.io/apikey/14c056a2415b6e0d2b9f55985214f3f1/
 REACT_APP_ALCHEMY_POLYGON_URL=https://polygon-mainnet.g.alchemy.com/v2/458rwsHQDajSOTCdC5AACXQUMYrllacR
 REACT_APP_ETHEREUM_NODE_URL=https://mainnet.infura.io/v3/71acfee9f8544347a4676bd8affa26b8
 REACT_APP_AVALANCHE_NODE_URL=https://api.avax.network/ext/bc/C/rpc


### PR DESCRIPTION
## Description

cherry-pick from https://github.com/shapeshift/web/pull/2577 as a hotfix, picking only the env fix from it

## Notice

<!-- Before submitting a pull request, please make sure you have answered the following: -->

- [x] Have you followed the guidelines in our [Contributing]('https://github.com/shapeshift/web/CONTRIBUTING.md) guide?
- [x] Have you checked to ensure there aren't other open [Pull Requests](https://github.com/shapeshift/web/pulls) for the same update/change?

## Pull Request Type

- [x] :bug: Bug fix (Non-breaking Change: Fixes an issue)
- [ ] :hammer_and_wrench: Chore (Non-breaking Change: Doc updates, pkg upgrades, typos, etc..)
- [ ] :nail_care: New Feature (Breaking/Non-breaking Change)

## Issue (if applicable)

<!-----------------------------------------------------------------------------
If applicable, please link to the github issue and put `closes #XXXX` in your comment to auto-close the issue that your PR fixes.
------------------------------------------------------------------------------>

N/A - hotfix

## Risk

None, just reverts env vars to how they were before

## Testing

### Engineering

- Test we're able to get a Swapper quote for ATOM<->OSMO and proceed with a trade

### Operations

- Only related to Thor Osmo<->ATOM swapper trades, so no user-facing changes for ops to test with the `Thor` flag off but that will make you guys able to test whichever swapper changes come on Monday against an unrugged prod

## Screenshots (if applicable)

<img width="800" alt="image" src="https://user-images.githubusercontent.com/17035424/186968839-7119da7d-9b31-47dc-9999-8317d7907763.png">
<img width="1024" alt="image" src="https://user-images.githubusercontent.com/17035424/186969096-fb28bb62-6a6a-4685-b46d-506ac37ad302.png">

