### PR TITLE
fix: use sell AssetId in getInboundAddressDataForChain

### DIFF
--- a/package.json
+++ b/package.json
@@ -103,7 +103,7 @@
     "@shapeshiftoss/investor-yearn": "^6.1.7",
     "@shapeshiftoss/logger": "^1.1.3",
     "@shapeshiftoss/market-service": "^7.2.2",
-    "@shapeshiftoss/swapper": "^14.5.3",
+    "@shapeshiftoss/swapper": "^14.7.1",
     "@shapeshiftoss/types": "^8.3.2",
     "@shapeshiftoss/unchained-client": "^10.4.1",
     "@uniswap/sdk": "^3.0.3",

--- a/yarn.lock
+++ b/yarn.lock
@@ -4370,10 +4370,10 @@
     google-protobuf "^3.17.0"
     long "^4.0.0"
 
-"@shapeshiftoss/swapper@^14.5.3":
-  version "14.6.0"
-  resolved "https://registry.yarnpkg.com/@shapeshiftoss/swapper/-/swapper-14.6.0.tgz#34a154434b724195de75bf69f7d534fe9824b83e"
-  integrity sha512-SA0IDyqTtF4qr8fO5SPcaoo3zU4JnHcAEfz1wBw2vkPto3kp78abdY8phBLkT3d7Fpm2USzuk3DaEhsZesqoOQ==
+"@shapeshiftoss/swapper@^14.7.1":
+  version "14.7.1"
+  resolved "https://registry.yarnpkg.com/@shapeshiftoss/swapper/-/swapper-14.7.1.tgz#ce0227adc0f28134d37d899ffc88ce0712615b80"
+  integrity sha512-nOSVmD4zXa3ttr4/iGXPO/mWJ20WyG6K+OUcrZHBXhH8/2GLZp2KiRzOkAmd4LYfsgTcyLA/iSYgTav2yfGCxQ==
   dependencies:
     axios "^0.26.1"
     bignumber.js "^9.0.2"


### PR DESCRIPTION
## Description

Fixes a bug where Avalanche trades on THORSwap were using a hard-coded (and incorrect) `AssetId`.

## Notice

- [x] Have you followed the guidelines in our [Contributing]('https://github.com/shapeshift/web/blob/develop/CONTRIBUTING.md) guide?
- [x] Have you checked to ensure there aren't other open [Pull Requests](https://github.com/shapeshift/web/pulls) for the same update/change?

## Pull Request Type

- [x] :bug: Bug fix (Non-breaking Change: Fixes an issue)
- [ ] :hammer_and_wrench: Chore (Non-breaking Change: Doc updates, pkg upgrades, typos, etc..)
- [ ] :nail_care: New Feature (Breaking/Non-breaking Change)

## Issue (if applicable)

N/A

## Risk

Small.

## Testing

Perform an AVAX to DOGE trade (ensure it's using THORSwap). It should go through correctly, and DOGE should be received.

### Engineering

☝️ 

### Operations

☝️

## Screenshots (if applicable)

N/A