### PR TITLE
feat: cosmos DeFi opportunity modals multi-account support

### DIFF
--- a/src/components/AccountDropdown/AccountDropdown.tsx
+++ b/src/components/AccountDropdown/AccountDropdown.tsx
@@ -16,9 +16,11 @@ import {
   type AssetId,
   btcChainId,
   CHAIN_NAMESPACE,
+  cosmosChainId,
   fromAssetId,
   fromChainId,
   ltcChainId,
+  osmosisChainId,
 } from '@shapeshiftoss/caip'
 import { UtxoAccountType } from '@shapeshiftoss/types'
 import { chain } from 'lodash'
@@ -113,6 +115,7 @@ export const AccountDropdown: FC<AccountDropdownProps> = ({
    * react on accountIds on first render
    */
   useEffect(() => {
+    debugger
     if (!accountIds.length) return
     const validatedAccountIdFromArgs = accountIds.find(accountId => accountId === defaultAccountId)
     const firstAccountId = accountIds[0]
@@ -250,7 +253,10 @@ export const AccountDropdown: FC<AccountDropdownProps> = ({
    * the effectful logic above will still run for other chains, and return the first account
    * via the onChange callback on mount, but nothing will be visually rendered
    */
-  const existingMultiAccountChainIds = useMemo(() => [btcChainId, ltcChainId], [])
+  const existingMultiAccountChainIds = useMemo(
+    () => [btcChainId, ltcChainId, cosmosChainId, osmosisChainId],
+    [],
+  )
   const isMultiAccountsEnabled = useFeatureFlag('MultiAccounts')
   if (!isMultiAccountsEnabled && !existingMultiAccountChainIds.includes(chainId)) return null
 

--- a/src/components/AccountDropdown/AccountDropdown.tsx
+++ b/src/components/AccountDropdown/AccountDropdown.tsx
@@ -16,11 +16,9 @@ import {
   type AssetId,
   btcChainId,
   CHAIN_NAMESPACE,
-  cosmosChainId,
   fromAssetId,
   fromChainId,
   ltcChainId,
-  osmosisChainId,
 } from '@shapeshiftoss/caip'
 import { UtxoAccountType } from '@shapeshiftoss/types'
 import { chain } from 'lodash'
@@ -115,7 +113,6 @@ export const AccountDropdown: FC<AccountDropdownProps> = ({
    * react on accountIds on first render
    */
   useEffect(() => {
-    debugger
     if (!accountIds.length) return
     const validatedAccountIdFromArgs = accountIds.find(accountId => accountId === defaultAccountId)
     const firstAccountId = accountIds[0]
@@ -253,10 +250,7 @@ export const AccountDropdown: FC<AccountDropdownProps> = ({
    * the effectful logic above will still run for other chains, and return the first account
    * via the onChange callback on mount, but nothing will be visually rendered
    */
-  const existingMultiAccountChainIds = useMemo(
-    () => [btcChainId, ltcChainId, cosmosChainId, osmosisChainId],
-    [],
-  )
+  const existingMultiAccountChainIds = useMemo(() => [btcChainId, ltcChainId], [])
   const isMultiAccountsEnabled = useFeatureFlag('MultiAccounts')
   if (!isMultiAccountsEnabled && !existingMultiAccountChainIds.includes(chainId)) return null
 

--- a/src/components/DeFi/components/AssetInput.tsx
+++ b/src/components/DeFi/components/AssetInput.tsx
@@ -8,7 +8,7 @@ import {
   Stack,
   useColorModeValue,
 } from '@chakra-ui/react'
-import type { AssetId } from '@shapeshiftoss/caip'
+import type { AccountId, AssetId } from '@shapeshiftoss/caip'
 import { PairIcons } from 'features/defi/components/PairIcons/PairIcons'
 import type { PropsWithChildren } from 'react'
 import { useRef, useState } from 'react'
@@ -25,6 +25,7 @@ import { useLocaleFormatter } from 'hooks/useLocaleFormatter/useLocaleFormatter'
 import { useToggle } from 'hooks/useToggle/useToggle'
 import { bnOrZero } from 'lib/bignumber/bignumber'
 import { colors } from 'theme/colors'
+import type { Nullable } from 'types/common'
 
 import { Balance } from './Balance'
 import { MaxButtonGroup } from './MaxButtonGroup'
@@ -46,6 +47,7 @@ const CryptoInput = (props: InputProps) => (
 )
 
 export type AssetInputProps = {
+  accountId?: Nullable<AccountId>
   assetId?: AssetId
   assetSymbol: string
   assetIcon: string
@@ -66,6 +68,7 @@ export type AssetInputProps = {
 } & PropsWithChildren
 
 export const AssetInput: React.FC<AssetInputProps> = ({
+  accountId,
   assetId,
   assetSymbol,
   assetIcon,
@@ -190,6 +193,7 @@ export const AssetInput: React.FC<AssetInputProps> = ({
       {handleAccountIdChange && assetId && (
         <Stack direction='row' py={2} px={4} justifyContent='space-between' alignItems='center'>
           <AccountDropdown
+            {...(accountId ? { defaultAccountId: accountId } : {})}
             assetId={assetId}
             onChange={handleAccountIdChange}
             buttonProps={{ variant: 'ghost', width: 'full', padding: 0 }}

--- a/src/features/defi/components/Deposit/Deposit.tsx
+++ b/src/features/defi/components/Deposit/Deposit.tsx
@@ -1,5 +1,6 @@
 import { Button, Stack, useColorModeValue } from '@chakra-ui/react'
 import type { Asset } from '@shapeshiftoss/asset-service'
+import type { AccountId } from '@shapeshiftoss/caip'
 import type { MarketData } from '@shapeshiftoss/types'
 import get from 'lodash/get'
 import { useCallback } from 'react'
@@ -14,8 +15,10 @@ import { FormField } from 'components/DeFi/components/FormField'
 import { Row } from 'components/Row/Row'
 import { Text } from 'components/Text'
 import { bnOrZero } from 'lib/bignumber/bignumber'
+import type { Nullable } from 'types/common'
 
 type DepositProps = {
+  accountId?: Nullable<AccountId>
   asset: Asset
   rewardAsset?: Asset
   // Estimated apy (Deposit Only)
@@ -61,6 +64,7 @@ function calculateYearlyYield(apy: string, amount: string = '') {
 }
 
 export const Deposit = ({
+  accountId,
   apy,
   asset,
   marketData,
@@ -152,6 +156,7 @@ export const Deposit = ({
       <Stack spacing={6} as='form' width='full' onSubmit={handleSubmit(onSubmit)}>
         <FormField label={translate('modals.deposit.amountToDeposit')}>
           <AssetInput
+            accountId={accountId}
             cryptoAmount={cryptoAmount?.value}
             assetId={asset.assetId}
             onAccountIdChange={handleAccountIdChange}

--- a/src/features/defi/components/Overview/Overview.tsx
+++ b/src/features/defi/components/Overview/Overview.tsx
@@ -19,6 +19,7 @@ import type { AssetDescriptionTeaserProps } from 'components/AssetDescriptionTea
 import { AssetDescriptionTeaser } from 'components/AssetDescriptionTeaser'
 import { AssetIcon } from 'components/AssetIcon'
 import { RawText, Text } from 'components/Text'
+import type { Nullable } from 'types/common'
 
 import type { DefiActionButtonProps } from '../DefiActionButtons'
 import { DefiActionButtons } from '../DefiActionButtons'
@@ -31,6 +32,7 @@ export type AssetWithBalance = {
 } & Asset
 
 type OverviewProps = {
+  accountId?: Nullable<AccountId>
   onAccountIdChange?: (accountId: AccountId) => void
   underlyingAssets: AssetWithBalance[]
   rewardAssets?: AssetWithBalance[]
@@ -47,6 +49,7 @@ type OverviewProps = {
   PropsWithChildren
 
 export const Overview: React.FC<OverviewProps> = ({
+  accountId,
   onAccountIdChange,
   underlyingAssets,
   rewardAssets,
@@ -117,6 +120,7 @@ export const Overview: React.FC<OverviewProps> = ({
                   </RawText>
                   {onAccountIdChange ? (
                     <AccountDropdown
+                      {...(accountId ? { defaultAccountId: accountId } : {})}
                       assetId={asset.assetId}
                       onChange={onAccountIdChange}
                       buttonProps={{ height: 5, variant: 'solid' }}

--- a/src/features/defi/components/Withdraw/Withdraw.tsx
+++ b/src/features/defi/components/Withdraw/Withdraw.tsx
@@ -12,6 +12,7 @@ import {
   Stack,
 } from '@chakra-ui/react'
 import type { Asset } from '@shapeshiftoss/asset-service'
+import type { AccountId } from '@shapeshiftoss/caip'
 import type { MarketData } from '@shapeshiftoss/types'
 import type { PropsWithChildren, ReactNode } from 'react'
 import React from 'react'
@@ -27,6 +28,7 @@ import { Text } from 'components/Text'
 import { WalletActions } from 'context/WalletProvider/actions'
 import { useWallet } from 'hooks/useWallet/useWallet'
 import { bnOrZero } from 'lib/bignumber/bignumber'
+import type { Nullable } from 'types/common'
 
 export type FlexFieldProps = {
   control: any
@@ -42,6 +44,7 @@ type InputDefaultValue = {
 }
 
 type WithdrawProps = {
+  accountId?: Nullable<AccountId>
   asset: Asset
   // Users available amount
   cryptoAmountAvailable: string
@@ -88,6 +91,7 @@ export type WithdrawValues = {
 const DEFAULT_SLIPPAGE = '0.5'
 
 export const Withdraw: React.FC<WithdrawProps> = ({
+  accountId,
   asset,
   marketData,
   cryptoAmountAvailable,
@@ -172,6 +176,7 @@ export const Withdraw: React.FC<WithdrawProps> = ({
     <Stack spacing={6} as='form' maxWidth='lg' width='full' onSubmit={handleSubmit(onSubmit)}>
       <FormField label={translate('modals.withdraw.amountToWithdraw')}>
         <AssetInput
+          accountId={accountId}
           cryptoAmount={cryptoAmount?.value}
           onAccountIdChange={handleAccountIdChange}
           onChange={(value, isFiat) => handleInputChange(value, isFiat)}

--- a/src/features/defi/contexts/DefiManagerProvider/DefiCommon.ts
+++ b/src/features/defi/contexts/DefiManagerProvider/DefiCommon.ts
@@ -1,4 +1,4 @@
-import type { ChainId } from '@shapeshiftoss/caip'
+import type { AccountId, ChainId } from '@shapeshiftoss/caip'
 
 export enum DefiType {
   LiquidityPool = 'liquidity_pool',
@@ -47,6 +47,7 @@ export type DefiParams = {
 }
 
 export type DefiQueryParams = {
+  defaultAccountId?: AccountId
   chainId: ChainId
   contractAddress: string
   assetReference: string

--- a/src/features/defi/providers/cosmos/components/CosmosManager/Claim/CosmosClaim.tsx
+++ b/src/features/defi/providers/cosmos/components/CosmosManager/Claim/CosmosClaim.tsx
@@ -33,7 +33,9 @@ const moduleLogger = logger.child({
   namespace: ['DeFi', 'Providers', 'Cosmos', 'CosmosClaim'],
 })
 
-export const CosmosClaim: React.FC<{ accountId?: Nullable<AccountId> }> = ({ accountId }) => {
+type CosmosClaimProps = { accountId?: Nullable<AccountId> }
+
+export const CosmosClaim: React.FC<CosmosClaimProps> = ({ accountId }) => {
   const [state, dispatch] = useReducer(reducer, initialState)
   const { query, history, location } = useBrowserRouter<DefiQueryParams, DefiParams>()
   const { contractAddress, assetReference, chainId } = query

--- a/src/features/defi/providers/cosmos/components/CosmosManager/Claim/CosmosClaim.tsx
+++ b/src/features/defi/providers/cosmos/components/CosmosManager/Claim/CosmosClaim.tsx
@@ -1,4 +1,5 @@
 import { Center, CircularProgress } from '@chakra-ui/react'
+import type { AccountId } from '@shapeshiftoss/caip'
 import { toAssetId } from '@shapeshiftoss/caip'
 import type { CosmosSdkBaseAdapter, CosmosSdkChainId } from '@shapeshiftoss/chain-adapters'
 import { DefiModalContent } from 'features/defi/components/DefiModal/DefiModalContent'
@@ -9,7 +10,7 @@ import type {
 } from 'features/defi/contexts/DefiManagerProvider/DefiCommon'
 import { DefiAction, DefiStep } from 'features/defi/contexts/DefiManagerProvider/DefiCommon'
 import qs from 'qs'
-import { useCallback, useEffect, useMemo, useReducer } from 'react'
+import React, { useCallback, useEffect, useMemo, useReducer } from 'react'
 import { useTranslate } from 'react-polyglot'
 import type { DefiStepProps } from 'components/DeFi/components/Steps'
 import { Steps } from 'components/DeFi/components/Steps'
@@ -20,6 +21,7 @@ import { logger } from 'lib/logger'
 import { useCosmosSdkStakingBalances } from 'pages/Defi/hooks/useCosmosSdkStakingBalances'
 import { selectAssetById } from 'state/slices/selectors'
 import { useAppSelector } from 'state/store'
+import type { Nullable } from 'types/common'
 
 import { CosmosClaimActionType } from './ClaimCommon'
 import { ClaimContext } from './ClaimContext'
@@ -31,7 +33,7 @@ const moduleLogger = logger.child({
   namespace: ['DeFi', 'Providers', 'Cosmos', 'CosmosClaim'],
 })
 
-export const CosmosClaim = () => {
+export const CosmosClaim: React.FC<{ accountId?: Nullable<AccountId> }> = ({ accountId }) => {
   const [state, dispatch] = useReducer(reducer, initialState)
   const { query, history, location } = useBrowserRouter<DefiQueryParams, DefiParams>()
   const { contractAddress, assetReference, chainId } = query
@@ -95,14 +97,14 @@ export const CosmosClaim = () => {
     return {
       [DefiStep.Confirm]: {
         label: translate('defi.steps.confirm.title'),
-        component: Confirm,
+        component: ownProps => <Confirm {...ownProps} accountId={accountId} />,
       },
       [DefiStep.Status]: {
         label: translate('defi.steps.status.title'),
         component: Status,
       },
     }
-  }, [translate])
+  }, [accountId, translate])
 
   if (!asset) {
     return (

--- a/src/features/defi/providers/cosmos/components/CosmosManager/Claim/CosmosClaim.tsx
+++ b/src/features/defi/providers/cosmos/components/CosmosManager/Claim/CosmosClaim.tsx
@@ -45,7 +45,7 @@ export const CosmosClaim: React.FC<{ accountId?: Nullable<AccountId> }> = ({ acc
     assetReference, // TODO: handle multiple denoms
   })
 
-  const opportunities = useCosmosSdkStakingBalances({ assetId })
+  const opportunities = useCosmosSdkStakingBalances({ accountId, assetId })
   const cosmosOpportunity = useMemo(
     () =>
       opportunities?.cosmosSdkStakingOpportunities?.find(

--- a/src/features/defi/providers/cosmos/components/CosmosManager/Claim/components/Confirm.tsx
+++ b/src/features/defi/providers/cosmos/components/CosmosManager/Claim/components/Confirm.tsx
@@ -37,10 +37,9 @@ const moduleLogger = logger.child({
   namespace: ['DeFi', 'Providers', 'Cosmos', 'Claim', 'Confirm'],
 })
 
-export const Confirm = ({
-  accountId,
-  onNext,
-}: StepComponentProps & { accountId?: Nullable<AccountId> }) => {
+type ConfirmProps = StepComponentProps & { accountId?: Nullable<AccountId> }
+
+export const Confirm: React.FC<ConfirmProps> = ({ accountId, onNext }) => {
   const { state, dispatch } = useContext(ClaimContext)
   const opportunity = state?.opportunity
   const { query, history } = useBrowserRouter<DefiQueryParams, DefiParams>()

--- a/src/features/defi/providers/cosmos/components/CosmosManager/Claim/components/Confirm.tsx
+++ b/src/features/defi/providers/cosmos/components/CosmosManager/Claim/components/Confirm.tsx
@@ -1,4 +1,5 @@
 import { Button, Link, Skeleton, SkeletonText, Stack, useToast } from '@chakra-ui/react'
+import type { AccountId } from '@shapeshiftoss/caip'
 import { toAssetId } from '@shapeshiftoss/caip'
 import type {
   DefiParams,
@@ -8,7 +9,7 @@ import { DefiStep } from 'features/defi/contexts/DefiManagerProvider/DefiCommon'
 import { StakingAction } from 'plugins/cosmos/components/modals/Staking/StakingCommon'
 import { useStakingAction } from 'plugins/cosmos/hooks/useStakingAction/useStakingAction'
 import { getFormFees } from 'plugins/cosmos/utils'
-import { useContext, useEffect } from 'react'
+import { useCallback, useContext, useEffect, useMemo } from 'react'
 import { useTranslate } from 'react-polyglot'
 import { Amount } from 'components/Amount/Amount'
 import { AssetIcon } from 'components/AssetIcon'
@@ -21,8 +22,13 @@ import { useBrowserRouter } from 'hooks/useBrowserRouter/useBrowserRouter'
 import { useWallet } from 'hooks/useWallet/useWallet'
 import { bnOrZero } from 'lib/bignumber/bignumber'
 import { logger } from 'lib/logger'
-import { selectAssetById, selectMarketDataById } from 'state/slices/selectors'
+import {
+  selectAssetById,
+  selectBIP44ParamsByAccountId,
+  selectMarketDataById,
+} from 'state/slices/selectors'
 import { useAppSelector } from 'state/store'
+import type { Nullable } from 'types/common'
 
 import { CosmosClaimActionType } from '../ClaimCommon'
 import { ClaimContext } from '../ClaimContext'
@@ -31,7 +37,10 @@ const moduleLogger = logger.child({
   namespace: ['DeFi', 'Providers', 'Cosmos', 'Claim', 'Confirm'],
 })
 
-export const Confirm = ({ onNext }: StepComponentProps) => {
+export const Confirm = ({
+  accountId,
+  onNext,
+}: StepComponentProps & { accountId?: Nullable<AccountId> }) => {
   const { state, dispatch } = useContext(ClaimContext)
   const opportunity = state?.opportunity
   const { query, history } = useBrowserRouter<DefiQueryParams, DefiParams>()
@@ -79,10 +88,12 @@ export const Confirm = ({ onNext }: StepComponentProps) => {
     dispatch,
   ])
 
-  if (!state || !dispatch || !asset) return null
+  const accountFilter = useMemo(() => ({ accountId: accountId ?? '' }), [accountId])
+  const bip44Params = useAppSelector(state => selectBIP44ParamsByAccountId(state, accountFilter))
 
-  const handleConfirm = async () => {
-    if (!walletState.wallet || !contractAddress || !state?.userAddress || !dispatch) return
+  const handleConfirm = useCallback(async () => {
+    if (!(walletState.wallet && contractAddress && state?.userAddress && dispatch && bip44Params))
+      return
     dispatch({ type: CosmosClaimActionType.SET_LOADING, payload: true })
 
     const { gasLimit, gasPrice } = await getFormFees(asset, feeMarketData.price)
@@ -90,6 +101,7 @@ export const Confirm = ({ onNext }: StepComponentProps) => {
     try {
       const broadcastTxId = await handleStakingAction({
         asset,
+        bip44Params,
         validator: contractAddress,
         chainSpecific: {
           gas: gasLimit,
@@ -111,7 +123,22 @@ export const Confirm = ({ onNext }: StepComponentProps) => {
     } finally {
       dispatch({ type: CosmosClaimActionType.SET_LOADING, payload: false })
     }
-  }
+  }, [
+    asset,
+    bip44Params,
+    claimAmount,
+    contractAddress,
+    dispatch,
+    feeMarketData?.price,
+    handleStakingAction,
+    onNext,
+    state?.userAddress,
+    toast,
+    translate,
+    walletState?.wallet,
+  ])
+
+  if (!state || !dispatch || !asset) return null
 
   const handleBack = history.goBack
 
@@ -135,13 +162,13 @@ export const Confirm = ({ onNext }: StepComponentProps) => {
             <Text translation='defi.modals.claim.claimToAddress' />
           </Row.Label>
           <Row.Value>
-            <Skeleton minWidth='100px' isLoaded={!!state.userAddress}>
+            <Skeleton minWidth='100px' isLoaded={!!state.userAddress && !!accountId}>
               <Link
                 isExternal
                 color='blue.500'
-                href={`${asset?.explorerAddressLink}${state.userAddress}`}
+                href={`${asset?.explorerAddressLink}${accountId ?? state.userAddress}`}
               >
-                {state.userAddress && <MiddleEllipsis value={state.userAddress} />}
+                {state.userAddress && <MiddleEllipsis value={accountId ?? state.userAddress} />}
               </Link>
             </Skeleton>
           </Row.Value>

--- a/src/features/defi/providers/cosmos/components/CosmosManager/CosmosManager.tsx
+++ b/src/features/defi/providers/cosmos/components/CosmosManager/CosmosManager.tsx
@@ -1,9 +1,11 @@
+import type { AccountId } from '@shapeshiftoss/caip'
 import type {
   DefiParams,
   DefiQueryParams,
 } from 'features/defi/contexts/DefiManagerProvider/DefiCommon'
 import { DefiAction } from 'features/defi/contexts/DefiManagerProvider/DefiCommon'
 import { AnimatePresence } from 'framer-motion'
+import { useState } from 'react'
 import { SlideTransition } from 'components/SlideTransition'
 import { useBrowserRouter } from 'hooks/useBrowserRouter/useBrowserRouter'
 
@@ -16,6 +18,8 @@ import { CosmosWithdraw } from './Withdraw/CosmosWithdraw'
 export const CosmosManager = () => {
   const { query, history: browserHistory } = useBrowserRouter<DefiQueryParams, DefiParams>()
   const { modal } = query
+  const [accountId, setAccountId] = useState<AccountId | null>(null)
+
   const handleCancel = () => {
     browserHistory.goBack()
   }
@@ -30,22 +34,22 @@ export const CosmosManager = () => {
 
       {modal === DefiAction.Overview && (
         <SlideTransition key={DefiAction.Overview}>
-          <CosmosOverview />
+          <CosmosOverview accountId={accountId} onAccountIdChange={setAccountId} />
         </SlideTransition>
       )}
       {modal === DefiAction.Deposit && (
         <SlideTransition key={DefiAction.Deposit}>
-          <CosmosDeposit />
+          <CosmosDeposit onAccountIdChange={setAccountId} accountId={accountId} />
         </SlideTransition>
       )}
       {modal === DefiAction.Withdraw && (
         <SlideTransition key={DefiAction.Withdraw}>
-          <CosmosWithdraw />
+          <CosmosWithdraw onAccountIdChange={setAccountId} accountId={accountId} />
         </SlideTransition>
       )}
       {modal === DefiAction.Claim && (
         <SlideTransition key={DefiAction.Claim}>
-          <CosmosClaim />
+          <CosmosClaim accountId={accountId} />
         </SlideTransition>
       )}
     </AnimatePresence>

--- a/src/features/defi/providers/cosmos/components/CosmosManager/CosmosManager.tsx
+++ b/src/features/defi/providers/cosmos/components/CosmosManager/CosmosManager.tsx
@@ -8,6 +8,7 @@ import { AnimatePresence } from 'framer-motion'
 import { useState } from 'react'
 import { SlideTransition } from 'components/SlideTransition'
 import { useBrowserRouter } from 'hooks/useBrowserRouter/useBrowserRouter'
+import type { Nullable } from 'types/common'
 
 import { CosmosClaim } from './Claim/CosmosClaim'
 import { CosmosDeposit } from './Deposit/CosmosDeposit'
@@ -18,7 +19,7 @@ import { CosmosWithdraw } from './Withdraw/CosmosWithdraw'
 export const CosmosManager = () => {
   const { query, history: browserHistory } = useBrowserRouter<DefiQueryParams, DefiParams>()
   const { modal } = query
-  const [accountId, setAccountId] = useState<AccountId | null>(null)
+  const [accountId, setAccountId] = useState<Nullable<AccountId>>(null)
 
   const handleCancel = () => {
     browserHistory.goBack()

--- a/src/features/defi/providers/cosmos/components/CosmosManager/Deposit/CosmosDeposit.tsx
+++ b/src/features/defi/providers/cosmos/components/CosmosManager/Deposit/CosmosDeposit.tsx
@@ -88,7 +88,7 @@ export const CosmosDeposit: React.FC<CosmosDepositProps> = ({
 
         const chainAdapterManager = getChainAdapterManager()
         const chainAdapter = chainAdapterManager.get(chainId)
-        if (!(walletState.wallet && contractAddress && chainAdapter && apr)) return
+        if (!(walletState.wallet && contractAddress && chainAdapter && apr && bip44Params)) return
 
         const address = await chainAdapter.getAddress({ bip44Params, wallet: walletState.wallet })
 

--- a/src/features/defi/providers/cosmos/components/CosmosManager/Deposit/CosmosDeposit.tsx
+++ b/src/features/defi/providers/cosmos/components/CosmosManager/Deposit/CosmosDeposit.tsx
@@ -42,10 +42,15 @@ const moduleLogger = logger.child({
   namespace: ['DeFi', 'Providers', 'Cosmos', 'CosmosDeposit'],
 })
 
-export const CosmosDeposit: React.FC<{
+type CosmosDepositProps = {
   onAccountIdChange: AccountDropdownProps['onChange']
   accountId: AccountId | null
-}> = ({ onAccountIdChange: handleAccountIdChange, accountId }) => {
+}
+
+export const CosmosDeposit: React.FC<CosmosDepositProps> = ({
+  onAccountIdChange: handleAccountIdChange,
+  accountId,
+}) => {
   const translate = useTranslate()
   const [state, dispatch] = useReducer(reducer, initialState)
   const { query, history, location } = useBrowserRouter<DefiQueryParams, DefiParams>()

--- a/src/features/defi/providers/cosmos/components/CosmosManager/Deposit/CosmosDeposit.tsx
+++ b/src/features/defi/providers/cosmos/components/CosmosManager/Deposit/CosmosDeposit.tsx
@@ -30,6 +30,7 @@ import {
   selectValidatorByAddress,
 } from 'state/slices/selectors'
 import { useAppSelector } from 'state/store'
+import type { Nullable } from 'types/common'
 
 import { Confirm } from './components/Confirm'
 import { Deposit } from './components/Deposit'
@@ -44,7 +45,7 @@ const moduleLogger = logger.child({
 
 type CosmosDepositProps = {
   onAccountIdChange: AccountDropdownProps['onChange']
-  accountId: AccountId | null
+  accountId: Nullable<AccountId>
 }
 
 export const CosmosDeposit: React.FC<CosmosDepositProps> = ({

--- a/src/features/defi/providers/cosmos/components/CosmosManager/Deposit/CosmosDeposit.tsx
+++ b/src/features/defi/providers/cosmos/components/CosmosManager/Deposit/CosmosDeposit.tsx
@@ -64,7 +64,7 @@ export const CosmosDeposit: React.FC<{
 
   const apr = useMemo(() => bnOrZero(validatorData?.apr).toString(), [validatorData])
 
-  const opportunities = useCosmosSdkStakingBalances({ assetId })
+  const opportunities = useCosmosSdkStakingBalances({ accountId, assetId })
   const cosmosOpportunity = useMemo(
     () =>
       opportunities?.cosmosSdkStakingOpportunities?.find(

--- a/src/features/defi/providers/cosmos/components/CosmosManager/Deposit/components/Confirm.tsx
+++ b/src/features/defi/providers/cosmos/components/CosmosManager/Deposit/components/Confirm.tsx
@@ -1,4 +1,5 @@
 import { Alert, AlertIcon, Box, Stack, useToast } from '@chakra-ui/react'
+import type { AccountId } from '@shapeshiftoss/caip'
 import { ASSET_REFERENCE, toAssetId } from '@shapeshiftoss/caip'
 import { Confirm as ReusableConfirm } from 'features/defi/components/Confirm/Confirm'
 import { Summary } from 'features/defi/components/Summary'
@@ -10,7 +11,7 @@ import { DefiStep } from 'features/defi/contexts/DefiManagerProvider/DefiCommon'
 import { StakingAction } from 'plugins/cosmos/components/modals/Staking/StakingCommon'
 import { useStakingAction } from 'plugins/cosmos/hooks/useStakingAction/useStakingAction'
 import { getFormFees } from 'plugins/cosmos/utils'
-import { useContext } from 'react'
+import { useCallback, useContext, useMemo } from 'react'
 import { useTranslate } from 'react-polyglot'
 import { Amount } from 'components/Amount/Amount'
 import { AssetIcon } from 'components/AssetIcon'
@@ -23,8 +24,9 @@ import { bnOrZero } from 'lib/bignumber/bignumber'
 import { logger } from 'lib/logger'
 import {
   selectAssetById,
+  selectBIP44ParamsByAccountId,
   selectMarketDataById,
-  selectPortfolioCryptoHumanBalanceByAssetId,
+  selectPortfolioCryptoHumanBalanceByFilter,
 } from 'state/slices/selectors'
 import { useAppSelector } from 'state/store'
 
@@ -35,7 +37,10 @@ const moduleLogger = logger.child({
   namespace: ['DeFi', 'Providers', 'Cosmos', 'Deposit', 'Confirm'],
 })
 
-export const Confirm = ({ onNext }: StepComponentProps) => {
+export const Confirm: React.FC<StepComponentProps & { accountId?: AccountId | null }> = ({
+  onNext,
+  accountId,
+}) => {
   const { state, dispatch } = useContext(DepositContext)
   const translate = useTranslate()
   const { query } = useBrowserRouter<DefiQueryParams, DefiParams>()
@@ -58,18 +63,24 @@ export const Confirm = ({ onNext }: StepComponentProps) => {
   // notify
   const toast = useToast()
 
+  const filter = useMemo(
+    () => ({ assetId: feeAsset?.assetId ?? '', accountId: accountId ?? '' }),
+    [feeAsset?.assetId, accountId],
+  )
   const feeAssetBalance = useAppSelector(state =>
-    selectPortfolioCryptoHumanBalanceByAssetId(state, { assetId: feeAsset?.assetId ?? '' }),
+    selectPortfolioCryptoHumanBalanceByFilter(state, filter),
   )
 
   const marketData = useAppSelector(state => selectMarketDataById(state, assetId))
 
   const { handleStakingAction } = useStakingAction()
 
-  if (!state || !dispatch) return null
+  const accountFilter = useMemo(() => ({ accountId: accountId ?? '' }), [accountId])
+  const bip44Params = useAppSelector(state => selectBIP44ParamsByAccountId(state, accountFilter))
 
-  const handleDeposit = async () => {
-    if (!state.userAddress || !assetReference || !walletState.wallet) return
+  const handleDeposit = useCallback(async () => {
+    if (!(state?.userAddress && dispatch && bip44Params && assetReference && walletState.wallet))
+      return
     dispatch({ type: CosmosDepositActionType.SET_LOADING, payload: true })
 
     const { gasLimit, gasPrice } = await getFormFees(asset, marketData.price)
@@ -77,6 +88,7 @@ export const Confirm = ({ onNext }: StepComponentProps) => {
     try {
       const broadcastTxId = await handleStakingAction({
         asset,
+        bip44Params,
         validator: contractAddress,
         chainSpecific: {
           gas: gasLimit,
@@ -110,7 +122,23 @@ export const Confirm = ({ onNext }: StepComponentProps) => {
       onNext(DefiStep.Status)
       dispatch({ type: CosmosDepositActionType.SET_LOADING, payload: false })
     }
-  }
+  }, [
+    asset,
+    assetReference,
+    bip44Params,
+    contractAddress,
+    dispatch,
+    handleStakingAction,
+    marketData,
+    onNext,
+    state?.deposit.cryptoAmount,
+    state?.userAddress,
+    toast,
+    translate,
+    walletState?.wallet,
+  ])
+
+  if (!state || !dispatch) return null
 
   const hasEnoughBalanceForGas = bnOrZero(feeAssetBalance).gte(
     bnOrZero(state.deposit.cryptoAmount).plus(

--- a/src/features/defi/providers/cosmos/components/CosmosManager/Deposit/components/Confirm.tsx
+++ b/src/features/defi/providers/cosmos/components/CosmosManager/Deposit/components/Confirm.tsx
@@ -29,6 +29,7 @@ import {
   selectPortfolioCryptoHumanBalanceByFilter,
 } from 'state/slices/selectors'
 import { useAppSelector } from 'state/store'
+import type { Nullable } from 'types/common'
 
 import { CosmosDepositActionType } from '../DepositCommon'
 import { DepositContext } from '../DepositContext'
@@ -37,7 +38,7 @@ const moduleLogger = logger.child({
   namespace: ['DeFi', 'Providers', 'Cosmos', 'Deposit', 'Confirm'],
 })
 
-type ConfirmProps = StepComponentProps & { accountId?: AccountId | null }
+type ConfirmProps = StepComponentProps & { accountId?: Nullable<AccountId> }
 
 export const Confirm: React.FC<ConfirmProps> = ({ onNext, accountId }) => {
   const { state, dispatch } = useContext(DepositContext)

--- a/src/features/defi/providers/cosmos/components/CosmosManager/Deposit/components/Confirm.tsx
+++ b/src/features/defi/providers/cosmos/components/CosmosManager/Deposit/components/Confirm.tsx
@@ -37,10 +37,9 @@ const moduleLogger = logger.child({
   namespace: ['DeFi', 'Providers', 'Cosmos', 'Deposit', 'Confirm'],
 })
 
-export const Confirm: React.FC<StepComponentProps & { accountId?: AccountId | null }> = ({
-  onNext,
-  accountId,
-}) => {
+type ConfirmProps = StepComponentProps & { accountId?: AccountId | null }
+
+export const Confirm: React.FC<ConfirmProps> = ({ onNext, accountId }) => {
   const { state, dispatch } = useContext(DepositContext)
   const translate = useTranslate()
   const { query } = useBrowserRouter<DefiQueryParams, DefiParams>()

--- a/src/features/defi/providers/cosmos/components/CosmosManager/Deposit/components/Deposit.tsx
+++ b/src/features/defi/providers/cosmos/components/CosmosManager/Deposit/components/Deposit.tsx
@@ -30,12 +30,16 @@ import { DepositContext } from '../DepositContext'
 
 const moduleLogger = logger.child({ namespace: ['CosmosDeposit:Deposit'] })
 
-export const Deposit: React.FC<
-  StepComponentProps & {
-    accountId: Nullable<AccountId>
-    onAccountIdChange: AccountDropdownProps['onChange']
-  }
-> = ({ onNext, accountId, onAccountIdChange: handleAccountIdChange }) => {
+type DepositProps = StepComponentProps & {
+  accountId: Nullable<AccountId>
+  onAccountIdChange: AccountDropdownProps['onChange']
+}
+
+export const Deposit: React.FC<DepositProps> = ({
+  onNext,
+  accountId,
+  onAccountIdChange: handleAccountIdChange,
+}) => {
   const { state, dispatch } = useContext(DepositContext)
   const history = useHistory()
   const translate = useTranslate()

--- a/src/features/defi/providers/cosmos/components/CosmosManager/Deposit/components/Deposit.tsx
+++ b/src/features/defi/providers/cosmos/components/CosmosManager/Deposit/components/Deposit.tsx
@@ -1,4 +1,5 @@
 import { useToast } from '@chakra-ui/react'
+import type { AccountId } from '@shapeshiftoss/caip'
 import { toAssetId } from '@shapeshiftoss/caip'
 import type { DepositValues } from 'features/defi/components/Deposit/Deposit'
 import { Deposit as ReusableDeposit } from 'features/defi/components/Deposit/Deposit'
@@ -11,6 +12,7 @@ import { getFormFees } from 'plugins/cosmos/utils'
 import { useCallback, useContext, useMemo } from 'react'
 import { useTranslate } from 'react-polyglot'
 import { useHistory } from 'react-router-dom'
+import type { AccountDropdownProps } from 'components/AccountDropdown/AccountDropdown'
 import type { StepComponentProps } from 'components/DeFi/components/Steps'
 import { useBrowserRouter } from 'hooks/useBrowserRouter/useBrowserRouter'
 import { BigNumber, bnOrZero } from 'lib/bignumber/bignumber'
@@ -18,16 +20,22 @@ import { logger } from 'lib/logger'
 import {
   selectAssetById,
   selectMarketDataById,
-  selectPortfolioCryptoBalanceByAssetId,
+  selectPortfolioCryptoBalanceByFilter,
 } from 'state/slices/selectors'
 import { useAppSelector } from 'state/store'
+import type { Nullable } from 'types/common'
 
 import { CosmosDepositActionType } from '../DepositCommon'
 import { DepositContext } from '../DepositContext'
 
 const moduleLogger = logger.child({ namespace: ['CosmosDeposit:Deposit'] })
 
-export const Deposit: React.FC<StepComponentProps> = ({ onNext }) => {
+export const Deposit: React.FC<
+  StepComponentProps & {
+    accountId: Nullable<AccountId>
+    onAccountIdChange: AccountDropdownProps['onChange']
+  }
+> = ({ onNext, accountId, onAccountIdChange: handleAccountIdChange }) => {
   const { state, dispatch } = useContext(DepositContext)
   const history = useHistory()
   const translate = useTranslate()
@@ -42,7 +50,8 @@ export const Deposit: React.FC<StepComponentProps> = ({ onNext }) => {
   const opportunity = useMemo(() => state?.cosmosOpportunity, [state])
 
   // user info
-  const balance = useAppSelector(state => selectPortfolioCryptoBalanceByAssetId(state, { assetId }))
+  const filter = useMemo(() => ({ assetId, accountId: accountId ?? '' }), [assetId, accountId])
+  const balance = useAppSelector(state => selectPortfolioCryptoBalanceByFilter(state, filter))
 
   // notify
   const toast = useToast()
@@ -124,6 +133,8 @@ export const Deposit: React.FC<StepComponentProps> = ({ onNext }) => {
 
   return (
     <ReusableDeposit
+      accountId={accountId}
+      onAccountIdChange={handleAccountIdChange}
       asset={asset}
       isLoading={state.loading}
       apy={String(opportunity?.apr)}

--- a/src/features/defi/providers/cosmos/components/CosmosManager/Overview/CosmosOverview.tsx
+++ b/src/features/defi/providers/cosmos/components/CosmosManager/Overview/CosmosOverview.tsx
@@ -1,5 +1,6 @@
 import { ArrowDownIcon, ArrowUpIcon } from '@chakra-ui/icons'
 import { Center } from '@chakra-ui/react'
+import type { AccountId } from '@shapeshiftoss/caip'
 import { cosmosChainId, osmosisChainId, toAssetId } from '@shapeshiftoss/caip'
 import { supportsCosmos, supportsOsmosis } from '@shapeshiftoss/hdwallet-core'
 import { DefiModalContent } from 'features/defi/components/DefiModal/DefiModalContent'
@@ -13,6 +14,7 @@ import qs from 'qs'
 import { useMemo } from 'react'
 import { FaGift } from 'react-icons/fa'
 import { useTranslate } from 'react-polyglot'
+import type { AccountDropdownProps } from 'components/AccountDropdown/AccountDropdown'
 import { CircularProgress } from 'components/CircularProgress/CircularProgress'
 import { useBrowserRouter } from 'hooks/useBrowserRouter/useBrowserRouter'
 import { useWallet } from 'hooks/useWallet/useWallet'
@@ -29,11 +31,15 @@ import {
 } from 'state/slices/selectors'
 import { getDefaultValidatorAddressFromAssetId } from 'state/slices/validatorDataSlice/utils'
 import { useAppSelector } from 'state/store'
+import type { Nullable } from 'types/common'
 
 import { CosmosEmpty } from './CosmosEmpty'
 import { WithdrawCard } from './WithdrawCard'
 
-export const CosmosOverview = () => {
+export const CosmosOverview: React.FC<{
+  accountId: Nullable<AccountId>
+  onAccountIdChange: AccountDropdownProps['onChange']
+}> = ({ accountId, onAccountIdChange: handleAccountIdChange }) => {
   const translate = useTranslate()
   const { query, history, location } = useBrowserRouter<DefiQueryParams, DefiParams>()
   const { chainId, contractAddress, assetReference } = query
@@ -73,13 +79,14 @@ export const CosmosOverview = () => {
 
   const stakingAsset = useAppSelector(state => selectAssetById(state, stakingAssetId))
 
+  // TODO: Remove - currently, we need this to fire the first onChange() in `<AccountDropdown />`
   const accountSpecifier = useAppSelector(state =>
     selectFirstAccountSpecifierByChainId(state, stakingAsset?.chainId),
   )
 
   const totalBondings = useAppSelector(state =>
     selectTotalBondingsBalanceByAssetId(state, {
-      accountSpecifier,
+      accountSpecifier: accountId ?? accountSpecifier,
       validatorAddress: contractAddress,
       assetId: stakingAsset.assetId,
     }),
@@ -146,6 +153,8 @@ export const CosmosOverview = () => {
 
   return (
     <Overview
+      accountId={accountId}
+      onAccountIdChange={handleAccountIdChange}
       asset={stakingAsset}
       name={opportunity.moniker}
       opportunityFiatBalance={fiatAmountAvailable.toFixed(2)}
@@ -186,7 +195,7 @@ export const CosmosOverview = () => {
       tvl={bnOrZero(opportunity.tvl).toFixed(2)}
       apy={apr?.toString()}
     >
-      <WithdrawCard asset={stakingAsset} />
+      <WithdrawCard accountId={accountId} asset={stakingAsset} />
     </Overview>
   )
 }

--- a/src/features/defi/providers/cosmos/components/CosmosManager/Overview/CosmosOverview.tsx
+++ b/src/features/defi/providers/cosmos/components/CosmosManager/Overview/CosmosOverview.tsx
@@ -36,10 +36,15 @@ import type { Nullable } from 'types/common'
 import { CosmosEmpty } from './CosmosEmpty'
 import { WithdrawCard } from './WithdrawCard'
 
-export const CosmosOverview: React.FC<{
+type CosmosOverviewProps = {
   accountId: Nullable<AccountId>
   onAccountIdChange: AccountDropdownProps['onChange']
-}> = ({ accountId, onAccountIdChange: handleAccountIdChange }) => {
+}
+
+export const CosmosOverview: React.FC<CosmosOverviewProps> = ({
+  accountId,
+  onAccountIdChange: handleAccountIdChange,
+}) => {
   const translate = useTranslate()
   const { query, history, location } = useBrowserRouter<DefiQueryParams, DefiParams>()
   const { chainId, contractAddress, assetReference } = query

--- a/src/features/defi/providers/cosmos/components/CosmosManager/Overview/CosmosOverview.tsx
+++ b/src/features/defi/providers/cosmos/components/CosmosManager/Overview/CosmosOverview.tsx
@@ -63,6 +63,7 @@ export const CosmosOverview: React.FC<{
   }, [chainId, wallet])
 
   const opportunities = useCosmosSdkStakingBalances({
+    accountId,
     assetId: stakingAssetId,
     supportsCosmosSdk,
   })

--- a/src/features/defi/providers/cosmos/components/CosmosManager/Overview/CosmosOverview.tsx
+++ b/src/features/defi/providers/cosmos/components/CosmosManager/Overview/CosmosOverview.tsx
@@ -42,12 +42,17 @@ type CosmosOverviewProps = {
 }
 
 export const CosmosOverview: React.FC<CosmosOverviewProps> = ({
-  accountId,
+  accountId: defaultAccountId,
   onAccountIdChange: handleAccountIdChange,
 }) => {
   const translate = useTranslate()
   const { query, history, location } = useBrowserRouter<DefiQueryParams, DefiParams>()
-  const { chainId, contractAddress, assetReference } = query
+  const { defaultAccountId: queryAccountId, chainId, contractAddress, assetReference } = query
+
+  const accountId = useMemo(
+    () => defaultAccountId ?? queryAccountId,
+    [defaultAccountId, queryAccountId],
+  )
 
   const assetNamespace = 'slip44'
   const stakingAssetId = toAssetId({

--- a/src/features/defi/providers/cosmos/components/CosmosManager/Overview/WithdrawCard.tsx
+++ b/src/features/defi/providers/cosmos/components/CosmosManager/Overview/WithdrawCard.tsx
@@ -1,5 +1,6 @@
 import { Button, Stack, useColorModeValue } from '@chakra-ui/react'
 import type { Asset } from '@shapeshiftoss/asset-service'
+import type { AccountId } from '@shapeshiftoss/caip'
 import dayjs from 'dayjs'
 import type {
   DefiParams,
@@ -17,12 +18,14 @@ import {
   selectUnbondingEntriesByAccountSpecifier,
 } from 'state/slices/selectors'
 import { useAppSelector } from 'state/store'
+import type { Nullable } from 'types/common'
 
 type WithdrawCardProps = {
   asset: Asset
+  accountId?: Nullable<AccountId>
 }
 
-export const WithdrawCard = ({ asset }: WithdrawCardProps) => {
+export const WithdrawCard = ({ asset, accountId }: WithdrawCardProps) => {
   const { query } = useBrowserRouter<DefiQueryParams, DefiParams>()
   const { contractAddress } = query
 
@@ -30,9 +33,10 @@ export const WithdrawCard = ({ asset }: WithdrawCardProps) => {
     selectFirstAccountSpecifierByChainId(state, asset?.chainId),
   )
 
+  // TODO: Remove - currently, we need this to fire the first onChange() in `<AccountDropdown />`
   const undelegationEntries = useAppSelector(state =>
     selectUnbondingEntriesByAccountSpecifier(state, {
-      accountSpecifier,
+      accountSpecifier: accountId ?? accountSpecifier,
       validatorAddress: contractAddress,
       assetId: asset.assetId,
     }),

--- a/src/features/defi/providers/cosmos/components/CosmosManager/Withdraw/CosmosWithdraw.tsx
+++ b/src/features/defi/providers/cosmos/components/CosmosManager/Withdraw/CosmosWithdraw.tsx
@@ -39,10 +39,14 @@ const moduleLogger = logger.child({
   namespace: ['DeFi', 'Providers', 'Cosmos', 'CosmosWithdraw'],
 })
 
-export const CosmosWithdraw: React.FC<{
-  onAccountIdChange: AccountDropdownProps['onChange']
+type CosmosWithdrawProps = {
   accountId: AccountId | null
-}> = ({ onAccountIdChange: handleAccountIdChange, accountId }) => {
+  onAccountIdChange: AccountDropdownProps['onChange']
+}
+export const CosmosWithdraw: React.FC<CosmosWithdrawProps> = ({
+  onAccountIdChange: handleAccountIdChange,
+  accountId,
+}) => {
   const translate = useTranslate()
   const [state, dispatch] = useReducer(reducer, initialState)
   const { query, history, location } = useBrowserRouter<DefiQueryParams, DefiParams>()

--- a/src/features/defi/providers/cosmos/components/CosmosManager/Withdraw/CosmosWithdraw.tsx
+++ b/src/features/defi/providers/cosmos/components/CosmosManager/Withdraw/CosmosWithdraw.tsx
@@ -76,7 +76,7 @@ export const CosmosWithdraw: React.FC<{
   const chainAdapter = chainAdapterManager.get(chainId)
   const { state: walletState } = useWallet()
 
-  const opportunities = useCosmosSdkStakingBalances({ assetId })
+  const opportunities = useCosmosSdkStakingBalances({ accountId, assetId })
   const cosmosOpportunity = useMemo(
     () =>
       opportunities?.cosmosSdkStakingOpportunities?.find(

--- a/src/features/defi/providers/cosmos/components/CosmosManager/Withdraw/CosmosWithdraw.tsx
+++ b/src/features/defi/providers/cosmos/components/CosmosManager/Withdraw/CosmosWithdraw.tsx
@@ -27,6 +27,7 @@ import {
   selectMarketDataById,
 } from 'state/slices/selectors'
 import { useAppSelector } from 'state/store'
+import type { Nullable } from 'types/common'
 
 import { Confirm } from './components/Confirm'
 import { Status } from './components/Status'
@@ -40,7 +41,7 @@ const moduleLogger = logger.child({
 })
 
 type CosmosWithdrawProps = {
-  accountId: AccountId | null
+  accountId: Nullable<AccountId>
   onAccountIdChange: AccountDropdownProps['onChange']
 }
 export const CosmosWithdraw: React.FC<CosmosWithdrawProps> = ({

--- a/src/features/defi/providers/cosmos/components/CosmosManager/Withdraw/components/Confirm.tsx
+++ b/src/features/defi/providers/cosmos/components/CosmosManager/Withdraw/components/Confirm.tsx
@@ -40,10 +40,9 @@ const moduleLogger = logger.child({
   namespace: ['DeFi', 'Providers', 'Cosmos', 'Withdraw', 'Confirm'],
 })
 
-export const Confirm: React.FC<StepComponentProps & { accountId: AccountId | null }> = ({
-  onNext,
-  accountId,
-}) => {
+type ConfirmProps = StepComponentProps & { accountId: AccountId | null }
+
+export const Confirm: React.FC<ConfirmProps> = ({ onNext, accountId }) => {
   const [gasLimit, setGasLimit] = useState<string | null>(null)
   const [gasPrice, setGasPrice] = useState<string | null>(null)
   const { state, dispatch } = useContext(WithdrawContext)

--- a/src/features/defi/providers/cosmos/components/CosmosManager/Withdraw/components/Withdraw.tsx
+++ b/src/features/defi/providers/cosmos/components/CosmosManager/Withdraw/components/Withdraw.tsx
@@ -35,12 +35,15 @@ export type CosmosWithdrawValues = {
 
 const moduleLogger = logger.child({ namespace: ['CosmosWithdraw:Withdraw'] })
 
-export const Withdraw: React.FC<
-  StepComponentProps & {
-    accountId: AccountId | null
-    onAccountIdChange: AccountDropdownProps['onChange']
-  }
-> = ({ accountId, onAccountIdChange: handleAccountIdChange, onNext }) => {
+type WithdrawProps = StepComponentProps & {
+  accountId: AccountId | null
+  onAccountIdChange: AccountDropdownProps['onChange']
+}
+export const Withdraw: React.FC<WithdrawProps> = ({
+  accountId,
+  onAccountIdChange: handleAccountIdChange,
+  onNext,
+}) => {
   const { state, dispatch } = useContext(WithdrawContext)
   const translate = useTranslate()
   const { query, history: browserHistory } = useBrowserRouter<DefiQueryParams, DefiParams>()

--- a/src/features/defi/providers/cosmos/components/CosmosManager/Withdraw/components/Withdraw.tsx
+++ b/src/features/defi/providers/cosmos/components/CosmosManager/Withdraw/components/Withdraw.tsx
@@ -25,6 +25,7 @@ import {
   selectMarketDataById,
 } from 'state/slices/selectors'
 import { useAppSelector } from 'state/store'
+import type { Nullable } from 'types/common'
 
 import { CosmosWithdrawActionType } from '../WithdrawCommon'
 import { WithdrawContext } from '../WithdrawContext'
@@ -36,7 +37,7 @@ export type CosmosWithdrawValues = {
 const moduleLogger = logger.child({ namespace: ['CosmosWithdraw:Withdraw'] })
 
 type WithdrawProps = StepComponentProps & {
-  accountId: AccountId | null
+  accountId: Nullable<AccountId>
   onAccountIdChange: AccountDropdownProps['onChange']
 }
 export const Withdraw: React.FC<WithdrawProps> = ({

--- a/src/features/defi/providers/cosmos/components/CosmosManager/Withdraw/components/Withdraw.tsx
+++ b/src/features/defi/providers/cosmos/components/CosmosManager/Withdraw/components/Withdraw.tsx
@@ -1,4 +1,5 @@
 import { useToast } from '@chakra-ui/react'
+import type { AccountId } from '@shapeshiftoss/caip'
 import { toAssetId } from '@shapeshiftoss/caip'
 import { WithdrawType } from '@shapeshiftoss/types'
 import type { WithdrawValues } from 'features/defi/components/Withdraw/Withdraw'
@@ -12,6 +13,7 @@ import { getFormFees } from 'plugins/cosmos/utils'
 import { useCallback, useContext } from 'react'
 import { FormProvider, useForm } from 'react-hook-form'
 import { useTranslate } from 'react-polyglot'
+import type { AccountDropdownProps } from 'components/AccountDropdown/AccountDropdown'
 import type { StepComponentProps } from 'components/DeFi/components/Steps'
 import { useBrowserRouter } from 'hooks/useBrowserRouter/useBrowserRouter'
 import { BigNumber, bn, bnOrZero } from 'lib/bignumber/bignumber'
@@ -33,7 +35,12 @@ export type CosmosWithdrawValues = {
 
 const moduleLogger = logger.child({ namespace: ['CosmosWithdraw:Withdraw'] })
 
-export const Withdraw: React.FC<StepComponentProps> = ({ onNext }) => {
+export const Withdraw: React.FC<
+  StepComponentProps & {
+    accountId: AccountId | null
+    onAccountIdChange: AccountDropdownProps['onChange']
+  }
+> = ({ accountId, onAccountIdChange: handleAccountIdChange, onNext }) => {
   const { state, dispatch } = useContext(WithdrawContext)
   const translate = useTranslate()
   const { query, history: browserHistory } = useBrowserRouter<DefiQueryParams, DefiParams>()
@@ -67,9 +74,10 @@ export const Withdraw: React.FC<StepComponentProps> = ({ onNext }) => {
     selectFirstAccountSpecifierByChainId(state, asset?.chainId),
   )
 
+  // TODO: Remove - currently, we need this to fire the first onChange() in `<AccountDropdown />`
   const cryptoStakeBalance = useAppSelector(state =>
     selectDelegationCryptoAmountByAssetIdAndValidator(state, {
-      accountSpecifier,
+      accountSpecifier: accountId ?? accountSpecifier,
       validatorAddress: contractAddress,
       assetId,
     }),
@@ -189,6 +197,8 @@ export const Withdraw: React.FC<StepComponentProps> = ({ onNext }) => {
   return (
     <FormProvider {...methods}>
       <ReusableWithdraw
+        accountId={accountId}
+        onAccountIdChange={handleAccountIdChange}
         asset={stakingAsset}
         cryptoAmountAvailable={cryptoStakeBalanceHuman.toString()}
         cryptoInputValidation={{

--- a/src/pages/Defi/hooks/useCosmosSdkStakingBalances.tsx
+++ b/src/pages/Defi/hooks/useCosmosSdkStakingBalances.tsx
@@ -1,4 +1,4 @@
-import type { AssetId, ChainId } from '@shapeshiftoss/caip'
+import type { AccountId, AssetId, ChainId } from '@shapeshiftoss/caip'
 import type { cosmos } from '@shapeshiftoss/unchained-client'
 import { useMemo } from 'react'
 import type { BigNumber } from 'lib/bignumber/bignumber'
@@ -12,8 +12,10 @@ import {
 } from 'state/slices/selectors'
 import { getDefaultValidatorAddressFromAssetId } from 'state/slices/validatorDataSlice/utils'
 import { useAppSelector } from 'state/store'
+import type { Nullable } from 'types/common'
 
 type UseCosmosStakingBalancesProps = {
+  accountId?: Nullable<AccountId>
   assetId: AssetId
   supportsCosmosSdk?: boolean
 }
@@ -40,11 +42,13 @@ export type MergedStakingOpportunity = cosmos.Validator & {
 
 export function useCosmosSdkStakingBalances({
   assetId,
+  accountId,
   supportsCosmosSdk = true,
 }: UseCosmosStakingBalancesProps): UseCosmosStakingBalancesReturn {
   const marketData = useAppSelector(state => selectMarketDataById(state, assetId))
   const asset = useAppSelector(state => selectAssetById(state, assetId))
 
+  // TODO: Remove - currently, we need this to fire the first onChange() in `<AccountDropdown />`
   const accountSpecifier = useAppSelector(state =>
     selectFirstAccountSpecifierByChainId(state, asset?.chainId),
   )
@@ -55,7 +59,7 @@ export function useCosmosSdkStakingBalances({
   )
   const stakingOpportunities = useAppSelector(state =>
     selectStakingOpportunitiesDataFull(state, {
-      accountSpecifier: supportsCosmosSdk ? accountSpecifier : defaultAccountSpecifier,
+      accountSpecifier: supportsCosmosSdk ? accountId ?? accountSpecifier : defaultAccountSpecifier,
       assetId,
       supportsCosmosSdk,
     }),

--- a/src/plugins/cosmos/hooks/useStakingAction/useStakingAction.tsx
+++ b/src/plugins/cosmos/hooks/useStakingAction/useStakingAction.tsx
@@ -45,7 +45,7 @@ export const useStakingAction = () => {
   const handleStakingAction = async (data: StakingInput) => {
     const { bip44Params, chainSpecific, validator, action, value, asset } = data
 
-    if (!wallet) return
+    if (!(wallet && bip44Params)) return
 
     try {
       // Native and KeepKey hdwallets only support offline signing, not broadcasting signed TXs like e.g Metamask

--- a/src/plugins/cosmos/hooks/useStakingAction/useStakingAction.tsx
+++ b/src/plugins/cosmos/hooks/useStakingAction/useStakingAction.tsx
@@ -1,5 +1,6 @@
 import type { Asset } from '@shapeshiftoss/asset-service'
 import type { cosmossdk } from '@shapeshiftoss/chain-adapters'
+import type { BIP44Params } from '@shapeshiftoss/types'
 import {
   isStakingChainAdapter,
   StakingAction,
@@ -19,21 +20,21 @@ const shapeshiftValidators = [
   SHAPESHIFT_OSMOSIS_VALIDATOR_ADDRESS,
 ]
 
-type StakingInput =
+type StakingInput = {
+  asset: Asset
+  chainSpecific: cosmossdk.BuildTxInput
+  validator: string
+  bip44Params: BIP44Params
+} & (
   | {
-      asset: Asset
-      chainSpecific: cosmossdk.BuildTxInput
-      validator: string
       action: StakingAction.Claim
       value?: string
     }
   | {
-      asset: Asset
-      chainSpecific: cosmossdk.BuildTxInput
-      validator: string
       action: StakingAction.Stake | StakingAction.Unstake
       value: string
     }
+)
 
 export const useStakingAction = () => {
   const chainAdapterManager = getChainAdapterManager()
@@ -42,7 +43,7 @@ export const useStakingAction = () => {
   } = useWallet()
 
   const handleStakingAction = async (data: StakingInput) => {
-    const { chainSpecific, validator, action, value, asset } = data
+    const { bip44Params, chainSpecific, validator, action, value, asset } = data
 
     if (!wallet) return
 
@@ -66,6 +67,7 @@ export const useStakingAction = () => {
         switch (action) {
           case StakingAction.Claim:
             return adapter.buildClaimRewardsTransaction({
+              bip44Params,
               wallet,
               validator,
               chainSpecific,
@@ -73,6 +75,7 @@ export const useStakingAction = () => {
             })
           case StakingAction.Stake:
             return adapter.buildDelegateTransaction({
+              bip44Params,
               wallet,
               validator,
               value,
@@ -81,6 +84,7 @@ export const useStakingAction = () => {
             })
           case StakingAction.Unstake:
             return adapter.buildUndelegateTransaction({
+              bip44Params,
               wallet,
               validator,
               value,


### PR DESCRIPTION
## Description

- [x] Overview account selection
- [x] Deposit account selection across all steps
- [x] Withdraw account selection
- [x] Broadcast deposits/withdraws Txs from the selected account
- [x] Available amounts staked in overview / available to deposit/withdraw are matching the ones for the account
- [x] Claim amount for the selected account
- [x] Regression test with the flag off
- [ ] FOUC on deposit/withdraw modals - investigate reconciliation of `<AccountDropdown />`
- [ ] ~~Confirm Osmosis is working~~ - not for this PR since Osmosis multi account isn't properly working currently
- [ ] ~~Deep-linking - use query state instead of props drilling?~~ TBD in https://github.com/shapeshift/web/issues/2615

## Notice

<!-- Before submitting a pull request, please make sure you have answered the following: -->

- [x] Have you followed the guidelines in our [Contributing]('https://github.com/shapeshift/web/blob/develop/CONTRIBUTING.md) guide?
- [x] Have you checked to ensure there aren't other open [Pull Requests](https://github.com/shapeshift/web/pulls) for the same update/change?

## Pull Request Type

- [ ] :bug: Bug fix (Non-breaking Change: Fixes an issue)
- [ ] :hammer_and_wrench: Chore (Non-breaking Change: Doc updates, pkg upgrades, typos, etc..)
- [x] :nail_care: New Feature (Breaking/Non-breaking Change)

## Issue (if applicable)

closes https://github.com/shapeshift/web/issues/2606

## Risk

Full regression test needed with the flag off, logic has been revamped to account for multi-account.

## Testing

#### With the `MultiAccounts` flag on

- Add a Cosmos account and send some ATOM to it
- Open the Cosmos overview modal for a validator you're currently delegating to on account #0, select account #1 and click "Deposit"
- Notice account #1 is pre-selected at Deposit step, with the right amount to deposit 
- Deposit some ATOM - ATOM should be deposited from account #1
- Disconnect and reconnect wallet, then reopen the Cosmos overview modal and select withdraw with account #1 selected
- Notice account #1 is pre-selected at Withdraw step, with the right amount available to withdraw
- Withdraw some ATOM - ATOM should be withdrawn from account #1
- Disconnect and reconnect wallet, then reopen the Cosmos overview modal with account #1 selected and notice the undelegation is shown in the unstaking list
- Click "Claim" and notice the claim is TBD from account #1, with the right amount to claim (most likely 0 because of the precision we use, if you try a few blocks later you should see some actual displayed amount - confirmed through console debugging the amount to claim is correct)
- Claim should go through from account #1


### Engineering

- Refer to top-level testing steps

<!-----------------------------------------------------------------------------
Include sufficient information here for an engineer to test your PR. This may include how to test locally, in a built environment, changes to infrastructure etc.
------------------------------------------------------------------------------>

### Operations

- Refer to top-level testing steps
- Regression test with the `MultiAccounts` flag off, making sure to disconnect and reconnect your native wallet when turning the flag on and off.

<!-----------------------------------------------------------------------------
If your changes have a user-facing impact, describe how a non-technical QA team can functionally test your changes in a preview environment.

If they are not user-facing please describe how to test for any regressions that may occur.
------------------------------------------------------------------------------>

## Screenshots (if applicable)

#### No account added

<img width="530" alt="image" src="https://user-images.githubusercontent.com/17035424/189914262-67962687-f2b4-4e7c-aedc-d345802ca427.png">
<img width="538" alt="image" src="https://user-images.githubusercontent.com/17035424/189914312-0e24efca-3ece-4e1a-91c8-a8c858e2008c.png">
<img width="527" alt="image" src="https://user-images.githubusercontent.com/17035424/189914363-50c3f626-6f28-40dd-ba4a-5abdfc48d895.png">

#### Second Cosmos account added

<img width="528" alt="image" src="https://user-images.githubusercontent.com/17035424/189914534-838a1cae-5f9e-48b3-b235-cdc53fb517b7.png">
<img width="541" alt="image" src="https://user-images.githubusercontent.com/17035424/189914590-248617a7-655d-43ea-b28b-8a61b53f028c.png">
<img width="530" alt="image" src="https://user-images.githubusercontent.com/17035424/189914685-e1cede77-55ce-43e1-86e1-b878c481cb75.png">
<img width="529" alt="image" src="https://user-images.githubusercontent.com/17035424/189914715-1e5aeeb6-0740-4193-bb48-6d8760ffcf93.png">