### PR TITLE
fix: rune asset trades

### DIFF
--- a/packages/caip/src/adapters/thortrading/index.ts
+++ b/packages/caip/src/adapters/thortrading/index.ts
@@ -10,6 +10,7 @@ import {
   dogeAssetId,
   ethAssetId,
   ltcAssetId,
+  thorchainAssetId,
 } from '../../constants'
 
 // derived from https://midgard.thorchain.info/v2/pools
@@ -67,6 +68,7 @@ const thorPoolIdAssetIdSymbolMap: Record<string, AssetId> = {
   'BNB.BNB': binanceAssetId,
   'AVAX.USDC-0XB97EF9EF8734C71904D8002F8B6BC66DD9C48A6E':
     'eip155:43114/erc20:0xb97ef9ef8734c71904d8002f8b6bc66dd9c48a6e',
+  'THOR.RUNE': thorchainAssetId,
 }
 
 const assetIdToPoolAssetIdMap = invert(thorPoolIdAssetIdSymbolMap)


### PR DESCRIPTION
## Description

Adds a THORChain pool mapping to `thorchainAssetId`, allowing trades into and out of RUNE to use the quotes endpoint. Currently they are falling back to the hacking pool size approximation to get quote data.

## Pull Request Type

- [x] :bug: Bug fix (Non-breaking Change: Fixes an issue)
- [ ] :hammer_and_wrench: Chore (Non-breaking Change: Doc updates, pkg upgrades, typos, etc..)
- [ ] :nail_care: New Feature (Breaking/Non-breaking Change)

## Issue (if applicable)

N/A, bug in production.

## Risk

Small - changes quote source for RUNE quotes to a more accurate one.

## Testing

With the network tab open, stage a THORChain trade to or from RUNE to the Trade confirm screen.

Observe that requests to the `lcd/thorchain/quote/swap` endpoint no longer have `undefined` as the `from_asset` or `to_asset`, and that the request now returns a quote instead of an error.

### Engineering

☝️

### Operations

☝️

+ check that RUNE trades still work as expected.

## Screenshots (if applicable)

N/A
