### PR TITLE
fix: set quote on route change

### DIFF
--- a/src/components/Trade/hooks/useTradeQuoteService.tsx
+++ b/src/components/Trade/hooks/useTradeQuoteService.tsx
@@ -93,6 +93,7 @@ export const useTradeQuoteService = () => {
   const amount = useWatch({ control, name: 'amount' })
   const action = useWatch({ control, name: 'action' })
   const isSendMax = useWatch({ control, name: 'isSendMax' })
+  const quote = useWatch({ control, name: 'quote' })
 
   // Types
   type TradeQuoteQueryInput = Parameters<typeof useGetTradeQuoteQuery>
@@ -175,10 +176,14 @@ export const useTradeQuoteService = () => {
     isSendMax,
   ])
 
-  // Set trade quote
+  // Update trade quote
+  useEffect(() => setValue('quote', tradeQuote), [tradeQuote, setValue])
+
+  // Set trade quote if not yet set (e.g. on page load)
   useEffect(() => {
-    setValue('quote', tradeQuote)
-  }, [tradeQuote, setValue])
+    // Checking that no quote has been set and tradeQuote exists prevents an infinite render
+    !quote && tradeQuote && setValue('quote', tradeQuote)
+  }, [quote, setValue, tradeQuote])
 
   return { isLoadingTradeQuote }
 }


### PR DESCRIPTION
## Description

Sometimes on route change the React Hook Form trade form instantiation would be torn down and re-initialized.
This would fire a `useEffect` that cleared the `quote`, and so we'd have no initial rate on a route change until the RTK query polled or an input changed.

This PR adds a `useEffect` that fires in this case to re-set the quote to the current `tradeQuote` value in `useTradeQuoteService`, ensuring it stays defined.

## Notice

- [x] Have you followed the guidelines in our [Contributing]('https://github.com/shapeshift/web/blob/develop/CONTRIBUTING.md) guide?
- [x] Have you checked to ensure there aren't other open [Pull Requests](https://github.com/shapeshift/web/pulls) for the same update/change?

## Pull Request Type

- [x] :bug: Bug fix (Non-breaking Change: Fixes an issue)
- [ ] :hammer_and_wrench: Chore (Non-breaking Change: Doc updates, pkg upgrades, typos, etc..)
- [ ] :nail_care: New Feature (Breaking/Non-breaking Change)

## Issue (if applicable)

N/A

## Risk

Small. Some risk of an infinite render, though I'm 99% sure I've mitigated it.

## Testing

Navigate between the Dashboard and the trade page.
We should no longer have "No rate available" shown for a period of time, when it shouldn't.

### Engineering

☝️ 

### Operations

☝️ 

## Screenshots (if applicable)

N/A