### PR TITLE
chore: remove translation dupe key and strings

### DIFF
--- a/src/assets/translations/en/main.json
+++ b/src/assets/translations/en/main.json
@@ -616,13 +616,6 @@
         }
       }
     },
-    "stake": {
-      "txFees": {
-        "low": "Low",
-        "medium": "Medium",
-        "high": "High"
-      }
-    },
     "send": {
       "getBalanceError": "Error getting wallet balances",
       "broadcastingTransaction": "Broadcasting Transaction",

--- a/src/assets/translations/id/main.json
+++ b/src/assets/translations/id/main.json
@@ -436,13 +436,6 @@
         }
       }
     },
-    "stake": {
-      "txFees": {
-        "low": "Rendah",
-        "medium": "Medium",
-        "high": "Tinggi"
-      }
-    },
     "send": {
       "getBalanceError": "Kesalahan mendapatkan saldo dompet",
       "broadcastingTransaction": "Transaksi Penyiaran",

--- a/src/assets/translations/ko/main.json
+++ b/src/assets/translations/ko/main.json
@@ -463,13 +463,6 @@
         }
       }
     },
-    "stake": {
-      "txFees": {
-        "low": "낮음",
-        "medium": "중간",
-        "high": "높음"
-      }
-    },
     "send": {
       "getBalanceError": "지갑 잔액을 가져오는 중에 오류가 발생했습니다.",
       "broadcastingTransaction": "트랜잭션을 브로드캐스팅하는 중입니다.",

--- a/src/assets/translations/zh/main.json
+++ b/src/assets/translations/zh/main.json
@@ -427,13 +427,6 @@
         }
       }
     },
-    "stake": {
-      "txFees": {
-        "low": "低的",
-        "medium": "中等的",
-        "high": "高的"
-      }
-    },
     "send": {
       "getBalanceError": "获取钱包余额出现错误",
       "broadcastingTransaction": "广播交易中",


### PR DESCRIPTION
## Description

Removing a duplicate key `modals.stake` in the translation files and its currently unused strings.

## Notice

<!-- Before submitting a pull request, please make sure you have answered the following: -->

- [x] Have you followed the guidelines in our [Contributing]('https://github.com/shapeshift/web/blob/develop/CONTRIBUTING.md) guide?
- [x] Have you checked to ensure there aren't other open [Pull Requests](https://github.com/shapeshift/web/pulls) for the same update/change?

## Pull Request Type

- [ ] :bug: Bug fix (Non-breaking Change: Fixes an issue)
- [x] :hammer_and_wrench: Chore (Non-breaking Change: Doc updates, pkg upgrades, typos, etc..)
- [ ] :nail_care: New Feature (Breaking/Non-breaking Change)

## Issue (if applicable)

Closes #2747

## Risk

None.

## Testing

The changes in these files relate to unused strings, nothing to test.

### Engineering

The changes in these files relate to unused strings, nothing to test.
### Operations

The changes in these files relate to unused strings, nothing to test.
