### PR TITLE
feat(savers): pass dust amount / network fee in withdraw routes

### DIFF
--- a/src/features/defi/providers/thorchain-savers/components/ThorchainSaversManager/Withdraw/WithdrawCommon.ts
+++ b/src/features/defi/providers/thorchain-savers/components/ThorchainSaversManager/Withdraw/WithdrawCommon.ts
@@ -9,6 +9,8 @@ type ThorchainSaversWithdrawValues = WithdrawValues &
   EstimatedGas & {
     txStatus: string
     usedGasFee: string
+    dustAmountCryptoPrecision: string
+    withdrawFeeCryptoBaseUnit: string
   }
 
 export type ThorchainSaversWithdrawState = {

--- a/src/features/defi/providers/thorchain-savers/components/ThorchainSaversManager/Withdraw/WithdrawCommon.ts
+++ b/src/features/defi/providers/thorchain-savers/components/ThorchainSaversManager/Withdraw/WithdrawCommon.ts
@@ -9,7 +9,7 @@ type ThorchainSaversWithdrawValues = WithdrawValues &
   EstimatedGas & {
     txStatus: string
     usedGasFee: string
-    dustAmountCryptoPrecision: string
+    dustAmountCryptoBaseUnit: string
     withdrawFeeCryptoBaseUnit: string
   }
 

--- a/src/features/defi/providers/thorchain-savers/components/ThorchainSaversManager/Withdraw/WithdrawReducer.ts
+++ b/src/features/defi/providers/thorchain-savers/components/ThorchainSaversManager/Withdraw/WithdrawReducer.ts
@@ -13,7 +13,7 @@ export const initialState: ThorchainSaversWithdrawState = {
     slippage: '',
     txStatus: 'pending',
     usedGasFee: '',
-    dustAmountCryptoPrecision: '',
+    dustAmountCryptoBaseUnit: '',
     withdrawFeeCryptoBaseUnit: '',
   },
 }

--- a/src/features/defi/providers/thorchain-savers/components/ThorchainSaversManager/Withdraw/WithdrawReducer.ts
+++ b/src/features/defi/providers/thorchain-savers/components/ThorchainSaversManager/Withdraw/WithdrawReducer.ts
@@ -13,6 +13,8 @@ export const initialState: ThorchainSaversWithdrawState = {
     slippage: '',
     txStatus: 'pending',
     usedGasFee: '',
+    dustAmountCryptoPrecision: '',
+    withdrawFeeCryptoBaseUnit: '',
   },
 }
 

--- a/src/features/defi/providers/thorchain-savers/components/ThorchainSaversManager/Withdraw/components/Confirm.tsx
+++ b/src/features/defi/providers/thorchain-savers/components/ThorchainSaversManager/Withdraw/components/Confirm.tsx
@@ -34,7 +34,6 @@ import {
   getThorchainSaversPosition,
   getThorchainSaversWithdrawQuote,
   getWithdrawBps,
-  THOR_PRECISION,
   toThorBaseUnit,
 } from 'state/slices/opportunitiesSlice/resolvers/thorchainsavers/utils'
 import { serializeUserStakingId, toOpportunityId } from 'state/slices/opportunitiesSlice/utils'
@@ -168,11 +167,10 @@ export const Confirm: React.FC<ConfirmProps> = ({ accountId, onNext }) => {
       const { dust_amount, expected_amount_out } = quote
 
       setWithdrawFeeCryptoBaseUnit(
-        amountCryptoThorBaseUnit
-          .minus(expected_amount_out)
-          .div(bn(10).pow(THOR_PRECISION))
-          .times(bn(10).pow(asset.precision))
-          .toFixed(),
+        toBaseUnit(
+          fromThorBaseUnit(amountCryptoThorBaseUnit.minus(expected_amount_out)),
+          asset.precision,
+        ),
       )
       setDustAmountCryptoBaseUnit(
         bnOrZero(toBaseUnit(fromThorBaseUnit(dust_amount), asset.precision)).toFixed(
@@ -232,11 +230,12 @@ export const Confirm: React.FC<ConfirmProps> = ({ accountId, onNext }) => {
       valueCryptoBaseUnit: amountCryptoBaseUnit,
       asset,
     })
-    const withdrawFee = amountCryptoThorBaseUnit
-      .minus(expected_amount_out)
-      .div(bn(10).pow(asset.precision))
-
-    setWithdrawFeeCryptoBaseUnit(withdrawFee.toFixed())
+    setWithdrawFeeCryptoBaseUnit(
+      toBaseUnit(
+        fromThorBaseUnit(amountCryptoThorBaseUnit.minus(expected_amount_out)),
+        asset.precision,
+      ),
+    )
 
     if (!quote) throw new Error('Cannot get THORCHain savers withdraw quote')
 

--- a/src/features/defi/providers/thorchain-savers/components/ThorchainSaversManager/Withdraw/components/Status.tsx
+++ b/src/features/defi/providers/thorchain-savers/components/ThorchainSaversManager/Withdraw/components/Status.tsx
@@ -159,7 +159,7 @@ export const Status = () => {
                     : state.withdraw.usedGasFee,
                 )
                   .div(bn(10).pow(asset.precision))
-                  .toFixed(5)}
+                  .toFixed()}
                 symbol={asset.symbol}
               />
             </Box>

