### PR TITLE
fix: don't throw in Cosmos SDK <Withdraw /> render while assetId is loading

### DIFF
--- a/src/features/defi/providers/cosmos/components/CosmosManager/Claim/components/Confirm.tsx
+++ b/src/features/defi/providers/cosmos/components/CosmosManager/Claim/components/Confirm.tsx
@@ -1,6 +1,6 @@
 import { Button, Link, Skeleton, SkeletonText, Stack, useToast } from '@chakra-ui/react'
 import type { AccountId } from '@shapeshiftoss/caip'
-import { ethAssetId, toAssetId } from '@shapeshiftoss/caip'
+import { toAssetId } from '@shapeshiftoss/caip'
 import type {
   DefiParams,
   DefiQueryParams,
@@ -61,7 +61,6 @@ export const Confirm: React.FC<ConfirmProps> = ({ accountId, onNext }) => {
   const feeAsset = useAppSelector(state => selectAssetById(state, feeAssetId))
   const feeMarketData = useAppSelector(state => selectMarketDataById(state, feeAssetId))
 
-  if (!asset) throw new Error(`Asset not found for AssetId ${ethAssetId}`)
   if (!feeAsset) throw new Error(`Fee asset not found for AssetId ${feeAssetId}`)
 
   const toast = useToast()
@@ -96,7 +95,16 @@ export const Confirm: React.FC<ConfirmProps> = ({ accountId, onNext }) => {
   const bip44Params = useAppSelector(state => selectBIP44ParamsByAccountId(state, accountFilter))
 
   const handleConfirm = useCallback(async () => {
-    if (!(walletState.wallet && contractAddress && state?.userAddress && dispatch && bip44Params))
+    if (
+      !(
+        asset &&
+        walletState.wallet &&
+        contractAddress &&
+        state?.userAddress &&
+        dispatch &&
+        bip44Params
+      )
+    )
       return
     dispatch({ type: CosmosClaimActionType.SET_LOADING, payload: true })
 

--- a/src/features/defi/providers/cosmos/components/CosmosManager/Claim/components/Confirm.tsx
+++ b/src/features/defi/providers/cosmos/components/CosmosManager/Claim/components/Confirm.tsx
@@ -117,7 +117,7 @@ export const Confirm: React.FC<ConfirmProps> = ({ accountId, onNext }) => {
         validator: contractAddress,
         chainSpecific: {
           gas: gasLimit,
-          fee: bnOrZero(gasPrice).times(`1e+${asset?.precision}`).toString(),
+          fee: bnOrZero(gasPrice).times(`1e+${asset.precision}`).toString(),
         },
         value: bnOrZero(claimAmount).times(`1e+${asset.precision}`).toString(),
         action: StakingAction.Claim,
@@ -162,7 +162,7 @@ export const Confirm: React.FC<ConfirmProps> = ({ accountId, onNext }) => {
             fontSize='3xl'
             fontWeight='medium'
             value={bnOrZero(claimAmount).div(`1e+${asset.precision}`).toString()}
-            symbol={asset?.symbol}
+            symbol={asset.symbol}
           />
         </Stack>
       </Stack>
@@ -176,7 +176,7 @@ export const Confirm: React.FC<ConfirmProps> = ({ accountId, onNext }) => {
               <Link
                 isExternal
                 color='blue.500'
-                href={`${asset?.explorerAddressLink}${accountId ?? state.userAddress}`}
+                href={`${asset.explorerAddressLink}${accountId ?? state.userAddress}`}
               >
                 {state.userAddress && <MiddleEllipsis value={accountId ?? state.userAddress} />}
               </Link>


### PR DESCRIPTION
## Description

Precisely what the PR title says - the extra safety made the render loop with loading `assetId` crash the component, kicking the error boundary in

## Notice

<!-- Before submitting a pull request, please make sure you have answered the following: -->

- [x] Have you followed the guidelines in our [Contributing]('https://github.com/shapeshift/web/blob/develop/CONTRIBUTING.md) guide?
- [x] Have you checked to ensure there aren't other open [Pull Requests](https://github.com/shapeshift/web/pulls) for the same update/change?

## Pull Request Type

- [x] :bug: Bug fix (Non-breaking Change: Fixes an issue)
- [ ] :hammer_and_wrench: Chore (Non-breaking Change: Doc updates, pkg upgrades, typos, etc..)
- [ ] :nail_care: New Feature (Breaking/Non-breaking Change)

## Issue (if applicable)

- closes https://github.com/shapeshift/web/issues/3588

## Risk

<!-----------------------------------------------------------------------------
Outline the scope of your changes and the risk associated with them. You must use your discretion as an engineer to determine the potential impact of your changes.

E.g. an upgrade to `hdwallet` or core state management would be considered higher risk, and might require a full regression test. UI or isolated view changes, or something behind a feature flag may have near zero risk. Small bug fixes might require testing isolated to the specific fix.
------------------------------------------------------------------------------>

N/A

## Testing

<!-----------------------------------------------------------------------------
We treat every PR to be merged with the same scrutiny as if we were merging directly to production.

Your PR will not be merged if you do not complete the sections below for our engineering and operations teams to test.
------------------------------------------------------------------------------>

- While having some active position with claimable amounts for ATOM, open the relevant card/row
- Confirm clicking Claim doesn't result in an errored state and it is possible to continue with the flow

### Engineering

<!-----------------------------------------------------------------------------
Include sufficient information here for an engineer to test your PR. This may include how to test locally, in a built environment, changes to infrastructure etc.
------------------------------------------------------------------------------>

☝🏽 

### Operations

<!-----------------------------------------------------------------------------
If your changes have a user-facing impact, describe how a non-technical QA team can functionally test your changes in a preview environment.

If they are not user-facing please describe how to test for any regressions that may occur.
------------------------------------------------------------------------------>

☝🏽 

## Screenshots (if applicable)

<img width="525" alt="image" src="https://user-images.githubusercontent.com/17035424/211402918-a9d29a60-6d3a-44ec-bb14-e3843ec582b6.png">