### PR TITLE
feat(defi): asset 1/2 -> 0/1 terminology

### DIFF
--- a/src/features/defi/components/Deposit/PairDeposit.tsx
+++ b/src/features/defi/components/Deposit/PairDeposit.tsx
@@ -76,10 +76,10 @@ export const PairDeposit = ({
   destAsset,
   marketData0,
   marketData1,
-  cryptoAmountAvailable0: cryptoAmountAvailable1,
-  cryptoAmountAvailable1: cryptoAmountAvailable2,
-  fiatAmountAvailable0: fiatAmountAvailable1,
-  fiatAmountAvailable1: fiatAmountAvailable2,
+  cryptoAmountAvailable0,
+  cryptoAmountAvailable1,
+  fiatAmountAvailable0,
+  fiatAmountAvailable1,
   cryptoInputValidation0,
   cryptoInputValidation1,
   fiatInputValidation0,
@@ -180,7 +180,7 @@ export const PairDeposit = ({
     const fiatField = isForAsset0 ? Field.FiatAmount0 : Field.FiatAmount1
     const cryptoField = isForAsset0 ? Field.CryptoAmount0 : Field.CryptoAmount1
     const cryptoAmount = bnOrZero(
-      isForAsset0 ? cryptoAmountAvailable1 : cryptoAmountAvailable2,
+      isForAsset0 ? cryptoAmountAvailable0 : cryptoAmountAvailable1,
     ).times(percent)
     const fiatAmount = bnOrZero(cryptoAmount).times(assetMarketData.price)
     setValue(fiatField, fiatAmount.toString(), {
@@ -223,8 +223,8 @@ export const PairDeposit = ({
             assetId={asset0.assetId}
             assetIcon={asset0.icon}
             assetSymbol={asset0.symbol}
-            balance={cryptoAmountAvailable1}
-            fiatBalance={fiatAmountAvailable1}
+            balance={cryptoAmountAvailable0}
+            fiatBalance={fiatAmountAvailable0}
             onAccountIdChange={handleAccountIdChange}
             onPercentOptionClick={value => handlePercentClick(value, true)}
             percentOptions={percentOptions}
@@ -239,8 +239,8 @@ export const PairDeposit = ({
             assetId={asset1.assetId}
             assetIcon={asset1.icon}
             assetSymbol={asset1.symbol}
-            balance={cryptoAmountAvailable2}
-            fiatBalance={fiatAmountAvailable2}
+            balance={cryptoAmountAvailable1}
+            fiatBalance={fiatAmountAvailable1}
             onAccountIdChange={handleAccountIdChange}
             onPercentOptionClick={value => handlePercentClick(value, false)}
             percentOptions={percentOptions}

--- a/src/features/defi/components/Deposit/PairDeposit.tsx
+++ b/src/features/defi/components/Deposit/PairDeposit.tsx
@@ -105,7 +105,7 @@ export const PairDeposit = ({
       [Field.FiatAmount0]: '',
       [Field.FiatAmount1]: '',
       [Field.CryptoAmount0]: '',
-      [Field.CryptoAmount0]: '',
+      [Field.CryptoAmount1]: '',
     },
   })
 

--- a/src/features/defi/components/Deposit/PairDeposit.tsx
+++ b/src/features/defi/components/Deposit/PairDeposit.tsx
@@ -228,7 +228,7 @@ export const PairDeposit = ({
             onAccountIdChange={handleAccountIdChange}
             onPercentOptionClick={value => handlePercentClick(value, true)}
             percentOptions={percentOptions}
-            errors={cryptoError0 || fiatError1}
+            errors={cryptoError0 || fiatError0}
           />
           <AssetInput
             {...(accountId ? { accountId } : {})}

--- a/src/features/defi/components/Deposit/PairDeposit.tsx
+++ b/src/features/defi/components/Deposit/PairDeposit.tsx
@@ -20,29 +20,29 @@ import { PairIcons } from '../PairIcons/PairIcons'
 
 type DepositProps = {
   accountId?: AccountId | undefined
+  asset0: Asset
   asset1: Asset
-  asset2: Asset
   destAsset: Asset
   // Estimated apy (Deposit Only)
   apy: string
   // Users available amount
+  cryptoAmountAvailable0: string
   cryptoAmountAvailable1: string
-  cryptoAmountAvailable2: string
   // Validation rules for the crypto input
+  cryptoInputValidation0?: ControllerProps['rules']
   cryptoInputValidation1?: ControllerProps['rules']
-  cryptoInputValidation2?: ControllerProps['rules']
   // Users available amount
+  fiatAmountAvailable0: string
   fiatAmountAvailable1: string
-  fiatAmountAvailable2: string
   // Validation rules for the fiat input
+  fiatInputValidation0?: ControllerProps['rules']
   fiatInputValidation1?: ControllerProps['rules']
-  fiatInputValidation2?: ControllerProps['rules']
   // enables slippage UI (defaults to true)
   enableSlippage?: boolean
   // Asset1 market data
-  marketData1: MarketData
+  marketData0: MarketData
   // Asset2 market data
-  marketData2: MarketData
+  marketData1: MarketData
   // Array of the % options
   percentOptions: number[]
   isLoading: boolean
@@ -55,35 +55,35 @@ type DepositProps = {
 }
 
 enum Field {
+  FiatAmount0 = 'fiatAmount0',
   FiatAmount1 = 'fiatAmount1',
-  FiatAmount2 = 'fiatAmount2',
+  CryptoAmount0 = 'cryptoAmount0',
   CryptoAmount1 = 'cryptoAmount1',
-  CryptoAmount2 = 'cryptoAmount2',
 }
 
 export type DepositValues = {
+  [Field.FiatAmount0]: string
+  [Field.CryptoAmount0]: string
   [Field.FiatAmount1]: string
   [Field.CryptoAmount1]: string
-  [Field.FiatAmount2]: string
-  [Field.CryptoAmount2]: string
 }
 
 export const PairDeposit = ({
   apy,
   accountId,
+  asset0,
   asset1,
-  asset2,
   destAsset,
+  marketData0,
   marketData1,
-  marketData2,
-  cryptoAmountAvailable1,
-  cryptoAmountAvailable2,
-  fiatAmountAvailable1,
-  fiatAmountAvailable2,
+  cryptoAmountAvailable0: cryptoAmountAvailable1,
+  cryptoAmountAvailable1: cryptoAmountAvailable2,
+  fiatAmountAvailable0: fiatAmountAvailable1,
+  fiatAmountAvailable1: fiatAmountAvailable2,
+  cryptoInputValidation0,
   cryptoInputValidation1,
-  cryptoInputValidation2,
+  fiatInputValidation0,
   fiatInputValidation1,
-  fiatInputValidation2,
   isLoading,
   onAccountIdChange: handleAccountIdChange,
   onContinue,
@@ -102,49 +102,49 @@ export const PairDeposit = ({
   } = useForm<DepositValues>({
     mode: 'onChange',
     defaultValues: {
+      [Field.FiatAmount0]: '',
       [Field.FiatAmount1]: '',
-      [Field.FiatAmount2]: '',
-      [Field.CryptoAmount1]: '',
-      [Field.CryptoAmount2]: '',
+      [Field.CryptoAmount0]: '',
+      [Field.CryptoAmount0]: '',
     },
   })
 
   const values = useWatch({ control })
+  const { field: cryptoAmount0 } = useController({
+    name: 'cryptoAmount0',
+    control,
+    rules: cryptoInputValidation0,
+  })
   const { field: cryptoAmount1 } = useController({
     name: 'cryptoAmount1',
     control,
     rules: cryptoInputValidation1,
   })
-  const { field: cryptoAmount2 } = useController({
-    name: 'cryptoAmount2',
+  const { field: fiatAmount0 } = useController({
+    name: 'fiatAmount0',
     control,
-    rules: cryptoInputValidation2,
+    rules: fiatInputValidation0,
   })
   const { field: fiatAmount1 } = useController({
     name: 'fiatAmount1',
     control,
     rules: fiatInputValidation1,
   })
-  const { field: fiatAmount2 } = useController({
-    name: 'fiatAmount2',
-    control,
-    rules: fiatInputValidation2,
-  })
+  const cryptoError0 = get(errors, 'cryptoAmount0.message', null)
   const cryptoError1 = get(errors, 'cryptoAmount1.message', null)
-  const cryptoError2 = get(errors, 'cryptoAmount2.message', null)
+  const fiatError0 = get(errors, 'fiatAmount0.message', null)
   const fiatError1 = get(errors, 'fiatAmount1.message', null)
-  const fiatError2 = get(errors, 'fiatAmount2.message', null)
-  const fieldError = cryptoError1 || cryptoError2 || fiatError1 || fiatError2
+  const fieldError = cryptoError0 || cryptoError1 || fiatError0 || fiatError1
 
-  const handleInputChange = (value: string, isForAsset1: boolean, isFiat?: boolean) => {
-    const assetMarketData = isForAsset1 ? marketData1 : marketData2
-    const fiatField = isForAsset1 ? Field.FiatAmount1 : Field.FiatAmount2
-    const cryptoField = isForAsset1 ? Field.CryptoAmount1 : Field.CryptoAmount2
+  const handleInputChange = (value: string, isForAsset0: boolean, isFiat?: boolean) => {
+    const assetMarketData = isForAsset0 ? marketData0 : marketData1
+    const fiatField = isForAsset0 ? Field.FiatAmount0 : Field.FiatAmount1
+    const cryptoField = isForAsset0 ? Field.CryptoAmount0 : Field.CryptoAmount0
 
     // for keeping inputs synced
-    const otherFiatInput = !isForAsset1 ? Field.FiatAmount1 : Field.FiatAmount2
-    const otherCryptoInput = !isForAsset1 ? Field.CryptoAmount1 : Field.CryptoAmount2
-    const otherAssetMarketData = !isForAsset1 ? marketData1 : marketData2
+    const otherFiatInput = !isForAsset0 ? Field.FiatAmount0 : Field.FiatAmount1
+    const otherCryptoInput = !isForAsset0 ? Field.CryptoAmount0 : Field.CryptoAmount1
+    const otherAssetMarketData = !isForAsset0 ? marketData0 : marketData1
     if (isFiat) {
       setValue(fiatField, value, { shouldValidate: true })
       setValue(cryptoField, bnOrZero(value).div(assetMarketData.price).toString(), {
@@ -175,12 +175,12 @@ export const PairDeposit = ({
     }
   }
 
-  const handlePercentClick = (percent: number, isForAsset1: boolean) => {
-    const assetMarketData = isForAsset1 ? marketData1 : marketData2
-    const fiatField = isForAsset1 ? Field.FiatAmount1 : Field.FiatAmount2
-    const cryptoField = isForAsset1 ? Field.CryptoAmount1 : Field.CryptoAmount2
+  const handlePercentClick = (percent: number, isForAsset0: boolean) => {
+    const assetMarketData = isForAsset0 ? marketData0 : marketData1
+    const fiatField = isForAsset0 ? Field.FiatAmount0 : Field.FiatAmount1
+    const cryptoField = isForAsset0 ? Field.CryptoAmount0 : Field.CryptoAmount1
     const cryptoAmount = bnOrZero(
-      isForAsset1 ? cryptoAmountAvailable1 : cryptoAmountAvailable2,
+      isForAsset0 ? cryptoAmountAvailable1 : cryptoAmountAvailable2,
     ).times(percent)
     const fiatAmount = bnOrZero(cryptoAmount).times(assetMarketData.price)
     setValue(fiatField, fiatAmount.toString(), {
@@ -191,9 +191,9 @@ export const PairDeposit = ({
     })
     if (syncPair) {
       // for keeping inputs synced
-      const otherFiatInput = !isForAsset1 ? Field.FiatAmount1 : Field.FiatAmount2
-      const otherCryptoInput = !isForAsset1 ? Field.CryptoAmount1 : Field.CryptoAmount2
-      const otherAssetMarketData = !isForAsset1 ? marketData1 : marketData2
+      const otherFiatInput = !isForAsset0 ? Field.FiatAmount0 : Field.FiatAmount1
+      const otherCryptoInput = !isForAsset0 ? Field.CryptoAmount0 : Field.CryptoAmount1
+      const otherAssetMarketData = !isForAsset0 ? marketData0 : marketData1
       setValue(otherFiatInput, fiatAmount.toString(), {
         shouldValidate: true,
       })
@@ -208,7 +208,7 @@ export const PairDeposit = ({
   }
 
   const cryptoYield = calculateYearlyYield(apy, values.cryptoAmount1)
-  const fiatYield = bnOrZero(cryptoYield).times(marketData1.price).toFixed(2)
+  const fiatYield = bnOrZero(cryptoYield).times(marketData0.price).toFixed(2)
 
   return (
     <>
@@ -216,35 +216,35 @@ export const PairDeposit = ({
         <FormField label={translate('modals.deposit.amountToDeposit')}>
           <AssetInput
             {...(accountId ? { accountId } : {})}
-            cryptoAmount={cryptoAmount1?.value}
+            cryptoAmount={cryptoAmount0?.value}
             onChange={(value, isFiat) => handleInputChange(value, true, isFiat)}
-            fiatAmount={fiatAmount1?.value}
+            fiatAmount={fiatAmount0?.value}
             showFiatAmount={true}
-            assetId={asset1.assetId}
-            assetIcon={asset1.icon}
-            assetSymbol={asset1.symbol}
+            assetId={asset0.assetId}
+            assetIcon={asset0.icon}
+            assetSymbol={asset0.symbol}
             balance={cryptoAmountAvailable1}
             fiatBalance={fiatAmountAvailable1}
             onAccountIdChange={handleAccountIdChange}
             onPercentOptionClick={value => handlePercentClick(value, true)}
             percentOptions={percentOptions}
-            errors={cryptoError1 || fiatError1}
+            errors={cryptoError0 || fiatError1}
           />
           <AssetInput
             {...(accountId ? { accountId } : {})}
-            cryptoAmount={cryptoAmount2?.value}
+            cryptoAmount={cryptoAmount1?.value}
             onChange={(value, isFiat) => handleInputChange(value, false, isFiat)}
-            fiatAmount={fiatAmount2?.value}
+            fiatAmount={fiatAmount1?.value}
             showFiatAmount={true}
-            assetId={asset2.assetId}
-            assetIcon={asset2.icon}
-            assetSymbol={asset2.symbol}
+            assetId={asset1.assetId}
+            assetIcon={asset1.icon}
+            assetSymbol={asset1.symbol}
             balance={cryptoAmountAvailable2}
             fiatBalance={fiatAmountAvailable2}
             onAccountIdChange={handleAccountIdChange}
             onPercentOptionClick={value => handlePercentClick(value, false)}
             percentOptions={percentOptions}
-            errors={cryptoError2 || fiatError2}
+            errors={cryptoError1 || fiatError1}
           />
           <Row>
             <Stack flex={1} spacing={0}>

--- a/src/features/defi/components/Deposit/PairDeposit.tsx
+++ b/src/features/defi/components/Deposit/PairDeposit.tsx
@@ -139,7 +139,7 @@ export const PairDeposit = ({
   const handleInputChange = (value: string, isForAsset0: boolean, isFiat?: boolean) => {
     const assetMarketData = isForAsset0 ? marketData0 : marketData1
     const fiatField = isForAsset0 ? Field.FiatAmount0 : Field.FiatAmount1
-    const cryptoField = isForAsset0 ? Field.CryptoAmount0 : Field.CryptoAmount0
+    const cryptoField = isForAsset0 ? Field.CryptoAmount0 : Field.CryptoAmount1
 
     // for keeping inputs synced
     const otherFiatInput = !isForAsset0 ? Field.FiatAmount0 : Field.FiatAmount1

--- a/src/features/defi/components/Deposit/PairDepositWithAllocation.tsx
+++ b/src/features/defi/components/Deposit/PairDepositWithAllocation.tsx
@@ -45,11 +45,11 @@ type DepositProps = {
       }
     | undefined
   // Validation rules for the crypto input
+  cryptoInputValidation0?: ControllerProps['rules']
   cryptoInputValidation1?: ControllerProps['rules']
-  cryptoInputValidation2?: ControllerProps['rules']
   // Validation rules for the fiat input
+  fiatInputValidation0?: ControllerProps['rules']
   fiatInputValidation1?: ControllerProps['rules']
-  fiatInputValidation2?: ControllerProps['rules']
   // enables slippage UI (defaults to true)
   enableSlippage?: boolean
   // Array of the % options
@@ -63,19 +63,19 @@ type DepositProps = {
 }
 
 enum Field {
+  FiatAmount0 = 'fiatAmount0',
   FiatAmount1 = 'fiatAmount1',
-  FiatAmount2 = 'fiatAmount2',
+  CryptoAmount0 = 'cryptoAmount0',
   CryptoAmount1 = 'cryptoAmount1',
-  CryptoAmount2 = 'cryptoAmount2',
   AllocationFraction = 'allocationFraction',
   ShareOutAmount = 'shareOutAmount',
 }
 
 export type DepositValues = {
+  [Field.FiatAmount0]: string
+  [Field.CryptoAmount0]: string
   [Field.FiatAmount1]: string
   [Field.CryptoAmount1]: string
-  [Field.FiatAmount2]: string
-  [Field.CryptoAmount2]: string
   [Field.AllocationFraction]: string
   [Field.ShareOutAmount]: string
 }
@@ -83,11 +83,11 @@ export type DepositValues = {
 export const PairDepositWithAllocation = ({
   accountId,
   calculateAllocations,
+  cryptoInputValidation0,
   cryptoInputValidation1,
-  cryptoInputValidation2,
   destAssetId,
+  fiatInputValidation0,
   fiatInputValidation1,
-  fiatInputValidation2,
   isLoading,
   opportunity,
   onAccountIdChange: handleAccountIdChange,
@@ -106,10 +106,10 @@ export const PairDepositWithAllocation = ({
   } = useForm<DepositValues>({
     mode: 'onChange',
     defaultValues: {
+      [Field.FiatAmount0]: '',
       [Field.FiatAmount1]: '',
-      [Field.FiatAmount2]: '',
+      [Field.CryptoAmount0]: '',
       [Field.CryptoAmount1]: '',
-      [Field.CryptoAmount2]: '',
       [Field.AllocationFraction]: '',
       [Field.ShareOutAmount]: '',
     },
@@ -117,63 +117,63 @@ export const PairDepositWithAllocation = ({
 
   const apy = opportunity.apy?.toString() ?? ''
   const destAsset: Asset | undefined = useAppSelector(state => selectAssetById(state, destAssetId))
-  const asset1 = useAppSelector(state =>
+  const asset0 = useAppSelector(state =>
     selectAssetById(state, opportunity?.underlyingAssetIds[0] ?? ''),
   )
-  const asset2 = useAppSelector(state =>
+  const asset1 = useAppSelector(state =>
     selectAssetById(state, opportunity?.underlyingAssetIds[1] ?? ''),
   )
 
-  const underlyingAsset1Balance = useAppSelector(state =>
+  const underlyingAsset0Balance = useAppSelector(state =>
     selectPortfolioCryptoBalanceByFilter(state, {
       assetId: opportunity?.underlyingAssetIds[0],
       accountId: accountId ?? '',
     }),
   )
-  const underlyingAsset2Balance = useAppSelector(state =>
+  const underlyingAsset1Balance = useAppSelector(state =>
     selectPortfolioCryptoBalanceByFilter(state, {
       assetId: opportunity?.underlyingAssetIds[1],
       accountId: accountId ?? '',
     }),
   )
 
+  const underlyingAsset0CryptoAmountAvailablePrecision = bnOrZero(underlyingAsset0Balance)
+    .div(bn(10).pow(asset0?.precision ?? '0'))
+    .toString()
+
   const underlyingAsset1CryptoAmountAvailablePrecision = bnOrZero(underlyingAsset1Balance)
     .div(bn(10).pow(asset1?.precision ?? '0'))
     .toString()
 
-  const underlyingAsset2CryptoAmountAvailablePrecision = bnOrZero(underlyingAsset2Balance)
-    .div(bn(10).pow(asset2?.precision ?? '0'))
-    .toString()
-
+  const asset0MarketData = useAppSelector(state =>
+    selectMarketDataById(state, asset0?.assetId ?? ''),
+  )
   const asset1MarketData = useAppSelector(state =>
     selectMarketDataById(state, asset1?.assetId ?? ''),
-  )
-  const asset2MarketData = useAppSelector(state =>
-    selectMarketDataById(state, asset2?.assetId ?? ''),
   )
 
   const icons = opportunity.icons
 
   const values = useWatch({ control })
+  const { field: cryptoAmount0 } = useController({
+    name: 'cryptoAmount0',
+    control,
+    rules: cryptoInputValidation0,
+  })
   const { field: cryptoAmount1 } = useController({
     name: 'cryptoAmount1',
     control,
     rules: cryptoInputValidation1,
   })
-  const { field: cryptoAmount2 } = useController({
-    name: 'cryptoAmount2',
+  const { field: fiatAmount0 } = useController({
+    name: 'fiatAmount0',
     control,
-    rules: cryptoInputValidation2,
+    rules: fiatInputValidation0,
   })
   const { field: fiatAmount1 } = useController({
     name: 'fiatAmount1',
     control,
     rules: fiatInputValidation1,
-  })
-  const { field: fiatAmount2 } = useController({
-    name: 'fiatAmount2',
-    control,
-    rules: fiatInputValidation2,
   })
 
   const { field: allocationFraction } = useController({
@@ -185,25 +185,25 @@ export const PairDepositWithAllocation = ({
     control,
   })
 
-  if (!(asset1 && asset2 && destAsset)) return null
+  if (!(asset0 && asset1 && destAsset)) return null
 
+  const cryptoError0 = get(errors, 'cryptoAmount0.message', null)
   const cryptoError1 = get(errors, 'cryptoAmount1.message', null)
-  const cryptoError2 = get(errors, 'cryptoAmount2.message', null)
+  const fiatError0 = get(errors, 'fiatAmount0.message', null)
   const fiatError1 = get(errors, 'fiatAmount1.message', null)
-  const fiatError2 = get(errors, 'fiatAmount2.message', null)
-  const fieldError = cryptoError1 || cryptoError2 || fiatError1 || fiatError2
+  const fieldError = cryptoError0 || cryptoError1 || fiatError0 || fiatError1
 
-  const handleInputChange = (value: string, isForAsset1: boolean, isFiat?: boolean) => {
-    const assetMarketData = isForAsset1 ? asset1MarketData : asset2MarketData
-    const fiatField = isForAsset1 ? Field.FiatAmount1 : Field.FiatAmount2
-    const cryptoField = isForAsset1 ? Field.CryptoAmount1 : Field.CryptoAmount2
-    const selectedAsset = isForAsset1 ? asset1 : asset2
+  const handleInputChange = (value: string, isForAsset0: boolean, isFiat?: boolean) => {
+    const assetMarketData = isForAsset0 ? asset0MarketData : asset1MarketData
+    const fiatField = isForAsset0 ? Field.FiatAmount0 : Field.FiatAmount1
+    const cryptoField = isForAsset0 ? Field.CryptoAmount0 : Field.CryptoAmount1
+    const selectedAsset = isForAsset0 ? asset0 : asset1
 
     // for keeping inputs synced
-    const otherFiatInput = !isForAsset1 ? Field.FiatAmount1 : Field.FiatAmount2
-    const otherCryptoInput = !isForAsset1 ? Field.CryptoAmount1 : Field.CryptoAmount2
-    const otherAssetMarketData = !isForAsset1 ? asset1MarketData : asset2MarketData
-    const otherAsset = !isForAsset1 ? asset1 : asset2
+    const otherFiatInput = !isForAsset0 ? Field.FiatAmount0 : Field.FiatAmount1
+    const otherCryptoInput = !isForAsset0 ? Field.CryptoAmount0 : Field.CryptoAmount1
+    const otherAssetMarketData = !isForAsset0 ? asset0MarketData : asset1MarketData
+    const otherAsset = !isForAsset0 ? asset0 : asset1
     if (isFiat) {
       setValue(fiatField, value, { shouldValidate: true })
       setValue(
@@ -257,16 +257,16 @@ export const PairDepositWithAllocation = ({
     setValue(Field.ShareOutAmount, allocations.shareOutAmountCryptoPrecision)
   }
 
-  const handlePercentClick = (percent: number, isForAsset1: boolean) => {
-    const assetMarketData = isForAsset1 ? asset1MarketData : asset2MarketData
-    const fiatField = isForAsset1 ? Field.FiatAmount1 : Field.FiatAmount2
-    const cryptoField = isForAsset1 ? Field.CryptoAmount1 : Field.CryptoAmount2
-    const selectedAsset = isForAsset1 ? asset1 : asset2
+  const handlePercentClick = (percent: number, isForAsset0: boolean) => {
+    const assetMarketData = isForAsset0 ? asset0MarketData : asset1MarketData
+    const fiatField = isForAsset0 ? Field.FiatAmount0 : Field.FiatAmount1
+    const cryptoField = isForAsset0 ? Field.CryptoAmount0 : Field.CryptoAmount1
+    const selectedAsset = isForAsset0 ? asset0 : asset1
 
     const cryptoAmount = bnOrZero(
-      isForAsset1
-        ? underlyingAsset1CryptoAmountAvailablePrecision
-        : underlyingAsset2CryptoAmountAvailablePrecision,
+      isForAsset0
+        ? underlyingAsset0CryptoAmountAvailablePrecision
+        : underlyingAsset1CryptoAmountAvailablePrecision,
     ).times(percent)
     const fiatAmount = bnOrZero(cryptoAmount).times(assetMarketData.price)
     setValue(fiatField, fiatAmount.toString(), {
@@ -277,9 +277,9 @@ export const PairDepositWithAllocation = ({
     })
     if (syncPair) {
       // for keeping inputs synced
-      const otherFiatInput = !isForAsset1 ? Field.FiatAmount1 : Field.FiatAmount2
-      const otherCryptoInput = !isForAsset1 ? Field.CryptoAmount1 : Field.CryptoAmount2
-      const otherAssetMarketData = !isForAsset1 ? asset1MarketData : asset2MarketData
+      const otherFiatInput = !isForAsset0 ? Field.FiatAmount0 : Field.FiatAmount1
+      const otherCryptoInput = !isForAsset0 ? Field.CryptoAmount0 : Field.CryptoAmount1
+      const otherAssetMarketData = !isForAsset0 ? asset0MarketData : asset1MarketData
       setValue(otherFiatInput, fiatAmount.toString(), {
         shouldValidate: true,
       })
@@ -298,12 +298,12 @@ export const PairDepositWithAllocation = ({
   }
 
   const cryptoYield = calculateYearlyYield(apy, values.cryptoAmount1)
-  const fiatYield = bnOrZero(cryptoYield).times(asset1MarketData.price).toFixed(2)
-  const fiatAmountAvailable1 = bnOrZero(underlyingAsset1CryptoAmountAvailablePrecision)
-    .times(asset1MarketData.price)
+  const fiatYield = bnOrZero(cryptoYield).times(asset0MarketData.price).toFixed(2)
+  const fiatAmountAvailable1 = bnOrZero(underlyingAsset0CryptoAmountAvailablePrecision)
+    .times(asset0MarketData.price)
     .toString()
-  const fiatAmountAvailable2 = bnOrZero(underlyingAsset2CryptoAmountAvailablePrecision)
-    .times(asset2MarketData.price)
+  const fiatAmountAvailable2 = bnOrZero(underlyingAsset1CryptoAmountAvailablePrecision)
+    .times(asset1MarketData.price)
     .toString()
 
   return (
@@ -312,14 +312,14 @@ export const PairDepositWithAllocation = ({
         <FormField label={translate('modals.deposit.amountToDeposit')}>
           <AssetInput
             {...(accountId ? { accountId } : {})}
-            cryptoAmount={cryptoAmount1?.value}
+            cryptoAmount={cryptoAmount0?.value}
             onChange={(value, isFiat) => handleInputChange(value, true, isFiat)}
-            fiatAmount={fiatAmount1?.value}
+            fiatAmount={fiatAmount0?.value}
             showFiatAmount={true}
-            assetId={asset1.assetId}
-            assetIcon={asset1.icon}
-            assetSymbol={asset1.symbol}
-            balance={underlyingAsset1CryptoAmountAvailablePrecision}
+            assetId={asset0.assetId}
+            assetIcon={asset0.icon}
+            assetSymbol={asset0.symbol}
+            balance={underlyingAsset0CryptoAmountAvailablePrecision}
             fiatBalance={fiatAmountAvailable1}
             onAccountIdChange={handleAccountIdChange}
             onPercentOptionClick={value => handlePercentClick(value, true)}
@@ -328,29 +328,29 @@ export const PairDepositWithAllocation = ({
           />
           <AssetInput
             {...(accountId ? { accountId } : {})}
-            cryptoAmount={cryptoAmount2?.value}
+            cryptoAmount={cryptoAmount1?.value}
             onChange={(value, isFiat) => handleInputChange(value, false, isFiat)}
-            fiatAmount={fiatAmount2?.value}
+            fiatAmount={fiatAmount1?.value}
             showFiatAmount={true}
-            assetId={asset2.assetId}
-            assetIcon={asset2.icon}
-            assetSymbol={asset2.symbol}
-            balance={underlyingAsset2CryptoAmountAvailablePrecision}
+            assetId={asset1.assetId}
+            assetIcon={asset1.icon}
+            assetSymbol={asset1.symbol}
+            balance={underlyingAsset1CryptoAmountAvailablePrecision}
             fiatBalance={fiatAmountAvailable2}
             onAccountIdChange={handleAccountIdChange}
             onPercentOptionClick={value => handlePercentClick(value, false)}
             percentOptions={percentOptions}
-            errors={cryptoError2 || fiatError2}
+            errors={cryptoError1 || fiatError1}
           />
         </FormField>
         <Allocation
           {...(accountId ? { accountId } : {})}
           allocationFraction={allocationFraction?.value}
           assetId={destAsset.assetId}
-          assetSymbol={`${asset1.symbol}-${asset2.symbol}`}
+          assetSymbol={`${asset0.symbol}-${asset1.symbol}`}
           cryptoAmount={shareOutAmount.value}
-          errors={cryptoError2 || fiatError2}
-          fiatAmount={bnOrZero(fiatAmount1?.value).plus(bnOrZero(fiatAmount2?.value)).toString()}
+          errors={cryptoError1 || fiatError1}
+          fiatAmount={bnOrZero(fiatAmount1?.value).plus(bnOrZero(fiatAmount1?.value)).toString()}
           icons={icons}
           isReadOnly={true}
           onAccountIdChange={handleAccountIdChange}

--- a/src/features/defi/components/Deposit/PairDepositWithAllocation.tsx
+++ b/src/features/defi/components/Deposit/PairDepositWithAllocation.tsx
@@ -324,7 +324,7 @@ export const PairDepositWithAllocation = ({
             onAccountIdChange={handleAccountIdChange}
             onPercentOptionClick={value => handlePercentClick(value, true)}
             percentOptions={percentOptions}
-            errors={cryptoError1 || fiatError1}
+            errors={cryptoError0 || fiatError0}
           />
           <AssetInput
             {...(accountId ? { accountId } : {})}

--- a/src/features/defi/components/Deposit/PairDepositWithAllocation.tsx
+++ b/src/features/defi/components/Deposit/PairDepositWithAllocation.tsx
@@ -299,10 +299,10 @@ export const PairDepositWithAllocation = ({
 
   const cryptoYield = calculateYearlyYield(apy, values.cryptoAmount1)
   const fiatYield = bnOrZero(cryptoYield).times(asset0MarketData.price).toFixed(2)
-  const fiatAmountAvailable1 = bnOrZero(underlyingAsset0CryptoAmountAvailablePrecision)
+  const fiatAmountAvailable0 = bnOrZero(underlyingAsset0CryptoAmountAvailablePrecision)
     .times(asset0MarketData.price)
     .toString()
-  const fiatAmountAvailable2 = bnOrZero(underlyingAsset1CryptoAmountAvailablePrecision)
+  const fiatAmountAvailable1 = bnOrZero(underlyingAsset1CryptoAmountAvailablePrecision)
     .times(asset1MarketData.price)
     .toString()
 
@@ -320,7 +320,7 @@ export const PairDepositWithAllocation = ({
             assetIcon={asset0.icon}
             assetSymbol={asset0.symbol}
             balance={underlyingAsset0CryptoAmountAvailablePrecision}
-            fiatBalance={fiatAmountAvailable1}
+            fiatBalance={fiatAmountAvailable0}
             onAccountIdChange={handleAccountIdChange}
             onPercentOptionClick={value => handlePercentClick(value, true)}
             percentOptions={percentOptions}
@@ -336,7 +336,7 @@ export const PairDepositWithAllocation = ({
             assetIcon={asset1.icon}
             assetSymbol={asset1.symbol}
             balance={underlyingAsset1CryptoAmountAvailablePrecision}
-            fiatBalance={fiatAmountAvailable2}
+            fiatBalance={fiatAmountAvailable1}
             onAccountIdChange={handleAccountIdChange}
             onPercentOptionClick={value => handlePercentClick(value, false)}
             percentOptions={percentOptions}

--- a/src/features/defi/providers/fox-eth-lp/components/FoxEthLpManager/Deposit/components/Deposit.tsx
+++ b/src/features/defi/providers/fox-eth-lp/components/FoxEthLpManager/Deposit/components/Deposit.tsx
@@ -160,7 +160,7 @@ export const Deposit: React.FC<DepositProps> = ({
 
   const validateCryptoAmount = (value: string, isForAsset0: boolean) => {
     const crypto = bnOrZero(isForAsset0 ? ethBalance : foxBalance).div(
-      `1e+${(isForAsset0 ? foxAsset : ethAsset).precision}`,
+      bn(10).pow((isForAsset0 ? foxAsset : ethAsset).precision),
     )
     const _value = bnOrZero(value)
     const hasValidBalance = crypto.gt(0) && _value.gt(0) && crypto.gte(value)
@@ -170,7 +170,7 @@ export const Deposit: React.FC<DepositProps> = ({
 
   const validateFiatAmount = (value: string, isForAsset0: boolean) => {
     const crypto = bnOrZero(isForAsset0 ? ethBalance : foxBalance).div(
-      `1e+${(isForAsset0 ? foxAsset : ethAsset).precision}`,
+      bn(10).pow((isForAsset0 ? foxAsset : ethAsset).precision),
     )
     const fiat = crypto.times((isForAsset0 ? ethMarketData : foxMarketData).price)
     const _value = bnOrZero(value)

--- a/src/features/defi/providers/fox-eth-lp/components/FoxEthLpManager/Deposit/components/Deposit.tsx
+++ b/src/features/defi/providers/fox-eth-lp/components/FoxEthLpManager/Deposit/components/Deposit.tsx
@@ -83,7 +83,7 @@ export const Deposit: React.FC<DepositProps> = ({
 
   const getDepositGasEstimate = async (deposit: DepositValues): Promise<string | undefined> => {
     try {
-      const gasData = await getDepositGasData(deposit.cryptoAmount1, deposit.cryptoAmount2)
+      const gasData = await getDepositGasData(deposit.cryptoAmount0, deposit.cryptoAmount1)
       if (!gasData) return
       return bnOrZero(gasData.average.txFee).div(bn(10).pow(ethAsset.precision)).toPrecision()
     } catch (error) {
@@ -106,10 +106,10 @@ export const Deposit: React.FC<DepositProps> = ({
     dispatch({
       type: FoxEthLpDepositActionType.SET_DEPOSIT,
       payload: {
+        ethCryptoAmount: formValues.cryptoAmount0,
+        ethFiatAmount: formValues.fiatAmount0,
         foxCryptoAmount: formValues.cryptoAmount1,
         foxFiatAmount: formValues.fiatAmount1,
-        ethCryptoAmount: formValues.cryptoAmount2,
-        ethFiatAmount: formValues.fiatAmount2,
       },
     })
     dispatch({ type: FoxEthLpDepositActionType.SET_LOADING, payload: true })
@@ -158,9 +158,9 @@ export const Deposit: React.FC<DepositProps> = ({
     browserHistory.goBack()
   }
 
-  const validateCryptoAmount = (value: string, isForAsset1: boolean) => {
-    const crypto = bnOrZero(isForAsset1 ? foxBalance : ethBalance).div(
-      `1e+${(isForAsset1 ? foxAsset : ethAsset).precision}`,
+  const validateCryptoAmount = (value: string, isForAsset0: boolean) => {
+    const crypto = bnOrZero(isForAsset0 ? ethBalance : foxBalance).div(
+      `1e+${(isForAsset0 ? foxAsset : ethAsset).precision}`,
     )
     const _value = bnOrZero(value)
     const hasValidBalance = crypto.gt(0) && _value.gt(0) && crypto.gte(value)
@@ -168,11 +168,11 @@ export const Deposit: React.FC<DepositProps> = ({
     return hasValidBalance || 'common.insufficientFunds'
   }
 
-  const validateFiatAmount = (value: string, isForAsset1: boolean) => {
-    const crypto = bnOrZero(isForAsset1 ? foxBalance : ethBalance).div(
-      `1e+${(isForAsset1 ? foxAsset : ethAsset).precision}`,
+  const validateFiatAmount = (value: string, isForAsset0: boolean) => {
+    const crypto = bnOrZero(isForAsset0 ? ethBalance : foxBalance).div(
+      `1e+${(isForAsset0 ? foxAsset : ethAsset).precision}`,
     )
-    const fiat = crypto.times((isForAsset1 ? foxMarketData : ethMarketData).price)
+    const fiat = crypto.times((isForAsset0 ? ethMarketData : foxMarketData).price)
     const _value = bnOrZero(value)
     const hasValidBalance = fiat.gt(0) && _value.gt(0) && fiat.gte(value)
     if (_value.isEqualTo(0)) return ''
@@ -197,33 +197,33 @@ export const Deposit: React.FC<DepositProps> = ({
   return (
     <PairDeposit
       accountId={accountId}
+      asset0={ethAsset}
       asset1={foxAsset}
-      asset2={ethAsset}
       icons={opportunity?.icons}
       destAsset={asset}
       apy={opportunity?.apy?.toString() ?? ''}
+      cryptoAmountAvailable0={ethCryptoAmountAvailable.toPrecision()}
       cryptoAmountAvailable1={foxCryptoAmountAvailable.toPrecision()}
-      cryptoAmountAvailable2={ethCryptoAmountAvailable.toPrecision()}
+      cryptoInputValidation0={{
+        required: true,
+        validate: { validateCryptoAmount0: (val: string) => validateCryptoAmount(val, true) },
+      }}
       cryptoInputValidation1={{
         required: true,
-        validate: { validateCryptoAmount1: (val: string) => validateCryptoAmount(val, true) },
+        validate: { validateCryptoAmount1: (val: string) => validateCryptoAmount(val, false) },
       }}
-      cryptoInputValidation2={{
-        required: true,
-        validate: { validateCryptoAmount2: (val: string) => validateCryptoAmount(val, false) },
-      }}
+      fiatAmountAvailable0={ethFiatAmountAvailable.toFixed(2)}
       fiatAmountAvailable1={foxFiatAmountAvailable.toFixed(2)}
-      fiatAmountAvailable2={ethFiatAmountAvailable.toFixed(2)}
+      fiatInputValidation0={{
+        required: true,
+        validate: { validateFiatAmount0: (val: string) => validateFiatAmount(val, true) },
+      }}
       fiatInputValidation1={{
         required: true,
-        validate: { validateFiatAmount1: (val: string) => validateFiatAmount(val, true) },
+        validate: { validateFiatAmount1: (val: string) => validateFiatAmount(val, false) },
       }}
-      fiatInputValidation2={{
-        required: true,
-        validate: { validateFiatAmount2: (val: string) => validateFiatAmount(val, false) },
-      }}
+      marketData0={ethMarketData}
       marketData1={foxMarketData}
-      marketData2={ethMarketData}
       onCancel={handleCancel}
       onAccountIdChange={handleAccountIdChange}
       onContinue={handleContinue}

--- a/src/features/defi/providers/osmosis/components/OsmosisManager/Lp/Deposit/components/Deposit.tsx
+++ b/src/features/defi/providers/osmosis/components/OsmosisManager/Lp/Deposit/components/Deposit.tsx
@@ -224,11 +224,11 @@ export const Deposit: React.FC<DepositProps> = ({
       const allocations = await calculateAllocations(underlyingAsset0, formValues.cryptoAmount1)
       if (!allocations) return
 
-      const asset0AmountBaseUnit = bnOrZero(formValues.cryptoAmount1)
+      const asset0AmountBaseUnit = bnOrZero(formValues.cryptoAmount0)
         .multipliedBy(bn(10).pow(bnOrZero(underlyingAsset0.precision)))
         .toFixed()
 
-      const asset1AmountBaseUnit = bnOrZero(formValues.cryptoAmount2)
+      const asset1AmountBaseUnit = bnOrZero(formValues.cryptoAmount1)
         .multipliedBy(bn(10).pow(bnOrZero(underlyingAsset1.precision)))
         .toFixed()
 
@@ -360,21 +360,21 @@ export const Deposit: React.FC<DepositProps> = ({
       opportunity={osmosisOpportunity}
       destAssetId={lpAssetId}
       calculateAllocations={calculateAllocations}
+      cryptoInputValidation0={{
+        required: true,
+        validate: { validateCryptoAmount0: (val: string) => validateCryptoAmount(val, true) },
+      }}
       cryptoInputValidation1={{
         required: true,
-        validate: { validateCryptoAmount1: (val: string) => validateCryptoAmount(val, true) },
+        validate: { validateCryptoAmount1: (val: string) => validateCryptoAmount(val, false) },
       }}
-      cryptoInputValidation2={{
+      fiatInputValidation0={{
         required: true,
-        validate: { validateCryptoAmount2: (val: string) => validateCryptoAmount(val, false) },
+        validate: { validateFiatAmount0: (val: string) => validateFiatAmount(val, true) },
       }}
       fiatInputValidation1={{
         required: true,
-        validate: { validateFiatAmount1: (val: string) => validateFiatAmount(val, true) },
-      }}
-      fiatInputValidation2={{
-        required: true,
-        validate: { validateFiatAmount2: (val: string) => validateFiatAmount(val, false) },
+        validate: { validateFiatAmount1: (val: string) => validateFiatAmount(val, false) },
       }}
       onCancel={handleCancel}
       onAccountIdChange={handleAccountIdChange}


### PR DESCRIPTION
## Description

This PR

- Consolidates the pair terminology from asset 1/2 currently to being consistent in referring to the first and second asset of a pair as asset 0/1, like how e.g Uniswap is referring to pair tokens as `token0` and `token1`
- Fixes the order of ETH and FOX in the ETH/FOX components.

## Notice

<!-- Before submitting a pull request, please make sure you have answered the following: -->

- [x] Have you followed the guidelines in our [Contributing]('https://github.com/shapeshift/web/blob/develop/CONTRIBUTING.md) guide?
- [x] Have you checked to ensure there aren't other open [Pull Requests](https://github.com/shapeshift/web/pulls) for the same update/change?

## Pull Request Type

- [ ] :bug: Bug fix (Non-breaking Change: Fixes an issue)
- [ ] :hammer_and_wrench: Chore (Non-breaking Change: Doc updates, pkg upgrades, typos, etc..)
- [x] :nail_care: New Feature (Breaking/Non-breaking Change)

## Issue (if applicable)

N/A

## Risk

<!-----------------------------------------------------------------------------
Outline the scope of your changes and the risk associated with them. You must use your discretion as an engineer to determine the potential impact of your changes.

E.g. an upgrade to `hdwallet` or core state management would be considered higher risk, and might require a full regression test. UI or isolated view changes, or something behind a feature flag may have near zero risk. Small bug fixes might require testing isolated to the specific fix.
------------------------------------------------------------------------------>

Low, though scrutinize I didn't derp the rename, and ETH/FOX and Osmo LP deposits show no regressions

## Testing

<!-----------------------------------------------------------------------------
We treat every PR to be merged with the same scrutiny as if we were merging directly to production.

Your PR will not be merged if you do not complete the sections below for our engineering and operations teams to test.
------------------------------------------------------------------------------>

- Osmosis pair deposit shows no regressions
- ETH/FOX pair deposit shows no regressions
- ETH/FOX pair displays ETH as the asset 0 and FOX as the asset 1, matching the "ETH/FOX" pool order where ETH is the `token0` and FOX is the `token1`, not the other way around

### Engineering

<!-----------------------------------------------------------------------------
Include sufficient information here for an engineer to test your PR. This may include how to test locally, in a built environment, changes to infrastructure etc.
------------------------------------------------------------------------------>

- ☝🏽 

### Operations

<!-----------------------------------------------------------------------------
If your changes have a user-facing impact, describe how a non-technical QA team can functionally test your changes in a preview environment.

If they are not user-facing please describe how to test for any regressions that may occur.
------------------------------------------------------------------------------>

- ☝🏽 

## Screenshots (if applicable)

<img width="543" alt="image" src="https://user-images.githubusercontent.com/17035424/220730840-232f5d85-b75b-4a5d-9ac8-aab8571cce16.png">
