### PR TITLE
feat: use either savers previous address or highest balance xpub address as `from`

### DIFF
--- a/src/features/defi/providers/thorchain-savers/components/ThorchainSaversManager/Deposit/components/Confirm.tsx
+++ b/src/features/defi/providers/thorchain-savers/components/ThorchainSaversManager/Deposit/components/Confirm.tsx
@@ -194,13 +194,11 @@ export const Confirm: React.FC<ConfirmProps> = ({ accountId, onNext }) => {
       const quote = await getThorchainSaversQuote(asset, amountCryptoBaseUnit)
 
       const sendInput: SendInput = {
-        cryptoAmount: bnOrZero(state?.deposit.cryptoAmount)
-          .plus(state?.deposit?.estimatedGasCrypto)
-          .toFixed(),
+        cryptoAmount: '',
         asset,
         from: '', // Let coinselect do its magic here
         to: maybeFromUTXOAccountAddress,
-        sendMax: false,
+        sendMax: true,
         accountId: accountId ?? '',
         amountFieldError: '',
         cryptoSymbol: asset?.symbol ?? '',
@@ -265,10 +263,7 @@ export const Confirm: React.FC<ConfirmProps> = ({ accountId, onNext }) => {
       txId = await handleSend({
         sendInput: depositInput,
         wallet: walletState.wallet,
-      }).catch(e => {
-        console.log(e)
-        return ''
-      })
+      }).catch(_e => '')
     }
 
     return txId
@@ -290,7 +285,7 @@ export const Confirm: React.FC<ConfirmProps> = ({ accountId, onNext }) => {
               return highestBalanceAccount
             })
         : ''
-      setmaybeFromUTXOAccountAddress(accountAddress)
+      setMaybeFromUTXOAccountAddress(accountAddress)
     })()
   }, [chainId, accountId, assetId])
 

--- a/src/features/defi/providers/thorchain-savers/components/ThorchainSaversManager/Deposit/components/Confirm.tsx
+++ b/src/features/defi/providers/thorchain-savers/components/ThorchainSaversManager/Deposit/components/Confirm.tsx
@@ -118,27 +118,6 @@ export const Confirm: React.FC<ConfirmProps> = ({ accountId, onNext }) => {
     }
   }, [accountId, asset, state?.deposit.cryptoAmount])
 
