### PR TITLE
feat(foxEth): consolidate getAddress() calls in FOX-ETH LP/farming hooks

### DIFF
--- a/src/context/FoxEthProvider/FoxEthProvider.tsx
+++ b/src/context/FoxEthProvider/FoxEthProvider.tsx
@@ -151,9 +151,9 @@ export const FoxEthProvider = ({ children }: FoxEthProviderProps) => {
   const [lpEthBalance, setLpEthBalance] = useState<string | null>(null)
   const [ongoingTxId, setOngoingTxId] = useState<string | null>(null)
   const [foxEthLpOpportunity, setFoxEthLpOpportunity] = useState<EarnOpportunityType>(lpOpportunity)
-  const { calculateHoldings, getLpTVL } = useFoxEthLiquidityPool()
-
   const [connectedWalletEthAddress, setConnectedWalletEthAddress] = useState<string | null>(null)
+  const { calculateHoldings, getLpTVL } = useFoxEthLiquidityPool(connectedWalletEthAddress)
+
   const [farmingLoading, setFarmingLoading] = useState<boolean>(true)
   const [foxFarmingTotalBalance, setFoxFarmingTotalBalance] = useState<string>('')
   const [foxFarmingOpportunities, setFoxFarmingOpportunities] = useState<

--- a/src/features/defi/providers/fox-eth-lp/components/FoxEthLpManager/Deposit/components/Approve.tsx
+++ b/src/features/defi/providers/fox-eth-lp/components/FoxEthLpManager/Deposit/components/Approve.tsx
@@ -8,6 +8,7 @@ import { useFoxEthLiquidityPool } from 'features/defi/providers/fox-eth-lp/hooks
 import { FOX_TOKEN_CONTRACT_ADDRESS } from 'plugins/foxPage/const'
 import { useContext } from 'react'
 import { useTranslate } from 'react-polyglot'
+import { useFoxEth } from 'context/FoxEthProvider/FoxEthProvider'
 import { useWallet } from 'hooks/useWallet/useWallet'
 import { bn, bnOrZero } from 'lib/bignumber/bignumber'
 import { logger } from 'lib/logger'
@@ -27,7 +28,9 @@ const moduleLogger = logger.child({ namespace: ['FoxEthLpDeposit:Approve'] })
 export const Approve: React.FC<FoxEthLpApproveProps> = ({ onNext }) => {
   const { state, dispatch } = useContext(DepositContext)
   const translate = useTranslate()
-  const { approve, allowance, getDepositGasData } = useFoxEthLiquidityPool()
+  const { connectedWalletEthAddress } = useFoxEth()
+  const { approve, allowance, getDepositGasData } =
+    useFoxEthLiquidityPool(connectedWalletEthAddress)
   const opportunity = state?.opportunity
 
   const foxAsset = useAppSelector(state => selectAssetById(state, foxAssetId))

--- a/src/features/defi/providers/fox-eth-lp/components/FoxEthLpManager/Deposit/components/Confirm.tsx
+++ b/src/features/defi/providers/fox-eth-lp/components/FoxEthLpManager/Deposit/components/Confirm.tsx
@@ -37,9 +37,9 @@ const moduleLogger = logger.child({ namespace: ['FoxEthLpDeposit:Confirm'] })
 export const Confirm: React.FC<StepComponentProps> = ({ onNext }) => {
   const { state, dispatch } = useContext(DepositContext)
   const translate = useTranslate()
-  const { onOngoingTxIdChange } = useFoxEth()
+  const { connectedWalletEthAddress, onOngoingTxIdChange } = useFoxEth()
   const { query } = useBrowserRouter<DefiQueryParams, DefiParams>()
-  const { addLiquidity } = useFoxEthLiquidityPool()
+  const { addLiquidity } = useFoxEthLiquidityPool(connectedWalletEthAddress)
   const opportunity = useMemo(() => state?.opportunity, [state])
   const { chainId, assetReference } = query
 

--- a/src/features/defi/providers/fox-eth-lp/components/FoxEthLpManager/Deposit/components/Deposit.tsx
+++ b/src/features/defi/providers/fox-eth-lp/components/FoxEthLpManager/Deposit/components/Deposit.tsx
@@ -14,6 +14,7 @@ import { useContext } from 'react'
 import { useTranslate } from 'react-polyglot'
 import { useHistory } from 'react-router-dom'
 import { StepComponentProps } from 'components/DeFi/components/Steps'
+import { useFoxEth } from 'context/FoxEthProvider/FoxEthProvider'
 import { useBrowserRouter } from 'hooks/useBrowserRouter/useBrowserRouter'
 import { bn, bnOrZero } from 'lib/bignumber/bignumber'
 import { logger } from 'lib/logger'
@@ -36,7 +37,9 @@ export const Deposit: React.FC<StepComponentProps> = ({ onNext }) => {
   const { query, history: browserHistory } = useBrowserRouter<DefiQueryParams, DefiParams>()
   const { chainId, assetReference } = query
   const opportunity = state?.opportunity
-  const { allowance, getApproveGasData, getDepositGasData } = useFoxEthLiquidityPool()
+  const { connectedWalletEthAddress } = useFoxEth()
+  const { allowance, getApproveGasData, getDepositGasData } =
+    useFoxEthLiquidityPool(connectedWalletEthAddress)
 
   const assetNamespace = 'erc20'
   const assetId = toAssetId({ chainId, assetNamespace, assetReference })

--- a/src/features/defi/providers/fox-eth-lp/components/FoxEthLpManager/Withdraw/components/Approve.tsx
+++ b/src/features/defi/providers/fox-eth-lp/components/FoxEthLpManager/Withdraw/components/Approve.tsx
@@ -10,6 +10,7 @@ import {
 import { useFoxEthLiquidityPool } from 'features/defi/providers/fox-eth-lp/hooks/useFoxEthLiquidityPool'
 import { useContext } from 'react'
 import { useTranslate } from 'react-polyglot'
+import { useFoxEth } from 'context/FoxEthProvider/FoxEthProvider'
 import { useWallet } from 'hooks/useWallet/useWallet'
 import { bn, bnOrZero } from 'lib/bignumber/bignumber'
 import { logger } from 'lib/logger'
@@ -29,7 +30,9 @@ const moduleLogger = logger.child({ namespace: ['FoxEthLpWithdraw:Approve'] })
 export const Approve: React.FC<FoxEthLpApproveProps> = ({ onNext }) => {
   const { state, dispatch } = useContext(WithdrawContext)
   const translate = useTranslate()
-  const { approve, allowance, getWithdrawGasData } = useFoxEthLiquidityPool()
+  const { connectedWalletEthAddress } = useFoxEth()
+  const { approve, allowance, getWithdrawGasData } =
+    useFoxEthLiquidityPool(connectedWalletEthAddress)
   const opportunity = state?.opportunity
 
   const foxAsset = useAppSelector(state => selectAssetById(state, foxAssetId))

--- a/src/features/defi/providers/fox-eth-lp/components/FoxEthLpManager/Withdraw/components/Confirm.tsx
+++ b/src/features/defi/providers/fox-eth-lp/components/FoxEthLpManager/Withdraw/components/Confirm.tsx
@@ -33,8 +33,12 @@ const moduleLogger = logger.child({ namespace: ['Confirm'] })
 export const Confirm = ({ onNext }: StepComponentProps) => {
   const { state, dispatch } = useContext(WithdrawContext)
   const translate = useTranslate()
-  const { foxEthLpOpportunity: opportunity, onOngoingTxIdChange } = useFoxEth()
-  const { removeLiquidity } = useFoxEthLiquidityPool()
+  const {
+    connectedWalletEthAddress,
+    foxEthLpOpportunity: opportunity,
+    onOngoingTxIdChange,
+  } = useFoxEth()
+  const { removeLiquidity } = useFoxEthLiquidityPool(connectedWalletEthAddress)
 
   const ethAsset = useAppSelector(state => selectAssetById(state, ethAssetId))
   const ethMarketData = useAppSelector(state => selectMarketDataById(state, ethAssetId))

--- a/src/features/defi/providers/fox-eth-lp/components/FoxEthLpManager/Withdraw/components/Withdraw.tsx
+++ b/src/features/defi/providers/fox-eth-lp/components/FoxEthLpManager/Withdraw/components/Withdraw.tsx
@@ -39,9 +39,11 @@ export const Withdraw: React.FC<StepComponentProps> = ({ onNext }) => {
     lpFoxBalance: foxBalance,
     lpEthBalance: ethBalance,
     lpLoading: loading,
+    connectedWalletEthAddress,
   } = useFoxEth()
 
-  const { allowance, getApproveGasData, getWithdrawGasData } = useFoxEthLiquidityPool()
+  const { allowance, getApproveGasData, getWithdrawGasData } =
+    useFoxEthLiquidityPool(connectedWalletEthAddress)
   const [foxAmount, setFoxAmount] = useState('0')
   const [ethAmount, setEthAmount] = useState('0')
 

--- a/src/features/defi/providers/fox-eth-lp/hooks/useFoxEthLiquidityPool.ts
+++ b/src/features/defi/providers/fox-eth-lp/hooks/useFoxEthLiquidityPool.ts
@@ -12,7 +12,7 @@ import { KnownChainIds } from '@shapeshiftoss/types'
 import IUniswapV2Pair from '@uniswap/v2-core/build/IUniswapV2Pair.json'
 import { FOX_TOKEN_CONTRACT_ADDRESS } from 'plugins/foxPage/const'
 import { getEthersProvider } from 'plugins/foxPage/utils'
-import { useCallback, useEffect, useMemo, useState } from 'react'
+import { useCallback, useMemo } from 'react'
 import { getChainAdapterManager } from 'context/PluginProvider/chainAdapterSingleton'
 import { useEvm } from 'hooks/useEvm/useEvm'
 import { useWallet } from 'hooks/useWallet/useWallet'
@@ -45,8 +45,7 @@ function calculateSlippageMargin(amount: string | null, precision: number) {
     .toFixed()
 }
 
-export const useFoxEthLiquidityPool = () => {
-  const [connectedWalletEthAddress, setConnectedWalletEthAddress] = useState<string | null>(null)
+export const useFoxEthLiquidityPool = (connectedWalletEthAddress: string | null) => {
   const { supportedEvmChainIds } = useEvm()
   const ethAsset = useAppSelector(state => selectAssetById(state, ethAssetId))
   const foxAsset = useAppSelector(state => selectAssetById(state, foxAssetId))
@@ -58,16 +57,6 @@ export const useFoxEthLiquidityPool = () => {
 
   const chainAdapterManager = getChainAdapterManager()
   const adapter = chainAdapterManager.get(ethAsset.chainId) as ChainAdapter<KnownChainIds>
-
-  useEffect(() => {
-    if (wallet && adapter) {
-      ;(async () => {
-        if (!supportsETH(wallet)) return
-        const address = await adapter.getAddress({ wallet })
-        setConnectedWalletEthAddress(address)
-      })()
-    }
-  }, [adapter, wallet])
 
   const uniswapRouterContract = useMemo(
     () => new Contract(UNISWAP_V2_ROUTER_ADDRESS, IUniswapV2Router02ABI.abi, ethersProvider),

--- a/src/features/defi/providers/fox-farming/components/FoxFarmingManager/Deposit/components/Deposit.tsx
+++ b/src/features/defi/providers/fox-farming/components/FoxFarmingManager/Deposit/components/Deposit.tsx
@@ -15,6 +15,7 @@ import { useCallback, useContext, useEffect, useState } from 'react'
 import { useTranslate } from 'react-polyglot'
 import { useHistory } from 'react-router-dom'
 import { StepComponentProps } from 'components/DeFi/components/Steps'
+import { useFoxEth } from 'context/FoxEthProvider/FoxEthProvider'
 import { useBrowserRouter } from 'hooks/useBrowserRouter/useBrowserRouter'
 import { bn, bnOrZero } from 'lib/bignumber/bignumber'
 import { logger } from 'lib/logger'
@@ -34,7 +35,8 @@ export const Deposit: React.FC<StepComponentProps> = ({ onNext }) => {
   const { query, history: browserHistory } = useBrowserRouter<DefiQueryParams, DefiParams>()
   const { chainId, assetReference, contractAddress } = query
   const opportunity = state?.opportunity
-  const { getLpTokenPrice } = useFoxEthLiquidityPool()
+  const { connectedWalletEthAddress } = useFoxEth()
+  const { getLpTokenPrice } = useFoxEthLiquidityPool(connectedWalletEthAddress)
   const {
     allowance: foxFarmingAllowance,
     getStakeGasData,

--- a/src/features/defi/providers/fox-farming/hooks/useFoxFarming.ts
+++ b/src/features/defi/providers/fox-farming/hooks/useFoxFarming.ts
@@ -11,7 +11,8 @@ import { supportsETH } from '@shapeshiftoss/hdwallet-core'
 import { KnownChainIds } from '@shapeshiftoss/types'
 import IUniswapV2Pair from '@uniswap/v2-core/build/IUniswapV2Pair.json'
 import { getEthersProvider } from 'plugins/foxPage/utils'
-import { useCallback, useEffect, useMemo, useState } from 'react'
+import { useCallback, useMemo } from 'react'
+import { useFoxEth } from 'context/FoxEthProvider/FoxEthProvider'
 import { getChainAdapterManager } from 'context/PluginProvider/chainAdapterSingleton'
 import { useEvm } from 'hooks/useEvm/useEvm'
 import { useWallet } from 'hooks/useWallet/useWallet'
@@ -37,7 +38,7 @@ const ethersProvider = getEthersProvider()
  * @param contractAddress farming contract address, since there could be multiple contracts
  */
 export const useFoxFarming = (contractAddress: string) => {
-  const [connectedWalletEthAddress, setConnectedWalletEthAddress] = useState<string | null>(null)
+  const { connectedWalletEthAddress } = useFoxEth()
   const { supportedEvmChainIds } = useEvm()
   const ethAsset = useAppSelector(state => selectAssetById(state, ethAssetId))
   const lpAsset = useAppSelector(state => selectAssetById(state, foxEthLpAssetId))
@@ -47,16 +48,6 @@ export const useFoxFarming = (contractAddress: string) => {
 
   const chainAdapterManager = getChainAdapterManager()
   const adapter = chainAdapterManager.get(ethAsset.chainId) as ChainAdapter<KnownChainIds>
-
-  useEffect(() => {
-    if (wallet && adapter) {
-      ;(async () => {
-        if (!supportsETH(wallet)) return
-        const address = await adapter.getAddress({ wallet })
-        setConnectedWalletEthAddress(address)
-      })()
-    }
-  }, [adapter, wallet])
 
   const uniswapRouterContract = useMemo(
     () => new Contract(UNISWAP_V2_ROUTER_ADDRESS, IUniswapV2Router02ABI.abi, ethersProvider),


### PR DESCRIPTION
## Description

This PR consolidates `getAddress` calls within the FOX-ETH Farming/LP DeFi hooks into the `FoxEthProvider` context provider, making it a single-source-of-truth across hooks.

Note: `useFoxEthLiquidityPool` receives `connectedWalletEthAddress` to avoid circular dependencies.

## Notice

<!-- Before submitting a pull request, please make sure you have answered the following: -->

- [x] Have you followed the guidelines in our [Contributing]('https://github.com/shapeshift/web/CONTRIBUTING.md) guide?
- [x] Have you checked to ensure there aren't other open [Pull Requests](https://github.com/shapeshift/web/pulls) for the same update/change?

## Pull Request Type

- [ ] :bug: Bug fix (Non-breaking Change: Fixes an issue)
- [ ] :hammer_and_wrench: Chore (Non-breaking Change: Doc updates, pkg upgrades, typos, etc..)
- [x] :nail_care: New Feature (Breaking/Non-breaking Change)

## Issue (if applicable)

<!-----------------------------------------------------------------------------
If applicable, please link to the github issue and put `closes #XXXX` in your comment to auto-close the issue that your PR fixes.
------------------------------------------------------------------------------>

- contributes to https://github.com/shapeshift/web/issues/2609
- contributes to https://github.com/shapeshift/web/issues/2610

## Risk

None, this reuses the existing `connectedWalletEthAddress` by consuming it from the context.

## Testing

<!-----------------------------------------------------------------------------
We treat every PR to be merged with the same scrutiny as if we were merging directly to production.

Your PR will not be merged if you do not complete the sections below for our engineering and operations teams to test.
------------------------------------------------------------------------------>

### Engineering

- All steps of the FOX-ETH Farming/LP modals should still work with no regressions
- No console errors should be emitted from the FOX-ETH Farming/LP modal

### Operations

<!-----------------------------------------------------------------------------
If your changes have a user-facing impact, describe how a non-technical QA team can functionally test your changes in a preview environment.

If they are not user-facing please describe how to test for any regressions that may occur.
------------------------------------------------------------------------------>

- Same as the engineering testing steps

## Screenshots (if applicable)
