### PR TITLE
fix: removes portis from mobile app

### DIFF
--- a/src/context/WalletProvider/Portis/config.ts
+++ b/src/context/WalletProvider/Portis/config.ts
@@ -4,7 +4,7 @@ import type { SupportedWalletInfo } from 'context/WalletProvider/config'
 
 export const PortisConfig: Omit<SupportedWalletInfo, 'routes'> = {
   adapter: PortisAdapter,
-  supportsMobile: 'both',
+  supportsMobile: 'browser',
   icon: PortisIcon,
   name: 'Portis',
 }


### PR DESCRIPTION
## Description

We haven't tested portis on the mobile app and it doesn't seem to be working at first glance, so we should remove it and can worry about adding it back in at a later date (just like wallet connect)

## Notice

<!-- Before submitting a pull request, please make sure you have answered the following: -->

- [x] Have you followed the guidelines in our [Contributing]('https://github.com/shapeshift/web/blob/develop/CONTRIBUTING.md) guide?
- [x] Have you checked to ensure there aren't other open [Pull Requests](https://github.com/shapeshift/web/pulls) for the same update/change?

## Pull Request Type

- [x] :bug: Bug fix (Non-breaking Change: Fixes an issue)
- [ ] :hammer_and_wrench: Chore (Non-breaking Change: Doc updates, pkg upgrades, typos, etc..)
- [ ] :nail_care: New Feature (Breaking/Non-breaking Change)

## Issue (if applicable)

<!-----------------------------------------------------------------------------
If applicable, please link to the github issue and put `closes #XXXX` in your comment to auto-close the issue that your PR fixes.
------------------------------------------------------------------------------>

closes #

## Risk
That this change removes portis from more than just the mobile app

## Testing


Confirm that the portis wallet stills hows up as an option for mobile web and normal desktop web, but does not show up for the mobile app

## Screenshots (if applicable)
