### PR TITLE
feat: thorchain savers metadata resolver

### DIFF
--- a/src/state/slices/opportunitiesSlice/opportunitiesSlice.ts
+++ b/src/state/slices/opportunitiesSlice/opportunitiesSlice.ts
@@ -7,6 +7,7 @@ import { PURGE } from 'redux-persist'
 import { logger } from 'lib/logger'
 import { BASE_RTK_CREATE_API_CONFIG } from 'state/apis/const'
 
+import type { ReduxApi } from './resolvers/types'
 import {
   getMetadataResolversByDefiProviderAndDefiType,
   getOpportunitiesMetadataResolversByDefiProviderAndDefiType,
@@ -47,6 +48,20 @@ export const initialState: OpportunitiesState = {
 }
 
 const moduleLogger = logger.child({ namespace: ['opportunitiesSlice'] })
+
+// tsc is drunk, extracting this makes it happy
+const getOpportunityIds = (
+  { defiProvider, defiType }: Pick<GetOpportunityMetadataInput, 'defiProvider' | 'defiType'>,
+  { getState }: { getState: ReduxApi['getState'] },
+): OpportunityId[] | undefined => {
+  const selectOpportunityIds = opportunitiesApi.endpoints.getOpportunityIds.select({
+    defiType,
+    defiProvider,
+  })
+  const { data: opportunityIds } = selectOpportunityIds(getState() as any)
+
+  return opportunityIds
+}
 
 export const opportunities = createSlice({
   name: 'opportunitiesData',
@@ -148,12 +163,7 @@ export const opportunitiesApi = createApi({
     >({
       queryFn: async ({ opportunityType, defiType, defiProvider }, { dispatch, getState }) => {
         try {
-          const state: any = getState() // ReduxState causes circular dependency
-          const selectOpportunityIds = opportunitiesApi.endpoints.getOpportunityIds.select({
-            defiType,
-            defiProvider,
-          })
-          const { data: opportunityIds } = selectOpportunityIds(state)
+          const opportunityIds = getOpportunityIds({ defiProvider, defiType }, { getState })
 
           if (!opportunityIds) {
             throw new Error("Can't select staking OpportunityIds")
@@ -245,12 +255,7 @@ export const opportunitiesApi = createApi({
         { dispatch, getState },
       ) => {
         try {
-          const state: any = getState() // ReduxState causes circular dependency
-          const selectOpportunityIds = opportunitiesApi.endpoints.getOpportunityIds.select({
-            defiType,
-            defiProvider,
-          })
-          const { data: opportunityIds } = selectOpportunityIds(state)
+          const opportunityIds = getOpportunityIds({ defiProvider, defiType }, { getState })
 
           if (!opportunityIds) {
             throw new Error("Can't select staking OpportunityIds")

--- a/src/state/slices/opportunitiesSlice/opportunitiesSlice.ts
+++ b/src/state/slices/opportunitiesSlice/opportunitiesSlice.ts
@@ -165,10 +165,6 @@ export const opportunitiesApi = createApi({
         try {
           const opportunityIds = getOpportunityIds({ defiProvider, defiType }, { getState })
 
-          if (!opportunityIds) {
-            throw new Error("Can't select staking OpportunityIds")
-          }
-
           const resolver = getOpportunitiesMetadataResolversByDefiProviderAndDefiType(
             defiProvider,
             defiType,

--- a/src/state/slices/opportunitiesSlice/opportunitiesSlice.ts
+++ b/src/state/slices/opportunitiesSlice/opportunitiesSlice.ts
@@ -148,11 +148,19 @@ export const opportunitiesApi = createApi({
     >({
       queryFn: async ({ opportunityType, defiType, defiProvider }, { dispatch, getState }) => {
         try {
+          const state: any = getState() // ReduxState causes circular dependency
+          const selectOpportunityIds = opportunitiesApi.endpoints.getOpportunityIds.select({
+            defiType,
+            defiProvider,
+          })
+          const { data: opportunityIds } = selectOpportunityIds(state)
+
           const resolver = getOpportunitiesMetadataResolversByDefiProviderAndDefiType(
             defiProvider,
             defiType,
           )
           const resolved = await resolver({
+            opportunityIds,
             opportunityType,
             reduxApi: { dispatch, getState },
           })

--- a/src/state/slices/opportunitiesSlice/opportunitiesSlice.ts
+++ b/src/state/slices/opportunitiesSlice/opportunitiesSlice.ts
@@ -155,6 +155,10 @@ export const opportunitiesApi = createApi({
           })
           const { data: opportunityIds } = selectOpportunityIds(state)
 
+          if (!opportunityIds) {
+            throw new Error("Can't select staking OpportunityIds")
+          }
+
           const resolver = getOpportunitiesMetadataResolversByDefiProviderAndDefiType(
             defiProvider,
             defiType,

--- a/src/state/slices/opportunitiesSlice/resolvers/index.ts
+++ b/src/state/slices/opportunitiesSlice/resolvers/index.ts
@@ -13,7 +13,10 @@ import {
   idleStakingOpportunitiesUserDataResolver,
   idleStakingOpportunityIdsResolver,
 } from './idle'
-import { thorchainSaversOpportunityIdsResolver } from './thorchainsavers'
+import {
+  thorchainSaversOpportunityIdsResolver,
+  thorchainSaversStakingOpportunitiesMetadataResolver,
+} from './thorchainsavers'
 import {
   yearnStakingOpportunitiesMetadataResolver,
   yearnStakingOpportunitiesUserDataResolver,
@@ -33,6 +36,9 @@ export const DefiProviderToOpportunitiesMetadataResolverByDeFiType = {
   },
   [`${DefiProvider.Yearn}`]: {
     [`${DefiType.Staking}`]: yearnStakingOpportunitiesMetadataResolver,
+  },
+  [`${DefiProvider.ThorchainSavers}`]: {
+    [`${DefiType.Staking}`]: thorchainSaversStakingOpportunitiesMetadataResolver,
   },
 }
 

--- a/src/state/slices/opportunitiesSlice/resolvers/thorchainsavers/index.ts
+++ b/src/state/slices/opportunitiesSlice/resolvers/thorchainsavers/index.ts
@@ -13,7 +13,6 @@ import type {
   GetOpportunityMetadataOutput,
   OpportunitiesState,
   OpportunityId,
-  OpportunityMetadata,
   StakingId,
 } from '../../types'
 import type { OpportunitiesMetadataResolverInput } from '../types'
@@ -67,23 +66,13 @@ export const thorchainSaversStakingOpportunitiesMetadataResolver = async ({
   const { SaversVaults } = selectFeatureFlags(state)
 
   if (!(SaversVaults && opportunityIds?.length)) {
-    return {
-      data: {
-        byId: {} as Partial<Record<StakingId, OpportunityMetadata>>,
-        type: opportunityType,
-      },
-    }
+    throw new Error('Not ready to fetch THORChain savers metadata')
   }
 
   const thorchainPools = await getThorchainPools()
 
   if (!thorchainPools?.length) {
-    return {
-      data: {
-        byId: {} as Partial<Record<StakingId, OpportunityMetadata>>,
-        type: opportunityType,
-      },
-    }
+    throw new Error('Error fetching THORChain pools')
   }
 
   const stakingOpportunitiesById: OpportunitiesState[DefiType.Staking]['byId'] = {}

--- a/src/state/slices/opportunitiesSlice/resolvers/thorchainsavers/index.ts
+++ b/src/state/slices/opportunitiesSlice/resolvers/thorchainsavers/index.ts
@@ -111,9 +111,7 @@ export const thorchainSaversStakingOpportunitiesMetadataResolver = async ({
       type: DefiType.Staking,
       underlyingAssetId: assetId,
       underlyingAssetIds: [assetId] as [AssetId],
-      ...{
-        rewardAssetIds: [assetId] as [AssetId],
-      },
+      rewardAssetIds: [assetId] as [AssetId],
       // Thorchain opportunities represent a single native asset being staked, so the ratio will always be 1
       underlyingAssetRatios: ['1'],
       name: `${underlyingAsset.symbol} Vault`,

--- a/src/state/slices/opportunitiesSlice/resolvers/thorchainsavers/index.ts
+++ b/src/state/slices/opportunitiesSlice/resolvers/thorchainsavers/index.ts
@@ -34,7 +34,9 @@ export const thorchainSaversOpportunityIdsResolver = async (): Promise<{
 }> => {
   const thorchainPools = await getThorchainPools()
 
-  if (!thorchainPools.length) return { data: [] }
+  if (!thorchainPools.length) {
+    throw new Error('Error fetching THORChain pools')
+  }
 
   const opportunityIds = thorchainPools.reduce<OpportunityId[]>((acc, currentPool) => {
     const maybeOpportunityId = adapters.poolAssetIdToAssetId(currentPool.asset)
@@ -71,7 +73,7 @@ export const thorchainSaversStakingOpportunitiesMetadataResolver = async ({
 
   const thorchainPools = await getThorchainPools()
 
-  if (!thorchainPools?.length) {
+  if (!thorchainPools.length) {
     throw new Error('Error fetching THORChain pools')
   }
 

--- a/src/state/slices/opportunitiesSlice/resolvers/thorchainsavers/index.ts
+++ b/src/state/slices/opportunitiesSlice/resolvers/thorchainsavers/index.ts
@@ -101,7 +101,7 @@ export const thorchainSaversStakingOpportunitiesMetadataResolver = async ({
       ...{
         rewardAssetIds: [maybeAssetId] as [AssetId],
       },
-      // Idle opportunities wrap a single yield-bearing asset, so the ratio will always be 1
+      // Thorchain opportunities represent a single native asset being staked, so the ratio will always be 1
       underlyingAssetRatios: ['1'],
       name: `${underlyingAsset.symbol} Vault`,
     }

--- a/src/state/slices/opportunitiesSlice/resolvers/thorchainsavers/index.ts
+++ b/src/state/slices/opportunitiesSlice/resolvers/thorchainsavers/index.ts
@@ -1,27 +1,47 @@
+import type { AssetId } from '@shapeshiftoss/caip'
 import { adapters } from '@shapeshiftoss/caip'
 import type { ThornodePoolResponse } from '@shapeshiftoss/swapper'
 import axios from 'axios'
 import { getConfig } from 'config'
+import { DefiProvider, DefiType } from 'features/defi/contexts/DefiManagerProvider/DefiCommon'
+import memoize from 'lodash/memoize'
 import { bnOrZero } from 'lib/bignumber/bignumber'
+import { selectAssetById } from 'state/slices/selectors'
 
-import type { GetOpportunityIdsOutput, OpportunityId, StakingId } from '../../types'
+import type {
+  GetOpportunityIdsOutput,
+  GetOpportunityMetadataOutput,
+  OpportunitiesState,
+  OpportunityId,
+  OpportunityMetadata,
+  StakingId,
+} from '../../types'
+import type { OpportunitiesMetadataResolverInput } from '../types'
 
-export const thorchainSaversOpportunityIdsResolver = async (): Promise<{
-  data: GetOpportunityIdsOutput
-}> => {
+const getThorchainPools = memoize(async (): Promise<ThornodePoolResponse[]> => {
   const { data: opportunitiesData } = await axios.get<ThornodePoolResponse[]>(
     `${getConfig().REACT_APP_THORCHAIN_NODE_URL}/lcd/thorchain/pools`,
   )
 
-  if (!opportunitiesData) return { data: [] }
+  if (!opportunitiesData) return []
 
-  const opportunityIds = opportunitiesData.reduce<OpportunityId[]>((acc, currentOpportunity) => {
-    const maybeOpportunityId = adapters.poolAssetIdToAssetId(currentOpportunity.asset)
+  return opportunitiesData
+})
+
+export const thorchainSaversOpportunityIdsResolver = async (): Promise<{
+  data: GetOpportunityIdsOutput
+}> => {
+  const thorchainPools = await getThorchainPools()
+
+  if (!thorchainPools.length) return { data: [] }
+
+  const opportunityIds = thorchainPools.reduce<OpportunityId[]>((acc, currentPool) => {
+    const maybeOpportunityId = adapters.poolAssetIdToAssetId(currentPool.asset)
 
     if (
-      bnOrZero(currentOpportunity.savers_depth).gt(0) &&
+      bnOrZero(currentPool.savers_depth).gt(0) &&
       maybeOpportunityId &&
-      currentOpportunity.status === 'Available'
+      currentPool.status === 'Available'
     ) {
       acc.push(maybeOpportunityId as StakingId)
     }
@@ -32,4 +52,65 @@ export const thorchainSaversOpportunityIdsResolver = async (): Promise<{
   return {
     data: opportunityIds,
   }
+}
+
+export const thorchainSaversStakingOpportunitiesMetadataResolver = async ({
+  opportunityType,
+  reduxApi,
+}: OpportunitiesMetadataResolverInput): Promise<{ data: GetOpportunityMetadataOutput }> => {
+  const thorchainPools = await getThorchainPools()
+
+  if (!thorchainPools?.length) {
+    return {
+      data: {
+        byId: {} as Partial<Record<StakingId, OpportunityMetadata>>,
+        type: opportunityType,
+      },
+    }
+  }
+
+  const { getState } = reduxApi
+  const state: any = getState() // ReduxState causes circular dependency
+
+  const stakingOpportunitiesById: OpportunitiesState[DefiType.Staking]['byId'] = {}
+
+  for (const thorchainPool of thorchainPools) {
+    const maybeAssetId = adapters.poolAssetIdToAssetId(thorchainPool.asset)
+    if (!maybeAssetId) continue
+
+    const opportunityId = maybeAssetId as OpportunityId
+
+    // Thorchain is slightly different from other opportunities in that there is no contract address for the opportunity
+    // The way we represent it, the opportunityId is both the opportunityId/assetId and the underlyingAssetId
+    // That's an oversimplification, as this ties a native AssetId e.g btcAssetId or ethAssetId, to a Savers opportunity
+    // If we were to ever support another native asset staking opportunity e.g Ethereum 2.0 consensus layer staking
+    // we would need to revisit this by using generic keys as an opportunityId
+    const asset = selectAssetById(state, maybeAssetId)
+    const underlyingAsset = selectAssetById(state, maybeAssetId)
+
+    if (!asset || !underlyingAsset) continue
+
+    stakingOpportunitiesById[opportunityId] = {
+      apy: opportunity.apy.toFixed(),
+      assetId: maybeAssetId,
+      provider: DefiProvider.ThorchainSavers,
+      tvl: opportunity.tvl.balance.toFixed(),
+      type: DefiType.Staking,
+      underlyingAssetId: maybeAssetId,
+      underlyingAssetIds: [maybeAssetId] as [AssetId],
+      ...{
+        rewardAssetIds: [maybeAssetId] as [AssetId],
+      },
+      // Idle opportunities wrap a single yield-bearing asset, so the ratio will always be 1
+      underlyingAssetRatios: ['1'],
+      name: `${underlyingAsset.symbol} Vault`,
+    }
+  }
+
+  const data = {
+    byId: stakingOpportunitiesById,
+    type: opportunityType,
+  }
+
+  return { data }
 }

--- a/src/state/slices/opportunitiesSlice/resolvers/thorchainsavers/index.ts
+++ b/src/state/slices/opportunitiesSlice/resolvers/thorchainsavers/index.ts
@@ -4,7 +4,6 @@ import type { ThornodePoolResponse } from '@shapeshiftoss/swapper'
 import axios from 'axios'
 import { getConfig } from 'config'
 import { DefiProvider, DefiType } from 'features/defi/contexts/DefiManagerProvider/DefiCommon'
-import memoize from 'lodash/memoize'
 import { bn, bnOrZero } from 'lib/bignumber/bignumber'
 import { selectAssetById, selectFeatureFlags, selectMarketDataById } from 'state/slices/selectors'
 
@@ -19,7 +18,7 @@ import type { OpportunitiesMetadataResolverInput } from '../types'
 
 const THOR_PRECISION = 8
 
-const getThorchainPools = memoize(async (): Promise<ThornodePoolResponse[]> => {
+const getThorchainPools = async (): Promise<ThornodePoolResponse[]> => {
   const { data: opportunitiesData } = await axios.get<ThornodePoolResponse[]>(
     `${getConfig().REACT_APP_THORCHAIN_NODE_URL}/lcd/thorchain/pools`,
   )
@@ -27,7 +26,7 @@ const getThorchainPools = memoize(async (): Promise<ThornodePoolResponse[]> => {
   if (!opportunitiesData) return []
 
   return opportunitiesData
-})
+}
 
 export const thorchainSaversOpportunityIdsResolver = async (): Promise<{
   data: GetOpportunityIdsOutput

--- a/src/state/slices/opportunitiesSlice/resolvers/thorchainsavers/index.ts
+++ b/src/state/slices/opportunitiesSlice/resolvers/thorchainsavers/index.ts
@@ -100,7 +100,7 @@ export const thorchainSaversStakingOpportunitiesMetadataResolver = async ({
       .toFixed()
 
     stakingOpportunitiesById[opportunityId] = {
-      // TODO(gomes): saversApr is exposed from https://midgard.ninerealms.com/v2/pools which we don't proxy yet
+      // TODO(gomes): saversApr is exposed from https://midgard.ninerealms.com/v2/pools - we need to update our Midgard to support it
       // This is a function of liquidity over the last 4-5 days, so we can't just calculate it in the client
       apy: '42',
       assetId,

--- a/src/state/slices/opportunitiesSlice/resolvers/thorchainsavers/index.ts
+++ b/src/state/slices/opportunitiesSlice/resolvers/thorchainsavers/index.ts
@@ -6,7 +6,7 @@ import { getConfig } from 'config'
 import { DefiProvider, DefiType } from 'features/defi/contexts/DefiManagerProvider/DefiCommon'
 import memoize from 'lodash/memoize'
 import { bn, bnOrZero } from 'lib/bignumber/bignumber'
-import { selectAssetById, selectMarketDataById } from 'state/slices/selectors'
+import { selectAssetById, selectFeatureFlags, selectMarketDataById } from 'state/slices/selectors'
 
 import type {
   GetOpportunityIdsOutput,
@@ -61,7 +61,12 @@ export const thorchainSaversStakingOpportunitiesMetadataResolver = async ({
   opportunityType,
   reduxApi,
 }: OpportunitiesMetadataResolverInput): Promise<{ data: GetOpportunityMetadataOutput }> => {
-  if (!opportunityIds?.length) {
+  const { getState } = reduxApi
+  const state: any = getState() // ReduxState causes circular dependency
+
+  const { SaversVaults } = selectFeatureFlags(state)
+
+  if (!(SaversVaults && opportunityIds?.length)) {
     return {
       data: {
         byId: {} as Partial<Record<StakingId, OpportunityMetadata>>,
@@ -80,9 +85,6 @@ export const thorchainSaversStakingOpportunitiesMetadataResolver = async ({
       },
     }
   }
-
-  const { getState } = reduxApi
-  const state: any = getState() // ReduxState causes circular dependency
 
   const stakingOpportunitiesById: OpportunitiesState[DefiType.Staking]['byId'] = {}
 

--- a/src/state/slices/opportunitiesSlice/resolvers/types.ts
+++ b/src/state/slices/opportunitiesSlice/resolvers/types.ts
@@ -6,6 +6,7 @@ import type { OpportunityDefiType, OpportunityId } from '../types'
 export type ReduxApi = Pick<BaseQueryApi, 'dispatch' | 'getState'>
 
 export type OpportunitiesMetadataResolverInput = {
+  opportunityIds?: OpportunityId[]
   opportunityType: OpportunityDefiType
   reduxApi: ReduxApi
 }

--- a/src/state/slices/opportunitiesSlice/thunks.ts
+++ b/src/state/slices/opportunitiesSlice/thunks.ts
@@ -37,6 +37,17 @@ export const fetchAllStakingOpportunitiesMetadata = async (
       opportunitiesApi.endpoints.getOpportunitiesMetadata.initiate(
         {
           defiType: DefiType.Staking,
+          defiProvider: DefiProvider.ThorchainSavers,
+          opportunityType: DefiType.Staking,
+        },
+        // Any previous query without portfolio loaded will be rejected, the first successful one will be cached
+        { forceRefetch: false, ...options },
+      ),
+    ),
+    store.dispatch(
+      opportunitiesApi.endpoints.getOpportunitiesMetadata.initiate(
+        {
+          defiType: DefiType.Staking,
           defiProvider: DefiProvider.Idle,
           opportunityType: DefiType.Staking,
         },


### PR DESCRIPTION
## Description

This PR resolves and populates `DefiProvider.ThorchainSavers` opportunities.

Notes:

- APR cannot yet be fetched - to be fixed in a follow-up web PR after we upgrade our Midgard proxy:

https://github.com/shapeshift/web/blob/a369170145b78979ee9f9482664a50b75e5fe858/src/state/slices/opportunitiesSlice/resolvers/thorchainsavers/index.ts#L103-L105

- Ethereum opportunity doesn't yet appear, figure out why and fix it in a follow-up web PR

## Notice

<!-- Before submitting a pull request, please make sure you have answered the following: -->

- [x] Have you followed the guidelines in our [Contributing]('https://github.com/shapeshift/web/blob/develop/CONTRIBUTING.md) guide?
- [x] Have you checked to ensure there aren't other open [Pull Requests](https://github.com/shapeshift/web/pulls) for the same update/change?

## Pull Request Type

- [ ] :bug: Bug fix (Non-breaking Change: Fixes an issue)
- [ ] :hammer_and_wrench: Chore (Non-breaking Change: Doc updates, pkg upgrades, typos, etc..)
- [x] :nail_care: New Feature (Breaking/Non-breaking Change)

## Issue (if applicable)

- Tackles https://github.com/shapeshift/web/issues/3584

## Risk

In theory, none given the resolver short circuits with the flag off right at entrypoint - in practice, see ops testing notes for actual risks given the slight refactor

## Testing

<!-----------------------------------------------------------------------------
We treat every PR to be merged with the same scrutiny as if we were merging directly to production.

Your PR will not be merged if you do not complete the sections below for our engineering and operations teams to test.
------------------------------------------------------------------------------>

### Engineering

- Toggle `REACT_APP_FEATURE_SAVERS_VAULTS`
- Ensure Thorchain Savers metadata is populated in store

<!-----------------------------------------------------------------------------
Include sufficient information here for an engineer to test your PR. This may include how to test locally, in a built environment, changes to infrastructure etc.
------------------------------------------------------------------------------>

### Operations

- Logic has been slightly revamped because tsc is drunk - clear your persisted opportunities cache and confirm no regressions

<!-----------------------------------------------------------------------------
If your changes have a user-facing impact, describe how a non-technical QA team can functionally test your changes in a preview environment.

If they are not user-facing please describe how to test for any regressions that may occur.
------------------------------------------------------------------------------>

## Screenshots (if applicable)

<img width="1178" alt="image" src="https://user-images.githubusercontent.com/17035424/211299484-976607d8-c2b4-4a42-91f8-8257eec40a92.png">
