### PR TITLE
chore: fix ThorSwap beforeFees amount

### DIFF
--- a/src/components/Trade/TradeConfirm/TradeConfirm.tsx
+++ b/src/components/Trade/TradeConfirm/TradeConfirm.tsx
@@ -282,7 +282,7 @@ export const TradeConfirm = ({ history }: RouterProps) => {
                 <ReceiveSummary
                   symbol={trade.buyAsset.symbol ?? ''}
                   amount={buyTradeAsset?.amount ?? ''}
-                  beforeFees={tradeAmountConstants?.sellAmountBeforeFeesBuyAsset ?? ''}
+                  beforeFees={tradeAmountConstants?.beforeFeesBuyAsset ?? ''}
                   protocolFee={tradeAmountConstants?.totalTradeFeeBuyAsset ?? ''}
                   shapeShiftFee='0'
                   slippage={slippage}

--- a/src/components/Trade/TradeInputV2.tsx
+++ b/src/components/Trade/TradeInputV2.tsx
@@ -369,7 +369,7 @@ export const TradeInput = () => {
               isLoading={!quoteAvailableForCurrentAssetPair && isSwapperApiPending}
               symbol={buyTradeAsset?.asset?.symbol ?? ''}
               amount={buyTradeAsset?.amount ?? ''}
-              beforeFees={tradeAmountConstants?.sellAmountBeforeFeesBuyAsset ?? ''}
+              beforeFees={tradeAmountConstants?.beforeFeesBuyAsset ?? ''}
               protocolFee={tradeAmountConstants?.totalTradeFeeBuyAsset ?? ''}
               shapeShiftFee='0'
               slippage={slippage}

--- a/src/components/Trade/TradeInputV2.tsx
+++ b/src/components/Trade/TradeInputV2.tsx
@@ -229,6 +229,33 @@ export const TradeInput = () => {
   const handleBuyAccountIdChange: AccountDropdownProps['onChange'] = accountId =>
     setValue('selectedBuyAssetAccountId', accountId)
 
+  const isBelowMinSellAmount = useMemo(() => {
+    const minSellAmount = toBaseUnit(bnOrZero(quote?.minimum), quote?.sellAsset.precision || 0)
+
+    return (
+      bnOrZero(
+        toBaseUnit(bnOrZero(sellTradeAsset?.amount), sellTradeAsset?.asset?.precision || 0),
+      ).lt(minSellAmount) &&
+      hasValidSellAmount &&
+      !isTradeQuotePending
+    )
+  }, [
+    hasValidSellAmount,
+    isTradeQuotePending,
+    quote?.minimum,
+    quote?.sellAsset.precision,
+    sellTradeAsset?.amount,
+    sellTradeAsset?.asset?.precision,
+  ])
+
+  const feesExceedsSellAmount = useMemo(
+    () =>
+      bnOrZero(sellTradeAsset?.amount).isGreaterThan(0) &&
+      bnOrZero(buyTradeAsset?.amount).isLessThanOrEqualTo(0) &&
+      !isTradeQuotePending,
+    [sellTradeAsset?.amount, buyTradeAsset?.amount, isTradeQuotePending],
+  )
+
   const getTranslationKey = useCallback((): string | [string, InterpolationOptions] => {
     const hasValidTradeBalance = bnOrZero(sellAssetBalanceHuman).gte(
       bnOrZero(sellTradeAsset?.amount),
@@ -243,18 +270,7 @@ export const TradeInput = () => {
       .minus(tradeDeduction)
       .gte(0)
 
-    const minSellAmount = toBaseUnit(bnOrZero(quote?.minimum), quote?.sellAsset.precision || 0)
     const minLimit = `${bnOrZero(quote?.minimum).decimalPlaces(6)} ${quote?.sellAsset.symbol}`
-    const isBelowMinSellAmount =
-      bnOrZero(
-        toBaseUnit(bnOrZero(sellTradeAsset?.amount), sellTradeAsset?.asset?.precision || 0),
-      ).lt(minSellAmount) &&
-      hasValidSellAmount &&
-      !isTradeQuotePending
-    const feesExceedsSellAmount =
-      bnOrZero(sellTradeAsset?.amount).isGreaterThan(0) &&
-      bnOrZero(buyTradeAsset?.amount).isLessThanOrEqualTo(0) &&
-      !isTradeQuotePending
 
     if (!wallet) return 'common.connectWallet'
     if (!walletSupportsSellAssetChain)
@@ -277,19 +293,21 @@ export const TradeInput = () => {
 
     return 'trade.previewTrade'
   }, [
-    sellAssetBalanceHuman,
-    sellTradeAsset,
-    sellFeeAsset,
-    feeAssetBalance,
-    quote,
-    hasValidSellAmount,
-    isTradeQuotePending,
-    buyTradeAsset,
-    wallet,
-    walletSupportsSellAssetChain,
-    walletSupportsBuyAssetChain,
     bestTradeSwapper,
+    buyTradeAsset,
+    feeAssetBalance,
+    feesExceedsSellAmount,
+    hasValidSellAmount,
+    isBelowMinSellAmount,
+    isTradeQuotePending,
+    quote,
     quoteAvailableForCurrentAssetPair,
+    sellAssetBalanceHuman,
+    sellFeeAsset,
+    sellTradeAsset,
+    wallet,
+    walletSupportsBuyAssetChain,
+    walletSupportsSellAssetChain,
   ])
 
   const hasError = useMemo(() => {
@@ -304,13 +322,13 @@ export const TradeInput = () => {
 
   const sellAmountTooSmall = useMemo(() => {
     switch (true) {
-      case getTranslationKey() === 'trade.errors.sellAmountDoesNotCoverFee':
-      case getTranslationKey()[0] === 'trade.errors.amountTooSmall':
+      case isBelowMinSellAmount:
+      case feesExceedsSellAmount:
         return true
       default:
         return false
     }
-  }, [getTranslationKey])
+  }, [isBelowMinSellAmount, feesExceedsSellAmount])
 
   return (
     <SlideTransition>

--- a/src/components/Trade/TradeInputV2.tsx
+++ b/src/components/Trade/TradeInputV2.tsx
@@ -302,6 +302,16 @@ export const TradeInput = () => {
     }
   }, [getTranslationKey])
 
+  const sellAmountTooSmall = useMemo(() => {
+    switch (true) {
+      case getTranslationKey() === 'trade.errors.sellAmountDoesNotCoverFee':
+      case getTranslationKey()[0] === 'trade.errors.amountTooSmall':
+        return true
+      default:
+        return false
+    }
+  }, [getTranslationKey])
+
   return (
     <SlideTransition>
       <Stack spacing={6} as='form' onSubmit={handleSubmit(onSubmit)}>
@@ -364,7 +374,7 @@ export const TradeInput = () => {
             isLoading={isSwapperApiPending && !quoteAvailableForCurrentAssetPair}
             isError={!walletSupportsTradeAssetChains}
           />
-          {walletSupportsTradeAssetChains ? (
+          {walletSupportsTradeAssetChains && !sellAmountTooSmall ? (
             <ReceiveSummary
               isLoading={!quoteAvailableForCurrentAssetPair && isSwapperApiPending}
               symbol={buyTradeAsset?.asset?.symbol ?? ''}

--- a/src/components/Trade/hooks/useGetTradeAmounts.tsx
+++ b/src/components/Trade/hooks/useGetTradeAmounts.tsx
@@ -51,6 +51,12 @@ export const getTradeAmountConstants = ({
     }
   })()
 
+  const sellAmountBeforeFeesBuyAsset: string = bnOrZero(
+    fromBaseUnit(sellAmountBeforeFeesBaseUnit, sellAsset.precision),
+  )
+    .div(assetPriceRatio)
+    .toString()
+
   const buyAmountBeforeFees = fromBaseUnit(buyAmountBeforeFeesBaseUnit, buyAsset.precision)
 
   const sellAssetTradeFeeSellAssetBaseUnit = toBaseUnit(
@@ -91,12 +97,6 @@ export const getTradeAmountConstants = ({
 
   const totalTradeFeeBuyAsset = fromBaseUnit(totalTradeFeeBuyAssetBaseUnit, buyAsset.precision)
 
-  const buyAmountAfterFeesBaseUnit = bnOrZero(buyAmountBeforeFeesBaseUnit)
-    .minus(totalTradeFeeBuyAssetBaseUnit)
-    .toString()
-
-  const buyAmountAfterFees = fromBaseUnit(buyAmountAfterFeesBaseUnit, buyAsset.precision)
-
   const sellAmountPlusFeesBaseUnit = bnOrZero(sellAmountBeforeFeesBaseUnit)
     .plus(totalTradeFeeSellAssetBaseUnit)
     .toString()
@@ -122,9 +122,16 @@ export const getTradeAmountConstants = ({
     .times(selectedCurrencyToUsdRate)
     .toFixed(2)
 
-  const sellAmountBeforeFeesBuyAsset: string = bnOrZero(sellAmountPlusFeesFiat)
-    .div(buyAssetUsdRate)
+  const sellAmountBeforeFeesBuyAssetBaseUnit = toBaseUnit(
+    sellAmountBeforeFeesBuyAsset,
+    buyAsset.precision,
+  )
+
+  const buyAmountAfterFeesBaseUnit = bnOrZero(sellAmountBeforeFeesBuyAssetBaseUnit)
+    .minus(totalTradeFeeBuyAssetBaseUnit)
     .toString()
+
+  const buyAmountAfterFees = fromBaseUnit(buyAmountAfterFeesBaseUnit, buyAsset.precision)
 
   const buyAmountAfterFeesFiat = bnOrZero(
     fromBaseUnit(buyAmountAfterFeesBaseUnit, buyAsset.precision),
@@ -132,6 +139,27 @@ export const getTradeAmountConstants = ({
     .times(buyAssetUsdRate)
     .times(selectedCurrencyToUsdRate)
     .toFixed(2)
+
+  const beforeFeesBuyAsset: string = (() => {
+    switch (action) {
+      case TradeAmountInputField.SELL_CRYPTO:
+        return bnOrZero(amount).div(assetPriceRatio).toString()
+      case TradeAmountInputField.SELL_FIAT:
+        return bnOrZero(fromBaseUnit(sellAmountBeforeFeesBaseUnit, sellAsset.precision))
+          .div(assetPriceRatio)
+          .toString()
+      case TradeAmountInputField.BUY_CRYPTO:
+        return bnOrZero(fromBaseUnit(sellAmountPlusFeesBaseUnit, sellAsset.precision))
+          .div(assetPriceRatio)
+          .toString()
+      case TradeAmountInputField.BUY_FIAT:
+        return bnOrZero(fromBaseUnit(sellAmountPlusFeesBaseUnit, sellAsset.precision))
+          .div(assetPriceRatio)
+          .toString()
+      default:
+        return '0'
+    }
+  })()
 
   return {
     buyAmountBeforeFeesFiat,
@@ -147,6 +175,7 @@ export const getTradeAmountConstants = ({
     buyAmountAfterFees,
     buyAmountBeforeFees,
     totalTradeFeeBuyAsset,
+    beforeFeesBuyAsset,
   }
 }
 


### PR DESCRIPTION
## Description

Now that ThorSwap fees are coming through correctly, we've exposed that the logic to display "beforeFees" is incorrect for ThorSwap quotes.

Calculating the `beforeFeesBuyAsset` value requires the context of the action, which we don't currently consider.

This PR adds a constant to compute a `beforeFeesBuyAsset` that is passed into the `beforeFees` prop of the `ReceiveSummary` component.

**Before:**

<img width="386" alt="Screen Shot 2022-10-04 at 4 57 48 pm" src="https://user-images.githubusercontent.com/97164662/193745272-bd1d6123-253b-41ce-a545-6cf1bbc3c51d.png">

**After:**

<img width="396" alt="Screen Shot 2022-10-04 at 5 19 07 pm" src="https://user-images.githubusercontent.com/97164662/193748232-57d35928-d521-4605-a5ed-46039a894ea3.png">

The `ReceiveSummary` is now hidden is the sell amount is too small.

## Notice

- [x] Have you followed the guidelines in our [Contributing]('https://github.com/shapeshift/web/blob/develop/CONTRIBUTING.md) guide?
- [x] Have you checked to ensure there aren't other open [Pull Requests](https://github.com/shapeshift/web/pulls) for the same update/change?

## Pull Request Type

- [x] :bug: Bug fix (Non-breaking Change: Fixes an issue)
- [ ] :hammer_and_wrench: Chore (Non-breaking Change: Doc updates, pkg upgrades, typos, etc..)
- [ ] :nail_care: New Feature (Breaking/Non-breaking Change)

## Issue (if applicable)

Closes https://github.com/shapeshift/web/issues/2963

## Risk

Small, though there may be an impact to other swapper fee amounts if implemented incorrectly.

## Testing

With ThorSwap enabled, enter sell amount. It's easiest to observe with a small value, such as with the "before" screenshot above.

The "beforeFees" should be correct, i.e. not be larger that it should be.

### Engineering

As above.

### Operations

As above.

## Screenshots (if applicable)

See description section for before and after.
