### PR TITLE
fix: asset account totals

### DIFF
--- a/src/components/AssetHeader/AssetChart.tsx
+++ b/src/components/AssetHeader/AssetChart.tsx
@@ -32,12 +32,9 @@ import { bnOrZero } from 'lib/bignumber/bignumber'
 import { useEarnBalances } from 'pages/Defi/hooks/useEarnBalances'
 import type { AccountSpecifier } from 'state/slices/accountSpecifiersSlice/accountSpecifiersSlice'
 import {
-  selectTotalCryptoBalanceWithDelegations,
-  selectTotalFiatBalanceWithDelegations,
-} from 'state/slices/portfolioSlice/selectors'
-import {
   selectAssetById,
-  selectFirstAccountSpecifierByChainId,
+  selectCryptoBalanceIncludingStakingByFilter,
+  selectFiatBalanceIncludingStakingByFilter,
   selectMarketDataById,
 } from 'state/slices/selectors'
 import { useAppSelector } from 'state/store'
@@ -68,22 +65,12 @@ export const AssetChart = ({ accountId, assetId, isLoaded }: AssetChartProps) =>
   const { price } = marketData || {}
   const assetPrice = toFiat(price) ?? 0
   const [view, setView] = useState(accountId ? View.Balance : View.Price)
-  const accountSpecifier = useAppSelector(state =>
-    selectFirstAccountSpecifierByChainId(state, asset?.chainId),
-  )
-  const filter = useMemo(
-    () => ({ assetId, accountId, accountSpecifier }),
-    [assetId, accountId, accountSpecifier],
-  )
+
+  const filter = useMemo(() => ({ assetId, accountId }), [assetId, accountId])
   const translate = useTranslate()
 
-  const fiatBalanceWithDelegations = useAppSelector(state =>
-    selectTotalFiatBalanceWithDelegations(state, filter),
-  )
-
-  const cryptoBalanceWithDelegations = useAppSelector(state =>
-    selectTotalCryptoBalanceWithDelegations(state, filter),
-  )
+  const fiatBalance = useAppSelector(s => selectFiatBalanceIncludingStakingByFilter(s, filter))
+  const cryptoBalance = useAppSelector(s => selectCryptoBalanceIncludingStakingByFilter(s, filter))
 
   const earnBalances = useEarnBalances()
   const delegationBalance = useMemo(() => {
@@ -92,10 +79,8 @@ export const AssetChart = ({ accountId, assetId, isLoaded }: AssetChartProps) =>
   }, [assetId, earnBalances.opportunities])
 
   useEffect(() => {
-    if (bnOrZero(fiatBalanceWithDelegations).gt(0)) {
-      setView(View.Balance)
-    }
-  }, [fiatBalanceWithDelegations])
+    bnOrZero(fiatBalance).gt(0) && setView(View.Balance)
+  }, [fiatBalance])
 
   return (
     <Card>
@@ -124,7 +109,7 @@ export const AssetChart = ({ accountId, assetId, isLoaded }: AssetChartProps) =>
           <Card.Heading fontSize='4xl' lineHeight={1} mb={2}>
             <Skeleton isLoaded={isLoaded}>
               <NumberFormat
-                value={view === View.Price ? assetPrice : toFiat(fiatBalanceWithDelegations)}
+                value={view === View.Price ? assetPrice : toFiat(fiatBalance)}
                 displayType={'text'}
                 thousandSeparator={true}
                 isNumericString={true}
@@ -147,7 +132,7 @@ export const AssetChart = ({ accountId, assetId, isLoaded }: AssetChartProps) =>
             {view === View.Balance && (
               <Stat size='sm' color='gray.500'>
                 <Skeleton isLoaded={isLoaded}>
-                  <StatNumber>{`${cryptoBalanceWithDelegations} ${asset.symbol}`}</StatNumber>
+                  <StatNumber>{`${cryptoBalance} ${asset.symbol}`}</StatNumber>
                 </Skeleton>
               </Stat>
             )}

--- a/src/state/slices/portfolioSlice/selectors.ts
+++ b/src/state/slices/portfolioSlice/selectors.ts
@@ -40,7 +40,10 @@ import type { ReduxState } from 'state/reducer'
 import { createDeepEqualOutputSelector } from 'state/selector-utils'
 import { selectAssets } from 'state/slices/assetsSlice/selectors'
 import { selectMarketData } from 'state/slices/marketDataSlice/selectors'
-import { accountIdToFeeAssetId } from 'state/slices/portfolioSlice/utils'
+import {
+  accountIdToFeeAssetId,
+  genericBalanceIncludingStakingByFilter,
+} from 'state/slices/portfolioSlice/utils'
 import { selectBalanceThreshold } from 'state/slices/preferencesSlice/selectors'
 
 import type { AccountSpecifier } from '../accountSpecifiersSlice/accountSpecifiersSlice'
@@ -853,6 +856,20 @@ export const selectPortfolioAccountsFiatBalancesIncludingStaking = createDeepEqu
         }, {})
     )
   },
