### PR TITLE
fix: bring backup wallet out of sub menu

### DIFF
--- a/src/components/Layout/Header/NavBar/ExpandedMenuItem.tsx
+++ b/src/components/Layout/Header/NavBar/ExpandedMenuItem.tsx
@@ -1,8 +1,7 @@
 import { ChevronDownIcon, ChevronRightIcon, ExternalLinkIcon } from '@chakra-ui/icons'
-import { Badge } from '@chakra-ui/layout'
 import { MenuItem } from '@chakra-ui/menu'
 import type { MenuItemProps } from '@chakra-ui/menu/dist/declarations/src/menu'
-import { Link, useColorModeValue } from '@chakra-ui/react'
+import { Link, Tag, useColorModeValue } from '@chakra-ui/react'
 import type { ThemeTypings } from '@chakra-ui/styled-system'
 import type { ColorProps } from '@chakra-ui/styled-system/dist/declarations/src/config/color'
 import type { InterpolationOptions } from 'node-polyglot'
@@ -71,9 +70,9 @@ export const ExpandedMenuItem = ({
         {value}
       </RawText>
       {badge && (
-        <Badge ml={2} p={1} borderRadius='lg' colorScheme={badgeColor} fontWeight='semibold'>
+        <Tag ml={2} size='sm' borderRadius='lg' colorScheme={badgeColor}>
           {badge}
-        </Badge>
+        </Tag>
       )}
       {hasSubmenu &&
         (isOpen ? (

--- a/src/components/Layout/Header/NavBar/ExpandedMenuItem.tsx
+++ b/src/components/Layout/Header/NavBar/ExpandedMenuItem.tsx
@@ -59,7 +59,6 @@ export const ExpandedMenuItem = ({
       alignItems='center'
       px={3}
       flex={1}
-      width='full'
       closeOnSelect={!hasSubmenu}
       isDisabled={isDisabled}
       style={isDisabled ? disabledStyleOverride : undefined}

--- a/src/components/Layout/Header/NavBar/ExpandedMenuItem.tsx
+++ b/src/components/Layout/Header/NavBar/ExpandedMenuItem.tsx
@@ -59,13 +59,15 @@ export const ExpandedMenuItem = ({
       display='flex'
       alignItems='center'
       px={3}
+      flex={1}
+      width='full'
       closeOnSelect={!hasSubmenu}
       isDisabled={isDisabled}
       style={isDisabled ? disabledStyleOverride : undefined}
       {...props}
     >
       <Text flex={1} translation={label} />
-      <RawText ml={3} color={valueColor}>
+      <RawText ml={3} color={valueColor} fontSize='xs'>
         {value}
       </RawText>
       {badge && (
@@ -84,7 +86,7 @@ export const ExpandedMenuItem = ({
   )
 
   return externalUrl && !isDisabled ? (
-    <Link href={externalUrl} isExternal style={{ textDecoration: 'none' }}>
+    <Link href={externalUrl} isExternal style={{ textDecoration: 'none' }} display='flex'>
       {expandedMenuItem}
     </Link>
   ) : (

--- a/src/components/Layout/Header/NavBar/Native/NativeMenu.tsx
+++ b/src/components/Layout/Header/NavBar/Native/NativeMenu.tsx
@@ -1,35 +1,24 @@
+import { ChevronRightIcon } from '@chakra-ui/icons'
 import { MenuDivider, MenuGroup, MenuItem } from '@chakra-ui/menu'
-import { Flex } from '@chakra-ui/react'
-import { useTranslate } from 'react-polyglot'
-import { SubMenuContainer } from 'components/Layout/Header/NavBar/SubMenuContainer'
-import { SubmenuHeader } from 'components/Layout/Header/NavBar/SubmenuHeader'
-import { WalletImage } from 'components/Layout/Header/NavBar/WalletImage'
-import { RawText, Text } from 'components/Text'
+import { Button } from '@chakra-ui/react'
+import { Text } from 'components/Text'
 import { useModal } from 'hooks/useModal/useModal'
-import { useWallet } from 'hooks/useWallet/useWallet'
 
 export const NativeMenu = () => {
-  const translate = useTranslate()
-  const {
-    state: { walletInfo },
-  } = useWallet()
   const { backupNativePassphrase } = useModal()
 
   return (
-    <SubMenuContainer>
-      <SubmenuHeader title={translate('common.connectedWalletSettings')} />
-      <MenuGroup>
-        <Flex px={4} py={2}>
-          <WalletImage walletInfo={walletInfo} />
-          <Flex flex={1} ml={3} justifyContent='space-between' alignItems='center'>
-            <RawText>{walletInfo?.name}</RawText>
-          </Flex>
-        </Flex>
-        <MenuDivider />
-        <MenuItem onClick={() => backupNativePassphrase.open({})}>
-          <Text translation='modals.shapeShift.backupPassphrase.menuItem' />
-        </MenuItem>
-      </MenuGroup>
-    </SubMenuContainer>
+    <>
+      <MenuDivider />
+      <MenuItem
+        as={Button}
+        variant='ghost'
+        justifyContent='space-between'
+        rightIcon={<ChevronRightIcon />}
+        onClick={() => backupNativePassphrase.open({})}
+      >
+        <Text translation='modals.shapeShift.backupPassphrase.menuItem' />
+      </MenuItem>
+    </>
   )
 }

--- a/src/components/Layout/Header/NavBar/Native/NativeMenu.tsx
+++ b/src/components/Layout/Header/NavBar/Native/NativeMenu.tsx
@@ -1,5 +1,5 @@
 import { ChevronRightIcon } from '@chakra-ui/icons'
-import { MenuDivider, MenuGroup, MenuItem } from '@chakra-ui/menu'
+import { MenuDivider, MenuItem } from '@chakra-ui/menu'
 import { Button } from '@chakra-ui/react'
 import { Text } from 'components/Text'
 import { useModal } from 'hooks/useModal/useModal'

--- a/src/components/Layout/Header/NavBar/UserMenu.tsx
+++ b/src/components/Layout/Header/NavBar/UserMenu.tsx
@@ -156,7 +156,7 @@ export const UserMenu: React.FC<{ onClick?: () => void }> = ({ onClick }) => {
           walletInfo={walletInfo}
           isConnected={isConnected}
           isDemoWallet={isDemoWallet}
-          isLoadingLocalWallet={state.isLoadingLocalWallet}
+          isLoadingLocalWallet={isLoadingLocalWallet}
           data-test='navigation-wallet-dropdown-button'
         />
         <MenuList

--- a/src/components/Layout/Header/NavBar/UserMenu.tsx
+++ b/src/components/Layout/Header/NavBar/UserMenu.tsx
@@ -140,7 +140,7 @@ const WalletButton: FC<WalletButtonProps> = ({
 
 export const UserMenu: React.FC<{ onClick?: () => void }> = ({ onClick }) => {
   const { state, dispatch, disconnect } = useWallet()
-  const { isConnected, isDemoWallet, walletInfo, type, isLocked } = state
+  const { isConnected, isDemoWallet, walletInfo, type, isLocked, isLoadingLocalWallet } = state
 
   if (isLocked) disconnect()
   const hasWallet = Boolean(walletInfo?.deviceId)
@@ -150,7 +150,7 @@ export const UserMenu: React.FC<{ onClick?: () => void }> = ({ onClick }) => {
   }
   return (
     <ButtonGroup width='full'>
-      <Menu>
+      <Menu autoSelect={false}>
         <WalletButton
           onConnect={handleConnect}
           walletInfo={walletInfo}

--- a/src/components/Layout/Header/NavBar/UserMenu.tsx
+++ b/src/components/Layout/Header/NavBar/UserMenu.tsx
@@ -1,6 +1,6 @@
 import { ChevronDownIcon, WarningTwoIcon } from '@chakra-ui/icons'
 import { Menu, MenuButton, MenuGroup, MenuItem, MenuList } from '@chakra-ui/menu'
-import { Button, ButtonGroup, Flex, HStack, IconButton, useColorModeValue } from '@chakra-ui/react'
+import { Button, ButtonGroup, Flex, HStack, useColorModeValue } from '@chakra-ui/react'
 import type { FC } from 'react'
 import { useEffect, useState } from 'react'
 import { FaWallet } from 'react-icons/fa'
@@ -98,11 +98,13 @@ const WalletButton: FC<WalletButtonProps> = ({
   }, [ensName, isEnsNameLoading, isEnsNameLoaded, walletInfo])
 
   return Boolean(walletInfo?.deviceId) || isLoadingLocalWallet ? (
-    <Button
+    <MenuButton
+      as={Button}
       width={{ base: '100%', lg: 'auto' }}
       justifyContent='flex-start'
       variant='outline'
       isLoading={isLoadingLocalWallet}
+      rightIcon={<ChevronDownIcon />}
       leftIcon={
         <HStack>
           {!(isConnected || isDemoWallet) && (
@@ -128,7 +130,7 @@ const WalletButton: FC<WalletButtonProps> = ({
           <RawText>{walletInfo?.name}</RawText>
         )}
       </Flex>
-    </Button>
+    </MenuButton>
   ) : (
     <Button onClick={onConnect} leftIcon={<FaWallet />}>
       <Text translation='common.connectWallet' />
@@ -148,18 +150,13 @@ export const UserMenu: React.FC<{ onClick?: () => void }> = ({ onClick }) => {
   }
   return (
     <ButtonGroup width='full'>
-      <WalletButton
-        onConnect={handleConnect}
-        walletInfo={walletInfo}
-        isConnected={isConnected}
-        isDemoWallet={isDemoWallet}
-        isLoadingLocalWallet={state.isLoadingLocalWallet}
-      />
       <Menu>
-        <MenuButton
-          as={IconButton}
-          aria-label='Open wallet dropdown menu'
-          icon={<ChevronDownIcon />}
+        <WalletButton
+          onConnect={handleConnect}
+          walletInfo={walletInfo}
+          isConnected={isConnected}
+          isDemoWallet={isDemoWallet}
+          isLoadingLocalWallet={state.isLoadingLocalWallet}
           data-test='navigation-wallet-dropdown-button'
         />
         <MenuList

--- a/src/components/Layout/Header/NavBar/WalletConnectedMenu.tsx
+++ b/src/components/Layout/Header/NavBar/WalletConnectedMenu.tsx
@@ -29,12 +29,17 @@ export const WalletConnectedMenu = ({
     () => type && SUPPORTED_WALLETS[type].connectedWalletMenuRoutes,
     [type],
   )
+  const ConnectMenuComponent = useMemo(
+    () => type && SUPPORTED_WALLETS[type].connectedMenuComponent,
+    [type],
+  )
 
   const ConnectedMenu = () => {
     return (
       <MenuGroup title={translate('common.connectedWallet')} color='gray.500'>
         <MenuItem
           closeOnSelect={!connectedWalletMenuRoutes}
+          isDisabled={!connectedWalletMenuRoutes}
           onClick={
             connectedWalletMenuRoutes
               ? () =>
@@ -58,6 +63,7 @@ export const WalletConnectedMenu = ({
             {connectedWalletMenuRoutes && <ChevronRightIcon />}
           </Flex>
         </MenuItem>
+        {ConnectMenuComponent && <ConnectMenuComponent />}
         <MenuDivider />
         <MenuItem icon={<RepeatIcon />} onClick={onSwitchProvider}>
           {translate('connectWallet.menu.switchWallet')}

--- a/src/context/WalletProvider/config.ts
+++ b/src/context/WalletProvider/config.ts
@@ -75,6 +75,7 @@ export interface SupportedWalletInfo {
   routes: RouteProps[]
   connectedWalletMenuRoutes?: RouteProps[]
   connectedWalletMenuInitialPath?: WalletConnectedRoutes
+  connectedMenuComponent?: React.ComponentType<any> | undefined
 }
 
 export const SUPPORTED_WALLETS: Record<KeyManager, SupportedWalletInfo> = {
@@ -111,8 +112,7 @@ export const SUPPORTED_WALLETS: Record<KeyManager, SupportedWalletInfo> = {
       { path: '/native/legacy/login', component: NativeLegacyLogin },
       { path: '/native/legacy/login/success', component: NativeLegacySuccess },
     ],
-    connectedWalletMenuRoutes: [{ path: WalletConnectedRoutes.Native, component: NativeMenu }],
-    connectedWalletMenuInitialPath: WalletConnectedRoutes.Native,
+    connectedMenuComponent: NativeMenu,
   },
   [KeyManager.KeepKey]: {
     ...KeepKeyConfig,

--- a/src/context/WalletProvider/config.ts
+++ b/src/context/WalletProvider/config.ts
@@ -75,7 +75,7 @@ export interface SupportedWalletInfo {
   routes: RouteProps[]
   connectedWalletMenuRoutes?: RouteProps[]
   connectedWalletMenuInitialPath?: WalletConnectedRoutes
-  connectedMenuComponent?: React.ComponentType<any> | undefined
+  connectedMenuComponent?: React.ComponentType<any>
 }
 
 export const SUPPORTED_WALLETS: Record<KeyManager, SupportedWalletInfo> = {

--- a/src/context/WalletProvider/config.ts
+++ b/src/context/WalletProvider/config.ts
@@ -94,8 +94,7 @@ export const SUPPORTED_WALLETS: Record<KeyManager, SupportedWalletInfo> = {
       // WalletProvider.create looks for the first path that ends in "create"
       { path: '/mobile/legacy/create', component: MobileLegacyCreate },
     ],
-    connectedWalletMenuRoutes: [{ path: WalletConnectedRoutes.Native, component: NativeMenu }],
-    connectedWalletMenuInitialPath: WalletConnectedRoutes.Native,
+    connectedMenuComponent: NativeMenu,
   },
   [KeyManager.Native]: {
     ...NativeConfig,


### PR DESCRIPTION
## Description

- Wallets can now add a `connectedMenuComponent` that will render within the wallet dropdown
- Native right now is the only wallet that will use this
- I also tidied up the KeepKey menu a little

## Notice

<!-- Before submitting a pull request, please make sure you have answered the following: -->

- [x] Have you followed the guidelines in our [Contributing]('https://github.com/shapeshift/web/blob/develop/CONTRIBUTING.md) guide?
- [x] Have you checked to ensure there aren't other open [Pull Requests](https://github.com/shapeshift/web/pulls) for the same update/change?

## Pull Request Type

- [x] :bug: Bug fix (Non-breaking Change: Fixes an issue)
- [ ] :hammer_and_wrench: Chore (Non-breaking Change: Doc updates, pkg upgrades, typos, etc..)
- [ ] :nail_care: New Feature (Breaking/Non-breaking Change)

## Issue (if applicable)

<!-----------------------------------------------------------------------------
If applicable, please link to the github issue and put `closes #XXXX` in your comment to auto-close the issue that your PR fixes.
------------------------------------------------------------------------------>

closes #3829 

## Risk

<!-----------------------------------------------------------------------------
Outline the scope of your changes and the risk associated with them. You must use your discretion as an engineer to determine the potential impact of your changes.

E.g. an upgrade to `hdwallet` or core state management would be considered higher risk, and might require a full regression test. UI or isolated view changes, or something behind a feature flag may have near zero risk. Small bug fixes might require testing isolated to the specific fix.
------------------------------------------------------------------------------>
small risk

## Testing

<!-----------------------------------------------------------------------------
We treat every PR to be merged with the same scrutiny as if we were merging directly to production.

Your PR will not be merged if you do not complete the sections below for our engineering and operations teams to test.
------------------------------------------------------------------------------>

### Engineering

<!-----------------------------------------------------------------------------
Include sufficient information here for an engineer to test your PR. This may include how to test locally, in a built environment, changes to infrastructure etc.
------------------------------------------------------------------------------>

### Operations

<!-----------------------------------------------------------------------------
If your changes have a user-facing impact, describe how a non-technical QA team can functionally test your changes in a preview environment.

If they are not user-facing please describe how to test for any regressions that may occur.
------------------------------------------------------------------------------>
When connected to a native wallet you will now see in the wallet dropdown a "backup my wallet" menu item. And the header should be in a disabled state to signify that it has no sub menu.

This should not change the currently functionality for existing wallet sub menus e.g. KeepKey

## Screenshots (if applicable)
![Screen Shot 2023-02-14 at 10 55 02 AM](https://user-images.githubusercontent.com/89934888/218804642-2c7ed2ee-0072-48e5-9dec-1cdb69b05e15.png)
![Screen Shot 2023-02-14 at 10 56 39 AM](https://user-images.githubusercontent.com/89934888/218805038-80d2c3d0-845b-4ae6-95ae-8b32435f6e2d.png)

