### PR TITLE
fix: update trade loading state and dropdown placement 

### DIFF
--- a/src/components/DeFi/components/AssetInput.tsx
+++ b/src/components/DeFi/components/AssetInput.tsx
@@ -1,5 +1,5 @@
 import { ChevronDownIcon } from '@chakra-ui/icons'
-import type { InputProps } from '@chakra-ui/react'
+import type { FormControlProps, InputProps } from '@chakra-ui/react'
 import {
   Button,
   FormControl,
@@ -36,13 +36,14 @@ const CryptoInput = (props: InputProps) => (
     size='lg'
     fontSize='xl'
     borderRadius={0}
-    py={1}
+    py={0}
     height='auto'
     type='number'
     textAlign='right'
     variant='inline'
     placeholder='Enter amount'
     style={{ caretColor: colors.blue[200] }}
+    autocomplete='off'
     {...props}
   />
 )
@@ -68,6 +69,7 @@ export type AssetInputProps = {
   onAccountIdChange?: AccountDropdownProps['onChange']
   showInputSkeleton?: boolean
   showFiatSkeleton?: boolean
+  formControlProps?: FormControlProps
 } & PropsWithChildren
 
 export const AssetInput: React.FC<AssetInputProps> = ({
@@ -92,6 +94,7 @@ export const AssetInput: React.FC<AssetInputProps> = ({
   onAccountIdChange: handleAccountIdChange,
   showInputSkeleton,
   showFiatSkeleton,
+  formControlProps,
 }) => {
   const {
     number: { localeParts },
@@ -119,7 +122,9 @@ export const AssetInput: React.FC<AssetInputProps> = ({
       borderRadius='xl'
       _hover={{ bg: isReadOnly ? bgColor : focusBg }}
       isInvalid={!!errors}
-      py={2}
+      pt={3}
+      pb={2}
+      {...formControlProps}
     >
       <Stack direction='row' alignItems='center' px={4}>
         <Button
@@ -167,20 +172,23 @@ export const AssetInput: React.FC<AssetInputProps> = ({
         </Stack>
       </Stack>
 
-      {showFiatAmount && !showFiatSkeleton && (
-        <Stack width='full' alignItems='flex-end' px={4} pb={2}>
+      {showFiatAmount && (
+        <Stack width='full' alignItems='flex-end' px={4} pb={2} mt={1}>
           <Button
             onClick={toggleIsFiat}
             size='xs'
+            disabled={showFiatSkeleton}
             fontWeight='medium'
             variant='link'
             color='gray.500'
           >
-            {isFiat ? (
-              <Amount.Crypto value={cryptoAmount ?? ''} symbol={assetSymbol} />
-            ) : (
-              <Amount.Fiat value={fiatAmount ?? ''} prefix='≈' />
-            )}
+            <Skeleton isLoaded={!showFiatSkeleton}>
+              {isFiat ? (
+                <Amount.Crypto value={cryptoAmount ?? ''} symbol={assetSymbol} />
+              ) : (
+                <Amount.Fiat value={fiatAmount ?? ''} prefix='≈' />
+              )}
+            </Skeleton>
           </Button>
         </Stack>
       )}

--- a/src/components/Modals/FiatRamps/components/FiatRampButton.tsx
+++ b/src/components/Modals/FiatRamps/components/FiatRampButton.tsx
@@ -71,9 +71,9 @@ export const FiatRampButton: React.FC<FiatRampButtonProps> = ({
       >
         <Flex
           flex={1}
-          flexDirection={['column', 'row']}
+          flexWrap='wrap'
           justifyContent='space-between'
-          alignItems={['baseline', 'center']}
+          alignItems='center'
           gap={['1em', 0]}
           width='100%'
         >
@@ -84,9 +84,7 @@ export const FiatRampButton: React.FC<FiatRampButtonProps> = ({
               <Text translation={info ?? ''} />
             </Box>
           </Flex>
-          <Flex display={['none', 'flex']} gap={2}>
-            {renderTags}
-          </Flex>
+          <Flex gap={2}>{renderTags}</Flex>
         </Flex>
       </Button>
     </Tooltip>

--- a/src/components/Modals/Receive/ReceiveInfo.tsx
+++ b/src/components/Modals/Receive/ReceiveInfo.tsx
@@ -179,6 +179,12 @@ export const ReceiveInfo = ({ asset, accountId }: ReceivePropsType) => {
                 />
               </SkeletonText>
             </Box>
+            <AccountDropdown
+              assetId={asset.assetId}
+              defaultAccountId={selectedAccountId || undefined}
+              onChange={setSelectedAccountId}
+              buttonProps={{ variant: 'solid', width: 'full', mt: 4 }}
+            />
             <Flex justifyContent='center'>
               {ensReceiveAddress && (
                 <Tag bg={bg} borderRadius='full' color='gray.500' mt={8} pl={4} pr={4}>
@@ -186,6 +192,7 @@ export const ReceiveInfo = ({ asset, accountId }: ReceivePropsType) => {
                 </Tag>
               )}
             </Flex>
+
             <Card
               variant='unstyled'
               borderRadius='xl'
@@ -199,12 +206,6 @@ export const ReceiveInfo = ({ asset, accountId }: ReceivePropsType) => {
             >
               <Card.Body display='inline-block' textAlign='center' p={6}>
                 <LightMode>
-                  <AccountDropdown
-                    assetId={asset.assetId}
-                    defaultAccountId={selectedAccountId || undefined}
-                    onChange={setSelectedAccountId}
-                    buttonProps={{ variant: 'solid', width: 'full' }}
-                  />
                   <Skeleton isLoaded={!!receiveAddress} mb={2}>
                     <QRCode text={receiveAddress} data-test='receive-qr-code' />
                   </Skeleton>


### PR DESCRIPTION
## Description

- Move account dropdown out of QR code so its more visible
- Fix skeleton loading to keep the trade widget from jumping around
- Disable auto-complete on asset input's input field

## Notice

<!-- Before submitting a pull request, please make sure you have answered the following: -->

- [x] Have you followed the guidelines in our [Contributing]('https://github.com/shapeshift/web/blob/develop/CONTRIBUTING.md) guide?
- [x] Have you checked to ensure there aren't other open [Pull Requests](https://github.com/shapeshift/web/pulls) for the same update/change?

## Pull Request Type

- [x] :bug: Bug fix (Non-breaking Change: Fixes an issue)
- [ ] :hammer_and_wrench: Chore (Non-breaking Change: Doc updates, pkg upgrades, typos, etc..)
- [ ] :nail_care: New Feature (Breaking/Non-breaking Change)

## Issue (if applicable)

n/a

## Risk

no real risk, mostly just visual changes

## Testing



### Engineering

n/a

### Operations

With multi account flag on, go to receive and see that the account drop has been moved out of the QR code.

The trade midget should not jump around in a loading state now as well.

## Screenshots (if applicable)

https://user-images.githubusercontent.com/89934888/193678507-10041b00-0d92-473b-9da0-32a31749ed52.mov

![Screen Shot 2022-10-03 at 3 42 18 PM](https://user-images.githubusercontent.com/89934888/193678542-be634f05-54f2-42a3-a8fa-2cdbee606ee1.png)
