### PR TITLE
fix: lazily load market data for fiat ramp assets

### DIFF
--- a/src/pages/Buy/Buy.tsx
+++ b/src/pages/Buy/Buy.tsx
@@ -14,7 +14,7 @@ import { FiatForm } from 'components/Modals/FiatRamps/views/FiatForm'
 import { Text } from 'components/Text'
 import { WalletActions } from 'context/WalletProvider/actions'
 import { useWallet } from 'hooks/useWallet/useWallet'
-import { useFetchFiatAssetMarketData } from 'state/apis/fiatRamps/selectors'
+import { useFetchFiatAssetMarketData } from 'state/apis/fiatRamps/hooks'
 
 import { PageContainer } from './components/PageContainer'
 import { TopAssets } from './TopAssets'

--- a/src/pages/Buy/Buy.tsx
+++ b/src/pages/Buy/Buy.tsx
@@ -14,6 +14,7 @@ import { FiatForm } from 'components/Modals/FiatRamps/views/FiatForm'
 import { Text } from 'components/Text'
 import { WalletActions } from 'context/WalletProvider/actions'
 import { useWallet } from 'hooks/useWallet/useWallet'
+import { useFetchFiatAssetMarketData } from 'state/apis/fiatRamps/selectors'
 
 import { PageContainer } from './components/PageContainer'
 import { TopAssets } from './TopAssets'
@@ -31,6 +32,8 @@ export const Buy = () => {
     state: { isConnected, isDemoWallet },
   } = useWallet()
   const translate = useTranslate()
