### PR TITLE
fix: guard against missing account type for UTXO buy account in default assets

### DIFF
--- a/src/components/Trade/hooks/useDefaultAssets.tsx
+++ b/src/components/Trade/hooks/useDefaultAssets.tsx
@@ -22,6 +22,7 @@ import { useWallet } from 'hooks/useWallet/useWallet'
 import { swapperApi } from 'state/apis/swapper/swapperApi'
 import { selectAssets } from 'state/slices/assetsSlice/selectors'
 import { selectPortfolioAccountMetadata } from 'state/slices/portfolioSlice/selectors'
+import { isUtxoAccountId } from 'state/slices/portfolioSlice/utils'
 import { selectFeatureFlags } from 'state/slices/preferencesSlice/selectors'
 import { selectWalletAccountIds } from 'state/slices/selectors'
 import { useAppDispatch, useAppSelector } from 'state/store'
@@ -122,14 +123,16 @@ export const useDefaultAssets = (routeBuyAssetId?: AssetId) => {
     })()
 
     if (assetPair && wallet) {
-      const accountIds = walletAccountIds.filter(
+      const buyAccountIds = walletAccountIds.filter(
         accountId => fromAccountId(accountId).chainId === assetPair.buyAsset.chainId,
       )
       // As long as we have at least one account id for the buy asset, we can do a trade
-      const firstAccountId = accountIds[0]
-      if (!firstAccountId) return
-      const accountMetadata = portfolioAccountMetaData[firstAccountId]
+      const firstBuyAccountId = buyAccountIds[0]
+      if (!firstBuyAccountId) return
+      const accountMetadata = portfolioAccountMetaData[firstBuyAccountId]
       if (!accountMetadata) return
+      if (isUtxoAccountId(firstBuyAccountId) && !accountMetadata.accountType) return
+
       const receiveAddress = await getReceiveAddress({
         asset: assetPair.buyAsset,
         wallet,


### PR DESCRIPTION
## Description

Guard against possible missing account type when generating UTXO account addresses in default assets hook.

## Notice

- [x] Have you followed the guidelines in our [Contributing]('https://github.com/shapeshift/web/blob/develop/CONTRIBUTING.md) guide?
- [x] Have you checked to ensure there aren't other open [Pull Requests](https://github.com/shapeshift/web/pulls) for the same update/change?

## Pull Request Type

- [x] :bug: Bug fix (Non-breaking Change: Fixes an issue)
- [x] :hammer_and_wrench: Chore (Non-breaking Change: Doc updates, pkg upgrades, typos, etc..)
- [ ] :nail_care: New Feature (Breaking/Non-breaking Change)

## Issue (if applicable)

N/A - paranoia and safety.

## Risk

Small, isolated to getting default assets.

## Testing

Ensure default assets still work as expected, particularly for UTXO assets.

### Engineering

☝️ 

### Operations

☝️ 

## Screenshots (if applicable)

N/A