### PR TITLE
fix: clear stale values on asset toggle

### DIFF
--- a/src/components/Trade/TradeInputV2.tsx
+++ b/src/components/Trade/TradeInputV2.tsx
@@ -127,6 +127,11 @@ export const TradeInput = () => {
       setValue('fiatBuyAmount', '0')
       setValue('buyAssetFiatRate', currentValues.sellAssetFiatRate)
       setValue('sellAssetFiatRate', currentValues.buyAssetFiatRate)
+
+      // The below values all change on asset change. Clear them so no inaccurate data is shown in the UI.
+      setValue('feeAssetFiatRate', undefined)
+      setValue('quote', undefined)
+      setValue('fees', undefined)
     } catch (e) {
       moduleLogger.error(e, 'handleToggle error')
     }

--- a/src/components/Trade/hooks/useGetTradeAmounts.tsx
+++ b/src/components/Trade/hooks/useGetTradeAmounts.tsx
@@ -179,7 +179,7 @@ export const useGetTradeAmounts = () => {
   const buyAssetTradeFeeUsd = bnOrZero(fees?.buyAssetTradeFeeUsd)
 
   const tradeAmountConstants =
-    buyAsset && sellAsset && action
+    buyAsset && sellAsset && action && buyAssetUsdRate && sellAssetUsdRate
       ? getTradeAmountConstants({
           amount,
           buyAsset,

--- a/src/components/Trade/hooks/useTradeAmounts.tsx
+++ b/src/components/Trade/hooks/useTradeAmounts.tsx
@@ -94,7 +94,7 @@ export const useTradeAmounts = () => {
       const buyAssetUsdRate = args.buyAssetUsdRate ?? buyAssetFiatRateFormState
       const sellAssetUsdRate = args.sellAssetUsdRate ?? sellAssetFiatRateFormState
       const fees = args.fees ?? feesFormState
-      if (sellAsset && buyAsset && amount && action) {
+      if (sellAsset && buyAsset && amount && action && buyAssetUsdRate && sellAssetUsdRate) {
         setTradeAmounts({
           amount,
           action,

--- a/src/components/Trade/types.ts
+++ b/src/components/Trade/types.ts
@@ -40,9 +40,9 @@ export type TradeState<C extends ChainId> = {
   buyTradeAsset: TradeAsset | undefined
   fiatSellAmount: string
   fiatBuyAmount: string
-  sellAssetFiatRate: string
-  buyAssetFiatRate: string
-  feeAssetFiatRate: string
+  sellAssetFiatRate?: string
+  buyAssetFiatRate?: string
+  feeAssetFiatRate?: string
   fees?: DisplayFeeData<C>
   action: TradeAmountInputField | undefined
   isExactAllowance?: boolean


### PR DESCRIPTION
## Description

When toggling assets in `swapperV2` there are a few UI issues that surface when a `useEffect` doesn't fire when expected, or a quote or rate request fails/takes a long time to return.

This can be observed with the gas fee or rate (1 ETH = 333 POO) where they will briefly flash an incorrect value when toggling assets. In some case the they will stay an incorrect value.

This PR clears values we know become stale when an asset changes so they are never shown to the user.

## Notice

- [x] Have you followed the guidelines in our [Contributing]('https://github.com/shapeshift/web/blob/develop/CONTRIBUTING.md) guide?
- [x] Have you checked to ensure there aren't other open [Pull Requests](https://github.com/shapeshift/web/pulls) for the same update/change?

## Pull Request Type

- [x] :bug: Bug fix (Non-breaking Change: Fixes an issue)
- [ ] :hammer_and_wrench: Chore (Non-breaking Change: Doc updates, pkg upgrades, typos, etc..)
- [ ] :nail_care: New Feature (Breaking/Non-breaking Change)

## Issue (if applicable)

N/A - general swapper improvement.

## Risk

Minimal - only clears swapper data that is stale.

## Testing

With `swapperV2` enabled, notice that when toggling assets we don't get a flash of incorrect values in the rate or gas fields.

### Engineering

As above.

### Operations

As above.

## Screenshots (if applicable)

N/A
