### PR TITLE
fix: update styles of chart and gas fee selector

### DIFF
--- a/src/components/BalanceChart/BalanceChart.tsx
+++ b/src/components/BalanceChart/BalanceChart.tsx
@@ -1,7 +1,7 @@
+import { Box } from '@chakra-ui/react'
 import type { AssetId } from '@shapeshiftoss/caip'
 import type { HistoryTimeframe } from '@shapeshiftoss/types'
 import { useEffect } from 'react'
-import { Card } from 'components/Card/Card'
 import { Graph } from 'components/Graph/Graph'
 import { useBalanceChartData } from 'hooks/useBalanceChartData/useBalanceChartData'
 import { calculatePercentChange } from 'lib/charts'
@@ -37,7 +37,7 @@ export const BalanceChart: React.FC<BalanceChartArgs> = ({
   const color = percentChange > 0 ? 'green.500' : 'red.500'
 
   return (
-    <Card.Body p={0} height='350px'>
+    <Box height='350px'>
       <Graph
         color={color}
         data={balanceChartData}
@@ -45,6 +45,6 @@ export const BalanceChart: React.FC<BalanceChartArgs> = ({
         isLoaded={!balanceChartDataLoading}
         isRainbowChart={isRainbowChart}
       />
-    </Card.Body>
+    </Box>
   )
 }

--- a/src/components/Button/Button.theme.ts
+++ b/src/components/Button/Button.theme.ts
@@ -11,7 +11,25 @@ export const ButtonStyle: ComponentStyleConfig = {
     },
   },
   // styles for different sizes ("sm", "md", "lg")
-  sizes: {},
+  sizes: {
+    sm: {
+      svg: {
+        width: '1rem',
+        height: '1rem',
+      },
+    },
+    lg: (props: StyleFunctionProps) => {
+      const { variant: v } = props
+      return {
+        svg: {
+          width: '1.5rem',
+          height: '1.5rem',
+        },
+        fontSize: v === 'nav-link' ? 'md' : 'lg',
+        px: v === 'nav-link' ? 4 : 6,
+      }
+    },
+  },
   // styles for different visual variants ("outline", "solid")
   variants: {
     solid: (props: StyleFunctionProps) => {
@@ -181,10 +199,6 @@ export const ButtonStyle: ComponentStyleConfig = {
         return {
           color: 'gray.500',
           height: '48px',
-          svg: {
-            width: '1.5rem',
-            height: '1.5rem',
-          },
           _hover: {
             color: mode('inherit', 'whiteAlpha.800')(props),
             bg: mode('gray.100', 'gray.750')(props),
@@ -204,10 +218,6 @@ export const ButtonStyle: ComponentStyleConfig = {
       return {
         color: mode(`${c}.500`, `${c}.200`)(props),
         height: '48px',
-        svg: {
-          width: '1.5rem',
-          height: '1.5rem',
-        },
         _hover: {
           bg: mode(`${c}.50`, darkHoverBg)(props),
           color: mode(`${c}.500`, `${c}.200`)(props),

--- a/src/components/Layout/Header/NavBar/NavBar.tsx
+++ b/src/components/Layout/Header/NavBar/NavBar.tsx
@@ -63,6 +63,7 @@ export const NavBar = ({ isCompact, onClick, ...rest }: NavBarProps) => {
                 leftIcon={item.icon}
                 href={item.path}
                 to={item.path}
+                size='lg'
                 onClick={onClick}
                 label={translate(item.label)}
                 aria-label={translate(item.label)}

--- a/src/components/Layout/Header/SideNavContent.tsx
+++ b/src/components/Layout/Header/SideNavContent.tsx
@@ -65,20 +65,20 @@ export const SideNavContent = ({ isCompact, onClose }: HeaderContentProps) => {
       )}
 
       <NavBar isCompact={isCompact} mt={6} onClick={() => handleClick()} />
-      <Stack width='full' mt={6}>
+      <Stack width='full' mt={6} spacing={0}>
         <MainNavLink
-          variant='ghost'
           isCompact={isCompact}
+          size='sm'
           onClick={() => handleClick(() => settings.open({}))}
           label={translate('common.settings')}
           leftIcon={<SettingsIcon />}
           data-test='navigation-settings-button'
         />
         <MainNavLink
-          variant='ghost'
           isCompact={isCompact}
           as={Link}
           isExternal
+          size='sm'
           href='https://discord.gg/RQhAMsadpu' // unique link to attribute visitors, rather than discord.gg/shapeshift
           label={translate('common.joinDiscord')}
           leftIcon={<DiscordIcon />}
@@ -88,7 +88,7 @@ export const SideNavContent = ({ isCompact, onClose }: HeaderContentProps) => {
           leftIcon={<ChatIcon />}
           isCompact={isCompact}
           as={Link}
-          variant='ghost'
+          size='sm'
           onClick={() => handleClick()}
           label={translate('common.submitFeedback')}
           isExternal

--- a/src/components/Modals/Send/TxFeeRadioGroup.tsx
+++ b/src/components/Modals/Send/TxFeeRadioGroup.tsx
@@ -1,4 +1,4 @@
-import { Box, Button, ButtonGroup, Radio, Spinner, useColorModeValue } from '@chakra-ui/react'
+import { Box, Button, Radio, Spinner, Stack, useColorModeValue } from '@chakra-ui/react'
 import { FeeDataKey } from '@shapeshiftoss/chain-adapters'
 import { useController, useFormContext, useWatch } from 'react-hook-form'
 import { Amount } from 'components/Amount/Amount'
@@ -71,9 +71,9 @@ export const TxFeeRadioGroup = ({ fees }: TxFeeRadioGroupProps) => {
   }
 
   return (
-    <ButtonGroup
-      variant='ghost'
+    <Stack
       width='full'
+      direction={{ base: 'column', md: 'row' }}
       bg={bg}
       borderWidth={1}
       borderColor={borderColor}
@@ -89,9 +89,11 @@ export const TxFeeRadioGroup = ({ fees }: TxFeeRadioGroupProps) => {
         return (
           <Button
             display='flex'
-            flexDir='column'
+            flexDir={{ base: 'row', md: 'column' }}
+            variant='ghost'
             textAlign='left'
             alignItems='flex-start'
+            justifyContent='space-between'
             key={`fee-${key}`}
             py={2}
             width='full'
@@ -109,22 +111,24 @@ export const TxFeeRadioGroup = ({ fees }: TxFeeRadioGroupProps) => {
               />
               <Text translation={translation} />
             </Box>
-            <Amount.Crypto
-              fontSize='sm'
-              fontWeight='normal'
-              maximumFractionDigits={6}
-              symbol={feeAsset.symbol}
-              value={current.txFee}
-            />
-            <Amount.Fiat
-              color='gray.500'
-              fontSize='sm'
-              fontWeight='normal'
-              value={current.fiatFee}
-            />
+            <Stack spacing={0} alignItems={{ base: 'flex-end', md: 'flex-start' }}>
+              <Amount.Crypto
+                fontSize='sm'
+                fontWeight='normal'
+                maximumFractionDigits={6}
+                symbol={feeAsset.symbol}
+                value={current.txFee}
+              />
+              <Amount.Fiat
+                color='gray.500'
+                fontSize='sm'
+                fontWeight='normal'
+                value={current.fiatFee}
+              />
+            </Stack>
           </Button>
         )
       })}
-    </ButtonGroup>
+    </Stack>
   )
 }

--- a/src/components/Modals/Send/TxFeeRadioGroup.tsx
+++ b/src/components/Modals/Send/TxFeeRadioGroup.tsx
@@ -92,7 +92,7 @@ export const TxFeeRadioGroup = ({ fees }: TxFeeRadioGroupProps) => {
             flexDir={{ base: 'row', md: 'column' }}
             variant='ghost'
             textAlign='left'
-            alignItems='flex-start'
+            alignItems={{ base: 'center', md: 'flex-start' }}
             justifyContent='space-between'
             key={`fee-${key}`}
             py={2}
@@ -101,7 +101,7 @@ export const TxFeeRadioGroup = ({ fees }: TxFeeRadioGroupProps) => {
             onClick={() => field.onChange(key)}
             isActive={activeFee === key}
           >
-            <Box fontSize='sm' mb={2} display='flex' alignItems='center'>
+            <Box fontSize='sm' mb={{ base: 0, md: 2 }} display='flex' alignItems='center'>
               <Radio
                 colorScheme={color}
                 id={key}

--- a/src/components/PriceChart/PriceChart.tsx
+++ b/src/components/PriceChart/PriceChart.tsx
@@ -4,7 +4,6 @@ import type { AssetId } from '@shapeshiftoss/caip'
 import type { HistoryTimeframe } from '@shapeshiftoss/types'
 import { useEffect, useMemo } from 'react'
 import { FaInfoCircle } from 'react-icons/fa'
-import { Card } from 'components/Card/Card'
 import { Graph } from 'components/Graph/Graph'
 import { IconCircle } from 'components/IconCircle'
 import { Text } from 'components/Text'
@@ -71,8 +70,8 @@ export const PriceChart: React.FC<PriceChartArgs> = ({
     )
 
   return (
-    <Card.Body p={0} height={chartHeight} {...props}>
+    <Box height={chartHeight} {...props}>
       <Graph color={color} data={data} loading={loading} isLoaded={!loading} />
-    </Card.Body>
+    </Box>
   )
 }


### PR DESCRIPTION
## Description

- Remove extra padding on charts
- Make the gas selection stack correctly on mobile
- Make the secondary links in the navbar smaller

## Notice

<!-- Before submitting a pull request, please make sure you have answered the following: -->

- [x] Have you followed the guidelines in our [Contributing]('https://github.com/shapeshift/web/blob/develop/CONTRIBUTING.md) guide?
- [x] Have you checked to ensure there aren't other open [Pull Requests](https://github.com/shapeshift/web/pulls) for the same update/change?

## Pull Request Type

- [x] :bug: Bug fix (Non-breaking Change: Fixes an issue)
- [ ] :hammer_and_wrench: Chore (Non-breaking Change: Doc updates, pkg upgrades, typos, etc..)
- [ ] :nail_care: New Feature (Breaking/Non-breaking Change)

## Issue (if applicable)

n/a

## Risk

no risk, all styles

## Testing

The gas selector on the send modal should stack.

### Engineering

n/a

### Operations

When on mobile --- the send modal's gas selector should stack and you should see 3 rows for reach selection.

## Screenshots (if applicable)

![Screen Shot 2022-09-13 at 5 47 05 PM](https://user-images.githubusercontent.com/89934888/190022525-e734579f-617f-4d19-a5df-cd77262f32d0.png)
