### PR TITLE
chore: tighten THORSwap halt errors

### DIFF
--- a/src/components/Trade/TradeInput.tsx
+++ b/src/components/Trade/TradeInput.tsx
@@ -2,6 +2,7 @@ import { ArrowDownIcon } from '@chakra-ui/icons'
 import { Button, IconButton, Stack, useColorModeValue } from '@chakra-ui/react'
 import type { Asset } from '@shapeshiftoss/asset-service'
 import { ethAssetId } from '@shapeshiftoss/caip'
+import { SwapperName } from '@shapeshiftoss/swapper'
 import type { KnownChainIds } from '@shapeshiftoss/types'
 import type { InterpolationOptions } from 'node-polyglot'
 import { useCallback, useMemo, useState } from 'react'
@@ -331,7 +332,8 @@ export const TradeInput = () => {
             buyTradeAsset?.asset?.symbol ?? translate('trade.errors.buyAssetStartSentence'),
         },
       ]
-    if (!isTradingActiveOnSellPool) {
+    if (!bestTradeSwapper) return 'trade.errors.invalidTradePairBtnText'
+    if (!isTradingActiveOnSellPool && bestTradeSwapper.name === SwapperName.Thorchain) {
       return [
         'trade.errors.tradingNotActive',
         {
@@ -339,7 +341,6 @@ export const TradeInput = () => {
         },
       ]
     }
-    if (!bestTradeSwapper) return 'trade.errors.invalidTradePairBtnText'
     if (!hasValidTradeBalance) return 'common.insufficientFunds'
     if (hasValidTradeBalance && !hasEnoughBalanceForGas && hasValidSellAmount)
       return [


### PR DESCRIPTION
## Description

Possibly avoids a bug where we get a false negative "trade halt" message when we can't get a trade swapper.

I suspect we were hitting: 

```ts
if (!isTradingActiveOnSellPool && bestTradeSwapper.name === SwapperName.Thorchain) {
...
```

When we should have been hitting:

```ts
if (!bestTradeSwapper) return 'trade.errors.invalidTradePairBtnText'
```

## Notice

- [x] Have you followed the guidelines in our [Contributing]('https://github.com/shapeshift/web/blob/develop/CONTRIBUTING.md) guide?
- [x] Have you checked to ensure there aren't other open [Pull Requests](https://github.com/shapeshift/web/pulls) for the same update/change?

## Pull Request Type

- [x] :bug: Bug fix (Non-breaking Change: Fixes an issue)
- [ ] :hammer_and_wrench: Chore (Non-breaking Change: Doc updates, pkg upgrades, typos, etc..)
- [ ] :nail_care: New Feature (Breaking/Non-breaking Change)

## Issue (if applicable)

Might fix https://discord.com/channels/554694662431178782/1062449976325718096/1062449979492413440

## Risk

Small.

## Testing

@0xdef1cafe do what you did to replicate the bug, and it should now show the `invalidTradePairBtnText` translation instead.

### Engineering

☝️ 

### Operations

We should not show the trading halt message on the preview trade button for Osmo trades.

## Screenshots (if applicable)

N/A