### PR TITLE
feat: lock buy account to sell account for 0x & CowSwaps

### DIFF
--- a/package.json
+++ b/package.json
@@ -107,7 +107,7 @@
     "@shapeshiftoss/investor-yearn": "^6.1.2",
     "@shapeshiftoss/logger": "^1.1.3",
     "@shapeshiftoss/market-service": "^7.1.0",
-    "@shapeshiftoss/swapper": "^11.5.5",
+    "@shapeshiftoss/swapper": "^11.5.6",
     "@shapeshiftoss/types": "^8.3.1",
     "@shapeshiftoss/unchained-client": "^10.1.2",
     "@uniswap/sdk": "^3.0.3",

--- a/src/components/AccountDropdown/AccountDropdown.tsx
+++ b/src/components/AccountDropdown/AccountDropdown.tsx
@@ -125,8 +125,8 @@ export const AccountDropdown: FC<AccountDropdownProps> = ({
       validatedAccountIdFromArgs ??
       (autoSelectHighestBalance ? highestFiatBalanceAccountId : undefined) ??
       firstAccountId
-    firstAccountId !== selectedAccountId && setSelectedAccountId(preSelectedAccountId) // don't set to same thing again
-    // this effect sets selectedAccountId for the first render when we receive accountIds
+    setSelectedAccountId(preSelectedAccountId)
+    // this effect sets selectedAccountId on first render when we receive accountIds and when defaultAccountId changes
     // eslint-disable-next-line react-hooks/exhaustive-deps
   }, [assetId, accountIds, defaultAccountId])
 

