### PR TITLE
fix: properly type partial records

### DIFF
--- a/src/features/defi/providers/fox-eth-lp/components/FoxEthLpManager/Overview/FoxEthLpOverview.tsx
+++ b/src/features/defi/providers/fox-eth-lp/components/FoxEthLpManager/Overview/FoxEthLpOverview.tsx
@@ -11,6 +11,7 @@ import { bnOrZero } from 'lib/bignumber/bignumber'
 import { fromBaseUnit } from 'lib/math'
 import { useGetAssetDescriptionQuery } from 'state/slices/assetsSlice/assetsSlice'
 import { foxEthLpAssetId, foxEthLpOpportunityName } from 'state/slices/foxEthSlice/constants'
+import type { LpId } from 'state/slices/opportunitiesSlice/types'
 import {
   selectAssetById,
   selectHighestBalanceAccountIdByLpId,
@@ -39,23 +40,22 @@ export const FoxEthLpOverview: React.FC<FoxEthLpOverviewProps> = ({
   )
 
   const lpOpportunitiesById = useAppSelector(state => selectLpOpportunitiesById(state))
-  const opportunityId = foxEthLpAssetId
+  const opportunityId: LpId = foxEthLpAssetId
 
   const highestBalanceAccountIdFilter = useMemo(() => ({ lpId: opportunityId }), [opportunityId])
   const highestBalanceAccountId = useAppSelector(state =>
     selectHighestBalanceAccountIdByLpId(state, highestBalanceAccountIdFilter),
   )
-
   const opportunityMetadata = useMemo(
     () => lpOpportunitiesById[opportunityId],
     [lpOpportunitiesById, opportunityId],
   )
 
-  const lpAsset = useAppSelector(state => selectAssetById(state, opportunityId ?? ''))
+  const lpAsset = useAppSelector(state => selectAssetById(state, opportunityId.toString() ?? ''))
 
   const lpAssetBalanceFilter = useMemo(
     () => ({
-      assetId: opportunityId ?? '',
+      assetId: opportunityId.toString() ?? '',
       accountId: accountId ?? '',
     }),
     [accountId, opportunityId],
@@ -79,13 +79,13 @@ export const FoxEthLpOverview: React.FC<FoxEthLpOverviewProps> = ({
       assets,
       lpAssetBalance,
       opportunityMetadata?.underlyingAssetIds,
-      opportunityMetadata.underlyingAssetRatios,
+      opportunityMetadata?.underlyingAssetRatios,
     ],
   )
 
   const underlyingAssetsFiatBalanceFilter = useMemo(
     () => ({
-      assetId: opportunityId ?? '',
+      assetId: opportunityId.toString() ?? '',
       accountId: accountId ?? '',
     }),
     [accountId, opportunityId],

--- a/src/lib/utils.ts
+++ b/src/lib/utils.ts
@@ -64,3 +64,5 @@ export const isValidAccountNumber = (
   if (accountNumber === null) return false
   return Number.isInteger(accountNumber) && accountNumber >= 0
 }
+
+export type PartialRecord<K extends keyof any, T> = Partial<Record<K, T>>

--- a/src/state/slices/opportunitiesSlice/selectors.test.ts
+++ b/src/state/slices/opportunitiesSlice/selectors.test.ts
@@ -1,7 +1,10 @@
+import type { AssetId } from '@shapeshiftoss/caip'
+import { ethAssetId, foxAssetId } from '@shapeshiftoss/caip'
 import { DefiProvider, DefiType } from 'features/defi/contexts/DefiManagerProvider/DefiCommon'
 import { mockStore } from 'test/mocks/store'
+import type { OpportunityMetadata } from 'state/slices/opportunitiesSlice/types'
 
-import { foxEthPair } from './constants'
+import { foxEthLpAssetId, foxEthPair } from './constants'
 import {
   catpuccinoAccountId,
   fauxmesAccountId,
@@ -135,11 +138,30 @@ describe('opportunitiesSlice selectors', () => {
     })
   })
   describe('selectUserStakingOpportunityByUserStakingId', () => {
+    const mockOpportunityMetadata: OpportunityMetadata = {
+      // The LP token AssetId
+      assetId: foxEthLpAssetId,
+      provider: DefiProvider.FoxEthLP,
+      tvl: '424242',
+      apy: '0.42',
+      type: DefiType.LiquidityPool,
+      underlyingAssetIds: [foxAssetId, ethAssetId] as [AssetId, AssetId],
+      underlyingAssetRatios: ['5000000000000000', '202200000000000000000'] as [string, string],
+    }
     const staking = {
       ...initialState.staking,
+      ids: [
+        serializeUserStakingId(gomesAccountId, mockStakingContractTwo),
+        serializeUserStakingId(gomesAccountId, mockStakingContractOne),
+        serializeUserStakingId(fauxmesAccountId, mockStakingContractOne),
+      ],
+      byId: {
+        [mockStakingContractOne]: mockOpportunityMetadata,
+        [mockStakingContractTwo]: mockOpportunityMetadata,
+      },
     }
     const userStaking = {
-      ...initialState.staking,
+      ...initialState.userStaking,
       ids: [
         serializeUserStakingId(gomesAccountId, mockStakingContractTwo),
         serializeUserStakingId(gomesAccountId, mockStakingContractOne),
@@ -172,16 +194,36 @@ describe('opportunitiesSlice selectors', () => {
           userStakingId: serializeUserStakingId(gomesAccountId, mockStakingContractTwo),
         }),
       ).toEqual({
-        stakedAmountCryptoPrecision: '1337',
+        apy: '0.42',
+        assetId: 'eip155:1/erc20:0x470e8de2ebaef52014a47cb5e6af86884947f08c',
+        provider: 'UNI V2',
         rewardsAmountCryptoPrecision: '420',
+        stakedAmountCryptoPrecision: '1337',
+        tvl: '424242',
+        type: 'lp',
+        underlyingAssetIds: [
+          'eip155:1/erc20:0xc770eefad204b5180df6a14ee197d99d808ee52d',
+          'eip155:1/slip44:60',
+        ],
+        underlyingAssetRatios: ['5000000000000000', '202200000000000000000'],
       })
       expect(
         selectUserStakingOpportunityByUserStakingId(mockState, {
           userStakingId: serializeUserStakingId(gomesAccountId, mockStakingContractOne),
         }),
       ).toEqual({
+        apy: '0.42',
+        assetId: 'eip155:1/erc20:0x470e8de2ebaef52014a47cb5e6af86884947f08c',
+        provider: 'UNI V2',
         stakedAmountCryptoPrecision: '4',
         rewardsAmountCryptoPrecision: '3',
+        tvl: '424242',
+        type: 'lp',
+        underlyingAssetIds: [
+          'eip155:1/erc20:0xc770eefad204b5180df6a14ee197d99d808ee52d',
+          'eip155:1/slip44:60',
+        ],
+        underlyingAssetRatios: ['5000000000000000', '202200000000000000000'],
       })
     })
   })

--- a/src/state/slices/opportunitiesSlice/selectors.ts
+++ b/src/state/slices/opportunitiesSlice/selectors.ts
@@ -143,17 +143,18 @@ export const selectHighestBalanceAccountIdByStakingId = createSelector(
   (userStakingOpportunities, stakingId): AccountId | null => {
     if (!stakingId) return '*' // Narrowing flavoured type
 
-    const userStakingOpportunitiesEntries = Object.entries(userStakingOpportunities) as [
-      UserStakingId,
-      UserStakingOpportunity,
-    ][]
+    const userStakingOpportunitiesEntries: [UserStakingId, UserStakingOpportunity | undefined][] =
+      Object.entries(userStakingOpportunities).map(([userStakingId, userStakingOpportunity]) => [
+        userStakingId as UserStakingId,
+        userStakingOpportunity,
+      ])
     const foundEntry = (userStakingOpportunitiesEntries ?? [])
       .filter(([userStakingId]) =>
         filterUserStakingIdByStakingIdCompareFn(userStakingId, stakingId),
       )
       .sort(([, userStakingOpportunityA], [, userStakingOpportunityB]) =>
-        bnOrZero(userStakingOpportunityB.stakedAmountCryptoPrecision)
-          .minus(userStakingOpportunityA.stakedAmountCryptoPrecision)
+        bnOrZero(userStakingOpportunityB?.stakedAmountCryptoPrecision)
+          .minus(userStakingOpportunityA?.stakedAmountCryptoPrecision ?? '0')
           .toNumber(),
       )?.[0]
 

--- a/src/state/slices/opportunitiesSlice/selectors.ts
+++ b/src/state/slices/opportunitiesSlice/selectors.ts
@@ -54,7 +54,7 @@ export const selectStakingOpportunityIdsByAccountId = createDeepEqualOutputSelec
 export const selectDeserializedStakingIdFromUserStakingIdParam = createSelector(
   selectUserStakingIdParamFromFilter,
   (userStakingId): StakingId => {
-    if (!userStakingId) return '*' // Narrowing flavoured template litteral type
+    if (!userStakingId) return '*' // Narrowing flavoured template literal type
     const parts = deserializeUserStakingId(userStakingId)
     const [, stakingId] = parts
     return stakingId
@@ -73,7 +73,6 @@ export const selectUserStakingOpportunityByUserStakingId = createDeepEqualOutput
     stakingId,
     stakingOpportunities,
   ): (UserStakingOpportunity & OpportunityMetadata) | undefined => {
-    // if (!userStakingId) return // Narrowing flavoured template literal type
     const userOpportunity = userStakingId ? userStakingOpportunities[userStakingId] : undefined
     const opportunityMetadata = stakingOpportunities[stakingId]
     return userOpportunity && opportunityMetadata
@@ -115,26 +114,25 @@ export const selectUserStakingOpportunitiesByStakingId = createDeepEqualOutputSe
 // "Give me the total values over all my accounts aggregated into one for that specific opportunity"
 export const selectAggregatedUserStakingOpportunityByStakingId = createDeepEqualOutputSelector(
   selectUserStakingOpportunitiesByStakingId,
-  (userStakingOpportunities): UserStakingOpportunity & OpportunityMetadata => {
-    const initial = {} as UserStakingOpportunity & OpportunityMetadata
+  (userStakingOpportunities): (UserStakingOpportunity & OpportunityMetadata) | undefined => {
+    // const initial = {} as UserStakingOpportunity & OpportunityMetadata
 
-    return userStakingOpportunities.reduce<UserStakingOpportunity & OpportunityMetadata>(
-      (acc, userStakingOpportunity) => {
-        const { userStakingId, ...userStakingOpportunityWithoutUserStakingId } =
-          userStakingOpportunity // It makes sense to have it when we have a collection, but becomes useless when aggregated
+    return userStakingOpportunities.reduce<
+      (UserStakingOpportunity & OpportunityMetadata) | undefined
+    >((acc, userStakingOpportunity) => {
+      const { userStakingId, ...userStakingOpportunityWithoutUserStakingId } =
+        userStakingOpportunity // It makes sense to have it when we have a collection, but becomes useless when aggregated
 
-        return {
-          ...userStakingOpportunityWithoutUserStakingId,
-          stakedAmountCryptoPrecision: bnOrZero(acc.stakedAmountCryptoPrecision)
-            .plus(userStakingOpportunity.stakedAmountCryptoPrecision)
-            .toString(),
-          rewardsAmountCryptoPrecision: bnOrZero(acc.rewardsAmountCryptoPrecision)
-            .plus(userStakingOpportunity.rewardsAmountCryptoPrecision)
-            .toString(),
-        }
-      },
-      initial,
-    )
+      return {
+        ...userStakingOpportunityWithoutUserStakingId,
+        stakedAmountCryptoPrecision: bnOrZero(acc?.stakedAmountCryptoPrecision)
+          .plus(userStakingOpportunity.stakedAmountCryptoPrecision)
+          .toString(),
+        rewardsAmountCryptoPrecision: bnOrZero(acc?.rewardsAmountCryptoPrecision)
+          .plus(userStakingOpportunity.rewardsAmountCryptoPrecision)
+          .toString(),
+      }
+    }, undefined)
   },
 )
 

--- a/src/state/slices/opportunitiesSlice/selectors.ts
+++ b/src/state/slices/opportunitiesSlice/selectors.ts
@@ -39,7 +39,10 @@ export const selectStakingOpportunitiesById = (state: ReduxState) =>
 export const selectLpOpportunityIdsByAccountId = createDeepEqualOutputSelector(
   selectLpOpportunitiesByAccountId,
   selectAccountIdParamFromFilter,
-  (lpIdsByAccountId, accountId): LpId[] => (accountId ? lpIdsByAccountId[accountId] : []),
+  (lpIdsByAccountId, accountId): LpId[] => {
+    const maybeLpIds = accountId && lpIdsByAccountId[accountId]
+    return maybeLpIds ?? []
+  },
 )
 
 // "Give me all the staking opportunities this AccountId has", so I can get their metadata and their data from the slice

--- a/src/state/slices/opportunitiesSlice/selectors.ts
+++ b/src/state/slices/opportunitiesSlice/selectors.ts
@@ -1,7 +1,7 @@
 import { createSelector } from '@reduxjs/toolkit'
 import type { AccountId, AssetId } from '@shapeshiftoss/caip'
 import { bn, bnOrZero } from 'lib/bignumber/bignumber'
-import { isDefined } from 'lib/utils'
+import { isSome } from 'lib/utils'
 import type { ReduxState } from 'state/reducer'
 import { createDeepEqualOutputSelector } from 'state/selector-utils'
 import {
@@ -107,7 +107,7 @@ export const selectUserStakingOpportunitiesByStakingId = createDeepEqualOutputSe
           ? { ...userStakingOpportunity, ...stakingOpportunity, userStakingId }
           : undefined
       })
-      .filter(isDefined)
+      .filter(isSome)
   },
 )
 

--- a/src/state/slices/opportunitiesSlice/selectors.ts
+++ b/src/state/slices/opportunitiesSlice/selectors.ts
@@ -115,8 +115,6 @@ export const selectUserStakingOpportunitiesByStakingId = createDeepEqualOutputSe
 export const selectAggregatedUserStakingOpportunityByStakingId = createDeepEqualOutputSelector(
   selectUserStakingOpportunitiesByStakingId,
   (userStakingOpportunities): (UserStakingOpportunity & OpportunityMetadata) | undefined => {
-    // const initial = {} as UserStakingOpportunity & OpportunityMetadata
-
     return userStakingOpportunities.reduce<
       (UserStakingOpportunity & OpportunityMetadata) | undefined
     >((acc, userStakingOpportunity) => {

--- a/src/state/slices/opportunitiesSlice/types.ts
+++ b/src/state/slices/opportunitiesSlice/types.ts
@@ -1,5 +1,6 @@
 import type { AccountId, AssetId } from '@shapeshiftoss/caip'
 import type { DefiProvider, DefiType } from 'features/defi/contexts/DefiManagerProvider/DefiCommon'
+import type { PartialRecord } from 'lib/utils'
 import type { Nominal } from 'types/common'
 
 export type OpportunityDefiType = DefiType.LiquidityPool | DefiType.Staking
@@ -34,21 +35,21 @@ export type UserStakingId = `${AccountId}*${StakingId}`
 
 export type OpportunitiesState = {
   lp: {
-    byAccountId: Partial<Record<AccountId, LpId[]>> // a 1:n foreign key of which user AccountIds hold this LpId
-    byId: Partial<Record<LpId, OpportunityMetadata>>
+    byAccountId: PartialRecord<AccountId, LpId[]> // a 1:n foreign key of which user AccountIds hold this LpId
+    byId: PartialRecord<LpId, OpportunityMetadata>
     ids: LpId[]
   }
   // Staking is the odd one here - it isn't a portfolio holding, but rather a synthetic value living on a smart contract
   // Which means we can't just derive the data from portfolio, marketData and other slices but have to actually store the amount in the slice
   userStaking: {
-    byId: Record<UserStakingId, UserStakingOpportunity>
+    byId: PartialRecord<UserStakingId, UserStakingOpportunity>
     ids: UserStakingId[]
   }
 
   staking: {
     // a 1:n foreign key of which user AccountIds hold this StakingId
-    byAccountId: Record<AccountId, StakingId[]>
-    byId: Record<StakingId, OpportunityMetadata>
+    byAccountId: PartialRecord<AccountId, StakingId[]>
+    byId: PartialRecord<StakingId, OpportunityMetadata>
     ids: StakingId[]
   }
 }

--- a/src/state/slices/opportunitiesSlice/types.ts
+++ b/src/state/slices/opportunitiesSlice/types.ts
@@ -1,5 +1,4 @@
-import type { AccountId } from '@shapeshiftoss/caip'
-import type { AssetId } from '@shapeshiftoss/caip'
+import type { AccountId, AssetId } from '@shapeshiftoss/caip'
 import type { DefiProvider, DefiType } from 'features/defi/contexts/DefiManagerProvider/DefiCommon'
 import type { Nominal } from 'types/common'
 
@@ -35,8 +34,8 @@ export type UserStakingId = `${AccountId}*${StakingId}`
 
 export type OpportunitiesState = {
   lp: {
-    byAccountId: Record<AccountId, LpId[]> // a 1:n foreign key of which user AccountIds hold this LpId
-    byId: Record<LpId, OpportunityMetadata>
+    byAccountId: Partial<Record<AccountId, LpId[]>> // a 1:n foreign key of which user AccountIds hold this LpId
+    byId: Partial<Record<LpId, OpportunityMetadata>>
     ids: LpId[]
   }
   // Staking is the odd one here - it isn't a portfolio holding, but rather a synthetic value living on a smart contract


### PR DESCRIPTION
## Description

When we attempt to access an object property with type `Record<T, U>` via dynamic bracket notation the resulting type is `U`, i.e. always defined - TS assumes that if our accessor expression matches type `T` then we get a result of type `U`.

This is not true at runtime. E.g.:

```ts
const opportunityMetadata = stakingOpportunities['notARealId'] // OpportunityMetadata
const opportunityMetadataAssetId = opportunityMetadata.assetId // Throws - attempted to access a property of undefined
```

This PR fixes the types in the Opportunities Slice by using a `PartialRecord` helper (that we should implement more broadly).

Now, continuing our example, when trying to access a property of `opportunityMetadata` the compiler will force us to handle the `undefined` case.

This fixes a whole host of bugs by forcing us to correctly handle `undefined` values.

## Notice

- [X] Have you followed the guidelines in our [Contributing]('https://github.com/shapeshift/web/blob/develop/CONTRIBUTING.md) guide?
- [X] Have you checked to ensure there aren't other open [Pull Requests](https://github.com/shapeshift/web/pulls) for the same update/change?

## Pull Request Type

- [x] :bug: Bug fix (Non-breaking Change: Fixes an issue)
- [ ] :hammer_and_wrench: Chore (Non-breaking Change: Doc updates, pkg upgrades, typos, etc..)
- [ ] :nail_care: New Feature (Breaking/Non-breaking Change)

## Issue (if applicable)

Mostly tackles https://github.com/shapeshift/web/issues/3206 (we no longer throw, resulting in a black screen - we never load the modal though).

## Risk

Touches the opportunities slice, though no adverse changes are expected (only less throwing).

## Testing

The opportunities page should be much more robust when values aren't yet (or never will be) loaded.
In particular, refreshing whilst an opportunity overview modal is open should no longer throw, leaving the user with a black screen.

### Engineering

☝️ 

### Operations

☝️ 

## Screenshots (if applicable)

N/A