### PR TITLE
feat: add dynamic slippage to trades

### DIFF
--- a/package.json
+++ b/package.json
@@ -106,7 +106,7 @@
     "@shapeshiftoss/investor-yearn": "^6.1.7",
     "@shapeshiftoss/logger": "^1.1.3",
     "@shapeshiftoss/market-service": "^7.2.2",
-    "@shapeshiftoss/swapper": "^14.4.0",
+    "@shapeshiftoss/swapper": "^14.5.0",
     "@shapeshiftoss/types": "^8.3.2",
     "@shapeshiftoss/unchained-client": "^10.4.0",
     "@types/eth-url-parser": "^1.0.0",

--- a/src/components/Trade/Trade.tsx
+++ b/src/components/Trade/Trade.tsx
@@ -1,4 +1,5 @@
 import type { AssetId } from '@shapeshiftoss/caip'
+import { DEFAULT_SLIPPAGE } from 'constants/constants'
 import { useEffect, useState } from 'react'
 import { FormProvider, useForm } from 'react-hook-form'
 import { MemoryRouter, useLocation } from 'react-router-dom'
@@ -26,7 +27,7 @@ export const Trade = ({ defaultBuyAssetId }: TradeProps) => {
       sellTradeAsset: { amount: '0' },
       buyTradeAsset: { amount: '0' },
       isExactAllowance: false,
-      slippage: 0.002,
+      slippage: DEFAULT_SLIPPAGE,
       action: TradeAmountInputField.SELL_CRYPTO,
       isSendMax: false,
     },

--- a/src/components/Trade/TradeConfirm/ReceiveSummary.tsx
+++ b/src/components/Trade/TradeConfirm/ReceiveSummary.tsx
@@ -13,7 +13,7 @@ import { Amount } from 'components/Amount/Amount'
 import { HelperTooltip } from 'components/HelperTooltip/HelperTooltip'
 import { type RowProps, Row } from 'components/Row/Row'
 import { RawText, Text } from 'components/Text'
