### PR TITLE
fix(swapper): thorchain getTradeRate include fees and slippage

### DIFF
--- a/packages/swapper/src/swappers/thorchain/cosmossdk/getCosmosTxData.ts
+++ b/packages/swapper/src/swappers/thorchain/cosmossdk/getCosmosTxData.ts
@@ -58,6 +58,7 @@ export const getCosmosTxData = async (input: GetCosmosTxDataInput) => {
     slippageTolerance,
     deps,
     buyAssetTradeFeeUsd: quote.feeData.buyAssetTradeFeeUsd,
+    receiveAddress: destinationAddress,
   })
 
   const memo = makeSwapMemo({

--- a/packages/swapper/src/swappers/thorchain/evm/utils/getThorTxData.ts
+++ b/packages/swapper/src/swappers/thorchain/evm/utils/getThorTxData.ts
@@ -53,6 +53,7 @@ export const getThorTxInfo: GetBtcThorTxInfo = async ({
       slippageTolerance,
       deps,
       buyAssetTradeFeeUsd,
+      receiveAddress: destinationAddress,
     })
 
     const memo = makeSwapMemo({

--- a/packages/swapper/src/swappers/thorchain/getThorTradeQuote/getTradeQuote.test.ts
+++ b/packages/swapper/src/swappers/thorchain/getThorTradeQuote/getTradeQuote.test.ts
@@ -22,7 +22,7 @@ const expectedQuoteResponse: TradeQuote<KnownChainIds.EthereumMainnet> = {
   maximum: '100000000000000000000000000',
   sellAmountBeforeFeesCryptoBaseUnit: '10000000000000000000', // 10 FOX
   allowanceContract: '0x3624525075b88B24ecc29CE226b0CEc1fFcB6976',
-  buyAmountCryptoBaseUnit: '784000000000000',
+  buyAmountCryptoBaseUnit: '4633547338118093212830055',
   feeData: {
     chainSpecific: {
       estimatedGas: '100000',
@@ -33,7 +33,7 @@ const expectedQuoteResponse: TradeQuote<KnownChainIds.EthereumMainnet> = {
     sellAssetTradeFeeUsd: '0',
     networkFeeCryptoBaseUnit: '700000',
   },
-  rate: '0.0000784',
+  rate: '463354.73381180932128300549',
   sources: [{ name: SwapperName.Thorchain, proportion: '1' }],
   buyAsset: ETH,
   sellAsset: FOX,
@@ -59,7 +59,28 @@ describe('getTradeQuote', () => {
         case '/lcd/thorchain/inbound_addresses':
           return Promise.resolve({ data: mockInboundAddresses })
         default:
-          return Promise.resolve({ data: undefined })
+          // '/lcd/thorchain/swap' fallthrough
+          return Promise.resolve({
+            data: {
+              dust_threshold: '10000',
+              expected_amount_out: '261454522054192',
+              expiry: 1681132269,
+              fees: {
+                affiliate: '0',
+                asset: 'ETH.FOX-0XC770EEFAD204B5180DF6A14EE197D99D808EE52D',
+                outbound: '16554235812',
+              },
+              inbound_address: 'bc1qucjrczghvwl5d66klz6npv7tshkpwpzlw0zzj8',
+              inbound_confirmation_blocks: 2,
+              inbound_confirmation_seconds: 1200,
+              notes:
+                'First output should be to inbound_address, second output should be change back to self, third output should be OP_RETURN, limited to 80 bytes. Do not send below the dust threshold. Do not use exotic spend scripts, locks or address formats (P2WSH with Bech32 address format preferred).',
+              outbound_delay_blocks: 575,
+              outbound_delay_seconds: 6900,
+              slippage_bps: 4357,
+              warning: 'Do not cache this response. Do not send funds after the expiry.',
+            },
+          })
       }
     })
     ;(getUsdRate as jest.Mock<unknown>)

--- a/packages/swapper/src/swappers/thorchain/getThorTradeQuote/getTradeQuote.test.ts
+++ b/packages/swapper/src/swappers/thorchain/getThorTradeQuote/getTradeQuote.test.ts
@@ -59,7 +59,7 @@ describe('getTradeQuote', () => {
         case '/lcd/thorchain/inbound_addresses':
           return Promise.resolve({ data: mockInboundAddresses })
         default:
-          // '/lcd/thorchain/swap' fallthrough
+          // '/lcd/thorchain/quote/swap/<swapQueryParams>' fallthrough
           return Promise.resolve({
             data: {
               dust_threshold: '10000',

--- a/packages/swapper/src/swappers/thorchain/getThorTradeQuote/getTradeQuote.ts
+++ b/packages/swapper/src/swappers/thorchain/getThorTradeQuote/getTradeQuote.ts
@@ -68,7 +68,13 @@ export const getThorTradeQuote: GetThorTradeQuote = async ({ deps, input }) => {
         },
       )
 
-    const rate = await getTradeRate(sellAsset, buyAsset.assetId, sellAmountCryptoBaseUnit, deps)
+    const rate = await getTradeRate({
+      sellAsset,
+      buyAssetId: buyAsset.assetId,
+      sellAmountCryptoBaseUnit,
+      receiveAddress,
+      deps,
+    })
 
     const buyAmountCryptoBaseUnit = toBaseUnit(
       bnOrZero(fromBaseUnit(sellAmountCryptoBaseUnit, sellAsset.precision)).times(rate),

--- a/packages/swapper/src/swappers/thorchain/types.ts
+++ b/packages/swapper/src/swappers/thorchain/types.ts
@@ -26,23 +26,25 @@ export type ThornodePoolResponse = {
   synth_units: string
 }
 
-export type ThornodeQuoteResponse = {
-  expected_amount_out: string
-  expiry: string
-  fees: {
-    affiliate: string
-    asset: string
-    outbound: string
-  }
-  inbound_address: string
-  memo: string
-  notes: string
-  outbound_delay_blocks: number
-  outbound_delay_seconds: number
-  router: string
-  slippage_bps: number
-  warning: string
-}
+export type ThornodeQuoteResponse =
+  | {
+      expected_amount_out: string
+      expiry: string
+      fees: {
+        affiliate: string
+        asset: string
+        outbound: string
+      }
+      inbound_address: string
+      memo: string
+      notes: string
+      outbound_delay_blocks: number
+      outbound_delay_seconds: number
+      router: string
+      slippage_bps: number
+      warning: string
+    }
+  | { error: string }
 
 type MidgardCoins = {
   asset: string

--- a/packages/swapper/src/swappers/thorchain/types.ts
+++ b/packages/swapper/src/swappers/thorchain/types.ts
@@ -26,6 +26,24 @@ export type ThornodePoolResponse = {
   synth_units: string
 }
 
+export type ThornodeQuoteResponse = {
+  expected_amount_out: string
+  expiry: string
+  fees: {
+    affiliate: string
+    asset: string
+    outbound: string
+  }
+  inbound_address: string
+  memo: string
+  notes: string
+  outbound_delay_blocks: number
+  outbound_delay_seconds: number
+  router: string
+  slippage_bps: number
+  warning: string
+}
+
 type MidgardCoins = {
   asset: string
 }[]

--- a/packages/swapper/src/swappers/thorchain/utils/getLimit/getLimit.test.ts
+++ b/packages/swapper/src/swappers/thorchain/utils/getLimit/getLimit.test.ts
@@ -35,7 +35,7 @@ const thorchainSwapperDeps: ThorchainSwapperDeps = {
 }
 
 describe('getLimit', () => {
-  it('should get limit when buy asset is EVM fee asset and sell asset is a UTXO', async () => {
+  it('should get limit when sell asset is EVM fee asset and buy asset is a UTXO', async () => {
     ;(getUsdRate as jest.Mock<unknown>)
       .mockReturnValueOnce(Promise.resolve('1595')) // sellFeeAssetUsdRate (ETH)
       .mockReturnValueOnce(Promise.resolve('20683')) // buyAssetUsdRate (BTC)
@@ -46,6 +46,7 @@ describe('getLimit', () => {
     const getLimitArgs: GetLimitArgs = {
       sellAsset: ETH,
       buyAssetId: BTC.assetId,
+      receiveAddress: '1A1zP1eP5QGefi2DMPTfTL5SLmv7DivfNa',
       sellAmountCryptoBaseUnit: '82535000000000000',
       deps: thorchainSwapperDeps,
       slippageTolerance: DEFAULT_SLIPPAGE,
@@ -55,7 +56,7 @@ describe('getLimit', () => {
     expect(limit).toBe('592056')
   })
 
-  it('should get limit when buy asset is EVM non-fee asset and sell asset is a UTXO', async () => {
+  it('should get limit when sell asset is EVM non-fee asset and buy asset is a UTXO', async () => {
     ;(getUsdRate as jest.Mock<unknown>)
       .mockReturnValueOnce(Promise.resolve('1595')) // sellFeeAssetUsdRate (ETH)
       .mockReturnValueOnce(Promise.resolve('20683')) // buyAssetUsdRate (BTC)
@@ -66,6 +67,7 @@ describe('getLimit', () => {
     const getLimitArgs: GetLimitArgs = {
       sellAsset: FOX,
       buyAssetId: BTC.assetId,
+      receiveAddress: '1A1zP1eP5QGefi2DMPTfTL5SLmv7DivfNa',
       sellAmountCryptoBaseUnit: '489830019000000000000',
       deps: thorchainSwapperDeps,
       slippageTolerance: DEFAULT_SLIPPAGE,
@@ -86,6 +88,7 @@ describe('getLimit', () => {
     const getLimitArgs: GetLimitArgs = {
       sellAsset: FOX,
       buyAssetId: RUNE.assetId,
+      receiveAddress: 'thor1234j5yq9qg7xqf0yq9qg7xqf0yq9qg7xqf0yq9q',
       sellAmountCryptoBaseUnit: '984229076000000000000',
       deps: thorchainSwapperDeps,
       slippageTolerance: DEFAULT_SLIPPAGE,
@@ -108,6 +111,7 @@ describe('getLimit', () => {
     const getLimitArgs: GetLimitArgs = {
       sellAsset: RUNE,
       buyAssetId: FOX.assetId,
+      receiveAddress: '0xFooBar',
       sellAmountCryptoBaseUnit: '988381400',
       deps: thorchainSwapperDeps,
       slippageTolerance: DEFAULT_SLIPPAGE,

--- a/packages/swapper/src/swappers/thorchain/utils/getLimit/getLimit.ts
+++ b/packages/swapper/src/swappers/thorchain/utils/getLimit/getLimit.ts
@@ -14,6 +14,7 @@ import { getUsdRate } from '../getUsdRate/getUsdRate'
 import { isRune } from '../isRune/isRune'
 
 export type GetLimitArgs = {
+  receiveAddress: string
   buyAssetId: string
   sellAsset: Asset
   sellAmountCryptoBaseUnit: string
@@ -25,12 +26,19 @@ export type GetLimitArgs = {
 export const getLimit = async ({
   sellAsset,
   buyAssetId,
+  receiveAddress,
   sellAmountCryptoBaseUnit,
   deps,
   slippageTolerance,
   buyAssetTradeFeeUsd,
 }: GetLimitArgs): Promise<string> => {
-  const tradeRate = await getTradeRate(sellAsset, buyAssetId, sellAmountCryptoBaseUnit, deps)
+  const tradeRate = await getTradeRate({
+    sellAsset,
+    buyAssetId,
+    sellAmountCryptoBaseUnit,
+    receiveAddress,
+    deps,
+  })
   const sellAssetChainFeeAssetId = deps.adapterManager.get(sellAsset.chainId)?.getFeeAssetId()
   const buyAssetChainFeeAssetId = deps.adapterManager
     .get(fromAssetId(buyAssetId).chainId)

--- a/packages/swapper/src/swappers/thorchain/utils/getTradeRate/getTradeRate.test.ts
+++ b/packages/swapper/src/swappers/thorchain/utils/getTradeRate/getTradeRate.test.ts
@@ -3,7 +3,6 @@ import type Web3 from 'web3'
 
 import { BTC, ETH, FOX, UNSUPPORTED } from '../../../utils/test-data/assets'
 import type { ThorchainSwapperDeps } from '../../types'
-import { btcThornodePool, ethThornodePool, foxThornodePool } from '../test-data/responses'
 import { thorService } from '../thorService'
 import { getTradeRate } from './getTradeRate'
 jest.mock('../thorService')
@@ -16,57 +15,168 @@ describe('getTradeRate', () => {
     web3: {} as Web3,
   }
 
-  it('should calculate a correct rate for trading fox to eth', async () => {
+  it('should calculate a correct rate for trading ETH to FOX', async () => {
     ;(thorService.get as jest.Mock<unknown>).mockReturnValue(
-      Promise.resolve({ data: [foxThornodePool, ethThornodePool] }),
+      Promise.resolve({
+        data: {
+          expected_amount_out: '1575048772',
+          expiry: 1681129306,
+          fees: {
+            affiliate: '0',
+            asset: 'ETH.ETH',
+            outbound: '720000',
+          },
+          inbound_address: '0xInboundAddress',
+          memo: '=:ETH.ETH:0x5daF465a9cCf64DEB146eEaE9E7Bd40d6761c986',
+          notes:
+            'Base Asset: Send the inbound_address the asset with the memo encoded in hex in the data field. Tokens: First approve router to spend tokens from user: asset.approve(router, amount). Then call router.depositWithExpiry(inbound_address, asset, amount, memo, expiry). Asset is the token contract address. Amount should be in native asset decimals (eg 1e18 for most tokens). Do not send to or from contract addresses.',
+          outbound_delay_blocks: 183,
+          outbound_delay_seconds: 2196,
+          router: '0xD37BbE5744D730a1d98d8DC97c42F0Ca46aD7146',
+          slippage_bps: 879,
+          warning: 'Do not cache this response. Do not send funds after the expiry.',
+        },
+      }),
     )
 
-    // 1 eth
-    const rate = await getTradeRate(ETH, FOX.assetId, '1000000000000000000', deps)
-    const expectedRate = '12554.215976'
+    const receiveAddress = '0xFooBar'
+
+    const rate = await getTradeRate({
+      sellAsset: ETH,
+      buyAssetId: FOX.assetId,
+      sellAmountCryptoBaseUnit: '1000000000000000000000000',
+      receiveAddress,
+      deps,
+    })
+    const expectedRate = '0.00001727627203157549'
     expect(rate).toEqual(expectedRate)
   })
 
-  it('should calculate a correct rate for trading eth to fox', async () => {
+  it('should calculate a correct rate for trading FOX to ETH', async () => {
     ;(thorService.get as jest.Mock<unknown>).mockReturnValue(
-      Promise.resolve({ data: [foxThornodePool, ethThornodePool] }),
+      Promise.resolve({
+        data: {
+          expected_amount_out: '1168571',
+          expiry: 1681132574,
+          fees: {
+            affiliate: '0',
+            asset: 'ETH.ETH',
+            outbound: '720000',
+          },
+          inbound_address: '0x3a4ed81942f6267b409a553767f95af94b790902',
+          notes:
+            'Base Asset: Send the inbound_address the asset with the memo encoded in hex in the data field. Tokens: First approve router to spend tokens from user: asset.approve(router, amount). Then call router.depositWithExpiry(inbound_address, asset, amount, memo, expiry). Asset is the token contract address. Amount should be in native asset decimals (eg 1e18 for most tokens). Do not send to or from contract addresses.',
+          outbound_delay_blocks: 0,
+          outbound_delay_seconds: 0,
+          router: '0xD37BbE5744D730a1d98d8DC97c42F0Ca46aD7146',
+          slippage_bps: 1,
+          warning: 'Do not cache this response. Do not send funds after the expiry.',
+        },
+      }),
     )
 
-    // 1 fox
-    const rate = await getTradeRate(FOX, ETH.assetId, '1000000000000000000', deps)
-    const expectedRate = '0.000078'
+    const receiveAddress = '0xFooBar'
+
+    const rate = await getTradeRate({
+      sellAsset: FOX,
+      buyAssetId: ETH.assetId,
+      sellAmountCryptoBaseUnit: '100000000000',
+      receiveAddress,
+      deps,
+    })
+    const expectedRate = '188875.98759875987598759876'
     expect(rate).toEqual(expectedRate)
   })
 
-  it('should calculate a correct rate for trading fox to btc', async () => {
+  it('should calculate a correct rate for trading FOX to BTC', async () => {
     ;(thorService.get as jest.Mock<unknown>).mockReturnValue(
-      Promise.resolve({ data: [foxThornodePool, btcThornodePool] }),
+      Promise.resolve({
+        data: {
+          expected_amount_out: '75710',
+          expiry: 1681132683,
+          fees: {
+            affiliate: '0',
+            asset: 'BTC.BTC',
+            outbound: '48000',
+          },
+          inbound_address: '0x3a4ed81942f6267b409a553767f95af94b790902',
+          notes:
+            'Base Asset: Send the inbound_address the asset with the memo encoded in hex in the data field. Tokens: First approve router to spend tokens from user: asset.approve(router, amount). Then call router.depositWithExpiry(inbound_address, asset, amount, memo, expiry). Asset is the token contract address. Amount should be in native asset decimals (eg 1e18 for most tokens). Do not send to or from contract addresses.',
+          outbound_delay_blocks: 0,
+          outbound_delay_seconds: 0,
+          router: '0xD37BbE5744D730a1d98d8DC97c42F0Ca46aD7146',
+          slippage_bps: 1,
+          warning: 'Do not cache this response. Do not send funds after the expiry.',
+        },
+      }),
     )
 
-    // 1 fox
-    const rate = await getTradeRate(FOX, BTC.assetId, '1000000000000000000', deps)
-    const expectedRate = '0.000005'
+    const receiveAddress = '1A1zP1eP5QGefi2DMPTfTL5SLmv7DivfNa'
+
+    const rate = await getTradeRate({
+      sellAsset: FOX,
+      buyAssetId: BTC.assetId,
+      sellAmountCryptoBaseUnit: '100000000000',
+      receiveAddress,
+      deps,
+    })
+    const expectedRate = '12372.23722372237223722372'
     expect(rate).toEqual(expectedRate)
   })
 
-  it('should calculate a correct rate for trading btc to fox', async () => {
+  it('should calculate a correct rate for trading BTC to FOX', async () => {
     ;(thorService.get as jest.Mock<unknown>).mockReturnValue(
-      Promise.resolve({ data: [foxThornodePool, btcThornodePool] }),
+      Promise.resolve({
+        data: {
+          dust_threshold: '10000',
+          expected_amount_out: '261454522054192',
+          expiry: 1681132269,
+          fees: {
+            affiliate: '0',
+            asset: 'ETH.FOX-0XC770EEFAD204B5180DF6A14EE197D99D808EE52D',
+            outbound: '16554235812',
+          },
+          inbound_address: 'bc1qucjrczghvwl5d66klz6npv7tshkpwpzlw0zzj8',
+          inbound_confirmation_blocks: 2,
+          inbound_confirmation_seconds: 1200,
+          notes:
+            'First output should be to inbound_address, second output should be change back to self, third output should be OP_RETURN, limited to 80 bytes. Do not send below the dust threshold. Do not use exotic spend scripts, locks or address formats (P2WSH with Bech32 address format preferred).',
+          outbound_delay_blocks: 575,
+          outbound_delay_seconds: 6900,
+          slippage_bps: 4357,
+          warning: 'Do not cache this response. Do not send funds after the expiry.',
+        },
+      }),
     )
 
-    // 0.01 btc
-    const rate = await getTradeRate(BTC, FOX.assetId, '1000000', deps)
-    const expectedRate = '193385.0366'
+    const receiveAddress = '0xFooBar'
+
+    const rate = await getTradeRate({
+      sellAsset: BTC,
+      buyAssetId: FOX.assetId,
+      sellAmountCryptoBaseUnit: '1000000000',
+      receiveAddress,
+      deps,
+    })
+    const expectedRate = '463354.73381180932128300549'
     expect(rate).toEqual(expectedRate)
   })
 
   it('should throw if trying to calculate a rate for an unsupported asset', async () => {
     ;(thorService.get as jest.Mock<unknown>).mockReturnValue(
-      Promise.resolve({ data: [foxThornodePool, ethThornodePool] }),
+      Promise.resolve({ data: { error: 'Unsupported asset' } }),
     )
 
+    const receiveAddress = '0xFooBar'
+
     await expect(
-      getTradeRate(UNSUPPORTED, ETH.assetId, '1000000000000000000', deps),
+      getTradeRate({
+        sellAsset: UNSUPPORTED,
+        buyAssetId: ETH.assetId,
+        sellAmountCryptoBaseUnit: '1000000000000000000',
+        receiveAddress,
+        deps,
+      }),
     ).rejects.toThrow(`[getTradeRate]: No sellPoolId for asset ${UNSUPPORTED.assetId}`)
   })
 })

--- a/packages/swapper/src/swappers/thorchain/utils/getTradeRate/getTradeRate.ts
+++ b/packages/swapper/src/swappers/thorchain/utils/getTradeRate/getTradeRate.ts
@@ -36,7 +36,6 @@ export const getTradeRate = async ({
   receiveAddress: string
   deps: ThorchainSwapperDeps
 }): Promise<string> => {
-  // TODO(gomes): is this still valid?
   // we can't get a quote for a zero amount so use getPriceRatio between pools instead
   if (bnOrZero(sellAmountCryptoBaseUnit).eq(0)) {
     return getPriceRatio(deps, {

--- a/packages/swapper/src/swappers/thorchain/utils/getTradeRate/getTradeRate.ts
+++ b/packages/swapper/src/swappers/thorchain/utils/getTradeRate/getTradeRate.ts
@@ -74,6 +74,15 @@ export const getTradeRate = async ({
     `${deps.daemonUrl}/lcd/thorchain/quote/swap?amount=${sellAmountCryptoThorBaseUnit}&from_asset=${sellPoolId}&to_asset=${buyPoolId}&destination=${receiveAddress}`,
   )
 
+  // There was an error getting a quote from the thorchain api. This could be because e.g the amount being swapped is too small
+  // Fallback to returning a rate based on pools data
+  if ('error' in data) {
+    return getPriceRatio(deps, {
+      sellAssetId: sellAsset.assetId,
+      buyAssetId,
+    })
+  }
+
   const { slippage_bps, fees, expected_amount_out: expectedAmountOutThorBaseUnit } = data
 
   // Add back the outbound fees

--- a/packages/swapper/src/swappers/thorchain/utxo/utils/getThorTxData.ts
+++ b/packages/swapper/src/swappers/thorchain/utxo/utils/getThorTxData.ts
@@ -54,6 +54,7 @@ export const getThorTxInfo: GetThorTxInfo = async ({
       slippageTolerance,
       deps,
       buyAssetTradeFeeUsd,
+      receiveAddress: destinationAddress,
     })
 
     const memo = makeSwapMemo({


### PR DESCRIPTION
## Description

This PR makes sure Thorchain's `getTradeRate` gives us the original trade rate (from the THOR quote), i.e the rate including fees and slippage, so we can deduct these later on.

We are currently getting a rate which is already fee-deducted, which results in us getting too low before/after fees amounts in https://github.com/shapeshift/web/pull/4217.

Since this consumes the THOR swap quote, this puts us in a very close place to reflect *akschual* swap quote amounts from THOR.

Coincidentally fixes a bunch of stuff that was just wrong in tests, fixes the signature of `getTradeQuote` naming `sellAmountCryptoBaseUnit` when it was actually a base unit, and LSP destructures to object args instead of arity insanity.

## Notice

<!-- Before submitting a pull request, please make sure you have answered the following: -->

- [x] Have you followed the guidelines in our [Contributing]('https://github.com/shapeshift/web/blob/develop/CONTRIBUTING.md) guide?
- [x] Have you checked to ensure there aren't other open [Pull Requests](https://github.com/shapeshift/web/pulls) for the same update/change?

## Pull Request Type

- [x] :bug: Bug fix (Non-breaking Change: Fixes an issue)
- [ ] :hammer_and_wrench: Chore (Non-breaking Change: Doc updates, pkg upgrades, typos, etc..)
- [ ] :nail_care: New Feature (Breaking/Non-breaking Change)

## Issue (if applicable)

N/A

## Risk

<!-----------------------------------------------------------------------------
Outline the scope of your changes and the risk associated with them. You must use your discretion as an engineer to determine the potential impact of your changes.

E.g. an upgrade to `hdwallet` or core state management would be considered higher risk, and might require a full regression test. UI or isolated view changes, or something behind a feature flag may have near zero risk. Small bug fixes might require testing isolated to the specific fix.
------------------------------------------------------------------------------>

Fixed in 41043621a3996beb91113bad2a1b86738194ef8f
~~Now that we consume the swap endpoint, this will break minimums. To be fixed as a follow-up~~


## Testing

<!-----------------------------------------------------------------------------
We treat every PR to be merged with the same scrutiny as if we were merging directly to production.

Your PR will not be merged if you do not complete the sections below for our engineering and operations teams to test.
------------------------------------------------------------------------------>

- Test against big amounts e.g https://thornode.ninerealms.com/thorchain/quote/swap?amount=8920000000000&from_asset=ETH.DAI-0X6B175474E89094C44DA98B954EEDEAC495271D0F&to_asset=BTC.BTC 89,200 DAI -> BTC
- Only Thorchain swapper is affected by these changes. Test both smaller and larger amounts, as well as different precision assets (e.g 6 dp USDC/DAI, 8 dp UTXOs and 18 dp ETH / most ERC-20s)
- The amounts should now be actually correct vs. the Thorchain quote endpoint, since we're consuming it to build the rate
  - Refer to the screenshots
  - If you're testing this in isolation, this is still expected to be wrong vs. the Thor quote, but puts us in a better place. What we show as Before/after fees/ "You Get" amounts are still going to be wrong, but what we show as "Min. expected after slippage should now be pretty much equal to the `expected_amount_out` + amount deducted by the slippage + fees e.g in the screenshot above
  - If you're testing as part of https://github.com/shapeshift/web/pull/4217, the amounts (both "You get" and "Min. after fees and slippage") will now be correct and matching the network ones

### Engineering

<!-----------------------------------------------------------------------------
Include sufficient information here for an engineer to test your PR. This may include how to test locally, in a built environment, changes to infrastructure etc.
------------------------------------------------------------------------------>

### Operations

<!-----------------------------------------------------------------------------
If your changes have a user-facing impact, describe how a non-technical QA team can functionally test your changes in a preview environment.

If they are not user-facing please describe how to test for any regressions that may occur.
------------------------------------------------------------------------------>

## Screenshots (if applicable)

Develop:

<img width="622" alt="image" src="https://user-images.githubusercontent.com/17035424/230952768-ecfa56ee-eb8f-464a-b23a-da76b3022f49.png">

Now that we went monorails, there's two different versions of this you will see depending on when you test it

- When testing on https://github.com/shapeshift/web/pull/4217 / after it has been merged

<img width="627" alt="image" src="https://user-images.githubusercontent.com/17035424/230909497-258dc264-9793-4a64-8c12-088d03f85a6b.png">

- When testing in isolation

<img width="631" alt="image" src="https://user-images.githubusercontent.com/17035424/230952178-7978e2dd-65ca-4add-9012-21d8f497c86a.png">

- Minimums

<img width="652" alt="image" src="https://user-images.githubusercontent.com/17035424/231112549-f90cef77-9849-41f1-b0b5-2c2dac8e10fd.png">
<img width="646" alt="image" src="https://user-images.githubusercontent.com/17035424/231112776-e31858ea-5bcc-4cd0-924e-4bc19bfad33c.png">

<img width="647" alt="image" src="https://user-images.githubusercontent.com/17035424/231112838-aeaaf8e0-57b7-4dcd-bbaa-d1869fbda2e1.png">
<img width="624" alt="image" src="https://user-images.githubusercontent.com/17035424/231112932-7dc369b1-c267-4e54-88eb-24b4dd653a7d.png">