### PR TITLE
fix: increase osmosis lp default slippage tolerance

### DIFF
--- a/src/features/defi/providers/osmosis/components/OsmosisManager/Lp/Deposit/components/Deposit.tsx
+++ b/src/features/defi/providers/osmosis/components/OsmosisManager/Lp/Deposit/components/Deposit.tsx
@@ -38,7 +38,7 @@ import { useAppSelector } from 'state/store'
 import { OsmosisDepositActionType } from '../LpDepositCommon'
 import { DepositContext } from '../LpDepositContext'
 
-const DEFAULT_SLIPPAGE = '0.0025' // Allow for 0.25% slippage. TODO(pastaghost): is there a better way to do this?
+const DEFAULT_SLIPPAGE = '0.025' // Allow for 2.5% slippage. TODO(pastaghost): is there a better way to do this?
 
 const moduleLogger = logger.child({
   namespace: ['DeFi', 'Providers', 'Osmosis', 'Deposit', 'Deposit'],

--- a/src/features/defi/providers/osmosis/components/OsmosisManager/Lp/Withdraw/components/Confirm.tsx
+++ b/src/features/defi/providers/osmosis/components/OsmosisManager/Lp/Withdraw/components/Confirm.tsx
@@ -38,7 +38,7 @@ import { useAppSelector } from 'state/store'
 import { OsmosisWithdrawActionType } from '../LpWithdrawCommon'
 import { WithdrawContext } from '../LpWithdrawContext'
 
-const DEFAULT_SLIPPAGE = '0.0025' // Allow for 0.25% slippage. TODO:(pastaghost) is there a better way to do this?
+const DEFAULT_SLIPPAGE = '0.025' // Allow for 2.5% slippage. TODO:(pastaghost) is there a better way to do this?
 
 const moduleLogger = logger.child({
   namespace: ['Defi', 'Providers', 'Osmosis', 'OsmosisManager', 'Withdraw', 'Confirm'],


### PR DESCRIPTION
## Description

<!-- Please describe your changes -->
* Updates the default slippage tolerance for Osmosis LP deposit/withdraw transactions to 2.5%. This matches the default settings used on app.osmosis.zone, and will improve the reliability of lp deposit/withdraw transactions.
## Notice

<!-- Before submitting a pull request, please make sure you have answered the following: -->

- [x] Have you followed the guidelines in our [Contributing]('https://github.com/shapeshift/web/blob/develop/CONTRIBUTING.md) guide?
- [x] Have you checked to ensure there aren't other open [Pull Requests](https://github.com/shapeshift/web/pulls) for the same update/change?

## Pull Request Type

- [x] :bug: Bug fix (Non-breaking Change: Fixes an issue)
- [ ] :hammer_and_wrench: Chore (Non-breaking Change: Doc updates, pkg upgrades, typos, etc..)
- [ ] :nail_care: New Feature (Breaking/Non-breaking Change)

## Issue (if applicable)

<!-----------------------------------------------------------------------------
If applicable, please link to the github issue and put `closes #XXXX` in your comment to auto-close the issue that your PR fixes.
------------------------------------------------------------------------------>

closes #

## Risk

<!-----------------------------------------------------------------------------
Outline the scope of your changes and the risk associated with them. You must use your discretion as an engineer to determine the potential impact of your changes.

E.g. an upgrade to `hdwallet` or core state management would be considered higher risk, and might require a full regression test. UI or isolated view changes, or something behind a feature flag may have near zero risk. Small bug fixes might require testing isolated to the specific fix.
------------------------------------------------------------------------------>
None 

## Testing

<!-----------------------------------------------------------------------------
We treat every PR to be merged with the same scrutiny as if we were merging directly to production.

Your PR will not be merged if you do not complete the sections below for our engineering and operations teams to test.
------------------------------------------------------------------------------>

### Engineering

<!-----------------------------------------------------------------------------
Include sufficient information here for an engineer to test your PR. This may include how to test locally, in a built environment, changes to infrastructure etc.
------------------------------------------------------------------------------>
*From the DeFi section, select any Osmosis LP opportunity.
* Ensure that LP deposit and withdraw transactions are broadcast successfully, and that the shareOutAmount slippage does not exceed 2.5%.

### Operations

<!-----------------------------------------------------------------------------
If your changes have a user-facing impact, describe how a non-technical QA team can functionally test your changes in a preview environment.

If they are not user-facing please describe how to test for any regressions that may occur.
------------------------------------------------------------------------------>
See above.

## Screenshots (if applicable)
