### PR TITLE
feat(mobile): support seed phrase recovery for the mobile app

### DIFF
--- a/src/components/Layout/Header/NavBar/Native/BackupPassphraseModal/BackupPassphraseCommon.ts
+++ b/src/components/Layout/Header/NavBar/Native/BackupPassphraseModal/BackupPassphraseCommon.ts
@@ -1,10 +1,13 @@
-import type { Vault } from '@shapeshiftoss/hdwallet-native-vault'
+import type { RevocableWallet } from 'context/WalletProvider/MobileWallet/RevocableWallet'
 
 export enum BackupPassphraseRoutes {
+  Start = '/backup-passphrase/',
   Password = '/backup-passphrase/password',
   Info = '/backup-passphrase/info',
   Test = '/backup-passphrase/test',
   Success = '/backup-passphrase/success',
 }
 
-export type LocationState = { vault: Vault }
+export type LocationState = {
+  revocableWallet: RevocableWallet
+}

--- a/src/components/Layout/Header/NavBar/Native/BackupPassphraseModal/BackupPassphraseInfo.tsx
+++ b/src/components/Layout/Header/NavBar/Native/BackupPassphraseModal/BackupPassphraseInfo.tsx
@@ -12,46 +12,56 @@ import {
   ModalHeader,
   Tag,
   useColorModeValue,
+  useUnmountEffect,
   Wrap,
 } from '@chakra-ui/react'
-import type { Vault } from '@shapeshiftoss/hdwallet-native-vault'
 import range from 'lodash/range'
-import type { ReactNode } from 'react'
-import { useEffect, useMemo, useState } from 'react'
+import React, { useMemo, useRef, useState } from 'react'
 import { FaEye } from 'react-icons/fa'
 import { useTranslate } from 'react-polyglot'
 import { useHistory } from 'react-router'
 import { SlideTransition } from 'components/SlideTransition'
 import { Text } from 'components/Text'
+import { Revocable, revocable } from 'context/WalletProvider/MobileWallet/RevocableWallet'
 import { useModal } from 'hooks/useModal/useModal'
 import { logger } from 'lib/logger'
 
+import type { LocationState } from './BackupPassphraseCommon'
 import { BackupPassphraseRoutes } from './BackupPassphraseCommon'
 
 const moduleLogger = logger.child({
   namespace: ['Layout', 'Header', 'NavBar', 'Native', 'BackupNativePassphrase'],
 })
 
