### PR TITLE
fix: infinite AccountDropdown toggle

### DIFF
--- a/src/components/AccountDropdown/AccountDropdown.tsx
+++ b/src/components/AccountDropdown/AccountDropdown.tsx
@@ -26,7 +26,7 @@ import { UtxoAccountType } from '@shapeshiftoss/types'
 import { chain } from 'lodash'
 import isEmpty from 'lodash/isEmpty'
 import sortBy from 'lodash/sortBy'
-import { type FC, useCallback, useEffect, useMemo, useState } from 'react'
+import React, { type FC, useCallback, useEffect, useMemo, useState } from 'react'
 import { useTranslate } from 'react-polyglot'
 import { useSelector } from 'react-redux'
 import { useFeatureFlag } from 'hooks/useFeatureFlag/useFeatureFlag'
@@ -209,9 +209,8 @@ export const AccountDropdown: FC<AccountDropdownProps> = ({
         ? getAccountIdsSortedByBalance(accountIds)
         : getAccountIdsSortedByUtxoAccountType(accountIds)
       return (
-        <>
+        <React.Fragment key={accountNumber}>
           <AccountSegment
-            key={accountNumber}
             title={translate('accounts.accountNumber', { accountNumber })}
             subtitle={''} // hide me until we have the option to "nickname" accounts
           />
@@ -230,7 +229,7 @@ export const AccountDropdown: FC<AccountDropdownProps> = ({
               {...listProps}
             />
           ))}
-        </>
+        </React.Fragment>
       )
     })
   }, [


### PR DESCRIPTION
## Description

This PR fixes the infinite AccountDropdown by narrowing the conditions under which `onChange()` should run.
The guts of this is using a poor man's componentDidUpdate for react hooks a.k.a `usePrevious`, which allows us to detect when the value of the `selectedAccountId` didn't actually change, and thus calling `onChange` would create infinite toggles back and forth.

## Notice

<!-- Before submitting a pull request, please make sure you have answered the following: -->

- [x] Have you followed the guidelines in our [Contributing]('https://github.com/shapeshift/web/blob/develop/CONTRIBUTING.md) guide?
- [x] Have you checked to ensure there aren't other open [Pull Requests](https://github.com/shapeshift/web/pulls) for the same update/change?

## Pull Request Type

- [x] :bug: Bug fix (Non-breaking Change: Fixes an issue)
- [ ] :hammer_and_wrench: Chore (Non-breaking Change: Doc updates, pkg upgrades, typos, etc..)
- [ ] :nail_care: New Feature (Breaking/Non-breaking Change)

## Issue (if applicable)


closes https://github.com/shapeshift/web/issues/3095 - note this says swapper but the same issue is happening on FOX/ETH currently with the autoselected highest balance account

## Risk

<!-----------------------------------------------------------------------------
Outline the scope of your changes and the risk associated with them. You must use your discretion as an engineer to determine the potential impact of your changes.

E.g. an upgrade to `hdwallet` or core state management would be considered higher risk, and might require a full regression test. UI or isolated view changes, or something behind a feature flag may have near zero risk. Small bug fixes might require testing isolated to the specific fix.
------------------------------------------------------------------------------>

Account selection could be borked, test accordingly

## Testing

<!-----------------------------------------------------------------------------
We treat every PR to be merged with the same scrutiny as if we were merging directly to production.

Your PR will not be merged if you do not complete the sections below for our engineering and operations teams to test.
------------------------------------------------------------------------------>

- In swapper, select an account that is *not* the autoselected highest balance one for either the buy or sell asset
- Reselect the same buy or sell asset
- There should be no infinite toggle
<!----->
- In the FOX/ETH LP/farming, have some balance in account 1 or greater, that is greater than the account 0 one (account 0 should *not* be totally empty)
- Open the DeFi modal from the DeFi section in either Overview or Earn
- The highest balance account should be selected without infinite toggle
- When opening the modal from account and asset pages, we should still route to the right account

### Engineering

<!-----------------------------------------------------------------------------
Include sufficient information here for an engineer to test your PR. This may include how to test locally, in a built environment, changes to infrastructure etc.
------------------------------------------------------------------------------>

☝🏽 

### Operations

<!-----------------------------------------------------------------------------
If your changes have a user-facing impact, describe how a non-technical QA team can functionally test your changes in a preview environment.

If they are not user-facing please describe how to test for any regressions that may occur.
------------------------------------------------------------------------------>

☝🏽

## Screenshots (if applicable)
