### PR TITLE
fix: input when selling CosmosSDK asset

### DIFF
--- a/src/components/Trade/hooks/useSwapper/getTradeQuoteArgs.tsx
+++ b/src/components/Trade/hooks/useSwapper/getTradeQuoteArgs.tsx
@@ -3,7 +3,11 @@ import type { UtxoBaseAdapter, UtxoChainId } from '@shapeshiftoss/chain-adapters
 import type { HDWallet } from '@shapeshiftoss/hdwallet-core'
 import type { GetTradeQuoteInput } from '@shapeshiftoss/swapper'
 import type { UtxoAccountType } from '@shapeshiftoss/types'
-import { isEvmSwap, isUtxoSwap } from 'components/Trade/hooks/useSwapper/typeGuards'
+import {
+  isCosmosSdkSwap,
+  isEvmSwap,
+  isUtxoSwap,
+} from 'components/Trade/hooks/useSwapper/typeGuards'
 import type { TradeQuoteInputCommonArgs } from 'components/Trade/types'
 import { getChainAdapterManager } from 'context/PluginProvider/chainAdapterSingleton'
 import { toBaseUnit } from 'lib/math'
@@ -42,7 +46,7 @@ export const getTradeQuoteArgs = async ({
     receiveAddress,
     accountNumber: sellAccountNumber,
   }
-  if (isEvmSwap(sellAsset?.chainId)) {
+  if (isEvmSwap(sellAsset?.chainId) || isCosmosSdkSwap(sellAsset?.chainId)) {
     return {
       ...tradeQuoteInputCommonArgs,
       chainId: sellAsset.chainId,


### PR DESCRIPTION
## Description

Trading from a CosmosSDK asset is currently broken, as entering input amounts do not work.

This PR adds a missing check to update `tradeQuoteArgs` on input for CosmosSDK assets, fixing a regression caused in https://github.com/shapeshift/web/pull/3947.

## Notice

- [x] Have you followed the guidelines in our [Contributing]('https://github.com/shapeshift/web/blob/develop/CONTRIBUTING.md) guide?
- [x] Have you checked to ensure there aren't other open [Pull Requests](https://github.com/shapeshift/web/pulls) for the same update/change?

## Pull Request Type

- [x] :bug: Bug fix (Non-breaking Change: Fixes an issue)
- [ ] :hammer_and_wrench: Chore (Non-breaking Change: Doc updates, pkg upgrades, typos, etc..)
- [ ] :nail_care: New Feature (Breaking/Non-breaking Change)

## Issue (if applicable)

N/A - production bug

## Risk

Very small.

## Testing

Input amounts when trading from CosmosSDK assets should work correctly.

### Engineering

☝️ 

### Operations

☝️ 

## Screenshots (if applicable)

N/A