### PR TITLE
feat: rename connectedWalletEthAddress -> accountAddress

### DIFF
--- a/src/features/defi/providers/fox-eth-lp/components/FoxEthLpManager/Deposit/components/Approve.tsx
+++ b/src/features/defi/providers/fox-eth-lp/components/FoxEthLpManager/Deposit/components/Approve.tsx
@@ -28,9 +28,8 @@ const moduleLogger = logger.child({ namespace: ['FoxEthLpDeposit:Approve'] })
 export const Approve: React.FC<FoxEthLpApproveProps> = ({ onNext }) => {
   const { state, dispatch } = useContext(DepositContext)
   const translate = useTranslate()
-  const { connectedWalletEthAddress } = useFoxEth()
-  const { approve, allowance, getDepositGasData } =
-    useFoxEthLiquidityPool(connectedWalletEthAddress)
+  const { accountAddress } = useFoxEth()
+  const { approve, allowance, getDepositGasData } = useFoxEthLiquidityPool(accountAddress)
   const opportunity = state?.opportunity
 
   const foxAsset = useAppSelector(state => selectAssetById(state, foxAssetId))

--- a/src/features/defi/providers/fox-eth-lp/components/FoxEthLpManager/Deposit/components/Confirm.tsx
+++ b/src/features/defi/providers/fox-eth-lp/components/FoxEthLpManager/Deposit/components/Confirm.tsx
@@ -37,9 +37,9 @@ const moduleLogger = logger.child({ namespace: ['FoxEthLpDeposit:Confirm'] })
 export const Confirm: React.FC<StepComponentProps> = ({ onNext }) => {
   const { state, dispatch } = useContext(DepositContext)
   const translate = useTranslate()
-  const { connectedWalletEthAddress, onOngoingTxIdChange } = useFoxEth()
+  const { accountAddress, onOngoingTxIdChange } = useFoxEth()
   const { query } = useBrowserRouter<DefiQueryParams, DefiParams>()
-  const { addLiquidity } = useFoxEthLiquidityPool(connectedWalletEthAddress)
+  const { addLiquidity } = useFoxEthLiquidityPool(accountAddress)
   const opportunity = useMemo(() => state?.opportunity, [state])
   const { chainId, assetReference } = query
 

--- a/src/features/defi/providers/fox-eth-lp/components/FoxEthLpManager/Deposit/components/Deposit.tsx
+++ b/src/features/defi/providers/fox-eth-lp/components/FoxEthLpManager/Deposit/components/Deposit.tsx
@@ -37,9 +37,8 @@ export const Deposit: React.FC<StepComponentProps> = ({ onNext }) => {
   const { query, history: browserHistory } = useBrowserRouter<DefiQueryParams, DefiParams>()
   const { chainId, assetReference } = query
   const opportunity = state?.opportunity
-  const { connectedWalletEthAddress } = useFoxEth()
-  const { allowance, getApproveGasData, getDepositGasData } =
-    useFoxEthLiquidityPool(connectedWalletEthAddress)
+  const { accountAddress } = useFoxEth()
+  const { allowance, getApproveGasData, getDepositGasData } = useFoxEthLiquidityPool(accountAddress)
 
   const assetNamespace = 'erc20'
   const assetId = toAssetId({ chainId, assetNamespace, assetReference })

--- a/src/features/defi/providers/fox-eth-lp/components/FoxEthLpManager/Deposit/components/Status.tsx
+++ b/src/features/defi/providers/fox-eth-lp/components/FoxEthLpManager/Deposit/components/Status.tsx
@@ -32,7 +32,7 @@ export const Status = () => {
   const { state, dispatch } = useContext(DepositContext)
   const { query, history: browserHistory } = useBrowserRouter<DefiQueryParams, DefiParams>()
   const { chainId } = query
-  const { connectedWalletEthAddress: userAddress, foxEthLpOpportunity } = useFoxEth()
+  const { accountAddress, foxEthLpOpportunity } = useFoxEth()
 
   const feeAssetId = toAssetId({
     chainId,
@@ -49,9 +49,9 @@ export const Status = () => {
   )
 
   const serializedTxIndex = useMemo(() => {
-    if (!(state?.txid && userAddress)) return ''
-    return serializeTxIndex(accountSpecifier, state.txid, userAddress)
-  }, [state?.txid, userAddress, accountSpecifier])
+    if (!(state?.txid && accountAddress)) return ''
+    return serializeTxIndex(accountSpecifier, state.txid, accountAddress)
+  }, [state?.txid, accountAddress, accountSpecifier])
   const confirmedTransaction = useAppSelector(gs => selectTxById(gs, serializedTxIndex))
 
   useEffect(() => {

--- a/src/features/defi/providers/fox-eth-lp/components/FoxEthLpManager/Withdraw/components/Approve.tsx
+++ b/src/features/defi/providers/fox-eth-lp/components/FoxEthLpManager/Withdraw/components/Approve.tsx
@@ -30,9 +30,8 @@ const moduleLogger = logger.child({ namespace: ['FoxEthLpWithdraw:Approve'] })
 export const Approve: React.FC<FoxEthLpApproveProps> = ({ onNext }) => {
   const { state, dispatch } = useContext(WithdrawContext)
   const translate = useTranslate()
-  const { connectedWalletEthAddress } = useFoxEth()
-  const { approve, allowance, getWithdrawGasData } =
-    useFoxEthLiquidityPool(connectedWalletEthAddress)
+  const { accountAddress } = useFoxEth()
+  const { approve, allowance, getWithdrawGasData } = useFoxEthLiquidityPool(accountAddress)
   const opportunity = state?.opportunity
 
   const foxAsset = useAppSelector(state => selectAssetById(state, foxAssetId))

--- a/src/features/defi/providers/fox-eth-lp/components/FoxEthLpManager/Withdraw/components/Confirm.tsx
+++ b/src/features/defi/providers/fox-eth-lp/components/FoxEthLpManager/Withdraw/components/Confirm.tsx
@@ -33,12 +33,8 @@ const moduleLogger = logger.child({ namespace: ['Confirm'] })
 export const Confirm = ({ onNext }: StepComponentProps) => {
   const { state, dispatch } = useContext(WithdrawContext)
   const translate = useTranslate()
-  const {
-    connectedWalletEthAddress,
-    foxEthLpOpportunity: opportunity,
-    onOngoingTxIdChange,
-  } = useFoxEth()
-  const { removeLiquidity } = useFoxEthLiquidityPool(connectedWalletEthAddress)
+  const { accountAddress, foxEthLpOpportunity: opportunity, onOngoingTxIdChange } = useFoxEth()
+  const { removeLiquidity } = useFoxEthLiquidityPool(accountAddress)
 
   const ethAsset = useAppSelector(state => selectAssetById(state, ethAssetId))
   const ethMarketData = useAppSelector(state => selectMarketDataById(state, ethAssetId))

--- a/src/features/defi/providers/fox-eth-lp/components/FoxEthLpManager/Withdraw/components/Status.tsx
+++ b/src/features/defi/providers/fox-eth-lp/components/FoxEthLpManager/Withdraw/components/Status.tsx
@@ -33,7 +33,7 @@ export const Status = () => {
   const { state, dispatch } = useContext(WithdrawContext)
   const { query, history: browserHistory } = useBrowserRouter<DefiQueryParams, DefiParams>()
   const { chainId } = query
-  const { connectedWalletEthAddress: userAddress, foxEthLpOpportunity: opportunity } = useFoxEth()
+  const { accountAddress, foxEthLpOpportunity: opportunity } = useFoxEth()
 
   const ethAsset = useAppSelector(state => selectAssetById(state, ethAssetId))
   const ethMarketData = useAppSelector(state => selectMarketDataById(state, ethAssetId))
@@ -45,9 +45,9 @@ export const Status = () => {
   )
 
   const serializedTxIndex = useMemo(() => {
-    if (!(state?.txid && userAddress)) return ''
-    return serializeTxIndex(accountSpecifier, state.txid, userAddress)
-  }, [state?.txid, userAddress, accountSpecifier])
+    if (!(state?.txid && accountAddress)) return ''
+    return serializeTxIndex(accountSpecifier, state.txid, accountAddress)
+  }, [state?.txid, accountAddress, accountSpecifier])
   const confirmedTransaction = useAppSelector(gs => selectTxById(gs, serializedTxIndex))
 
   useEffect(() => {

--- a/src/features/defi/providers/fox-eth-lp/components/FoxEthLpManager/Withdraw/components/Withdraw.tsx
+++ b/src/features/defi/providers/fox-eth-lp/components/FoxEthLpManager/Withdraw/components/Withdraw.tsx
@@ -39,11 +39,11 @@ export const Withdraw: React.FC<StepComponentProps> = ({ onNext }) => {
     lpFoxBalance: foxBalance,
     lpEthBalance: ethBalance,
     lpLoading: loading,
-    connectedWalletEthAddress,
+    accountAddress,
   } = useFoxEth()
 
   const { allowance, getApproveGasData, getWithdrawGasData } =
-    useFoxEthLiquidityPool(connectedWalletEthAddress)
+    useFoxEthLiquidityPool(accountAddress)
   const [foxAmount, setFoxAmount] = useState('0')
   const [ethAmount, setEthAmount] = useState('0')
 

--- a/src/features/defi/providers/fox-farming/components/FoxFarmingManager/Deposit/FoxFarmingDeposit.tsx
+++ b/src/features/defi/providers/fox-farming/components/FoxFarmingManager/Deposit/FoxFarmingDeposit.tsx
@@ -47,11 +47,7 @@ export const FoxFarmingDeposit = () => {
   const assetId = toAssetId({ chainId, assetNamespace, assetReference })
   const asset = useAppSelector(state => selectAssetById(state, assetId))
   const marketData = useAppSelector(state => selectMarketDataById(state, assetId))
-  const {
-    connectedWalletEthAddress: userAddress,
-    foxFarmingOpportunities,
-    farmingLoading: foxFarmingLoading,
-  } = useFoxEth()
+  const { accountAddress, foxFarmingOpportunities, farmingLoading: foxFarmingLoading } = useFoxEth()
   const opportunity = foxFarmingOpportunities.find(e => e.contractAddress === contractAddress)
 
   const loading = useSelector(selectPortfolioLoading)
@@ -59,16 +55,16 @@ export const FoxFarmingDeposit = () => {
   useEffect(() => {
     ;(async () => {
       try {
-        if (!(userAddress && contractAddress && opportunity)) return
+        if (!(accountAddress && contractAddress && opportunity)) return
 
-        dispatch({ type: FoxFarmingDepositActionType.SET_USER_ADDRESS, payload: userAddress })
+        dispatch({ type: FoxFarmingDepositActionType.SET_USER_ADDRESS, payload: accountAddress })
         dispatch({ type: FoxFarmingDepositActionType.SET_OPPORTUNITY, payload: opportunity })
       } catch (error) {
         // TODO: handle client side errors
         moduleLogger.error(error, 'FoxFarmingDeposit error')
       }
     })()
-  }, [userAddress, translate, toast, contractAddress, opportunity])
+  }, [accountAddress, translate, toast, contractAddress, opportunity])
 
   const handleBack = () => {
     history.push({

--- a/src/features/defi/providers/fox-farming/components/FoxFarmingManager/Deposit/components/Deposit.tsx
+++ b/src/features/defi/providers/fox-farming/components/FoxFarmingManager/Deposit/components/Deposit.tsx
@@ -35,8 +35,8 @@ export const Deposit: React.FC<StepComponentProps> = ({ onNext }) => {
   const { query, history: browserHistory } = useBrowserRouter<DefiQueryParams, DefiParams>()
   const { chainId, assetReference, contractAddress } = query
   const opportunity = state?.opportunity
-  const { connectedWalletEthAddress } = useFoxEth()
-  const { getLpTokenPrice } = useFoxEthLiquidityPool(connectedWalletEthAddress)
+  const { accountAddress } = useFoxEth()
+  const { getLpTokenPrice } = useFoxEthLiquidityPool(accountAddress)
   const {
     allowance: foxFarmingAllowance,
     getStakeGasData,

--- a/src/features/defi/providers/fox-farming/components/FoxFarmingManager/Overview/Claim/ClaimConfirm.tsx
+++ b/src/features/defi/providers/fox-farming/components/FoxFarmingManager/Overview/Claim/ClaimConfirm.tsx
@@ -52,7 +52,7 @@ export const ClaimConfirm = ({
   const { claimRewards, getClaimGasData, foxFarmingContract } = useFoxFarming(contractAddress)
   const translate = useTranslate()
   const history = useHistory()
-  const { connectedWalletEthAddress: userAddress, onOngoingTxIdChange } = useFoxEth()
+  const { accountAddress: userAddress, onOngoingTxIdChange } = useFoxEth()
 
   // Asset Info
   const asset = useAppSelector(state => selectAssetById(state, assetId))

--- a/src/features/defi/providers/fox-farming/components/FoxFarmingManager/Withdraw/FoxFarmingWithdraw.tsx
+++ b/src/features/defi/providers/fox-farming/components/FoxFarmingManager/Withdraw/FoxFarmingWithdraw.tsx
@@ -37,11 +37,7 @@ export const FoxFarmingWithdraw = () => {
   const { query, history, location } = useBrowserRouter<DefiQueryParams, DefiParams>()
   const { contractAddress } = query
 
-  const {
-    connectedWalletEthAddress: userAddress,
-    foxFarmingOpportunities,
-    farmingLoading: foxFarmingLoading,
-  } = useFoxEth()
+  const { accountAddress, foxFarmingOpportunities, farmingLoading: foxFarmingLoading } = useFoxEth()
   const opportunity = useMemo(
     () => foxFarmingOpportunities.find(e => e.contractAddress === contractAddress),
     [contractAddress, foxFarmingOpportunities],
@@ -52,16 +48,16 @@ export const FoxFarmingWithdraw = () => {
   useEffect(() => {
     ;(async () => {
       try {
-        if (!(userAddress && contractAddress && opportunity)) return
+        if (!(accountAddress && contractAddress && opportunity)) return
 
-        dispatch({ type: FoxFarmingWithdrawActionType.SET_USER_ADDRESS, payload: userAddress })
+        dispatch({ type: FoxFarmingWithdrawActionType.SET_USER_ADDRESS, payload: accountAddress })
         dispatch({ type: FoxFarmingWithdrawActionType.SET_OPPORTUNITY, payload: opportunity })
       } catch (error) {
         // TODO: handle client side errors
         moduleLogger.error(error, 'FoxFarmingWithdraw error')
       }
     })()
-  }, [userAddress, translate, contractAddress, opportunity])
+  }, [accountAddress, translate, contractAddress, opportunity])
 
   const handleBack = () => {
     history.push({

--- a/src/features/defi/providers/fox-farming/hooks/useFoxFarming.ts
+++ b/src/features/defi/providers/fox-farming/hooks/useFoxFarming.ts
@@ -38,7 +38,7 @@ const ethersProvider = getEthersProvider()
  * @param contractAddress farming contract address, since there could be multiple contracts
  */
 export const useFoxFarming = (contractAddress: string) => {
-  const { connectedWalletEthAddress } = useFoxEth()
+  const { accountAddress } = useFoxEth()
   const { supportedEvmChainIds } = useEvm()
   const ethAsset = useAppSelector(state => selectAssetById(state, ethAssetId))
   const lpAsset = useAppSelector(state => selectAssetById(state, foxEthLpAssetId))
@@ -67,7 +67,7 @@ export const useFoxFarming = (contractAddress: string) => {
   const stake = useCallback(
     async (lpAmount: string) => {
       try {
-        if (!connectedWalletEthAddress || !foxFarmingContract || !wallet) return
+        if (!accountAddress || !foxFarmingContract || !wallet) return
         if (!adapter)
           throw new Error(`addLiquidityEth: no adapter available for ${ethAsset.chainId}`)
         const data = foxFarmingContract.interface.encodeFunctionData('stake', [
@@ -79,7 +79,7 @@ export const useFoxFarming = (contractAddress: string) => {
           value: '0',
           chainSpecific: {
             contractData: data,
-            from: connectedWalletEthAddress,
+            from: accountAddress,
           },
         })
         const result = await (async () => {
@@ -145,7 +145,7 @@ export const useFoxFarming = (contractAddress: string) => {
     },
     [
       adapter,
-      connectedWalletEthAddress,
+      accountAddress,
       contractAddress,
       ethAsset.chainId,
       foxFarmingContract,
@@ -158,7 +158,7 @@ export const useFoxFarming = (contractAddress: string) => {
   const unstake = useCallback(
     async (lpAmount: string, isExiting: boolean) => {
       try {
-        if (!connectedWalletEthAddress || !foxFarmingContract || !wallet) return
+        if (!accountAddress || !foxFarmingContract || !wallet) return
         const chainAdapterManager = getChainAdapterManager()
         const adapter = chainAdapterManager.get(ethAsset.chainId) as ChainAdapter<KnownChainIds>
         if (!adapter)
@@ -174,7 +174,7 @@ export const useFoxFarming = (contractAddress: string) => {
           value: '0',
           chainSpecific: {
             contractData: data,
-            from: connectedWalletEthAddress,
+            from: accountAddress,
           },
         })
         const result = await (async () => {
@@ -239,7 +239,7 @@ export const useFoxFarming = (contractAddress: string) => {
       }
     },
     [
-      connectedWalletEthAddress,
+      accountAddress,
       contractAddress,
       ethAsset.chainId,
       foxFarmingContract,
@@ -250,13 +250,13 @@ export const useFoxFarming = (contractAddress: string) => {
   )
 
   const allowance = useCallback(async () => {
-    if (!connectedWalletEthAddress || !uniV2LPContract) return
-    const _allowance = await uniV2LPContract.allowance(connectedWalletEthAddress, contractAddress)
+    if (!accountAddress || !uniV2LPContract) return
+    const _allowance = await uniV2LPContract.allowance(accountAddress, contractAddress)
     return _allowance.toString()
-  }, [connectedWalletEthAddress, contractAddress, uniV2LPContract])
+  }, [accountAddress, contractAddress, uniV2LPContract])
 
   const getApproveGasData = useCallback(async () => {
-    if (adapter && connectedWalletEthAddress && uniV2LPContract) {
+    if (adapter && accountAddress && uniV2LPContract) {
       const data = uniV2LPContract.interface.encodeFunctionData('approve', [
         contractAddress,
         MAX_ALLOWANCE,
@@ -266,17 +266,17 @@ export const useFoxFarming = (contractAddress: string) => {
         value: '0',
         chainSpecific: {
           contractData: data,
-          from: connectedWalletEthAddress,
+          from: accountAddress,
           contractAddress: uniV2LPContract.address,
         },
       })
       return fees
     }
-  }, [adapter, connectedWalletEthAddress, contractAddress, uniV2LPContract])
+  }, [adapter, accountAddress, contractAddress, uniV2LPContract])
 
   const getStakeGasData = useCallback(
     async (lpAmount: string) => {
-      if (!connectedWalletEthAddress || !uniswapRouterContract) return
+      if (!accountAddress || !uniswapRouterContract) return
       const data = foxFarmingContract.interface.encodeFunctionData('stake', [
         bnOrZero(lpAmount).times(bnOrZero(10).exponentiatedBy(lpAsset.precision)).toFixed(0),
       ])
@@ -285,14 +285,14 @@ export const useFoxFarming = (contractAddress: string) => {
         value: '0',
         chainSpecific: {
           contractData: data,
-          from: connectedWalletEthAddress,
+          from: accountAddress,
         },
       })
       return estimatedFees
     },
     [
       adapter,
-      connectedWalletEthAddress,
+      accountAddress,
       contractAddress,
       foxFarmingContract.interface,
       lpAsset.precision,
@@ -302,7 +302,7 @@ export const useFoxFarming = (contractAddress: string) => {
 
   const getUnstakeGasData = useCallback(
     async (lpAmount: string, isExiting: boolean) => {
-      if (!connectedWalletEthAddress || !uniswapRouterContract) return
+      if (!accountAddress || !uniswapRouterContract) return
       const data = isExiting
         ? foxFarmingContract.interface.encodeFunctionData('exit')
         : foxFarmingContract.interface.encodeFunctionData('withdraw', [
@@ -313,14 +313,14 @@ export const useFoxFarming = (contractAddress: string) => {
         value: '0',
         chainSpecific: {
           contractData: data,
-          from: connectedWalletEthAddress,
+          from: accountAddress,
         },
       })
       return estimatedFees
     },
     [
       adapter,
-      connectedWalletEthAddress,
+      accountAddress,
       contractAddress,
       foxFarmingContract.interface,
       lpAsset.precision,
@@ -397,14 +397,14 @@ export const useFoxFarming = (contractAddress: string) => {
   )
 
   const claimRewards = useCallback(async () => {
-    if (!wallet || !foxFarmingContract || !connectedWalletEthAddress) return
+    if (!wallet || !foxFarmingContract || !accountAddress) return
     const data = foxFarmingContract.interface.encodeFunctionData('getReward')
     const estimatedFees = await (adapter as unknown as EvmBaseAdapter<EvmChainId>).getFeeData({
       to: contractAddress,
       value: '0',
       chainSpecific: {
         contractData: data,
-        from: connectedWalletEthAddress,
+        from: accountAddress,
       },
     })
     const fees = estimatedFees.average as FeeData<EvmChainId>
@@ -448,7 +448,7 @@ export const useFoxFarming = (contractAddress: string) => {
       }
     })()
     return broadcastTXID
-  }, [adapter, connectedWalletEthAddress, contractAddress, foxFarmingContract, wallet])
+  }, [adapter, accountAddress, contractAddress, foxFarmingContract, wallet])
 
   return {
     allowance,


### PR DESCRIPTION
## Description

Renames the instances of `connectedWalletEthAddress` to `accountAddress` since effectively, this state field will not necessarily refer to the *connected* account anymore, but will refer to the selected account in the `<AccountDropdown />` component after we support multi-account derivation for Ethereum.

## Notice

<!-- Before submitting a pull request, please make sure you have answered the following: -->

- [x] Have you followed the guidelines in our [Contributing]('https://github.com/shapeshift/web/CONTRIBUTING.md) guide?
- [x] Have you checked to ensure there aren't other open [Pull Requests](https://github.com/shapeshift/web/pulls) for the same update/change?

## Pull Request Type

- [ ] :bug: Bug fix (Non-breaking Change: Fixes an issue)
- [ ] :hammer_and_wrench: Chore (Non-breaking Change: Doc updates, pkg upgrades, typos, etc..)
- [x] :nail_care: New Feature (Breaking/Non-breaking Change)

## Issue (if applicable

- relates to https://github.com/shapeshift/web/issues/2609
- relates to https://github.com/shapeshift/web/issues/2610

## Risk

- None, this is a change of terminology

## Testing

- If CI is happy, we are 🛍️  

### Engineering

- Refer to testing notes

### Operations

- No user-facing changes

## Screenshots (if applicable)
