### PR TITLE
feat(savers): minimum outbound fee for 0 dust_limit assets

### DIFF
--- a/src/features/defi/providers/thorchain-savers/components/ThorchainSaversManager/Deposit/components/Deposit.tsx
+++ b/src/features/defi/providers/thorchain-savers/components/ThorchainSaversManager/Deposit/components/Deposit.tsx
@@ -109,7 +109,7 @@ export const Deposit: React.FC<DepositProps> = ({
     if (!assetId) return '0'
 
     // We only want to display the outbound fee as a minimum for assets which have a zero dust threshold i.e EVM and Cosmos assets
-    if (!bn(THORCHAIN_SAVERS_DUST_THRESHOLDS[assetId]).isZero) return '0'
+    if (!bn(THORCHAIN_SAVERS_DUST_THRESHOLDS[assetId]).isZero()) return '0'
     const daemonUrl = getConfig().REACT_APP_THORCHAIN_NODE_URL
     const inboundAddressData = await getInboundAddressDataForChain(daemonUrl, assetId)
 
@@ -245,7 +245,9 @@ export const Deposit: React.FC<DepositProps> = ({
     (value: string) => {
       const valueCryptoBaseUnit = bnOrZero(value).times(bn(10).pow(asset.precision))
       const isBelowMinSellAmount = !isAboveDepositDustThreshold({ valueCryptoBaseUnit, assetId })
-      const isBelowOutboundFee = bnOrZero(valueCryptoBaseUnit).lt(outboundFeeCryptoBaseUnit)
+      const isBelowOutboundFee =
+        bn(outboundFeeCryptoBaseUnit).gt(0) &&
+        bnOrZero(valueCryptoBaseUnit).lt(outboundFeeCryptoBaseUnit)
 
       const minLimitCryptoPrecision = bn(THORCHAIN_SAVERS_DUST_THRESHOLDS[assetId]).div(
         bn(10).pow(asset.precision),

--- a/src/features/defi/providers/thorchain-savers/components/ThorchainSaversManager/Deposit/components/Deposit.tsx
+++ b/src/features/defi/providers/thorchain-savers/components/ThorchainSaversManager/Deposit/components/Deposit.tsx
@@ -127,9 +127,9 @@ export const Deposit: React.FC<DepositProps> = ({
       if (outboundFeeCryptoBaseUnit) return
 
       const outboundFee = await getOutboundFeeCryptoBaseUnit()
-      if (!outboundFee) return ''
+      if (!outboundFee) return
 
-      setOutboundFeeCryptoBaseUnit(outboundFee ?? '')
+      setOutboundFeeCryptoBaseUnit(outboundFee)
     })()
   }, [getOutboundFeeCryptoBaseUnit, outboundFeeCryptoBaseUnit])
   // notify

--- a/src/features/defi/providers/thorchain-savers/components/ThorchainSaversManager/Deposit/components/Deposit.tsx
+++ b/src/features/defi/providers/thorchain-savers/components/ThorchainSaversManager/Deposit/components/Deposit.tsx
@@ -3,7 +3,8 @@ import type { Asset } from '@shapeshiftoss/asset-service'
 import type { AccountId } from '@shapeshiftoss/caip'
 import { fromAccountId, toAssetId } from '@shapeshiftoss/caip'
 import type { UtxoBaseAdapter, UtxoChainId } from '@shapeshiftoss/chain-adapters'
-import { SwapperName } from '@shapeshiftoss/swapper'
+import { getInboundAddressDataForChain, SwapperName } from '@shapeshiftoss/swapper'
+import { getConfig } from 'config'
 import type { DepositValues } from 'features/defi/components/Deposit/Deposit'
 import { Deposit as ReusableDeposit } from 'features/defi/components/Deposit/Deposit'
 import type {
@@ -12,7 +13,7 @@ import type {
 } from 'features/defi/contexts/DefiManagerProvider/DefiCommon'
 import { DefiAction, DefiStep } from 'features/defi/contexts/DefiManagerProvider/DefiCommon'
 import qs from 'qs'
-import { useCallback, useContext, useMemo } from 'react'
+import { useCallback, useContext, useEffect, useMemo, useState } from 'react'
 import { useTranslate } from 'react-polyglot'
 import { useHistory } from 'react-router-dom'
 import type { AccountDropdownProps } from 'components/AccountDropdown/AccountDropdown'
@@ -21,8 +22,10 @@ import { getChainAdapterManager } from 'context/PluginProvider/chainAdapterSingl
 import { useBrowserRouter } from 'hooks/useBrowserRouter/useBrowserRouter'
 import { bn, bnOrZero } from 'lib/bignumber/bignumber'
 import { logger } from 'lib/logger'
+import { toBaseUnit } from 'lib/math'
 import { getIsTradingActiveApi } from 'state/apis/swapper/getIsTradingActiveApi'
 import {
+  fromThorBaseUnit,
   getThorchainSaversDepositQuote,
   isAboveDepositDustThreshold,
   THORCHAIN_SAVERS_DUST_THRESHOLDS,
@@ -52,6 +55,7 @@ export const Deposit: React.FC<DepositProps> = ({
   onAccountIdChange: handleAccountIdChange,
   onNext,
 }) => {
+  const [outboundFeeCryptoBaseUnit, setOutboundFeeCryptoBaseUnit] = useState('')
   const { state, dispatch: contextDispatch } = useContext(DepositContext)
   const appDispatch = useAppDispatch()
   const history = useHistory()
@@ -101,6 +105,33 @@ export const Deposit: React.FC<DepositProps> = ({
     selectPortfolioCryptoBalanceByFilter(state, balanceFilter),
   )
 
+  const getOutboundFeeCryptoBaseUnit = useCallback(async (): Promise<string> => {
+    if (!assetId) return '0'
+
+    // We only want to display the outbound fee as a minimum for assets which have a zero dust threshold i.e EVM and Cosmos assets
+    if (!bn(THORCHAIN_SAVERS_DUST_THRESHOLDS[assetId]).isZero) return '0'
+    const daemonUrl = getConfig().REACT_APP_THORCHAIN_NODE_URL
+    const inboundAddressData = await getInboundAddressDataForChain(daemonUrl, assetId)
+
+    if (!inboundAddressData) return '0'
+
+    const { outbound_fee } = inboundAddressData
+
+    const outboundFeeCryptoBaseUnit = toBaseUnit(fromThorBaseUnit(outbound_fee), asset.precision)
+
+    return outboundFeeCryptoBaseUnit
+  }, [asset.precision, assetId])
+
+  useEffect(() => {
+    ;(async () => {
+      if (outboundFeeCryptoBaseUnit) return
+
+      const outboundFee = await getOutboundFeeCryptoBaseUnit()
+      if (!outboundFee) return ''
+
+      setOutboundFeeCryptoBaseUnit(outboundFee ?? '')
+    })()
+  }, [getOutboundFeeCryptoBaseUnit, outboundFeeCryptoBaseUnit])
   // notify
   const toast = useToast()
 
@@ -214,13 +245,20 @@ export const Deposit: React.FC<DepositProps> = ({
     (value: string) => {
       const valueCryptoBaseUnit = bnOrZero(value).times(bn(10).pow(asset.precision))
       const isBelowMinSellAmount = !isAboveDepositDustThreshold({ valueCryptoBaseUnit, assetId })
+      const isBelowOutboundFee = bnOrZero(valueCryptoBaseUnit).lt(outboundFeeCryptoBaseUnit)
 
       const minLimitCryptoPrecision = bn(THORCHAIN_SAVERS_DUST_THRESHOLDS[assetId]).div(
         bn(10).pow(asset.precision),
       )
+      const outboundFeeCryptoPrecision = bn(outboundFeeCryptoBaseUnit).div(
+        bn(10).pow(asset.precision),
+      )
       const minLimit = `${minLimitCryptoPrecision} ${asset.symbol}`
+      const outboundFeeLimit = `${outboundFeeCryptoPrecision} ${asset.symbol}`
 
       if (isBelowMinSellAmount) return translate('trade.errors.amountTooSmall', { minLimit })
+      if (isBelowOutboundFee)
+        return translate('trade.errors.amountTooSmall', { minLimit: outboundFeeLimit })
 
       const cryptoBalancePrecision = bnOrZero(balance).div(bn(10).pow(asset.precision))
       const valueCryptoPrecision = bnOrZero(value)
@@ -231,7 +269,7 @@ export const Deposit: React.FC<DepositProps> = ({
       if (valueCryptoPrecision.isEqualTo(0)) return ''
       return hasValidBalance || 'common.insufficientFunds'
     },
-    [asset.precision, asset.symbol, assetId, translate, balance],
+    [asset.precision, asset.symbol, assetId, outboundFeeCryptoBaseUnit, translate, balance],
   )
 
   const validateFiatAmount = useCallback(
@@ -242,13 +280,20 @@ export const Deposit: React.FC<DepositProps> = ({
         .div(marketData.price)
         .times(bn(10).pow(asset.precision))
       const isBelowMinSellAmount = !isAboveDepositDustThreshold({ valueCryptoBaseUnit, assetId })
+      const isBelowOutboundFee = bnOrZero(valueCryptoBaseUnit).lt(outboundFeeCryptoBaseUnit)
 
       const minLimitCryptoPrecision = bn(THORCHAIN_SAVERS_DUST_THRESHOLDS[assetId]).div(
         bn(10).pow(asset.precision),
       )
+      const outboundFeeCryptoPrecision = bn(outboundFeeCryptoBaseUnit).div(
+        bn(10).pow(asset.precision),
+      )
       const minLimit = `${minLimitCryptoPrecision} ${asset.symbol}`
+      const outboundFeeLimit = `${outboundFeeCryptoPrecision} ${asset.symbol}`
 
       if (isBelowMinSellAmount) return translate('trade.errors.amountTooSmall', { minLimit })
+      if (isBelowOutboundFee)
+        return translate('trade.errors.amountTooSmall', { minLimit: outboundFeeLimit })
 
       const fiat = crypto.times(marketData.price)
       const _value = bnOrZero(value)
@@ -256,7 +301,15 @@ export const Deposit: React.FC<DepositProps> = ({
       if (_value.isEqualTo(0)) return ''
       return hasValidBalance || 'common.insufficientFunds'
     },
-    [balance, asset.precision, asset.symbol, marketData.price, assetId, translate],
+    [
+      balance,
+      asset.precision,
+      asset.symbol,
+      marketData.price,
+      assetId,
+      outboundFeeCryptoBaseUnit,
+      translate,
+    ],
   )
 
   const cryptoAmountAvailable = useMemo(


### PR DESCRIPTION
## Description

Some assets (EVM and Cosmos assets, i.e any savers L1 that's not an UTXO) supposedly have a 0 dust_limit, which theoretically means 0 is the limit of dust to send for deposits/withdraws.
However, sending a value that's very close to zero will fail quote checks at "not enough fee".

Fixed by setting `outboundFeeCryptoBaseUnit` as a state field and checking if the current amount is lower than it, in addition to the dust amount checks.

Note that for UTXO assets, we set the outbound fee to 0, since the dust limit is enough to pass quote validation, resulting in smaller amounts being able to be deposited (e.g DOGE would be 1 DOGE dust limit but 15 DOGE outbound fee


## Notice

<!-- Before submitting a pull request, please make sure you have answered the following: -->

- [x] Have you followed the guidelines in our [Contributing]('https://github.com/shapeshift/web/blob/develop/CONTRIBUTING.md) guide?
- [x] Have you checked to ensure there aren't other open [Pull Requests](https://github.com/shapeshift/web/pulls) for the same update/change?

## Pull Request Type

- [ ] :bug: Bug fix (Non-breaking Change: Fixes an issue)
- [ ] :hammer_and_wrench: Chore (Non-breaking Change: Doc updates, pkg upgrades, typos, etc..)
- [x] :nail_care: New Feature (Breaking/Non-breaking Change)

## Issue (if applicable)

N/A

## Risk

<!-----------------------------------------------------------------------------
Outline the scope of your changes and the risk associated with them. You must use your discretion as an engineer to determine the potential impact of your changes.

E.g. an upgrade to `hdwallet` or core state management would be considered higher risk, and might require a full regression test. UI or isolated view changes, or something behind a feature flag may have near zero risk. Small bug fixes might require testing isolated to the specific fix.
------------------------------------------------------------------------------>

## Testing

<!-----------------------------------------------------------------------------
We treat every PR to be merged with the same scrutiny as if we were merging directly to production.

Your PR will not be merged if you do not complete the sections below for our engineering and operations teams to test.
------------------------------------------------------------------------------>

- Minimum deposit amounts are the same as develop/prod for UTXOs
- Minimum deposit amounts are higher than develop/prod for ATOM, AVAX and ETH
- Deposits still work (test with at least one EVM chain, one UTXO and ATOM)

### Engineering

<!-----------------------------------------------------------------------------
Include sufficient information here for an engineer to test your PR. This may include how to test locally, in a built environment, changes to infrastructure etc.
------------------------------------------------------------------------------>

- ☝🏽 

### Operations

<!-----------------------------------------------------------------------------
If your changes have a user-facing impact, describe how a non-technical QA team can functionally test your changes in a preview environment.

If they are not user-facing please describe how to test for any regressions that may occur.
------------------------------------------------------------------------------>

- ☝🏽 

## Screenshots (if applicable)

<img width="559" alt="image" src="https://user-images.githubusercontent.com/17035424/215782777-6ee2bf6f-e772-4115-aa53-e6d376617cd6.png">
<img width="536" alt="image" src="https://user-images.githubusercontent.com/17035424/215808419-d5f61519-5eb3-4465-9399-2f144d545bf6.png">
<img width="540" alt="image" src="https://user-images.githubusercontent.com/17035424/215808522-e0f2274d-b517-4e99-ab82-00303e86cfc7.png">
<img width="546" alt="image" src="https://user-images.githubusercontent.com/17035424/215808565-178810ff-3e3b-487f-a42e-8f8fbe8f0d3c.png">
<img width="542" alt="image" src="https://user-images.githubusercontent.com/17035424/215808636-2720920d-ebdd-4c65-baf8-0ad02060d1c0.png">
<img width="542" alt="image" src="https://user-images.githubusercontent.com/17035424/215808703-e0c7a202-ca75-49a7-b865-228b748e0fd5.png">

