### PR TITLE
fix: max width on cosmos learn more modals

### DIFF
--- a/src/features/defi/providers/cosmos/components/CosmosManager/LearnMore/CosmosLearnMore.tsx
+++ b/src/features/defi/providers/cosmos/components/CosmosManager/LearnMore/CosmosLearnMore.tsx
@@ -107,13 +107,7 @@ export const CosmosLearnMore = ({ onClose }: LearnMoreProps) => {
         minWidth={{ base: '100%', md: '500px' }}
         maxWidth={{ base: 'full', md: '500px' }}
       >
-        <Flex
-          direction='column'
-          maxWidth='395px'
-          height='520px'
-          alignItems='center'
-          justifyContent='space-between'
-        >
+        <Flex direction='column' height='520px' alignItems='center' justifyContent='space-between'>
           <SlideTransition key={activeStep}>
             <Flex direction='column' alignItems='center'>
               <DefiModalHeader

--- a/src/plugins/cosmos/components/modals/Staking/views/GetStarted/GetStarted.tsx
+++ b/src/plugins/cosmos/components/modals/Staking/views/GetStarted/GetStarted.tsx
@@ -45,7 +45,7 @@ export const GetStarted = ({ assetId }: GetStartedProps) => {
   return (
     <Box pt='51px' pb='20px' px='24px'>
       <ModalCloseButton borderRadius='full' />
-      <Flex direction='column' maxWidth='395px' alignItems='center' justifyContent='space-between'>
+      <Flex direction='column' alignItems='center' justifyContent='space-between'>
         <DefiModalHeader
           headerImageSrc={asset.icon}
           headerImageMaxWidth={68}

--- a/src/plugins/cosmos/components/modals/Staking/views/GetStarted/LearnMore.tsx
+++ b/src/plugins/cosmos/components/modals/Staking/views/GetStarted/LearnMore.tsx
@@ -89,13 +89,7 @@ export const LearnMore = ({ assetId }: LearnMoreProps) => {
         onClick={handlePrevClick}
       />
       <Box pt='36px' pb='20px' px='24px'>
-        <Flex
-          direction='column'
-          maxWidth='395px'
-          height='520px'
-          alignItems='center'
-          justifyContent='space-between'
-        >
+        <Flex direction='column' height='520px' alignItems='center' justifyContent='space-between'>
           <SlideTransition key={activeStep}>
             <Flex direction='column' alignItems='center'>
               <DefiModalHeader


### PR DESCRIPTION
## Description

- Remove max width to fill entire modal

## Notice

<!-- Before submitting a pull request, please make sure you have answered the following: -->

- [x] Have you followed the guidelines in our [Contributing]('https://github.com/shapeshift/web/blob/develop/CONTRIBUTING.md) guide?
- [x] Have you checked to ensure there aren't other open [Pull Requests](https://github.com/shapeshift/web/pulls) for the same update/change?

## Pull Request Type

- [x] :bug: Bug fix (Non-breaking Change: Fixes an issue)
- [ ] :hammer_and_wrench: Chore (Non-breaking Change: Doc updates, pkg upgrades, typos, etc..)
- [ ] :nail_care: New Feature (Breaking/Non-breaking Change)

## Issue (if applicable)

<!-----------------------------------------------------------------------------
If applicable, please link to the github issue and put `closes #XXXX` in your comment to auto-close the issue that your PR fixes.
------------------------------------------------------------------------------>

closes #3073 

## Risk

no risk visual

## Testing

<!-----------------------------------------------------------------------------
We treat every PR to be merged with the same scrutiny as if we were merging directly to production.

Your PR will not be merged if you do not complete the sections below for our engineering and operations teams to test.
------------------------------------------------------------------------------>

### Engineering

n/a

### Operations

Go to cosmos asset, and click get started and then learn more. The modal should fill the entire space available and not be cut off.

## Screenshots (if applicable)
![Screen Shot 2022-10-14 at 4 31 56 PM](https://user-images.githubusercontent.com/89934888/195947199-f60b3e13-5751-4ae7-9f3b-497b6b87c671.png)
