### PR TITLE
feat: wire up thorchain savers metadata/overview

### DIFF
--- a/src/components/StakingVaults/AllEarnOpportunities.tsx
+++ b/src/components/StakingVaults/AllEarnOpportunities.tsx
@@ -10,7 +10,6 @@ import type { EarnOpportunityType } from 'features/defi/helpers/normalizeOpportu
 import { useNormalizeOpportunities } from 'features/defi/helpers/normalizeOpportunity'
 import qs from 'qs'
 import { useCallback, useMemo } from 'react'
-import { useSelector } from 'react-redux'
 import { useHistory, useLocation } from 'react-router'
 import { Card } from 'components/Card/Card'
 import { Text } from 'components/Text'
@@ -24,36 +23,11 @@ import type { StakingId } from 'state/slices/opportunitiesSlice/types'
 import {
   selectAggregatedEarnUserLpOpportunity,
   selectAggregatedEarnUserStakingOpportunitiesIncludeEmpty,
-  selectFeatureFlags,
   selectFirstAccountIdByChainId,
 } from 'state/slices/selectors'
 import { useAppSelector } from 'state/store'
 
 import { StakingTable } from './StakingTable'
-
-// TODO (gomes) delete this after we get resolvers setup
-
-const exampleSaverVault: EarnOpportunityType = {
-  contractAddress: '0xa354f35829ae975e850e23e9615b11da1b3dc4de',
-  apy: '0.02711977967163448',
-  assetId: 'eip155:1/erc20:0xa354f35829ae975e850e23e9615b11da1b3dc4de',
-  provider: 'THORChain Savers',
-  tvl: '36780518.043089',
-  type: 'staking',
-  underlyingAssetId: 'eip155:1/erc20:0xa354f35829ae975e850e23e9615b11da1b3dc4de',
-  version: '0.4.3',
-  expired: false,
-  rewardAddress: '0x1234',
-  chainId: 'eip155:1',
-  cryptoAmountPrecision: '0.721463',
-  cryptoAmountBaseUnit: '721463',
-  fiatAmount: '0.73911939776344621755',
-  isLoaded: true,
-  icons: [
-    'https://rawcdn.githack.com/trustwallet/assets/master/blockchains/ethereum/assets/0xA0b86991c6218b36c1d19D4a2e9Eb0cE3606eB48/logo.png',
-  ],
-  opportunityName: 'USDC Vault',
-}
 
 export const AllEarnOpportunities = () => {
   const history = useHistory()
@@ -62,8 +36,6 @@ export const AllEarnOpportunities = () => {
     state: { isConnected, isDemoWallet },
     dispatch,
   } = useWallet()
-
-  const { SaversVaults } = useSelector(selectFeatureFlags)
 
   const { data: foxyBalancesData } = useFoxyBalances()
 
@@ -112,8 +84,6 @@ export const AllEarnOpportunities = () => {
         !opportunity.expired ||
         (opportunity.expired && bnOrZero(opportunity.cryptoAmountBaseUnit).gt(0)),
     ),
-    // TODO (gomes) delete this after we get resolvers setup
-    saversVaults: SaversVaults ? [exampleSaverVault] : [],
   })
 
   const filteredRows = useMemo(
@@ -129,7 +99,7 @@ export const AllEarnOpportunities = () => {
   const handleClick = useCallback(
     (opportunity: EarnOpportunityType) => {
       const { provider, contractAddress, chainId, rewardAddress, assetId } = opportunity
-      const { assetReference } = fromAssetId(assetId)
+      const { assetReference, assetNamespace } = fromAssetId(assetId)
       const defaultAccountId = assetId === cosmosAssetId ? cosmosAccountId : osmosisAccountId
 
       if (!isConnected && isDemoWallet) {
@@ -144,6 +114,7 @@ export const AllEarnOpportunities = () => {
           chainId,
           defaultAccountId,
           contractAddress,
+          assetNamespace,
           assetReference,
           highestBalanceAccountAddress: opportunity.highestBalanceAccountAddress,
           rewardId: rewardAddress,

--- a/src/components/StakingVaults/EarnOpportunities.tsx
+++ b/src/components/StakingVaults/EarnOpportunities.tsx
@@ -80,7 +80,7 @@ export const EarnOpportunities = ({ assetId, accountId }: EarnOpportunitiesProps
 
   const handleClick = (opportunity: EarnOpportunityType) => {
     const { provider, contractAddress, chainId, assetId, rewardAddress } = opportunity
-    const { assetReference } = fromAssetId(assetId)
+    const { assetReference, assetNamespace } = fromAssetId(assetId)
     if (!isConnected) {
       dispatch({ type: WalletActions.SET_WALLET_MODAL, payload: true })
       return
@@ -91,6 +91,7 @@ export const EarnOpportunities = ({ assetId, accountId }: EarnOpportunitiesProps
       search: qs.stringify({
         chainId,
         contractAddress,
+        assetNamespace,
         assetReference,
         highestBalanceAccountAddress: opportunity.highestBalanceAccountAddress,
         rewardId: rewardAddress,

--- a/src/features/defi/contexts/DefiManagerProvider/DefiCommon.ts
+++ b/src/features/defi/contexts/DefiManagerProvider/DefiCommon.ts
@@ -1,4 +1,4 @@
-import type { AccountId, ChainId } from '@shapeshiftoss/caip'
+import type { AccountId, AssetNamespace, AssetReference, ChainId } from '@shapeshiftoss/caip'
 
 export enum DefiType {
   LiquidityPool = 'lp',
@@ -46,7 +46,8 @@ export type DefiQueryParams = {
   chainId: ChainId
   highestBalanceAccountAddress?: string
   contractAddress: string
-  assetReference: string
+  assetNamespace: AssetNamespace
+  assetReference: AssetReference
   rewardId: string
   modal: string
   provider: string

--- a/src/features/defi/helpers/normalizeOpportunity.tsx
+++ b/src/features/defi/helpers/normalizeOpportunity.tsx
@@ -11,7 +11,7 @@ export type EarnOpportunityType = {
   type?: string
   provider: string
   version?: string
-  contractAddress: string
+  contractAddress?: string
   rewardAddress: string
   apy?: number | string
   tvl: string
@@ -107,7 +107,6 @@ type NormalizeOpportunitiesProps = {
   cosmosSdkStakingOpportunities: MergedActiveStakingOpportunity[]
   foxEthLpOpportunity?: EarnOpportunityType
   stakingOpportunities?: EarnOpportunityType[]
-  saversVaults?: EarnOpportunityType[]
 }
 
 export const useNormalizeOpportunities = ({
@@ -115,13 +114,11 @@ export const useNormalizeOpportunities = ({
   cosmosSdkStakingOpportunities = [],
   foxEthLpOpportunity,
   stakingOpportunities,
-  saversVaults,
 }: NormalizeOpportunitiesProps): EarnOpportunityType[] => {
   return [
     ...transformFoxy(foxyArray),
     ...useTransformCosmosStaking(cosmosSdkStakingOpportunities),
     ...(stakingOpportunities ? stakingOpportunities : []),
     ...(foxEthLpOpportunity ? [foxEthLpOpportunity] : []),
-    ...(saversVaults ? saversVaults : []),
   ]
 }

--- a/src/pages/Defi/components/OpportunityCard.tsx
+++ b/src/pages/Defi/components/OpportunityCard.tsx
@@ -70,7 +70,7 @@ export const OpportunityCard = ({
   const asset = useAppSelector(state => selectAssetById(state, underlyingAssetId ?? assetId))
   if (!asset) throw new Error(`Asset not found for AssetId ${underlyingAssetId}`)
 
-  const { assetReference } = fromAssetId(assetId)
+  const { assetReference, assetNamespace } = fromAssetId(assetId)
 
   const assets = useAppSelector(selectAssets)
 
@@ -88,6 +88,7 @@ export const OpportunityCard = ({
           chainId,
           highestBalanceAccountAddress,
           contractAddress,
+          assetNamespace,
           assetReference,
           rewardId: rewardAddress,
           modal: 'overview',

--- a/src/state/slices/opportunitiesSlice/selectors.ts
+++ b/src/state/slices/opportunitiesSlice/selectors.ts
@@ -8,7 +8,7 @@ import sumBy from 'lodash/sumBy'
 import uniqBy from 'lodash/uniqBy'
 import { bn, bnOrZero } from 'lib/bignumber/bignumber'
 import { fromBaseUnit, toBaseUnit } from 'lib/math'
-import { isSome } from 'lib/utils'
+import { isSome, isToken } from 'lib/utils'
 import type { ReduxState } from 'state/reducer'
 import { createDeepEqualOutputSelector } from 'state/selector-utils'
 import {
@@ -296,12 +296,14 @@ export const selectAggregatedEarnUserStakingOpportunities = createDeepEqualOutpu
 
       return Object.assign(
         {},
-        {
-          // TODO: The guts of getting contractAddress for Idle
-          // ETH/FOX opportunities contractAddress will be overwritten by STAKING_EARN_OPPORTUNITIES
-          // Can we generalize this? This is getting messy
-          contractAddress: fromAssetId(opportunity.underlyingAssetId).assetReference,
-        },
+        isToken(fromAssetId(opportunity.underlyingAssetId).assetReference)
+          ? {
+              // TODO: The guts of getting contractAddress for Idle
+              // ETH/FOX opportunities contractAddress will be overwritten by STAKING_EARN_OPPORTUNITIES
+              // Can we generalize this? This is getting messy
+              contractAddress: fromAssetId(opportunity.underlyingAssetId).assetReference,
+            }
+          : {},
         STAKING_EARN_OPPORTUNITIES[opportunity.assetId],
         opportunity,
         {
@@ -339,12 +341,14 @@ export const selectAggregatedEarnUserStakingOpportunitiesIncludeEmpty =
         .reduce((acc, opportunity) => {
           const earnOpportunity = Object.assign(
             {},
-            {
-              // TODO: The guts of getting contractAddress for Idle
-              // ETH/FOX opportunities contractAddress will be overwritten by STAKING_EARN_OPPORTUNITIES
-              // Can we generalize this? This is getting messy
-              contractAddress: fromAssetId(opportunity.underlyingAssetId).assetReference,
-            },
+            isToken(fromAssetId(opportunity.underlyingAssetId).assetReference)
+              ? {
+                  // TODO: The guts of getting contractAddress for Idle
+                  // ETH/FOX opportunities contractAddress will be overwritten by STAKING_EARN_OPPORTUNITIES
+                  // Can we generalize this? This is getting messy
+                  contractAddress: fromAssetId(opportunity.underlyingAssetId).assetReference,
+                }
+              : {},
             STAKING_EARN_OPPORTUNITIES[opportunity.assetId],
             opportunity,
             {
@@ -367,7 +371,7 @@ export const selectAggregatedEarnUserStakingOpportunitiesIncludeEmpty =
       // Keep only the version with actual data if it exists, else keep the zero'd out version
       const aggregatedEarnUserStakingOpportunitiesIncludeEmpty = uniqBy(
         [...aggregatedEarnUserStakingOpportunities, ...emptyEarnOpportunitiesTypes],
-        'contractAddress',
+        ({ contractAddress, assetId }) => contractAddress ?? assetId,
       )
 
       return aggregatedEarnUserStakingOpportunitiesIncludeEmpty.filter(opportunity => {


### PR DESCRIPTION
## Description

First wire-up of Thorchain Savers metadata with functional overview modal.

Note, cap will need to bring a new concept of `opportunitySpecific` discriminated union a la `chainSpecific` - to be done in https://github.com/shapeshift/web/issues/3595.

## Notice

<!-- Before submitting a pull request, please make sure you have answered the following: -->

- [x] Have you followed the guidelines in our [Contributing]('https://github.com/shapeshift/web/blob/develop/CONTRIBUTING.md) guide?
- [x] Have you checked to ensure there aren't other open [Pull Requests](https://github.com/shapeshift/web/pulls) for the same update/change?

## Pull Request Type

- [ ] :bug: Bug fix (Non-breaking Change: Fixes an issue)
- [ ] :hammer_and_wrench: Chore (Non-breaking Change: Doc updates, pkg upgrades, typos, etc..)
- [x] :nail_care: New Feature (Breaking/Non-breaking Change)

## Issue (if applicable)

<!-----------------------------------------------------------------------------
If applicable, please link to the github issue and put `closes #XXXX` in your comment to auto-close the issue that your PR fixes.
------------------------------------------------------------------------------>

closes https://github.com/shapeshift/web/issues/3584

## Risk

<!-----------------------------------------------------------------------------
Outline the scope of your changes and the risk associated with them. You must use your discretion as an engineer to determine the potential impact of your changes.

E.g. an upgrade to `hdwallet` or core state management would be considered higher risk, and might require a full regression test. UI or isolated view changes, or something behind a feature flag may have near zero risk. Small bug fixes might require testing isolated to the specific fix.
------------------------------------------------------------------------------>

Low given Thorchain savers metadata resolution is under flag, though the selectors logic has been slightly revamped, which could cause regressions.

## Testing

<!-----------------------------------------------------------------------------
We treat every PR to be merged with the same scrutiny as if we were merging directly to production.

Your PR will not be merged if you do not complete the sections below for our engineering and operations teams to test.
------------------------------------------------------------------------------>

- Enable the `SaversVaults` flag
- Ensure opportunity details is matching the one in https://app.thorswap.finance/earn / https://app.thoryield.com/savers

### Engineering

<!-----------------------------------------------------------------------------
Include sufficient information here for an engineer to test your PR. This may include how to test locally, in a built environment, changes to infrastructure etc.
------------------------------------------------------------------------------>

- This reads as sane code
- ☝🏽 

### Operations

<!-----------------------------------------------------------------------------
If your changes have a user-facing impact, describe how a non-technical QA team can functionally test your changes in a preview environment.

If they are not user-facing please describe how to test for any regressions that may occur.
------------------------------------------------------------------------------>

-☝🏽doesn't need to be tested since this is under flag
- Clear your cache and ensure opportunities still load as before (note intermittent node failures can happen in all envs and are *not* related to this PR)

## Screenshots (if applicable)

<img width="1242" alt="image" src="https://user-images.githubusercontent.com/17035424/211416675-5e48a7ba-0ac0-4505-ab1e-516361254ed4.png">
<img width="510" alt="image" src="https://user-images.githubusercontent.com/17035424/211420812-5793e075-0daa-4485-9de7-eb9a5944becb.png">
<img width="511" alt="image" src="https://user-images.githubusercontent.com/17035424/211420830-78ccb0a9-6386-400d-a58f-96af001596ae.png">
<img width="508" alt="image" src="https://user-images.githubusercontent.com/17035424/211420861-93988935-5f48-433c-89a5-2fd7b0f4a087.png">