### PR TITLE
feat: account selection FOX-ETH LP 

### DIFF
--- a/src/context/FoxEthProvider/FoxEthProvider.tsx
+++ b/src/context/FoxEthProvider/FoxEthProvider.tsx
@@ -1,4 +1,4 @@
-import { ethAssetId, ethChainId } from '@shapeshiftoss/caip'
+import { AccountId, ethAssetId, ethChainId, fromAccountId } from '@shapeshiftoss/caip'
 import { ChainAdapter } from '@shapeshiftoss/chain-adapters'
 import { supportsETH } from '@shapeshiftoss/hdwallet-core'
 import { KnownChainIds } from '@shapeshiftoss/types'
@@ -152,9 +152,10 @@ export const FoxEthProvider = ({ children }: FoxEthProviderProps) => {
   const [ongoingTxId, setOngoingTxId] = useState<string | null>(null)
   const [foxEthLpOpportunity, setFoxEthLpOpportunity] = useState<EarnOpportunityType>(lpOpportunity)
   const [connectedWalletEthAddress, setConnectedWalletEthAddress] = useState<string | null>(null)
+  const [accountId, setAccountId] = useState<AccountId | null>(null)
   const { calculateHoldings, getLpTVL } = useFoxEthLiquidityPool(connectedWalletEthAddress)
 
-  const [farmingLoading, setFarmingLoading] = useState<boolean>(true)
+  const [farmingLoading, setFarmingLoading] = useState<boolean>(false)
   const [foxFarmingTotalBalance, setFoxFarmingTotalBalance] = useState<string>('')
   const [foxFarmingOpportunities, setFoxFarmingOpportunities] = useState<
     FoxFarmingEarnOpportunityType[]
@@ -170,6 +171,9 @@ export const FoxEthProvider = ({ children }: FoxEthProviderProps) => {
   const [lpTokenPrice, setLpTokenPrice] = useState<string | null>(null)
   const featureFlags = useAppSelector(selectFeatureFlags)
 
+  // TODO: Remove this useEffect
+  // The reason why it is still here is because we use connectedWalletEthAddress both for the modals, and to display the DeFi cards/rows
+  // If we remove it now, we will be unable to get to the modal in the first place to change accounts
   useEffect(() => {
     if (
       // get price if at least one of lp or farming were on
@@ -208,6 +212,14 @@ export const FoxEthProvider = ({ children }: FoxEthProviderProps) => {
       })()
     }
   }, [adapter, wallet])
+
+  useEffect(() => {
+    if (!accountId) return
+    ;(async () => {
+      const accountAddress = fromAccountId(accountId).account
+      setConnectedWalletEthAddress(accountAddress)
+    })()
+  }, [accountId])
 
   const fetchFarmingOpportunities = useCallback(async () => {
     moduleLogger.info('fetching farming opportunities')
@@ -355,6 +367,8 @@ export const FoxEthProvider = ({ children }: FoxEthProviderProps) => {
 
   const value = useMemo(
     () => ({
+      accountId,
+      setAccountId,
       connectedWalletEthAddress,
       totalBalance: bnOrZero(featureFlags.FoxLP ? foxEthLpOpportunity.fiatAmount : 0)
         .plus(featureFlags.FoxFarming ? foxFarmingTotalBalance : 0)
@@ -377,6 +391,8 @@ export const FoxEthProvider = ({ children }: FoxEthProviderProps) => {
     [
       featureFlags.FoxLP,
       featureFlags.FoxFarming,
+      accountId,
+      setAccountId,
       connectedWalletEthAddress,
       foxEthLpOpportunity,
       foxFarmingTotalBalance,

--- a/src/context/FoxEthProvider/FoxEthProvider.tsx
+++ b/src/context/FoxEthProvider/FoxEthProvider.tsx
@@ -106,6 +106,8 @@ type FoxEthProviderProps = {
 }
 
 type IFoxLpAndFarmingOpportunitiesContext = {
+  accountId: AccountId | null
+  setAccountId: (accountId: AccountId) => void
   totalBalance: string
   lpFoxBalance: string | null
   lpEthBalance: string | null
@@ -121,6 +123,8 @@ type IFoxLpAndFarmingOpportunitiesContext = {
 }
 
 const FoxLpAndFarmingOpportunitiesContext = createContext<IFoxLpAndFarmingOpportunitiesContext>({
+  setAccountId: _accountId => {},
+  accountId: null,
   totalBalance: '0',
   lpFoxBalance: null,
   lpEthBalance: null,
@@ -155,7 +159,7 @@ export const FoxEthProvider = ({ children }: FoxEthProviderProps) => {
   const [accountId, setAccountId] = useState<AccountId | null>(null)
   const { calculateHoldings, getLpTVL } = useFoxEthLiquidityPool(connectedWalletEthAddress)
 
-  const [farmingLoading, setFarmingLoading] = useState<boolean>(false)
+  const [farmingLoading, setFarmingLoading] = useState<boolean>(true)
   const [foxFarmingTotalBalance, setFoxFarmingTotalBalance] = useState<string>('')
   const [foxFarmingOpportunities, setFoxFarmingOpportunities] = useState<
     FoxFarmingEarnOpportunityType[]

--- a/src/features/defi/components/Overview/Overview.tsx
+++ b/src/features/defi/components/Overview/Overview.tsx
@@ -10,7 +10,9 @@ import {
   Tag,
 } from '@chakra-ui/react'
 import { Asset } from '@shapeshiftoss/asset-service'
+import { AccountId } from '@shapeshiftoss/caip'
 import { PropsWithChildren, useMemo } from 'react'
+import { AccountDropdown } from 'components/AccountDropdown/AccountDropdown'
 import { Amount } from 'components/Amount/Amount'
 import {
   AssetDescriptionTeaser,
@@ -29,6 +31,7 @@ export type AssetWithBalance = {
 } & Asset
 
 type OverviewProps = {
+  onAccountChange?: (accountId: AccountId) => void
   underlyingAssets: AssetWithBalance[]
   rewardAssets?: AssetWithBalance[]
   name: string
@@ -44,6 +47,7 @@ type OverviewProps = {
   PropsWithChildren
 
 export const Overview: React.FC<OverviewProps> = ({
+  onAccountChange,
   underlyingAssets,
   rewardAssets,
   asset,
@@ -111,9 +115,17 @@ export const Overview: React.FC<OverviewProps> = ({
                   <RawText fontSize='lg' lineHeight='shorter'>
                     {name}
                   </RawText>
-                  <RawText color='gray.500' fontSize='sm' lineHeight='shorter'>
-                    {provider}
-                  </RawText>
+                  {onAccountChange ? (
+                    <AccountDropdown
+                      assetId={asset.assetId}
+                      onChange={onAccountChange}
+                      buttonProps={{ height: 5, variant: 'solid' }}
+                    />
+                  ) : (
+                    <RawText color='gray.500' fontSize='sm' lineHeight='shorter'>
+                      {provider}
+                    </RawText>
+                  )}
                 </Stack>
               </Stack>
               <Amount.Fiat fontSize='xl' value={opportunityFiatBalance} />

--- a/src/features/defi/providers/fox-eth-lp/components/FoxEthLpManager/FoxEthLpManager.tsx
+++ b/src/features/defi/providers/fox-eth-lp/components/FoxEthLpManager/FoxEthLpManager.tsx
@@ -5,6 +5,7 @@ import {
 } from 'features/defi/contexts/DefiManagerProvider/DefiCommon'
 import { AnimatePresence } from 'framer-motion'
 import { SlideTransition } from 'components/SlideTransition'
+import { useFoxEth } from 'context/FoxEthProvider/FoxEthProvider'
 import { useBrowserRouter } from 'hooks/useBrowserRouter/useBrowserRouter'
 
 import { FoxEthLpDeposit } from './Deposit/FoxEthLpDeposit'
@@ -14,12 +15,13 @@ import { FoxEthLpWithdraw } from './Withdraw/FoxEthLpWithdraw'
 export const FoxEthLpManager = () => {
   const { query } = useBrowserRouter<DefiQueryParams, DefiParams>()
   const { modal } = query
+  const { accountId, setAccountId } = useFoxEth()
 
   return (
     <AnimatePresence exitBeforeEnter initial={false}>
       {modal === DefiAction.Overview && (
         <SlideTransition key={DefiAction.Overview}>
-          <FoxEthLpOverview />
+          <FoxEthLpOverview onAccountChange={setAccountId} />
         </SlideTransition>
       )}
       {modal === DefiAction.Deposit && (

--- a/src/features/defi/providers/fox-eth-lp/components/FoxEthLpManager/FoxEthLpManager.tsx
+++ b/src/features/defi/providers/fox-eth-lp/components/FoxEthLpManager/FoxEthLpManager.tsx
@@ -5,7 +5,6 @@ import {
 } from 'features/defi/contexts/DefiManagerProvider/DefiCommon'
 import { AnimatePresence } from 'framer-motion'
 import { SlideTransition } from 'components/SlideTransition'
-import { useFoxEth } from 'context/FoxEthProvider/FoxEthProvider'
 import { useBrowserRouter } from 'hooks/useBrowserRouter/useBrowserRouter'
 
 import { FoxEthLpDeposit } from './Deposit/FoxEthLpDeposit'
@@ -15,13 +14,12 @@ import { FoxEthLpWithdraw } from './Withdraw/FoxEthLpWithdraw'
 export const FoxEthLpManager = () => {
   const { query } = useBrowserRouter<DefiQueryParams, DefiParams>()
   const { modal } = query
-  const { setAccountId } = useFoxEth()
 
   return (
     <AnimatePresence exitBeforeEnter initial={false}>
       {modal === DefiAction.Overview && (
         <SlideTransition key={DefiAction.Overview}>
-          <FoxEthLpOverview onAccountChange={setAccountId} />
+          <FoxEthLpOverview />
         </SlideTransition>
       )}
       {modal === DefiAction.Deposit && (

--- a/src/features/defi/providers/fox-eth-lp/components/FoxEthLpManager/FoxEthLpManager.tsx
+++ b/src/features/defi/providers/fox-eth-lp/components/FoxEthLpManager/FoxEthLpManager.tsx
@@ -15,7 +15,7 @@ import { FoxEthLpWithdraw } from './Withdraw/FoxEthLpWithdraw'
 export const FoxEthLpManager = () => {
   const { query } = useBrowserRouter<DefiQueryParams, DefiParams>()
   const { modal } = query
-  const { accountId, setAccountId } = useFoxEth()
+  const { setAccountId } = useFoxEth()
 
   return (
     <AnimatePresence exitBeforeEnter initial={false}>

--- a/src/features/defi/providers/fox-eth-lp/components/FoxEthLpManager/Overview/FoxEthLpOverview.tsx
+++ b/src/features/defi/providers/fox-eth-lp/components/FoxEthLpManager/Overview/FoxEthLpOverview.tsx
@@ -1,6 +1,6 @@
 import { ArrowDownIcon, ArrowUpIcon } from '@chakra-ui/icons'
 import { Center, CircularProgress } from '@chakra-ui/react'
-import { AccountId, ethAssetId } from '@shapeshiftoss/caip'
+import { ethAssetId } from '@shapeshiftoss/caip'
 import { DefiModalContent } from 'features/defi/components/DefiModal/DefiModalContent'
 import { Overview } from 'features/defi/components/Overview/Overview'
 import { DefiAction } from 'features/defi/contexts/DefiManagerProvider/DefiCommon'
@@ -11,18 +11,13 @@ import { useAppSelector } from 'state/store'
 
 import { foxAssetId, foxEthLpOpportunityName } from '../../../constants'
 
-type FoxEthLpOverviewProps = {
-  onAccountChange: (accountId: AccountId) => void
-}
-
-export const FoxEthLpOverview = ({
-  onAccountChange: handleAccountChange,
-}: FoxEthLpOverviewProps) => {
+export const FoxEthLpOverview = () => {
   const {
     foxEthLpOpportunity: opportunity,
     lpFoxBalance: foxBalance,
     lpEthBalance: ethBalance,
     lpLoading: loading,
+    setAccountId: handleAccountChange,
   } = useFoxEth()
 
   const lpAsset = useAppSelector(state => selectAssetById(state, opportunity.assetId))

--- a/src/features/defi/providers/fox-eth-lp/components/FoxEthLpManager/Overview/FoxEthLpOverview.tsx
+++ b/src/features/defi/providers/fox-eth-lp/components/FoxEthLpManager/Overview/FoxEthLpOverview.tsx
@@ -6,7 +6,7 @@ import { Overview } from 'features/defi/components/Overview/Overview'
 import { DefiAction } from 'features/defi/contexts/DefiManagerProvider/DefiCommon'
 import { useFoxEth } from 'context/FoxEthProvider/FoxEthProvider'
 import { useGetAssetDescriptionQuery } from 'state/slices/assetsSlice/assetsSlice'
-import { selectAssetById, selectSelectedLocale } from 'state/slices/selectors'
+import { selectAssetById, selectFeatureFlags, selectSelectedLocale } from 'state/slices/selectors'
 import { useAppSelector } from 'state/store'
 
 import { foxAssetId, foxEthLpOpportunityName } from '../../../constants'
@@ -32,6 +32,8 @@ export const FoxEthLpOverview = ({
   const selectedLocale = useAppSelector(selectSelectedLocale)
   const descriptionQuery = useGetAssetDescriptionQuery({ assetId: lpAsset.assetId, selectedLocale })
 
+  const featureFlags = useAppSelector(selectFeatureFlags)
+
   if (loading || !opportunity) {
     return (
       <DefiModalContent>
@@ -44,7 +46,7 @@ export const FoxEthLpOverview = ({
 
   return (
     <Overview
-      onAccountChange={handleAccountChange}
+      {...(featureFlags.MultiAccounts ? { onAccountChange: handleAccountChange } : {})}
       asset={lpAsset}
       icons={opportunity.icons}
       name={foxEthLpOpportunityName}

--- a/src/features/defi/providers/fox-eth-lp/components/FoxEthLpManager/Overview/FoxEthLpOverview.tsx
+++ b/src/features/defi/providers/fox-eth-lp/components/FoxEthLpManager/Overview/FoxEthLpOverview.tsx
@@ -1,6 +1,6 @@
 import { ArrowDownIcon, ArrowUpIcon } from '@chakra-ui/icons'
 import { Center, CircularProgress } from '@chakra-ui/react'
-import { ethAssetId } from '@shapeshiftoss/caip'
+import { AccountId, ethAssetId } from '@shapeshiftoss/caip'
 import { DefiModalContent } from 'features/defi/components/DefiModal/DefiModalContent'
 import { Overview } from 'features/defi/components/Overview/Overview'
 import { DefiAction } from 'features/defi/contexts/DefiManagerProvider/DefiCommon'
@@ -11,7 +11,15 @@ import { useAppSelector } from 'state/store'
 
 import { foxAssetId, foxEthLpOpportunityName } from '../../../constants'
 
-export const FoxEthLpOverview = () => {
+type FoxEthLpOverviewProps = {
+  onAccountChange: (accountId: AccountId) => void
+  accountId: AccountId | null
+}
+
+export const FoxEthLpOverview = ({
+  onAccountChange: handleAccountChange,
+  accountId,
+}: FoxEthLpOverviewProps) => {
   const {
     foxEthLpOpportunity: opportunity,
     lpFoxBalance: foxBalance,
@@ -38,6 +46,7 @@ export const FoxEthLpOverview = () => {
 
   return (
     <Overview
+      onAccountChange={handleAccountChange}
       asset={lpAsset}
       icons={opportunity.icons}
       name={foxEthLpOpportunityName}

--- a/src/features/defi/providers/fox-eth-lp/components/FoxEthLpManager/Overview/FoxEthLpOverview.tsx
+++ b/src/features/defi/providers/fox-eth-lp/components/FoxEthLpManager/Overview/FoxEthLpOverview.tsx
@@ -13,12 +13,10 @@ import { foxAssetId, foxEthLpOpportunityName } from '../../../constants'
 
 type FoxEthLpOverviewProps = {
   onAccountChange: (accountId: AccountId) => void
-  accountId: AccountId | null
 }
 
 export const FoxEthLpOverview = ({
   onAccountChange: handleAccountChange,
-  accountId,
 }: FoxEthLpOverviewProps) => {
   const {
     foxEthLpOpportunity: opportunity,


### PR DESCRIPTION
## Description

This adds initial support for account selection in the FOX-ETH LP modal.

The current logic makes it so it *is* possible to handle accounts change, however, we still need the current logic until https://github.com/shapeshift/web/issues/2615 is implemented, so this is an intermediary, hybrid address-getting step which is needed for now.

This does **not** remove the `accountNumber` hardcoding yet.

## Notice

<!-- Before submitting a pull request, please make sure you have answered the following: -->

- [x] Have you followed the guidelines in our [Contributing]('https://github.com/shapeshift/web/CONTRIBUTING.md) guide?
- [x] Have you checked to ensure there aren't other open [Pull Requests](https://github.com/shapeshift/web/pulls) for the same update/change?

## Pull Request Type

- [ ] :bug: Bug fix (Non-breaking Change: Fixes an issue)
- [ ] :hammer_and_wrench: Chore (Non-breaking Change: Doc updates, pkg upgrades, typos, etc..)
- [x] :nail_care: New Feature (Breaking/Non-breaking Change)

## Issue (if applicable)

- tackles https://github.com/shapeshift/web/issues/2609

## Risk

Reconciliation could be wrong and rug the FOX-ETH LP feature, test accordingly.

## Testing

- FOX-ETH LP and Farming cards/rows should still be displayed in the DeFi overview/earn sections both with the MultiAccount flag on and off 
- FOX-ETH LP and Farming modals should show no regressions both with the MultiAccount flag on and off 

### Engineering

- Refer to the top-level steps
- console.log/debug that `setAccountId` is called
- console.log/debug that this hook runs and sets the "connected address" accordingly https://github.com/shapeshift/web/pull/2630/files#diff-6c36dba312b06e690f92edb784df2a088acf182f22a9ddea49832f491c3ae9e7R184-R191

<!-----------------------------------------------------------------------------
Include sufficient information here for an engineer to test your PR. This may include how to test locally, in a built environment, changes to infrastructure etc.
------------------------------------------------------------------------------>

### Operations

- Refer to the top-level steps
- Note: with the MultiAccount Flag on, the opportunity type isn't displayed anymore, as it will be replaced by account selection:

<img width="228" alt="image" src="https://user-images.githubusercontent.com/17035424/187978739-a0d9491b-a4f8-4fd2-a953-1f0662a4b947.png">

<!-----------------------------------------------------------------------------
If your changes have a user-facing impact, describe how a non-technical QA team can functionally test your changes in a preview environment.

If they are not user-facing please describe how to test for any regressions that may occur.
------------------------------------------------------------------------------>

## Screenshots (if applicable)
