### PR TITLE
feat: subtle buy button animation

### DIFF
--- a/src/components/Layout/Header/NavBar/FiatRamps.tsx
+++ b/src/components/Layout/Header/NavBar/FiatRamps.tsx
@@ -27,9 +27,18 @@ export const FiatRamps = (props: FiatRampsProps) => {
 
   const rainbow = keyframes`
     0% {
-      background-position: 10% 0%;
+      background-position: 10% 0;
     }
-
+    2% {
+      background-position: 10% 0;
+    }
+    
+    10% {
+      background-position: 91% 100%;
+    }
+    14% {
+      background-position: 91% 100%;
+    }
     100% {
       background-position: 91% 100%;
     }
@@ -43,7 +52,7 @@ export const FiatRamps = (props: FiatRampsProps) => {
           data-test='fiat-ramps-button'
           bg={bg}
           backgroundSize='300% 300%'
-          animation={`${rainbow} 3s ease infinite`}
+          animation={`${rainbow} 10s ease infinite`}
           width='full'
           aria-label={translate('fiatRamps.headerLabel')}
           onClick={() => (isConnected ? fiatRamps.open({}) : handleWalletModalOpen())}

--- a/src/components/Layout/Header/NavBar/FiatRamps.tsx
+++ b/src/components/Layout/Header/NavBar/FiatRamps.tsx
@@ -1,4 +1,6 @@
 import type { BoxProps } from '@chakra-ui/react'
+import { useColorModeValue } from '@chakra-ui/react'
+import { keyframes } from '@chakra-ui/react'
 import { Box, IconButton, Tooltip } from '@chakra-ui/react'
 import { FaCreditCard } from 'react-icons/fa'
 import { useTranslate } from 'react-polyglot'
@@ -18,12 +20,30 @@ export const FiatRamps = (props: FiatRampsProps) => {
   const handleWalletModalOpen = () =>
     dispatch({ type: WalletActions.SET_WALLET_MODAL, payload: true })
 
+  const bg = useColorModeValue(
+    'linear-gradient(126deg, var(--chakra-colors-gray-100) 0%, var(--chakra-colors-gray-100) 40%, var(--chakra-colors-white) 50%, var(--chakra-colors-gray-100) 60%)',
+    'linear-gradient(126deg, var(--chakra-colors-gray-700) 0%, var(--chakra-colors-gray-700) 40%, var(--chakra-colors-gray-500) 50%, var(--chakra-colors-gray-700) 60%)',
+  )
+
+  const rainbow = keyframes`
+    0% {
+      background-position: 10% 0%;
+    }
+
+    100% {
+      background-position: 91% 100%;
+    }
+  `
+
   return (
     <Box {...props}>
       <Tooltip label={translate('fiatRamps.headerLabel')}>
         <IconButton
           icon={<FaCreditCard />}
           data-test='fiat-ramps-button'
+          bg={bg}
+          backgroundSize='300% 300%'
+          animation={`${rainbow} 3s ease infinite`}
           width='full'
           aria-label={translate('fiatRamps.headerLabel')}
           onClick={() => (isConnected ? fiatRamps.open({}) : handleWalletModalOpen())}


### PR DESCRIPTION
## Description

Add a subtle shine animation to the buy button

## Notice

<!-- Before submitting a pull request, please make sure you have answered the following: -->

- [x] Have you followed the guidelines in our [Contributing]('https://github.com/shapeshift/web/blob/develop/CONTRIBUTING.md) guide?
- [x] Have you checked to ensure there aren't other open [Pull Requests](https://github.com/shapeshift/web/pulls) for the same update/change?

## Pull Request Type

- [ ] :bug: Bug fix (Non-breaking Change: Fixes an issue)
- [ ] :hammer_and_wrench: Chore (Non-breaking Change: Doc updates, pkg upgrades, typos, etc..)
- [x] :nail_care: New Feature (Breaking/Non-breaking Change)

## Issue (if applicable)

n/a

## Risk

no risk

## Testing

n/a

### Engineering

n/a

### Operations

On the top right buy/sell button you should see it shine.

## Screenshots (if applicable)
![Screen Shot 2022-09-26 at 11 59 01 PM](https://user-images.githubusercontent.com/89934888/192435807-84eeeb4f-a896-4ec4-bdd7-e9fe4cb2f9a7.png)
