### PR TITLE
feat: rune swapping confirmed state

### DIFF
--- a/src/components/Trade/TradeConfirm/TradeConfirm.tsx
+++ b/src/components/Trade/TradeConfirm/TradeConfirm.tsx
@@ -13,7 +13,7 @@ import {
   StackDivider,
   useColorModeValue,
 } from '@chakra-ui/react'
-import { osmosisAssetId } from '@shapeshiftoss/caip'
+import { fromAccountId, osmosisAssetId, thorchainAssetId } from '@shapeshiftoss/caip'
 import { type TradeTxs, isCowTrade } from '@shapeshiftoss/swapper'
 import { TxStatus } from '@shapeshiftoss/unchained-client'
 import { useMemo, useState } from 'react'
@@ -71,9 +71,16 @@ export const TradeConfirm = ({ history }: RouterProps) => {
     buyAssetFiatRate,
     slippage,
     buyAssetAccountId,
+    sellAssetAccountId,
   }: Pick<
     TS,
-    'buyAssetAccountId' | 'trade' | 'fees' | 'sellAssetFiatRate' | 'buyAssetFiatRate' | 'slippage'
+    | 'sellAssetAccountId'
+    | 'buyAssetAccountId'
+    | 'trade'
+    | 'fees'
+    | 'sellAssetFiatRate'
+    | 'buyAssetFiatRate'
+    | 'slippage'
   > = getValues()
   const { executeQuote, reset, getTradeTxs } = useSwapper()
   const location = useLocation<TradeConfirmParams>()
@@ -91,10 +98,24 @@ export const TradeConfirm = ({ history }: RouterProps) => {
     selectFeeAssetByChainId(state, trade?.sellAsset?.chainId ?? ''),
   )
 
-  const parsedBuyTxId = useMemo(
-    () => serializeTxIndex(buyAssetAccountId ?? '', buyTxid, trade?.receiveAddress ?? ''),
-    [buyAssetAccountId, trade?.receiveAddress, buyTxid],
-  )
+  const parsedBuyTxId = useMemo(() => {
+    const isThorTrade = [trade?.sellAsset.assetId, trade?.buyAsset.assetId].includes(
+      thorchainAssetId,
+    )
+    const buyAccountId = isThorTrade ? sellAssetAccountId : buyAssetAccountId
+    const receiveAddress = isThorTrade
+      ? fromAccountId(sellAssetAccountId!).account
+      : trade?.receiveAddress
+    const txId = isThorTrade ? buyTxid.toUpperCase() : buyTxid // Midgard monkey patch Txid is lowercase, but we store Cosmos SDK Txs uppercase
+    return serializeTxIndex(buyAccountId!, txId, receiveAddress ?? '')
+  }, [
+    sellAssetAccountId,
+    trade?.buyAsset.assetId,
+    trade?.sellAsset.assetId,
+    buyAssetAccountId,
+    trade?.receiveAddress,
+    buyTxid,
+  ])
 
   const status =
     useAppSelector(state => selectTxStatusById(state, parsedBuyTxId)) ?? TxStatus.Pending

--- a/src/components/Trade/hooks/useTradeAmounts.tsx
+++ b/src/components/Trade/hooks/useTradeAmounts.tsx
@@ -172,11 +172,13 @@ export const useTradeAmounts = () => {
         sellAccountFilter,
       )
 
