### PR TITLE
feat: foxy opportunities full multi-account support

### DIFF
--- a/src/components/StakingVaults/AllEarnOpportunities.tsx
+++ b/src/components/StakingVaults/AllEarnOpportunities.tsx
@@ -29,7 +29,7 @@ export const AllEarnOpportunities = () => {
 
   const sortedVaults = useSortedVaults()
 
-  const { data: foxyBalancesData } = useFoxyBalances()
+  const { data: foxyBalancesData } = useFoxyBalances({ accountNumber: 0 })
   const { onlyVisibleFoxFarmingOpportunities, foxEthLpOpportunity } = useFoxEth()
 
   const { cosmosSdkStakingOpportunities: cosmosStakingOpportunities } = useCosmosSdkStakingBalances(

--- a/src/components/StakingVaults/EarnOpportunities.tsx
+++ b/src/components/StakingVaults/EarnOpportunities.tsx
@@ -36,7 +36,7 @@ export const EarnOpportunities = ({ assetId }: EarnOpportunitiesProps) => {
   } = useWallet()
   const asset = useAppSelector(state => selectAssetById(state, assetId))
   const { vaults } = useVaultBalances()
-  const { data: foxyBalancesData } = useFoxyBalances()
+  const { data: foxyBalancesData } = useFoxyBalances({ accountNumber: 0 })
 
   const { onlyVisibleFoxFarmingOpportunities, foxEthLpOpportunity } = useFoxEth()
   const featureFlags = useAppSelector(selectFeatureFlags)

--- a/src/features/defi/providers/foxy/components/FoxyManager/Deposit/FoxyDeposit.tsx
+++ b/src/features/defi/providers/foxy/components/FoxyManager/Deposit/FoxyDeposit.tsx
@@ -108,7 +108,9 @@ export const FoxyDeposit: React.FC<{
       [DefiStep.Info]: {
         label: translate('defi.steps.deposit.info.title'),
         description: translate('defi.steps.deposit.info.description', { asset: asset.symbol }),
-        component: ownProps => <Deposit {...ownProps} onAccountIdChange={handleAccountIdChange} />,
+        component: ownProps => (
+          <Deposit {...ownProps} accountId={accountId} onAccountIdChange={handleAccountIdChange} />
+        ),
       },
       [DefiStep.Approve]: {
         label: translate('defi.steps.approve.title'),

--- a/src/features/defi/providers/foxy/components/FoxyManager/Deposit/components/Approve.tsx
+++ b/src/features/defi/providers/foxy/components/FoxyManager/Deposit/components/Approve.tsx
@@ -59,7 +59,10 @@ export const Approve: React.FC<ApproveProps> = ({ accountId, onNext }) => {
   const { state: walletState } = useWallet()
 
   const accountFilter = useMemo(() => ({ accountId: accountId ?? '' }), [accountId])
-  const accountAddress = useMemo(() => fromAccountId(accountId ?? '').account, [accountId])
+  const accountAddress = useMemo(
+    () => (accountId ? fromAccountId(accountId).account : null),
+    [accountId],
+  )
   const bip44Params = useAppSelector(state => selectBIP44ParamsByAccountId(state, accountFilter))
 
   const getDepositGasEstimate = useCallback(
@@ -162,7 +165,6 @@ export const Approve: React.FC<ApproveProps> = ({ accountId, onNext }) => {
     getDepositGasEstimate,
     onNext,
     state,
-    state?.deposit,
     toast,
     translate,
     walletState.wallet,

--- a/src/features/defi/providers/foxy/components/FoxyManager/Deposit/components/Confirm.tsx
+++ b/src/features/defi/providers/foxy/components/FoxyManager/Deposit/components/Confirm.tsx
@@ -60,7 +60,10 @@ export const Confirm: React.FC<ConfirmProps> = ({ onNext, accountId }) => {
   const feeMarketData = useAppSelector(state => selectMarketDataById(state, feeAssetId))
 
   const accountFilter = useMemo(() => ({ accountId: accountId ?? '' }), [accountId])
-  const accountAddress = useMemo(() => fromAccountId(accountId ?? '').account, [accountId])
+  const accountAddress = useMemo(
+    () => (accountId ? fromAccountId(accountId).account : null),
+    [accountId],
+  )
   const bip44Params = useAppSelector(state => selectBIP44ParamsByAccountId(state, accountFilter))
 
   // user info

--- a/src/features/defi/providers/foxy/components/FoxyManager/Deposit/components/Deposit.tsx
+++ b/src/features/defi/providers/foxy/components/FoxyManager/Deposit/components/Deposit.tsx
@@ -55,7 +55,10 @@ export const Deposit: React.FC<DepositProps> = ({
   const opportunity = useMemo(() => state?.foxyOpportunity, [state])
 
   // user info
-  const accountAddress = useMemo(() => fromAccountId(accountId ?? '').account, [accountId])
+  const accountAddress = useMemo(
+    () => (accountId ? fromAccountId(accountId).account : null),
+    [accountId],
+  )
   const filter = useMemo(() => ({ assetId, accountId: accountId ?? '' }), [assetId, accountId])
   const balance = useAppSelector(state => selectPortfolioCryptoBalanceByFilter(state, filter))
 
@@ -64,7 +67,7 @@ export const Deposit: React.FC<DepositProps> = ({
 
   const handleContinue = useCallback(
     async (formValues: DepositValues) => {
-      if (!(state && accountAddress?.length && dispatch && api)) return
+      if (!(state && accountAddress && dispatch && api)) return
 
       const getApproveGasEstimate = async () => {
         if (!accountAddress || !assetReference || !api) return

--- a/src/features/defi/providers/foxy/components/FoxyManager/FoxyManager.tsx
+++ b/src/features/defi/providers/foxy/components/FoxyManager/FoxyManager.tsx
@@ -24,7 +24,7 @@ export const FoxyManager = () => {
     <AnimatePresence exitBeforeEnter initial={false}>
       {modal === DefiAction.Overview && (
         <SlideTransition key={DefiAction.Overview}>
-          <FoxyOverview onAccountIdChange={setAccountId} />
+          <FoxyOverview onAccountIdChange={setAccountId} accountId={accountId} />
         </SlideTransition>
       )}
       {modal === DefiAction.Deposit && (

--- a/src/features/defi/providers/foxy/components/FoxyManager/Overview/Claim/ClaimRoutes.tsx
+++ b/src/features/defi/providers/foxy/components/FoxyManager/Overview/Claim/ClaimRoutes.tsx
@@ -38,7 +38,7 @@ export const ClaimRoutes: React.FC<ClaimRouteProps> = ({ onBack, accountId }) =>
     assetNamespace,
     assetReference,
   })
-  const { data: foxyBalancesData } = useFoxyBalances()
+  const { data: foxyBalancesData } = useFoxyBalances({ accountNumber: 0 })
   const opportunity = (foxyBalancesData?.opportunities || []).find(
     e => e.contractAddress === contractAddress,
   )

--- a/src/features/defi/providers/foxy/components/FoxyManager/Overview/Claim/ClaimRoutes.tsx
+++ b/src/features/defi/providers/foxy/components/FoxyManager/Overview/Claim/ClaimRoutes.tsx
@@ -5,10 +5,13 @@ import type {
   DefiQueryParams,
 } from 'features/defi/contexts/DefiManagerProvider/DefiCommon'
 import { AnimatePresence } from 'framer-motion'
+import { useMemo } from 'react'
 import { Route, Switch, useLocation } from 'react-router'
 import { SlideTransition } from 'components/SlideTransition'
 import { useBrowserRouter } from 'hooks/useBrowserRouter/useBrowserRouter'
 import { useFoxyBalances } from 'pages/Defi/hooks/useFoxyBalances'
+import { selectBIP44ParamsByAccountId } from 'state/slices/selectors'
+import { useAppSelector } from 'state/store'
 import type { Nullable } from 'types/common'
 
 import { ClaimConfirm } from './ClaimConfirm'
@@ -38,7 +41,11 @@ export const ClaimRoutes: React.FC<ClaimRouteProps> = ({ onBack, accountId }) =>
     assetNamespace,
     assetReference,
   })
-  const { data: foxyBalancesData } = useFoxyBalances({ accountNumber: 0 })
+
+  const accountFilter = useMemo(() => ({ accountId: accountId ?? '' }), [accountId])
+  const bip44Params = useAppSelector(state => selectBIP44ParamsByAccountId(state, accountFilter))
+
+  const { data: foxyBalancesData } = useFoxyBalances({ accountNumber: bip44Params?.accountNumber })
   const opportunity = (foxyBalancesData?.opportunities || []).find(
     e => e.contractAddress === contractAddress,
   )
@@ -58,7 +65,9 @@ export const ClaimRoutes: React.FC<ClaimRouteProps> = ({ onBack, accountId }) =>
               amount={opportunity?.withdrawInfo.amount}
             />
           </Route>
-          <Route exact path='/status' component={ClaimStatus} />
+          <Route exact path='/status'>
+            <ClaimStatus accountId={accountId} />
+          </Route>
         </Switch>
       </AnimatePresence>
     </SlideTransition>

--- a/src/features/defi/providers/foxy/components/FoxyManager/Overview/Claim/ClaimStatus.tsx
+++ b/src/features/defi/providers/foxy/components/FoxyManager/Overview/Claim/ClaimStatus.tsx
@@ -88,7 +88,7 @@ export const ClaimStatus = () => {
   const feeAsset = useAppSelector(state => selectAssetById(state, feeAssetId))
   const feeMarketData = useAppSelector(state => selectMarketDataById(state, feeAssetId))
 
-  const { refetch: refetchFoxyBalances } = useFoxyBalances()
+  const { refetch: refetchFoxyBalances } = useFoxyBalances({ accountNumber: 0 })
   useEffect(() => {
     ;(async () => {
       if (!foxy || !txid) return

--- a/src/features/defi/providers/foxy/components/FoxyManager/Overview/FoxyDetails.tsx
+++ b/src/features/defi/providers/foxy/components/FoxyManager/Overview/FoxyDetails.tsx
@@ -1,9 +1,11 @@
 import { Center, Flex, ModalBody, ModalFooter, Skeleton, Stack, Tag } from '@chakra-ui/react'
+import type { AccountId } from '@shapeshiftoss/caip'
 import { toAssetId } from '@shapeshiftoss/caip'
 import type {
   DefiParams,
   DefiQueryParams,
 } from 'features/defi/contexts/DefiManagerProvider/DefiCommon'
+import { useMemo } from 'react'
 import { matchPath } from 'react-router'
 import { Amount } from 'components/Amount/Amount'
 import { AssetIcon } from 'components/AssetIcon'
@@ -12,15 +14,23 @@ import { Text } from 'components/Text'
 import { useBrowserRouter } from 'hooks/useBrowserRouter/useBrowserRouter'
 import { bnOrZero } from 'lib/bignumber/bignumber'
 import { useFoxyBalances } from 'pages/Defi/hooks/useFoxyBalances'
-import { selectAssetById } from 'state/slices/selectors'
+import { selectAssetById, selectBIP44ParamsByAccountId } from 'state/slices/selectors'
 import { useAppSelector } from 'state/store'
+import type { Nullable } from 'types/common'
 
 import { FoxyEmpty } from './FoxyEmpty'
 import { WithdrawCard } from './WithdrawCard'
 
-export const FoxyDetails = () => {
+type FoxyDetailsProps = {
+  accountId: Nullable<AccountId>
+}
+
+export const FoxyDetails: React.FC<FoxyDetailsProps> = ({ accountId }) => {
+  const accountFilter = useMemo(() => ({ accountId: accountId ?? '' }), [accountId])
+  const bip44Params = useAppSelector(state => selectBIP44ParamsByAccountId(state, accountFilter))
+
   const { data: foxyBalancesData, isLoading: isFoxyBalancesLoading } = useFoxyBalances({
-    accountNumber: 0,
+    accountNumber: bip44Params?.accountNumber,
   })
   const {
     query,

--- a/src/features/defi/providers/foxy/components/FoxyManager/Overview/FoxyDetails.tsx
+++ b/src/features/defi/providers/foxy/components/FoxyManager/Overview/FoxyDetails.tsx
@@ -19,7 +19,9 @@ import { FoxyEmpty } from './FoxyEmpty'
 import { WithdrawCard } from './WithdrawCard'
 
 export const FoxyDetails = () => {
-  const { data: foxyBalancesData, isLoading: isFoxyBalancesLoading } = useFoxyBalances()
+  const { data: foxyBalancesData, isLoading: isFoxyBalancesLoading } = useFoxyBalances({
+    accountNumber: 0,
+  })
   const {
     query,
     history: browserHistory,

--- a/src/features/defi/providers/foxy/components/FoxyManager/Overview/FoxyOverview.tsx
+++ b/src/features/defi/providers/foxy/components/FoxyManager/Overview/FoxyOverview.tsx
@@ -1,7 +1,7 @@
 import { ArrowDownIcon, ArrowUpIcon } from '@chakra-ui/icons'
 import { Center } from '@chakra-ui/react'
 import type { AccountId } from '@shapeshiftoss/caip'
-import { fromAccountId, toAssetId } from '@shapeshiftoss/caip'
+import { toAssetId } from '@shapeshiftoss/caip'
 import dayjs from 'dayjs'
 import { DefiModalContent } from 'features/defi/components/DefiModal/DefiModalContent'
 import { Overview } from 'features/defi/components/Overview/Overview'
@@ -20,7 +20,12 @@ import { useBrowserRouter } from 'hooks/useBrowserRouter/useBrowserRouter'
 import { bnOrZero } from 'lib/bignumber/bignumber'
 import { useFoxyBalances } from 'pages/Defi/hooks/useFoxyBalances'
 import { useGetAssetDescriptionQuery } from 'state/slices/assetsSlice/assetsSlice'
-import { selectAssetById, selectMarketDataById, selectSelectedLocale } from 'state/slices/selectors'
+import {
+  selectAssetById,
+  selectBIP44ParamsByAccountId,
+  selectMarketDataById,
+  selectSelectedLocale,
+} from 'state/slices/selectors'
 import { useAppSelector } from 'state/store'
 import type { Nullable } from 'types/common'
 
@@ -36,12 +41,10 @@ export const FoxyOverview: React.FC<FoxyOverviewProps> = ({
   accountId,
   onAccountIdChange: handleAccountIdChange,
 }) => {
-  const accountAddress = useMemo(
-    () => (accountId ? fromAccountId(accountId).account : null),
-    [accountId],
-  )
+  const accountFilter = useMemo(() => ({ accountId: accountId ?? '' }), [accountId])
+  const bip44Params = useAppSelector(state => selectBIP44ParamsByAccountId(state, accountFilter))
   const { data: foxyBalancesData, isLoading: isFoxyBalancesLoading } = useFoxyBalances({
-    defaultUserAddress: accountAddress,
+    accountNumber: bip44Params?.accountNumber,
   })
   const translate = useTranslate()
   const { query, history, location } = useBrowserRouter<DefiQueryParams, DefiParams>()

--- a/src/features/defi/providers/foxy/components/FoxyManager/Overview/FoxyOverview.tsx
+++ b/src/features/defi/providers/foxy/components/FoxyManager/Overview/FoxyOverview.tsx
@@ -1,7 +1,7 @@
 import { ArrowDownIcon, ArrowUpIcon } from '@chakra-ui/icons'
 import { Center } from '@chakra-ui/react'
 import type { AccountId } from '@shapeshiftoss/caip'
-import { toAssetId } from '@shapeshiftoss/caip'
+import { fromAccountId, toAssetId } from '@shapeshiftoss/caip'
 import dayjs from 'dayjs'
 import { DefiModalContent } from 'features/defi/components/DefiModal/DefiModalContent'
 import { Overview } from 'features/defi/components/Overview/Overview'
@@ -36,7 +36,13 @@ export const FoxyOverview: React.FC<FoxyOverviewProps> = ({
   accountId,
   onAccountIdChange: handleAccountIdChange,
 }) => {
-  const { data: foxyBalancesData, isLoading: isFoxyBalancesLoading } = useFoxyBalances()
+  const accountAddress = useMemo(
+    () => (accountId ? fromAccountId(accountId).account : null),
+    [accountId],
+  )
+  const { data: foxyBalancesData, isLoading: isFoxyBalancesLoading } = useFoxyBalances({
+    defaultUserAddress: accountAddress,
+  })
   const translate = useTranslate()
   const { query, history, location } = useBrowserRouter<DefiQueryParams, DefiParams>()
   const { chainId, contractAddress, assetReference, rewardId } = query

--- a/src/features/defi/providers/foxy/components/FoxyManager/Overview/FoxyOverview.tsx
+++ b/src/features/defi/providers/foxy/components/FoxyManager/Overview/FoxyOverview.tsx
@@ -1,5 +1,6 @@
 import { ArrowDownIcon, ArrowUpIcon } from '@chakra-ui/icons'
 import { Center } from '@chakra-ui/react'
+import type { AccountId } from '@shapeshiftoss/caip'
 import { toAssetId } from '@shapeshiftoss/caip'
 import dayjs from 'dayjs'
 import { DefiModalContent } from 'features/defi/components/DefiModal/DefiModalContent'
@@ -21,11 +22,18 @@ import { useFoxyBalances } from 'pages/Defi/hooks/useFoxyBalances'
 import { useGetAssetDescriptionQuery } from 'state/slices/assetsSlice/assetsSlice'
 import { selectAssetById, selectMarketDataById, selectSelectedLocale } from 'state/slices/selectors'
 import { useAppSelector } from 'state/store'
+import type { Nullable } from 'types/common'
 
 import { FoxyEmpty } from './FoxyEmpty'
 import { WithdrawCard } from './WithdrawCard'
 
-export const FoxyOverview: React.FC<{ onAccountIdChange: AccountDropdownProps['onChange'] }> = ({
+type FoxyOverviewProps = {
+  accountId: Nullable<AccountId>
+  onAccountIdChange: AccountDropdownProps['onChange']
+}
+
+export const FoxyOverview: React.FC<FoxyOverviewProps> = ({
+  accountId,
   onAccountIdChange: handleAccountIdChange,
 }) => {
   const { data: foxyBalancesData, isLoading: isFoxyBalancesLoading } = useFoxyBalances()
@@ -92,6 +100,7 @@ export const FoxyOverview: React.FC<{ onAccountIdChange: AccountDropdownProps['o
 
   return (
     <Overview
+      accountId={accountId}
       onAccountIdChange={handleAccountIdChange}
       asset={rewardAsset}
       name='FOX Yieldy'

--- a/src/features/defi/providers/foxy/components/FoxyManager/Withdraw/components/Confirm.tsx
+++ b/src/features/defi/providers/foxy/components/FoxyManager/Withdraw/components/Confirm.tsx
@@ -149,10 +149,8 @@ export const Confirm: React.FC<StepComponentProps & { accountId?: Nullable<Accou
     dispatch,
     onNext,
     rewardId,
-    state?.loading,
     accountAddress,
-    state?.withdraw.cryptoAmount,
-    state?.withdraw.withdrawType,
+    state,
     walletState.wallet,
   ])
 

--- a/src/features/defi/providers/foxy/components/FoxyManager/Withdraw/components/Confirm.tsx
+++ b/src/features/defi/providers/foxy/components/FoxyManager/Withdraw/components/Confirm.tsx
@@ -1,6 +1,6 @@
 import { Alert, AlertIcon, Box, Stack } from '@chakra-ui/react'
 import type { AccountId } from '@shapeshiftoss/caip'
-import { ASSET_REFERENCE, toAssetId } from '@shapeshiftoss/caip'
+import { ASSET_REFERENCE, fromAccountId, toAssetId } from '@shapeshiftoss/caip'
 import { WithdrawType } from '@shapeshiftoss/types'
 import { Confirm as ReusableConfirm } from 'features/defi/components/Confirm/Confirm'
 import { Summary } from 'features/defi/components/Summary'
@@ -87,6 +87,7 @@ export const Confirm: React.FC<StepComponentProps & { accountId?: Nullable<Accou
     selectPortfolioCryptoHumanBalanceByAssetId(state, { assetId: feeAsset?.assetId ?? '' }),
   )
 
+  const accountAddress = useMemo(() => fromAccountId(accountId ?? '').account, [accountId])
   const accountFilter = useMemo(() => ({ accountId: accountId ?? '' }), [accountId])
   const bip44Params = useAppSelector(state => selectBIP44ParamsByAccountId(state, accountFilter))
 
@@ -94,14 +95,22 @@ export const Confirm: React.FC<StepComponentProps & { accountId?: Nullable<Accou
     try {
       if (
         state?.loading ||
-        !(state?.userAddress && rewardId && walletState.wallet && api && dispatch && bip44Params)
+        !(
+          state &&
+          accountAddress &&
+          rewardId &&
+          walletState.wallet &&
+          api &&
+          dispatch &&
+          bip44Params
+        )
       )
         return
       dispatch({ type: FoxyWithdrawActionType.SET_LOADING, payload: true })
       const [txid, gasPrice] = await Promise.all([
         api.withdraw({
           tokenContractAddress: rewardId,
-          userAddress: state.userAddress,
+          userAddress: accountAddress,
           contractAddress,
           wallet: walletState.wallet,
           amountDesired: bnOrZero(state.withdraw.cryptoAmount)
@@ -141,7 +150,7 @@ export const Confirm: React.FC<StepComponentProps & { accountId?: Nullable<Accou
     onNext,
     rewardId,
     state?.loading,
-    state?.userAddress,
+    accountAddress,
     state?.withdraw.cryptoAmount,
     state?.withdraw.withdrawType,
     walletState.wallet,

--- a/src/features/defi/providers/foxy/components/FoxyManager/Withdraw/components/Withdraw.tsx
+++ b/src/features/defi/providers/foxy/components/FoxyManager/Withdraw/components/Withdraw.tsx
@@ -262,6 +262,7 @@ export const Withdraw: React.FC<
   return (
     <FormProvider {...methods}>
       <ReusableWithdraw
+        accountId={accountId}
         onAccountIdChange={handleAccountIdChange}
         asset={stakingAsset}
         cryptoAmountAvailable={cryptoAmountAvailable.toPrecision()}

--- a/src/pages/Defi/hooks/useEarnBalances.tsx
+++ b/src/pages/Defi/hooks/useEarnBalances.tsx
@@ -21,7 +21,9 @@ export type UseEarnBalancesReturn = {
 export type SerializableOpportunity = MergedEarnVault
 
 export function useEarnBalances(): UseEarnBalancesReturn {
-  const { isLoading: isFoxyBalancesLoading, data: foxyBalancesData } = useFoxyBalances()
+  const { isLoading: isFoxyBalancesLoading, data: foxyBalancesData } = useFoxyBalances({
+    accountNumber: 0,
+  })
   const { vaults, totalBalance: vaultsTotalBalance, loading: vaultsLoading } = useVaultBalances()
   const vaultArray: SerializableOpportunity[] = useMemo(() => Object.values(vaults), [vaults])
   const { cosmosSdkStakingOpportunities, totalBalance: totalCosmosStakingBalance } =

--- a/src/pages/Defi/hooks/useFoxyBalances.tsx
+++ b/src/pages/Defi/hooks/useFoxyBalances.tsx
@@ -23,7 +23,7 @@ export function useFoxyBalances({ accountNumber }: { accountNumber: number }) {
   )
 
   const userAddress = useMemo(() => {
-    const accountId = accountsByNumber[accountNumber ?? 0]?.[0] // Only one account zero for EVM chains i.e no multiple scriptTypes - use 0 as a default fetched account
+    const accountId = accountsByNumber[accountNumber ?? 0]?.[0] // Only one address per account for EVM chains i.e no multiple accountTypes
     return accountId ? fromAccountId(accountId).account : null
   }, [accountNumber, accountsByNumber])
 

--- a/src/pages/Defi/hooks/useFoxyBalances.tsx
+++ b/src/pages/Defi/hooks/useFoxyBalances.tsx
@@ -51,7 +51,6 @@ export function useFoxyBalances({
 
   const foxyBalances = useGetFoxyBalancesQuery(
     {
-      userAddress: userAddress!,
       foxyApr: foxyAprData?.foxyApr!,
       accountId: accountId!,
     },

--- a/src/plugins/foxPage/components/MainOpportunity.tsx
+++ b/src/plugins/foxPage/components/MainOpportunity.tsx
@@ -31,7 +31,9 @@ export const MainOpportunity = ({
 
   const selectedAsset = useAppSelector(state => selectAssetById(state, assetId))
 
-  const { data: foxyBalancesData, isLoading: isFoxyBalancesLoading } = useFoxyBalances()
+  const { data: foxyBalancesData, isLoading: isFoxyBalancesLoading } = useFoxyBalances({
+    accountNumber: 0,
+  })
   const hasActiveStaking = bnOrZero(foxyBalancesData?.opportunities?.[0]?.balance).gt(0)
 
   return (

--- a/src/plugins/foxPage/foxPage.tsx
+++ b/src/plugins/foxPage/foxPage.tsx
@@ -78,7 +78,9 @@ export const FoxPage = () => {
   // TODO(gomes): Use useRouteAssetId and selectAssetById programatically
   const assetFox = useAppSelector(state => selectAssetById(state, foxAssetId))
   const assetFoxy = useAppSelector(state => selectAssetById(state, foxyAssetId))
-  const { data: foxyBalancesData, isLoading: isFoxyBalancesLoading } = useFoxyBalances()
+  const { data: foxyBalancesData, isLoading: isFoxyBalancesLoading } = useFoxyBalances({
+    accountNumber: 0,
+  })
   const otherOpportunities = useOtherOpportunities(activeAssetId)
 
   const assets = useMemo(() => [assetFox, assetFoxy], [assetFox, assetFoxy])

--- a/src/state/apis/foxy/foxyApi.ts
+++ b/src/state/apis/foxy/foxyApi.ts
@@ -29,7 +29,6 @@ const TOKEMAK_TFOX_POOL_ADDRESS = '0x808d3e6b23516967ceae4f17a5f9038383ed5311'
 
 type GetFoxyBalancesInput = {
   accountId: AccountId
-  userAddress: string
   foxyApr: string
 }
 type GetFoxyBalancesOutput = {
@@ -189,7 +188,7 @@ export const foxyApi = createApi({
   reducerPath: 'foxyApi',
   endpoints: build => ({
     getFoxyBalances: build.query<GetFoxyBalancesOutput, GetFoxyBalancesInput>({
-      queryFn: async ({ userAddress: _userAddress, accountId, foxyApr }, injected) => {
+      queryFn: async ({ accountId, foxyApr }, injected) => {
         const chainAdapterManager = getChainAdapterManager()
         if (!chainAdapterManager.has(KnownChainIds.EthereumMainnet))
           return {

--- a/src/state/apis/foxy/foxyApi.ts
+++ b/src/state/apis/foxy/foxyApi.ts
@@ -1,6 +1,6 @@
 import { createApi } from '@reduxjs/toolkit/dist/query/react'
 import type { AccountId, AssetId, ChainId } from '@shapeshiftoss/caip'
-import { CHAIN_REFERENCE, toAssetId } from '@shapeshiftoss/caip'
+import { CHAIN_REFERENCE, fromAccountId, toAssetId } from '@shapeshiftoss/caip'
 import type { DefiType, FoxyApi, WithdrawInfo } from '@shapeshiftoss/investor-foxy'
 import type { BIP44Params, MarketData } from '@shapeshiftoss/types'
 import { KnownChainIds } from '@shapeshiftoss/types'
@@ -189,7 +189,7 @@ export const foxyApi = createApi({
   reducerPath: 'foxyApi',
   endpoints: build => ({
     getFoxyBalances: build.query<GetFoxyBalancesOutput, GetFoxyBalancesInput>({
-      queryFn: async ({ userAddress, accountId, foxyApr }, injected) => {
+      queryFn: async ({ userAddress: _userAddress, accountId, foxyApr }, injected) => {
         const chainAdapterManager = getChainAdapterManager()
         if (!chainAdapterManager.has(KnownChainIds.EthereumMainnet))
           return {
@@ -220,6 +220,7 @@ export const foxyApi = createApi({
 
         // RTK caches queries from inputs, thus re-calling this query for the same opportunity will return the cache data if not invalidated
         const accountFilter = { accountId }
+        const accountAddress = fromAccountId(accountId).account
         const bip44Params = selectBIP44ParamsByAccountId(state, accountFilter)
 
         if (!bip44Params) {
@@ -235,7 +236,7 @@ export const foxyApi = createApi({
           const foxyOpportunities = await getFoxyOpportunities(
             balances,
             foxy,
-            userAddress,
+            accountAddress,
             foxyApr ?? '',
             bip44Params,
           )

--- a/src/state/apis/foxy/foxyApi.ts
+++ b/src/state/apis/foxy/foxyApi.ts
@@ -126,7 +126,7 @@ const makeMergedOpportunities = (
   })
 
 async function getFoxyOpportunities(
-  state: any,
+  state: any, // ReduxState - can't use the actual typings here because of circular dependencies
   api: FoxyApi,
   foxyApr: string,
   accountId: AccountId,

--- a/src/state/apis/foxy/foxyApi.ts
+++ b/src/state/apis/foxy/foxyApi.ts
@@ -2,7 +2,7 @@ import { createApi } from '@reduxjs/toolkit/dist/query/react'
 import type { AccountId, AssetId, ChainId } from '@shapeshiftoss/caip'
 import { CHAIN_REFERENCE, fromAccountId, toAssetId } from '@shapeshiftoss/caip'
 import type { DefiType, FoxyApi, WithdrawInfo } from '@shapeshiftoss/investor-foxy'
-import type { BIP44Params, MarketData } from '@shapeshiftoss/types'
+import type { MarketData } from '@shapeshiftoss/types'
 import { KnownChainIds } from '@shapeshiftoss/types'
 import type { AxiosError } from 'axios'
 import axios from 'axios'
@@ -12,12 +12,11 @@ import type { BigNumber, BN } from 'lib/bignumber/bignumber'
 import { bn, bnOrZero } from 'lib/bignumber/bignumber'
 import { logger } from 'lib/logger'
 import type { AssetsById } from 'state/slices/assetsSlice/assetsSlice'
-import type { PortfolioBalancesById } from 'state/slices/portfolioSlice/portfolioSliceCommon'
 import {
   selectAssets,
   selectBIP44ParamsByAccountId,
   selectMarketData,
-  selectPortfolioAssetBalances,
+  selectPortfolioCryptoBalanceByFilter,
   selectPortfolioLoading,
 } from 'state/slices/selectors'
 
@@ -127,12 +126,20 @@ const makeMergedOpportunities = (
   })
 
 async function getFoxyOpportunities(
-  balances: PortfolioBalancesById,
+  state: any,
   api: FoxyApi,
-  userAddress: string,
   foxyApr: string,
-  bip44Params: BIP44Params,
+  accountId: AccountId,
 ) {
+  // RTK caches queries from inputs, thus re-calling this query for the same opportunity will return the cache data if not invalidated
+  const accountFilter = { accountId }
+  const userAddress = fromAccountId(accountId).account
+  const bip44Params = selectBIP44ParamsByAccountId(state, accountFilter)
+
+  if (!bip44Params) {
+    throw new Error(`AccountMetadata for AccountId ${accountId} not loaded`)
+  }
+
   const acc: Record<string, FoxyOpportunity> = {}
   try {
     const opportunities = await api.getFoxyOpportunities()
@@ -148,6 +155,12 @@ async function getFoxyOpportunities(
         assetNamespace: 'erc20',
         assetReference: opportunity.rewardToken,
       })
+
+      const balance = selectPortfolioCryptoBalanceByFilter(state, {
+        accountId,
+        assetId: rewardTokenAssetId,
+      })
+
       const contractAssetId = toAssetId({
         chainId: opportunity.chain,
         assetNamespace: 'erc20',
@@ -158,7 +171,6 @@ async function getFoxyOpportunities(
         assetNamespace: 'erc20',
         assetReference: opportunity.stakingToken,
       })
-      const balance = balances[rewardTokenAssetId]
 
       const pricePerShare = api.pricePerShare()
       acc[opportunity.contractAddress] = {
@@ -215,29 +227,13 @@ export const foxyApi = createApi({
 
         const marketData = selectMarketData(state)
         const assets = selectAssets(state)
-        const balances = selectPortfolioAssetBalances(state)
-
-        // RTK caches queries from inputs, thus re-calling this query for the same opportunity will return the cache data if not invalidated
-        const accountFilter = { accountId }
-        const accountAddress = fromAccountId(accountId).account
-        const bip44Params = selectBIP44ParamsByAccountId(state, accountFilter)
-
-        if (!bip44Params) {
-          return {
-            error: {
-              error: `Accountmetadata for account ${accountId} is not loaded`,
-              status: 'CUSTOM_ERROR',
-            },
-          }
-        }
 
         try {
           const foxyOpportunities = await getFoxyOpportunities(
-            balances,
+            state,
             foxy,
-            accountAddress,
             foxyApr ?? '',
-            bip44Params,
+            accountId,
           )
 
           const totalBalance = makeTotalBalance(foxyOpportunities, assets, marketData)


### PR DESCRIPTION
## Description

- Overview
  - [x] Account selection
  - [x] Use selected account data
  - [ ] Route from DeFi cards - TBD in https://github.com/shapeshift/web/issues/2615
- [x] Deposit
  - [x] Approve
  - [x] Confirm
  - [x] Use selected account data in all steps
  - [x] Poll (regression test against account 0 on prod) 
- [x] Withdraw
  - [x] Approve
  - [x] Confirm 
  - [x] Use selected account data in all steps
  - [x] Poll (regression test against account 0 on prod)
 

## Notice

<!-- Before submitting a pull request, please make sure you have answered the following: -->

- [x] Have you followed the guidelines in our [Contributing]('https://github.com/shapeshift/web/blob/develop/CONTRIBUTING.md) guide?
- [x] Have you checked to ensure there aren't other open [Pull Requests](https://github.com/shapeshift/web/pulls) for the same update/change?

## Pull Request Type

- [ ] :bug: Bug fix (Non-breaking Change: Fixes an issue)
- [ ] :hammer_and_wrench: Chore (Non-breaking Change: Doc updates, pkg upgrades, typos, etc..)
- [x] :nail_care: New Feature (Breaking/Non-breaking Change)

## Issue (if applicable)

- relates to the closed https://github.com/shapeshift/web/issues/2611
- relates to https://github.com/shapeshift/web/issues/2615
- relates to https://github.com/shapeshift/web/issues/2730
- closes https://github.com/shapeshift/web/issues/2758

## Risk

Tested with MetaMask (which has only account 0 support) but this could bring regressions forFOXy modal for single accounts, test accordingly

## Testing (with KeepKey and Native)

- Add an Ethereum account and send some ETH and FOX
- Stake in some opportunity (or skip this step if already staked in FOXy), reload the app (websocket is currently borked) and click on the opportunity card for it
- Select account 1 and click deposit
- Notice account 1 is pre-selected at Deposit step, with the right FOX amount to deposit 
- Deposit some more of FOX, sign and broadcast it - it should be deposited from account 1
- Disconnect and reconnect wallet, then reopen the overview modal and select withdraw with account 1 selected in overview
- Notice account 1 is pre-selected at Withdraw step, with the right amount of FOXy available to withdraw
- Withdraw some of your FOXy - it should be withdrawn from account 1
- Disconnect and reconnect wallet, then reopen the FOXy overview modal with account 1 selected

### Engineering

<!-----------------------------------------------------------------------------
Include sufficient information here for an engineer to test your PR. This may include how to test locally, in a built environment, changes to infrastructure etc.
------------------------------------------------------------------------------>

- Refer to top-level testing steps
- Double-check the logic looks sound in deposit withdraw and claim for all steps

### Operations

- Refer to top-level testing steps

<!-----------------------------------------------------------------------------
If your changes have a user-facing impact, describe how a non-technical QA team can functionally test your changes in a preview environment.

If they are not user-facing please describe how to test for any regressions that may occur.
------------------------------------------------------------------------------>

## Screenshots

<img width="535" alt="image" src="https://user-images.githubusercontent.com/17035424/191129554-b9b13fc3-7cb9-40c3-84fa-0c3ec74df03b.png">
<img width="534" alt="image" src="https://user-images.githubusercontent.com/17035424/191129492-f88f2caa-988c-43c6-ace9-a853823de568.png">
<img width="531" alt="image" src="https://user-images.githubusercontent.com/17035424/191129517-6c8c2513-fc4c-4165-87a2-0ba058db6428.png">
