### PR TITLE
fix: trade amount constants and confirm

### DIFF
--- a/src/components/Trade/TradeConfirm/ReceiveSummary.tsx
+++ b/src/components/Trade/TradeConfirm/ReceiveSummary.tsx
@@ -13,7 +13,6 @@ import { Amount } from 'components/Amount/Amount'
 import { HelperTooltip } from 'components/HelperTooltip/HelperTooltip'
 import { type RowProps, Row } from 'components/Row/Row'
 import { RawText, Text } from 'components/Text'
-import { useSwapper } from 'components/Trade/hooks/useSwapper/useSwapperV2'
 import { bnOrZero } from 'lib/bignumber/bignumber'
 
 type ReceiveSummaryProps = {
@@ -25,6 +24,7 @@ type ReceiveSummaryProps = {
   protocolFee?: string
   shapeShiftFee?: string
   slippage: number
+  swapperName: string
 } & RowProps
 
 export const ReceiveSummary: FC<ReceiveSummaryProps> = ({
@@ -35,6 +35,7 @@ export const ReceiveSummary: FC<ReceiveSummaryProps> = ({
   protocolFee,
   shapeShiftFee,
   slippage,
+  swapperName,
   isLoading,
   ...rest
 }) => {
@@ -46,7 +47,6 @@ export const ReceiveSummary: FC<ReceiveSummaryProps> = ({
   const redColor = useColorModeValue('red.500', 'red.300')
   const greenColor = useColorModeValue('green.500', 'green.200')
   const textColor = useColorModeValue('gray.800', 'whiteAlpha.900')
-  const { bestTradeSwapper } = useSwapper()
 
   const slippageAsPercentageString = bnOrZero(slippage).times(100).toString()
   const amountAfterSlippage = bnOrZero(amount)
@@ -87,7 +87,7 @@ export const ReceiveSummary: FC<ReceiveSummaryProps> = ({
           px={4}
           py={2}
         >
-          {bestTradeSwapper && (
+          {swapperName && (
             <Row>
               <HelperTooltip label={translate('trade.tooltip.protocol')}>
                 <Row.Label>
@@ -97,7 +97,7 @@ export const ReceiveSummary: FC<ReceiveSummaryProps> = ({
               <Row.Value>
                 <Row.Label>
                   <RawText fontWeight='semibold' color={textColor}>
-                    {bestTradeSwapper.name}
+                    {swapperName}
                   </RawText>
                 </Row.Label>
               </Row.Value>

--- a/src/components/Trade/TradeConfirm/ReceiveSummary.tsx
+++ b/src/components/Trade/TradeConfirm/ReceiveSummary.tsx
@@ -87,22 +87,20 @@ export const ReceiveSummary: FC<ReceiveSummaryProps> = ({
           px={4}
           py={2}
         >
-          {swapperName && (
-            <Row>
-              <HelperTooltip label={translate('trade.tooltip.protocol')}>
-                <Row.Label>
-                  <Text translation='trade.protocol' />
-                </Row.Label>
-              </HelperTooltip>
-              <Row.Value>
-                <Row.Label>
-                  <RawText fontWeight='semibold' color={textColor}>
-                    {swapperName}
-                  </RawText>
-                </Row.Label>
-              </Row.Value>
-            </Row>
-          )}
+          <Row>
+            <HelperTooltip label={translate('trade.tooltip.protocol')}>
+              <Row.Label>
+                <Text translation='trade.protocol' />
+              </Row.Label>
+            </HelperTooltip>
+            <Row.Value>
+              <Row.Label>
+                <RawText fontWeight='semibold' color={textColor}>
+                  {swapperName}
+                </RawText>
+              </Row.Label>
+            </Row.Value>
+          </Row>
           {beforeFees && (
             <Row>
               <Row.Label>

--- a/src/components/Trade/TradeConfirm/TradeConfirm.tsx
+++ b/src/components/Trade/TradeConfirm/TradeConfirm.tsx
@@ -37,6 +37,7 @@ import { useWallet } from 'hooks/useWallet/useWallet'
 import { bnOrZero } from 'lib/bignumber/bignumber'
 import { firstNonZeroDecimal, fromBaseUnit } from 'lib/math'
 import { poll } from 'lib/poll/poll'
+import { selectFeatureFlags } from 'state/slices/preferencesSlice/selectors'
 import {
   selectAssetById,
   selectFeeAssetByChainId,
@@ -46,7 +47,6 @@ import {
 import { serializeTxIndex } from 'state/slices/txHistorySlice/utils'
 import { useAppSelector } from 'state/store'
 
-import { selectFeatureFlags } from '../../../state/slices/preferencesSlice/selectors'
 import { getSwapperManager } from '../hooks/useSwapper/swapperManager'
 import type { TS } from '../types'
 import { TradeRoutePaths } from '../types'

--- a/src/components/Trade/TradeInputV2.tsx
+++ b/src/components/Trade/TradeInputV2.tsx
@@ -338,6 +338,8 @@ export const TradeInput = () => {
     }
   }, [isBelowMinSellAmount, feesExceedsSellAmount])
 
+  const swapperName = useMemo(() => bestTradeSwapper?.name ?? '', [bestTradeSwapper])
+
   return (
     <SlideTransition>
       <Stack spacing={6} as='form' onSubmit={handleSubmit(onSubmit)}>
@@ -409,6 +411,7 @@ export const TradeInput = () => {
               protocolFee={tradeAmountConstants?.totalTradeFeeBuyAsset ?? ''}
               shapeShiftFee='0'
               slippage={slippage}
+              swapperName={swapperName}
             />
           ) : null}
         </Stack>

--- a/src/components/Trade/hooks/useGetTradeAmounts.tsx
+++ b/src/components/Trade/hooks/useGetTradeAmounts.tsx
@@ -196,21 +196,22 @@ export const useGetTradeAmounts = () => {
   const sellAsset = sellTradeAsset?.asset
   const sellAssetTradeFeeUsd = bnOrZero(fees?.sellAssetTradeFeeUsd)
   const buyAssetTradeFeeUsd = bnOrZero(fees?.buyAssetTradeFeeUsd)
+  if (!bnOrZero(buyTradeAsset?.amount).gt(0) || !bnOrZero(sellTradeAsset?.amount).gt(0)) return
+  if (!amount) return
+  if (!action) return
+  if (!fees) return
+  if (!buyAsset || !sellAsset) return
+  if (!buyAssetUsdRate || !sellAssetUsdRate) return
 
-  const tradeAmountConstants =
-    buyAsset && sellAsset && action && buyAssetUsdRate && sellAssetUsdRate
-      ? getTradeAmountConstants({
-          amount,
-          buyAsset,
-          sellAsset,
-          buyAssetUsdRate,
-          sellAssetUsdRate,
-          selectedCurrencyToUsdRate,
-          sellAssetTradeFeeUsd,
-          buyAssetTradeFeeUsd,
-          action,
-        })
-      : undefined
-
-  return tradeAmountConstants
+  return getTradeAmountConstants({
+    amount,
+    buyAsset,
+    sellAsset,
+    buyAssetUsdRate,
+    sellAssetUsdRate,
+    selectedCurrencyToUsdRate,
+    sellAssetTradeFeeUsd,
+    buyAssetTradeFeeUsd,
+    action,
+  })
 }

--- a/src/components/Trade/hooks/useSwapper/useSwapper.tsx
+++ b/src/components/Trade/hooks/useSwapper/useSwapper.tsx
@@ -350,6 +350,7 @@ export const useSwapper = () => {
   }
 
   const executeQuote = async (): Promise<TradeResult> => {
+    // TODO(0xdef1cafe): this should be pure be passed a quote to execute - the best swapper could change underneath us...
     const swapper = await swapperManager.getBestSwapper({
       buyAssetId: trade.buyAsset.assetId,
       sellAssetId: trade.sellAsset.assetId,

--- a/src/components/Trade/hooks/useTradeAmounts.tsx
+++ b/src/components/Trade/hooks/useTradeAmounts.tsx
@@ -233,6 +233,7 @@ export const useTradeAmounts = () => {
         setValue('sellAssetFiatRate', undefined)
         setValue('buyAssetFiatRate', undefined)
         setValue('feeAssetFiatRate', undefined)
+        setValue('fees', undefined)
       }
     },
     [


### PR DESCRIPTION
## Description

<!-- Please describe your changes -->

draft - needs a well rested set of eyes before merging

this fixes a lot of stale value bugs we've been seeing by more aggressively guarding against invalid
inputs to the `getTradeAmountConstants` function

without doing this, it was possible to get into two very broken states

1) we should never be able to display a "Before Fees", or a "Protocol Fee" amount, without having
either a buy or sell amount, i.e. you can't possibly be receiving an amount "Before Fees" if you're
not swapping anything

2) we could see conditions where we were displaying a protocol fee for 0x quotes, or no protocol fee
for thorchain quotes. both of these are wrong.

it's possible we can revert the changes to `ReceiveSummary` and `TradeConfirm`, but both are
probably worthwhile

* receive summary should be purely presentational, and not calling `useGetTradeAmounts`, especiallya
  s it's used on the trade confirm screen
* it just seems prudent to snapshot the quote before we execute it, as there's no guarantees
  somethign can't mutate the values underneath us, and we display the wrong thing on the trade
  confirm screen

## Notice

<!-- Before submitting a pull request, please make sure you have answered the following: -->

- [x] Have you followed the guidelines in our [Contributing]('https://github.com/shapeshift/web/blob/develop/CONTRIBUTING.md) guide?
- [x] Have you checked to ensure there aren't other open [Pull Requests](https://github.com/shapeshift/web/pulls) for the same update/change?

## Pull Request Type

- [x] :bug: Bug fix (Non-breaking Change: Fixes an issue)
- [ ] :hammer_and_wrench: Chore (Non-breaking Change: Doc updates, pkg upgrades, typos, etc..)
- [ ] :nail_care: New Feature (Breaking/Non-breaking Change)

## Issue (if applicable)

<!-----------------------------------------------------------------------------
If applicable, please link to the github issue and put `closes #XXXX` in your comment to auto-close the issue that your PR fixes.
------------------------------------------------------------------------------>

closes #2979
closes #2962 

## Risk

* isolated to swapper v2, please test 0x and thor trades

<!-----------------------------------------------------------------------------
Outline the scope of your changes and the risk associated with them. You must use your discretion as an engineer to determine the potential impact of your changes.

E.g. an upgrade to `hdwallet` or core state management would be considered higher risk, and might require a full regression test. UI or isolated view changes, or something behind a feature flag may have near zero risk. Small bug fixes might require testing isolated to the specific fix.
------------------------------------------------------------------------------>

## Testing

<!-----------------------------------------------------------------------------
We treat every PR to be merged with the same scrutiny as if we were merging directly to production.

Your PR will not be merged if you do not complete the sections below for our engineering and operations teams to test.
------------------------------------------------------------------------------>

### Engineering

* throw some logging after the guard conditions and before we call `getTradeAmountConstants` to
  ensure we always have necessary and sufficient data
* github actions is rekt, run CI locally before merging https://www.githubstatus.com/

<!-----------------------------------------------------------------------------
Include sufficient information here for an engineer to test your PR. This may include how to test locally, in a built environment, changes to infrastructure etc.
------------------------------------------------------------------------------>

### Operations

* **please always expand the "Expected Amount" section before previewing trades**
* if you are doing a thor trade, ensure you always see a protocol fee before previewing trades
* if you are doing a 0x trade, ensure you never see a protocol fee before previewing trades
* **please always expand the "Expected Amount" section before confirming trades**
* take a screenshot of the confirm trade page before confirming, and ensure amounts don't change
  after the transaction has confirmed on chain. watch the relevent block explorer of the sell asset
  for the source of truth.

<!-----------------------------------------------------------------------------
If your changes have a user-facing impact, describe how a non-technical QA team can functionally test your changes in a preview environment.

If they are not user-facing please describe how to test for any regressions that may occur.
------------------------------------------------------------------------------>

## Screenshots (if applicable)

before - this should not be possible

<img width="664" alt="Screen Shot 2022-10-05 at 12 13 20 AM" src="https://user-images.githubusercontent.com/88504456/193996728-ec0ecb99-1af4-42e5-a391-86489048d936.png">

