### PR TITLE
chore: increase slippage to 0.5%

### DIFF
--- a/src/constants/constants.ts
+++ b/src/constants/constants.ts
@@ -1,2 +1,2 @@
 export const USDC_PRECISION = 6
-export const DEFAULT_SLIPPAGE = '0.002' // .2%
+export const DEFAULT_SLIPPAGE = '0.005' // .5%


### PR DESCRIPTION
## Description

Increase the default slippage (currently only used by 0x (or THORSwaper if the dynamic calculation fails)) to 0.5% as per discussion: https://discord.com/channels/554694662431178782/1080598617800319057/1080645067158597792

## Notice

- [x] Have you followed the guidelines in our [Contributing]('https://github.com/shapeshift/web/blob/develop/CONTRIBUTING.md) guide?
- [x] Have you checked to ensure there aren't other open [Pull Requests](https://github.com/shapeshift/web/pulls) for the same update/change?

## Pull Request Type

- [ ] :bug: Bug fix (Non-breaking Change: Fixes an issue)
- [x] :hammer_and_wrench: Chore (Non-breaking Change: Doc updates, pkg upgrades, typos, etc..)
- [ ] :nail_care: New Feature (Breaking/Non-breaking Change)

## Issue (if applicable)

N/A: https://discord.com/channels/554694662431178782/1080598617800319057/1080645067158597792

## Risk

Very small.

## Testing

Trades (specifically 0x, and more specifically ETH -> USDC) should go through.

### Engineering

☝️ 

### Operations

☝️ 

## Screenshots (if applicable)

N/A