### PR TITLE
fix: reset input when clearing filters

### DIFF
--- a/src/pages/TransactionHistory/TransactionHistory.tsx
+++ b/src/pages/TransactionHistory/TransactionHistory.tsx
@@ -1,5 +1,5 @@
 import { Flex, Heading } from '@chakra-ui/react'
-import { useMemo } from 'react'
+import { useCallback, useMemo, useRef } from 'react'
 import { Card } from 'components/Card/Card'
 import { Main } from 'components/Layout/Main'
 import { Text } from 'components/Text'
@@ -14,6 +14,7 @@ import { TransactionHistoryFilter } from './TransactionHistoryFilter'
 import { TransactionHistorySearch } from './TransactionHistorySearch'
 
 export const TransactionHistory = () => {
+  const inputRef = useRef<HTMLInputElement | null>(null)
   const { searchTerm, matchingAssets, handleInputChange } = useSearch()
   const { filters, setFilters, resetFilters } = useFilters()
   const selectorFilters = useMemo(
@@ -27,6 +28,14 @@ export const TransactionHistory = () => {
   const txIds = useAppSelector(state =>
     selectTxIdsBasedOnSearchTermAndFilters(state, selectorFilters),
   )
+  const handleReset = useCallback(() => {
+    resetFilters()
+    if (inputRef?.current?.value) {
+      inputRef.current.value = ''
+      handleInputChange('')
+    }
+  }, [handleInputChange, resetFilters])
+
   return (
     <Main>
       <Heading mb={{ base: 1, md: 4 }} ml={4} fontSize={['md', 'lg', '3xl']}>
@@ -36,9 +45,9 @@ export const TransactionHistory = () => {
         <Card.Heading p={[2, 3, 6]}>
           <Flex justifyContent='space-between'>
             <Flex>
-              <TransactionHistorySearch handleInputChange={handleInputChange} />
+              <TransactionHistorySearch ref={inputRef} handleInputChange={handleInputChange} />
               <TransactionHistoryFilter
-                resetFilters={resetFilters}
+                resetFilters={handleReset}
                 setFilters={setFilters}
                 hasAppliedFilter={!!Object.values(filters).filter(Boolean).length}
               />

--- a/src/pages/TransactionHistory/TransactionHistoryFilter.tsx
+++ b/src/pages/TransactionHistory/TransactionHistoryFilter.tsx
@@ -117,7 +117,6 @@ export const TransactionHistoryFilter = ({
               <Text translation='transactionHistory.filter' />
             </Button>
             <IconButton
-              isDisabled={!hasAppliedFilter}
               variant='ghost-filled'
               colorScheme='blue'
               aria-label={translate('transactionHistory.filters.resetFilters')}

--- a/src/pages/TransactionHistory/TransactionHistorySearch.tsx
+++ b/src/pages/TransactionHistory/TransactionHistorySearch.tsx
@@ -1,11 +1,11 @@
 import { SearchIcon } from '@chakra-ui/icons'
 import { Input, InputGroup, InputLeftElement, useColorModeValue } from '@chakra-ui/react'
+import { forwardRef } from 'react'
 
-export const TransactionHistorySearch = ({
-  handleInputChange,
-}: {
-  handleInputChange: Function
-}) => {
+export const TransactionHistorySearch = forwardRef<
+  HTMLInputElement,
+  { handleInputChange: Function }
+>(({ handleInputChange }, ref) => {
   return (
     <InputGroup mr={[3, 3, 6]}>
       <InputLeftElement pointerEvents='none'>
@@ -17,7 +17,8 @@ export const TransactionHistorySearch = ({
         placeholder='Search'
         pl={10}
         variant='filled'
+        ref={ref}
       />
     </InputGroup>
   )
-}
+})


### PR DESCRIPTION
## Description

- Allow user to clear search input when the filters are reset
- The clear button should always be enabled -- no real benefit to it being disabled or not.

## Notice

<!-- Before submitting a pull request, please make sure you have answered the following: -->

- [x] Have you followed the guidelines in our [Contributing]('https://github.com/shapeshift/web/blob/develop/CONTRIBUTING.md) guide?
- [x] Have you checked to ensure there aren't other open [Pull Requests](https://github.com/shapeshift/web/pulls) for the same update/change?

## Pull Request Type

- [x] :bug: Bug fix (Non-breaking Change: Fixes an issue)
- [ ] :hammer_and_wrench: Chore (Non-breaking Change: Doc updates, pkg upgrades, typos, etc..)
- [ ] :nail_care: New Feature (Breaking/Non-breaking Change)

## Issue (if applicable)

<!-----------------------------------------------------------------------------
If applicable, please link to the github issue and put `closes #XXXX` in your comment to auto-close the issue that your PR fixes.
------------------------------------------------------------------------------>

closes #3038 

## Risk

no big risk

## Testing

<!-----------------------------------------------------------------------------
We treat every PR to be merged with the same scrutiny as if we were merging directly to production.

Your PR will not be merged if you do not complete the sections below for our engineering and operations teams to test.
------------------------------------------------------------------------------>

### Engineering

To avoid controlled/uncontrolled field issue, used a ref to clear the field value.

### Operations

When typing in a search string on the tx history, you should be able to clear it by clicking the "x" button connected to filters.

## Screenshots (if applicable)
![Screen Shot 2022-10-14 at 3 06 31 PM](https://user-images.githubusercontent.com/89934888/195933030-b191bdbe-f472-4065-ba14-5b0c1424a0c8.png)
