### PR TITLE
fix(pendo): special-case handling for blank contentUrl files

### DIFF
--- a/src/plugins/pendo/agent/ajax.ts
+++ b/src/plugins/pendo/agent/ajax.ts
@@ -30,8 +30,10 @@ function getTransmissionData(this: PendoEnv, url: URL, body: BodyInit | undefine
 }
 
 async function filteredFetch(this: PendoEnv, url: string, init?: RequestInit): Promise<Response> {
+  init ??= {}
+
   const urlObj = new URL(url)
-  const dataObj = getTransmissionData.call(this, urlObj, init?.body ?? undefined)
+  const dataObj = getTransmissionData.call(this, urlObj, init.body ?? undefined)
 
   // Don't report agent errors because we probably caused them ourselves.
   if (dataObj?.error) {
@@ -41,7 +43,7 @@ async function filteredFetch(this: PendoEnv, url: string, init?: RequestInit): P
 
   // Throw if fetch isn't allowed.
   try {
-    filterRequest.call(this, urlObj, dataObj, init?.integrity)
+    Object.assign(init, filterRequest.call(this, urlObj, dataObj, init.integrity))
   } catch (e) {
     if (this.sealed) {
       moduleLogger.error(e, 'fetch failed filters')


### PR DESCRIPTION
## Description

Special-case handling to allow Pendo to fetch an otherwise unverifiable but blank file. Pendo's designer seems to have started adding this in certain guides as a `contentUrl` field. (Not sure why it started doing this now, but it's harmless -- if a bit of a pain to track down.)

## Notice

<!-- Before submitting a pull request, please make sure you have answered the following: -->

- [x] Have you followed the guidelines in our [Contributing]('https://github.com/shapeshift/web/blob/develop/CONTRIBUTING.md) guide?
- [x] Have you checked to ensure there aren't other open [Pull Requests](https://github.com/shapeshift/web/pulls) for the same update/change?

## Pull Request Type

- [x] :bug: Bug fix (Non-breaking Change: Fixes an issue)
- [ ] :hammer_and_wrench: Chore (Non-breaking Change: Doc updates, pkg upgrades, typos, etc..)
- [ ] :nail_care: New Feature (Breaking/Non-breaking Change)

## Risk

Low risk.

## Testing

<!-----------------------------------------------------------------------------
We treat every PR to be merged with the same scrutiny as if we were merging directly to production.

Your PR will not be merged if you do not complete the sections below for our engineering and operations teams to test.
------------------------------------------------------------------------------>

### Engineering

This error should go away:
![image](https://user-images.githubusercontent.com/645226/213344191-a3cad35a-dc36-4b21-a5f8-ac0ed35913f3.png)

### Operations

Please check that Pendo agent loads and submits analytics normally.