### PR TITLE
fix: correct zrx approve amount

### DIFF
--- a/package.json
+++ b/package.json
@@ -104,7 +104,7 @@
     "@shapeshiftoss/investor-yearn": "^6.4.0",
     "@shapeshiftoss/logger": "^1.1.3",
     "@shapeshiftoss/market-service": "^7.5.0",
-    "@shapeshiftoss/swapper": "^16.0.0",
+    "@shapeshiftoss/swapper": "^16.0.1",
     "@shapeshiftoss/types": "8.5.0",
     "@shapeshiftoss/unchained-client": "^10.11.0",
     "@uniswap/sdk": "^3.0.3",

--- a/src/components/Trade/TradeConfirm/TradeConfirm.tsx
+++ b/src/components/Trade/TradeConfirm/TradeConfirm.tsx
@@ -396,7 +396,7 @@ export const TradeConfirm = () => {
                   </HelperTooltip>
                   <Row.Value>
                     {defaultFeeAsset &&
-                      `${bnOrZero(fees?.networkFeeCryptoHuman).toNumber()} ${
+                      `${bnOrZero(fees?.networkFeeCryptoHuman).toFixed()} ${
                         defaultFeeAsset.symbol
                       } ≃ ${toFiat(networkFeeFiat.toNumber())}`}
                   </Row.Value>

--- a/yarn.lock
+++ b/yarn.lock
@@ -4370,10 +4370,10 @@
     google-protobuf "^3.17.0"
     long "^4.0.0"
 
-"@shapeshiftoss/swapper@^16.0.0":
-  version "16.0.0"
-  resolved "https://registry.yarnpkg.com/@shapeshiftoss/swapper/-/swapper-16.0.0.tgz#6afc2ec39f359c43697e56ff9607e59fb81efc65"
-  integrity sha512-8E4I3X+zrqkgQNUqRZ0YxedCmsFk9kg4BkM5mkHeHj2JEnrBoAmcCKE3UKlMnOVtQgwHtKlYHqw7J2Z8moN8Lw==
+"@shapeshiftoss/swapper@^16.0.1":
+  version "16.0.1"
+  resolved "https://registry.yarnpkg.com/@shapeshiftoss/swapper/-/swapper-16.0.1.tgz#dd6544f18bac6e0fc1581cf2718f5010ad0013fc"
+  integrity sha512-lzQAd+X6692sBKcbD3wSEa4YBONOKqtJR7Gm2xzeN5vpIw2seRjMCWrqKmHT1kR61tn7+Cwy623ar9QnKsuXmA==
   dependencies:
     axios "^0.26.1"
     axios-cache-adapter "^2.7.3"


### PR DESCRIPTION
## Description

- bump swapper package to fix zrx approve infinite amount
- use `toFixed()` over `toNumber()` to avoid scientific notation on fee amount

## Notice

<!-- Before submitting a pull request, please make sure you have answered the following: -->

- [x] Have you followed the guidelines in our [Contributing]('https://github.com/shapeshift/web/blob/develop/CONTRIBUTING.md) guide?
- [x] Have you checked to ensure there aren't other open [Pull Requests](https://github.com/shapeshift/web/pulls) for the same update/change?

## Pull Request Type

- [x] :bug: Bug fix (Non-breaking Change: Fixes an issue)
- [ ] :hammer_and_wrench: Chore (Non-breaking Change: Doc updates, pkg upgrades, typos, etc..)
- [ ] :nail_care: New Feature (Breaking/Non-breaking Change)

## Issue (if applicable)

<!-----------------------------------------------------------------------------
If applicable, please link to the github issue and put `closes #XXXX` in your comment to auto-close the issue that your PR fixes.
------------------------------------------------------------------------------>

closes #

## Risk

low

## Testing

- zrx approve infinite should use correct `MAX_APPROVAL_AMOUNT` and not require re-approval on subsequent trades
- zrx trade network fee should be shown in crypto amount (not scientific notation)

### Engineering

:point_up: 

### Operations

:point_up: 

## Screenshots (if applicable)

Before:
![image](https://user-images.githubusercontent.com/35275952/215861623-3c011530-c5c2-4cd7-ae2d-090816d5cdce.png)

After:
![image](https://user-images.githubusercontent.com/35275952/215862091-0d84d404-edd6-4903-9b2c-ecf0547382c4.png)
