### PR TITLE
fix: trade screen regression

### DIFF
--- a/src/components/Trade/Trade.tsx
+++ b/src/components/Trade/Trade.tsx
@@ -27,7 +27,6 @@ export const Trade = ({ defaultBuyAssetId }: TradeProps) => {
   const updateAction = useSwapperStore(state => state.updateAction)
   const updateIsExactAllowance = useSwapperStore(state => state.updateIsExactAllowance)
   const updateAmount = useSwapperStore(state => state.updateAmount)
-  const updateTrade = useSwapperStore(state => state.updateTrade)
   const updateBuyAsset = useSwapperStore(state => state.updateBuyAsset)
   const updateSellAsset = useSwapperStore(state => state.updateSellAsset)
   const updateBuyAmountCryptoPrecision = useSwapperStore(
@@ -41,8 +40,6 @@ export const Trade = ({ defaultBuyAssetId }: TradeProps) => {
   useEffect(() => setHasSetDefaultValues(false), [location])
 
   useEffect(() => {
-    // Don't run this effect within the lifecycle of /trade routes
-    if (location.pathname === '/trade') return
     if (hasSetDefaultValues) return
     ;(async () => {
       const result = await getDefaultAssets()
@@ -60,7 +57,6 @@ export const Trade = ({ defaultBuyAssetId }: TradeProps) => {
       updateSellAssetFiatRate(undefined)
       updateBuyAssetFiatRate(undefined)
       updateFeeAssetFiatRate(undefined)
-      updateTrade(undefined)
       const defaultAssetsAreChainDefaults =
         sellAsset?.assetId === defaultAssetIdPair?.sellAssetId &&
         buyAsset?.assetId === defaultAssetIdPair?.buyAssetId
@@ -87,7 +83,6 @@ export const Trade = ({ defaultBuyAssetId }: TradeProps) => {
     updateAction,
     updateIsExactAllowance,
     updateAmount,
-    updateTrade,
     updateBuyAsset,
     updateBuyAmountCryptoPrecision,
     updateSellAsset,

--- a/src/components/Trade/TradeConfirm/TradeConfirm.tsx
+++ b/src/components/Trade/TradeConfirm/TradeConfirm.tsx
@@ -83,6 +83,7 @@ export const TradeConfirm = () => {
   const buyAssetAccountId = useSwapperStore(state => state.buyAssetAccountId)
   const sellAssetAccountId = useSwapperStore(state => state.sellAssetAccountId)
   const buyAmountCryptoPrecision = useSwapperStore(state => state.buyAmountCryptoPrecision)
+  const updateTrade = useSwapperStore(state => state.updateTrade)
 
   const assets = useAppSelector(selectAssets)
 
@@ -249,9 +250,10 @@ export const TradeConfirm = () => {
   const handleBack = useCallback(() => {
     if (sellTradeId) {
       clearAmounts()
+      updateTrade(undefined)
     }
     history.push(TradeRoutePaths.Input)
-  }, [clearAmounts, history, sellTradeId])
+  }, [clearAmounts, history, sellTradeId, updateTrade])
 
   const networkFeeFiat = bnOrZero(fees?.networkFeeCryptoHuman).times(feeAssetFiatRate ?? 1)
 


### PR DESCRIPTION
## Description

Fixes a regression caused by https://github.com/shapeshift/web/pull/4112/ where the swapper would not load on the trade screen when accessed directly (e.g. navigating to the trade route URL).

This PR takes a different approach to fixing the bug that https://github.com/shapeshift/web/pull/4112 fixed, whilst also undoing it's changes.

## Notice

- [x] Have you followed the guidelines in our [Contributing]('https://github.com/shapeshift/web/blob/develop/CONTRIBUTING.md) guide?
- [x] Have you checked to ensure there aren't other open [Pull Requests](https://github.com/shapeshift/web/pulls) for the same update/change?

## Pull Request Type

- [x] :bug: Bug fix (Non-breaking Change: Fixes an issue)
- [ ] :hammer_and_wrench: Chore (Non-breaking Change: Doc updates, pkg upgrades, typos, etc..)
- [ ] :nail_care: New Feature (Breaking/Non-breaking Change)

## Issue (if applicable)

N/A - prod bug

## Risk

Small.

## Testing

- When loading the trade screen directly, and when refreshing on it and entering a password (for Native Wallet), the swapper should load correctly
- The Trade Confirm modal should not disappear when selecting "Confirm & Trade"

### Engineering

☝️ 

### Operations

☝️ 

## Screenshots (if applicable)

Before:

<img width="592" alt="Screenshot 2023-03-23 at 1 03 12 pm" src="https://user-images.githubusercontent.com/97164662/227080226-f47a43cc-5058-4cc9-87a8-86bfcb04be45.png">
