### PR TITLE
feat: no transfers filter on asset page

### DIFF
--- a/src/components/TransactionHistory/TransactionsGroupByDate.tsx
+++ b/src/components/TransactionHistory/TransactionsGroupByDate.tsx
@@ -4,8 +4,7 @@ import { useMemo } from 'react'
 import { TransactionDate } from 'components/TransactionHistoryRows/TransactionDate'
 import { TransactionRow } from 'components/TransactionHistoryRows/TransactionRow'
 import { useResizeObserver } from 'hooks/useResizeObserver/useResizeObserver'
-import { useRouteAssetId } from 'hooks/useRouteAssetId/useRouteAssetId'
-import { selectAssetById, selectTxDateByIds } from 'state/slices/selectors'
+import { selectTxDateByIds } from 'state/slices/selectors'
 import type { TxId } from 'state/slices/txHistorySlice/txHistorySlice'
 import { useAppSelector } from 'state/store'
 
@@ -23,9 +22,6 @@ export const TransactionsGroupByDate: React.FC<TransactionsGroupByDateProps> = (
   txIds,
   useCompactMode = false,
 }) => {
-  const assetId = useRouteAssetId()
-  const asset = useAppSelector(state => selectAssetById(state, assetId))
-
   const { setNode, entry } = useResizeObserver()
   const transactions = useAppSelector(state => selectTxDateByIds(state, txIds))
   const borderTopColor = useColorModeValue('gray.100', 'gray.750')
@@ -54,7 +50,6 @@ export const TransactionsGroupByDate: React.FC<TransactionsGroupByDateProps> = (
           <TransactionRow
             key={txId}
             txId={txId}
-            activeAsset={asset}
             useCompactMode={useCompactMode}
             showDateAndGuide={index === 0}
             parentWidth={entry?.contentRect.width ?? 360}
@@ -62,7 +57,7 @@ export const TransactionsGroupByDate: React.FC<TransactionsGroupByDateProps> = (
         ))}
       </Stack>
     ))
