### PR TITLE
fix: idle market data / underlying token amounts

### DIFF
--- a/package.json
+++ b/package.json
@@ -105,7 +105,7 @@
     "@shapeshiftoss/investor-idle": "^2.3.2",
     "@shapeshiftoss/investor-yearn": "^6.1.7",
     "@shapeshiftoss/logger": "^1.1.3",
-    "@shapeshiftoss/market-service": "^7.2.1",
+    "@shapeshiftoss/market-service": "https://gitpkg.now.sh/shapeshift/lib/packages/market-service?fix_idle_market_data",
     "@shapeshiftoss/swapper": "^14.4.0",
     "@shapeshiftoss/types": "^8.3.2",
     "@shapeshiftoss/unchained-client": "^10.4.0",

--- a/package.json
+++ b/package.json
@@ -105,7 +105,7 @@
     "@shapeshiftoss/investor-idle": "^2.3.2",
     "@shapeshiftoss/investor-yearn": "^6.1.7",
     "@shapeshiftoss/logger": "^1.1.3",
-    "@shapeshiftoss/market-service": "https://gitpkg.now.sh/shapeshift/lib/packages/market-service?fix_idle_market_data",
+    "@shapeshiftoss/market-service": "^7.2.2",
     "@shapeshiftoss/swapper": "^14.4.0",
     "@shapeshiftoss/types": "^8.3.2",
     "@shapeshiftoss/unchained-client": "^10.4.0",

