### PR TITLE
fix: make selectAccountIdsByAssetId call stable in FoxEthProvider

### DIFF
--- a/src/components/AssetHeader/AssetHeader.tsx
+++ b/src/components/AssetHeader/AssetHeader.tsx
@@ -1,5 +1,6 @@
 import { Box, Flex, Heading } from '@chakra-ui/react'
 import type { AssetId } from '@shapeshiftoss/caip'
+import isEqual from 'lodash/isEqual'
 import { useMemo } from 'react'
 import { AssetIcon } from 'components/AssetIcon'
 import { useWallet } from 'hooks/useWallet/useWallet'
@@ -22,7 +23,11 @@ type AssetHeaderProps = {
 export const AssetHeader: React.FC<AssetHeaderProps> = ({ assetId, accountId }) => {
   const asset = useAppSelector(state => selectAssetById(state, assetId))
   const chainId = asset.chainId
-  const accountIds = useAppSelector(state => selectAccountIdsByAssetId(state, { assetId }))
+  const accountIdsFilter = useMemo(() => ({ assetId: assetId ?? '' }), [assetId])
+  const accountIds = useAppSelector(
+    state => selectAccountIdsByAssetId(state, accountIdsFilter),
+    isEqual,
+  )
   const singleAccount = accountIds && accountIds.length === 1 ? accountIds[0] : undefined
   const { name, symbol } = asset || {}
 

--- a/src/components/Trade/SelectAccount.tsx
+++ b/src/components/Trade/SelectAccount.tsx
@@ -1,5 +1,7 @@
 import { Stack } from '@chakra-ui/react'
 import type { KnownChainIds } from '@shapeshiftoss/types'
+import isEqual from 'lodash/isEqual'
+import { useMemo } from 'react'
 import { useFormContext } from 'react-hook-form'
 import type { RouteComponentProps } from 'react-router-dom'
 import { AssetAccountRow } from 'components/AssetAccounts/AssetAccountRow'
@@ -16,9 +18,8 @@ import { useAppSelector } from 'state/store'
 export const SelectAccount = ({ history }: RouteComponentProps) => {
   const { getValues, setValue } = useFormContext<TradeState<KnownChainIds>>()
   const assetId = getValues('sellTradeAsset')?.asset?.assetId
-  const accountIds = useAppSelector(state =>
-    selectAccountIdsByAssetId(state, { assetId: assetId ?? '' }),
-  )
+  const filter = useMemo(() => ({ assetId: assetId ?? '' }), [assetId])
+  const accountIds = useAppSelector(state => selectAccountIdsByAssetId(state, filter), isEqual)
   const asset = useAppSelector(state => selectAssetById(state, assetId ?? ''))
 
   const handleBack = () => {

--- a/src/components/Trade/TradeInput.tsx
+++ b/src/components/Trade/TradeInput.tsx
@@ -2,6 +2,7 @@ import { Box, Button, FormControl, FormErrorMessage, IconButton } from '@chakra-
 import { fromAccountId } from '@shapeshiftoss/caip'
 import type { SwapErrorTypes } from '@shapeshiftoss/swapper'
 import type { KnownChainIds } from '@shapeshiftoss/types'
+import isEqual from 'lodash/isEqual'
 import type { InterpolationOptions } from 'node-polyglot'
 import { useCallback, useEffect, useMemo, useState } from 'react'
 import { Controller, useFormContext, useWatch } from 'react-hook-form'
@@ -99,8 +100,13 @@ export const TradeInput = ({ history }: RouterProps) => {
   } = useWallet()
   const [isUpdatingTrade, setIsUpdatingTrade] = useState(false)
 
-  const accountIds = useAppSelector(state =>
-    selectAccountIdsByAssetId(state, { assetId: sellTradeAsset?.asset?.assetId ?? '' }),
+  const accountIdsFilter = useMemo(
+    () => ({ assetId: sellTradeAsset?.asset?.assetId ?? '' }),
+    [sellTradeAsset?.asset?.assetId],
+  )
+  const accountIds = useAppSelector(
+    state => selectAccountIdsByAssetId(state, accountIdsFilter),
+    isEqual,
   )
 
   const shouldShowAccountSelection = sellTradeAsset?.asset && accountIds.length > 1

--- a/src/components/TransactionHistory/AssetTransactionHistory.tsx
+++ b/src/components/TransactionHistory/AssetTransactionHistory.tsx
@@ -1,4 +1,5 @@
 import type { AssetId } from '@shapeshiftoss/caip'
+import isEqual from 'lodash/isEqual'
 import { useMemo } from 'react'
 import { useTranslate } from 'react-polyglot'
 import { Card } from 'components/Card/Card'
@@ -33,7 +34,11 @@ export const AssetTransactionHistory: React.FC<AssetTransactionHistoryProps> = (
 
   const asset = useAppSelector(state => selectAssetById(state, assetId))
   const chainId = asset.chainId
-  const accountIds = useAppSelector(state => selectAccountIdsByAssetId(state, { assetId }))
+  const accountIdsFilter = useMemo(() => ({ assetId }), [assetId])
+  const accountIds = useAppSelector(
+    state => selectAccountIdsByAssetId(state, accountIdsFilter),
+    isEqual,
+  )
   const filter = useMemo(
     // if we are passed an accountId, we're on an asset account page, use that specifically.
     // otherwise, we're on an asset page, use all accountIds related to this asset

--- a/src/context/FoxEthProvider/FoxEthProvider.tsx
+++ b/src/context/FoxEthProvider/FoxEthProvider.tsx
@@ -5,6 +5,7 @@ import { supportsETH } from '@shapeshiftoss/hdwallet-core'
 import type { KnownChainIds } from '@shapeshiftoss/types'
 import { TxStatus } from '@shapeshiftoss/unchained-client'
 import type { EarnOpportunityType } from 'features/defi/helpers/normalizeOpportunity'
+import isEqual from 'lodash/isEqual'
 import React, { createContext, useContext, useMemo } from 'react'
 import { useCallback, useEffect, useState } from 'react'
 import { getChainAdapterManager } from 'context/PluginProvider/chainAdapterSingleton'
@@ -86,9 +87,11 @@ export const FoxEthProvider = ({ children }: FoxEthProviderProps) => {
     [readyToFetchLpData, accountAddress, foxLpEnabled, foxEthLpMarketData.price],
   )
 
-  const ethAccountIds = useAppSelector(state =>
-    selectAccountIdsByAssetId(state, { assetId: ethAssetId }),
-  )
+  const filter = useMemo(() => ({ assetId: ethAssetId }), [])
+
+  // TODO(gomes): deepEqualOutputFn should happen on the selector itself and give us the same reference every call but it somehow doesn't
+  // Remove the equalityFn second arg here after we figure out why
+  const ethAccountIds = useAppSelector(state => selectAccountIdsByAssetId(state, filter), isEqual)
 
   const refetchFoxEthLpAccountData = useCallback(async () => {
     if (!ethAccountIds?.length || !readyToFetchLpAccountData) return

--- a/src/pages/Defi/views/StakingVaults.tsx
+++ b/src/pages/Defi/views/StakingVaults.tsx
@@ -12,9 +12,10 @@ import { ethAssetId, ethChainId, foxAssetId, fromAccountId } from '@shapeshiftos
 import { DefiProvider } from 'features/defi/contexts/DefiManagerProvider/DefiCommon'
 import { UNISWAP_V2_WETH_FOX_POOL_ADDRESS } from 'features/defi/providers/fox-eth-lp/constants'
 import { FOX_FARMING_V4_CONTRACT_ADDRESS } from 'features/defi/providers/fox-farming/constants'
+import isEqual from 'lodash/isEqual'
 import { FOX_TOKEN_CONTRACT_ADDRESS } from 'plugins/foxPage/const'
 import qs from 'qs'
-import { useCallback, useEffect, useState } from 'react'
+import { useCallback, useEffect, useMemo, useState } from 'react'
 import { useTranslate } from 'react-polyglot'
 import { useHistory, useLocation } from 'react-router'
 import { Amount } from 'components/Amount/Amount'
@@ -55,9 +56,8 @@ const FoxFarmCTA = () => {
   const [isLpAprLoaded, setIsLpAprLoaded] = useState<boolean>(false)
   const [isFarmingAprV4Loaded, setIsFarmingAprV4Loaded] = useState<boolean>(false)
 
-  const ethAccountIds = useAppSelector(state =>
-    selectAccountIdsByAssetId(state, { assetId: ethAssetId }),
-  )
+  const filter = useMemo(() => ({ assetId: ethAssetId }), [])
+  const ethAccountIds = useAppSelector(state => selectAccountIdsByAssetId(state, filter), isEqual)
 
   useEffect(() => {
     ;(async () => {

--- a/src/plugins/foxPage/components/AssetActions.tsx
+++ b/src/plugins/foxPage/components/AssetActions.tsx
@@ -17,6 +17,7 @@ import { foxAssetId } from '@shapeshiftoss/caip'
 import { supportsETH } from '@shapeshiftoss/hdwallet-core/dist/wallet'
 import { foxyAddresses } from '@shapeshiftoss/investor-foxy'
 import { DefiProvider } from 'features/defi/contexts/DefiManagerProvider/DefiCommon'
+import isEqual from 'lodash/isEqual'
 import qs from 'qs'
 import { useCallback, useMemo } from 'react'
 import { useTranslate } from 'react-polyglot'
@@ -50,7 +51,8 @@ export const AssetActions: React.FC<FoxTabProps> = ({ assetId }) => {
   const trimmedDescription = trimWithEndEllipsis(description, TrimmedDescriptionLength)
   const isFoxAsset = assetId === foxAssetId
 
-  const accountIds = useAppSelector(state => selectAccountIdsByAssetId(state, { assetId }))
+  const filter = useMemo(() => ({ assetId }), [assetId])
+  const accountIds = useAppSelector(state => selectAccountIdsByAssetId(state, filter), isEqual)
   const accountId = accountIds?.[0]
 
   const {

--- a/src/plugins/foxPage/hooks/useOtherOpportunities.ts
+++ b/src/plugins/foxPage/hooks/useOtherOpportunities.ts
@@ -6,6 +6,7 @@ import {
   UNISWAP_V2_WETH_FOX_POOL_ADDRESS,
 } from 'features/defi/providers/fox-eth-lp/constants'
 import { FOX_FARMING_V4_CONTRACT_ADDRESS } from 'features/defi/providers/fox-farming/constants'
+import isEqual from 'lodash/isEqual'
 import { useEffect, useMemo, useState } from 'react'
 import { bnOrZero } from 'lib/bignumber/bignumber'
 import { foxEthApi } from 'state/slices/foxEthSlice/foxEthSlice'
@@ -25,9 +26,8 @@ export const useOtherOpportunities = (assetId: AssetId) => {
   const [isLpAprLoaded, setIsLpAprLoaded] = useState<boolean>(false)
   const [isFarmingAprV4Loaded, setIsFarmingAprV4Loaded] = useState<boolean>(false)
 
-  const ethAccountIds = useAppSelector(state =>
-    selectAccountIdsByAssetId(state, { assetId: ethAssetId }),
-  )
+  const filter = useMemo(() => ({ assetId: ethAssetId }), [])
+  const ethAccountIds = useAppSelector(state => selectAccountIdsByAssetId(state, filter), isEqual)
 
   useEffect(() => {
     ;(async () => {

--- a/src/state/slices/portfolioSlice/selectors.ts
+++ b/src/state/slices/portfolioSlice/selectors.ts
@@ -119,7 +119,10 @@ const selectValidatorAddressParamFromFilter = selectParamFromFilter('validatorAd
 const selectAccountIdParamFromFilterOptional = selectParamFromFilterOptional('accountId')
 const selectAssetIdParamFromFilterOptional = selectParamFromFilterOptional('assetId')
 
-export const selectPortfolioAccounts = (state: ReduxState) => state.portfolio.accounts.byId
+export const selectPortfolioAccounts = createSelector(
+  (state: ReduxState) => state.portfolio.accounts.byId,
+  byId => byId,
+)
 
 export const selectPortfolioAssetIds = createDeepEqualOutputSelector(
   (state: ReduxState): PortfolioAssetBalances['ids'] => state.portfolio.assetBalances.ids,


### PR DESCRIPTION
## Description

Currently, `selectAccountIdsByAssetId` is somehow unstable, despite the output being deeply equal.

https://github.com/shapeshift/web/blob/e69906f95940a3e3b8dffc7831875f4ec15db1e8/src/context/FoxEthProvider/FoxEthProvider.tsx#L89-L91

When called in `EthProvider`, this invalidated reference on every call causes `ethAccountIds` to invalidate, and the memoized callback to invalidate as a return in `refetchFoxEthLpAccountData` deps.

https://github.com/shapeshift/web/blob/e69906f95940a3e3b8dffc7831875f4ec15db1e8/src/context/FoxEthProvider/FoxEthProvider.tsx#L93-L108

Since we have an effect reacting on `readyToFetchLpData` and `refetchFoxEthLpAccountData` reference to fire refetch, this causes refetch to fire infinitely, causing an infinite XHR loop and performance issues.

This is a quick fix for it until we actually make the selector stable

## Notice

<!-- Before submitting a pull request, please make sure you have answered the following: -->

- [x] Have you followed the guidelines in our [Contributing]('https://github.com/shapeshift/web/blob/develop/CONTRIBUTING.md) guide?
- [x] Have you checked to ensure there aren't other open [Pull Requests](https://github.com/shapeshift/web/pulls) for the same update/change?

## Pull Request Type

- [x] :bug: Bug fix (Non-breaking Change: Fixes an issue)
- [ ] :hammer_and_wrench: Chore (Non-breaking Change: Doc updates, pkg upgrades, typos, etc..)
- [ ] :nail_care: New Feature (Breaking/Non-breaking Change)

## Issue (if applicable)

- relates to the closed https://github.com/shapeshift/web/issues/2447

## Risk

<!-----------------------------------------------------------------------------
Outline the scope of your changes and the risk associated with them. You must use your discretion as an engineer to determine the potential impact of your changes.

E.g. an upgrade to `hdwallet` or core state management would be considered higher risk, and might require a full regression test. UI or isolated view changes, or something behind a feature flag may have near zero risk. Small bug fixes might require testing isolated to the specific fix.
------------------------------------------------------------------------------>

This makes things more stable, if this breaks somethings, we have bigger problems

## Testing

<!-----------------------------------------------------------------------------
We treat every PR to be merged with the same scrutiny as if we were merging directly to production.

Your PR will not be merged if you do not complete the sections below for our engineering and operations teams to test.
------------------------------------------------------------------------------>

- Go to an UTXO asset page
- The page should be stable i.e
  - everything should load
  - hovering over UI elements/clicking them e.g time frame buttons shouldn't be laggy, which would indicate stuck event loop, and as a result of our logic, congested main thread being extremely slow at painting
- Open your console and filter messages by `'message' handler took`. There should be a few (~5-15) which is the normal behavior, but you shouldn't see this number increase every second or so infinitely

### Engineering

☝🏽

### Operations

☝🏽

## Screenshots (if applicable)
