### PR TITLE
feat: toHuman should return a human amount

### DIFF
--- a/src/components/Approval/Approval.tsx
+++ b/src/components/Approval/Approval.tsx
@@ -31,7 +31,7 @@ import { WalletActions } from 'context/WalletProvider/actions'
 import { useErrorHandler } from 'hooks/useErrorToast/useErrorToast'
 import { useLocaleFormatter } from 'hooks/useLocaleFormatter/useLocaleFormatter'
 import { useWallet } from 'hooks/useWallet/useWallet'
-import { bnOrZero, toHuman } from 'lib/bignumber/bignumber'
+import { baseUnitToHuman, bnOrZero } from 'lib/bignumber/bignumber'
 import { logger } from 'lib/logger'
 import { selectFeeAssetById } from 'state/slices/selectors'
 import { useAppSelector } from 'state/store'
@@ -88,7 +88,7 @@ export const Approval = () => {
     moduleLogger.debug({ fees }, 'chainSpecific undefined for fees')
   }
 
-  const approvalFeeCryptoHuman = toHuman({
+  const approvalFeeCryptoHuman = baseUnitToHuman({
     value: bnOrZero(fees?.chainSpecific?.approvalFeeCryptoBaseUnit),
     inputPrecision: sellFeeAsset?.precision ?? 0,
   })

--- a/src/lib/bignumber/bignumber.test.ts
+++ b/src/lib/bignumber/bignumber.test.ts
@@ -1,4 +1,4 @@
-import { BigNumber, bn, bnOrZero, convertPrecision } from './bignumber'
+import { BigNumber, bn, bnOrZero, convertPrecision, toHuman } from './bignumber'
 
 describe('bignumber', () => {
   describe('bnOrZero', () => {
@@ -57,6 +57,56 @@ describe('bignumber', () => {
 
       const result = convertPrecision({ value, inputPrecision: 6, outputPrecision: 3 })
       expect(result).toEqual(expectation)
+    })
+  })
+
+  describe('toHuman', () => {
+    it('converts BigNumber value to human-readable format with 6 decimal places (inputPrecision 8)', () => {
+      const value = '123456789012345'
+      const inputPrecision = 8
+      const result = toHuman({ value, inputPrecision })
+
+      expect(result.toFixed()).toBe('1234567.890123')
+    })
+
+    it('converts BigNumber value to human-readable format with 6 decimal places (inputPrecision 6)', () => {
+      const value = '12345000000'
+      const inputPrecision = 6
+      const result = toHuman({ value, inputPrecision })
+
+      expect(result.toFixed()).toBe('12345')
+    })
+
+    it('converts BigNumber value to human-readable format with 6 decimal places (inputPrecision 18)', () => {
+      const value = '100000000000000000000'
+      const inputPrecision = 18
+      const result = toHuman({ value, inputPrecision })
+
+      expect(result.toFixed()).toBe('100')
+    })
+
+    it('rounds down BigNumber value to human-readable format with 6 decimal places (inputPrecision 8)', () => {
+      const value = '123456789012345'
+      const inputPrecision = 8
+      const result = toHuman({ value, inputPrecision })
+
+      expect(result.toFixed()).toBe('1234567.890123')
+    })
+
+    it('rounds up BigNumber value close to 1 to human-readable format with 6 decimal places (inputPrecision 18)', () => {
+      const value = '999999999999999999'
+      const inputPrecision = 18
+      const result = toHuman({ value, inputPrecision })
+
+      expect(result.toFixed()).toBe('1')
+    })
+
+    it('rounds up the last decimal of a BigNumber value to human-readable format with 6 decimal places (inputPrecision 18)', () => {
+      const value = '123459900000000000'
+      const inputPrecision = 18
+      const result = toHuman({ value, inputPrecision })
+
+      expect(result.toFixed()).toBe('0.12346')
     })
   })
 })

--- a/src/lib/bignumber/bignumber.test.ts
+++ b/src/lib/bignumber/bignumber.test.ts
@@ -1,4 +1,4 @@
-import { BigNumber, bn, bnOrZero, convertPrecision, toHuman } from './bignumber'
+import { baseUnitToHuman, BigNumber, bn, bnOrZero, convertPrecision } from './bignumber'
 
 describe('bignumber', () => {
   describe('bnOrZero', () => {
@@ -60,11 +60,11 @@ describe('bignumber', () => {
     })
   })
 
-  describe('toHuman', () => {
+  describe('baseUnitToHuman', () => {
     it('converts BigNumber value to human-readable format with 6 decimal places (inputPrecision 8)', () => {
       const value = '123456789012345'
       const inputPrecision = 8
-      const result = toHuman({ value, inputPrecision })
+      const result = baseUnitToHuman({ value, inputPrecision })
 
       expect(result.toFixed()).toBe('1234567.890123')
     })
@@ -72,7 +72,7 @@ describe('bignumber', () => {
     it('converts BigNumber value to human-readable format with 6 decimal places (inputPrecision 6)', () => {
       const value = '12345000000'
       const inputPrecision = 6
-      const result = toHuman({ value, inputPrecision })
+      const result = baseUnitToHuman({ value, inputPrecision })
 
       expect(result.toFixed()).toBe('12345')
     })
@@ -80,7 +80,7 @@ describe('bignumber', () => {
     it('converts BigNumber value to human-readable format with 6 decimal places (inputPrecision 18)', () => {
       const value = '100000000000000000000'
       const inputPrecision = 18
-      const result = toHuman({ value, inputPrecision })
+      const result = baseUnitToHuman({ value, inputPrecision })
 
       expect(result.toFixed()).toBe('100')
     })
@@ -88,7 +88,7 @@ describe('bignumber', () => {
     it('rounds down BigNumber value to human-readable format with 6 decimal places (inputPrecision 8)', () => {
       const value = '123456789012345'
       const inputPrecision = 8
-      const result = toHuman({ value, inputPrecision })
+      const result = baseUnitToHuman({ value, inputPrecision })
 
       expect(result.toFixed()).toBe('1234567.890123')
     })
@@ -96,7 +96,7 @@ describe('bignumber', () => {
     it('rounds up BigNumber value close to 1 to human-readable format with 6 decimal places (inputPrecision 18)', () => {
       const value = '999999999999999999'
       const inputPrecision = 18
-      const result = toHuman({ value, inputPrecision })
+      const result = baseUnitToHuman({ value, inputPrecision })
 
       expect(result.toFixed()).toBe('1')
     })
@@ -104,7 +104,7 @@ describe('bignumber', () => {
     it('rounds up the last decimal of a BigNumber value to human-readable format with 6 decimal places (inputPrecision 18)', () => {
       const value = '123459900000000000'
       const inputPrecision = 18
-      const result = toHuman({ value, inputPrecision })
+      const result = baseUnitToHuman({ value, inputPrecision })
 
       expect(result.toFixed()).toBe('0.12346')
     })

--- a/src/lib/bignumber/bignumber.ts
+++ b/src/lib/bignumber/bignumber.ts
@@ -30,13 +30,31 @@ export const convertPrecision = ({
     .multipliedBy(bn(10).exponentiatedBy(outputPrecision))
 }
 
+// copilot write JSDoc docs for this function
+
+/**
+ * Converts a BigNumber to a human readable amount
+ * @example
+ * toHuman({ value: '123456789', inputPrecision: 18 })
+ * // => 0.123456
+ * @example
+ * toHuman({ value: '123456789', inputPrecision: 6 })
+ * // => 1234.56789
+ * @example
+ * toHuman({ value: '123456789', inputPrecision: 0 })
+ * // => 123456789
+ */
 export const toHuman = ({
   value,
   inputPrecision,
 }: {
   value: BigNumber.Value
   inputPrecision: number
-}) => convertPrecision({ value, inputPrecision, outputPrecision: 0 })
+}) => {
+  const precisionAmount = convertPrecision({ value, inputPrecision, outputPrecision: 0 })
+  // trimming to 6 decimals is what we call "human amount"
+  return precisionAmount.decimalPlaces(6)
+}
 
 export const fromHuman = ({
   value,

--- a/src/lib/bignumber/bignumber.ts
+++ b/src/lib/bignumber/bignumber.ts
@@ -30,19 +30,14 @@ export const convertPrecision = ({
     .multipliedBy(bn(10).exponentiatedBy(outputPrecision))
 }
 
-// copilot write JSDoc docs for this function
-
 /**
  * Converts a base unit amount to a human readable amount
  * @example
- * toHuman({ value: '123456789', inputPrecision: 18 })
- * // => 0.123456
- * @example
- * toHuman({ value: '123456789', inputPrecision: 6 })
- * // => 1234.56789
- * @example
- * toHuman({ value: '123456789', inputPrecision: 0 })
- * // => 123456789
+ * toHuman({ value: '123459900000000000', inputPrecision: 18 })
+ * // => 0.12346
+ * * @example
+ * toHuman({ value: '12345000000', inputPrecision: 6 })
+ * // => 12345
  */
 export const toHuman = ({
   value,

--- a/src/lib/bignumber/bignumber.ts
+++ b/src/lib/bignumber/bignumber.ts
@@ -33,7 +33,7 @@ export const convertPrecision = ({
 // copilot write JSDoc docs for this function
 
 /**
- * Converts a BigNumber to a human readable amount
+ * Converts a base unit amount to a human readable amount
  * @example
  * toHuman({ value: '123456789', inputPrecision: 18 })
  * // => 0.123456

--- a/src/lib/bignumber/bignumber.ts
+++ b/src/lib/bignumber/bignumber.ts
@@ -30,16 +30,7 @@ export const convertPrecision = ({
     .multipliedBy(bn(10).exponentiatedBy(outputPrecision))
 }
 
-/**
- * Converts a base unit amount to a human readable amount
- * @example
- * toHuman({ value: '123459900000000000', inputPrecision: 18 })
- * // => 0.12346
- * * @example
- * toHuman({ value: '12345000000', inputPrecision: 6 })
- * // => 12345
- */
-export const toHuman = ({
+export const baseUnitToHuman = ({
   value,
   inputPrecision,
 }: {

--- a/src/lib/swapper/LifiSwapper/utils/cryptoLifiToUsdHuman/cryptoLifiToUsdHuman.ts
+++ b/src/lib/swapper/LifiSwapper/utils/cryptoLifiToUsdHuman/cryptoLifiToUsdHuman.ts
@@ -1,12 +1,15 @@
 import type { Token as LifiToken } from '@lifi/sdk'
 import type { BigNumber } from 'lib/bignumber/bignumber'
-import { bnOrZero, toHuman } from 'lib/bignumber/bignumber'
+import { baseUnitToHuman, bnOrZero } from 'lib/bignumber/bignumber'
 
 export const cryptoLifiToUsdHuman = (
   amountCryptoLifi: BigNumber,
   lifiToken: LifiToken,
 ): BigNumber => {
-  const amountCroptoHuman = toHuman({ value: amountCryptoLifi, inputPrecision: lifiToken.decimals })
+  const amountCroptoHuman = baseUnitToHuman({
+    value: amountCryptoLifi,
+    inputPrecision: lifiToken.decimals,
+  })
   const usdRate = bnOrZero(lifiToken.priceUSD)
 
   return amountCroptoHuman.times(usdRate)

--- a/src/lib/swapper/LifiSwapper/utils/transformLifiFeeData/transformLifiFeeData.ts
+++ b/src/lib/swapper/LifiSwapper/utils/transformLifiFeeData/transformLifiFeeData.ts
@@ -3,7 +3,7 @@ import type { AssetId, ChainId } from '@shapeshiftoss/caip'
 import type { EvmChainId } from '@shapeshiftoss/chain-adapters'
 import type { QuoteFeeData } from '@shapeshiftoss/swapper'
 import { APPROVAL_GAS_LIMIT } from '@shapeshiftoss/swapper/dist/swappers/utils/constants'
-import { bn, bnOrZero, toHuman } from 'lib/bignumber/bignumber'
+import { baseUnitToHuman, bn, bnOrZero } from 'lib/bignumber/bignumber'
 import { getEvmChainAdapter } from 'lib/swapper/LifiSwapper/utils/getEvmChainAdapter'
 import { getFeeAssets } from 'lib/swapper/LifiSwapper/utils/getFeeAssets/getFeeAssets'
 import { processGasCosts } from 'lib/swapper/LifiSwapper/utils/processGasCosts/processGasCosts'
@@ -36,9 +36,10 @@ export const transformLifiFeeData = async ({
   const buyAssetTradeFeeUsd =
     buyAssetRouteFeeCosts
       .map(feeCost =>
-        toHuman({ value: feeCost.amount, inputPrecision: feeCost.token.decimals }).multipliedBy(
-          bnOrZero(feeCost.token.priceUSD),
-        ),
+        baseUnitToHuman({
+          value: feeCost.amount,
+          inputPrecision: feeCost.token.decimals,
+        }).multipliedBy(bnOrZero(feeCost.token.priceUSD)),
       )
       .reduce((acc, amountUsd) => acc.plus(amountUsd), bn(0)) ?? bn(0)
 
@@ -47,9 +48,10 @@ export const transformLifiFeeData = async ({
   const initialSellAssetTradeFeeUsd =
     sellAssetRouteFeeCosts
       .map(feeCost =>
-        toHuman({ value: feeCost.amount, inputPrecision: feeCost.token.decimals }).multipliedBy(
-          bnOrZero(feeCost.token.priceUSD),
-        ),
+        baseUnitToHuman({
+          value: feeCost.amount,
+          inputPrecision: feeCost.token.decimals,
+        }).multipliedBy(bnOrZero(feeCost.token.priceUSD)),
       )
       .reduce((acc, amountUsd) => acc.plus(amountUsd), bn(0)) ?? bn(0)
 


### PR DESCRIPTION
## Description

This PR ensures `toHuman` returns a human amount (it was currently returning a precision amount) from a base unit, i.e an amount stripped to 6 dp (what we call a human amount), auto-rounded up/down by BigNumber.js' `.decimalPlaces()`.

While at it, renames it to `baseUnitToHuman` for clarity ~~Adds tests and JSDocs description and examples to make it clear this takes a base unit amount in as input.~~

## Pull Request Type

- [ ] :bug: Bug fix (Non-breaking Change: Fixes an issue)
- [ ] :hammer_and_wrench: Chore (Non-breaking Change: Doc updates, pkg upgrades, typos, etc..)
- [x] :nail_care: New Feature (Breaking/Non-breaking Change)

## Issue (if applicable)

N/A

## Risk

<!-----------------------------------------------------------------------------
Outline the scope of your changes and the risk associated with them. You must use your discretion as an engineer to determine the potential impact of your changes.

E.g. an upgrade to `hdwallet` or core state management would be considered higher risk, and might require a full regression test. UI or isolated view changes, or something behind a feature flag may have near zero risk. Small bug fixes might require testing isolated to the specific fix.
------------------------------------------------------------------------------>

Very small risk, consumption is isolated to:

- Li.Fi trade fee USD ~~though this is going to be mitigated in a follow-up by not using human amounts~~
- Li.Fi minimum USD fee ~~(not an actual issue since we're dealing with a `20` *integer*, not a float, so no loss of precision is going to happen)~~

Disregard my previous comments regarding the two above. We're now *akschually* displaying crypto human amounts as we should, so if anything, things should look better.

## Testing

<!-----------------------------------------------------------------------------
We treat every PR to be merged with the same scrutiny as if we were merging directly to production.

Your PR will not be merged if you do not complete the sections below for our engineering and operations teams to test.
------------------------------------------------------------------------------>

- Tests look sane

### Engineering

<!-----------------------------------------------------------------------------
Include sufficient information here for an engineer to test your PR. This may include how to test locally, in a built environment, changes to infrastructure etc.
------------------------------------------------------------------------------>

- ☝🏽 

### Operations

<!-----------------------------------------------------------------------------
If your changes have a user-facing impact, describe how a non-technical QA team can functionally test your changes in a preview environment.

If they are not user-facing please describe how to test for any regressions that may occur.
------------------------------------------------------------------------------>

None

## Screenshots (if applicable)

<img width="844" alt="image" src="https://user-images.githubusercontent.com/17035424/231758106-52a0e548-b03e-4bc7-9279-cf809702f0d1.png">