### PR TITLE
feat: selectStakingOpportunities -> selectStakingOpportunityByFilter

### DIFF
--- a/src/features/defi/providers/foxy/components/FoxyManager/Deposit/FoxyDeposit.tsx
+++ b/src/features/defi/providers/foxy/components/FoxyManager/Deposit/FoxyDeposit.tsx
@@ -29,7 +29,7 @@ import {
   selectBIP44ParamsByAccountId,
   selectMarketDataById,
   selectPortfolioLoading,
-  selectStakingOpportunitiesById,
+  selectStakingOpportunityByFilter,
 } from 'state/slices/selectors'
 import { useAppSelector } from 'state/store'
 
@@ -57,11 +57,9 @@ export const FoxyDeposit: React.FC<{
   // ContractAssetId
   const assetId = toAssetId({ chainId, assetNamespace, assetReference })
 
-  const opportunitiesMetadata = useAppSelector(state => selectStakingOpportunitiesById(state))
-
-  const opportunityMetadata = useMemo(
-    () => opportunitiesMetadata[assetId as StakingId],
-    [assetId, opportunitiesMetadata],
+  const opportunityMetadataFilter = useMemo(() => ({ stakingId: assetId as StakingId }), [assetId])
+  const opportunityMetadata = useAppSelector(state =>
+    selectStakingOpportunityByFilter(state, opportunityMetadataFilter),
   )
 
   const stakingAssetId = opportunityMetadata?.underlyingAssetIds[0] ?? ''

--- a/src/features/defi/providers/foxy/components/FoxyManager/useFoxyQuery.ts
+++ b/src/features/defi/providers/foxy/components/FoxyManager/useFoxyQuery.ts
@@ -7,7 +7,7 @@ import { useMemo } from 'react'
 import { useBrowserRouter } from 'hooks/useBrowserRouter/useBrowserRouter'
 import { selectAssetById } from 'state/slices/assetsSlice/selectors'
 import { selectMarketDataById } from 'state/slices/marketDataSlice/selectors'
-import { selectStakingOpportunitiesById } from 'state/slices/opportunitiesSlice/selectors'
+import { selectStakingOpportunityByFilter } from 'state/slices/opportunitiesSlice/selectors'
 import type { StakingId } from 'state/slices/opportunitiesSlice/types'
 import { useAppSelector } from 'state/store'
 
@@ -15,11 +15,12 @@ export const useFoxyQuery = () => {
   const { query } = useBrowserRouter<DefiQueryParams, DefiParams>()
   const { chainId, assetReference: contractAddress, assetNamespace } = query
   const contractAssetId = toAssetId({ chainId, assetNamespace, assetReference: contractAddress })
-  const opportunitiesMetadata = useAppSelector(state => selectStakingOpportunitiesById(state))
-
-  const opportunityMetadata = useMemo(
-    () => opportunitiesMetadata[contractAssetId as StakingId],
-    [contractAssetId, opportunitiesMetadata],
+  const opportunityMetadataFilter = useMemo(
+    () => ({ stakingId: contractAssetId as StakingId }),
+    [contractAssetId],
+  )
+  const opportunityMetadata = useAppSelector(state =>
+    selectStakingOpportunityByFilter(state, opportunityMetadataFilter),
   )
 
   const underlyingAssetId = opportunityMetadata?.underlyingAssetId ?? ''

--- a/src/features/defi/providers/idle/components/IdleManager/Claim/IdleClaim.tsx
+++ b/src/features/defi/providers/idle/components/IdleManager/Claim/IdleClaim.tsx
@@ -19,7 +19,7 @@ import type { StakingId } from 'state/slices/opportunitiesSlice/types'
 import {
   selectAssetById,
   selectMarketDataById,
-  selectStakingOpportunitiesById,
+  selectStakingOpportunityByFilter,
 } from 'state/slices/selectors'
 import { useAppSelector } from 'state/store'
 
@@ -55,10 +55,9 @@ export const IdleClaim: React.FC<IdleClaimProps> = ({ accountId }) => {
 
   const marketData = useAppSelector(state => selectMarketDataById(state, underlyingAssetId))
 
-  const opportunitiesMetadata = useAppSelector(state => selectStakingOpportunitiesById(state))
-  const opportunityMetadata = useMemo(
-    () => opportunitiesMetadata[assetId as StakingId],
-    [assetId, opportunitiesMetadata],
+  const opportunityMetadataFilter = useMemo(() => ({ stakingId: assetId as StakingId }), [assetId])
+  const opportunityMetadata = useAppSelector(state =>
+    selectStakingOpportunityByFilter(state, opportunityMetadataFilter),
   )
 
   // user info

--- a/src/features/defi/providers/thorchain-savers/components/ThorchainSaversManager/Overview/ThorchainSaversOverview.tsx
+++ b/src/features/defi/providers/thorchain-savers/components/ThorchainSaversManager/Overview/ThorchainSaversOverview.tsx
@@ -55,7 +55,7 @@ import {
   selectHighestBalanceAccountIdByStakingId,
   selectMarketDataById,
   selectOpportunitiesApiQueriesByFilter,
-  selectStakingOpportunitiesById,
+  selectStakingOpportunityByFilter,
   selectTxsByFilter,
   selectUnderlyingStakingAssetsWithBalancesAndIcons,
 } from 'state/slices/selectors'
@@ -149,12 +149,10 @@ export const ThorchainSaversOverview: React.FC<OverviewProps> = ({
       : undefined,
   )
 
-  const opportunitiesMetadata = useAppSelector(state => selectStakingOpportunitiesById(state))
-
-  const opportunityMetadata = useMemo(
-    () => opportunitiesMetadata[assetId as StakingId],
-    [assetId, opportunitiesMetadata],
-  ) as ThorchainSaversStakingSpecificMetadata | undefined
+  const opportunityMetadataFilter = useMemo(() => ({ stakingId: assetId as StakingId }), [assetId])
+  const opportunityMetadata = useAppSelector(state =>
+    selectStakingOpportunityByFilter(state, opportunityMetadataFilter),
+  ) as ThorchainSaversStakingSpecificMetadata
 
   const currentCapFillPercentage = bnOrZero(opportunityMetadata?.tvl)
     .div(bnOrZero(opportunityMetadata?.saversMaxSupplyFiat))

--- a/src/state/slices/opportunitiesSlice/selectors/stakingSelectors.ts
+++ b/src/state/slices/opportunitiesSlice/selectors/stakingSelectors.ts
@@ -84,12 +84,14 @@ export const selectStakingOpportunityByFilter = createDeepEqualOutputSelector(
   selectDefiTypeParamFromFilter,
   selectAssetIdParamFromFilter,
   selectValidatorIdParamFromFilter,
+  selectStakingIdParamFromFilter,
   (
     stakingOpportunitiesById,
     defiProvider,
     defiType,
     assetId,
     validatorId,
+    stakingId,
   ): OpportunityMetadata | undefined => {
     return Object.values(stakingOpportunitiesById).find(
       stakingOpportunity =>
@@ -97,7 +99,7 @@ export const selectStakingOpportunityByFilter = createDeepEqualOutputSelector(
         defiProvider === stakingOpportunity.provider &&
         defiType === stakingOpportunity.type &&
         assetId === stakingOpportunity.assetId &&
-        validatorId === stakingOpportunity.id,
+        [validatorId, stakingId].includes(stakingOpportunity.id),
     )
   },
 )

--- a/src/state/slices/opportunitiesSlice/selectors/stakingSelectors.ts
+++ b/src/state/slices/opportunitiesSlice/selectors/stakingSelectors.ts
@@ -96,10 +96,10 @@ export const selectStakingOpportunityByFilter = createDeepEqualOutputSelector(
     return Object.values(stakingOpportunitiesById).find(
       stakingOpportunity =>
         stakingOpportunity &&
-        defiProvider === stakingOpportunity.provider &&
-        defiType === stakingOpportunity.type &&
-        assetId === stakingOpportunity.assetId &&
-        [validatorId, stakingId].includes(stakingOpportunity.id),
+        (!defiProvider || defiProvider === stakingOpportunity.provider) &&
+        (!defiType || defiType === stakingOpportunity.type) &&
+        (!assetId || assetId === stakingOpportunity.assetId) &&
+        (!(validatorId || stakingId) || [validatorId, stakingId].includes(stakingOpportunity.id)),
     )
   },
 )


### PR DESCRIPTION
## Description

Making sure we use the right selector - `selectStakingOpportunityByFilter` previously didn't exist and we had to select all opportunities then index by the LpId/StakingId. Now that we have an `id` field, we can use the byFilter selector to select opportunities.

## Notice

<!-- Before submitting a pull request, please make sure you have answered the following: -->

- [x] Have you followed the guidelines in our [Contributing]('https://github.com/shapeshift/web/blob/develop/CONTRIBUTING.md) guide?
- [x] Have you checked to ensure there aren't other open [Pull Requests](https://github.com/shapeshift/web/pulls) for the same update/change?

## Pull Request Type

- [ ] :bug: Bug fix (Non-breaking Change: Fixes an issue)
- [ ] :hammer_and_wrench: Chore (Non-breaking Change: Doc updates, pkg upgrades, typos, etc..)
- [x] :nail_care: New Feature (Breaking/Non-breaking Change)

## Issue (if applicable)

N/A

## Risk

<!-----------------------------------------------------------------------------
Outline the scope of your changes and the risk associated with them. You must use your discretion as an engineer to determine the potential impact of your changes.

E.g. an upgrade to `hdwallet` or core state management would be considered higher risk, and might require a full regression test. UI or isolated view changes, or something behind a feature flag may have near zero risk. Small bug fixes might require testing isolated to the specific fix.
------------------------------------------------------------------------------>

Theoretically none, same thing better selector

## Testing

<!-----------------------------------------------------------------------------
We treat every PR to be merged with the same scrutiny as if we were merging directly to production.

Your PR will not be merged if you do not complete the sections below for our engineering and operations teams to test.
------------------------------------------------------------------------------>

- No need to broadcast an actual Tx for any of these, only ensure against prod that the displayed data looks sane
- THORCHain saver overview modal show no regressions
- FOXy flow (all modals) show no regressions
- Idle claim modal shows no regressions

### Engineering

<!-----------------------------------------------------------------------------
Include sufficient information here for an engineer to test your PR. This may include how to test locally, in a built environment, changes to infrastructure etc.
------------------------------------------------------------------------------>

- ☝🏽

### Operations

<!-----------------------------------------------------------------------------
If your changes have a user-facing impact, describe how a non-technical QA team can functionally test your changes in a preview environment.

If they are not user-facing please describe how to test for any regressions that may occur.
------------------------------------------------------------------------------>

- ☝🏽 

## Screenshots (if applicable)

<img width="551" alt="image" src="https://user-images.githubusercontent.com/17035424/224382584-9e12188e-3b2c-438d-8414-57d4b0a540d6.png">
<img width="569" alt="image" src="https://user-images.githubusercontent.com/17035424/224386054-9f0d4bd1-f38c-427f-99d2-7263b9719628.png">
<img width="546" alt="image" src="https://user-images.githubusercontent.com/17035424/224386109-d9b45b92-b294-4796-bf58-4f0333c377d7.png">
<img width="556" alt="image" src="https://user-images.githubusercontent.com/17035424/224386164-46403fba-ebea-4560-903f-9a87d1fedb35.png">
<img width="539" alt="image" src="https://user-images.githubusercontent.com/17035424/224386229-d5f8c383-3870-4bc5-bc7c-6c6fa44c9e54.png">
<img width="550" alt="image" src="https://user-images.githubusercontent.com/17035424/224386783-8e00f022-ae87-40be-b2f8-db64ee58559b.png">
<img width="551" alt="image" src="https://user-images.githubusercontent.com/17035424/224386817-4bec177c-f9f1-4991-81ce-afe0ceecff18.png">
<img width="544" alt="image" src="https://user-images.githubusercontent.com/17035424/224386852-12db3aef-93d2-4898-9a90-494c77214932.png">
<img width="542" alt="image" src="https://user-images.githubusercontent.com/17035424/224386877-5662bdef-c533-4a52-abcd-c9e9e0b9d9c2.png">