--- a/src/components/DeFi/components/AssetInput.tsx
+++ b/src/components/DeFi/components/AssetInput.tsx
@@ -70,6 +70,7 @@ export type AssetInputProps = {
   showInputSkeleton?: boolean
   showFiatSkeleton?: boolean
   formControlProps?: FormControlProps
+  accountSelectionDisabled?: boolean
 } & PropsWithChildren
 
 export const AssetInput: React.FC<AssetInputProps> = ({
@@ -95,6 +96,7 @@ export const AssetInput: React.FC<AssetInputProps> = ({
   showInputSkeleton,
   showFiatSkeleton,
   formControlProps,
+  accountSelectionDisabled,
 }) => {
   const {
     number: { localeParts },
@@ -223,6 +225,7 @@ export const AssetInput: React.FC<AssetInputProps> = ({
           assetId={assetId}
           onChange={handleAccountIdChange}
           buttonProps={{ variant: 'ghost', width: 'full', paddingX: 2, paddingY: 0 }}
+          disabled={accountSelectionDisabled}
           autoSelectHighestBalance
         />
       )}

--- a/src/components/Trade/TradeInputV2.tsx
+++ b/src/components/Trade/TradeInputV2.tsx
@@ -45,7 +45,8 @@ export const TradeInput = () => {
   useSwapperService()
   const [isLoading, setIsLoading] = useState(false)
   const { setTradeAmountsUsingExistingData, setTradeAmountsRefetchData } = useTradeAmounts()
-  const { checkApprovalNeeded, getTrade, bestTradeSwapper } = useSwapper()
+  const { checkApprovalNeeded, getTrade, bestTradeSwapper, swapperSupportsCrossAccountTrade } =
+    useSwapper()
   const history = useHistory()
   const borderColor = useColorModeValue('gray.100', 'gray.750')
   const { control, setValue, getValues, handleSubmit } = useFormContext<TradeState<KnownChainIds>>()
@@ -389,6 +390,7 @@ export const TradeInput = () => {
             percentOptions={[1]}
             onAssetClick={() => history.push(TradeRoutePaths.BuySelect)}
             onAccountIdChange={handleBuyAccountIdChange}
+            accountSelectionDisabled={!swapperSupportsCrossAccountTrade}
             showInputSkeleton={isSwapperApiPending && !quoteAvailableForCurrentAssetPair}
             showFiatSkeleton={isSwapperApiPending && !quoteAvailableForCurrentAssetPair}
           />

--- a/src/components/Trade/hooks/useSwapper/useSwapperV2.tsx
+++ b/src/components/Trade/hooks/useSwapper/useSwapperV2.tsx
@@ -1,6 +1,11 @@
 import { type Asset } from '@shapeshiftoss/asset-service'
 import type { UtxoBaseAdapter } from '@shapeshiftoss/chain-adapters'
-import { type Swapper, type UtxoSupportedChainIds, SwapperManager } from '@shapeshiftoss/swapper'
+import {
+  type Swapper,
+  type UtxoSupportedChainIds,
+  SwapperManager,
+  SwapperName,
+} from '@shapeshiftoss/swapper'
 import type { KnownChainIds } from '@shapeshiftoss/types'
 import { useCallback, useEffect, useMemo, useState } from 'react'
 import { useFormContext, useWatch } from 'react-hook-form'
@@ -91,6 +96,19 @@ export const useSwapper = () => {
   const buyAccountMetadata = useAppSelector(state =>
     selectPortfolioAccountMetadataByAccountId(state, buyAccountFilter),
   )
+
+  const swapperSupportsCrossAccountTrade = useMemo(() => {
+    if (!bestTradeSwapper) return false
+    switch (bestTradeSwapper.name) {
+      case SwapperName.Thorchain:
+        return true
+      case SwapperName.Zrx:
+      case SwapperName.CowSwap:
+        return false
+      default:
+        return false
+    }
+  }, [bestTradeSwapper])
 
   const getReceiveAddressFromBuyAsset = useCallback(
     async (buyAsset: Asset) => {
@@ -227,5 +245,6 @@ export const useSwapper = () => {
     receiveAddress,
     getReceiveAddressFromBuyAsset,
     getTrade,
+    swapperSupportsCrossAccountTrade,
   }
 }

--- a/yarn.lock
+++ b/yarn.lock
@@ -4340,10 +4340,10 @@
     google-protobuf "^3.17.0"
     long "^4.0.0"
 
-"@shapeshiftoss/swapper@^11.5.5":
-  version "11.5.5"
-  resolved "https://registry.yarnpkg.com/@shapeshiftoss/swapper/-/swapper-11.5.5.tgz#78aec5496abbf348b657dc602138b81dc0d72b91"
-  integrity sha512-7jLYlo+BIZZODMoCYWMPmseSLsThOKazV1eQQgAvD4BUIyw4LGYFKsCHpT14O8u4LvSrgJofY30ur222RAVj/Q==
+"@shapeshiftoss/swapper@^11.5.6":
+  version "11.5.6"
+  resolved "https://registry.yarnpkg.com/@shapeshiftoss/swapper/-/swapper-11.5.6.tgz#d8c2b9dd1f1d51823905759c8e3f01580f0b2716"
+  integrity sha512-Ksmhdf7Mg0mYgXTyHxppFfMxrzviGA8CVdAqAvfm0jGkU5KJokOm+3Mfjfk4pXwHK0s0lgdHv3y+hJhBi9R++A==
   dependencies:
     axios "^0.26.1"
     bignumber.js "^9.0.2"


### PR DESCRIPTION
## Description

This PR locks the buy asset account ID to the sell asset account ID for 0x and CowSwap trades, as these protocols don't support sending to different receive addresses.

## Notice

- [x] Have you followed the guidelines in our [Contributing]('https://github.com/shapeshift/web/blob/develop/CONTRIBUTING.md) guide?
- [x] Have you checked to ensure there aren't other open [Pull Requests](https://github.com/shapeshift/web/pulls) for the same update/change?

## Pull Request Type

- [ ] :bug: Bug fix (Non-breaking Change: Fixes an issue)
- [ ] :hammer_and_wrench: Chore (Non-breaking Change: Doc updates, pkg upgrades, typos, etc..)
- [x] :nail_care: New Feature (Breaking/Non-breaking Change)

## Issue (if applicable)

Closes https://github.com/shapeshift/web/issues/3019

## Risk

Small, some risk that the `onChange` handler fires more than once, or some other useEffecty bug caused by the removal of `firstAccountId !== selectedAccountId`.

## Testing

1. Enable the multi-account flag.
2. Connect a wallet that supports multiple EVM accounts, e.g. Native
3. Ensure a trade asset pair is selected such that 0x or CowSwap is used as the swapping protocol
4. The buy asset account should be disabled for selection, and locked to the selected sell asset account value

### Engineering

☝️ 

### Operations

☝️ 

## Screenshots (if applicable)

<img width="403" alt="Screen Shot 2022-10-11 at 1 31 23 pm" src="https://user-images.githubusercontent.com/97164662/194983742-7c79bb34-181d-40a0-9b44-a87772e5a6ba.png">
