### PR TITLE
feat: fox LP deposit/withdraw account selection

### DIFF
--- a/src/features/defi/components/Deposit/PairDeposit.tsx
+++ b/src/features/defi/components/Deposit/PairDeposit.tsx
@@ -1,11 +1,11 @@
 import { Button, Stack, useColorModeValue } from '@chakra-ui/react'
 import { Asset } from '@shapeshiftoss/asset-service'
-import { AccountId } from '@shapeshiftoss/caip'
 import { MarketData } from '@shapeshiftoss/types'
 import get from 'lodash/get'
 import { calculateYearlyYield } from 'plugins/cosmos/components/modals/Staking/StakingCommon'
 import { ControllerProps, useController, useForm, useWatch } from 'react-hook-form'
 import { useTranslate } from 'react-polyglot'
+import { AccountDropdownProps } from 'components/AccountDropdown/AccountDropdown'
 import { Amount } from 'components/Amount/Amount'
 import { AssetIcon } from 'components/AssetIcon'
 import { AssetInput } from 'components/DeFi/components/AssetInput'
@@ -43,7 +43,7 @@ type DepositProps = {
   // Array of the % options
   percentOptions: number[]
   isLoading: boolean
-  onAccountChange?: (accountId: AccountId) => void
+  onAccountIdChange?: AccountDropdownProps['onChange']
   onContinue(values: DepositValues): void
   onBack?(): void
   onCancel(): void
@@ -81,7 +81,7 @@ export const PairDeposit = ({
   fiatInputValidation1,
   fiatInputValidation2,
   isLoading,
-  onAccountChange,
+  onAccountIdChange: handleAccountIdChange,
   onContinue,
   percentOptions,
   syncPair = true,
@@ -220,7 +220,7 @@ export const PairDeposit = ({
             assetSymbol={asset1.symbol}
             balance={cryptoAmountAvailable1}
             fiatBalance={fiatAmountAvailable1}
-            onAccountChange={onAccountChange}
+            onAccountIdChange={handleAccountIdChange}
             onMaxClick={value => handlePercentClick(value, true)}
             percentOptions={percentOptions}
             errors={cryptoError1 || fiatError1}
@@ -235,7 +235,7 @@ export const PairDeposit = ({
             assetSymbol={asset2.symbol}
             balance={cryptoAmountAvailable2}
             fiatBalance={fiatAmountAvailable2}
-            onAccountChange={onAccountChange}
+            onAccountIdChange={handleAccountIdChange}
             onMaxClick={value => handlePercentClick(value, false)}
             percentOptions={percentOptions}
             errors={cryptoError2 || fiatError2}

--- a/src/features/defi/components/Deposit/PairDeposit.tsx
+++ b/src/features/defi/components/Deposit/PairDeposit.tsx
@@ -1,5 +1,6 @@
 import { Button, Stack, useColorModeValue } from '@chakra-ui/react'
 import { Asset } from '@shapeshiftoss/asset-service'
+import { AccountId } from '@shapeshiftoss/caip'
 import { MarketData } from '@shapeshiftoss/types'
 import get from 'lodash/get'
 import { calculateYearlyYield } from 'plugins/cosmos/components/modals/Staking/StakingCommon'
@@ -42,6 +43,7 @@ type DepositProps = {
   // Array of the % options
   percentOptions: number[]
   isLoading: boolean
+  onAccountChange?: (accountId: AccountId) => void
   onContinue(values: DepositValues): void
   onBack?(): void
   onCancel(): void
@@ -79,6 +81,7 @@ export const PairDeposit = ({
   fiatInputValidation1,
   fiatInputValidation2,
   isLoading,
+  onAccountChange,
   onContinue,
   percentOptions,
   syncPair = true,
@@ -212,10 +215,12 @@ export const PairDeposit = ({
             onChange={(value, isFiat) => handleInputChange(value, true, isFiat)}
             fiatAmount={fiatAmount1?.value}
             showFiatAmount={true}
+            assetId={asset1.assetId}
             assetIcon={asset1.icon}
             assetSymbol={asset1.symbol}
             balance={cryptoAmountAvailable1}
             fiatBalance={fiatAmountAvailable1}
+            onAccountChange={onAccountChange}
             onMaxClick={value => handlePercentClick(value, true)}
             percentOptions={percentOptions}
             errors={cryptoError1 || fiatError1}
@@ -225,10 +230,12 @@ export const PairDeposit = ({
             onChange={(value, isFiat) => handleInputChange(value, false, isFiat)}
             fiatAmount={fiatAmount2?.value}
             showFiatAmount={true}
+            assetId={asset2.assetId}
             assetIcon={asset2.icon}
             assetSymbol={asset2.symbol}
             balance={cryptoAmountAvailable2}
             fiatBalance={fiatAmountAvailable2}
+            onAccountChange={onAccountChange}
             onMaxClick={value => handlePercentClick(value, false)}
             percentOptions={percentOptions}
             errors={cryptoError2 || fiatError2}

--- a/src/features/defi/providers/fox-eth-lp/components/FoxEthLpManager/Deposit/components/Deposit.tsx
+++ b/src/features/defi/providers/fox-eth-lp/components/FoxEthLpManager/Deposit/components/Deposit.tsx
@@ -19,6 +19,7 @@ import { bn, bnOrZero } from 'lib/bignumber/bignumber'
 import { logger } from 'lib/logger'
 import {
   selectAssetById,
+  selectFeatureFlags,
   selectMarketDataById,
   selectPortfolioCryptoBalanceByAssetId,
 } from 'state/slices/selectors'
@@ -36,7 +37,7 @@ export const Deposit: React.FC<StepComponentProps> = ({ onNext }) => {
   const { query, history: browserHistory } = useBrowserRouter<DefiQueryParams, DefiParams>()
   const { chainId, assetReference } = query
   const opportunity = state?.opportunity
-  const { accountAddress } = useFoxEth()
+  const { accountAddress, setAccountId: handleAccountChange } = useFoxEth()
   const { allowance, getApproveGasData, getDepositGasData } = useFoxEthLiquidityPool(accountAddress)
 
   const assetNamespace = 'erc20'
@@ -57,6 +58,8 @@ export const Deposit: React.FC<StepComponentProps> = ({ onNext }) => {
 
   // notify
   const toast = useToast()
+
+  const featureFlags = useAppSelector(selectFeatureFlags)
 
   if (!state || !dispatch) return null
 
@@ -203,6 +206,7 @@ export const Deposit: React.FC<StepComponentProps> = ({ onNext }) => {
       marketData1={foxMarketData}
       marketData2={ethMarketData}
       onCancel={handleCancel}
+      {...(featureFlags.MultiAccounts ? { onAccountChange: handleAccountChange } : {})}
       onContinue={handleContinue}
       onBack={handleBack}
       percentOptions={[0.25, 0.5, 0.75, 1]}

--- a/src/features/defi/providers/fox-eth-lp/components/FoxEthLpManager/Deposit/components/Deposit.tsx
+++ b/src/features/defi/providers/fox-eth-lp/components/FoxEthLpManager/Deposit/components/Deposit.tsx
@@ -37,7 +37,7 @@ export const Deposit: React.FC<StepComponentProps> = ({ onNext }) => {
   const { query, history: browserHistory } = useBrowserRouter<DefiQueryParams, DefiParams>()
   const { chainId, assetReference } = query
   const opportunity = state?.opportunity
-  const { accountAddress, setAccountId: handleAccountChange } = useFoxEth()
+  const { accountAddress, setAccountId: handleAccountIdChange } = useFoxEth()
   const { allowance, getApproveGasData, getDepositGasData } = useFoxEthLiquidityPool(accountAddress)
 
   const assetNamespace = 'erc20'
@@ -206,7 +206,7 @@ export const Deposit: React.FC<StepComponentProps> = ({ onNext }) => {
       marketData1={foxMarketData}
       marketData2={ethMarketData}
       onCancel={handleCancel}
-      {...(featureFlags.MultiAccounts ? { onAccountChange: handleAccountChange } : {})}
+      {...(featureFlags.MultiAccounts ? { onAccountIdChange: handleAccountIdChange } : {})}
       onContinue={handleContinue}
       onBack={handleBack}
       percentOptions={[0.25, 0.5, 0.75, 1]}

--- a/src/features/defi/providers/fox-eth-lp/components/FoxEthLpManager/Withdraw/components/Withdraw.tsx
+++ b/src/features/defi/providers/fox-eth-lp/components/FoxEthLpManager/Withdraw/components/Withdraw.tsx
@@ -41,7 +41,7 @@ export const Withdraw: React.FC<StepComponentProps> = ({ onNext }) => {
     lpEthBalance: ethBalance,
     lpLoading: loading,
     accountAddress,
-    setAccountId: handleAccountChange,
+    setAccountId: handleAccountIdChange,
   } = useFoxEth()
 
   const { allowance, getApproveGasData, getWithdrawGasData } =
@@ -189,7 +189,7 @@ export const Withdraw: React.FC<StepComponentProps> = ({ onNext }) => {
           volume: '0',
           changePercent24Hr: 0,
         }}
-        {...(featureFlags.MultiAccounts ? { onAccountChange: handleAccountChange } : {})}
+        {...(featureFlags.MultiAccounts ? { onAccountIdChange: handleAccountIdChange } : {})}
         onCancel={handleCancel}
         onContinue={handleContinue}
         isLoading={state.loading || loading}

--- a/src/features/defi/providers/fox-eth-lp/components/FoxEthLpManager/Withdraw/components/Withdraw.tsx
+++ b/src/features/defi/providers/fox-eth-lp/components/FoxEthLpManager/Withdraw/components/Withdraw.tsx
@@ -21,6 +21,7 @@ import { bn, bnOrZero } from 'lib/bignumber/bignumber'
 import { logger } from 'lib/logger'
 import {
   selectAssetById,
+  selectFeatureFlags,
   selectMarketDataById,
   selectPortfolioCryptoBalanceByAssetId,
 } from 'state/slices/selectors'
@@ -40,6 +41,7 @@ export const Withdraw: React.FC<StepComponentProps> = ({ onNext }) => {
     lpEthBalance: ethBalance,
     lpLoading: loading,
     accountAddress,
+    setAccountId: handleAccountChange,
   } = useFoxEth()
 
   const { allowance, getApproveGasData, getWithdrawGasData } =
@@ -65,6 +67,9 @@ export const Withdraw: React.FC<StepComponentProps> = ({ onNext }) => {
   const balance = useAppSelector(state =>
     selectPortfolioCryptoBalanceByAssetId(state, { assetId: opportunity.assetId }),
   )
+
+  const featureFlags = useAppSelector(selectFeatureFlags)
+
   const cryptoAmountAvailable = bnOrZero(balance).div(bn(10).pow(asset?.precision))
 
   if (!state || !dispatch) return null
@@ -184,6 +189,7 @@ export const Withdraw: React.FC<StepComponentProps> = ({ onNext }) => {
           volume: '0',
           changePercent24Hr: 0,
         }}
+        {...(featureFlags.MultiAccounts ? { onAccountChange: handleAccountChange } : {})}
         onCancel={handleCancel}
         onContinue={handleContinue}
         isLoading={state.loading || loading}


### PR DESCRIPTION
## Description

This adds initial support for account selection in the FOX-ETH deposit/withdraw steps of the LP modal.

Note: Syncing won't work in the current state as this requires `<AccountDropdown />` to be optionally controlled, which currently isn't the case.

## Notice

<!-- Before submitting a pull request, please make sure you have answered the following: -->

- [x] Have you followed the guidelines in our [Contributing]('https://github.com/shapeshift/web/CONTRIBUTING.md) guide?
- [x] Have you checked to ensure there aren't other open [Pull Requests](https://github.com/shapeshift/web/pulls) for the same update/change?

## Pull Request Type

- [ ] :bug: Bug fix (Non-breaking Change: Fixes an issue)
- [ ] :hammer_and_wrench: Chore (Non-breaking Change: Doc updates, pkg upgrades, typos, etc..)
- [x] :nail_care: New Feature (Breaking/Non-breaking Change)

## Issue (if applicable)

- closes https://github.com/shapeshift/web/issues/2609

## Risk

Reconciliation could be wrong and rug the FOX-ETH LP feature, test accordingly.

## Testing

- The multi-account selection dropdown should be displayed at deposit/withdraw steps of the FOX-ETH LP modal with the `MultiAccount` flag on
- FOX-ETH LP and Farming cards/rows should still be displayed in the DeFi overview/earn sections both with the MultiAccount flag on and off (this implies `FoxFarming` and `FoxLP` flags on as Fox Farming and LP opportunities will never be displayed otherwise)
- FOX-ETH LP and Farming modals should show no regressions both with the MultiAccount flag on and off (this implies `FoxFarming` and `FoxLP` flags on as Fox Farming and LP opportunities will never be displayed otherwise) - test the full flow of the modal, including deposit/withdraw

### Engineering

- Refer to the top-level steps
- console.log/debug that `setAccountId` is called

<!-----------------------------------------------------------------------------
Include sufficient information here for an engineer to test your PR. This may include how to test locally, in a built environment, changes to infrastructure etc.
------------------------------------------------------------------------------>

### Operations

- Refer to the top-level steps
- Note: You'll need both the `FoxFarming` and `MultiAccount` flags on to test this - `FoxFarming` can also be enabled to test for FOX Farming regressions

<!-----------------------------------------------------------------------------
If your changes have a user-facing impact, describe how a non-technical QA team can functionally test your changes in a preview environment.

If they are not user-facing please describe how to test for any regressions that may occur.
------------------------------------------------------------------------------>

## Screenshots (if applicable)
<img width="525" alt="image" src="https://user-images.githubusercontent.com/17035424/188333440-497cb903-bc8a-41ce-8d9d-eecbaba1b89b.png">
<img width="532" alt="image" src="https://user-images.githubusercontent.com/17035424/188333444-8af69631-8236-4ff0-afcc-765473696b8d.png">