### PR TITLE
fix: default asset pair issues

### DIFF
--- a/src/components/Trade/TradeRoutes/TradeRoutes.tsx
+++ b/src/components/Trade/TradeRoutes/TradeRoutes.tsx
@@ -4,6 +4,7 @@ import { AnimatePresence } from 'framer-motion'
 import { Redirect, Route, RouteComponentProps, Switch, useLocation } from 'react-router-dom'
 import { Approval } from 'components/Approval/Approval'
 import { SelectAccount } from 'components/Trade/SelectAccount'
+import { useDefaultAssetsService } from 'components/Trade/services/useDefaultAssetsService'
 import { useFeatureFlag } from 'hooks/useFeatureFlag/useFeatureFlag'
 
 import { useSwapper } from '../hooks/useSwapper/useSwapperV2'
@@ -16,14 +17,11 @@ import { TradeRoutePaths } from '../types'
 
 export const entries = ['/send/details', '/send/confirm']
 
-type TradeRoutesProps = {
-  defaultBuyAssetId?: AssetId
-}
-
-export const TradeRoutes = ({ defaultBuyAssetId }: TradeRoutesProps) => {
-  const location = useLocation()
-  const { handleAssetClick } = useTradeRoutes(defaultBuyAssetId)
+export const TradeRoutes = (defaultBuyAssetId?: AssetId) => {
+  useDefaultAssetsService(defaultBuyAssetId)
   const { getSupportedSellableAssets, getSupportedBuyAssetsFromSellAsset } = useSwapper()
+  const location = useLocation()
+  const { handleAssetClick } = useTradeRoutes()
 
   const isSwapperV2 = useFeatureFlag('SwapperV2')
   const TradeInputComponent = isSwapperV2 ? TradeInputV2 : TradeInputV1

--- a/src/components/Trade/TradeRoutes/TradeRoutes.tsx
+++ b/src/components/Trade/TradeRoutes/TradeRoutes.tsx
@@ -17,7 +17,11 @@ import { TradeRoutePaths } from '../types'
 
 export const entries = ['/send/details', '/send/confirm']
 
-export const TradeRoutes = (defaultBuyAssetId?: AssetId) => {
+type TradeRoutesProps = {
+  defaultBuyAssetId?: AssetId
+}
+
+export const TradeRoutes = ({ defaultBuyAssetId }: TradeRoutesProps) => {
   useDefaultAssetsService(defaultBuyAssetId)
   const { getSupportedSellableAssets, getSupportedBuyAssetsFromSellAsset } = useSwapper()
   const location = useLocation()

--- a/src/components/Trade/hooks/useTradeRoutes/useTradeRoutes.ts
+++ b/src/components/Trade/hooks/useTradeRoutes/useTradeRoutes.ts
@@ -1,158 +1,23 @@
 import { Asset } from '@shapeshiftoss/asset-service'
-import {
-  AssetId,
-  cosmosChainId,
-  ethChainId,
-  fromAssetId,
-  osmosisChainId,
-} from '@shapeshiftoss/caip'
-import { supportsCosmos, supportsETH, supportsOsmosis } from '@shapeshiftoss/hdwallet-core'
 import { KnownChainIds } from '@shapeshiftoss/types'
-import isEmpty from 'lodash/isEmpty'
-import { useCallback, useEffect, useMemo } from 'react'
+import { useCallback } from 'react'
 import { useFormContext } from 'react-hook-form'
-import { useSelector } from 'react-redux'
 import { useHistory } from 'react-router-dom'
-import { getDefaultAssetIdPairByChainId } from 'components/Trade/hooks/useSwapper/utils'
 import { TradeAmountInputField, TradeRoutePaths, TradeState } from 'components/Trade/types'
-import { getChainAdapterManager } from 'context/PluginProvider/chainAdapterSingleton'
-import { useEvm } from 'hooks/useEvm/useEvm'
-import { useWallet } from 'hooks/useWallet/useWallet'
-import { logger } from 'lib/logger'
-import { selectFeatureFlags } from 'state/slices/preferencesSlice/selectors'
-import { selectAssetById, selectAssets } from 'state/slices/selectors'
-import { useAppSelector } from 'state/store'
-
-import { useSwapper } from '../useSwapper/useSwapperV2'
-
-const moduleLogger = logger.child({ namespace: ['useTradeRoutes'] })
 
 export enum AssetClickAction {
   Buy = 'buy',
   Sell = 'sell',
 }
 
-export const useTradeRoutes = (
-  routeBuyAssetId?: AssetId,
-): {
+export const useTradeRoutes = (): {
   handleAssetClick: (asset: Asset, action: AssetClickAction) => void
 } => {
   const history = useHistory()
   const { getValues, setValue } = useFormContext<TradeState<KnownChainIds>>()
-  const { swapperManager } = useSwapper()
-  const featureFlags = useAppSelector(selectFeatureFlags)
   const buyTradeAsset = getValues('buyTradeAsset')
   const sellTradeAsset = getValues('sellTradeAsset')
   const fiatSellAmount = getValues('fiatSellAmount')
-  const assets = useSelector(selectAssets)
-  const {
-    state: { wallet },
-  } = useWallet()
-
-  const { connectedEvmChainId } = useEvm()
-
-  // If the wallet is connected to a chain, use that ChainId
-  // Else, return a prioritized ChainId based on the wallet's supported chains
-  const walletChainId = useMemo(() => {
-    if (connectedEvmChainId) return connectedEvmChainId
-    if (!wallet) return
-    if (supportsETH(wallet)) return ethChainId
-    if (supportsCosmos(wallet)) return cosmosChainId
-    if (supportsOsmosis(wallet)) return osmosisChainId
-  }, [connectedEvmChainId, wallet])
-
-  // Use the ChainId of the route's AssetId if we have one, else use the wallet's fallback ChainId
-  const buyAssetChainId = routeBuyAssetId ? fromAssetId(routeBuyAssetId).chainId : walletChainId
-  const [defaultSellAssetId, defaultBuyAssetId] = getDefaultAssetIdPairByChainId(
-    buyAssetChainId,
-    featureFlags,
-  )
-
-  const { chainId: defaultSellChainId } = fromAssetId(defaultSellAssetId)
-  const defaultFeeAssetId = getChainAdapterManager().get(defaultSellChainId)!.getFeeAssetId()
-  const defaultFeeAsset = useAppSelector(state => selectAssetById(state, defaultFeeAssetId))
-
-  const setDefaultAssets = useCallback(async () => {
-    const bestSwapper = await swapperManager.getBestSwapper({
-      sellAssetId: defaultSellAssetId,
-      buyAssetId: defaultBuyAssetId,
-    })
-    // wait for assets to be loaded and swappers to be initialized
-    if (isEmpty(assets) || !defaultFeeAsset || !bestSwapper) return
-    try {
-      const routeDefaultSellAsset = assets[defaultSellAssetId]
-
-      const preBuyAssetToCheckId = routeBuyAssetId ?? defaultBuyAssetId
-
-      // make sure the same buy and sell assets arent selected
-      const buyAssetToCheckId =
-        preBuyAssetToCheckId === defaultSellAssetId ? defaultBuyAssetId : preBuyAssetToCheckId
-
-      const bestSwapper = await swapperManager.getBestSwapper({
-        buyAssetId: buyAssetToCheckId,
-        sellAssetId: defaultSellAssetId,
-      })
-
-      // TODO update swapper to have an official way to validate a pair is supported.
-      // This works for now
-      const isSupportedPair = await (async () => {
-        try {
-          if (bestSwapper) {
-            await bestSwapper.getUsdRate({ ...assets[buyAssetToCheckId] })
-            return true
-          }
-        } catch (e) {}
-        return false
-      })()
-
-      const buyAssetId = isSupportedPair ? buyAssetToCheckId : defaultBuyAssetId
-
-      const routeDefaultBuyAsset = assets[buyAssetId]
-
-      // If we don't have a quote already, get one for the route's default assets
-      if (
-        routeDefaultSellAsset &&
-        routeDefaultBuyAsset &&
-        !(buyTradeAsset?.asset || sellTradeAsset?.asset)
-      ) {
-        setValue('buyTradeAsset.asset', routeDefaultBuyAsset)
-        setValue('sellTradeAsset.asset', routeDefaultSellAsset)
-        setValue('action', TradeAmountInputField.SELL_CRYPTO)
-        setValue('amount', '0')
-      }
-    } catch (e) {
-      moduleLogger.warn(e, 'useTradeRoutes:setDefaultAssets error')
-    }
-  }, [
-    assets,
-    buyTradeAsset,
-    defaultBuyAssetId,
-    defaultFeeAsset,
-    defaultSellAssetId,
-    routeBuyAssetId,
-    sellTradeAsset,
-    setValue,
-    swapperManager,
-  ])
-
-  useEffect(() => {
-    if (!buyTradeAsset?.amount || !sellTradeAsset?.amount) {
-      setDefaultAssets()
-    }
-  }, [
-    assets,
-    routeBuyAssetId,
-    wallet,
-    swapperManager,
-    defaultFeeAsset,
-    setDefaultAssets,
-    buyTradeAsset,
-    sellTradeAsset,
-  ])
-
-  useEffect(() => {
-    setDefaultAssets()
-  }, [connectedEvmChainId, setDefaultAssets])
 
   const handleAssetClick = useCallback(
     (asset: Asset, action: AssetClickAction) => {

--- a/src/components/Trade/services/useDefaultAssetsService.ts
+++ b/src/components/Trade/services/useDefaultAssetsService.ts
@@ -61,12 +61,7 @@ export const useDefaultAssetsService = (routeBuyAssetId?: AssetId) => {
     setDefaultAssetIdPair([defaultSellAssetId, defaultBuyAssetId])
   }, [featureFlags, maybeWalletChainId, routeBuyAssetId])
 
-  const { data: buyAssetFiatRateData } = useGetUsdRateQuery(buyAssetFiatRateArgs, {
-    pollingInterval: 30000,
-    selectFromResult: ({ data }) => ({
-      data: data?.usdRate,
-    }),
-  })
+  const { data: buyAssetFiatRateData } = useGetUsdRateQuery(buyAssetFiatRateArgs)
 
   useEffect(
     () =>

--- a/src/components/Trade/services/useDefaultAssetsService.ts
+++ b/src/components/Trade/services/useDefaultAssetsService.ts
@@ -1,0 +1,93 @@
+/*
+The Default Asset Service is responsible for populating the trade widget with initial assets.
+It mutates the buyTradeAsset, sellTradeAsset, amount, and action properties of TradeState.
+*/
+import { skipToken } from '@reduxjs/toolkit/query'
+import {
+  AssetId,
+  cosmosChainId,
+  ethChainId,
+  fromAssetId,
+  osmosisChainId,
+} from '@shapeshiftoss/caip'
+import { supportsCosmos, supportsETH, supportsOsmosis } from '@shapeshiftoss/hdwallet-core'
+import { KnownChainIds } from '@shapeshiftoss/types'
+import { useCallback, useEffect, useMemo, useState } from 'react'
+import { useFormContext } from 'react-hook-form'
+import { useSelector } from 'react-redux'
+import { getDefaultAssetIdPairByChainId } from 'components/Trade/hooks/useSwapper/utils'
+import { TradeAmountInputField, TradeState } from 'components/Trade/types'
+import { useEvm } from 'hooks/useEvm/useEvm'
+import { useWallet } from 'hooks/useWallet/useWallet'
+import { useGetUsdRateQuery } from 'state/apis/swapper/swapperApi'
+import { selectAssets } from 'state/slices/assetsSlice/selectors'
+import { selectFeatureFlags } from 'state/slices/preferencesSlice/selectors'
+import { useAppSelector } from 'state/store'
+
+export const useDefaultAssetsService = (routeBuyAssetId?: AssetId) => {
+  type UsdRateQueryInput = Parameters<typeof useGetUsdRateQuery>
+  type UsdRateInputArg = UsdRateQueryInput[0]
+
+  const {
+    state: { wallet },
+  } = useWallet()
+  const { connectedEvmChainId } = useEvm()
+  const { setValue } = useFormContext<TradeState<KnownChainIds>>()
+  const [buyAssetFiatRateArgs, setBuyAssetFiatRateArgs] = useState<UsdRateInputArg>(skipToken)
+  const [defaultAssetIdPair, setDefaultAssetIdPair] = useState<[AssetId, AssetId]>()
+
+  const featureFlags = useAppSelector(selectFeatureFlags)
+  const assets = useSelector(selectAssets)
+
+  // If the wallet is connected to a chain, use that ChainId
+  // Else, return a prioritized ChainId based on the wallet's supported chains
+  const maybeWalletChainId = useMemo(() => {
+    if (connectedEvmChainId) return connectedEvmChainId
+    if (!wallet) return
+    if (supportsETH(wallet)) return ethChainId
+    if (supportsCosmos(wallet)) return cosmosChainId
+    if (supportsOsmosis(wallet)) return osmosisChainId
+  }, [connectedEvmChainId, wallet])
+
+  useEffect(() => {
+    // Use the ChainId of the route's AssetId if we have one, else use the wallet's fallback ChainId
+    const maybeBuyAssetChainId = routeBuyAssetId
+      ? fromAssetId(routeBuyAssetId).chainId
+      : maybeWalletChainId
+    const [defaultSellAssetId, defaultBuyAssetId] = getDefaultAssetIdPairByChainId(
+      maybeBuyAssetChainId,
+      featureFlags,
+    )
+    setDefaultAssetIdPair([defaultSellAssetId, defaultBuyAssetId])
+  }, [featureFlags, maybeWalletChainId, routeBuyAssetId])
+
+  const { data: buyAssetFiatRateData } = useGetUsdRateQuery(buyAssetFiatRateArgs, {
+    pollingInterval: 30000,
+    selectFromResult: ({ data }) => ({
+      data: data?.usdRate,
+    }),
+  })
+
+  useEffect(
+    () =>
+      defaultAssetIdPair &&
+      setBuyAssetFiatRateArgs({
+        buyAssetId: defaultAssetIdPair[1],
+        sellAssetId: defaultAssetIdPair[0],
+        rateAssetId: defaultAssetIdPair[1],
+      }),
+    [defaultAssetIdPair],
+  )
+
+  const setInitialAssets = useCallback(() => {
+    // TODO: update Swapper to have an proper way to validate a pair is supported.
+    if (buyAssetFiatRateData && defaultAssetIdPair) {
+      setValue('buyTradeAsset.asset', assets[defaultAssetIdPair[1]])
+      setValue('sellTradeAsset.asset', assets[defaultAssetIdPair[0]])
+      setValue('action', TradeAmountInputField.SELL_CRYPTO)
+      setValue('amount', '0')
+    }
+  }, [assets, buyAssetFiatRateData, defaultAssetIdPair, setValue])
+
+  useEffect(() => setInitialAssets(), [setInitialAssets])
+}

--- a/src/hooks/useEvm/useEvm.ts
+++ b/src/hooks/useEvm/useEvm.ts
@@ -12,7 +12,7 @@ export const useEvm = () => {
     state: { wallet },
   } = useWallet()
   const [isLoading, setIsLoading] = useState<boolean>(true)
-  const [ethNetwork, setEthNetwork] = useState<string>()
+  const [ethNetwork, setEthNetwork] = useState<string | null>()
   const [connectedEvmChainId, setConnectedEvmChainId] = useState<ChainId>()
   const featureFlags = useAppSelector(selectFeatureFlags)
   const supportedEvmChainIds = useMemo(
@@ -28,7 +28,7 @@ export const useEvm = () => {
   useEffect(() => {
     ;(async () => {
       setIsLoading(true)
-      setEthNetwork(undefined)
+      setEthNetwork(null)
       const ethNetwork = await (wallet as ETHWallet)?.ethGetChainId?.()
       if (ethNetwork) setEthNetwork(bnOrZero(ethNetwork).toString())
     })()

--- a/src/hooks/useEvm/useEvm.ts
+++ b/src/hooks/useEvm/useEvm.ts
@@ -1,4 +1,4 @@
-import { CHAIN_NAMESPACE, fromChainId } from '@shapeshiftoss/caip'
+import { CHAIN_NAMESPACE, ChainId, fromChainId } from '@shapeshiftoss/caip'
 import { ETHWallet } from '@shapeshiftoss/hdwallet-core'
 import { useEffect, useMemo, useState } from 'react'
 import { getChainAdapterManager } from 'context/PluginProvider/chainAdapterSingleton'
@@ -8,9 +8,12 @@ import { selectFeatureFlags } from 'state/slices/preferencesSlice/selectors'
 import { useAppSelector } from 'state/store'
 
 export const useEvm = () => {
-  const { state } = useWallet()
+  const {
+    state: { wallet },
+  } = useWallet()
   const [isLoading, setIsLoading] = useState<boolean>(true)
-  const [ethNetwork, setEthNetwork] = useState<string | null>(null)
+  const [ethNetwork, setEthNetwork] = useState<string>()
+  const [connectedEvmChainId, setConnectedEvmChainId] = useState<ChainId>()
   const featureFlags = useAppSelector(selectFeatureFlags)
   const supportedEvmChainIds = useMemo(
     () =>
@@ -25,17 +28,19 @@ export const useEvm = () => {
   useEffect(() => {
     ;(async () => {
       setIsLoading(true)
-      const ethNetwork = await (state.wallet as ETHWallet)?.ethGetChainId?.()
+      setEthNetwork(undefined)
+      const ethNetwork = await (wallet as ETHWallet)?.ethGetChainId?.()
       if (ethNetwork) setEthNetwork(bnOrZero(ethNetwork).toString())
     })()
-  }, [state])
+  }, [wallet])
 
-  const connectedEvmChainId = useMemo(() => {
-    if (ethNetwork && isLoading) {
-      setIsLoading(false)
-    }
-    return supportedEvmChainIds.find(chainId => fromChainId(chainId).chainReference === ethNetwork)
-  }, [isLoading, ethNetwork, supportedEvmChainIds])
+  useEffect(() => {
+    ethNetwork && isLoading && setIsLoading(false)
+    const connectedEvmChainId = supportedEvmChainIds.find(
+      chainId => fromChainId(chainId).chainReference === ethNetwork,
+    )
+    setConnectedEvmChainId(connectedEvmChainId)
+  }, [ethNetwork, isLoading, supportedEvmChainIds])
 
   return { supportedEvmChainIds, connectedEvmChainId, setEthNetwork, isLoading }
 }


### PR DESCRIPTION
## Description

Simplifies the default asset setting logic, and turns it into a dedicated service, which inadvertently fixes all known related bugs.

- Switches `getUsdRate` calls to RTK query, cutting network calls to this endpoint by ~70% vs current production build
- Fixes `useEffect` logic so it only fires once, instead of multiple times, which is causing default assets for a connected wallet to be overwritten by default assets (ETH/FOX)
- Correctly resets `ethNetwork` between wallet reconnections

Note, this fixes the bugs across both V1 and V2 swapper.

## Notice

- [X] Have you followed the guidelines in our [Contributing]('https://github.com/shapeshift/web/CONTRIBUTING.md) guide?
- [X] Have you checked to ensure there aren't other open [Pull Requests](https://github.com/shapeshift/web/pulls) for the same update/change?

## Pull Request Type

- [x] :bug: Bug fix (Non-breaking Change: Fixes an issue)
- [x] :hammer_and_wrench: Chore (Non-breaking Change: Doc updates, pkg upgrades, typos, etc..)
- [ ] :nail_care: New Feature (Breaking/Non-breaking Change)

## Issue (if applicable)

Closes https://github.com/shapeshift/web/issues/2446
Closes https://github.com/shapeshift/web/issues/2627

## Risk

Touches default asset setting in the trade component. There is a risk these will not be set correctly.

## Testing

Default assets are no longer overwritten:

1. Connect to a wallet on Avalanche, e.g. MetaMask, and load the Dashboard. Notice that the default assets are correctly set to the AVAX/WETH pair.

Switching wallets resets `ethNetwork`, and thus triggers default assets to reset:

1. Connect to MetaMask on the Avalanche chain
2. Observe that AVAX is selected as a default asset
3. Switch to a Native wallet.
4. Observe that ETH is now selected, instead of AVAX

### Engineering

See shared instructions above.

### Operations

See shared instructions above.

## Screenshots (if applicable)

N/A