### PR TITLE
chore: break out AssetSearchModal out of modal provider

### DIFF
--- a/src/components/AssetHeader/AssetActions.tsx
+++ b/src/components/AssetHeader/AssetActions.tsx
@@ -8,7 +8,6 @@ import { FaCreditCard } from 'react-icons/fa'
 import { IoSwapVertical } from 'react-icons/io5'
 import { useTranslate } from 'react-polyglot'
 import { useHistory } from 'react-router-dom'
-import { FiatRampAction } from 'components/Modals/FiatRamps/FiatRampsCommon'
 import { getChainAdapterManager } from 'context/PluginProvider/chainAdapterSingleton'
 import { WalletActions } from 'context/WalletProvider/actions'
 import { useFeatureFlag } from 'hooks/useFeatureFlag/useFeatureFlag'
@@ -62,7 +61,6 @@ export const AssetActions: React.FC<AssetActionProps> = ({ assetId, accountId, c
   const handleBuySellClick = useCallback(() => {
     fiatRamps.open({
       assetId: assetSupportsBuy ? assetId : ethAssetId,
-      fiatRampAction: FiatRampAction.Buy,
       accountId,
     })
   }, [accountId, assetId, assetSupportsBuy, fiatRamps])

--- a/src/components/Modals/AssetSearch/AssetSearchModal.tsx
+++ b/src/components/Modals/AssetSearch/AssetSearchModal.tsx
@@ -13,40 +13,43 @@ import { useCallback } from 'react'
 import { useTranslate } from 'react-polyglot'
 import type { AssetSearchProps } from 'components/AssetSearch/AssetSearch'
 import { AssetSearch } from 'components/AssetSearch/AssetSearch'
-import { useModal } from 'hooks/useModal/useModal'
 import { useWindowSize } from 'hooks/useWindowSize/useWindowSize'
 import { breakpoints } from 'theme/theme'
 
 interface AssetSearchModalProps extends AssetSearchProps {
-  onClick: Required<AssetSearchProps>['onClick']
+  isOpen: boolean
   title?: string
+  onClick: Required<AssetSearchProps>['onClick']
+  onClose: () => void
 }
 
 export const AssetSearchModal: FC<AssetSearchModalProps> = ({
-  onClick,
   assets,
   disableUnsupported,
+  isOpen,
   title = 'common.selectAsset',
+  onClick,
+  onClose,
 }) => {
   const translate = useTranslate()
   const [isLargerThanMd] = useMediaQuery(`(min-width: ${breakpoints['md']})`, { ssr: false })
   const { height: windowHeight } = useWindowSize()
-  const {
-    assetSearch: { close, isOpen },
-  } = useModal()
+
   const handleClick = useCallback(
     (asset: Asset) => {
       onClick(asset)
-      close()
+      onClose()
     },
-    [close, onClick],
+    [onClose, onClick],
   )
+
   const modalHeight = windowHeight
     ? // Converts pixel units to vh for Modal component
       Math.min(Math.round((680 / windowHeight) * 100), 80)
     : 80
+
   return (
-    <Modal isOpen={isOpen} onClose={close} isCentered={isLargerThanMd} trapFocus={false}>
+    <Modal isOpen={isOpen} onClose={onClose} isCentered={isLargerThanMd} trapFocus={false}>
       <ModalOverlay />
       <ModalContent height={`${modalHeight}vh`}>
         <ModalHeader>{translate(title)}</ModalHeader>

--- a/src/components/Modals/FiatRamps/FiatRampsModal.tsx
+++ b/src/components/Modals/FiatRamps/FiatRampsModal.tsx
@@ -5,19 +5,12 @@ import { FiatForm } from 'components/Modals/FiatRamps/views/FiatForm'
 import { useModal } from 'hooks/useModal/useModal'
 import { breakpoints } from 'theme/theme'
 
-import type { FiatRampAction } from './FiatRampsCommon'
-
 type FiatRampsModalProps = {
   assetId: AssetId
   accountId?: AccountId
-  fiatRampAction: FiatRampAction
 }
 
-export const FiatRampsModal: React.FC<FiatRampsModalProps> = ({
-  fiatRampAction,
-  assetId,
-  accountId,
-}) => {
+export const FiatRampsModal: React.FC<FiatRampsModalProps> = ({ assetId, accountId }) => {
   const { fiatRamps } = useModal()
   const { close, isOpen } = fiatRamps
   const [isLargerThanMd] = useMediaQuery(`(min-width: ${breakpoints['md']})`, { ssr: false })
@@ -38,7 +31,7 @@ export const FiatRampsModal: React.FC<FiatRampsModalProps> = ({
         minWidth={{ base: '100%', md: '500px' }}
         maxWidth={{ base: 'full', md: '500px' }}
       >
-        <FiatForm assetId={assetId} fiatRampAction={fiatRampAction} accountId={accountId} />
+        <FiatForm assetId={assetId} accountId={accountId} />
       </ModalContent>
     </Modal>
   )

--- a/src/components/Modals/FiatRamps/views/Overview.tsx
+++ b/src/components/Modals/FiatRamps/views/Overview.tsx
@@ -58,21 +58,19 @@ type OverviewProps = {
   address: string
   vanityAddress: string
   assetId: AssetId
-  defaultAction: FiatRampAction
   handleIsSelectingAsset: (fiatRampAction: FiatRampAction) => void
   handleAccountIdChange: (accountId: AccountId) => void
 }
 
 export const Overview: React.FC<OverviewProps> = ({
   handleIsSelectingAsset,
-  defaultAction = FiatRampAction.Buy,
   assetId,
   handleAccountIdChange,
   accountId,
   address,
   vanityAddress,
 }) => {
-  const [fiatRampAction, setFiatRampAction] = useState<FiatRampAction>(defaultAction)
+  const [fiatRampAction, setFiatRampAction] = useState<FiatRampAction>(FiatRampAction.Buy)
   const [fiatCurrency, setFiatCurrency] = useState<CommonFiatCurrencies>('USD')
   const { popup } = useModal()
   const selectedLocale = useAppSelector(selectSelectedLocale)

--- a/src/context/ModalProvider/ModalProvider.tsx
+++ b/src/context/ModalProvider/ModalProvider.tsx
@@ -2,7 +2,6 @@ import noop from 'lodash/noop'
 import React, { useCallback, useMemo, useReducer } from 'react'
 import { WipeModal } from 'components/Layout/Header/NavBar/KeepKey/Modals/Wipe'
 import { BackupPassphraseModal } from 'components/Layout/Header/NavBar/Native/BackupPassphraseModal/BackupPassphraseModal'
-import { AssetSearchModal } from 'components/Modals/AssetSearch/AssetSearchModal'
 import { FiatRampsModal } from 'components/Modals/FiatRamps/FiatRampsModal'
 import { LiveSupportModal } from 'components/Modals/LiveSupport/LiveSupport'
 import { MobileWelcomeModal } from 'components/Modals/MobileWelcome/MobileWelcomeModal'
@@ -28,7 +27,6 @@ const MODALS = {
   backupNativePassphrase: BackupPassphraseModal,
   mobileWelcomeModal: MobileWelcomeModal,
   addAccount: AddAccountModal,
-  assetSearch: AssetSearchModal,
   popup: PopupWindowModal,
   nativeOnboard: NativeOnboarding,
   liveSupport: LiveSupportModal,

--- a/src/features/defi/providers/idle/components/IdleManager/Overview/IdleEmpty.tsx
+++ b/src/features/defi/providers/idle/components/IdleManager/Overview/IdleEmpty.tsx
@@ -22,7 +22,6 @@ import JuniorTrancheIcon from 'assets/junior-tranche.svg'
 import SeniorTrancheIcon from 'assets/senior-tranche.svg'
 import { AssetIcon } from 'components/AssetIcon'
 import { Carousel } from 'components/Carousel/Carousel'
-import { FiatRampAction } from 'components/Modals/FiatRamps/FiatRampsCommon'
 import { SlideTransition } from 'components/SlideTransition'
 import { Text } from 'components/Text'
 import { useModal } from 'hooks/useModal/useModal'
@@ -115,7 +114,7 @@ export const IdleEmpty = ({ assetId, onClick, tags, apy }: IdleEmptyProps) => {
   )
 
   const handleAssetBuyClick = useCallback(() => {
-    openFiatRamp({ assetId, fiatRampAction: FiatRampAction.Buy })
+    openFiatRamp({ assetId })
   }, [assetId, openFiatRamp])
 
   const renderFooter = useMemo(() => {

--- a/src/features/defi/providers/thorchain-savers/components/ThorchainSaversManager/Overview/ThorchainSaversEmpty.tsx
+++ b/src/features/defi/providers/thorchain-savers/components/ThorchainSaversManager/Overview/ThorchainSaversEmpty.tsx
@@ -6,7 +6,6 @@ import { useCallback, useMemo } from 'react'
 import { useTranslate } from 'react-polyglot'
 import SaversVaultTop from 'assets/savers-vault-top.png'
 import { AssetIcon } from 'components/AssetIcon'
-import { FiatRampAction } from 'components/Modals/FiatRamps/FiatRampsCommon'
 import { RawText, Text } from 'components/Text'
 import { useModal } from 'hooks/useModal/useModal'
 import { bnOrZero } from 'lib/bignumber/bignumber'
@@ -37,7 +36,7 @@ export const ThorchainSaversEmpty = ({ assetId, onClick }: ThorchainSaversEmptyP
   )
 
   const handleAssetBuyClick = useCallback(() => {
-    openFiatRamp({ assetId, fiatRampAction: FiatRampAction.Buy })
+    openFiatRamp({ assetId })
   }, [assetId, openFiatRamp])
 
   const renderFooter = useMemo(() => {

--- a/src/pages/Buy/Buy.tsx
+++ b/src/pages/Buy/Buy.tsx
@@ -9,7 +9,6 @@ import FoxPane from 'assets/fox-cta-pane.png'
 import { Card } from 'components/Card/Card'
 import { Main } from 'components/Layout/Main'
 import { SEO } from 'components/Layout/Seo'
-import { FiatRampAction } from 'components/Modals/FiatRamps/FiatRampsCommon'
 import { FiatForm } from 'components/Modals/FiatRamps/views/FiatForm'
 import { Text } from 'components/Text'
 import { WalletActions } from 'context/WalletProvider/actions'
@@ -85,7 +84,7 @@ export const Buy = () => {
             </Flex>
             <Box flexBasis='400px'>
               <Card mx={{ base: -4, md: 0 }}>
-                <FiatForm assetId={selectedAssetId} fiatRampAction={FiatRampAction.Buy} />
+                <FiatForm assetId={selectedAssetId} />
               </Card>
             </Box>
           </Flex>

--- a/src/pages/Buy/TopAssets.tsx
+++ b/src/pages/Buy/TopAssets.tsx
@@ -5,7 +5,6 @@ import { useTranslate } from 'react-polyglot'
 import { useSelector } from 'react-redux'
 import type { Column, Row } from 'react-table'
 import { Amount } from 'components/Amount/Amount'
-import { FiatRampAction } from 'components/Modals/FiatRamps/FiatRampsCommon'
 import { ReactTable } from 'components/ReactTable/ReactTable'
 import { AssetCell } from 'components/StakingVaults/Cells'
 import { Text } from 'components/Text'
@@ -81,10 +80,7 @@ export const TopAssets: React.FC = () => {
     [],
   )
 
-  const handleClick = useCallback(
-    (assetId: AssetId) => fiatRamps.open({ assetId, fiatRampAction: FiatRampAction.Buy }),
-    [fiatRamps],
-  )
+  const handleClick = useCallback((assetId: AssetId) => fiatRamps.open({ assetId }), [fiatRamps])
 
   return (
     <Box>

--- a/src/plugins/arkeo/FoxTokenHolders.tsx
+++ b/src/plugins/arkeo/FoxTokenHolders.tsx
@@ -5,7 +5,6 @@ import { useTranslate } from 'react-polyglot'
 import { useHistory } from 'react-router'
 import { AssetIcon } from 'components/AssetIcon'
 import { Card } from 'components/Card/Card'
-import { FiatRampAction } from 'components/Modals/FiatRamps/FiatRampsCommon'
 import { Text } from 'components/Text'
 import { useModal } from 'hooks/useModal/useModal'
 import { getMixPanel } from 'lib/mixpanel/mixPanelSingleton'
@@ -26,7 +25,6 @@ export const FoxTokenHolders = () => {
   const handleBuySellClick = useCallback(() => {
     fiatRamps.open({
       assetId: foxAssetId,
-      fiatRampAction: FiatRampAction.Buy,
     })
   }, [fiatRamps])
 


### PR DESCRIPTION
## Description

This change moves the asset search modal out of the modal provider.

## Pull Request Type

- [ ] :bug: Bug fix (Non-breaking Change: Fixes an issue)
- [x] :hammer_and_wrench: Chore (Non-breaking Change: Doc updates, pkg upgrades, typos, etc..)
- [ ] :nail_care: New Feature (Breaking/Non-breaking Change)

## Issue (if applicable)

<!-----------------------------------------------------------------------------
If applicable, please link to the github issue and put `closes #XXXX` in your comment to auto-close the issue that your PR fixes.
------------------------------------------------------------------------------>

NA

## Risk

- low risk of asset search modal not opening/closing correctly
- low risk of asset search modal not rendering correctly (might be hidden, appear behind components, not centered or something)

<!-----------------------------------------------------------------------------
Outline the scope of your changes and the risk associated with them. You must use your discretion as an engineer to determine the potential impact of your changes.

E.g. an upgrade to `hdwallet` or core state management would be considered higher risk, and might require a full regression test. UI or isolated view changes, or something behind a feature flag may have near zero risk. Small bug fixes might require testing isolated to the specific fix.
------------------------------------------------------------------------------>

## Testing

<!-----------------------------------------------------------------------------
We treat every PR to be merged with the same scrutiny as if we were merging directly to production.

Your PR will not be merged if you do not complete the sections below for our engineering and operations teams to test.
------------------------------------------------------------------------------>

Have tested asset search modal is working correctly around the app.

### Engineering

Prop drilling of `fiatRampAction` is removed because it is always the same value for all usages, which also aligns with the default inside `src/components/Modals/FiatRamps/views/Overview.tsx` -- which is `FiatRampAction.Buy`

### Operations

- This change is user facing
- Should have no change in behavior whatsoever - this is intended to reduce code complexity and improve performance later

## Screenshots (if applicable)
