### PR TITLE
feat: don't double count portfolio and staked amounts

### DIFF
--- a/src/state/slices/portfolioSlice/selectors.ts
+++ b/src/state/slices/portfolioSlice/selectors.ts
@@ -424,9 +424,18 @@ export const selectPortfolioAccountsCryptoBalancesIncludingStaking = createDeepE
       (acc, [accountId, account]) => {
         if (!acc[accountId]) acc[accountId] = {}
         Object.entries(account).forEach(([assetId, balance]) => {
-          acc[accountId][assetId] = bnOrZero(balance)
-            .plus(bnOrZero(stakingBalances[accountId]?.[assetId]))
-            .toString()
+          const accountAssetStakingBalance = stakingBalances[accountId]?.[assetId]
+          // TODO(gomes): This is a temporary fix until we figure out the DeFi heuristics for isDefiOpportunity or similarly named property
+          // i.e a property that will allow us to know whether or not a wallet asset is exclusively used as a DeFi opportunity
+          // This is obviously a suboptimal fix as if you stake the exact same amount (to the smallest base unit) of an asset as you have in your wallet,
+          // it would not be counted in crypto (and hence fiat) total
+          if (accountAssetStakingBalance === balance) {
+            acc[accountId][assetId] = bnOrZero(balance).toString()
+          } else {
+            acc[accountId][assetId] = bnOrZero(balance)
+              .plus(bnOrZero(accountAssetStakingBalance))
+              .toString()
+          }
         })
         return acc
       },


### PR DESCRIPTION
## Description

<!-- Please describe your changes -->

## Pull Request Type

- [x] :bug: Bug fix (Non-breaking Change: Fixes an issue)
- [ ] :hammer_and_wrench: Chore (Non-breaking Change: Doc updates, pkg upgrades, typos, etc..)
- [ ] :nail_care: New Feature (Breaking/Non-breaking Change)

## Issue (if applicable)

closes https://github.com/shapeshift/web/issues/4328 implementing the best naive implementation - doesn't tackle `isDefi` yet which will be a bigger lift and needs to be discussed

## Risk

<!-----------------------------------------------------------------------------
Outline the scope of your changes and the risk associated with them. You must use your discretion as an engineer to determine the potential impact of your changes.

E.g. an upgrade to `hdwallet` or core state management would be considered higher risk, and might require a full regression test. UI or isolated view changes, or something behind a feature flag may have near zero risk. Small bug fixes might require testing isolated to the specific fix.
------------------------------------------------------------------------------>

Low/medium - see comment. If you have the *exact* same amount staked, to the base unit, this will produce regressions. Given this is only a temporary fix and you usually wouldn't have the same staked and wallet balance for a given asset across accounts/for an account, up to the smallest unit, that's probably a low enough risk until we tackle this holistically

## Testing

<!-----------------------------------------------------------------------------
We treat every PR to be merged with the same scrutiny as if we were merging directly to production.

Your PR will not be merged if you do not complete the sections below for our engineering and operations teams to test.
------------------------------------------------------------------------------>

- Go to an Idle asset you're staked in
- Ensure balances are matching the ones in Etherscan
- Ensure accounts page balance looks good
- Ensure there are no regressions across other opportunities in asset page i.e ETH/FOX LP, Osmosis LP
### Engineering

<!-----------------------------------------------------------------------------
Include sufficient information here for an engineer to test your PR. This may include how to test locally, in a built environment, changes to infrastructure etc.
------------------------------------------------------------------------------>

### Operations

<!-----------------------------------------------------------------------------
If your changes have a user-facing impact, describe how a non-technical QA team can functionally test your changes in a preview environment.

If they are not user-facing please describe how to test for any regressions that may occur.
------------------------------------------------------------------------------>

- ☝🏽 

## Screenshots (if applicable)

- This diff

<img width="898" alt="image" src="https://user-images.githubusercontent.com/17035424/233609926-3bd24095-2968-469c-a8df-cea061982ef8.png">

- Prod

<img width="893" alt="image" src="https://user-images.githubusercontent.com/17035424/233609967-ee1a40a2-edaf-4aea-8f9f-09bf8de68707.png">

- Explorer

<img width="282" alt="image" src="https://user-images.githubusercontent.com/17035424/233610035-f0c391a5-5efc-4e55-8211-b04acd2073fb.png">
