### PR TITLE
feat: remove days to break even on savers withdraw

### DIFF
--- a/src/features/defi/providers/thorchain-savers/components/ThorchainSaversManager/Withdraw/components/Confirm.tsx
+++ b/src/features/defi/providers/thorchain-savers/components/ThorchainSaversManager/Withdraw/components/Confirm.tsx
@@ -81,7 +81,6 @@ export const Confirm: React.FC<ConfirmProps> = ({ accountId, onNext }) => {
   const [slippageCryptoAmountPrecision, setSlippageCryptoAmountPrecision] = useState<string | null>(
     null,
   )
-  const [daysToBreakEven, setDaysToBreakEven] = useState<string | null>(null)
   const { state, dispatch: contextDispatch } = useContext(WithdrawContext)
   const appDispatch = useAppDispatch()
   const translate = useTranslate()
@@ -203,17 +202,6 @@ export const Confirm: React.FC<ConfirmProps> = ({ accountId, onNext }) => {
           .times(percentage)
           .div(100)
         setSlippageCryptoAmountPrecision(cryptoSlippageAmountPrecision.toString())
-
-        // daily upside
-        const dailyEarnAmount = bnOrZero(fromThorBaseUnit(expected_amount_out))
-          .times(opportunity?.apy ?? 0)
-          .div(365)
-
-        const daysToBreakEven = cryptoSlippageAmountPrecision
-          .div(dailyEarnAmount)
-          .toFixed(0)
-          .toString()
-        setDaysToBreakEven(daysToBreakEven)
       } catch (e) {
         moduleLogger.error({ fn: 'useEffect', e }, 'Error getting savers withdraw quote')
       } finally {
@@ -635,21 +623,6 @@ export const Confirm: React.FC<ConfirmProps> = ({ accountId, onNext }) => {
           <Row.Label>{translate('common.slippage')}</Row.Label>
           <Row.Value>
             <Amount.Crypto value={slippageCryptoAmountPrecision ?? ''} symbol={asset.symbol} />
-          </Row.Value>
-        </Row>
-        <Row variant='gutter'>
-          <Row.Label>
-            <HelperTooltip label={translate('defi.modals.saversVaults.timeToBreakEven.tooltip')}>
-              {translate('defi.modals.saversVaults.timeToBreakEven.title')}
-            </HelperTooltip>
-          </Row.Label>
-          <Row.Value>
-            <Skeleton isLoaded={!quoteLoading}>
-              {translate(
-                `defi.modals.saversVaults.${bnOrZero(daysToBreakEven).eq(1) ? 'day' : 'days'}`,
-                { amount: daysToBreakEven ?? '0' },
-              )}
-            </Skeleton>
           </Row.Value>
         </Row>
         <Row variant='gutter'>


### PR DESCRIPTION
## Description

This PR removes the "days to break even" feature on THORChain savers withdraw. Fair dinkum, once you withdraw, you're not earning any more yield, so why talk about "breaking even"? It's like trying to teach a koala how to surf - it just doesn't make sense.

By ditching this feature, we're keeping it simple, like throwing another shrimp on the barbie. You've withdrawn your savers deposit, you've earned your crypto, and now it's time to enjoy your hard yakka. No more worries about breaking even - it's time to put your feet up and have a cold one with your mates.

So go ahead, withdraw those profits and enjoy your newfound riches. No more cobblers, just pure, unadulterated gains. I'm stoked to be making this change and hope you'll be chuffed too.

## Notice

<!-- Before submitting a pull request, please make sure you have answered the following: -->

- [x] Have you followed the guidelines in our [Contributing]('https://github.com/shapeshift/web/blob/develop/CONTRIBUTING.md) guide?
- [x] Have you checked to ensure there aren't other open [Pull Requests](https://github.com/shapeshift/web/pulls) for the same update/change?

## Pull Request Type

- [ ] :bug: Bug fix (Non-breaking Change: Fixes an issue)
- [ ] :hammer_and_wrench: Chore (Non-breaking Change: Doc updates, pkg upgrades, typos, etc..)
- [x] :nail_care: New Feature (Breaking/Non-breaking Change)

## Issue (if applicable)

N/A

## Risk

<!-----------------------------------------------------------------------------
Outline the scope of your changes and the risk associated with them. You must use your discretion as an engineer to determine the potential impact of your changes.

E.g. an upgrade to `hdwallet` or core state management would be considered higher risk, and might require a full regression test. UI or isolated view changes, or something behind a feature flag may have near zero risk. Small bug fixes might require testing isolated to the specific fix.
------------------------------------------------------------------------------>

## Testing

<!-----------------------------------------------------------------------------
We treat every PR to be merged with the same scrutiny as if we were merging directly to production.

Your PR will not be merged if you do not complete the sections below for our engineering and operations teams to test.
------------------------------------------------------------------------------>

- There is no "Days to break even" shown when withdrawing from savers

### Engineering

<!-----------------------------------------------------------------------------
Include sufficient information here for an engineer to test your PR. This may include how to test locally, in a built environment, changes to infrastructure etc.
------------------------------------------------------------------------------>

- Removal looks sane

### Operations

<!-----------------------------------------------------------------------------
If your changes have a user-facing impact, describe how a non-technical QA team can functionally test your changes in a preview environment.

If they are not user-facing please describe how to test for any regressions that may occur.
------------------------------------------------------------------------------>

- ☝🏽 

## Screenshots (if applicable)

![image](https://user-images.githubusercontent.com/17035424/230420827-b3050d6c-72f7-4a52-b03d-37e337636e00.png)
![image](https://user-images.githubusercontent.com/17035424/230420900-67ff67f5-7b41-4482-8de6-894b1cc1554d.png)