### PR TITLE
fix: default asset rug

### DIFF
--- a/src/components/Trade/Trade.tsx
+++ b/src/components/Trade/Trade.tsx
@@ -1,7 +1,7 @@
 import type { AssetId } from '@shapeshiftoss/caip'
-import { useEffect } from 'react'
+import { useEffect, useState } from 'react'
 import { FormProvider, useForm } from 'react-hook-form'
-import { MemoryRouter, Route, Switch } from 'react-router-dom'
+import { MemoryRouter, Route, Switch, useLocation } from 'react-router-dom'
 
 import { useDefaultAssets } from './hooks/useDefaultAssets'
 import { entries, TradeRoutes } from './TradeRoutes/TradeRoutes'
@@ -13,7 +13,9 @@ export type TradeProps = {
 }
 
 export const Trade = ({ defaultBuyAssetId }: TradeProps) => {
-  const { getDefaultAssets } = useDefaultAssets(defaultBuyAssetId)
+  const { getDefaultAssets, defaultAssetIdPair } = useDefaultAssets(defaultBuyAssetId)
+  const location = useLocation()
+  const [hasSetDefaultValues, setHasSetDefaultValues] = useState<boolean>(false)
 
   const methods = useForm<TS>({
     mode: 'onChange',
@@ -30,15 +32,35 @@ export const Trade = ({ defaultBuyAssetId }: TradeProps) => {
     },
   })
 
+  // The route has changed, so re-enable the default values useEffect
+  useEffect(() => setHasSetDefaultValues(false), [location])
+
   useEffect(() => {
+    if (hasSetDefaultValues) return
     ;(async () => {
       const result = await getDefaultAssets()
       if (!result) return
       const { buyAsset, sellAsset } = result
       methods.setValue('sellTradeAsset.asset', sellAsset)
       methods.setValue('buyTradeAsset.asset', buyAsset)
+      const defaultAssetsAreChainDefaults =
+        sellAsset.assetId === defaultAssetIdPair?.sellAssetId &&
+        buyAsset.assetId === defaultAssetIdPair?.buyAssetId
+      if (!defaultAssetsAreChainDefaults) {
+        // If the default assets are the chain defaults then keep this useEffect active as we might not have stabilized
+        // Else, we know the default values have been set, so don't run this again unless the route changes
+        setHasSetDefaultValues(true)
+      }
     })()
-  }, [defaultBuyAssetId, getDefaultAssets, methods])
+  }, [
+    defaultBuyAssetId,
+    getDefaultAssets,
+    methods,
+    location,
+    hasSetDefaultValues,
+    defaultAssetIdPair?.sellAssetId,
+    defaultAssetIdPair?.buyAssetId,
+  ])
 
   if (!methods) return null
 

