### PR TITLE
chore: cosmos sdk selector rationalization

### DIFF
--- a/src/components/Bridge/BridgeRoutes/Confirm.tsx
+++ b/src/components/Bridge/BridgeRoutes/Confirm.tsx
@@ -86,9 +86,7 @@ export const Confirm: React.FC<SelectAssetProps> = ({ history }) => {
     selectMarketDataById(state, bridgeAsset?.assetId ?? ''),
   )
   const { assetReference } = fromAssetId(bridgeAsset?.assetId ?? '')
-  const accountSpecifier = useAppSelector(state =>
-    selectFirstAccountIdByChainId(state, asset?.chainId),
-  )
+  const accountId = useAppSelector(state => selectFirstAccountIdByChainId(state, asset?.chainId))
 
   const sourceChainName = fromChain?.name ? chainNameToEvmChain(fromChain.name) : undefined
   const destinationChainName = toChain?.name ? chainNameToEvmChain(toChain.name) : undefined
@@ -143,7 +141,7 @@ export const Confirm: React.FC<SelectAssetProps> = ({ history }) => {
         asset,
         address: depositAddress,
         sendMax: false,
-        accountId: accountSpecifier,
+        accountId: accountId ?? '',
         contractAddress: assetReference,
       }
 
@@ -154,7 +152,7 @@ export const Confirm: React.FC<SelectAssetProps> = ({ history }) => {
         asset,
         address: depositAddress,
         sendMax: false,
-        accountId: accountSpecifier,
+        accountId: accountId ?? '',
         amountFieldError: '',
         cryptoSymbol: bridgeAsset?.symbol ?? '',
         estimatedFees,

--- a/src/components/Bridge/BridgeRoutes/Confirm.tsx
+++ b/src/components/Bridge/BridgeRoutes/Confirm.tsx
@@ -27,7 +27,7 @@ import { RawText, Text } from 'components/Text'
 import { bnOrZero } from 'lib/bignumber/bignumber'
 import { logger } from 'lib/logger'
 import { fromBaseUnit } from 'lib/math'
-import { selectFirstAccountSpecifierByChainId } from 'state/slices/accountSpecifiersSlice/selectors'
+import { selectFirstAccountIdByChainId } from 'state/slices/accountSpecifiersSlice/selectors'
 import { selectAssetById } from 'state/slices/assetsSlice/selectors'
 import { selectMarketDataById } from 'state/slices/marketDataSlice/selectors'
 import { selectSelectedCurrency } from 'state/slices/preferencesSlice/selectors'
@@ -87,7 +87,7 @@ export const Confirm: React.FC<SelectAssetProps> = ({ history }) => {
   )
   const { assetReference } = fromAssetId(bridgeAsset?.assetId ?? '')
   const accountSpecifier = useAppSelector(state =>
-    selectFirstAccountSpecifierByChainId(state, asset?.chainId),
+    selectFirstAccountIdByChainId(state, asset?.chainId),
   )
 
   const sourceChainName = fromChain?.name ? chainNameToEvmChain(fromChain.name) : undefined

--- a/src/components/Delegate/StakingOpportunities.tsx
+++ b/src/components/Delegate/StakingOpportunities.tsx
@@ -84,10 +84,7 @@ export const StakingOpportunities = ({ assetId, accountId }: StakingOpportunitie
   const asset = useAppSelector(state => selectAssetById(state, assetId))
   const marketData = useAppSelector(state => selectMarketDataById(state, assetId))
   const history = useHistory()
-  const filter = useMemo(
-    () => ({ assetId, accountSpecifier: accountId ?? '' }),
-    [assetId, accountId],
-  )
+  const filter = useMemo(() => ({ assetId, accountId: accountId ?? '' }), [assetId, accountId])
 
   // this is returning data grouped by validator, not by account
   const stakingOpportunitiesData = useAppSelector(s =>

--- a/src/components/StakingVaults/AllEarnOpportunities.tsx
+++ b/src/components/StakingVaults/AllEarnOpportunities.tsx
@@ -1,6 +1,5 @@
 import { Box } from '@chakra-ui/react'
 import { cosmosAssetId, fromAssetId, osmosisAssetId } from '@shapeshiftoss/caip'
-import { supportsCosmos, supportsOsmosis } from '@shapeshiftoss/hdwallet-core'
 import type { EarnOpportunityType } from 'features/defi/helpers/normalizeOpportunity'
 import { useNormalizeOpportunities } from 'features/defi/helpers/normalizeOpportunity'
 import qs from 'qs'
@@ -23,7 +22,7 @@ export const AllEarnOpportunities = () => {
   const history = useHistory()
   const location = useLocation()
   const {
-    state: { isConnected, isDemoWallet, wallet },
+    state: { isConnected, isDemoWallet },
     dispatch,
   } = useWallet()
 
@@ -35,13 +34,11 @@ export const AllEarnOpportunities = () => {
   const { cosmosSdkStakingOpportunities: cosmosStakingOpportunities } = useCosmosSdkStakingBalances(
     {
       assetId: cosmosAssetId,
-      supportsCosmosSdk: wallet ? supportsCosmos(wallet) : undefined,
     },
   )
   const { cosmosSdkStakingOpportunities: osmosisStakingOpportunities } =
     useCosmosSdkStakingBalances({
       assetId: osmosisAssetId,
-      supportsCosmosSdk: wallet ? Boolean(supportsOsmosis(wallet)) : undefined,
     })
   const featureFlags = useAppSelector(selectFeatureFlags)
   const allRows = useNormalizeOpportunities({

--- a/src/components/Trade/AssetAccountRow.tsx
+++ b/src/components/Trade/AssetAccountRow.tsx
@@ -10,9 +10,8 @@ import type { AccountSpecifier } from 'state/slices/accountSpecifiersSlice/accou
 import { accountIdToFeeAssetId, accountIdToLabel } from 'state/slices/portfolioSlice/utils'
 import {
   selectAssetById,
-  selectFirstAccountSpecifierByChainId,
-  selectTotalCryptoBalanceWithDelegations,
-  selectTotalFiatBalanceWithDelegations,
+  selectCryptoHumanBalanceIncludingStakingByFilter,
+  selectFiatBalanceIncludingStakingByFilter,
 } from 'state/slices/selectors'
 import { useAppSelector } from 'state/store'
 
@@ -29,16 +28,11 @@ export const AssetAccountRow = ({ accountId, assetId, onClick }: AssetAccountRow
   const feeAssetId = accountIdToFeeAssetId(accountId)
   const rowAssetId = assetId ? assetId : feeAssetId
   const asset = useAppSelector(state => selectAssetById(state, rowAssetId))
-  const accountSpecifier = useAppSelector(state =>
-    selectFirstAccountSpecifierByChainId(state, asset?.chainId),
-  )
-  const filter = useMemo(
-    () => ({ assetId: rowAssetId, accountId, accountSpecifier }),
-    [rowAssetId, accountId, accountSpecifier],
-  )
-  const fiatBalance = useAppSelector(state => selectTotalFiatBalanceWithDelegations(state, filter))
-  const cryptoHumanBalance = useAppSelector(state =>
-    selectTotalCryptoBalanceWithDelegations(state, filter),
+  const filter = useMemo(() => ({ assetId: rowAssetId, accountId }), [rowAssetId, accountId])
+  // i don't care if this change works - this is all dead code only used by old swapper
+  const fiatBalance = useAppSelector(s => selectFiatBalanceIncludingStakingByFilter(s, filter))
+  const cryptoHumanBalance = useAppSelector(s =>
+    selectCryptoHumanBalanceIncludingStakingByFilter(s, filter),
   )
 
   const label = accountIdToLabel(accountId)

--- a/src/components/Trade/TradeInput.tsx
+++ b/src/components/Trade/TradeInput.tsx
@@ -30,7 +30,7 @@ import {
   selectAssetById,
   selectFeatureFlags,
   selectFiatToUsdRate,
-  selectFirstAccountSpecifierByChainId,
+  selectFirstAccountIdByChainId,
   selectHighestFiatBalanceAccountByAssetId,
   selectPortfolioCryptoHumanBalanceByAssetId,
   selectPortfolioCryptoHumanBalanceByFilter,
@@ -121,7 +121,7 @@ export const TradeInput = ({ history }: RouterProps) => {
   )
 
   const sellAssetAccountSpecifier = useAppSelector(state =>
-    selectFirstAccountSpecifierByChainId(state, sellAsset?.chainId ?? ''),
+    selectFirstAccountIdByChainId(state, sellAsset?.chainId ?? ''),
   )
   const filter = useMemo(
     () => ({

--- a/src/components/Trade/hooks/useAccountsService.tsx
+++ b/src/components/Trade/hooks/useAccountsService.tsx
@@ -2,7 +2,7 @@ import { useEffect, useMemo } from 'react'
 import { useFormContext, useWatch } from 'react-hook-form'
 import { useSwapper } from 'components/Trade/hooks/useSwapper/useSwapperV2'
 import type { TS } from 'components/Trade/types'
-import { selectFirstAccountSpecifierByChainId } from 'state/slices/accountSpecifiersSlice/selectors'
+import { selectFirstAccountIdByChainId } from 'state/slices/accountSpecifiersSlice/selectors'
 import { selectAssetById } from 'state/slices/assetsSlice/selectors'
 import { selectHighestFiatBalanceAccountByAssetId } from 'state/slices/portfolioSlice/selectors'
 import { useAppSelector } from 'state/store'
@@ -42,10 +42,10 @@ export const useAccountsService = () => {
     }),
   )
   const sellAssetAccountSpecifier = useAppSelector(state =>
-    selectFirstAccountSpecifierByChainId(state, sellAsset?.chainId ?? ''),
+    selectFirstAccountIdByChainId(state, sellAsset?.chainId ?? ''),
   )
   const buyAssetAccountSpecifier = useAppSelector(state =>
-    selectFirstAccountSpecifierByChainId(state, buyAsset?.chainId ?? ''),
+    selectFirstAccountIdByChainId(state, buyAsset?.chainId ?? ''),
   )
 
   const sellAssetAccountId = useMemo(

--- a/src/features/defi/providers/cosmos/components/CosmosManager/Overview/CosmosOverview.tsx
+++ b/src/features/defi/providers/cosmos/components/CosmosManager/Overview/CosmosOverview.tsx
@@ -23,7 +23,7 @@ import { useCosmosSdkStakingBalances } from 'pages/Defi/hooks/useCosmosSdkStakin
 import { useGetAssetDescriptionQuery } from 'state/slices/assetsSlice/assetsSlice'
 import {
   selectAssetById,
-  selectFirstAccountSpecifierByChainId,
+  selectFirstAccountIdByChainId,
   selectMarketDataById,
   selectSelectedLocale,
   selectTotalBondingsBalanceByAssetId,
@@ -91,13 +91,13 @@ export const CosmosOverview: React.FC<CosmosOverviewProps> = ({
   const stakingAsset = useAppSelector(state => selectAssetById(state, stakingAssetId))
 
   // TODO: Remove - currently, we need this to fire the first onChange() in `<AccountDropdown />`
-  const accountSpecifier = useAppSelector(state =>
-    selectFirstAccountSpecifierByChainId(state, stakingAsset?.chainId),
+  const firstAccountId = useAppSelector(state =>
+    selectFirstAccountIdByChainId(state, stakingAsset?.chainId),
   )
 
   const totalBondings = useAppSelector(state =>
     selectTotalBondingsBalanceByAssetId(state, {
-      accountSpecifier: accountId ?? accountSpecifier,
+      accountId: firstAccountId ?? accountId,
       validatorAddress: contractAddress,
       assetId: stakingAsset.assetId,
     }),

--- a/src/features/defi/providers/cosmos/components/CosmosManager/Overview/CosmosOverview.tsx
+++ b/src/features/defi/providers/cosmos/components/CosmosManager/Overview/CosmosOverview.tsx
@@ -89,7 +89,6 @@ export const CosmosOverview: React.FC<CosmosOverviewProps> = ({
     }),
     [accountId, contractAddress, firstAccountId, stakingAsset.assetId],
   )
-  // TODO(0xdef1cafe): this selector needs to respect the accountId too
   const totalBondings = useAppSelector(s => selectTotalBondingsBalanceByAssetId(s, filter))
 
   const marketData = useAppSelector(state => selectMarketDataById(state, stakingAssetId))

--- a/src/features/defi/providers/cosmos/components/CosmosManager/Overview/CosmosOverview.tsx
+++ b/src/features/defi/providers/cosmos/components/CosmosManager/Overview/CosmosOverview.tsx
@@ -103,6 +103,7 @@ export const CosmosOverview: React.FC<CosmosOverviewProps> = ({
     }),
     [accountId, contractAddress, firstAccountId, stakingAsset.assetId],
   )
+  // TODO(0xdef1cafe): this selector needs to respect the accountId too
   const totalBondings = useAppSelector(s => selectTotalBondingsBalanceByAssetId(s, filter))
 
   const marketData = useAppSelector(state => selectMarketDataById(state, stakingAssetId))

--- a/src/features/defi/providers/cosmos/components/CosmosManager/Overview/CosmosOverview.tsx
+++ b/src/features/defi/providers/cosmos/components/CosmosManager/Overview/CosmosOverview.tsx
@@ -95,13 +95,15 @@ export const CosmosOverview: React.FC<CosmosOverviewProps> = ({
     selectFirstAccountIdByChainId(state, stakingAsset?.chainId),
   )
 
-  const totalBondings = useAppSelector(state =>
-    selectTotalBondingsBalanceByAssetId(state, {
+  const filter = useMemo(
+    () => ({
       accountId: firstAccountId ?? accountId,
       validatorAddress: contractAddress,
       assetId: stakingAsset.assetId,
     }),
+    [accountId, contractAddress, firstAccountId, stakingAsset.assetId],
   )
+  const totalBondings = useAppSelector(s => selectTotalBondingsBalanceByAssetId(s, filter))
 
   const marketData = useAppSelector(state => selectMarketDataById(state, stakingAssetId))
   const cryptoAmountAvailable = bnOrZero(totalBondings).div(`1e${stakingAsset.precision}`)

--- a/src/features/defi/providers/cosmos/components/CosmosManager/Overview/CosmosOverview.tsx
+++ b/src/features/defi/providers/cosmos/components/CosmosManager/Overview/CosmosOverview.tsx
@@ -1,8 +1,7 @@
 import { ArrowDownIcon, ArrowUpIcon } from '@chakra-ui/icons'
 import { Center } from '@chakra-ui/react'
 import type { AccountId } from '@shapeshiftoss/caip'
-import { cosmosChainId, osmosisChainId, toAssetId } from '@shapeshiftoss/caip'
-import { supportsCosmos, supportsOsmosis } from '@shapeshiftoss/hdwallet-core'
+import { toAssetId } from '@shapeshiftoss/caip'
 import { DefiModalContent } from 'features/defi/components/DefiModal/DefiModalContent'
 import { Overview } from 'features/defi/components/Overview/Overview'
 import type {
@@ -17,7 +16,6 @@ import { useTranslate } from 'react-polyglot'
 import type { AccountDropdownProps } from 'components/AccountDropdown/AccountDropdown'
 import { CircularProgress } from 'components/CircularProgress/CircularProgress'
 import { useBrowserRouter } from 'hooks/useBrowserRouter/useBrowserRouter'
-import { useWallet } from 'hooks/useWallet/useWallet'
 import { bnOrZero } from 'lib/bignumber/bignumber'
 import { useCosmosSdkStakingBalances } from 'pages/Defi/hooks/useCosmosSdkStakingBalances'
 import { useGetAssetDescriptionQuery } from 'state/slices/assetsSlice/assetsSlice'
@@ -61,21 +59,9 @@ export const CosmosOverview: React.FC<CosmosOverviewProps> = ({
     assetReference,
   })
 
-  const {
-    state: { wallet },
-  } = useWallet()
-
-  const supportsCosmosSdk = useMemo(() => {
-    if (!wallet) return
-
-    if (chainId === cosmosChainId) return supportsCosmos(wallet)
-    if (chainId === osmosisChainId) return supportsOsmosis(wallet)
-  }, [chainId, wallet])
-
   const opportunities = useCosmosSdkStakingBalances({
     accountId,
     assetId: stakingAssetId,
-    supportsCosmosSdk,
   })
 
   const opportunity = useMemo(

--- a/src/features/defi/providers/cosmos/components/CosmosManager/Overview/CosmosOverview.tsx
+++ b/src/features/defi/providers/cosmos/components/CosmosManager/Overview/CosmosOverview.tsx
@@ -97,7 +97,7 @@ export const CosmosOverview: React.FC<CosmosOverviewProps> = ({
 
   const filter = useMemo(
     () => ({
-      accountId: firstAccountId ?? accountId,
+      accountId: accountId ?? firstAccountId,
       validatorAddress: contractAddress,
       assetId: stakingAsset.assetId,
     }),

--- a/src/features/defi/providers/cosmos/components/CosmosManager/Overview/WithdrawCard.tsx
+++ b/src/features/defi/providers/cosmos/components/CosmosManager/Overview/WithdrawCard.tsx
@@ -14,7 +14,7 @@ import { Text } from 'components/Text'
 import { useBrowserRouter } from 'hooks/useBrowserRouter/useBrowserRouter'
 import { bnOrZero } from 'lib/bignumber/bignumber'
 import {
-  selectFirstAccountSpecifierByChainId,
+  selectFirstAccountIdByChainId,
   selectUnbondingEntriesByAccountSpecifier,
 } from 'state/slices/selectors'
 import { useAppSelector } from 'state/store'
@@ -25,21 +25,22 @@ type WithdrawCardProps = {
   accountId?: Nullable<AccountId>
 }
 
-export const WithdrawCard = ({ asset, accountId }: WithdrawCardProps) => {
+export const WithdrawCard = ({ asset, accountId: routeAccountId }: WithdrawCardProps) => {
   const { query } = useBrowserRouter<DefiQueryParams, DefiParams>()
   const { contractAddress } = query
 
-  const accountSpecifier = useAppSelector(state =>
-    selectFirstAccountSpecifierByChainId(state, asset?.chainId),
-  )
+  const accountId = useAppSelector(state => selectFirstAccountIdByChainId(state, asset.chainId))
 
-  // TODO: Remove - currently, we need this to fire the first onChange() in `<AccountDropdown />`
-  const undelegationEntries = useAppSelector(state =>
-    selectUnbondingEntriesByAccountSpecifier(state, {
-      accountSpecifier: accountId ?? accountSpecifier,
+  const filter = useMemo(
+    () => ({
+      accountId: routeAccountId ?? accountId,
       validatorAddress: contractAddress,
       assetId: asset.assetId,
     }),
+    [accountId, asset.assetId, contractAddress, routeAccountId],
+  )
+  const undelegationEntries = useAppSelector(s =>
+    selectUnbondingEntriesByAccountSpecifier(s, filter),
   )
 
   const hasClaim = useMemo(() => Boolean(undelegationEntries.length), [undelegationEntries])

--- a/src/features/defi/providers/cosmos/components/CosmosManager/Withdraw/components/Withdraw.tsx
+++ b/src/features/defi/providers/cosmos/components/CosmosManager/Withdraw/components/Withdraw.tsx
@@ -10,7 +10,7 @@ import type {
 } from 'features/defi/contexts/DefiManagerProvider/DefiCommon'
 import { DefiStep } from 'features/defi/contexts/DefiManagerProvider/DefiCommon'
 import { getFormFees } from 'plugins/cosmos/utils'
-import { useCallback, useContext } from 'react'
+import { useCallback, useContext, useMemo } from 'react'
 import { FormProvider, useForm } from 'react-hook-form'
 import { useTranslate } from 'react-polyglot'
 import type { AccountDropdownProps } from 'components/AccountDropdown/AccountDropdown'
@@ -21,7 +21,6 @@ import { logger } from 'lib/logger'
 import {
   selectAssetById,
   selectDelegationCryptoAmountByAssetIdAndValidator,
-  selectFirstAccountSpecifierByChainId,
   selectMarketDataById,
 } from 'state/slices/selectors'
 import { useAppSelector } from 'state/store'
@@ -74,17 +73,16 @@ export const Withdraw: React.FC<WithdrawProps> = ({
   })
   const stakingAsset = useAppSelector(state => selectAssetById(state, stakingAssetId))
 
-  const accountSpecifier = useAppSelector(state =>
-    selectFirstAccountSpecifierByChainId(state, asset?.chainId),
-  )
-
-  // TODO: Remove - currently, we need this to fire the first onChange() in `<AccountDropdown />`
-  const cryptoStakeBalance = useAppSelector(state =>
-    selectDelegationCryptoAmountByAssetIdAndValidator(state, {
-      accountSpecifier: accountId ?? accountSpecifier,
+  const filter = useMemo(
+    () => ({
+      accountId: accountId ?? '',
       validatorAddress: contractAddress,
       assetId,
     }),
+    [accountId, assetId, contractAddress],
+  )
+  const cryptoStakeBalance = useAppSelector(s =>
+    selectDelegationCryptoAmountByAssetIdAndValidator(s, filter),
   )
   const cryptoStakeBalanceHuman = bnOrZero(cryptoStakeBalance).div(`1e+${asset?.precision}`)
 

--- a/src/features/defi/providers/idle/components/IdleManager/Claim/components/Status.tsx
+++ b/src/features/defi/providers/idle/components/IdleManager/Claim/components/Status.tsx
@@ -18,7 +18,7 @@ import { useBrowserRouter } from 'hooks/useBrowserRouter/useBrowserRouter'
 import { bnOrZero } from 'lib/bignumber/bignumber'
 import {
   selectAssetById,
-  selectFirstAccountSpecifierByChainId,
+  selectFirstAccountIdByChainId,
   selectMarketDataById,
   selectTxById,
 } from 'state/slices/selectors'
@@ -57,9 +57,7 @@ export const Status = () => {
   const feeAsset = useAppSelector(state => selectAssetById(state, feeAssetId))
   const feeMarketData = useAppSelector(state => selectMarketDataById(state, feeAssetId))
 
-  const accountSpecifier = useAppSelector(state =>
-    selectFirstAccountSpecifierByChainId(state, chainId),
-  )
+  const accountSpecifier = useAppSelector(state => selectFirstAccountIdByChainId(state, chainId))
 
   const serializedTxIndex = useMemo(() => {
     if (!(state?.txid && state?.userAddress)) return ''

--- a/src/features/defi/providers/idle/components/IdleManager/Claim/components/Status.tsx
+++ b/src/features/defi/providers/idle/components/IdleManager/Claim/components/Status.tsx
@@ -57,12 +57,12 @@ export const Status = () => {
   const feeAsset = useAppSelector(state => selectAssetById(state, feeAssetId))
   const feeMarketData = useAppSelector(state => selectMarketDataById(state, feeAssetId))
 
-  const accountSpecifier = useAppSelector(state => selectFirstAccountIdByChainId(state, chainId))
+  const accountId = useAppSelector(state => selectFirstAccountIdByChainId(state, chainId))
 
   const serializedTxIndex = useMemo(() => {
-    if (!(state?.txid && state?.userAddress)) return ''
-    return serializeTxIndex(accountSpecifier, state.txid, state.userAddress)
-  }, [state?.txid, state?.userAddress, accountSpecifier])
+    if (!(state?.txid && state?.userAddress && accountId)) return ''
+    return serializeTxIndex(accountId, state.txid, state.userAddress)
+  }, [state?.txid, state?.userAddress, accountId])
   const confirmedTransaction = useAppSelector(gs => selectTxById(gs, serializedTxIndex))
 
   useEffect(() => {

--- a/src/features/defi/providers/idle/components/IdleManager/Deposit/components/Status.tsx
+++ b/src/features/defi/providers/idle/components/IdleManager/Deposit/components/Status.tsx
@@ -18,7 +18,7 @@ import { useBrowserRouter } from 'hooks/useBrowserRouter/useBrowserRouter'
 import { bnOrZero } from 'lib/bignumber/bignumber'
 import {
   selectAssetById,
-  selectFirstAccountSpecifierByChainId,
+  selectFirstAccountIdByChainId,
   selectMarketDataById,
   selectTxById,
 } from 'state/slices/selectors'
@@ -47,9 +47,7 @@ export const Status = () => {
   const feeAsset = useAppSelector(state => selectAssetById(state, feeAssetId))
   const feeMarketData = useAppSelector(state => selectMarketDataById(state, feeAssetId))
 
-  const accountSpecifier = useAppSelector(state =>
-    selectFirstAccountSpecifierByChainId(state, chainId),
-  )
+  const accountSpecifier = useAppSelector(state => selectFirstAccountIdByChainId(state, chainId))
 
   const serializedTxIndex = useMemo(() => {
     if (!(state?.txid && state?.userAddress)) return ''

--- a/src/features/defi/providers/idle/components/IdleManager/Deposit/components/Status.tsx
+++ b/src/features/defi/providers/idle/components/IdleManager/Deposit/components/Status.tsx
@@ -47,12 +47,12 @@ export const Status = () => {
   const feeAsset = useAppSelector(state => selectAssetById(state, feeAssetId))
   const feeMarketData = useAppSelector(state => selectMarketDataById(state, feeAssetId))
 
-  const accountSpecifier = useAppSelector(state => selectFirstAccountIdByChainId(state, chainId))
+  const accountId = useAppSelector(state => selectFirstAccountIdByChainId(state, chainId))
 
   const serializedTxIndex = useMemo(() => {
-    if (!(state?.txid && state?.userAddress)) return ''
-    return serializeTxIndex(accountSpecifier, state.txid, state.userAddress)
-  }, [state?.txid, state?.userAddress, accountSpecifier])
+    if (!(state?.txid && state?.userAddress && accountId)) return ''
+    return serializeTxIndex(accountId, state.txid, state.userAddress)
+  }, [state?.txid, state?.userAddress, accountId])
   const confirmedTransaction = useAppSelector(gs => selectTxById(gs, serializedTxIndex))
 
   useEffect(() => {

--- a/src/features/defi/providers/idle/components/IdleManager/Withdraw/components/Status.tsx
+++ b/src/features/defi/providers/idle/components/IdleManager/Withdraw/components/Status.tsx
@@ -18,7 +18,7 @@ import { useBrowserRouter } from 'hooks/useBrowserRouter/useBrowserRouter'
 import { bnOrZero } from 'lib/bignumber/bignumber'
 import {
   selectAssetById,
-  selectFirstAccountSpecifierByChainId,
+  selectFirstAccountIdByChainId,
   selectMarketDataById,
   selectTxById,
 } from 'state/slices/selectors'
@@ -56,9 +56,7 @@ export const Status = () => {
   const feeAsset = useAppSelector(state => selectAssetById(state, feeAssetId))
   const feeMarketData = useAppSelector(state => selectMarketDataById(state, feeAssetId))
 
-  const accountSpecifier = useAppSelector(state =>
-    selectFirstAccountSpecifierByChainId(state, chainId),
-  )
+  const accountSpecifier = useAppSelector(state => selectFirstAccountIdByChainId(state, chainId))
 
   const serializedTxIndex = useMemo(() => {
     if (!(state?.txid && state?.userAddress)) return ''

--- a/src/features/defi/providers/idle/components/IdleManager/Withdraw/components/Status.tsx
+++ b/src/features/defi/providers/idle/components/IdleManager/Withdraw/components/Status.tsx
@@ -56,12 +56,12 @@ export const Status = () => {
   const feeAsset = useAppSelector(state => selectAssetById(state, feeAssetId))
   const feeMarketData = useAppSelector(state => selectMarketDataById(state, feeAssetId))
 
-  const accountSpecifier = useAppSelector(state => selectFirstAccountIdByChainId(state, chainId))
+  const accountId = useAppSelector(state => selectFirstAccountIdByChainId(state, chainId))
 
   const serializedTxIndex = useMemo(() => {
-    if (!(state?.txid && state?.userAddress)) return ''
-    return serializeTxIndex(accountSpecifier, state.txid, state.userAddress)
-  }, [state?.txid, state?.userAddress, accountSpecifier])
+    if (!(state?.txid && state?.userAddress && accountId)) return ''
+    return serializeTxIndex(accountId, state.txid, state.userAddress)
+  }, [state?.txid, state?.userAddress, accountId])
   const confirmedTransaction = useAppSelector(gs => selectTxById(gs, serializedTxIndex))
 
   useEffect(() => {

--- a/src/pages/Defi/hooks/__snapshots__/useCosmosStakingBalances.test.tsx.snap
+++ b/src/pages/Defi/hooks/__snapshots__/useCosmosStakingBalances.test.tsx.snap
@@ -39,5 +39,3 @@ Array [
   },
 ]
 `;
-
-exports[`useCosmosStakingBalances returns empty array for active opportunities and the shapeshift validator as a staking opportunity when staking data is empty and validators data are loaded 1`] = `Array []`;

--- a/src/pages/Defi/hooks/useCosmosSdkStakingBalances.tsx
+++ b/src/pages/Defi/hooks/useCosmosSdkStakingBalances.tsx
@@ -14,7 +14,6 @@ import type { Nullable } from 'types/common'
 type UseCosmosStakingBalancesProps = {
   accountId?: Nullable<AccountId>
   assetId: AssetId
-  supportsCosmosSdk?: boolean
 }
 
 export type UseCosmosStakingBalancesReturn = {

--- a/src/pages/Defi/hooks/useCosmosSdkStakingBalances.tsx
+++ b/src/pages/Defi/hooks/useCosmosSdkStakingBalances.tsx
@@ -38,12 +38,16 @@ export function useCosmosSdkStakingBalances({
   const marketData = useAppSelector(state => selectMarketDataById(state, assetId))
   const asset = useAppSelector(state => selectAssetById(state, assetId))
 
-  const stakingOpportunities = useAppSelector(state =>
-    selectStakingOpportunitiesDataFullByFilter(state, {
-      accountSpecifier: accountId,
+  const filter = useMemo(
+    () => ({
+      accountId: accountId ?? '',
       assetId,
       supportsCosmosSdk,
     }),
+    [accountId, assetId, supportsCosmosSdk],
+  )
+  const stakingOpportunities = useAppSelector(s =>
+    selectStakingOpportunitiesDataFullByFilter(s, filter),
   )
 
   const mergedActiveStakingOpportunities = useMemo(() => {

--- a/src/pages/Defi/hooks/useCosmosSdkStakingBalances.tsx
+++ b/src/pages/Defi/hooks/useCosmosSdkStakingBalances.tsx
@@ -33,7 +33,6 @@ export type MergedActiveStakingOpportunity = ActiveStakingOpportunity & {
 export function useCosmosSdkStakingBalances({
   assetId,
   accountId,
-  supportsCosmosSdk = true,
 }: UseCosmosStakingBalancesProps): UseCosmosStakingBalancesReturn {
   const marketData = useAppSelector(state => selectMarketDataById(state, assetId))
   const asset = useAppSelector(state => selectAssetById(state, assetId))
@@ -42,9 +41,8 @@ export function useCosmosSdkStakingBalances({
     () => ({
       accountId: accountId ?? '',
       assetId,
-      supportsCosmosSdk,
     }),
-    [accountId, assetId, supportsCosmosSdk],
+    [accountId, assetId],
   )
   const stakingOpportunities = useAppSelector(s =>
     selectStakingOpportunitiesDataFullByFilter(s, filter),

--- a/src/pages/Defi/hooks/useCosmosStakingBalances.test.tsx
+++ b/src/pages/Defi/hooks/useCosmosStakingBalances.test.tsx
@@ -58,25 +58,7 @@ function setup() {
   return { result }
 }
 
-// TODO: Will unskip
 describe('useCosmosStakingBalances', () => {
-  it('returns empty array for active opportunities and the shapeshift validator as a staking opportunity when staking data is empty and validators data are loaded', async () => {
-    store.dispatch(
-      validatorData.actions.upsertValidatorData({
-        validators: MOCK_VALIDATORS,
-      }),
-    )
-    store.dispatch(
-      validatorData.actions.upsertValidatorData({
-        validators: MOCK_VALIDATORS,
-      }),
-    )
-
-    const { result } = setup()
-    expect(result.current.cosmosSdkStakingOpportunities).toMatchSnapshot()
-    expect(result.current.totalBalance).toEqual('0')
-  })
-
   it('returns active and non active staking opportunities when staking and validators data are loaded', async () => {
     store.dispatch(
       validatorData.actions.upsertValidatorData({

--- a/src/state/slices/accountSpecifiersSlice/selectors.ts
+++ b/src/state/slices/accountSpecifiersSlice/selectors.ts
@@ -1,7 +1,9 @@
-import type { ChainId } from '@shapeshiftoss/caip'
+import type { AccountId, ChainId } from '@shapeshiftoss/caip'
+import { fromAccountId } from '@shapeshiftoss/caip'
 import { createSelector } from 'reselect'
 import type { ReduxState } from 'state/reducer'
 
+import { selectPortfolioAccountIds } from '../portfolioSlice/selectors'
 import { createDeepEqualOutputSelector } from './../../selector-utils'
 
 export const selectAccountSpecifiers = createDeepEqualOutputSelector(
@@ -15,24 +17,9 @@ export const selectAccountSpecifierStrings = (state: ReduxState) =>
     Object.entries(accountSpecifier)[0].join(':'),
   )
 
-// Returns a ChainId-indexed object with all the `chainId:pubkeyish` accounts for that chainId
-// For most accounts, that's effectively an AssetId, but not for e.g UTXO chains thus the pubkeyish naming
-// We use this in cosmos plugin to get the pubkey as an AssetId, without needing to use chain-adapters in components
-// Since the pubkey is already in state
-export const selectAccountSpecifiersByChainId = (state: ReduxState, chainId: ChainId) =>
-  state.accountSpecifiers.accountSpecifiers.reduce<string[]>((acc, accountSpecifier) => {
-    const pubkeyish = Object.entries(accountSpecifier)[0].join(':')
-    const currentChainId = Object.keys(accountSpecifier)[0]
-
-    if (currentChainId !== chainId) return acc
-
-    acc.push(pubkeyish)
-
-    return acc
-  }, [])
-
-// TODO(0xdef1cafe): DELETE - this is dangerous with multi account
-export const selectFirstAccountSpecifierByChainId = createSelector(
-  selectAccountSpecifiersByChainId,
-  accountSpecifiers => accountSpecifiers[0],
+export const selectFirstAccountIdByChainId = createSelector(
+  selectPortfolioAccountIds,
+  (_s: ReduxState, chainId: ChainId) => chainId,
+  (accountIds, chainId): AccountId | undefined =>
+    accountIds.filter(accountId => fromAccountId(accountId).chainId === chainId)[0],
 )

--- a/src/state/slices/portfolioSlice/portfolioSlice.test.ts
+++ b/src/state/slices/portfolioSlice/portfolioSlice.test.ts
@@ -1,10 +1,8 @@
 import { btcAssetId, ethAssetId, foxAssetId } from '@shapeshiftoss/caip'
 import {
   assetIds,
-  btcAccountIds,
   btcAddresses,
   btcPubKeys,
-  ethAccountIds,
   ethPubKeys,
   mockBtcAccount,
   mockBtcAddress,
@@ -27,7 +25,6 @@ import { assets as assetsSlice } from '../assetsSlice/assetsSlice'
 import { marketData as marketDataSlice } from '../marketDataSlice/marketDataSlice'
 import { portfolio as portfolioSlice } from './portfolioSlice'
 import {
-  selectAccountIdByAddress,
   selectHighestFiatBalanceAccountByAssetId,
   selectPortfolioAccountIdsSortedFiat,
   selectPortfolioAccountRows,
@@ -247,44 +244,6 @@ describe('portfolioSlice', () => {
         const selected = selectPortfolioAssetAccounts(state, ethAssetId)
         const expected = [ethAccountId, ethAccount2Id]
         expect(selected).toEqual(expected)
-      })
-    })
-
-    describe('selectAccountIdByAddress', () => {
-      const store = createStore()
-      const { ethAccount, btcAccount, ethAccountId, btcAccountId } = mockEthAndBtcAccounts()
-
-      store.dispatch(
-        portfolioSlice.actions.upsertPortfolio(
-          mockUpsertPortfolio([ethAccount, btcAccount], assetIds),
-        ),
-      )
-      const state = store.getState()
-
-      it('can select account id by address (accountId)', () => {
-        const btcAccSpecifier = selectAccountIdByAddress(state, {
-          accountSpecifier: btcAccountIds[0],
-        })
-        const ethAccSpecifier = selectAccountIdByAddress(state, {
-          accountSpecifier: ethAccountIds[0],
-        })
-
-        expect(btcAccSpecifier).toEqual(btcAccountId)
-        expect(ethAccSpecifier).toEqual(ethAccountId)
-      })
-
-      it('can select account id with address in non checksum format', () => {
-        // AccountIds in state in non checksum format
-        const btcAccSpecifier = selectAccountIdByAddress(state, {
-          accountSpecifier: btcAccountIds[0],
-        })
-        expect(btcAccSpecifier).toEqual(btcAccountId)
-
-        // AccountId argument in non checksum format
-        const ethAccSpecifier = selectAccountIdByAddress(state, {
-          accountSpecifier: ethAccountIds[0].toUpperCase(),
-        })
-        expect(ethAccSpecifier).toEqual(ethAccountId)
       })
     })
 

--- a/src/state/slices/portfolioSlice/portfolioSlice.test.ts
+++ b/src/state/slices/portfolioSlice/portfolioSlice.test.ts
@@ -1,5 +1,4 @@
-import { btcAssetId, cosmosAssetId, ethAssetId, foxAssetId } from '@shapeshiftoss/caip'
-import merge from 'lodash/merge'
+import { btcAssetId, ethAssetId, foxAssetId } from '@shapeshiftoss/caip'
 import {
   assetIds,
   btcAccountIds,
@@ -9,9 +8,6 @@ import {
   ethPubKeys,
   mockBtcAccount,
   mockBtcAddress,
-  mockCosmosAccount,
-  mockCosmosAccountWithOnlyUndelegations,
-  mockCosmosAccountWithStakingData,
   mockEthAccount,
   mockEthAndBtcAccounts,
   mockEthToken,
@@ -22,7 +18,7 @@ import {
   yvusdcAssetId,
   zeroAssetId,
 } from 'test/mocks/accounts'
-import { cosmos, mockAssetState } from 'test/mocks/assets'
+import { mockAssetState } from 'test/mocks/assets'
 import { mockMarketData } from 'test/mocks/marketData'
 import { mockChainAdapters, mockUpsertPortfolio } from 'test/mocks/portfolio'
 import { createStore } from 'state/store'
@@ -44,7 +40,6 @@ import {
   selectPortfolioFiatAccountBalances,
   selectPortfolioFiatBalanceByFilter,
   selectPortfolioTotalFiatBalanceByAccount,
-  selectTotalFiatBalanceWithDelegations,
 } from './selectors'
 
 jest.mock('context/PluginProvider/chainAdapterSingleton', () => ({
@@ -828,132 +823,6 @@ describe('portfolioSlice', () => {
       it('should return correct portfolio rows in case of 100% allocation on one asset', () => {
         const result = selectPortfolioAccountRows(state)
         expect(result).toMatchSnapshot()
-      })
-    })
-
-    describe('selectTotalFiatBalanceWithDelegations', () => {
-      const cosmosAccountSpecifier: string =
-        'cosmos:cosmoshub-4:cosmos1wc4rv7dv8lafv38s50pfp5qsgv7eknetyml669'
-
-      it('should return correct fiat balance in case there are delegations, undelegations and asset balance', () => {
-        const store = createStore()
-        const assetData = mockAssetState({
-          byId: {
-            [cosmos.assetId]: cosmos,
-          },
-          ids: [cosmos.assetId],
-        })
-        store.dispatch(assetsSlice.actions.setAssets(assetData))
-
-        const cosmosMarketData = mockMarketData({ price: '77.55' })
-        store.dispatch(
-          marketDataSlice.actions.setCryptoMarketData({
-            [cosmos.assetId]: cosmosMarketData,
-          }),
-        )
-
-        const cosmosAccount = merge(mockCosmosAccount(mockCosmosAccountWithStakingData), {
-          balance: '1000',
-        })
-
-        store.dispatch(
-          portfolioSlice.actions.upsertPortfolio(
-            mockUpsertPortfolio([cosmosAccount], [cosmosAssetId]),
-          ),
-        )
-
-        const result = selectTotalFiatBalanceWithDelegations(store.getState(), {
-          assetId: cosmosAssetId,
-          accountSpecifier: cosmosAccountSpecifier,
-        })
-        expect(result).toEqual('1.25002845')
-      })
-
-      it('should return correct fiat balance in case there are delegations and undelegations but no asset balance', () => {
-        const store = createStore()
-        const assetData = mockAssetState({
-          byId: {
-            [cosmos.assetId]: cosmos,
-          },
-          ids: [cosmos.assetId],
-        })
-        store.dispatch(assetsSlice.actions.setAssets(assetData))
-
-        const cosmosMarketData = mockMarketData({ price: '77.55' })
-        store.dispatch(
-          marketDataSlice.actions.setCryptoMarketData({
-            [cosmos.assetId]: cosmosMarketData,
-          }),
-        )
-
-        const cosmosAccount = mockCosmosAccount(mockCosmosAccountWithStakingData)
-        store.dispatch(
-          portfolioSlice.actions.upsertPortfolio(
-            mockUpsertPortfolio([cosmosAccount], [cosmosAssetId]),
-          ),
-        )
-
-        const result = selectTotalFiatBalanceWithDelegations(store.getState(), {
-          assetId: cosmosAssetId,
-          accountSpecifier: cosmosAccountSpecifier,
-        })
-        expect(result).toEqual('1.17247845')
-      })
-
-      it('should return non zero fiat balance in case there are only undelegations but no asset balance', () => {
-        const store = createStore()
-        const assetData = mockAssetState({
-          byId: {
-            [cosmos.assetId]: cosmos,
-          },
-          ids: [cosmos.assetId],
-        })
-        store.dispatch(assetsSlice.actions.setAssets(assetData))
-
-        const cosmosMarketData = mockMarketData({ price: '77.55' })
-        store.dispatch(
-          marketDataSlice.actions.setCryptoMarketData({
-            [cosmos.assetId]: cosmosMarketData,
-          }),
-        )
-
-        const cosmosAccount = mockCosmosAccount(mockCosmosAccountWithOnlyUndelegations)
-
-        store.dispatch(
-          portfolioSlice.actions.upsertPortfolio(
-            mockUpsertPortfolio([cosmosAccount], [cosmosAssetId]),
-          ),
-        )
-
-        const result = selectTotalFiatBalanceWithDelegations(store.getState(), {
-          assetId: cosmosAssetId,
-          accountSpecifier: cosmosAccountSpecifier,
-        })
-        expect(result).toEqual('0.0271425')
-      })
-
-      it('should return zero fiat balance in case there are no delegations nor asset balance', () => {
-        const store = createStore()
-        const assetData = mockAssetState({
-          byId: {
-            [cosmos.assetId]: cosmos,
-          },
-          ids: [cosmos.assetId],
-        })
-        store.dispatch(assetsSlice.actions.setAssets(assetData))
-
-        const cosmosMarketData = mockMarketData({ price: '77.55' })
-        store.dispatch(
-          marketDataSlice.actions.setCryptoMarketData({
-            [cosmos.assetId]: cosmosMarketData,
-          }),
-        )
-
-        const result = selectTotalFiatBalanceWithDelegations(store.getState(), {
-          assetId: cosmosAssetId,
-          accountSpecifier: cosmosAccountSpecifier,
-        })
-        expect(result).toEqual('0')
       })
     })
   })

--- a/src/state/slices/portfolioSlice/selectors.ts
+++ b/src/state/slices/portfolioSlice/selectors.ts
@@ -511,47 +511,6 @@ export const selectTotalStakingUndelegationCryptoByAccountSpecifier = createSele
   },
 )
 
-// TODO(0xdef1cafe): DO NOT USE THIS - delete when there are no references
-export const selectTotalStakingDelegationCryptoByFilter = createSelector(
-  selectAssetIdParamFromFilterOptional,
-  (state: ReduxState) => state.assets.byId,
-  selectTotalStakingDelegationCryptoByAccountSpecifier,
-  selectTotalStakingUndelegationCryptoByAccountSpecifier,
-  (assetId, assets, totalDelegations, totalUndelegations) => {
-    const total = bnOrZero(totalDelegations).plus(totalUndelegations)
-    return fromBaseUnit(total, assets?.[assetId]?.precision ?? 0).toString()
-  },
-)
-
-// TODO(0xdef1cafe): delete me - i don't respect account ids
-export const selectTotalFiatBalanceWithDelegations = createSelector(
-  selectPortfolioCryptoHumanBalanceByFilter,
-  selectTotalStakingDelegationCryptoByFilter,
-  selectMarketData,
-  selectAssetIdParamFromFilter,
-  (cryptoBalance, delegationCryptoBalance, marketData, assetId): string => {
-    const price = marketData[assetId]?.price ?? 0
-    const cryptoBalanceWithDelegations = bnOrZero(cryptoBalance)
-      .plus(delegationCryptoBalance)
-      .toString()
-
-    return bnOrZero(cryptoBalanceWithDelegations).times(price).toString()
-  },
-)
-
-// TODO(0xdef1cafe): DO NOT USE THIS - delete when there are no references
-export const selectTotalCryptoBalanceWithDelegations = createSelector(
-  selectPortfolioCryptoHumanBalanceByFilter,
-  selectTotalStakingDelegationCryptoByFilter,
-  (cryptoBalance, delegationCryptoBalance): string => {
-    const cryptoBalanceWithDelegations = bnOrZero(cryptoBalance)
-      .plus(delegationCryptoBalance)
-      .toString()
-
-    return bnOrZero(cryptoBalanceWithDelegations).toString()
-  },
-)
-
 /**
  * this selector is very specific; we need to consider
  * - raw account balances, that are

--- a/src/state/slices/portfolioSlice/selectors.ts
+++ b/src/state/slices/portfolioSlice/selectors.ts
@@ -73,14 +73,12 @@ type ParamFilter = {
   accountId: AccountId
   accountNumber: number
   chainId: ChainId
-  accountSpecifier: string
   validatorAddress: PubKey
   supportsCosmosSdk: boolean
 }
 type OptionalParamFilter = {
-  assetId: AssetId
+  assetId?: AssetId
   accountId?: AccountId
-  accountSpecifier?: string | null
   validatorAddress?: PubKey
   supportsCosmosSdk?: boolean
 }
@@ -1002,7 +1000,7 @@ export type AccountRowData = {
   symbol: string
   fiatAmount: string
   cryptoAmount: string
-  assetId: AccountId
+  assetId: AssetId
   allocation: number
   price: string
   priceChange: number

--- a/src/state/slices/portfolioSlice/selectors.ts
+++ b/src/state/slices/portfolioSlice/selectors.ts
@@ -74,13 +74,11 @@ type ParamFilter = {
   accountNumber: number
   chainId: ChainId
   validatorAddress: PubKey
-  supportsCosmosSdk: boolean
 }
 type OptionalParamFilter = {
   assetId?: AssetId
   accountId?: AccountId
   validatorAddress?: PubKey
-  supportsCosmosSdk?: boolean
 }
 type ParamFilterKey = keyof ParamFilter
 type OptionalParamFilterKey = keyof OptionalParamFilter
@@ -115,19 +113,6 @@ const selectValidatorAddressParamFromFilter = selectParamFromFilter('validatorAd
 
 const selectAccountIdParamFromFilterOptional = selectParamFromFilterOptional('accountId')
 const selectAssetIdParamFromFilterOptional = selectParamFromFilterOptional('assetId')
-const selectSupportsCosmosSdkParamFromFilterOptional =
-  selectParamFromFilterOptional('supportsCosmosSdk')
-
-export type OpportunitiesDataFull = {
-  totalDelegations: string
-  rewards: string
-  isLoaded: boolean
-  address: string
-  moniker: string
-  tokens?: string
-  apr: string
-  commission: string
-}
 
 export const selectPortfolioAccounts = (state: ReduxState) => state.portfolio.accounts.byId
 
@@ -1164,16 +1149,22 @@ export const selectValidatorIdsByFilter = createDeepEqualOutputSelector(
 
 const selectDefaultStakingDataByValidatorId = createSelector(
   selectAssetIdParamFromFilterOptional,
-  selectSupportsCosmosSdkParamFromFilterOptional,
   selectValidators,
-  (assetId, supportsCosmosSdk = true, stakingDataByValidator) => {
-    if (supportsCosmosSdk || !assetId) return null
-
-    const defaultValidatorAddress = getDefaultValidatorAddressFromAssetId(assetId)
-
-    return stakingDataByValidator[defaultValidatorAddress]
-  },
+  (assetId, stakingDataByValidator) =>
+    stakingDataByValidator[getDefaultValidatorAddressFromAssetId(assetId)],
 )
+
+export type OpportunitiesDataFull = {
+  totalDelegations: string
+  rewards: string
+  isLoaded: boolean
+  address: string
+  moniker: string
+  tokens?: string
+  apr: string
+  commission: string
+}
+
 export const selectStakingOpportunitiesDataFullByFilter = createDeepEqualOutputSelector(
   selectValidatorIdsByFilter,
   selectValidators,

--- a/src/state/slices/portfolioSlice/selectors.ts
+++ b/src/state/slices/portfolioSlice/selectors.ts
@@ -1148,10 +1148,12 @@ export const selectValidatorIdsByFilter = createDeepEqualOutputSelector(
 )
 
 const selectDefaultStakingDataByValidatorId = createSelector(
-  selectAssetIdParamFromFilterOptional,
+  selectAssetIdParamFromFilter,
   selectValidators,
-  (assetId, stakingDataByValidator) =>
-    stakingDataByValidator[getDefaultValidatorAddressFromAssetId(assetId)],
+  (assetId, stakingDataByValidator) => {
+    if (!assetId) return
+    return stakingDataByValidator[getDefaultValidatorAddressFromAssetId(assetId)]
+  },
 )
 
 export type OpportunitiesDataFull = {

--- a/src/state/slices/portfolioSlice/selectors.ts
+++ b/src/state/slices/portfolioSlice/selectors.ts
@@ -461,56 +461,6 @@ export const selectStakingDataByMaybeAccountSpecifier = createSelector(
   },
 )
 
-export const selectTotalStakingDelegationCryptoByAccountSpecifier = createDeepEqualOutputSelector(
-  selectStakingDataByMaybeAccountSpecifier,
-  selectAssetIdParamFromFilter,
-  // We make the assumption that all delegation rewards come from a single denom (asset)
-  // In the future there may be chains that support rewards in multiple denoms and this will need to be parsed differently
-  (stakingData, assetId): string => {
-    // Since we pass an accountSpecifier (AccountId) in, stakingData is guaranteed to be 0-length
-    // Thus, we can simply unwrap it by accessing the 0th item
-    const unwrappedStakingData = stakingData[0] ?? {}
-    const delegations = Object.values(unwrappedStakingData)
-      .flatMap(validatorStaking => validatorStaking[assetId]?.delegations?.[0])
-      .filter(Boolean)
-    const amount = reduce(
-      delegations,
-      (acc, delegation) => acc.plus(bnOrZero(delegation.amount)),
-      bn(0),
-    )
-
-    return amount.toString()
-  },
-)
-
-export const selectTotalStakingUndelegationCryptoByAccountSpecifier = createSelector(
-  selectStakingDataByMaybeAccountSpecifier,
-  selectAssetIdParamFromFilter,
-  // We make the assumption that all delegation rewards come from a single denom (asset)
-  // In the future there may be chains that support rewards in multiple denoms and this will need to be parsed differently
-  (stakingData, assetId) => {
-    // Since we pass an accountSpecifier (AccountId) in, stakingData is guaranteed to be 0-length
-    // Thus, we can simply unwrap it by accessing the 0th item
-    const unwrappedStakingData = stakingData[0]
-    if (!unwrappedStakingData) return '0'
-
-    const stakingDataFilteredByAssetId = Object.values(unwrappedStakingData).flatMap(
-      validatorStakingData => validatorStakingData[assetId],
-    )
-    const amount = Object.values(stakingDataFilteredByAssetId)
-      .reduce((acc, validatorStakingData) => {
-        validatorStakingData?.undelegations?.forEach(undelegationEntry => {
-          acc = acc.plus(undelegationEntry.amount)
-        })
-
-        return acc
-      }, bn(0))
-      .toString()
-
-    return amount
-  },
-)
-
 /**
  * this selector is very specific; we need to consider
  * - raw account balances, that are

--- a/src/state/slices/portfolioSlice/selectors.ts
+++ b/src/state/slices/portfolioSlice/selectors.ts
@@ -1087,13 +1087,6 @@ export type ActiveStakingOpportunity = {
   rewards?: string
 }
 
-export type AmountByValidatorAddressType = {
-  // This maps from validator pubkey -> staked asset in base precision
-  // e.g for 1 ATOM staked on ShapeShift DAO validator:
-  // {"cosmosvaloper199mlc7fr6ll5t54w7tts7f4s0cvnqgc59nmuxf": "1000000"}
-  [k: PubKey]: string
-}
-
 export const selectDelegationCryptoAmountByAssetIdAndValidator = createSelector(
   selectStakingDataByFilter,
   selectValidatorAddressParamFromFilter,

--- a/src/state/slices/txHistorySlice/utils.ts
+++ b/src/state/slices/txHistorySlice/utils.ts
@@ -1,8 +1,7 @@
-import type { AssetId } from '@shapeshiftoss/caip'
+import type { AccountId, AssetId } from '@shapeshiftoss/caip'
 import intersection from 'lodash/intersection'
 import union from 'lodash/union'
 
-import type { AccountSpecifier } from '../portfolioSlice/portfolioSliceCommon'
 import type { Tx } from './txHistorySlice'
 
 type TxIndex = string
@@ -48,7 +47,7 @@ export const addToIndex = <T>(parentIndex: T[], childIndex: T[], newItem: T): T[
 // we can't use a hyphen as a delimiter, as it appears in the chain reference for cosmos
 export const UNIQUE_TX_ID_DELIMITER = '*'
 export const serializeTxIndex = (
-  accountId: AccountSpecifier,
+  accountId: AccountId,
   txId: Tx['txid'],
   txAddress: Tx['address'],
 ): TxIndex => [accountId, txId, txAddress.toLowerCase()].join(UNIQUE_TX_ID_DELIMITER)


### PR DESCRIPTION
## Description

<!-- Please describe your changes -->

this should fix the issues described in #3062 and uhh deletes a bit of code along the way

the impetus for this was the insanity around the duplication of accountSpecifier and accountId terminology, this was essentially the minimum change that could be made to make the consumption of these selectors sane and bug free, and along the way managed to find a bunch of selectors that were redundant and their associated tests.

this also removes any selectors and filters using the old `accountSpecifier` terminology for future travelers benefits

## Notice

<!-- Before submitting a pull request, please make sure you have answered the following: -->

- [x] Have you followed the guidelines in our [Contributing]('https://github.com/shapeshift/web/blob/develop/CONTRIBUTING.md) guide?
- [x] Have you checked to ensure there aren't other open [Pull Requests](https://github.com/shapeshift/web/pulls) for the same update/change?

## Pull Request Type

- [x] :bug: Bug fix (Non-breaking Change: Fixes an issue)
- [x] :hammer_and_wrench: Chore (Non-breaking Change: Doc updates, pkg upgrades, typos, etc..)
- [ ] :nail_care: New Feature (Breaking/Non-breaking Change)

## Issue (if applicable)

<!-----------------------------------------------------------------------------
If applicable, please link to the github issue and put `closes #XXXX` in your comment to auto-close the issue that your PR fixes.
------------------------------------------------------------------------------>

closes #3062

## Risk

pretty big around cosmos staking

<!-----------------------------------------------------------------------------
Outline the scope of your changes and the risk associated with them. You must use your discretion as an engineer to determine the potential impact of your changes.

E.g. an upgrade to `hdwallet` or core state management would be considered higher risk, and might require a full regression test. UI or isolated view changes, or something behind a feature flag may have near zero risk. Small bug fixes might require testing isolated to the specific fix.
------------------------------------------------------------------------------>

## Testing

<!-----------------------------------------------------------------------------
We treat every PR to be merged with the same scrutiny as if we were merging directly to production.

Your PR will not be merged if you do not complete the sections below for our engineering and operations teams to test.
------------------------------------------------------------------------------>

### Engineering

<!-----------------------------------------------------------------------------
Include sufficient information here for an engineer to test your PR. This may include how to test locally, in a built environment, changes to infrastructure etc.
------------------------------------------------------------------------------>

### Operations

* please test with multi account flag on
* if a wallet doesn't have any cosmos sdk staking balances, the get started CTA should appear on the asset, account, and defi pages
* if a wallet has a cosmos sdk staking balance on one or more accounts, it should show the aggregated balance on a single row
* choosing an account from the cosmos modal that doesn't have a staking balance will kick you to the get started modal for that account
* choosing an account with a balance will allow you to deposit/withdraw/claim as expected

<!-----------------------------------------------------------------------------
If your changes have a user-facing impact, describe how a non-technical QA team can functionally test your changes in a preview environment.

If they are not user-facing please describe how to test for any regressions that may occur.
------------------------------------------------------------------------------>

## Screenshots (if applicable)
