### PR TITLE
fix(defi): deposit percentage precision

### DIFF
--- a/src/features/defi/components/Deposit/Deposit.tsx
+++ b/src/features/defi/components/Deposit/Deposit.tsx
@@ -133,12 +133,18 @@ export const Deposit = ({
 
   const handlePercentClick = useCallback(
     (percent: number) => {
-      const cryptoAmount = bnOrZero(cryptoAmountAvailable).times(percent).precision(asset.precision)
-      const fiatAmount = bnOrZero(cryptoAmount).times(marketData.price)
-      setValue(Field.FiatAmount, fiatAmount.toString(), {
+      // The human crypto amount as a result of amount * percentage / 100, possibly with too many digits
+      const percentageCryptoAmount = bnOrZero(cryptoAmountAvailable).times(percent)
+      const percentageFiatAmount = percentageCryptoAmount.times(marketData.price)
+      const percentageCryptoAmountHuman = percentageCryptoAmount
+        .decimalPlaces(asset.precision)
+        .toString()
+      setValue(Field.FiatAmount, percentageFiatAmount.toString(), {
         shouldValidate: true,
       })
-      setValue(Field.CryptoAmount, cryptoAmount.toString(), {
+      // TODO(gomes): DeFi UI abstraction should use base precision amount everywhere, and the explicit crypto/human vernacular
+      // Passing human amounts around is a bug waiting to happen, like the one this commit fixes
+      setValue(Field.CryptoAmount, percentageCryptoAmountHuman, {
         shouldValidate: true,
       })
     },


### PR DESCRIPTION
## Description

<!-- Please describe your changes -->

Layers on top of https://github.com/shapeshift/web/pull/3179 bringing more sanity

In the DeFi deposit step, we were doing amount * percentage / 100, which
does exactly this, gives us the result of this operation.

However, making such a division on human amounts will possibly reduce in
more precision than the initial one, which this PR fixes.

Expect more PRs on top of this to:

1. Use the abstracted `handlePercentOptionClick` from
   https://github.com/shapeshift/web/pull/3171 everywhere across the
   DeFi section, to ensure the bug is fixed consistently across deposit
   and withdraws
2. Another PR to bring the crypto/human amount vernacular over the DeFi
   section

<!-- Before submitting a pull request, please make sure you have answered the following: -->

- [x] Have you followed the guidelines in our [Contributing]('https://github.com/shapeshift/web/blob/develop/CONTRIBUTING.md) guide?
- [x] Have you checked to ensure there aren't other open [Pull Requests](https://github.com/shapeshift/web/pulls) for the same update/change?

## Pull Request Type

- [x] :bug: Bug fix (Non-breaking Change: Fixes an issue)
- [ ] :hammer_and_wrench: Chore (Non-breaking Change: Doc updates, pkg upgrades, typos, etc..)
- [ ] :nail_care: New Feature (Breaking/Non-breaking Change)

## Issue (if applicable)

<!-----------------------------------------------------------------------------
If applicable, please link to the github issue and put `closes #XXXX` in your comment to auto-close the issue that your PR fixes.
------------------------------------------------------------------------------>

- technically speaking, closes https://github.com/shapeshift/web/issues/3065, but this is not
strictly limited to staking as we use the same implementation
everywhere.

## Risk

<!-----------------------------------------------------------------------------
Outline the scope of your changes and the risk associated with them. You must use your discretion as an engineer to determine the potential impact of your changes.

E.g. an upgrade to `hdwallet` or core state management would be considered higher risk, and might require a full regression test. UI or isolated view changes, or something behind a feature flag may have near zero risk. Small bug fixes might require testing isolated to the specific fix.
------------------------------------------------------------------------------>

None

## Testing

<!-----------------------------------------------------------------------------
We treat every PR to be merged with the same scrutiny as if we were merging directly to production.

Your PR will not be merged if you do not complete the sections below for our engineering and operations teams to test.
------------------------------------------------------------------------------>

- Crypto and fiat amounts look sane at deposit step when clicking a percent option / max for different assets (test with USDC, ATOM, and some ERC20 of your choice that's not a stablecoin as these tend to have lower precision). Ensure the asset decimal places are honored: 6dp for ATOM and USDC, 18 for most ERC20s

### Engineering

<!-----------------------------------------------------------------------------
Include sufficient information here for an engineer to test your PR. This may include how to test locally, in a built environment, changes to infrastructure etc.
------------------------------------------------------------------------------>

^



### Operations

<!-----------------------------------------------------------------------------
If your changes have a user-facing impact, describe how a non-technical QA team can functionally test your changes in a preview environment.

If they are not user-facing please describe how to test for any regressions that may occur.
------------------------------------------------------------------------------>

^
## Screenshots (if applicable)

Develop / Prod

<img width="532" alt="image" src="https://user-images.githubusercontent.com/17035424/198706093-197e4804-859f-49a9-ad86-4584dcb93d8d.png">
<img width="1118" alt="image" src="https://user-images.githubusercontent.com/17035424/198706149-fcf1be01-8eb4-474f-aaf1-bf6db6461296.png">



This diff

<img width="526" alt="image" src="https://user-images.githubusercontent.com/17035424/198706231-c2ba5ccf-aade-4ab6-af9f-4963ed407cc2.png">
<img width="525" alt="image" src="https://user-images.githubusercontent.com/17035424/198706274-0d111bca-e561-4087-aa0f-2e126aa9a6aa.png">
