### PR TITLE
fix: pass accountId to useCosmosSdkStakingBalances

### DIFF
--- a/src/components/StakingVaults/AllEarnOpportunities.tsx
+++ b/src/components/StakingVaults/AllEarnOpportunities.tsx
@@ -1,5 +1,11 @@
 import { Box } from '@chakra-ui/react'
-import { cosmosAssetId, fromAssetId, osmosisAssetId } from '@shapeshiftoss/caip'
+import {
+  cosmosAssetId,
+  cosmosChainId,
+  fromAssetId,
+  osmosisAssetId,
+  osmosisChainId,
+} from '@shapeshiftoss/caip'
 import type { EarnOpportunityType } from 'features/defi/helpers/normalizeOpportunity'
 import { useNormalizeOpportunities } from 'features/defi/helpers/normalizeOpportunity'
 import qs from 'qs'
@@ -17,6 +23,7 @@ import type { StakingId } from 'state/slices/opportunitiesSlice/types'
 import {
   selectAggregatedEarnUserLpOpportunity,
   selectAggregatedEarnUserStakingOpportunitiesIncludeEmpty,
+  selectFirstAccountIdByChainId,
 } from 'state/slices/selectors'
 import { useAppSelector } from 'state/store'
 
@@ -36,6 +43,13 @@ export const AllEarnOpportunities = () => {
     selectAggregatedEarnUserStakingOpportunitiesIncludeEmpty,
   )
 
+  const cosmosAccountId = useAppSelector(state =>
+    selectFirstAccountIdByChainId(state, cosmosChainId),
+  )
+  const osmosisAccountId = useAppSelector(state =>
+    selectFirstAccountIdByChainId(state, osmosisChainId),
+  )
+
   const foxEthLpOpportunityFilter = useMemo(
     () => ({
       lpId: foxEthLpAssetId,
@@ -49,12 +63,15 @@ export const AllEarnOpportunities = () => {
   const { cosmosSdkStakingOpportunities: cosmosStakingOpportunities } = useCosmosSdkStakingBalances(
     {
       assetId: cosmosAssetId,
+      accountId: cosmosAccountId,
     },
   )
   const { cosmosSdkStakingOpportunities: osmosisStakingOpportunities } =
     useCosmosSdkStakingBalances({
       assetId: osmosisAssetId,
+      accountId: osmosisAccountId,
     })
+
   const allRows = useNormalizeOpportunities({
     foxyArray: foxyBalancesData?.opportunities ?? [],
     cosmosSdkStakingOpportunities: useMemo(
@@ -83,6 +100,8 @@ export const AllEarnOpportunities = () => {
     (opportunity: EarnOpportunityType) => {
       const { provider, contractAddress, chainId, rewardAddress, assetId } = opportunity
       const { assetReference } = fromAssetId(assetId)
+      const defaultAccountId = assetId === cosmosAssetId ? cosmosAccountId : osmosisAccountId
+
       if (!isConnected && isDemoWallet) {
         dispatch({ type: WalletActions.SET_WALLET_MODAL, payload: true })
         return
@@ -93,6 +112,7 @@ export const AllEarnOpportunities = () => {
         search: qs.stringify({
           provider,
           chainId,
+          defaultAccountId,
           contractAddress,
           assetReference,
           highestBalanceAccountAddress: opportunity.highestBalanceAccountAddress,


### PR DESCRIPTION
## Description

This bug was only seen on wallets that had ATOM staking.  If no accountId was passed to useCosmosSdkStakingBalances then it would default validator information to ATOM.

Fix:
Pass accountId to useCosmosSdkStakingBalances so correct opportunity gets passed through.

## Notice

<!-- Before submitting a pull request, please make sure you have answered the following: -->

- [x] Have you followed the guidelines in our [Contributing]('https://github.com/shapeshift/web/blob/develop/CONTRIBUTING.md) guide?
- [x] Have you checked to ensure there aren't other open [Pull Requests](https://github.com/shapeshift/web/pulls) for the same update/change?

## Pull Request Type

- [x] :bug: Bug fix (Non-breaking Change: Fixes an issue)
- [ ] :hammer_and_wrench: Chore (Non-breaking Change: Doc updates, pkg upgrades, typos, etc..)
- [ ] :nail_care: New Feature (Breaking/Non-breaking Change)

## Issue (if applicable)

<!-----------------------------------------------------------------------------
If applicable, please link to the github issue and put `closes #XXXX` in your comment to auto-close the issue that your PR fixes.
------------------------------------------------------------------------------>

closes #

## Risk

Breaks Cosmos staking
<!-----------------------------------------------------------------------------
Outline the scope of your changes and the risk associated with them. You must use your discretion as an engineer to determine the potential impact of your changes.

E.g. an upgrade to `hdwallet` or core state management would be considered higher risk, and might require a full regression test. UI or isolated view changes, or something behind a feature flag may have near zero risk. Small bug fixes might require testing isolated to the specific fix.
------------------------------------------------------------------------------>

## Testing

<!-----------------------------------------------------------------------------
We treat every PR to be merged with the same scrutiny as if we were merging directly to production.

Your PR will not be merged if you do not complete the sections below for our engineering and operations teams to test.
------------------------------------------------------------------------------>

### Engineering

Test that OSMO staking/unstaking works
Test that ATOM staking/unstaking works
<!-----------------------------------------------------------------------------
Include sufficient information here for an engineer to test your PR. This may include how to test locally, in a built environment, changes to infrastructure etc.
------------------------------------------------------------------------------>

### Operations

Test that OSMO staking/unstaking works
Test that ATOM staking/unstaking works
<!-----------------------------------------------------------------------------
If your changes have a user-facing impact, describe how a non-technical QA team can functionally test your changes in a preview environment.

If they are not user-facing please describe how to test for any regressions that may occur.
------------------------------------------------------------------------------>

## Screenshots (if applicable)
