### PR TITLE
feat: add delete accounts button to settings

### DIFF
--- a/src/assets/translations/en/main.json
+++ b/src/assets/translations/en/main.json
@@ -821,6 +821,8 @@
     "settings": {
       "settings": "Settings",
       "currency": "Currency",
+      "clearWalletAccountData": "Delete all accounts & wallet data",
+      "deleteAccountsConfirm": "Are you sure?\n\nThis will remove all personal data including wallets, accounts, balances.\n\nVerify that you have backed up your wallets before continuing.",
       "currencyFormat": "Currency Format",
       "language": "Language",
       "balanceThreshold": "Balance Threshold",

--- a/src/components/Modals/Settings/SettingsList.tsx
+++ b/src/components/Modals/Settings/SettingsList.tsx
@@ -12,14 +12,18 @@ import {
   useColorModeValue,
 } from '@chakra-ui/react'
 import { useCallback, useState } from 'react'
-import { FaCoins, FaDollarSign, FaGreaterThanEqual } from 'react-icons/fa'
+import { FaCoins, FaDollarSign, FaGreaterThanEqual, FaTrash } from 'react-icons/fa'
 import { IoDocumentTextOutline, IoLockClosed } from 'react-icons/io5'
 import { MdChevronRight, MdLanguage } from 'react-icons/md'
 import { useTranslate } from 'react-polyglot'
 import type { RouteComponentProps } from 'react-router-dom'
 import { SlideTransition } from 'components/SlideTransition'
 import { RawText } from 'components/Text'
+import { mobileLogger } from 'context/WalletProvider/MobileWallet/config'
+import { deleteWallet } from 'context/WalletProvider/MobileWallet/mobileMessageHandlers'
 import { useModal } from 'hooks/useModal/useModal'
+import { useWallet } from 'hooks/useWallet/useWallet'
+import { isMobile as isMobileApp } from 'lib/globals'
 import {
   selectCurrencyFormat,
   selectSelectedCurrency,
@@ -37,6 +41,7 @@ type SettingsListProps = {
 } & RouteComponentProps
 
 export const SettingsList = ({ appHistory, ...routeProps }: SettingsListProps) => {
+  const { disconnect } = useWallet()
   const translate = useTranslate()
   const { settings } = useModal()
   const { toggleColorMode } = useColorMode()
@@ -65,6 +70,17 @@ export const SettingsList = ({ appHistory, ...routeProps }: SettingsListProps) =
   const closeModalAndNavigateTo = (linkHref: string) => {
     settings.close()
     appHistory.push(linkHref)
+  }
+
+  const handleDeleteAccountsClick = async () => {
+    if (window.confirm(translate('modals.settings.deleteAccountsConfirm'))) {
+      try {
+        await deleteWallet('*')
+        disconnect()
+      } catch (e) {
+        mobileLogger.error(e, 'Error deleting wallets')
+      }
+    }
   }
 
   return (
@@ -144,6 +160,17 @@ export const SettingsList = ({ appHistory, ...routeProps }: SettingsListProps) =
             onClick={() => closeModalAndNavigateTo('/legal/privacy-policy')}
             icon={<Icon as={IoDocumentTextOutline} color='gray.500' />}
           />
+          {isMobileApp && (
+            <>
+              <Divider my={1} />
+              <SettingsListItem
+                color='red.500'
+                label='modals.settings.clearWalletAccountData'
+                onClick={handleDeleteAccountsClick}
+                icon={<FaTrash />}
+              />
+            </>
+          )}
         </Stack>
       </ModalBody>
     </SlideTransition>


### PR DESCRIPTION
## Description

- per IOS requirements, the user needs a way to delete their "accounts" and wallets.
- Added a new button that only shows up on mobile
- Once clicked should delete wallets, and disconnect them.

## Notice

<!-- Before submitting a pull request, please make sure you have answered the following: -->

- [x] Have you followed the guidelines in our [Contributing]('https://github.com/shapeshift/web/blob/develop/CONTRIBUTING.md) guide?
- [x] Have you checked to ensure there aren't other open [Pull Requests](https://github.com/shapeshift/web/pulls) for the same update/change?

## Pull Request Type

- [ ] :bug: Bug fix (Non-breaking Change: Fixes an issue)
- [ ] :hammer_and_wrench: Chore (Non-breaking Change: Doc updates, pkg upgrades, typos, etc..)
- [x] :nail_care: New Feature (Breaking/Non-breaking Change)

## Issue (if applicable)

n/a

## Risk

No risk to web users

## Testing

### Engineering

I don't know if this fully works, needs to be tested on an actual mobile device with a wallet.

### Operations

On the mobile app, open the settings modal. Click the delete accounts and wallet data button. You should see a confirm prompt. Once that happens you should be taken to the splash page.

## Screenshots (if applicable)
![Screen_Shot_2022-09-30_at_3 52 00_PM](https://user-images.githubusercontent.com/89934888/193356142-00b9128b-15cc-4ad2-a80e-f67b3c4b70bf.png)
