### PR TITLE
fix: promo banner light mode

### DIFF
--- a/src/components/Promo/PromoCard.tsx
+++ b/src/components/Promo/PromoCard.tsx
@@ -9,6 +9,7 @@ import { Carousel } from 'components/Carousel/Carousel'
 import { RawText } from 'components/Text'
 import { WalletActions } from 'context/WalletProvider/actions'
 import { useWallet } from 'hooks/useWallet/useWallet'
+
 dayjs.extend(isBetween)
 
 const promoData = [
@@ -72,8 +73,10 @@ export const PromoCard = () => {
               gap={2}
               pb={filteredPromoCards.length > 1 ? 8 : 6}
             >
-              <RawText fontWeight='bold'>{title}</RawText>
-              <RawText fontSize='sm' mr={24}>
+              <RawText fontWeight='bold' color={'whiteAlpha.900'}>
+                {title}
+              </RawText>
+              <RawText fontSize='sm' mr={24} color={'whiteAlpha.900'}>
                 {body}
               </RawText>
               <Button


### PR DESCRIPTION
## Description

Makes promo banner text visible in light mode.

## Notice

- [x] Have you followed the guidelines in our [Contributing]('https://github.com/shapeshift/web/blob/develop/CONTRIBUTING.md) guide?
- [x] Have you checked to ensure there aren't other open [Pull Requests](https://github.com/shapeshift/web/pulls) for the same update/change?

## Pull Request Type

- [x] :bug: Bug fix (Non-breaking Change: Fixes an issue)
- [ ] :hammer_and_wrench: Chore (Non-breaking Change: Doc updates, pkg upgrades, typos, etc..)
- [ ] :nail_care: New Feature (Breaking/Non-breaking Change)

## Issue (if applicable)

Closes https://github.com/shapeshift/web/issues/3429

## Risk

Almost literally zero.

## Testing

Promo banner text should be white, and visible, in light mode.

### Engineering

☝️ 

### Operations

☝️ 

## Screenshots (if applicable)

<img width="410" alt="Screenshot 2022-11-30 at 11 04 03 am" src="https://user-images.githubusercontent.com/97164662/204675322-cfe9dc37-ebf4-488e-b4a6-d83f45ec3f32.png">


