### PR TITLE
feat: optimism l1 fees

### DIFF
--- a/packages/chain-adapters/src/evm/avalanche/AvalancheChainAdapter.test.ts
+++ b/packages/chain-adapters/src/evm/avalanche/AvalancheChainAdapter.test.ts
@@ -146,7 +146,7 @@ describe('AvalancheChainAdapter', () => {
           average: {
             chainSpecific: {
               gasLimit: '21000',
-              gasPrice: '5',
+              gasPrice: '300',
               maxFeePerGas: '300',
               maxPriorityFeePerGas: '10',
             },
@@ -155,7 +155,7 @@ describe('AvalancheChainAdapter', () => {
           fast: {
             chainSpecific: {
               gasLimit: '21000',
-              gasPrice: '6',
+              gasPrice: '360',
               maxFeePerGas: '360',
               maxPriorityFeePerGas: '12',
             },
@@ -164,7 +164,7 @@ describe('AvalancheChainAdapter', () => {
           slow: {
             chainSpecific: {
               gasLimit: '21000',
-              gasPrice: '4',
+              gasPrice: '240',
               maxFeePerGas: '240',
               maxPriorityFeePerGas: '8',
             },
@@ -189,17 +189,17 @@ describe('AvalancheChainAdapter', () => {
       expect(data).toEqual(
         expect.objectContaining({
           average: {
-            gasPrice: '5',
+            gasPrice: '300',
             maxFeePerGas: '300',
             maxPriorityFeePerGas: '10',
           },
           fast: {
-            gasPrice: '6',
+            gasPrice: '360',
             maxFeePerGas: '360',
             maxPriorityFeePerGas: '12',
           },
           slow: {
-            gasPrice: '4',
+            gasPrice: '240',
             maxFeePerGas: '240',
             maxPriorityFeePerGas: '8',
           },

--- a/packages/chain-adapters/src/evm/avalanche/AvalancheChainAdapter.ts
+++ b/packages/chain-adapters/src/evm/avalanche/AvalancheChainAdapter.ts
@@ -6,11 +6,10 @@ import * as unchained from '@shapeshiftoss/unchained-client'
 
 import type { FeeDataEstimate, GetFeeDataInput } from '../../types'
 import { ChainAdapterDisplayName } from '../../types'
-import { bn, calcFee } from '../../utils'
+import { bn, bnOrZero } from '../../utils'
 import type { ChainAdapterArgs } from '../EvmBaseAdapter'
 import { EvmBaseAdapter } from '../EvmBaseAdapter'
 import type { GasFeeDataEstimate } from '../types'
-import { getTxFee } from '../utils'
 
 const SUPPORTED_CHAIN_IDS = [KnownChainIds.AvalancheMainnet]
 const DEFAULT_CHAIN_ID = KnownChainIds.AvalancheMainnet
@@ -61,23 +60,21 @@ export class ChainAdapter extends EvmBaseAdapter<KnownChainIds.AvalancheMainnet>
   }
 
   async getGasFeeData(): Promise<GasFeeDataEstimate> {
-    const { gasPrice, fast, average, slow } = await this.api.getGasFees()
-
-    const scalars = { fast: bn(1.2), average: bn(1), slow: bn(0.8) }
+    const { fast, average, slow } = await this.api.getGasFees()
 
     return {
       fast: {
-        gasPrice: calcFee(gasPrice, 'fast', scalars),
+        gasPrice: fast.maxFeePerGas ?? '0',
         maxFeePerGas: fast.maxFeePerGas,
         maxPriorityFeePerGas: fast.maxPriorityFeePerGas,
       },
       average: {
-        gasPrice: calcFee(gasPrice, 'average', scalars),
+        gasPrice: average.maxFeePerGas ?? '0',
         maxFeePerGas: average.maxFeePerGas,
         maxPriorityFeePerGas: average.maxPriorityFeePerGas,
       },
       slow: {
-        gasPrice: calcFee(gasPrice, 'slow', scalars),
+        gasPrice: slow.maxFeePerGas ?? '0',
         maxFeePerGas: slow.maxFeePerGas,
         maxPriorityFeePerGas: slow.maxPriorityFeePerGas,
       },
@@ -94,15 +91,15 @@ export class ChainAdapter extends EvmBaseAdapter<KnownChainIds.AvalancheMainnet>
 
     return {
       fast: {
-        txFee: getTxFee({ gasLimit, ...fast }),
+        txFee: bnOrZero(bn(fast.gasPrice).times(gasLimit)).toFixed(0),
         chainSpecific: { gasLimit, ...fast },
       },
       average: {
-        txFee: getTxFee({ gasLimit, ...average }),
+        txFee: bnOrZero(bn(average.gasPrice).times(gasLimit)).toFixed(0),
         chainSpecific: { gasLimit, ...average },
       },
       slow: {
-        txFee: getTxFee({ gasLimit, ...slow }),
+        txFee: bnOrZero(bn(slow.gasPrice).times(gasLimit)).toFixed(0),
         chainSpecific: { gasLimit, ...slow },
       },
     }

--- a/packages/chain-adapters/src/evm/ethereum/EthereumChainAdapter.test.ts
+++ b/packages/chain-adapters/src/evm/ethereum/EthereumChainAdapter.test.ts
@@ -38,25 +38,6 @@ const getWallet = async (): Promise<ETHWallet> => {
   return wallet
 }
 
-jest.mock('axios', () => ({
-  get: jest.fn(() =>
-    Promise.resolve({
-      data: {
-        result: [
-          {
-            source: 'MEDIAN',
-            timestamp: 1639978534,
-            instant: 55477500000,
-            fast: 50180000000,
-            standard: 45000000000,
-            low: 41000000000,
-          },
-        ],
-      },
-    }),
-  ),
-}))
-
 describe('EthereumChainAdapter', () => {
   const gasPrice = '42'
   const gasLimit = '42000'
@@ -170,29 +151,29 @@ describe('EthereumChainAdapter', () => {
           average: {
             chainSpecific: {
               gasLimit: '21000',
-              gasPrice: '45000000000',
+              gasPrice: '300',
               maxFeePerGas: '300',
               maxPriorityFeePerGas: '10',
             },
-            txFee: '945000000000000',
+            txFee: '6300000',
           },
           fast: {
             chainSpecific: {
               gasLimit: '21000',
-              gasPrice: '50180000000',
+              gasPrice: '335',
               maxFeePerGas: '335',
               maxPriorityFeePerGas: '12',
             },
-            txFee: '1053780000000000',
+            txFee: '7035000',
           },
           slow: {
             chainSpecific: {
               gasLimit: '21000',
-              gasPrice: '41000000000',
+              gasPrice: '274',
               maxFeePerGas: '274',
               maxPriorityFeePerGas: '10',
             },
-            txFee: '861000000000000',
+            txFee: '5754000',
           },
         }),
       )
@@ -213,17 +194,17 @@ describe('EthereumChainAdapter', () => {
       expect(data).toEqual(
         expect.objectContaining({
           average: {
-            gasPrice: '45000000000',
+            gasPrice: '300',
             maxFeePerGas: '300',
             maxPriorityFeePerGas: '10',
           },
           fast: {
-            gasPrice: '50180000000',
+            gasPrice: '335',
             maxFeePerGas: '335',
             maxPriorityFeePerGas: '12',
           },
           slow: {
-            gasPrice: '41000000000',
+            gasPrice: '274',
             maxFeePerGas: '274',
             maxPriorityFeePerGas: '10',
           },

--- a/packages/chain-adapters/src/evm/ethereum/EthereumChainAdapter.ts
+++ b/packages/chain-adapters/src/evm/ethereum/EthereumChainAdapter.ts
@@ -3,20 +3,13 @@ import { ASSET_REFERENCE, ethAssetId } from '@shapeshiftoss/caip'
 import type { BIP44Params } from '@shapeshiftoss/types'
 import { KnownChainIds } from '@shapeshiftoss/types'
 import * as unchained from '@shapeshiftoss/unchained-client'
-import axios from 'axios'
 
-import type {
-  FeeDataEstimate,
-  GetFeeDataInput,
-  ValidAddressResult,
-  ZrxGasApiResponse,
-} from '../../types'
+import type { FeeDataEstimate, GetFeeDataInput, ValidAddressResult } from '../../types'
 import { ChainAdapterDisplayName, ValidAddressResultType } from '../../types'
-import { bnOrZero } from '../../utils'
+import { bn, bnOrZero } from '../../utils'
 import type { ChainAdapterArgs } from '../EvmBaseAdapter'
 import { EvmBaseAdapter } from '../EvmBaseAdapter'
 import type { GasFeeDataEstimate } from '../types'
-import { getTxFee } from '../utils'
 
 const SUPPORTED_CHAIN_IDS = [KnownChainIds.EthereumMainnet]
 const DEFAULT_CHAIN_ID = KnownChainIds.EthereumMainnet
@@ -67,26 +60,21 @@ export class ChainAdapter extends EvmBaseAdapter<KnownChainIds.EthereumMainnet> 
   }
 
   async getGasFeeData(): Promise<GasFeeDataEstimate> {
-    const { data: responseData } = await axios.get<ZrxGasApiResponse>('https://gas.api.0x.org/')
-    const medianFees = responseData.result.find(result => result.source === 'MEDIAN')
-
-    if (!medianFees) throw new TypeError('ETH Gas Fees should always exist')
-
     const { fast, average, slow } = await this.api.getGasFees()
 
     return {
       fast: {
-        gasPrice: bnOrZero(medianFees.fast).toString(),
+        gasPrice: fast.maxFeePerGas ?? '0',
         maxFeePerGas: fast.maxFeePerGas,
         maxPriorityFeePerGas: fast.maxPriorityFeePerGas,
       },
       average: {
-        gasPrice: bnOrZero(medianFees.standard).toString(),
+        gasPrice: average.maxFeePerGas ?? '0',
         maxFeePerGas: average.maxFeePerGas,
         maxPriorityFeePerGas: average.maxPriorityFeePerGas,
       },
       slow: {
-        gasPrice: bnOrZero(medianFees.low).toString(),
+        gasPrice: slow.maxFeePerGas ?? '0',
         maxFeePerGas: slow.maxFeePerGas,
         maxPriorityFeePerGas: slow.maxPriorityFeePerGas,
       },
@@ -103,15 +91,15 @@ export class ChainAdapter extends EvmBaseAdapter<KnownChainIds.EthereumMainnet> 
 
     return {
       fast: {
-        txFee: getTxFee({ gasLimit, ...fast }),
+        txFee: bnOrZero(bn(fast.gasPrice).times(gasLimit)).toFixed(0),
         chainSpecific: { gasLimit, ...fast },
       },
       average: {
-        txFee: getTxFee({ gasLimit, ...average }),
+        txFee: bnOrZero(bn(average.gasPrice).times(gasLimit)).toFixed(0),
         chainSpecific: { gasLimit, ...average },
       },
       slow: {
-        txFee: getTxFee({ gasLimit, ...slow }),
+        txFee: bnOrZero(bn(slow.gasPrice).times(gasLimit)).toFixed(0),
         chainSpecific: { gasLimit, ...slow },
       },
     }

--- a/packages/chain-adapters/src/evm/optimism/OptimismChainAdapter.ts
+++ b/packages/chain-adapters/src/evm/optimism/OptimismChainAdapter.ts
@@ -14,6 +14,10 @@ import type { GasFeeDataEstimate } from '../types'
 const SUPPORTED_CHAIN_IDS = [KnownChainIds.OptimismMainnet]
 const DEFAULT_CHAIN_ID = KnownChainIds.OptimismMainnet
 
+export const isOptimismChainAdapter = (adapter: unknown): adapter is ChainAdapter => {
+  return (adapter as ChainAdapter).getType() === KnownChainIds.OptimismMainnet
+}
+
 export class ChainAdapter extends EvmBaseAdapter<KnownChainIds.OptimismMainnet> {
   public static readonly defaultBIP44Params: BIP44Params = {
     purpose: 44,

--- a/packages/chain-adapters/src/evm/polygon/PolygonChainAdapter.test.ts
+++ b/packages/chain-adapters/src/evm/polygon/PolygonChainAdapter.test.ts
@@ -141,7 +141,7 @@ describe('PolygonChainAdapter', () => {
           average: {
             chainSpecific: {
               gasLimit: '21000',
-              gasPrice: '5',
+              gasPrice: '300',
               maxFeePerGas: '300',
               maxPriorityFeePerGas: '10',
             },
@@ -150,7 +150,7 @@ describe('PolygonChainAdapter', () => {
           fast: {
             chainSpecific: {
               gasLimit: '21000',
-              gasPrice: '6',
+              gasPrice: '360',
               maxFeePerGas: '360',
               maxPriorityFeePerGas: '12',
             },
@@ -159,7 +159,7 @@ describe('PolygonChainAdapter', () => {
           slow: {
             chainSpecific: {
               gasLimit: '21000',
-              gasPrice: '4',
+              gasPrice: '240',
               maxFeePerGas: '240',
               maxPriorityFeePerGas: '8',
             },
@@ -184,17 +184,17 @@ describe('PolygonChainAdapter', () => {
       expect(data).toEqual(
         expect.objectContaining({
           average: {
-            gasPrice: '5',
+            gasPrice: '300',
             maxFeePerGas: '300',
             maxPriorityFeePerGas: '10',
           },
           fast: {
-            gasPrice: '6',
+            gasPrice: '360',
             maxFeePerGas: '360',
             maxPriorityFeePerGas: '12',
           },
           slow: {
-            gasPrice: '4',
+            gasPrice: '240',
             maxFeePerGas: '240',
             maxPriorityFeePerGas: '8',
           },

--- a/packages/chain-adapters/src/evm/utils.ts
+++ b/packages/chain-adapters/src/evm/utils.ts
@@ -1,7 +1,5 @@
 import { Contract } from '@ethersproject/contracts'
-import BigNumber from 'bignumber.js'
 
-import { bnOrZero } from '../utils'
 import erc20Abi from './erc20Abi.json'
 
 export const getErc20Data = async (
@@ -13,19 +11,4 @@ export const getErc20Data = async (
   const erc20Contract = new Contract(contractAddress, erc20Abi)
   const { data: callData } = await erc20Contract.populateTransaction.transfer(to, value)
   return callData || ''
-}
-
-type GetTxFee = {
-  gasLimit: string
-  gasPrice: string
-  maxFeePerGas?: string
-}
-
-export const getTxFee = ({
-  gasLimit,
-  gasPrice: legacyGasPrice,
-  maxFeePerGas: eip1559GasPrice,
-}: GetTxFee): string => {
-  const gasPrice = bnOrZero(BigNumber.max(eip1559GasPrice ?? 0, legacyGasPrice))
-  return gasPrice.times(bnOrZero(gasLimit)).toFixed(0)
 }

--- a/src/components/Trade/hooks/useSwapper/utils.ts
+++ b/src/components/Trade/hooks/useSwapper/utils.ts
@@ -73,14 +73,6 @@ const getEvmFees = <T extends EvmChainId>(
   if (trade.feeData && !trade.feeData.chainSpecific) {
     moduleLogger.debug({ trade }, 'feeData.chainSpecific undefined for trade')
   }
-  const approvalFeeCryptoPrecision = bnOrZero(
-    trade.feeData.chainSpecific?.approvalFeeCryptoBaseUnit,
-  )
-    .dividedBy(bn(10).exponentiatedBy(feeAsset.precision))
-    .toString()
-  const totalFeeCryptoPrecision = bnOrZero(networkFeeCryptoPrecision)
-    .plus(approvalFeeCryptoPrecision)
-    .toString()
   const gasPriceCryptoBaseUnit = bnOrZero(
     trade.feeData.chainSpecific?.gasPriceCryptoBaseUnit,
   ).toString()
@@ -93,7 +85,6 @@ const getEvmFees = <T extends EvmChainId>(
       approvalFeeCryptoBaseUnit: trade.feeData.chainSpecific?.approvalFeeCryptoBaseUnit ?? '0',
       gasPriceCryptoBaseUnit,
       estimatedGasCryptoBaseUnit,
-      totalFee: totalFeeCryptoPrecision,
     },
     tradeFeeSource,
     buyAssetTradeFeeUsd: trade.feeData.buyAssetTradeFeeUsd,

--- a/src/features/defi/helpers/utils.ts
+++ b/src/features/defi/helpers/utils.ts
@@ -10,7 +10,7 @@ import type {
 } from '@shapeshiftoss/chain-adapters'
 import type { HDWallet } from '@shapeshiftoss/hdwallet-core'
 import { supportsETH } from '@shapeshiftoss/hdwallet-core'
-import { BigNumber, bn, bnOrZero } from 'lib/bignumber/bignumber'
+import { bnOrZero } from 'lib/bignumber/bignumber'
 import { selectPortfolioCryptoPrecisionBalanceByFilter } from 'state/slices/selectors'
 import { store } from 'state/store'
 
@@ -46,15 +46,11 @@ export const canCoverTxFees = ({
 
 export const getFeeDataFromEstimate = ({
   average,
-  fast,
 }: FeeDataEstimate<EvmChainId>): FeeData<EvmChainId> => ({
-  txFee: BigNumber.max(
-    average.txFee,
-    bnOrZero(bn(fast.chainSpecific.gasPrice).times(average.chainSpecific.gasLimit)),
-  ).toFixed(0), // use worst case average eip1559 vs fast legacy
+  txFee: average.txFee,
   chainSpecific: {
-    gasLimit: average.chainSpecific.gasLimit, // average and fast gasLimit values are the same
-    gasPrice: fast.chainSpecific.gasPrice, // fast gas price since it is underestimated currently
+    gasLimit: average.chainSpecific.gasLimit,
+    gasPrice: average.chainSpecific.gasPrice,
     maxFeePerGas: average.chainSpecific.maxFeePerGas,
     maxPriorityFeePerGas: average.chainSpecific.maxPriorityFeePerGas,
   },

--- a/src/lib/swapper/api.ts
+++ b/src/lib/swapper/api.ts
@@ -38,7 +38,6 @@ export type EvmFeeData = {
   estimatedGasCryptoBaseUnit?: string
   gasPriceCryptoBaseUnit?: string
   approvalFeeCryptoBaseUnit?: string
-  totalFee?: string
   maxFeePerGas?: string
   maxPriorityFeePerGas?: string
 }

--- a/src/lib/swapper/swappers/CowSwapper/getCowSwapTradeQuote/getCowSwapTradeQuote.ts
+++ b/src/lib/swapper/swappers/CowSwapper/getCowSwapTradeQuote/getCowSwapTradeQuote.ts
@@ -149,7 +149,7 @@ export async function getCowSwapTradeQuote(
       ? '0'
       : buyAmountCryptoBaseUnit
 
-    const { average, fast } = feeData
+    const { average } = feeData
 
     return Ok({
       rate,
@@ -159,10 +159,10 @@ export async function getCowSwapTradeQuote(
         networkFeeCryptoBaseUnit: '0', // no miner fee for CowSwap
         chainSpecific: {
           estimatedGasCryptoBaseUnit: average.chainSpecific.gasLimit,
-          gasPriceCryptoBaseUnit: fast.chainSpecific.gasPrice, // fast gas price since it is underestimated currently
+          gasPriceCryptoBaseUnit: average.chainSpecific.gasPrice,
           maxFeePerGas: average.chainSpecific.maxFeePerGas,
           maxPriorityFeePerGas: average.chainSpecific.maxPriorityFeePerGas,
-          approvalFeeCryptoBaseUnit: fast.txFee, // use worst case fast fee
+          approvalFeeCryptoBaseUnit: average.txFee,
         },
         buyAssetTradeFeeUsd: '0', // Trade fees for buy Asset are always 0 since trade fees are subtracted from sell asset
         sellAssetTradeFeeUsd,

--- a/src/lib/swapper/swappers/ThorchainSwapper/getThorTradeQuote/getTradeQuote.test.ts
+++ b/src/lib/swapper/swappers/ThorchainSwapper/getThorTradeQuote/getTradeQuote.test.ts
@@ -26,14 +26,14 @@ const expectedQuoteResponse: TradeQuote<KnownChainIds.EthereumMainnet> = {
   feeData: {
     chainSpecific: {
       estimatedGasCryptoBaseUnit: '100000',
-      approvalFeeCryptoBaseUnit: '700000',
-      gasPriceCryptoBaseUnit: '7',
+      approvalFeeCryptoBaseUnit: '400000',
+      gasPriceCryptoBaseUnit: '4',
       maxFeePerGas: '5',
       maxPriorityFeePerGas: '6',
     },
     buyAssetTradeFeeUsd: '19.14',
     sellAssetTradeFeeUsd: '0',
-    networkFeeCryptoBaseUnit: '700000',
+    networkFeeCryptoBaseUnit: '400000',
   },
   rate: '144114.94366197183098591549',
   sources: [{ name: SwapperName.Thorchain, proportion: '1' }],

--- a/src/lib/swapper/swappers/ZrxSwapper/getZrxTradeQuote/getZrxTradeQuote.test.ts
+++ b/src/lib/swapper/swappers/ZrxSwapper/getZrxTradeQuote/getZrxTradeQuote.test.ts
@@ -58,12 +58,12 @@ describe('getZrxTradeQuote', () => {
       chainSpecific: {
         estimatedGasCryptoBaseUnit: '1000000',
         gasPriceCryptoBaseUnit: '79036500000',
-        approvalFeeCryptoBaseUnit: '21621475811200000',
+        approvalFeeCryptoBaseUnit: '7903650000000000',
         maxFeePerGas: '216214758112',
         maxPriorityFeePerGas: '2982734547',
       },
       buyAssetTradeFeeUsd: '0',
-      networkFeeCryptoBaseUnit: '216214758112000000',
+      networkFeeCryptoBaseUnit: '79036500000000000',
       sellAssetTradeFeeUsd: '0',
     })
     expect(quote.rate).toBe('100')
@@ -115,7 +115,7 @@ describe('getZrxTradeQuote', () => {
     expect(quote?.feeData).toStrictEqual({
       chainSpecific: {
         estimatedGasCryptoBaseUnit: '0',
-        approvalFeeCryptoBaseUnit: '21621475811200000',
+        approvalFeeCryptoBaseUnit: '7903650000000000',
         gasPriceCryptoBaseUnit: '79036500000',
         maxFeePerGas: '216214758112',
         maxPriorityFeePerGas: '2982734547',

--- a/src/lib/swapper/swappers/ZrxSwapper/getZrxTradeQuote/getZrxTradeQuote.test.ts
+++ b/src/lib/swapper/swappers/ZrxSwapper/getZrxTradeQuote/getZrxTradeQuote.test.ts
@@ -56,14 +56,14 @@ describe('getZrxTradeQuote', () => {
     const quote = maybeQuote.unwrap()
     expect(quote.feeData).toStrictEqual({
       chainSpecific: {
-        estimatedGasCryptoBaseUnit: '1000000',
+        estimatedGasCryptoBaseUnit: '1200000',
         gasPriceCryptoBaseUnit: '79036500000',
         approvalFeeCryptoBaseUnit: '7903650000000000',
         maxFeePerGas: '216214758112',
         maxPriorityFeePerGas: '2982734547',
       },
       buyAssetTradeFeeUsd: '0',
-      networkFeeCryptoBaseUnit: '79036500000000000',
+      networkFeeCryptoBaseUnit: '94843800000000000',
       sellAssetTradeFeeUsd: '0',
     })
     expect(quote.rate).toBe('100')

--- a/src/lib/swapper/swappers/ZrxSwapper/getZrxTradeQuote/getZrxTradeQuote.ts
+++ b/src/lib/swapper/swappers/ZrxSwapper/getZrxTradeQuote/getZrxTradeQuote.ts
@@ -71,7 +71,10 @@ export async function getZrxTradeQuote<T extends ZrxSupportedChainId>(
 
     const useSellAmount = !!sellAmount
     const rate = useSellAmount ? data.price : bn(1).div(data.price).toString()
-    const gasLimit = bnOrZero(data.gas)
+
+    // add gas limit buffer to account for the fact we perform all of our validation on the trade quote estimations
+    // which are inaccurate and not what we use for the tx to broadcast
+    const gasLimit = bnOrZero(data.gas).times(1.2)
 
     // 0x approvals are cheaper than trades, but we don't have dynamic quote data for them.
     // Instead, we use a hardcoded gasLimit estimate in place of the estimatedGas in the 0x quote response.

--- a/src/lib/swapper/swappers/ZrxSwapper/getZrxTradeQuote/getZrxTradeQuote.ts
+++ b/src/lib/swapper/swappers/ZrxSwapper/getZrxTradeQuote/getZrxTradeQuote.ts
@@ -1,13 +1,19 @@
+import { optimism } from '@shapeshiftoss/chain-adapters'
 import type { Result } from '@sniptt/monads'
 import { Err, Ok } from '@sniptt/monads'
-import { BigNumber, bn, bnOrZero } from 'lib/bignumber/bignumber'
+import { bn, bnOrZero } from 'lib/bignumber/bignumber'
 import type { GetEvmTradeQuoteInput, SwapErrorRight, TradeQuote } from 'lib/swapper/api'
 import { makeSwapErrorRight, SwapError, SwapErrorType } from 'lib/swapper/api'
 import { APPROVAL_GAS_LIMIT } from 'lib/swapper/swappers/utils/constants'
 import { normalizeAmount } from 'lib/swapper/swappers/utils/helpers/helpers'
 import { getZrxMinMax } from 'lib/swapper/swappers/ZrxSwapper/getZrxMinMax/getZrxMinMax'
 import type { ZrxPriceResponse, ZrxSwapperDeps } from 'lib/swapper/swappers/ZrxSwapper/types'
-import { AFFILIATE_ADDRESS, DEFAULT_SOURCE } from 'lib/swapper/swappers/ZrxSwapper/utils/constants'
+import {
+  AFFILIATE_ADDRESS,
+  DEFAULT_SOURCE,
+  OPTIMISM_L1_APPROVE_GAS_LIMIT,
+  OPTIMISM_L1_SWAP_GAS_LIMIT,
+} from 'lib/swapper/swappers/ZrxSwapper/utils/constants'
 import {
   assertValidTradePair,
   assetToToken,
@@ -63,19 +69,34 @@ export async function getZrxTradeQuote<T extends ZrxSupportedChainId>(
       )
     }
 
-    const { average, fast } = await adapter.getGasFeeData()
-
-    // use worst case average eip1559 vs fast legacy
-    const maxGasPrice = bnOrZero(BigNumber.max(average.maxFeePerGas ?? 0, fast.gasPrice))
-
-    // 0x approvals are cheaper than trades, but we don't have dynamic quote data for them.
-    // Instead, we use a hardcoded gasLimit estimate in place of the estimatedGas in the 0x quote response.
-    const approvalFeeCryptoBaseUnit = bn(APPROVAL_GAS_LIMIT).times(maxGasPrice).toFixed(0)
-
     const useSellAmount = !!sellAmount
     const rate = useSellAmount ? data.price : bn(1).div(data.price).toString()
     const gasLimit = bnOrZero(data.gas)
-    const txFee = gasLimit.times(maxGasPrice)
+
+    // 0x approvals are cheaper than trades, but we don't have dynamic quote data for them.
+    // Instead, we use a hardcoded gasLimit estimate in place of the estimatedGas in the 0x quote response.
+    const { average, approvalFee, txFee } = await (async () => {
+      if (optimism.isOptimismChainAdapter(adapter)) {
+        const { average, l1GasPrice } = await adapter.getGasFeeData()
+
+        // account for l1 transaction fees for optimism
+        const l1ApprovalFee = bn(OPTIMISM_L1_APPROVE_GAS_LIMIT).times(l1GasPrice)
+        const l1TxFee = bn(OPTIMISM_L1_SWAP_GAS_LIMIT).times(l1GasPrice)
+
+        return {
+          average,
+          approvalFee: bn(APPROVAL_GAS_LIMIT).times(average.gasPrice).plus(l1ApprovalFee),
+          txFee: gasLimit.times(average.gasPrice).plus(l1TxFee),
+        }
+      }
+
+      const { average } = await adapter.getGasFeeData()
+
+      const approvalFee = bn(APPROVAL_GAS_LIMIT).times(average.gasPrice)
+      const txFee = gasLimit.times(average.gasPrice)
+
+      return { average, approvalFee, txFee }
+    })()
 
     const tradeQuote: TradeQuote<ZrxSupportedChainId> = {
       buyAsset,
@@ -87,10 +108,10 @@ export async function getZrxTradeQuote<T extends ZrxSupportedChainId>(
       feeData: {
         chainSpecific: {
           estimatedGasCryptoBaseUnit: gasLimit.toFixed(0),
-          gasPriceCryptoBaseUnit: fast.gasPrice, // fast gas price since it is underestimated currently
+          gasPriceCryptoBaseUnit: average.gasPrice,
           maxFeePerGas: average.maxFeePerGas,
           maxPriorityFeePerGas: average.maxPriorityFeePerGas,
-          approvalFeeCryptoBaseUnit,
+          approvalFeeCryptoBaseUnit: approvalFee.toFixed(0),
         },
         networkFeeCryptoBaseUnit: txFee.toFixed(0),
         buyAssetTradeFeeUsd: '0',

--- a/src/lib/swapper/swappers/ZrxSwapper/utils/constants.ts
+++ b/src/lib/swapper/swappers/ZrxSwapper/utils/constants.ts
@@ -5,3 +5,5 @@ export const MAX_ALLOWANCE = '100000000000000000000000000'
 export const MAX_ZRX_TRADE = '100000000000000000000000000'
 export const DEFAULT_SOURCE: SwapSource[] = [{ name: SwapperName.Zrx, proportion: '1' }]
 export const AFFILIATE_ADDRESS = '0xc770eefad204b5180df6a14ee197d99d808ee52d'
+export const OPTIMISM_L1_SWAP_GAS_LIMIT = '50000'
+export const OPTIMISM_L1_APPROVE_GAS_LIMIT = '10000'

--- a/src/lib/swapper/swappers/ZrxSwapper/zrxBuildTrade/zrxBuildTrade.test.ts
+++ b/src/lib/swapper/swappers/ZrxSwapper/zrxBuildTrade/zrxBuildTrade.test.ts
@@ -98,7 +98,7 @@ describe('zrxBuildTrade', () => {
         maxFeePerGas: '216214758112',
         maxPriorityFeePerGas: '2982734547',
       },
-      networkFeeCryptoBaseUnit: '21621475811200000',
+      networkFeeCryptoBaseUnit: '4080654495000000',
       sellAssetTradeFeeUsd: '0',
       buyAssetTradeFeeUsd: '0',
     },
@@ -170,7 +170,7 @@ describe('zrxBuildTrade', () => {
       },
       buyAssetTradeFeeUsd: '0',
       sellAssetTradeFeeUsd: '0',
-      networkFeeCryptoBaseUnit: '21621475811200000',
+      networkFeeCryptoBaseUnit: '4080654495000000',
     }
 
     const maybeBuiltTrade = await zrxBuildTrade(deps, { ...buildTradeInput, wallet })

--- a/src/lib/swapper/swappers/ZrxSwapper/zrxBuildTrade/zrxBuildTrade.ts
+++ b/src/lib/swapper/swappers/ZrxSwapper/zrxBuildTrade/zrxBuildTrade.ts
@@ -2,7 +2,7 @@ import type { Result } from '@sniptt/monads'
 import { Err, Ok } from '@sniptt/monads'
 import type { AxiosResponse } from 'axios'
 import * as rax from 'retry-axios'
-import { BigNumber, bn, bnOrZero } from 'lib/bignumber/bignumber'
+import { bnOrZero } from 'lib/bignumber/bignumber'
 import type { BuildTradeInput, SwapErrorRight } from 'lib/swapper/api'
 import { makeSwapErrorRight, SwapError, SwapErrorType } from 'lib/swapper/api'
 import { DEFAULT_SLIPPAGE } from 'lib/swapper/swappers/utils/constants'
@@ -66,7 +66,7 @@ export async function zrxBuildTrade<T extends ZrxSupportedChainId>(
       },
     )
 
-    const { average, fast } = await adapter.getFeeData({
+    const { average } = await adapter.getFeeData({
       to: quote.to,
       value: quote.value,
       chainSpecific: {
@@ -74,14 +74,6 @@ export async function zrxBuildTrade<T extends ZrxSupportedChainId>(
         contractData: quote.data,
       },
     })
-
-    // use worst case average eip1559 vs fast legacy
-    const maxGasPrice = BigNumber.max(
-      average.chainSpecific.maxFeePerGas ?? 0,
-      fast.chainSpecific.gasPrice,
-    )
-
-    const txFee = bnOrZero(bn(fast.chainSpecific.gasLimit).times(maxGasPrice))
 
     const trade: ZrxTrade<ZrxSupportedChainId> = {
       sellAsset,
@@ -93,11 +85,11 @@ export async function zrxBuildTrade<T extends ZrxSupportedChainId>(
       feeData: {
         chainSpecific: {
           estimatedGasCryptoBaseUnit: quote.gas,
-          gasPriceCryptoBaseUnit: fast.chainSpecific.gasPrice, // fast gas price since it is underestimated currently
+          gasPriceCryptoBaseUnit: average.chainSpecific.gasPrice,
           maxFeePerGas: average.chainSpecific.maxFeePerGas,
           maxPriorityFeePerGas: average.chainSpecific.maxPriorityFeePerGas,
         },
-        networkFeeCryptoBaseUnit: txFee.toFixed(0),
+        networkFeeCryptoBaseUnit: average.txFee,
         buyAssetTradeFeeUsd: '0',
         sellAssetTradeFeeUsd: '0',
       },

--- a/src/state/zustand/swapperStore/testData.ts
+++ b/src/state/zustand/swapperStore/testData.ts
@@ -152,7 +152,6 @@ export const baseSwapperState: SwapperState = {
       approvalFeeCryptoBaseUnit: '1800000000000000',
       gasPriceCryptoBaseUnit: '18000000000',
       estimatedGasCryptoBaseUnit: '100000',
-      totalFee: '0.0036',
     },
     tradeFeeSource: SwapperName.Thorchain,
     buyAssetTradeFeeUsd: '8.5196229516043797526224',


### PR DESCRIPTION
## Description

- use `maxFeePerGas` as `gasPrice` for chains that support eip1559
- the above change allows us to remove zrx gas api and the average vs fast comparison logic
- add more constants for L1 gas limits to account for L1 fees on optimism (swaps/approvals)
- a little bit of type narrowing jank to access `l1GasPrice`
- remove `totalFee` which looks to be unused and irrelevant (correct me if I am wrong)

The L1 fee edge case is small and was also covered up by the arbitrary 50% gas limit buffer that existed before the eip1559 fee refactor.

## Pull Request Type

- [x] :bug: Bug fix (Non-breaking Change: Fixes an issue)
- [ ] :hammer_and_wrench: Chore (Non-breaking Change: Doc updates, pkg upgrades, typos, etc..)
- [x] :nail_care: New Feature (Breaking/Non-breaking Change)

## Issue (if applicable)

https://discord.com/channels/554694662431178782/876953436908822568/1101532729859911765

## Risk

Low/Med

## Testing

- Test Zrx swap and approval flow on Optimism
- Sanity check defi interaction (fox-farming/univ2) and swaps (no gas limit/broadcast issues)
- The actual edge case will be hard to validate on optimism just do to slim eth on optimism balance window, @gomesalexandre may still be in a wallet state to validate here

### Engineering

:point_up: 

### Operations

:point_up: 

## Screenshots (if applicable)