+)
+
+export const selectFiatBalanceIncludingStakingByFilter = createSelector(
+  selectPortfolioAccountsFiatBalancesIncludingStaking,
+  selectAssetIdParamFromFilterOptional,
+  selectAccountIdParamFromFilterOptional,
+  genericBalanceIncludingStakingByFilter,
+)
+
+export const selectCryptoBalanceIncludingStakingByFilter = createSelector(
+  selectPortfolioAccountsCryptoHumanBalancesIncludingStaking,
+  selectAssetIdParamFromFilterOptional,
+  selectAccountIdParamFromFilterOptional,
+  genericBalanceIncludingStakingByFilter,
 )
 
 export const selectPortfolioChainIdsSortedFiat = createDeepEqualOutputSelector(


### PR DESCRIPTION
## Description

<!-- Please describe your changes -->

fixes fiat and crypto amounts on asset and account pages, see screenshots

## Notice

<!-- Before submitting a pull request, please make sure you have answered the following: -->

- [x] Have you followed the guidelines in our [Contributing]('https://github.com/shapeshift/web/blob/develop/CONTRIBUTING.md) guide?
- [x] Have you checked to ensure there aren't other open [Pull Requests](https://github.com/shapeshift/web/pulls) for the same update/change?

## Pull Request Type

- [x] :bug: Bug fix (Non-breaking Change: Fixes an issue)
- [ ] :hammer_and_wrench: Chore (Non-breaking Change: Doc updates, pkg upgrades, typos, etc..)
- [ ] :nail_care: New Feature (Breaking/Non-breaking Change)

## Issue (if applicable)

<!-----------------------------------------------------------------------------
If applicable, please link to the github issue and put `closes #XXXX` in your comment to auto-close the issue that your PR fixes.
------------------------------------------------------------------------------>

does not close but related to #2614

## Risk

<!-----------------------------------------------------------------------------
Outline the scope of your changes and the risk associated with them. You must use your discretion as an engineer to determine the potential impact of your changes.

E.g. an upgrade to `hdwallet` or core state management would be considered higher risk, and might require a full regression test. UI or isolated view changes, or something behind a feature flag may have near zero risk. Small bug fixes might require testing isolated to the specific fix.
------------------------------------------------------------------------------>

* fiat or crypto total amounts may be incorrect on asset or individual account pages

## Testing

<!-----------------------------------------------------------------------------
We treat every PR to be merged with the same scrutiny as if we were merging directly to production.

Your PR will not be merged if you do not complete the sections below for our engineering and operations teams to test.
------------------------------------------------------------------------------>

### Engineering

* check my logic for filtering by optional account and asset ids, given we use the
  `PortfolioBalancesById` type we can reuse the same generic reduce logic across multiple selectors

<!-----------------------------------------------------------------------------
Include sufficient information here for an engineer to test your PR. This may include how to test locally, in a built environment, changes to infrastructure etc.
------------------------------------------------------------------------------>

### Operations

* follow the same testing steps as #2731, but this applies to the fiat and crypto balances show in
  the screenshots below
* please note the *staked amount* will still be incorrect, this fixes the fiat and crypto totals
  shown
* check that the asset pages aggregates the fiat and crypto amounts across all accounts correctly
* check that the account pages show the individual fiat and crypto amounts correctly

<!-----------------------------------------------------------------------------
If your changes have a user-facing impact, describe how a non-technical QA team can functionally test your changes in a preview environment.

If they are not user-facing please describe how to test for any regressions that may occur.
------------------------------------------------------------------------------>

## Screenshots (if applicable)

**after**

*asset* page

<img width="775" alt="image" src="https://user-images.githubusercontent.com/88504456/190230708-8f61f01b-b820-42ef-bb97-db41742a9102.png">

*account 0* page

<img width="784" alt="image" src="https://user-images.githubusercontent.com/88504456/190230771-03531aad-af60-4504-a5d8-1c062d15fd74.png">

*account 1* page

<img width="797" alt="image" src="https://user-images.githubusercontent.com/88504456/190230844-a0061870-9f54-40fe-af38-2b54900f3f07.png">

