### PR TITLE
fix: unrug default assets

### DIFF
--- a/src/components/Trade/hooks/useDefaultAssetsService.ts
+++ b/src/components/Trade/hooks/useDefaultAssetsService.ts
@@ -153,13 +153,14 @@ export const useDefaultAssetsService = (routeBuyAssetId?: AssetId) => {
         setValue('sellTradeAsset.asset', sellAsset)
       })()
     }
+    // We don't want to run this effect when getReceiveAddressFromBuyAsset changes
+    // eslint-disable-next-line react-hooks/exhaustive-deps
   }, [
     assets,
     buyAssetFiatRateData,
     buyAssetId,
     defaultAssetFiatRateData,
     defaultAssetIdPair,
-    getReceiveAddressFromBuyAsset,
     isBuyAssetFiatRateLoading,
     isBuyAssetFiatRateUninitialized,
     isDefaultAssetFiatRateLoading,

--- a/src/components/Trade/hooks/useDefaultAssetsService.ts
+++ b/src/components/Trade/hooks/useDefaultAssetsService.ts
@@ -11,7 +11,7 @@ import {
 } from '@shapeshiftoss/caip'
 import { supportsCosmos, supportsETH, supportsOsmosis } from '@shapeshiftoss/hdwallet-core'
 import { useEffect, useMemo, useState } from 'react'
-import { useFormContext, useWatch } from 'react-hook-form'
+import { useFormContext } from 'react-hook-form'
 import { useSelector } from 'react-redux'
 import { useSwapper } from 'components/Trade/hooks/useSwapper/useSwapperV2'
 import { getDefaultAssetIdPairByChainId } from 'components/Trade/hooks/useSwapper/utils'
@@ -36,8 +36,7 @@ export const useDefaultAssetsService = (routeBuyAssetId?: AssetId) => {
     state: { wallet },
   } = useWallet()
   const { connectedEvmChainId } = useEvm()
-  const { setValue, control } = useFormContext<TS>()
-  const buyAssetAccountId = useWatch({ control, name: 'buyAssetAccountId' })
+  const { setValue } = useFormContext<TS>()
   const [buyAssetFiatRateArgs, setBuyAssetFiatRateArgs] = useState<UsdRateInputArg>(skipToken)
   const [defaultAssetFiatRateArgs, setDefaultAssetFiatRateArgs] =
     useState<UsdRateInputArg>(skipToken)
@@ -145,8 +144,9 @@ export const useDefaultAssetsService = (routeBuyAssetId?: AssetId) => {
 
     if (assetPair) {
       ;(async () => {
-        const buyAsset = buyAssetAccountId ? assetPair.buyAsset : assets[foxAssetId]
-        const sellAsset = buyAssetAccountId ? assetPair.sellAsset : assets[ethAssetId]
+        const receiveAddress = await getReceiveAddressFromBuyAsset(assetPair.buyAsset)
+        const buyAsset = receiveAddress ? assetPair.buyAsset : assets[foxAssetId]
+        const sellAsset = receiveAddress ? assetPair.sellAsset : assets[ethAssetId]
         setValue('action', TradeAmountInputField.SELL_CRYPTO)
         setValue('amount', '0')
         setValue('buyTradeAsset.asset', buyAsset)
@@ -155,7 +155,6 @@ export const useDefaultAssetsService = (routeBuyAssetId?: AssetId) => {
     }
   }, [
     assets,
-    buyAssetAccountId,
     buyAssetFiatRateData,
     buyAssetId,
     defaultAssetFiatRateData,

--- a/src/components/Trade/hooks/useDefaultAssetsService.ts
+++ b/src/components/Trade/hooks/useDefaultAssetsService.ts
@@ -11,7 +11,7 @@ import {
 } from '@shapeshiftoss/caip'
 import { supportsCosmos, supportsETH, supportsOsmosis } from '@shapeshiftoss/hdwallet-core'
 import { useEffect, useMemo, useState } from 'react'
-import { useFormContext } from 'react-hook-form'
+import { useFormContext, useWatch } from 'react-hook-form'
 import { useSelector } from 'react-redux'
 import { useSwapper } from 'components/Trade/hooks/useSwapper/useSwapperV2'
 import { getDefaultAssetIdPairByChainId } from 'components/Trade/hooks/useSwapper/utils'
@@ -36,7 +36,8 @@ export const useDefaultAssetsService = (routeBuyAssetId?: AssetId) => {
     state: { wallet },
   } = useWallet()
   const { connectedEvmChainId } = useEvm()
-  const { setValue } = useFormContext<TS>()
+  const { setValue, control } = useFormContext<TS>()
+  const buyAssetAccountId = useWatch({ control, name: 'buyAssetAccountId' })
   const [buyAssetFiatRateArgs, setBuyAssetFiatRateArgs] = useState<UsdRateInputArg>(skipToken)
   const [defaultAssetFiatRateArgs, setDefaultAssetFiatRateArgs] =
     useState<UsdRateInputArg>(skipToken)
@@ -144,23 +145,22 @@ export const useDefaultAssetsService = (routeBuyAssetId?: AssetId) => {
 
     if (assetPair) {
       ;(async () => {
-        const receiveAddress = await getReceiveAddressFromBuyAsset()
-        const buyAsset = receiveAddress ? assetPair.buyAsset : assets[foxAssetId]
-        const sellAsset = receiveAddress ? assetPair.sellAsset : assets[ethAssetId]
+        const buyAsset = buyAssetAccountId ? assetPair.buyAsset : assets[foxAssetId]
+        const sellAsset = buyAssetAccountId ? assetPair.sellAsset : assets[ethAssetId]
         setValue('action', TradeAmountInputField.SELL_CRYPTO)
         setValue('amount', '0')
         setValue('buyTradeAsset.asset', buyAsset)
         setValue('sellTradeAsset.asset', sellAsset)
       })()
     }
-    // We don't want to run this effect when getReceiveAddressFromBuyAsset changes
-    // eslint-disable-next-line react-hooks/exhaustive-deps
   }, [
     assets,
+    buyAssetAccountId,
     buyAssetFiatRateData,
     buyAssetId,
     defaultAssetFiatRateData,
     defaultAssetIdPair,
+    getReceiveAddressFromBuyAsset,
     isBuyAssetFiatRateLoading,
     isBuyAssetFiatRateUninitialized,
     isDefaultAssetFiatRateLoading,

--- a/src/components/Trade/hooks/useSwapper/useSwapperV2.ts
+++ b/src/components/Trade/hooks/useSwapper/useSwapperV2.ts
@@ -10,6 +10,7 @@ import { getSwapperManager } from 'components/Trade/hooks/useSwapper/swapperMana
 import {
   filterAssetsByIds,
   getFirstReceiveAddress,
+  getSelectedReceiveAddress,
   getUtxoParams,
   isSupportedNonUtxoSwappingChain,
   isSupportedUtxoSwappingChain,
@@ -37,6 +38,7 @@ export const useSwapper = () => {
   const buyTradeAsset = useWatch({ control, name: 'buyTradeAsset' })
   const quote = useWatch({ control, name: 'quote' })
   const sellAssetAccountId = useWatch({ control, name: 'sellAssetAccountId' })
+  const buyAssetAccountId = useWatch({ control, name: 'buyAssetAccountId' })
 
   // Constants
   const sellAsset = sellTradeAsset?.asset
@@ -74,17 +76,25 @@ export const useSwapper = () => {
       const chainAdapter = getChainAdapterManager().get(receiveAddressChainId)
       if (!(chainAdapter && wallet)) return
       try {
-        return await getFirstReceiveAddress({
-          accountSpecifiersList,
-          buyAsset,
-          chainAdapter,
-          wallet,
-        })
+        const receiveAddress = await (async () =>
+          buyAssetAccountId
+            ? getSelectedReceiveAddress({
+                chainAdapter,
+                wallet,
+                buyAssetAccountId,
+              })
+            : getFirstReceiveAddress({
+                accountSpecifiersList,
+                buyAsset,
+                chainAdapter,
+                wallet,
+              }))()
+        return receiveAddress
       } catch (e) {
         moduleLogger.info(e, 'No receive address for buy asset, using default asset pair')
       }
     },
-    [accountSpecifiersList, wallet],
+    [accountSpecifiersList, buyAssetAccountId, wallet],
   )
 
   const getSupportedBuyAssetsFromSellAsset = useCallback(

--- a/src/components/Trade/hooks/useSwapper/useSwapperV2.ts
+++ b/src/components/Trade/hooks/useSwapper/useSwapperV2.ts
@@ -1,5 +1,5 @@
 import { type Asset } from '@shapeshiftoss/asset-service'
-import { fromAccountId } from '@shapeshiftoss/caip'
+import { fromAssetId } from '@shapeshiftoss/caip'
 import type { UtxoBaseAdapter } from '@shapeshiftoss/chain-adapters'
 import { type Swapper, type UtxoSupportedChainIds, SwapperManager } from '@shapeshiftoss/swapper'
 import type { KnownChainIds } from '@shapeshiftoss/types'
@@ -9,7 +9,7 @@ import { useSelector } from 'react-redux'
 import { getSwapperManager } from 'components/Trade/hooks/useSwapper/swapperManager'
 import {
   filterAssetsByIds,
-  getSelectedReceiveAddress,
+  getFirstReceiveAddress,
   getUtxoParams,
   isSupportedNonUtxoSwappingChain,
   isSupportedUtxoSwappingChain,
@@ -20,6 +20,7 @@ import { getChainAdapterManager } from 'context/PluginProvider/chainAdapterSingl
 import { useWallet } from 'hooks/useWallet/useWallet'
 import { logger } from 'lib/logger'
 import { toBaseUnit } from 'lib/math'
+import { selectAccountSpecifiers } from 'state/slices/accountSpecifiersSlice/selectors'
 import { selectAssetIds } from 'state/slices/assetsSlice/selectors'
 import { selectFeatureFlags } from 'state/slices/preferencesSlice/selectors'
 
@@ -36,7 +37,6 @@ export const useSwapper = () => {
   const buyTradeAsset = useWatch({ control, name: 'buyTradeAsset' })
   const quote = useWatch({ control, name: 'quote' })
   const sellAssetAccountId = useWatch({ control, name: 'sellAssetAccountId' })
-  const buyAssetAccountId = useWatch({ control, name: 'buyAssetAccountId' })
 
   // Constants
   const sellAsset = sellTradeAsset?.asset
@@ -55,6 +55,7 @@ export const useSwapper = () => {
   // Selectors
   const flags = useSelector(selectFeatureFlags)
   const assetIds = useSelector(selectAssetIds)
+  const accountSpecifiersList = useSelector(selectAccountSpecifiers)
 
   // Callbacks
   const getSupportedSellableAssets = useCallback(
@@ -67,22 +68,24 @@ export const useSwapper = () => {
     [assetIds, swapperManager],
   )
 
-  const getReceiveAddressFromBuyAsset = useCallback(async () => {
-    if (!(buyAssetAccountId && wallet)) return
-    const { chainId: receiveAddressChainId } = fromAccountId(buyAssetAccountId)
-    // const { chainId: receiveAddressChainId } = fromAssetId(buyAsset.assetId)
-    const chainAdapter = getChainAdapterManager().get(receiveAddressChainId)
-    if (!chainAdapter) return
-    try {
-      return await getSelectedReceiveAddress({
-        chainAdapter,
-        wallet,
-        accountId: buyAssetAccountId,
-      })
-    } catch (e) {
-      moduleLogger.info(e, 'No receive address for buy asset, using default asset pair')
-    }
-  }, [buyAssetAccountId, wallet])
+  const getReceiveAddressFromBuyAsset = useCallback(
+    async (buyAsset: Asset) => {
+      const { chainId: receiveAddressChainId } = fromAssetId(buyAsset.assetId)
+      const chainAdapter = getChainAdapterManager().get(receiveAddressChainId)
+      if (!(chainAdapter && wallet)) return
+      try {
+        return await getFirstReceiveAddress({
+          accountSpecifiersList,
+          buyAsset,
+          chainAdapter,
+          wallet,
+        })
+      } catch (e) {
+        moduleLogger.info(e, 'No receive address for buy asset, using default asset pair')
+      }
+    },
+    [accountSpecifiersList, wallet],
+  )
 
   const getSupportedBuyAssetsFromSellAsset = useCallback(
     (assets: Asset[]): Asset[] | undefined => {
@@ -189,7 +192,7 @@ export const useSwapper = () => {
     ;(async () => {
       // TODO: get the actual receive address instead of the first
       try {
-        const receiveAddress = await getReceiveAddressFromBuyAsset()
+        const receiveAddress = await getReceiveAddressFromBuyAsset(buyAsset)
         setReceiveAddress(receiveAddress)
       } catch (e) {
         setReceiveAddress(null)

--- a/src/components/Trade/hooks/useSwapper/utils.ts
+++ b/src/components/Trade/hooks/useSwapper/utils.ts
@@ -10,6 +10,7 @@ import {
   fromAssetId,
   fromChainId,
   osmosisAssetId,
+  toAccountId,
 } from '@shapeshiftoss/caip'
 import { type EvmChainId } from '@shapeshiftoss/chain-adapters'
 import {
@@ -52,11 +53,23 @@ export const isSupportedNonUtxoSwappingChain = (
 }
 
 // Pure functions
-export const getSelectedReceiveAddress: GetFirstReceiveAddress = async ({
+export const getFirstReceiveAddress: GetFirstReceiveAddress = async ({
+  accountSpecifiersList,
+  buyAsset,
   chainAdapter,
   wallet,
-  accountId,
 }) => {
+  const receiveAddressAccountSpecifiers = accountSpecifiersList.find(
+    specifiers => specifiers[buyAsset.chainId],
+  )
+
+  if (!receiveAddressAccountSpecifiers) throw new Error('no receiveAddressAccountSpecifiers')
+  const account = receiveAddressAccountSpecifiers[buyAsset.chainId]
+  if (!account) throw new Error(`no account for ${buyAsset.chainId}`)
+
+  const { chainId } = buyAsset
+  const accountId = toAccountId({ chainId, account })
+
   // TODO accountType and accountNumber need to come from account metadata
   const { accountType, utxoParams } = accountIdToUtxoParams(accountId, 0)
   return await chainAdapter.getAddress({ wallet, accountType, ...utxoParams })

--- a/src/components/Trade/hooks/useSwapper/utils.ts
+++ b/src/components/Trade/hooks/useSwapper/utils.ts
@@ -23,8 +23,8 @@ import { getSwapperManager } from 'components/Trade/hooks/useSwapper/swapperMana
 import {
   type AssetIdTradePair,
   type DisplayFeeData,
+  type GetFirstReceiveAddress,
   type GetFormFeesArgs,
-  type GetSelectedReceiveAddress,
   type SupportedSwappingChain,
 } from 'components/Trade/types'
 import { bn, bnOrZero } from 'lib/bignumber/bignumber'
@@ -52,7 +52,7 @@ export const isSupportedNonUtxoSwappingChain = (
 }
 
 // Pure functions
-export const getSelectedReceiveAddress: GetSelectedReceiveAddress = async ({
+export const getSelectedReceiveAddress: GetFirstReceiveAddress = async ({
   chainAdapter,
   wallet,
   accountId,

--- a/src/components/Trade/hooks/useSwapper/utils.ts
+++ b/src/components/Trade/hooks/useSwapper/utils.ts
@@ -21,6 +21,7 @@ import {
 } from '@shapeshiftoss/swapper'
 import { KnownChainIds } from '@shapeshiftoss/types'
 import { getSwapperManager } from 'components/Trade/hooks/useSwapper/swapperManager'
+import type { GetSelectedReceiveAddress } from 'components/Trade/types'
 import {
   type AssetIdTradePair,
   type DisplayFeeData,
@@ -70,6 +71,16 @@ export const getFirstReceiveAddress: GetFirstReceiveAddress = async ({
   const { chainId } = buyAsset
   const accountId = toAccountId({ chainId, account })
 
+  // TODO accountType and accountNumber need to come from account metadata
+  const { accountType, utxoParams } = accountIdToUtxoParams(accountId, 0)
+  return await chainAdapter.getAddress({ wallet, accountType, ...utxoParams })
+}
+
+export const getSelectedReceiveAddress: GetSelectedReceiveAddress = async ({
+  chainAdapter,
+  wallet,
+  buyAssetAccountId: accountId,
+}) => {
   // TODO accountType and accountNumber need to come from account metadata
   const { accountType, utxoParams } = accountIdToUtxoParams(accountId, 0)
   return await chainAdapter.getAddress({ wallet, accountType, ...utxoParams })

--- a/src/components/Trade/hooks/useTradeQuoteService.ts
+++ b/src/components/Trade/hooks/useTradeQuoteService.ts
@@ -42,9 +42,7 @@ export const useTradeQuoteService = () => {
     state: { wallet },
   } = useWallet()
   const [tradeQuoteArgs, setTradeQuoteArgs] = useState<TradeQuoteInputArg>(skipToken)
-
-  // Hooks
-  const { getReceiveAddressFromBuyAsset } = useSwapper()
+  const { receiveAddress } = useSwapper()
 
   // Constants
   const sellAsset = sellTradeAsset?.asset
@@ -61,10 +59,8 @@ export const useTradeQuoteService = () => {
   // Trigger trade quote query
   useEffect(() => {
     const sellTradeAssetAmount = sellTradeAsset?.amount
-    if (sellAsset && buyAsset && wallet && sellTradeAssetAmount) {
+    if (sellAsset && buyAsset && wallet && sellTradeAssetAmount && receiveAddress) {
       ;(async () => {
-        const receiveAddress = await getReceiveAddressFromBuyAsset()
-        if (!receiveAddress) return
         const { chainId: receiveAddressChainId } = fromAssetId(buyAsset.assetId)
         const chainAdapter = getChainAdapterManager().get(receiveAddressChainId)
 
@@ -114,7 +110,7 @@ export const useTradeQuoteService = () => {
     amount,
     buyAsset,
     buyTradeAsset,
-    getReceiveAddressFromBuyAsset,
+    receiveAddress,
     selectedCurrencyToUsdRate,
     sellAsset,
     sellAssetAccountId,

--- a/src/components/Trade/types.ts
+++ b/src/components/Trade/types.ts
@@ -1,5 +1,5 @@
 import { type Asset } from '@shapeshiftoss/asset-service'
-import type { AssetId } from '@shapeshiftoss/caip'
+import type { AccountId, AssetId } from '@shapeshiftoss/caip'
 import { type ChainId } from '@shapeshiftoss/caip'
 import { type ChainAdapter } from '@shapeshiftoss/chain-adapters'
 import { type HDWallet } from '@shapeshiftoss/hdwallet-core'
@@ -78,7 +78,14 @@ type GetFirstReceiveAddressArgs = {
   wallet: HDWallet
 }
 
+type GetSelectedReceiveAddressArgs = {
+  chainAdapter: ChainAdapter<ChainId>
+  wallet: HDWallet
+  buyAssetAccountId: AccountId
+}
+
 export type GetFirstReceiveAddress = (args: GetFirstReceiveAddressArgs) => Promise<string>
+export type GetSelectedReceiveAddress = (args: GetSelectedReceiveAddressArgs) => Promise<string>
 
 export type TradeQuoteInputCommonArgs = Pick<
   GetTradeQuoteInput,

--- a/src/components/Trade/types.ts
+++ b/src/components/Trade/types.ts
@@ -70,13 +70,13 @@ export type SupportedSwappingChain =
   | KnownChainIds.OsmosisMainnet
   | KnownChainIds.CosmosMainnet
 
-type GetSelectedReceiveAddressArgs = {
+type GetFirstReceiveAddressArgs = {
   chainAdapter: ChainAdapter<ChainId>
   wallet: HDWallet
   accountId: AccountId
 }
 
-export type GetSelectedReceiveAddress = (args: GetSelectedReceiveAddressArgs) => Promise<string>
+export type GetFirstReceiveAddress = (args: GetFirstReceiveAddressArgs) => Promise<string>
 
 export type TradeQuoteInputCommonArgs = Pick<
   GetTradeQuoteInput,

--- a/src/components/Trade/types.ts
+++ b/src/components/Trade/types.ts
@@ -1,5 +1,5 @@
 import { type Asset } from '@shapeshiftoss/asset-service'
-import type { AccountId, AssetId } from '@shapeshiftoss/caip'
+import type { AssetId } from '@shapeshiftoss/caip'
 import { type ChainId } from '@shapeshiftoss/caip'
 import { type ChainAdapter } from '@shapeshiftoss/chain-adapters'
 import { type HDWallet } from '@shapeshiftoss/hdwallet-core'
@@ -12,6 +12,7 @@ import {
   type TradeQuote,
 } from '@shapeshiftoss/swapper'
 import type { KnownChainIds } from '@shapeshiftoss/types'
+import type { selectAccountSpecifiers } from 'state/slices/accountSpecifiersSlice/selectors'
 import { type AccountSpecifier } from 'state/slices/portfolioSlice/portfolioSliceCommon'
 
 export enum TradeAmountInputField {
@@ -71,9 +72,10 @@ export type SupportedSwappingChain =
   | KnownChainIds.CosmosMainnet
 
 type GetFirstReceiveAddressArgs = {
+  accountSpecifiersList: ReturnType<typeof selectAccountSpecifiers>
+  buyAsset: Asset
   chainAdapter: ChainAdapter<ChainId>
   wallet: HDWallet
-  accountId: AccountId
 }
 
 export type GetFirstReceiveAddress = (args: GetFirstReceiveAddressArgs) => Promise<string>


### PR DESCRIPTION
## Description

Recent logic that was intended for swapperV2, in combination with recent account selection PRs, inadvertently affected swapperV1, and caused the default assets to be set incorrectly.

This PR reverts a previous implementation of the "select receive address" implementation and reimplements a new one that avoids changing existing swapperV1 logic.

The only "new" code here is in https://github.com/shapeshift/web/commit/52988ce242f42c2914a81cfcb84c37f521cca087 - the rest simply re-instates where develop was 24 hours ago.

## Notice

- [x] Have you followed the guidelines in our [Contributing]('https://github.com/shapeshift/web/blob/develop/CONTRIBUTING.md) guide?
- [x] Have you checked to ensure there aren't other open [Pull Requests](https://github.com/shapeshift/web/pulls) for the same update/change?

## Pull Request Type

- [x] :bug: Bug fix (Non-breaking Change: Fixes an issue)
- [ ] :hammer_and_wrench: Chore (Non-breaking Change: Doc updates, pkg upgrades, typos, etc..)
- [ ] :nail_care: New Feature (Breaking/Non-breaking Change)

## Issue (if applicable)

Existing release bug.

## Risk

Touches receive address logic, which is consumed downstream by the `useDefaultAssetsService'. There is a risk default assets are still broken for some wallets/assets.

## Testing

When using swapperV1, default asset pairs should be set correctly on both the dashboard and assets page.

`swapperV2` should still work, though that is not the intent of this PR.

### Engineering

As above.

### Operations

As above.

## Screenshots (if applicable)

N/A