### PR TITLE
fix: remove high low values on rainbow

### DIFF
--- a/src/components/Graph/RainbowChart/RainbowChart.tsx
+++ b/src/components/Graph/RainbowChart/RainbowChart.tsx
@@ -1,21 +1,19 @@
 import { Stack, Text } from '@chakra-ui/react'
-import { useColorModeValue, useToken } from '@chakra-ui/system'
+import { useColorModeValue } from '@chakra-ui/system'
 import { curveLinear } from '@visx/curve'
 import { Group } from '@visx/group'
 import { ScaleSVG } from '@visx/responsive'
-import { Text as VisxText } from '@visx/text'
 import type { Margin } from '@visx/xychart'
 import { AreaSeries, AreaStack, Axis, Tooltip, XYChart } from '@visx/xychart'
 import type { Numeric } from 'd3-array'
 import { extent } from 'd3-array'
 import dayjs from 'dayjs'
 import omit from 'lodash/omit'
-import React, { useCallback, useMemo } from 'react'
+import React, { useMemo } from 'react'
 import { useSelector } from 'react-redux'
 import { Amount } from 'components/Amount/Amount'
 import { AssetIcon } from 'components/AssetIcon'
 import type { RainbowData } from 'hooks/useBalanceChartData/useBalanceChartData'
-import { useLocaleFormatter } from 'hooks/useLocaleFormatter/useLocaleFormatter'
 import { selectAssets, selectSelectedLocale } from 'state/slices/selectors'
 import { useAppSelector } from 'state/store'
 import { colors } from 'theme/colors'
@@ -28,27 +26,17 @@ export type RainbowChartProps = {
   margin?: Margin
 }
 
-const getScaledX = (date: number, start: number, end: number, width: number) =>
-  ((date - start) / (end - start)) * width
-
-const getScaledY = (price: number, min: number, max: number, height: number) =>
-  ((max - price) / (max - min)) * height
-
 // https://codesandbox.io/s/github/airbnb/visx/tree/master/packages/visx-demo/src/sandboxes/visx-xychart?file=/customTheme.ts:50-280
 export const RainbowChart: React.FC<RainbowChartProps> = ({
   data,
   width,
   height,
-  color,
   margin = { top: 0, right: 0, bottom: 0, left: 0 },
 }) => {
   const selectedLocale = useAppSelector(selectSelectedLocale)
   const assetIds = useMemo(() => Object.keys(omit(data[0], ['date', 'total'])), [data])
   const assets = useSelector(selectAssets)
 
-  const {
-    number: { toFiat },
-  } = useLocaleFormatter()
   const magicXAxisOffset = 37
 
   type Accessor = (d: RainbowData) => number
@@ -86,30 +74,7 @@ export const RainbowChart: React.FC<RainbowChartProps> = ({
   const totals = useMemo(() => data.map(d => d.total), [data])
   const minPrice = Math.min(...totals)
   const maxPrice = Math.max(...totals)
-  const maxPriceDate = data.find(x => x.total === maxPrice)!.date
-  const minPriceDate = data.find(x => x.total === minPrice)!.date
 
-  const handleTextPosition = useCallback(
-    (x: number): { x: number; anchor: 'end' | 'start' | 'middle' } => {
-      const offsetWidth = width / 2
-      const buffer = 16
-      const end = width - offsetWidth
-      if (x < offsetWidth) {
-        return { x: x + buffer, anchor: 'start' }
-      } else if (x > end) {
-        return { x, anchor: 'end' }
-      } else {
-        return { x, anchor: 'start' }
-      }
-    },
-    [width],
-  )
-  const scaledMaxPriceX = handleTextPosition(
-    getScaledX(maxPriceDate, xScale.domain[0].getTime(), xScale.domain[1].getTime(), width),
-  )
-  const scaledMinPriceX = handleTextPosition(
-    getScaledX(minPriceDate, xScale.domain[0].getTime(), xScale.domain[1].getTime(), width),
-  )
   const yMax = Math.max(height - margin.top - margin.bottom, 0)
   const yScale = useMemo(
     () => ({
@@ -120,13 +85,10 @@ export const RainbowChart: React.FC<RainbowChartProps> = ({
     }),
     [margin.top, maxPrice, minPrice, yMax],
   )
-  const scaledMaxPriceY = getScaledY(maxPrice, minPrice, maxPrice, height - margin.bottom)
-  const scaledMinPriceY = getScaledY(minPrice, minPrice, maxPrice, height - margin.bottom)
 
   const tooltipBg = useColorModeValue('white', colors.gray[700])
   const tooltipBorder = useColorModeValue(colors.gray[200], colors.gray[600])
   const tooltipColor = useColorModeValue(colors.gray[800], 'white')
-  const minMaxTextColor = useToken('colors', color)
 
   const areaLines = useMemo(
     () =>
@@ -202,35 +164,6 @@ export const RainbowChart: React.FC<RainbowChartProps> = ({
               )
             }}
           />
-          <Group top={margin.top} left={margin.left}>
-            <g>
-              <VisxText
-                x={scaledMaxPriceX.x}
-                textAnchor={scaledMaxPriceX.anchor}
-                y={scaledMaxPriceY}
-                fill={minMaxTextColor}
-                fontSize='12px'
-                dy='1rem'
-                dx='-0.5rem'
-              >
-                {toFiat(maxPrice)}
-              </VisxText>
-            </g>
-            <g>
-              <VisxText
-                x={scaledMinPriceX.x}
-                textAnchor={scaledMinPriceX.anchor}
-                y={scaledMinPriceY}
-                fill={minMaxTextColor}
-                fontSize='12px'
-                dy='1rem'
-                dx='-0.5rem'
-                width={100}
-              >
-                {toFiat(minPrice)}
-              </VisxText>
-            </g>
-          </Group>
         </XYChart>
       </ScaleSVG>
     </div>


### PR DESCRIPTION
## Description

- remove the min/max on the rainbow chart

## Notice

<!-- Before submitting a pull request, please make sure you have answered the following: -->

- [x] Have you followed the guidelines in our [Contributing]('https://github.com/shapeshift/web/blob/develop/CONTRIBUTING.md) guide?
- [x] Have you checked to ensure there aren't other open [Pull Requests](https://github.com/shapeshift/web/pulls) for the same update/change?

## Pull Request Type

- [x] :bug: Bug fix (Non-breaking Change: Fixes an issue)
- [ ] :hammer_and_wrench: Chore (Non-breaking Change: Doc updates, pkg upgrades, typos, etc..)
- [ ] :nail_care: New Feature (Breaking/Non-breaking Change)

## Issue (if applicable)

n/a

## Risk

no risk

## Testing

n/a

### Engineering

n/a

### Operations

turn on rainbow, see the min/max values are gone.

## Screenshots (if applicable)
![Screen Shot 2022-09-26 at 2 33 40 PM](https://user-images.githubusercontent.com/89934888/192364003-31e9c3d5-4ce2-4110-96e9-ec4febcb1cb5.png)
