### PR TITLE
fix: only non-default validator data selection

### DIFF
--- a/src/state/slices/portfolioSlice/selectors.ts
+++ b/src/state/slices/portfolioSlice/selectors.ts
@@ -1100,17 +1100,19 @@ export const selectStakingOpportunitiesDataFullByFilter = createCachedSelector(
     assetId,
     defaultStakingData,
   ): OpportunitiesDataFull[] => {
-    if (!defaultStakingData) return []
-    const dummy: OpportunitiesDataFull[] = [
-      {
-        isLoaded: true,
-        rewards: '0',
-        totalDelegations: '0',
-        ...defaultStakingData,
-      },
-    ]
-    if (defaultStakingData && !portfolioValidatorIds.length) return dummy
-    if (!assetId) return dummy
+    if (defaultStakingData) {
+      const dummy: OpportunitiesDataFull[] = [
+        {
+          isLoaded: true,
+          rewards: '0',
+          totalDelegations: '0',
+          ...defaultStakingData,
+        },
+      ]
+      if (!portfolioValidatorIds.length) return dummy
+      if (!assetId) return dummy
+    }
+    if (!assetId) return []
     return portfolioValidatorIds.map(validatorId => {
       const delegatedAmount = stakingDataByValidator
         .reduce((acc, currentStakingDataByValidator) => {


### PR DESCRIPTION
## Description

Fixes a bug introduced during types refactor, where we early return from `selectStakingOpportunitiesDataFullByFilter` in case of `!defaultValidatorData`.

That's wrong, since `defaultValidatorData` is the default validator data for a given `ValidatorId`, however, if said `ValidatorId` is a non-default one, we will make selection a no-op, effectively meaning being staked in a non-default ShapeShift validator will select empty opportunity data.

Fixed by tightening the logic to check for the presence of `defaultValidatorData` before making more checks WRT early return and encapsulating this in its own if statement.

## Notice

<!-- Before submitting a pull request, please make sure you have answered the following: -->

- [x] Have you followed the guidelines in our [Contributing]('https://github.com/shapeshift/web/blob/develop/CONTRIBUTING.md) guide?
- [x] Have you checked to ensure there aren't other open [Pull Requests](https://github.com/shapeshift/web/pulls) for the same update/change?

## Pull Request Type

- [x] :bug: Bug fix (Non-breaking Change: Fixes an issue)
- [ ] :hammer_and_wrench: Chore (Non-breaking Change: Doc updates, pkg upgrades, typos, etc..)
- [ ] :nail_care: New Feature (Breaking/Non-breaking Change)

## Issue (if applicable)

<!-----------------------------------------------------------------------------
If applicable, please link to the github issue and put `closes #XXXX` in your comment to auto-close the issue that your PR fixes.
------------------------------------------------------------------------------>

closes https://github.com/shapeshift/web/issues/3293

## Risk

<!-----------------------------------------------------------------------------
Outline the scope of your changes and the risk associated with them. You must use your discretion as an engineer to determine the potential impact of your changes.

E.g. an upgrade to `hdwallet` or core state management would be considered higher risk, and might require a full regression test. UI or isolated view changes, or something behind a feature flag may have near zero risk. Small bug fixes might require testing isolated to the specific fix.
------------------------------------------------------------------------------>

None?

## Testing

<!-----------------------------------------------------------------------------
We treat every PR to be merged with the same scrutiny as if we were merging directly to production.

Your PR will not be merged if you do not complete the sections below for our engineering and operations teams to test.
------------------------------------------------------------------------------>

- Have an account with default ShapeShift validator staking data only
- Have another account with non-default ShapeShift validator staking data only
- Have another account with default ShapeShift validator + non-default validator staking data 

For all these accounts:

- Staking data should be present over the app when switching from any wallet to a native wallet (ATOM account / asset pages, DeFi section)
- Staking data should be present over the app when switching from any wallet to a Keplr wallet (ATOM account / asset pages, DeFi section)
- Staking data should be present over the app on reload with Keplr/Native wallet connected
- When making a staking data Tx (deposit/withdraw/claim), either on default or non-default validator and reloading, the validator data shouldn't disappear

### Engineering

<!-----------------------------------------------------------------------------
Include sufficient information here for an engineer to test your PR. This may include how to test locally, in a built environment, changes to infrastructure etc.
------------------------------------------------------------------------------>

☝🏽 

### Operations

<!-----------------------------------------------------------------------------
If your changes have a user-facing impact, describe how a non-technical QA team can functionally test your changes in a preview environment.

If they are not user-facing please describe how to test for any regressions that may occur.
------------------------------------------------------------------------------>

☝🏽 

## Screenshots (if applicable)

Tested with @DiggyDiggy2 's seed

#### Develop

<img width="862" alt="image" src="https://user-images.githubusercontent.com/17035424/201426267-27e8723f-8059-4ae0-ad15-bab391c4b070.png">

#### This diff

<img width="868" alt="image" src="https://user-images.githubusercontent.com/17035424/201426113-1cdcf4b6-2173-4ec3-9b85-192611d774b4.png">