### PR TITLE
feat: tail halted swappers

### DIFF
--- a/src/components/Trade/hooks/useAvailableSwappers.tsx
+++ b/src/components/Trade/hooks/useAvailableSwappers.tsx
@@ -133,10 +133,13 @@ export const useAvailableSwappers = () => {
 
       const [active, halted] = partitionedSwapperPromises.filter(isFulfilled).map(p => p.value)
 
-      // Put all halted swappers last
-      const reOrderedSwappers = [...active, ...halted]
-      const activeSwapperWithQuoteMetadata = reOrderedSwappers?.[0]
-      updateAvailableSwappersWithMetadata(reOrderedSwappers)
+      /*
+        If we have active swappers, show only them. Else, show any halted swappers so the user knows the trade pair
+        is actually supported by us, it's just currently halted.
+       */
+      const swappersToDisplay = active.length > 0 ? active : halted
+      const activeSwapperWithQuoteMetadata = swappersToDisplay?.[0]
+      updateAvailableSwappersWithMetadata(swappersToDisplay)
       updateActiveSwapperWithMetadata(activeSwapperWithQuoteMetadata)
       feeAsset && updateFees(feeAsset)
     })()

--- a/src/components/Trade/hooks/useAvailableSwappers.tsx
+++ b/src/components/Trade/hooks/useAvailableSwappers.tsx
@@ -101,7 +101,7 @@ export const useAvailableSwappers = () => {
        */
       const active: SwapperWithQuoteMetadata[] = []
       const halted: SwapperWithQuoteMetadata[] = []
-      await Promise.allSettled(
+      await Promise.all(
         swappersWithQuoteMetadata.map(async swapperWithQuoteMetadata => {
           const isActive = await (async () => {
             const activeSwapper = swapperWithQuoteMetadata.swapper

--- a/src/components/Trade/hooks/useAvailableSwappers.tsx
+++ b/src/components/Trade/hooks/useAvailableSwappers.tsx
@@ -94,8 +94,8 @@ export const useAvailableSwappers = () => {
     ;(async () => {
       if (!swappersWithQuoteMetadata) return
       /*
-        The available swappers endpoint returns all available swappers for a given trade pair, ordered by rate.
-        A halted swapper may well have the best rate, but we want to put it last in the list.
+        The available swappers endpoint returns all available swappers for a given trade pair, ordered by rate, including halted.
+        A halted swapper may well have the best rate, but we don't want to show it unless there are none other available.
        */
       const partitionedSwapperPromises = await Promise.allSettled(
         partition(swappersWithQuoteMetadata, async swapperWithQuoteMetadata => {


### PR DESCRIPTION
## Description

When multiple swappers are available, we want to show halted swappers last in the list (even if they have the best rate). The list order is also used to determine the initial (active) swapper selection, which should be the best non-halted swapper.

## Notice

- [x] Have you followed the guidelines in our [Contributing]('https://github.com/shapeshift/web/blob/develop/CONTRIBUTING.md) guide?
- [x] Have you checked to ensure there aren't other open [Pull Requests](https://github.com/shapeshift/web/pulls) for the same update/change?

## Pull Request Type

- [ ] :bug: Bug fix (Non-breaking Change: Fixes an issue)
- [ ] :hammer_and_wrench: Chore (Non-breaking Change: Doc updates, pkg upgrades, typos, etc..)
- [x] :nail_care: New Feature (Breaking/Non-breaking Change)

## Issue (if applicable)

Contributes to https://github.com/shapeshift/web/issues/3468.

## Risk

Small. If we are getting all expected swappers, all is well.

## Testing

Enable the `REACT_APP_FEATURE_TRADE_RATES` feature and ensure swappers are shown in the correct order, and that all expected swappers are listed.

### Engineering

👆

You could monkey patch the halt flag to false is interested.

### Operations

👆

## Screenshots (if applicable)

N/A
