### PR TITLE
chore: improve `useHasAppUpdated` for local development

### DIFF
--- a/src/hooks/useHasAppUpdated/useHasAppUpdated.ts
+++ b/src/hooks/useHasAppUpdated/useHasAppUpdated.ts
@@ -3,39 +3,40 @@ import isEqual from 'lodash/isEqual'
 import { useCallback, useEffect, useState } from 'react'
 import { useInterval } from 'hooks/useInterval/useInterval'
 import { logger } from 'lib/logger'
+
 const moduleLogger = logger.child({ namespace: ['useHasAppUpdated'] })
 
 export const APP_UPDATE_CHECK_INTERVAL = 1000 * 60
+
+// Treat private IPs as local: 192.168.0.0/16, 10.0.0.0/16, 127.0.0.0/16, and 'localhost'
+const localhostRegEx = /(?:192\.168|10\.0|127\.0)\.\d{1,3}\.\d{1,3}|localhost/
+
+// 'asset-manifest.json' keeps track of the latest minified built files
+const assetManifestUrl = `/asset-manifest.json`
 
 export const useHasAppUpdated = () => {
   const [hasUpdated, setHasUpdated] = useState(false)
   const [initialManifestMainJs, setInitialManifestMainJs] = useState<unknown>()
   const [initialEnvMainJs, setInitialEnvMainJs] = useState<unknown>()
 
-  const isLocalhost = window.location.hostname === 'localhost'
+  const isLocalhost = localhostRegEx.test(window.location.hostname)
+  moduleLogger.trace({ isLocalhost }, 'isLocalhost?')
 
-  const fetchData = useCallback(
-    async (url: string): Promise<unknown> => {
-      // don't ever try to fetch on localhost - we don't care
-      if (isLocalhost) return {} // need to return dummy value
-      try {
-        // dummy query param to bypass the browser cache.
-        const { data } = await axios.get(`${url}?${new Date().valueOf()}`)
-        return data
-      } catch (e) {
-        moduleLogger.error(e, `useHasAppUpdated: error fetching data from URL: ${url}`)
-        return null
-      }
-    },
-    [isLocalhost],
-  )
+  const fetchData = useCallback(async (url: string): Promise<unknown> => {
+    try {
+      // dummy query param to bypass the browser cache.
+      const { data } = await axios.get(`${url}?${new Date().valueOf()}`)
+      return data
+    } catch (e) {
+      moduleLogger.error(e, `useHasAppUpdated: error fetching data from URL: ${url}`)
+      return null
+    }
+  }, [])
 
-  // 'asset-manifest.json' keeps track of the latest minified built files
-  const assetManifestUrl = `/asset-manifest.json`
   const storeMainManifestJs = useCallback(async () => {
     const manifestMainJs = await fetchData(assetManifestUrl)
     manifestMainJs && setInitialManifestMainJs(manifestMainJs)
-  }, [assetManifestUrl, fetchData])
+  }, [fetchData])
 
   // 'asset-manifest.json' keeps track of the current environment variables
   const envUrl = `/env.json`
@@ -46,24 +47,29 @@ export const useHasAppUpdated = () => {
 
   // store initial values once
   useEffect(() => {
+    if (isLocalhost) return
     storeMainManifestJs()
     storeMainEnvJs()
-  }, [storeMainEnvJs, storeMainManifestJs])
+  }, [isLocalhost, storeMainEnvJs, storeMainManifestJs])
 
-  useInterval(async () => {
-    if (isLocalhost) return
-    const [currentManifestJs, currentEnvJs] = await Promise.all([
-      fetchData(assetManifestUrl),
-      fetchData(envUrl),
-    ])
-    if (currentEnvJs && currentManifestJs) {
-      const isExactAssetManifest = isEqual(initialManifestMainJs, currentManifestJs)
-      const isExactEnv = isEqual(initialEnvMainJs, currentEnvJs)
+  useInterval(
+    async () => {
+      if (isLocalhost) return
+      const [currentManifestJs, currentEnvJs] = await Promise.all([
+        fetchData(assetManifestUrl),
+        fetchData(envUrl),
+      ])
+      if (currentEnvJs && currentManifestJs) {
+        const isExactAssetManifest = isEqual(initialManifestMainJs, currentManifestJs)
+        const isExactEnv = isEqual(initialEnvMainJs, currentEnvJs)
 
-      const eitherHasChanged = !isExactAssetManifest || !isExactEnv
-      setHasUpdated(eitherHasChanged)
-    }
-  }, APP_UPDATE_CHECK_INTERVAL)
+        const eitherHasChanged = !isExactAssetManifest || !isExactEnv
+        setHasUpdated(eitherHasChanged)
+      }
+    },
+    // Don't implement the interval check for local development
+    isLocalhost ? null : APP_UPDATE_CHECK_INTERVAL,
+  )
 
   if (isLocalhost) return false // never return true on localhost
   return hasUpdated


### PR DESCRIPTION
## Description
* treat private IPs as localhost (192.168.0.0/16, 10.0.0.0/16, 127.0.0.0/16)
* skip the update check interval for local development

## Notice

<!-- Before submitting a pull request, please make sure you have answered the following: -->

- [X] Have you followed the guidelines in our [Contributing]('https://github.com/shapeshift/web/blob/develop/CONTRIBUTING.md) guide?
- [X] Have you checked to ensure there aren't other open [Pull Requests](https://github.com/shapeshift/web/pulls) for the same update/change?

## Pull Request Type

- [ ] :bug: Bug fix (Non-breaking Change: Fixes an issue)
- [X] :hammer_and_wrench: Chore (Non-breaking Change: Doc updates, pkg upgrades, typos, etc..)
- [ ] :nail_care: New Feature (Breaking/Non-breaking Change)

## Issue (if applicable)
Reported in Discord

## Risk
Low. Only changes how the checks work for local development
## Testing
Unit tests pass.

### Engineering
1. `yarn build`
2. `http-server -p 3000 build`
3. use `ngrok` or similar tunnel to get a public URL
4. Open the tunnel URL in the browser
5. Edit `env.json` and change a variable, like `LOG_LEVEL`
6. Wait for 1 minute
7. You should get the app updated toast
8. Open `http://127.0.0.1:3000` in the browser
9. Check the `Console` and `Network` tabs in the Dev Tools
10. There won't be any errors related to `useHasAppUpdated`

### Operations
There isn't a non-technical way to test this.
<!-----------------------------------------------------------------------------
If your changes have a user-facing impact, describe how a non-technical QA team can functionally test your changes in a preview environment.

If they are not user-facing please describe how to test for any regressions that may occur.
------------------------------------------------------------------------------>

## Screenshots (if applicable)
### Before
![image](https://user-images.githubusercontent.com/1958266/188547929-9114730a-3a51-4b02-b882-59847e40248c.png)

### After
