### PR TITLE
fix: completed atom to osmo trades

### DIFF
--- a/src/state/slices/txHistorySlice/utils.ts
+++ b/src/state/slices/txHistorySlice/utils.ts
@@ -41,7 +41,7 @@ export const serializeTxIndex = (
   data?: Tx['data'],
 ): TxIndex => {
   // special case for thorchain transactions sent back in multiple parts
-  if (data && data.parser === 'swap') {
+  if (data && data.parser === 'swap' && !address.toLowerCase().startsWith('osmo')) {
     return [accountId, txid, address.toLowerCase(), data.memo].join(UNIQUE_TX_ID_DELIMITER)
   }
 

--- a/src/state/slices/txHistorySlice/utils.ts
+++ b/src/state/slices/txHistorySlice/utils.ts
@@ -41,7 +41,7 @@ export const serializeTxIndex = (
   data?: Tx['data'],
 ): TxIndex => {
   // special case for thorchain transactions sent back in multiple parts
-  if (data && data.parser === 'swap' && !address.toLowerCase().startsWith('osmo')) {
+  if (data && data.parser === 'swap' && address.toLowerCase().startsWith('thor')) {
     return [accountId, txid, address.toLowerCase(), data.memo].join(UNIQUE_TX_ID_DELIMITER)
   }
 


### PR DESCRIPTION
## Description

Special case logic for thorchain was causing a "*" character to be unintentionally added to the serialized osmo trade txs.

This caused it to not detect "atom -> osmo" trades being completed because it couldnt match the string correctly

## Notice


## Risk

low risk bug fix

## Testing

trade atom -> osmo and see it completes successfully

### Engineering

see testing

### Operations

see testing

## Screenshots (if applica
<img width="457" alt="Screen Shot 2023-01-10 at 11 37 28 PM" src="https://user-images.githubusercontent.com/6187559/211735895-de1c7839-0666-4f9b-824a-8608bca4512e.png">
ble)
