### PR TITLE
fix: use amount instead of amount after slippage

### DIFF
--- a/src/components/Trade/TradeConfirm/ReceiveSummary.tsx
+++ b/src/components/Trade/TradeConfirm/ReceiveSummary.tsx
@@ -66,7 +66,7 @@ export const ReceiveSummary: FC<ReceiveSummaryProps> = ({
         <Row.Value display='flex' columnGap={2} alignItems='center'>
           <Stack spacing={0} alignItems='flex-end'>
             <Skeleton isLoaded={!isLoading}>
-              <Amount.Crypto value={isAmountPositive ? amountAfterSlippage : '0'} symbol={symbol} />
+              <Amount.Crypto value={isAmountPositive ? amount : '0'} symbol={symbol} />
             </Skeleton>
             {fiatAmount && (
               <Skeleton isLoaded={!isLoading}>


### PR DESCRIPTION
## Description

- change from `amountAfterSlippage` to `amount`

## Notice

<!-- Before submitting a pull request, please make sure you have answered the following: -->

- [x] Have you followed the guidelines in our [Contributing]('https://github.com/shapeshift/web/blob/develop/CONTRIBUTING.md) guide?
- [x] Have you checked to ensure there aren't other open [Pull Requests](https://github.com/shapeshift/web/pulls) for the same update/change?

## Pull Request Type

- [x] :bug: Bug fix (Non-breaking Change: Fixes an issue)
- [ ] :hammer_and_wrench: Chore (Non-breaking Change: Doc updates, pkg upgrades, typos, etc..)
- [ ] :nail_care: New Feature (Breaking/Non-breaking Change)

## Issue (if applicable)

<!-----------------------------------------------------------------------------
If applicable, please link to the github issue and put `closes #XXXX` in your comment to auto-close the issue that your PR fixes.
------------------------------------------------------------------------------>

closes #2973 

## Risk

very little risk

## Testing

<!-----------------------------------------------------------------------------
We treat every PR to be merged with the same scrutiny as if we were merging directly to production.

Your PR will not be merged if you do not complete the sections below for our engineering and operations teams to test.
------------------------------------------------------------------------------>

### Engineering

turn on thorchain
put in trade
the amount in the buy amount should match the expected amount

### Operations

turn on thorchain
put in trade
the amount in the buy amount should match the expected amount

## Screenshot
![Screen Shot 2022-10-04 at 1 57 45 PM](https://user-images.githubusercontent.com/89934888/193903117-eecaea3f-8d88-42cb-a2c2-70dfd622de53.png)
s (if applicable)