+      if (!sellAccountMetadata) return // no-op, need at least bip44Params to get tradequoteArgs
+
       const tradeQuoteArgs = await getTradeQuoteArgs({
         buyAsset,
         sellAsset,
-        sellAccountType: sellAccountMetadata?.accountType,
-        sellAccountBip44Params: sellAccountMetadata?.bip44Params,
+        sellAccountType: sellAccountMetadata.accountType,
+        sellAccountBip44Params: sellAccountMetadata.bip44Params,
         wallet,
         receiveAddress,
         sellAmount: sellTradeAsset?.amount || amountToUse || '0',

--- a/src/components/Trade/hooks/useTradeAmounts.tsx
+++ b/src/components/Trade/hooks/useTradeAmounts.tsx
@@ -172,7 +172,7 @@ export const useTradeAmounts = () => {
         sellAccountFilter,
       )
 
-      if (!sellAccountMetadata) return // no-op, need at least bip44Params to get tradequoteArgs
+      if (!sellAccountMetadata) return // no-op, need at least bip44Params to get tradeQuoteArgs
 
       const tradeQuoteArgs = await getTradeQuoteArgs({
         buyAsset,

--- a/src/components/Trade/hooks/useTradeAmounts.tsx
+++ b/src/components/Trade/hooks/useTradeAmounts.tsx
@@ -175,8 +175,8 @@ export const useTradeAmounts = () => {
       const tradeQuoteArgs = await getTradeQuoteArgs({
         buyAsset,
         sellAsset,
-        sellAccountType: sellAccountMetadata.accountType,
-        sellAccountBip44Params: sellAccountMetadata.bip44Params,
+        sellAccountType: sellAccountMetadata?.accountType,
+        sellAccountBip44Params: sellAccountMetadata?.bip44Params,
         wallet,
         receiveAddress,
         sellAmount: sellTradeAsset?.amount || amountToUse || '0',


### PR DESCRIPTION
## Description

This PR fixes the confirmed state for RUNE swapping, using the sell Txid / account data as a buy Txid, so we can react on it to display Tx confirmed state.

## Notice

<!-- Before submitting a pull request, please make sure you have answered the following: -->

- [x] Have you followed the guidelines in our [Contributing]('https://github.com/shapeshift/web/blob/develop/CONTRIBUTING.md) guide?
- [x] Have you checked to ensure there aren't other open [Pull Requests](https://github.com/shapeshift/web/pulls) for the same update/change?

## Pull Request Type

- [ ] :bug: Bug fix (Non-breaking Change: Fixes an issue)
- [ ] :hammer_and_wrench: Chore (Non-breaking Change: Doc updates, pkg upgrades, typos, etc..)
- [x] :nail_care: New Feature (Breaking/Non-breaking Change)

## Issue (if applicable)

<!-----------------------------------------------------------------------------
If applicable, please link to the github issue and put `closes #XXXX` in your comment to auto-close the issue that your PR fixes.
------------------------------------------------------------------------------>

closes https://github.com/shapeshift/web/issues/2892

## Risk

Thor detection logic could be borked and erroneously use the sell side data to serialize the buy Txid for swaps other than RUNE.

<!-----------------------------------------------------------------------------
Outline the scope of your changes and the risk associated with them. You must use your discretion as an engineer to determine the potential impact of your changes.

E.g. an upgrade to `hdwallet` or core state management would be considered higher risk, and might require a full regression test. UI or isolated view changes, or something behind a feature flag may have near zero risk. Small bug fixes might require testing isolated to the specific fix.
------------------------------------------------------------------------------>

## Testing

- Swaps from RUNE are shown as completed after on-chain completion
- Swaps to RUNE are shown as completed after on-chain completion

<!-----------------------------------------------------------------------------
We treat every PR to be merged with the same scrutiny as if we were merging directly to production.

Your PR will not be merged if you do not complete the sections below for our engineering and operations teams to test.
------------------------------------------------------------------------------>

### Engineering

- Refer to top-level steps
- Thor detection logic looks sane
<!-----------------------------------------------------------------------------
Include sufficient information here for an engineer to test your PR. This may include how to test locally, in a built environment, changes to infrastructure etc.
------------------------------------------------------------------------------>

### Operations

- Refer to top-level steps
- No swapper regressions are spotted for other Thor swaps

<!-----------------------------------------------------------------------------
If your changes have a user-facing impact, describe how a non-technical QA team can functionally test your changes in a preview environment.

If they are not user-facing please describe how to test for any regressions that may occur.
------------------------------------------------------------------------------>

## Screenshots (if applicable)

<img width="1046" alt="image" src="https://user-images.githubusercontent.com/17035424/192649281-128ff874-56d3-4721-a691-6c7bedfd064d.png">
<img width="1032" alt="image" src="https://user-images.githubusercontent.com/17035424/192649587-d84bab69-c5d9-4c46-bf6f-2bcdf03fe3bf.png">