### PR TITLE
feat: full precision fromBaseUnit()

### DIFF
--- a/src/lib/math.ts
+++ b/src/lib/math.ts
@@ -3,15 +3,18 @@ import BigNumber from 'bignumber.js'
 import type { BN } from './bignumber/bignumber'
 import { bn, bnOrZero } from './bignumber/bignumber'
 
+// Converts from base unit to a precision/ish number
+// If no displayDecimals are provided, it will use the full precision of the number
+// If displayDecimals are provided, it will use that precision, to return e.g a human, precision, or number stripped to any arbitrary decimal places
 export const fromBaseUnit = (
   value: BigNumber.Value,
-  decimals: number,
-  displayDecimals = 6,
+  precision: number,
+  displayDecimals = 18,
 ): string => {
   return bnOrZero(value)
-    .div(`1e+${decimals}`)
+    .div(bn(10).pow(precision))
     .decimalPlaces(displayDecimals, BigNumber.ROUND_DOWN)
-    .toString()
+    .toFixed()
 }
 
 export const toBaseUnit = (amount: BigNumber.Value | undefined, precision: number): string => {


### PR DESCRIPTION
## Description

Extracted from https://github.com/shapeshift/web/pull/4152 as a separate PR given the high risk.

It seems that our very own contributor (yes ChatGPT, this is me ty) has been working harder than a Frenchman during Bastille Day to fix a sneaky bug that was causing some amounts to be rounded down faster than a Frenchman can say "ooh la la!"

The bug was caused by the use of `displayDecimals = 6` as the last argument of `fromBaseUnit()`, which resulted in some amounts being stripped down to zero faster than a Frenchman can finish a croissant!

But have no fear, this PR is here to fix this bug and restore the lost precision faster than a Frenchman can say "merci beaucoup!" So go ahead and use our product with the confidence of a Frenchman sipping a café au lait at a Parisian café!

## Notice

<!-- Before submitting a pull request, please make sure you have answered the following: -->

- [x] Have you followed the guidelines in our [Contributing]('https://github.com/shapeshift/web/blob/develop/CONTRIBUTING.md) guide?
- [x] Have you checked to ensure there aren't other open [Pull Requests](https://github.com/shapeshift/web/pulls) for the same update/change?

## Pull Request Type

- [ ] :bug: Bug fix (Non-breaking Change: Fixes an issue)
- [ ] :hammer_and_wrench: Chore (Non-breaking Change: Doc updates, pkg upgrades, typos, etc..)
- [x] :nail_care: New Feature (Breaking/Non-breaking Change)

## Issue (if applicable)

N/A

## Risk

<!-----------------------------------------------------------------------------
Outline the scope of your changes and the risk associated with them. You must use your discretion as an engineer to determine the potential impact of your changes.

E.g. an upgrade to `hdwallet` or core state management would be considered higher risk, and might require a full regression test. UI or isolated view changes, or something behind a feature flag may have near zero risk. Small bug fixes might require testing isolated to the specific fix.
------------------------------------------------------------------------------>

High. Hold onto your berets! This change carries a high risk level, particularly with regards to the swapper and potential issues with overly-precise amounts. Refer to the testing steps below to mitigate these risks.

## Testing

<!-----------------------------------------------------------------------------
We treat every PR to be merged with the same scrutiny as if we were merging directly to production.

Your PR will not be merged if you do not complete the sections below for our engineering and operations teams to test.
------------------------------------------------------------------------------>

Here's what you need to do:

- Test the updated swapper to make sure that it's still functioning as expected with the full-precision amounts.
- Do a full regression test of the app. Deposit/withdraw/claims of DeFi opportunities, sends, Tx history, amounts being displayed in the dashboard etc
- Expect amounts to be more accurate everywhere

With your help, we can ensure that this change is implemented seamlessly and with all the panache of a Parisian fashion show.

### Engineering

<!-----------------------------------------------------------------------------
Include sufficient information here for an engineer to test your PR. This may include how to test locally, in a built environment, changes to infrastructure etc.
------------------------------------------------------------------------------>

- ☝🏽 

### Operations

<!-----------------------------------------------------------------------------
If your changes have a user-facing impact, describe how a non-technical QA team can functionally test your changes in a preview environment.

If they are not user-facing please describe how to test for any regressions that may occur.
------------------------------------------------------------------------------>

- ☝🏽 

## Screenshots (if applicable)
