### PR TITLE
fix: no `accountId` on asset select

### DIFF
--- a/src/components/Trade/TradeInputV2.tsx
+++ b/src/components/Trade/TradeInputV2.tsx
@@ -224,7 +224,7 @@ export const TradeInput = () => {
         setIsLoading(false)
       }
     },
-    [checkApprovalNeeded, feeAssetFiatRate, getTrade, history, setValue],
+    [checkApprovalNeeded, feeAssetFiatRate, getTrade, history, setValue, sellAssetAccountId],
   )
 
   const onSellAssetInputChange: TradeAssetInputProps['onChange'] = useCallback(

--- a/src/components/Trade/TradeInputV2.tsx
+++ b/src/components/Trade/TradeInputV2.tsx
@@ -224,7 +224,7 @@ export const TradeInput = () => {
         setIsLoading(false)
       }
     },
-    [checkApprovalNeeded, feeAssetFiatRate, getTrade, history, setValue, sellAssetAccountId],
+    [checkApprovalNeeded, feeAssetFiatRate, getTrade, history, setValue],
   )
 
   const onSellAssetInputChange: TradeAssetInputProps['onChange'] = useCallback(

--- a/src/components/Trade/hooks/useAccountsService.tsx
+++ b/src/components/Trade/hooks/useAccountsService.tsx
@@ -18,6 +18,8 @@ export const useAccountsService = () => {
   const selectedBuyAssetAccountId = useWatch({ control, name: 'selectedBuyAssetAccountId' })
   const sellTradeAsset = useWatch({ control, name: 'sellTradeAsset' })
   const buyTradeAsset = useWatch({ control, name: 'buyTradeAsset' })
+  const formSellAssetAccountId = useWatch({ control, name: 'sellAssetAccountId' })
+  const formBuyAssetAccountId = useWatch({ control, name: 'buyAssetAccountId' })
 
   // Custom hooks
   const { swapperSupportsCrossAccountTrade } = useSwapper()
@@ -60,7 +62,8 @@ export const useAccountsService = () => {
   // Set sellAssetAccountId
   useEffect(
     () => setValue('sellAssetAccountId', sellAssetAccountId),
-    [sellAssetAccountId, setValue],
+    // formSellAssetAccountId is important here as it ensures this useEffect re-runs when the form value is cleared
+    [sellAssetAccountId, setValue, formSellAssetAccountId],
   )
 
   // Set buyAssetAccountId
@@ -70,5 +73,12 @@ export const useAccountsService = () => {
       // If the swapper does not support cross-account trades the buyAssetAccountId must match the sellAssetAccountId
       swapperSupportsCrossAccountTrade ? buyAssetAccountId : sellAssetAccountId,
     )
-  }, [buyAssetAccountId, sellAssetAccountId, setValue, swapperSupportsCrossAccountTrade])
+    // formBuyAssetAccountId is important here as it ensures this useEffect re-runs when the form value is cleared
+  }, [
+    buyAssetAccountId,
+    sellAssetAccountId,
+    setValue,
+    swapperSupportsCrossAccountTrade,
+    formBuyAssetAccountId,
+  ])
 }


### PR DESCRIPTION
## Description

When an asset is selected we clear the `accountId`. This is good, as it ensures we don't have stale account data.
When the selected asset has the same `accountId` as the previous asset, the `useEffect`s that set `sellAssetAccountId` and `buyAssetAccountId` do not re-run. This is bad, as we are stuck with an `undefined` `accountId`.

This PR ensures `sellAssetAccountId` and `buyAssetAccountId` is correctly re-set after it has been cleared.

## Notice

- [x] Have you followed the guidelines in our [Contributing]('https://github.com/shapeshift/web/blob/develop/CONTRIBUTING.md) guide?
- [x] Have you checked to ensure there aren't other open [Pull Requests](https://github.com/shapeshift/web/pulls) for the same update/change?

## Pull Request Type

- [x] :bug: Bug fix (Non-breaking Change: Fixes an issue)
- [ ] :hammer_and_wrench: Chore (Non-breaking Change: Doc updates, pkg upgrades, typos, etc..)
- [ ] :nail_care: New Feature (Breaking/Non-breaking Change)

## Issue (if applicable)

N/A - raised by ops in a thread.

## Risk

Small - though could affect account selection somehow.

## Testing

With an already approved asset pair, say USDT -> ETH, attempt to trade by clicking "Preview Trade".
We should get to the confirm screen.

Note, it is important that the assets be selected manually, rather than via the asset route.

### Engineering

☝️ 

Sense check re-renders/useEffect calls.

### Operations

☝️ 

## Screenshots (if applicable)
