### PR TITLE
feat: cleanup log spew

### DIFF
--- a/src/features/defi/contexts/DefiManagerProvider/DefiManagerProvider.tsx
+++ b/src/features/defi/contexts/DefiManagerProvider/DefiManagerProvider.tsx
@@ -25,6 +25,8 @@ export function DefiManagerProvider({ children }: DefiManagerProviderProps) {
   const { type, provider } = query
 
   const renderModules = useMemo(() => {
+    if (!provider) return null
+
     return Object.values(DefiProvider).map(defiProvider => {
       const maybeModules = getDefiProviderModulesResolvers(provider as DefiProvider)
 

--- a/src/features/defi/contexts/YearnProvider/YearnProvider.tsx
+++ b/src/features/defi/contexts/YearnProvider/YearnProvider.tsx
@@ -34,9 +34,10 @@ export const YearnProvider: React.FC<PropsWithChildren> = ({ children }) => {
     ;(async () => {
       try {
         if (!Yearn) {
-          throw new Error(
+          moduleLogger.debug(
             'Yearn feature flag disabled, not initializing Yearn @yfi/sdk opportunities',
           )
+          return
         }
 
         if (!chainAdapterManager.has(KnownChainIds.EthereumMainnet)) return

--- a/src/state/slices/opportunitiesSlice/resolvers/foxFarming/index.ts
+++ b/src/state/slices/opportunitiesSlice/resolvers/foxFarming/index.ts
@@ -1,4 +1,4 @@
-import { ethAssetId, foxAssetId, fromAccountId, fromAssetId } from '@shapeshiftoss/caip'
+import { ethAssetId, ethChainId, foxAssetId, fromAccountId, fromAssetId } from '@shapeshiftoss/caip'
 import type { MarketData } from '@shapeshiftoss/types'
 import { HistoryTimeframe } from '@shapeshiftoss/types'
 import { Fetcher, Token } from '@uniswap/sdk'
@@ -235,6 +235,11 @@ export const foxFarmingLpUserDataResolver = ({
   accountId,
   reduxApi,
 }: OpportunityUserDataResolverInput): Promise<void> => {
+  const { chainId: accountChainId } = fromAccountId(accountId)
+  if (accountChainId !== ethChainId)
+    throw new Error(
+      `No-op. Won't fetch ETH/FOX farming userStakingData for chainId: ${accountChainId}`,
+    )
   const { getState } = reduxApi
   const state: ReduxState = getState() as any
   const portfolioLoadingStatusGranular = selectPortfolioLoadingStatusGranular(state)
@@ -262,6 +267,11 @@ export const foxFarmingStakingUserDataResolver = async ({
   accountId,
   reduxApi,
 }: OpportunityUserDataResolverInput): Promise<{ data: GetOpportunityUserStakingDataOutput }> => {
+  const { chainId: accountChainId } = fromAccountId(accountId)
+  if (accountChainId !== ethChainId)
+    throw new Error(
+      `No-op. Won't fetch ETH/FOX farming userStakingData for chainId: ${accountChainId}`,
+    )
   const { getState } = reduxApi
   const state: any = getState() // ReduxState causes circular dependency
   const lpTokenMarketData: MarketData = selectMarketDataById(state, foxEthLpAssetId)

--- a/src/state/slices/opportunitiesSlice/resolvers/foxy/index.ts
+++ b/src/state/slices/opportunitiesSlice/resolvers/foxy/index.ts
@@ -1,5 +1,5 @@
 import type { ToAssetIdArgs } from '@shapeshiftoss/caip'
-import { ethChainId, foxyAssetId, fromAssetId, toAssetId } from '@shapeshiftoss/caip'
+import { ethChainId, foxyAssetId, fromAccountId, fromAssetId, toAssetId } from '@shapeshiftoss/caip'
 import { bnOrZero } from '@shapeshiftoss/investor-foxy'
 import { DefiProvider, DefiType } from 'features/defi/contexts/DefiManagerProvider/DefiCommon'
 import { foxyApi } from 'state/apis/foxy/foxyApi'
@@ -97,6 +97,10 @@ export const foxyStakingOpportunitiesUserDataResolver = async ({
   reduxApi,
   opportunityIds,
 }: OpportunitiesUserDataResolverInput): Promise<{ data: GetOpportunityUserStakingDataOutput }> => {
+  const { chainId: accountChainId } = fromAccountId(accountId)
+  if (accountChainId !== ethChainId)
+    throw new Error(`No-op. Won't fetch FOXy userStakingData for chainId: ${accountChainId}`)
+
   const { getState } = reduxApi
   const state: any = getState() // ReduxState causes circular dependency
 


### PR DESCRIPTION
## Description

Kills three birds with one stone:

- Doesn't throw on Yearn feature flag disabled. That's a developers' concern only, so outputs a debug log and early returns instead of throwing
- Handles `query.provider` not being defined in the context of `<DefiManagerProvider />` which made us loop over all providers in `renderModules` and eventually return `undefined`. The reason for that is as a provider, it's not only "rendered" when in the context of a DeFi module, but is rather *always*  rendered
- Adds missing early bail safety factor based on chainId checks for resolvers

## Notice

<!-- Before submitting a pull request, please make sure you have answered the following: -->

- [x] Have you followed the guidelines in our [Contributing]('https://github.com/shapeshift/web/blob/develop/CONTRIBUTING.md) guide?
- [x] Have you checked to ensure there aren't other open [Pull Requests](https://github.com/shapeshift/web/pulls) for the same update/change?

## Pull Request Type

- [ ] :bug: Bug fix (Non-breaking Change: Fixes an issue)
- [ ] :hammer_and_wrench: Chore (Non-breaking Change: Doc updates, pkg upgrades, typos, etc..)
- [x] :nail_care: New Feature (Breaking/Non-breaking Change)

## Issue (if applicable)

N/A

## Risk

<!-----------------------------------------------------------------------------
Outline the scope of your changes and the risk associated with them. You must use your discretion as an engineer to determine the potential impact of your changes.

E.g. an upgrade to `hdwallet` or core state management would be considered higher risk, and might require a full regression test. UI or isolated view changes, or something behind a feature flag may have near zero risk. Small bug fixes might require testing isolated to the specific fix.
------------------------------------------------------------------------------>

None, though as a stretch this effectively touches the `<DefiManagerProvider />` logic, ensure DeFi modals still open

## Testing

<!-----------------------------------------------------------------------------
We treat every PR to be merged with the same scrutiny as if we were merging directly to production.

Your PR will not be merged if you do not complete the sections below for our engineering and operations teams to test.
------------------------------------------------------------------------------>

- DeFi modals still open
- Console is happier with debug level
- Console is even happier with error/warn/info levels

### Engineering

<!-----------------------------------------------------------------------------
Include sufficient information here for an engineer to test your PR. This may include how to test locally, in a built environment, changes to infrastructure etc.
------------------------------------------------------------------------------>

- ☝🏽  

### Operations

<!-----------------------------------------------------------------------------
If your changes have a user-facing impact, describe how a non-technical QA team can functionally test your changes in a preview environment.

If they are not user-facing please describe how to test for any regressions that may occur.
------------------------------------------------------------------------------>

- None

## Screenshots (if applicable)
