### PR TITLE
chore: add #2691 hash to git blame ignore revs

### DIFF
--- a/.git-blame-ignore-revs
+++ b/.git-blame-ignore-revs
@@ -4,3 +4,5 @@
 9287cd7ad557150b4900e010c1e87b189df2eb90
 # chore: add array-type lint rule (#2685)
 a19b440bd20285cf4ae1928cd31a449c08c8a1d1
+# feat: add @typescript-eslint/consistent-type-imports rule (#2691)
+47c64e5d7ce4d4702dacac14e61e949aac5415b7


### PR DESCRIPTION
## Description

Add #2691 hash to git blame ignore revs.

## Notice

- [x] Have you followed the guidelines in our [Contributing]('https://github.com/shapeshift/web/blob/develop/CONTRIBUTING.md) guide?
- [x] Have you checked to ensure there aren't other open [Pull Requests](https://github.com/shapeshift/web/pulls) for the same update/change?

## Pull Request Type

- [ ] :bug: Bug fix (Non-breaking Change: Fixes an issue)
- [x] :hammer_and_wrench: Chore (Non-breaking Change: Doc updates, pkg upgrades, typos, etc..)
- [ ] :nail_care: New Feature (Breaking/Non-breaking Change)

## Issue (if applicable)

N/A

## Risk

Almost literally 0.

## Testing

### Engineering

CI should pass.

### Operations

N/A

## Screenshots (if applicable)

N/A