### PR TITLE
fix: close modal after delete

### DIFF
--- a/src/components/Modals/Settings/SettingsList.tsx
+++ b/src/components/Modals/Settings/SettingsList.tsx
@@ -76,6 +76,7 @@ export const SettingsList = ({ appHistory, ...routeProps }: SettingsListProps) =
     if (window.confirm(translate('modals.settings.deleteAccountsConfirm'))) {
       try {
         await deleteWallet('*')
+        settings.close()
         disconnect()
       } catch (e) {
         mobileLogger.error(e, 'Error deleting wallets')


### PR DESCRIPTION
## Description

- close the modal after deleting "accounts"

## Notice

<!-- Before submitting a pull request, please make sure you have answered the following: -->

- [x] Have you followed the guidelines in our [Contributing]('https://github.com/shapeshift/web/blob/develop/CONTRIBUTING.md) guide?
- [x] Have you checked to ensure there aren't other open [Pull Requests](https://github.com/shapeshift/web/pulls) for the same update/change?

## Pull Request Type

- [x] :bug: Bug fix (Non-breaking Change: Fixes an issue)
- [ ] :hammer_and_wrench: Chore (Non-breaking Change: Doc updates, pkg upgrades, typos, etc..)
- [ ] :nail_care: New Feature (Breaking/Non-breaking Change)

## Issue (if applicable)

n/a

## Risk

n/a

## Testing

<!-----------------------------------------------------------------------------
We treat every PR to be merged with the same scrutiny as if we were merging directly to production.

Your PR will not be merged if you do not complete the sections below for our engineering and operations teams to test.
------------------------------------------------------------------------------>

### Engineering

n/a

### Operations

Modal should close now after the "accounts" are removed.

## Screenshots (if applicable)
