### PR TITLE
revert: fix: use placeholder when value is zero (#2989)

### DIFF
--- a/src/components/DeFi/components/AssetInput.tsx
+++ b/src/components/DeFi/components/AssetInput.tsx
@@ -110,13 +110,9 @@ export const AssetInput: React.FC<AssetInputProps> = ({
 
   // Lower the decimal places when the integer is greater than 8 significant digits for better UI
   const cryptoAmountIntegerCount = bnOrZero(bnOrZero(cryptoAmount).toFixed(0)).precision(true)
-  const formattedCryptoAmount = bnOrZero(cryptoAmount).gt(0)
-    ? bnOrZero(cryptoAmountIntegerCount).isLessThanOrEqualTo(8)
-      ? cryptoAmount
-      : bnOrZero(cryptoAmount).toFixed(3)
-    : null
-
-  const formattedFiatAmount = bnOrZero(fiatAmount).gt(0) ? bnOrZero(fiatAmount).toFixed(2) : null
+  const formattedCryptoAmount = bnOrZero(cryptoAmountIntegerCount).isLessThanOrEqualTo(8)
+    ? cryptoAmount
+    : bnOrZero(cryptoAmount).toFixed(3)
 
   return (
     <FormControl
@@ -154,11 +150,10 @@ export const AssetInput: React.FC<AssetInputProps> = ({
               disabled={isReadOnly}
               suffix={isFiat ? localeParts.postfix : ''}
               prefix={isFiat ? localeParts.prefix : ''}
-              placeholder={isFiat ? `${localeParts.prefix}0.00${localeParts.postfix}` : '0.00'}
               decimalSeparator={localeParts.decimal}
               inputMode='decimal'
               thousandSeparator={localeParts.group}
-              value={isFiat ? formattedFiatAmount : formattedCryptoAmount}
+              value={isFiat ? bnOrZero(fiatAmount).toFixed(2) : formattedCryptoAmount}
               onValueChange={values => {
                 // This fires anytime value changes including setting it on max click
                 // Store the value in a ref to send when we actually want the onChange to fire


### PR DESCRIPTION
This reverts commit d9a9932baa58015b34f6b944567994a969d39df9.

## Description

Reverts https://github.com/shapeshift/web/pull/2989.

This PR causes a number of issues with the swapper:

- When changing assets (using asset selection or toggling), the sell amount is not cleared, and the amounts aren't updated
- When fees are higher than the buy amount (easy to replicate with ThorSwap), and a sell amount is entered, the amounts to not update
- I suspect some other things get a bit dicky

It's probably a simple fix, though I haven't had time to look into it further and the feature isn't worth the bug.
Something probably expects a `'0'` and is now receiving a `null`.


https://user-images.githubusercontent.com/97164662/195052122-6e0f6c28-127c-47c1-9a27-b0876451207e.mov

## Notice

- [x] Have you followed the guidelines in our [Contributing]('https://github.com/shapeshift/web/blob/develop/CONTRIBUTING.md) guide?
- [x] Have you checked to ensure there aren't other open [Pull Requests](https://github.com/shapeshift/web/pulls) for the same update/change?

## Pull Request Type

- [x] :bug: Bug fix (Non-breaking Change: Fixes an issue)
- [ ] :hammer_and_wrench: Chore (Non-breaking Change: Doc updates, pkg upgrades, typos, etc..)
- [ ] :nail_care: New Feature (Breaking/Non-breaking Change)

## Issue (if applicable)

N/A

## Risk

Minimal, reverts a small and recent commit.

## Testing

The issues described above should no longer occur.

### Engineering

☝️ 

### Operations

☝️ 

## Screenshots (if applicable)

N/A