### PR TITLE
fix: spacing of the alert message

### DIFF
--- a/src/components/Trade/TradeConfirm/TradeConfirm.tsx
+++ b/src/components/Trade/TradeConfirm/TradeConfirm.tsx
@@ -295,7 +295,7 @@ export const TradeConfirm = ({ history }: RouterProps) => {
                   </Row.Value>
                 </Row>
                 {isFeeRatioOverThreshold && (
-                  <Flex justifyContent='space-evenly' alignItems='center'>
+                  <Flex justifyContent='center' gap={4} alignItems='center'>
                     <WarningTwoIcon w={5} h={5} color='red.400' />
                     <Text
                       color='red.400'


### PR DESCRIPTION
## Description

- fix spacing on the gas exceeds message on trade

## Notice

<!-- Before submitting a pull request, please make sure you have answered the following: -->

- [x] Have you followed the guidelines in our [Contributing]('https://github.com/shapeshift/web/blob/develop/CONTRIBUTING.md) guide?
- [x] Have you checked to ensure there aren't other open [Pull Requests](https://github.com/shapeshift/web/pulls) for the same update/change?

## Pull Request Type

- [x] :bug: Bug fix (Non-breaking Change: Fixes an issue)
- [ ] :hammer_and_wrench: Chore (Non-breaking Change: Doc updates, pkg upgrades, typos, etc..)
- [ ] :nail_care: New Feature (Breaking/Non-breaking Change)

## Issue (if applicable)

n/a
## Risk

no risk

## Testing

n/a

### Engineering

n/a

### Operations

when you do a trade and get the gas exceeds % of trade. The alert icon should be spaced correctly on both trade page and trade widget.

## Screenshots (if applicable)
![Screen Shot 2022-09-26 at 10 43 57 AM](https://user-images.githubusercontent.com/89934888/192323704-195229fc-839c-4ad2-b3e0-bea7c87bc336.png)
![Screen_Shot_2022-09-26_at_10 41 19_AM](https://user-images.githubusercontent.com/89934888/192323909-fbc71dc5-9486-4091-a93d-01b5981a002b.png)

