### PR TITLE
fix(defi): select feeAssetBalance by granular AccountId

### DIFF
--- a/src/features/defi/providers/cosmos/components/CosmosManager/Withdraw/components/Confirm.tsx
+++ b/src/features/defi/providers/cosmos/components/CosmosManager/Withdraw/components/Confirm.tsx
@@ -29,7 +29,7 @@ import {
   selectAssetById,
   selectBIP44ParamsByAccountId,
   selectMarketDataById,
-  selectPortfolioCryptoHumanBalanceByAssetId,
+  selectPortfolioCryptoHumanBalanceByFilter,
 } from 'state/slices/selectors'
 import { useAppSelector } from 'state/store'
 
@@ -89,8 +89,12 @@ export const Confirm: React.FC<ConfirmProps> = ({ onNext, accountId }) => {
     })()
   }, [asset, asset.precision, feeMarketData.price])
 
-  const feeAssetBalance = useAppSelector(state =>
-    selectPortfolioCryptoHumanBalanceByAssetId(state, { assetId: feeAsset?.assetId ?? '' }),
+  const feeAssetBalanceFilter = useMemo(
+    () => ({ assetId: feeAsset?.assetId, accountId: accountId ?? '' }),
+    [accountId, feeAsset?.assetId],
+  )
+  const feeAssetBalance = useAppSelector(s =>
+    selectPortfolioCryptoHumanBalanceByFilter(s, feeAssetBalanceFilter),
   )
 
   const accountFilter = useMemo(() => ({ accountId: accountId ?? '' }), [accountId])

--- a/src/features/defi/providers/fox-eth-lp/components/FoxEthLpManager/Deposit/FoxEthLpDeposit.tsx
+++ b/src/features/defi/providers/fox-eth-lp/components/FoxEthLpManager/Deposit/FoxEthLpDeposit.tsx
@@ -91,7 +91,7 @@ export const FoxEthLpDeposit: React.FC<FoxEthLpDepositProps> = ({
       },
       [DefiStep.Confirm]: {
         label: translate('defi.steps.confirm.title'),
-        component: Confirm,
+        component: ownProps => <Confirm {...ownProps} accountId={accountId} />,
       },
       [DefiStep.Status]: {
         label: 'Status',

--- a/src/features/defi/providers/fox-eth-lp/components/FoxEthLpManager/Deposit/components/Confirm.tsx
+++ b/src/features/defi/providers/fox-eth-lp/components/FoxEthLpManager/Deposit/components/Confirm.tsx
@@ -35,9 +35,9 @@ import { DepositContext } from '../DepositContext'
 
 const moduleLogger = logger.child({ namespace: ['FoxEthLpDeposit:Confirm'] })
 
-type ConfirmProps = { accountId: Nullable<AccountId> }
+type ConfirmProps = { accountId: Nullable<AccountId> } & StepComponentProps
 
-export const Confirm: React.FC<ConfirmProps & StepComponentProps> = ({ accountId, onNext }) => {
+export const Confirm: React.FC<ConfirmProps> = ({ accountId, onNext }) => {
   const { state, dispatch } = useContext(DepositContext)
   const translate = useTranslate()
   const { lpAccountAddress, onOngoingLpTxIdChange } = useFoxEth()

--- a/src/features/defi/providers/fox-eth-lp/components/FoxEthLpManager/Deposit/components/Confirm.tsx
+++ b/src/features/defi/providers/fox-eth-lp/components/FoxEthLpManager/Deposit/components/Confirm.tsx
@@ -1,4 +1,5 @@
 import { Alert, AlertIcon, Box, Stack, useToast } from '@chakra-ui/react'
+import type { AccountId } from '@shapeshiftoss/caip'
 import { ASSET_REFERENCE, ethAssetId, foxAssetId, toAssetId } from '@shapeshiftoss/caip'
 import { supportsETH } from '@shapeshiftoss/hdwallet-core'
 import { Confirm as ReusableConfirm } from 'features/defi/components/Confirm/Confirm'
@@ -24,16 +25,19 @@ import { logger } from 'lib/logger'
 import {
   selectAssetById,
   selectMarketDataById,
-  selectPortfolioCryptoHumanBalanceByAssetId,
+  selectPortfolioCryptoHumanBalanceByFilter,
 } from 'state/slices/selectors'
 import { useAppSelector } from 'state/store'
+import type { Nullable } from 'types/common'
 
 import { FoxEthLpDepositActionType } from '../DepositCommon'
 import { DepositContext } from '../DepositContext'
 
 const moduleLogger = logger.child({ namespace: ['FoxEthLpDeposit:Confirm'] })
 
-export const Confirm: React.FC<StepComponentProps> = ({ onNext }) => {
+type ConfirmProps = { accountId: Nullable<AccountId> }
+
+export const Confirm: React.FC<ConfirmProps & StepComponentProps> = ({ accountId, onNext }) => {
   const { state, dispatch } = useContext(DepositContext)
   const translate = useTranslate()
   const { lpAccountAddress, onOngoingLpTxIdChange } = useFoxEth()
@@ -58,8 +62,12 @@ export const Confirm: React.FC<StepComponentProps> = ({ onNext }) => {
   // notify
   const toast = useToast()
 
-  const feeAssetBalance = useAppSelector(state =>
-    selectPortfolioCryptoHumanBalanceByAssetId(state, { assetId: feeAsset?.assetId ?? '' }),
+  const feeAssetBalanceFilter = useMemo(
+    () => ({ assetId: feeAsset?.assetId, accountId: accountId ?? '' }),
+    [accountId, feeAsset?.assetId],
+  )
+  const feeAssetBalance = useAppSelector(s =>
+    selectPortfolioCryptoHumanBalanceByFilter(s, feeAssetBalanceFilter),
   )
 
   if (!state || !dispatch) return null

--- a/src/features/defi/providers/fox-eth-lp/components/FoxEthLpManager/Withdraw/FoxEthLpWithdraw.tsx
+++ b/src/features/defi/providers/fox-eth-lp/components/FoxEthLpManager/Withdraw/FoxEthLpWithdraw.tsx
@@ -112,7 +112,7 @@ export const FoxEthLpWithdraw: React.FC<FoxEthLpWithdrawProps> = ({
       },
       [DefiStep.Confirm]: {
         label: translate('defi.steps.confirm.title'),
-        component: Confirm,
+        component: ownProps => <Confirm {...ownProps} accountId={accountId} />,
       },
       [DefiStep.Status]: {
         label: 'Status',

--- a/src/features/defi/providers/fox-eth-lp/components/FoxEthLpManager/Withdraw/components/Confirm.tsx
+++ b/src/features/defi/providers/fox-eth-lp/components/FoxEthLpManager/Withdraw/components/Confirm.tsx
@@ -32,9 +32,9 @@ import { WithdrawContext } from '../WithdrawContext'
 
 const moduleLogger = logger.child({ namespace: ['Confirm'] })
 
-type ConfirmProps = { accountId: Nullable<AccountId> }
+type ConfirmProps = { accountId: Nullable<AccountId> } & StepComponentProps
 
-export const Confirm = ({ accountId, onNext }: ConfirmProps & StepComponentProps) => {
+export const Confirm = ({ accountId, onNext }: ConfirmProps) => {
   const { state, dispatch } = useContext(WithdrawContext)
   const opportunity = state?.opportunity
   const translate = useTranslate()

--- a/src/features/defi/providers/fox-eth-lp/components/FoxEthLpManager/Withdraw/components/Confirm.tsx
+++ b/src/features/defi/providers/fox-eth-lp/components/FoxEthLpManager/Withdraw/components/Confirm.tsx
@@ -1,4 +1,5 @@
 import { Alert, AlertIcon, Box, Stack } from '@chakra-ui/react'
+import type { AccountId } from '@shapeshiftoss/caip'
 import { ethAssetId, foxAssetId } from '@shapeshiftoss/caip'
 import { supportsETH } from '@shapeshiftoss/hdwallet-core'
 import { Confirm as ReusableConfirm } from 'features/defi/components/Confirm/Confirm'
@@ -7,7 +8,7 @@ import { Summary } from 'features/defi/components/Summary'
 import { DefiStep } from 'features/defi/contexts/DefiManagerProvider/DefiCommon'
 import { foxEthLpAssetId } from 'features/defi/providers/fox-eth-lp/constants'
 import { useFoxEthLiquidityPool } from 'features/defi/providers/fox-eth-lp/hooks/useFoxEthLiquidityPool'
-import { useContext } from 'react'
+import { useContext, useMemo } from 'react'
 import { useTranslate } from 'react-polyglot'
 import { Amount } from 'components/Amount/Amount'
 import { AssetIcon } from 'components/AssetIcon'
@@ -21,16 +22,19 @@ import { logger } from 'lib/logger'
 import {
   selectAssetById,
   selectMarketDataById,
-  selectPortfolioCryptoHumanBalanceByAssetId,
+  selectPortfolioCryptoHumanBalanceByFilter,
 } from 'state/slices/selectors'
 import { useAppSelector } from 'state/store'
+import type { Nullable } from 'types/common'
 
 import { FoxEthLpWithdrawActionType } from '../WithdrawCommon'
 import { WithdrawContext } from '../WithdrawContext'
 
 const moduleLogger = logger.child({ namespace: ['Confirm'] })
 
-export const Confirm = ({ onNext }: StepComponentProps) => {
+type ConfirmProps = { accountId: Nullable<AccountId> }
+
+export const Confirm = ({ accountId, onNext }: ConfirmProps & StepComponentProps) => {
   const { state, dispatch } = useContext(WithdrawContext)
   const opportunity = state?.opportunity
   const translate = useTranslate()
@@ -47,8 +51,12 @@ export const Confirm = ({ onNext }: StepComponentProps) => {
   // user info
   const { state: walletState } = useWallet()
 
-  const feeAssetBalance = useAppSelector(state =>
-    selectPortfolioCryptoHumanBalanceByAssetId(state, { assetId: ethAsset?.assetId ?? '' }),
+  const feeAssetBalanceFilter = useMemo(
+    () => ({ assetId: ethAssetId, accountId: accountId ?? '' }),
+    [accountId],
+  )
+  const feeAssetBalance = useAppSelector(s =>
+    selectPortfolioCryptoHumanBalanceByFilter(s, feeAssetBalanceFilter),
   )
 
   if (!state || !dispatch || !opportunity) return null

--- a/src/features/defi/providers/fox-farming/components/FoxFarmingManager/Deposit/components/Confirm.tsx
+++ b/src/features/defi/providers/fox-farming/components/FoxFarmingManager/Deposit/components/Confirm.tsx
@@ -24,7 +24,7 @@ import { logger } from 'lib/logger'
 import {
   selectAssetById,
   selectMarketDataById,
-  selectPortfolioCryptoHumanBalanceByAssetId,
+  selectPortfolioCryptoHumanBalanceByFilter,
 } from 'state/slices/selectors'
 import { useAppSelector } from 'state/store'
 import type { Nullable } from 'types/common'
@@ -64,8 +64,12 @@ export const Confirm: React.FC<StepComponentProps & { accountId: Nullable<Accoun
   // notify
   const toast = useToast()
 
-  const feeAssetBalance = useAppSelector(state =>
-    selectPortfolioCryptoHumanBalanceByAssetId(state, { assetId: feeAsset?.assetId ?? '' }),
+  const feeAssetBalanceFilter = useMemo(
+    () => ({ assetId: feeAsset?.assetId, accountId: accountId ?? '' }),
+    [accountId, feeAsset?.assetId],
+  )
+  const feeAssetBalance = useAppSelector(s =>
+    selectPortfolioCryptoHumanBalanceByFilter(s, feeAssetBalanceFilter),
   )
 
   if (!state || !dispatch || !opportunity) return null

--- a/src/features/defi/providers/fox-farming/components/FoxFarmingManager/Withdraw/FoxFarmingWithdraw.tsx
+++ b/src/features/defi/providers/fox-farming/components/FoxFarmingManager/Withdraw/FoxFarmingWithdraw.tsx
@@ -118,7 +118,7 @@ export const FoxFarmingWithdraw: React.FC<FoxFarmingWithdrawProps> = ({
       },
       [DefiStep.Confirm]: {
         label: translate('defi.steps.confirm.title'),
-        component: Confirm,
+        component: ownProps => <Confirm {...ownProps} accountId={accountId} />,
       },
       [DefiStep.Status]: {
         label: 'Status',

--- a/src/features/defi/providers/fox-farming/components/FoxFarmingManager/Withdraw/components/Confirm.tsx
+++ b/src/features/defi/providers/fox-farming/components/FoxFarmingManager/Withdraw/components/Confirm.tsx
@@ -1,4 +1,5 @@
 import { Box, Stack } from '@chakra-ui/react'
+import type { AccountId } from '@shapeshiftoss/caip'
 import { ASSET_REFERENCE, toAssetId } from '@shapeshiftoss/caip'
 import { Confirm as ReusableConfirm } from 'features/defi/components/Confirm/Confirm'
 import { PairIcons } from 'features/defi/components/PairIcons/PairIcons'
@@ -9,7 +10,7 @@ import type {
 } from 'features/defi/contexts/DefiManagerProvider/DefiCommon'
 import { DefiStep } from 'features/defi/contexts/DefiManagerProvider/DefiCommon'
 import { useFoxFarming } from 'features/defi/providers/fox-farming/hooks/useFoxFarming'
-import { useContext } from 'react'
+import { useContext, useMemo } from 'react'
 import { useTranslate } from 'react-polyglot'
 import { Amount } from 'components/Amount/Amount'
 import type { StepComponentProps } from 'components/DeFi/components/Steps'
@@ -23,9 +24,10 @@ import { logger } from 'lib/logger'
 import {
   selectAssetById,
   selectMarketDataById,
-  selectPortfolioCryptoHumanBalanceByAssetId,
+  selectPortfolioCryptoHumanBalanceByFilter,
 } from 'state/slices/selectors'
 import { useAppSelector } from 'state/store'
+import type { Nullable } from 'types/common'
 
 import { FoxFarmingWithdrawActionType } from '../WithdrawCommon'
 import { WithdrawContext } from '../WithdrawContext'
@@ -34,9 +36,9 @@ const moduleLogger = logger.child({
   namespace: ['DeFi', 'Providers', 'FoxFarming', 'Withdraw', 'Confirm'],
 })
 
-type ConfirmProps = StepComponentProps
+type ConfirmProps = { accountId: Nullable<AccountId> } & StepComponentProps
 
-export const Confirm: React.FC<ConfirmProps> = ({ onNext }) => {
+export const Confirm: React.FC<ConfirmProps> = ({ accountId, onNext }) => {
   const { state, dispatch } = useContext(WithdrawContext)
   const translate = useTranslate()
   const { query } = useBrowserRouter<DefiQueryParams, DefiParams>()
@@ -63,8 +65,12 @@ export const Confirm: React.FC<ConfirmProps> = ({ onNext }) => {
   // user info
   const { state: walletState } = useWallet()
 
-  const feeAssetBalance = useAppSelector(state =>
-    selectPortfolioCryptoHumanBalanceByAssetId(state, { assetId: feeAsset?.assetId ?? '' }),
+  const feeAssetBalanceFilter = useMemo(
+    () => ({ assetId: feeAsset?.assetId, accountId: accountId ?? '' }),
+    [feeAsset?.assetId],
+  )
+  const feeAssetBalance = useAppSelector(s =>
+    selectPortfolioCryptoHumanBalanceByFilter(s, feeAssetBalanceFilter),
   )
 
   if (!state || !dispatch || !opportunity) return null

--- a/src/features/defi/providers/fox-farming/components/FoxFarmingManager/Withdraw/components/Confirm.tsx
+++ b/src/features/defi/providers/fox-farming/components/FoxFarmingManager/Withdraw/components/Confirm.tsx
@@ -67,7 +67,7 @@ export const Confirm: React.FC<ConfirmProps> = ({ accountId, onNext }) => {
 
   const feeAssetBalanceFilter = useMemo(
     () => ({ assetId: feeAsset?.assetId, accountId: accountId ?? '' }),
-    [feeAsset?.assetId],
+    [accountId, feeAsset?.assetId],
   )
   const feeAssetBalance = useAppSelector(s =>
     selectPortfolioCryptoHumanBalanceByFilter(s, feeAssetBalanceFilter),

--- a/src/features/defi/providers/foxy/components/FoxyManager/Deposit/components/Confirm.tsx
+++ b/src/features/defi/providers/foxy/components/FoxyManager/Deposit/components/Confirm.tsx
@@ -74,7 +74,7 @@ export const Confirm: React.FC<ConfirmProps> = ({ onNext, accountId }) => {
 
   const feeAssetBalanceFilter = useMemo(
     () => ({ assetId: feeAsset?.assetId, accountId: accountId ?? '' }),
-    [feeAsset?.assetId],
+    [accountId, feeAsset?.assetId],
   )
   const feeAssetBalance = useAppSelector(s =>
     selectPortfolioCryptoHumanBalanceByFilter(s, feeAssetBalanceFilter),

--- a/src/features/defi/providers/foxy/components/FoxyManager/Deposit/components/Confirm.tsx
+++ b/src/features/defi/providers/foxy/components/FoxyManager/Deposit/components/Confirm.tsx
@@ -27,7 +27,7 @@ import {
   selectAssetById,
   selectBIP44ParamsByAccountId,
   selectMarketDataById,
-  selectPortfolioCryptoHumanBalanceByAssetId,
+  selectPortfolioCryptoHumanBalanceByFilter,
 } from 'state/slices/selectors'
 import { useAppSelector } from 'state/store'
 import type { Nullable } from 'types/common'
@@ -72,8 +72,12 @@ export const Confirm: React.FC<ConfirmProps> = ({ onNext, accountId }) => {
   // notify
   const toast = useToast()
 
-  const feeAssetBalance = useAppSelector(state =>
-    selectPortfolioCryptoHumanBalanceByAssetId(state, { assetId: feeAsset?.assetId ?? '' }),
+  const feeAssetBalanceFilter = useMemo(
+    () => ({ assetId: feeAsset?.assetId, accountId: accountId ?? '' }),
+    [feeAsset?.assetId],
+  )
+  const feeAssetBalance = useAppSelector(s =>
+    selectPortfolioCryptoHumanBalanceByFilter(s, feeAssetBalanceFilter),
   )
 
   const handleDeposit = useCallback(async () => {

--- a/src/features/defi/providers/foxy/components/FoxyManager/Withdraw/components/Confirm.tsx
+++ b/src/features/defi/providers/foxy/components/FoxyManager/Withdraw/components/Confirm.tsx
@@ -85,7 +85,7 @@ export const Confirm: React.FC<StepComponentProps & { accountId?: Nullable<Accou
 
   const feeAssetBalanceFilter = useMemo(
     () => ({ assetId: feeAsset?.assetId, accountId: accountId ?? '' }),
-    [feeAsset?.assetId],
+    [accountId, feeAsset?.assetId],
   )
   const feeAssetBalance = useAppSelector(s =>
     selectPortfolioCryptoHumanBalanceByFilter(s, feeAssetBalanceFilter),

--- a/src/features/defi/providers/foxy/components/FoxyManager/Withdraw/components/Confirm.tsx
+++ b/src/features/defi/providers/foxy/components/FoxyManager/Withdraw/components/Confirm.tsx
@@ -28,7 +28,7 @@ import {
   selectAssetById,
   selectBIP44ParamsByAccountId,
   selectMarketDataById,
-  selectPortfolioCryptoHumanBalanceByAssetId,
+  selectPortfolioCryptoHumanBalanceByFilter,
 } from 'state/slices/selectors'
 import { useAppSelector } from 'state/store'
 import type { Nullable } from 'types/common'
@@ -83,8 +83,12 @@ export const Confirm: React.FC<StepComponentProps & { accountId?: Nullable<Accou
       : '0'
   }, [state?.withdraw.withdrawType, state?.withdraw.cryptoAmount, state?.foxyFeePercentage])
 
-  const feeAssetBalance = useAppSelector(state =>
-    selectPortfolioCryptoHumanBalanceByAssetId(state, { assetId: feeAsset?.assetId ?? '' }),
+  const feeAssetBalanceFilter = useMemo(
+    () => ({ assetId: feeAsset?.assetId, accountId: accountId ?? '' }),
+    [feeAsset?.assetId],
+  )
+  const feeAssetBalance = useAppSelector(s =>
+    selectPortfolioCryptoHumanBalanceByFilter(s, feeAssetBalanceFilter),
   )
 
   const accountAddress = useMemo(

--- a/src/features/defi/providers/idle/components/IdleManager/Claim/IdleClaim.tsx
+++ b/src/features/defi/providers/idle/components/IdleManager/Claim/IdleClaim.tsx
@@ -1,4 +1,5 @@
 import { Center, useToast } from '@chakra-ui/react'
+import type { AccountId } from '@shapeshiftoss/caip'
 import { toAssetId } from '@shapeshiftoss/caip'
 import { KnownChainIds } from '@shapeshiftoss/types'
 import { DefiModalContent } from 'features/defi/components/DefiModal/DefiModalContent'
@@ -21,6 +22,7 @@ import { useWallet } from 'hooks/useWallet/useWallet'
 import { logger } from 'lib/logger'
 import { selectAssetById, selectMarketDataById } from 'state/slices/selectors'
 import { useAppSelector } from 'state/store'
+import type { Nullable } from 'types/common'
 
 import { IdleClaimActionType } from './ClaimCommon'
 import { ClaimContext } from './ClaimContext'
@@ -32,7 +34,9 @@ const moduleLogger = logger.child({
   namespace: ['DeFi', 'Providers', 'Idle', 'IdleClaim'],
 })
 
-export const IdleClaim = () => {
+type IdleClaimProps = { accountId: Nullable<AccountId> }
+
+export const IdleClaim: React.FC<IdleClaimProps> = ({ accountId }) => {
   const { idleInvestor } = useIdle()
   const [state, dispatch] = useReducer(reducer, initialState)
   const translate = useTranslate()
@@ -120,7 +124,7 @@ export const IdleClaim = () => {
         description: translate('defi.steps.claim.info.description', {
           asset: underlyingAsset.symbol,
         }),
-        component: Confirm,
+        component: ownProps => <Confirm {...ownProps} accountId={accountId} />,
       },
       [DefiStep.Status]: {
         label: translate('defi.steps.status.title'),
@@ -128,7 +132,7 @@ export const IdleClaim = () => {
       },
     }
     // We only need this to update on symbol change
-  }, [translate, underlyingAsset.symbol])
+  }, [accountId, translate, underlyingAsset.symbol])
 
   if (!asset || !marketData || !state.userAddress || !state.claimableTokens)
     return (

--- a/src/features/defi/providers/idle/components/IdleManager/Claim/components/Confirm.tsx
+++ b/src/features/defi/providers/idle/components/IdleManager/Claim/components/Confirm.tsx
@@ -1,4 +1,5 @@
 import { Alert, AlertIcon, Box, Stack } from '@chakra-ui/react'
+import type { AccountId } from '@shapeshiftoss/caip'
 import { toAssetId } from '@shapeshiftoss/caip'
 import { supportsETH } from '@shapeshiftoss/hdwallet-core'
 import { Confirm as ReusableConfirm } from 'features/defi/components/Confirm/Confirm'
@@ -24,9 +25,10 @@ import { logger } from 'lib/logger'
 import {
   selectAssetById,
   selectMarketDataById,
-  selectPortfolioCryptoHumanBalanceByAssetId,
+  selectPortfolioCryptoHumanBalanceByFilter,
 } from 'state/slices/selectors'
 import { useAppSelector } from 'state/store'
+import type { Nullable } from 'types/common'
 
 import { IdleClaimActionType } from '../ClaimCommon'
 import { ClaimContext } from '../ClaimContext'
@@ -34,7 +36,9 @@ import { ClaimableAsset } from './ClaimableAsset'
 
 const moduleLogger = logger.child({ namespace: ['IdleClaim:Confirm'] })
 
-export const Confirm = ({ onNext }: StepComponentProps) => {
+type ConfirmProps = { accountId: Nullable<AccountId> } & StepComponentProps
+
+export const Confirm = ({ accountId, onNext }: ConfirmProps) => {
   const translate = useTranslate()
   const { state, dispatch } = useContext(ClaimContext)
   const { idleInvestor } = useIdle()
@@ -58,8 +62,12 @@ export const Confirm = ({ onNext }: StepComponentProps) => {
   // user info
   const { state: walletState } = useWallet()
 
-  const feeAssetBalance = useAppSelector(state =>
-    selectPortfolioCryptoHumanBalanceByAssetId(state, { assetId: feeAsset?.assetId ?? '' }),
+  const feeAssetBalanceFilter = useMemo(
+    () => ({ assetId: feeAsset?.assetId, accountId: accountId ?? '' }),
+    [feeAsset?.assetId],
+  )
+  const feeAssetBalance = useAppSelector(s =>
+    selectPortfolioCryptoHumanBalanceByFilter(s, feeAssetBalanceFilter),
   )
 
   useEffect(() => {

--- a/src/features/defi/providers/idle/components/IdleManager/Claim/components/Confirm.tsx
+++ b/src/features/defi/providers/idle/components/IdleManager/Claim/components/Confirm.tsx
@@ -64,7 +64,7 @@ export const Confirm = ({ accountId, onNext }: ConfirmProps) => {
 
   const feeAssetBalanceFilter = useMemo(
     () => ({ assetId: feeAsset?.assetId, accountId: accountId ?? '' }),
-    [feeAsset?.assetId],
+    [accountId, feeAsset?.assetId],
   )
   const feeAssetBalance = useAppSelector(s =>
     selectPortfolioCryptoHumanBalanceByFilter(s, feeAssetBalanceFilter),

--- a/src/features/defi/providers/idle/components/IdleManager/Deposit/IdleDeposit.tsx
+++ b/src/features/defi/providers/idle/components/IdleManager/Deposit/IdleDeposit.tsx
@@ -1,4 +1,5 @@
 import { Center, useToast } from '@chakra-ui/react'
+import type { AccountId } from '@shapeshiftoss/caip'
 import { toAssetId } from '@shapeshiftoss/caip'
 import { KnownChainIds } from '@shapeshiftoss/types'
 import { DefiModalContent } from 'features/defi/components/DefiModal/DefiModalContent'
@@ -13,6 +14,7 @@ import qs from 'qs'
 import { useCallback, useEffect, useMemo, useReducer } from 'react'
 import { useTranslate } from 'react-polyglot'
 import { useSelector } from 'react-redux'
+import type { AccountDropdownProps } from 'components/AccountDropdown/AccountDropdown'
 import { CircularProgress } from 'components/CircularProgress/CircularProgress'
 import type { DefiStepProps } from 'components/DeFi/components/Steps'
 import { Steps } from 'components/DeFi/components/Steps'
@@ -26,6 +28,7 @@ import {
   selectPortfolioLoading,
 } from 'state/slices/selectors'
 import { useAppSelector } from 'state/store'
+import type { Nullable } from 'types/common'
 
 import { Approve } from './components/Approve'
 import { Confirm } from './components/Confirm'
@@ -39,7 +42,15 @@ const moduleLogger = logger.child({
   namespace: ['Defi', 'Providers', 'Idle', 'IdleManager', 'Deposit', 'IdleDeposit'],
 })
 
-export const IdleDeposit = () => {
+type IdleDepositProps = {
+  accountId: Nullable<AccountId>
+  onAccountIdChange: AccountDropdownProps['onChange']
+}
+
+export const IdleDeposit: React.FC<IdleDepositProps> = ({
+  accountId,
+  onAccountIdChange: handleAccountIdChange,
+}) => {
   const { idleInvestor } = useIdle()
   const [state, dispatch] = useReducer(reducer, initialState)
   const translate = useTranslate()
@@ -112,22 +123,24 @@ export const IdleDeposit = () => {
       [DefiStep.Info]: {
         label: translate('defi.steps.deposit.info.title'),
         description: translate('defi.steps.deposit.info.description', { asset: asset.symbol }),
-        component: Deposit,
+        component: ownProps => (
+          <Deposit {...ownProps} accountId={accountId} onAccountIdChange={handleAccountIdChange} />
+        ),
       },
       [DefiStep.Approve]: {
         label: translate('defi.steps.approve.title'),
-        component: Approve,
+        component: ownProps => <Approve {...ownProps} accountId={accountId} />,
       },
       [DefiStep.Confirm]: {
         label: translate('defi.steps.confirm.title'),
-        component: Confirm,
+        component: ownProps => <Confirm {...ownProps} accountId={accountId} />,
       },
       [DefiStep.Status]: {
         label: translate('defi.steps.status.title'),
         component: Status,
       },
     }
-  }, [translate, asset.symbol])
+  }, [translate, asset.symbol, accountId, handleAccountIdChange])
 
   if (loading || !asset || !marketData || !idleInvestor) {
     return (

--- a/src/features/defi/providers/idle/components/IdleManager/Deposit/components/Approve.tsx
+++ b/src/features/defi/providers/idle/components/IdleManager/Deposit/components/Approve.tsx
@@ -1,4 +1,5 @@
 import { useToast } from '@chakra-ui/react'
+import type { AccountId } from '@shapeshiftoss/caip'
 import { toAssetId } from '@shapeshiftoss/caip'
 import { supportsETH } from '@shapeshiftoss/hdwallet-core'
 import { ssRouterContractAddress } from '@shapeshiftoss/investor-idle'
@@ -14,6 +15,7 @@ import { useIdle } from 'features/defi/contexts/IdleProvider/IdleProvider'
 import { canCoverTxFees } from 'features/defi/helpers/utils'
 import { useCallback, useContext, useMemo } from 'react'
 import { useTranslate } from 'react-polyglot'
+import type { StepComponentProps } from 'components/DeFi/components/Steps'
 import { getChainAdapterManager } from 'context/PluginProvider/chainAdapterSingleton'
 import { useBrowserRouter } from 'hooks/useBrowserRouter/useBrowserRouter'
 import { useWallet } from 'hooks/useWallet/useWallet'
@@ -22,13 +24,12 @@ import { logger } from 'lib/logger'
 import { poll } from 'lib/poll/poll'
 import { selectAssetById, selectMarketDataById } from 'state/slices/selectors'
 import { useAppSelector } from 'state/store'
+import type { Nullable } from 'types/common'
 
 import { IdleDepositActionType } from '../DepositCommon'
 import { DepositContext } from '../DepositContext'
 
-type IdleApproveProps = {
-  onNext: (arg: DefiStep) => void
-}
+type IdleApproveProps = StepComponentProps & { accountId: Nullable<AccountId> }
 
 const moduleLogger = logger.child({ namespace: ['IdleDeposit:Approve'] })
 

--- a/src/features/defi/providers/idle/components/IdleManager/Deposit/components/Confirm.tsx
+++ b/src/features/defi/providers/idle/components/IdleManager/Deposit/components/Confirm.tsx
@@ -1,4 +1,5 @@
 import { Alert, AlertIcon, Box, Stack, useToast } from '@chakra-ui/react'
+import type { AccountId } from '@shapeshiftoss/caip'
 import { toAssetId } from '@shapeshiftoss/caip'
 import { supportsETH } from '@shapeshiftoss/hdwallet-core'
 import { Confirm as ReusableConfirm } from 'features/defi/components/Confirm/Confirm'
@@ -24,16 +25,19 @@ import { logger } from 'lib/logger'
 import {
   selectAssetById,
   selectMarketDataById,
-  selectPortfolioCryptoHumanBalanceByAssetId,
+  selectPortfolioCryptoHumanBalanceByFilter,
 } from 'state/slices/selectors'
 import { useAppSelector } from 'state/store'
+import type { Nullable } from 'types/common'
 
 import { IdleDepositActionType } from '../DepositCommon'
 import { DepositContext } from '../DepositContext'
 
 const moduleLogger = logger.child({ namespace: ['IdleDeposit:Confirm'] })
 
-export const Confirm: React.FC<StepComponentProps> = ({ onNext }) => {
+type ConfirmProps = { accountId: Nullable<AccountId> } & StepComponentProps
+
+export const Confirm: React.FC<ConfirmProps> = ({ accountId, onNext }) => {
   const { state, dispatch } = useContext(DepositContext)
   const translate = useTranslate()
   const { query } = useBrowserRouter<DefiQueryParams, DefiParams>()
@@ -56,8 +60,12 @@ export const Confirm: React.FC<StepComponentProps> = ({ onNext }) => {
   // notify
   const toast = useToast()
 
-  const feeAssetBalance = useAppSelector(state =>
-    selectPortfolioCryptoHumanBalanceByAssetId(state, { assetId: feeAsset?.assetId ?? '' }),
+  const feeAssetBalanceFilter = useMemo(
+    () => ({ assetId: feeAsset?.assetId, accountId: accountId ?? '' }),
+    [accountId, feeAsset?.assetId],
+  )
+  const feeAssetBalance = useAppSelector(s =>
+    selectPortfolioCryptoHumanBalanceByFilter(s, feeAssetBalanceFilter),
   )
 
   const handleDeposit = useCallback(async () => {

--- a/src/features/defi/providers/idle/components/IdleManager/Deposit/components/Deposit.tsx
+++ b/src/features/defi/providers/idle/components/IdleManager/Deposit/components/Deposit.tsx
@@ -1,4 +1,5 @@
 import { useToast } from '@chakra-ui/react'
+import type { AccountId } from '@shapeshiftoss/caip'
 import { toAssetId } from '@shapeshiftoss/caip'
 import type { DepositValues } from 'features/defi/components/Deposit/Deposit'
 import { Deposit as ReusableDeposit } from 'features/defi/components/Deposit/Deposit'
@@ -12,6 +13,7 @@ import qs from 'qs'
 import { useCallback, useContext, useMemo } from 'react'
 import { useTranslate } from 'react-polyglot'
 import { useHistory } from 'react-router-dom'
+import type { AccountDropdownProps } from 'components/AccountDropdown/AccountDropdown'
 import type { StepComponentProps } from 'components/DeFi/components/Steps'
 import { useBrowserRouter } from 'hooks/useBrowserRouter/useBrowserRouter'
 import { bnOrZero } from 'lib/bignumber/bignumber'
@@ -22,13 +24,23 @@ import {
   selectPortfolioCryptoBalanceByAssetId,
 } from 'state/slices/selectors'
 import { useAppSelector } from 'state/store'
+import type { Nullable } from 'types/common'
 
 import { IdleDepositActionType } from '../DepositCommon'
 import { DepositContext } from '../DepositContext'
 
 const moduleLogger = logger.child({ namespace: ['IdleDeposit:Deposit'] })
 
-export const Deposit: React.FC<StepComponentProps> = ({ onNext }) => {
+type DepositProps = StepComponentProps & {
+  accountId?: Nullable<AccountId>
+  onAccountIdChange: AccountDropdownProps['onChange']
+} & StepComponentProps
+
+export const Deposit: React.FC<DepositProps> = ({
+  accountId,
+  onAccountIdChange: handleAccountIdChange,
+  onNext,
+}) => {
   const { state, dispatch } = useContext(DepositContext)
   const history = useHistory()
   const translate = useTranslate()
@@ -225,6 +237,8 @@ export const Deposit: React.FC<StepComponentProps> = ({ onNext }) => {
 
   return (
     <ReusableDeposit
+      accountId={accountId}
+      onAccountIdChange={handleAccountIdChange}
       asset={asset}
       apy={bnOrZero(opportunity?.metadata.apy?.net_apy).toString()}
       cryptoAmountAvailable={cryptoAmountAvailable.toPrecision()}

--- a/src/features/defi/providers/idle/components/IdleManager/IdleManager.tsx
+++ b/src/features/defi/providers/idle/components/IdleManager/IdleManager.tsx
@@ -1,11 +1,14 @@
+import type { AccountId } from '@shapeshiftoss/caip'
 import type {
   DefiParams,
   DefiQueryParams,
 } from 'features/defi/contexts/DefiManagerProvider/DefiCommon'
 import { DefiAction } from 'features/defi/contexts/DefiManagerProvider/DefiCommon'
 import { AnimatePresence } from 'framer-motion'
+import { useState } from 'react'
 import { SlideTransition } from 'components/SlideTransition'
 import { useBrowserRouter } from 'hooks/useBrowserRouter/useBrowserRouter'
+import type { Nullable } from 'types/common'
 
 import { IdleClaim } from './Claim/IdleClaim'
 import { IdleDeposit } from './Deposit/IdleDeposit'
@@ -13,6 +16,7 @@ import { IdleOverview } from './Overview/IdleOverview'
 import { IdleWithdraw } from './Withdraw/IdleWithdraw'
 
 export const IdleManager = () => {
+  const [accountId, setAccountId] = useState<Nullable<AccountId>>(null)
   const { query } = useBrowserRouter<DefiQueryParams, DefiParams>()
   const { modal } = query
 
@@ -20,22 +24,22 @@ export const IdleManager = () => {
     <AnimatePresence exitBeforeEnter initial={false}>
       {modal === DefiAction.Overview && (
         <SlideTransition key={DefiAction.Overview}>
-          <IdleOverview />
+          <IdleOverview onAccountIdChange={setAccountId} accountId={accountId} />
         </SlideTransition>
       )}
       {modal === DefiAction.Deposit && (
         <SlideTransition key={DefiAction.Deposit}>
-          <IdleDeposit />
+          <IdleDeposit onAccountIdChange={setAccountId} accountId={accountId} />
         </SlideTransition>
       )}
       {modal === DefiAction.Withdraw && (
         <SlideTransition key={DefiAction.Withdraw}>
-          <IdleWithdraw />
+          <IdleWithdraw onAccountIdChange={setAccountId} accountId={accountId} />
         </SlideTransition>
       )}
       {modal === DefiAction.Claim && (
         <SlideTransition key={DefiAction.Claim}>
-          <IdleClaim />
+          <IdleClaim accountId={accountId} />
         </SlideTransition>
       )}
     </AnimatePresence>

--- a/src/features/defi/providers/idle/components/IdleManager/Overview/IdleOverview.tsx
+++ b/src/features/defi/providers/idle/components/IdleManager/Overview/IdleOverview.tsx
@@ -1,5 +1,6 @@
 import { ArrowDownIcon, ArrowUpIcon } from '@chakra-ui/icons'
 import { Center, useToast } from '@chakra-ui/react'
+import type { AccountId } from '@shapeshiftoss/caip'
 import { toAssetId } from '@shapeshiftoss/caip'
 import type { ClaimableToken, IdleOpportunity } from '@shapeshiftoss/investor-idle'
 import { KnownChainIds } from '@shapeshiftoss/types'
@@ -16,6 +17,7 @@ import { useIdle } from 'features/defi/contexts/IdleProvider/IdleProvider'
 import { useEffect, useMemo, useState } from 'react'
 import { FaGift } from 'react-icons/fa'
 import { useTranslate } from 'react-polyglot'
+import type { AccountDropdownProps } from 'components/AccountDropdown/AccountDropdown'
 import { CircularProgress } from 'components/CircularProgress/CircularProgress'
 import { getChainAdapterManager } from 'context/PluginProvider/chainAdapterSingleton'
 import { useBrowserRouter } from 'hooks/useBrowserRouter/useBrowserRouter'
@@ -30,6 +32,7 @@ import {
   selectSelectedLocale,
 } from 'state/slices/selectors'
 import { useAppSelector } from 'state/store'
+import type { Nullable } from 'types/common'
 
 const moduleLogger = logger.child({
   namespace: ['Defi', 'Providers', 'Idle', 'IdleManager', 'Overview', 'IdleOverview'],
@@ -48,7 +51,15 @@ const defaultMenu: DefiButtonProps[] = [
   },
 ]
 
-export const IdleOverview = () => {
+type IdleOverviewProps = {
+  accountId: Nullable<AccountId>
+  onAccountIdChange: AccountDropdownProps['onChange']
+}
+
+export const IdleOverview: React.FC<IdleOverviewProps> = ({
+  accountId,
+  onAccountIdChange: handleAccountIdChange,
+}) => {
   const { idleInvestor } = useIdle()
   const translate = useTranslate()
   const toast = useToast()
@@ -185,6 +196,8 @@ export const IdleOverview = () => {
 
   return (
     <Overview
+      accountId={accountId}
+      onAccountIdChange={handleAccountIdChange}
       asset={asset}
       name={`${underlyingToken.name} Vault (${opportunity.version})`}
       opportunityFiatBalance={fiatAmountAvailable.toFixed(2)}

--- a/src/features/defi/providers/idle/components/IdleManager/Withdraw/IdleWithdraw.tsx
+++ b/src/features/defi/providers/idle/components/IdleManager/Withdraw/IdleWithdraw.tsx
@@ -1,4 +1,5 @@
 import { Center, useToast } from '@chakra-ui/react'
+import type { AccountId } from '@shapeshiftoss/caip'
 import { toAssetId } from '@shapeshiftoss/caip'
 import { KnownChainIds } from '@shapeshiftoss/types'
 import { DefiModalContent } from 'features/defi/components/DefiModal/DefiModalContent'
@@ -13,6 +14,7 @@ import qs from 'qs'
 import { useCallback, useEffect, useMemo, useReducer } from 'react'
 import { useTranslate } from 'react-polyglot'
 import { useSelector } from 'react-redux'
+import type { AccountDropdownProps } from 'components/AccountDropdown/AccountDropdown'
 import { CircularProgress } from 'components/CircularProgress/CircularProgress'
 import type { DefiStepProps } from 'components/DeFi/components/Steps'
 import { Steps } from 'components/DeFi/components/Steps'
@@ -26,6 +28,7 @@ import {
   selectPortfolioLoading,
 } from 'state/slices/selectors'
 import { useAppSelector } from 'state/store'
+import type { Nullable } from 'types/common'
 
 import { Confirm } from './components/Confirm'
 import { Status } from './components/Status'
@@ -38,7 +41,12 @@ const moduleLogger = logger.child({
   namespace: ['Defi', 'Providers', 'Idle', 'IdleManager', 'Withdraw', 'IdleWithdraw'],
 })
 
-export const IdleWithdraw = () => {
+type WithdrawProps = {
+  accountId: Nullable<AccountId>
+  onAccountIdChange: AccountDropdownProps['onChange']
+}
+
+export const IdleWithdraw: React.FC<WithdrawProps> = ({ accountId }) => {
   const { idleInvestor } = useIdle()
   const [state, dispatch] = useReducer(reducer, initialState)
   const translate = useTranslate()
@@ -128,7 +136,7 @@ export const IdleWithdraw = () => {
       },
       [DefiStep.Confirm]: {
         label: translate('defi.steps.confirm.title'),
-        component: Confirm,
+        component: ownProps => <Confirm {...ownProps} accountId={accountId} />,
       },
       [DefiStep.Status]: {
         label: translate('defi.steps.status.title'),
@@ -136,7 +144,7 @@ export const IdleWithdraw = () => {
       },
     }
     // We only need this to update on symbol change
-  }, [translate, underlyingAsset.symbol])
+  }, [accountId, translate, underlyingAsset.symbol])
 
   if (loading || !asset || !marketData)
     return (

--- a/src/features/defi/providers/idle/components/IdleManager/Withdraw/components/Confirm.tsx
+++ b/src/features/defi/providers/idle/components/IdleManager/Withdraw/components/Confirm.tsx
@@ -39,7 +39,7 @@ const moduleLogger = logger.child({
 
 type ConfirmProps = { accountId: Nullable<AccountId> } & StepComponentProps
 
-export const Confirm = ({ accountId, onNext }: ConfirmProps) => {
+export const Confirm: React.FC<ConfirmProps> = ({ accountId, onNext }) => {
   const { state, dispatch } = useContext(WithdrawContext)
   const translate = useTranslate()
   const { query } = useBrowserRouter<DefiQueryParams, DefiParams>()

--- a/src/features/defi/providers/idle/components/IdleManager/Withdraw/components/Confirm.tsx
+++ b/src/features/defi/providers/idle/components/IdleManager/Withdraw/components/Confirm.tsx
@@ -1,4 +1,5 @@
 import { Alert, AlertIcon, Box, Stack } from '@chakra-ui/react'
+import type { AccountId } from '@shapeshiftoss/caip'
 import { toAssetId } from '@shapeshiftoss/caip'
 import { supportsETH } from '@shapeshiftoss/hdwallet-core'
 import { Confirm as ReusableConfirm } from 'features/defi/components/Confirm/Confirm'
@@ -24,9 +25,10 @@ import { logger } from 'lib/logger'
 import {
   selectAssetById,
   selectMarketDataById,
-  selectPortfolioCryptoHumanBalanceByAssetId,
+  selectPortfolioCryptoHumanBalanceByFilter,
 } from 'state/slices/selectors'
 import { useAppSelector } from 'state/store'
+import type { Nullable } from 'types/common'
 
 import { IdleWithdrawActionType } from '../WithdrawCommon'
 import { WithdrawContext } from '../WithdrawContext'
@@ -35,7 +37,9 @@ const moduleLogger = logger.child({
   namespace: ['Defi', 'Providers', 'Idle', 'IdleManager', 'Withdraw', 'Confirm'],
 })
 
-export const Confirm = ({ onNext }: StepComponentProps) => {
+type ConfirmProps = { accountId: Nullable<AccountId> } & StepComponentProps
+
+export const Confirm = ({ accountId, onNext }: ConfirmProps) => {
   const { state, dispatch } = useContext(WithdrawContext)
   const translate = useTranslate()
   const { query } = useBrowserRouter<DefiQueryParams, DefiParams>()
@@ -65,8 +69,12 @@ export const Confirm = ({ onNext }: StepComponentProps) => {
   // user info
   const { state: walletState } = useWallet()
 
-  const feeAssetBalance = useAppSelector(state =>
-    selectPortfolioCryptoHumanBalanceByAssetId(state, { assetId: feeAsset?.assetId ?? '' }),
+  const feeAssetBalanceFilter = useMemo(
+    () => ({ assetId: feeAsset?.assetId, accountId: accountId ?? '' }),
+    [accountId, feeAsset?.assetId],
+  )
+  const feeAssetBalance = useAppSelector(s =>
+    selectPortfolioCryptoHumanBalanceByFilter(s, feeAssetBalanceFilter),
   )
 
   const handleConfirm = useCallback(async () => {

--- a/src/features/defi/providers/yearn/components/YearnManager/Deposit/components/Confirm.tsx
+++ b/src/features/defi/providers/yearn/components/YearnManager/Deposit/components/Confirm.tsx
@@ -67,7 +67,7 @@ export const Confirm: React.FC<StepComponentProps & { accountId: Nullable<Accoun
 
   const feeAssetBalanceFilter = useMemo(
     () => ({ assetId: feeAsset?.assetId, accountId: accountId ?? '' }),
-    [feeAsset?.assetId],
+    [accountId, feeAsset?.assetId],
   )
   const feeAssetBalance = useAppSelector(s =>
     selectPortfolioCryptoHumanBalanceByFilter(s, feeAssetBalanceFilter),

--- a/src/features/defi/providers/yearn/components/YearnManager/Deposit/components/Confirm.tsx
+++ b/src/features/defi/providers/yearn/components/YearnManager/Deposit/components/Confirm.tsx
@@ -26,7 +26,7 @@ import {
   selectAssetById,
   selectBIP44ParamsByAccountId,
   selectMarketDataById,
-  selectPortfolioCryptoHumanBalanceByAssetId,
+  selectPortfolioCryptoHumanBalanceByFilter,
 } from 'state/slices/selectors'
 import { useAppSelector } from 'state/store'
 import type { Nullable } from 'types/common'
@@ -65,8 +65,12 @@ export const Confirm: React.FC<StepComponentProps & { accountId: Nullable<Accoun
   // notify
   const toast = useToast()
 
-  const feeAssetBalance = useAppSelector(state =>
-    selectPortfolioCryptoHumanBalanceByAssetId(state, { assetId: feeAsset?.assetId ?? '' }),
+  const feeAssetBalanceFilter = useMemo(
+    () => ({ assetId: feeAsset?.assetId, accountId: accountId ?? '' }),
+    [feeAsset?.assetId],
+  )
+  const feeAssetBalance = useAppSelector(s =>
+    selectPortfolioCryptoHumanBalanceByFilter(s, feeAssetBalanceFilter),
   )
 
   const accountAddress = useMemo(

--- a/src/features/defi/providers/yearn/components/YearnManager/Withdraw/components/Confirm.tsx
+++ b/src/features/defi/providers/yearn/components/YearnManager/Withdraw/components/Confirm.tsx
@@ -26,7 +26,7 @@ import {
   selectAssetById,
   selectBIP44ParamsByAccountId,
   selectMarketDataById,
-  selectPortfolioCryptoHumanBalanceByAssetId,
+  selectPortfolioCryptoHumanBalanceByFilter,
 } from 'state/slices/selectors'
 import { useAppSelector } from 'state/store'
 import type { Nullable } from 'types/common'
@@ -74,8 +74,12 @@ export const Confirm: React.FC<StepComponentProps & { accountId: Nullable<Accoun
   // user info
   const { state: walletState } = useWallet()
 
-  const feeAssetBalance = useAppSelector(state =>
-    selectPortfolioCryptoHumanBalanceByAssetId(state, { assetId: feeAsset?.assetId ?? '' }),
+  const feeAssetBalanceFilter = useMemo(
+    () => ({ assetId: feeAsset?.assetId, accountId: accountId ?? '' }),
+    [accountId, feeAsset?.assetId],
+  )
+  const feeAssetBalance = useAppSelector(s =>
+    selectPortfolioCryptoHumanBalanceByFilter(s, feeAssetBalanceFilter),
   )
 
   const accountAddress = useMemo(


### PR DESCRIPTION
## Description

This PR fixes the `feeAssetBalance` to use a granular portfolio balance by AccountId, as opposed to selecting the aggregation over all accounts currently.

Accidentally brings multi account ish support over the Idle DeFi provider, although this only passes `AccountId` around for consistency and does not bring account bip44Params support yet, TBD in https://github.com/shapeshift/lib/issues/943

## Notice

<!-- Before submitting a pull request, please make sure you have answered the following: -->

- [x] Have you followed the guidelines in our [Contributing]('https://github.com/shapeshift/web/blob/develop/CONTRIBUTING.md) guide?
- [x] Have you checked to ensure there aren't other open [Pull Requests](https://github.com/shapeshift/web/pulls) for the same update/change?

## Pull Request Type

- [x] :bug: Bug fix (Non-breaking Change: Fixes an issue)
- [ ] :hammer_and_wrench: Chore (Non-breaking Change: Doc updates, pkg upgrades, typos, etc..)
- [ ] :nail_care: New Feature (Breaking/Non-breaking Change)

## Issue (if applicable)

<!-----------------------------------------------------------------------------
If applicable, please link to the github issue and put `closes #XXXX` in your comment to auto-close the issue that your PR fixes.
------------------------------------------------------------------------------>

closes https://github.com/shapeshift/web/issues/3209

## Risk

<!-----------------------------------------------------------------------------
Outline the scope of your changes and the risk associated with them. You must use your discretion as an engineer to determine the potential impact of your changes.

E.g. an upgrade to `hdwallet` or core state management would be considered higher risk, and might require a full regression test. UI or isolated view changes, or something behind a feature flag may have near zero risk. Small bug fixes might require testing isolated to the specific fix.
------------------------------------------------------------------------------>

- Multi-account could be borked over the DeFi section, test accordingly

## Testing

<!-----------------------------------------------------------------------------
We treat every PR to be merged with the same scrutiny as if we were merging directly to production.

Your PR will not be merged if you do not complete the sections below for our engineering and operations teams to test.
------------------------------------------------------------------------------>

- Have an account, either 0 or another without enough ETH for gas, but either enough dust to deposit, staked amount to withdraw, or rewards to claim
- Have some ETH balance over your other accounts to total to a significant amount to cover gas
- Ensure when depositing/withdrawing/claiming for your account without enough ETH for gas, the "Not enough ETH to cover gas" message is shown and the sign and broadcast button is disabled
- Ensure when depositing/withdrawing/claiming for another account with enough ETH for gas, it is possible to continue with the flow

### Engineering

<!-----------------------------------------------------------------------------
Include sufficient information here for an engineer to test your PR. This may include how to test locally, in a built environment, changes to infrastructure etc.
------------------------------------------------------------------------------>

☝🏽 

### Operations

<!-----------------------------------------------------------------------------
If your changes have a user-facing impact, describe how a non-technical QA team can functionally test your changes in a preview environment.

If they are not user-facing please describe how to test for any regressions that may occur.
------------------------------------------------------------------------------>

☝🏽

## Screenshots (if applicable)

<img width="524" alt="image" src="https://user-images.githubusercontent.com/17035424/199617088-4aad5eea-4bb4-49a4-808b-a6bd01bc04cf.png">
<img width="523" alt="image" src="https://user-images.githubusercontent.com/17035424/199619077-8bb4b5d6-a999-4fd9-82ad-a6d343aa80ed.png">

<img width="524" alt="image" src="https://user-images.githubusercontent.com/17035424/199619108-642e8349-3069-4c71-9a4e-00febf4567e4.png">
<img width="529" alt="image" src="https://user-images.githubusercontent.com/17035424/199619136-8090d8d5-1c4a-458b-9f05-4b503fe7ebcd.png">

<img width="524" alt="image" src="https://user-images.githubusercontent.com/17035424/199619167-0c59b9c1-eb6c-4ddf-b153-0352c1c36240.png">
<img width="533" alt="image" src="https://user-images.githubusercontent.com/17035424/199619543-23a33cd2-6417-4731-9805-0fd543c2eeb5.png">