### PR TITLE
fix: show the fee crypto amount and send amount

### DIFF
--- a/src/components/Modals/Send/views/Confirm.tsx
+++ b/src/components/Modals/Send/views/Confirm.tsx
@@ -27,6 +27,8 @@ import { SlideTransition } from 'components/SlideTransition'
 import { RawText, Text } from 'components/Text'
 import { useFeatureFlag } from 'hooks/useFeatureFlag/useFeatureFlag'
 import { bnOrZero } from 'lib/bignumber/bignumber'
+import { selectFeeAssetById } from 'state/slices/selectors'
+import { useAppSelector } from 'state/store'
 
 import type { SendInput } from '../Form'
 import { useSendFees } from '../hooks/useSendFees/useSendFees'
@@ -63,6 +65,7 @@ export const Confirm = () => {
   const { fees } = useSendFees()
   const isMultiAccountsEnabled = useFeatureFlag('MultiAccounts')
 
+  const feeAsset = useAppSelector(state => selectFeeAssetById(state, asset?.assetId ?? ''))
   const showMemoRow = useMemo(
     () => Boolean(asset && fromAssetId(asset.assetId).chainNamespace === CHAIN_NAMESPACE.CosmosSdk),
     [asset],
@@ -72,6 +75,11 @@ export const Confirm = () => {
     const { fiatFee } = fees ? fees[feeType as FeeDataKey] : { fiatFee: 0 }
     return bnOrZero(fiatAmount).plus(fiatFee).toString()
   }, [fiatAmount, fees, feeType])
+
+  const cryptoAmountFee = useMemo(() => {
+    const { txFee } = fees ? fees[feeType as FeeDataKey] : { txFee: 0 }
+    return txFee.toString()
+  }, [fees, feeType])
 
   const borderColor = useColorModeValue('gray.100', 'gray.750')
 
@@ -160,28 +168,34 @@ export const Confirm = () => {
         </Stack>
       </ModalBody>
       <ModalFooter flexDirection='column' borderTopWidth={1} borderColor={borderColor}>
-        <Row>
-          <Box>
+        <Row gap={2}>
+          <Box flex={1}>
             <Row.Label color='inherit' fontWeight='bold'>
               <Text translation='modals.send.confirm.total' />
             </Row.Label>
-            <Row.Label flexDirection='row' display='flex'>
+            <Row.Label
+              flexDirection='row'
+              display='flex'
+              flexWrap='wrap'
+              justifyContent='flex-start'
+            >
               <Text translation='modals.send.confirm.amount' />
               <RawText mx={1}>+</RawText>
               <Text translation='modals.send.confirm.transactionFee' />
             </Row.Label>
           </Box>
-          <Box textAlign='right'>
-            <Row.Value>
+          <Box textAlign='right' flex={1}>
+            <Row.Value flex={1}>
+              <Amount.Fiat value={amountWithFees} fontWeight='bold' />
+            </Row.Value>
+            <Row.Label display='flex' gap={1} flexWrap='wrap' justifyContent='flex-end'>
               <Amount.Crypto
                 textTransform='uppercase'
                 maximumFractionDigits={6}
                 symbol={cryptoSymbol}
                 value={cryptoAmount}
               />
-            </Row.Value>
-            <Row.Label>
-              <Amount.Fiat value={amountWithFees} />
+              <Amount.Crypto prefix='+' value={cryptoAmountFee} symbol={feeAsset.symbol} />
             </Row.Label>
           </Box>
         </Row>


### PR DESCRIPTION
## Description

- On the send modal confirm, we should show the breakdown of the fee (Amount + Fee Amount)

## Notice

<!-- Before submitting a pull request, please make sure you have answered the following: -->

- [x] Have you followed the guidelines in our [Contributing]('https://github.com/shapeshift/web/blob/develop/CONTRIBUTING.md) guide?
- [x] Have you checked to ensure there aren't other open [Pull Requests](https://github.com/shapeshift/web/pulls) for the same update/change?

## Pull Request Type

- [x] :bug: Bug fix (Non-breaking Change: Fixes an issue)
- [ ] :hammer_and_wrench: Chore (Non-breaking Change: Doc updates, pkg upgrades, typos, etc..)
- [ ] :nail_care: New Feature (Breaking/Non-breaking Change)

## Issue (if applicable)

no issue

## Risk

small risk

## Testing

<!-----------------------------------------------------------------------------
We treat every PR to be merged with the same scrutiny as if we were merging directly to production.

Your PR will not be merged if you do not complete the sections below for our engineering and operations teams to test.
------------------------------------------------------------------------------>

### Engineering

<!-----------------------------------------------------------------------------
Include sufficient information here for an engineer to test your PR. This may include how to test locally, in a built environment, changes to infrastructure etc.
------------------------------------------------------------------------------>

### Operations

Go to send, and on the confirm step you should see the Amount you are sending and the fee amount. With the combined total amount on top.

## Screenshot
![Screen_Shot_2022-10-26_at_3 38 03_PM](https://user-images.githubusercontent.com/89934888/198133114-79aaa9bd-a6af-4298-a5aa-a159d82e626c.png)
s (if applicable)

