### PR TITLE
chore: ignore monorail commit and add project references

### DIFF
--- a/.git-blame-ignore-revs
+++ b/.git-blame-ignore-revs
@@ -12,3 +12,5 @@ a19b440bd20285cf4ae1928cd31a449c08c8a1d1
 505516c23b582ff1cd2d684b6c84a117157e3423
 # chore: add array-type lint rule (#1017)
 cfd28ee08c22be19069c5b88d025deb5fc699cef
+# chore: monorail choo choo (#4208)
+1e3429b18e91bf61f235c59c46c2134626e44012

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -34,4 +34,20 @@
   },
   "include": ["src/**/*", "src/**/*.json", "packages/**/*", "packages/**/*.json", "cypress/**/*"],
   "exclude": ["dist", "node_modules", "**/*.test.ts", "**/*.spec.ts", "**/__mocks__", "**/*.js"],
+  "references": [
+    { "path": "./packages/asset-service" },
+    { "path": "./packages/caip" },
+    { "path": "./packages/chain-adapters" },
+    { "path": "./packages/errors" },
+    { "path": "./packages/eslint-plugin-logger" },
+    { "path": "./packages/investor" },
+    { "path": "./packages/investor-foxy" },
+    { "path": "./packages/investor-idle" },
+    { "path": "./packages/investor-yearn" },
+    { "path": "./packages/logger" },
+    { "path": "./packages/market-service" },
+    { "path": "./packages/swapper" },
+    { "path": "./packages/types" },
+    { "path": "./packages/unchained-client" },
+  ]
 }


### PR DESCRIPTION
## Description

- ignore monorail commit for git history (even though lib history unfortunately got squashed...)
- add project references so find by reference links resolve to `.ts` source instead of `.js` dist

## Pull Request Type

- [ ] :bug: Bug fix (Non-breaking Change: Fixes an issue)
- [ ] :hammer_and_wrench: Chore (Non-breaking Change: Doc updates, pkg upgrades, typos, etc..)
- [x] :nail_care: New Feature (Breaking/Non-breaking Change)

## Issue (if applicable)

<!-----------------------------------------------------------------------------
If applicable, please link to the github issue and put `closes #XXXX` in your comment to auto-close the issue that your PR fixes.
------------------------------------------------------------------------------>

closes #

## Risk

None

## Testing

N/A

### Engineering

- you should see import paths resolve to `/src` now to make find by reference more friendly

### Operations

N/A

## Screenshots (if applicable)

![image](https://user-images.githubusercontent.com/35275952/232841865-81266701-a003-4a9a-a16a-134770fdd00a.png)