### PR TITLE
fix: by provider claimable rewards column

### DIFF
--- a/src/state/slices/opportunitiesSlice/selectors/combined.ts
+++ b/src/state/slices/opportunitiesSlice/selectors/combined.ts
@@ -188,21 +188,20 @@ export const selectAggregatedEarnOpportunitiesByProvider = createDeepEqualOutput
       if (cur.type === DefiType.Staking) {
         acc[provider].opportunities.staking.push(cur.id)
         const stakingOpportunity = cur as StakingEarnOpportunityType
-        const rewardsAmountFiat = Array.from(stakingOpportunity.rewardAssetIds ?? []).reduce(
-          (sum, assetId, index) => {
-            const asset = assets[assetId]
-            if (!asset) return sum
-            const marketDataPrice = marketData[assetId]?.price
-            const cryptoAmountPrecision = bnOrZero(
-              stakingOpportunity?.rewardsAmountsCryptoBaseUnit?.[index],
-            ).div(bnOrZero(10).pow(asset?.precision))
-            return bnOrZero(cryptoAmountPrecision)
-              .times(marketDataPrice ?? 0)
-              .plus(bnOrZero(sum))
-              .toNumber()
-          },
-          0,
-        )
+        const rewardsAmountFiat = stakingOpportunity.isClaimableRewards
+          ? Array.from(stakingOpportunity.rewardAssetIds ?? []).reduce((sum, assetId, index) => {
+              const asset = assets[assetId]
+              if (!asset) return sum
+              const marketDataPrice = marketData[assetId]?.price
+              const cryptoAmountPrecision = bnOrZero(
+                stakingOpportunity?.rewardsAmountsCryptoBaseUnit?.[index],
+              ).div(bnOrZero(10).pow(asset?.precision))
+              return bnOrZero(cryptoAmountPrecision)
+                .times(marketDataPrice ?? 0)
+                .plus(bnOrZero(sum))
+                .toNumber()
+            }, 0)
+          : '0'
 
         acc[provider].fiatRewardsAmount = bnOrZero(rewardsAmountFiat)
           .plus(acc[provider].fiatRewardsAmount)


### PR DESCRIPTION
## Description

Fixes the `By Provider` view so that claimable rewards are only displayed in the columb header in case there are *akschually* *claimable* rewards for that provider

## Notice

<!-- Before submitting a pull request, please make sure you have answered the following: -->

- [x] Have you followed the guidelines in our [Contributing]('https://github.com/shapeshift/web/blob/develop/CONTRIBUTING.md) guide?
- [x] Have you checked to ensure there aren't other open [Pull Requests](https://github.com/shapeshift/web/pulls) for the same update/change?

## Pull Request Type

- [x] :bug: Bug fix (Non-breaking Change: Fixes an issue)
- [ ] :hammer_and_wrench: Chore (Non-breaking Change: Doc updates, pkg upgrades, typos, etc..)
- [ ] :nail_care: New Feature (Breaking/Non-breaking Change)

## Issue (if applicable)

N/A

## Risk

<!-----------------------------------------------------------------------------
Outline the scope of your changes and the risk associated with them. You must use your discretion as an engineer to determine the potential impact of your changes.

E.g. an upgrade to `hdwallet` or core state management would be considered higher risk, and might require a full regression test. UI or isolated view changes, or something behind a feature flag may have near zero risk. Small bug fixes might require testing isolated to the specific fix.
------------------------------------------------------------------------------>

None

## Testing

<!-----------------------------------------------------------------------------
We treat every PR to be merged with the same scrutiny as if we were merging directly to production.

Your PR will not be merged if you do not complete the sections below for our engineering and operations teams to test.
------------------------------------------------------------------------------>

- With the new `DefiAggregation` flag enabled, open the `By Provider` view
- Ensure that, in the outer column for that provider, rewards are shown in case you have rewards, else `-`
- Ensure the inner columns (i.e the aggregated opportunities) are matching the outer column ones i.e no rewards for that provider should mean no rewards for individual opportunities


### Engineering

<!-----------------------------------------------------------------------------
Include sufficient information here for an engineer to test your PR. This may include how to test locally, in a built environment, changes to infrastructure etc.
------------------------------------------------------------------------------>

- ☝🏽 

### Operations

<!-----------------------------------------------------------------------------
If your changes have a user-facing impact, describe how a non-technical QA team can functionally test your changes in a preview environment.

If they are not user-facing please describe how to test for any regressions that may occur.
------------------------------------------------------------------------------>

- ☝🏽 

## Screenshots (if applicable)

<img width="1264" alt="image" src="https://user-images.githubusercontent.com/17035424/226433393-26a12fdb-5a63-4f93-93b2-6de217afc90d.png">
