### PR TITLE
fix: disable next button on invalid password

### DIFF
--- a/src/context/WalletProvider/NativeWallet/components/EnterPassword.tsx
+++ b/src/context/WalletProvider/NativeWallet/components/EnterPassword.tsx
@@ -150,7 +150,7 @@ export const EnterPassword = () => {
             width='full'
             type='submit'
             isLoading={isSubmitting}
-            disabled={!isValid}
+            isDisabled={!isValid}
             data-test='wallet-password-submit-button'
           >
             <Text translation={'walletProvider.shapeShift.password.button'} />

--- a/src/context/WalletProvider/NativeWallet/components/EnterPassword.tsx
+++ b/src/context/WalletProvider/NativeWallet/components/EnterPassword.tsx
@@ -39,7 +39,7 @@ export const EnterPassword = () => {
     setError,
     handleSubmit,
     register,
-    formState: { errors, isSubmitting },
+    formState: { errors, isSubmitting, isValid },
   } = useForm<NativeWalletValues>({ mode: 'onChange', shouldUnregister: true })
 
   const handleShowClick = () => setShowPw(!showPw)
@@ -150,6 +150,7 @@ export const EnterPassword = () => {
             width='full'
             type='submit'
             isLoading={isSubmitting}
+            disabled={!isValid}
             data-test='wallet-password-submit-button'
           >
             <Text translation={'walletProvider.shapeShift.password.button'} />


### PR DESCRIPTION
## Description

A quick quality of life PR to update the native wallet password "Next" button to be disabled on invalid input.

## Pull Request Type

- [x] :bug: Bug fix (Non-breaking Change: Fixes an issue)
- [ ] :hammer_and_wrench: Chore (Non-breaking Change: Doc updates, pkg upgrades, typos, etc..)
- [ ] :nail_care: New Feature (Breaking/Non-breaking Change)

## Issue (if applicable)

N/A

## Risk

Risk that the logic is incorrect and the user can't click "Next".

## Testing

Enter an invalid input (a password not containing 8 characters) and see that the "Next button is disabled.

<img width="385" alt="Screenshot 2023-04-16 at 11 17 06 am" src="https://user-images.githubusercontent.com/97164662/232260957-cd8c8d6a-20e7-4fa2-923e-53f4fa719b92.png">

<img width="379" alt="Screenshot 2023-04-16 at 11 18 48 am" src="https://user-images.githubusercontent.com/97164662/232261008-2ab4ef53-2dc1-429d-9d63-37efac48a2b2.png">

### Engineering

☝️

### Operations

☝️

## Screenshots (if applicable)

N/A