### PR TITLE
fix: zendesk maximized on mobile

### DIFF
--- a/src/components/Zendesk/zendesk.css
+++ b/src/components/Zendesk/zendesk.css
@@ -5,3 +5,12 @@
 #launcher, #webWidget {
   color-scheme: none;
 }
+
+#webWidget {
+  /* the mobile webview doesn't respect the restricted areas, e.g. notches on iphones.
+   * without this the minimize button ends up hiding behind battery/clock/wifi icons.
+   * this 71px matches the app header height so it looks natural.
+   * this also makes the widget shorter vertically on desktop, but no one cares.
+   */
+  padding-top: 71px;
+}


### PR DESCRIPTION
## Description

<!-- Please describe your changes -->
the mobile webview doesn't respect the restricted areas, e.g. notches on iphones.
without this the minimize button ends up hiding behind battery/clock/wifi icons.
this 71px matches the app header height so it looks natural.
this also makes the widget shorter vertically on desktop, but no one cares.

## Notice

<!-- Before submitting a pull request, please make sure you have answered the following: -->

- [x] Have you followed the guidelines in our [Contributing]('https://github.com/shapeshift/web/blob/develop/CONTRIBUTING.md) guide?
- [x] Have you checked to ensure there aren't other open [Pull Requests](https://github.com/shapeshift/web/pulls) for the same update/change?

## Pull Request Type

- [x] :bug: Bug fix (Non-breaking Change: Fixes an issue)
- [ ] :hammer_and_wrench: Chore (Non-breaking Change: Doc updates, pkg upgrades, typos, etc..)
- [ ] :nail_care: New Feature (Breaking/Non-breaking Change)

## Issue (if applicable)

<!-----------------------------------------------------------------------------
If applicable, please link to the github issue and put `closes #XXXX` in your comment to auto-close the issue that your PR fixes.
------------------------------------------------------------------------------>

n/a - discovered in develop on mobile

## Risk

<!-----------------------------------------------------------------------------
Outline the scope of your changes and the risk associated with them. You must use your discretion as an engineer to determine the potential impact of your changes.

E.g. an upgrade to `hdwallet` or core state management would be considered higher risk, and might require a full regression test. UI or isolated view changes, or something behind a feature flag may have near zero risk. Small bug fixes might require testing isolated to the specific fix.
------------------------------------------------------------------------------>

purely isolated to rendering of the zendesk widget when it's open. it can't possibly be worse than
it was.

## Testing

<!-----------------------------------------------------------------------------
We treat every PR to be merged with the same scrutiny as if we were merging directly to production.

Your PR will not be merged if you do not complete the sections below for our engineering and operations teams to test.
------------------------------------------------------------------------------>

* point mobile app at `develop`
* open zendesk
* you should be able to close it now!

### Engineering

<!-----------------------------------------------------------------------------
Include sufficient information here for an engineer to test your PR. This may include how to test locally, in a built environment, changes to infrastructure etc.
------------------------------------------------------------------------------>

### Operations

<!-----------------------------------------------------------------------------
If your changes have a user-facing impact, describe how a non-technical QA team can functionally test your changes in a preview environment.

If they are not user-facing please describe how to test for any regressions that may occur.
------------------------------------------------------------------------------>

## Screenshots (if applicable)

before/after left/right respectively

![image](https://user-images.githubusercontent.com/88504456/192394728-6fad2a46-029f-420d-9d69-a4b6b2d9fde1.png)

before

![image](https://user-images.githubusercontent.com/88504456/192394777-c62168e3-a4e4-477b-a341-ce315745d160.png)

after what it *should* look like on mobile

![image](https://user-images.githubusercontent.com/88504456/192394752-42b79644-b063-4e63-ad6f-72e7a525f9e8.png)

