### PR TITLE
fix: update vault cap tooltip

### DIFF
--- a/src/assets/translations/en/main.json
+++ b/src/assets/translations/en/main.json
@@ -310,7 +310,7 @@
       "saversVaults": {
         "description": "Earn yield on your %{asset} through the THORChain Savers Vaults. There is no lock up time, and rewards are accumulated automatically. Yield on THORChain comes from swap fees and block rewards. Single-sided yield is capped at half the double-sided yield of liquidity providers.",
         "vaultCap": "Vault Cap",
-        "vaultCapTooltip": "Something about vault caps",
+        "vaultCapTooltip": "Current maximum capacity for this vault",
         "haltedTitle": "Deposits are temporarily halted.",
         "haltedDescription": "Please tweet at @THORChain to raise the caps!",
         "estimatedFee": "Estimated Fee",


### PR DESCRIPTION
Tooltip copy update:
"Something about vault caps" -> "Current maximum capacity for this vault"
![image](https://user-images.githubusercontent.com/88504456/229963951-809b0fda-4b7e-4cb0-a3d0-925bfc4b7255.png)

