### PR TITLE
fix: default assets using `bip44Params`

### DIFF
--- a/src/components/Trade/TradeRoutes/TradeRoutes.tsx
+++ b/src/components/Trade/TradeRoutes/TradeRoutes.tsx
@@ -1,10 +1,11 @@
 import type { Asset } from '@shapeshiftoss/asset-service'
 import type { AssetId } from '@shapeshiftoss/caip'
 import { AnimatePresence } from 'framer-motion'
+import { useEffect } from 'react'
 import type { RouteComponentProps } from 'react-router-dom'
 import { Redirect, Route, Switch, useLocation } from 'react-router-dom'
 import { Approval } from 'components/Approval/Approval'
-import { useDefaultAssetsService } from 'components/Trade/hooks/useDefaultAssetsService'
+import { useDefaultAssets } from 'components/Trade/hooks/useDefaultAssets'
 import { SelectAccount } from 'components/Trade/SelectAccount'
 import { useFeatureFlag } from 'hooks/useFeatureFlag/useFeatureFlag'
 
@@ -23,10 +24,16 @@ type TradeRoutesProps = {
 }
 
 export const TradeRoutes = ({ defaultBuyAssetId }: TradeRoutesProps) => {
-  useDefaultAssetsService(defaultBuyAssetId)
+  const { setDefaultAssets } = useDefaultAssets(defaultBuyAssetId)
   const { getSupportedSellableAssets, getSupportedBuyAssetsFromSellAsset } = useSwapper()
   const location = useLocation()
   const { handleAssetClick } = useTradeRoutes()
+
+  useEffect(() => {
+    ;(async () => {
+      await setDefaultAssets()
+    })()
+  }, [setDefaultAssets])
 
   const isSwapperV2 = useFeatureFlag('SwapperV2')
   const TradeInputComponent = isSwapperV2 ? TradeInputV2 : TradeInputV1

--- a/src/components/Trade/hooks/useTradeQuoteService.tsx
+++ b/src/components/Trade/hooks/useTradeQuoteService.tsx
@@ -7,7 +7,6 @@ import { type GetTradeQuoteInput, type UtxoSupportedChainIds } from '@shapeshift
 import type { BIP44Params, UtxoAccountType } from '@shapeshiftoss/types'
 import { useEffect, useState } from 'react'
 import { useFormContext, useWatch } from 'react-hook-form'
-import { useSelector } from 'react-redux'
 import { useSwapper } from 'components/Trade/hooks/useSwapper/useSwapperV2'
 import {
   isSupportedNonUtxoSwappingChain,
@@ -20,7 +19,6 @@ import { useWallet } from 'hooks/useWallet/useWallet'
 import { toBaseUnit } from 'lib/math'
 import { useGetTradeQuoteQuery } from 'state/apis/swapper/swapperApi'
 import {
-  selectAccountSpecifiers,
   selectFiatToUsdRate,
   selectPortfolioAccountIdsByAssetId,
   selectPortfolioAccountMetadataByAccountId,
@@ -110,7 +108,6 @@ export const useTradeQuoteService = () => {
 
   // Selectors
   const selectedCurrencyToUsdRate = useAppSelector(selectFiatToUsdRate)
-  const accountSpecifiersList = useSelector(selectAccountSpecifiers)
 
   const sellAssetAccountIds = useAppSelector(state =>
     selectPortfolioAccountIdsByAssetId(state, {
@@ -153,7 +150,6 @@ export const useTradeQuoteService = () => {
       })()
     }
   }, [
-    accountSpecifiersList,
     action,
     amount,
     buyAsset,

--- a/src/components/Trade/types.ts
+++ b/src/components/Trade/types.ts
@@ -1,7 +1,6 @@
 import { type Asset } from '@shapeshiftoss/asset-service'
 import type { AssetId } from '@shapeshiftoss/caip'
 import { type ChainId } from '@shapeshiftoss/caip'
-import { type ChainAdapter } from '@shapeshiftoss/chain-adapters'
 import { type HDWallet } from '@shapeshiftoss/hdwallet-core'
 import {
   type BuildTradeInput,
@@ -12,7 +11,6 @@ import {
   type TradeQuote,
 } from '@shapeshiftoss/swapper'
 import type { BIP44Params, KnownChainIds, UtxoAccountType } from '@shapeshiftoss/types'
-import type { selectAccountSpecifiers } from 'state/slices/accountSpecifiersSlice/selectors'
 import { type AccountSpecifier } from 'state/slices/portfolioSlice/portfolioSliceCommon'
 
 export enum TradeAmountInputField {
@@ -71,24 +69,12 @@ export type SupportedSwappingChain =
   | KnownChainIds.OsmosisMainnet
   | KnownChainIds.CosmosMainnet
 
-type GetFirstReceiveAddressArgs = {
-  accountSpecifiersList: ReturnType<typeof selectAccountSpecifiers>
-  buyAsset: Asset
-  chainAdapter: ChainAdapter<ChainId>
-  wallet: HDWallet
+export type GetReceiveAddressArgs = {
+  asset: Asset
+  wallet: HDWallet | null
   bip44Params: BIP44Params
-  accountType: UtxoAccountType | undefined
+  accountType?: UtxoAccountType
 }
-
-type GetSelectedReceiveAddressArgs = {
-  chainAdapter: ChainAdapter<ChainId>
-  wallet: HDWallet
-  bip44Params: BIP44Params
-  accountType: UtxoAccountType | undefined
-}
-
-export type GetFirstReceiveAddress = (args: GetFirstReceiveAddressArgs) => Promise<string>
-export type GetSelectedReceiveAddress = (args: GetSelectedReceiveAddressArgs) => Promise<string>
 
 export type TradeQuoteInputCommonArgs = Pick<
   GetTradeQuoteInput,


### PR DESCRIPTION
## Description

Default assets broke when implementing `bip44Params` in https://github.com/shapeshift/web/pull/2877.

This PR fixes default assets and refactors the default asset logic into an explicit callback to give us better control over when it's called.

## Notice

- [x] Have you followed the guidelines in our [Contributing]('https://github.com/shapeshift/web/blob/develop/CONTRIBUTING.md) guide?
- [x] Have you checked to ensure there aren't other open [Pull Requests](https://github.com/shapeshift/web/pulls) for the same update/change?

## Pull Request Type

- [x] :bug: Bug fix (Non-breaking Change: Fixes an issue)
- [ ] :hammer_and_wrench: Chore (Non-breaking Change: Doc updates, pkg upgrades, typos, etc..)
- [ ] :nail_care: New Feature (Breaking/Non-breaking Change)

## Issue (if applicable)

N/A

## Risk

Small-medium. Touches default asset and account logic.

## Testing

Default assets should populate properly again based on the wallet connected, and the current route.

Check ERC20, Avalanche, and UTXO assets across multiple wallets.

### Engineering

As above.

### Operations

As above.

## Screenshots (if applicable)

N/A