### PR TITLE
feat: context-specific swapper colors

### DIFF
--- a/src/components/Trade/Components/TradeQuotes/TradeQuote.tsx
+++ b/src/components/Trade/Components/TradeQuotes/TradeQuote.tsx
@@ -14,6 +14,7 @@ import { FaGasPump } from 'react-icons/fa'
 import { useTranslate } from 'react-polyglot'
 import { Amount } from 'components/Amount/Amount'
 import { RawText } from 'components/Text'
+import { useIsTradingActive } from 'components/Trade/hooks/useIsTradingActive'
 import { bnOrZero } from 'lib/bignumber/bignumber'
 import { fromBaseUnit } from 'lib/math'
 import { selectFeeAssetByChainId, selectFeeAssetById } from 'state/slices/selectors'
@@ -79,8 +80,11 @@ export const TradeQuoteLoaded: React.FC<TradeQuoteLoadedProps> = ({
   const translate = useTranslate()
   const borderColor = useColorModeValue('blackAlpha.100', 'whiteAlpha.100')
   const greenColor = useColorModeValue('green.500', 'green.200')
+  const redColor = useColorModeValue('red.500', 'red.200')
   const hoverColor = useColorModeValue('blackAlpha.300', 'whiteAlpha.300')
   const focusColor = useColorModeValue('blackAlpha.400', 'whiteAlpha.400')
+
+  const { isTradingActive } = useIsTradingActive()
 
   const feeAssetFiatRate = useSwapperStore(selectFeeAssetFiatRate)
   const buyAsset = useSwapperStore(selectBuyAsset)
@@ -145,13 +149,21 @@ export const TradeQuoteLoaded: React.FC<TradeQuoteLoadedProps> = ({
         return <Tag size='sm'>{translate('common.alternative')}</Tag>
     }
   }, [isBest, negativeRatio, translate])
+
+  const activeSwapperColor = (() => {
+    if (!isTradingActive) return redColor
+    if (!hasAmountWithPositiveReceive) return redColor
+    if (isActive) return greenColor
+    return borderColor
+  })()
+
   return networkFeeFiat && totalReceiveAmountCryptoPrecision ? (
     <Flex
       borderWidth={1}
       cursor='pointer'
-      borderColor={isActive ? greenColor : borderColor}
-      _hover={{ borderColor: isActive ? greenColor : hoverColor }}
-      _active={{ borderColor: isActive ? greenColor : focusColor }}
+      borderColor={isActive ? activeSwapperColor : borderColor}
+      _hover={{ borderColor: isActive ? activeSwapperColor : hoverColor }}
+      _active={{ borderColor: isActive ? activeSwapperColor : focusColor }}
       borderRadius='xl'
       flexDir='column'
       gap={2}

--- a/src/components/Trade/hooks/useIsTradingActive.tsx
+++ b/src/components/Trade/hooks/useIsTradingActive.tsx
@@ -49,5 +49,9 @@ export const useIsTradingActive = () => {
     })()
   }, [activeSwapper, buyAssetId, dispatch, getIsTradingActive, sellAssetId])
 
-  return { isTradingActiveOnSellPool, isTradingActiveOnBuyPool }
+  return {
+    isTradingActiveOnSellPool,
+    isTradingActiveOnBuyPool,
+    isTradingActive: isTradingActiveOnSellPool && isTradingActiveOnBuyPool,
+  }
 }


### PR DESCRIPTION
## Description

Improves colors of swapper boarders to better reflect their status (see screenshots below). 

## Notice

- [x] Have you followed the guidelines in our [Contributing]('https://github.com/shapeshift/web/blob/develop/CONTRIBUTING.md) guide?
- [x] Have you checked to ensure there aren't other open [Pull Requests](https://github.com/shapeshift/web/pulls) for the same update/change?

## Pull Request Type

- [ ] :bug: Bug fix (Non-breaking Change: Fixes an issue)
- [ ] :hammer_and_wrench: Chore (Non-breaking Change: Doc updates, pkg upgrades, typos, etc..)
- [x] :nail_care: New Feature (Breaking/Non-breaking Change)

## Issue (if applicable)

N/A

## Risk

Small - isolated to one component, and visual-only.

## Testing

Test each of the different quote states in the screenshot below and ensure that the UI looks as expected.
Additionally, ensure no happy-path regressions.

### Engineering

☝️

### Operations

☝️

## Screenshots (if applicable)

**No amounts entered**

<img width="878" alt="Screenshot 2023-04-03 at 11 45 09 am" src="https://user-images.githubusercontent.com/97164662/229394449-81ba56a3-e30f-44f0-a128-1c5351b08317.png">

**Valid quote, swapper not halted**

<img width="861" alt="Screenshot 2023-04-03 at 11 45 32 am" src="https://user-images.githubusercontent.com/97164662/229394480-ea96f215-a386-4e7c-b24c-206aa9b16bb1.png">

**Fees higher than sell amount**

<img width="875" alt="Screenshot 2023-04-03 at 11 45 54 am" src="https://user-images.githubusercontent.com/97164662/229394541-ae20f740-e4d5-4501-8ee2-a48d3a3cc620.png">

**Swapper halted**

<img width="887" alt="Screenshot 2023-04-03 at 11 49 32 am" src="https://user-images.githubusercontent.com/97164662/229394792-9d438ad6-bd51-4584-ba48-c79ee10b5582.png">
