### PR TITLE
fix: call setDefaultAssets only on `<TradeRoutes />` mount

### DIFF
--- a/src/components/Trade/TradeRoutes/TradeRoutes.tsx
+++ b/src/components/Trade/TradeRoutes/TradeRoutes.tsx
@@ -33,7 +33,9 @@ export const TradeRoutes = ({ defaultBuyAssetId }: TradeRoutesProps) => {
     ;(async () => {
       await setDefaultAssets()
     })()
-  }, [setDefaultAssets])
+    // This should be ran only once on <TradeRoutes /> mount, no matter the dependencies change of setDefaultAssets
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, [])
 
   const isSwapperV2 = useFeatureFlag('SwapperV2')
   const TradeInputComponent = isSwapperV2 ? TradeInputV2 : TradeInputV1


### PR DESCRIPTION
## Description

This removes the `setDefaultAssets` dependency in `<TradeRoutes />`'s useEffect, so that we really only call it on routes mount.

Between broadcast and broadcasted step, it was called again setting default values (default asset pair), thus using ETH/FOX values in place of the completed swap's pair values.

The offender of this re-render would most likely be:

https://github.com/shapeshift/web/blob/814c56ac6450bcf78e871af6938c0857613afc14/src/components/Trade/hooks/useDefaultAssets.tsx#L160

Which we need for reconciliation across asset pages.

## Notice

<!-- Before submitting a pull request, please make sure you have answered the following: -->

- [x] Have you followed the guidelines in our [Contributing]('https://github.com/shapeshift/web/blob/develop/CONTRIBUTING.md) guide?
- [x] Have you checked to ensure there aren't other open [Pull Requests](https://github.com/shapeshift/web/pulls) for the same update/change?

## Pull Request Type

- [x] :bug: Bug fix (Non-breaking Change: Fixes an issue)
- [ ] :hammer_and_wrench: Chore (Non-breaking Change: Doc updates, pkg upgrades, typos, etc..)
- [ ] :nail_care: New Feature (Breaking/Non-breaking Change)

## Issue (if applicable)

<!-----------------------------------------------------------------------------
If applicable, please link to the github issue and put `closes #XXXX` in your comment to auto-close the issue that your PR fixes.
------------------------------------------------------------------------------>

- tackles https://github.com/shapeshift/web/issues/2873

## Risk

Default pairs could be borked across the app, test accordingly

<!-----------------------------------------------------------------------------
Outline the scope of your changes and the risk associated with them. You must use your discretion as an engineer to determine the potential impact of your changes.

E.g. an upgrade to `hdwallet` or core state management would be considered higher risk, and might require a full regression test. UI or isolated view changes, or something behind a feature flag may have near zero risk. Small bug fixes might require testing isolated to the specific fix.
------------------------------------------------------------------------------>

## Testing

- Default pairs show no regressions
- Swapper values (amount/fees etc) don't get updated to weird 0 / invalid values at confirm step (currently happens between broadcasting and broadcasted time)

<!-----------------------------------------------------------------------------
We treat every PR to be merged with the same scrutiny as if we were merging directly to production.

Your PR will not be merged if you do not complete the sections below for our engineering and operations teams to test.
------------------------------------------------------------------------------>

### Engineering

- Dependency removal looks sane

<!-----------------------------------------------------------------------------
Include sufficient information here for an engineer to test your PR. This may include how to test locally, in a built environment, changes to infrastructure etc.
------------------------------------------------------------------------------>

### Operations

<!-----------------------------------------------------------------------------
If your changes have a user-facing impact, describe how a non-technical QA team can functionally test your changes in a preview environment.

If they are not user-facing please describe how to test for any regressions that may occur.
------------------------------------------------------------------------------>

## Screenshots (if applicable)

#### Develop

https://user-images.githubusercontent.com/17035424/193272248-2fd80865-8f5c-4ee0-8332-69f8966cc2eb.mov

#### This diff


https://user-images.githubusercontent.com/17035424/193273044-c877f26e-dc74-4b34-bb82-5a8b709c5ec7.mov