### PR TITLE
fix: re-calculate values on NAN amount

### DIFF
--- a/src/components/Trade/hooks/useTradeAmounts.tsx
+++ b/src/components/Trade/hooks/useTradeAmounts.tsx
@@ -96,7 +96,7 @@ export const useTradeAmounts = () => {
       const buyAssetUsdRate = args.buyAssetUsdRate ?? buyAssetFiatRateFormState
       const sellAssetUsdRate = args.sellAssetUsdRate ?? sellAssetFiatRateFormState
       const fees = args.fees ?? feesFormState
-      if (sellAsset && buyAsset && amount && action && buyAssetUsdRate && sellAssetUsdRate) {
+      if (sellAsset && buyAsset && action && buyAssetUsdRate && sellAssetUsdRate) {
         setTradeAmounts({
           amount,
           action,


### PR DESCRIPTION
## Description

This PR fixes an issue where highlighting the trade input amount for the buy or sell asset and pressing delete would not actually delete the values.

On the second press, it would show the placeholder, but still not actually delete the values.

## Notice

- [x] Have you followed the guidelines in our [Contributing]('https://github.com/shapeshift/web/blob/develop/CONTRIBUTING.md) guide?
- [x] Have you checked to ensure there aren't other open [Pull Requests](https://github.com/shapeshift/web/pulls) for the same update/change?

## Pull Request Type

- [x] :bug: Bug fix (Non-breaking Change: Fixes an issue)
- [ ] :hammer_and_wrench: Chore (Non-breaking Change: Doc updates, pkg upgrades, typos, etc..)
- [ ] :nail_care: New Feature (Breaking/Non-breaking Change)

## Issue (if applicable)

Closes https://github.com/shapeshift/web/issues/3185

## Risk

Small, relates to the input values of a trade. 

## Testing

1. On the trade modal, type in a value into the input asset
2. Highlight the value and press delete
3. Notice it now deletes the value as expected

### Engineering

☝️ 

### Operations

☝️ 

## Screenshots (if applicable)

N/A