### PR TITLE
fix: negative send max quote request

### DIFF
--- a/src/components/Trade/hooks/useSwapper/utils.ts
+++ b/src/components/Trade/hooks/useSwapper/utils.ts
@@ -78,12 +78,14 @@ export const getSendMaxAmount = (
   const feeEstimate = bnOrZero(quote?.feeData?.fee)
   // sell asset balance minus expected fee = maxTradeAmount
   // only subtract if sell asset is fee asset
-  return fromBaseUnit(
+  const maxSendAmount = fromBaseUnit(
     bnOrZero(sellAssetBalance)
       .minus(isFeeAsset ? feeEstimate : 0)
       .toString(),
     sellAsset.precision,
   )
+
+  return bn(maxSendAmount).isPositive() ? maxSendAmount : '0'
 }
 
 const getEvmFees = <T extends EvmChainId>(

--- a/src/components/Trade/hooks/useSwapper/utils.ts
+++ b/src/components/Trade/hooks/useSwapper/utils.ts
@@ -28,7 +28,7 @@ import {
   type SupportedSwappingChain,
 } from 'components/Trade/types'
 import { getChainAdapterManager } from 'context/PluginProvider/chainAdapterSingleton'
-import { bn, bnOrZero } from 'lib/bignumber/bignumber'
+import { bn, bnOrZero, positiveOrZero } from 'lib/bignumber/bignumber'
 import { logger } from 'lib/logger'
 import { fromBaseUnit } from 'lib/math'
 import { accountIdToUtxoParams } from 'state/slices/portfolioSlice/utils'
@@ -78,14 +78,14 @@ export const getSendMaxAmount = (
   const feeEstimate = bnOrZero(quote?.feeData?.fee)
   // sell asset balance minus expected fee = maxTradeAmount
   // only subtract if sell asset is fee asset
-  const maxSendAmount = fromBaseUnit(
-    bnOrZero(sellAssetBalance)
-      .minus(isFeeAsset ? feeEstimate : 0)
-      .toString(),
-    sellAsset.precision,
-  )
-
-  return bn(maxSendAmount).isPositive() ? maxSendAmount : '0'
+  return positiveOrZero(
+    fromBaseUnit(
+      bnOrZero(sellAssetBalance)
+        .minus(isFeeAsset ? feeEstimate : 0)
+        .toString(),
+      sellAsset.precision,
+    ),
+  ).toString()
 }
 
 const getEvmFees = <T extends EvmChainId>(


### PR DESCRIPTION
## Description

Currently, when "Max" is pressed when there is not enough of the sell asset to complete a trade, the `getSendMaxAmount` function will return a negative value.

This negative value is then used in the quote request, which fails.
This would sometimes cause the "Max" button to become disabled, with no way to re-enable it.

This PR updates `getSendMaxAmount` to return `'0'` if the max send amount is not positive.

## Notice

- [x] Have you followed the guidelines in our [Contributing]('https://github.com/shapeshift/web/blob/develop/CONTRIBUTING.md) guide?
- [x] Have you checked to ensure there aren't other open [Pull Requests](https://github.com/shapeshift/web/pulls) for the same update/change?

## Pull Request Type

- [x] :bug: Bug fix (Non-breaking Change: Fixes an issue)
- [ ] :hammer_and_wrench: Chore (Non-breaking Change: Doc updates, pkg upgrades, typos, etc..)
- [ ] :nail_care: New Feature (Breaking/Non-breaking Change)

## Issue (if applicable)

N/A - discovered whilst messing with the swapper.

## Risk

Very small - touches only the pure function that calculates the max send amount.

## Testing

Click "Max" when there is not enough of the sell asset to perform the trade, but the balance is greater than `0`.
The sell amount should be, and stay `0`. The "Max" button should not become disabled.

### Engineering

Ensure that the quote requests are all returning `200`, and that the `sellAmount` is positive or `0`.

### Operations

☝️ 

## Screenshots (if applicable)

Before:

<img width="421" alt="Screen Shot 2022-10-11 at 1 23 40 pm" src="https://user-images.githubusercontent.com/97164662/194984407-841f2a48-5937-40e8-9487-7cd5f5fcf384.png">

