### PR TITLE
fix: close the drawer when an item is clicked in the navbar

### DIFF
--- a/src/components/Layout/Header/NavBar/NavBar.tsx
+++ b/src/components/Layout/Header/NavBar/NavBar.tsx
@@ -15,9 +15,10 @@ import { MainNavLink } from './MainNavLink'
 
 type NavBarProps = {
   isCompact?: boolean
+  onClick?: () => void
 } & StackProps
 
-export const NavBar = ({ isCompact, ...rest }: NavBarProps) => {
+export const NavBar = ({ isCompact, onClick, ...rest }: NavBarProps) => {
   const translate = useTranslate()
   const { routes: pluginRoutes } = usePlugins()
   const isYatFeatureEnabled = useFeatureFlag('Yat')
@@ -62,6 +63,7 @@ export const NavBar = ({ isCompact, ...rest }: NavBarProps) => {
                 leftIcon={item.icon}
                 href={item.path}
                 to={item.path}
+                onClick={onClick}
                 label={translate(item.label)}
                 aria-label={translate(item.label)}
                 data-test={`navigation-${item.label.split('.')[1]}-button`}

--- a/src/components/Layout/Header/SideNavContent.tsx
+++ b/src/components/Layout/Header/SideNavContent.tsx
@@ -64,7 +64,7 @@ export const SideNavContent = ({ isCompact, onClose }: HeaderContentProps) => {
         </Flex>
       )}
 
-      <NavBar isCompact={isCompact} mt={6} />
+      <NavBar isCompact={isCompact} mt={6} onClick={() => handleClick()} />
       <Stack width='full' mt={6}>
         <MainNavLink
           variant='ghost'


### PR DESCRIPTION
## Description

For mobile users we need to close the drawer when the user clicks on a navbar item.

## Notice

<!-- Before submitting a pull request, please make sure you have answered the following: -->

- [x] Have you followed the guidelines in our [Contributing]('https://github.com/shapeshift/web/blob/develop/CONTRIBUTING.md) guide?
- [x] Have you checked to ensure there aren't other open [Pull Requests](https://github.com/shapeshift/web/pulls) for the same update/change?

## Pull Request Type

- [x] :bug: Bug fix (Non-breaking Change: Fixes an issue)
- [ ] :hammer_and_wrench: Chore (Non-breaking Change: Doc updates, pkg upgrades, typos, etc..)
- [ ] :nail_care: New Feature (Breaking/Non-breaking Change)

## Issue (if applicable)

closes #2681 

closes #

## Risk

No risk

## Testing

On mobile devices, when you open the drawer and click on a navbar item. The drawer should auto close.

### Engineering

N/A

### Operations

On mobile devices, when you open the drawer and click on a navbar item. The drawer should auto close.

## Screenshots (if applicable)

N/A