### PR TITLE
chore: optimise selectFoxEthLpAccountsOpportunitiesAggregated

### DIFF
--- a/src/state/slices/foxEthSlice/selectors.ts
+++ b/src/state/slices/foxEthSlice/selectors.ts
@@ -84,21 +84,21 @@ export const selectFoxEthLpAccountsOpportunitiesAggregated = createDeepEqualOutp
     const aggregatedOpportunity = wrappedEthLpOpportunities.reduce<
       Partial<FoxEthLpEarnOpportunityType | undefined>
     >(
-      (acc, currentOpportunity) => ({
-        ...currentOpportunity,
-        underlyingFoxAmount: bnOrZero(acc?.underlyingFoxAmount)
-          .plus(currentOpportunity?.underlyingFoxAmount ?? '')
-          .toString(),
-        underlyingEthAmount: bnOrZero(acc?.underlyingEthAmount)
-          .plus(currentOpportunity?.underlyingEthAmount ?? '')
-          .toString(),
-        cryptoAmount: bnOrZero(acc?.cryptoAmount)
-          .plus(currentOpportunity?.cryptoAmount ?? '')
-          .toString(),
-        fiatAmount: bnOrZero(acc?.fiatAmount)
-          .plus(currentOpportunity?.fiatAmount ?? '')
-          .toString(),
-      }),
+      (acc, currentOpportunity) =>
+        Object.assign(acc ?? {}, {
+          underlyingFoxAmount: bnOrZero(acc?.underlyingFoxAmount)
+            .plus(currentOpportunity?.underlyingFoxAmount ?? '')
+            .toString(),
+          underlyingEthAmount: bnOrZero(acc?.underlyingEthAmount)
+            .plus(currentOpportunity?.underlyingEthAmount ?? '')
+            .toString(),
+          cryptoAmount: bnOrZero(acc?.cryptoAmount)
+            .plus(currentOpportunity?.cryptoAmount ?? '')
+            .toString(),
+          fiatAmount: bnOrZero(acc?.fiatAmount)
+            .plus(currentOpportunity?.fiatAmount ?? '')
+            .toString(),
+        }),
       undefined,
     )
 

