### PR TITLE
feat(savers): use 0th address index for UTXO deposits

### DIFF
--- a/src/features/defi/providers/thorchain-savers/components/ThorchainSaversManager/Deposit/components/Confirm.tsx
+++ b/src/features/defi/providers/thorchain-savers/components/ThorchainSaversManager/Deposit/components/Confirm.tsx
@@ -2,7 +2,12 @@ import { Alert, AlertIcon, Box, Stack, useToast } from '@chakra-ui/react'
 import type { Asset } from '@shapeshiftoss/asset-service'
 import type { AccountId } from '@shapeshiftoss/caip'
 import { bchChainId, fromAccountId, toAssetId } from '@shapeshiftoss/caip'
-import type { FeeData, FeeDataEstimate, UtxoChainId } from '@shapeshiftoss/chain-adapters'
+import type {
+  FeeData,
+  FeeDataEstimate,
+  UtxoBaseAdapter,
+  UtxoChainId,
+} from '@shapeshiftoss/chain-adapters'
 import { FeeDataKey } from '@shapeshiftoss/chain-adapters'
 import { supportsETH } from '@shapeshiftoss/hdwallet-core'
 import { SwapperName } from '@shapeshiftoss/swapper/dist/api'
@@ -73,7 +78,11 @@ export const Confirm: React.FC<ConfirmProps> = ({ accountId, onNext }) => {
   const { query } = useBrowserRouter<DefiQueryParams, DefiParams>()
   const { chainId, assetNamespace, assetReference } = query
   const opportunity = useMemo(() => state?.opportunity, [state])
-  const chainAdapter = getChainAdapterManager().get(chainId)
+
+  // Technically any chain adapter, but is only used for UTXO ChainIds in this file, so effectively an UTXO adapter
+  const chainAdapter = getChainAdapterManager().get(
+    chainId,
+  ) as unknown as UtxoBaseAdapter<UtxoChainId>
 
   const assetId = toAssetId({
     chainId,
@@ -397,7 +406,7 @@ export const Confirm: React.FC<ConfirmProps> = ({ accountId, onNext }) => {
   }, [chainId, getDepositInput, getPreDepositInput, walletState.wallet])
 
   useEffect(() => {
-    if (!(accountId && chainAdapter && walletState?.wallet && bip44Params)) return
+    if (!(accountId && chainAdapter && walletState?.wallet && bip44Params && accountType)) return
     ;(async () => {
       const accountAddress = isUtxoChainId(chainId)
         ? await getThorchainSaversPosition({ accountId, assetId })


### PR DESCRIPTION
## Description

This PR is both a feature and a safety net:

- By using the 0th address index for UTXO deposits vs. the highest balance address previously, we ensure that we are consistent with THOR UIs (THORSwap, RUNE wallet) and deposits from the same address, meaning that positions from ShapeShift will be visible on other UIs, and vice versa
- Since unchained accounts for unconfirmed balances in addresses balances, and the highest balance account address may effectively change after a deposit (but while savers didn't yet process it, meaning this address doesn't appear on the savers list we get), there is a chance users might re-deposit. If they do so, and another address is used, we would effectively be in a situation where funds are "stuck", as we use xpubs as indexes and aren't able to display positions from two derived addresses from the same xpub.

## Notice

<!-- Before submitting a pull request, please make sure you have answered the following: -->

- [x] Have you followed the guidelines in our [Contributing]('https://github.com/shapeshift/web/blob/develop/CONTRIBUTING.md) guide?
- [x] Have you checked to ensure there aren't other open [Pull Requests](https://github.com/shapeshift/web/pulls) for the same update/change?

## Pull Request Type

- [ ] :bug: Bug fix (Non-breaking Change: Fixes an issue)
- [ ] :hammer_and_wrench: Chore (Non-breaking Change: Doc updates, pkg upgrades, typos, etc..)
- [x] :nail_care: New Feature (Breaking/Non-breaking Change)

## Issue (if applicable)

N/A

## Risk

<!-----------------------------------------------------------------------------
Outline the scope of your changes and the risk associated with them. You must use your discretion as an engineer to determine the potential impact of your changes.

E.g. an upgrade to `hdwallet` or core state management would be considered higher risk, and might require a full regression test. UI or isolated view changes, or something behind a feature flag may have near zero risk. Small bug fixes might require testing isolated to the specific fix.
------------------------------------------------------------------------------>

None, this will not affect existing operations positions, which will still be displayed, which address will still be used for deposit, and which withdraws will still work

## Testing

<!-----------------------------------------------------------------------------
We treat every PR to be merged with the same scrutiny as if we were merging directly to production.

Your PR will not be merged if you do not complete the sections below for our engineering and operations teams to test.
------------------------------------------------------------------------------>

- Choose an UTXO and ensure you have either no position, or withdraw all, wait for on-chain confirmation and reload the app (the position may not disappear from your DeFi cards/rows, this is a known bug)
- Go to `https://d ev-a pi.{yourUtxo}.shapeshift.com/api/v1/account/{yourXpub}` (remove spaces)
- Ensure your `nextReceiveAddressIndex` is > 0 (which it should if you just sent some funds to it using your xpub)
- Deposit into savers
- Ensure the outgoing Tx is made from your 0th address in unchained addresses list

Additionally, but not required:

- Import your seed into THORSwap
- Ensure the receive address in THOR wallet matches the one that was used for this Tx

### Engineering

<!-----------------------------------------------------------------------------
Include sufficient information here for an engineer to test your PR. This may include how to test locally, in a built environment, changes to infrastructure etc.
------------------------------------------------------------------------------>

- ☝🏽 

### Operations

<!-----------------------------------------------------------------------------
If your changes have a user-facing impact, describe how a non-technical QA team can functionally test your changes in a preview environment.

If they are not user-facing please describe how to test for any regressions that may occur.
------------------------------------------------------------------------------>

- Savers deposits are still working

## Screenshots (if applicable)

<img width="594" alt="image" src="https://user-images.githubusercontent.com/17035424/215440151-9a0a2002-5b41-49d2-8df9-3df4a1ba962d.png">
<img width="1258" alt="image" src="https://user-images.githubusercontent.com/17035424/215439834-bf122896-98fb-4933-89f5-7c83690ebff5.png">
<img width="560" alt="image" src="https://user-images.githubusercontent.com/17035424/215440458-4920c479-df03-4b25-848d-5940bfbc9cdb.png">