### PR TITLE
fix: fix build cache limit issue

### DIFF
--- a/react-app-rewired/index.ts
+++ b/react-app-rewired/index.ts
@@ -9,6 +9,7 @@ import * as path from 'path'
 import * as ssri from 'ssri'
 import * as webpack from 'webpack'
 import { SubresourceIntegrityPlugin } from 'webpack-subresource-integrity'
+import WorkBoxPlugin from 'workbox-webpack-plugin'
 
 import { cspMeta, headers, serializeCsp } from './headers'
 import { progressPlugin } from './progress'
@@ -323,6 +324,17 @@ const reactAppRewireConfig = {
           }
         : {},
     )
+
+    // after adding BSC chain, the build got even more bloated, so we need to increase the limit
+    // of cached assets, to avoid compiling with warnings, which emit a non-zero exit code, causing the build
+    // to "fail", even though build artefacts are emitted.
+    // https://www.appsloveworld.com/reactjs/100/54/workaround-for-cache-size-limit-in-create-react-app-pwa-service-worker
+    config.plugins?.forEach(plugin => {
+      if (plugin instanceof WorkBoxPlugin.InjectManifest) {
+        // @ts-ignore
+        plugin.config.maximumFileSizeToCacheInBytes = 50 * 1024 * 1024
+      }
+    })
 
     return config
   },

--- a/react-app-rewired/index.ts
+++ b/react-app-rewired/index.ts
@@ -325,6 +325,8 @@ const reactAppRewireConfig = {
         : {},
     )
 
+    const MAXIMUM_FILE_SIZE_TO_CACHE_IN_BYTES = 50 * 1024 * 1024 // 50MB
+
     // after adding BSC chain, the build got even more bloated, so we need to increase the limit
     // of cached assets, to avoid compiling with warnings, which emit a non-zero exit code, causing the build
     // to "fail", even though build artefacts are emitted.
@@ -332,7 +334,7 @@ const reactAppRewireConfig = {
     config.plugins?.forEach(plugin => {
       if (plugin instanceof WorkBoxPlugin.InjectManifest) {
         // @ts-ignore
-        plugin.config.maximumFileSizeToCacheInBytes = 50 * 1024 * 1024
+        plugin.config.maximumFileSizeToCacheInBytes = MAXIMUM_FILE_SIZE_TO_CACHE_IN_BYTES
       }
     })
 


### PR DESCRIPTION
## Description

<!-- Please describe your changes -->

i hate everything about this

the app has become so large (again) that now some other webpack plugin within create react app is bitching about the size of generated assets being too large to be cached

this increases the cache size of the assets - if it works i simply don't care about this approach being nasty

## Notice

<!-- Before submitting a pull request, please make sure you have answered the following: -->

- [x] Have you followed the guidelines in our [Contributing]('https://github.com/shapeshift/web/blob/develop/CONTRIBUTING.md) guide?
- [x] Have you checked to ensure there aren't other open [Pull Requests](https://github.com/shapeshift/web/pulls) for the same update/change?

## Pull Request Type

- [x] :bug: Bug fix (Non-breaking Change: Fixes an issue)
- [ ] :hammer_and_wrench: Chore (Non-breaking Change: Doc updates, pkg upgrades, typos, etc..)
- [ ] :nail_care: New Feature (Breaking/Non-breaking Change)

## Issue (if applicable)

<!-----------------------------------------------------------------------------
If applicable, please link to the github issue and put `closes #XXXX` in your comment to auto-close the issue that your PR fixes.
------------------------------------------------------------------------------>

n/a

## Risk

like everything in life, it's a coin flip - it either works or it doesn't

<!-----------------------------------------------------------------------------
Outline the scope of your changes and the risk associated with them. You must use your discretion as an engineer to determine the potential impact of your changes.

E.g. an upgrade to `hdwallet` or core state management would be considered higher risk, and might require a full regression test. UI or isolated view changes, or something behind a feature flag may have near zero risk. Small bug fixes might require testing isolated to the specific fix.
------------------------------------------------------------------------------>

## Testing

<!-----------------------------------------------------------------------------
We treat every PR to be merged with the same scrutiny as if we were merging directly to production.

Your PR will not be merged if you do not complete the sections below for our engineering and operations teams to test.
------------------------------------------------------------------------------>

### Engineering

pull branch and run the build locally

if you don't see

```
Compiled with warnings.

/static/js/30.fc1b3e4d.js is 7.19 MB, and won't be precached. Configure maximumFileSizeToCacheInBytes to change this limit.
``` we're good

<!-----------------------------------------------------------------------------
Include sufficient information here for an engineer to test your PR. This may include how to test locally, in a built environment, changes to infrastructure etc.
------------------------------------------------------------------------------>

### Operations

not testable by operations

<!-----------------------------------------------------------------------------
If your changes have a user-facing impact, describe how a non-technical QA team can functionally test your changes in a preview environment.

If they are not user-facing please describe how to test for any regressions that may occur.
------------------------------------------------------------------------------>

## Screenshots (if applicable)
