### PR TITLE
fix: missing pendo tag on preview trade v2

### DIFF
--- a/src/components/Trade/TradeInputV2.tsx
+++ b/src/components/Trade/TradeInputV2.tsx
@@ -380,6 +380,7 @@ export const TradeInput = () => {
           type='submit'
           colorScheme={hasError ? 'red' : 'blue'}
           size='lg'
+          data-test='trade-form-preview-button'
           isDisabled={hasError || isSwapperApiPending || !hasValidSellAmount || !quote}
           isLoading={isLoading}
         >


### PR DESCRIPTION
## Description

- Added back the data-test tag for the new version of swapper preview trade

## Notice

<!-- Before submitting a pull request, please make sure you have answered the following: -->

- [x] Have you followed the guidelines in our [Contributing]('https://github.com/shapeshift/web/blob/develop/CONTRIBUTING.md) guide?
- [x] Have you checked to ensure there aren't other open [Pull Requests](https://github.com/shapeshift/web/pulls) for the same update/change?

## Pull Request Type

- [x] :bug: Bug fix (Non-breaking Change: Fixes an issue)
- [ ] :hammer_and_wrench: Chore (Non-breaking Change: Doc updates, pkg upgrades, typos, etc..)
- [ ] :nail_care: New Feature (Breaking/Non-breaking Change)

## Issue (if applicable)

n/a

## Risk

no risk

## Testing



### Engineering

n/a

### Operations

n/a

## Screenshots (if applicable)
