### PR TITLE
fix(mobile): on create location.state can be undefed

### DIFF
--- a/src/context/WalletProvider/MobileWallet/components/MobileCreate.tsx
+++ b/src/context/WalletProvider/MobileWallet/components/MobileCreate.tsx
@@ -38,7 +38,7 @@ type MobileCreateProps = {
 export const MobileCreate: React.FC<MobileCreateProps> = props => {
   const { HeaderComponent } = props
   const history = useHistory()
-  const location = useLocation<MobileLocationState>()
+  const location = useLocation<MobileLocationState | undefined>()
   const [revealed, setRevealed] = useState<boolean>(false)
   const revealedOnce = useRef<boolean>(false)
   const handleShow = () => {
@@ -70,11 +70,11 @@ export const MobileCreate: React.FC<MobileCreateProps> = props => {
 
   useEffect(() => {
     try {
-      if (!vault) setVault(location.state.vault || createWallet())
+      if (!vault) setVault(location.state?.vault || createWallet())
     } catch (e) {
       moduleLogger.error(e, 'Create Wallet')
     }
-  }, [location.state.vault, setVault, vault])
+  }, [location.state?.vault, setVault, vault])
 
   useEffect(() => {
     if (!vault) return


### PR DESCRIPTION
## Description

Fix a regression in MobileCreate.

MobileCreate added a check for `location.state.vault` to see if vault was coming in from the LegacyLogin flow
but I forgot to check if `state` was undefined.

## Notice

<!-- Before submitting a pull request, please make sure you have answered the following: -->

- [X] Have you followed the guidelines in our [Contributing]('https://github.com/shapeshift/web/blob/develop/CONTRIBUTING.md) guide?
- [X] Have you checked to ensure there aren't other open [Pull Requests](https://github.com/shapeshift/web/pulls) for the same update/change?

## Pull Request Type

- [X] :bug: Bug fix (Non-breaking Change: Fixes an issue)
- [ ] :hammer_and_wrench: Chore (Non-breaking Change: Doc updates, pkg upgrades, typos, etc..)
- [ ] :nail_care: New Feature (Breaking/Non-breaking Change)

## Issue (if applicable)

<!-----------------------------------------------------------------------------
If applicable, please link to the github issue and put `closes #XXXX` in your comment to auto-close the issue that your PR fixes.
------------------------------------------------------------------------------>

N/A - reported in Mobile App Testing thread

## Risk
Very low. Only affects mobile.
<!-----------------------------------------------------------------------------
Outline the scope of your changes and the risk associated with them. You must use your discretion as an engineer to determine the potential impact of your changes.

E.g. an upgrade to `hdwallet` or core state management would be considered higher risk, and might require a full regression test. UI or isolated view changes, or something behind a feature flag may have near zero risk. Small bug fixes might require testing isolated to the specific fix.
------------------------------------------------------------------------------>

## Testing
In mobile,
1. Connect Wallet
2. ShapeShift Mobile
3. Create a wallet
4. Complete the flow

Next
1. Disconnect wallet
2. ShapeShift Mobile
3. Log In
4. Use a valid shapeshift account to login

### Engineering

<!-----------------------------------------------------------------------------
Include sufficient information here for an engineer to test your PR. This may include how to test locally, in a built environment, changes to infrastructure etc.
------------------------------------------------------------------------------>

### Operations

<!-----------------------------------------------------------------------------
If your changes have a user-facing impact, describe how a non-technical QA team can functionally test your changes in a preview environment.

If they are not user-facing please describe how to test for any regressions that may occur.
------------------------------------------------------------------------------>

## Screenshots (if applicable)
