### PR TITLE
feat: use selectors for swapperApi state

### DIFF
--- a/src/assets/translations/en/main.json
+++ b/src/assets/translations/en/main.json
@@ -489,6 +489,7 @@
     "free": "Free",
     "slowSwapTitle": "%{protocol} trade",
     "slowSwapBody": "This swap may take a few minutes to complete.",
+    "updatingQuote": "Updating quote...",
     "tooltip": {
       "rate": "This is the expected rate for this trade pair.",
       "noRateAvailable": "This is often due to very limited or no liquidity on the trade pair.",

--- a/src/components/Trade/TradeInputV2.tsx
+++ b/src/components/Trade/TradeInputV2.tsx
@@ -91,6 +91,14 @@ export const TradeInput = () => {
   const isTradeQuotePending = useSelector(selectSwapperApiTradeQuotePending)
   const isUsdRatesPending = useSelector(selectSwapperApiUsdRatesPending)
 
+  const quoteAvailableForCurrentAssetPair = useMemo(() => {
+    if (!quote) return false
+    return (
+      quote.buyAsset?.assetId === buyTradeAsset?.asset?.assetId &&
+      quote.sellAsset?.assetId === sellTradeAsset?.asset?.assetId
+    )
+  }, [buyTradeAsset?.asset?.assetId, quote, sellTradeAsset?.asset?.assetId])
+
   // Constants
   const walletSupportsSellAssetChain =
     sellTradeAsset?.asset?.chainId &&
@@ -295,8 +303,7 @@ export const TradeInput = () => {
             onMaxClick={handleSendMax}
             onAssetClick={() => history.push(TradeRoutePaths.SellSelect)}
             onAccountIdChange={handleSellAccountIdChange}
-            showFiatAmount={!isUsdRatesPending}
-            showFiatSkeleton={isUsdRatesPending || isTradeQuotePending}
+            showFiatSkeleton={isUsdRatesPending}
           />
           <Stack justifyContent='center' alignItems='center'>
             <IconButton
@@ -328,8 +335,8 @@ export const TradeInput = () => {
             percentOptions={[1]}
             onAssetClick={() => history.push(TradeRoutePaths.BuySelect)}
             onAccountIdChange={handleBuyAccountIdChange}
-            showInputSkeleton={isSwapperApiPending}
-            showFiatSkeleton={isSwapperApiPending}
+            showInputSkeleton={isSwapperApiPending && !quoteAvailableForCurrentAssetPair}
+            showFiatSkeleton={isSwapperApiPending && !quoteAvailableForCurrentAssetPair}
           />
         </Stack>
         <Stack boxShadow='sm' p={4} borderColor={borderColor} borderRadius='xl' borderWidth={1}>
@@ -338,12 +345,12 @@ export const TradeInput = () => {
             buySymbol={buyTradeAsset?.asset?.symbol}
             gasFee={gasFee}
             rate={quote?.rate}
-            isLoading={isSwapperApiPending}
+            isLoading={isSwapperApiPending && !quoteAvailableForCurrentAssetPair}
             isError={!walletSupportsTradeAssetChains}
           />
           {walletSupportsTradeAssetChains ? (
             <ReceiveSummary
-              isLoading={!quote || isSwapperApiPending}
+              isLoading={!quoteAvailableForCurrentAssetPair && isSwapperApiPending}
               symbol={buyTradeAsset?.asset?.symbol ?? ''}
               amount={buyTradeAsset?.amount ?? ''}
               beforeFees={tradeAmountConstants?.buyAmountBeforeFees ?? ''}

--- a/src/components/Trade/hooks/useSwapperService.tsx
+++ b/src/components/Trade/hooks/useSwapperService.tsx
@@ -8,10 +8,8 @@ The Swapper Service is responsible for reacting to changes to the Trade form and
 */
 export const useSwapperService = () => {
   // Initialize child services
-  const { isLoadingFiatRateData } = useFiatRateService()
-  const { isLoadingTradeQuote } = useTradeQuoteService()
+  useFiatRateService()
+  useTradeQuoteService()
   useFeesService()
   useAccountsService()
-
-  return { isLoadingTradeQuote, isLoadingFiatRateData }
 }

--- a/src/components/Trade/hooks/useTradeAmounts.tsx
+++ b/src/components/Trade/hooks/useTradeAmounts.tsx
@@ -188,8 +188,6 @@ export const useTradeAmounts = () => {
         ? await dispatch(getTradeQuote.initiate(tradeQuoteArgs))
         : undefined
 
-      setValue('quote', quoteResponse?.data)
-
       // If we can't get a quote our trade fee will be 0 - this is likely not desired long-term
       const formFees = quoteResponse?.data
         ? getFormFees({
@@ -200,8 +198,6 @@ export const useTradeAmounts = () => {
           })
         : undefined
 
-      setValue('fees', formFees)
-
       const { data: usdRates } = await dispatch(
         getUsdRates.initiate({
           buyAssetId: buyAssetIdToUse,
@@ -211,6 +207,8 @@ export const useTradeAmounts = () => {
       )
 
       if (usdRates) {
+        setValue('quote', quoteResponse?.data)
+        setValue('fees', formFees)
         setTradeAmounts({
           amount: amountToUse,
           action: actionToUse,

--- a/src/state/apis/swapper/selectors.ts
+++ b/src/state/apis/swapper/selectors.ts
@@ -1,0 +1,14 @@
+import type { ReduxState } from 'state/reducer'
+
+export const selectSwapperApiPending = (state: ReduxState) =>
+  Object.values(state.swapperApi.queries).some(query => query?.status === 'pending')
+
+export const selectSwapperApiTradeQuotePending = (state: ReduxState) =>
+  Object.values(state.swapperApi.queries).some(
+    query => query?.endpointName === 'getTradeQuote' && query?.status === 'pending',
+  )
+
+export const selectSwapperApiUsdRatesPending = (state: ReduxState) =>
+  Object.values(state.swapperApi.queries).some(
+    query => query?.endpointName === 'getUsdRates' && query?.status === 'pending',
+  )

--- a/src/state/reducer.ts
+++ b/src/state/reducer.ts
@@ -37,6 +37,7 @@ export const sliceReducers = {
   preferences: persistReducer(preferencesPersistConfig, preferences.reducer),
   accountSpecifiers: accountSpecifiers.reducer,
   validatorData: validatorData.reducer,
+  swapperApi: swapperApi.reducer,
 }
 
 export const apiSlices = {


### PR DESCRIPTION
## Description

The `isLoading` property of an RTK query hook only returns the state of the instantiation in the current context.
As an RTK query can be called from anywhere in the app, we need to have a global way of knowing if we are waiting for a response from an endpoint.

By using the API's reducer we can query the global state of the API as a whole, or an individual endpoint.

## Notice

- [x] Have you followed the guidelines in our [Contributing]('https://github.com/shapeshift/web/blob/develop/CONTRIBUTING.md) guide?
- [x] Have you checked to ensure there aren't other open [Pull Requests](https://github.com/shapeshift/web/pulls) for the same update/change?

## Pull Request Type

- [ ] :bug: Bug fix (Non-breaking Change: Fixes an issue)
- [x] :hammer_and_wrench: Chore (Non-breaking Change: Doc updates, pkg upgrades, typos, etc..)
- [ ] :nail_care: New Feature (Breaking/Non-breaking Change)

## Issue (if applicable)

N/A - swapper improvements.

## Risk

Minimal - only affects loading state UI.

## Testing

When we are getting a quote or rates, the swapper should show appropriate loading states.

The main improvement here is that we should no longer see the "Rate not available" show before getting a rate, as we now correctly understand when we are searching for rates.

In addition, trade quotes refresh when the trade amounts change, so an "Updating quote..." state is now shown.

### Engineering

As above.

### Operations

As above.

## Screenshots (if applicable)

N/A