### PR TITLE
feat: yearn multi account

### DIFF
--- a/package.json
+++ b/package.json
@@ -103,7 +103,7 @@
     "@shapeshiftoss/hdwallet-xdefi": "^1.29.0",
     "@shapeshiftoss/investor-foxy": "^5.0.1",
     "@shapeshiftoss/investor-idle": "^2.0.1",
-    "@shapeshiftoss/investor-yearn": "^5.0.1",
+    "@shapeshiftoss/investor-yearn": "^6.0.0",
     "@shapeshiftoss/logger": "^1.1.2",
     "@shapeshiftoss/market-service": "^7.0.1",
     "@shapeshiftoss/swapper": "^11.0.1",

--- a/src/features/defi/providers/yearn/components/YearnManager/Deposit/YearnDeposit.tsx
+++ b/src/features/defi/providers/yearn/components/YearnManager/Deposit/YearnDeposit.tsx
@@ -13,6 +13,7 @@ import qs from 'qs'
 import { useEffect, useMemo, useReducer } from 'react'
 import { useTranslate } from 'react-polyglot'
 import { useSelector } from 'react-redux'
+import { AccountDropdownProps } from 'components/AccountDropdown/AccountDropdown'
 import { CircularProgress } from 'components/CircularProgress/CircularProgress'
 import { DefiStepProps, Steps } from 'components/DeFi/components/Steps'
 import { getChainAdapterManager } from 'context/PluginProvider/chainAdapterSingleton'
