### PR TITLE
fix: use correct confirm amounts

### DIFF
--- a/src/components/Trade/TradeConfirm/TradeConfirm.tsx
+++ b/src/components/Trade/TradeConfirm/TradeConfirm.tsx
@@ -220,10 +220,6 @@ export const TradeConfirm = () => {
     .times(bnOrZero(sellAssetFiatRate))
     .times(selectedCurrencyToUsdRate)
 
-  const buyAmountFiat = bnOrZero(buyAmountCrypto)
-    .times(bnOrZero(buyAssetFiatRate))
-    .times(selectedCurrencyToUsdRate)
-
   const networkFeeFiat = bnOrZero(fees?.networkFeeCryptoHuman)
     .times(feeAssetFiatRate ?? 1)
     .times(selectedCurrencyToUsdRate)
@@ -308,7 +304,7 @@ export const TradeConfirm = () => {
                   protocolFee={tradeAmounts?.totalTradeFeeBuyAsset ?? ''}
                   shapeShiftFee='0'
                   slippage={slippage}
-                  fiatAmount={buyAmountFiat.toString()}
+                  fiatAmount={tradeAmounts?.buyAmountAfterFeesFiat ?? ''}
                   swapperName={swapper?.name ?? ''}
                 />
               </Stack>

--- a/src/components/Trade/TradeConfirm/TradeConfirm.tsx
+++ b/src/components/Trade/TradeConfirm/TradeConfirm.tsx
@@ -82,9 +82,7 @@ export const TradeConfirm = () => {
     tradeAmounts,
     trade,
     fees,
-    sellAssetFiatRate,
     feeAssetFiatRate,
-    buyAssetFiatRate,
     slippage,
     buyAssetAccountId,
     sellAssetAccountId,
@@ -207,26 +205,13 @@ export const TradeConfirm = () => {
     history.push(TradeRoutePaths.Input)
   }
 
-  const sellAmountCrypto = fromBaseUnit(
-    bnOrZero(trade.sellAmountCryptoPrecision),
-    trade.sellAsset?.precision ?? 0,
-  )
-  const buyAmountCrypto = fromBaseUnit(
-    bnOrZero(trade.buyAmountCryptoPrecision),
-    trade.buyAsset?.precision ?? 0,
-  )
-
-  const sellAmountFiat = bnOrZero(sellAmountCrypto)
-    .times(bnOrZero(sellAssetFiatRate))
-    .times(selectedCurrencyToUsdRate)
-
   const networkFeeFiat = bnOrZero(fees?.networkFeeCryptoHuman)
     .times(feeAssetFiatRate ?? 1)
     .times(selectedCurrencyToUsdRate)
 
   // Ratio of the fiat value of the gas fee to the fiat value of the trade value express in percentage
   const networkFeeToTradeRatioPercentage = networkFeeFiat
-    .dividedBy(sellAmountFiat)
+    .dividedBy(tradeAmounts?.sellAmountBeforeFeesFiat ?? 1)
     .times(100)
     .toNumber()
   const networkFeeToTradeRatioPercentageThreshold = 5
@@ -293,8 +278,20 @@ export const TradeConfirm = () => {
                 <Row>
                   <Row.Label>{translate('common.send')}</Row.Label>
                   <Row.Value textAlign='right'>
-                    <Amount.Crypto value={sellAmountCrypto} symbol={trade.sellAsset.symbol} />
-                    <Amount.Fiat color='gray.500' value={sellAmountFiat.toString()} prefix='≈' />
+                    <Amount.Crypto
+                      value={
+                        fromBaseUnit(
+                          tradeAmounts?.sellAmountBeforeFeesBaseUnit ?? '',
+                          trade.sellAsset.precision,
+                        ) ?? ''
+                      }
+                      symbol={trade.sellAsset.symbol}
+                    />
+                    <Amount.Fiat
+                      color='gray.500'
+                      value={tradeAmounts?.sellAmountBeforeFeesFiat ?? ''}
+                      prefix='≈'
+                    />
                   </Row.Value>
                 </Row>
                 <ReceiveSummary


### PR DESCRIPTION
## Description

Uses the correct fiat buy amount on the confirm screen instead of incorrectly rolling our own inside the component.

## Notice

- [x] Have you followed the guidelines in our [Contributing]('https://github.com/shapeshift/web/blob/develop/CONTRIBUTING.md) guide?
- [x] Have you checked to ensure there aren't other open [Pull Requests](https://github.com/shapeshift/web/pulls) for the same update/change?

## Pull Request Type

- [x] :bug: Bug fix (Non-breaking Change: Fixes an issue)
- [ ] :hammer_and_wrench: Chore (Non-breaking Change: Doc updates, pkg upgrades, typos, etc..)
- [ ] :nail_care: New Feature (Breaking/Non-breaking Change)

## Issue (if applicable)

Closes https://github.com/shapeshift/web/issues/3328

## Risk

Small. All changes are limited to the confirm trade modal - only UI is affected.

## Testing

Stage the same trade as Willy in the issue above (LTC to ATOM) or similar THORChain trade with.
The expected fiat amount should now correctly include the trading fee and match the value given on the trade quote page.

### Engineering

☝️ 

### Operations

☝️ 

## Screenshots (if applicable)

N/A