### PR TITLE
feat: improve savers deposit halt flow

### DIFF
--- a/src/features/defi/providers/thorchain-savers/components/ThorchainSaversManager/Deposit/components/Deposit.tsx
+++ b/src/features/defi/providers/thorchain-savers/components/ThorchainSaversManager/Deposit/components/Deposit.tsx
@@ -3,7 +3,7 @@ import type { Asset } from '@shapeshiftoss/asset-service'
 import type { AccountId } from '@shapeshiftoss/caip'
 import { fromAccountId, toAssetId } from '@shapeshiftoss/caip'
 import type { UtxoBaseAdapter, UtxoChainId } from '@shapeshiftoss/chain-adapters'
-import { getInboundAddressDataForChain, SwapperName } from '@shapeshiftoss/swapper'
+import { getInboundAddressDataForChain } from '@shapeshiftoss/swapper'
 import { getConfig } from 'config'
 import type { DepositValues } from 'features/defi/components/Deposit/Deposit'
 import { Deposit as ReusableDeposit } from 'features/defi/components/Deposit/Deposit'
@@ -28,7 +28,6 @@ import { getSupportedEvmChainIds } from 'hooks/useEvm/useEvm'
 import { bn, bnOrZero } from 'lib/bignumber/bignumber'
 import { logger } from 'lib/logger'
 import { toBaseUnit } from 'lib/math'
-import { getIsTradingActiveApi } from 'state/apis/swapper/getIsTradingActiveApi'
 import {
   BASE_BPS_POINTS,
   fromThorBaseUnit,
@@ -44,7 +43,7 @@ import {
   selectMarketDataById,
   selectPortfolioCryptoBalanceByFilter,
 } from 'state/slices/selectors'
-import { useAppDispatch, useAppSelector } from 'state/store'
+import { useAppSelector } from 'state/store'
 
 import { ThorchainSaversDepositActionType } from '../DepositCommon'
 import { DepositContext } from '../DepositContext'
@@ -63,7 +62,6 @@ export const Deposit: React.FC<DepositProps> = ({
 }) => {
   const [outboundFeeCryptoBaseUnit, setOutboundFeeCryptoBaseUnit] = useState('')
   const { state, dispatch: contextDispatch } = useContext(DepositContext)
-  const appDispatch = useAppDispatch()
   const history = useHistory()
   const translate = useTranslate()
   const [slippageCryptoAmountPrecision, setSlippageCryptoAmountPrecision] = useState<string | null>(
@@ -215,18 +213,6 @@ export const Deposit: React.FC<DepositProps> = ({
       contextDispatch({ type: ThorchainSaversDepositActionType.SET_DEPOSIT, payload: formValues })
       contextDispatch({ type: ThorchainSaversDepositActionType.SET_LOADING, payload: true })
       try {
-        const { getIsTradingActive } = getIsTradingActiveApi.endpoints
-        const { data: isTradingActive } = await appDispatch(
-          getIsTradingActive.initiate({
-            assetId,
-            swapperName: SwapperName.Thorchain,
-          }),
-        )
-
-        if (!isTradingActive) {
-          throw new Error(`THORChain pool halted for assetId: ${assetId}`)
-        }
-
         const estimatedGasCrypto = await getDepositGasEstimate(formValues)
         if (!estimatedGasCrypto) return
         contextDispatch({
@@ -250,8 +236,6 @@ export const Deposit: React.FC<DepositProps> = ({
       userAddress,
       opportunityData,
       contextDispatch,
-      appDispatch,
-      assetId,
       getDepositGasEstimate,
       onNext,
       toast,

--- a/src/state/apis/swapper/selectors.ts
+++ b/src/state/apis/swapper/selectors.ts
@@ -13,3 +13,8 @@ export const selectSwapperApiUsdRatesPending = (state: ReduxState) =>
   Object.values(state.swapperApi.queries).some(
     query => query?.endpointName === 'getUsdRates' && query?.status === QueryStatus.pending,
   )
+
+export const selectSwapperApiTradingActivePending = (state: ReduxState) =>
+  Object.values(state.swapperApi.queries).some(
+    query => query?.endpointName === 'getIsTradingActive' && query?.status === QueryStatus.pending,
+  )


### PR DESCRIPTION
## Description

Little UX improvement, spotted while testing LTC savers while the THOR LTC pool was halted.
Moves the halted check from the deposit step to the overview, ensures the modal is in a loading state while the active trading query is pending, and disables the deposit button if trading is halted.

## Notice

<!-- Before submitting a pull request, please make sure you have answered the following: -->

- [x] Have you followed the guidelines in our [Contributing]('https://github.com/shapeshift/web/blob/develop/CONTRIBUTING.md) guide?
- [x] Have you checked to ensure there aren't other open [Pull Requests](https://github.com/shapeshift/web/pulls) for the same update/change?

## Pull Request Type

- [ ] :bug: Bug fix (Non-breaking Change: Fixes an issue)
- [ ] :hammer_and_wrench: Chore (Non-breaking Change: Doc updates, pkg upgrades, typos, etc..)
- [x] :nail_care: New Feature (Breaking/Non-breaking Change)

## Issue (if applicable)

N/A

## Risk

<!-----------------------------------------------------------------------------
Outline the scope of your changes and the risk associated with them. You must use your discretion as an engineer to determine the potential impact of your changes.

E.g. an upgrade to `hdwallet` or core state management would be considered higher risk, and might require a full regression test. UI or isolated view changes, or something behind a feature flag may have near zero risk. Small bug fixes might require testing isolated to the specific fix.
------------------------------------------------------------------------------>

## Testing

<!-----------------------------------------------------------------------------
We treat every PR to be merged with the same scrutiny as if we were merging directly to production.

Your PR will not be merged if you do not complete the sections below for our engineering and operations teams to test.
------------------------------------------------------------------------------>

- If testing while some THOR pools are halted, ensure the deposit button is disabled and the tooltip matches the one on the screenshot
- If all THOR pools we support as savers are live, there shouldn't be any flow change here

### Engineering

<!-----------------------------------------------------------------------------
Include sufficient information here for an engineer to test your PR. This may include how to test locally, in a built environment, changes to infrastructure etc.
------------------------------------------------------------------------------>

- ☝🏽 

### Operations

<!-----------------------------------------------------------------------------
If your changes have a user-facing impact, describe how a non-technical QA team can functionally test your changes in a preview environment.

If they are not user-facing please describe how to test for any regressions that may occur.
------------------------------------------------------------------------------>

- ☝🏽 

## Screenshots (if applicable)

<img width="533" alt="image" src="https://user-images.githubusercontent.com/17035424/221450363-6d5d656a-3163-4b9e-b186-edab004530a3.png">