### PR TITLE
fix: rework the way we handle clicking on accounts and expanding them

### DIFF
--- a/src/assets/translations/en/main.json
+++ b/src/assets/translations/en/main.json
@@ -1341,7 +1341,8 @@
     "newAccountAdded": "New %{name} Account added",
     "youCanNowUse": "You can now use %{name} Account #%{accountNumber}",
     "showAssets": "Show assets",
-    "hideAssets": "Hide assets"
+    "hideAssets": "Hide assets",
+    "viewAccount": "View account"
   },
   "loremIpsum": "Lorem ipsum dolor sit amet, consectetur adipiscing elit. Ut sed lectus efficitur, iaculis sapien eu, luctus tellus. Maecenas eget sapien dignissim, finibus mauris nec, mollis ipsum. Donec sodales sit amet felis sagittis vestibulum. Ut in consectetur lacus. Suspendisse potenti. Aenean at massa consequat lectus semper pretium. Cras sed bibendum enim. Mauris euismod sit amet dolor in placerat.",
   "transactionHistory": {

--- a/src/assets/translations/en/main.json
+++ b/src/assets/translations/en/main.json
@@ -1339,7 +1339,9 @@
     "selectChain": "Select the chain you would like to create an account for.",
     "requiresPriorTxHistory": "You can only add a new account if the existing account(s) have prior transaction history",
     "newAccountAdded": "New %{name} Account added",
-    "youCanNowUse": "You can now use %{name} Account #%{accountNumber}"
+    "youCanNowUse": "You can now use %{name} Account #%{accountNumber}",
+    "showAssets": "Show assets",
+    "hideAssets": "Hide assets"
   },
   "loremIpsum": "Lorem ipsum dolor sit amet, consectetur adipiscing elit. Ut sed lectus efficitur, iaculis sapien eu, luctus tellus. Maecenas eget sapien dignissim, finibus mauris nec, mollis ipsum. Donec sodales sit amet felis sagittis vestibulum. Ut in consectetur lacus. Suspendisse potenti. Aenean at massa consequat lectus semper pretium. Cras sed bibendum enim. Mauris euismod sit amet dolor in placerat.",
   "transactionHistory": {

--- a/src/pages/Accounts/components/AccountNumberRow.tsx
+++ b/src/pages/Accounts/components/AccountNumberRow.tsx
@@ -169,15 +169,6 @@ export const AccountNumberRow: React.FC<AccountNumberRowProps> = ({
             <Amount.Fiat value={fiatBalance} />
           </Stack>
         </Button>
-        {/* <IconButton
-          size='sm'
-          variant='ghost'
-          isActive={isOpen}
-          aria-label='Expand Account'
-          data-test='expand-account-button'
-          icon={isOpen ? <ArrowUpIcon /> : <ArrowDownIcon />}
-          onClick={onToggle}
-        /> */}
         {buttonProps.onClick && (
           <Menu>
             <MenuButton

--- a/src/pages/Accounts/components/AccountNumberRow.tsx
+++ b/src/pages/Accounts/components/AccountNumberRow.tsx
@@ -1,5 +1,7 @@
 import { ArrowDownIcon, ArrowUpIcon } from '@chakra-ui/icons'
 import type { ButtonProps } from '@chakra-ui/react'
+import { MenuGroup } from '@chakra-ui/react'
+import { Menu, MenuButton, MenuItem, MenuList } from '@chakra-ui/react'
 import {
   Avatar,
   Button,
@@ -13,6 +15,8 @@ import {
 import type { AccountId, ChainId } from '@shapeshiftoss/caip'
 import { fromAccountId } from '@shapeshiftoss/caip'
 import { useMemo } from 'react'
+import { MdOutlineMoreVert } from 'react-icons/md'
+import { RiWindow2Line } from 'react-icons/ri'
 import { useTranslate } from 'react-polyglot'
 import { useSelector } from 'react-redux'
 import { Amount } from 'components/Amount/Amount'
@@ -151,7 +155,7 @@ export const AccountNumberRow: React.FC<AccountNumberRowProps> = ({
             <Avatar bg={`${color}20`} color={color} size='sm' name={`# ${accountNumber}`} />
           }
           {...buttonProps}
-          onClick={isUtxoAccount ? onToggle : buttonProps.onClick}
+          onClick={onToggle}
         >
           <Stack alignItems='flex-start' spacing={0}>
             <RawText color='var(--chakra-colors-chakra-body-text)' fontFamily={fontFamily}>
@@ -165,7 +169,7 @@ export const AccountNumberRow: React.FC<AccountNumberRowProps> = ({
             <Amount.Fiat value={fiatBalance} />
           </Stack>
         </Button>
-        <IconButton
+        {/* <IconButton
           size='sm'
           variant='ghost'
           isActive={isOpen}
@@ -173,7 +177,34 @@ export const AccountNumberRow: React.FC<AccountNumberRowProps> = ({
           data-test='expand-account-button'
           icon={isOpen ? <ArrowUpIcon /> : <ArrowDownIcon />}
           onClick={onToggle}
-        />
+        /> */}
+        {buttonProps.onClick && (
+          <Menu>
+            <MenuButton
+              as={IconButton}
+              size='sm'
+              variant='ghost'
+              aria-label='Expand Account'
+              icon={<MdOutlineMoreVert />}
+            />
+            <MenuList>
+              <MenuGroup
+                title={translate('accounts.accountNumber', { accountNumber })}
+                color='gray.500'
+              >
+                <MenuItem
+                  icon={<RiWindow2Line />}
+                  onClick={buttonProps.onClick && buttonProps.onClick}
+                >
+                  View account
+                </MenuItem>
+                <MenuItem onClick={onToggle} icon={isOpen ? <ArrowUpIcon /> : <ArrowDownIcon />}>
+                  {translate(isOpen ? 'accounts.hideAssets' : 'accounts.showAssets')}
+                </MenuItem>
+              </MenuGroup>
+            </MenuList>
+          </Menu>
+        )}
       </Flex>
       <NestedList as={Collapse} in={isOpen} pr={0}>
         <ListItem>{accountEntries}</ListItem>

--- a/src/pages/Accounts/components/AccountNumberRow.tsx
+++ b/src/pages/Accounts/components/AccountNumberRow.tsx
@@ -187,7 +187,7 @@ export const AccountNumberRow: React.FC<AccountNumberRowProps> = ({
                   icon={<RiWindow2Line />}
                   onClick={buttonProps.onClick && buttonProps.onClick}
                 >
-                  View account
+                  {translate('accounts.viewAccount')}
                 </MenuItem>
                 <MenuItem onClick={onToggle} icon={isOpen ? <ArrowUpIcon /> : <ArrowDownIcon />}>
                   {translate(isOpen ? 'accounts.hideAssets' : 'accounts.showAssets')}

--- a/src/pages/Accounts/components/ChainRow.tsx
+++ b/src/pages/Accounts/components/ChainRow.tsx
@@ -1,5 +1,13 @@
 import { ArrowDownIcon, ArrowUpIcon } from '@chakra-ui/icons'
-import { Circle, Collapse, IconButton, ListItem, Stack, useDisclosure } from '@chakra-ui/react'
+import {
+  Center,
+  Circle,
+  Collapse,
+  ListItem,
+  Stack,
+  useColorModeValue,
+  useDisclosure,
+} from '@chakra-ui/react'
 import type { ChainId } from '@shapeshiftoss/caip'
 import { useMemo } from 'react'
 import { useHistory } from 'react-router'
@@ -33,6 +41,7 @@ export const ChainRow: React.FC<ChainRowProps> = ({ chainId }) => {
     selectPortfolioAccountsGroupedByNumberByChainId(s, filter),
   )
 
+  const hoverBorderColor = useColorModeValue('gray.300', 'gray.700')
   const color = asset?.color
   const name = asset?.name
 
@@ -54,12 +63,25 @@ export const ChainRow: React.FC<ChainRowProps> = ({ chainId }) => {
   }, [accountIdsByAccountNumber, chainId, history])
 
   return asset ? (
-    <ListItem as={Card} py={4} pl={2} fontWeight='semibold' fontSize={{ base: 'sm', md: 'md' }}>
+    <ListItem
+      as={Card}
+      py={4}
+      pl={2}
+      fontWeight='semibold'
+      transitionProperty='common'
+      transitionDuration='normal'
+      fontSize={{ base: 'sm', md: 'md' }}
+      borderWidth={{ base: 0, md: 1 }}
+      _hover={{ borderColor: hoverBorderColor }}
+    >
       <Stack
         direction='row'
+        cursor='pointer'
         justifyContent='space-between'
         alignItems='center'
         px={{ base: 2, md: 4 }}
+        data-test='expand-accounts-button'
+        onClick={onToggle}
         py={2}
       >
         <Stack direction='row' alignItems='center' spacing={4}>
@@ -68,15 +90,7 @@ export const ChainRow: React.FC<ChainRowProps> = ({ chainId }) => {
         </Stack>
         <Stack direction='row' alignItems='center' spacing={6}>
           <Amount.Fiat value={chainFiatBalance} />
-          <IconButton
-            size='sm'
-            variant='ghost'
-            isActive={isOpen}
-            aria-label='Expand Accounts'
-            data-test='expand-accounts-button'
-            onClick={onToggle}
-            icon={isOpen ? <ArrowUpIcon /> : <ArrowDownIcon />}
-          />
+          <Center boxSize='32px'>{isOpen ? <ArrowUpIcon /> : <ArrowDownIcon />}</Center>
         </Stack>
       </Stack>
       <NestedList as={Collapse} in={isOpen}>


### PR DESCRIPTION
## Description

- Based on some user feedback, now when you click the rows they expand the items below it.
- Added a more button to expand account options e.g. (Show Account, Hide Assets)

## Notice

<!-- Before submitting a pull request, please make sure you have answered the following: -->

- [x] Have you followed the guidelines in our [Contributing]('https://github.com/shapeshift/web/blob/develop/CONTRIBUTING.md) guide?
- [x] Have you checked to ensure there aren't other open [Pull Requests](https://github.com/shapeshift/web/pulls) for the same update/change?

## Pull Request Type

- [x] :bug: Bug fix (Non-breaking Change: Fixes an issue)
- [ ] :hammer_and_wrench: Chore (Non-breaking Change: Doc updates, pkg upgrades, typos, etc..)
- [ ] :nail_care: New Feature (Breaking/Non-breaking Change)

## Issue (if applicable)

<!-----------------------------------------------------------------------------
If applicable, please link to the github issue and put `closes #XXXX` in your comment to auto-close the issue that your PR fixes.
------------------------------------------------------------------------------>

closes #3216
closes #3207 

## Risk

Small risk

## Testing

<!-----------------------------------------------------------------------------
We treat every PR to be merged with the same scrutiny as if we were merging directly to production.

Your PR will not be merged if you do not complete the sections below for our engineering and operations teams to test.
------------------------------------------------------------------------------>

### Engineering

<!-----------------------------------------------------------------------------
Include sufficient information here for an engineer to test your PR. This may include how to test locally, in a built environment, changes to infrastructure etc.
------------------------------------------------------------------------------>

### Operations

When going to the accounts page, if you click a chain --- it will expand the accounts below it.

When you click on an account it should expand the assets below it.

If you click the (...) more button you should see a 2 menu items (VIew account, show/hide assets)

This should fix the other two issues as well.

## Screenshots (if applicable)
![Screen Shot 2022-11-04 at 12 17 49 PM](https://user-images.githubusercontent.com/89934888/200036785-faa45dfc-1814-44b5-85ed-da12410b2e7e.png)
