### PR TITLE
fix: wallet switching doesn't always turn off demo mode

### DIFF
--- a/src/context/WalletProvider/KeepKey/components/Connect.tsx
+++ b/src/context/WalletProvider/KeepKey/components/Connect.tsx
@@ -90,7 +90,6 @@ export const KeepKeyConnect = () => {
           type: WalletActions.SET_WALLET,
           payload: { wallet, name: label, icon, deviceId, meta: { label } },
         })
-        dispatch({ type: WalletActions.SET_IS_DEMO_WALLET, payload: false })
         dispatch({ type: WalletActions.SET_IS_CONNECTED, payload: true })
         /**
          * The real deviceId of KeepKey wallet could be different from the

--- a/src/context/WalletProvider/KeepKey/hooks/useKeepKeyEventHandler.ts
+++ b/src/context/WalletProvider/KeepKey/hooks/useKeepKeyEventHandler.ts
@@ -242,7 +242,6 @@ export const useKeepKeyEventHandler = (
               icon: state.walletInfo.icon, // We're reconnecting the same wallet so we can reuse the walletInfo
             },
           })
-          dispatch({ type: WalletActions.SET_IS_DEMO_WALLET, payload: false })
           dispatch({ type: WalletActions.SET_IS_CONNECTED, payload: true })
         }
       } catch (e) {

--- a/src/context/WalletProvider/Keplr/components/Connect.tsx
+++ b/src/context/WalletProvider/Keplr/components/Connect.tsx
@@ -52,7 +52,6 @@ export const KeplrConnect = ({ history }: KeplrSetupProps) => {
           type: WalletActions.SET_WALLET,
           payload: { wallet, name, icon, deviceId },
         })
-        dispatch({ type: WalletActions.SET_IS_DEMO_WALLET, payload: false })
         dispatch({ type: WalletActions.SET_IS_CONNECTED, payload: true })
         setLocalWalletTypeAndDeviceId(KeyManager.Keplr, deviceId)
         dispatch({ type: WalletActions.SET_WALLET_MODAL, payload: false })

--- a/src/context/WalletProvider/MetaMask/components/Connect.tsx
+++ b/src/context/WalletProvider/MetaMask/components/Connect.tsx
@@ -70,7 +70,6 @@ export const MetaMaskConnect = ({ history }: MetaMaskSetupProps) => {
           type: WalletActions.SET_WALLET,
           payload: { wallet, name, icon, deviceId },
         })
-        dispatch({ type: WalletActions.SET_IS_DEMO_WALLET, payload: false })
         dispatch({ type: WalletActions.SET_IS_CONNECTED, payload: true })
         dispatch({ type: WalletActions.SET_IS_LOCKED, payload: isLocked })
         setLocalWalletTypeAndDeviceId(KeyManager.MetaMask, deviceId)

--- a/src/context/WalletProvider/NativeWallet/components/EnterPassword.tsx
+++ b/src/context/WalletProvider/NativeWallet/components/EnterPassword.tsx
@@ -64,7 +64,6 @@ export const EnterPassword = () => {
           meta: { label: vault.meta.get('name') as string },
         },
       })
-      dispatch({ type: WalletActions.SET_IS_DEMO_WALLET, payload: false })
       dispatch({ type: WalletActions.SET_IS_CONNECTED, payload: true })
       dispatch({ type: WalletActions.SET_LOCAL_WALLET_LOADING, payload: false })
       dispatch({ type: WalletActions.SET_WALLET_MODAL, payload: false })

--- a/src/context/WalletProvider/NativeWallet/components/NativeLoad.tsx
+++ b/src/context/WalletProvider/NativeWallet/components/NativeLoad.tsx
@@ -87,7 +87,6 @@ export const NativeLoad = ({ history }: RouteComponentProps) => {
             type: WalletActions.SET_WALLET,
             payload: { wallet, name, icon, deviceId, meta: { label: item.name } },
           })
-          dispatch({ type: WalletActions.SET_IS_DEMO_WALLET, payload: false })
           dispatch({ type: WalletActions.SET_IS_CONNECTED, payload: true })
           // The wallet is already initialized so we can close the modal
           dispatch({ type: WalletActions.SET_WALLET_MODAL, payload: false })

--- a/src/context/WalletProvider/NativeWallet/hooks/useNativeSuccess.ts
+++ b/src/context/WalletProvider/NativeWallet/hooks/useNativeSuccess.ts
@@ -47,7 +47,6 @@ export const useNativeSuccess = ({ vault }: UseNativeSuccessPropTypes) => {
             meta: { label: walletLabel },
           },
         })
-        dispatch({ type: WalletActions.SET_IS_DEMO_WALLET, payload: false })
         dispatch({ type: WalletActions.SET_IS_CONNECTED, payload: true })
         dispatch({ type: WalletActions.SET_WALLET_MODAL, payload: false })
         setLocalWalletTypeAndDeviceId(KeyManager.Native, deviceId)

--- a/src/context/WalletProvider/Portis/components/Connect.tsx
+++ b/src/context/WalletProvider/Portis/components/Connect.tsx
@@ -45,7 +45,6 @@ export const PortisConnect = ({ history }: PortisSetupProps) => {
           type: WalletActions.SET_WALLET,
           payload: { wallet, name, icon, deviceId: 'test' },
         })
-        dispatch({ type: WalletActions.SET_IS_DEMO_WALLET, payload: false })
         dispatch({ type: WalletActions.SET_IS_CONNECTED, payload: true })
         setLocalWalletTypeAndDeviceId(KeyManager.Portis, 'test')
         dispatch({ type: WalletActions.SET_WALLET_MODAL, payload: false })

--- a/src/context/WalletProvider/TallyHo/components/Connect.tsx
+++ b/src/context/WalletProvider/TallyHo/components/Connect.tsx
@@ -78,7 +78,6 @@ export const TallyHoConnect = ({ history }: TallyHoSetupProps) => {
           type: WalletActions.SET_WALLET,
           payload: { wallet, name, icon, deviceId },
         })
-        dispatch({ type: WalletActions.SET_IS_DEMO_WALLET, payload: false })
         dispatch({ type: WalletActions.SET_IS_CONNECTED, payload: true })
         setLocalWalletTypeAndDeviceId(KeyManager.TallyHo, deviceId)
         dispatch({ type: WalletActions.SET_WALLET_MODAL, payload: false })

--- a/src/context/WalletProvider/WalletConnect/components/Connect.tsx
+++ b/src/context/WalletProvider/WalletConnect/components/Connect.tsx
@@ -79,7 +79,6 @@ export const WalletConnectConnect = ({ history }: WalletConnectSetupProps) => {
           type: WalletActions.SET_WALLET,
           payload: { wallet, name, icon, deviceId },
         })
-        dispatch({ type: WalletActions.SET_IS_DEMO_WALLET, payload: false })
         dispatch({ type: WalletActions.SET_IS_CONNECTED, payload: true })
         setLocalWalletTypeAndDeviceId(KeyManager.WalletConnect, deviceId)
         dispatch({ type: WalletActions.SET_WALLET_MODAL, payload: false })

--- a/src/context/WalletProvider/WalletProvider.tsx
+++ b/src/context/WalletProvider/WalletProvider.tsx
@@ -152,6 +152,7 @@ const reducer = (state: InitialState, action: ActionTypes) => {
     case WalletActions.SET_WALLET:
       return {
         ...state,
+        isDemoWallet: Boolean(action.payload.isDemoWallet),
         wallet: action.payload.wallet,
         walletInfo: {
           name: action?.payload?.name,
@@ -163,8 +164,6 @@ const reducer = (state: InitialState, action: ActionTypes) => {
           },
         },
       }
-    case WalletActions.SET_IS_DEMO_WALLET:
-      return { ...state, isDemoWallet: action.payload }
     case WalletActions.SET_PROVIDER:
       return { ...state, provider: action.payload }
     case WalletActions.SET_IS_CONNECTED:
@@ -786,6 +785,7 @@ export const WalletProvider = ({ children }: { children: React.ReactNode }): JSX
     dispatch({
       type: WalletActions.SET_WALLET,
       payload: {
+        isDemoWallet: true,
         wallet,
         name,
         icon,
@@ -795,7 +795,6 @@ export const WalletProvider = ({ children }: { children: React.ReactNode }): JSX
     })
     dispatch({ type: WalletActions.SET_IS_CONNECTED, payload: false })
     dispatch({ type: WalletActions.SET_LOCAL_WALLET_LOADING, payload: false })
-    dispatch({ type: WalletActions.SET_IS_DEMO_WALLET, payload: true })
   }, [state.keyring])
 
   const create = useCallback(async (type: KeyManager) => {

--- a/src/context/WalletProvider/XDEFI/components/Connect.tsx
+++ b/src/context/WalletProvider/XDEFI/components/Connect.tsx
@@ -64,7 +64,6 @@ export const XDEFIConnect = ({ history }: XDEFISetupProps) => {
           type: WalletActions.SET_WALLET,
           payload: { wallet, name, icon, deviceId },
         })
-        dispatch({ type: WalletActions.SET_IS_DEMO_WALLET, payload: false })
         dispatch({ type: WalletActions.SET_IS_CONNECTED, payload: true })
         setLocalWalletTypeAndDeviceId(KeyManager.XDefi, deviceId)
         dispatch({ type: WalletActions.SET_WALLET_MODAL, payload: false })

--- a/src/context/WalletProvider/actions.ts
+++ b/src/context/WalletProvider/actions.ts
@@ -11,7 +11,6 @@ export enum WalletActions {
   SET_CONNECTOR_TYPE = 'SET_CONNECTOR_TYPE',
   SET_INITIAL_ROUTE = 'SET_INITIAL_ROUTE',
   SET_IS_CONNECTED = 'SET_IS_CONNECTED',
-  SET_IS_DEMO_WALLET = 'SET_IS_DEMO_WALLET',
   SET_PROVIDER = 'SET_PROVIDER',
   SET_IS_LOCKED = 'SET_IS_LOCKED',
   SET_WALLET_MODAL = 'SET_WALLET_MODAL',
@@ -33,10 +32,9 @@ export type ActionTypes =
   | { type: WalletActions.SET_ADAPTERS; payload: Adapters }
   | {
       type: WalletActions.SET_WALLET
-      payload: WalletInfo & { wallet: HDWallet | null }
+      payload: WalletInfo & { isDemoWallet?: boolean; wallet: HDWallet | null }
     }
   | { type: WalletActions.SET_IS_CONNECTED; payload: boolean }
-  | { type: WalletActions.SET_IS_DEMO_WALLET; payload: boolean }
   | { type: WalletActions.SET_PROVIDER; payload: InitialState['provider'] }
   | { type: WalletActions.SET_IS_LOCKED; payload: boolean }
   | { type: WalletActions.SET_CONNECTOR_TYPE; payload: KeyManager }


### PR DESCRIPTION
## Description

Remove `SET_IS_DEMO_WALLET`. Change `SET_WALLET` to set the `isDemoWallet` state.

The only place that `SET_IS_DEMO_WALLET` was called was immediately after a `SET_WALLET` call, so I don't see any reason why it should be a separate action.

Changing `SET_WALLET` ensures that we don't have this bug in the future by forgetting to call `SET_IS_DEMO_WALLET` for a new wallet pairing flow.

## Notice

<!-- Before submitting a pull request, please make sure you have answered the following: -->

- [X] Have you followed the guidelines in our [Contributing]('https://github.com/shapeshift/web/blob/develop/CONTRIBUTING.md) guide?
- [X] Have you checked to ensure there aren't other open [Pull Requests](https://github.com/shapeshift/web/pulls) for the same update/change?

## Pull Request Type

- [X] :bug: Bug fix (Non-breaking Change: Fixes an issue)
- [ ] :hammer_and_wrench: Chore (Non-breaking Change: Doc updates, pkg upgrades, typos, etc..)
- [ ] :nail_care: New Feature (Breaking/Non-breaking Change)

## Issue (if applicable)

<!-----------------------------------------------------------------------------
If applicable, please link to the github issue and put `closes #XXXX` in your comment to auto-close the issue that your PR fixes.
------------------------------------------------------------------------------>

closes https://github.com/shapeshift/mobile-app/issues/68

## Risk
Low - only affects wallet pairing
## Testing
1. Pair the demo wallet
2. Switch wallets
3. Switch back to demo

### Engineering

### Operations
Test web wallet pairing for regressions. Test mobile wallet pairing.

## Screenshots (if applicable)
