### PR TITLE
fix: guard against possible missing account type before generating address

### DIFF
--- a/src/components/Trade/hooks/useSwapper/useSwapper.tsx
+++ b/src/components/Trade/hooks/useSwapper/useSwapper.tsx
@@ -24,6 +24,7 @@ import { getChainAdapterManager } from 'context/PluginProvider/chainAdapterSingl
 import { useWallet } from 'hooks/useWallet/useWallet'
 import { toBaseUnit } from 'lib/math'
 import { selectAssetIds } from 'state/slices/assetsSlice/selectors'
+import { isUtxoAccountId } from 'state/slices/portfolioSlice/utils'
 import { selectFeatureFlags } from 'state/slices/preferencesSlice/selectors'
 import {
   selectBIP44ParamsByAccountId,
@@ -115,11 +116,14 @@ export const useSwapper = () => {
 
   const getReceiveAddressFromBuyAsset = useCallback(
     (buyAsset: Asset) => {
+      if (!buyAssetAccountId) return
       if (!buyAccountMetadata) return
       const { accountType, bip44Params } = buyAccountMetadata
+      if (isUtxoAccountId(buyAssetAccountId) && !accountType)
+        throw new Error(`Missing accountType for UTXO account ${buyAssetAccountId}`)
       return getReceiveAddress({ asset: buyAsset, wallet, bip44Params, accountType })
     },
-    [buyAccountMetadata, wallet],
+    [buyAssetAccountId, buyAccountMetadata, wallet],
   )
 
   const getSupportedBuyAssetsFromSellAsset = useCallback(


### PR DESCRIPTION
## Description

<!-- Please describe your changes -->

guard against possible missing account type when generating utxo account addresses

## Notice

<!-- Before submitting a pull request, please make sure you have answered the following: -->

- [x] Have you followed the guidelines in our [Contributing]('https://github.com/shapeshift/web/blob/develop/CONTRIBUTING.md) guide?
- [x] Have you checked to ensure there aren't other open [Pull Requests](https://github.com/shapeshift/web/pulls) for the same update/change?

## Pull Request Type

- [x] :bug: Bug fix (Non-breaking Change: Fixes an issue)
- [x] :hammer_and_wrench: Chore (Non-breaking Change: Doc updates, pkg upgrades, typos, etc..)
- [ ] :nail_care: New Feature (Breaking/Non-breaking Change)

## Issue (if applicable)

<!-----------------------------------------------------------------------------
If applicable, please link to the github issue and put `closes #XXXX` in your comment to auto-close the issue that your PR fixes.
------------------------------------------------------------------------------>

n/a - more paranoia/safety

## Risk

very small, isolated to swapper - more safer receive address generation in swapper

<!-----------------------------------------------------------------------------
Outline the scope of your changes and the risk associated with them. You must use your discretion as an engineer to determine the potential impact of your changes.

E.g. an upgrade to `hdwallet` or core state management would be considered higher risk, and might require a full regression test. UI or isolated view changes, or something behind a feature flag may have near zero risk. Small bug fixes might require testing isolated to the specific fix.
------------------------------------------------------------------------------>

## Testing

* ensure we can get trade quotes when buying a utxo asset, and complete a small trade

<!-----------------------------------------------------------------------------
We treat every PR to be merged with the same scrutiny as if we were merging directly to production.

Your PR will not be merged if you do not complete the sections below for our engineering and operations teams to test.
------------------------------------------------------------------------------>

### Engineering

👆

<!-----------------------------------------------------------------------------
Include sufficient information here for an engineer to test your PR. This may include how to test locally, in a built environment, changes to infrastructure etc.
------------------------------------------------------------------------------>

### Operations

👆

<!-----------------------------------------------------------------------------
If your changes have a user-facing impact, describe how a non-technical QA team can functionally test your changes in a preview environment.

If they are not user-facing please describe how to test for any regressions that may occur.
------------------------------------------------------------------------------>

## Screenshots (if applicable)

n/a
