### PR TITLE
feat: decouple handleSend and handleFormSend

### DIFF
--- a/src/components/Bridge/BridgeRoutes/Confirm.tsx
+++ b/src/components/Bridge/BridgeRoutes/Confirm.tsx
@@ -45,7 +45,7 @@ export const Confirm: React.FC = () => {
   const [isLoadingRelayerFee, setIsLoadingRelayerFee] = useState(true)
   const [isExecutingTransaction, setIsExecutingTransaction] = useState(false)
   const selectedCurrency = useAppSelector(selectSelectedCurrency)
-  const { handleSend } = useFormSend()
+  const { handleFormSend } = useFormSend()
   const translate = useTranslate()
 
   const axelarAssetTransferSdk = getAxelarAssetTransferSdk()
@@ -162,7 +162,7 @@ export const Confirm: React.FC = () => {
         input: depositAddress,
       }
 
-      await handleSend(handleSendArgs)
+      await handleFormSend(handleSendArgs)
       history.push(BridgeRoutePaths.Status)
     } catch (e) {
       moduleLogger.error(e, 'GasFee error')

--- a/src/components/Modals/Send/Form.tsx
+++ b/src/components/Modals/Send/Form.tsx
@@ -42,7 +42,7 @@ type SendFormProps = {
 export const Form: React.FC<SendFormProps> = ({ asset: initialAsset, accountId }) => {
   const location = useLocation()
   const history = useHistory()
-  const { handleSend } = useFormSend()
+  const { handleFormSend } = useFormSend()
   const selectedCurrency = useAppSelector(selectSelectedCurrency)
   const marketData = useAppSelector(state => selectMarketDataById(state, initialAsset.assetId))
 
@@ -87,7 +87,7 @@ export const Form: React.FC<SendFormProps> = ({ asset: initialAsset, accountId }
   return (
     <FormProvider {...methods}>
       {/* eslint-disable-next-line jsx-a11y/no-noninteractive-element-interactions */}
-      <form onSubmit={methods.handleSubmit(handleSend)} onKeyDown={checkKeyDown}>
+      <form onSubmit={methods.handleSubmit(handleFormSend)} onKeyDown={checkKeyDown}>
         <AnimatePresence exitBeforeEnter initial={false}>
           <Switch location={location} key={location.key}>
             <Route path={SendRoutes.Select}>

--- a/src/components/Modals/Send/hooks/useFormSend/useFormSend.test.tsx
+++ b/src/components/Modals/Send/hooks/useFormSend/useFormSend.test.tsx
@@ -174,7 +174,7 @@ describe.each([
 
     const { result } = renderHook(() => useFormSend())
     jest.useFakeTimers()
-    await result.current.handleSend(formData)
+    await result.current.handleFormSend(formData)
     jest.advanceTimersByTime(5000)
     expect(toaster).toHaveBeenCalledWith(expect.objectContaining({ status: 'success' }))
     expect(sendClose).toHaveBeenCalled()
@@ -224,7 +224,7 @@ describe.each([
 
     const { result } = renderHook(() => useFormSend())
     jest.useFakeTimers()
-    await result.current.handleSend(formDataEnsAddress)
+    await result.current.handleFormSend(formDataEnsAddress)
     jest.advanceTimersByTime(5000)
     expect(toaster).toHaveBeenCalledWith(expect.objectContaining({ status: 'success' }))
     expect(sendClose).toHaveBeenCalled()
@@ -269,7 +269,7 @@ describe.each([
 
     const { result } = renderHook(() => useFormSend())
     jest.useFakeTimers()
-    await result.current.handleSend(formData)
+    await result.current.handleFormSend(formData)
     jest.advanceTimersByTime(5000)
     expect(toaster).toHaveBeenCalledWith(expect.objectContaining({ status: 'success' }))
     expect(sendClose).toHaveBeenCalled()
@@ -319,7 +319,7 @@ describe.each([
 
     const { result } = renderHook(() => useFormSend())
     jest.useFakeTimers()
-    await result.current.handleSend(formDataEnsAddress)
+    await result.current.handleFormSend(formDataEnsAddress)
     jest.advanceTimersByTime(5000)
     expect(toaster).toHaveBeenCalledWith(expect.objectContaining({ status: 'success' }))
     expect(sendClose).toHaveBeenCalled()
@@ -358,7 +358,7 @@ describe.each([
     )
 
     const { result } = renderHook(() => useFormSend())
-    await expect(result.current.handleSend(formData)).rejects.toThrow()
+    await expect(result.current.handleFormSend(formData)).rejects.toThrow()
     expect(toaster).toHaveBeenCalledWith(expect.objectContaining({ status: 'error' }))
     expect(sendClose).toHaveBeenCalled()
   })

--- a/src/components/Modals/Send/hooks/useFormSend/useFormSend.tsx
+++ b/src/components/Modals/Send/hooks/useFormSend/useFormSend.tsx
@@ -11,176 +11,199 @@ import {
   type UtxoChainId,
   utxoChainIds,
 } from '@shapeshiftoss/chain-adapters'
+import type { HDWallet } from '@shapeshiftoss/hdwallet-core'
 import { supportsETH } from '@shapeshiftoss/hdwallet-core'
 import type { KnownChainIds } from '@shapeshiftoss/types'
+import { useCallback } from 'react'
 import { useTranslate } from 'react-polyglot'
-import { useSelector } from 'react-redux'
 import { getChainAdapterManager } from 'context/PluginProvider/chainAdapterSingleton'
-import { useEvm } from 'hooks/useEvm/useEvm'
+import { getSupportedEvmChainIds } from 'hooks/useEvm/useEvm'
 import { useModal } from 'hooks/useModal/useModal'
 import { useWallet } from 'hooks/useWallet/useWallet'
 import { bn, bnOrZero } from 'lib/bignumber/bignumber'
 import { logger } from 'lib/logger'
 import { tokenOrUndefined } from 'lib/utils'
-import { selectPortfolioAccountMetadata } from 'state/slices/selectors'
+import { selectPortfolioAccountMetadataByAccountId } from 'state/slices/selectors'
+import { store } from 'state/store'
 
 import type { SendInput } from '../../Form'
 
 const moduleLogger = logger.child({ namespace: ['Modals', 'Send', 'Hooks', 'UseFormSend'] })
 
+const handleSend = async ({
+  sendInput,
+  wallet,
+}: {
+  sendInput: SendInput
+  wallet: HDWallet
+}): Promise<string> => {
+  const chainAdapterManager = getChainAdapterManager()
+  const supportedEvmChainIds = getSupportedEvmChainIds()
+
+  try {
+    const state = store.getState()
+    const acccountMetadataFilter = { accountId: sendInput.accountId }
+    const accountMetadata = selectPortfolioAccountMetadataByAccountId(state, acccountMetadataFilter)
+    // Native and KeepKey hdwallets only support offline signing, not broadcasting signed TXs like e.g Metamask
+    if (
+      fromChainId(sendInput.asset.chainId).chainNamespace === CHAIN_NAMESPACE.CosmosSdk &&
+      !wallet.supportsOfflineSigning()
+    ) {
+      throw new Error(`unsupported wallet: ${await wallet.getModel()}`)
+    }
+
+    const adapter = chainAdapterManager.get(sendInput.asset.chainId) as ChainAdapter<KnownChainIds>
+    if (!adapter)
+      throw new Error(`useFormSend: no adapter available for ${sendInput.asset.chainId}`)
+
+    const value = bnOrZero(sendInput.cryptoAmount)
+      .times(bn(10).exponentiatedBy(sendInput.asset.precision))
+      .toFixed(0)
+
+    const chainId = adapter.getChainId()
+
+    const { estimatedFees, feeType, address: to } = sendInput
+
+    if (!accountMetadata)
+      throw new Error(`useFormSend: no accountMetadata for ${sendInput.accountId}`)
+    const { bip44Params, accountType } = accountMetadata
+    if (!bip44Params) {
+      throw new Error(`useFormSend: no bip44Params for accountId ${sendInput.accountId}`)
+    }
+
+    const result = await (async () => {
+      if (supportedEvmChainIds.includes(chainId)) {
+        if (!supportsETH(wallet)) throw new Error(`useFormSend: wallet does not support ethereum`)
+        const fees = estimatedFees[feeType] as FeeData<EvmChainId>
+        const {
+          chainSpecific: { gasPrice, gasLimit, maxFeePerGas, maxPriorityFeePerGas },
+        } = fees
+        const shouldUseEIP1559Fees =
+          (await wallet.ethSupportsEIP1559()) &&
+          maxFeePerGas !== undefined &&
+          maxPriorityFeePerGas !== undefined
+        if (!shouldUseEIP1559Fees && gasPrice === undefined) {
+          throw new Error(`useFormSend: missing gasPrice for non-EIP-1559 tx`)
+        }
+        const erc20ContractAddress = tokenOrUndefined(
+          fromAssetId(sendInput.asset.assetId).assetReference,
+        )
+        const { accountNumber } = bip44Params
+        return await (adapter as unknown as EvmBaseAdapter<EvmChainId>).buildSendTransaction({
+          to,
+          value,
+          wallet,
+          accountNumber,
+          chainSpecific: {
+            erc20ContractAddress,
+            gasLimit,
+            ...(shouldUseEIP1559Fees ? { maxFeePerGas, maxPriorityFeePerGas } : { gasPrice }),
+          },
+          sendMax: sendInput.sendMax,
+        })
+      }
+
+      if (utxoChainIds.some(utxoChainId => utxoChainId === chainId)) {
+        const fees = estimatedFees[feeType] as FeeData<UtxoChainId>
+
+        if (!accountType) {
+          throw new Error(
+            `useFormSend: no accountType for utxo from accountId: ${sendInput.accountId}`,
+          )
+        }
+        const { accountNumber } = bip44Params
+        return (adapter as unknown as UtxoBaseAdapter<UtxoChainId>).buildSendTransaction({
+          to,
+          value,
+          wallet,
+          accountNumber,
+          chainSpecific: {
+            satoshiPerByte: fees.chainSpecific.satoshiPerByte,
+            accountType,
+          },
+          sendMax: sendInput.sendMax,
+        })
+      }
+
+      if (fromChainId(sendInput.asset.chainId).chainNamespace === CHAIN_NAMESPACE.CosmosSdk) {
+        const fees = estimatedFees[feeType] as FeeData<CosmosSdkChainId>
+        const { accountNumber } = bip44Params
+        return adapter.buildSendTransaction({
+          to,
+          memo: (sendInput as SendInput<CosmosSdkChainId>).memo,
+          value,
+          wallet,
+          accountNumber,
+          chainSpecific: { gas: fees.chainSpecific.gasLimit, fee: fees.txFee },
+          sendMax: sendInput.sendMax,
+        })
+      }
+
+      throw new Error(`${chainId} not supported`)
+    })()
+
+    const txToSign = result.txToSign
+
+    const broadcastTXID = await (async () => {
+      if (wallet.supportsOfflineSigning()) {
+        const signedTx = await adapter.signTransaction({
+          txToSign,
+          wallet,
+        })
+        return adapter.broadcastTransaction(signedTx)
+      } else if (wallet.supportsBroadcast()) {
+        /**
+         * signAndBroadcastTransaction is an optional method on the HDWallet interface.
+         * Check and see if it exists; if so, call and make sure a txhash is returned
+         */
+        if (!adapter.signAndBroadcastTransaction) {
+          throw new Error('signAndBroadcastTransaction undefined for wallet')
+        }
+        return adapter.signAndBroadcastTransaction?.({ txToSign, wallet })
+      } else {
+        throw new Error('Bad hdwallet config')
+      }
+    })()
+
+    if (!broadcastTXID) {
+      throw new Error('Broadcast failed')
+    }
+
+    return broadcastTXID
+  } catch (error) {
+    moduleLogger.error(error, { fn: 'handleSend' }, 'Error handling send')
+    throw new Error('useFormSend: transaction rejected')
+  }
+}
+
 export const useFormSend = () => {
   const toast = useToast()
   const translate = useTranslate()
-  const chainAdapterManager = getChainAdapterManager()
   const { send } = useModal()
   const {
     state: { wallet },
   } = useWallet()
-  const { supportedEvmChainIds } = useEvm()
-  const accountMetadata = useSelector(selectPortfolioAccountMetadata)
 
-  const handleSend = async (data: SendInput) => {
-    if (wallet) {
+  const handleFormSend = useCallback(
+    async (sendInput: SendInput) => {
       try {
-        // Native and KeepKey hdwallets only support offline signing, not broadcasting signed TXs like e.g Metamask
-        if (
-          fromChainId(data.asset.chainId).chainNamespace === CHAIN_NAMESPACE.CosmosSdk &&
-          !wallet.supportsOfflineSigning()
-        ) {
-          throw new Error(`unsupported wallet: ${await wallet.getModel()}`)
-        }
+        if (!wallet) throw new Error('No wallet connected')
 
-        const adapter = chainAdapterManager.get(data.asset.chainId) as ChainAdapter<KnownChainIds>
-        if (!adapter) throw new Error(`useFormSend: no adapter available for ${data.asset.chainId}`)
-
-        if (!accountMetadata?.[data.accountId])
-          throw new Error(`useFormSend: no accountMetadata for ${data.accountId}`)
-
-        const value = bnOrZero(data.cryptoAmount)
-          .times(bn(10).exponentiatedBy(data.asset.precision))
-          .toFixed(0)
-
-        const chainId = adapter.getChainId()
-
-        const { estimatedFees, feeType, address: to } = data
-
-        const { bip44Params, accountType } = accountMetadata[data.accountId]
-        if (!bip44Params) {
-          throw new Error(`useFormSend: no bip44Params for accountId ${data.accountId}`)
-        }
-
-        const result = await (async () => {
-          if (supportedEvmChainIds.includes(chainId)) {
-            if (!supportsETH(wallet))
-              throw new Error(`useFormSend: wallet does not support ethereum`)
-            const fees = estimatedFees[feeType] as FeeData<EvmChainId>
-            const {
-              chainSpecific: { gasPrice, gasLimit, maxFeePerGas, maxPriorityFeePerGas },
-            } = fees
-            const shouldUseEIP1559Fees =
-              (await wallet.ethSupportsEIP1559()) &&
-              maxFeePerGas !== undefined &&
-              maxPriorityFeePerGas !== undefined
-            if (!shouldUseEIP1559Fees && gasPrice === undefined) {
-              throw new Error(`useFormSend: missing gasPrice for non-EIP-1559 tx`)
-            }
-            const erc20ContractAddress = tokenOrUndefined(
-              fromAssetId(data.asset.assetId).assetReference,
-            )
-            const { accountNumber } = bip44Params
-            return await (adapter as unknown as EvmBaseAdapter<EvmChainId>).buildSendTransaction({
-              to,
-              value,
-              wallet,
-              accountNumber,
-              chainSpecific: {
-                erc20ContractAddress,
-                gasLimit,
-                ...(shouldUseEIP1559Fees ? { maxFeePerGas, maxPriorityFeePerGas } : { gasPrice }),
-              },
-              sendMax: data.sendMax,
-            })
-          }
-
-          if (utxoChainIds.some(utxoChainId => utxoChainId === chainId)) {
-            const fees = estimatedFees[feeType] as FeeData<UtxoChainId>
-
-            if (!accountType) {
-              throw new Error(
-                `useFormSend: no accountType for utxo from accountId: ${data.accountId}`,
-              )
-            }
-            const { accountNumber } = bip44Params
-            return (adapter as unknown as UtxoBaseAdapter<UtxoChainId>).buildSendTransaction({
-              to,
-              value,
-              wallet,
-              accountNumber,
-              chainSpecific: {
-                satoshiPerByte: fees.chainSpecific.satoshiPerByte,
-                accountType,
-              },
-              sendMax: data.sendMax,
-            })
-          }
-
-          if (fromChainId(data.asset.chainId).chainNamespace === CHAIN_NAMESPACE.CosmosSdk) {
-            const fees = estimatedFees[feeType] as FeeData<CosmosSdkChainId>
-            const { accountNumber } = bip44Params
-            return adapter.buildSendTransaction({
-              to,
-              memo: (data as SendInput<CosmosSdkChainId>).memo,
-              value,
-              wallet,
-              accountNumber,
-              chainSpecific: { gas: fees.chainSpecific.gasLimit, fee: fees.txFee },
-              sendMax: data.sendMax,
-            })
-          }
-
-          throw new Error(`${chainId} not supported`)
-        })()
-
-        const txToSign = result.txToSign
-
-        const broadcastTXID = await (async () => {
-          if (wallet.supportsOfflineSigning()) {
-            const signedTx = await adapter.signTransaction({
-              txToSign,
-              wallet,
-            })
-            return adapter.broadcastTransaction(signedTx)
-          } else if (wallet.supportsBroadcast()) {
-            /**
-             * signAndBroadcastTransaction is an optional method on the HDWallet interface.
-             * Check and see if it exists; if so, call and make sure a txhash is returned
-             */
-            if (!adapter.signAndBroadcastTransaction) {
-              throw new Error('signAndBroadcastTransaction undefined for wallet')
-            }
-            return adapter.signAndBroadcastTransaction?.({ txToSign, wallet })
-          } else {
-            throw new Error('Bad hdwallet config')
-          }
-        })()
-
-        if (!broadcastTXID) {
-          throw new Error('Broadcast failed')
-        }
+        const broadcastTXID = await handleSend({ wallet, sendInput })
 
         setTimeout(() => {
           toast({
-            title: translate('modals.send.sent', { asset: data.asset.name }),
+            title: translate('modals.send.sent', { asset: sendInput.asset.name }),
             description: (
               <Text>
                 <Text>
                   {translate('modals.send.youHaveSent', {
-                    amount: data.cryptoAmount,
-                    symbol: data.cryptoSymbol,
+                    amount: sendInput.cryptoAmount,
+                    symbol: sendInput.cryptoSymbol,
                   })}
                 </Text>
-                {data.asset.explorerTxLink && (
-                  <Link href={`${data.asset.explorerTxLink}${broadcastTXID}`} isExternal>
+                {sendInput.asset.explorerTxLink && (
+                  <Link href={`${sendInput.asset.explorerTxLink}${broadcastTXID}`} isExternal>
                     {translate('modals.status.viewExplorer')} <ExternalLinkIcon mx='2px' />
                   </Link>
                 )}
@@ -192,11 +215,10 @@ export const useFormSend = () => {
             position: 'top-right',
           })
         }, 5000)
-      } catch (error) {
-        moduleLogger.error(error, { fn: 'handleSend' }, 'Error handling send')
+      } catch {
         toast({
           title: translate('modals.send.errorTitle', {
-            asset: data.asset.name,
+            asset: sendInput.asset.name,
           }),
           description: translate('modals.send.errors.transactionRejected'),
           status: 'error',
@@ -204,13 +226,14 @@ export const useFormSend = () => {
           isClosable: true,
           position: 'top-right',
         })
-        throw new Error('useFormSend: transaction rejected')
       } finally {
         send.close()
       }
-    }
-  }
+    },
+    [send, toast, translate, wallet],
+  )
+
   return {
-    handleSend,
+    handleFormSend,
   }
 }

--- a/src/components/Modals/Send/hooks/useFormSend/useFormSend.tsx
+++ b/src/components/Modals/Send/hooks/useFormSend/useFormSend.tsx
@@ -1,180 +1,15 @@
 import { ExternalLinkIcon } from '@chakra-ui/icons'
 import { Link, Text, useToast } from '@chakra-ui/react'
-import { CHAIN_NAMESPACE, fromAssetId, fromChainId } from '@shapeshiftoss/caip'
-import type { CosmosSdkChainId } from '@shapeshiftoss/chain-adapters'
-import {
-  type ChainAdapter,
-  type EvmBaseAdapter,
-  type EvmChainId,
-  type FeeData,
-  type UtxoBaseAdapter,
-  type UtxoChainId,
-  utxoChainIds,
-} from '@shapeshiftoss/chain-adapters'
-import type { HDWallet } from '@shapeshiftoss/hdwallet-core'
-import { supportsETH } from '@shapeshiftoss/hdwallet-core'
-import type { KnownChainIds } from '@shapeshiftoss/types'
 import { useCallback } from 'react'
 import { useTranslate } from 'react-polyglot'
-import { getChainAdapterManager } from 'context/PluginProvider/chainAdapterSingleton'
-import { getSupportedEvmChainIds } from 'hooks/useEvm/useEvm'
 import { useModal } from 'hooks/useModal/useModal'
 import { useWallet } from 'hooks/useWallet/useWallet'
-import { bn, bnOrZero } from 'lib/bignumber/bignumber'
 import { logger } from 'lib/logger'
-import { tokenOrUndefined } from 'lib/utils'
-import { selectPortfolioAccountMetadataByAccountId } from 'state/slices/selectors'
-import { store } from 'state/store'
 
 import type { SendInput } from '../../Form'
+import { handleSend } from '../../utils'
 
 const moduleLogger = logger.child({ namespace: ['Modals', 'Send', 'Hooks', 'UseFormSend'] })
-
-const handleSend = async ({
-  sendInput,
-  wallet,
-}: {
-  sendInput: SendInput
-  wallet: HDWallet
-}): Promise<string> => {
-  const chainAdapterManager = getChainAdapterManager()
-  const supportedEvmChainIds = getSupportedEvmChainIds()
-
-  try {
-    const state = store.getState()
-    const acccountMetadataFilter = { accountId: sendInput.accountId }
-    const accountMetadata = selectPortfolioAccountMetadataByAccountId(state, acccountMetadataFilter)
-    // Native and KeepKey hdwallets only support offline signing, not broadcasting signed TXs like e.g Metamask
-    if (
-      fromChainId(sendInput.asset.chainId).chainNamespace === CHAIN_NAMESPACE.CosmosSdk &&
-      !wallet.supportsOfflineSigning()
-    ) {
-      throw new Error(`unsupported wallet: ${await wallet.getModel()}`)
-    }
-
-    const adapter = chainAdapterManager.get(sendInput.asset.chainId) as ChainAdapter<KnownChainIds>
-    if (!adapter)
-      throw new Error(`useFormSend: no adapter available for ${sendInput.asset.chainId}`)
-
-    const value = bnOrZero(sendInput.cryptoAmount)
-      .times(bn(10).exponentiatedBy(sendInput.asset.precision))
-      .toFixed(0)
-
-    const chainId = adapter.getChainId()
-
-    const { estimatedFees, feeType, address: to } = sendInput
-
-    if (!accountMetadata)
-      throw new Error(`useFormSend: no accountMetadata for ${sendInput.accountId}`)
-    const { bip44Params, accountType } = accountMetadata
-    if (!bip44Params) {
-      throw new Error(`useFormSend: no bip44Params for accountId ${sendInput.accountId}`)
-    }
-
-    const result = await (async () => {
-      if (supportedEvmChainIds.includes(chainId)) {
-        if (!supportsETH(wallet)) throw new Error(`useFormSend: wallet does not support ethereum`)
-        const fees = estimatedFees[feeType] as FeeData<EvmChainId>
-        const {
-          chainSpecific: { gasPrice, gasLimit, maxFeePerGas, maxPriorityFeePerGas },
-        } = fees
-        const shouldUseEIP1559Fees =
-          (await wallet.ethSupportsEIP1559()) &&
-          maxFeePerGas !== undefined &&
-          maxPriorityFeePerGas !== undefined
-        if (!shouldUseEIP1559Fees && gasPrice === undefined) {
-          throw new Error(`useFormSend: missing gasPrice for non-EIP-1559 tx`)
-        }
-        const erc20ContractAddress = tokenOrUndefined(
-          fromAssetId(sendInput.asset.assetId).assetReference,
-        )
-        const { accountNumber } = bip44Params
-        return await (adapter as unknown as EvmBaseAdapter<EvmChainId>).buildSendTransaction({
-          to,
-          value,
-          wallet,
-          accountNumber,
-          chainSpecific: {
-            erc20ContractAddress,
-            gasLimit,
-            ...(shouldUseEIP1559Fees ? { maxFeePerGas, maxPriorityFeePerGas } : { gasPrice }),
-          },
-          sendMax: sendInput.sendMax,
-        })
-      }
-
-      if (utxoChainIds.some(utxoChainId => utxoChainId === chainId)) {
-        const fees = estimatedFees[feeType] as FeeData<UtxoChainId>
-
-        if (!accountType) {
-          throw new Error(
-            `useFormSend: no accountType for utxo from accountId: ${sendInput.accountId}`,
-          )
-        }
-        const { accountNumber } = bip44Params
-        return (adapter as unknown as UtxoBaseAdapter<UtxoChainId>).buildSendTransaction({
-          to,
-          value,
-          wallet,
-          accountNumber,
-          chainSpecific: {
-            satoshiPerByte: fees.chainSpecific.satoshiPerByte,
-            accountType,
-          },
-          sendMax: sendInput.sendMax,
-        })
-      }
-
-      if (fromChainId(sendInput.asset.chainId).chainNamespace === CHAIN_NAMESPACE.CosmosSdk) {
-        const fees = estimatedFees[feeType] as FeeData<CosmosSdkChainId>
-        const { accountNumber } = bip44Params
-        return adapter.buildSendTransaction({
-          to,
-          memo: (sendInput as SendInput<CosmosSdkChainId>).memo,
-          value,
-          wallet,
-          accountNumber,
-          chainSpecific: { gas: fees.chainSpecific.gasLimit, fee: fees.txFee },
-          sendMax: sendInput.sendMax,
-        })
-      }
-
-      throw new Error(`${chainId} not supported`)
-    })()
-
-    const txToSign = result.txToSign
-
-    const broadcastTXID = await (async () => {
-      if (wallet.supportsOfflineSigning()) {
-        const signedTx = await adapter.signTransaction({
-          txToSign,
-          wallet,
-        })
-        return adapter.broadcastTransaction(signedTx)
-      } else if (wallet.supportsBroadcast()) {
-        /**
-         * signAndBroadcastTransaction is an optional method on the HDWallet interface.
-         * Check and see if it exists; if so, call and make sure a txhash is returned
-         */
-        if (!adapter.signAndBroadcastTransaction) {
-          throw new Error('signAndBroadcastTransaction undefined for wallet')
-        }
-        return adapter.signAndBroadcastTransaction?.({ txToSign, wallet })
-      } else {
-        throw new Error('Bad hdwallet config')
-      }
-    })()
-
-    if (!broadcastTXID) {
-      throw new Error('Broadcast failed')
-    }
-
-    return broadcastTXID
-  } catch (error) {
-    moduleLogger.error(error, { fn: 'handleSend' }, 'Error handling send')
-    throw new Error('useFormSend: transaction rejected')
-  }
-}
 
 export const useFormSend = () => {
   const toast = useToast()
@@ -215,7 +50,8 @@ export const useFormSend = () => {
             position: 'top-right',
           })
         }, 5000)
-      } catch {
+      } catch (e) {
+        moduleLogger.error(e, 'Error handling form send')
         toast({
           title: translate('modals.send.errorTitle', {
             asset: sendInput.asset.name,

--- a/src/components/Modals/Send/hooks/useFormSend/useFormSend.tsx
+++ b/src/components/Modals/Send/hooks/useFormSend/useFormSend.tsx
@@ -50,7 +50,7 @@ export const useFormSend = () => {
             position: 'top-right',
           })
         }, 5000)
-      } catch (e) {
+      } catch (e: any) {
         moduleLogger.error(e, 'Error handling form send')
         toast({
           title: translate('modals.send.errorTitle', {

--- a/src/components/Modals/Send/hooks/useFormSend/useFormSend.tsx
+++ b/src/components/Modals/Send/hooks/useFormSend/useFormSend.tsx
@@ -62,6 +62,8 @@ export const useFormSend = () => {
           isClosable: true,
           position: 'top-right',
         })
+
+        throw new Error(e)
       } finally {
         send.close()
       }

--- a/src/components/Modals/Send/utils.ts
+++ b/src/components/Modals/Send/utils.ts
@@ -1,15 +1,28 @@
 import type { Asset } from '@shapeshiftoss/asset-service'
 import type { ChainId } from '@shapeshiftoss/caip'
-import { CHAIN_NAMESPACE, fromAccountId, fromChainId } from '@shapeshiftoss/caip'
-import type {
-  EvmBaseAdapter,
-  EvmChainId,
-  FeeDataEstimate,
-  UtxoBaseAdapter,
-  UtxoChainId,
+import { CHAIN_NAMESPACE, fromAccountId, fromAssetId, fromChainId } from '@shapeshiftoss/caip'
+import type { CosmosSdkChainId, FeeDataEstimate } from '@shapeshiftoss/chain-adapters'
+import {
+  type ChainAdapter,
+  type EvmBaseAdapter,
+  type EvmChainId,
+  type FeeData,
+  type UtxoBaseAdapter,
+  type UtxoChainId,
+  utxoChainIds,
 } from '@shapeshiftoss/chain-adapters'
+import type { HDWallet } from '@shapeshiftoss/hdwallet-core'
+import { supportsETH } from '@shapeshiftoss/hdwallet-core'
+import type { KnownChainIds } from '@shapeshiftoss/types'
 import { getChainAdapterManager } from 'context/PluginProvider/chainAdapterSingleton'
+import { getSupportedEvmChainIds } from 'hooks/useEvm/useEvm'
 import { bn, bnOrZero } from 'lib/bignumber/bignumber'
+import { logger } from 'lib/logger'
+import { tokenOrUndefined } from 'lib/utils'
+import { selectPortfolioAccountMetadataByAccountId } from 'state/slices/selectors'
+import { store } from 'state/store'
+
+import type { SendInput } from './Form'
 
 export type EstimateFeesInput = {
   cryptoAmount: string
@@ -19,6 +32,8 @@ export type EstimateFeesInput = {
   accountId: string
   contractAddress: string | undefined
 }
+
+const moduleLogger = logger.child({ namespace: ['Modals', 'Send', 'utils'] })
 
 export const estimateFees = ({
   cryptoAmount,
@@ -60,5 +75,151 @@ export const estimateFees = ({
     }
     default:
       throw new Error(`${chainNamespace} not supported`)
+  }
+}
+
+export const handleSend = async ({
+  sendInput,
+  wallet,
+}: {
+  sendInput: SendInput
+  wallet: HDWallet
+}): Promise<string> => {
+  const chainAdapterManager = getChainAdapterManager()
+  const supportedEvmChainIds = getSupportedEvmChainIds()
+
+  try {
+    const state = store.getState()
+    const acccountMetadataFilter = { accountId: sendInput.accountId }
+    const accountMetadata = selectPortfolioAccountMetadataByAccountId(state, acccountMetadataFilter)
+    // Native and KeepKey hdwallets only support offline signing, not broadcasting signed TXs like e.g Metamask
+    if (
+      fromChainId(sendInput.asset.chainId).chainNamespace === CHAIN_NAMESPACE.CosmosSdk &&
+      !wallet.supportsOfflineSigning()
+    ) {
+      throw new Error(`unsupported wallet: ${await wallet.getModel()}`)
+    }
+
+    const adapter = chainAdapterManager.get(sendInput.asset.chainId) as ChainAdapter<KnownChainIds>
+    if (!adapter)
+      throw new Error(`useFormSend: no adapter available for ${sendInput.asset.chainId}`)
+
+    const value = bnOrZero(sendInput.cryptoAmount)
+      .times(bn(10).exponentiatedBy(sendInput.asset.precision))
+      .toFixed(0)
+
+    const chainId = adapter.getChainId()
+
+    const { estimatedFees, feeType, address: to } = sendInput
+
+    if (!accountMetadata)
+      throw new Error(`useFormSend: no accountMetadata for ${sendInput.accountId}`)
+    const { bip44Params, accountType } = accountMetadata
+    if (!bip44Params) {
+      throw new Error(`useFormSend: no bip44Params for accountId ${sendInput.accountId}`)
+    }
+
+    const result = await (async () => {
+      if (supportedEvmChainIds.includes(chainId)) {
+        if (!supportsETH(wallet)) throw new Error(`useFormSend: wallet does not support ethereum`)
+        const fees = estimatedFees[feeType] as FeeData<EvmChainId>
+        const {
+          chainSpecific: { gasPrice, gasLimit, maxFeePerGas, maxPriorityFeePerGas },
+        } = fees
+        const shouldUseEIP1559Fees =
+          (await wallet.ethSupportsEIP1559()) &&
+          maxFeePerGas !== undefined &&
+          maxPriorityFeePerGas !== undefined
+        if (!shouldUseEIP1559Fees && gasPrice === undefined) {
+          throw new Error(`useFormSend: missing gasPrice for non-EIP-1559 tx`)
+        }
+        const erc20ContractAddress = tokenOrUndefined(
+          fromAssetId(sendInput.asset.assetId).assetReference,
+        )
+        const { accountNumber } = bip44Params
+        return await (adapter as unknown as EvmBaseAdapter<EvmChainId>).buildSendTransaction({
+          to,
+          value,
+          wallet,
+          accountNumber,
+          chainSpecific: {
+            erc20ContractAddress,
+            gasLimit,
+            ...(shouldUseEIP1559Fees ? { maxFeePerGas, maxPriorityFeePerGas } : { gasPrice }),
+          },
+          sendMax: sendInput.sendMax,
+        })
+      }
+
+      if (utxoChainIds.some(utxoChainId => utxoChainId === chainId)) {
+        const fees = estimatedFees[feeType] as FeeData<UtxoChainId>
+
+        if (!accountType) {
+          throw new Error(
+            `useFormSend: no accountType for utxo from accountId: ${sendInput.accountId}`,
+          )
+        }
+        const { accountNumber } = bip44Params
+        return (adapter as unknown as UtxoBaseAdapter<UtxoChainId>).buildSendTransaction({
+          to,
+          value,
+          wallet,
+          accountNumber,
+          chainSpecific: {
+            satoshiPerByte: fees.chainSpecific.satoshiPerByte,
+            accountType,
+          },
+          sendMax: sendInput.sendMax,
+        })
+      }
+
+      if (fromChainId(sendInput.asset.chainId).chainNamespace === CHAIN_NAMESPACE.CosmosSdk) {
+        const fees = estimatedFees[feeType] as FeeData<CosmosSdkChainId>
+        const { accountNumber } = bip44Params
+        return adapter.buildSendTransaction({
+          to,
+          memo: (sendInput as SendInput<CosmosSdkChainId>).memo,
+          value,
+          wallet,
+          accountNumber,
+          chainSpecific: { gas: fees.chainSpecific.gasLimit, fee: fees.txFee },
+          sendMax: sendInput.sendMax,
+        })
+      }
+
+      throw new Error(`${chainId} not supported`)
+    })()
+
+    const txToSign = result.txToSign
+
+    const broadcastTXID = await (async () => {
+      if (wallet.supportsOfflineSigning()) {
+        const signedTx = await adapter.signTransaction({
+          txToSign,
+          wallet,
+        })
+        return adapter.broadcastTransaction(signedTx)
+      } else if (wallet.supportsBroadcast()) {
+        /**
+         * signAndBroadcastTransaction is an optional method on the HDWallet interface.
+         * Check and see if it exists; if so, call and make sure a txhash is returned
+         */
+        if (!adapter.signAndBroadcastTransaction) {
+          throw new Error('signAndBroadcastTransaction undefined for wallet')
+        }
+        return adapter.signAndBroadcastTransaction?.({ txToSign, wallet })
+      } else {
+        throw new Error('Bad hdwallet config')
+      }
+    })()
+
+    if (!broadcastTXID) {
+      throw new Error('Broadcast failed')
+    }
+
+    return broadcastTXID
+  } catch (error) {
+    moduleLogger.error(error, { fn: 'handleSend' }, 'Error handling send')
+    throw new Error('handleSend: transaction rejected')
   }
 }

--- a/src/hooks/useEvm/useEvm.ts
+++ b/src/hooks/useEvm/useEvm.ts
@@ -17,6 +17,11 @@ const chainIdFromEthNetwork = (
   return supportedEvmChainIds.find(chainId => fromChainId(chainId).chainReference === ethNetwork)
 }
 
+export const getSupportedEvmChainIds = () =>
+  Array.from(getChainAdapterManager().keys()).filter(
+    chainId => fromChainId(chainId).chainNamespace === CHAIN_NAMESPACE.Evm,
+  )
+
 export const useEvm = () => {
   const {
     state: { wallet },
@@ -25,10 +30,7 @@ export const useEvm = () => {
   const [ethNetwork, setEthNetwork] = useState<string>()
   const featureFlags = useAppSelector(selectFeatureFlags)
   const supportedEvmChainIds = useMemo(
-    () =>
-      Array.from(getChainAdapterManager().keys()).filter(
-        chainId => fromChainId(chainId).chainNamespace === CHAIN_NAMESPACE.Evm,
-      ),
+    () => getSupportedEvmChainIds(),
     // We want to explicitly react on featureFlags to get a new reference here
     // eslint-disable-next-line react-hooks/exhaustive-deps
     [featureFlags],


### PR DESCRIPTION
## Description

This PR decouples the sending logic from `handleSend` to the view-layer stuff that's ran as part of it (toasts and modal close). Accidentally improves error-handling by making `handleSend` pure.

Required for THORChain savers deposits - since these are considered deposits from a UX perspective vs. sends, the DeFi modal will handle success and error states the toast would be handling.

Note, to keep this diff minimal, this does *not* give `handleSend` a better home yet, but I'll PR a follow-up on top of this after the quotes/deposit PR https://github.com/shapeshift/web/pull/3630 is ready, to move it from `src/components/Modals/Send` to `src/lib/send`.

## Notice

<!-- Before submitting a pull request, please make sure you have answered the following: -->

- [x] Have you followed the guidelines in our [Contributing]('https://github.com/shapeshift/web/blob/develop/CONTRIBUTING.md) guide?
- [x] Have you checked to ensure there aren't other open [Pull Requests](https://github.com/shapeshift/web/pulls) for the same update/change?

## Pull Request Type

- [ ] :bug: Bug fix (Non-breaking Change: Fixes an issue)
- [ ] :hammer_and_wrench: Chore (Non-breaking Change: Doc updates, pkg upgrades, typos, etc..)
- [x] :nail_care: New Feature (Breaking/Non-breaking Change)

## Issue (if applicable)

N/A

## Risk

<!-----------------------------------------------------------------------------
Outline the scope of your changes and the risk associated with them. You must use your discretion as an engineer to determine the potential impact of your changes.

E.g. an upgrade to `hdwallet` or core state management would be considered higher risk, and might require a full regression test. UI or isolated view changes, or something behind a feature flag may have near zero risk. Small bug fixes might require testing isolated to the specific fix.
------------------------------------------------------------------------------>

Moderate - there should be no runtime change for actual sends, though the side-effects might be broken - tested with ATOM which successfully closed the modal on success/failure, and broadcasted success and error toasts with no regressions.

## Testing

<!-----------------------------------------------------------------------------
We treat every PR to be merged with the same scrutiny as if we were merging directly to production.

Your PR will not be merged if you do not complete the sections below for our engineering and operations teams to test.
------------------------------------------------------------------------------>

- Sends still work
- Send modal still closes on send success/failure
- Send toasts still pop up

### Engineering

<!-----------------------------------------------------------------------------
Include sufficient information here for an engineer to test your PR. This may include how to test locally, in a built environment, changes to infrastructure etc.
------------------------------------------------------------------------------>

- ☝🏽 

### Operations

<!-----------------------------------------------------------------------------
If your changes have a user-facing impact, describe how a non-technical QA team can functionally test your changes in a preview environment.

If they are not user-facing please describe how to test for any regressions that may occur.
------------------------------------------------------------------------------>

☝🏽 

## Screenshots (if applicable)
