### PR TITLE
refactor: simplify `useToggle`

### DIFF
--- a/src/hooks/useToggle/useToggle.ts
+++ b/src/hooks/useToggle/useToggle.ts
@@ -1,8 +1,4 @@
-import { useCallback, useState } from 'react'
+import { ReducerWithoutAction, useReducer } from 'react'
 
-// Inspired ty https://usehooks.com/useToggle/
-export const useToggle = (initialState: boolean = false): [boolean, () => void] => {
-  const [state, setState] = useState<boolean>(initialState)
-  const toggle = useCallback((): void => setState(state => !state), [])
-  return [state, toggle]
-}
+export const useToggle = (initialState = false) =>
+  useReducer<ReducerWithoutAction<boolean>>(state => !state, initialState)


### PR DESCRIPTION
## Description

I found a much cleaner way to create a `useToggle` hook using `useReducer`.

## Notice

- [x] Have you followed the guidelines in our [Contributing]('https://github.com/shapeshift/web/CONTRIBUTING.md) guide?
- [x] Have you checked to ensure there aren't other open [Pull Requests](https://github.com/shapeshift/web/pulls) for the same update/change?

## Pull Request Type

- [ ] :bug: Bug fix (Non-breaking Change: Fixes an issue)
- [x] :hammer_and_wrench: Chore (Non-breaking Change: Doc updates, pkg upgrades, typos, etc..)
- [ ] :nail_care: New Feature (Breaking/Non-breaking Change)

## Issue (if applicable)

Contributes to https://github.com/shapeshift/web/issues/2556

## Risk

Minimal. `useToggle` is only used in swapper v2 to change between fiat and crypto input, and that still works.

## Testing

### Engineering

With the `SwapperV2` feature flag enabled, confirm that we can still swap between crypto and fiat input.

### Operations

N/A - no user-facing changes at present.

## Screenshots (if applicable)

N/A
