### PR TITLE
fix: clear quote & rates on failure or asset change

### DIFF
--- a/src/components/Trade/Trade.tsx
+++ b/src/components/Trade/Trade.tsx
@@ -7,6 +7,7 @@ import { MemoryRouter, Route, Switch } from 'react-router-dom'
 import { useDefaultAssets } from './hooks/useDefaultAssets'
 import { entries, TradeRoutes } from './TradeRoutes/TradeRoutes'
 import type { TS } from './types'
+import { TradeAmountInputField } from './types'
 
 export type TradeProps = {
   defaultBuyAssetId?: AssetId
@@ -27,6 +28,7 @@ export const Trade = ({ defaultBuyAssetId }: TradeProps) => {
       buyTradeAsset: { amount: '0', asset: buyAsset },
       isExactAllowance: false,
       slippage: 0.002,
+      action: TradeAmountInputField.SELL_CRYPTO,
     },
   })
 

--- a/src/components/Trade/hooks/useTradeAmounts.tsx
+++ b/src/components/Trade/hooks/useTradeAmounts.tsx
@@ -200,7 +200,7 @@ export const useTradeAmounts = () => {
           })
         : undefined
 
-      formFees ? setValue('fees', formFees) : setValue('fees', undefined)
+      setValue('fees', formFees)
 
       const { data: usdRates } = await dispatch(
         getUsdRates.initiate({

--- a/src/components/Trade/hooks/useTradeAmounts.tsx
+++ b/src/components/Trade/hooks/useTradeAmounts.tsx
@@ -157,7 +157,11 @@ export const useTradeAmounts = () => {
         sellAssetId: sellAssetIdToUse,
       })
 
-      if (!bestTradeSwapper) return
+      if (!bestTradeSwapper) {
+        setValue('quote', undefined)
+        setValue('fees', undefined)
+        return
+      }
       const state = store.getState()
       const sellAssetAccountIds = selectPortfolioAccountIdsByAssetId(state, {
         assetId: sellAsset.assetId,
@@ -184,7 +188,7 @@ export const useTradeAmounts = () => {
         ? await dispatch(getTradeQuote.initiate(tradeQuoteArgs))
         : undefined
 
-      quoteResponse?.data ? setValue('quote', quoteResponse.data) : setValue('quote', undefined)
+      setValue('quote', quoteResponse?.data)
 
       // If we can't get a quote our trade fee will be 0 - this is likely not desired long-term
       const formFees = quoteResponse?.data
@@ -206,7 +210,7 @@ export const useTradeAmounts = () => {
         }),
       )
 
-      usdRates &&
+      if (usdRates) {
         setTradeAmounts({
           amount: amountToUse,
           action: actionToUse,
@@ -218,6 +222,11 @@ export const useTradeAmounts = () => {
           buyAssetTradeFeeUsd: bnOrZero(formFees?.buyAssetTradeFeeUsd),
           sellAssetTradeFeeUsd: bnOrZero(formFees?.sellAssetTradeFeeUsd),
         })
+      } else {
+        setValue('sellAssetFiatRate', undefined)
+        setValue('buyAssetFiatRate', undefined)
+        setValue('feeAssetFiatRate', undefined)
+      }
     },
     [
       actionFormState,

--- a/src/components/Trade/hooks/useTradeQuoteService.tsx
+++ b/src/components/Trade/hooks/useTradeQuoteService.tsx
@@ -172,7 +172,7 @@ export const useTradeQuoteService = () => {
 
   // Set trade quote
   useEffect(() => {
-    tradeQuote && setValue('quote', tradeQuote)
+    setValue('quote', tradeQuote)
   }, [tradeQuote, setValue])
 
   return { isLoadingTradeQuote }

--- a/src/components/Trade/hooks/useTradeRoutes/useTradeRoutes.tsx
+++ b/src/components/Trade/hooks/useTradeRoutes/useTradeRoutes.tsx
@@ -49,6 +49,10 @@ export const useTradeRoutes = (): {
       setValue('buyTradeAsset.amount', '0')
       setValue('fiatBuyAmount', '0')
       setValue('fiatSellAmount', '0')
+      setValue('quote', undefined)
+      setValue('sellAssetFiatRate', undefined)
+      setValue('buyAssetFiatRate', undefined)
+      setValue('feeAssetFiatRate', undefined)
 
       history.push(TradeRoutePaths.Input)
 


### PR DESCRIPTION
## Description

This PR ensures that quote and rates are cleared when assets are changed (as they are no longer valid at this time).

## Notice

- [x] Have you followed the guidelines in our [Contributing]('https://github.com/shapeshift/web/blob/develop/CONTRIBUTING.md) guide?
- [x] Have you checked to ensure there aren't other open [Pull Requests](https://github.com/shapeshift/web/pulls) for the same update/change?

## Pull Request Type

- [x] :bug: Bug fix (Non-breaking Change: Fixes an issue)
- [ ] :hammer_and_wrench: Chore (Non-breaking Change: Doc updates, pkg upgrades, typos, etc..)
- [ ] :nail_care: New Feature (Breaking/Non-breaking Change)

## Issue (if applicable)

N/A - general swapper housekeeping.

## Risk

Minimal - any bugs that are surfaced from this PR likely already existed, and are now exposed by it.

## Testing

We should still always have quotes when we expect to.

That said, this PR likely exposes issues with quote data which may have been fixed down the graphite stack - before rejecting this PR, please check state at the bottom of the stack to see if they have been resolved (yes, in hindsight this PR should have been at the bottom of the stack - derp.

### Engineering

As above.

### Operations

N/A

## Screenshots (if applicable)

N/A