### PR TITLE
fix: dynamic THORSwapper slippage

### DIFF
--- a/src/components/Trade/TradeConfirm/TradeConfirm.tsx
+++ b/src/components/Trade/TradeConfirm/TradeConfirm.tsx
@@ -49,6 +49,7 @@ import {
 } from 'state/slices/selectors'
 import { serializeTxIndex } from 'state/slices/txHistorySlice/utils'
 import { useAppSelector } from 'state/store'
+import { selectSlippage } from 'state/zustand/swapperStore/selectors'
 import { useSwapperStore } from 'state/zustand/swapperStore/useSwapperStore'
 
 import { TradeRoutePaths } from '../types'
@@ -83,7 +84,7 @@ export const TradeConfirm = () => {
   const trade = useSwapperStore(state => state.trade)
   const fees = useSwapperStore(state => state.fees)
   const feeAssetFiatRate = useSwapperStore(state => state.feeAssetFiatRate)
-  const slippage = useSwapperStore(state => state.slippage)
+  const slippage = useSwapperStore(selectSlippage)
   const buyAssetAccountId = useSwapperStore(state => state.buyAssetAccountId)
   const sellAssetAccountId = useSwapperStore(state => state.sellAssetAccountId)
   const buyAmountCryptoPrecision = useSwapperStore(state => state.buyAmountCryptoPrecision)

--- a/src/components/Trade/TradeInput.tsx
+++ b/src/components/Trade/TradeInput.tsx
@@ -39,6 +39,7 @@ import {
   selectPortfolioCryptoHumanBalanceByFilter,
 } from 'state/slices/selectors'
 import { useAppSelector } from 'state/store'
+import { selectSlippage } from 'state/zustand/swapperStore/selectors'
 import { useSwapperStore } from 'state/zustand/swapperStore/useSwapperStore'
 import { breakpoints } from 'theme/theme'
 
@@ -73,7 +74,7 @@ export const TradeInput = () => {
   )
   const activeQuote = useSwapperStore(state => state.activeSwapperWithMetadata?.quote)
   const fees = useSwapperStore(state => state.fees)
-  const slippage = useSwapperStore(state => state.slippage)
+  const slippage = useSwapperStore(selectSlippage)
   const updateFees = useSwapperStore(state => state.updateFees)
   const updateTrade = useSwapperStore(state => state.updateTrade)
   const updateAction = useSwapperStore(state => state.updateAction)

--- a/src/components/Trade/hooks/useSwapper/useSwapper.tsx
+++ b/src/components/Trade/hooks/useSwapper/useSwapper.tsx
@@ -22,6 +22,7 @@ import {
   selectPortfolioAccountMetadataByAccountId,
 } from 'state/slices/selectors'
 import { useAppSelector } from 'state/store'
+import { selectSlippage } from 'state/zustand/swapperStore/selectors'
 import { useSwapperStore } from 'state/zustand/swapperStore/useSwapperStore'
 
 /*
@@ -35,7 +36,7 @@ export const useSwapper = () => {
   const buyAssetAccountId = useSwapperStore(state => state.buyAssetAccountId)
   const isSendMax = useSwapperStore(state => state.isSendMax)
   const isExactAllowance = useSwapperStore(state => state.isExactAllowance)
-  const slippage = useSwapperStore(state => state.slippage)
+  const slippage = useSwapperStore(selectSlippage)
   const receiveAddress = useSwapperStore(state => state.receiveAddress)
   const buyAsset = useSwapperStore(state => state.buyAsset)
   const sellAsset = useSwapperStore(state => state.sellAsset)

--- a/src/state/zustand/swapperStore/selectors.ts
+++ b/src/state/zustand/swapperStore/selectors.ts
@@ -1,0 +1,5 @@
+import { DEFAULT_SLIPPAGE } from 'constants/constants'
+import type { SwapperState } from 'state/zustand/swapperStore/useSwapperStore'
+
+export const selectSlippage = (state: SwapperState) =>
+  state.activeSwapperWithMetadata?.quote.recommendedSlippage ?? DEFAULT_SLIPPAGE

--- a/src/state/zustand/swapperStore/types.ts
+++ b/src/state/zustand/swapperStore/types.ts
@@ -20,7 +20,6 @@ export type SwapperStore<C extends KnownChainIds = KnownChainIds> = {
   feeAssetFiatRate?: string
   action: TradeAmountInputField
   isExactAllowance: boolean
-  slippage: string
   isSendMax: boolean
   amount: string
   receiveAddress?: string
@@ -51,7 +50,6 @@ export type SwapperAction = {
   clearAmounts: () => void
   updateAction: (action: SwapperStore['action']) => void
   updateIsExactAllowance: (isExactAllowance: SwapperStore['isExactAllowance']) => void
-  updateSlippage: (slippage: SwapperStore['slippage']) => void
   updateIsSendMax: (isSendMax: SwapperStore['isSendMax']) => void
   updateAmount: (amount: SwapperStore['amount']) => void
   updateReceiveAddress: (receiveAddress: SwapperStore['receiveAddress']) => void

--- a/src/state/zustand/swapperStore/useSwapperStore.ts
+++ b/src/state/zustand/swapperStore/useSwapperStore.ts
@@ -1,5 +1,4 @@
 import type { KnownChainIds } from '@shapeshiftoss/types'
-import { DEFAULT_SLIPPAGE } from 'constants/constants'
 import { create } from 'zustand'
 import { devtools } from 'zustand/middleware'
 import { immer } from 'zustand/middleware/immer'
@@ -29,7 +28,6 @@ export const useSwapperStore = (() => {
           buyAmountFiat: '0',
           amount: '0',
           isExactAllowance: false,
-          slippage: DEFAULT_SLIPPAGE,
           action: TradeAmountInputField.SELL_CRYPTO,
           isSendMax: false,
           buyAmountCryptoPrecision: '0',
@@ -105,7 +103,6 @@ export const useSwapperStore = (() => {
               `swapper/toggleIsExactAllowance`,
             )
           },
-          updateSlippage: createUpdateAction(set, 'slippage'),
           updateAction: createUpdateAction(set, 'action'),
           updateIsSendMax: createUpdateAction(set, 'isSendMax'),
           updateReceiveAddress: createUpdateAction(set, 'receiveAddress'),


### PR DESCRIPTION
## Description

We are not correctly using the dynamic slippage value from THORSwapper, and are instead using the default of `0.2%` for all trades.

This PR fixes that bug, and adds a selector on the zustand swapper store to access it, better normalising the state.

## Notice

- [x] Have you followed the guidelines in our [Contributing]('https://github.com/shapeshift/web/blob/develop/CONTRIBUTING.md) guide?
- [x] Have you checked to ensure there aren't other open [Pull Requests](https://github.com/shapeshift/web/pulls) for the same update/change?

## Pull Request Type

- [x] :bug: Bug fix (Non-breaking Change: Fixes an issue)
- [ ] :hammer_and_wrench: Chore (Non-breaking Change: Doc updates, pkg upgrades, typos, etc..)
- [ ] :nail_care: New Feature (Breaking/Non-breaking Change)

## Issue (if applicable)

N/A, noticed a comment in #general: https://discord.com/channels/554694662431178782/554694662896615436/1086852480484253737

## Risk

Small, only affects the slippage used in a trade. If it's too low (as it currently is for very large trades) the trade will simply not go through.

## Testing

When performing a THORSwap trade we should see a dynamic slippage value instead of the default 0.2%.

<img width="727" alt="Screenshot 2023-03-20 at 6 50 51 pm" src="https://user-images.githubusercontent.com/97164662/226278031-46587482-8591-499e-9f84-23149dc26b05.png">

### Engineering

☝️ 

### Operations

☝️

## Screenshots (if applicable)

N/A