### PR TITLE
fix: use new axelar url

### DIFF
--- a/react-app-rewired/headers/csps/bridges/axelar.ts
+++ b/react-app-rewired/headers/csps/bridges/axelar.ts
@@ -6,5 +6,6 @@ export const csp: Csp = {
     'https://nest-server-mainnet.axelar.dev',
     'wss://nest-server-mainnet.axelar.dev',
     'https://axelar-lcd.quickapi.com/',
+    'https://lcd-axelar.imperator.co/'
   ],
 }

--- a/src/components/Bridge/BridgeRoutes/Confirm.tsx
+++ b/src/components/Bridge/BridgeRoutes/Confirm.tsx
@@ -94,7 +94,7 @@ export const Confirm: React.FC = () => {
     ;(async () => {
       try {
         // We can't use axelarQuerySdk.getTransferFee() because of a CORS issue with the SDK
-        const baseUrl = 'https://axelar-lcd.quickapi.com/axelar/nexus/v1beta1/transfer_fee'
+        const baseUrl = 'https://lcd-axelar.imperator.co/axelar/nexus/v1beta1/transfer_fee'
         const requestUrl = `${baseUrl}?source_chain=${sourceChainName}&destination_chain=${destinationChainName}&amount=${cryptoAmount}${assetDenom}`
         const {
           data: {


### PR DESCRIPTION
## Description

`https://axelar-lcd.quickapi.com` no longer provides access control allow origin headers, and the `web` app doesn't accept responses that don't contain them.

Update the Axelar URL to one that does.

## Notice

- [x] Have you followed the guidelines in our [Contributing]('https://github.com/shapeshift/web/blob/develop/CONTRIBUTING.md) guide?
- [x] Have you checked to ensure there aren't other open [Pull Requests](https://github.com/shapeshift/web/pulls) for the same update/change?

## Pull Request Type

- [x] :bug: Bug fix (Non-breaking Change: Fixes an issue)
- [ ] :hammer_and_wrench: Chore (Non-breaking Change: Doc updates, pkg upgrades, typos, etc..)
- [ ] :nail_care: New Feature (Breaking/Non-breaking Change)

## Issue (if applicable)

N/A

## Risk

Minimal - feature flagged.

## Testing

### Engineering

Quotes can be received again for Axelar bridges.

### Operations

N/A

## Screenshots (if applicable)

N/A
