### PR TITLE
feat: rename CHAIN_NAMESPACE.Ethereum -> CHAIN_NAMESPACE.Evm

### DIFF
--- a/src/components/AccountAssets/AccountAssets.tsx
+++ b/src/components/AccountAssets/AccountAssets.tsx
@@ -17,7 +17,7 @@ export const AccountAssets = ({ assetId, accountId }: AccountAssetsProps) => {
     selectPortfolioAssetIdsByAccountIdExcludeFeeAsset(state, { accountId }),
   )
   const { chainNamespace } = fromAssetId(assetId)
-  if (!(chainNamespace === CHAIN_NAMESPACE.Ethereum) || assetIds.length === 0) return null
+  if (!(chainNamespace === CHAIN_NAMESPACE.Evm) || assetIds.length === 0) return null
 
   return (
     <Card>

--- a/src/components/Modals/Send/hooks/useSendDetails/useSendDetails.tsx
+++ b/src/components/Modals/Send/hooks/useSendDetails/useSendDetails.tsx
@@ -240,7 +240,7 @@ export const useSendDetails = (): UseSendDetailsReturnType => {
               const fastFee = adapterFees.fast.txFee
               return { adapterFees, fastFee }
             }
-            case CHAIN_NAMESPACE.Ethereum: {
+            case CHAIN_NAMESPACE.Evm: {
               const evmAdapter = adapter as unknown as EvmBaseAdapter<EvmChainId>
               const adapterFees = await evmAdapter.getFeeData({
                 to,

--- a/src/components/Modals/Send/utils.ts
+++ b/src/components/Modals/Send/utils.ts
@@ -39,7 +39,7 @@ export const estimateFees = ({
   switch (chainNamespace) {
     case CHAIN_NAMESPACE.Cosmos:
       return adapter.getFeeData({})
-    case CHAIN_NAMESPACE.Ethereum:
+    case CHAIN_NAMESPACE.Evm:
       return (adapter as unknown as EvmBaseAdapter<EvmChainId>).getFeeData({
         to: address,
         value,

--- a/src/components/Trade/hooks/useSwapper/useSwapper.ts
+++ b/src/components/Trade/hooks/useSwapper/useSwapper.ts
@@ -606,7 +606,7 @@ export const useSwapper = () => {
     const { chainNamespace } = fromAssetId(sellAsset.assetId)
 
     switch (chainNamespace) {
-      case CHAIN_NAMESPACE.Ethereum:
+      case CHAIN_NAMESPACE.Evm:
         const fees = getEvmFees()
         setValue('fees', fees)
         break

--- a/src/components/Trade/hooks/useSwapper/utils.ts
+++ b/src/components/Trade/hooks/useSwapper/utils.ts
@@ -165,7 +165,7 @@ export const getFormFees = ({
   const fee = feeBN.toString()
   const { chainNamespace } = fromAssetId(sellAsset.assetId)
   switch (chainNamespace) {
-    case CHAIN_NAMESPACE.Ethereum:
+    case CHAIN_NAMESPACE.Evm:
       return getEvmFees(
         trade as Trade<EvmChainId> | TradeQuote<EvmChainId>,
         feeAsset,

--- a/src/context/AppProvider/AppContext.tsx
+++ b/src/context/AppProvider/AppContext.tsx
@@ -186,7 +186,7 @@ export const AppProvider = ({ children }: { children: React.ReactNode }) => {
               break
             }
 
-            case CHAIN_NAMESPACE.Ethereum: {
+            case CHAIN_NAMESPACE.Evm: {
               if (chainReference === CHAIN_REFERENCE.EthereumMainnet) {
                 if (!supportsETH(wallet)) continue
               }

--- a/src/hooks/useEvm/useEvm.ts
+++ b/src/hooks/useEvm/useEvm.ts
@@ -15,7 +15,7 @@ export const useEvm = () => {
   const supportedEvmChainIds = useMemo(
     () =>
       Array.from(getChainAdapterManager().keys()).filter(
-        chainId => fromChainId(chainId).chainNamespace === CHAIN_NAMESPACE.Ethereum,
+        chainId => fromChainId(chainId).chainNamespace === CHAIN_NAMESPACE.Evm,
       ),
     // We want to explicitly react on featureFlags to get a new reference here
     // eslint-disable-next-line react-hooks/exhaustive-deps

--- a/src/state/slices/assetsSlice/selectors.ts
+++ b/src/state/slices/assetsSlice/selectors.ts
@@ -77,7 +77,7 @@ const chainIdFeeAssetReferenceMap = (
           default:
             throw new Error(`Chain namespace ${chainNamespace} on ${chainReference} not supported.`)
         }
-      case CHAIN_NAMESPACE.Ethereum:
+      case CHAIN_NAMESPACE.Evm:
         switch (chainReference) {
           case CHAIN_REFERENCE.AvalancheCChain:
             return ASSET_REFERENCE.AvalancheC

--- a/src/state/slices/portfolioSlice/utils.ts
+++ b/src/state/slices/portfolioSlice/utils.ts
@@ -189,7 +189,7 @@ export const accountToPortfolio: AccountToPortfolio = args => {
     const { chainNamespace } = fromChainId(chainId)
 
     switch (chainNamespace) {
-      case CHAIN_NAMESPACE.Ethereum: {
+      case CHAIN_NAMESPACE.Evm: {
         const ethAccount = account as Account<KnownChainIds.EthereumMainnet>
         const { chainId, assetId, pubkey } = account
         // TODO(0xdef1cafe): remove accountSpecifier here, it's the same as accountId below


### PR DESCRIPTION
## Description

Renames the usages of the `EVM` CHAIN_NAMESPACE to be `Evm` following https://github.com/shapeshift/lib/pull/1007

⚠️ Merge as a stack from Graphite since this requires CAIP version bump and will break unless all CHAIN_NAMESPACE changes are updated at once

## Notice

<!-- Before submitting a pull request, please make sure you have answered the following: -->

- [x] Have you followed the guidelines in our [Contributing]('https://github.com/shapeshift/web/CONTRIBUTING.md) guide?
- [x] Have you checked to ensure there aren't other open [Pull Requests](https://github.com/shapeshift/web/pulls) for the same update/change?

## Pull Request Type

- [ ] :bug: Bug fix (Non-breaking Change: Fixes an issue)
- [ ] :hammer_and_wrench: Chore (Non-breaking Change: Doc updates, pkg upgrades, typos, etc..)
- [x] :nail_care: New Feature (Breaking/Non-breaking Change)

## Issue (if applicable)

N/A - relates to mutli-account M2 https://github.com/shapeshift/web/milestone/31

## Risk

None

## Testing


### Engineering

- CI is happy

### Operations

- None, as long as this is PR has a green tick, we are good here

## Screenshots (if applicable)
