### PR TITLE
fix: default UTXO assets

### DIFF
--- a/src/components/Trade/hooks/useSwapper/utils.ts
+++ b/src/components/Trade/hooks/useSwapper/utils.ts
@@ -71,9 +71,8 @@ export const getFirstReceiveAddress: GetFirstReceiveAddress = async ({
   const accountId = toAccountId({ chainId, account })
 
   // TODO accountType and accountNumber need to come from account metadata
-  const { accountType } = accountIdToUtxoParams(accountId, 0)
-  const bip44Params = chainAdapter.getBIP44Params({ accountNumber: 0 })
-  return await chainAdapter.getAddress({ wallet, accountType, bip44Params })
+  const { accountType, utxoParams } = accountIdToUtxoParams(accountId, 0)
+  return await chainAdapter.getAddress({ wallet, accountType, ...utxoParams })
 }
 
 export const getUtxoParams = (sellAssetAccountId: string) => {


### PR DESCRIPTION
## Description

[This change](https://github.com/shapeshift/web/pull/2632/files#diff-0f315d183697744fb9d565e7d8f222eb50a96ee74a2ba513081de2fe5295f54b) in https://github.com/shapeshift/web/pull/2632 broke default asset setting for UTXOs.

This PR reverts the part of the PR that broke it.

## Notice

- [x] Have you followed the guidelines in our [Contributing]('https://github.com/shapeshift/web/blob/develop/CONTRIBUTING.md) guide?
- [x] Have you checked to ensure there aren't other open [Pull Requests](https://github.com/shapeshift/web/pulls) for the same update/change?

## Pull Request Type

- [x] :bug: Bug fix (Non-breaking Change: Fixes an issue)
- [ ] :hammer_and_wrench: Chore (Non-breaking Change: Doc updates, pkg upgrades, typos, etc..)
- [ ] :nail_care: New Feature (Breaking/Non-breaking Change)

## Issue (if applicable)

N/A

## Risk

Something else breaks that the change was meant to support.

## Testing

With the `ThorSwap` flag enabled, select a UTXO asset (e.g. BTC), and note that the default trade pair is now ETH:BTC instead of the fallback ETH:FOX.

### Engineering

As above.

### Operations

As above.

## Screenshots (if applicable)

<img width="408" alt="Screen Shot 2022-09-14 at 11 49 55 am" src="https://user-images.githubusercontent.com/97164662/190040527-a5387b68-a53a-4fa6-ba9e-34a22e07fbf8.png">
