### PR TITLE
fix: bump wherever version to support mobile gap

### DIFF
--- a/package.json
+++ b/package.json
@@ -115,7 +115,7 @@
     "@visx/xychart": "^2.12.2",
     "@wagmi/core": "^0.5.5",
     "@walletconnect/web3-provider": "^1.7.8",
-    "@wherever/react-notification-feed": "^0.3.11",
+    "@wherever/react-notification-feed": "^0.3.13",
     "allsettled-polyfill": "^1.0.4",
     "axios": "^0.26.1",
     "bignumber.js": "^9.0.2",

--- a/yarn.lock
+++ b/yarn.lock
@@ -6260,10 +6260,10 @@
   dependencies:
     lodash "^4"
 
-"@wherever/react-notification-feed@^0.3.11":
-  version "0.3.11"
-  resolved "https://registry.yarnpkg.com/@wherever/react-notification-feed/-/react-notification-feed-0.3.11.tgz#ca6f1860900cc2b483f31c3f70a613d1c4e7bd2c"
-  integrity sha512-q3MpRew3DzqLhQABMKA3SxlzkAhXU63vNPTM93cQLu5yO6YAR7pnUafmxuJztoRUg24LSb8HWp52HjayU4C2rA==
+"@wherever/react-notification-feed@^0.3.13":
+  version "0.3.13"
+  resolved "https://registry.yarnpkg.com/@wherever/react-notification-feed/-/react-notification-feed-0.3.13.tgz#808d428908edb0716ba16380aa3f584cc5e9b34a"
+  integrity sha512-C008QYE8r1YLXZjTc5TwqdYDfVu5OUYi7v4vfVhb5qIIxpnF3bQSngJgaL3TnK7DQVfrTGzDXzIF8iQ3haIYWQ==
   dependencies:
     "@apollo/client" "^3.6.9"
     "@epnsproject/sdk-restapi" "^0.1.20"


### PR DESCRIPTION
## Description

Updated Wherever widget version which includes padding top using `env(safe-area-inset-top)` to account for mobile notch

## Notice

<!-- Before submitting a pull request, please make sure you have answered the following: -->

- [x] Have you followed the guidelines in our [Contributing]('https://github.com/shapeshift/web/blob/develop/CONTRIBUTING.md) guide?
- [x] Have you checked to ensure there aren't other open [Pull Requests](https://github.com/shapeshift/web/pulls) for the same update/change?

## Pull Request Type

- [x] :bug: Bug fix (Non-breaking Change: Fixes an issue)
- [ ] :hammer_and_wrench: Chore (Non-breaking Change: Doc updates, pkg upgrades, typos, etc..)
- [ ] :nail_care: New Feature (Breaking/Non-breaking Change)

