### PR TITLE
chore: add and use assertIsFoxEthStakingContractAddress type guard assertion and helper

### DIFF
--- a/src/features/defi/providers/fox-farming/components/FoxFarmingManager/Deposit/components/Approve.tsx
+++ b/src/features/defi/providers/fox-farming/components/FoxFarmingManager/Deposit/components/Approve.tsx
@@ -19,7 +19,7 @@ import { bn, bnOrZero } from 'lib/bignumber/bignumber'
 import { logger } from 'lib/logger'
 import { poll } from 'lib/poll/poll'
 import { isSome } from 'lib/utils'
-import { isFoxEthStakingContractAddress } from 'state/slices/opportunitiesSlice/constants'
+import { assertIsFoxEthStakingContractAddress } from 'state/slices/opportunitiesSlice/constants'
 import { selectAssetById, selectMarketDataById } from 'state/slices/selectors'
 import { useAppSelector } from 'state/store'
 
@@ -41,9 +41,7 @@ export const Approve: React.FC<FoxFarmingApproveProps> = ({ accountId, onNext })
   const { chainId, contractAddress } = query
   const opportunity = state?.opportunity
 
-  if (!isFoxEthStakingContractAddress(contractAddress)) {
-    throw new Error("Contract address isn't a known ETH/FOX staking address")
-  }
+  assertIsFoxEthStakingContractAddress(contractAddress)
 
   const { allowance, approve, getStakeGasData } = useFoxFarming(contractAddress)
 

--- a/src/features/defi/providers/fox-farming/components/FoxFarmingManager/Deposit/components/Confirm.tsx
+++ b/src/features/defi/providers/fox-farming/components/FoxFarmingManager/Deposit/components/Confirm.tsx
@@ -21,7 +21,7 @@ import { useBrowserRouter } from 'hooks/useBrowserRouter/useBrowserRouter'
 import { useWallet } from 'hooks/useWallet/useWallet'
 import { bnOrZero } from 'lib/bignumber/bignumber'
 import { logger } from 'lib/logger'
