### PR TITLE
fix(fox-eth LP): sync PairDeposit AccountIds

### DIFF
--- a/src/features/defi/providers/fox-eth-lp/components/FoxEthLpManager/Deposit/FoxEthLpDeposit.tsx
+++ b/src/features/defi/providers/fox-eth-lp/components/FoxEthLpManager/Deposit/FoxEthLpDeposit.tsx
@@ -85,8 +85,7 @@ export const FoxEthLpDeposit: React.FC<FoxEthLpDepositProps> = ({
         component: ownProps => <Status {...ownProps} accountId={accountId} />,
       },
     }
-    // eslint-disable-next-line react-hooks/exhaustive-deps
-  }, [asset.symbol])
+  }, [accountId, asset.symbol, handleAccountIdChange, translate])
 
   useEffect(() => {
     dispatch({ type: FoxEthLpDepositActionType.SET_OPPORTUNITY, payload: opportunity })

--- a/src/features/defi/providers/fox-eth-lp/components/FoxEthLpManager/Withdraw/FoxEthLpWithdraw.tsx
+++ b/src/features/defi/providers/fox-eth-lp/components/FoxEthLpManager/Withdraw/FoxEthLpWithdraw.tsx
@@ -111,9 +111,7 @@ export const FoxEthLpWithdraw: React.FC<FoxEthLpWithdrawProps> = ({
         component: ownProps => <Status {...ownProps} accountId={accountId} />,
       },
     }
-    // We only need this to update on symbol change
-    // eslint-disable-next-line react-hooks/exhaustive-deps
-  }, [underlyingAsset.symbol])
+  }, [accountId, handleAccountIdChange, translate, underlyingAsset.symbol])
 
   if (loading || !asset || !marketData)
     return (


### PR DESCRIPTION
## Description

<!-- Please describe your changes -->

This PR fixes the `<PairDeposit />` fields not being synced for FOX/ETH LP, by not ignoring the accountId dependency in the StepConfig useMemo() deps.

Note, there is a flash of content happening when changing accounts from
pair deposit, but this is an optimization that's outside of the scope of
this bugfix.

## Notice

<!-- Before submitting a pull request, please make sure you have answered the following: -->

- [x] Have you followed the guidelines in our [Contributing]('https://github.com/shapeshift/web/blob/develop/CONTRIBUTING.md) guide?
- [x] Have you checked to ensure there aren't other open [Pull Requests](https://github.com/shapeshift/web/pulls) for the same update/change?

## Pull Request Type

- [x] :bug: Bug fix (Non-breaking Change: Fixes an issue)
- [ ] :hammer_and_wrench: Chore (Non-breaking Change: Doc updates, pkg upgrades, typos, etc..)
- [ ] :nail_care: New Feature (Breaking/Non-breaking Change)

## Issue (if applicable)

<!-----------------------------------------------------------------------------
If applicable, please link to the github issue and put `closes #XXXX` in your comment to auto-close the issue that your PR fixes.
------------------------------------------------------------------------------>

closes #3022

## Risk

<!-----------------------------------------------------------------------------
Outline the scope of your changes and the risk associated with them. You must use your discretion as an engineer to determine the potential impact of your changes.

E.g. an upgrade to `hdwallet` or core state management would be considered higher risk, and might require a full regression test. UI or isolated view changes, or something behind a feature flag may have near zero risk. Small bug fixes might require testing isolated to the specific fix.
------------------------------------------------------------------------------>

None, this properly passes accountId down, which is the same as manually
syncing both previously.

## Testing

<!-----------------------------------------------------------------------------
We treat every PR to be merged with the same scrutiny as if we were merging directly to production.

Your PR will not be merged if you do not complete the sections below for our engineering and operations teams to test.
------------------------------------------------------------------------------>

- Enable MultiAccounts flag
- Add an Ethereum account
- In the FOX/ETH LP deposit modal, select either account 0 or 1 at
  overview step
- Click deposit and in any of the pair deposit inputs, select your other
  account
- Both pair deposit inputs should be updated to reflect the account
  change

### Engineering

<!-----------------------------------------------------------------------------
Include sufficient information here for an engineer to test your PR. This may include how to test locally, in a built environment, changes to infrastructure etc.
------------------------------------------------------------------------------>

- Refer to top-level notes

### Operations

<!-----------------------------------------------------------------------------
If your changes have a user-facing impact, describe how a non-technical QA team can functionally test your changes in a preview environment.

If they are not user-facing please describe how to test for any regressions that may occur.
------------------------------------------------------------------------------>

- Refer to top-level notes

## Screenshots (if applicable)
