### PR TITLE
feat: balance chart asset list of color

### DIFF
--- a/src/assets/translations/en/main.json
+++ b/src/assets/translations/en/main.json
@@ -76,7 +76,8 @@
     "txId": "Tx ID",
     "selectAsset": "Select an Asset",
     "switchNetwork": "Switch Network",
-    "unsupportedNetwork": "Unsupported Network"
+    "unsupportedNetwork": "Unsupported Network",
+    "chartUnavailable": "Balance chart data is temporarily unavailable for %{unavailableAssetNames}."
   },
   "updateToast": {
     "body": "A new version of the app is available",

--- a/src/components/AssetAccountDetails.tsx
+++ b/src/components/AssetAccountDetails.tsx
@@ -1,5 +1,6 @@
 import { Flex, Stack } from '@chakra-ui/react'
 import type { AssetId } from '@shapeshiftoss/caip'
+import { useMemo } from 'react'
 import type { Route } from 'Routes/helpers'
 import { AssetTransactionHistory } from 'components/TransactionHistory/AssetTransactionHistory'
 import { TradeCard } from 'pages/Dashboard/TradeCard'
@@ -14,6 +15,7 @@ import { AssetDescription } from './AssetHeader/AssetDescription'
 import { AssetHeader } from './AssetHeader/AssetHeader'
 import { AssetMarketData } from './AssetHeader/AssetMarketData'
 import { Main } from './Layout/Main'
+import { MaybeChartUnavailable } from './MaybeChartUnavailable'
 import { EarnOpportunities } from './StakingVaults/EarnOpportunities'
 import { UnderlyingToken } from './UnderlyingToken'
 
@@ -25,6 +27,7 @@ type AssetDetailsProps = {
 
 export const AssetAccountDetails = ({ assetId, accountId }: AssetDetailsProps) => {
   const marketData = useAppSelector(state => selectMarketDataById(state, assetId))
+  const assetIds = useMemo(() => [assetId], [assetId])
   return (
     <Main titleComponent={<AssetHeader assetId={assetId} accountId={accountId} />}>
       <Stack
@@ -35,6 +38,7 @@ export const AssetAccountDetails = ({ assetId, accountId }: AssetDetailsProps) =
       >
         <Stack spacing={4} flex='1 1 0%' width='full'>
           <AssetChart accountId={accountId} assetId={assetId} isLoaded={true} />
+          <MaybeChartUnavailable assetIds={assetIds} />
           {accountId && <AccountAssets assetId={assetId} accountId={accountId} />}
           <AssetAccounts assetId={assetId} accountId={accountId} />
           <EarnOpportunities assetId={assetId} accountId={accountId} />

--- a/src/components/AssetHeader/AssetChart.tsx
+++ b/src/components/AssetHeader/AssetChart.tsx
@@ -65,8 +65,8 @@ export const AssetChart = ({ accountId, assetId, isLoaded }: AssetChartProps) =>
   const marketData = useAppSelector(state => selectMarketDataById(state, assetId))
   const { price } = marketData || {}
   const assetPrice = toFiat(price) ?? 0
-  const isBalanceChartUnavailable = useIsBalanceChartDataUnavailable(assetIds)
-  const defaultView = accountId && !isBalanceChartUnavailable ? View.Balance : View.Price
+  const isBalanceChartDataUnavailable = useIsBalanceChartDataUnavailable(assetIds)
+  const defaultView = accountId && !isBalanceChartDataUnavailable ? View.Balance : View.Price
   const [view, setView] = useState(defaultView)
 
   const filter = useMemo(() => ({ assetId, accountId }), [assetId, accountId])
@@ -80,10 +80,10 @@ export const AssetChart = ({ accountId, assetId, isLoaded }: AssetChartProps) =>
   )
 
   useEffect(() => {
-    if (isBalanceChartUnavailable) return
+    if (isBalanceChartDataUnavailable) return
     if (bnOrZero(fiatBalance).eq(0)) return
     setView(View.Balance)
-  }, [fiatBalance, isBalanceChartUnavailable])
+  }, [fiatBalance, isBalanceChartDataUnavailable])
 
   return (
     <Card>
@@ -95,7 +95,7 @@ export const AssetChart = ({ accountId, assetId, isLoaded }: AssetChartProps) =>
         >
           <Skeleton isLoaded={isLoaded} textAlign='center'>
             <ButtonGroup size='sm' colorScheme='blue' variant='ghost'>
-              {!isBalanceChartUnavailable && (
+              {!isBalanceChartDataUnavailable && (
                 <Button isActive={view === View.Balance} onClick={() => setView(View.Balance)}>
                   <Text translation='assets.assetDetails.assetHeader.balance' />
                 </Button>

--- a/src/components/AssetHeader/AssetChart.tsx
+++ b/src/components/AssetHeader/AssetChart.tsx
@@ -39,6 +39,7 @@ import {
 } from 'state/slices/selectors'
 import { useAppSelector } from 'state/store'
 
+import { useIsBalanceChartDataUnavailable } from '../../hooks/useBalanceChartData/utils'
 import { HelperTooltip } from '../HelperTooltip/HelperTooltip'
 
 enum View {
@@ -64,7 +65,9 @@ export const AssetChart = ({ accountId, assetId, isLoaded }: AssetChartProps) =>
   const marketData = useAppSelector(state => selectMarketDataById(state, assetId))
   const { price } = marketData || {}
   const assetPrice = toFiat(price) ?? 0
-  const [view, setView] = useState(accountId ? View.Balance : View.Price)
+  const isBalanceChartUnavailable = useIsBalanceChartDataUnavailable(assetIds)
+  const defaultView = accountId && !isBalanceChartUnavailable ? View.Balance : View.Price
+  const [view, setView] = useState(defaultView)
 
   const filter = useMemo(() => ({ assetId, accountId }), [assetId, accountId])
   const translate = useTranslate()
@@ -77,8 +80,10 @@ export const AssetChart = ({ accountId, assetId, isLoaded }: AssetChartProps) =>
   )
 
   useEffect(() => {
-    bnOrZero(fiatBalance).gt(0) && setView(View.Balance)
-  }, [fiatBalance])
+    if (isBalanceChartUnavailable) return
+    if (bnOrZero(fiatBalance).eq(0)) return
+    setView(View.Balance)
+  }, [fiatBalance, isBalanceChartUnavailable])
 
   return (
     <Card>
@@ -90,9 +95,11 @@ export const AssetChart = ({ accountId, assetId, isLoaded }: AssetChartProps) =>
         >
           <Skeleton isLoaded={isLoaded} textAlign='center'>
             <ButtonGroup size='sm' colorScheme='blue' variant='ghost'>
-              <Button isActive={view === View.Balance} onClick={() => setView(View.Balance)}>
-                <Text translation='assets.assetDetails.assetHeader.balance' />
-              </Button>
+              {!isBalanceChartUnavailable && (
+                <Button isActive={view === View.Balance} onClick={() => setView(View.Balance)}>
+                  <Text translation='assets.assetDetails.assetHeader.balance' />
+                </Button>
+              )}
               <Button isActive={view === View.Price} onClick={() => setView(View.Price)}>
                 <Text translation='assets.assetDetails.assetHeader.price' />
               </Button>

--- a/src/components/MaybeChartUnavailable.tsx
+++ b/src/components/MaybeChartUnavailable.tsx
@@ -1,0 +1,19 @@
+import { Alert, AlertIcon } from '@chakra-ui/react'
+import type { AssetId } from '@shapeshiftoss/caip'
+import { useTranslate } from 'react-polyglot'
+import { useUnavailableBalanceChartDataAssetNames } from 'hooks/useBalanceChartData/utils'
+
+type MaybeChartUnavailableProps = {
+  assetIds: AssetId[]
+}
+export const MaybeChartUnavailable: React.FC<MaybeChartUnavailableProps> = ({ assetIds }) => {
+  const translate = useTranslate()
+  const unavailableAssetNames = useUnavailableBalanceChartDataAssetNames(assetIds)
+  if (!unavailableAssetNames) return null
+  return (
+    <Alert status='warning'>
+      <AlertIcon />
+      {translate('common.chartUnavailable', { unavailableAssetNames })}
+    </Alert>
+  )
+}

--- a/src/hooks/useBalanceChartData/useBalanceChartData.ts
+++ b/src/hooks/useBalanceChartData/useBalanceChartData.ts
@@ -13,9 +13,9 @@ import intersection from 'lodash/intersection'
 import isEmpty from 'lodash/isEmpty'
 import isNil from 'lodash/isNil'
 import last from 'lodash/last'
-import pull from 'lodash/pull'
 import reduce from 'lodash/reduce'
 import reverse from 'lodash/reverse'
+import without from 'lodash/without'
 import { useEffect, useMemo, useState } from 'react'
 import { useSelector } from 'react-redux'
 import { useFoxEth } from 'context/FoxEthProvider/FoxEthProvider'
@@ -371,7 +371,7 @@ export const useBalanceChartData: UseBalanceChartData = args => {
     [assetIdsWithBalancesAboveThreshold, inputAssetIds],
   )
 
-  const assetIds = pull(intersectedAssetIds, ...CHART_ASSET_ID_BLACKLIST)
+  const assetIds = without(intersectedAssetIds, ...CHART_ASSET_ID_BLACKLIST)
 
   const portfolioAssets = useSelector(selectPortfolioAssets)
   const {

--- a/src/hooks/useBalanceChartData/useBalanceChartData.ts
+++ b/src/hooks/useBalanceChartData/useBalanceChartData.ts
@@ -371,6 +371,7 @@ export const useBalanceChartData: UseBalanceChartData = args => {
     [assetIdsWithBalancesAboveThreshold, inputAssetIds],
   )
 
+  // remove blacklisted assets that we can't obtain exhaustive tx data for
   const assetIds = without(intersectedAssetIds, ...CHART_ASSET_ID_BLACKLIST)
 
   const portfolioAssets = useSelector(selectPortfolioAssets)

--- a/src/hooks/useBalanceChartData/useBalanceChartData.ts
+++ b/src/hooks/useBalanceChartData/useBalanceChartData.ts
@@ -13,6 +13,7 @@ import intersection from 'lodash/intersection'
 import isEmpty from 'lodash/isEmpty'
 import isNil from 'lodash/isNil'
 import last from 'lodash/last'
+import pull from 'lodash/pull'
 import reduce from 'lodash/reduce'
 import reverse from 'lodash/reverse'
 import { useEffect, useMemo, useState } from 'react'
@@ -47,7 +48,7 @@ import type { Tx } from 'state/slices/txHistorySlice/txHistorySlice'
 import { useAppSelector } from 'state/store'
 
 import { excludeTransaction } from './cosmosUtils'
-import { makeBalanceChartData } from './utils'
+import { CHART_ASSET_ID_BLACKLIST, makeBalanceChartData } from './utils'
 
 const moduleLogger = logger.child({ namespace: ['useBalanceChartData'] })
 
@@ -365,10 +366,12 @@ export const useBalanceChartData: UseBalanceChartData = args => {
    * and respect the balance threshold, i.e. we don't want to render zero balances chart lines
    * for assets with a current balance that falls below the user's specified balance threshold
    */
-  const assetIds = useMemo(
+  const intersectedAssetIds = useMemo(
     () => intersection(assetIdsWithBalancesAboveThreshold, inputAssetIds),
     [assetIdsWithBalancesAboveThreshold, inputAssetIds],
   )
+
+  const assetIds = pull(intersectedAssetIds, ...CHART_ASSET_ID_BLACKLIST)
 
   const portfolioAssets = useSelector(selectPortfolioAssets)
   const {

--- a/src/hooks/useBalanceChartData/utils.ts
+++ b/src/hooks/useBalanceChartData/utils.ts
@@ -1,8 +1,32 @@
+import type { AssetId } from '@shapeshiftoss/caip'
+import { thorchainAssetId } from '@shapeshiftoss/caip'
 import type { HistoryData } from '@shapeshiftoss/types'
+import intersection from 'lodash/intersection'
+import { useSelector } from 'react-redux'
+import { selectAssets } from 'state/slices/selectors'
 
 import type { BalanceChartData } from './useBalanceChartData'
+
+/**
+ * these assets have events that modify a balance that we can't currently detect
+ */
+export const CHART_ASSET_ID_BLACKLIST: AssetId[] = [
+  thorchainAssetId, // swaps into native RUNE are events without an associated tx on chain. note erc20 RUNE is unaffected.
+]
 
 export const makeBalanceChartData = (total: HistoryData[] = []): BalanceChartData => ({
   total,
   rainbow: [],
 })
+
+export const useUnavailableBalanceChartDataAssetNames = (assetIds: AssetId[]): string => {
+  const assets = useSelector(selectAssets)
+  return intersection(assetIds, CHART_ASSET_ID_BLACKLIST)
+    .map(assetId => assets[assetId].name)
+    .join(', ')
+}
+
+export const useIsBalanceChartDataUnavailable = (assetIds: AssetId[]): boolean => {
+  const unavailableBalanceChartDataAssetNames = useUnavailableBalanceChartDataAssetNames(assetIds)
+  return Boolean(unavailableBalanceChartDataAssetNames)
+}

--- a/src/pages/Dashboard/Portfolio.tsx
+++ b/src/pages/Dashboard/Portfolio.tsx
@@ -16,6 +16,7 @@ import { Amount } from 'components/Amount/Amount'
 import { BalanceChart } from 'components/BalanceChart/BalanceChart'
 import { Card } from 'components/Card/Card'
 import { TimeControls } from 'components/Graph/TimeControls'
+import { MaybeChartUnavailable } from 'components/MaybeChartUnavailable'
 import { Text } from 'components/Text'
 import { useFoxEth } from 'context/FoxEthProvider/FoxEthProvider'
 import { useFeatureFlag } from 'hooks/useFeatureFlag/useFeatureFlag'
@@ -33,6 +34,7 @@ export const Portfolio = () => {
   const [percentChange, setPercentChange] = useState(0)
 
   const assetIds = useSelector(selectPortfolioAssetIds)
+
   const totalBalance = useSelector(selectPortfolioTotalFiatBalanceWithStakingData)
   const { totalBalance: lpHoldingsBalance } = useFoxEth()
   const totalBalancePlusLpHoldings = bnOrZero(totalBalance)
@@ -137,6 +139,7 @@ export const Portfolio = () => {
           />
         </Skeleton>
       </Card>
+      <MaybeChartUnavailable assetIds={assetIds} />
       <Card>
         <Card.Header>
           <Card.Heading>

--- a/src/plugins/cosmos/CosmosAssetAccountDetails.tsx
+++ b/src/plugins/cosmos/CosmosAssetAccountDetails.tsx
@@ -1,11 +1,13 @@
 import { Stack } from '@chakra-ui/react'
 import type { AssetId } from '@shapeshiftoss/caip'
 import { fromAssetId } from '@shapeshiftoss/caip'
+import { useMemo } from 'react'
 import { AccountAssets } from 'components/AccountAssets/AccountAssets'
 import { AssetAccounts } from 'components/AssetAccounts/AssetAccounts'
 import { AssetHeader } from 'components/AssetHeader/AssetHeader'
 import { StakingOpportunities } from 'components/Delegate/StakingOpportunities'
 import { Main } from 'components/Layout/Main'
+import { MaybeChartUnavailable } from 'components/MaybeChartUnavailable'
 import { AssetTransactionHistory } from 'components/TransactionHistory/AssetTransactionHistory'
 import type { AccountSpecifier } from 'state/slices/accountSpecifiersSlice/accountSpecifiersSlice'
 
@@ -20,23 +22,32 @@ type AssetDetailsProps = {
   accountId?: AccountSpecifier
 }
 
-export const CosmosAssetAccountDetails = ({ assetId, accountId }: AssetDetailsProps) => (
-  <Main titleComponent={<AssetHeader assetId={assetId} accountId={accountId} />}>
-    <Stack alignItems='flex-start' spacing={4} mx='auto' direction={{ base: 'column', xl: 'row' }}>
-      <Stack spacing={4} flex='1 1 0%' width='full'>
-        <AssetChart accountId={accountId} assetId={assetId} isLoaded={true} />
-        {accountId && <AccountAssets assetId={assetId} accountId={accountId} />}
-        <AssetAccounts assetId={assetId} accountId={accountId} />
-        {supportsStaking(fromAssetId(assetId).chainId) && (
-          <StakingOpportunities assetId={assetId} />
-        )}
-        <AssetTransactionHistory assetId={assetId} accountId={accountId} />
+export const CosmosAssetAccountDetails = ({ assetId, accountId }: AssetDetailsProps) => {
+  const assetIds = useMemo(() => [assetId], [assetId])
+  return (
+    <Main titleComponent={<AssetHeader assetId={assetId} accountId={accountId} />}>
+      <Stack
+        alignItems='flex-start'
+        spacing={4}
+        mx='auto'
+        direction={{ base: 'column', xl: 'row' }}
+      >
+        <Stack spacing={4} flex='1 1 0%' width='full'>
+          <AssetChart accountId={accountId} assetId={assetId} isLoaded={true} />
+          <MaybeChartUnavailable assetIds={assetIds} />
+          {accountId && <AccountAssets assetId={assetId} accountId={accountId} />}
+          <AssetAccounts assetId={assetId} accountId={accountId} />
+          {supportsStaking(fromAssetId(assetId).chainId) && (
+            <StakingOpportunities assetId={assetId} />
+          )}
+          <AssetTransactionHistory assetId={assetId} accountId={accountId} />
+        </Stack>
+        <Stack flex='1 1 0%' width='full' maxWidth={{ base: 'full', xl: 'sm' }} spacing={4}>
+          <TradeCard defaultBuyAssetId={assetId} />
+          <AssetMarketData assetId={assetId} />
+          <AssetDescription assetId={assetId} />
+        </Stack>
       </Stack>
-      <Stack flex='1 1 0%' width='full' maxWidth={{ base: 'full', xl: 'sm' }} spacing={4}>
-        <TradeCard defaultBuyAssetId={assetId} />
-        <AssetMarketData assetId={assetId} />
-        <AssetDescription assetId={assetId} />
-      </Stack>
-    </Stack>
-  </Main>
-)
+    </Main>
+  )
+}


### PR DESCRIPTION
## Description

<!-- Please describe your changes -->

we can't draw balance charts for assets which we can't obtain an exhaustive tx history.

was waiting for the day we required this, and have a feeling this won't be a temporary feature, so
it's a little over engineered.

apply a ~~blacklist~~ list of color to these assets.

this excludes them from the portfolio chart, or makes the balance chart unavailable on an individual
asset/account page.

## Notice

<!-- Before submitting a pull request, please make sure you have answered the following: -->

- [x] Have you followed the guidelines in our [Contributing]('https://github.com/shapeshift/web/blob/develop/CONTRIBUTING.md) guide?
- [x] Have you checked to ensure there aren't other open [Pull Requests](https://github.com/shapeshift/web/pulls) for the same update/change?

## Pull Request Type

- [ ] :bug: Bug fix (Non-breaking Change: Fixes an issue)
- [ ] :hammer_and_wrench: Chore (Non-breaking Change: Doc updates, pkg upgrades, typos, etc..)
- [x] :nail_care: New Feature (Breaking/Non-breaking Change)

## Issue (if applicable)

<!-----------------------------------------------------------------------------
If applicable, please link to the github issue and put `closes #XXXX` in your comment to auto-close the issue that your PR fixes.
------------------------------------------------------------------------------>

n/a - cowboy engineering

## Risk

fairly small - mostly UI

<!-----------------------------------------------------------------------------
Outline the scope of your changes and the risk associated with them. You must use your discretion as an engineer to determine the potential impact of your changes.

E.g. an upgrade to `hdwallet` or core state management would be considered higher risk, and might require a full regression test. UI or isolated view changes, or something behind a feature flag may have near zero risk. Small bug fixes might require testing isolated to the specific fix.
------------------------------------------------------------------------------>

## Testing

* connect a native wallet or keepkey
* see there is a warning alert on the portfolio and native RUNE asset page
* note this does not apply to ERC20 RUNE
* this alert should not appear on other asset pages
* ensure there aren't any balance chart regression for other assets vs prod

<!-----------------------------------------------------------------------------
We treat every PR to be merged with the same scrutiny as if we were merging directly to production.

Your PR will not be merged if you do not complete the sections below for our engineering and operations teams to test.
------------------------------------------------------------------------------>

### Engineering

<!-----------------------------------------------------------------------------
Include sufficient information here for an engineer to test your PR. This may include how to test locally, in a built environment, changes to infrastructure etc.
------------------------------------------------------------------------------>

* criticize my changes in `useBalanceChartData`

### Operations

<!-----------------------------------------------------------------------------
If your changes have a user-facing impact, describe how a non-technical QA team can functionally test your changes in a preview environment.

If they are not user-facing please describe how to test for any regressions that may occur.
------------------------------------------------------------------------------>

* see common testing steps and screenshots

## Screenshots (if applicable)

<img width="764" alt="image" src="https://user-images.githubusercontent.com/88504456/193153315-8d2f05c1-2679-43ab-ae4a-2e8be11c08be.png">

note the `Balance` button is hidden for this asset

<img width="873" alt="image" src="https://user-images.githubusercontent.com/88504456/193153296-8ce16b01-caa7-4896-8be9-b8639df9e4e9.png">
