### PR TITLE
chore: selector performance via cached selectors

### DIFF
--- a/src/state/slices/assetsSlice/selectors.ts
+++ b/src/state/slices/assetsSlice/selectors.ts
@@ -120,7 +120,7 @@ export const selectFeeAssetByChainId = createSelector(
   },
 )
 
-export const selectFeeAssetById = createSelector(
+export const selectFeeAssetById = createCachedSelector(
   selectAssets,
   (_state: ReduxState, assetId: AssetId) => assetId,
   (assetsById, assetId): Asset => {
@@ -133,4 +133,4 @@ export const selectFeeAssetById = createSelector(
     })
     return assetsById[feeAssetId]
   },
-)
+)((_s: ReduxState, assetId: AssetId) => assetId ?? 'assetId')

--- a/src/state/slices/foxEthSlice/selectors.ts
+++ b/src/state/slices/foxEthSlice/selectors.ts
@@ -81,18 +81,18 @@ const selectEthAccountIdsByAssetId = createCachedSelector(
   },
 )((_accountIds, paramFilter) => paramFilter?.assetId ?? 'undefined')
 
-export const selectFoxEthLpAccountOpportunitiesByMaybeAccountAddress =
-  createDeepEqualOutputSelector(
-    (state: ReduxState) => state.foxEth,
-    selectAccountAddressParamFromFilterOptional,
-    selectEthAccountIdsByAssetId,
-    (foxEthState, accountAddress, ethAccountIds) => {
-      const ethAccountAddresses = ethAccountIds.map(accountId => fromAccountId(accountId).account)
-      return (accountAddress ? [accountAddress] : ethAccountAddresses).map(
-        accountAddress => foxEthState[accountAddress]?.lpOpportunity,
-      )
-    },
-  )
+export const selectFoxEthLpAccountOpportunitiesByMaybeAccountAddress = createCachedSelector(
+  // TODO(0xdef1cafe): this causes 200+ renders, we can't react on the entire slice changing!
+  (state: ReduxState) => state.foxEth,
+  selectAccountAddressParamFromFilterOptional,
+  selectEthAccountIdsByAssetId,
+  (foxEthState, accountAddress, ethAccountIds) => {
+    const ethAccountAddresses = ethAccountIds.map(accountId => fromAccountId(accountId).account)
+    return (accountAddress ? [accountAddress] : ethAccountAddresses).map(
+      accountAddress => foxEthState[accountAddress]?.lpOpportunity,
+    )
+  },
+)((_s: ReduxState, filter) => filter?.accountAddress ?? 'accountAddress')
 
 export const selectFoxEthLpOpportunityByAccountAddress = createSelector(
   selectFoxEthLpAccountOpportunitiesByMaybeAccountAddress,
@@ -138,6 +138,7 @@ export const selectFoxEthLpAccountsOpportunitiesAggregated = createDeepEqualOutp
 )
 
 export const selectFoxFarmingOpportunitiesByMaybeAccountAddress = createDeepEqualOutputSelector(
+  // TODO(0xdef1cafe): this causes 200+ renders, we can't react on the entire slice changing!
   (state: ReduxState) => state.foxEth,
   selectAccountAddressParamFromFilterOptional,
   selectEthAccountIdsByAssetId,
@@ -276,6 +277,7 @@ const selectPortfolioAccounts = (state: ReduxState) => state.portfolio.accounts.
 export const selectFoxEthLpFiatBalance = createSelector(
   selectMarketData,
   selectPortfolioAccounts,
+  // TODO(0xdef1cafe): this causes 200+ renders, we can't react on the entire slice changing!
   (state: ReduxState) => state.foxEth,
   (marketData, portfolioAccounts, foxEthState) => {
     // Cannot use selectAccountIdsByAssetId because of a. circular deps and b. it applying balance threshold

--- a/src/state/slices/marketDataSlice/selectors.ts
+++ b/src/state/slices/marketDataSlice/selectors.ts
@@ -55,7 +55,7 @@ export const selectMarketDataById = createCachedSelector(
   (cryptoMarketData, assetId): MarketData => {
     return cryptoMarketData[assetId] ?? defaultMarketData
   },
-)((_state: ReduxState, assetId: AssetId | undefined): AssetId => assetId ?? 'undefined')
+)((_state: ReduxState, assetId?: AssetId): AssetId => assetId ?? 'assetId')
 
 // assets we have loaded market data for
 export const selectCryptoMarketDataIds = (state: ReduxState) => state.marketData.crypto.ids

--- a/src/state/slices/portfolioSlice/selectors.ts
+++ b/src/state/slices/portfolioSlice/selectors.ts
@@ -81,14 +81,21 @@ type OptionalParamFilter = {
 type ParamFilterKey = keyof ParamFilter
 type OptionalParamFilterKey = keyof OptionalParamFilter
 
-const selectParamFromFilter =
-  <T extends ParamFilterKey>(param: T) =>
-  (_state: ReduxState, filter: Pick<ParamFilter, T>): ParamFilter[T] | '' =>
-    filter?.[param] ?? ''
-const selectParamFromFilterOptional =
-  <T extends OptionalParamFilterKey>(param: T) =>
-  (_state: ReduxState, filter: Pick<OptionalParamFilter, T>): OptionalParamFilter[T] | '' =>
-    filter?.[param] ?? ''
+const selectParamFromFilter = <T extends ParamFilterKey>(param: T) =>
+  createCachedSelector(
+    (_state: ReduxState, filter: Pick<ParamFilter, T>): ParamFilter[T] | '' =>
+      filter?.[param] ?? '',
+    param => param,
+  )((_state: ReduxState, filter: Pick<ParamFilter, T>) => filter?.[param] ?? param)
+const selectParamFromFilterOptional = <T extends OptionalParamFilterKey>(param: T) =>
+  createCachedSelector(
+    (_state: ReduxState, filter: Pick<OptionalParamFilter, T>): OptionalParamFilter[T] | '' =>
+      filter?.[param] ?? '',
+    param => param,
+  )(
+    (_state: ReduxState, filter: Pick<OptionalParamFilter, T>) =>
+      `${param}-${filter?.[param]}` ?? param,
+  )
 
 // We should prob change this once we add more chains
 const FEE_ASSET_IDS = [
@@ -121,33 +128,36 @@ export const selectPortfolioAssetIds = createDeepEqualOutputSelector(
   (state: ReduxState): PortfolioAssetBalances['ids'] => state.portfolio.assetBalances.ids,
   ids => ids,
 )
-export const selectPortfolioAssetBalances = (state: ReduxState): PortfolioAssetBalances['byId'] =>
-  state.portfolio.assetBalances.byId
-export const selectPortfolioAccountBalances = (
-  state: ReduxState,
-): PortfolioAccountBalances['byId'] => state.portfolio.accountBalances.byId
+export const selectPortfolioAssetBalances = createDeepEqualOutputSelector(
+  (state: ReduxState): PortfolioAssetBalances['byId'] => state.portfolio.assetBalances.byId,
+  assetBalances => assetBalances,
+)
+export const selectPortfolioAccountBalances = createDeepEqualOutputSelector(
+  (state: ReduxState): PortfolioAccountBalances['byId'] => state.portfolio.accountBalances.byId,
+  accountBalances => accountBalances,
+)
 
 export const selectPortfolioAccountMetadata = createDeepEqualOutputSelector(
   (state: ReduxState): AccountMetadataById => state.portfolio.accountSpecifiers.accountMetadataById,
   accountMetadata => accountMetadata,
 )
 
-export const selectPortfolioAccountMetadataByAccountId = createSelector(
+export const selectPortfolioAccountMetadataByAccountId = createCachedSelector(
   selectPortfolioAccountMetadata,
   selectAccountIdParamFromFilter,
   (accountMetadata, accountId): AccountMetadata => accountMetadata[accountId],
-)
+)((_s: ReduxState, filter) => filter?.accountId ?? 'accountId')
 
-export const selectBIP44ParamsByAccountId = createSelector(
+export const selectBIP44ParamsByAccountId = createCachedSelector(
   selectPortfolioAccountMetadata,
   selectAccountIdParamFromFilter,
   (accountMetadata, accountId): BIP44Params | undefined => accountMetadata[accountId]?.bip44Params,
-)
+)((_s: ReduxState, filter) => filter?.accountId ?? 'accountId')
 
-export const selectAccountNumberByAccountId = createSelector(
+export const selectAccountNumberByAccountId = createCachedSelector(
   selectBIP44ParamsByAccountId,
   (bip44Params): number | undefined => bip44Params?.accountNumber,
-)
+)((_s: ReduxState, filter) => filter?.accountId ?? 'accountId')
 
 type PortfolioLoadingStatus = 'loading' | 'success' | 'error'
 
@@ -179,7 +189,7 @@ export const selectPortfolioLoadingStatus = createSelector(
   },
 )
 
-export const selectPortfolioFiatBalances = createSelector(
+export const selectPortfolioFiatBalances = createDeepEqualOutputSelector(
   selectAssets,
   selectMarketData,
   selectPortfolioAssetBalances,
@@ -199,7 +209,7 @@ export const selectPortfolioFiatBalances = createSelector(
     ),
 )
 
-export const selectPortfolioFiatAccountBalances = createSelector(
+export const selectPortfolioFiatAccountBalances = createDeepEqualOutputSelector(
   selectAssets,
   selectPortfolioAccountBalances,
   selectMarketData,
@@ -347,13 +357,13 @@ export const selectPortfolioTotalFiatBalanceWithStakingData = createSelector(
   },
 )
 
-export const selectPortfolioFiatBalanceByAssetId = createSelector(
+export const selectPortfolioFiatBalanceByAssetId = createCachedSelector(
   selectPortfolioFiatBalances,
   selectAssetIdParamFromFilter,
   (portfolioFiatBalances, assetId) => portfolioFiatBalances[assetId],
-)
+)((_s: ReduxState, filter) => filter?.assetId ?? 'assetId')
 
-export const selectPortfolioFiatBalanceByFilter = createSelector(
+export const selectPortfolioFiatBalanceByFilter = createCachedSelector(
   selectPortfolioFiatBalances,
   selectPortfolioFiatAccountBalances,
   selectAssetIdParamFromFilter,
@@ -373,15 +383,15 @@ export const selectPortfolioFiatBalanceByFilter = createSelector(
     }
     return '0'
   },
-)
+)((_s: ReduxState, filter) => `${filter?.accountId}-${filter?.assetId}` ?? 'accountId-assetId')
 
-export const selectPortfolioCryptoBalanceByAssetId = createSelector(
+export const selectPortfolioCryptoBalanceByAssetId = createCachedSelector(
   selectPortfolioAssetBalances,
   selectAssetIdParamFromFilter,
   (byId, assetId): string => byId[assetId] ?? 0,
-)
+)((_s: ReduxState, filter) => filter?.assetId ?? 'assetId')
 
-export const selectPortfolioCryptoHumanBalanceByFilter = createSelector(
+export const selectPortfolioCryptoHumanBalanceByFilter = createCachedSelector(
   selectAssets,
   selectPortfolioAccountBalances,
   selectPortfolioAssetBalances,
@@ -397,7 +407,7 @@ export const selectPortfolioCryptoHumanBalanceByFilter = createSelector(
 
     return fromBaseUnit(bnOrZero(assetBalances[assetId]), assets?.[assetId]?.precision ?? 0)
   },
-)
+)((_s: ReduxState, filter) => `${filter?.accountId}-${filter?.assetId}` ?? 'accountId-assetId')
 
 export const selectPortfolioAccountIds = createDeepEqualOutputSelector(
   (state: ReduxState): AccountId[] => state.portfolio.accounts.ids,
@@ -418,12 +428,12 @@ export const selectPortfolioAccountIdsByAssetId = createCachedSelector(
     const { chainId } = fromAssetId(assetId)
     return accountIds.filter(accountId => fromAccountId(accountId).chainId === chainId)
   },
-)((_accountIds, paramFilter) => paramFilter?.assetId ?? 'undefined')
+)((_accountIds, paramFilter) => paramFilter?.assetId ?? 'assetId')
 
 // If an AccountId is passed, selects data by AccountId
 // Else, aggregates the data for all AccountIds for said asset
 // Always returns an array, either of one or many - needs to be unwrapped
-export const selectStakingDataByFilter = createSelector(
+export const selectStakingDataByFilter = createCachedSelector(
   selectPortfolioAccounts,
   selectAccountIdParamFromFilterOptional,
   selectPortfolioAccountIdsByAssetId,
@@ -432,7 +442,7 @@ export const selectStakingDataByFilter = createSelector(
       accountId => portfolioAccounts?.[accountId]?.stakingDataByValidatorId || null,
     )
   },
-)
+)((_s: ReduxState, filter) => `${filter?.accountId}-${filter?.assetId}` ?? 'accountId-assetId')
 
 /**
  * this selector is very specific; we need to consider
@@ -507,7 +517,7 @@ export const selectBalanceChartCryptoBalancesByAccountIdAboveThreshold =
     },
   )
 
-export const selectPortfolioCryptoBalanceByFilter = createSelector(
+export const selectPortfolioCryptoBalanceByFilter = createCachedSelector(
   selectPortfolioAccountBalances,
   selectPortfolioAssetBalances,
   selectAccountIdParamFromFilterOptional,
@@ -518,17 +528,17 @@ export const selectPortfolioCryptoBalanceByFilter = createSelector(
     }
     return assetBalances[assetId] ?? '0'
   },
-)
+)((_s: ReduxState, filter) => `${filter?.accountId}-${filter?.assetId}` ?? 'accountId-assetId')
 
-export const selectPortfolioCryptoHumanBalanceByAssetId = createSelector(
+export const selectPortfolioCryptoHumanBalanceByAssetId = createCachedSelector(
   selectAssets,
   selectPortfolioAssetBalances,
   selectAssetIdParamFromFilter,
   (assets, balances, assetId): string =>
     fromBaseUnit(bnOrZero(balances[assetId]), assets[assetId]?.precision ?? 0),
-)
+)((_s: ReduxState, filter) => filter?.assetId ?? 'assetId')
 
-export const selectPortfolioMixedHumanBalancesBySymbol = createSelector(
+export const selectPortfolioMixedHumanBalancesBySymbol = createDeepEqualOutputSelector(
   selectAssets,
   selectMarketData,
   selectPortfolioAssetBalances,
@@ -552,7 +562,7 @@ export const selectPortfolioLoading = createSelector(
   (ids): boolean => !Boolean(ids.length),
 )
 
-export const selectPortfolioAssetAccountBalancesSortedFiat = createSelector(
+export const selectPortfolioAssetAccountBalancesSortedFiat = createDeepEqualOutputSelector(
   selectPortfolioFiatAccountBalances,
   selectBalanceThreshold,
   (portfolioFiatAccountBalances, balanceThreshold): PortfolioAccountBalancesById => {
@@ -574,7 +584,7 @@ export const selectPortfolioAssetAccountBalancesSortedFiat = createSelector(
   },
 )
 
-export const selectHighestFiatBalanceAccountByAssetId = createSelector(
+export const selectHighestFiatBalanceAccountByAssetId = createCachedSelector(
   selectPortfolioAssetAccountBalancesSortedFiat,
   selectAssetIdParamFromFilter,
   (accountSpecifierAssetValues, assetId): AccountId | undefined => {
@@ -587,9 +597,9 @@ export const selectHighestFiatBalanceAccountByAssetId = createSelector(
     )
     return highestBalanceAccountToAmount?.[0]
   },
-)
+)((_s: ReduxState, filter) => filter?.assetId ?? 'assetId')
 
-export const selectPortfolioAllocationPercentByFilter = createSelector(
+export const selectPortfolioAllocationPercentByFilter = createCachedSelector(
   selectPortfolioFiatBalances,
   selectPortfolioFiatAccountBalances,
   selectAccountIdParamFromFilter,
@@ -609,7 +619,7 @@ export const selectPortfolioAllocationPercentByFilter = createSelector(
 
     return balanceAllocationById[accountId]
   },
-)
+)((_s: ReduxState, filter) => `${filter?.accountId}-${filter?.assetId}` ?? 'accountId-assetId')
 
 /**
  * shape of PortfolioAccountBalancesById, but just delegation/undelegation/redelagation
@@ -641,7 +651,7 @@ export const selectPortfolioStakingCryptoBalances = createDeepEqualOutputSelecto
 /**
  * returns crypto human staking amount by assetId and accountId filter
  */
-export const selectPortfolioStakingCryptoHumanBalanceByFilter = createSelector(
+export const selectPortfolioStakingCryptoHumanBalanceByFilter = createCachedSelector(
   selectAssets,
   selectPortfolioStakingCryptoBalances,
   selectAssetIdParamFromFilterOptional,
@@ -660,7 +670,7 @@ export const selectPortfolioStakingCryptoHumanBalanceByFilter = createSelector(
       }, bn(0))
       .toString()
   },
-)
+)((_s: ReduxState, filter) => `${filter?.accountId}-${filter?.assetId}` ?? 'accountId-assetId')
 
 /**
  * selects all accounts in PortfolioAccountBalancesById form, including all
@@ -750,19 +760,19 @@ export const selectPortfolioAccountsFiatBalancesIncludingStaking = createDeepEqu
   },
 )
 
-export const selectFiatBalanceIncludingStakingByFilter = createSelector(
+export const selectFiatBalanceIncludingStakingByFilter = createCachedSelector(
   selectPortfolioAccountsFiatBalancesIncludingStaking,
   selectAssetIdParamFromFilterOptional,
   selectAccountIdParamFromFilterOptional,
   genericBalanceIncludingStakingByFilter,
-)
+)((_s: ReduxState, filter) => `${filter?.accountId}-${filter?.assetId}` ?? 'accountId-assetId')
 
-export const selectCryptoHumanBalanceIncludingStakingByFilter = createSelector(
+export const selectCryptoHumanBalanceIncludingStakingByFilter = createCachedSelector(
   selectPortfolioAccountsCryptoHumanBalancesIncludingStaking,
   selectAssetIdParamFromFilterOptional,
   selectAccountIdParamFromFilterOptional,
   genericBalanceIncludingStakingByFilter,
-)
+)((_s: ReduxState, filter) => `${filter?.accountId}-${filter?.assetId}` ?? 'accountId-assetId')
 
 export const selectPortfolioChainIdsSortedFiat = createDeepEqualOutputSelector(
   selectPortfolioAccountsFiatBalancesIncludingStaking,
@@ -772,7 +782,7 @@ export const selectPortfolioChainIdsSortedFiat = createDeepEqualOutputSelector(
     ),
 )
 
-export const selectPortfolioTotalBalanceByChainIdIncludeStaking = createSelector(
+export const selectPortfolioTotalBalanceByChainIdIncludeStaking = createCachedSelector(
   selectPortfolioAccountsFiatBalancesIncludingStaking,
   selectChainIdParamFromFilter,
   (fiatAccountBalances, chainId): string => {
@@ -787,9 +797,9 @@ export const selectPortfolioTotalBalanceByChainIdIncludeStaking = createSelector
       }, bn(0))
       .toFixed(2)
   },
-)
+)((_s: ReduxState, filter) => filter?.chainId ?? 'chainId')
 
-export const selectPortfolioAccountBalanceByAccountNumberAndChainId = createSelector(
+export const selectPortfolioAccountBalanceByAccountNumberAndChainId = createCachedSelector(
   selectPortfolioAccountsFiatBalancesIncludingStaking,
   selectPortfolioAccountMetadata,
   selectAccountNumberParamFromFilter,
@@ -811,11 +821,14 @@ export const selectPortfolioAccountBalanceByAccountNumberAndChainId = createSele
       }, bn(0))
       .toFixed(2)
   },
+)(
+  (_s: ReduxState, filter) =>
+    `${filter?.accountNumber}-${filter?.chainId}` ?? 'accountNumber-chainId',
 )
 
 export type PortfolioAccountsGroupedByNumber = { [accountNumber: number]: AccountId[] }
 
-export const selectPortfolioAccountsGroupedByNumberByChainId = createDeepEqualOutputSelector(
+export const selectPortfolioAccountsGroupedByNumberByChainId = createCachedSelector(
   selectPortfolioAccountsFiatBalancesIncludingStaking,
   selectPortfolioAccountMetadata,
   selectChainIdParamFromFilter,
@@ -831,9 +844,9 @@ export const selectPortfolioAccountsGroupedByNumberByChainId = createDeepEqualOu
       {},
     )
   },
-)
+)((_s: ReduxState, filter) => filter?.chainId ?? 'chainId')
 
-export const selectPortfolioAssetIdsByAccountIdExcludeFeeAsset = createDeepEqualOutputSelector(
+export const selectPortfolioAssetIdsByAccountIdExcludeFeeAsset = createCachedSelector(
   selectPortfolioAssetAccountBalancesSortedFiat,
   selectAccountIdParamFromFilter,
   selectAssets,
@@ -849,15 +862,15 @@ export const selectPortfolioAssetIdsByAccountIdExcludeFeeAsset = createDeepEqual
       )
       .map(([assetId]) => assetId)
   },
-)
+)((_s: ReduxState, filter) => filter?.accountId ?? 'accountId')
 
-export const selectAccountIdsByAssetId = createDeepEqualOutputSelector(
+export const selectAccountIdsByAssetId = createCachedSelector(
   selectPortfolioAccounts,
   selectAssetIdParamFromFilter,
   findAccountsByAssetId,
-)
+)((_s: ReduxState, filter) => filter?.assetId ?? 'assetId')
 
-export const selectAccountIdsByAssetIdAboveBalanceThreshold = createDeepEqualOutputSelector(
+export const selectAccountIdsByAssetIdAboveBalanceThreshold = createCachedSelector(
   selectPortfolioAccounts,
   selectAssetIdParamFromFilter,
   selectPortfolioFiatAccountBalances,
@@ -882,7 +895,7 @@ export const selectAccountIdsByAssetIdAboveBalanceThreshold = createDeepEqualOut
     )
     return aboveThreshold
   },
-)
+)((_s: ReduxState, filter) => filter?.assetId ?? 'assetId')
 
 export type AccountRowData = {
   name: string
@@ -948,7 +961,7 @@ export const selectPortfolioAccountRows = createDeepEqualOutputSelector(
   },
 )
 
-export const selectPortfolioBridgeAssets = createSelector(
+export const selectPortfolioBridgeAssets = createDeepEqualOutputSelector(
   selectPortfolioAccountRows,
   (portfolioAssets): BridgeAsset[] => {
     return Object.entries(portfolioAssets).map(([_, v]) => {
@@ -975,7 +988,7 @@ export type ActiveStakingOpportunity = {
   rewards?: string
 }
 
-export const selectDelegationCryptoAmountByAssetIdAndValidator = createSelector(
+export const selectDelegationCryptoAmountByAssetIdAndValidator = createCachedSelector(
   selectStakingDataByFilter,
   selectValidatorAddressParamFromFilter,
   selectAssetIdParamFromFilter,
@@ -992,6 +1005,9 @@ export const selectDelegationCryptoAmountByAssetIdAndValidator = createSelector(
       }, bn(0))
       .toString()
   },
+)(
+  (_s: ReduxState, filter) =>
+    `${filter?.validatorAddress}-${filter?.assetId}` ?? 'validatorAddress-assetId',
 )
 
 export const selectUnbondingEntriesByAccountSpecifier = createDeepEqualOutputSelector(
@@ -1072,7 +1088,7 @@ export type OpportunitiesDataFull = {
   commission: string
 }
 
-export const selectStakingOpportunitiesDataFullByFilter = createDeepEqualOutputSelector(
+export const selectStakingOpportunitiesDataFullByFilter = createCachedSelector(
   selectValidatorIdsByFilter,
   selectValidators,
   selectStakingDataByFilter,
@@ -1143,7 +1159,7 @@ export const selectStakingOpportunitiesDataFullByFilter = createDeepEqualOutputS
       }
     })
   },
-)
+)((_s: ReduxState, filter) => `${filter?.accountId}-${filter?.assetId}` ?? 'accountId-assetId')
 
 export const selectHasActiveStakingOpportunity = createSelector(
   selectStakingOpportunitiesDataFullByFilter,


### PR DESCRIPTION
## Description

<!-- Please describe your changes -->

we uhhh should have done this a while ago

selectors have a memoization depth of 1 https://github.com/reduxjs/reselect#q-why-is-my-selector-recomputing-when-the-input-state-stays-the-same

re-reselect solves this problem and gives us an infinite cache size https://github.com/toomuchdesign/re-reselect

this PR gives us a two order of magnitude performance increase in terms of selector recomputation and subsequent react renders by giving selectors sufficiently unique cache key names

## Notice

<!-- Before submitting a pull request, please make sure you have answered the following: -->

- [ ] Have you followed the guidelines in our [Contributing]('https://github.com/shapeshift/web/blob/develop/CONTRIBUTING.md) guide?
- [ ] Have you checked to ensure there aren't other open [Pull Requests](https://github.com/shapeshift/web/pulls) for the same update/change?

## Pull Request Type

- [x] :bug: Bug fix (Non-breaking Change: Fixes an issue)
- [x] :hammer_and_wrench: Chore (Non-breaking Change: Doc updates, pkg upgrades, typos, etc..)
- [ ] :nail_care: New Feature (Breaking/Non-breaking Change)

## Issue (if applicable)

<!-----------------------------------------------------------------------------
If applicable, please link to the github issue and put `closes #XXXX` in your comment to auto-close the issue that your PR fixes.
------------------------------------------------------------------------------>

n/a - bug chasing got out of hand

## Risk

* reasonably high - gives the app a good smoke test all around, looking for stale data
* things should feel considerably faster

<!-----------------------------------------------------------------------------
Outline the scope of your changes and the risk associated with them. You must use your discretion as an engineer to determine the potential impact of your changes.

E.g. an upgrade to `hdwallet` or core state management would be considered higher risk, and might require a full regression test. UI or isolated view changes, or something behind a feature flag may have near zero risk. Small bug fixes might require testing isolated to the specific fix.
------------------------------------------------------------------------------>

## Testing

<!-----------------------------------------------------------------------------
We treat every PR to be merged with the same scrutiny as if we were merging directly to production.

Your PR will not be merged if you do not complete the sections below for our engineering and operations teams to test.
------------------------------------------------------------------------------>

### Engineering

<!-----------------------------------------------------------------------------
Include sufficient information here for an engineer to test your PR. This may include how to test locally, in a built environment, changes to infrastructure etc.
------------------------------------------------------------------------------>

### Operations

<!-----------------------------------------------------------------------------
If your changes have a user-facing impact, describe how a non-technical QA team can functionally test your changes in a preview environment.

If they are not user-facing please describe how to test for any regressions that may occur.
------------------------------------------------------------------------------>

## Screenshots (if applicable)
