### PR TITLE
fix: eth/fox lp fox page routing

### DIFF
--- a/src/context/FoxEthProvider/FoxEthProvider.tsx
+++ b/src/context/FoxEthProvider/FoxEthProvider.tsx
@@ -1,4 +1,4 @@
-import type { AccountId } from '@shapeshiftoss/caip'
+import type { AccountId, AssetId } from '@shapeshiftoss/caip'
 import { ethAssetId, fromAccountId } from '@shapeshiftoss/caip'
 import type { ChainAdapter } from '@shapeshiftoss/chain-adapters'
 import { supportsETH } from '@shapeshiftoss/hdwallet-core'
@@ -37,6 +37,7 @@ export type FoxFarmingEarnOpportunityType = {
   underlyingToken0Amount?: string
   underlyingToken1Amount?: string
   isVisible?: boolean
+  underlyingAssetId: AssetId
 } & EarnOpportunityType
 
 type FoxEthProviderProps = {

--- a/src/context/FoxEthProvider/FoxEthProvider.tsx
+++ b/src/context/FoxEthProvider/FoxEthProvider.tsx
@@ -37,7 +37,7 @@ export type FoxFarmingEarnOpportunityType = {
   underlyingToken0Amount?: string
   underlyingToken1Amount?: string
   isVisible?: boolean
-  underlyingAssetId: AssetId
+  underlyingAssetId?: AssetId
 } & EarnOpportunityType
 
 type FoxEthProviderProps = {

--- a/src/features/defi/providers/fox-eth-lp/hooks/useFoxEthLiquidityPool.ts
+++ b/src/features/defi/providers/fox-eth-lp/hooks/useFoxEthLiquidityPool.ts
@@ -1,5 +1,5 @@
 import { Contract } from '@ethersproject/contracts'
-import { ethAssetId, ethChainId, foxAssetId, toAccountId } from '@shapeshiftoss/caip'
+import { ethAssetId, ethChainId, foxAssetId, fromAssetId, toAccountId } from '@shapeshiftoss/caip'
 import type {
   ChainAdapter,
   ethereum,
@@ -415,7 +415,7 @@ export const useFoxEthLiquidityPool = (
       if (skip || !accountAddress || !uniswapRouterContract) return
       const value = bnOrZero(ethAmount).times(bn(10).exponentiatedBy(ethAsset.precision)).toFixed(0)
       const data = uniswapRouterContract.interface.encodeFunctionData('addLiquidityETH', [
-        FOX_TOKEN_CONTRACT_ADDRESS,
+        fromAssetId(foxAssetId).assetReference,
         bnOrZero(foxAmount).times(bn(10).exponentiatedBy(foxAsset.precision)).toFixed(0),
         calculateSlippageMargin(foxAmount, foxAsset.precision),
         calculateSlippageMargin(ethAmount, ethAsset.precision),

--- a/src/plugins/foxPage/components/OtherOpportunities/FoxOtherOpportunityPanelRow.tsx
+++ b/src/plugins/foxPage/components/OtherOpportunities/FoxOtherOpportunityPanelRow.tsx
@@ -84,7 +84,9 @@ export const FoxOtherOpportunityPanelRow: React.FC<FoxOtherOpportunityPanelRowPr
           provider,
           chainId,
           contractAddress,
-          assetReference: fromAssetId(earnOpportunity.underlyingAssetId).assetReference,
+          assetReference: earnOpportunity.underlyingAssetId
+            ? fromAssetId(earnOpportunity.underlyingAssetId).assetReference
+            : undefined,
           highestBalanceAccountAddress: opportunity.highestBalanceAccountAddress,
           rewardId: rewardAddress,
           modal: 'overview',

--- a/src/plugins/foxPage/components/OtherOpportunities/FoxOtherOpportunityPanelRow.tsx
+++ b/src/plugins/foxPage/components/OtherOpportunities/FoxOtherOpportunityPanelRow.tsx
@@ -77,15 +77,14 @@ export const FoxOtherOpportunityPanelRow: React.FC<FoxOtherOpportunityPanelRowPr
     }
 
     if (earnOpportunity) {
-      const { provider, chainId, contractAddress, assetId, rewardAddress } = earnOpportunity
-      const { assetReference } = fromAssetId(assetId)
+      const { provider, chainId, contractAddress, rewardAddress } = earnOpportunity
       history.push({
         pathname: location.pathname,
         search: qs.stringify({
           provider,
           chainId,
           contractAddress,
-          assetReference,
+          assetReference: fromAssetId(earnOpportunity.underlyingAssetId).assetReference,
           highestBalanceAccountAddress: opportunity.highestBalanceAccountAddress,
           rewardId: rewardAddress,
           modal: 'overview',
@@ -94,16 +93,7 @@ export const FoxOtherOpportunityPanelRow: React.FC<FoxOtherOpportunityPanelRowPr
       })
       return
     }
-  }, [
-    opportunity.highestBalanceAccountAddress,
-    isDemoWallet,
-    earnOpportunity,
-    dispatch,
-    history,
-    location,
-    opportunity.link,
-    wallet,
-  ])
+  }, [opportunity, isDemoWallet, wallet, earnOpportunity, dispatch, history, location])
 
   const opportunityButtonTranslation = useMemo(() => {
     if (opportunity.link) return 'plugins.foxPage.getStarted'


### PR DESCRIPTION
## Description

Fixes the LP routing from the FOX page, ensuring we pass the assetReference of the underlying AssetId (the LP token), not the one of the actual AssetId (the farming contract)

## Notice

<!-- Before submitting a pull request, please make sure you have answered the following: -->

- [x] Have you followed the guidelines in our [Contributing]('https://github.com/shapeshift/web/blob/develop/CONTRIBUTING.md) guide?
- [x] Have you checked to ensure there aren't other open [Pull Requests](https://github.com/shapeshift/web/pulls) for the same update/change?

## Pull Request Type

- [x] :bug: Bug fix (Non-breaking Change: Fixes an issue)
- [ ] :hammer_and_wrench: Chore (Non-breaking Change: Doc updates, pkg upgrades, typos, etc..)
- [ ] :nail_care: New Feature (Breaking/Non-breaking Change)

## Issue (if applicable)

N/A

## Risk

<!-----------------------------------------------------------------------------
Outline the scope of your changes and the risk associated with them. You must use your discretion as an engineer to determine the potential impact of your changes.

E.g. an upgrade to `hdwallet` or core state management would be considered higher risk, and might require a full regression test. UI or isolated view changes, or something behind a feature flag may have near zero risk. Small bug fixes might require testing isolated to the specific fix.
------------------------------------------------------------------------------>

FOX/ETH LP could be broken from the DeFi page, tested both in FOX page and DeFi page 

## Testing

<!-----------------------------------------------------------------------------
We treat every PR to be merged with the same scrutiny as if we were merging directly to production.

Your PR will not be merged if you do not complete the sections below for our engineering and operations teams to test.
------------------------------------------------------------------------------>

- When opened from the FOX Page, ETH/FOX lp modal is able to continue with the deposit flow all the way to confirmation
- When opened from the DeFi Page, ETH/FOX lp modal is able to continue with the deposit flow all the way to confirmation

### Engineering

<!-----------------------------------------------------------------------------
Include sufficient information here for an engineer to test your PR. This may include how to test locally, in a built environment, changes to infrastructure etc.
------------------------------------------------------------------------------>

☝🏽 

### Operations

<!-----------------------------------------------------------------------------
If your changes have a user-facing impact, describe how a non-technical QA team can functionally test your changes in a preview environment.

If they are not user-facing please describe how to test for any regressions that may occur.
------------------------------------------------------------------------------>

☝🏽 

## Screenshots (if applicable)

<img width="766" alt="image" src="https://user-images.githubusercontent.com/17035424/201219370-8c51daa5-16fb-45aa-9b7e-5aa2d3001a78.png">
<img width="536" alt="image" src="https://user-images.githubusercontent.com/17035424/201219462-f2051d68-a6bb-4593-b6eb-72488e2912de.png">