-  }, [asset, entry?.contentRect.width, txRows, useCompactMode])
+  }, [entry?.contentRect.width, txRows, useCompactMode])
 
   return (
     <Stack ref={setNode} divider={<StackDivider borderColor={borderTopColor} />}>

--- a/src/components/TransactionHistoryRows/TransactionRow.tsx
+++ b/src/components/TransactionHistoryRows/TransactionRow.tsx
@@ -25,7 +25,6 @@ export type TransactionRowProps = {
 
 export const TransactionRow = ({
   txId,
-  activeAsset,
   showDateAndGuide = false,
   useCompactMode = false,
   parentWidth,
@@ -40,7 +39,7 @@ export const TransactionRow = ({
   const toggleOpen = () => setIsOpen(!isOpen)
   const rowHoverBg = useColorModeValue('gray.100', 'gray.750')
   const borderColor = useColorModeValue('blackAlpha.100', 'whiteAlpha.100')
-  const txDetails = useTxDetails(txId, activeAsset)
+  const txDetails = useTxDetails(txId)
 
   const renderTransactionType = (
     txDetails: TxDetails,

--- a/src/hooks/useTxDetails/useTxDetails.test.ts
+++ b/src/hooks/useTxDetails/useTxDetails.test.ts
@@ -1,12 +1,11 @@
 import type { AssetId } from '@shapeshiftoss/caip'
 import type { MarketData } from '@shapeshiftoss/types'
 import { TradeType, TransferType } from '@shapeshiftoss/unchained-client'
-import { mockAssetState, usdc } from 'test/mocks/assets'
+import { mockAssetState } from 'test/mocks/assets'
 import { createMockEthTxs, EthReceive, EthSend, TradeTx } from 'test/mocks/txs'
 import { getTransfers, getTxType } from 'hooks/useTxDetails/useTxDetails'
 
-const [deposit, , withdrawUsdc] = createMockEthTxs('foo')
-
+const [deposit] = createMockEthTxs('foo')
 const marketData = {} as Record<AssetId, MarketData | undefined>
 
 describe('useTxDetails', () => {
@@ -40,11 +39,5 @@ describe('useTxDetails', () => {
     const transfers = getTransfers(unknown.transfers, mockAssetState().byId, marketData)
     const type = getTxType(unknown, transfers)
     expect(type).toEqual('unknown')
-  })
-
-  it('should filter transfers by active asset', () => {
-    const transfers = getTransfers(withdrawUsdc.transfers, mockAssetState().byId, marketData, usdc)
-    expect(transfers.length).toEqual(1)
-    expect(transfers[0].asset).toEqual(usdc)
   })
 })

--- a/src/hooks/useTxDetails/useTxDetails.ts
+++ b/src/hooks/useTxDetails/useTxDetails.ts
@@ -1,5 +1,6 @@
 import type { Asset } from '@shapeshiftoss/asset-service'
 import type { AssetId } from '@shapeshiftoss/caip'
+//import { fromAssetId } from '@shapeshiftoss/caip'
 import type { TxTransfer } from '@shapeshiftoss/chain-adapters'
 import type { MarketData } from '@shapeshiftoss/types'
 import type * as unchained from '@shapeshiftoss/unchained-client'
@@ -23,7 +24,7 @@ export type Fee = unchained.Fee & { asset: Asset; marketData: MarketData }
 export type TxType = unchained.TransferType | unchained.TradeType | 'method' | 'unknown'
 
 // Adding a new supported method?
-// Also update transactionRow.parser translations and TransactionContract.tsx
+// Also update transactionRow.parser translations and TransactionMethod.tsx
 export enum Method {
   Deposit = 'deposit',
   Approve = 'approve',
@@ -70,10 +71,8 @@ export const getTransfers = (
   transfers: TxTransfer[],
   assets: AssetsById,
   marketData: Record<AssetId, MarketData | undefined>,
-  activeAsset?: Asset,
 ): Transfer[] => {
   return transfers.reduce<Transfer[]>((prev, transfer) => {
-    if (activeAsset && activeAsset.assetId !== transfer.assetId) return prev
     const asset = assets[transfer.assetId]
     return [
       ...prev,
@@ -82,13 +81,13 @@ export const getTransfers = (
   }, [])
 }
 
-export const useTxDetails = (txId: string, activeAsset?: Asset): TxDetails => {
+export const useTxDetails = (txId: string): TxDetails => {
   const tx = useAppSelector((state: ReduxState) => selectTxById(state, txId))
   const assets = useAppSelector(selectAssets)
   const marketData = useAppSelector(selectMarketData)
   const transfers = useMemo(
-    () => getTransfers(tx.transfers, assets, marketData, activeAsset),
-    [tx.transfers, assets, marketData, activeAsset],
+    () => getTransfers(tx.transfers, assets, marketData),
+    [tx.transfers, assets, marketData],
   )
 
   const fee = useMemo(() => {

--- a/src/hooks/useTxDetails/useTxDetails.ts
+++ b/src/hooks/useTxDetails/useTxDetails.ts
@@ -1,6 +1,5 @@
 import type { Asset } from '@shapeshiftoss/asset-service'
 import type { AssetId } from '@shapeshiftoss/caip'
-//import { fromAssetId } from '@shapeshiftoss/caip'
 import type { TxTransfer } from '@shapeshiftoss/chain-adapters'
 import type { MarketData } from '@shapeshiftoss/types'
 import type * as unchained from '@shapeshiftoss/unchained-client'


### PR DESCRIPTION
## Description

Remove `assetId` filter on transfers array to show full transaction view on asset page.

## Notice

<!-- Before submitting a pull request, please make sure you have answered the following: -->

- [x] Have you followed the guidelines in our [Contributing]('https://github.com/shapeshift/web/blob/develop/CONTRIBUTING.md) guide?
- [x] Have you checked to ensure there aren't other open [Pull Requests](https://github.com/shapeshift/web/pulls) for the same update/change?

## Pull Request Type

- [ ] :bug: Bug fix (Non-breaking Change: Fixes an issue)
- [ ] :hammer_and_wrench: Chore (Non-breaking Change: Doc updates, pkg upgrades, typos, etc..)
- [x] :nail_care: New Feature (Breaking/Non-breaking Change)

## Issue (if applicable)

<!-----------------------------------------------------------------------------
If applicable, please link to the github issue and put `closes #XXXX` in your comment to auto-close the issue that your PR fixes.
------------------------------------------------------------------------------>

closes #

## Risk

Low

## Testing

Ensure new transaction view on asset page looks correct/better @shapeshift/product 

### Engineering

:point_up: 

### Operations

:point_up: 

## Screenshots (if applicable)

#### Ethereum Asset Page Example
*Before (Left) -> After (Right)*
![image](https://user-images.githubusercontent.com/35275952/205104364-c1a1575b-f882-4e0e-af58-16e038623d1a.png)
![image](https://user-images.githubusercontent.com/35275952/205104590-3bcd4c0c-a225-4ae5-bdcb-220b62f59776.png)
