### PR TITLE
feat: bump @shapeshiftoss/chain-adapters

### DIFF
--- a/package.json
+++ b/package.json
@@ -88,7 +88,7 @@
     "@reduxjs/toolkit": "^1.8.2",
     "@shapeshiftoss/asset-service": "^8.1.5",
     "@shapeshiftoss/caip": "^8.4.4",
-    "@shapeshiftoss/chain-adapters": "^10.1.1",
+    "@shapeshiftoss/chain-adapters": "^10.1.3",
     "@shapeshiftoss/errors": "^1.1.3",
     "@shapeshiftoss/hdwallet-core": "1.36.0",
     "@shapeshiftoss/hdwallet-keepkey": "1.36.0",

--- a/yarn.lock
+++ b/yarn.lock
@@ -4015,10 +4015,10 @@
   resolved "https://registry.yarnpkg.com/@shapeshiftoss/caip/-/caip-8.4.4.tgz#5e119ed745daa78bc3848de034591031ad13869c"
   integrity sha512-XWo9HrmMfEesw7I+VE0G/K53E6NKB299dQK5GN1ETiwsZRMSL1+ssWxg9O+KIarnVqDUkSBa5c4vzEKGQbXzhw==
 
-"@shapeshiftoss/chain-adapters@^10.1.1":
-  version "10.1.1"
-  resolved "https://registry.yarnpkg.com/@shapeshiftoss/chain-adapters/-/chain-adapters-10.1.1.tgz#8514b06f96578547834e811c9088f57b807dd91b"
-  integrity sha512-B3M03NJMX/prdVQ3e0+9F64ehnQ+sQPLd3QUX70TM6ybnwyipnbK4autGmmpQ57J+KJzcHeWNYD0WkjbTng/4w==
+"@shapeshiftoss/chain-adapters@^10.1.3":
+  version "10.1.3"
+  resolved "https://registry.yarnpkg.com/@shapeshiftoss/chain-adapters/-/chain-adapters-10.1.3.tgz#8ab8e98fa19bd0963f0cb75e9e150b6139c87be4"
+  integrity sha512-mHIA5B0RDbD1C1coSJ7tIO3HaRaKk5qtvmHQ30z53Mww/XEkNPlZxvpGLyvKs8pGdEmgH0KKwwnbC2bWFLnNdQ==
   dependencies:
     axios "^0.26.1"
     bech32 "^2.0.0"


### PR DESCRIPTION
## Description

Included changes:

- https://github.com/shapeshift/lib/pull/1074
- https://github.com/shapeshift/lib/pull/1079

## Notice

<!-- Before submitting a pull request, please make sure you have answered the following: -->

- [x] Have you followed the guidelines in our [Contributing]('https://github.com/shapeshift/web/blob/develop/CONTRIBUTING.md) guide?
- [x] Have you checked to ensure there aren't other open [Pull Requests](https://github.com/shapeshift/web/pulls) for the same update/change?

## Pull Request Type

- [ ] :bug: Bug fix (Non-breaking Change: Fixes an issue)
- [ ] :hammer_and_wrench: Chore (Non-breaking Change: Doc updates, pkg upgrades, typos, etc..)
- [x] :nail_care: New Feature (Breaking/Non-breaking Change)

## Issue (if applicable)

- closes https://github.com/shapeshift/web/issues/3177

## Risk

<!-----------------------------------------------------------------------------
Outline the scope of your changes and the risk associated with them. You must use your discretion as an engineer to determine the potential impact of your changes.

E.g. an upgrade to `hdwallet` or core state management would be considered higher risk, and might require a full regression test. UI or isolated view changes, or something behind a feature flag may have near zero risk. Small bug fixes might require testing isolated to the specific fix.
------------------------------------------------------------------------------>

- Cosmos Tx history could be borked
- Yearn SDK update might rug us for everything Yearn
- AVAX featureset could be borked

## Testing

<!-----------------------------------------------------------------------------
We treat every PR to be merged with the same scrutiny as if we were merging directly to production.

Your PR will not be merged if you do not complete the sections below for our engineering and operations teams to test.
------------------------------------------------------------------------------>

- Cosmos Tx history looks good and also includes staking operations
- Cosmos account balance **and** staking data live updates on a staking operation - over the DeFi section overview, earn and DeFi modals / rows as well as in the accounts and assets pages


- AVAX data is still displayed across the app and we can broadcast AVAX Txs with both MM (native is still borked pending https://github.com/shapeshift/hdwallet/pull/583 merge)


- Yearn data is still displayed correctly and we can broadcast a Yearn Tx


- Devtools console shows no new errors

### Engineering

<!-----------------------------------------------------------------------------
Include sufficient information here for an engineer to test your PR. This may include how to test locally, in a built environment, changes to infrastructure etc.
------------------------------------------------------------------------------>

☝🏽 

### Operations

<!-----------------------------------------------------------------------------
If your changes have a user-facing impact, describe how a non-technical QA team can functionally test your changes in a preview environment.

If they are not user-facing please describe how to test for any regressions that may occur.
------------------------------------------------------------------------------>

☝🏽 
## Screenshots (if applicable)
