### PR TITLE
feat(foxEth): consolidate getAddress() calls in DeFi components

### DIFF
--- a/src/context/FoxEthProvider/FoxEthProvider.tsx
+++ b/src/context/FoxEthProvider/FoxEthProvider.tsx
@@ -151,9 +151,9 @@ export const FoxEthProvider = ({ children }: FoxEthProviderProps) => {
   const [lpEthBalance, setLpEthBalance] = useState<string | null>(null)
   const [ongoingTxId, setOngoingTxId] = useState<string | null>(null)
   const [foxEthLpOpportunity, setFoxEthLpOpportunity] = useState<EarnOpportunityType>(lpOpportunity)
-  const { calculateHoldings, getLpTVL } = useFoxEthLiquidityPool()
-
   const [connectedWalletEthAddress, setConnectedWalletEthAddress] = useState<string | null>(null)
+  const { calculateHoldings, getLpTVL } = useFoxEthLiquidityPool(connectedWalletEthAddress)
+
   const [farmingLoading, setFarmingLoading] = useState<boolean>(true)
   const [foxFarmingTotalBalance, setFoxFarmingTotalBalance] = useState<string>('')
   const [foxFarmingOpportunities, setFoxFarmingOpportunities] = useState<

--- a/src/context/FoxEthProvider/FoxEthProvider.tsx
+++ b/src/context/FoxEthProvider/FoxEthProvider.tsx
@@ -112,6 +112,7 @@ type IFoxLpAndFarmingOpportunitiesContext = {
   lpTokenPrice: string | null
   foxFarmingTotalBalanceInBaseUnit: string | null
   foxEthLpOpportunity: EarnOpportunityType
+  connectedWalletEthAddress: string | null
   foxFarmingOpportunities: FoxFarmingEarnOpportunityType[]
   onlyVisibleFoxFarmingOpportunities: FoxFarmingEarnOpportunityType[]
   lpLoading: boolean
@@ -125,6 +126,7 @@ const FoxLpAndFarmingOpportunitiesContext = createContext<IFoxLpAndFarmingOpport
   lpEthBalance: null,
   lpTokenPrice: null,
   foxFarmingTotalBalanceInBaseUnit: null,
+  connectedWalletEthAddress: null,
   foxEthLpOpportunity: lpOpportunity,
   foxFarmingOpportunities: [v4FarmingOpportunity],
   onlyVisibleFoxFarmingOpportunities: [v4FarmingOpportunity],
@@ -353,6 +355,7 @@ export const FoxEthProvider = ({ children }: FoxEthProviderProps) => {
 
   const value = useMemo(
     () => ({
+      connectedWalletEthAddress,
       totalBalance: bnOrZero(featureFlags.FoxLP ? foxEthLpOpportunity.fiatAmount : 0)
         .plus(featureFlags.FoxFarming ? foxFarmingTotalBalance : 0)
         .toString(),
@@ -374,6 +377,7 @@ export const FoxEthProvider = ({ children }: FoxEthProviderProps) => {
     [
       featureFlags.FoxLP,
       featureFlags.FoxFarming,
+      connectedWalletEthAddress,
       foxEthLpOpportunity,
       foxFarmingTotalBalance,
       foxFarmingTotalCryptoAmount,

--- a/src/features/defi/providers/fox-eth-lp/components/FoxEthLpManager/Deposit/components/Approve.tsx
+++ b/src/features/defi/providers/fox-eth-lp/components/FoxEthLpManager/Deposit/components/Approve.tsx
@@ -8,6 +8,7 @@ import { useFoxEthLiquidityPool } from 'features/defi/providers/fox-eth-lp/hooks
 import { FOX_TOKEN_CONTRACT_ADDRESS } from 'plugins/foxPage/const'
 import { useContext } from 'react'
 import { useTranslate } from 'react-polyglot'
+import { useFoxEth } from 'context/FoxEthProvider/FoxEthProvider'
 import { useWallet } from 'hooks/useWallet/useWallet'
 import { bn, bnOrZero } from 'lib/bignumber/bignumber'
 import { logger } from 'lib/logger'
@@ -27,7 +28,9 @@ const moduleLogger = logger.child({ namespace: ['FoxEthLpDeposit:Approve'] })
 export const Approve: React.FC<FoxEthLpApproveProps> = ({ onNext }) => {
   const { state, dispatch } = useContext(DepositContext)
   const translate = useTranslate()
-  const { approve, allowance, getDepositGasData } = useFoxEthLiquidityPool()
+  const { connectedWalletEthAddress } = useFoxEth()
+  const { approve, allowance, getDepositGasData } =
+    useFoxEthLiquidityPool(connectedWalletEthAddress)
   const opportunity = state?.opportunity
 
   const foxAsset = useAppSelector(state => selectAssetById(state, foxAssetId))

--- a/src/features/defi/providers/fox-eth-lp/components/FoxEthLpManager/Deposit/components/Confirm.tsx
+++ b/src/features/defi/providers/fox-eth-lp/components/FoxEthLpManager/Deposit/components/Confirm.tsx
@@ -37,9 +37,9 @@ const moduleLogger = logger.child({ namespace: ['FoxEthLpDeposit:Confirm'] })
 export const Confirm: React.FC<StepComponentProps> = ({ onNext }) => {
   const { state, dispatch } = useContext(DepositContext)
   const translate = useTranslate()
-  const { onOngoingTxIdChange } = useFoxEth()
+  const { connectedWalletEthAddress, onOngoingTxIdChange } = useFoxEth()
   const { query } = useBrowserRouter<DefiQueryParams, DefiParams>()
-  const { addLiquidity } = useFoxEthLiquidityPool()
+  const { addLiquidity } = useFoxEthLiquidityPool(connectedWalletEthAddress)
   const opportunity = useMemo(() => state?.opportunity, [state])
   const { chainId, assetReference } = query
 

--- a/src/features/defi/providers/fox-eth-lp/components/FoxEthLpManager/Deposit/components/Deposit.tsx
+++ b/src/features/defi/providers/fox-eth-lp/components/FoxEthLpManager/Deposit/components/Deposit.tsx
@@ -14,6 +14,7 @@ import { useContext } from 'react'
 import { useTranslate } from 'react-polyglot'
 import { useHistory } from 'react-router-dom'
 import { StepComponentProps } from 'components/DeFi/components/Steps'
+import { useFoxEth } from 'context/FoxEthProvider/FoxEthProvider'
 import { useBrowserRouter } from 'hooks/useBrowserRouter/useBrowserRouter'
 import { bn, bnOrZero } from 'lib/bignumber/bignumber'
 import { logger } from 'lib/logger'
@@ -36,7 +37,9 @@ export const Deposit: React.FC<StepComponentProps> = ({ onNext }) => {
   const { query, history: browserHistory } = useBrowserRouter<DefiQueryParams, DefiParams>()
   const { chainId, assetReference } = query
   const opportunity = state?.opportunity
-  const { allowance, getApproveGasData, getDepositGasData } = useFoxEthLiquidityPool()
+  const { connectedWalletEthAddress } = useFoxEth()
+  const { allowance, getApproveGasData, getDepositGasData } =
+    useFoxEthLiquidityPool(connectedWalletEthAddress)
 
   const assetNamespace = 'erc20'
   const assetId = toAssetId({ chainId, assetNamespace, assetReference })

--- a/src/features/defi/providers/fox-eth-lp/components/FoxEthLpManager/Deposit/components/Status.tsx
+++ b/src/features/defi/providers/fox-eth-lp/components/FoxEthLpManager/Deposit/components/Status.tsx
@@ -1,13 +1,11 @@
 import { CheckIcon, CloseIcon, ExternalLinkIcon } from '@chakra-ui/icons'
 import { Box, Button, Link, Stack } from '@chakra-ui/react'
 import { ASSET_REFERENCE, ethAssetId, toAssetId } from '@shapeshiftoss/caip'
-import { ChainAdapter } from '@shapeshiftoss/chain-adapters'
-import { KnownChainIds } from '@shapeshiftoss/types'
 import { Summary } from 'features/defi/components/Summary'
 import { TxStatus } from 'features/defi/components/TxStatus/TxStatus'
 import { DefiParams, DefiQueryParams } from 'features/defi/contexts/DefiManagerProvider/DefiCommon'
 import { foxAssetId } from 'features/defi/providers/fox-eth-lp/constants'
-import { useContext, useEffect, useMemo, useState } from 'react'
+import { useContext, useEffect, useMemo } from 'react'
 import { useTranslate } from 'react-polyglot'
 import { Amount } from 'components/Amount/Amount'
 import { AssetIcon } from 'components/AssetIcon'
@@ -15,9 +13,7 @@ import { StatusTextEnum } from 'components/RouteSteps/RouteSteps'
 import { Row } from 'components/Row/Row'
 import { RawText, Text } from 'components/Text'
 import { useFoxEth } from 'context/FoxEthProvider/FoxEthProvider'
-import { getChainAdapterManager } from 'context/PluginProvider/chainAdapterSingleton'
 import { useBrowserRouter } from 'hooks/useBrowserRouter/useBrowserRouter'
-import { useWallet } from 'hooks/useWallet/useWallet'
 import { bnOrZero } from 'lib/bignumber/bignumber'
 import {
   selectAssetById,
@@ -32,15 +28,11 @@ import { FoxEthLpDepositActionType } from '../DepositCommon'
 import { DepositContext } from '../DepositContext'
 
 export const Status = () => {
-  const [userAddress, setUserAddres] = useState<string | null>(null)
   const translate = useTranslate()
   const { state, dispatch } = useContext(DepositContext)
   const { query, history: browserHistory } = useBrowserRouter<DefiQueryParams, DefiParams>()
   const { chainId } = query
-  const { foxEthLpOpportunity } = useFoxEth()
-  const {
-    state: { wallet },
-  } = useWallet()
+  const { connectedWalletEthAddress: userAddress, foxEthLpOpportunity } = useFoxEth()
 
   const feeAssetId = toAssetId({
     chainId,
@@ -55,17 +47,6 @@ export const Status = () => {
   const accountSpecifier = useAppSelector(state =>
     selectFirstAccountSpecifierByChainId(state, chainId),
   )
-
-  useEffect(() => {
-    const chainAdapterManager = getChainAdapterManager()
-    const adapter = chainAdapterManager.get(ethAsset.chainId) as ChainAdapter<KnownChainIds>
-    if (wallet && adapter) {
-      ;(async () => {
-        const address = await adapter.getAddress({ wallet })
-        setUserAddres(address)
-      })()
-    }
-  }, [ethAsset.chainId, wallet])
 
   const serializedTxIndex = useMemo(() => {
     if (!(state?.txid && userAddress)) return ''

--- a/src/features/defi/providers/fox-eth-lp/components/FoxEthLpManager/Withdraw/components/Approve.tsx
+++ b/src/features/defi/providers/fox-eth-lp/components/FoxEthLpManager/Withdraw/components/Approve.tsx
@@ -10,6 +10,7 @@ import {
 import { useFoxEthLiquidityPool } from 'features/defi/providers/fox-eth-lp/hooks/useFoxEthLiquidityPool'
 import { useContext } from 'react'
 import { useTranslate } from 'react-polyglot'
+import { useFoxEth } from 'context/FoxEthProvider/FoxEthProvider'
 import { useWallet } from 'hooks/useWallet/useWallet'
 import { bn, bnOrZero } from 'lib/bignumber/bignumber'
 import { logger } from 'lib/logger'
@@ -29,7 +30,9 @@ const moduleLogger = logger.child({ namespace: ['FoxEthLpWithdraw:Approve'] })
 export const Approve: React.FC<FoxEthLpApproveProps> = ({ onNext }) => {
   const { state, dispatch } = useContext(WithdrawContext)
   const translate = useTranslate()
-  const { approve, allowance, getWithdrawGasData } = useFoxEthLiquidityPool()
+  const { connectedWalletEthAddress } = useFoxEth()
+  const { approve, allowance, getWithdrawGasData } =
+    useFoxEthLiquidityPool(connectedWalletEthAddress)
   const opportunity = state?.opportunity
 
   const foxAsset = useAppSelector(state => selectAssetById(state, foxAssetId))

--- a/src/features/defi/providers/fox-eth-lp/components/FoxEthLpManager/Withdraw/components/Confirm.tsx
+++ b/src/features/defi/providers/fox-eth-lp/components/FoxEthLpManager/Withdraw/components/Confirm.tsx
@@ -33,8 +33,12 @@ const moduleLogger = logger.child({ namespace: ['Confirm'] })
 export const Confirm = ({ onNext }: StepComponentProps) => {
   const { state, dispatch } = useContext(WithdrawContext)
   const translate = useTranslate()
-  const { foxEthLpOpportunity: opportunity, onOngoingTxIdChange } = useFoxEth()
-  const { removeLiquidity } = useFoxEthLiquidityPool()
+  const {
+    connectedWalletEthAddress,
+    foxEthLpOpportunity: opportunity,
+    onOngoingTxIdChange,
+  } = useFoxEth()
+  const { removeLiquidity } = useFoxEthLiquidityPool(connectedWalletEthAddress)
 
   const ethAsset = useAppSelector(state => selectAssetById(state, ethAssetId))
   const ethMarketData = useAppSelector(state => selectMarketDataById(state, ethAssetId))

--- a/src/features/defi/providers/fox-eth-lp/components/FoxEthLpManager/Withdraw/components/Status.tsx
+++ b/src/features/defi/providers/fox-eth-lp/components/FoxEthLpManager/Withdraw/components/Status.tsx
@@ -1,14 +1,12 @@
 import { CheckIcon, CloseIcon, ExternalLinkIcon } from '@chakra-ui/icons'
 import { Box, Button, Link, Stack } from '@chakra-ui/react'
 import { ethAssetId } from '@shapeshiftoss/caip'
-import { ChainAdapter } from '@shapeshiftoss/chain-adapters'
-import { KnownChainIds } from '@shapeshiftoss/types'
 import { PairIcons } from 'features/defi/components/PairIcons/PairIcons'
 import { Summary } from 'features/defi/components/Summary'
 import { TxStatus } from 'features/defi/components/TxStatus/TxStatus'
 import { DefiParams, DefiQueryParams } from 'features/defi/contexts/DefiManagerProvider/DefiCommon'
 import { foxAssetId, foxEthLpAssetId } from 'features/defi/providers/fox-eth-lp/constants'
-import { useContext, useEffect, useMemo, useState } from 'react'
+import { useContext, useEffect, useMemo } from 'react'
 import { useTranslate } from 'react-polyglot'
 import { Amount } from 'components/Amount/Amount'
 import { AssetIcon } from 'components/AssetIcon'
@@ -16,9 +14,7 @@ import { StatusTextEnum } from 'components/RouteSteps/RouteSteps'
 import { Row } from 'components/Row/Row'
 import { RawText, Text } from 'components/Text'
 import { useFoxEth } from 'context/FoxEthProvider/FoxEthProvider'
-import { getChainAdapterManager } from 'context/PluginProvider/chainAdapterSingleton'
 import { useBrowserRouter } from 'hooks/useBrowserRouter/useBrowserRouter'
-import { useWallet } from 'hooks/useWallet/useWallet'
 import { bnOrZero } from 'lib/bignumber/bignumber'
 import {
   selectAssetById,
@@ -33,15 +29,11 @@ import { FoxEthLpWithdrawActionType } from '../WithdrawCommon'
 import { WithdrawContext } from '../WithdrawContext'
 
 export const Status = () => {
-  const [userAddress, setUserAddres] = useState<string | null>(null)
   const translate = useTranslate()
   const { state, dispatch } = useContext(WithdrawContext)
   const { query, history: browserHistory } = useBrowserRouter<DefiQueryParams, DefiParams>()
   const { chainId } = query
-  const { foxEthLpOpportunity: opportunity } = useFoxEth()
-  const {
-    state: { wallet },
-  } = useWallet()
+  const { connectedWalletEthAddress: userAddress, foxEthLpOpportunity: opportunity } = useFoxEth()
 
   const ethAsset = useAppSelector(state => selectAssetById(state, ethAssetId))
   const ethMarketData = useAppSelector(state => selectMarketDataById(state, ethAssetId))
@@ -51,16 +43,6 @@ export const Status = () => {
   const accountSpecifier = useAppSelector(state =>
     selectFirstAccountSpecifierByChainId(state, chainId),
   )
-  useEffect(() => {
-    const chainAdapterManager = getChainAdapterManager()
-    const adapter = chainAdapterManager.get(ethAsset.chainId) as ChainAdapter<KnownChainIds>
-    if (wallet && adapter) {
-      ;(async () => {
-        const address = await adapter.getAddress({ wallet })
-        setUserAddres(address)
-      })()
-    }
-  }, [ethAsset.chainId, wallet])
 
   const serializedTxIndex = useMemo(() => {
     if (!(state?.txid && userAddress)) return ''

--- a/src/features/defi/providers/fox-eth-lp/components/FoxEthLpManager/Withdraw/components/Withdraw.tsx
+++ b/src/features/defi/providers/fox-eth-lp/components/FoxEthLpManager/Withdraw/components/Withdraw.tsx
@@ -39,9 +39,11 @@ export const Withdraw: React.FC<StepComponentProps> = ({ onNext }) => {
     lpFoxBalance: foxBalance,
     lpEthBalance: ethBalance,
     lpLoading: loading,
+    connectedWalletEthAddress,
   } = useFoxEth()
 
-  const { allowance, getApproveGasData, getWithdrawGasData } = useFoxEthLiquidityPool()
+  const { allowance, getApproveGasData, getWithdrawGasData } =
+    useFoxEthLiquidityPool(connectedWalletEthAddress)
   const [foxAmount, setFoxAmount] = useState('0')
   const [ethAmount, setEthAmount] = useState('0')
 

--- a/src/features/defi/providers/fox-eth-lp/hooks/useFoxEthLiquidityPool.ts
+++ b/src/features/defi/providers/fox-eth-lp/hooks/useFoxEthLiquidityPool.ts
@@ -12,7 +12,7 @@ import { KnownChainIds } from '@shapeshiftoss/types'
 import IUniswapV2Pair from '@uniswap/v2-core/build/IUniswapV2Pair.json'
 import { FOX_TOKEN_CONTRACT_ADDRESS } from 'plugins/foxPage/const'
 import { getEthersProvider } from 'plugins/foxPage/utils'
-import { useCallback, useEffect, useMemo, useState } from 'react'
+import { useCallback, useMemo } from 'react'
 import { getChainAdapterManager } from 'context/PluginProvider/chainAdapterSingleton'
 import { useEvm } from 'hooks/useEvm/useEvm'
 import { useWallet } from 'hooks/useWallet/useWallet'
@@ -45,8 +45,7 @@ function calculateSlippageMargin(amount: string | null, precision: number) {
     .toFixed()
 }
 
-export const useFoxEthLiquidityPool = () => {
-  const [connectedWalletEthAddress, setConnectedWalletEthAddress] = useState<string | null>(null)
+export const useFoxEthLiquidityPool = (connectedWalletEthAddress: string | null) => {
   const { supportedEvmChainIds } = useEvm()
   const ethAsset = useAppSelector(state => selectAssetById(state, ethAssetId))
   const foxAsset = useAppSelector(state => selectAssetById(state, foxAssetId))
@@ -58,16 +57,6 @@ export const useFoxEthLiquidityPool = () => {
 
   const chainAdapterManager = getChainAdapterManager()
   const adapter = chainAdapterManager.get(ethAsset.chainId) as ChainAdapter<KnownChainIds>
-
-  useEffect(() => {
-    if (wallet && adapter) {
-      ;(async () => {
-        if (!supportsETH(wallet)) return
-        const address = await adapter.getAddress({ wallet })
-        setConnectedWalletEthAddress(address)
-      })()
-    }
-  }, [adapter, wallet])
 
   const uniswapRouterContract = useMemo(
     () => new Contract(UNISWAP_V2_ROUTER_ADDRESS, IUniswapV2Router02ABI.abi, ethersProvider),

--- a/src/features/defi/providers/fox-farming/components/FoxFarmingManager/Deposit/FoxFarmingDeposit.tsx
+++ b/src/features/defi/providers/fox-farming/components/FoxFarmingManager/Deposit/FoxFarmingDeposit.tsx
@@ -68,7 +68,7 @@ export const FoxFarmingDeposit = () => {
         moduleLogger.error(error, 'FoxFarmingDeposit error')
       }
     })()
-  }, [userAddress, translate, toast, chainId, contractAddress, opportunity])
+  }, [userAddress, translate, toast, contractAddress, opportunity])
 
   const handleBack = () => {
     history.push({

--- a/src/features/defi/providers/fox-farming/components/FoxFarmingManager/Deposit/FoxFarmingDeposit.tsx
+++ b/src/features/defi/providers/fox-farming/components/FoxFarmingManager/Deposit/FoxFarmingDeposit.tsx
@@ -15,9 +15,7 @@ import { useSelector } from 'react-redux'
 import { CircularProgress } from 'components/CircularProgress/CircularProgress'
 import { DefiStepProps, Steps } from 'components/DeFi/components/Steps'
 import { useFoxEth } from 'context/FoxEthProvider/FoxEthProvider'
-import { getChainAdapterManager } from 'context/PluginProvider/chainAdapterSingleton'
 import { useBrowserRouter } from 'hooks/useBrowserRouter/useBrowserRouter'
-import { useWallet } from 'hooks/useWallet/useWallet'
 import { logger } from 'lib/logger'
 import {
   selectAssetById,
@@ -43,35 +41,34 @@ export const FoxFarmingDeposit = () => {
   const translate = useTranslate()
   const toast = useToast()
   const { query, history, location } = useBrowserRouter<DefiQueryParams, DefiParams>()
-  const chainAdapterManager = getChainAdapterManager()
   const { chainId, contractAddress, assetReference } = query
 
   const assetNamespace = 'erc20'
   const assetId = toAssetId({ chainId, assetNamespace, assetReference })
   const asset = useAppSelector(state => selectAssetById(state, assetId))
   const marketData = useAppSelector(state => selectMarketDataById(state, assetId))
-  const { foxFarmingOpportunities, farmingLoading: foxFarmingLoading } = useFoxEth()
+  const {
+    connectedWalletEthAddress: userAddress,
+    foxFarmingOpportunities,
+    farmingLoading: foxFarmingLoading,
+  } = useFoxEth()
   const opportunity = foxFarmingOpportunities.find(e => e.contractAddress === contractAddress)
 
-  // user info
-  const chainAdapter = chainAdapterManager.get(chainId)
-  const { state: walletState } = useWallet()
   const loading = useSelector(selectPortfolioLoading)
 
   useEffect(() => {
     ;(async () => {
       try {
-        if (!(walletState.wallet && contractAddress && chainAdapter && opportunity)) return
-        const address = await chainAdapter.getAddress({ wallet: walletState.wallet })
+        if (!(userAddress && contractAddress && opportunity)) return
 
-        dispatch({ type: FoxFarmingDepositActionType.SET_USER_ADDRESS, payload: address })
+        dispatch({ type: FoxFarmingDepositActionType.SET_USER_ADDRESS, payload: userAddress })
         dispatch({ type: FoxFarmingDepositActionType.SET_OPPORTUNITY, payload: opportunity })
       } catch (error) {
         // TODO: handle client side errors
         moduleLogger.error(error, 'FoxFarmingDeposit error')
       }
     })()
-  }, [chainAdapter, walletState.wallet, translate, toast, chainId, contractAddress, opportunity])
+  }, [userAddress, translate, toast, chainId, contractAddress, opportunity])
 
   const handleBack = () => {
     history.push({

--- a/src/features/defi/providers/fox-farming/components/FoxFarmingManager/Deposit/components/Deposit.tsx
+++ b/src/features/defi/providers/fox-farming/components/FoxFarmingManager/Deposit/components/Deposit.tsx
@@ -15,6 +15,7 @@ import { useCallback, useContext, useEffect, useState } from 'react'
 import { useTranslate } from 'react-polyglot'
 import { useHistory } from 'react-router-dom'
 import { StepComponentProps } from 'components/DeFi/components/Steps'
+import { useFoxEth } from 'context/FoxEthProvider/FoxEthProvider'
 import { useBrowserRouter } from 'hooks/useBrowserRouter/useBrowserRouter'
 import { bn, bnOrZero } from 'lib/bignumber/bignumber'
 import { logger } from 'lib/logger'
@@ -34,7 +35,8 @@ export const Deposit: React.FC<StepComponentProps> = ({ onNext }) => {
   const { query, history: browserHistory } = useBrowserRouter<DefiQueryParams, DefiParams>()
   const { chainId, assetReference, contractAddress } = query
   const opportunity = state?.opportunity
-  const { getLpTokenPrice } = useFoxEthLiquidityPool()
+  const { connectedWalletEthAddress } = useFoxEth()
+  const { getLpTokenPrice } = useFoxEthLiquidityPool(connectedWalletEthAddress)
   const {
     allowance: foxFarmingAllowance,
     getStakeGasData,

--- a/src/features/defi/providers/fox-farming/components/FoxFarmingManager/Overview/Claim/ClaimConfirm.tsx
+++ b/src/features/defi/providers/fox-farming/components/FoxFarmingManager/Overview/Claim/ClaimConfirm.tsx
@@ -9,7 +9,6 @@ import {
   useToast,
 } from '@chakra-ui/react'
 import { ASSET_REFERENCE, AssetId, ChainId, toAssetId } from '@shapeshiftoss/caip'
-import { KnownChainIds } from '@shapeshiftoss/types'
 import { useFoxFarming } from 'features/defi/providers/fox-farming/hooks/useFoxFarming'
 import { useEffect, useState } from 'react'
 import { useTranslate } from 'react-polyglot'
@@ -21,7 +20,6 @@ import { Row } from 'components/Row/Row'
 import { SlideTransition } from 'components/SlideTransition'
 import { Text } from 'components/Text'
 import { useFoxEth } from 'context/FoxEthProvider/FoxEthProvider'
-import { getChainAdapterManager } from 'context/PluginProvider/chainAdapterSingleton'
 import { useWallet } from 'hooks/useWallet/useWallet'
 import { bnOrZero } from 'lib/bignumber/bignumber'
 import { logger } from 'lib/logger'
@@ -47,7 +45,6 @@ export const ClaimConfirm = ({
   chainId,
   onBack,
 }: ClaimConfirmProps) => {
-  const [userAddress, setUserAddress] = useState<string>('')
   const [estimatedGas, setEstimatedGas] = useState<string>('0')
   const [loading, setLoading] = useState<boolean>(false)
   const [canClaim, setCanClaim] = useState<boolean>(false)
@@ -55,9 +52,7 @@ export const ClaimConfirm = ({
   const { claimRewards, getClaimGasData, foxFarmingContract } = useFoxFarming(contractAddress)
   const translate = useTranslate()
   const history = useHistory()
-  const { onOngoingTxIdChange } = useFoxEth()
-
-  const chainAdapterManager = getChainAdapterManager()
+  const { connectedWalletEthAddress: userAddress, onOngoingTxIdChange } = useFoxEth()
 
   // Asset Info
   const asset = useAppSelector(state => selectAssetById(state, assetId))
@@ -98,20 +93,6 @@ export const ClaimConfirm = ({
       setLoading(false)
     }
   }
-
-  useEffect(() => {
-    ;(async () => {
-      try {
-        const chainAdapter = chainAdapterManager.get(KnownChainIds.EthereumMainnet)
-        if (!(walletState.wallet && chainAdapter)) return
-        const userAddress = await chainAdapter.getAddress({ wallet: walletState.wallet })
-        setUserAddress(userAddress)
-      } catch (error) {
-        // TODO: handle client side errors
-        moduleLogger.error(error, 'FoxFarmingClaim error')
-      }
-    })()
-  }, [chainAdapterManager, walletState.wallet])
 
   useEffect(() => {
     ;(async () => {
@@ -172,7 +153,7 @@ export const ClaimConfirm = ({
                   color='blue.500'
                   href={`${asset?.explorerAddressLink}${userAddress}`}
                 >
-                  <MiddleEllipsis value={userAddress} />
+                  <MiddleEllipsis value={userAddress ?? ''} />
                 </Link>
               </Skeleton>
             </Row.Value>

--- a/src/features/defi/providers/fox-farming/components/FoxFarmingManager/Withdraw/FoxFarmingWithdraw.tsx
+++ b/src/features/defi/providers/fox-farming/components/FoxFarmingManager/Withdraw/FoxFarmingWithdraw.tsx
@@ -14,7 +14,6 @@ import { useSelector } from 'react-redux'
 import { CircularProgress } from 'components/CircularProgress/CircularProgress'
 import { DefiStepProps, Steps } from 'components/DeFi/components/Steps'
 import { useFoxEth } from 'context/FoxEthProvider/FoxEthProvider'
-import { getChainAdapterManager } from 'context/PluginProvider/chainAdapterSingleton'
 import { useBrowserRouter } from 'hooks/useBrowserRouter/useBrowserRouter'
 import { logger } from 'lib/logger'
 import { selectPortfolioLoading } from 'state/slices/selectors'
@@ -36,10 +35,7 @@ export const FoxFarmingWithdraw = () => {
   const [state, dispatch] = useReducer(reducer, initialState)
   const translate = useTranslate()
   const { query, history, location } = useBrowserRouter<DefiQueryParams, DefiParams>()
-  const { chainId, contractAddress } = query
-
-  const chainAdapterManager = getChainAdapterManager()
-  const chainAdapter = chainAdapterManager.get(chainId)
+  const { contractAddress } = query
 
   const {
     connectedWalletEthAddress: userAddress,
@@ -56,7 +52,7 @@ export const FoxFarmingWithdraw = () => {
   useEffect(() => {
     ;(async () => {
       try {
-        if (!(userAddress && contractAddress && chainAdapter && opportunity)) return
+        if (!(userAddress && contractAddress && opportunity)) return
 
         dispatch({ type: FoxFarmingWithdrawActionType.SET_USER_ADDRESS, payload: userAddress })
         dispatch({ type: FoxFarmingWithdrawActionType.SET_OPPORTUNITY, payload: opportunity })
@@ -65,7 +61,7 @@ export const FoxFarmingWithdraw = () => {
         moduleLogger.error(error, 'FoxFarmingWithdraw error')
       }
     })()
-  }, [userAddress, chainAdapter, translate, chainId, contractAddress, opportunity])
+  }, [userAddress, translate, contractAddress, opportunity])
 
   const handleBack = () => {
     history.push({

--- a/src/features/defi/providers/fox-farming/components/FoxFarmingManager/Withdraw/FoxFarmingWithdraw.tsx
+++ b/src/features/defi/providers/fox-farming/components/FoxFarmingManager/Withdraw/FoxFarmingWithdraw.tsx
@@ -16,7 +16,6 @@ import { DefiStepProps, Steps } from 'components/DeFi/components/Steps'
 import { useFoxEth } from 'context/FoxEthProvider/FoxEthProvider'
 import { getChainAdapterManager } from 'context/PluginProvider/chainAdapterSingleton'
 import { useBrowserRouter } from 'hooks/useBrowserRouter/useBrowserRouter'
-import { useWallet } from 'hooks/useWallet/useWallet'
 import { logger } from 'lib/logger'
 import { selectPortfolioLoading } from 'state/slices/selectors'
 
@@ -42,30 +41,31 @@ export const FoxFarmingWithdraw = () => {
   const chainAdapterManager = getChainAdapterManager()
   const chainAdapter = chainAdapterManager.get(chainId)
 
-  const { foxFarmingOpportunities, farmingLoading: foxFarmingLoading } = useFoxEth()
+  const {
+    connectedWalletEthAddress: userAddress,
+    foxFarmingOpportunities,
+    farmingLoading: foxFarmingLoading,
+  } = useFoxEth()
   const opportunity = useMemo(
     () => foxFarmingOpportunities.find(e => e.contractAddress === contractAddress),
     [contractAddress, foxFarmingOpportunities],
   )
 
-  // user info
-  const { state: walletState } = useWallet()
   const loading = useSelector(selectPortfolioLoading)
 
   useEffect(() => {
     ;(async () => {
       try {
-        if (!(walletState.wallet && contractAddress && chainAdapter && opportunity)) return
-        const address = await chainAdapter.getAddress({ wallet: walletState.wallet })
+        if (!(userAddress && contractAddress && chainAdapter && opportunity)) return
 
-        dispatch({ type: FoxFarmingWithdrawActionType.SET_USER_ADDRESS, payload: address })
+        dispatch({ type: FoxFarmingWithdrawActionType.SET_USER_ADDRESS, payload: userAddress })
         dispatch({ type: FoxFarmingWithdrawActionType.SET_OPPORTUNITY, payload: opportunity })
       } catch (error) {
         // TODO: handle client side errors
         moduleLogger.error(error, 'FoxFarmingWithdraw error')
       }
     })()
-  }, [chainAdapter, walletState.wallet, translate, chainId, contractAddress, opportunity])
+  }, [userAddress, chainAdapter, translate, chainId, contractAddress, opportunity])
 
   const handleBack = () => {
     history.push({

--- a/src/features/defi/providers/fox-farming/hooks/useFoxFarming.ts
+++ b/src/features/defi/providers/fox-farming/hooks/useFoxFarming.ts
@@ -11,7 +11,8 @@ import { supportsETH } from '@shapeshiftoss/hdwallet-core'
 import { KnownChainIds } from '@shapeshiftoss/types'
 import IUniswapV2Pair from '@uniswap/v2-core/build/IUniswapV2Pair.json'
 import { getEthersProvider } from 'plugins/foxPage/utils'
-import { useCallback, useEffect, useMemo, useState } from 'react'
+import { useCallback, useMemo } from 'react'
+import { useFoxEth } from 'context/FoxEthProvider/FoxEthProvider'
 import { getChainAdapterManager } from 'context/PluginProvider/chainAdapterSingleton'
 import { useEvm } from 'hooks/useEvm/useEvm'
 import { useWallet } from 'hooks/useWallet/useWallet'
@@ -37,7 +38,7 @@ const ethersProvider = getEthersProvider()
  * @param contractAddress farming contract address, since there could be multiple contracts
  */
 export const useFoxFarming = (contractAddress: string) => {
-  const [connectedWalletEthAddress, setConnectedWalletEthAddress] = useState<string | null>(null)
+  const { connectedWalletEthAddress } = useFoxEth()
   const { supportedEvmChainIds } = useEvm()
   const ethAsset = useAppSelector(state => selectAssetById(state, ethAssetId))
   const lpAsset = useAppSelector(state => selectAssetById(state, foxEthLpAssetId))
@@ -47,16 +48,6 @@ export const useFoxFarming = (contractAddress: string) => {
 
   const chainAdapterManager = getChainAdapterManager()
   const adapter = chainAdapterManager.get(ethAsset.chainId) as ChainAdapter<KnownChainIds>
-
-  useEffect(() => {
-    if (wallet && adapter) {
-      ;(async () => {
-        if (!supportsETH(wallet)) return
-        const address = await adapter.getAddress({ wallet })
-        setConnectedWalletEthAddress(address)
-      })()
-    }
-  }, [adapter, wallet])
 
   const uniswapRouterContract = useMemo(
     () => new Contract(UNISWAP_V2_ROUTER_ADDRESS, IUniswapV2Router02ABI.abi, ethersProvider),


### PR DESCRIPTION
## Description

This PR consolidates `getAddress` calls within the FOX-ETH Farming/LP DeFi components into the `FoxEthProvider` context provider, making it a single-source-of-truth across components.

Note: There are still two remaining calls in `useFoxFarming` and `useFoxEthLiquidityPool` which haven't been lifted up yet for performance reasons and will be tackled in a follow-up PR, ~~as we do *not* want to consume the `useFoxEth()` hook there.~~

^ These two calls will still be authored in a follow-up PR to keep things atomic, but consuming `useFoxEth()` is fine since this really just exposes a context provider, which is there either way. We will have to refactor things a bit to avoid circular dependencies, however.

## Notice

<!-- Before submitting a pull request, please make sure you have answered the following: -->

- [x] Have you followed the guidelines in our [Contributing]('https://github.com/shapeshift/web/CONTRIBUTING.md) guide?
- [x] Have you checked to ensure there aren't other open [Pull Requests](https://github.com/shapeshift/web/pulls) for the same update/change?

## Pull Request Type

- [ ] :bug: Bug fix (Non-breaking Change: Fixes an issue)
- [ ] :hammer_and_wrench: Chore (Non-breaking Change: Doc updates, pkg upgrades, typos, etc..)
- [x] :nail_care: New Feature (Breaking/Non-breaking Change)

## Issue (if applicable)

<!-----------------------------------------------------------------------------
If applicable, please link to the github issue and put `closes #XXXX` in your comment to auto-close the issue that your PR fixes.
------------------------------------------------------------------------------>

- contributes to https://github.com/shapeshift/web/issues/2609
- contributes to https://github.com/shapeshift/web/issues/2610


## Risk

None, this reuses the existing `connectedWalletEthAddress` by exposing it.

## Testing

<!-----------------------------------------------------------------------------
We treat every PR to be merged with the same scrutiny as if we were merging directly to production.

Your PR will not be merged if you do not complete the sections below for our engineering and operations teams to test.
------------------------------------------------------------------------------>

### Engineering

- All steps of the FOX-ETH Farming/LP modals should still work with no regressions
- No console errors should be emitted from the FOX-ETH Farming/LP modal

### Operations

<!-----------------------------------------------------------------------------
If your changes have a user-facing impact, describe how a non-technical QA team can functionally test your changes in a preview environment.

If they are not user-facing please describe how to test for any regressions that may occur.
------------------------------------------------------------------------------>

- Same as the engineering testing steps

## Screenshots (if applicable)
