### PR TITLE
fix: loading state for send max

### DIFF
--- a/src/components/Trade/TradeInputV2.tsx
+++ b/src/components/Trade/TradeInputV2.tsx
@@ -373,7 +373,7 @@ export const TradeInput = () => {
             assetIcon={sellTradeAsset?.asset?.icon ?? ''}
             cryptoAmount={positiveOrZero(sellTradeAsset?.amount).toString()}
             fiatAmount={positiveOrZero(fiatSellAmount).toString()}
-            isSendMaxDisabled={!quote}
+            isSendMaxDisabled={isSwapperApiPending || !quoteAvailableForCurrentAssetPair}
             onChange={onSellAssetInputChange}
             percentOptions={[1]}
             onMaxClick={handleSendMax}


### PR DESCRIPTION
## Description

The Send Max button is not currently disabled when there is not enough data to use it, or the API is loading (trade amounts don't populate until it's finished loading anyway).

This PR ensures it's disabled unless we are in a position to use it to populate trade amounts.

## Notice

- [x] Have you followed the guidelines in our [Contributing]('https://github.com/shapeshift/web/blob/develop/CONTRIBUTING.md) guide?
- [x] Have you checked to ensure there aren't other open [Pull Requests](https://github.com/shapeshift/web/pulls) for the same update/change?

## Pull Request Type

- [ ] :bug: Bug fix (Non-breaking Change: Fixes an issue)
- [ ] :hammer_and_wrench: Chore (Non-breaking Change: Doc updates, pkg upgrades, typos, etc..)
- [x] :nail_care: New Feature (Breaking/Non-breaking Change)

## Issue (if applicable)

N/A

## Risk

Very small.

## Testing

Change assets to get a ThorSwap quote (slower, so easier to see).
a) Notice the "Max" button is disabled until we have a quote
b) The "Max" button disables whilst max is being calculated

### Engineering

☝️ 

### Operations

☝️

## Screenshots (if applicable)

N/A