### PR TITLE
fix(mobile): turn off wallet loading spinner

### DIFF
--- a/src/context/WalletProvider/WalletProvider.tsx
+++ b/src/context/WalletProvider/WalletProvider.tsx
@@ -376,6 +376,8 @@ export const WalletProvider = ({ children }: { children: React.ReactNode }): JSX
                       },
                     })
                     dispatch({ type: WalletActions.SET_IS_CONNECTED, payload: true })
+                    // Turn off the loading spinner for the wallet button in
+                    dispatch({ type: WalletActions.SET_LOCAL_WALLET_LOADING, payload: false })
                   } else {
                     disconnect()
                   }

--- a/src/context/WalletProvider/config.ts
+++ b/src/context/WalletProvider/config.ts
@@ -84,9 +84,6 @@ export const SUPPORTED_WALLETS: Record<KeyManager, SupportedWalletInfo> = {
       { path: '/mobile/create-test', component: MobileTestPhrase },
       { path: '/mobile/success', component: MobileSuccess },
     ],
-    // @TODO: Update
-    connectedWalletMenuRoutes: [{ path: WalletConnectedRoutes.Native, component: NativeMenu }],
-    connectedWalletMenuInitialPath: WalletConnectedRoutes.Native,
   },
   [KeyManager.Native]: {
     ...NativeConfig,


### PR DESCRIPTION
## Description

When the app launches and finds a locally saved to pair, if the wallet is a `mobile` wallet, turn off the loading spinner in the UserMenu.

See https://github.com/shapeshift/mobile-app/issues/50

## Notice

<!-- Before submitting a pull request, please make sure you have answered the following: -->

- [X] Have you followed the guidelines in our [Contributing]('https://github.com/shapeshift/web/blob/develop/CONTRIBUTING.md) guide?
- [X] Have you checked to ensure there aren't other open [Pull Requests](https://github.com/shapeshift/web/pulls) for the same update/change?

## Pull Request Type

- [X] :bug: Bug fix (Non-breaking Change: Fixes an issue)
- [ ] :hammer_and_wrench: Chore (Non-breaking Change: Doc updates, pkg upgrades, typos, etc..)
- [ ] :nail_care: New Feature (Breaking/Non-breaking Change)

## Issue (if applicable)

See https://github.com/shapeshift/mobile-app/issues/50

## Risk
None/Very low - fixes a bug with a one line change. There shouldn't be any side-effects or regressions.
## Testing
1. Pair a mobile wallet
2. Close the app
3. Open the app
4. You should be taken to the Dashboad
5. Click hamburger menu
6. You should see the name of your mobile wallet at the top

### Engineering
See Testing
### Operations
See Testing
## Screenshots (if applicable)
### Before
![image](https://user-images.githubusercontent.com/1958266/190875447-e02cc12e-2d6d-436b-ba94-4426086dcb6f.png)
### After
![image](https://user-images.githubusercontent.com/1958266/190875453-62dce526-6159-4ca7-baa1-fc0bae8548c9.png)
