### PR TITLE
fix: race condition between form & custom hook state

### DIFF
--- a/src/components/Trade/hooks/useAvailableSwappers.tsx
+++ b/src/components/Trade/hooks/useAvailableSwappers.tsx
@@ -1,8 +1,10 @@
 import type { Asset } from '@shapeshiftoss/asset-service'
 import type { GetSwappersWithQuoteMetadataReturn } from '@shapeshiftoss/swapper'
 import { useEffect, useState } from 'react'
+import { useFormContext, useWatch } from 'react-hook-form'
 import { getSwapperManager } from 'components/Trade/hooks/useSwapper/swapperManager'
 import { useTradeQuoteService } from 'components/Trade/hooks/useTradeQuoteService'
+import type { TS } from 'components/Trade/types'
 import { isSome } from 'lib/utils'
 import { getSwappersApi } from 'state/apis/swapper/getSwappersApi'
 import { selectFeatureFlags } from 'state/slices/preferencesSlice/selectors'
@@ -12,6 +14,17 @@ type AvailableSwapperArgs = { feeAsset: Asset | undefined }
 
 // A helper hook to get the available swappers from the RTK API, mapping the SwapperTypes to swappers
 export const useAvailableSwappers = ({ feeAsset }: AvailableSwapperArgs) => {
+  // Form hooks
+  const { control } = useFormContext<TS>()
+  const sellTradeAsset = useWatch({ control, name: 'sellTradeAsset' })
+  const buyTradeAsset = useWatch({ control, name: 'buyTradeAsset' })
+
+  // Constants
+  const sellAsset = sellTradeAsset?.asset
+  const buyAsset = buyTradeAsset?.asset
+  const buyAssetId = buyAsset?.assetId
+  const sellAssetId = sellAsset?.assetId
+
   const [swappersWithQuoteMetadata, setSwappersWithQuoteMetadata] =
     useState<GetSwappersWithQuoteMetadataReturn>()
   const dispatch = useAppDispatch()
@@ -48,9 +61,23 @@ export const useAvailableSwappers = ({ feeAsset }: AvailableSwapperArgs) => {
             : undefined
         })
         .filter(isSome)
-      setSwappersWithQuoteMetadata(availableSwappersWithQuoteMetadata)
+      // Handle a race condition between form state and useTradeQuoteService
+      if (
+        tradeQuoteArgs?.buyAsset.assetId === buyAssetId &&
+        tradeQuoteArgs?.sellAsset.assetId === sellAssetId
+      ) {
+        setSwappersWithQuoteMetadata(availableSwappersWithQuoteMetadata)
+      }
     })()
-  }, [dispatch, featureFlags, feeAsset, getAvailableSwappers, tradeQuoteArgs])
+  }, [
+    buyAssetId,
+    dispatch,
+    featureFlags,
+    feeAsset,
+    getAvailableSwappers,
+    sellAssetId,
+    tradeQuoteArgs,
+  ])
 
   const bestSwapperWithQuoteMetadata = swappersWithQuoteMetadata?.[0]
 


### PR DESCRIPTION
## Description

Fixes a race condition between the trade form state and `useTradeQuoteService` custom hook state.

Side note, I think we need to rearchitect the way we store and mutate trade state (i.e. don't use a form to store global-ish state).

A proper reducer would likely solve a lot of these race conditions we need to guard against and keep us in a more reliable/consistent state.

@kaladinlight FYI, this fixes your Optimism bug.

## Notice

- [x] Have you followed the guidelines in our [Contributing]('https://github.com/shapeshift/web/blob/develop/CONTRIBUTING.md) guide?
- [x] Have you checked to ensure there aren't other open [Pull Requests](https://github.com/shapeshift/web/pulls) for the same update/change?

## Pull Request Type

- [ x] :bug: Bug fix (Non-breaking Change: Fixes an issue)
- [ ] :hammer_and_wrench: Chore (Non-breaking Change: Doc updates, pkg upgrades, typos, etc..)
- [ ] :nail_care: New Feature (Breaking/Non-breaking Change)

## Issue (if applicable)

N/A

## Risk

Small, only adds a guard against setting `availableSwappersWithQuoteMetadata` when the trade form state is mismatched.

## Testing

1. Hard refresh on dashboard
2. Navigate to ETH on Optimism
3. Click "Trade" and _don't_ see the halt error state

### Engineering

☝️ 

### Operations

☝️ 

## Screenshots (if applicable)

N/A