### PR TITLE
fix: cosmos asset account allocation

### DIFF
--- a/src/components/AssetAccounts/AssetAccountRow.tsx
+++ b/src/components/AssetAccounts/AssetAccountRow.tsx
@@ -20,10 +20,9 @@ import type { AccountSpecifier } from 'state/slices/accountSpecifiersSlice/accou
 import { accountIdToFeeAssetId, accountIdToLabel } from 'state/slices/portfolioSlice/utils'
 import {
   selectAssetById,
-  selectFirstAccountSpecifierByChainId,
+  selectCryptoHumanBalanceIncludingStakingByFilter,
+  selectFiatBalanceIncludingStakingByFilter,
   selectPortfolioAllocationPercentByFilter,
-  selectTotalCryptoBalanceWithDelegations,
-  selectTotalFiatBalanceWithDelegations,
 } from 'state/slices/selectors'
 import { useAppSelector } from 'state/store'
 import { breakpoints } from 'theme/theme'
@@ -52,18 +51,13 @@ export const AssetAccountRow = ({
   const rowAssetId = assetId ? assetId : feeAssetId
   const asset = useAppSelector(state => selectAssetById(state, rowAssetId))
   const feeAsset = useAppSelector(state => selectAssetById(state, feeAssetId))
-  const accountSpecifier = useAppSelector(state =>
-    selectFirstAccountSpecifierByChainId(state, asset?.chainId),
-  )
   const { assetReference, assetNamespace } = fromAssetId(asset.assetId)
 
-  const filter = useMemo(
-    () => ({ assetId: rowAssetId, accountId, accountSpecifier }),
-    [rowAssetId, accountId, accountSpecifier],
-  )
-  const fiatBalance = useAppSelector(state => selectTotalFiatBalanceWithDelegations(state, filter))
-  const cryptoHumanBalance = useAppSelector(state =>
-    selectTotalCryptoBalanceWithDelegations(state, filter),
+  const filter = useMemo(() => ({ assetId: rowAssetId, accountId }), [rowAssetId, accountId])
+
+  const fiatBalance = useAppSelector(s => selectFiatBalanceIncludingStakingByFilter(s, filter))
+  const cryptoHumanBalance = useAppSelector(s =>
+    selectCryptoHumanBalanceIncludingStakingByFilter(s, filter),
   )
   const allocation = useAppSelector(state =>
     selectPortfolioAllocationPercentByFilter(state, { accountId, assetId: rowAssetId }),
@@ -97,7 +91,6 @@ export const AssetAccountRow = ({
     >
       <Flex alignItems='center'>
         <Box position='relative'>
-          {/** don't show "exponentiated" asset icons for fee assets */}
           <AssetIcon assetId={asset.assetId} boxSize='30px' mr={2} />
         </Box>
         <Flex flexDir='column' ml={2} maxWidth='100%'>

--- a/src/components/AssetHeader/AssetChart.tsx
+++ b/src/components/AssetHeader/AssetChart.tsx
@@ -32,7 +32,7 @@ import { bnOrZero } from 'lib/bignumber/bignumber'
 import type { AccountSpecifier } from 'state/slices/accountSpecifiersSlice/accountSpecifiersSlice'
 import {
   selectAssetById,
-  selectCryptoBalanceIncludingStakingByFilter,
+  selectCryptoHumanBalanceIncludingStakingByFilter,
   selectFiatBalanceIncludingStakingByFilter,
   selectMarketDataById,
   selectPortfolioStakingCryptoHumanBalanceByFilter,
@@ -73,7 +73,9 @@ export const AssetChart = ({ accountId, assetId, isLoaded }: AssetChartProps) =>
   const translate = useTranslate()
 
   const fiatBalance = useAppSelector(s => selectFiatBalanceIncludingStakingByFilter(s, filter))
-  const cryptoBalance = useAppSelector(s => selectCryptoBalanceIncludingStakingByFilter(s, filter))
+  const cryptoHumanBalance = useAppSelector(s =>
+    selectCryptoHumanBalanceIncludingStakingByFilter(s, filter),
+  )
 
   const stakingFiatBalance = useAppSelector(s =>
     selectPortfolioStakingCryptoHumanBalanceByFilter(s, filter),
@@ -137,7 +139,7 @@ export const AssetChart = ({ accountId, assetId, isLoaded }: AssetChartProps) =>
             {view === View.Balance && (
               <Stat size='sm' color='gray.500'>
                 <Skeleton isLoaded={isLoaded}>
-                  <StatNumber>{`${cryptoBalance} ${asset.symbol}`}</StatNumber>
+                  <StatNumber>{`${cryptoHumanBalance} ${asset.symbol}`}</StatNumber>
                 </Skeleton>
               </Stat>
             )}

--- a/src/state/slices/accountSpecifiersSlice/selectors.ts
+++ b/src/state/slices/accountSpecifiersSlice/selectors.ts
@@ -31,6 +31,7 @@ export const selectAccountSpecifiersByChainId = (state: ReduxState, chainId: Cha
     return acc
   }, [])
 
+// TODO(0xdef1cafe): DELETE - this is dangerous with multi account
 export const selectFirstAccountSpecifierByChainId = createSelector(
   selectAccountSpecifiersByChainId,
   accountSpecifiers => accountSpecifiers[0],

--- a/src/state/slices/portfolioSlice/selectors.ts
+++ b/src/state/slices/portfolioSlice/selectors.ts
@@ -471,6 +471,7 @@ export const selectTotalStakingUndelegationCryptoByAccountSpecifier = createSele
   },
 )
 
+// TODO(0xdef1cafe): DO NOT USE THIS - delete when there are no references
 export const selectTotalStakingDelegationCryptoByFilter = createSelector(
   selectAssetIdParamFromFilterOptional,
   (state: ReduxState) => state.assets.byId,
@@ -497,6 +498,7 @@ export const selectTotalFiatBalanceWithDelegations = createSelector(
   },
 )
 
+// TODO(0xdef1cafe): DO NOT USE THIS - delete when there are no references
 export const selectTotalCryptoBalanceWithDelegations = createSelector(
   selectPortfolioCryptoHumanBalanceByFilter,
   selectTotalStakingDelegationCryptoByFilter,
@@ -919,7 +921,7 @@ export const selectFiatBalanceIncludingStakingByFilter = createSelector(
   genericBalanceIncludingStakingByFilter,
 )
 
-export const selectCryptoBalanceIncludingStakingByFilter = createSelector(
+export const selectCryptoHumanBalanceIncludingStakingByFilter = createSelector(
   selectPortfolioAccountsCryptoHumanBalancesIncludingStaking,
   selectAssetIdParamFromFilterOptional,
   selectAccountIdParamFromFilterOptional,


### PR DESCRIPTION
## Description

<!-- Please describe your changes -->

fix: asset account allocations for cosmos

we were previously using the first account id everywhere, causing account > 0 to include staking balances from account 0. this updates selector usage to use the correct selectors with the correct account ids.

**note - this does *not* fix the staking section**

## Notice

<!-- Before submitting a pull request, please make sure you have answered the following: -->

- [x] Have you followed the guidelines in our [Contributing]('https://github.com/shapeshift/web/blob/develop/CONTRIBUTING.md) guide?
- [x] Have you checked to ensure there aren't other open [Pull Requests](https://github.com/shapeshift/web/pulls) for the same update/change?

## Pull Request Type

- [ ] :bug: Bug fix (Non-breaking Change: Fixes an issue)
- [x] :hammer_and_wrench: Chore (Non-breaking Change: Doc updates, pkg upgrades, typos, etc..)
- [ ] :nail_care: New Feature (Breaking/Non-breaking Change)

## Issue (if applicable)

<!-----------------------------------------------------------------------------
If applicable, please link to the github issue and put `closes #XXXX` in your comment to auto-close the issue that your PR fixes.
------------------------------------------------------------------------------>

n/a - multi account related

## Risk

* we should the wrong amounts for accounts on asset and account pages

<!-----------------------------------------------------------------------------
Outline the scope of your changes and the risk associated with them. You must use your discretion as an engineer to determine the potential impact of your changes.

E.g. an upgrade to `hdwallet` or core state management would be considered higher risk, and might require a full regression test. UI or isolated view changes, or something behind a feature flag may have near zero risk. Small bug fixes might require testing isolated to the specific fix.
------------------------------------------------------------------------------>

## Testing

* have a wallet with cosmos balances in more than one account
* with the multi account flag off - ensure the total shown on the cosmos asset pages matches what is displayed in the asset allocation row
* with the multi account flag on - navigate back to the cosmos asset page. the total shown above the chart, in both fiat and crypto human amounts, should match the sum of what is displayed in the in the asset allocation section
* navigate to each individual cosmos account and ensure the balances are specific to that account

<!-----------------------------------------------------------------------------
We treat every PR to be merged with the same scrutiny as if we were merging directly to production.

Your PR will not be merged if you do not complete the sections below for our engineering and operations teams to test.
------------------------------------------------------------------------------>

### Engineering

* see common testing steps

<!-----------------------------------------------------------------------------
Include sufficient information here for an engineer to test your PR. This may include how to test locally, in a built environment, changes to infrastructure etc.
------------------------------------------------------------------------------>

### Operations

* see common testing steps

<!-----------------------------------------------------------------------------
If your changes have a user-facing impact, describe how a non-technical QA team can functionally test your changes in a preview environment.

If they are not user-facing please describe how to test for any regressions that may occur.
------------------------------------------------------------------------------>

## Screenshots (if applicable)

before/after left/right respectively

<img width="1792" alt="image" src="https://user-images.githubusercontent.com/88504456/194965494-321e891c-b2ad-4bb8-bd5e-48b5a6b78be3.png">

