### PR TITLE
fix: osmosis lp deposit asset 1 fiat balance

### DIFF
--- a/src/features/defi/components/Deposit/PairDepositWithAllocation.tsx
+++ b/src/features/defi/components/Deposit/PairDepositWithAllocation.tsx
@@ -303,7 +303,7 @@ export const PairDepositWithAllocation = ({
     .times(asset1MarketData.price)
     .toString()
   const fiatAmountAvailable2 = bnOrZero(underlyingAsset2CryptoAmountAvailablePrecision)
-    .times(asset1MarketData.price)
+    .times(asset2MarketData.price)
     .toString()
 
   return (


### PR DESCRIPTION
## Description

Spotted by ops in https://discord.com/channels/554694662431178782/1066088208905031681/1077736668167163904

> 5.Select USD amount still gives a higher balance of osmo than is in the account 


Fixes the wrong market data of asset "1" being used instead of the asset "2" one in https://github.com/shapeshift/web/pull/3890/commits/f40ffe833abff6103a4034e8cee12b05b533a999

~~Also consolidates the terminology from asset 1/2 to 0/1 in https://github.com/shapeshift/web/pull/3890/commits/295b4568c694ae4f1e47f776aef35db8bf0d1b22 to avoid such confusion in the future~~  split as a follow-up stack in https://github.com/shapeshift/web/pull/3892

## Notice

<!-- Before submitting a pull request, please make sure you have answered the following: -->

- [x] Have you followed the guidelines in our [Contributing]('https://github.com/shapeshift/web/blob/develop/CONTRIBUTING.md) guide?
- [x] Have you checked to ensure there aren't other open [Pull Requests](https://github.com/shapeshift/web/pulls) for the same update/change?

## Pull Request Type

- [x] :bug: Bug fix (Non-breaking Change: Fixes an issue)
- [ ] :hammer_and_wrench: Chore (Non-breaking Change: Doc updates, pkg upgrades, typos, etc..)
- [ ] :nail_care: New Feature (Breaking/Non-breaking Change)

## Issue (if applicable)

N/A

## Risk

<!-----------------------------------------------------------------------------
Outline the scope of your changes and the risk associated with them. You must use your discretion as an engineer to determine the potential impact of your changes.

E.g. an upgrade to `hdwallet` or core state management would be considered higher risk, and might require a full regression test. UI or isolated view changes, or something behind a feature flag may have near zero risk. Small bug fixes might require testing isolated to the specific fix.
------------------------------------------------------------------------------>

None

## Testing

<!-----------------------------------------------------------------------------
We treat every PR to be merged with the same scrutiny as if we were merging directly to production.

Your PR will not be merged if you do not complete the sections below for our engineering and operations teams to test.
------------------------------------------------------------------------------>

- Deposit to any Osmo LP - test with a few different ones including ATOM/OSMO
- Ensure the fiat balance shown for the asset 1 (e.g OSMO in ATOM/OSMO) is correct and matches your wallet balance.

### Engineering

<!-----------------------------------------------------------------------------
Include sufficient information here for an engineer to test your PR. This may include how to test locally, in a built environment, changes to infrastructure etc.
------------------------------------------------------------------------------>

- ☝🏽 

### Operations

<!-----------------------------------------------------------------------------
If your changes have a user-facing impact, describe how a non-technical QA team can functionally test your changes in a preview environment.

If they are not user-facing please describe how to test for any regressions that may occur.
------------------------------------------------------------------------------>

- ☝🏽 

## Screenshots (if applicable)

#### This diff

<img width="539" alt="image" src="https://user-images.githubusercontent.com/17035424/220690325-6f7de341-4238-4a3d-86a7-5f2e3415bb15.png">

#### Prod

<img width="543" alt="image" src="https://user-images.githubusercontent.com/17035424/220690430-d398a9bd-961e-420f-8e26-a3b37a3caa2a.png">
