### PR TITLE
fix: index opportunities against correct chains

### DIFF
--- a/src/lib/utils.test.ts
+++ b/src/lib/utils.test.ts
@@ -1,4 +1,22 @@
+import type { ChainId } from '@shapeshiftoss/caip'
+import {
+  cosmosAssetId,
+  cosmosChainId,
+  ethChainId,
+  foxAssetId,
+  foxyAssetId,
+  osmosisAssetId,
+  osmosisChainId,
+} from '@shapeshiftoss/caip'
+
 import { fauxmesAccountId } from '../state/slices/opportunitiesSlice/mocks'
+import type {
+  LpId,
+  OpportunityId,
+  StakingId,
+  ValidatorId,
+} from '../state/slices/opportunitiesSlice/types'
+import { opportunityIdToChainId } from '../state/slices/opportunitiesSlice/utils'
 import {
   deepUpsertArray,
   hashCode,
@@ -9,6 +27,38 @@ import {
 } from './utils'
 
 describe('lib/utils', () => {
+  describe('opportunityIdToChainId', () => {
+    test('returns the correct chain ID for an LpId', () => {
+      const lpId: LpId = foxAssetId
+      const result: ChainId = opportunityIdToChainId(lpId)
+      expect(result).toEqual(ethChainId)
+    })
+
+    test('returns the correct chain ID for a StakingId', () => {
+      const stakingId: StakingId = foxyAssetId
+      const result: ChainId = opportunityIdToChainId(stakingId)
+      expect(result).toEqual(ethChainId)
+    })
+
+    test('returns the correct chain ID for a ValidatorId', () => {
+      const validatorId: ValidatorId = fauxmesAccountId
+      const result: ChainId = opportunityIdToChainId(validatorId)
+      expect(result).toEqual(ethChainId)
+    })
+
+    test('returns the correct chain ID for a Cosmos asset ID', () => {
+      const cosmosOpportunityId: OpportunityId = cosmosAssetId
+      const result: ChainId = opportunityIdToChainId(cosmosOpportunityId)
+      expect(result).toEqual(cosmosChainId)
+    })
+
+    test('returns the correct chain ID for an Osmosis asset ID', () => {
+      const osmosisOpportunityId: OpportunityId = osmosisAssetId
+      const result: ChainId = opportunityIdToChainId(osmosisOpportunityId)
+      expect(result).toEqual(osmosisChainId)
+    })
+  })
+
   describe('deepUpsertArray', () => {
     const l1Key = 'l1Key'
     const l2Key = 'l2Key'

--- a/src/state/slices/opportunitiesSlice/utils.ts
+++ b/src/state/slices/opportunitiesSlice/utils.ts
@@ -1,6 +1,6 @@
 import type { Asset } from '@shapeshiftoss/asset-service'
-import type { AccountId, AssetId } from '@shapeshiftoss/caip'
-import { toAccountId, toAssetId } from '@shapeshiftoss/caip'
+import type { AccountId, AssetId, ChainId } from '@shapeshiftoss/caip'
+import { fromAccountId, fromAssetId, toAccountId, toAssetId } from '@shapeshiftoss/caip'
 import { bnOrZero } from '@shapeshiftoss/investor-foxy'
 import type { MarketData } from '@shapeshiftoss/types'
 import { DefiProvider } from 'features/defi/contexts/DefiManagerProvider/DefiCommon'
@@ -54,6 +54,19 @@ export const filterUserStakingIdByStakingIdCompareFn = (
 // That may be a L1 AssetId (THOR savers), or a smart contract account, which for all intent and purposes is an ERC20 i.e an asset
 export const toOpportunityId = (...[args]: Parameters<typeof toAssetId>) =>
   toAssetId(args) as OpportunityId
+
+export const opportunityIdToChainId = (opportunityId: OpportunityId): ChainId => {
+  // an OpportunityId can be an AssetId or AccountId, try fromAssetId first, and if it throws
+  // it's an AccountId
+  try {
+    const { chainId } = fromAssetId(opportunityId)
+    return chainId
+  } catch (e) {
+    // we're pretty confident it's an AccountId now
+    const { chainId } = fromAccountId(opportunityId)
+    return chainId
+  }
+}
 
 type GetUnderlyingAssetIdsBalancesArgs = {
   assetId: AssetId


### PR DESCRIPTION
## Description

<!-- Please describe your changes -->

* fix - don't upsert opportunities against wrong account ids in `getOpportunityUserData`, i.e. don't upsert eth mainnet LP opportunities against cosmossdk/utxo accounts
* fix - add additional guards such that we can't do this in other places
* adds `opportunityIdToChainId` function which converts an `OpportunityId` to a `ChainId` w/ test coverage

## Notice

<!-- Before submitting a pull request, please make sure you have answered the following: -->

- [x] Have you followed the guidelines in our [Contributing]('https://github.com/shapeshift/web/blob/develop/CONTRIBUTING.md) guide?
- [x] Have you checked to ensure there aren't other open [Pull Requests](https://github.com/shapeshift/web/pulls) for the same update/change?

## Pull Request Type

- [x] :bug: Bug fix (Non-breaking Change: Fixes an issue)
- [ ] :hammer_and_wrench: Chore (Non-breaking Change: Doc updates, pkg upgrades, typos, etc..)
- [ ] :nail_care: New Feature (Breaking/Non-breaking Change)

## Issue (if applicable)

<!-----------------------------------------------------------------------------
If applicable, please link to the github issue and put `closes #XXXX` in your comment to auto-close the issue that your PR fixes.
------------------------------------------------------------------------------>

n/a - noticed by @reallybeard

## Risk

related to defi section

<!-----------------------------------------------------------------------------
Outline the scope of your changes and the risk associated with them. You must use your discretion as an engineer to determine the potential impact of your changes.

E.g. an upgrade to `hdwallet` or core state management would be considered higher risk, and might require a full regression test. UI or isolated view changes, or something behind a feature flag may have near zero risk. Small bug fixes might require testing isolated to the specific fix.
------------------------------------------------------------------------------>

## Testing

* ensure eligible opportunities still appear
* ensure all active opportunities are still appearing correctly (no need to do txs)

<!-----------------------------------------------------------------------------
We treat every PR to be merged with the same scrutiny as if we were merging directly to production.

Your PR will not be merged if you do not complete the sections below for our engineering and operations teams to test.
------------------------------------------------------------------------------>

### Engineering

<!-----------------------------------------------------------------------------
Include sufficient information here for an engineer to test your PR. This may include how to test locally, in a built environment, changes to infrastructure etc.
------------------------------------------------------------------------------>

### Operations

<!-----------------------------------------------------------------------------
If your changes have a user-facing impact, describe how a non-technical QA team can functionally test your changes in a preview environment.

If they are not user-facing please describe how to test for any regressions that may occur.
------------------------------------------------------------------------------>

## Screenshots (if applicable)

engineering only

before

<img width="1038" alt="Screenshot 2023-04-11 at 2 24 21 PM" src="https://user-images.githubusercontent.com/88504456/231280034-2c5f172f-48d1-4360-9b3d-070c2d6cf4a3.png">

after

<img width="908" alt="image" src="https://user-images.githubusercontent.com/88504456/231279862-3940e360-f6eb-4815-a0d4-20109ebada2d.png">

