### PR TITLE
fix: fox page demo wallet / ready state checks

### DIFF
--- a/src/plugins/foxPage/components/AssetActions.tsx
+++ b/src/plugins/foxPage/components/AssetActions.tsx
@@ -67,7 +67,7 @@ export const AssetActions: React.FC<FoxTabProps> = ({ assetId }) => {
   )
   const handleReceiveClick = useCallback(
     () =>
-      isDemoWallet || (isConnected && walletSupportsETH)
+      !isDemoWallet && isConnected && walletSupportsETH
         ? receive.open({ asset, accountId })
         : handleWalletModalOpen(),
     [

--- a/src/plugins/foxPage/components/AssetActions.tsx
+++ b/src/plugins/foxPage/components/AssetActions.tsx
@@ -54,26 +54,36 @@ export const AssetActions: React.FC<FoxTabProps> = ({ assetId }) => {
   const accountId = accountIds?.[0]
 
   const {
-    state: { isConnected, wallet },
+    state: { isConnected, isDemoWallet, wallet },
     dispatch,
   } = useWallet()
   const { receive } = useModal()
+
+  const walletSupportsETH = useMemo(() => Boolean(wallet && supportsETH(wallet)), [wallet])
+
   const handleWalletModalOpen = useCallback(
     () => dispatch({ type: WalletActions.SET_WALLET_MODAL, payload: true }),
     [dispatch],
   )
   const handleReceiveClick = useCallback(
     () =>
-      wallet && isConnected && supportsETH(wallet)
+      isDemoWallet || (isConnected && walletSupportsETH)
         ? receive.open({ asset, accountId })
         : handleWalletModalOpen(),
-    [accountId, asset, handleWalletModalOpen, isConnected, receive, wallet],
+    [
+      accountId,
+      asset,
+      handleWalletModalOpen,
+      isConnected,
+      isDemoWallet,
+      receive,
+      walletSupportsETH,
+    ],
   )
 
-  const walletSupportsETH = useMemo(() => Boolean(wallet && supportsETH(wallet)), [wallet])
   const receiveButtonTranslation = useMemo(
-    () => (walletSupportsETH ? 'plugins.foxPage.receive' : 'common.connectWallet'),
-    [walletSupportsETH],
+    () => (!isDemoWallet && walletSupportsETH ? 'plugins.foxPage.receive' : 'common.connectWallet'),
+    [isDemoWallet, walletSupportsETH],
   )
 
   const onGetAssetClick = useCallback(() => {
@@ -144,7 +154,7 @@ export const AssetActions: React.FC<FoxTabProps> = ({ assetId }) => {
                 )}
                 <Skeleton width='full' isLoaded={Boolean(wallet)}>
                   <Button
-                    disabled={walletSupportsETH}
+                    disabled={!walletSupportsETH}
                     onClick={handleReceiveClick}
                     width='full'
                     size='lg'

--- a/src/plugins/foxPage/components/AssetActions.tsx
+++ b/src/plugins/foxPage/components/AssetActions.tsx
@@ -153,13 +153,7 @@ export const AssetActions: React.FC<FoxTabProps> = ({ assetId }) => {
                   </Button>
                 )}
                 <Skeleton width='full' isLoaded={Boolean(wallet)}>
-                  <Button
-                    disabled={!walletSupportsETH}
-                    onClick={handleReceiveClick}
-                    width='full'
-                    size='lg'
-                    colorScheme='gray'
-                  >
+                  <Button onClick={handleReceiveClick} width='full' size='lg' colorScheme='gray'>
                     <Text translation={receiveButtonTranslation} />
                   </Button>
                 </Skeleton>

--- a/src/plugins/foxPage/components/MainOpportunity.tsx
+++ b/src/plugins/foxPage/components/MainOpportunity.tsx
@@ -29,7 +29,7 @@ export const MainOpportunity = ({
   isLoaded,
 }: MainOpportunityProps) => {
   const {
-    state: { wallet },
+    state: { wallet, isDemoWallet },
   } = useWallet()
 
   const selectedAsset = useAppSelector(state => selectAssetById(state, assetId))
@@ -40,14 +40,14 @@ export const MainOpportunity = ({
   const hasActiveStaking = bnOrZero(foxyBalancesData?.opportunities?.[0]?.balance).gt(0)
 
   const opportunityButtonTranslation = useMemo(() => {
+    if (isDemoWallet || !wallet || !supportsETH(wallet)) return 'common.connectWallet'
     if (hasActiveStaking) return 'plugins.foxPage.manage'
-    if (!wallet || !supportsETH(wallet)) return 'common.connectWallet'
     return 'plugins.foxPage.getStarted'
-  }, [wallet, hasActiveStaking])
+  }, [isDemoWallet, wallet, hasActiveStaking])
 
   const isOpportunityButtonReady = useMemo(
-    () => Boolean((wallet && !supportsETH(wallet)) || isFoxyBalancesLoading),
-    [wallet, isFoxyBalancesLoading],
+    () => Boolean(isDemoWallet || (wallet && !supportsETH(wallet)) || !isFoxyBalancesLoading),
+    [wallet, isDemoWallet, isFoxyBalancesLoading],
   )
 
   return (

--- a/src/plugins/foxPage/components/OtherOpportunities/FoxOtherOpportunityPanelRow.tsx
+++ b/src/plugins/foxPage/components/OtherOpportunities/FoxOtherOpportunityPanelRow.tsx
@@ -24,7 +24,7 @@ export const FoxOtherOpportunityPanelRow: React.FC<FoxOtherOpportunityPanelRowPr
   opportunity,
 }) => {
   const {
-    state: { wallet },
+    state: { isDemoWallet, wallet },
     dispatch,
   } = useWallet()
   const hoverOpportunityBg = useColorModeValue('gray.100', 'gray.750')
@@ -43,7 +43,7 @@ export const FoxOtherOpportunityPanelRow: React.FC<FoxOtherOpportunityPanelRowPr
       return
     }
 
-    if (!wallet || !supportsETH(wallet)) {
+    if (isDemoWallet || !wallet || !supportsETH(wallet)) {
       dispatch({ type: WalletActions.SET_WALLET_MODAL, payload: true })
       return
     }
@@ -65,18 +65,18 @@ export const FoxOtherOpportunityPanelRow: React.FC<FoxOtherOpportunityPanelRowPr
       })
       return
     }
-  }, [defiOpportunity, dispatch, history, location, opportunity.link, wallet])
+  }, [isDemoWallet, defiOpportunity, dispatch, history, location, opportunity.link, wallet])
 
   const opportunityButtonTranslation = useMemo(() => {
     if (opportunity.link) return 'plugins.foxPage.getStarted'
-    if (!wallet || !supportsETH(wallet)) return 'common.connectWallet'
+    if (isDemoWallet || !wallet || !supportsETH(wallet)) return 'common.connectWallet'
 
     return hasActivePosition ? 'plugins.foxPage.manage' : 'plugins.foxPage.getStarted'
-  }, [opportunity.link, hasActivePosition, wallet])
+  }, [isDemoWallet, opportunity.link, hasActivePosition, wallet])
 
   const isOpportunityButtonReady = useMemo(
-    () => Boolean((wallet && !supportsETH(wallet)) || defiOpportunity?.isLoaded),
-    [wallet, defiOpportunity],
+    () => Boolean(isDemoWallet || (wallet && !supportsETH(wallet)) || defiOpportunity?.isLoaded),
+    [isDemoWallet, wallet, defiOpportunity],
   )
 
   return (


### PR DESCRIPTION
## Description

This PR fixes:

- The Fox Page for demo wallet, using the "Connect Wallet" flow instead of the current demo wallet FOX/y / FOX/ETH LP/Farming balances flow, as discussed with @shapeshift/product
- The disabled state for wallets supporting ETH, which erroneously got broken in https://github.com/shapeshift/web/pull/2981/files#diff-dc299dddf3dc49cb7c52673353de768f670fb824a279931b461717bdcf50299cR147 - we should never end up in a disabled state

## Notice

<!-- Before submitting a pull request, please make sure you have answered the following: -->

- [x] Have you followed the guidelines in our [Contributing]('https://github.com/shapeshift/web/blob/develop/CONTRIBUTING.md) guide?
- [x] Have you checked to ensure there aren't other open [Pull Requests](https://github.com/shapeshift/web/pulls) for the same update/change?

## Pull Request Type

- [x] :bug: Bug fix (Non-breaking Change: Fixes an issue)
- [ ] :hammer_and_wrench: Chore (Non-breaking Change: Doc updates, pkg upgrades, typos, etc..)
- [ ] :nail_care: New Feature (Breaking/Non-breaking Change)

## Issue (if applicable)

<!-----------------------------------------------------------------------------
If applicable, please link to the github issue and put `closes #XXXX` in your comment to auto-close the issue that your PR fixes.
------------------------------------------------------------------------------>

- relates to the closed https://github.com/shapeshift/web/issues/2980

## Risk

<!-----------------------------------------------------------------------------
Outline the scope of your changes and the risk associated with them. You must use your discretion as an engineer to determine the potential impact of your changes.

E.g. an upgrade to `hdwallet` or core state management would be considered higher risk, and might require a full regression test. UI or isolated view changes, or something behind a feature flag may have near zero risk. Small bug fixes might require testing isolated to the specific fix.
------------------------------------------------------------------------------>

FOX page could be borked for wallets, test accordingly

## Testing

<!-----------------------------------------------------------------------------
We treat every PR to be merged with the same scrutiny as if we were merging directly to production.

Your PR will not be merged if you do not complete the sections below for our engineering and operations teams to test.
------------------------------------------------------------------------------>

- FOX Page looks good with demo wallet / Keplr connected and shows a "Connect Wallet" instead of "Get Started / Manage"
- FOX Page with native wallet / MM shows no regressions, showing the "Get Started / Manage" copy depending on balance for said opportunity
- On a wallet supporting ETH receive connected (i.e not demo wallet), Receive is shown on the "Get FOX" component and clicking it opens the receive FOX modal
- On a wallet not supporting ETH receive connected (e.g Keplr), Connect Wallet is shown on the "Get FOX" component and clicking it opens the connect wallet modal

### Engineering

<!-----------------------------------------------------------------------------
Include sufficient information here for an engineer to test your PR. This may include how to test locally, in a built environment, changes to infrastructure etc.
------------------------------------------------------------------------------>

- See top-level notes ☝🏽
- Implementation looks sane

### Operations

<!-----------------------------------------------------------------------------
If your changes have a user-facing impact, describe how a non-technical QA team can functionally test your changes in a preview environment.

If they are not user-facing please describe how to test for any regressions that may occur.
------------------------------------------------------------------------------>

- See top-level notes ☝🏽 

## Screenshots (if applicable)

<img width="1717" alt="image" src="https://user-images.githubusercontent.com/17035424/195006016-174b4177-a8de-4d2c-996e-55ee5e563792.png">
<img width="1721" alt="image" src="https://user-images.githubusercontent.com/17035424/195006056-c12ec231-d318-4a18-a523-3eb0cc62952d.png">
<img width="1719" alt="image" src="https://user-images.githubusercontent.com/17035424/195006150-20717d7d-3914-48fe-a398-9b9f536719c7.png">