### PR TITLE
fix: return user to splash on failed pairing

### DIFF
--- a/src/context/WalletProvider/WalletProvider.tsx
+++ b/src/context/WalletProvider/WalletProvider.tsx
@@ -383,6 +383,10 @@ export const WalletProvider = ({ children }: { children: React.ReactNode }): JSX
                   } else {
                     disconnect()
                   }
+                } else {
+                  // in the case we return a null from the mobile app and fail to get the wallet
+                  // we want to disconnect and return the user back to the splash screen
+                  disconnect()
                 }
               } catch (e) {
                 moduleLogger.child({ name: 'load' }).error(e, 'Error loading mobile wallet')


### PR DESCRIPTION
## Description

Fixes an issue where a user could decline or error out of biometrics and the app would hang due to no wallet being connected.

## Notice

<!-- Before submitting a pull request, please make sure you have answered the following: -->

- [x] Have you followed the guidelines in our [Contributing]('https://github.com/shapeshift/web/blob/develop/CONTRIBUTING.md) guide?
- [x] Have you checked to ensure there aren't other open [Pull Requests](https://github.com/shapeshift/web/pulls) for the same update/change?

## Pull Request Type

- [x] :bug: Bug fix (Non-breaking Change: Fixes an issue)
- [ ] :hammer_and_wrench: Chore (Non-breaking Change: Doc updates, pkg upgrades, typos, etc..)
- [ ] :nail_care: New Feature (Breaking/Non-breaking Change)
## Risk
Low, only mobile app failure mode should be affected.
## Testing

1. Pair a wallet to the mobile app
2. on the dashboard, pull down to refresh the app with the phone pointed away from your face
3. When asked to retry, click cancel
4. This should now take you back to splash screen

### Engineering

<!-----------------------------------------------------------------------------
Include sufficient information here for an engineer to test your PR. This may include how to test locally, in a built environment, changes to infrastructure etc.
------------------------------------------------------------------------------>

### Operations

<!-----------------------------------------------------------------------------
If your changes have a user-facing impact, describe how a non-technical QA team can functionally test your changes in a preview environment.

If they are not user-facing please describe how to test for any regressions that may occur.
------------------------------------------------------------------------------>

## Screenshots (if applicable)
