### PR TITLE
chore: use thorchain daemon

### DIFF
--- a/.env.app
+++ b/.env.app
@@ -34,7 +34,7 @@ REACT_APP_UNCHAINED_THORCHAIN_HTTP_URL=https://api.thorchain.shapeshift.com
 REACT_APP_UNCHAINED_THORCHAIN_WS_URL=wss://api.thorchain.shapeshift.com
 
 # nodes
-REACT_APP_THORCHAIN_NODE_URL=https://daemon.thorchain.shapeshift.com/lcd
+REACT_APP_THORCHAIN_NODE_URL=https://daemon.thorchain.shapeshift.com
 REACT_APP_ETHEREUM_NODE_URL=https://daemon.ethereum.shapeshift.com
 REACT_APP_ETHEREUM_INFURA_URL=https://mainnet.infura.io/v3/6e2f28ff4f5340fdb0db5da3baec0af2
 

--- a/.env.dev
+++ b/.env.dev
@@ -38,7 +38,7 @@ REACT_APP_UNCHAINED_THORCHAIN_HTTP_URL=https://dev-api.thorchain.shapeshift.com
 REACT_APP_UNCHAINED_THORCHAIN_WS_URL=wss://dev-api.thorchain.shapeshift.com
 
 # nodes
-REACT_APP_THORCHAIN_NODE_URL=https://dev-daemon.thorchain.shapeshift.com/lcd
+REACT_APP_THORCHAIN_NODE_URL=https://dev-daemon.thorchain.shapeshift.com
 REACT_APP_ETHEREUM_NODE_URL=https://dev-daemon.ethereum.shapeshift.com
 REACT_APP_ETHEREUM_INFURA_URL=https://mainnet.infura.io/v3/fb05c87983c4431baafd4600fd33de7e
 

--- a/.env.develop
+++ b/.env.develop
@@ -36,7 +36,7 @@ REACT_APP_UNCHAINED_THORCHAIN_HTTP_URL=https://dev-api.thorchain.shapeshift.com
 REACT_APP_UNCHAINED_THORCHAIN_WS_URL=wss://dev-api.thorchain.shapeshift.com
 
 # nodes
-REACT_APP_THORCHAIN_NODE_URL=https://dev-daemon.thorchain.shapeshift.com/lcd
+REACT_APP_THORCHAIN_NODE_URL=https://dev-daemon.thorchain.shapeshift.com
 REACT_APP_ETHEREUM_NODE_URL=https://dev-daemon.ethereum.shapeshift.com
 REACT_APP_ETHEREUM_INFURA_URL=https://mainnet.infura.io/v3/d28923bef53e4b26b21a094ae38d32b3
 

--- a/.env.private
+++ b/.env.private
@@ -25,7 +25,7 @@ REACT_APP_UNCHAINED_THORCHAIN_HTTP_URL=https://api.thorchain.shapeshift.com
 REACT_APP_UNCHAINED_THORCHAIN_WS_URL=wss://api.thorchain.shapeshift.com
 
 # nodes
-REACT_APP_THORCHAIN_NODE_URL=https://daemon.thorchain.shapeshift.com/lcd
+REACT_APP_THORCHAIN_NODE_URL=https://daemon.thorchain.shapeshift.com
 REACT_APP_ETHEREUM_NODE_URL=https://daemon.ethereum.shapeshift.com
 REACT_APP_ETHEREUM_INFURA_URL=https://mainnet.infura.io/v3/6e2f28ff4f5340fdb0db5da3baec0af2
 

--- a/package.json
+++ b/package.json
@@ -106,7 +106,7 @@
     "@shapeshiftoss/investor-yearn": "^6.1.2",
     "@shapeshiftoss/logger": "^1.1.3",
     "@shapeshiftoss/market-service": "^7.1.0",
