### PR TITLE
fix: race condition with available swappers

### DIFF
--- a/src/state/apis/swapper/selectors.ts
+++ b/src/state/apis/swapper/selectors.ts
@@ -21,3 +21,23 @@ export const selectSwapperApiTradingActivePending = (state: ReduxState) =>
 
 export const selectSwapperQueriesInitiated = (state: ReduxState) =>
   Object.keys(state.swapperApi.queries).length
+
+export const selectAvailableSwapperApiMostRecentQueryTimestamp = (state: ReduxState) => {
+  const queries = Object.values(state.swapperApi.queries).filter(
+    query => query?.endpointName === 'getAvailableSwappers',
+  )
+
+  if (queries.length === 0) {
+    return null
+  }
+
+  return queries.reduce((maxTimestamp: number | null, query) => {
+    if (query && query.startedTimeStamp) {
+      return maxTimestamp === null
+        ? query.startedTimeStamp
+        : Math.max(maxTimestamp, query.startedTimeStamp)
+    }
+
+    return maxTimestamp
+  }, null)
+}


### PR DESCRIPTION
## Description

We are getting rugged in one edge case where when we are loading avaliable swappers for an asset pair that supports CoW Swap, 0x, and THORSwap swappers, and then quickly switch to an asset pair that only supports THORSwap.

If the former response returns _after_ the latter, the avaliable swappers + quotes get overwritten.

This PR adds a check to ensure we only update the swappers and quotes _only_ if the response is from the most recent request.

## Notice

- [x] Have you followed the guidelines in our [Contributing]('https://github.com/shapeshift/web/blob/develop/CONTRIBUTING.md) guide?
- [x] Have you checked to ensure there aren't other open [Pull Requests](https://github.com/shapeshift/web/pulls) for the same update/change?

## Pull Request Type

- [x] :bug: Bug fix (Non-breaking Change: Fixes an issue)
- [ ] :hammer_and_wrench: Chore (Non-breaking Change: Doc updates, pkg upgrades, typos, etc..)
- [ ] :nail_care: New Feature (Breaking/Non-breaking Change)

## Issue (if applicable)

N/A

## Risk

Small - if we are still showing quotes every time we should, this is probably working as expected. 

## Testing

Refresh the app whilst on the trade page, and then immediately switch assets for you are trading FOX to ETH, then swap the FOX asset for BTC.

At present we are ending up in a race condition here where we'll show 3 swappers available (where there should only be 1, THORSwapper).

REACT_APP_FEATURE_TRADE_RATES must be set to true to test this.

### Engineering

☝️

### Operations

☝️

## Screenshots (if applicable)
