### PR TITLE
fix: update balance threshold tooltip

### DIFF
--- a/src/assets/translations/en/main.json
+++ b/src/assets/translations/en/main.json
@@ -802,7 +802,7 @@
       "currencyFormat": "Currency Format",
       "language": "Language",
       "balanceThreshold": "Balance Threshold",
-      "balanceThresholdTooltip": "Hide balances below this value",
+      "balanceThresholdTooltip": "On dashboard and charts, hide balances below this value",
       "currencies": {
         "CNY": "Chinese Yuan",
         "USD": "United States Dollar (default)",


### PR DESCRIPTION
## Description

Change to balance threshold tooltip to "On dashboard and charts, hide balances below this value"

## Notice

<!-- Before submitting a pull request, please make sure you have answered the following: -->

- [x] Have you followed the guidelines in our [Contributing]('https://github.com/shapeshift/web/blob/develop/CONTRIBUTING.md) guide?
- [x] Have you checked to ensure there aren't other open [Pull Requests](https://github.com/shapeshift/web/pulls) for the same update/change?

## Pull Request Type

- [x] :bug: Bug fix (Non-breaking Change: Fixes an issue)
- [ ] :hammer_and_wrench: Chore (Non-breaking Change: Doc updates, pkg upgrades, typos, etc..)
- [ ] :nail_care: New Feature (Breaking/Non-breaking Change)

## Issue (if applicable)

closes #2692 


## Risk

No risk

## Testing

n/a

### Engineering

n/a

### Operations

Confirm the tooltip has the updated value

## Screenshots (if applicable)
![Screen Shot 2022-09-12 at 9 59 48 AM](https://user-images.githubusercontent.com/89934888/189687761-30bb2b15-d1a4-4c15-97c7-aba6c0b8b278.png)
