### PR TITLE
fix: load default assets on refresh

### DIFF
--- a/src/components/Trade/hooks/useTradeRoutes/useTradeRoutes.ts
+++ b/src/components/Trade/hooks/useTradeRoutes/useTradeRoutes.ts
@@ -105,7 +105,11 @@ export const useTradeRoutes = (
       const routeDefaultBuyAsset = assets[buyAssetId]
 
       // If we don't have a quote already, get one for the route's default assets
-      if (routeDefaultSellAsset && routeDefaultBuyAsset && !(buyTradeAsset || sellTradeAsset)) {
+      if (
+        routeDefaultSellAsset &&
+        routeDefaultBuyAsset &&
+        !(buyTradeAsset?.asset || sellTradeAsset?.asset)
+      ) {
         setValue('buyTradeAsset.asset', routeDefaultBuyAsset)
         setValue('sellTradeAsset.asset', routeDefaultSellAsset)
         setValue('action', TradeAmountInputField.SELL_CRYPTO)


### PR DESCRIPTION
## Description

Fixes a bug where we'd have a `TradeAsset` object with no `Asset` on it. 

This state fails the inverted boolean check (`!(buyTradeAsset || sellTradeAsset)`) and so does not correctly set the default assets on the initial load.

## Notice

- [x] Have you followed the guidelines in our [Contributing]('https://github.com/shapeshift/web/CONTRIBUTING.md) guide?
- [x] Have you checked to ensure there aren't other open [Pull Requests](https://github.com/shapeshift/web/pulls) for the same update/change?

## Pull Request Type

- [x] :bug: Bug fix (Non-breaking Change: Fixes an issue)
- [ ] :hammer_and_wrench: Chore (Non-breaking Change: Doc updates, pkg upgrades, typos, etc..)
- [ ] :nail_care: New Feature (Breaking/Non-breaking Change)

## Issue (if applicable)

Contributes to https://github.com/shapeshift/web/issues/2556

## Risk

Minimal.

## Testing

### Engineering

When refreshing the app the default assets should now load first time, every time.

### Operations

When refreshing the app the default assets should now load first time, every time.

## Screenshots (if applicable)

N/A