### PR TITLE
fix: pass `sendMax` to `buildTrade` and `getTradeQuote`

### DIFF
--- a/package.json
+++ b/package.json
@@ -107,7 +107,7 @@
     "@shapeshiftoss/investor-yearn": "^6.1.2",
     "@shapeshiftoss/logger": "^1.1.3",
     "@shapeshiftoss/market-service": "^7.1.0",
-    "@shapeshiftoss/swapper": "^11.5.2",
+    "@shapeshiftoss/swapper": "^11.5.3",
     "@shapeshiftoss/types": "^8.3.1",
     "@shapeshiftoss/unchained-client": "^10.1.2",
     "@uniswap/sdk": "^3.0.3",

--- a/src/components/Trade/Trade.tsx
+++ b/src/components/Trade/Trade.tsx
@@ -29,6 +29,7 @@ export const Trade = ({ defaultBuyAssetId }: TradeProps) => {
       isExactAllowance: false,
       slippage: 0.002,
       action: TradeAmountInputField.SELL_CRYPTO,
+      isSendMax: false,
     },
   })
 

--- a/src/components/Trade/TradeInputV2.tsx
+++ b/src/components/Trade/TradeInputV2.tsx
@@ -37,7 +37,7 @@ import { RateGasRow } from './Components/RateGasRow'
 import type { TradeAssetInputProps } from './Components/TradeAssetInput'
 import { TradeAssetInput } from './Components/TradeAssetInput'
 import { ReceiveSummary } from './TradeConfirm/ReceiveSummary'
-import { type TradeState, TradeAmountInputField, TradeRoutePaths } from './types'
+import { TradeAmountInputField, TradeRoutePaths, type TradeState } from './types'
 
 const moduleLogger = logger.child({ namespace: ['TradeInput'] })
 
