### PR TITLE
fix: no receive address error state

### DIFF
--- a/src/assets/translations/en/main.json
+++ b/src/assets/translations/en/main.json
@@ -556,6 +556,7 @@
       "unsupportedChain": "This chain is not currently supported.",
       "rateError": "We're not able to get a quote for this pair",
       "assetNotSupportedByWallet": "%{assetSymbol} not supported by wallet",
+      "noReceiveAddress": "No receive address for %{assetSymbol}",
       "signing": {
         "failed": "An error occurred signing the transaction",
         "required": "A signed transaction is required"

--- a/src/components/Trade/TradeInputV2.tsx
+++ b/src/components/Trade/TradeInputV2.tsx
@@ -56,6 +56,7 @@ export const TradeInput = () => {
     getSupportedSellableAssets,
     getSupportedBuyAssetsFromSellAsset,
     swapperSupportsCrossAccountTrade,
+    receiveAddress,
   } = useSwapper()
   const history = useHistory()
   const borderColor = useColorModeValue('gray.100', 'gray.750')
@@ -308,21 +309,32 @@ export const TradeInput = () => {
     if (isBelowMinSellAmount) return ['trade.errors.amountTooSmall', { minLimit }]
     if (feesExceedsSellAmount) return 'trade.errors.sellAmountDoesNotCoverFee'
     if (isTradeQuotePending && quoteAvailableForCurrentAssetPair) return 'trade.updatingQuote'
+    if (!receiveAddress)
+      return [
+        'trade.errors.noReceiveAddress',
+        { assetSymbol: buyTradeAsset?.asset?.symbol ?? 'buy asset' },
+      ]
 
     return 'trade.previewTrade'
   }, [
     bestTradeSwapper,
-    buyTradeAsset,
+    buyTradeAsset?.asset?.symbol,
     feeAssetBalance,
     feesExceedsSellAmount,
     hasValidSellAmount,
     isBelowMinSellAmount,
     isTradeQuotePending,
-    quote,
+    quote?.feeData.networkFee,
+    quote?.minimum,
+    quote?.sellAsset.symbol,
     quoteAvailableForCurrentAssetPair,
+    receiveAddress,
     sellAssetBalanceHuman,
-    sellFeeAsset,
-    sellTradeAsset,
+    sellFeeAsset?.assetId,
+    sellFeeAsset?.precision,
+    sellTradeAsset?.amount,
+    sellTradeAsset?.asset?.assetId,
+    sellTradeAsset?.asset?.symbol,
     wallet,
     walletSupportsBuyAssetChain,
     walletSupportsSellAssetChain,


### PR DESCRIPTION
## Description

We currently don't disable the "Preview Trade" button if the `receiveAddress` is still loading.
This results in "dead clicks" - an exception throws, but this isn't obvious to the user.

This PR adds an error to show this state.

## Notice

- [x] Have you followed the guidelines in our [Contributing]('https://github.com/shapeshift/web/blob/develop/CONTRIBUTING.md) guide?
- [x] Have you checked to ensure there aren't other open [Pull Requests](https://github.com/shapeshift/web/pulls) for the same update/change?

## Pull Request Type

- [x] :bug: Bug fix (Non-breaking Change: Fixes an issue)
- [ ] :hammer_and_wrench: Chore (Non-breaking Change: Doc updates, pkg upgrades, typos, etc..)
- [ ] :nail_care: New Feature (Breaking/Non-breaking Change)

## Issue (if applicable)

N/A

## Risk

Very small.

## Testing

1. Get to the confirm trade screen for a pair such as DOGE -> BCH.
2. Press back from the confirm screen, and for a moment the "Preview Trade" button will be disabled and show "No receive address for BCH", and be disabled.

### Engineering

☝️ 

### Operations

☝️ 

## Screenshots (if applicable)

<img width="648" alt="Screen_Shot_2022-10-20_at_1 32 15_pm" src="https://user-images.githubusercontent.com/97164662/196867849-01c01fbc-f092-4b92-ac33-6afab4ac068d.png">
