### PR TITLE
fix: don't refetch existing txs

### DIFF
--- a/src/state/apis/types.ts
+++ b/src/state/apis/types.ts
@@ -1,7 +1,9 @@
 import type { AssetsState } from 'state/slices/assetsSlice/assetsSlice'
 import type { Preferences } from 'state/slices/preferencesSlice/preferencesSlice'
+import type { TxHistory } from 'state/slices/txHistorySlice/txHistorySlice'
 
 export type State = {
   assets: AssetsState
   preferences: Preferences
+  txHistory: TxHistory
 }

--- a/src/state/slices/txHistorySlice/txHistorySlice.ts
+++ b/src/state/slices/txHistorySlice/txHistorySlice.ts
@@ -16,6 +16,7 @@ import type { PartialRecord } from 'lib/utils'
 import { deepUpsertArray, isSome } from 'lib/utils'
 import { BASE_RTK_CREATE_API_CONFIG } from 'state/apis/const'
 import { getFoxyApi } from 'state/apis/foxy/foxyApiSingleton'
+import type { State } from 'state/apis/types'
 import type { Nominal } from 'types/common'
 
 import { getRelatedAssetIds, serializeTxIndex, UNIQUE_TX_ID_DELIMITER } from './utils'
@@ -264,7 +265,8 @@ export const txHistoryApi = createApi({
 
                 currentCursor = cursor
 
-                const txState = (getState() as any).txHistory.txs as TxsState
+                const state = getState() as State
+                const txState = state.txHistory.txs
                 // the existing tx indexes for this account
                 const existingTxIndexes = Object.values(
                   txState?.byAccountIdAssetId?.[accountId] ?? {},


### PR DESCRIPTION
## Description

<!-- Please describe your changes -->

we'd previously keep paginating all tx history until we no longer had any pages to fetch from the backend

this change causes us to always at least fetch the first page of txs per account, which are ordered as newest first.

this means we'll always pick up latest txs on a fresh page load.

we then compare the fetch tx ids to the existing tx ids in the store. if there aren't any new txs, we stop paginating tx history for that accounts.

this means reduced network requests and better render performance for accounts with large tx history.

## Notice

<!-- Before submitting a pull request, please make sure you have answered the following: -->

- [x] Have you followed the guidelines in our [Contributing]('https://github.com/shapeshift/web/blob/develop/CONTRIBUTING.md) guide?
- [x] Have you checked to ensure there aren't other open [Pull Requests](https://github.com/shapeshift/web/pulls) for the same update/change?

## Pull Request Type

- [ ] :bug: Bug fix (Non-breaking Change: Fixes an issue)
- [x] :hammer_and_wrench: Chore (Non-breaking Change: Doc updates, pkg upgrades, typos, etc..)
- [ ] :nail_care: New Feature (Breaking/Non-breaking Change)

## Issue (if applicable)

<!-----------------------------------------------------------------------------
If applicable, please link to the github issue and put `closes #XXXX` in your comment to auto-close the issue that your PR fixes.
------------------------------------------------------------------------------>

slightly inaccurate description, but closes #3928

## Risk

isolated to tx history

<!-----------------------------------------------------------------------------
Outline the scope of your changes and the risk associated with them. You must use your discretion as an engineer to determine the potential impact of your changes.

E.g. an upgrade to `hdwallet` or core state management would be considered higher risk, and might require a full regression test. UI or isolated view changes, or something behind a feature flag may have near zero risk. Small bug fixes might require testing isolated to the specific fix.
------------------------------------------------------------------------------>

## Testing

<!-----------------------------------------------------------------------------
We treat every PR to be merged with the same scrutiny as if we were merging directly to production.

Your PR will not be merged if you do not complete the sections below for our engineering and operations teams to test.
------------------------------------------------------------------------------>

### Engineering

* for a given wallet in prod, clear your application storage, then load up a chosen wallet. check the total tx ids length in redux.
* clear your application storage locally against this branch. load the same wallet. check the tx ids length match.

<!-----------------------------------------------------------------------------
Include sufficient information here for an engineer to test your PR. This may include how to test locally, in a built environment, changes to infrastructure etc.
------------------------------------------------------------------------------>

### Operations

* load a wallet in prod, look at the first and last tx's in tx history page, and per account tx history page.
* load the same wallet in release, do the same.
* clear your local storage, refresh the page and let the wallet history load all txs (as we do now)
* reload the page - tx history should be the same, but a bit faster.

<!-----------------------------------------------------------------------------
If your changes have a user-facing impact, describe how a non-technical QA team can functionally test your changes in a preview environment.

If they are not user-facing please describe how to test for any regressions that may occur.
------------------------------------------------------------------------------>

## Screenshots (if applicable)

no visual changes.
