### PR TITLE
feat: thorchain savers withdraw

### DIFF
--- a/src/features/defi/providers/thorchain-savers/components/ThorchainSaversManager/Deposit/components/Confirm.tsx
+++ b/src/features/defi/providers/thorchain-savers/components/ThorchainSaversManager/Deposit/components/Confirm.tsx
@@ -31,8 +31,8 @@ import { logger } from 'lib/logger'
 import { getIsTradingActiveApi } from 'state/apis/swapper/getIsTradingActiveApi'
 import {
   getAccountAddressesWithBalances,
+  getThorchainSaversDepositQuote,
   getThorchainSaversPosition,
-  getThorchainSaversQuote,
 } from 'state/slices/opportunitiesSlice/resolvers/thorchainsavers/utils'
 import { isUtxoChainId } from 'state/slices/portfolioSlice/utils'
 import {
@@ -106,7 +106,7 @@ export const Confirm: React.FC<ConfirmProps> = ({ accountId, onNext }) => {
     const amountCryptoBaseUnit = bnOrZero(state.deposit.cryptoAmount).times(
       bn(10).pow(asset.precision),
     )
-    const quote = await getThorchainSaversQuote(asset, amountCryptoBaseUnit)
+    const quote = await getThorchainSaversDepositQuote(asset, amountCryptoBaseUnit)
 
     return {
       cryptoAmount: state.deposit.cryptoAmount,
@@ -129,7 +129,7 @@ export const Confirm: React.FC<ConfirmProps> = ({ accountId, onNext }) => {
       const amountCryptoBaseUnit = bnOrZero(state.deposit.cryptoAmount).times(
         bn(10).pow(asset.precision),
       )
-      const quote = await getThorchainSaversQuote(asset, amountCryptoBaseUnit)
+      const quote = await getThorchainSaversDepositQuote(asset, amountCryptoBaseUnit)
 
       const sendInput: SendInput = {
         cryptoAmount: state.deposit.cryptoAmount,
@@ -170,7 +170,7 @@ export const Confirm: React.FC<ConfirmProps> = ({ accountId, onNext }) => {
       const amountCryptoBaseUnit = bnOrZero(state?.deposit.cryptoAmount).times(
         bn(10).pow(asset.precision),
       )
-      const quote = await getThorchainSaversQuote(asset, amountCryptoBaseUnit)
+      const quote = await getThorchainSaversDepositQuote(asset, amountCryptoBaseUnit)
 
       const sendInput: SendInput = {
         cryptoAmount: '',

--- a/src/features/defi/providers/thorchain-savers/components/ThorchainSaversManager/Deposit/components/Confirm.tsx
+++ b/src/features/defi/providers/thorchain-savers/components/ThorchainSaversManager/Deposit/components/Confirm.tsx
@@ -106,7 +106,7 @@ export const Confirm: React.FC<ConfirmProps> = ({ accountId, onNext }) => {
     const amountCryptoBaseUnit = bnOrZero(state.deposit.cryptoAmount).times(
       bn(10).pow(asset.precision),
     )
-    const quote = await getThorchainSaversDepositQuote(asset, amountCryptoBaseUnit)
+    const quote = await getThorchainSaversDepositQuote({ asset, amountCryptoBaseUnit })
 
     return {
       cryptoAmount: state.deposit.cryptoAmount,
@@ -129,7 +129,7 @@ export const Confirm: React.FC<ConfirmProps> = ({ accountId, onNext }) => {
       const amountCryptoBaseUnit = bnOrZero(state.deposit.cryptoAmount).times(
         bn(10).pow(asset.precision),
       )
-      const quote = await getThorchainSaversDepositQuote(asset, amountCryptoBaseUnit)
+      const quote = await getThorchainSaversDepositQuote({ asset, amountCryptoBaseUnit })
 
       const sendInput: SendInput = {
         cryptoAmount: state.deposit.cryptoAmount,
@@ -170,7 +170,7 @@ export const Confirm: React.FC<ConfirmProps> = ({ accountId, onNext }) => {
       const amountCryptoBaseUnit = bnOrZero(state?.deposit.cryptoAmount).times(
         bn(10).pow(asset.precision),
       )
-      const quote = await getThorchainSaversDepositQuote(asset, amountCryptoBaseUnit)
+      const quote = await getThorchainSaversDepositQuote({ asset, amountCryptoBaseUnit })
 
       const sendInput: SendInput = {
         cryptoAmount: '',
@@ -254,7 +254,7 @@ export const Confirm: React.FC<ConfirmProps> = ({ accountId, onNext }) => {
     if (!accountId) return
     ;(async () => {
       const accountAddress = isUtxoChainId(chainId)
-        ? await getThorchainSaversPosition(accountId, assetId)
+        ? await getThorchainSaversPosition({ accountId, assetId })
             .then(({ asset_address }) =>
               chainId === bchChainId ? `bitcoincash:${asset_address}` : asset_address,
             )

--- a/src/features/defi/providers/thorchain-savers/components/ThorchainSaversManager/Deposit/components/Deposit.tsx
+++ b/src/features/defi/providers/thorchain-savers/components/ThorchainSaversManager/Deposit/components/Deposit.tsx
@@ -111,7 +111,7 @@ export const Deposit: React.FC<DepositProps> = ({
         const amountCryptoBaseUnit = bnOrZero(deposit.cryptoAmount).times(
           bn(10).pow(asset.precision),
         )
-        const quote = await getThorchainSaversDepositQuote(asset, amountCryptoBaseUnit)
+        const quote = await getThorchainSaversDepositQuote({ asset, amountCryptoBaseUnit })
         const chainAdapters = getChainAdapterManager()
         // We're lying to Ts, this isn't always an UtxoBaseAdapter
         // But typing this as any chain-adapter won't narrow down its type and we'll have errors at `chainSpecific` property

--- a/src/features/defi/providers/thorchain-savers/components/ThorchainSaversManager/Deposit/components/Deposit.tsx
+++ b/src/features/defi/providers/thorchain-savers/components/ThorchainSaversManager/Deposit/components/Deposit.tsx
@@ -25,7 +25,7 @@ import { getIsTradingActiveApi } from 'state/apis/swapper/getIsTradingActiveApi'
 import {
   getThorchainSaversDepositQuote,
   isAboveDepositDustThreshold,
-  THOR_DEPOSIT_DUST_THRESHOLDS,
+  THORCHAIN_SAVERS_DUST_THRESHOLDS,
 } from 'state/slices/opportunitiesSlice/resolvers/thorchainsavers/utils'
 import { serializeUserStakingId, toOpportunityId } from 'state/slices/opportunitiesSlice/utils'
 import {
@@ -205,7 +205,7 @@ export const Deposit: React.FC<DepositProps> = ({
       const valueCryptoBaseUnit = bnOrZero(value).times(bn(10).pow(asset.precision))
       const isBelowMinSellAmount = !isAboveDepositDustThreshold(valueCryptoBaseUnit, assetId)
 
-      const minLimitCryptoPrecision = bn(THOR_DEPOSIT_DUST_THRESHOLDS[assetId]).div(
+      const minLimitCryptoPrecision = bn(THORCHAIN_SAVERS_DUST_THRESHOLDS[assetId]).div(
         bn(10).pow(asset.precision),
       )
       const minLimit = `${minLimitCryptoPrecision} ${asset.symbol}`
@@ -233,7 +233,7 @@ export const Deposit: React.FC<DepositProps> = ({
         .times(bn(10).pow(asset.precision))
       const isBelowMinSellAmount = !isAboveDepositDustThreshold(valueCryptoBaseUnit, assetId)
 
-      const minLimitCryptoPrecision = bn(THOR_DEPOSIT_DUST_THRESHOLDS[assetId]).div(
+      const minLimitCryptoPrecision = bn(THORCHAIN_SAVERS_DUST_THRESHOLDS[assetId]).div(
         bn(10).pow(asset.precision),
       )
       const minLimit = `${minLimitCryptoPrecision} ${asset.symbol}`

--- a/src/features/defi/providers/thorchain-savers/components/ThorchainSaversManager/Deposit/components/Deposit.tsx
+++ b/src/features/defi/providers/thorchain-savers/components/ThorchainSaversManager/Deposit/components/Deposit.tsx
@@ -203,7 +203,7 @@ export const Deposit: React.FC<DepositProps> = ({
   const validateCryptoAmount = useCallback(
     (value: string) => {
       const valueCryptoBaseUnit = bnOrZero(value).times(bn(10).pow(asset.precision))
-      const isBelowMinSellAmount = !isAboveDepositDustThreshold(valueCryptoBaseUnit, assetId)
+      const isBelowMinSellAmount = !isAboveDepositDustThreshold({ valueCryptoBaseUnit, assetId })
 
       const minLimitCryptoPrecision = bn(THORCHAIN_SAVERS_DUST_THRESHOLDS[assetId]).div(
         bn(10).pow(asset.precision),
@@ -231,7 +231,7 @@ export const Deposit: React.FC<DepositProps> = ({
       const valueCryptoBaseUnit = bnOrZero(value)
         .div(marketData.price)
         .times(bn(10).pow(asset.precision))
-      const isBelowMinSellAmount = !isAboveDepositDustThreshold(valueCryptoBaseUnit, assetId)
+      const isBelowMinSellAmount = !isAboveDepositDustThreshold({ valueCryptoBaseUnit, assetId })
 
       const minLimitCryptoPrecision = bn(THORCHAIN_SAVERS_DUST_THRESHOLDS[assetId]).div(
         bn(10).pow(asset.precision),

--- a/src/features/defi/providers/thorchain-savers/components/ThorchainSaversManager/Deposit/components/Deposit.tsx
+++ b/src/features/defi/providers/thorchain-savers/components/ThorchainSaversManager/Deposit/components/Deposit.tsx
@@ -23,7 +23,7 @@ import { bn, bnOrZero } from 'lib/bignumber/bignumber'
 import { logger } from 'lib/logger'
 import { getIsTradingActiveApi } from 'state/apis/swapper/getIsTradingActiveApi'
 import {
-  getThorchainSaversQuote,
+  getThorchainSaversDepositQuote,
   isAboveDepositDustThreshold,
   THOR_DEPOSIT_DUST_THRESHOLDS,
 } from 'state/slices/opportunitiesSlice/resolvers/thorchainsavers/utils'
@@ -111,7 +111,7 @@ export const Deposit: React.FC<DepositProps> = ({
         const amountCryptoBaseUnit = bnOrZero(deposit.cryptoAmount).times(
           bn(10).pow(asset.precision),
         )
-        const quote = await getThorchainSaversQuote(asset, amountCryptoBaseUnit)
+        const quote = await getThorchainSaversDepositQuote(asset, amountCryptoBaseUnit)
         const chainAdapters = getChainAdapterManager()
         // We're lying to Ts, this isn't always an UtxoBaseAdapter
         // But typing this as any chain-adapter won't narrow down its type and we'll have errors at `chainSpecific` property

--- a/src/features/defi/providers/thorchain-savers/components/ThorchainSaversManager/Withdraw/ThorchainSaversWithdraw.tsx
+++ b/src/features/defi/providers/thorchain-savers/components/ThorchainSaversManager/Withdraw/ThorchainSaversWithdraw.tsx
@@ -50,9 +50,7 @@ export const ThorchainSaversWithdraw: React.FC<WithdrawProps> = ({ accountId }) 
     assetReference,
   })
   const asset = useAppSelector(state => selectAssetById(state, assetId))
-  const underlyingAsset = useAppSelector(state => selectAssetById(state, assetId))
   if (!asset) throw new Error(`Asset not found for AssetId ${assetId}`)
-  if (!underlyingAsset) throw new Error(`Asset not found for AssetId ${assetId}`)
 
   const marketData = useAppSelector(state => selectMarketDataById(state, assetId))
 
@@ -109,7 +107,7 @@ export const ThorchainSaversWithdraw: React.FC<WithdrawProps> = ({ accountId }) 
       [DefiStep.Info]: {
         label: translate('defi.steps.withdraw.info.title'),
         description: translate('defi.steps.withdraw.info.description', {
-          asset: underlyingAsset.symbol,
+          asset: asset.symbol,
         }),
         component: ownProps => <Withdraw {...ownProps} accountId={accountId} />,
       },
@@ -123,7 +121,7 @@ export const ThorchainSaversWithdraw: React.FC<WithdrawProps> = ({ accountId }) 
       },
     }
     // We only need this to update on symbol change
-  }, [accountId, translate, underlyingAsset.symbol])
+  }, [accountId, asset.symbol, translate])
 
   const value = useMemo(() => ({ state, dispatch }), [state])
 
@@ -139,7 +137,7 @@ export const ThorchainSaversWithdraw: React.FC<WithdrawProps> = ({ accountId }) 
       <DefiModalContent>
         <DefiModalHeader
           title={translate('modals.withdraw.withdrawFrom', {
-            opportunity: `${underlyingAsset.symbol} Vault`,
+            opportunity: `${asset.symbol} Vault`,
           })}
           onBack={handleBack}
         />

--- a/src/features/defi/providers/thorchain-savers/components/ThorchainSaversManager/Withdraw/ThorchainSaversWithdraw.tsx
+++ b/src/features/defi/providers/thorchain-savers/components/ThorchainSaversManager/Withdraw/ThorchainSaversWithdraw.tsx
@@ -42,30 +42,23 @@ export const ThorchainSaversWithdraw: React.FC<WithdrawProps> = ({ accountId }) 
   const [state, dispatch] = useReducer(reducer, initialState)
   const translate = useTranslate()
   const { query, history, location } = useBrowserRouter<DefiQueryParams, DefiParams>()
-  const { chainId, contractAddress, assetReference } = query
+  const { chainId, assetNamespace, assetReference } = query
 
-  const assetNamespace = 'erc20'
-  // Asset info
-  const underlyingAssetId = toAssetId({
+  const assetId = toAssetId({
     chainId,
     assetNamespace,
     assetReference,
   })
-  const assetId = toAssetId({
-    chainId,
-    assetNamespace,
-    assetReference: contractAddress,
-  })
   const asset = useAppSelector(state => selectAssetById(state, assetId))
-  const underlyingAsset = useAppSelector(state => selectAssetById(state, underlyingAssetId))
+  const underlyingAsset = useAppSelector(state => selectAssetById(state, assetId))
   if (!asset) throw new Error(`Asset not found for AssetId ${assetId}`)
-  if (!underlyingAsset) throw new Error(`Asset not found for AssetId ${underlyingAssetId}`)
+  if (!underlyingAsset) throw new Error(`Asset not found for AssetId ${assetId}`)
 
-  const marketData = useAppSelector(state => selectMarketDataById(state, underlyingAssetId))
+  const marketData = useAppSelector(state => selectMarketDataById(state, assetId))
 
   const opportunityId = useMemo(
-    () => toOpportunityId({ chainId, assetNamespace: 'erc20', assetReference: contractAddress }),
-    [chainId, contractAddress],
+    () => toOpportunityId({ chainId, assetNamespace, assetReference }),
+    [assetNamespace, assetReference, chainId],
   )
   const highestBalanceAccountIdFilter = useMemo(
     () => ({ stakingId: opportunityId }),
@@ -80,12 +73,12 @@ export const ThorchainSaversWithdraw: React.FC<WithdrawProps> = ({ accountId }) 
         (accountId ?? highestBalanceAccountId)!,
         toOpportunityId({
           chainId,
-          assetNamespace: 'erc20',
-          assetReference: contractAddress,
+          assetNamespace,
+          assetReference,
         }),
       ),
     }),
-    [accountId, chainId, contractAddress, highestBalanceAccountId],
+    [accountId, assetNamespace, assetReference, chainId, highestBalanceAccountId],
   )
 
   const opportunityData = useAppSelector(state =>
@@ -97,9 +90,9 @@ export const ThorchainSaversWithdraw: React.FC<WithdrawProps> = ({ accountId }) 
 
   useEffect(() => {
     if (state.opportunity) return
-    if (!(walletState.wallet && contractAddress && opportunityData)) return
+    if (!(walletState.wallet && opportunityData)) return
     dispatch({ type: ThorchainSaversWithdrawActionType.SET_OPPORTUNITY, payload: opportunityData })
-  }, [contractAddress, opportunityData, state.opportunity, walletState.wallet])
+  }, [opportunityData, state.opportunity, walletState.wallet])
 
   const handleBack = useCallback(() => {
     history.push({

--- a/src/features/defi/providers/thorchain-savers/components/ThorchainSaversManager/Withdraw/components/Confirm.tsx
+++ b/src/features/defi/providers/thorchain-savers/components/ThorchainSaversManager/Withdraw/components/Confirm.tsx
@@ -164,7 +164,7 @@ export const Confirm: React.FC<ConfirmProps> = ({ accountId, onNext }) => {
       const { dust_amount, expected_amount_out } = quote
       const withdrawFee = amountCryptoThorBaseUnit
         .minus(expected_amount_out)
-        .div(`1e+${THOR_PRECISION}`)
+        .div(bn(10).pow(THOR_PRECISION))
 
       const dustAmountCryptoPrecision = fromThorBaseUnit(dust_amount)
 
@@ -220,7 +220,7 @@ export const Confirm: React.FC<ConfirmProps> = ({ accountId, onNext }) => {
     })
     const withdrawFee = amountCryptoThorBaseUnit
       .minus(expected_amount_out)
-      .div(`1e+${THOR_PRECISION}`)
+      .div(bn(10).pow(asset.precision))
 
     setWithdrawFee(withdrawFee.toFixed())
 
@@ -384,25 +384,24 @@ export const Confirm: React.FC<ConfirmProps> = ({ accountId, onNext }) => {
     const txId = await handleSend({
       sendInput: withdrawInput,
       wallet: walletState.wallet,
-    })
-      .catch(async () => {
-        // 2. coinselect threw when building a Tx, meaning there's not enough value in the picked address - send funds to it
-        const preWithdrawInput = await getPreWithdrawInput()
-        if (!preWithdrawInput) throw new Error('Error building send input')
+    }).catch(async () => {
+      // 2. coinselect threw when building a Tx, meaning there's not enough value in the picked address - send funds to it
+      const preWithdrawInput = await getPreWithdrawInput()
+      if (!preWithdrawInput) throw new Error('Error building send input')
 
-        return handleSend({
-          sendInput: preWithdrawInput,
-          wallet: walletState.wallet!,
-        })
+      return handleSend({
+        sendInput: preWithdrawInput,
+        wallet: walletState.wallet!,
       })
-      .then(() =>
-        // 3. Sign and broadcast the depooosit Tx again
-        handleSend({
-          sendInput: withdrawInput,
-          wallet: walletState.wallet!,
-        }).catch(_e => ''),
-      )
-      .catch(_e => '')
+        .then(() =>
+          // 3. Sign and broadcast the depooosit Tx again
+          handleSend({
+            sendInput: withdrawInput,
+            wallet: walletState.wallet!,
+          }).catch(_e => ''),
+        )
+        .catch(_e => '')
+    })
 
     return txId
   }, [getPreWithdrawInput, getWithdrawInput, walletState.wallet])
@@ -484,7 +483,7 @@ export const Confirm: React.FC<ConfirmProps> = ({ accountId, onNext }) => {
   const hasEnoughBalanceForGas = useMemo(
     () =>
       bnOrZero(assetBalance)
-        .minus(bnOrZero(state?.withdraw.estimatedGasCrypto).div(`1e+${asset.precision}`))
+        .minus(bnOrZero(state?.withdraw.estimatedGasCrypto).div(bn(10).pow(asset.precision)))
         .gte(0),
     [assetBalance, state?.withdraw.estimatedGasCrypto, asset?.precision],
   )

--- a/src/features/defi/providers/thorchain-savers/components/ThorchainSaversManager/Withdraw/components/Confirm.tsx
+++ b/src/features/defi/providers/thorchain-savers/components/ThorchainSaversManager/Withdraw/components/Confirm.tsx
@@ -148,15 +148,18 @@ export const Confirm: React.FC<ConfirmProps> = ({ accountId, onNext }) => {
 
       if (amountCryptoBaseUnit.isZero()) return
 
-      const amountCryptoThorBaseUnit = toThorBaseUnit(amountCryptoBaseUnit, asset)
+      const amountCryptoThorBaseUnit = toThorBaseUnit({
+        valueCryptoBaseUnit: amountCryptoBaseUnit,
+        asset,
+      })
 
-      const withdrawBps = getWithdrawBps(
-        amountCryptoBaseUnit,
-        opportunityData.stakedAmountCryptoBaseUnit,
-        opportunityData?.rewardsAmountsCryptoBaseUnit?.[0] ?? '0',
-      )
+      const withdrawBps = getWithdrawBps({
+        withdrawAmountCryptoBaseUnit: amountCryptoBaseUnit,
+        stakedAmountCryptoBaseUnit: opportunityData.stakedAmountCryptoBaseUnit,
+        rewardsamountCryptoBaseUnit: opportunityData?.rewardsAmountsCryptoBaseUnit?.[0] ?? '0',
+      })
 
-      const quote = await getThorchainSaversWithdrawQuote(asset, accountId, withdrawBps)
+      const quote = await getThorchainSaversWithdrawQuote({ asset, accountId, bps: withdrawBps })
 
       const { dust_amount, expected_amount_out } = quote
       const withdrawFee = amountCryptoThorBaseUnit
@@ -181,7 +184,7 @@ export const Confirm: React.FC<ConfirmProps> = ({ accountId, onNext }) => {
     if (!isUtxoChainId(chainId)) return ''
 
     try {
-      const position = await getThorchainSaversPosition(accountId, assetId)
+      const position = await getThorchainSaversPosition({ accountId, assetId })
       debugger
       const { asset_address } = position
       const accountAddress = chainId === bchChainId ? `bitcoincash:${asset_address}` : asset_address
@@ -200,18 +203,21 @@ export const Confirm: React.FC<ConfirmProps> = ({ accountId, onNext }) => {
       bn(10).pow(asset.precision),
     )
 
-    const withdrawBps = getWithdrawBps(
-      amountCryptoBaseUnit,
-      opportunityData?.stakedAmountCryptoBaseUnit,
-      opportunityData?.rewardsAmountsCryptoBaseUnit?.[0] ?? '0',
-    )
-    const quote = await getThorchainSaversWithdrawQuote(asset, accountId, withdrawBps)
+    const withdrawBps = getWithdrawBps({
+      withdrawAmountCryptoBaseUnit: amountCryptoBaseUnit,
+      stakedAmountCryptoBaseUnit: opportunityData?.stakedAmountCryptoBaseUnit,
+      rewardsamountCryptoBaseUnit: opportunityData?.rewardsAmountsCryptoBaseUnit?.[0] ?? '0',
+    })
+    const quote = await getThorchainSaversWithdrawQuote({ asset, accountId, bps: withdrawBps })
 
     const maybeUtxoAccountAddress = await getMaybeUtxoAccountAddress()
 
     const { expected_amount_out, dust_amount } = quote
 
-    const amountCryptoThorBaseUnit = toThorBaseUnit(amountCryptoBaseUnit, asset)
+    const amountCryptoThorBaseUnit = toThorBaseUnit({
+      valueCryptoBaseUnit: amountCryptoBaseUnit,
+      asset,
+    })
     const withdrawFee = amountCryptoThorBaseUnit
       .minus(expected_amount_out)
       .div(`1e+${THOR_PRECISION}`)
@@ -255,13 +261,13 @@ export const Confirm: React.FC<ConfirmProps> = ({ accountId, onNext }) => {
         bn(10).pow(asset.precision),
       )
 
-      const bps = getWithdrawBps(
-        amountCryptoBaseUnit,
-        opportunityData?.stakedAmountCryptoBaseUnit,
-        opportunityData?.rewardsAmountsCryptoBaseUnit?.[0] ?? '0',
-      )
+      const bps = getWithdrawBps({
+        withdrawAmountCryptoBaseUnit: amountCryptoBaseUnit,
+        stakedAmountCryptoBaseUnit: opportunityData?.stakedAmountCryptoBaseUnit,
+        rewardsamountCryptoBaseUnit: opportunityData?.rewardsAmountsCryptoBaseUnit?.[0] ?? '0',
+      })
 
-      const quote = await getThorchainSaversWithdrawQuote(asset, accountId, bps)
+      const quote = await getThorchainSaversWithdrawQuote({ asset, accountId, bps })
       const accountAddress = await getMaybeUtxoAccountAddress()
 
       const sendInput: SendInput = {
@@ -307,13 +313,13 @@ export const Confirm: React.FC<ConfirmProps> = ({ accountId, onNext }) => {
         bn(10).pow(asset.precision),
       )
 
-      const withdrawBps = getWithdrawBps(
-        amountCryptoBaseUnit,
-        opportunityData?.stakedAmountCryptoBaseUnit,
-        opportunityData?.rewardsAmountsCryptoBaseUnit?.[0] ?? '0',
-      )
+      const withdrawBps = getWithdrawBps({
+        withdrawAmountCryptoBaseUnit: amountCryptoBaseUnit,
+        stakedAmountCryptoBaseUnit: opportunityData?.stakedAmountCryptoBaseUnit,
+        rewardsamountCryptoBaseUnit: opportunityData?.rewardsAmountsCryptoBaseUnit?.[0] ?? '0',
+      })
 
-      const quote = await getThorchainSaversWithdrawQuote(asset, accountId, withdrawBps)
+      const quote = await getThorchainSaversWithdrawQuote({ asset, accountId, bps: withdrawBps })
 
       if (!quote) throw new Error('Error getting THORChain savers withdraw quote')
 

--- a/src/features/defi/providers/thorchain-savers/components/ThorchainSaversManager/Withdraw/components/Confirm.tsx
+++ b/src/features/defi/providers/thorchain-savers/components/ThorchainSaversManager/Withdraw/components/Confirm.tsx
@@ -211,6 +211,10 @@ export const Confirm: React.FC<ConfirmProps> = ({ accountId, onNext }) => {
 
     const maybeUtxoAccountAddress = await getMaybeUtxoAccountAddress()
 
+    if (isUtxoChainId(chainId) && !maybeUtxoAccountAddress) {
+      throw new Error('Account address required to withdraw from THORChain savers')
+    }
+
     const { expected_amount_out, dust_amount } = quote
 
     const amountCryptoThorBaseUnit = toThorBaseUnit({
@@ -237,6 +241,7 @@ export const Confirm: React.FC<ConfirmProps> = ({ accountId, onNext }) => {
   }, [
     accountId,
     asset,
+    chainId,
     getMaybeUtxoAccountAddress,
     opportunityData?.rewardsAmountsCryptoBaseUnit,
     opportunityData?.stakedAmountCryptoBaseUnit,
@@ -324,13 +329,17 @@ export const Confirm: React.FC<ConfirmProps> = ({ accountId, onNext }) => {
 
       const { dust_amount } = quote
 
-      const accountAddress = await getMaybeUtxoAccountAddress()
+      const maybeUtxoAccountAddress = await getMaybeUtxoAccountAddress()
+
+      if (isUtxoChainId(chainId) && !maybeUtxoAccountAddress) {
+        throw new Error('Account address required to withdraw from THORChain savers')
+      }
 
       const sendInput: SendInput = {
         cryptoAmount: fromThorBaseUnit(dust_amount).toFixed(asset.precision),
         asset,
         to: quote.inbound_address,
-        from: accountAddress,
+        from: maybeUtxoAccountAddress,
         sendMax: false,
         accountId,
         amountFieldError: '',
@@ -350,12 +359,13 @@ export const Confirm: React.FC<ConfirmProps> = ({ accountId, onNext }) => {
   }, [
     accountId,
     assetId,
+    opportunityData?.stakedAmountCryptoBaseUnit,
+    opportunityData?.rewardsAmountsCryptoBaseUnit,
     getEstimateFeesArgs,
     state?.withdraw.cryptoAmount,
     asset,
-    opportunityData?.stakedAmountCryptoBaseUnit,
-    opportunityData?.rewardsAmountsCryptoBaseUnit,
     getMaybeUtxoAccountAddress,
+    chainId,
     selectedCurrency,
   ])
 

--- a/src/features/defi/providers/thorchain-savers/components/ThorchainSaversManager/Withdraw/components/Confirm.tsx
+++ b/src/features/defi/providers/thorchain-savers/components/ThorchainSaversManager/Withdraw/components/Confirm.tsx
@@ -52,7 +52,7 @@ export const Confirm: React.FC<ConfirmProps> = ({ accountId, onNext }) => {
   const { state, dispatch } = useContext(WithdrawContext)
   const translate = useTranslate()
   const { query } = useBrowserRouter<DefiQueryParams, DefiParams>()
-  const { chainId, contractAddress, assetReference } = query
+  const { chainId, assetNamespace, assetReference } = query
   const opportunity = state?.opportunity
   const chainAdapter = getChainAdapterManager().get(chainId)
 
@@ -60,8 +60,8 @@ export const Confirm: React.FC<ConfirmProps> = ({ accountId, onNext }) => {
   const feeAssetId = chainAdapter?.getFeeAssetId()
 
   const opportunityId = useMemo(
-    () => toOpportunityId({ chainId, assetNamespace: 'erc20', assetReference: contractAddress }),
-    [chainId, contractAddress],
+    () => toOpportunityId({ chainId, assetNamespace, assetReference }),
+    [assetNamespace, assetReference, chainId],
   )
   const highestBalanceAccountIdFilter = useMemo(
     () => ({ stakingId: opportunityId }),
@@ -77,12 +77,12 @@ export const Confirm: React.FC<ConfirmProps> = ({ accountId, onNext }) => {
         (accountId ?? highestBalanceAccountId)!,
         toOpportunityId({
           chainId,
-          assetNamespace: 'erc20',
-          assetReference: contractAddress,
+          assetNamespace,
+          assetReference,
         }),
       ),
     }),
-    [accountId, chainId, contractAddress, highestBalanceAccountId],
+    [accountId, assetNamespace, assetReference, chainId, highestBalanceAccountId],
   )
 
   const opportunityData = useAppSelector(state =>

--- a/src/features/defi/providers/thorchain-savers/components/ThorchainSaversManager/Withdraw/components/Confirm.tsx
+++ b/src/features/defi/providers/thorchain-savers/components/ThorchainSaversManager/Withdraw/components/Confirm.tsx
@@ -185,7 +185,6 @@ export const Confirm: React.FC<ConfirmProps> = ({ accountId, onNext }) => {
 
     try {
       const position = await getThorchainSaversPosition({ accountId, assetId })
-      debugger
       const { asset_address } = position
       const accountAddress = chainId === bchChainId ? `bitcoincash:${asset_address}` : asset_address
 

--- a/src/features/defi/providers/thorchain-savers/components/ThorchainSaversManager/Withdraw/components/Confirm.tsx
+++ b/src/features/defi/providers/thorchain-savers/components/ThorchainSaversManager/Withdraw/components/Confirm.tsx
@@ -272,13 +272,17 @@ export const Confirm: React.FC<ConfirmProps> = ({ accountId, onNext }) => {
       })
 
       const quote = await getThorchainSaversWithdrawQuote({ asset, accountId, bps })
-      const accountAddress = await getMaybeUtxoAccountAddress()
+      const maybeUtxoAccountAddress = await getMaybeUtxoAccountAddress()
+
+      if (isUtxoChainId(chainId) && !maybeUtxoAccountAddress) {
+        throw new Error('Account address required to withdraw from THORChain savers')
+      }
 
       const sendInput: SendInput = {
         cryptoAmount: '',
         asset,
         from: '', // Let coinselect do its magic here
-        to: accountAddress,
+        to: maybeUtxoAccountAddress,
         sendMax: true,
         accountId,
         amountFieldError: '',
@@ -305,6 +309,7 @@ export const Confirm: React.FC<ConfirmProps> = ({ accountId, onNext }) => {
     getEstimateFeesArgs,
     asset,
     getMaybeUtxoAccountAddress,
+    chainId,
     selectedCurrency,
   ])
 

--- a/src/features/defi/providers/thorchain-savers/components/ThorchainSaversManager/Withdraw/components/Confirm.tsx
+++ b/src/features/defi/providers/thorchain-savers/components/ThorchainSaversManager/Withdraw/components/Confirm.tsx
@@ -231,7 +231,7 @@ export const Confirm: React.FC<ConfirmProps> = ({ accountId, onNext }) => {
       asset,
       to: quote.inbound_address,
       sendMax: false,
-      accountId: accountId ?? '',
+      accountId,
       contractAddress: '',
     }
   }, [
@@ -332,7 +332,7 @@ export const Confirm: React.FC<ConfirmProps> = ({ accountId, onNext }) => {
         to: quote.inbound_address,
         from: accountAddress,
         sendMax: false,
-        accountId: accountId ?? '',
+        accountId,
         amountFieldError: '',
         cryptoSymbol: asset?.symbol ?? '',
         estimatedFees,

--- a/src/features/defi/providers/thorchain-savers/components/ThorchainSaversManager/Withdraw/components/Status.tsx
+++ b/src/features/defi/providers/thorchain-savers/components/ThorchainSaversManager/Withdraw/components/Status.tsx
@@ -1,6 +1,6 @@
 import { CheckIcon, CloseIcon, ExternalLinkIcon } from '@chakra-ui/icons'
 import { Box, Button, Link, Stack } from '@chakra-ui/react'
-import { ASSET_REFERENCE, fromAccountId, toAssetId } from '@shapeshiftoss/caip'
+import { fromAccountId } from '@shapeshiftoss/caip'
 import { Summary } from 'features/defi/components/Summary'
 import { TxStatus } from 'features/defi/components/TxStatus/TxStatus'
 import type {
@@ -33,33 +33,15 @@ export const Status = () => {
   const translate = useTranslate()
   const { state, dispatch } = useContext(WithdrawContext)
   const { query, history: browserHistory } = useBrowserRouter<DefiQueryParams, DefiParams>()
-  const { chainId, assetReference } = query
+  const { chainId } = query
 
-  const assetNamespace = 'erc20'
+  const assetId = state?.opportunity?.assetId
+  const feeAssetId = assetId
 
-  const assetId = state?.opportunity?.underlyingAssetIds?.[0] ?? ''
-  // Asset info
-  const underlyingAssetId = toAssetId({
-    chainId,
-    assetNamespace,
-    assetReference,
-  })
-  const underlyingAsset = useAppSelector(state => selectAssetById(state, underlyingAssetId))
-  const asset = useAppSelector(state => selectAssetById(state, assetId))
-  const feeAssetId = toAssetId({
-    chainId,
-    assetNamespace: 'slip44',
-    assetReference: ASSET_REFERENCE.Ethereum,
-  })
-  const feeAsset = useAppSelector(state => selectAssetById(state, feeAssetId))
-  if (!underlyingAsset) throw new Error(`Asset not found for AssetId ${underlyingAssetId}`)
-  if (!asset) throw new Error(`Asset not found for AssetId ${assetId}`)
-  if (!feeAsset) throw new Error(`Fee asset not found for AssetId ${feeAssetId}`)
-
-  const feeMarketData = useAppSelector(state => selectMarketDataById(state, feeAssetId))
+  const asset = useAppSelector(state => selectAssetById(state, feeAssetId ?? ''))
+  const feeMarketData = useAppSelector(state => selectMarketDataById(state, feeAssetId ?? ''))
 
   const accountId = useAppSelector(state => selectFirstAccountIdByChainId(state, chainId))
-
   const userAddress = useMemo(() => accountId && fromAccountId(accountId).account, [accountId])
 
   const serializedTxIndex = useMemo(() => {
@@ -88,7 +70,7 @@ export const Status = () => {
     browserHistory.goBack()
   }, [browserHistory])
 
-  if (!state) return null
+  if (!(state && asset)) return null
 
   const { statusIcon, statusText, statusBg, statusBody } = (() => {
     switch (state.withdraw.txStatus) {
@@ -98,7 +80,7 @@ export const Status = () => {
           statusIcon: <CheckIcon color='white' />,
           statusBg: 'green.500',
           statusBody: translate('modals.withdraw.status.success', {
-            opportunity: `${underlyingAsset.symbol} Vault`,
+            opportunity: `${asset.symbol} Vault`,
           }),
         }
       case 'failed':
@@ -136,7 +118,7 @@ export const Status = () => {
           </Row.Label>
           <Row px={0} fontWeight='medium'>
             <Stack direction='row' alignItems='center'>
-              <AssetIcon size='xs' src={underlyingAsset.icon} />
+              <AssetIcon size='xs' src={asset.icon} />
               <RawText>{asset.name}</RawText>
             </Stack>
             <Row.Value>
@@ -165,7 +147,7 @@ export const Status = () => {
                     ? state.withdraw.estimatedGasCrypto
                     : state.withdraw.usedGasFee,
                 )
-                  .div(`1e+${feeAsset.precision}`)
+                  .div(`1e+${asset.precision}`)
                   .times(feeMarketData.price)
                   .toFixed(2)}
               />
@@ -176,7 +158,7 @@ export const Status = () => {
                     ? state.withdraw.estimatedGasCrypto
                     : state.withdraw.usedGasFee,
                 )
-                  .div(`1e+${feeAsset.precision}`)
+                  .div(`1e+${asset.precision}`)
                   .toFixed(5)}
                 symbol='ETH'
               />
@@ -192,7 +174,7 @@ export const Status = () => {
           <Row.Value>
             <Box textAlign='right'>
               <Amount.Fiat fontWeight='bold' value='0' />
-              <Amount.Crypto color='gray.500' value='0' symbol={feeAsset.symbol} />
+              <Amount.Crypto color='gray.500' value='0' symbol={asset.symbol} />
             </Box>
           </Row.Value>
         </Row>

--- a/src/features/defi/providers/thorchain-savers/components/ThorchainSaversManager/Withdraw/components/Status.tsx
+++ b/src/features/defi/providers/thorchain-savers/components/ThorchainSaversManager/Withdraw/components/Status.tsx
@@ -160,7 +160,7 @@ export const Status = () => {
                 )
                   .div(bn(10).pow(asset.precision))
                   .toFixed(5)}
-                symbol='ETH'
+                symbol={asset.symbol}
               />
             </Box>
           </Row.Value>

--- a/src/features/defi/providers/thorchain-savers/components/ThorchainSaversManager/Withdraw/components/Status.tsx
+++ b/src/features/defi/providers/thorchain-savers/components/ThorchainSaversManager/Withdraw/components/Status.tsx
@@ -16,7 +16,7 @@ import { StatusTextEnum } from 'components/RouteSteps/RouteSteps'
 import { Row } from 'components/Row/Row'
 import { RawText, Text } from 'components/Text'
 import { useBrowserRouter } from 'hooks/useBrowserRouter/useBrowserRouter'
-import { bnOrZero } from 'lib/bignumber/bignumber'
+import { bn, bnOrZero } from 'lib/bignumber/bignumber'
 import {
   selectAssetById,
   selectFirstAccountIdByChainId,
@@ -147,7 +147,7 @@ export const Status = () => {
                     ? state.withdraw.estimatedGasCrypto
                     : state.withdraw.usedGasFee,
                 )
-                  .div(`1e+${asset.precision}`)
+                  .div(bn(10).pow(asset.precision))
                   .times(feeMarketData.price)
                   .toFixed(2)}
               />
@@ -158,7 +158,7 @@ export const Status = () => {
                     ? state.withdraw.estimatedGasCrypto
                     : state.withdraw.usedGasFee,
                 )
-                  .div(`1e+${asset.precision}`)
+                  .div(bn(10).pow(asset.precision))
                   .toFixed(5)}
                 symbol='ETH'
               />

--- a/src/features/defi/providers/thorchain-savers/components/ThorchainSaversManager/Withdraw/components/Status.tsx
+++ b/src/features/defi/providers/thorchain-savers/components/ThorchainSaversManager/Withdraw/components/Status.tsx
@@ -186,7 +186,7 @@ export const Status = () => {
             variant='ghost-filled'
             colorScheme='green'
             rightIcon={<ExternalLinkIcon />}
-            href={`${asset.explorerTxLink}/${state.txid}`}
+            href={`${asset.explorerTxLink}${state.txid}`}
           >
             {translate('defi.viewOnChain')}
           </Button>

--- a/src/features/defi/providers/thorchain-savers/components/ThorchainSaversManager/Withdraw/components/Withdraw.tsx
+++ b/src/features/defi/providers/thorchain-savers/components/ThorchainSaversManager/Withdraw/components/Withdraw.tsx
@@ -1,7 +1,8 @@
+import { useToast } from '@chakra-ui/react'
 import type { Asset } from '@shapeshiftoss/asset-service'
 import type { AccountId } from '@shapeshiftoss/caip'
-import { fromAccountId } from '@shapeshiftoss/caip'
-import type { YearnOpportunity } from '@shapeshiftoss/investor-yearn'
+import { fromAccountId, toAssetId } from '@shapeshiftoss/caip'
+import type { UtxoBaseAdapter, UtxoChainId } from '@shapeshiftoss/chain-adapters'
 import type { WithdrawValues } from 'features/defi/components/Withdraw/Withdraw'
 import { Field, Withdraw as ReusableWithdraw } from 'features/defi/components/Withdraw/Withdraw'
 import type {
@@ -9,14 +10,17 @@ import type {
   DefiQueryParams,
 } from 'features/defi/contexts/DefiManagerProvider/DefiCommon'
 import { DefiStep } from 'features/defi/contexts/DefiManagerProvider/DefiCommon'
-import { getYearnInvestor } from 'features/defi/contexts/YearnProvider/yearnInvestorSingleton'
-import { useCallback, useContext, useEffect, useMemo, useState } from 'react'
+import { useCallback, useContext, useMemo } from 'react'
 import { FormProvider, useForm } from 'react-hook-form'
+import { useTranslate } from 'react-polyglot'
 import type { StepComponentProps } from 'components/DeFi/components/Steps'
+import { getChainAdapterManager } from 'context/PluginProvider/chainAdapterSingleton'
 import { useBrowserRouter } from 'hooks/useBrowserRouter/useBrowserRouter'
 import { bn, bnOrZero } from 'lib/bignumber/bignumber'
 import { logger } from 'lib/logger'
+import { getThorchainSaversDepositQuote } from 'state/slices/opportunitiesSlice/resolvers/thorchainsavers/utils'
 import { serializeUserStakingId, toOpportunityId } from 'state/slices/opportunitiesSlice/utils'
+import { isUtxoChainId } from 'state/slices/portfolioSlice/utils'
 import {
   selectAssetById,
   selectEarnUserStakingOpportunityByUserStakingId,
@@ -29,26 +33,32 @@ import { ThorchainSaversWithdrawActionType } from '../WithdrawCommon'
 import { WithdrawContext } from '../WithdrawContext'
 
 const moduleLogger = logger.child({
-  namespace: ['DeFi', 'Providers', 'Yearn', 'YearnWithdraw'],
+  namespace: ['DeFi', 'Providers', 'ThorchainSavers', 'ThorchainSaversWithdraw'],
 })
 
 type WithdrawProps = StepComponentProps & { accountId: AccountId | undefined }
 
 export const Withdraw: React.FC<WithdrawProps> = ({ accountId, onNext }) => {
-  const yearnInvestor = useMemo(() => getYearnInvestor(), [])
-  const [yearnOpportunity, setYearnOpportunity] = useState<YearnOpportunity>()
   const { state, dispatch } = useContext(WithdrawContext)
+  const translate = useTranslate()
+  const toast = useToast()
   const { query, history: browserHistory } = useBrowserRouter<DefiQueryParams, DefiParams>()
-  const { chainId, contractAddress, assetReference } = query
+  const { chainId, assetNamespace, assetReference } = query
 
   const methods = useForm<WithdrawValues>({ mode: 'onChange' })
   const { setValue } = methods
 
   // Asset info
 
+  const assetId = toAssetId({
+    chainId,
+    assetNamespace,
+    assetReference,
+  })
+
   const opportunityId = useMemo(
-    () => toOpportunityId({ chainId, assetNamespace: 'erc20', assetReference: contractAddress }),
-    [chainId, contractAddress],
+    () => (assetId ? toOpportunityId({ chainId, assetNamespace, assetReference }) : undefined),
+    [assetId, assetNamespace, assetReference, chainId],
   )
 
   const highestBalanceAccountIdFilter = useMemo(
@@ -62,37 +72,19 @@ export const Withdraw: React.FC<WithdrawProps> = ({ accountId, onNext }) => {
   const opportunityDataFilter = useMemo(
     () => ({
       userStakingId: serializeUserStakingId(
-        (accountId ?? highestBalanceAccountId)!,
-        toOpportunityId({
-          chainId,
-          assetNamespace: 'erc20',
-          assetReference: contractAddress,
-        }),
+        accountId ?? highestBalanceAccountId ?? '',
+        opportunityId ?? '',
       ),
     }),
-    [accountId, chainId, contractAddress, highestBalanceAccountId],
+    [accountId, highestBalanceAccountId, opportunityId],
   )
 
   const opportunityData = useAppSelector(state =>
     selectEarnUserStakingOpportunityByUserStakingId(state, opportunityDataFilter),
   )
 
-  useEffect(() => {
-    if (!opportunityData?.assetId) return
-    ;(async () => {
-      setYearnOpportunity(await yearnInvestor.findByOpportunityId(opportunityData.assetId))
-    })()
-  }, [yearnInvestor, opportunityData?.assetId, setYearnOpportunity])
-
-  const assetMarketData = useAppSelector(state =>
-    selectMarketDataById(state, opportunityData?.assetId ?? ''),
-  )
-
-  const asset: Asset | undefined = useAppSelector(state =>
-    selectAssetById(state, opportunityData?.assetId ?? ''),
-  )
-
-  if (!asset) throw new Error(`Asset not found for AssetId ${opportunityData?.assetId}`)
+  const asset: Asset | undefined = useAppSelector(state => selectAssetById(state, assetId))
+  if (!asset) throw new Error(`Asset not found for AssetId ${assetId}`)
 
   const userAddress = useMemo(() => accountId && fromAccountId(accountId).account, [accountId])
 
@@ -101,32 +93,48 @@ export const Withdraw: React.FC<WithdrawProps> = ({ accountId, onNext }) => {
     return bnOrZero(opportunityData?.stakedAmountCryptoBaseUnit).div(bn(10).pow(asset.precision))
   }, [asset.precision, opportunityData?.stakedAmountCryptoBaseUnit])
 
+  const assetMarketData = useAppSelector(state => selectMarketDataById(state, assetId))
   const fiatAmountAvailable = useMemo(
     () => bnOrZero(amountAvailableCryptoPrecision).times(assetMarketData.price),
-    [amountAvailableCryptoPrecision, assetMarketData],
+    [amountAvailableCryptoPrecision, assetMarketData.price],
   )
 
   const getWithdrawGasEstimate = useCallback(
     async (withdraw: WithdrawValues) => {
-      if (!(userAddress && opportunityData && assetReference)) return
+      if (!(userAddress && assetReference && accountId && opportunityData)) return
       try {
-        if (!yearnOpportunity) throw new Error('No opportunity')
-        const preparedTx = await yearnOpportunity.prepareWithdrawal({
-          amount: bnOrZero(withdraw.cryptoAmount)
-            .times(bn(10).pow(asset?.precision))
-            .integerValue(),
-          address: userAddress,
-        })
-        return bnOrZero(preparedTx.gasPrice)
-          .times(preparedTx.estimatedGas)
-          .integerValue()
+        const amountCryptoBaseUnit = bnOrZero(withdraw.cryptoAmount).times(
+          bn(10).pow(asset.precision),
+        )
+        const quote = await getThorchainSaversDepositQuote(asset, amountCryptoBaseUnit)
+        const chainAdapters = getChainAdapterManager()
+        const adapter = chainAdapters.get(chainId) as unknown as UtxoBaseAdapter<UtxoChainId>
+        const fee = (
+          await adapter.getFeeData({
+            to: quote.inbound_address,
+            value: amountCryptoBaseUnit.toFixed(0),
+            chainSpecific: { pubkey: userAddress, from: '' },
+            sendMax: false,
+          })
+        ).fast.txFee
+        // We might need a dust reconciliation Tx for UTXOs, so we assume gas * 2
+        return bnOrZero(fee)
+          .times(isUtxoChainId(chainId) ? 2 : 1)
           .toString()
       } catch (error) {
-        // TODO: handle client side errors maybe add a toast?
-        moduleLogger.error(error, 'YearnWithdraw:Withdraw:getWithdrawGasEstimate error')
+        moduleLogger.error(
+          { fn: 'getDepositGasEstimate', error },
+          'Error getting deposit gas estimate',
+        )
+        toast({
+          position: 'top-right',
+          description: translate('common.somethingWentWrongBody'),
+          title: translate('common.somethingWentWrong'),
+          status: 'error',
+        })
       }
     },
-    [userAddress, opportunityData, assetReference, yearnOpportunity, asset?.precision],
+    [userAddress, assetReference, accountId, opportunityData, asset, chainId, toast, translate],
   )
 
   const handleContinue = useCallback(

--- a/src/features/defi/providers/thorchain-savers/components/ThorchainSaversManager/Withdraw/components/Withdraw.tsx
+++ b/src/features/defi/providers/thorchain-savers/components/ThorchainSaversManager/Withdraw/components/Withdraw.tsx
@@ -112,13 +112,13 @@ export const Withdraw: React.FC<WithdrawProps> = ({ accountId, onNext }) => {
         const amountCryptoBaseUnit = bnOrZero(withdraw.cryptoAmount).times(
           bn(10).pow(asset.precision),
         )
-        const withdrawBps = getWithdrawBps(
-          amountCryptoBaseUnit,
-          opportunityData?.stakedAmountCryptoBaseUnit,
-          opportunityData?.rewardsAmountsCryptoBaseUnit?.[0] ?? '0',
-        )
+        const withdrawBps = getWithdrawBps({
+          withdrawAmountCryptoBaseUnit: amountCryptoBaseUnit,
+          stakedAmountCryptoBaseUnit: opportunityData?.stakedAmountCryptoBaseUnit,
+          rewardsamountCryptoBaseUnit: opportunityData?.rewardsAmountsCryptoBaseUnit?.[0] ?? '0',
+        })
 
-        const quote = await getThorchainSaversWithdrawQuote(asset, accountId, withdrawBps)
+        const quote = await getThorchainSaversWithdrawQuote({ asset, accountId, bps: withdrawBps })
         const chainAdapters = getChainAdapterManager()
         const adapter = chainAdapters.get(chainId) as unknown as UtxoBaseAdapter<UtxoChainId>
         const fee = (

--- a/src/features/defi/providers/thorchain-savers/components/ThorchainSaversManager/Withdraw/components/Withdraw.tsx
+++ b/src/features/defi/providers/thorchain-savers/components/ThorchainSaversManager/Withdraw/components/Withdraw.tsx
@@ -104,7 +104,10 @@ export const Withdraw: React.FC<WithdrawProps> = ({ accountId, onNext }) => {
 
   const getWithdrawGasEstimate = useCallback(
     async (withdraw: WithdrawValues) => {
-      if (!(userAddress && assetReference && accountId && opportunityData)) return
+      if (
+        !(userAddress && assetReference && accountId && opportunityData?.stakedAmountCryptoBaseUnit)
+      )
+        return
       try {
         const amountCryptoBaseUnit = bnOrZero(withdraw.cryptoAmount).times(
           bn(10).pow(asset.precision),
@@ -112,7 +115,7 @@ export const Withdraw: React.FC<WithdrawProps> = ({ accountId, onNext }) => {
         const withdrawBps = getWithdrawBps(
           amountCryptoBaseUnit,
           opportunityData?.stakedAmountCryptoBaseUnit,
-          opportunityData?.rewardsAmountsCryptoBaseUnit?.[0],
+          opportunityData?.rewardsAmountsCryptoBaseUnit?.[0] ?? '0',
         )
 
         const quote = await getThorchainSaversWithdrawQuote(asset, accountId, withdrawBps)

--- a/src/features/defi/providers/thorchain-savers/components/ThorchainSaversManager/Withdraw/components/Withdraw.tsx
+++ b/src/features/defi/providers/thorchain-savers/components/ThorchainSaversManager/Withdraw/components/Withdraw.tsx
@@ -18,7 +18,10 @@ import { getChainAdapterManager } from 'context/PluginProvider/chainAdapterSingl
 import { useBrowserRouter } from 'hooks/useBrowserRouter/useBrowserRouter'
 import { bn, bnOrZero } from 'lib/bignumber/bignumber'
 import { logger } from 'lib/logger'
-import { getThorchainSaversWithdrawQuote } from 'state/slices/opportunitiesSlice/resolvers/thorchainsavers/utils'
+import {
+  getThorchainSaversWithdrawQuote,
+  getWithdrawBps,
+} from 'state/slices/opportunitiesSlice/resolvers/thorchainsavers/utils'
 import { serializeUserStakingId, toOpportunityId } from 'state/slices/opportunitiesSlice/utils'
 import { isUtxoChainId } from 'state/slices/portfolioSlice/utils'
 import {
@@ -106,7 +109,13 @@ export const Withdraw: React.FC<WithdrawProps> = ({ accountId, onNext }) => {
         const amountCryptoBaseUnit = bnOrZero(withdraw.cryptoAmount).times(
           bn(10).pow(asset.precision),
         )
-        const quote = await getThorchainSaversWithdrawQuote(asset, amountCryptoBaseUnit, accountId)
+        const withdrawBps = getWithdrawBps(
+          amountCryptoBaseUnit,
+          opportunityData?.stakedAmountCryptoBaseUnit,
+          opportunityData?.rewardsAmountsCryptoBaseUnit?.[0],
+        )
+
+        const quote = await getThorchainSaversWithdrawQuote(asset, accountId, withdrawBps)
         const chainAdapters = getChainAdapterManager()
         const adapter = chainAdapters.get(chainId) as unknown as UtxoBaseAdapter<UtxoChainId>
         const fee = (

--- a/src/state/slices/opportunitiesSlice/resolvers/thorchainsavers/index.ts
+++ b/src/state/slices/opportunitiesSlice/resolvers/thorchainsavers/index.ts
@@ -182,7 +182,10 @@ export const thorchainSaversStakingOpportunitiesUserDataResolver = async ({
         `Error fetching THORCHain savers positions for assetId: ${stakingOpportunityId}`,
       )
 
-    const accountPosition = await getThorchainSaversPosition(accountId, stakingOpportunityId)
+    const accountPosition = await getThorchainSaversPosition({
+      accountId,
+      assetId: stakingOpportunityId,
+    })
 
     const { asset_deposit_value, asset_redeem_value } = accountPosition
 

--- a/src/state/slices/opportunitiesSlice/resolvers/thorchainsavers/types.ts
+++ b/src/state/slices/opportunitiesSlice/resolvers/thorchainsavers/types.ts
@@ -40,7 +40,9 @@ export type ThorchainSaverPositionResponse = {
   growth_pct: string
 }
 
-export type ThorchainSaversDepositQuoteResponseSuccess = {
+export type ThorchainSaversCommonQuoteResponseSuccess = {
+  expiry: string // TODO(gomes): guard against expired quote
+  dust_threshold: string
   expected_amount_out: string
   fees: {
     affiliate: string
@@ -48,15 +50,32 @@ export type ThorchainSaversDepositQuoteResponseSuccess = {
     outbound: string
   }
   inbound_address: string
-  inbound_confirmation_blocks: number
   memo: string
   slippage_bps: number
+  notes: string
+  warning: string
 }
 
-export type ThorchainSaversDepositQuoteResponseError = {
+export type ThorchainSaversCommonQuoteResponseError = {
   error: string
 }
 
+export type ThorchainSaversDepositQuoteResponseSuccess =
+  ThorchainSaversCommonQuoteResponseSuccess & {
+    inbound_confirmation_blocks: number
+  }
+
+export type ThorchainSaversWithdrawQuoteResponseSuccess =
+  ThorchainSaversCommonQuoteResponseSuccess & {
+    outbound_delay_blocks: number
+    outbound_delay_seconds: number
+    slippage_bps: number
+  }
+
 export type ThorchainSaversDepositQuoteResponse =
   | ThorchainSaversDepositQuoteResponseSuccess
-  | ThorchainSaversDepositQuoteResponseError
+  | ThorchainSaversCommonQuoteResponseError
+
+export type ThorchainSaversWithdrawQuoteResponse =
+  | ThorchainSaversWithdrawQuoteResponseSuccess
+  | ThorchainSaversCommonQuoteResponseError

--- a/src/state/slices/opportunitiesSlice/resolvers/thorchainsavers/types.ts
+++ b/src/state/slices/opportunitiesSlice/resolvers/thorchainsavers/types.ts
@@ -40,7 +40,7 @@ export type ThorchainSaverPositionResponse = {
   growth_pct: string
 }
 
-export type ThorchainSaversQuoteResponseSuccess = {
+export type ThorchainSaversDepositQuoteResponseSuccess = {
   expected_amount_out: string
   fees: {
     affiliate: string
@@ -53,10 +53,10 @@ export type ThorchainSaversQuoteResponseSuccess = {
   slippage_bps: number
 }
 
-export type ThorchainSaversQuoteResponseError = {
+export type ThorchainSaversDepositQuoteResponseError = {
   error: string
 }
 
-export type ThorchainSaversQuoteResponse =
-  | ThorchainSaversQuoteResponseSuccess
-  | ThorchainSaversQuoteResponseError
+export type ThorchainSaversDepositQuoteResponse =
+  | ThorchainSaversDepositQuoteResponseSuccess
+  | ThorchainSaversDepositQuoteResponseError

--- a/src/state/slices/opportunitiesSlice/resolvers/thorchainsavers/types.ts
+++ b/src/state/slices/opportunitiesSlice/resolvers/thorchainsavers/types.ts
@@ -70,6 +70,7 @@ export type ThorchainSaversWithdrawQuoteResponseSuccess =
     outbound_delay_blocks: number
     outbound_delay_seconds: number
     slippage_bps: number
+    dust_amount: string
   }
 
 export type ThorchainSaversDepositQuoteResponse =

--- a/src/state/slices/opportunitiesSlice/resolvers/thorchainsavers/utils.test.ts
+++ b/src/state/slices/opportunitiesSlice/resolvers/thorchainsavers/utils.test.ts
@@ -46,7 +46,10 @@ describe('resolvers/thorchainSavers/utils', () => {
       )
 
       const btcAssetMock = getAssetService().getAll()[btcAssetId]
-      const saversQuote = await getThorchainSaversDepositQuote(btcAssetMock, '10000000')
+      const saversQuote = await getThorchainSaversDepositQuote({
+        asset: btcAssetMock,
+        amountCryptoBaseUnit: '10000000',
+      })
 
       expect(saversQuote).toMatchObject(btcQuote)
     })
@@ -58,7 +61,9 @@ describe('resolvers/thorchainSavers/utils', () => {
       )
 
       const osmoAssetMock = { assetId: osmosisAssetId, precision: 6 } as unknown as Asset
-      await expect(getThorchainSaversDepositQuote(osmoAssetMock, '10000000')).rejects.toThrow()
+      await expect(
+        getThorchainSaversDepositQuote({ asset: osmoAssetMock, amountCryptoBaseUnit: '10000000' }),
+      ).rejects.toThrow()
     })
     it('throws when deposit is over the max synth mint supply', async () => {
       mockAxios.get.mockImplementationOnce(() =>
@@ -68,7 +73,12 @@ describe('resolvers/thorchainSavers/utils', () => {
       )
 
       const btcAssetMock = getAssetService().getAll()[btcAssetId]
-      await expect(getThorchainSaversDepositQuote(btcAssetMock, '10000000000000')).rejects.toThrow()
+      await expect(
+        getThorchainSaversDepositQuote({
+          asset: btcAssetMock,
+          amountCryptoBaseUnit: '10000000000000',
+        }),
+      ).rejects.toThrow()
     })
   })
 })

--- a/src/state/slices/opportunitiesSlice/resolvers/thorchainsavers/utils.test.ts
+++ b/src/state/slices/opportunitiesSlice/resolvers/thorchainsavers/utils.test.ts
@@ -3,7 +3,7 @@ import { AssetService } from '@shapeshiftoss/asset-service'
 import { btcAssetId, osmosisAssetId } from '@shapeshiftoss/caip'
 import axios from 'axios'
 
-import { getThorchainSaversQuote } from './utils'
+import { getThorchainSaversDepositQuote } from './utils'
 
 jest.mock('axios')
 const mockAxios = axios as jest.Mocked<typeof axios>
@@ -46,7 +46,7 @@ describe('resolvers/thorchainSavers/utils', () => {
       )
 
       const btcAssetMock = getAssetService().getAll()[btcAssetId]
-      const saversQuote = await getThorchainSaversQuote(btcAssetMock, '10000000')
+      const saversQuote = await getThorchainSaversDepositQuote(btcAssetMock, '10000000')
 
       expect(saversQuote).toMatchObject(btcQuote)
     })
@@ -58,7 +58,7 @@ describe('resolvers/thorchainSavers/utils', () => {
       )
 
       const osmoAssetMock = { assetId: osmosisAssetId, precision: 6 } as unknown as Asset
-      await expect(getThorchainSaversQuote(osmoAssetMock, '10000000')).rejects.toThrow()
+      await expect(getThorchainSaversDepositQuote(osmoAssetMock, '10000000')).rejects.toThrow()
     })
     it('throws when deposit is over the max synth mint supply', async () => {
       mockAxios.get.mockImplementationOnce(() =>
@@ -68,7 +68,7 @@ describe('resolvers/thorchainSavers/utils', () => {
       )
 
       const btcAssetMock = getAssetService().getAll()[btcAssetId]
-      await expect(getThorchainSaversQuote(btcAssetMock, '10000000000000')).rejects.toThrow()
+      await expect(getThorchainSaversDepositQuote(btcAssetMock, '10000000000000')).rejects.toThrow()
     })
   })
 })

--- a/src/state/slices/opportunitiesSlice/resolvers/thorchainsavers/utils.ts
+++ b/src/state/slices/opportunitiesSlice/resolvers/thorchainsavers/utils.ts
@@ -34,7 +34,9 @@ import type {
 const THOR_PRECISION = '8'
 const BASE_BPS_POINTS = '10000'
 
-export const THOR_DEPOSIT_DUST_THRESHOLDS = {
+// The minimum amount to be sent both for deposit and withdraws
+// else it will be considered a dust attack and gifted to the network
+export const THORCHAIN_SAVERS_DUST_THRESHOLDS = {
   [btcAssetId]: '10000',
   [bchAssetId]: '10000',
   [ltcAssetId]: '10000',
@@ -217,7 +219,7 @@ export const toThorBaseUnit = (
 export const isAboveDepositDustThreshold = (
   valueCryptoBaseUnit: BigNumber.Value | null | undefined,
   assetId: AssetId,
-) => bnOrZero(valueCryptoBaseUnit).gte(THOR_DEPOSIT_DUST_THRESHOLDS[assetId])
+) => bnOrZero(valueCryptoBaseUnit).gte(THORCHAIN_SAVERS_DUST_THRESHOLDS[assetId])
 
 export const getWithdrawBps = (
   withdrawAmountCryptoBaseUnit: BigNumber.Value,

--- a/src/state/slices/opportunitiesSlice/resolvers/thorchainsavers/utils.ts
+++ b/src/state/slices/opportunitiesSlice/resolvers/thorchainsavers/utils.ts
@@ -106,10 +106,13 @@ export const getAllThorchainSaversPositions = async (
   return opportunitiesData
 }
 
-export const getThorchainSaversPosition = async (
-  accountId: AccountId,
-  assetId: AssetId,
-): Promise<ThorchainSaverPositionResponse> => {
+export const getThorchainSaversPosition = async ({
+  accountId,
+  assetId,
+}: {
+  accountId: AccountId
+  assetId: AssetId
+}): Promise<ThorchainSaverPositionResponse> => {
   const allPositions = await getAllThorchainSaversPositions(assetId)
 
   if (!allPositions.length)
@@ -132,15 +135,21 @@ export const getThorchainSaversPosition = async (
   return accountPosition
 }
 
-export const getThorchainSaversDepositQuote = async (
-  asset: Asset,
-  amountCryptoBaseUnit: BigNumber.Value | null | undefined,
-): Promise<ThorchainSaversDepositQuoteResponseSuccess> => {
+export const getThorchainSaversDepositQuote = async ({
+  asset,
+  amountCryptoBaseUnit,
+}: {
+  asset: Asset
+  amountCryptoBaseUnit: BigNumber.Value | null | undefined
+}): Promise<ThorchainSaversDepositQuoteResponseSuccess> => {
   const poolId = adapters.assetIdToPoolAssetId({ assetId: asset.assetId })
 
   if (!poolId) throw new Error(`Invalid assetId for THORCHain savers: ${asset.assetId}`)
 
-  const amountThorBaseUnit = toThorBaseUnit(amountCryptoBaseUnit, asset).toString()
+  const amountThorBaseUnit = toThorBaseUnit({
+    valueCryptoBaseUnit: amountCryptoBaseUnit,
+    asset,
+  }).toString()
 
   const { data: quoteData } = await axios.get<ThorchainSaversDepositQuoteResponse>(
     `${
@@ -154,11 +163,15 @@ export const getThorchainSaversDepositQuote = async (
   return quoteData
 }
 
-export const getThorchainSaversWithdrawQuote = async (
-  asset: Asset,
-  accountId: AccountId,
-  bps: string,
-): Promise<ThorchainSaversWithdrawQuoteResponseSuccess> => {
+export const getThorchainSaversWithdrawQuote = async ({
+  asset,
+  accountId,
+  bps,
+}: {
+  asset: Asset
+  accountId: AccountId
+  bps: string
+}): Promise<ThorchainSaversWithdrawQuoteResponseSuccess> => {
   const poolId = adapters.assetIdToPoolAssetId({ assetId: asset.assetId })
 
   if (!poolId) throw new Error(`Invalid assetId for THORCHain savers: ${asset.assetId}`)
@@ -204,10 +217,13 @@ export const getMidgardPools = async (): Promise<MidgardPoolResponse[]> => {
 export const fromThorBaseUnit = (valueThorBaseUnit: BigNumber.Value | null | undefined): BN =>
   bnOrZero(valueThorBaseUnit).div(bn(10).pow(THOR_PRECISION)) // to crypto precision from THOR 8 dp base unit
 
-export const toThorBaseUnit = (
-  valueCryptoBaseUnit: BigNumber.Value | null | undefined,
-  asset: Asset,
-): BN => {
+export const toThorBaseUnit = ({
+  valueCryptoBaseUnit,
+  asset,
+}: {
+  valueCryptoBaseUnit: BigNumber.Value | null | undefined
+  asset: Asset
+}): BN => {
   if (!asset?.precision) return bn(0)
 
   return bnOrZero(valueCryptoBaseUnit)
@@ -216,16 +232,23 @@ export const toThorBaseUnit = (
     .decimalPlaces(0) // THORChain expects ints, not floats
 }
 
-export const isAboveDepositDustThreshold = (
-  valueCryptoBaseUnit: BigNumber.Value | null | undefined,
-  assetId: AssetId,
-) => bnOrZero(valueCryptoBaseUnit).gte(THORCHAIN_SAVERS_DUST_THRESHOLDS[assetId])
+export const isAboveDepositDustThreshold = ({
+  valueCryptoBaseUnit,
+  assetId,
+}: {
+  valueCryptoBaseUnit: BigNumber.Value | null | undefined
+  assetId: AssetId
+}) => bnOrZero(valueCryptoBaseUnit).gte(THORCHAIN_SAVERS_DUST_THRESHOLDS[assetId])
 
-export const getWithdrawBps = (
-  withdrawAmountCryptoBaseUnit: BigNumber.Value,
-  stakedAmountCryptoBaseUnit: BigNumber.Value,
-  rewardsamountCryptoBaseUnit: BigNumber.Value,
-) => {
+export const getWithdrawBps = ({
+  withdrawAmountCryptoBaseUnit,
+  stakedAmountCryptoBaseUnit,
+  rewardsamountCryptoBaseUnit,
+}: {
+  withdrawAmountCryptoBaseUnit: BigNumber.Value
+  stakedAmountCryptoBaseUnit: BigNumber.Value
+  rewardsamountCryptoBaseUnit: BigNumber.Value
+}) => {
   const stakedAmountCryptoBaseUnitIncludeRewards = bnOrZero(stakedAmountCryptoBaseUnit).plus(
     rewardsamountCryptoBaseUnit,
   )

--- a/src/state/slices/opportunitiesSlice/resolvers/thorchainsavers/utils.ts
+++ b/src/state/slices/opportunitiesSlice/resolvers/thorchainsavers/utils.ts
@@ -31,7 +31,7 @@ import type {
   ThorchainSaversWithdrawQuoteResponseSuccess,
 } from './types'
 
-const THOR_PRECISION = '10000'
+const THOR_PRECISION = '8'
 const BASE_BPS_POINTS = '10000'
 
 export const THOR_DEPOSIT_DUST_THRESHOLDS = {
@@ -154,15 +154,12 @@ export const getThorchainSaversDepositQuote = async (
 
 export const getThorchainSaversWithdrawQuote = async (
   asset: Asset,
-  amountCryptoBaseUnit: BigNumber.Value | null | undefined,
   accountId: AccountId,
+  bps: string,
 ): Promise<ThorchainSaversWithdrawQuoteResponseSuccess> => {
   const poolId = adapters.assetIdToPoolAssetId({ assetId: asset.assetId })
 
   if (!poolId) throw new Error(`Invalid assetId for THORCHain savers: ${asset.assetId}`)
-
-  // TODO(gomes)
-  const withdrawBasePoints = toThorBaseUnit(amountCryptoBaseUnit, asset).toString()
 
   const accountAddresses = await getAccountAddresses(accountId)
 
@@ -183,7 +180,7 @@ export const getThorchainSaversWithdrawQuote = async (
   const { data: quoteData } = await axios.get<ThorchainSaversWithdrawQuoteResponse>(
     `${
       getConfig().REACT_APP_THORCHAIN_NODE_URL
-    }/lcd/thorchain/quote/saver/withdraw?asset=${poolId}&address=${asset_address}&withdraw_bps=${withdrawBasePoints}`,
+    }/lcd/thorchain/quote/saver/withdraw?asset=${poolId}&address=${asset_address}&withdraw_bps=${bps}`,
   )
 
   if (!quoteData || 'error' in quoteData)
@@ -235,13 +232,7 @@ export const getWithdrawBps = (
     stakedAmountCryptoBaseUnitIncludeRewards,
   )
 
-  debugger
+  const withdrawBps = withdrawRatio.times(BASE_BPS_POINTS).toFixed(0)
 
-  const withdrawBps = withdrawRatio
-    .times(stakedAmountCryptoBaseUnit)
-    .times(BASE_BPS_POINTS)
-    .toFixed(0)
-
-  debugger
   return withdrawBps
 }

--- a/src/state/slices/opportunitiesSlice/resolvers/thorchainsavers/utils.ts
+++ b/src/state/slices/opportunitiesSlice/resolvers/thorchainsavers/utils.ts
@@ -220,9 +220,9 @@ export const isAboveDepositDustThreshold = (
 ) => bnOrZero(valueCryptoBaseUnit).gte(THOR_DEPOSIT_DUST_THRESHOLDS[assetId])
 
 export const getWithdrawBps = (
-  withdrawAmountCryptoBaseUnit: BigNumber.Value | null | undefined,
-  stakedAmountCryptoBaseUnit: BigNumber.Value | null | undefined,
-  rewardsamountCryptoBaseUnit: BigNumber.Value | null | undefined,
+  withdrawAmountCryptoBaseUnit: BigNumber.Value,
+  stakedAmountCryptoBaseUnit: BigNumber.Value,
+  rewardsamountCryptoBaseUnit: BigNumber.Value,
 ) => {
   const stakedAmountCryptoBaseUnitIncludeRewards = bnOrZero(stakedAmountCryptoBaseUnit).plus(
     rewardsamountCryptoBaseUnit,

--- a/src/state/slices/opportunitiesSlice/resolvers/thorchainsavers/utils.ts
+++ b/src/state/slices/opportunitiesSlice/resolvers/thorchainsavers/utils.ts
@@ -31,7 +31,7 @@ import type {
   ThorchainSaversWithdrawQuoteResponseSuccess,
 } from './types'
 
-const THOR_PRECISION = '8'
+export const THOR_PRECISION = '8'
 const BASE_BPS_POINTS = '10000'
 
 // The minimum amount to be sent both for deposit and withdraws

--- a/src/state/slices/opportunitiesSlice/resolvers/thorchainsavers/utils.ts
+++ b/src/state/slices/opportunitiesSlice/resolvers/thorchainsavers/utils.ts
@@ -25,8 +25,8 @@ import { isUtxoAccountId } from 'state/slices/portfolioSlice/utils'
 import type {
   MidgardPoolResponse,
   ThorchainSaverPositionResponse,
-  ThorchainSaversQuoteResponse,
-  ThorchainSaversQuoteResponseSuccess,
+  ThorchainSaversDepositQuoteResponse,
+  ThorchainSaversDepositQuoteResponseSuccess,
 } from './types'
 
 const THOR_PRECISION = 8
@@ -127,17 +127,39 @@ export const getThorchainSaversPosition = async (
   return accountPosition
 }
 
-export const getThorchainSaversQuote = async (
+export const getThorchainSaversDepositQuote = async (
   asset: Asset,
   amountCryptoBaseUnit: BigNumber.Value | null | undefined,
-): Promise<ThorchainSaversQuoteResponseSuccess> => {
+): Promise<ThorchainSaversDepositQuoteResponseSuccess> => {
   const poolId = adapters.assetIdToPoolAssetId({ assetId: asset.assetId })
 
   if (!poolId) throw new Error(`Invalid assetId for THORCHain savers: ${asset.assetId}`)
 
   const amountThorBaseUnit = toThorBaseUnit(amountCryptoBaseUnit, asset).toString()
 
-  const { data: quoteData } = await axios.get<ThorchainSaversQuoteResponse>(
+  const { data: quoteData } = await axios.get<ThorchainSaversDepositQuoteResponse>(
+    `${
+      getConfig().REACT_APP_THORCHAIN_NODE_URL
+    }/lcd/thorchain/quote/saver/deposit?asset=${poolId}&amount=${amountThorBaseUnit}`,
+  )
+
+  if (!quoteData || 'error' in quoteData)
+    throw new Error(`Error fetching THORChain savers quote: ${quoteData?.error}`)
+
+  return quoteData
+}
+
+export const getThorchainSaversWithdrawQuote = async (
+  asset: Asset,
+  amountCryptoBaseUnit: BigNumber.Value | null | undefined,
+): Promise<ThorchainSaversDepositQuoteResponseSuccess> => {
+  const poolId = adapters.assetIdToPoolAssetId({ assetId: asset.assetId })
+
+  if (!poolId) throw new Error(`Invalid assetId for THORCHain savers: ${asset.assetId}`)
+
+  const amountThorBaseUnit = toThorBaseUnit(amountCryptoBaseUnit, asset).toString()
+
+  const { data: quoteData } = await axios.get<ThorchainSaversDepositQuoteResponse>(
     `${
       getConfig().REACT_APP_THORCHAIN_NODE_URL
     }/lcd/thorchain/quote/saver/deposit?asset=${poolId}&amount=${amountThorBaseUnit}`,

--- a/src/state/slices/opportunitiesSlice/resolvers/thorchainsavers/utils.ts
+++ b/src/state/slices/opportunitiesSlice/resolvers/thorchainsavers/utils.ts
@@ -31,7 +31,8 @@ import type {
   ThorchainSaversWithdrawQuoteResponseSuccess,
 } from './types'
 
-const THOR_PRECISION = 8
+const THOR_PRECISION = '10000'
+const BASE_BPS_POINTS = '10000'
 
 export const THOR_DEPOSIT_DUST_THRESHOLDS = {
   [btcAssetId]: '10000',
@@ -220,3 +221,27 @@ export const isAboveDepositDustThreshold = (
   valueCryptoBaseUnit: BigNumber.Value | null | undefined,
   assetId: AssetId,
 ) => bnOrZero(valueCryptoBaseUnit).gte(THOR_DEPOSIT_DUST_THRESHOLDS[assetId])
+
+export const getWithdrawBps = (
+  withdrawAmountCryptoBaseUnit: BigNumber.Value | null | undefined,
+  stakedAmountCryptoBaseUnit: BigNumber.Value | null | undefined,
+  rewardsamountCryptoBaseUnit: BigNumber.Value | null | undefined,
+) => {
+  const stakedAmountCryptoBaseUnitIncludeRewards = bnOrZero(stakedAmountCryptoBaseUnit).plus(
+    rewardsamountCryptoBaseUnit,
+  )
+
+  const withdrawRatio = bnOrZero(withdrawAmountCryptoBaseUnit).div(
+    stakedAmountCryptoBaseUnitIncludeRewards,
+  )
+
+  debugger
+
+  const withdrawBps = withdrawRatio
+    .times(stakedAmountCryptoBaseUnit)
+    .times(BASE_BPS_POINTS)
+    .toFixed(0)
+
+  debugger
+  return withdrawBps
+}


### PR DESCRIPTION
## Description

This PR handles THORChain savers withdraws - memoless for the time being.

To be handled as stack on top of this one: 

- The status screen doesn't yet show dust/fees. We will need some additional routing logic for that: given at this point the Tx is already ongoing and the quote is final, we should *not* do the same quote-fetching logic we're doing here

- Confirmed working:
  - [ ] BTC
  - [x] BCH
  - [x] ATOM
  - [ ] DOGE
  - [x] LTC
  - [ ] ETH
  - [x] AVAX

## Notice

<!-- Before submitting a pull request, please make sure you have answered the following: -->

- [x] Have you followed the guidelines in our [Contributing]('https://github.com/shapeshift/web/blob/develop/CONTRIBUTING.md) guide?
- [x] Have you checked to ensure there aren't other open [Pull Requests](https://github.com/shapeshift/web/pulls) for the same update/change?

## Pull Request Type

- [ ] :bug: Bug fix (Non-breaking Change: Fixes an issue)
- [ ] :hammer_and_wrench: Chore (Non-breaking Change: Doc updates, pkg upgrades, typos, etc..)
- [x] :nail_care: New Feature (Breaking/Non-breaking Change)

## Issue (if applicable)

N/A

## Risk

<!-----------------------------------------------------------------------------
Outline the scope of your changes and the risk associated with them. You must use your discretion as an engineer to determine the potential impact of your changes.

E.g. an upgrade to `hdwallet` or core state management would be considered higher risk, and might require a full regression test. UI or isolated view changes, or something behind a feature flag may have near zero risk. Small bug fixes might require testing isolated to the specific fix.
------------------------------------------------------------------------------>

None, isolated to savers

## Testing

<!-----------------------------------------------------------------------------
We treat every PR to be merged with the same scrutiny as if we were merging directly to production.

Your PR will not be merged if you do not complete the sections below for our engineering and operations teams to test.
------------------------------------------------------------------------------>

- Enable the savers flag
- Withdraw a percentage of your position that's not close to the max (can be user-input or a percent option)
- Wait for the Tx to be confirmed on-chain
- Reload the app, wait for the position to refresh, and ensure funds are deducted from your DeFi position and back in your wallet

### Engineering

<!-----------------------------------------------------------------------------
Include sufficient information here for an engineer to test your PR. This may include how to test locally, in a built environment, changes to infrastructure etc.
------------------------------------------------------------------------------>

☝🏽 

### Operations

<!-----------------------------------------------------------------------------
If your changes have a user-facing impact, describe how a non-technical QA team can functionally test your changes in a preview environment.

If they are not user-facing please describe how to test for any regressions that may occur.
------------------------------------------------------------------------------>

☝🏽 

## Screenshots (if applicable)

### BCH

<img width="361" alt="image" src="https://user-images.githubusercontent.com/17035424/213745959-6fa0005d-6464-46b6-8919-ac5c91a024fc.png">
<img width="518" alt="image" src="https://user-images.githubusercontent.com/17035424/213745929-aa8a3d71-69df-468e-b85e-4547ecc00163.png">
<img width="522" alt="image" src="https://user-images.githubusercontent.com/17035424/213745768-2f584c6f-4855-4834-a859-2b679c345bab.png">
<img width="536" alt="image" src="https://user-images.githubusercontent.com/17035424/213745071-289250cf-2bbb-489c-842d-d51fc9a066d4.png">
<img width="351" alt="image" src="https://user-images.githubusercontent.com/17035424/213761966-3ab64bdf-6483-4ce5-a10b-3c697b74eaa3.png">


### LTC

<img width="356" alt="image" src="https://user-images.githubusercontent.com/17035424/213762498-c6215c04-6844-4484-b858-11b8e5e099ed.png">
<img width="534" alt="image" src="https://user-images.githubusercontent.com/17035424/213762541-e9cdf610-862b-41aa-b93a-2dbfdcdbcf6b.png">
<img width="521" alt="image" src="https://user-images.githubusercontent.com/17035424/213762595-9eb69fa8-afd3-4fe7-a2f1-9824a4e560e2.png">
<img width="536" alt="image" src="https://user-images.githubusercontent.com/17035424/213762679-64a11924-ff54-49be-bb48-524a887612a3.png">
<img width="367" alt="image" src="https://user-images.githubusercontent.com/17035424/213765821-091597aa-6e5c-438f-b590-8d9ae49539f4.png">


### ATOM

<img width="418" alt="image" src="https://user-images.githubusercontent.com/17035424/213773591-e6ee4b23-94b0-42e4-bb15-c1c33db6cf03.png">
<img width="508" alt="image" src="https://user-images.githubusercontent.com/17035424/213773631-1ba0acca-2f82-4be8-9e2b-5abe451b1c40.png">
<img width="522" alt="image" src="https://user-images.githubusercontent.com/17035424/213773664-caa05764-20e9-4358-bc76-bb166b15ca84.png">
<img width="538" alt="image" src="https://user-images.githubusercontent.com/17035424/213773743-920a2cee-cc7d-461d-871f-09d6c6b7906c.png">
<img width="430" alt="image" src="https://user-images.githubusercontent.com/17035424/213773961-9abd5651-47fb-48d9-9733-5a2d54366363.png">

### AVAX

<img width="364" alt="image" src="https://user-images.githubusercontent.com/17035424/213786707-acbfb982-175c-4077-a5c6-604530c805c0.png">
<img width="529" alt="image" src="https://user-images.githubusercontent.com/17035424/213786733-919f36c3-4599-4d4a-8137-9fee20bc6291.png">
<img width="532" alt="image" src="https://user-images.githubusercontent.com/17035424/213786759-c7e2f64c-783a-419f-8ea5-aa4a6ab345ba.png">
<img width="547" alt="image" src="https://user-images.githubusercontent.com/17035424/213786811-a5b18c9f-ee66-4f3a-8f57-4c7e93a090d6.png">
<img width="355" alt="image" src="https://user-images.githubusercontent.com/17035424/213786969-2e47d2c4-f44a-4ebb-b81d-313da60d185f.png">

