### PR TITLE
perf: don't compute icons for dynamic LP pairs

### DIFF
--- a/src/state/slices/assetsSlice/assetsSlice.ts
+++ b/src/state/slices/assetsSlice/assetsSlice.ts
@@ -2,7 +2,7 @@ import type { PayloadAction } from '@reduxjs/toolkit'
 import { createSlice } from '@reduxjs/toolkit'
 import { createApi } from '@reduxjs/toolkit/dist/query/react'
 import type { Asset } from '@shapeshiftoss/asset-service'
-import { AssetService, getRenderedIdenticonBase64 } from '@shapeshiftoss/asset-service'
+import { AssetService } from '@shapeshiftoss/asset-service'
 import type { AssetId } from '@shapeshiftoss/caip'
 import {
   bscChainId,
@@ -79,10 +79,8 @@ export const makeAsset = (minimalAsset: MinimalAsset): Asset => {
     return fromAssetId(assetId).chainId
   })()
 
-  const icon = (() => {
-    if (minimalAsset.icon) return minimalAsset.icon
-    return getRenderedIdenticonBase64(assetId)
-  })()
+  // currently, dynamic assets are LP pairs, and they have two icon urls and are rendered differently
+  const icon = minimalAsset?.icon ?? ''
 
   type ExplorerLinks = Pick<Asset, 'explorer' | 'explorerTxLink' | 'explorerAddressLink'>
 
@@ -97,13 +95,7 @@ export const makeAsset = (minimalAsset: MinimalAsset): Asset => {
     }
   })()
 
-  return {
-    ...minimalAsset,
-    ...explorerLinks,
-    chainId,
-    color,
-    icon,
-  }
+  return Object.assign({}, minimalAsset, explorerLinks, { chainId, color, icon })
 }
 
 export const assets = createSlice({


### PR DESCRIPTION
## Description

<!-- Please describe your changes -->

this was taking ~800ms on app load to generate icons for LP pairs, that we never actually used

## Pull Request Type

- [ ] :bug: Bug fix (Non-breaking Change: Fixes an issue)
- [x] :hammer_and_wrench: Chore (Non-breaking Change: Doc updates, pkg upgrades, typos, etc..)
- [ ] :nail_care: New Feature (Breaking/Non-breaking Change)

## Issue (if applicable)

<!-----------------------------------------------------------------------------
If applicable, please link to the github issue and put `closes #XXXX` in your comment to auto-close the issue that your PR fixes.
------------------------------------------------------------------------------>

n/a - more perf things

## Risk

LP pairs don't render correctly

<!-----------------------------------------------------------------------------
Outline the scope of your changes and the risk associated with them. You must use your discretion as an engineer to determine the potential impact of your changes.

E.g. an upgrade to `hdwallet` or core state management would be considered higher risk, and might require a full regression test. UI or isolated view changes, or something behind a feature flag may have near zero risk. Small bug fixes might require testing isolated to the specific fix.
------------------------------------------------------------------------------>

## Testing

check the earn section, see LP pairs appear as expected

<!-----------------------------------------------------------------------------
We treat every PR to be merged with the same scrutiny as if we were merging directly to production.

Your PR will not be merged if you do not complete the sections below for our engineering and operations teams to test.
------------------------------------------------------------------------------>

### Engineering

<!-----------------------------------------------------------------------------
Include sufficient information here for an engineer to test your PR. This may include how to test locally, in a built environment, changes to infrastructure etc.
------------------------------------------------------------------------------>

### Operations

<!-----------------------------------------------------------------------------
If your changes have a user-facing impact, describe how a non-technical QA team can functionally test your changes in a preview environment.

If they are not user-facing please describe how to test for any regressions that may occur.
------------------------------------------------------------------------------>

## Screenshots (if applicable)

no visual difference - LP pairs show both underlying asset icons side by side
