### PR TITLE
feat(defi): sane max / percent click handlers

### DIFF
--- a/src/components/Bridge/BridgeRoutes/BridgeInput.tsx
+++ b/src/components/Bridge/BridgeRoutes/BridgeInput.tsx
@@ -157,7 +157,7 @@ export const BridgeInput = () => {
           assetIcon={asset.value?.icon ?? ''}
           onAssetClick={() => history.push(BridgeRoutePaths.SelectAsset)}
           percentOptions={[0.25, 0.5, 0.75, 1]}
-          onMaxClick={handlePercentClick}
+          onPercentOptionClick={handlePercentClick}
           onChange={(value, isFiat) => handleInputChange(value, isFiat)}
         />
         <List bg='gray.850' variant='rounded' borderColor='gray.750' borderWidth={1}>

--- a/src/components/DeFi/components/AssetInput.tsx
+++ b/src/components/DeFi/components/AssetInput.tsx
@@ -55,7 +55,8 @@ export type AssetInputProps = {
   assetIcon: string
   onChange?: (value: string, isFiat?: boolean) => void
   onAssetClick?: () => void
-  onMaxClick?: (args: number) => void
+  onMaxClick?: () => Promise<void>
+  onPercentOptionClick?: (args: number) => void
   isReadOnly?: boolean
   isSendMaxDisabled?: boolean
   cryptoAmount?: string
@@ -81,6 +82,7 @@ export const AssetInput: React.FC<AssetInputProps> = ({
   onChange = () => {},
   onAssetClick,
   onMaxClick,
+  onPercentOptionClick,
   cryptoAmount,
   isReadOnly,
   isSendMaxDisabled,
@@ -194,7 +196,7 @@ export const AssetInput: React.FC<AssetInputProps> = ({
           </Button>
         </Stack>
       )}
-      {(onMaxClick || balance) && (
+      {(onPercentOptionClick || balance) && (
         <Stack direction='row' py={2} px={4} justifyContent='space-between' alignItems='center'>
           {balance && (
             <Balance
@@ -205,11 +207,12 @@ export const AssetInput: React.FC<AssetInputProps> = ({
               label={translate('common.balance')}
             />
           )}
-          {onMaxClick && (
+          {onPercentOptionClick && (
             <PercentOptionsButtonGroup
               options={percentOptions}
               isDisabled={isReadOnly || isSendMaxDisabled}
-              onClick={onMaxClick}
+              onMaxClick={onMaxClick}
+              onClick={onPercentOptionClick}
             />
           )}
         </Stack>

--- a/src/components/Trade/TradeInputV2.tsx
+++ b/src/components/Trade/TradeInputV2.tsx
@@ -174,7 +174,7 @@ export const TradeInput = () => {
     }
   }, [getValues, setValue])
 
-  const handleSendMax: TradeAssetInputProps['onMaxClick'] = useCallback(async () => {
+  const handleSendMax: TradeAssetInputProps['onPercentOptionClick'] = useCallback(async () => {
     if (!(sellTradeAsset?.asset && quote)) return
     const maxSendAmount = getSendMaxAmount(
       sellTradeAsset.asset,
@@ -392,7 +392,7 @@ export const TradeInput = () => {
             isSendMaxDisabled={isSwapperApiPending || !quoteAvailableForCurrentAssetPair}
             onChange={onSellAssetInputChange}
             percentOptions={[1]}
-            onMaxClick={handleSendMax}
+            onPercentOptionClick={handleSendMax}
             onAssetClick={() => handleInputAssetClick(AssetClickAction.Sell)}
             onAccountIdChange={handleSellAccountIdChange}
             showFiatSkeleton={isUsdRatesPending}

--- a/src/features/defi/components/Deposit/Deposit.tsx
+++ b/src/features/defi/components/Deposit/Deposit.tsx
@@ -4,7 +4,7 @@ import type { AccountId } from '@shapeshiftoss/caip'
 import type { MarketData } from '@shapeshiftoss/types'
 import get from 'lodash/get'
 import { useCallback } from 'react'
-import type { ControllerProps } from 'react-hook-form'
+import type { ControllerProps, UseFormSetValue } from 'react-hook-form'
 import { useController, useForm, useWatch } from 'react-hook-form'
 import { useTranslate } from 'react-polyglot'
 import type { AccountDropdownProps } from 'components/AccountDropdown/AccountDropdown'
@@ -36,6 +36,7 @@ type DepositProps = {
   // Asset market data
   marketData: MarketData
   onAccountIdChange?: AccountDropdownProps['onChange']
+  onMaxClick?: (setValue: UseFormSetValue<DepositValues>) => Promise<void>
   // Array of the % options
   percentOptions: number[]
   isLoading: boolean
@@ -75,6 +76,7 @@ export const Deposit = ({
   isLoading,
   onAccountIdChange: handleAccountIdChange,
   onContinue,
+  onMaxClick,
   percentOptions,
   inputIcons,
   rewardAsset,
@@ -95,6 +97,8 @@ export const Deposit = ({
       [Field.Slippage]: DEFAULT_SLIPPAGE,
     },
   })
+
+  const handleMaxClick = useCallback(() => onMaxClick!(setValue), [onMaxClick, setValue])
 
   const values = useWatch({ control })
   const { field: cryptoAmount } = useController({
@@ -129,10 +133,7 @@ export const Deposit = ({
 
   const handlePercentClick = useCallback(
     (percent: number) => {
-      const cryptoAmount =
-        percent === 1
-          ? cryptoAmountAvailable
-          : bnOrZero(cryptoAmountAvailable).times(percent).precision(asset.precision)
+      const cryptoAmount = bnOrZero(cryptoAmountAvailable).times(percent).precision(asset.precision)
       const fiatAmount = bnOrZero(cryptoAmount).times(marketData.price)
       setValue(Field.FiatAmount, fiatAmount.toString(), {
         shouldValidate: true,
@@ -161,13 +162,14 @@ export const Deposit = ({
             assetId={asset.assetId}
             onAccountIdChange={handleAccountIdChange}
             onChange={(value, isFiat) => handleInputChange(value, isFiat)}
+            {...(onMaxClick ? { onMaxClick: handleMaxClick } : {})}
             fiatAmount={fiatAmount?.value}
             showFiatAmount={true}
             assetIcon={asset.icon}
             assetSymbol={asset.symbol}
             balance={cryptoAmountAvailable}
             fiatBalance={fiatAmountAvailable}
-            onMaxClick={value => handlePercentClick(value)}
+            onPercentOptionClick={handlePercentClick}
             percentOptions={percentOptions}
             icons={inputIcons}
           />

--- a/src/features/defi/components/Deposit/PairDeposit.tsx
+++ b/src/features/defi/components/Deposit/PairDeposit.tsx
@@ -227,7 +227,7 @@ export const PairDeposit = ({
             balance={cryptoAmountAvailable1}
             fiatBalance={fiatAmountAvailable1}
             onAccountIdChange={handleAccountIdChange}
-            onMaxClick={value => handlePercentClick(value, true)}
+            onPercentOptionClick={value => handlePercentClick(value, true)}
             percentOptions={percentOptions}
             errors={cryptoError1 || fiatError1}
           />
@@ -243,7 +243,7 @@ export const PairDeposit = ({
             balance={cryptoAmountAvailable2}
             fiatBalance={fiatAmountAvailable2}
             onAccountIdChange={handleAccountIdChange}
-            onMaxClick={value => handlePercentClick(value, false)}
+            onPercentOptionClick={value => handlePercentClick(value, false)}
             percentOptions={percentOptions}
             errors={cryptoError2 || fiatError2}
           />

--- a/src/features/defi/components/Withdraw/Withdraw.tsx
+++ b/src/features/defi/components/Withdraw/Withdraw.tsx
@@ -179,7 +179,7 @@ export const Withdraw: React.FC<WithdrawProps> = ({
           assetSymbol={asset.symbol}
           balance={cryptoAmountAvailable}
           fiatBalance={fiatAmountAvailable}
-          onMaxClick={value => handlePercentClick(value)}
+          onPercentOptionClick={value => handlePercentClick(value)}
           percentOptions={percentOptions}
           isReadOnly={disableInput}
           icons={icons}

--- a/src/features/defi/providers/cosmos/components/CosmosManager/Deposit/components/Deposit.tsx
+++ b/src/features/defi/providers/cosmos/components/CosmosManager/Deposit/components/Deposit.tsx
@@ -155,7 +155,6 @@ export const Deposit: React.FC<DepositProps> = ({
       marketData={marketData}
       onCancel={handleCancel}
       onContinue={handleContinue}
-      onMaxClick={handleMaxClick}
       percentOptions={[0.25, 0.5, 0.75, 1]}
       enableSlippage={false}
     />

--- a/src/features/defi/providers/cosmos/components/CosmosManager/Deposit/components/Deposit.tsx
+++ b/src/features/defi/providers/cosmos/components/CosmosManager/Deposit/components/Deposit.tsx
@@ -155,6 +155,7 @@ export const Deposit: React.FC<DepositProps> = ({
       marketData={marketData}
       onCancel={handleCancel}
       onContinue={handleContinue}
+      onMaxClick={handleMaxClick}
       percentOptions={[0.25, 0.5, 0.75, 1]}
       enableSlippage={false}
     />

--- a/src/stories/Forms.stories.mdx
+++ b/src/stories/Forms.stories.mdx
@@ -68,7 +68,7 @@ export const ExampleDeposit = () => {
       rewardAmount.onChange(value)
     }
   }
-  const handleMax = (value: number) => {
+  const handlePercentOptionClick = (value: number) => {
     const amount = bnOrZero(balance).times(value)
     fiatAmount.onChange(amount.times(price).toString())
     cryptoAmount.onChange(amount.toString())
@@ -94,7 +94,7 @@ export const ExampleDeposit = () => {
               balance='1000'
               onChange={(value, isFiat) => handleOnChange(value, isFiat)}
               assetName='FOX'
-              onMaxClick={value => handleMax(value)}
+              onPercentOptionClick={value => handlePercentOptionClick(value)}
               assetIcon='https://assets.coincap.io/assets/icons/256/fox.png'
             />
           </FormField>


### PR DESCRIPTION
## Description

<!-- Please describe your changes -->

Currently in the DeFi section we use `onMaxClick` as a catch-all method for all percent options click which is wrong.

This PR fixes the wrong terminology, and while at it, separates it into `onPercentOptionClick` - the current one, and `onMaxClick` which actually handles max clicks.

The latter is optional and provides chain-specific implementations, typically to subtract fees - in case this is not needed e.g unstaking from Cosmos where the full staking balance is used, then `onMaxClick` doesn't need to be passed down and we can rely on the current `onPercentOptionClick` implementation.

<!-- Before submitting a pull request, please make sure you have answered the following: -->

- [x] Have you followed the guidelines in our [Contributing]('https://github.com/shapeshift/web/blob/develop/CONTRIBUTING.md) guide?
- [x] Have you checked to ensure there aren't other open [Pull Requests](https://github.com/shapeshift/web/pulls) for the same update/change?

## Pull Request Type

- [ ] :bug: Bug fix (Non-breaking Change: Fixes an issue)
- [ ] :hammer_and_wrench: Chore (Non-breaking Change: Doc updates, pkg upgrades, typos, etc..)
- [x] :nail_care: New Feature (Breaking/Non-breaking Change)

## Issue (if applicable)

<!-----------------------------------------------------------------------------
If applicable, please link to the github issue and put `closes #XXXX` in your comment to auto-close the issue that your PR fixes.
------------------------------------------------------------------------------>

- relates to #1966
## Risk

<!-----------------------------------------------------------------------------
Outline the scope of your changes and the risk associated with them. You must use your discretion as an engineer to determine the potential impact of your changes.

E.g. an upgrade to `hdwallet` or core state management would be considered higher risk, and might require a full regression test. UI or isolated view changes, or something behind a feature flag may have near zero risk. Small bug fixes might require testing isolated to the specific fix.
------------------------------------------------------------------------------>

- Percent options / maxes could be borked, test accordingly

## Testing

<!-----------------------------------------------------------------------------
We treat every PR to be merged with the same scrutiny as if we were merging directly to production.

Your PR will not be merged if you do not complete the sections below for our engineering and operations teams to test.
------------------------------------------------------------------------------>

- See risks

### Engineering

<!-----------------------------------------------------------------------------
Include sufficient information here for an engineer to test your PR. This may include how to test locally, in a built environment, changes to infrastructure etc.
------------------------------------------------------------------------------>

### Operations

<!-----------------------------------------------------------------------------
If your changes have a user-facing impact, describe how a non-technical QA team can functionally test your changes in a preview environment.

If they are not user-facing please describe how to test for any regressions that may occur.
------------------------------------------------------------------------------>

## Screenshots (if applicable)
