### PR TITLE
fix: foxy max delayed withdraw

### DIFF
--- a/src/state/slices/opportunitiesSlice/resolvers/foxy/index.ts
+++ b/src/state/slices/opportunitiesSlice/resolvers/foxy/index.ts
@@ -134,15 +134,6 @@ export const foxyStakingOpportunitiesUserDataResolver = async ({
     const opportunityId = toOpportunityId(toAssetIdParts)
     const userStakingId = serializeUserStakingId(accountId, opportunityId)
 
-    if (bnOrZero(balance).eq(0)) {
-      stakingOpportunitiesUserDataByUserStakingId[userStakingId] = {
-        userStakingId,
-        stakedAmountCryptoBaseUnit: '0',
-        rewardsCryptoBaseUnit: { amounts: ['0'], claimable: false },
-      }
-      continue
-    }
-
     const opportunities = await foxyInvestor.getFoxyOpportunities()
 
     // investor-foxy is architected around many FOXy addresses/opportunity, but akchually there's only one

--- a/src/state/slices/opportunitiesSlice/selectors/stakingSelectors.ts
+++ b/src/state/slices/opportunitiesSlice/selectors/stakingSelectors.ts
@@ -239,9 +239,10 @@ export const selectHasClaimByUserStakingId = createSelector(
   selectUserStakingOpportunityByUserStakingId,
   (userStakingOpportunity): boolean =>
     Boolean(
-      userStakingOpportunity?.rewardsCryptoBaseUnit.amounts.some(rewardAmount =>
-        bnOrZero(rewardAmount).gt(0),
-      ),
+      userStakingOpportunity?.rewardsCryptoBaseUnit.claimable &&
+        userStakingOpportunity?.rewardsCryptoBaseUnit.amounts.some(rewardAmount =>
+          bnOrZero(rewardAmount).gt(0),
+        ),
     ),
 )
 


### PR DESCRIPTION
## Description

Fixes the max delayed withdraws making the opportunity "disappear" for FOXy after the delayed withdraw is initiated.

## Notice

<!-- Before submitting a pull request, please make sure you have answered the following: -->

- [x] Have you followed the guidelines in our [Contributing]('https://github.com/shapeshift/web/blob/develop/CONTRIBUTING.md) guide?
- [x] Have you checked to ensure there aren't other open [Pull Requests](https://github.com/shapeshift/web/pulls) for the same update/change?

## Pull Request Type

- [x] :bug: Bug fix (Non-breaking Change: Fixes an issue)
- [ ] :hammer_and_wrench: Chore (Non-breaking Change: Doc updates, pkg upgrades, typos, etc..)
- [ ] :nail_care: New Feature (Breaking/Non-breaking Change)

## Issue (if applicable)

<!-----------------------------------------------------------------------------
If applicable, please link to the github issue and put `closes #XXXX` in your comment to auto-close the issue that your PR fixes.
------------------------------------------------------------------------------>

closes https://github.com/shapeshift/web/issues/4103

## Risk

<!-----------------------------------------------------------------------------
Outline the scope of your changes and the risk associated with them. You must use your discretion as an engineer to determine the potential impact of your changes.

E.g. an upgrade to `hdwallet` or core state management would be considered higher risk, and might require a full regression test. UI or isolated view changes, or something behind a feature flag may have near zero risk. Small bug fixes might require testing isolated to the specific fix.
------------------------------------------------------------------------------>

I got the heuristics wrong and claimable after the completionTime isn't working, test accordingly

## Testing

<!-----------------------------------------------------------------------------
We treat every PR to be merged with the same scrutiny as if we were merging directly to production.

Your PR will not be merged if you do not complete the sections below for our engineering and operations teams to test.
------------------------------------------------------------------------------>

1. Percent withdraw FOXy with delayed withdraw
2. Ensure your position is still visible after the Tx completes and positions refetch - should also still be visible after a refresh
3. Hard refresh and repeat testing steps 1. and 2. 

### Engineering

<!-----------------------------------------------------------------------------
Include sufficient information here for an engineer to test your PR. This may include how to test locally, in a built environment, changes to infrastructure etc.
------------------------------------------------------------------------------>

- Rewards / pending claims heuristics look sane

### Operations

<!-----------------------------------------------------------------------------
If your changes have a user-facing impact, describe how a non-technical QA team can functionally test your changes in a preview environment.

If they are not user-facing please describe how to test for any regressions that may occur.
------------------------------------------------------------------------------>

- ☝🏽 
## Screenshots (if applicable)

<img width="561" alt="image" src="https://user-images.githubusercontent.com/17035424/226894854-265cf440-8abe-4f7b-b438-bbfb24dbba59.png">
