### PR TITLE
fix: walletProvider translation

### DIFF
--- a/src/context/WalletProvider/Keplr/components/Failure.tsx
+++ b/src/context/WalletProvider/Keplr/components/Failure.tsx
@@ -3,7 +3,7 @@ import { FailureModal } from 'context/WalletProvider/components/FailureModal'
 export const KeplrFailure = () => {
   return (
     <FailureModal
-      headerText={'walletprovider.keplr.failure.header'}
+      headerText={'walletProvider.keplr.failure.header'}
       bodyText={'walletProvider.keplr.failure.body'}
     ></FailureModal>
   )

--- a/src/context/WalletProvider/Portis/components/Failure.tsx
+++ b/src/context/WalletProvider/Portis/components/Failure.tsx
@@ -3,7 +3,7 @@ import { FailureModal } from 'context/WalletProvider/components/FailureModal'
 export const PortisFailure = () => {
   return (
     <FailureModal
-      headerText={'walletprovider.portisFailure.header'}
+      headerText={'walletProvider.portisFailure.header'}
       bodyText={'walletProvider.portisFailure.body'}
     ></FailureModal>
   )


### PR DESCRIPTION
## Description

The `walletprovider` translation key does not exist.

Correct the translation to `walletProvider`.

## Notice

- [x] Have you followed the guidelines in our [Contributing]('https://github.com/shapeshift/web/blob/develop/CONTRIBUTING.md) guide?
- [x] Have you checked to ensure there aren't other open [Pull Requests](https://github.com/shapeshift/web/pulls) for the same update/change?

## Pull Request Type

- [x] :bug: Bug fix (Non-breaking Change: Fixes an issue)
- [ ] :hammer_and_wrench: Chore (Non-breaking Change: Doc updates, pkg upgrades, typos, etc..)
- [ ] :nail_care: New Feature (Breaking/Non-breaking Change)

## Issue (if applicable)

N/A

## Risk

Almost literally 0.

## Testing

Not worth testing, but I assume that Keplr and Portis errors now show the key value, rather than the invalid key.

### Engineering

N/A

### Operations

N/A

## Screenshots (if applicable)

N/A