### PR TITLE
chore: use swapper selectors

### DIFF
--- a/src/components/Approval/Approval.tsx
+++ b/src/components/Approval/Approval.tsx
@@ -35,6 +35,7 @@ import { bn, bnOrZero } from 'lib/bignumber/bignumber'
 import { logger } from 'lib/logger'
 import { selectFeeAssetById, selectFiatToUsdRate } from 'state/slices/selectors'
 import { useAppSelector } from 'state/store'
+import { selectQuote } from 'state/zustand/swapperStore/selectors'
 import { useSwapperStore } from 'state/zustand/swapperStore/useSwapperStore'
 import { theme } from 'theme/theme'
 
@@ -53,7 +54,7 @@ export const Approval = () => {
     formState: { isSubmitting },
   } = useFormContext()
 
-  const activeQuote = useSwapperStore(state => state.activeSwapperWithMetadata?.quote)
+  const activeQuote = useSwapperStore(selectQuote)
   const feeAssetFiatRate = useSwapperStore(state => state.feeAssetFiatRate)
   const isExactAllowance = useSwapperStore(state => state.isExactAllowance)
   const toggleIsExactAllowance = useSwapperStore(state => state.toggleIsExactAllowance)

--- a/src/components/Trade/TradeInput.tsx
+++ b/src/components/Trade/TradeInput.tsx
@@ -40,6 +40,7 @@ import {
 } from 'state/slices/selectors'
 import { useAppSelector } from 'state/store'
 import {
+  selectCheckApprovalNeededForWallet,
   selectQuote,
   selectSlippage,
   selectSwapperSupportsCrossAccountTrade,
@@ -110,21 +111,15 @@ export const TradeInput = () => {
     state => state.updateSellAmountCryptoPrecision,
   )
   const swapperSupportsCrossAccountTrade = useSwapperStore(selectSwapperSupportsCrossAccountTrade)
+  const checkApprovalNeeded = useSwapperStore(selectCheckApprovalNeededForWallet)
 
-  const {
-    checkApprovalNeeded,
-    getTrade,
-    getSupportedSellableAssets,
-    getSupportedBuyAssetsFromSellAsset,
-  } = useSwapper()
+  const { getTrade, getSupportedSellableAssets, getSupportedBuyAssetsFromSellAsset } = useSwapper()
   const translate = useTranslate()
   const history = useHistory()
   const mixpanel = getMixPanel()
   const borderColor = useColorModeValue('gray.100', 'gray.750')
   const { handleSubmit } = useFormContext()
-  const {
-    state: { wallet },
-  } = useWallet()
+  const wallet = useWallet().state.wallet
   const tradeAmountConstants = useGetTradeAmounts()
   const { assetSearch } = useModal()
   const { handleAssetClick } = useTradeRoutes()
@@ -311,7 +306,8 @@ export const TradeInput = () => {
           [compositeSellAsset]: sellAmountCryptoPrecision,
         })
       }
