### PR TITLE
feat: remove deprecated precision amounts

### DIFF
--- a/src/components/Trade/TradeInput.tsx
+++ b/src/components/Trade/TradeInput.tsx
@@ -32,7 +32,7 @@ import { selectFeeAssetById } from 'state/slices/assetsSlice/selectors'
 import {
   selectPortfolioCryptoBalanceByFilter,
   selectPortfolioCryptoHumanBalanceByFilter,
-} from 'state/slices/portfolioSlice/selectors'
+} from 'state/slices/selectors'
 import { useAppSelector } from 'state/store'
 
 import { RateGasRow } from './Components/RateGasRow'

--- a/src/components/Trade/hooks/useDefaultAssets.tsx
+++ b/src/components/Trade/hooks/useDefaultAssets.tsx
@@ -23,9 +23,8 @@ import { swapperApi } from 'state/apis/swapper/swapperApi'
 import { selectAssets } from 'state/slices/assetsSlice/selectors'
 import { selectPortfolioAccountMetadata } from 'state/slices/portfolioSlice/selectors'
 import { selectFeatureFlags } from 'state/slices/preferencesSlice/selectors'
+import { selectWalletAccountIds } from 'state/slices/selectors'
 import { useAppDispatch, useAppSelector } from 'state/store'
-
-import { selectWalletAccountIds } from '../../../state/slices/portfolioSlice/selectors'
 
 /*
 The Default Asset Hook is responsible for populating the trade widget with initial assets.

--- a/src/features/defi/components/Overview/Overview.tsx
+++ b/src/features/defi/components/Overview/Overview.tsx
@@ -27,7 +27,7 @@ import { UnderlyingAssetsMenu } from './UnderlyingAssetsMenu'
 import { UnderlyingAssetsTags } from './UnderlyingAssetsTags'
 
 export type AssetWithBalance = {
-  cryptoBalance: string
+  cryptoBalancePrecision: string
   allocationPercentage?: string
   icons?: string[]
 } & Asset
@@ -38,8 +38,8 @@ type OverviewProps = {
   // The LP asset this opportunity represents
   lpAsset?: AssetWithBalance
   // The assets underlying the LP one
-  underlyingAssets: AssetWithBalance[]
-  rewardAssets?: AssetWithBalance[]
+  underlyingAssetsCryptoPrecision: AssetWithBalance[]
+  rewardAssetsCryptoPrecision?: AssetWithBalance[]
   name: string
   description?: AssetDescriptionTeaserProps
   asset: Asset
@@ -56,8 +56,8 @@ export const Overview: React.FC<OverviewProps> = ({
   accountId,
   onAccountIdChange,
   lpAsset,
-  underlyingAssets,
-  rewardAssets,
+  underlyingAssetsCryptoPrecision,
+  rewardAssetsCryptoPrecision,
   asset,
   name,
   opportunityFiatBalance,
@@ -71,14 +71,14 @@ export const Overview: React.FC<OverviewProps> = ({
   expired,
 }) => {
   const renderRewardAssets = useMemo(() => {
-    if (!rewardAssets) return null
-    return rewardAssets.map((asset, index) => (
+    if (!rewardAssetsCryptoPrecision) return null
+    return rewardAssetsCryptoPrecision.map((asset, index) => (
       <Tag variant='xs-subtle' columnGap={2} key={`${asset.assetId}_${index}`}>
         <AssetIcon src={asset.icon} size='2xs' />
-        <Amount.Crypto fontSize='sm' value={asset.cryptoBalance} symbol={asset.symbol} />
+        <Amount.Crypto fontSize='sm' value={asset.cryptoBalancePrecision} symbol={asset.symbol} />
       </Tag>
     ))
-  }, [rewardAssets])
+  }, [rewardAssetsCryptoPrecision])
 
   return (
     <Flex
@@ -128,13 +128,19 @@ export const Overview: React.FC<OverviewProps> = ({
               <Text fontWeight='medium' translation='defi.modals.overview.underlyingTokens' />
               <Flex flexDir='row' columnGap={2} rowGap={2} flexWrap='wrap'>
                 {lpAsset ? (
-                  <UnderlyingAssetsMenu lpAsset={lpAsset} underlyingAssets={underlyingAssets} />
+                  <UnderlyingAssetsMenu
+                    lpAsset={lpAsset}
+                    underlyingAssets={underlyingAssetsCryptoPrecision}
+                  />
                 ) : (
-                  <UnderlyingAssetsTags underlyingAssets={underlyingAssets} showPercentage />
+                  <UnderlyingAssetsTags
+                    underlyingAssets={underlyingAssetsCryptoPrecision}
+                    showPercentage
+                  />
                 )}
               </Flex>
             </Stack>
-            {rewardAssets && (
+            {rewardAssetsCryptoPrecision && (
               <Stack flex={1} spacing={4}>
                 <Text fontWeight='medium' translation='defi.modals.overview.availableRewards' />
                 <Flex flexDir='row' columnGap={2} rowGap={2} flexWrap='wrap'>

--- a/src/features/defi/components/Overview/UnderlyingAssetsMenu.tsx
+++ b/src/features/defi/components/Overview/UnderlyingAssetsMenu.tsx
@@ -30,7 +30,11 @@ export const UnderlyingAssetsMenu = ({ lpAsset, underlyingAssets }: UnderlyingAs
               ) : (
                 <AssetIcon src={asset.icon} size='2xs' />
               )}
-              <Amount.Crypto fontSize='sm' value={asset.cryptoBalance} symbol={asset.symbol} />
+              <Amount.Crypto
+                fontSize='sm'
+                value={asset.cryptoBalancePrecision}
+                symbol={asset.symbol}
+              />
               {asset.allocationPercentage && (
                 <Amount.Percent
                   color='gray.500'

--- a/src/features/defi/components/Overview/UnderlyingAssetsTags.tsx
+++ b/src/features/defi/components/Overview/UnderlyingAssetsTags.tsx
@@ -29,7 +29,7 @@ export const UnderlyingAssetTag = ({
     ) : (
       <AssetIcon src={asset.icon} size='2xs' />
     )}
-    <Amount.Crypto fontSize='sm' value={asset.cryptoBalance} symbol={asset.symbol} />
+    <Amount.Crypto fontSize='sm' value={asset.cryptoBalancePrecision} symbol={asset.symbol} />
     {showPercentage && asset.allocationPercentage && (
       <Amount.Percent color='gray.500' value={asset.allocationPercentage} />
     )}

--- a/src/features/defi/providers/cosmos/components/CosmosManager/Overview/CosmosOverview.tsx
+++ b/src/features/defi/providers/cosmos/components/CosmosManager/Overview/CosmosOverview.tsx
@@ -156,10 +156,10 @@ export const CosmosOverview: React.FC<CosmosOverviewProps> = ({
       asset={stakingAsset}
       name={opportunity.moniker}
       opportunityFiatBalance={fiatAmountAvailable.toFixed(2)}
-      underlyingAssets={[
+      underlyingAssetsCryptoPrecision={[
         {
           ...stakingAsset,
-          cryptoBalance: cryptoAmountAvailable.toFixed(stakingAsset.precision),
+          cryptoBalancePrecision: cryptoAmountAvailable.toFixed(stakingAsset.precision),
           allocationPercentage: '1',
         },
       ]}

--- a/src/features/defi/providers/fox-eth-lp/components/FoxEthLpManager/Overview/FoxEthLpOverview.tsx
+++ b/src/features/defi/providers/fox-eth-lp/components/FoxEthLpManager/Overview/FoxEthLpOverview.tsx
@@ -119,7 +119,7 @@ export const FoxEthLpOverview: React.FC<FoxEthLpOverviewProps> = ({
       icons={foxEthLpOpportunity.icons}
       name={foxEthLpOpportunity.opportunityName}
       opportunityFiatBalance={underlyingAssetsFiatBalance}
-      underlyingAssets={underlyingAssetsWithBalancesAndIcons}
+      underlyingAssetsCryptoPrecision={underlyingAssetsWithBalancesAndIcons}
       provider={foxEthLpOpportunity.provider}
       description={{
         description: lpAsset?.description,

--- a/src/features/defi/providers/fox-eth-lp/components/FoxEthLpManager/Withdraw/components/Withdraw.tsx
+++ b/src/features/defi/providers/fox-eth-lp/components/FoxEthLpManager/Withdraw/components/Withdraw.tsx
@@ -248,11 +248,16 @@ export const Withdraw: React.FC<WithdrawProps> = ({
             showFiatAmount={true}
             assetIcon={foxAsset.icon}
             assetSymbol={foxAsset.symbol}
-            balance={foxEthLpOpportunity?.underlyingToken1AmountCryptoBaseUnit ?? undefined}
+            balance={
+              fromBaseUnit(
+                foxEthLpOpportunity?.underlyingToken1AmountCryptoBaseUnit,
+                foxAsset.precision,
+              ) ?? undefined
+            }
             fiatBalance={bnOrZero(
               fromBaseUnit(
                 foxEthLpOpportunity?.underlyingToken1AmountCryptoBaseUnit ?? '0',
-                asset.precision,
+                foxAsset.precision,
               ),
             )
               .times(foxMarketData.price)
@@ -267,7 +272,12 @@ export const Withdraw: React.FC<WithdrawProps> = ({
             showFiatAmount={true}
             assetIcon={ethAsset.icon}
             assetSymbol={ethAsset.symbol}
-            balance={foxEthLpOpportunity?.underlyingToken0AmountCryptoBaseUnit ?? undefined}
+            balance={
+              fromBaseUnit(
+                foxEthLpOpportunity?.underlyingToken0AmountCryptoBaseUnit ?? '0',
+                ethAsset.precision,
+              ) ?? undefined
+            }
             fiatBalance={bnOrZero(
               fromBaseUnit(
                 foxEthLpOpportunity?.underlyingToken0AmountCryptoBaseUnit ?? '0',

--- a/src/features/defi/providers/fox-eth-lp/components/FoxEthLpManager/Withdraw/components/Withdraw.tsx
+++ b/src/features/defi/providers/fox-eth-lp/components/FoxEthLpManager/Withdraw/components/Withdraw.tsx
@@ -175,24 +175,10 @@ export const Withdraw: React.FC<WithdrawProps> = ({
       foxEthLpOpportunity?.underlyingToken0AmountCryptoBaseUnit
     ) {
       setFoxAmountCryptoBaseUnit(
-        bnOrZero(percent)
-          .times(foxEthLpOpportunity.underlyingToken1AmountCryptoBaseUnit)
-          .div(
-            bn(10).pow(
-              assets[foxEthLpOpportunity?.underlyingAssetIds?.[1] ?? '']?.precision ?? '0',
-            ),
-          )
-          .toFixed(8),
+        bnOrZero(percent).times(foxEthLpOpportunity.underlyingToken1AmountCryptoBaseUnit).toFixed(),
       )
       setEthAmountCryptoBaseUnit(
-        bnOrZero(percent)
-          .times(foxEthLpOpportunity.underlyingToken0AmountCryptoBaseUnit)
-          .div(
-            bn(10).pow(
-              assets[foxEthLpOpportunity?.underlyingAssetIds?.[0] ?? '']?.precision ?? '0',
-            ),
-          )
-          .toFixed(8),
+        bnOrZero(percent).times(foxEthLpOpportunity.underlyingToken0AmountCryptoBaseUnit).toFixed(),
       )
     }
   }
@@ -265,12 +251,13 @@ export const Withdraw: React.FC<WithdrawProps> = ({
             showFiatAmount={true}
             assetIcon={foxAsset.icon}
             assetSymbol={foxAsset.symbol}
-            balance={
-              fromBaseUnit(
-                foxEthLpOpportunity?.underlyingToken1AmountCryptoBaseUnit ?? '0',
-                foxAsset.precision,
-              ) ?? undefined
-            }
+            balance={bnOrZero(foxEthLpOpportunity.underlyingToken1AmountCryptoBaseUnit)
+              .div(
+                bn(10).pow(
+                  assets[foxEthLpOpportunity?.underlyingAssetIds?.[1] ?? '']?.precision ?? '0',
+                ),
+              )
+              .toFixed()}
             fiatBalance={bnOrZero(
               fromBaseUnit(
                 foxEthLpOpportunity?.underlyingToken1AmountCryptoBaseUnit ?? '0',
@@ -284,17 +271,18 @@ export const Withdraw: React.FC<WithdrawProps> = ({
           />
           <AssetInput
             {...(accountId ? { accountId } : {})}
-            cryptoAmount={ethAmountCryptoBaseUnit}
+            cryptoAmount={ethAmountCryptoPrecision}
             fiatAmount={bnOrZero(ethAmountCryptoPrecision).times(ethMarketData.price).toFixed(2)}
             showFiatAmount={true}
             assetIcon={ethAsset.icon}
             assetSymbol={ethAsset.symbol}
-            balance={
-              fromBaseUnit(
-                foxEthLpOpportunity?.underlyingToken0AmountCryptoBaseUnit ?? '0',
-                ethAsset.precision,
-              ) ?? undefined
-            }
+            balance={bnOrZero(foxEthLpOpportunity.underlyingToken0AmountCryptoBaseUnit)
+              .div(
+                bn(10).pow(
+                  assets[foxEthLpOpportunity?.underlyingAssetIds?.[0] ?? '']?.precision ?? '0',
+                ),
+              )
+              .toFixed()}
             fiatBalance={bnOrZero(
               fromBaseUnit(
                 foxEthLpOpportunity?.underlyingToken0AmountCryptoBaseUnit ?? '0',

--- a/src/features/defi/providers/fox-eth-lp/components/FoxEthLpManager/Withdraw/components/Withdraw.tsx
+++ b/src/features/defi/providers/fox-eth-lp/components/FoxEthLpManager/Withdraw/components/Withdraw.tsx
@@ -17,6 +17,7 @@ import { Text } from 'components/Text'
 import { useBrowserRouter } from 'hooks/useBrowserRouter/useBrowserRouter'
 import { bn, bnOrZero } from 'lib/bignumber/bignumber'
 import { logger } from 'lib/logger'
+import { fromBaseUnit } from 'lib/math'
 import { foxEthLpAssetId } from 'state/slices/opportunitiesSlice/constants'
 import {
   selectAssetById,
@@ -248,7 +249,12 @@ export const Withdraw: React.FC<WithdrawProps> = ({
             assetIcon={foxAsset.icon}
             assetSymbol={foxAsset.symbol}
             balance={foxEthLpOpportunity?.underlyingToken1AmountCryptoBaseUnit ?? undefined}
-            fiatBalance={bnOrZero(foxEthLpOpportunity?.underlyingToken1AmountCryptoBaseUnit)
+            fiatBalance={bnOrZero(
+              fromBaseUnit(
+                foxEthLpOpportunity?.underlyingToken1AmountCryptoBaseUnit ?? '0',
+                asset.precision,
+              ),
+            )
               .times(foxMarketData.price)
               .toFixed(2)}
             percentOptions={[]}
@@ -262,7 +268,12 @@ export const Withdraw: React.FC<WithdrawProps> = ({
             assetIcon={ethAsset.icon}
             assetSymbol={ethAsset.symbol}
             balance={foxEthLpOpportunity?.underlyingToken0AmountCryptoBaseUnit ?? undefined}
-            fiatBalance={bnOrZero(foxEthLpOpportunity?.underlyingToken0AmountCryptoBaseUnit)
+            fiatBalance={bnOrZero(
+              fromBaseUnit(
+                foxEthLpOpportunity?.underlyingToken0AmountCryptoBaseUnit ?? '0',
+                ethAsset.precision,
+              ),
+            )
               .times(ethMarketData.price)
               .toFixed(2)}
             percentOptions={[]}

--- a/src/features/defi/providers/fox-eth-lp/components/FoxEthLpManager/Withdraw/components/Withdraw.tsx
+++ b/src/features/defi/providers/fox-eth-lp/components/FoxEthLpManager/Withdraw/components/Withdraw.tsx
@@ -20,6 +20,7 @@ import { logger } from 'lib/logger'
 import { foxEthLpAssetId } from 'state/slices/opportunitiesSlice/constants'
 import {
   selectAssetById,
+  selectAssets,
   selectEarnUserLpOpportunity,
   selectMarketData,
   selectMarketDataById,
@@ -45,6 +46,8 @@ export const Withdraw: React.FC<WithdrawProps> = ({
   const marketData = useAppSelector(selectMarketData)
   const { state, dispatch } = useContext(WithdrawContext)
   const { history: browserHistory } = useBrowserRouter<DefiQueryParams, DefiParams>()
+
+  const assets = useAppSelector(selectAssets)
 
   const foxEthLpOpportunityFilter = useMemo(
     () => ({
@@ -150,17 +153,27 @@ export const Withdraw: React.FC<WithdrawProps> = ({
     setValue(Field.FiatAmount, fiatAmount, { shouldValidate: true })
     setValue(Field.CryptoAmount, cryptoAmount, { shouldValidate: true })
     if (
-      foxEthLpOpportunity?.underlyingToken1AmountCryptoPrecision &&
-      foxEthLpOpportunity?.underlyingToken0AmountCryptoPrecision
+      foxEthLpOpportunity?.underlyingToken1AmountCryptoBaseUnit &&
+      foxEthLpOpportunity?.underlyingToken0AmountCryptoBaseUnit
     ) {
       setFoxAmount(
         bnOrZero(percent)
-          .times(foxEthLpOpportunity.underlyingToken1AmountCryptoPrecision)
+          .times(foxEthLpOpportunity.underlyingToken1AmountCryptoBaseUnit)
+          .div(
+            bn(10).pow(
+              assets[foxEthLpOpportunity?.underlyingAssetIds?.[1] ?? '']?.precision ?? '0',
+            ),
+          )
           .toFixed(8),
       )
       setEthAmount(
         bnOrZero(percent)
-          .times(foxEthLpOpportunity.underlyingToken0AmountCryptoPrecision)
+          .times(foxEthLpOpportunity.underlyingToken0AmountCryptoBaseUnit)
+          .div(
+            bn(10).pow(
+              assets[foxEthLpOpportunity?.underlyingAssetIds?.[0] ?? '']?.precision ?? '0',
+            ),
+          )
           .toFixed(8),
       )
     }
@@ -171,14 +184,14 @@ export const Withdraw: React.FC<WithdrawProps> = ({
       bnOrZero(isFiat ? fiatAmountAvailable : cryptoAmountAvailable),
     )
     if (
-      foxEthLpOpportunity?.underlyingToken1AmountCryptoPrecision &&
-      foxEthLpOpportunity?.underlyingToken0AmountCryptoPrecision
+      foxEthLpOpportunity?.underlyingToken1AmountCryptoBaseUnit &&
+      foxEthLpOpportunity?.underlyingToken0AmountCryptoBaseUnit
     ) {
       setFoxAmount(
-        percentage.times(foxEthLpOpportunity.underlyingToken1AmountCryptoPrecision).toFixed(8),
+        percentage.times(foxEthLpOpportunity.underlyingToken1AmountCryptoBaseUnit).toFixed(8),
       )
       setEthAmount(
-        percentage.times(foxEthLpOpportunity.underlyingToken0AmountCryptoPrecision).toFixed(8),
+        percentage.times(foxEthLpOpportunity.underlyingToken0AmountCryptoBaseUnit).toFixed(8),
       )
     }
   }
@@ -234,8 +247,8 @@ export const Withdraw: React.FC<WithdrawProps> = ({
             showFiatAmount={true}
             assetIcon={foxAsset.icon}
             assetSymbol={foxAsset.symbol}
-            balance={foxEthLpOpportunity?.underlyingToken1AmountCryptoPrecision ?? undefined}
-            fiatBalance={bnOrZero(foxEthLpOpportunity?.underlyingToken1AmountCryptoPrecision)
+            balance={foxEthLpOpportunity?.underlyingToken1AmountCryptoBaseUnit ?? undefined}
+            fiatBalance={bnOrZero(foxEthLpOpportunity?.underlyingToken1AmountCryptoBaseUnit)
               .times(foxMarketData.price)
               .toFixed(2)}
             percentOptions={[]}
@@ -248,8 +261,8 @@ export const Withdraw: React.FC<WithdrawProps> = ({
             showFiatAmount={true}
             assetIcon={ethAsset.icon}
             assetSymbol={ethAsset.symbol}
-            balance={foxEthLpOpportunity?.underlyingToken0AmountCryptoPrecision ?? undefined}
-            fiatBalance={bnOrZero(foxEthLpOpportunity?.underlyingToken0AmountCryptoPrecision)
+            balance={foxEthLpOpportunity?.underlyingToken0AmountCryptoBaseUnit ?? undefined}
+            fiatBalance={bnOrZero(foxEthLpOpportunity?.underlyingToken0AmountCryptoBaseUnit)
               .times(ethMarketData.price)
               .toFixed(2)}
             percentOptions={[]}

--- a/src/features/defi/providers/fox-farming/components/FoxFarmingManager/Overview/FoxFarmingOverview.tsx
+++ b/src/features/defi/providers/fox-farming/components/FoxFarmingManager/Overview/FoxFarmingOverview.tsx
@@ -114,7 +114,7 @@ export const FoxFarmingOverview: React.FC<FoxFarmingOverviewProps> = ({
   const lpAssetWithBalancesAndIcons = useMemo(
     () => ({
       ...lpAsset,
-      cryptoBalance: bnOrZero(opportunityData?.stakedAmountCryptoBaseUnit)
+      cryptoBalancePrecision: bnOrZero(opportunityData?.stakedAmountCryptoBaseUnit)
         .div(bn(10).pow(stakingAsset.precision))
         .toFixed(6),
       allocationPercentage: '1',
@@ -141,7 +141,9 @@ export const FoxFarmingOverview: React.FC<FoxFarmingOverviewProps> = ({
   const cryptoAmountAvailable = bnOrZero(opportunityData?.stakedAmountCryptoBaseUnit).div(
     bn(10).pow(stakingAsset.precision),
   )
-  const rewardAmountAvailable = bnOrZero(opportunityData?.rewardsAmountsCryptoPrecision[0])
+  const rewardAmountAvailable = bnOrZero(opportunityData?.rewardsAmountsCryptoBaseUnit[0]).div(
+    bn(10).pow(rewardAsset.precision),
+  )
   const hasClaim = rewardAmountAvailable.gt(0)
 
   if (!opportunityData || !underlyingAssetsWithBalancesAndIcons || !underlyingAssetsIcons) {
@@ -182,7 +184,7 @@ export const FoxFarmingOverview: React.FC<FoxFarmingOverviewProps> = ({
       icons={underlyingAssetsIcons}
       opportunityFiatBalance={underlyingAssetsFiatBalance}
       lpAsset={lpAssetWithBalancesAndIcons}
-      underlyingAssets={underlyingAssetsWithBalancesAndIcons}
+      underlyingAssetsCryptoPrecision={underlyingAssetsWithBalancesAndIcons}
       provider='ShapeShift'
       menu={
         opportunityData.expired

--- a/src/features/defi/providers/fox-farming/components/FoxFarmingManager/Withdraw/components/ExpiredWithdraw.tsx
+++ b/src/features/defi/providers/fox-farming/components/FoxFarmingManager/Withdraw/components/ExpiredWithdraw.tsx
@@ -18,7 +18,7 @@ import { useFoxEth } from 'context/FoxEthProvider/FoxEthProvider'
 import { useBrowserRouter } from 'hooks/useBrowserRouter/useBrowserRouter'
 import { bn, bnOrZero } from 'lib/bignumber/bignumber'
 import { logger } from 'lib/logger'
-import { selectAssetById, selectMarketDataById } from 'state/slices/selectors'
+import { selectAssetById, selectAssets, selectMarketDataById } from 'state/slices/selectors'
 import { useAppSelector } from 'state/store'
 
 import { FoxFarmingWithdrawActionType } from '../WithdrawCommon'
@@ -38,6 +38,8 @@ export const ExpiredWithdraw: React.FC<StepComponentProps> = ({ onNext }) => {
 
   const methods = useForm<WithdrawValues>({ mode: 'onChange' })
 
+  const assets = useAppSelector(selectAssets)
+
   const asset = useAppSelector(state =>
     selectAssetById(state, opportunity?.underlyingAssetId ?? ''),
   )
@@ -49,6 +51,13 @@ export const ExpiredWithdraw: React.FC<StepComponentProps> = ({ onNext }) => {
   )
 
   // user info
+  const rewardAmountCryptoPrecision = useMemo(
+    () =>
+      bnOrZero(opportunity?.rewardsAmountsCryptoBaseUnit?.[0])
+        .div(bn(10).pow(assets[opportunity?.underlyingAssetId ?? '']?.precision))
+        .toFixed(),
+    [assets, opportunity?.rewardsAmountsCryptoBaseUnit, opportunity?.underlyingAssetId],
+  )
   const amountAvailableCryptoPrecision = useMemo(
     () => bnOrZero(opportunity?.cryptoAmountBaseUnit).div(bn(10).pow(asset?.precision)),
     [asset?.precision, opportunity?.cryptoAmountBaseUnit],
@@ -157,10 +166,7 @@ export const ExpiredWithdraw: React.FC<StepComponentProps> = ({ onNext }) => {
             />
             <Stack direction='row'>
               <AssetIcon assetId={foxAssetId} size='xs' />
-              <Amount.Crypto
-                value={opportunity.rewardsAmountsCryptoPrecision?.[0] ?? '0'}
-                symbol={foxAsset.symbol}
-              />
+              <Amount.Crypto value={rewardAmountCryptoPrecision} symbol={foxAsset.symbol} />
             </Stack>
           </Stack>
         }

--- a/src/features/defi/providers/foxy/components/FoxyManager/Overview/FoxyOverview.tsx
+++ b/src/features/defi/providers/foxy/components/FoxyManager/Overview/FoxyOverview.tsx
@@ -123,10 +123,10 @@ export const FoxyOverview: React.FC<FoxyOverviewProps> = ({
       asset={rewardAsset}
       name='FOX Yieldy'
       opportunityFiatBalance={fiatAmountAvailable.toFixed(2)}
-      underlyingAssets={[
+      underlyingAssetsCryptoPrecision={[
         {
           ...stakingAsset,
-          cryptoBalance: cryptoAmountAvailable.toFixed(4),
+          cryptoBalancePrecision: cryptoAmountAvailable.toFixed(4),
           allocationPercentage: '1',
         },
       ]}

--- a/src/features/defi/providers/idle/components/IdleManager/Overview/IdleOverview.tsx
+++ b/src/features/defi/providers/idle/components/IdleManager/Overview/IdleOverview.tsx
@@ -132,7 +132,7 @@ export const IdleOverview: React.FC<IdleOverviewProps> = ({
     () => [
       {
         ...underlyingAsset,
-        cryptoBalance: cryptoAmountAvailable.toPrecision(),
+        cryptoBalancePrecision: cryptoAmountAvailable.toPrecision(),
         allocationPercentage: '1',
       },
     ],
@@ -146,16 +146,18 @@ export const IdleOverview: React.FC<IdleOverviewProps> = ({
   })
 
   const rewardAssets = useMemo(() => {
-    if (!opportunityData?.rewardsAmountsCryptoPrecision?.length) return []
+    if (!opportunityData?.rewardsAmountsCryptoBaseUnit?.length) return []
 
-    return opportunityData!.rewardsAmountsCryptoPrecision
+    return opportunityData!.rewardsAmountsCryptoBaseUnit
       .map((amount, i) => {
         if (!opportunityData?.rewardAssetIds?.[i]) return undefined
         if (!assets[opportunityData.rewardAssetIds[i]]) return undefined
         if (bnOrZero(amount).isZero()) return undefined
         return {
           ...assets[opportunityData.rewardAssetIds[i]],
-          cryptoBalance: bnOrZero(amount).toFixed(6),
+          cryptoBalancePrecision: bnOrZero(amount)
+            .div(bn(10).pow(assets[opportunityData.rewardAssetIds[i]]?.precision ?? '0'))
+            .toFixed(6),
         }
       })
       .filter(isSome)
@@ -165,13 +167,13 @@ export const IdleOverview: React.FC<IdleOverviewProps> = ({
     if (!opportunityData?.rewardAssetIds?.length) return false
 
     return opportunityData.rewardAssetIds?.some((_rewardAssetId, i) =>
-      bnOrZero(opportunityData?.rewardsAmountsCryptoPrecision?.[i]).gt(0),
+      bnOrZero(opportunityData?.rewardsAmountsCryptoBaseUnit?.[i]).gt(0),
     )
-  }, [opportunityData?.rewardAssetIds, opportunityData?.rewardsAmountsCryptoPrecision])
+  }, [opportunityData?.rewardAssetIds, opportunityData?.rewardsAmountsCryptoBaseUnit])
 
   const menu: DefiButtonProps[] = useMemo(() => {
     if (!(contractAddress && idleInvestor && opportunityData)) return defaultMenu
-    if (!opportunityData?.rewardsAmountsCryptoPrecision?.length) return defaultMenu
+    if (!opportunityData?.rewardsAmountsCryptoBaseUnit?.length) return defaultMenu
 
     return [
       ...defaultMenu,
@@ -204,7 +206,7 @@ export const IdleOverview: React.FC<IdleOverviewProps> = ({
       asset={vaultAsset}
       name={opportunityData.name ?? ''}
       opportunityFiatBalance={fiatAmountAvailable.toFixed(2)}
-      underlyingAssets={underlyingAssets}
+      underlyingAssetsCryptoPrecision={underlyingAssets}
       provider='Idle Finance'
       description={{
         description: underlyingAsset.description,
@@ -214,7 +216,7 @@ export const IdleOverview: React.FC<IdleOverviewProps> = ({
       tvl={bnOrZero(opportunityData.tvl).toFixed(2)}
       apy={opportunityData.apy}
       menu={menu}
-      rewardAssets={rewardAssets}
+      rewardAssetsCryptoPrecision={rewardAssets}
     />
   )
 }

--- a/src/features/defi/providers/yearn/components/YearnManager/Overview/YearnOverview.tsx
+++ b/src/features/defi/providers/yearn/components/YearnManager/Overview/YearnOverview.tsx
@@ -59,8 +59,8 @@ export const YearnOverview: React.FC<{
   )
   const balance = useAppSelector(state => selectPortfolioCryptoBalanceByFilter(state, filter))
 
-  const cryptoAmountAvailable = bnOrZero(balance).div(`1e${asset.precision}`)
-  const fiatAmountAvailable = bnOrZero(cryptoAmountAvailable).times(marketData.price)
+  const amountAvailableCryptoPrecision = bnOrZero(balance).div(`1e${asset.precision}`)
+  const fiatAmountAvailable = bnOrZero(amountAvailableCryptoPrecision).times(marketData.price)
 
   const selectedLocale = useAppSelector(selectSelectedLocale)
   const descriptionQuery = useGetAssetDescriptionQuery({ assetId, selectedLocale })
@@ -94,11 +94,11 @@ export const YearnOverview: React.FC<{
     () => [
       {
         ...underlyingToken,
-        cryptoBalance: cryptoAmountAvailable.toPrecision(),
+        cryptoBalancePrecision: amountAvailableCryptoPrecision.toPrecision(),
         allocationPercentage: '1',
       },
     ],
-    [cryptoAmountAvailable, underlyingToken],
+    [amountAvailableCryptoPrecision, underlyingToken],
   )
 
   const description = useMemo(
@@ -141,7 +141,7 @@ export const YearnOverview: React.FC<{
       asset={asset}
       name={`${underlyingToken.name} Vault (${opportunity.version})`}
       opportunityFiatBalance={fiatAmountAvailable.toFixed(2)}
-      underlyingAssets={underlyingAssets}
+      underlyingAssetsCryptoPrecision={underlyingAssets}
       provider='Yearn Finance'
       description={description}
       tvl={opportunity.tvl.balanceUsdc.div(`1e+${USDC_PRECISION}`).toString()}

--- a/src/state/slices/common-selectors.ts
+++ b/src/state/slices/common-selectors.ts
@@ -1,0 +1,65 @@
+import type { AccountId, AssetId } from '@shapeshiftoss/caip'
+import pickBy from 'lodash/pickBy'
+import createCachedSelector from 're-reselect'
+import { bnOrZero } from 'lib/bignumber/bignumber'
+import { fromBaseUnit } from 'lib/math'
+import type { ReduxState } from 'state/reducer'
+import { createDeepEqualOutputSelector } from 'state/selector-utils'
+import { selectAccountIdParamFromFilter, selectAssetIdParamFromFilter } from 'state/selectors'
+
+import { selectAssets } from './assetsSlice/selectors'
+import type { PortfolioAccountBalancesById } from './portfolioSlice/portfolioSliceCommon'
+
+export const selectWalletId = (state: ReduxState) => state.portfolio.walletId
+
+export const selectWalletAccountIds = createDeepEqualOutputSelector(
+  selectWalletId,
+  (state: ReduxState) => state.portfolio.wallet.byId,
+  (walletId, walletById): AccountId[] => (walletId && walletById[walletId]) ?? [],
+)
+
+export const selectPortfolioAccountBalances = createDeepEqualOutputSelector(
+  selectWalletAccountIds,
+  (state: ReduxState): PortfolioAccountBalancesById => state.portfolio.accountBalances.byId,
+  (walletAccountIds, accountBalancesById) =>
+    pickBy(accountBalancesById, (_balances, accountId: AccountId) =>
+      walletAccountIds.includes(accountId),
+    ),
+)
+
+export const selectPortfolioAssetBalances = createDeepEqualOutputSelector(
+  selectPortfolioAccountBalances,
+  (accountBalancesById): Record<AssetId, string> =>
+    Object.values(accountBalancesById).reduce<Record<AssetId, string>>((acc, byAccountId) => {
+      Object.entries(byAccountId).forEach(
+        ([assetId, balance]) =>
+          (acc[assetId] = bnOrZero(acc[assetId]).plus(bnOrZero(balance)).toFixed()),
+      )
+      return acc
+    }, {}),
+)
+
+export const selectPortfolioCryptoBalanceByFilter = createCachedSelector(
+  selectPortfolioAccountBalances,
+  selectPortfolioAssetBalances,
+  selectAccountIdParamFromFilter,
+  selectAssetIdParamFromFilter,
+  (accountBalances, assetBalances, accountId, assetId): string => {
+    if (accountId && assetId) return accountBalances?.[accountId]?.[assetId]
+    return assetId ? assetBalances[assetId] : '0'
+  },
+)((_s: ReduxState, filter) => `${filter?.accountId}-${filter?.assetId}` ?? 'accountId-assetId')
+
+export const selectPortfolioCryptoHumanBalanceByFilter = createCachedSelector(
+  selectAssets,
+  selectPortfolioAccountBalances,
+  selectPortfolioAssetBalances,
+  selectAccountIdParamFromFilter,
+  selectAssetIdParamFromFilter,
+  (assets, accountBalances, assetBalances, accountId, assetId): string | undefined => {
+    if (!assetId) return
+    const precision = assets?.[assetId]?.precision ?? 0
+    if (accountId) return fromBaseUnit(bnOrZero(accountBalances?.[accountId]?.[assetId]), precision)
+    return fromBaseUnit(bnOrZero(assetBalances[assetId]), precision)
+  },
+)((_s: ReduxState, filter) => `${filter?.accountId}-${filter?.assetId}` ?? 'accountId-assetId')

--- a/src/state/slices/opportunitiesSlice/constants.ts
+++ b/src/state/slices/opportunitiesSlice/constants.ts
@@ -75,7 +75,6 @@ export const baseEarnFarmingOpportunity = {
   fiatAmount: '',
   cryptoAmountBaseUnit: '',
   cryptoAmountPrecision: '',
-  rewardsAmountsCryptoPrecision: '',
   isLoaded: false,
   type: DefiType.Farming,
 }

--- a/src/state/slices/opportunitiesSlice/opportunitiesSlice.test.ts
+++ b/src/state/slices/opportunitiesSlice/opportunitiesSlice.test.ts
@@ -196,8 +196,6 @@ describe('opportunitiesSlice', () => {
           byId: {
             [serializeUserStakingId(gomesAccountId, 'eip155:1:0xMyStakingContract')]: {
               stakedAmountCryptoBaseUnit: '42000',
-              stakedAmountCryptoPrecision: '0.000000000000042',
-              rewardsAmountsCryptoPrecision: ['42'] as [string],
               rewardsAmountsCryptoBaseUnit: ['42000000000000000000'] as [string],
             },
           },
@@ -211,8 +209,6 @@ describe('opportunitiesSlice', () => {
           byId: {
             [serializeUserStakingId(gomesAccountId, 'eip155:1:0xMyStakingContract')]: {
               stakedAmountCryptoBaseUnit: '42000',
-              stakedAmountCryptoPrecision: '0.000000000000042',
-              rewardsAmountsCryptoPrecision: ['42'] as [string],
               rewardsAmountsCryptoBaseUnit: ['42000000000000000000'] as [string],
             },
           },
@@ -227,8 +223,6 @@ describe('opportunitiesSlice', () => {
           byId: {
             [serializeUserStakingId(fauxmesAccountId, 'eip155:1:0xMyStakingContract')]: {
               stakedAmountCryptoBaseUnit: '42000',
-              stakedAmountCryptoPrecision: '0.000000000000042',
-              rewardsAmountsCryptoPrecision: ['42'] as [string],
               rewardsAmountsCryptoBaseUnit: ['42000000000000000000'] as [string],
             },
           },

--- a/src/state/slices/opportunitiesSlice/resolvers/foxFarming/index.ts
+++ b/src/state/slices/opportunitiesSlice/resolvers/foxFarming/index.ts
@@ -261,11 +261,8 @@ export const foxFarmingStakingUserDataResolver = async ({
 }: OpportunityUserDataResolverInput): Promise<{ data: GetOpportunityUserStakingDataOutput }> => {
   const { getState } = reduxApi
   const state: any = getState() // ReduxState causes circular dependency
-  const assets: AssetsState = state.assets
-  const foxPrecision = assets.byId[foxAssetId].precision
   const lpTokenMarketData: MarketData = selectMarketDataById(state, foxEthLpAssetId)
   const lpTokenPrice = lpTokenMarketData?.price
-  const lpAssetPrecision = assets.byId[foxEthLpAssetId].precision
 
   const { assetReference: contractAddress } = fromAssetId(opportunityId)
   const { account: accountAddress } = fromAccountId(accountId)
@@ -279,18 +276,12 @@ export const foxFarmingStakingUserDataResolver = async ({
   const stakedBalance = await foxFarmingContract.balanceOf(accountAddress)
   const earned = await foxFarmingContract.earned(accountAddress)
   const stakedAmountCryptoBaseUnit = bnOrZero(stakedBalance.toString()).toString()
-  const stakedAmountCryptoPrecision = stakedBalance.div(bn(10).pow(lpAssetPrecision))
-  const rewardsAmountsCryptoPrecision = [
-    bnOrZero(earned.toString()).div(bn(10).pow(foxPrecision)).toFixed(),
-  ] as [string]
   const rewardsAmountsCryptoBaseUnit = [earned.toString()] as [string]
 
   const data = {
     byId: {
       [serializeUserStakingId(accountId, opportunityId)]: {
         stakedAmountCryptoBaseUnit,
-        stakedAmountCryptoPrecision,
-        rewardsAmountsCryptoPrecision,
         rewardsAmountsCryptoBaseUnit,
       },
     },

--- a/src/state/slices/opportunitiesSlice/selectors.test.ts
+++ b/src/state/slices/opportunitiesSlice/selectors.test.ts
@@ -372,7 +372,7 @@ describe('opportunitiesSlice selectors', () => {
           rewardsAmountsCryptoBaseUnit: ['421000000000000000000'] as [string],
           rewardsAmountsCryptoPrecision: ['430'] as [string],
           stakedAmountCryptoBaseUnit: '1437',
-          stakedAmountCryptoPrecision: '0.000000000000001437',
+          stakedAmountCryptoPrecision: '0.0000000000000001',
         })
       })
     })

--- a/src/state/slices/opportunitiesSlice/selectors.test.ts
+++ b/src/state/slices/opportunitiesSlice/selectors.test.ts
@@ -85,20 +85,14 @@ describe('opportunitiesSlice selectors', () => {
       byId: {
         [serializeUserStakingId(gomesAccountId, mockStakingContractTwo)]: {
           stakedAmountCryptoBaseUnit: '1337',
-          stakedAmountCryptoPrecision: '0.000000000000001337',
-          rewardsAmountsCryptoPrecision: ['420'] as [string],
           rewardsAmountsCryptoBaseUnit: ['420000000000000000000'] as [string],
         },
         [serializeUserStakingId(gomesAccountId, mockStakingContractOne)]: {
           stakedAmountCryptoBaseUnit: '4',
-          stakedAmountCryptoPrecision: '0.000000000000000004',
-          rewardsAmountsCryptoPrecision: ['3'] as [string],
           rewardsAmountsCryptoBaseUnit: ['3000000000000000000'] as [string],
         },
         [serializeUserStakingId(fauxmesAccountId, mockStakingContractOne)]: {
           stakedAmountCryptoBaseUnit: '9000',
-          stakedAmountCryptoPrecision: '0.000000000000009',
-          rewardsAmountsCryptoPrecision: ['1'] as [string],
           rewardsAmountsCryptoBaseUnit: ['1000000000000000000'] as [string],
         },
       },
@@ -189,14 +183,10 @@ describe('opportunitiesSlice selectors', () => {
       byId: {
         [serializeUserStakingId(gomesAccountId, mockStakingContractTwo)]: {
           stakedAmountCryptoBaseUnit: '1337',
-          stakedAmountCryptoPrecision: '0.000000000000001337',
-          rewardsAmountsCryptoPrecision: ['420'] as [string],
           rewardsAmountsCryptoBaseUnit: ['420000000000000000000'] as [string],
         },
         [serializeUserStakingId(gomesAccountId, mockStakingContractOne)]: {
           stakedAmountCryptoBaseUnit: '4',
-          stakedAmountCryptoPrecision: '0.000000000000000004',
-          rewardsAmountsCryptoPrecision: ['3'] as [string],
           rewardsAmountsCryptoBaseUnit: ['3000000000000000000'] as [string],
         },
       },
@@ -221,9 +211,7 @@ describe('opportunitiesSlice selectors', () => {
         assetId: 'eip155:1/erc20:0x470e8de2ebaef52014a47cb5e6af86884947f08c',
         provider: 'UNI V2',
         rewardsAmountsCryptoBaseUnit: ['420000000000000000000'],
-        rewardsAmountsCryptoPrecision: ['420'],
         stakedAmountCryptoBaseUnit: '1337',
-        stakedAmountCryptoPrecision: '0.000000000000001337',
         tvl: '424242',
         type: 'lp',
         underlyingAssetId: 'eip155:1/erc20:0x470e8de2ebaef52014a47cb5e6af86884947f08c',
@@ -242,9 +230,7 @@ describe('opportunitiesSlice selectors', () => {
         assetId: 'eip155:1/erc20:0x470e8de2ebaef52014a47cb5e6af86884947f08c',
         provider: 'UNI V2',
         stakedAmountCryptoBaseUnit: '4',
-        stakedAmountCryptoPrecision: '0.000000000000000004',
         rewardsAmountsCryptoBaseUnit: ['3000000000000000000'] as [string],
-        rewardsAmountsCryptoPrecision: ['3'] as [string],
         tvl: '424242',
         type: 'lp',
         underlyingAssetId: 'eip155:1/erc20:0x470e8de2ebaef52014a47cb5e6af86884947f08c',
@@ -283,20 +269,14 @@ describe('opportunitiesSlice selectors', () => {
       byId: {
         [serializeUserStakingId(gomesAccountId, mockStakingContractTwo)]: {
           stakedAmountCryptoBaseUnit: '1337',
-          stakedAmountCryptoPrecision: '0.000000000000001337',
-          rewardsAmountsCryptoPrecision: ['420'] as [string],
           rewardsAmountsCryptoBaseUnit: ['420000000000000000000'] as [string],
         },
         [serializeUserStakingId(catpuccinoAccountId, mockStakingContractTwo)]: {
           stakedAmountCryptoBaseUnit: '100',
-          stakedAmountCryptoPrecision: '0.0000000000000001',
-          rewardsAmountsCryptoPrecision: ['10'] as [string],
           rewardsAmountsCryptoBaseUnit: ['1000000000000000000'] as [string],
         },
         [serializeUserStakingId(gomesAccountId, mockStakingContractOne)]: {
           stakedAmountCryptoBaseUnit: '4',
-          stakedAmountCryptoPrecision: '0.000000000000000004',
-          rewardsAmountsCryptoPrecision: ['3'] as [string],
           rewardsAmountsCryptoBaseUnit: ['3000000000000000000'] as [string],
         },
       },
@@ -321,9 +301,7 @@ describe('opportunitiesSlice selectors', () => {
             assetId: mockStakingContractTwo,
             provider: DefiProvider.FoxEthLP,
             rewardsAmountsCryptoBaseUnit: ['420000000000000000000'] as [string],
-            rewardsAmountsCryptoPrecision: ['420'] as [string],
             stakedAmountCryptoBaseUnit: '1337',
-            stakedAmountCryptoPrecision: '0.000000000000001337',
             tvl: '91283233211',
             type: DefiType.LiquidityPool,
             underlyingAssetId: foxEthLpAssetId,
@@ -339,9 +317,7 @@ describe('opportunitiesSlice selectors', () => {
             assetId: mockStakingContractTwo,
             provider: DefiProvider.FoxEthLP,
             rewardsAmountsCryptoBaseUnit: ['1000000000000000000'] as [string],
-            rewardsAmountsCryptoPrecision: ['10'] as [string],
             stakedAmountCryptoBaseUnit: '100',
-            stakedAmountCryptoPrecision: '0.0000000000000001',
             tvl: '91283233211',
             type: DefiType.LiquidityPool,
             underlyingAssetId: foxEthLpAssetId,
@@ -370,9 +346,7 @@ describe('opportunitiesSlice selectors', () => {
           underlyingAssetIds: foxEthPair,
           underlyingAssetRatios: ['5000000000000000', '202200000000000000000'] as [string, string],
           rewardsAmountsCryptoBaseUnit: ['421000000000000000000'] as [string],
-          rewardsAmountsCryptoPrecision: ['430'] as [string],
           stakedAmountCryptoBaseUnit: '1437',
-          stakedAmountCryptoPrecision: '0.0000000000000001',
         })
       })
     })

--- a/src/state/slices/opportunitiesSlice/selectors.ts
+++ b/src/state/slices/opportunitiesSlice/selectors.ts
@@ -399,7 +399,6 @@ export const selectAggregatedEarnUserStakingOpportunity = createDeepEqualOutputS
           .plus(acc?.stakedAmountCryptoBaseUnit ?? 0)
           .toString(),
         fiatAmount: bnOrZero(currentOpportunity?.rewardsAmountsCryptoBaseUnit?.[0])
-          .div(bn(10).pow(asset?.precision ?? underlyingAsset?.precision))
           .plus(acc?.rewardsAmountsCryptoBaseUnit?.[0] ?? 0)
           .div(bn(10).pow(asset?.precision ?? underlyingAsset?.precision))
           .toString(),
@@ -694,8 +693,9 @@ export const selectUnderlyingStakingAssetsWithBalancesAndIcons = createSelector(
     )
     return userStakingOpportunity.underlyingAssetIds.map((assetId, i, original) => ({
       ...assets[assetId],
-      cryptoBalance: bnOrZero(userStakingOpportunities.stakedAmountCryptoBaseUnit)
-        .times(userStakingOpportunities.underlyingAssetRatios[i] ?? '1')
+      cryptoBalancePrecision: bnOrZero(userStakingOpportunity.stakedAmountCryptoBaseUnit)
+        .times(userStakingOpportunity.underlyingAssetRatios[i] ?? '1') // Ratios are in base unit, this needs to be first
+        .div(bn(10).pow(asset?.precision ?? underlyingAsset?.precision))
         .toFixed(),
       icons: [underlyingAssetsIcons[i]],
       allocationPercentage: bn('1').div(original.length).toString(),

--- a/src/state/slices/opportunitiesSlice/selectors.ts
+++ b/src/state/slices/opportunitiesSlice/selectors.ts
@@ -366,7 +366,6 @@ export const selectAggregatedEarnUserStakingOpportunitiesIncludeEmpty =
               isLoaded: true,
               icons: opportunity.underlyingAssetIds.map(assetId => assets[assetId].icon),
               opportunityName: opportunity.name,
-              rewardsAmountsCryptoPrecision: [] as const,
             },
           )
 

--- a/src/state/slices/opportunitiesSlice/selectors.ts
+++ b/src/state/slices/opportunitiesSlice/selectors.ts
@@ -144,13 +144,7 @@ export const selectUserStakingOpportunityByUserStakingId = createDeepEqualOutput
     return {
       // Overwritten by userOpportunity if it exists, else we keep defaulting to 0
       stakedAmountCryptoBaseUnit: '0',
-      stakedAmountCryptoPrecision: '0',
       rewardsAmountsCryptoBaseUnit: (opportunityMetadata.rewardAssetIds?.map(() => '0') ?? []) as
-        | []
-        | [string, string]
-        | [string],
-
-      rewardsAmountsCryptoPrecision: (opportunityMetadata.rewardAssetIds?.map(() => '0') ?? []) as
         | []
         | [string, string]
         | [string],
@@ -252,14 +246,6 @@ const getAggregatedUserStakingOpportunityByStakingId = (
       stakedAmountCryptoBaseUnit: bnOrZero(acc?.stakedAmountCryptoBaseUnit)
         .plus(userStakingOpportunity.stakedAmountCryptoBaseUnit)
         .toString(),
-      stakedAmountCryptoPrecision: bnOrZero(acc?.stakedAmountCryptoPrecision)
-        .plus(userStakingOpportunity.stakedAmountCryptoPrecision)
-        .toFixed(),
-      rewardsAmountsCryptoPrecision: (
-        userStakingOpportunity.rewardsAmountsCryptoPrecision ?? []
-      ).map((amount, i) =>
-        bnOrZero(acc?.rewardsAmountsCryptoPrecision?.[i]).plus(amount).toString(),
-      ) as [string, string] | [string] | [],
       rewardsAmountsCryptoBaseUnit: (userStakingOpportunity.rewardsAmountsCryptoBaseUnit ?? []).map(
         (amount, i) => bnOrZero(acc?.rewardsAmountsCryptoBaseUnit?.[i]).plus(amount).toString(),
       ) as [string, string] | [string] | [],
@@ -297,7 +283,6 @@ export const selectAggregatedEarnUserStakingOpportunityByStakingId = createDeepE
       isLoaded: true,
       icons: opportunity.underlyingAssetIds.map(assetId => assets[assetId].icon),
       opportunityName: opportunity.name,
-      rewardsAmountsCryptoPrecision: opportunity.rewardsAmountsCryptoPrecision,
     }),
 )
 
@@ -346,7 +331,6 @@ export const selectAggregatedEarnUserStakingOpportunities = createDeepEqualOutpu
           isLoaded: true,
           icons: opportunity.underlyingAssetIds.map(assetId => assets[assetId].icon),
           opportunityName: opportunity.name,
-          rewardsAmountsCryptoPrecision: opportunity.rewardsAmountsCryptoPrecision,
         },
       )
     }),
@@ -403,25 +387,25 @@ export const selectAggregatedEarnUserStakingOpportunitiesIncludeEmpty =
 // TODO: testme
 export const selectAggregatedEarnUserStakingOpportunity = createDeepEqualOutputSelector(
   selectAggregatedEarnUserStakingOpportunities,
-  (earnOpportunities): StakingEarnOpportunityType | undefined =>
+  selectAssets,
+  (earnOpportunities, assets): StakingEarnOpportunityType | undefined =>
     earnOpportunities.reduce<StakingEarnOpportunityType | undefined>((acc, currentOpportunity) => {
+      const asset = assets[currentOpportunity.assetId]
+      const underlyingAsset = assets[currentOpportunity.underlyingAssetId]
+
       return Object.assign({}, acc, currentOpportunity, {
         cryptoAmountBaseUnit: bnOrZero(currentOpportunity.stakedAmountCryptoBaseUnit)
+          .div(bn(10).pow(asset?.precision ?? underlyingAsset?.precision))
           .plus(acc?.stakedAmountCryptoBaseUnit ?? 0)
           .toString(),
-        fiatAmount: bnOrZero(currentOpportunity?.rewardsAmountsCryptoPrecision?.[0])
-          .plus(acc?.rewardsAmountsCryptoPrecision?.[0] ?? 0)
+        fiatAmount: bnOrZero(currentOpportunity?.rewardsAmountsCryptoBaseUnit?.[0])
+          .div(bn(10).pow(asset?.precision ?? underlyingAsset?.precision))
+          .plus(acc?.rewardsAmountsCryptoBaseUnit?.[0] ?? 0)
+          .div(bn(10).pow(asset?.precision ?? underlyingAsset?.precision))
           .toString(),
         stakedAmountCryptoBaseUnit: bnOrZero(currentOpportunity.stakedAmountCryptoBaseUnit)
           .plus(acc?.stakedAmountCryptoBaseUnit ?? 0)
           .toString(),
-        rewardsAmountsCryptoPrecision: (
-          currentOpportunity?.rewardsAmountsCryptoPrecision ?? []
-        ).map((amount, i) =>
-          bnOrZero(amount)
-            .plus(acc?.rewardsAmountsCryptoPrecision?.[i] ?? 0)
-            .toString(),
-        ),
       })
     }, undefined),
 )
@@ -540,7 +524,6 @@ export const selectEarnUserStakingOpportunity = createDeepEqualOutputSelector(
         .times(marketDataPrice ?? '0')
         .toString(),
       stakedAmountCryptoBaseUnit: userStakingOpportunity.stakedAmountCryptoBaseUnit ?? '0',
-      rewardsAmountsCryptoPrecision: userStakingOpportunity.rewardsAmountsCryptoPrecision,
       opportunityName: userStakingOpportunity.name,
       icons: userStakingOpportunity.underlyingAssetIds.map(assetId => assets[assetId].icon),
     }
@@ -676,7 +659,7 @@ export const selectUnderlyingLpAssetsWithBalancesAndIcons = createSelector(
   selectLpOpportunitiesById,
   selectPortfolioCryptoHumanBalanceByFilter,
   selectAssets,
-  (lpId, lpOpportunitiesById, lpAssetBalance, assets): AssetWithBalance[] | undefined => {
+  (lpId, lpOpportunitiesById, lpAssetBalancePrecision, assets): AssetWithBalance[] | undefined => {
     if (!lpId) return
     const opportunityMetadata = lpOpportunitiesById[lpId]
 
@@ -686,7 +669,7 @@ export const selectUnderlyingLpAssetsWithBalancesAndIcons = createSelector(
     )
     return opportunityMetadata.underlyingAssetIds.map((assetId, i) => ({
       ...assets[assetId],
-      cryptoBalance: bnOrZero(lpAssetBalance)
+      cryptoBalancePrecision: bnOrZero(lpAssetBalancePrecision)
         .times(
           fromBaseUnit(opportunityMetadata.underlyingAssetRatios[i], assets[assetId].precision),
         )
@@ -700,13 +683,16 @@ export const selectUnderlyingLpAssetsWithBalancesAndIcons = createSelector(
 export const selectUnderlyingStakingAssetsWithBalancesAndIcons = createSelector(
   selectUserStakingOpportunityByUserStakingId,
   selectAssets,
-  (userStakingOpportunities, assets): AssetWithBalance[] | undefined => {
-    if (!userStakingOpportunities) return
+  (userStakingOpportunity, assets): AssetWithBalance[] | undefined => {
+    if (!userStakingOpportunity) return
 
-    const underlyingAssetsIcons = userStakingOpportunities.underlyingAssetIds.map(
+    const asset = assets[userStakingOpportunity.assetId]
+    const underlyingAsset = assets[userStakingOpportunity.underlyingAssetId]
+
+    const underlyingAssetsIcons = userStakingOpportunity.underlyingAssetIds.map(
       assetId => assets[assetId].icon,
     )
-    return userStakingOpportunities.underlyingAssetIds.map((assetId, i, original) => ({
+    return userStakingOpportunity.underlyingAssetIds.map((assetId, i, original) => ({
       ...assets[assetId],
       cryptoBalance: bnOrZero(userStakingOpportunities.stakedAmountCryptoBaseUnit)
         .times(userStakingOpportunities.underlyingAssetRatios[i] ?? '1')

--- a/src/state/slices/opportunitiesSlice/selectors.ts
+++ b/src/state/slices/opportunitiesSlice/selectors.ts
@@ -407,7 +407,7 @@ export const selectEarnUserLpOpportunity = createDeepEqualOutputSelector(
     assets,
     marketData,
   ): StakingEarnOpportunityType | undefined => {
-    if (!lpId || !lpAssetBalanceCryptoBaseUnit) return
+    if (!lpId) return
 
     const marketDataPrice = marketData[lpId as AssetId]?.price
     const opportunityMetadata = lpOpportunitiesById[lpId]

--- a/src/state/slices/opportunitiesSlice/selectors.ts
+++ b/src/state/slices/opportunitiesSlice/selectors.ts
@@ -482,11 +482,11 @@ export const selectEarnUserLpOpportunity = createDeepEqualOutputSelector(
           .toString(),
       )
     const [underlyingToken0AmountCryptoBaseUnit, underlyingToken1AmountCryptoBaseUnit] =
-      opportunityMetadata?.underlyingAssetIds.map((_assetId, i) =>
+      opportunityMetadata?.underlyingAssetIds.map((assetId, i) =>
         bnOrZero(lpAssetBalanceCryptoBaseUnit)
-          .times(opportunityMetadata?.underlyingAssetRatios[i] ?? '0')
-          .toFixed(6)
-          .toString(),
+          .times(opportunityMetadata?.underlyingAssetRatios[i])
+          .div(bn(10).pow(bnOrZero(assets[assetId]?.precision)))
+          .toFixed(6),
       )
 
     const opportunity = {
@@ -501,7 +501,7 @@ export const selectEarnUserLpOpportunity = createDeepEqualOutputSelector(
       underlyingToken1AmountCryptoBaseUnit,
       cryptoAmountBaseUnit: lpAssetBalanceCryptoBaseUnit,
       fiatAmount: bnOrZero(lpAssetBalanceCryptoBaseUnit)
-        .div(assets[opportunityMetadata.assetId].precision)
+        .div(bn(10).pow(bnOrZero(assets[opportunityMetadata?.assetId]?.precision)))
         .times(marketDataPrice ?? '0')
         .toString(),
       icons: opportunityMetadata.underlyingAssetIds.map(assetId => assets[assetId].icon),
@@ -570,7 +570,7 @@ export const selectAggregatedEarnUserLpOpportunity = createDeepEqualOutputSelect
           .times(
             fromBaseUnit(
               opportunityMetadata?.underlyingAssetRatios[i] ?? '0',
-              assets[assetId].precision,
+              assets[assetId]?.precision,
             ),
           )
           .toFixed(6)
@@ -578,9 +578,10 @@ export const selectAggregatedEarnUserLpOpportunity = createDeepEqualOutputSelect
       )
 
     const [underlyingToken0AmountCryptoBaseUnit, underlyingToken1AmountCryptoBaseUnit] =
-      opportunityMetadata.underlyingAssetIds.map((_assetId, i) =>
+      opportunityMetadata.underlyingAssetIds.map((assetId, i) =>
         bnOrZero(aggregatedLpAssetBalance)
           .times(opportunityMetadata?.underlyingAssetRatios[i] ?? '0')
+          .div(bn(10).pow(bnOrZero(assets[assetId]?.precision)))
           .toFixed(6)
           .toString(),
       )
@@ -706,7 +707,12 @@ export const selectUnderlyingStakingAssetsWithBalancesAndIcons = createSelector(
     return userStakingOpportunity.underlyingAssetIds.map((assetId, i, original) => ({
       ...assets[assetId],
       cryptoBalancePrecision: bnOrZero(userStakingOpportunity.stakedAmountCryptoBaseUnit)
-        .times(userStakingOpportunity.underlyingAssetRatios[i] ?? '1') // Ratios are in base unit, this needs to be first
+        .times(
+          fromBaseUnit(
+            userStakingOpportunity.underlyingAssetRatios[i],
+            assets[assetId]?.precision,
+          ) ?? '1',
+        )
         .div(bn(10).pow(asset?.precision ?? underlyingAsset?.precision))
         .toFixed(),
       icons: [underlyingAssetsIcons[i]],

--- a/src/state/slices/opportunitiesSlice/selectors.ts
+++ b/src/state/slices/opportunitiesSlice/selectors.ts
@@ -325,8 +325,8 @@ export const selectAggregatedEarnUserStakingOpportunities = createDeepEqualOutpu
             .toFixed(),
           cryptoAmountBaseUnit: opportunity.stakedAmountCryptoBaseUnit,
           fiatAmount: bnOrZero(opportunity.stakedAmountCryptoBaseUnit)
-            .div(bn(10).pow(asset?.precision ?? underlyingAsset?.precision))
             .times(marketData[asset?.assetId ?? underlyingAsset?.assetId]?.price ?? '0')
+            .div(bn(10).pow(asset?.precision ?? underlyingAsset?.precision))
             .toString(),
           isLoaded: true,
           icons: opportunity.underlyingAssetIds.map(assetId => assets[assetId].icon),
@@ -394,8 +394,8 @@ export const selectAggregatedEarnUserStakingOpportunity = createDeepEqualOutputS
 
       return Object.assign({}, acc, currentOpportunity, {
         cryptoAmountBaseUnit: bnOrZero(currentOpportunity.stakedAmountCryptoBaseUnit)
-          .div(bn(10).pow(asset?.precision ?? underlyingAsset?.precision))
           .plus(acc?.stakedAmountCryptoBaseUnit ?? 0)
+          .div(bn(10).pow(asset?.precision ?? underlyingAsset?.precision))
           .toString(),
         fiatAmount: bnOrZero(currentOpportunity?.rewardsAmountsCryptoBaseUnit?.[0])
           .plus(acc?.rewardsAmountsCryptoBaseUnit?.[0] ?? 0)

--- a/src/state/slices/opportunitiesSlice/types.ts
+++ b/src/state/slices/opportunitiesSlice/types.ts
@@ -42,14 +42,7 @@ export type OpportunityMetadata = {
 export type UserStakingOpportunity = {
   // The amount of farmed LP tokens
   stakedAmountCryptoBaseUnit: string
-  /** @deprecated use stakedAmountCryptoBaseUnit instead and derive precision amount from it*/
-  stakedAmountCryptoPrecision: string
   // The amount of rewards available to claim for the farmed LP position
