### PR TITLE
feat: active blended APY by AssetId/Provider

### DIFF
--- a/src/assets/translations/de/main.json
+++ b/src/assets/translations/de/main.json
@@ -404,7 +404,6 @@
     "totalValue": "Gesamtwert",
     "byPosition": "Nach Position",
     "byProvider": "Nach Anbieter",
-    "netApy": "Netto APY",
     "claimableRewards": "Forderbare Belohnungen",
     "reawrds": "Belohnungen",
     "stakingPosition": "Stake Position",

--- a/src/assets/translations/en/main.json
+++ b/src/assets/translations/en/main.json
@@ -410,7 +410,6 @@
     "totalValue": "Total Value",
     "byPosition": "By Position",
     "byProvider": "By Provider",
-    "netApy": "Net APY",
     "claimableRewards": "Claimable Rewards",
     "reawrds": "Rewards",
     "stakingPosition": "Staking Position",

--- a/src/assets/translations/es/main.json
+++ b/src/assets/translations/es/main.json
@@ -404,7 +404,6 @@
     "totalValue": "Valor Total",
     "byPosition": "Por Posición",
     "byProvider": "Por Proveedor",
-    "netApy": "APY neto",
     "claimableRewards": "Recompensas reclamables",
     "reawrds": "Recompensas",
     "stakingPosition": "Posición Staking",

--- a/src/assets/translations/fr/main.json
+++ b/src/assets/translations/fr/main.json
@@ -404,7 +404,6 @@
     "totalValue": "Valeur totale",
     "byPosition": "Par position",
     "byProvider": "Par fournisseur",
-    "netApy": "APY Net",
     "claimableRewards": "Récompenses réclamables",
     "reawrds": "Récompenses",
     "stakingPosition": "Position de mises",

--- a/src/assets/translations/pt/main.json
+++ b/src/assets/translations/pt/main.json
@@ -404,7 +404,6 @@
     "totalValue": "Valor total",
     "byPosition": "Por posição",
     "byProvider": "Por Provedor de Liquidez",
-    "netApy": "APY Total",
     "claimableRewards": "Recompensas Resgatáveis",
     "reawrds": "Recompensas",
     "stakingPosition": "Posição em Stake",

--- a/src/assets/translations/ru/main.json
+++ b/src/assets/translations/ru/main.json
@@ -401,7 +401,6 @@
     "poolValue": "Обьем пула",
     "yearn": "Yearn Finance",
     "totalValue": "Общая стоимость",
-    "netApy": "Net APY",
     "claimableRewards": "Вознаграждения, на которые можно претендовать",
     "reawrds": "Вознаграждения",
     "stakingPosition": "Позиция стейкинга",

--- a/src/assets/translations/tr/main.json
+++ b/src/assets/translations/tr/main.json
@@ -404,7 +404,6 @@
     "totalValue": "Toplam Değer",
     "byPosition": "Pozisyona Göre",
     "byProvider": "Sağlayıcıya Göre",
-    "netApy": "Net APY",
     "claimableRewards": "Talep Edilebilir Ödüller",
     "reawrds": "Ödüller",
     "stakingPosition": "Staking Pozisyonu",

--- a/src/assets/translations/uk/main.json
+++ b/src/assets/translations/uk/main.json
@@ -401,7 +401,6 @@
     "poolValue": "Вартість пулу",
     "yearn": "Yearn Finance",
     "totalValue": "Загальна вартість",
-    "netApy": "Net APY",
     "claimableRewards": "Винагороди, які можна отримати",
     "reawrds": "Винагороди",
     "stakingPosition": "Позиція в стейкінгу",