-      const isApprovalNeeded = await checkApprovalNeeded()
+      if (!wallet) throw new Error('No wallet available')
+      const isApprovalNeeded = await checkApprovalNeeded(wallet)
       if (isApprovalNeeded) {
         history.push({ pathname: TradeRoutePaths.Approval })
         return
@@ -337,6 +333,7 @@ export const TradeInput = () => {
     sellAsset,
     swapperName,
     updateTrade,
+    wallet,
   ])
 
   const onSellAssetInputChange: TradeAssetInputProps['onChange'] = useCallback(

--- a/src/components/Trade/TradeInput.tsx
+++ b/src/components/Trade/TradeInput.tsx
@@ -39,7 +39,7 @@ import {
   selectPortfolioCryptoHumanBalanceByFilter,
 } from 'state/slices/selectors'
 import { useAppSelector } from 'state/store'
-import { selectSlippage } from 'state/zustand/swapperStore/selectors'
+import { selectQuote, selectSlippage } from 'state/zustand/swapperStore/selectors'
 import { useSwapperStore } from 'state/zustand/swapperStore/useSwapperStore'
 import { breakpoints } from 'theme/theme'
 
@@ -72,7 +72,7 @@ export const TradeInput = () => {
   const updateSelectedBuyAssetAccountId = useSwapperStore(
     state => state.updateSelectedBuyAssetAccountId,
   )
-  const activeQuote = useSwapperStore(state => state.activeSwapperWithMetadata?.quote)
+  const activeQuote = useSwapperStore(selectQuote)
   const fees = useSwapperStore(state => state.fees)
   const slippage = useSwapperStore(selectSlippage)
   const updateFees = useSwapperStore(state => state.updateFees)

--- a/src/components/Trade/TradeInput.tsx
+++ b/src/components/Trade/TradeInput.tsx
@@ -39,7 +39,11 @@ import {
   selectPortfolioCryptoHumanBalanceByFilter,
 } from 'state/slices/selectors'
 import { useAppSelector } from 'state/store'
-import { selectQuote, selectSlippage } from 'state/zustand/swapperStore/selectors'
+import {
+  selectQuote,
+  selectSlippage,
+  selectSwapperSupportsCrossAccountTrade,
+} from 'state/zustand/swapperStore/selectors'
 import { useSwapperStore } from 'state/zustand/swapperStore/useSwapperStore'
 import { breakpoints } from 'theme/theme'
 
@@ -105,13 +109,13 @@ export const TradeInput = () => {
   const updateSellAmountCryptoPrecision = useSwapperStore(
     state => state.updateSellAmountCryptoPrecision,
   )
+  const swapperSupportsCrossAccountTrade = useSwapperStore(selectSwapperSupportsCrossAccountTrade)
 
   const {
     checkApprovalNeeded,
     getTrade,
     getSupportedSellableAssets,
     getSupportedBuyAssetsFromSellAsset,
-    swapperSupportsCrossAccountTrade,
   } = useSwapper()
   const translate = useTranslate()
   const history = useHistory()

--- a/src/components/Trade/hooks/useAccountsService.tsx
+++ b/src/components/Trade/hooks/useAccountsService.tsx
@@ -1,8 +1,8 @@
 import { useEffect, useMemo } from 'react'
-import { useSwapper } from 'components/Trade/hooks/useSwapper/useSwapper'
 import { selectHighestFiatBalanceAccountByAssetId } from 'state/slices/portfolioSlice/selectors'
 import { selectFirstAccountIdByChainId } from 'state/slices/selectors'
 import { useAppSelector } from 'state/store'
+import { selectSwapperSupportsCrossAccountTrade } from 'state/zustand/swapperStore/selectors'
 import { useSwapperStore } from 'state/zustand/swapperStore/useSwapperStore'
 
 /*
@@ -10,9 +10,6 @@ The Accounts Service is responsible for reacting to changes to trade assets and 
 It sets sellAssetAccountId and buyAssetAccountId properties.
 */
 export const useAccountsService = () => {
-  // Custom hooks
-  const { swapperSupportsCrossAccountTrade } = useSwapper()
-
   // Selectors
   const stateBuyAssetAccountId = useSwapperStore(state => state.buyAssetAccountId)
   const stateSellAssetAccountId = useSwapperStore(state => state.sellAssetAccountId)
@@ -23,6 +20,7 @@ export const useAccountsService = () => {
   const bestTradeSwapper = useSwapperStore(state => state.activeSwapperWithMetadata?.swapper)
   const buyAsset = useSwapperStore(state => state.buyAsset)
   const sellAsset = useSwapperStore(state => state.sellAsset)
+  const swapperSupportsCrossAccountTrade = useSwapperStore(selectSwapperSupportsCrossAccountTrade)
 
   const sellAssetId = sellAsset?.assetId
   const buyAssetId = buyAsset?.assetId

--- a/src/components/Trade/hooks/useFeesService.tsx
+++ b/src/components/Trade/hooks/useFeesService.tsx
@@ -3,6 +3,7 @@ import { useEffect } from 'react'
 import { getFormFees } from 'components/Trade/hooks/useSwapper/utils'
 import { selectFeeAssetById } from 'state/slices/assetsSlice/selectors'
 import { useAppSelector } from 'state/store'
+import { selectQuote } from 'state/zustand/swapperStore/selectors'
 import { useSwapperStore } from 'state/zustand/swapperStore/useSwapperStore'
 
 /*
@@ -12,7 +13,7 @@ The only mutation is on Swapper State's fees property.
 export const useFeesService = () => {
   // Selectors
   const activeTradeSwapper = useSwapperStore(state => state.activeSwapperWithMetadata?.swapper)
-  const activeQuote = useSwapperStore(state => state.activeSwapperWithMetadata?.quote)
+  const activeQuote = useSwapperStore(selectQuote)
   const sellAsset = useSwapperStore(state => state.sellAsset)
   const sellFeeAsset = useAppSelector(state =>
     selectFeeAssetById(state, sellAsset?.assetId ?? ethAssetId),

--- a/src/components/Trade/hooks/useSwapper/useSwapper.tsx
+++ b/src/components/Trade/hooks/useSwapper/useSwapper.tsx
@@ -1,19 +1,10 @@
 import { type Asset } from '@shapeshiftoss/asset-service'
-import type { UtxoBaseAdapter, UtxoChainId } from '@shapeshiftoss/chain-adapters'
 import { SwapperManager } from '@shapeshiftoss/swapper'
 import { useCallback, useEffect, useMemo, useState } from 'react'
 import { useSelector } from 'react-redux'
 import { getSwapperManager } from 'components/Trade/hooks/useSwapper/swapperManager'
-import {
-  isSupportedCosmosSdkSwappingChain,
-  isSupportedNonUtxoSwappingChain,
-  isSupportedUtxoSwappingChain,
-} from 'components/Trade/hooks/useSwapper/typeGuards'
 import { filterAssetsByIds } from 'components/Trade/hooks/useSwapper/utils'
-import { type BuildTradeInputCommonArgs } from 'components/Trade/types'
-import { getChainAdapterManager } from 'context/PluginProvider/chainAdapterSingleton'
 import { useWallet } from 'hooks/useWallet/useWallet'
-import { toBaseUnit } from 'lib/math'
 import { selectAssetIds } from 'state/slices/assetsSlice/selectors'
 import { selectFeatureFlags } from 'state/slices/preferencesSlice/selectors'
 import {
@@ -22,7 +13,7 @@ import {
   selectPortfolioAccountMetadataByAccountId,
 } from 'state/slices/selectors'
 import { useAppSelector } from 'state/store'
-import { selectQuote, selectSlippage } from 'state/zustand/swapperStore/selectors'
+import { selectGetTradeForWallet, selectQuote } from 'state/zustand/swapperStore/selectors'
 import { useSwapperStore } from 'state/zustand/swapperStore/useSwapperStore'
 
 /*
@@ -34,13 +25,10 @@ export const useSwapper = () => {
   const activeSwapper = useSwapperStore(state => state.activeSwapperWithMetadata?.swapper)
   const sellAssetAccountId = useSwapperStore(state => state.sellAssetAccountId)
   const buyAssetAccountId = useSwapperStore(state => state.buyAssetAccountId)
-  const isSendMax = useSwapperStore(state => state.isSendMax)
   const isExactAllowance = useSwapperStore(state => state.isExactAllowance)
-  const slippage = useSwapperStore(selectSlippage)
-  const receiveAddress = useSwapperStore(state => state.receiveAddress)
   const buyAsset = useSwapperStore(state => state.buyAsset)
   const sellAsset = useSwapperStore(state => state.sellAsset)
-  const sellAmountCryptoPrecision = useSwapperStore(state => state.sellAmountCryptoPrecision)
+  const getTradeForWallet = useSwapperStore(selectGetTradeForWallet)
 
   // Selectors
   const flags = useSelector(selectFeatureFlags)
@@ -120,79 +108,16 @@ export const useSwapper = () => {
     return txid
   }, [activeSwapper, isExactAllowance, activeQuote, wallet])
 
-  const getTrade = useCallback(async () => {
-    if (!sellAsset) throw new Error('No sellAsset')
-    if (!activeSwapper) throw new Error('No swapper available')
-    if (!sellAmountCryptoPrecision) throw new Error('Missing sellTradeAsset.amount')
-    if (!sellAsset) throw new Error('Missing sellAsset')
-    if (!buyAsset) throw new Error('Missing buyAsset')
-    if (!wallet) throw new Error('Missing wallet')
-    if (!receiveAddress) throw new Error('Missing receiveAddress')
-    if (!sellAssetAccountId) throw new Error('Missing sellAssetAccountId')
-    if (!sellAccountBip44Params) throw new Error('Missing sellAccountBip44Params')
-    if (!buyAccountBip44Params) throw new Error('Missing buyAccountBip44Params')
-    if (!sellAccountMetadata) throw new Error('Missing sellAccountMetadata')
-
-    const buildTradeCommonArgs: BuildTradeInputCommonArgs = {
-      sellAmountBeforeFeesCryptoBaseUnit: toBaseUnit(
-        sellAmountCryptoPrecision,
-        sellAsset.precision,
-      ),
-      sellAsset,
-      buyAsset,
-      wallet,
-      sendMax: isSendMax,
-      receiveAddress,
-      slippage,
-    }
-    const sellAssetChainId = sellAsset.chainId
-    if (isSupportedCosmosSdkSwappingChain(sellAssetChainId)) {
-      const { accountNumber } = sellAccountBip44Params
-      const { accountNumber: receiveAccountNumber } = buyAccountBip44Params
-      return activeSwapper.buildTrade({
-        ...buildTradeCommonArgs,
-        chainId: sellAssetChainId,
-        accountNumber,
-        receiveAccountNumber,
-      })
-    } else if (isSupportedNonUtxoSwappingChain(sellAssetChainId)) {
-      const { accountNumber } = sellAccountBip44Params
-      return activeSwapper.buildTrade({
-        ...buildTradeCommonArgs,
-        chainId: sellAssetChainId,
-        accountNumber,
-      })
-    } else if (isSupportedUtxoSwappingChain(sellAssetChainId)) {
-      const { accountType, bip44Params } = sellAccountMetadata
-      const { accountNumber } = bip44Params
-      if (!bip44Params) throw new Error('no bip44Params')
-      if (!accountType) throw new Error('no accountType')
-      const sellAssetChainAdapter = getChainAdapterManager().get(
-        sellAssetChainId,
-      ) as unknown as UtxoBaseAdapter<UtxoChainId>
-      const { xpub } = await sellAssetChainAdapter.getPublicKey(wallet, accountNumber, accountType)
-      return activeSwapper.buildTrade({
-        ...buildTradeCommonArgs,
-        chainId: sellAssetChainId,
-        accountNumber,
-        accountType,
-        xpub,
-      })
-    }
-  }, [
-    sellAsset,
-    activeSwapper,
-    sellAmountCryptoPrecision,
-    buyAsset,
-    wallet,
-    receiveAddress,
-    sellAssetAccountId,
-    sellAccountBip44Params,
-    buyAccountBip44Params,
-    sellAccountMetadata,
-    isSendMax,
-    slippage,
-  ])
+  const getTrade = useCallback(
+    async () =>
+      await getTradeForWallet({
+        wallet,
+        sellAccountBip44Params,
+        sellAccountMetadata,
+        buyAccountBip44Params,
+      }),
+    [wallet, getTradeForWallet, sellAccountBip44Params, sellAccountMetadata, buyAccountBip44Params],
+  )
 
   useEffect(() => {
     ;(async () => {

--- a/src/components/Trade/hooks/useSwapper/useSwapper.tsx
+++ b/src/components/Trade/hooks/useSwapper/useSwapper.tsx
@@ -22,7 +22,7 @@ import {
   selectPortfolioAccountMetadataByAccountId,
 } from 'state/slices/selectors'
 import { useAppSelector } from 'state/store'
-import { selectSlippage } from 'state/zustand/swapperStore/selectors'
+import { selectQuote, selectSlippage } from 'state/zustand/swapperStore/selectors'
 import { useSwapperStore } from 'state/zustand/swapperStore/useSwapperStore'
 
 /*
@@ -30,7 +30,7 @@ The Swapper hook is responsible for providing computed swapper state to consumer
 It does not mutate state.
 */
 export const useSwapper = () => {
-  const activeQuote = useSwapperStore(state => state.activeSwapperWithMetadata?.quote)
+  const activeQuote = useSwapperStore(selectQuote)
   const activeSwapper = useSwapperStore(state => state.activeSwapperWithMetadata?.swapper)
   const sellAssetAccountId = useSwapperStore(state => state.sellAssetAccountId)
   const buyAssetAccountId = useSwapperStore(state => state.buyAssetAccountId)

--- a/src/components/Trade/hooks/useSwapper/useSwapper.tsx
+++ b/src/components/Trade/hooks/useSwapper/useSwapper.tsx
@@ -108,16 +108,21 @@ export const useSwapper = () => {
     return txid
   }, [activeSwapper, isExactAllowance, activeQuote, wallet])
 
-  const getTrade = useCallback(
-    async () =>
-      await getTradeForWallet({
-        wallet,
-        sellAccountBip44Params,
-        sellAccountMetadata,
-        buyAccountBip44Params,
-      }),
-    [wallet, getTradeForWallet, sellAccountBip44Params, sellAccountMetadata, buyAccountBip44Params],
-  )
+  const getTrade = useCallback(async () => {
+    if (!wallet) throw new Error('no wallet available')
+    return await getTradeForWallet({
+      wallet,
+      sellAccountBip44Params,
+      sellAccountMetadata,
+      buyAccountBip44Params,
+    })
+  }, [
+    wallet,
+    getTradeForWallet,
+    sellAccountBip44Params,
+    sellAccountMetadata,
+    buyAccountBip44Params,
+  ])
 
   useEffect(() => {
     ;(async () => {

--- a/src/components/Trade/hooks/useSwapper/useSwapper.tsx
+++ b/src/components/Trade/hooks/useSwapper/useSwapper.tsx
@@ -1,6 +1,6 @@
 import { type Asset } from '@shapeshiftoss/asset-service'
 import type { UtxoBaseAdapter, UtxoChainId } from '@shapeshiftoss/chain-adapters'
-import { SwapperManager, SwapperName } from '@shapeshiftoss/swapper'
+import { SwapperManager } from '@shapeshiftoss/swapper'
 import { useCallback, useEffect, useMemo, useState } from 'react'
 import { useSelector } from 'react-redux'
 import { getSwapperManager } from 'components/Trade/hooks/useSwapper/swapperManager'
@@ -90,27 +90,6 @@ export const useSwapper = () => {
   const buyAccountBip44Params = useAppSelector(state =>
     selectBIP44ParamsByAccountId(state, buyAccountFilter),
   )
-
-  /*
-  Cross-account trading means trades that are either:
-    - Trades between assets on the same chain but different accounts
-    - Trades between assets on different chains (and possibly different accounts)
-   When adding a new swapper, ensure that `true` is returned here if either of the above apply.
-   */
-  const swapperSupportsCrossAccountTrade = useMemo(() => {
-    if (!activeSwapper) return undefined
-    switch (activeSwapper.name) {
-      case SwapperName.Thorchain:
-      case SwapperName.Osmosis:
-      case SwapperName.LIFI:
-        return true
-      case SwapperName.Zrx:
-      case SwapperName.CowSwap:
-        return false
-      default:
-        return false
-    }
-  }, [activeSwapper])
 
   const getSupportedBuyAssetsFromSellAsset = useCallback(
     (assets: Asset[]): Asset[] | undefined => {
@@ -235,7 +214,6 @@ export const useSwapper = () => {
     swapperManager,
     checkApprovalNeeded,
     getTrade,
-    swapperSupportsCrossAccountTrade,
     approve,
   }
 }

--- a/src/components/Trade/hooks/useSwapper/useSwapper.tsx
+++ b/src/components/Trade/hooks/useSwapper/useSwapper.tsx
@@ -106,14 +106,6 @@ export const useSwapper = () => {
     [swapperManager, sellAsset],
   )
 
-  const checkApprovalNeeded = useCallback(async (): Promise<boolean> => {
-    if (!activeSwapper) throw new Error('No swapper available')
-    if (!wallet) throw new Error('No wallet available')
-    if (!activeQuote) throw new Error('No quote available')
-    const { approvalNeeded } = await activeSwapper.approvalNeeded({ quote: activeQuote, wallet })
-    return approvalNeeded
-  }, [activeSwapper, activeQuote, wallet])
-
   const approve = useCallback(async (): Promise<string> => {
     if (!activeSwapper) throw new Error('No swapper available')
     if (!wallet) throw new Error('no wallet available')
@@ -212,7 +204,6 @@ export const useSwapper = () => {
     getSupportedSellableAssets,
     getSupportedBuyAssetsFromSellAsset,
     swapperManager,
-    checkApprovalNeeded,
     getTrade,
     approve,
   }

--- a/src/state/zustand/swapperStore/selectors.ts
+++ b/src/state/zustand/swapperStore/selectors.ts
@@ -57,7 +57,7 @@ export const selectCheckApprovalNeededForWallet = (
 }
 
 type SelectGetTradeForWalletArgs = {
-  wallet: HDWallet | null
+  wallet: HDWallet
   sellAccountBip44Params: BIP44Params | undefined
   buyAccountBip44Params: BIP44Params | undefined
   sellAccountMetadata: AccountMetadata | undefined
@@ -84,7 +84,6 @@ export const selectGetTradeForWallet = (
 
     if (!activeSwapper) throw new Error('No swapper available')
     if (!activeQuote) throw new Error('No quote available')
-    if (!wallet) throw new Error('No wallet available')
 
     if (!sellAsset) throw new Error('No sellAsset')
     if (!activeSwapper) throw new Error('No swapper available')

--- a/src/state/zustand/swapperStore/selectors.ts
+++ b/src/state/zustand/swapperStore/selectors.ts
@@ -1,7 +1,31 @@
+import type { ChainId } from '@shapeshiftoss/caip'
+import type { TradeQuote } from '@shapeshiftoss/swapper'
+import { SwapperName } from '@shapeshiftoss/swapper'
 import { DEFAULT_SLIPPAGE } from 'constants/constants'
 import type { SwapperState } from 'state/zustand/swapperStore/useSwapperStore'
 
-export const selectSlippage = (state: SwapperState) =>
+export const selectSlippage = (state: SwapperState): string =>
   state.activeSwapperWithMetadata?.quote.recommendedSlippage ?? DEFAULT_SLIPPAGE
 
-export const selectQuote = (state: SwapperState) => state.activeSwapperWithMetadata?.quote
+export const selectQuote = (state: SwapperState): TradeQuote<ChainId> | undefined =>
+  state.activeSwapperWithMetadata?.quote
+
+/*
+  Cross-account trading means trades that are either:
+    - Trades between assets on the same chain but different accounts
+    - Trades between assets on different chains (and possibly different accounts)
+   When adding a new swapper, ensure that `true` is returned here if either of the above apply.
+   */
+export const selectSwapperSupportsCrossAccountTrade = (state: SwapperState): boolean => {
+  const activeSwapper = state.activeSwapperWithMetadata?.swapper
+  switch (activeSwapper?.name) {
+    case SwapperName.Thorchain:
+    case SwapperName.Osmosis:
+      return true
+    case SwapperName.Zrx:
+    case SwapperName.CowSwap:
+      return false
+    default:
+      return false
+  }
+}

--- a/src/state/zustand/swapperStore/selectors.ts
+++ b/src/state/zustand/swapperStore/selectors.ts
@@ -3,3 +3,5 @@ import type { SwapperState } from 'state/zustand/swapperStore/useSwapperStore'
 
 export const selectSlippage = (state: SwapperState) =>
   state.activeSwapperWithMetadata?.quote.recommendedSlippage ?? DEFAULT_SLIPPAGE
+
+export const selectQuote = (state: SwapperState) => state.activeSwapperWithMetadata?.quote

--- a/src/state/zustand/swapperStore/selectors.ts
+++ b/src/state/zustand/swapperStore/selectors.ts
@@ -1,8 +1,19 @@
 import type { ChainId } from '@shapeshiftoss/caip'
+import type { UtxoBaseAdapter, UtxoChainId } from '@shapeshiftoss/chain-adapters'
 import type { HDWallet } from '@shapeshiftoss/hdwallet-core'
-import type { TradeQuote } from '@shapeshiftoss/swapper'
+import type { Trade, TradeQuote } from '@shapeshiftoss/swapper'
 import { SwapperName } from '@shapeshiftoss/swapper'
+import type { BIP44Params } from '@shapeshiftoss/types'
 import { DEFAULT_SLIPPAGE } from 'constants/constants'
+import {
+  isSupportedCosmosSdkSwappingChain,
+  isSupportedNonUtxoSwappingChain,
+  isSupportedUtxoSwappingChain,
+} from 'components/Trade/hooks/useSwapper/typeGuards'
+import type { BuildTradeInputCommonArgs } from 'components/Trade/types'
+import { getChainAdapterManager } from 'context/PluginProvider/chainAdapterSingleton'
+import { toBaseUnit } from 'lib/math'
+import type { AccountMetadata } from 'state/slices/portfolioSlice/portfolioSliceCommon'
 import type { SwapperState } from 'state/zustand/swapperStore/useSwapperStore'
 
 export const selectSlippage = (state: SwapperState): string =>
@@ -42,5 +53,96 @@ export const selectCheckApprovalNeededForWallet = (
 
     const { approvalNeeded } = await activeSwapper.approvalNeeded({ quote: activeQuote, wallet })
     return approvalNeeded
+  }
+}
+
+type SelectGetTradeForWalletArgs = {
+  wallet: HDWallet | null
+  sellAccountBip44Params: BIP44Params | undefined
+  buyAccountBip44Params: BIP44Params | undefined
+  sellAccountMetadata: AccountMetadata | undefined
+}
+type SelectGetTradeForWalletReturn = Promise<Trade<ChainId> | undefined>
+export const selectGetTradeForWallet = (
+  state: SwapperState,
+): ((_: SelectGetTradeForWalletArgs) => SelectGetTradeForWalletReturn) => {
+  return async ({
+    wallet,
+    sellAccountMetadata,
+    sellAccountBip44Params,
+    buyAccountBip44Params,
+  }: SelectGetTradeForWalletArgs): SelectGetTradeForWalletReturn => {
+    const activeSwapper = state.activeSwapperWithMetadata?.swapper
+    const activeQuote = state.activeSwapperWithMetadata?.quote
+    const sellAsset = state.sellAsset
+    const sellAmountCryptoPrecision = state.sellAmountCryptoPrecision
+    const buyAsset = state.buyAsset
+    const receiveAddress = state.receiveAddress
+    const sellAssetAccountId = state.sellAssetAccountId
+    const slippage = selectSlippage(state)
+    const isSendMax = state.isSendMax
+
+    if (!activeSwapper) throw new Error('No swapper available')
+    if (!activeQuote) throw new Error('No quote available')
+    if (!wallet) throw new Error('No wallet available')
+
+    if (!sellAsset) throw new Error('No sellAsset')
+    if (!activeSwapper) throw new Error('No swapper available')
+    if (!sellAmountCryptoPrecision) throw new Error('Missing sellTradeAsset.amount')
+    if (!sellAsset) throw new Error('Missing sellAsset')
+    if (!buyAsset) throw new Error('Missing buyAsset')
+    if (!wallet) throw new Error('Missing wallet')
+    if (!receiveAddress) throw new Error('Missing receiveAddress')
+    if (!sellAssetAccountId) throw new Error('Missing sellAssetAccountId')
+    if (!sellAccountBip44Params) throw new Error('Missing sellAccountBip44Params')
+    if (!buyAccountBip44Params) throw new Error('Missing buyAccountBip44Params')
+    if (!sellAccountMetadata) throw new Error('Missing sellAccountMetadata')
+
+    const buildTradeCommonArgs: BuildTradeInputCommonArgs = {
+      sellAmountBeforeFeesCryptoBaseUnit: toBaseUnit(
+        sellAmountCryptoPrecision,
+        sellAsset.precision,
+      ),
+      sellAsset,
+      buyAsset,
+      wallet,
+      sendMax: isSendMax,
+      receiveAddress,
+      slippage,
+    }
+    const sellAssetChainId = sellAsset.chainId
+    if (isSupportedCosmosSdkSwappingChain(sellAssetChainId)) {
+      const { accountNumber } = sellAccountBip44Params
+      const { accountNumber: receiveAccountNumber } = buyAccountBip44Params
+      return activeSwapper.buildTrade({
+        ...buildTradeCommonArgs,
+        chainId: sellAssetChainId,
+        accountNumber,
+        receiveAccountNumber,
+      })
+    } else if (isSupportedNonUtxoSwappingChain(sellAssetChainId)) {
+      const { accountNumber } = sellAccountBip44Params
+      return activeSwapper.buildTrade({
+        ...buildTradeCommonArgs,
+        chainId: sellAssetChainId,
+        accountNumber,
+      })
+    } else if (isSupportedUtxoSwappingChain(sellAssetChainId)) {
+      const { accountType, bip44Params } = sellAccountMetadata
+      const { accountNumber } = bip44Params
+      if (!bip44Params) throw new Error('no bip44Params')
+      if (!accountType) throw new Error('no accountType')
+      const sellAssetChainAdapter = getChainAdapterManager().get(
+        sellAssetChainId,
+      ) as unknown as UtxoBaseAdapter<UtxoChainId>
+      const { xpub } = await sellAssetChainAdapter.getPublicKey(wallet, accountNumber, accountType)
+      return activeSwapper.buildTrade({
+        ...buildTradeCommonArgs,
+        chainId: sellAssetChainId,
+        accountNumber,
+        accountType,
+        xpub,
+      })
+    }
   }
 }

--- a/src/state/zustand/swapperStore/selectors.ts
+++ b/src/state/zustand/swapperStore/selectors.ts
@@ -1,4 +1,5 @@
 import type { ChainId } from '@shapeshiftoss/caip'
+import type { HDWallet } from '@shapeshiftoss/hdwallet-core'
 import type { TradeQuote } from '@shapeshiftoss/swapper'
 import { SwapperName } from '@shapeshiftoss/swapper'
 import { DEFAULT_SLIPPAGE } from 'constants/constants'
@@ -27,5 +28,19 @@ export const selectSwapperSupportsCrossAccountTrade = (state: SwapperState): boo
       return false
     default:
       return false
+  }
+}
+
+export const selectCheckApprovalNeededForWallet = (
+  state: SwapperState,
+): ((wallet: HDWallet) => Promise<boolean>) => {
+  return async (wallet: HDWallet): Promise<boolean> => {
+    const activeSwapper = state.activeSwapperWithMetadata?.swapper
+    const activeQuote = state.activeSwapperWithMetadata?.quote
+    if (!activeSwapper) throw new Error('No swapper available')
+    if (!activeQuote) throw new Error('No quote available')
+
+    const { approvalNeeded } = await activeSwapper.approvalNeeded({ quote: activeQuote, wallet })
+    return approvalNeeded
   }
 }


### PR DESCRIPTION
## Description

More swapper clean-up now that zustand is in - move some more logic to selectors so we can rely less on custom React hooks and select straight from the zustand state.

## Notice

- [x] Have you followed the guidelines in our [Contributing]('https://github.com/shapeshift/web/blob/develop/CONTRIBUTING.md) guide?
- [x] Have you checked to ensure there aren't other open [Pull Requests](https://github.com/shapeshift/web/pulls) for the same update/change?

## Pull Request Type

- [ ] :bug: Bug fix (Non-breaking Change: Fixes an issue)
- [x] :hammer_and_wrench: Chore (Non-breaking Change: Doc updates, pkg upgrades, typos, etc..)
- [ ] :nail_care: New Feature (Breaking/Non-breaking Change)

## Issue (if applicable)

Improving architecture as we move towards swapper selection.

## Risk

Small, no logic changes - just extracted Reactive code into pure selectors.

## Testing

Swapper should work normally, in particular:

- Approvals
- Cross-account trade lock (e.g. 0x)

### Engineering

☝️ 

### Operations

☝️ 

## Screenshots (if applicable)

N/A