-import { isFoxEthStakingContractAddress } from 'state/slices/opportunitiesSlice/constants'
+import { assertIsFoxEthStakingContractAddress } from 'state/slices/opportunitiesSlice/constants'
 import {
   selectAssetById,
   selectMarketDataById,
@@ -45,9 +45,7 @@ export const Confirm: React.FC<StepComponentProps & { accountId: AccountId | und
   const { query } = useBrowserRouter<DefiQueryParams, DefiParams>()
   const { contractAddress, assetReference } = query
 
-  if (!isFoxEthStakingContractAddress(contractAddress)) {
-    throw new Error("Contract address isn't a known ETH/FOX staking address")
-  }
+  assertIsFoxEthStakingContractAddress(contractAddress)
 
   const { stake } = useFoxFarming(contractAddress)
   const opportunity = state?.opportunity

--- a/src/features/defi/providers/fox-farming/components/FoxFarmingManager/Deposit/components/Deposit.tsx
+++ b/src/features/defi/providers/fox-farming/components/FoxFarmingManager/Deposit/components/Deposit.tsx
@@ -20,8 +20,8 @@ import { useBrowserRouter } from 'hooks/useBrowserRouter/useBrowserRouter'
 import { bn, bnOrZero } from 'lib/bignumber/bignumber'
 import { logger } from 'lib/logger'
 import {
+  assertIsFoxEthStakingContractAddress,
   foxEthLpAssetId,
-  isFoxEthStakingContractAddress,
 } from 'state/slices/opportunitiesSlice/constants'
 import {
   selectAssetById,
@@ -64,9 +64,7 @@ export const Deposit: React.FC<DepositProps> = ({
 
   const { getLpTokenPrice } = useFoxEthLiquidityPool(accountId)
 
-  if (!isFoxEthStakingContractAddress(contractAddress)) {
-    throw new Error("Contract address isn't a known ETH/FOX staking address")
-  }
+  assertIsFoxEthStakingContractAddress(contractAddress)
 
   const {
     allowance: foxFarmingAllowance,

--- a/src/features/defi/providers/fox-farming/components/FoxFarmingManager/Overview/Claim/ClaimConfirm.tsx
+++ b/src/features/defi/providers/fox-farming/components/FoxFarmingManager/Overview/Claim/ClaimConfirm.tsx
@@ -24,7 +24,7 @@ import { useFoxEth } from 'context/FoxEthProvider/FoxEthProvider'
 import { useWallet } from 'hooks/useWallet/useWallet'
 import { bnOrZero } from 'lib/bignumber/bignumber'
 import { logger } from 'lib/logger'
-import { isFoxEthStakingContractAddress } from 'state/slices/opportunitiesSlice/constants'
+import { assertIsFoxEthStakingContractAddress } from 'state/slices/opportunitiesSlice/constants'
 import { selectAssetById, selectMarketDataById } from 'state/slices/selectors'
 import { useAppSelector } from 'state/store'
 
@@ -54,9 +54,7 @@ export const ClaimConfirm = ({
   const [canClaim, setCanClaim] = useState<boolean>(false)
   const { state: walletState } = useWallet()
 
-  if (!isFoxEthStakingContractAddress(contractAddress)) {
-    throw new Error("Contract address isn't a known ETH/FOX staking address")
-  }
+  assertIsFoxEthStakingContractAddress(contractAddress)
 
   const { claimRewards, getClaimGasData, foxFarmingContract } = useFoxFarming(contractAddress)
   const translate = useTranslate()

--- a/src/features/defi/providers/fox-farming/components/FoxFarmingManager/Withdraw/components/Approve.tsx
+++ b/src/features/defi/providers/fox-farming/components/FoxFarmingManager/Withdraw/components/Approve.tsx
@@ -20,7 +20,7 @@ import { bn, bnOrZero } from 'lib/bignumber/bignumber'
 import { logger } from 'lib/logger'
 import { poll } from 'lib/poll/poll'
 import { isSome } from 'lib/utils'
-import { isFoxEthStakingContractAddress } from 'state/slices/opportunitiesSlice/constants'
+import { assertIsFoxEthStakingContractAddress } from 'state/slices/opportunitiesSlice/constants'
 import { selectAssetById, selectMarketDataById } from 'state/slices/selectors'
 import { useAppSelector } from 'state/store'
 
@@ -41,9 +41,7 @@ export const Approve: React.FC<ApproveProps> = ({ accountId, onNext }) => {
   const { chainId, contractAddress, rewardId } = query
   const opportunity = state?.opportunity
 
-  if (!isFoxEthStakingContractAddress(contractAddress)) {
-    throw new Error("Contract address isn't a known ETH/FOX staking address")
-  }
+  assertIsFoxEthStakingContractAddress(contractAddress)
 
   const { allowance, approve, getUnstakeGasData } = useFoxFarming(contractAddress)
   const toast = useToast()

--- a/src/features/defi/providers/fox-farming/components/FoxFarmingManager/Withdraw/components/Confirm.tsx
+++ b/src/features/defi/providers/fox-farming/components/FoxFarmingManager/Withdraw/components/Confirm.tsx
@@ -21,7 +21,7 @@ import { useBrowserRouter } from 'hooks/useBrowserRouter/useBrowserRouter'
 import { useWallet } from 'hooks/useWallet/useWallet'
 import { bnOrZero } from 'lib/bignumber/bignumber'
 import { logger } from 'lib/logger'
-import { isFoxEthStakingContractAddress } from 'state/slices/opportunitiesSlice/constants'
+import { assertIsFoxEthStakingContractAddress } from 'state/slices/opportunitiesSlice/constants'
 import {
   selectAssetById,
   selectMarketDataById,
@@ -45,9 +45,7 @@ export const Confirm: React.FC<ConfirmProps> = ({ accountId, onNext }) => {
   const { chainId, contractAddress, rewardId } = query
   const opportunity = state?.opportunity
 
-  if (!isFoxEthStakingContractAddress(contractAddress)) {
-    throw new Error("Contract address isn't a known ETH/FOX staking address")
-  }
+  assertIsFoxEthStakingContractAddress(contractAddress)
 
   const { unstake } = useFoxFarming(contractAddress)
   const { onOngoingFarmingTxIdChange } = useFoxEth()

--- a/src/features/defi/providers/fox-farming/components/FoxFarmingManager/Withdraw/components/ExpiredWithdraw.tsx
+++ b/src/features/defi/providers/fox-farming/components/FoxFarmingManager/Withdraw/components/ExpiredWithdraw.tsx
@@ -18,7 +18,7 @@ import { useFoxEth } from 'context/FoxEthProvider/FoxEthProvider'
 import { useBrowserRouter } from 'hooks/useBrowserRouter/useBrowserRouter'
 import { bn, bnOrZero } from 'lib/bignumber/bignumber'
 import { logger } from 'lib/logger'
-import { isFoxEthStakingContractAddress } from 'state/slices/opportunitiesSlice/constants'
+import { assertIsFoxEthStakingContractAddress } from 'state/slices/opportunitiesSlice/constants'
 import { selectAssetById, selectAssets, selectMarketDataById } from 'state/slices/selectors'
 import { useAppSelector } from 'state/store'
 
@@ -35,9 +35,7 @@ export const ExpiredWithdraw: React.FC<StepComponentProps> = ({ onNext }) => {
   const { contractAddress } = query
   const opportunity = state?.opportunity
 
-  if (!isFoxEthStakingContractAddress(contractAddress)) {
-    throw new Error("Contract address isn't a known ETH/FOX staking address")
-  }
+  assertIsFoxEthStakingContractAddress(contractAddress)
 
   const { getUnstakeGasData, allowance, getApproveGasData } = useFoxFarming(contractAddress)
   const { setFarmingAccountId: handleFarmingAccountIdChange } = useFoxEth()

--- a/src/features/defi/providers/fox-farming/components/FoxFarmingManager/Withdraw/components/Withdraw.tsx
+++ b/src/features/defi/providers/fox-farming/components/FoxFarmingManager/Withdraw/components/Withdraw.tsx
@@ -15,7 +15,7 @@ import type { StepComponentProps } from 'components/DeFi/components/Steps'
 import { useBrowserRouter } from 'hooks/useBrowserRouter/useBrowserRouter'
 import { bn, bnOrZero } from 'lib/bignumber/bignumber'
 import { logger } from 'lib/logger'
-import { isFoxEthStakingContractAddress } from 'state/slices/opportunitiesSlice/constants'
+import { assertIsFoxEthStakingContractAddress } from 'state/slices/opportunitiesSlice/constants'
 import { serializeUserStakingId, toOpportunityId } from 'state/slices/opportunitiesSlice/utils'
 import {
   selectAssetById,
@@ -57,9 +57,7 @@ export const Withdraw: React.FC<WithdrawProps> = ({
     }),
   )
 
-  if (!isFoxEthStakingContractAddress(contractAddress)) {
-    throw new Error("Contract address isn't a known ETH/FOX staking address")
-  }
+  assertIsFoxEthStakingContractAddress(contractAddress)
 
   const { getUnstakeGasData, allowance, getApproveGasData } = useFoxFarming(contractAddress)
 

--- a/src/lib/utils.ts
+++ b/src/lib/utils.ts
@@ -105,3 +105,9 @@ export const deepUpsertArray = <T>(
   if (!level1) level1 = data[level1Key] = {}
   level1[level2Key] = union(level1[level2Key] ?? [], [value])
 }
+
+export const getTypeGuardAssertion =
+  <T, U>(typeGuard: (maybeT: T | U) => maybeT is T, message: string) =>
+  (value: T | U): asserts value is T => {
+    if (!typeGuard(value)) throw new Error(`${message}: ${value}`)
+  }

--- a/src/state/slices/opportunitiesSlice/constants.ts
+++ b/src/state/slices/opportunitiesSlice/constants.ts
@@ -45,7 +45,7 @@ export const assertIsFoxEthStakingContractAddress: (
   value: FoxEthStakingContractAddress | string,
 ) => asserts value is FoxEthStakingContractAddress = getTypeGuardAssertion(
   isFoxEthStakingContractAddress,
-  "assertIsFoxEthStakingContractAddress: Contract address isn't a known ETH/FOX staking address",
+  "Contract address isn't a known ETH/FOX staking address",
 )
 
 // Staking contracts as flavored StakingIds

--- a/src/state/slices/opportunitiesSlice/constants.ts
+++ b/src/state/slices/opportunitiesSlice/constants.ts
@@ -2,6 +2,7 @@ import type { AssetId } from '@shapeshiftoss/caip'
 import { ethAssetId, ethChainId, foxAssetId, fromAssetId } from '@shapeshiftoss/caip'
 import { DefiProvider, DefiType } from 'features/defi/contexts/DefiManagerProvider/DefiCommon'
 import type { EarnOpportunityType } from 'features/defi/helpers/normalizeOpportunity'
+import { getTypeGuardAssertion } from 'lib/utils'
 
 import type { LpId, StakingId } from './types'
 
@@ -35,10 +36,17 @@ export const foxEthStakingContractAddresses = [
 
 export type FoxEthStakingContractAddress = typeof foxEthStakingContractAddresses[number]
 
-export const isFoxEthStakingContractAddress = (
-  address: string,
+const isFoxEthStakingContractAddress = (
+  address: FoxEthStakingContractAddress | string,
 ): address is FoxEthStakingContractAddress =>
   foxEthStakingContractAddresses.includes(address as FoxEthStakingContractAddress)
+
+export const assertIsFoxEthStakingContractAddress: (
+  value: FoxEthStakingContractAddress | string,
+) => asserts value is FoxEthStakingContractAddress = getTypeGuardAssertion(
+  isFoxEthStakingContractAddress,
+  "assertIsFoxEthStakingContractAddress: Contract address isn't a known ETH/FOX staking address",
+)
 
 // Staking contracts as flavored StakingIds
 export const foxEthStakingAssetIdV1: StakingId =

--- a/src/state/slices/opportunitiesSlice/resolvers/foxFarming/index.ts
+++ b/src/state/slices/opportunitiesSlice/resolvers/foxFarming/index.ts
@@ -21,12 +21,12 @@ import { selectPortfolioLoadingStatusGranular } from 'state/slices/portfolioSlic
 import { selectMarketDataById, selectPortfolioAccountBalances } from 'state/slices/selectors'
 
 import {
+  assertIsFoxEthStakingContractAddress,
   foxEthLpAssetId,
   foxEthLpAssetIds,
   foxEthLpContractAddress,
   foxEthPair,
   foxEthStakingIds,
-  isFoxEthStakingContractAddress,
   LP_EARN_OPPORTUNITIES,
   STAKING_ID_TO_VERSION,
 } from '../../constants'
@@ -154,9 +154,7 @@ export const foxFarmingStakingMetadataResolver = async ({
   }
 
   const ethersProvider = getEthersProvider()
-  if (!isFoxEthStakingContractAddress(contractAddress)) {
-    throw new Error("Contract address isn't a known ETH/FOX staking address")
-  }
+  assertIsFoxEthStakingContractAddress(contractAddress)
   const foxFarmingContract = getOrCreateContract(contractAddress)
   const uniV2LPContract = getOrCreateContract(foxEthLpContractAddress)
 
@@ -272,9 +270,7 @@ export const foxFarmingStakingUserDataResolver = async ({
     throw new Error(`Market data not ready for ${foxEthLpAssetId}`)
   }
 
-  if (!isFoxEthStakingContractAddress(contractAddress)) {
-    throw new Error("Contract address isn't a known ETH/FOX staking address")
-  }
+  assertIsFoxEthStakingContractAddress(contractAddress)
 
   const foxFarmingContract = getOrCreateContract(contractAddress)
 


### PR DESCRIPTION
## Description

- Use a type guard assertion to narrow to `FoxEthStakingContractAddress`
- Add a `getTypeGuardAssertion` convenience util to encourage more usage of this pattern moving forward

## Notice

- [x] Have you followed the guidelines in our [Contributing]('https://github.com/shapeshift/web/blob/develop/CONTRIBUTING.md) guide?
- [x] Have you checked to ensure there aren't other open [Pull Requests](https://github.com/shapeshift/web/pulls) for the same update/change?

## Pull Request Type

- [ ] :bug: Bug fix (Non-breaking Change: Fixes an issue)
- [x] :hammer_and_wrench: Chore (Non-breaking Change: Doc updates, pkg upgrades, typos, etc..)
- [ ] :nail_care: New Feature (Breaking/Non-breaking Change)

## Issue (if applicable)

N/A - codebase quality.

## Risk

Minimal - no run-time changes expected.

## Testing

Not applicable - no runtime changes expected.

### Engineering

☝️ 

### Operations

☝️ 

## Screenshots (if applicable)

N/A