### PR TITLE
chore: add swapperSupportsCrossAccountTrade commentary

### DIFF
--- a/src/components/Trade/hooks/useAccountsService.tsx
+++ b/src/components/Trade/hooks/useAccountsService.tsx
@@ -69,8 +69,11 @@ export const useAccountsService = () => {
   useEffect(() => {
     setValue(
       'buyAssetAccountId',
-      // If the swapper does not support cross-account trades the buyAssetAccountId must match the sellAssetAccountId
-      // If we don't have a swapper, we should not switch the buyAssetAccountId
+      /*
+        This is extremely dangerous. We only want to do this if we have a swapper, and that swapper does not do either of:
+          - Trades between assets on the same chain but different accounts
+          - Trades between assets on different chains (and possibly different accounts)
+       */
       swapperSupportsCrossAccountTrade || !bestTradeSwapper
         ? buyAssetAccountId
         : sellAssetAccountId,

--- a/src/components/Trade/hooks/useAccountsService.tsx
+++ b/src/components/Trade/hooks/useAccountsService.tsx
@@ -70,7 +70,8 @@ export const useAccountsService = () => {
     setValue(
       'buyAssetAccountId',
       /*
-        This is extremely dangerous. We only want to do this if we have a swapper, and that swapper does not do either of:
+        This is extremely dangerous. We only want to substitute the buyAssetAccountId with the sellAssetAccountId
+        if we have a swapper, and that swapper does not do either of:
           - Trades between assets on the same chain but different accounts
           - Trades between assets on different chains (and possibly different accounts)
        */

--- a/src/components/Trade/hooks/useSwapper/useSwapper.tsx
+++ b/src/components/Trade/hooks/useSwapper/useSwapper.tsx
@@ -97,8 +97,14 @@ export const useSwapper = () => {
     selectBIP44ParamsByAccountId(state, sellAccountFilter),
   )
 
+  /*
+  Cross-account trading means trades that are either:
+    - Trades between assets on the same chain but different accounts
+    - Trades between assets on different chains (and possibly different accounts)
+   When adding a new swapper, ensure that `true` is returned here if either of the above apply.
+   */
   const swapperSupportsCrossAccountTrade = useMemo(() => {
-    if (!bestTradeSwapper) return false
+    if (!bestTradeSwapper) return undefined
     switch (bestTradeSwapper.name) {
       case SwapperName.Thorchain:
       case SwapperName.Osmosis:


### PR DESCRIPTION
## Description

- Add commentary on the `swapperSupportsCrossAccountTrade` util, as it's an important function that we do not want to use incorrectly
- Update `false` to be `undefined`. No runtime changes here, but semantically more correct - if we have no swapper, the disposition of a swapper can be neither `true` or `false`.

## Notice

- [x] Have you followed the guidelines in our [Contributing]('https://github.com/shapeshift/web/blob/develop/CONTRIBUTING.md) guide?
- [x] Have you checked to ensure there aren't other open [Pull Requests](https://github.com/shapeshift/web/pulls) for the same update/change?

## Pull Request Type

- [ ] :bug: Bug fix (Non-breaking Change: Fixes an issue)
- [x] :hammer_and_wrench: Chore (Non-breaking Change: Doc updates, pkg upgrades, typos, etc..)
- [ ] :nail_care: New Feature (Breaking/Non-breaking Change)

## Issue (if applicable)

N/A

## Risk

Almost 0.

## Testing

N/A

### Engineering

☝️ 

### Operations

☝️ 

## Screenshots (if applicable)

N/A