### PR TITLE
fix: mobile styles

### DIFF
--- a/src/components/AssetHeader/AssetDescription.tsx
+++ b/src/components/AssetHeader/AssetDescription.tsx
@@ -23,7 +23,7 @@ export const AssetDescription = ({ assetId }: AssetDescriptionProps) => {
 
   return (
     <Card>
-      <Card.Footer>
+      <Card.Body>
         <Skeleton isLoaded={isLoaded} size='md'>
           <Card.Heading mb={4}>
             {translate('assets.assetDetails.assetHeader.aboutAsset', { asset: name })}
@@ -34,7 +34,7 @@ export const AssetDescription = ({ assetId }: AssetDescriptionProps) => {
           isLoaded={isLoaded}
           isTrustedDescription={isTrustedDescription}
         />
-      </Card.Footer>
+      </Card.Body>
     </Card>
   )
 }

--- a/src/components/Card/Card.theme.ts
+++ b/src/components/Card/Card.theme.ts
@@ -16,7 +16,10 @@ export const CardStyle = {
   sizes: {
     md: {
       header: {
-        px: 6,
+        px: {
+          base: 4,
+          md: 6,
+        },
         py: 4,
       },
       heading: {
@@ -25,7 +28,10 @@ export const CardStyle = {
       },
       body: {
         py: 4,
-        px: 6,
+        px: {
+          base: 4,
+          md: 6,
+        },
       },
       footer: {
         py: 4,

--- a/src/components/Delegate/StakingOpportunities.tsx
+++ b/src/components/Delegate/StakingOpportunities.tsx
@@ -1,5 +1,5 @@
 import { ArrowForwardIcon } from '@chakra-ui/icons'
-import { Box, Button, Flex, HStack, Skeleton, Tag, TagLabel } from '@chakra-ui/react'
+import { Box, Button, Flex, HStack, Skeleton, Stack, Tag, TagLabel } from '@chakra-ui/react'
 import type { AssetId, ChainId } from '@shapeshiftoss/caip'
 import { cosmosChainId, fromAssetId, osmosisChainId } from '@shapeshiftoss/caip'
 import { chainIdToLabel } from 'features/defi/helpers/utils'
@@ -33,6 +33,7 @@ type ValidatorNameProps = {
   moniker: string
   isStaking: boolean
   validatorAddress: string
+  apr?: string
 }
 
 export const ValidatorName = ({
@@ -40,6 +41,7 @@ export const ValidatorName = ({
   isStaking,
   validatorAddress,
   chainId,
+  apr,
 }: ValidatorNameProps) => {
   const assetIcon = useMemo(() => {
     if (!isStaking) return 'https://assets.coincap.io/assets/icons/256/atom.png'
@@ -60,15 +62,19 @@ export const ValidatorName = ({
 
   return (
     <Box cursor='pointer'>
-      <Flex alignItems='center' maxWidth='180px' mr={'-20px'}>
-        <AssetIcon mr={8} src={assetIcon} boxSize='8' />
-        {isStaking ? (
-          <Tag colorScheme='blue'>
-            <TagLabel>{moniker}</TagLabel>
-          </Tag>
-        ) : (
+      <Flex alignItems='center' maxWidth='180px' gap={4}>
+        <AssetIcon src={assetIcon} boxSize='8' />
+        <Stack spacing={2} alignItems='flex-start'>
           <RawText fontWeight='bold'>{`${moniker}`}</RawText>
-        )}
+          {apr && (
+            <AprTag
+              display={{ base: 'inline-flex', md: 'none' }}
+              size='sm'
+              percentage={apr}
+              showAprSuffix
+            />
+          )}
+        </Stack>
       </Flex>
     </Box>
   )
@@ -126,6 +132,7 @@ export const StakingOpportunities = ({ assetId }: StakingOpportunitiesProps) => 
                 moniker={validator?.moniker}
                 isStaking={true}
                 chainId={asset?.chainId}
+                apr={validator?.apr}
               />
             </Skeleton>
           )
@@ -135,7 +142,7 @@ export const StakingOpportunities = ({ assetId }: StakingOpportunitiesProps) => 
       {
         Header: <Text translation='defi.apr' />,
         id: 'apr',
-        display: { base: 'table-cell' },
+        display: { base: 'none', md: 'table-cell' },
         Cell: ({ row }: { row: { original: OpportunitiesDataFull } }) => {
           const validator = row.original
           return (

--- a/src/components/Delegate/StakingOpportunities.tsx
+++ b/src/components/Delegate/StakingOpportunities.tsx
@@ -1,5 +1,5 @@
 import { ArrowForwardIcon } from '@chakra-ui/icons'
-import { Box, Button, Flex, HStack, Skeleton, Stack, Tag, TagLabel } from '@chakra-ui/react'
+import { Box, Button, Flex, HStack, Skeleton, Stack } from '@chakra-ui/react'
 import type { AssetId, ChainId } from '@shapeshiftoss/caip'
 import { cosmosChainId, fromAssetId, osmosisChainId } from '@shapeshiftoss/caip'
 import { chainIdToLabel } from 'features/defi/helpers/utils'

--- a/src/components/Layout/Header/NavBar/Native/BackupPassphraseModal/BackupPassphraseInfo.tsx
+++ b/src/components/Layout/Header/NavBar/Native/BackupPassphraseModal/BackupPassphraseInfo.tsx
@@ -54,7 +54,8 @@ export const BackupPassphraseInfo = ({ vault }: { vault: Vault | null }) => {
           (await vault.unwrap().get('#mnemonic')).split(' ').map((word: string, index: number) => (
             <Tag
               p={2}
-              flexBasis='31%'
+              flexGrow={4}
+              flexBasis='auto'
               justifyContent='flex-start'
               fontSize='md'
               key={index}
@@ -76,7 +77,8 @@ export const BackupPassphraseInfo = ({ vault }: { vault: Vault | null }) => {
     return range(1, 13).map(i => (
       <Tag
         p={2}
-        flexBasis='31%'
+        flexGrow={4}
+        flexBasis='auto'
         justifyContent='flex-start'
         fontSize='md'
         colorScheme='blue'

--- a/src/components/Layout/Header/NavBar/Native/BackupPassphraseModal/BackupPassphraseModal.tsx
+++ b/src/components/Layout/Header/NavBar/Native/BackupPassphraseModal/BackupPassphraseModal.tsx
@@ -37,7 +37,7 @@ export const BackupPassphraseModal: React.FC<BackupPassphraseModalProps> = ({ pr
       onClose={handleClose}
     >
       <ModalOverlay />
-      <ModalContent justifyContent='center' pt={3} pb={6}>
+      <ModalContent justifyContent='center' px={{ base: 0, md: 4 }} pt={3} pb={6}>
         <MemoryRouter initialEntries={entries}>
           <Switch>
             <Route path='/'>

--- a/src/components/Layout/Header/NavBar/Native/BackupPassphraseModal/BackupPassphraseModal.tsx
+++ b/src/components/Layout/Header/NavBar/Native/BackupPassphraseModal/BackupPassphraseModal.tsx
@@ -37,7 +37,7 @@ export const BackupPassphraseModal: React.FC<BackupPassphraseModalProps> = ({ pr
       onClose={handleClose}
     >
       <ModalOverlay />
-      <ModalContent justifyContent='center' px={3} pt={3} pb={6}>
+      <ModalContent justifyContent='center' pt={3} pb={6}>
         <MemoryRouter initialEntries={entries}>
           <Switch>
             <Route path='/'>

--- a/src/components/Layout/Header/NavBar/Native/BackupPassphraseModal/BackupPassphraseTest.tsx
+++ b/src/components/Layout/Header/NavBar/Native/BackupPassphraseModal/BackupPassphraseTest.tsx
@@ -160,8 +160,8 @@ export const BackupPassphraseTest = ({ vault }: { vault: Vault | null }) => {
               revocable(
                 <Button
                   key={index}
-                  flex='1'
-                  minW='30%'
+                  flexGrow={4}
+                  flexBasis='auto'
                   variant='ghost-filled'
                   colorScheme='blue'
                   onClick={() => handleClick(index)}

--- a/src/components/NestedList.tsx
+++ b/src/components/NestedList.tsx
@@ -7,8 +7,8 @@ export const NestedList = forwardRef<ListProps, 'div'>((props, ref) => {
   return (
     <List
       px={{ base: 2, md: 4 }}
-      ml={{ base: 6, md: 8 }}
-      borderLeftWidth={1}
+      ml={{ base: 2, md: 8 }}
+      borderLeftWidth={{ base: 0, md: 1 }}
       borderColor={borderColor}
       ref={ref}
       {...props}

--- a/src/components/StakingVaults/StakingTable.tsx
+++ b/src/components/StakingVaults/StakingTable.tsx
@@ -64,7 +64,7 @@ export const StakingTable = ({ data, onClick, showTeaser }: StakingTableProps) =
         isNumeric: true,
         Cell: ({ value, row }: { value: string | number | undefined; row: RowProps }) => (
           <Skeleton isLoaded={row.original.isLoaded}>
-            <Tag size={{ base: 'sm', md: 'md' }}>
+            <Tag size={{ base: 'sm', md: 'md' }} colorScheme='green'>
               <Amount.Percent autoColor value={value ?? ''} />
             </Tag>
           </Skeleton>

--- a/src/components/TransactionHistoryRows/TransactionDate.tsx
+++ b/src/components/TransactionHistoryRows/TransactionDate.tsx
@@ -13,7 +13,7 @@ export const TransactionDate = ({ blockTime }: { blockTime: number }) => {
       color='gray.700'
       lineHeight='taller'
       whiteSpace='nowrap'
-      px={4}
+      px={{ base: 2, md: 4 }}
     >
       {dayjs(blockTime * 1000)
         .locale(selectedLocale)

--- a/src/components/TransactionHistoryRows/TransactionGenericRow.tsx
+++ b/src/components/TransactionHistoryRows/TransactionGenericRow.tsx
@@ -121,7 +121,7 @@ export const TransactionGenericRow = ({
       fontWeight='inherit'
       variant='unstyled'
       w='full'
-      p={4}
+      p={{ base: 2, md: 4 }}
       onClick={() => toggleOpen()}
     >
       <SimpleGrid

--- a/src/context/WalletProvider/NativeWallet/components/NativeTestPhrase.tsx
+++ b/src/context/WalletProvider/NativeWallet/components/NativeTestPhrase.tsx
@@ -132,8 +132,8 @@ export const NativeTestPhrase = ({ history, location }: NativeSetupProps) => {
               revocable(
                 <Button
                   key={index}
-                  flex='1'
-                  minW='30%'
+                  flexGrow={4}
+                  flexBasis='auto'
                   variant='ghost-filled'
                   colorScheme={invalidTries.includes(index) ? 'gray' : 'blue'}
                   isDisabled={invalidTries.includes(index)}

--- a/src/pages/Accounts/components/AccountEntryRow.tsx
+++ b/src/pages/Accounts/components/AccountEntryRow.tsx
@@ -58,6 +58,7 @@ export const AccountEntryRow: React.FC<AccountEntryRowProps> = ({
         width='full'
         height='auto'
         iconSpacing={4}
+        fontSize={{ base: 'sm', md: 'md' }}
         leftIcon={<Avatar size='sm' src={icon} />}
         onClick={() => history.push(generatePath('/accounts/:accountId/:assetId', filter))}
         {...buttonProps}

--- a/src/pages/Accounts/components/AccountNumberRow.tsx
+++ b/src/pages/Accounts/components/AccountNumberRow.tsx
@@ -141,6 +141,7 @@ export const AccountNumberRow: React.FC<AccountNumberRowProps> = ({
           flex={1}
           height='auto'
           iconSpacing={4}
+          fontSize={{ base: 'sm', md: 'md' }}
           leftIcon={
             // space in string interpolation is not a bug - see Chakra UI Avatar docs
             <Avatar bg={`${color}20`} color={color} size='sm' name={`# ${accountNumber}`} />

--- a/src/pages/Accounts/components/ChainRow.tsx
+++ b/src/pages/Accounts/components/ChainRow.tsx
@@ -53,7 +53,7 @@ export const ChainRow: React.FC<ChainRowProps> = ({ chainId }) => {
   }, [accountIdsByAccountNumber, chainId, history])
 
   return (
-    <ListItem as={Card} py={4} pl={2} fontWeight='semibold'>
+    <ListItem as={Card} py={4} pl={2} fontWeight='semibold' fontSize={{ base: 'sm', md: 'md' }}>
       <Stack
         direction='row'
         justifyContent='space-between'
@@ -61,7 +61,7 @@ export const ChainRow: React.FC<ChainRowProps> = ({ chainId }) => {
         px={{ base: 2, md: 4 }}
         py={2}
       >
-        <Stack direction='row' fontSize='md' alignItems='center' spacing={4}>
+        <Stack direction='row' alignItems='center' spacing={4}>
           <Circle size={8} borderWidth={2} borderColor={color} />
           <RawText>{name}</RawText>
         </Stack>

--- a/src/plugins/foxPage/components/Layout.tsx
+++ b/src/plugins/foxPage/components/Layout.tsx
@@ -50,7 +50,7 @@ export const Layout = ({ children, icon, title, description }: FoxLayoutProps) =
         </Box>
       </Box>
 
-      <Container px={{ base: 4, md: 20 }} maxW='container.xl'>
+      <Container px={{ base: 0, md: 20 }} maxW='container.xl'>
         {children}
       </Container>
     </>

--- a/src/plugins/foxPage/components/MainOpportunity.tsx
+++ b/src/plugins/foxPage/components/MainOpportunity.tsx
@@ -53,30 +53,50 @@ export const MainOpportunity = ({
         <Text translation='plugins.foxPage.mainStakingDescription' color='gray.500' />
       </Card.Header>
       <Card.Body>
-        <Flex justifyContent='space-between' flexDirection={{ base: 'column', md: 'row' }}>
-          <Box>
+        <Flex
+          width='full'
+          justifyContent='space-between'
+          gap={4}
+          flexDirection={{ base: 'column', md: 'row' }}
+        >
+          <Flex
+            flexDirection={{ base: 'row', md: 'column' }}
+            width='full'
+            justifyContent='space-between'
+            alignItems={{ base: 'center', md: 'flex-start' }}
+          >
             <Text translation='plugins.foxPage.currentApy' color='gray.500' mb={1} />
             <Skeleton isLoaded={Boolean(apy)}>
               <Box color='green.400' fontSize={'xl'}>
                 <Amount.Percent value={apy} />
               </Box>
             </Skeleton>
-          </Box>
-          <Box>
+          </Flex>
+          <Flex
+            flexDirection={{ base: 'row', md: 'column' }}
+            width='full'
+            justifyContent='space-between'
+            alignItems={{ base: 'center', md: 'flex-start' }}
+          >
             <Text translation='plugins.foxPage.tvl' color='gray.500' mb={1} />
             <Skeleton isLoaded={isLoaded}>
               <Amount.Fiat color='inherit' fontSize={'xl'} fontWeight='semibold' value={tvl} />
             </Skeleton>
-          </Box>
-          <Box>
+          </Flex>
+          <Flex
+            flexDirection={{ base: 'row', md: 'column' }}
+            width='full'
+            justifyContent='space-between'
+            alignItems={{ base: 'center', md: 'flex-start' }}
+          >
             <Text translation='plugins.foxPage.balance' color='gray.500' mb={1} />
             <CText color='inherit' fontSize={'xl'}>
               {balance}
             </CText>
-          </Box>
-          <Skeleton isLoaded={!isFoxyBalancesLoading} alignSelf='center'>
-            <Box>
-              <Button onClick={onClick} colorScheme={'blue'}>
+          </Flex>
+          <Skeleton width='full' isLoaded={!isFoxyBalancesLoading} alignSelf='center'>
+            <Box width='full'>
+              <Button width='full' onClick={onClick} colorScheme={'blue'}>
                 <CText>
                   {translate(
                     hasActiveStaking ? 'plugins.foxPage.manage' : 'plugins.foxPage.getStarted',

--- a/src/plugins/foxPage/components/OtherOpportunities/FoxOtherOpportunityPanelRow.tsx
+++ b/src/plugins/foxPage/components/OtherOpportunities/FoxOtherOpportunityPanelRow.tsx
@@ -35,9 +35,9 @@ export const FoxOtherOpportunityPanelRow: React.FC<FoxOtherOpportunityPanelRowPr
   return (
     <Flex
       justifyContent='space-between'
-      flexDirection={'row'}
+      flexDirection='row'
       _hover={{ bg: hoverOpportunityBg, textDecoration: 'none' }}
-      px={{ base: 2, md: 4 }}
+      px={4}
       py={4}
       borderRadius={8}
       {...wrapperLinkProps}
@@ -56,7 +56,10 @@ export const FoxOtherOpportunityPanelRow: React.FC<FoxOtherOpportunityPanelRowPr
           {opportunity.title}
         </CText>
       </Flex>
-      <Skeleton isLoaded={opportunity.isLoaded ? true : false} textAlign='center'>
+      <Skeleton
+        isLoaded={opportunity.isLoaded ? true : false}
+        textAlign={{ base: 'right', md: 'center' }}
+      >
         <Box>
           <Text translation='plugins.foxPage.currentApy' color='gray.500' mb={1} />
           <Box
@@ -69,7 +72,7 @@ export const FoxOtherOpportunityPanelRow: React.FC<FoxOtherOpportunityPanelRowPr
           </Box>
         </Box>
       </Skeleton>
-      <Box alignSelf='center' display={{ base: 'none', sm: 'block' }}>
+      <Box alignSelf='center' display={{ base: 'none', md: 'block' }}>
         <Skeleton isLoaded={defiOpportunity?.isLoaded ?? true} textAlign='center'>
           {defiOpportunity ? (
             <Button

--- a/src/plugins/foxPage/foxPage.tsx
+++ b/src/plugins/foxPage/foxPage.tsx
@@ -180,24 +180,26 @@ export const FoxPage = () => {
             {!isLargerThanMd && (
               <Box mb={4}>
                 <Menu>
-                  <MenuButton
-                    borderWidth='2px'
-                    borderColor='primary'
-                    height='auto'
-                    as={Button}
-                    rightIcon={<ChevronDownIcon />}
-                    bg={mobileTabBg}
-                    width='full'
-                  >
-                    {selectedAsset && (
-                      <FoxTab
-                        assetSymbol={selectedAsset.symbol}
-                        assetIcon={selectedAsset.icon}
-                        cryptoAmount={cryptoBalances[selectedAssetIndex]}
-                        fiatAmount={fiatBalances[selectedAssetIndex]}
-                      />
-                    )}
-                  </MenuButton>
+                  <Box mx={{ base: 4, md: 0 }}>
+                    <MenuButton
+                      borderWidth='2px'
+                      borderColor='primary'
+                      height='auto'
+                      as={Button}
+                      rightIcon={<ChevronDownIcon />}
+                      bg={mobileTabBg}
+                      width='full'
+                    >
+                      {selectedAsset && (
+                        <FoxTab
+                          assetSymbol={selectedAsset.symbol}
+                          assetIcon={selectedAsset.icon}
+                          cryptoAmount={cryptoBalances[selectedAssetIndex]}
+                          fiatAmount={fiatBalances[selectedAssetIndex]}
+                        />
+                      )}
+                    </MenuButton>
+                  </Box>
                   <MenuList zIndex={3}>
                     {assets.map((asset, index) => (
                       <MenuItem key={asset.assetId} onClick={() => handleTabClick(asset.assetId)}>


### PR DESCRIPTION
## Description

- Wrap the seed phrase words when they are too long
- Fix sizing of the staking opportunity for cosmos
- Reduce padding of cards
- Reduce padding of tx history rows
- Remove lines for accounts on mobile
- Fix fox page cards to fit better on mobile

## Notice

<!-- Before submitting a pull request, please make sure you have answered the following: -->

- [x] Have you followed the guidelines in our [Contributing]('https://github.com/shapeshift/web/blob/develop/CONTRIBUTING.md) guide?
- [x] Have you checked to ensure there aren't other open [Pull Requests](https://github.com/shapeshift/web/pulls) for the same update/change?

## Pull Request Type

- [x] :bug: Bug fix (Non-breaking Change: Fixes an issue)
- [ ] :hammer_and_wrench: Chore (Non-breaking Change: Doc updates, pkg upgrades, typos, etc..)
- [ ] :nail_care: New Feature (Breaking/Non-breaking Change)

## Issue (if applicable)

n/a

## Risk

Small risk, no new functionality added --- just styling.

## Testing

n/a

### Engineering

n/a

### Operations

Confirm everything looks good on mobile and nothing is running into each other, and scrolling off the screen.

## Screenshots (if applicable)
