### PR TITLE
chore: bump swapper to 11.5.1

### DIFF
--- a/package.json
+++ b/package.json
@@ -106,7 +106,7 @@
     "@shapeshiftoss/investor-yearn": "^6.1.2",
     "@shapeshiftoss/logger": "^1.1.3",
     "@shapeshiftoss/market-service": "^7.1.0",
-    "@shapeshiftoss/swapper": "^11.5.0",
+    "@shapeshiftoss/swapper": "^11.5.1",
     "@shapeshiftoss/types": "^8.3.1",
     "@shapeshiftoss/unchained-client": "^10.1.2",
     "@uniswap/sdk": "^3.0.3",

--- a/yarn.lock
+++ b/yarn.lock
@@ -4340,10 +4340,10 @@
     google-protobuf "^3.17.0"
     long "^4.0.0"
 
-"@shapeshiftoss/swapper@^11.5.0":
-  version "11.5.0"
-  resolved "https://registry.yarnpkg.com/@shapeshiftoss/swapper/-/swapper-11.5.0.tgz#ff1259d3e26ec32938c6544ce721126d115ec2c0"
-  integrity sha512-9cinBfXOm5NIrC448/eBi5zg0nFgIyPBCUkcP/jJp/2gNsmwz1kMwBlQEzNJXJhbONTrSie0rUnXSBICKpoCDw==
+"@shapeshiftoss/swapper@^11.5.1":
+  version "11.5.1"
+  resolved "https://registry.yarnpkg.com/@shapeshiftoss/swapper/-/swapper-11.5.1.tgz#d0ef1f794c06954d63122af9d2376e8031b48650"
+  integrity sha512-uVOJtUPLwsBA+Zi5hR+KHE1NoDBskB/98k6gbNMAlwfCELfWwIZ3m1od5I1Vfju00vytldaCkQ9xoXAN+F0PNA==
   dependencies:
     axios "^0.26.1"
     bignumber.js "^9.0.2"


### PR DESCRIPTION
## Description

Bump swapper to 11.5.1 - this will fix the gas amount on the trade confirm screen for 0x trades.

## Notice

- [x] Have you followed the guidelines in our [Contributing]('https://github.com/shapeshift/web/blob/develop/CONTRIBUTING.md) guide?
- [x] Have you checked to ensure there aren't other open [Pull Requests](https://github.com/shapeshift/web/pulls) for the same update/change?

## Pull Request Type

- [x] :bug: Bug fix (Non-breaking Change: Fixes an issue)
- [ ] :hammer_and_wrench: Chore (Non-breaking Change: Doc updates, pkg upgrades, typos, etc..)
- [ ] :nail_care: New Feature (Breaking/Non-breaking Change)

## Issue (if applicable)

N/A

## Risk

Very small - fixes trade quote data.

## Testing

Get to the confirm screen of a 0x trade - a gas fee should be shown.

### Engineering

As above.

### Operations

As above.

## Screenshots (if applicable)

N/A
