### PR TITLE
feat: no side effects on onProviderChange

### DIFF
--- a/src/context/WalletProvider/WalletContext.tsx
+++ b/src/context/WalletProvider/WalletContext.tsx
@@ -2,7 +2,7 @@ import React, { createContext } from 'react'
 
 import { ActionTypes } from './actions'
 import { KeyManager } from './KeyManager'
-import type { DeviceState, InitialState } from './WalletProvider'
+import type { DeviceState, InitialState, KeyManagerWithProvider } from './WalletProvider'
 
 export interface IWalletContext {
   state: InitialState
@@ -13,7 +13,7 @@ export interface IWalletContext {
   load: () => void
   setDeviceState: (deviceState: Partial<DeviceState>) => void
   connectDemo: () => Promise<void>
-  onProviderChange: (localWalletType: KeyManager) => Promise<void>
+  onProviderChange: (localWalletType: KeyManagerWithProvider) => Promise<void>
 }
 
 export const WalletContext = createContext<IWalletContext | null>(null)

--- a/src/context/WalletProvider/WalletProvider.tsx
+++ b/src/context/WalletProvider/WalletProvider.tsx
@@ -74,6 +74,13 @@ const initialDeviceState: DeviceState = {
 }
 export type MetaMaskLikeProvider = providers.Web3Provider & { isTally?: boolean }
 
+// A subset of wallets which have an EIP-1193-like provider
+export type KeyManagerWithProvider =
+  | KeyManager.TallyHo
+  | KeyManager.XDefi
+  | KeyManager.MetaMask
+  | KeyManager.WalletConnect
+
 export interface InitialState {
   keyring: Keyring
   adapters: Adapters | null
@@ -111,6 +118,19 @@ const initialState: InitialState = {
   keepKeyPinRequestType: null,
   deviceState: initialDeviceState,
 }
+
+export const isKeyManagerWithProvider = (
+  keyManager: KeyManager | null,
+): keyManager is KeyManagerWithProvider =>
+  Boolean(
+    keyManager &&
+      [
+        KeyManager.TallyHo,
+        KeyManager.XDefi,
+        KeyManager.MetaMask,
+        KeyManager.WalletConnect,
+      ].includes(keyManager),
+  )
 
 const reducer = (state: InitialState, action: ActionTypes) => {
   switch (action.type) {
@@ -278,7 +298,7 @@ export const WalletProvider = ({ children }: { children: React.ReactNode }): JSX
   // External, exposed state to be consumed with useWallet()
   const [state, dispatch] = useReducer(reducer, getInitialState())
   // Internal state, for memoization purposes only
-  const [walletType, setWalletType] = useState<KeyManager | null>(null)
+  const [walletType, setWalletType] = useState<KeyManagerWithProvider | null>(null)
 
   const disconnect = useCallback(() => {
     /**
@@ -533,52 +553,61 @@ export const WalletProvider = ({ children }: { children: React.ReactNode }): JSX
 
   const resetState = useCallback(() => dispatch({ type: WalletActions.RESET_STATE }), [])
 
+  const setProviderEvents = useCallback(
+    async (maybeProvider: InitialState['provider']) => {
+      if (!(maybeProvider && walletType)) return
+
+      maybeProvider?.on?.('accountsChanged', resetState)
+      maybeProvider?.on?.('chainChanged', resetState)
+
+      const wallet = await state.adapters?.get(walletType)?.pairDevice()
+      if (wallet) {
+        const oldDisconnect = wallet.disconnect.bind(wallet)
+        wallet.disconnect = () => {
+          maybeProvider?.removeListener?.('accountsChanged', resetState)
+          maybeProvider?.removeListener?.('chainChanged', resetState)
+          return oldDisconnect()
+        }
+      }
+    },
+    [resetState, state.adapters, walletType],
+  )
+
   // Register a MetaMask-like (EIP-1193) provider on wallet connect or load
   const onProviderChange = useCallback(
-    async (localWalletType: KeyManager | null) => {
+    async (localWalletType: KeyManagerWithProvider | null) => {
       if (!localWalletType) return
       setWalletType(localWalletType)
       if (!walletType) return
       try {
-        let maybeProvider: InitialState['provider'] = null
-
-        if ([KeyManager.MetaMask, KeyManager.TallyHo].includes(walletType)) {
-          maybeProvider = (await detectEthereumProvider()) as MetaMaskLikeProvider
-        }
-
-        if (walletType === KeyManager.XDefi) {
-          try {
-            maybeProvider = globalThis?.xfi?.ethereum as unknown as MetaMaskLikeProvider
-          } catch (error) {
-            throw new Error('walletProvider.xdefi.errors.connectFailure')
+        const maybeProvider = await (async (): Promise<InitialState['provider']> => {
+          if ([KeyManager.MetaMask, KeyManager.TallyHo].includes(walletType)) {
+            return (await detectEthereumProvider()) as MetaMaskLikeProvider
           }
-        }
-        if (walletType === KeyManager.WalletConnect) {
-          const config: WalletConnectProviderConfig = {
-            /** List of RPC URLs indexed by chain ID */
-            rpc: {
-              1: getConfig().REACT_APP_ETHEREUM_NODE_URL,
-            },
-          }
-          maybeProvider = new WalletConnectProvider(config)
-        }
-
-        if (maybeProvider) {
-          maybeProvider?.on?.('accountsChanged', resetState)
-          maybeProvider?.on?.('chainChanged', resetState)
-
-          const wallet = await state.adapters?.get(walletType)?.pairDevice()
-          if (wallet) {
-            const oldDisconnect = wallet.disconnect.bind(wallet)
-            wallet.disconnect = () => {
-              maybeProvider?.removeListener?.('accountsChanged', resetState)
-              maybeProvider?.removeListener?.('chainChanged', resetState)
-              return oldDisconnect()
+          if (walletType === KeyManager.XDefi) {
+            try {
+              return globalThis?.xfi?.ethereum as unknown as MetaMaskLikeProvider
+            } catch (error) {
+              throw new Error('walletProvider.xdefi.errors.connectFailure')
             }
           }
-        }
+          if (walletType === KeyManager.WalletConnect) {
+            const config: WalletConnectProviderConfig = {
+              /** List of RPC URLs indexed by chain ID */
+              rpc: {
+                1: getConfig().REACT_APP_ETHEREUM_NODE_URL,
+              },
+            }
+            return new WalletConnectProvider(config)
+          }
 
-        dispatch({ type: WalletActions.SET_PROVIDER, payload: maybeProvider })
+          return null
+        })()
+
+        if (maybeProvider) {
+          await setProviderEvents(maybeProvider)
+          dispatch({ type: WalletActions.SET_PROVIDER, payload: maybeProvider })
+        }
       } catch (e) {
         if (!isMobile) moduleLogger.error(e, 'onProviderChange error')
       }
@@ -592,6 +621,8 @@ export const WalletProvider = ({ children }: { children: React.ReactNode }): JSX
   useEffect(() => {
     ;(async () => {
       const localWalletType = getLocalWalletType()
+      if (!isKeyManagerWithProvider(localWalletType)) return
+
       await onProviderChange(localWalletType)
     })()
   }, [state.wallet, onProviderChange])


### PR DESCRIPTION
## Description

This moves away from the side effects model in `<WalletProvider />`'s `onProviderChange`, as proposed by @0xApotheosis in https://github.com/shapeshift/web/pull/2586#discussion_r958190835:

> Not blocking, though I'm not a fan of mixing computations with actions in this way.
> 
> A more functional version would have maybeProvider as a constant equal to the evaluation of an IIFE, and the provider events mutated by an action function, say `setProviderEvents()'.

Also adds a new `KeyManagerWithProvider` type and an associated type guard, with stricter provider discrimination and checks.

## Notice

<!-- Before submitting a pull request, please make sure you have answered the following: -->

- [x] Have you followed the guidelines in our [Contributing]('https://github.com/shapeshift/web/CONTRIBUTING.md) guide?
- [x] Have you checked to ensure there aren't other open [Pull Requests](https://github.com/shapeshift/web/pulls) for the same update/change?

## Pull Request Type

- [ ] :bug: Bug fix (Non-breaking Change: Fixes an issue)
- [ ] :hammer_and_wrench: Chore (Non-breaking Change: Doc updates, pkg upgrades, typos, etc..)
- [x] :nail_care: New Feature (Breaking/Non-breaking Change)

## Issue (if applicable)

Relates to https://github.com/shapeshift/web/issues/2585 - which should be closed by the time this follow-up gets merged

## Risk

In theory this is just changing from a side effects model to a declarative flow with little runtime changes, but the whole testing criteria of https://github.com/shapeshift/web/pull/2586 should be followed again when testing this. The following testing criteria is copied over from the base PR.

## Testing

### Engineering

- Regression testing according to the featureset of https://github.com/shapeshift/web/issues/2585
- Event handlers should be firing while reloading any MetaMask-like wallet as well as WalletConnect. This can be tested by switching chains/accounts, which should disconnect the app
- Event handlers should still work when connecting a wallet through the wallet connect modal vs. reloading the app

### Operations

- Ensure all wallet features still work
- Regression test that switching from a MetaMask-like or WalletConnect to native/KK/Portis still works
- Regression test that connecting a prioritized TallyHo / XDEFI when MetaMask is installed still works

## Screenshots (if applicable)
