### PR TITLE
fix: use indexed vote data from Boardroom API

### DIFF
--- a/src/plugins/foxPage/components/Governance.tsx
+++ b/src/plugins/foxPage/components/Governance.tsx
@@ -53,7 +53,12 @@ export const Governance = () => {
                     <CText fontWeight='semibold'>{choice}</CText>
 
                     <Flex>
-                      <Amount value={proposal.results[i].absolute} fontWeight='semibold' mr={2} />
+                      <Amount
+                        value={proposal.results[i].absolute}
+                        maximumFractionDigits={2}
+                        fontWeight='semibold'
+                        mr={2}
+                      />
                       <Badge
                         colorScheme='blue'
                         display='flex'

--- a/src/plugins/foxPage/hooks/getGovernanceData.test.ts
+++ b/src/plugins/foxPage/hooks/getGovernanceData.test.ts
@@ -6,14 +6,14 @@ const EMPTY_RESULTS_PROPOSAL: BoardroomGovernanceResult = {
   title: 'Proposal 1',
   currentState: 'active',
   choices: ['YES', 'NO'],
-  results: [],
+  indexedResult: [],
 }
 const PARTIAL_RESULTS_PROPOSAL: BoardroomGovernanceResult = {
   refId: 'refId2',
   title: 'Proposal 2',
   currentState: 'active',
   choices: ['YES', 'NO'],
-  results: [
+  indexedResult: [
     {
       total: 362512.22,
       choice: 0,
@@ -26,7 +26,7 @@ const ALL_RESULTS_PROPOSAL: BoardroomGovernanceResult = {
   title: 'Proposal 3',
   currentState: 'closed',
   choices: ['Yes (For)', 'No (Against)'],
-  results: [
+  indexedResult: [
     {
       total: 4122544.5,
       choice: 0,
@@ -43,7 +43,7 @@ const INACTIVE_PROPOSAL: BoardroomGovernanceResult = {
   title: 'Proposal 4',
   currentState: 'closed',
   choices: ['For', 'Against'],
-  results: [
+  indexedResult: [
     {
       total: 5876468,
       choice: 0,
@@ -56,7 +56,7 @@ const INACTIVE_PROPOSAL_TWO: BoardroomGovernanceResult = {
   title: 'Proposal 5',
   currentState: 'closed',
   choices: ['For', 'Against'],
-  results: [
+  indexedResult: [
     {
       total: 5876468,
       choice: 0,

--- a/src/plugins/foxPage/hooks/getGovernanceData.ts
+++ b/src/plugins/foxPage/hooks/getGovernanceData.ts
@@ -8,7 +8,7 @@ export type BoardroomGovernanceResult = {
   currentState: string
   title: string
   choices: string[]
-  results: { total: number; choice: number }[]
+  indexedResult: { total: number; choice: number }[]
   refId: string
 }
 
@@ -30,8 +30,8 @@ export const parseGovernanceData = (
   const activeProposals = governanceData.filter(data => data.currentState === 'active')
   const proposals = activeProposals.length ? activeProposals : [governanceData[0]]
 
-  return proposals.map(({ title, choices, results, refId }) => {
-    const totalResults = results.reduce((acc, currentResult) => {
+  return proposals.map(({ title, choices, indexedResult, refId }) => {
+    const totalResults = indexedResult.reduce((acc, currentResult) => {
       acc = acc.plus(currentResult.total)
       return acc
     }, bnOrZero('0'))
@@ -41,8 +41,8 @@ export const parseGovernanceData = (
       title,
       choices,
       results: choices.map((_, i) => ({
-        absolute: bnOrZero(results[i]?.total).toString(),
-        percent: results[i] ? bnOrZero(results[i].total).div(totalResults).toString() : '0',
+        absolute: bnOrZero(indexedResult[i]?.total).toString(),
+        percent: indexedResult[i] ? bnOrZero(indexedResult[i].total).div(totalResults).toString() : '0',
       })),
     }
   })

--- a/src/plugins/foxPage/hooks/getGovernanceData.ts
+++ b/src/plugins/foxPage/hooks/getGovernanceData.ts
@@ -42,7 +42,9 @@ export const parseGovernanceData = (
       choices,
       results: choices.map((_, i) => ({
         absolute: bnOrZero(indexedResult[i]?.total).toString(),
-        percent: indexedResult[i] ? bnOrZero(indexedResult[i].total).div(totalResults).toString() : '0',
+        percent: indexedResult[i]
+          ? bnOrZero(indexedResult[i].total).div(totalResults).toString()
+          : '0',
       })),
     }
   })


### PR DESCRIPTION
## Description

Matching what Boardroom actually displays on their app so the data we display is consistent with it. The Boardroom API we currently use has the correct data under another JSON key named `indexedResult`.

## Notice

<!-- Before submitting a pull request, please make sure you have answered the following: -->

- [x] Have you followed the guidelines in our [Contributing]('https://github.com/shapeshift/web/blob/develop/CONTRIBUTING.md) guide?
- [x] Have you checked to ensure there aren't other open [Pull Requests](https://github.com/shapeshift/web/pulls) for the same update/change?

## Pull Request Type

- [x] :bug: Bug fix (Non-breaking Change: Fixes an issue)
- [ ] :hammer_and_wrench: Chore (Non-breaking Change: Doc updates, pkg upgrades, typos, etc..)
- [ ] :nail_care: New Feature (Breaking/Non-breaking Change)

## Issue (if applicable)

Closes #

(I did report the issue to the bot on Discord but I don't think a Github issue has been created yet, I just wanted to try my hand on a small bug fix after finally setting up a dev env with WSL 😆).

## Risk

Minimal/None

## Testing

### Engineering

Unit tests updated to use the updated structure.

### Operations

Verifying that the vote data displayed on Boardroom and the app are matching now.

## Screenshots (if applicable)

Boardroom app:
![image](https://user-images.githubusercontent.com/88804546/201501188-082aadd5-56a1-46e6-b78a-0902b9906598.png)

Current (wrong) values: 
![image](https://user-images.githubusercontent.com/88804546/201501175-579ec7eb-4e8f-4b4f-a18c-1a4b1506feaf.png)

Fixed values:
![image](https://user-images.githubusercontent.com/88804546/201501198-01111b4e-dbaa-4261-a4d8-17a286330b63.png)

