### PR TITLE
fix: canCoverTxFees precision

### DIFF
--- a/src/features/defi/components/Approve/Approve.tsx
+++ b/src/features/defi/components/Approve/Approve.tsx
@@ -20,7 +20,7 @@ type ApproveProps = {
   providerIcon?: string
   icons?: string[]
   feeAsset: Asset
-  cryptoEstimatedGasFee: string
+  estimatedGasFeeCryptoPrecision: string
   fiatEstimatedGasFee: string
   isExactAllowance?: boolean
   learnMoreLink?: string
@@ -36,7 +36,7 @@ type ApproveProps = {
 export const Approve = ({
   asset,
   contractAddress,
-  cryptoEstimatedGasFee,
+  estimatedGasFeeCryptoPrecision,
   disabled,
   feeAsset,
   fiatEstimatedGasFee,
@@ -160,7 +160,7 @@ export const Approve = ({
               <Amount.Fiat value={fiatEstimatedGasFee} />
               <Amount.Crypto
                 color='gray.500'
-                value={cryptoEstimatedGasFee}
+                value={estimatedGasFeeCryptoPrecision}
                 symbol={feeAsset.symbol}
               />
             </Box>

--- a/src/features/defi/components/Approve/ApprovePreFooter.tsx
+++ b/src/features/defi/components/Approve/ApprovePreFooter.tsx
@@ -13,12 +13,12 @@ import { isSome } from 'lib/utils'
 export const ApprovePreFooter = ({
   action,
   feeAsset,
-  estimatedGasCrypto: estimatedGasCryptoPrecision,
+  estimatedGasCryptoPrecision: estimatedGasCryptoPrecision,
   accountId,
 }: {
   accountId: AccountId | undefined
   action: DefiAction.Deposit | DefiAction.Withdraw
-  estimatedGasCrypto: string | undefined
+  estimatedGasCryptoPrecision: string | undefined
   feeAsset: Asset
 }) => {
   const translate = useTranslate()

--- a/src/features/defi/components/Approve/ApprovePreFooter.tsx
+++ b/src/features/defi/components/Approve/ApprovePreFooter.tsx
@@ -13,7 +13,7 @@ import { isSome } from 'lib/utils'
 export const ApprovePreFooter = ({
   action,
   feeAsset,
-  estimatedGasCryptoPrecision: estimatedGasCryptoPrecision,
+  estimatedGasCryptoPrecision,
   accountId,
 }: {
   accountId: AccountId | undefined

--- a/src/features/defi/components/Approve/ApprovePreFooter.tsx
+++ b/src/features/defi/components/Approve/ApprovePreFooter.tsx
@@ -13,7 +13,7 @@ import { isSome } from 'lib/utils'
 export const ApprovePreFooter = ({
   action,
   feeAsset,
-  estimatedGasCrypto,
+  estimatedGasCrypto: estimatedGasCryptoPrecision,
   accountId,
 }: {
   accountId: AccountId | undefined
@@ -26,10 +26,14 @@ export const ApprovePreFooter = ({
   const alertTextColor = useColorModeValue('blue.800', 'white')
   const hasEnoughBalanceForGas = useMemo(
     () =>
-      isSome(estimatedGasCrypto) &&
+      isSome(estimatedGasCryptoPrecision) &&
       isSome(accountId) &&
-      canCoverTxFees({ feeAsset, estimatedGasCrypto, accountId }),
-    [estimatedGasCrypto, accountId, feeAsset],
+      canCoverTxFees({
+        feeAsset,
+        estimatedGasCryptoPrecision,
+        accountId,
+      }),
+    [estimatedGasCryptoPrecision, accountId, feeAsset],
   )
 
   const feeTranslation = useMemo(

--- a/src/features/defi/helpers/utils.ts
+++ b/src/features/defi/helpers/utils.ts
@@ -19,20 +19,18 @@ export const chainIdToLabel = (chainId: ChainId): string => {
 
 export const canCoverTxFees = ({
   feeAsset,
-  estimatedGasCrypto,
+  estimatedGasCryptoPrecision,
   accountId,
 }: {
   feeAsset: Asset
-  estimatedGasCrypto: string
+  estimatedGasCryptoPrecision: string
   accountId: AccountId
 }) => {
   const state = store.getState()
-  const feeAssetBalance = selectPortfolioCryptoHumanBalanceByFilter(state, {
+  const feeAssetBalanceCryptoHuman = selectPortfolioCryptoHumanBalanceByFilter(state, {
     accountId,
     assetId: feeAsset.assetId,
   })
 
-  return bnOrZero(feeAssetBalance)
-    .minus(bnOrZero(estimatedGasCrypto).div(`1e+${feeAsset.precision}`))
-    .gte(0)
+  return bnOrZero(feeAssetBalanceCryptoHuman).minus(bnOrZero(estimatedGasCryptoPrecision)).gte(0)
 }

--- a/src/features/defi/providers/cosmos/components/CosmosManager/Claim/ClaimCommon.ts
+++ b/src/features/defi/providers/cosmos/components/CosmosManager/Claim/ClaimCommon.ts
@@ -8,7 +8,6 @@ export enum TxStatus {
 
 type CosmosClaimValues = {
   estimatedGasCrypto?: string
-  usedGasFee?: string
   txStatus: TxStatus
 }
 

--- a/src/features/defi/providers/cosmos/components/CosmosManager/Claim/ClaimReducer.ts
+++ b/src/features/defi/providers/cosmos/components/CosmosManager/Claim/ClaimReducer.ts
@@ -8,7 +8,6 @@ export const initialState: CosmosClaimState = {
   opportunity: {} as StakingEarnOpportunityType,
   loading: false,
   claim: {
-    usedGasFee: '',
     txStatus: TxStatus.PENDING,
   },
 }

--- a/src/features/defi/providers/cosmos/components/CosmosManager/Deposit/DepositCommon.ts
+++ b/src/features/defi/providers/cosmos/components/CosmosManager/Deposit/DepositCommon.ts
@@ -8,7 +8,6 @@ type EstimatedGas = {
 type CosmosDepositValues = Omit<DepositValues, DepositField.Slippage> &
   EstimatedGas & {
     txStatus: string
-    usedGasFee: string // TODO: remove this property?
   }
 
 export type CosmosDepositState = {

--- a/src/features/defi/providers/cosmos/components/CosmosManager/Deposit/DepositReducer.ts
+++ b/src/features/defi/providers/cosmos/components/CosmosManager/Deposit/DepositReducer.ts
@@ -10,7 +10,6 @@ export const initialState: CosmosDepositState = {
     fiatAmount: '',
     cryptoAmount: '',
     txStatus: 'pending',
-    usedGasFee: '',
   },
 }
 

--- a/src/features/defi/providers/fox-eth-lp/components/FoxEthLpManager/Deposit/DepositCommon.ts
+++ b/src/features/defi/providers/fox-eth-lp/components/FoxEthLpManager/Deposit/DepositCommon.ts
@@ -1,5 +1,5 @@
 type EstimatedGas = {
-  estimatedGasCrypto?: string
+  estimatedGasCryptoPrecision?: string
 }
 
 type DepositValues = {

--- a/src/features/defi/providers/fox-eth-lp/components/FoxEthLpManager/Deposit/DepositCommon.ts
+++ b/src/features/defi/providers/fox-eth-lp/components/FoxEthLpManager/Deposit/DepositCommon.ts
@@ -36,7 +36,7 @@ type SetApprove = {
 
 type SetDeposit = {
   type: FoxEthLpDepositActionType.SET_DEPOSIT
-  payload: any
+  payload: Partial<FoxEthLpDepositValues>
 }
 
 type SetLoading = {

--- a/src/features/defi/providers/fox-eth-lp/components/FoxEthLpManager/Deposit/DepositCommon.ts
+++ b/src/features/defi/providers/fox-eth-lp/components/FoxEthLpManager/Deposit/DepositCommon.ts
@@ -12,7 +12,7 @@ type DepositValues = {
 type FoxEthLpDepositValues = DepositValues &
   EstimatedGas & {
     txStatus: string
-    usedGasFee: string
+    usedGasFeeCryptoPrecision: string
   }
 
 export type FoxEthLpDepositState = {

--- a/src/features/defi/providers/fox-eth-lp/components/FoxEthLpManager/Deposit/DepositReducer.ts
+++ b/src/features/defi/providers/fox-eth-lp/components/FoxEthLpManager/Deposit/DepositReducer.ts
@@ -11,7 +11,7 @@ export const initialState: FoxEthLpDepositState = {
     ethFiatAmount: '',
     ethCryptoAmount: '',
     txStatus: 'pending',
-    usedGasFee: '',
+    usedGasFeeCryptoPrecision: '',
   },
 }
 

--- a/src/features/defi/providers/fox-eth-lp/components/FoxEthLpManager/Deposit/components/Approve.tsx
+++ b/src/features/defi/providers/fox-eth-lp/components/FoxEthLpManager/Deposit/components/Approve.tsx
@@ -100,12 +100,12 @@ export const Approve: React.FC<FoxEthLpApproveProps> = ({ accountId, onNext }) =
         token1Amount: state.deposit.foxCryptoAmount,
       })
       if (!gasData) return
-      const estimatedGasCrypto = bnOrZero(gasData.average.txFee)
+      const estimatedGasCryptoPrecision = bnOrZero(gasData.average.txFee)
         .div(bn(10).pow(feeAsset.precision))
         .toPrecision()
       dispatch({
         type: FoxEthLpDepositActionType.SET_DEPOSIT,
-        payload: { estimatedGasCrypto },
+        payload: { estimatedGasCryptoPrecision },
       })
 
       onNext(DefiStep.Confirm)

--- a/src/features/defi/providers/fox-eth-lp/components/FoxEthLpManager/Deposit/components/Approve.tsx
+++ b/src/features/defi/providers/fox-eth-lp/components/FoxEthLpManager/Deposit/components/Approve.tsx
@@ -180,7 +180,7 @@ export const Approve: React.FC<FoxEthLpApproveProps> = ({ accountId, onNext }) =
     <ReusableApprove
       asset={foxAsset}
       feeAsset={feeAsset}
-      cryptoEstimatedGasFee={bnOrZero(estimatedGasCryptoPrecision).toFixed(5)}
+      estimatedGasFeeCryptoPrecision={bnOrZero(estimatedGasCryptoPrecision).toFixed(5)}
       disabled={!hasEnoughBalanceForGas}
       fiatEstimatedGasFee={bnOrZero(estimatedGasCryptoPrecision)
         .times(feeMarketData.price)

--- a/src/features/defi/providers/fox-eth-lp/components/FoxEthLpManager/Deposit/components/Approve.tsx
+++ b/src/features/defi/providers/fox-eth-lp/components/FoxEthLpManager/Deposit/components/Approve.tsx
@@ -41,7 +41,7 @@ const moduleLogger = logger.child({ namespace: ['FoxEthLpDeposit:Approve'] })
 
 export const Approve: React.FC<FoxEthLpApproveProps> = ({ accountId, onNext }) => {
   const { state, dispatch } = useContext(DepositContext)
-  const estimatedGasCrypto = state?.approve.estimatedGasCrypto
+  const estimatedGasCryptoPrecision = state?.approve.estimatedGasCryptoPrecision
   const translate = useTranslate()
   const mixpanel = getMixPanel()
   const { lpAccountId } = useFoxEth()
@@ -144,6 +144,7 @@ export const Approve: React.FC<FoxEthLpApproveProps> = ({ accountId, onNext }) =
     translate,
   ])
 
+<<<<<<< HEAD
   const hasEnoughBalanceForGas = useMemo(
     () =>
       isSome(estimatedGasCrypto) &&
@@ -155,6 +156,19 @@ export const Approve: React.FC<FoxEthLpApproveProps> = ({ accountId, onNext }) =
       }),
     [estimatedGasCrypto, accountId, feeAsset],
   )
+=======
+  useEffect(() => {
+    setHasEnoughBalanceForGas(
+      isSome(estimatedGasCryptoPrecision) &&
+        isSome(accountId) &&
+        canCoverTxFees({
+          feeAsset,
+          estimatedGasCryptoPrecision,
+          accountId,
+        }),
+    )
+  }, [accountId, estimatedGasCryptoPrecision, feeAsset])
+>>>>>>> 7ef53945d (feat: bring the crypto precision vernacular all across the gas estimation domain)
 
   const preFooter = useMemo(
     () => (
@@ -162,10 +176,10 @@ export const Approve: React.FC<FoxEthLpApproveProps> = ({ accountId, onNext }) =
         accountId={accountId}
         action={DefiAction.Deposit}
         feeAsset={feeAsset}
-        estimatedGasCrypto={estimatedGasCrypto}
+        estimatedGasCrypto={estimatedGasCryptoPrecision}
       />
     ),
-    [accountId, feeAsset, estimatedGasCrypto],
+    [accountId, feeAsset, estimatedGasCryptoPrecision],
   )
 
   useEffect(() => {
@@ -176,13 +190,17 @@ export const Approve: React.FC<FoxEthLpApproveProps> = ({ accountId, onNext }) =
 
   if (!state || !dispatch) return null
 
+  console.log({ accountId, hasEnoughBalanceForGas })
+
   return (
     <ReusableApprove
       asset={foxAsset}
       feeAsset={feeAsset}
-      cryptoEstimatedGasFee={bnOrZero(estimatedGasCrypto).toFixed(5)}
+      cryptoEstimatedGasFee={bnOrZero(estimatedGasCryptoPrecision).toFixed(5)}
       disabled={!hasEnoughBalanceForGas}
-      fiatEstimatedGasFee={bnOrZero(estimatedGasCrypto).times(feeMarketData.price).toFixed(2)}
+      fiatEstimatedGasFee={bnOrZero(estimatedGasCryptoPrecision)
+        .times(feeMarketData.price)
+        .toFixed(2)}
       loading={state.loading}
       loadingText={translate('common.approveOnWallet')}
       preFooter={preFooter}

--- a/src/features/defi/providers/fox-eth-lp/components/FoxEthLpManager/Deposit/components/Approve.tsx
+++ b/src/features/defi/providers/fox-eth-lp/components/FoxEthLpManager/Deposit/components/Approve.tsx
@@ -190,8 +190,6 @@ export const Approve: React.FC<FoxEthLpApproveProps> = ({ accountId, onNext }) =
 
   if (!state || !dispatch) return null
 
-  console.log({ accountId, hasEnoughBalanceForGas })
-
   return (
     <ReusableApprove
       asset={foxAsset}

--- a/src/features/defi/providers/fox-eth-lp/components/FoxEthLpManager/Deposit/components/Approve.tsx
+++ b/src/features/defi/providers/fox-eth-lp/components/FoxEthLpManager/Deposit/components/Approve.tsx
@@ -144,31 +144,17 @@ export const Approve: React.FC<FoxEthLpApproveProps> = ({ accountId, onNext }) =
     translate,
   ])
 
-<<<<<<< HEAD
   const hasEnoughBalanceForGas = useMemo(
     () =>
-      isSome(estimatedGasCrypto) &&
+      isSome(estimatedGasCryptoPrecision) &&
       isSome(accountId) &&
       canCoverTxFees({
         feeAsset,
-        estimatedGasCrypto,
+        estimatedGasCryptoPrecision,
         accountId,
       }),
-    [estimatedGasCrypto, accountId, feeAsset],
+    [estimatedGasCryptoPrecision, accountId, feeAsset],
   )
-=======
-  useEffect(() => {
-    setHasEnoughBalanceForGas(
-      isSome(estimatedGasCryptoPrecision) &&
-        isSome(accountId) &&
-        canCoverTxFees({
-          feeAsset,
-          estimatedGasCryptoPrecision,
-          accountId,
-        }),
-    )
-  }, [accountId, estimatedGasCryptoPrecision, feeAsset])
->>>>>>> 7ef53945d (feat: bring the crypto precision vernacular all across the gas estimation domain)
 
   const preFooter = useMemo(
     () => (

--- a/src/features/defi/providers/fox-eth-lp/components/FoxEthLpManager/Deposit/components/Approve.tsx
+++ b/src/features/defi/providers/fox-eth-lp/components/FoxEthLpManager/Deposit/components/Approve.tsx
@@ -45,7 +45,11 @@ export const Approve: React.FC<FoxEthLpApproveProps> = ({ accountId, onNext }) =
   const translate = useTranslate()
   const mixpanel = getMixPanel()
   const { lpAccountId } = useFoxEth()
-  const { approve, allowance, getDepositGasData } = useFoxEthLiquidityPool(lpAccountId)
+  const {
+    approve,
+    allowance,
+    getDepositGasDataCryptoBaseUnit: getDepositGasData,
+  } = useFoxEthLiquidityPool(lpAccountId)
 
   const foxEthLpOpportunityFilter = useMemo(
     () => ({

--- a/src/features/defi/providers/fox-eth-lp/components/FoxEthLpManager/Deposit/components/Approve.tsx
+++ b/src/features/defi/providers/fox-eth-lp/components/FoxEthLpManager/Deposit/components/Approve.tsx
@@ -162,7 +162,7 @@ export const Approve: React.FC<FoxEthLpApproveProps> = ({ accountId, onNext }) =
         accountId={accountId}
         action={DefiAction.Deposit}
         feeAsset={feeAsset}
-        estimatedGasCrypto={estimatedGasCryptoPrecision}
+        estimatedGasCryptoPrecision={estimatedGasCryptoPrecision}
       />
     ),
     [accountId, feeAsset, estimatedGasCryptoPrecision],

--- a/src/features/defi/providers/fox-eth-lp/components/FoxEthLpManager/Deposit/components/Approve.tsx
+++ b/src/features/defi/providers/fox-eth-lp/components/FoxEthLpManager/Deposit/components/Approve.tsx
@@ -45,11 +45,8 @@ export const Approve: React.FC<FoxEthLpApproveProps> = ({ accountId, onNext }) =
   const translate = useTranslate()
   const mixpanel = getMixPanel()
   const { lpAccountId } = useFoxEth()
-  const {
-    approve,
-    allowance,
-    getDepositGasDataCryptoBaseUnit: getDepositGasData,
-  } = useFoxEthLiquidityPool(lpAccountId)
+  const { approve, allowance, getDepositGasDataCryptoBaseUnit } =
+    useFoxEthLiquidityPool(lpAccountId)
 
   const foxEthLpOpportunityFilter = useMemo(
     () => ({
@@ -95,7 +92,7 @@ export const Approve: React.FC<FoxEthLpApproveProps> = ({ accountId, onNext }) =
         maxAttempts: 30,
       })
       // Get deposit gas estimate
-      const gasData = await getDepositGasData({
+      const gasData = await getDepositGasDataCryptoBaseUnit({
         token0Amount: state.deposit.ethCryptoAmount,
         token1Amount: state.deposit.foxCryptoAmount,
       })
@@ -138,7 +135,7 @@ export const Approve: React.FC<FoxEthLpApproveProps> = ({ accountId, onNext }) =
     foxEthLpOpportunity,
     wallet,
     approve,
-    getDepositGasData,
+    getDepositGasDataCryptoBaseUnit,
     feeAsset.precision,
     onNext,
     foxAsset,

--- a/src/features/defi/providers/fox-eth-lp/components/FoxEthLpManager/Deposit/components/Confirm.tsx
+++ b/src/features/defi/providers/fox-eth-lp/components/FoxEthLpManager/Deposit/components/Confirm.tsx
@@ -87,12 +87,12 @@ export const Confirm: React.FC<ConfirmProps> = ({ accountId, onNext }) => {
     () => ({ assetId: feeAsset?.assetId, accountId: accountId ?? '' }),
     [accountId, feeAsset?.assetId],
   )
-  const feeAssetBalance = useAppSelector(s =>
+  const feeAssetBalanceCryptoHuman = useAppSelector(s =>
     selectPortfolioCryptoHumanBalanceByFilter(s, feeAssetBalanceFilter),
   )
 
-  const hasEnoughBalanceForGas = bnOrZero(feeAssetBalance)
-    .minus(bnOrZero(state?.deposit.estimatedGasCrypto))
+  const hasEnoughBalanceForGas = bnOrZero(feeAssetBalanceCryptoHuman)
+    .minus(bnOrZero(state?.deposit.estimatedGasCryptoPrecision))
     .minus(bnOrZero(state?.deposit.ethCryptoAmount))
     .gte(0)
 
@@ -192,13 +192,13 @@ export const Confirm: React.FC<ConfirmProps> = ({ accountId, onNext }) => {
             <Box textAlign='right'>
               <Amount.Fiat
                 fontWeight='bold'
-                value={bnOrZero(state.deposit.estimatedGasCrypto)
+                value={bnOrZero(state.deposit.estimatedGasCryptoPrecision)
                   .times(feeMarketData.price)
                   .toFixed(2)}
               />
               <Amount.Crypto
                 color='gray.500'
-                value={bnOrZero(state.deposit.estimatedGasCrypto).toFixed(5)}
+                value={bnOrZero(state.deposit.estimatedGasCryptoPrecision).toFixed(5)}
                 symbol={feeAsset.symbol}
               />
             </Box>

--- a/src/features/defi/providers/fox-eth-lp/components/FoxEthLpManager/Deposit/components/Deposit.tsx
+++ b/src/features/defi/providers/fox-eth-lp/components/FoxEthLpManager/Deposit/components/Deposit.tsx
@@ -63,11 +63,8 @@ export const Deposit: React.FC<DepositProps> = ({
     selectEarnUserLpOpportunity(state, foxEthLpOpportunityFilter),
   )
   const { lpAccountId } = useFoxEth()
-  const {
-    allowance,
-    getApproveGasData,
-    getDepositGasDataCryptoBaseUnit: getDepositGasData,
-  } = useFoxEthLiquidityPool(lpAccountId)
+  const { allowance, getApproveGasData, getDepositGasDataCryptoBaseUnit } =
+    useFoxEthLiquidityPool(lpAccountId)
 
   const assetNamespace = 'erc20'
   const assetId = toAssetId({ chainId, assetNamespace, assetReference })
@@ -106,7 +103,7 @@ export const Deposit: React.FC<DepositProps> = ({
   ): Promise<string | undefined> => {
     const { cryptoAmount0: token0Amount, cryptoAmount1: token1Amount } = deposit
     try {
-      const gasData = await getDepositGasData({
+      const gasData = await getDepositGasDataCryptoBaseUnit({
         token0Amount,
         token1Amount,
       })
@@ -163,7 +160,7 @@ export const Deposit: React.FC<DepositProps> = ({
         if (!estimatedGasCryptoPrecision) return
         dispatch({
           type: FoxEthLpDepositActionType.SET_DEPOSIT,
-          payload: { estimatedGasCrypto: estimatedGasCryptoPrecision },
+          payload: { estimatedGasCryptoPrecision },
         })
         onNext(DefiStep.Confirm)
         dispatch({ type: FoxEthLpDepositActionType.SET_LOADING, payload: false })

--- a/src/features/defi/providers/fox-eth-lp/components/FoxEthLpManager/Deposit/components/Deposit.tsx
+++ b/src/features/defi/providers/fox-eth-lp/components/FoxEthLpManager/Deposit/components/Deposit.tsx
@@ -97,7 +97,9 @@ export const Deposit: React.FC<DepositProps> = ({
 
   if (!state || !dispatch) return null
 
-  const getDepositGasEstimate = async (deposit: DepositValues): Promise<string | undefined> => {
+  const getDepositGasEstimateCryptoPrecision = async (
+    deposit: DepositValues,
+  ): Promise<string | undefined> => {
     const { cryptoAmount0: token0Amount, cryptoAmount1: token1Amount } = deposit
     try {
       const gasData = await getDepositGasData({
@@ -108,7 +110,7 @@ export const Deposit: React.FC<DepositProps> = ({
       return bnOrZero(gasData.average.txFee).div(bn(10).pow(ethAsset.precision)).toPrecision()
     } catch (error) {
       moduleLogger.error(
-        { fn: 'getDepositGasEstimate', error },
+        { fn: 'getDepositGasEstimateCryptoPrecision', error },
         'Error getting deposit gas estimate',
       )
       toast({
@@ -153,11 +155,11 @@ export const Deposit: React.FC<DepositProps> = ({
 
       // Skip approval step if user allowance is greater than or equal requested deposit amount
       if (allowanceAmount.gte(bnOrZero(formValues.cryptoAmount1))) {
-        const estimatedGasCrypto = await getDepositGasEstimate(formValues)
-        if (!estimatedGasCrypto) return
+        const estimatedGasCryptoPrecision = await getDepositGasEstimateCryptoPrecision(formValues)
+        if (!estimatedGasCryptoPrecision) return
         dispatch({
           type: FoxEthLpDepositActionType.SET_DEPOSIT,
-          payload: { estimatedGasCrypto },
+          payload: { estimatedGasCrypto: estimatedGasCryptoPrecision },
         })
         onNext(DefiStep.Confirm)
         dispatch({ type: FoxEthLpDepositActionType.SET_LOADING, payload: false })
@@ -167,7 +169,7 @@ export const Deposit: React.FC<DepositProps> = ({
         dispatch({
           type: FoxEthLpDepositActionType.SET_APPROVE,
           payload: {
-            estimatedGasCrypto: bnOrZero(estimatedGasCrypto.average.txFee)
+            estimatedGasCryptoPrecision: bnOrZero(estimatedGasCrypto.average.txFee)
               .div(bn(10).pow(ethAsset.precision))
               .toPrecision(),
           },

--- a/src/features/defi/providers/fox-eth-lp/components/FoxEthLpManager/Deposit/components/Deposit.tsx
+++ b/src/features/defi/providers/fox-eth-lp/components/FoxEthLpManager/Deposit/components/Deposit.tsx
@@ -63,7 +63,11 @@ export const Deposit: React.FC<DepositProps> = ({
     selectEarnUserLpOpportunity(state, foxEthLpOpportunityFilter),
   )
   const { lpAccountId } = useFoxEth()
-  const { allowance, getApproveGasData, getDepositGasData } = useFoxEthLiquidityPool(lpAccountId)
+  const {
+    allowance,
+    getApproveGasData,
+    getDepositGasDataCryptoBaseUnit: getDepositGasData,
+  } = useFoxEthLiquidityPool(lpAccountId)
 
   const assetNamespace = 'erc20'
   const assetId = toAssetId({ chainId, assetNamespace, assetReference })

--- a/src/features/defi/providers/fox-eth-lp/components/FoxEthLpManager/Deposit/components/Status.tsx
+++ b/src/features/defi/providers/fox-eth-lp/components/FoxEthLpManager/Deposit/components/Status.tsx
@@ -89,7 +89,7 @@ export const Status: React.FC<StatusProps> = ({ accountId }) => {
         type: FoxEthLpDepositActionType.SET_DEPOSIT,
         payload: {
           txStatus: confirmedTransaction.status === 'Confirmed' ? 'success' : 'failed',
-          usedGasFee: confirmedTransaction.fee
+          usedGasFeeCryptoPrecision: confirmedTransaction.fee
             ? bnOrZero(confirmedTransaction.fee.value)
                 .div(bn(10).pow(ethAsset.precision))
                 .toString()

--- a/src/features/defi/providers/fox-eth-lp/components/FoxEthLpManager/Deposit/components/Status.tsx
+++ b/src/features/defi/providers/fox-eth-lp/components/FoxEthLpManager/Deposit/components/Status.tsx
@@ -211,7 +211,7 @@ export const Status: React.FC<StatusProps> = ({ accountId }) => {
                 fontWeight='bold'
                 value={bnOrZero(
                   state.deposit.txStatus === 'pending'
-                    ? state.deposit.estimatedGasCrypto
+                    ? state.deposit.estimatedGasCryptoPrecision
                     : state.deposit.usedGasFee,
                 )
                   .times(feeMarketData.price)
@@ -221,7 +221,7 @@ export const Status: React.FC<StatusProps> = ({ accountId }) => {
                 color='gray.500'
                 value={bnOrZero(
                   state.deposit.txStatus === 'pending'
-                    ? state.deposit.estimatedGasCrypto
+                    ? state.deposit.estimatedGasCryptoPrecision
                     : state.deposit.usedGasFee,
                 ).toFixed(5)}
                 symbol='ETH'

--- a/src/features/defi/providers/fox-eth-lp/components/FoxEthLpManager/Deposit/components/Status.tsx
+++ b/src/features/defi/providers/fox-eth-lp/components/FoxEthLpManager/Deposit/components/Status.tsx
@@ -22,7 +22,7 @@ import { StatusTextEnum } from 'components/RouteSteps/RouteSteps'
 import { Row } from 'components/Row/Row'
 import { RawText, Text } from 'components/Text'
 import { useBrowserRouter } from 'hooks/useBrowserRouter/useBrowserRouter'
-import { bnOrZero } from 'lib/bignumber/bignumber'
+import { bn, bnOrZero } from 'lib/bignumber/bignumber'
 import { trackOpportunityEvent } from 'lib/mixpanel/helpers'
 import { MixPanelEvents } from 'lib/mixpanel/types'
 import { foxEthLpAssetId } from 'state/slices/opportunitiesSlice/constants'
@@ -90,7 +90,9 @@ export const Status: React.FC<StatusProps> = ({ accountId }) => {
         payload: {
           txStatus: confirmedTransaction.status === 'Confirmed' ? 'success' : 'failed',
           usedGasFee: confirmedTransaction.fee
-            ? bnOrZero(confirmedTransaction.fee.value).div(`1e${ethAsset.precision}`).toString()
+            ? bnOrZero(confirmedTransaction.fee.value)
+                .div(bn(10).pow(ethAsset.precision))
+                .toString()
             : '0',
         },
       })
@@ -212,7 +214,7 @@ export const Status: React.FC<StatusProps> = ({ accountId }) => {
                 value={bnOrZero(
                   state.deposit.txStatus === 'pending'
                     ? state.deposit.estimatedGasCryptoPrecision
-                    : state.deposit.usedGasFee,
+                    : state.deposit.usedGasFeeCryptoPrecision,
                 )
                   .times(feeMarketData.price)
                   .toFixed(2)}
@@ -222,7 +224,7 @@ export const Status: React.FC<StatusProps> = ({ accountId }) => {
                 value={bnOrZero(
                   state.deposit.txStatus === 'pending'
                     ? state.deposit.estimatedGasCryptoPrecision
-                    : state.deposit.usedGasFee,
+                    : state.deposit.usedGasFeeCryptoPrecision,
                 ).toFixed(5)}
                 symbol='ETH'
               />

--- a/src/features/defi/providers/fox-eth-lp/components/FoxEthLpManager/Deposit/components/Status.tsx
+++ b/src/features/defi/providers/fox-eth-lp/components/FoxEthLpManager/Deposit/components/Status.tsx
@@ -71,9 +71,11 @@ export const Status: React.FC<StatusProps> = ({ accountId }) => {
   })
   const foxAsset = useAppSelector(state => selectAssetById(state, foxAssetId))
   const ethAsset = useAppSelector(state => selectAssetById(state, ethAssetId))
+  const feeAsset = useAppSelector(state => selectAssetById(state, feeAssetId))
   const assets = useAppSelector(selectAssets)
   if (!foxAsset) throw new Error(`Asset not found for AssetId ${foxAssetId}`)
   if (!ethAsset) throw new Error(`Asset not found for AssetId ${ethAssetId}`)
+  if (!feeAsset) throw new Error(`Asset not found for AssetId ${feeAssetId}`)
 
   const feeMarketData = useAppSelector(state => selectMarketDataById(state, feeAssetId))
 
@@ -91,13 +93,13 @@ export const Status: React.FC<StatusProps> = ({ accountId }) => {
           txStatus: confirmedTransaction.status === 'Confirmed' ? 'success' : 'failed',
           usedGasFeeCryptoPrecision: confirmedTransaction.fee
             ? bnOrZero(confirmedTransaction.fee.value)
-                .div(bn(10).pow(ethAsset.precision))
+                .div(bn(10).pow(feeAsset?.precision))
                 .toString()
             : '0',
         },
       })
     }
-  }, [confirmedTransaction, dispatch, ethAsset.precision])
+  }, [confirmedTransaction, dispatch, feeAsset.precision])
 
   const handleViewPosition = () => {
     browserHistory.push('/defi')

--- a/src/features/defi/providers/fox-eth-lp/components/FoxEthLpManager/Withdraw/WithdrawCommon.ts
+++ b/src/features/defi/providers/fox-eth-lp/components/FoxEthLpManager/Withdraw/WithdrawCommon.ts
@@ -1,5 +1,5 @@
 type EstimatedGas = {
-  estimatedGasCrypto?: string
+  estimatedGasCryptoPrecision?: string
 }
 
 type WithdrawValues = {

--- a/src/features/defi/providers/fox-eth-lp/components/FoxEthLpManager/Withdraw/WithdrawCommon.ts
+++ b/src/features/defi/providers/fox-eth-lp/components/FoxEthLpManager/Withdraw/WithdrawCommon.ts
@@ -12,7 +12,7 @@ type WithdrawValues = {
 type FoxEthLpWithdrawValues = WithdrawValues &
   EstimatedGas & {
     txStatus: string
-    usedGasFee: string
+    usedGasFeeCryptoPrecision: string
   }
 
 export type FoxEthLpWithdrawState = {

--- a/src/features/defi/providers/fox-eth-lp/components/FoxEthLpManager/Withdraw/WithdrawReducer.ts
+++ b/src/features/defi/providers/fox-eth-lp/components/FoxEthLpManager/Withdraw/WithdrawReducer.ts
@@ -11,7 +11,7 @@ export const initialState: FoxEthLpWithdrawState = {
     foxAmount: '',
     ethAmount: '',
     txStatus: 'pending',
-    usedGasFee: '',
+    usedGasFeeCryptoPrecision: '',
   },
 }
 

--- a/src/features/defi/providers/fox-eth-lp/components/FoxEthLpManager/Withdraw/components/Approve.tsx
+++ b/src/features/defi/providers/fox-eth-lp/components/FoxEthLpManager/Withdraw/components/Approve.tsx
@@ -160,7 +160,7 @@ export const Approve: React.FC<FoxEthLpApproveProps> = ({ accountId, onNext }) =
         accountId={accountId}
         action={DefiAction.Withdraw}
         feeAsset={feeAsset}
-        estimatedGasCrypto={estimatedGasCryptoPrecision}
+        estimatedGasCryptoPrecision={estimatedGasCryptoPrecision}
       />
     ),
     [accountId, feeAsset, estimatedGasCryptoPrecision],

--- a/src/features/defi/providers/fox-eth-lp/components/FoxEthLpManager/Withdraw/components/Approve.tsx
+++ b/src/features/defi/providers/fox-eth-lp/components/FoxEthLpManager/Withdraw/components/Approve.tsx
@@ -97,12 +97,12 @@ export const Approve: React.FC<FoxEthLpApproveProps> = ({ accountId, onNext }) =
         state.withdraw.ethAmount,
       )
       if (!gasData) return
-      const estimatedGasCrypto = bnOrZero(gasData.average.txFee)
+      const estimatedGasCryptoPrecision = bnOrZero(gasData.average.txFee)
         .div(bn(10).pow(feeAsset.precision))
         .toPrecision()
       dispatch({
         type: FoxEthLpWithdrawActionType.SET_WITHDRAW,
-        payload: { estimatedGasCryptoPrecision: estimatedGasCrypto },
+        payload: { estimatedGasCryptoPrecision },
       })
 
       onNext(DefiStep.Confirm)

--- a/src/features/defi/providers/fox-eth-lp/components/FoxEthLpManager/Withdraw/components/Approve.tsx
+++ b/src/features/defi/providers/fox-eth-lp/components/FoxEthLpManager/Withdraw/components/Approve.tsx
@@ -40,7 +40,7 @@ const moduleLogger = logger.child({ namespace: ['FoxEthLpWithdraw:Approve'] })
 
 export const Approve: React.FC<FoxEthLpApproveProps> = ({ accountId, onNext }) => {
   const { state, dispatch } = useContext(WithdrawContext)
-  const estimatedGasCrypto = state?.approve.estimatedGasCrypto
+  const estimatedGasCryptoPrecision = state?.approve.estimatedGasCryptoPrecision
   const translate = useTranslate()
   const mixpanel = getMixPanel()
   const { lpAccountId } = useFoxEth()
@@ -102,7 +102,7 @@ export const Approve: React.FC<FoxEthLpApproveProps> = ({ accountId, onNext }) =
         .toPrecision()
       dispatch({
         type: FoxEthLpWithdrawActionType.SET_WITHDRAW,
-        payload: { estimatedGasCrypto },
+        payload: { estimatedGasCryptoPrecision: estimatedGasCrypto },
       })
 
       onNext(DefiStep.Confirm)
@@ -144,14 +144,14 @@ export const Approve: React.FC<FoxEthLpApproveProps> = ({ accountId, onNext }) =
 
   const hasEnoughBalanceForGas = useMemo(
     () =>
-      isSome(estimatedGasCrypto) &&
+      isSome(estimatedGasCryptoPrecision) &&
       isSome(accountId) &&
       canCoverTxFees({
         feeAsset,
-        estimatedGasCrypto,
+        estimatedGasCryptoPrecision,
         accountId,
       }),
-    [accountId, feeAsset, estimatedGasCrypto],
+    [accountId, feeAsset, estimatedGasCryptoPrecision],
   )
 
   const preFooter = useMemo(
@@ -160,10 +160,10 @@ export const Approve: React.FC<FoxEthLpApproveProps> = ({ accountId, onNext }) =
         accountId={accountId}
         action={DefiAction.Withdraw}
         feeAsset={feeAsset}
-        estimatedGasCrypto={estimatedGasCrypto}
+        estimatedGasCrypto={estimatedGasCryptoPrecision}
       />
     ),
-    [accountId, feeAsset, estimatedGasCrypto],
+    [accountId, feeAsset, estimatedGasCryptoPrecision],
   )
 
   useEffect(() => {
@@ -178,9 +178,11 @@ export const Approve: React.FC<FoxEthLpApproveProps> = ({ accountId, onNext }) =
     <ReusableApprove
       asset={foxAsset}
       feeAsset={feeAsset}
-      cryptoEstimatedGasFee={bnOrZero(estimatedGasCrypto).toFixed(5)}
+      cryptoEstimatedGasFee={bnOrZero(estimatedGasCryptoPrecision).toFixed(5)}
       disabled={!hasEnoughBalanceForGas}
-      fiatEstimatedGasFee={bnOrZero(estimatedGasCrypto).times(feeMarketData.price).toFixed(2)}
+      fiatEstimatedGasFee={bnOrZero(estimatedGasCryptoPrecision)
+        .times(feeMarketData.price)
+        .toFixed(2)}
       loading={state.loading}
       loadingText={translate('common.approveOnWallet')}
       preFooter={preFooter}

--- a/src/features/defi/providers/fox-eth-lp/components/FoxEthLpManager/Withdraw/components/Approve.tsx
+++ b/src/features/defi/providers/fox-eth-lp/components/FoxEthLpManager/Withdraw/components/Approve.tsx
@@ -178,7 +178,7 @@ export const Approve: React.FC<FoxEthLpApproveProps> = ({ accountId, onNext }) =
     <ReusableApprove
       asset={foxAsset}
       feeAsset={feeAsset}
-      cryptoEstimatedGasFee={bnOrZero(estimatedGasCryptoPrecision).toFixed(5)}
+      estimatedGasFeeCryptoPrecision={bnOrZero(estimatedGasCryptoPrecision).toFixed(5)}
       disabled={!hasEnoughBalanceForGas}
       fiatEstimatedGasFee={bnOrZero(estimatedGasCryptoPrecision)
         .times(feeMarketData.price)

--- a/src/features/defi/providers/fox-eth-lp/components/FoxEthLpManager/Withdraw/components/Confirm.tsx
+++ b/src/features/defi/providers/fox-eth-lp/components/FoxEthLpManager/Withdraw/components/Confirm.tsx
@@ -77,13 +77,16 @@ export const Confirm = ({ accountId, onNext }: ConfirmProps) => {
     () => ({ assetId: ethAssetId, accountId: accountId ?? '' }),
     [accountId],
   )
-  const feeAssetBalance = useAppSelector(s =>
+  const feeAssetBalanceCryptoHuman = useAppSelector(s =>
     selectPortfolioCryptoHumanBalanceByFilter(s, feeAssetBalanceFilter),
   )
 
   const hasEnoughBalanceForGas = useMemo(
-    () => bnOrZero(feeAssetBalance).minus(bnOrZero(state?.withdraw.estimatedGasCrypto)).gte(0),
-    [feeAssetBalance, state?.withdraw.estimatedGasCrypto],
+    () =>
+      bnOrZero(feeAssetBalanceCryptoHuman)
+        .minus(bnOrZero(state?.withdraw.estimatedGasCryptoPrecision))
+        .gte(0),
+    [feeAssetBalanceCryptoHuman, state?.withdraw.estimatedGasCryptoPrecision],
   )
 
   useEffect(() => {
@@ -212,13 +215,13 @@ export const Confirm = ({ accountId, onNext }: ConfirmProps) => {
             <Box textAlign='right'>
               <Amount.Fiat
                 fontWeight='bold'
-                value={bnOrZero(state.withdraw.estimatedGasCrypto)
+                value={bnOrZero(state.withdraw.estimatedGasCryptoPrecision)
                   .times(ethMarketData.price)
                   .toFixed(2)}
               />
               <Amount.Crypto
                 color='gray.500'
-                value={bnOrZero(state.withdraw.estimatedGasCrypto).toFixed(5)}
+                value={bnOrZero(state.withdraw.estimatedGasCryptoPrecision).toFixed(5)}
                 symbol={ethAsset.symbol}
               />
             </Box>

--- a/src/features/defi/providers/fox-eth-lp/components/FoxEthLpManager/Withdraw/components/Status.tsx
+++ b/src/features/defi/providers/fox-eth-lp/components/FoxEthLpManager/Withdraw/components/Status.tsx
@@ -17,7 +17,7 @@ import { StatusTextEnum } from 'components/RouteSteps/RouteSteps'
 import { Row } from 'components/Row/Row'
 import { RawText, Text } from 'components/Text'
 import { useBrowserRouter } from 'hooks/useBrowserRouter/useBrowserRouter'
-import { bnOrZero } from 'lib/bignumber/bignumber'
+import { bn, bnOrZero } from 'lib/bignumber/bignumber'
 import { trackOpportunityEvent } from 'lib/mixpanel/helpers'
 import { MixPanelEvents } from 'lib/mixpanel/types'
 import { foxEthLpAssetId } from 'state/slices/opportunitiesSlice/constants'
@@ -82,7 +82,9 @@ export const Status: React.FC<StatusProps> = ({ accountId }) => {
         payload: {
           txStatus: confirmedTransaction.status === 'Confirmed' ? 'success' : 'failed',
           usedGasFeeCryptoPrecision: confirmedTransaction.fee
-            ? bnOrZero(confirmedTransaction.fee.value).div(`1e${ethAsset.precision}`).toString()
+            ? bnOrZero(confirmedTransaction.fee.value)
+                .div(bn(10).pow(ethAsset.precision))
+                .toString()
             : '0',
         },
       })

--- a/src/features/defi/providers/fox-eth-lp/components/FoxEthLpManager/Withdraw/components/Status.tsx
+++ b/src/features/defi/providers/fox-eth-lp/components/FoxEthLpManager/Withdraw/components/Status.tsx
@@ -81,7 +81,7 @@ export const Status: React.FC<StatusProps> = ({ accountId }) => {
         type: FoxEthLpWithdrawActionType.SET_WITHDRAW,
         payload: {
           txStatus: confirmedTransaction.status === 'Confirmed' ? 'success' : 'failed',
-          usedGasFee: confirmedTransaction.fee
+          usedGasFeeCryptoPrecision: confirmedTransaction.fee
             ? bnOrZero(confirmedTransaction.fee.value).div(`1e${ethAsset.precision}`).toString()
             : '0',
         },
@@ -228,7 +228,7 @@ export const Status: React.FC<StatusProps> = ({ accountId }) => {
                 value={bnOrZero(
                   state.withdraw.txStatus === 'pending'
                     ? state.withdraw.estimatedGasCryptoPrecision
-                    : state.withdraw.usedGasFee,
+                    : state.withdraw.usedGasFeeCryptoPrecision,
                 )
                   .times(ethMarketData.price)
                   .toFixed(2)}
@@ -238,7 +238,7 @@ export const Status: React.FC<StatusProps> = ({ accountId }) => {
                 value={bnOrZero(
                   state.withdraw.txStatus === 'pending'
                     ? state.withdraw.estimatedGasCryptoPrecision
-                    : state.withdraw.usedGasFee,
+                    : state.withdraw.usedGasFeeCryptoPrecision,
                 ).toFixed(5)}
                 symbol='ETH'
               />

--- a/src/features/defi/providers/fox-eth-lp/components/FoxEthLpManager/Withdraw/components/Status.tsx
+++ b/src/features/defi/providers/fox-eth-lp/components/FoxEthLpManager/Withdraw/components/Status.tsx
@@ -227,7 +227,7 @@ export const Status: React.FC<StatusProps> = ({ accountId }) => {
                 fontWeight='bold'
                 value={bnOrZero(
                   state.withdraw.txStatus === 'pending'
-                    ? state.withdraw.estimatedGasCrypto
+                    ? state.withdraw.estimatedGasCryptoPrecision
                     : state.withdraw.usedGasFee,
                 )
                   .times(ethMarketData.price)
@@ -237,7 +237,7 @@ export const Status: React.FC<StatusProps> = ({ accountId }) => {
                 color='gray.500'
                 value={bnOrZero(
                   state.withdraw.txStatus === 'pending'
-                    ? state.withdraw.estimatedGasCrypto
+                    ? state.withdraw.estimatedGasCryptoPrecision
                     : state.withdraw.usedGasFee,
                 ).toFixed(5)}
                 symbol='ETH'

--- a/src/features/defi/providers/fox-eth-lp/components/FoxEthLpManager/Withdraw/components/Withdraw.tsx
+++ b/src/features/defi/providers/fox-eth-lp/components/FoxEthLpManager/Withdraw/components/Withdraw.tsx
@@ -155,24 +155,25 @@ export const Withdraw: React.FC<WithdrawProps> = ({
 
     // Skip approval step if user allowance is greater than or equal requested deposit amount
     if (allowanceAmount.gte(bnOrZero(formValues.cryptoAmount))) {
-      const estimatedGasCrypto = await getWithdrawGasEstimateCryptoPrecision(formValues)
-      if (!estimatedGasCrypto) {
+      const estimatedGasCryptoPrecision = await getWithdrawGasEstimateCryptoPrecision(formValues)
+      if (!estimatedGasCryptoPrecision) {
         dispatch({ type: FoxEthLpWithdrawActionType.SET_LOADING, payload: false })
         return
       }
       dispatch({
         type: FoxEthLpWithdrawActionType.SET_WITHDRAW,
-        payload: { estimatedGasCryptoPrecision: estimatedGasCrypto },
+        payload: { estimatedGasCryptoPrecision },
       })
       onNext(DefiStep.Confirm)
       dispatch({ type: FoxEthLpWithdrawActionType.SET_LOADING, payload: false })
     } else {
-      const estimatedGasCrypto = await getApproveGasData(true)
-      if (!estimatedGasCrypto) return
+      const estimatedGasCryptoPrecision = await getApproveGasData(true)
+      debugger
+      if (!estimatedGasCryptoPrecision) return
       dispatch({
         type: FoxEthLpWithdrawActionType.SET_APPROVE,
         payload: {
-          estimatedGasCryptoPrecision: bnOrZero(estimatedGasCrypto.average.txFee)
+          estimatedGasCryptoPrecision: bnOrZero(estimatedGasCryptoPrecision.average.txFee)
             .div(bn(10).pow(ethAsset.precision))
             .toPrecision(),
         },

--- a/src/features/defi/providers/fox-eth-lp/components/FoxEthLpManager/Withdraw/components/Withdraw.tsx
+++ b/src/features/defi/providers/fox-eth-lp/components/FoxEthLpManager/Withdraw/components/Withdraw.tsx
@@ -168,7 +168,6 @@ export const Withdraw: React.FC<WithdrawProps> = ({
       dispatch({ type: FoxEthLpWithdrawActionType.SET_LOADING, payload: false })
     } else {
       const estimatedGasCryptoPrecision = await getApproveGasData(true)
-      debugger
       if (!estimatedGasCryptoPrecision) return
       dispatch({
         type: FoxEthLpWithdrawActionType.SET_APPROVE,

--- a/src/features/defi/providers/fox-eth-lp/components/FoxEthLpManager/Withdraw/components/Withdraw.tsx
+++ b/src/features/defi/providers/fox-eth-lp/components/FoxEthLpManager/Withdraw/components/Withdraw.tsx
@@ -108,7 +108,7 @@ export const Withdraw: React.FC<WithdrawProps> = ({
 
   if (!state || !dispatch || !foxEthLpOpportunity?.icons) return null
 
-  const getWithdrawGasEstimate = async (withdraw: WithdrawValues) => {
+  const getWithdrawGasEstimateCryptoPrecision = async (withdraw: WithdrawValues) => {
     try {
       const fee = await getWithdrawGasData(
         withdraw.cryptoAmount,
@@ -155,14 +155,14 @@ export const Withdraw: React.FC<WithdrawProps> = ({
 
     // Skip approval step if user allowance is greater than or equal requested deposit amount
     if (allowanceAmount.gte(bnOrZero(formValues.cryptoAmount))) {
-      const estimatedGasCrypto = await getWithdrawGasEstimate(formValues)
+      const estimatedGasCrypto = await getWithdrawGasEstimateCryptoPrecision(formValues)
       if (!estimatedGasCrypto) {
         dispatch({ type: FoxEthLpWithdrawActionType.SET_LOADING, payload: false })
         return
       }
       dispatch({
         type: FoxEthLpWithdrawActionType.SET_WITHDRAW,
-        payload: { estimatedGasCrypto },
+        payload: { estimatedGasCryptoPrecision: estimatedGasCrypto },
       })
       onNext(DefiStep.Confirm)
       dispatch({ type: FoxEthLpWithdrawActionType.SET_LOADING, payload: false })
@@ -172,7 +172,7 @@ export const Withdraw: React.FC<WithdrawProps> = ({
       dispatch({
         type: FoxEthLpWithdrawActionType.SET_APPROVE,
         payload: {
-          estimatedGasCrypto: bnOrZero(estimatedGasCrypto.average.txFee)
+          estimatedGasCryptoPrecision: bnOrZero(estimatedGasCrypto.average.txFee)
             .div(bn(10).pow(ethAsset.precision))
             .toPrecision(),
         },

--- a/src/features/defi/providers/fox-eth-lp/hooks/useFoxEthLiquidityPool.ts
+++ b/src/features/defi/providers/fox-eth-lp/hooks/useFoxEthLiquidityPool.ts
@@ -368,7 +368,7 @@ export const useFoxEthLiquidityPool = (
     [skip, uniV2LPContract, foxContract, adapter, accountId],
   )
 
-  const getDepositGasData = useCallback(
+  const getDepositGasDataCryptoBaseUnit = useCallback(
     async ({ token0Amount, token1Amount }: { token0Amount: string; token1Amount: string }) => {
       if (skip || !accountId || !uniswapRouterContract) return
       const value = bnOrZero(token0Amount)
@@ -490,7 +490,7 @@ export const useFoxEthLiquidityPool = (
     approve,
     calculateHoldings,
     getApproveGasData,
-    getDepositGasData,
+    getDepositGasDataCryptoBaseUnit,
     getLpTVL,
     getWithdrawGasData,
     removeLiquidity,

--- a/src/features/defi/providers/fox-farming/components/FoxFarmingManager/Claim/ClaimStatus.tsx
+++ b/src/features/defi/providers/fox-farming/components/FoxFarmingManager/Claim/ClaimStatus.tsx
@@ -35,7 +35,7 @@ interface ClaimStatusState {
   amount: string
   userAddress: string
   estimatedGas: string
-  usedGasFee?: string
+  usedGasFeeCryptoPrecision?: string
   status: string
   chainId: ChainId
   contractAddress: string
@@ -49,7 +49,7 @@ enum TxStatus {
 
 type ClaimState = {
   txStatus: TxStatus
-  usedGasFee?: string
+  usedGasFeeCryptoPrecision?: string
 }
 
 const StatusInfo = {
@@ -127,7 +127,7 @@ export const ClaimStatus: React.FC<ClaimStatusProps> = ({ accountId }) => {
     if (confirmedTransaction && confirmedTransaction.status !== 'Pending') {
       setState({
         txStatus: confirmedTransaction.status === 'Confirmed' ? TxStatus.SUCCESS : TxStatus.FAILED,
-        usedGasFee: confirmedTransaction.fee
+        usedGasFeeCryptoPrecision: confirmedTransaction.fee
           ? bnOrZero(confirmedTransaction.fee.value).div(`1e${feeAsset.precision}`).toString()
           : '0',
       })
@@ -219,7 +219,9 @@ export const ClaimStatus: React.FC<ClaimStatusProps> = ({ accountId }) => {
                 <Amount.Fiat
                   fontWeight='bold'
                   value={bnOrZero(
-                    state.txStatus === TxStatus.PENDING ? estimatedGas : state.usedGasFee,
+                    state.txStatus === TxStatus.PENDING
+                      ? estimatedGas
+                      : state.usedGasFeeCryptoPrecision,
                   )
                     .times(feeMarketData.price)
                     .toFixed(2)}
@@ -227,7 +229,9 @@ export const ClaimStatus: React.FC<ClaimStatusProps> = ({ accountId }) => {
                 <Amount.Crypto
                   color='gray.500'
                   value={bnOrZero(
-                    state.txStatus === TxStatus.PENDING ? estimatedGas : state.usedGasFee,
+                    state.txStatus === TxStatus.PENDING
+                      ? estimatedGas
+                      : state.usedGasFeeCryptoPrecision,
                   ).toFixed(5)}
                   symbol='ETH'
                 />

--- a/src/features/defi/providers/fox-farming/components/FoxFarmingManager/Deposit/DepositCommon.ts
+++ b/src/features/defi/providers/fox-farming/components/FoxFarmingManager/Deposit/DepositCommon.ts
@@ -1,5 +1,5 @@
 type EstimatedGas = {
-  estimatedGasCrypto?: string
+  estimatedGasCryptoPrecision?: string
 }
 
 type DepositValues = {

--- a/src/features/defi/providers/fox-farming/components/FoxFarmingManager/Deposit/DepositCommon.ts
+++ b/src/features/defi/providers/fox-farming/components/FoxFarmingManager/Deposit/DepositCommon.ts
@@ -10,7 +10,7 @@ type DepositValues = {
 type FoxFarmingDepositValues = DepositValues &
   EstimatedGas & {
     txStatus: string
-    usedGasFee: string
+    usedGasFeeCryptoPrecision: string
   }
 
 export type FoxFarmingDepositState = {

--- a/src/features/defi/providers/fox-farming/components/FoxFarmingManager/Deposit/DepositCommon.ts
+++ b/src/features/defi/providers/fox-farming/components/FoxFarmingManager/Deposit/DepositCommon.ts
@@ -34,7 +34,7 @@ type SetApprove = {
 
 type SetDeposit = {
   type: FoxFarmingDepositActionType.SET_DEPOSIT
-  payload: any
+  payload: Partial<FoxFarmingDepositValues>
 }
 
 type SetLoading = {

--- a/src/features/defi/providers/fox-farming/components/FoxFarmingManager/Deposit/DepositReducer.ts
+++ b/src/features/defi/providers/fox-farming/components/FoxFarmingManager/Deposit/DepositReducer.ts
@@ -9,7 +9,7 @@ export const initialState: FoxFarmingDepositState = {
     fiatAmount: '',
     cryptoAmount: '',
     txStatus: 'pending',
-    usedGasFee: '',
+    usedGasFeeCryptoPrecision: '',
   },
 }
 

--- a/src/features/defi/providers/fox-farming/components/FoxFarmingManager/Deposit/components/Approve.tsx
+++ b/src/features/defi/providers/fox-farming/components/FoxFarmingManager/Deposit/components/Approve.tsx
@@ -186,7 +186,7 @@ export const Approve: React.FC<FoxFarmingApproveProps> = ({ accountId, onNext })
       asset={asset}
       feeAsset={feeAsset}
       icons={foxFarmingOpportunity?.icons}
-      cryptoEstimatedGasFee={bnOrZero(state.approve.estimatedGasCrypto).toFixed(5)}
+      estimatedGasFeeCryptoPrecision={bnOrZero(state.approve.estimatedGasCrypto).toFixed(5)}
       disabled={!hasEnoughBalanceForGas}
       fiatEstimatedGasFee={bnOrZero(state.approve.estimatedGasCrypto)
         .times(feeMarketData.price)

--- a/src/features/defi/providers/fox-farming/components/FoxFarmingManager/Deposit/components/Approve.tsx
+++ b/src/features/defi/providers/fox-farming/components/FoxFarmingManager/Deposit/components/Approve.tsx
@@ -43,7 +43,7 @@ const moduleLogger = logger.child({ namespace: ['FoxFarmingDeposit:Approve'] })
 
 export const Approve: React.FC<FoxFarmingApproveProps> = ({ accountId, onNext }) => {
   const { state, dispatch } = useContext(DepositContext)
-  const estimatedGasCryptoPrecision = state?.approve.estimatedGasCrypto
+  const estimatedGasCryptoPrecision = state?.approve.estimatedGasCryptoPrecision
   const translate = useTranslate()
   const { query } = useBrowserRouter<DefiQueryParams, DefiParams>()
   const { assetNamespace, chainId, contractAddress } = query
@@ -116,7 +116,7 @@ export const Approve: React.FC<FoxFarmingApproveProps> = ({ accountId, onNext })
         .toPrecision()
       dispatch({
         type: FoxFarmingDepositActionType.SET_DEPOSIT,
-        payload: { estimatedGasCrypto },
+        payload: { estimatedGasCryptoPrecision: estimatedGasCrypto },
       })
 
       onNext(DefiStep.Confirm)
@@ -186,9 +186,11 @@ export const Approve: React.FC<FoxFarmingApproveProps> = ({ accountId, onNext })
       asset={asset}
       feeAsset={feeAsset}
       icons={foxFarmingOpportunity?.icons}
-      estimatedGasFeeCryptoPrecision={bnOrZero(state.approve.estimatedGasCrypto).toFixed(5)}
+      estimatedGasFeeCryptoPrecision={bnOrZero(state.approve.estimatedGasCryptoPrecision).toFixed(
+        5,
+      )}
       disabled={!hasEnoughBalanceForGas}
-      fiatEstimatedGasFee={bnOrZero(state.approve.estimatedGasCrypto)
+      fiatEstimatedGasFee={bnOrZero(state.approve.estimatedGasCryptoPrecision)
         .times(feeMarketData.price)
         .toFixed(2)}
       loading={state.loading}

--- a/src/features/defi/providers/fox-farming/components/FoxFarmingManager/Deposit/components/Approve.tsx
+++ b/src/features/defi/providers/fox-farming/components/FoxFarmingManager/Deposit/components/Approve.tsx
@@ -111,12 +111,12 @@ export const Approve: React.FC<FoxFarmingApproveProps> = ({ accountId, onNext })
       // Get deposit gas estimate
       const gasData = await getStakeGasData(state.deposit.cryptoAmount)
       if (!gasData) return
-      const estimatedGasCrypto = bnOrZero(gasData.average.txFee)
+      const estimatedGasCryptoPrecision = bnOrZero(gasData.average.txFee)
         .div(bn(10).pow(feeAsset.precision))
         .toPrecision()
       dispatch({
         type: FoxFarmingDepositActionType.SET_DEPOSIT,
-        payload: { estimatedGasCryptoPrecision: estimatedGasCrypto },
+        payload: { estimatedGasCryptoPrecision },
       })
 
       onNext(DefiStep.Confirm)

--- a/src/features/defi/providers/fox-farming/components/FoxFarmingManager/Deposit/components/Approve.tsx
+++ b/src/features/defi/providers/fox-farming/components/FoxFarmingManager/Deposit/components/Approve.tsx
@@ -174,7 +174,7 @@ export const Approve: React.FC<FoxFarmingApproveProps> = ({ accountId, onNext })
         accountId={accountId}
         action={DefiAction.Deposit}
         feeAsset={feeAsset}
-        estimatedGasCrypto={estimatedGasCryptoPrecision}
+        estimatedGasCryptoPrecision={estimatedGasCryptoPrecision}
       />
     ),
     [accountId, feeAsset, estimatedGasCryptoPrecision],

--- a/src/features/defi/providers/fox-farming/components/FoxFarmingManager/Deposit/components/Approve.tsx
+++ b/src/features/defi/providers/fox-farming/components/FoxFarmingManager/Deposit/components/Approve.tsx
@@ -43,7 +43,7 @@ const moduleLogger = logger.child({ namespace: ['FoxFarmingDeposit:Approve'] })
 
 export const Approve: React.FC<FoxFarmingApproveProps> = ({ accountId, onNext }) => {
   const { state, dispatch } = useContext(DepositContext)
-  const estimatedGasCrypto = state?.approve.estimatedGasCrypto
+  const estimatedGasCryptoPrecision = state?.approve.estimatedGasCrypto
   const translate = useTranslate()
   const { query } = useBrowserRouter<DefiQueryParams, DefiParams>()
   const { assetNamespace, chainId, contractAddress } = query
@@ -158,14 +158,14 @@ export const Approve: React.FC<FoxFarmingApproveProps> = ({ accountId, onNext })
 
   const hasEnoughBalanceForGas = useMemo(
     () =>
-      isSome(estimatedGasCrypto) &&
+      isSome(estimatedGasCryptoPrecision) &&
       isSome(accountId) &&
       canCoverTxFees({
         feeAsset,
-        estimatedGasCrypto,
+        estimatedGasCryptoPrecision,
         accountId,
       }),
-    [accountId, feeAsset, estimatedGasCrypto],
+    [accountId, feeAsset, estimatedGasCryptoPrecision],
   )
 
   const preFooter = useMemo(
@@ -174,10 +174,10 @@ export const Approve: React.FC<FoxFarmingApproveProps> = ({ accountId, onNext })
         accountId={accountId}
         action={DefiAction.Deposit}
         feeAsset={feeAsset}
-        estimatedGasCrypto={estimatedGasCrypto}
+        estimatedGasCrypto={estimatedGasCryptoPrecision}
       />
     ),
-    [accountId, feeAsset, estimatedGasCrypto],
+    [accountId, feeAsset, estimatedGasCryptoPrecision],
   )
   if (!state || !dispatch || !foxFarmingOpportunity || !asset) return null
 

--- a/src/features/defi/providers/fox-farming/components/FoxFarmingManager/Deposit/components/Confirm.tsx
+++ b/src/features/defi/providers/fox-farming/components/FoxFarmingManager/Deposit/components/Confirm.tsx
@@ -105,8 +105,9 @@ export const Confirm: React.FC<StepComponentProps & { accountId: AccountId | und
   )
 
   const hasEnoughBalanceForGas = useMemo(
-    () => bnOrZero(feeAssetBalance).minus(bnOrZero(state?.deposit.estimatedGasCrypto)).gte(0),
-    [feeAssetBalance, state?.deposit.estimatedGasCrypto],
+    () =>
+      bnOrZero(feeAssetBalance).minus(bnOrZero(state?.deposit.estimatedGasCryptoPrecision)).gte(0),
+    [feeAssetBalance, state?.deposit.estimatedGasCryptoPrecision],
   )
 
   const handleDeposit = useCallback(async () => {
@@ -215,13 +216,13 @@ export const Confirm: React.FC<StepComponentProps & { accountId: AccountId | und
             <Box textAlign='right'>
               <Amount.Fiat
                 fontWeight='bold'
-                value={bnOrZero(state.deposit.estimatedGasCrypto)
+                value={bnOrZero(state.deposit.estimatedGasCryptoPrecision)
                   .times(feeMarketData.price)
                   .toFixed(2)}
               />
               <Amount.Crypto
                 color='gray.500'
-                value={bnOrZero(state.deposit.estimatedGasCrypto).toFixed(5)}
+                value={bnOrZero(state.deposit.estimatedGasCryptoPrecision).toFixed(5)}
                 symbol={feeAsset.symbol}
               />
             </Box>

--- a/src/features/defi/providers/fox-farming/components/FoxFarmingManager/Deposit/components/Deposit.tsx
+++ b/src/features/defi/providers/fox-farming/components/FoxFarmingManager/Deposit/components/Deposit.tsx
@@ -122,7 +122,9 @@ export const Deposit: React.FC<DepositProps> = ({
     async (formValues: DepositValues) => {
       if (!(state && dispatch && feeAsset && foxFarmingOpportunity)) return
 
-      const getDepositGasEstimate = async (deposit: DepositValues): Promise<string | undefined> => {
+      const getDepositGasEstimateCryptoPrecision = async (
+        deposit: DepositValues,
+      ): Promise<string | undefined> => {
         if (!assetReference) return
         try {
           const gasData = await getStakeGasData(deposit.cryptoAmount)
@@ -130,7 +132,7 @@ export const Deposit: React.FC<DepositProps> = ({
           return bnOrZero(gasData.average.txFee).div(bn(10).pow(feeAsset.precision)).toPrecision()
         } catch (error) {
           moduleLogger.error(
-            { fn: 'getDepositGasEstimate', error },
+            { fn: 'getDepositGasEstimateCryptoPrecision', error },
             'Error getting deposit gas estimate',
           )
           toast({
@@ -153,7 +155,7 @@ export const Deposit: React.FC<DepositProps> = ({
 
         // Skip approval step if user allowance is greater than or equal requested deposit amount
         if (allowance.gte(formValues.cryptoAmount)) {
-          const estimatedGasCrypto = await getDepositGasEstimate(formValues)
+          const estimatedGasCrypto = await getDepositGasEstimateCryptoPrecision(formValues)
           if (!estimatedGasCrypto) return
           dispatch({
             type: FoxFarmingDepositActionType.SET_DEPOSIT,

--- a/src/features/defi/providers/fox-farming/components/FoxFarmingManager/Deposit/components/Deposit.tsx
+++ b/src/features/defi/providers/fox-farming/components/FoxFarmingManager/Deposit/components/Deposit.tsx
@@ -159,7 +159,7 @@ export const Deposit: React.FC<DepositProps> = ({
           if (!estimatedGasCrypto) return
           dispatch({
             type: FoxFarmingDepositActionType.SET_DEPOSIT,
-            payload: { estimatedGasCrypto },
+            payload: { estimatedGasCryptoPrecision: estimatedGasCrypto },
           })
           onNext(DefiStep.Confirm)
           dispatch({ type: FoxFarmingDepositActionType.SET_LOADING, payload: false })
@@ -175,12 +175,12 @@ export const Deposit: React.FC<DepositProps> = ({
             assets,
           )
         } else {
-          const estimatedGasCrypto = await getApproveGasData()
-          if (!estimatedGasCrypto) return
+          const estimatedGasCryptoBaseUnit = await getApproveGasData()
+          if (!estimatedGasCryptoBaseUnit) return
           dispatch({
             type: FoxFarmingDepositActionType.SET_APPROVE,
             payload: {
-              estimatedGasCrypto: bnOrZero(estimatedGasCrypto.average.txFee)
+              estimatedGasCryptoPrecision: bnOrZero(estimatedGasCryptoBaseUnit.average.txFee)
                 .div(bn(10).pow(feeAsset.precision))
                 .toPrecision(),
             },

--- a/src/features/defi/providers/fox-farming/components/FoxFarmingManager/Deposit/components/Status.tsx
+++ b/src/features/defi/providers/fox-farming/components/FoxFarmingManager/Deposit/components/Status.tsx
@@ -18,7 +18,7 @@ import { Row } from 'components/Row/Row'
 import { RawText, Text } from 'components/Text'
 import { getChainAdapterManager } from 'context/PluginProvider/chainAdapterSingleton'
 import { useBrowserRouter } from 'hooks/useBrowserRouter/useBrowserRouter'
-import { bnOrZero } from 'lib/bignumber/bignumber'
+import { bn, bnOrZero } from 'lib/bignumber/bignumber'
 import { trackOpportunityEvent } from 'lib/mixpanel/helpers'
 import { MixPanelEvents } from 'lib/mixpanel/types'
 import { toOpportunityId } from 'state/slices/opportunitiesSlice/utils'
@@ -97,8 +97,10 @@ export const Status: React.FC<StatusProps> = ({ accountId }) => {
         type: FoxFarmingDepositActionType.SET_DEPOSIT,
         payload: {
           txStatus: confirmedTransaction.status === 'Confirmed' ? 'success' : 'failed',
-          usedGasFee: confirmedTransaction.fee
-            ? bnOrZero(confirmedTransaction.fee.value).div(`1e${feeAsset.precision}`).toString()
+          usedGasFeeCryptoPrecision: confirmedTransaction.fee
+            ? bnOrZero(confirmedTransaction.fee.value)
+                .div(bn(10).pow(feeAsset.precision))
+                .toString()
             : '0',
         },
       })
@@ -209,7 +211,7 @@ export const Status: React.FC<StatusProps> = ({ accountId }) => {
                 value={bnOrZero(
                   state.deposit.txStatus === 'pending'
                     ? state.deposit.estimatedGasCryptoPrecision
-                    : state.deposit.usedGasFee,
+                    : state.deposit.usedGasFeeCryptoPrecision,
                 )
                   .times(feeMarketData.price)
                   .toFixed(2)}
@@ -219,7 +221,7 @@ export const Status: React.FC<StatusProps> = ({ accountId }) => {
                 value={bnOrZero(
                   state.deposit.txStatus === 'pending'
                     ? state.deposit.estimatedGasCryptoPrecision
-                    : state.deposit.usedGasFee,
+                    : state.deposit.usedGasFeeCryptoPrecision,
                 ).toFixed(5)}
                 symbol='ETH'
               />

--- a/src/features/defi/providers/fox-farming/components/FoxFarmingManager/Deposit/components/Status.tsx
+++ b/src/features/defi/providers/fox-farming/components/FoxFarmingManager/Deposit/components/Status.tsx
@@ -208,7 +208,7 @@ export const Status: React.FC<StatusProps> = ({ accountId }) => {
                 fontWeight='bold'
                 value={bnOrZero(
                   state.deposit.txStatus === 'pending'
-                    ? state.deposit.estimatedGasCrypto
+                    ? state.deposit.estimatedGasCryptoPrecision
                     : state.deposit.usedGasFee,
                 )
                   .times(feeMarketData.price)
@@ -218,7 +218,7 @@ export const Status: React.FC<StatusProps> = ({ accountId }) => {
                 color='gray.500'
                 value={bnOrZero(
                   state.deposit.txStatus === 'pending'
-                    ? state.deposit.estimatedGasCrypto
+                    ? state.deposit.estimatedGasCryptoPrecision
                     : state.deposit.usedGasFee,
                 ).toFixed(5)}
                 symbol='ETH'

--- a/src/features/defi/providers/fox-farming/components/FoxFarmingManager/Withdraw/WithdrawCommon.ts
+++ b/src/features/defi/providers/fox-farming/components/FoxFarmingManager/Withdraw/WithdrawCommon.ts
@@ -1,5 +1,5 @@
 type EstimatedGas = {
-  estimatedGasCrypto?: string
+  estimatedGasCryptoPrecision?: string
 }
 
 type WithdrawValues = {
@@ -10,7 +10,7 @@ type WithdrawValues = {
 type FoxFarmingWithdrawValues = WithdrawValues &
   EstimatedGas & {
     txStatus: string
-    usedGasFee: string
+    usedGasFeeCryptoPrecision: string
     isExiting: boolean
   }
 

--- a/src/features/defi/providers/fox-farming/components/FoxFarmingManager/Withdraw/WithdrawReducer.ts
+++ b/src/features/defi/providers/fox-farming/components/FoxFarmingManager/Withdraw/WithdrawReducer.ts
@@ -9,7 +9,7 @@ export const initialState: FoxFarmingWithdrawState = {
     lpAmount: '',
     fiatAmount: '',
     txStatus: 'pending',
-    usedGasFee: '',
+    usedGasFeeCryptoPrecision: '',
     isExiting: false,
   },
 }

--- a/src/features/defi/providers/fox-farming/components/FoxFarmingManager/Withdraw/components/Approve.tsx
+++ b/src/features/defi/providers/fox-farming/components/FoxFarmingManager/Withdraw/components/Approve.tsx
@@ -44,7 +44,7 @@ type ApproveProps = StepComponentProps & { accountId: AccountId | undefined }
 
 export const Approve: React.FC<ApproveProps> = ({ accountId, onNext }) => {
   const { state, dispatch } = useContext(WithdrawContext)
-  const estimatedGasCrypto = state?.approve.estimatedGasCrypto
+  const estimatedGasCryptoPrecision = state?.approve.estimatedGasCrypto
   const translate = useTranslate()
   const { query } = useBrowserRouter<DefiQueryParams, DefiParams>()
   const { assetNamespace, chainId, contractAddress, rewardId } = query
@@ -157,13 +157,13 @@ export const Approve: React.FC<ApproveProps> = ({ accountId, onNext }) => {
   const hasEnoughBalanceForGas = useMemo(
     () =>
       isSome(accountId) &&
-      isSome(estimatedGasCrypto) &&
+      isSome(estimatedGasCryptoPrecision) &&
       canCoverTxFees({
         feeAsset,
-        estimatedGasCrypto,
+        estimatedGasCryptoPrecision,
         accountId,
       }),
-    [accountId, estimatedGasCrypto, feeAsset],
+    [accountId, estimatedGasCryptoPrecision, feeAsset],
   )
 
   const preFooter = useMemo(
@@ -172,10 +172,10 @@ export const Approve: React.FC<ApproveProps> = ({ accountId, onNext }) => {
         accountId={accountId}
         action={DefiAction.Withdraw}
         feeAsset={feeAsset}
-        estimatedGasCrypto={estimatedGasCrypto}
+        estimatedGasCrypto={estimatedGasCryptoPrecision}
       />
     ),
-    [accountId, feeAsset, estimatedGasCrypto],
+    [accountId, feeAsset, estimatedGasCryptoPrecision],
   )
 
   if (!state || !dispatch || !opportunity || !underlyingAsset) return null
@@ -184,9 +184,11 @@ export const Approve: React.FC<ApproveProps> = ({ accountId, onNext }) => {
     <ReusableApprove
       asset={underlyingAsset}
       feeAsset={feeAsset}
-      cryptoEstimatedGasFee={bnOrZero(estimatedGasCrypto).toFixed(5)}
+      cryptoEstimatedGasFee={bnOrZero(estimatedGasCryptoPrecision).toFixed(5)}
       disabled={!hasEnoughBalanceForGas}
-      fiatEstimatedGasFee={bnOrZero(estimatedGasCrypto).times(feeMarketData.price).toFixed(2)}
+      fiatEstimatedGasFee={bnOrZero(estimatedGasCryptoPrecision)
+        .times(feeMarketData.price)
+        .toFixed(2)}
       loading={state.loading}
       loadingText={translate('common.approve')}
       learnMoreLink='https://shapeshift.zendesk.com/hc/en-us/articles/360018501700'

--- a/src/features/defi/providers/fox-farming/components/FoxFarmingManager/Withdraw/components/Approve.tsx
+++ b/src/features/defi/providers/fox-farming/components/FoxFarmingManager/Withdraw/components/Approve.tsx
@@ -172,7 +172,7 @@ export const Approve: React.FC<ApproveProps> = ({ accountId, onNext }) => {
         accountId={accountId}
         action={DefiAction.Withdraw}
         feeAsset={feeAsset}
-        estimatedGasCrypto={estimatedGasCryptoPrecision}
+        estimatedGasCryptoPrecision={estimatedGasCryptoPrecision}
       />
     ),
     [accountId, feeAsset, estimatedGasCryptoPrecision],

--- a/src/features/defi/providers/fox-farming/components/FoxFarmingManager/Withdraw/components/Approve.tsx
+++ b/src/features/defi/providers/fox-farming/components/FoxFarmingManager/Withdraw/components/Approve.tsx
@@ -44,7 +44,7 @@ type ApproveProps = StepComponentProps & { accountId: AccountId | undefined }
 
 export const Approve: React.FC<ApproveProps> = ({ accountId, onNext }) => {
   const { state, dispatch } = useContext(WithdrawContext)
-  const estimatedGasCryptoPrecision = state?.approve.estimatedGasCrypto
+  const estimatedGasCryptoPrecision = state?.approve.estimatedGasCryptoPrecision
   const translate = useTranslate()
   const { query } = useBrowserRouter<DefiQueryParams, DefiParams>()
   const { assetNamespace, chainId, contractAddress, rewardId } = query
@@ -114,7 +114,7 @@ export const Approve: React.FC<ApproveProps> = ({ accountId, onNext }) => {
         .toPrecision()
       dispatch({
         type: FoxFarmingWithdrawActionType.SET_WITHDRAW,
-        payload: { estimatedGasCrypto },
+        payload: { estimatedGasCryptoPrecision: estimatedGasCrypto },
       })
 
       onNext(DefiStep.Confirm)

--- a/src/features/defi/providers/fox-farming/components/FoxFarmingManager/Withdraw/components/Approve.tsx
+++ b/src/features/defi/providers/fox-farming/components/FoxFarmingManager/Withdraw/components/Approve.tsx
@@ -184,7 +184,7 @@ export const Approve: React.FC<ApproveProps> = ({ accountId, onNext }) => {
     <ReusableApprove
       asset={underlyingAsset}
       feeAsset={feeAsset}
-      cryptoEstimatedGasFee={bnOrZero(estimatedGasCryptoPrecision).toFixed(5)}
+      estimatedGasFeeCryptoPrecision={bnOrZero(estimatedGasCryptoPrecision).toFixed(5)}
       disabled={!hasEnoughBalanceForGas}
       fiatEstimatedGasFee={bnOrZero(estimatedGasCryptoPrecision)
         .times(feeMarketData.price)

--- a/src/features/defi/providers/fox-farming/components/FoxFarmingManager/Withdraw/components/Confirm.tsx
+++ b/src/features/defi/providers/fox-farming/components/FoxFarmingManager/Withdraw/components/Confirm.tsx
@@ -94,8 +94,9 @@ export const Confirm: React.FC<ConfirmProps> = ({ accountId, onNext }) => {
   )
 
   const hasEnoughBalanceForGas = useMemo(
-    () => bnOrZero(feeAssetBalance).minus(bnOrZero(state?.withdraw.estimatedGasCrypto)).gte(0),
-    [feeAssetBalance, state?.withdraw.estimatedGasCrypto],
+    () =>
+      bnOrZero(feeAssetBalance).minus(bnOrZero(state?.withdraw.estimatedGasCryptoPrecision)).gte(0),
+    [feeAssetBalance, state?.withdraw.estimatedGasCryptoPrecision],
   )
 
   const handleConfirm = useCallback(async () => {
@@ -192,13 +193,13 @@ export const Confirm: React.FC<ConfirmProps> = ({ accountId, onNext }) => {
             <Box textAlign='right'>
               <Amount.Fiat
                 fontWeight='bold'
-                value={bnOrZero(state.withdraw.estimatedGasCrypto)
+                value={bnOrZero(state.withdraw.estimatedGasCryptoPrecision)
                   .times(feeMarketData.price)
                   .toFixed(2)}
               />
               <Amount.Crypto
                 color='gray.500'
-                value={bnOrZero(state.withdraw.estimatedGasCrypto).toFixed(5)}
+                value={bnOrZero(state.withdraw.estimatedGasCryptoPrecision).toFixed(5)}
                 symbol={feeAsset.symbol}
               />
             </Box>

--- a/src/features/defi/providers/fox-farming/components/FoxFarmingManager/Withdraw/components/ExpiredWithdraw.tsx
+++ b/src/features/defi/providers/fox-farming/components/FoxFarmingManager/Withdraw/components/ExpiredWithdraw.tsx
@@ -143,7 +143,7 @@ export const ExpiredWithdraw: React.FC<ExpiredWithdrawProps> = ({
       }
       dispatch({
         type: FoxFarmingWithdrawActionType.SET_WITHDRAW,
-        payload: { estimatedGasCrypto },
+        payload: { estimatedGasCryptoPrecision: estimatedGasCrypto },
       })
       onNext(DefiStep.Confirm)
       dispatch({ type: FoxFarmingWithdrawActionType.SET_LOADING, payload: false })
@@ -167,7 +167,7 @@ export const ExpiredWithdraw: React.FC<ExpiredWithdrawProps> = ({
       dispatch({
         type: FoxFarmingWithdrawActionType.SET_APPROVE,
         payload: {
-          estimatedGasCrypto: bnOrZero(estimatedGasCrypto.average.txFee)
+          estimatedGasCryptoPrecision: bnOrZero(estimatedGasCrypto.average.txFee)
             .div(bn(10).pow(feeAsset.precision))
             .toPrecision(),
         },

--- a/src/features/defi/providers/fox-farming/components/FoxFarmingManager/Withdraw/components/Status.tsx
+++ b/src/features/defi/providers/fox-farming/components/FoxFarmingManager/Withdraw/components/Status.tsx
@@ -100,7 +100,7 @@ export const Status: React.FC<StatusProps> = ({ accountId }) => {
         type: FoxFarmingWithdrawActionType.SET_WITHDRAW,
         payload: {
           txStatus: confirmedTransaction.status === 'Confirmed' ? 'success' : 'failed',
-          usedGasFee: confirmedTransaction.fee
+          usedGasFeeCryptoPrecision: confirmedTransaction.fee
             ? bnOrZero(confirmedTransaction.fee.value).div(`1e${feeAsset.precision}`).toString()
             : '0',
         },
@@ -209,8 +209,8 @@ export const Status: React.FC<StatusProps> = ({ accountId }) => {
                 fontWeight='bold'
                 value={bnOrZero(
                   state.withdraw.txStatus === 'pending'
-                    ? state.withdraw.estimatedGasCrypto
-                    : state.withdraw.usedGasFee,
+                    ? state.withdraw.estimatedGasCryptoPrecision
+                    : state.withdraw.usedGasFeeCryptoPrecision,
                 )
                   .times(feeMarketData.price)
                   .toFixed(2)}
@@ -219,8 +219,8 @@ export const Status: React.FC<StatusProps> = ({ accountId }) => {
                 color='gray.500'
                 value={bnOrZero(
                   state.withdraw.txStatus === 'pending'
-                    ? state.withdraw.estimatedGasCrypto
-                    : state.withdraw.usedGasFee,
+                    ? state.withdraw.estimatedGasCryptoPrecision
+                    : state.withdraw.usedGasFeeCryptoPrecision,
                 ).toFixed(5)}
                 symbol='ETH'
               />

--- a/src/features/defi/providers/fox-farming/components/FoxFarmingManager/Withdraw/components/Withdraw.tsx
+++ b/src/features/defi/providers/fox-farming/components/FoxFarmingManager/Withdraw/components/Withdraw.tsx
@@ -92,7 +92,7 @@ export const Withdraw: React.FC<WithdrawProps> = ({
     [underlyingAsset.precision, opportunity?.cryptoAmountBaseUnit],
   )
 
-  const getWithdrawGasEstimate = useCallback(
+  const getWithdrawGasEstimateCryptoPrecision = useCallback(
     async (withdraw: WithdrawValues) => {
       try {
         const fee = await getUnstakeGasData(withdraw.cryptoAmount, isExiting)
@@ -124,14 +124,14 @@ export const Withdraw: React.FC<WithdrawProps> = ({
 
       // Skip approval step if user allowance is greater than or equal requested deposit amount
       if (allowanceAmount.gte(bnOrZero(formValues.cryptoAmount))) {
-        const estimatedGasCrypto = await getWithdrawGasEstimate(formValues)
-        if (!estimatedGasCrypto) {
+        const estimatedGasCryptoPrecision = await getWithdrawGasEstimateCryptoPrecision(formValues)
+        if (!estimatedGasCryptoPrecision) {
           dispatch({ type: FoxFarmingWithdrawActionType.SET_LOADING, payload: false })
           return
         }
         dispatch({
           type: FoxFarmingWithdrawActionType.SET_WITHDRAW,
-          payload: { estimatedGasCrypto },
+          payload: { estimatedGasCryptoPrecision },
         })
         onNext(DefiStep.Confirm)
         dispatch({ type: FoxFarmingWithdrawActionType.SET_LOADING, payload: false })
@@ -152,7 +152,7 @@ export const Withdraw: React.FC<WithdrawProps> = ({
         dispatch({
           type: FoxFarmingWithdrawActionType.SET_APPROVE,
           payload: {
-            estimatedGasCrypto: bnOrZero(estimatedGasCrypto.average.txFee)
+            estimatedGasCryptoPrecision: bnOrZero(estimatedGasCrypto.average.txFee)
               .div(bn(10).pow(feeAsset.precision))
               .toPrecision(),
           },
@@ -167,7 +167,7 @@ export const Withdraw: React.FC<WithdrawProps> = ({
       dispatch,
       feeAsset.precision,
       getApproveGasData,
-      getWithdrawGasEstimate,
+      getWithdrawGasEstimateCryptoPrecision,
       isExiting,
       onNext,
       opportunity,

--- a/src/features/defi/providers/fox-farming/hooks/useFoxFarming.ts
+++ b/src/features/defi/providers/fox-farming/hooks/useFoxFarming.ts
@@ -276,7 +276,7 @@ export const useFoxFarming = (
     return _allowance.toString()
   }, [farmingAccountId, contractAddress, uniV2LPContract, skip])
 
-  const getApproveGasData = useCallback(async () => {
+  const getApproveGasDataCryptoBaseUnit = useCallback(async () => {
     if (adapter && farmingAccountId && uniV2LPContract) {
       const data = uniV2LPContract.interface.encodeFunctionData('approve', [
         contractAddress,
@@ -360,7 +360,7 @@ export const useFoxFarming = (
       contractAddress,
       MaxUint256,
     ])
-    const gasData = await getApproveGasData()
+    const gasData = await getApproveGasDataCryptoBaseUnit()
     if (!gasData) return
     const fees = gasData.average as FeeData<EvmChainId>
     const {
@@ -401,7 +401,14 @@ export const useFoxFarming = (
       }
     })()
     return broadcastTXID
-  }, [accountNumber, adapter, contractAddress, getApproveGasData, uniV2LPContract, wallet])
+  }, [
+    accountNumber,
+    adapter,
+    contractAddress,
+    getApproveGasDataCryptoBaseUnit,
+    uniV2LPContract,
+    wallet,
+  ])
 
   const getClaimGasData = useCallback(
     async (userAddress: string) => {
@@ -483,7 +490,7 @@ export const useFoxFarming = (
   return {
     allowance,
     approve,
-    getApproveGasData,
+    getApproveGasData: getApproveGasDataCryptoBaseUnit,
     getStakeGasData,
     getClaimGasData,
     getUnstakeGasData,

--- a/src/features/defi/providers/foxy/components/FoxyManager/Deposit/DepositCommon.ts
+++ b/src/features/defi/providers/foxy/components/FoxyManager/Deposit/DepositCommon.ts
@@ -23,7 +23,7 @@ type EstimatedGas = {
 type FoxyDepositValues = DepositValues &
   EstimatedGas & {
     txStatus: string
-    usedGasFee: string
+    usedGasFeeCryptoBaseUnit: string
   }
 
 export type FoxyDepositState = {

--- a/src/features/defi/providers/foxy/components/FoxyManager/Deposit/DepositCommon.ts
+++ b/src/features/defi/providers/foxy/components/FoxyManager/Deposit/DepositCommon.ts
@@ -17,7 +17,7 @@ type SupportedFoxyOpportunity = {
 }
 
 type EstimatedGas = {
-  estimatedGasCrypto?: string
+  estimatedGasCryptoBaseUnit?: string
 }
 
 type FoxyDepositValues = DepositValues &

--- a/src/features/defi/providers/foxy/components/FoxyManager/Deposit/DepositReducer.ts
+++ b/src/features/defi/providers/foxy/components/FoxyManager/Deposit/DepositReducer.ts
@@ -27,7 +27,7 @@ export const initialState: FoxyDepositState = {
     cryptoAmount: '',
     slippage: '',
     txStatus: 'pending',
-    usedGasFee: '',
+    usedGasFeeCryptoBaseUnit: '',
   },
   isExactAllowance: false,
 }

--- a/src/features/defi/providers/foxy/components/FoxyManager/Deposit/components/Approve.tsx
+++ b/src/features/defi/providers/foxy/components/FoxyManager/Deposit/components/Approve.tsx
@@ -42,6 +42,14 @@ export const Approve: React.FC<ApproveProps> = ({ accountId, onNext }) => {
     feeAsset,
   } = useFoxyQuery()
 
+  const estimatedGasCryptoPrecision = useMemo(
+    () =>
+      bnOrZero(estimatedGasCryptoBaseUnit)
+        .div(bn(10).pow(feeAsset?.precision ?? 0))
+        .toFixed(),
+    [estimatedGasCryptoBaseUnit, feeAsset?.precision],
+  )
+
   // user info
   const { state: walletState } = useWallet()
 
@@ -61,7 +69,7 @@ export const Approve: React.FC<ApproveProps> = ({ accountId, onNext }) => {
             tokenContractAddress: assetReference,
             contractAddress,
             amountDesired: bnOrZero(deposit.cryptoAmount)
-              .times(`1e+${asset.precision}`)
+              .times(bn(10).pow(asset.precision))
               .decimalPlaces(0),
             userAddress: accountAddress,
           }),
@@ -177,10 +185,10 @@ export const Approve: React.FC<ApproveProps> = ({ accountId, onNext }) => {
         accountId={accountId}
         action={DefiAction.Deposit}
         feeAsset={feeAsset}
-        estimatedGasCryptoPrecision={estimatedGasCryptoBaseUnit}
+        estimatedGasCryptoPrecision={estimatedGasCryptoPrecision}
       />
     ),
-    [accountId, feeAsset, estimatedGasCryptoBaseUnit],
+    [accountId, feeAsset, estimatedGasCryptoPrecision],
   )
 
   if (!state || !dispatch) return null

--- a/src/features/defi/providers/foxy/components/FoxyManager/Deposit/components/Approve.tsx
+++ b/src/features/defi/providers/foxy/components/FoxyManager/Deposit/components/Approve.tsx
@@ -173,10 +173,10 @@ export const Approve: React.FC<ApproveProps> = ({ accountId, onNext }) => {
       isSome(estimatedGasCryptoBaseUnit) &&
       canCoverTxFees({
         feeAsset,
-        estimatedGasCryptoPrecision: estimatedGasCryptoBaseUnit,
+        estimatedGasCryptoPrecision,
         accountId,
       }),
-    [accountId, feeAsset, estimatedGasCryptoBaseUnit],
+    [accountId, estimatedGasCryptoBaseUnit, feeAsset, estimatedGasCryptoPrecision],
   )
 
   const preFooter = useMemo(

--- a/src/features/defi/providers/foxy/components/FoxyManager/Deposit/components/Approve.tsx
+++ b/src/features/defi/providers/foxy/components/FoxyManager/Deposit/components/Approve.tsx
@@ -189,7 +189,7 @@ export const Approve: React.FC<ApproveProps> = ({ accountId, onNext }) => {
     <ReusableApprove
       asset={asset}
       feeAsset={feeAsset}
-      cryptoEstimatedGasFee={bnOrZero(estimatedGasCryptoBaseUnit)
+      estimatedGasFeeCryptoPrecision={bnOrZero(estimatedGasCryptoBaseUnit)
         .div(bn(10).pow(feeAsset.precision))
         .toFixed(5)}
       disabled={!hasEnoughBalanceForGas}

--- a/src/features/defi/providers/foxy/components/FoxyManager/Deposit/components/Approve.tsx
+++ b/src/features/defi/providers/foxy/components/FoxyManager/Deposit/components/Approve.tsx
@@ -30,7 +30,7 @@ type ApproveProps = StepComponentProps & { accountId: AccountId | undefined }
 export const Approve: React.FC<ApproveProps> = ({ accountId, onNext }) => {
   const foxyApi = getFoxyApi()
   const { state, dispatch } = useContext(DepositContext)
-  const estimatedGasCrypto = state?.approve.estimatedGasCrypto
+  const estimatedGasCryptoPrecision = state?.approve.estimatedGasCrypto
   const history = useHistory()
   const translate = useTranslate()
   const toast = useToast()
@@ -52,7 +52,7 @@ export const Approve: React.FC<ApproveProps> = ({ accountId, onNext }) => {
   )
   const bip44Params = useAppSelector(state => selectBIP44ParamsByAccountId(state, accountFilter))
 
-  const getDepositGasEstimate = useCallback(
+  const getDepositGasEstimateCryptoPrecision = useCallback(
     async (deposit: DepositValues) => {
       if (!accountAddress || !assetReference || !foxyApi) return
       try {
@@ -70,7 +70,7 @@ export const Approve: React.FC<ApproveProps> = ({ accountId, onNext }) => {
         return bnOrZero(gasPrice).times(gasLimit).toFixed(0)
       } catch (error) {
         moduleLogger.error(
-          { fn: 'getDepositGasEstimate', error },
+          { fn: 'getDepositGasEstimateCryptoPrecision', error },
           'Error getting deposit gas estimate',
         )
         toast({
@@ -124,7 +124,7 @@ export const Approve: React.FC<ApproveProps> = ({ accountId, onNext }) => {
         maxAttempts: 60,
       })
       // Get deposit gas estimate
-      const estimatedGasCrypto = await getDepositGasEstimate(state?.deposit)
+      const estimatedGasCrypto = await getDepositGasEstimateCryptoPrecision(state?.deposit)
       if (!estimatedGasCrypto) return
       dispatch({
         type: FoxyDepositActionType.SET_DEPOSIT,
@@ -151,7 +151,7 @@ export const Approve: React.FC<ApproveProps> = ({ accountId, onNext }) => {
     bip44Params,
     contractAddress,
     dispatch,
-    getDepositGasEstimate,
+    getDepositGasEstimateCryptoPrecision,
     onNext,
     state,
     toast,
@@ -162,13 +162,13 @@ export const Approve: React.FC<ApproveProps> = ({ accountId, onNext }) => {
   const hasEnoughBalanceForGas = useMemo(
     () =>
       isSome(accountId) &&
-      isSome(estimatedGasCrypto) &&
+      isSome(estimatedGasCryptoPrecision) &&
       canCoverTxFees({
         feeAsset,
-        estimatedGasCrypto,
+        estimatedGasCryptoPrecision,
         accountId,
       }),
-    [accountId, feeAsset, estimatedGasCrypto],
+    [accountId, feeAsset, estimatedGasCryptoPrecision],
   )
 
   const preFooter = useMemo(
@@ -177,10 +177,10 @@ export const Approve: React.FC<ApproveProps> = ({ accountId, onNext }) => {
         accountId={accountId}
         action={DefiAction.Deposit}
         feeAsset={feeAsset}
-        estimatedGasCrypto={estimatedGasCrypto}
+        estimatedGasCrypto={estimatedGasCryptoPrecision}
       />
     ),
-    [accountId, feeAsset, estimatedGasCrypto],
+    [accountId, feeAsset, estimatedGasCryptoPrecision],
   )
 
   if (!state || !dispatch) return null
@@ -189,11 +189,11 @@ export const Approve: React.FC<ApproveProps> = ({ accountId, onNext }) => {
     <ReusableApprove
       asset={asset}
       feeAsset={feeAsset}
-      cryptoEstimatedGasFee={bnOrZero(estimatedGasCrypto)
+      cryptoEstimatedGasFee={bnOrZero(estimatedGasCryptoPrecision)
         .div(bn(10).pow(feeAsset.precision))
         .toFixed(5)}
       disabled={!hasEnoughBalanceForGas}
-      fiatEstimatedGasFee={bnOrZero(estimatedGasCrypto)
+      fiatEstimatedGasFee={bnOrZero(estimatedGasCryptoPrecision)
         .div(bn(10).pow(feeAsset.precision))
         .times(feeMarketData.price)
         .toFixed(2)}

--- a/src/features/defi/providers/foxy/components/FoxyManager/Deposit/components/Approve.tsx
+++ b/src/features/defi/providers/foxy/components/FoxyManager/Deposit/components/Approve.tsx
@@ -177,7 +177,7 @@ export const Approve: React.FC<ApproveProps> = ({ accountId, onNext }) => {
         accountId={accountId}
         action={DefiAction.Deposit}
         feeAsset={feeAsset}
-        estimatedGasCrypto={estimatedGasCryptoBaseUnit}
+        estimatedGasCryptoPrecision={estimatedGasCryptoBaseUnit}
       />
     ),
     [accountId, feeAsset, estimatedGasCryptoBaseUnit],

--- a/src/features/defi/providers/foxy/components/FoxyManager/Deposit/components/Confirm.tsx
+++ b/src/features/defi/providers/foxy/components/FoxyManager/Deposit/components/Confirm.tsx
@@ -15,7 +15,7 @@ import type { StepComponentProps } from 'components/DeFi/components/Steps'
 import { Row } from 'components/Row/Row'
 import { RawText, Text } from 'components/Text'
 import { useWallet } from 'hooks/useWallet/useWallet'
-import { bnOrZero } from 'lib/bignumber/bignumber'
+import { bn, bnOrZero } from 'lib/bignumber/bignumber'
 import { logger } from 'lib/logger'
 import { poll } from 'lib/poll/poll'
 import { getFoxyApi } from 'state/apis/foxy/foxyApiSingleton'
@@ -84,7 +84,7 @@ export const Confirm: React.FC<ConfirmProps> = ({ onNext, accountId }) => {
       const [txid, gasPrice] = await Promise.all([
         foxyApi.deposit({
           amountDesired: bnOrZero(state?.deposit.cryptoAmount)
-            .times(`1e+${asset.precision}`)
+            .times(bn(10).pow(asset.precision))
             .decimalPlaces(0),
           tokenContractAddress: assetReference,
           userAddress: accountAddress,
@@ -139,7 +139,7 @@ export const Confirm: React.FC<ConfirmProps> = ({ onNext, accountId }) => {
   if (!state || !dispatch) return null
 
   const hasEnoughBalanceForGas = bnOrZero(feeAssetBalance)
-    .minus(bnOrZero(state.deposit.estimatedGasCryptoBaseUnit).div(`1e+${feeAsset.precision}`))
+    .minus(bnOrZero(state.deposit.estimatedGasCryptoBaseUnit).div(bn(10).pow(feeAsset.precision)))
     .gte(0)
 
   return (
@@ -175,14 +175,14 @@ export const Confirm: React.FC<ConfirmProps> = ({ onNext, accountId }) => {
               <Amount.Fiat
                 fontWeight='bold'
                 value={bnOrZero(state.deposit.estimatedGasCryptoBaseUnit)
-                  .div(`1e+${feeAsset.precision}`)
+                  .div(bn(10).pow(feeAsset.precision))
                   .times(feeMarketData.price)
                   .toFixed(2)}
               />
               <Amount.Crypto
                 color='gray.500'
                 value={bnOrZero(state.deposit.estimatedGasCryptoBaseUnit)
-                  .div(`1e+${feeAsset.precision}`)
+                  .div(bn(10).pow(feeAsset.precision))
                   .toFixed(5)}
                 symbol={feeAsset.symbol}
               />

--- a/src/features/defi/providers/foxy/components/FoxyManager/Deposit/components/Confirm.tsx
+++ b/src/features/defi/providers/foxy/components/FoxyManager/Deposit/components/Confirm.tsx
@@ -139,7 +139,7 @@ export const Confirm: React.FC<ConfirmProps> = ({ onNext, accountId }) => {
   if (!state || !dispatch) return null
 
   const hasEnoughBalanceForGas = bnOrZero(feeAssetBalance)
-    .minus(bnOrZero(state.deposit.estimatedGasCrypto).div(`1e+${feeAsset.precision}`))
+    .minus(bnOrZero(state.deposit.estimatedGasCryptoBaseUnit).div(`1e+${feeAsset.precision}`))
     .gte(0)
 
   return (
@@ -174,14 +174,14 @@ export const Confirm: React.FC<ConfirmProps> = ({ onNext, accountId }) => {
             <Box textAlign='right'>
               <Amount.Fiat
                 fontWeight='bold'
-                value={bnOrZero(state.deposit.estimatedGasCrypto)
+                value={bnOrZero(state.deposit.estimatedGasCryptoBaseUnit)
                   .div(`1e+${feeAsset.precision}`)
                   .times(feeMarketData.price)
                   .toFixed(2)}
               />
               <Amount.Crypto
                 color='gray.500'
-                value={bnOrZero(state.deposit.estimatedGasCrypto)
+                value={bnOrZero(state.deposit.estimatedGasCryptoBaseUnit)
                   .div(`1e+${feeAsset.precision}`)
                   .toFixed(5)}
                 symbol={feeAsset.symbol}

--- a/src/features/defi/providers/foxy/components/FoxyManager/Deposit/components/Confirm.tsx
+++ b/src/features/defi/providers/foxy/components/FoxyManager/Deposit/components/Confirm.tsx
@@ -107,7 +107,7 @@ export const Confirm: React.FC<ConfirmProps> = ({ onNext, accountId }) => {
         type: FoxyDepositActionType.SET_DEPOSIT,
         payload: {
           txStatus: transactionReceipt.status === true ? 'success' : 'failed',
-          usedGasFee: bnOrZero(gasPrice).times(transactionReceipt.gasUsed).toFixed(0),
+          usedGasFeeCryptoBaseUnit: bnOrZero(gasPrice).times(transactionReceipt.gasUsed).toFixed(0),
         },
       })
     } catch (error) {

--- a/src/features/defi/providers/foxy/components/FoxyManager/Deposit/components/Deposit.tsx
+++ b/src/features/defi/providers/foxy/components/FoxyManager/Deposit/components/Deposit.tsx
@@ -87,7 +87,7 @@ export const Deposit: React.FC<DepositProps> = ({
         }
       }
 
-      const getDepositGasEstimateCryptoPrecision = async (deposit: DepositValues) => {
+      const getDepositGasEstimateCryptoBaseUnit = async (deposit: DepositValues) => {
         if (!accountAddress || !assetReference || !foxyApi) return
         try {
           const [gasLimit, gasPrice] = await Promise.all([
@@ -104,7 +104,7 @@ export const Deposit: React.FC<DepositProps> = ({
           return bnOrZero(gasPrice).times(gasLimit).toFixed(0)
         } catch (error) {
           moduleLogger.error(
-            { fn: 'getDepositGasEstimateCryptoPrecision', error },
+            { fn: 'getDepositGasEstimateCryptoBaseUnit', error },
             'Error getting deposit gas estimate',
           )
           toast({
@@ -130,11 +130,11 @@ export const Deposit: React.FC<DepositProps> = ({
 
         // Skip approval step if user allowance is greater than or equal requested deposit amount
         if (allowance.gte(formValues.cryptoAmount)) {
-          const estimatedGasCrypto = await getDepositGasEstimateCryptoPrecision(formValues)
-          if (!estimatedGasCrypto) return
+          const estimatedGasCryptoBaseUnit = await getDepositGasEstimateCryptoBaseUnit(formValues)
+          if (!estimatedGasCryptoBaseUnit) return
           dispatch({
             type: FoxyDepositActionType.SET_DEPOSIT,
-            payload: { estimatedGasCrypto },
+            payload: { estimatedGasCryptoBaseUnit },
           })
           onNext(DefiStep.Confirm)
           dispatch({ type: FoxyDepositActionType.SET_LOADING, payload: false })
@@ -143,7 +143,7 @@ export const Deposit: React.FC<DepositProps> = ({
           if (!estimatedGasCrypto) return
           dispatch({
             type: FoxyDepositActionType.SET_APPROVE,
-            payload: { estimatedGasCrypto },
+            payload: { estimatedGasCryptoBaseUnit: estimatedGasCrypto },
           })
           onNext(DefiStep.Approve)
           dispatch({ type: FoxyDepositActionType.SET_LOADING, payload: false })

--- a/src/features/defi/providers/foxy/components/FoxyManager/Deposit/components/Deposit.tsx
+++ b/src/features/defi/providers/foxy/components/FoxyManager/Deposit/components/Deposit.tsx
@@ -87,7 +87,7 @@ export const Deposit: React.FC<DepositProps> = ({
         }
       }
 
-      const getDepositGasEstimate = async (deposit: DepositValues) => {
+      const getDepositGasEstimateCryptoPrecision = async (deposit: DepositValues) => {
         if (!accountAddress || !assetReference || !foxyApi) return
         try {
           const [gasLimit, gasPrice] = await Promise.all([
@@ -104,7 +104,7 @@ export const Deposit: React.FC<DepositProps> = ({
           return bnOrZero(gasPrice).times(gasLimit).toFixed(0)
         } catch (error) {
           moduleLogger.error(
-            { fn: 'getDepositGasEstimate', error },
+            { fn: 'getDepositGasEstimateCryptoPrecision', error },
             'Error getting deposit gas estimate',
           )
           toast({
@@ -130,7 +130,7 @@ export const Deposit: React.FC<DepositProps> = ({
 
         // Skip approval step if user allowance is greater than or equal requested deposit amount
         if (allowance.gte(formValues.cryptoAmount)) {
-          const estimatedGasCrypto = await getDepositGasEstimate(formValues)
+          const estimatedGasCrypto = await getDepositGasEstimateCryptoPrecision(formValues)
           if (!estimatedGasCrypto) return
           dispatch({
             type: FoxyDepositActionType.SET_DEPOSIT,

--- a/src/features/defi/providers/foxy/components/FoxyManager/Deposit/components/Status.tsx
+++ b/src/features/defi/providers/foxy/components/FoxyManager/Deposit/components/Status.tsx
@@ -16,7 +16,7 @@ import { StatusTextEnum } from 'components/RouteSteps/RouteSteps'
 import { Row } from 'components/Row/Row'
 import { RawText, Text } from 'components/Text'
 import { useBrowserRouter } from 'hooks/useBrowserRouter/useBrowserRouter'
-import { bnOrZero } from 'lib/bignumber/bignumber'
+import { bn, bnOrZero } from 'lib/bignumber/bignumber'
 
 import { DepositContext } from '../DepositContext'
 
@@ -108,7 +108,7 @@ export const Status = () => {
                     ? state.deposit.estimatedGasCryptoBaseUnit
                     : state.deposit.usedGasFee,
                 )
-                  .div(`1e+${feeAsset.precision}`)
+                  .div(bn(10).pow(feeAsset.precision))
                   .times(feeMarketData.price)
                   .toFixed(2)}
               />
@@ -119,7 +119,7 @@ export const Status = () => {
                     ? state.deposit.estimatedGasCryptoBaseUnit
                     : state.deposit.usedGasFee,
                 )
-                  .div(`1e+${feeAsset.precision}`)
+                  .div(bn(10).pow(feeAsset.precision))
                   .toFixed(5)}
                 symbol='ETH'
               />

--- a/src/features/defi/providers/foxy/components/FoxyManager/Deposit/components/Status.tsx
+++ b/src/features/defi/providers/foxy/components/FoxyManager/Deposit/components/Status.tsx
@@ -105,7 +105,7 @@ export const Status = () => {
                 fontWeight='bold'
                 value={bnOrZero(
                   state.deposit.txStatus === 'pending'
-                    ? state.deposit.estimatedGasCrypto
+                    ? state.deposit.estimatedGasCryptoBaseUnit
                     : state.deposit.usedGasFee,
                 )
                   .div(`1e+${feeAsset.precision}`)
@@ -116,7 +116,7 @@ export const Status = () => {
                 color='gray.500'
                 value={bnOrZero(
                   state.deposit.txStatus === 'pending'
-                    ? state.deposit.estimatedGasCrypto
+                    ? state.deposit.estimatedGasCryptoBaseUnit
                     : state.deposit.usedGasFee,
                 )
                   .div(`1e+${feeAsset.precision}`)

--- a/src/features/defi/providers/foxy/components/FoxyManager/Deposit/components/Status.tsx
+++ b/src/features/defi/providers/foxy/components/FoxyManager/Deposit/components/Status.tsx
@@ -106,7 +106,7 @@ export const Status = () => {
                 value={bnOrZero(
                   state.deposit.txStatus === 'pending'
                     ? state.deposit.estimatedGasCryptoBaseUnit
-                    : state.deposit.usedGasFee,
+                    : state.deposit.usedGasFeeCryptoBaseUnit,
                 )
                   .div(bn(10).pow(feeAsset.precision))
                   .times(feeMarketData.price)
@@ -117,7 +117,7 @@ export const Status = () => {
                 value={bnOrZero(
                   state.deposit.txStatus === 'pending'
                     ? state.deposit.estimatedGasCryptoBaseUnit
-                    : state.deposit.usedGasFee,
+                    : state.deposit.usedGasFeeCryptoBaseUnit,
                 )
                   .div(bn(10).pow(feeAsset.precision))
                   .toFixed(5)}

--- a/src/features/defi/providers/foxy/components/FoxyManager/Overview/Claim/ClaimStatus.tsx
+++ b/src/features/defi/providers/foxy/components/FoxyManager/Overview/Claim/ClaimStatus.tsx
@@ -31,7 +31,7 @@ interface ClaimStatusState {
   amount: string
   userAddress: string
   estimatedGas: string
-  usedGasFee?: string
+  usedGasFeeCryptoPrecision?: string
   status: string
   chainId: ChainId
 }

--- a/src/features/defi/providers/foxy/components/FoxyManager/Withdraw/WithdrawCommon.ts
+++ b/src/features/defi/providers/foxy/components/FoxyManager/Withdraw/WithdrawCommon.ts
@@ -24,7 +24,7 @@ type EstimatedGas = {
 type FoxyWithdrawValues = WithdrawValues &
   EstimatedGas & {
     txStatus: string
-    usedGasFee: string
+    usedGasFeeCryptoBaseUnit: string
     withdrawType: WithdrawType
   }
 

--- a/src/features/defi/providers/foxy/components/FoxyManager/Withdraw/WithdrawCommon.ts
+++ b/src/features/defi/providers/foxy/components/FoxyManager/Withdraw/WithdrawCommon.ts
@@ -18,7 +18,7 @@ type SupportedFoxyOpportunity = {
 }
 
 type EstimatedGas = {
-  estimatedGasCrypto?: string
+  estimatedGasCryptoBaseUnit?: string
 }
 
 type FoxyWithdrawValues = WithdrawValues &

--- a/src/features/defi/providers/foxy/components/FoxyManager/Withdraw/WithdrawReducer.ts
+++ b/src/features/defi/providers/foxy/components/FoxyManager/Withdraw/WithdrawReducer.ts
@@ -26,7 +26,7 @@ export const initialState: FoxyWithdrawState = {
     cryptoAmount: '',
     slippage: '',
     txStatus: 'pending',
-    usedGasFee: '',
+    usedGasFeeCryptoBaseUnit: '',
     withdrawType: WithdrawType.DELAYED,
   },
   foxyFeePercentage: '',

--- a/src/features/defi/providers/foxy/components/FoxyManager/Withdraw/components/Approve.tsx
+++ b/src/features/defi/providers/foxy/components/FoxyManager/Withdraw/components/Approve.tsx
@@ -31,7 +31,7 @@ type ApproveProps = StepComponentProps & { accountId: AccountId | undefined }
 export const Approve: React.FC<ApproveProps> = ({ accountId, onNext }) => {
   const foxyApi = getFoxyApi()
   const { state, dispatch } = useContext(WithdrawContext)
-  const estimatedGasCryptoPrecision = state?.approve.estimatedGasCrypto
+  const estimatedGasCryptoPrecisionBaseUnit = state?.approve.estimatedGasCryptoBaseUnit
   const translate = useTranslate()
   const {
     underlyingAsset: asset,
@@ -139,7 +139,7 @@ export const Approve: React.FC<ApproveProps> = ({ accountId, onNext }) => {
       if (!estimatedGasCrypto) return
       dispatch({
         type: FoxyWithdrawActionType.SET_WITHDRAW,
-        payload: { estimatedGasCrypto },
+        payload: { estimatedGasCryptoBaseUnit: estimatedGasCrypto },
       })
       onNext(DefiStep.Confirm)
     } catch (error) {
@@ -171,14 +171,14 @@ export const Approve: React.FC<ApproveProps> = ({ accountId, onNext }) => {
 
   const hasEnoughBalanceForGas = useMemo(
     () =>
-      isSome(estimatedGasCryptoPrecision) &&
+      isSome(estimatedGasCryptoPrecisionBaseUnit) &&
       isSome(accountId) &&
       canCoverTxFees({
         feeAsset,
-        estimatedGasCryptoPrecision,
+        estimatedGasCryptoPrecision: estimatedGasCryptoPrecisionBaseUnit,
         accountId,
       }),
-    [accountId, feeAsset, estimatedGasCryptoPrecision],
+    [accountId, feeAsset, estimatedGasCryptoPrecisionBaseUnit],
   )
 
   const preFooter = useMemo(
@@ -187,10 +187,10 @@ export const Approve: React.FC<ApproveProps> = ({ accountId, onNext }) => {
         accountId={accountId}
         action={DefiAction.Withdraw}
         feeAsset={feeAsset}
-        estimatedGasCrypto={estimatedGasCryptoPrecision}
+        estimatedGasCrypto={estimatedGasCryptoPrecisionBaseUnit}
       />
     ),
-    [accountId, feeAsset, estimatedGasCryptoPrecision],
+    [accountId, feeAsset, estimatedGasCryptoPrecisionBaseUnit],
   )
 
   if (!state || !dispatch) return null
@@ -199,11 +199,11 @@ export const Approve: React.FC<ApproveProps> = ({ accountId, onNext }) => {
     <ReusableApprove
       asset={asset}
       feeAsset={feeAsset}
-      cryptoEstimatedGasFee={bnOrZero(estimatedGasCryptoPrecision)
+      cryptoEstimatedGasFee={bnOrZero(estimatedGasCryptoPrecisionBaseUnit)
         .div(bn(10).pow(feeAsset.precision))
         .toFixed(5)}
       disabled={!hasEnoughBalanceForGas}
-      fiatEstimatedGasFee={bnOrZero(estimatedGasCryptoPrecision)
+      fiatEstimatedGasFee={bnOrZero(estimatedGasCryptoPrecisionBaseUnit)
         .div(bn(10).pow(feeAsset.precision))
         .times(feeMarketData.price)
         .toFixed(2)}

--- a/src/features/defi/providers/foxy/components/FoxyManager/Withdraw/components/Approve.tsx
+++ b/src/features/defi/providers/foxy/components/FoxyManager/Withdraw/components/Approve.tsx
@@ -187,7 +187,7 @@ export const Approve: React.FC<ApproveProps> = ({ accountId, onNext }) => {
         accountId={accountId}
         action={DefiAction.Withdraw}
         feeAsset={feeAsset}
-        estimatedGasCrypto={estimatedGasCryptoPrecisionBaseUnit}
+        estimatedGasCryptoPrecision={estimatedGasCryptoPrecisionBaseUnit}
       />
     ),
     [accountId, feeAsset, estimatedGasCryptoPrecisionBaseUnit],

--- a/src/features/defi/providers/foxy/components/FoxyManager/Withdraw/components/Approve.tsx
+++ b/src/features/defi/providers/foxy/components/FoxyManager/Withdraw/components/Approve.tsx
@@ -199,7 +199,7 @@ export const Approve: React.FC<ApproveProps> = ({ accountId, onNext }) => {
     <ReusableApprove
       asset={asset}
       feeAsset={feeAsset}
-      cryptoEstimatedGasFee={bnOrZero(estimatedGasCryptoPrecisionBaseUnit)
+      estimatedGasFeeCryptoPrecision={bnOrZero(estimatedGasCryptoPrecisionBaseUnit)
         .div(bn(10).pow(feeAsset.precision))
         .toFixed(5)}
       disabled={!hasEnoughBalanceForGas}

--- a/src/features/defi/providers/foxy/components/FoxyManager/Withdraw/components/Approve.tsx
+++ b/src/features/defi/providers/foxy/components/FoxyManager/Withdraw/components/Approve.tsx
@@ -184,10 +184,10 @@ export const Approve: React.FC<ApproveProps> = ({ accountId, onNext }) => {
       isSome(accountId) &&
       canCoverTxFees({
         feeAsset,
-        estimatedGasCryptoPrecision: estimatedGasCryptoBaseUnit,
+        estimatedGasCryptoPrecision,
         accountId,
       }),
-    [accountId, feeAsset, estimatedGasCryptoBaseUnit],
+    [estimatedGasCryptoBaseUnit, accountId, feeAsset, estimatedGasCryptoPrecision],
   )
 
   const preFooter = useMemo(

--- a/src/features/defi/providers/foxy/components/FoxyManager/Withdraw/components/Approve.tsx
+++ b/src/features/defi/providers/foxy/components/FoxyManager/Withdraw/components/Approve.tsx
@@ -31,7 +31,7 @@ type ApproveProps = StepComponentProps & { accountId: AccountId | undefined }
 export const Approve: React.FC<ApproveProps> = ({ accountId, onNext }) => {
   const foxyApi = getFoxyApi()
   const { state, dispatch } = useContext(WithdrawContext)
-  const estimatedGasCryptoPrecisionBaseUnit = state?.approve.estimatedGasCryptoBaseUnit
+  const estimatedGasCryptoBaseUnit = state?.approve.estimatedGasCryptoBaseUnit
   const translate = useTranslate()
   const {
     underlyingAsset: asset,
@@ -43,6 +43,14 @@ export const Approve: React.FC<ApproveProps> = ({ accountId, onNext }) => {
   const toast = useToast()
 
   const userAddress: string | undefined = accountId && fromAccountId(accountId).account
+
+  const estimatedGasCryptoPrecision = useMemo(
+    () =>
+      bnOrZero(estimatedGasCryptoBaseUnit)
+        .div(bn(10).pow(feeAsset?.precision ?? 0))
+        .toFixed(),
+    [estimatedGasCryptoBaseUnit, feeAsset?.precision],
+  )
 
   // user info
   const { state: walletState } = useWallet()
@@ -139,7 +147,7 @@ export const Approve: React.FC<ApproveProps> = ({ accountId, onNext }) => {
       if (!estimatedGasCrypto) return
       dispatch({
         type: FoxyWithdrawActionType.SET_WITHDRAW,
-        payload: { estimatedGasCryptoBaseUnit: estimatedGasCrypto },
+        payload: { estimatedGasCryptoBaseUnit },
       })
       onNext(DefiStep.Confirm)
     } catch (error) {
@@ -154,31 +162,32 @@ export const Approve: React.FC<ApproveProps> = ({ accountId, onNext }) => {
       dispatch({ type: FoxyWithdrawActionType.SET_LOADING, payload: false })
     }
   }, [
-    rewardId,
-    walletState.wallet,
-    userAddress,
-    state?.withdraw,
-    foxyApi,
-    dispatch,
+    asset.precision,
     bip44Params,
     contractAddress,
+    dispatch,
+    estimatedGasCryptoBaseUnit,
+    foxyApi,
     getWithdrawGasEstimate,
     onNext,
-    asset.precision,
+    rewardId,
+    state?.withdraw,
     toast,
     translate,
+    userAddress,
+    walletState.wallet,
   ])
 
   const hasEnoughBalanceForGas = useMemo(
     () =>
-      isSome(estimatedGasCryptoPrecisionBaseUnit) &&
+      isSome(estimatedGasCryptoBaseUnit) &&
       isSome(accountId) &&
       canCoverTxFees({
         feeAsset,
-        estimatedGasCryptoPrecision: estimatedGasCryptoPrecisionBaseUnit,
+        estimatedGasCryptoPrecision: estimatedGasCryptoBaseUnit,
         accountId,
       }),
-    [accountId, feeAsset, estimatedGasCryptoPrecisionBaseUnit],
+    [accountId, feeAsset, estimatedGasCryptoBaseUnit],
   )
 
   const preFooter = useMemo(
@@ -187,10 +196,10 @@ export const Approve: React.FC<ApproveProps> = ({ accountId, onNext }) => {
         accountId={accountId}
         action={DefiAction.Withdraw}
         feeAsset={feeAsset}
-        estimatedGasCryptoPrecision={estimatedGasCryptoPrecisionBaseUnit}
+        estimatedGasCryptoPrecision={estimatedGasCryptoPrecision}
       />
     ),
-    [accountId, feeAsset, estimatedGasCryptoPrecisionBaseUnit],
+    [accountId, feeAsset, estimatedGasCryptoPrecision],
   )
 
   if (!state || !dispatch) return null
@@ -199,11 +208,11 @@ export const Approve: React.FC<ApproveProps> = ({ accountId, onNext }) => {
     <ReusableApprove
       asset={asset}
       feeAsset={feeAsset}
-      estimatedGasFeeCryptoPrecision={bnOrZero(estimatedGasCryptoPrecisionBaseUnit)
+      estimatedGasFeeCryptoPrecision={bnOrZero(estimatedGasCryptoBaseUnit)
         .div(bn(10).pow(feeAsset.precision))
         .toFixed(5)}
       disabled={!hasEnoughBalanceForGas}
-      fiatEstimatedGasFee={bnOrZero(estimatedGasCryptoPrecisionBaseUnit)
+      fiatEstimatedGasFee={bnOrZero(estimatedGasCryptoBaseUnit)
         .div(bn(10).pow(feeAsset.precision))
         .times(feeMarketData.price)
         .toFixed(2)}

--- a/src/features/defi/providers/foxy/components/FoxyManager/Withdraw/components/Approve.tsx
+++ b/src/features/defi/providers/foxy/components/FoxyManager/Withdraw/components/Approve.tsx
@@ -31,7 +31,7 @@ type ApproveProps = StepComponentProps & { accountId: AccountId | undefined }
 export const Approve: React.FC<ApproveProps> = ({ accountId, onNext }) => {
   const foxyApi = getFoxyApi()
   const { state, dispatch } = useContext(WithdrawContext)
-  const estimatedGasCrypto = state?.approve.estimatedGasCrypto
+  const estimatedGasCryptoPrecision = state?.approve.estimatedGasCrypto
   const translate = useTranslate()
   const {
     underlyingAsset: asset,
@@ -171,14 +171,14 @@ export const Approve: React.FC<ApproveProps> = ({ accountId, onNext }) => {
 
   const hasEnoughBalanceForGas = useMemo(
     () =>
-      isSome(estimatedGasCrypto) &&
+      isSome(estimatedGasCryptoPrecision) &&
       isSome(accountId) &&
       canCoverTxFees({
         feeAsset,
-        estimatedGasCrypto,
+        estimatedGasCryptoPrecision,
         accountId,
       }),
-    [accountId, feeAsset, estimatedGasCrypto],
+    [accountId, feeAsset, estimatedGasCryptoPrecision],
   )
 
   const preFooter = useMemo(
@@ -187,10 +187,10 @@ export const Approve: React.FC<ApproveProps> = ({ accountId, onNext }) => {
         accountId={accountId}
         action={DefiAction.Withdraw}
         feeAsset={feeAsset}
-        estimatedGasCrypto={estimatedGasCrypto}
+        estimatedGasCrypto={estimatedGasCryptoPrecision}
       />
     ),
-    [accountId, feeAsset, estimatedGasCrypto],
+    [accountId, feeAsset, estimatedGasCryptoPrecision],
   )
 
   if (!state || !dispatch) return null
@@ -199,11 +199,11 @@ export const Approve: React.FC<ApproveProps> = ({ accountId, onNext }) => {
     <ReusableApprove
       asset={asset}
       feeAsset={feeAsset}
-      cryptoEstimatedGasFee={bnOrZero(estimatedGasCrypto)
+      cryptoEstimatedGasFee={bnOrZero(estimatedGasCryptoPrecision)
         .div(bn(10).pow(feeAsset.precision))
         .toFixed(5)}
       disabled={!hasEnoughBalanceForGas}
-      fiatEstimatedGasFee={bnOrZero(estimatedGasCrypto)
+      fiatEstimatedGasFee={bnOrZero(estimatedGasCryptoPrecision)
         .div(bn(10).pow(feeAsset.precision))
         .times(feeMarketData.price)
         .toFixed(2)}

--- a/src/features/defi/providers/foxy/components/FoxyManager/Withdraw/components/Confirm.tsx
+++ b/src/features/defi/providers/foxy/components/FoxyManager/Withdraw/components/Confirm.tsx
@@ -92,7 +92,7 @@ export const Confirm: React.FC<StepComponentProps & { accountId?: AccountId | un
           contractAddress,
           wallet: walletState.wallet,
           amountDesired: bnOrZero(state.withdraw.cryptoAmount)
-            .times(`1e+${underlyingAsset.precision}`)
+            .times(bn(10).pow(underlyingAsset.precision))
             .decimalPlaces(0),
           type: state.withdraw.withdrawType,
           bip44Params,
@@ -135,7 +135,7 @@ export const Confirm: React.FC<StepComponentProps & { accountId?: AccountId | un
   if (!state || !dispatch) return null
 
   const hasEnoughBalanceForGas = bnOrZero(feeAssetBalance)
-    .minus(bnOrZero(state.withdraw.estimatedGasCryptoBaseUnit).div(`1e+${feeAsset.precision}`))
+    .minus(bnOrZero(state.withdraw.estimatedGasCryptoBaseUnit).div(bn(10).pow(feeAsset.precision)))
     .gte(0)
 
   return (
@@ -191,14 +191,14 @@ export const Confirm: React.FC<StepComponentProps & { accountId?: AccountId | un
               <Amount.Fiat
                 fontWeight='bold'
                 value={bnOrZero(state.withdraw.estimatedGasCryptoBaseUnit)
-                  .div(`1e+${feeAsset.precision}`)
+                  .div(bn(10).pow(feeAsset.precision))
                   .times(feeMarketData.price)
                   .toFixed(2)}
               />
               <Amount.Crypto
                 color='gray.500'
                 value={bnOrZero(state.withdraw.estimatedGasCryptoBaseUnit)
-                  .div(`1e+${feeAsset.precision}`)
+                  .div(bn(10).pow(feeAsset.precision))
                   .toFixed(5)}
                 symbol={feeAsset.symbol}
               />

--- a/src/features/defi/providers/foxy/components/FoxyManager/Withdraw/components/Confirm.tsx
+++ b/src/features/defi/providers/foxy/components/FoxyManager/Withdraw/components/Confirm.tsx
@@ -135,7 +135,7 @@ export const Confirm: React.FC<StepComponentProps & { accountId?: AccountId | un
   if (!state || !dispatch) return null
 
   const hasEnoughBalanceForGas = bnOrZero(feeAssetBalance)
-    .minus(bnOrZero(state.withdraw.estimatedGasCrypto).div(`1e+${feeAsset.precision}`))
+    .minus(bnOrZero(state.withdraw.estimatedGasCryptoBaseUnit).div(`1e+${feeAsset.precision}`))
     .gte(0)
 
   return (
@@ -190,14 +190,14 @@ export const Confirm: React.FC<StepComponentProps & { accountId?: AccountId | un
             <Box textAlign='right'>
               <Amount.Fiat
                 fontWeight='bold'
-                value={bnOrZero(state.withdraw.estimatedGasCrypto)
+                value={bnOrZero(state.withdraw.estimatedGasCryptoBaseUnit)
                   .div(`1e+${feeAsset.precision}`)
                   .times(feeMarketData.price)
                   .toFixed(2)}
               />
               <Amount.Crypto
                 color='gray.500'
-                value={bnOrZero(state.withdraw.estimatedGasCrypto)
+                value={bnOrZero(state.withdraw.estimatedGasCryptoBaseUnit)
                   .div(`1e+${feeAsset.precision}`)
                   .toFixed(5)}
                 symbol={feeAsset.symbol}

--- a/src/features/defi/providers/foxy/components/FoxyManager/Withdraw/components/Confirm.tsx
+++ b/src/features/defi/providers/foxy/components/FoxyManager/Withdraw/components/Confirm.tsx
@@ -112,7 +112,9 @@ export const Confirm: React.FC<StepComponentProps & { accountId?: AccountId | un
         type: FoxyWithdrawActionType.SET_WITHDRAW,
         payload: {
           txStatus: transactionReceipt.status ? 'success' : 'failed',
-          usedGasFee: bnOrZero(bn(gasPrice).times(transactionReceipt.gasUsed)).toFixed(0),
+          usedGasFeeCryptoBaseUnit: bnOrZero(
+            bn(gasPrice).times(transactionReceipt.gasUsed),
+          ).toFixed(0),
         },
       })
       dispatch({ type: FoxyWithdrawActionType.SET_LOADING, payload: false })

--- a/src/features/defi/providers/foxy/components/FoxyManager/Withdraw/components/Status.tsx
+++ b/src/features/defi/providers/foxy/components/FoxyManager/Withdraw/components/Status.tsx
@@ -134,7 +134,7 @@ export const Status: React.FC<StatusProps> = ({ accountId }) => {
                 value={bnOrZero(
                   state.withdraw.txStatus === 'pending'
                     ? state.withdraw.estimatedGasCryptoBaseUnit
-                    : state.withdraw.usedGasFee,
+                    : state.withdraw.usedGasFeeCryptoBaseUnit,
                 )
                   .div(`1e+${feeAsset.precision}`)
                   .times(feeMarketData.price)
@@ -145,7 +145,7 @@ export const Status: React.FC<StatusProps> = ({ accountId }) => {
                 value={bnOrZero(
                   state.withdraw.txStatus === 'pending'
                     ? state.withdraw.estimatedGasCryptoBaseUnit
-                    : state.withdraw.usedGasFee,
+                    : state.withdraw.usedGasFeeCryptoBaseUnit,
                 )
                   .div(`1e+${feeAsset.precision}`)
                   .toFixed(5)}

--- a/src/features/defi/providers/foxy/components/FoxyManager/Withdraw/components/Status.tsx
+++ b/src/features/defi/providers/foxy/components/FoxyManager/Withdraw/components/Status.tsx
@@ -133,7 +133,7 @@ export const Status: React.FC<StatusProps> = ({ accountId }) => {
                 fontWeight='bold'
                 value={bnOrZero(
                   state.withdraw.txStatus === 'pending'
-                    ? state.withdraw.estimatedGasCrypto
+                    ? state.withdraw.estimatedGasCryptoBaseUnit
                     : state.withdraw.usedGasFee,
                 )
                   .div(`1e+${feeAsset.precision}`)
@@ -144,7 +144,7 @@ export const Status: React.FC<StatusProps> = ({ accountId }) => {
                 color='gray.500'
                 value={bnOrZero(
                   state.withdraw.txStatus === 'pending'
-                    ? state.withdraw.estimatedGasCrypto
+                    ? state.withdraw.estimatedGasCryptoBaseUnit
                     : state.withdraw.usedGasFee,
                 )
                   .div(`1e+${feeAsset.precision}`)

--- a/src/features/defi/providers/foxy/components/FoxyManager/Withdraw/components/Withdraw.tsx
+++ b/src/features/defi/providers/foxy/components/FoxyManager/Withdraw/components/Withdraw.tsx
@@ -98,7 +98,7 @@ export const Withdraw: React.FC<
     async (formValues: FoxyWithdrawValues) => {
       if (!(accountAddress && dispatch && rewardId && foxyApi && bip44Params)) return
 
-      const getApproveGasEstimate = async () => {
+      const getApproveGasEstimateCryptoBaseUnit = async () => {
         if (!accountAddress) return
 
         try {
@@ -122,7 +122,7 @@ export const Withdraw: React.FC<
         }
       }
 
-      const getWithdrawGasEstimate = async (withdraw: FoxyWithdrawValues) => {
+      const getWithdrawGasEstimateCryptoBaseUnit = async (withdraw: FoxyWithdrawValues) => {
         if (!accountAddress) return
 
         try {
@@ -131,7 +131,7 @@ export const Withdraw: React.FC<
               tokenContractAddress: rewardId,
               contractAddress,
               amountDesired: bnOrZero(
-                bn(withdraw.cryptoAmount).times(`1e+${asset.precision}`),
+                bn(withdraw.cryptoAmount).times(bn(10).pow(asset.precision)),
               ).decimalPlaces(0),
               userAddress: accountAddress,
               type: withdraw.withdrawType,
@@ -179,11 +179,11 @@ export const Withdraw: React.FC<
 
         // Skip approval step if user allowance is greater than or equal requested deposit amount
         if (allowance.gte(formValues.cryptoAmount)) {
-          const estimatedGasCrypto = await getWithdrawGasEstimate(formValues)
-          if (!estimatedGasCrypto) return
+          const estimatedGasCryptoBaseUnit = await getWithdrawGasEstimateCryptoBaseUnit(formValues)
+          if (!estimatedGasCryptoBaseUnit) return
           dispatch({
             type: FoxyWithdrawActionType.SET_WITHDRAW,
-            payload: { estimatedGasCryptoBaseUnit: estimatedGasCrypto },
+            payload: { estimatedGasCryptoBaseUnit },
           })
           onNext(DefiStep.Confirm)
           dispatch({
@@ -191,11 +191,11 @@ export const Withdraw: React.FC<
             payload: false,
           })
         } else {
-          const estimatedGasCrypto = await getApproveGasEstimate()
-          if (!estimatedGasCrypto) return
+          const estimatedGasCryptoBaseUnit = await getApproveGasEstimateCryptoBaseUnit()
+          if (!estimatedGasCryptoBaseUnit) return
           dispatch({
             type: FoxyWithdrawActionType.SET_APPROVE,
-            payload: { estimatedGasCryptoBaseUnit: estimatedGasCrypto },
+            payload: { estimatedGasCryptoBaseUnit },
           })
           onNext(DefiStep.Approve)
           dispatch({

--- a/src/features/defi/providers/foxy/components/FoxyManager/Withdraw/components/Withdraw.tsx
+++ b/src/features/defi/providers/foxy/components/FoxyManager/Withdraw/components/Withdraw.tsx
@@ -183,7 +183,7 @@ export const Withdraw: React.FC<
           if (!estimatedGasCrypto) return
           dispatch({
             type: FoxyWithdrawActionType.SET_WITHDRAW,
-            payload: { estimatedGasCrypto },
+            payload: { estimatedGasCryptoBaseUnit: estimatedGasCrypto },
           })
           onNext(DefiStep.Confirm)
           dispatch({
@@ -195,7 +195,7 @@ export const Withdraw: React.FC<
           if (!estimatedGasCrypto) return
           dispatch({
             type: FoxyWithdrawActionType.SET_APPROVE,
-            payload: { estimatedGasCrypto },
+            payload: { estimatedGasCryptoBaseUnit: estimatedGasCrypto },
           })
           onNext(DefiStep.Approve)
           dispatch({

--- a/src/features/defi/providers/idle/components/IdleManager/Deposit/DepositCommon.ts
+++ b/src/features/defi/providers/idle/components/IdleManager/Deposit/DepositCommon.ts
@@ -2,7 +2,7 @@ import type { DepositValues } from 'features/defi/components/Deposit/Deposit'
 import type { StakingEarnOpportunityType } from 'state/slices/opportunitiesSlice/types'
 
 type EstimatedGas = {
-  estimatedGasCrypto?: string
+  estimatedGasCryptoBaseUnit?: string
 }
 
 type IdleDepositValues = DepositValues &

--- a/src/features/defi/providers/idle/components/IdleManager/Deposit/DepositCommon.ts
+++ b/src/features/defi/providers/idle/components/IdleManager/Deposit/DepositCommon.ts
@@ -8,7 +8,7 @@ type EstimatedGas = {
 type IdleDepositValues = DepositValues &
   EstimatedGas & {
     txStatus: string
-    usedGasFee: string
+    usedGasFeeCryptoBaseUnit: string
   }
 
 export type IdleDepositState = {

--- a/src/features/defi/providers/idle/components/IdleManager/Deposit/DepositReducer.ts
+++ b/src/features/defi/providers/idle/components/IdleManager/Deposit/DepositReducer.ts
@@ -11,7 +11,7 @@ export const initialState: IdleDepositState = {
     cryptoAmount: '',
     slippage: '',
     txStatus: 'pending',
-    usedGasFee: '',
+    usedGasFeeCryptoBaseUnit: '',
   },
 }
 

--- a/src/features/defi/providers/idle/components/IdleManager/Deposit/components/Approve.tsx
+++ b/src/features/defi/providers/idle/components/IdleManager/Deposit/components/Approve.tsx
@@ -75,7 +75,7 @@ export const Approve: React.FC<IdleApproveProps> = ({ accountId, onNext }) => {
   // notify
   const toast = useToast()
 
-  const getDepositGasEstimate = useCallback(
+  const getDepositGasEstimateCryptoPrecision = useCallback(
     async (deposit: DepositValues): Promise<string | undefined> => {
       if (!(userAddress && opportunity && assetReference && idleInvestor && underlyingAsset)) return
       try {
@@ -94,7 +94,7 @@ export const Approve: React.FC<IdleApproveProps> = ({ accountId, onNext }) => {
           .toString()
       } catch (error) {
         moduleLogger.error(
-          { fn: 'getDepositGasEstimate', error },
+          { fn: 'getDepositGasEstimateCryptoPrecision', error },
           'Error getting deposit gas estimate',
         )
         toast({
@@ -147,7 +147,7 @@ export const Approve: React.FC<IdleApproveProps> = ({ accountId, onNext }) => {
         maxAttempts: 30,
       })
       // Get deposit gas estimate
-      const estimatedGasCrypto = await getDepositGasEstimate(state.deposit)
+      const estimatedGasCrypto = await getDepositGasEstimateCryptoPrecision(state.deposit)
       if (!estimatedGasCrypto) return
       dispatch({
         type: IdleDepositActionType.SET_DEPOSIT,
@@ -185,7 +185,7 @@ export const Approve: React.FC<IdleApproveProps> = ({ accountId, onNext }) => {
     chainAdapter,
     underlyingAsset,
     idleInvestor,
-    getDepositGasEstimate,
+    getDepositGasEstimateCryptoPrecision,
     state?.deposit,
     onNext,
     assets,
@@ -199,7 +199,7 @@ export const Approve: React.FC<IdleApproveProps> = ({ accountId, onNext }) => {
       isSome(estimatedGasCrypto) &&
       canCoverTxFees({
         feeAsset,
-        estimatedGasCrypto,
+        estimatedGasCryptoPrecision: estimatedGasCrypto,
         accountId,
       }),
     [accountId, feeAsset, estimatedGasCrypto],

--- a/src/features/defi/providers/idle/components/IdleManager/Deposit/components/Approve.tsx
+++ b/src/features/defi/providers/idle/components/IdleManager/Deposit/components/Approve.tsx
@@ -69,6 +69,14 @@ export const Approve: React.FC<IdleApproveProps> = ({ accountId, onNext }) => {
   if (!asset) throw new Error(`Asset not found for AssetId ${assetId}`)
   if (!feeAsset) throw new Error(`Fee asset not found for AssetId ${feeAssetId}`)
 
+  const estimatedGasCryptoPrecision = useMemo(
+    () =>
+      bnOrZero(estimatedGasCryptoBaseUnit)
+        .div(bn(10).pow(feeAsset?.precision ?? 0))
+        .toFixed(),
+    [estimatedGasCryptoBaseUnit, feeAsset?.precision],
+  )
+
   // user info
   const { state: walletState } = useWallet()
 
@@ -148,7 +156,6 @@ export const Approve: React.FC<IdleApproveProps> = ({ accountId, onNext }) => {
       })
       // Get deposit gas estimate
       const estimatedGasCryptoBaseUnit = await getDepositGasEstimateCryptoBaseUnit(state.deposit)
-      debugger
       if (!estimatedGasCryptoBaseUnit) return
       dispatch({
         type: IdleDepositActionType.SET_DEPOSIT,
@@ -200,10 +207,10 @@ export const Approve: React.FC<IdleApproveProps> = ({ accountId, onNext }) => {
       isSome(estimatedGasCryptoBaseUnit) &&
       canCoverTxFees({
         feeAsset,
-        estimatedGasCryptoPrecision: estimatedGasCryptoBaseUnit,
+        estimatedGasCryptoPrecision,
         accountId,
       }),
-    [accountId, feeAsset, estimatedGasCryptoBaseUnit],
+    [accountId, estimatedGasCryptoBaseUnit, feeAsset, estimatedGasCryptoPrecision],
   )
 
   const preFooter = useMemo(

--- a/src/features/defi/providers/idle/components/IdleManager/Deposit/components/Approve.tsx
+++ b/src/features/defi/providers/idle/components/IdleManager/Deposit/components/Approve.tsx
@@ -212,7 +212,7 @@ export const Approve: React.FC<IdleApproveProps> = ({ accountId, onNext }) => {
         accountId={accountId}
         action={DefiAction.Deposit}
         feeAsset={feeAsset}
-        estimatedGasCrypto={estimatedGasCryptoBaseUnit}
+        estimatedGasCryptoPrecision={estimatedGasCryptoBaseUnit}
       />
     ),
     [accountId, feeAsset, estimatedGasCryptoBaseUnit],

--- a/src/features/defi/providers/idle/components/IdleManager/Deposit/components/Approve.tsx
+++ b/src/features/defi/providers/idle/components/IdleManager/Deposit/components/Approve.tsx
@@ -219,7 +219,7 @@ export const Approve: React.FC<IdleApproveProps> = ({ accountId, onNext }) => {
         accountId={accountId}
         action={DefiAction.Deposit}
         feeAsset={feeAsset}
-        estimatedGasCryptoPrecision={estimatedGasCryptoBaseUnit}
+        estimatedGasCryptoPrecision={estimatedGasCryptoPrecision}
       />
     ),
     [accountId, feeAsset, estimatedGasCryptoBaseUnit],

--- a/src/features/defi/providers/idle/components/IdleManager/Deposit/components/Approve.tsx
+++ b/src/features/defi/providers/idle/components/IdleManager/Deposit/components/Approve.tsx
@@ -222,7 +222,7 @@ export const Approve: React.FC<IdleApproveProps> = ({ accountId, onNext }) => {
         estimatedGasCryptoPrecision={estimatedGasCryptoPrecision}
       />
     ),
-    [accountId, feeAsset, estimatedGasCryptoBaseUnit],
+    [accountId, feeAsset, estimatedGasCryptoPrecision],
   )
 
   if (!state || !dispatch || !estimatedGasCryptoBaseUnit) return null

--- a/src/features/defi/providers/idle/components/IdleManager/Deposit/components/Confirm.tsx
+++ b/src/features/defi/providers/idle/components/IdleManager/Deposit/components/Confirm.tsx
@@ -199,7 +199,7 @@ export const Confirm: React.FC<ConfirmProps> = ({ accountId, onNext }) => {
   const hasEnoughBalanceForGas = useMemo(
     () =>
       bnOrZero(feeAssetBalance)
-        .minus(bnOrZero(state?.deposit.estimatedGasCrypto).div(`1e+${feeAsset.precision}`))
+        .minus(bnOrZero(state?.deposit.estimatedGasCryptoBaseUnit).div(`1e+${feeAsset.precision}`))
         .gte(0),
     [feeAssetBalance, state?.deposit, feeAsset?.precision],
   )
@@ -244,14 +244,14 @@ export const Confirm: React.FC<ConfirmProps> = ({ accountId, onNext }) => {
             <Box textAlign='right'>
               <Amount.Fiat
                 fontWeight='bold'
-                value={bnOrZero(state.deposit.estimatedGasCrypto)
+                value={bnOrZero(state.deposit.estimatedGasCryptoBaseUnit)
                   .div(`1e+${feeAsset.precision}`)
                   .times(feeMarketData.price)
                   .toFixed(2)}
               />
               <Amount.Crypto
                 color='gray.500'
-                value={bnOrZero(state.deposit.estimatedGasCrypto)
+                value={bnOrZero(state.deposit.estimatedGasCryptoBaseUnit)
                   .div(`1e+${feeAsset.precision}`)
                   .toFixed(5)}
                 symbol={feeAsset.symbol}

--- a/src/features/defi/providers/idle/components/IdleManager/Deposit/components/Deposit.tsx
+++ b/src/features/defi/providers/idle/components/IdleManager/Deposit/components/Deposit.tsx
@@ -185,7 +185,6 @@ export const Deposit: React.FC<DepositProps> = ({
         // Skip approval step if user allowance is greater than requested deposit amount
         if (allowance.gte(formValues.cryptoAmount)) {
           const estimatedGasCryptoBaseUnit = await getDepositGasEstimateCryptoBaseUnit(formValues)
-          debugger
           if (!estimatedGasCryptoBaseUnit) return
           dispatch({
             type: IdleDepositActionType.SET_DEPOSIT,

--- a/src/features/defi/providers/idle/components/IdleManager/Deposit/components/Deposit.tsx
+++ b/src/features/defi/providers/idle/components/IdleManager/Deposit/components/Deposit.tsx
@@ -103,7 +103,7 @@ export const Deposit: React.FC<DepositProps> = ({
   // notify
   const toast = useToast()
 
-  const getDepositGasEstimate = useCallback(
+  const getDepositGasEstimateCryptoPrecision = useCallback(
     async (deposit: DepositValues): Promise<string | undefined> => {
       if (!(userAddress && assetReference && idleInvestor && accountId && opportunityData)) return
       try {
@@ -120,7 +120,7 @@ export const Deposit: React.FC<DepositProps> = ({
           .toString()
       } catch (error) {
         moduleLogger.error(
-          { fn: 'getDepositGasEstimate', error },
+          { fn: 'getDepositGasEstimateCryptoPrecision', error },
           'Error getting deposit gas estimate',
         )
         toast({
@@ -184,7 +184,7 @@ export const Deposit: React.FC<DepositProps> = ({
 
         // Skip approval step if user allowance is greater than requested deposit amount
         if (allowance.gte(formValues.cryptoAmount)) {
-          const estimatedGasCrypto = await getDepositGasEstimate(formValues)
+          const estimatedGasCrypto = await getDepositGasEstimateCryptoPrecision(formValues)
           if (!estimatedGasCrypto) return
           dispatch({
             type: IdleDepositActionType.SET_DEPOSIT,
@@ -228,7 +228,7 @@ export const Deposit: React.FC<DepositProps> = ({
       dispatch,
       idleInvestor,
       asset.precision,
-      getDepositGasEstimate,
+      getDepositGasEstimateCryptoPrecision,
       onNext,
       assetId,
       getApproveGasEstimate,

--- a/src/features/defi/providers/idle/components/IdleManager/Deposit/components/Deposit.tsx
+++ b/src/features/defi/providers/idle/components/IdleManager/Deposit/components/Deposit.tsx
@@ -103,7 +103,7 @@ export const Deposit: React.FC<DepositProps> = ({
   // notify
   const toast = useToast()
 
-  const getDepositGasEstimateCryptoPrecision = useCallback(
+  const getDepositGasEstimateCryptoBaseUnit = useCallback(
     async (deposit: DepositValues): Promise<string | undefined> => {
       if (!(userAddress && assetReference && idleInvestor && accountId && opportunityData)) return
       try {
@@ -120,7 +120,7 @@ export const Deposit: React.FC<DepositProps> = ({
           .toString()
       } catch (error) {
         moduleLogger.error(
-          { fn: 'getDepositGasEstimateCryptoPrecision', error },
+          { fn: 'getDepositGasEstimateCryptoBaseUnit', error },
           'Error getting deposit gas estimate',
         )
         toast({
@@ -184,11 +184,12 @@ export const Deposit: React.FC<DepositProps> = ({
 
         // Skip approval step if user allowance is greater than requested deposit amount
         if (allowance.gte(formValues.cryptoAmount)) {
-          const estimatedGasCrypto = await getDepositGasEstimateCryptoPrecision(formValues)
-          if (!estimatedGasCrypto) return
+          const estimatedGasCryptoBaseUnit = await getDepositGasEstimateCryptoBaseUnit(formValues)
+          debugger
+          if (!estimatedGasCryptoBaseUnit) return
           dispatch({
             type: IdleDepositActionType.SET_DEPOSIT,
-            payload: { estimatedGasCrypto },
+            payload: { estimatedGasCryptoBaseUnit },
           })
           onNext(DefiStep.Confirm)
           dispatch({ type: IdleDepositActionType.SET_LOADING, payload: false })
@@ -206,7 +207,7 @@ export const Deposit: React.FC<DepositProps> = ({
           if (!estimatedGasCrypto) return
           dispatch({
             type: IdleDepositActionType.SET_APPROVE,
-            payload: { estimatedGasCrypto },
+            payload: { estimatedGasCryptoBaseUnit: estimatedGasCrypto },
           })
           onNext(DefiStep.Approve)
           dispatch({ type: IdleDepositActionType.SET_LOADING, payload: false })
@@ -228,7 +229,7 @@ export const Deposit: React.FC<DepositProps> = ({
       dispatch,
       idleInvestor,
       asset.precision,
-      getDepositGasEstimateCryptoPrecision,
+      getDepositGasEstimateCryptoBaseUnit,
       onNext,
       assetId,
       getApproveGasEstimate,

--- a/src/features/defi/providers/idle/components/IdleManager/Deposit/components/Status.tsx
+++ b/src/features/defi/providers/idle/components/IdleManager/Deposit/components/Status.tsx
@@ -70,7 +70,7 @@ export const Status = () => {
         type: IdleDepositActionType.SET_DEPOSIT,
         payload: {
           txStatus: confirmedTransaction.status === 'Confirmed' ? 'success' : 'failed',
-          usedGasFee: confirmedTransaction.fee?.value,
+          usedGasFeeCryptoBaseUnit: confirmedTransaction.fee?.value,
         },
       })
     }
@@ -179,7 +179,7 @@ export const Status = () => {
                 value={bnOrZero(
                   state.deposit.txStatus === 'pending'
                     ? state.deposit.estimatedGasCryptoBaseUnit
-                    : state.deposit.usedGasFee,
+                    : state.deposit.usedGasFeeCryptoBaseUnit,
                 )
                   .div(`1e+${feeAsset.precision}`)
                   .times(feeMarketData.price)
@@ -190,7 +190,7 @@ export const Status = () => {
                 value={bnOrZero(
                   state.deposit.txStatus === 'pending'
                     ? state.deposit.estimatedGasCryptoBaseUnit
-                    : state.deposit.usedGasFee,
+                    : state.deposit.usedGasFeeCryptoBaseUnit,
                 )
                   .div(`1e+${feeAsset.precision}`)
                   .toFixed(5)}

--- a/src/features/defi/providers/idle/components/IdleManager/Deposit/components/Status.tsx
+++ b/src/features/defi/providers/idle/components/IdleManager/Deposit/components/Status.tsx
@@ -178,7 +178,7 @@ export const Status = () => {
                 fontWeight='bold'
                 value={bnOrZero(
                   state.deposit.txStatus === 'pending'
-                    ? state.deposit.estimatedGasCrypto
+                    ? state.deposit.estimatedGasCryptoBaseUnit
                     : state.deposit.usedGasFee,
                 )
                   .div(`1e+${feeAsset.precision}`)
@@ -189,7 +189,7 @@ export const Status = () => {
                 color='gray.500'
                 value={bnOrZero(
                   state.deposit.txStatus === 'pending'
-                    ? state.deposit.estimatedGasCrypto
+                    ? state.deposit.estimatedGasCryptoBaseUnit
                     : state.deposit.usedGasFee,
                 )
                   .div(`1e+${feeAsset.precision}`)

--- a/src/features/defi/providers/idle/components/IdleManager/Withdraw/WithdrawCommon.ts
+++ b/src/features/defi/providers/idle/components/IdleManager/Withdraw/WithdrawCommon.ts
@@ -8,7 +8,7 @@ type EstimatedGas = {
 type IdleWithdrawValues = WithdrawValues &
   EstimatedGas & {
     txStatus: string
-    usedGasFee: string
+    usedGasFeeCryptoBaseUnit: string
   }
 
 export type IdleWithdrawState = {

--- a/src/features/defi/providers/idle/components/IdleManager/Withdraw/WithdrawReducer.ts
+++ b/src/features/defi/providers/idle/components/IdleManager/Withdraw/WithdrawReducer.ts
@@ -11,7 +11,7 @@ export const initialState: IdleWithdrawState = {
     cryptoAmount: '',
     slippage: '',
     txStatus: 'pending',
-    usedGasFee: '',
+    usedGasFeeCryptoBaseUnit: '',
   },
 }
 

--- a/src/features/defi/providers/idle/components/IdleManager/Withdraw/components/Status.tsx
+++ b/src/features/defi/providers/idle/components/IdleManager/Withdraw/components/Status.tsx
@@ -79,7 +79,7 @@ export const Status = () => {
         type: IdleWithdrawActionType.SET_WITHDRAW,
         payload: {
           txStatus: confirmedTransaction.status === 'Confirmed' ? 'success' : 'failed',
-          usedGasFee: confirmedTransaction.fee?.value,
+          usedGasFeeCryptoBaseUnit: confirmedTransaction.fee?.value,
         },
       })
     }
@@ -188,7 +188,7 @@ export const Status = () => {
                 value={bnOrZero(
                   state.withdraw.txStatus === 'pending'
                     ? state.withdraw.estimatedGasCrypto
-                    : state.withdraw.usedGasFee,
+                    : state.withdraw.usedGasFeeCryptoBaseUnit,
                 )
                   .div(`1e+${feeAsset.precision}`)
                   .times(feeMarketData.price)
@@ -199,7 +199,7 @@ export const Status = () => {
                 value={bnOrZero(
                   state.withdraw.txStatus === 'pending'
                     ? state.withdraw.estimatedGasCrypto
-                    : state.withdraw.usedGasFee,
+                    : state.withdraw.usedGasFeeCryptoBaseUnit,
                 )
                   .div(`1e+${feeAsset.precision}`)
                   .toFixed(5)}

--- a/src/features/defi/providers/thorchain-savers/components/ThorchainSaversManager/Deposit/DepositCommon.ts
+++ b/src/features/defi/providers/thorchain-savers/components/ThorchainSaversManager/Deposit/DepositCommon.ts
@@ -2,7 +2,7 @@ import type { DepositValues } from 'features/defi/components/Deposit/Deposit'
 import type { StakingEarnOpportunityType } from 'state/slices/opportunitiesSlice/types'
 
 type EstimatedGas = {
-  estimatedGasCrypto?: string
+  estimatedGasCryptoPrecision?: string
 }
 
 type ThorchainSaversDepositValues = DepositValues &

--- a/src/features/defi/providers/thorchain-savers/components/ThorchainSaversManager/Deposit/DepositCommon.ts
+++ b/src/features/defi/providers/thorchain-savers/components/ThorchainSaversManager/Deposit/DepositCommon.ts
@@ -8,7 +8,6 @@ type EstimatedGas = {
 type ThorchainSaversDepositValues = DepositValues &
   EstimatedGas & {
     txStatus: string
-    usedGasFee: string
     depositFeeCryptoBaseUnit: string
     maybeFromUTXOAccountAddress: string
     sendMax?: boolean

--- a/src/features/defi/providers/thorchain-savers/components/ThorchainSaversManager/Deposit/DepositReducer.ts
+++ b/src/features/defi/providers/thorchain-savers/components/ThorchainSaversManager/Deposit/DepositReducer.ts
@@ -12,7 +12,6 @@ export const initialState: ThorchainSaversDepositState = {
     cryptoAmount: '',
     slippage: '',
     txStatus: 'pending',
-    usedGasFee: '',
     depositFeeCryptoBaseUnit: '',
     maybeFromUTXOAccountAddress: '',
   },

--- a/src/features/defi/providers/thorchain-savers/components/ThorchainSaversManager/Deposit/components/Approve.tsx
+++ b/src/features/defi/providers/thorchain-savers/components/ThorchainSaversManager/Deposit/components/Approve.tsx
@@ -45,7 +45,7 @@ const moduleLogger = logger.child({ namespace: ['YearnDeposit:Approve'] })
 export const Approve: React.FC<YearnApprovalProps> = ({ accountId, onNext }) => {
   const yearnInvestor = useMemo(() => getYearnInvestor(), [])
   const { state, dispatch } = useContext(DepositContext)
-  const estimatedGasCrypto = state?.approve.estimatedGasCryptoPrecision
+  const estimatedGasCryptoPrecision = state?.approve.estimatedGasCryptoPrecision
   const translate = useTranslate()
   const mixpanel = getMixPanel()
   const { query } = useBrowserRouter<DefiQueryParams, DefiParams>()
@@ -200,13 +200,13 @@ export const Approve: React.FC<YearnApprovalProps> = ({ accountId, onNext }) => 
   const hasEnoughBalanceForGas = useMemo(
     () =>
       isSome(accountId) &&
-      isSome(estimatedGasCrypto) &&
+      isSome(estimatedGasCryptoPrecision) &&
       canCoverTxFees({
         feeAsset,
-        estimatedGasCryptoPrecision: estimatedGasCrypto,
+        estimatedGasCryptoPrecision,
         accountId,
       }),
-    [accountId, feeAsset, estimatedGasCrypto],
+    [accountId, feeAsset, estimatedGasCryptoPrecision],
   )
 
   const preFooter = useMemo(
@@ -215,10 +215,10 @@ export const Approve: React.FC<YearnApprovalProps> = ({ accountId, onNext }) => 
         accountId={accountId}
         action={DefiAction.Deposit}
         feeAsset={feeAsset}
-        estimatedGasCryptoPrecision={estimatedGasCrypto}
+        estimatedGasCryptoPrecision={estimatedGasCryptoPrecision}
       />
     ),
-    [accountId, feeAsset, estimatedGasCrypto],
+    [accountId, feeAsset, estimatedGasCryptoPrecision],
   )
 
   useEffect(() => {
@@ -227,7 +227,7 @@ export const Approve: React.FC<YearnApprovalProps> = ({ accountId, onNext }) => 
     }
   }, [hasEnoughBalanceForGas, mixpanel])
 
-  if (!state || !dispatch || !estimatedGasCrypto) return null
+  if (!state || !dispatch || !estimatedGasCryptoPrecision) return null
 
   return (
     <ReusableApprove

--- a/src/features/defi/providers/thorchain-savers/components/ThorchainSaversManager/Deposit/components/Approve.tsx
+++ b/src/features/defi/providers/thorchain-savers/components/ThorchainSaversManager/Deposit/components/Approve.tsx
@@ -78,7 +78,7 @@ export const Approve: React.FC<YearnApprovalProps> = ({ accountId, onNext }) => 
   // notify
   const toast = useToast()
 
-  const getDepositGasEstimate = useCallback(
+  const getDepositGasEstimateCryptoPrecision = useCallback(
     async (deposit: DepositValues): Promise<string | undefined> => {
       if (!(userAddress && opportunity && assetReference && yearnInvestor && underlyingAsset))
         return
@@ -98,7 +98,7 @@ export const Approve: React.FC<YearnApprovalProps> = ({ accountId, onNext }) => 
           .toString()
       } catch (error) {
         moduleLogger.error(
-          { fn: 'getDepositGasEstimate', error },
+          { fn: 'getDepositGasEstimateCryptoPrecision', error },
           'Error getting deposit gas estimate',
         )
         toast({
@@ -151,7 +151,7 @@ export const Approve: React.FC<YearnApprovalProps> = ({ accountId, onNext }) => 
         maxAttempts: 30,
       })
       // Get deposit gas estimate
-      const estimatedGasCrypto = await getDepositGasEstimate(state.deposit)
+      const estimatedGasCrypto = await getDepositGasEstimateCryptoPrecision(state.deposit)
       if (!estimatedGasCrypto) return
       dispatch({
         type: ThorchainSaversDepositActionType.SET_DEPOSIT,
@@ -190,7 +190,7 @@ export const Approve: React.FC<YearnApprovalProps> = ({ accountId, onNext }) => 
     chainAdapter,
     underlyingAsset,
     yearnInvestor,
-    getDepositGasEstimate,
+    getDepositGasEstimateCryptoPrecision,
     state?.deposit,
     onNext,
     toast,
@@ -203,7 +203,7 @@ export const Approve: React.FC<YearnApprovalProps> = ({ accountId, onNext }) => 
       isSome(estimatedGasCrypto) &&
       canCoverTxFees({
         feeAsset,
-        estimatedGasCrypto,
+        estimatedGasCryptoPrecision: estimatedGasCrypto,
         accountId,
       }),
     [accountId, feeAsset, estimatedGasCrypto],

--- a/src/features/defi/providers/thorchain-savers/components/ThorchainSaversManager/Deposit/components/Approve.tsx
+++ b/src/features/defi/providers/thorchain-savers/components/ThorchainSaversManager/Deposit/components/Approve.tsx
@@ -215,7 +215,7 @@ export const Approve: React.FC<YearnApprovalProps> = ({ accountId, onNext }) => 
         accountId={accountId}
         action={DefiAction.Deposit}
         feeAsset={feeAsset}
-        estimatedGasCrypto={estimatedGasCrypto}
+        estimatedGasCryptoPrecision={estimatedGasCrypto}
       />
     ),
     [accountId, feeAsset, estimatedGasCrypto],

--- a/src/features/defi/providers/thorchain-savers/components/ThorchainSaversManager/Deposit/components/Approve.tsx
+++ b/src/features/defi/providers/thorchain-savers/components/ThorchainSaversManager/Deposit/components/Approve.tsx
@@ -151,11 +151,11 @@ export const Approve: React.FC<YearnApprovalProps> = ({ accountId, onNext }) => 
         maxAttempts: 30,
       })
       // Get deposit gas estimate
-      const estimatedGasCrypto = await getDepositGasEstimateCryptoPrecision(state.deposit)
-      if (!estimatedGasCrypto) return
+      const estimatedGasCryptoPrecision = await getDepositGasEstimateCryptoPrecision(state.deposit)
+      if (!estimatedGasCryptoPrecision) return
       dispatch({
         type: ThorchainSaversDepositActionType.SET_DEPOSIT,
-        payload: { estimatedGasCryptoPrecision: estimatedGasCrypto },
+        payload: { estimatedGasCryptoPrecision },
       })
 
       onNext(DefiStep.Confirm)

--- a/src/features/defi/providers/thorchain-savers/components/ThorchainSaversManager/Deposit/components/Approve.tsx
+++ b/src/features/defi/providers/thorchain-savers/components/ThorchainSaversManager/Deposit/components/Approve.tsx
@@ -45,7 +45,7 @@ const moduleLogger = logger.child({ namespace: ['YearnDeposit:Approve'] })
 export const Approve: React.FC<YearnApprovalProps> = ({ accountId, onNext }) => {
   const yearnInvestor = useMemo(() => getYearnInvestor(), [])
   const { state, dispatch } = useContext(DepositContext)
-  const estimatedGasCrypto = state?.approve.estimatedGasCrypto
+  const estimatedGasCrypto = state?.approve.estimatedGasCryptoPrecision
   const translate = useTranslate()
   const mixpanel = getMixPanel()
   const { query } = useBrowserRouter<DefiQueryParams, DefiParams>()
@@ -155,7 +155,7 @@ export const Approve: React.FC<YearnApprovalProps> = ({ accountId, onNext }) => 
       if (!estimatedGasCrypto) return
       dispatch({
         type: ThorchainSaversDepositActionType.SET_DEPOSIT,
-        payload: { estimatedGasCrypto },
+        payload: { estimatedGasCryptoPrecision: estimatedGasCrypto },
       })
 
       onNext(DefiStep.Confirm)
@@ -233,11 +233,11 @@ export const Approve: React.FC<YearnApprovalProps> = ({ accountId, onNext }) => 
     <ReusableApprove
       asset={asset}
       feeAsset={feeAsset}
-      cryptoEstimatedGasFee={bnOrZero(state.approve.estimatedGasCrypto)
+      estimatedGasFeeCryptoPrecision={bnOrZero(state.approve.estimatedGasCryptoPrecision)
         .div(bn(10).pow(feeAsset?.precision))
         .toFixed(5)}
       disabled={!hasEnoughBalanceForGas}
-      fiatEstimatedGasFee={bnOrZero(state.approve.estimatedGasCrypto)
+      fiatEstimatedGasFee={bnOrZero(state.approve.estimatedGasCryptoPrecision)
         .div(bn(10).pow(feeAsset?.precision))
         .times(feeMarketData.price)
         .toFixed(2)}

--- a/src/features/defi/providers/thorchain-savers/components/ThorchainSaversManager/Deposit/components/Confirm.tsx
+++ b/src/features/defi/providers/thorchain-savers/components/ThorchainSaversManager/Deposit/components/Confirm.tsx
@@ -338,7 +338,7 @@ export const Confirm: React.FC<ConfirmProps> = ({ accountId, onNext }) => {
   ])
 
   const getPreDepositInput: () => Promise<SendInput | undefined> = useCallback(async () => {
-    if (!(accountId && assetId && state?.deposit?.estimatedGasCrypto)) return
+    if (!(accountId && assetId && state?.deposit?.estimatedGasCryptoPrecision)) return
 
     try {
       const estimatedFees = await estimateFees(await getEstimateFeesArgs())
@@ -375,7 +375,7 @@ export const Confirm: React.FC<ConfirmProps> = ({ accountId, onNext }) => {
   }, [
     accountId,
     assetId,
-    state?.deposit?.estimatedGasCrypto,
+    state?.deposit?.estimatedGasCryptoPrecision,
     state?.deposit.cryptoAmount,
     getEstimateFeesArgs,
     asset,
@@ -564,9 +564,9 @@ export const Confirm: React.FC<ConfirmProps> = ({ accountId, onNext }) => {
   const hasEnoughBalanceForGas = useMemo(
     () =>
       bnOrZero(assetBalanceCryptoBaseUnit)
-        .minus(state?.deposit.estimatedGasCrypto ?? 0)
+        .minus(state?.deposit.estimatedGasCryptoPrecision ?? 0)
         .gte(0),
-    [assetBalanceCryptoBaseUnit, state?.deposit.estimatedGasCrypto],
+    [assetBalanceCryptoBaseUnit, state?.deposit.estimatedGasCryptoPrecision],
   )
 
   useEffect(() => {

--- a/src/features/defi/providers/thorchain-savers/components/ThorchainSaversManager/Deposit/components/Deposit.tsx
+++ b/src/features/defi/providers/thorchain-savers/components/ThorchainSaversManager/Deposit/components/Deposit.tsx
@@ -153,7 +153,7 @@ export const Deposit: React.FC<DepositProps> = ({
   const toast = useToast()
 
   const supportedEvmChainIds = useMemo(() => getSupportedEvmChainIds(), [])
-  const getDepositGasEstimate = useCallback(
+  const getDepositGasEstimateCryptoPrecision = useCallback(
     async (deposit: DepositValues): Promise<string | undefined> => {
       if (!(userAddress && assetReference && accountId && opportunityData)) return
       try {
@@ -185,7 +185,7 @@ export const Deposit: React.FC<DepositProps> = ({
         return bnOrZero(fastFeeCryptoPrecision).toString()
       } catch (error) {
         moduleLogger.error(
-          { fn: 'getDepositGasEstimate', error },
+          { fn: 'getDepositGasEstimateCryptoPrecision', error },
           'Error getting deposit gas estimate',
         )
         toast({
@@ -217,7 +217,7 @@ export const Deposit: React.FC<DepositProps> = ({
       contextDispatch({ type: ThorchainSaversDepositActionType.SET_DEPOSIT, payload: formValues })
       contextDispatch({ type: ThorchainSaversDepositActionType.SET_LOADING, payload: true })
       try {
-        const estimatedGasCrypto = await getDepositGasEstimate(formValues)
+        const estimatedGasCrypto = await getDepositGasEstimateCryptoPrecision(formValues)
         if (!estimatedGasCrypto) return
         contextDispatch({
           type: ThorchainSaversDepositActionType.SET_DEPOSIT,
@@ -250,7 +250,7 @@ export const Deposit: React.FC<DepositProps> = ({
       userAddress,
       opportunityData,
       contextDispatch,
-      getDepositGasEstimate,
+      getDepositGasEstimateCryptoPrecision,
       onNext,
       assetId,
       toast,

--- a/src/features/defi/providers/thorchain-savers/components/ThorchainSaversManager/Deposit/components/Deposit.tsx
+++ b/src/features/defi/providers/thorchain-savers/components/ThorchainSaversManager/Deposit/components/Deposit.tsx
@@ -217,11 +217,11 @@ export const Deposit: React.FC<DepositProps> = ({
       contextDispatch({ type: ThorchainSaversDepositActionType.SET_DEPOSIT, payload: formValues })
       contextDispatch({ type: ThorchainSaversDepositActionType.SET_LOADING, payload: true })
       try {
-        const estimatedGasCrypto = await getDepositGasEstimateCryptoPrecision(formValues)
-        if (!estimatedGasCrypto) return
+        const estimatedGasCryptoPrecision = await getDepositGasEstimateCryptoPrecision(formValues)
+        if (!estimatedGasCryptoPrecision) return
         contextDispatch({
           type: ThorchainSaversDepositActionType.SET_DEPOSIT,
-          payload: { estimatedGasCrypto },
+          payload: { estimatedGasCryptoPrecision },
         })
         onNext(DefiStep.Confirm)
         contextDispatch({ type: ThorchainSaversDepositActionType.SET_LOADING, payload: false })

--- a/src/features/defi/providers/thorchain-savers/components/ThorchainSaversManager/Deposit/components/Status.tsx
+++ b/src/features/defi/providers/thorchain-savers/components/ThorchainSaversManager/Deposit/components/Status.tsx
@@ -82,7 +82,6 @@ export const Status: React.FC<StatusProps> = ({ accountId }) => {
             type: ThorchainSaversDepositActionType.SET_DEPOSIT,
             payload: {
               txStatus: confirmedTransaction.status === 'Confirmed' ? 'success' : 'failed',
-              usedGasFee: confirmedTransaction.fee?.value,
             },
           })
         }

--- a/src/features/defi/providers/thorchain-savers/components/ThorchainSaversManager/Withdraw/WithdrawCommon.ts
+++ b/src/features/defi/providers/thorchain-savers/components/ThorchainSaversManager/Withdraw/WithdrawCommon.ts
@@ -8,7 +8,6 @@ type EstimatedGas = {
 type ThorchainSaversWithdrawValues = WithdrawValues &
   EstimatedGas & {
     txStatus: string
-    usedGasFee: string
     dustAmountCryptoBaseUnit: string
     withdrawFeeCryptoBaseUnit: string
     maybeFromUTXOAccountAddress: string

--- a/src/features/defi/providers/thorchain-savers/components/ThorchainSaversManager/Withdraw/WithdrawReducer.ts
+++ b/src/features/defi/providers/thorchain-savers/components/ThorchainSaversManager/Withdraw/WithdrawReducer.ts
@@ -11,7 +11,6 @@ export const initialState: ThorchainSaversWithdrawState = {
     cryptoAmount: '',
     slippage: '',
     txStatus: 'pending',
-    usedGasFee: '',
     dustAmountCryptoBaseUnit: '',
     withdrawFeeCryptoBaseUnit: '',
     maybeFromUTXOAccountAddress: '',

--- a/src/features/defi/providers/thorchain-savers/components/ThorchainSaversManager/Withdraw/components/Status.tsx
+++ b/src/features/defi/providers/thorchain-savers/components/ThorchainSaversManager/Withdraw/components/Status.tsx
@@ -81,7 +81,6 @@ export const Status: React.FC<StatusProps> = ({ accountId }) => {
             type: ThorchainSaversWithdrawActionType.SET_WITHDRAW,
             payload: {
               txStatus: confirmedTransaction.status === 'Confirmed' ? 'success' : 'failed',
-              usedGasFee: confirmedTransaction.fee?.value,
             },
           })
         }

--- a/src/features/defi/providers/yearn/components/YearnManager/Deposit/DepositCommon.ts
+++ b/src/features/defi/providers/yearn/components/YearnManager/Deposit/DepositCommon.ts
@@ -9,7 +9,7 @@ type EstimatedGas = {
 type YearnDepositValues = DepositValues &
   EstimatedGas & {
     txStatus: string
-    usedGasFee: string
+    usedGasFeeCryptoBaseUnit: string
   }
 
 // Redux only stores things that are serializable. Class methods are removed when put in state.

--- a/src/features/defi/providers/yearn/components/YearnManager/Deposit/DepositCommon.ts
+++ b/src/features/defi/providers/yearn/components/YearnManager/Deposit/DepositCommon.ts
@@ -3,7 +3,7 @@ import type { DepositValues } from 'features/defi/components/Deposit/Deposit'
 import type { StakingEarnOpportunityType } from 'state/slices/opportunitiesSlice/types'
 
 type EstimatedGas = {
-  estimatedGasCrypto?: string
+  estimatedGasCryptoBaseUnit?: string
 }
 
 type YearnDepositValues = DepositValues &

--- a/src/features/defi/providers/yearn/components/YearnManager/Deposit/DepositReducer.ts
+++ b/src/features/defi/providers/yearn/components/YearnManager/Deposit/DepositReducer.ts
@@ -12,7 +12,7 @@ export const initialState: YearnDepositState = {
     cryptoAmount: '',
     slippage: '',
     txStatus: 'pending',
-    usedGasFee: '',
+    usedGasFeeCryptoBaseUnit: '',
   },
 }
 

--- a/src/features/defi/providers/yearn/components/YearnManager/Deposit/components/Approve.tsx
+++ b/src/features/defi/providers/yearn/components/YearnManager/Deposit/components/Approve.tsx
@@ -41,7 +41,7 @@ const moduleLogger = logger.child({ namespace: ['YearnDeposit:Approve'] })
 export const Approve: React.FC<YearnApprovalProps> = ({ accountId, onNext }) => {
   const yearnInvestor = useMemo(() => getYearnInvestor(), [])
   const { state, dispatch } = useContext(DepositContext)
-  const estimatedGasCrypto = state?.approve.estimatedGasCrypto
+  const estimatedGasCryptoPrecision = state?.approve.estimatedGasCrypto
   const translate = useTranslate()
   const { query } = useBrowserRouter<DefiQueryParams, DefiParams>()
   const { chainId, assetReference } = query
@@ -72,7 +72,7 @@ export const Approve: React.FC<YearnApprovalProps> = ({ accountId, onNext }) => 
   // notify
   const toast = useToast()
 
-  const getDepositGasEstimate = useCallback(
+  const getDepositGasEstimateCryptoPrecision = useCallback(
     async (deposit: DepositValues): Promise<string | undefined> => {
       if (!(userAddress && opportunity && assetReference && yearnInvestor && underlyingAsset))
         return
@@ -92,7 +92,7 @@ export const Approve: React.FC<YearnApprovalProps> = ({ accountId, onNext }) => 
           .toString()
       } catch (error) {
         moduleLogger.error(
-          { fn: 'getDepositGasEstimate', error },
+          { fn: 'getDepositGasEstimateCryptoPrecision', error },
           'Error getting deposit gas estimate',
         )
         toast({
@@ -145,7 +145,7 @@ export const Approve: React.FC<YearnApprovalProps> = ({ accountId, onNext }) => 
         maxAttempts: 30,
       })
       // Get deposit gas estimate
-      const estimatedGasCrypto = await getDepositGasEstimate(state.deposit)
+      const estimatedGasCrypto = await getDepositGasEstimateCryptoPrecision(state.deposit)
       if (!estimatedGasCrypto) return
       dispatch({
         type: YearnDepositActionType.SET_DEPOSIT,
@@ -174,7 +174,7 @@ export const Approve: React.FC<YearnApprovalProps> = ({ accountId, onNext }) => 
     chainAdapter,
     underlyingAsset,
     yearnInvestor,
-    getDepositGasEstimate,
+    getDepositGasEstimateCryptoPrecision,
     state?.deposit,
     onNext,
     toast,
@@ -184,13 +184,13 @@ export const Approve: React.FC<YearnApprovalProps> = ({ accountId, onNext }) => 
   const hasEnoughBalanceForGas = useMemo(
     () =>
       isSome(accountId) &&
-      isSome(estimatedGasCrypto) &&
+      isSome(estimatedGasCryptoPrecision) &&
       canCoverTxFees({
         feeAsset,
-        estimatedGasCrypto,
+        estimatedGasCryptoPrecision,
         accountId,
       }),
-    [accountId, feeAsset, estimatedGasCrypto],
+    [accountId, feeAsset, estimatedGasCryptoPrecision],
   )
 
   const preFooter = useMemo(
@@ -199,13 +199,13 @@ export const Approve: React.FC<YearnApprovalProps> = ({ accountId, onNext }) => 
         accountId={accountId}
         action={DefiAction.Deposit}
         feeAsset={feeAsset}
-        estimatedGasCrypto={estimatedGasCrypto}
+        estimatedGasCrypto={estimatedGasCryptoPrecision}
       />
     ),
-    [accountId, feeAsset, estimatedGasCrypto],
+    [accountId, feeAsset, estimatedGasCryptoPrecision],
   )
 
-  if (!state || !dispatch || !estimatedGasCrypto) return null
+  if (!state || !dispatch || !estimatedGasCryptoPrecision) return null
 
   return (
     <ReusableApprove

--- a/src/features/defi/providers/yearn/components/YearnManager/Deposit/components/Approve.tsx
+++ b/src/features/defi/providers/yearn/components/YearnManager/Deposit/components/Approve.tsx
@@ -61,6 +61,14 @@ export const Approve: React.FC<YearnApprovalProps> = ({ accountId, onNext }) => 
   )
   const feeAsset = useAppSelector(state => selectAssetById(state, feeAssetId ?? ''))
 
+  const estimatedGasCryptoPrecision = useMemo(
+    () =>
+      bnOrZero(estimatedGasCryptoBaseUnit)
+        .div(bn(10).pow(feeAsset?.precision ?? 0))
+        .toFixed(),
+    [estimatedGasCryptoBaseUnit, feeAsset?.precision],
+  )
+
   if (!asset) throw new Error(`Asset not found for AssetId ${assetId}`)
   if (!feeAsset) throw new Error(`Fee asset not found for AssetId ${feeAssetId}`)
 
@@ -187,10 +195,10 @@ export const Approve: React.FC<YearnApprovalProps> = ({ accountId, onNext }) => 
       isSome(estimatedGasCryptoBaseUnit) &&
       canCoverTxFees({
         feeAsset,
-        estimatedGasCryptoPrecision: estimatedGasCryptoBaseUnit,
+        estimatedGasCryptoPrecision,
         accountId,
       }),
-    [accountId, feeAsset, estimatedGasCryptoBaseUnit],
+    [accountId, estimatedGasCryptoBaseUnit, feeAsset, estimatedGasCryptoPrecision],
   )
 
   const preFooter = useMemo(
@@ -199,10 +207,10 @@ export const Approve: React.FC<YearnApprovalProps> = ({ accountId, onNext }) => 
         accountId={accountId}
         action={DefiAction.Deposit}
         feeAsset={feeAsset}
-        estimatedGasCryptoPrecision={estimatedGasCryptoBaseUnit}
+        estimatedGasCryptoPrecision={estimatedGasCryptoPrecision}
       />
     ),
-    [accountId, feeAsset, estimatedGasCryptoBaseUnit],
+    [accountId, feeAsset, estimatedGasCryptoPrecision],
   )
 
   if (!state || !dispatch || !estimatedGasCryptoBaseUnit) return null

--- a/src/features/defi/providers/yearn/components/YearnManager/Deposit/components/Approve.tsx
+++ b/src/features/defi/providers/yearn/components/YearnManager/Deposit/components/Approve.tsx
@@ -199,7 +199,7 @@ export const Approve: React.FC<YearnApprovalProps> = ({ accountId, onNext }) => 
         accountId={accountId}
         action={DefiAction.Deposit}
         feeAsset={feeAsset}
-        estimatedGasCrypto={estimatedGasCryptoBaseUnit}
+        estimatedGasCryptoPrecision={estimatedGasCryptoBaseUnit}
       />
     ),
     [accountId, feeAsset, estimatedGasCryptoBaseUnit],

--- a/src/features/defi/providers/yearn/components/YearnManager/Deposit/components/Confirm.tsx
+++ b/src/features/defi/providers/yearn/components/YearnManager/Deposit/components/Confirm.tsx
@@ -178,7 +178,7 @@ export const Confirm: React.FC<ConfirmProps> = ({ accountId, onNext }) => {
   const hasEnoughBalanceForGas = useMemo(
     () =>
       bnOrZero(feeAssetBalance)
-        .minus(bnOrZero(state?.deposit.estimatedGasCrypto).div(`1e+${feeAsset.precision}`))
+        .minus(bnOrZero(state?.deposit.estimatedGasCryptoBaseUnit).div(`1e+${feeAsset.precision}`))
         .gte(0),
     [feeAssetBalance, state?.deposit, feeAsset?.precision],
   )
@@ -217,14 +217,14 @@ export const Confirm: React.FC<ConfirmProps> = ({ accountId, onNext }) => {
             <Box textAlign='right'>
               <Amount.Fiat
                 fontWeight='bold'
-                value={bnOrZero(state.deposit.estimatedGasCrypto)
+                value={bnOrZero(state.deposit.estimatedGasCryptoBaseUnit)
                   .div(`1e+${feeAsset.precision}`)
                   .times(feeMarketData.price)
                   .toFixed(2)}
               />
               <Amount.Crypto
                 color='gray.500'
-                value={bnOrZero(state.deposit.estimatedGasCrypto)
+                value={bnOrZero(state.deposit.estimatedGasCryptoBaseUnit)
                   .div(`1e+${feeAsset.precision}`)
                   .toFixed(5)}
                 symbol={feeAsset.symbol}

--- a/src/features/defi/providers/yearn/components/YearnManager/Deposit/components/Deposit.tsx
+++ b/src/features/defi/providers/yearn/components/YearnManager/Deposit/components/Deposit.tsx
@@ -186,7 +186,7 @@ export const Deposit: React.FC<DepositProps> = ({
           if (!estimatedGasCrypto) return
           dispatch({
             type: YearnDepositActionType.SET_DEPOSIT,
-            payload: { estimatedGasCrypto },
+            payload: { estimatedGasCryptoBaseUnit: estimatedGasCrypto },
           })
           onNext(DefiStep.Confirm)
           dispatch({ type: YearnDepositActionType.SET_LOADING, payload: false })
@@ -195,7 +195,7 @@ export const Deposit: React.FC<DepositProps> = ({
           if (!estimatedGasCrypto) return
           dispatch({
             type: YearnDepositActionType.SET_APPROVE,
-            payload: { estimatedGasCrypto },
+            payload: { estimatedGasCryptoBaseUnit: estimatedGasCrypto },
           })
           onNext(DefiStep.Approve)
           dispatch({ type: YearnDepositActionType.SET_LOADING, payload: false })

--- a/src/features/defi/providers/yearn/components/YearnManager/Deposit/components/Deposit.tsx
+++ b/src/features/defi/providers/yearn/components/YearnManager/Deposit/components/Deposit.tsx
@@ -99,7 +99,7 @@ export const Deposit: React.FC<DepositProps> = ({
   // notify
   const toast = useToast()
 
-  const getDepositGasEstimate = useCallback(
+  const getDepositGasEstimateCryptoPrecision = useCallback(
     async (deposit: DepositValues): Promise<string | undefined> => {
       if (!(userAddress && assetReference && yearnInvestor && accountId && opportunityData)) return
       try {
@@ -116,7 +116,7 @@ export const Deposit: React.FC<DepositProps> = ({
           .toString()
       } catch (error) {
         moduleLogger.error(
-          { fn: 'getDepositGasEstimate', error },
+          { fn: 'getDepositGasEstimateCryptoPrecision', error },
           'Error getting deposit gas estimate',
         )
         toast({
@@ -182,7 +182,7 @@ export const Deposit: React.FC<DepositProps> = ({
 
         // Skip approval step if user allowance is greater than requested deposit amount
         if (allowance.gte(formValues.cryptoAmount)) {
-          const estimatedGasCrypto = await getDepositGasEstimate(formValues)
+          const estimatedGasCrypto = await getDepositGasEstimateCryptoPrecision(formValues)
           if (!estimatedGasCrypto) return
           dispatch({
             type: YearnDepositActionType.SET_DEPOSIT,
@@ -217,7 +217,7 @@ export const Deposit: React.FC<DepositProps> = ({
       dispatch,
       yearnInvestor,
       asset.precision,
-      getDepositGasEstimate,
+      getDepositGasEstimateCryptoPrecision,
       onNext,
       getApproveGasEstimate,
       toast,

--- a/src/features/defi/providers/yearn/components/YearnManager/Deposit/components/Status.tsx
+++ b/src/features/defi/providers/yearn/components/YearnManager/Deposit/components/Status.tsx
@@ -64,7 +64,7 @@ export const Status = () => {
         type: YearnDepositActionType.SET_DEPOSIT,
         payload: {
           txStatus: confirmedTransaction.status === 'Confirmed' ? 'success' : 'failed',
-          usedGasFee: confirmedTransaction.fee?.value,
+          usedGasFeeCryptoBaseUnit: confirmedTransaction.fee?.value,
         },
       })
     }
@@ -151,7 +151,7 @@ export const Status = () => {
                 value={bnOrZero(
                   state.deposit.txStatus === 'pending'
                     ? state.deposit.estimatedGasCryptoBaseUnit
-                    : state.deposit.usedGasFee,
+                    : state.deposit.usedGasFeeCryptoBaseUnit,
                 )
                   .div(`1e+${feeAsset.precision}`)
                   .times(feeMarketData.price)
@@ -162,7 +162,7 @@ export const Status = () => {
                 value={bnOrZero(
                   state.deposit.txStatus === 'pending'
                     ? state.deposit.estimatedGasCryptoBaseUnit
-                    : state.deposit.usedGasFee,
+                    : state.deposit.usedGasFeeCryptoBaseUnit,
                 )
                   .div(`1e+${feeAsset.precision}`)
                   .toFixed(5)}

--- a/src/features/defi/providers/yearn/components/YearnManager/Deposit/components/Status.tsx
+++ b/src/features/defi/providers/yearn/components/YearnManager/Deposit/components/Status.tsx
@@ -150,7 +150,7 @@ export const Status = () => {
                 fontWeight='bold'
                 value={bnOrZero(
                   state.deposit.txStatus === 'pending'
-                    ? state.deposit.estimatedGasCrypto
+                    ? state.deposit.estimatedGasCryptoBaseUnit
                     : state.deposit.usedGasFee,
                 )
                   .div(`1e+${feeAsset.precision}`)
@@ -161,7 +161,7 @@ export const Status = () => {
                 color='gray.500'
                 value={bnOrZero(
                   state.deposit.txStatus === 'pending'
-                    ? state.deposit.estimatedGasCrypto
+                    ? state.deposit.estimatedGasCryptoBaseUnit
                     : state.deposit.usedGasFee,
                 )
                   .div(`1e+${feeAsset.precision}`)


### PR DESCRIPTION
## Description

`canCoverTxFees` currently takes in an `estimatedGasCrypto` (supposedly *base unit*), divides it by the power of 10 of ETH (or whichever native asset you pass in) to make it a *precision* amount, and subtracts it to the *human* (precision-ish) amount:

https://github.com/shapeshift/web/blob/88b78c7d8f0378b734de32e5d5e0905093d7dea4/src/features/defi/helpers/utils.ts#L35-L37

The assumption here was that a base unit amount would be passed, however, cross-checking the different consumptions, a precision amount is actually passed by most consumers. This results in the balance for gas logic not actually working in many cases, which was spotted in https://github.com/shapeshift/web/issues/4021.

Fixed by always passing precision down for now, since this is the least friction path currently. Going forward, the new vernacular will allow us to change that to base units for more accuracy without much hassle and while ensuring the change is propagated everywhere.

This PR:

- brings the correct `precision` vernacular to the `estimatedGasCrypto` destructured parameter
- brings the correct `human` vernacular to the local `feeAssetBalance` variable
- plumbs the `precision` / `baseUnit` vernacular throughout all variables and methods associated to gas estimation in DeFi modals
- does a bit of types / dead code / pow pow cleanup whilst in the neighborhood

As a result of the precision fix of `canCoverFees` as well of the vernacular plumbing, this makes the discrepancies between base unit / precision amounts being passed more obvious, and consequently fixes a bunch of other consumers alongside it.

## Notice

<!-- Before submitting a pull request, please make sure you have answered the following: -->

- [x] Have you followed the guidelines in our [Contributing]('https://github.com/shapeshift/web/blob/develop/CONTRIBUTING.md) guide?
- [x] Have you checked to ensure there aren't other open [Pull Requests](https://github.com/shapeshift/web/pulls) for the same update/change?

## Pull Request Type

- [x] :bug: Bug fix (Non-breaking Change: Fixes an issue)
- [ ] :hammer_and_wrench: Chore (Non-breaking Change: Doc updates, pkg upgrades, typos, etc..)
- [ ] :nail_care: New Feature (Breaking/Non-breaking Change)

## Issue (if applicable)

N/A

## Risk

<!-----------------------------------------------------------------------------
Outline the scope of your changes and the risk associated with them. You must use your discretion as an engineer to determine the potential impact of your changes.

E.g. an upgrade to `hdwallet` or core state management would be considered higher risk, and might require a full regression test. UI or isolated view changes, or something behind a feature flag may have near zero risk. Small bug fixes might require testing isolated to the specific fix.
------------------------------------------------------------------------------>

Low/medium - the current offenders of wrong `canCoverTxFees` are now fixed, though some others might show regressions.

## Testing

<!-----------------------------------------------------------------------------
We treat every PR to be merged with the same scrutiny as if we were merging directly to production.

Your PR will not be merged if you do not complete the sections below for our engineering and operations teams to test.
------------------------------------------------------------------------------>

### Engineering

<!-----------------------------------------------------------------------------
Include sufficient information here for an engineer to test your PR. This may include how to test locally, in a built environment, changes to infrastructure etc.
------------------------------------------------------------------------------>

- Cross check lib/diffed web implementations to ensure the correct base unit / precision vernacular has been used everywhere
- Cross check diffed web to ensure we are always passing down (possibly converted to, if starting from a base unit) precision amounts down to `<ApprovePreFooter />` and `canCoverTxFees`

### Operations

<!-----------------------------------------------------------------------------
If your changes have a user-facing impact, describe how a non-technical QA team can functionally test your changes in a preview environment.

If they are not user-facing please describe how to test for any regressions that may occur.
------------------------------------------------------------------------------>

- Ensure enough native asset for gas checks are working across opportunities, at deposit and withdrawal, both at confirm and approve steps (no need to broadcast actual Txs)
  - Not enough native asset for gas at approve/confirm step should display a "Not enough <native asset> to cover gas"
  - Enough native asset for gas should let you continue up to the confirm step, without disabled buttons/message

## Screenshots (if applicable)

### This diff

<img width="542" alt="image" src="https://user-images.githubusercontent.com/17035424/224986013-b01f5077-4458-4569-8527-420303f15613.png">
<img width="531" alt="image" src="https://user-images.githubusercontent.com/17035424/224986107-bf1c684b-fd4c-4f9a-a4e6-dc62c94562f4.png">

### Prod

<img width="558" alt="image" src="https://user-images.githubusercontent.com/17035424/224986189-229b543c-acf2-4106-b197-7ebd7a091543.png">
<img width="548" alt="image" src="https://user-images.githubusercontent.com/17035424/224986235-17eda38c-e530-4eb3-8fee-caac6ff905df.png">
