### PR TITLE
fix: recovery phrase grammar

### DIFF
--- a/src/assets/translations/en/main.json
+++ b/src/assets/translations/en/main.json
@@ -1127,7 +1127,7 @@
         "23th": "23th",
         "24th": "24th",
         "body2": " word",
-        "body3": "in your secret phrase.",
+        "body3": "in your secret phrase?",
         "button": "Next"
       },
       "rename": {


### PR DESCRIPTION
## Description

Noted by mogie - replace `.` here with `?` to fix the grammar.

![image](https://user-images.githubusercontent.com/97164662/188992300-64b90eab-a963-4b28-a71a-54a493ce2881.png)

## Notice

- [x] Have you followed the guidelines in our [Contributing]('https://github.com/shapeshift/web/blob/develop/CONTRIBUTING.md) guide?
- [x] Have you checked to ensure there aren't other open [Pull Requests](https://github.com/shapeshift/web/pulls) for the same update/change?

## Pull Request Type

- [x] :bug: Bug fix (Non-breaking Change: Fixes an issue)
- [ ] :hammer_and_wrench: Chore (Non-breaking Change: Doc updates, pkg upgrades, typos, etc..)
- [ ] :nail_care: New Feature (Breaking/Non-breaking Change)

## Issue (if applicable)

N/A - noticed by mogie.

## Risk

Almost literally 0.

## Testing

When setting up a new wallet we'll now see a `?` instead of a `.` when verifying seed phrase.

### Engineering

See above.

### Operations

See above.

## Screenshots (if applicable)

N/A