### PR TITLE
feat: swapperV2 improvements

### DIFF
--- a/src/components/DeFi/components/AssetInput.tsx
+++ b/src/components/DeFi/components/AssetInput.tsx
@@ -188,13 +188,11 @@ export const AssetInput: React.FC<AssetInputProps> = ({
         </Stack>
       )}
       {handleAccountIdChange && assetId && (
-        <Stack direction='row' py={2} px={4} justifyContent='space-between' alignItems='center'>
-          <AccountDropdown
-            assetId={assetId}
-            onChange={handleAccountIdChange}
-            buttonProps={{ variant: 'ghost', width: 'full', padding: 0 }}
-          />
-        </Stack>
+        <AccountDropdown
+          assetId={assetId}
+          onChange={handleAccountIdChange}
+          buttonProps={{ variant: 'ghost', width: 'full', paddingX: 4 }}
+        />
       )}
       {errors && <FormErrorMessage px={4}>{errors?.message}</FormErrorMessage>}
       {children && (

--- a/src/components/Trade/Trade.tsx
+++ b/src/components/Trade/Trade.tsx
@@ -1,20 +1,23 @@
 import type { AssetId } from '@shapeshiftoss/caip'
-import type { KnownChainIds } from '@shapeshiftoss/types'
 import { FormProvider, useForm } from 'react-hook-form'
 import { MemoryRouter, Route, Switch } from 'react-router-dom'
 
 import { entries, TradeRoutes } from './TradeRoutes/TradeRoutes'
-import type { TradeState } from './types'
+import type { TS } from './types'
 
 export type TradeProps = {
   defaultBuyAssetId?: AssetId
 }
 
 export const Trade = ({ defaultBuyAssetId }: TradeProps) => {
-  const methods = useForm<TradeState<KnownChainIds>>({
+  const methods = useForm<TS>({
     mode: 'onChange',
     defaultValues: {
-      fiatSellAmount: undefined,
+      fiatSellAmount: '0',
+      fiatBuyAmount: '0',
+      amount: '0',
+      sellTradeAsset: { amount: '0' },
+      buyTradeAsset: { amount: '0' },
       isExactAllowance: false,
     },
   })

--- a/src/components/Trade/Trade.tsx
+++ b/src/components/Trade/Trade.tsx
@@ -19,6 +19,7 @@ export const Trade = ({ defaultBuyAssetId }: TradeProps) => {
       sellTradeAsset: { amount: '0' },
       buyTradeAsset: { amount: '0' },
       isExactAllowance: false,
+      slippage: 0.002,
     },
   })
 

--- a/src/components/Trade/TradeConfirm/ReceiveSummary.tsx
+++ b/src/components/Trade/TradeConfirm/ReceiveSummary.tsx
@@ -37,7 +37,6 @@ export const ReceiveSummary: FC<ReceiveSummaryProps> = ({
   isLoading,
   ...rest
 }) => {
-  console.log('xxx ReceiveSummary protocolFee', protocolFee)
   const translate = useTranslate()
   const { isOpen, onToggle } = useDisclosure()
   const summaryBg = useColorModeValue('gray.50', 'gray.800')

--- a/src/components/Trade/TradeConfirm/ReceiveSummary.tsx
+++ b/src/components/Trade/TradeConfirm/ReceiveSummary.tsx
@@ -47,6 +47,8 @@ export const ReceiveSummary: FC<ReceiveSummaryProps> = ({
   const minAmountAfterSlippage = bnOrZero(beforeFees)
     .times(1 - slippage)
     .toString()
+  const slippageAsPercentageString = bnOrZero(slippage).times(100).toString()
+
   return (
     <>
       <Row fontSize='sm' fontWeight='medium' alignItems='flex-start' {...rest}>
@@ -125,7 +127,12 @@ export const ReceiveSummary: FC<ReceiveSummaryProps> = ({
               <Divider />
               <Row>
                 <Row.Label>
-                  <Text translation={['trade.minAmountAfterSlippage', { slippage: '0.2' }]} />
+                  <Text
+                    translation={[
+                      'trade.minAmountAfterSlippage',
+                      { slippage: slippageAsPercentageString },
+                    ]}
+                  />
                 </Row.Label>
                 <Row.Value whiteSpace='nowrap'>
                   <Skeleton isLoaded={!isLoading}>

--- a/src/components/Trade/TradeConfirm/ReceiveSummary.tsx
+++ b/src/components/Trade/TradeConfirm/ReceiveSummary.tsx
@@ -13,6 +13,7 @@ import { Amount } from 'components/Amount/Amount'
 import { HelperTooltip } from 'components/HelperTooltip/HelperTooltip'
 import { type RowProps, Row } from 'components/Row/Row'
 import { Text } from 'components/Text'
+import { bnOrZero } from 'lib/bignumber/bignumber'
 
 type ReceiveSummaryProps = {
   isLoading?: boolean
@@ -22,7 +23,7 @@ type ReceiveSummaryProps = {
   beforeFees?: string
   protocolFee?: string
   shapeShiftFee?: string
-  minAmountAfterSlippage?: string
+  slippage: number
 } & RowProps
 
 export const ReceiveSummary: FC<ReceiveSummaryProps> = ({
@@ -32,16 +33,21 @@ export const ReceiveSummary: FC<ReceiveSummaryProps> = ({
   beforeFees,
   protocolFee,
   shapeShiftFee,
-  minAmountAfterSlippage,
+  slippage,
   isLoading,
   ...rest
 }) => {
+  console.log('xxx ReceiveSummary protocolFee', protocolFee)
   const translate = useTranslate()
   const { isOpen, onToggle } = useDisclosure()
   const summaryBg = useColorModeValue('gray.50', 'gray.800')
   const borderColor = useColorModeValue('gray.100', 'gray.750')
   const hoverColor = useColorModeValue('black', 'white')
   const redColor = useColorModeValue('red.500', 'red.300')
+
+  const minAmountAfterSlippage = bnOrZero(beforeFees)
+    .times(1 - slippage)
+    .toString()
   return (
     <>
       <Row fontSize='sm' fontWeight='medium' alignItems='flex-start' {...rest}>

--- a/src/components/Trade/TradeConfirm/TradeConfirm.tsx
+++ b/src/components/Trade/TradeConfirm/TradeConfirm.tsx
@@ -65,7 +65,9 @@ export const TradeConfirm = ({ history }: RouterProps) => {
     fees,
     sellAssetFiatRate,
     buyAssetFiatRate,
-  }: Pick<TS, 'trade' | 'fees' | 'sellAssetFiatRate' | 'buyAssetFiatRate'> = getValues()
+    slippage,
+  }: Pick<TS, 'trade' | 'fees' | 'sellAssetFiatRate' | 'buyAssetFiatRate' | 'slippage'> =
+    getValues()
   const { executeQuote, reset, getTradeTxs } = useSwapper()
   const location = useLocation<TradeConfirmParams>()
   // TODO: Refactor to use fiatRate from TradeState - we don't need to pass fiatRate around.
@@ -228,6 +230,7 @@ export const TradeConfirm = ({ history }: RouterProps) => {
                   beforeFees={buyAmountCryptoBeforeFees}
                   protocolFee={fees?.tradeFee}
                   shapeShiftFee='0'
+                  slippage={slippage}
                 />
               </Stack>
               <Stack spacing={4}>

--- a/src/components/Trade/TradeInputV2.tsx
+++ b/src/components/Trade/TradeInputV2.tsx
@@ -2,7 +2,6 @@ import { ArrowDownIcon } from '@chakra-ui/icons'
 import { Button, IconButton, Stack, useColorModeValue } from '@chakra-ui/react'
 import { ethAssetId } from '@shapeshiftoss/caip'
 import type { KnownChainIds } from '@shapeshiftoss/types'
-import { useEffect } from 'react'
 import { useFormContext, useWatch } from 'react-hook-form'
 import { useTranslate } from 'react-polyglot'
 import { useHistory } from 'react-router'
@@ -61,16 +60,6 @@ export const TradeInput = () => {
       assetId: sellTradeAsset?.asset?.assetId ?? '',
     }),
   )
-
-  // Initialize the trade input fields with the default values of '0'
-  useEffect(() => {
-    const initialAmount = '0'
-    setValue('amount', initialAmount)
-    setValue('fiatSellAmount', initialAmount)
-    setValue('fiatBuyAmount', initialAmount)
-    setValue('sellTradeAsset.amount', initialAmount)
-    setValue('buyTradeAsset.amount', initialAmount)
-  }, [setValue])
 
   const protocolFee = fromBaseUnit(bnOrZero(fees?.tradeFee), buyTradeAsset?.asset?.precision ?? 0)
   const toCryptoAmountAfterFees = bnOrZero(buyTradeAsset?.amount).minus(bnOrZero(protocolFee))

--- a/src/components/Trade/TradeInputV2.tsx
+++ b/src/components/Trade/TradeInputV2.tsx
@@ -2,6 +2,7 @@ import { ArrowDownIcon } from '@chakra-ui/icons'
 import { Button, IconButton, Stack, useColorModeValue } from '@chakra-ui/react'
 import { ethAssetId } from '@shapeshiftoss/caip'
 import type { KnownChainIds } from '@shapeshiftoss/types'
+import { useState } from 'react'
 import { useFormContext, useWatch } from 'react-hook-form'
 import { useTranslate } from 'react-polyglot'
 import { useHistory } from 'react-router'
@@ -28,17 +29,12 @@ const moduleLogger = logger.child({ namespace: ['TradeInput'] })
 
 export const TradeInput = () => {
   useSwapperService()
+  const [isLoading, setIsLoading] = useState(false)
   const { setTradeAmounts } = useTradeAmounts()
   const { checkApprovalNeeded, getTrade } = useSwapper()
   const history = useHistory()
   const borderColor = useColorModeValue('gray.100', 'gray.750')
-  const {
-    control,
-    setValue,
-    getValues,
-    handleSubmit,
-    formState: { isValid },
-  } = useFormContext<TradeState<KnownChainIds>>()
+  const { control, setValue, getValues, handleSubmit } = useFormContext<TradeState<KnownChainIds>>()
 
   const sellTradeAsset = useWatch({ control, name: 'sellTradeAsset' })
   const buyTradeAsset = useWatch({ control, name: 'buyTradeAsset' })
@@ -100,6 +96,7 @@ export const TradeInput = () => {
   }
 
   const onSubmit = async (values: TradeState<KnownChainIds>) => {
+    setIsLoading(true)
     moduleLogger.info(values, 'debugging logger')
     try {
       const isApproveNeeded = await checkApprovalNeeded()
@@ -112,6 +109,8 @@ export const TradeInput = () => {
       history.push({ pathname: TradeRoutePaths.Confirm, state: { fiatRate: feeAssetFiatRate } })
     } catch (e) {
       moduleLogger.error(e, 'onSubmit error')
+    } finally {
+      setIsLoading(false)
     }
   }
 
@@ -196,7 +195,13 @@ export const TradeInput = () => {
             slippage={slippage}
           />
         </Stack>
-        <Button type='submit' colorScheme='blue' size='lg' isDisabled={!isValid}>
+        <Button
+          type='submit'
+          colorScheme='blue'
+          size='lg'
+          isDisabled={!quote}
+          isLoading={isLoading}
+        >
           {translate('trade.previewTrade')}
         </Button>
       </Stack>

--- a/src/components/Trade/TradeInputV2.tsx
+++ b/src/components/Trade/TradeInputV2.tsx
@@ -64,6 +64,7 @@ export const TradeInput = () => {
 
   const protocolFee = fromBaseUnit(bnOrZero(fees?.tradeFee), buyTradeAsset?.asset?.precision ?? 0)
   const toCryptoAmountAfterFees = bnOrZero(buyTradeAsset?.amount).minus(bnOrZero(protocolFee))
+  const gasFee = bnOrZero(fees?.fee).times(bnOrZero(feeAssetFiatRate)).toString()
 
   const handleInputChange = (action: TradeAmountInputField, amount: string) => {
     setValue('amount', amount)
@@ -182,7 +183,7 @@ export const TradeInput = () => {
           <RateGasRow
             sellSymbol={sellTradeAsset?.asset?.symbol}
             buySymbol={buyTradeAsset?.asset?.symbol}
-            gasFee={bnOrZero(fees?.fee).times(bnOrZero(feeAssetFiatRate)).toString()}
+            gasFee={gasFee}
             rate={quote?.rate}
           />
           <ReceiveSummary

--- a/src/components/Trade/TradeInputV2.tsx
+++ b/src/components/Trade/TradeInputV2.tsx
@@ -48,6 +48,7 @@ export const TradeInput = () => {
   const sellAssetAccountId = useWatch({ control, name: 'sellAssetAccountId' })
   const fiatSellAmount = useWatch({ control, name: 'fiatSellAmount' })
   const fiatBuyAmount = useWatch({ control, name: 'fiatBuyAmount' })
+  const slippage = useWatch({ control, name: 'slippage' })
 
   const translate = useTranslate()
 
@@ -191,7 +192,7 @@ export const TradeInput = () => {
             beforeFees={buyTradeAsset?.amount ?? ''}
             protocolFee={protocolFee}
             shapeShiftFee='0'
-            minAmountAfterSlippage={buyTradeAsset?.amount ?? ''}
+            slippage={slippage}
           />
         </Stack>
         <Button type='submit' colorScheme='blue' size='lg' isDisabled={!isValid}>

--- a/src/components/Trade/TradeInputV2.tsx
+++ b/src/components/Trade/TradeInputV2.tsx
@@ -14,6 +14,7 @@ import { useSwapperService } from 'components/Trade/hooks/useSwapperService'
 import { useTradeAmounts } from 'components/Trade/hooks/useTradeAmounts'
 import { bnOrZero } from 'lib/bignumber/bignumber'
 import { logger } from 'lib/logger'
+import { fromBaseUnit } from 'lib/math'
 import { selectFeeAssetById } from 'state/slices/assetsSlice/selectors'
 import { selectPortfolioCryptoBalanceByFilter } from 'state/slices/portfolioSlice/selectors'
 import { useAppSelector } from 'state/store'
@@ -71,7 +72,8 @@ export const TradeInput = () => {
     setValue('buyTradeAsset.amount', initialAmount)
   }, [setValue])
 
-  const toCryptoAmountAfterFees = bnOrZero(buyTradeAsset?.amount).minus(bnOrZero(fees?.tradeFee))
+  const protocolFee = fromBaseUnit(bnOrZero(fees?.tradeFee), buyTradeAsset?.asset?.precision ?? 0)
+  const toCryptoAmountAfterFees = bnOrZero(buyTradeAsset?.amount).minus(bnOrZero(protocolFee))
 
   const handleInputChange = (action: TradeAmountInputField, amount: string) => {
     setValue('amount', amount)
@@ -198,7 +200,7 @@ export const TradeInput = () => {
             symbol={buyTradeAsset?.asset?.symbol ?? ''}
             amount={toCryptoAmountAfterFees.toString()}
             beforeFees={buyTradeAsset?.amount ?? ''}
-            protocolFee={fees?.tradeFee}
+            protocolFee={protocolFee}
             shapeShiftFee='0'
             minAmountAfterSlippage={buyTradeAsset?.amount ?? ''}
           />

--- a/src/components/Trade/hooks/useDefaultAssetsService.ts
+++ b/src/components/Trade/hooks/useDefaultAssetsService.ts
@@ -11,7 +11,7 @@ import {
 } from '@shapeshiftoss/caip'
 import { supportsCosmos, supportsETH, supportsOsmosis } from '@shapeshiftoss/hdwallet-core'
 import { useEffect, useMemo, useState } from 'react'
-import { useFormContext, useWatch } from 'react-hook-form'
+import { useFormContext } from 'react-hook-form'
 import { useSelector } from 'react-redux'
 import { useSwapper } from 'components/Trade/hooks/useSwapper/useSwapperV2'
 import { getDefaultAssetIdPairByChainId } from 'components/Trade/hooks/useSwapper/utils'
@@ -36,8 +36,7 @@ export const useDefaultAssetsService = (routeBuyAssetId?: AssetId) => {
     state: { wallet },
   } = useWallet()
   const { connectedEvmChainId } = useEvm()
-  const { setValue, control } = useFormContext<TS>()
-  const buyAssetAccountId = useWatch({ control, name: 'buyAssetAccountId' })
+  const { setValue } = useFormContext<TS>()
   const [buyAssetFiatRateArgs, setBuyAssetFiatRateArgs] = useState<UsdRateInputArg>(skipToken)
   const [defaultAssetFiatRateArgs, setDefaultAssetFiatRateArgs] =
     useState<UsdRateInputArg>(skipToken)
@@ -145,22 +144,23 @@ export const useDefaultAssetsService = (routeBuyAssetId?: AssetId) => {
 
     if (assetPair) {
       ;(async () => {
-        const buyAsset = buyAssetAccountId ? assetPair.buyAsset : assets[foxAssetId]
-        const sellAsset = buyAssetAccountId ? assetPair.sellAsset : assets[ethAssetId]
+        const receiveAddress = await getReceiveAddressFromBuyAsset()
+        const buyAsset = receiveAddress ? assetPair.buyAsset : assets[foxAssetId]
+        const sellAsset = receiveAddress ? assetPair.sellAsset : assets[ethAssetId]
         setValue('action', TradeAmountInputField.SELL_CRYPTO)
         setValue('amount', '0')
         setValue('buyTradeAsset.asset', buyAsset)
         setValue('sellTradeAsset.asset', sellAsset)
       })()
     }
+    // We don't want to run this effect when getReceiveAddressFromBuyAsset changes
+    // eslint-disable-next-line react-hooks/exhaustive-deps
   }, [
     assets,
-    buyAssetAccountId,
     buyAssetFiatRateData,
     buyAssetId,
     defaultAssetFiatRateData,
     defaultAssetIdPair,
-    getReceiveAddressFromBuyAsset,
     isBuyAssetFiatRateLoading,
     isBuyAssetFiatRateUninitialized,
     isDefaultAssetFiatRateLoading,

--- a/src/components/Trade/hooks/useDefaultAssetsService.ts
+++ b/src/components/Trade/hooks/useDefaultAssetsService.ts
@@ -11,7 +11,7 @@ import {
 } from '@shapeshiftoss/caip'
 import { supportsCosmos, supportsETH, supportsOsmosis } from '@shapeshiftoss/hdwallet-core'
 import { useEffect, useMemo, useState } from 'react'
-import { useFormContext } from 'react-hook-form'
+import { useFormContext, useWatch } from 'react-hook-form'
 import { useSelector } from 'react-redux'
 import { useSwapper } from 'components/Trade/hooks/useSwapper/useSwapperV2'
 import { getDefaultAssetIdPairByChainId } from 'components/Trade/hooks/useSwapper/utils'
@@ -36,7 +36,8 @@ export const useDefaultAssetsService = (routeBuyAssetId?: AssetId) => {
     state: { wallet },
   } = useWallet()
   const { connectedEvmChainId } = useEvm()
-  const { setValue } = useFormContext<TS>()
+  const { setValue, control } = useFormContext<TS>()
+  const buyAssetAccountId = useWatch({ control, name: 'buyAssetAccountId' })
   const [buyAssetFiatRateArgs, setBuyAssetFiatRateArgs] = useState<UsdRateInputArg>(skipToken)
   const [defaultAssetFiatRateArgs, setDefaultAssetFiatRateArgs] =
     useState<UsdRateInputArg>(skipToken)
@@ -144,9 +145,8 @@ export const useDefaultAssetsService = (routeBuyAssetId?: AssetId) => {
 
     if (assetPair) {
       ;(async () => {
-        const receiveAddress = await getReceiveAddressFromBuyAsset(assetPair.buyAsset)
-        const buyAsset = receiveAddress ? assetPair.buyAsset : assets[foxAssetId]
-        const sellAsset = receiveAddress ? assetPair.sellAsset : assets[ethAssetId]
+        const buyAsset = buyAssetAccountId ? assetPair.buyAsset : assets[foxAssetId]
+        const sellAsset = buyAssetAccountId ? assetPair.sellAsset : assets[ethAssetId]
         setValue('action', TradeAmountInputField.SELL_CRYPTO)
         setValue('amount', '0')
         setValue('buyTradeAsset.asset', buyAsset)
@@ -155,6 +155,7 @@ export const useDefaultAssetsService = (routeBuyAssetId?: AssetId) => {
     }
   }, [
     assets,
+    buyAssetAccountId,
     buyAssetFiatRateData,
     buyAssetId,
     defaultAssetFiatRateData,

--- a/src/components/Trade/hooks/useSwapper/useSwapperV2.ts
+++ b/src/components/Trade/hooks/useSwapper/useSwapperV2.ts
@@ -40,7 +40,7 @@ export const useSwapper = () => {
 
   // Constants
   const sellAsset = sellTradeAsset?.asset
-  const buyAsset = sellTradeAsset?.asset
+  const buyAsset = buyTradeAsset?.asset
   const buyAssetId = buyAsset?.assetId
   const sellAssetId = sellAsset?.assetId
 

--- a/src/components/Trade/hooks/useSwapper/useSwapperV2.ts
+++ b/src/components/Trade/hooks/useSwapper/useSwapperV2.ts
@@ -1,5 +1,5 @@
 import { type Asset } from '@shapeshiftoss/asset-service'
-import { fromAssetId } from '@shapeshiftoss/caip'
+import { fromAccountId } from '@shapeshiftoss/caip'
 import type { UtxoBaseAdapter } from '@shapeshiftoss/chain-adapters'
 import { type Swapper, type UtxoSupportedChainIds, SwapperManager } from '@shapeshiftoss/swapper'
 import type { KnownChainIds } from '@shapeshiftoss/types'
@@ -9,7 +9,7 @@ import { useSelector } from 'react-redux'
 import { getSwapperManager } from 'components/Trade/hooks/useSwapper/swapperManager'
 import {
   filterAssetsByIds,
-  getFirstReceiveAddress,
+  getSelectedReceiveAddress,
   getUtxoParams,
   isSupportedNonUtxoSwappingChain,
   isSupportedUtxoSwappingChain,
@@ -20,7 +20,6 @@ import { getChainAdapterManager } from 'context/PluginProvider/chainAdapterSingl
 import { useWallet } from 'hooks/useWallet/useWallet'
 import { logger } from 'lib/logger'
 import { toBaseUnit } from 'lib/math'
-import { selectAccountSpecifiers } from 'state/slices/accountSpecifiersSlice/selectors'
 import { selectAssetIds } from 'state/slices/assetsSlice/selectors'
 import { selectFeatureFlags } from 'state/slices/preferencesSlice/selectors'
 
@@ -37,6 +36,7 @@ export const useSwapper = () => {
   const buyTradeAsset = useWatch({ control, name: 'buyTradeAsset' })
   const quote = useWatch({ control, name: 'quote' })
   const sellAssetAccountId = useWatch({ control, name: 'sellAssetAccountId' })
+  const buyAssetAccountId = useWatch({ control, name: 'buyAssetAccountId' })
 
   // Constants
   const sellAsset = sellTradeAsset?.asset
@@ -55,7 +55,6 @@ export const useSwapper = () => {
   // Selectors
   const flags = useSelector(selectFeatureFlags)
   const assetIds = useSelector(selectAssetIds)
-  const accountSpecifiersList = useSelector(selectAccountSpecifiers)
 
   // Callbacks
   const getSupportedSellableAssets = useCallback(
@@ -68,24 +67,22 @@ export const useSwapper = () => {
     [assetIds, swapperManager],
   )
 
-  const getReceiveAddressFromBuyAsset = useCallback(
-    async (buyAsset: Asset) => {
-      const { chainId: receiveAddressChainId } = fromAssetId(buyAsset.assetId)
-      const chainAdapter = getChainAdapterManager().get(receiveAddressChainId)
-      if (!(chainAdapter && wallet)) return
-      try {
-        return await getFirstReceiveAddress({
-          accountSpecifiersList,
-          buyAsset,
-          chainAdapter,
-          wallet,
-        })
-      } catch (e) {
-        moduleLogger.info(e, 'No receive address for buy asset, using default asset pair')
-      }
-    },
-    [accountSpecifiersList, wallet],
-  )
+  const getReceiveAddressFromBuyAsset = useCallback(async () => {
+    if (!(buyAssetAccountId && wallet)) return
+    const { chainId: receiveAddressChainId } = fromAccountId(buyAssetAccountId)
+    // const { chainId: receiveAddressChainId } = fromAssetId(buyAsset.assetId)
+    const chainAdapter = getChainAdapterManager().get(receiveAddressChainId)
+    if (!chainAdapter) return
+    try {
+      return await getSelectedReceiveAddress({
+        chainAdapter,
+        wallet,
+        accountId: buyAssetAccountId,
+      })
+    } catch (e) {
+      moduleLogger.info(e, 'No receive address for buy asset, using default asset pair')
+    }
+  }, [buyAssetAccountId, wallet])
 
   const getSupportedBuyAssetsFromSellAsset = useCallback(
     (assets: Asset[]): Asset[] | undefined => {
@@ -192,7 +189,7 @@ export const useSwapper = () => {
     ;(async () => {
       // TODO: get the actual receive address instead of the first
       try {
-        const receiveAddress = await getReceiveAddressFromBuyAsset(buyAsset)
+        const receiveAddress = await getReceiveAddressFromBuyAsset()
         setReceiveAddress(receiveAddress)
       } catch (e) {
         setReceiveAddress(null)

--- a/src/components/Trade/hooks/useSwapper/utils.ts
+++ b/src/components/Trade/hooks/useSwapper/utils.ts
@@ -23,8 +23,8 @@ import { getSwapperManager } from 'components/Trade/hooks/useSwapper/swapperMana
 import {
   type AssetIdTradePair,
   type DisplayFeeData,
-  type GetFirstReceiveAddress,
   type GetFormFeesArgs,
+  type GetSelectedReceiveAddress,
   type SupportedSwappingChain,
 } from 'components/Trade/types'
 import { bn, bnOrZero } from 'lib/bignumber/bignumber'
@@ -52,7 +52,7 @@ export const isSupportedNonUtxoSwappingChain = (
 }
 
 // Pure functions
-export const getSelectedReceiveAddress: GetFirstReceiveAddress = async ({
+export const getSelectedReceiveAddress: GetSelectedReceiveAddress = async ({
   chainAdapter,
   wallet,
   accountId,

--- a/src/components/Trade/hooks/useSwapper/utils.ts
+++ b/src/components/Trade/hooks/useSwapper/utils.ts
@@ -71,9 +71,8 @@ export const getFirstReceiveAddress: GetFirstReceiveAddress = async ({
   const accountId = toAccountId({ chainId, account })
 
   // TODO accountType and accountNumber need to come from account metadata
-  const { accountType } = accountIdToUtxoParams(accountId, 0)
-  const bip44Params = chainAdapter.getBIP44Params({ accountNumber: 0 })
-  return await chainAdapter.getAddress({ wallet, accountType, bip44Params })
+  const { accountType, utxoParams } = accountIdToUtxoParams(accountId, 0)
+  return await chainAdapter.getAddress({ wallet, accountType, ...utxoParams })
 }
 
 export const getUtxoParams = (sellAssetAccountId: string) => {

--- a/src/components/Trade/hooks/useSwapper/utils.ts
+++ b/src/components/Trade/hooks/useSwapper/utils.ts
@@ -110,6 +110,7 @@ const getEvmFees = <T extends EvmChainId>(
   feeAsset: Asset,
   tradeFeeSource: string,
 ): DisplayFeeData<T> => {
+  // The "gas" fee paid to the network for the transaction
   const feeBN = bnOrZero(trade?.feeData?.fee).dividedBy(bn(10).exponentiatedBy(feeAsset.precision))
   const fee = feeBN.toString()
   const approvalFee = bnOrZero(trade.feeData.chainSpecific.approvalFee)
@@ -127,6 +128,7 @@ const getEvmFees = <T extends EvmChainId>(
       estimatedGas,
       totalFee,
     },
+    // The fee paid to the protocol for the transaction
     tradeFee: trade.feeData.tradeFee,
     tradeFeeSource,
   } as DisplayFeeData<T>

--- a/src/components/Trade/hooks/useSwapper/utils.ts
+++ b/src/components/Trade/hooks/useSwapper/utils.ts
@@ -10,7 +10,6 @@ import {
   fromAssetId,
   fromChainId,
   osmosisAssetId,
-  toAccountId,
 } from '@shapeshiftoss/caip'
 import { type EvmChainId } from '@shapeshiftoss/chain-adapters'
 import {
@@ -53,23 +52,11 @@ export const isSupportedNonUtxoSwappingChain = (
 }
 
 // Pure functions
-export const getFirstReceiveAddress: GetFirstReceiveAddress = async ({
-  accountSpecifiersList,
-  buyAsset,
+export const getSelectedReceiveAddress: GetFirstReceiveAddress = async ({
   chainAdapter,
   wallet,
+  accountId,
 }) => {
-  const receiveAddressAccountSpecifiers = accountSpecifiersList.find(
-    specifiers => specifiers[buyAsset.chainId],
-  )
-
-  if (!receiveAddressAccountSpecifiers) throw new Error('no receiveAddressAccountSpecifiers')
-  const account = receiveAddressAccountSpecifiers[buyAsset.chainId]
-  if (!account) throw new Error(`no account for ${buyAsset.chainId}`)
-
-  const { chainId } = buyAsset
-  const accountId = toAccountId({ chainId, account })
-
   // TODO accountType and accountNumber need to come from account metadata
   const { accountType, utxoParams } = accountIdToUtxoParams(accountId, 0)
   return await chainAdapter.getAddress({ wallet, accountType, ...utxoParams })

--- a/src/components/Trade/hooks/useTradeQuoteService.ts
+++ b/src/components/Trade/hooks/useTradeQuoteService.ts
@@ -42,7 +42,9 @@ export const useTradeQuoteService = () => {
     state: { wallet },
   } = useWallet()
   const [tradeQuoteArgs, setTradeQuoteArgs] = useState<TradeQuoteInputArg>(skipToken)
-  const { receiveAddress } = useSwapper()
+
+  // Hooks
+  const { getReceiveAddressFromBuyAsset } = useSwapper()
 
   // Constants
   const sellAsset = sellTradeAsset?.asset
@@ -59,8 +61,10 @@ export const useTradeQuoteService = () => {
   // Trigger trade quote query
   useEffect(() => {
     const sellTradeAssetAmount = sellTradeAsset?.amount
-    if (sellAsset && buyAsset && wallet && sellTradeAssetAmount && receiveAddress) {
+    if (sellAsset && buyAsset && wallet && sellTradeAssetAmount) {
       ;(async () => {
+        const receiveAddress = await getReceiveAddressFromBuyAsset()
+        if (!receiveAddress) return
         const { chainId: receiveAddressChainId } = fromAssetId(buyAsset.assetId)
         const chainAdapter = getChainAdapterManager().get(receiveAddressChainId)
 
@@ -110,7 +114,7 @@ export const useTradeQuoteService = () => {
     amount,
     buyAsset,
     buyTradeAsset,
-    receiveAddress,
+    getReceiveAddressFromBuyAsset,
     selectedCurrencyToUsdRate,
     sellAsset,
     sellAssetAccountId,

--- a/src/components/Trade/types.ts
+++ b/src/components/Trade/types.ts
@@ -37,8 +37,8 @@ export type TradeState<C extends ChainId> = {
   selectedSellAssetAccountId?: AccountSpecifier
   selectedBuyAssetAccountId?: AccountSpecifier
   buyTradeAsset: TradeAsset | undefined
-  fiatSellAmount: string | undefined
-  fiatBuyAmount: string | undefined
+  fiatSellAmount: string
+  fiatBuyAmount: string
   sellAssetFiatRate: string
   buyAssetFiatRate: string
   feeAssetFiatRate: string
@@ -49,7 +49,7 @@ export type TradeState<C extends ChainId> = {
   trade?: Trade<C> | CowTrade<C>
   /** @deprecated use native react hook form errors instead */
   quoteError: string | null
-  amount: string | null
+  amount: string
   receiveAddress: string | null // TODO: Implement
 }
 

--- a/src/components/Trade/types.ts
+++ b/src/components/Trade/types.ts
@@ -70,13 +70,13 @@ export type SupportedSwappingChain =
   | KnownChainIds.OsmosisMainnet
   | KnownChainIds.CosmosMainnet
 
-type GetFirstReceiveAddressArgs = {
+type GetSelectedReceiveAddressArgs = {
   chainAdapter: ChainAdapter<ChainId>
   wallet: HDWallet
   accountId: AccountId
 }
 
-export type GetFirstReceiveAddress = (args: GetFirstReceiveAddressArgs) => Promise<string>
+export type GetSelectedReceiveAddress = (args: GetSelectedReceiveAddressArgs) => Promise<string>
 
 export type TradeQuoteInputCommonArgs = Pick<
   GetTradeQuoteInput,

--- a/src/components/Trade/types.ts
+++ b/src/components/Trade/types.ts
@@ -51,6 +51,7 @@ export type TradeState<C extends ChainId> = {
   quoteError: string | null
   amount: string
   receiveAddress: string | null // TODO: Implement
+  slippage: number
 }
 
 export type TS<T extends KnownChainIds = KnownChainIds> = TradeState<T>

--- a/src/components/Trade/types.ts
+++ b/src/components/Trade/types.ts
@@ -1,5 +1,5 @@
 import { type Asset } from '@shapeshiftoss/asset-service'
-import type { AssetId } from '@shapeshiftoss/caip'
+import type { AccountId, AssetId } from '@shapeshiftoss/caip'
 import { type ChainId } from '@shapeshiftoss/caip'
 import { type ChainAdapter } from '@shapeshiftoss/chain-adapters'
 import { type HDWallet } from '@shapeshiftoss/hdwallet-core'
@@ -12,7 +12,6 @@ import {
   type TradeQuote,
 } from '@shapeshiftoss/swapper'
 import type { KnownChainIds } from '@shapeshiftoss/types'
-import type { selectAccountSpecifiers } from 'state/slices/accountSpecifiersSlice/selectors'
 import { type AccountSpecifier } from 'state/slices/portfolioSlice/portfolioSliceCommon'
 
 export enum TradeAmountInputField {
@@ -72,10 +71,9 @@ export type SupportedSwappingChain =
   | KnownChainIds.CosmosMainnet
 
 type GetFirstReceiveAddressArgs = {
-  accountSpecifiersList: ReturnType<typeof selectAccountSpecifiers>
-  buyAsset: Asset
   chainAdapter: ChainAdapter<ChainId>
   wallet: HDWallet
+  accountId: AccountId
 }
 
 export type GetFirstReceiveAddress = (args: GetFirstReceiveAddressArgs) => Promise<string>


### PR DESCRIPTION
## Description

Additional improvements to `swapperV2`:

- Adds and propagates trade slippage (manually set at 0.2% until advanced trade settings are implemented)
- Refactors TradeState initial values
- Fixes protocol fee value display
- Allows for both sell and buy account selection for UTXOs

## Notice

- [x] Have you followed the guidelines in our [Contributing]('https://github.com/shapeshift/web/blob/develop/CONTRIBUTING.md) guide?
- [x] Have you checked to ensure there aren't other open [Pull Requests](https://github.com/shapeshift/web/pulls) for the same update/change?

## Pull Request Type

- [ ] :bug: Bug fix (Non-breaking Change: Fixes an issue)
- [ ] :hammer_and_wrench: Chore (Non-breaking Change: Doc updates, pkg upgrades, typos, etc..)
- [x] :nail_care: New Feature (Breaking/Non-breaking Change)

## Issue (if applicable)

Contributes to https://github.com/shapeshift/web/issues/2556

## Risk

Minimal to anything not feature-flagged.

## Testing

### Engineering

- We can now select both the buy and sell asset accounts for UTXOs (`ThorSwap` must be enabled)
- Shows trade slippage with default 0.2% applied

### Operations

N/A

## Screenshots (if applicable)

N/A