### PR TITLE
fix: add all UTXOs in isAssetSupportedByWallet

### DIFF
--- a/src/state/slices/portfolioSlice/utils.ts
+++ b/src/state/slices/portfolioSlice/utils.ts
@@ -432,6 +432,9 @@ export const isAssetSupportedByWallet = (assetId: AssetId, wallet: HDWallet): bo
     case ethChainId:
       return supportsETH(wallet)
     case btcChainId:
+    case ltcChainId:
+    case dogeChainId:
+    case bchChainId:
       return supportsBTC(wallet)
     case cosmosChainId:
       return supportsCosmos(wallet)


### PR DESCRIPTION
## Description

Spotted while testing https://github.com/shapeshift/web/pull/2657

This adds all our supported UTXOs in `isAssetSupportedByWallet`.

This util is used by fiat ramp for wallet feature detection. As a result
of these being missing, it is currently impossible to buy/sell UTXOs we
support apart from BTC, since they're displayed as disabled.

## Notice

<!-- Before submitting a pull request, please make sure you have answered the following: -->

- [x] Have you followed the guidelines in our [Contributing]('https://github.com/shapeshift/web/blob/develop/CONTRIBUTING.md) guide?
- [x] Have you checked to ensure there aren't other open [Pull Requests](https://github.com/shapeshift/web/pulls) for the same update/change?

## Pull Request Type

- [x] :bug: Bug fix (Non-breaking Change: Fixes an issue)
- [ ] :hammer_and_wrench: Chore (Non-breaking Change: Doc updates, pkg upgrades, typos, etc..)
- [ ] :nail_care: New Feature (Breaking/Non-breaking Change)

## Issue (if applicable)

N/A

## Risk

None, this is only used in fiat ramps:

```shell
➜  shapeshiftWeb git:(fix_utxos_isAssetSupportedByWallet) rg  -g '**/**.ts' "isAssetSupportedByWallet"
src/state/slices/portfolioSlice/utils.ts
426:export const isAssetSupportedByWallet = (assetId: AssetId, wallet: HDWallet): boolean => {

src/components/Modals/FiatRamps/hooks/useFiatRampCurrencyList.ts
6:import { isAssetSupportedByWallet } from 'state/slices/portfolioSlice/utils'
44:              disabled: !isAssetSupportedByWallet(asset?.assetId ?? '', wallet),
94:              disabled: !isAssetSupportedByWallet(asset.assetId, wallet),
```

## Testing

- Select the Gem ramp
- Ensure Bitcoin Cash and Litecoin are available as buy assets i.e not
  in disabled state
- Ensure clicking "Continue" routes to the right Gem destination link

### Engineering

- Refer to the top-level testing notes
- Ensure all missing UTXOs are in this diff

### Operations

- Refer to the top-level testing notes

## Screenshots (if applicable)

Prod:

<img width="522" alt="image" src="https://user-images.githubusercontent.com/17035424/188635240-4b861026-00d4-4155-9d29-a5a4f1f6086e.png">
<img width="530" alt="image" src="https://user-images.githubusercontent.com/17035424/188635193-d6b001d3-56e6-409d-895e-cf97c68bd7fe.png">

This diff:

<img width="532" alt="image" src="https://user-images.githubusercontent.com/17035424/188635338-47ecb09b-4756-484f-a867-f3efb2908714.png">
<img width="328" alt="image" src="https://user-images.githubusercontent.com/17035424/188635421-7a8032e1-f0f5-4b14-90ae-20ed1916a642.png">
<img width="518" alt="image" src="https://user-images.githubusercontent.com/17035424/188635518-f3b30972-5e6c-4b37-87fb-f1539c41d8d1.png">
<img width="329" alt="image" src="https://user-images.githubusercontent.com/17035424/188635600-1016c6ed-b0fa-4eb3-9ad0-9ebc0c12e753.png">
