### PR TITLE
fix: undefined swapper on first render (concise)

### DIFF
--- a/src/components/Trade/hooks/useAccountsService.tsx
+++ b/src/components/Trade/hooks/useAccountsService.tsx
@@ -22,7 +22,7 @@ export const useAccountsService = () => {
   const formBuyAssetAccountId = useWatch({ control, name: 'buyAssetAccountId' })
 
   // Custom hooks
-  const { swapperSupportsCrossAccountTrade } = useSwapper()
+  const { swapperSupportsCrossAccountTrade, bestTradeSwapper } = useSwapper()
 
   // Constants
   const sellAssetId = sellTradeAsset?.asset?.assetId
@@ -70,7 +70,10 @@ export const useAccountsService = () => {
     setValue(
       'buyAssetAccountId',
       // If the swapper does not support cross-account trades the buyAssetAccountId must match the sellAssetAccountId
-      swapperSupportsCrossAccountTrade ? buyAssetAccountId : sellAssetAccountId,
+      // If we don't have a swapper, we should not switch the buyAssetAccountId
+      swapperSupportsCrossAccountTrade || !bestTradeSwapper
+        ? buyAssetAccountId
+        : sellAssetAccountId,
     )
     // formBuyAssetAccountId is important here as it ensures this useEffect re-runs when the form value is cleared
   }, [
@@ -79,5 +82,6 @@ export const useAccountsService = () => {
     setValue,
     swapperSupportsCrossAccountTrade,
     formBuyAssetAccountId,
+    bestTradeSwapper,
   ])
 }


### PR DESCRIPTION
## Description

A less nice, but less risky version of https://github.com/shapeshift/web/pull/3609.

> **Fixes `undefined` swapper on first render**
Fixes an issue where we would not get a swapper in the first render cycle if the asset pair's swapper supports cross-account trades. 

It's a multi-factorial bug with a simple fix. 

In summary: the bug is a side-effect from the account bug fix, where the early returning on the first render now leaves us with a receive address of `undefined`. This stops the first quote from firing, which stops us from getting a swapper now that getting the best swapper requires a quote - and if we don't have a swapper we show "Invalid Trade Pair". Phew.

## Notice

- [x] Have you followed the guidelines in our [Contributing]('https://github.com/shapeshift/web/blob/develop/CONTRIBUTING.md) guide?
- [x] Have you checked to ensure there aren't other open [Pull Requests](https://github.com/shapeshift/web/pulls) for the same update/change?

## Pull Request Type

- [x] :bug: Bug fix (Non-breaking Change: Fixes an issue)
- [ ] :hammer_and_wrench: Chore (Non-breaking Change: Doc updates, pkg upgrades, typos, etc..)
- [ ] :nail_care: New Feature (Breaking/Non-breaking Change)

## Issue (if applicable)

N/A - known production bug.

## Risk

Medium - small surface area, but it does relate to accounts, so we must tread with caution.

## Testing

Things to test:

**Bug fix**

When selecting a UTXO asset from the Dashboard, we often display "Invalid Trade Pair" until the form is interacted with.
This should no longer occur.

**THORTrading**

Out of an abundance of caution, we should do a cross-chain swap on THORChain (i.e. one with a UTXO asset as the receive asset) and ensure that the funds are received.

### Engineering

☝️ 

### Operations

☝️ 

## Screenshots (if applicable)

N/A