### PR TITLE
chore: bump swapper to 11.5.7

### DIFF
--- a/package.json
+++ b/package.json
@@ -107,7 +107,7 @@
     "@shapeshiftoss/investor-yearn": "^6.1.2",
     "@shapeshiftoss/logger": "^1.1.3",
     "@shapeshiftoss/market-service": "^7.1.0",
-    "@shapeshiftoss/swapper": "^11.5.6",
+    "@shapeshiftoss/swapper": "^11.5.7",
     "@shapeshiftoss/types": "^8.3.1",
     "@shapeshiftoss/unchained-client": "^10.1.2",
     "@uniswap/sdk": "^3.0.3",

--- a/yarn.lock
+++ b/yarn.lock
@@ -4340,10 +4340,10 @@
     google-protobuf "^3.17.0"
     long "^4.0.0"
 
-"@shapeshiftoss/swapper@^11.5.6":
-  version "11.5.6"
-  resolved "https://registry.yarnpkg.com/@shapeshiftoss/swapper/-/swapper-11.5.6.tgz#d8c2b9dd1f1d51823905759c8e3f01580f0b2716"
-  integrity sha512-Ksmhdf7Mg0mYgXTyHxppFfMxrzviGA8CVdAqAvfm0jGkU5KJokOm+3Mfjfk4pXwHK0s0lgdHv3y+hJhBi9R++A==
+"@shapeshiftoss/swapper@^11.5.7":
+  version "11.5.7"
+  resolved "https://registry.yarnpkg.com/@shapeshiftoss/swapper/-/swapper-11.5.7.tgz#5306c36dcaa671e1cc3e1645ae311bbd3ebcce83"
+  integrity sha512-6mPHAxTBt1fUzEGVxsDVZFJ1YdiWn8VG5B3bAw+hZ72D90OLkrJmejR1D3Z5GDFrq9ghq3z+nXf+DSONOWCQUg==
   dependencies:
     axios "^0.26.1"
     bignumber.js "^9.0.2"


### PR DESCRIPTION
## Description

Bumps swapper to the version that makes THORchain trades into ETH Mainnet accounts have a $50 minimum.

## Notice

- [x] Have you followed the guidelines in our [Contributing]('https://github.com/shapeshift/web/blob/develop/CONTRIBUTING.md) guide?
- [x] Have you checked to ensure there aren't other open [Pull Requests](https://github.com/shapeshift/web/pulls) for the same update/change?

## Pull Request Type

- [ ] :bug: Bug fix (Non-breaking Change: Fixes an issue)
- [x] :hammer_and_wrench: Chore (Non-breaking Change: Doc updates, pkg upgrades, typos, etc..)
- [ ] :nail_care: New Feature (Breaking/Non-breaking Change)

## Issue (if applicable)

Ensures https://github.com/shapeshift/web/issues/3024 is resolved.

## Risk

Small, see https://github.com/shapeshift/lib/pull/1056

## Testing

1. Link branch to `web`
2. Ensure ThorSwap enabled in `web`
3. Get ThorSwap quote for any trade into the Ethereum Mainnet - the minimum amount of the sell asset should be approximately equal to $50

### Engineering

☝️ 

### Operations

☝️ 

## Screenshots (if applicable)

<img width="393" alt="Screen Shot 2022-10-12 at 10 09 46 am" src="https://user-images.githubusercontent.com/97164662/195218699-03c5c152-1f30-4b1c-9406-396fe6e3908f.png">
<img width="401" alt="Screen Shot 2022-10-12 at 10 09 55 am" src="https://user-images.githubusercontent.com/97164662/195218705-b3258fc9-9b65-4f2b-9545-2aec6793d90e.png">
