### PR TITLE
feat: add osmosis flag for swapping

### DIFF
--- a/.env.base
+++ b/.env.base
@@ -3,6 +3,7 @@
 # feature flags - other .env files will override these
 REACT_APP_FEATURE_ZENDESK=false
 REACT_APP_FEATURE_OSMOSIS=false
+REACT_APP_FEATURE_OSMOSIS_SWAP=false
 REACT_APP_FEATURE_PENDO=false
 REACT_APP_FEATURE_AXELAR=false
 REACT_APP_FEATURE_IDLE=false

--- a/src/components/Trade/hooks/useSwapper/swapperManager.ts
+++ b/src/components/Trade/hooks/useSwapper/swapperManager.ts
@@ -78,7 +78,7 @@ export const getSwapperManager = async (flags: FeatureFlags): Promise<SwapperMan
     })()
   }
 
-  if (flags.Osmosis) {
+  if (flags.OsmosisSwap) {
     const osmoUrl = getConfig().REACT_APP_OSMOSIS_NODE_URL
     const cosmosUrl = getConfig().REACT_APP_COSMOS_NODE_URL
     const osmoSwapper = new OsmosisSwapper({ adapterManager, osmoUrl, cosmosUrl })

--- a/src/components/Trade/hooks/useSwapper/utils.ts
+++ b/src/components/Trade/hooks/useSwapper/utils.ts
@@ -178,7 +178,7 @@ export const getDefaultAssetIdPairByChainId = (
   buyAssetChainId: ChainId | undefined,
   featureFlags: FeatureFlags,
 ): AssetIdTradePair => {
-  const osmosisEnabled = featureFlags.Osmosis
+  const osmosisEnabled = featureFlags.OsmosisSwap
   const ethFoxPair = {
     sellAssetId: ethAssetId,
     buyAssetId: foxAssetId,

--- a/src/config.ts
+++ b/src/config.ts
@@ -55,6 +55,7 @@ const validators = {
   REACT_APP_FEATURE_ZENDESK: bool({ default: false }),
   REACT_APP_FEATURE_YEARN: bool({ default: true }),
   REACT_APP_FEATURE_OSMOSIS: bool({ default: false }),
+  REACT_APP_FEATURE_OSMOSIS_SWAP: bool({ default: false }),
   REACT_APP_FEATURE_THORCHAIN: bool({ default: false }),
   REACT_APP_FEATURE_THOR_SWAP: bool({ default: false }),
   REACT_APP_FEATURE_IDLE: bool({ default: false }),

--- a/src/state/slices/preferencesSlice/preferencesSlice.ts
+++ b/src/state/slices/preferencesSlice/preferencesSlice.ts
@@ -9,6 +9,7 @@ dayjs.extend(localizedFormat)
 
 export type FeatureFlags = {
   Osmosis: boolean
+  OsmosisSwap: boolean
   Thorchain: boolean
   ThorSwap: boolean
   CowSwap: boolean
@@ -43,6 +44,7 @@ export type Preferences = {
 const initialState: Preferences = {
   featureFlags: {
     Osmosis: getConfig().REACT_APP_FEATURE_OSMOSIS,
+    OsmosisSwap: getConfig().REACT_APP_FEATURE_OSMOSIS_SWAP,
     Thorchain: getConfig().REACT_APP_FEATURE_THORCHAIN,
     ThorSwap: getConfig().REACT_APP_FEATURE_THOR_SWAP,
     CowSwap: getConfig().REACT_APP_FEATURE_COWSWAP,

--- a/src/test/mocks/store.ts
+++ b/src/test/mocks/store.ts
@@ -46,6 +46,7 @@ export const mockStore: ReduxState = {
   preferences: {
     featureFlags: {
       Osmosis: false,
+      OsmosisSwap: false,
       Thorchain: false,
       ThorSwap: false,
       CowSwap: false,


### PR DESCRIPTION
## Description

Added Osmosis flag to disable/enable swapping. 

The OSMO feature flag is still there to disable at the plugin level

## Notice

<!-- Before submitting a pull request, please make sure you have answered the following: -->

- [x] Have you followed the guidelines in our [Contributing]('https://github.com/shapeshift/web/blob/develop/CONTRIBUTING.md) guide?
- [x] Have you checked to ensure there aren't other open [Pull Requests](https://github.com/shapeshift/web/pulls) for the same update/change?

## Pull Request Type

- [ ] :bug: Bug fix (Non-breaking Change: Fixes an issue)
- [ ] :hammer_and_wrench: Chore (Non-breaking Change: Doc updates, pkg upgrades, typos, etc..)
- [x] :nail_care: New Feature (Breaking/Non-breaking Change)

## Issue (if applicable)

<!-----------------------------------------------------------------------------
If applicable, please link to the github issue and put `closes #XXXX` in your comment to auto-close the issue that your PR fixes.
------------------------------------------------------------------------------>

closes #

## Risk

None
<!-----------------------------------------------------------------------------
Outline the scope of your changes and the risk associated with them. You must use your discretion as an engineer to determine the potential impact of your changes.

E.g. an upgrade to `hdwallet` or core state management would be considered higher risk, and might require a full regression test. UI or isolated view changes, or something behind a feature flag may have near zero risk. Small bug fixes might require testing isolated to the specific fix.
------------------------------------------------------------------------------>

## Testing

Test with enabled/disable feature flag REACT_APP_FEATURE_OSMOSIS_SWAP to see if OSMO shows up in the sell asset for Trade
<!-----------------------------------------------------------------------------
We treat every PR to be merged with the same scrutiny as if we were merging directly to production.

Your PR will not be merged if you do not complete the sections below for our engineering and operations teams to test.
------------------------------------------------------------------------------>

### Engineering

Test with enabled/disable feature flag REACT_APP_FEATURE_OSMOSIS_SWAP to see if OSMO shows up in the sell asset for Trade
<!-----------------------------------------------------------------------------
Include sufficient information here for an engineer to test your PR. This may include how to test locally, in a built environment, changes to infrastructure etc.
------------------------------------------------------------------------------>

### Operations

Test with enabled/disable feature flag REACT_APP_FEATURE_OSMOSIS_SWAP to see if OSMO shows up in the sell asset for Trade
<!-----------------------------------------------------------------------------
If your changes have a user-facing impact, describe how a non-technical QA team can functionally test your changes in a preview environment.

If they are not user-facing please describe how to test for any regressions that may occur.
------------------------------------------------------------------------------>

## Screenshots (if applicable)
