### PR TITLE
feat: unstoppable domains reverse resolution

### DIFF
--- a/package.json
+++ b/package.json
@@ -110,7 +110,7 @@
     "@shapeshiftoss/types": "^8.3.1",
     "@shapeshiftoss/unchained-client": "^10.1.2",
     "@uniswap/sdk": "^3.0.3",
-    "@unstoppabledomains/resolution": "^7.1.4",
+    "@unstoppabledomains/resolution": "^8.3.3",
     "@visx/axis": "^2.10.0",
     "@visx/brush": "^2.10.1",
     "@visx/gradient": "^2.10.0",

--- a/react-app-rewired/headers/csps/chains/unstoppable.ts
+++ b/react-app-rewired/headers/csps/chains/unstoppable.ts
@@ -1,0 +1,5 @@
+import type { Csp } from "../../types";
+
+export const csp: Csp = {
+  "connect-src": ["https://metadata.unstoppabledomains.com"],
+};

--- a/src/lib/address/unstoppable-domains.ts
+++ b/src/lib/address/unstoppable-domains.ts
@@ -13,7 +13,7 @@ const moduleLogger = logger.child({ namespace: ['unstoppable-domains'] })
 let _resolution: Resolution | undefined
 
 const getResolution = (): Resolution => {
-  const infuraProviderUrl = getConfig().REACT_APP_ETHEREUM_INFURA_URL
+  const infuraProviderUrl = getConfig().REACT_APP_ETHEREUM_NODE_URL
 
   const polygonProviderUrl = getConfig().REACT_APP_ALCHEMY_POLYGON_URL
   if (!polygonProviderUrl)
@@ -69,7 +69,7 @@ export const resolveUnstoppableDomain: ResolveVanityAddress = async args => {
 
 // reverse lookup
 export const reverseLookupUnstoppableDomain: ReverseLookupVanityAddress = async args => {
-  const { chainId } = args
+  const { chainId, value } = args
   const ticker = chainIdToUDTicker[chainId]
   if (!ticker) {
     moduleLogger.error({ chainId }, 'cannot resolve unstoppable domain: unsupported chainId')
@@ -77,11 +77,11 @@ export const reverseLookupUnstoppableDomain: ReverseLookupVanityAddress = async 
   }
   // TODO(0xdef1cafe): uncomment this once this is actually published - docs are wrong
   // https://unstoppabledomains.github.io/resolution/v7.0.0/classes/resolution.html#reverse
-  // try {
-  //   const result = await getResolution().reverse(value, ticker)
-  //   if (result) return result
-  // } catch (e) {
-  //   moduleLogger.trace(e, 'cannot resolve')
-  // }
+   try {
+     const result = await getResolution().reverse(value)
+     if (result) return result
+   } catch (e) {
+     moduleLogger.trace(e, 'cannot resolve')
+   }
   return ''
 }

--- a/yarn.lock
+++ b/yarn.lock
@@ -6462,17 +6462,16 @@
   resolved "https://registry.yarnpkg.com/@uniswap/v2-core/-/v2-core-1.0.1.tgz#af8f508bf183204779938969e2e54043e147d425"
   integrity sha512-MtybtkUPSyysqLY2U210NBDeCHX+ltHt3oADGdjqoThZaFRDKwM6k1Nb3F0A3hk5hwuQvytFWhrWHOEq6nVJ8Q==
 
-"@unstoppabledomains/resolution@^7.1.4":
-  version "7.1.4"
-  resolved "https://registry.yarnpkg.com/@unstoppabledomains/resolution/-/resolution-7.1.4.tgz#f3f0f9d2f36b88bf0a3af92c26731a01e5dba94b"
-  integrity sha512-GdXLpP+oRk4lLWMISo7g7gPyKoCONyLoQtYH6GVhXtyY9t+CeHJW2kZ/btcbXg0lmEO6PSr5yYOlDz4wRCq2RA==
+"@unstoppabledomains/resolution@^8.3.3":
+  version "8.3.3"
+  resolved "https://registry.yarnpkg.com/@unstoppabledomains/resolution/-/resolution-8.3.3.tgz#599c5e2f068a36e24bd19c0f9e2f753036264a3b"
+  integrity sha512-jQ9757Lvx/xqU7Lg7JT4L9WQZuElHkMiJmtph0e6TSwfguIlkv1i5UgzURgVXDvVizVKpDejGS60kuvICkz9ZQ==
   dependencies:
     "@ethersproject/abi" "^5.0.1"
     bn.js "^4.4.0"
     cross-fetch "^3.1.4"
+    crypto-js "^4.1.1"
     elliptic "^6.5.4"
-    js-sha256 "^0.9.0"
-    js-sha3 "^0.8.0"
 
 "@visx/annotation@2.12.2":
   version "2.12.2"
@@ -15151,11 +15150,6 @@ js-pixel-fonts@^1.5.0:
   dependencies:
     loglevel "^1.6.1"
     pngjs "^3.3.3"
-
-js-sha256@^0.9.0:
-  version "0.9.0"
-  resolved "https://registry.yarnpkg.com/js-sha256/-/js-sha256-0.9.0.tgz#0b89ac166583e91ef9123644bd3c5334ce9d0966"
-  integrity sha512-sga3MHh9sgQN2+pJ9VYZ+1LPwXOxuBJBA5nrR5/ofPfuiJBE2hnjsaN8se8JznOmGLN2p49Pe5U/ttafcs/apA==
 
 js-sha3@0.8.0, js-sha3@^0.8.0:
   version "0.8.0"


### PR DESCRIPTION
Unstoppable Domains Added Reverse Resolution

## Description

- Updated reverse resolution for Unstoppable Domains.
- Users when entering in their wallet address will see their UD domain (if configured) when they send currency.

## Notice

<!-- Before submitting a pull request, please make sure you have answered the following: -->

- [X] Have you followed the guidelines in our [Contributing]('https://github.com/shapeshift/web/blob/develop/CONTRIBUTING.md) guide?
- [X] Have you checked to ensure there aren't other open [Pull Requests](https://github.com/shapeshift/web/pulls) for the same update/change?

## Pull Request Type

- [ ] :bug: Bug fix (Non-breaking Change: Fixes an issue)
- [ ] :hammer_and_wrench: Chore (Non-breaking Change: Doc updates, pkg upgrades, typos, etc..)
- [X] :nail_care: New Feature (Breaking/Non-breaking Change)

## Issue (if applicable)

N/A

## Risk

- Low risk (update to unstoppable resolution integration):
- Updating reverse resolution function within unstoppable-domains.ts
- Updating to most recent version of unstoppable/resolution library
- Adding unstoppable.ts to react-app-rewired/headers/csps/chains

## Testing

- Reverse resolution: Tested in send option to resolve wallet address to nft domain.

### Engineering

- Steps to test Unstoppable’s reverse resolution:
- In a local env, start the server and bring up the local env in a browser.
- Assets > Ethereum > Send > Enter in wallet address: 0xA4918d1D83259B82587efB6526887ee00BA26aB1
- Enter amount
- See value in “Send To” resolve to “<unstoppable.nft>, ex tawnymslc.wallet. [See doc](https://docs.unstoppabledomains.com/reverse-resolution/config-guides/ud-dashboard/) on how user set their wallet to reverse to domain.

### Operations

Same steps as Engineering

## Screenshots
![Screen Shot 2022-09-29 at 11 23 35 AM](https://user-images.githubusercontent.com/108841343/193134401-b1a8f50c-e843-4756-a65f-d9138e17e5ed.png)

![Screen Shot 2022-09-29 at 11 23 47 AM](https://user-images.githubusercontent.com/108841343/193134461-22e19fa1-6f7d-40ba-bebb-1ffc9b2343ef.png)



