### PR TITLE
chore: ensure preview trade loading button is blue

### DIFF
--- a/src/components/Trade/TradeInput.tsx
+++ b/src/components/Trade/TradeInput.tsx
@@ -395,6 +395,7 @@ export const TradeInput = () => {
     switch (getErrorTranslationKey()) {
       case 'trade.previewTrade':
       case 'trade.updatingQuote':
+      case 'common.loadingText':
         return false
       default:
         return true


### PR DESCRIPTION
## Description

When the "Preview trade" button is in the loading state it should be blue. This PR makes it so.

## Notice

- [x] Have you followed the guidelines in our [Contributing]('https://github.com/shapeshift/web/blob/develop/CONTRIBUTING.md) guide?
- [x] Have you checked to ensure there aren't other open [Pull Requests](https://github.com/shapeshift/web/pulls) for the same update/change?

## Pull Request Type

- [ ] :bug: Bug fix (Non-breaking Change: Fixes an issue)
- [x] :hammer_and_wrench: Chore (Non-breaking Change: Doc updates, pkg upgrades, typos, etc..)
- [ ] :nail_care: New Feature (Breaking/Non-breaking Change)

## Issue (if applicable)

Closes https://github.com/shapeshift/web/issues/3620

## Risk

As low as it gets.

## Testing

When the swapper widget is in the "Loading..." state the button should be blue (not red).

### Engineering

☝️ 

### Operations

☝️ 

## Screenshots (if applicable)

<img width="398" alt="Screenshot 2023-01-12 at 2 59 17 pm" src="https://user-images.githubusercontent.com/97164662/211972613-05210e97-e706-4822-9e05-a40720a420d7.png">
