### PR TITLE
feat: tx history assets transfers columns

### DIFF
--- a/src/components/TransactionHistoryRows/TransactionGenericRow.tsx
+++ b/src/components/TransactionHistoryRows/TransactionGenericRow.tsx
@@ -113,13 +113,11 @@ export const TransactionGenericRow = ({
       const typeTxTransfers = (txTransfers ?? []).filter(({ type }) => type === displayTransferType)
       const hasManyTypeTransfers = typeTxTransfers.length > 1
 
-      if (hasManyTypeTransfers) {
-        return (
-          <AssetsTransfers index={index} compactMode={compactMode} transfers={typeTxTransfers} />
-        )
-      }
-
-      return <AssetTransfer index={index} compactMode={compactMode} transfer={transfer} />
+      return hasManyTypeTransfers ? (
+        <AssetsTransfers index={index} compactMode={compactMode} transfers={typeTxTransfers} />
+      ) : (
+        <AssetTransfer index={index} compactMode={compactMode} transfer={transfer} />
+      )
     })
   }, [compactMode, txTransfers, displayTransfers])
 

--- a/src/components/TransactionHistoryRows/TransactionGenericRow.tsx
+++ b/src/components/TransactionHistoryRows/TransactionGenericRow.tsx
@@ -76,8 +76,7 @@ type TransactionGenericRowProps = {
   title?: string
   showDateAndGuide?: boolean
   compactMode?: boolean
-  displayTransfers: Transfer[]
-  txTransfers: Transfer[]
+  transfersByType: Record<TransferType, Transfer[]>
   fee?: Fee
   txid: TxId
   txData?: ReturnType<typeof getTxMetadataWithAssetId>
@@ -90,8 +89,7 @@ type TransactionGenericRowProps = {
 export const TransactionGenericRow = ({
   type,
   title,
-  displayTransfers,
-  txTransfers,
+  transfersByType,
   fee,
   txid,
   txData,
@@ -108,18 +106,16 @@ export const TransactionGenericRow = ({
   } = GetTxLayoutFormats({ parentWidth })
 
   const transfers = useMemo(() => {
-    return displayTransfers.map((transfer, index) => {
-      const displayTransferType = transfer.type
-      const typeTxTransfers = (txTransfers ?? []).filter(({ type }) => type === displayTransferType)
-      const hasManyTypeTransfers = typeTxTransfers.length > 1
+    return Object.entries(transfersByType).map(([, transfersOfType], index) => {
+      const hasManyTypeTransfers = transfersOfType.length > 1
 
       return hasManyTypeTransfers ? (
-        <AssetsTransfers index={index} compactMode={compactMode} transfers={typeTxTransfers} />
+        <AssetsTransfers index={index} compactMode={compactMode} transfers={transfersOfType} />
       ) : (
-        <AssetTransfer index={index} compactMode={compactMode} transfer={transfer} />
+        <AssetTransfer index={index} compactMode={compactMode} transfer={transfersOfType[0]} />
       )
     })
-  }, [compactMode, txTransfers, displayTransfers])
+  }, [compactMode, transfersByType])
 
   const cryptoValue = useMemo(() => {
     if (!fee) return '0'

--- a/src/components/TransactionHistoryRows/TransactionGenericRow.tsx
+++ b/src/components/TransactionHistoryRows/TransactionGenericRow.tsx
@@ -1,37 +1,25 @@
 import { ArrowDownIcon, ArrowUpIcon } from '@chakra-ui/icons'
-import {
-  Box,
-  Button,
-  Circle,
-  Flex,
-  SimpleGrid,
-  Stack,
-  Tag,
-  Text as CText,
-  useColorModeValue,
-} from '@chakra-ui/react'
+import { Box, Button, Flex, SimpleGrid, Stack, Tag } from '@chakra-ui/react'
 import type { AssetId } from '@shapeshiftoss/caip'
 import { TradeType, TransferType } from '@shapeshiftoss/unchained-client'
 import { useMemo } from 'react'
 import { FaArrowRight, FaExchangeAlt, FaStickyNote, FaThumbsUp } from 'react-icons/fa'
 import { Amount } from 'components/Amount/Amount'
-import { AssetIcon } from 'components/AssetIcon'
 import { IconCircle } from 'components/IconCircle'
 import { Text } from 'components/Text'
 import { TransactionLink } from 'components/TransactionHistoryRows/TransactionLink'
 import { TransactionTime } from 'components/TransactionHistoryRows/TransactionTime'
 import type { Fee, Transfer } from 'hooks/useTxDetails/useTxDetails'
 import { Method } from 'hooks/useTxDetails/useTxDetails'
-import { bn, bnOrZero } from 'lib/bignumber/bignumber'
+import { bnOrZero } from 'lib/bignumber/bignumber'
 import { fromBaseUnit } from 'lib/math'
 import type { TxId } from 'state/slices/txHistorySlice/txHistorySlice'
 import { breakpoints } from 'theme/theme'
 
 import { ApproveIcon } from './components/ApproveIcon'
+import { AssetsTransfers } from './components/AssetsTransfers'
+import { AssetTransfer } from './components/AssetTransfer'
 import type { getTxMetadataWithAssetId } from './utils'
-
-const FALLBACK_PRECISION = 18
-const FALLBACK_SYMBOL = 'N/A'
 
 export const GetTxLayoutFormats = ({ parentWidth }: { parentWidth: number }) => {
   const isLargerThanSm = parentWidth > parseInt(breakpoints['sm'], 10)
@@ -99,91 +87,6 @@ type TransactionGenericRowProps = {
   parentWidth: number
 }
 
-type TransferStackProps = {
-  compactMode?: boolean
-  transfer: Transfer
-  index: number
-}
-
-type TransfersStackProps = {
-  compactMode?: boolean
-  transfers: Transfer[]
-  index: number
-}
-
-const TransferStack: React.FC<TransferStackProps> = ({ index, compactMode, transfer }) => {
-  return (
-    <Stack
-      alignItems='center'
-      key={index}
-      flex={1}
-      mt={{ base: 2, md: 0, xl: compactMode ? 2 : 0 }}
-      direction={index === 0 ? 'row' : 'row-reverse'}
-      textAlign={index === 0 ? 'left' : 'right'}
-    >
-      <AssetIcon
-        assetId={transfer.asset?.assetId}
-        boxSize={{ base: '24px', lg: compactMode ? '24px' : '40px' }}
-      />
-      <Box flex={1}>
-        <Amount.Crypto
-          color='inherit'
-          fontWeight='medium'
-          value={fromBaseUnit(transfer.value, transfer.asset?.precision ?? FALLBACK_PRECISION)}
-          symbol={transfer.asset?.symbol ?? FALLBACK_SYMBOL}
-          maximumFractionDigits={4}
-        />
-        {transfer.marketData.price && (
-          <Amount.Fiat
-            color='gray.500'
-            fontSize='sm'
-            lineHeight='1'
-            value={bnOrZero(
-              fromBaseUnit(transfer.value, transfer.asset?.precision ?? FALLBACK_PRECISION),
-            )
-              .times(transfer.marketData.price)
-              .toString()}
-          />
-        )}
-      </Box>
-    </Stack>
-  )
-}
-
-const TransfersStack: React.FC<TransfersStackProps> = ({ index, compactMode, transfers }) => {
-  const circleBgColor = useColorModeValue('white', 'whiteAlpha.100')
-  const circleColor = useColorModeValue('blue.100', 'blue.200')
-  const aggregatedFiatValue = transfers
-    .reduce((acc, transfer) => {
-      if (!transfer) return acc
-      return acc.plus(
-        bnOrZero(
-          fromBaseUnit(transfer.value, transfer.asset?.precision ?? FALLBACK_PRECISION),
-        ).times(transfer.marketData.price),
-      )
-    }, bn(0))
-    .toString()
-
-  return (
-    <Stack
-      alignItems='center'
-      key={index}
-      flex={1}
-      mt={{ base: 2, md: 0, xl: compactMode ? 2 : 0 }}
-      direction={index === 0 ? 'row' : 'row-reverse'}
-      textAlign={index === 0 ? 'left' : 'right'}
-    >
-      <Circle size={8} color={circleColor} borderWidth={2} bg={circleBgColor}>
-        <CText>{transfers.length}</CText>
-      </Circle>
-      <Box flex={1}>
-        <CText fontWeight='bold'>{`${transfers.length} Assets`}</CText>
-        <Amount.Fiat color='gray.500' fontSize='sm' lineHeight='1' value={aggregatedFiatValue} />
-      </Box>
-    </Stack>
-  )
-}
-
 export const TransactionGenericRow = ({
   type,
   title,
@@ -212,11 +115,11 @@ export const TransactionGenericRow = ({
 
       if (hasManyTypeTransfers) {
         return (
-          <TransfersStack index={index} compactMode={compactMode} transfers={typeTxTransfers} />
+          <AssetsTransfers index={index} compactMode={compactMode} transfers={typeTxTransfers} />
         )
       }
 
-      return <TransferStack index={index} compactMode={compactMode} transfer={transfer} />
+      return <AssetTransfer index={index} compactMode={compactMode} transfer={transfer} />
     })
   }, [compactMode, txTransfers, displayTransfers])
 

--- a/src/components/TransactionHistoryRows/TransactionGenericRow.tsx
+++ b/src/components/TransactionHistoryRows/TransactionGenericRow.tsx
@@ -106,7 +106,7 @@ export const TransactionGenericRow = ({
   } = GetTxLayoutFormats({ parentWidth })
 
   const transfers = useMemo(() => {
-    return Object.entries(transfersByType).map(([, transfersOfType], index) => {
+    return Object.values(transfersByType).map((transfersOfType, index) => {
       const hasManyTypeTransfers = transfersOfType.length > 1
 
       return hasManyTypeTransfers ? (

--- a/src/components/TransactionHistoryRows/TransactionMethod.tsx
+++ b/src/components/TransactionHistoryRows/TransactionMethod.tsx
@@ -17,7 +17,7 @@ import { Transfers } from './TransactionDetails/Transfers'
 import { TxGrid } from './TransactionDetails/TxGrid'
 import { TransactionGenericRow } from './TransactionGenericRow'
 import type { TransactionRowProps } from './TransactionRow'
-import { getDisplayTransfers, getTxMetadataWithAssetId } from './utils'
+import { getTransfersByType, getTxMetadataWithAssetId } from './utils'
 
 export const TransactionMethod = ({
   txDetails,
@@ -35,8 +35,8 @@ export const TransactionMethod = ({
     selectAssetById(state, txMetadataWithAssetId?.assetId ?? ''),
   )
 
-  const displayTransfers = useMemo(
-    () => getDisplayTransfers(txDetails.transfers, [TransferType.Send, TransferType.Receive]),
+  const transfersByType = useMemo(
+    () => getTransfersByType(txDetails.transfers, [TransferType.Send, TransferType.Receive]),
     [txDetails.transfers],
   )
 
@@ -87,11 +87,12 @@ export const TransactionMethod = ({
         return Method.Approve
       default: {
         logger.warn(`unhandled method: ${txMetadata.method}`)
-        if (displayTransfers.length === 1) return displayTransfers[0].type // known single direction
+        const transferTypes = Object.keys(transfersByType)
+        if (transferTypes.length === 1) return transferTypes[0] // known single direction
         return ''
       }
     }
-  }, [displayTransfers, txMetadata.method])
+  }, [transfersByType, txMetadata.method])
 
   return (
     <>
@@ -101,8 +102,7 @@ export const TransactionMethod = ({
         compactMode={compactMode}
         title={title}
         blockTime={txDetails.tx.blockTime}
-        displayTransfers={displayTransfers}
-        txTransfers={txDetails.transfers}
+        transfersByType={transfersByType}
         fee={txDetails.fee}
         explorerTxLink={txDetails.explorerTxLink}
         txid={txDetails.tx.txid}

--- a/src/components/TransactionHistoryRows/TransactionMethod.tsx
+++ b/src/components/TransactionHistoryRows/TransactionMethod.tsx
@@ -102,6 +102,7 @@ export const TransactionMethod = ({
         title={title}
         blockTime={txDetails.tx.blockTime}
         displayTransfers={displayTransfers}
+        txTransfers={txDetails.transfers}
         fee={txDetails.fee}
         explorerTxLink={txDetails.explorerTxLink}
         txid={txDetails.tx.txid}

--- a/src/components/TransactionHistoryRows/TransactionReceive.tsx
+++ b/src/components/TransactionHistoryRows/TransactionReceive.tsx
@@ -10,7 +10,7 @@ import { Transfers } from './TransactionDetails/Transfers'
 import { TxGrid } from './TransactionDetails/TxGrid'
 import { TransactionGenericRow } from './TransactionGenericRow'
 import type { TransactionRowProps } from './TransactionRow'
-import { getDisplayTransfers } from './utils'
+import { getTransfersByType } from './utils'
 
 export const TransactionReceive = ({
   txDetails,
@@ -20,8 +20,8 @@ export const TransactionReceive = ({
   isOpen,
   parentWidth,
 }: TransactionRowProps) => {
-  const displayTransfers = useMemo(
-    () => getDisplayTransfers(txDetails.transfers, [TransferType.Receive]),
+  const transfersByType = useMemo(
+    () => getTransfersByType(txDetails.transfers, [TransferType.Receive]),
     [txDetails.transfers],
   )
 
@@ -32,8 +32,7 @@ export const TransactionReceive = ({
         toggleOpen={toggleOpen}
         compactMode={compactMode}
         blockTime={txDetails.tx.blockTime}
-        displayTransfers={displayTransfers}
-        txTransfers={txDetails.transfers}
+        transfersByType={transfersByType}
         fee={txDetails.fee}
         explorerTxLink={txDetails.explorerTxLink}
         txid={txDetails.tx.txid}

--- a/src/components/TransactionHistoryRows/TransactionReceive.tsx
+++ b/src/components/TransactionHistoryRows/TransactionReceive.tsx
@@ -10,7 +10,7 @@ import { Transfers } from './TransactionDetails/Transfers'
 import { TxGrid } from './TransactionDetails/TxGrid'
 import { TransactionGenericRow } from './TransactionGenericRow'
 import type { TransactionRowProps } from './TransactionRow'
-import { getDisplayTransfers } from './utils'
+import { getDisplayTransfers, getPairDisplayTransfers } from './utils'
 
 export const TransactionReceive = ({
   txDetails,

--- a/src/components/TransactionHistoryRows/TransactionReceive.tsx
+++ b/src/components/TransactionHistoryRows/TransactionReceive.tsx
@@ -10,7 +10,7 @@ import { Transfers } from './TransactionDetails/Transfers'
 import { TxGrid } from './TransactionDetails/TxGrid'
 import { TransactionGenericRow } from './TransactionGenericRow'
 import type { TransactionRowProps } from './TransactionRow'
-import { getDisplayTransfers, getPairDisplayTransfers } from './utils'
+import { getDisplayTransfers } from './utils'
 
 export const TransactionReceive = ({
   txDetails,
@@ -33,6 +33,7 @@ export const TransactionReceive = ({
         compactMode={compactMode}
         blockTime={txDetails.tx.blockTime}
         displayTransfers={displayTransfers}
+        txTransfers={txDetails.transfers}
         fee={txDetails.fee}
         explorerTxLink={txDetails.explorerTxLink}
         txid={txDetails.tx.txid}

--- a/src/components/TransactionHistoryRows/TransactionSend.tsx
+++ b/src/components/TransactionHistoryRows/TransactionSend.tsx
@@ -33,6 +33,7 @@ export const TransactionSend = ({
         compactMode={compactMode}
         blockTime={txDetails.tx.blockTime}
         displayTransfers={displayTransfers}
+        txTransfers={txDetails.transfers}
         fee={txDetails.fee}
         explorerTxLink={txDetails.explorerTxLink}
         txid={txDetails.tx.txid}

--- a/src/components/TransactionHistoryRows/TransactionSend.tsx
+++ b/src/components/TransactionHistoryRows/TransactionSend.tsx
@@ -10,7 +10,7 @@ import { Transfers } from './TransactionDetails/Transfers'
 import { TxGrid } from './TransactionDetails/TxGrid'
 import { TransactionGenericRow } from './TransactionGenericRow'
 import type { TransactionRowProps } from './TransactionRow'
-import { getDisplayTransfers } from './utils'
+import { getTransfersByType } from './utils'
 
 export const TransactionSend = ({
   txDetails,
@@ -20,8 +20,8 @@ export const TransactionSend = ({
   toggleOpen,
   parentWidth,
 }: TransactionRowProps) => {
-  const displayTransfers = useMemo(
-    () => getDisplayTransfers(txDetails.transfers, [TransferType.Send]),
+  const transfersByType = useMemo(
+    () => getTransfersByType(txDetails.transfers, [TransferType.Send]),
     [txDetails.transfers],
   )
 
@@ -32,8 +32,7 @@ export const TransactionSend = ({
         toggleOpen={toggleOpen}
         compactMode={compactMode}
         blockTime={txDetails.tx.blockTime}
-        displayTransfers={displayTransfers}
-        txTransfers={txDetails.transfers}
+        transfersByType={transfersByType}
         fee={txDetails.fee}
         explorerTxLink={txDetails.explorerTxLink}
         txid={txDetails.tx.txid}

--- a/src/components/TransactionHistoryRows/TransactionTrade.tsx
+++ b/src/components/TransactionHistoryRows/TransactionTrade.tsx
@@ -13,7 +13,7 @@ import { Transfers } from './TransactionDetails/Transfers'
 import { TxGrid } from './TransactionDetails/TxGrid'
 import { TransactionGenericRow } from './TransactionGenericRow'
 import type { TransactionRowProps } from './TransactionRow'
-import { getDisplayTransfers } from './utils'
+import { getTransfersByType } from './utils'
 
 export const TransactionTrade = ({
   txDetails,
@@ -26,8 +26,8 @@ export const TransactionTrade = ({
   const tradeFeeInput = useMemo(() => ({ txDetails }), [txDetails])
   const { tradeFees } = useTradeFees({ txDetails: tradeFeeInput.txDetails })
 
-  const displayTransfers = useMemo(
-    () => getDisplayTransfers(txDetails.transfers, [TransferType.Send, TransferType.Receive]),
+  const transfersByType = useMemo(
+    () => getTransfersByType(txDetails.transfers, [TransferType.Send, TransferType.Receive]),
     [txDetails.transfers],
   )
 
@@ -38,8 +38,7 @@ export const TransactionTrade = ({
         toggleOpen={toggleOpen}
         compactMode={compactMode}
         blockTime={txDetails.tx.blockTime}
-        displayTransfers={displayTransfers}
-        txTransfers={txDetails.transfers}
+        transfersByType={transfersByType}
         fee={txDetails.fee}
         explorerTxLink={txDetails.explorerTxLink}
         txid={txDetails.tx.txid}

--- a/src/components/TransactionHistoryRows/TransactionTrade.tsx
+++ b/src/components/TransactionHistoryRows/TransactionTrade.tsx
@@ -39,6 +39,7 @@ export const TransactionTrade = ({
         compactMode={compactMode}
         blockTime={txDetails.tx.blockTime}
         displayTransfers={displayTransfers}
+        txTransfers={txDetails.transfers}
         fee={txDetails.fee}
         explorerTxLink={txDetails.explorerTxLink}
         txid={txDetails.tx.txid}

--- a/src/components/TransactionHistoryRows/UnknownTransaction.tsx
+++ b/src/components/TransactionHistoryRows/UnknownTransaction.tsx
@@ -11,7 +11,7 @@ import { Transfers } from './TransactionDetails/Transfers'
 import { TxGrid } from './TransactionDetails/TxGrid'
 import { TransactionGenericRow } from './TransactionGenericRow'
 import type { TransactionRowProps } from './TransactionRow'
-import { getDisplayTransfers } from './utils'
+import { getTransfersByType } from './utils'
 
 export const UnknownTransaction = ({
   txDetails,
@@ -21,8 +21,8 @@ export const UnknownTransaction = ({
   toggleOpen,
   parentWidth,
 }: TransactionRowProps) => {
-  const displayTransfers = useMemo(
-    () => getDisplayTransfers(txDetails.transfers, [TransferType.Send, TransferType.Receive]),
+  const transfersByType = useMemo(
+    () => getTransfersByType(txDetails.transfers, [TransferType.Send, TransferType.Receive]),
     [txDetails.transfers],
   )
 
@@ -34,8 +34,7 @@ export const UnknownTransaction = ({
         compactMode={compactMode}
         title='transactionRow.unknown'
         blockTime={txDetails.tx.blockTime}
-        displayTransfers={displayTransfers}
-        txTransfers={txDetails.transfers}
+        transfersByType={transfersByType}
         fee={txDetails.fee}
         explorerTxLink={txDetails.explorerTxLink}
         txid={txDetails.tx.txid}

--- a/src/components/TransactionHistoryRows/UnknownTransaction.tsx
+++ b/src/components/TransactionHistoryRows/UnknownTransaction.tsx
@@ -35,6 +35,7 @@ export const UnknownTransaction = ({
         title='transactionRow.unknown'
         blockTime={txDetails.tx.blockTime}
         displayTransfers={displayTransfers}
+        txTransfers={txDetails.transfers}
         fee={txDetails.fee}
         explorerTxLink={txDetails.explorerTxLink}
         txid={txDetails.tx.txid}

--- a/src/components/TransactionHistoryRows/components/AssetTransfer.tsx
+++ b/src/components/TransactionHistoryRows/components/AssetTransfer.tsx
@@ -1,8 +1,9 @@
 import { Box, Stack } from '@chakra-ui/react'
-import { bnOrZero } from '@shapeshiftoss/investor-yearn'
+import { useMemo } from 'react'
 import { Amount } from 'components/Amount/Amount'
 import { AssetIcon } from 'components/AssetIcon'
 import type { Transfer } from 'hooks/useTxDetails/useTxDetails'
+import { bnOrZero } from 'lib/bignumber/bignumber'
 import { fromBaseUnit } from 'lib/math'
 
 import { FALLBACK_PRECISION, FALLBACK_SYMBOL } from '../constants'
@@ -13,39 +14,40 @@ type AssetTransferProps = {
   index: number
 }
 
-export const AssetTransfer: React.FC<AssetTransferProps> = ({ index, compactMode, transfer }) => (
-  <Stack
-    alignItems='center'
-    key={index}
-    flex={1}
-    mt={{ base: 2, md: 0, xl: compactMode ? 2 : 0 }}
-    direction={index === 0 ? 'row' : 'row-reverse'}
-    textAlign={index === 0 ? 'left' : 'right'}
-  >
-    <AssetIcon
-      assetId={transfer.asset?.assetId}
-      boxSize={{ base: '24px', lg: compactMode ? '24px' : '40px' }}
-    />
-    <Box flex={1}>
-      <Amount.Crypto
-        color='inherit'
-        fontWeight='medium'
-        value={fromBaseUnit(transfer.value, transfer.asset?.precision ?? FALLBACK_PRECISION)}
-        symbol={transfer.asset?.symbol ?? FALLBACK_SYMBOL}
-        maximumFractionDigits={4}
+export const AssetTransfer: React.FC<AssetTransferProps> = ({ index, compactMode, transfer }) => {
+  const cryptoAmount = useMemo(() => {
+    const precision = transfer.asset?.precision ?? FALLBACK_PRECISION
+    return fromBaseUnit(transfer.value, precision)
+  }, [transfer.asset?.precision, transfer.value])
+  const fiatAmount = useMemo(
+    () => bnOrZero(cryptoAmount).times(transfer.marketData.price).toString(),
+    [cryptoAmount, transfer.marketData.price],
+  )
+  return (
+    <Stack
+      alignItems='center'
+      key={index}
+      flex={1}
+      mt={{ base: 2, md: 0, xl: compactMode ? 2 : 0 }}
+      direction={index === 0 ? 'row' : 'row-reverse'}
+      textAlign={index === 0 ? 'left' : 'right'}
+    >
+      <AssetIcon
+        assetId={transfer.asset?.assetId}
+        boxSize={{ base: '24px', lg: compactMode ? '24px' : '40px' }}
       />
-      {transfer.marketData.price && (
-        <Amount.Fiat
-          color='gray.500'
-          fontSize='sm'
-          lineHeight='1'
-          value={bnOrZero(
-            fromBaseUnit(transfer.value, transfer.asset?.precision ?? FALLBACK_PRECISION),
-          )
-            .times(transfer.marketData.price)
-            .toString()}
+      <Box flex={1}>
+        <Amount.Crypto
+          color='inherit'
+          fontWeight='medium'
+          value={cryptoAmount}
+          symbol={transfer.asset?.symbol ?? FALLBACK_SYMBOL}
+          maximumFractionDigits={4}
         />
-      )}
-    </Box>
-  </Stack>
-)
+        {transfer.marketData.price && (
+          <Amount.Fiat color='gray.500' fontSize='sm' lineHeight='1' value={fiatAmount} />
+        )}
+      </Box>
+    </Stack>
+  )
+}

--- a/src/components/TransactionHistoryRows/components/AssetTransfer.tsx
+++ b/src/components/TransactionHistoryRows/components/AssetTransfer.tsx
@@ -1,0 +1,51 @@
+import { Box, Stack } from '@chakra-ui/react'
+import { bnOrZero } from '@shapeshiftoss/investor-yearn'
+import { Amount } from 'components/Amount/Amount'
+import { AssetIcon } from 'components/AssetIcon'
+import type { Transfer } from 'hooks/useTxDetails/useTxDetails'
+import { fromBaseUnit } from 'lib/math'
+
+import { FALLBACK_PRECISION, FALLBACK_SYMBOL } from '../constants'
+
+type AssetTransferProps = {
+  compactMode?: boolean
+  transfer: Transfer
+  index: number
+}
+
+export const AssetTransfer: React.FC<AssetTransferProps> = ({ index, compactMode, transfer }) => (
+  <Stack
+    alignItems='center'
+    key={index}
+    flex={1}
+    mt={{ base: 2, md: 0, xl: compactMode ? 2 : 0 }}
+    direction={index === 0 ? 'row' : 'row-reverse'}
+    textAlign={index === 0 ? 'left' : 'right'}
+  >
+    <AssetIcon
+      assetId={transfer.asset?.assetId}
+      boxSize={{ base: '24px', lg: compactMode ? '24px' : '40px' }}
+    />
+    <Box flex={1}>
+      <Amount.Crypto
+        color='inherit'
+        fontWeight='medium'
+        value={fromBaseUnit(transfer.value, transfer.asset?.precision ?? FALLBACK_PRECISION)}
+        symbol={transfer.asset?.symbol ?? FALLBACK_SYMBOL}
+        maximumFractionDigits={4}
+      />
+      {transfer.marketData.price && (
+        <Amount.Fiat
+          color='gray.500'
+          fontSize='sm'
+          lineHeight='1'
+          value={bnOrZero(
+            fromBaseUnit(transfer.value, transfer.asset?.precision ?? FALLBACK_PRECISION),
+          )
+            .times(transfer.marketData.price)
+            .toString()}
+        />
+      )}
+    </Box>
+  </Stack>
+)

--- a/src/components/TransactionHistoryRows/components/AssetTransfer.tsx
+++ b/src/components/TransactionHistoryRows/components/AssetTransfer.tsx
@@ -23,10 +23,15 @@ export const AssetTransfer: React.FC<AssetTransferProps> = ({ index, compactMode
     () => bnOrZero(cryptoAmount).times(transfer.marketData.price).toString(),
     [cryptoAmount, transfer.marketData.price],
   )
+  const key = useMemo(
+    () => `${transfer.type}*${transfer.assetId}*${transfer.value}`,
+    [transfer.type, transfer.assetId, transfer.value],
+  )
+
   return (
     <Stack
       alignItems='center'
-      key={index}
+      key={key}
       flex={1}
       mt={{ base: 2, md: 0, xl: compactMode ? 2 : 0 }}
       direction={index === 0 ? 'row' : 'row-reverse'}

--- a/src/components/TransactionHistoryRows/components/AssetsTransfers.tsx
+++ b/src/components/TransactionHistoryRows/components/AssetsTransfers.tsx
@@ -39,7 +39,11 @@ export const AssetsTransfers: React.FC<AssetsTransfersProps> = ({
       direction={index === 0 ? 'row' : 'row-reverse'}
       textAlign={index === 0 ? 'left' : 'right'}
     >
-      <Circle size={8} color={circleColor} bg={circleBgColor}>
+      <Circle
+        boxSize={{ base: '24px', lg: compactMode ? '24px' : '40px' }}
+        color={circleColor}
+        bg={circleBgColor}
+      >
         <CText>{transfers.length}</CText>
       </Circle>
       <Box flex={1}>

--- a/src/components/TransactionHistoryRows/components/AssetsTransfers.tsx
+++ b/src/components/TransactionHistoryRows/components/AssetsTransfers.tsx
@@ -1,0 +1,51 @@
+import { Box, Circle, Stack, Text as CText, useColorModeValue } from '@chakra-ui/react'
+import { Amount } from 'components/Amount/Amount'
+import type { Transfer } from 'hooks/useTxDetails/useTxDetails'
+import { bn, bnOrZero } from 'lib/bignumber/bignumber'
+import { fromBaseUnit } from 'lib/math'
+
+import { FALLBACK_PRECISION } from '../constants'
+
+type AssetsTransfersProps = {
+  compactMode?: boolean
+  transfers: Transfer[]
+  index: number
+}
+
+export const AssetsTransfers: React.FC<AssetsTransfersProps> = ({
+  index,
+  compactMode,
+  transfers,
+}) => {
+  const circleBgColor = '#333d59' // TODO: can we reuse the Button.theme here?
+  const circleColor = useColorModeValue('blue.100', 'blue.200')
+  const aggregatedFiatValue = transfers
+    .reduce((acc, transfer) => {
+      if (!transfer) return acc
+      return acc.plus(
+        bnOrZero(
+          fromBaseUnit(transfer.value, transfer.asset?.precision ?? FALLBACK_PRECISION),
+        ).times(transfer.marketData.price),
+      )
+    }, bn(0))
+    .toString()
+
+  return (
+    <Stack
+      alignItems='center'
+      key={index}
+      flex={1}
+      mt={{ base: 2, md: 0, xl: compactMode ? 2 : 0 }}
+      direction={index === 0 ? 'row' : 'row-reverse'}
+      textAlign={index === 0 ? 'left' : 'right'}
+    >
+      <Circle size={8} color={circleColor} bg={circleBgColor}>
+        <CText>{transfers.length}</CText>
+      </Circle>
+      <Box flex={1}>
+        <CText fontWeight='bold'>{`${transfers.length} Assets`}</CText>
+        <Amount.Fiat color='gray.500' fontSize='sm' lineHeight='1' value={aggregatedFiatValue} />
+      </Box>
+    </Stack>
+  )
+}

--- a/src/components/TransactionHistoryRows/components/AssetsTransfers.tsx
+++ b/src/components/TransactionHistoryRows/components/AssetsTransfers.tsx
@@ -1,5 +1,6 @@
-import { Box, Circle, Stack, Text as CText, useColorModeValue } from '@chakra-ui/react'
+import { Box, Circle, Stack, Text as CText } from '@chakra-ui/react'
 import { Amount } from 'components/Amount/Amount'
+import { useButtonStyles } from 'hooks/useButtonStyles/useButtonStyles'
 import type { Transfer } from 'hooks/useTxDetails/useTxDetails'
 import { bn, bnOrZero } from 'lib/bignumber/bignumber'
 import { fromBaseUnit } from 'lib/math'
@@ -17,8 +18,11 @@ export const AssetsTransfers: React.FC<AssetsTransfersProps> = ({
   compactMode,
   transfers,
 }) => {
-  const circleBgColor = '#333d59' // TODO: can we reuse the Button.theme here?
-  const circleColor = useColorModeValue('blue.100', 'blue.200')
+  const { bg: circleBgColor, color: circleColor } = useButtonStyles({
+    colorScheme: 'blue',
+    variant: 'ghost-filled',
+  })
+
   const aggregatedFiatValue = transfers
     .reduce((acc, transfer) => {
       if (!transfer) return acc

--- a/src/components/TransactionHistoryRows/components/AssetsTransfers.tsx
+++ b/src/components/TransactionHistoryRows/components/AssetsTransfers.tsx
@@ -24,17 +24,15 @@ export const AssetsTransfers: React.FC<AssetsTransfersProps> = ({
     variant: 'ghost-filled',
   })
 
-  const aggregatedFiatValue = useMemo(
-    () =>
-      transfers
-        .reduce((acc, transfer) => {
-          const precision = transfer.asset?.precision ?? FALLBACK_PRECISION
-          const cryptoValue = fromBaseUnit(transfer.value, precision)
-          return acc.plus(bnOrZero(cryptoValue).times(transfer.marketData.price))
-        }, bn(0))
-        .toString(),
-    [transfers],
-  )
+  const aggregatedFiatValue = useMemo(() => {
+    const fiatValue = transfers.reduce((acc, transfer) => {
+      const precision = transfer.asset?.precision ?? FALLBACK_PRECISION
+      const cryptoValue = fromBaseUnit(transfer.value, precision)
+      return acc.plus(bnOrZero(cryptoValue).times(transfer.marketData.price))
+    }, bn(0))
+
+    return fiatValue.toString()
+  }, [transfers])
 
   return (
     <Stack

--- a/src/components/TransactionHistoryRows/components/AssetsTransfers.tsx
+++ b/src/components/TransactionHistoryRows/components/AssetsTransfers.tsx
@@ -40,6 +40,7 @@ export const AssetsTransfers: React.FC<AssetsTransfersProps> = ({
       textAlign={index === 0 ? 'left' : 'right'}
     >
       <Circle
+        // @ts-ignore boxSize is a valid prop for <Circle />
         boxSize={{ base: '24px', lg: compactMode ? '24px' : '40px' }}
         color={circleColor}
         bg={circleBgColor}

--- a/src/components/TransactionHistoryRows/components/AssetsTransfers.tsx
+++ b/src/components/TransactionHistoryRows/components/AssetsTransfers.tsx
@@ -1,4 +1,5 @@
 import { Box, Circle, Stack, Text as CText } from '@chakra-ui/react'
+import { useMemo } from 'react'
 import { Amount } from 'components/Amount/Amount'
 import { useButtonStyles } from 'hooks/useButtonStyles/useButtonStyles'
 import type { Transfer } from 'hooks/useTxDetails/useTxDetails'
@@ -23,17 +24,17 @@ export const AssetsTransfers: React.FC<AssetsTransfersProps> = ({
     variant: 'ghost-filled',
   })
 
-  const aggregatedFiatValue = transfers
-    .reduce(
-      (acc, transfer) =>
-        acc.plus(
-          bnOrZero(
-            fromBaseUnit(transfer.value, transfer.asset?.precision ?? FALLBACK_PRECISION),
-          ).times(transfer.marketData.price),
-        ),
-      bn(0),
-    )
-    .toString()
+  const aggregatedFiatValue = useMemo(
+    () =>
+      transfers
+        .reduce((acc, transfer) => {
+          const precision = transfer.asset?.precision ?? FALLBACK_PRECISION
+          const cryptoValue = fromBaseUnit(transfer.value, precision)
+          return acc.plus(bnOrZero(cryptoValue).times(transfer.marketData.price))
+        }, bn(0))
+        .toString(),
+    [transfers],
+  )
 
   return (
     <Stack

--- a/src/components/TransactionHistoryRows/components/AssetsTransfers.tsx
+++ b/src/components/TransactionHistoryRows/components/AssetsTransfers.tsx
@@ -24,14 +24,15 @@ export const AssetsTransfers: React.FC<AssetsTransfersProps> = ({
   })
 
   const aggregatedFiatValue = transfers
-    .reduce((acc, transfer) => {
-      if (!transfer) return acc
-      return acc.plus(
-        bnOrZero(
-          fromBaseUnit(transfer.value, transfer.asset?.precision ?? FALLBACK_PRECISION),
-        ).times(transfer.marketData.price),
-      )
-    }, bn(0))
+    .reduce(
+      (acc, transfer) =>
+        acc.plus(
+          bnOrZero(
+            fromBaseUnit(transfer.value, transfer.asset?.precision ?? FALLBACK_PRECISION),
+          ).times(transfer.marketData.price),
+        ),
+      bn(0),
+    )
     .toString()
 
   return (

--- a/src/components/TransactionHistoryRows/constants.tsx
+++ b/src/components/TransactionHistoryRows/constants.tsx
@@ -1,0 +1,2 @@
+export const FALLBACK_PRECISION = 18
+export const FALLBACK_SYMBOL = 'N/A'

--- a/src/components/TransactionHistoryRows/utils.ts
+++ b/src/components/TransactionHistoryRows/utils.ts
@@ -12,14 +12,16 @@ export const getTxMetadataWithAssetId = (txMetadata?: TxMetadata) => {
   if (txMetadata && 'assetId' in txMetadata) return txMetadata
 }
 
-export const getDisplayTransfers = (transfers: Transfer[], types: TransferType[]): Transfer[] => {
-  return types.reduce<Transfer[]>((prev, type) => {
-    const transfer = transfers.find(t => t.type === type)
-    if (!transfer) return prev
-    prev.push(transfer)
+export const getTransfersByType = (
+  transfers: Transfer[],
+  types: TransferType[],
+): Record<TransferType, Transfer[]> =>
+  types.reduce((prev, type) => {
+    const transfersOfType = transfers.filter(t => t.type === type)
+    if (!transfersOfType.length) return prev
+    prev[type] = [...(prev[type] ?? []), ...transfersOfType]
     return prev
-  }, [])
-}
+  }, {} as Record<TransferType, Transfer[]>)
 
 type GetTradeFeesInput = {
   buy: Transfer

--- a/src/components/TransactionHistoryRows/utils.ts
+++ b/src/components/TransactionHistoryRows/utils.ts
@@ -17,9 +17,9 @@ export const getTransfersByType = (
   types: TransferType[],
 ): Record<TransferType, Transfer[]> =>
   types.reduce((prev, type) => {
-    const transfersOfType = transfers.filter(t => t.type === type)
-    if (!transfersOfType.length) return prev
-    prev[type] = [...(prev[type] ?? []), ...transfersOfType]
+    const transfersByType = transfers.filter(t => t.type === type)
+    if (!transfersByType.length) return prev
+    prev[type] = transfersByType
     return prev
   }, {} as Record<TransferType, Transfer[]>)
 


### PR DESCRIPTION
## Description

This PR brings support for multiple inbound / outbound assets transfers as a `<transfersAmount> transfers` column in Tx history. 

## Notice

<!-- Before submitting a pull request, please make sure you have answered the following: -->

- [x] Have you followed the guidelines in our [Contributing]('https://github.com/shapeshift/web/blob/develop/CONTRIBUTING.md) guide?
- [x] Have you checked to ensure there aren't other open [Pull Requests](https://github.com/shapeshift/web/pulls) for the same update/change?

## Pull Request Type

- [ ] :bug: Bug fix (Non-breaking Change: Fixes an issue)
- [ ] :hammer_and_wrench: Chore (Non-breaking Change: Doc updates, pkg upgrades, typos, etc..)
- [x] :nail_care: New Feature (Breaking/Non-breaking Change)

## Issue (if applicable)

<!-----------------------------------------------------------------------------
If applicable, please link to the github issue and put `closes #XXXX` in your comment to auto-close the issue that your PR fixes.
------------------------------------------------------------------------------>

closes https://github.com/shapeshift/web/issues/2428

## Risk

<!-----------------------------------------------------------------------------
Outline the scope of your changes and the risk associated with them. You must use your discretion as an engineer to determine the potential impact of your changes.

E.g. an upgrade to `hdwallet` or core state management would be considered higher risk, and might require a full regression test. UI or isolated view changes, or something behind a feature flag may have near zero risk. Small bug fixes might require testing isolated to the specific fix.
------------------------------------------------------------------------------>

We could wrongly parse Txs with a single transfer in/out as a many transfers Tx (see screenshot), and vice versa, which would indicate issues with unchained-client parsing

## Testing

<!-----------------------------------------------------------------------------
We treat every PR to be merged with the same scrutiny as if we were merging directly to production.

Your PR will not be merged if you do not complete the sections below for our engineering and operations teams to test.
------------------------------------------------------------------------------>

- Txs with a single inbound/outbound asset transfer should still be parsed as before
- Txs with multiple assets' transfers either inbound or outbound, should show `<x assets>` where x is the number of assets in the transfer type (send/receive), and the total fiat amount for said assets' value

### Engineering

<!-----------------------------------------------------------------------------
Include sufficient information here for an engineer to test your PR. This may include how to test locally, in a built environment, changes to infrastructure etc.
------------------------------------------------------------------------------>

- Implementation looks sane

### Operations

<!-----------------------------------------------------------------------------
If your changes have a user-facing impact, describe how a non-technical QA team can functionally test your changes in a preview environment.

- ☝🏽 
If they are not user-facing please describe how to test for any regressions that may occur.
------------------------------------------------------------------------------>

## Screenshots (if applicable)

<img width="1111" alt="image" src="https://user-images.githubusercontent.com/17035424/197350760-6534f462-9cbc-472e-8356-82326c39a988.png">

<img width="669" alt="image" src="https://user-images.githubusercontent.com/17035424/197350725-69b8a9ee-9362-4267-b3bb-85462dc52bee.png">
