### PR TITLE
chore: remove setupFiles config

### DIFF
--- a/package.json
+++ b/package.json
@@ -48,9 +48,6 @@
     "collectCoverageFrom": [],
     "coveragePathIgnorePatterns": [
       "./src/env"
-    ],
-    "setupFiles": [
-      "./src/test/setupGlobalMocks.ts"
     ]
   },
   "browserslist": {

--- a/src/test/setupGlobalMocks.ts
+++ b/src/test/setupGlobalMocks.ts
@@ -1,7 +1,0 @@
-jest.mock('@shapeshiftoss/market-service', () => ({
-  findAll: jest.fn,
-  findByAssetId: jest.fn,
-  findPriceHistoryByAssetId: jest.fn,
-}))
-
-export {}


### PR DESCRIPTION
## Description

Currently when attempting to run tests in an IDE we get an error due to the use of configuration not unsupported by Create React App:

```
These options in your package.json Jest configuration are not currently supported by Create React App:

  • setupFiles

If you wish to override other Jest options, you need to eject from the default setup. You can do so by running npm run eject but remember that this is a one-way operation. You may also file an issue with Create React App to discuss supporting more options out of the box.
```

This PR removes the offending config, which wasn't used or needed anyway.

Tests running in an IDE are great again.

<img width="630" alt="Screenshot 2022-12-06 at 9 43 44 pm" src="https://user-images.githubusercontent.com/97164662/206090454-54ec5d57-7d1e-424e-95cf-4d759b10efe2.png">


## Notice

- [x] Have you followed the guidelines in our [Contributing]('https://github.com/shapeshift/web/blob/develop/CONTRIBUTING.md) guide?
- [x] Have you checked to ensure there aren't other open [Pull Requests](https://github.com/shapeshift/web/pulls) for the same update/change?

## Pull Request Type

- [ ] :bug: Bug fix (Non-breaking Change: Fixes an issue)
- [x] :hammer_and_wrench: Chore (Non-breaking Change: Doc updates, pkg upgrades, typos, etc..)
- [ ] :nail_care: New Feature (Breaking/Non-breaking Change)

## Issue (if applicable)

N/A

## Risk

Small - if the tests pass we are 🛍️ 

## Testing

CI should pass.

### Engineering

☝️ 

### Operations

☝️ 

## Screenshots (if applicable)

N/A