--- a/src/features/defi/providers/thorchain-savers/components/ThorchainSaversManager/Withdraw/components/Status.tsx
+++ b/src/features/defi/providers/thorchain-savers/components/ThorchainSaversManager/Withdraw/components/Status.tsx
@@ -39,7 +39,7 @@ export const Status = () => {
   const feeAssetId = assetId
 
   const asset = useAppSelector(state => selectAssetById(state, feeAssetId ?? ''))
-  const feeMarketData = useAppSelector(state => selectMarketDataById(state, feeAssetId ?? ''))
+  const marketData = useAppSelector(state => selectMarketDataById(state, feeAssetId ?? ''))
 
   const accountId = useAppSelector(state => selectFirstAccountIdByChainId(state, chainId))
   const userAddress = useMemo(() => accountId && fromAccountId(accountId).account, [accountId])
@@ -148,8 +148,8 @@ export const Status = () => {
                     : state.withdraw.usedGasFee,
                 )
                   .div(bn(10).pow(asset.precision))
-                  .times(feeMarketData.price)
-                  .toFixed(2)}
+                  .times(marketData.price)
+                  .toFixed()}
               />
               <Amount.Crypto
                 color='gray.500'
@@ -173,8 +173,20 @@ export const Status = () => {
           </Row.Label>
           <Row.Value>
             <Box textAlign='right'>
-              <Amount.Fiat fontWeight='bold' value={state.withdraw.dustAmountCryptoPrecision} />
-              <Amount.Crypto color='gray.500' value='0' symbol={asset.symbol} />
+              <Amount.Fiat
+                fontWeight='bold'
+                value={bnOrZero(state.withdraw.dustAmountCryptoBaseUnit)
+                  .div(bn(10).pow(asset.precision))
+                  .times(marketData.price)
+                  .toFixed()}
+              />
+              <Amount.Crypto
+                color='gray.500'
+                value={bnOrZero(state.withdraw.dustAmountCryptoBaseUnit)
+                  .div(bn(10).pow(asset.precision))
+                  .toFixed()}
+                symbol={asset.symbol}
+              />
             </Box>
           </Row.Value>
         </Row>

--- a/src/features/defi/providers/thorchain-savers/components/ThorchainSaversManager/Withdraw/components/Status.tsx
+++ b/src/features/defi/providers/thorchain-savers/components/ThorchainSaversManager/Withdraw/components/Status.tsx
@@ -142,22 +142,14 @@ export const Status = () => {
             <Box textAlign='right'>
               <Amount.Fiat
                 fontWeight='bold'
-                value={bnOrZero(
-                  state.withdraw.txStatus === 'pending'
-                    ? state.withdraw.withdrawFeeCryptoBaseUnit
-                    : state.withdraw.usedGasFee,
-                )
+                value={bnOrZero(state.withdraw.withdrawFeeCryptoBaseUnit)
                   .div(bn(10).pow(asset.precision))
                   .times(marketData.price)
                   .toFixed()}
               />
               <Amount.Crypto
                 color='gray.500'
-                value={bnOrZero(
-                  state.withdraw.txStatus === 'pending'
-                    ? state.withdraw.withdrawFeeCryptoBaseUnit
-                    : state.withdraw.usedGasFee,
-                )
+                value={bnOrZero(state.withdraw.withdrawFeeCryptoBaseUnit)
                   .div(bn(10).pow(asset.precision))
                   .toFixed()}
                 symbol={asset.symbol}

--- a/src/features/defi/providers/thorchain-savers/components/ThorchainSaversManager/Withdraw/components/Status.tsx
+++ b/src/features/defi/providers/thorchain-savers/components/ThorchainSaversManager/Withdraw/components/Status.tsx
@@ -144,7 +144,7 @@ export const Status = () => {
                 fontWeight='bold'
                 value={bnOrZero(
                   state.withdraw.txStatus === 'pending'
-                    ? state.withdraw.estimatedGasCrypto
+                    ? state.withdraw.withdrawFeeCryptoBaseUnit
                     : state.withdraw.usedGasFee,
                 )
                   .div(bn(10).pow(asset.precision))
@@ -155,7 +155,7 @@ export const Status = () => {
                 color='gray.500'
                 value={bnOrZero(
                   state.withdraw.txStatus === 'pending'
-                    ? state.withdraw.estimatedGasCrypto
+                    ? state.withdraw.withdrawFeeCryptoBaseUnit
                     : state.withdraw.usedGasFee,
                 )
                   .div(bn(10).pow(asset.precision))
@@ -173,7 +173,7 @@ export const Status = () => {
           </Row.Label>
           <Row.Value>
             <Box textAlign='right'>
-              <Amount.Fiat fontWeight='bold' value='0' />
+              <Amount.Fiat fontWeight='bold' value={state.withdraw.dustAmountCryptoPrecision} />
               <Amount.Crypto color='gray.500' value='0' symbol={asset.symbol} />
             </Box>
           </Row.Value>

--- a/src/state/slices/opportunitiesSlice/resolvers/thorchainsavers/utils.ts
+++ b/src/state/slices/opportunitiesSlice/resolvers/thorchainsavers/utils.ts
@@ -31,7 +31,7 @@ import type {
   ThorchainSaversWithdrawQuoteResponseSuccess,
 } from './types'
 
-export const THOR_PRECISION = '8'
+const THOR_PRECISION = '8'
 const BASE_BPS_POINTS = '10000'
 
 // The minimum amount to be sent both for deposit and withdraws


### PR DESCRIPTION
## Description

Passes down the dust amount and network fee from the final quote as withdraw route params, so that we can consume them at status step.

## Notice

<!-- Before submitting a pull request, please make sure you have answered the following: -->

- [x] Have you followed the guidelines in our [Contributing]('https://github.com/shapeshift/web/blob/develop/CONTRIBUTING.md) guide?
- [x] Have you checked to ensure there aren't other open [Pull Requests](https://github.com/shapeshift/web/pulls) for the same update/change?

## Pull Request Type

- [ ] :bug: Bug fix (Non-breaking Change: Fixes an issue)
- [ ] :hammer_and_wrench: Chore (Non-breaking Change: Doc updates, pkg upgrades, typos, etc..)
- [x] :nail_care: New Feature (Breaking/Non-breaking Change)

## Issue (if applicable)

N/A

## Risk

<!-----------------------------------------------------------------------------
Outline the scope of your changes and the risk associated with them. You must use your discretion as an engineer to determine the potential impact of your changes.

E.g. an upgrade to `hdwallet` or core state management would be considered higher risk, and might require a full regression test. UI or isolated view changes, or something behind a feature flag may have near zero risk. Small bug fixes might require testing isolated to the specific fix.
------------------------------------------------------------------------------>

## Testing

<!-----------------------------------------------------------------------------
We treat every PR to be merged with the same scrutiny as if we were merging directly to production.

Your PR will not be merged if you do not complete the sections below for our engineering and operations teams to test.
------------------------------------------------------------------------------>

- Enable the savers flag
- Do a withdraw up to the sign and broadcast step
- Click sign and broadcast, and confirm the values are matching the ones at confirm step

### Engineering

<!-----------------------------------------------------------------------------
Include sufficient information here for an engineer to test your PR. This may include how to test locally, in a built environment, changes to infrastructure etc.
------------------------------------------------------------------------------>

- ☝🏽 

### Operations

<!-----------------------------------------------------------------------------
If your changes have a user-facing impact, describe how a non-technical QA team can functionally test your changes in a preview environment.

If they are not user-facing please describe how to test for any regressions that may occur.
------------------------------------------------------------------------------>

- ☝🏽 

## Screenshots (if applicable)

<img width="545" alt="image" src="https://user-images.githubusercontent.com/17035424/213858545-21324ce8-07a7-424a-8ba7-4a412756990e.png">
<img width="522" alt="image" src="https://user-images.githubusercontent.com/17035424/213858555-0b3c266c-aa1e-40bc-8a4c-154d795389af.png">
