### PR TITLE
feat: don't round down in fromBaseUnit if displayDecimals are omitted

### DIFF
--- a/src/lib/math.test.ts
+++ b/src/lib/math.test.ts
@@ -1,0 +1,35 @@
+import { fromBaseUnit } from './math'
+
+describe('lib/math', () => {
+  describe('fromBaseUnit', () => {
+    it('should correctly convert and round down with given displayDecimals', () => {
+      const result = fromBaseUnit(123456789, 4, 2)
+      expect(result).toBe('12345.67')
+    })
+
+    it('should correctly convert without displayDecimals and return full precision', () => {
+      const result = fromBaseUnit(123456789, 4)
+      expect(result).toBe('12345.6789')
+    })
+
+    it('should correctly convert and round down with given displayDecimals for another input', () => {
+      const result = fromBaseUnit(987654321, 6, 3)
+      expect(result).toBe('987.654')
+    })
+
+    it('should correctly convert without displayDecimals and return full precision for another input', () => {
+      const result = fromBaseUnit(987654321, 6)
+      expect(result).toBe('987.654321')
+    })
+
+    it('should correctly convert and round down with given displayDecimals for high precision input', () => {
+      const result = fromBaseUnit('182912819182912192', 18, 8)
+      expect(result).toBe('0.18291281')
+    })
+
+    it('should correctly convert without displayDecimals and return full precision for high precision input', () => {
+      const result = fromBaseUnit('182912819182912192', 18)
+      expect(result).toBe('0.182912819182912192')
+    })
+  })
+})

--- a/src/lib/math.ts
+++ b/src/lib/math.ts
@@ -4,8 +4,9 @@ import type { BN } from './bignumber/bignumber'
 import { bn, bnOrZero } from './bignumber/bignumber'
 
 // Converts from base unit to a precision/ish number
