### PR TITLE
fix: only show available thorchain pools

### DIFF
--- a/package.json
+++ b/package.json
@@ -107,7 +107,7 @@
     "@shapeshiftoss/investor-yearn": "^6.1.5",
     "@shapeshiftoss/logger": "^1.1.3",
     "@shapeshiftoss/market-service": "^7.1.1",
-    "@shapeshiftoss/swapper": "^12.0.3",
+    "@shapeshiftoss/swapper": "^12.1.0",
     "@shapeshiftoss/types": "^8.3.2",
     "@shapeshiftoss/unchained-client": "^10.2.0",
     "@uniswap/sdk": "^3.0.3",

--- a/yarn.lock
+++ b/yarn.lock
@@ -4340,10 +4340,10 @@
     google-protobuf "^3.17.0"
     long "^4.0.0"
 
-"@shapeshiftoss/swapper@^12.0.3":
-  version "12.0.3"
-  resolved "https://registry.yarnpkg.com/@shapeshiftoss/swapper/-/swapper-12.0.3.tgz#6e84dab72972d367e26040ed5a5812a6a62f23f4"
-  integrity sha512-Cv6MyXb1ktFL3QsGuiOAyjzfyCve0R8VSoK7vZ5BaVQiP4qk5rz9F7vfL5BufiR7jx/ZYxccCUSNkc0vCWqIVw==
+"@shapeshiftoss/swapper@^12.1.0":
+  version "12.1.0"
+  resolved "https://registry.yarnpkg.com/@shapeshiftoss/swapper/-/swapper-12.1.0.tgz#dff60c857dbb7516d65f77a384e92e9a7d6bfad1"
+  integrity sha512-byj1SztyTUaa+q/vsxpnmBuT5tP83FBCg6YVphFUKxnLc7buSTakAoE9NIUsLOUcDD3EKM/0sD/HkyssXqY6Ug==
   dependencies:
     axios "^0.26.1"
     bignumber.js "^9.0.2"


### PR DESCRIPTION
## Description

No longer show thorchain pools that are not in `Available` state

## Notice

<!-- Before submitting a pull request, please make sure you have answered the following: -->

- [x] Have you followed the guidelines in our [Contributing]('https://github.com/shapeshift/web/blob/develop/CONTRIBUTING.md) guide?
- [x] Have you checked to ensure there aren't other open [Pull Requests](https://github.com/shapeshift/web/pulls) for the same update/change?

## Pull Request Type

- [x] :bug: Bug fix (Non-breaking Change: Fixes an issue)
- [ ] :hammer_and_wrench: Chore (Non-breaking Change: Doc updates, pkg upgrades, typos, etc..)
- [ ] :nail_care: New Feature (Breaking/Non-breaking Change)

## Issue (if applicable)

<!-----------------------------------------------------------------------------
If applicable, please link to the github issue and put `closes #XXXX` in your comment to auto-close the issue that your PR fixes.
------------------------------------------------------------------------------>

closes #

## Risk

Low

## Testing

- Sushi should not show as an available thorchain pool anymore (along with any others that aren't `Available` as described here: https://daemon.thorchain.shapeshift.com/lcd/thorchain/pools)

### Engineering

:point_up: 

### Operations

:point_up: 

## Screenshots (if applicable)
Left is after, Right is before
![image](https://user-images.githubusercontent.com/35275952/196768855-8d25771f-ad5b-4a11-8496-d0ed064c76b8.png)