### PR TITLE
fix: partially unrug max button

### DIFF
--- a/src/components/Trade/hooks/useTradeQuoteService.tsx
+++ b/src/components/Trade/hooks/useTradeQuoteService.tsx
@@ -59,7 +59,7 @@ export const getTradeQuoteArgs = async ({
       bip44Params: sellAccountBip44Params,
     }
   } else if (isSupportedUtxoSwappingChain(sellAsset?.chainId)) {
-    if (!sellAccountType) throw new Error('no accountType')
+    if (!sellAccountType) return
     const sellAssetChainAdapter = getChainAdapterManager().get(
       sellAsset.chainId,
     ) as unknown as UtxoBaseAdapter<UtxoSupportedChainIds>


### PR DESCRIPTION
## Description

<!-- Please describe your changes -->

we were getting in a state where we had the option to throw, or return undefined, which was already
part of a valid type signature when hitting send max with a new quote

throwing would put us into an unrecoverable state where the send max button would remain disabled

returning early here allows the send max button to become enabled again when the dependencies of
this function are updated

## Notice

<!-- Before submitting a pull request, please make sure you have answered the following: -->

- [x] Have you followed the guidelines in our [Contributing]('https://github.com/shapeshift/web/blob/develop/CONTRIBUTING.md) guide?
- [x] Have you checked to ensure there aren't other open [Pull Requests](https://github.com/shapeshift/web/pulls) for the same update/change?

## Pull Request Type

- [x] :bug: Bug fix (Non-breaking Change: Fixes an issue)
- [ ] :hammer_and_wrench: Chore (Non-breaking Change: Doc updates, pkg upgrades, typos, etc..)
- [ ] :nail_care: New Feature (Breaking/Non-breaking Change)

## Issue (if applicable)

<!-----------------------------------------------------------------------------
If applicable, please link to the github issue and put `closes #XXXX` in your comment to auto-close the issue that your PR fixes.
------------------------------------------------------------------------------>

n/a - noticed while testing

## Risk

* this has an unintentional effect and makes things worse, isolated entirely to send max on swapper
  v2

<!-----------------------------------------------------------------------------
Outline the scope of your changes and the risk associated with them. You must use your discretion as an engineer to determine the potential impact of your changes.

E.g. an upgrade to `hdwallet` or core state management would be considered higher risk, and might require a full regression test. UI or isolated view changes, or something behind a feature flag may have near zero risk. Small bug fixes might require testing isolated to the specific fix.
------------------------------------------------------------------------------>

## Testing

* you should not see the `Max` button on the sell asset get stuck in a disabled state after a new
  quote is fetched, i.e. after you change a buy or sell asset or amount

<!-----------------------------------------------------------------------------
We treat every PR to be merged with the same scrutiny as if we were merging directly to production.

Your PR will not be merged if you do not complete the sections below for our engineering and operations teams to test.
------------------------------------------------------------------------------>

### Engineering

* see common steps

<!-----------------------------------------------------------------------------
Include sufficient information here for an engineer to test your PR. This may include how to test locally, in a built environment, changes to infrastructure etc.
------------------------------------------------------------------------------>

### Operations

* see common steps

<!-----------------------------------------------------------------------------
If your changes have a user-facing impact, describe how a non-technical QA team can functionally test your changes in a preview environment.

If they are not user-facing please describe how to test for any regressions that may occur.
------------------------------------------------------------------------------>

## Screenshots (if applicable)