-// If no displayDecimals are provided, it will use the full precision of the number being converted
-// If displayDecimals are provided, it will use that precision, to return e.g a human, precision, or number stripped to any arbitrary decimal places
+// - If no displayDecimals are provided, it will use the full precision of the number being converted
+// - If displayDecimals are provided, it will use that precision, to return e.g a human, precision, or number stripped to any arbitrary decimal places
+// and use the ROUND_DOWN rounding mode
 export const fromBaseUnit = (
   value: BigNumber.Value,
   precision: number,
@@ -13,7 +14,7 @@ export const fromBaseUnit = (
 ): string => {
   const precisionNumber = bnOrZero(value).div(bn(10).pow(precision))
 
-  if (displayDecimals && typeof displayDecimals === 'number') {
+  if (typeof displayDecimals === 'number') {
     return precisionNumber
       .decimalPlaces(displayDecimals, BigNumber.ROUND_DOWN)
       .toFixed(displayDecimals)

--- a/src/lib/math.ts
+++ b/src/lib/math.ts
@@ -11,10 +11,15 @@ export const fromBaseUnit = (
   precision: number,
   displayDecimals?: number,
 ): string => {
-  return bnOrZero(value)
-    .div(bn(10).pow(precision))
-    .decimalPlaces(displayDecimals ?? precision, BigNumber.ROUND_DOWN)
-    .toFixed()
+  const precisionNumber = bnOrZero(value).div(bn(10).pow(precision))
+
+  if (displayDecimals && typeof displayDecimals === 'number') {
+    return precisionNumber
+      .decimalPlaces(displayDecimals, BigNumber.ROUND_DOWN)
+      .toFixed(displayDecimals)
+  }
+
+  return precisionNumber.toFixed()
 }
 
 export const toBaseUnit = (amount: BigNumber.Value | undefined, precision: number): string => {

--- a/src/state/zustand/swapperStore/amountSelectors.test.ts
+++ b/src/state/zustand/swapperStore/amountSelectors.test.ts
@@ -49,7 +49,7 @@ describe('calculateAmounts', () => {
     // receive amount when requesting a quote
     expect(tradeAmountsByActionAndAmountFromQuote).toEqual({
       sellAmountSellAssetCryptoPrecision: '0.018665',
-      buyAmountBuyAssetCryptoPrecision: '-225.170392472859966803',
+      buyAmountBuyAssetCryptoPrecision: '-225.170392472859966802',
       fiatSellAmount: '32.981055',
       fiatBuyAmount: '1.089',
     })


### PR DESCRIPTION
## Description

Iterates on top of https://github.com/shapeshift/web/pull/4203, making sure we don't round down when unnecessary.

LLMgen'd description and tests

This pull request updates the fromBaseUnit() function to handle the displayDecimals parameter more safely and provides better control over the number of decimal places in the output. Previously, the function used the .decimalPlaces() method with the ROUND_DOWN mode, which could potentially cause loss of precision in certain cases.

The updated implementation of the fromBaseUnit() function checks if the displayDecimals parameter is provided and is a valid number. If it is, the function rounds down the result to the specified number of decimal places using the .decimalPlaces() method and then converts the resulting BigNumber to a string with exactly displayDecimals decimal places using the .toFixed(displayDecimals) method.

If the displayDecimals parameter is not provided or is not a valid number, the function will simply convert the full precision BigNumber result to a string using the .toFixed() method, without applying any rounding.

In addition to the updated implementation, this PR includes Jest tests to cover various input scenarios, ensuring that the fromBaseUnit() function behaves as expected for different input values and optional displayDecimals parameters. The test suite includes examples with lower and higher amounts of decimal places, such as 18-precision ETH amounts.

By implementing these changes, we improve the flexibility and safety of the fromBaseUnit() function, allowing for better control over the number of decimal places in the output while preserving the full precision when needed.

## Notice

<!-- Before submitting a pull request, please make sure you have answered the following: -->

- [x] Have you followed the guidelines in our [Contributing]('https://github.com/shapeshift/web/blob/develop/CONTRIBUTING.md) guide?
- [x] Have you checked to ensure there aren't other open [Pull Requests](https://github.com/shapeshift/web/pulls) for the same update/change?

## Pull Request Type

- [ ] :bug: Bug fix (Non-breaking Change: Fixes an issue)
- [ ] :hammer_and_wrench: Chore (Non-breaking Change: Doc updates, pkg upgrades, typos, etc..)
- [x] :nail_care: New Feature (Breaking/Non-breaking Change)

## Issue (if applicable)

N/A

## Risk

<!-----------------------------------------------------------------------------
Outline the scope of your changes and the risk associated with them. You must use your discretion as an engineer to determine the potential impact of your changes.

E.g. an upgrade to `hdwallet` or core state management would be considered higher risk, and might require a full regression test. UI or isolated view changes, or something behind a feature flag may have near zero risk. Small bug fixes might require testing isolated to the specific fix.
------------------------------------------------------------------------------>

It's worth noting that this change is considered high-risk as the fromBaseUnit() function is used extensively throughout the codebase. Any changes to its behavior could potentially impact various parts of the application. To mitigate this risk, a comprehensive test suite has been added to ensure that the function behaves as expected in different scenarios. Additionally, thorough testing and review should be performed before deploying these changes to production.

tl;dr Test amounts across the app similar to https://github.com/shapeshift/web/pull/4203 and ensure Tx history,sends, receives, balances, swaps are showing correct amounts

## Testing

<!-----------------------------------------------------------------------------
We treat every PR to be merged with the same scrutiny as if we were merging directly to production.

Your PR will not be merged if you do not complete the sections below for our engineering and operations teams to test.
------------------------------------------------------------------------------>

- Tx history, sends, receives, balances, swaps are displaying correct amounts
- DeFi opportunities display correct amounts
- Swapper is still happy

### Engineering

<!-----------------------------------------------------------------------------
Include sufficient information here for an engineer to test your PR. This may include how to test locally, in a built environment, changes to infrastructure etc.
------------------------------------------------------------------------------>

- Scrutinize I know how to write an if statement

### Operations

<!-----------------------------------------------------------------------------
If your changes have a user-facing impact, describe how a non-technical QA team can functionally test your changes in a preview environment.

If they are not user-facing please describe how to test for any regressions that may occur.
------------------------------------------------------------------------------>

- ☝🏽

## Screenshots (if applicable)
