### PR TITLE
fix: osmosis underlyingAssetRatiosBaseUnit

### DIFF
--- a/src/components/EarnDashboard/components/PositionDetails.tsx
+++ b/src/components/EarnDashboard/components/PositionDetails.tsx
@@ -12,7 +12,6 @@ export const PositionDetails: React.FC<AggregatedOpportunitiesByAssetIdReturn> =
   return (
     <Flex px={{ base: 4, md: 6 }} py={{ base: 2, md: 8 }} flexDir='column' gap={{ base: 2, md: 6 }}>
       <ProviderPositions ids={opportunities.staking} assetId={assetId} />
-
       <LpPositions ids={opportunities.lp} assetId={assetId} />
     </Flex>
   )

--- a/src/state/slices/opportunitiesSlice/resolvers/osmosis/index.ts
+++ b/src/state/slices/opportunitiesSlice/resolvers/osmosis/index.ts
@@ -1,5 +1,5 @@
 import type { ToAssetIdArgs } from '@shapeshiftoss/caip'
-import { osmosisAssetId, osmosisChainId, toAssetId } from '@shapeshiftoss/caip'
+import { osmosisChainId, toAssetId } from '@shapeshiftoss/caip'
 import { DefiProvider, DefiType } from 'features/defi/contexts/DefiManagerProvider/DefiCommon'
 import { bn } from 'lib/bignumber/bignumber'
 import { selectAssetById, selectFeatureFlags } from 'state/slices/selectors'
