### PR TITLE
fix: incorrect URL for THORSwap trade confirm

### DIFF
--- a/src/components/Trade/TradeConfirm/TradeConfirm.tsx
+++ b/src/components/Trade/TradeConfirm/TradeConfirm.tsx
@@ -149,7 +149,6 @@ export const TradeConfirm = () => {
         name: trade?.sources[0]?.name,
         defaultExplorerBaseUrl: trade?.sellAsset?.explorerTxLink ?? '',
         tradeId: sellTradeId,
-        isOrder: true,
       }),
     [sellTradeId, trade],
   )

--- a/src/lib/getTxLink.ts
+++ b/src/lib/getTxLink.ts
@@ -19,16 +19,16 @@ export const getTxBaseUrl = ({ name, defaultExplorerBaseUrl, isOrder }: GetBaseU
     case SwapperName.CowSwap:
     case Dex.CowSwap:
       return isOrder ? 'https://explorer.cow.fi/orders/' : 'https://explorer.cow.fi/tx/'
-    case SwapperName.Thorchain:
     case Dex.Thor:
-      return 'https://v2.viewblock.io/thorchain/tx/'
+    case SwapperName.Thorchain:
+      return isOrder ? defaultExplorerBaseUrl : 'https://v2.viewblock.io/thorchain/tx/'
     default:
       return defaultExplorerBaseUrl
   }
 }
 
 export const getTxLink = ({ name, defaultExplorerBaseUrl, txId, tradeId }: GetTxLink): string => {
-  const id = txId || tradeId
+  const id = txId ?? tradeId
   const isOrder = !!tradeId
   const baseUrl = getTxBaseUrl({ name, defaultExplorerBaseUrl, isOrder })
   return `${baseUrl}${id}`


### PR DESCRIPTION
## Description

Fixes an issue where, for THORSwaps, on the confirm page we'd attempt to use the viewblock TX ULR for the trade confirm URL. At this stage we only have the outbound TX, not the THORSwap TX ID, to we instead need to use the sell asset's `defaultExplorerBaseUrl`.

## Notice

- [x] Have you followed the guidelines in our [Contributing]('https://github.com/shapeshift/web/blob/develop/CONTRIBUTING.md) guide?
- [x] Have you checked to ensure there aren't other open [Pull Requests](https://github.com/shapeshift/web/pulls) for the same update/change?

## Pull Request Type

- [x] :bug: Bug fix (Non-breaking Change: Fixes an issue)
- [ ] :hammer_and_wrench: Chore (Non-breaking Change: Doc updates, pkg upgrades, typos, etc..)
- [ ] :nail_care: New Feature (Breaking/Non-breaking Change)

## Issue (if applicable)

N/A - an existing prod bug that came up during release testing.

https://discord.com/channels/554694662431178782/1049819884986572880/1049843176459993168

## Risk

Could break TX links across the board if incorrectly implemented, but very unlikely.

## Testing

When doing a THORSwap, say ETH -> BCH we should use the sell asset's `defaultExplorerBaseUrl` to generate the link shown on the trade confirm page. In this case, an Etherscan link will be generated.

### Engineering

☝️ 

### Operations

☝️ 

## Screenshots (if applicable)

N/A