### PR TITLE
chore: release v1.156.0 [DO NOT MERGE]

### DIFF
--- a/src/features/defi/components/Withdraw/Withdraw.tsx
+++ b/src/features/defi/components/Withdraw/Withdraw.tsx
@@ -163,6 +163,8 @@ export const Withdraw: React.FC<WithdrawProps> = ({
     onContinue(values)
   }
 
+  if (!asset) return null
+
   return (
     <Stack spacing={6} as='form' maxWidth='lg' width='full' onSubmit={handleSubmit(onSubmit)}>
       <FormField label={translate('modals.withdraw.amountToWithdraw')}>

--- a/src/features/defi/providers/fox-farming/components/FoxFarmingManager/Overview/Claim/ClaimConfirm.tsx
+++ b/src/features/defi/providers/fox-farming/components/FoxFarmingManager/Overview/Claim/ClaimConfirm.tsx
@@ -134,6 +134,8 @@ export const ClaimConfirm = ({
     foxFarmingContract,
   ])
 
+  if (!asset) return null
+
   return (
     <SlideTransition>
       <ModalBody>

--- a/src/features/defi/providers/fox-farming/components/FoxFarmingManager/Withdraw/components/ExpiredWithdraw.tsx
+++ b/src/features/defi/providers/fox-farming/components/FoxFarmingManager/Withdraw/components/ExpiredWithdraw.tsx
@@ -38,7 +38,9 @@ export const ExpiredWithdraw: React.FC<StepComponentProps> = ({ onNext }) => {
 
   const methods = useForm<WithdrawValues>({ mode: 'onChange' })
 
-  const asset = useAppSelector(state => selectAssetById(state, opportunity?.assetId ?? ''))
+  const asset = useAppSelector(state =>
+    selectAssetById(state, opportunity?.underlyingAssetId ?? ''),
+  )
   const ethAsset = useAppSelector(state => selectAssetById(state, ethAssetId))
   const foxAsset = useAppSelector(state => selectAssetById(state, foxAssetId))
 


### PR DESCRIPTION
fix: use underlyingAssetId in fox farming expired withdraws (#3371)