### PR TITLE
refactor: consolidate and simplify asset click logic

### DIFF
--- a/src/components/Trade/TradeRoutes/TradeRoutes.tsx
+++ b/src/components/Trade/TradeRoutes/TradeRoutes.tsx
@@ -1,3 +1,4 @@
+import { Asset } from '@shapeshiftoss/asset-service'
 import { AssetId } from '@shapeshiftoss/caip'
 import { AnimatePresence } from 'framer-motion'
 import { Redirect, Route, RouteComponentProps, Switch, useLocation } from 'react-router-dom'
@@ -6,7 +7,7 @@ import { SelectAccount } from 'components/Trade/SelectAccount'
 import { useFeatureFlag } from 'hooks/useFeatureFlag/useFeatureFlag'
 
 import { useSwapper } from '../hooks/useSwapper/useSwapperV2'
-import { useTradeRoutes } from '../hooks/useTradeRoutes/useTradeRoutes'
+import { AssetClickAction, useTradeRoutes } from '../hooks/useTradeRoutes/useTradeRoutes'
 import { SelectAsset } from '../SelectAsset'
 import { TradeConfirm } from '../TradeConfirm/TradeConfirm'
 import { TradeInput as TradeInputV1 } from '../TradeInput'
@@ -21,11 +22,13 @@ type TradeRoutesProps = {
 
 export const TradeRoutes = ({ defaultBuyAssetId }: TradeRoutesProps) => {
   const location = useLocation()
-  const { handleBuyClick, handleSellClick } = useTradeRoutes(defaultBuyAssetId)
+  const { handleAssetClick } = useTradeRoutes(defaultBuyAssetId)
   const { getSupportedSellableAssets, getSupportedBuyAssetsFromSellAsset } = useSwapper()
 
   const isSwapperV2 = useFeatureFlag('SwapperV2')
   const TradeInputComponent = isSwapperV2 ? TradeInputV2 : TradeInputV1
+  const handleAssetClickWithAction = (action: AssetClickAction) => (asset: Asset) =>
+    handleAssetClick(asset, action)
 
   return (
     <AnimatePresence exitBeforeEnter initial={false}>
@@ -34,7 +37,7 @@ export const TradeRoutes = ({ defaultBuyAssetId }: TradeRoutesProps) => {
           path={TradeRoutePaths.SellSelect}
           render={(props: RouteComponentProps) => (
             <SelectAsset
-              onClick={handleSellClick}
+              onClick={handleAssetClickWithAction(AssetClickAction.Sell)}
               filterBy={getSupportedSellableAssets}
               {...props}
             />
@@ -44,7 +47,7 @@ export const TradeRoutes = ({ defaultBuyAssetId }: TradeRoutesProps) => {
           path={TradeRoutePaths.BuySelect}
           render={(props: RouteComponentProps) => (
             <SelectAsset
-              onClick={handleBuyClick}
+              onClick={handleAssetClickWithAction(AssetClickAction.Buy)}
               filterBy={getSupportedBuyAssetsFromSellAsset}
               {...props}
             />

--- a/src/components/Trade/hooks/useTradeRoutes/useTradeRoutes.test.tsx
+++ b/src/components/Trade/hooks/useTradeRoutes/useTradeRoutes.test.tsx
@@ -7,7 +7,7 @@ import { TestProviders } from 'test/TestProviders'
 import { useSwapper } from 'components/Trade/hooks/useSwapper/useSwapper'
 import { TradeAmountInputField } from 'components/Trade/types'
 
-import { useTradeRoutes } from './useTradeRoutes'
+import { AssetClickAction, useTradeRoutes } from './useTradeRoutes'
 
 jest.mock('react-router-dom', () => ({
   useHistory: () => ({
@@ -67,43 +67,38 @@ function setup({ buyAmount, sellAmount }: { buyAmount?: string; sellAmount?: str
 describe('useTradeRoutes', () => {
   it('handles sell click with no buy amount', async () => {
     const { result, setValue } = setup({})
-    await result.current.handleSellClick(WETH)
+    await result.current.handleAssetClick(WETH, AssetClickAction.Sell)
     expect(setValue).toHaveBeenCalledWith('sellTradeAsset.asset', WETH)
-    expect(setValue).toHaveBeenCalledWith('buyTradeAsset.asset', mockFOX)
     expect(setValue).toHaveBeenCalledWith('action', TradeAmountInputField.SELL_FIAT)
   })
   it('handles sell click with buy amount', async () => {
     const { result, setValue } = setup({ buyAmount: '23' })
-    await result.current.handleSellClick(WETH)
+    await result.current.handleAssetClick(WETH, AssetClickAction.Sell)
     expect(setValue).toHaveBeenCalledWith('sellTradeAsset.asset', WETH)
-    expect(setValue).toHaveBeenCalledWith('buyTradeAsset.asset', mockFOX)
     expect(setValue).toHaveBeenCalledWith('action', TradeAmountInputField.SELL_FIAT)
   })
   it('swaps when same asset on sell click', async () => {
     const { result, setValue } = setup({})
-    await result.current.handleSellClick(mockFOX)
+    await result.current.handleAssetClick(mockFOX, AssetClickAction.Sell)
     expect(setValue).toHaveBeenCalledWith('buyTradeAsset.asset', WETH)
-    expect(setValue).toHaveBeenCalledWith('sellTradeAsset.asset', mockFOX)
     expect(setValue).toHaveBeenCalledWith('action', TradeAmountInputField.SELL_FIAT)
   })
   it('handles buy click with no sell amount', async () => {
     const { result, setValue } = setup({})
-    await result.current.handleBuyClick(mockFOX)
+    await result.current.handleAssetClick(mockFOX, AssetClickAction.Buy)
     expect(setValue).toHaveBeenCalledWith('buyTradeAsset.asset', mockFOX)
     expect(setValue).toHaveBeenCalledWith('action', TradeAmountInputField.SELL_FIAT)
   })
   it('handles buy click with sell amount', async () => {
     const { result, setValue } = setup({ sellAmount: '234' })
-    await result.current.handleBuyClick(mockFOX)
+    await result.current.handleAssetClick(mockFOX, AssetClickAction.Buy)
     expect(setValue).toHaveBeenCalledWith('buyTradeAsset.asset', mockFOX)
-    expect(setValue).toHaveBeenCalledWith('sellTradeAsset.asset', WETH)
     expect(setValue).toHaveBeenCalledWith('action', TradeAmountInputField.SELL_FIAT)
   })
   it('swaps when same asset on buy click', async () => {
     const { result, setValue } = setup({})
-    await result.current.handleBuyClick(WETH)
+    await result.current.handleAssetClick(WETH, AssetClickAction.Buy)
     expect(setValue).toHaveBeenCalledWith('buyTradeAsset.asset', WETH)
-    expect(setValue).toHaveBeenCalledWith('sellTradeAsset.asset', mockFOX)
     expect(setValue).toHaveBeenCalledWith('action', TradeAmountInputField.SELL_FIAT)
   })
 })

--- a/src/components/Trade/hooks/useTradeRoutes/useTradeRoutes.ts
+++ b/src/components/Trade/hooks/useTradeRoutes/useTradeRoutes.ts
@@ -105,7 +105,11 @@ export const useTradeRoutes = (
       const routeDefaultBuyAsset = assets[buyAssetId]
 
       // If we don't have a quote already, get one for the route's default assets
-      if (routeDefaultSellAsset && routeDefaultBuyAsset && !(buyTradeAsset || sellTradeAsset)) {
+      if (
+        routeDefaultSellAsset &&
+        routeDefaultBuyAsset &&
+        !(buyTradeAsset?.asset || sellTradeAsset?.asset)
+      ) {
         setValue('buyTradeAsset.asset', routeDefaultBuyAsset)
         setValue('sellTradeAsset.asset', routeDefaultSellAsset)
         setValue('action', TradeAmountInputField.SELL_CRYPTO)


### PR DESCRIPTION
## Description

DRY out asset selection logic as part of the broader swapper refactor.

## Notice

- [x] Have you followed the guidelines in our [Contributing]('https://github.com/shapeshift/web/CONTRIBUTING.md) guide?
- [x] Have you checked to ensure there aren't other open [Pull Requests](https://github.com/shapeshift/web/pulls) for the same update/change?

## Pull Request Type

- [ ] :bug: Bug fix (Non-breaking Change: Fixes an issue)
- [x] :hammer_and_wrench: Chore (Non-breaking Change: Doc updates, pkg upgrades, typos, etc..)
- [ ] :nail_care: New Feature (Breaking/Non-breaking Change)

## Issue (if applicable)

Contributes to https://github.com/shapeshift/web/issues/2556

## Risk

Risk that changing assets via the buy and sell buttons in the trade buttons breaks because I accidentally changed the logic.

## Testing

- Ensure changing between assets works as it always did.
- Check UTXO account selection still works as expected.

### Engineering

See top-level testing notes.

### Operations

See top-level testing notes.

## Screenshots (if applicable)

N/A