### PR TITLE
fix: trade confirmation UI zeroing out when changing network on wallet

### DIFF
--- a/src/components/Trade/Trade.tsx
+++ b/src/components/Trade/Trade.tsx
@@ -13,8 +13,9 @@ export type TradeProps = {
 }
 
 export const Trade = ({ defaultBuyAssetId }: TradeProps) => {
-  const { getDefaultAssets, defaultAssetIdPair } = useDefaultAssets(defaultBuyAssetId)
+  const { defaultAssets, defaultAssetIdPair } = useDefaultAssets(defaultBuyAssetId)
   const location = useLocation()
+
   const [hasSetDefaultValues, setHasSetDefaultValues] = useState<boolean>(false)
 
   const methods = useForm({ mode: 'onChange' })
@@ -40,35 +41,32 @@ export const Trade = ({ defaultBuyAssetId }: TradeProps) => {
   useEffect(() => setHasSetDefaultValues(false), [location])
 
   useEffect(() => {
-    if (hasSetDefaultValues) return
-    ;(async () => {
-      const result = await getDefaultAssets()
-      if (!result) return
-      const { buyAsset, sellAsset } = result
-      updateAction(TradeAmountInputField.SELL_FIAT)
-      updateIsExactAllowance(false)
-      updateBuyAsset(buyAsset)
-      updateBuyAmountCryptoPrecision('0')
-      updateAmount('0')
-      updateSellAsset(sellAsset)
-      updateSellAmountCryptoPrecision('0')
-      updateFiatBuyAmount('0')
-      updateFiatSellAmount('0')
-      updateSellAssetFiatRate(undefined)
-      updateBuyAssetFiatRate(undefined)
-      updateFeeAssetFiatRate(undefined)
-      const defaultAssetsAreChainDefaults =
-        sellAsset?.assetId === defaultAssetIdPair?.sellAssetId &&
-        buyAsset?.assetId === defaultAssetIdPair?.buyAssetId
-      if (!defaultAssetsAreChainDefaults && defaultAssetIdPair) {
-        // If the default assets are the chain defaults then keep this useEffect active as we might not have stabilized
-        // Else, we know the default values have been set, so don't run this again unless the route changes
-        setHasSetDefaultValues(true)
-      }
-    })()
+    if (hasSetDefaultValues || !defaultAssets) return
+
+    const { buyAsset, sellAsset } = defaultAssets
+    updateAction(TradeAmountInputField.SELL_FIAT)
+    updateIsExactAllowance(false)
+    updateBuyAsset(buyAsset)
+    updateBuyAmountCryptoPrecision('0')
+    updateAmount('0')
+    updateSellAsset(sellAsset)
+    updateSellAmountCryptoPrecision('0')
+    updateFiatBuyAmount('0')
+    updateFiatSellAmount('0')
+    updateSellAssetFiatRate(undefined)
+    updateBuyAssetFiatRate(undefined)
+    updateFeeAssetFiatRate(undefined)
+    const defaultAssetsAreChainDefaults =
+      sellAsset?.assetId === defaultAssetIdPair?.sellAssetId &&
+      buyAsset?.assetId === defaultAssetIdPair?.buyAssetId
+    if (!defaultAssetsAreChainDefaults && defaultAssetIdPair) {
+      // If the default assets are the chain defaults then keep this useEffect active as we might not have stabilized
+      // Else, we know the default values have been set, so don't run this again unless the route changes
+      setHasSetDefaultValues(true)
+    }
   }, [
     defaultBuyAssetId,
-    getDefaultAssets,
+    defaultAssets,
     methods,
     location,
     hasSetDefaultValues,

--- a/src/hooks/useDeepOutputMemo/useDeepOutputMemo.ts
+++ b/src/hooks/useDeepOutputMemo/useDeepOutputMemo.ts
@@ -1,0 +1,21 @@
+import cloneDeep from 'lodash/cloneDeep'
+import isEqual from 'lodash/isEqual'
+import type { DependencyList } from 'react'
+import { useMemo, useRef } from 'react'
+
+// this hook will only update the output if the output has changed deeply
+export const useDeepOutputMemo = <T>(fn: () => T, deps: DependencyList | undefined): T => {
+  const memoizedResultRef = useRef<T>(fn())
+  /* eslint-disable-next-line react-hooks/exhaustive-deps */
+  const memoizedResult = useMemo<T>(fn, deps)
+
+  const memoizationFn = (prevResult: T, nextResult: T) => {
+    return isEqual(prevResult, nextResult)
+  }
+
+  if (!memoizationFn(memoizedResultRef.current, memoizedResult)) {
+    memoizedResultRef.current = cloneDeep(memoizedResult)
+  }
+
+  return memoizedResultRef.current
+}


### PR DESCRIPTION
## Description

Changing network during trade confirmation results in the UI being zeroed out. 

This was caused by the network change to modify the wallet, which in turn triggered default asset logic to create duplicate objects with different memory addresses, forcing initialization of default assets to rerun --- which triggered trades to be zeroed out.

## Pull Request Type

- [x] :bug: Bug fix (Non-breaking Change: Fixes an issue)
- [ ] :hammer_and_wrench: Chore (Non-breaking Change: Doc updates, pkg upgrades, typos, etc..)
- [ ] :nail_care: New Feature (Breaking/Non-breaking Change)

## Issue (if applicable)

NA

## Risk

Risk of breaking the default asset setting logic - please test accordingly.

## Testing

- Create a trade and go to trade confirmation. 
- Change network on your wallet. 
- The numbers in the trade UI should  not get zeroed out, but rather the current trade values should persist unchanged.
- The trade should be executed with the correct values.

### Engineering

☝️

### Operations

☝️

## Screenshots (if applicable)

N/A