### PR TITLE
fix: incorrect farming ratio calculation

### DIFF
--- a/src/state/slices/opportunitiesSlice/resolvers/foxfarming.ts
+++ b/src/state/slices/opportunitiesSlice/resolvers/foxfarming.ts
@@ -181,18 +181,12 @@ export const foxFarmingStakingMetadataResolver = async ({
   )
 
   // Getting the ratio of the LP token for each asset
-  // fetchPairData().reserve0 and reserve1 somehow return crypto human amounts as opposed to getReserves() using full precision notation
-  const foxReserves = toBaseUnit(
-    bnOrZero(bnOrZero(pair.reserve1.toFixed()).toString()).toString(),
-    pair.token1.decimals,
-  )
-
-  const ethReserves = toBaseUnit(
-    bnOrZero(bnOrZero(pair.reserve0.toFixed()).toString()).toString(),
-    pair.token0.decimals,
-  )
-  const ethPoolRatio = bnOrZero(ethReserves).div(totalSupply.toString()).toString()
-  const foxPoolRatio = bnOrZero(foxReserves).div(totalSupply.toString()).toString()
+  const reserves = await uniV2LPContract.getReserves()
+  const lpTotalSupply = (await uniV2LPContract.totalSupply()).toString()
+  const foxReserves = bnOrZero(bnOrZero(reserves[1].toString()).toString())
+  const ethReserves = bnOrZero(bnOrZero(reserves[0].toString()).toString())
+  const ethPoolRatio = ethReserves.div(lpTotalSupply).toString()
+  const foxPoolRatio = foxReserves.div(lpTotalSupply).toString()
 
   const totalSupplyV2 = await uniV2LPContract.totalSupply()
 


### PR DESCRIPTION
## Description

Current implementation was using farming contract's totalSupply for ratios calculation in farming DeFi modals, which means they were effectively wrong since the totalSupply of the LP contract is what we should actually use for those calculations

## Notice

<!-- Before submitting a pull request, please make sure you have answered the following: -->

- [x] Have you followed the guidelines in our [Contributing]('https://github.com/shapeshift/web/blob/develop/CONTRIBUTING.md) guide?
- [x] Have you checked to ensure there aren't other open [Pull Requests](https://github.com/shapeshift/web/pulls) for the same update/change?

## Pull Request Type

- [x] :bug: Bug fix (Non-breaking Change: Fixes an issue)
- [ ] :hammer_and_wrench: Chore (Non-breaking Change: Doc updates, pkg upgrades, typos, etc..)
- [ ] :nail_care: New Feature (Breaking/Non-breaking Change)

## Issue (if applicable)

<!-----------------------------------------------------------------------------
If applicable, please link to the github issue and put `closes #XXXX` in your comment to auto-close the issue that your PR fixes.
------------------------------------------------------------------------------>

closes https://github.com/shapeshift/web/issues/3300

## Risk

<!-----------------------------------------------------------------------------
Outline the scope of your changes and the risk associated with them. You must use your discretion as an engineer to determine the potential impact of your changes.

E.g. an upgrade to `hdwallet` or core state management would be considered higher risk, and might require a full regression test. UI or isolated view changes, or something behind a feature flag may have near zero risk. Small bug fixes might require testing isolated to the specific fix.
------------------------------------------------------------------------------>

## Testing

- With an account with no staked LP tokens nor pooled ETH/FOX yet, stake some ETH/FOX e.g 10 FOX with the automatic prorate ETH tokens
- Stake your LP tokens
- Notice how the underlying tokens amount shown in the DeFi modal is the actual amount of tokens you have just pooled and staked

### Engineering

<!-----------------------------------------------------------------------------
Include sufficient information here for an engineer to test your PR. This may include how to test locally, in a built environment, changes to infrastructure etc.
------------------------------------------------------------------------------>

☝🏽

### Operations

<!-----------------------------------------------------------------------------
If your changes have a user-facing impact, describe how a non-technical QA team can functionally test your changes in a preview environment.

If they are not user-facing please describe how to test for any regressions that may occur.
------------------------------------------------------------------------------>

☝🏽

## Screenshots (if applicable)

#### This diff

<img width="555" alt="image" src="https://user-images.githubusercontent.com/17035424/201492918-e52c3bb4-8e41-4793-b792-31a7f181abbe.png">

#### Prod

<img width="534" alt="image" src="https://user-images.githubusercontent.com/17035424/201492931-1fd602c9-6f1e-4245-8b4a-787e4dac44b0.png">