+
+  useFetchFiatAssetMarketData()
 
   const handleConnect = useCallback(() => {
     dispatch({ type: WalletActions.SET_WALLET_MODAL, payload: true })

--- a/src/state/apis/fiatRamps/fiatRamps.ts
+++ b/src/state/apis/fiatRamps/fiatRamps.ts
@@ -1,12 +1,10 @@
 import { createApi } from '@reduxjs/toolkit/dist/query/react'
 import type { AssetId } from '@shapeshiftoss/caip'
-import { HistoryTimeframe } from '@shapeshiftoss/types'
 import type { FiatRamp } from 'components/Modals/FiatRamps/config'
 import { supportedFiatRamps } from 'components/Modals/FiatRamps/config'
 import type { FiatRampAction } from 'components/Modals/FiatRamps/FiatRampsCommon'
 import { logger } from 'lib/logger'
 import { BASE_RTK_CREATE_API_CONFIG } from 'state/apis/const'
-import { marketApi } from 'state/slices/marketDataSlice/marketDataSlice'
 
 const moduleLogger = logger.child({ namespace: ['fiatRampApi'] })
 
@@ -29,7 +27,7 @@ export const fiatRampApi = createApi({
   endpoints: build => ({
     getFiatRamps: build.query<FiatRampsByAssetId, void>({
       keepUnusedDataFor: Number.MAX_SAFE_INTEGER, // never refetch these
-      queryFn: async (_, { dispatch, getState }) => {
+      queryFn: async (_, { getState }) => {
         try {
           const activeProviders = Object.values(supportedFiatRamps).filter(provider =>
             provider.isActive((getState() as any).preferences.featureFlags),
@@ -60,15 +58,6 @@ export const fiatRampApi = createApi({
             },
             { byAssetId: {}, buyAssetIds: [], sellAssetIds: [] },
           )
-          const allFiatAssetIds = [...data.buyAssetIds, ...data.sellAssetIds]
-          const timeframe = HistoryTimeframe.DAY
-          // fetch market data for all fiat ramp asset ids
-          allFiatAssetIds.forEach(assetId => {
-            // spot market pricing
-            dispatch(marketApi.endpoints.findByAssetId.initiate(assetId))
-            // 24hr price history - needed for "spark charts" on fiat page
-            dispatch(marketApi.endpoints.findPriceHistoryByAssetId.initiate({ assetId, timeframe }))
-          })
           return { data }
         } catch (e) {
           const error = 'getFiatRampAssets: error fetching fiat ramp(s)'

--- a/src/state/apis/fiatRamps/hooks.ts
+++ b/src/state/apis/fiatRamps/hooks.ts
@@ -1,0 +1,34 @@
+import type { AssetId } from '@shapeshiftoss/caip'
+import { HistoryTimeframe } from '@shapeshiftoss/types'
+import { useEffect } from 'react'
+import { marketApi } from 'state/slices/marketDataSlice/marketDataSlice'
+import { useAppDispatch, useAppSelector } from 'state/store'
+
+import { fiatRampApi } from './fiatRamps'
+
+export const useIsSupportedFiatBuyAssetId = (assetId: AssetId): boolean =>
+  Boolean(
+    (useAppSelector(fiatRampApi.endpoints.getFiatRamps.select()).data?.buyAssetIds ?? []).includes(
+      assetId,
+    ),
+  )
+
+export const useIsSupportedFiatSellAssetId = (assetId: AssetId): boolean =>
+  Boolean(
+    (useAppSelector(fiatRampApi.endpoints.getFiatRamps.select()).data?.sellAssetIds ?? []).includes(
+      assetId,
+    ),
+  )
+
+export const useFetchFiatAssetMarketData = (): void => {
+  const { data } = useAppSelector(fiatRampApi.endpoints.getFiatRamps.select())
+  const dispatch = useAppDispatch()
+  useEffect(() => {
+    const timeframe = HistoryTimeframe.DAY
+    const assetIds = Object.keys(data?.byAssetId ?? {})
+    assetIds.forEach(assetId => {
+      dispatch(marketApi.endpoints.findByAssetId.initiate(assetId))
+      dispatch(marketApi.endpoints.findPriceHistoryByAssetId.initiate({ assetId, timeframe }))
+    })
+  }, [data, dispatch])
+}

--- a/src/state/apis/fiatRamps/selectors.ts
+++ b/src/state/apis/fiatRamps/selectors.ts
@@ -1,43 +1,12 @@
 import type { Asset } from '@shapeshiftoss/asset-service'
 import type { AssetId } from '@shapeshiftoss/caip'
 import type { MarketData } from '@shapeshiftoss/types'
-import { HistoryTimeframe } from '@shapeshiftoss/types'
-import { useEffect } from 'react'
 import { createSelector } from 'reselect'
 import { createDeepEqualOutputSelector } from 'state/selector-utils'
-import { defaultMarketData, marketApi } from 'state/slices/marketDataSlice/marketDataSlice'
+import { defaultMarketData } from 'state/slices/marketDataSlice/marketDataSlice'
 import { selectAssets, selectMarketData } from 'state/slices/selectors'
-import { useAppSelector } from 'state/store'
 
-import { useAppDispatch } from '../../store'
 import { fiatRampApi } from './fiatRamps'
-
-export const useIsSupportedFiatBuyAssetId = (assetId: AssetId): boolean =>
-  Boolean(
-    (useAppSelector(fiatRampApi.endpoints.getFiatRamps.select()).data?.buyAssetIds ?? []).includes(
-      assetId,
-    ),
-  )
-
-export const useIsSupportedFiatSellAssetId = (assetId: AssetId): boolean =>
-  Boolean(
-    (useAppSelector(fiatRampApi.endpoints.getFiatRamps.select()).data?.sellAssetIds ?? []).includes(
-      assetId,
-    ),
-  )
-
-export const useFetchFiatAssetMarketData = (): void => {
-  const { data } = useAppSelector(fiatRampApi.endpoints.getFiatRamps.select())
-  const dispatch = useAppDispatch()
-  useEffect(() => {
-    const timeframe = HistoryTimeframe.DAY
-    const assetIds = Object.keys(data?.byAssetId ?? {})
-    assetIds.forEach(assetId => {
-      dispatch(marketApi.endpoints.findByAssetId.initiate(assetId))
-      dispatch(marketApi.endpoints.findPriceHistoryByAssetId.initiate({ assetId, timeframe }))
-    })
-  }, [data, dispatch])
-}
 
 export const selectFiatBuyAssetIds = createDeepEqualOutputSelector(
   fiatRampApi.endpoints.getFiatRamps.select(),


### PR DESCRIPTION
## Description

<!-- Please describe your changes -->

we're beating up coingecko pretty hard w/ ~100 eager requests for market data and price history on app boot for the assets that have fiat ramp support

this defers loading this market data until the user navigates to the buy page where we display it

## Notice

<!-- Before submitting a pull request, please make sure you have answered the following: -->

- [x] Have you followed the guidelines in our [Contributing]('https://github.com/shapeshift/web/blob/develop/CONTRIBUTING.md) guide?
- [x] Have you checked to ensure there aren't other open [Pull Requests](https://github.com/shapeshift/web/pulls) for the same update/change?

## Pull Request Type

- [x] :bug: Bug fix (Non-breaking Change: Fixes an issue)
- [ ] :hammer_and_wrench: Chore (Non-breaking Change: Doc updates, pkg upgrades, typos, etc..)
- [ ] :nail_care: New Feature (Breaking/Non-breaking Change)

## Issue (if applicable)

<!-----------------------------------------------------------------------------
If applicable, please link to the github issue and put `closes #XXXX` in your comment to auto-close the issue that your PR fixes.
------------------------------------------------------------------------------>

closes #3334

## Risk

minimal - changes from eager to lazy loading of this data

<!-----------------------------------------------------------------------------
Outline the scope of your changes and the risk associated with them. You must use your discretion as an engineer to determine the potential impact of your changes.

E.g. an upgrade to `hdwallet` or core state management would be considered higher risk, and might require a full regression test. UI or isolated view changes, or something behind a feature flag may have near zero risk. Small bug fixes might require testing isolated to the specific fix.
------------------------------------------------------------------------------>

## Testing

<!-----------------------------------------------------------------------------
We treat every PR to be merged with the same scrutiny as if we were merging directly to production.

Your PR will not be merged if you do not complete the sections below for our engineering and operations teams to test.
------------------------------------------------------------------------------>

### Engineering

* see that we're not making these spot and price history requests until the `<Buy />` component mounts

<!-----------------------------------------------------------------------------
Include sufficient information here for an engineer to test your PR. This may include how to test locally, in a built environment, changes to infrastructure etc.
------------------------------------------------------------------------------>

### Operations

* refresh the page on the `/buy` route - the list of assets with prices and charts should load

<!-----------------------------------------------------------------------------
If your changes have a user-facing impact, describe how a non-technical QA team can functionally test your changes in a preview environment.

If they are not user-facing please describe how to test for any regressions that may occur.
------------------------------------------------------------------------------>

## Screenshots (if applicable)
