### PR TITLE
fix: update the asset to asset component colors

### DIFF
--- a/src/components/Trade/TradeConfirm/AssetToAsset.tsx
+++ b/src/components/Trade/TradeConfirm/AssetToAsset.tsx
@@ -9,17 +9,19 @@ type AssetToAssetProps = {
   buyIcon: string
   sellIcon: string
   status?: TxStatus
+  buyColor?: string
+  sellColor?: string
 } & FlexProps
 
 export const AssetToAsset: FC<AssetToAssetProps> = ({
   buyIcon,
   sellIcon,
   boxSize = '32px',
+  sellColor = '#2775CA',
+  buyColor = '#2775CA',
   status,
   ...rest
 }) => {
-  const sellAssetColor = !status ? '#F7931A' : '#2775CA'
-  const buyAssetColor = '#2775CA'
   const gray = useColorModeValue('white', 'gray.750')
   const red = useColorModeValue('white', 'red.500')
   const green = useColorModeValue('white', 'green.500')
@@ -62,7 +64,7 @@ export const AssetToAsset: FC<AssetToAssetProps> = ({
       <Box flex={1} maxWidth={`calc(50% - ${boxSize} / 2)`}>
         <Flex alignItems='center'>
           <AssetIcon src={sellIcon} boxSize={boxSize} />
-          <Divider borderBottomWidth={2} flex={1} bgColor={sellAssetColor} />
+          <Divider borderBottomWidth={2} flex={1} bgColor={sellColor} />
         </Flex>
       </Box>
       <Flex>
@@ -70,14 +72,14 @@ export const AssetToAsset: FC<AssetToAssetProps> = ({
           size={boxSize}
           bg='blue.500'
           p='2px'
-          background={`linear-gradient(to right, ${sellAssetColor}, ${buyAssetColor})`}
+          background={`linear-gradient(to right, ${sellColor}, ${buyColor})`}
         >
           {renderIcon()}
         </Circle>
       </Flex>
       <Flex flexDirection='column' flex={1} maxWidth={`calc(50% - ${boxSize} / 2)`}>
         <Flex alignItems='center' flex={1} justify='flex-start'>
-          <Divider borderBottomWidth={2} flex={1} bgColor={buyAssetColor} />
+          <Divider borderBottomWidth={2} flex={1} bgColor={buyColor} />
           <AssetIcon src={buyIcon} boxSize={boxSize} />
         </Flex>
       </Flex>

--- a/src/components/Trade/TradeConfirm/TradeConfirm.tsx
+++ b/src/components/Trade/TradeConfirm/TradeConfirm.tsx
@@ -263,6 +263,8 @@ export const TradeConfirm = ({ history }: RouterProps) => {
               <AssetToAsset
                 buyIcon={trade.buyAsset.icon}
                 sellIcon={trade.sellAsset.icon}
+                buyColor={trade.buyAsset.color}
+                sellColor={trade.sellAsset.color}
                 status={sellTxid || isSubmitting ? status : undefined}
               />
               <Flex direction='column' gap={2}>


### PR DESCRIPTION
## Description

- Now that we have asset colors we can update the asset to asset component to match

## Notice

<!-- Before submitting a pull request, please make sure you have answered the following: -->

- [x] Have you followed the guidelines in our [Contributing]('https://github.com/shapeshift/web/blob/develop/CONTRIBUTING.md) guide?
- [x] Have you checked to ensure there aren't other open [Pull Requests](https://github.com/shapeshift/web/pulls) for the same update/change?

## Pull Request Type

- [x] :bug: Bug fix (Non-breaking Change: Fixes an issue)
- [ ] :hammer_and_wrench: Chore (Non-breaking Change: Doc updates, pkg upgrades, typos, etc..)
- [ ] :nail_care: New Feature (Breaking/Non-breaking Change)

## Issue (if applicable)

<!-----------------------------------------------------------------------------
If applicable, please link to the github issue and put `closes #XXXX` in your comment to auto-close the issue that your PR fixes.
------------------------------------------------------------------------------>

closes #

## Risk

no risk visual change

## Testing

<!-----------------------------------------------------------------------------
We treat every PR to be merged with the same scrutiny as if we were merging directly to production.

Your PR will not be merged if you do not complete the sections below for our engineering and operations teams to test.
------------------------------------------------------------------------------>

### Engineering

<!-----------------------------------------------------------------------------
Include sufficient information here for an engineer to test your PR. This may include how to test locally, in a built environment, changes to infrastructure etc.
------------------------------------------------------------------------------>

### Operations

Going to trade confirm the line between to the two assets should be match the asset's colors.

## Screenshots (if applicable)
![Screen Shot 2022-11-14 at 10 23 57 AM](https://user-images.githubusercontent.com/89934888/201712606-11f2fc97-eaa7-4f10-ac01-f119312a7773.png)
