### PR TITLE
refactor: make `getDefaultPair` a pure function & rename

### DIFF
--- a/src/components/Trade/hooks/useSwapper/useSwapper.test.tsx
+++ b/src/components/Trade/hooks/useSwapper/useSwapper.test.tsx
@@ -1,4 +1,3 @@
-import { ethChainId } from '@shapeshiftoss/caip'
 import { HDWallet } from '@shapeshiftoss/hdwallet-core'
 import { SwapperManager } from '@shapeshiftoss/swapper'
 import { KnownChainIds } from '@shapeshiftoss/types'
@@ -175,13 +174,6 @@ describe('useSwapper', () => {
     await act(async () => {
       const approvalNeeded = await result.current.checkApprovalNeeded()
       expect(approvalNeeded).toBe(true)
-    })
-  })
-  it('gets default pair', async () => {
-    const { result } = setup()
-    await act(async () => {
-      const defaultPair = result.current.getDefaultPair(ethChainId)
-      expect(defaultPair).toHaveLength(2)
     })
   })
   it('swappermanager initializes with swapper', async () => {

--- a/src/components/Trade/hooks/useSwapper/useSwapper.ts
+++ b/src/components/Trade/hooks/useSwapper/useSwapper.ts
@@ -1,15 +1,6 @@
 import { useToast } from '@chakra-ui/react'
 import { Asset } from '@shapeshiftoss/asset-service'
-import {
-  avalancheAssetId,
-  CHAIN_NAMESPACE,
-  ChainId,
-  cosmosAssetId,
-  ethAssetId,
-  fromAssetId,
-  osmosisAssetId,
-  toAccountId,
-} from '@shapeshiftoss/caip'
+import { CHAIN_NAMESPACE, ChainId, ethAssetId, fromAssetId, toAccountId } from '@shapeshiftoss/caip'
 import { ChainAdapter, EvmChainId, UtxoBaseAdapter } from '@shapeshiftoss/chain-adapters'
 import { HDWallet } from '@shapeshiftoss/hdwallet-core'
 import {
@@ -33,7 +24,6 @@ import { getSwapperManager } from 'components/Trade/hooks/useSwapper/swapperMana
 import { DisplayFeeData, TradeAmountInputField, TradeAsset, TS } from 'components/Trade/types'
 import { getChainAdapterManager } from 'context/PluginProvider/chainAdapterSingleton'
 import { useErrorHandler } from 'hooks/useErrorToast/useErrorToast'
-import { useFeatureFlag } from 'hooks/useFeatureFlag/useFeatureFlag'
 import { useWallet } from 'hooks/useWallet/useWallet'
 import { BigNumber, bn, bnOrZero } from 'lib/bignumber/bignumber'
 import { fromBaseUnit, toBaseUnit } from 'lib/math'
@@ -178,8 +168,6 @@ export const useSwapper = () => {
     state: { wallet },
   } = useWallet()
 
-  const osmosisEnabled = useFeatureFlag('Osmosis')
-
   const filterAssetsByIds = (assets: Asset[], assetIds: string[]) => {
     const assetIdMap = Object.fromEntries(assetIds.map(assetId => [assetId, true]))
     return assets.filter(asset => assetIdMap[asset.assetId])
@@ -209,24 +197,6 @@ export const useSwapper = () => {
       return supportedBuyAssetIds ? filterAssetsByIds(assets, supportedBuyAssetIds) : undefined
     },
     [swapperManager, sellTradeAsset],
-  )
-
-  const getDefaultPair = useCallback(
-    (buyAssetChainId: ChainId | undefined) => {
-      const ethFoxPair = [ethAssetId, 'eip155:1/erc20:0xc770eefad204b5180df6a14ee197d99d808ee52d']
-      switch (buyAssetChainId) {
-        case KnownChainIds.AvalancheMainnet:
-          return [avalancheAssetId, 'eip155:43114/erc20:0x49d5c2bdffac6ce2bfdb6640f4f80f226bc10bab']
-        case KnownChainIds.CosmosMainnet:
-          return osmosisEnabled ? [cosmosAssetId, osmosisAssetId] : ethFoxPair
-        case KnownChainIds.OsmosisMainnet:
-          return osmosisEnabled ? [osmosisAssetId, cosmosAssetId] : ethFoxPair
-        case KnownChainIds.EthereumMainnet:
-        default:
-          return ethFoxPair
-      }
-    },
-    [osmosisEnabled],
   )
 
   const sellAssetBalance = useAppSelector(state =>
@@ -705,7 +675,6 @@ export const useSwapper = () => {
     executeQuote,
     getSupportedBuyAssetsFromSellAsset,
     getSupportedSellableAssets,
-    getDefaultPair,
     checkApprovalNeeded,
     approve,
     getSendMaxAmount,

--- a/src/components/Trade/hooks/useSwapper/useSwapperV2.ts
+++ b/src/components/Trade/hooks/useSwapper/useSwapperV2.ts
@@ -1,11 +1,4 @@
 import { type Asset } from '@shapeshiftoss/asset-service'
-import {
-  type ChainId,
-  avalancheAssetId,
-  cosmosAssetId,
-  ethAssetId,
-  osmosisAssetId,
-} from '@shapeshiftoss/caip'
 import { SwapperManager } from '@shapeshiftoss/swapper'
 import { KnownChainIds } from '@shapeshiftoss/types'
 import { useCallback, useEffect, useState } from 'react'
@@ -14,7 +7,6 @@ import { useSelector } from 'react-redux'
 import { getSwapperManager } from 'components/Trade/hooks/useSwapper/swapperManager'
 import { filterAssetsByIds } from 'components/Trade/hooks/useSwapper/utils'
 import { type TradeState } from 'components/Trade/types'
-import { useFeatureFlag } from 'hooks/useFeatureFlag/useFeatureFlag'
 import { selectAssetIds } from 'state/slices/assetsSlice/selectors'
 import { selectFeatureFlags } from 'state/slices/preferencesSlice/selectors'
 
@@ -67,29 +59,9 @@ export const useSwapper = () => {
     [swapperManager, sellTradeAsset],
   )
 
-  const osmosisEnabled = useFeatureFlag('Osmosis')
-  const getDefaultPair = useCallback(
-    (buyAssetChainId: ChainId | undefined) => {
-      const ethFoxPair = [ethAssetId, 'eip155:1/erc20:0xc770eefad204b5180df6a14ee197d99d808ee52d']
-      switch (buyAssetChainId) {
-        case KnownChainIds.AvalancheMainnet:
-          return [avalancheAssetId, 'eip155:43114/erc20:0x49d5c2bdffac6ce2bfdb6640f4f80f226bc10bab']
-        case KnownChainIds.CosmosMainnet:
-          return osmosisEnabled ? [cosmosAssetId, osmosisAssetId] : ethFoxPair
-        case KnownChainIds.OsmosisMainnet:
-          return osmosisEnabled ? [osmosisAssetId, cosmosAssetId] : ethFoxPair
-        case KnownChainIds.EthereumMainnet:
-        default:
-          return ethFoxPair
-      }
-    },
-    [osmosisEnabled],
-  )
-
   return {
     getSupportedSellableAssets,
     getSupportedBuyAssetsFromSellAsset,
     swapperManager,
-    getDefaultPair,
   }
 }

--- a/src/components/Trade/hooks/useSwapper/utils.ts
+++ b/src/components/Trade/hooks/useSwapper/utils.ts
@@ -2,9 +2,13 @@ import { type Asset } from '@shapeshiftoss/asset-service'
 import {
   type AssetId,
   type ChainId,
+  avalancheAssetId,
   CHAIN_NAMESPACE,
+  cosmosAssetId,
+  ethAssetId,
   fromAssetId,
   fromChainId,
+  osmosisAssetId,
   toAccountId,
 } from '@shapeshiftoss/caip'
 import { type EvmChainId, ChainAdapter } from '@shapeshiftoss/chain-adapters'
@@ -200,4 +204,29 @@ export const getBestSwapperFromArgs = async (
   })
   if (!swapper) throw new Error('swapper is undefined')
   return swapper
+}
+
+export const getDefaultAssetIdPairByChainId = (
+  buyAssetChainId: ChainId | undefined,
+  featureFlags: FeatureFlags,
+): AssetId[] => {
+  const osmosisEnabled = featureFlags.Osmosis
+  const ethFoxPair = [
+    ethAssetId,
+    'eip155:1/erc20:0xc770eefad204b5180df6a14ee197d99d808ee52d' as AssetId,
+  ]
+  switch (buyAssetChainId) {
+    case KnownChainIds.AvalancheMainnet:
+      return [
+        avalancheAssetId,
+        'eip155:43114/erc20:0x49d5c2bdffac6ce2bfdb6640f4f80f226bc10bab' as AssetId,
+      ]
+    case KnownChainIds.CosmosMainnet:
+      return osmosisEnabled ? [cosmosAssetId, osmosisAssetId] : ethFoxPair
+    case KnownChainIds.OsmosisMainnet:
+      return osmosisEnabled ? [osmosisAssetId, cosmosAssetId] : ethFoxPair
+    case KnownChainIds.EthereumMainnet:
+    default:
+      return ethFoxPair
+  }
 }

--- a/src/components/Trade/hooks/useTradeRoutes/useTradeRoutes.test.tsx
+++ b/src/components/Trade/hooks/useTradeRoutes/useTradeRoutes.test.tsx
@@ -39,12 +39,7 @@ jest.mock('context/PluginProvider/chainAdapterSingleton', () => ({
 function setup({ buyAmount, sellAmount }: { buyAmount?: string; sellAmount?: string }) {
   const setValue = jest.fn()
   ;(useWatch as jest.Mock<unknown>).mockImplementation(() => [{}, {}])
-  ;(useSwapper as jest.Mock<unknown>).mockImplementation(() => ({
-    getDefaultPair: () => [mockETH.assetId, mockFOX.assetId],
-    swapperManager: {
-      getBestSwapper: jest.fn(),
-    },
-  }))
+  ;(useSwapper as jest.Mock<unknown>).mockImplementation(() => ({}))
   ;(useFormContext as jest.Mock<unknown>).mockImplementation(() => ({
     setValue,
     getValues: jest.fn((search: string) => {

--- a/src/components/Trade/hooks/useTradeRoutes/useTradeRoutes.ts
+++ b/src/components/Trade/hooks/useTradeRoutes/useTradeRoutes.ts
@@ -13,11 +13,13 @@ import { useCallback, useEffect, useMemo } from 'react'
 import { useFormContext } from 'react-hook-form'
 import { useSelector } from 'react-redux'
 import { useHistory } from 'react-router-dom'
+import { getDefaultAssetIdPairByChainId } from 'components/Trade/hooks/useSwapper/utils'
 import { TradeAmountInputField, TradeRoutePaths, TradeState } from 'components/Trade/types'
 import { getChainAdapterManager } from 'context/PluginProvider/chainAdapterSingleton'
 import { useEvm } from 'hooks/useEvm/useEvm'
 import { useWallet } from 'hooks/useWallet/useWallet'
 import { logger } from 'lib/logger'
+import { selectFeatureFlags } from 'state/slices/preferencesSlice/selectors'
 import { selectAssetById, selectAssets } from 'state/slices/selectors'
 import { useAppSelector } from 'state/store'
 
@@ -33,7 +35,8 @@ export const useTradeRoutes = (
 } => {
   const history = useHistory()
   const { getValues, setValue } = useFormContext<TradeState<KnownChainIds>>()
-  const { getDefaultPair, swapperManager } = useSwapper()
+  const { swapperManager } = useSwapper()
+  const featureFlags = useAppSelector(selectFeatureFlags)
   const buyTradeAsset = getValues('buyTradeAsset')
   const sellTradeAsset = getValues('sellTradeAsset')
   const assets = useSelector(selectAssets)
@@ -55,7 +58,10 @@ export const useTradeRoutes = (
 
   // Use the ChainId of the route's AssetId if we have one, else use the wallet's fallback ChainId
   const buyAssetChainId = routeBuyAssetId ? fromAssetId(routeBuyAssetId).chainId : walletChainId
-  const [defaultSellAssetId, defaultBuyAssetId] = getDefaultPair(buyAssetChainId)
+  const [defaultSellAssetId, defaultBuyAssetId] = getDefaultAssetIdPairByChainId(
+    buyAssetChainId,
+    featureFlags,
+  )
 
   const { chainId: defaultSellChainId } = fromAssetId(defaultSellAssetId)
   const defaultFeeAssetId = getChainAdapterManager().get(defaultSellChainId)!.getFeeAssetId()

--- a/src/hooks/useToggle/useToggle.ts
+++ b/src/hooks/useToggle/useToggle.ts
@@ -1,8 +1,4 @@
-import { useCallback, useState } from 'react'
+import { ReducerWithoutAction, useReducer } from 'react'
 
-// Inspired ty https://usehooks.com/useToggle/
-export const useToggle = (initialState: boolean = false): [boolean, () => void] => {
-  const [state, setState] = useState<boolean>(initialState)
-  const toggle = useCallback((): void => setState(state => !state), [])
-  return [state, toggle]
-}
+export const useToggle = (initialState = false) =>
+  useReducer<ReducerWithoutAction<boolean>>(state => !state, initialState)


### PR DESCRIPTION
## Description

In paving the way for a `tradeRoutes` refactor, this PR makes the `getDefaultPair` callback a pure function.

## Notice

- [x] Have you followed the guidelines in our [Contributing]('https://github.com/shapeshift/web/CONTRIBUTING.md) guide?
- [x] Have you checked to ensure there aren't other open [Pull Requests](https://github.com/shapeshift/web/pulls) for the same update/change?

## Pull Request Type

- [ ] :bug: Bug fix (Non-breaking Change: Fixes an issue)
- [x] :hammer_and_wrench: Chore (Non-breaking Change: Doc updates, pkg upgrades, typos, etc..)
- [ ] :nail_care: New Feature (Breaking/Non-breaking Change)

## Issue (if applicable)

Contributes to https://github.com/shapeshift/web/issues/2556

## Risk

Small, no logic changes.

## Testing

### Engineering

If default assets still load when connecting to a wallet, loading a new page etc we are 🛍️ 

### Operations

If default assets still load when connecting to a wallet, loading a new page etc we are 🛍️ 

## Screenshots (if applicable)

N/A