### PR TITLE
fix: use underlyingAssetId in fox farming expired withdraws

### DIFF
--- a/src/features/defi/components/Withdraw/Withdraw.tsx
+++ b/src/features/defi/components/Withdraw/Withdraw.tsx
@@ -163,6 +163,8 @@ export const Withdraw: React.FC<WithdrawProps> = ({
     onContinue(values)
   }
 
+  if (!asset) return null
+
   return (
     <Stack spacing={6} as='form' maxWidth='lg' width='full' onSubmit={handleSubmit(onSubmit)}>
       <FormField label={translate('modals.withdraw.amountToWithdraw')}>

--- a/src/features/defi/providers/fox-farming/components/FoxFarmingManager/Overview/Claim/ClaimConfirm.tsx
+++ b/src/features/defi/providers/fox-farming/components/FoxFarmingManager/Overview/Claim/ClaimConfirm.tsx
@@ -134,6 +134,8 @@ export const ClaimConfirm = ({
     foxFarmingContract,
   ])
 
+  if (!asset) return null
+
   return (
     <SlideTransition>
       <ModalBody>

--- a/src/features/defi/providers/fox-farming/components/FoxFarmingManager/Withdraw/components/ExpiredWithdraw.tsx
+++ b/src/features/defi/providers/fox-farming/components/FoxFarmingManager/Withdraw/components/ExpiredWithdraw.tsx
@@ -38,7 +38,9 @@ export const ExpiredWithdraw: React.FC<StepComponentProps> = ({ onNext }) => {
 
   const methods = useForm<WithdrawValues>({ mode: 'onChange' })
 
-  const asset = useAppSelector(state => selectAssetById(state, opportunity?.assetId ?? ''))
+  const asset = useAppSelector(state =>
+    selectAssetById(state, opportunity?.underlyingAssetId ?? ''),
+  )
   const ethAsset = useAppSelector(state => selectAssetById(state, ethAssetId))
   const foxAsset = useAppSelector(state => selectAssetById(state, foxAssetId))
 


### PR DESCRIPTION
## Description

This PR makes sure we:

- use the new `underlyingAssetId` (FOX) for FOX farming withdraws, unrugging the withdraw and claim flow
- brings a bit of safety in the withdraw and claim components WRT `assetId` being falsy - if it renders empty, we know why that is

## Notice

<!-- Before submitting a pull request, please make sure you have answered the following: -->

- [x] Have you followed the guidelines in our [Contributing]('https://github.com/shapeshift/web/blob/develop/CONTRIBUTING.md) guide?
- [x] Have you checked to ensure there aren't other open [Pull Requests](https://github.com/shapeshift/web/pulls) for the same update/change?

## Pull Request Type

- [x] :bug: Bug fix (Non-breaking Change: Fixes an issue)
- [ ] :hammer_and_wrench: Chore (Non-breaking Change: Doc updates, pkg upgrades, typos, etc..)
- [ ] :nail_care: New Feature (Breaking/Non-breaking Change)

## Issue (if applicable)

N/A

## Risk

None

## Testing

<!-----------------------------------------------------------------------------
We treat every PR to be merged with the same scrutiny as if we were merging directly to production.

Your PR will not be merged if you do not complete the sections below for our engineering and operations teams to test.
------------------------------------------------------------------------------>

- Have a position in an expired ETH/FOX farm
- Ensure you can withdraw and claim

### Engineering

<!-----------------------------------------------------------------------------
Include sufficient information here for an engineer to test your PR. This may include how to test locally, in a built environment, changes to infrastructure etc.
------------------------------------------------------------------------------>

☝🏽 

### Operations

<!-----------------------------------------------------------------------------
If your changes have a user-facing impact, describe how a non-technical QA team can functionally test your changes in a preview environment.

If they are not user-facing please describe how to test for any regressions that may occur.
------------------------------------------------------------------------------>

☝🏽 
## Screenshots (if applicable)

<img width="540" alt="image" src="https://user-images.githubusercontent.com/17035424/202783967-35a57018-c3ea-40b3-ba92-ada2403f7eba.png">