### PR TITLE
fix: thorchain savers deposit days to break even

### DIFF
--- a/src/features/defi/providers/thorchain-savers/components/ThorchainSaversManager/Deposit/components/Confirm.tsx
+++ b/src/features/defi/providers/thorchain-savers/components/ThorchainSaversManager/Deposit/components/Confirm.tsx
@@ -163,7 +163,7 @@ export const Confirm: React.FC<ConfirmProps> = ({ accountId, onNext }) => {
 
       const slippagePercentage = bnOrZero(slippage_bps).div(BASE_BPS_POINTS).times(100)
 
-      // slippage going into position - 0.007 ETH for 5 ETH deposit
+      // slippage going into position - e.g. 0.007 ETH for 5 ETH deposit
       // This is NOT the same as the total THOR fees, which include the deposit fee in addition to the slippage
       const cryptoSlippageAmountPrecision = bnOrZero(state?.deposit.cryptoAmount)
         .times(slippagePercentage)

--- a/src/features/defi/providers/thorchain-savers/components/ThorchainSaversManager/Deposit/components/Confirm.tsx
+++ b/src/features/defi/providers/thorchain-savers/components/ThorchainSaversManager/Deposit/components/Confirm.tsx
@@ -46,6 +46,7 @@ import {
   fromThorBaseUnit,
   getThorchainSaversDepositQuote,
   getThorchainSaversPosition,
+  makeDaysToBreakEven,
   toThorBaseUnit,
 } from 'state/slices/opportunitiesSlice/resolvers/thorchainsavers/utils'
 import { isUtxoChainId } from 'state/slices/portfolioSlice/utils'
@@ -134,6 +135,7 @@ export const Confirm: React.FC<ConfirmProps> = ({ accountId, onNext }) => {
 
   useEffect(() => {
     ;(async () => {
+      if (!opportunity?.apy) return
       if (!(accountId && state?.deposit.cryptoAmount && asset)) return
       if (depositFeeCryptoBaseUnit) return
 
@@ -150,31 +152,30 @@ export const Confirm: React.FC<ConfirmProps> = ({ accountId, onNext }) => {
 
       const quote = await getThorchainSaversDepositQuote({ asset, amountCryptoBaseUnit })
 
-      const { expected_amount_out, slippage_bps } = quote
+      const { expected_amount_out: expectedAmountOutThorBaseUnit, slippage_bps } = quote
 
-      setDepositFeeCryptoBaseUnit(
-        toBaseUnit(
-          fromThorBaseUnit(amountCryptoThorBaseUnit.minus(expected_amount_out)),
-          asset.precision,
-        ),
+      // Total downside
+      const depositFeeCryptoPrecision = fromThorBaseUnit(
+        amountCryptoThorBaseUnit.minus(expectedAmountOutThorBaseUnit),
       )
-      const percentage = bnOrZero(slippage_bps).div(BASE_BPS_POINTS).times(100)
 
-      // total downside (slippage going into position) - 0.007 ETH for 5 ETH deposit
+      setDepositFeeCryptoBaseUnit(toBaseUnit(depositFeeCryptoPrecision, asset.precision))
+
+      const slippagePercentage = bnOrZero(slippage_bps).div(BASE_BPS_POINTS).times(100)
+
+      // slippage going into position - 0.007 ETH for 5 ETH deposit
+      // This is NOT the same as the total THOR fees, which include the deposit fee in addition to the slippage
       const cryptoSlippageAmountPrecision = bnOrZero(state?.deposit.cryptoAmount)
-        .times(percentage)
+        .times(slippagePercentage)
         .div(100)
       setSlippageCryptoAmountPrecision(cryptoSlippageAmountPrecision.toString())
 
-      // daily upside
-      const dailyEarnAmount = bnOrZero(fromThorBaseUnit(expected_amount_out))
-        .times(opportunity?.apy ?? 0)
-        .div(365)
-
-      const daysToBreakEven = cryptoSlippageAmountPrecision
-        .div(dailyEarnAmount)
-        .toFixed(0)
-        .toString()
+      const daysToBreakEven = makeDaysToBreakEven({
+        amountCryptoBaseUnit,
+        asset,
+        apy: opportunity.apy,
+        expectedAmountOutThorBaseUnit,
+      })
       setDaysToBreakEven(daysToBreakEven)
     })()
   }, [accountId, asset, depositFeeCryptoBaseUnit, opportunity?.apy, state?.deposit.cryptoAmount])

--- a/src/features/defi/providers/thorchain-savers/components/ThorchainSaversManager/Deposit/components/Deposit.tsx
+++ b/src/features/defi/providers/thorchain-savers/components/ThorchainSaversManager/Deposit/components/Deposit.tsx
@@ -35,6 +35,7 @@ import {
   fromThorBaseUnit,
   getThorchainSaversDepositQuote,
   isAboveDepositDustThreshold,
+  makeDaysToBreakEven,
   THORCHAIN_SAVERS_DUST_THRESHOLDS,
 } from 'state/slices/opportunitiesSlice/resolvers/thorchainsavers/utils'
 import { serializeUserStakingId, toOpportunityId } from 'state/slices/opportunitiesSlice/utils'
@@ -361,6 +362,7 @@ export const Deposit: React.FC<DepositProps> = ({
   )
 
   useEffect(() => {
+    if (!opportunityData?.apy) return
     if (!(accountId && inputValues && asset)) return
     const { cryptoAmount } = inputValues
     const amountCryptoBaseUnit = bnOrZero(cryptoAmount).times(bn(10).pow(asset.precision))
@@ -373,22 +375,22 @@ export const Deposit: React.FC<DepositProps> = ({
         asset,
         amountCryptoBaseUnit,
       })
-      const { slippage_bps, expected_amount_out } = quote
-      const percentage = bnOrZero(slippage_bps).div(BASE_BPS_POINTS).times(100)
-
-      // total downside (slippage going into position) - 0.007 ETH for 5 ETH deposit
-      const cryptoSlippageAmountPrecision = bnOrZero(cryptoAmount).times(percentage).div(100)
+      const { slippage_bps, expected_amount_out: expectedAmountOutThorBaseUnit } = quote
+      const slippagePercentage = bnOrZero(slippage_bps).div(BASE_BPS_POINTS).times(100)
+      // slippage going into position - 0.007 ETH for 5 ETH deposit
+      // This is NOT the same as the total THOR fees, which include the deposit fee in addition to the slippage
+      const cryptoSlippageAmountPrecision = bnOrZero(cryptoAmount)
+        .times(slippagePercentage)
+        .div(100)
       setSlippageCryptoAmountPrecision(cryptoSlippageAmountPrecision.toString())
 
       // daily upside
-      const dailyEarnAmount = bnOrZero(fromThorBaseUnit(expected_amount_out))
-        .times(opportunityData?.apy ?? 0)
-        .div(365)
-
-      const daysToBreakEven = cryptoSlippageAmountPrecision
-        .div(dailyEarnAmount)
-        .toFixed(0)
-        .toString()
+      const daysToBreakEven = makeDaysToBreakEven({
+        expectedAmountOutThorBaseUnit,
+        amountCryptoBaseUnit,
+        asset,
+        apy: opportunityData?.apy,
+      })
       setDaysToBreakEven(daysToBreakEven)
       setQuoteLoading(false)
     })

--- a/src/state/slices/opportunitiesSlice/resolvers/thorchainsavers/utils.ts
+++ b/src/state/slices/opportunitiesSlice/resolvers/thorchainsavers/utils.ts
@@ -323,7 +323,8 @@ export const makeDaysToBreakEven = ({
     .div(dailyEarnAmount.div(depositFeeCryptoPrecision))
     .toFixed()
   // If daysToBreakEvenOrZero is a fraction of 1, the daily upside is effectively higher than the fees
-  // meaning the user will break even as soon as rewards accrue, i.e on the next Thorchain block
+  // meaning the user will break even in a timeframe between the first rewards accrual (e.g next THOR block after deposit is confirmed)
+  // and ~ a day after deposit
   const daysToBreakEven = BigNumber.max(daysToBreakEvenOrZero, 1).toFixed(0)
   return daysToBreakEven
 }

--- a/src/state/slices/opportunitiesSlice/resolvers/thorchainsavers/utils.ts
+++ b/src/state/slices/opportunitiesSlice/resolvers/thorchainsavers/utils.ts
@@ -19,8 +19,8 @@ import axios from 'axios'
 import { getConfig } from 'config'
 import memoize from 'lodash/memoize'
 import { getChainAdapterManager } from 'context/PluginProvider/chainAdapterSingleton'
-import type { BigNumber, BN } from 'lib/bignumber/bignumber'
-import { bn, bnOrZero } from 'lib/bignumber/bignumber'
+import type { BN } from 'lib/bignumber/bignumber'
+import { BigNumber, bn, bnOrZero } from 'lib/bignumber/bignumber'
 import { setTimeoutAsync } from 'lib/utils'
 import { isUtxoAccountId } from 'state/slices/portfolioSlice/utils'
 
@@ -292,3 +292,38 @@ export const isSupportedThorchainSaversChainId = (chainId: ChainId) =>
   SUPPORTED_THORCHAIN_SAVERS_CHAIN_IDS.includes(chainId)
 
 export const waitForSaversUpdate = () => setTimeoutAsync(SAVERS_UPDATE_TIME)
+
+export const makeDaysToBreakEven = ({
+  expectedAmountOutThorBaseUnit,
+  amountCryptoBaseUnit,
+  asset,
+  apy,
+}: {
+  expectedAmountOutThorBaseUnit: string
+  amountCryptoBaseUnit: BigNumber
+  asset: Asset
+  apy: string
+}) => {
+  const amountCryptoThorBaseUnit = toThorBaseUnit({
+    valueCryptoBaseUnit: amountCryptoBaseUnit,
+    asset,
+  })
+  // The total downside that goes into a savers deposit, from THOR docs;
+  // "the minimum amount of the target asset the user can expect to deposit after fees"
+  // https://thornode.ninerealms.com/thorchain/doc/
+  const depositFeeCryptoPrecision = bnOrZero(
+    fromThorBaseUnit(amountCryptoThorBaseUnit.minus(expectedAmountOutThorBaseUnit)),
+  )
+  // Daily upside
+  const dailyEarnAmount = bnOrZero(fromThorBaseUnit(expectedAmountOutThorBaseUnit))
+    .times(apy)
+    .div(365)
+
+  const daysToBreakEvenOrZero = bnOrZero(1)
+    .div(dailyEarnAmount.div(depositFeeCryptoPrecision))
+    .toFixed()
+  // If daysToBreakEvenOrZero is a fraction of 1, the daily upside is effectively higher than the fees
+  // meaning the user will break even as soon as rewards accrue, i.e on the next Thorchain block
+  const daysToBreakEven = BigNumber.max(daysToBreakEvenOrZero, 1).toFixed(0)
+  return daysToBreakEven
+}


### PR DESCRIPTION
## Description

This PR fixes the "days to break even" calculation for THORChain savers deposits.
Previously, we were using the slippage to calculate these, which led to wrong days to break even.
The slippage only occurs on large amounts and is only a part of the total fee, which also includes outbound fees on the THOR network.

Fixed the break-even calculation to accurately reflect the total fee for the deposit:
- if the deposit fee is lower than the daily amount to break even, we now show a value of 1 (instead of 0, which is what we would get by `toFixed()`ing the result). Unconfirmed with @reallybeard, happy to actually show 0 or a fraction of 1 if we deem it to be better UX.
- if the fee is higher and it may take more than a day to recoup, we now show the correct amount of days.

While at it, abstracts the logic into a `makeDaysToBreakEven` method for reusability.

Notes:

- This doesn't tackle the "Estimated fees" tooltip/amount issue spotted by ops in https://discord.com/channels/554694662431178782/1093287338404225054/1093287379797823598
- This doesn't account for the inbound network fee, which we may or may not want to include in the calculation
- This doesn't yet tackle withdraws, to be done in a stacked PR once we're happy with these heuristics

## Notice

<!-- Before submitting a pull request, please make sure you have answered the following: -->

- [x] Have you followed the guidelines in our [Contributing]('https://github.com/shapeshift/web/blob/develop/CONTRIBUTING.md) guide?
- [x] Have you checked to ensure there aren't other open [Pull Requests](https://github.com/shapeshift/web/pulls) for the same update/change?

## Pull Request Type

- [x] :bug: Bug fix (Non-breaking Change: Fixes an issue)
- [ ] :hammer_and_wrench: Chore (Non-breaking Change: Doc updates, pkg upgrades, typos, etc..)
- [ ] :nail_care: New Feature (Breaking/Non-breaking Change)

## Issue (if applicable)

N/A

## Risk

<!-----------------------------------------------------------------------------
Outline the scope of your changes and the risk associated with them. You must use your discretion as an engineer to determine the potential impact of your changes.

E.g. an upgrade to `hdwallet` or core state management would be considered higher risk, and might require a full regression test. UI or isolated view changes, or something behind a feature flag may have near zero risk. Small bug fixes might require testing isolated to the specific fix.
------------------------------------------------------------------------------>

- Users might be sad seeing akschual numbers, truthhurtsmang.jpg

## Testing

<!-----------------------------------------------------------------------------
We treat every PR to be merged with the same scrutiny as if we were merging directly to production.

Your PR will not be merged if you do not complete the sections below for our engineering and operations teams to test.
------------------------------------------------------------------------------>

- Test against THORSwap UI and ensure the numbers are matching (you might see off-by-1 discrepancies on bigger deposits, since our estimated fees are slightly different)
- For smaller amounts or amounts where the days to break even are less than 1, verify that we show 1 day, versus 0 on THORSwap UI
    
### Engineering

<!-----------------------------------------------------------------------------
Include sufficient information here for an engineer to test your PR. This may include how to test locally, in a built environment, changes to infrastructure etc.
------------------------------------------------------------------------------>

- Run a debugger through the return value of `makeDaysToBreakEven` and ensure the calculation is correct

### Operations

<!-----------------------------------------------------------------------------
If your changes have a user-facing impact, describe how a non-technical QA team can functionally test your changes in a preview environment.

If they are not user-facing please describe how to test for any regressions that may occur.
------------------------------------------------------------------------------>

## Screenshots (if applicable)

Tested while monkey-patching sufficient account balance validation:

<img width="551" alt="image" src="https://user-images.githubusercontent.com/17035424/230380634-6bbfe2c0-f9ac-4dd2-a5d4-7caf9f90bfc4.png">
<img width="537" alt="image" src="https://user-images.githubusercontent.com/17035424/230380667-cc6e90d5-78b7-48aa-8427-fce819592a8e.png">
<img width="523" alt="image" src="https://user-images.githubusercontent.com/17035424/230380697-a3bccead-0dd9-424f-8473-b3a2c546e788.png">

<img width="535" alt="image" src="https://user-images.githubusercontent.com/17035424/230378528-e544f2b1-ee45-44b1-9011-64ad90869c35.png">
<img width="529" alt="image" src="https://user-images.githubusercontent.com/17035424/230378554-7896e321-9c9d-411b-8bbd-7e0230c11468.png">
<img width="506" alt="image" src="https://user-images.githubusercontent.com/17035424/230378650-75c72701-f3cb-45ac-8400-e794c8339cc9.png">

<img width="539" alt="image" src="https://user-images.githubusercontent.com/17035424/230378840-d00232ef-d107-45f9-a64d-bd60d1e8f095.png">
<img width="539" alt="image" src="https://user-images.githubusercontent.com/17035424/230378876-1320a079-ea7c-4ff6-a019-5e4c58710efd.png">
<img width="527" alt="image" src="https://user-images.githubusercontent.com/17035424/230378960-4d4b86ce-cbe7-4b61-b547-4b86f42905a9.png">

<img width="557" alt="image" src="https://user-images.githubusercontent.com/17035424/230379159-49f774e5-7419-42c1-826f-3a1a9d40352c.png">
<img width="554" alt="image" src="https://user-images.githubusercontent.com/17035424/230379245-e04f58d4-626b-481d-9c6b-4625453aaf59.png">
<img width="515" alt="image" src="https://user-images.githubusercontent.com/17035424/230379276-a91e845f-a8d0-40dc-8766-e444af21c4dd.png">

<img width="554" alt="image" src="https://user-images.githubusercontent.com/17035424/230379353-dbf49dd9-f247-4c0a-bd1d-9de0da119c5f.png">
<img width="547" alt="image" src="https://user-images.githubusercontent.com/17035424/230379419-2c29fcf6-d389-482e-823c-27960e4f9ae2.png">
<img width="501" alt="image" src="https://user-images.githubusercontent.com/17035424/230379388-7249f919-09cc-4276-8240-96a5b543b2c4.png">

<img width="554" alt="image" src="https://user-images.githubusercontent.com/17035424/230379487-c9b8e6a9-4c1c-4d49-a12d-97c072504805.png">
<img width="544" alt="image" src="https://user-images.githubusercontent.com/17035424/230379588-426d30f2-3bdd-4cce-a571-cf4b0437f5f0.png">
<img width="514" alt="image" src="https://user-images.githubusercontent.com/17035424/230379693-b85fb5a4-eada-4db3-afc5-03443fc25f56.png">