-    "@shapeshiftoss/swapper": "~11.3.0",
+    "@shapeshiftoss/swapper": "^11.4.0",
     "@shapeshiftoss/types": "^8.3.1",
     "@shapeshiftoss/unchained-client": "^10.1.2",
     "@uniswap/sdk": "^3.0.3",

--- a/src/components/Trade/hooks/useSwapper/swapperManager.ts
+++ b/src/components/Trade/hooks/useSwapper/swapperManager.ts
@@ -36,7 +36,9 @@ export const getSwapperManager = async (flags: FeatureFlags): Promise<SwapperMan
   if (flags.ThorSwap) {
     await (async () => {
       const midgardUrl = getConfig().REACT_APP_MIDGARD_URL
+      const daemonUrl = getConfig().REACT_APP_THORCHAIN_NODE_URL
       const thorSwapper = new ThorchainSwapper({
+        daemonUrl,
         midgardUrl,
         adapterManager,
         web3: ethWeb3,

--- a/yarn.lock
+++ b/yarn.lock
@@ -4340,10 +4340,10 @@
     google-protobuf "^3.17.0"
     long "^4.0.0"
 
-"@shapeshiftoss/swapper@~11.3.0":
-  version "11.3.1"
-  resolved "https://registry.yarnpkg.com/@shapeshiftoss/swapper/-/swapper-11.3.1.tgz#b2980faeb092fff386cd8b641b8ae47d1ebb7021"
-  integrity sha512-vCvBUInHE+DGgYbeMT/A8FFUOECT89jZ2aWYgdF8448lHADERx/haI9OZDp20lCqNbGx4Fei/gUEzz3LbTSGrQ==
+"@shapeshiftoss/swapper@^11.4.0":
+  version "11.4.0"
+  resolved "https://registry.yarnpkg.com/@shapeshiftoss/swapper/-/swapper-11.4.0.tgz#9c801aba8d38bbac06836d23e1f565fe32b05e2d"
+  integrity sha512-sB2VSYX0PsVe8UhZTrbw9UEzrVj8m0JlA0X3vOOza4aI5AQyqLYpWuvOZ+mx9tOEbAZdCAyaNS+kCn1PPaWvsQ==
   dependencies:
     axios "^0.26.1"
     bignumber.js "^9.0.2"


### PR DESCRIPTION
## Description

Updates the `ThorchainSwapper` instance to use a `daemonUrl`.

Handles new shape of `ThorchainSwapper` `deps` in https://github.com/shapeshift/lib/pull/1039.

Keeping in draft until https://github.com/shapeshift/lib/pull/1039 is published.

## Notice

- [x] Have you followed the guidelines in our [Contributing]('https://github.com/shapeshift/web/blob/develop/CONTRIBUTING.md) guide?
- [x] Have you checked to ensure there aren't other open [Pull Requests](https://github.com/shapeshift/web/pulls) for the same update/change?

## Pull Request Type

- [ ] :bug: Bug fix (Non-breaking Change: Fixes an issue)
- [ ] :hammer_and_wrench: Chore (Non-breaking Change: Doc updates, pkg upgrades, typos, etc..)
- [x] :nail_care: New Feature (Breaking/Non-breaking Change)

## Issue (if applicable)

Closes https://github.com/shapeshift/web/issues/2871

## Risk

Small - if we can still get ThorSwap quotes we are likely ok.

## Testing

### Engineering

1. Ensure the `REACT_APP_THORCHAIN_NODE_URL` in `.env` is set to `https://dev-daemon.thorchain.shapeshift.com`
2. Get a ThorSwap quote and observe requests to `https://dev-daemon.thorchain.shapeshift.com/lcd/thorchain/pools` via the network tab. They should be significantly faster (>500ms).

### Operations

1. Get a ThorSwap quote - it should feel significantly faster than before.

Note, in the network tab, ensure the prefix to `/lcd/thorchain/pools` is `https://dev-daemon.thorchain.shapeshift.com`.

## Screenshots (if applicable)

N/A
