### PR TITLE
fix: use placeholder when value is zero

### DIFF
--- a/src/components/DeFi/components/AssetInput.tsx
+++ b/src/components/DeFi/components/AssetInput.tsx
@@ -110,9 +110,13 @@ export const AssetInput: React.FC<AssetInputProps> = ({
 
   // Lower the decimal places when the integer is greater than 8 significant digits for better UI
   const cryptoAmountIntegerCount = bnOrZero(bnOrZero(cryptoAmount).toFixed(0)).precision(true)
-  const formattedCryptoAmount = bnOrZero(cryptoAmountIntegerCount).isLessThanOrEqualTo(8)
-    ? cryptoAmount
-    : bnOrZero(cryptoAmount).toFixed(3)
+  const formattedCryptoAmount = bnOrZero(cryptoAmount).gt(0)
+    ? bnOrZero(cryptoAmountIntegerCount).isLessThanOrEqualTo(8)
+      ? cryptoAmount
+      : bnOrZero(cryptoAmount).toFixed(3)
+    : null
+
+  const formattedFiatAmount = bnOrZero(fiatAmount).gt(0) ? bnOrZero(fiatAmount).toFixed(2) : null
 
   return (
     <FormControl
@@ -150,10 +154,11 @@ export const AssetInput: React.FC<AssetInputProps> = ({
               disabled={isReadOnly}
               suffix={isFiat ? localeParts.postfix : ''}
               prefix={isFiat ? localeParts.prefix : ''}
+              placeholder={isFiat ? `${localeParts.prefix}0.00${localeParts.postfix}` : '0.00'}
               decimalSeparator={localeParts.decimal}
               inputMode='decimal'
               thousandSeparator={localeParts.group}
-              value={isFiat ? bnOrZero(fiatAmount).toFixed(2) : formattedCryptoAmount}
+              value={isFiat ? formattedFiatAmount : formattedCryptoAmount}
               onValueChange={values => {
                 // This fires anytime value changes including setting it on max click
                 // Store the value in a ref to send when we actually want the onChange to fire


### PR DESCRIPTION
## Description

- In the asset input field, we should show the placeholder when the value is 0

## Notice

<!-- Before submitting a pull request, please make sure you have answered the following: -->

- [x] Have you followed the guidelines in our [Contributing]('https://github.com/shapeshift/web/blob/develop/CONTRIBUTING.md) guide?
- [x] Have you checked to ensure there aren't other open [Pull Requests](https://github.com/shapeshift/web/pulls) for the same update/change?

## Pull Request Type

- [x] :bug: Bug fix (Non-breaking Change: Fixes an issue)
- [ ] :hammer_and_wrench: Chore (Non-breaking Change: Doc updates, pkg upgrades, typos, etc..)
- [ ] :nail_care: New Feature (Breaking/Non-breaking Change)

## Issue (if applicable)

<!-----------------------------------------------------------------------------
If applicable, please link to the github issue and put `closes #XXXX` in your comment to auto-close the issue that your PR fixes.
------------------------------------------------------------------------------>

closes #2974 

## Risk

Possibly could effect trade logic when loading rates. However, this is only presentational and should not effect state.

## Testing

<!-----------------------------------------------------------------------------
We treat every PR to be merged with the same scrutiny as if we were merging directly to production.

Your PR will not be merged if you do not complete the sections below for our engineering and operations teams to test.
------------------------------------------------------------------------------>

### Engineering

n/a

### Operations

When coming to trade or DeFi modals, on first load you should see `0.00` in greyed out text. Once you click the input you should be able to type a value and it clears the 0.00.

This should also show the fiat placeholder value for USD ($0.00) and the same for other localized currency formats.

## Screenshots (if applicable)
![Screen Shot 2022-10-05 at 12 54 58 PM](https://user-images.githubusercontent.com/89934888/194129183-5bdff490-ec1b-41f1-a526-a79aae842200.png)
![Screen Shot 2022-10-05 at 12 55 02 PM](https://user-images.githubusercontent.com/89934888/194129185-4573a48b-d3e8-4e7b-88d2-0e70709b5950.png)
