### PR TITLE
fix: crash on empty account

### DIFF
--- a/src/lib/utils.ts
+++ b/src/lib/utils.ts
@@ -52,3 +52,5 @@ export const isToken = (assetReference: AssetReference | string) =>
 
 export const tokenOrUndefined = (assetReference: AssetReference | string) =>
   isToken(assetReference) ? assetReference : undefined
+
+export const isDefined = <T>(optional: T | undefined): optional is T => Boolean(optional)

--- a/src/lib/utils.ts
+++ b/src/lib/utils.ts
@@ -2,6 +2,7 @@ import type { AssetReference } from '@shapeshiftoss/caip'
 import { ASSET_REFERENCE } from '@shapeshiftoss/caip'
 import difference from 'lodash/difference'
 import intersection from 'lodash/intersection'
+import isUndefined from 'lodash/isUndefined'
 
 // we don't want utils to mutate by default, so spreading here is ok
 export const upsertArray = <T extends unknown>(arr: T[], item: T): T[] =>
@@ -53,4 +54,4 @@ export const isToken = (assetReference: AssetReference | string) =>
 export const tokenOrUndefined = (assetReference: AssetReference | string) =>
   isToken(assetReference) ? assetReference : undefined
 
-export const isDefined = <T>(optional: T | undefined): optional is T => Boolean(optional)
+export const isDefined = <T>(optional: T | undefined): optional is T => !isUndefined(optional)

--- a/src/state/slices/foxEthSlice/foxEthCommon.ts
+++ b/src/state/slices/foxEthSlice/foxEthCommon.ts
@@ -29,7 +29,7 @@ const icons = [
   'https://assets.coincap.io/assets/icons/256/fox.png',
 ]
 
