### PR TITLE
fix: keep correct decimal precision on percentage math

### DIFF
--- a/src/features/defi/components/Deposit/Deposit.tsx
+++ b/src/features/defi/components/Deposit/Deposit.tsx
@@ -133,7 +133,9 @@ export const Deposit = ({
 
   const handlePercentClick = useCallback(
     (percent: number) => {
-      const cryptoAmount = bnOrZero(cryptoAmountAvailable).times(percent).precision(asset.precision)
+      const cryptoAmount = bnOrZero(cryptoAmountAvailable)
+        .times(percent)
+        .decimalPlaces(asset.precision)
       const fiatAmount = bnOrZero(cryptoAmount).times(marketData.price)
       setValue(Field.FiatAmount, fiatAmount.toString(), {
         shouldValidate: true,


### PR DESCRIPTION
## Description

This change keeps the correct precision when doing percentage math to ensure we pass an integer value to the build transaction functions

## Notice

<!-- Before submitting a pull request, please make sure you have answered the following: -->

- [x] Have you followed the guidelines in our [Contributing]('https://github.com/shapeshift/web/blob/develop/CONTRIBUTING.md) guide?
- [x] Have you checked to ensure there aren't other open [Pull Requests](https://github.com/shapeshift/web/pulls) for the same update/change?

## Pull Request Type

- [x] :bug: Bug fix (Non-breaking Change: Fixes an issue)
- [ ] :hammer_and_wrench: Chore (Non-breaking Change: Doc updates, pkg upgrades, typos, etc..)
- [ ] :nail_care: New Feature (Breaking/Non-breaking Change)

## Issue (if applicable)

closes (https://github.com/shapeshift/web/issues/3065)

## Risk

Low

## Testing

Test staking at different percentage amounts. All options should work correctly and successfully broadcast a transaction

### Engineering

:point_up: 

### Operations

:point_up: 

## Screenshots (if applicable)
![image](https://user-images.githubusercontent.com/35275952/198697757-6cac81b2-ec3c-4c07-b566-414decf9c9e6.png)
