### PR TITLE
fix: get the correct `feeAssetId` in `setTradeAmountsRefetchData`

### DIFF
--- a/src/components/Trade/hooks/useSwapper/utils.ts
+++ b/src/components/Trade/hooks/useSwapper/utils.ts
@@ -164,7 +164,7 @@ export const getFormFees = ({
       return {
         fee,
         tradeFee: trade.feeData.tradeFee,
-        tradeFeeSource: trade.sources[0].name,
+        tradeFeeSource,
       }
     }
     case CHAIN_NAMESPACE.Utxo: {

--- a/src/components/Trade/hooks/useTradeAmounts.tsx
+++ b/src/components/Trade/hooks/useTradeAmounts.tsx
@@ -141,11 +141,11 @@ export const useTradeAmounts = () => {
       const amountToUse = amount ?? amountFormState
       const actionToUse = action ?? actionFormState ?? TradeAmountInputField.SELL_CRYPTO
       if (!buyAssetIdToUse || !sellAssetIdToUse || !wallet) return
+      const sellAsset = assets[sellAssetIdToUse]
       const buyAsset = assets[buyAssetIdToUse]
-      const feeAssetId = getChainAdapterManager().get(buyAsset.chainId)?.getFeeAssetId()
+      const feeAssetId = getChainAdapterManager().get(sellAsset.chainId)?.getFeeAssetId()
       if (!feeAssetId) return
       const feeAsset = assets[feeAssetId]
-      const sellAsset = assets[sellAssetIdToUse]
       const receiveAddress = await getReceiveAddressFromBuyAsset(buyAsset)
       if (!receiveAddress) return
 


### PR DESCRIPTION
## Description

Fixes a bug in `setTradeAmountsRefetchData` where we'd get the fee asset of the _buy_ trade asset instead of the _sell_ trade asset.

This was causing gas display issues when trading to assets on different chains.

## Notice

- [x] Have you followed the guidelines in our [Contributing]('https://github.com/shapeshift/web/blob/develop/CONTRIBUTING.md) guide?
- [x] Have you checked to ensure there aren't other open [Pull Requests](https://github.com/shapeshift/web/pulls) for the same update/change?

## Pull Request Type

- [x] :bug: Bug fix (Non-breaking Change: Fixes an issue)
- [ ] :hammer_and_wrench: Chore (Non-breaking Change: Doc updates, pkg upgrades, typos, etc..)
- [ ] :nail_care: New Feature (Breaking/Non-breaking Change)

## Issue (if applicable)

Closes https://github.com/shapeshift/web/issues/2875

## Risk

Small - only touches the fee asset in one path of the trade amounts computation.

## Testing

Get a quote a Cosmos-SDK asset as the sell asset, and an ERC20 asset as the buy asset.
The gas fee should be sane.

### Engineering

As above.

### Operations

As above.

## Screenshots (if applicable)

<img width="398" alt="Screen Shot 2022-09-27 at 4 01 27 pm" src="https://user-images.githubusercontent.com/97164662/192445248-871ef29d-52b4-4e28-afef-26a4e7342974.png">