--- a/src/components/StakingVaults/PositionTable.tsx
+++ b/src/components/StakingVaults/PositionTable.tsx
@@ -102,13 +102,13 @@ export const PositionTable: React.FC<PositionTableProps> = ({
         },
       },
       {
-        Header: translate('defi.netApy'),
-        accessor: 'netApy',
+        Header: translate('defi.apy'),
+        accessor: 'apy',
         textAlign: 'right',
         Cell: ({ row }: { row: RowProps }) => (
           <Flex justifyContent={{ base: 'flex-end', md: 'flex-start' }}>
             <Tag colorScheme='green' size={{ base: 'sm', md: 'md' }}>
-              <Amount.Percent value={row.original.netApy} />
+              <Amount.Percent value={row.original.apy} />
             </Tag>
           </Flex>
         ),

--- a/src/components/StakingVaults/ProviderTable.tsx
+++ b/src/components/StakingVaults/ProviderTable.tsx
@@ -91,13 +91,13 @@ export const ProviderTable: React.FC<ProviderTableProps> = ({
         },
       },
       {
-        Header: translate('defi.netApy'),
-        accessor: 'netApy',
+        Header: translate('defi.apy'),
+        accessor: 'apy',
         textAlign: 'right',
         Cell: ({ row }: { row: RowProps }) => (
           <Flex justifyContent={{ base: 'flex-end', md: 'flex-start' }}>
             <Tag colorScheme='green' size={{ base: 'sm', md: 'md' }}>
-              <Amount.Percent value={row.original.netApy} />
+              <Amount.Percent value={row.original.apy} />
             </Tag>
           </Flex>
         ),

--- a/src/state/slices/opportunitiesSlice/selectors/combined.ts
+++ b/src/state/slices/opportunitiesSlice/selectors/combined.ts
@@ -123,7 +123,7 @@ export const selectAggregatedEarnOpportunitiesByAssetId = createDeepEqualOutputS
         })
 
         if (
-          (!includeEarnBalances && !includeRewardsBalances) ||
+          (!includeEarnBalances && !includeRewardsBalances && bnOrZero(amountFiat).gt(0)) ||
           (includeEarnBalances && bnOrZero(amountFiat).gt(0)) ||
           (includeRewardsBalances && bnOrZero(maybeStakingRewardsAmountFiat).gt(0))
         ) {
@@ -337,7 +337,7 @@ export const selectAggregatedEarnOpportunitiesByProvider = createDeepEqualOutput
       })
 
       const isActiveOpportunityByFilter =
-        (!includeEarnBalances && !includeRewardsBalances) ||
+        (!includeEarnBalances && !includeRewardsBalances && bnOrZero(cur.fiatAmount).gt(0)) ||
         (includeEarnBalances && bnOrZero(cur.fiatAmount).gt(0)) ||
         (includeRewardsBalances && bnOrZero(maybeStakingRewardsAmountFiat).gt(0))
 

--- a/src/state/slices/opportunitiesSlice/selectors/combined.ts
+++ b/src/state/slices/opportunitiesSlice/selectors/combined.ts
@@ -132,7 +132,7 @@ export const selectAggregatedEarnOpportunitiesByAssetId = createDeepEqualOutputS
             acc[assetId] = {
               assetId,
               underlyingAssetIds: cur.underlyingAssetIds,
-              netApy: '0',
+              apy: '0',
               fiatAmount: '0',
               cryptoBalancePrecision: '0',
               fiatRewardsAmount: '0',
@@ -213,10 +213,8 @@ export const selectAggregatedEarnOpportunitiesByAssetId = createDeepEqualOutputS
     )
 
     for (const [assetId, totalVirtualFiatAmount] of Object.entries(totalFiatAmountByAssetId)) {
-      const netApy = bnOrZero(projectedAnnualizedYieldByAssetId[assetId]).div(
-        totalVirtualFiatAmount,
-      )
-      byAssetId[assetId].netApy = netApy.toFixed()
+      const apy = bnOrZero(projectedAnnualizedYieldByAssetId[assetId]).div(totalVirtualFiatAmount)
+      byAssetId[assetId].apy = apy.toFixed()
     }
 
     const aggregatedEarnOpportunitiesByAssetId = Object.values(byAssetId)
