### PR TITLE
feat: add smart banner support

### DIFF
--- a/public/index.html
+++ b/public/index.html
@@ -10,6 +10,8 @@
     <meta name="referrer" content="%REACT_APP_REFERRER%">
     <meta name="apple-mobile-web-app-status-bar-style" content="black-translucent">
     <meta http-equiv="Content-Security-Policy" content="%REACT_APP_CSP_META%" />
+    <meta name="apple-itunes-app" content="app-id=996569075">
+
     <!-- WalletConnect uses the first image found in the head metadata for their wallet connect SDKs (web, kotlin, swift) -->
     <link rel="apple-touch-icon" sizes="192x192" href="%PUBLIC_URL%/icon-192x192.png" integrity="%REACT_APP_SRI_ICON_192X192_PNG%" crossorigin="anonymous" />
     <link rel="apple-touch-icon" sizes="512x512" href="%PUBLIC_URL%/icon-512x512.png" integrity="%REACT_APP_SRI_ICON_512X512_PNG%" crossorigin="anonymous" />

--- a/public/index.html
+++ b/public/index.html
@@ -11,7 +11,6 @@
     <meta name="apple-mobile-web-app-status-bar-style" content="black-translucent">
     <meta http-equiv="Content-Security-Policy" content="%REACT_APP_CSP_META%" />
     <meta name="apple-itunes-app" content="app-id=996569075">
-
     <!-- WalletConnect uses the first image found in the head metadata for their wallet connect SDKs (web, kotlin, swift) -->
     <link rel="apple-touch-icon" sizes="192x192" href="%PUBLIC_URL%/icon-192x192.png" integrity="%REACT_APP_SRI_ICON_192X192_PNG%" crossorigin="anonymous" />
     <link rel="apple-touch-icon" sizes="512x512" href="%PUBLIC_URL%/icon-512x512.png" integrity="%REACT_APP_SRI_ICON_512X512_PNG%" crossorigin="anonymous" />

--- a/public/manifest.json
+++ b/public/manifest.json
@@ -28,5 +28,14 @@
       "sizes": "512x512",
       "type": "image/png"
     }
+  ],
+  "prefer_related_applications": true,
+  "related_applications": [
+    {
+      "platform": "play",
+      "id": "com.shapeshift.droid_shapeshift",
+      "url": "https://play.google.com/store/apps/details?id=com.shapeshift.droid_shapeshift"
+    }
   ]
+
 }


### PR DESCRIPTION
## Description

- Add meta tag for iOS
- Add the relevant info in the manifest for android (https://stackoverflow.com/questions/55838392/how-exactly-are-we-supposed-to-implement-the-native-app-install-prompt-for-chrom/66699710#66699710)

## Notice

<!-- Before submitting a pull request, please make sure you have answered the following: -->

- [x] Have you followed the guidelines in our [Contributing]('https://github.com/shapeshift/web/blob/develop/CONTRIBUTING.md) guide?
- [x] Have you checked to ensure there aren't other open [Pull Requests](https://github.com/shapeshift/web/pulls) for the same update/change?

## Pull Request Type

- [ ] :bug: Bug fix (Non-breaking Change: Fixes an issue)
- [ ] :hammer_and_wrench: Chore (Non-breaking Change: Doc updates, pkg upgrades, typos, etc..)
- [x] :nail_care: New Feature (Breaking/Non-breaking Change)

## Issue (if applicable)


closes #3045 

## Risk

Should pose no real risk here, the app should function as normal even if these smart banners don't work

## Testing

<!-----------------------------------------------------------------------------
We treat every PR to be merged with the same scrutiny as if we were merging directly to production.

Your PR will not be merged if you do not complete the sections below for our engineering and operations teams to test.
------------------------------------------------------------------------------>

### Engineering

We will need a fleak build to test if this is working like we think it is. Testing on both iOS and Android.

### Operations

When on an iOS phone you should see a banner at the top with a link to download the native app.

On android you should see a prompt to install the native version of the app.

## Screenshots (if applicable)
