### PR TITLE
fix: idle overview getOrdefaultBip44Params

### DIFF
--- a/src/features/defi/providers/idle/components/IdleManager/Overview/IdleOverview.tsx
+++ b/src/features/defi/providers/idle/components/IdleManager/Overview/IdleOverview.tsx
@@ -1,7 +1,7 @@
 import { ArrowDownIcon, ArrowUpIcon } from '@chakra-ui/icons'
 import { Center, useToast } from '@chakra-ui/react'
 import type { AccountId } from '@shapeshiftoss/caip'
-import { toAssetId } from '@shapeshiftoss/caip'
+import { ethChainId, toAssetId } from '@shapeshiftoss/caip'
 import type { ClaimableToken, IdleOpportunity } from '@shapeshiftoss/investor-idle'
 import { KnownChainIds } from '@shapeshiftoss/types'
 import { USDC_PRECISION } from 'constants/UsdcPrecision'
@@ -28,6 +28,7 @@ import { useGetAssetDescriptionQuery } from 'state/slices/assetsSlice/assetsSlic
 import {
   selectAssetById,
   selectBIP44ParamsByAccountId,
+  selectFirstAccountIdByChainId,
   selectMarketDataById,
   selectPortfolioCryptoBalanceByFilter,
   selectSelectedLocale,
@@ -61,7 +62,17 @@ export const IdleOverview: React.FC<IdleOverviewProps> = ({
   onAccountIdChange: handleAccountIdChange,
 }) => {
   const accountFilter = useMemo(() => ({ accountId }), [accountId])
-  const bip44Params = useAppSelector(state => selectBIP44ParamsByAccountId(state, accountFilter))
+  const accountBip44Params = useAppSelector(state =>
+    selectBIP44ParamsByAccountId(state, accountFilter),
+  )
+  const defaultAccountId = useAppSelector(state => selectFirstAccountIdByChainId(state, ethChainId))
+  const defaultBip44Params = useAppSelector(state =>
+    selectBIP44ParamsByAccountId(state, { accountId: defaultAccountId }),
+  )
+  const bip44Params = useMemo(
+    () => accountBip44Params ?? defaultBip44Params,
+    [accountBip44Params, defaultBip44Params],
+  )
   const idleInvestor = useMemo(() => getIdleInvestor(), [])
   const translate = useTranslate()
   const toast = useToast()


### PR DESCRIPTION
## Description

Unrugs Idle overview modal with default bip44Params if the passed `accountId` prop is undefined - following the other modals we'd ideally use highest balance logic, however until the abstraction that's currently being written is finished, we are blocked WRT *clean* multi-account logic and being able to use selectors which do not exist yet.

## Notice

<!-- Before submitting a pull request, please make sure you have answered the following: -->

- [x] Have you followed the guidelines in our [Contributing]('https://github.com/shapeshift/web/blob/develop/CONTRIBUTING.md) guide?
- [x] Have you checked to ensure there aren't other open [Pull Requests](https://github.com/shapeshift/web/pulls) for the same update/change?

## Pull Request Type

- [x] :bug: Bug fix (Non-breaking Change: Fixes an issue)
- [ ] :hammer_and_wrench: Chore (Non-breaking Change: Doc updates, pkg upgrades, typos, etc..)
- [ ] :nail_care: New Feature (Breaking/Non-breaking Change)

## Issue (if applicable)

- relates to the closed https://github.com/shapeshift/web/pull/3261

## Risk

<!-----------------------------------------------------------------------------
Outline the scope of your changes and the risk associated with them. You must use your discretion as an engineer to determine the potential impact of your changes.

E.g. an upgrade to `hdwallet` or core state management would be considered higher risk, and might require a full regression test. UI or isolated view changes, or something behind a feature flag may have near zero risk. Small bug fixes might require testing isolated to the specific fix.
------------------------------------------------------------------------------>

- None, we are currently rugged, this puts us back in a working place

## Testing

<!-----------------------------------------------------------------------------
We treat every PR to be merged with the same scrutiny as if we were merging directly to production.

Your PR will not be merged if you do not complete the sections below for our engineering and operations teams to test.
------------------------------------------------------------------------------>

- Idle modals open with MetaMask with account 0 selected initially
- Idle modals open with Native with account 0 selected initially
- It is still possible to select an account and switch away from account 0

### Engineering

<!-----------------------------------------------------------------------------
Include sufficient information here for an engineer to test your PR. This may include how to test locally, in a built environment, changes to infrastructure etc.
------------------------------------------------------------------------------>

☝🏽 

### Operations

<!-----------------------------------------------------------------------------
If your changes have a user-facing impact, describe how a non-technical QA team can functionally test your changes in a preview environment.

If they are not user-facing please describe how to test for any regressions that may occur.
------------------------------------------------------------------------------>

☝🏽 

## Screenshots (if applicable)
