### PR TITLE
chore: revert to using prod eth endpoints

### DIFF
--- a/.env.app
+++ b/.env.app
@@ -14,8 +14,8 @@ REACT_APP_PENDO_UNSAFE_DESIGNER_MODE=false
 REACT_APP_REFERRER=no-referrer
 
 # unchained
-REACT_APP_UNCHAINED_ETHEREUM_HTTP_URL=https://dev-api.ethereum.shapeshift.com
-REACT_APP_UNCHAINED_ETHEREUM_WS_URL=wss://dev-api.ethereum.shapeshift.com
+REACT_APP_UNCHAINED_ETHEREUM_HTTP_URL=https://api.ethereum.shapeshift.com
+REACT_APP_UNCHAINED_ETHEREUM_WS_URL=wss://api.ethereum.shapeshift.com
 REACT_APP_UNCHAINED_AVALANCHE_HTTP_URL=https://api.avalanche.shapeshift.com
 REACT_APP_UNCHAINED_AVALANCHE_WS_URL=wss://api.avalanche.shapeshift.com
 REACT_APP_UNCHAINED_BITCOIN_HTTP_URL=https://api.bitcoin.shapeshift.com

--- a/.env.private
+++ b/.env.private
@@ -5,8 +5,8 @@
 REACT_APP_REFERRER=no-referrer
 
 # unchained
-REACT_APP_UNCHAINED_ETHEREUM_HTTP_URL=https://dev-api.ethereum.shapeshift.com
-REACT_APP_UNCHAINED_ETHEREUM_WS_URL=wss://dev-api.ethereum.shapeshift.com
+REACT_APP_UNCHAINED_ETHEREUM_HTTP_URL=https://api.ethereum.shapeshift.com
+REACT_APP_UNCHAINED_ETHEREUM_WS_URL=wss://api.ethereum.shapeshift.com
 REACT_APP_UNCHAINED_AVALANCHE_HTTP_URL=https://api.avalanche.shapeshift.com
 REACT_APP_UNCHAINED_AVALANCHE_WS_URL=wss://api.avalanche.shapeshift.com
 REACT_APP_UNCHAINED_BITCOIN_HTTP_URL=https://api.bitcoin.shapeshift.com


### PR DESCRIPTION
## Description

Production ethereum coinstacks have stabilized post merge, so we can switch back to pointing to them for app and private

## Notice

<!-- Before submitting a pull request, please make sure you have answered the following: -->

- [x] Have you followed the guidelines in our [Contributing]('https://github.com/shapeshift/web/blob/develop/CONTRIBUTING.md) guide?
- [x] Have you checked to ensure there aren't other open [Pull Requests](https://github.com/shapeshift/web/pulls) for the same update/change?

## Pull Request Type

- [ ] :bug: Bug fix (Non-breaking Change: Fixes an issue)
- [x] :hammer_and_wrench: Chore (Non-breaking Change: Doc updates, pkg upgrades, typos, etc..)
- [ ] :nail_care: New Feature (Breaking/Non-breaking Change)

## Issue (if applicable)

<!-----------------------------------------------------------------------------
If applicable, please link to the github issue and put `closes #XXXX` in your comment to auto-close the issue that your PR fixes.
------------------------------------------------------------------------------>

closes #

## Risk

None

## Testing

- Ensure ETH/ERC20s and portfolio load properly

### Engineering

See  above

### Operations

See  above

## Screenshots (if applicable)