-  useEffect(() => {
-    if (!accountId) return
-    ;(async () => {
-      const accountAddress = isUtxoChainId(chainId)
-        ? await getThorchainSaversPosition(accountId, assetId)
-            .then(({ asset_address }) =>
-              chainId === bchChainId ? `bitcoincash:${asset_address}` : asset_address,
-            )
-            .catch(async () => {
-              const addressesWithBalances = await getAccountAddressesWithBalances(accountId)
-              const highestBalanceAccount = addressesWithBalances.sort((a, b) =>
-                bnOrZero(a.balance).gte(bnOrZero(b.balance)) ? -1 : 1,
-              )[0].address
-
-              return highestBalanceAccount
-            })
-        : ''
-      setMaybeFromUTXOAccountAddress(accountAddress)
-    })()
-  }, [chainId, accountId, assetId])
-
   const getDepositInput: () => Promise<SendInput | undefined> = useCallback(async () => {
     if (!(accountId && assetId)) return
     if (!state?.deposit.cryptoAmount) {
@@ -270,6 +249,7 @@ export const Confirm: React.FC<ConfirmProps> = ({ accountId, onNext }) => {
 
     return txId
   }, [getDepositInput, getPreDepositInput, walletState.wallet])
+
   useEffect(() => {
     if (!accountId) return
     ;(async () => {

--- a/src/features/defi/providers/thorchain-savers/components/ThorchainSaversManager/Deposit/components/Confirm.tsx
+++ b/src/features/defi/providers/thorchain-savers/components/ThorchainSaversManager/Deposit/components/Confirm.tsx
@@ -199,9 +199,9 @@ export const Confirm: React.FC<ConfirmProps> = ({ accountId, onNext }) => {
         from: '', // Let coinselect do its magic here
         to: maybeFromUTXOAccountAddress,
         sendMax: true,
-        accountId: accountId ?? '',
+        accountId,
         amountFieldError: '',
-        cryptoSymbol: asset?.symbol ?? '',
+        cryptoSymbol: asset.symbol,
         estimatedFees,
         feeType: FeeDataKey.Fast,
         fiatAmount: '',

--- a/src/features/defi/providers/thorchain-savers/components/ThorchainSaversManager/Deposit/components/Confirm.tsx
+++ b/src/features/defi/providers/thorchain-savers/components/ThorchainSaversManager/Deposit/components/Confirm.tsx
@@ -139,7 +139,7 @@ export const Confirm: React.FC<ConfirmProps> = ({ accountId, onNext }) => {
     })()
   }, [chainId, accountId, assetId])
 
-  const getSendInput: () => Promise<SendInput | undefined> = useCallback(async () => {
+  const getDepositInput: () => Promise<SendInput | undefined> = useCallback(async () => {
     if (!(accountId && assetId)) return
     if (!state?.deposit.cryptoAmount) {
       throw new Error('Cannot send 0-value THORCHain savers Tx')
@@ -183,6 +183,115 @@ export const Confirm: React.FC<ConfirmProps> = ({ accountId, onNext }) => {
     state?.deposit.cryptoAmount,
   ])
 
+  const getPreDepositInput: () => Promise<SendInput | undefined> = useCallback(async () => {
+    if (!(accountId && assetId)) return
+
+    try {
+      const estimatedFees = await estimateFees(await getEstimateFeesArgs())
+      const amountCryptoBaseUnit = bnOrZero(state?.deposit.cryptoAmount).times(
+        bn(10).pow(asset.precision),
+      )
+      const quote = await getThorchainSaversQuote(asset, amountCryptoBaseUnit)
+
+      const sendInput: SendInput = {
+        cryptoAmount: state?.deposit.cryptoAmount ?? '',
+        asset,
+        from: '', // Let coinselect do its magic here
+        to: maybeFromUTXOAccountAddress,
+        sendMax: false,
+        accountId: accountId ?? '',
+        amountFieldError: '',
+        cryptoSymbol: asset?.symbol ?? '',
+        estimatedFees,
+        feeType: FeeDataKey.Fast,
+        fiatAmount: '',
+        fiatSymbol: selectedCurrency,
+        vanityAddress: '',
+        input: quote.inbound_address,
+      }
+
+      return sendInput
+    } catch (e) {
+      moduleLogger.error({ fn: 'getSendInput', e }, 'Error building THORChain savers Tx')
+    }
+  }, [
+    maybeFromUTXOAccountAddress,
+    accountId,
+    asset,
+    assetId,
+    getEstimateFeesArgs,
+    selectedCurrency,
+    state?.deposit.cryptoAmount,
+  ])
+
+  const handleMultiTxSend = useCallback(async (): Promise<string | undefined> => {
+    if (!walletState.wallet) return
+
+    // THORChain Txs need to always be sent from the same address, since the address (NOT the pubkey) is used to identify an active position
+    // The way THORChain does this is by not being xpub-compliant, and only exposing a single address for UTXOs in their UI
+    // All deposit/withdraws done from their UI are always done with one/many UTXOs from the same address, and change sent back to the same address
+    // We also do this EXCLUSIVELY for THORChain Txs. The rest of the app uses xpubs, so the initially deposited from address isn't guaranteed to be populated
+    // if users send other UTXO Txs in the meantime after depositing
+    // Additionally, we select their highest balance UTXO address as a first deposit, which isn't guaranteed to contain enough value
+    //
+    // For both re/deposit flows, we will possibly need a pre-Tx to populate their highest UTXO/previously deposited from address with enough value
+
+    const depositInput = await getDepositInput()
+    if (!depositInput) throw new Error('Error building send input')
+
+    let txId: string
+
+    try {
+      // 1. Try to deposit from the originally deposited from / highest UTXO balance address
+      // If this is enough, no other Tx is needed
+      txId = await handleSend({
+        sendInput: depositInput,
+        wallet: walletState.wallet,
+      })
+    } catch (e) {
+      // 2. signAndBroadcastTransaction threw, meaning there's not enough value in the picked address - send funds to it
+      const preDepositInput = await getPreDepositInput()
+      if (!preDepositInput) throw new Error('Error building send input')
+      txId = await handleSend({
+        sendInput: preDepositInput,
+        wallet: walletState.wallet,
+      })
+      // 3. Sign and broadcast the depooosit Tx again
+
+      // Wait for the pre-deposit Tx to actually be in the mempool
+      await new Promise(resolve => setTimeout(resolve, 100000))
+      txId = await handleSend({
+        sendInput: depositInput,
+        wallet: walletState.wallet,
+      }).catch(e => {
+        console.log(e)
+        return ''
+      })
+    }
+
+    return txId
+  }, [getDepositInput, getPreDepositInput, walletState.wallet])
+  useEffect(() => {
+    if (!accountId) return
+    ;(async () => {
+      const accountAddress = isUtxoChainId(chainId)
+        ? await getThorchainSaversPosition(accountId, assetId)
+            .then(({ asset_address }) =>
+              chainId === bchChainId ? `bitcoincash:${asset_address}` : asset_address,
+            )
+            .catch(async () => {
+              const addressesWithBalances = await getAccountAddressesWithBalances(accountId)
+              const highestBalanceAccount = addressesWithBalances.sort((a, b) =>
+                bnOrZero(a.balance).gte(bnOrZero(b.balance)) ? -1 : 1,
+              )[0].address
+
+              return highestBalanceAccount
+            })
+        : ''
+      setmaybeFromUTXOAccountAddress(accountAddress)
+    })()
+  }, [chainId, accountId, assetId])
+
   const handleDeposit = useCallback(async () => {
     if (!contextDispatch || !bip44Params || !accountId || !assetId) return
     try {
@@ -216,18 +325,19 @@ export const Confirm: React.FC<ConfirmProps> = ({ accountId, onNext }) => {
         throw new Error(`THORChain pool halted for assetId: ${assetId}`)
       }
 
-      const sendInput = await getSendInput()
-      if (!sendInput) throw new Error('Error building send input')
+      const depositInput = await getDepositInput()
+      if (!depositInput) throw new Error('Error building send input')
 
-      const maybeTxId = await handleSend({
-        sendInput,
-        wallet: walletState.wallet,
-      })
+      const maybeTxId = await handleMultiTxSend()
+
+      if (!maybeTxId) {
+        throw new Error('Error sending THORCHain savers Txs')
+      }
 
       contextDispatch({ type: ThorchainSaversDepositActionType.SET_TXID, payload: maybeTxId })
       onNext(DefiStep.Status)
     } catch (error) {
-      moduleLogger.debug({ fn: 'handleDeposit' }, 'Error sending THORCHain savers Tx')
+      moduleLogger.debug({ fn: 'handleDeposit' }, 'Error sending THORCHain savers Txs')
       // TODO(gomes): UTXO reconciliation in a stacked PR
       toast({
         position: 'top-right',
@@ -250,7 +360,8 @@ export const Confirm: React.FC<ConfirmProps> = ({ accountId, onNext }) => {
     chainAdapter,
     state?.deposit.cryptoAmount,
     appDispatch,
-    getSendInput,
+    getDepositInput,
+    handleMultiTxSend,
     onNext,
     toast,
     translate,

--- a/src/features/defi/providers/thorchain-savers/components/ThorchainSaversManager/Deposit/components/Confirm.tsx
+++ b/src/features/defi/providers/thorchain-savers/components/ThorchainSaversManager/Deposit/components/Confirm.tsx
@@ -30,6 +30,7 @@ import { bn, bnOrZero } from 'lib/bignumber/bignumber'
 import { logger } from 'lib/logger'
 import { getIsTradingActiveApi } from 'state/apis/swapper/getIsTradingActiveApi'
 import {
+  getAccountAddressesWithBalances,
   getThorchainSaversPosition,
   getThorchainSaversQuote,
 } from 'state/slices/opportunitiesSlice/resolvers/thorchainsavers/utils'
@@ -125,7 +126,14 @@ export const Confirm: React.FC<ConfirmProps> = ({ accountId, onNext }) => {
             .then(({ asset_address }) =>
               chainId === bchChainId ? `bitcoincash:${asset_address}` : asset_address,
             )
-            .catch(() => '')
+            .catch(async () => {
+              const addressesWithBalances = await getAccountAddressesWithBalances(accountId)
+              const highestBalanceAccount = addressesWithBalances.sort((a, b) =>
+                bnOrZero(a.balance).gte(bnOrZero(b.balance)) ? -1 : 1,
+              )[0].address
+
+              return highestBalanceAccount
+            })
         : ''
       setMaybeFromUTXOAccountAddress(accountAddress)
     })()

--- a/src/features/defi/providers/thorchain-savers/components/ThorchainSaversManager/Deposit/components/Confirm.tsx
+++ b/src/features/defi/providers/thorchain-savers/components/ThorchainSaversManager/Deposit/components/Confirm.tsx
@@ -242,6 +242,10 @@ export const Confirm: React.FC<ConfirmProps> = ({ accountId, onNext }) => {
 
     let txId: string
 
+    // Try/catching and evaluating to something in the catch isn't a good pattern usually
+    // In our case, handleSend() catching means that after all our previous checks, building a Tx failed at coinselect time
+    // So we actually send reconciliate a reconciliate Tx, retry the original send within the same block
+    // and finally evaluate to either the original Tx or a falsy empty string
     try {
       // 1. Try to deposit from the originally deposited from / highest UTXO balance address
       // If this is enough, no other Tx is needed
@@ -250,7 +254,7 @@ export const Confirm: React.FC<ConfirmProps> = ({ accountId, onNext }) => {
         wallet: walletState.wallet,
       })
     } catch (e) {
-      // 2. signAndBroadcastTransaction threw, meaning there's not enough value in the picked address - send funds to it
+      // 2. coinselect threw when building a Tx, meaning there's not enough value in the picked address - send funds to it
       const preDepositInput = await getPreDepositInput()
       if (!preDepositInput) throw new Error('Error building send input')
       txId = await handleSend({

--- a/src/features/defi/providers/thorchain-savers/components/ThorchainSaversManager/Deposit/components/Confirm.tsx
+++ b/src/features/defi/providers/thorchain-savers/components/ThorchainSaversManager/Deposit/components/Confirm.tsx
@@ -171,7 +171,7 @@ export const Confirm: React.FC<ConfirmProps> = ({ accountId, onNext }) => {
 
       return sendInput
     } catch (e) {
-      moduleLogger.error({ fn: 'getSendInput', e }, 'Error building THORChain savers Tx')
+      moduleLogger.error({ fn: 'getDepositInput', e }, 'Error building THORChain savers Tx')
     }
   }, [
     maybeFromUTXOAccountAddress,
@@ -212,7 +212,7 @@ export const Confirm: React.FC<ConfirmProps> = ({ accountId, onNext }) => {
 
       return sendInput
     } catch (e) {
-      moduleLogger.error({ fn: 'getSendInput', e }, 'Error building THORChain savers Tx')
+      moduleLogger.error({ fn: 'getDepositInput', e }, 'Error building THORChain savers Tx')
     }
   }, [
     maybeFromUTXOAccountAddress,

--- a/src/features/defi/providers/thorchain-savers/components/ThorchainSaversManager/Deposit/components/Confirm.tsx
+++ b/src/features/defi/providers/thorchain-savers/components/ThorchainSaversManager/Deposit/components/Confirm.tsx
@@ -257,8 +257,6 @@ export const Confirm: React.FC<ConfirmProps> = ({ accountId, onNext }) => {
         sendInput: preDepositInput,
         wallet: walletState.wallet,
       })
-      // Wait for the pre-deposit Tx to actually be in the mempool
-      await new Promise(resolve => setTimeout(resolve, 10000))
       // 3. Sign and broadcast the depooosit Tx again
       txId = await handleSend({
         sendInput: depositInput,

--- a/src/features/defi/providers/thorchain-savers/components/ThorchainSaversManager/Deposit/components/Deposit.tsx
+++ b/src/features/defi/providers/thorchain-savers/components/ThorchainSaversManager/Deposit/components/Deposit.tsx
@@ -122,7 +122,7 @@ export const Deposit: React.FC<DepositProps> = ({
         ).fast.txFee
 
         const fastFeeCryptoPrecision = bnOrZero(
-          bn(fastFeeCryptoBaseUnit).div(`1e${asset.precision}`),
+          bn(fastFeeCryptoBaseUnit).div(bn(10).pow(asset.precision)),
         )
         return bnOrZero(fastFeeCryptoPrecision).toString()
       } catch (error) {

--- a/src/features/defi/providers/thorchain-savers/components/ThorchainSaversManager/Deposit/components/Deposit.tsx
+++ b/src/features/defi/providers/thorchain-savers/components/ThorchainSaversManager/Deposit/components/Deposit.tsx
@@ -112,7 +112,7 @@ export const Deposit: React.FC<DepositProps> = ({
         // We're lying to Ts, this isn't always an UtxoBaseAdapter
         // But typing this as any chain-adapter won't narrow down its type and we'll have errors at `chainSpecific` property
         const adapter = chainAdapters.get(chainId) as unknown as UtxoBaseAdapter<UtxoChainId>
-        const fee = (
+        const fastFeeCryptoBaseUnit = (
           await adapter.getFeeData({
             to: quote.inbound_address,
             value: amountCryptoBaseUnit.toFixed(0),
@@ -120,7 +120,11 @@ export const Deposit: React.FC<DepositProps> = ({
             sendMax: false,
           })
         ).fast.txFee
-        return bnOrZero(fee).toString()
+
+        const fastFeeCryptoPrecision = bnOrZero(
+          bn(fastFeeCryptoBaseUnit).div(`1e${asset.precision}`),
+        )
+        return bnOrZero(fastFeeCryptoPrecision).toString()
       } catch (error) {
         moduleLogger.error(
           { fn: 'getDepositGasEstimate', error },

--- a/src/state/slices/opportunitiesSlice/resolvers/thorchainsavers/utils.ts
+++ b/src/state/slices/opportunitiesSlice/resolvers/thorchainsavers/utils.ts
@@ -20,8 +20,6 @@ import type {
 
 const THOR_PRECISION = 8
 
-// Memoized on accountId, see lodash docs:
-// "By default, the first argument provided to the memoized function is used as the map cache key."
 export const getAccountAddressesWithBalances = async (
   accountId: AccountId,
 ): Promise<{ address: string; balance: string }[]> => {

--- a/src/state/slices/opportunitiesSlice/resolvers/thorchainsavers/utils.ts
+++ b/src/state/slices/opportunitiesSlice/resolvers/thorchainsavers/utils.ts
@@ -22,33 +22,31 @@ const THOR_PRECISION = 8
 
 // Memoized on accountId, see lodash docs:
 // "By default, the first argument provided to the memoized function is used as the map cache key."
-export const getAccountAddressesWithBalances = memoize(
-  async (accountId: AccountId): Promise<{ address: string; balance: string }[]> => {
-    if (isUtxoAccountId(accountId)) {
-      const { chainId, account: pubkey } = fromAccountId(accountId)
-      const chainAdapters = getChainAdapterManager()
-      const adapter = chainAdapters.get(chainId) as unknown as UtxoBaseAdapter<UtxoChainId>
-      if (!adapter) throw new Error(`no adapter for ${chainId} not available`)
+export const getAccountAddressesWithBalances = async (
+  accountId: AccountId,
+): Promise<{ address: string; balance: string }[]> => {
+  if (isUtxoAccountId(accountId)) {
+    const { chainId, account: pubkey } = fromAccountId(accountId)
+    const chainAdapters = getChainAdapterManager()
+    const adapter = chainAdapters.get(chainId) as unknown as UtxoBaseAdapter<UtxoChainId>
+    if (!adapter) throw new Error(`no adapter for ${chainId} not available`)
 
-      const {
-        chainSpecific: { addresses },
-      } = await adapter.getAccount(pubkey)
+    const {
+      chainSpecific: { addresses },
+    } = await adapter.getAccount(pubkey)
 
-      if (!addresses) return []
+    if (!addresses) return []
 
-      return addresses.map(({ pubkey, balance }) => {
-        const address = pubkey.startsWith('bitcoincash')
-          ? pubkey.replace('bitcoincash:', '')
-          : pubkey
+    return addresses.map(({ pubkey, balance }) => {
+      const address = pubkey.startsWith('bitcoincash') ? pubkey.replace('bitcoincash:', '') : pubkey
 
-        return { address, balance }
-      })
-    }
+      return { address, balance }
+    })
+  }
 
-    // We don't need balances for chain others than UTXOs
-    return [{ address: fromAccountId(accountId).account, balance: '' }]
-  },
-)
+  // We don't need balances for chain others than UTXOs
+  return [{ address: fromAccountId(accountId).account, balance: '' }]
+}
 
 // Memoized on accountId, see lodash docs:
 // "By default, the first argument provided to the memoized function is used as the map cache key."


### PR DESCRIPTION
## Description

This PR ensures we use either an arbitrary chosen address (the one with the most balance as accumulated UTXOs) or the previously deposited from address as `from`, meaning UTXOs will be filtered to be the one from it, and they will be used as a change address, see https://github.com/shapeshift/lib/pull/1168

This also brings the notion of either one or two Txs being broadcasted in the same block:

- At best, one Tx if the picked address has enough UTXO value
- At worst, a pre-Tx to send max to that address, and then the originally intended Tx

Notes:

- this only applies to UTXOs, since with other blockchains we support, the account *is* the address so we don't have such problem.

## Notice

<!-- Before submitting a pull request, please make sure you have answered the following: -->

- [x] Have you followed the guidelines in our [Contributing]('https://github.com/shapeshift/web/blob/develop/CONTRIBUTING.md) guide?
- [x] Have you checked to ensure there aren't other open [Pull Requests](https://github.com/shapeshift/web/pulls) for the same update/change?

## Pull Request Type

- [ ] :bug: Bug fix (Non-breaking Change: Fixes an issue)
- [ ] :hammer_and_wrench: Chore (Non-breaking Change: Doc updates, pkg upgrades, typos, etc..)
- [x] :nail_care: New Feature (Breaking/Non-breaking Change)

## Issue (if applicable)

N/A

## Risk

<!-----------------------------------------------------------------------------
Outline the scope of your changes and the risk associated with them. You must use your discretion as an engineer to determine the potential impact of your changes.

E.g. an upgrade to `hdwallet` or core state management would be considered higher risk, and might require a full regression test. UI or isolated view changes, or something behind a feature flag may have near zero risk. Small bug fixes might require testing isolated to the specific fix.
------------------------------------------------------------------------------>

- None, isolated to savers

## Testing

<!-----------------------------------------------------------------------------
We treat every PR to be merged with the same scrutiny as if we were merging directly to production.

Your PR will not be merged if you do not complete the sections below for our engineering and operations teams to test.
------------------------------------------------------------------------------>

### Engineering

<!-----------------------------------------------------------------------------
Include sufficient information here for an engineer to test your PR. This may include how to test locally, in a built environment, changes to infrastructure etc.
------------------------------------------------------------------------------>

- It is possible to deposit into UTXO savers
  - The change is sent to the address which input(s) was/were used 
- Ensure you can re-deposit into the same savers opportunities and confirm the input(s) address is the same as the original Tx
  - The change is sent to the address which input(s) was/were used 
  - Send max will not work - gas fee to be deducted for it in a follow-up PR, as well as making sure we send enough dust for one or a few re-deposits/withdraws in a follow-up PR
  
### Operations

<!-----------------------------------------------------------------------------
If your changes have a user-facing impact, describe how a non-technical QA team can functionally test your changes in a preview environment.

If they are not user-facing please describe how to test for any regressions that may occur.
------------------------------------------------------------------------------>

- Nothing to see here 

## Screenshots (if applicable)
