### PR TITLE
fix: bail on calculating fiat balances without precision

### DIFF
--- a/src/components/Trade/TradeConfirm/TradeConfirm.tsx
+++ b/src/components/Trade/TradeConfirm/TradeConfirm.tsx
@@ -197,6 +197,9 @@ export const TradeConfirm = () => {
     if (!(swapper && trade)) return null
     const compositeBuyAsset = getMaybeCompositeAssetSymbol(trade.buyAsset.assetId, assets)
     const compositeSellAsset = getMaybeCompositeAssetSymbol(trade.sellAsset.assetId, assets)
+    // mixpanel paranoia seeing impossibly high values
+    if (!trade?.sellAsset?.precision) return
+    if (!trade?.buyAsset?.precision) return
     const buyAmountCryptoPrecision = fromBaseUnit(
       buyAmountBeforeFeesBaseUnit,
       trade.sellAsset.precision,

--- a/src/state/slices/common-selectors.ts
+++ b/src/state/slices/common-selectors.ts
@@ -80,6 +80,7 @@ export const selectPortfolioFiatBalances = createDeepEqualOutputSelector(
       const asset = assetsById[assetId]
       if (!asset) return acc
       const precision = asset.precision
+      if (!precision) return acc
       const price = marketData[assetId]?.price
       const cryptoValue = fromBaseUnit(baseUnitBalance, precision)
       const assetFiatBalance = bnOrZero(cryptoValue).times(bnOrZero(price))


### PR DESCRIPTION
## Description

<!-- Please describe your changes -->

we have a user in mixpanel with 39 billion dollars of eth

the only explanation is we were missing eth asset precision, so the balance is inflated by 10^18

## Pull Request Type

- [x] :bug: Bug fix (Non-breaking Change: Fixes an issue)
- [ ] :hammer_and_wrench: Chore (Non-breaking Change: Doc updates, pkg upgrades, typos, etc..)
- [ ] :nail_care: New Feature (Breaking/Non-breaking Change)

## Issue (if applicable)

<!-----------------------------------------------------------------------------
If applicable, please link to the github issue and put `closes #XXXX` in your comment to auto-close the issue that your PR fixes.
------------------------------------------------------------------------------>

n/a

## Risk

low - safer than before

<!-----------------------------------------------------------------------------
Outline the scope of your changes and the risk associated with them. You must use your discretion as an engineer to determine the potential impact of your changes.

E.g. an upgrade to `hdwallet` or core state management would be considered higher risk, and might require a full regression test. UI or isolated view changes, or something behind a feature flag may have near zero risk. Small bug fixes might require testing isolated to the specific fix.
------------------------------------------------------------------------------>

## Testing

<!-----------------------------------------------------------------------------
We treat every PR to be merged with the same scrutiny as if we were merging directly to production.

Your PR will not be merged if you do not complete the sections below for our engineering and operations teams to test.
------------------------------------------------------------------------------>

### Engineering

check my early return is in the right spot?

<!-----------------------------------------------------------------------------
Include sufficient information here for an engineer to test your PR. This may include how to test locally, in a built environment, changes to infrastructure etc.
------------------------------------------------------------------------------>

### Operations

fiat balances should be the same as before

<!-----------------------------------------------------------------------------
If your changes have a user-facing impact, describe how a non-technical QA team can functionally test your changes in a preview environment.

If they are not user-facing please describe how to test for any regressions that may occur.
------------------------------------------------------------------------------>

## Screenshots (if applicable)

<img width="748" alt="image" src="https://user-images.githubusercontent.com/88504456/233151349-0c9ba7b7-3ada-4d09-a200-005d8326bec1.png">

this trade makes no sense