### PR TITLE
perf: batch reducers

### DIFF
--- a/src/state/slices/marketDataSlice/marketDataSlice.tsx
+++ b/src/state/slices/marketDataSlice/marketDataSlice.tsx
@@ -1,4 +1,4 @@
-import { createSlice } from '@reduxjs/toolkit'
+import { createSlice, prepareAutoBatched } from '@reduxjs/toolkit'
 import { createApi } from '@reduxjs/toolkit/dist/query/react'
 import type { AssetId } from '@shapeshiftoss/caip'
 import { fromAssetId } from '@shapeshiftoss/caip'
@@ -20,6 +20,7 @@ import type {
 } from 'state/slices/marketDataSlice/types'
 
 import { foxEthLpAssetId } from '../opportunitiesSlice/constants'
+import type { MarketDataById } from './types'
 
 const moduleLogger = logger.child({ namespace: ['marketDataSlice'] })
 
@@ -51,32 +52,42 @@ export const defaultMarketData: MarketData = {
   changePercent24Hr: 0,
 }
 
+type CryptoPriceHistoryPayload = { data: HistoryData[]; args: FindPriceHistoryByAssetIdArgs }
+
 export const marketData = createSlice({
   name: 'marketData',
   initialState,
   reducers: {
     clear: () => initialState,
-    setCryptoMarketData: (state, { payload }) => {
-      state.crypto.byId = { ...state.crypto.byId, ...payload } // upsert
-      const ids = Array.from(new Set([...state.crypto.ids, ...Object.keys(payload)]))
-      state.crypto.ids = ids // upsert unique
+    setCryptoMarketData: {
+      reducer: (state, { payload }: { payload: MarketDataById<AssetId> }) => {
+        state.crypto.byId = merge(state.crypto.byId, payload) // upsert
+        // upsert unique
+        state.crypto.ids = Array.from(new Set(state.crypto.ids.concat(Object.keys(payload))))
+      },
+
+      // Use the `prepareAutoBatched` utility to automatically
+      // add the `action.meta[SHOULD_AUTOBATCH]` field the enhancer needs
+      prepare: prepareAutoBatched<MarketDataById<AssetId>>(),
     },
-    setCryptoPriceHistory: (
-      state,
-      { payload }: { payload: { data: HistoryData[]; args: FindPriceHistoryByAssetIdArgs } },
-    ) => {
-      const { args, data } = payload
-      const { assetId, timeframe } = args
-      const incoming = {
-        crypto: {
-          priceHistory: {
-            [timeframe]: {
-              [assetId]: data,
+    setCryptoPriceHistory: {
+      reducer: (state, { payload }: { payload: CryptoPriceHistoryPayload }) => {
+        const { args } = payload
+        const { assetId, timeframe } = args
+        const incoming = {
+          crypto: {
+            priceHistory: {
+              [timeframe]: {
+                [assetId]: payload.data,
+              },
             },
           },
-        },
-      }
-      merge(state, incoming)
+        }
+        merge(state, incoming)
+      },
+      // Use the `prepareAutoBatched` utility to automatically
+      // add the `action.meta[SHOULD_AUTOBATCH]` field the enhancer needs
+      prepare: prepareAutoBatched<CryptoPriceHistoryPayload>(),
     },
     setFiatMarketData: (
       state,

--- a/src/state/slices/marketDataSlice/marketDataSlice.tsx
+++ b/src/state/slices/marketDataSlice/marketDataSlice.tsx
@@ -63,7 +63,7 @@ export const marketData = createSlice({
       reducer: (state, { payload }: { payload: MarketDataById<AssetId> }) => {
         state.crypto.byId = merge(state.crypto.byId, payload) // upsert
         // upsert unique
-        state.crypto.ids = Array.from(new Set(state.crypto.ids.concat(Object.keys(payload))))
+        state.crypto.ids = Object.keys(state.crypto.byId)
       },
 
       // Use the `prepareAutoBatched` utility to automatically

--- a/src/state/slices/marketDataSlice/marketDataSlice.tsx
+++ b/src/state/slices/marketDataSlice/marketDataSlice.tsx
@@ -61,8 +61,7 @@ export const marketData = createSlice({
     clear: () => initialState,
     setCryptoMarketData: {
       reducer: (state, { payload }: { payload: MarketDataById<AssetId> }) => {
-        state.crypto.byId = merge(state.crypto.byId, payload) // upsert
-        // upsert unique
+        state.crypto.byId = Object.assign(state.crypto.byId, payload) // upsert
         state.crypto.ids = Object.keys(state.crypto.byId)
       },
 

--- a/src/state/slices/opportunitiesSlice/opportunitiesSlice.ts
+++ b/src/state/slices/opportunitiesSlice/opportunitiesSlice.ts
@@ -3,7 +3,6 @@ import { createApi } from '@reduxjs/toolkit/query/react'
 import type { AccountId } from '@shapeshiftoss/caip'
 import { fromAccountId } from '@shapeshiftoss/caip'
 import { DefiProvider } from 'features/defi/contexts/DefiManagerProvider/DefiCommon'
-import merge from 'lodash/merge'
 import { PURGE } from 'redux-persist'
 import { logger } from 'lib/logger'
 import { BASE_RTK_CREATE_API_CONFIG } from 'state/apis/const'
@@ -83,11 +82,7 @@ export const opportunities = createSlice({
     clear: () => initialState,
     upsertOpportunityMetadata: {
       reducer: (draftState, { payload }: { payload: GetOpportunityMetadataOutput }) => {
-        draftState[payload.type].byId = Object.assign(
-          {},
-          draftState[payload.type].byId,
-          payload.byId,
-        )
+        draftState[payload.type].byId = Object.assign(draftState[payload.type].byId, payload.byId)
         draftState[payload.type].ids = Object.keys(draftState[payload.type].byId)
       },
       // Use the `prepareAutoBatched` utility to automatically
@@ -96,7 +91,7 @@ export const opportunities = createSlice({
     },
     upsertOpportunityAccounts: {
       reducer: (draftState, { payload }: { payload: GetOpportunityUserDataOutput }) => {
-        draftState[payload.type].byAccountId = merge(
+        draftState[payload.type].byAccountId = Object.assign(
           draftState[payload.type].byAccountId,
           payload.byAccountId,
         )
@@ -107,7 +102,7 @@ export const opportunities = createSlice({
     },
     upsertUserStakingOpportunities: {
       reducer: (draftState, { payload }: { payload: GetOpportunityUserStakingDataOutput }) => {
-        draftState.userStaking.byId = merge(draftState.userStaking.byId, payload.byId)
+        draftState.userStaking.byId = Object.assign(draftState.userStaking.byId, payload.byId)
         draftState.userStaking.ids = Object.keys(draftState.userStaking.byId) as UserStakingId[]
       },
 

--- a/src/state/slices/opportunitiesSlice/opportunitiesSlice.ts
+++ b/src/state/slices/opportunitiesSlice/opportunitiesSlice.ts
@@ -4,7 +4,6 @@ import type { AccountId } from '@shapeshiftoss/caip'
 import { fromAccountId } from '@shapeshiftoss/caip'
 import { DefiProvider } from 'features/defi/contexts/DefiManagerProvider/DefiCommon'
 import merge from 'lodash/merge'
-import uniq from 'lodash/uniq'
 import { PURGE } from 'redux-persist'
 import { logger } from 'lib/logger'
 import { BASE_RTK_CREATE_API_CONFIG } from 'state/apis/const'
@@ -84,35 +83,37 @@ export const opportunities = createSlice({
     clear: () => initialState,
     upsertOpportunityMetadata: {
       reducer: (draftState, { payload }: { payload: GetOpportunityMetadataOutput }) => {
-        const payloadIds = Object.keys(payload.byId) as OpportunityId[]
-
         draftState[payload.type].byId = Object.assign(
           {},
           draftState[payload.type].byId,
           payload.byId,
         )
-        draftState[payload.type].ids = uniq([...draftState[payload.type].ids, ...payloadIds])
+        draftState[payload.type].ids = Object.keys(draftState[payload.type].byId)
       },
       // Use the `prepareAutoBatched` utility to automatically
       // add the `action.meta[SHOULD_AUTOBATCH]` field the enhancer needs
       prepare: prepareAutoBatched<GetOpportunityMetadataOutput>(),
     },
-    upsertOpportunityAccounts: (
-      draftState,
-      { payload }: { payload: GetOpportunityUserDataOutput },
-    ) => {
-      draftState[payload.type].byAccountId = merge(
-        draftState[payload.type].byAccountId,
-        payload.byAccountId,
-      )
+    upsertOpportunityAccounts: {
+      reducer: (draftState, { payload }: { payload: GetOpportunityUserDataOutput }) => {
+        draftState[payload.type].byAccountId = merge(
+          draftState[payload.type].byAccountId,
+          payload.byAccountId,
+        )
+      },
+      // Use the `prepareAutoBatched` utility to automatically
+      // add the `action.meta[SHOULD_AUTOBATCH]` field the enhancer needs
+      prepare: prepareAutoBatched<GetOpportunityUserDataOutput>(),
     },
-    upsertUserStakingOpportunities: (
-      draftState,
-      { payload }: { payload: GetOpportunityUserStakingDataOutput },
-    ) => {
-      const payloadIds = Object.keys(payload.byId) as UserStakingId[]
-      draftState.userStaking.byId = merge(draftState.userStaking.byId, payload.byId)
-      draftState.userStaking.ids = uniq([...draftState.userStaking.ids, ...payloadIds])
+    upsertUserStakingOpportunities: {
+      reducer: (draftState, { payload }: { payload: GetOpportunityUserStakingDataOutput }) => {
+        draftState.userStaking.byId = merge(draftState.userStaking.byId, payload.byId)
+        draftState.userStaking.ids = Object.keys(draftState.userStaking.byId) as UserStakingId[]
+      },
+
+      // Use the `prepareAutoBatched` utility to automatically
+      // add the `action.meta[SHOULD_AUTOBATCH]` field the enhancer needs
+      prepare: prepareAutoBatched<GetOpportunityUserStakingDataOutput>(),
     },
   },
   extraReducers: builder => builder.addCase(PURGE, () => initialState),


### PR DESCRIPTION
## Description

<!-- Please describe your changes -->

this has a dramatic improvement on performance

by batching actions together in reducers, redux only notifies subscribers (selectors) on a timeout

this means selectors don't recompute, and in turn, react renders a whole lot less

see screenshots - we only render once on market data changes instead of ~10

## Pull Request Type

- [ ] :bug: Bug fix (Non-breaking Change: Fixes an issue)
- [x] :hammer_and_wrench: Chore (Non-breaking Change: Doc updates, pkg upgrades, typos, etc..)
- [ ] :nail_care: New Feature (Breaking/Non-breaking Change)

## Issue (if applicable)

<!-----------------------------------------------------------------------------
If applicable, please link to the github issue and put `closes #XXXX` in your comment to auto-close the issue that your PR fixes.
------------------------------------------------------------------------------>

n/a - i'm on a performance arc

## Risk

bigly - changes core state management reducers

<!-----------------------------------------------------------------------------
Outline the scope of your changes and the risk associated with them. You must use your discretion as an engineer to determine the potential impact of your changes.

E.g. an upgrade to `hdwallet` or core state management would be considered higher risk, and might require a full regression test. UI or isolated view changes, or something behind a feature flag may have near zero risk. Small bug fixes might require testing isolated to the specific fix.
------------------------------------------------------------------------------>

## Testing

<!-----------------------------------------------------------------------------
We treat every PR to be merged with the same scrutiny as if we were merging directly to production.

Your PR will not be merged if you do not complete the sections below for our engineering and operations teams to test.
------------------------------------------------------------------------------>

### Engineering

ensure my logic changes in reducers doesn't cause regressions

<!-----------------------------------------------------------------------------
Include sufficient information here for an engineer to test your PR. This may include how to test locally, in a built environment, changes to infrastructure etc.
------------------------------------------------------------------------------>

### Operations

a general smoke test of the app - switching wallets, checking market data, balances, and charts are correct.

<!-----------------------------------------------------------------------------
If your changes have a user-facing impact, describe how a non-technical QA team can functionally test your changes in a preview environment.

If they are not user-facing please describe how to test for any regressions that may occur.
------------------------------------------------------------------------------>

## Screenshots (if applicable)

before

<img width="992" alt="image" src="https://user-images.githubusercontent.com/88504456/234678146-06cd013d-b488-408b-be6e-191444414694.png">

after

<img width="639" alt="image" src="https://user-images.githubusercontent.com/88504456/234680128-491ccf64-df13-466a-939c-c7b175c505c2.png">

