### PR TITLE
fix: rework the trade page routing

### DIFF
--- a/src/Routes/RoutesCommon.tsx
+++ b/src/Routes/RoutesCommon.tsx
@@ -159,7 +159,7 @@ export const routes: NestedRoute[] = [
     routes: [
       {
         label: 'Trade Asset',
-        path: '/:assetId',
+        path: '/:chainId/:assetSubId',
         main: Trade,
         hide: true,
       },

--- a/src/components/AssetHeader/AssetActions.tsx
+++ b/src/components/AssetHeader/AssetActions.tsx
@@ -7,7 +7,7 @@ import { useCallback, useEffect, useMemo, useState } from 'react'
 import { FaCreditCard } from 'react-icons/fa'
 import { IoSwapVertical } from 'react-icons/io5'
 import { useTranslate } from 'react-polyglot'
-import { generatePath, Link } from 'react-router-dom'
+import { useHistory } from 'react-router-dom'
 import { FiatRampAction } from 'components/Modals/FiatRamps/FiatRampsCommon'
 import { getChainAdapterManager } from 'context/PluginProvider/chainAdapterSingleton'
 import { WalletActions } from 'context/WalletProvider/actions'
@@ -27,6 +27,7 @@ type AssetActionProps = {
 
 export const AssetActions: React.FC<AssetActionProps> = ({ assetId, accountId, cryptoBalance }) => {
   const isOsmosisSendEnabled = useFeatureFlag('OsmosisSend')
+  const history = useHistory()
 
   const [isValidChainId, setIsValidChainId] = useState(true)
   const chainAdapterManager = getChainAdapterManager()
@@ -37,7 +38,6 @@ export const AssetActions: React.FC<AssetActionProps> = ({ assetId, accountId, c
     dispatch,
   } = useWallet()
   const asset = useAppSelector(state => selectAssetById(state, assetId))
-  const tradeAssetLink = generatePath('/trade/:assetId', { assetId })
   const filter = useMemo(() => ({ assetId }), [assetId])
   const assetSupportsBuy = useAppSelector(s => selectSupportsFiatRampByAssetId(s, filter))
 
@@ -76,17 +76,19 @@ export const AssetActions: React.FC<AssetActionProps> = ({ assetId, accountId, c
       flex={1}
     >
       <Flex direction='row' gap={2} flexWrap='wrap'>
-        <Button
-          data-test='asset-action-trade'
-          display={{ base: 'auto', md: 'none' }}
-          flex={{ base: 1, md: 'auto' }}
-          leftIcon={<IoSwapVertical />}
-          size='sm-multiline'
-          width={{ base: '100%', md: 'auto' }}
-          isDisabled={!isValidChainId}
-        >
-          <Link to={tradeAssetLink}>{translate('assets.assetCards.assetActions.trade')}</Link>
-        </Button>
+        {isValidChainId && (
+          <Button
+            data-test='asset-action-trade'
+            flex={{ base: 1, md: 'auto' }}
+            leftIcon={<IoSwapVertical />}
+            size='sm-multiline'
+            width={{ base: '100%', md: 'auto' }}
+            onClick={() => history.push(`/trade/${assetId}`)}
+          >
+            {translate('assets.assetCards.assetActions.trade')}
+          </Button>
+        )}
+
         <Button
           data-test='asset-action-buy-sell'
           width={{ base: 'full', md: 'auto' }}

--- a/src/components/Breadcrumbs/Breadcrumbs.tsx
+++ b/src/components/Breadcrumbs/Breadcrumbs.tsx
@@ -54,14 +54,14 @@ const routes: BreadcrumbsRoute[] = [
   {
     path: '/trade',
     breadcrumb: 'Trade',
-    routes: [{ path: '/trade/:assetId', breadcrumb: GetAssetName }],
+    routes: [{ path: '/trade/:chainId/:assetSubId', breadcrumb: GetAssetName }],
   },
   { path: '/assets/:chainId/:assetSubId', breadcrumb: GetAssetName },
   { path: '*', breadcrumb: GetTranslatedPathPart },
 ]
 
 const options = {
-  excludePaths: ['/assets/:chainId'],
+  excludePaths: ['/assets/:chainId', '/trade/:chainId'],
 }
 
 export const Breadcrumbs = withBreadcrumbs(

--- a/src/pages/Trade/Trade.tsx
+++ b/src/pages/Trade/Trade.tsx
@@ -1,4 +1,7 @@
 import { Box, Container, Heading, Stack, useColorModeValue } from '@chakra-ui/react'
+import type { AssetId } from '@shapeshiftoss/caip'
+import { ethAssetId } from '@shapeshiftoss/caip'
+import { useEffect, useState } from 'react'
 import { useTranslate } from 'react-polyglot'
 import { useParams } from 'react-router'
 import { Main } from 'components/Layout/Main'
@@ -8,7 +11,8 @@ import { RecentTransactions } from 'pages/Dashboard/RecentTransactions'
 import { TradeCard } from 'pages/Dashboard/TradeCard'
 
 type MatchParams = {
-  assetId?: string
+  chainId?: string
+  assetSubId?: string
 }
 
 const TradeHeader = () => {
@@ -22,13 +26,20 @@ const TradeHeader = () => {
 }
 
 export const Trade = () => {
-  const { assetId } = useParams<MatchParams>()
-  const parsedAssetId = assetId ? decodeURIComponent(assetId) : undefined
+  const { chainId, assetSubId } = useParams<MatchParams>()
+  const [passedAssetId, setPassedAssetId] = useState<AssetId>(ethAssetId)
   const {
     state: { isDemoWallet },
   } = useWallet()
   const top = isDemoWallet ? '7rem' : '4.5rem'
   const borderColor = useColorModeValue('gray.100', 'gray.750')
+  useEffect(() => {
+    // Auto select asset when passed in via params
+    if (chainId && assetSubId) {
+      const assetId = `${chainId}/${assetSubId}`
+      setPassedAssetId(assetId)
+    }
+  }, [assetSubId, chainId])
   return (
     <Main py={0} px={0} display='flex' flex={1} width='full' titleComponent={<TradeHeader />}>
       <Stack
@@ -69,7 +80,7 @@ export const Trade = () => {
             position='relative'
             zIndex='2'
           >
-            <TradeCard defaultBuyAssetId={parsedAssetId} />
+            <TradeCard defaultBuyAssetId={passedAssetId} />
           </Container>
         </Box>
         <Stack


### PR DESCRIPTION
## Description

- The assetIds have slashes in them so we needed to break that up into two params on the route.
- Update the breadcrumbs to filter out the chainId on trade page
- Was seeing the `Link` component would intermittently work so went ahead and just used `history.push()`

Note: we do not currently have a way to check if an asset is supported for buy/sell. Talked to @0xApotheosis about how we can abstract out that logic and use it in other places in the app. 

The other thing thats worth mentioning --- when clicking the trade button on an asset page you would expect it to fill the `sell` side of the trade and not the `buy` but we only support setting the default buy asset ATM. So at some point would be good to get the other side too.

## Notice

<!-- Before submitting a pull request, please make sure you have answered the following: -->

- [x] Have you followed the guidelines in our [Contributing]('https://github.com/shapeshift/web/blob/develop/CONTRIBUTING.md) guide?
- [x] Have you checked to ensure there aren't other open [Pull Requests](https://github.com/shapeshift/web/pulls) for the same update/change?

## Pull Request Type

- [x] :bug: Bug fix (Non-breaking Change: Fixes an issue)
- [ ] :hammer_and_wrench: Chore (Non-breaking Change: Doc updates, pkg upgrades, typos, etc..)
- [ ] :nail_care: New Feature (Breaking/Non-breaking Change)

## Issue (if applicable)

<!-----------------------------------------------------------------------------
If applicable, please link to the github issue and put `closes #XXXX` in your comment to auto-close the issue that your PR fixes.
------------------------------------------------------------------------------>

closes #3482 

## Risk

<!-----------------------------------------------------------------------------
Outline the scope of your changes and the risk associated with them. You must use your discretion as an engineer to determine the potential impact of your changes.

E.g. an upgrade to `hdwallet` or core state management would be considered higher risk, and might require a full regression test. UI or isolated view changes, or something behind a feature flag may have near zero risk. Small bug fixes might require testing isolated to the specific fix.
------------------------------------------------------------------------------>

No more risk than the current deployment

## Testing

<!-----------------------------------------------------------------------------
We treat every PR to be merged with the same scrutiny as if we were merging directly to production.

Your PR will not be merged if you do not complete the sections below for our engineering and operations teams to test.
------------------------------------------------------------------------------>

### Engineering

<!-----------------------------------------------------------------------------
Include sufficient information here for an engineer to test your PR. This may include how to test locally, in a built environment, changes to infrastructure etc.
------------------------------------------------------------------------------>

### Operations

<!-----------------------------------------------------------------------------
If your changes have a user-facing impact, describe how a non-technical QA team can functionally test your changes in a preview environment.

If they are not user-facing please describe how to test for any regressions that may occur.
------------------------------------------------------------------------------>

Select an asset from the dashboard -- click on the trade button, you should see that asset now preselected on the buy side of the trade. We do not currently have a way to check if it's a supported asset for trade, so it's possible you will get the default trade pair if the asset you selected is not supported for buying.

## Screenshots (if applicable)
