### PR TITLE
fix: default pair refresh when navigating between native EVM asset pages

### DIFF
--- a/src/components/Trade/hooks/useDefaultAssets.tsx
+++ b/src/components/Trade/hooks/useDefaultAssets.tsx
@@ -75,11 +75,19 @@ export const useDefaultAssets = (routeBuyAssetId?: AssetId) => {
 
     return defaultAssetIdPair?.buyAssetId
   }, [defaultAssetIdPair, routeBuyAssetId])
+  const buyChainId = useMemo(
+    () => (buyAssetId ? fromAssetId(buyAssetId).chainId : null),
+    [buyAssetId],
+  )
 
   const previousBuyAssetId = usePrevious(buyAssetId)
+  const previousBuyChainId = useMemo(
+    () => (previousBuyAssetId ? fromAssetId(previousBuyAssetId).chainId : null),
+    [previousBuyAssetId],
+  )
 
   const setDefaultAssets = useCallback(async () => {
-    if (buyAssetId !== previousBuyAssetId) return
+    if (buyChainId !== previousBuyChainId) return
 
     const maybeBuyAssetChainId = routeBuyAssetId
       ? fromAssetId(routeBuyAssetId).chainId
@@ -141,6 +149,7 @@ export const useDefaultAssets = (routeBuyAssetId?: AssetId) => {
     }
   }, [
     assets,
+    buyChainId,
     buyAssetId,
     dispatch,
     featureFlags,
@@ -148,7 +157,7 @@ export const useDefaultAssets = (routeBuyAssetId?: AssetId) => {
     maybeWalletChainId,
     portfolioAccountIds,
     portfolioAccountMetaData,
-    previousBuyAssetId,
+    previousBuyChainId,
     routeBuyAssetId,
     setValue,
     wallet,


### PR DESCRIPTION
## Description

This PR fixes the routing between the asset pages of native EVM assets, where the default trading pairs do not get properly refreshed.

## Notice

<!-- Before submitting a pull request, please make sure you have answered the following: -->

- [x] Have you followed the guidelines in our [Contributing]('https://github.com/shapeshift/web/blob/develop/CONTRIBUTING.md) guide?
- [x] Have you checked to ensure there aren't other open [Pull Requests](https://github.com/shapeshift/web/pulls) for the same update/change?

## Pull Request Type

- [x] :bug: Bug fix (Non-breaking Change: Fixes an issue)
- [ ] :hammer_and_wrench: Chore (Non-breaking Change: Doc updates, pkg upgrades, typos, etc..)
- [ ] :nail_care: New Feature (Breaking/Non-breaking Change)

## Issue (if applicable)

<!-----------------------------------------------------------------------------
If applicable, please link to the github issue and put `closes #XXXX` in your comment to auto-close the issue that your PR fixes.
------------------------------------------------------------------------------>

closes https://github.com/shapeshift/web/issues/2897

## Risk

Tested UTXOs and Cosmos SDK default pairs on native wallet as a regression test and EVM default pairs on asset page navigation which all show no regressions, but this could technically break all default pairs, test accordingly.

<!-----------------------------------------------------------------------------
Outline the scope of your changes and the risk associated with them. You must use your discretion as an engineer to determine the potential impact of your changes.

E.g. an upgrade to `hdwallet` or core state management would be considered higher risk, and might require a full regression test. UI or isolated view changes, or something behind a feature flag may have near zero risk. Small bug fixes might require testing isolated to the specific fix.
------------------------------------------------------------------------------>

## Testing

- When navigating to AVAX or ETH asset from any page (e.g Dashboard), the default pair for that asset is displayed
- When navigating AVAX<->ETH (both directions) asset pages using asset search, the default pair for that asset is displayed
- Navigating from any asset (native / non-native) to any other asset (it can be on the same or on a different chain) page displays the correct default pair
- No default pair regressions are found

<!-----------------------------------------------------------------------------
We treat every PR to be merged with the same scrutiny as if we were merging directly to production.

Your PR will not be merged if you do not complete the sections below for our engineering and operations teams to test.
------------------------------------------------------------------------------>

### Engineering

- Logic looks sound and reactive
- Refer to top-level steps

<!-----------------------------------------------------------------------------
Include sufficient information here for an engineer to test your PR. This may include how to test locally, in a built environment, changes to infrastructure etc.
------------------------------------------------------------------------------>

### Operations

- Refer to top-level steps

<!-----------------------------------------------------------------------------
If your changes have a user-facing impact, describe how a non-technical QA team can functionally test your changes in a preview environment.

If they are not user-facing please describe how to test for any regressions that may occur.
------------------------------------------------------------------------------>

## Screenshots (if applicable)

https://user-images.githubusercontent.com/17035424/192764849-deb44da0-42ae-4115-b044-7d40b2333842.mov


