### PR TITLE
feat: wire-up THORChain opportunities caps

### DIFF
--- a/src/features/defi/providers/thorchain-savers/components/ThorchainSaversManager/Overview/ThorchainSaversOverview.tsx
+++ b/src/features/defi/providers/thorchain-savers/components/ThorchainSaversManager/Overview/ThorchainSaversOverview.tsx
@@ -131,9 +131,6 @@ export const ThorchainSaversOverview: React.FC<OverviewProps> = ({
     .div(bnOrZero(opportunityMetadata?.opportunitySpecific?.saversMaxSupplyFiat))
     .times(100)
     .toNumber()
-  const isCapUsed =
-    bnOrZero(opportunityMetadata?.opportunitySpecific?.saversMaxSupplyFiat).gt(0) &&
-    bnOrZero(currentCapFillPercentage).eq(100)
 
   const underlyingAssetsFiatBalanceCryptoPrecision = useMemo(() => {
     if (!asset || !earnOpportunityData?.underlyingAssetId) return '0'
@@ -165,8 +162,8 @@ export const ThorchainSaversOverview: React.FC<OverviewProps> = ({
   const menu: DefiButtonProps[] = useMemo(() => {
     if (!earnOpportunityData) return []
 
-    return makeDefaultMenu(isCapUsed)
-  }, [earnOpportunityData, isCapUsed])
+    return makeDefaultMenu(opportunityMetadata?.opportunitySpecific?.isFull)
+  }, [earnOpportunityData, opportunityMetadata?.opportunitySpecific?.isFull])
 
   const renderVaultCap = useMemo(() => {
     return (

--- a/src/features/defi/providers/thorchain-savers/components/ThorchainSaversManager/Overview/ThorchainSaversOverview.tsx
+++ b/src/features/defi/providers/thorchain-savers/components/ThorchainSaversManager/Overview/ThorchainSaversOverview.tsx
@@ -19,7 +19,6 @@ import { Overview } from 'features/defi/components/Overview/Overview'
 import type {
   DefiParams,
   DefiQueryParams,
-  DefiType,
 } from 'features/defi/contexts/DefiManagerProvider/DefiCommon'
 import { DefiAction, DefiProvider } from 'features/defi/contexts/DefiManagerProvider/DefiCommon'
 import { useMemo } from 'react'
@@ -32,7 +31,8 @@ import { HelperTooltip } from 'components/HelperTooltip/HelperTooltip'
 import { Text } from 'components/Text'
 import { useBrowserRouter } from 'hooks/useBrowserRouter/useBrowserRouter'
 import { bn, bnOrZero } from 'lib/bignumber/bignumber'
-import type { OpportunityMetadata, StakingId } from 'state/slices/opportunitiesSlice/types'
+import type { ThorchainSaversStakingSpecificMetadata } from 'state/slices/opportunitiesSlice/resolvers/thorchainsavers/types'
+import type { StakingId } from 'state/slices/opportunitiesSlice/types'
 import { serializeUserStakingId, toOpportunityId } from 'state/slices/opportunitiesSlice/utils'
 import {
   selectAssetById,
@@ -123,12 +123,10 @@ export const ThorchainSaversOverview: React.FC<OverviewProps> = ({
   const opportunityMetadata = useMemo(
     () => opportunitiesMetadata[assetId as StakingId],
     [assetId, opportunitiesMetadata],
-  ) as OpportunityMetadata<DefiProvider.ThorchainSavers, DefiType.Staking> | undefined
+  ) as ThorchainSaversStakingSpecificMetadata | undefined
 
-  const currentCapFillPercentage = bnOrZero(
-    opportunityMetadata?.opportunitySpecific?.saversSupplyIncludeAccruedFiat,
-  )
-    .div(bnOrZero(opportunityMetadata?.opportunitySpecific?.saversMaxSupplyFiat))
+  const currentCapFillPercentage = bnOrZero(opportunityMetadata?.saversSupplyIncludeAccruedFiat)
+    .div(bnOrZero(opportunityMetadata?.saversMaxSupplyFiat))
     .times(100)
     .toNumber()
 
@@ -162,8 +160,8 @@ export const ThorchainSaversOverview: React.FC<OverviewProps> = ({
   const menu: DefiButtonProps[] = useMemo(() => {
     if (!earnOpportunityData) return []
 
-    return makeDefaultMenu(opportunityMetadata?.opportunitySpecific?.isFull)
-  }, [earnOpportunityData, opportunityMetadata?.opportunitySpecific?.isFull])
+    return makeDefaultMenu(opportunityMetadata?.isFull)
+  }, [earnOpportunityData, opportunityMetadata?.isFull])
 
   const renderVaultCap = useMemo(() => {
     return (
@@ -173,11 +171,9 @@ export const ThorchainSaversOverview: React.FC<OverviewProps> = ({
             <Text fontWeight='medium' translation='defi.modals.saversVaults.vaultCap' />
           </HelperTooltip>
           <Flex gap={1}>
+            <Amount.Fiat value={opportunityMetadata?.saversSupplyIncludeAccruedFiat ?? 0} />
             <Amount.Fiat
-              value={opportunityMetadata?.opportunitySpecific?.saversSupplyIncludeAccruedFiat ?? 0}
-            />
-            <Amount.Fiat
-              value={opportunityMetadata?.opportunitySpecific?.saversMaxSupplyFiat ?? 0}
+              value={opportunityMetadata?.saversMaxSupplyFiat ?? 0}
               prefix='/'
               color='gray.500'
             />
@@ -214,8 +210,8 @@ export const ThorchainSaversOverview: React.FC<OverviewProps> = ({
   }, [
     alertBg,
     currentCapFillPercentage,
-    opportunityMetadata?.opportunitySpecific?.saversMaxSupplyFiat,
-    opportunityMetadata?.opportunitySpecific?.saversSupplyIncludeAccruedFiat,
+    opportunityMetadata?.saversMaxSupplyFiat,
+    opportunityMetadata?.saversSupplyIncludeAccruedFiat,
     translate,
     underlyingAsset?.symbol,
   ])
@@ -251,9 +247,7 @@ export const ThorchainSaversOverview: React.FC<OverviewProps> = ({
       apy={earnOpportunityData.apy}
       menu={menu}
       postChildren={
-        bnOrZero(opportunityMetadata?.opportunitySpecific?.saversMaxSupplyFiat).gt(0)
-          ? renderVaultCap
-          : null
+        bnOrZero(opportunityMetadata?.saversMaxSupplyFiat).gt(0) ? renderVaultCap : null
       }
     />
   )

--- a/src/state/slices/opportunitiesSlice/resolvers/thorchainsavers/index.ts
+++ b/src/state/slices/opportunitiesSlice/resolvers/thorchainsavers/index.ts
@@ -169,6 +169,7 @@ export const thorchainSaversStakingOpportunitiesMetadataResolver = async ({
       name: `${underlyingAsset.symbol} Vault`,
       saversSupplyIncludeAccruedFiat,
       saversMaxSupplyFiat,
+      isFull: thorchainPool.synth_mint_paused,
     }
   }
 

--- a/src/state/slices/opportunitiesSlice/resolvers/thorchainsavers/types.ts
+++ b/src/state/slices/opportunitiesSlice/resolvers/thorchainsavers/types.ts
@@ -7,4 +7,5 @@ export type ThorchainSaversStakingSpecificMetadata = OpportunityMetadataBase & {
   type: DefiType.Staking
   saversSupplyIncludeAccruedFiat: string
   saversMaxSupplyFiat: string
+  isFull: boolean
 }

--- a/src/state/slices/opportunitiesSlice/types.ts
+++ b/src/state/slices/opportunitiesSlice/types.ts
@@ -81,7 +81,7 @@ export type OpportunitiesState = {
   staking: {
     // a 1:n foreign key of which user AccountIds hold this StakingId
     byAccountId: PartialRecord<AccountId, StakingId[]>
-    byId: PartialRecord<StakingId, OpportunityMetadataBase>
+    byId: PartialRecord<StakingId, OpportunityMetadata>
     ids: StakingId[]
   }
 }


### PR DESCRIPTION
## Description

Wire-up of THORChain opportunities caps, consuming current saver fill and max saver cap to display the ratio as a percentage

## Notice

<!-- Before submitting a pull request, please make sure you have answered the following: -->

- [x] Have you followed the guidelines in our [Contributing]('https://github.com/shapeshift/web/blob/develop/CONTRIBUTING.md) guide?
- [x] Have you checked to ensure there aren't other open [Pull Requests](https://github.com/shapeshift/web/pulls) for the same update/change?

## Pull Request Type

- [ ] :bug: Bug fix (Non-breaking Change: Fixes an issue)
- [ ] :hammer_and_wrench: Chore (Non-breaking Change: Doc updates, pkg upgrades, typos, etc..)
- [x] :nail_care: New Feature (Breaking/Non-breaking Change)

## Issue (if applicable)

<!-----------------------------------------------------------------------------
If applicable, please link to the github issue and put `closes #XXXX` in your comment to auto-close the issue that your PR fixes.
------------------------------------------------------------------------------>

closes https://github.com/shapeshift/web/issues/3595

## Risk

<!-----------------------------------------------------------------------------
Outline the scope of your changes and the risk associated with them. You must use your discretion as an engineer to determine the potential impact of your changes.

E.g. an upgrade to `hdwallet` or core state management would be considered higher risk, and might require a full regression test. UI or isolated view changes, or something behind a feature flag may have near zero risk. Small bug fixes might require testing isolated to the specific fix.
------------------------------------------------------------------------------>

None, isolated to flagged THORChain savers feature

## Testing

<!-----------------------------------------------------------------------------
We treat every PR to be merged with the same scrutiny as if we were merging directly to production.

Your PR will not be merged if you do not complete the sections below for our engineering and operations teams to test.
------------------------------------------------------------------------------>

### Engineering

<!-----------------------------------------------------------------------------
Include sufficient information here for an engineer to test your PR. This may include how to test locally, in a built environment, changes to infrastructure etc.
------------------------------------------------------------------------------>

- Amounts/ratios look similar to https://app.thoryield.com/savers / https://app.thorswap.finance/earn

Note that numbers mightn't be the exact same because of discrepancies in the freshness of data from THORCHain API and the data in THORCHain UI / THORYield, as well as in the market data in those two UIs and ours
  
### Operations

<!-----------------------------------------------------------------------------
If your changes have a user-facing impact, describe how a non-technical QA team can functionally test your changes in a preview environment.

If they are not user-facing please describe how to test for any regressions that may occur.
------------------------------------------------------------------------------>

- Nothing to see here 🕵️

## Screenshots (if applicable)

<img width="543" alt="image" src="https://user-images.githubusercontent.com/17035424/211791837-8141da71-3b7d-4a0f-95e8-197b2873e684.png">
<img width="529" alt="image" src="https://user-images.githubusercontent.com/17035424/211791064-33008fb8-0b9e-4f42-88eb-a11269efd1a1.png">
<img width="532" alt="image" src="https://user-images.githubusercontent.com/17035424/211791105-8bd44823-8743-422a-9192-ff2979ea071d.png">
<img width="514" alt="image" src="https://user-images.githubusercontent.com/17035424/211791142-7a904e42-a531-460c-b48f-fe6cd13d0d41.png">
<img width="517" alt="image" src="https://user-images.githubusercontent.com/17035424/211791179-4a5e1b31-5a88-443a-91aa-22d66d81008b.png">
<img width="524" alt="image" src="https://user-images.githubusercontent.com/17035424/211791269-ac2325ec-263b-49fc-971e-de44aaa7634a.png">
<img width="516" alt="image" src="https://user-images.githubusercontent.com/17035424/211791998-c04a814e-8df6-4992-aa6d-64a4590e8e3f.png">