### PR TITLE
refactor: re-name min max to show units

### DIFF
--- a/packages/swapper/src/api.ts
+++ b/packages/swapper/src/api.ts
@@ -180,8 +180,8 @@ export type SwapSource = {
 }
 
 export interface MinMaxOutput {
-  minimum: string
-  maximum: string
+  minimumAmountCryptoHuman: string
+  maximumAmountCryptoHuman: string
 }
 
 export type ApprovalNeededOutput = {

--- a/packages/swapper/src/api.ts
+++ b/packages/swapper/src/api.ts
@@ -137,7 +137,7 @@ interface TradeBase<C extends ChainId> {
 export interface TradeQuote<C extends ChainId> extends TradeBase<C> {
   allowanceContract: string
   minimumCryptoHuman: string
-  maximum: string
+  maximumCryptoHuman: string
   recommendedSlippage?: string
 
   /** @deprecated Use minimumCryptoHuman instead */

--- a/packages/swapper/src/manager/testData.ts
+++ b/packages/swapper/src/manager/testData.ts
@@ -72,7 +72,7 @@ export const getThorchainSwapper = () => new ThorchainSwapper(thorchainSwapperDe
 
 export const tradeQuote: TradeQuote<KnownChainIds.EthereumMainnet> = {
   minimumCryptoHuman: '60',
-  maximum: '1000000000000000000000',
+  maximumCryptoHuman: '1000000000000000000000',
   sellAmountBeforeFeesCryptoBaseUnit: '1000000000000000000000', // 1000 FOX
   allowanceContract: '0x3624525075b88B24ecc29CE226b0CEc1fFcB6976',
   buyAmountCryptoBaseUnit: '23448326921811747', // 0.023 ETH

--- a/packages/swapper/src/swappers/cow/getCowSwapMinMax/getCowSwapMinMax.test.ts
+++ b/packages/swapper/src/swappers/cow/getCowSwapMinMax/getCowSwapMinMax.test.ts
@@ -19,14 +19,14 @@ const DEPS = {
 describe('getCowSwapMinMax', () => {
   it('returns minimum and maximum', async () => {
     const minMax = await getCowSwapMinMax(DEPS, FOX, WETH)
-    expect(minMax.minimum).toBe('80')
-    expect(minMax.maximum).toBe(MAX_COWSWAP_TRADE)
+    expect(minMax.minimumAmountCryptoHuman).toBe('80')
+    expect(minMax.maximumAmountCryptoHuman).toBe(MAX_COWSWAP_TRADE)
   })
 
   it('returns minimum and maximum for ETH as buy asset', async () => {
     const minMax = await getCowSwapMinMax(DEPS, FOX, ETH)
-    expect(minMax.minimum).toBe('80')
-    expect(minMax.maximum).toBe(MAX_COWSWAP_TRADE)
+    expect(minMax.minimumAmountCryptoHuman).toBe('80')
+    expect(minMax.maximumAmountCryptoHuman).toBe(MAX_COWSWAP_TRADE)
   })
 
   it('fails on non erc 20 sell assets and non ETH-mainnet buy assets', async () => {

--- a/packages/swapper/src/swappers/cow/getCowSwapMinMax/getCowSwapMinMax.test.ts
+++ b/packages/swapper/src/swappers/cow/getCowSwapMinMax/getCowSwapMinMax.test.ts
@@ -17,13 +17,13 @@ const DEPS = {
 }
 
 describe('getCowSwapMinMax', () => {
-  it('returns minimum and maximum', async () => {
+  it('returns minimumAmountCryptoHuman and maximumAmountCryptoHuman', async () => {
     const minMax = await getCowSwapMinMax(DEPS, FOX, WETH)
     expect(minMax.minimumAmountCryptoHuman).toBe('80')
     expect(minMax.maximumAmountCryptoHuman).toBe(MAX_COWSWAP_TRADE)
   })
 
-  it('returns minimum and maximum for ETH as buy asset', async () => {
+  it('returns minimumAmountCryptoHuman and maximumAmountCryptoHuman for ETH as buy asset', async () => {
     const minMax = await getCowSwapMinMax(DEPS, FOX, ETH)
     expect(minMax.minimumAmountCryptoHuman).toBe('80')
     expect(minMax.maximumAmountCryptoHuman).toBe(MAX_COWSWAP_TRADE)

--- a/packages/swapper/src/swappers/cow/getCowSwapMinMax/getCowSwapMinMax.ts
+++ b/packages/swapper/src/swappers/cow/getCowSwapMinMax/getCowSwapMinMax.ts
@@ -24,11 +24,13 @@ export const getCowSwapMinMax = async (
 
     const usdRate = await getUsdRate(deps, sellAsset)
 
-    const minimum = bn(MIN_COWSWAP_VALUE_USD).dividedBy(bnOrZero(usdRate)).toString() // $10 worth of the sell token.
-    const maximum = MAX_COWSWAP_TRADE // Arbitrarily large value. 10e+28 here.
+    const minimumAmountCryptoHuman = bn(MIN_COWSWAP_VALUE_USD)
+      .dividedBy(bnOrZero(usdRate))
+      .toString() // $10 worth of the sell token.
+    const maximumAmountCryptoHuman = MAX_COWSWAP_TRADE // Arbitrarily large value. 10e+28 here.
     return {
-      minimumAmountCryptoHuman: minimum,
-      maximumAmountCryptoHuman: maximum,
+      minimumAmountCryptoHuman,
+      maximumAmountCryptoHuman,
     }
   } catch (e) {
     if (e instanceof SwapError) throw e

--- a/packages/swapper/src/swappers/cow/getCowSwapMinMax/getCowSwapMinMax.ts
+++ b/packages/swapper/src/swappers/cow/getCowSwapMinMax/getCowSwapMinMax.ts
@@ -27,8 +27,8 @@ export const getCowSwapMinMax = async (
     const minimum = bn(MIN_COWSWAP_VALUE_USD).dividedBy(bnOrZero(usdRate)).toString() // $10 worth of the sell token.
     const maximum = MAX_COWSWAP_TRADE // Arbitrarily large value. 10e+28 here.
     return {
-      minimum,
-      maximum,
+      minimumAmountCryptoHuman: minimum,
+      maximumAmountCryptoHuman: maximum,
     }
   } catch (e) {
     if (e instanceof SwapError) throw e

--- a/packages/swapper/src/swappers/cow/getCowSwapTradeQuote/getCowSwapTradeQuote.test.ts
+++ b/packages/swapper/src/swappers/cow/getCowSwapTradeQuote/getCowSwapTradeQuote.test.ts
@@ -42,10 +42,16 @@ jest.mock('../getCowSwapMinMax/getCowSwapMinMax', () => {
   return {
     getCowSwapMinMax: (_args: CowSwapperDeps, sellAsset: Asset) => {
       if (sellAsset.assetId === FOX.assetId) {
-        return { minimum: '229.09507445589919816724', maximum: '100000000000000000000000000' }
+        return {
+          minimumAmountCryptoHuman: '229.09507445589919816724',
+          maximumAmountCryptoHuman: '100000000000000000000000000',
+        }
       }
 
-      return { minimum: '0.011624', maximum: '100000000000000000000000000' }
+      return {
+        minimumAmountCryptoHuman: '0.011624',
+        maximumAmountCryptoHuman: '100000000000000000000000000',
+      }
     },
   }
 })
@@ -119,7 +125,7 @@ const expectedApiInputFoxToEth: CowSwapSellQuoteApiInput = {
 const expectedTradeQuoteWethToFox: TradeQuote<KnownChainIds.EthereumMainnet> = {
   rate: '14716.04718939437505555958', // 14716 FOX per WETH
   minimumCryptoHuman: '0.011624',
-  maximum: '100000000000000000000000000',
+  maximumCryptoHuman: '100000000000000000000000000',
   feeData: {
     chainSpecific: {
       estimatedGas: '100000',
@@ -142,7 +148,7 @@ const expectedTradeQuoteWethToFox: TradeQuote<KnownChainIds.EthereumMainnet> = {
 const expectedTradeQuoteFoxToEth: TradeQuote<KnownChainIds.EthereumMainnet> = {
   rate: '0.00004995640398295996',
   minimumCryptoHuman: '229.09507445589919816724',
-  maximum: '100000000000000000000000000',
+  maximumCryptoHuman: '100000000000000000000000000',
   feeData: {
     chainSpecific: {
       estimatedGas: '100000',
@@ -165,7 +171,7 @@ const expectedTradeQuoteFoxToEth: TradeQuote<KnownChainIds.EthereumMainnet> = {
 const expectedTradeQuoteSmallAmountWethToFox: TradeQuote<KnownChainIds.EthereumMainnet> = {
   rate: '14716.04718939437523468382', // 14716 FOX per WETH
   minimumCryptoHuman: '0.011624',
-  maximum: '100000000000000000000000000',
+  maximumCryptoHuman: '100000000000000000000000000',
   feeData: {
     chainSpecific: {
       estimatedGas: '100000',

--- a/packages/swapper/src/swappers/cow/getCowSwapTradeQuote/getCowSwapTradeQuote.ts
+++ b/packages/swapper/src/swappers/cow/getCowSwapTradeQuote/getCowSwapTradeQuote.ts
@@ -170,7 +170,7 @@ export async function getCowSwapTradeQuote(
     return {
       rate,
       minimumCryptoHuman: minimumAmountCryptoHuman,
-      maximum: maximumAmountCryptoHuman,
+      maximumCryptoHuman: maximumAmountCryptoHuman,
       feeData: {
         networkFeeCryptoBaseUnit: '0', // no miner fee for CowSwap
         chainSpecific: {

--- a/packages/swapper/src/swappers/cow/getCowSwapTradeQuote/getCowSwapTradeQuote.ts
+++ b/packages/swapper/src/swappers/cow/getCowSwapTradeQuote/getCowSwapTradeQuote.ts
@@ -61,9 +61,15 @@ export async function getCowSwapTradeQuote(
 
     const buyToken =
       buyAsset.assetId !== ethAssetId ? buyAssetErc20Address : COW_SWAP_ETH_MARKER_ADDRESS
-    const { minimum, maximum } = await getCowSwapMinMax(deps, sellAsset, buyAsset)
+    const { minimumAmountCryptoHuman, maximumAmountCryptoHuman } = await getCowSwapMinMax(
+      deps,
+      sellAsset,
+      buyAsset,
+    )
 
-    const minQuoteSellAmount = bnOrZero(minimum).times(bn(10).exponentiatedBy(sellAsset.precision))
+    const minQuoteSellAmount = bnOrZero(minimumAmountCryptoHuman).times(
+      bn(10).exponentiatedBy(sellAsset.precision),
+    )
     const isSellAmountBelowMinimum = bnOrZero(sellAmountBeforeFeesCryptoBaseUnit).lt(
       minQuoteSellAmount,
     )
@@ -163,8 +169,8 @@ export async function getCowSwapTradeQuote(
 
     return {
       rate,
-      minimumCryptoHuman: minimum,
-      maximum,
+      minimumCryptoHuman: minimumAmountCryptoHuman,
+      maximum: maximumAmountCryptoHuman,
       feeData: {
         networkFeeCryptoBaseUnit: '0', // no miner fee for CowSwap
         chainSpecific: {

--- a/packages/swapper/src/swappers/osmosis/OsmosisSwapper.ts
+++ b/packages/swapper/src/swappers/osmosis/OsmosisSwapper.ts
@@ -110,12 +110,12 @@ export class OsmosisSwapper implements Swapper<ChainId> {
   async getMinMax(input: { sellAsset: Asset }): Promise<MinMaxOutput> {
     const { sellAsset } = input
     const usdRate = await this.getUsdRate({ ...sellAsset })
-    const minimum = bn(1).dividedBy(bnOrZero(usdRate)).toString()
-    const maximum = MAX_SWAPPER_SELL
+    const minimumAmountCryptoHuman = bn(1).dividedBy(bnOrZero(usdRate)).toString()
+    const maximumAmountCryptoHuman = MAX_SWAPPER_SELL
 
     return {
-      minimumAmountCryptoHuman: minimum,
-      maximumAmountCryptoHuman: maximum,
+      minimumAmountCryptoHuman,
+      maximumAmountCryptoHuman,
     }
   }
 

--- a/packages/swapper/src/swappers/osmosis/OsmosisSwapper.ts
+++ b/packages/swapper/src/swappers/osmosis/OsmosisSwapper.ts
@@ -248,7 +248,7 @@ export class OsmosisSwapper implements Swapper<ChainId> {
         sellAssetTradeFeeUsd: '0',
         buyAssetTradeFeeUsd,
       },
-      maximum: maximumAmountCryptoHuman,
+      maximumCryptoHuman: maximumAmountCryptoHuman,
       minimumCryptoHuman: minimumAmountCryptoHuman, // TODO(gomes): shorthand?
       accountNumber,
       rate,

--- a/packages/swapper/src/swappers/osmosis/OsmosisSwapper.ts
+++ b/packages/swapper/src/swappers/osmosis/OsmosisSwapper.ts
@@ -114,8 +114,8 @@ export class OsmosisSwapper implements Swapper<ChainId> {
     const maximum = MAX_SWAPPER_SELL
 
     return {
-      minimum,
-      maximum,
+      minimumAmountCryptoHuman: minimum,
+      maximumAmountCryptoHuman: maximum,
     }
   }
 
@@ -227,7 +227,7 @@ export class OsmosisSwapper implements Swapper<ChainId> {
       this.deps.osmoUrl,
     )
 
-    const { minimum, maximum } = await this.getMinMax(input)
+    const { minimumAmountCryptoHuman, maximumAmountCryptoHuman } = await this.getMinMax(input)
 
     const osmosisAdapter = this.deps.adapterManager.get(osmosisChainId) as
       | osmosis.ChainAdapter
@@ -248,8 +248,8 @@ export class OsmosisSwapper implements Swapper<ChainId> {
         sellAssetTradeFeeUsd: '0',
         buyAssetTradeFeeUsd,
       },
-      maximum,
-      minimumCryptoHuman: minimum, // TODO(gomes): shorthand?
+      maximum: maximumAmountCryptoHuman,
+      minimumCryptoHuman: minimumAmountCryptoHuman, // TODO(gomes): shorthand?
       accountNumber,
       rate,
       sellAsset,

--- a/packages/swapper/src/swappers/thorchain/getThorTradeQuote/getTradeQuote.test.ts
+++ b/packages/swapper/src/swappers/thorchain/getThorTradeQuote/getTradeQuote.test.ts
@@ -19,7 +19,7 @@ const mockedAxios = jest.mocked(thorService)
 
 const expectedQuoteResponse: TradeQuote<KnownChainIds.EthereumMainnet> = {
   minimumCryptoHuman: '59.658672054814851787728',
-  maximum: '100000000000000000000000000',
+  maximumCryptoHuman: '100000000000000000000000000',
   sellAmountBeforeFeesCryptoBaseUnit: '10000000000000000000', // 10 FOX
   allowanceContract: '0x3624525075b88B24ecc29CE226b0CEc1fFcB6976',
   buyAmountCryptoBaseUnit: '4633547338118093212830055',

--- a/packages/swapper/src/swappers/thorchain/getThorTradeQuote/getTradeQuote.ts
+++ b/packages/swapper/src/swappers/thorchain/getThorTradeQuote/getTradeQuote.ts
@@ -123,7 +123,7 @@ export const getThorTradeQuote: GetThorTradeQuote = async ({ deps, input }) => {
 
     const commonQuoteFields: CommonQuoteFields = {
       rate,
-      maximum: MAX_THORCHAIN_TRADE,
+      maximumCryptoHuman: MAX_THORCHAIN_TRADE,
       sellAmountBeforeFeesCryptoBaseUnit: sellAmountCryptoBaseUnit,
       buyAmountCryptoBaseUnit,
       sources: [{ name: SwapperName.Thorchain, proportion: '1' }],

--- a/packages/swapper/src/swappers/utils/test-data/setupSwapQuote.ts
+++ b/packages/swapper/src/swappers/utils/test-data/setupSwapQuote.ts
@@ -16,7 +16,7 @@ export const setupQuote = () => {
     allowanceContract: 'allowanceContractAddress',
     accountNumber: 0,
     minimumCryptoHuman: '0',
-    maximum: '999999999999',
+    maximumCryptoHuman: '999999999999',
     feeData: {
       chainSpecific: {},
       sellAssetTradeFeeUsd: '0',

--- a/packages/swapper/src/swappers/zrx/getZrxMinMax/getZrxMinMax.test.ts
+++ b/packages/swapper/src/swappers/zrx/getZrxMinMax/getZrxMinMax.test.ts
@@ -11,7 +11,7 @@ jest.mock('../utils/helpers/helpers', () => ({
 }))
 
 describe('getZrxMinMax', () => {
-  it('returns minimum and maximum', async () => {
+  it('returns minimumAmountCryptoHuman and maximumAmountCryptoHuman', async () => {
     const minMax = await getZrxMinMax(FOX, WETH)
     expect(minMax.minimumAmountCryptoHuman).toBe('1')
     expect(minMax.maximumAmountCryptoHuman).toBe(MAX_ZRX_TRADE)

--- a/packages/swapper/src/swappers/zrx/getZrxMinMax/getZrxMinMax.test.ts
+++ b/packages/swapper/src/swappers/zrx/getZrxMinMax/getZrxMinMax.test.ts
@@ -13,8 +13,8 @@ jest.mock('../utils/helpers/helpers', () => ({
 describe('getZrxMinMax', () => {
   it('returns minimum and maximum', async () => {
     const minMax = await getZrxMinMax(FOX, WETH)
-    expect(minMax.minimum).toBe('1')
-    expect(minMax.maximum).toBe(MAX_ZRX_TRADE)
+    expect(minMax.minimumAmountCryptoHuman).toBe('1')
+    expect(minMax.maximumAmountCryptoHuman).toBe(MAX_ZRX_TRADE)
   })
 
   it('fails on invalid evm asset', async () => {

--- a/packages/swapper/src/swappers/zrx/getZrxMinMax/getZrxMinMax.ts
+++ b/packages/swapper/src/swappers/zrx/getZrxMinMax/getZrxMinMax.ts
@@ -24,8 +24,8 @@ export const getZrxMinMax = async (sellAsset: Asset, buyAsset: Asset): Promise<M
     const minimum = bn(1).dividedBy(bnOrZero(usdRate)).toString() // $1 worth of the sell token.
     const maximum = MAX_ZRX_TRADE // Arbitrarily large value. 10e+28 here.
     return {
-      minimum,
-      maximum,
+      minimumAmountCryptoHuman: minimum,
+      maximumAmountCryptoHuman: maximum,
     }
   } catch (e) {
     if (e instanceof SwapError) throw e

--- a/packages/swapper/src/swappers/zrx/getZrxMinMax/getZrxMinMax.ts
+++ b/packages/swapper/src/swappers/zrx/getZrxMinMax/getZrxMinMax.ts
@@ -21,11 +21,11 @@ export const getZrxMinMax = async (sellAsset: Asset, buyAsset: Asset): Promise<M
 
     const usdRate = await getUsdRate({ ...sellAsset })
 
-    const minimum = bn(1).dividedBy(bnOrZero(usdRate)).toString() // $1 worth of the sell token.
-    const maximum = MAX_ZRX_TRADE // Arbitrarily large value. 10e+28 here.
+    const minimumAmountCryptoHuman = bn(1).dividedBy(bnOrZero(usdRate)).toString() // $1 worth of the sell token.
+    const maximumAmountCryptoHuman = MAX_ZRX_TRADE // Arbitrarily large value. 10e+28 here.
     return {
-      minimumAmountCryptoHuman: minimum,
-      maximumAmountCryptoHuman: maximum,
+      minimumAmountCryptoHuman,
+      maximumAmountCryptoHuman,
     }
   } catch (e) {
     if (e instanceof SwapError) throw e

--- a/packages/swapper/src/swappers/zrx/getZrxTradeQuote/getZrxTradeQuote.ts
+++ b/packages/swapper/src/swappers/zrx/getZrxTradeQuote/getZrxTradeQuote.ts
@@ -98,7 +98,7 @@ export async function getZrxTradeQuote<T extends ZrxSupportedChainId>(
     const tradeQuote: TradeQuote<ZrxSupportedChainId> = {
       rate,
       minimumCryptoHuman: minimumAmountCryptoHuman,
-      maximum: maximumAmountCryptoHuman,
+      maximumCryptoHuman: maximumAmountCryptoHuman,
       feeData: {
         chainSpecific: {
           estimatedGas: estimatedGas.toString(),

--- a/packages/swapper/src/swappers/zrx/getZrxTradeQuote/getZrxTradeQuote.ts
+++ b/packages/swapper/src/swappers/zrx/getZrxTradeQuote/getZrxTradeQuote.ts
@@ -39,13 +39,13 @@ export async function getZrxTradeQuote<T extends ZrxSupportedChainId>(
       sellAsset,
       buyAsset,
     )
-    const minQuotesellAmountCryptoBaseUnit = bnOrZero(minimumAmountCryptoHuman).times(
+    const minQuoteSellAmountCryptoBaseUnit = bnOrZero(minimumAmountCryptoHuman).times(
       bn(10).exponentiatedBy(sellAsset.precision),
     )
 
     const normalizedSellAmount = normalizeAmount(
       bnOrZero(sellAmountCryptoBaseUnit).eq(0)
-        ? minQuotesellAmountCryptoBaseUnit
+        ? minQuoteSellAmountCryptoBaseUnit
         : sellAmountCryptoBaseUnit,
     )
     const baseUrl = baseUrlFromChainId(buyAsset.chainId)

--- a/packages/swapper/src/swappers/zrx/getZrxTradeQuote/getZrxTradeQuote.ts
+++ b/packages/swapper/src/swappers/zrx/getZrxTradeQuote/getZrxTradeQuote.ts
@@ -35,8 +35,11 @@ export async function getZrxTradeQuote<T extends ZrxSupportedChainId>(
     const buyToken = assetToToken(buyAsset)
     const sellToken = assetToToken(sellAsset)
 
-    const { minimum, maximum } = await getZrxMinMax(sellAsset, buyAsset)
-    const minQuotesellAmountCryptoBaseUnit = bnOrZero(minimum).times(
+    const { minimumAmountCryptoHuman, maximumAmountCryptoHuman } = await getZrxMinMax(
+      sellAsset,
+      buyAsset,
+    )
+    const minQuotesellAmountCryptoBaseUnit = bnOrZero(minimumAmountCryptoHuman).times(
       bn(10).exponentiatedBy(sellAsset.precision),
     )
 
@@ -94,8 +97,8 @@ export async function getZrxTradeQuote<T extends ZrxSupportedChainId>(
 
     const tradeQuote: TradeQuote<ZrxSupportedChainId> = {
       rate,
-      minimumCryptoHuman: minimum,
-      maximum,
+      minimumCryptoHuman: minimumAmountCryptoHuman,
+      maximum: maximumAmountCryptoHuman,
       feeData: {
         chainSpecific: {
           estimatedGas: estimatedGas.toString(),

--- a/src/lib/swapper/LifiSwapper/getTradeQuote/getTradeQuote.ts
+++ b/src/lib/swapper/LifiSwapper/getTradeQuote/getTradeQuote.ts
@@ -184,7 +184,7 @@ export async function getTradeQuote(
     buyAmountCryptoBaseUnit: bnOrZero(selectedRoute.toAmount).toString(),
     buyAsset,
     feeData,
-    maximum: MAX_LIFI_TRADE,
+    maximumCryptoHuman: MAX_LIFI_TRADE,
     minimumCryptoHuman,
     rate: estimateRate,
     recommendedSlippage: maxSlippage.toString(),

--- a/src/state/zustand/swapperStore/testData.ts
+++ b/src/state/zustand/swapperStore/testData.ts
@@ -59,7 +59,7 @@ export const baseSwapperState: SwapperState = {
       quote: {
         rate: '52652.792329231222224912',
         minimumCryptoHuman: '0.000565612596529604',
-        maximum: '100000000000000000000000000',
+        maximumCryptoHuman: '100000000000000000000000000',
         feeData: {
           networkFeeCryptoBaseUnit: '2997000000000000',
           buyAssetTradeFeeUsd: '0',
@@ -86,7 +86,7 @@ export const baseSwapperState: SwapperState = {
       } as Swapper<ChainId>,
       quote: {
         rate: '52867.94647736405036163943',
-        maximum: '100000000000000000000000000',
+        maximumCryptoHuman: '100000000000000000000000000',
         sellAmountBeforeFeesCryptoBaseUnit: '18665000000000000',
         buyAmountCryptoBaseUnit: '986780221000000000000',
         sources: [
@@ -116,7 +116,7 @@ export const baseSwapperState: SwapperState = {
     } as Swapper<ChainId>,
     quote: {
       rate: '52867.94647736405036163943',
-      maximum: '100000000000000000000000000',
+      maximumCryptoHuman: '100000000000000000000000000',
       sellAmountBeforeFeesCryptoBaseUnit: '18665000000000000',
       buyAmountCryptoBaseUnit: '986780221000000000000',
       sources: [


### PR DESCRIPTION
## Description

Thanks to our friendly monorail service, this is now quick and easy.

Updates vernacular of min and max to include units.

## Notice

- [x] Have you followed the guidelines in our [Contributing]('https://github.com/shapeshift/web/blob/develop/CONTRIBUTING.md) guide?
- [x] Have you checked to ensure there aren't other open [Pull Requests](https://github.com/shapeshift/web/pulls) for the same update/change?

## Pull Request Type

- [ ] :bug: Bug fix (Non-breaking Change: Fixes an issue)
- [x] :hammer_and_wrench: Chore (Non-breaking Change: Doc updates, pkg upgrades, typos, etc..)
- [ ] :nail_care: New Feature (Breaking/Non-breaking Change)

## Issue (if applicable)

N/A

## Risk

Almost none.

## Testing

Everything should work just as it did before.

### Engineering

☝️

### Operations

☝️

## Screenshots (if applicable)

N/A
