### PR TITLE
fix: undefined swapper on first render

### DIFF
--- a/src/components/Trade/TradeInput.tsx
+++ b/src/components/Trade/TradeInput.tsx
@@ -257,8 +257,17 @@ export const TradeInput = () => {
     [handleInputChange],
   )
 
-  const handleSellAccountIdChange: AccountDropdownProps['onChange'] = accountId =>
+  const handleSellAccountIdChange: AccountDropdownProps['onChange'] = accountId => {
     setValue('selectedSellAssetAccountId', accountId)
+    if (!swapperSupportsCrossAccountTrade && bestTradeSwapper) {
+      /*
+        This is extremely dangerous. We only want to do this if we have a swapper, and that swapper does not do either of:
+          - Trades between assets on the same chain but different accounts
+          - Trades between assets on different chains (and possibly different accounts)
+       */
+      setValue('selectedBuyAssetAccountId', accountId)
+    }
+  }
 
   const handleBuyAccountIdChange: AccountDropdownProps['onChange'] = accountId =>
     setValue('selectedBuyAssetAccountId', accountId)

--- a/src/components/Trade/hooks/useAccountsService.tsx
+++ b/src/components/Trade/hooks/useAccountsService.tsx
@@ -1,6 +1,5 @@
 import { useEffect, useMemo } from 'react'
 import { useFormContext, useWatch } from 'react-hook-form'
-import { useSwapper } from 'components/Trade/hooks/useSwapper/useSwapper'
 import type { TS } from 'components/Trade/types'
 import { selectAssetById } from 'state/slices/assetsSlice/selectors'
 import { selectHighestFiatBalanceAccountByAssetId } from 'state/slices/portfolioSlice/selectors'
@@ -20,9 +19,6 @@ export const useAccountsService = () => {
   const buyTradeAsset = useWatch({ control, name: 'buyTradeAsset' })
   const formSellAssetAccountId = useWatch({ control, name: 'sellAssetAccountId' })
   const formBuyAssetAccountId = useWatch({ control, name: 'buyAssetAccountId' })
-
-  // Custom hooks
-  const { swapperSupportsCrossAccountTrade } = useSwapper()
 
   // Constants
   const sellAssetId = sellTradeAsset?.asset?.assetId
@@ -66,18 +62,9 @@ export const useAccountsService = () => {
   )
 
   // Set buyAssetAccountId
-  useEffect(() => {
-    setValue(
-      'buyAssetAccountId',
-      // If the swapper does not support cross-account trades the buyAssetAccountId must match the sellAssetAccountId
-      swapperSupportsCrossAccountTrade ? buyAssetAccountId : sellAssetAccountId,
-    )
+  useEffect(
+    () => setValue('buyAssetAccountId', buyAssetAccountId),
     // formBuyAssetAccountId is important here as it ensures this useEffect re-runs when the form value is cleared
-  }, [
-    buyAssetAccountId,
-    sellAssetAccountId,
-    setValue,
-    swapperSupportsCrossAccountTrade,
-    formBuyAssetAccountId,
-  ])
+    [buyAssetAccountId, setValue, formBuyAssetAccountId],
+  )
 }

--- a/src/components/Trade/hooks/useSwapper/useSwapper.tsx
+++ b/src/components/Trade/hooks/useSwapper/useSwapper.tsx
@@ -97,8 +97,15 @@ export const useSwapper = () => {
     selectBIP44ParamsByAccountId(state, sellAccountFilter),
   )
 
+  /*
+  Cross-account trading means trades that are either:
+    - Trades between assets on the same chain but different accounts
+    - Trades between assets on different chains (and possibly different accounts)
+
+   When adding a new swapper, ensure that `true` is returned here if either of the above apply.
+   */
   const swapperSupportsCrossAccountTrade = useMemo(() => {
-    if (!bestTradeSwapper) return false
+    if (!bestTradeSwapper) return undefined
     switch (bestTradeSwapper.name) {
       case SwapperName.Thorchain:
       case SwapperName.Osmosis:


### PR DESCRIPTION
## Description

**Fixes `undefined` swapper on first render**
Fixes an issue where we would not get a swapper in the first render cycle if the asset pair's swapper supports cross-account trades. 

It's a multi-factorial bug with a simple fix. 

In summary: the bug is a side-effect from the account bug fix, where the early returning on the first render now leaves us with a receive address of `undefined`. This stops the first quote from firing, which stops us from getting a swapper now that getting the best swapper requires a quote - and if we don't have a swapper we show "Invalid Trade Pair". Phew.

**Adds commentary for safety**
Adds commentary about logic that could, if changed in an incorrect way, result in an incorrect receive asset being used for a trade (this is now checked for downstream, but _this_ is the root cause of what was going on)

## Notice

- [x] Have you followed the guidelines in our [Contributing]('https://github.com/shapeshift/web/blob/develop/CONTRIBUTING.md) guide?
- [x] Have you checked to ensure there aren't other open [Pull Requests](https://github.com/shapeshift/web/pulls) for the same update/change?

## Pull Request Type

- [x] :bug: Bug fix (Non-breaking Change: Fixes an issue)
- [ ] :hammer_and_wrench: Chore (Non-breaking Change: Doc updates, pkg upgrades, typos, etc..)
- [ ] :nail_care: New Feature (Breaking/Non-breaking Change)

## Issue (if applicable)

N/A - safety first.

## Risk

High risk as this touches account selection.

## Testing

Things to test:

**Bug fix**

When selecting a UTXO asset from the Dashboard, we often display "Invalid Trade Pair" until the form is interacted with.
This should no longer occur.

**Synchronised account selection**

- For swappers that do not support multi-account (`0x` and `CoW Swap`), we should only be able to select the sell asset account. The buy asset should then update to match any selections.
- For swappers that _do_ support multi-account (`THORSwapper` and `Osmosis`), we should be able to select the sell asset account and buy asset accounts independently

**THORTrading**

Out of an abundance of caution, we should do a cross-chain swap on THORChain (i.e. one with a UTXO asset as the receive asset) and ensure that the funds are received.

### Engineering

☝️ 

### Operations

☝️ 

## Screenshots (if applicable)

N/A
