### PR TITLE
perf: optimized asset filtering in zrx and cow swappers

### DIFF
--- a/src/lib/swapper/manager/SwapperManager.test.ts
+++ b/src/lib/swapper/manager/SwapperManager.test.ts
@@ -1,6 +1,6 @@
 import type { ChainId } from '@shapeshiftoss/caip'
 import { Ok } from '@sniptt/monads'
-import { BTC, ETH, FOX, WBTC, WETH } from 'lib/swapper/swappers/utils/test-data/assets'
+import { BSC, BTC, ETH, FOX, WBTC, WETH } from 'lib/swapper/swappers/utils/test-data/assets'
 
 import type { Swapper, SwapperWithQuoteMetadata } from '../api'
 import { SwapperType } from '../api'
@@ -28,7 +28,7 @@ const cowSwapper = getCowSwapper()
 const thorchainSwapper = getThorchainSwapper()
 
 jest.mock('state/slices/selectors', () => {
-  const { BTC, ETH, FOX, WBTC, WETH } = require('lib/swapper/swappers/utils/test-data/assets') // Move the import inside the factory function
+  const { BSC, BTC, ETH, FOX, WBTC, WETH } = require('lib/swapper/swappers/utils/test-data/assets') // Move the import inside the factory function
 
   return {
     selectAssets: () => ({
@@ -37,6 +37,7 @@ jest.mock('state/slices/selectors', () => {
       [FOX.assetId]: FOX,
       [WBTC.assetId]: WBTC,
       [WETH.assetId]: WETH,
+      [BSC.assetId]: BSC,
     }),
   }
 })
@@ -175,7 +176,7 @@ describe('SwapperManager', () => {
   })
 
   describe('getSupportedSellableAssets', () => {
-    it('should return an array of supported sell assetIds', () => {
+    it('should return an array of supported sell assetIds zrx eth mainnet', () => {
       const assetIds = [BTC.assetId, WETH.assetId, FOX.assetId]
 
       const swapperManager = new SwapperManager()
@@ -185,6 +186,15 @@ describe('SwapperManager', () => {
         WETH.assetId,
         FOX.assetId,
       ])
+    })
+
+    it('should return an array of supported sell assetIds zrx bsc', () => {
+      const assetIds = [BSC.assetId, FOX.assetId]
+
+      const swapperManager = new SwapperManager()
+      swapperManager.addSwapper(zrxBscSwapper)
+
+      expect(swapperManager.getSupportedSellableAssetIds({ assetIds })).toStrictEqual([BSC.assetId])
     })
 
     it('should return unique assetIds', () => {

--- a/src/lib/swapper/manager/SwapperManager.test.ts
+++ b/src/lib/swapper/manager/SwapperManager.test.ts
@@ -162,9 +162,9 @@ describe('SwapperManager', () => {
     })
 
     it('should return unique assetIds', () => {
-      const assetIds = [BTC.assetId, WETH.assetId, FOX.assetId, FOX.assetId]
+      const assetIds = [BTC.assetId, WETH.assetId, WETH.assetId, FOX.assetId]
 
-      const sellAssetId = 'eip155:1/erc20:0xc770eefad204b5180df6a14ee197d99d808ee52d'
+      const sellAssetId = FOX.assetId
       const swapperManager = new SwapperManager()
       swapperManager.addSwapper(zrxEthereumSwapper)
 

--- a/src/lib/swapper/swappers/CowSwapper/CowSwapper.test.ts
+++ b/src/lib/swapper/swappers/CowSwapper/CowSwapper.test.ts
@@ -2,10 +2,10 @@ import type { ethereum } from '@shapeshiftoss/chain-adapters'
 import type { HDWallet } from '@shapeshiftoss/hdwallet-core'
 import type { KnownChainIds } from '@shapeshiftoss/types'
 import type Web3 from 'web3'
+import { BTC, ETH, FOX, WBTC, WETH } from 'lib/swapper/swappers/utils/test-data/assets'
 
 import type { TradeResult } from '../../api'
 import { SwapperName, SwapperType } from '../../api'
-import { BTC, ETH, FOX, WBTC, WETH } from '../utils/test-data/assets'
 import { setupBuildTrade, setupQuote } from '../utils/test-data/setupSwapQuote'
 import { cowApprovalNeeded } from './cowApprovalNeeded/cowApprovalNeeded'
 import { cowApproveAmount, cowApproveInfinite } from './cowApprove/cowApprove'
@@ -19,6 +19,19 @@ import type { CowTrade } from './types'
 import { getUsdRate } from './utils/helpers/helpers'
 
 jest.mock('./utils/helpers/helpers')
+jest.mock('state/slices/selectors', () => {
+  const { BTC, ETH, FOX, WBTC, WETH } = require('lib/swapper/swappers/utils/test-data/assets') // Move the import inside the factory function
+
+  return {
+    selectAssets: () => ({
+      [BTC.assetId]: BTC,
+      [ETH.assetId]: ETH,
+      [FOX.assetId]: FOX,
+      [WBTC.assetId]: WBTC,
+      [WETH.assetId]: WETH,
+    }),
+  }
+})
 
 jest.mock('./cowApprovalNeeded/cowApprovalNeeded', () => ({
   cowApprovalNeeded: jest.fn(),

--- a/src/lib/swapper/swappers/ZrxSwapper/ZrxSwapper.ts
+++ b/src/lib/swapper/swappers/ZrxSwapper/ZrxSwapper.ts
@@ -1,6 +1,5 @@
 import type { Asset } from '@shapeshiftoss/asset-service'
 import type { AssetId, ChainId } from '@shapeshiftoss/caip'
-import { fromAssetId } from '@shapeshiftoss/caip'
 import type { avalanche, bnbsmartchain, ethereum, optimism } from '@shapeshiftoss/chain-adapters'
 import { KnownChainIds } from '@shapeshiftoss/types'
 import type { Result } from '@sniptt/monads'
@@ -35,6 +34,8 @@ import {
 } from 'lib/swapper/swappers/ZrxSwapper/zrxApprove/zrxApprove'
 import { zrxBuildTrade } from 'lib/swapper/swappers/ZrxSwapper/zrxBuildTrade/zrxBuildTrade'
 import { zrxExecuteTrade } from 'lib/swapper/swappers/ZrxSwapper/zrxExecuteTrade/zrxExecuteTrade'
+import { selectAssets } from 'state/slices/selectors'
+import { store } from 'state/store'
 
 export type ZrxSupportedChainId =
   | KnownChainIds.EthereumMainnet
@@ -105,17 +106,19 @@ export class ZrxSwapper<T extends ZrxSupportedChainId> implements Swapper<T> {
 
   filterBuyAssetsBySellAssetId(args: BuyAssetBySellIdInput): AssetId[] {
     const { assetIds = [], sellAssetId } = args
+    const assets = selectAssets(store.getState())
     return assetIds.filter(
       id =>
-        fromAssetId(id).chainId === this.chainId &&
-        fromAssetId(sellAssetId).chainId === this.chainId &&
+        assets[id]?.chainId === this.chainId &&
+        assets[sellAssetId]?.chainId === this.chainId &&
         !UNSUPPORTED_ASSETS.includes(id),
     )
   }
 
   filterAssetIdsBySellable(assetIds: AssetId[] = []): AssetId[] {
+    const assets = selectAssets(store.getState())
     return assetIds.filter(
-      id => fromAssetId(id).chainId === this.chainId && !UNSUPPORTED_ASSETS.includes(id),
+      id => assets[id]?.chainId === this.chainId && !UNSUPPORTED_ASSETS.includes(id),
     )
   }
 


### PR DESCRIPTION
## Description

This PR improved the performance of ZRX and Cow swappers to reduce app load time be ~1.24s, and reduces glitching during trade input.

## Pull Request Type

- [ ] :bug: Bug fix (Non-breaking Change: Fixes an issue)
- [x] :hammer_and_wrench: Chore (Non-breaking Change: Doc updates, pkg upgrades, typos, etc..)
- [ ] :nail_care: New Feature (Breaking/Non-breaking Change)

## Issue (if applicable)

<!-----------------------------------------------------------------------------
If applicable, please link to the github issue and put `closes #XXXX` in your comment to auto-close the issue that your PR fixes.
------------------------------------------------------------------------------>

NA

## Risk

<!-----------------------------------------------------------------------------
Outline the scope of your changes and the risk associated with them. You must use your discretion as an engineer to determine the potential impact of your changes.

E.g. an upgrade to `hdwallet` or core state management would be considered higher risk, and might require a full regression test. UI or isolated view changes, or something behind a feature flag may have near zero risk. Small bug fixes might require testing isolated to the specific fix.
------------------------------------------------------------------------------>

- Minor risk of asset filtering broken. This should would at worst display "invalid trade pair" or prevent assets being selected - would not break actual trades

## Testing

<!-----------------------------------------------------------------------------
We treat every PR to be merged with the same scrutiny as if we were merging directly to production.

Your PR will not be merged if you do not complete the sections below for our engineering and operations teams to test.
------------------------------------------------------------------------------>

- Automated tests updated. 
- Manually tested to check assets are being displayed as expected.

Performance before changes - 1240 milliseconds
![image.png](https://graphite-user-uploaded-assets-prod.s3.amazonaws.com/fWy9zaB1RnMsjKC90SgH/ecbc8b69-64fb-432a-bdb5-7883f694d4c6/image.png)

Performance after changes - 74 milliseconds
![image.png](https://graphite-user-uploaded-assets-prod.s3.amazonaws.com/fWy9zaB1RnMsjKC90SgH/acf1afe3-f2bb-4b6d-954a-a5e3923a2fe1/image.png)


### Engineering

<!-----------------------------------------------------------------------------
Include sufficient information here for an engineer to test your PR. This may include how to test locally, in a built environment, changes to infrastructure etc.
------------------------------------------------------------------------------>

### Operations

<!-----------------------------------------------------------------------------
If your changes have a user-facing impact, describe how a non-technical QA team can functionally test your changes in a preview environment.

If they are not user-facing please describe how to test for any regressions that may occur.
------------------------------------------------------------------------------>

- This is user facing
- Test that trade pairs are working as expected against production. Available assets and trade pairs should be identical to production.

## Screenshots (if applicable)

