### PR TITLE
fix: fix symbol for trade with insufficient fee error

### DIFF
--- a/src/components/Trade/TradeInput.tsx
+++ b/src/components/Trade/TradeInput.tsx
@@ -321,8 +321,7 @@ export const TradeInput = () => {
       return [
         'common.insufficientAmountForGas',
         {
-          assetSymbol:
-            sellTradeAsset?.asset?.symbol ?? translate('trade.errors.sellAssetMiddleSentence'),
+          assetSymbol: sellFeeAsset?.symbol ?? translate('trade.errors.sellAssetMiddleSentence'),
         },
       ]
     if (isBelowMinSellAmount) return ['trade.errors.amountTooSmall', { minLimit }]
@@ -340,7 +339,7 @@ export const TradeInput = () => {
     return 'trade.previewTrade'
   }, [
     bestTradeSwapper,
-    buyTradeAsset?.asset,
+    buyTradeAsset?.asset?.symbol,
     feeAssetBalance,
     feesExceedsSellAmount,
     hasValidSellAmount,
@@ -354,8 +353,10 @@ export const TradeInput = () => {
     sellAssetBalanceHuman,
     sellFeeAsset?.assetId,
     sellFeeAsset?.precision,
+    sellFeeAsset?.symbol,
     sellTradeAsset?.amount,
-    sellTradeAsset?.asset,
+    sellTradeAsset?.asset?.assetId,
+    sellTradeAsset?.asset?.symbol,
     translate,
     wallet,
     walletSupportsBuyAssetChain,


### PR DESCRIPTION
## Description

Fix the error message for insufficient gas so it uses the `sellFeeAsset` symbol when available, it currently erroneously uses the `sellTradeAsset` asset symbol.

## Notice

<!-- Before submitting a pull request, please make sure you have answered the following: -->

- [x] Have you followed the guidelines in our [Contributing]('https://github.com/shapeshift/web/blob/develop/CONTRIBUTING.md) guide?
- [x] Have you checked to ensure there aren't other open [Pull Requests](https://github.com/shapeshift/web/pulls) for the same update/change?

## Pull Request Type

- [x] :bug: Bug fix (Non-breaking Change: Fixes an issue)
- [ ] :hammer_and_wrench: Chore (Non-breaking Change: Doc updates, pkg upgrades, typos, etc..)
- [ ] :nail_care: New Feature (Breaking/Non-breaking Change)

## Issue (if applicable)

<!-----------------------------------------------------------------------------
If applicable, please link to the github issue and put `closes #XXXX` in your comment to auto-close the issue that your PR fixes.
------------------------------------------------------------------------------>

closes #

## Risk

None.

<!-----------------------------------------------------------------------------
Outline the scope of your changes and the risk associated with them. You must use your discretion as an engineer to determine the potential impact of your changes.

E.g. an upgrade to `hdwallet` or core state management would be considered higher risk, and might require a full regression test. UI or isolated view changes, or something behind a feature flag may have near zero risk. Small bug fixes might require testing isolated to the specific fix.
------------------------------------------------------------------------------>

## Testing

You need a wallet with (near) 0 balance for the chain's native asset (not enough to cover fees), but a non-zero balance for an other asset and attempt to trade it. It should display the native asset symbol in the error message about insufficient fees.

<!-----------------------------------------------------------------------------
We treat every PR to be merged with the same scrutiny as if we were merging directly to production.

Your PR will not be merged if you do not complete the sections below for our engineering and operations teams to test.
------------------------------------------------------------------------------>

### Engineering
☝️ 
<!-----------------------------------------------------------------------------
Include sufficient information here for an engineer to test your PR. This may include how to test locally, in a built environment, changes to infrastructure etc.
------------------------------------------------------------------------------>

### Operations
☝️ 
<!-----------------------------------------------------------------------------
If your changes have a user-facing impact, describe how a non-technical QA team can functionally test your changes in a preview environment.

If they are not user-facing please describe how to test for any regressions that may occur.
------------------------------------------------------------------------------>

## Screenshots (if applicable)
Both assets in this screenshot are on Avalanche and should use AVAX for fees (at least with a 0x route)

Before: 
![image](https://user-images.githubusercontent.com/88804546/205329595-62fb85aa-a58d-4a2d-a818-6860f48147e6.png)

After:
![image](https://user-images.githubusercontent.com/88804546/205329659-8bba7e53-7053-408d-84d8-ac7536d269cb.png)
