### PR TITLE
feat: add send from to the confirm send screen

### DIFF
--- a/src/assets/translations/en/main.json
+++ b/src/assets/translations/en/main.json
@@ -643,6 +643,7 @@
         "sendAsset": "Send %{asset}",
         "send": "Send",
         "sendTo": "Send To",
+        "sendFrom": "Send From",
         "edit": "Edit",
         "total": "Total",
         "amount": "Amount",

--- a/src/components/AccountDropdown/AccountDropdown.tsx
+++ b/src/components/AccountDropdown/AccountDropdown.tsx
@@ -275,7 +275,6 @@ export const AccountDropdown: FC<AccountDropdownProps> = ({
           <Text fontWeight='medium' color='grey.500'>
             {accountLabel}
           </Text>
-          <RawText fontFamily='monospace' color='gray.500'></RawText>
         </Stack>
       </MenuButton>
       <MenuList minWidth='fit-content' maxHeight='200px' overflowY='auto' zIndex='modal'>

--- a/src/components/Modals/Send/views/Confirm.tsx
+++ b/src/components/Modals/Send/views/Confirm.tsx
@@ -105,12 +105,12 @@ export const Confirm = () => {
             <Row.Label>
               <Text translation='modals.send.confirm.sendFrom' />
             </Row.Label>
-            <Row.Value>
+            <Row.Value display='flex' alignItems='center'>
               <AccountDropdown
                 onChange={handleAccountChange}
                 assetId={asset.assetId}
                 defaultAccountId={accountId}
-                buttonProps={{ variant: 'solid' }}
+                buttonProps={{ variant: 'ghost', height: 'auto', p: 0, size: 'md' }}
                 disabled
               />
             </Row.Value>

--- a/src/components/Modals/Send/views/Confirm.tsx
+++ b/src/components/Modals/Send/views/Confirm.tsx
@@ -65,6 +65,9 @@ export const Confirm = () => {
 
   const borderColor = useColorModeValue('gray.100', 'gray.750')
 
+  // We don't want this firing -- but need it for typing
+  const handleAccountChange = () => {}
+
   if (!(address && asset?.name && cryptoSymbol && cryptoAmount && fiatAmount && feeType))
     return null
 
@@ -104,7 +107,7 @@ export const Confirm = () => {
             </Row.Label>
             <Row.Value>
               <AccountDropdown
-                onChange={() => {}}
+                onChange={handleAccountChange}
                 assetId={asset.assetId}
                 defaultAccountId={accountId}
                 buttonProps={{ variant: 'solid' }}

--- a/src/components/Modals/Send/views/Confirm.tsx
+++ b/src/components/Modals/Send/views/Confirm.tsx
@@ -17,6 +17,7 @@ import { useMemo } from 'react'
 import { useFormContext, useWatch } from 'react-hook-form'
 import { useTranslate } from 'react-polyglot'
 import { useHistory } from 'react-router-dom'
+import { AccountDropdown } from 'components/AccountDropdown/AccountDropdown'
 import { Amount } from 'components/Amount/Amount'
 import { MiddleEllipsis } from 'components/MiddleEllipsis/MiddleEllipsis'
 import { Row } from 'components/Row/Row'
@@ -43,10 +44,18 @@ export const Confirm = () => {
   } = useFormContext<SendInput>()
   const history = useHistory()
   const translate = useTranslate()
-  const { vanityAddress, address, asset, cryptoAmount, cryptoSymbol, fiatAmount, feeType } =
-    useWatch({
-      control,
-    })
+  const {
+    vanityAddress,
+    address,
+    asset,
+    cryptoAmount,
+    cryptoSymbol,
+    fiatAmount,
+    feeType,
+    accountId,
+  } = useWatch({
+    control,
+  }) as Partial<SendInput>
   const { fees } = useSendFees()
 
   const amountWithFees = useMemo(() => {
@@ -89,6 +98,20 @@ export const Confirm = () => {
           <Amount.Fiat color='gray.500' fontSize='xl' lineHeight='short' value={fiatAmount} />
         </Flex>
         <Stack spacing={4} mb={4}>
+          <Row alignItems='center'>
+            <Row.Label>
+              <Text translation='modals.send.confirm.sendFrom' />
+            </Row.Label>
+            <Row.Value>
+              <AccountDropdown
+                onChange={() => {}}
+                assetId={asset.assetId}
+                defaultAccountId={accountId}
+                buttonProps={{ variant: 'solid' }}
+                disabled
+              />
+            </Row.Value>
+          </Row>
           <Row>
             <Row.Label>
               <Text translation={'modals.send.confirm.sendTo'} />

--- a/src/plugins/cosmos/components/modals/Send/views/Confirm.tsx
+++ b/src/plugins/cosmos/components/modals/Send/views/Confirm.tsx
@@ -17,6 +17,7 @@ import { useMemo } from 'react'
 import { useFormContext, useWatch } from 'react-hook-form'
 import { useTranslate } from 'react-polyglot'
 import { useHistory } from 'react-router-dom'
+import { AccountDropdown } from 'components/AccountDropdown/AccountDropdown'
 import { Amount } from 'components/Amount/Amount'
 import { MiddleEllipsis } from 'components/MiddleEllipsis/MiddleEllipsis'
 import { useSendFees } from 'components/Modals/Send/hooks/useSendFees/useSendFees'
@@ -36,9 +37,10 @@ export const Confirm = () => {
   } = useFormContext<SendInput>()
   const history = useHistory()
   const translate = useTranslate()
-  const { address, asset, cryptoAmount, cryptoSymbol, fiatAmount, feeType, memo } = useWatch({
-    control,
-  })
+  const { address, asset, cryptoAmount, cryptoSymbol, fiatAmount, feeType, memo, accountId } =
+    useWatch({
+      control,
+    }) as Partial<SendInput>
   const { fees } = useSendFees()
 
   const amountWithFees = useMemo(() => {
@@ -47,6 +49,9 @@ export const Confirm = () => {
   }, [fiatAmount, fees, feeType])
 
   const borderColor = useColorModeValue('gray.100', 'gray.750')
+
+  // We don't want this firing -- but need it for typing
+  const handleAccountChange = () => {}
 
   if (!(address && asset?.name && cryptoSymbol && cryptoAmount && fiatAmount && feeType))
     return null
@@ -81,6 +86,20 @@ export const Confirm = () => {
           <Amount.Fiat color='gray.500' fontSize='xl' lineHeight='short' value={fiatAmount} />
         </Flex>
         <Stack spacing={4} mb={4}>
+          <Row alignItems='center'>
+            <Row.Label>
+              <Text translation='modals.send.confirm.sendFrom' />
+            </Row.Label>
+            <Row.Value display='flex' alignItems='center'>
+              <AccountDropdown
+                onChange={handleAccountChange}
+                assetId={asset.assetId}
+                defaultAccountId={accountId}
+                buttonProps={{ variant: 'ghost', height: 'auto', p: 0, size: 'md' }}
+                disabled
+              />
+            </Row.Value>
+          </Row>
           <Row>
             <Row.Label>
               <Text translation={'modals.send.confirm.sendTo'} />


### PR DESCRIPTION
## Description

- Reuse our new `AccountDropdown` component to display what account you are sending from

## Notice

<!-- Before submitting a pull request, please make sure you have answered the following: -->

- [x] Have you followed the guidelines in our [Contributing]('https://github.com/shapeshift/web/blob/develop/CONTRIBUTING.md) guide?
- [x] Have you checked to ensure there aren't other open [Pull Requests](https://github.com/shapeshift/web/pulls) for the same update/change?

## Pull Request Type

- [ ] :bug: Bug fix (Non-breaking Change: Fixes an issue)
- [ ] :hammer_and_wrench: Chore (Non-breaking Change: Doc updates, pkg upgrades, typos, etc..)
- [x] :nail_care: New Feature (Breaking/Non-breaking Change)

## Issue (if applicable)

n/a

## Risk

this should pose no risk

## Testing

Confirm that the account that is displayed is accurate

### Engineering

Implemented this the same way we do for the details view, so should act in the same way.

### Operations

On the confirm screen of send, verify that the account shown is the correct account.

## Screenshots (if applicable)
![Screen Shot 2022-09-13 at 5 27 13 PM](https://user-images.githubusercontent.com/89934888/190021246-901f4096-a70a-4f30-95fa-0eeb25311a83.png)
