### PR TITLE
fix: locked wallet UI

### DIFF
--- a/src/assets/translations/en/main.json
+++ b/src/assets/translations/en/main.json
@@ -222,7 +222,8 @@
       "triggerButton": "Connect Wallet",
       "switchWallet": "Switch Wallet Provider",
       "disconnect": "Disconnect",
-      "disconnected": "(Disconnected)"
+      "disconnected": "(Disconnected)",
+      "connecting": "Connecting..."
     }
   },
   "defi": {

--- a/src/components/Layout/Header/NavBar/UserMenu.tsx
+++ b/src/components/Layout/Header/NavBar/UserMenu.tsx
@@ -104,7 +104,6 @@ const WalletButton: FC<WalletButtonProps> = ({
       width={{ base: '100%', lg: 'auto' }}
       justifyContent='flex-start'
       variant='outline'
-      isLoading={isLoadingLocalWallet}
       rightIcon={<ChevronDownIcon />}
       leftIcon={
         <HStack>
@@ -167,7 +166,7 @@ export const UserMenu: React.FC<{ onClick?: () => void }> = ({ onClick }) => {
           // Override zIndex to prevent InputLeftElement displaying over menu
           zIndex={2}
         >
-          {hasWallet ? (
+          {hasWallet || isLoadingLocalWallet ? (
             <WalletConnected
               isConnected={isConnected || isDemoWallet}
               walletInfo={walletInfo}

--- a/src/components/Layout/Header/NavBar/WalletConnectedMenu.tsx
+++ b/src/components/Layout/Header/NavBar/WalletConnectedMenu.tsx
@@ -1,4 +1,4 @@
-import { ChevronRightIcon, CloseIcon, RepeatIcon } from '@chakra-ui/icons'
+import { ChevronRightIcon, CloseIcon, RepeatIcon, WarningTwoIcon } from '@chakra-ui/icons'
 import { MenuDivider, MenuGroup, MenuItem } from '@chakra-ui/menu'
 import { Flex } from '@chakra-ui/react'
 import { AnimatePresence } from 'framer-motion'
@@ -37,32 +37,38 @@ export const WalletConnectedMenu = ({
   const ConnectedMenu = () => {
     return (
       <MenuGroup title={translate('common.connectedWallet')} color='gray.500'>
-        <MenuItem
-          closeOnSelect={!connectedWalletMenuRoutes}
-          isDisabled={!connectedWalletMenuRoutes}
-          onClick={
-            connectedWalletMenuRoutes
-              ? () =>
-                  navigateToRoute(
-                    (type && SUPPORTED_WALLETS[type])?.connectedWalletMenuInitialPath ??
-                      WalletConnectedRoutes.Connected,
-                  )
-              : undefined
-          }
-          icon={<WalletImage walletInfo={walletInfo} />}
-        >
-          <Flex flexDir='row' justifyContent='space-between' alignItems='center'>
-            <RawText>{walletInfo?.name}</RawText>
-            {!isConnected && (
-              <Text
-                translation={'connectWallet.menu.disconnected'}
-                fontSize='sm'
-                color='yellow.500'
-              />
-            )}
-            {connectedWalletMenuRoutes && <ChevronRightIcon />}
-          </Flex>
-        </MenuItem>
+        {walletInfo ? (
+          <MenuItem
+            closeOnSelect={!connectedWalletMenuRoutes}
+            isDisabled={!connectedWalletMenuRoutes}
+            onClick={
+              connectedWalletMenuRoutes
+                ? () =>
+                    navigateToRoute(
+                      (type && SUPPORTED_WALLETS[type])?.connectedWalletMenuInitialPath ??
+                        WalletConnectedRoutes.Connected,
+                    )
+                : undefined
+            }
+            icon={<WalletImage walletInfo={walletInfo} />}
+          >
+            <Flex flexDir='row' justifyContent='space-between' alignItems='center'>
+              <RawText>{walletInfo?.name}</RawText>
+              {!isConnected && (
+                <Text
+                  translation={'connectWallet.menu.disconnected'}
+                  fontSize='sm'
+                  color='yellow.500'
+                />
+              )}
+              {connectedWalletMenuRoutes && <ChevronRightIcon />}
+            </Flex>
+          </MenuItem>
+        ) : (
+          <MenuItem icon={<WarningTwoIcon />} onClick={onSwitchProvider} isDisabled={true}>
+            {translate('connectWallet.menu.connecting')}
+          </MenuItem>
+        )}
         {ConnectMenuComponent && <ConnectMenuComponent />}
         <MenuDivider />
         <MenuItem icon={<RepeatIcon />} onClick={onSwitchProvider}>


### PR DESCRIPTION
## Description

The current UI when a wallet is locked is a little rough on the user. 

As a user, if my Metamask wallet is locked, and I want to disconnect it or switch to another wallet, I have to first unlock my wallet to access the menu to do so. If the Metamask plugin is in a broken state, or I don't have my password available I'm now stuck.

This PR enables access to the menu whilst a wallet is locked.

Production:

<img width="176" alt="Screenshot 2023-04-04 at 11 53 38 am" src="https://user-images.githubusercontent.com/97164662/229667052-8d0cb3e8-4254-452c-ae98-0376cb932273.png">

This PR:

<img width="372" alt="Screenshot 2023-04-04 at 11 52 52 am" src="https://user-images.githubusercontent.com/97164662/229667068-528fb521-d047-43fb-8f33-640b35ee7281.png">


CC @shapeshift/product & @reallybeard.

## Notice

- [x] Have you followed the guidelines in our [Contributing]('https://github.com/shapeshift/web/blob/develop/CONTRIBUTING.md) guide?
- [x] Have you checked to ensure there aren't other open [Pull Requests](https://github.com/shapeshift/web/pulls) for the same update/change?

## Pull Request Type

- [x] :bug: Bug fix (Non-breaking Change: Fixes an issue)
- [ ] :hammer_and_wrench: Chore (Non-breaking Change: Doc updates, pkg upgrades, typos, etc..)
- [ ] :nail_care: New Feature (Breaking/Non-breaking Change)

## Issue (if applicable)

N/A

## Risk

Small

## Testing

To replicate the state this PR aims to improve:

1. Connect to the Dashboard with Metamask
2. Lock the wallet
3. Refresh the dashboard
4. Notice that you can now disconnect/switch wallets

Also ensure that there are no regressions connecting to or disconnecting from other wallets.

### Engineering

☝️

### Operations

☝️

## Screenshots (if applicable)

As above.
