### PR TITLE
wip: bypass native password modal on refresh

### DIFF
--- a/src/components/Layout/Header/NavBar/UserMenu.tsx
+++ b/src/components/Layout/Header/NavBar/UserMenu.tsx
@@ -140,9 +140,8 @@ const WalletButton: FC<WalletButtonProps> = ({
 
 export const UserMenu: React.FC<{ onClick?: () => void }> = ({ onClick }) => {
   const { state, dispatch, disconnect } = useWallet()
-  const { isConnected, isDemoWallet, walletInfo, type, isLocked, isLoadingLocalWallet } = state
+  const { isConnected, isDemoWallet, walletInfo, type, isLoadingLocalWallet } = state
 
-  if (isLocked) disconnect()
   const hasWallet = Boolean(walletInfo?.deviceId)
   const handleConnect = () => {
     onClick && onClick()

--- a/src/context/FoxEthProvider/FoxEthProvider.tsx
+++ b/src/context/FoxEthProvider/FoxEthProvider.tsx
@@ -47,7 +47,7 @@ const FoxEthContext = createContext<IFoxEthContext>({
 
 export const FoxEthProvider = ({ children }: FoxEthProviderProps) => {
   const {
-    state: { wallet },
+    state: { isLocked, wallet },
   } = useWallet()
   const ethAsset = useAppSelector(state => selectAssetById(state, ethAssetId))
   if (!ethAsset) throw new Error(`Asset not found for AssetId ${ethAssetId}`)
@@ -83,6 +83,7 @@ export const FoxEthProvider = ({ children }: FoxEthProviderProps) => {
     // Get initial account 0 address from wallet, TODO: nuke it?
     if (wallet && adapter && lpBip44Params) {
       ;(async () => {
+        if (isLocked) return
         if (!supportsETH(wallet)) return
         const { accountNumber } = lpBip44Params
         const address = await adapter.getAddress({ wallet, accountNumber })

--- a/src/context/FoxEthProvider/FoxEthProvider.tsx
+++ b/src/context/FoxEthProvider/FoxEthProvider.tsx
@@ -92,7 +92,7 @@ export const FoxEthProvider = ({ children }: FoxEthProviderProps) => {
         setLpAccountId(toAccountId({ chainId: ethChainId, account: address }))
       })()
     }
-  }, [adapter, wallet, lpBip44Params])
+  }, [adapter, isLocked, wallet, lpBip44Params])
 
   const transaction = useAppSelector(gs => selectTxById(gs, ongoingTxId ?? ''))
 

--- a/src/context/WalletProvider/NativeWallet/hooks/useNativeEventHandler.ts
+++ b/src/context/WalletProvider/NativeWallet/hooks/useNativeEventHandler.ts
@@ -28,7 +28,6 @@ export const useNativeEventHandler = (state: KeyringState, dispatch: Dispatch<Ac
     const handleEvent = async (e: [deviceId: string, message: Event]) => {
       moduleLogger.info({ e }, 'Event')
       const deviceId = e[0]
-      console.log({ message: e[1].message_type })
       switch (e[1].message_type) {
         case NativeEvents.MNEMONIC_REQUIRED:
           if (!deviceId) break

--- a/src/context/WalletProvider/NativeWallet/hooks/useNativeEventHandler.ts
+++ b/src/context/WalletProvider/NativeWallet/hooks/useNativeEventHandler.ts
@@ -40,7 +40,7 @@ export const useNativeEventHandler = (state: KeyringState, dispatch: Dispatch<Ac
             !['/connect-wallet', '/trade'].includes(location.pathname) &&
             !hasDismissedNativePassword
           ) {
-            dispatch({ type: WalletActions.SET_NATIVE_DEVICE_ID, payload: true })
+            dispatch({ type: WalletActions.SET_NATIVE_DEVICE_ID, payload: { deviceId } })
             if (state.deviceId) {
               setHasDismissedNativePassword(true)
               break

--- a/src/context/WalletProvider/NativeWallet/hooks/useNativeEventHandler.ts
+++ b/src/context/WalletProvider/NativeWallet/hooks/useNativeEventHandler.ts
@@ -36,8 +36,11 @@ export const useNativeEventHandler = (state: KeyringState, dispatch: Dispatch<Ac
           // 2. We're reacting on keyring state, so isLocked being falsy (il.e not set yet) is a good way to check we're dealing with the initial useEffect cycle here, but not enough:
           // 3. Since hooks aren't singletons, we need an additional safety
           // When this hook will render from a different context, then
-          if (location.pathname !== '/connect-wallet' && !hasDismissedNativePassword) {
-            dispatch({ type: WalletActions.SET_NATIVE_DEVICE_ID, payload: { deviceId } })
+          if (
+            !['/connect-wallet', '/trade'].includes(location.pathname) &&
+            !hasDismissedNativePassword
+          ) {
+            dispatch({ type: WalletActions.SET_NATIVE_DEVICE_ID, payload: true })
             if (state.deviceId) {
               setHasDismissedNativePassword(true)
               break

--- a/src/context/WalletProvider/NativeWallet/hooks/useNativeEventHandler.ts
+++ b/src/context/WalletProvider/NativeWallet/hooks/useNativeEventHandler.ts
@@ -28,6 +28,7 @@ export const useNativeEventHandler = (state: KeyringState, dispatch: Dispatch<Ac
     const handleEvent = async (e: [deviceId: string, message: Event]) => {
       moduleLogger.info({ e }, 'Event')
       const deviceId = e[0]
+      console.log({ message: e[1].message_type })
       switch (e[1].message_type) {
         case NativeEvents.MNEMONIC_REQUIRED:
           if (!deviceId) break
@@ -66,6 +67,7 @@ export const useNativeEventHandler = (state: KeyringState, dispatch: Dispatch<Ac
           dispatch({ type: WalletActions.NATIVE_PASSWORD_OPEN, payload: { modal: true, deviceId } })
           break
         case NativeEvents.READY:
+          dispatch({ type: WalletActions.SET_IS_LOCKED, payload: false })
           if (modal) {
             dispatch({ type: WalletActions.SET_WALLET_MODAL, payload: false })
           }

--- a/src/context/WalletProvider/NativeWallet/hooks/useNativeEventHandler.ts
+++ b/src/context/WalletProvider/NativeWallet/hooks/useNativeEventHandler.ts
@@ -37,6 +37,7 @@ export const useNativeEventHandler = (state: KeyringState, dispatch: Dispatch<Ac
           // 3. Since hooks aren't singletons, we need an additional safety
           // When this hook will render from a different context, then
           if (location.pathname !== '/connect-wallet' && !hasDismissedNativePassword) {
+            dispatch({ type: WalletActions.SET_NATIVE_DEVICE_ID, payload: { deviceId } })
             if (state.deviceId) {
               setHasDismissedNativePassword(true)
               break

--- a/src/context/WalletProvider/NativeWallet/hooks/useNativeEventHandler.ts
+++ b/src/context/WalletProvider/NativeWallet/hooks/useNativeEventHandler.ts
@@ -1,28 +1,65 @@
 import type { Event } from '@shapeshiftoss/hdwallet-core'
+import type { NativeHDWallet } from '@shapeshiftoss/hdwallet-native'
 import { NativeEvents } from '@shapeshiftoss/hdwallet-native'
 import type { Dispatch } from 'react'
-import { useEffect } from 'react'
+import { useEffect, useState } from 'react'
+import { useLocation } from 'react-router-dom'
 import type { ActionTypes } from 'context/WalletProvider/actions'
 import { WalletActions } from 'context/WalletProvider/actions'
+import { KeyManager } from 'context/WalletProvider/KeyManager'
 import type { InitialState } from 'context/WalletProvider/WalletProvider'
 import { logger } from 'lib/logger'
 
+import { NativeConfig } from '../config'
+
 const moduleLogger = logger.child({ namespace: ['NativeWallet'] })
 
-type KeyringState = Pick<InitialState, 'keyring' | 'walletInfo' | 'modal'>
+type KeyringState = Pick<
+  InitialState,
+  'keyring' | 'walletInfo' | 'modal' | 'adapters' | 'isLocked' | 'deviceId'
+>
 
 export const useNativeEventHandler = (state: KeyringState, dispatch: Dispatch<ActionTypes>) => {
   const { keyring, modal } = state
+  const location = useLocation()
+  const [hasDismissedNativePassword, setHasDismissedNativePassword] = useState<boolean>(false)
 
   useEffect(() => {
-    const handleEvent = (e: [deviceId: string, message: Event]) => {
+    const handleEvent = async (e: [deviceId: string, message: Event]) => {
       moduleLogger.info({ e }, 'Event')
       const deviceId = e[0]
       switch (e[1].message_type) {
         case NativeEvents.MNEMONIC_REQUIRED:
           if (!deviceId) break
+          // A few things to note here
+          // 1. Connecting a wallet in /connect-wallet is valid and shouldn't be prevented
+          // 2. We're reacting on keyring state, so isLocked being falsy (il.e not set yet) is a good way to check we're dealing with the initial useEffect cycle here, but not enough:
+          // 3. Since hooks aren't singletons, we need an additional safety
+          // When this hook will render from a different context, then
+          if (location.pathname !== '/connect-wallet' && !hasDismissedNativePassword) {
+            if (state.deviceId) {
+              setHasDismissedNativePassword(true)
+              break
+            }
+            const adapters = state?.adapters?.get(KeyManager.Native)
+            const { name, icon } = NativeConfig
+            const wallet = (await adapters?.[0].pairDevice?.(deviceId)) as NativeHDWallet
+            dispatch({
+              type: WalletActions.SET_WALLET,
+              payload: {
+                wallet,
+                name,
+                icon,
+                deviceId,
+                meta: { label: 'TODO wallet label' },
+              },
+            })
+            dispatch({ type: WalletActions.SET_IS_CONNECTED, payload: true })
+            dispatch({ type: WalletActions.SET_IS_LOCKED, payload: true })
+            dispatch({ type: WalletActions.SET_LOCAL_WALLET_LOADING, payload: false })
+            break
+          }
           dispatch({ type: WalletActions.NATIVE_PASSWORD_OPEN, payload: { modal: true, deviceId } })
-
           break
         case NativeEvents.READY:
           if (modal) {
@@ -43,5 +80,13 @@ export const useNativeEventHandler = (state: KeyringState, dispatch: Dispatch<Ac
       keyring.off(['Native', '*', NativeEvents.MNEMONIC_REQUIRED], handleEvent)
       keyring.off(['Native', '*', NativeEvents.READY], handleEvent)
     }
-  }, [dispatch, keyring, modal])
+  }, [
+    keyring,
+    location.pathname,
+    modal,
+    state.deviceId,
+    state?.adapters,
+    dispatch,
+    hasDismissedNativePassword,
+  ])
 }

--- a/src/context/WalletProvider/NativeWallet/hooks/useNativeSuccess.ts
+++ b/src/context/WalletProvider/NativeWallet/hooks/useNativeSuccess.ts
@@ -50,6 +50,7 @@ export const useNativeSuccess = ({ vault }: UseNativeSuccessPropTypes) => {
           },
         })
         dispatch({ type: WalletActions.SET_IS_CONNECTED, payload: true })
+        dispatch({ type: WalletActions.SET_IS_LOCKED, payload: false })
         dispatch({ type: WalletActions.SET_WALLET_MODAL, payload: false })
         setLocalWalletTypeAndDeviceId(KeyManager.Native, deviceId)
         setLocalNativeWalletName(walletLabel)

--- a/src/context/WalletProvider/WalletProvider.test.tsx
+++ b/src/context/WalletProvider/WalletProvider.test.tsx
@@ -27,6 +27,16 @@ jest.mock('@shapeshiftoss/hdwallet-metamask', () => ({
   },
 }))
 
+jest.mock('context/WalletProvider/NativeWallet/hooks/useNativeEventHandler', () => ({
+  useNativeEventHandler: () => {},
+}))
+
+// This mock fixes an issue with rendering the OptInModal in WalletViewsSwitch
+// when the Pendo plugin is disabled
+jest.mock('./WalletViewsRouter', () => ({
+  WalletViewsRouter: () => null,
+}))
+
 const walletInfoPayload = {
   name: SUPPORTED_WALLETS.native.name,
   icon: SUPPORTED_WALLETS.native.icon,

--- a/src/context/WalletProvider/WalletProvider.tsx
+++ b/src/context/WalletProvider/WalletProvider.tsx
@@ -166,7 +166,7 @@ const reducer = (state: InitialState, action: ActionTypes) => {
           deviceId,
           meta: {
             label: action.payload.meta?.label ?? '',
-            address: (action.payload.wallet as MetaMaskHDWallet | PortisHDWallet).ethAddress ?? '',
+            address: (action.payload.wallet as MetaMaskHDWallet | PortisHDWallet)?.ethAddress ?? '',
           },
         },
       }
@@ -226,6 +226,12 @@ const reducer = (state: InitialState, action: ActionTypes) => {
         showBackButton: !state.isLoadingLocalWallet,
         deviceId: action.payload.deviceId,
         initialRoute: '/native/enter-password',
+      }
+    case WalletActions.SET_NATIVE_DEVICE_ID:
+      return {
+        ...state,
+        type: KeyManager.Native,
+        deviceId: action.payload.deviceId,
       }
     case WalletActions.OPEN_KEEPKEY_PIN: {
       const { showBackButton, deviceId, pinRequestType } = action.payload

--- a/src/context/WalletProvider/WalletViewsSwitch.tsx
+++ b/src/context/WalletProvider/WalletViewsSwitch.tsx
@@ -116,7 +116,7 @@ export const WalletViewsSwitch = () => {
         isOpen={modal}
         onClose={onClose}
         isCentered
-        trapFocus={false}
+        trapFocus={true}
         closeOnOverlayClick={false}
       >
         <ModalOverlay />

--- a/src/context/WalletProvider/actions.ts
+++ b/src/context/WalletProvider/actions.ts
@@ -13,6 +13,8 @@ export enum WalletActions {
   SET_PROVIDER = 'SET_PROVIDER',
   SET_IS_LOCKED = 'SET_IS_LOCKED',
   SET_WALLET_MODAL = 'SET_WALLET_MODAL',
+  SET_NATIVE_DEVICE_ID = 'SET_NATIVE_DEVICE_ID',
+  SET_IS_UNLOCKED = 'SET_IS_UNLOCKED',
   RESET_STATE = 'RESET_STATE',
   RESET_LAST_DEVICE_INTERACTION_STATE = 'RESET_LAST_DEVICE_INTERACTION_STATE',
   SET_LOCAL_WALLET_LOADING = 'SET_LOCAL_WALLET_LOADING',
@@ -49,6 +51,12 @@ export type ActionTypes =
       type: WalletActions.NATIVE_PASSWORD_OPEN
       payload: {
         modal: boolean
+        deviceId: string
+      }
+    }
+  | {
+      type: WalletActions.SET_NATIVE_DEVICE_ID
+      payload: {
         deviceId: string
       }
     }

--- a/src/features/defi/providers/cosmos/components/CosmosManager/Deposit/CosmosDeposit.tsx
+++ b/src/features/defi/providers/cosmos/components/CosmosManager/Deposit/CosmosDeposit.tsx
@@ -1,6 +1,6 @@
 import { Center } from '@chakra-ui/react'
 import type { AccountId } from '@shapeshiftoss/caip'
-import { toAssetId } from '@shapeshiftoss/caip'
+import { fromAccountId, toAssetId } from '@shapeshiftoss/caip'
 import { DefiModalContent } from 'features/defi/components/DefiModal/DefiModalContent'
 import { DefiModalHeader } from 'features/defi/components/DefiModal/DefiModalHeader'
 import type {
@@ -23,7 +23,6 @@ import { logger } from 'lib/logger'
 import { serializeUserStakingId, toValidatorId } from 'state/slices/opportunitiesSlice/utils'
 import {
   selectAssetById,
-  selectBIP44ParamsByAccountId,
   selectEarnUserStakingOpportunityByUserStakingId,
   selectMarketDataById,
   selectPortfolioLoading,
@@ -79,11 +78,8 @@ export const CosmosDeposit: React.FC<CosmosDepositProps> = ({
       : undefined,
   )
 
-  const accountFilter = useMemo(() => ({ accountId: accountId ?? '' }), [accountId])
-  const bip44Params = useAppSelector(state => selectBIP44ParamsByAccountId(state, accountFilter))
-
   useEffect(() => {
-    ;(async () => {
+    ;(() => {
       try {
         if (!earnOpportunityData) return
 
@@ -95,12 +91,11 @@ export const CosmosDeposit: React.FC<CosmosDepositProps> = ({
             validatorAddress &&
             chainAdapter &&
             earnOpportunityData?.apy &&
-            bip44Params
+            accountId
           )
         )
           return
-        const { accountNumber } = bip44Params
-        const address = await chainAdapter.getAddress({ accountNumber, wallet: walletState.wallet })
+        const address = fromAccountId(accountId).account
 
         dispatch({ type: CosmosDepositActionType.SET_USER_ADDRESS, payload: address })
         dispatch({
@@ -112,7 +107,7 @@ export const CosmosDeposit: React.FC<CosmosDepositProps> = ({
         moduleLogger.error(error, 'CosmosDeposit error')
       }
     })()
-  }, [bip44Params, chainId, validatorAddress, walletState.wallet, earnOpportunityData])
+  }, [chainId, validatorAddress, walletState.wallet, earnOpportunityData, accountId])
 
   const handleBack = () => {
     history.push({

--- a/src/features/defi/providers/fox-eth-lp/components/FoxEthLpManager/Withdraw/components/Confirm.tsx
+++ b/src/features/defi/providers/fox-eth-lp/components/FoxEthLpManager/Withdraw/components/Confirm.tsx
@@ -1,4 +1,4 @@
-import { Alert, AlertIcon, Box, Stack } from '@chakra-ui/react'
+import { Alert, AlertIcon, Box, Stack, usePrevious } from '@chakra-ui/react'
 import type { AccountId } from '@shapeshiftoss/caip'
 import { ethAssetId, foxAssetId } from '@shapeshiftoss/caip'
 import { supportsETH } from '@shapeshiftoss/hdwallet-core'
@@ -7,7 +7,7 @@ import { PairIcons } from 'features/defi/components/PairIcons/PairIcons'
 import { Summary } from 'features/defi/components/Summary'
 import { DefiStep } from 'features/defi/contexts/DefiManagerProvider/DefiCommon'
 import { useFoxEthLiquidityPool } from 'features/defi/providers/fox-eth-lp/hooks/useFoxEthLiquidityPool'
-import { useCallback, useContext, useMemo } from 'react'
+import { useCallback, useContext, useEffect, useMemo } from 'react'
 import { useTranslate } from 'react-polyglot'
 import { Amount } from 'components/Amount/Amount'
 import { AssetIcon } from 'components/AssetIcon'
@@ -53,6 +53,8 @@ export const Confirm = ({ accountId, onNext }: ConfirmProps) => {
 
   // user info
   const { state: walletState } = useWallet()
+  const isLocked = walletState.isLocked
+  const previousIsLocked = usePrevious(isLocked)
 
   const feeAssetBalanceFilter = useMemo(
     () => ({ assetId: ethAssetId, accountId: accountId ?? '' }),
@@ -101,6 +103,12 @@ export const Confirm = ({ accountId, onNext }: ConfirmProps) => {
     state?.withdraw.lpAmount,
     walletState.wallet,
   ])
+
+  useEffect(() => {
+    if (!isLocked && previousIsLocked && state?.loading) {
+      ;(async () => await handleConfirm())()
+    }
+  }, [handleConfirm, isLocked, previousIsLocked, state?.loading])
 
   if (!state || !dispatch || !opportunity) return null
 

--- a/src/features/defi/providers/foxy/components/FoxyManager/Deposit/FoxyDeposit.tsx
+++ b/src/features/defi/providers/foxy/components/FoxyManager/Deposit/FoxyDeposit.tsx
@@ -1,6 +1,6 @@
 import { Center } from '@chakra-ui/react'
 import type { AccountId } from '@shapeshiftoss/caip'
-import { toAssetId } from '@shapeshiftoss/caip'
+import { fromAccountId, toAssetId } from '@shapeshiftoss/caip'
 import { KnownChainIds } from '@shapeshiftoss/types'
 import { DefiModalContent } from 'features/defi/components/DefiModal/DefiModalContent'
 import { DefiModalHeader } from 'features/defi/components/DefiModal/DefiModalHeader'
@@ -89,16 +89,14 @@ export const FoxyDeposit: React.FC<{
             !isFoxyAprLoading &&
             chainAdapter &&
             foxyApi &&
-            bip44Params
+            bip44Params &&
+            accountId
           )
         )
           return
-        const { accountNumber } = bip44Params
-        const [address, foxyOpportunity] = await Promise.all([
-          chainAdapter.getAddress({ wallet: walletState.wallet, accountNumber }),
-          foxyApi.getFoxyOpportunityByStakingAddress(contractAddress),
-        ])
-        dispatch({ type: FoxyDepositActionType.SET_USER_ADDRESS, payload: address })
+        const accountAddress = fromAccountId(accountId).account
+        const foxyOpportunity = await foxyApi.getFoxyOpportunityByStakingAddress(contractAddress)
+        dispatch({ type: FoxyDepositActionType.SET_USER_ADDRESS, payload: accountAddress })
         dispatch({
           type: FoxyDepositActionType.SET_OPPORTUNITY,
           payload: { ...foxyOpportunity, apy: foxyAprData?.foxyApr ?? '' },
@@ -116,6 +114,7 @@ export const FoxyDeposit: React.FC<{
     walletState.wallet,
     foxyAprData?.foxyApr,
     isFoxyAprLoading,
+    accountId,
   ])
 
   const handleBack = () => {

--- a/src/features/defi/providers/foxy/components/FoxyManager/Deposit/components/Confirm.tsx
+++ b/src/features/defi/providers/foxy/components/FoxyManager/Deposit/components/Confirm.tsx
@@ -1,4 +1,4 @@
-import { Alert, AlertIcon, Box, Stack, useToast } from '@chakra-ui/react'
+import { Alert, AlertIcon, Box, Stack, usePrevious, useToast } from '@chakra-ui/react'
 import type { AccountId } from '@shapeshiftoss/caip'
 import { fromAccountId } from '@shapeshiftoss/caip'
 import { Confirm as ReusableConfirm } from 'features/defi/components/Confirm/Confirm'
@@ -6,7 +6,7 @@ import { Summary } from 'features/defi/components/Summary'
 import { DefiStep } from 'features/defi/contexts/DefiManagerProvider/DefiCommon'
 import { useFoxyQuery } from 'features/defi/providers/foxy/components/FoxyManager/useFoxyQuery'
 import isNil from 'lodash/isNil'
-import { useCallback, useContext, useMemo } from 'react'
+import { useCallback, useContext, useEffect, useMemo } from 'react'
 import { useTranslate } from 'react-polyglot'
 import type { TransactionReceipt } from 'web3-core/types'
 import { Amount } from 'components/Amount/Amount'
@@ -55,6 +55,8 @@ export const Confirm: React.FC<ConfirmProps> = ({ onNext, accountId }) => {
 
   // user info
   const { state: walletState } = useWallet()
+  const isLocked = walletState.isLocked
+  const previousIsLocked = usePrevious(isLocked)
 
   // notify
   const toast = useToast()
@@ -135,6 +137,12 @@ export const Confirm: React.FC<ConfirmProps> = ({ onNext, accountId }) => {
     translate,
     walletState.wallet,
   ])
+
+  useEffect(() => {
+    if (!isLocked && previousIsLocked && state?.loading) {
+      ;(async () => await handleDeposit())()
+    }
+  }, [handleDeposit, isLocked, previousIsLocked, state?.loading])
 
   if (!state || !dispatch) return null
 

--- a/src/features/defi/providers/foxy/components/FoxyManager/Withdraw/components/Confirm.tsx
+++ b/src/features/defi/providers/foxy/components/FoxyManager/Withdraw/components/Confirm.tsx
@@ -1,4 +1,4 @@
-import { Alert, AlertIcon, Box, Stack } from '@chakra-ui/react'
+import { Alert, AlertIcon, Box, Stack, usePrevious } from '@chakra-ui/react'
 import type { AccountId } from '@shapeshiftoss/caip'
 import { fromAccountId } from '@shapeshiftoss/caip'
 import { WithdrawType } from '@shapeshiftoss/types'
@@ -7,7 +7,7 @@ import { Summary } from 'features/defi/components/Summary'
 import { DefiStep } from 'features/defi/contexts/DefiManagerProvider/DefiCommon'
 import { useFoxyQuery } from 'features/defi/providers/foxy/components/FoxyManager/useFoxyQuery'
 import isNil from 'lodash/isNil'
-import { useCallback, useContext, useMemo } from 'react'
+import { useCallback, useContext, useEffect, useMemo } from 'react'
 import { useTranslate } from 'react-polyglot'
 import type { TransactionReceipt } from 'web3-core/types'
 import { Amount } from 'components/Amount/Amount'
@@ -45,6 +45,8 @@ export const Confirm: React.FC<StepComponentProps & { accountId?: AccountId | un
 
   // user info
   const { state: walletState } = useWallet()
+  const isLocked = walletState.isLocked
+  const previousIsLocked = usePrevious(isLocked)
 
   const withdrawalFee = useMemo(() => {
     return state?.withdraw.withdrawType === WithdrawType.INSTANT
@@ -131,6 +133,12 @@ export const Confirm: React.FC<StepComponentProps & { accountId?: AccountId | un
     state,
     walletState.wallet,
   ])
+
+  useEffect(() => {
+    if (!isLocked && previousIsLocked && state?.loading) {
+      ;(async () => await handleConfirm())()
+    }
+  }, [handleConfirm, isLocked, previousIsLocked, state?.loading])
 
   if (!state || !dispatch) return null
 

--- a/src/features/defi/providers/thorchain-savers/components/ThorchainSaversManager/Deposit/components/Confirm.tsx
+++ b/src/features/defi/providers/thorchain-savers/components/ThorchainSaversManager/Deposit/components/Confirm.tsx
@@ -445,13 +445,8 @@ export const Confirm: React.FC<ConfirmProps> = ({ accountId, onNext }) => {
               return chainId === bchChainId ? `bitcoincash:${asset_address}` : asset_address
             })
             .catch(async () => {
-              const firstReceiveAddress = await chainAdapter.getAddress({
-                wallet: walletState.wallet!,
-                accountNumber: bip44Params.accountNumber,
-                accountType,
-                index: 0,
-              })
-
+              const account = await chainAdapter.getAccount(fromAccountId(accountId).account)
+              const firstReceiveAddress = account.chainSpecific.addresses?.[0]?.pubkey ?? ''
               return firstReceiveAddress
             })
         : ''

--- a/src/pages/Dashboard/TradeCard.tsx
+++ b/src/pages/Dashboard/TradeCard.tsx
@@ -4,6 +4,7 @@ import { KeplrHDWallet } from '@shapeshiftoss/hdwallet-keplr/dist/keplr'
 import { useMemo } from 'react'
 import { useTranslate } from 'react-polyglot'
 import { useSelector } from 'react-redux'
+import { useLocation } from 'react-router'
 import { Bridge } from 'components/Bridge/Bridge'
 import type { CardProps } from 'components/Card/Card'
 import { Card } from 'components/Card/Card'
@@ -23,6 +24,8 @@ export const TradeCard = ({ defaultBuyAssetId, ...rest }: TradeCardProps) => {
     state: { isLocked, wallet },
   } = useWallet()
   const isKeplr = useMemo(() => wallet instanceof KeplrHDWallet, [wallet])
+  const location = useLocation()
+  const isTradePage = /trade/.test(location.pathname)
 
   const translate = useTranslate()
   const overlayTitle = useMemo(
@@ -31,7 +34,8 @@ export const TradeCard = ({ defaultBuyAssetId, ...rest }: TradeCardProps) => {
   )
 
   // TODO: We should be able to let users proceed with trades to unlock their wallet
-  if (isLocked) return null
+  // For now, we hide the card in dashboard but display it in trade page
+  if (isLocked && !isTradePage) return null
   return (
     <MessageOverlay show={isKeplr} title={overlayTitle}>
       <Card flex={1} {...rest}>

--- a/src/pages/Dashboard/TradeCard.tsx
+++ b/src/pages/Dashboard/TradeCard.tsx
@@ -20,7 +20,7 @@ type TradeCardProps = {
 export const TradeCard = ({ defaultBuyAssetId, ...rest }: TradeCardProps) => {
   const { Axelar } = useSelector(selectFeatureFlags)
   const {
-    state: { wallet },
+    state: { isLocked, wallet },
   } = useWallet()
   const isKeplr = useMemo(() => wallet instanceof KeplrHDWallet, [wallet])
 
@@ -30,6 +30,8 @@ export const TradeCard = ({ defaultBuyAssetId, ...rest }: TradeCardProps) => {
     [translate],
   )
 
+  // TODO: We should be able to let users proceed with trades to unlock their wallet
+  if (isLocked) return
   return (
     <MessageOverlay show={isKeplr} title={overlayTitle}>
       <Card flex={1} {...rest}>

--- a/src/pages/Dashboard/TradeCard.tsx
+++ b/src/pages/Dashboard/TradeCard.tsx
@@ -31,7 +31,7 @@ export const TradeCard = ({ defaultBuyAssetId, ...rest }: TradeCardProps) => {
   )
 
   // TODO: We should be able to let users proceed with trades to unlock their wallet
-  if (isLocked) return
+  if (isLocked) return null
   return (
     <MessageOverlay show={isKeplr} title={overlayTitle}>
       <Card flex={1} {...rest}>


### PR DESCRIPTION
## Description

Very rough first draft, to be discussed during architecture things.

Works ish, with some rough edges:

1. ~~The current UX e.g DeFi modals doesn't accomodate for waiting for mnemonic, and we will try signing/broadcasting a Tx in the background (which will obviously fail) while input is pending~~ fixed by actually waiting for the mnemonic while the initial Tx has had a failed sign/broadcast try which trigger the mnemonic required event
2. This assumes we only emit `NativeEvents.MNEMONIC_REQUIRED` when a mnemonic is *actually* required. Many `getAddress` calls e.g in the dashboard are rugging this - for DeFi modals, this has been solved by not calling `getAddress`. This is really a legacy way of doing things, now that we're storing user staking IDs, which deserialize to an AccountId, which itself deserializes to an address.
Q: *Can we do the same in e.g swapper `getReceiveAddress` ? 

## Notice

<!-- Before submitting a pull request, please make sure you have answered the following: -->

- [x] Have you followed the guidelines in our [Contributing]('https://github.com/shapeshift/web/blob/develop/CONTRIBUTING.md) guide?
- [x] Have you checked to ensure there aren't other open [Pull Requests](https://github.com/shapeshift/web/pulls) for the same update/change?

## Pull Request Type

- [ ] :bug: Bug fix (Non-breaking Change: Fixes an issue)
- [ ] :hammer_and_wrench: Chore (Non-breaking Change: Doc updates, pkg upgrades, typos, etc..)
- [x] :nail_care: New Feature (Breaking/Non-breaking Change)

## Issue (if applicable)

N/A

## Risk

<!-----------------------------------------------------------------------------
Outline the scope of your changes and the risk associated with them. You must use your discretion as an engineer to determine the potential impact of your changes.

E.g. an upgrade to `hdwallet` or core state management would be considered higher risk, and might require a full regression test. UI or isolated view changes, or something behind a feature flag may have near zero risk. Small bug fixes might require testing isolated to the specific fix.
------------------------------------------------------------------------------>

## Testing

<!-----------------------------------------------------------------------------
We treat every PR to be merged with the same scrutiny as if we were merging directly to production.

Your PR will not be merged if you do not complete the sections below for our engineering and operations teams to test.
------------------------------------------------------------------------------>

### Engineering

<!-----------------------------------------------------------------------------
Include sufficient information here for an engineer to test your PR. This may include how to test locally, in a built environment, changes to infrastructure etc.
------------------------------------------------------------------------------>

### Operations

<!-----------------------------------------------------------------------------
If your changes have a user-facing impact, describe how a non-technical QA team can functionally test your changes in a preview environment.

If they are not user-facing please describe how to test for any regressions that may occur.
------------------------------------------------------------------------------>

## Screenshots (if applicable)