-  rewardsAmountsCryptoPrecision:
-    | readonly [string, string, string]
-    | readonly [string, string]
-    | readonly [string]
-    | readonly []
   rewardsAmountsCryptoBaseUnit:
     | readonly [string, string, string]
     | readonly [string, string]
@@ -132,15 +125,6 @@ export type StakingEarnOpportunityType = OpportunityMetadata & {
     | readonly [string, string]
     | readonly [string]
     | readonly []
-  /** @deprecated use rewardsAmountsCryptoBaseUnit instead and derive precision amount from it*/
-  rewardsAmountsCryptoPrecision?:
-    | readonly [string, string, string]
-    | readonly [string, string]
-    | readonly [string]
-    | readonly []
-  /** @deprecated use base unit underlying amounts instead and derive precision amount from it*/
-  underlyingToken0AmountCryptoPrecision?: string
-  underlyingToken1AmountCryptoPrecision?: string
   underlyingToken0AmountCryptoBaseUnit?: string
   underlyingToken1AmountCryptoBaseUnit?: string
   isVisible?: boolean

--- a/src/state/slices/portfolioSlice/portfolioSlice.test.ts
+++ b/src/state/slices/portfolioSlice/portfolioSlice.test.ts
@@ -23,6 +23,7 @@ import { mockChainAdapters, mockUpsertPortfolio } from 'test/mocks/portfolio'
 import { createStore } from 'state/store'
 
 import { assets as assetsSlice } from '../assetsSlice/assetsSlice'
+import { selectPortfolioCryptoHumanBalanceByFilter } from '../common-selectors'
 import { marketData as marketDataSlice } from '../marketDataSlice/marketDataSlice'
 import { portfolio as portfolioSlice } from './portfolioSlice'
 import {
@@ -30,7 +31,6 @@ import {
   selectPortfolioAccountRows,
   selectPortfolioAllocationPercentByFilter,
   selectPortfolioAssetIdsByAccountIdExcludeFeeAsset,
-  selectPortfolioCryptoHumanBalanceByFilter,
   selectPortfolioFiatBalanceByFilter,
   selectPortfolioFiatBalancesByAccount,
 } from './selectors'

--- a/src/state/slices/portfolioSlice/selectors.ts
+++ b/src/state/slices/portfolioSlice/selectors.ts
@@ -50,6 +50,11 @@ import {
 } from 'state/slices/portfolioSlice/utils'
 import { selectBalanceThreshold, selectFeatureFlags } from 'state/slices/preferencesSlice/selectors'
 
+import {
+  selectPortfolioAccountBalances,
+  selectPortfolioAssetBalances,
+  selectWalletAccountIds,
+} from '../common-selectors'
 import { foxEthLpAssetId, foxEthStakingIds } from '../opportunitiesSlice/constants'
 import type { StakingId } from '../opportunitiesSlice/types'
 import {
@@ -85,43 +90,11 @@ const FEE_ASSET_IDS = [
   avalancheAssetId,
 ]
 
-export const selectWalletId = (state: ReduxState) => state.portfolio.walletId
-
-/**
- * the accountIds from the wallet, not necessarily loaded
- */
-export const selectWalletAccountIds = createDeepEqualOutputSelector(
-  selectWalletId,
-  (state: ReduxState) => state.portfolio.wallet.byId,
-  (walletId, walletById): AccountId[] => (walletId && walletById[walletId]) ?? [],
-)
-
 export const selectPortfolioAccounts = createDeepEqualOutputSelector(
   selectWalletAccountIds,
   (state: ReduxState) => state.portfolio.accounts.byId,
   (walletAccountIds, accountsById): PortfolioAccounts['byId'] =>
     pickBy(accountsById, (_account, accountId: AccountId) => walletAccountIds.includes(accountId)),
-)
-
-export const selectPortfolioAccountBalances = createDeepEqualOutputSelector(
-  selectWalletAccountIds,
-  (state: ReduxState): PortfolioAccountBalancesById => state.portfolio.accountBalances.byId,
-  (walletAccountIds, accountBalancesById) =>
-    pickBy(accountBalancesById, (_balances, accountId: AccountId) =>
-      walletAccountIds.includes(accountId),
-    ),
-)
-
-export const selectPortfolioAssetBalances = createDeepEqualOutputSelector(
-  selectPortfolioAccountBalances,
-  (accountBalancesById): Record<AssetId, string> =>
-    Object.values(accountBalancesById).reduce<Record<AssetId, string>>((acc, byAccountId) => {
-      Object.entries(byAccountId).forEach(
-        ([assetId, balance]) =>
-          (acc[assetId] = bnOrZero(acc[assetId]).plus(bnOrZero(balance)).toFixed()),
-      )
-      return acc
-    }, {}),
 )
 
 export const selectPortfolioAssetIds = createDeepEqualOutputSelector(
@@ -394,20 +367,6 @@ export const selectPortfolioCryptoBalanceByAssetId = createCachedSelector(
   (byId, assetId): string | undefined => assetId && byId[assetId],
 )((state: ReduxState, filter) => `${state.portfolio.walletId}-${filter?.assetId}` ?? 'assetId')
 
-export const selectPortfolioCryptoHumanBalanceByFilter = createCachedSelector(
-  selectAssets,
-  selectPortfolioAccountBalances,
-  selectPortfolioAssetBalances,
-  selectAccountIdParamFromFilter,
-  selectAssetIdParamFromFilter,
-  (assets, accountBalances, assetBalances, accountId, assetId): string | undefined => {
-    if (!assetId) return
-    const precision = assets?.[assetId]?.precision ?? 0
-    if (accountId) return fromBaseUnit(bnOrZero(accountBalances?.[accountId]?.[assetId]), precision)
-    return fromBaseUnit(bnOrZero(assetBalances[assetId]), precision)
-  },
-)((_s: ReduxState, filter) => `${filter?.accountId}-${filter?.assetId}` ?? 'accountId-assetId')
-
 export const selectFirstAccountIdByChainId = createSelector(
   selectWalletAccountIds,
   (_s: ReduxState, chainId: ChainId) => chainId,
@@ -525,17 +484,6 @@ export const selectBalanceChartCryptoBalancesByAccountIdAboveThreshold =
       return aboveThresholdBalances
     },
   )
-
-export const selectPortfolioCryptoBalanceByFilter = createCachedSelector(
-  selectPortfolioAccountBalances,
-  selectPortfolioAssetBalances,
-  selectAccountIdParamFromFilter,
-  selectAssetIdParamFromFilter,
-  (accountBalances, assetBalances, accountId, assetId): string => {
-    if (accountId && assetId) return accountBalances?.[accountId]?.[assetId]
-    return assetId ? assetBalances[assetId] : '0'
-  },
-)((_s: ReduxState, filter) => `${filter?.accountId}-${filter?.assetId}` ?? 'accountId-assetId')
 
 export const selectPortfolioMixedHumanBalancesBySymbol = createDeepEqualOutputSelector(
   selectAssets,

--- a/src/state/slices/selectors.ts
+++ b/src/state/slices/selectors.ts
@@ -14,3 +14,12 @@ export * from './preferencesSlice/selectors'
 export * from './txHistorySlice/selectors'
 export * from './validatorDataSlice/selectors'
 export * from './opportunitiesSlice/selectors'
+
+/**
+ * some selectors span multiple business logic domains, e.g. portfolio and opportunities
+ * slices are closely related in logic
+ *
+ * to avoid both circular dependencies and duplication of logic,
+ * we define them higher up the tree at a common place
+ */
+export * from './common-selectors'

--- a/src/state/slices/txHistorySlice/selectors.ts
+++ b/src/state/slices/txHistorySlice/selectors.ts
@@ -17,8 +17,9 @@ import {
   selectChainIdParamFromFilter,
 } from 'state/selectors'
 
+import { selectWalletAccountIds } from '../common-selectors'
 import type { AccountMetadata } from '../portfolioSlice/portfolioSliceCommon'
-import { selectPortfolioAccountMetadata, selectWalletAccountIds } from '../portfolioSlice/selectors'
+import { selectPortfolioAccountMetadata } from '../portfolioSlice/selectors'
 import type {
   RebaseId,
   RebaseIdsByAccountIdAssetId,


### PR DESCRIPTION
## Description

Part 2 of base units refactor - DeFi still expects precision amounts within the abstraction, but those are now derived in-place at component-level.

This PR:

- removes the precision amounts that were marked as deprecated in https://github.com/shapeshift/web/pull/3409
- adds `precision` vernacular to the passed down props
- does the base unit to precision conversion in-place in components

This puts us in a sane place for a follow-up PR to 
- remove the in-place precision conversion
- have DeFi take base units
and use precision amounts as *display only*, while never doing back and forth conversion 

## Notice

<!-- Before submitting a pull request, please make sure you have answered the following: -->

- [x] Have you followed the guidelines in our [Contributing]('https://github.com/shapeshift/web/blob/develop/CONTRIBUTING.md) guide?
- [x] Have you checked to ensure there aren't other open [Pull Requests](https://github.com/shapeshift/web/pulls) for the same update/change?

## Pull Request Type

- [ ] :bug: Bug fix (Non-breaking Change: Fixes an issue)
- [ ] :hammer_and_wrench: Chore (Non-breaking Change: Doc updates, pkg upgrades, typos, etc..)
- [x] :nail_care: New Feature (Breaking/Non-breaking Change)

## Issue (if applicable)

N/A

## Risk

<!-----------------------------------------------------------------------------
Outline the scope of your changes and the risk associated with them. You must use your discretion as an engineer to determine the potential impact of your changes.

E.g. an upgrade to `hdwallet` or core state management would be considered higher risk, and might require a full regression test. UI or isolated view changes, or something behind a feature flag may have near zero risk. Small bug fixes might require testing isolated to the specific fix.
------------------------------------------------------------------------------>

Low/medium - precision used could be the wrong one in some DeFi domain places

## Testing

<!-----------------------------------------------------------------------------
We treat every PR to be merged with the same scrutiny as if we were merging directly to production.

Your PR will not be merged if you do not complete the sections below for our engineering and operations teams to test.
------------------------------------------------------------------------------>

- DeFi modals amount show no regression, test all opportunities, all steps, test max withdraws are still working. Fiat amounts should still look the same, and inputting crypto/fiat should show no regression on the mirrored field
- DeFi cards/rows amounts should show no regression, over all opportunities
- DeFi earn balance/net worth should show no regression

### Engineering

<!-----------------------------------------------------------------------------
Include sufficient information here for an engineer to test your PR. This may include how to test locally, in a built environment, changes to infrastructure etc.
------------------------------------------------------------------------------>

- Precision amounts have been consistently removed

### Operations

☝🏽 

<!-----------------------------------------------------------------------------
If your changes have a user-facing impact, describe how a non-technical QA team can functionally test your changes in a preview environment.

If they are not user-facing please describe how to test for any regressions that may occur.
------------------------------------------------------------------------------>


## Screenshots (if applicable)