### PR TITLE
chore: use base unit vernacular for estimated gas

### DIFF
--- a/packages/swapper/src/api.ts
+++ b/packages/swapper/src/api.ts
@@ -11,25 +11,25 @@ type ChainSpecificQuoteFeeData<T extends ChainId> = ChainSpecific<
   T,
   {
     [KnownChainIds.EthereumMainnet]: {
-      estimatedGas?: string
+      estimatedGasCryptoBaseUnit?: string
       gasPriceCryptoBaseUnit?: string
       approvalFeeCryptoBaseUnit?: string
       totalFee?: string
     }
     [KnownChainIds.AvalancheMainnet]: {
-      estimatedGas?: string
+      estimatedGasCryptoBaseUnit?: string
       gasPriceCryptoBaseUnit?: string
       approvalFeeCryptoBaseUnit?: string
       totalFee?: string
     }
     [KnownChainIds.OptimismMainnet]: {
-      estimatedGas?: string
+      estimatedGasCryptoBaseUnit?: string
       gasPriceCryptoBaseUnit?: string
       approvalFeeCryptoBaseUnit?: string
       totalFee?: string
     }
     [KnownChainIds.BnbSmartChainMainnet]: {
-      estimatedGas?: string
+      estimatedGasCryptoBaseUnit?: string
       gasPriceCryptoBaseUnit?: string
       approvalFeeCryptoBaseUnit?: string
       totalFee?: string
@@ -51,10 +51,10 @@ type ChainSpecificQuoteFeeData<T extends ChainId> = ChainSpecific<
       satsPerByte: string
     }
     [KnownChainIds.CosmosMainnet]: {
-      estimatedGas: string
+      estimatedGasCryptoBaseUnit: string
     }
     [KnownChainIds.ThorchainMainnet]: {
-      estimatedGas: string
+      estimatedGasCryptoBaseUnit: string
     }
   }
 >

