### PR TITLE
fix: rainbow charts asset icon

### DIFF
--- a/src/components/AssetIcon.tsx
+++ b/src/components/AssetIcon.tsx
@@ -8,6 +8,7 @@ import { FoxIcon } from './Icons/FoxIcon'
 
 type AssetIconProps = {
   assetId?: string
+  showFeeAsset?: boolean
 } & AvatarProps
 
 // @TODO: this will be replaced with whatever we do for icons later
@@ -48,14 +49,19 @@ const AssetWithNetwork: React.FC<AssetWithNetworkProps> = ({ assetId, icon, size
   )
 }
 
-export const AssetIcon = ({ assetId, src, ...rest }: AssetIconProps) => {
+export const AssetIcon = ({ assetId, src, showFeeAsset = true, ...rest }: AssetIconProps) => {
   const assetIconBg = useColorModeValue('gray.200', 'gray.700')
   const assetIconColor = useColorModeValue('gray.500', 'gray.500')
+
+  const asset = useAppSelector(state => selectAssetById(state, assetId ?? ''))
 
   if (!assetId && !src) {
     return null
   }
-  return assetId ? (
+
+  const imgSrc = src ?? asset?.icon
+
+  return assetId && showFeeAsset ? (
     <AssetWithNetwork
       assetId={assetId}
       icon={<FoxIcon boxSize='16px' color={assetIconColor} />}
@@ -64,7 +70,7 @@ export const AssetIcon = ({ assetId, src, ...rest }: AssetIconProps) => {
   ) : (
     <Box position='relative'>
       <Avatar
-        src={src}
+        src={imgSrc}
         bg={assetIconBg}
         icon={<FoxIcon boxSize='16px' color={assetIconColor} />}
         {...rest}

--- a/src/components/Graph/RainbowChart/RainbowChart.tsx
+++ b/src/components/Graph/RainbowChart/RainbowChart.tsx
@@ -153,7 +153,7 @@ export const RainbowChart: React.FC<RainbowChartProps> = ({
                   p={2}
                 >
                   <Stack direction='row' alignItems={'center'}>
-                    <AssetIcon assetId={assetId} size='2xs' />
+                    <AssetIcon assetId={assetId} size='2xs' showFeeAsset={false} />
                     <Text fontWeight='bold'>{symbol}</Text>
                   </Stack>
                   <Amount.Fiat value={price} fontWeight='bold' />


### PR DESCRIPTION
## Description

This PR fixes the `<AssetIcon />` usage in rainbow charts following
https://github.com/shapeshift/web/pull/2906 by accepting
an optional `showFeeAsset` prop - defaulting to true.
Passing `showFeeAsset={false}` will make it render as it was previously.

## Notice

<!-- Before submitting a pull request, please make sure you have answered the following: -->

- [x] Have you followed the guidelines in our [Contributing]('https://github.com/shapeshift/web/blob/develop/CONTRIBUTING.md) guide?
- [x] Have you checked to ensure there aren't other open [Pull Requests](https://github.com/shapeshift/web/pulls) for the same update/change?

## Pull Request Type

- [x] :bug: Bug fix (Non-breaking Change: Fixes an issue)
- [ ] :hammer_and_wrench: Chore (Non-breaking Change: Doc updates, pkg upgrades, typos, etc..)
- [ ] :nail_care: New Feature (Breaking/Non-breaking Change)

## Issue (if applicable)

- relates to the closed https://github.com/shapeshift/web/issues/2905

## Risk

Quickfix, this will not show the network but will make develop happy for
release without a revert

## Testing

- `<AssetIcon />` should look good in rainbow charts
- All consumers of `<AssetIcon />` are happy

### Engineering

- Refer to top-level steps

<!-----------------------------------------------------------------------------
Include sufficient information here for an engineer to test your PR. This may include how to test locally, in a built environment, changes to infrastructure etc.
------------------------------------------------------------------------------>

### Operations

- Refer to top-level steps

<!-----------------------------------------------------------------------------
If your changes have a user-facing impact, describe how a non-technical QA team can functionally test your changes in a preview environment.

If they are not user-facing please describe how to test for any regressions that may occur.
------------------------------------------------------------------------------>

## Screenshots (if applicable)

This diff

![image](https://user-images.githubusercontent.com/17035424/193323578-476cae01-7efa-408b-b5f2-737d89631cbf.png)

Develop

![image](https://user-images.githubusercontent.com/17035424/193323865-3b41c7b4-ed9d-4473-8494-f46e35bafed3.png)
