### PR TITLE
chore: remove Korean, Indonesian, and Chinese languages from selector

### DIFF
--- a/src/assets/translations/constants.ts
+++ b/src/assets/translations/constants.ts
@@ -16,23 +16,11 @@ export const locales = [
     label: 'Français',
   },
   {
-    key: 'id',
-    label: 'Bahasa Indonesia',
-  },
-  {
-    key: 'ko',
-    label: '한국어',
-  },
-  {
     key: 'pt',
     label: 'Português',
   },
   {
     key: 'ru',
     label: 'Русский',
-  },
-  {
-    key: 'zh',
-    label: '中文',
   },
 ]


### PR DESCRIPTION
## Description

Removes Korean, Indonesian, and Chinese languages from the language selector as they are not yet supported by the Globalisation team.

CC @firebomb1.

## Notice

- [x] Have you followed the guidelines in our [Contributing]('https://github.com/shapeshift/web/blob/develop/CONTRIBUTING.md) guide?
- [x] Have you checked to ensure there aren't other open [Pull Requests](https://github.com/shapeshift/web/pulls) for the same update/change?

## Pull Request Type

- [ ] :bug: Bug fix (Non-breaking Change: Fixes an issue)
- [x] :hammer_and_wrench: Chore (Non-breaking Change: Doc updates, pkg upgrades, typos, etc..)
- [ ] :nail_care: New Feature (Breaking/Non-breaking Change)

## Issue (if applicable)

Closes https://github.com/shapeshift/web/issues/3182

## Risk

Minimal.

## Testing

Korean, Indonesian, and Chinese languages should no longer be visible in the language selector.

### Engineering

☝️

### Operations

☝️

## Screenshots (if applicable)

<img width="401" alt="Screenshot 2022-11-10 at 4 19 53 pm" src="https://user-images.githubusercontent.com/97164662/201007146-fdf87e47-d5fb-4d9a-934d-4a0a560cef8a.png">
