### PR TITLE
feat: install-lib-pr-packages script

### DIFF
--- a/package.json
+++ b/package.json
@@ -5,6 +5,7 @@
   "scripts": {
     "show-linked-packages": "find node_modules node_modules/@* -maxdepth 1 -type l -print",
     "link-packages": "./scripts/link-packages.sh",
+    "install-lib-pr-packages": "ts-node --skipProject ./scripts/install-lib-pr-packages.ts",
     "unlink-packages": "find node_modules node_modules/@* -maxdepth 1 -type l -print | awk -F/ '{ printf \"%s/%s\\n\",$2,$3; }' | xargs yarn unlink && yarn install --force",
     "build": "NODE_OPTIONS=--max-old-space-size=4096 IMAGE_INLINE_SIZE_LIMIT=0 INLINE_RUNTIME_CHUNK=false DISABLE_ESLINT_PLUGIN=true react-app-rewired build && node ./scripts/writeHeaders.js && ./scripts/sha256sums.sh && ./scripts/verifyWebpackHashes.sh && ts-node --skipProject ./scripts/writeBuildMetadata.ts",
     "dev": "NODE_OPTIONS=--max-old-space-size=4096 ESLINT_NO_DEV_ERRORS=true TSC_COMPILE_ON_ERROR=true IMAGE_INLINE_SIZE_LIMIT=0 INLINE_RUNTIME_CHUNK=false CYPRESS_RELAXED_SECURITY=true react-app-rewired start",

--- a/scripts/install-lib-pr-packages.ts
+++ b/scripts/install-lib-pr-packages.ts
@@ -1,0 +1,33 @@
+import chalk from 'chalk' // do not upgrade to v5, not compatible with ts-node
+import { exec } from 'child_process'
+import pify from 'pify'
+
+const main = async () => {
+  const args = process.argv.slice(2)
+  if (!args.length) {
+    console.log(chalk.red('No lib PR number passed as argument. Usage: yarn install-lib-pr-packages <pr_number>'))
+    process.exit(0)
+  }
+  const [libPr] = args
+  const diffedFilesCommand = `gh pr diff ${libPr} --name-only -R https://github.com/shapeshift/lib`
+  const diffedFiles: string = await pify(exec)(diffedFilesCommand)
+
+  const prInfoCommand = `gh pr view ${libPr} -R https://github.com/shapeshift/lib --json headRefName`
+  const prInfo = await pify(exec)(prInfoCommand)
+  const { headRefName: branchName } = JSON.parse(prInfo.replace(/\n/g, ""))
+
+  const diffedPackages = diffedFiles.split(`\n`).reduce<string[]>((acc, currentFile) => {
+    const diffedPackage = currentFile.match(/packages\/(?<package>[a-zA-Z-]*)\//)?.groups?.package
+    if (diffedPackage?.length && acc.indexOf(diffedPackage) < 0) { acc.push(diffedPackage) }
+
+    return acc
+  }, [])
+
+  for (const diffedPackage of diffedPackages) {
+    const command = `yarn add 'https://gitpkg.now.sh/shapeshift/lib/packages/${diffedPackage}?${branchName}'`
+    await pify(exec)(command)
+    console.log(chalk.green(`Successfully installed @shapeshiftoss/${diffedPackage} from https://github.com/shapeshift/lib/pull/${libPr}`))
+  }
+}
+
+main()


### PR DESCRIPTION
## Description

Little script making the gitpkg install process programmatic.

[`gitpkg`](https://gitpkg.vercel.app/) ([source](https://github.com/EqualMa/gitpkg)) is a hosted service that allows installing GitHub subfolders as npm packages, compatible with monorepos, and allows to select commits-ish(e.g branches).

Which gives us all we need to install lib packages locally from lib PRs, using `gh` to programmatically fetch all we need from the PR (HEAD ref name and files diff), to construct a gitpkg URL to be installed.

Notes:
- there's no magic here and gitpkg will really just install packages as diffs. Any lerna specifics like linking monorepo packages internally won't work, so this script will only work in the case of single/independent lib package diffs where one 
package diff doesn't rely on another package diff from the same PR.
- gitpkg seems to work well with some packages and not others - `market-service` compiles and is usable in web, but not e.g `swapper`

## Notice

<!-- Before submitting a pull request, please make sure you have answered the following: -->

- [x] Have you followed the guidelines in our [Contributing]('https://github.com/shapeshift/web/blob/develop/CONTRIBUTING.md) guide?
- [x] Have you checked to ensure there aren't other open [Pull Requests](https://github.com/shapeshift/web/pulls) for the same update/change?

## Pull Request Type

- [ ] :bug: Bug fix (Non-breaking Change: Fixes an issue)
- [ ] :hammer_and_wrench: Chore (Non-breaking Change: Doc updates, pkg upgrades, typos, etc..)
- [x] :nail_care: New Feature (Breaking/Non-breaking Change)

## Issue (if applicable)

N/A

## Risk

<!-----------------------------------------------------------------------------
Outline the scope of your changes and the risk associated with them. You must use your discretion as an engineer to determine the potential impact of your changes.

E.g. an upgrade to `hdwallet` or core state management would be considered higher risk, and might require a full regression test. UI or isolated view changes, or something behind a feature flag may have near zero risk. Small bug fixes might require testing isolated to the specific fix.
------------------------------------------------------------------------------>

## Testing

<!-----------------------------------------------------------------------------
We treat every PR to be merged with the same scrutiny as if we were merging directly to production.

Your PR will not be merged if you do not complete the sections below for our engineering and operations teams to test.
------------------------------------------------------------------------------>

### Engineering

<!-----------------------------------------------------------------------------
Include sufficient information here for an engineer to test your PR. This may include how to test locally, in a built environment, changes to infrastructure etc.
------------------------------------------------------------------------------>

- run `yarn install-lib-pr-packages` without an argv and notice we error out
- run `yarn install-lib-pr-packages 1102` (or any other lib PR) and notice the lib PR packages are installed

### Operations

<!-----------------------------------------------------------------------------
If your changes have a user-facing impact, describe how a non-technical QA team can functionally test your changes in a preview environment.

If they are not user-facing please describe how to test for any regressions that may occur.
------------------------------------------------------------------------------>

None

## Screenshots (if applicable)

<img width="912" alt="image" src="https://user-images.githubusercontent.com/17035424/204537977-e216ef29-78fc-4c0a-ab7e-600f4fd58666.png">