### PR TITLE
feat: move providers to wallet state

### DIFF
--- a/src/context/WalletProvider/MetaMask/components/Connect.tsx
+++ b/src/context/WalletProvider/MetaMask/components/Connect.tsx
@@ -1,5 +1,4 @@
-import detectEthereumProvider from '@metamask/detect-provider'
-import React, { useEffect, useState } from 'react'
+import React, { useState } from 'react'
 import { isMobile } from 'react-device-detect'
 import { RouteComponentProps } from 'react-router-dom'
 import { ActionTypes, WalletActions } from 'context/WalletProvider/actions'
@@ -27,31 +26,20 @@ export const MetaMaskConnect = ({ history }: MetaMaskSetupProps) => {
   const { dispatch, state } = useWallet()
   const [loading, setLoading] = useState(false)
   const [error, setError] = useState<string | null>(null)
-  const [provider, setProvider] = useState<any>()
 
   // eslint-disable-next-line no-sequences
   const setErrorLoading = (e: string | null) => (setError(e), setLoading(false))
-
-  useEffect(() => {
-    ;(async () => {
-      try {
-        setProvider(await detectEthereumProvider())
-      } catch (e) {
-        if (!isMobile) moduleLogger.error(e, 'MetaMaskConnect errror')
-      }
-    })()
-  }, [setProvider])
 
   const pairDevice = async () => {
     setError(null)
     setLoading(true)
 
-    if (!provider) {
+    if (!state.provider) {
       throw new Error('walletProvider.metaMask.errors.connectFailure')
     }
 
     //Handles UX issues caused by MM and Tally Ho both being injected.
-    if (provider.isTally) {
+    if (state.provider.isTally) {
       setErrorLoading('walletProvider.metaMask.errors.tallyInstalledAndSetToDefault')
       throw new Error('Tally Ho wallet installed and set as default')
     }
@@ -70,14 +58,14 @@ export const MetaMaskConnect = ({ history }: MetaMaskSetupProps) => {
         // Hack to handle MetaMask account changes
         //TODO: handle this properly
         const resetState = () => dispatch({ type: WalletActions.RESET_STATE })
-        provider?.on?.('accountsChanged', resetState)
-        provider?.on?.('chainChanged', resetState)
+        state.provider?.on?.('accountsChanged', resetState)
+        state.provider?.on?.('chainChanged', resetState)
         const isLocked = await wallet.isLocked()
 
         const oldDisconnect = wallet.disconnect.bind(wallet)
         wallet.disconnect = () => {
-          provider?.removeListener?.('accountsChanged', resetState)
-          provider?.removeListener?.('chainChanged', resetState)
+          state.provider?.removeListener?.('accountsChanged', resetState)
+          state.provider?.removeListener?.('chainChanged', resetState)
           return oldDisconnect()
         }
 
@@ -114,7 +102,7 @@ export const MetaMaskConnect = ({ history }: MetaMaskSetupProps) => {
 
   // The MM mobile app itself injects a provider, so we'll use pairDevice once
   // we've reopened ourselves in that environment.
-  return !provider && isMobile ? (
+  return !state.provider && isMobile ? (
     <RedirectModal
       headerText={'walletProvider.metaMask.redirect.header'}
       bodyText={'walletProvider.metaMask.redirect.body'}

--- a/src/context/WalletProvider/MetaMask/components/Connect.tsx
+++ b/src/context/WalletProvider/MetaMask/components/Connect.tsx
@@ -64,8 +64,6 @@ export const MetaMaskConnect = ({ history }: MetaMaskSetupProps) => {
         // Hack to handle MetaMask account changes
         //TODO: handle this properly
         const resetState = () => dispatch({ type: WalletActions.RESET_STATE })
-        state.provider?.on?.('accountsChanged', resetState)
-        state.provider?.on?.('chainChanged', resetState)
         const isLocked = await wallet.isLocked()
 
         const oldDisconnect = wallet.disconnect.bind(wallet)

--- a/src/context/WalletProvider/MetaMask/components/Connect.tsx
+++ b/src/context/WalletProvider/MetaMask/components/Connect.tsx
@@ -61,17 +61,7 @@ export const MetaMaskConnect = ({ history }: MetaMaskSetupProps) => {
       try {
         const deviceId = await wallet.getDeviceID()
 
-        // Hack to handle MetaMask account changes
-        //TODO: handle this properly
-        const resetState = () => dispatch({ type: WalletActions.RESET_STATE })
         const isLocked = await wallet.isLocked()
-
-        const oldDisconnect = wallet.disconnect.bind(wallet)
-        wallet.disconnect = () => {
-          state.provider?.removeListener?.('accountsChanged', resetState)
-          state.provider?.removeListener?.('chainChanged', resetState)
-          return oldDisconnect()
-        }
 
         await wallet.initialize()
 

--- a/src/context/WalletProvider/MetaMask/components/Connect.tsx
+++ b/src/context/WalletProvider/MetaMask/components/Connect.tsx
@@ -1,4 +1,4 @@
-import React, { useState } from 'react'
+import React, { useEffect, useState } from 'react'
 import { isMobile } from 'react-device-detect'
 import { RouteComponentProps } from 'react-router-dom'
 import { ActionTypes, WalletActions } from 'context/WalletProvider/actions'
@@ -23,12 +23,18 @@ export interface MetaMaskSetupProps
 }
 
 export const MetaMaskConnect = ({ history }: MetaMaskSetupProps) => {
-  const { dispatch, state } = useWallet()
+  const { dispatch, state, onProviderChange } = useWallet()
   const [loading, setLoading] = useState(false)
   const [error, setError] = useState<string | null>(null)
 
   // eslint-disable-next-line no-sequences
   const setErrorLoading = (e: string | null) => (setError(e), setLoading(false))
+
+  useEffect(() => {
+    ;(async () => {
+      await onProviderChange(KeyManager.MetaMask)
+    })()
+  }, [onProviderChange])
 
   const pairDevice = async () => {
     setError(null)

--- a/src/context/WalletProvider/TallyHo/components/Connect.tsx
+++ b/src/context/WalletProvider/TallyHo/components/Connect.tsx
@@ -1,6 +1,6 @@
 import { CHAIN_REFERENCE } from '@shapeshiftoss/caip'
 import { TallyHoHDWallet } from '@shapeshiftoss/hdwallet-tallyho'
-import React, { useState } from 'react'
+import React, { useEffect, useState } from 'react'
 import { isMobile } from 'react-device-detect'
 import { RouteComponentProps } from 'react-router-dom'
 import { ActionTypes, WalletActions } from 'context/WalletProvider/actions'
@@ -27,12 +27,18 @@ export interface TallyHoSetupProps
 const moduleLogger = logger.child({ namespace: ['NativeWallet'] })
 
 export const TallyHoConnect = ({ history }: TallyHoSetupProps) => {
-  const { dispatch, state } = useWallet()
+  const { dispatch, state, onProviderChange } = useWallet()
   const [loading, setLoading] = useState(false)
   const [error, setError] = useState<string | null>(null)
 
   // eslint-disable-next-line no-sequences
   const setErrorLoading = (e: string | null) => (setError(e), setLoading(false))
+
+  useEffect(() => {
+    ;(async () => {
+      await onProviderChange(KeyManager.TallyHo)
+    })()
+  }, [onProviderChange])
 
   const pairDevice = async () => {
     setError(null)

--- a/src/context/WalletProvider/TallyHo/components/Connect.tsx
+++ b/src/context/WalletProvider/TallyHo/components/Connect.tsx
@@ -71,11 +71,7 @@ export const TallyHoConnect = ({ history }: TallyHoSetupProps) => {
           throw new Error('walletProvider.tallyHo.errors.network')
         }
 
-        // Hack to handle Tally account changes
-        //TODO: handle this properly
         const resetState = () => dispatch({ type: WalletActions.RESET_STATE })
-        state.provider?.on?.('accountsChanged', resetState)
-        state.provider?.on?.('chainChanged', resetState)
 
         const oldDisconnect = wallet.disconnect.bind(wallet)
         wallet.disconnect = () => {

--- a/src/context/WalletProvider/TallyHo/components/Connect.tsx
+++ b/src/context/WalletProvider/TallyHo/components/Connect.tsx
@@ -71,15 +71,6 @@ export const TallyHoConnect = ({ history }: TallyHoSetupProps) => {
           throw new Error('walletProvider.tallyHo.errors.network')
         }
 
-        const resetState = () => dispatch({ type: WalletActions.RESET_STATE })
-
-        const oldDisconnect = wallet.disconnect.bind(wallet)
-        wallet.disconnect = () => {
-          state.provider?.removeListener?.('accountsChanged', resetState)
-          state.provider?.removeListener?.('chainChanged', resetState)
-          return oldDisconnect()
-        }
-
         await wallet.initialize()
 
         dispatch({

--- a/src/context/WalletProvider/WalletConnect/components/Connect.tsx
+++ b/src/context/WalletProvider/WalletConnect/components/Connect.tsx
@@ -1,8 +1,5 @@
 import { WalletConnectHDWallet } from '@shapeshiftoss/hdwallet-walletconnect'
-import { WalletConnectProviderConfig } from '@shapeshiftoss/hdwallet-walletconnect'
-import WalletConnectProvider from '@walletconnect/web3-provider'
-import { getConfig } from 'config'
-import React, { useState } from 'react'
+import React, { useEffect, useState } from 'react'
 import { useTranslate } from 'react-polyglot'
 import { RouteComponentProps } from 'react-router-dom'
 import { ActionTypes, WalletActions } from 'context/WalletProvider/actions'
@@ -35,7 +32,7 @@ const moduleLogger = logger.child({
  * Test WalletConnect Tool: https://test.walletconnect.org/
  */
 export const WalletConnectConnect = ({ history }: WalletConnectSetupProps) => {
-  const { dispatch, state } = useWallet()
+  const { dispatch, state, onProviderChange } = useWallet()
   const [loading, setLoading] = useState(false)
   const [error, setError] = useState<string | null>(null)
   const translate = useTranslate()
@@ -45,20 +42,23 @@ export const WalletConnectConnect = ({ history }: WalletConnectSetupProps) => {
     setLoading(false)
   }
 
+  useEffect(() => {
+    ;(async () => {
+      await onProviderChange(KeyManager.WalletConnect)
+    })()
+  }, [onProviderChange])
+
   const pairDevice = async () => {
     setError(null)
     setLoading(true)
 
-    try {
-      const config: WalletConnectProviderConfig = {
-        /** List of RPC URLs indexed by chain ID */
-        rpc: {
-          1: getConfig().REACT_APP_ETHEREUM_NODE_URL,
-        },
-      }
+    if (!(state.provider && 'connector' in state.provider)) {
+      // TODO: error-handling in a stacked PR
+      return
+    }
 
-      const provider = new WalletConnectProvider(config)
-      provider.connector.on('disconnect', () => {
+    try {
+      state.provider.connector.on('disconnect', () => {
         // Handle WalletConnect session rejection
         history.push('/walletconnect/failure')
       })

--- a/src/context/WalletProvider/WalletContext.tsx
+++ b/src/context/WalletProvider/WalletContext.tsx
@@ -13,6 +13,7 @@ export interface IWalletContext {
   load: () => void
   setDeviceState: (deviceState: Partial<DeviceState>) => void
   connectDemo: () => Promise<void>
+  onProviderChange: (localWalletType: KeyManager) => Promise<void>
 }
 
 export const WalletContext = createContext<IWalletContext | null>(null)

--- a/src/context/WalletProvider/WalletProvider.tsx
+++ b/src/context/WalletProvider/WalletProvider.tsx
@@ -8,6 +8,7 @@ import { PortisHDWallet } from '@shapeshiftoss/hdwallet-portis'
 import { WalletConnectProviderConfig } from '@shapeshiftoss/hdwallet-walletconnect'
 import { getConfig } from 'config'
 import { PublicWalletXpubs } from 'constants/PublicWalletXpubs'
+import { providers } from 'ethers'
 import findIndex from 'lodash/findIndex'
 import omit from 'lodash/omit'
 import React, { useCallback, useEffect, useMemo, useReducer } from 'react'
@@ -70,6 +71,7 @@ const initialDeviceState: DeviceState = {
   recoveryCharacterIndex: undefined,
   recoveryWordIndex: undefined,
 }
+export type MetaMaskLikeProvider = providers.Web3Provider & { isTally?: boolean }
 
 export interface InitialState {
   keyring: Keyring
@@ -80,7 +82,7 @@ export interface InitialState {
   walletInfo: WalletInfo | null
   isConnected: boolean
   isDemoWallet: boolean
-  provider: any
+  provider: MetaMaskLikeProvider | null
   isLocked: boolean
   modal: boolean
   isLoadingLocalWallet: boolean
@@ -255,7 +257,7 @@ const getInitialState = () => {
   const localWalletDeviceId = getLocalWalletDeviceId()
   //Handle Tally Default bug - When user toggles TallyHo default button before disconnecting connected wallet
   if (
-    (localWalletType === 'metamask' && (window as any)?.ethereum?.isTally) ||
+    (localWalletType === 'metamask' && (window?.ethereum as MetaMaskLikeProvider)?.isTally) ||
     (localWalletType === 'tallyho' && window?.ethereum?.isMetaMask)
   )
     return initialState
@@ -374,7 +376,11 @@ export const WalletProvider = ({ children }: { children: React.ReactNode }): JSX
               break
             case KeyManager.MetaMask:
               //Handle refresh bug - when a user changes TallyHo to default, is connected to MM and refreshs the page
-              if (localWalletType === 'metamask' && (window as any)?.ethereum?.isTally) disconnect()
+              if (
+                localWalletType === 'metamask' &&
+                (window?.ethereum as MetaMaskLikeProvider)?.isTally
+              )
+                disconnect()
               const localMetaMaskWallet = await state.adapters
                 .get(KeyManager.MetaMask)
                 ?.pairDevice()

--- a/src/context/WalletProvider/WalletProvider.tsx
+++ b/src/context/WalletProvider/WalletProvider.tsx
@@ -549,8 +549,6 @@ export const WalletProvider = ({ children }: { children: React.ReactNode }): JSX
         if (walletType === KeyManager.XDefi) {
           try {
             maybeProvider = globalThis?.xfi?.ethereum as unknown as MetaMaskLikeProvider
-            state.provider?.on?.('accountsChanged', resetState)
-            state.provider?.on?.('chainChanged', resetState)
           } catch (error) {
             throw new Error('walletProvider.xdefi.errors.connectFailure')
           }

--- a/src/context/WalletProvider/XDEFI/components/Connect.tsx
+++ b/src/context/WalletProvider/XDEFI/components/Connect.tsx
@@ -1,5 +1,5 @@
 import { XDEFIHDWallet } from '@shapeshiftoss/hdwallet-xdefi'
-import React, { useCallback, useState } from 'react'
+import React, { useCallback, useEffect, useState } from 'react'
 import { RouteComponentProps } from 'react-router-dom'
 import { ActionTypes, WalletActions } from 'context/WalletProvider/actions'
 import { KeyManager } from 'context/WalletProvider/KeyManager'
@@ -22,12 +22,18 @@ export interface XDEFISetupProps
 }
 
 export const XDEFIConnect = ({ history }: XDEFISetupProps) => {
-  const { dispatch, state } = useWallet()
+  const { dispatch, state, onProviderChange } = useWallet()
   const [loading, setLoading] = useState(false)
   const [error, setError] = useState<string | null>(null)
 
   // eslint-disable-next-line no-sequences
   const setErrorLoading = (e: string | null) => (setError(e), setLoading(false))
+
+  useEffect(() => {
+    ;(async () => {
+      await onProviderChange(KeyManager.XDefi)
+    })()
+  }, [onProviderChange])
 
   const pairDevice = useCallback(async () => {
     setError(null)

--- a/src/context/WalletProvider/XDEFI/components/Connect.tsx
+++ b/src/context/WalletProvider/XDEFI/components/Connect.tsx
@@ -57,17 +57,6 @@ export const XDEFIConnect = ({ history }: XDEFISetupProps) => {
           throw new Error('walletProvider.xdefi.errors.multipleWallets')
         }
 
-        // Hack to handle XDEFI account changes
-        //TODO: handle this properly
-        const resetState = () => dispatch({ type: WalletActions.RESET_STATE })
-
-        const oldDisconnect = wallet.disconnect.bind(wallet)
-        wallet.disconnect = () => {
-          state.provider?.removeListener?.('accountsChanged', resetState)
-          state.provider?.removeListener?.('chainChanged', resetState)
-          return oldDisconnect()
-        }
-
         await wallet.initialize()
 
         dispatch({

--- a/src/context/WalletProvider/XDEFI/components/Connect.tsx
+++ b/src/context/WalletProvider/XDEFI/components/Connect.tsx
@@ -60,8 +60,6 @@ export const XDEFIConnect = ({ history }: XDEFISetupProps) => {
         // Hack to handle XDEFI account changes
         //TODO: handle this properly
         const resetState = () => dispatch({ type: WalletActions.RESET_STATE })
-        state.provider?.on?.('accountsChanged', resetState)
-        state.provider?.on?.('chainChanged', resetState)
 
         const oldDisconnect = wallet.disconnect.bind(wallet)
         wallet.disconnect = () => {

--- a/src/context/WalletProvider/actions.ts
+++ b/src/context/WalletProvider/actions.ts
@@ -13,6 +13,7 @@ export enum WalletActions {
   SET_INITIAL_ROUTE = 'SET_INITIAL_ROUTE',
   SET_IS_CONNECTED = 'SET_IS_CONNECTED',
   SET_IS_DEMO_WALLET = 'SET_IS_DEMO_WALLET',
+  SET_PROVIDER = 'SET_PROVIDER',
   SET_IS_LOCKED = 'SET_IS_LOCKED',
   SET_WALLET_MODAL = 'SET_WALLET_MODAL',
   RESET_STATE = 'RESET_STATE',
@@ -41,6 +42,7 @@ export type ActionTypes =
     }
   | { type: WalletActions.SET_IS_CONNECTED; payload: boolean }
   | { type: WalletActions.SET_IS_DEMO_WALLET; payload: boolean }
+  | { type: WalletActions.SET_PROVIDER; payload: any }
   | { type: WalletActions.SET_IS_LOCKED; payload: boolean }
   | { type: WalletActions.SET_CONNECTOR_TYPE; payload: KeyManager }
   | { type: WalletActions.SET_INITIAL_ROUTE; payload: string }

--- a/src/context/WalletProvider/actions.ts
+++ b/src/context/WalletProvider/actions.ts
@@ -3,7 +3,7 @@ import { HDWallet } from '@shapeshiftoss/hdwallet-core'
 
 import { PinMatrixRequestType } from './KeepKey/KeepKeyTypes'
 import { KeyManager } from './KeyManager'
-import type { Adapters } from './WalletProvider'
+import type { Adapters, InitialState } from './WalletProvider'
 import { DeviceState } from './WalletProvider'
 
 export enum WalletActions {
@@ -42,7 +42,7 @@ export type ActionTypes =
     }
   | { type: WalletActions.SET_IS_CONNECTED; payload: boolean }
   | { type: WalletActions.SET_IS_DEMO_WALLET; payload: boolean }
-  | { type: WalletActions.SET_PROVIDER; payload: any }
+  | { type: WalletActions.SET_PROVIDER; payload: InitialState['provider'] }
   | { type: WalletActions.SET_IS_LOCKED; payload: boolean }
   | { type: WalletActions.SET_CONNECTOR_TYPE; payload: KeyManager }
   | { type: WalletActions.SET_INITIAL_ROUTE; payload: string }


### PR DESCRIPTION
## Description

This moves the provider-setting logic from the silo'd `src/context/WalletProvider/<WalletName>/components/Connect.tsx` components, to the memoized wallet provider context.

Since the provider is now consumed from a single source of truth, this makes sure event handlers are added to a unique instance, both on wallet pairing (wallet connect screen) and load (app refresh).

This will prepare us for properly handling accounts and chain switch events, which currently disconnect the app and should be handled gracefully.

- [x] Wallet context as a single source of provider truth
- [x] Types
- [x] Programmatic wallet provider detection based on local wallet type / selected wallet connect option

## Notice

<!-- Before submitting a pull request, please make sure you have answered the following: -->

- [x] Have you followed the guidelines in our [Contributing]('https://github.com/shapeshift/web/CONTRIBUTING.md) guide?
- [x] Have you checked to ensure there aren't other open [Pull Requests](https://github.com/shapeshift/web/pulls) for the same update/change?

## Pull Request Type

- [ ] :bug: Bug fix (Non-breaking Change: Fixes an issue)
- [ ] :hammer_and_wrench: Chore (Non-breaking Change: Doc updates, pkg upgrades, typos, etc..)
- [x] :nail_care: New Feature (Breaking/Non-breaking Change)

## Issue (if applicable)

<!-----------------------------------------------------------------------------
If applicable, please link to the github issue and put `closes #XXXX` in your comment to auto-close the issue that your PR fixes.
------------------------------------------------------------------------------>

closes https://github.com/shapeshift/web/issues/2585

## Risk

High. Affected areas are:

- Wallet pairing (after app load, and after disconnecting a wallet than reconnecting the same or another wallet)
- Wallet detection (MetaMask lookalikes should be properly detected, with prioritization and multiple wallets error-handling still working)
- Wallet features (address getting, broadcast, fees estimate, network detection and switch)
- Wallet refresh on load
- Wallet disconnected state

## Testing

### Engineering

- Regression testing according to the criteria above
- Event handlers should be firing while reloading any MetaMask-like wallet as well as WalletConnect. This can be tested by switching chains/accounts, which should disconnect the app
- Event handlers should still work when connecting a wallet through the wallet connect modal vs. reloading the app

### Operations

- Ensure all wallet features still work
- Regression test that switching from a MetaMask-like or WalletConnect to native/KK/Portis still works
- Regression test that connecting a prioritized TallyHo / XDEFI when MetaMask is installed still works

## Screenshots (if applicable)

N/A