### PR TITLE
fix(savers): estimate gas for deposits > 19.152396814393078034 AVAX/ 11,532.471398198970121614 ETH

### DIFF
--- a/src/features/defi/providers/thorchain-savers/components/ThorchainSaversManager/Deposit/components/Deposit.tsx
+++ b/src/features/defi/providers/thorchain-savers/components/ThorchainSaversManager/Deposit/components/Deposit.tsx
@@ -168,7 +168,7 @@ export const Deposit: React.FC<DepositProps> = ({
             to: quote.inbound_address,
             value: amountCryptoBaseUnit.toFixed(0),
             // EVM chains are the only ones explicitly requiring a `from` param for the gas estimation to work
-            // UTXOs simply call /api/v1/fees (common for all acocunts), and Cosmos assets fees are hardcoded
+            // UTXOs simply call /api/v1/fees (common for all accounts), and Cosmos assets fees are hardcoded
             chainSpecific: {
               pubkey: userAddress,
               from: supportedEvmChainIds.includes(chainId) ? userAddress : '',

--- a/src/features/defi/providers/thorchain-savers/components/ThorchainSaversManager/Deposit/components/Deposit.tsx
+++ b/src/features/defi/providers/thorchain-savers/components/ThorchainSaversManager/Deposit/components/Deposit.tsx
@@ -36,6 +36,7 @@ import {
   THORCHAIN_SAVERS_DUST_THRESHOLDS,
 } from 'state/slices/opportunitiesSlice/resolvers/thorchainsavers/utils'
 import { serializeUserStakingId, toOpportunityId } from 'state/slices/opportunitiesSlice/utils'
+import { isUtxoChainId } from 'state/slices/portfolioSlice/utils'
 import {
   selectAssetById,
   selectEarnUserStakingOpportunityByUserStakingId,
@@ -165,7 +166,9 @@ export const Deposit: React.FC<DepositProps> = ({
           await adapter.getFeeData({
             to: quote.inbound_address,
             value: amountCryptoBaseUnit.toFixed(0),
-            chainSpecific: { pubkey: userAddress, from: '' },
+            // EVM chains are the only ones explicitly requiring a `from` param for the gas estimation to work
+            // UTXOs simply call /api/v1/fees (common for all acocunts), and Cosmos assets fees are hardcoded
+            chainSpecific: { pubkey: userAddress, from: isUtxoChainId(chainId) ? '' : userAddress },
             sendMax: Boolean(state?.deposit.sendMax),
           })
         ).fast.txFee

--- a/src/features/defi/providers/thorchain-savers/components/ThorchainSaversManager/Withdraw/components/Withdraw.tsx
+++ b/src/features/defi/providers/thorchain-savers/components/ThorchainSaversManager/Withdraw/components/Withdraw.tsx
@@ -168,7 +168,7 @@ export const Withdraw: React.FC<WithdrawProps> = ({ accountId, onNext }) => {
             to: quote.inbound_address,
             value: amountCryptoBaseUnit.toFixed(0),
             // EVM chains are the only ones explicitly requiring a `from` param for the gas estimation to work
-            // UTXOs simply call /api/v1/fees (common for all acocunts), and Cosmos assets fees are hardcoded
+            // UTXOs simply call /api/v1/fees (common for all accounts), and Cosmos assets fees are hardcoded
             chainSpecific: {
               pubkey: userAddress,
               from: supportedEvmChainIds.includes(chainId) ? userAddress : '',


### PR DESCRIPTION
## Description

Oddly specific PR name checks out:

We weren't passing the `from` param to `getFeeData`, which is actually fine for UTXO chainIds (UTXO adapters simply call `/v1/api/fees`) and Cosmos SDK chains for which the gas fee is an overestimated hardcoded fee.

What happens for EVM chains you might ask? We call the fees estimation endpoint with an empty string, which gets casted and eventually passed as the zero address as an Ethereum JSON-RPC arg.

Which in the Avalanche network means https://snowtrace.io/address/0x0000000000000000000000000000000000000000 (19.152396814393078034 AVAX  at the time of writing) and in the Ethereum world https://etherscan.io/address/0x0000000000000000000000000000000000000000 (11,532.471398198970121614 ETH at the time of writing).

tl;dr if you deposit > ~400$ AVAX or > ~191M$ ETH, your deposit wouldn't go through currently

## Notice

<!-- Before submitting a pull request, please make sure you have answered the following: -->

- [x] Have you followed the guidelines in our [Contributing]('https://github.com/shapeshift/web/blob/develop/CONTRIBUTING.md) guide?
- [x] Have you checked to ensure there aren't other open [Pull Requests](https://github.com/shapeshift/web/pulls) for the same update/change?

## Pull Request Type

- [ ] :bug: Bug fix (Non-breaking Change: Fixes an issue)
- [ ] :hammer_and_wrench: Chore (Non-breaking Change: Doc updates, pkg upgrades, typos, etc..)
- [x] :nail_care: New Feature (Breaking/Non-breaking Change)

## Issue (if applicable)

N/A

## Risk

<!-----------------------------------------------------------------------------
Outline the scope of your changes and the risk associated with them. You must use your discretion as an engineer to determine the potential impact of your changes.

E.g. an upgrade to `hdwallet` or core state management would be considered higher risk, and might require a full regression test. UI or isolated view changes, or something behind a feature flag may have near zero risk. Small bug fixes might require testing isolated to the specific fix.
------------------------------------------------------------------------------>

None

## Testing

<!-----------------------------------------------------------------------------
We treat every PR to be merged with the same scrutiny as if we were merging directly to production.

Your PR will not be merged if you do not complete the sections below for our engineering and operations teams to test.
------------------------------------------------------------------------------>

- Savers deposit are still going through
- AVAX deposits larger than the current https://snowtrace.io/address/0x0000000000000000000000000000000000000000 AVAX balance are going through

### Engineering

<!-----------------------------------------------------------------------------
Include sufficient information here for an engineer to test your PR. This may include how to test locally, in a built environment, changes to infrastructure etc.
------------------------------------------------------------------------------>

- ☝🏽 

### Operations

<!-----------------------------------------------------------------------------
If your changes have a user-facing impact, describe how a non-technical QA team can functionally test your changes in a preview environment.

If they are not user-facing please describe how to test for any regressions that may occur.
------------------------------------------------------------------------------>

- ☝🏽 

## Screenshots (if applicable)
