### PR TITLE
chore: skip commitlint in merge group CI invocation

### DIFF
--- a/.github/workflows/pr.yml
+++ b/.github/workflows/pr.yml
@@ -31,6 +31,11 @@ jobs:
 
       # needs to run after install
       - name: Commitlint PR Title
+        # https://docs.github.com/en/actions/using-workflows/workflow-syntax-for-github-actions#example-using-contexts
+        # only commitlint on PRs - pull_request.title not available in merge_group (merge queue)
+        # https://docs.github.com/en/developers/webhooks-and-events/webhooks/webhook-events-and-payloads#merge_group
+        # once a PR is in the merge queue, it's title has already been commitlint'd
+        if: ${{ github.event_name == 'pull_request' }}
         env:
           TITLE: ${{ github.event.pull_request.title }}
         run: printf '%s' "$TITLE" | npx commitlint

--- a/.github/workflows/pr.yml
+++ b/.github/workflows/pr.yml
@@ -34,7 +34,7 @@ jobs:
         # https://docs.github.com/en/actions/using-workflows/workflow-syntax-for-github-actions#example-using-contexts
         # only commitlint on PRs - pull_request.title not available in merge_group (merge queue)
         # https://docs.github.com/en/developers/webhooks-and-events/webhooks/webhook-events-and-payloads#merge_group
-        # once a PR is in the merge queue, it's title has already been commitlint'd
+        # once a PR is in the merge queue, its title has already been commitlint'd
         if: ${{ github.event_name == 'pull_request' }}
         env:
           TITLE: ${{ github.event.pull_request.title }}


### PR DESCRIPTION
## Description

<!-- Please describe your changes -->

CI runs can now be triggered by PRs, or the merge queue

the PR title isn't available in the merge queue, so it immediately fails

this is a teething issue - if we fully adopt the queue we'll skip CI on the PR and only run it in the queue

## Notice

<!-- Before submitting a pull request, please make sure you have answered the following: -->

- [x] Have you followed the guidelines in our [Contributing]('https://github.com/shapeshift/web/blob/develop/CONTRIBUTING.md) guide?
- [x] Have you checked to ensure there aren't other open [Pull Requests](https://github.com/shapeshift/web/pulls) for the same update/change?

## Pull Request Type

- [ ] :bug: Bug fix (Non-breaking Change: Fixes an issue)
- [x] :hammer_and_wrench: Chore (Non-breaking Change: Doc updates, pkg upgrades, typos, etc..)
- [ ] :nail_care: New Feature (Breaking/Non-breaking Change)

## Issue (if applicable)

<!-----------------------------------------------------------------------------
If applicable, please link to the github issue and put `closes #XXXX` in your comment to auto-close the issue that your PR fixes.
------------------------------------------------------------------------------>

n/a

## Risk

CI is sad

<!-----------------------------------------------------------------------------
Outline the scope of your changes and the risk associated with them. You must use your discretion as an engineer to determine the potential impact of your changes.

E.g. an upgrade to `hdwallet` or core state management would be considered higher risk, and might require a full regression test. UI or isolated view changes, or something behind a feature flag may have near zero risk. Small bug fixes might require testing isolated to the specific fix.
------------------------------------------------------------------------------>

## Testing

<!-----------------------------------------------------------------------------
We treat every PR to be merged with the same scrutiny as if we were merging directly to production.

Your PR will not be merged if you do not complete the sections below for our engineering and operations teams to test.
------------------------------------------------------------------------------>

### Engineering

send it and see

<!-----------------------------------------------------------------------------
Include sufficient information here for an engineer to test your PR. This may include how to test locally, in a built environment, changes to infrastructure etc.
------------------------------------------------------------------------------>

### Operations

no app code changes/testing required

<!-----------------------------------------------------------------------------
If your changes have a user-facing impact, describe how a non-technical QA team can functionally test your changes in a preview environment.

If they are not user-facing please describe how to test for any regressions that may occur.
------------------------------------------------------------------------------>

## Screenshots (if applicable)
