### PR TITLE
fix: tradeConfirm render & composition

### DIFF
--- a/src/components/Trade/TradeConfirm/TradeConfirm.tsx
+++ b/src/components/Trade/TradeConfirm/TradeConfirm.tsx
@@ -257,8 +257,8 @@ export const TradeConfirm = () => {
     [handleBack, status],
   )
 
-  const tradeWarning: JSX.Element = useMemo(
-    () => (
+  const tradeWarning: JSX.Element | null = useMemo(() => {
+    const tradeWarningElement = (
       <Flex direction='column' gap={2}>
         {fees?.tradeFeeSource === 'Thorchain' && (
           <Alert status='info' width='auto' fontSize='sm'>
@@ -282,9 +282,10 @@ export const TradeConfirm = () => {
           </Alert>
         )}
       </Flex>
-    ),
-    [fees?.tradeFeeSource, trade.buyAsset.assetId, translate],
-  )
+    )
+    const shouldRenderWarnings = tradeWarningElement.props.children.type !== null
+    return shouldRenderWarnings ? tradeWarningElement : null
+  }, [fees?.tradeFeeSource, trade.buyAsset.assetId, translate])
 
   const sendReceiveSummary: JSX.Element = useMemo(
     () => (

--- a/src/components/Trade/TradeConfirm/TradeConfirm.tsx
+++ b/src/components/Trade/TradeConfirm/TradeConfirm.tsx
@@ -237,22 +237,117 @@ export const TradeConfirm = () => {
   const isFeeRatioOverThreshold =
     networkFeeToTradeRatioPercentage > networkFeeToTradeRatioPercentageThreshold
 
+  const header: JSX.Element = useMemo(
+    () => (
+      <>
+        <Card.Header px={0} pt={0}>
+          <WithBackButton handleBack={handleBack}>
+            <Card.Heading textAlign='center'>
+              <Text
+                translation={
+                  status === TxStatus.Confirmed ? 'trade.complete' : 'trade.confirmDetails'
+                }
+              />
+            </Card.Heading>
+          </WithBackButton>
+        </Card.Header>
+        <Divider />
+      </>
+    ),
+    [handleBack, status],
+  )
+
+  const tradeWarning: JSX.Element = useMemo(
+    () => (
+      <Flex direction='column' gap={2}>
+        {fees?.tradeFeeSource === 'Thorchain' && (
+          <Alert status='info' width='auto' fontSize='sm'>
+            <AlertIcon />
+            <Stack spacing={0}>
+              <AlertTitle>{translate('trade.slowSwapTitle', { protocol: 'THORChain' })}</AlertTitle>
+              <AlertDescription lineHeight='short'>
+                {translate('trade.slowSwapBody')}
+              </AlertDescription>
+            </Stack>
+          </Alert>
+        )}
+        {trade.buyAsset.assetId === thorchainAssetId && (
+          <Alert status='info' width='auto' mb={3} fontSize='sm'>
+            <AlertIcon />
+            <Stack spacing={0}>
+              <AlertDescription lineHeight='short'>
+                {translate('trade.intoRUNEBody')}
+              </AlertDescription>
+            </Stack>
+          </Alert>
+        )}
+      </Flex>
+    ),
+    [fees?.tradeFeeSource, trade.buyAsset.assetId, translate],
+  )
+
+  const sendReceiveSummary: JSX.Element = useMemo(
+    () => (
+      <Stack spacing={4}>
+        <Row>
+          <Row.Label>{translate('common.send')}</Row.Label>
+          <Row.Value textAlign='right'>
+            <Amount.Crypto value={sellAmountCrypto} symbol={trade.sellAsset.symbol} />
+            <Amount.Fiat color='gray.500' value={sellAmountFiat.toString()} prefix='≈' />
+          </Row.Value>
+        </Row>
+        <ReceiveSummary
+          symbol={trade.buyAsset.symbol ?? ''}
+          amount={buyTradeAsset?.amount ?? ''}
+          beforeFees={tradeAmounts?.beforeFeesBuyAsset ?? ''}
+          protocolFee={tradeAmounts?.totalTradeFeeBuyAsset ?? ''}
+          shapeShiftFee='0'
+          slippage={slippage}
+          fiatAmount={buyAmountFiat.toString()}
+          swapperName={swapper?.name ?? ''}
+        />
+      </Stack>
+    ),
+    [
+      buyAmountFiat,
+      buyTradeAsset?.amount,
+      sellAmountCrypto,
+      sellAmountFiat,
+      slippage,
+      swapper?.name,
+      trade.buyAsset.symbol,
+      trade.sellAsset.symbol,
+      tradeAmounts?.beforeFeesBuyAsset,
+      tradeAmounts?.totalTradeFeeBuyAsset,
+      translate,
+    ],
+  )
+
+  const footer: JSX.Element = useMemo(
+    () => (
+      <Card.Footer px={0} py={0}>
+        {!sellTxid && !isSubmitting && (
+          <Button
+            colorScheme='blue'
+            size='lg'
+            width='full'
+            mt={6}
+            data-test='trade-form-confirm-and-trade-button'
+            type='submit'
+          >
+            <Text translation='trade.confirmAndTrade' />
+          </Button>
+        )}
+      </Card.Footer>
+    ),
+    [isSubmitting, sellTxid],
+  )
+
   return (
     <SlideTransition>
       <Box as='form' onSubmit={handleSubmit(onSubmit)}>
         <Card variant='unstyled'>
-          <Card.Header px={0} pt={0}>
-            <WithBackButton handleBack={handleBack}>
-              <Card.Heading textAlign='center'>
-                <Text
-                  translation={
-                    status === TxStatus.Confirmed ? 'trade.complete' : 'trade.confirmDetails'
-                  }
-                />
-              </Card.Heading>
-            </WithBackButton>
-          </Card.Header>
-          <Divider />
+          {header}
           <Card.Body pb={0} px={0}>
             <Stack
               spacing={4}
@@ -268,50 +363,8 @@ export const TradeConfirm = () => {
                 sellColor={trade.sellAsset.color}
                 status={sellTxid || isSubmitting ? status : undefined}
               />
-              <Flex direction='column' gap={2}>
-                {fees?.tradeFeeSource === 'Thorchain' && (
-                  <Alert status='info' width='auto' fontSize='sm'>
-                    <AlertIcon />
-                    <Stack spacing={0}>
-                      <AlertTitle>
-                        {translate('trade.slowSwapTitle', { protocol: 'THORChain' })}
-                      </AlertTitle>
-                      <AlertDescription lineHeight='short'>
-                        {translate('trade.slowSwapBody')}
-                      </AlertDescription>
-                    </Stack>
-                  </Alert>
-                )}
-                {trade.buyAsset.assetId === thorchainAssetId && (
-                  <Alert status='info' width='auto' mb={3} fontSize='sm'>
-                    <AlertIcon />
-                    <Stack spacing={0}>
-                      <AlertDescription lineHeight='short'>
-                        {translate('trade.intoRUNEBody')}
-                      </AlertDescription>
-                    </Stack>
-                  </Alert>
-                )}
-              </Flex>
-              <Stack spacing={4}>
-                <Row>
-                  <Row.Label>{translate('common.send')}</Row.Label>
-                  <Row.Value textAlign='right'>
-                    <Amount.Crypto value={sellAmountCrypto} symbol={trade.sellAsset.symbol} />
-                    <Amount.Fiat color='gray.500' value={sellAmountFiat.toString()} prefix='≈' />
-                  </Row.Value>
-                </Row>
-                <ReceiveSummary
-                  symbol={trade.buyAsset.symbol ?? ''}
-                  amount={buyTradeAsset?.amount ?? ''}
-                  beforeFees={tradeAmounts?.beforeFeesBuyAsset ?? ''}
-                  protocolFee={tradeAmounts?.totalTradeFeeBuyAsset ?? ''}
-                  shapeShiftFee='0'
-                  slippage={slippage}
-                  fiatAmount={buyAmountFiat.toString()}
-                  swapperName={swapper?.name ?? ''}
-                />
-              </Stack>
+              {tradeWarning}
+              {sendReceiveSummary}
               <Stack spacing={4}>
                 {sellTxid && (
                   <Row>
@@ -368,20 +421,7 @@ export const TradeConfirm = () => {
               </Stack>
             </Stack>
           </Card.Body>
-          <Card.Footer px={0} py={0}>
-            {!sellTxid && !isSubmitting && (
-              <Button
-                colorScheme='blue'
-                size='lg'
-                width='full'
-                mt={6}
-                data-test='trade-form-confirm-and-trade-button'
-                type='submit'
-              >
-                <Text translation='trade.confirmAndTrade' />
-              </Button>
-            )}
-          </Card.Footer>
+          {footer}
         </Card>
       </Box>
     </SlideTransition>

--- a/src/components/Trade/TradeConfirm/TradeConfirm.tsx
+++ b/src/components/Trade/TradeConfirm/TradeConfirm.tsx
@@ -264,7 +264,9 @@ export const TradeConfirm = () => {
         )}
       </Flex>
     )
-    const shouldRenderWarnings = tradeWarningElement.props.children.type !== null
+    const shouldRenderWarnings = tradeWarningElement.props?.children?.some(
+      (child: JSX.Element | false) => !!child,
+    )
     return shouldRenderWarnings ? tradeWarningElement : null
   }, [fees?.tradeFeeSource, trade.buyAsset.assetId, translate])
 

--- a/src/components/Trade/TradeConfirm/TradeConfirm.tsx
+++ b/src/components/Trade/TradeConfirm/TradeConfirm.tsx
@@ -200,12 +200,12 @@ export const TradeConfirm = () => {
     }
   }
 
-  const handleBack = () => {
+  const handleBack = useCallback(() => {
     if (sellTxid) {
       reset()
     }
     history.push(TradeRoutePaths.Input)
-  }
+  }, [history, reset, sellTxid])
 
   const sellAmountCrypto = fromBaseUnit(
     bnOrZero(trade.sellAmountCryptoPrecision),


### PR DESCRIPTION
## Description

- Fixes a bug where we always render the `Flex` dom element to contain the trade warnings, even if there are none
- Refactors the `TradeConfirm` component to use better composition (the JSX is getting too hard to comprehend)

## Notice

- [x] Have you followed the guidelines in our [Contributing]('https://github.com/shapeshift/web/blob/develop/CONTRIBUTING.md) guide?
- [x] Have you checked to ensure there aren't other open [Pull Requests](https://github.com/shapeshift/web/pulls) for the same update/change?

## Pull Request Type

- [x] :bug: Bug fix (Non-breaking Change: Fixes an issue)
- [x] :hammer_and_wrench: Chore (Non-breaking Change: Doc updates, pkg upgrades, typos, etc..)
- [ ] :nail_care: New Feature (Breaking/Non-breaking Change)

## Issue (if applicable)

N/A

## Risk

Small - mostly a refactor, with a small rendering logic change.

## Testing

- The confirm change should show no changes or regressions
- We should still render trade warnings, e.g. when trading into RUNE

### Engineering

☝️ 

### Operations

☝️ 

## Screenshots (if applicable)

Before:

<img width="400" alt="Screenshot 2022-11-21 at 11 57 50 am" src="https://user-images.githubusercontent.com/97164662/202937558-f361c570-1b91-4b62-8fb0-d89303e5b10a.png">

After:

<img width="395" alt="Screenshot 2022-11-21 at 11 57 54 am" src="https://user-images.githubusercontent.com/97164662/202937568-6229f563-0c96-4a0c-ab98-be2b224b3506.png">
