### PR TITLE
fix: update investor-foxy package to fix exact approvals

### DIFF
--- a/package.json
+++ b/package.json
@@ -98,7 +98,7 @@
     "@shapeshiftoss/hdwallet-tallyho": "^1.41.0",
     "@shapeshiftoss/hdwallet-walletconnect": "^1.41.0",
     "@shapeshiftoss/hdwallet-xdefi": "^1.41.0",
-    "@shapeshiftoss/investor-foxy": "^7.0.2",
+    "@shapeshiftoss/investor-foxy": "^7.0.4",
     "@shapeshiftoss/investor-idle": "^2.4.1",
     "@shapeshiftoss/investor-yearn": "^6.3.0",
     "@shapeshiftoss/logger": "^1.1.3",

--- a/yarn.lock
+++ b/yarn.lock
@@ -4316,10 +4316,10 @@
     "@shapeshiftoss/hdwallet-core" "1.41.0"
     lodash "^4.17.21"
 
-"@shapeshiftoss/investor-foxy@^7.0.2":
-  version "7.0.2"
-  resolved "https://registry.yarnpkg.com/@shapeshiftoss/investor-foxy/-/investor-foxy-7.0.2.tgz#6ca3eeb3a8567ee6c40e3745496125f796c6f71c"
-  integrity sha512-/dUZtWTC4JPlKdBfOCEAmwAlabkPpDFuGOikn75ZklJUi9VD2Us/oyvJK9V4xEJbUCrVXF4oTclibHBCzhh72g==
+"@shapeshiftoss/investor-foxy@^7.0.4":
+  version "7.0.4"
+  resolved "https://registry.yarnpkg.com/@shapeshiftoss/investor-foxy/-/investor-foxy-7.0.4.tgz#9097a47f3db195609f9d9592d9305ce2f1a072c7"
+  integrity sha512-tYpgiddemJWbaNiTca6SkXO2D649yC4cpPBHFBwIoSUm8U5fuHsryUPN2h9efHAlxl2kBeA5el+BATdv01dpXA==
   dependencies:
     "@ethersproject/providers" "^5.5.3"
     axios "^0.26.1"


### PR DESCRIPTION
## Description

lib was still rugging us after the `toFixed()` change in web, this bumps `investor-foxy` to normalize the approve amount on exact approvals

## Notice

<!-- Before submitting a pull request, please make sure you have answered the following: -->

- [x] Have you followed the guidelines in our [Contributing]('https://github.com/shapeshift/web/blob/develop/CONTRIBUTING.md) guide?
- [x] Have you checked to ensure there aren't other open [Pull Requests](https://github.com/shapeshift/web/pulls) for the same update/change?

## Pull Request Type

- [x] :bug: Bug fix (Non-breaking Change: Fixes an issue)
- [ ] :hammer_and_wrench: Chore (Non-breaking Change: Doc updates, pkg upgrades, typos, etc..)
- [ ] :nail_care: New Feature (Breaking/Non-breaking Change)

## Issue (if applicable)

<!-----------------------------------------------------------------------------
If applicable, please link to the github issue and put `closes #XXXX` in your comment to auto-close the issue that your PR fixes.
------------------------------------------------------------------------------>

closes #

## Risk

low

## Testing

- perform exact approval for foxy deposit with crypto value of >=1000

### Engineering

:point_up: 

### Operations

:point_up: 

## Screenshots (if applicable)
![image](https://user-images.githubusercontent.com/35275952/210898529-b48827b2-1a3e-41a9-90a3-4415efc54897.png)
