### PR TITLE
feat(savers): maxish UTXO deposits / mempool seen safety

### DIFF
--- a/src/features/defi/providers/thorchain-savers/components/ThorchainSaversManager/Deposit/components/Confirm.tsx
+++ b/src/features/defi/providers/thorchain-savers/components/ThorchainSaversManager/Deposit/components/Confirm.tsx
@@ -42,7 +42,7 @@ import {
   selectAssetById,
   selectBIP44ParamsByAccountId,
   selectMarketDataById,
-  selectPortfolioCryptoHumanBalanceByFilter,
+  selectPortfolioCryptoBalanceByFilter,
   selectSelectedCurrency,
 } from 'state/slices/selectors'
 import { useAppDispatch, useAppSelector } from 'state/store'
@@ -91,8 +91,9 @@ export const Confirm: React.FC<ConfirmProps> = ({ accountId, onNext }) => {
     () => ({ assetId: asset?.assetId, accountId }),
     [accountId, asset?.assetId],
   )
-  const assetBalance = useAppSelector(s =>
-    selectPortfolioCryptoHumanBalanceByFilter(s, assetBalanceFilter),
+
+  const assetBalanceCryptoBaseUnit = useAppSelector(s =>
+    selectPortfolioCryptoBalanceByFilter(s, assetBalanceFilter),
   )
 
   const selectedCurrency = useAppSelector(selectSelectedCurrency)
@@ -160,54 +161,77 @@ export const Confirm: React.FC<ConfirmProps> = ({ accountId, onNext }) => {
     }
   }, [accountId, asset, state?.deposit.cryptoAmount])
 
-  const getDepositInput: () => Promise<SendInput | undefined> = useCallback(async () => {
-    if (!(accountId && assetId)) return
-    if (!state?.deposit.cryptoAmount) {
-      throw new Error('Cannot send 0-value THORCHain savers Tx')
-    }
+  const getDepositInput: (params: { isRetry: boolean }) => Promise<SendInput | undefined> =
+    useCallback(
+      async ({ isRetry = false }) => {
+        if (!(accountId && assetId && assetBalanceCryptoBaseUnit)) return
+        if (!state?.deposit.cryptoAmount) {
+          throw new Error('Cannot send 0-value THORCHain savers Tx')
+        }
 
-    try {
-      const estimatedFees = await estimateFees(await getEstimateFeesArgs())
-      const amountCryptoBaseUnit = bnOrZero(state.deposit.cryptoAmount).times(
-        bn(10).pow(asset.precision),
-      )
-      const quote = await getThorchainSaversDepositQuote({ asset, amountCryptoBaseUnit })
+        try {
+          const estimatedFees = await estimateFees(await getEstimateFeesArgs())
+          const amountCryptoBaseUnit = bnOrZero(state.deposit.cryptoAmount).times(
+            bn(10).pow(asset.precision),
+          )
+          const quote = await getThorchainSaversDepositQuote({ asset, amountCryptoBaseUnit })
 
-      if (isUtxoChainId(chainId) && !maybeFromUTXOAccountAddress) {
-        throw new Error('Account address required to deposit in THORChain savers')
-      }
+          let maybeGasDeductedCryptoAmountCryptoPrecision = ''
+          if (isUtxoChainId(chainId)) {
+            if (!maybeFromUTXOAccountAddress) {
+              throw new Error('Account address required to deposit in THORChain savers')
+            }
 
-      const sendInput: SendInput = {
-        cryptoAmount: state.deposit.cryptoAmount,
-        asset,
-        to: quote.inbound_address,
-        from: maybeFromUTXOAccountAddress,
-        sendMax: false,
+            if (isRetry) {
+              const fastFees = estimatedFees.fast.txFee
+              const needsFeeDeduction = bnOrZero(state.deposit.cryptoAmount)
+                .times(bn(10).pow(asset.precision))
+                .plus(fastFees)
+                .gte(assetBalanceCryptoBaseUnit)
+
+              if (needsFeeDeduction)
+                // We tend to overestimate so that SHOULD be safe but this is both
+                // a safety factor as well as ensuring we keep a bit of gas away for another Tx
+                maybeGasDeductedCryptoAmountCryptoPrecision = bnOrZero(state.deposit.cryptoAmount)
+                  .minus(bn(fastFees).times(3).div(bn(10).pow(asset.precision)))
+                  .toFixed()
+            }
+          }
+
+          const sendInput: SendInput = {
+            cryptoAmount: maybeGasDeductedCryptoAmountCryptoPrecision ?? state.deposit.cryptoAmount,
+            asset,
+            to: quote.inbound_address,
+            from: maybeFromUTXOAccountAddress,
+            sendMax: false,
+            accountId,
+            amountFieldError: '',
+            cryptoSymbol: asset.symbol,
+            estimatedFees,
+            feeType: FeeDataKey.Fast,
+            fiatAmount: '',
+            fiatSymbol: selectedCurrency,
+            vanityAddress: '',
+            input: quote.inbound_address,
+          }
+
+          return sendInput
+        } catch (e) {
+          moduleLogger.error({ fn: 'getDepositInput', e }, 'Error building THORChain savers Tx')
+        }
+      },
+      [
         accountId,
-        amountFieldError: '',
-        cryptoSymbol: asset.symbol,
-        estimatedFees,
-        feeType: FeeDataKey.Fast,
-        fiatAmount: '',
-        fiatSymbol: selectedCurrency,
-        vanityAddress: '',
-        input: quote.inbound_address,
-      }
-
-      return sendInput
-    } catch (e) {
-      moduleLogger.error({ fn: 'getDepositInput', e }, 'Error building THORChain savers Tx')
-    }
-  }, [
-    accountId,
-    assetId,
-    state?.deposit.cryptoAmount,
-    getEstimateFeesArgs,
-    asset,
-    chainId,
-    maybeFromUTXOAccountAddress,
-    selectedCurrency,
-  ])
+        assetId,
+        state?.deposit.cryptoAmount,
+        getEstimateFeesArgs,
+        asset,
+        chainId,
+        maybeFromUTXOAccountAddress,
+        selectedCurrency,
+        assetBalanceCryptoBaseUnit,
+      ],
+    )
 
   const getPreDepositInput: () => Promise<SendInput | undefined> = useCallback(async () => {
     if (!(accountId && assetId && state?.deposit?.estimatedGasCrypto)) return
@@ -268,7 +292,7 @@ export const Confirm: React.FC<ConfirmProps> = ({ accountId, onNext }) => {
     //
     // For both re/deposit flows, we will possibly need a pre-Tx to populate their highest UTXO/previously deposited from address with enough value
 
-    const depositInput = await getDepositInput()
+    const depositInput = await getDepositInput({ isRetry: false })
     if (!depositInput) throw new Error('Error building send input')
     if (!walletState?.wallet) throw new Error('Wallet is required')
 
@@ -291,13 +315,18 @@ export const Confirm: React.FC<ConfirmProps> = ({ accountId, onNext }) => {
       return handleSend({
         sendInput: preDepositInput,
         wallet: walletState.wallet!,
-      }).then(() =>
+      }).then(async () => {
+        // Safety factor for the Tx to be seen in the mempool
+        await new Promise(resolve => setTimeout(resolve, 5000))
+        // We get a fresh deposit input, since amounts close to 100% balance might not work anymore after a pre-tx
+        const depositInput = await getDepositInput({ isRetry: true })
+        if (!depositInput) throw new Error('Error building send input')
         // 3. Sign and broadcast the depooosit Tx again
-        handleSend({
+        return handleSend({
           sendInput: depositInput,
           wallet: walletState.wallet!,
-        }),
-      )
+        })
+      })
     })
 
     return txId
