### PR TITLE
fix(idle): clear unstaked positions

### DIFF
--- a/src/state/slices/opportunitiesSlice/resolvers/idle/index.ts
+++ b/src/state/slices/opportunitiesSlice/resolvers/idle/index.ts
@@ -146,6 +146,9 @@ export const idleStakingOpportunitiesUserDataResolver = async ({
     const opportunityId = toOpportunityId(toAssetIdParts)
     const userStakingId = serializeUserStakingId(accountId, opportunityId)
 
+    // This works because of Idle assets being both a portfolio-owned asset and a yield-bearing "staking asset"
+    // If you use me as a reference and copy me into a resolver for another opportunity, that might or might not be the case
+    // Don't do what monkey see, and adapt the business logic to the opportunity you're implementing
     if (bnOrZero(balance).eq(0)) {
       // Zero out this user staking opportunity including rewards - all rewards are automatically claimed when withdrawing, see
       // https://docs.idle.finance/developers/best-yield/methods/redeemidletoken-1


### PR DESCRIPTION
## Description

This PR zero's out the previously staked Idle positions (which users now have a zero portfolio balance for) when upserting, instead of skipping them.

Note, this was specific to Idle, confirmed ETH/FOX LP/staking isn't affected and opportunities are successfully removed from the DeFi section on unstake.

## Notice

<!-- Before submitting a pull request, please make sure you have answered the following: -->

- [x] Have you followed the guidelines in our [Contributing]('https://github.com/shapeshift/web/blob/develop/CONTRIBUTING.md) guide?
- [x] Have you checked to ensure there aren't other open [Pull Requests](https://github.com/shapeshift/web/pulls) for the same update/change?

## Pull Request Type

- [x] :bug: Bug fix (Non-breaking Change: Fixes an issue)
- [ ] :hammer_and_wrench: Chore (Non-breaking Change: Doc updates, pkg upgrades, typos, etc..)
- [ ] :nail_care: New Feature (Breaking/Non-breaking Change)

## Issue (if applicable)

closes https://github.com/shapeshift/web/issues/3400

## Risk

<!-----------------------------------------------------------------------------
Outline the scope of your changes and the risk associated with them. You must use your discretion as an engineer to determine the potential impact of your changes.

E.g. an upgrade to `hdwallet` or core state management would be considered higher risk, and might require a full regression test. UI or isolated view changes, or something behind a feature flag may have near zero risk. Small bug fixes might require testing isolated to the specific fix.
------------------------------------------------------------------------------>

See testing steps, rewards are the only risk, tested with best yield

## Testing

<!-----------------------------------------------------------------------------
We treat every PR to be merged with the same scrutiny as if we were merging directly to production.

Your PR will not be merged if you do not complete the sections below for our engineering and operations teams to test.
------------------------------------------------------------------------------>

- Ensure Idle.finance UI is matching ours, e.g removed cards/rows in DeFi earn/overview for the unstaked position should also be inactive on Idle's UI both for tranches and best yield
- The previously staked amounts should no longer be accounted for across the app (dashboard, account, asset and DeFi earn/overview pages)

### Engineering

<!-----------------------------------------------------------------------------
Include sufficient information here for an engineer to test your PR. This may include how to test locally, in a built environment, changes to infrastructure etc.
------------------------------------------------------------------------------>

☝🏽 

### Operations

<!-----------------------------------------------------------------------------
If your changes have a user-facing impact, describe how a non-technical QA team can functionally test your changes in a preview environment.

If they are not user-facing please describe how to test for any regressions that may occur.
------------------------------------------------------------------------------>

☝🏽 

## Screenshots (if applicable)

#### Prod

<img width="1293" alt="image" src="https://user-images.githubusercontent.com/17035424/204003379-d750faec-cb84-4258-879c-acc50a816a9c.png">
<img width="1258" alt="image" src="https://user-images.githubusercontent.com/17035424/204003446-3ff19127-e44d-42bf-a3fd-53f6de689cdd.png">
<img width="532" alt="image" src="https://user-images.githubusercontent.com/17035424/204003402-e1ec755f-de74-4ea9-9f79-5c0eb7967f40.png">

#### This diff

<img width="1317" alt="image" src="https://user-images.githubusercontent.com/17035424/204003550-d985a619-0c71-4f01-87f5-9fd746bfdd02.png">
<img width="1263" alt="image" src="https://user-images.githubusercontent.com/17035424/204003566-26c9fe46-d30f-47ab-bedd-05986d874915.png">
<img width="576" alt="image" src="https://user-images.githubusercontent.com/17035424/204003612-bcc81b9e-6b90-40fe-811f-8f21bcd441b7.png">