### PR TITLE
feat: account selection FOX-ETH farming

### DIFF
--- a/src/features/defi/providers/fox-farming/components/FoxFarmingManager/Overview/FoxFarmingOverview.tsx
+++ b/src/features/defi/providers/fox-farming/components/FoxFarmingManager/Overview/FoxFarmingOverview.tsx
@@ -18,7 +18,7 @@ import { useFoxEth } from 'context/FoxEthProvider/FoxEthProvider'
 import { useBrowserRouter } from 'hooks/useBrowserRouter/useBrowserRouter'
 import { bnOrZero } from 'lib/bignumber/bignumber'
 import { useGetAssetDescriptionQuery } from 'state/slices/assetsSlice/assetsSlice'
-import { selectAssetById, selectSelectedLocale } from 'state/slices/selectors'
+import { selectAssetById, selectFeatureFlags, selectSelectedLocale } from 'state/slices/selectors'
 import { useAppSelector } from 'state/store'
 
 import { FoxFarmingEmpty } from './FoxFarmingEmpty'
@@ -28,7 +28,11 @@ export const FoxFarmingOverview = () => {
   const translate = useTranslate()
   const { query, history, location } = useBrowserRouter<DefiQueryParams, DefiParams>()
   const { chainId, contractAddress, assetReference } = query
-  const { foxFarmingOpportunities, farmingLoading: loading } = useFoxEth()
+  const {
+    setAccountId: handleAccountChange,
+    foxFarmingOpportunities,
+    farmingLoading: loading,
+  } = useFoxEth()
   const opportunity = useMemo(
     () => foxFarmingOpportunities.find(e => e.contractAddress === contractAddress),
     [contractAddress, foxFarmingOpportunities],
@@ -48,6 +52,8 @@ export const FoxFarmingOverview = () => {
 
   const selectedLocale = useAppSelector(selectSelectedLocale)
   const descriptionQuery = useGetAssetDescriptionQuery({ assetId: stakingAssetId, selectedLocale })
+
+  const featureFlags = useAppSelector(selectFeatureFlags)
 
   if (loading || !opportunity || !opportunity.apy) {
     return (
@@ -80,6 +86,7 @@ export const FoxFarmingOverview = () => {
 
   return (
     <Overview
+      {...(featureFlags.MultiAccounts ? { onAccountChange: handleAccountChange } : {})}
       asset={rewardAsset}
       name={opportunity.opportunityName ?? ''}
       icons={opportunity.icons}


### PR DESCRIPTION
## Description

This adds initial support for account selection in the FOX-ETH farming modal.

The current logic makes it so it *is* possible to handle accounts change, however, we still need the current logic until https://github.com/shapeshift/web/issues/2615 is implemented, so this is an intermediary, hybrid address-getting step which is needed for now.

This does **not** remove the `accountNumber` hardcoding yet.

## Notice

<!-- Before submitting a pull request, please make sure you have answered the following: -->

- [x] Have you followed the guidelines in our [Contributing]('https://github.com/shapeshift/web/CONTRIBUTING.md) guide?
- [x] Have you checked to ensure there aren't other open [Pull Requests](https://github.com/shapeshift/web/pulls) for the same update/change?

## Pull Request Type

- [ ] :bug: Bug fix (Non-breaking Change: Fixes an issue)
- [ ] :hammer_and_wrench: Chore (Non-breaking Change: Doc updates, pkg upgrades, typos, etc..)
- [x] :nail_care: New Feature (Breaking/Non-breaking Change)

## Issue (if applicable)

- tackles https://github.com/shapeshift/web/issues/2610

## Risk

Reconciliation could be wrong and rug the FOX-ETH farming feature, test accordingly.

## Testing

- The multi-account selection dropdown should be displayed in the FOX-ETH Farming modal with the `MultiAccount` flag on
- FOX-ETH LP and Farming cards/rows should still be displayed in the DeFi overview/earn sections both with the MultiAccount flag on and off (this implies `FoxFarming` and `FoxLP` flags on as Fox Farming and LP opportunities will never be displayed otherwise)
- FOX-ETH LP and Farming modals should show no regressions both with the MultiAccount flag on and off (this implies `FoxFarming` and `FoxLP` flags on as Fox Farming and LP opportunities will never be displayed otherwise)

### Engineering

- Refer to the top-level steps
- console.log/debug that `setAccountId` is called
- console.log/debug that this hook runs and sets the "connected address" accordingly https://github.com/shapeshift/web/pull/2630/files#diff-6c36dba312b06e690f92edb784df2a088acf182f22a9ddea49832f491c3ae9e7R184-R191

<!-----------------------------------------------------------------------------
Include sufficient information here for an engineer to test your PR. This may include how to test locally, in a built environment, changes to infrastructure etc.
------------------------------------------------------------------------------>

### Operations

- Refer to the top-level steps
- Note: You'll need both the `FoxFarming` and `MultiAccount` flags on to test this - `FoxLP` can also be enabled to test for FOX LP regressions
- Note: with the MultiAccount Flag on, the opportunity type isn't displayed anymore, and is now replaced by account selection:

<img width="305" alt="image" src="https://user-images.githubusercontent.com/17035424/188210861-3501773d-d9bd-4a7f-a94e-e767888443fb.png">


<!-----------------------------------------------------------------------------
If your changes have a user-facing impact, describe how a non-technical QA team can functionally test your changes in a preview environment.

If they are not user-facing please describe how to test for any regressions that may occur.
------------------------------------------------------------------------------>

## Screenshots (if applicable)

<img width="514" alt="image" src="https://user-images.githubusercontent.com/17035424/188211985-ab6d49c8-9c3a-44f2-a5e4-56bdc5bffa92.png">
