### PR TITLE
feat: selectPortfolioCryptoHumanBalanceByFilter -> selectPortfolioCryptoPrecisionBalanceByFilter

### DIFF
--- a/src/components/AccountRow/AccountRow.tsx
+++ b/src/components/AccountRow/AccountRow.tsx
@@ -9,7 +9,7 @@ import { RawText } from 'components/Text'
 import {
   selectAssetById,
   selectMarketDataById,
-  selectPortfolioCryptoHumanBalanceByFilter,
+  selectPortfolioCryptoPrecisionBalanceByFilter,
   selectPortfolioFiatBalanceByAssetId,
 } from 'state/slices/selectors'
 import { useAppSelector } from 'state/store'
@@ -29,7 +29,8 @@ export const AccountRow = ({ allocationValue, assetId, ...rest }: AccountRowArgs
   const asset = useAppSelector(state => selectAssetById(state, assetId))
   const marketData = useAppSelector(state => selectMarketDataById(state, assetId))
   const cryptoValue =
-    useAppSelector(state => selectPortfolioCryptoHumanBalanceByFilter(state, { assetId })) ?? '0'
+    useAppSelector(state => selectPortfolioCryptoPrecisionBalanceByFilter(state, { assetId })) ??
+    '0'
   const fiatValue =
     useAppSelector(state => selectPortfolioFiatBalanceByAssetId(state, { assetId })) ?? '0'
 

--- a/src/components/AssetHeader/AssetHeader.tsx
+++ b/src/components/AssetHeader/AssetHeader.tsx
@@ -15,7 +15,7 @@ import {
   selectAccountIdsByAssetId,
   selectAssetById,
   selectMarketDataById,
-  selectPortfolioCryptoHumanBalanceByFilter,
+  selectPortfolioCryptoPrecisionBalanceByFilter,
 } from 'state/slices/selectors'
 import { useAppSelector } from 'state/store'
 
@@ -51,7 +51,7 @@ export const AssetHeader: React.FC<AssetHeaderProps> = ({ assetId, accountId }) 
 
   const filter = useMemo(() => ({ assetId, accountId }), [assetId, accountId])
   const cryptoBalance =
-    useAppSelector(state => selectPortfolioCryptoHumanBalanceByFilter(state, filter)) ?? '0'
+    useAppSelector(state => selectPortfolioCryptoPrecisionBalanceByFilter(state, filter)) ?? '0'
 
   const formattedPrice = toFiat(marketData.price)
 

--- a/src/components/AssetSearch/AssetRow.tsx
+++ b/src/components/AssetSearch/AssetRow.tsx
@@ -11,7 +11,7 @@ import { useWallet } from 'hooks/useWallet/useWallet'
 import { firstNonZeroDecimal } from 'lib/math'
 import { isAssetSupportedByWallet } from 'state/slices/portfolioSlice/utils'
 import {
-  selectPortfolioCryptoHumanBalanceByFilter,
+  selectPortfolioCryptoPrecisionBalanceByFilter,
   selectPortfolioFiatBalanceByAssetId,
 } from 'state/slices/selectors'
 import { useAppSelector } from 'state/store'
@@ -30,7 +30,7 @@ export const AssetRow: FC<ListChildComponentProps<AssetData>> = ({
   const filter = useMemo(() => ({ assetId }), [assetId])
   const isSupported = wallet && isAssetSupportedByWallet(assetId, wallet)
   const cryptoHumanBalance = useAppSelector(s =>
-    selectPortfolioCryptoHumanBalanceByFilter(s, filter),
+    selectPortfolioCryptoPrecisionBalanceByFilter(s, filter),
   )
   const fiatBalance = useAppSelector(s => selectPortfolioFiatBalanceByAssetId(s, filter)) ?? '0'
   if (!asset) return null

--- a/src/components/Modals/Send/hooks/useSendDetails/useSendDetails.test.tsx
+++ b/src/components/Modals/Send/hooks/useSendDetails/useSendDetails.test.tsx
@@ -16,7 +16,7 @@ import {
   selectFeeAssetById,
   selectMarketDataById,
   selectPortfolioCryptoBalanceByFilter,
-  selectPortfolioCryptoHumanBalanceByFilter,
+  selectPortfolioCryptoPrecisionBalanceByFilter,
   selectPortfolioFiatBalanceByFilter,
 } from 'state/slices/selectors'
 
@@ -40,7 +40,7 @@ jest.mock('lib/address/ens', () => ({ ensLookup: jest.fn() }))
 jest.mock('state/slices/selectors', () => ({
   ...jest.requireActual('state/slices/selectors'),
   selectFeeAssetById: jest.fn(),
-  selectPortfolioCryptoHumanBalanceByFilter: jest.fn(),
+  selectPortfolioCryptoPrecisionBalanceByFilter: jest.fn(),
   selectPortfolioCryptoBalanceByFilter: jest.fn(),
   selectPortfolioFiatBalanceByFilter: jest.fn(),
   selectMarketDataById: jest.fn(),
@@ -101,7 +101,7 @@ const setup = ({
     return fakeMarketData[assetId]
   })
   mocked(selectFeeAssetById).mockReturnValue(mockEthereum)
-  mocked(selectPortfolioCryptoHumanBalanceByFilter).mockReturnValue(
+  mocked(selectPortfolioCryptoPrecisionBalanceByFilter).mockReturnValue(
     fromBaseUnit(assetBalance, asset.precision),
   )
   mocked(selectPortfolioCryptoBalanceByFilter).mockReturnValue(assetBalance)

--- a/src/components/Modals/Send/hooks/useSendDetails/useSendDetails.tsx
+++ b/src/components/Modals/Send/hooks/useSendDetails/useSendDetails.tsx
@@ -22,7 +22,7 @@ import {
   selectFeeAssetById,
   selectMarketDataById,
   selectPortfolioCryptoBalanceByFilter,
-  selectPortfolioCryptoHumanBalanceByFilter,
+  selectPortfolioCryptoPrecisionBalanceByFilter,
   selectPortfolioFiatBalanceByFilter,
 } from 'state/slices/selectors'
 import { useAppSelector } from 'state/store'
@@ -75,7 +75,7 @@ export const useSendDetails = (): UseSendDetailsReturnType => {
 
   const cryptoHumanBalance = bnOrZero(
     useAppSelector(state =>
-      selectPortfolioCryptoHumanBalanceByFilter(state, {
+      selectPortfolioCryptoPrecisionBalanceByFilter(state, {
         assetId,
         accountId,
       }),

--- a/src/components/Trade/Components/TradeAssetInput.tsx
+++ b/src/components/Trade/Components/TradeAssetInput.tsx
@@ -5,7 +5,7 @@ import React, { useMemo } from 'react'
 import type { AssetInputProps } from 'components/DeFi/components/AssetInput'
 import {
   selectMarketDataById,
-  selectPortfolioCryptoHumanBalanceByFilter,
+  selectPortfolioCryptoPrecisionBalanceByFilter,
 } from 'state/slices/selectors'
 import { useAppSelector } from 'state/store'
 
@@ -43,7 +43,9 @@ const AssetInputWithAsset: React.FC<AssetInputLoadedProps> = props => {
     }),
     [accountId, assetId],
   )
-  const balance = useAppSelector(state => selectPortfolioCryptoHumanBalanceByFilter(state, filter))
+  const balance = useAppSelector(state =>
+    selectPortfolioCryptoPrecisionBalanceByFilter(state, filter),
+  )
   const fiatBalance = bnOrZero(balance).times(marketData.price).toString()
 
   return <TradeAmountInput balance={balance} fiatBalance={fiatBalance} {...props} />

--- a/src/components/Trade/TradeInput.tsx
+++ b/src/components/Trade/TradeInput.tsx
@@ -37,7 +37,7 @@ import {
 import { selectAssets, selectFeeAssetById } from 'state/slices/assetsSlice/selectors'
 import {
   selectPortfolioCryptoBalanceByFilter,
-  selectPortfolioCryptoHumanBalanceByFilter,
+  selectPortfolioCryptoPrecisionBalanceByFilter,
 } from 'state/slices/selectors'
 import { useAppSelector } from 'state/store'
 import {
@@ -146,7 +146,7 @@ export const TradeInput = () => {
     [sellAssetAccountId, sellFeeAsset?.assetId],
   )
   const feeAssetBalance = useAppSelector(s =>
-    selectPortfolioCryptoHumanBalanceByFilter(s, feeAssetBalanceFilter),
+    selectPortfolioCryptoPrecisionBalanceByFilter(s, feeAssetBalanceFilter),
   )
 
   const sellAssetBalanceFilter = useMemo(
@@ -157,7 +157,7 @@ export const TradeInput = () => {
     selectPortfolioCryptoBalanceByFilter(state, sellAssetBalanceFilter),
   )
   const sellAssetBalanceHuman = useAppSelector(state =>
-    selectPortfolioCryptoHumanBalanceByFilter(state, sellAssetBalanceFilter),
+    selectPortfolioCryptoPrecisionBalanceByFilter(state, sellAssetBalanceFilter),
   )
 
   const isSwapperApiPending = useSelector(selectSwapperApiPending)

--- a/src/features/defi/helpers/utils.ts
+++ b/src/features/defi/helpers/utils.ts
@@ -2,7 +2,7 @@ import type { Asset } from '@shapeshiftoss/asset-service'
 import type { AccountId, ChainId } from '@shapeshiftoss/caip'
 import { cosmosChainId, osmosisChainId } from '@shapeshiftoss/caip'
 import { bnOrZero } from 'lib/bignumber/bignumber'
-import { selectPortfolioCryptoHumanBalanceByFilter } from 'state/slices/selectors'
+import { selectPortfolioCryptoPrecisionBalanceByFilter } from 'state/slices/selectors'
 import { store } from 'state/store'
 
 export const chainIdToLabel = (chainId: ChainId): string => {
@@ -27,7 +27,7 @@ export const canCoverTxFees = ({
   accountId: AccountId
 }) => {
   const state = store.getState()
-  const feeAssetBalanceCryptoHuman = selectPortfolioCryptoHumanBalanceByFilter(state, {
+  const feeAssetBalanceCryptoHuman = selectPortfolioCryptoPrecisionBalanceByFilter(state, {
     accountId,
     assetId: feeAsset.assetId,
   })

--- a/src/features/defi/providers/cosmos/components/CosmosManager/Deposit/components/Confirm.tsx
+++ b/src/features/defi/providers/cosmos/components/CosmosManager/Deposit/components/Confirm.tsx
@@ -33,7 +33,7 @@ import {
   selectAssets,
   selectBIP44ParamsByAccountId,
   selectMarketDataById,
-  selectPortfolioCryptoHumanBalanceByFilter,
+  selectPortfolioCryptoPrecisionBalanceByFilter,
   selectStakingOpportunityByFilter,
 } from 'state/slices/selectors'
 import { useAppSelector } from 'state/store'
@@ -100,7 +100,7 @@ export const Confirm: React.FC<ConfirmProps> = ({ onNext, accountId }) => {
     [feeAsset?.assetId, accountId],
   )
   const feeAssetBalance = useAppSelector(state =>
-    selectPortfolioCryptoHumanBalanceByFilter(state, filter),
+    selectPortfolioCryptoPrecisionBalanceByFilter(state, filter),
   )
 
   const marketData = useAppSelector(state => selectMarketDataById(state, assetId))

--- a/src/features/defi/providers/cosmos/components/CosmosManager/Withdraw/components/Confirm.tsx
+++ b/src/features/defi/providers/cosmos/components/CosmosManager/Withdraw/components/Confirm.tsx
@@ -36,7 +36,7 @@ import {
   selectAssets,
   selectBIP44ParamsByAccountId,
   selectMarketDataById,
-  selectPortfolioCryptoHumanBalanceByFilter,
+  selectPortfolioCryptoPrecisionBalanceByFilter,
   selectStakingOpportunityByFilter,
 } from 'state/slices/selectors'
 import { useAppSelector } from 'state/store'
@@ -119,7 +119,7 @@ export const Confirm: React.FC<ConfirmProps> = ({ onNext, accountId }) => {
     [accountId, feeAsset?.assetId],
   )
   const feeAssetBalance = useAppSelector(s =>
-    selectPortfolioCryptoHumanBalanceByFilter(s, feeAssetBalanceFilter),
+    selectPortfolioCryptoPrecisionBalanceByFilter(s, feeAssetBalanceFilter),
   )
 
   const accountFilter = useMemo(() => ({ accountId: accountId ?? '' }), [accountId])

--- a/src/features/defi/providers/fox-farming/components/FoxFarmingManager/Claim/ClaimConfirm.tsx
+++ b/src/features/defi/providers/fox-farming/components/FoxFarmingManager/Claim/ClaimConfirm.tsx
@@ -42,7 +42,7 @@ import {
   selectAssets,
   selectEarnUserStakingOpportunityByUserStakingId,
   selectMarketDataById,
-  selectPortfolioCryptoHumanBalanceByFilter,
+  selectPortfolioCryptoPrecisionBalanceByFilter,
 } from 'state/slices/selectors'
 import { useAppSelector } from 'state/store'
 
@@ -185,7 +185,7 @@ export const ClaimConfirm = ({ accountId, assetId, amount, onBack }: ClaimConfir
   )
 
   const feeAssetBalance = useAppSelector(s =>
-    selectPortfolioCryptoHumanBalanceByFilter(s, feeAssetBalanceFilter),
+    selectPortfolioCryptoPrecisionBalanceByFilter(s, feeAssetBalanceFilter),
   )
 
   const hasEnoughBalanceForGas = useMemo(

--- a/src/features/defi/providers/fox-farming/components/FoxFarmingManager/Deposit/components/Confirm.tsx
+++ b/src/features/defi/providers/fox-farming/components/FoxFarmingManager/Deposit/components/Confirm.tsx
@@ -32,7 +32,7 @@ import {
   selectAssetById,
   selectAssets,
   selectMarketDataById,
-  selectPortfolioCryptoHumanBalanceByFilter,
+  selectPortfolioCryptoPrecisionBalanceByFilter,
 } from 'state/slices/selectors'
 import { useAppSelector } from 'state/store'
 
@@ -101,7 +101,7 @@ export const Confirm: React.FC<StepComponentProps & { accountId: AccountId | und
     [accountId, feeAsset?.assetId],
   )
   const feeAssetBalance = useAppSelector(s =>
-    selectPortfolioCryptoHumanBalanceByFilter(s, feeAssetBalanceFilter),
+    selectPortfolioCryptoPrecisionBalanceByFilter(s, feeAssetBalanceFilter),
   )
 
   const hasEnoughBalanceForGas = useMemo(

--- a/src/features/defi/providers/fox-farming/components/FoxFarmingManager/Withdraw/components/Confirm.tsx
+++ b/src/features/defi/providers/fox-farming/components/FoxFarmingManager/Withdraw/components/Confirm.tsx
@@ -31,7 +31,7 @@ import {
   selectAssets,
   selectEarnUserStakingOpportunityByUserStakingId,
   selectMarketDataById,
-  selectPortfolioCryptoHumanBalanceByFilter,
+  selectPortfolioCryptoPrecisionBalanceByFilter,
 } from 'state/slices/selectors'
 import { useAppSelector } from 'state/store'
 
@@ -90,7 +90,7 @@ export const Confirm: React.FC<ConfirmProps> = ({ accountId, onNext }) => {
     [accountId, feeAsset?.assetId],
   )
   const feeAssetBalance = useAppSelector(s =>
-    selectPortfolioCryptoHumanBalanceByFilter(s, feeAssetBalanceFilter),
+    selectPortfolioCryptoPrecisionBalanceByFilter(s, feeAssetBalanceFilter),
   )
 
   const hasEnoughBalanceForGas = useMemo(

--- a/src/features/defi/providers/foxy/components/FoxyManager/Deposit/components/Confirm.tsx
+++ b/src/features/defi/providers/foxy/components/FoxyManager/Deposit/components/Confirm.tsx
@@ -21,7 +21,7 @@ import { poll } from 'lib/poll/poll'
 import { getFoxyApi } from 'state/apis/foxy/foxyApiSingleton'
 import {
   selectBIP44ParamsByAccountId,
-  selectPortfolioCryptoHumanBalanceByFilter,
+  selectPortfolioCryptoPrecisionBalanceByFilter,
 } from 'state/slices/selectors'
 import { useAppSelector } from 'state/store'
 
@@ -64,7 +64,7 @@ export const Confirm: React.FC<ConfirmProps> = ({ onNext, accountId }) => {
     [accountId, feeAsset?.assetId],
   )
   const feeAssetBalance = useAppSelector(s =>
-    selectPortfolioCryptoHumanBalanceByFilter(s, feeAssetBalanceFilter),
+    selectPortfolioCryptoPrecisionBalanceByFilter(s, feeAssetBalanceFilter),
   )
 
   const handleDeposit = useCallback(async () => {

--- a/src/features/defi/providers/foxy/components/FoxyManager/Withdraw/components/Confirm.tsx
+++ b/src/features/defi/providers/foxy/components/FoxyManager/Withdraw/components/Confirm.tsx
@@ -22,7 +22,7 @@ import { poll } from 'lib/poll/poll'
 import { getFoxyApi } from 'state/apis/foxy/foxyApiSingleton'
 import {
   selectBIP44ParamsByAccountId,
-  selectPortfolioCryptoHumanBalanceByFilter,
+  selectPortfolioCryptoPrecisionBalanceByFilter,
 } from 'state/slices/selectors'
 import { useAppSelector } from 'state/store'
 
@@ -59,7 +59,7 @@ export const Confirm: React.FC<StepComponentProps & { accountId?: AccountId | un
     [accountId, feeAsset?.assetId],
   )
   const feeAssetBalance = useAppSelector(s =>
-    selectPortfolioCryptoHumanBalanceByFilter(s, feeAssetBalanceFilter),
+    selectPortfolioCryptoPrecisionBalanceByFilter(s, feeAssetBalanceFilter),
   )
 
   const accountAddress = useMemo(

--- a/src/features/defi/providers/idle/components/IdleManager/Claim/components/Confirm.tsx
+++ b/src/features/defi/providers/idle/components/IdleManager/Claim/components/Confirm.tsx
@@ -35,7 +35,7 @@ import {
   selectHighestBalanceAccountIdByStakingId,
   selectMarketDataById,
   selectMarketDataSortedByMarketCap,
-  selectPortfolioCryptoHumanBalanceByFilter,
+  selectPortfolioCryptoPrecisionBalanceByFilter,
 } from 'state/slices/selectors'
 import { useAppSelector } from 'state/store'
 
@@ -115,7 +115,7 @@ export const Confirm = ({ accountId, onNext }: ConfirmProps) => {
     [accountId, feeAsset?.assetId],
   )
   const feeAssetBalance = useAppSelector(s =>
-    selectPortfolioCryptoHumanBalanceByFilter(s, feeAssetBalanceFilter),
+    selectPortfolioCryptoPrecisionBalanceByFilter(s, feeAssetBalanceFilter),
   )
 
   useEffect(() => {

--- a/src/features/defi/providers/idle/components/IdleManager/Deposit/components/Confirm.tsx
+++ b/src/features/defi/providers/idle/components/IdleManager/Deposit/components/Confirm.tsx
@@ -34,7 +34,7 @@ import {
   selectEarnUserStakingOpportunityByUserStakingId,
   selectHighestBalanceAccountIdByStakingId,
   selectMarketDataById,
-  selectPortfolioCryptoHumanBalanceByFilter,
+  selectPortfolioCryptoPrecisionBalanceByFilter,
 } from 'state/slices/selectors'
 import { useAppSelector } from 'state/store'
 
@@ -115,7 +115,7 @@ export const Confirm: React.FC<ConfirmProps> = ({ accountId, onNext }) => {
     [accountId, feeAsset?.assetId],
   )
   const feeAssetBalance = useAppSelector(s =>
-    selectPortfolioCryptoHumanBalanceByFilter(s, feeAssetBalanceFilter),
+    selectPortfolioCryptoPrecisionBalanceByFilter(s, feeAssetBalanceFilter),
   )
 
   const handleDeposit = useCallback(async () => {

--- a/src/features/defi/providers/idle/components/IdleManager/Overview/IdleEmpty.tsx
+++ b/src/features/defi/providers/idle/components/IdleManager/Overview/IdleEmpty.tsx
@@ -29,7 +29,10 @@ import { useModal } from 'hooks/useModal/useModal'
 import { bnOrZero } from 'lib/bignumber/bignumber'
 import { selectSupportsFiatRampByAssetId } from 'state/apis/fiatRamps/selectors'
 import { IdleTag } from 'state/slices/opportunitiesSlice/resolvers/idle/constants'
-import { selectAssetById, selectPortfolioCryptoHumanBalanceByFilter } from 'state/slices/selectors'
+import {
+  selectAssetById,
+  selectPortfolioCryptoPrecisionBalanceByFilter,
+} from 'state/slices/selectors'
 import { useAppSelector } from 'state/store'
 
 type OnboardingStep = {
@@ -104,7 +107,7 @@ export const IdleEmpty = ({ assetId, onClick, tags, apy }: IdleEmptyProps) => {
   const bgImage = useColorModeValue('none', IdleBg)
   const assetSupportsFiatRamp = useAppSelector(s => selectSupportsFiatRampByAssetId(s, filter))
   const cryptoBalance =
-    useAppSelector(state => selectPortfolioCryptoHumanBalanceByFilter(state, filter)) ?? '0'
+    useAppSelector(state => selectPortfolioCryptoPrecisionBalanceByFilter(state, filter)) ?? '0'
   const hasZeroCryptoBalance = bnOrZero(cryptoBalance).eq(0)
   const textShadow = useColorModeValue(
     '--chakra-colors-blackAlpha-50',

--- a/src/features/defi/providers/idle/components/IdleManager/Withdraw/components/Confirm.tsx
+++ b/src/features/defi/providers/idle/components/IdleManager/Withdraw/components/Confirm.tsx
@@ -36,7 +36,7 @@ import {
   selectEarnUserStakingOpportunityByUserStakingId,
   selectHighestBalanceAccountIdByStakingId,
   selectMarketDataById,
-  selectPortfolioCryptoHumanBalanceByFilter,
+  selectPortfolioCryptoPrecisionBalanceByFilter,
 } from 'state/slices/selectors'
 import { useAppSelector } from 'state/store'
 
@@ -123,7 +123,7 @@ export const Confirm: React.FC<ConfirmProps> = ({ accountId, onNext }) => {
     [accountId, feeAsset?.assetId],
   )
   const feeAssetBalance = useAppSelector(s =>
-    selectPortfolioCryptoHumanBalanceByFilter(s, feeAssetBalanceFilter),
+    selectPortfolioCryptoPrecisionBalanceByFilter(s, feeAssetBalanceFilter),
   )
 
   const handleConfirm = useCallback(async () => {

--- a/src/features/defi/providers/osmosis/components/OsmosisManager/Lp/Deposit/components/Confirm.tsx
+++ b/src/features/defi/providers/osmosis/components/OsmosisManager/Lp/Deposit/components/Confirm.tsx
@@ -37,7 +37,7 @@ import {
   selectBIP44ParamsByAccountId,
   selectMarketDataById,
   selectMarketDataSortedByMarketCap,
-  selectPortfolioCryptoHumanBalanceByFilter,
+  selectPortfolioCryptoPrecisionBalanceByFilter,
 } from 'state/slices/selectors'
 import { useAppSelector } from 'state/store'
 
@@ -98,7 +98,7 @@ export const Confirm: React.FC<ConfirmProps> = ({ onNext, accountId }) => {
     [accountId, feeAsset?.assetId],
   )
   const feeAssetBalance = useAppSelector(s =>
-    selectPortfolioCryptoHumanBalanceByFilter(s, feeAssetBalanceFilter),
+    selectPortfolioCryptoPrecisionBalanceByFilter(s, feeAssetBalanceFilter),
   )
 
   const handleDeposit = async () => {

--- a/src/features/defi/providers/osmosis/components/OsmosisManager/Lp/Withdraw/components/Confirm.tsx
+++ b/src/features/defi/providers/osmosis/components/OsmosisManager/Lp/Withdraw/components/Confirm.tsx
@@ -37,7 +37,7 @@ import {
   selectBIP44ParamsByAccountId,
   selectMarketDataById,
   selectMarketDataSortedByMarketCap,
-  selectPortfolioCryptoHumanBalanceByFilter,
+  selectPortfolioCryptoPrecisionBalanceByFilter,
 } from 'state/slices/selectors'
 import { useAppSelector } from 'state/store'
 
@@ -103,7 +103,7 @@ export const Confirm: React.FC<ConfirmProps> = ({ accountId, onNext }) => {
     [accountId, feeAsset?.assetId],
   )
   const feeAssetBalance = useAppSelector(state =>
-    selectPortfolioCryptoHumanBalanceByFilter(state, feeAssetBalanceFilter),
+    selectPortfolioCryptoPrecisionBalanceByFilter(state, feeAssetBalanceFilter),
   )
 
   const handleWithdraw = useCallback(async () => {

--- a/src/features/defi/providers/thorchain-savers/components/ThorchainSaversManager/Overview/ThorchainSaversEmpty.tsx
+++ b/src/features/defi/providers/thorchain-savers/components/ThorchainSaversManager/Overview/ThorchainSaversEmpty.tsx
@@ -11,7 +11,10 @@ import { RawText, Text } from 'components/Text'
 import { useModal } from 'hooks/useModal/useModal'
 import { bnOrZero } from 'lib/bignumber/bignumber'
 import { selectSupportsFiatRampByAssetId } from 'state/apis/fiatRamps/selectors'
-import { selectAssetById, selectPortfolioCryptoHumanBalanceByFilter } from 'state/slices/selectors'
+import {
+  selectAssetById,
+  selectPortfolioCryptoPrecisionBalanceByFilter,
+} from 'state/slices/selectors'
 import { useAppSelector } from 'state/store'
 
 type ThorchainSaversEmptyProps = {
@@ -26,7 +29,7 @@ export const ThorchainSaversEmpty = ({ assetId, onClick }: ThorchainSaversEmptyP
   const filter = useMemo(() => ({ assetId }), [assetId])
   const assetSupportsBuy = useAppSelector(s => selectSupportsFiatRampByAssetId(s, filter))
   const cryptoBalance =
-    useAppSelector(state => selectPortfolioCryptoHumanBalanceByFilter(state, filter)) ?? '0'
+    useAppSelector(state => selectPortfolioCryptoPrecisionBalanceByFilter(state, filter)) ?? '0'
   const linkColor = useColorModeValue('blue.500', 'blue.200')
   const textShadow = useColorModeValue(
     '--chakra-colors-blackAlpha-50',

--- a/src/features/defi/providers/thorchain-savers/components/ThorchainSaversManager/Withdraw/components/Confirm.tsx
+++ b/src/features/defi/providers/thorchain-savers/components/ThorchainSaversManager/Withdraw/components/Confirm.tsx
@@ -51,7 +51,7 @@ import {
   selectEarnUserStakingOpportunityByUserStakingId,
   selectHighestBalanceAccountIdByStakingId,
   selectMarketDataById,
-  selectPortfolioCryptoHumanBalanceByFilter,
+  selectPortfolioCryptoPrecisionBalanceByFilter,
   selectSelectedCurrency,
 } from 'state/slices/selectors'
 import { useAppDispatch, useAppSelector } from 'state/store'
@@ -145,7 +145,7 @@ export const Confirm: React.FC<ConfirmProps> = ({ accountId, onNext }) => {
     [accountId, asset?.assetId],
   )
   const assetBalance = useAppSelector(s =>
-    selectPortfolioCryptoHumanBalanceByFilter(s, assetBalanceFilter),
+    selectPortfolioCryptoPrecisionBalanceByFilter(s, assetBalanceFilter),
   )
 
   const selectedCurrency = useAppSelector(selectSelectedCurrency)

--- a/src/features/defi/providers/univ2/components/UniV2Manager/Deposit/components/Confirm.tsx
+++ b/src/features/defi/providers/univ2/components/UniV2Manager/Deposit/components/Confirm.tsx
@@ -31,7 +31,7 @@ import {
   selectAssets,
   selectEarnUserLpOpportunity,
   selectMarketDataById,
-  selectPortfolioCryptoHumanBalanceByFilter,
+  selectPortfolioCryptoPrecisionBalanceByFilter,
 } from 'state/slices/selectors'
 import { useAppSelector } from 'state/store'
 
@@ -100,7 +100,7 @@ export const Confirm: React.FC<ConfirmProps> = ({ accountId, onNext }) => {
     [accountId, feeAsset?.assetId],
   )
   const feeAssetBalanceCryptoHuman = useAppSelector(s =>
-    selectPortfolioCryptoHumanBalanceByFilter(s, feeAssetBalanceFilter),
+    selectPortfolioCryptoPrecisionBalanceByFilter(s, feeAssetBalanceFilter),
   )
 
   const hasEnoughBalanceForGas = bnOrZero(feeAssetBalanceCryptoHuman)

--- a/src/features/defi/providers/univ2/components/UniV2Manager/Withdraw/components/Confirm.tsx
+++ b/src/features/defi/providers/univ2/components/UniV2Manager/Withdraw/components/Confirm.tsx
@@ -32,7 +32,7 @@ import {
   selectAssets,
   selectEarnUserLpOpportunity,
   selectMarketDataById,
-  selectPortfolioCryptoHumanBalanceByFilter,
+  selectPortfolioCryptoPrecisionBalanceByFilter,
 } from 'state/slices/selectors'
 import { useAppSelector } from 'state/store'
 
@@ -98,7 +98,7 @@ export const Confirm = ({ accountId, onNext }: ConfirmProps) => {
     [accountId],
   )
   const feeAssetBalanceCryptoHuman = useAppSelector(s =>
-    selectPortfolioCryptoHumanBalanceByFilter(s, feeAssetBalanceFilter),
+    selectPortfolioCryptoPrecisionBalanceByFilter(s, feeAssetBalanceFilter),
   )
 
   const hasEnoughBalanceForGas = useMemo(

--- a/src/features/defi/providers/yearn/components/YearnManager/Deposit/components/Confirm.tsx
+++ b/src/features/defi/providers/yearn/components/YearnManager/Deposit/components/Confirm.tsx
@@ -30,7 +30,7 @@ import {
   selectEarnUserStakingOpportunityByUserStakingId,
   selectHighestBalanceAccountIdByStakingId,
   selectMarketDataById,
-  selectPortfolioCryptoHumanBalanceByFilter,
+  selectPortfolioCryptoPrecisionBalanceByFilter,
 } from 'state/slices/selectors'
 import { useAppSelector } from 'state/store'
 
@@ -108,7 +108,7 @@ export const Confirm: React.FC<ConfirmProps> = ({ accountId, onNext }) => {
     [accountId, feeAsset?.assetId],
   )
   const feeAssetBalance = useAppSelector(s =>
-    selectPortfolioCryptoHumanBalanceByFilter(s, feeAssetBalanceFilter),
+    selectPortfolioCryptoPrecisionBalanceByFilter(s, feeAssetBalanceFilter),
   )
 
   const handleDeposit = useCallback(async () => {

--- a/src/features/defi/providers/yearn/components/YearnManager/Withdraw/components/Confirm.tsx
+++ b/src/features/defi/providers/yearn/components/YearnManager/Withdraw/components/Confirm.tsx
@@ -32,7 +32,7 @@ import {
   selectEarnUserStakingOpportunityByUserStakingId,
   selectHighestBalanceAccountIdByStakingId,
   selectMarketDataById,
-  selectPortfolioCryptoHumanBalanceByFilter,
+  selectPortfolioCryptoPrecisionBalanceByFilter,
 } from 'state/slices/selectors'
 import { useAppSelector } from 'state/store'
 
@@ -117,7 +117,7 @@ export const Confirm: React.FC<ConfirmProps> = ({ accountId, onNext }) => {
     [accountId, feeAsset?.assetId],
   )
   const feeAssetBalance = useAppSelector(s =>
-    selectPortfolioCryptoHumanBalanceByFilter(s, feeAssetBalanceFilter),
+    selectPortfolioCryptoPrecisionBalanceByFilter(s, feeAssetBalanceFilter),
   )
 
   const handleConfirm = useCallback(async () => {

--- a/src/plugins/foxPage/foxPage.tsx
+++ b/src/plugins/foxPage/foxPage.tsx
@@ -40,7 +40,7 @@ import {
   selectAggregatedEarnUserStakingOpportunityByStakingId,
   selectAssetById,
   selectAssets,
-  selectPortfolioCryptoHumanBalanceByFilter,
+  selectPortfolioCryptoPrecisionBalanceByFilter,
   selectPortfolioFiatBalanceByAssetId,
   selectSelectedLocale,
 } from 'state/slices/selectors'
@@ -113,9 +113,9 @@ export const FoxPage = () => {
   const fiatBalanceFoxy =
     useAppSelector(s => selectPortfolioFiatBalanceByAssetId(s, foxyFilter)) ?? '0'
   const cryptoHumanBalanceFox =
-    useAppSelector(s => selectPortfolioCryptoHumanBalanceByFilter(s, foxFilter)) ?? '0'
+    useAppSelector(s => selectPortfolioCryptoPrecisionBalanceByFilter(s, foxFilter)) ?? '0'
   const cryptoHumanBalanceFoxy =
-    useAppSelector(s => selectPortfolioCryptoHumanBalanceByFilter(s, foxyFilter)) ?? '0'
+    useAppSelector(s => selectPortfolioCryptoPrecisionBalanceByFilter(s, foxyFilter)) ?? '0'
 
   const fiatBalances = useMemo(
     () => [fiatBalanceFox, fiatBalanceFoxy],

--- a/src/state/slices/common-selectors.ts
+++ b/src/state/slices/common-selectors.ts
@@ -53,7 +53,7 @@ export const selectPortfolioCryptoBalanceByFilter = createCachedSelector(
   },
 )((_s: ReduxState, filter) => `${filter?.accountId}-${filter?.assetId}` ?? 'accountId-assetId')
 
-export const selectPortfolioCryptoHumanBalanceByFilter = createCachedSelector(
+export const selectPortfolioCryptoPrecisionBalanceByFilter = createCachedSelector(
   selectAssets,
   selectPortfolioAccountBalances,
   selectPortfolioAssetBalances,

--- a/src/state/slices/opportunitiesSlice/selectors/lpSelectors.ts
+++ b/src/state/slices/opportunitiesSlice/selectors/lpSelectors.ts
@@ -14,7 +14,7 @@ import {
   selectPortfolioAccountBalances,
   selectPortfolioAssetBalances,
   selectPortfolioCryptoBalanceByFilter,
-  selectPortfolioCryptoHumanBalanceByFilter,
+  selectPortfolioCryptoPrecisionBalanceByFilter,
 } from '../../common-selectors'
 import { selectMarketDataSortedByMarketCap } from '../../marketDataSlice/selectors'
 import { getUnderlyingAssetIdsBalances } from '../utils'
@@ -84,7 +84,7 @@ export const selectEarnUserLpOpportunity = createDeepEqualOutputSelector(
 export const selectAggregatedEarnUserLpOpportunity = createDeepEqualOutputSelector(
   selectLpOpportunitiesById,
   selectLpIdParamFromFilter,
-  selectPortfolioCryptoHumanBalanceByFilter,
+  selectPortfolioCryptoPrecisionBalanceByFilter,
   selectAssets,
   selectMarketDataSortedByMarketCap,
   (
@@ -162,7 +162,7 @@ export const selectHighestBalanceAccountIdByLpId = createSelector(
 export const selectUnderlyingLpAssetsWithBalancesAndIcons = createSelector(
   selectLpIdParamFromFilter,
   selectLpOpportunitiesById,
-  selectPortfolioCryptoHumanBalanceByFilter,
+  selectPortfolioCryptoPrecisionBalanceByFilter,
   selectAssets,
   selectMarketDataSortedByMarketCap,
   (

--- a/src/state/slices/portfolioSlice/portfolioSlice.test.ts
+++ b/src/state/slices/portfolioSlice/portfolioSlice.test.ts
@@ -23,7 +23,7 @@ import { mockChainAdapters, mockUpsertPortfolio } from 'test/mocks/portfolio'
 import { createStore } from 'state/store'
 
 import { assets as assetsSlice } from '../assetsSlice/assetsSlice'
-import { selectPortfolioCryptoHumanBalanceByFilter } from '../common-selectors'
+import { selectPortfolioCryptoPrecisionBalanceByFilter } from '../common-selectors'
 import { marketData as marketDataSlice } from '../marketDataSlice/marketDataSlice'
 import { portfolio as portfolioSlice } from './portfolioSlice'
 import {
@@ -527,7 +527,7 @@ describe('portfolioSlice', () => {
       })
     })
 
-    describe('selectPortfolioCryptoHumanBalanceByFilter', () => {
+    describe('selectPortfolioCryptoPrecisionBalanceByFilter', () => {
       const store = createStore()
       const { ethAccount, ethAccount2, ethAccountId, ethAccount2Id } = mockEthAndBtcAccounts({
         ethAccountObj: { balance: '1000009000000000000' },
@@ -579,13 +579,13 @@ describe('portfolioSlice', () => {
 
       it('should be able to filter by assetId', () => {
         const expected = '1.200009'
-        const result = selectPortfolioCryptoHumanBalanceByFilter(state, { assetId: ethAssetId })
+        const result = selectPortfolioCryptoPrecisionBalanceByFilter(state, { assetId: ethAssetId })
         expect(result).toEqual(expected)
       })
 
       it('should be able to filter by accountId and assetId', () => {
         const expected = '0.2001'
-        const result = selectPortfolioCryptoHumanBalanceByFilter(state, {
+        const result = selectPortfolioCryptoPrecisionBalanceByFilter(state, {
           accountId: ethAccount2Id,
           assetId: foxAssetId,
         })


### PR DESCRIPTION
## Description

Iterating on https://github.com/shapeshift/web/pull/4203, now that `fromBaseUnit()` properly returns *akschual* full-precision amounts, does an LSP rename on `selectPortfolioCryptoHumanBalanceByFilter` to `selectPortfolioCryptoPrecisionBalanceByFilter`

## Notice

<!-- Before submitting a pull request, please make sure you have answered the following: -->

- [x] Have you followed the guidelines in our [Contributing]('https://github.com/shapeshift/web/blob/develop/CONTRIBUTING.md) guide?
- [x] Have you checked to ensure there aren't other open [Pull Requests](https://github.com/shapeshift/web/pulls) for the same update/change?

## Pull Request Type

- [ ] :bug: Bug fix (Non-breaking Change: Fixes an issue)
- [ ] :hammer_and_wrench: Chore (Non-breaking Change: Doc updates, pkg upgrades, typos, etc..)
- [x] :nail_care: New Feature (Breaking/Non-breaking Change)

## Issue (if applicable)

N/A

## Risk

<!-----------------------------------------------------------------------------
Outline the scope of your changes and the risk associated with them. You must use your discretion as an engineer to determine the potential impact of your changes.

E.g. an upgrade to `hdwallet` or core state management would be considered higher risk, and might require a full regression test. UI or isolated view changes, or something behind a feature flag may have near zero risk. Small bug fixes might require testing isolated to the specific fix.
------------------------------------------------------------------------------>

None - if we're happy with https://github.com/shapeshift/web/pull/4203, then this is just a name change

This PR has the added benefit of making current `selectPortfolioCryptoHumanBalanceByFilter` explicit - this way, we can follow-up with another PR in the stack `toFixed()`ing at view-layer level wherever we deem necessary.

## Testing

<!-----------------------------------------------------------------------------
We treat every PR to be merged with the same scrutiny as if we were merging directly to production.

Your PR will not be merged if you do not complete the sections below for our engineering and operations teams to test.
------------------------------------------------------------------------------>

None

### Engineering

<!-----------------------------------------------------------------------------
Include sufficient information here for an engineer to test your PR. This may include how to test locally, in a built environment, changes to infrastructure etc.
------------------------------------------------------------------------------>

### Operations

<!-----------------------------------------------------------------------------
If your changes have a user-facing impact, describe how a non-technical QA team can functionally test your changes in a preview environment.

If they are not user-facing please describe how to test for any regressions that may occur.
------------------------------------------------------------------------------>

## Screenshots (if applicable)
