### PR TITLE
feat(foxFarming): granularily refetch staking userData only

### DIFF
--- a/src/context/FoxEthProvider/FoxEthProvider.tsx
+++ b/src/context/FoxEthProvider/FoxEthProvider.tsx
@@ -124,7 +124,7 @@ export const FoxEthProvider = ({ children }: FoxEthProviderProps) => {
   useEffect(() => {
     if (farmingAccountId && transaction && transaction.status !== TxStatus.Pending) {
       if (transaction.status === TxStatus.Confirmed) {
-        moduleLogger.info('Refetching fox lp/farming opportunities')
+        moduleLogger.info('Refetching ETH/FOX staking opportunities')
         refetchFoxEthStakingAccountData()
         if (ongoingTxContractAddress)
           dispatch(

--- a/src/context/FoxEthProvider/FoxEthProvider.tsx
+++ b/src/context/FoxEthProvider/FoxEthProvider.tsx
@@ -10,15 +10,11 @@ import { getChainAdapterManager } from 'context/PluginProvider/chainAdapterSingl
 import { useWallet } from 'hooks/useWallet/useWallet'
 import { logger } from 'lib/logger'
 import { opportunitiesApi } from 'state/slices/opportunitiesSlice/opportunitiesSlice'
-import {
-  fetchAllOpportunitiesMetadata,
-  fetchAllOpportunitiesUserData,
-} from 'state/slices/opportunitiesSlice/thunks'
+import { fetchAllStakingOpportunitiesUserData } from 'state/slices/opportunitiesSlice/thunks'
 import { toOpportunityId } from 'state/slices/opportunitiesSlice/utils'
 import {
   selectAssetById,
   selectBIP44ParamsByAccountId,
-  selectLpAccountIds,
   selectStakingAccountIds,
   selectTxById,
 } from 'state/slices/selectors'
@@ -67,24 +63,16 @@ export const FoxEthProvider = ({ children }: FoxEthProviderProps) => {
   const [farmingAccountId, setFarmingAccountId] = useState<AccountId | undefined>()
   const [lpAccountId, setLpAccountId] = useState<AccountId | undefined>()
 
-  const lpAccountIds = useAppSelector(selectLpAccountIds)
   const stakingAccountIds = useAppSelector(selectStakingAccountIds)
 
-  const refetchFoxEthLpAccountData = useCallback(async () => {
+  const refetchFoxEthStakingAccountData = useCallback(async () => {
     await Promise.all(
-      lpAccountIds.map(
-        async accountId => await fetchAllOpportunitiesUserData(accountId, { forceRefetch: true }),
+      stakingAccountIds.map(
+        async accountId =>
+          await fetchAllStakingOpportunitiesUserData(accountId, { forceRefetch: true }),
       ),
     )
-  }, [lpAccountIds])
-
-  useEffect(() => {
-    fetchAllOpportunitiesMetadata()
-  }, [lpAccountIds, stakingAccountIds, dispatch, refetchFoxEthLpAccountData])
-
-  useEffect(() => {
-    refetchFoxEthLpAccountData()
-  }, [refetchFoxEthLpAccountData])
+  }, [stakingAccountIds])
 
   const lpAccountFilter = useMemo(() => ({ accountId: lpAccountId }), [lpAccountId])
   const lpBip44Params = useAppSelector(state =>
@@ -137,7 +125,7 @@ export const FoxEthProvider = ({ children }: FoxEthProviderProps) => {
     if (farmingAccountId && transaction && transaction.status !== TxStatus.Pending) {
       if (transaction.status === TxStatus.Confirmed) {
         moduleLogger.info('Refetching fox lp/farming opportunities')
-        refetchFoxEthLpAccountData()
+        refetchFoxEthStakingAccountData()
         if (ongoingTxContractAddress)
           dispatch(
             opportunitiesApi.endpoints.getOpportunityUserData.initiate(
@@ -165,7 +153,7 @@ export const FoxEthProvider = ({ children }: FoxEthProviderProps) => {
     dispatch,
     farmingAccountId,
     ongoingTxContractAddress,
-    refetchFoxEthLpAccountData,
+    refetchFoxEthStakingAccountData,
     transaction,
   ])
 

--- a/src/state/slices/opportunitiesSlice/selectors.ts
+++ b/src/state/slices/opportunitiesSlice/selectors.ts
@@ -68,11 +68,6 @@ export const selectUserStakingOpportunitiesById = createSelector(
 export const selectStakingOpportunitiesById = (state: ReduxState) =>
   state.opportunities.staking.byId
 
-export const selectLpAccountIds = createDeepEqualOutputSelector(
-  selectLpOpportunitiesByAccountId,
-  (byAccountId): AccountId[] => Object.keys(byAccountId),
-)
-
 export const selectStakingAccountIds = createDeepEqualOutputSelector(
   selectStakingOpportunitiesByAccountId,
   (byAccountId): AccountId[] => Object.keys(byAccountId),


### PR DESCRIPTION
## Description

The current re/fetch on `<FoxEthProvider />` mechanism was a relic of the previous one which didn't use the opportunities abstraction:

- We should never select / re/fetch ETH/FOX LP userData. LP data is simply portfolio data, and the porfolio handles that as it should - the matching resolver is really just a check within the abstraction, *introspecting* portfolio balances for the LP token to check readiness, but not actually *resolving* it. Removed the relevant selector and its usage
- We should not call `fetchAllOpportunitiesUserData` when what we actually need is to only fetch *staking* data - `fetchAllStakingOpportunitiesUserData` is the guy, though still not optimized, we should make it fetch ETH/FOX staking data only in a follow-up PR
- We should not fetch opportunities data when this provider mounts. `<AppContext />` run thunks fetching opportunities ids - metadata - userData in that order for a reason, and `<FoxEthProvider />` broke the order, effectively firing useless RTK queries

This looks like this is only a `perf` improvement, but this really is a feat/preventive fix. Spotted while working on https://github.com/shapeshift/web/pull/3583 and running a debugger, this rugs the whole order of thunks

## Notice

<!-- Before submitting a pull request, please make sure you have answered the following: -->

- [x] Have you followed the guidelines in our [Contributing]('https://github.com/shapeshift/web/blob/develop/CONTRIBUTING.md) guide?
- [x] Have you checked to ensure there aren't other open [Pull Requests](https://github.com/shapeshift/web/pulls) for the same update/change?

## Pull Request Type

- [ ] :bug: Bug fix (Non-breaking Change: Fixes an issue)
- [ ] :hammer_and_wrench: Chore (Non-breaking Change: Doc updates, pkg upgrades, typos, etc..)
- [x] :nail_care: New Feature (Breaking/Non-breaking Change)

## Issue (if applicable)

N/A

## Risk

ETH/FOX LP could be broken, test accordingly - tested with purged persisted store, confirmed opportunities are still fetched on initial load, re-fetched on staking Txs, and we're still reactive on LP txs

## Testing

<!-----------------------------------------------------------------------------
We treat every PR to be merged with the same scrutiny as if we were merging directly to production.

Your PR will not be merged if you do not complete the sections below for our engineering and operations teams to test.
------------------------------------------------------------------------------>

- Clear your persisted redux store
- ETH/FOX LP and farming opportunities should still load
- FOX Farming data should still update after a deposit/withdraw/claim Tx
- ETH/FOX LP data should still update after a deposit/withdraw Tx

### Engineering

<!-----------------------------------------------------------------------------
Include sufficient information here for an engineer to test your PR. This may include how to test locally, in a built environment, changes to infrastructure etc.
------------------------------------------------------------------------------>

- ☝🏽
- Ensure opportunity IDs are consistently fetched first

### Operations

<!-----------------------------------------------------------------------------
If your changes have a user-facing impact, describe how a non-technical QA team can functionally test your changes in a preview environment.

If they are not user-facing please describe how to test for any regressions that may occur.
------------------------------------------------------------------------------>

☝🏽 

## Screenshots (if applicable)
