### PR TITLE
chore: use selectors for swapperAPI loading state

### DIFF
--- a/src/components/Trade/TradeInputV2.tsx
+++ b/src/components/Trade/TradeInputV2.tsx
@@ -5,6 +5,7 @@ import type { KnownChainIds } from '@shapeshiftoss/types'
 import type { InterpolationOptions } from 'node-polyglot'
 import { useCallback, useMemo, useState } from 'react'
 import { useFormContext, useWatch } from 'react-hook-form'
+import { useSelector } from 'react-redux'
 import { useHistory } from 'react-router'
 import type { AccountDropdownProps } from 'components/AccountDropdown/AccountDropdown'
 import { SlideTransition } from 'components/SlideTransition'
@@ -19,6 +20,7 @@ import { walletSupportsChain } from 'hooks/useWalletSupportsChain/useWalletSuppo
 import { bn, bnOrZero, positiveOrZero } from 'lib/bignumber/bignumber'
 import { logger } from 'lib/logger'
 import { fromBaseUnit, toBaseUnit } from 'lib/math'
+import { selectSwapperApiPending } from 'state/apis/swapper/selectors'
 import { selectFeeAssetById } from 'state/slices/assetsSlice/selectors'
 import {
   selectPortfolioCryptoBalanceByFilter,
@@ -80,6 +82,8 @@ export const TradeInput = () => {
   const sellAssetBalanceHuman = useAppSelector(state =>
     selectPortfolioCryptoHumanBalanceByFilter(state, sellAssetBalanceFilter),
   )
+
+  const isSwapperApiLoading = useSelector(selectSwapperApiPending)
 
   // Constants
   const walletSupportsSellAssetChain =
@@ -334,12 +338,12 @@ export const TradeInput = () => {
             buySymbol={buyTradeAsset?.asset?.symbol}
             gasFee={gasFee}
             rate={quote?.rate}
-            isLoading={isLoadingFiatRateData || isLoadingTradeQuote}
+            isLoading={isSwapperApiLoading}
             isError={!walletSupportsTradeAssetChains}
           />
           {walletSupportsTradeAssetChains ? (
             <ReceiveSummary
-              isLoading={!quote || isLoadingTradeQuote}
+              isLoading={!quote || isSwapperApiLoading}
               symbol={buyTradeAsset?.asset?.symbol ?? ''}
               amount={buyTradeAsset?.amount ?? ''}
               beforeFees={tradeAmountConstants?.buyAmountBeforeFees ?? ''}

--- a/src/components/Trade/TradeInputV2.tsx
+++ b/src/components/Trade/TradeInputV2.tsx
@@ -20,7 +20,11 @@ import { walletSupportsChain } from 'hooks/useWalletSupportsChain/useWalletSuppo
 import { bn, bnOrZero, positiveOrZero } from 'lib/bignumber/bignumber'
 import { logger } from 'lib/logger'
 import { fromBaseUnit, toBaseUnit } from 'lib/math'
-import { selectSwapperApiPending } from 'state/apis/swapper/selectors'
+import {
+  selectSwapperApiPending,
+  selectSwapperApiTradeQuotePending,
+  selectSwapperApiUsdRatesPending,
+} from 'state/apis/swapper/selectors'
 import { selectFeeAssetById } from 'state/slices/assetsSlice/selectors'
 import {
   selectPortfolioCryptoBalanceByFilter,
@@ -38,7 +42,7 @@ import { type TradeState, TradeAmountInputField, TradeRoutePaths } from './types
 const moduleLogger = logger.child({ namespace: ['TradeInput'] })
 
 export const TradeInput = () => {
-  const { isLoadingTradeQuote, isLoadingFiatRateData } = useSwapperService()
+  useSwapperService()
   const [isLoading, setIsLoading] = useState(false)
   const { setTradeAmountsUsingExistingData, setTradeAmountsRefetchData } = useTradeAmounts()
   const { checkApprovalNeeded, getTrade, bestTradeSwapper } = useSwapper()
@@ -83,7 +87,9 @@ export const TradeInput = () => {
     selectPortfolioCryptoHumanBalanceByFilter(state, sellAssetBalanceFilter),
   )
 
-  const isSwapperApiLoading = useSelector(selectSwapperApiPending)
+  const isSwapperApiPending = useSelector(selectSwapperApiPending)
+  const isTradeQuotePending = useSelector(selectSwapperApiTradeQuotePending)
+  const isUsdRatesPending = useSelector(selectSwapperApiUsdRatesPending)
 
   // Constants
   const walletSupportsSellAssetChain =
@@ -105,17 +111,11 @@ export const TradeInput = () => {
       setValue('amount', amount)
       setValue('action', action)
 
-      isLoadingFiatRateData || isLoadingTradeQuote
+      isSwapperApiPending
         ? await setTradeAmountsRefetchData({ amount, action })
         : setTradeAmountsUsingExistingData({ amount, action })
     },
-    [
-      isLoadingFiatRateData,
-      isLoadingTradeQuote,
-      setTradeAmountsUsingExistingData,
-      setTradeAmountsRefetchData,
-      setValue,
-    ],
+    [isSwapperApiPending, setTradeAmountsUsingExistingData, setTradeAmountsRefetchData, setValue],
   )
 
   const handleToggle = useCallback(async () => {
@@ -234,11 +234,11 @@ export const TradeInput = () => {
         toBaseUnit(bnOrZero(sellTradeAsset?.amount), sellTradeAsset?.asset?.precision || 0),
       ).lt(minSellAmount) &&
       hasValidSellAmount &&
-      !isLoadingTradeQuote
+      !isTradeQuotePending
     const feesExceedsSellAmount =
       bnOrZero(sellTradeAsset?.amount).isGreaterThan(0) &&
       bnOrZero(buyTradeAsset?.amount).isLessThanOrEqualTo(0) &&
-      !isLoadingTradeQuote
+      !isTradeQuotePending
 
     if (!wallet) return 'common.connectWallet'
     if (!walletSupportsSellAssetChain)
@@ -266,7 +266,7 @@ export const TradeInput = () => {
     feeAssetBalance,
     quote,
     hasValidSellAmount,
-    isLoadingTradeQuote,
+    isTradeQuotePending,
     buyTradeAsset,
     wallet,
     walletSupportsSellAssetChain,
@@ -295,8 +295,8 @@ export const TradeInput = () => {
             onMaxClick={handleSendMax}
             onAssetClick={() => history.push(TradeRoutePaths.SellSelect)}
             onAccountIdChange={handleSellAccountIdChange}
-            showFiatAmount={!isLoadingFiatRateData}
-            showFiatSkeleton={isLoadingFiatRateData || isLoadingTradeQuote}
+            showFiatAmount={!isUsdRatesPending}
+            showFiatSkeleton={isUsdRatesPending || isTradeQuotePending}
           />
           <Stack justifyContent='center' alignItems='center'>
             <IconButton
@@ -328,8 +328,8 @@ export const TradeInput = () => {
             percentOptions={[1]}
             onAssetClick={() => history.push(TradeRoutePaths.BuySelect)}
             onAccountIdChange={handleBuyAccountIdChange}
-            showInputSkeleton={isLoadingFiatRateData || isLoadingTradeQuote}
-            showFiatSkeleton={isLoadingFiatRateData || isLoadingTradeQuote}
+            showInputSkeleton={isSwapperApiPending}
+            showFiatSkeleton={isSwapperApiPending}
           />
         </Stack>
         <Stack boxShadow='sm' p={4} borderColor={borderColor} borderRadius='xl' borderWidth={1}>
@@ -338,12 +338,12 @@ export const TradeInput = () => {
             buySymbol={buyTradeAsset?.asset?.symbol}
             gasFee={gasFee}
             rate={quote?.rate}
-            isLoading={isSwapperApiLoading}
+            isLoading={isSwapperApiPending}
             isError={!walletSupportsTradeAssetChains}
           />
           {walletSupportsTradeAssetChains ? (
             <ReceiveSummary
-              isLoading={!quote || isSwapperApiLoading}
+              isLoading={!quote || isSwapperApiPending}
               symbol={buyTradeAsset?.asset?.symbol ?? ''}
               amount={buyTradeAsset?.amount ?? ''}
               beforeFees={tradeAmountConstants?.buyAmountBeforeFees ?? ''}
@@ -357,13 +357,7 @@ export const TradeInput = () => {
           type='submit'
           colorScheme={hasError ? 'red' : 'blue'}
           size='lg'
-          isDisabled={
-            hasError ||
-            isLoadingFiatRateData ||
-            isLoadingTradeQuote ||
-            !hasValidSellAmount ||
-            !quote
-          }
+          isDisabled={hasError || isSwapperApiPending || !hasValidSellAmount || !quote}
           isLoading={isLoading}
         >
           <Text translation={getTranslationKey()} />

--- a/src/components/Trade/hooks/useSwapperService.tsx
+++ b/src/components/Trade/hooks/useSwapperService.tsx
@@ -8,10 +8,8 @@ The Swapper Service is responsible for reacting to changes to the Trade form and
 */
 export const useSwapperService = () => {
   // Initialize child services
-  const { isLoadingFiatRateData } = useFiatRateService()
-  const { isLoadingTradeQuote } = useTradeQuoteService()
+  useFiatRateService()
+  useTradeQuoteService()
   useFeesService()
   useAccountsService()
-
-  return { isLoadingTradeQuote, isLoadingFiatRateData }
 }

--- a/src/components/Trade/hooks/useTradeAmounts.tsx
+++ b/src/components/Trade/hooks/useTradeAmounts.tsx
@@ -157,7 +157,11 @@ export const useTradeAmounts = () => {
         sellAssetId: sellAssetIdToUse,
       })
 
-      if (!bestTradeSwapper) return
+      if (!bestTradeSwapper) {
+        setValue('quote', undefined)
+        setValue('fees', undefined)
+        return
+      }
       const state = store.getState()
       const sellAssetAccountIds = selectPortfolioAccountIdsByAssetId(state, {
         assetId: sellAsset.assetId,
@@ -184,7 +188,7 @@ export const useTradeAmounts = () => {
         ? await dispatch(getTradeQuote.initiate(tradeQuoteArgs))
         : undefined
 
-      quoteResponse?.data ? setValue('quote', quoteResponse.data) : setValue('quote', undefined)
+      setValue('quote', quoteResponse?.data)
 
       // If we can't get a quote our trade fee will be 0 - this is likely not desired long-term
       const formFees = quoteResponse?.data
@@ -206,7 +210,7 @@ export const useTradeAmounts = () => {
         }),
       )
 
-      usdRates &&
+      if (usdRates) {
         setTradeAmounts({
           amount: amountToUse,
           action: actionToUse,
@@ -218,6 +222,11 @@ export const useTradeAmounts = () => {
           buyAssetTradeFeeUsd: bnOrZero(formFees?.buyAssetTradeFeeUsd),
           sellAssetTradeFeeUsd: bnOrZero(formFees?.sellAssetTradeFeeUsd),
         })
+      } else {
+        setValue('sellAssetFiatRate', undefined)
+        setValue('buyAssetFiatRate', undefined)
+        setValue('feeAssetFiatRate', undefined)
+      }
     },
     [
       actionFormState,

--- a/src/components/Trade/hooks/useTradeQuoteService.tsx
+++ b/src/components/Trade/hooks/useTradeQuoteService.tsx
@@ -172,7 +172,7 @@ export const useTradeQuoteService = () => {
 
   // Set trade quote
   useEffect(() => {
-    tradeQuote && setValue('quote', tradeQuote)
+    setValue('quote', tradeQuote)
   }, [tradeQuote, setValue])
 
   return { isLoadingTradeQuote }

--- a/src/components/Trade/hooks/useTradeRoutes/useTradeRoutes.tsx
+++ b/src/components/Trade/hooks/useTradeRoutes/useTradeRoutes.tsx
@@ -49,6 +49,10 @@ export const useTradeRoutes = (): {
       setValue('buyTradeAsset.amount', '0')
       setValue('fiatBuyAmount', '0')
       setValue('fiatSellAmount', '0')
+      setValue('quote', undefined)
+      setValue('sellAssetFiatRate', undefined)
+      setValue('buyAssetFiatRate', undefined)
+      setValue('feeAssetFiatRate', undefined)
 
       history.push(TradeRoutePaths.Input)
 

--- a/src/state/apis/swapper/selectors.ts
+++ b/src/state/apis/swapper/selectors.ts
@@ -2,3 +2,13 @@ import type { ReduxState } from 'state/reducer'
 
 export const selectSwapperApiPending = (state: ReduxState) =>
   Object.values(state.swapperApi.queries).some(query => query?.status === 'pending')
+
+export const selectSwapperApiTradeQuotePending = (state: ReduxState) =>
+  Object.values(state.swapperApi.queries).some(
+    query => query?.endpointName === 'getTradeQuote' && query?.status === 'pending',
+  )
+
+export const selectSwapperApiUsdRatesPending = (state: ReduxState) =>
+  Object.values(state.swapperApi.queries).some(
+    query => query?.endpointName === 'getUsdRates' && query?.status === 'pending',
+  )

--- a/src/state/apis/swapper/selectors.ts
+++ b/src/state/apis/swapper/selectors.ts
@@ -1,0 +1,4 @@
+import type { ReduxState } from 'state/reducer'
+
+export const selectSwapperApiPending = (state: ReduxState) =>
+  Object.values(state.swapperApi.queries).some(query => query?.status === 'pending')

--- a/src/state/reducer.ts
+++ b/src/state/reducer.ts
@@ -37,6 +37,7 @@ export const sliceReducers = {
   preferences: persistReducer(preferencesPersistConfig, preferences.reducer),
   accountSpecifiers: accountSpecifiers.reducer,
   validatorData: validatorData.reducer,
+  swapperApi: swapperApi.reducer,
 }
 
 export const apiSlices = {


### PR DESCRIPTION
## Description

The `isLoading` property of an RTK query hook only returns the state of the instantiation in the current context.
As an RTK query can be called from anywhere in the app, we need to have a global way of knowing if we are waiting for a response from an endpoint.

By using the API's reducer we can query the global state of the API as a whole, or an individual endpoint.

Also clears quote + rate data when we can't get a response, and when changing assets, to ensure we aren't left with stale data.

## Notice

- [x] Have you followed the guidelines in our [Contributing]('https://github.com/shapeshift/web/blob/develop/CONTRIBUTING.md) guide?
- [x] Have you checked to ensure there aren't other open [Pull Requests](https://github.com/shapeshift/web/pulls) for the same update/change?

## Pull Request Type

- [ ] :bug: Bug fix (Non-breaking Change: Fixes an issue)
- [x] :hammer_and_wrench: Chore (Non-breaking Change: Doc updates, pkg upgrades, typos, etc..)
- [ ] :nail_care: New Feature (Breaking/Non-breaking Change)

## Issue (if applicable)

N/A - swapper improvements.

## Risk

Minimal - only affects loading state UI.

## Testing

When we are getting a quote or rates, the swapper should show appropriate loading states.
A significant improvement here is that we should no longer see the "Rate not available" show before getting a rate, as we now correctly understand when we are searching for rates.

### Engineering

TODO

### Operations

TODO

## Screenshots (if applicable)

N/A