### PR TITLE
feat: gracefully handle network change

### DIFF
--- a/src/context/WalletProvider/WalletProvider.tsx
+++ b/src/context/WalletProvider/WalletProvider.tsx
@@ -551,9 +551,7 @@ export const WalletProvider = ({ children }: { children: React.ReactNode }): JSX
     // eslint-disable-next-line react-hooks/exhaustive-deps
   }, [state.adapters, state.keyring])
 
-  const resetState = useCallback(() => dispatch({ type: WalletActions.RESET_STATE }), [])
-
-  const handleAccountsChanged = useCallback(async () => {
+  const handleAccountsOrChainChanged = useCallback(async () => {
     if (!walletType || !state.adapters) return
 
     const localWallet = await state.adapters.get(walletType)?.pairDevice()
@@ -582,20 +580,20 @@ export const WalletProvider = ({ children }: { children: React.ReactNode }): JSX
     async (maybeProvider: InitialState['provider']) => {
       if (!(maybeProvider && walletType)) return
 
-      maybeProvider?.on?.('accountsChanged', handleAccountsChanged)
-      maybeProvider?.on?.('chainChanged', resetState)
+      maybeProvider?.on?.('accountsChanged', handleAccountsOrChainChanged)
+      maybeProvider?.on?.('chainChanged', handleAccountsOrChainChanged)
 
       const wallet = await state.adapters?.get(walletType)?.pairDevice()
       if (wallet) {
         const oldDisconnect = wallet.disconnect.bind(wallet)
         wallet.disconnect = () => {
-          maybeProvider?.removeListener?.('accountsChanged', handleAccountsChanged)
-          maybeProvider?.removeListener?.('chainChanged', resetState)
+          maybeProvider?.removeListener?.('accountsChanged', handleAccountsOrChainChanged)
+          maybeProvider?.removeListener?.('chainChanged', handleAccountsOrChainChanged)
           return oldDisconnect()
         }
       }
     },
-    [resetState, state.adapters, walletType, handleAccountsChanged],
+    [state.adapters, walletType, handleAccountsOrChainChanged],
   )
 
   // Register a MetaMask-like (EIP-1193) provider on wallet connect or load


### PR DESCRIPTION
## Description

This PRs adds support for gracefully handling network change from MetaMask-like wallets.

## Notice

<!-- Before submitting a pull request, please make sure you have answered the following: -->

- [x] Have you followed the guidelines in our [Contributing]('https://github.com/shapeshift/web/CONTRIBUTING.md) guide?
- [x] Have you checked to ensure there aren't other open [Pull Requests](https://github.com/shapeshift/web/pulls) for the same update/change?

## Pull Request Type

- [ ] :bug: Bug fix (Non-breaking Change: Fixes an issue)
- [ ] :hammer_and_wrench: Chore (Non-breaking Change: Doc updates, pkg upgrades, typos, etc..)
- [x] :nail_care: New Feature (Breaking/Non-breaking Change)

## Issue (if applicable)

closes https://github.com/shapeshift/web/issues/2335


## Risk

High, needs a full wallet regression testing and ensuring there are no unnecessary reloads, both on the current flow and while switching network.

## Testing


### Engineering

<!-----------------------------------------------------------------------------
Include sufficient information here for an engineer to test your PR. This may include how to test locally, in a built environment, changes to infrastructure etc.
------------------------------------------------------------------------------>

- Connect MM or XDEFI with Mainnet or Avalanche
- Switch networks in your wallet
- The app should refresh to reflect the change i.e the chain menu should show the newly selected chain
- This should work both on wallet connection through the wallet connect modal as well as on app reload
- Ensure there are no console errors when switching networks

Note: When switching from a supported to an unsupported network, the chain menu will disappear - unsupported networks display will be added in https://github.com/shapeshift/web/pull/2582

### Operations

- See engineering testing notes
- Ensure the app doesn't refresh on incoming Txs
- Ensure wallet connection, disconnection still works

Note: While testing against prod, you might notice inconsistencies in the current disconnect behavior. That's expected, the guts of these PRs is that they fix an issue we currently have, where accounts/network changed are only handled if you connect through the wallet connect menu, but if you connect to the app by reloading the page, they are never handled and produce no effect at all currently.
Please make sure to test against the disconnect behavior in prod by explicitly connecting a wallet vs. reloading the app with it already connected.

## Screenshots (if applicable)
