### PR TITLE
feat: use receive amount data from quotes

### DIFF
--- a/src/components/Trade/Components/TradeQuotes/TradeQuote.tsx
+++ b/src/components/Trade/Components/TradeQuotes/TradeQuote.tsx
@@ -97,17 +97,17 @@ export const TradeQuoteLoaded: React.FC<TradeQuoteLoadedProps> = ({
     state => state.updateActiveSwapperWithMetadata,
   )
   const updateFees = useSwapperStore(state => state.updateFees)
-  const handleInputAmountChange = useSwapperStore(state => state.handleInputAmountChange)
+  const updateTradeAmountsFromQuote = useSwapperStore(state => state.updateTradeAmountsFromQuote)
 
   const handleSwapperSelection = useCallback(
     (activeSwapperWithMetadata: SwapperWithQuoteMetadata) => {
       updateActiveSwapperWithMetadata(activeSwapperWithMetadata)
       if (!sellFeeAsset) throw new Error(`Asset not found for AssetId ${sellAsset?.assetId}`)
       updateFees(sellFeeAsset)
-      handleInputAmountChange()
+      updateTradeAmountsFromQuote()
     },
     [
-      handleInputAmountChange,
+      updateTradeAmountsFromQuote,
       sellAsset?.assetId,
       sellFeeAsset,
       updateActiveSwapperWithMetadata,

--- a/src/components/Trade/Components/TradeQuotes/TradeQuotes.tsx
+++ b/src/components/Trade/Components/TradeQuotes/TradeQuotes.tsx
@@ -1,7 +1,6 @@
 import { Collapse, Flex } from '@chakra-ui/react'
 import { bn, bnOrZero } from 'lib/bignumber/bignumber'
 import { fromBaseUnit } from 'lib/math'
-import { selectSellAmountBeforeFeesBuyAssetBaseUnit } from 'state/zustand/swapperStore/amountSelectors'
 import {
   selectActiveSwapperWithMetadata,
   selectAvailableSwappersWithMetadata,
@@ -35,17 +34,12 @@ export const TradeQuotes: React.FC<TradeQuotesProps> = ({ isOpen, isLoading }) =
     ? bnOrZero(bestBuyAmountCryptoPrecision).minus(bestBuyAssetTradeFeeCryptoPrecision).toString()
     : undefined
 
-  const sellAmountBeforeFeesBuyAssetBaseUnit = useSwapperStore(
-    selectSellAmountBeforeFeesBuyAssetBaseUnit,
-  )
-
   const quotes = availableSwappersWithMetadata
     ? availableSwappersWithMetadata.map((swapperWithMetadata, i) => {
         const quote = swapperWithMetadata.quote
-        const buyAmountBeforeFeesCryptoPrecision =
-          sellAmountBeforeFeesBuyAssetBaseUnit && buyAsset
-            ? fromBaseUnit(sellAmountBeforeFeesBuyAssetBaseUnit, buyAsset.precision)
-            : undefined
+        const buyAmountBeforeFeesCryptoPrecision = buyAsset
+          ? fromBaseUnit(quote.buyAmountCryptoBaseUnit, buyAsset.precision)
+          : undefined
 
         const buyAssetTradeFeeBuyAssetCryptoPrecision = buyAssetFiatRate
           ? bnOrZero(quote.feeData.buyAssetTradeFeeUsd).div(buyAssetFiatRate)

--- a/src/components/Trade/TradeConfirm/ReceiveSummary.tsx
+++ b/src/components/Trade/TradeConfirm/ReceiveSummary.tsx
@@ -13,7 +13,7 @@ import { Amount } from 'components/Amount/Amount'
 import { HelperTooltip } from 'components/HelperTooltip/HelperTooltip'
 import { type RowProps, Row } from 'components/Row/Row'
 import { RawText, Text } from 'components/Text'
-import { bn, bnOrZero } from 'lib/bignumber/bignumber'
+import { bnOrZero } from 'lib/bignumber/bignumber'
 
 type ReceiveSummaryProps = {
   isLoading?: boolean
@@ -49,8 +49,7 @@ export const ReceiveSummary: FC<ReceiveSummaryProps> = ({
   const textColor = useColorModeValue('gray.800', 'whiteAlpha.900')
 
   const slippageAsPercentageString = bnOrZero(slippage).times(100).toString()
-  const amountAfterSlippage = bnOrZero(amount).times(bn(1).minus(slippage)).toString()
-  const isAmountPositive = bnOrZero(amountAfterSlippage).gt(0)
+  const isAmountPositive = bnOrZero(amount).gt(0)
 
   return (
     <>
@@ -152,10 +151,7 @@ export const ReceiveSummary: FC<ReceiveSummaryProps> = ({
               </Row.Label>
               <Row.Value whiteSpace='nowrap'>
                 <Skeleton isLoaded={!isLoading}>
-                  <Amount.Crypto
-                    value={isAmountPositive ? amountAfterSlippage : '0'}
-                    symbol={symbol}
-                  />
+                  <Amount.Crypto value={isAmountPositive ? amount : '0'} symbol={symbol} />
                 </Skeleton>
               </Row.Value>
             </Row>

--- a/src/components/Trade/TradeConfirm/TradeConfirm.tsx
+++ b/src/components/Trade/TradeConfirm/TradeConfirm.tsx
@@ -46,7 +46,7 @@ import { useAppSelector } from 'state/store'
 import {
   selectBuyAmountAfterFeesFiat,
   selectBuyAmountBeforeFeesBaseUnit,
-  selectBuyAmountBeforeFeesBuyAssetCryptoPrecision,
+  selectQuoteBuyAmountCryptoPrecision,
   selectSellAmountBeforeFeesBaseUnitByAction,
   selectSellAmountBeforeFeesFiat,
   selectTotalTradeFeeBuyAssetCryptoPrecision,
@@ -101,9 +101,7 @@ export const TradeConfirm = () => {
   const updateTrade = useSwapperStore(state => state.updateTrade)
   const sellAmountBeforeFeesBaseUnit = useSwapperStore(selectSellAmountBeforeFeesBaseUnitByAction)
   const sellAmountBeforeFeesFiat = useSwapperStore(selectSellAmountBeforeFeesFiat)
-  const buyAmountBeforeFeesBuyAssetCryptoPrecision = useSwapperStore(
-    selectBuyAmountBeforeFeesBuyAssetCryptoPrecision,
-  )
+  const quoteBuyAmountCryptoPrecision = useSwapperStore(selectQuoteBuyAmountCryptoPrecision)
   const totalTradeFeeBuyAssetCryptoPrecision = useSwapperStore(
     selectTotalTradeFeeBuyAssetCryptoPrecision,
   )
@@ -386,7 +384,7 @@ export const TradeConfirm = () => {
           <ReceiveSummary
             symbol={trade.buyAsset.symbol ?? ''}
             amount={buyAmountCryptoPrecision ?? ''}
-            beforeFees={buyAmountBeforeFeesBuyAssetCryptoPrecision ?? ''}
+            beforeFees={quoteBuyAmountCryptoPrecision ?? ''}
             protocolFee={totalTradeFeeBuyAssetCryptoPrecision ?? ''}
             shapeShiftFee='0'
             slippage={slippage}
@@ -396,7 +394,7 @@ export const TradeConfirm = () => {
         </Stack>
       ) : null,
     [
-      buyAmountBeforeFeesBuyAssetCryptoPrecision,
+      quoteBuyAmountCryptoPrecision,
       buyAmountAfterFeesFiat,
       buyAmountCryptoPrecision,
       sellAmountBeforeFeesBaseUnit,

--- a/src/components/Trade/TradeConfirm/TradeConfirm.tsx
+++ b/src/components/Trade/TradeConfirm/TradeConfirm.tsx
@@ -394,15 +394,16 @@ export const TradeConfirm = () => {
         </Stack>
       ) : null,
     [
-      quoteBuyAmountCryptoPrecision,
-      buyAmountCryptoPrecision,
-      sellAmountBeforeFeesBaseUnit,
-      sellAmountBeforeFeesFiat,
-      slippage,
-      swapper?.name,
-      totalTradeFeeBuyAssetCryptoPrecision,
       trade,
       translate,
+      sellAmountBeforeFeesBaseUnit,
+      sellAmountBeforeFeesFiat,
+      buyAmountCryptoPrecision,
+      quoteBuyAmountCryptoPrecision,
+      totalTradeFeeBuyAssetCryptoPrecision,
+      slippage,
+      fiatBuyAmount,
+      swapper?.name,
     ],
   )
 

--- a/src/components/Trade/TradeConfirm/TradeConfirm.tsx
+++ b/src/components/Trade/TradeConfirm/TradeConfirm.tsx
@@ -32,7 +32,7 @@ import { WalletActions } from 'context/WalletProvider/actions'
 import { useErrorHandler } from 'hooks/useErrorToast/useErrorToast'
 import { useLocaleFormatter } from 'hooks/useLocaleFormatter/useLocaleFormatter'
 import { useWallet } from 'hooks/useWallet/useWallet'
-import { bnOrZero } from 'lib/bignumber/bignumber'
+import { bnOrZero, positiveOrZero } from 'lib/bignumber/bignumber'
 import { getTxLink } from 'lib/getTxLink'
 import { firstNonZeroDecimal, fromBaseUnit } from 'lib/math'
 import { getMaybeCompositeAssetSymbol } from 'lib/mixpanel/helpers'
@@ -44,7 +44,6 @@ import { selectAssets, selectFeeAssetByChainId, selectTxStatusById } from 'state
 import { serializeTxIndex } from 'state/slices/txHistorySlice/utils'
 import { useAppSelector } from 'state/store'
 import {
-  selectBuyAmountAfterFeesFiat,
   selectBuyAmountBeforeFeesBaseUnit,
   selectQuoteBuyAmountCryptoPrecision,
   selectSellAmountBeforeFeesBaseUnitByAction,
@@ -53,6 +52,7 @@ import {
 } from 'state/zustand/swapperStore/amountSelectors'
 import {
   selectBuyAmountCryptoPrecision,
+  selectBuyAmountFiat,
   selectBuyAssetAccountId,
   selectFeeAssetFiatRate,
   selectFees,
@@ -105,7 +105,7 @@ export const TradeConfirm = () => {
   const totalTradeFeeBuyAssetCryptoPrecision = useSwapperStore(
     selectTotalTradeFeeBuyAssetCryptoPrecision,
   )
-  const buyAmountAfterFeesFiat = useSwapperStore(selectBuyAmountAfterFeesFiat)
+  const fiatBuyAmount = useSwapperStore(selectBuyAmountFiat)
   const buyAmountBeforeFeesBaseUnit = useSwapperStore(selectBuyAmountBeforeFeesBaseUnit)
 
   const assets = useAppSelector(selectAssets)
@@ -388,14 +388,13 @@ export const TradeConfirm = () => {
             protocolFee={totalTradeFeeBuyAssetCryptoPrecision ?? ''}
             shapeShiftFee='0'
             slippage={slippage}
-            fiatAmount={bnOrZero(buyAmountAfterFeesFiat).toFixed(2)}
+            fiatAmount={positiveOrZero(fiatBuyAmount).toFixed(2)}
             swapperName={swapper?.name ?? ''}
           />
         </Stack>
       ) : null,
     [
       quoteBuyAmountCryptoPrecision,
-      buyAmountAfterFeesFiat,
       buyAmountCryptoPrecision,
       sellAmountBeforeFeesBaseUnit,
       sellAmountBeforeFeesFiat,

--- a/src/components/Trade/TradeInput.tsx
+++ b/src/components/Trade/TradeInput.tsx
@@ -41,7 +41,7 @@ import {
 } from 'state/slices/selectors'
 import { useAppSelector } from 'state/store'
 import {
-  selectBuyAmountBeforeFeesBuyAssetCryptoPrecision,
+  selectQuoteBuyAmountCryptoPrecision,
   selectTotalTradeFeeBuyAssetCryptoPrecision,
 } from 'state/zustand/swapperStore/amountSelectors'
 import {
@@ -114,9 +114,7 @@ export const TradeInput = () => {
   const checkApprovalNeeded = useSwapperStore(selectCheckApprovalNeededForWallet)
   const handleSwitchAssets = useSwapperStore(state => state.handleSwitchAssets)
   const handleInputAmountChange = useSwapperStore(state => state.handleInputAmountChange)
-  const buyAmountBeforeFeesBuyAssetCryptoPrecision = useSwapperStore(
-    selectBuyAmountBeforeFeesBuyAssetCryptoPrecision,
-  )
+  const quoteBuyAmountCryptoPrecision = useSwapperStore(selectQuoteBuyAmountCryptoPrecision)
   const totalTradeFeeBuyAssetCryptoPrecision = useSwapperStore(
     selectTotalTradeFeeBuyAssetCryptoPrecision,
   )
@@ -567,7 +565,7 @@ export const TradeInput = () => {
               isLoading={tradeStateLoading}
               symbol={buyAsset?.symbol ?? ''}
               amount={buyAmountCryptoPrecision ?? ''}
-              beforeFees={buyAmountBeforeFeesBuyAssetCryptoPrecision ?? ''}
+              beforeFees={quoteBuyAmountCryptoPrecision ?? ''}
               protocolFee={totalTradeFeeBuyAssetCryptoPrecision ?? ''}
               shapeShiftFee='0'
               slippage={slippage}

--- a/src/components/Trade/TradeInput.tsx
+++ b/src/components/Trade/TradeInput.tsx
@@ -120,7 +120,6 @@ export const TradeInput = () => {
   const totalTradeFeeBuyAssetCryptoPrecision = useSwapperStore(
     selectTotalTradeFeeBuyAssetCryptoPrecision,
   )
-
   const { getTrade, getSupportedSellableAssets, getSupportedBuyAssetsFromSellAsset } = useSwapper()
   const translate = useTranslate()
   const history = useHistory()
@@ -524,6 +523,7 @@ export const TradeInput = () => {
             label={translate('trade.youPay')}
           />
           <TradeAssetInput
+            isReadOnly={true}
             accountId={buyAssetAccountId}
             assetId={buyAsset?.assetId}
             assetSymbol={buyAsset?.symbol ?? ''}

--- a/src/components/Trade/TradeInput.tsx
+++ b/src/components/Trade/TradeInput.tsx
@@ -45,6 +45,7 @@ import {
   selectTotalTradeFeeBuyAssetCryptoPrecision,
 } from 'state/zustand/swapperStore/amountSelectors'
 import {
+  selectAction,
   selectBuyAmountCryptoPrecision,
   selectBuyAmountFiat,
   selectBuyAsset,
@@ -118,6 +119,7 @@ export const TradeInput = () => {
   const totalTradeFeeBuyAssetCryptoPrecision = useSwapperStore(
     selectTotalTradeFeeBuyAssetCryptoPrecision,
   )
+  const action = useSwapperStore(selectAction)
   const { getTrade, getSupportedSellableAssets, getSupportedBuyAssetsFromSellAsset } = useSwapper()
   const translate = useTranslate()
   const history = useHistory()
@@ -467,6 +469,17 @@ export const TradeInput = () => {
     [isSwapperApiPending, quoteAvailableForCurrentAssetPair, isSwapperApiInitiated],
   )
 
+  const isSellAction = useMemo(() => {
+    return (
+      action === TradeAmountInputField.SELL_CRYPTO || action === TradeAmountInputField.SELL_FIAT
+    )
+  }, [action])
+
+  const receiveAmountLoading = useMemo(
+    () => isSwapperApiPending && isSellAction,
+    [isSwapperApiPending, isSellAction],
+  )
+
   return (
     <SlideTransition>
       <Stack spacing={6} as='form' onSubmit={handleSubmit(onSubmit)}>
@@ -530,8 +543,8 @@ export const TradeInput = () => {
             fiatAmount={positiveOrZero(fiatBuyAmount).toFixed(2)}
             onChange={onBuyAssetInputChange}
             percentOptions={[1]}
-            showInputSkeleton={tradeStateLoading}
-            showFiatSkeleton={tradeStateLoading}
+            showInputSkeleton={receiveAmountLoading}
+            showFiatSkeleton={receiveAmountLoading}
             label={translate('trade.youGet')}
             rightRegion={
               isTradeRatesEnabled ? (

--- a/src/components/Trade/hooks/useAvailableSwappers.tsx
+++ b/src/components/Trade/hooks/useAvailableSwappers.tsx
@@ -29,6 +29,7 @@ export const useAvailableSwappers = () => {
   const buyAsset = useSwapperStore(selectBuyAsset)
   const sellAsset = useSwapperStore(selectSellAsset)
   const updateFees = useSwapperStore(state => state.updateFees)
+  const updateTradeAmountsFromQuote = useSwapperStore(state => state.updateTradeAmountsFromQuote)
 
   // Constants
   const buyAssetId = buyAsset?.assetId
@@ -151,6 +152,7 @@ export const useAvailableSwappers = () => {
       const activeSwapperWithQuoteMetadata = swappersToDisplay?.[0]
       updateAvailableSwappersWithMetadata(swappersToDisplay)
       updateActiveSwapperWithMetadata(activeSwapperWithQuoteMetadata)
+      updateTradeAmountsFromQuote()
       feeAsset && updateFees(feeAsset)
     })()
   }, [
@@ -164,5 +166,6 @@ export const useAvailableSwappers = () => {
     updateActiveSwapperWithMetadata,
     updateAvailableSwappersWithMetadata,
     updateFees,
+    updateTradeAmountsFromQuote,
   ])
 }

--- a/src/components/Trade/hooks/useAvailableSwappers.tsx
+++ b/src/components/Trade/hooks/useAvailableSwappers.tsx
@@ -160,7 +160,6 @@ export const useAvailableSwappers = () => {
     dispatch,
     feeAsset,
     getIsTradingActive,
-    sellAsset?.assetId,
     sellAssetId,
     swappersWithQuoteMetadata,
     updateActiveSwapperWithMetadata,

--- a/src/components/Trade/hooks/useTradeQuoteService.tsx
+++ b/src/components/Trade/hooks/useTradeQuoteService.tsx
@@ -12,7 +12,6 @@ import {
 } from 'state/slices/selectors'
 import { useAppSelector } from 'state/store'
 import {
-  selectBuyAmountCryptoPrecision,
   selectBuyAsset,
   selectIsSendMax,
   selectReceiveAddress,
@@ -38,7 +37,6 @@ export const useTradeQuoteService = () => {
   const sellAsset = useSwapperStore(selectSellAsset)
   const buyAsset = useSwapperStore(selectBuyAsset)
   const sellAmountCryptoPrecision = useSwapperStore(selectSellAmountCryptoPrecision)
-  const buyAmountCryptoPrecision = useSwapperStore(selectBuyAmountCryptoPrecision)
 
   const sellAssetAccountIds = useAppSelector(state =>
     selectPortfolioAccountIdsByAssetId(state, {
@@ -90,7 +88,6 @@ export const useTradeQuoteService = () => {
     sellAmountCryptoPrecision,
     sellAsset,
     wallet,
-    buyAmountCryptoPrecision,
   ])
 
   return {

--- a/src/components/Trade/hooks/useTradeQuoteService.tsx
+++ b/src/components/Trade/hooks/useTradeQuoteService.tsx
@@ -12,6 +12,7 @@ import {
 } from 'state/slices/selectors'
 import { useAppSelector } from 'state/store'
 import {
+  selectBuyAmountCryptoPrecision,
   selectBuyAsset,
   selectIsSendMax,
   selectReceiveAddress,
@@ -37,6 +38,7 @@ export const useTradeQuoteService = () => {
   const sellAsset = useSwapperStore(selectSellAsset)
   const buyAsset = useSwapperStore(selectBuyAsset)
   const sellAmountCryptoPrecision = useSwapperStore(selectSellAmountCryptoPrecision)
+  const buyAmountCryptoPrecision = useSwapperStore(selectBuyAmountCryptoPrecision)
 
   const sellAssetAccountIds = useAppSelector(state =>
     selectPortfolioAccountIdsByAssetId(state, {
@@ -88,6 +90,7 @@ export const useTradeQuoteService = () => {
     sellAmountCryptoPrecision,
     sellAsset,
     wallet,
+    buyAmountCryptoPrecision,
   ])
 
   return {

--- a/src/state/zustand/swapperStore/actions.ts
+++ b/src/state/zustand/swapperStore/actions.ts
@@ -2,7 +2,6 @@ import type { Asset } from '@shapeshiftoss/asset-service'
 import { getFormFees } from 'components/Trade/hooks/useSwapper/utils'
 import { AssetClickAction } from 'components/Trade/hooks/useTradeRoutes/types'
 import { TradeAmountInputField } from 'components/Trade/types'
-import { fromBaseUnit } from 'lib/math'
 import {
   selectTradeAmountsByActionAndAmount,
   selectTradeAmountsByActionAndAmountFromQuote,
@@ -80,25 +79,16 @@ export const handleInputAmountChange =
   () =>
     set(
       draft => {
-        const tradeAmountsByActionAndAmount = selectTradeAmountsByActionAndAmount(draft)
-        const sellAsset = draft.sellAsset
-        const buyAsset = draft.buyAsset
         const {
-          sellAmountSellAssetBaseUnit,
-          buyAmountBuyAssetBaseUnit,
+          sellAmountSellAssetCryptoPrecision,
+          buyAmountBuyAssetCryptoPrecision,
           fiatSellAmount,
           fiatBuyAmount,
-        } = tradeAmountsByActionAndAmount
-        const buyAmountCryptoPrecision =
-          buyAmountBuyAssetBaseUnit && buyAsset
-            ? fromBaseUnit(buyAmountBuyAssetBaseUnit, buyAsset.precision)
-            : '0'
-        const sellAmountCryptoPrecision =
-          sellAmountSellAssetBaseUnit && sellAsset
-            ? fromBaseUnit(sellAmountSellAssetBaseUnit, sellAsset.precision)
-            : '0'
-        draft.buyAmountCryptoPrecision = buyAmountCryptoPrecision
-        draft.sellAmountCryptoPrecision = sellAmountCryptoPrecision
+        } = selectTradeAmountsByActionAndAmount(draft)
+        if (buyAmountBuyAssetCryptoPrecision)
+          draft.buyAmountCryptoPrecision = buyAmountBuyAssetCryptoPrecision
+        if (sellAmountSellAssetCryptoPrecision)
+          draft.sellAmountCryptoPrecision = sellAmountSellAssetCryptoPrecision
         if (fiatBuyAmount) draft.buyAmountFiat = fiatBuyAmount
         if (fiatSellAmount) draft.sellAmountFiat = fiatSellAmount
         return draft
@@ -180,25 +170,16 @@ export const updateFees = (set: SetSwapperStoreAction<SwapperState>) => (sellFee
 export const updateTradeAmountsFromQuote = (set: SetSwapperStoreAction<SwapperState>) => () =>
   set(
     draft => {
-      const tradeAmountsByActionAndAmount = selectTradeAmountsByActionAndAmountFromQuote(draft)
-      const sellAsset = draft.sellAsset
-      const buyAsset = draft.buyAsset
       const {
-        sellAmountSellAssetBaseUnit,
-        buyAmountBuyAssetBaseUnit,
+        sellAmountSellAssetCryptoPrecision,
+        buyAmountBuyAssetCryptoPrecision,
         fiatSellAmount,
         fiatBuyAmount,
-      } = tradeAmountsByActionAndAmount
-      const buyAmountCryptoPrecision =
-        buyAmountBuyAssetBaseUnit && buyAsset
-          ? fromBaseUnit(buyAmountBuyAssetBaseUnit, buyAsset.precision)
-          : '0'
-      const sellAmountCryptoPrecision =
-        sellAmountSellAssetBaseUnit && sellAsset
-          ? fromBaseUnit(sellAmountSellAssetBaseUnit, sellAsset.precision)
-          : '0'
-      draft.buyAmountCryptoPrecision = buyAmountCryptoPrecision
-      draft.sellAmountCryptoPrecision = sellAmountCryptoPrecision
+      } = selectTradeAmountsByActionAndAmountFromQuote(draft)
+      if (buyAmountBuyAssetCryptoPrecision)
+        draft.buyAmountCryptoPrecision = buyAmountBuyAssetCryptoPrecision
+      if (sellAmountSellAssetCryptoPrecision)
+        draft.sellAmountCryptoPrecision = sellAmountSellAssetCryptoPrecision
       if (fiatBuyAmount) draft.buyAmountFiat = fiatBuyAmount
       if (fiatSellAmount) draft.sellAmountFiat = fiatSellAmount
       return draft

--- a/src/state/zustand/swapperStore/actions.ts
+++ b/src/state/zustand/swapperStore/actions.ts
@@ -3,7 +3,10 @@ import { getFormFees } from 'components/Trade/hooks/useSwapper/utils'
 import { AssetClickAction } from 'components/Trade/hooks/useTradeRoutes/types'
 import { TradeAmountInputField } from 'components/Trade/types'
 import { fromBaseUnit } from 'lib/math'
-import { selectTradeAmountsByActionAndAmount } from 'state/zustand/swapperStore/amountSelectors'
+import {
+  selectTradeAmountsByActionAndAmount,
+  selectTradeAmountsByActionAndAmountFromQuote,
+} from 'state/zustand/swapperStore/amountSelectors'
 import { selectQuote } from 'state/zustand/swapperStore/selectors'
 import type { SetSwapperStoreAction, SwapperState } from 'state/zustand/swapperStore/types'
 
@@ -172,4 +175,34 @@ export const updateFees = (set: SetSwapperStoreAction<SwapperState>) => (sellFee
     },
     false,
     `swapper/updateFees`,
+  )
+
+export const updateTradeAmountsFromQuote = (set: SetSwapperStoreAction<SwapperState>) => () =>
+  set(
+    draft => {
+      const tradeAmountsByActionAndAmount = selectTradeAmountsByActionAndAmountFromQuote(draft)
+      const sellAsset = draft.sellAsset
+      const buyAsset = draft.buyAsset
+      const {
+        sellAmountSellAssetBaseUnit,
+        buyAmountBuyAssetBaseUnit,
+        fiatSellAmount,
+        fiatBuyAmount,
+      } = tradeAmountsByActionAndAmount
+      const buyAmountCryptoPrecision =
+        buyAmountBuyAssetBaseUnit && buyAsset
+          ? fromBaseUnit(buyAmountBuyAssetBaseUnit, buyAsset.precision)
+          : '0'
+      const sellAmountCryptoPrecision =
+        sellAmountSellAssetBaseUnit && sellAsset
+          ? fromBaseUnit(sellAmountSellAssetBaseUnit, sellAsset.precision)
+          : '0'
+      draft.buyAmountCryptoPrecision = buyAmountCryptoPrecision
+      draft.sellAmountCryptoPrecision = sellAmountCryptoPrecision
+      if (fiatBuyAmount) draft.buyAmountFiat = fiatBuyAmount
+      if (fiatSellAmount) draft.sellAmountFiat = fiatSellAmount
+      return draft
+    },
+    false,
+    `swapper/updateTradeAmountsFromQuote`,
   )

--- a/src/state/zustand/swapperStore/amountSelectors.test.ts
+++ b/src/state/zustand/swapperStore/amountSelectors.test.ts
@@ -1,5 +1,8 @@
 import { TradeAmountInputField } from 'components/Trade/types'
-import { selectTradeAmountsByActionAndAmount } from 'state/zustand/swapperStore/amountSelectors'
+import {
+  selectTradeAmountsByActionAndAmount,
+  selectTradeAmountsByActionAndAmountFromQuote,
+} from 'state/zustand/swapperStore/amountSelectors'
 import { baseSwapperState } from 'state/zustand/swapperStore/testData'
 import type { SwapperState } from 'state/zustand/swapperStore/types'
 
@@ -9,13 +12,22 @@ describe('calculateAmounts', () => {
     const amount = '0.001'
     const state: SwapperState = { ...baseSwapperState, action, amount }
     const tradeAmountsByActionAndAmount = selectTradeAmountsByActionAndAmount(state)
+    const tradeAmountsByActionAndAmountFromQuote =
+      selectTradeAmountsByActionAndAmountFromQuote(state)
 
     // Negative values are expected as the swapper fees are higher than the sell amount
     expect(tradeAmountsByActionAndAmount).toEqual({
       sellAmountSellAssetBaseUnit: '1000000000000000',
-      buyAmountBuyAssetBaseUnit: '-204624937927405447829',
+      buyAmountBuyAssetBaseUnit: '0',
       fiatSellAmount: '1.767',
-      fiatBuyAmount: '-6.752622951604379778357',
+      fiatBuyAmount: '0',
+    })
+
+    expect(tradeAmountsByActionAndAmountFromQuote).toEqual({
+      sellAmountSellAssetBaseUnit: '1000000000000000',
+      buyAmountBuyAssetBaseUnit: '986780221000000000000',
+      fiatSellAmount: '1.767',
+      fiatBuyAmount: '32.563747293',
     })
   })
 
@@ -23,11 +35,22 @@ describe('calculateAmounts', () => {
     const action = TradeAmountInputField.BUY_CRYPTO
     const state: SwapperState = { ...baseSwapperState, action }
     const tradeAmountsByActionAndAmount = selectTradeAmountsByActionAndAmount(state)
+    const tradeAmountsByActionAndAmountFromQuote =
+      selectTradeAmountsByActionAndAmountFromQuote(state)
 
     expect(tradeAmountsByActionAndAmount).toEqual({
-      sellAmountSellAssetBaseUnit: '5437817176912496',
+      sellAmountSellAssetBaseUnit: '0',
       buyAmountBuyAssetBaseUnit: '33000000000000000000',
-      fiatSellAmount: '9.608622951604380432',
+      fiatSellAmount: '0',
+      fiatBuyAmount: '1.089',
+    })
+
+    // These outputs are "correct" with the current logic, but don't really make sense unless we can specify a desired
+    // receive amount when requesting a quote
+    expect(tradeAmountsByActionAndAmountFromQuote).toEqual({
+      sellAmountSellAssetBaseUnit: '18665000000000000',
+      buyAmountBuyAssetBaseUnit: '-225170392472859992504',
+      fiatSellAmount: '32.981055',
       fiatBuyAmount: '1.089',
     })
   })
@@ -36,12 +59,21 @@ describe('calculateAmounts', () => {
     const action = TradeAmountInputField.SELL_FIAT
     const state: SwapperState = { ...baseSwapperState, action }
     const tradeAmountsByActionAndAmount = selectTradeAmountsByActionAndAmount(state)
+    const tradeAmountsByActionAndAmountFromQuote =
+      selectTradeAmountsByActionAndAmountFromQuote(state)
 
     expect(tradeAmountsByActionAndAmount).toEqual({
       sellAmountSellAssetBaseUnit: '18675721561969440',
-      buyAmountBuyAssetBaseUnit: '741829607527140007496',
+      buyAmountBuyAssetBaseUnit: '0',
       fiatSellAmount: '33',
-      fiatBuyAmount: '24.480377048395620247368',
+      fiatBuyAmount: '0',
+    })
+
+    expect(tradeAmountsByActionAndAmountFromQuote).toEqual({
+      sellAmountSellAssetBaseUnit: '18675721561969440',
+      buyAmountBuyAssetBaseUnit: '986780221000000000000',
+      fiatSellAmount: '32.998725',
+      fiatBuyAmount: '32.563747293',
     })
   })
 
@@ -49,12 +81,23 @@ describe('calculateAmounts', () => {
     const action = TradeAmountInputField.BUY_FIAT
     const state: SwapperState = { ...baseSwapperState, action }
     const tradeAmountsByActionAndAmount = selectTradeAmountsByActionAndAmount(state)
+    const tradeAmountsByActionAndAmountFromQuote =
+      selectTradeAmountsByActionAndAmountFromQuote(state)
 
     expect(tradeAmountsByActionAndAmount).toEqual({
-      sellAmountSellAssetBaseUnit: '23497239927336944',
+      sellAmountSellAssetBaseUnit: '0',
       buyAmountBuyAssetBaseUnit: '1000000000000000000000',
-      fiatSellAmount: '41.519622951604380048',
+      fiatSellAmount: '0',
       fiatBuyAmount: '33',
+    })
+
+    // These outputs are "correct" with the current logic, but don't really make sense unless we can specify a desired
+    // receive amount when requesting a quote
+    expect(tradeAmountsByActionAndAmountFromQuote).toEqual({
+      sellAmountSellAssetBaseUnit: '18665000000000000',
+      buyAmountBuyAssetBaseUnit: '1000000000000000000000',
+      fiatSellAmount: '32.981055',
+      fiatBuyAmount: '24.480377031',
     })
   })
 })

--- a/src/state/zustand/swapperStore/amountSelectors.test.ts
+++ b/src/state/zustand/swapperStore/amountSelectors.test.ts
@@ -7,7 +7,7 @@ import { baseSwapperState } from 'state/zustand/swapperStore/testData'
 import type { SwapperState } from 'state/zustand/swapperStore/types'
 
 describe('calculateAmounts', () => {
-  it('returns sellAmountSellAssetBaseUnit, buyAmountBuyAssetBaseUnit, fiatSellAmount, fiatBuyAmount for SELL_CRYPTO action', () => {
+  it('returns sellAmountSellAssetCryptoPrecision, buyAmountBuyAssetBaseUnit, fiatSellAmount, fiatBuyAmount for SELL_CRYPTO action', () => {
     const action = TradeAmountInputField.SELL_CRYPTO
     const amount = '0.001'
     const state: SwapperState = { ...baseSwapperState, action, amount }
@@ -17,21 +17,21 @@ describe('calculateAmounts', () => {
 
     // Negative values are expected as the swapper fees are higher than the sell amount
     expect(tradeAmountsByActionAndAmount).toEqual({
-      sellAmountSellAssetBaseUnit: '1000000000000000',
-      buyAmountBuyAssetBaseUnit: '0',
+      sellAmountSellAssetCryptoPrecision: '0.001',
+      buyAmountBuyAssetCryptoPrecision: '0',
       fiatSellAmount: '1.767',
       fiatBuyAmount: '0',
     })
 
     expect(tradeAmountsByActionAndAmountFromQuote).toEqual({
-      sellAmountSellAssetBaseUnit: '1000000000000000',
-      buyAmountBuyAssetBaseUnit: '986780221000000000000',
+      sellAmountSellAssetCryptoPrecision: '0.001',
+      buyAmountBuyAssetCryptoPrecision: '728.53893838230606312222513796069583299584',
       fiatSellAmount: '1.767',
-      fiatBuyAmount: '32.563747293',
+      fiatBuyAmount: '24.044124341395620247368',
     })
   })
 
-  it('returns sellAmountSellAssetBaseUnit, buyAmountBuyAssetBaseUnit, fiatSellAmount, fiatBuyAmount for BUY_CRYPTO action', () => {
+  it('returns sellAmountSellAssetCryptoPrecision, buyAmountBuyAssetCryptoPrecision, fiatSellAmount, fiatBuyAmount for BUY_CRYPTO action', () => {
     const action = TradeAmountInputField.BUY_CRYPTO
     const state: SwapperState = { ...baseSwapperState, action }
     const tradeAmountsByActionAndAmount = selectTradeAmountsByActionAndAmount(state)
@@ -39,8 +39,8 @@ describe('calculateAmounts', () => {
       selectTradeAmountsByActionAndAmountFromQuote(state)
 
     expect(tradeAmountsByActionAndAmount).toEqual({
-      sellAmountSellAssetBaseUnit: '0',
-      buyAmountBuyAssetBaseUnit: '33000000000000000000',
+      sellAmountSellAssetCryptoPrecision: '0',
+      buyAmountBuyAssetCryptoPrecision: '33',
       fiatSellAmount: '0',
       fiatBuyAmount: '1.089',
     })
@@ -48,14 +48,14 @@ describe('calculateAmounts', () => {
     // These outputs are "correct" with the current logic, but don't really make sense unless we can specify a desired
     // receive amount when requesting a quote
     expect(tradeAmountsByActionAndAmountFromQuote).toEqual({
-      sellAmountSellAssetBaseUnit: '18665000000000000',
-      buyAmountBuyAssetBaseUnit: '-225170392472859992504',
+      sellAmountSellAssetCryptoPrecision: '0.018665',
+      buyAmountBuyAssetCryptoPrecision: '-225.170392472859966803',
       fiatSellAmount: '32.981055',
       fiatBuyAmount: '1.089',
     })
   })
 
-  it('returns sellAmountSellAssetBaseUnit, buyAmountBuyAssetBaseUnit, fiatSellAmount, fiatBuyAmount for SELL_FIAT action', () => {
+  it('returns sellAmountSellAssetCryptoPrecision, buyAmountBuyAssetCryptoPrecision, fiatSellAmount, fiatBuyAmount for SELL_FIAT action', () => {
     const action = TradeAmountInputField.SELL_FIAT
     const state: SwapperState = { ...baseSwapperState, action }
     const tradeAmountsByActionAndAmount = selectTradeAmountsByActionAndAmount(state)
@@ -63,21 +63,21 @@ describe('calculateAmounts', () => {
       selectTradeAmountsByActionAndAmountFromQuote(state)
 
     expect(tradeAmountsByActionAndAmount).toEqual({
-      sellAmountSellAssetBaseUnit: '18675721561969440',
-      buyAmountBuyAssetBaseUnit: '0',
+      sellAmountSellAssetCryptoPrecision: '0.01867572156196944',
+      buyAmountBuyAssetCryptoPrecision: '0',
       fiatSellAmount: '33',
       fiatBuyAmount: '0',
     })
 
     expect(tradeAmountsByActionAndAmountFromQuote).toEqual({
-      sellAmountSellAssetBaseUnit: '18675721561969440',
-      buyAmountBuyAssetBaseUnit: '986780221000000000000',
-      fiatSellAmount: '32.998725',
-      fiatBuyAmount: '32.563747293',
+      sellAmountSellAssetCryptoPrecision: '0.01867572156196944',
+      buyAmountBuyAssetCryptoPrecision: '728.53893838230606312222513796069583299584',
+      fiatSellAmount: '33',
+      fiatBuyAmount: '24.044124341395620247368',
     })
   })
 
-  it('returns sellAmountSellAssetBaseUnit, buyAmountBuyAssetBaseUnit, fiatSellAmount, fiatBuyAmount for BUY_FIAT action', () => {
+  it('returns sellAmountSellAssetCryptoPrecision, buyAmountBuyAssetCryptoPrecision, fiatSellAmount, fiatBuyAmount for BUY_FIAT action', () => {
     const action = TradeAmountInputField.BUY_FIAT
     const state: SwapperState = { ...baseSwapperState, action }
     const tradeAmountsByActionAndAmount = selectTradeAmountsByActionAndAmount(state)
@@ -85,8 +85,8 @@ describe('calculateAmounts', () => {
       selectTradeAmountsByActionAndAmountFromQuote(state)
 
     expect(tradeAmountsByActionAndAmount).toEqual({
-      sellAmountSellAssetBaseUnit: '0',
-      buyAmountBuyAssetBaseUnit: '1000000000000000000000',
+      sellAmountSellAssetCryptoPrecision: '0',
+      buyAmountBuyAssetCryptoPrecision: '1000',
       fiatSellAmount: '0',
       fiatBuyAmount: '33',
     })
@@ -94,10 +94,10 @@ describe('calculateAmounts', () => {
     // These outputs are "correct" with the current logic, but don't really make sense unless we can specify a desired
     // receive amount when requesting a quote
     expect(tradeAmountsByActionAndAmountFromQuote).toEqual({
-      sellAmountSellAssetBaseUnit: '18665000000000000',
-      buyAmountBuyAssetBaseUnit: '1000000000000000000000',
+      sellAmountSellAssetCryptoPrecision: '0.018665',
+      buyAmountBuyAssetCryptoPrecision: '1000',
       fiatSellAmount: '32.981055',
-      fiatBuyAmount: '24.480377031',
+      fiatBuyAmount: '24.480377048395620247368',
     })
   })
 })

--- a/src/state/zustand/swapperStore/amountSelectors.ts
+++ b/src/state/zustand/swapperStore/amountSelectors.ts
@@ -514,8 +514,8 @@ export const selectTradeAmountsByActionAndAmountFromQuote: Selector<
       fiatSellAmount: '0',
       fiatBuyAmount: '0',
     }
-    if (!sellAsset || !buyAsset || bnOrZero(amount).isZero()) return defaultReturn
-    const quoteBuyAmountAfterFeesCryptoPrecisionAfterSlippage = bnOrZero(
+    if (!sellAsset || !buyAsset || bnOrZero(amount).lte(0)) return defaultReturn
+    const quoteBuyAmountAfterFeesAndSlippageCryptoPrecision = bnOrZero(
       quoteBuyAmountAfterFeesCryptoPrecision,
     )
       .times(bn(1).minus(slippage))
@@ -524,7 +524,7 @@ export const selectTradeAmountsByActionAndAmountFromQuote: Selector<
       case TradeAmountInputField.SELL_CRYPTO: {
         return {
           sellAmountSellAssetCryptoPrecision: amount,
-          buyAmountBuyAssetCryptoPrecision: quoteBuyAmountAfterFeesCryptoPrecisionAfterSlippage,
+          buyAmountBuyAssetCryptoPrecision: quoteBuyAmountAfterFeesAndSlippageCryptoPrecision,
           fiatSellAmount: sellAmountBeforeFeesFiat,
           fiatBuyAmount: quoteBuyAmountAfterFeesFiat,
         }
@@ -532,7 +532,7 @@ export const selectTradeAmountsByActionAndAmountFromQuote: Selector<
       case TradeAmountInputField.SELL_FIAT: {
         return {
           sellAmountSellAssetCryptoPrecision: sellAmountBeforeFeesCryptoPrecision,
-          buyAmountBuyAssetCryptoPrecision: quoteBuyAmountAfterFeesCryptoPrecisionAfterSlippage,
+          buyAmountBuyAssetCryptoPrecision: quoteBuyAmountAfterFeesAndSlippageCryptoPrecision,
           fiatSellAmount: amount,
           fiatBuyAmount: quoteBuyAmountAfterFeesFiat,
         }

--- a/src/state/zustand/swapperStore/testData.ts
+++ b/src/state/zustand/swapperStore/testData.ts
@@ -34,6 +34,7 @@ const mockActions: SwapperAction = {
   updateSellAssetFiatRate(): void {},
   updateTrade(): void {},
   handleAssetSelection(): void {},
+  updateTradeAmountsFromQuote(): void {},
 }
 
 export const baseSwapperState: SwapperState = {

--- a/src/state/zustand/swapperStore/types.ts
+++ b/src/state/zustand/swapperStore/types.ts
@@ -66,6 +66,7 @@ export type SwapperAction = {
   handleInputAmountChange: () => void
   handleAssetSelection: (handleAssetSelectionInput: HandleAssetSelectionInput) => void
   updateFees: (sellFeeAsset: Asset) => void
+  updateTradeAmountsFromQuote: () => void
 }
 
 // https://github.com/pmndrs/zustand/blob/main/src/vanilla.ts#L1

--- a/src/state/zustand/swapperStore/useSwapperStore.ts
+++ b/src/state/zustand/swapperStore/useSwapperStore.ts
@@ -9,6 +9,7 @@ import {
   handleSwitchAssets,
   toggleIsExactAllowance,
   updateFees,
+  updateTradeAmountsFromQuote,
 } from 'state/zustand/swapperStore/actions'
 import type { SetSwapperStoreAction, SwapperState } from 'state/zustand/swapperStore/types'
 
@@ -67,6 +68,7 @@ export const useSwapperStore = (() => {
           updateSelectedCurrencyToUsdRate: createUpdateAction(set, 'selectedCurrencyToUsdRate'),
           handleInputAmountChange: handleInputAmountChange(set),
           handleAssetSelection: handleAssetSelection(set),
+          updateTradeAmountsFromQuote: updateTradeAmountsFromQuote(set),
         }),
         { name: 'SwapperStore' },
       ),


### PR DESCRIPTION
## Description

This PR:

- Uses data from the quote responses to populate amounts shown to the user
- Updates the receive amount calculation to include the slippage amount, so the "you get" field accurately presents to the user what they can expect to receive
- Fixes "max" amount logic, whereby we now get an initial quote with some arbitrary value (instead of `0`) before computing the max send amount, giving us a more accurate send amount. Also backs off the total send amount by 1% as it was often failing due to how close it was to the limit
- Prevents the input of receive amounts (confirmed with product) - we'll add this logic when we bed down the current implementation and invest more time into getting it right, as it's non-trivial/risky

For reviewers:

- The main change here is addition and use of the [selectTradeAmountsByActionAndAmountFromQuote](https://github.com/shapeshift/web/pull/4217/files#diff-5d596f09a0ba2f9df7660be3e0b36a5577ecc9a692ae777c7d53ad2630593493R475) selector, which is called after a quote is received to update all amounts based on the data in the quote response (instead of using a guestimate conversion using fiat rates from the sell amount)
- The second change is to the `selectTradeAmountsByActionAndAmount`, which now only updates the values we have enough data for (i.e. if we are entering a fiat sell amount, we can compute the crypto amount, and vice versa, but not the buy amounts because we need to wait for the quote response). So, we set the values we can't compute to `0` to prevent stale data, and set the input field to a loading skeleton whilst we wait for the quote
- There is a bug with CoW Swap minimums that gets exposed by this PR, which is fixed in `lib` here https://github.com/shapeshift/lib/pull/1235

## Notice

- [x] Have you followed the guidelines in our [Contributing]('https://github.com/shapeshift/web/blob/develop/CONTRIBUTING.md) guide?
- [x] Have you checked to ensure there aren't other open [Pull Requests](https://github.com/shapeshift/web/pulls) for the same update/change?

## Pull Request Type

- [x] :bug: Bug fix (Non-breaking Change: Fixes an issue)
- [ ] :hammer_and_wrench: Chore (Non-breaking Change: Doc updates, pkg upgrades, typos, etc..)
- [x] :nail_care: New Feature (Breaking/Non-breaking Change)

## Issue (if applicable)

Fixes prod issues, and improves architecture / logic.

## Risk

High - this touches most value computations in the swapper.

## Testing

This needs a very good test of everything swapper related - quotes, amounts on input entry, trade confirmation page, receive amounts from trades etc.

### Engineering

☝️ 

### Operations

☝️ 

## Screenshots (if applicable)

<img width="478" alt="Screenshot 2023-04-10 at 2 24 29 pm" src="https://user-images.githubusercontent.com/97164662/230825637-cc94d746-2813-4099-8a79-63981f0f4907.png">