-export const BackupPassphraseInfo = ({ vault }: { vault: Vault | null }) => {
+export const BackupPassphraseInfo: React.FC<LocationState> = props => {
+  const { revocableWallet } = props
   const translate = useTranslate()
+  const [revoker] = useState(new (Revocable(class {}))())
   const { goBack: handleBackClick, ...history } = useHistory()
+  const [revealed, setRevealed] = useState<boolean>(false)
+  const revealedOnce = useRef<boolean>(false)
+  const handleShow = () => {
+    revealedOnce.current = true
+    setRevealed(!revealed)
+  }
   const {
     backupNativePassphrase: {
       props: { preventClose },
     },
   } = useModal()
-  const [revealed, setRevealed] = useState<boolean>(false)
-  const handleShow = () => {
-    setRevealed(!revealed)
-  }
-  const [words, setWords] = useState<ReactNode[] | null>(null)
   const alertColor = useColorModeValue('blue.500', 'blue.200')
-  useEffect(() => {
-    if (!vault) return
-    ;(async () => {
-      try {
-        setWords(
-          (await vault.unwrap().get('#mnemonic')).split(' ').map((word: string, index: number) => (
+
+  useUnmountEffect(() => {
+    if (revealedOnce.current) revoker.revoke()
+  }, [revoker])
+
+  const words = useMemo(() => {
+    if (!revocableWallet) return
+
+    try {
+      return (
+        revocableWallet.getWords()?.map((word: string, index: number) =>
+          revocable(
             <Tag
               p={2}
               flexGrow={4}
@@ -60,18 +70,21 @@ export const BackupPassphraseInfo = ({ vault }: { vault: Vault | null }) => {
               fontSize='md'
               key={index}
               colorScheme='blue'
+              overflow='hidden'
             >
               <Code mr={2}>{index + 1}</Code>
               {word}
-            </Tag>
-          )),
-        )
-      } catch (e) {
-        moduleLogger.error(e, 'failed to get Secret Recovery Phrase')
-        setWords(null)
-      }
-    })()
-  }, [setWords, vault])
+            </Tag>,
+            revoker.addRevoker.bind(revoker),
+          ),
+        ) ?? null
+      )
+    } catch (e) {
+      moduleLogger.error(e, 'failed to get Secret Recovery Phrase')
+    }
+
+    return null
+  }, [revocableWallet, revoker])
 
   const placeholders = useMemo(() => {
     return range(1, 13).map(i => (
@@ -134,14 +147,8 @@ export const BackupPassphraseInfo = ({ vault }: { vault: Vault | null }) => {
         <Button
           colorScheme='blue'
           size='lg'
-          disabled={!(vault && words)}
-          onClick={() => {
-            if (vault) {
-              history.push(BackupPassphraseRoutes.Test, {
-                vault,
-              })
-            }
-          }}
+          disabled={!(words && revealedOnce.current)}
+          onClick={() => history.push(BackupPassphraseRoutes.Test)}
         >
           <Text translation={'walletProvider.shapeShift.create.button'} />
         </Button>

--- a/src/components/Layout/Header/NavBar/Native/BackupPassphraseModal/BackupPassphraseModal.tsx
+++ b/src/components/Layout/Header/NavBar/Native/BackupPassphraseModal/BackupPassphraseModal.tsx
@@ -1,6 +1,5 @@
 import { Modal, ModalContent, ModalOverlay } from '@chakra-ui/react'
-import type { Vault } from '@shapeshiftoss/hdwallet-native-vault'
-import { useState } from 'react'
+import React from 'react'
 import { MemoryRouter, Route, Switch } from 'react-router-dom'
 import { useModal } from 'hooks/useModal/useModal'
 
@@ -8,6 +7,7 @@ import { BackupPassphraseRoutes } from './BackupPassphraseCommon'
 import { BackupPassphraseRouter } from './BackupPassphraseRouter'
 
 export const entries = [
+  BackupPassphraseRoutes.Start,
   BackupPassphraseRoutes.Password,
   BackupPassphraseRoutes.Info,
   BackupPassphraseRoutes.Test,
@@ -19,14 +19,8 @@ type BackupPassphraseModalProps = {
 }
 
 export const BackupPassphraseModal: React.FC<BackupPassphraseModalProps> = ({ preventClose }) => {
-  const [vault, setVault] = useState<Vault | null>(null)
   const { backupNativePassphrase } = useModal()
   const { close, isOpen } = backupNativePassphrase
-
-  const handleClose = () => {
-    vault?.seal()
-    close()
-  }
 
   return (
     <Modal
@@ -34,14 +28,14 @@ export const BackupPassphraseModal: React.FC<BackupPassphraseModalProps> = ({ pr
       closeOnOverlayClick={!preventClose}
       closeOnEsc={!preventClose}
       isOpen={isOpen}
-      onClose={handleClose}
+      onClose={close}
     >
       <ModalOverlay />
       <ModalContent justifyContent='center' px={{ base: 0, md: 4 }} pt={3} pb={6}>
         <MemoryRouter initialEntries={entries}>
           <Switch>
             <Route path='/'>
-              <BackupPassphraseRouter vault={vault} setVault={setVault} />
+              <BackupPassphraseRouter />
             </Route>
           </Switch>
         </MemoryRouter>

--- a/src/components/Layout/Header/NavBar/Native/BackupPassphraseModal/BackupPassphraseStart.tsx
+++ b/src/components/Layout/Header/NavBar/Native/BackupPassphraseModal/BackupPassphraseStart.tsx
@@ -1,0 +1,41 @@
+import { useEffect, useState } from 'react'
+import { useHistory } from 'react-router-dom'
+import { KeyManager } from 'context/WalletProvider/KeyManager'
+import { getWallet } from 'context/WalletProvider/MobileWallet/mobileMessageHandlers'
+import { useWallet } from 'hooks/useWallet/useWallet'
+
+import type { LocationState } from './BackupPassphraseCommon'
+import { BackupPassphraseRoutes } from './BackupPassphraseCommon'
+
+export const BackupPassphraseStart: React.FC<LocationState> = props => {
+  const { revocableWallet } = props
+  const history = useHistory<LocationState>()
+  const { state } = useWallet()
+  const [error, setError] = useState<string | null>(null)
+
+  useEffect(() => {
+    ;(async () => {
+      switch (state.type) {
+        case KeyManager.Native:
+          // Native wallets require a password to decrypt
+          history.push(BackupPassphraseRoutes.Password)
+          break
+        case KeyManager.Mobile:
+          const wallet = await getWallet(state.walletInfo?.deviceId ?? '')
+          if (wallet?.mnemonic) {
+            revocableWallet.mnemonic = wallet.mnemonic
+            history.push(BackupPassphraseRoutes.Info)
+          } else {
+            setError('Error')
+          }
+          // Mobile wallet access is controlled via the OS, so we can skip the password screen
+          break
+        default:
+          // No other wallets are supported
+          break
+      }
+    })()
+  }, [history, revocableWallet, state.walletInfo, state.type])
+
+  return error ? <div>{error}</div> : null
+}

--- a/src/context/WalletProvider/WalletProvider.tsx
+++ b/src/context/WalletProvider/WalletProvider.tsx
@@ -351,6 +351,9 @@ export const WalletProvider = ({ children }: { children: React.ReactNode }): JSX
     if (localWalletType && localWalletDeviceId && state.adapters) {
       ;(async () => {
         if (state.adapters?.has(localWalletType)) {
+          // Fixes issue with wallet `type` being null when the wallet is loaded from state
+          dispatch({ type: WalletActions.SET_CONNECTOR_TYPE, payload: localWalletType })
+
           switch (localWalletType) {
             case KeyManager.Mobile:
               try {

--- a/src/context/WalletProvider/config.ts
+++ b/src/context/WalletProvider/config.ts
@@ -91,6 +91,8 @@ export const SUPPORTED_WALLETS: Record<KeyManager, SupportedWalletInfo> = {
       // WalletProvider.create looks for the first path that ends in "create"
       { path: '/mobile/legacy/create', component: MobileLegacyCreate },
     ],
+    connectedWalletMenuRoutes: [{ path: WalletConnectedRoutes.Native, component: NativeMenu }],
+    connectedWalletMenuInitialPath: WalletConnectedRoutes.Native,
   },
   [KeyManager.Native]: {
     ...NativeConfig,


### PR DESCRIPTION
## Description

See shapeshift/mobile-app#59

Change the BackupPassphrase flow (which is incorrectly named, it's not a passphrase) to support both Native and Mobile wallets

* Don't use `hdwallet-native-vault` except to read the mnemonic from a Native wallet
* Pass the mnemonic around in a RevocableWallet object

## Notice

<!-- Before submitting a pull request, please make sure you have answered the following: -->

- [X] Have you followed the guidelines in our [Contributing]('https://github.com/shapeshift/web/blob/develop/CONTRIBUTING.md) guide?
- [X] Have you checked to ensure there aren't other open [Pull Requests](https://github.com/shapeshift/web/pulls) for the same update/change?

## Pull Request Type

- [ ] :bug: Bug fix (Non-breaking Change: Fixes an issue)
- [ ] :hammer_and_wrench: Chore (Non-breaking Change: Doc updates, pkg upgrades, typos, etc..)
- [X] :nail_care: New Feature (Breaking/Non-breaking Change)

## Issue (if applicable)
closes shapeshift/mobile-app#59

## Risk
Low - only affects seed phrase backup of mobile/native wallets

## Testing
1. Connect a web native wallet
2. Click on the menu
3. Click on the down arrow
4. Click Back up my wallet ("Backup"?)
5. Follow the flow
6. Repeat for mobile

### Engineering
Testing mobile requires Android and/or iOS simulator

### Operations
See above

## Screenshots (
![Screenshot_1664581447](https://user-images.githubusercontent.com/1958266/193370428-6017e638-5b27-42ac-bd38-5c67788ffcb4.png)
![Screenshot_1664581513](https://user-images.githubusercontent.com/1958266/193370429-db15ba31-c737-4471-bb31-4dc3f04eb8e3.png)
![Screenshot_1664581524](https://user-images.githubusercontent.com/1958266/193370431-53133a10-084f-4d56-80db-514fd1c3448d.png)
![Screenshot_1664581696](https://user-images.githubusercontent.com/1958266/193370433-c9e7fae2-491b-4348-9ea3-e62c9b3905d8.png)
if applicable)
