### PR TITLE
fix: hanging ETH/FOX LP/staking selected AccountId 

### DIFF
--- a/src/context/FoxEthProvider/FoxEthProvider.tsx
+++ b/src/context/FoxEthProvider/FoxEthProvider.tsx
@@ -29,9 +29,9 @@ type FoxEthProviderProps = {
 
 type IFoxEthContext = {
   farmingAccountId: AccountId | undefined
-  setFarmingAccountId: (accountId: AccountId) => void
+  setFarmingAccountId: (accountId: AccountId | undefined) => void
   lpAccountId: AccountId | undefined
-  setLpAccountId: (accountId: AccountId) => void
+  setLpAccountId: (accountId: AccountId | undefined) => void
   onOngoingFarmingTxIdChange: (txid: string, contractAddress?: string) => void
   onOngoingLpTxIdChange: (txid: string, contractAddress?: string) => void
 }

--- a/src/features/defi/providers/fox-eth-lp/components/FoxEthLpManager/FoxEthLpManager.tsx
+++ b/src/features/defi/providers/fox-eth-lp/components/FoxEthLpManager/FoxEthLpManager.tsx
@@ -4,6 +4,7 @@ import type {
 } from 'features/defi/contexts/DefiManagerProvider/DefiCommon'
 import { DefiAction } from 'features/defi/contexts/DefiManagerProvider/DefiCommon'
 import { AnimatePresence } from 'framer-motion'
+import { useEffect } from 'react'
 import { SlideTransition } from 'components/SlideTransition'
 import { useFoxEth } from 'context/FoxEthProvider/FoxEthProvider'
 import { useBrowserRouter } from 'hooks/useBrowserRouter/useBrowserRouter'
@@ -16,6 +17,14 @@ export const FoxEthLpManager = () => {
   const { query } = useBrowserRouter<DefiQueryParams, DefiParams>()
   const { modal } = query
   const { lpAccountId, setLpAccountId: handleLpAccountIdChange } = useFoxEth()
+
+  // lpAccountId isn't a local state field - it is a memoized state field from the <FoxEthContext /> and will stay hanging
+  // This makes sure to clear it on modal close
+  useEffect(() => {
+    return () => {
+      handleLpAccountIdChange(undefined)
+    }
+  })
 
   return (
     <AnimatePresence exitBeforeEnter initial={false}>

--- a/src/features/defi/providers/fox-farming/components/FoxFarmingManager/FoxFarmingManager.tsx
+++ b/src/features/defi/providers/fox-farming/components/FoxFarmingManager/FoxFarmingManager.tsx
@@ -4,6 +4,7 @@ import type {
 } from 'features/defi/contexts/DefiManagerProvider/DefiCommon'
 import { DefiAction } from 'features/defi/contexts/DefiManagerProvider/DefiCommon'
 import { AnimatePresence } from 'framer-motion'
+import { useEffect } from 'react'
 import { SlideTransition } from 'components/SlideTransition'
 import { useFoxEth } from 'context/FoxEthProvider/FoxEthProvider'
 import { useBrowserRouter } from 'hooks/useBrowserRouter/useBrowserRouter'
@@ -17,6 +18,14 @@ export const FoxFarmingManager = () => {
   const { query } = useBrowserRouter<DefiQueryParams, DefiParams>()
   const { modal } = query
   const { farmingAccountId, setFarmingAccountId: handleFarmingAccountIdChange } = useFoxEth()
+
+  // farmingAccountId isn't a local state field - it is a memoized state field from the <FoxEthContext /> and will stay hanging
+  // This makes sure to clear it on modal close
+  useEffect(() => {
+    return () => {
+      handleFarmingAccountIdChange(undefined)
+    }
+  })
 
   return (
     <AnimatePresence exitBeforeEnter initial={false}>


### PR DESCRIPTION
## Description

Does what it says on the box, see [spotted bug by @MBMaria](https://discord.com/channels/554694662431178782/1083140756652433428/1083149078365483008) in https://github.com/shapeshift/web/pull/3989:

> the account with the highest balance comes up when selecting eth/fox LP pre and post deposit. However, after i do a deposit or withdraw, the overview will default to account 0, even though my highest balance is account 1 🤔 


## Notice

<!-- Before submitting a pull request, please make sure you have answered the following: -->

- [x] Have you followed the guidelines in our [Contributing]('https://github.com/shapeshift/web/blob/develop/CONTRIBUTING.md) guide?
- [x] Have you checked to ensure there aren't other open [Pull Requests](https://github.com/shapeshift/web/pulls) for the same update/change?

## Pull Request Type

- [x] :bug: Bug fix (Non-breaking Change: Fixes an issue)
- [ ] :hammer_and_wrench: Chore (Non-breaking Change: Doc updates, pkg upgrades, typos, etc..)
- [ ] :nail_care: New Feature (Breaking/Non-breaking Change)

## Issue (if applicable)

<!-----------------------------------------------------------------------------
If applicable, please link to the github issue and put `closes #XXXX` in your comment to auto-close the issue that your PR fixes.
------------------------------------------------------------------------------>

N/A

## Risk

<!-----------------------------------------------------------------------------
Outline the scope of your changes and the risk associated with them. You must use your discretion as an engineer to determine the potential impact of your changes.

E.g. an upgrade to `hdwallet` or core state management would be considered higher risk, and might require a full regression test. UI or isolated view changes, or something behind a feature flag may have near zero risk. Small bug fixes might require testing isolated to the specific fix.
------------------------------------------------------------------------------>

- This could actually unveil some deeper issue and rug the account selection altogether if we happen to do unmounts and remounts we shouldn't

## Testing

<!-----------------------------------------------------------------------------
We treat every PR to be merged with the same scrutiny as if we were merging directly to production.

Your PR will not be merged if you do not complete the sections below for our engineering and operations teams to test.
------------------------------------------------------------------------------>

- Have your highest LP/Staking staked balance on any account > 0
- Open the modal
- Ensure the highest balance account is still selected
- Select account 0 (or any account other than your highest balance one for that matter) and do a deposit / withdraw (or don't, doesn't *ackhually* matter)
- Ensure the highest balance account is still selected after closing and reopening the modal

### Engineering

<!-----------------------------------------------------------------------------
Include sufficient information here for an engineer to test your PR. This may include how to test locally, in a built environment, changes to infrastructure etc.
------------------------------------------------------------------------------>

- ☝🏽 

### Operations

<!-----------------------------------------------------------------------------
If your changes have a user-facing impact, describe how a non-technical QA team can functionally test your changes in a preview environment.

If they are not user-facing please describe how to test for any regressions that may occur.
------------------------------------------------------------------------------>

- ☝🏽 

## Screenshots (if applicable)
