### PR TITLE
fix: cosmossdk sends

### DIFF
--- a/package.json
+++ b/package.json
@@ -88,7 +88,7 @@
     "@reduxjs/toolkit": "^1.8.2",
     "@shapeshiftoss/asset-service": "^8.1.5",
     "@shapeshiftoss/caip": "^8.4.4",
-    "@shapeshiftoss/chain-adapters": "^10.2.0",
+    "@shapeshiftoss/chain-adapters": "^10.2.1",
     "@shapeshiftoss/errors": "^1.1.3",
     "@shapeshiftoss/hdwallet-core": "1.36.0",
     "@shapeshiftoss/hdwallet-keepkey": "1.36.0",

--- a/yarn.lock
+++ b/yarn.lock
@@ -4015,10 +4015,10 @@
   resolved "https://registry.yarnpkg.com/@shapeshiftoss/caip/-/caip-8.4.4.tgz#5e119ed745daa78bc3848de034591031ad13869c"
   integrity sha512-XWo9HrmMfEesw7I+VE0G/K53E6NKB299dQK5GN1ETiwsZRMSL1+ssWxg9O+KIarnVqDUkSBa5c4vzEKGQbXzhw==
 
-"@shapeshiftoss/chain-adapters@^10.2.0":
-  version "10.2.0"
-  resolved "https://registry.yarnpkg.com/@shapeshiftoss/chain-adapters/-/chain-adapters-10.2.0.tgz#a20854e08d23e9088246a53a6d8813f8a281bdf7"
-  integrity sha512-RrTJ1NEIMT2meABB1BcJsAnTpo138Sf/pZZKqVhSRdKl4y6FSasvUWX81ZNrl6j6ABy6TR/O5aOixeASVXh/Lw==
+"@shapeshiftoss/chain-adapters@^10.2.1":
+  version "10.2.1"
+  resolved "https://registry.yarnpkg.com/@shapeshiftoss/chain-adapters/-/chain-adapters-10.2.1.tgz#19350ff80cbe97a4162d5e73e41599fe45ce1586"
+  integrity sha512-ZWwcTtQQQBb+v8v+K96N1Mc47V2CJxnBSyCFCnOPDrXm/jsHPoXSLxiFjKcrGBRqHK53N++Ee2DI3XF89CItvQ==
   dependencies:
     axios "^0.26.1"
     bech32 "^2.0.0"


### PR DESCRIPTION
## Description

- bump chain-adapters to fix broken cosmos-sdk sends on keepkey
- 
## Notice

<!-- Before submitting a pull request, please make sure you have answered the following: -->

- [x] Have you followed the guidelines in our [Contributing]('https://github.com/shapeshift/web/blob/develop/CONTRIBUTING.md) guide?
- [x] Have you checked to ensure there aren't other open [Pull Requests](https://github.com/shapeshift/web/pulls) for the same update/change?

## Pull Request Type

- [x] :bug: Bug fix (Non-breaking Change: Fixes an issue)
- [ ] :hammer_and_wrench: Chore (Non-breaking Change: Doc updates, pkg upgrades, typos, etc..)
- [ ] :nail_care: New Feature (Breaking/Non-breaking Change)

## Issue (if applicable)

<!-----------------------------------------------------------------------------
If applicable, please link to the github issue and put `closes #XXXX` in your comment to auto-close the issue that your PR fixes.
------------------------------------------------------------------------------>

closes #

## Risk

Low

## Testing

- Ensure cosmos/osmosis/thorchain sends work on keepkey, and double check they still work on any other supported wallets

### Engineering

:point_up: 

### Operations

:point_up: 

## Screenshots (if applicable)
