### PR TITLE
chore: reset form state on asset change

### DIFF
--- a/src/components/Trade/Trade.tsx
+++ b/src/components/Trade/Trade.tsx
@@ -37,6 +37,18 @@ export const Trade = ({ defaultBuyAssetId }: TradeProps) => {
       const { buyAsset, sellAsset } = result
       methods.setValue('sellTradeAsset.asset', sellAsset)
       methods.setValue('buyTradeAsset.asset', buyAsset)
+      methods.setValue('action', TradeAmountInputField.SELL_FIAT)
+      methods.setValue('amount', '0')
+      methods.setValue('sellTradeAsset.amount', '0')
+      methods.setValue('buyTradeAsset.amount', '0')
+      methods.setValue('fiatBuyAmount', '0')
+      methods.setValue('fiatSellAmount', '0')
+      methods.setValue('quote', undefined)
+      methods.setValue('trade', undefined)
+      methods.setValue('sellAssetFiatRate', undefined)
+      methods.setValue('buyAssetFiatRate', undefined)
+      methods.setValue('feeAssetFiatRate', undefined)
+      methods.setValue('isSendMax', false)
     })()
   }, [defaultBuyAssetId, getDefaultAssets, methods])
 

--- a/src/components/Trade/TradeInputV2.tsx
+++ b/src/components/Trade/TradeInputV2.tsx
@@ -166,6 +166,7 @@ export const TradeInput = () => {
       // The below values all change on asset change. Clear them so no inaccurate data is shown in the UI.
       setValue('feeAssetFiatRate', undefined)
       setValue('quote', undefined)
+      setValue('trade', undefined)
       setValue('fees', undefined)
     } catch (e) {
       moduleLogger.error(e, 'handleToggle error')

--- a/src/components/Trade/hooks/useTradeRoutes/useTradeRoutes.tsx
+++ b/src/components/Trade/hooks/useTradeRoutes/useTradeRoutes.tsx
@@ -50,6 +50,7 @@ export const useTradeRoutes = (): {
       setValue('fiatBuyAmount', '0')
       setValue('fiatSellAmount', '0')
       setValue('quote', undefined)
+      setValue('trade', undefined)
       setValue('sellAssetFiatRate', undefined)
       setValue('buyAssetFiatRate', undefined)
       setValue('feeAssetFiatRate', undefined)


### PR DESCRIPTION
## Description

We are not correctly clearing the form state when assets change, which leaves us with stale values that are temporarily shown in the UI.

A prime example of this is gas fees being off, which in particular can be observed when getting a trade quote (all the way to the trade confirm screen) for ETH -> FOX, then backing out and getting a regular quote for BTC -> DODGE.

The cached `trade` value was causing the fee asset to be wrong, which broke the gas fee UI.

## Notice

- [x] Have you followed the guidelines in our [Contributing]('https://github.com/shapeshift/web/blob/develop/CONTRIBUTING.md) guide?
- [x] Have you checked to ensure there aren't other open [Pull Requests](https://github.com/shapeshift/web/pulls) for the same update/change?

## Pull Request Type

- [x] :bug: Bug fix (Non-breaking Change: Fixes an issue)
- [ ] :hammer_and_wrench: Chore (Non-breaking Change: Doc updates, pkg upgrades, typos, etc..)
- [ ] :nail_care: New Feature (Breaking/Non-breaking Change)

## Issue (if applicable)

Closes https://github.com/shapeshift/web/issues/3107

## Risk

Fairly small - only touches swapper form state values.

## Testing

Try the example given in the description - there should be no more gas fee issues on the quote or trade confirm page.

### Engineering

☝️ 

### Operations

☝️

## Screenshots (if applicable)

N/A