@@ -39,9 +40,9 @@ const moduleLogger = logger.child({
 })
 
 export const YearnDeposit: React.FC<{
-  onAccountChange: (accountId: AccountId) => void
+  onAccountIdChange: AccountDropdownProps['onChange']
   accountId: AccountId | null
-}> = ({ onAccountChange: handleAccountChange, accountId }) => {
+}> = ({ onAccountIdChange: handleAccountIdChange, accountId }) => {
   const { yearn: api } = useYearn()
   const [state, dispatch] = useReducer(reducer, initialState)
   const translate = useTranslate()
@@ -103,7 +104,7 @@ export const YearnDeposit: React.FC<{
       [DefiStep.Info]: {
         label: translate('defi.steps.deposit.info.title'),
         description: translate('defi.steps.deposit.info.description', { asset: asset.symbol }),
-        component: ownProps => <Deposit {...ownProps} onAccountChange={handleAccountChange} />,
+        component: ownProps => <Deposit {...ownProps} onAccountIdChange={handleAccountIdChange} />,
       },
       [DefiStep.Approve]: {
         label: translate('defi.steps.approve.title'),
@@ -121,7 +122,7 @@ export const YearnDeposit: React.FC<{
         component: Status,
       },
     }
-  }, [accountId, handleAccountChange, vaultAddress, asset.symbol, translate])
+  }, [accountId, handleAccountIdChange, vaultAddress, asset.symbol, translate])
 
   if (loading || !asset || !marketData || !api) {
     return (

--- a/src/features/defi/providers/yearn/components/YearnManager/Deposit/YearnDeposit.tsx
+++ b/src/features/defi/providers/yearn/components/YearnManager/Deposit/YearnDeposit.tsx
@@ -1,5 +1,5 @@
 import { Center, useToast } from '@chakra-ui/react'
-import { toAssetId } from '@shapeshiftoss/caip'
+import { AccountId, toAssetId } from '@shapeshiftoss/caip'
 import { DefiModalContent } from 'features/defi/components/DefiModal/DefiModalContent'
 import { DefiModalHeader } from 'features/defi/components/DefiModal/DefiModalHeader'
 import {
@@ -20,6 +20,7 @@ import { useBrowserRouter } from 'hooks/useBrowserRouter/useBrowserRouter'
 import { useWallet } from 'hooks/useWallet/useWallet'
 import { logger } from 'lib/logger'
 import {
+  selectAccountNumberByAccountId,
   selectAssetById,
   selectMarketDataById,
   selectPortfolioLoading,
@@ -38,7 +39,10 @@ const moduleLogger = logger.child({
   namespace: ['DeFi', 'Providers', 'Yearn', 'YearnDeposit'],
 })
 
-export const YearnDeposit = () => {
+export const YearnDeposit: React.FC<{
+  onAccountChange: (accountId: AccountId) => void
+  accountId: AccountId | null
+}> = ({ onAccountChange: handleAccountChange, accountId }) => {
   const { yearn: api } = useYearn()
   const [state, dispatch] = useReducer(reducer, initialState)
   const translate = useTranslate()
@@ -95,12 +99,15 @@ export const YearnDeposit = () => {
     })
   }
 
+  const filter = useMemo(() => ({ accountId: accountId ?? '' }), [accountId])
+  const accountNumber = useAppSelector(state => selectAccountNumberByAccountId(state, filter))
+
   const StepConfig: DefiStepProps = useMemo(() => {
     return {
       [DefiStep.Info]: {
         label: translate('defi.steps.deposit.info.title'),
         description: translate('defi.steps.deposit.info.description', { asset: asset.symbol }),
-        component: Deposit,
+        component: props => <Deposit {...props} onAccountChange={handleAccountChange} />,
       },
       [DefiStep.Approve]: {
         label: translate('defi.steps.approve.title'),
@@ -111,14 +118,14 @@ export const YearnDeposit = () => {
       },
       [DefiStep.Confirm]: {
         label: translate('defi.steps.confirm.title'),
-        component: Confirm,
+        component: props => <Confirm {...props} accountNumber={accountNumber} />,
       },
       [DefiStep.Status]: {
         label: 'Status',
         component: Status,
       },
     }
-  }, [vaultAddress, asset.symbol, translate])
+  }, [accountNumber, handleAccountChange, vaultAddress, asset.symbol, translate])
 
   if (loading || !asset || !marketData || !api) {
     return (

--- a/src/features/defi/providers/yearn/components/YearnManager/Deposit/YearnDeposit.tsx
+++ b/src/features/defi/providers/yearn/components/YearnManager/Deposit/YearnDeposit.tsx
@@ -107,7 +107,7 @@ export const YearnDeposit: React.FC<{
       [DefiStep.Info]: {
         label: translate('defi.steps.deposit.info.title'),
         description: translate('defi.steps.deposit.info.description', { asset: asset.symbol }),
-        component: props => <Deposit {...props} onAccountChange={handleAccountChange} />,
+        component: ownProps => <Deposit {...ownProps} onAccountChange={handleAccountChange} />,
       },
       [DefiStep.Approve]: {
         label: translate('defi.steps.approve.title'),
@@ -118,7 +118,7 @@ export const YearnDeposit: React.FC<{
       },
       [DefiStep.Confirm]: {
         label: translate('defi.steps.confirm.title'),
-        component: props => <Confirm {...props} accountNumber={accountNumber} />,
+        component: ownProps => <Confirm {...ownProps} accountNumber={accountNumber} />,
       },
       [DefiStep.Status]: {
         label: 'Status',

--- a/src/features/defi/providers/yearn/components/YearnManager/Deposit/YearnDeposit.tsx
+++ b/src/features/defi/providers/yearn/components/YearnManager/Deposit/YearnDeposit.tsx
@@ -20,7 +20,6 @@ import { useBrowserRouter } from 'hooks/useBrowserRouter/useBrowserRouter'
 import { useWallet } from 'hooks/useWallet/useWallet'
 import { logger } from 'lib/logger'
 import {
-  selectAccountNumberByAccountId,
   selectAssetById,
   selectMarketDataById,
   selectPortfolioLoading,
@@ -99,9 +98,6 @@ export const YearnDeposit: React.FC<{
     })
   }
 
-  const filter = useMemo(() => ({ accountId: accountId ?? '' }), [accountId])
-  const accountNumber = useAppSelector(state => selectAccountNumberByAccountId(state, filter))
-
   const StepConfig: DefiStepProps = useMemo(() => {
     return {
       [DefiStep.Info]: {
@@ -118,14 +114,14 @@ export const YearnDeposit: React.FC<{
       },
       [DefiStep.Confirm]: {
         label: translate('defi.steps.confirm.title'),
-        component: ownProps => <Confirm {...ownProps} accountNumber={accountNumber} />,
+        component: ownProps => <Confirm {...ownProps} accountId={accountId} />,
       },
       [DefiStep.Status]: {
         label: 'Status',
         component: Status,
       },
     }
-  }, [accountNumber, handleAccountChange, vaultAddress, asset.symbol, translate])
+  }, [accountId, handleAccountChange, vaultAddress, asset.symbol, translate])
 
   if (loading || !asset || !marketData || !api) {
     return (

--- a/src/features/defi/providers/yearn/components/YearnManager/Deposit/components/Confirm.tsx
+++ b/src/features/defi/providers/yearn/components/YearnManager/Deposit/components/Confirm.tsx
@@ -22,8 +22,8 @@ import { bnOrZero } from 'lib/bignumber/bignumber'
 import { logger } from 'lib/logger'
 import {
   selectAssetById,
+  selectBIP44ParamsByAccountId,
   selectMarketDataById,
-  selectPortfolioAccountMetadataByAccountId,
   selectPortfolioCryptoHumanBalanceByAssetId,
 } from 'state/slices/selectors'
 import { useAppSelector } from 'state/store'
@@ -67,11 +67,7 @@ export const Confirm: React.FC<StepComponentProps & { accountId: AccountId | nul
   )
 
   const accountFilter = useMemo(() => ({ accountId: accountId ?? '' }), [accountId])
-  const accountMetaData = useAppSelector(state =>
-    selectPortfolioAccountMetadataByAccountId(state, accountFilter),
-  )
-
-  const bip44Params = accountMetaData?.bip44Params
+  const bip44Params = useAppSelector(state => selectBIP44ParamsByAccountId(state, accountFilter))
 
   const handleDeposit = useCallback(async () => {
     if (

--- a/src/features/defi/providers/yearn/components/YearnManager/Deposit/components/Deposit.tsx
+++ b/src/features/defi/providers/yearn/components/YearnManager/Deposit/components/Deposit.tsx
@@ -1,5 +1,5 @@
 import { useToast } from '@chakra-ui/react'
-import { AccountId, toAssetId } from '@shapeshiftoss/caip'
+import { toAssetId } from '@shapeshiftoss/caip'
 import { Deposit as ReusableDeposit, DepositValues } from 'features/defi/components/Deposit/Deposit'
 import {
   DefiAction,

--- a/src/features/defi/providers/yearn/components/YearnManager/Deposit/components/Deposit.tsx
+++ b/src/features/defi/providers/yearn/components/YearnManager/Deposit/components/Deposit.tsx
@@ -1,5 +1,5 @@
 import { useToast } from '@chakra-ui/react'
-import { toAssetId } from '@shapeshiftoss/caip'
+import { AccountId, toAssetId } from '@shapeshiftoss/caip'
 import { Deposit as ReusableDeposit, DepositValues } from 'features/defi/components/Deposit/Deposit'
 import {
   DefiAction,
@@ -28,7 +28,9 @@ import { DepositContext } from '../DepositContext'
 
 const moduleLogger = logger.child({ namespace: ['YearnDeposit:Deposit'] })
 
-export const Deposit: React.FC<StepComponentProps> = ({ onNext }) => {
+export const Deposit: React.FC<
+  StepComponentProps & { onAccountChange: (accountId: AccountId) => void }
+> = ({ onNext, onAccountChange: handleAccountChange }) => {
   const { state, dispatch } = useContext(DepositContext)
   const history = useHistory()
   const translate = useTranslate()
@@ -200,6 +202,7 @@ export const Deposit: React.FC<StepComponentProps> = ({ onNext }) => {
 
   return (
     <ReusableDeposit
+      onAccountChange={handleAccountChange}
       asset={asset}
       apy={String(opportunity?.metadata.apy?.net_apy)}
       cryptoAmountAvailable={cryptoAmountAvailable.toPrecision()}

--- a/src/features/defi/providers/yearn/components/YearnManager/Deposit/components/Deposit.tsx
+++ b/src/features/defi/providers/yearn/components/YearnManager/Deposit/components/Deposit.tsx
@@ -12,6 +12,7 @@ import qs from 'qs'
 import { useCallback, useContext } from 'react'
 import { useTranslate } from 'react-polyglot'
 import { useHistory } from 'react-router-dom'
+import { AccountDropdownProps } from 'components/AccountDropdown/AccountDropdown'
 import { StepComponentProps } from 'components/DeFi/components/Steps'
 import { useBrowserRouter } from 'hooks/useBrowserRouter/useBrowserRouter'
 import { bn, bnOrZero } from 'lib/bignumber/bignumber'
@@ -29,8 +30,8 @@ import { DepositContext } from '../DepositContext'
 const moduleLogger = logger.child({ namespace: ['YearnDeposit:Deposit'] })
 
 export const Deposit: React.FC<
-  StepComponentProps & { onAccountChange: (accountId: AccountId) => void }
-> = ({ onNext, onAccountChange: handleAccountChange }) => {
+  StepComponentProps & { onAccountIdChange: AccountDropdownProps['onChange'] }
+> = ({ onNext, onAccountIdChange: handleAccountIdChange }) => {
   const { state, dispatch } = useContext(DepositContext)
   const history = useHistory()
   const translate = useTranslate()
@@ -202,7 +203,7 @@ export const Deposit: React.FC<
 
   return (
     <ReusableDeposit
-      onAccountChange={handleAccountChange}
+      onAccountIdChange={handleAccountIdChange}
       asset={asset}
       apy={String(opportunity?.metadata.apy?.net_apy)}
       cryptoAmountAvailable={cryptoAmountAvailable.toPrecision()}

--- a/src/features/defi/providers/yearn/components/YearnManager/Overview/YearnOverview.tsx
+++ b/src/features/defi/providers/yearn/components/YearnManager/Overview/YearnOverview.tsx
@@ -1,6 +1,6 @@
 import { ArrowDownIcon, ArrowUpIcon } from '@chakra-ui/icons'
 import { Center, useToast } from '@chakra-ui/react'
-import { toAssetId } from '@shapeshiftoss/caip'
+import { AccountId, toAssetId } from '@shapeshiftoss/caip'
 import { YearnOpportunity } from '@shapeshiftoss/investor-yearn'
 import { USDC_PRECISION } from 'constants/UsdcPrecision'
 import { Overview } from 'features/defi/components/Overview/Overview'
@@ -19,6 +19,7 @@ import { logger } from 'lib/logger'
 import { useGetAssetDescriptionQuery } from 'state/slices/assetsSlice/assetsSlice'
 import {
   selectAssetById,
+  selectFeatureFlags,
   selectMarketDataById,
   selectPortfolioCryptoBalanceByAssetId,
   selectSelectedLocale,
@@ -29,7 +30,9 @@ const moduleLogger = logger.child({
   namespace: ['DeFi', 'Providers', 'Yearn', 'YearnOverview'],
 })
 
-export const YearnOverview = () => {
+export const YearnOverview: React.FC<{ onAccountChange: (accountId: AccountId) => void }> = ({
+  onAccountChange: handleAccountChange,
+}) => {
   const { yearn: api } = useYearn()
   const translate = useTranslate()
   const toast = useToast()
@@ -83,6 +86,8 @@ export const YearnOverview = () => {
     })()
   }, [api, vaultAddress, chainId, toast, translate])
 
+  const featureFlags = useAppSelector(selectFeatureFlags)
+
   if (!opportunity) {
     return (
       <Center minW='500px' minH='350px'>
@@ -93,6 +98,7 @@ export const YearnOverview = () => {
 
   return (
     <Overview
+      {...(featureFlags.MultiAccounts ? { onAccountChange: handleAccountChange } : {})}
       asset={asset}
       name={`${underlyingToken.name} Vault (${opportunity.version})`}
       opportunityFiatBalance={fiatAmountAvailable.toFixed(2)}

--- a/src/features/defi/providers/yearn/components/YearnManager/Overview/YearnOverview.tsx
+++ b/src/features/defi/providers/yearn/components/YearnManager/Overview/YearnOverview.tsx
@@ -99,7 +99,7 @@ export const YearnOverview: React.FC<{ onAccountIdChange: AccountDropdownProps['
 
   return (
     <Overview
-      {...(featureFlags.MultiAccounts ? { onAccountChange: handleAccountIdChange } : {})}
+      {...(featureFlags.MultiAccounts ? { onAccountIdChange: handleAccountIdChange } : {})}
       asset={asset}
       name={`${underlyingToken.name} Vault (${opportunity.version})`}
       opportunityFiatBalance={fiatAmountAvailable.toFixed(2)}

--- a/src/features/defi/providers/yearn/components/YearnManager/Overview/YearnOverview.tsx
+++ b/src/features/defi/providers/yearn/components/YearnManager/Overview/YearnOverview.tsx
@@ -12,6 +12,7 @@ import {
 import { useYearn } from 'features/defi/contexts/YearnProvider/YearnProvider'
 import { useEffect, useState } from 'react'
 import { useTranslate } from 'react-polyglot'
+import { AccountDropdownProps } from 'components/AccountDropdown/AccountDropdown'
 import { CircularProgress } from 'components/CircularProgress/CircularProgress'
 import { useBrowserRouter } from 'hooks/useBrowserRouter/useBrowserRouter'
 import { bnOrZero } from 'lib/bignumber/bignumber'
@@ -30,8 +31,8 @@ const moduleLogger = logger.child({
   namespace: ['DeFi', 'Providers', 'Yearn', 'YearnOverview'],
 })
 
-export const YearnOverview: React.FC<{ onAccountChange: (accountId: AccountId) => void }> = ({
-  onAccountChange: handleAccountChange,
+export const YearnOverview: React.FC<{ onAccountIdChange: AccountDropdownProps['onChange'] }> = ({
+  onAccountIdChange: handleAccountIdChange,
 }) => {
   const { yearn: api } = useYearn()
   const translate = useTranslate()
@@ -98,7 +99,7 @@ export const YearnOverview: React.FC<{ onAccountChange: (accountId: AccountId) =
 
   return (
     <Overview
-      {...(featureFlags.MultiAccounts ? { onAccountChange: handleAccountChange } : {})}
+      {...(featureFlags.MultiAccounts ? { onAccountChange: handleAccountIdChange } : {})}
       asset={asset}
       name={`${underlyingToken.name} Vault (${opportunity.version})`}
       opportunityFiatBalance={fiatAmountAvailable.toFixed(2)}

--- a/src/features/defi/providers/yearn/components/YearnManager/Overview/YearnOverview.tsx
+++ b/src/features/defi/providers/yearn/components/YearnManager/Overview/YearnOverview.tsx
@@ -1,6 +1,6 @@
 import { ArrowDownIcon, ArrowUpIcon } from '@chakra-ui/icons'
 import { Center, useToast } from '@chakra-ui/react'
-import { AccountId, toAssetId } from '@shapeshiftoss/caip'
+import { toAssetId } from '@shapeshiftoss/caip'
 import { YearnOpportunity } from '@shapeshiftoss/investor-yearn'
 import { USDC_PRECISION } from 'constants/UsdcPrecision'
 import { Overview } from 'features/defi/components/Overview/Overview'

--- a/src/features/defi/providers/yearn/components/YearnManager/Withdraw/YearnWithdraw.tsx
+++ b/src/features/defi/providers/yearn/components/YearnManager/Withdraw/YearnWithdraw.tsx
@@ -39,9 +39,9 @@ const moduleLogger = logger.child({
 })
 
 export const YearnWithdraw: React.FC<{
-  onAccountChange: (accountId: AccountId) => void
+  onAccountIdChange: (accountId: AccountId) => void
   accountId: AccountId | null
-}> = ({ onAccountChange: handleAccountChange, accountId }) => {
+}> = ({ onAccountIdChange: handleAccountIdChange, accountId }) => {
   const { yearn: api } = useYearn()
   const [state, dispatch] = useReducer(reducer, initialState)
   const translate = useTranslate()
@@ -115,7 +115,7 @@ export const YearnWithdraw: React.FC<{
         description: translate('defi.steps.withdraw.info.description', {
           asset: underlyingAsset.symbol,
         }),
-        component: ownProps => <Withdraw {...ownProps} onAccountChange={handleAccountChange} />,
+        component: ownProps => <Withdraw {...ownProps} onAccountIdChange={handleAccountIdChange} />,
       },
       [DefiStep.Confirm]: {
         label: translate('defi.steps.confirm.title'),
@@ -126,7 +126,7 @@ export const YearnWithdraw: React.FC<{
         component: Status,
       },
     }
-  }, [accountId, translate, underlyingAsset.symbol, handleAccountChange])
+  }, [accountId, translate, underlyingAsset.symbol, handleAccountIdChange])
 
   if (loading || !asset || !marketData)
     return (

--- a/src/features/defi/providers/yearn/components/YearnManager/Withdraw/YearnWithdraw.tsx
+++ b/src/features/defi/providers/yearn/components/YearnManager/Withdraw/YearnWithdraw.tsx
@@ -119,11 +119,11 @@ export const YearnWithdraw: React.FC<{
         description: translate('defi.steps.withdraw.info.description', {
           asset: underlyingAsset.symbol,
         }),
-        component: props => <Withdraw {...props} onAccountChange={handleAccountChange} />,
+        component: ownProps => <Withdraw {...ownProps} onAccountChange={handleAccountChange} />,
       },
       [DefiStep.Confirm]: {
         label: translate('defi.steps.confirm.title'),
-        component: props => <Confirm {...props} accountNumber={accountNumber} />,
+        component: ownProps => <Confirm {...ownProps} accountNumber={accountNumber} />,
       },
       [DefiStep.Status]: {
         label: 'Status',

--- a/src/features/defi/providers/yearn/components/YearnManager/Withdraw/YearnWithdraw.tsx
+++ b/src/features/defi/providers/yearn/components/YearnManager/Withdraw/YearnWithdraw.tsx
@@ -21,7 +21,6 @@ import { useBrowserRouter } from 'hooks/useBrowserRouter/useBrowserRouter'
 import { useWallet } from 'hooks/useWallet/useWallet'
 import { logger } from 'lib/logger'
 import {
-  selectAccountNumberByAccountId,
   selectAssetById,
   selectMarketDataById,
   selectPortfolioLoading,
@@ -109,9 +108,6 @@ export const YearnWithdraw: React.FC<{
     })
   }
 
-  const filter = useMemo(() => ({ accountId: accountId ?? '' }), [accountId])
-  const accountNumber = useAppSelector(state => selectAccountNumberByAccountId(state, filter))
-
   const StepConfig: DefiStepProps = useMemo(() => {
     return {
       [DefiStep.Info]: {
@@ -123,14 +119,14 @@ export const YearnWithdraw: React.FC<{
       },
       [DefiStep.Confirm]: {
         label: translate('defi.steps.confirm.title'),
-        component: ownProps => <Confirm {...ownProps} accountNumber={accountNumber} />,
+        component: ownProps => <Confirm {...ownProps} accountId={accountId} />,
       },
       [DefiStep.Status]: {
         label: 'Status',
         component: Status,
       },
     }
-  }, [accountNumber, translate, underlyingAsset.symbol, handleAccountChange])
+  }, [accountId, translate, underlyingAsset.symbol, handleAccountChange])
 
   if (loading || !asset || !marketData)
     return (

--- a/src/features/defi/providers/yearn/components/YearnManager/Withdraw/YearnWithdraw.tsx
+++ b/src/features/defi/providers/yearn/components/YearnManager/Withdraw/YearnWithdraw.tsx
@@ -14,6 +14,7 @@ import qs from 'qs'
 import { useEffect, useMemo, useReducer } from 'react'
 import { useTranslate } from 'react-polyglot'
 import { useSelector } from 'react-redux'
+import { AccountDropdownProps } from 'components/AccountDropdown/AccountDropdown'
 import { CircularProgress } from 'components/CircularProgress/CircularProgress'
 import { DefiStepProps, Steps } from 'components/DeFi/components/Steps'
 import { getChainAdapterManager } from 'context/PluginProvider/chainAdapterSingleton'
@@ -39,7 +40,7 @@ const moduleLogger = logger.child({
 })
 
 export const YearnWithdraw: React.FC<{
-  onAccountIdChange: (accountId: AccountId) => void
+  onAccountIdChange: AccountDropdownProps['onChange']
   accountId: AccountId | null
 }> = ({ onAccountIdChange: handleAccountIdChange, accountId }) => {
   const { yearn: api } = useYearn()

--- a/src/features/defi/providers/yearn/components/YearnManager/Withdraw/components/Confirm.tsx
+++ b/src/features/defi/providers/yearn/components/YearnManager/Withdraw/components/Confirm.tsx
@@ -22,8 +22,8 @@ import { bnOrZero } from 'lib/bignumber/bignumber'
 import { logger } from 'lib/logger'
 import {
   selectAssetById,
+  selectBIP44ParamsByAccountId,
   selectMarketDataById,
-  selectPortfolioAccountMetadataByAccountId,
   selectPortfolioCryptoHumanBalanceByAssetId,
 } from 'state/slices/selectors'
 import { useAppSelector } from 'state/store'
@@ -76,11 +76,7 @@ export const Confirm: React.FC<StepComponentProps & { accountId: AccountId | nul
   )
 
   const accountFilter = useMemo(() => ({ accountId: accountId ?? '' }), [accountId])
-  const accountMetaData = useAppSelector(state =>
-    selectPortfolioAccountMetadataByAccountId(state, accountFilter),
-  )
-
-  const bip44Params = accountMetaData?.bip44Params
+  const bip44Params = useAppSelector(state => selectBIP44ParamsByAccountId(state, accountFilter))
 
   const handleConfirm = useCallback(async () => {
     if (

--- a/src/features/defi/providers/yearn/components/YearnManager/Withdraw/components/Confirm.tsx
+++ b/src/features/defi/providers/yearn/components/YearnManager/Withdraw/components/Confirm.tsx
@@ -121,9 +121,9 @@ export const Confirm: React.FC<StepComponentProps & { accountId: AccountId | nul
       dispatch({ type: YearnWithdrawActionType.SET_LOADING, payload: false })
     }
   }, [
-    accountId,
     asset.precision,
     assetReference,
+    bip44Params,
     dispatch,
     onNext,
     opportunity,

--- a/src/features/defi/providers/yearn/components/YearnManager/Withdraw/components/Withdraw.tsx
+++ b/src/features/defi/providers/yearn/components/YearnManager/Withdraw/components/Withdraw.tsx
@@ -1,4 +1,4 @@
-import { toAssetId } from '@shapeshiftoss/caip'
+import { AccountId, toAssetId } from '@shapeshiftoss/caip'
 import {
   Field,
   Withdraw as ReusableWithdraw,
@@ -30,7 +30,9 @@ const moduleLogger = logger.child({
   namespace: ['DeFi', 'Providers', 'Yearn', 'Withdraw', 'Withdraw'],
 })
 
-export const Withdraw: React.FC<StepComponentProps> = ({ onNext }) => {
+export const Withdraw: React.FC<
+  StepComponentProps & { onAccountChange: (accountId: AccountId) => void }
+> = ({ onAccountChange: handleAccountChange, onNext }) => {
   const { state, dispatch } = useContext(WithdrawContext)
   const { query, history: browserHistory } = useBrowserRouter<DefiQueryParams, DefiParams>()
   const { yearn: yearnInvestor } = useYearn()
@@ -148,6 +150,7 @@ export const Withdraw: React.FC<StepComponentProps> = ({ onNext }) => {
   return (
     <FormProvider {...methods}>
       <ReusableWithdraw
+        onAccountChange={handleAccountChange}
         asset={underlyingAsset}
         cryptoAmountAvailable={cryptoAmountAvailable.toPrecision()}
         cryptoInputValidation={{

--- a/src/features/defi/providers/yearn/components/YearnManager/Withdraw/components/Withdraw.tsx
+++ b/src/features/defi/providers/yearn/components/YearnManager/Withdraw/components/Withdraw.tsx
@@ -1,4 +1,4 @@
-import { AccountId, toAssetId } from '@shapeshiftoss/caip'
+import { toAssetId } from '@shapeshiftoss/caip'
 import {
   Field,
   Withdraw as ReusableWithdraw,
@@ -12,6 +12,7 @@ import {
 import { useYearn } from 'features/defi/contexts/YearnProvider/YearnProvider'
 import { useCallback, useContext } from 'react'
 import { FormProvider, useForm } from 'react-hook-form'
+import { AccountDropdownProps } from 'components/AccountDropdown/AccountDropdown'
 import { StepComponentProps } from 'components/DeFi/components/Steps'
 import { useBrowserRouter } from 'hooks/useBrowserRouter/useBrowserRouter'
 import { bnOrZero } from 'lib/bignumber/bignumber'
@@ -31,8 +32,8 @@ const moduleLogger = logger.child({
 })
 
 export const Withdraw: React.FC<
-  StepComponentProps & { onAccountChange: (accountId: AccountId) => void }
-> = ({ onAccountChange: handleAccountChange, onNext }) => {
+  StepComponentProps & { onAccountIdChange: AccountDropdownProps['onChange'] }
+> = ({ onAccountIdChange: handleAccountIdChange, onNext }) => {
   const { state, dispatch } = useContext(WithdrawContext)
   const { query, history: browserHistory } = useBrowserRouter<DefiQueryParams, DefiParams>()
   const { yearn: yearnInvestor } = useYearn()
@@ -150,7 +151,7 @@ export const Withdraw: React.FC<
   return (
     <FormProvider {...methods}>
       <ReusableWithdraw
-        onAccountChange={handleAccountChange}
+        onAccountIdChange={handleAccountIdChange}
         asset={underlyingAsset}
         cryptoAmountAvailable={cryptoAmountAvailable.toPrecision()}
         cryptoInputValidation={{

--- a/src/features/defi/providers/yearn/components/YearnManager/YearnManager.tsx
+++ b/src/features/defi/providers/yearn/components/YearnManager/YearnManager.tsx
@@ -1,9 +1,11 @@
+import { AccountId } from '@shapeshiftoss/caip'
 import {
   DefiAction,
   DefiParams,
   DefiQueryParams,
 } from 'features/defi/contexts/DefiManagerProvider/DefiCommon'
 import { AnimatePresence } from 'framer-motion'
+import { useState } from 'react'
 import { SlideTransition } from 'components/SlideTransition'
 import { useBrowserRouter } from 'hooks/useBrowserRouter/useBrowserRouter'
 
@@ -14,22 +16,23 @@ import { YearnWithdraw } from './Withdraw/YearnWithdraw'
 export const YearnManager = () => {
   const { query } = useBrowserRouter<DefiQueryParams, DefiParams>()
   const { modal } = query
+  const [accountId, setAccountId] = useState<AccountId | null>(null)
 
   return (
     <AnimatePresence exitBeforeEnter initial={false}>
       {modal === DefiAction.Overview && (
         <SlideTransition key={DefiAction.Overview}>
-          <YearnOverview />
+          <YearnOverview onAccountChange={setAccountId} />
         </SlideTransition>
       )}
       {modal === DefiAction.Deposit && (
         <SlideTransition key={DefiAction.Deposit}>
-          <YearnDeposit />
+          <YearnDeposit onAccountChange={setAccountId} accountId={accountId} />
         </SlideTransition>
       )}
       {modal === DefiAction.Withdraw && (
         <SlideTransition key={DefiAction.Withdraw}>
-          <YearnWithdraw />
+          <YearnWithdraw onAccountChange={setAccountId} accountId={accountId} />
         </SlideTransition>
       )}
     </AnimatePresence>

--- a/src/features/defi/providers/yearn/components/YearnManager/YearnManager.tsx
+++ b/src/features/defi/providers/yearn/components/YearnManager/YearnManager.tsx
@@ -22,17 +22,17 @@ export const YearnManager = () => {
     <AnimatePresence exitBeforeEnter initial={false}>
       {modal === DefiAction.Overview && (
         <SlideTransition key={DefiAction.Overview}>
-          <YearnOverview onAccountChange={setAccountId} />
+          <YearnOverview onAccountIdChange={setAccountId} />
         </SlideTransition>
       )}
       {modal === DefiAction.Deposit && (
         <SlideTransition key={DefiAction.Deposit}>
-          <YearnDeposit onAccountChange={setAccountId} accountId={accountId} />
+          <YearnDeposit onAccountIdChange={setAccountId} accountId={accountId} />
         </SlideTransition>
       )}
       {modal === DefiAction.Withdraw && (
         <SlideTransition key={DefiAction.Withdraw}>
-          <YearnWithdraw onAccountChange={setAccountId} accountId={accountId} />
+          <YearnWithdraw onAccountIdChange={setAccountId} accountId={accountId} />
         </SlideTransition>
       )}
     </AnimatePresence>

--- a/src/state/slices/portfolioSlice/selectors.ts
+++ b/src/state/slices/portfolioSlice/selectors.ts
@@ -52,6 +52,7 @@ import {
 import { PubKey } from '../validatorDataSlice/validatorDataSlice'
 import { selectAccountSpecifiers } from './../accountSpecifiersSlice/selectors'
 import {
+  AccountMetadata,
   AccountMetadataById,
   PortfolioAccountBalances,
   PortfolioAccountSpecifiers,
@@ -144,15 +145,21 @@ export const selectPortfolioAccountMetadata = createDeepEqualOutputSelector(
   accountMetadata => accountMetadata,
 )
 
+export const selectPortfolioAccountMetadataByAccountId = createSelector(
+  selectPortfolioAccountMetadata,
+  selectAccountIdParamFromFilter,
+  (accountMetadata, accountId): AccountMetadata => accountMetadata[accountId],
+)
+
 export const selectBIP44ParamsByAccountId = createSelector(
   selectPortfolioAccountMetadata,
   selectAccountIdParamFromFilter,
-  (accountMetadata, accountId): BIP44Params | undefined => accountMetadata[accountId]?.bip44Params,
+  (accountMetadata, accountId): BIP44Params => accountMetadata[accountId]?.bip44Params,
 )
 
 export const selectAccountNumberByAccountId = createSelector(
   selectBIP44ParamsByAccountId,
-  (bip44Params): number | undefined => bip44Params?.accountNumber,
+  (bip44Params): number => bip44Params.accountNumber,
 )
 
 export const selectAccountTypeByAccountId = createSelector(

--- a/src/state/slices/portfolioSlice/selectors.ts
+++ b/src/state/slices/portfolioSlice/selectors.ts
@@ -159,7 +159,7 @@ export const selectBIP44ParamsByAccountId = createSelector(
 
 export const selectAccountNumberByAccountId = createSelector(
   selectBIP44ParamsByAccountId,
-  (bip44Params): number => bip44Params.accountNumber,
+  (bip44Params): number | undefined => bip44Params?.accountNumber,
 )
 
 export const selectAccountTypeByAccountId = createSelector(

--- a/yarn.lock
+++ b/yarn.lock
@@ -4053,10 +4053,10 @@
     web3-core "1.7.4"
     web3-utils "1.7.4"
 
-"@shapeshiftoss/investor-yearn@^5.0.1":
-  version "5.0.1"
-  resolved "https://registry.yarnpkg.com/@shapeshiftoss/investor-yearn/-/investor-yearn-5.0.1.tgz#8bbed751cd218735669de20caecf46a551b39d7a"
-  integrity sha512-3Fa1W4FUgLUif0CfNfSGNk2jWyn9mdEmzf4gXsnqQMOTELi37cUxTLUiIWyhw9by0o3jG6Ei1qT9xxwxbsK9gQ==
+"@shapeshiftoss/investor-yearn@^6.0.0":
+  version "6.0.0"
+  resolved "https://registry.yarnpkg.com/@shapeshiftoss/investor-yearn/-/investor-yearn-6.0.0.tgz#017336698f1cf7f639f856c07e30d3063ccceedc"
+  integrity sha512-yN9r9Y/0NgYl3f0WZgQOt8zoP6MPSBg8jYLWzEMdZcpZu+4bDH72xdZsELJlZBBdGw/DBqcmnq717ED6WcXf2g==
   dependencies:
     "@ethersproject/providers" "^5.5.3"
     "@yfi/sdk" "^1.0.30"


### PR DESCRIPTION
## Description

This adds multi account support for Yearn DeFi opportunities:

- Overview
- Deposit
- Withdraw

## Notice

<!-- Before submitting a pull request, please make sure you have answered the following: -->

- [x] Have you followed the guidelines in our [Contributing]('https://github.com/shapeshift/web/blob/develop/CONTRIBUTING.md) guide?
- [x] Have you checked to ensure there aren't other open [Pull Requests](https://github.com/shapeshift/web/pulls) for the same update/change?

## Pull Request Type

- [x] :bug: Bug fix (Non-breaking Change: Fixes an issue)
- [x] :hammer_and_wrench: Chore (Non-breaking Change: Doc updates, pkg upgrades, typos, etc..)
- [x] :nail_care: New Feature (Breaking/Non-breaking Change)

## Issue (if applicable)

closes https://github.com/shapeshift/web/issues/2605

## Risk

Yearn modal should be fully regression tested - in theory, this brings no changes for now and uses programmatic accountNumber vs. hardcoded accountNumber, but this requires a breaking(ish) change in the lib PR.

## Testing

- With the `MultiAccounts` flag on, the account dropdown should be present in Yearn opportunities Overview, Deposit, and Withdraw steps
- With the `MultiAccounts` flag off, there should be no user-facing changes nor regressions with the current flow

### Engineering

- Refer to the top-level testing notes
- `console.log` or debug `accountNumber` props in components to ensure the right account number is passed down

### Operations

- Refer to the top-level testing notes
- Regression test the whole Yearn modal flow, including making deposit and withdraws

## Screenshots (if applicable)

<img width="528" alt="image" src="https://user-images.githubusercontent.com/17035424/188703055-8dcb46d6-d7b9-4997-b845-0261eb8e5cdf.png">
<img width="520" alt="image" src="https://user-images.githubusercontent.com/17035424/188703085-3875a3e0-acd1-493c-be63-804d72e5722c.png">
<img width="519" alt="image" src="https://user-images.githubusercontent.com/17035424/188703115-a5bb7407-4e1b-48ee-a184-9b3e09fb68d6.png">