@@ -118,6 +118,8 @@ export const TradeInput = () => {
     async (action: TradeAmountInputField, amount: string) => {
       setValue('amount', amount)
       setValue('action', action)
+      // If we've overridden the input we are no longer in sendMax mode
+      setValue('isSendMax', false)
 
       if (isSwapperApiPending && !quoteAvailableForCurrentAssetPair) {
         await setTradeAmountsRefetchData({ amount, action })
@@ -157,7 +159,7 @@ export const TradeInput = () => {
     }
   }, [getValues, setValue])
 
-  const handleSendMax: TradeAssetInputProps['onMaxClick'] = useCallback(() => {
+  const handleSendMax: TradeAssetInputProps['onMaxClick'] = useCallback(async () => {
     if (!(sellTradeAsset?.asset && quote)) return
     const maxSendAmount = getSendMaxAmount(
       sellTradeAsset.asset,
@@ -168,17 +170,23 @@ export const TradeInput = () => {
     setValue('action', TradeAmountInputField.SELL_CRYPTO)
     setValue('sellTradeAsset.amount', maxSendAmount)
     setValue('amount', maxSendAmount)
+    setValue('isSendMax', true)
 
-    setTradeAmountsUsingExistingData({
+    // We need to get a fresh quote with the sendMax flag true
+    await setTradeAmountsRefetchData({
+      sellAssetId: sellTradeAsset.asset.assetId,
+      buyAssetId: buyTradeAsset?.asset?.assetId,
       amount: maxSendAmount,
       action: TradeAmountInputField.SELL_CRYPTO,
+      sendMax: true,
     })
   }, [
+    buyTradeAsset?.asset?.assetId,
     quote,
     sellAssetBalanceCrypto,
     sellFeeAsset,
     sellTradeAsset?.asset,
-    setTradeAmountsUsingExistingData,
+    setTradeAmountsRefetchData,
     setValue,
   ])
 

--- a/src/components/Trade/TradeInputV2.tsx
+++ b/src/components/Trade/TradeInputV2.tsx
@@ -37,7 +37,7 @@ import { RateGasRow } from './Components/RateGasRow'
 import type { TradeAssetInputProps } from './Components/TradeAssetInput'
 import { TradeAssetInput } from './Components/TradeAssetInput'
 import { ReceiveSummary } from './TradeConfirm/ReceiveSummary'
-import { TradeAmountInputField, TradeRoutePaths, type TradeState } from './types'
+import { type TradeState, TradeAmountInputField, TradeRoutePaths } from './types'
 
 const moduleLogger = logger.child({ namespace: ['TradeInput'] })
 

--- a/src/components/Trade/hooks/useSwapper/useSwapperV2.tsx
+++ b/src/components/Trade/hooks/useSwapper/useSwapperV2.tsx
@@ -39,6 +39,7 @@ export const useSwapper = () => {
   const quote = useWatch({ control, name: 'quote' })
   const sellAssetAccountId = useWatch({ control, name: 'sellAssetAccountId' })
   const buyAssetAccountId = useWatch({ control, name: 'buyAssetAccountId' })
+  const isSendMax = useWatch({ control, name: 'isSendMax' })
 
   // Constants
   const sellAsset = sellTradeAsset?.asset
@@ -141,7 +142,7 @@ export const useSwapper = () => {
       sellAsset: sellTradeAsset?.asset,
       buyAsset: buyTradeAsset?.asset,
       wallet,
-      sendMax: false,
+      sendMax: isSendMax,
       receiveAddress,
     }
     const sellAssetChainId = sellAsset.chainId
@@ -173,6 +174,7 @@ export const useSwapper = () => {
   }, [
     bestTradeSwapper,
     buyTradeAsset?.asset,
+    isSendMax,
     receiveAddress,
     sellAccountBip44Params,
     sellAsset,

--- a/src/components/Trade/hooks/useTradeAmounts.tsx
+++ b/src/components/Trade/hooks/useTradeAmounts.tsx
@@ -33,6 +33,7 @@ export const useTradeAmounts = () => {
   const feesFormState = useWatch({ control, name: 'fees' })
   const amountFormState = useWatch({ control, name: 'amount' })
   const actionFormState = useWatch({ control, name: 'action' })
+  const isSendMaxFormState = useWatch({ control, name: 'isSendMax' })
 
   const dispatch = useAppDispatch()
   const { swapperManager, getReceiveAddressFromBuyAsset } = useSwapper()
@@ -50,6 +51,7 @@ export const useTradeAmounts = () => {
     buyAssetId?: AssetId
     amount?: string
     action?: TradeAmountInputField
+    sendMax?: boolean
   }
   type SetTradeAmountsArgs = CalculateAmountsArgs
 
@@ -124,7 +126,13 @@ export const useTradeAmounts = () => {
   // Use the args provided to get new fiat rates and a fresh quote
   // Useful when changing assets where we expect response data to meaningfully change - so wait before updating amounts
   const setTradeAmountsRefetchData = useCallback(
-    async ({ sellAssetId, buyAssetId, amount, action }: SetTradeAmountsSynchronousArgs) => {
+    async ({
+      sellAssetId,
+      buyAssetId,
+      amount,
+      action,
+      sendMax,
+    }: SetTradeAmountsSynchronousArgs) => {
       // Eagerly update the input field to improve UX whilst we wait for API responses
       switch (action) {
         case TradeAmountInputField.SELL_FIAT:
@@ -182,6 +190,7 @@ export const useTradeAmounts = () => {
         wallet,
         receiveAddress,
         sellAmount: sellTradeAsset?.amount || amountToUse || '0',
+        isSendMax: sendMax ?? isSendMaxFormState,
       })
 
       const quoteResponse = tradeQuoteArgs
@@ -235,6 +244,7 @@ export const useTradeAmounts = () => {
       getReceiveAddressFromBuyAsset,
       getTradeQuote,
       getUsdRates,
+      isSendMaxFormState,
       selectedCurrencyToUsdRate,
       sellAssetFormState?.assetId,
       sellTradeAsset?.amount,

--- a/src/components/Trade/hooks/useTradeQuoteService.tsx
+++ b/src/components/Trade/hooks/useTradeQuoteService.tsx
@@ -33,6 +33,7 @@ type GetTradeQuoteInputArgs = {
   wallet: HDWallet
   receiveAddress: NonNullable<TS['receiveAddress']>
   sellAmount: string
+  isSendMax: boolean
 }
 
 export const getTradeQuoteArgs = async ({
@@ -43,13 +44,14 @@ export const getTradeQuoteArgs = async ({
   wallet,
   receiveAddress,
   sellAmount,
+  isSendMax,
 }: GetTradeQuoteInputArgs) => {
   if (!sellAsset || !buyAsset) return undefined
   const tradeQuoteInputCommonArgs: TradeQuoteInputCommonArgs = {
     sellAmount: toBaseUnit(sellAmount, sellAsset?.precision || 0),
     sellAsset,
     buyAsset,
-    sendMax: false,
+    sendMax: isSendMax,
     receiveAddress,
   }
   if (isSupportedNonUtxoSwappingChain(sellAsset?.chainId)) {
@@ -90,6 +92,7 @@ export const useTradeQuoteService = () => {
   const sellAssetAccountId = useWatch({ control, name: 'sellAssetAccountId' })
   const amount = useWatch({ control, name: 'amount' })
   const action = useWatch({ control, name: 'action' })
+  const isSendMax = useWatch({ control, name: 'isSendMax' })
 
   // Types
   type TradeQuoteQueryInput = Parameters<typeof useGetTradeQuoteQuery>
@@ -152,6 +155,7 @@ export const useTradeQuoteService = () => {
           wallet,
           receiveAddress,
           sellAmount: sellTradeAssetAmount,
+          isSendMax,
         })
         tradeQuoteInputArgs && setTradeQuoteArgs(tradeQuoteInputArgs)
       })()
@@ -168,6 +172,7 @@ export const useTradeQuoteService = () => {
     sellTradeAsset,
     setValue,
     wallet,
+    isSendMax,
   ])
 
   // Set trade quote

--- a/src/components/Trade/hooks/useTradeRoutes/useTradeRoutes.tsx
+++ b/src/components/Trade/hooks/useTradeRoutes/useTradeRoutes.tsx
@@ -53,6 +53,7 @@ export const useTradeRoutes = (): {
       setValue('sellAssetFiatRate', undefined)
       setValue('buyAssetFiatRate', undefined)
       setValue('feeAssetFiatRate', undefined)
+      setValue('isSendMax', false)
 
       history.push(TradeRoutePaths.Input)
 

--- a/src/components/Trade/types.ts
+++ b/src/components/Trade/types.ts
@@ -53,6 +53,7 @@ export type TradeState<C extends ChainId> = {
   amount: string
   receiveAddress: string | null // TODO: Implement
   slippage: number
+  isSendMax: boolean
 }
 
 export type TS<T extends KnownChainIds = KnownChainIds> = TradeState<T>

--- a/yarn.lock
+++ b/yarn.lock
@@ -4340,10 +4340,10 @@
     google-protobuf "^3.17.0"
     long "^4.0.0"
 
-"@shapeshiftoss/swapper@^11.5.2":
-  version "11.5.2"
-  resolved "https://registry.yarnpkg.com/@shapeshiftoss/swapper/-/swapper-11.5.2.tgz#d7e2c2d87a08ca91f46f4583a070e3f5f8783a96"
-  integrity sha512-fM6DmPHrBziRo+OwHvXyqiAzHS2o4D4GIIYprRlCG5FrcoWK8K3Ciibz3A2wHIafSVwII4gd/5IqvrIH05wdPQ==
+"@shapeshiftoss/swapper@^11.5.3":
+  version "11.5.3"
+  resolved "https://registry.yarnpkg.com/@shapeshiftoss/swapper/-/swapper-11.5.3.tgz#9500151b089e267447f3212e2c3e8edcf157a63e"
+  integrity sha512-66ROkH+kL6C7nhJBeaRhU4tKr0ntz0kjh2+Fr36WoRChnReRI0XbbUqRasU10GD1gwlyNsq2KrAUQAc5XJgBIg==
   dependencies:
     axios "^0.26.1"
     bignumber.js "^9.0.2"


### PR DESCRIPTION
## Description

Passes `sendMax` to `buildTrade` and `getTradeQuote`

Requires https://github.com/shapeshift/lib/pull/1046 to actually consume the value.

TODO: update swapper package once `lib` PR is merged.

## Notice

- [x] Have you followed the guidelines in our [Contributing]('https://github.com/shapeshift/web/blob/develop/CONTRIBUTING.md) guide?
- [x] Have you checked to ensure there aren't other open [Pull Requests](https://github.com/shapeshift/web/pulls) for the same update/change?

## Pull Request Type

- [x] :bug: Bug fix (Non-breaking Change: Fixes an issue)
- [ ] :hammer_and_wrench: Chore (Non-breaking Change: Doc updates, pkg upgrades, typos, etc..)
- [ ] :nail_care: New Feature (Breaking/Non-breaking Change)

## Issue (if applicable)

Closes https://github.com/shapeshift/web/issues/2949

## Risk

Minimal - only touches a flag on `buildTrade` and `getTradeQuote` args.

## Testing

When using the "Max" button when getting a quote, we should be able to proceed to the confirm screen without error, and ultimately perform a trade.

Check both EVM and UTXO assets.

### Engineering

As above.

### Operations

As above.

## Screenshots (if applicable)

N/A