### PR TITLE
fix: don't show empty errored chain names

### DIFF
--- a/src/components/Layout/Layout.tsx
+++ b/src/components/Layout/Layout.tsx
@@ -56,6 +56,8 @@ const DegradedStateBanner = () => {
     )
   }, [dispatch, erroredAccountIds])
 
+  if (!erroredAccountNames?.length) return null
+
   return (
     <Alert
       status='warning'


### PR DESCRIPTION
## Description

<!-- Please describe your changes -->

fix - don't show error/warning banner about not being able to fetch a chain if the flag is off and we don't have the chain name

we often have issues with chains shortly after we launch them

case in point - bnb node currently sad, and we're showing the error in screenshot below with an empty name, which isn't useful to the user

this is because of the plugin model and we don't have the chain adapter available, hence no chain name

## Notice

<!-- Before submitting a pull request, please make sure you have answered the following: -->

- [x] Have you followed the guidelines in our [Contributing]('https://github.com/shapeshift/web/blob/develop/CONTRIBUTING.md) guide?
- [x] Have you checked to ensure there aren't other open [Pull Requests](https://github.com/shapeshift/web/pulls) for the same update/change?

## Pull Request Type

- [x] :bug: Bug fix (Non-breaking Change: Fixes an issue)
- [ ] :hammer_and_wrench: Chore (Non-breaking Change: Doc updates, pkg upgrades, typos, etc..)
- [ ] :nail_care: New Feature (Breaking/Non-breaking Change)

## Issue (if applicable)

<!-----------------------------------------------------------------------------
If applicable, please link to the github issue and put `closes #XXXX` in your comment to auto-close the issue that your PR fixes.
------------------------------------------------------------------------------>

n/a

## Risk

basically zero - hiding a banner if we don't have useful info to display

<!-----------------------------------------------------------------------------
Outline the scope of your changes and the risk associated with them. You must use your discretion as an engineer to determine the potential impact of your changes.

E.g. an upgrade to `hdwallet` or core state management would be considered higher risk, and might require a full regression test. UI or isolated view changes, or something behind a feature flag may have near zero risk. Small bug fixes might require testing isolated to the specific fix.
------------------------------------------------------------------------------>

## Testing

<!-----------------------------------------------------------------------------
We treat every PR to be merged with the same scrutiny as if we were merging directly to production.

Your PR will not be merged if you do not complete the sections below for our engineering and operations teams to test.
------------------------------------------------------------------------------>

### Engineering

ensure my early return is sane lmeow

<!-----------------------------------------------------------------------------
Include sufficient information here for an engineer to test your PR. This may include how to test locally, in a built environment, changes to infrastructure etc.
------------------------------------------------------------------------------>

### Operations

unable to be tested by ops

<!-----------------------------------------------------------------------------
If your changes have a user-facing impact, describe how a non-technical QA team can functionally test your changes in a preview environment.

If they are not user-facing please describe how to test for any regressions that may occur.
------------------------------------------------------------------------------>

## Screenshots (if applicable)

prod currently

<img width="424" alt="image" src="https://user-images.githubusercontent.com/88504456/228964997-cb08a795-b981-4b8a-90d9-dd9f747da826.png">

this diff

<img width="426" alt="image" src="https://user-images.githubusercontent.com/88504456/228965029-7a648976-88a0-464c-9f71-31ad4f93ae45.png">