-export const lpOpportunity: EarnOpportunityType = {
+export const baseLpOpportunity: EarnOpportunityType = {
   provider: DefiProvider.FoxEthLP,
   contractAddress: UNISWAP_V2_WETH_FOX_POOL_ADDRESS,
   rewardAddress: '',

--- a/src/state/slices/foxEthSlice/foxEthSlice.ts
+++ b/src/state/slices/foxEthSlice/foxEthSlice.ts
@@ -91,7 +91,7 @@ export const foxEth = createSlice({
         draftState[action.payload.accountAddress ?? ''] = {
           farmingOpportunities: [],
           lpOpportunity: undefined,
-        } as FoxEthOpportunities
+        }
       }
 
       // There's an entry for that accountAddress but no farmingOpportunities field - meaning we only have lpOpportunity so far

--- a/src/state/slices/foxEthSlice/foxEthSlice.ts
+++ b/src/state/slices/foxEthSlice/foxEthSlice.ts
@@ -7,7 +7,6 @@ import { HistoryTimeframe } from '@shapeshiftoss/types'
 import { Fetcher, Token } from '@uniswap/sdk'
 import IUniswapV2Pair from '@uniswap/v2-core/build/IUniswapV2Pair.json'
 import dayjs from 'dayjs'
-import type { EarnOpportunityType } from 'features/defi/helpers/normalizeOpportunity'
 import {
   foxEthLpAssetId,
   UNISWAP_V2_WETH_FOX_POOL_ADDRESS,
@@ -29,7 +28,7 @@ import { selectMarketDataById } from '../selectors'
 import { FOX_TOKEN_CONTRACT_ADDRESS, WETH_TOKEN_CONTRACT_ADDRESS } from './constants'
 import { getOrCreateContract } from './contractManager'
 import type { FoxEthLpEarnOpportunityType, FoxFarmingEarnOpportunityType } from './foxEthCommon'
-import { farmingOpportunities, lpOpportunity } from './foxEthCommon'
+import { baseLpOpportunity, farmingOpportunities } from './foxEthCommon'
 import type {
   GetFoxEthLpAccountDataArgs,
   GetFoxEthLpAccountDataReturn,
@@ -44,7 +43,7 @@ import { fetchPairData } from './utils'
 
 type FoxEthOpportunities = {
   farmingOpportunities: FoxFarmingEarnOpportunityType[]
-  lpOpportunity: FoxEthLpEarnOpportunityType
+  lpOpportunity: FoxEthLpEarnOpportunityType | undefined
 }
 
 type FoxEthState = Record<
@@ -69,7 +68,7 @@ export const foxEth = createSlice({
         draftState[action.payload.accountAddress] = {} as FoxEthOpportunities
       }
       draftState[action.payload.accountAddress ?? ''].lpOpportunity = {
-        ...lpOpportunity, // Common LP properties
+        ...baseLpOpportunity, // Common LP properties
         ...(draftState[action.payload.accountAddress ?? '']?.lpOpportunity ?? {}),
         ...action.payload,
       }
@@ -91,7 +90,7 @@ export const foxEth = createSlice({
       if (!draftState[action.payload.accountAddress ?? '']) {
         draftState[action.payload.accountAddress ?? ''] = {
           farmingOpportunities: [],
-          lpOpportunity: {} as EarnOpportunityType,
+          lpOpportunity: undefined,
         } as FoxEthOpportunities
       }
 

--- a/src/state/slices/foxEthSlice/selectors.ts
+++ b/src/state/slices/foxEthSlice/selectors.ts
@@ -65,7 +65,7 @@ export const selectFoxEthLpAccountOpportunitiesByMaybeAccountAddress = createCac
   (state: ReduxState) => state.foxEth,
   selectAccountAddressParamFromFilterOptional,
   selectEthAccountIdsByAssetId,
-  (foxEthState, accountAddress, ethAccountIds) => {
+  (foxEthState, accountAddress, ethAccountIds): (FoxEthLpEarnOpportunityType | undefined)[] => {
     const ethAccountAddresses = ethAccountIds.map(accountId => fromAccountId(accountId).account)
     return (accountAddress ? [accountAddress] : ethAccountAddresses).map(
       accountAddress => foxEthState[accountAddress]?.lpOpportunity,

--- a/src/state/slices/foxEthSlice/selectors.ts
+++ b/src/state/slices/foxEthSlice/selectors.ts
@@ -84,26 +84,26 @@ export const selectFoxEthLpAccountsOpportunitiesAggregated = createDeepEqualOutp
   selectFoxEthLpAccountOpportunitiesByMaybeAccountAddress,
   (state: ReduxState) => state,
   (wrappedEthLpOpportunities, state): FoxEthLpEarnOpportunityType => {
-    const aggregatedOpportunity = wrappedEthLpOpportunities
-      .filter(Boolean)
-      .reduce<Partial<FoxEthLpEarnOpportunityType | undefined>>(
-        (acc, currentOpportunity) => ({
-          ...currentOpportunity,
-          underlyingFoxAmount: bnOrZero(acc?.underlyingFoxAmount)
-            .plus(currentOpportunity?.underlyingFoxAmount ?? '')
-            .toString(),
-          underlyingEthAmount: bnOrZero(acc?.underlyingEthAmount)
-            .plus(currentOpportunity?.underlyingEthAmount ?? '')
-            .toString(),
-          cryptoAmount: bnOrZero(acc?.cryptoAmount)
-            .plus(currentOpportunity?.cryptoAmount ?? '')
-            .toString(),
-          fiatAmount: bnOrZero(acc?.fiatAmount)
-            .plus(currentOpportunity?.fiatAmount ?? '')
-            .toString(),
-        }),
-        undefined,
-      )
+    const aggregatedOpportunity = wrappedEthLpOpportunities.reduce<
+      Partial<FoxEthLpEarnOpportunityType | undefined>
+    >(
+      (acc, currentOpportunity) => ({
+        ...currentOpportunity,
+        underlyingFoxAmount: bnOrZero(acc?.underlyingFoxAmount)
+          .plus(currentOpportunity?.underlyingFoxAmount ?? '')
+          .toString(),
+        underlyingEthAmount: bnOrZero(acc?.underlyingEthAmount)
+          .plus(currentOpportunity?.underlyingEthAmount ?? '')
+          .toString(),
+        cryptoAmount: bnOrZero(acc?.cryptoAmount)
+          .plus(currentOpportunity?.cryptoAmount ?? '')
+          .toString(),
+        fiatAmount: bnOrZero(acc?.fiatAmount)
+          .plus(currentOpportunity?.fiatAmount ?? '')
+          .toString(),
+      }),
+      undefined,
+    )
 
     const highestBalanceAccountAddress = selectHighestBalanceFoxLpOpportunityAccountAddress(
       state,
@@ -220,11 +220,8 @@ export const selectHighestBalanceFoxFarmingOpportunityAccountAddress = createSel
 export const selectHighestBalanceFoxLpOpportunityAccountAddress = createSelector(
   selectFoxEthLpAccountOpportunitiesByMaybeAccountAddress,
   opportunities =>
-    opportunities.sort((a, b) => {
-      return bnOrZero(b?.fiatAmount)
-        .minus(a?.fiatAmount ?? '0')
-        .toNumber()
-    })[0]?.accountAddress ?? '',
+    opportunities.sort((a, b) => bn(b.fiatAmount).minus(a.fiatAmount).toNumber())[0]
+      ?.accountAddress ?? '',
 )
 
 export const selectFarmContractsAccountsBalanceAggregated = createSelector(

--- a/src/state/slices/foxEthSlice/selectors.ts
+++ b/src/state/slices/foxEthSlice/selectors.ts
@@ -5,6 +5,7 @@ import keys from 'lodash/keys'
 import { createCachedSelector } from 're-reselect'
 import { bn, bnOrZero } from 'lib/bignumber/bignumber'
 import { toBaseUnit } from 'lib/math'
+import { isDefined } from 'lib/utils'
 import type { ReduxState } from 'state/reducer'
 import { createDeepEqualOutputSelector } from 'state/selector-utils'
 import {
@@ -65,11 +66,11 @@ export const selectFoxEthLpAccountOpportunitiesByMaybeAccountAddress = createCac
   (state: ReduxState) => state.foxEth,
   selectAccountAddressParamFromFilterOptional,
   selectEthAccountIdsByAssetId,
-  (foxEthState, accountAddress, ethAccountIds): (FoxEthLpEarnOpportunityType | undefined)[] => {
+  (foxEthState, accountAddress, ethAccountIds): FoxEthLpEarnOpportunityType[] => {
     const ethAccountAddresses = ethAccountIds.map(accountId => fromAccountId(accountId).account)
-    return (accountAddress ? [accountAddress] : ethAccountAddresses).map(
-      accountAddress => foxEthState[accountAddress]?.lpOpportunity,
-    )
+    return (accountAddress ? [accountAddress] : ethAccountAddresses)
+      .map(accountAddress => foxEthState[accountAddress]?.lpOpportunity)
+      .filter(isDefined)
   },
 )((_s: ReduxState, filter) => filter?.accountAddress ?? 'accountAddress')
 

--- a/src/state/slices/foxEthSlice/selectors.ts
+++ b/src/state/slices/foxEthSlice/selectors.ts
@@ -16,6 +16,7 @@ import { selectMarketData } from 'state/slices/marketDataSlice/selectors'
 
 import { foxEthLpAssetId } from './constants'
 import type { FoxEthLpEarnOpportunityType, FoxFarmingEarnOpportunityType } from './foxEthCommon'
+import { baseLpOpportunity } from './foxEthCommon'
 
 const farmingOpportunitiesReducer = (
   acc: Record<string, FoxFarmingEarnOpportunityType>,
@@ -81,27 +82,27 @@ export const selectFoxEthLpOpportunityByAccountAddress = createSelector(
 export const selectFoxEthLpAccountsOpportunitiesAggregated = createDeepEqualOutputSelector(
   selectFoxEthLpAccountOpportunitiesByMaybeAccountAddress,
   (state: ReduxState) => state,
-  (wrappedEthLpOpportunities, state) => {
+  (wrappedEthLpOpportunities, state): FoxEthLpEarnOpportunityType => {
     const aggregatedOpportunity = wrappedEthLpOpportunities
       .filter(Boolean)
-      .reduce((acc, currentOpportunity) => {
-        acc = {
+      .reduce<Partial<FoxEthLpEarnOpportunityType | undefined>>(
+        (acc, currentOpportunity) => ({
           ...currentOpportunity,
-          underlyingFoxAmount: bnOrZero(acc.underlyingFoxAmount)
-            .plus(currentOpportunity.underlyingFoxAmount ?? '')
+          underlyingFoxAmount: bnOrZero(acc?.underlyingFoxAmount)
+            .plus(currentOpportunity?.underlyingFoxAmount ?? '')
             .toString(),
-          underlyingEthAmount: bnOrZero(acc.underlyingEthAmount)
-            .plus(currentOpportunity.underlyingEthAmount ?? '')
+          underlyingEthAmount: bnOrZero(acc?.underlyingEthAmount)
+            .plus(currentOpportunity?.underlyingEthAmount ?? '')
             .toString(),
-          cryptoAmount: bnOrZero(acc.cryptoAmount)
-            .plus(currentOpportunity.cryptoAmount ?? '')
+          cryptoAmount: bnOrZero(acc?.cryptoAmount)
+            .plus(currentOpportunity?.cryptoAmount ?? '')
             .toString(),
-          fiatAmount: bnOrZero(acc.fiatAmount)
-            .plus(currentOpportunity.fiatAmount ?? '')
+          fiatAmount: bnOrZero(acc?.fiatAmount)
+            .plus(currentOpportunity?.fiatAmount ?? '')
             .toString(),
-        }
-        return acc
-      }, {} as FoxEthLpEarnOpportunityType)
+        }),
+        undefined,
+      )
 
     const highestBalanceAccountAddress = selectHighestBalanceFoxLpOpportunityAccountAddress(
       state,
@@ -109,6 +110,7 @@ export const selectFoxEthLpAccountsOpportunitiesAggregated = createDeepEqualOutp
     )
 
     return {
+      ...baseLpOpportunity,
       ...aggregatedOpportunity,
       highestBalanceAccountAddress,
     }
@@ -218,7 +220,9 @@ export const selectHighestBalanceFoxLpOpportunityAccountAddress = createSelector
   selectFoxEthLpAccountOpportunitiesByMaybeAccountAddress,
   opportunities =>
     opportunities.sort((a, b) => {
-      return bn(b.fiatAmount).minus(a.fiatAmount).toNumber()
+      return bnOrZero(b?.fiatAmount)
+        .minus(a?.fiatAmount ?? '0')
+        .toNumber()
     })[0]?.accountAddress ?? '',
 )
 


### PR DESCRIPTION
## Description

Type casting an empty object (don't do this!) caused a bug.

This PR:

- Improves the type of `FoxEthOpportunities` to account for the fact that it can indeed by `undefined`
- Adds explicit typing to `selectFoxEthLpAccountsOpportunitiesAggregated` and `selectFoxEthLpAccountOpportunitiesByMaybeAccountAddress`, handling the resulting complier errors, to further reduce the risk of bugs
- Improves `selectFoxEthLpAccountOpportunitiesByMaybeAccountAddress` return type. 

## Notice

- [x] Have you followed the guidelines in our [Contributing]('https://github.com/shapeshift/web/blob/develop/CONTRIBUTING.md) guide?
- [x] Have you checked to ensure there aren't other open [Pull Requests](https://github.com/shapeshift/web/pulls) for the same update/change?

## Pull Request Type

- [x] :bug: Bug fix (Non-breaking Change: Fixes an issue)
- [ ] :hammer_and_wrench: Chore (Non-breaking Change: Doc updates, pkg upgrades, typos, etc..)
- [ ] :nail_care: New Feature (Breaking/Non-breaking Change)

## Issue (if applicable)

Closes https://github.com/shapeshift/web/issues/3210

## Risk

Small. Touches opportunity logic, though in a small way.

## Testing

I was able to replicate the bug described in https://github.com/shapeshift/web/issues/3210 by:

1. Starting a fresh incognito session
2. Connecting a Native wallet
3. Adding a new ETH account from the accounts page
4. Clicking on the new ETH account

### Engineering

☝️ 

### Operations

☝️ 

## Screenshots (if applicable)

N/A