--- a/src/features/defi/providers/idle/components/IdleManager/Overview/IdleOverview.tsx
+++ b/src/features/defi/providers/idle/components/IdleManager/Overview/IdleOverview.tsx
@@ -85,13 +85,10 @@ export const IdleOverview: React.FC<IdleOverviewProps> = ({
     () => bnOrZero(balance).div(bn(10).pow(vaultAsset?.precision)),
     [balance, vaultAsset?.precision],
   )
-  const fiatAmountAvailable = useMemo(() => {
-    if (!idleOpportunity) return bn(0)
-
-    const pricePerShare = idleOpportunity.positionAsset.underlyingPerPosition
-
-    return bnOrZero(cryptoAmountAvailable).times(pricePerShare).times(marketData.price)
-  }, [cryptoAmountAvailable, idleOpportunity, marketData.price])
+  const fiatAmountAvailable = useMemo(
+    () => bnOrZero(cryptoAmountAvailable).times(marketData.price),
+    [cryptoAmountAvailable, marketData.price],
+  )
 
   const opportunityId = useMemo(
     () => toOpportunityId({ chainId, assetNamespace: 'erc20', assetReference: contractAddress }),

--- a/src/features/defi/providers/idle/components/IdleManager/Overview/IdleOverview.tsx
+++ b/src/features/defi/providers/idle/components/IdleManager/Overview/IdleOverview.tsx
@@ -3,7 +3,6 @@ import { Center } from '@chakra-ui/react'
 import type { Asset } from '@shapeshiftoss/asset-service'
 import type { AccountId } from '@shapeshiftoss/caip'
 import { ethChainId, toAssetId } from '@shapeshiftoss/caip'
-import type { IdleOpportunity } from '@shapeshiftoss/investor-idle'
 import type { DefiButtonProps } from 'features/defi/components/DefiActionButtons'
 import { Overview } from 'features/defi/components/Overview/Overview'
 import type {
@@ -12,7 +11,7 @@ import type {
 } from 'features/defi/contexts/DefiManagerProvider/DefiCommon'
 import { DefiAction } from 'features/defi/contexts/DefiManagerProvider/DefiCommon'
 import { getIdleInvestor } from 'features/defi/contexts/IdleProvider/idleInvestorSingleton'
-import { useEffect, useMemo, useState } from 'react'
+import { useMemo } from 'react'
 import { FaGift } from 'react-icons/fa'
 import { useTranslate } from 'react-polyglot'
 import type { AccountDropdownProps } from 'components/AccountDropdown/AccountDropdown'
@@ -57,7 +56,6 @@ export const IdleOverview: React.FC<IdleOverviewProps> = ({
   onAccountIdChange: handleAccountIdChange,
 }) => {
   const idleInvestor = useMemo(() => getIdleInvestor(), [])
-  const [idleOpportunity, setIdleOpportunity] = useState<IdleOpportunity>()
   const translate = useTranslate()
   const { query } = useBrowserRouter<DefiQueryParams, DefiParams>()
   const { chainId, contractAddress, assetReference } = query
@@ -125,13 +123,6 @@ export const IdleOverview: React.FC<IdleOverviewProps> = ({
     selectEarnUserStakingOpportunity(state, opportunityDataFilter),
   )
 
-  useEffect(() => {
-    if (!opportunityData?.assetId) return
-    ;(async () => {
-      setIdleOpportunity(await idleInvestor.findByOpportunityId(opportunityData?.assetId))
-    })()
-  }, [idleInvestor, opportunityData?.assetId, setIdleOpportunity])
-
   const underlyingAssetId = useMemo(
     () => opportunityData?.underlyingAssetIds?.[0],
     [opportunityData?.underlyingAssetIds],
@@ -140,18 +131,16 @@ export const IdleOverview: React.FC<IdleOverviewProps> = ({
     () => assets[underlyingAssetId ?? ''],
     [assets, underlyingAssetId],
   )
-  const underlyingAssets = useMemo(() => {
-    if (!idleOpportunity) return []
-
-    const pricePerShare = idleOpportunity.positionAsset.underlyingPerPosition
-    return [
+  const underlyingAssets = useMemo(
+    () => [
       {
         ...underlyingAsset,
-        cryptoBalance: cryptoAmountAvailable.times(pricePerShare).toPrecision(),
+        cryptoBalance: cryptoAmountAvailable.toPrecision(),
         allocationPercentage: '1',
       },
-    ]
-  }, [cryptoAmountAvailable, idleOpportunity, underlyingAsset])
+    ],
+    [cryptoAmountAvailable, underlyingAsset],
+  )
 
   const selectedLocale = useAppSelector(selectSelectedLocale)
   const descriptionQuery = useGetAssetDescriptionQuery({

--- a/yarn.lock
+++ b/yarn.lock
@@ -4271,9 +4271,10 @@
   resolved "https://registry.yarnpkg.com/@shapeshiftoss/logger/-/logger-1.1.3.tgz#ff05765775351c8adc99cf747f14b5619311e023"
   integrity sha512-II9vFeaB5RCnGiEUVGpZC599vJeO3JK186v1SPUIMM7Q+U/FjroN5MybHgnJ+buBx3f8HpXorv6ksgVT2f5Xwg==
 
-"@shapeshiftoss/market-service@^7.2.1", "@shapeshiftoss/market-service@https://gitpkg.now.sh/shapeshift/lib/packages/market-service?fix_idle_market_data":
-  version "7.2.1"
-  resolved "https://gitpkg.now.sh/shapeshift/lib/packages/market-service?fix_idle_market_data#50b32faf1e93dc1773b9a5b1aea2386b2da9526a"
+"@shapeshiftoss/market-service@^7.2.2":
+  version "7.2.2"
+  resolved "https://registry.yarnpkg.com/@shapeshiftoss/market-service/-/market-service-7.2.2.tgz#ef4967df20bc8b7fe206a7a07b67fbdbe6a1a906"
+  integrity sha512-PCSbfusybEbyRZthsZSJUDsvfRZAxT8UIero7r6Az5IHXq0bFD4OAwawn6zw5795bzgFw7mZwFGYI4cV7xRliw==
   dependencies:
     "@ethersproject/providers" "^5.5.3"
     "@yfi/sdk" "^1.2.0"

--- a/yarn.lock
+++ b/yarn.lock
@@ -4271,10 +4271,9 @@
   resolved "https://registry.yarnpkg.com/@shapeshiftoss/logger/-/logger-1.1.3.tgz#ff05765775351c8adc99cf747f14b5619311e023"
   integrity sha512-II9vFeaB5RCnGiEUVGpZC599vJeO3JK186v1SPUIMM7Q+U/FjroN5MybHgnJ+buBx3f8HpXorv6ksgVT2f5Xwg==
 
-"@shapeshiftoss/market-service@^7.2.1":
+"@shapeshiftoss/market-service@^7.2.1", "@shapeshiftoss/market-service@https://gitpkg.now.sh/shapeshift/lib/packages/market-service?fix_idle_market_data":
   version "7.2.1"
-  resolved "https://registry.yarnpkg.com/@shapeshiftoss/market-service/-/market-service-7.2.1.tgz#90f88a799a2004ae4c075ce00e2e7996df1c6685"
-  integrity sha512-898WG1KhU287/g9MFsb9Y7Z95w5rdIonWseAzxbx/dGHYTAvgK7Ta0DO3u+LW7I8lMsno64wny08n0/nP8wMlA==
+  resolved "https://gitpkg.now.sh/shapeshift/lib/packages/market-service?fix_idle_market_data#50b32faf1e93dc1773b9a5b1aea2386b2da9526a"
   dependencies:
     "@ethersproject/providers" "^5.5.3"
     "@yfi/sdk" "^1.2.0"


### PR DESCRIPTION
## Description

This PR:

- consumes https://github.com/shapeshift/lib/pull/1100 giving us reliable market data
- consistently uses Idle token amounts instead of underlying amounts in overview and withdraw
- as a result of both of the above, makes sure we have the same market data / Idle token amounts everywhere across the app

## Notice

<!-- Before submitting a pull request, please make sure you have answered the following: -->

- [x] Have you followed the guidelines in our [Contributing]('https://github.com/shapeshift/web/blob/develop/CONTRIBUTING.md) guide?
- [x] Have you checked to ensure there aren't other open [Pull Requests](https://github.com/shapeshift/web/pulls) for the same update/change?

## Pull Request Type

- [x] :bug: Bug fix (Non-breaking Change: Fixes an issue)
- [ ] :hammer_and_wrench: Chore (Non-breaking Change: Doc updates, pkg upgrades, typos, etc..)
- [ ] :nail_care: New Feature (Breaking/Non-breaking Change)

## Issue (if applicable)

<!-----------------------------------------------------------------------------
If applicable, please link to the github issue and put `closes #XXXX` in your comment to auto-close the issue that your PR fixes.
------------------------------------------------------------------------------>

relates to https://github.com/shapeshift/web/issues/3392

## Risk

<!-----------------------------------------------------------------------------
Outline the scope of your changes and the risk associated with them. You must use your discretion as an engineer to determine the potential impact of your changes.

E.g. an upgrade to `hdwallet` or core state management would be considered higher risk, and might require a full regression test. UI or isolated view changes, or something behind a feature flag may have near zero risk. Small bug fixes might require testing isolated to the specific fix.
------------------------------------------------------------------------------>

If Idle XHR fails, we are in a borked state where we display 0$ positions - not much we can do except for lib Idle XHRs caching in investor-idle (`market-service` already caches requests)

## Testing

<!-----------------------------------------------------------------------------
We treat every PR to be merged with the same scrutiny as if we were merging directly to production.

Your PR will not be merged if you do not complete the sections below for our engineering and operations teams to test.
------------------------------------------------------------------------------>

- No need for a lib link, just run `yarn` which will install the gitpkg package
- Market data and asset amounts for Idle positions is the same in DeFi cards, rows, overview (top-right value), withdraw available amount
- The Idle token is used as a source of truth in overview and withdraw instead of the underlying asset - note that Idle asset-service currently uses the asset name as a symbol which can get confusing, in many cases the Idle asset name *IS* the name of the underlying symbol 🐒 
- It is possible to withdraw max from Idle opportunities
- Market data is present for all Idle opportunities and matches the Etherscan one (note that something something discrepancies between Etherscan and us, might be off by one dp)

### Engineering

<!-----------------------------------------------------------------------------
Include sufficient information here for an engineer to test your PR. This may include how to test locally, in a built environment, changes to infrastructure etc.
------------------------------------------------------------------------------>

- Grep for `underlyingPerPosition` and `pricePerShare` and confirm my grep fu didn't fail me, should be removed in all Idle components (not hooks)

### Operations

<!-----------------------------------------------------------------------------
If your changes have a user-facing impact, describe how a non-technical QA team can functionally test your changes in a preview environment.

If they are not user-facing please describe how to test for any regressions that may occur.
------------------------------------------------------------------------------>

☝🏽 

## Screenshots (if applicable)

<img width="371" alt="image" src="https://user-images.githubusercontent.com/17035424/204057595-c3c54be5-ad44-4811-a909-ffbf31762597.png">
<img width="1024" alt="image" src="https://user-images.githubusercontent.com/17035424/204057622-3a330b23-86ef-47c3-acc6-432998663196.png">
<img width="1039" alt="image" src="https://user-images.githubusercontent.com/17035424/204057734-51976e15-01fc-4802-9558-532e5f480e8c.png">
<img width="534" alt="image" src="https://user-images.githubusercontent.com/17035424/204057757-107dc85d-a181-4789-b9dc-08547cd468a8.png">
<img width="554" alt="image" src="https://user-images.githubusercontent.com/17035424/204057824-fd3a46a8-fc5c-47ea-b2c4-c74249c9717c.png">
<img width="654" alt="image" src="https://user-images.githubusercontent.com/17035424/204057960-1842e12d-e31a-4a60-b730-358dbccb1b6b.png">