### PR TITLE
feat: add react-memo/require-usememo eslint rule

### DIFF
--- a/.eslintrc
+++ b/.eslintrc
@@ -8,7 +8,8 @@
   "plugins": [
     "jest",
     "prettier",
-    "simple-import-sort"
+    "simple-import-sort",
+    "eslint-plugin-react-memo"
   ],
   "parser": "@typescript-eslint/parser",
   "parserOptions": {
@@ -72,6 +73,7 @@
     "react-hooks/exhaustive-deps": "error",
     "@typescript-eslint/array-type": "error",
     "@typescript-eslint/consistent-type-imports": "error",
-    "react/jsx-handler-names": "error"
+    "react/jsx-handler-names": "error",
+    "react-memo/require-usememo": "warn"
   }
 }

--- a/package.json
+++ b/package.json
@@ -132,6 +132,7 @@
     "dayjs": "^1.11.3",
     "dompurify": "^2.3.8",
     "envalid": "^7.3.1",
+    "eslint-plugin-react-memo": "^0.0.3",
     "framer-motion": "^6.3.11",
     "friendly-challenge": "0.9.2",
     "html-react-parser": "^1.4.14",

--- a/yarn.lock
+++ b/yarn.lock
@@ -10979,6 +10979,11 @@ eslint-plugin-react-hooks@^4.3.0:
   resolved "https://registry.yarnpkg.com/eslint-plugin-react-hooks/-/eslint-plugin-react-hooks-4.3.0.tgz#318dbf312e06fab1c835a4abef00121751ac1172"
   integrity sha512-XslZy0LnMn+84NEG9jSGR6eGqaZB3133L8xewQo3fQagbQuGt7a63gf+P1NGKZavEYEC3UXaWEAA/AqDkuN6xA==
 
+eslint-plugin-react-memo@^0.0.3:
+  version "0.0.3"
+  resolved "https://registry.yarnpkg.com/eslint-plugin-react-memo/-/eslint-plugin-react-memo-0.0.3.tgz#26542aa2eeabed37f354c64c6b4eabc07051cf78"
+  integrity sha512-IZzLDZJF4V84XL9+v74ypDSts/hAQtNeYFZGc3wvdX+YgIw4pkn4GiXPJ6MNUccNTPYJqr89Nnvqo3rcesEBOQ==
+
 eslint-plugin-react@^7.27.1:
   version "7.29.3"
   resolved "https://registry.yarnpkg.com/eslint-plugin-react/-/eslint-plugin-react-7.29.3.tgz#f4eab757f2756d25d6d4c2a58a9e20b004791f05"


### PR DESCRIPTION
## Description

This adds the [`react-memo/require-usememo`](https://github.com/steadicat/eslint-plugin-react-memo#require-usememo) eslint rule.

Only emits warnings, since this will currently emit 900+ lint violations.

See https://github.com/shapeshift/web/pull/2699 for a demo of how these can be fixed.

## Notice

<!-- Before submitting a pull request, please make sure you have answered the following: -->

- [x] Have you followed the guidelines in our [Contributing]('https://github.com/shapeshift/web/blob/develop/CONTRIBUTING.md) guide?
- [x] Have you checked to ensure there aren't other open [Pull Requests](https://github.com/shapeshift/web/pulls) for the same update/change?

## Pull Request Type

- [ ] :bug: Bug fix (Non-breaking Change: Fixes an issue)
- [ ] :hammer_and_wrench: Chore (Non-breaking Change: Doc updates, pkg upgrades, typos, etc..)
- [x] :nail_care: New Feature (Breaking/Non-breaking Change)

## Issue (if applicable)

N/A

## Risk

None

## Testing

- If CI is happy, we are 🛍️ 

### Engineering

- See top-level notes

### Operations

- Nothing to see here

## Screenshots (if applicable)
