### PR TITLE
chore: improve API error handling

### DIFF
--- a/src/state/apis/swapper/getBestSwapperApi.ts
+++ b/src/state/apis/swapper/getBestSwapperApi.ts
@@ -3,6 +3,7 @@ import type { GetTradeQuoteInput, SwapperType } from '@shapeshiftoss/swapper'
 import { getSwapperManager } from 'components/Trade/hooks/useSwapper/swapperManager'
 import { swapperApi } from 'state/apis/swapper/swapperApi'
 import type { State } from 'state/apis/types'
+import { handleApiError } from 'state/apis/utils'
 
 type GetBestSwapperArgs = GetTradeQuoteInput & { feeAsset: Asset }
 
@@ -10,7 +11,7 @@ type GetBestSwapperArgs = GetTradeQuoteInput & { feeAsset: Asset }
 We can't return the swapper directly as it is not serializable, so we return the SwapperType which can be matched
 to a swapper in the swapperManager, which is keyed by SwapperType
  */
-type GetBestSwapperReturn = SwapperType | undefined
+type GetBestSwapperReturn = SwapperType
 
 export const getBestSwapperApi = swapperApi.injectEndpoints({
   endpoints: build => ({
@@ -23,14 +24,10 @@ export const getBestSwapperApi = swapperApi.injectEndpoints({
         try {
           const bestSwapper = await swapperManager.getBestSwapper(args)
           const type = bestSwapper?.getType()
+          if (!type) throw new Error('getBestSwapperType: No swapper type found')
           return { data: type }
         } catch (e) {
-          return {
-            error: {
-              error: 'getBestSwapper: error getting best swapper type',
-              status: 'CUSTOM_ERROR',
-            },
-          }
+          return handleApiError(e, 'getBestSwapperType: error getting best swapper type')
         }
       },
     }),

--- a/src/state/apis/swapper/getBestSwapperApi.ts
+++ b/src/state/apis/swapper/getBestSwapperApi.ts
@@ -3,7 +3,7 @@ import type { GetTradeQuoteInput, SwapperType } from '@shapeshiftoss/swapper'
 import { getSwapperManager } from 'components/Trade/hooks/useSwapper/swapperManager'
 import { swapperApi } from 'state/apis/swapper/swapperApi'
 import type { State } from 'state/apis/types'
-import { handleApiError } from 'state/apis/utils'
+import { apiErrorHandler } from 'state/apis/utils'
 
 type GetBestSwapperArgs = GetTradeQuoteInput & { feeAsset: Asset }
 
@@ -12,6 +12,10 @@ We can't return the swapper directly as it is not serializable, so we return the
 to a swapper in the swapperManager, which is keyed by SwapperType
  */
 type GetBestSwapperReturn = SwapperType
+
+const getBestSwapperErrorHandler = apiErrorHandler(
+  'getBestSwapperType: error getting best swapper type',
+)
 
 export const getBestSwapperApi = swapperApi.injectEndpoints({
   endpoints: build => ({
@@ -24,10 +28,10 @@ export const getBestSwapperApi = swapperApi.injectEndpoints({
         try {
           const bestSwapper = await swapperManager.getBestSwapper(args)
           const type = bestSwapper?.getType()
-          if (!type) throw new Error('getBestSwapperType: No swapper type found')
+          if (!type) return getBestSwapperErrorHandler()
           return { data: type }
-        } catch (e) {
-          return handleApiError(e, 'getBestSwapperType: error getting best swapper type')
+        } catch (error) {
+          return getBestSwapperErrorHandler(error)
         }
       },
     }),

--- a/src/state/apis/swapper/getTradeQuoteApi.ts
+++ b/src/state/apis/swapper/getTradeQuoteApi.ts
@@ -5,11 +5,13 @@ import { getChainAdapterManager } from 'context/PluginProvider/chainAdapterSingl
 import { getBestSwapperApi } from 'state/apis/swapper/getBestSwapperApi'
 import { swapperApi } from 'state/apis/swapper/swapperApi'
 import type { State } from 'state/apis/types'
-import { handleApiError } from 'state/apis/utils'
+import { apiErrorHandler } from 'state/apis/utils'
 
 type GetTradeQuoteReturn = TradeQuote<ChainId>
 
 const getBestSwapperType = getBestSwapperApi.endpoints.getBestSwapperType
+
+const getTradeQuoteErrorHandler = apiErrorHandler('getTradeQuote: error fetching trade quote')
 
 export const getTradeQuoteApi = swapperApi.injectEndpoints({
   endpoints: build => ({
@@ -32,10 +34,12 @@ export const getTradeQuoteApi = swapperApi.injectEndpoints({
           ).then(r => r.data)
           const swapper = swapperType ? swappers.get(swapperType) : undefined
           const tradeQuote = await swapper?.getTradeQuote(args)
-          if (!tradeQuote) throw new Error('getTradeQuote: No trade quote found')
+          if (!tradeQuote)
+            return getTradeQuoteErrorHandler({ message: 'getTradeQuote: No trade quote found' })
+
           return { data: tradeQuote }
-        } catch (e) {
-          return handleApiError(e, 'getTradeQuote: error fetching trade quote')
+        } catch (error) {
+          return getTradeQuoteErrorHandler()
         }
       },
     }),

--- a/src/state/apis/swapper/getTradeQuoteApi.ts
+++ b/src/state/apis/swapper/getTradeQuoteApi.ts
@@ -5,6 +5,7 @@ import { getChainAdapterManager } from 'context/PluginProvider/chainAdapterSingl
 import { getBestSwapperApi } from 'state/apis/swapper/getBestSwapperApi'
 import { swapperApi } from 'state/apis/swapper/swapperApi'
 import type { State } from 'state/apis/types'
+import { handleApiError } from 'state/apis/utils'
 
 type GetTradeQuoteReturn = TradeQuote<ChainId>
 
@@ -30,16 +31,11 @@ export const getTradeQuoteApi = swapperApi.injectEndpoints({
             getBestSwapperType.initiate({ ...args, feeAsset }),
           ).then(r => r.data)
           const swapper = swapperType ? swappers.get(swapperType) : undefined
-
           const tradeQuote = await swapper?.getTradeQuote(args)
+          if (!tradeQuote) throw new Error('getTradeQuote: No trade quote found')
           return { data: tradeQuote }
         } catch (e) {
-          return {
-            error: {
-              error: 'getTradeQuote: error fetching trade quote',
-              status: 'CUSTOM_ERROR',
-            },
-          }
+          return handleApiError(e, 'getTradeQuote: error fetching trade quote')
         }
       },
     }),

--- a/src/state/apis/swapper/getUsdRateApi.ts
+++ b/src/state/apis/swapper/getUsdRateApi.ts
@@ -3,6 +3,7 @@ import type { SwapperType } from '@shapeshiftoss/swapper'
 import { getSwapperManager } from 'components/Trade/hooks/useSwapper/swapperManager'
 import { swapperApi } from 'state/apis/swapper/swapperApi'
 import type { State } from 'state/apis/types'
+import { handleApiError } from 'state/apis/utils'
 
 export type GetUsdRateArgs = { assetId: AssetId; swapperType: SwapperType }
 type GetUsdRateReturn = string | undefined
@@ -24,15 +25,10 @@ export const getUsdRateApi = swapperApi.injectEndpoints({
           const swappers = swapperManager.swappers
           const swapper = swapperType ? swappers.get(swapperType) : undefined
           const rate = await swapper?.getUsdRate(asset)
-
+          if (!rate) throw new Error('getUsdRate: No rate found')
           return { data: rate }
         } catch (e) {
-          return {
-            error: {
-              error: 'getUsdRate: error fetching USD rate',
-              status: 'CUSTOM_ERROR',
-            },
-          }
+          return handleApiError(e, 'getUsdRate: error fetching USD rate')
         }
       },
     }),

--- a/src/state/apis/swapper/getUsdRateApi.ts
+++ b/src/state/apis/swapper/getUsdRateApi.ts
@@ -3,10 +3,12 @@ import type { SwapperType } from '@shapeshiftoss/swapper'
 import { getSwapperManager } from 'components/Trade/hooks/useSwapper/swapperManager'
 import { swapperApi } from 'state/apis/swapper/swapperApi'
 import type { State } from 'state/apis/types'
-import { handleApiError } from 'state/apis/utils'
+import { apiErrorHandler } from 'state/apis/utils'
 
 export type GetUsdRateArgs = { assetId: AssetId; swapperType: SwapperType }
 type GetUsdRateReturn = string | undefined
+
+const getUsdRateErrorHandler = apiErrorHandler('getUsdRate: error fetching USD rate')
 
 export const getUsdRateApi = swapperApi.injectEndpoints({
   endpoints: build => ({
@@ -25,10 +27,11 @@ export const getUsdRateApi = swapperApi.injectEndpoints({
           const swappers = swapperManager.swappers
           const swapper = swapperType ? swappers.get(swapperType) : undefined
           const rate = await swapper?.getUsdRate(asset)
-          if (!rate) throw new Error('getUsdRate: No rate found')
+          if (!rate)
+            return getUsdRateErrorHandler({ message: 'getUsdRate: getUsdRate: No rate found' })
           return { data: rate }
-        } catch (e) {
-          return handleApiError(e, 'getUsdRate: error fetching USD rate')
+        } catch (error) {
+          return getUsdRateErrorHandler()
         }
       },
     }),

--- a/src/state/apis/swapper/getUsdRatesApi.ts
+++ b/src/state/apis/swapper/getUsdRatesApi.ts
@@ -7,6 +7,7 @@ import { getBestSwapperApi } from 'state/apis/swapper/getBestSwapperApi'
 import { getUsdRateApi } from 'state/apis/swapper/getUsdRateApi'
 import { swapperApi } from 'state/apis/swapper/swapperApi'
 import type { State } from 'state/apis/types'
+import { handleApiError } from 'state/apis/utils'
 
 export type GetUsdRatesArgs = {
   feeAssetId: AssetId
@@ -53,7 +54,7 @@ export const getUsdRatesApi = swapperApi.injectEndpoints({
             }),
           ).then(r => r.data)
 
-          if (!swapperType) throw new Error(`Swapper type not found.`)
+          if (!swapperType) throw new Error('Swapper type not found')
 
           const assetIds = [feeAssetId, buyAssetId, sellAssetId]
           const usdRatePromises = await Promise.allSettled(
@@ -64,16 +65,11 @@ export const getUsdRatesApi = swapperApi.injectEndpoints({
             .map(p => p.value?.data)
 
           if (!feeAssetUsdRate || !buyAssetUsdRate || !sellAssetUsdRate)
-            throw new Error(`USD rates not found.`)
+            throw new Error('getUsdRates: USD rates not found')
           const data = { feeAssetUsdRate, buyAssetUsdRate, sellAssetUsdRate }
           return { data }
         } catch (e) {
-          return {
-            error: {
-              error: 'getUsdRates: error fetching USD rates',
-              status: 'CUSTOM_ERROR',
-            },
-          }
+          return handleApiError(e, 'getUsdRates: error fetching USD rates')
         }
       },
     }),

--- a/src/state/apis/swapper/getUsdRatesApi.ts
+++ b/src/state/apis/swapper/getUsdRatesApi.ts
@@ -7,7 +7,7 @@ import { getBestSwapperApi } from 'state/apis/swapper/getBestSwapperApi'
 import { getUsdRateApi } from 'state/apis/swapper/getUsdRateApi'
 import { swapperApi } from 'state/apis/swapper/swapperApi'
 import type { State } from 'state/apis/types'
-import { handleApiError } from 'state/apis/utils'
+import { apiErrorHandler } from 'state/apis/utils'
 
 export type GetUsdRatesArgs = {
   feeAssetId: AssetId
@@ -24,6 +24,8 @@ type GetUsdRatesReturn = {
 
 const getBestSwapperType = getBestSwapperApi.endpoints.getBestSwapperType
 const getUsdRate = getUsdRateApi.endpoints.getUsdRate
+
+const getUsdRatesErrorHandler = apiErrorHandler('getUsdRates: error fetching USD rates')
 
 export const getUsdRatesApi = swapperApi.injectEndpoints({
   endpoints: build => ({
@@ -43,9 +45,14 @@ export const getUsdRatesApi = swapperApi.injectEndpoints({
             ? await getTradeQuoteArgs(args.tradeQuoteInputArgs)
             : args.tradeQuoteArgs
 
-          if (!tradeQuoteArgs) throw new Error('tradeQuoteArgs is undefined')
+          if (!tradeQuoteArgs)
+            return getUsdRatesErrorHandler({ message: 'getUsdRates: tradeQuoteArgs is undefined' })
+
           const feeAsset = assets.byId[feeAssetId]
-          if (!feeAsset) throw new Error(`Asset not found for AssetId ${feeAssetId}`)
+          if (!feeAsset)
+            return getUsdRatesErrorHandler({
+              message: `getUsdRates: Asset not found for AssetId ${feeAssetId}`,
+            })
 
           const swapperType = await dispatch(
             getBestSwapperType.initiate({
@@ -54,7 +61,8 @@ export const getUsdRatesApi = swapperApi.injectEndpoints({
             }),
           ).then(r => r.data)
 
-          if (!swapperType) throw new Error('Swapper type not found')
+          if (!swapperType)
+            return getUsdRatesErrorHandler({ message: 'getUsdRates: Swapper type not found' })
 
           const assetIds = [feeAssetId, buyAssetId, sellAssetId]
           const usdRatePromises = await Promise.allSettled(
@@ -65,11 +73,12 @@ export const getUsdRatesApi = swapperApi.injectEndpoints({
             .map(p => p.value?.data)
 
           if (!feeAssetUsdRate || !buyAssetUsdRate || !sellAssetUsdRate)
-            throw new Error('getUsdRates: USD rates not found')
+            return getUsdRatesErrorHandler({ message: 'getUsdRates: USD rates not found' })
+
           const data = { feeAssetUsdRate, buyAssetUsdRate, sellAssetUsdRate }
           return { data }
-        } catch (e) {
-          return handleApiError(e, 'getUsdRates: error fetching USD rates')
+        } catch (error) {
+          return getUsdRatesErrorHandler()
         }
       },
     }),

--- a/src/state/apis/utils.ts
+++ b/src/state/apis/utils.ts
@@ -1,0 +1,13 @@
+export const handleApiError = (
+  e: unknown,
+  defaultErrorMessage: string,
+): { error: Record<string, unknown> } => {
+  if (e instanceof Error) return { error: { ...e } }
+  else
+    return {
+      error: {
+        error: defaultErrorMessage,
+        status: 'CUSTOM_ERROR',
+      },
+    }
+}

--- a/src/state/apis/utils.ts
+++ b/src/state/apis/utils.ts
@@ -1,17 +1,27 @@
 import { ErrorWithDetails } from '@shapeshiftoss/errors'
 
-export const handleApiError = (
-  e: unknown,
-  defaultErrorMessage: string,
-): { error: Record<string, unknown> } => {
+type HandleApiErrorArgs = {
+  message: string
+  error?: unknown
+}
+
+const handleApiError = ({
+  error,
+  message,
+}: HandleApiErrorArgs): { error: Record<string, unknown> } => {
   // 'code' is a getter of ErrorWithDetails, so we need to access it specifically
-  if (e instanceof ErrorWithDetails) return { error: { ...e, code: e.code } }
-  if (e instanceof Error) return { error: { ...e } }
+  if (error instanceof ErrorWithDetails) return { error: { ...error, code: error.code } }
+  if (error instanceof Error) return { error: { ...error } }
   else
     return {
       error: {
-        error: defaultErrorMessage,
+        error: message,
         status: 'CUSTOM_ERROR',
       },
     }
 }
+
+export const apiErrorHandler =
+  (defaultMessage: HandleApiErrorArgs['message']) =>
+  (error?: HandleApiErrorArgs['error'], message?: HandleApiErrorArgs['message']) =>
+    handleApiError({ message: message ?? defaultMessage, error })

--- a/src/state/apis/utils.ts
+++ b/src/state/apis/utils.ts
@@ -1,7 +1,11 @@
+import { ErrorWithDetails } from '@shapeshiftoss/errors'
+
 export const handleApiError = (
   e: unknown,
   defaultErrorMessage: string,
 ): { error: Record<string, unknown> } => {
+  // 'code' is a getter of ErrorWithDetails, so we need to access it specifically
+  if (e instanceof ErrorWithDetails) return { error: { ...e, code: e.code } }
   if (e instanceof Error) return { error: { ...e } }
   else
     return {

--- a/src/state/apis/utils.ts
+++ b/src/state/apis/utils.ts
@@ -9,7 +9,7 @@ const handleApiError = ({
   error,
   message,
 }: HandleApiErrorArgs): { error: Record<string, unknown> } => {
-  // 'code' is a getter of ErrorWithDetails, so we need to access it specifically
+  // 'code' is a getter on the ErrorWithDetails class, so we need to explicitly add it to our object
   if (error instanceof ErrorWithDetails) return { error: { ...error, code: error.code } }
   if (error instanceof Error) return { error: { ...error } }
   else

--- a/src/state/apis/utils.ts
+++ b/src/state/apis/utils.ts
@@ -1,4 +1,5 @@
 import { ErrorWithDetails } from '@shapeshiftoss/errors'
+import isEmpty from 'lodash/isEmpty'
 
 type HandleApiErrorArgs = {
   message: string
@@ -11,7 +12,7 @@ const handleApiError = ({
 }: HandleApiErrorArgs): { error: Record<string, unknown> } => {
   // 'code' is a getter on the ErrorWithDetails class, so we need to explicitly add it to our object
   if (error instanceof ErrorWithDetails) return { error: { ...error, code: error.code } }
-  if (error instanceof Error) return { error: { ...error } }
+  if (error instanceof Error && !isEmpty(error)) return { error: { ...error } }
   else
     return {
       error: {
@@ -21,6 +22,7 @@ const handleApiError = ({
     }
 }
 
+// Returns a curried handleApiError function with a default value for the message argument that can be overridden once instantiated
 export const apiErrorHandler =
   (defaultMessage: HandleApiErrorArgs['message']) =>
   (error?: HandleApiErrorArgs['error'], message?: HandleApiErrorArgs['message']) =>


### PR DESCRIPTION
## Description

Part of some pre-factor work to handle THORSwap `halt` flags to better handle errors from `lib` and in our RTK query APIs.

- Improve error handling in the swapper API by returning an error object of the expected shape instead of throwing
- Ensure we always return a value on either the `error` or `data` keys of the RTK API response (a requirement of RTK query, but not enforced at a type level)

## Notice

- [x] Have you followed the guidelines in our [Contributing]('https://github.com/shapeshift/web/blob/develop/CONTRIBUTING.md) guide?
- [x] Have you checked to ensure there aren't other open [Pull Requests](https://github.com/shapeshift/web/pulls) for the same update/change?

## Pull Request Type

- [ ] :bug: Bug fix (Non-breaking Change: Fixes an issue)
- [x] :hammer_and_wrench: Chore (Non-breaking Change: Doc updates, pkg upgrades, typos, etc..)
- [ ] :nail_care: New Feature (Breaking/Non-breaking Change)

## Issue (if applicable)

Contributes to https://github.com/shapeshift/web/issues/2925

## Risk

Small. Whilst it touches swapper APIs, if everything feels right we should be 🛍️ 

## Testing

A quick sense check that the trade widget still functions normally, though no changes are expected.

### Engineering

☝️ 

### Operations

☝️ 

## Screenshots (if applicable)

N/A