### PR TITLE
chore: enable REACT_APP_FEATURE_OSMOSIS_SEND on develop

### DIFF
--- a/.env.develop
+++ b/.env.develop
@@ -45,3 +45,6 @@ REACT_APP_THORCHAIN_NODE_URL=https://dev-daemon.thorchain.shapeshift.com
 
 # thorchain
 REACT_APP_MIDGARD_URL=https://dev-indexer.thorchain.shapeshift.com/v2
+
+# Osmosis
+REACT_APP_FEATURE_OSMOSIS_SEND=true


### PR DESCRIPTION
## Description

Enable `REACT_APP_FEATURE_OSMOSIS_SEND` on `develop`.

## Notice

- [x] Have you followed the guidelines in our [Contributing]('https://github.com/shapeshift/web/blob/develop/CONTRIBUTING.md) guide?
- [x] Have you checked to ensure there aren't other open [Pull Requests](https://github.com/shapeshift/web/pulls) for the same update/change?

## Pull Request Type

- [ ] :bug: Bug fix (Non-breaking Change: Fixes an issue)
- [ ] :hammer_and_wrench: Chore (Non-breaking Change: Doc updates, pkg upgrades, typos, etc..)
- [x] :nail_care: New Feature (Breaking/Non-breaking Change)

## Issue (if applicable)

N/A

## Risk

Small, should only affect "Send" functionality of Osmosis.

## Testing

On develop.shapeshift.com, from the Osmosis asset page you should have able to use the "send" functionality for Osmosis.

No other Osmosis functionality should be enabled by turning on this flag.

### Engineering

☝️ 

### Operations

☝️ 

## Screenshots (if applicable)

<img width="886" alt="Screenshot 2022-12-06 at 1 34 35 pm" src="https://user-images.githubusercontent.com/97164662/206017188-c95f6bc6-6e51-463c-a9d9-be7b364122d5.png">