### PR TITLE
chore: add additional default asset safety

### DIFF
--- a/src/components/Trade/hooks/useDefaultAssets.tsx
+++ b/src/components/Trade/hooks/useDefaultAssets.tsx
@@ -133,6 +133,11 @@ export const useDefaultAssets = (routeBuyAssetId?: AssetId) => {
       if (!accountMetadata) return
       if (isUtxoAccountId(firstBuyAccountId) && !accountMetadata.accountType) return
 
+      // guard against erroneous state
+      const buyAssetChainId = assetPair.buyAsset.chainId
+      const buyAssetAccountChainId = fromAccountId(firstBuyAccountId).chainId
+      if (buyAssetChainId !== buyAssetAccountChainId) return
+
       const receiveAddress = await getReceiveAddress({
         asset: assetPair.buyAsset,
         wallet,


### PR DESCRIPTION
## Description

Adds a similar guard as https://github.com/shapeshift/web/commit/080d71b0292d0a80b7dee467d5326a761ee41dd6, though the receive address here is not used when building transactions, so it's much less important.

This PR simply ensures we don't get false positives when checking for supported assets when selecting the defaults.

## Notice

- [x] Have you followed the guidelines in our [Contributing]('https://github.com/shapeshift/web/blob/develop/CONTRIBUTING.md) guide?
- [x] Have you checked to ensure there aren't other open [Pull Requests](https://github.com/shapeshift/web/pulls) for the same update/change?

## Pull Request Type

- [ ] :bug: Bug fix (Non-breaking Change: Fixes an issue)
- [x] :hammer_and_wrench: Chore (Non-breaking Change: Doc updates, pkg upgrades, typos, etc..)
- [ ] :nail_care: New Feature (Breaking/Non-breaking Change)

## Issue (if applicable)

N/A

## Risk

Small - limited to default asset computation.

## Testing

Default assets should still show as expected.

### Engineering

☝️

### Operations

☝️

## Screenshots (if applicable)

N/A