@@ -357,7 +386,7 @@ export const Confirm: React.FC<ConfirmProps> = ({ accountId, onNext }) => {
         throw new Error(`THORChain pool halted for assetId: ${assetId}`)
       }
 
-      const depositInput = await getDepositInput()
+      const depositInput = await getDepositInput({ isRetry: false })
       if (!depositInput) throw new Error('Error building send input')
 
       const maybeTxId = await handleMultiTxSend()
@@ -412,10 +441,10 @@ export const Confirm: React.FC<ConfirmProps> = ({ accountId, onNext }) => {
 
   const hasEnoughBalanceForGas = useMemo(
     () =>
-      bnOrZero(assetBalance)
-        .minus(bnOrZero(state?.deposit.estimatedGasCrypto).div(bn(10).pow(asset.precision)))
+      bnOrZero(assetBalanceCryptoBaseUnit)
+        .minus(state?.deposit.estimatedGasCrypto ?? 0)
         .gte(0),
-    [assetBalance, state?.deposit.estimatedGasCrypto, asset.precision],
+    [assetBalanceCryptoBaseUnit, state?.deposit.estimatedGasCrypto],
   )
 
   if (!state || !contextDispatch) return null


### PR DESCRIPTION
## Description

Adds missing savers safety:

- Deducts gas from maxish sends when doing a reconciliation Tx - uses gas * 3 as safety factor and to keep gas away for future Txs
- Awaits a `setTimeout` of 5000ms to ensure the reconciliation Tx is seen on the mempool before the second gets broadcasted

## Notice

<!-- Before submitting a pull request, please make sure you have answered the following: -->

- [x] Have you followed the guidelines in our [Contributing]('https://github.com/shapeshift/web/blob/develop/CONTRIBUTING.md) guide?
- [x] Have you checked to ensure there aren't other open [Pull Requests](https://github.com/shapeshift/web/pulls) for the same update/change?

## Pull Request Type

- [ ] :bug: Bug fix (Non-breaking Change: Fixes an issue)
- [ ] :hammer_and_wrench: Chore (Non-breaking Change: Doc updates, pkg upgrades, typos, etc..)
- [x] :nail_care: New Feature (Breaking/Non-breaking Change)

## Issue (if applicable)

N/A

## Risk

<!-----------------------------------------------------------------------------
Outline the scope of your changes and the risk associated with them. You must use your discretion as an engineer to determine the potential impact of your changes.

E.g. an upgrade to `hdwallet` or core state management would be considered higher risk, and might require a full regression test. UI or isolated view changes, or something behind a feature flag may have near zero risk. Small bug fixes might require testing isolated to the specific fix.
------------------------------------------------------------------------------>

This handles maxish sends, but smallish ones could be rugged if I got this wrong

## Testing

<!-----------------------------------------------------------------------------
We treat every PR to be merged with the same scrutiny as if we were merging directly to production.

Your PR will not be merged if you do not complete the sections below for our engineering and operations teams to test.
------------------------------------------------------------------------------>

- Deposit around max of any UTXO (max, or anything between max and the `fastFee` e.g 1 sat less than max)
- Ensure the deposit goes through and some dust is returned to you for future Txs

### Engineering

<!-----------------------------------------------------------------------------
Include sufficient information here for an engineer to test your PR. This may include how to test locally, in a built environment, changes to infrastructure etc.
------------------------------------------------------------------------------>

- ☝🏽 

### Operations

<!-----------------------------------------------------------------------------
If your changes have a user-facing impact, describe how a non-technical QA team can functionally test your changes in a preview environment.

If they are not user-facing please describe how to test for any regressions that may occur.
------------------------------------------------------------------------------>

- ☝🏽 

## Screenshots (if applicable)
