### PR TITLE
fix: getFormFees crash

### DIFF
--- a/src/components/Approval/Approval.tsx
+++ b/src/components/Approval/Approval.tsx
@@ -74,9 +74,13 @@ export const Approval = () => {
     selectFeeAssetById(state, quote?.sellAsset?.assetId ?? ethAssetId),
   )
 
-  const approvalFeeCryptoPrecision = bnOrZero(fees?.chainSpecific.approvalFeeCryptoBaseUnit).div(
-    bn(10).pow(sellFeeAsset?.precision ?? 0),
-  )
+  if (fees && !fees.chainSpecific) {
+    moduleLogger.debug({ fees }, 'chainSpecific undefined for fees')
+  }
+
+  const approvalFeeCryptoPrecision = bnOrZero(
+    fees?.chainSpecific?.approvalFeeCryptoBaseUnit ?? '0',
+  ).div(bn(10).pow(sellFeeAsset?.precision ?? 0))
 
   const handleExactAllowanceToggle = useCallback(
     () => swapperDispatch({ type: SwapperActionType.TOGGLE_IS_EXACT_ALLOWANCE }),

--- a/src/components/Trade/hooks/useSwapper/utils.ts
+++ b/src/components/Trade/hooks/useSwapper/utils.ts
@@ -68,7 +68,12 @@ const getEvmFees = <T extends EvmChainId>(
     .div(bn(10).exponentiatedBy(feeAsset.precision))
     .toFixed()
 
-  const approvalFeeCryptoPrecision = bnOrZero(trade.feeData.chainSpecific.approvalFeeCryptoBaseUnit)
+  if (!trade.feeData.chainSpecific) {
+    moduleLogger.debug({ trade }, 'feeData.chainSpecific undefined for trade')
+  }
+  const approvalFeeCryptoPrecision = bnOrZero(
+    trade.feeData.chainSpecific?.approvalFeeCryptoBaseUnit ?? '0',
+  )
     .dividedBy(bn(10).exponentiatedBy(feeAsset.precision))
     .toString()
   const totalFeeCryptoPrecision = bnOrZero(networkFeeCryptoPrecision)

--- a/src/components/Trade/hooks/useSwapper/utils.ts
+++ b/src/components/Trade/hooks/useSwapper/utils.ts
@@ -68,7 +68,7 @@ const getEvmFees = <T extends EvmChainId>(
     .div(bn(10).exponentiatedBy(feeAsset.precision))
     .toFixed()
 
-  if (!trade.feeData.chainSpecific) {
+  if (trade.feeData && !trade.feeData.chainSpecific) {
     moduleLogger.debug({ trade }, 'feeData.chainSpecific undefined for trade')
   }
   const approvalFeeCryptoPrecision = bnOrZero(

--- a/src/components/Trade/hooks/useSwapper/utils.ts
+++ b/src/components/Trade/hooks/useSwapper/utils.ts
@@ -86,7 +86,7 @@ const getEvmFees = <T extends EvmChainId>(
 
   return {
     chainSpecific: {
-      approvalFeeCryptoBaseUnit: trade.feeData.chainSpecific.approvalFeeCryptoBaseUnit,
+      approvalFeeCryptoBaseUnit: trade.feeData.chainSpecific?.approvalFeeCryptoBaseUnit ?? '0',
       gasPriceCryptoBaseUnit,
       estimatedGas: estimatedGasCryptoBaseUnit,
       totalFee: totalFeeCryptoPrecision,

--- a/src/components/Trade/hooks/useSwapper/utils.ts
+++ b/src/components/Trade/hooks/useSwapper/utils.ts
@@ -72,7 +72,7 @@ const getEvmFees = <T extends EvmChainId>(
     moduleLogger.debug({ trade }, 'feeData.chainSpecific undefined for trade')
   }
   const approvalFeeCryptoPrecision = bnOrZero(
-    trade.feeData.chainSpecific?.approvalFeeCryptoBaseUnit ?? '0',
+    trade.feeData.chainSpecific?.approvalFeeCryptoBaseUnit,
   )
     .dividedBy(bn(10).exponentiatedBy(feeAsset.precision))
     .toString()
@@ -80,9 +80,9 @@ const getEvmFees = <T extends EvmChainId>(
     .plus(approvalFeeCryptoPrecision)
     .toString()
   const gasPriceCryptoBaseUnit = bnOrZero(
-    trade.feeData.chainSpecific.gasPriceCryptoBaseUnit,
+    trade.feeData.chainSpecific?.gasPriceCryptoBaseUnit,
   ).toString()
-  const estimatedGasCryptoBaseUnit = bnOrZero(trade.feeData.chainSpecific.estimatedGas).toString()
+  const estimatedGasCryptoBaseUnit = bnOrZero(trade.feeData.chainSpecific?.estimatedGas).toString()
 
   return {
     chainSpecific: {


### PR DESCRIPTION
## Description

Brings some additional safety in `chainSpecific` being undefined - it shouldn't be, but if it is across render cycles, we will now gracefully handle it and log it at debug level.

See error spotted by @wesleygravess 
 
![image](https://user-images.githubusercontent.com/17035424/222783090-dfceff4d-f710-4980-a2fe-f0d18d8e59b2.png)


## Notice

<!-- Before submitting a pull request, please make sure you have answered the following: -->

- [x] Have you followed the guidelines in our [Contributing]('https://github.com/shapeshift/web/blob/develop/CONTRIBUTING.md) guide?
- [x] Have you checked to ensure there aren't other open [Pull Requests](https://github.com/shapeshift/web/pulls) for the same update/change?

## Pull Request Type

- [x] :bug: Bug fix (Non-breaking Change: Fixes an issue)
- [ ] :hammer_and_wrench: Chore (Non-breaking Change: Doc updates, pkg upgrades, typos, etc..)
- [ ] :nail_care: New Feature (Breaking/Non-breaking Change)

## Issue (if applicable)

N/A

## Risk

<!-----------------------------------------------------------------------------
Outline the scope of your changes and the risk associated with them. You must use your discretion as an engineer to determine the potential impact of your changes.

E.g. an upgrade to `hdwallet` or core state management would be considered higher risk, and might require a full regression test. UI or isolated view changes, or something behind a feature flag may have near zero risk. Small bug fixes might require testing isolated to the specific fix.
------------------------------------------------------------------------------>

None, apart from this not fixing the root cause but it will at least give us some indication whether or not that's an actual upstream error, or only render cycles shaenanigans.

## Testing

<!-----------------------------------------------------------------------------
We treat every PR to be merged with the same scrutiny as if we were merging directly to production.

Your PR will not be merged if you do not complete the sections below for our engineering and operations teams to test.
------------------------------------------------------------------------------>

- Connect to the app with native or KK
- Go to Osmosis asset
- Wait ~30ish seconds
- Go back to dashboard and ensure the app doesn't crash
- Repeat, refresh, repeat again and ensure the app still doesn't crash with the error above

### Engineering

<!-----------------------------------------------------------------------------
Include sufficient information here for an engineer to test your PR. This may include how to test locally, in a built environment, changes to infrastructure etc.
------------------------------------------------------------------------------>

- Logging looks sane

### Operations

<!-----------------------------------------------------------------------------
If your changes have a user-facing impact, describe how a non-technical QA team can functionally test your changes in a preview environment.

If they are not user-facing please describe how to test for any regressions that may occur.
------------------------------------------------------------------------------>

- ☝🏽 

## Screenshots (if applicable)
