### PR TITLE
fix: utxo-accounts dead click

### DIFF
--- a/src/pages/Accounts/components/AccountNumberRow.tsx
+++ b/src/pages/Accounts/components/AccountNumberRow.tsx
@@ -151,6 +151,7 @@ export const AccountNumberRow: React.FC<AccountNumberRowProps> = ({
             <Avatar bg={`${color}20`} color={color} size='sm' name={`# ${accountNumber}`} />
           }
           {...buttonProps}
+          onClick={isUtxoAccount ? onToggle : buttonProps.onClick}
         >
           <Stack alignItems='flex-start' spacing={0}>
             <RawText color='var(--chakra-colors-chakra-body-text)' fontFamily={fontFamily}>


### PR DESCRIPTION
## Description

fixes UTXO accounts dead click, using option two described in the issue. the UTXO account button now toggles the underlying accounts instead of doing nothing.

## Notice

<!-- Before submitting a pull request, please make sure you have answered the following: -->

- [x] Have you followed the guidelines in our [Contributing]('https://github.com/shapeshift/web/blob/develop/CONTRIBUTING.md) guide?
- [x] Have you checked to ensure there aren't other open [Pull Requests](https://github.com/shapeshift/web/pulls) for the same update/change?

## Pull Request Type

- [x] :bug: Bug fix (Non-breaking Change: Fixes an issue)
- [ ] :hammer_and_wrench: Chore (Non-breaking Change: Doc updates, pkg upgrades, typos, etc..)
- [ ] :nail_care: New Feature (Breaking/Non-breaking Change)

## Issue (if applicable)

closes #2994

## Risk

none

## Testing

connect to a wallet that supports UTXO accounts (btc, ltc, bch), head over to accounts page.
click the arrow-down button on BTC/LTC/BCH, clicking the account row should toggle the underlying accounts.

### Engineering

see above

### Operations

see above

## Screenshots (if applicable)
n/a