### PR TITLE
feat: clear cache button

### DIFF
--- a/src/assets/translations/en/main.json
+++ b/src/assets/translations/en/main.json
@@ -1017,6 +1017,8 @@
       "loadingText": "Pairing Wallet"
     },
     "settings": {
+      "clearCache": "Clear cache",
+      "clearCacheTooltip": "Clear cache and reload app",
       "settings": "Settings",
       "currency": "Currency",
       "clearWalletAccountData": "Delete all accounts & wallet data",

--- a/src/components/Modals/Settings/SettingsList.tsx
+++ b/src/components/Modals/Settings/SettingsList.tsx
@@ -13,7 +13,7 @@ import {
 } from '@chakra-ui/react'
 import type { FC } from 'react'
 import { useCallback, useState } from 'react'
-import { FaCoins, FaDollarSign, FaGreaterThanEqual, FaTrash } from 'react-icons/fa'
+import { FaBroom, FaCoins, FaDollarSign, FaGreaterThanEqual, FaTrash } from 'react-icons/fa'
 import { IoDocumentTextOutline, IoLockClosed } from 'react-icons/io5'
 import { MdChevronRight, MdLanguage } from 'react-icons/md'
 import { useTranslate } from 'react-polyglot'
@@ -32,7 +32,7 @@ import {
   selectSelectedCurrency,
   selectSelectedLocale,
 } from 'state/slices/selectors'
-import { useAppSelector } from 'state/store'
+import { persistor, useAppSelector } from 'state/store'
 
 import { BalanceThresholdInput } from './BalanceThresholdInput'
 import { currencyFormatsRepresenter, SettingsRoutes } from './SettingsCommon'
@@ -85,6 +85,17 @@ export const SettingsList: FC<SettingsListProps> = ({ appHistory }) => {
         mobileLogger.error(e, 'Error deleting wallets')
       }
     }
+  }
+
+  const handleClearCacheClick = async () => {
+    try {
+      // clear store
+      await persistor.purge()
+      // send them back to dashboard in case the bug was something to do with the current page
+      appHistory.replace('/')
+      // reload the page
+      window.location.reload()
+    } catch (e) {}
   }
 
   return (
@@ -152,6 +163,13 @@ export const SettingsList: FC<SettingsListProps> = ({ appHistory }) => {
           >
             <BalanceThresholdInput />
           </SettingsListItem>
+          <Divider my={1} />
+          <SettingsListItem
+            label='modals.settings.clearCache'
+            icon={<Icon as={FaBroom} color='gray.500' />}
+            tooltipText='modals.settings.clearCacheTooltip'
+            onClick={handleClearCacheClick}
+          />
           <Divider my={1} />
           <SettingsListItem
             label='common.terms'

--- a/src/components/Modals/Settings/SettingsList.tsx
+++ b/src/components/Modals/Settings/SettingsList.tsx
@@ -87,7 +87,7 @@ export const SettingsList: FC<SettingsListProps> = ({ appHistory }) => {
     }
   }
 
-  const handleClearCacheClick = async () => {
+  const handleClearCacheClick = useCallback(async () => {
     try {
       // clear store
       await persistor.purge()
@@ -96,7 +96,7 @@ export const SettingsList: FC<SettingsListProps> = ({ appHistory }) => {
       // reload the page
       window.location.reload()
     } catch (e) {}
-  }
+  }, [appHistory])
 
   return (
     <SlideTransition>


### PR DESCRIPTION
## Description

<!-- Please describe your changes -->

requested by ops - a button in the settings modal to clear the redux cache and reload the app

this PR will

* clear the redux cache
* navigate the user back to the dashboard
* do a hard reload of the app

## Notice

<!-- Before submitting a pull request, please make sure you have answered the following: -->

- [x] Have you followed the guidelines in our [Contributing]('https://github.com/shapeshift/web/blob/develop/CONTRIBUTING.md) guide?
- [x] Have you checked to ensure there aren't other open [Pull Requests](https://github.com/shapeshift/web/pulls) for the same update/change?

## Pull Request Type

- [x] :bug: Bug fix (Non-breaking Change: Fixes an issue)
- [ ] :hammer_and_wrench: Chore (Non-breaking Change: Doc updates, pkg upgrades, typos, etc..)
- [x] :nail_care: New Feature (Breaking/Non-breaking Change)

## Issue (if applicable)

<!-----------------------------------------------------------------------------
If applicable, please link to the github issue and put `closes #XXXX` in your comment to auto-close the issue that your PR fixes.
------------------------------------------------------------------------------>

n/a

## Risk

low - clearing cache is useful for support to triage issues

<!-----------------------------------------------------------------------------
Outline the scope of your changes and the risk associated with them. You must use your discretion as an engineer to determine the potential impact of your changes.

E.g. an upgrade to `hdwallet` or core state management would be considered higher risk, and might require a full regression test. UI or isolated view changes, or something behind a feature flag may have near zero risk. Small bug fixes might require testing isolated to the specific fix.
------------------------------------------------------------------------------>

## Testing

* hit the button
* notice the app reloads
* see wallet/earn/rewards balance repopulate
* see consent banner reappears (this won't mess with mixpanel tracking)

<!-----------------------------------------------------------------------------
We treat every PR to be merged with the same scrutiny as if we were merging directly to production.

Your PR will not be merged if you do not complete the sections below for our engineering and operations teams to test.
------------------------------------------------------------------------------>

### Engineering

as above

<!-----------------------------------------------------------------------------
Include sufficient information here for an engineer to test your PR. This may include how to test locally, in a built environment, changes to infrastructure etc.
------------------------------------------------------------------------------>

### Operations

as above

<!-----------------------------------------------------------------------------
If your changes have a user-facing impact, describe how a non-technical QA team can functionally test your changes in a preview environment.

If they are not user-facing please describe how to test for any regressions that may occur.
------------------------------------------------------------------------------>

## Screenshots (if applicable)


https://user-images.githubusercontent.com/88504456/228676635-92b5469a-d1ef-43ff-a466-cb0753a6466f.mov
