### PR TITLE
fix: show total crypto value with fees

### DIFF
--- a/src/components/Modals/Send/views/Confirm.tsx
+++ b/src/components/Modals/Send/views/Confirm.tsx
@@ -63,6 +63,11 @@ export const Confirm = () => {
     return bnOrZero(fiatAmount).plus(fiatFee).toString()
   }, [fiatAmount, fees, feeType])
 
+  const cryptoAmountWithFees = useMemo(() => {
+    const { txFee } = fees ? fees[feeType as FeeDataKey] : { txFee: 0 }
+    return bnOrZero(cryptoAmount).plus(txFee).toString()
+  }, [cryptoAmount, fees, feeType])
+
   const borderColor = useColorModeValue('gray.100', 'gray.750')
 
   // We don't want this firing -- but need it for typing
@@ -153,7 +158,7 @@ export const Confirm = () => {
                 textTransform='uppercase'
                 maximumFractionDigits={6}
                 symbol={cryptoSymbol}
-                value={cryptoAmount}
+                value={cryptoAmountWithFees}
               />
             </Row.Value>
             <Row.Label>

--- a/src/plugins/cosmos/components/modals/Send/views/Confirm.tsx
+++ b/src/plugins/cosmos/components/modals/Send/views/Confirm.tsx
@@ -48,6 +48,11 @@ export const Confirm = () => {
     return bnOrZero(fiatAmount).plus(fiatFee).toString()
   }, [fiatAmount, fees, feeType])
 
+  const cryptoAmountWithFees = useMemo(() => {
+    const { txFee } = fees ? fees[feeType as FeeDataKey] : { txFee: 0 }
+    return bnOrZero(cryptoAmount).plus(txFee).toString()
+  }, [cryptoAmount, fees, feeType])
+
   const borderColor = useColorModeValue('gray.100', 'gray.750')
 
   // We don't want this firing -- but need it for typing
@@ -148,7 +153,7 @@ export const Confirm = () => {
                 textTransform='uppercase'
                 maximumFractionDigits={6}
                 symbol={cryptoSymbol}
-                value={cryptoAmount}
+                value={cryptoAmountWithFees}
               />
             </Row.Value>
             <Row.Label>


### PR DESCRIPTION
## Description

Show total crypto value with fees in Confirm summary

## Notice

<!-- Before submitting a pull request, please make sure you have answered the following: -->

- [x] Have you followed the guidelines in our [Contributing]('https://github.com/shapeshift/web/blob/develop/CONTRIBUTING.md) guide?
- [ ] Have you checked to ensure there aren't other open [Pull Requests](https://github.com/shapeshift/web/pulls) for the same update/change?

## Pull Request Type

- [x] :bug: Bug fix (Non-breaking Change: Fixes an issue)
- [ ] :hammer_and_wrench: Chore (Non-breaking Change: Doc updates, pkg upgrades, typos, etc..)
- [ ] :nail_care: New Feature (Breaking/Non-breaking Change)

## Issue (if applicable)

<!-----------------------------------------------------------------------------
If applicable, please link to the github issue and put `closes #XXXX` in your comment to auto-close the issue that your PR fixes.
------------------------------------------------------------------------------>

closes #

## Risk

Low - math should add up

## Testing

Verify `Total` crypto value on Confirm summary displays the correct amount (cryptoAmount + fee)

### Engineering

see above

### Operations

see above

## Screenshots (if applicable)

### CosmosSDK Modal

#### Before
![image](https://user-images.githubusercontent.com/35275952/190231042-ee9b7f75-e2d9-4189-9211-76fc3a64654e.png)

#### After
![image](https://user-images.githubusercontent.com/35275952/190230778-10117558-4dfc-42c4-b342-a87fcabf9948.png)

### Common Modal

#### Before
![image](https://user-images.githubusercontent.com/35275952/190231463-9b227326-e75f-4552-8f77-2ee19260df88.png)

#### After
![image](https://user-images.githubusercontent.com/35275952/190231339-7fa076b3-56ff-4b40-9df2-4776694aded6.png)