### PR TITLE
fix: incorrect RUNE halt

### DIFF
--- a/package.json
+++ b/package.json
@@ -104,7 +104,7 @@
     "@shapeshiftoss/investor-yearn": "^6.4.0",
     "@shapeshiftoss/logger": "^1.1.3",
     "@shapeshiftoss/market-service": "^7.5.0",
-    "@shapeshiftoss/swapper": "^16.0.1",
+    "@shapeshiftoss/swapper": "^16.0.2",
     "@shapeshiftoss/types": "8.5.0",
     "@shapeshiftoss/unchained-client": "^10.11.0",
     "@uniswap/sdk": "^3.0.3",

--- a/src/components/Trade/utils.ts
+++ b/src/components/Trade/utils.ts
@@ -1,5 +1,5 @@
 import type { AssetId } from '@shapeshiftoss/caip'
-import { getInboundAddressDataForChain, SwapperName } from '@shapeshiftoss/swapper'
+import { getInboundAddressDataForChain, isRune, SwapperName } from '@shapeshiftoss/swapper'
 import { getConfig } from 'config'
 
 export const isTradingActive = async (
@@ -10,9 +10,23 @@ export const isTradingActive = async (
     case SwapperName.Thorchain: {
       const daemonUrl = getConfig().REACT_APP_THORCHAIN_NODE_URL
       const inboundAddressData = await getInboundAddressDataForChain(daemonUrl, assetId, false)
-      // If we can't get inbound address data, we MUST assume trading is halted for safety
-      return inboundAddressData ? !inboundAddressData.halted : false
+      /*
+      Unless we are trading from RUNE, which has no inbound address data, we MUST
+      get confirmation that trading is not halted. We fail-closed for safety.
+       */
+      switch (true) {
+        // The sell asset is RUNE, there is no inbound address data to check against
+        case assetId && isRune(assetId):
+          return true
+        // We have inboundAddressData for the sell asset, check if it is halted
+        case !!inboundAddressData:
+          return !inboundAddressData!.halted
+        // We have no inboundAddressData for the sell asset, fail-closed
+        default:
+          return false
+      }
     }
+    // The swapper does not require any additional checks, we assume trading is active
     default:
       return true
   }

--- a/src/components/Trade/utils.ts
+++ b/src/components/Trade/utils.ts
@@ -15,10 +15,8 @@ export const isTradingActive = async (
       const inboundAddressData = sellAssetIsRune
         ? undefined
         : await getInboundAddressDataForChain(daemonUrl, assetId, false)
-      /*
-      Unless we are trading from RUNE, which has no inbound address data, we MUST
-      get confirmation that trading is not halted. We fail-closed for safety.
-       */
+
+      // We MUST get confirmation that trading is not halted. We fail-closed for safety.
       switch (true) {
         // The sell asset is RUNE, there is no inbound address data to check against
         // Check the HALTTHORCHAIN flag on the mimir endpoint instead

--- a/yarn.lock
+++ b/yarn.lock
@@ -4370,10 +4370,10 @@
     google-protobuf "^3.17.0"
     long "^4.0.0"
 
-"@shapeshiftoss/swapper@^16.0.1":
-  version "16.0.1"
-  resolved "https://registry.yarnpkg.com/@shapeshiftoss/swapper/-/swapper-16.0.1.tgz#dd6544f18bac6e0fc1581cf2718f5010ad0013fc"
-  integrity sha512-lzQAd+X6692sBKcbD3wSEa4YBONOKqtJR7Gm2xzeN5vpIw2seRjMCWrqKmHT1kR61tn7+Cwy623ar9QnKsuXmA==
+"@shapeshiftoss/swapper@^16.0.2":
+  version "16.0.2"
+  resolved "https://registry.yarnpkg.com/@shapeshiftoss/swapper/-/swapper-16.0.2.tgz#82397a4dc5c824d036ab013669bd6cb4bd9f5130"
+  integrity sha512-Aqh4lYrq5VhSTogPR0lwGkZ9eTMcrr+pILhD1q8pclx1cV6SC3EP4JBVreE/+Tj6rEQxpRF0u39ojEjMUY4pEQ==
   dependencies:
     axios "^0.26.1"
     axios-cache-adapter "^2.7.3"


### PR DESCRIPTION
## Description

We currently enforce that all THORChain trades require confirmation that the sell asset's inbound asset in not halted.
We do this via the `inbound_addresses` endpoint, but this is not relevant for `RUNE` (it's a single hop trade, and does not have an inbound address, per se).

This PR adds a new, different, check on trades form `RUNE` against the `HALTTHORCHAIN` flag on the `mimir` endpoint to ensure that THORChain is not halted. 

This check is likely overkill, as the transaction, in theory, wouldn't even go through if the chain was halted, but safety first.

## Notice

- [x] Have you followed the guidelines in our [Contributing]('https://github.com/shapeshift/web/blob/develop/CONTRIBUTING.md) guide?
- [x] Have you checked to ensure there aren't other open [Pull Requests](https://github.com/shapeshift/web/pulls) for the same update/change?

## Pull Request Type

- [x] :bug: Bug fix (Non-breaking Change: Fixes an issue)
- [ ] :hammer_and_wrench: Chore (Non-breaking Change: Doc updates, pkg upgrades, typos, etc..)
- [ ] :nail_care: New Feature (Breaking/Non-breaking Change)

## Issue (if applicable)

https://twitter.com/cryptoisnice/status/1621680381329129474

## Risk

Small - well contained, though affects halt logic so if incorrect could incorrectly halt assets.

## Testing

Ensure that:

1. Trading from RUNE is possible (not halted)
2. Using THORSwap for other assets performs as expected
3. Non-THORSwap trades perform as expected

For each of the above, getting to the quote confirmation screen is enough.

### Engineering

☝️ 

### Operations

☝️ 

## Screenshots (if applicable)

N/A