### PR TITLE
fix: display claimable rewards only in defi aggregation table

### DIFF
--- a/src/state/slices/opportunitiesSlice/selectors/stakingSelectors.ts
+++ b/src/state/slices/opportunitiesSlice/selectors/stakingSelectors.ts
@@ -331,6 +331,8 @@ const getAggregatedUserStakingOpportunityByStakingId = (
         amounts: userStakingOpportunity.rewardsCryptoBaseUnit.amounts.map((amount, i) =>
           bnOrZero(acc?.rewardsCryptoBaseUnit.amounts[i]).plus(amount).toString(),
         ) as [string, string] | [string] | [],
+        // This aggregates by StakingId, meaning this is the same opportunity over multiple amounts
+        // Same rewards AssetIds, same arity etc
         claimable: userStakingOpportunity.isClaimableRewards,
       }
       const undelegations = [


### PR DESCRIPTION
## Description

Brings up discrimination between the claimable and unclaimable rewards, so that we only display the ones that are actually claimable.

## Notice

<!-- Before submitting a pull request, please make sure you have answered the following: -->

- [x] Have you followed the guidelines in our [Contributing]('https://github.com/shapeshift/web/blob/develop/CONTRIBUTING.md) guide?
- [x] Have you checked to ensure there aren't other open [Pull Requests](https://github.com/shapeshift/web/pulls) for the same update/change?

## Pull Request Type

- [x] :bug: Bug fix (Non-breaking Change: Fixes an issue)
- [ ] :hammer_and_wrench: Chore (Non-breaking Change: Doc updates, pkg upgrades, typos, etc..)
- [ ] :nail_care: New Feature (Breaking/Non-breaking Change)

## Issue (if applicable)

N/A

## Risk

<!-----------------------------------------------------------------------------
Outline the scope of your changes and the risk associated with them. You must use your discretion as an engineer to determine the potential impact of your changes.

E.g. an upgrade to `hdwallet` or core state management would be considered higher risk, and might require a full regression test. UI or isolated view changes, or something behind a feature flag may have near zero risk. Small bug fixes might require testing isolated to the specific fix.
------------------------------------------------------------------------------>

## Testing

<!-----------------------------------------------------------------------------
We treat every PR to be merged with the same scrutiny as if we were merging directly to production.

Your PR will not be merged if you do not complete the sections below for our engineering and operations teams to test.
------------------------------------------------------------------------------>

- Ensure the `DefiAggregation` flag is on
- Go to DeFi Earn
- With either the "By Provider" or "By Position" table selected, only the total of claimable rewards from opportunities with claimable rewards should be displayed, e.g THORChain should never have claimable rewards, but ETH/FOX staking rewards should always account for the total. If it appears on the individual rows, then it should account for the total of that provider
- This shouldn't bring regressions in the actual amounts e.g Net Worth

### Engineering

<!-----------------------------------------------------------------------------
Include sufficient information here for an engineer to test your PR. This may include how to test locally, in a built environment, changes to infrastructure etc.
------------------------------------------------------------------------------>

- ☝🏽 

### Operations

<!-----------------------------------------------------------------------------
If your changes have a user-facing impact, describe how a non-technical QA team can functionally test your changes in a preview environment.

If they are not user-facing please describe how to test for any regressions that may occur.
------------------------------------------------------------------------------>

- ☝🏽 

## Screenshots (if applicable)
