### PR TITLE
chore: type-guard boolean filters

### DIFF
--- a/src/components/AssetHeader/AssetChart.tsx
+++ b/src/components/AssetHeader/AssetChart.tsx
@@ -29,6 +29,7 @@ import { PriceChart } from 'components/PriceChart/PriceChart'
 import { RawText, Text } from 'components/Text'
 import { useLocaleFormatter } from 'hooks/useLocaleFormatter/useLocaleFormatter'
 import { bnOrZero } from 'lib/bignumber/bignumber'
+import { isSome } from 'lib/utils'
 import {
   selectAssetById,
   selectCryptoHumanBalanceIncludingStakingByFilter,
@@ -59,7 +60,7 @@ export const AssetChart = ({ accountId, assetId, isLoaded }: AssetChartProps) =>
   const [percentChange, setPercentChange] = useState(0)
   const alertIconColor = useColorModeValue('blue.500', 'blue.200')
   const [timeframe, setTimeframe] = useState<HistoryTimeframe>(DEFAULT_HISTORY_TIMEFRAME)
-  const assetIds = useMemo(() => [assetId].filter(Boolean), [assetId])
+  const assetIds = useMemo(() => [assetId].filter(isSome), [assetId])
   const asset = useAppSelector(state => selectAssetById(state, assetId))
   const marketData = useAppSelector(state => selectMarketDataById(state, assetId))
   const { price } = marketData || {}

--- a/src/components/Modals/FiatRamps/fiatRampProviders/mtpelerin.ts
+++ b/src/components/Modals/FiatRamps/fiatRampProviders/mtpelerin.ts
@@ -3,6 +3,7 @@ import { adapters } from '@shapeshiftoss/caip'
 import axios from 'axios'
 import { getConfig } from 'config'
 import { logger } from 'lib/logger'
+import { isSome } from 'lib/utils'
 
 import { FiatRampAction } from '../FiatRampsCommon'
 
@@ -32,7 +33,7 @@ export async function getMtPelerinAssets(): Promise<AssetId[]> {
   const mtPelerinSymbols = Object.values(data).map(({ symbol }) => symbol)
   return Array.from(
     new Set(mtPelerinSymbols.flatMap(symbol => adapters.mtPelerinSymbolToAssetIds(symbol))),
-  ).filter(Boolean)
+  ).filter(isSome)
 }
 
 export const createMtPelerinUrl = (action: FiatRampAction, assetId: AssetId): string => {

--- a/src/components/Modals/FiatRamps/utils.ts
+++ b/src/components/Modals/FiatRamps/utils.ts
@@ -1,5 +1,6 @@
 import type { AssetId } from '@shapeshiftoss/caip'
 import intersection from 'lodash/intersection'
+import { isSome } from 'lib/utils'
 import { selectPortfolioAssetIdsSortedFiat } from 'state/slices/selectors'
 import { store } from 'state/store'
 
@@ -12,7 +13,7 @@ export const filterAssetsBySearchTerm = (search: string, assetIds: AssetId[]) =>
   const portfolioAssetIdsSortedFiat = selectPortfolioAssetIdsSortedFiat(state)
   const actionableAssetIdsSortedFiat = intersection(portfolioAssetIdsSortedFiat, assetIds)
   const uniqueSortedAssetIds = Array.from(new Set([...actionableAssetIdsSortedFiat, ...assetIds]))
-  const assets = uniqueSortedAssetIds.map(assetId => assetsById[assetId]).filter(Boolean)
+  const assets = uniqueSortedAssetIds.map(assetId => assetsById[assetId]).filter(isSome)
   return assets
     .filter(asset => `${asset?.name}${asset?.symbol}`.toLowerCase().includes(search.toLowerCase()))
     .map(({ assetId }) => assetId)

--- a/src/lib/utils.ts
+++ b/src/lib/utils.ts
@@ -1,5 +1,6 @@
 import type { AssetReference } from '@shapeshiftoss/caip'
 import { ASSET_REFERENCE } from '@shapeshiftoss/caip'
+import { isNull } from 'lodash'
 import difference from 'lodash/difference'
 import intersection from 'lodash/intersection'
 import isUndefined from 'lodash/isUndefined'
@@ -54,7 +55,8 @@ export const isToken = (assetReference: AssetReference | string) =>
 export const tokenOrUndefined = (assetReference: AssetReference | string) =>
   isToken(assetReference) ? assetReference : undefined
 
-export const isDefined = <T>(optional: T | undefined): optional is T => !isUndefined(optional)
+export const isSome = <T>(option: T | null | undefined): option is T =>
+  !isUndefined(option) && !isNull(option)
 
 // 0 is valid but falsy, dum language
 export const isValidAccountNumber = (

--- a/src/pages/TransactionHistory/TransactionHistory.tsx
+++ b/src/pages/TransactionHistory/TransactionHistory.tsx
@@ -6,6 +6,7 @@ import { Main } from 'components/Layout/Main'
 import { SEO } from 'components/Layout/Seo'
 import { Text } from 'components/Text'
 import { TransactionHistoryList } from 'components/TransactionHistory/TransactionHistoryList'
+import { isSome } from 'lib/utils'
 import { selectTxIdsBasedOnSearchTermAndFilters } from 'state/slices/selectors'
 import { useAppSelector } from 'state/store'
 
@@ -53,7 +54,7 @@ export const TransactionHistory = () => {
               <TransactionHistoryFilter
                 resetFilters={handleReset}
                 setFilters={setFilters}
-                hasAppliedFilter={!!Object.values(filters).filter(Boolean).length}
+                hasAppliedFilter={!!Object.values(filters).filter(isSome).length}
               />
             </Flex>
             <DownloadButton txIds={txIds} />

--- a/src/state/slices/foxEthSlice/selectors.ts
+++ b/src/state/slices/foxEthSlice/selectors.ts
@@ -5,7 +5,7 @@ import keys from 'lodash/keys'
 import { createCachedSelector } from 're-reselect'
 import { bn, bnOrZero } from 'lib/bignumber/bignumber'
 import { toBaseUnit } from 'lib/math'
-import { isDefined } from 'lib/utils'
+import { isSome } from 'lib/utils'
 import type { ReduxState } from 'state/reducer'
 import { createDeepEqualOutputSelector } from 'state/selector-utils'
 import { selectAccountAddressParamFromFilter } from 'state/selectors'
@@ -67,7 +67,7 @@ export const selectFoxEthLpAccountOpportunitiesByMaybeAccountAddress = createCac
     const ethAccountAddresses = ethAccountIds.map(accountId => fromAccountId(accountId).account)
     return (accountAddress ? [accountAddress] : ethAccountAddresses)
       .map(accountAddress => foxEthState[accountAddress]?.lpOpportunity)
-      .filter(isDefined)
+      .filter(isSome)
   },
 )((_s: ReduxState, filter) => filter?.accountAddress ?? 'accountAddress')
 
@@ -264,7 +264,7 @@ export const selectFoxEthLpFiatBalance = createSelector(
     const accountAddresses = accountIds.map(accountId => fromAccountId(accountId).account)
     const lpOpportunities = accountAddresses
       .map(accountAddress => foxEthState[accountAddress]?.lpOpportunity)
-      .filter(Boolean)
+      .filter(isSome)
 
     const lpTokenPrice = marketData[foxEthLpAssetId]?.price ?? 0
     const lpOpportunitiesCryptoAmount = lpOpportunities.reduce((acc, currentLpOpportunity) => {

--- a/src/state/slices/portfolioSlice/utils.ts
+++ b/src/state/slices/portfolioSlice/utils.ts
@@ -34,6 +34,7 @@ import last from 'lodash/last'
 import { getChainAdapterManager } from 'context/PluginProvider/chainAdapterSingleton'
 import type { BigNumber } from 'lib/bignumber/bignumber'
 import { bn, bnOrZero } from 'lib/bignumber/bignumber'
+import { isSome } from 'lib/utils'
 
 import type { PubKey } from '../validatorDataSlice/validatorDataSlice'
 import type {
@@ -247,7 +248,7 @@ export const accountToPortfolio: AccountToPortfolio = args => {
                 .map(undelegation => {
                   return undelegation?.validator?.address
                 })
-                .filter(Boolean),
+                .filter(isSome),
               cosmosAccount.chainSpecific.rewards.map(reward => reward.validator.address),
             ].flat(),
           ),


### PR DESCRIPTION
## Description

There are two issues with the way we are currently using `.filter(Boolean)`:

1. Using it to filter out falsey values does not type guard the result. This has gone unnoticed because we have not been correctly typing values that can be `null` or `undefined`
1. In all current usages, it seems that the intention is to filter out `null` or `undefined`, not falsey values

This PR:

1. Updates the current type guard helper to accept `null` in addition to `undefined` types
1. Renames the helper from `isDefined` to `isSome`
1. Replaces all filter usages of `Boolean` with `isSome` which will assist with the in-progress type improvements throughout the codebase

## Notice

- [x] Have you followed the guidelines in our [Contributing]('https://github.com/shapeshift/web/blob/develop/CONTRIBUTING.md) guide?
- [x] Have you checked to ensure there aren't other open [Pull Requests](https://github.com/shapeshift/web/pulls) for the same update/change?

## Pull Request Type

- [ ] :bug: Bug fix (Non-breaking Change: Fixes an issue)
- [x] :hammer_and_wrench: Chore (Non-breaking Change: Doc updates, pkg upgrades, typos, etc..)
- [ ] :nail_care: New Feature (Breaking/Non-breaking Change)

## Issue (if applicable)

N/A

## Risk

The behaviour has changed slightly. There is a small risk that somewhere we were using a falsely value (`''` or `0`) when we should have been using `undefined` or `null`. If that is the case, behaviour may change in unpredictable ways.

## Testing

Everything should function as it does now - it's worth giving the app a smoke test to confirm.

### Engineering

☝️ 

### Operations

☝️ 

## Screenshots (if applicable)

N/A