### PR TITLE
fix: foxy floating-point approvals

### DIFF
--- a/src/features/defi/providers/foxy/components/FoxyManager/Deposit/components/Approve.tsx
+++ b/src/features/defi/providers/foxy/components/FoxyManager/Deposit/components/Approve.tsx
@@ -118,7 +118,9 @@ export const Approve: React.FC<ApproveProps> = ({ accountId, onNext }) => {
         contractAddress,
         userAddress: accountAddress,
         wallet: walletState.wallet,
-        amount: bnOrZero(state?.deposit.cryptoAmount).times(`1e+${asset.precision}`).toString(),
+        amount: bn(
+          bnOrZero(state?.deposit.cryptoAmount).times(`1e+${asset.precision}`).integerValue(),
+        ).toString(),
         bip44Params,
       })
       await poll({

--- a/src/features/defi/providers/foxy/components/FoxyManager/Deposit/components/Approve.tsx
+++ b/src/features/defi/providers/foxy/components/FoxyManager/Deposit/components/Approve.tsx
@@ -119,7 +119,7 @@ export const Approve: React.FC<ApproveProps> = ({ accountId, onNext }) => {
         userAddress: accountAddress,
         wallet: walletState.wallet,
         amount: bn(
-          bnOrZero(state?.deposit.cryptoAmount).times(`1e+${asset.precision}`).integerValue(),
+          bnOrZero(state?.deposit.cryptoAmount).times(bn(10).pow(asset.precision)).integerValue(),
         ).toString(),
         bip44Params,
       })


### PR DESCRIPTION
## Description

This PR fixes FOXy approvals sometimes being passed to investor-foxy as floats, by ensuring we pass a stringified int-as-string vs. a float-as-string currently.

Note, this is only a temporary fix, and the incoming base unit refactor will allow us to have our cake (be safe from errors) and eat it (don't lose precision, by using base unit amounts retaining all precision instead of converting precision amounts to integers instead of )

## Notice

<!-- Before submitting a pull request, please make sure you have answered the following: -->

- [x] Have you followed the guidelines in our [Contributing]('https://github.com/shapeshift/web/blob/develop/CONTRIBUTING.md) guide?
- [x] Have you checked to ensure there aren't other open [Pull Requests](https://github.com/shapeshift/web/pulls) for the same update/change?

## Pull Request Type

- [x] :bug: Bug fix (Non-breaking Change: Fixes an issue)
- [ ] :hammer_and_wrench: Chore (Non-breaking Change: Doc updates, pkg upgrades, typos, etc..)
- [ ] :nail_care: New Feature (Breaking/Non-breaking Change)

## Issue (if applicable)

<!-----------------------------------------------------------------------------
If applicable, please link to the github issue and put `closes #XXXX` in your comment to auto-close the issue that your PR fixes.
------------------------------------------------------------------------------>

closes https://github.com/shapeshift/web/issues/3428

## Risk

<!-----------------------------------------------------------------------------
Outline the scope of your changes and the risk associated with them. You must use your discretion as an engineer to determine the potential impact of your changes.

E.g. an upgrade to `hdwallet` or core state management would be considered higher risk, and might require a full regression test. UI or isolated view changes, or something behind a feature flag may have near zero risk. Small bug fixes might require testing isolated to the specific fix.
------------------------------------------------------------------------------>

A loss of precision which might affect max. amounts in particular, but it's not really worse than what we have currently with our precision amounts

## Testing

<!-----------------------------------------------------------------------------
We treat every PR to be merged with the same scrutiny as if we were merging directly to production.

Your PR will not be merged if you do not complete the sections below for our engineering and operations teams to test.
------------------------------------------------------------------------------>

- Open the FOXy deposit modal
- Enter a fiat amount e.g 5$
- Select approve exact amount
- Ensure the MM window pops up instead of an app/console error

### Engineering

<!-----------------------------------------------------------------------------
Include sufficient information here for an engineer to test your PR. This may include how to test locally, in a built environment, changes to infrastructure etc.
------------------------------------------------------------------------------>

☝🏽 

### Operations

<!-----------------------------------------------------------------------------
If your changes have a user-facing impact, describe how a non-technical QA team can functionally test your changes in a preview environment.

If they are not user-facing please describe how to test for any regressions that may occur.
------------------------------------------------------------------------------>

☝🏽 

## Screenshots (if applicable)

#### This branch

<img width="1389" alt="image" src="https://user-images.githubusercontent.com/17035424/205769335-578cd9a0-b748-45aa-aa1d-dee5925659a6.png">

#### Prod

<img width="1117" alt="image" src="https://user-images.githubusercontent.com/17035424/205769456-9fd6d30c-9223-4ff7-8e2f-7119c157b0ba.png">
