### PR TITLE
fix: copy address not vanity address to clipboard

### DIFF
--- a/src/components/Modals/FiatRamps/views/Overview.tsx
+++ b/src/components/Modals/FiatRamps/views/Overview.tsx
@@ -110,10 +110,10 @@ export const Overview: React.FC<OverviewProps> = ({
     const isClosable = true
     const toastPayload = { duration, isClosable }
     try {
-      await navigator.clipboard.writeText(vanityAddress || address)
+      await navigator.clipboard.writeText(address)
       const title = translate('common.copied')
       const status = 'success'
-      const description = vanityAddress ?? address
+      const description = address
       toast({ description, title, status, ...toastPayload })
     } catch (e) {
       const title = translate('common.copyFailed')
@@ -121,7 +121,7 @@ export const Overview: React.FC<OverviewProps> = ({
       const description = translate('common.copyFailedDescription')
       toast({ description, title, status })
     }
-  }, [address, vanityAddress, toast, translate])
+  }, [address, toast, translate])
 
   const supportsAddressVerification = useMemo(() => wallet instanceof KeepKeyHDWallet, [wallet])
 


### PR DESCRIPTION
## Description

On the Fiat Ramp form when users click on the copy icon we should copy the address and not the vanity address (Unstoppable Domains//ENS/etc.) as these ramps might not support vanity addresses yet but will always support simple addresses.

Vanity addresses are still displayed and can be manually copied from the input field if needed.

<!-- Please describe your changes -->

## Notice

<!-- Before submitting a pull request, please make sure you have answered the following: -->

- [x] Have you followed the guidelines in our [Contributing]('https://github.com/shapeshift/web/blob/develop/CONTRIBUTING.md) guide?
- [x] Have you checked to ensure there aren't other open [Pull Requests](https://github.com/shapeshift/web/pulls) for the same update/change?

## Pull Request Type

- [x] :bug: Bug fix (Non-breaking Change: Fixes an issue)
- [ ] :hammer_and_wrench: Chore (Non-breaking Change: Doc updates, pkg upgrades, typos, etc..)
- [ ] :nail_care: New Feature (Breaking/Non-breaking Change)

## Issue (if applicable)

<!-----------------------------------------------------------------------------
If applicable, please link to the github issue and put `closes #XXXX` in your comment to auto-close the issue that your PR fixes.
------------------------------------------------------------------------------>

N/A

## Risk

None.

<!-----------------------------------------------------------------------------
Outline the scope of your changes and the risk associated with them. You must use your discretion as an engineer to determine the potential impact of your changes.

E.g. an upgrade to `hdwallet` or core state management would be considered higher risk, and might require a full regression test. UI or isolated view changes, or something behind a feature flag may have near zero risk. Small bug fixes might require testing isolated to the specific fix.
------------------------------------------------------------------------------>

## Testing

<!-----------------------------------------------------------------------------
We treat every PR to be merged with the same scrutiny as if we were merging directly to production.

Your PR will not be merged if you do not complete the sections below for our engineering and operations teams to test.
------------------------------------------------------------------------------>

### Engineering

<!-----------------------------------------------------------------------------
Include sufficient information here for an engineer to test your PR. This may include how to test locally, in a built environment, changes to infrastructure etc.
------------------------------------------------------------------------------>

### Operations

Test copying the address with accounts which have and don't have Unstoppable Domains/ENS vanity addresses, it should always copy the address and not the vanity address.

## Screenshots (if applicable)
