### PR TITLE
feat: split fox/eth LP/farming accountIds

### DIFF
--- a/src/components/StakingVaults/EarnOpportunities.tsx
+++ b/src/components/StakingVaults/EarnOpportunities.tsx
@@ -58,11 +58,14 @@ export const EarnOpportunities = ({ assetId, accountId }: EarnOpportunitiesProps
     selectFoxEthLpAccountOpportunitiesByMaybeAccountAddress(state, filter),
   )
 
-  const { setAccountId } = useFoxEth()
+  const { setLpAccountId, setFarmingAccountId } = useFoxEth()
 
   useEffect(() => {
-    if (accountId) setAccountId(accountId)
-  }, [setAccountId, accountId])
+    if (accountId) {
+      setFarmingAccountId(accountId)
+      setLpAccountId(accountId)
+    }
+  }, [setLpAccountId, setFarmingAccountId, accountId])
 
   const allRows = useNormalizeOpportunities({
     vaultArray: Object.values(vaults),

--- a/src/context/FoxEthProvider/FoxEthProvider.tsx
+++ b/src/context/FoxEthProvider/FoxEthProvider.tsx
@@ -39,17 +39,25 @@ type FoxEthProviderProps = {
 }
 
 type IFoxEthContext = {
-  accountId: Nullable<AccountId>
-  setAccountId: (accountId: AccountId) => void
-  accountAddress: string
-  onOngoingTxIdChange: (txid: string, contractAddress?: string) => Promise<void>
+  farmingAccountId: Nullable<AccountId>
+  setFarmingAccountId: (accountId: AccountId) => void
+  lpAccountId: Nullable<AccountId>
+  setLpAccountId: (accountId: AccountId) => void
+  lpAccountAddress: string
+  farmingAccountAddress: string
+  onOngoingFarmingTxIdChange: (txid: string, contractAddress?: string) => Promise<void>
+  onOngoingLpTxIdChange: (txid: string, contractAddress?: string) => Promise<void>
 }
 
 const FoxEthContext = createContext<IFoxEthContext>({
-  setAccountId: _accountId => {},
-  accountId: null,
-  accountAddress: '',
-  onOngoingTxIdChange: (_txid: string) => Promise.resolve(),
+  lpAccountId: null,
+  farmingAccountId: null,
+  setLpAccountId: _accountId => {},
+  setFarmingAccountId: _accountId => {},
+  lpAccountAddress: '',
+  farmingAccountAddress: '',
+  onOngoingFarmingTxIdChange: (_txid: string) => Promise.resolve(),
+  onOngoingLpTxIdChange: (_txid: string) => Promise.resolve(),
 })
 
 export const FoxEthProvider = ({ children }: FoxEthProviderProps) => {
@@ -69,8 +77,10 @@ export const FoxEthProvider = ({ children }: FoxEthProviderProps) => {
   ) as ChainAdapter<KnownChainIds.EthereumMainnet>
   const [ongoingTxId, setOngoingTxId] = useState<string | null>(null)
   const [ongoingTxContractAddress, setOngoingTxContractAddress] = useState<string | null>(null)
-  const [accountAddress, setAccountAddress] = useState<string>('')
-  const [accountId, setAccountId] = useState<Nullable<AccountId>>(null)
+  const [lpAccountAddress, setLpAccountAddress] = useState<string>('')
+  const [farmingAccountAddress, setFarmingAccountAddress] = useState<string>('')
+  const [farmingAccountId, setFarmingAccountId] = useState<Nullable<AccountId>>(null)
+  const [lpAccountId, setLpAccountId] = useState<Nullable<AccountId>>(null)
   const readyToFetchLpData = useMemo(
     () => !isPortfolioLoading && wallet && supportsETH(wallet),
     [isPortfolioLoading, wallet],
@@ -82,9 +92,9 @@ export const FoxEthProvider = ({ children }: FoxEthProviderProps) => {
   const readyToFetchLpAccountData = useMemo(
     () =>
       Boolean(
-        readyToFetchLpData && accountAddress && foxLpEnabled && foxEthLpMarketData.price !== '0',
+        readyToFetchLpData && lpAccountAddress && foxLpEnabled && foxEthLpMarketData.price !== '0',
       ),
-    [readyToFetchLpData, accountAddress, foxLpEnabled, foxEthLpMarketData.price],
+    [readyToFetchLpData, lpAccountAddress, foxLpEnabled, foxEthLpMarketData.price],
   )
 
   const filter = useMemo(() => ({ assetId: ethAssetId }), [])
@@ -120,7 +130,7 @@ export const FoxEthProvider = ({ children }: FoxEthProviderProps) => {
         dispatch(foxEthApi.endpoints.getFoxEthLpMetrics.initiate({ accountAddress }))
       })
     })()
-  }, [ethAccountIds, accountAddress, dispatch, readyToFetchLpData, refetchFoxEthLpAccountData])
+  }, [ethAccountIds, dispatch, readyToFetchLpData, refetchFoxEthLpAccountData])
 
   useEffect(() => {
     ;(async () => {
@@ -130,28 +140,35 @@ export const FoxEthProvider = ({ children }: FoxEthProviderProps) => {
     })()
   }, [refetchFoxEthLpAccountData, readyToFetchLpData])
 
-  const accountFilter = useMemo(() => ({ accountId: accountId ?? '' }), [accountId])
+  const lpAccountFilter = useMemo(() => ({ accountId: lpAccountId ?? '' }), [lpAccountId])
   // Use the account number of the consumer if we have it, else use account 0
-  const bip44Params =
-    useAppSelector(state => selectBIP44ParamsByAccountId(state, accountFilter)) ??
+  const lpBip44Params =
+    useAppSelector(state => selectBIP44ParamsByAccountId(state, lpAccountFilter)) ??
     adapter.getBIP44Params({ accountNumber: 0 })
 
   useEffect(() => {
-    if (wallet && adapter && bip44Params) {
+    // Get initial account 0 address from wallet, TODO: nuke it?
+    if (wallet && adapter && lpBip44Params) {
       ;(async () => {
         if (!supportsETH(wallet)) return
-        const address = await adapter.getAddress({ wallet, bip44Params })
+        const address = await adapter.getAddress({ wallet, bip44Params: lpBip44Params })
         // eth.getAddress and similar return a checksummed address, but state opportunities aren't
-        setAccountAddress(address.toLowerCase())
+        setLpAccountAddress(address.toLowerCase())
       })()
     }
-  }, [adapter, wallet, bip44Params])
+  }, [adapter, wallet, lpBip44Params])
 
   useEffect(() => {
-    if (!accountId) return
-    const accountAddress = fromAccountId(accountId).account
-    setAccountAddress(accountAddress)
-  }, [accountId])
+    if (!lpAccountId) return
+    const lpAccountAddress = fromAccountId(lpAccountId).account
+    setLpAccountAddress(lpAccountAddress)
+  }, [lpAccountId])
+
+  useEffect(() => {
+    if (!farmingAccountId) return
+    const farmingAccountAddress = fromAccountId(farmingAccountId).account
+    setFarmingAccountAddress(farmingAccountAddress)
+  }, [farmingAccountId])
 
   // this hook handles the data we need from the farming opportunities
   useEffect(() => {
@@ -180,28 +197,45 @@ export const FoxEthProvider = ({ children }: FoxEthProviderProps) => {
         })
       })
     })()
