### PR TITLE
feat: buy-sell button only for supported assets

### DIFF
--- a/src/assets/translations/en/main.json
+++ b/src/assets/translations/en/main.json
@@ -84,7 +84,7 @@
     "pageNotFound": "The page you're looking for cannot be found",
     "buySell": "Buy/Sell",
     "all": "All",
-    "viewAll": "View All",
+    "viewAll": "View All"
   },
   "errorPage": {
     "title": "Oops!",

--- a/src/assets/translations/en/main.json
+++ b/src/assets/translations/en/main.json
@@ -82,8 +82,7 @@
     "enterAmount": "Enter Amount",
     "pageNotFound": "The page you're looking for cannot be found",
     "buySell": "Buy/Sell",
-    "viewAll": "View All",
-    "buySellAsset": "Buy/Sell %{symbol}"
+    "viewAll": "View All"
   },
   "errorPage": {
     "title": "Oops!",

--- a/src/components/AssetHeader/AssetActions.tsx
+++ b/src/components/AssetHeader/AssetActions.tsx
@@ -89,18 +89,18 @@ export const AssetActions: React.FC<AssetActionProps> = ({ assetId, accountId, c
           </Button>
         )}
 
-        <Button
-          data-test='asset-action-buy-sell'
-          width={{ base: 'full', md: 'auto' }}
-          flex={{ base: 1, md: 'auto' }}
-          onClick={handleBuySellClick}
-          leftIcon={<FaCreditCard />}
-          size='sm-multiline'
-        >
-          {assetSupportsBuy
-            ? translate('common.buySellAsset', { symbol: asset.symbol })
-            : translate('common.buySell')}
-        </Button>
+        {assetSupportsBuy && (
+          <Button
+            data-test='asset-action-buy-sell'
+            width={{ base: 'full', md: 'auto' }}
+            flex={{ base: 1, md: 'auto' }}
+            onClick={handleBuySellClick}
+            leftIcon={<FaCreditCard />}
+            size='sm-multiline'
+          >
+            {translate('common.buySell')}
+          </Button>
+        )}
       </Flex>
       <Flex direction='row' gap={2} flexWrap='wrap'>
         <Button


### PR DESCRIPTION
## Description

- Buy/Sell button in `AssetActions` only displayed for asset which are supported by our fiat ramps.
- Removal of the symbol in the button as it is implied by the context (with other asset actions). Not listed in the related issue but discussed/requested by @reallybeard

<!-- Please describe your changes -->

## Notice

<!-- Before submitting a pull request, please make sure you have answered the following: -->

- [x] Have you followed the guidelines in our [Contributing]('https://github.com/shapeshift/web/blob/develop/CONTRIBUTING.md) guide?
- [x] Have you checked to ensure there aren't other open [Pull Requests](https://github.com/shapeshift/web/pulls) for the same update/change?

## Pull Request Type

- [ ] :bug: Bug fix (Non-breaking Change: Fixes an issue)
- [ ] :hammer_and_wrench: Chore (Non-breaking Change: Doc updates, pkg upgrades, typos, etc..)
- [x] :nail_care: New Feature (Breaking/Non-breaking Change)

## Issue (if applicable)

<!-----------------------------------------------------------------------------
If applicable, please link to the github issue and put `closes #XXXX` in your comment to auto-close the issue that your PR fixes.
------------------------------------------------------------------------------>

closes #3490 

## Risk
 
None.

<!-----------------------------------------------------------------------------
Outline the scope of your changes and the risk associated with them. You must use your discretion as an engineer to determine the potential impact of your changes.

E.g. an upgrade to `hdwallet` or core state management would be considered higher risk, and might require a full regression test. UI or isolated view changes, or something behind a feature flag may have near zero risk. Small bug fixes might require testing isolated to the specific fix.
------------------------------------------------------------------------------>

## Testing

Verify the presence/absence of the `Buy/Sell` button on Asset and Account/Asset pages based on the support the asset has on our fiat ramps.

<!-----------------------------------------------------------------------------
We treat every PR to be merged with the same scrutiny as if we were merging directly to production.

Your PR will not be merged if you do not complete the sections below for our engineering and operations teams to test.
------------------------------------------------------------------------------>

### Engineering
☝️ 

<!-----------------------------------------------------------------------------
Include sufficient information here for an engineer to test your PR. This may include how to test locally, in a built environment, changes to infrastructure etc.
------------------------------------------------------------------------------>

### Operations
☝️ 
<!-----------------------------------------------------------------------------
If your changes have a user-facing impact, describe how a non-technical QA team can functionally test your changes in a preview environment.

If they are not user-facing please describe how to test for any regressions that may occur.
------------------------------------------------------------------------------>

## Screenshots (if applicable)

Asset supported by fiat ramp (note: no more symbol displayed in the button):
![image](https://user-images.githubusercontent.com/88804546/206287614-8ce888f8-3ce7-4307-88db-fcf7c7b0d9c6.png)

Asset not supported:
![image](https://user-images.githubusercontent.com/88804546/206287895-dc0f7ff4-5f28-474e-aaae-11f4af854c1e.png)
