### PR TITLE
feat: opportunities userData resolvers chainId safety

### DIFF
--- a/src/features/defi/providers/thorchain-savers/components/ThorchainSaversManager/Overview/ThorchainSaversOverview.tsx
+++ b/src/features/defi/providers/thorchain-savers/components/ThorchainSaversManager/Overview/ThorchainSaversOverview.tsx
@@ -247,11 +247,7 @@ export const ThorchainSaversOverview: React.FC<OverviewProps> = ({
       apy={earnOpportunityData.apy}
       menu={menu}
       postChildren={
-        bnOrZero(opportunityMetadata?.saversMaxSupplyFiat).gt(0)
-          ? renderVaultCap
-          : null
-          ? renderVaultCap
-          : null
+        bnOrZero(opportunityMetadata?.saversMaxSupplyFiat).gt(0) ? renderVaultCap : null
       }
     />
   )

--- a/src/features/defi/providers/thorchain-savers/components/ThorchainSaversManager/Overview/ThorchainSaversOverview.tsx
+++ b/src/features/defi/providers/thorchain-savers/components/ThorchainSaversManager/Overview/ThorchainSaversOverview.tsx
@@ -247,7 +247,11 @@ export const ThorchainSaversOverview: React.FC<OverviewProps> = ({
       apy={earnOpportunityData.apy}
       menu={menu}
       postChildren={
-        bnOrZero(opportunityMetadata?.saversMaxSupplyFiat).gt(0) ? renderVaultCap : null
+        bnOrZero(opportunityMetadata?.saversMaxSupplyFiat).gt(0)
+          ? renderVaultCap
+          : null
+          ? renderVaultCap
+          : null
       }
     />
   )

--- a/src/state/slices/opportunitiesSlice/resolvers/idle/index.ts
+++ b/src/state/slices/opportunitiesSlice/resolvers/idle/index.ts
@@ -1,5 +1,5 @@
 import type { AssetId, ToAssetIdArgs } from '@shapeshiftoss/caip'
-import { fromAccountId, fromAssetId, toAssetId } from '@shapeshiftoss/caip'
+import { ethChainId, fromAccountId, fromAssetId, toAssetId } from '@shapeshiftoss/caip'
 import { bnOrZero } from '@shapeshiftoss/investor-foxy'
 import { DefiProvider, DefiType } from 'features/defi/contexts/DefiManagerProvider/DefiCommon'
 import { getIdleInvestor } from 'features/defi/contexts/IdleProvider/idleInvestorSingleton'
@@ -132,6 +132,10 @@ export const idleStakingOpportunitiesUserDataResolver = async ({
   reduxApi,
   opportunityIds,
 }: OpportunitiesUserDataResolverInput): Promise<{ data: GetOpportunityUserStakingDataOutput }> => {
+  const { chainId: accountChainId } = fromAccountId(accountId)
+  if (accountChainId !== ethChainId)
+    throw new Error(`No-op. Won't fetch idle userStakingData for chainId: ${accountChainId}`)
+
   const { getState } = reduxApi
   const state: any = getState() // ReduxState causes circular dependency
 

--- a/src/state/slices/opportunitiesSlice/resolvers/yearn/index.ts
+++ b/src/state/slices/opportunitiesSlice/resolvers/yearn/index.ts
@@ -1,5 +1,5 @@
 import type { ToAssetIdArgs } from '@shapeshiftoss/caip'
-import { fromAssetId, toAssetId } from '@shapeshiftoss/caip'
+import { ethChainId, fromAccountId, fromAssetId, toAssetId } from '@shapeshiftoss/caip'
 import { bnOrZero } from '@shapeshiftoss/investor-foxy'
 import { USDC_PRECISION } from 'constants/constants'
 import { DefiProvider, DefiType } from 'features/defi/contexts/DefiManagerProvider/DefiCommon'
@@ -81,6 +81,10 @@ export const yearnStakingOpportunitiesUserDataResolver = async ({
   reduxApi,
   opportunityIds,
 }: OpportunitiesUserDataResolverInput): Promise<{ data: GetOpportunityUserStakingDataOutput }> => {
+  const { chainId: accountChainId } = fromAccountId(accountId)
+  if (accountChainId !== ethChainId)
+    throw new Error(`No-op. Won't fetch Yearn userStakingData for chainId: ${accountChainId}`)
+
   const { getState } = reduxApi
   const state: any = getState() // ReduxState causes circular dependency
 


### PR DESCRIPTION
## Description

Rationale: We dispatch thunks in fetching all opportunities (LP/staking) user data in `<AppContext />`, one full run for each requestedAccountIds.
Currently that's not a lot of them given we only do so for ethChainId, but as we implement THORChain savers, that might be a lot of overfetching we could avoid.

## Notice

<!-- Before submitting a pull request, please make sure you have answered the following: -->

- [x] Have you followed the guidelines in our [Contributing]('https://github.com/shapeshift/web/blob/develop/CONTRIBUTING.md) guide?
- [x] Have you checked to ensure there aren't other open [Pull Requests](https://github.com/shapeshift/web/pulls) for the same update/change?

## Pull Request Type

- [ ] :bug: Bug fix (Non-breaking Change: Fixes an issue)
- [ ] :hammer_and_wrench: Chore (Non-breaking Change: Doc updates, pkg upgrades, typos, etc..)
- [x] :nail_care: New Feature (Breaking/Non-breaking Change)

## Issue (if applicable)

N/A

## Risk

<!-----------------------------------------------------------------------------
Outline the scope of your changes and the risk associated with them. You must use your discretion as an engineer to determine the potential impact of your changes.

E.g. an upgrade to `hdwallet` or core state management would be considered higher risk, and might require a full regression test. UI or isolated view changes, or something behind a feature flag may have near zero risk. Small bug fixes might require testing isolated to the specific fix.
------------------------------------------------------------------------------>

None, if this causes regressions, we have bigger problems.

## Testing

- Purge your persisted redux store
- Ensure opportunities meta/data is still fetched and displayed

<!-----------------------------------------------------------------------------
We treat every PR to be merged with the same scrutiny as if we were merging directly to production.

Your PR will not be merged if you do not complete the sections below for our engineering and operations teams to test.
------------------------------------------------------------------------------>

### Engineering

- ^

<!-----------------------------------------------------------------------------
Include sufficient information here for an engineer to test your PR. This may include how to test locally, in a built environment, changes to infrastructure etc.
------------------------------------------------------------------------------>

### Operations

- ^

<!-----------------------------------------------------------------------------
If your changes have a user-facing impact, describe how a non-technical QA team can functionally test your changes in a preview environment.

If they are not user-facing please describe how to test for any regressions that may occur.
------------------------------------------------------------------------------>

## Screenshots (if applicable)
