### PR TITLE
feat: include claimable rewards in net worth

### DIFF
--- a/src/pages/Dashboard/Portfolio.tsx
+++ b/src/pages/Dashboard/Portfolio.tsx
@@ -20,6 +20,7 @@ import { Text } from 'components/Text'
 import { bnOrZero } from 'lib/bignumber/bignumber'
 import { EligibleCarousel } from 'pages/Defi/components/EligibleCarousel'
 import {
+  selectClaimableRewards,
   selectEarnBalancesFiatAmountFull,
   selectPortfolioAssetIds,
   selectPortfolioLoading,
@@ -36,11 +37,19 @@ export const Portfolio = () => {
 
   const assetIds = useAppSelector(selectPortfolioAssetIds)
 
-  const earnBalance = useAppSelector(selectEarnBalancesFiatAmountFull).toFixed()
+  const earnFiatBalance = useAppSelector(selectEarnBalancesFiatAmountFull).toFixed()
   const portfolioTotalFiatBalance = useAppSelector(selectPortfolioTotalFiatBalanceExcludeEarnDupes)
+  const claimableRewardsFiatBalanceFilter = useMemo(() => ({}), [])
+  const claimableRewardsFiatBalance = useAppSelector(state =>
+    selectClaimableRewards(state, claimableRewardsFiatBalanceFilter),
+  )
   const totalBalance = useMemo(
-    () => bnOrZero(earnBalance).plus(portfolioTotalFiatBalance).toFixed(),
-    [earnBalance, portfolioTotalFiatBalance],
+    () =>
+      bnOrZero(earnFiatBalance)
+        .plus(portfolioTotalFiatBalance)
+        .plus(claimableRewardsFiatBalance)
+        .toFixed(),
+    [claimableRewardsFiatBalance, earnFiatBalance, portfolioTotalFiatBalance],
   )
 
   const loading = useAppSelector(selectPortfolioLoading)

--- a/src/pages/Dashboard/PortfolioBreakdown.tsx
+++ b/src/pages/Dashboard/PortfolioBreakdown.tsx
@@ -7,6 +7,7 @@ import { CircularProgress } from 'components/CircularProgress/CircularProgress'
 import { Text } from 'components/Text'
 import { bnOrZero } from 'lib/bignumber/bignumber'
 import {
+  selectClaimableRewards,
   selectEarnBalancesFiatAmountFull,
   selectPortfolioTotalFiatBalanceExcludeEarnDupes,
 } from 'state/slices/selectors'
@@ -53,11 +54,19 @@ const BreakdownCard: React.FC<StatCardProps> = ({
 
 export const PortfolioBreakdown = () => {
   const history = useHistory()
-  const earnBalance = useAppSelector(selectEarnBalancesFiatAmountFull).toFixed()
+  const earnFiatBalance = useAppSelector(selectEarnBalancesFiatAmountFull).toFixed()
+  const claimableRewardsFiatBalanceFilter = useMemo(() => ({}), [])
+  const claimableRewardsFiatBalance = useAppSelector(state =>
+    selectClaimableRewards(state, claimableRewardsFiatBalanceFilter),
+  )
   const portfolioTotalFiatBalance = useAppSelector(selectPortfolioTotalFiatBalanceExcludeEarnDupes)
   const netWorth = useMemo(
-    () => bnOrZero(earnBalance).plus(portfolioTotalFiatBalance).toFixed(),
-    [earnBalance, portfolioTotalFiatBalance],
+    () =>
+      bnOrZero(earnFiatBalance)
+        .plus(portfolioTotalFiatBalance)
+        .plus(claimableRewardsFiatBalance)
+        .toFixed(),
+    [claimableRewardsFiatBalance, earnFiatBalance, portfolioTotalFiatBalance],
   )
 
   const isDefiDashboardEnabled = useFeatureFlag('DefiDashboard')
@@ -73,8 +82,8 @@ export const PortfolioBreakdown = () => {
         onClick={() => history.push('/accounts')}
       />
       <BreakdownCard
-        value={earnBalance}
-        percentage={bnOrZero(earnBalance).div(netWorth).times(100).toNumber()}
+        value={earnFiatBalance}
+        percentage={bnOrZero(earnFiatBalance).div(netWorth).times(100).toNumber()}
         label='defi.earnBalance'
         color='green.500'
         onClick={() => history.push('/defi')}

--- a/src/pages/Dashboard/components/DashboardHeader.tsx
+++ b/src/pages/Dashboard/components/DashboardHeader.tsx
@@ -17,12 +17,19 @@ import { useAppSelector } from 'state/store'
 import { DashboardTab } from './DashboardTab'
 
 export const DashboardHeader = () => {
-  const claimableRewardsBalance = useAppSelector(state => selectClaimableRewards(state, {}))
-  const earnBalance = useAppSelector(selectEarnBalancesFiatAmountFull).toFixed()
+  const claimableRewardsFiatBalanceFilter = useMemo(() => ({}), [])
+  const claimableRewardsFiatBalance = useAppSelector(state =>
+    selectClaimableRewards(state, claimableRewardsFiatBalanceFilter),
+  )
+  const earnFiatBalance = useAppSelector(selectEarnBalancesFiatAmountFull).toFixed()
   const portfolioTotalFiatBalance = useAppSelector(selectPortfolioTotalFiatBalanceExcludeEarnDupes)
   const netWorth = useMemo(
-    () => bnOrZero(earnBalance).plus(portfolioTotalFiatBalance).toFixed(),
-    [earnBalance, portfolioTotalFiatBalance],
+    () =>
+      bnOrZero(earnFiatBalance)
+        .plus(portfolioTotalFiatBalance)
+        .plus(claimableRewardsFiatBalance)
+        .toFixed(),
+    [claimableRewardsFiatBalance, earnFiatBalance, portfolioTotalFiatBalance],
   )
   const borderColor = useColorModeValue('gray.100', 'gray.750')
   return (
@@ -62,14 +69,14 @@ export const DashboardHeader = () => {
         <DashboardTab
           label='defi.earnBalance'
           icon={<DefiIcon />}
-          fiatValue={earnBalance}
+          fiatValue={earnFiatBalance}
           path='/dashboard/earn'
           color='purple.500'
         />
         <DashboardTab
           label='defi.rewardBalance'
           icon={<RewardsIcon />}
-          fiatValue={claimableRewardsBalance}
+          fiatValue={claimableRewardsFiatBalance}
           path='/dashboard/rewards'
           color='green.500'
         />


### PR DESCRIPTION
## Description

Following up on https://github.com/shapeshift/web/pull/4111, now that we have tabs showing the breakdown between wallet, earn, and reward balances, the total doesn't match up "Net worth" as the rewards are currently not included in that number.

This PR includes them - note that this only includes *claimable* rewards. Discussed this one out with @reallybeard and since we don't include unclaimable ones in the "Reward Balance"

## Notice

<!-- Before submitting a pull request, please make sure you have answered the following: -->

- [x] Have you followed the guidelines in our [Contributing]('https://github.com/shapeshift/web/blob/develop/CONTRIBUTING.md) guide?
- [x] Have you checked to ensure there aren't other open [Pull Requests](https://github.com/shapeshift/web/pulls) for the same update/change?

## Pull Request Type

- [ ] :bug: Bug fix (Non-breaking Change: Fixes an issue)
- [ ] :hammer_and_wrench: Chore (Non-breaking Change: Doc updates, pkg upgrades, typos, etc..)
- [ ] :nail_care: New Feature (Breaking/Non-breaking Change)

## Issue (if applicable)

N/A

## Risk

<!-----------------------------------------------------------------------------
Outline the scope of your changes and the risk associated with them. You must use your discretion as an engineer to determine the potential impact of your changes.

E.g. an upgrade to `hdwallet` or core state management would be considered higher risk, and might require a full regression test. UI or isolated view changes, or something behind a feature flag may have near zero risk. Small bug fixes might require testing isolated to the specific fix.
------------------------------------------------------------------------------>

Low/none, if we got this wrong, we got bigger problems

## Testing

<!-----------------------------------------------------------------------------
We treat every PR to be merged with the same scrutiny as if we were merging directly to production.

Your PR will not be merged if you do not complete the sections below for our engineering and operations teams to test.
------------------------------------------------------------------------------>

- Enable the `DashboardTabs` flag (to be consolidated into `DefiDashboard` in a follow-up PR, so if you're testing this as the follow-up as been merged, enable `DefiDashboard` instead)
- Ensure "Wallet Balance" + "Earn Balance" + "Reward Balance" equals to the net worth

### Engineering

<!-----------------------------------------------------------------------------
Include sufficient information here for an engineer to test your PR. This may include how to test locally, in a built environment, changes to infrastructure etc.
------------------------------------------------------------------------------>

- ☝🏽 

### Operations

<!-----------------------------------------------------------------------------
If your changes have a user-facing impact, describe how a non-technical QA team can functionally test your changes in a preview environment.

If they are not user-facing please describe how to test for any regressions that may occur.
------------------------------------------------------------------------------>

- ☝🏽 

## Screenshots (if applicable)

<img width="1284" alt="image" src="https://user-images.githubusercontent.com/17035424/227336429-0c8f1369-4f19-4071-9126-9c52eaf64ddd.png">