### PR TITLE
fix: insufficientAmountForGas translation

### DIFF
--- a/src/assets/translations/en/main.json
+++ b/src/assets/translations/en/main.json
@@ -16,7 +16,7 @@
     "insufficientFunds": "Insufficient Funds",
     "estimatedGas": "Estimated Gas Fee",
     "relayerGasFee": "Relayer Gas Fee",
-    "insufficientAmountForGas": "Not enough ETH to cover gas",
+    "insufficientAmountForGas": "Not enough %{assetSymbol} to cover gas",
     "invalidAddress": "Invalid Address",
     "invalidAddressOrYat": "Invalid Address or Yat",
     "deposit": "Deposit",

--- a/src/components/Trade/TradeInputV2.tsx
+++ b/src/components/Trade/TradeInputV2.tsx
@@ -41,7 +41,7 @@ import { TradeAssetInput } from './Components/TradeAssetInput'
 import { AssetClickAction, useTradeRoutes } from './hooks/useTradeRoutes/useTradeRoutes'
 import { ReceiveSummary } from './TradeConfirm/ReceiveSummary'
 import type { TS } from './types'
-import { type TradeState, TradeAmountInputField, TradeRoutePaths } from './types'
+import { TradeAmountInputField, TradeRoutePaths, type TradeState } from './types'
 
 const moduleLogger = logger.child({ namespace: ['TradeInput'] })
 
@@ -304,7 +304,10 @@ export const TradeInput = () => {
     if (!bestTradeSwapper) return 'trade.errors.invalidTradePairBtnText'
     if (!hasValidTradeBalance) return 'common.insufficientFunds'
     if (hasValidTradeBalance && !hasEnoughBalanceForGas && hasValidSellAmount)
-      return 'common.insufficientAmountForGas'
+      return [
+        'common.insufficientAmountForGas',
+        { assetSymbol: sellTradeAsset?.asset?.symbol ?? 'sell asset' },
+      ]
     if (isBelowMinSellAmount) return ['trade.errors.amountTooSmall', { minLimit }]
     if (feesExceedsSellAmount) return 'trade.errors.sellAmountDoesNotCoverFee'
     if (isTradeQuotePending && quoteAvailableForCurrentAssetPair) return 'trade.updatingQuote'


### PR DESCRIPTION
## Description

We had ETH as the fee hardcoded for our `insufficientAmountForGas` translation.

Before:

<img width="648" alt="Screen_Shot_2022-10-20_at_1 32 15_pm" src="https://user-images.githubusercontent.com/97164662/196859540-8b8478e5-d077-4c2d-9742-4cf44e56f4be.png">


After:

<img width="627" alt="Screen Shot 2022-10-20 at 3 50 42 pm" src="https://user-images.githubusercontent.com/97164662/196859529-63b04757-301b-4174-9f8c-17eb800501ef.png">

## Notice

- [x] Have you followed the guidelines in our [Contributing]('https://github.com/shapeshift/web/blob/develop/CONTRIBUTING.md) guide?
- [x] Have you checked to ensure there aren't other open [Pull Requests](https://github.com/shapeshift/web/pulls) for the same update/change?

## Pull Request Type

- [x] :bug: Bug fix (Non-breaking Change: Fixes an issue)
- [ ] :hammer_and_wrench: Chore (Non-breaking Change: Doc updates, pkg upgrades, typos, etc..)
- [ ] :nail_care: New Feature (Breaking/Non-breaking Change)

## Issue (if applicable)

N/A

## Risk

Minimal.

## Testing

When performing a trade where the fee asset is not ETH, and these is not enough of the fee asset to perform the trade, the correct fee asset should be shown in the error message.

### Engineering

☝️ 

### Operations

☝️ 

## Screenshots (if applicable)

As above.