### PR TITLE
feat: rename MaxButtonGroup -> PercentOptionsButtonGroup

### DIFF
--- a/src/components/DeFi/components/AssetInput.tsx
+++ b/src/components/DeFi/components/AssetInput.tsx
@@ -29,7 +29,7 @@ import { colors } from 'theme/colors'
 import type { Nullable } from 'types/common'
 
 import { Balance } from './Balance'
-import { MaxButtonGroup } from './MaxButtonGroup'
+import { PercentOptionsButtonGroup } from './PercentOptionsButtonGroup'
 
 const CryptoInput = (props: InputProps) => (
   <Input
@@ -206,7 +206,7 @@ export const AssetInput: React.FC<AssetInputProps> = ({
             />
           )}
           {onMaxClick && (
-            <MaxButtonGroup
+            <PercentOptionsButtonGroup
               options={percentOptions}
               isDisabled={isReadOnly || isSendMaxDisabled}
               onClick={onMaxClick}

--- a/src/components/DeFi/components/PercentOptionsButtonGroup.tsx
+++ b/src/components/DeFi/components/PercentOptionsButtonGroup.tsx
@@ -1,19 +1,28 @@
 import { Button, ButtonGroup } from '@chakra-ui/react'
+import { useCallback } from 'react'
 import { Amount } from 'components/Amount/Amount'
 
 type MaxButtonGroupProps = {
+  isDisabled?: boolean
+  onClick: (args: number) => void
+  onMaxClick?: () => Promise<void>
   options: number[]
   value?: number | null
-  onClick: (args: number) => void
-  isDisabled?: boolean
 }
 
-export const MaxButtonGroup: React.FC<MaxButtonGroupProps> = ({
+export const PercentOptionsButtonGroup: React.FC<MaxButtonGroupProps> = ({
+  isDisabled,
+  onClick,
+  onMaxClick,
   options,
   value,
-  onClick,
-  isDisabled,
 }) => {
+  const handleClick = useCallback(
+    async (option: number) => {
+      onMaxClick && option === 1 ? await onMaxClick() : onClick(option)
+    },
+    [onClick, onMaxClick],
+  )
   return (
     <ButtonGroup justifyContent='flex-end' size='xs'>
       {options.map(option => (
@@ -21,7 +30,7 @@ export const MaxButtonGroup: React.FC<MaxButtonGroupProps> = ({
           isDisabled={isDisabled}
           isActive={option === value}
           key={option}
-          onClick={() => onClick(option)}
+          onClick={() => handleClick(option)}
         >
           {option === 1 ? (
             'Max'


### PR DESCRIPTION
## Description

<!-- Please describe your changes -->

Makes things more intelligible for the following-up stacked PRs.
Mostly a rename to match what this component actually is, although this bring two actual changes:

- a new optional `onMaxClick` prop to be passed down
- consumption of said prop - the regular percent buttons onClick will be used if `onMaxClick` is not defined so this won't bring any runtime changes for now.


<!-- Before submitting a pull request, please make sure you have answered the following: -->

- [x] Have you followed the guidelines in our [Contributing]('https://github.com/shapeshift/web/blob/develop/CONTRIBUTING.md) guide?
- [x] Have you checked to ensure there aren't other open [Pull Requests](https://github.com/shapeshift/web/pulls) for the same update/change?

## Pull Request Type

- [ ] :bug: Bug fix (Non-breaking Change: Fixes an issue)
- [ ] :hammer_and_wrench: Chore (Non-breaking Change: Doc updates, pkg upgrades, typos, etc..)
- [x] :nail_care: New Feature (Breaking/Non-breaking Change)

## Issue (if applicable)

<!-----------------------------------------------------------------------------
If applicable, please link to the github issue and put `closes #XXXX` in your comment to auto-close the issue that your PR fixes.
------------------------------------------------------------------------------>

- relates to https://github.com/shapeshift/web/issues/1966

## Risk

<!-----------------------------------------------------------------------------
Outline the scope of your changes and the risk associated with them. You must use your discretion as an engineer to determine the potential impact of your changes.

E.g. an upgrade to `hdwallet` or core state management would be considered higher risk, and might require a full regression test. UI or isolated view changes, or something behind a feature flag may have near zero risk. Small bug fixes might require testing isolated to the specific fix.
------------------------------------------------------------------------------>

## Testing

<!-----------------------------------------------------------------------------
We treat every PR to be merged with the same scrutiny as if we were merging directly to production.

Your PR will not be merged if you do not complete the sections below for our engineering and operations teams to test.
------------------------------------------------------------------------------>

- Ensure percent click buttons on IBC and EVM chains, including max, still react on click

### Engineering

<!-----------------------------------------------------------------------------
Include sufficient information here for an engineer to test your PR. This may include how to test locally, in a built environment, changes to infrastructure etc.
------------------------------------------------------------------------------>

### Operations

<!-----------------------------------------------------------------------------
If your changes have a user-facing impact, describe how a non-technical QA team can functionally test your changes in a preview environment.

If they are not user-facing please describe how to test for any regressions that may occur.
------------------------------------------------------------------------------>

## Screenshots (if applicable)
