### PR TITLE
feat: pendo track visits

### DIFF
--- a/src/plugins/pendo/agent/types.ts
+++ b/src/plugins/pendo/agent/types.ts
@@ -72,7 +72,8 @@ export interface Pendo {
   identify(): void
   updateOptions(): void
   pageLoad(): void
-  track(): void
+  // https://developers.pendo.io/docs/?bash#track-events
+  track(trackType: string, metadata?: Record<string, unknown>): void
 }
 
 export interface Window {

--- a/src/plugins/pendo/launcher.ts
+++ b/src/plugins/pendo/launcher.ts
@@ -1,4 +1,5 @@
 import { getConfig } from 'config'
+import { isMobile as isMobileApp } from 'lib/globals'
 import { logger } from 'lib/logger'
 
 import type { PendoConfig, PendoEnv, PendoInitializeParams } from './agent'
@@ -21,6 +22,8 @@ const makeBasePendoInitializeParams = (pendoEnv: PendoEnv) => ({
   events: {
     ready: () => {
       pendoEventsLogger.trace('ready')
+      pendoEnv.pendo.track('visit', { mobile_app: isMobileApp })
+      pendoEventsLogger.trace('trackedVisit')
     },
     deliverablesLoaded: () => {
       pendoEventsLogger.trace('deliverablesLoaded')


### PR DESCRIPTION
## Description

<!-- Please describe your changes -->

tracks a visit once with a key of `mobile_app` based on the `isMobileApp` flag when pendo is ready

## Notice

<!-- Before submitting a pull request, please make sure you have answered the following: -->

- [x] Have you followed the guidelines in our [Contributing]('https://github.com/shapeshift/web/blob/develop/CONTRIBUTING.md) guide?
- [x] Have you checked to ensure there aren't other open [Pull Requests](https://github.com/shapeshift/web/pulls) for the same update/change?

## Pull Request Type

- [ ] :bug: Bug fix (Non-breaking Change: Fixes an issue)
- [ ] :hammer_and_wrench: Chore (Non-breaking Change: Doc updates, pkg upgrades, typos, etc..)
- [x] :nail_care: New Feature (Breaking/Non-breaking Change)

## Issue (if applicable)

<!-----------------------------------------------------------------------------
If applicable, please link to the github issue and put `closes #XXXX` in your comment to auto-close the issue that your PR fixes.
------------------------------------------------------------------------------>

n/a

## Risk

* low - look for `trackedVisit` and no errors in the console
* will only run if pendo is enabled
* pendo is enabled by default without consent in the mobile app, consent is required in the browser

<!-----------------------------------------------------------------------------
Outline the scope of your changes and the risk associated with them. You must use your discretion as an engineer to determine the potential impact of your changes.

E.g. an upgrade to `hdwallet` or core state management would be considered higher risk, and might require a full regression test. UI or isolated view changes, or something behind a feature flag may have near zero risk. Small bug fixes might require testing isolated to the specific fix.
------------------------------------------------------------------------------>

## Testing

<!-----------------------------------------------------------------------------
We treat every PR to be merged with the same scrutiny as if we were merging directly to production.

Your PR will not be merged if you do not complete the sections below for our engineering and operations teams to test.
------------------------------------------------------------------------------>

### Engineering

* check my code looks sane, and you can see the `trackedVisit` trace log in the browser with pendo
  enabled

<!-----------------------------------------------------------------------------
Include sufficient information here for an engineer to test your PR. This may include how to test locally, in a built environment, changes to infrastructure etc.
------------------------------------------------------------------------------>

### Operations

* not testable by operations

<!-----------------------------------------------------------------------------
If your changes have a user-facing impact, describe how a non-technical QA team can functionally test your changes in a preview environment.

If they are not user-facing please describe how to test for any regressions that may occur.
------------------------------------------------------------------------------>

## Screenshots (if applicable)

n/a