--- a/src/components/Trade/TradeConfirm/TradeConfirm.tsx
+++ b/src/components/Trade/TradeConfirm/TradeConfirm.tsx
@@ -59,10 +59,6 @@ export const TradeConfirm = ({ history }: RouterProps) => {
   const borderColor = useColorModeValue('gray.100', 'gray.750')
   const [sellTxid, setSellTxid] = useState('')
   const [buyTxid, setBuyTxid] = useState('')
-  const [frozenTradeAmountConstants, setFrozenTradeAmountConstants] =
-    useState<ReturnType<typeof getTradeAmountConstants>>()
-  const [frozenTrade, setFrozenTrade] = useState<TS['trade']>()
-  const [frozenFees, setFrozenFees] = useState<TS['fees']>()
   const {
     handleSubmit,
     setValue,
@@ -76,34 +72,94 @@ export const TradeConfirm = ({ history }: RouterProps) => {
 
   const formTrade = useWatch({ control, name: 'trade' })
   const formFees = useWatch({ control, name: 'fees' })
-  const sellAssetFiatRate = useWatch({ control, name: 'sellAssetFiatRate' })
-  const feeAssetFiatRate = useWatch({ control, name: 'feeAssetFiatRate' })
-  const slippage = useWatch({ control, name: 'slippage' })
-  const buyAssetAccountId = useWatch({ control, name: 'buyAssetAccountId' })
-  const sellAssetAccountId = useWatch({ control, name: 'sellAssetAccountId' })
-  const buyTradeAsset = useWatch({ control, name: 'buyTradeAsset' })
+  const formSellAssetFiatRate = useWatch({ control, name: 'sellAssetFiatRate' })
+  const formFeeAssetFiatRate = useWatch({ control, name: 'feeAssetFiatRate' })
+  const formSlippage = useWatch({ control, name: 'slippage' })
+  const formBuyAssetAccountId = useWatch({ control, name: 'buyAssetAccountId' })
+  const formSellAssetAccountId = useWatch({ control, name: 'sellAssetAccountId' })
+  const formBuyTradeAsset = useWatch({ control, name: 'buyTradeAsset' })
+
+  const [frozenTradeAmountConstants, setFrozenTradeAmountConstants] =
+    useState<ReturnType<typeof getTradeAmountConstants>>()
+  const [frozenTrade, setFrozenTrade] = useState<TS['trade']>()
+  const [frozenFees, setFrozenFees] = useState<TS['fees']>()
+  const [frozenSellAssetFiatRate, setFrozenSellAssetFiatRate] = useState<TS['sellAssetFiatRate']>()
+  const [frozenFeeAssetFiatRate, setFrozenFeeAssetFiatRate] = useState<TS['feeAssetFiatRate']>()
+  const [frozenSlippage, setFrozenSlippage] = useState<TS['slippage']>()
+  const [frozenBuyAssetAccountId, setFrozenBuyAssetAccountId] = useState<TS['buyAssetAccountId']>()
+  const [frozenSellAssetAccountId, setFrozenSellAssetAccountId] =
+    useState<TS['sellAssetAccountId']>()
+  const [frozenBuyTradeAsset, setFrozenBuyTradeAsset] = useState<TS['buyTradeAsset']>()
 
   const tradeAmountConstants = useGetTradeAmounts()
   const {
     number: { toFiat },
   } = useLocaleFormatter()
 
-  setFrozenTradeAmountConstants(tradeAmountConstants)
-  setFrozenTrade(formTrade)
-  setFrozenFees(formFees)
+  useEffect(() => {
+    !frozenTradeAmountConstants && setFrozenTradeAmountConstants(tradeAmountConstants)
+    !frozenTrade && setFrozenTrade(formTrade)
+    !frozenFees && setFrozenFees(formFees)
+    !frozenSellAssetFiatRate && setFrozenSellAssetFiatRate(formSellAssetFiatRate)
+    !frozenFeeAssetFiatRate && setFrozenFeeAssetFiatRate(formFeeAssetFiatRate)
+    !frozenSlippage && setFrozenSlippage(formSlippage)
+    !frozenBuyAssetAccountId && setFrozenBuyAssetAccountId(formBuyAssetAccountId)
+    !frozenSellAssetAccountId && setFrozenSellAssetAccountId(formSellAssetAccountId)
+    !frozenBuyTradeAsset && setFrozenBuyTradeAsset(formBuyTradeAsset)
+  }, [
+    formBuyAssetAccountId,
+    formBuyTradeAsset,
+    formFeeAssetFiatRate,
+    formFees,
+    formSellAssetAccountId,
+    formSellAssetFiatRate,
+    formSlippage,
+    formTrade,
+    frozenBuyAssetAccountId,
+    frozenBuyTradeAsset,
+    frozenFeeAssetFiatRate,
+    frozenFees,
+    frozenSellAssetAccountId,
+    frozenSellAssetFiatRate,
+    frozenSlippage,
+    frozenTrade,
+    frozenTradeAmountConstants,
+    tradeAmountConstants,
+  ])
+
+  // If an executed value exists we want to ignore any subsequent updates and use the executed value
+  const tradeAmounts = useMemo(
+    () => frozenTradeAmountConstants ?? tradeAmountConstants,
+    [frozenTradeAmountConstants, tradeAmountConstants],
+  )
+  const trade = useMemo(() => frozenTrade ?? formTrade, [frozenTrade, formTrade])
+  const fees = useMemo(() => frozenFees ?? formFees, [frozenFees, formFees])
+  const sellAssetFiatRate = useMemo(
+    () => frozenSellAssetFiatRate ?? formSellAssetFiatRate,
+    [frozenSellAssetFiatRate, formSellAssetFiatRate],
+  )
+  const feeAssetFiatRate = useMemo(
+    () => frozenFeeAssetFiatRate ?? formFeeAssetFiatRate,
+    [frozenFeeAssetFiatRate, formFeeAssetFiatRate],
+  )
+  const slippage = useMemo(() => frozenSlippage ?? formSlippage, [frozenSlippage, formSlippage])
+  const buyAssetAccountId = useMemo(
+    () => frozenBuyAssetAccountId ?? formBuyAssetAccountId,
+    [frozenBuyAssetAccountId, formBuyAssetAccountId],
+  )
+  const sellAssetAccountId = useMemo(
+    () => frozenSellAssetAccountId ?? formSellAssetAccountId,
+    [frozenSellAssetAccountId, formSellAssetAccountId],
+  )
+  const buyTradeAsset = useMemo(
+    () => frozenBuyTradeAsset ?? formBuyTradeAsset,
+    [frozenBuyTradeAsset, formBuyTradeAsset],
+  )
 
   const {
     state: { isConnected, wallet },
     dispatch,
   } = useWallet()
-
-  // If an executed value exists we want to ignore any subsequent updates and use the executed value
-  const trade = useMemo(() => frozenTrade ?? formTrade, [frozenTrade, formTrade])
-  const fees = useMemo(() => frozenFees ?? formFees, [frozenFees, formFees])
-  const tradeAmounts = useMemo(
-    () => frozenTradeAmountConstants ?? tradeAmountConstants,
-    [frozenTradeAmountConstants, tradeAmountConstants],
-  )
 
   const defaultFeeAsset = useAppSelector(state =>
     selectFeeAssetByChainId(state, trade?.sellAsset?.chainId ?? ''),

--- a/src/components/Trade/TradeConfirm/TradeConfirm.tsx
+++ b/src/components/Trade/TradeConfirm/TradeConfirm.tsx
@@ -59,9 +59,10 @@ export const TradeConfirm = ({ history }: RouterProps) => {
   const borderColor = useColorModeValue('gray.100', 'gray.750')
   const [sellTxid, setSellTxid] = useState('')
   const [buyTxid, setBuyTxid] = useState('')
-  const [executedTradeAmountConstants, setExecutedTradeAmountConstants] =
+  const [frozenTradeAmountConstants, setFrozenTradeAmountConstants] =
     useState<ReturnType<typeof getTradeAmountConstants>>()
-  const [executedTrade, setExecutedTrade] = useState<TS['trade']>()
+  const [frozenTrade, setFrozenTrade] = useState<TS['trade']>()
+  const [frozenFees, setFrozenFees] = useState<TS['fees']>()
   const {
     handleSubmit,
     setValue,
@@ -74,7 +75,7 @@ export const TradeConfirm = ({ history }: RouterProps) => {
   const flags = useSelector(selectFeatureFlags)
 
   const formTrade = useWatch({ control, name: 'trade' })
-  const fees = useWatch({ control, name: 'fees' })
+  const formFees = useWatch({ control, name: 'fees' })
   const sellAssetFiatRate = useWatch({ control, name: 'sellAssetFiatRate' })
   const feeAssetFiatRate = useWatch({ control, name: 'feeAssetFiatRate' })
   const slippage = useWatch({ control, name: 'slippage' })
@@ -86,16 +87,22 @@ export const TradeConfirm = ({ history }: RouterProps) => {
   const {
     number: { toFiat },
   } = useLocaleFormatter()
+
+  setFrozenTradeAmountConstants(tradeAmountConstants)
+  setFrozenTrade(formTrade)
+  setFrozenFees(formFees)
+
   const {
     state: { isConnected, wallet },
     dispatch,
   } = useWallet()
 
   // If an executed value exists we want to ignore any subsequent updates and use the executed value
-  const trade = useMemo(() => executedTrade ?? formTrade, [executedTrade, formTrade])
+  const trade = useMemo(() => frozenTrade ?? formTrade, [frozenTrade, formTrade])
+  const fees = useMemo(() => frozenFees ?? formFees, [frozenFees, formFees])
   const tradeAmounts = useMemo(
-    () => executedTradeAmountConstants ?? tradeAmountConstants,
-    [executedTradeAmountConstants, tradeAmountConstants],
+    () => frozenTradeAmountConstants ?? tradeAmountConstants,
+    [frozenTradeAmountConstants, tradeAmountConstants],
   )
 
   const defaultFeeAsset = useAppSelector(state =>
@@ -181,8 +188,6 @@ export const TradeConfirm = ({ history }: RouterProps) => {
       }
 
       const result = await swapper.executeTrade({ trade, wallet })
-      setExecutedTradeAmountConstants(tradeAmountConstants)
-      setExecutedTrade(formTrade)
       setSellTxid(result.tradeId)
 
       // Poll until we have a "buy" txid

--- a/src/components/Trade/TradeConfirm/useFrozenTradeValues.tsx
+++ b/src/components/Trade/TradeConfirm/useFrozenTradeValues.tsx
@@ -1,0 +1,103 @@
+import { useEffect, useMemo, useState } from 'react'
+import { useFormContext, useWatch } from 'react-hook-form'
+import type { getTradeAmountConstants } from 'components/Trade/hooks/useGetTradeAmounts'
+import { useGetTradeAmounts } from 'components/Trade/hooks/useGetTradeAmounts'
+import type { TS } from 'components/Trade/types'
+
+export const useFrozenTradeValues = () => {
+  const { control } = useFormContext<TS>()
+  const formTrade = useWatch({ control, name: 'trade' })
+  const formFees = useWatch({ control, name: 'fees' })
+  const formSellAssetFiatRate = useWatch({ control, name: 'sellAssetFiatRate' })
+  const formFeeAssetFiatRate = useWatch({ control, name: 'feeAssetFiatRate' })
+  const formSlippage = useWatch({ control, name: 'slippage' })
+  const formBuyAssetAccountId = useWatch({ control, name: 'buyAssetAccountId' })
+  const formSellAssetAccountId = useWatch({ control, name: 'sellAssetAccountId' })
+  const formBuyTradeAsset = useWatch({ control, name: 'buyTradeAsset' })
+
+  const [frozenTradeAmountConstants, setFrozenTradeAmountConstants] =
+    useState<ReturnType<typeof getTradeAmountConstants>>()
+  const [frozenTrade, setFrozenTrade] = useState<TS['trade']>()
+  const [frozenFees, setFrozenFees] = useState<TS['fees']>()
+  const [frozenSellAssetFiatRate, setFrozenSellAssetFiatRate] = useState<TS['sellAssetFiatRate']>()
+  const [frozenFeeAssetFiatRate, setFrozenFeeAssetFiatRate] = useState<TS['feeAssetFiatRate']>()
+  const [frozenSlippage, setFrozenSlippage] = useState<TS['slippage']>()
+  const [frozenBuyAssetAccountId, setFrozenBuyAssetAccountId] = useState<TS['buyAssetAccountId']>()
+  const [frozenSellAssetAccountId, setFrozenSellAssetAccountId] =
+    useState<TS['sellAssetAccountId']>()
+  const [frozenBuyTradeAsset, setFrozenBuyTradeAsset] = useState<TS['buyTradeAsset']>()
+
+  const tradeAmountConstants = useGetTradeAmounts()
+
+  useEffect(() => {
+    !frozenTradeAmountConstants && setFrozenTradeAmountConstants(tradeAmountConstants)
+    !frozenTrade && setFrozenTrade(formTrade)
+    !frozenFees && setFrozenFees(formFees)
+    !frozenSellAssetFiatRate && setFrozenSellAssetFiatRate(formSellAssetFiatRate)
+    !frozenFeeAssetFiatRate && setFrozenFeeAssetFiatRate(formFeeAssetFiatRate)
+    !frozenSlippage && setFrozenSlippage(formSlippage)
+    !frozenBuyAssetAccountId && setFrozenBuyAssetAccountId(formBuyAssetAccountId)
+    !frozenSellAssetAccountId && setFrozenSellAssetAccountId(formSellAssetAccountId)
+    !frozenBuyTradeAsset && setFrozenBuyTradeAsset(formBuyTradeAsset)
+  }, [
+    formBuyAssetAccountId,
+    formBuyTradeAsset,
+    formFeeAssetFiatRate,
+    formFees,
+    formSellAssetAccountId,
+    formSellAssetFiatRate,
+    formSlippage,
+    formTrade,
+    frozenBuyAssetAccountId,
+    frozenBuyTradeAsset,
+    frozenFeeAssetFiatRate,
+    frozenFees,
+    frozenSellAssetAccountId,
+    frozenSellAssetFiatRate,
+    frozenSlippage,
+    frozenTrade,
+    frozenTradeAmountConstants,
+    tradeAmountConstants,
+  ])
+
+  // If an executed value exists we want to ignore any subsequent updates and use the executed value
+  const tradeAmounts = useMemo(
+    () => frozenTradeAmountConstants ?? tradeAmountConstants,
+    [frozenTradeAmountConstants, tradeAmountConstants],
+  )
+  const trade = useMemo(() => frozenTrade ?? formTrade, [frozenTrade, formTrade])
+  const fees = useMemo(() => frozenFees ?? formFees, [frozenFees, formFees])
+  const sellAssetFiatRate = useMemo(
+    () => frozenSellAssetFiatRate ?? formSellAssetFiatRate,
+    [frozenSellAssetFiatRate, formSellAssetFiatRate],
+  )
+  const feeAssetFiatRate = useMemo(
+    () => frozenFeeAssetFiatRate ?? formFeeAssetFiatRate,
+    [frozenFeeAssetFiatRate, formFeeAssetFiatRate],
+  )
+  const slippage = useMemo(() => frozenSlippage ?? formSlippage, [frozenSlippage, formSlippage])
+  const buyAssetAccountId = useMemo(
+    () => frozenBuyAssetAccountId ?? formBuyAssetAccountId,
+    [frozenBuyAssetAccountId, formBuyAssetAccountId],
+  )
+  const sellAssetAccountId = useMemo(
+    () => frozenSellAssetAccountId ?? formSellAssetAccountId,
+    [frozenSellAssetAccountId, formSellAssetAccountId],
+  )
+  const buyTradeAsset = useMemo(
+    () => frozenBuyTradeAsset ?? formBuyTradeAsset,
+    [frozenBuyTradeAsset, formBuyTradeAsset],
+  )
+
+  return {
+    tradeAmounts,
+    trade,
+    fees,
+    sellAssetFiatRate,
+    feeAssetFiatRate,
+    slippage,
+    buyAssetAccountId,
+    sellAssetAccountId,
+    buyTradeAsset,
+  }
+}

--- a/src/components/Trade/hooks/useDefaultAssets.tsx
+++ b/src/components/Trade/hooks/useDefaultAssets.tsx
@@ -157,5 +157,5 @@ export const useDefaultAssets = (routeBuyAssetId?: AssetId) => {
     wallet,
   ])
 
-  return { getDefaultAssets }
+  return { getDefaultAssets, defaultAssetIdPair }
 }

--- a/src/components/Trade/hooks/useSwapper/utils.ts
+++ b/src/components/Trade/hooks/useSwapper/utils.ts
@@ -126,7 +126,6 @@ export const getFormFees = ({
   feeAsset,
 }: GetFormFeesArgs): DisplayFeeData<KnownChainIds> => {
   const networkFeeCryptoHuman = fromBaseUnit(trade?.feeData?.networkFee, feeAsset.precision)
-  console.log('xxx fee asset calc', { feeAsset, trade, networkFeeCryptoHuman })
 
   const { chainNamespace } = fromAssetId(sellAsset.assetId)
   switch (chainNamespace) {

--- a/src/components/Trade/hooks/useSwapper/utils.ts
+++ b/src/components/Trade/hooks/useSwapper/utils.ts
@@ -126,6 +126,7 @@ export const getFormFees = ({
   feeAsset,
 }: GetFormFeesArgs): DisplayFeeData<KnownChainIds> => {
   const networkFeeCryptoHuman = fromBaseUnit(trade?.feeData?.networkFee, feeAsset.precision)
+  console.log('xxx fee asset calc', { feeAsset, trade, networkFeeCryptoHuman })
 
   const { chainNamespace } = fromAssetId(sellAsset.assetId)
   switch (chainNamespace) {


### PR DESCRIPTION
## Description

This PR prevents the trade assets being reset to the default assets if they have already been set for that route.

We only really want to set default assets on route change, so we ensure that if the default assets returned from `getDefaultAssets` are not the chain's default assets, then we've stabilized, so prevent the default assets being set again until the route is changed.

## Notice

- [x] Have you followed the guidelines in our [Contributing]('https://github.com/shapeshift/web/blob/develop/CONTRIBUTING.md) guide?
- [x] Have you checked to ensure there aren't other open [Pull Requests](https://github.com/shapeshift/web/pulls) for the same update/change?

## Pull Request Type

- [x] :bug: Bug fix (Non-breaking Change: Fixes an issue)
- [ ] :hammer_and_wrench: Chore (Non-breaking Change: Doc updates, pkg upgrades, typos, etc..)
- [ ] :nail_care: New Feature (Breaking/Non-breaking Change)

## Issue (if applicable)

Closes https://github.com/shapeshift/web/issues/3105

## Risk

Small, though it could prevent default assets from being set when they otherwise should be.

## Testing

The bug that this fixes was super hard to reproduce, so whilst the logic in this PR should fix the issue, it is difficult to be sure (I get just be getting false negatives).

It seems to occur when trading between UTXO assets, though that's about as much as I have.
When clicking "Preview Trade" we should no longer have the default assets callback fire on occasion.

### Engineering

The real issue is that something is causing `Trade` to re-render when "Preview Trade" is clicked, but only very rarely.
This doesn't fix that, only the symptom.

### Operations

☝️ 

## Screenshots (if applicable)

N/A