### PR TITLE
fix: unbreak lp opportunity fiat amounts

### DIFF
--- a/src/state/slices/opportunitiesSlice/selectors/lpSelectors.ts
+++ b/src/state/slices/opportunitiesSlice/selectors/lpSelectors.ts
@@ -279,9 +279,10 @@ export const selectAggregatedEarnUserLpOpportunities = createDeepEqualOutputSele
         underlyingToken1AmountCryptoBaseUnit,
         cryptoAmountPrecision: '',
         // TODO(gomes): use base unit as source of truth, conversions back and forth are unsafe
-        cryptoAmountBaseUnit: toBaseUnit(aggregatedLpAssetBalance, assets[lpId]?.precision ?? 0),
+        cryptoAmountBaseUnit: aggregatedLpAssetBalance,
         fiatAmount: bnOrZero(aggregatedLpAssetBalance)
           .times(marketDataPrice ?? '0')
+          .div(bn(10).pow(assets[lpId]?.precision ?? '0'))
           .toString(),
         icons: opportunityMetadata.underlyingAssetIds
           .map(assetId => assets[assetId]?.icon)


### PR DESCRIPTION
## Description

<!-- Please describe your changes -->
* fixes LP opportunity fiat amounts that were previously shown multiplied by a factor of 10^{asset_precision}

## Notice

<!-- Before submitting a pull request, please make sure you have answered the following: -->

- [x] Have you followed the guidelines in our [Contributing]('https://github.com/shapeshift/web/blob/develop/CONTRIBUTING.md) guide?
- [x] Have you checked to ensure there aren't other open [Pull Requests](https://github.com/shapeshift/web/pulls) for the same update/change?

## Pull Request Type

- [x] :bug: Bug fix (Non-breaking Change: Fixes an issue)
- [ ] :hammer_and_wrench: Chore (Non-breaking Change: Doc updates, pkg upgrades, typos, etc..)
- [ ] :nail_care: New Feature (Breaking/Non-breaking Change)

## Issue (if applicable)

<!-----------------------------------------------------------------------------
If applicable, please link to the github issue and put `closes #XXXX` in your comment to auto-close the issue that your PR fixes.
------------------------------------------------------------------------------>

closes #

## Risk
None
<!-----------------------------------------------------------------------------
Outline the scope of your changes and the risk associated with them. You must use your discretion as an engineer to determine the potential impact of your changes.

E.g. an upgrade to `hdwallet` or core state management would be considered higher risk, and might require a full regression test. UI or isolated view changes, or something behind a feature flag may have near zero risk. Small bug fixes might require testing isolated to the specific fix.
------------------------------------------------------------------------------>

## Testing

<!-----------------------------------------------------------------------------
We treat every PR to be merged with the same scrutiny as if we were merging directly to production.

Your PR will not be merged if you do not complete the sections below for our engineering and operations teams to test.
------------------------------------------------------------------------------>

### Engineering
* In both the prod and dev environments, start the application with the demo wallet attached. 
* Navigate to the defi overview page.
* Verify that the fiat balance shown for the ETH/FOX pool match 
<!-----------------------------------------------------------------------------
Include sufficient information here for an engineer to test your PR. This may include how to test locally, in a built environment, changes to infrastructure etc.
------------------------------------------------------------------------------>

### Operations
Same as above.
<!-----------------------------------------------------------------------------
If your changes have a user-facing impact, describe how a non-technical QA team can functionally test your changes in a preview environment.

If they are not user-facing please describe how to test for any regressions that may occur.
------------------------------------------------------------------------------>

## Screenshots (if applicable)
Current state of the defi overview page in the develop environment:
<img width="796" alt="Screenshot 2023-01-20 at 1 23 25 AM" src="https://user-images.githubusercontent.com/62026038/213650391-ffbdddce-6af2-455d-8ced-608db1bca8b9.png">


Current state of the defi overview page in the production environment:
<img width="794" alt="Screenshot 2023-01-20 at 1 23 41 AM" src="https://user-images.githubusercontent.com/62026038/213650473-0f628331-ac25-44a2-89b1-db99c9327cc5.png">


Defi overview page in local environment with fix applied:
<img width="792" alt="Screenshot 2023-01-20 at 1 23 34 AM" src="https://user-images.githubusercontent.com/62026038/213650591-67a5cbc5-661f-40a6-b46c-f6d901e65424.png">