--- a/packages/swapper/src/manager/testData.ts
+++ b/packages/swapper/src/manager/testData.ts
@@ -78,7 +78,7 @@ export const tradeQuote: TradeQuote<KnownChainIds.EthereumMainnet> = {
   buyAmountCryptoBaseUnit: '23448326921811747', // 0.023 ETH
   feeData: {
     chainSpecific: {
-      estimatedGas: '100000',
+      estimatedGasCryptoBaseUnit: '100000',
       approvalFeeCryptoBaseUnit: '700000',
       gasPriceCryptoBaseUnit: '7',
     },
@@ -98,7 +98,7 @@ export const goodTradeQuote: TradeQuote<KnownChainIds.EthereumMainnet> = {
   buyAmountCryptoBaseUnit: '23000000000000000', // 0.023 ETH
   feeData: {
     chainSpecific: {
-      estimatedGas: '100000',
+      estimatedGasCryptoBaseUnit: '100000',
       approvalFeeCryptoBaseUnit: '700000',
       gasPriceCryptoBaseUnit: '7',
     },
@@ -114,7 +114,7 @@ export const badTradeQuote: TradeQuote<KnownChainIds.EthereumMainnet> = {
   buyAmountCryptoBaseUnit: '21000000000000000', // 0.021 ETH
   feeData: {
     chainSpecific: {
-      estimatedGas: '100000',
+      estimatedGasCryptoBaseUnit: '100000',
       approvalFeeCryptoBaseUnit: '700000',
       gasPriceCryptoBaseUnit: '7',
     },

--- a/packages/swapper/src/swappers/cow/CowSwapper.test.ts
+++ b/packages/swapper/src/swappers/cow/CowSwapper.test.ts
@@ -215,7 +215,7 @@ describe('CowSwapper', () => {
         rate: '14716.04718939437505555958',
         feeData: {
           chainSpecific: {
-            estimatedGas: '100000',
+            estimatedGasCryptoBaseUnit: '100000',
             gasPriceCryptoBaseUnit: '79036500000',
           },
           buyAssetTradeFeeUsd: '0',

--- a/packages/swapper/src/swappers/cow/cowBuildTrade/cowBuildTrade.test.ts
+++ b/packages/swapper/src/swappers/cow/cowBuildTrade/cowBuildTrade.test.ts
@@ -113,7 +113,7 @@ const expectedTradeWethToFox: CowTrade<KnownChainIds.EthereumMainnet> = {
   rate: '14716.04718939437505555958', // 14716 FOX per WETH
   feeData: {
     chainSpecific: {
-      estimatedGas: '100000',
+      estimatedGasCryptoBaseUnit: '100000',
       gasPriceCryptoBaseUnit: '79036500000',
     },
     buyAssetTradeFeeUsd: '0',
@@ -136,7 +136,7 @@ const expectedTradeQuoteWbtcToWethWithApprovalFeeCryptoBaseUnit: CowTrade<KnownC
     rate: '19.13939810252384532346', // 19.14 WETH per WBTC
     feeData: {
       chainSpecific: {
-        estimatedGas: '100000',
+        estimatedGasCryptoBaseUnit: '100000',
         gasPriceCryptoBaseUnit: '79036500000',
         approvalFeeCryptoBaseUnit: '7903650000000000',
       },
@@ -159,7 +159,7 @@ const expectedTradeQuoteFoxToEth: CowTrade<KnownChainIds.EthereumMainnet> = {
   rate: '0.00004995640398295996',
   feeData: {
     chainSpecific: {
-      estimatedGas: '100000',
+      estimatedGasCryptoBaseUnit: '100000',
       gasPriceCryptoBaseUnit: '79036500000',
     },
     buyAssetTradeFeeUsd: '0',

--- a/packages/swapper/src/swappers/cow/cowBuildTrade/cowBuildTrade.ts
+++ b/packages/swapper/src/swappers/cow/cowBuildTrade/cowBuildTrade.ts
@@ -127,7 +127,7 @@ export async function cowBuildTrade(
       feeData: {
         networkFeeCryptoBaseUnit: '0', // no miner fee for CowSwap
         chainSpecific: {
-          estimatedGas: feeData.chainSpecific.gasLimit,
+          estimatedGasCryptoBaseUnit: feeData.chainSpecific.gasLimit,
           gasPriceCryptoBaseUnit: feeData.chainSpecific.gasPrice,
         },
         buyAssetTradeFeeUsd: '0', // Trade fees for buy Asset are always 0 since trade fees are subtracted from sell asset

--- a/packages/swapper/src/swappers/cow/cowExecuteTrade/cowExecuteTrade.test.ts
+++ b/packages/swapper/src/swappers/cow/cowExecuteTrade/cowExecuteTrade.test.ts
@@ -55,7 +55,7 @@ const cowTradeEthToFox: CowTrade<KnownChainIds.EthereumMainnet> = {
   rate: '14716.04718939437505555958',
   feeData: {
     chainSpecific: {
-      estimatedGas: '100000',
+      estimatedGasCryptoBaseUnit: '100000',
       gasPriceCryptoBaseUnit: '79036500000',
     },
     buyAssetTradeFeeUsd: '0',
@@ -77,7 +77,7 @@ const cowTradeWethToFox: CowTrade<KnownChainIds.EthereumMainnet> = {
   rate: '14716.04718939437505555958',
   feeData: {
     chainSpecific: {
-      estimatedGas: '100000',
+      estimatedGasCryptoBaseUnit: '100000',
       gasPriceCryptoBaseUnit: '79036500000',
     },
     buyAssetTradeFeeUsd: '0',
@@ -99,7 +99,7 @@ const cowTradeFoxToEth: CowTrade<KnownChainIds.EthereumMainnet> = {
   rate: '0.00004995640398295996',
   feeData: {
     chainSpecific: {
-      estimatedGas: '100000',
+      estimatedGasCryptoBaseUnit: '100000',
       gasPriceCryptoBaseUnit: '79036500000',
     },
     buyAssetTradeFeeUsd: '5.3955565850972847808512',

--- a/packages/swapper/src/swappers/cow/getCowSwapTradeQuote/getCowSwapTradeQuote.test.ts
+++ b/packages/swapper/src/swappers/cow/getCowSwapTradeQuote/getCowSwapTradeQuote.test.ts
@@ -122,7 +122,7 @@ const expectedTradeQuoteWethToFox: TradeQuote<KnownChainIds.EthereumMainnet> = {
   maximum: '100000000000000000000000000',
   feeData: {
     chainSpecific: {
-      estimatedGas: '100000',
+      estimatedGasCryptoBaseUnit: '100000',
       gasPriceCryptoBaseUnit: '79036500000',
       approvalFeeCryptoBaseUnit: '7903650000000000',
     },
@@ -145,7 +145,7 @@ const expectedTradeQuoteFoxToEth: TradeQuote<KnownChainIds.EthereumMainnet> = {
   maximum: '100000000000000000000000000',
   feeData: {
     chainSpecific: {
-      estimatedGas: '100000',
+      estimatedGasCryptoBaseUnit: '100000',
       gasPriceCryptoBaseUnit: '79036500000',
       approvalFeeCryptoBaseUnit: '7903650000000000',
     },
@@ -168,7 +168,7 @@ const expectedTradeQuoteSmallAmountWethToFox: TradeQuote<KnownChainIds.EthereumM
   maximum: '100000000000000000000000000',
   feeData: {
     chainSpecific: {
-      estimatedGas: '100000',
+      estimatedGasCryptoBaseUnit: '100000',
       gasPriceCryptoBaseUnit: '79036500000',
       approvalFeeCryptoBaseUnit: '7903650000000000',
     },

--- a/packages/swapper/src/swappers/cow/getCowSwapTradeQuote/getCowSwapTradeQuote.ts
+++ b/packages/swapper/src/swappers/cow/getCowSwapTradeQuote/getCowSwapTradeQuote.ts
@@ -168,7 +168,7 @@ export async function getCowSwapTradeQuote(
       feeData: {
         networkFeeCryptoBaseUnit: '0', // no miner fee for CowSwap
         chainSpecific: {
-          estimatedGas: feeData.chainSpecific.gasLimit,
+          estimatedGasCryptoBaseUnit: feeData.chainSpecific.gasLimit,
           gasPriceCryptoBaseUnit: feeData.chainSpecific.gasPrice,
           approvalFeeCryptoBaseUnit: bnOrZero(feeData.chainSpecific.gasLimit)
             .multipliedBy(bnOrZero(feeData.chainSpecific.gasPrice))

--- a/packages/swapper/src/swappers/thorchain/buildThorTrade/buildThorTrade.ts
+++ b/packages/swapper/src/swappers/thorchain/buildThorTrade/buildThorTrade.ts
@@ -65,7 +65,8 @@ export const buildTrade = async ({ deps, input }: BuildTradeArgs): Promise<ThorT
           (quote as TradeQuote<ThorEvmSupportedChainId>).feeData.chainSpecific
             ?.gasPriceCryptoBaseUnit ?? '0',
         gasLimit:
-          (quote as TradeQuote<ThorEvmSupportedChainId>).feeData.chainSpecific?.estimatedGas ?? '0',
+          (quote as TradeQuote<ThorEvmSupportedChainId>).feeData.chainSpecific
+            ?.estimatedGasCryptoBaseUnit ?? '0',
         buyAssetTradeFeeUsd: quote.feeData.buyAssetTradeFeeUsd,
       })
 

--- a/packages/swapper/src/swappers/thorchain/cosmossdk/getCosmosTxData.ts
+++ b/packages/swapper/src/swappers/thorchain/cosmossdk/getCosmosTxData.ts
@@ -76,7 +76,7 @@ export const getCosmosTxData = async (input: GetCosmosTxDataInput) => {
           wallet,
           memo,
           chainSpecific: {
-            gas: quote.feeData.chainSpecific.estimatedGas,
+            gas: quote.feeData.chainSpecific.estimatedGasCryptoBaseUnit,
             fee: quote.feeData.networkFeeCryptoBaseUnit,
           },
         })
@@ -97,7 +97,7 @@ export const getCosmosTxData = async (input: GetCosmosTxDataInput) => {
           memo,
           chainSpecific: {
             gas: (quote as TradeQuote<ThorCosmosSdkSupportedChainId>).feeData.chainSpecific
-              .estimatedGas,
+              .estimatedGasCryptoBaseUnit,
             fee: quote.feeData.networkFeeCryptoBaseUnit,
           },
         })

--- a/packages/swapper/src/swappers/thorchain/getThorTradeQuote/getTradeQuote.test.ts
+++ b/packages/swapper/src/swappers/thorchain/getThorTradeQuote/getTradeQuote.test.ts
@@ -25,7 +25,7 @@ const expectedQuoteResponse: TradeQuote<KnownChainIds.EthereumMainnet> = {
   buyAmountCryptoBaseUnit: '4633547338118093212830055',
   feeData: {
     chainSpecific: {
-      estimatedGas: '100000',
+      estimatedGasCryptoBaseUnit: '100000',
       approvalFeeCryptoBaseUnit: '700000',
       gasPriceCryptoBaseUnit: '7',
     },

--- a/packages/swapper/src/swappers/thorchain/getThorTradeQuote/getTradeQuote.ts
+++ b/packages/swapper/src/swappers/thorchain/getThorTradeQuote/getTradeQuote.ts
@@ -205,7 +205,7 @@ export const getThorTradeQuote: GetThorTradeQuote = async ({ deps, input }) => {
               networkFeeCryptoBaseUnit: feeData.fast.txFee,
               buyAssetTradeFeeUsd,
               sellAssetTradeFeeUsd: '0',
-              chainSpecific: { estimatedGas: feeData.fast.chainSpecific.gasLimit },
+              chainSpecific: { estimatedGasCryptoBaseUnit: feeData.fast.chainSpecific.gasLimit },
             },
           }
         })()

--- a/packages/swapper/src/swappers/thorchain/utils/txFeeHelpers/evmTxFees/getEvmTxFees.ts
+++ b/packages/swapper/src/swappers/thorchain/utils/txFeeHelpers/evmTxFees/getEvmTxFees.ts
@@ -43,7 +43,7 @@ export const getEvmTxFees = async ({
     return {
       networkFeeCryptoBaseUnit: feeData.txFee,
       chainSpecific: {
-        estimatedGas: feeData.chainSpecific.gasLimit,
+        estimatedGasCryptoBaseUnit: feeData.chainSpecific.gasLimit,
         gasPriceCryptoBaseUnit: feeData.chainSpecific.gasPrice,
         approvalFeeCryptoBaseUnit:
           sellAssetReference &&

--- a/packages/swapper/src/swappers/utils/helpers/helpers.ts
+++ b/packages/swapper/src/swappers/utils/helpers/helpers.ts
@@ -127,7 +127,7 @@ export const grantAllowance = async <T extends EvmChainId>({
       chainSpecific: {
         tokenContractAddress: sellAssetErc20Address,
         gasPrice: numberToHex(quote.feeData?.chainSpecific?.gasPriceCryptoBaseUnit || 0),
-        gasLimit: numberToHex(quote.feeData?.chainSpecific?.estimatedGas || 0),
+        gasLimit: numberToHex(quote.feeData?.chainSpecific?.estimatedGasCryptoBaseUnit || 0),
       },
     })
 

--- a/packages/swapper/src/swappers/zrx/getZrxTradeQuote/getZrxTradeQuote.test.ts
+++ b/packages/swapper/src/swappers/zrx/getZrxTradeQuote/getZrxTradeQuote.test.ts
@@ -45,7 +45,7 @@ describe('getZrxTradeQuote', () => {
     const quote = await swapper.getTradeQuote(quoteInput)
     expect(quote.feeData).toStrictEqual({
       chainSpecific: {
-        estimatedGas: '1500000',
+        estimatedGasCryptoBaseUnit: '1500000',
         gasPriceCryptoBaseUnit: '1000',
         approvalFeeCryptoBaseUnit: '100000000',
       },
@@ -92,7 +92,7 @@ describe('getZrxTradeQuote', () => {
     const quote = await swapper.getTradeQuote(quoteInput)
     expect(quote?.feeData).toStrictEqual({
       chainSpecific: {
-        estimatedGas: '0',
+        estimatedGasCryptoBaseUnit: '0',
         approvalFeeCryptoBaseUnit: '0',
         gasPriceCryptoBaseUnit: undefined,
       },

--- a/packages/swapper/src/swappers/zrx/getZrxTradeQuote/getZrxTradeQuote.ts
+++ b/packages/swapper/src/swappers/zrx/getZrxTradeQuote/getZrxTradeQuote.ts
@@ -98,7 +98,7 @@ export async function getZrxTradeQuote<T extends ZrxSupportedChainId>(
       maximum,
       feeData: {
         chainSpecific: {
-          estimatedGas: estimatedGas.toString(),
+          estimatedGasCryptoBaseUnit: estimatedGas.toString(),
           gasPriceCryptoBaseUnit,
           approvalFeeCryptoBaseUnit,
         },

--- a/packages/swapper/src/swappers/zrx/zrxBuildTrade/zrxBuildTrade.test.ts
+++ b/packages/swapper/src/swappers/zrx/zrxBuildTrade/zrxBuildTrade.test.ts
@@ -92,7 +92,7 @@ describe('zrxBuildTrade', () => {
     feeData: {
       chainSpecific: {
         approvalFeeCryptoBaseUnit: '123600000',
-        estimatedGas: '1235',
+        estimatedGasCryptoBaseUnit: '1235',
         gasPriceCryptoBaseUnit: '1236',
       },
       networkFeeCryptoBaseUnit: (
@@ -164,7 +164,7 @@ describe('zrxBuildTrade', () => {
           .multipliedBy(gasPriceCryptoBaseUnit)
           .toString(),
         gasPriceCryptoBaseUnit,
-        estimatedGas,
+        estimatedGasCryptoBaseUnit: estimatedGas,
       },
       buyAssetTradeFeeUsd: '0',
       sellAssetTradeFeeUsd: '0',

--- a/packages/swapper/src/swappers/zrx/zrxBuildTrade/zrxBuildTrade.ts
+++ b/packages/swapper/src/swappers/zrx/zrxBuildTrade/zrxBuildTrade.ts
@@ -122,7 +122,7 @@ export async function zrxBuildTrade<T extends ZrxSupportedChainId>(
       depositAddress: to,
       feeData: {
         chainSpecific: {
-          estimatedGas: estimatedGas.toString(),
+          estimatedGasCryptoBaseUnit: estimatedGas.toString(),
           gasPriceCryptoBaseUnit,
           approvalFeeCryptoBaseUnit: approvalRequired ? approvalFee : undefined,
         },

--- a/packages/swapper/src/swappers/zrx/zrxExecuteTrade/zrxExecuteTrade.test.ts
+++ b/packages/swapper/src/swappers/zrx/zrxExecuteTrade/zrxExecuteTrade.test.ts
@@ -35,7 +35,7 @@ describe('ZrxExecuteTrade', () => {
     feeData: {
       chainSpecific: {
         approvalFeeCryptoBaseUnit: '123600000',
-        estimatedGas: '1235',
+        estimatedGasCryptoBaseUnit: '1235',
         gasPriceCryptoBaseUnit: '1236',
       },
       buyAssetTradeFeeUsd: '0',

--- a/packages/swapper/src/swappers/zrx/zrxExecuteTrade/zrxExecuteTrade.ts
+++ b/packages/swapper/src/swappers/zrx/zrxExecuteTrade/zrxExecuteTrade.ts
@@ -24,7 +24,7 @@ export async function zrxExecuteTrade<T extends ZrxSupportedChainId>(
       to: trade.depositAddress,
       chainSpecific: {
         gasPrice: numberToHex(trade.feeData?.chainSpecific?.gasPriceCryptoBaseUnit || 0),
-        gasLimit: numberToHex(trade.feeData?.chainSpecific?.estimatedGas || 0),
+        gasLimit: numberToHex(trade.feeData?.chainSpecific?.estimatedGasCryptoBaseUnit || 0),
       },
       accountNumber,
     })

--- a/src/components/Trade/hooks/useSwapper/utils.ts
+++ b/src/components/Trade/hooks/useSwapper/utils.ts
@@ -83,13 +83,15 @@ const getEvmFees = <T extends EvmChainId>(
   const gasPriceCryptoBaseUnit = bnOrZero(
     trade.feeData.chainSpecific?.gasPriceCryptoBaseUnit,
   ).toString()
-  const estimatedGasCryptoBaseUnit = bnOrZero(trade.feeData.chainSpecific?.estimatedGas).toString()
+  const estimatedGasCryptoBaseUnit = bnOrZero(
+    trade.feeData.chainSpecific?.estimatedGasCryptoBaseUnit,
+  ).toString()
 
   return {
     chainSpecific: {
       approvalFeeCryptoBaseUnit: trade.feeData.chainSpecific?.approvalFeeCryptoBaseUnit ?? '0',
       gasPriceCryptoBaseUnit,
-      estimatedGas: estimatedGasCryptoBaseUnit,
+      estimatedGasCryptoBaseUnit,
       totalFee: totalFeeCryptoPrecision,
     },
     tradeFeeSource,

--- a/src/lib/swapper/LifiSwapper/utils/transformLifiFeeData/transformLifiFeeData.ts
+++ b/src/lib/swapper/LifiSwapper/utils/transformLifiFeeData/transformLifiFeeData.ts
@@ -78,7 +78,7 @@ export const transformLifiFeeData = ({
 
       // lifi handles approval gas internally but need to set a gas limit so the
       // approval limit isnt exceeded when the trade is executed.
-      estimatedGas: APPROVAL_GAS_LIMIT,
+      estimatedGasCryptoBaseUnit: APPROVAL_GAS_LIMIT,
       approvalFeeCryptoBaseUnit: approvalFeeCryptoBaseUnit.toString(),
     },
     // UI shows the sum of these as "protocol fee"

--- a/src/state/zustand/swapperStore/testData.ts
+++ b/src/state/zustand/swapperStore/testData.ts
@@ -151,7 +151,7 @@ export const baseSwapperState: SwapperState = {
     chainSpecific: {
       approvalFeeCryptoBaseUnit: '1800000000000000',
       gasPriceCryptoBaseUnit: '18000000000',
-      estimatedGas: '100000',
+      estimatedGasCryptoBaseUnit: '100000',
       totalFee: '0.0036',
     },
     tradeFeeSource: 'THORChain',


### PR DESCRIPTION
## Description

More vernacular improvements - update `estimatedGas` to `estimatedGasCryptoBaseUnit`.

## Notice

- [x] Have you followed the guidelines in our [Contributing]('https://github.com/shapeshift/web/blob/develop/CONTRIBUTING.md) guide?
- [x] Have you checked to ensure there aren't other open [Pull Requests](https://github.com/shapeshift/web/pulls) for the same update/change?

## Pull Request Type

- [ ] :bug: Bug fix (Non-breaking Change: Fixes an issue)
- [x] :hammer_and_wrench: Chore (Non-breaking Change: Doc updates, pkg upgrades, typos, etc..)
- [ ] :nail_care: New Feature (Breaking/Non-breaking Change)

## Issue (if applicable)

N/A

## Risk

Minimum

## Testing

Everything should work as it did before.

### Engineering

☝️

### Operations

☝️

## Screenshots (if applicable)

N/A
