### PR TITLE
chore: use react router better

### DIFF
--- a/src/Routes/Routes.tsx
+++ b/src/Routes/Routes.tsx
@@ -107,7 +107,9 @@ export const Routes = () => {
         </Layout>
       </Route>
       <Redirect from='/' to='/dashboard' />
-      <Route component={NotFound} />
+      <Route>
+        <NotFound />
+      </Route>
     </Switch>
   )
 }

--- a/src/components/Bridge/Bridge.tsx
+++ b/src/components/Bridge/Bridge.tsx
@@ -1,5 +1,5 @@
 import { FormProvider, useForm } from 'react-hook-form'
-import { MemoryRouter, Route, Switch } from 'react-router-dom'
+import { MemoryRouter } from 'react-router-dom'
 
 import { BridgeRoutes, entries } from './BridgeRoutes/BridgeRoutes'
 import type { BridgeState } from './types'
@@ -12,11 +12,7 @@ export const Bridge = () => {
   return (
     <FormProvider {...methods}>
       <MemoryRouter initialEntries={entries}>
-        <Switch>
-          <Route path='/'>
-            <BridgeRoutes />
-          </Route>
-        </Switch>
+        <BridgeRoutes />
       </MemoryRouter>
     </FormProvider>
   )

--- a/src/components/Bridge/BridgeRoutes/BridgeRoutes.tsx
+++ b/src/components/Bridge/BridgeRoutes/BridgeRoutes.tsx
@@ -1,6 +1,7 @@
 import { AnimatePresence } from 'framer-motion'
 import type { RouteComponentProps } from 'react-router-dom'
 import { Redirect, Route, Switch, useLocation } from 'react-router-dom'
+import { SendRoutes } from 'components/Modals/Send/SendCommon'
 
 import { useBridgeRoutes } from '../hooks/useBridgeRoutes'
 import { BridgeRoutePaths } from '../types'
@@ -10,7 +11,7 @@ import { SelectAsset } from './SelectAsset'
 import { SelectChain } from './SelectChain'
 import { Status } from './Status'
 
-export const entries = ['/send/details', '/send/confirm']
+export const entries = [SendRoutes.Confirm, SendRoutes.Details]
 
 export const BridgeRoutes = () => {
   const location = useLocation()

--- a/src/components/Layout/Header/NavBar/Native/BackupPassphraseModal/BackupPassphraseModal.tsx
+++ b/src/components/Layout/Header/NavBar/Native/BackupPassphraseModal/BackupPassphraseModal.tsx
@@ -1,18 +1,12 @@
 import { Modal, ModalContent, ModalOverlay } from '@chakra-ui/react'
 import React from 'react'
-import { MemoryRouter, Route, Switch } from 'react-router-dom'
+import { MemoryRouter } from 'react-router-dom'
 import { useModal } from 'hooks/useModal/useModal'
 
 import { BackupPassphraseRoutes } from './BackupPassphraseCommon'
 import { BackupPassphraseRouter } from './BackupPassphraseRouter'
 
-export const entries = [
-  BackupPassphraseRoutes.Start,
-  BackupPassphraseRoutes.Password,
-  BackupPassphraseRoutes.Info,
-  BackupPassphraseRoutes.Test,
-  BackupPassphraseRoutes.Success,
-]
+export const entries = Object.values(BackupPassphraseRoutes)
 
 type BackupPassphraseModalProps = {
   preventClose?: boolean
@@ -33,11 +27,7 @@ export const BackupPassphraseModal: React.FC<BackupPassphraseModalProps> = ({ pr
       <ModalOverlay />
       <ModalContent justifyContent='center' px={{ base: 0, md: 4 }} pt={3} pb={6}>
         <MemoryRouter initialEntries={entries}>
-          <Switch>
-            <Route path='/'>
-              <BackupPassphraseRouter />
-            </Route>
-          </Switch>
+          <BackupPassphraseRouter />
         </MemoryRouter>
       </ModalContent>
     </Modal>

--- a/src/components/Layout/Header/NavBar/UserMenu.tsx
+++ b/src/components/Layout/Header/NavBar/UserMenu.tsx
@@ -5,7 +5,7 @@ import type { FC } from 'react'
 import { useEffect, useState } from 'react'
 import { FaWallet } from 'react-icons/fa'
 import { useTranslate } from 'react-polyglot'
-import { MemoryRouter, Route, Switch } from 'react-router-dom'
+import { MemoryRouter } from 'react-router-dom'
 import { useEnsName } from 'wagmi'
 import { WalletConnectedRoutes } from 'components/Layout/Header/NavBar/hooks/useMenuRoutes'
 import { WalletConnectedMenu } from 'components/Layout/Header/NavBar/WalletConnectedMenu'
@@ -38,17 +38,13 @@ export type WalletConnectedProps = {
 export const WalletConnected = (props: WalletConnectedProps) => {
   return (
     <MemoryRouter initialEntries={entries}>
-      <Switch>
-        <Route path='/'>
-          <WalletConnectedMenu
-            isConnected={props.isConnected}
-            walletInfo={props.walletInfo}
-            onDisconnect={props.onDisconnect}
-            onSwitchProvider={props.onSwitchProvider}
-            type={props.type}
-          />
-        </Route>
-      </Switch>
+      <WalletConnectedMenu
+        isConnected={props.isConnected}
+        walletInfo={props.walletInfo}
+        onDisconnect={props.onDisconnect}
+        onSwitchProvider={props.onSwitchProvider}
+        type={props.type}
+      />
     </MemoryRouter>
   )
 }

--- a/src/components/Modals/FiatRamps/views/FiatRamps.tsx
+++ b/src/components/Modals/FiatRamps/views/FiatRamps.tsx
@@ -23,11 +23,7 @@ type FiatFormProps = {
   fiatRampAction?: FiatRampAction
 }
 
-export const FiatForm: React.FC<FiatFormProps> = ({
-  handleIsSelectingAsset,
-  assetId = ethAssetId,
-  fiatRampAction,
-}) => {
+export const FiatForm: React.FC<FiatFormProps> = ({ assetId = ethAssetId, fiatRampAction }) => {
   const walletAccountIds = useSelector(selectWalletAccountIds)
   const portfolioAccountMetadata = useSelector(selectPortfolioAccountMetadata)
   const [accountId, setAccountId] = useState<AccountId | undefined>()

--- a/src/components/Modals/Receive/Receive.tsx
+++ b/src/components/Modals/Receive/Receive.tsx
@@ -1,8 +1,7 @@
 import { Modal, ModalContent, ModalOverlay } from '@chakra-ui/react'
 import type { Asset } from '@shapeshiftoss/asset-service'
 import type { AccountId } from '@shapeshiftoss/caip'
-import type { RouteComponentProps } from 'react-router-dom'
-import { MemoryRouter, Route, Switch } from 'react-router-dom'
+import { MemoryRouter } from 'react-router-dom'
 import { useModal } from 'hooks/useModal/useModal'
 
 import { ReceiveRoutes } from './ReceiveCommon'
@@ -24,14 +23,7 @@ const Receive = ({ asset, accountId }: ReceivePropsType) => {
       <ModalOverlay />
       <ModalContent>
         <MemoryRouter initialEntries={entries}>
-          <Switch>
-            <Route
-              path='/'
-              component={(props: RouteComponentProps) => (
-                <ReceiveRouter asset={asset} accountId={accountId} {...props} />
-              )}
-            />
-          </Switch>
+          <ReceiveRouter asset={asset} accountId={accountId} />
         </MemoryRouter>
       </ModalContent>
     </Modal>

--- a/src/components/Modals/Send/Send.tsx
+++ b/src/components/Modals/Send/Send.tsx
@@ -2,20 +2,13 @@ import { Modal, ModalContent, ModalOverlay } from '@chakra-ui/react'
 import type { Asset } from '@shapeshiftoss/asset-service'
 import type { AccountId } from '@shapeshiftoss/caip'
 import { useRef } from 'react'
-import type { RouteComponentProps } from 'react-router-dom'
-import { MemoryRouter, Route, Switch } from 'react-router-dom'
+import { MemoryRouter } from 'react-router-dom'
 import { useModal } from 'hooks/useModal/useModal'
 
 import { Form } from './Form'
 import { SendRoutes } from './SendCommon'
 
-export const entries = [
-  SendRoutes.Address,
-  SendRoutes.Details,
-  SendRoutes.Confirm,
-  SendRoutes.Scan,
-  SendRoutes.Select,
-]
+export const entries = Object.values(SendRoutes)
 
 type SendModalProps = {
   asset: Asset
@@ -32,14 +25,7 @@ export const SendModal = ({ asset, accountId }: SendModalProps) => {
       <ModalOverlay />
       <ModalContent maxW='500px'>
         <MemoryRouter initialEntries={entries}>
-          <Switch>
-            <Route
-              path='/'
-              component={(props: RouteComponentProps) => (
-                <Form asset={asset} accountId={accountId} {...props} />
-              )}
-            />
-          </Switch>
+          <Form asset={asset} accountId={accountId} />
         </MemoryRouter>
       </ModalContent>
     </Modal>

--- a/src/components/Modals/Send/SendCommon.tsx
+++ b/src/components/Modals/Send/SendCommon.tsx
@@ -1,8 +1,8 @@
 export enum SendRoutes {
-  Select = '/send/select',
   Address = '/send/address',
   Details = '/send/details',
   Confirm = '/send/confirm',
+  Select = '/send/select',
   Scan = '/send/scan',
 }
 

--- a/src/components/Modals/Settings/Settings.tsx
+++ b/src/components/Modals/Settings/Settings.tsx
@@ -1,18 +1,13 @@
 import { Modal, ModalContent, ModalOverlay } from '@chakra-ui/react'
 import type { MobileMessageEvent } from 'plugins/mobile'
 import { useEffect } from 'react'
-import { MemoryRouter, Route, Switch, useHistory } from 'react-router-dom'
+import { MemoryRouter, useHistory } from 'react-router-dom'
 import { useModal } from 'hooks/useModal/useModal'
 
 import { SettingsRoutes } from './SettingsCommon'
 import { SettingsRouter } from './SettingsRouter'
 
-export const entries = [
-  SettingsRoutes.Index,
-  SettingsRoutes.Languages,
-  SettingsRoutes.FiatCurrencies,
-  SettingsRoutes.CurrencyFormat,
-]
+export const entries = Object.values(SettingsRoutes)
 
 const Settings = () => {
   /**
@@ -45,11 +40,7 @@ const Settings = () => {
       <ModalOverlay />
       <ModalContent>
         <MemoryRouter initialEntries={entries}>
-          <Switch>
-            <Route path='/'>
-              <SettingsRouter appHistory={appHistory} />
-            </Route>
-          </Switch>
+          <SettingsRouter appHistory={appHistory} />
         </MemoryRouter>
       </ModalContent>
     </Modal>

--- a/src/components/SelectAssets/SelectAssetRouter.tsx
+++ b/src/components/SelectAssets/SelectAssetRouter.tsx
@@ -1,7 +1,6 @@
 import type { Asset } from '@shapeshiftoss/asset-service'
 import type { AssetId } from '@shapeshiftoss/caip'
-import type { RouteComponentProps } from 'react-router-dom'
-import { MemoryRouter, Route, Switch, useLocation } from 'react-router-dom'
+import { MemoryRouter, useLocation } from 'react-router-dom'
 
 import { SelectAssetRoutes } from './SelectAssetCommon'
 import { SelectAssetView } from './SelectAssetView'
@@ -11,7 +10,7 @@ export const entries = [SelectAssetRoutes.Search]
 type SelectAssetRouterProps = {
   onClick: (asset: Asset) => void
   onBack?: () => void
-} & RouteComponentProps
+}
 
 export type SelectAssetLocation = {
   toRoute: SelectAssetRoutes
@@ -22,14 +21,7 @@ export const SelectAssetRouter = ({ onClick, onBack: handleBack }: SelectAssetRo
   const { state } = useLocation<SelectAssetLocation>()
   return (
     <MemoryRouter initialEntries={entries}>
-      <Switch>
-        <Route
-          path='/'
-          component={(props: RouteComponentProps) => (
-            <SelectAssetView onClick={onClick} onBack={handleBack} {...state} {...props} />
-          )}
-        />
-      </Switch>
+      <SelectAssetView onClick={onClick} onBack={handleBack} {...state} />
     </MemoryRouter>
   )
 }

--- a/src/components/SelectAssets/SelectAssetView.tsx
+++ b/src/components/SelectAssets/SelectAssetView.tsx
@@ -1,6 +1,5 @@
 import type { Asset } from '@shapeshiftoss/asset-service'
 import { useEffect } from 'react'
-import type { RouteComponentProps } from 'react-router-dom'
 import { Redirect, Route, Switch, useHistory, useLocation } from 'react-router-dom'
 
 import { SelectAssetRoutes } from './SelectAssetCommon'
@@ -30,12 +29,9 @@ export const SelectAssetView = ({
 
   return (
     <Switch location={location} key={location.key}>
-      <Route
-        path={SelectAssetRoutes.Search}
-        component={(props: RouteComponentProps) => (
-          <SelectAssets onBack={handleBack} onClick={onClick} {...props} />
-        )}
-      />
+      <Route path={SelectAssetRoutes.Search}>
+        <SelectAssets onBack={handleBack} onClick={onClick} />
+      </Route>
       <Redirect from='/' to={SelectAssetRoutes.Search} />
     </Switch>
   )

--- a/src/components/SelectAssets/SelectAssetView.tsx
+++ b/src/components/SelectAssets/SelectAssetView.tsx
@@ -10,8 +10,7 @@ import { SelectAssets } from './SelectAssets'
 type SelectAssetViewProps = {
   onClick: (asset: Asset) => void
   onBack?: () => void
-} & SelectAssetLocation &
-  RouteComponentProps
+} & SelectAssetLocation
 
 export const SelectAssetView = ({
   onClick,

--- a/src/components/SelectAssets/SelectAssets.tsx
+++ b/src/components/SelectAssets/SelectAssets.tsx
@@ -1,7 +1,6 @@
 import { ArrowBackIcon } from '@chakra-ui/icons'
 import { IconButton, ModalBody, ModalCloseButton, ModalHeader, Stack } from '@chakra-ui/react'
 import { useTranslate } from 'react-polyglot'
-import type { RouteComponentProps } from 'react-router-dom'
 import { AssetSearch } from 'components/AssetSearch/AssetSearch'
 import { SlideTransition } from 'components/SlideTransition'
 
@@ -10,7 +9,7 @@ export type Asset = {}
 type SelectAssetsProps = {
   onClick(asset: Asset): void
   onBack?: () => void
-} & RouteComponentProps
+}
 
 export const SelectAssets = ({ onClick, onBack: handleBack }: SelectAssetsProps) => {
   const translate = useTranslate()

--- a/src/components/Trade/SelectAccount.tsx
+++ b/src/components/Trade/SelectAccount.tsx
@@ -4,7 +4,7 @@ import type { KnownChainIds } from '@shapeshiftoss/types'
 import isEqual from 'lodash/isEqual'
 import { useMemo } from 'react'
 import { useFormContext } from 'react-hook-form'
-import type { RouteComponentProps } from 'react-router-dom'
+import { useHistory } from 'react-router-dom'
 import { AssetAccountRow } from 'components/AssetAccounts/AssetAccountRow'
 import { Card } from 'components/Card/Card'
 import { SlideTransition } from 'components/SlideTransition'
@@ -15,7 +15,8 @@ import { WithBackButton } from 'components/Trade/WithBackButton'
 import { selectAccountIdsByAssetId, selectAssetById } from 'state/slices/selectors'
 import { useAppSelector } from 'state/store'
 
-export const SelectAccount = ({ history }: RouteComponentProps) => {
+export const SelectAccount = () => {
+  const history = useHistory()
   const { getValues, setValue } = useFormContext<TradeState<KnownChainIds>>()
   const assetId = getValues('sellTradeAsset')?.asset?.assetId
   const filter = useMemo(() => ({ assetId: assetId ?? '' }), [assetId])

--- a/src/components/Trade/Trade.tsx
+++ b/src/components/Trade/Trade.tsx
@@ -1,10 +1,10 @@
 import type { AssetId } from '@shapeshiftoss/caip'
 import { useEffect, useState } from 'react'
 import { FormProvider, useForm } from 'react-hook-form'
-import { MemoryRouter, Route, Switch, useLocation } from 'react-router-dom'
+import { MemoryRouter, useLocation } from 'react-router-dom'
 
 import { useDefaultAssets } from './hooks/useDefaultAssets'
-import { entries, TradeRoutes } from './TradeRoutes/TradeRoutes'
+import { TradeRoutes } from './TradeRoutes/TradeRoutes'
 import type { TS } from './types'
 import { TradeAmountInputField } from './types'
 
@@ -79,12 +79,8 @@ export const Trade = ({ defaultBuyAssetId }: TradeProps) => {
 
   return (
     <FormProvider {...methods}>
-      <MemoryRouter initialEntries={entries}>
-        <Switch>
-          <Route path='/'>
-            <TradeRoutes />
-          </Route>
-        </Switch>
+      <MemoryRouter>
+        <TradeRoutes />
       </MemoryRouter>
     </FormProvider>
   )

--- a/src/components/Trade/TradeConfirm/TradeConfirm.tsx
+++ b/src/components/Trade/TradeConfirm/TradeConfirm.tsx
@@ -22,7 +22,7 @@ import { useCallback, useEffect, useMemo, useState } from 'react'
 import { useFormContext } from 'react-hook-form'
 import { useTranslate } from 'react-polyglot'
 import { useSelector } from 'react-redux'
-import { type RouterProps } from 'react-router-dom'
+import { useHistory } from 'react-router-dom'
 import { Amount } from 'components/Amount/Amount'
 import { Card } from 'components/Card/Card'
 import { HelperTooltip } from 'components/HelperTooltip/HelperTooltip'
@@ -54,7 +54,8 @@ import { WithBackButton } from '../WithBackButton'
 import { AssetToAsset } from './AssetToAsset'
 import { ReceiveSummary } from './ReceiveSummary'
 
-export const TradeConfirm = ({ history }: RouterProps) => {
+export const TradeConfirm = () => {
+  const history = useHistory()
   const borderColor = useColorModeValue('gray.100', 'gray.750')
   const [sellTxid, setSellTxid] = useState('')
   const [buyTxid, setBuyTxid] = useState('')

--- a/src/components/Trade/TradeRoutes/TradeRoutes.tsx
+++ b/src/components/Trade/TradeRoutes/TradeRoutes.tsx
@@ -12,8 +12,6 @@ import { TradeConfirm } from '../TradeConfirm/TradeConfirm'
 import { TradeInput as TradeInputV2 } from '../TradeInput'
 import { TradeRoutePaths } from '../types'
 
-export const entries = ['/send/details', '/send/confirm']
-
 export const TradeRoutes = () => {
   const { getSupportedSellableAssets, getSupportedBuyAssetsFromSellAsset } = useSwapper()
   const location = useLocation()

--- a/src/components/Trade/TradeRoutes/TradeRoutes.tsx
+++ b/src/components/Trade/TradeRoutes/TradeRoutes.tsx
@@ -9,7 +9,7 @@ import { useSwapper } from '../hooks/useSwapper/useSwapper'
 import { AssetClickAction, useTradeRoutes } from '../hooks/useTradeRoutes/useTradeRoutes'
 import { SelectAsset } from '../SelectAsset'
 import { TradeConfirm } from '../TradeConfirm/TradeConfirm'
-import { TradeInput as TradeInputV2 } from '../TradeInput'
+import { TradeInput } from '../TradeInput'
 import { TradeRoutePaths } from '../types'
 
 export const TradeRoutes = () => {
@@ -43,10 +43,18 @@ export const TradeRoutes = () => {
             />
           )}
         />
-        <Route path={TradeRoutePaths.Input} component={TradeInputV2} />
-        <Route path={TradeRoutePaths.Confirm} component={TradeConfirm} />
-        <Route path={TradeRoutePaths.Approval} component={Approval} />
-        <Route path={TradeRoutePaths.AccountSelect} component={SelectAccount} />
+        <Route path={TradeRoutePaths.Input}>
+          <TradeInput />
+        </Route>
+        <Route path={TradeRoutePaths.Confirm}>
+          <TradeConfirm />
+        </Route>
+        <Route path={TradeRoutePaths.Approval}>
+          <Approval />
+        </Route>
+        <Route path={TradeRoutePaths.AccountSelect}>
+          <SelectAccount />
+        </Route>
         <Redirect from='/' to={TradeRoutePaths.Input} />
       </Switch>
     </AnimatePresence>


### PR DESCRIPTION
## Description

We have a lot of low-hanging fruit to improve app-wide performance due to the way we are using `react-router`:

1. We use the `Route`'s `component` prop extensively, which is not considered best practice because it creates a new component every render. This results in the existing component unmounting and the new component mounting every single render, and is likely causing some of the wired performance issues we get with routes.
2. We unnecessarily wrap a lot of components in `Switch`s and `Route`s - this is not needed when there is only one component - I suspect some monkey see monkey do has gotten us here.

This PR is still a WIP, more to do.

## Notice

- [x] Have you followed the guidelines in our [Contributing]('https://github.com/shapeshift/web/blob/develop/CONTRIBUTING.md) guide?
- [x] Have you checked to ensure there aren't other open [Pull Requests](https://github.com/shapeshift/web/pulls) for the same update/change?

## Pull Request Type

- [ ] :bug: Bug fix (Non-breaking Change: Fixes an issue)
- [x] :hammer_and_wrench: Chore (Non-breaking Change: Doc updates, pkg upgrades, typos, etc..)
- [ ] :nail_care: New Feature (Breaking/Non-breaking Change)

## Issue (if applicable)

N/A

## Risk

Medium to high - a lot of optimisations were made to routes, so we'll want to ensure that when navigating between pages and routes that everything still works as expected.

## Testing

Do a smoke test navigating between both pages and routes.

### Engineering

☝️ 

All args that were passed via props should now be accessed using hooks.

### Operations

☝️ 

## Screenshots (if applicable)

N/A