--- a/src/state/slices/foxEthSlice/selectors.ts
+++ b/src/state/slices/foxEthSlice/selectors.ts
@@ -85,7 +85,7 @@ export const selectFoxEthLpAccountsOpportunitiesAggregated = createDeepEqualOutp
       Partial<FoxEthLpEarnOpportunityType | undefined>
     >(
       (acc, currentOpportunity) =>
-        Object.assign(acc ?? {}, {
+        Object.assign(acc ?? {}, currentOpportunity, {
           underlyingFoxAmount: bnOrZero(acc?.underlyingFoxAmount)
             .plus(currentOpportunity?.underlyingFoxAmount ?? '')
             .toString(),


### PR DESCRIPTION
## Description

Using `Object.assign` over a spread results in significant performance improvements.

I clocked `4,377 ops/s` for `Object.assign` with 10,000 opportunities vs `578 ops/s` with spread.

[Perflink](https://perf.link/#eyJpZCI6IjQxanF0MmJnMGVvIiwidGl0bGUiOiJPYmplY3QuYXNzaWduIHZzIHNwcmVhZCBwZXJmb3JtYW5jZSIsImJlZm9yZSI6ImNvbnN0IGJhc2VMcE9wcG9ydHVuaXR5ID0ge1xuICBwcm92aWRlcjogXCJEZWZpUHJvdmlkZXJcIixcbn1cblxuY29uc3Qgb3Bwb3J0dW5pdGllcyA9IEFycmF5KDEwMDAwKS5maWxsKGJhc2VMcE9wcG9ydHVuaXR5KSIsInRlc3RzIjpbeyJuYW1lIjoiVGVzdCBDYXNlIiwiY29kZSI6Im9wcG9ydHVuaXRpZXMucmVkdWNlKFxuICAoYWNjLCBjdXJyZW50T3Bwb3J0dW5pdHkpID0%2BIChPYmplY3QuYXNzaWduKGFjYyA%2FPyB7fSwgeyB1bmRlcmx5aW5nRm94QW1vdW50OiBhY2M%2FLnByb3ZpZGVyID8%2FICcnIH0pKSxcbiAgdW5kZWZpbmVkLFxuKSIsInJ1bnMiOls0NDExLDQyMzUsNDI5NCw0Mjk0LDQ0MTEsNDI5NCw0NDcwLDQzNTIsNDQ3MCw0MzUyLDQ0NzAsNDM1Miw0NDExLDQyOTQsNDQ3MCw0Mjk0LDQyOTQsNDIzNSw0NDExLDQ1MjksNDM1Miw0NDExLDQyOTQsNDM1Miw0NDExLDQ0NzAsNDUyOSw0NDExLDQyMzUsNDI5NCw0NDExLDQyOTQsNDQxMSw0MzUyLDQzNTIsNDQ3MCw0Mjk0LDQyOTQsNDQ3MCw0MjM1LDQ1MjksNDM1Miw0NDcwLDQ0NzAsNDUyOSw0NDExLDQzNTIsNDQ3MCw0NDExLDQyOTQsNDUyOSw0MzUyLDQ0NzAsNDM1Miw0NDcwLDQ0MTEsNDI5NCw0MjM1LDQzNTIsNDIzNSw0NTI5LDQyMzUsNDQxMSw0NDcwLDQ0NzAsNDQxMSw0NDcwLDQzNTIsNDQxMSw0NDcwLDQyOTQsNDI5NCw0Mjk0LDQ0NzAsNDIzNSw0NDcwLDQzNTIsNDI5NCw0NTI5LDQyOTQsNDIzNSw0NDExLDQyOTQsNDQ3MCw0NTI5LDQyOTQsNDQxMSw0NTI5LDQxNzYsNDQ3MCw0NDExLDQ0NzAsNDI5NCw0NTI5LDQyOTQsNDIzNSw0Mjk0LDQyOTQsNDE3Niw0NDcwXSwib3BzIjo0Mzc3fSx7Im5hbWUiOiJUZXN0IENhc2UiLCJjb2RlIjoib3Bwb3J0dW5pdGllcy5yZWR1Y2UoXG4gIChhY2MsIGN1cnJlbnRPcHBvcnR1bml0eSkgPT4gKHtcbiAgICAuLi5jdXJyZW50T3Bwb3J0dW5pdHksXG4gICAgdW5kZXJseWluZ0ZveEFtb3VudDogJycsXG4gIH0pLFxuICB1bmRlZmluZWQsXG4pIiwicnVucyI6WzU4OCw1MjksNTg4LDU4OCw1ODgsNTg4LDU4OCw1ODgsNTg4LDU4OCw1ODgsNTg4LDU4OCw1MjksNTI5LDU4OCw1MjksNTg4LDU4OCw1ODgsNTg4LDU4OCw1ODgsNTg4LDUyOSw1ODgsNTg4LDUyOSw1ODgsNTI5LDU4OCw1ODgsNTg4LDU4OCw1ODgsNTg4LDU4OCw1MjksNTg4LDU4OCw1ODgsNTI5LDU4OCw1ODgsNTg4LDU4OCw1ODgsNTg4LDU4OCw1ODgsNTg4LDU4OCw1ODgsNTI5LDUyOSw1ODgsNTg4LDU4OCw1ODgsNTg4LDU4OCw1ODgsNTg4LDU4OCw1ODgsNTg4LDU4OCw1MjksNTg4LDU4OCw1ODgsNTg4LDUyOSw1ODgsNTg4LDU4OCw1ODgsNTg4LDU4OCw1ODgsNTg4LDU4OCw1ODgsNTg4LDU4OCw1ODgsNTI5LDU4OCw1ODgsNTI5LDU4OCw1ODgsNTI5LDU4OCw1ODgsNTg4LDU4OCw1ODgsNTg4LDU4OF0sIm9wcyI6NTc4fV0sInVwZGF0ZWQiOiIyMDIyLTExLTA4VDIzOjQ5OjQ0LjQ1OFoifQ%3D%3D)

## Notice

- [x] Have you followed the guidelines in our [Contributing]('https://github.com/shapeshift/web/blob/develop/CONTRIBUTING.md) guide?
- [x] Have you checked to ensure there aren't other open [Pull Requests](https://github.com/shapeshift/web/pulls) for the same update/change?

## Pull Request Type

- [ ] :bug: Bug fix (Non-breaking Change: Fixes an issue)
- [x] :hammer_and_wrench: Chore (Non-breaking Change: Doc updates, pkg upgrades, typos, etc..)
- [ ] :nail_care: New Feature (Breaking/Non-breaking Change)

## Issue (if applicable)

N/A - performance improvement.

## Risk

Small - Fox/Eth opportunities touched, but as a refactor.

## Testing

Fox/Eth opportunities should work as expected.

### Engineering

☝️ 

### Operations

☝️

## Screenshots (if applicable)

<img width="1017" alt="Screenshot 2022-11-09 at 10 50 58 am" src="https://user-images.githubusercontent.com/97164662/200701081-603b6e37-a265-417f-bba7-04c079aa6563.png">

