### PR TITLE
fix: osmosis lp withdrawal confirm amounts

### DIFF
--- a/src/features/defi/providers/osmosis/components/OsmosisManager/Lp/Withdraw/components/Confirm.tsx
+++ b/src/features/defi/providers/osmosis/components/OsmosisManager/Lp/Withdraw/components/Confirm.tsx
@@ -226,13 +226,14 @@ export const Confirm: React.FC<ConfirmProps> = ({ accountId, onNext }) => {
     return null
 
   const underlyingAsset0AmountPrecision = bnOrZero(state.withdraw.underlyingAsset0.amount)
-    .dividedBy(bn(10).pow(lpAsset.precision ?? '0'))
+    .dividedBy(bn(10).pow(underlyingAsset0.precision ?? '0'))
     .toString()
   const underlyingAsset1AmountPrecision = bnOrZero(state.withdraw.underlyingAsset1.amount)
-    .dividedBy(bn(10).pow(lpAsset.precision ?? '0'))
+    .dividedBy(bn(10).pow(underlyingAsset1.precision ?? '0'))
     .toString()
 
-  if (!(feeAsset && lpAsset)) return null
+  if (!(feeAsset && lpAsset && underlyingAsset0AmountPrecision && underlyingAsset1AmountPrecision))
+    return null
 
   return (
     <ReusableConfirm


### PR DESCRIPTION
## Description

<!-- Please describe your changes -->
* fixes zero amounts on Osmosis LP withdraw confirm modal
* automatically switches the osmosis lp withdraw receive amount precision on value entry
## Notice

<!-- Before submitting a pull request, please make sure you have answered the following: -->

- [x] Have you followed the guidelines in our [Contributing]('https://github.com/shapeshift/web/blob/develop/CONTRIBUTING.md) guide?
- [x] Have you checked to ensure there aren't other open [Pull Requests](https://github.com/shapeshift/web/pulls) for the same update/change?

## Pull Request Type

- [x] :bug: Bug fix (Non-breaking Change: Fixes an issue)
- [ ] :hammer_and_wrench: Chore (Non-breaking Change: Doc updates, pkg upgrades, typos, etc..)
- [ ] :nail_care: New Feature (Breaking/Non-breaking Change)

## Issue (if applicable)

<!-----------------------------------------------------------------------------
If applicable, please link to the github issue and put `closes #XXXX` in your comment to auto-close the issue that your PR fixes.
------------------------------------------------------------------------------>

closes #

## Risk

<!-----------------------------------------------------------------------------
Outline the scope of your changes and the risk associated with them. You must use your discretion as an engineer to determine the potential impact of your changes.

E.g. an upgrade to `hdwallet` or core state management would be considered higher risk, and might require a full regression test. UI or isolated view changes, or something behind a feature flag may have near zero risk. Small bug fixes might require testing isolated to the specific fix.
------------------------------------------------------------------------------>

## Testing

<!-----------------------------------------------------------------------------
We treat every PR to be merged with the same scrutiny as if we were merging directly to production.

Your PR will not be merged if you do not complete the sections below for our engineering and operations teams to test.
------------------------------------------------------------------------------>

### Engineering

<!-----------------------------------------------------------------------------
Include sufficient information here for an engineer to test your PR. This may include how to test locally, in a built environment, changes to infrastructure etc.
------------------------------------------------------------------------------>

### Operations

<!-----------------------------------------------------------------------------
If your changes have a user-facing impact, describe how a non-technical QA team can functionally test your changes in a preview environment.

If they are not user-facing please describe how to test for any regressions that may occur.
------------------------------------------------------------------------------>
* Select an Osmosis LP opportunity from the DeFi earn page
* Initiate a withdrawal and verify that the amount field values are formatted in single-digit precision before a value is entered and six-digit precision after a value has been entered
* Click continue and verify that the confirm modal amount fields contain the correct values

## Screenshots (if applicable)
<img width="526" alt="Screenshot 2023-02-16 at 10 52 59 PM" src="https://user-images.githubusercontent.com/62026038/219561713-ebc6f3c8-3c8c-475d-85a4-be90491a9eec.png">
<img width="524" alt="Screenshot 2023-02-16 at 10 53 28 PM" src="https://user-images.githubusercontent.com/62026038/219561735-88679872-e5b5-4f40-a16e-586ce0344713.png">
<img width="522" alt="Screenshot 2023-02-16 at 10 53 33 PM" src="https://user-images.githubusercontent.com/62026038/219561756-6d55c501-d293-4fa6-9077-1136350b68f9.png">




