### PR TITLE
fix: adds required wallet nickname for mobile wallets

### DIFF
--- a/src/assets/translations/en/main.json
+++ b/src/assets/translations/en/main.json
@@ -613,6 +613,7 @@
         "error": {
           "invalid": "Invalid Password",
           "required": "Password is required",
+          "walletNameRequired": "Wallet nickname is required",
           "length": "Your password must be at least %{length} characters",
           "maxLength": "Nickname must be %{length} characters maximum"
         }

--- a/src/context/WalletProvider/MobileWallet/components/MobileImport.tsx
+++ b/src/context/WalletProvider/MobileWallet/components/MobileImport.tsx
@@ -90,6 +90,7 @@ export const MobileImport = ({ history }: RouteComponentProps) => {
           <FormControl mb={6} isInvalid={Boolean(errors.name)}>
             <Input
               {...register('name', {
+                required: translate('modals.shapeShift.password.error.walletNameRequired'),
                 maxLength: {
                   value: 64,
                   message: translate('modals.shapeShift.password.error.maxLength', { length: 64 }),


### PR DESCRIPTION
## Description

Forces mobile wallets being imported to have a nickname 

## Notice

<!-- Before submitting a pull request, please make sure you have answered the following: -->

- [x] Have you followed the guidelines in our [Contributing]('https://github.com/shapeshift/web/blob/develop/CONTRIBUTING.md) guide?
- [x] Have you checked to ensure there aren't other open [Pull Requests](https://github.com/shapeshift/web/pulls) for the same update/change?

## Pull Request Type

- [x] :bug: Bug fix (Non-breaking Change: Fixes an issue)
- [ ] :hammer_and_wrench: Chore (Non-breaking Change: Doc updates, pkg upgrades, typos, etc..)
- [ ] :nail_care: New Feature (Breaking/Non-breaking Change)

## Issue (if applicable)
closes #2929 

## Risk

Low risk - only should affect mobile flows 

## Testing

- no changes to the optional nickname when importing a native wallet on desktop or mobile web
- requires a name for importing a native wallet on mobile app

### Engineering

<!-----------------------------------------------------------------------------
Include sufficient information here for an engineer to test your PR. This may include how to test locally, in a built environment, changes to infrastructure etc.
------------------------------------------------------------------------------>

### Operations

<!-----------------------------------------------------------------------------
If your changes have a user-facing impact, describe how a non-technical QA team can functionally test your changes in a preview environment.

If they are not user-facing please describe how to test for any regressions that may occur.
------------------------------------------------------------------------------>

## Screenshots (if applicable)
<img width="443" alt="Screen Shot 2022-10-03 at 12 52 27 PM" src="https://user-images.githubusercontent.com/15096737/193655847-a1808c56-1a5d-421a-a1da-22a3cca107ae.png">

