### PR TITLE
fix: gas fee base unit

### DIFF
--- a/src/components/Modals/Send/hooks/useSendDetails/useSendDetails.test.tsx
+++ b/src/components/Modals/Send/hooks/useSendDetails/useSendDetails.test.tsx
@@ -253,7 +253,10 @@ describe('useSendDetails', () => {
       expect(setValue).toHaveBeenNthCalledWith(1, 'amountFieldError', '')
       expect(setValue).toHaveBeenNthCalledWith(2, 'sendMax', true)
       expect(setValue).toHaveBeenNthCalledWith(3, 'estimatedFees', {
-        fast: { chainSpecific: { feePerTx: '6000000000000000' }, networkFee: '6000000000000000' },
+        fast: {
+          chainSpecific: { feePerTx: '6000000000000000' },
+          networkFee: '6000000000000000',
+        },
       })
       expect(setValue).toHaveBeenNthCalledWith(6, 'fiatAmount', '17500.00')
       expect(setValue).toHaveBeenNthCalledWith(5, 'cryptoAmount', '5')

--- a/src/components/Trade/TradeConfirm/TradeConfirm.tsx
+++ b/src/components/Trade/TradeConfirm/TradeConfirm.tsx
@@ -204,7 +204,9 @@ export const TradeConfirm = ({ history }: RouterProps) => {
     .times(bnOrZero(sellAssetFiatRate))
     .times(selectedCurrencyToUsdRate)
 
-  const networkFeeFiat = bnOrZero(fees?.networkFee).times(fiatRate).times(selectedCurrencyToUsdRate)
+  const networkFeeFiat = bnOrZero(fees?.networkFeeCryptoHuman)
+    .times(fiatRate)
+    .times(selectedCurrencyToUsdRate)
 
   // Ratio of the fiat value of the gas fee to the fiat value of the trade value express in percentage
   const networkFeeToTradeRatioPercentage = networkFeeFiat

--- a/src/components/Trade/TradeInputV2.tsx
+++ b/src/components/Trade/TradeInputV2.tsx
@@ -92,7 +92,8 @@ export const TradeInput = () => {
 
   const walletSupportsTradeAssetChains = walletSupportsBuyAssetChain && walletSupportsSellAssetChain
 
-  const gasFee = bnOrZero(fees?.networkFee).times(bnOrZero(feeAssetFiatRate)).toString()
+  const gasFee = bnOrZero(fees?.networkFeeCryptoHuman).times(bnOrZero(feeAssetFiatRate)).toString()
+
   const hasValidSellAmount = bnOrZero(sellTradeAsset?.amount).gt(0)
 
   const handleInputChange = useCallback(

--- a/src/components/Trade/hooks/useSwapper/utils.ts
+++ b/src/components/Trade/hooks/useSwapper/utils.ts
@@ -91,20 +91,17 @@ const getEvmFees = <T extends EvmChainId>(
   feeAsset: Asset,
   tradeFeeSource: string,
 ): DisplayFeeData<EvmChainId> => {
-  // The "gas" fee paid to the network for the transaction
-  const feeBN = bnOrZero(trade?.feeData?.networkFee).dividedBy(
-    bn(10).exponentiatedBy(feeAsset.precision),
-  )
-  const fee = feeBN.toString()
+  const networkFeeCryptoHuman = fromBaseUnit(trade?.feeData?.networkFee ?? 0, feeAsset.precision)
+
   const approvalFee = bnOrZero(trade.feeData.chainSpecific.approvalFee)
     .dividedBy(bn(10).exponentiatedBy(feeAsset.precision))
     .toString()
-  const totalFee = feeBN.plus(approvalFee).toString()
+  const totalFee = bnOrZero(networkFeeCryptoHuman).plus(approvalFee).toString()
   const gasPrice = bnOrZero(trade.feeData.chainSpecific.gasPrice).toString()
   const estimatedGas = bnOrZero(trade.feeData.chainSpecific.estimatedGas).toString()
 
   return {
-    fee,
+    fee: networkFeeCryptoHuman,
     chainSpecific: {
       approvalFee,
       gasPrice,
@@ -116,7 +113,7 @@ const getEvmFees = <T extends EvmChainId>(
     tradeFeeSource,
     buyAssetTradeFeeUsd: trade.feeData.buyAssetTradeFeeUsd,
     sellAssetTradeFeeUsd: trade.feeData.sellAssetTradeFeeUsd,
-    networkFee: trade.feeData.networkFee,
+    networkFeeCryptoHuman,
   }
 }
 
@@ -126,10 +123,8 @@ export const getFormFees = ({
   tradeFeeSource,
   feeAsset,
 }: GetFormFeesArgs): DisplayFeeData<KnownChainIds> => {
-  const feeBN = bnOrZero(trade?.feeData?.networkFee).dividedBy(
-    bn(10).exponentiatedBy(feeAsset.precision),
-  )
-  const fee = feeBN.toString()
+  const networkFeeCryptoHuman = fromBaseUnit(trade?.feeData?.networkFee, feeAsset.precision)
+
   const { chainNamespace } = fromAssetId(sellAsset.assetId)
   switch (chainNamespace) {
     case CHAIN_NAMESPACE.Evm:
@@ -140,8 +135,8 @@ export const getFormFees = ({
       )
     case CHAIN_NAMESPACE.CosmosSdk: {
       return {
-        networkFee: fee,
-        fee,
+        networkFeeCryptoHuman,
+        fee: networkFeeCryptoHuman,
         sellAssetTradeFeeUsd: trade.feeData.sellAssetTradeFeeUsd ?? '',
         tradeFee: trade.feeData.sellAssetTradeFeeUsd ?? '',
         buyAssetTradeFeeUsd: trade.feeData.buyAssetTradeFeeUsd ?? '',
@@ -151,8 +146,8 @@ export const getFormFees = ({
     case CHAIN_NAMESPACE.Utxo: {
       const utxoTrade = trade as Trade<UtxoSupportedChainIds>
       return {
-        networkFee: fee,
-        fee,
+        networkFeeCryptoHuman,
+        fee: networkFeeCryptoHuman,
         chainSpecific: utxoTrade.feeData.chainSpecific,
         tradeFee: utxoTrade.feeData.sellAssetTradeFeeUsd ?? '',
         buyAssetTradeFeeUsd: utxoTrade.feeData.buyAssetTradeFeeUsd ?? '',

--- a/src/components/Trade/types.ts
+++ b/src/components/Trade/types.ts
@@ -26,7 +26,10 @@ export type TradeAsset = {
   fiatAmount?: string
 }
 
-export type DisplayFeeData<C extends ChainId> = QuoteFeeData<C> & { tradeFeeSource: string }
+export type DisplayFeeData<C extends ChainId> = Omit<QuoteFeeData<C>, 'networkFee'> & {
+  tradeFeeSource: string
+  networkFeeCryptoHuman: string
+}
 
 export type TradeState<C extends ChainId> = {
   sellTradeAsset: TradeAsset | undefined

--- a/src/test/constants.ts
+++ b/src/test/constants.ts
@@ -104,7 +104,7 @@ export const ETHCHAIN_QUOTE_FEES: DisplayFeeData<KnownChainIds.EthereumMainnet> 
   tradeFee: '0',
   tradeFeeSource: '0x',
   fee: '0.1532445',
-  networkFee: '0.1532445',
+  networkFeeCryptoHuman: '0.1532445',
   buyAssetTradeFeeUsd: '0',
   sellAssetTradeFeeUsd: '0',
 }


### PR DESCRIPTION
## Description

We are using `networkFee` as `networkFeeBaseUnit` in some places, and `networkFeeCryptoHuman` in others.

This PR properly types the difference by updating `DisplayFeeData` to reflect `web`'s  consumption of the gas fee (as crypto human balance) and ensures the values are set as such consistently across all chains.

This fixes the wildly high fee issue we currently have on `develop`.

**Outstanding issues before opening:**

- [x] Trade confirm fees from `lib` are `0`. https://github.com/shapeshift/lib/pull/1045 will fix this.
- [ ] Quote data gets stale and results in wrong or `0` gas fee

## Notice

- [x] Have you followed the guidelines in our [Contributing]('https://github.com/shapeshift/web/blob/develop/CONTRIBUTING.md) guide?
- [x] Have you checked to ensure there aren't other open [Pull Requests](https://github.com/shapeshift/web/pulls) for the same update/change?

## Pull Request Type

- [x] :bug: Bug fix (Non-breaking Change: Fixes an issue)
- [ ] :hammer_and_wrench: Chore (Non-breaking Change: Doc updates, pkg upgrades, typos, etc..)
- [ ] :nail_care: New Feature (Breaking/Non-breaking Change)

## Issue (if applicable)

N/A

## Risk

Touches the consumption and transformation of `networkFees`, medium risk, though fairly quick to determine if it's working as expected.

## Testing

Get quotes for `0x`, `Cowswap`, and `ThorSwap` and check values on both the quote screen and the trade confirm screen.

### Engineering

As above.

### Operations

As above.

## Screenshots (if applicable)

N/A