-  }, [accountAddress, ethAccountIds, dispatch, foxFarmingEnabled, readyToFetchFarmingData])
+  }, [ethAccountIds, dispatch, foxFarmingEnabled, readyToFetchFarmingData])
 
   const transaction = useAppSelector(gs => selectTxById(gs, ongoingTxId ?? ''))
 
   const handleOngoingTxIdChange = useCallback(
-    async (txid: string, contractAddress?: string) => {
-      if (!accountAddress) return
+    async (type: 'farming' | 'lp', txid: string, contractAddress?: string) => {
+      const accountId = type === 'farming' ? farmingAccountId : lpAccountId
+      const accountAddress = type === 'farming' ? farmingAccountAddress : lpAccountAddress
       setOngoingTxId(serializeTxIndex(accountId ?? '', txid, accountAddress))
       if (contractAddress) setOngoingTxContractAddress(contractAddress)
     },
-    [accountId, accountAddress],
+    [lpAccountId, lpAccountAddress, farmingAccountId, farmingAccountAddress],
+  )
+
+  const handleOngoingFarmingTxIdChange = useCallback(
+    async (txid: string, contractAddress?: string) => {
+      if (!farmingAccountAddress) return
+      handleOngoingTxIdChange('farming', txid, contractAddress)
+    },
+    [farmingAccountId, farmingAccountAddress, handleOngoingTxIdChange],
+  )
+
+  const handleOngoingLpTxIdChange = useCallback(
+    async (txid: string, contractAddress?: string) => {
+      if (!lpAccountAddress) return
+      handleOngoingTxIdChange('lp', txid, contractAddress)
+    },
+    [lpAccountId, lpAccountAddress, handleOngoingTxIdChange],
   )
 
   useEffect(() => {
-    if (accountAddress && transaction && transaction.status !== TxStatus.Pending) {
+    if (farmingAccountAddress && transaction && transaction.status !== TxStatus.Pending) {
       if (transaction.status === TxStatus.Confirmed) {
         moduleLogger.info('Refetching fox lp/farming opportunities')
         refetchFoxEthLpAccountData()
         if (ongoingTxContractAddress)
           dispatch(
             foxEthApi.endpoints.getFoxFarmingContractAccountData.initiate(
-              { accountAddress, contractAddress: ongoingTxContractAddress },
+              { accountAddress: farmingAccountAddress, contractAddress: ongoingTxContractAddress },
               { forceRefetch: true },
             ),
           )
@@ -209,16 +243,36 @@ export const FoxEthProvider = ({ children }: FoxEthProviderProps) => {
         setOngoingTxContractAddress(null)
       }
     }
-  }, [accountAddress, ongoingTxContractAddress, dispatch, transaction, refetchFoxEthLpAccountData])
+  }, [
+    dispatch,
+    farmingAccountAddress,
+    ongoingTxContractAddress,
+    refetchFoxEthLpAccountData,
+    transaction,
+  ])
 
   const value = useMemo(
     () => ({
-      accountId,
-      setAccountId,
-      accountAddress,
-      onOngoingTxIdChange: handleOngoingTxIdChange,
+      farmingAccountAddress,
+      farmingAccountId,
+      lpAccountAddress,
+      lpAccountId,
+      onOngoingLpTxIdChange: handleOngoingLpTxIdChange,
+      onOngoingFarmingTxIdChange: handleOngoingFarmingTxIdChange,
+      setFarmingAccountId,
+      setLpAccountId,
+      setLpAccountAddress,
     }),
-    [accountId, setAccountId, accountAddress, handleOngoingTxIdChange],
+    [
+      farmingAccountAddress,
+      farmingAccountId,
+      handleOngoingFarmingTxIdChange,
+      handleOngoingLpTxIdChange,
+      lpAccountAddress,
+      lpAccountId,
+      setLpAccountAddress,
+      setLpAccountId,
+    ],
   )
 
   return <FoxEthContext.Provider value={value}>{children}</FoxEthContext.Provider>

--- a/src/context/FoxEthProvider/FoxEthProvider.tsx
+++ b/src/context/FoxEthProvider/FoxEthProvider.tsx
@@ -216,7 +216,7 @@ export const FoxEthProvider = ({ children }: FoxEthProviderProps) => {
       if (!farmingAccountAddress) return
       handleOngoingTxIdChange('farming', txid, contractAddress)
     },
-    [farmingAccountId, farmingAccountAddress, handleOngoingTxIdChange],
+    [farmingAccountAddress, handleOngoingTxIdChange],
   )
 
   const handleOngoingLpTxIdChange = useCallback(
@@ -224,7 +224,7 @@ export const FoxEthProvider = ({ children }: FoxEthProviderProps) => {
       if (!lpAccountAddress) return
       handleOngoingTxIdChange('lp', txid, contractAddress)
     },
-    [lpAccountId, lpAccountAddress, handleOngoingTxIdChange],
+    [lpAccountAddress, handleOngoingTxIdChange],
   )
 
   useEffect(() => {

--- a/src/features/defi/providers/fox-eth-lp/components/FoxEthLpManager/Deposit/components/Approve.tsx
+++ b/src/features/defi/providers/fox-eth-lp/components/FoxEthLpManager/Deposit/components/Approve.tsx
@@ -29,8 +29,8 @@ const moduleLogger = logger.child({ namespace: ['FoxEthLpDeposit:Approve'] })
 export const Approve: React.FC<FoxEthLpApproveProps> = ({ onNext }) => {
   const { state, dispatch } = useContext(DepositContext)
   const translate = useTranslate()
-  const { accountAddress } = useFoxEth()
-  const { approve, allowance, getDepositGasData } = useFoxEthLiquidityPool(accountAddress)
+  const { lpAccountAddress } = useFoxEth()
+  const { approve, allowance, getDepositGasData } = useFoxEthLiquidityPool(lpAccountAddress)
   const opportunity = state?.opportunity
 
   const foxAsset = useAppSelector(state => selectAssetById(state, foxAssetId))

--- a/src/features/defi/providers/fox-eth-lp/components/FoxEthLpManager/Deposit/components/Confirm.tsx
+++ b/src/features/defi/providers/fox-eth-lp/components/FoxEthLpManager/Deposit/components/Confirm.tsx
@@ -36,9 +36,9 @@ const moduleLogger = logger.child({ namespace: ['FoxEthLpDeposit:Confirm'] })
 export const Confirm: React.FC<StepComponentProps> = ({ onNext }) => {
   const { state, dispatch } = useContext(DepositContext)
   const translate = useTranslate()
-  const { accountAddress, onOngoingTxIdChange } = useFoxEth()
+  const { lpAccountAddress, onOngoingLpTxIdChange } = useFoxEth()
   const { query } = useBrowserRouter<DefiQueryParams, DefiParams>()
-  const { addLiquidity } = useFoxEthLiquidityPool(accountAddress)
+  const { addLiquidity } = useFoxEthLiquidityPool(lpAccountAddress)
   const opportunity = useMemo(() => state?.opportunity, [state])
   const { chainId, assetReference } = query
 
@@ -73,7 +73,7 @@ export const Confirm: React.FC<StepComponentProps> = ({ onNext }) => {
       const txid = await addLiquidity(state.deposit.foxCryptoAmount, state.deposit.ethCryptoAmount)
       if (!txid) throw new Error('addLiquidity failed')
       dispatch({ type: FoxEthLpDepositActionType.SET_TXID, payload: txid })
-      onOngoingTxIdChange(txid)
+      onOngoingLpTxIdChange(txid)
       onNext(DefiStep.Status)
     } catch (error) {
       moduleLogger.error({ fn: 'handleDeposit', error }, 'Error adding liquidity')

--- a/src/features/defi/providers/fox-eth-lp/components/FoxEthLpManager/Deposit/components/Deposit.tsx
+++ b/src/features/defi/providers/fox-eth-lp/components/FoxEthLpManager/Deposit/components/Deposit.tsx
@@ -48,8 +48,9 @@ export const Deposit: React.FC<DepositProps> = ({
   const { query, history: browserHistory } = useBrowserRouter<DefiQueryParams, DefiParams>()
   const { chainId, assetReference } = query
   const opportunity = state?.opportunity
-  const { accountAddress } = useFoxEth()
-  const { allowance, getApproveGasData, getDepositGasData } = useFoxEthLiquidityPool(accountAddress)
+  const { lpAccountAddress } = useFoxEth()
+  const { allowance, getApproveGasData, getDepositGasData } =
+    useFoxEthLiquidityPool(lpAccountAddress)
 
   const assetNamespace = 'erc20'
   const assetId = toAssetId({ chainId, assetNamespace, assetReference })

--- a/src/features/defi/providers/fox-eth-lp/components/FoxEthLpManager/FoxEthLpManager.tsx
+++ b/src/features/defi/providers/fox-eth-lp/components/FoxEthLpManager/FoxEthLpManager.tsx
@@ -15,23 +15,23 @@ import { FoxEthLpWithdraw } from './Withdraw/FoxEthLpWithdraw'
 export const FoxEthLpManager = () => {
   const { query } = useBrowserRouter<DefiQueryParams, DefiParams>()
   const { modal } = query
-  const { accountId, setAccountId: handleAccountIdChange } = useFoxEth()
+  const { lpAccountId, setLpAccountId: handleLpAccountIdChange } = useFoxEth()
 
   return (
     <AnimatePresence exitBeforeEnter initial={false}>
       {modal === DefiAction.Overview && (
         <SlideTransition key={DefiAction.Overview}>
-          <FoxEthLpOverview accountId={accountId} onAccountIdChange={handleAccountIdChange} />
+          <FoxEthLpOverview accountId={lpAccountId} onAccountIdChange={handleLpAccountIdChange} />
         </SlideTransition>
       )}
       {modal === DefiAction.Deposit && (
         <SlideTransition key={DefiAction.Deposit}>
-          <FoxEthLpDeposit accountId={accountId} onAccountIdChange={handleAccountIdChange} />
+          <FoxEthLpDeposit accountId={lpAccountId} onAccountIdChange={handleLpAccountIdChange} />
         </SlideTransition>
       )}
       {modal === DefiAction.Withdraw && (
         <SlideTransition key={DefiAction.Withdraw}>
-          <FoxEthLpWithdraw accountId={accountId} onAccountIdChange={handleAccountIdChange} />
+          <FoxEthLpWithdraw accountId={lpAccountId} onAccountIdChange={handleLpAccountIdChange} />
         </SlideTransition>
       )}
     </AnimatePresence>

--- a/src/features/defi/providers/fox-eth-lp/components/FoxEthLpManager/Withdraw/components/Approve.tsx
+++ b/src/features/defi/providers/fox-eth-lp/components/FoxEthLpManager/Withdraw/components/Approve.tsx
@@ -29,8 +29,8 @@ const moduleLogger = logger.child({ namespace: ['FoxEthLpWithdraw:Approve'] })
 export const Approve: React.FC<FoxEthLpApproveProps> = ({ onNext }) => {
   const { state, dispatch } = useContext(WithdrawContext)
   const translate = useTranslate()
-  const { accountAddress } = useFoxEth()
-  const { approve, allowance, getWithdrawGasData } = useFoxEthLiquidityPool(accountAddress)
+  const { lpAccountAddress } = useFoxEth()
+  const { approve, allowance, getWithdrawGasData } = useFoxEthLiquidityPool(lpAccountAddress)
   const opportunity = state?.opportunity
 
   const foxAsset = useAppSelector(state => selectAssetById(state, foxAssetId))

--- a/src/features/defi/providers/fox-eth-lp/components/FoxEthLpManager/Withdraw/components/Confirm.tsx
+++ b/src/features/defi/providers/fox-eth-lp/components/FoxEthLpManager/Withdraw/components/Confirm.tsx
@@ -34,8 +34,8 @@ export const Confirm = ({ onNext }: StepComponentProps) => {
   const { state, dispatch } = useContext(WithdrawContext)
   const opportunity = state?.opportunity
   const translate = useTranslate()
-  const { accountAddress, onOngoingTxIdChange } = useFoxEth()
-  const { removeLiquidity } = useFoxEthLiquidityPool(accountAddress)
+  const { lpAccountAddress, onOngoingLpTxIdChange } = useFoxEth()
+  const { removeLiquidity } = useFoxEthLiquidityPool(lpAccountAddress)
 
   const ethAsset = useAppSelector(state => selectAssetById(state, ethAssetId))
   const ethMarketData = useAppSelector(state => selectMarketDataById(state, ethAssetId))
@@ -65,7 +65,7 @@ export const Confirm = ({ onNext }: StepComponentProps) => {
       )
       if (!txid) throw new Error(`Transaction failed`)
       dispatch({ type: FoxEthLpWithdrawActionType.SET_TXID, payload: txid })
-      onOngoingTxIdChange(txid)
+      onOngoingLpTxIdChange(txid)
       onNext(DefiStep.Status)
     } catch (error) {
       moduleLogger.error(error, 'FoxEthLpWithdraw:handleConfirm error')

--- a/src/features/defi/providers/fox-farming/components/FoxFarmingManager/Deposit/FoxFarmingDeposit.tsx
+++ b/src/features/defi/providers/fox-farming/components/FoxFarmingManager/Deposit/FoxFarmingDeposit.tsx
@@ -59,11 +59,11 @@ export const FoxFarmingDeposit: React.FC<FoxFarmingDepositProps> = ({
   const asset = useAppSelector(state => selectAssetById(state, assetId))
   const marketData = useAppSelector(state => selectMarketDataById(state, assetId))
 
-  const { accountAddress } = useFoxEth()
+  const { farmingAccountAddress } = useFoxEth()
 
   const filter = useMemo(
-    () => ({ accountAddress, contractAddress }),
-    [accountAddress, contractAddress],
+    () => ({ accountAddress: farmingAccountAddress, contractAddress }),
+    [farmingAccountAddress, contractAddress],
   )
 
   const opportunity = useAppSelector(state =>
@@ -75,16 +75,19 @@ export const FoxFarmingDeposit: React.FC<FoxFarmingDepositProps> = ({
   useEffect(() => {
     ;(async () => {
       try {
-        if (!(accountAddress && contractAddress && opportunity)) return
+        if (!(farmingAccountAddress && contractAddress && opportunity)) return
 
-        dispatch({ type: FoxFarmingDepositActionType.SET_USER_ADDRESS, payload: accountAddress })
+        dispatch({
+          type: FoxFarmingDepositActionType.SET_USER_ADDRESS,
+          payload: farmingAccountAddress,
+        })
         dispatch({ type: FoxFarmingDepositActionType.SET_OPPORTUNITY, payload: opportunity })
       } catch (error) {
         // TODO: handle client side errors
         moduleLogger.error(error, 'FoxFarmingDeposit error')
       }
     })()
-  }, [accountAddress, translate, toast, contractAddress, opportunity])
+  }, [farmingAccountAddress, translate, toast, contractAddress, opportunity])
 
   const handleBack = () => {
     history.push({

--- a/src/features/defi/providers/fox-farming/components/FoxFarmingManager/Deposit/components/Confirm.tsx
+++ b/src/features/defi/providers/fox-farming/components/FoxFarmingManager/Deposit/components/Confirm.tsx
@@ -48,7 +48,7 @@ export const Confirm: React.FC<StepComponentProps & { accountId: Nullable<Accoun
   const assetNamespace = 'erc20'
   const assetId = toAssetId({ chainId, assetNamespace, assetReference })
   const opportunity = state?.opportunity
-  const { onOngoingTxIdChange } = useFoxEth()
+  const { onOngoingFarmingTxIdChange } = useFoxEth()
 
   const asset = useAppSelector(state => selectAssetById(state, assetId))
   const feeAsset = useAppSelector(state => selectAssetById(state, ethAssetId))
@@ -77,7 +77,7 @@ export const Confirm: React.FC<StepComponentProps & { accountId: Nullable<Accoun
       const txid = await stake(state.deposit.cryptoAmount)
       if (!txid) throw new Error('Transaction failed')
       dispatch({ type: FoxFarmingDepositActionType.SET_TXID, payload: txid })
-      onOngoingTxIdChange(txid, contractAddress)
+      onOngoingFarmingTxIdChange(txid, contractAddress)
       onNext(DefiStep.Status)
     } catch (error) {
       moduleLogger.error(error, { fn: 'handleDeposit' }, 'handleDeposit error')

--- a/src/features/defi/providers/fox-farming/components/FoxFarmingManager/FoxFarmingManager.tsx
+++ b/src/features/defi/providers/fox-farming/components/FoxFarmingManager/FoxFarmingManager.tsx
@@ -16,28 +16,37 @@ import { FoxFarmingWithdraw } from './Withdraw/FoxFarmingWithdraw'
 export const FoxFarmingManager = () => {
   const { query } = useBrowserRouter<DefiQueryParams, DefiParams>()
   const { modal } = query
-  const { accountId, setAccountId: handleAccountIdChange } = useFoxEth()
+  const { farmingAccountId, setFarmingAccountId: handleFarmingAccountIdChange } = useFoxEth()
 
   return (
     <AnimatePresence exitBeforeEnter initial={false}>
       {modal === DefiAction.Overview && (
         <SlideTransition key={DefiAction.Overview}>
-          <FoxFarmingOverview accountId={accountId} onAccountIdChange={handleAccountIdChange} />
+          <FoxFarmingOverview
+            accountId={farmingAccountId}
+            onAccountIdChange={handleFarmingAccountIdChange}
+          />
         </SlideTransition>
       )}
       {modal === DefiAction.Deposit && (
         <SlideTransition key={DefiAction.Deposit}>
-          <FoxFarmingDeposit accountId={accountId} onAccountIdChange={handleAccountIdChange} />
+          <FoxFarmingDeposit
+            accountId={farmingAccountId}
+            onAccountIdChange={handleFarmingAccountIdChange}
+          />
         </SlideTransition>
       )}
       {modal === DefiAction.Withdraw && (
         <SlideTransition key={DefiAction.Withdraw}>
-          <FoxFarmingWithdraw accountId={accountId} onAccountIdChange={handleAccountIdChange} />
+          <FoxFarmingWithdraw
+            accountId={farmingAccountId}
+            onAccountIdChange={handleFarmingAccountIdChange}
+          />
         </SlideTransition>
       )}
       {modal === DefiAction.Claim && (
         <SlideTransition key={DefiAction.Claim}>
-          <Claim accountId={accountId} />
+          <Claim accountId={farmingAccountId} />
         </SlideTransition>
       )}
     </AnimatePresence>

--- a/src/features/defi/providers/fox-farming/components/FoxFarmingManager/Overview/Claim/ClaimConfirm.tsx
+++ b/src/features/defi/providers/fox-farming/components/FoxFarmingManager/Overview/Claim/ClaimConfirm.tsx
@@ -56,7 +56,7 @@ export const ClaimConfirm = ({
   const { claimRewards, getClaimGasData, foxFarmingContract } = useFoxFarming(contractAddress)
   const translate = useTranslate()
   const history = useHistory()
-  const { onOngoingTxIdChange } = useFoxEth()
+  const { onOngoingFarmingTxIdChange } = useFoxEth()
 
   const accountAddress = useMemo(
     () => (accountId ? fromAccountId(accountId).account : null),
@@ -81,7 +81,7 @@ export const ClaimConfirm = ({
     try {
       const txid = await claimRewards()
       if (!txid) throw new Error(`Transaction failed`)
-      onOngoingTxIdChange(txid, contractAddress)
+      onOngoingFarmingTxIdChange(txid, contractAddress)
       history.push('/status', {
         txid,
         assetId,

--- a/src/features/defi/providers/fox-farming/components/FoxFarmingManager/Overview/Claim/ClaimRoutes.tsx
+++ b/src/features/defi/providers/fox-farming/components/FoxFarmingManager/Overview/Claim/ClaimRoutes.tsx
@@ -37,11 +37,11 @@ export const ClaimRoutes = ({ accountId, onBack }: ClaimRouteProps) => {
   const { query } = useBrowserRouter<DefiQueryParams, DefiParams>()
   const { contractAddress, chainId } = query
 
-  const { accountAddress } = useFoxEth()
+  const { farmingAccountAddress } = useFoxEth()
 
   const filter = useMemo(
-    () => ({ accountAddress, contractAddress }),
-    [accountAddress, contractAddress],
+    () => ({ accountAddress: farmingAccountAddress, contractAddress }),
+    [farmingAccountAddress, contractAddress],
   )
   const opportunity = useAppSelector(state =>
     selectFoxFarmingOpportunityByContractAddress(state, filter),

--- a/src/features/defi/providers/fox-farming/components/FoxFarmingManager/Withdraw/FoxFarmingWithdraw.tsx
+++ b/src/features/defi/providers/fox-farming/components/FoxFarmingManager/Withdraw/FoxFarmingWithdraw.tsx
@@ -51,11 +51,11 @@ export const FoxFarmingWithdraw: React.FC<FoxFarmingWithdrawProps> = ({
   const { query, history, location } = useBrowserRouter<DefiQueryParams, DefiParams>()
   const { contractAddress } = query
 
-  const { accountAddress } = useFoxEth()
+  const { farmingAccountAddress } = useFoxEth()
 
   const filter = useMemo(
-    () => ({ accountAddress, contractAddress }),
-    [accountAddress, contractAddress],
+    () => ({ accountAddress: farmingAccountAddress ?? '', contractAddress }),
+    [farmingAccountAddress, contractAddress],
   )
 
   const opportunity = useAppSelector(state =>
@@ -67,16 +67,19 @@ export const FoxFarmingWithdraw: React.FC<FoxFarmingWithdrawProps> = ({
   useEffect(() => {
     ;(async () => {
       try {
-        if (!(accountAddress && contractAddress && opportunity)) return
+        if (!(farmingAccountAddress && contractAddress && opportunity)) return
 
-        dispatch({ type: FoxFarmingWithdrawActionType.SET_USER_ADDRESS, payload: accountAddress })
+        dispatch({
+          type: FoxFarmingWithdrawActionType.SET_USER_ADDRESS,
+          payload: farmingAccountAddress,
+        })
         dispatch({ type: FoxFarmingWithdrawActionType.SET_OPPORTUNITY, payload: opportunity })
       } catch (error) {
         // TODO: handle client side errors
         moduleLogger.error(error, 'FoxFarmingWithdraw error')
       }
     })()
-  }, [accountAddress, translate, contractAddress, opportunity])
+  }, [farmingAccountAddress, translate, contractAddress, opportunity])
 
   const handleBack = () => {
     history.push({

--- a/src/features/defi/providers/fox-farming/components/FoxFarmingManager/Withdraw/components/Confirm.tsx
+++ b/src/features/defi/providers/fox-farming/components/FoxFarmingManager/Withdraw/components/Confirm.tsx
@@ -43,7 +43,7 @@ export const Confirm: React.FC<ConfirmProps> = ({ onNext }) => {
   const { chainId, contractAddress, assetReference, rewardId } = query
   const opportunity = state?.opportunity
   const { unstake } = useFoxFarming(contractAddress)
-  const { onOngoingTxIdChange } = useFoxEth()
+  const { onOngoingFarmingTxIdChange } = useFoxEth()
   const assetNamespace = 'erc20'
   // Asset info
   const underlyingAssetId = toAssetId({
@@ -76,7 +76,7 @@ export const Confirm: React.FC<ConfirmProps> = ({ onNext }) => {
       const txid = await unstake(state.withdraw.lpAmount, state.withdraw.isExiting)
       if (!txid) throw new Error(`Transaction failed`)
       dispatch({ type: FoxFarmingWithdrawActionType.SET_TXID, payload: txid })
-      onOngoingTxIdChange(txid, contractAddress)
+      onOngoingFarmingTxIdChange(txid, contractAddress)
       onNext(DefiStep.Status)
       dispatch({ type: FoxFarmingWithdrawActionType.SET_LOADING, payload: false })
     } catch (error) {

--- a/src/features/defi/providers/fox-farming/components/FoxFarmingManager/Withdraw/components/ExpiredWithdraw.tsx
+++ b/src/features/defi/providers/fox-farming/components/FoxFarmingManager/Withdraw/components/ExpiredWithdraw.tsx
@@ -34,7 +34,7 @@ export const ExpiredWithdraw: React.FC<StepComponentProps> = ({ onNext }) => {
   const { contractAddress } = query
   const opportunity = state?.opportunity
   const { getUnstakeGasData, allowance, getApproveGasData } = useFoxFarming(contractAddress)
-  const { setAccountId: handleAccountIdChange } = useFoxEth()
+  const { setFarmingAccountId: handleFarmingAccountIdChange } = useFoxEth()
 
   const methods = useForm<WithdrawValues>({ mode: 'onChange' })
 
@@ -135,7 +135,7 @@ export const ExpiredWithdraw: React.FC<StepComponentProps> = ({ onNext }) => {
           volume: '0',
           changePercent24Hr: 0,
         }}
-        onAccountIdChange={handleAccountIdChange}
+        onAccountIdChange={handleFarmingAccountIdChange}
         onCancel={handleCancel}
         onContinue={handleContinue}
         isLoading={state.loading}

--- a/src/features/defi/providers/fox-farming/hooks/useFoxFarming.ts
+++ b/src/features/defi/providers/fox-farming/hooks/useFoxFarming.ts
@@ -43,20 +43,20 @@ type UseFoxFarmingOptions = {
  * @param contractAddress farming contract address, since there could be multiple contracts
  */
 export const useFoxFarming = (contractAddress: string, { skip }: UseFoxFarmingOptions = {}) => {
-  const { accountAddress } = useFoxEth()
+  const { farmingAccountAddress } = useFoxEth()
   const { supportedEvmChainIds } = useEvm()
   const ethAsset = useAppSelector(state => selectAssetById(state, ethAssetId))
   const lpAsset = useAppSelector(state => selectAssetById(state, foxEthLpAssetId))
 
   const accountId = useMemo(
     () =>
-      accountAddress
+      farmingAccountAddress
         ? toAccountId({
             chainId: ethChainId,
-            account: accountAddress,
+            account: farmingAccountAddress,
           })
         : '',
-    [accountAddress],
+    [farmingAccountAddress],
   )
 
   const filter = useMemo(() => ({ accountId }), [accountId])
@@ -100,7 +100,13 @@ export const useFoxFarming = (contractAddress: string, { skip }: UseFoxFarmingOp
   const stake = useCallback(
     async (lpAmount: string) => {
       try {
-        if (skip || !accountAddress || !isNumber(accountNumber) || !foxFarmingContract || !wallet)
+        if (
+          skip ||
+          !farmingAccountAddress ||
+          !isNumber(accountNumber) ||
+          !foxFarmingContract ||
+          !wallet
+        )
           return
         if (!adapter)
           throw new Error(`addLiquidityEth: no adapter available for ${ethAsset.chainId}`)
@@ -113,7 +119,7 @@ export const useFoxFarming = (contractAddress: string, { skip }: UseFoxFarmingOp
           value: '0',
           chainSpecific: {
             contractData: data,
-            from: accountAddress,
+            from: farmingAccountAddress,
           },
         })
         const result = await (async () => {
@@ -179,7 +185,7 @@ export const useFoxFarming = (contractAddress: string, { skip }: UseFoxFarmingOp
     },
     [
       adapter,
-      accountAddress,
+      farmingAccountAddress,
       accountNumber,
       contractAddress,
       ethAsset.chainId,
@@ -194,7 +200,13 @@ export const useFoxFarming = (contractAddress: string, { skip }: UseFoxFarmingOp
   const unstake = useCallback(
     async (lpAmount: string, isExiting: boolean) => {
       try {
-        if (skip || !accountAddress || !isNumber(accountNumber) || !foxFarmingContract || !wallet)
+        if (
+          skip ||
+          !farmingAccountAddress ||
+          !isNumber(accountNumber) ||
+          !foxFarmingContract ||
+          !wallet
+        )
           return
         const chainAdapterManager = getChainAdapterManager()
         const adapter = chainAdapterManager.get(ethAsset.chainId) as ChainAdapter<KnownChainIds>
@@ -211,7 +223,7 @@ export const useFoxFarming = (contractAddress: string, { skip }: UseFoxFarmingOp
           value: '0',
           chainSpecific: {
             contractData: data,
-            from: accountAddress,
+            from: farmingAccountAddress,
           },
         })
         const result = await (async () => {
@@ -276,7 +288,7 @@ export const useFoxFarming = (contractAddress: string, { skip }: UseFoxFarmingOp
       }
     },
     [
-      accountAddress,
+      farmingAccountAddress,
       accountNumber,
       contractAddress,
       ethAsset.chainId,
@@ -289,13 +301,13 @@ export const useFoxFarming = (contractAddress: string, { skip }: UseFoxFarmingOp
   )
 
   const allowance = useCallback(async () => {
-    if (skip || !accountAddress || !uniV2LPContract) return
-    const _allowance = await uniV2LPContract.allowance(accountAddress, contractAddress)
+    if (skip || !farmingAccountAddress || !uniV2LPContract) return
+    const _allowance = await uniV2LPContract.allowance(farmingAccountAddress, contractAddress)
     return _allowance.toString()
-  }, [accountAddress, contractAddress, uniV2LPContract, skip])
+  }, [farmingAccountAddress, contractAddress, uniV2LPContract, skip])
 
   const getApproveGasData = useCallback(async () => {
-    if (adapter && accountAddress && uniV2LPContract) {
+    if (adapter && farmingAccountAddress && uniV2LPContract) {
       const data = uniV2LPContract.interface.encodeFunctionData('approve', [
         contractAddress,
         MAX_ALLOWANCE,
@@ -305,17 +317,17 @@ export const useFoxFarming = (contractAddress: string, { skip }: UseFoxFarmingOp
         value: '0',
         chainSpecific: {
           contractData: data,
-          from: accountAddress,
+          from: farmingAccountAddress,
           contractAddress: uniV2LPContract.address,
         },
       })
       return fees
     }
-  }, [adapter, accountAddress, contractAddress, uniV2LPContract])
+  }, [adapter, farmingAccountAddress, contractAddress, uniV2LPContract])
 
   const getStakeGasData = useCallback(
     async (lpAmount: string) => {
-      if (skip || !accountAddress || !uniswapRouterContract) return
+      if (skip || !farmingAccountAddress || !uniswapRouterContract) return
       const data = foxFarmingContract!.interface.encodeFunctionData('stake', [
         bnOrZero(lpAmount).times(bnOrZero(10).exponentiatedBy(lpAsset.precision)).toFixed(0),
       ])
@@ -324,14 +336,14 @@ export const useFoxFarming = (contractAddress: string, { skip }: UseFoxFarmingOp
         value: '0',
         chainSpecific: {
           contractData: data,
-          from: accountAddress,
+          from: farmingAccountAddress,
         },
       })
       return estimatedFees
     },
     [
       adapter,
-      accountAddress,
+      farmingAccountAddress,
       contractAddress,
       foxFarmingContract,
       lpAsset.precision,
@@ -342,7 +354,7 @@ export const useFoxFarming = (contractAddress: string, { skip }: UseFoxFarmingOp
 
   const getUnstakeGasData = useCallback(
     async (lpAmount: string, isExiting: boolean) => {
-      if (skip || !accountAddress || !uniswapRouterContract) return
+      if (skip || !farmingAccountAddress || !uniswapRouterContract) return
       const data = isExiting
         ? foxFarmingContract!.interface.encodeFunctionData('exit')
         : foxFarmingContract!.interface.encodeFunctionData('withdraw', [
@@ -353,14 +365,14 @@ export const useFoxFarming = (contractAddress: string, { skip }: UseFoxFarmingOp
         value: '0',
         chainSpecific: {
           contractData: data,
-          from: accountAddress,
+          from: farmingAccountAddress,
         },
       })
       return estimatedFees
     },
     [
       adapter,
-      accountAddress,
+      farmingAccountAddress,
       contractAddress,
       foxFarmingContract,
       lpAsset.precision,
@@ -438,7 +450,13 @@ export const useFoxFarming = (contractAddress: string, { skip }: UseFoxFarmingOp
   )
 
   const claimRewards = useCallback(async () => {
-    if (skip || !wallet || !isNumber(accountNumber) || !foxFarmingContract || !accountAddress)
+    if (
+      skip ||
+      !wallet ||
+      !isNumber(accountNumber) ||
+      !foxFarmingContract ||
+      !farmingAccountAddress
+    )
       return
     const data = foxFarmingContract.interface.encodeFunctionData('getReward')
     const estimatedFees = await (adapter as unknown as EvmBaseAdapter<EvmChainId>).getFeeData({
@@ -446,7 +464,7 @@ export const useFoxFarming = (contractAddress: string, { skip }: UseFoxFarmingOp
       value: '0',
       chainSpecific: {
         contractData: data,
-        from: accountAddress,
+        from: farmingAccountAddress,
       },
     })
     const fees = estimatedFees.average as FeeData<EvmChainId>
@@ -490,7 +508,15 @@ export const useFoxFarming = (contractAddress: string, { skip }: UseFoxFarmingOp
       }
     })()
     return broadcastTXID
-  }, [accountNumber, adapter, accountAddress, contractAddress, foxFarmingContract, skip, wallet])
+  }, [
+    accountNumber,
+    adapter,
+    farmingAccountAddress,
+    contractAddress,
+    foxFarmingContract,
+    skip,
+    wallet,
+  ])
 
   return {
     allowance,


### PR DESCRIPTION
## Description

Currently, we use a single `accountId` in the FoxEth provider, both for farming and LP.

This desyncs them, so that selecting an account in one doesn't keep it selected for the other.

## Notice

<!-- Before submitting a pull request, please make sure you have answered the following: -->

- [x] Have you followed the guidelines in our [Contributing]('https://github.com/shapeshift/web/blob/develop/CONTRIBUTING.md) guide?
- [x] Have you checked to ensure there aren't other open [Pull Requests](https://github.com/shapeshift/web/pulls) for the same update/change?

## Pull Request Type

- [ ] :bug: Bug fix (Non-breaking Change: Fixes an issue)
- [ ] :hammer_and_wrench: Chore (Non-breaking Change: Doc updates, pkg upgrades, typos, etc..)
- [x] :nail_care: New Feature (Breaking/Non-breaking Change)

## Issue (if applicable)

<!-----------------------------------------------------------------------------
If applicable, please link to the github issue and put `closes #XXXX` in your comment to auto-close the issue that your PR fixes.
------------------------------------------------------------------------------>

- relates to the closed https://github.com/shapeshift/web/issues/2447

## Risk

<!-----------------------------------------------------------------------------
Outline the scope of your changes and the risk associated with them. You must use your discretion as an engineer to determine the potential impact of your changes.

E.g. an upgrade to `hdwallet` or core state management would be considered higher risk, and might require a full regression test. UI or isolated view changes, or something behind a feature flag may have near zero risk. Small bug fixes might require testing isolated to the specific fix.
------------------------------------------------------------------------------>

The accountId logic should be the same as before, just now split so this is relatively low risk

## Testing

<!-----------------------------------------------------------------------------
We treat every PR to be merged with the same scrutiny as if we were merging directly to production.

Your PR will not be merged if you do not complete the sections below for our engineering and operations teams to test.
------------------------------------------------------------------------------>

- AccountId should be propagated everywhere on the LP/farming flow the same as before
- It should now be unsynced, meaning that selecting account 1 on the farming modal doesn't keep it as the selected one when opening the LP modal
- The highest balance autoselect should still take precedence i.e, when opening a FOX/ETH modal from DeFi cards/rows, the highest balance should be selected

### Engineering

<!-----------------------------------------------------------------------------
Include sufficient information here for an engineer to test your PR. This may include how to test locally, in a built environment, changes to infrastructure etc.
------------------------------------------------------------------------------>

- Split logic looks sane

### Operations

<!-----------------------------------------------------------------------------
If your changes have a user-facing impact, describe how a non-technical QA team can functionally test your changes in a preview environment.

If they are not user-facing please describe how to test for any regressions that may occur.
------------------------------------------------------------------------------>

☝🏽 

## Screenshots (if applicable)
