### PR TITLE
fix: side scroll trade screen

### DIFF
--- a/src/pages/Trade/Trade.tsx
+++ b/src/pages/Trade/Trade.tsx
@@ -43,9 +43,9 @@ export const Trade = () => {
       >
         <Center
           height={{ base: 'auto', lg: '100%' }}
-          flex='1 1 0%'
           width='full'
-          overflow={{ base: 'visible', lg: 'hidden' }}
+          flex={{ base: 'auto', lg: '1 1 0%' }}
+          overflow='hidden'
           position='relative'
           mx={0}
           _before={{


### PR DESCRIPTION
## Description

- Background was running over causing the view to scroll horizontally on mobile

## Notice

<!-- Before submitting a pull request, please make sure you have answered the following: -->

- [x] Have you followed the guidelines in our [Contributing]('https://github.com/shapeshift/web/blob/develop/CONTRIBUTING.md) guide?
- [x] Have you checked to ensure there aren't other open [Pull Requests](https://github.com/shapeshift/web/pulls) for the same update/change?

## Pull Request Type

- [x] :bug: Bug fix (Non-breaking Change: Fixes an issue)
- [ ] :hammer_and_wrench: Chore (Non-breaking Change: Doc updates, pkg upgrades, typos, etc..)
- [ ] :nail_care: New Feature (Breaking/Non-breaking Change)

## Issue (if applicable)

n/a

## Risk

none

## Testing

On mobile screen size there should be no scrolling left or right on mobile sizes

### Engineering

n/a

### Operations

Go to trade page on mobile and confirm the screen doesn't scroll left and right

## Screenshots (if applicable)
