### PR TITLE
fix: osmosis lp withdraw asset 1 precision

### DIFF
--- a/src/features/defi/providers/osmosis/components/OsmosisManager/Lp/Withdraw/components/Withdraw.tsx
+++ b/src/features/defi/providers/osmosis/components/OsmosisManager/Lp/Withdraw/components/Withdraw.tsx
@@ -509,7 +509,7 @@ export const Withdraw: React.FC<WithdrawProps> = ({
             cryptoAmount={
               bnOrZero(receiveAmounts?.[1]?.cryptoAmountBaseUnit).gt(0)
                 ? bnOrZero(receiveAmounts?.[1]?.cryptoAmountBaseUnit)
-                    .div(bn(10).pow(underlyingAsset0.precision ?? '0'))
+                    .div(bn(10).pow(underlyingAsset1.precision ?? '0'))
                     .toFixed(underlyingAsset1.precision, BigNumber.ROUND_DOWN)
                 : '0'
             }


### PR DESCRIPTION
## Description

Spotted by ops in https://discord.com/channels/554694662431178782/1066088208905031681/1077736668167163904

> 2. still showing 0 osmo in the withdraw screen for token LP withdrawals


Fixes the wrong precision of asset 0 being used for asset 1 at withdraw step, which accidentally worked for the ATOM/OSMO LP since both have the same precision, but won't work for some IBC token / OSMO, since they might have any precision (18 for INJ), but OSMO only has 6 dp.

## Notice

<!-- Before submitting a pull request, please make sure you have answered the following: -->

- [x] Have you followed the guidelines in our [Contributing]('https://github.com/shapeshift/web/blob/develop/CONTRIBUTING.md) guide?
- [x] Have you checked to ensure there aren't other open [Pull Requests](https://github.com/shapeshift/web/pulls) for the same update/change?

## Pull Request Type

- [x] :bug: Bug fix (Non-breaking Change: Fixes an issue)
- [ ] :hammer_and_wrench: Chore (Non-breaking Change: Doc updates, pkg upgrades, typos, etc..)
- [ ] :nail_care: New Feature (Breaking/Non-breaking Change)

## Issue (if applicable)

N/A

## Risk

<!-----------------------------------------------------------------------------
Outline the scope of your changes and the risk associated with them. You must use your discretion as an engineer to determine the potential impact of your changes.

E.g. an upgrade to `hdwallet` or core state management would be considered higher risk, and might require a full regression test. UI or isolated view changes, or something behind a feature flag may have near zero risk. Small bug fixes might require testing isolated to the specific fix.
------------------------------------------------------------------------------>

None

## Testing

<!-----------------------------------------------------------------------------
We treat every PR to be merged with the same scrutiny as if we were merging directly to production.

Your PR will not be merged if you do not complete the sections below for our engineering and operations teams to test.
------------------------------------------------------------------------------>

- Withdraw from any Osmo LP - test with a few different ones including ATOM/OSMO
- Ensure a crypto value is present both for asset 0 and asset 1

### Engineering

<!-----------------------------------------------------------------------------
Include sufficient information here for an engineer to test your PR. This may include how to test locally, in a built environment, changes to infrastructure etc.
------------------------------------------------------------------------------>

- ☝🏽 

### Operations

<!-----------------------------------------------------------------------------
If your changes have a user-facing impact, describe how a non-technical QA team can functionally test your changes in a preview environment.

If they are not user-facing please describe how to test for any regressions that may occur.
------------------------------------------------------------------------------>

- ☝🏽 

## Screenshots (if applicable)

#### This diff

<img width="565" alt="image" src="https://user-images.githubusercontent.com/17035424/220677830-01a2dfaa-554b-4a4f-8b9d-28bd2a3ab7b1.png">
<img width="533" alt="image" src="https://user-images.githubusercontent.com/17035424/220677924-535d2740-54e0-410f-bb5d-74f9700360a0.png">

#### Prod

<img width="531" alt="image" src="https://user-images.githubusercontent.com/17035424/220680276-9618169b-8fde-47b6-8d94-978a56021458.png">
<img width="515" alt="image" src="https://user-images.githubusercontent.com/17035424/220680494-3a60d5db-f12a-49b8-8231-f6d85913d598.png">