### PR TITLE
feat: fox/eth full multi account support

### DIFF
--- a/src/components/StakingVaults/EarnOpportunities.tsx
+++ b/src/components/StakingVaults/EarnOpportunities.tsx
@@ -6,6 +6,7 @@ import type { EarnOpportunityType } from 'features/defi/helpers/normalizeOpportu
 import { useNormalizeOpportunities } from 'features/defi/helpers/normalizeOpportunity'
 import { foxEthLpAssetId } from 'features/defi/providers/fox-eth-lp/constants'
 import qs from 'qs'
+import { useEffect } from 'react'
 import { NavLink, useHistory, useLocation } from 'react-router-dom'
 import { Card } from 'components/Card/Card'
 import { Text } from 'components/Text'
@@ -27,7 +28,7 @@ type EarnOpportunitiesProps = {
   isLoaded?: boolean
 }
 
-export const EarnOpportunities = ({ assetId }: EarnOpportunitiesProps) => {
+export const EarnOpportunities = ({ assetId, accountId }: EarnOpportunitiesProps) => {
   const history = useHistory()
   const location = useLocation()
   const {
@@ -38,7 +39,12 @@ export const EarnOpportunities = ({ assetId }: EarnOpportunitiesProps) => {
   const { vaults } = useVaultBalances()
   const { data: foxyBalancesData } = useFoxyBalances()
 
-  const { onlyVisibleFoxFarmingOpportunities, foxEthLpOpportunity } = useFoxEth()
+  const { setAccountId, onlyVisibleFoxFarmingOpportunities, foxEthLpOpportunity } = useFoxEth()
+
+  useEffect(() => {
+    if (accountId) setAccountId(accountId)
+  }, [setAccountId, accountId])
+
   const featureFlags = useAppSelector(selectFeatureFlags)
   //@TODO: This needs to be updated to account for accountId -- show only vaults that are on that account
 

--- a/src/features/defi/components/Deposit/PairDeposit.tsx
+++ b/src/features/defi/components/Deposit/PairDeposit.tsx
@@ -1,5 +1,6 @@
 import { Button, Stack, useColorModeValue } from '@chakra-ui/react'
 import type { Asset } from '@shapeshiftoss/asset-service'
+import type { AccountId } from '@shapeshiftoss/caip/dist/accountId/accountId'
 import type { MarketData } from '@shapeshiftoss/types'
 import get from 'lodash/get'
 import { calculateYearlyYield } from 'plugins/cosmos/components/modals/Staking/StakingCommon'
@@ -14,10 +15,12 @@ import { FormField } from 'components/DeFi/components/FormField'
 import { Row } from 'components/Row/Row'
 import { Text } from 'components/Text'
 import { bnOrZero } from 'lib/bignumber/bignumber'
+import type { Nullable } from 'types/common'
 
 import { PairIcons } from '../PairIcons/PairIcons'
 
 type DepositProps = {
+  accountId?: Nullable<AccountId>
   asset1: Asset
   asset2: Asset
   destAsset: Asset
@@ -68,6 +71,7 @@ export type DepositValues = {
 
 export const PairDeposit = ({
   apy,
+  accountId,
   asset1,
   asset2,
   destAsset,
@@ -212,6 +216,7 @@ export const PairDeposit = ({
       <Stack spacing={6} as='form' width='full' onSubmit={handleSubmit(onSubmit)}>
         <FormField label={translate('modals.deposit.amountToDeposit')}>
           <AssetInput
+            {...(accountId ? { accountId } : {})}
             cryptoAmount={cryptoAmount1?.value}
             onChange={(value, isFiat) => handleInputChange(value, true, isFiat)}
             fiatAmount={fiatAmount1?.value}
@@ -227,6 +232,7 @@ export const PairDeposit = ({
             errors={cryptoError1 || fiatError1}
           />
           <AssetInput
+            {...(accountId ? { accountId } : {})}
             cryptoAmount={cryptoAmount2?.value}
             onChange={(value, isFiat) => handleInputChange(value, false, isFiat)}
             fiatAmount={fiatAmount2?.value}

--- a/src/features/defi/providers/fox-eth-lp/components/FoxEthLpManager/Deposit/FoxEthLpDeposit.tsx
+++ b/src/features/defi/providers/fox-eth-lp/components/FoxEthLpManager/Deposit/FoxEthLpDeposit.tsx
@@ -1,4 +1,5 @@
 import { Center } from '@chakra-ui/react'
+import type { AccountId } from '@shapeshiftoss/caip/dist/accountId/accountId'
 import { DefiModalContent } from 'features/defi/components/DefiModal/DefiModalContent'
 import { DefiModalHeader } from 'features/defi/components/DefiModal/DefiModalHeader'
 import type {
@@ -10,6 +11,7 @@ import qs from 'qs'
 import { useEffect, useMemo, useReducer } from 'react'
 import { useTranslate } from 'react-polyglot'
 import { useSelector } from 'react-redux'
+import type { AccountDropdownProps } from 'components/AccountDropdown/AccountDropdown'
 import { CircularProgress } from 'components/CircularProgress/CircularProgress'
 import type { DefiStepProps } from 'components/DeFi/components/Steps'
 import { Steps } from 'components/DeFi/components/Steps'
@@ -21,6 +23,7 @@ import {
   selectPortfolioLoading,
 } from 'state/slices/selectors'
 import { useAppSelector } from 'state/store'
+import type { Nullable } from 'types/common'
 
 import { foxEthLpOpportunityName } from '../../../constants'
 import { Approve } from './components/Approve'
@@ -31,7 +34,15 @@ import { FoxEthLpDepositActionType } from './DepositCommon'
 import { DepositContext } from './DepositContext'
 import { initialState, reducer } from './DepositReducer'
 
-export const FoxEthLpDeposit = () => {
+type FoxEthLpDepositProps = {
+  onAccountIdChange: AccountDropdownProps['onChange']
+  accountId: Nullable<AccountId>
+}
+
+export const FoxEthLpDeposit: React.FC<FoxEthLpDepositProps> = ({
+  accountId,
+  onAccountIdChange: handleAccountIdChange,
+}) => {
   const [state, dispatch] = useReducer(reducer, initialState)
   const translate = useTranslate()
   const { query, history, location } = useBrowserRouter<DefiQueryParams, DefiParams>()
@@ -57,7 +68,9 @@ export const FoxEthLpDeposit = () => {
       [DefiStep.Info]: {
         label: translate('defi.steps.deposit.info.title'),
         description: translate('defi.steps.deposit.info.description', { asset: asset.symbol }),
-        component: Deposit,
+        component: ownProps => (
+          <Deposit {...ownProps} accountId={accountId} onAccountIdChange={handleAccountIdChange} />
+        ),
       },
       [DefiStep.Approve]: {
         label: translate('defi.steps.approve.title'),

--- a/src/features/defi/providers/fox-eth-lp/components/FoxEthLpManager/Deposit/components/Deposit.tsx
+++ b/src/features/defi/providers/fox-eth-lp/components/FoxEthLpManager/Deposit/components/Deposit.tsx
@@ -1,4 +1,5 @@
 import { useToast } from '@chakra-ui/react'
+import type { AccountId } from '@shapeshiftoss/caip'
 import { ethAssetId, foxAssetId, toAssetId } from '@shapeshiftoss/caip'
 import type { DepositValues } from 'features/defi/components/Deposit/PairDeposit'
 import { PairDeposit } from 'features/defi/components/Deposit/PairDeposit'
@@ -12,6 +13,7 @@ import qs from 'qs'
 import { useContext } from 'react'
 import { useTranslate } from 'react-polyglot'
 import { useHistory } from 'react-router-dom'
+import type { AccountDropdownProps } from 'components/AccountDropdown/AccountDropdown'
 import type { StepComponentProps } from 'components/DeFi/components/Steps'
 import { useFoxEth } from 'context/FoxEthProvider/FoxEthProvider'
 import { useBrowserRouter } from 'hooks/useBrowserRouter/useBrowserRouter'
@@ -23,20 +25,30 @@ import {
   selectPortfolioCryptoBalanceByAssetId,
 } from 'state/slices/selectors'
 import { useAppSelector } from 'state/store'
+import type { Nullable } from 'types/common'
 
 import { FoxEthLpDepositActionType } from '../DepositCommon'
 import { DepositContext } from '../DepositContext'
 
 const moduleLogger = logger.child({ namespace: ['FoxEthLpDeposit:Deposit'] })
 
-export const Deposit: React.FC<StepComponentProps> = ({ onNext }) => {
+type DepositProps = StepComponentProps & {
+  accountId: Nullable<AccountId>
+  onAccountIdChange?: AccountDropdownProps['onChange']
+}
+
+export const Deposit: React.FC<DepositProps> = ({
+  accountId,
+  onAccountIdChange: handleAccountIdChange,
+  onNext,
+}) => {
   const { state, dispatch } = useContext(DepositContext)
   const history = useHistory()
   const translate = useTranslate()
   const { query, history: browserHistory } = useBrowserRouter<DefiQueryParams, DefiParams>()
   const { chainId, assetReference } = query
   const opportunity = state?.opportunity
-  const { accountAddress, setAccountId: handleAccountIdChange } = useFoxEth()
+  const { accountAddress } = useFoxEth()
   const { allowance, getApproveGasData, getDepositGasData } = useFoxEthLiquidityPool(accountAddress)
 
   const assetNamespace = 'erc20'
@@ -175,6 +187,7 @@ export const Deposit: React.FC<StepComponentProps> = ({ onNext }) => {
 
   return (
     <PairDeposit
+      accountId={accountId}
       asset1={foxAsset}
       asset2={ethAsset}
       icons={opportunity?.icons}

--- a/src/features/defi/providers/fox-eth-lp/components/FoxEthLpManager/FoxEthLpManager.tsx
+++ b/src/features/defi/providers/fox-eth-lp/components/FoxEthLpManager/FoxEthLpManager.tsx
@@ -5,6 +5,7 @@ import type {
 import { DefiAction } from 'features/defi/contexts/DefiManagerProvider/DefiCommon'
 import { AnimatePresence } from 'framer-motion'
 import { SlideTransition } from 'components/SlideTransition'
+import { useFoxEth } from 'context/FoxEthProvider/FoxEthProvider'
 import { useBrowserRouter } from 'hooks/useBrowserRouter/useBrowserRouter'
 
 import { FoxEthLpDeposit } from './Deposit/FoxEthLpDeposit'
@@ -14,22 +15,23 @@ import { FoxEthLpWithdraw } from './Withdraw/FoxEthLpWithdraw'
 export const FoxEthLpManager = () => {
   const { query } = useBrowserRouter<DefiQueryParams, DefiParams>()
   const { modal } = query
+  const { accountId, setAccountId: handleAccountIdChange } = useFoxEth()
 
   return (
     <AnimatePresence exitBeforeEnter initial={false}>
       {modal === DefiAction.Overview && (
         <SlideTransition key={DefiAction.Overview}>
-          <FoxEthLpOverview />
+          <FoxEthLpOverview accountId={accountId} onAccountIdChange={handleAccountIdChange} />
         </SlideTransition>
       )}
       {modal === DefiAction.Deposit && (
         <SlideTransition key={DefiAction.Deposit}>
-          <FoxEthLpDeposit />
+          <FoxEthLpDeposit accountId={accountId} onAccountIdChange={handleAccountIdChange} />
         </SlideTransition>
       )}
       {modal === DefiAction.Withdraw && (
         <SlideTransition key={DefiAction.Withdraw}>
-          <FoxEthLpWithdraw />
+          <FoxEthLpWithdraw accountId={accountId} onAccountIdChange={handleAccountIdChange} />
         </SlideTransition>
       )}
     </AnimatePresence>

--- a/src/features/defi/providers/fox-eth-lp/components/FoxEthLpManager/Overview/FoxEthLpOverview.tsx
+++ b/src/features/defi/providers/fox-eth-lp/components/FoxEthLpManager/Overview/FoxEthLpOverview.tsx
@@ -1,23 +1,33 @@
 import { ArrowDownIcon, ArrowUpIcon } from '@chakra-ui/icons'
 import { Center, CircularProgress } from '@chakra-ui/react'
+import type { AccountId } from '@shapeshiftoss/caip'
 import { ethAssetId, foxAssetId } from '@shapeshiftoss/caip'
 import { DefiModalContent } from 'features/defi/components/DefiModal/DefiModalContent'
 import { Overview } from 'features/defi/components/Overview/Overview'
 import { DefiAction } from 'features/defi/contexts/DefiManagerProvider/DefiCommon'
+import type { AccountDropdownProps } from 'components/AccountDropdown/AccountDropdown'
 import { useFoxEth } from 'context/FoxEthProvider/FoxEthProvider'
 import { useGetAssetDescriptionQuery } from 'state/slices/assetsSlice/assetsSlice'
 import { selectAssetById, selectSelectedLocale } from 'state/slices/selectors'
 import { useAppSelector } from 'state/store'
+import type { Nullable } from 'types/common'
 
 import { foxEthLpOpportunityName } from '../../../constants'
 
-export const FoxEthLpOverview = () => {
+type FoxEthLpOverviewProps = {
+  accountId: Nullable<AccountId>
+  onAccountIdChange: AccountDropdownProps['onChange']
+}
+
+export const FoxEthLpOverview: React.FC<FoxEthLpOverviewProps> = ({
+  accountId,
+  onAccountIdChange: handleAccountIdChange,
+}) => {
   const {
     foxEthLpOpportunity: opportunity,
     lpFoxBalance: foxBalance,
     lpEthBalance: ethBalance,
     lpLoading: loading,
-    setAccountId: handleAccountIdChange,
   } = useFoxEth()
 
   const lpAsset = useAppSelector(state => selectAssetById(state, opportunity.assetId))
@@ -39,6 +49,7 @@ export const FoxEthLpOverview = () => {
 
   return (
     <Overview
+      accountId={accountId}
       onAccountIdChange={handleAccountIdChange}
       asset={lpAsset}
       icons={opportunity.icons}

--- a/src/features/defi/providers/fox-eth-lp/components/FoxEthLpManager/Withdraw/FoxEthLpWithdraw.tsx
+++ b/src/features/defi/providers/fox-eth-lp/components/FoxEthLpManager/Withdraw/FoxEthLpWithdraw.tsx
@@ -1,4 +1,5 @@
 import { Center } from '@chakra-ui/react'
+import type { AccountId } from '@shapeshiftoss/caip'
 import { toAssetId } from '@shapeshiftoss/caip'
 import { DefiModalContent } from 'features/defi/components/DefiModal/DefiModalContent'
 import { DefiModalHeader } from 'features/defi/components/DefiModal/DefiModalHeader'
@@ -11,6 +12,7 @@ import qs from 'qs'
 import { useEffect, useMemo, useReducer } from 'react'
 import { useTranslate } from 'react-polyglot'
 import { useSelector } from 'react-redux'
+import type { AccountDropdownProps } from 'components/AccountDropdown/AccountDropdown'
 import { CircularProgress } from 'components/CircularProgress/CircularProgress'
 import type { DefiStepProps } from 'components/DeFi/components/Steps'
 import { Steps } from 'components/DeFi/components/Steps'
@@ -23,6 +25,7 @@ import {
   selectPortfolioLoading,
 } from 'state/slices/selectors'
 import { useAppSelector } from 'state/store'
+import type { Nullable } from 'types/common'
 
 import { foxEthLpOpportunityName } from '../../../constants'
 import { Approve } from './components/Approve'
@@ -33,7 +36,15 @@ import { FoxEthLpWithdrawActionType } from './WithdrawCommon'
 import { WithdrawContext } from './WithdrawContext'
 import { initialState, reducer } from './WithdrawReducer'
 
-export const FoxEthLpWithdraw = () => {
+type FoxEthLpWithdrawProps = {
+  accountId: Nullable<AccountId>
+  onAccountIdChange: AccountDropdownProps['onChange']
+}
+
+export const FoxEthLpWithdraw: React.FC<FoxEthLpWithdrawProps> = ({
+  accountId,
+  onAccountIdChange: handleAccountIdChange,
+}) => {
   const [state, dispatch] = useReducer(reducer, initialState)
   const translate = useTranslate()
   const { query, history, location } = useBrowserRouter<DefiQueryParams, DefiParams>()
@@ -83,7 +94,9 @@ export const FoxEthLpWithdraw = () => {
         description: translate('defi.steps.withdraw.info.description', {
           asset: underlyingAsset.symbol,
         }),
-        component: Withdraw,
+        component: ownProps => (
+          <Withdraw {...ownProps} accountId={accountId} onAccountIdChange={handleAccountIdChange} />
+        ),
       },
       [DefiStep.Approve]: {
         label: translate('defi.steps.approve.title'),

--- a/src/features/defi/providers/fox-eth-lp/components/FoxEthLpManager/Withdraw/components/Withdraw.tsx
+++ b/src/features/defi/providers/fox-eth-lp/components/FoxEthLpManager/Withdraw/components/Withdraw.tsx
@@ -176,6 +176,7 @@ export const Withdraw: React.FC<WithdrawProps> = ({
   return (
     <FormProvider {...methods}>
       <ReusableWithdraw
+        accountId={accountId}
         asset={asset}
         icons={opportunity.icons}
         cryptoAmountAvailable={cryptoAmountAvailable.toPrecision()}
@@ -208,6 +209,7 @@ export const Withdraw: React.FC<WithdrawProps> = ({
         <>
           <Text translation='common.receive' />
           <AssetInput
+            {...(accountId ? { accountId } : {})}
             cryptoAmount={foxAmount}
             fiatAmount={bnOrZero(foxAmount).times(foxMarketData.price).toFixed(2)}
             showFiatAmount={true}
@@ -219,6 +221,7 @@ export const Withdraw: React.FC<WithdrawProps> = ({
             isReadOnly={true}
           />
           <AssetInput
+            {...(accountId ? { accountId } : {})}
             cryptoAmount={ethAmount}
             fiatAmount={bnOrZero(ethAmount).times(ethMarketData.price).toFixed(2)}
             showFiatAmount={true}

--- a/src/features/defi/providers/fox-eth-lp/components/FoxEthLpManager/Withdraw/components/Withdraw.tsx
+++ b/src/features/defi/providers/fox-eth-lp/components/FoxEthLpManager/Withdraw/components/Withdraw.tsx
@@ -1,3 +1,4 @@
+import type { AccountId } from '@shapeshiftoss/caip'
 import { ethAssetId, foxAssetId } from '@shapeshiftoss/caip'
 import type { WithdrawValues } from 'features/defi/components/Withdraw/Withdraw'
 import { Field, Withdraw as ReusableWithdraw } from 'features/defi/components/Withdraw/Withdraw'
@@ -7,8 +8,9 @@ import type {
 } from 'features/defi/contexts/DefiManagerProvider/DefiCommon'
 import { DefiStep } from 'features/defi/contexts/DefiManagerProvider/DefiCommon'
 import { useFoxEthLiquidityPool } from 'features/defi/providers/fox-eth-lp/hooks/useFoxEthLiquidityPool'
-import { useContext, useState } from 'react'
+import { useContext, useMemo, useState } from 'react'
 import { FormProvider, useForm } from 'react-hook-form'
+import type { AccountDropdownProps } from 'components/AccountDropdown/AccountDropdown'
 import { AssetInput } from 'components/DeFi/components/AssetInput'
 import type { StepComponentProps } from 'components/DeFi/components/Steps'
 import { Text } from 'components/Text'
@@ -19,16 +21,26 @@ import { logger } from 'lib/logger'
 import {
   selectAssetById,
   selectMarketDataById,
-  selectPortfolioCryptoBalanceByAssetId,
+  selectPortfolioCryptoBalanceByFilter,
 } from 'state/slices/selectors'
 import { useAppSelector } from 'state/store'
+import type { Nullable } from 'types/common'
 
 import { FoxEthLpWithdrawActionType } from '../WithdrawCommon'
 import { WithdrawContext } from '../WithdrawContext'
 
 const moduleLogger = logger.child({ namespace: ['Withdraw'] })
 
-export const Withdraw: React.FC<StepComponentProps> = ({ onNext }) => {
+type WithdrawProps = StepComponentProps & {
+  accountId: Nullable<AccountId>
+  onAccountIdChange: AccountDropdownProps['onChange']
+}
+
+export const Withdraw: React.FC<WithdrawProps> = ({
+  accountId,
+  onAccountIdChange: handleAccountIdChange,
+  onNext,
+}) => {
   const { state, dispatch } = useContext(WithdrawContext)
   const { history: browserHistory } = useBrowserRouter<DefiQueryParams, DefiParams>()
   const {
@@ -37,7 +49,6 @@ export const Withdraw: React.FC<StepComponentProps> = ({ onNext }) => {
     lpEthBalance: ethBalance,
     lpLoading: loading,
     accountAddress,
-    setAccountId: handleAccountIdChange,
   } = useFoxEth()
 
   const { allowance, getApproveGasData, getWithdrawGasData } =
@@ -60,9 +71,11 @@ export const Withdraw: React.FC<StepComponentProps> = ({ onNext }) => {
     .toFixed(2)
 
   // user info
-  const balance = useAppSelector(state =>
-    selectPortfolioCryptoBalanceByAssetId(state, { assetId: opportunity.assetId }),
+  const filter = useMemo(
+    () => ({ assetId: opportunity?.assetId, accountId: accountId ?? '' }),
+    [opportunity?.assetId, accountId],
   )
+  const balance = useAppSelector(state => selectPortfolioCryptoBalanceByFilter(state, filter))
 
   const cryptoAmountAvailable = bnOrZero(balance).div(bn(10).pow(asset?.precision))
 

--- a/src/features/defi/providers/fox-farming/components/FoxFarmingManager/Deposit/FoxFarmingDeposit.tsx
+++ b/src/features/defi/providers/fox-farming/components/FoxFarmingManager/Deposit/FoxFarmingDeposit.tsx
@@ -1,4 +1,5 @@
 import { Center, useToast } from '@chakra-ui/react'
+import type { AccountId } from '@shapeshiftoss/caip'
 import { toAssetId } from '@shapeshiftoss/caip'
 import { DefiModalContent } from 'features/defi/components/DefiModal/DefiModalContent'
 import { DefiModalHeader } from 'features/defi/components/DefiModal/DefiModalHeader'
@@ -11,6 +12,7 @@ import qs from 'qs'
 import { useEffect, useMemo, useReducer } from 'react'
 import { useTranslate } from 'react-polyglot'
 import { useSelector } from 'react-redux'
+import type { AccountDropdownProps } from 'components/AccountDropdown/AccountDropdown'
 import { CircularProgress } from 'components/CircularProgress/CircularProgress'
 import type { DefiStepProps } from 'components/DeFi/components/Steps'
 import { Steps } from 'components/DeFi/components/Steps'
@@ -23,6 +25,7 @@ import {
   selectPortfolioLoading,
 } from 'state/slices/selectors'
 import { useAppSelector } from 'state/store'
+import type { Nullable } from 'types/common'
 
 import { Approve } from './components/Approve'
 import { Confirm } from './components/Confirm'
@@ -36,7 +39,14 @@ const moduleLogger = logger.child({
   namespace: ['DeFi', 'Providers', 'FoxFarming', 'FoxFarmingDeposit'],
 })
 
-export const FoxFarmingDeposit = () => {
+type FoxFarmingDepositProps = {
+  onAccountIdChange: AccountDropdownProps['onChange']
+  accountId: Nullable<AccountId>
+}
+export const FoxFarmingDeposit: React.FC<FoxFarmingDepositProps> = ({
+  accountId,
+  onAccountIdChange: handleAccountIdChange,
+}) => {
   const [state, dispatch] = useReducer(reducer, initialState)
   const translate = useTranslate()
   const toast = useToast()
@@ -81,7 +91,9 @@ export const FoxFarmingDeposit = () => {
       [DefiStep.Info]: {
         label: translate('defi.steps.deposit.info.title'),
         description: translate('defi.steps.deposit.info.description', { asset: asset.symbol }),
-        component: Deposit,
+        component: ownProps => (
+          <Deposit {...ownProps} accountId={accountId} onAccountIdChange={handleAccountIdChange} />
+        ),
       },
       [DefiStep.Approve]: {
         label: translate('defi.steps.approve.title'),
@@ -92,14 +104,14 @@ export const FoxFarmingDeposit = () => {
       },
       [DefiStep.Confirm]: {
         label: translate('defi.steps.confirm.title'),
-        component: Confirm,
+        component: ownProps => <Confirm {...ownProps} accountId={accountId} />,
       },
       [DefiStep.Status]: {
         label: 'Status',
-        component: Status,
+        component: ownProps => <Status {...ownProps} accountId={accountId} />,
       },
     }
-  }, [translate, asset.symbol, contractAddress])
+  }, [accountId, handleAccountIdChange, translate, asset.symbol, contractAddress])
 
   if (loading || foxFarmingLoading || !asset || !marketData || !opportunity) {
     return (

--- a/src/features/defi/providers/fox-farming/components/FoxFarmingManager/Deposit/components/Deposit.tsx
+++ b/src/features/defi/providers/fox-farming/components/FoxFarmingManager/Deposit/components/Deposit.tsx
@@ -1,5 +1,6 @@
 import { useToast } from '@chakra-ui/react'
-import { ethAssetId, foxAssetId, toAssetId } from '@shapeshiftoss/caip'
+import type { AccountId } from '@shapeshiftoss/caip'
+import { ethAssetId, foxAssetId, fromAccountId, toAssetId } from '@shapeshiftoss/caip'
 import type { DepositValues } from 'features/defi/components/Deposit/Deposit'
 import { Deposit as ReusableDeposit } from 'features/defi/components/Deposit/Deposit'
 import type {
@@ -10,23 +11,32 @@ import { DefiAction, DefiStep } from 'features/defi/contexts/DefiManagerProvider
 import { useFoxEthLiquidityPool } from 'features/defi/providers/fox-eth-lp/hooks/useFoxEthLiquidityPool'
 import { useFoxFarming } from 'features/defi/providers/fox-farming/hooks/useFoxFarming'
 import qs from 'qs'
-import { useCallback, useContext, useEffect, useState } from 'react'
+import { useCallback, useContext, useEffect, useMemo, useState } from 'react'
 import { useTranslate } from 'react-polyglot'
 import { useHistory } from 'react-router-dom'
+import type { AccountDropdownProps } from 'components/AccountDropdown/AccountDropdown'
 import type { StepComponentProps } from 'components/DeFi/components/Steps'
-import { useFoxEth } from 'context/FoxEthProvider/FoxEthProvider'
 import { useBrowserRouter } from 'hooks/useBrowserRouter/useBrowserRouter'
 import { bn, bnOrZero } from 'lib/bignumber/bignumber'
 import { logger } from 'lib/logger'
-import { selectAssetById, selectPortfolioCryptoBalanceByAssetId } from 'state/slices/selectors'
+import { selectAssetById, selectPortfolioCryptoBalanceByFilter } from 'state/slices/selectors'
 import { useAppSelector } from 'state/store'
+import type { Nullable } from 'types/common'
 
 import { FoxFarmingDepositActionType } from '../DepositCommon'
 import { DepositContext } from '../DepositContext'
 
 const moduleLogger = logger.child({ namespace: ['FoxFarmingDeposit:Deposit'] })
 
-export const Deposit: React.FC<StepComponentProps> = ({ onNext }) => {
+type DepositProps = StepComponentProps & {
+  accountId?: Nullable<AccountId>
+  onAccountIdChange: AccountDropdownProps['onChange']
+}
+export const Deposit: React.FC<DepositProps> = ({
+  accountId,
+  onAccountIdChange: handleAccountIdChange,
+  onNext,
+}) => {
   const [lpTokenPrice, setLpTokenPrice] = useState<string | null>(null)
   const { state, dispatch } = useContext(DepositContext)
   const history = useHistory()
@@ -34,7 +44,19 @@ export const Deposit: React.FC<StepComponentProps> = ({ onNext }) => {
   const { query, history: browserHistory } = useBrowserRouter<DefiQueryParams, DefiParams>()
   const { chainId, assetReference, contractAddress } = query
   const opportunity = state?.opportunity
-  const { accountAddress, setAccountId: handleAccountIdChange } = useFoxEth()
+
+  const assetNamespace = 'erc20'
+  const assetId = toAssetId({ chainId, assetNamespace, assetReference })
+  const asset = useAppSelector(state => selectAssetById(state, assetId))
+
+  // user info
+  const accountAddress = useMemo(
+    () => (accountId ? fromAccountId(accountId).account : ''),
+    [accountId],
+  )
+  const filter = useMemo(() => ({ assetId, accountId: accountId ?? '' }), [assetId, accountId])
+  const balance = useAppSelector(state => selectPortfolioCryptoBalanceByFilter(state, filter))
+
   const { getLpTokenPrice } = useFoxEthLiquidityPool(accountAddress)
   const {
     allowance: foxFarmingAllowance,
@@ -42,9 +64,6 @@ export const Deposit: React.FC<StepComponentProps> = ({ onNext }) => {
     getApproveGasData,
   } = useFoxFarming(contractAddress)
 
-  const assetNamespace = 'erc20'
-  const assetId = toAssetId({ chainId, assetNamespace, assetReference })
-  const asset = useAppSelector(state => selectAssetById(state, assetId))
   const ethAsset = useAppSelector(state => selectAssetById(state, ethAssetId))
   const marketData = {
     // The LP token doesnt have market data.
@@ -55,9 +74,6 @@ export const Deposit: React.FC<StepComponentProps> = ({ onNext }) => {
     changePercent24Hr: 0,
   }
   const rewardAsset = useAppSelector(state => selectAssetById(state, foxAssetId))
-
-  // user info
-  const balance = useAppSelector(state => selectPortfolioCryptoBalanceByAssetId(state, { assetId }))
 
   // notify
   const toast = useToast()
@@ -188,6 +204,7 @@ export const Deposit: React.FC<StepComponentProps> = ({ onNext }) => {
 
   return (
     <ReusableDeposit
+      accountId={accountId}
       asset={asset}
       rewardAsset={rewardAsset}
       inputIcons={opportunity?.icons}

--- a/src/features/defi/providers/fox-farming/components/FoxFarmingManager/Deposit/components/Status.tsx
+++ b/src/features/defi/providers/fox-farming/components/FoxFarmingManager/Deposit/components/Status.tsx
@@ -1,6 +1,7 @@
 import { CheckIcon, CloseIcon, ExternalLinkIcon } from '@chakra-ui/icons'
 import { Box, Button, Link, Stack } from '@chakra-ui/react'
-import { ASSET_REFERENCE, toAssetId } from '@shapeshiftoss/caip'
+import type { AccountId } from '@shapeshiftoss/caip'
+import { ASSET_REFERENCE, fromAccountId, toAssetId } from '@shapeshiftoss/caip'
 import { PairIcons } from 'features/defi/components/PairIcons/PairIcons'
 import { Summary } from 'features/defi/components/Summary'
 import { TxStatus } from 'features/defi/components/TxStatus/TxStatus'
@@ -17,19 +18,16 @@ import { Row } from 'components/Row/Row'
 import { RawText, Text } from 'components/Text'
 import { useBrowserRouter } from 'hooks/useBrowserRouter/useBrowserRouter'
 import { bnOrZero } from 'lib/bignumber/bignumber'
-import {
-  selectAssetById,
-  selectFirstAccountSpecifierByChainId,
-  selectMarketDataById,
-  selectTxById,
-} from 'state/slices/selectors'
+import { selectAssetById, selectMarketDataById, selectTxById } from 'state/slices/selectors'
 import { serializeTxIndex } from 'state/slices/txHistorySlice/utils'
 import { useAppSelector } from 'state/store'
+import type { Nullable } from 'types/common'
 
 import { FoxFarmingDepositActionType } from '../DepositCommon'
 import { DepositContext } from '../DepositContext'
 
-export const Status = () => {
+type StatusProps = { accountId: Nullable<AccountId> }
+export const Status: React.FC<StatusProps> = ({ accountId }) => {
   const translate = useTranslate()
   const { state, dispatch } = useContext(DepositContext)
   const opportunity = state?.opportunity
@@ -48,20 +46,18 @@ export const Status = () => {
   const feeAsset = useAppSelector(state => selectAssetById(state, feeAssetId))
   const feeMarketData = useAppSelector(state => selectMarketDataById(state, feeAssetId))
 
-  const accountSpecifier = useAppSelector(state =>
-    selectFirstAccountSpecifierByChainId(state, chainId),
-  )
-
   const handleViewPosition = useCallback(() => {
     browserHistory.push('/defi')
   }, [browserHistory])
 
   const handleCancel = history.goBack
 
+  const accountAddress = useMemo(() => fromAccountId(accountId ?? '').account, [accountId])
+
   const serializedTxIndex = useMemo(() => {
-    if (!(state?.txid && state?.userAddress)) return ''
-    return serializeTxIndex(accountSpecifier, state.txid, state?.userAddress)
-  }, [state?.txid, state?.userAddress, accountSpecifier])
+    if (!(state?.txid && accountId && accountAddress)) return ''
+    return serializeTxIndex(accountId, state.txid, accountAddress)
+  }, [state?.txid, accountAddress, accountId])
   const confirmedTransaction = useAppSelector(gs => selectTxById(gs, serializedTxIndex))
 
   useEffect(() => {

--- a/src/features/defi/providers/fox-farming/components/FoxFarmingManager/FoxFarmingManager.tsx
+++ b/src/features/defi/providers/fox-farming/components/FoxFarmingManager/FoxFarmingManager.tsx
@@ -5,6 +5,7 @@ import type {
 import { DefiAction } from 'features/defi/contexts/DefiManagerProvider/DefiCommon'
 import { AnimatePresence } from 'framer-motion'
 import { SlideTransition } from 'components/SlideTransition'
+import { useFoxEth } from 'context/FoxEthProvider/FoxEthProvider'
 import { useBrowserRouter } from 'hooks/useBrowserRouter/useBrowserRouter'
 
 import { FoxFarmingDeposit } from './Deposit/FoxFarmingDeposit'
@@ -15,22 +16,23 @@ import { FoxFarmingWithdraw } from './Withdraw/FoxFarmingWithdraw'
 export const FoxFarmingManager = () => {
   const { query } = useBrowserRouter<DefiQueryParams, DefiParams>()
   const { modal } = query
+  const { accountId, setAccountId: handleAccountIdChange } = useFoxEth()
 
   return (
     <AnimatePresence exitBeforeEnter initial={false}>
       {modal === DefiAction.Overview && (
         <SlideTransition key={DefiAction.Overview}>
-          <FoxFarmingOverview />
+          <FoxFarmingOverview accountId={accountId} onAccountIdChange={handleAccountIdChange} />
         </SlideTransition>
       )}
       {modal === DefiAction.Deposit && (
         <SlideTransition key={DefiAction.Deposit}>
-          <FoxFarmingDeposit />
+          <FoxFarmingDeposit accountId={accountId} onAccountIdChange={handleAccountIdChange} />
         </SlideTransition>
       )}
       {modal === DefiAction.Withdraw && (
         <SlideTransition key={DefiAction.Withdraw}>
-          <FoxFarmingWithdraw />
+          <FoxFarmingWithdraw accountId={accountId} onAccountIdChange={handleAccountIdChange} />
         </SlideTransition>
       )}
       {modal === DefiAction.Claim && (

--- a/src/features/defi/providers/fox-farming/components/FoxFarmingManager/Overview/FoxFarmingOverview.tsx
+++ b/src/features/defi/providers/fox-farming/components/FoxFarmingManager/Overview/FoxFarmingOverview.tsx
@@ -1,5 +1,6 @@
 import { ArrowDownIcon, ArrowUpIcon } from '@chakra-ui/icons'
 import { Center } from '@chakra-ui/react'
+import type { AccountId } from '@shapeshiftoss/caip'
 import { foxAssetId, toAssetId } from '@shapeshiftoss/caip'
 import { DefiModalContent } from 'features/defi/components/DefiModal/DefiModalContent'
 import { Overview } from 'features/defi/components/Overview/Overview'
@@ -12,6 +13,7 @@ import qs from 'qs'
 import { useMemo } from 'react'
 import { FaGift } from 'react-icons/fa'
 import { useTranslate } from 'react-polyglot'
+import type { AccountDropdownProps } from 'components/AccountDropdown/AccountDropdown'
 import { CircularProgress } from 'components/CircularProgress/CircularProgress'
 import { useFoxEth } from 'context/FoxEthProvider/FoxEthProvider'
 import { useBrowserRouter } from 'hooks/useBrowserRouter/useBrowserRouter'
@@ -19,19 +21,24 @@ import { bnOrZero } from 'lib/bignumber/bignumber'
 import { useGetAssetDescriptionQuery } from 'state/slices/assetsSlice/assetsSlice'
 import { selectAssetById, selectSelectedLocale } from 'state/slices/selectors'
 import { useAppSelector } from 'state/store'
+import type { Nullable } from 'types/common'
 
 import { FoxFarmingEmpty } from './FoxFarmingEmpty'
 import { WithdrawCard } from './WithdrawCard'
 
-export const FoxFarmingOverview = () => {
+type FoxFarmingOverviewProps = {
+  accountId?: Nullable<AccountId>
+  onAccountIdChange: AccountDropdownProps['onChange']
+}
+
+export const FoxFarmingOverview: React.FC<FoxFarmingOverviewProps> = ({
+  accountId,
+  onAccountIdChange: handleAccountIdChange,
+}) => {
   const translate = useTranslate()
   const { query, history, location } = useBrowserRouter<DefiQueryParams, DefiParams>()
   const { chainId, contractAddress, assetReference } = query
-  const {
-    setAccountId: handleAccountIdChange,
-    foxFarmingOpportunities,
-    farmingLoading: loading,
-  } = useFoxEth()
+  const { foxFarmingOpportunities, farmingLoading: loading } = useFoxEth()
   const opportunity = useMemo(
     () => foxFarmingOpportunities.find(e => e.contractAddress === contractAddress),
     [contractAddress, foxFarmingOpportunities],
@@ -83,6 +90,7 @@ export const FoxFarmingOverview = () => {
 
   return (
     <Overview
+      accountId={accountId}
       onAccountIdChange={handleAccountIdChange}
       asset={rewardAsset}
       name={opportunity.opportunityName ?? ''}

--- a/src/features/defi/providers/fox-farming/components/FoxFarmingManager/Withdraw/components/Confirm.tsx
+++ b/src/features/defi/providers/fox-farming/components/FoxFarmingManager/Withdraw/components/Confirm.tsx
@@ -34,7 +34,9 @@ const moduleLogger = logger.child({
   namespace: ['DeFi', 'Providers', 'FoxFarming', 'Withdraw', 'Confirm'],
 })
 
-export const Confirm = ({ onNext }: StepComponentProps) => {
+type ConfirmProps = StepComponentProps
+
+export const Confirm: React.FC<ConfirmProps> = ({ onNext }) => {
   const { state, dispatch } = useContext(WithdrawContext)
   const translate = useTranslate()
   const { query } = useBrowserRouter<DefiQueryParams, DefiParams>()

--- a/src/features/defi/providers/fox-farming/components/FoxFarmingManager/Withdraw/components/Status.tsx
+++ b/src/features/defi/providers/fox-farming/components/FoxFarmingManager/Withdraw/components/Status.tsx
@@ -1,6 +1,7 @@
 import { CheckIcon, CloseIcon, ExternalLinkIcon } from '@chakra-ui/icons'
 import { Box, Button, Link, Stack } from '@chakra-ui/react'
-import { ASSET_REFERENCE, toAssetId } from '@shapeshiftoss/caip'
+import type { AccountId } from '@shapeshiftoss/caip'
+import { ASSET_REFERENCE, fromAccountId, toAssetId } from '@shapeshiftoss/caip'
 import { PairIcons } from 'features/defi/components/PairIcons/PairIcons'
 import { Summary } from 'features/defi/components/Summary'
 import { TxStatus } from 'features/defi/components/TxStatus/TxStatus'
@@ -17,19 +18,19 @@ import { Row } from 'components/Row/Row'
 import { RawText, Text } from 'components/Text'
 import { useBrowserRouter } from 'hooks/useBrowserRouter/useBrowserRouter'
 import { bnOrZero } from 'lib/bignumber/bignumber'
-import {
-  selectAssetById,
-  selectFirstAccountSpecifierByChainId,
-  selectMarketDataById,
-  selectTxById,
-} from 'state/slices/selectors'
+import { selectAssetById, selectMarketDataById, selectTxById } from 'state/slices/selectors'
 import { serializeTxIndex } from 'state/slices/txHistorySlice/utils'
 import { useAppSelector } from 'state/store'
+import type { Nullable } from 'types/common'
 
 import { FoxFarmingWithdrawActionType } from '../WithdrawCommon'
 import { WithdrawContext } from '../WithdrawContext'
 
-export const Status = () => {
+type StatusProps = {
+  accountId: Nullable<AccountId>
+}
+
+export const Status: React.FC<StatusProps> = ({ accountId }) => {
   const translate = useTranslate()
   const { state, dispatch } = useContext(WithdrawContext)
   const opportunity = state?.opportunity
@@ -48,9 +49,7 @@ export const Status = () => {
   const feeAsset = useAppSelector(state => selectAssetById(state, feeAssetId))
   const feeMarketData = useAppSelector(state => selectMarketDataById(state, feeAssetId))
 
-  const accountSpecifier = useAppSelector(state =>
-    selectFirstAccountSpecifierByChainId(state, chainId),
-  )
+  const accountAddress = useMemo(() => fromAccountId(accountId ?? '').account, [accountId])
 
   const handleViewPosition = useCallback(() => {
     browserHistory.push('/defi')
@@ -59,9 +58,10 @@ export const Status = () => {
   const handleCancel = history.goBack
 
   const serializedTxIndex = useMemo(() => {
-    if (!(state?.txid && state?.userAddress)) return ''
-    return serializeTxIndex(accountSpecifier, state.txid, state?.userAddress)
-  }, [state?.txid, state?.userAddress, accountSpecifier])
+    if (!(state?.txid && accountId && accountAddress?.length)) return ''
+    return serializeTxIndex(accountId, state.txid, accountAddress)
+  }, [state?.txid, accountAddress, accountId])
+
   const confirmedTransaction = useAppSelector(gs => selectTxById(gs, serializedTxIndex))
 
   useEffect(() => {

--- a/src/features/defi/providers/fox-farming/components/FoxFarmingManager/Withdraw/components/Withdraw.tsx
+++ b/src/features/defi/providers/fox-farming/components/FoxFarmingManager/Withdraw/components/Withdraw.tsx
@@ -1,3 +1,4 @@
+import type { AccountId } from '@shapeshiftoss/caip'
 import { ethAssetId } from '@shapeshiftoss/caip'
 import type { WithdrawValues } from 'features/defi/components/Withdraw/Withdraw'
 import { Field, Withdraw as ReusableWithdraw } from 'features/defi/components/Withdraw/Withdraw'
@@ -9,26 +10,35 @@ import { DefiStep } from 'features/defi/contexts/DefiManagerProvider/DefiCommon'
 import { useFoxFarming } from 'features/defi/providers/fox-farming/hooks/useFoxFarming'
 import { useContext, useState } from 'react'
 import { FormProvider, useForm } from 'react-hook-form'
+import type { AccountDropdownProps } from 'components/AccountDropdown/AccountDropdown'
 import type { StepComponentProps } from 'components/DeFi/components/Steps'
-import { useFoxEth } from 'context/FoxEthProvider/FoxEthProvider'
 import { useBrowserRouter } from 'hooks/useBrowserRouter/useBrowserRouter'
 import { bn, bnOrZero } from 'lib/bignumber/bignumber'
 import { logger } from 'lib/logger'
 import { selectAssetById } from 'state/slices/selectors'
 import { useAppSelector } from 'state/store'
+import type { Nullable } from 'types/common'
 
 import { FoxFarmingWithdrawActionType } from '../WithdrawCommon'
 import { WithdrawContext } from '../WithdrawContext'
 const moduleLogger = logger.child({ namespace: ['Withdraw'] })
 
-export const Withdraw: React.FC<StepComponentProps> = ({ onNext }) => {
+type WithdrawProps = StepComponentProps & {
+  accountId?: Nullable<AccountId>
+  onAccountIdChange: AccountDropdownProps['onChange']
+}
+
+export const Withdraw: React.FC<WithdrawProps> = ({
+  accountId,
+  onAccountIdChange: handleAccountIdChange,
+  onNext,
+}) => {
   const { state, dispatch } = useContext(WithdrawContext)
   const [isExiting, setIsExiting] = useState<boolean>(false)
   const { history: browserHistory, query } = useBrowserRouter<DefiQueryParams, DefiParams>()
   const { contractAddress } = query
   const opportunity = state?.opportunity
   const { getUnstakeGasData, allowance, getApproveGasData } = useFoxFarming(contractAddress)
-  const { setAccountId: handleAccountIdChange } = useFoxEth()
 
   const methods = useForm<WithdrawValues>({ mode: 'onChange' })
   const { setValue } = methods
@@ -135,6 +145,7 @@ export const Withdraw: React.FC<StepComponentProps> = ({ onNext }) => {
   return (
     <FormProvider {...methods}>
       <ReusableWithdraw
+        accountId={accountId}
         asset={asset}
         icons={opportunity?.icons}
         cryptoAmountAvailable={cryptoAmountAvailable.toPrecision()}


### PR DESCRIPTION
## Description

- Overview
  - [x] Account selection
  - [x] Use selected account data
- [x] Deposit
  - [x] Approve
  - [x] Confirm
  - [x] Use selected account data in all steps
  - [ ] Poll (regression test against account 0 on prod) - seems borked, possibly because of unstable WS
- [x] Withdraw
  - [x] Approve
  - [x] Confirm 
  - [x] Use selected account data in all steps
  - [ ] Poll (regression test against account 0 on prod) - seems borked, possibly because of unstable WS
- [x] Claim
  - [x] Claim from selected account 
  - [x] Poll (regression test against account 0 on prod)
- [x] Deep-linking
  - [x] Open modal at current account from account asset page
  - [x] Display the balance of current account in account select page
 

## Notice

<!-- Before submitting a pull request, please make sure you have answered the following: -->

- [x] Have you followed the guidelines in our [Contributing]('https://github.com/shapeshift/web/blob/develop/CONTRIBUTING.md) guide?
- [x] Have you checked to ensure there aren't other open [Pull Requests](https://github.com/shapeshift/web/pulls) for the same update/change?

## Pull Request Type

- [ ] :bug: Bug fix (Non-breaking Change: Fixes an issue)
- [ ] :hammer_and_wrench: Chore (Non-breaking Change: Doc updates, pkg upgrades, typos, etc..)
- [x] :nail_care: New Feature (Breaking/Non-breaking Change)

## Issue (if applicable)

- relates to the closed https://github.com/shapeshift/web/issues/2609
- relates to the closed https://github.com/shapeshift/web/issues/2610
- relates to https://github.com/shapeshift/web/issues/2615
- relates to https://github.com/shapeshift/web/issues/2730

## Risk

Tested with MetaMask (which has only account 0 support) but this could bring regressions for the FOX/ETH modal for single accounts, test accordingly

## Testing (with KeepKey / Native)

- Enable the FOX/ETH LP / Farming flags as well as MultiAccount

- Add an Ethereum account and send some ETH and FOX to it
- Stake some FOX into FOX LP, reload the app (to avoid websocket shenanigans) and open Fox Farming from the DeFi earn section
- Select account 1 and click deposit
- Notice account #1 is pre-selected at Deposit step, with the right amount to deposit 
- Deposit some LP tokens into Fox Farming, sign and broadcast it - it should be deposited from account #1
- Disconnect and reconnect wallet, then reopen the Fox Farming modal and select withdraw with account #1 selected in overview
- Notice account #1 is pre-selected at Withdraw step, with the right amount available to withdraw
- Withdraw some LP tokens from Fox Farming - it should be withdrawn from account #1

- The aforementioned flow is working both for FOX LP / Farming

- When accessing the ETH/FOX Pool account asset page for an account (e.g 1), the farming/LP balances should be the ones from that account
- Clicking the farming/LP rows on account asset page should open the modal for the current account page

- Ensure the aforementioned flow still works with the MultiAccount flag off

### Engineering

<!-----------------------------------------------------------------------------
Include sufficient information here for an engineer to test your PR. This may include how to test locally, in a built environment, changes to infrastructure etc.
------------------------------------------------------------------------------>

- Refer to top-level testing steps
- Double-check the logic looks sound in deposit, withdraw, overview and claim for all steps

### Operations

- Refer to top-level testing steps

<!-----------------------------------------------------------------------------
If your changes have a user-facing impact, describe how a non-technical QA team can functionally test your changes in a preview environment.

If they are not user-facing please describe how to test for any regressions that may occur.
------------------------------------------------------------------------------>

## Screenshots 

#### Farming Deposit

<img width="539" alt="image" src="https://user-images.githubusercontent.com/17035424/191581701-95de2cc5-4450-43c1-8600-60f4a5c7bb97.png">
<img width="531" alt="image" src="https://user-images.githubusercontent.com/17035424/191581746-67735549-f333-4c27-9483-5371e127849f.png">
<img width="525" alt="image" src="https://user-images.githubusercontent.com/17035424/191581789-f5b196a2-b429-4579-9732-20fdf1fbd4e5.png">

#### Farming Withdraw

<img width="525" alt="image" src="https://user-images.githubusercontent.com/17035424/191582043-b0337f83-f903-42f7-8065-29121135d746.png">
<img width="519" alt="image" src="https://user-images.githubusercontent.com/17035424/191582096-4abd5ea7-20ac-4e3f-9572-fd077abd68d9.png">

#### LP Deposit

<img width="537" alt="image" src="https://user-images.githubusercontent.com/17035424/191582252-955c6b95-9c31-470c-bc1e-23ad726478b9.png">
<img width="523" alt="image" src="https://user-images.githubusercontent.com/17035424/191582336-f74b6f79-ef5d-49a7-a6f4-fbdc36e43f37.png">

#### LP Withdraw

<img width="536" alt="image" src="https://user-images.githubusercontent.com/17035424/191583958-322d9378-ef47-4448-88bd-2af30a0a7cb2.png">
<img width="532" alt="image" src="https://user-images.githubusercontent.com/17035424/191584008-d65950fe-6da0-4474-bbcd-4ed86ab61155.png">
<img width="538" alt="image" src="https://user-images.githubusercontent.com/17035424/191591071-81ac6fd7-47d4-485c-b439-a2d86e642562.png">
