### PR TITLE
fix: remove console errors

### DIFF
--- a/src/Routes/Routes.tsx
+++ b/src/Routes/Routes.tsx
@@ -73,7 +73,7 @@ export const Routes = () => {
       {appRoutes.map(route => {
         const MainComponent = route.main
         return (
-          <PrivateRoute path={route.path} exact hasWallet={hasWallet}>
+          <PrivateRoute path={route.path} exact key='privateRoute' hasWallet={hasWallet}>
             <Layout>{MainComponent && <MainComponent />}</Layout>
           </PrivateRoute>
         )

--- a/src/components/Icons/DeFi.tsx
+++ b/src/components/Icons/DeFi.tsx
@@ -3,7 +3,7 @@ import { createIcon } from '@chakra-ui/react'
 export const DefiIcon = createIcon({
   displayName: 'DeFiIcon',
   path: (
-    <g clip-path='url(#clip0_25_654)'>
+    <g clipPath='url(#clip0_25_654)'>
       <path
         fillRule='evenodd'
         clipRule='evenodd'

--- a/src/components/Layout/Header/NavBar/WalletConnectedMenu.tsx
+++ b/src/components/Layout/Header/NavBar/WalletConnectedMenu.tsx
@@ -80,7 +80,12 @@ export const WalletConnectedMenu = ({
         {connectedWalletMenuRoutes?.map(route => {
           const Component = route.component
           return !Component ? null : (
-            <Route exact path={route.path} render={routeProps => <Component {...routeProps} />} />
+            <Route
+              key='walletConnectedMenuRoute'
+              exact
+              path={route.path}
+              render={routeProps => <Component {...routeProps} />}
+            />
           )
         })}
       </Switch>

--- a/src/context/WalletProvider/WalletViewsSwitch.tsx
+++ b/src/context/WalletProvider/WalletViewsSwitch.tsx
@@ -105,6 +105,7 @@ export const WalletViewsSwitch = () => {
                     const Component = route.component
                     return !Component ? null : (
                       <Route
+                        key='walletViewRoute'
                         exact
                         path={route.path}
                         render={routeProps => <Component {...routeProps} />}


### PR DESCRIPTION
## Description

This PR removes the current console errors in develop:

- gives a "unique" `key` to mapped routes (shared across all mapped routes to avoid creating new references, effectively the same behavior as https://github.com/shapeshift/web/pull/2557 without the react warnings)
- renames `clip-path` to `clipPath` in `<DefiIcon />` to honor react convention of camelCased html tags

## Notice

<!-- Before submitting a pull request, please make sure you have answered the following: -->

- [x] Have you followed the guidelines in our [Contributing]('https://github.com/shapeshift/web/CONTRIBUTING.md) guide?
- [x] Have you checked to ensure there aren't other open [Pull Requests](https://github.com/shapeshift/web/pulls) for the same update/change?

## Pull Request Type

- [x] :bug: Bug fix (Non-breaking Change: Fixes an issue)
- [ ] :hammer_and_wrench: Chore (Non-breaking Change: Doc updates, pkg upgrades, typos, etc..)
- [ ] :nail_care: New Feature (Breaking/Non-breaking Change)

## Issue (if applicable)

N/A

## Risk

- None. Same behavior, different syntactic sugar, happier compilers

## Testing

<!-----------------------------------------------------------------------------
We treat every PR to be merged with the same scrutiny as if we were merging directly to production.

Your PR will not be merged if you do not complete the sections below for our engineering and operations teams to test.
------------------------------------------------------------------------------>

### Engineering

- Ensure there are no ` Each child in an array should have a unique "key" prop` errors emitted from mapped routes
- Ensure there are no <code>Warning: Invalid DOM property `clip-path`. Did you mean `clipPath`?</code> errors emitted from `<DefiIcon />`

### Operations

<!-----------------------------------------------------------------------------
If your changes have a user-facing impact, describe how a non-technical QA team can functionally test your changes in a preview environment.

If they are not user-facing please describe how to test for any regressions that may occur.
------------------------------------------------------------------------------>

- The flickering native wallet on route change fixed in https://github.com/shapeshift/web/pull/2557 should still be fixed i.e there is no flash of loading native wallet label when switching routes
- The DeFi navbar icon looks the same as in production

## Screenshots (if applicable)


This diff:

<img width="378" alt="image" src="https://user-images.githubusercontent.com/17035424/187311511-4a323eb9-6905-4478-9bce-5e135e86ee20.png">

Develop:

<img width="751" alt="image" src="https://user-images.githubusercontent.com/17035424/187311584-8f3b5b59-f5f0-4067-8953-09a4cce8fc61.png">
<img width="549" alt="image" src="https://user-images.githubusercontent.com/17035424/187311608-7aeef0b6-1de2-4624-8527-ede2684d76a4.png">
<img width="676" alt="image" src="https://user-images.githubusercontent.com/17035424/187311636-ba3e6aad-453f-4c74-9f80-da61416f14f9.png">
<img width="686" alt="image" src="https://user-images.githubusercontent.com/17035424/187311768-4063419e-477e-4cf0-81cd-ac4b4bd4d20f.png">