@@ -294,7 +292,7 @@ export const selectAggregatedEarnOpportunitiesByProvider = createDeepEqualOutput
 
     const makeEmptyPayload = (provider: DefiProvider): AggregatedOpportunitiesByProviderReturn => ({
       provider,
-      netApy: '0',
+      apy: '0',
       fiatAmount: '0',
       fiatRewardsAmount: '0',
       opportunities: {
@@ -356,10 +354,10 @@ export const selectAggregatedEarnOpportunitiesByProvider = createDeepEqualOutput
     }, initial)
 
     for (const [provider, totalVirtualFiatAmount] of Object.entries(totalFiatAmountByProvider)) {
-      const netApy = bnOrZero(projectedAnnualizedYieldByProvider[provider as DefiProvider]).div(
+      const apy = bnOrZero(projectedAnnualizedYieldByProvider[provider as DefiProvider]).div(
         totalVirtualFiatAmount,
       )
-      byProvider[provider as DefiProvider].netApy = netApy.toFixed()
+      byProvider[provider as DefiProvider].apy = apy.toFixed()
     }
 
     const aggregatedEarnOpportunitiesByProvider = Object.values(byProvider).reduce<

--- a/src/state/slices/opportunitiesSlice/types.ts
+++ b/src/state/slices/opportunitiesSlice/types.ts
@@ -191,7 +191,7 @@ export type EarnOpportunityType = StakingEarnOpportunityType | LpEarnOpportunity
 export type AggregatedOpportunitiesByAssetIdReturn = {
   assetId: AssetId
   underlyingAssetIds: AssetIdsTuple
-  netApy: string
+  apy: string
   fiatAmount: string
   cryptoBalancePrecision: string
   fiatRewardsAmount: string
@@ -200,7 +200,7 @@ export type AggregatedOpportunitiesByAssetIdReturn = {
 
 export type AggregatedOpportunitiesByProviderReturn = {
   provider: DefiProvider
-  netApy: string
+  apy: string
   fiatAmount: string
   fiatRewardsAmount: string
   opportunities: Record<DefiType, OpportunityId[]>


### PR DESCRIPTION
## Description

This PR tackles the APY displayed for DeFi providers/AssetIds tables - ensures we display top-level blended active APYs *only* (i.e, not the ones inactive), in case the user has an active staking for said asset/opportunity type.

Else, if the user has no active staking, ~~blends inactive APYs only~~ use the highest APY from the displayed opportunities (discussed with @willyogo).

Note, this does not contribute the APYs range. The reason for this is a range is not a number, thus:

- sorting wouldn't work anymore
- we wouldn't be able to use `<Amount.Percent />` and would have to resort to a bunch of hacks to get the same UI as the current one

## Notice

<!-- Before submitting a pull request, please make sure you have answered the following: -->

- [x] Have you followed the guidelines in our [Contributing]('https://github.com/shapeshift/web/blob/develop/CONTRIBUTING.md) guide?
- [x] Have you checked to ensure there aren't other open [Pull Requests](https://github.com/shapeshift/web/pulls) for the same update/change?

## Pull Request Type

- [ ] :bug: Bug fix (Non-breaking Change: Fixes an issue)
- [ ] :hammer_and_wrench: Chore (Non-breaking Change: Doc updates, pkg upgrades, typos, etc..)
- [x] :nail_care: New Feature (Breaking/Non-breaking Change)

## Issue (if applicable)

<!-----------------------------------------------------------------------------
If applicable, please link to the github issue and put `closes #XXXX` in your comment to auto-close the issue that your PR fixes.
------------------------------------------------------------------------------>

closes https://github.com/shapeshift/web/issues/4117

## Risk

<!-----------------------------------------------------------------------------
Outline the scope of your changes and the risk associated with them. You must use your discretion as an engineer to determine the potential impact of your changes.

E.g. an upgrade to `hdwallet` or core state management would be considered higher risk, and might require a full regression test. UI or isolated view changes, or something behind a feature flag may have near zero risk. Small bug fixes might require testing isolated to the specific fix.
------------------------------------------------------------------------------>

## Testing

<!-----------------------------------------------------------------------------
We treat every PR to be merged with the same scrutiny as if we were merging directly to production.

Your PR will not be merged if you do not complete the sections below for our engineering and operations teams to test.
------------------------------------------------------------------------------>

### Engineering

<!-----------------------------------------------------------------------------
Include sufficient information here for an engineer to test your PR. This may include how to test locally, in a built environment, changes to infrastructure etc.
------------------------------------------------------------------------------>

### Operations

<!-----------------------------------------------------------------------------
If your changes have a user-facing impact, describe how a non-technical QA team can functionally test your changes in a preview environment.

If they are not user-facing please describe how to test for any regressions that may occur.
------------------------------------------------------------------------------>

## Screenshots (if applicable)

### Earn page - inactive by position

<img width="1010" alt="image" src="https://user-images.githubusercontent.com/17035424/229547494-4677f980-a199-469f-aba2-2a30d1095aa9.png">

### Earn page - inactive by provider

<img width="1079" alt="image" src="https://user-images.githubusercontent.com/17035424/229547808-0ea572bc-1c85-4586-9394-de8ca24c67e7.png">

### Earn page - active by position

<img width="1085" alt="image" src="https://user-images.githubusercontent.com/17035424/229548026-792d0807-9ab3-4394-b4e0-6c4fbcd931ff.png">

### Earn page - active by provider

<img width="1090" alt="image" src="https://user-images.githubusercontent.com/17035424/229548198-7689f603-3179-4d45-b1a3-baa46d71566f.png">
<img width="1091" alt="image" src="https://user-images.githubusercontent.com/17035424/229548248-153ef260-f948-4685-8c3c-7b32e2334edf.png">
<img width="1092" alt="image" src="https://user-images.githubusercontent.com/17035424/229548308-1f271b34-6c38-4315-9258-74cd0244f86a.png">

### Earn balance - active by position

<img width="1097" alt="image" src="https://user-images.githubusercontent.com/17035424/229548456-3ac95cac-e1ef-4e8e-9ac2-10e151210915.png">

### Earn balance - active by provider

<img width="1094" alt="image" src="https://user-images.githubusercontent.com/17035424/229548604-f8d6d7d7-4f4f-445f-8602-abf010871d7b.png">

### Rewards balance - active by position

<img width="1090" alt="image" src="https://user-images.githubusercontent.com/17035424/229548743-31b9fda3-bb3f-488c-9846-6b712d059e78.png">

### Rewards balance - active by provider

<img width="1080" alt="image" src="https://user-images.githubusercontent.com/17035424/229548852-c7056ba2-a954-4668-a10f-0a6ad90bfb60.png">