-import { bnOrZero } from 'lib/bignumber/bignumber'
+import { bn, bnOrZero } from 'lib/bignumber/bignumber'
 
 type ReceiveSummaryProps = {
   isLoading?: boolean
@@ -49,9 +49,7 @@ export const ReceiveSummary: FC<ReceiveSummaryProps> = ({
   const textColor = useColorModeValue('gray.800', 'whiteAlpha.900')
 
   const slippageAsPercentageString = bnOrZero(slippage).times(100).toString()
-  const amountAfterSlippage = bnOrZero(amount)
-    .times(1 - Number(slippage))
-    .toString()
+  const amountAfterSlippage = bnOrZero(amount).times(bn(1).minus(slippage)).toString()
   const isAmountPositive = bnOrZero(amountAfterSlippage).gt(0)
 
   return (

--- a/src/components/Trade/TradeConfirm/ReceiveSummary.tsx
+++ b/src/components/Trade/TradeConfirm/ReceiveSummary.tsx
@@ -23,7 +23,7 @@ type ReceiveSummaryProps = {
   beforeFees?: string
   protocolFee?: string
   shapeShiftFee?: string
-  slippage: number
+  slippage: string
   swapperName: string
 } & RowProps
 
@@ -50,7 +50,7 @@ export const ReceiveSummary: FC<ReceiveSummaryProps> = ({
 
   const slippageAsPercentageString = bnOrZero(slippage).times(100).toString()
   const amountAfterSlippage = bnOrZero(amount)
-    .times(1 - slippage)
+    .times(1 - Number(slippage))
     .toString()
   const isAmountPositive = bnOrZero(amountAfterSlippage).gt(0)
 

--- a/src/components/Trade/hooks/useSwapper/useSwapper.tsx
+++ b/src/components/Trade/hooks/useSwapper/useSwapper.tsx
@@ -46,6 +46,7 @@ export const useSwapper = () => {
   const buyAssetAccountId = useWatch({ control, name: 'buyAssetAccountId' })
   const isSendMax = useWatch({ control, name: 'isSendMax' })
   const isExactAllowance = useWatch({ control, name: 'isExactAllowance' })
+  const slippage = useWatch({ control, name: 'slippage' })
 
   // Constants
   const sellAsset = sellTradeAsset?.asset
@@ -176,6 +177,7 @@ export const useSwapper = () => {
       wallet,
       sendMax: isSendMax,
       receiveAddress,
+      slippage,
     }
     const sellAssetChainId = sellAsset.chainId
     if (isSupportedNonUtxoSwappingChain(sellAssetChainId)) {
@@ -213,6 +215,7 @@ export const useSwapper = () => {
     sellAssetAccountId,
     sellTradeAsset?.amount,
     sellTradeAsset?.asset,
+    slippage,
     wallet,
   ])
 

--- a/src/components/Trade/hooks/useTradeQuoteService.tsx
+++ b/src/components/Trade/hooks/useTradeQuoteService.tsx
@@ -5,6 +5,7 @@ import type { UtxoBaseAdapter } from '@shapeshiftoss/chain-adapters'
 import type { HDWallet } from '@shapeshiftoss/hdwallet-core'
 import { type GetTradeQuoteInput, type UtxoSupportedChainIds } from '@shapeshiftoss/swapper'
 import type { BIP44Params, UtxoAccountType } from '@shapeshiftoss/types'
+import { DEFAULT_SLIPPAGE } from 'constants/constants'
 import { useEffect, useState } from 'react'
 import { useFormContext, useWatch } from 'react-hook-form'
 import { useSwapper } from 'components/Trade/hooks/useSwapper/useSwapper'
@@ -178,6 +179,16 @@ export const useTradeQuoteService = () => {
 
   // Update trade quote
   useEffect(() => setValue('quote', tradeQuote), [tradeQuote, setValue])
+
+  // Set slippage if the quote contains a recommended value, else use the default
+  useEffect(
+    () =>
+      setValue(
+        'slippage',
+        tradeQuote?.recommendedSlippage ? tradeQuote.recommendedSlippage : DEFAULT_SLIPPAGE,
+      ),
+    [tradeQuote, setValue],
+  )
 
   // Set trade quote if not yet set (e.g. on page load)
   useEffect(() => {

--- a/src/components/Trade/types.ts
+++ b/src/components/Trade/types.ts
@@ -51,7 +51,7 @@ export type TradeState<C extends ChainId> = {
   quoteError: string | null
   amount: string
   receiveAddress: string | null // TODO: Implement
-  slippage: number
+  slippage: string
   isSendMax: boolean
 }
 
@@ -86,7 +86,13 @@ export type TradeQuoteInputCommonArgs = Pick<
 
 export type BuildTradeInputCommonArgs = Pick<
   BuildTradeInput,
-  'sellAmountCryptoPrecision' | 'sellAsset' | 'buyAsset' | 'sendMax' | 'receiveAddress' | 'wallet'
+  | 'sellAmountCryptoPrecision'
+  | 'sellAsset'
+  | 'buyAsset'
+  | 'sendMax'
+  | 'receiveAddress'
+  | 'wallet'
+  | 'slippage'
 >
 
 export type GetFormFeesArgs = {

--- a/src/constants/UsdcPrecision.ts
+++ b/src/constants/UsdcPrecision.ts
@@ -1,1 +1,0 @@
-export const USDC_PRECISION = 6

--- a/src/constants/constants.ts
+++ b/src/constants/constants.ts
@@ -1,0 +1,2 @@
+export const USDC_PRECISION = 6
+export const DEFAULT_SLIPPAGE = '0.03' // 3%

--- a/src/features/defi/helpers/normalizeOpportunity.tsx
+++ b/src/features/defi/helpers/normalizeOpportunity.tsx
@@ -1,6 +1,6 @@
 import type { AssetId, ChainId } from '@shapeshiftoss/caip'
 import { fromAssetId } from '@shapeshiftoss/caip'
-import { USDC_PRECISION } from 'constants/UsdcPrecision'
+import { USDC_PRECISION } from 'constants/constants'
 import { useTranslate } from 'react-polyglot'
 import { useSelector } from 'react-redux'
 import { bnOrZero } from 'lib/bignumber/bignumber'

--- a/src/features/defi/providers/yearn/components/YearnManager/Overview/YearnOverview.tsx
+++ b/src/features/defi/providers/yearn/components/YearnManager/Overview/YearnOverview.tsx
@@ -3,7 +3,7 @@ import { Center, useToast } from '@chakra-ui/react'
 import type { AccountId } from '@shapeshiftoss/caip'
 import { toAssetId } from '@shapeshiftoss/caip'
 import type { YearnOpportunity } from '@shapeshiftoss/investor-yearn'
-import { USDC_PRECISION } from 'constants/UsdcPrecision'
+import { USDC_PRECISION } from 'constants/constants'
 import { Overview } from 'features/defi/components/Overview/Overview'
 import type {
   DefiParams,

--- a/src/hooks/useSortedVaults/useSortedVaults.ts
+++ b/src/hooks/useSortedVaults/useSortedVaults.ts
@@ -1,4 +1,4 @@
-import { USDC_PRECISION } from 'constants/UsdcPrecision'
+import { USDC_PRECISION } from 'constants/constants'
 import { useMemo } from 'react'
 import { useVaultWithoutBalance } from 'hooks/useVaultWithoutBalance/useVaultWithoutBalance'
 import { bnOrZero } from 'lib/bignumber/bignumber'

--- a/yarn.lock
+++ b/yarn.lock
@@ -4297,10 +4297,10 @@
     google-protobuf "^3.17.0"
     long "^4.0.0"
 
-"@shapeshiftoss/swapper@^14.4.0":
-  version "14.4.0"
-  resolved "https://registry.yarnpkg.com/@shapeshiftoss/swapper/-/swapper-14.4.0.tgz#6d11423a98f56e4265fd63cc789ade5cd1bdcb29"
-  integrity sha512-XqarDHpITCgGXzZ1cU9A4c7iVY4tm5DNxcSAIKV/QkvrIImhwSGEJ/k93hYlUi0zbhxAZ4SzyNXk3jOtWR9sdw==
+"@shapeshiftoss/swapper@^14.5.0":
+  version "14.5.0"
+  resolved "https://registry.yarnpkg.com/@shapeshiftoss/swapper/-/swapper-14.5.0.tgz#7f1e60265be65777b89ea08afc3fc6831a7f9d84"
+  integrity sha512-UnD3XyPwbhZuQ+4Ne52rZnXBIlU/W/XckHjM2UENlGkKoEP+j8aIa88XjIpXkJCYNFR1jl/JVKIBUFrhkdI18Q==
   dependencies:
     axios "^0.26.1"
     bignumber.js "^9.0.2"


### PR DESCRIPTION
## Description

Uses the `recommendedSlippage` value provided by the trade quote when it's available, else uses the default value.

Requires https://github.com/shapeshift/lib/pull/1102 to be published.

## Notice

- [x] Have you followed the guidelines in our [Contributing]('https://github.com/shapeshift/web/blob/develop/CONTRIBUTING.md) guide?
- [x] Have you checked to ensure there aren't other open [Pull Requests](https://github.com/shapeshift/web/pulls) for the same update/change?

## Pull Request Type

- [ ] :bug: Bug fix (Non-breaking Change: Fixes an issue)
- [ ] :hammer_and_wrench: Chore (Non-breaking Change: Doc updates, pkg upgrades, typos, etc..)
- [x] :nail_care: New Feature (Breaking/Non-breaking Change)

## Issue (if applicable)

Closes https://github.com/shapeshift/lib/issues/1094

## Risk

Small/medium - worst case the `recommendedSlippage` doesn't work and our `limit` is slightly smaller than it should be, causing trades to fail.

## Testing

Trades on swappers that utilise slippage values (currently 0x and THORSwap) should still go through correctly.

### Engineering

The bulk of the engineering review should have already taken place on https://github.com/shapeshift/lib/pull/1102.

### Operations

☝️ 

## Screenshots (if applicable)

N/A