### PR TITLE
fix: memoize asset ids to avoid default asset rerender

### DIFF
--- a/src/components/Trade/Trade.tsx
+++ b/src/components/Trade/Trade.tsx
@@ -1,6 +1,5 @@
-import type { Asset } from '@shapeshiftoss/asset-service'
 import type { AssetId } from '@shapeshiftoss/caip'
-import { useEffect, useState } from 'react'
+import { useEffect } from 'react'
 import { FormProvider, useForm } from 'react-hook-form'
 import { MemoryRouter, Route, Switch } from 'react-router-dom'
 
@@ -15,8 +14,6 @@ export type TradeProps = {
 
 export const Trade = ({ defaultBuyAssetId }: TradeProps) => {
   const { getDefaultAssets } = useDefaultAssets(defaultBuyAssetId)
-  const [sellAsset, setSellAsset] = useState<Asset | undefined>()
-  const [buyAsset, setBuyAsset] = useState<Asset | undefined>()
 
   const methods = useForm<TS>({
     mode: 'onChange',
@@ -24,8 +21,8 @@ export const Trade = ({ defaultBuyAssetId }: TradeProps) => {
       fiatSellAmount: '0',
       fiatBuyAmount: '0',
       amount: '0',
-      sellTradeAsset: { amount: '0', asset: sellAsset },
-      buyTradeAsset: { amount: '0', asset: buyAsset },
+      sellTradeAsset: { amount: '0' },
+      buyTradeAsset: { amount: '0' },
       isExactAllowance: false,
       slippage: 0.002,
       action: TradeAmountInputField.SELL_CRYPTO,
@@ -38,8 +35,6 @@ export const Trade = ({ defaultBuyAssetId }: TradeProps) => {
       const result = await getDefaultAssets()
       if (!result) return
       const { buyAsset, sellAsset } = result
-      setSellAsset(sellAsset)
-      setBuyAsset(buyAsset)
       methods.setValue('sellTradeAsset.asset', sellAsset)
       methods.setValue('buyTradeAsset.asset', buyAsset)
     })()

--- a/src/state/slices/portfolioSlice/selectors.ts
+++ b/src/state/slices/portfolioSlice/selectors.ts
@@ -627,8 +627,10 @@ export const selectPortfolioAssets = createSelector(
     }, {}),
 )
 
-export const selectPortfolioAccountIds = (state: ReduxState): AccountSpecifier[] =>
-  state.portfolio.accounts.ids
+export const selectPortfolioAccountIds = createDeepEqualOutputSelector(
+  (state: ReduxState): AccountSpecifier[] => state.portfolio.accounts.ids,
+  accountIds => accountIds,
+)
 
 /**
  * selects portfolio account ids that *can* contain an assetId


### PR DESCRIPTION
## Description

<!-- Please describe your changes -->

this array *should* have been stable but wasn't, causing an unnecessary render, and causing the
default assets to change on trade confirmation, and hence causing the swapper protocol to change on
the trade confirmation page

## Notice

<!-- Before submitting a pull request, please make sure you have answered the following: -->

- [x] Have you followed the guidelines in our [Contributing]('https://github.com/shapeshift/web/blob/develop/CONTRIBUTING.md) guide?
- [x] Have you checked to ensure there aren't other open [Pull Requests](https://github.com/shapeshift/web/pulls) for the same update/change?

## Pull Request Type

- [x] :bug: Bug fix (Non-breaking Change: Fixes an issue)
- [ ] :hammer_and_wrench: Chore (Non-breaking Change: Doc updates, pkg upgrades, typos, etc..)
- [ ] :nail_care: New Feature (Breaking/Non-breaking Change)

## Issue (if applicable)

<!-----------------------------------------------------------------------------
If applicable, please link to the github issue and put `closes #XXXX` in your comment to auto-close the issue that your PR fixes.
------------------------------------------------------------------------------>

closes #2959
closes #2958 

## Risk

<!-----------------------------------------------------------------------------
Outline the scope of your changes and the risk associated with them. You must use your discretion as an engineer to determine the potential impact of your changes.

E.g. an upgrade to `hdwallet` or core state management would be considered higher risk, and might require a full regression test. UI or isolated view changes, or something behind a feature flag may have near zero risk. Small bug fixes might require testing isolated to the specific fix.
------------------------------------------------------------------------------>

* we break the default asset logic
* other parts of the app *don't* render when they should

## Testing

* on the dashboard, ensure that the default pair is ETH/FOX, being routed via THORChain
* setup a trade, ensure it's routed via 0x, not THORChain, e.g. ETH -> UNI
* on the trade confirmation step, expand the expected amount section, ensuring the protocol is 0x
* confirm the trade, and wait for the trade to complete
* the protocol and other values should remain as 0x, and not switch back to THORChain once the trade is complete

<!-----------------------------------------------------------------------------
We treat every PR to be merged with the same scrutiny as if we were merging directly to production.

Your PR will not be merged if you do not complete the sections below for our engineering and operations teams to test.
------------------------------------------------------------------------------>

### Engineering

* see common testing steps

<!-----------------------------------------------------------------------------
Include sufficient information here for an engineer to test your PR. This may include how to test locally, in a built environment, changes to infrastructure etc.
------------------------------------------------------------------------------>

### Operations

* see common testing steps

<!-----------------------------------------------------------------------------
If your changes have a user-facing impact, describe how a non-technical QA team can functionally test your changes in a preview environment.

If they are not user-facing please describe how to test for any regressions that may occur.
------------------------------------------------------------------------------>

## Screenshots (if applicable)
