### PR TITLE
feat: handle THORSwap halts

### DIFF
--- a/package.json
+++ b/package.json
@@ -103,7 +103,7 @@
     "@shapeshiftoss/investor-yearn": "^6.3.0",
     "@shapeshiftoss/logger": "^1.1.3",
     "@shapeshiftoss/market-service": "^7.2.2",
-    "@shapeshiftoss/swapper": "15.2.2",
+    "@shapeshiftoss/swapper": "15.3.0",
     "@shapeshiftoss/types": "8.3.3",
     "@shapeshiftoss/unchained-client": "^10.8.0",
     "@uniswap/sdk": "^3.0.3",

--- a/src/assets/translations/en/main.json
+++ b/src/assets/translations/en/main.json
@@ -626,7 +626,7 @@
       "rateError": "We're not able to get a quote for this pair",
       "assetNotSupportedByWallet": "%{assetSymbol} not supported by wallet",
       "noReceiveAddress": "No receive address for %{assetSymbol}",
-      "tradingNotActive": "Trading currently halted %{assetSymbol}",
+      "tradingNotActive": "Trading currently halted for %{assetSymbol}",
       "signing": {
         "failed": "An error occurred signing the transaction",
         "required": "A signed transaction is required"

--- a/src/assets/translations/en/main.json
+++ b/src/assets/translations/en/main.json
@@ -626,6 +626,7 @@
       "rateError": "We're not able to get a quote for this pair",
       "assetNotSupportedByWallet": "%{assetSymbol} not supported by wallet",
       "noReceiveAddress": "No receive address for %{assetSymbol}",
+      "tradingNotActive": "Trading currently halted %{assetSymbol}",
       "signing": {
         "failed": "An error occurred signing the transaction",
         "required": "A signed transaction is required"

--- a/src/components/Trade/TradeInput.tsx
+++ b/src/components/Trade/TradeInput.tsx
@@ -52,7 +52,7 @@ export const TradeInput = () => {
   const [isLoading, setIsLoading] = useState(false)
 
   const { setTradeAmountsUsingExistingData, setTradeAmountsRefetchData } = useTradeAmounts()
-  const { isTradingActiveOnSellChain } = useIsTradingActive()
+  const { isTradingActiveOnSellPool } = useIsTradingActive()
   const {
     checkApprovalNeeded,
     getTrade,
@@ -331,7 +331,7 @@ export const TradeInput = () => {
             buyTradeAsset?.asset?.symbol ?? translate('trade.errors.buyAssetStartSentence'),
         },
       ]
-    if (!isTradingActiveOnSellChain) {
+    if (!isTradingActiveOnSellPool) {
       return [
         'trade.errors.tradingNotActive',
         {
@@ -369,7 +369,7 @@ export const TradeInput = () => {
     hasValidSellAmount,
     isBelowMinSellAmount,
     isTradeQuotePending,
-    isTradingActiveOnSellChain,
+    isTradingActiveOnSellPool,
     quote?.feeData.networkFeeCryptoBaseUnit,
     quote?.minimum,
     quote?.sellAsset.symbol,

--- a/src/components/Trade/TradeInput.tsx
+++ b/src/components/Trade/TradeInput.tsx
@@ -13,6 +13,7 @@ import type { AccountDropdownProps } from 'components/AccountDropdown/AccountDro
 import { SlideTransition } from 'components/SlideTransition'
 import { Text } from 'components/Text'
 import { useGetTradeAmounts } from 'components/Trade/hooks/useGetTradeAmounts'
+import { useIsTradingActive } from 'components/Trade/hooks/useIsTradingActive'
 import { useReceiveAddress } from 'components/Trade/hooks/useReceiveAddress'
 import { useSwapper } from 'components/Trade/hooks/useSwapper/useSwapper'
 import { getSendMaxAmount } from 'components/Trade/hooks/useSwapper/utils'
@@ -49,7 +50,9 @@ const moduleLogger = logger.child({ namespace: ['TradeInput'] })
 export const TradeInput = () => {
   useSwapperService()
   const [isLoading, setIsLoading] = useState(false)
+
   const { setTradeAmountsUsingExistingData, setTradeAmountsRefetchData } = useTradeAmounts()
+  const { isTradingActiveOnSellChain } = useIsTradingActive()
   const {
     checkApprovalNeeded,
     getTrade,
@@ -328,6 +331,14 @@ export const TradeInput = () => {
             buyTradeAsset?.asset?.symbol ?? translate('trade.errors.buyAssetStartSentence'),
         },
       ]
+    if (!isTradingActiveOnSellChain) {
+      return [
+        'trade.errors.tradingNotActive',
+        {
+          assetSymbol: sellTradeAsset?.asset?.symbol ?? '',
+        },
+      ]
+    }
     if (!bestTradeSwapper) return 'trade.errors.invalidTradePairBtnText'
     if (!hasValidTradeBalance) return 'common.insufficientFunds'
     if (hasValidTradeBalance && !hasEnoughBalanceForGas && hasValidSellAmount)
@@ -358,6 +369,7 @@ export const TradeInput = () => {
     hasValidSellAmount,
     isBelowMinSellAmount,
     isTradeQuotePending,
+    isTradingActiveOnSellChain,
     quote?.feeData.networkFeeCryptoBaseUnit,
     quote?.minimum,
     quote?.sellAsset.symbol,

--- a/src/components/Trade/hooks/useIsTradingActive.tsx
+++ b/src/components/Trade/hooks/useIsTradingActive.tsx
@@ -6,7 +6,7 @@ import { getIsTradingActiveApi } from 'state/apis/swapper/getIsTradingActiveApi'
 import { useAppDispatch } from 'state/store'
 
 export const useIsTradingActive = () => {
-  const [isTradingActiveOnSellChain, setIsTradingActiveOnSellChain] = useState(false)
+  const [isTradingActiveOnSellPool, setIsTradingActiveOnSellPool] = useState(false)
 
   const { bestTradeSwapper } = useSwapper()
   const dispatch = useAppDispatch()
@@ -31,9 +31,9 @@ export const useIsTradingActive = () => {
           )
         ).data
 
-      setIsTradingActiveOnSellChain(!!isTradingActiveResult)
+      setIsTradingActiveOnSellPool(!!isTradingActiveResult)
     })()
   }, [bestTradeSwapper, dispatch, getIsTradingActive, sellTradeAssetId])
 
-  return { isTradingActiveOnSellChain }
+  return { isTradingActiveOnSellPool }
 }

--- a/src/components/Trade/hooks/useIsTradingActive.tsx
+++ b/src/components/Trade/hooks/useIsTradingActive.tsx
@@ -1,0 +1,39 @@
+import { useEffect, useState } from 'react'
+import { useFormContext, useWatch } from 'react-hook-form'
+import { useSwapper } from 'components/Trade/hooks/useSwapper/useSwapper'
+import type { TS } from 'components/Trade/types'
+import { getIsTradingActiveApi } from 'state/apis/swapper/getIsTradingActiveApi'
+import { useAppDispatch } from 'state/store'
+
+export const useIsTradingActive = () => {
+  const [isTradingActiveOnSellChain, setIsTradingActiveOnSellChain] = useState(false)
+
+  const { bestTradeSwapper } = useSwapper()
+  const dispatch = useAppDispatch()
+
+  const { control } = useFormContext<TS>()
+  const sellTradeAsset = useWatch({ control, name: 'sellTradeAsset' })
+  const sellTradeAssetId = sellTradeAsset?.asset?.assetId
+
+  const { getIsTradingActive } = getIsTradingActiveApi.endpoints
+
+  useEffect(() => {
+    ;(async () => {
+      const isTradingActiveResult =
+        sellTradeAssetId &&
+        bestTradeSwapper &&
+        (
+          await dispatch(
+            getIsTradingActive.initiate({
+              assetId: sellTradeAssetId,
+              swapperName: bestTradeSwapper.name,
+            }),
+          )
+        ).data
+
+      setIsTradingActiveOnSellChain(!!isTradingActiveResult)
+    })()
+  }, [bestTradeSwapper, dispatch, getIsTradingActive, sellTradeAssetId])
+
+  return { isTradingActiveOnSellChain }
+}

--- a/src/components/Trade/utils.test.ts
+++ b/src/components/Trade/utils.test.ts
@@ -8,20 +8,20 @@ jest.mock('@shapeshiftoss/swapper', () => ({
 }))
 
 describe('isTradingActive', () => {
-  it('detects an active chain from a valid response', async () => {
+  it('detects an active pool from a valid response', async () => {
     ;(getInboundAddressDataForChain as jest.Mock).mockResolvedValueOnce({ halted: false })
 
     const isTradingActiveResponse = await isTradingActive(btcAssetId, SwapperName.Thorchain)
     expect(isTradingActiveResponse).toBe(true)
   })
 
-  it('detects an halted chain from a valid response', async () => {
+  it('detects an halted pool from a valid response', async () => {
     ;(getInboundAddressDataForChain as jest.Mock).mockResolvedValueOnce({ halted: true })
     const isTradingActiveResponse = await isTradingActive(btcAssetId, SwapperName.Thorchain)
     expect(isTradingActiveResponse).toBe(false)
   })
 
-  it('assumes a halted chain on invalid response', async () => {
+  it('assumes a halted pool on invalid response', async () => {
     ;(getInboundAddressDataForChain as jest.Mock).mockResolvedValueOnce(undefined)
     const isTradingActiveResponse = await isTradingActive(btcAssetId, SwapperName.Thorchain)
     expect(isTradingActiveResponse).toBe(false)

--- a/src/components/Trade/utils.test.ts
+++ b/src/components/Trade/utils.test.ts
@@ -1,5 +1,5 @@
 import { btcAssetId } from '@shapeshiftoss/caip'
-import { getInboundAddressDataForChain, SwapperType } from '@shapeshiftoss/swapper'
+import { getInboundAddressDataForChain, SwapperName } from '@shapeshiftoss/swapper'
 import { isTradingActive } from 'components/Trade/utils'
 
 jest.mock('@shapeshiftoss/swapper', () => ({
@@ -11,25 +11,25 @@ describe('isTradingActive', () => {
   it('detects an active chain from a valid response', async () => {
     ;(getInboundAddressDataForChain as jest.Mock).mockResolvedValueOnce({ halted: false })
 
-    const isTradingActiveResponse = await isTradingActive(btcAssetId, SwapperType.Thorchain)
+    const isTradingActiveResponse = await isTradingActive(btcAssetId, SwapperName.Thorchain)
     expect(isTradingActiveResponse).toBe(true)
   })
 
   it('detects an halted chain from a valid response', async () => {
     ;(getInboundAddressDataForChain as jest.Mock).mockResolvedValueOnce({ halted: true })
-    const isTradingActiveResponse = await isTradingActive(btcAssetId, SwapperType.Thorchain)
+    const isTradingActiveResponse = await isTradingActive(btcAssetId, SwapperName.Thorchain)
     expect(isTradingActiveResponse).toBe(false)
   })
 
   it('assumes a halted chain on invalid response', async () => {
     ;(getInboundAddressDataForChain as jest.Mock).mockResolvedValueOnce(undefined)
-    const isTradingActiveResponse = await isTradingActive(btcAssetId, SwapperType.Thorchain)
+    const isTradingActiveResponse = await isTradingActive(btcAssetId, SwapperName.Thorchain)
     expect(isTradingActiveResponse).toBe(false)
   })
 
-  it('does not look for halted flags unless the SwapperType is Thorchain', async () => {
+  it('does not look for halted flags unless the SwapperName is Thorchain', async () => {
     ;(getInboundAddressDataForChain as jest.Mock).mockResolvedValueOnce({ halted: true })
-    const isTradingActiveResponse = await isTradingActive(btcAssetId, SwapperType.CowSwap)
+    const isTradingActiveResponse = await isTradingActive(btcAssetId, SwapperName.CowSwap)
     expect(isTradingActiveResponse).toBe(true)
   })
 })

--- a/src/components/Trade/utils.test.ts
+++ b/src/components/Trade/utils.test.ts
@@ -1,0 +1,35 @@
+import { btcAssetId } from '@shapeshiftoss/caip'
+import { getInboundAddressDataForChain, SwapperType } from '@shapeshiftoss/swapper'
+import { isTradingActive } from 'components/Trade/utils'
+
+jest.mock('@shapeshiftoss/swapper', () => ({
+  ...jest.requireActual('@shapeshiftoss/swapper'),
+  getInboundAddressDataForChain: jest.fn(),
+}))
+
+describe('isTradingActive', () => {
+  it('detects an active chain from a valid response', async () => {
+    ;(getInboundAddressDataForChain as jest.Mock).mockResolvedValueOnce({ halted: false })
+
+    const isTradingActiveResponse = await isTradingActive(btcAssetId, SwapperType.Thorchain)
+    expect(isTradingActiveResponse).toBe(true)
+  })
+
+  it('detects an halted chain from a valid response', async () => {
+    ;(getInboundAddressDataForChain as jest.Mock).mockResolvedValueOnce({ halted: true })
+    const isTradingActiveResponse = await isTradingActive(btcAssetId, SwapperType.Thorchain)
+    expect(isTradingActiveResponse).toBe(false)
+  })
+
+  it('assumes a halted chain on invalid response', async () => {
+    ;(getInboundAddressDataForChain as jest.Mock).mockResolvedValueOnce(undefined)
+    const isTradingActiveResponse = await isTradingActive(btcAssetId, SwapperType.Thorchain)
+    expect(isTradingActiveResponse).toBe(false)
+  })
+
+  it('does not look for halted flags unless the SwapperType is Thorchain', async () => {
+    ;(getInboundAddressDataForChain as jest.Mock).mockResolvedValueOnce({ halted: true })
+    const isTradingActiveResponse = await isTradingActive(btcAssetId, SwapperType.CowSwap)
+    expect(isTradingActiveResponse).toBe(true)
+  })
+})

--- a/src/components/Trade/utils.ts
+++ b/src/components/Trade/utils.ts
@@ -1,0 +1,19 @@
+import type { AssetId } from '@shapeshiftoss/caip'
+import { getInboundAddressDataForChain, SwapperType } from '@shapeshiftoss/swapper'
+import { getConfig } from 'config'
+
+export const isTradingActive = async (
+  assetId: AssetId,
+  swapperType: SwapperType,
+): Promise<boolean> => {
+  switch (swapperType) {
+    case SwapperType.Thorchain: {
+      const daemonUrl = getConfig().REACT_APP_THORCHAIN_NODE_URL
+      const inboundAddressData = await getInboundAddressDataForChain(daemonUrl, assetId, false)
+      // If we can't get inbound address data, we MUST assume trading is halted for safety
+      return inboundAddressData ? !inboundAddressData.halted : false
+    }
+    default:
+      return true
+  }
+}

--- a/src/components/Trade/utils.ts
+++ b/src/components/Trade/utils.ts
@@ -1,13 +1,13 @@
 import type { AssetId } from '@shapeshiftoss/caip'
-import { getInboundAddressDataForChain, SwapperType } from '@shapeshiftoss/swapper'
+import { getInboundAddressDataForChain, SwapperName } from '@shapeshiftoss/swapper'
 import { getConfig } from 'config'
 
 export const isTradingActive = async (
-  assetId: AssetId,
-  swapperType: SwapperType,
+  assetId: AssetId | undefined,
+  swapperName: SwapperName,
 ): Promise<boolean> => {
-  switch (swapperType) {
-    case SwapperType.Thorchain: {
+  switch (swapperName) {
+    case SwapperName.Thorchain: {
       const daemonUrl = getConfig().REACT_APP_THORCHAIN_NODE_URL
       const inboundAddressData = await getInboundAddressDataForChain(daemonUrl, assetId, false)
       // If we can't get inbound address data, we MUST assume trading is halted for safety

--- a/src/state/apis/swapper/getIsTradingActiveApi.ts
+++ b/src/state/apis/swapper/getIsTradingActiveApi.ts
@@ -1,0 +1,27 @@
+import type { AssetId } from '@shapeshiftoss/caip'
+import type { SwapperType } from '@shapeshiftoss/swapper'
+import { isTradingActive } from 'components/Trade/utils'
+import { swapperApi } from 'state/apis/swapper/swapperApi'
+import { apiErrorHandler } from 'state/apis/utils'
+
+type GetIsTradingActiveArgs = { assetId: AssetId; swapperType: SwapperType }
+
+type GetIsTradingActiveReturn = Boolean
+
+const getIsTradingActiveErrorHandler = apiErrorHandler(
+  'getIsTradingActiveApi: error getting trading status',
+)
+
+export const getIsTradingActiveApi = swapperApi.injectEndpoints({
+  endpoints: build => ({
+    getIsTradingActive: build.query<GetIsTradingActiveReturn, GetIsTradingActiveArgs>({
+      queryFn: async ({ assetId, swapperType }) => {
+        try {
+          return { data: await isTradingActive(assetId, swapperType) }
+        } catch (error) {
+          return getIsTradingActiveErrorHandler(error)
+        }
+      },
+    }),
+  }),
+})

--- a/src/state/apis/swapper/getIsTradingActiveApi.ts
+++ b/src/state/apis/swapper/getIsTradingActiveApi.ts
@@ -1,12 +1,12 @@
 import type { AssetId } from '@shapeshiftoss/caip'
-import type { SwapperType } from '@shapeshiftoss/swapper'
+import type { SwapperName } from '@shapeshiftoss/swapper'
 import { isTradingActive } from 'components/Trade/utils'
 import { swapperApi } from 'state/apis/swapper/swapperApi'
 import { apiErrorHandler } from 'state/apis/utils'
 
-type GetIsTradingActiveArgs = { assetId: AssetId; swapperType: SwapperType }
+type GetIsTradingActiveArgs = { assetId: AssetId | undefined; swapperName: SwapperName }
 
-type GetIsTradingActiveReturn = Boolean
+type GetIsTradingActiveReturn = boolean
 
 const getIsTradingActiveErrorHandler = apiErrorHandler(
   'getIsTradingActiveApi: error getting trading status',
@@ -15,9 +15,9 @@ const getIsTradingActiveErrorHandler = apiErrorHandler(
 export const getIsTradingActiveApi = swapperApi.injectEndpoints({
   endpoints: build => ({
     getIsTradingActive: build.query<GetIsTradingActiveReturn, GetIsTradingActiveArgs>({
-      queryFn: async ({ assetId, swapperType }) => {
+      queryFn: async ({ assetId, swapperName }) => {
         try {
-          return { data: await isTradingActive(assetId, swapperType) }
+          return { data: await isTradingActive(assetId, swapperName) }
         } catch (error) {
           return getIsTradingActiveErrorHandler(error)
         }

--- a/yarn.lock
+++ b/yarn.lock
@@ -4385,10 +4385,10 @@
     google-protobuf "^3.17.0"
     long "^4.0.0"
 
-"@shapeshiftoss/swapper@15.2.2":
-  version "15.2.2"
-  resolved "https://registry.yarnpkg.com/@shapeshiftoss/swapper/-/swapper-15.2.2.tgz#f232a76254a2d63d353f91246a452465bc2c2854"
-  integrity sha512-gN0G3x/l5R/alHiyxQKjlUvGwU3YdBZDnnx/0ROecP2E07rhBNRFIDn9yYdagbb1n1Jwxd2xpO8ASxJr3EJWjA==
+"@shapeshiftoss/swapper@15.3.0":
+  version "15.3.0"
+  resolved "https://registry.yarnpkg.com/@shapeshiftoss/swapper/-/swapper-15.3.0.tgz#cacfecb06e0f864cab6ae54af267d82f8c7c3b15"
+  integrity sha512-W0o9WD7jEWsKLu8gw6oc7V27RCnZAC4LfCic9vItjdQ4o1K1sRXobjNgw8RTrslBzhLrVgr0WZaQD2sIhFstfQ==
   dependencies:
     axios "^0.26.1"
     axios-cache-adapter "^2.7.3"


### PR DESCRIPTION
## Description

When a halt is placed on the THORSwap receiving pool of the outbound asset we'll still get quotes, but the "preview trade" button will be disabled, with a message informing the user of the halt.

- Prevents trades from being created whilst a THOR pool is halted.
- Adopts a fail-closed implementation. I.e. if we can't get confirmation from the THOR node that _an asset's pool is **not** halted_, we do not let the user create a trade.
- Adds a pure function consuming `getInboundAddressDataForChain`, which is consumed by an RTK query, which is consumed by a custom hook, which is consumed by the Trade component (React 🤯 )

TODO in a follow-up PR: make `getBestSwapper` logic aware of when a swapper can get a quote, but trading is disabled. This case requires some thought - do we just not include the swapper in the available list? If we do that, the trading halt message will never show, because we'll never get the swapper in the first place.

## Notice

- [x] Have you followed the guidelines in our [Contributing]('https://github.com/shapeshift/web/blob/develop/CONTRIBUTING.md) guide?
- [x] Have you checked to ensure there aren't other open [Pull Requests](https://github.com/shapeshift/web/pulls) for the same update/change?

## Pull Request Type

- [ ] :bug: Bug fix (Non-breaking Change: Fixes an issue)
- [x] :hammer_and_wrench: Chore (Non-breaking Change: Doc updates, pkg upgrades, typos, etc..)
- [x] :nail_care: New Feature (Breaking/Non-breaking Change)

## Issue (if applicable)

Contributes to https://github.com/shapeshift/web/issues/2925

## Risk

Small, any issues should be immediately visible by the error translation being incorrectly triggered.

## Testing



### Engineering

Monkey patch the `isTradingActive` function (e.g. return `false` in one of the switch cases and confirm working as expected).

||

Monkey patch the pools response, replacing the value of 'halted' on one of the pools with `true`.

### Operations

No simple way to test a true positive, but regressions can be tested for by confirming the swapper still functions as expected.

## Screenshots (if applicable)

<img width="415" alt="Screenshot 2023-01-10 at 5 03 51 pm" src="https://user-images.githubusercontent.com/97164662/211473754-2dca3a21-c201-426c-987f-1b7d4d20e048.png">

