### PR TITLE
fix: show recent txs instead of trades on trade page

### DIFF
--- a/src/pages/Trade/Trade.tsx
+++ b/src/pages/Trade/Trade.tsx
@@ -1,5 +1,4 @@
 import { Box, Center, Container, Heading, Stack, useColorModeValue } from '@chakra-ui/react'
-import { TradeType } from '@shapeshiftoss/unchained-client'
 import { useTranslate } from 'react-polyglot'
 import { Card } from 'components/Card/Card'
 import { Main } from 'components/Layout/Main'
@@ -25,9 +24,10 @@ export const Trade = () => {
   } = useWallet()
   const top = isDemoWallet ? '7rem' : '4.5rem'
   const borderColor = useColorModeValue('gray.100', 'gray.750')
+  const headerBg = useColorModeValue('gray.100', 'gray.800')
   const txIds = useAppSelector(state =>
     selectTxIdsBasedOnSearchTermAndFilters(state, {
-      types: [TradeType.Trade],
+      types: null,
       matchingAssets: null,
       fromDate: null,
       toDate: null,
@@ -86,9 +86,9 @@ export const Trade = () => {
           overflowY='auto'
         >
           <Card variant='unstyled' width='full'>
-            <Card.Header>
+            <Card.Header position='sticky' top={0} bg={headerBg} zIndex={2}>
               <Card.Heading>
-                <Text translation='trade.recentTrades' />
+                <Text translation='dashboard.recentTransactions.recentTransactions' />
               </Card.Heading>
             </Card.Header>
             <TransactionHistoryList txIds={txIds} useCompactMode={true} />


### PR DESCRIPTION
## Description

- Replace the filter and show all transactions

## Notice

<!-- Before submitting a pull request, please make sure you have answered the following: -->

- [x] Have you followed the guidelines in our [Contributing]('https://github.com/shapeshift/web/blob/develop/CONTRIBUTING.md) guide?
- [x] Have you checked to ensure there aren't other open [Pull Requests](https://github.com/shapeshift/web/pulls) for the same update/change?

## Pull Request Type

- [x] :bug: Bug fix (Non-breaking Change: Fixes an issue)
- [ ] :hammer_and_wrench: Chore (Non-breaking Change: Doc updates, pkg upgrades, typos, etc..)
- [ ] :nail_care: New Feature (Breaking/Non-breaking Change)

## Issue (if applicable)

n/a

## Risk

no risk

## Testing

### Engineering

Should just work

### Operations

Go to trade page, and you should see the list of your recent transactions and not just trades.

## Screenshots (if applicable)
![Screen Shot 2022-09-29 at 3 43 29 PM](https://user-images.githubusercontent.com/89934888/193138089-d6efc0ef-3de9-4c73-8911-68831fd7ec51.png)
