### PR TITLE
feat(savers): don't sendMax UTXO sendMaxes

### DIFF
--- a/src/components/Modals/Send/utils.ts
+++ b/src/components/Modals/Send/utils.ts
@@ -27,6 +27,7 @@ import type { SendInput } from './Form'
 export type EstimateFeesInput = {
   cryptoAmount: string
   asset: Asset
+  from?: string
   to: string
   sendMax: boolean
   accountId: string
@@ -38,6 +39,7 @@ const moduleLogger = logger.child({ namespace: ['Modals', 'Send', 'utils'] })
 export const estimateFees = ({
   cryptoAmount,
   asset,
+  from,
   to,
   sendMax,
   accountId,
@@ -69,7 +71,7 @@ export const estimateFees = ({
       return (adapter as unknown as UtxoBaseAdapter<UtxoChainId>).getFeeData({
         to,
         value,
-        chainSpecific: { pubkey: account },
+        chainSpecific: { from, pubkey: account },
         sendMax,
       })
     }

--- a/src/features/defi/providers/thorchain-savers/components/ThorchainSaversManager/Deposit/components/Confirm.tsx
+++ b/src/features/defi/providers/thorchain-savers/components/ThorchainSaversManager/Deposit/components/Confirm.tsx
@@ -56,7 +56,11 @@ const moduleLogger = logger.child({ namespace: ['ThorchainSaversDeposit:Confirm'
 type ConfirmProps = { accountId: AccountId | undefined } & StepComponentProps
 
 // The amount of Txs we want to keep gas away for
-const TXS_BUFFER = 2
+// Estimated miner fees are approximative since there might be a reconciliation Tx
+// and an actual savers Tx with different fees, and we're doubling the fees
+// So the actual buffer is at best 3 Txs (4 -1 Tx), at worst 2 Txs (4 - 2 Txs)
+// Or even a bit less
+const TXS_BUFFER = 8
 
 export const Confirm: React.FC<ConfirmProps> = ({ accountId, onNext }) => {
   const [depositFeeCryptoBaseUnit, setDepositFeeCryptoBaseUnit] = useState<string>('')

--- a/src/features/defi/providers/thorchain-savers/components/ThorchainSaversManager/Deposit/components/Confirm.tsx
+++ b/src/features/defi/providers/thorchain-savers/components/ThorchainSaversManager/Deposit/components/Confirm.tsx
@@ -155,11 +155,11 @@ export const Confirm: React.FC<ConfirmProps> = ({ accountId, onNext }) => {
       cryptoAmount: state.deposit.cryptoAmount,
       asset,
       to: quote.inbound_address,
-      sendMax: Boolean(state?.deposit.sendMax),
+      sendMax: Boolean(!isUtxoChainId(chainId) && state?.deposit.sendMax),
       accountId,
       contractAddress: '',
     }
-  }, [accountId, asset, state?.deposit.cryptoAmount, state?.deposit.sendMax])
+  }, [accountId, asset, chainId, state?.deposit.cryptoAmount, state?.deposit.sendMax])
 
   const getDepositInput: (params: { isRetry: boolean }) => Promise<SendInput | undefined> =
     useCallback(
@@ -203,7 +203,7 @@ export const Confirm: React.FC<ConfirmProps> = ({ accountId, onNext }) => {
             asset,
             to: quote.inbound_address,
             from: maybeFromUTXOAccountAddress,
-            sendMax: Boolean(state?.deposit.sendMax),
+            sendMax: Boolean(!isUtxoChainId(chainId) && state?.deposit.sendMax),
             accountId,
             amountFieldError: '',
             cryptoSymbol: asset.symbol,

--- a/src/features/defi/providers/thorchain-savers/components/ThorchainSaversManager/Deposit/components/Confirm.tsx
+++ b/src/features/defi/providers/thorchain-savers/components/ThorchainSaversManager/Deposit/components/Confirm.tsx
@@ -2,7 +2,6 @@ import { Alert, AlertIcon, Box, Stack, useToast } from '@chakra-ui/react'
 import type { Asset } from '@shapeshiftoss/asset-service'
 import type { AccountId } from '@shapeshiftoss/caip'
 import { bchChainId, fromAccountId, toAssetId } from '@shapeshiftoss/caip'
-import type { FeeData, FeeDataEstimate, UtxoChainId } from '@shapeshiftoss/chain-adapters'
 import { FeeDataKey } from '@shapeshiftoss/chain-adapters'
 import { supportsETH } from '@shapeshiftoss/hdwallet-core'
 import { SwapperName } from '@shapeshiftoss/swapper/dist/api'
@@ -56,7 +55,7 @@ const moduleLogger = logger.child({ namespace: ['ThorchainSaversDeposit:Confirm'
 type ConfirmProps = { accountId: AccountId | undefined } & StepComponentProps
 
 // The amount of Txs we want to keep gas away for
-const TXS_BUFFER = 2
+const TXS_BUFFER = 4
 
 export const Confirm: React.FC<ConfirmProps> = ({ accountId, onNext }) => {
   const [depositFeeCryptoBaseUnit, setDepositFeeCryptoBaseUnit] = useState<string>('')
@@ -183,25 +182,7 @@ export const Confirm: React.FC<ConfirmProps> = ({ accountId, onNext }) => {
     }
 
     try {
-      // Estimated fees tend to produce too low fees on e.g Dogecoin
-      // Since UTXOs are fairly cheap, we *2 the fees to ensure the Txs are not stuck in the mempool
-      const estimatedFees = Object.fromEntries(
-        Object.entries(await estimateFees(await getEstimateFeesArgs())).map(
-          ([feeType, feeData]) => [
-            feeType as FeeDataKey,
-            {
-              ...feeData,
-              txFee: bn(feeData.txFee).times(2).toString(),
-              chainSpecific: {
-                ...(feeData as FeeData<UtxoChainId>).chainSpecific,
-                satoshiPerByte: bn((feeData as FeeData<UtxoChainId>).chainSpecific.satoshiPerByte)
-                  .times(2)
-                  .toString(),
-              },
-            },
-          ],
-        ),
-      ) as FeeDataEstimate<UtxoChainId> // We're lying to TS, this can be a FeeDataEstimate from any ChainId
+      const estimatedFees = await estimateFees(await getEstimateFeesArgs())
       const amountCryptoBaseUnit = bnOrZero(state.deposit.cryptoAmount).times(
         bn(10).pow(asset.precision),
       )


### PR DESCRIPTION
## Description

With regular sends, sendMaxes are precisely that, combine all your available inputs and send it all, you will effectively send all of your balance and the receiving address will receive all your balance, minus the gas that occurs, using the `split` algorithm:

> Split - splits the input values evenly between all outputs, any provided output with .value remains unchanged

However, in savers context, sending max means we want to keep gas away for future deposit/withdraws, so we escape hatch from the sendMax split logic, send max minus some gas kept away, and let coinselect figure out the optimal algorithm.

## Notice

<!-- Before submitting a pull request, please make sure you have answered the following: -->

- [x] Have you followed the guidelines in our [Contributing]('https://github.com/shapeshift/web/blob/develop/CONTRIBUTING.md) guide?
- [x] Have you checked to ensure there aren't other open [Pull Requests](https://github.com/shapeshift/web/pulls) for the same update/change?

## Pull Request Type

- [ ] :bug: Bug fix (Non-breaking Change: Fixes an issue)
- [ ] :hammer_and_wrench: Chore (Non-breaking Change: Doc updates, pkg upgrades, typos, etc..)
- [ ] :nail_care: New Feature (Breaking/Non-breaking Change)

## Issue (if applicable)

<!-----------------------------------------------------------------------------
If applicable, please link to the github issue and put `closes #XXXX` in your comment to auto-close the issue that your PR fixes.
------------------------------------------------------------------------------>

closes #

## Risk

<!-----------------------------------------------------------------------------
Outline the scope of your changes and the risk associated with them. You must use your discretion as an engineer to determine the potential impact of your changes.

E.g. an upgrade to `hdwallet` or core state management would be considered higher risk, and might require a full regression test. UI or isolated view changes, or something behind a feature flag may have near zero risk. Small bug fixes might require testing isolated to the specific fix.
------------------------------------------------------------------------------>

## Testing

<!-----------------------------------------------------------------------------
We treat every PR to be merged with the same scrutiny as if we were merging directly to production.

Your PR will not be merged if you do not complete the sections below for our engineering and operations teams to test.
------------------------------------------------------------------------------>

### Engineering

<!-----------------------------------------------------------------------------
Include sufficient information here for an engineer to test your PR. This may include how to test locally, in a built environment, changes to infrastructure etc.
------------------------------------------------------------------------------>

### Operations

<!-----------------------------------------------------------------------------
If your changes have a user-facing impact, describe how a non-technical QA team can functionally test your changes in a preview environment.

If they are not user-facing please describe how to test for any regressions that may occur.
------------------------------------------------------------------------------>

## Screenshots (if applicable)

<img width="1053" alt="image" src="https://user-images.githubusercontent.com/17035424/214618536-27d6c6f7-ab58-42d3-9ba2-0a8fdd118e42.png">
<img width="529" alt="image" src="https://user-images.githubusercontent.com/17035424/214618643-8b5567cd-d859-4d07-9e5a-207e6588db26.png">
<img width="1044" alt="image" src="https://user-images.githubusercontent.com/17035424/214619104-b5cb64f9-d75f-460c-a816-440ccb075b68.png">