@@ -46,9 +46,8 @@ export const osmosisLpOpportunitiesMetadataResolver = async ({
     const underlyingAssetId1 = generateAssetIdFromOsmosisDenom(pool.pool_assets[1].token.denom)
     const opportunityId = toOpportunityId(toAssetIdParts)
     const asset = selectAssetById(state, assetId)
-    const feeAsset = selectAssetById(state, osmosisAssetId)
 
-    if (!asset || !feeAsset) continue
+    if (!asset) continue
 
     const totalSupply = bn(pool.total_shares.amount)
     const token0Reserves = bn(pool.pool_assets[0].token.amount)

--- a/src/state/slices/opportunitiesSlice/resolvers/osmosis/index.ts
+++ b/src/state/slices/opportunitiesSlice/resolvers/osmosis/index.ts
@@ -46,8 +46,10 @@ export const osmosisLpOpportunitiesMetadataResolver = async ({
     const underlyingAssetId1 = generateAssetIdFromOsmosisDenom(pool.pool_assets[1].token.denom)
     const opportunityId = toOpportunityId(toAssetIdParts)
     const asset = selectAssetById(state, assetId)
+    const underlyingAsset0 = selectAssetById(state, underlyingAssetId0)
+    const underlyingAsset1 = selectAssetById(state, underlyingAssetId1)
 
-    if (!asset) continue
+    if (!asset || !underlyingAsset0 || !underlyingAsset1) continue
 
     const totalSupply = bn(pool.total_shares.amount)
     const token0Reserves = bn(pool.pool_assets[0].token.amount)
@@ -55,11 +57,11 @@ export const osmosisLpOpportunitiesMetadataResolver = async ({
 
     const underlyingAsset0RatioBaseUnit = token0Reserves
       .div(totalSupply)
-      .times(bn(10).pow(asset.precision))
+      .times(bn(10).pow(underlyingAsset0.precision))
       .toFixed()
     const underlyingAsset1RatioBaseUnit = token1Reserves
       .div(totalSupply)
-      .times(bn(10).pow(asset.precision))
+      .times(bn(10).pow(underlyingAsset1.precision))
       .toFixed()
 
     lpOpportunitiesById[opportunityId] = {

--- a/src/state/slices/opportunitiesSlice/resolvers/osmosis/index.ts
+++ b/src/state/slices/opportunitiesSlice/resolvers/osmosis/index.ts
@@ -72,8 +72,6 @@ export const osmosisLpOpportunitiesMetadataResolver = async ({
       ] as const,
       name: pool.name,
     }
-
-    debugger
   }
 
   const data = {

--- a/src/state/slices/opportunitiesSlice/selectors/lpSelectors.ts
+++ b/src/state/slices/opportunitiesSlice/selectors/lpSelectors.ts
@@ -194,11 +194,12 @@ export const selectUnderlyingLpAssetsWithBalancesAndIcons = createSelector(
 
     const underlyingBalances = getUnderlyingAssetIdsBalances({
       cryptoAmountBaseUnit: bnOrZero(lpAssetBalancePrecision)
-        .div(bnOrZero(10).pow(lpAsset?.precision))
+        .times(bnOrZero(10).pow(lpAsset.precision))
         .toString(),
       underlyingAssetIds: opportunityMetadata.underlyingAssetIds,
       underlyingAssetRatiosBaseUnit: opportunityMetadata.underlyingAssetRatiosBaseUnit,
       assets,
+      assetId: lpId,
       marketData,
     })
     const underlyingAssetsIcons = opportunityMetadata.underlyingAssetIds

--- a/src/state/slices/opportunitiesSlice/selectors/lpSelectors.ts
+++ b/src/state/slices/opportunitiesSlice/selectors/lpSelectors.ts
@@ -3,7 +3,7 @@ import type { AccountId, AssetId } from '@shapeshiftoss/caip'
 import { fromAssetId } from '@shapeshiftoss/caip'
 import type { AssetWithBalance } from 'features/defi/components/Overview/Overview'
 import { bn, bnOrZero } from 'lib/bignumber/bignumber'
-import { fromBaseUnit, toBaseUnit } from 'lib/math'
+import { toBaseUnit } from 'lib/math'
 import { isSome } from 'lib/utils'
 import type { ReduxState } from 'state/reducer'
 import { createDeepEqualOutputSelector } from 'state/selector-utils'
@@ -59,18 +59,6 @@ export const selectEarnUserLpOpportunity = createDeepEqualOutputSelector(
 
     if (!opportunityMetadata) return
 
-    const [underlyingToken0AmountCryptoPrecision, underlyingToken1AmountCryptoPrecision] =
-      opportunityMetadata?.underlyingAssetIds.map((assetId, i) =>
-        bnOrZero(lpAssetBalanceCryptoBaseUnit)
-          .times(
-            fromBaseUnit(
-              opportunityMetadata?.underlyingAssetRatiosBaseUnit[i] ?? '0',
-              assets[assetId]?.precision ?? 0,
-            ),
-          )
-          .toFixed(6)
-          .toString(),
-      )
     const [underlyingToken0AmountCryptoBaseUnit, underlyingToken1AmountCryptoBaseUnit] =
       opportunityMetadata?.underlyingAssetIds.map((assetId, i) =>
         bnOrZero(lpAssetBalanceCryptoBaseUnit)
@@ -85,8 +73,6 @@ export const selectEarnUserLpOpportunity = createDeepEqualOutputSelector(
       isLoaded: true,
       contractAddress: fromAssetId(lpId as AssetId).assetReference,
       chainId: fromAssetId(lpId as AssetId).chainId,
-      underlyingToken1AmountCryptoPrecision,
-      underlyingToken0AmountCryptoPrecision,
       underlyingToken0AmountCryptoBaseUnit,
       underlyingToken1AmountCryptoBaseUnit,
       cryptoAmountBaseUnit: lpAssetBalanceCryptoBaseUnit,
@@ -128,19 +114,6 @@ export const selectAggregatedEarnUserLpOpportunity = createDeepEqualOutputSelect
 
     if (!opportunityMetadata) return
 
-    const [underlyingToken0AmountCryptoPrecision, underlyingToken1AmountCryptoPrecision] =
-      opportunityMetadata.underlyingAssetIds.map((assetId, i) =>
-        bnOrZero(aggregatedLpAssetBalance)
-          .times(
-            fromBaseUnit(
-              opportunityMetadata?.underlyingAssetRatiosBaseUnit[i] ?? '0',
-              assets[assetId]?.precision ?? 0,
-            ),
-          )
-          .toFixed(6)
-          .toString(),
-      )
-
     const [underlyingToken0AmountCryptoBaseUnit, underlyingToken1AmountCryptoBaseUnit] =
       opportunityMetadata.underlyingAssetIds.map((assetId, i) =>
         bnOrZero(aggregatedLpAssetBalance)
@@ -155,8 +128,6 @@ export const selectAggregatedEarnUserLpOpportunity = createDeepEqualOutputSelect
       isLoaded: true,
       contractAddress: fromAssetId(lpId as AssetId).assetReference,
       chainId: fromAssetId(lpId as AssetId).chainId,
-      underlyingToken1AmountCryptoPrecision,
-      underlyingToken0AmountCryptoPrecision,
       underlyingToken0AmountCryptoBaseUnit,
       underlyingToken1AmountCryptoBaseUnit,
       cryptoAmountPrecision: aggregatedLpAssetBalance,

--- a/src/state/slices/opportunitiesSlice/utils.ts
+++ b/src/state/slices/opportunitiesSlice/utils.ts
@@ -57,6 +57,7 @@ export const toOpportunityId = (...[args]: Parameters<typeof toAssetId>) =>
   toAssetId(args) as OpportunityId
 
 type GetUnderlyingAssetIdsBalancesArgs = {
+  assetId?: AssetId
   cryptoAmountBaseUnit: string
   assets: Partial<Record<AssetId, Asset>>
   marketData: Partial<Record<AssetId, MarketData>>
@@ -74,22 +75,24 @@ export const getUnderlyingAssetIdsBalances: GetUnderlyingAssetIdsBalances = ({
   underlyingAssetRatiosBaseUnit,
   cryptoAmountBaseUnit,
   assets,
+  assetId,
   marketData,
 }) => {
   return Object.values(underlyingAssetIds).reduce<GetUnderlyingAssetIdsBalancesReturn>(
     (acc, underlyingAssetId, index) => {
       const underlyingAsset = assets[underlyingAssetId]
+      const asset = assets[assetId ?? '']
       const marketDataPrice = marketData[underlyingAssetId]?.price
       if (!underlyingAsset) return acc
       debugger
       const fiatAmount = bnOrZero(cryptoAmountBaseUnit)
         .times(fromBaseUnit(underlyingAssetRatiosBaseUnit[index], underlyingAsset.precision))
-        .div(bnOrZero(10).pow(underlyingAsset?.precision))
+        .div(bnOrZero(10).pow(asset?.precision ?? underlyingAsset.precision))
         .times(marketDataPrice ?? 0)
         .toString()
       const cryptoBalancePrecision = bnOrZero(cryptoAmountBaseUnit)
         .times(fromBaseUnit(underlyingAssetRatiosBaseUnit[index], underlyingAsset.precision))
-        .div(bnOrZero(10).pow(underlyingAsset?.precision))
+        .div(bnOrZero(10).pow(asset?.precision ?? underlyingAsset?.precision))
         .toString()
       acc[underlyingAssetId] = { fiatAmount, cryptoBalancePrecision }
       return acc

--- a/src/state/slices/opportunitiesSlice/utils.ts
+++ b/src/state/slices/opportunitiesSlice/utils.ts
@@ -84,7 +84,6 @@ export const getUnderlyingAssetIdsBalances: GetUnderlyingAssetIdsBalances = ({
       const asset = assets[assetId ?? '']
       const marketDataPrice = marketData[underlyingAssetId]?.price
       if (!underlyingAsset) return acc
-      debugger
       const fiatAmount = bnOrZero(cryptoAmountBaseUnit)
         .times(fromBaseUnit(underlyingAssetRatiosBaseUnit[index], underlyingAsset.precision))
         .div(bnOrZero(10).pow(asset?.precision ?? underlyingAsset.precision))

--- a/src/state/slices/opportunitiesSlice/utils.ts
+++ b/src/state/slices/opportunitiesSlice/utils.ts
@@ -84,16 +84,16 @@ export const getUnderlyingAssetIdsBalances: GetUnderlyingAssetIdsBalances = ({
       const asset = assets[assetId ?? '']
       const marketDataPrice = marketData[underlyingAssetId]?.price
       if (!underlyingAsset) return acc
-      const fiatAmount = bnOrZero(cryptoAmountBaseUnit)
-        .times(fromBaseUnit(underlyingAssetRatiosBaseUnit[index], underlyingAsset.precision))
-        .div(bnOrZero(10).pow(asset?.precision ?? underlyingAsset.precision))
-        .times(marketDataPrice ?? 0)
-        .toString()
+
       const cryptoBalancePrecision = bnOrZero(cryptoAmountBaseUnit)
         .times(fromBaseUnit(underlyingAssetRatiosBaseUnit[index], underlyingAsset.precision))
         .div(bnOrZero(10).pow(asset?.precision ?? underlyingAsset?.precision))
-        .toString()
-      acc[underlyingAssetId] = { fiatAmount, cryptoBalancePrecision }
+
+      const fiatAmount = cryptoBalancePrecision.times(marketDataPrice ?? 0).toString()
+      acc[underlyingAssetId] = {
+        fiatAmount,
+        cryptoBalancePrecision: cryptoBalancePrecision.toFixed(),
+      }
       return acc
     },
     {},

--- a/src/state/slices/opportunitiesSlice/utils.ts
+++ b/src/state/slices/opportunitiesSlice/utils.ts
@@ -81,6 +81,7 @@ export const getUnderlyingAssetIdsBalances: GetUnderlyingAssetIdsBalances = ({
       const underlyingAsset = assets[underlyingAssetId]
       const marketDataPrice = marketData[underlyingAssetId]?.price
       if (!underlyingAsset) return acc
+      debugger
       const fiatAmount = bnOrZero(cryptoAmountBaseUnit)
         .times(fromBaseUnit(underlyingAssetRatiosBaseUnit[index], underlyingAsset.precision))
         .div(bnOrZero(10).pow(underlyingAsset?.precision))


### PR DESCRIPTION
## Description

This PR:

- implements `underlyingAssetRatiosBaseUnit` which was wrong for Osmosis LP resolver
- removes `underlyingAssetsCryptoPrecision` and a bunch of associated effect/state fields fluff
- removes unused `underlyingToken0AmountCryptoPrecision` and `underlyingToken1AmountCryptoPrecision` for osmosis
- fixes `getUnderlyingAssetIdsBalances` logic which was dividing the final *LP amount * ratio* number by `underlyingAssetPrecision`, where this number should eventually be divided by the *lp* asset (the one which precision we originally start from, since we're starting from an LP token amount, not an underlying amount)
- fixes consumption of `getUnderlyingAssetIdsBalances` in  `selectUnderlyingLpAssetsWithBalancesAndIcons` where we passed what was intended to be`cryptoAmountBaseUnit` , but was actually a precision amount divided by the precision exponent instead of multiplying it by it 

## Notice

<!-- Before submitting a pull request, please make sure you have answered the following: -->

- [x] Have you followed the guidelines in our [Contributing]('https://github.com/shapeshift/web/blob/develop/CONTRIBUTING.md) guide?
- [x] Have you checked to ensure there aren't other open [Pull Requests](https://github.com/shapeshift/web/pulls) for the same update/change?

## Pull Request Type

- [x] :bug: Bug fix (Non-breaking Change: Fixes an issue)
- [ ] :hammer_and_wrench: Chore (Non-breaking Change: Doc updates, pkg upgrades, typos, etc..)
- [ ] :nail_care: New Feature (Breaking/Non-breaking Change)

## Issue (if applicable)

N/A

## Risk

<!-----------------------------------------------------------------------------
Outline the scope of your changes and the risk associated with them. You must use your discretion as an engineer to determine the potential impact of your changes.

E.g. an upgrade to `hdwallet` or core state management would be considered higher risk, and might require a full regression test. UI or isolated view changes, or something behind a feature flag may have near zero risk. Small bug fixes might require testing isolated to the specific fix.
------------------------------------------------------------------------------>

Medium - amounts might be borked all over the DeFi section, test accordingly:

## Testing

<!-----------------------------------------------------------------------------
We treat every PR to be merged with the same scrutiny as if we were merging directly to production.

Your PR will not be merged if you do not complete the sections below for our engineering and operations teams to test.
------------------------------------------------------------------------------>

- Underlying amounts should show no regressions across all overview modals, LP in particular:
 - Osmosis LPshould show no regressions (numbers might be a tad bit different since we're not using market data to calculate them anymore so except smolish discrepancy which actually mean more accuracy)
 - ETH/FOX LP overview should be great again
- LP/staking assets (both the LP asset as well as asset 0 and 1) should show no regressions at deposit and withdraw steps
- DeFi earn row/cards amounts should show no regressions

### Engineering

<!-----------------------------------------------------------------------------
Include sufficient information here for an engineer to test your PR. This may include how to test locally, in a built environment, changes to infrastructure etc.
------------------------------------------------------------------------------>

- Fixes look sane
- The new DeFi earn grouping should now show correct data for Osmosis LP with the `DefiDashboard` flag on (correct data can be tested either by using Keplr and comparing with Osmosis UI, or by going to withdraw in your opportunity and ensuring values match. Note that if testing with the latter, defi earn grouping is doing an aggregation over accounts so you'll have to add up all values)

**Note that for the latter, `DefiDashboard` is still under flag and this is an improvement in the actual amounts only and doesn't change the precision, which is still borked in the defi earn grouping - to be tackled in a separate PR. Only ensure that the amounts are looking sane, they're still off by ~12 digits. Ops, no need to test this**


### Operations

<!-----------------------------------------------------------------------------
If your changes have a user-facing impact, describe how a non-technical QA team can functionally test your changes in a preview environment.

If they are not user-facing please describe how to test for any regressions that may occur.
------------------------------------------------------------------------------>

- ☝🏽 

## Screenshots (if applicable)

### This diff

![image](https://user-images.githubusercontent.com/17035424/225647014-88cf40d3-0917-4f1e-92cd-79d73dfad3ae.png)
![image](https://user-images.githubusercontent.com/17035424/225648248-929ff56a-cac7-4276-ae3a-644efa1d68b8.png)
![image](https://user-images.githubusercontent.com/17035424/225648184-5526e7ae-06d3-4c6e-8fb6-b2abdc97ba59.png)

### Prod

![image](https://user-images.githubusercontent.com/17035424/225647750-d58647fe-a386-4225-837f-04ea8fab4687.png)
![image](https://user-images.githubusercontent.com/17035424/225648314-e204ed19-1cfd-416a-ad83-ea5e44befd96.png)
![image](https://user-images.githubusercontent.com/17035424/225648120-04157967-0b83-4f60-ac0c-37d876be5db5.png)
