### PR TITLE
fix: actually use the passed in size for the asset icon

### DIFF
--- a/src/components/AssetIcon.tsx
+++ b/src/components/AssetIcon.tsx
@@ -20,7 +20,7 @@ type AssetWithNetworkProps = {
   assetId: AssetId
 } & AvatarProps
 
-const AssetWithNetwork: React.FC<AssetWithNetworkProps> = ({ assetId, icon, size, ...rest }) => {
+const AssetWithNetwork: React.FC<AssetWithNetworkProps> = ({ assetId, icon, ...rest }) => {
   const asset = useAppSelector(state => selectAssetById(state, assetId ?? ''))
   const feeAsset = useAppSelector(state => selectFeeAssetById(state, assetId))
   const showFeeAsset = asset.assetId !== feeAsset.assetId
@@ -29,22 +29,22 @@ const AssetWithNetwork: React.FC<AssetWithNetworkProps> = ({ assetId, icon, size
     `0 0 0 0.2em ${feeAsset.color}50, 0 0 0.5em 2px rgba(0,0,0,.5)`,
   )
   return (
-    <Box position='relative' {...rest}>
+    <Avatar src={asset.icon} icon={icon} border={0} bg='none' {...rest}>
       {showFeeAsset && (
         <Avatar
-          boxSize='0.75em'
+          boxSize='0.85em'
           zIndex={2}
           position='absolute'
           right='-0.15em'
           top='-0.15em'
           border={0}
           bg='none'
+          fontSize='inherit'
           src={feeAsset.icon}
           boxShadow={boxShadow}
         />
       )}
-      <Avatar src={asset.icon} icon={icon} boxSize='auto' border={0} bg='none' />
-    </Box>
+    </Avatar>
   )
 }
 

--- a/src/components/AssetIcon.tsx
+++ b/src/components/AssetIcon.tsx
@@ -1,5 +1,5 @@
 import type { AvatarProps } from '@chakra-ui/react'
-import { Avatar, Box, Circle, useColorModeValue, useMultiStyleConfig } from '@chakra-ui/react'
+import { Avatar, Circle, useColorModeValue, useMultiStyleConfig } from '@chakra-ui/react'
 import type { AssetId } from '@shapeshiftoss/caip'
 import { selectAssetById, selectFeeAssetById } from 'state/slices/selectors'
 import { useAppSelector } from 'state/store'
@@ -62,14 +62,12 @@ export const AssetIcon = ({ assetId, src, ...rest }: AssetIconProps) => {
       {...rest}
     />
   ) : (
-    <Box position='relative'>
-      <Avatar
-        src={src}
-        bg={assetIconBg}
-        icon={<FoxIcon boxSize='16px' color={assetIconColor} />}
-        {...rest}
-      />
-    </Box>
+    <Avatar
+      src={src}
+      bg={assetIconBg}
+      icon={<FoxIcon boxSize='16px' color={assetIconColor} />}
+      {...rest}
+    />
   )
 }
 


### PR DESCRIPTION
## Description

- Use the size passed in props to determine the size of the asseticon and network icon

## Notice

<!-- Before submitting a pull request, please make sure you have answered the following: -->

- [x] Have you followed the guidelines in our [Contributing]('https://github.com/shapeshift/web/blob/develop/CONTRIBUTING.md) guide?
- [x] Have you checked to ensure there aren't other open [Pull Requests](https://github.com/shapeshift/web/pulls) for the same update/change?

## Pull Request Type

- [x] :bug: Bug fix (Non-breaking Change: Fixes an issue)
- [ ] :hammer_and_wrench: Chore (Non-breaking Change: Doc updates, pkg upgrades, typos, etc..)
- [ ] :nail_care: New Feature (Breaking/Non-breaking Change)

## Issue (if applicable)

n/a

## Risk

no risk

## Testing

### Engineering

no special steps

### Operations

Icon should be the correct size throughout the app, and the chain icon should scale with the size of the icon.
![Screen Shot 2022-09-30 at 12 31 03 PM](https://user-images.githubusercontent.com/89934888/193325064-20a4b3bb-5649-4ff9-8588-d0d7a69c2940.png)

## Screenshots (if applicable)
![Screen Shot 2022-09-30 at 12 31 08 PM](https://user-images.githubusercontent.com/89934888/193325042-db37e2d0-cc43-4717-a510-64d5df2d1cba.png)
