### PR TITLE
feat: 0x donations

### DIFF
--- a/src/components/Trade/TradeConfirm/TradeConfirm.tsx
+++ b/src/components/Trade/TradeConfirm/TradeConfirm.tsx
@@ -415,9 +415,11 @@ export const TradeConfirm = () => {
     [fees?.tradeFeeSource],
   )
 
+  const is0xSwap = useMemo(() => fees?.tradeFeeSource === SwapperName.Zrx, [fees?.tradeFeeSource])
+
   const shouldShowDonationOption = useMemo(() => {
-    return isTHORChainSwap && !isDonationAmountBelowMinimum
-  }, [isDonationAmountBelowMinimum, isTHORChainSwap])
+    return (isTHORChainSwap || is0xSwap) && !isDonationAmountBelowMinimum
+  }, [is0xSwap, isDonationAmountBelowMinimum, isTHORChainSwap])
 
   const tradeWarning: JSX.Element | null = useMemo(() => {
     if (!trade) return null

--- a/src/components/Trade/TradeConfirm/TradeConfirm.tsx
+++ b/src/components/Trade/TradeConfirm/TradeConfirm.tsx
@@ -67,6 +67,7 @@ import {
   selectSellAssetAccountId,
   selectSlippage,
   selectSwapperDefaultAffiliateBps,
+  selectSwapperName,
   selectTrade,
 } from 'state/zustand/swapperStore/selectors'
 import { useSwapperStore } from 'state/zustand/swapperStore/useSwapperStore'
@@ -108,6 +109,7 @@ export const TradeConfirm = () => {
 
   const trade = useSwapperStore(selectTrade)
   const fees = useSwapperStore(selectFees)
+  const swapperName = useSwapperStore(selectSwapperName)
   const feeAssetFiatRate = useSwapperStore(selectFeeAssetFiatRate)
   const slippage = useSwapperStore(selectSlippage)
   const buyAssetAccountId = useSwapperStore(selectBuyAssetAccountId)
@@ -410,12 +412,8 @@ export const TradeConfirm = () => {
     ],
   )
 
-  const isTHORChainSwap = useMemo(
-    () => fees?.tradeFeeSource === SwapperName.Thorchain,
-    [fees?.tradeFeeSource],
-  )
-
-  const is0xSwap = useMemo(() => fees?.tradeFeeSource === SwapperName.Zrx, [fees?.tradeFeeSource])
+  const isTHORChainSwap = useMemo(() => swapperName === SwapperName.Thorchain, [swapperName])
+  const is0xSwap = useMemo(() => swapperName === SwapperName.Zrx, [swapperName])
 
   const shouldShowDonationOption = useMemo(() => {
     return (isTHORChainSwap || is0xSwap) && !isDonationAmountBelowMinimum

--- a/src/constants/treasury.ts
+++ b/src/constants/treasury.ts
@@ -1,0 +1,3 @@
+// Wallets relating to the ShapeShift DAO Treasury
+
+export const DAO_TREASURY_ETHEREUM_MAINNET = '0x90a48d5cf7343b08da12e067680b4c6dbfe551be'

--- a/src/constants/treasury.ts
+++ b/src/constants/treasury.ts
@@ -1,3 +1,14 @@
 // Wallets relating to the ShapeShift DAO Treasury
+// https://forum.shapeshift.com/thread/dao-treasuries-and-multisigs-43646
 
+// Safes
 export const DAO_TREASURY_ETHEREUM_MAINNET = '0x90a48d5cf7343b08da12e067680b4c6dbfe551be'
+export const DAO_TREASURY_OPTIMISM = '0x6268d07327f4fb7380732dc6d63d95F88c0E083b'
+export const DAO_TREASURY_AVALANCHE = '0x74d63F31C2335b5b3BA7ad2812357672b2624cEd'
+export const DAO_TREASURY_POLYGON = '0xB5F944600785724e31Edb90F9DFa16dBF01Af000'
+export const DAO_TREASURY_GNOSIS = '0xb0E3175341794D1dc8E5F02a02F9D26989EbedB3'
+export const DAO_TREASURY_BSC = '0x8b92b1698b57bEDF2142297e9397875ADBb2297E'
+
+// Multisigs
+export const DAO_TREASURY_COSMOS = 'cosmos1qgmqsmytnwm6mhyxwjeur966lv9jacfexgfzxs'
+export const DAO_TREASURY_THORCHAIN = 'thor1xmaggkcln5m5fnha2780xrdrulmplvfrz6wj3l'

--- a/src/lib/swapper/swappers/OneInchSwapper/buildTrade/buildTrade.ts
+++ b/src/lib/swapper/swappers/OneInchSwapper/buildTrade/buildTrade.ts
@@ -3,11 +3,12 @@ import type { EvmChainId } from '@shapeshiftoss/chain-adapters'
 import { isEvmChainId } from '@shapeshiftoss/chain-adapters'
 import type { Result } from '@sniptt/monads'
 import { Err, Ok } from '@sniptt/monads'
+import { DAO_TREASURY_ETHEREUM_MAINNET } from 'constants/treasury'
 import { bnOrZero } from 'lib/bignumber/bignumber'
 import type { BuildTradeInput, SwapErrorRight } from 'lib/swapper/api'
 import { makeSwapErrorRight, SwapErrorType } from 'lib/swapper/api'
 
-import { DEFAULT_SLIPPAGE, DEFAULT_SOURCE, REFERRAL_ADDRESS } from '../utils/constants'
+import { DEFAULT_SLIPPAGE, DEFAULT_SOURCE } from '../utils/constants'
 import { getRate } from '../utils/helpers'
 import { oneInchService } from '../utils/oneInchService'
 import type {
@@ -72,7 +73,7 @@ export const buildTrade = async (
     amount: sellAmountBeforeFeesCryptoBaseUnit,
     slippage: slippagePercentage,
     allowPartialFill: false,
-    referrerAddress: REFERRAL_ADDRESS,
+    referrerAddress: DAO_TREASURY_ETHEREUM_MAINNET,
     disableEstimate: false,
   }
 

--- a/src/lib/swapper/swappers/OneInchSwapper/utils/constants.ts
+++ b/src/lib/swapper/swappers/OneInchSwapper/utils/constants.ts
@@ -7,7 +7,6 @@ export const MIN_ONEINCH_VALUE_USD = 1
 export const DEFAULT_SLIPPAGE = '0.002' // .2%
 export const DEFAULT_SOURCE: SwapSource[] = [{ name: SwapperName.OneInch, proportion: '1' }]
 // TODO: How does this work for other chains, do we need multisigs on all the chains?
-export const REFERRAL_ADDRESS = '0x90a48d5cf7343b08da12e067680b4c6dbfe551be' // DAO treasury?
 export const WETH_ASSET_ID = 'eip155:1/erc20:0xc02aaa39b223fe8d0a0e5c4f27ead9083c756cc2'
 export const WAVAX_ASSET_ID = 'eip155:43114/erc20:0xb31f66aa3c1e785363f0875a1b74e27b85fd66c7'
 export const WBNB_ASSET_ID = 'eip155:56/erc20:0xbb4CdB9CBd36B01bD1cBaEBF2De08d9173bc095c'

--- a/src/lib/swapper/swappers/ZrxSwapper/getZrxTradeQuote/getZrxTradeQuote.ts
+++ b/src/lib/swapper/swappers/ZrxSwapper/getZrxTradeQuote/getZrxTradeQuote.ts
@@ -1,7 +1,6 @@
 import { optimism } from '@shapeshiftoss/chain-adapters'
 import type { Result } from '@sniptt/monads'
 import { Err, Ok } from '@sniptt/monads'
-import { DAO_TREASURY_ETHEREUM_MAINNET } from 'constants/treasury'
 import { bn, bnOrZero } from 'lib/bignumber/bignumber'
 import type { GetEvmTradeQuoteInput, SwapErrorRight, TradeQuote } from 'lib/swapper/api'
 import { normalizeAmount } from 'lib/swapper/swappers/utils/helpers/helpers'
@@ -17,6 +16,7 @@ import {
   assertValidTradePair,
   assetToToken,
   baseUrlFromChainId,
+  getTreasuryAddressForReceiveAsset,
 } from 'lib/swapper/swappers/ZrxSwapper/utils/helpers/helpers'
 import { zrxServiceFactory } from 'lib/swapper/swappers/ZrxSwapper/utils/zrxService'
 import type { ZrxSupportedChainId } from 'lib/swapper/swappers/ZrxSwapper/ZrxSwapper'
@@ -53,6 +53,7 @@ export async function getZrxTradeQuote<T extends ZrxSupportedChainId>(
   )
 
   const buyTokenPercentageFee = convertBasisPointsToDecimalPercentage(affiliateBps).toNumber()
+  const feeRecipient = getTreasuryAddressForReceiveAsset(buyAsset.assetId)
 
   // https://docs.0x.org/0x-swap-api/api-references/get-swap-v1-price
   const maybeZrxPriceResponse = (
@@ -64,7 +65,7 @@ export async function getZrxTradeQuote<T extends ZrxSupportedChainId>(
         takerAddress: receiveAddress,
         affiliateAddress: AFFILIATE_ADDRESS, // Used for 0x analytics
         skipValidation: true,
-        feeRecipient: DAO_TREASURY_ETHEREUM_MAINNET, // Where affiliate fees are sent
+        feeRecipient, // Where affiliate fees are sent
         buyTokenPercentageFee,
       },
     })

--- a/src/lib/swapper/swappers/ZrxSwapper/getZrxTradeQuote/getZrxTradeQuote.ts
+++ b/src/lib/swapper/swappers/ZrxSwapper/getZrxTradeQuote/getZrxTradeQuote.ts
@@ -1,6 +1,7 @@
 import { optimism } from '@shapeshiftoss/chain-adapters'
 import type { Result } from '@sniptt/monads'
 import { Err, Ok } from '@sniptt/monads'
+import { DAO_TREASURY_ETHEREUM_MAINNET } from 'constants/treasury'
 import { bn, bnOrZero } from 'lib/bignumber/bignumber'
 import type { GetEvmTradeQuoteInput, SwapErrorRight, TradeQuote } from 'lib/swapper/api'
 import { normalizeAmount } from 'lib/swapper/swappers/utils/helpers/helpers'
@@ -9,7 +10,6 @@ import type { ZrxPriceResponse, ZrxSwapperDeps } from 'lib/swapper/swappers/ZrxS
 import {
   AFFILIATE_ADDRESS,
   DEFAULT_SOURCE,
-  FEE_RECIPIENT,
   OPTIMISM_L1_APPROVE_GAS_LIMIT,
   OPTIMISM_L1_SWAP_GAS_LIMIT,
 } from 'lib/swapper/swappers/ZrxSwapper/utils/constants'
@@ -64,7 +64,7 @@ export async function getZrxTradeQuote<T extends ZrxSupportedChainId>(
         takerAddress: receiveAddress,
         affiliateAddress: AFFILIATE_ADDRESS, // Used for 0x analytics
         skipValidation: true,
-        feeRecipient: FEE_RECIPIENT, // Where affiliate fees are sent
+        feeRecipient: DAO_TREASURY_ETHEREUM_MAINNET, // Where affiliate fees are sent
         buyTokenPercentageFee,
       },
     })

--- a/src/lib/swapper/swappers/ZrxSwapper/utils/constants.ts
+++ b/src/lib/swapper/swappers/ZrxSwapper/utils/constants.ts
@@ -6,4 +6,3 @@ export const DEFAULT_SOURCE: SwapSource[] = [{ name: SwapperName.Zrx, proportion
 export const AFFILIATE_ADDRESS = '0xc770eefad204b5180df6a14ee197d99d808ee52d'
 export const OPTIMISM_L1_SWAP_GAS_LIMIT = '50000'
 export const OPTIMISM_L1_APPROVE_GAS_LIMIT = '10000'
-export const FEE_RECIPIENT = '0x90A48D5CF7343B08dA12E067680B4C6dbfE551Be' // DAO treasury

--- a/src/lib/swapper/swappers/ZrxSwapper/utils/constants.ts
+++ b/src/lib/swapper/swappers/ZrxSwapper/utils/constants.ts
@@ -6,3 +6,4 @@ export const DEFAULT_SOURCE: SwapSource[] = [{ name: SwapperName.Zrx, proportion
 export const AFFILIATE_ADDRESS = '0xc770eefad204b5180df6a14ee197d99d808ee52d'
 export const OPTIMISM_L1_SWAP_GAS_LIMIT = '50000'
 export const OPTIMISM_L1_APPROVE_GAS_LIMIT = '10000'
+export const FEE_RECIPIENT = '0x90A48D5CF7343B08dA12E067680B4C6dbfE551Be' // DAO treasury

--- a/src/lib/swapper/swappers/ZrxSwapper/utils/helpers/helpers.test.ts
+++ b/src/lib/swapper/swappers/ZrxSwapper/utils/helpers/helpers.test.ts
@@ -1,8 +1,9 @@
+import { ethAssetId, foxAssetId, optimismAssetId, thorchainAssetId } from '@shapeshiftoss/caip'
 import { Ok } from '@sniptt/monads'
 import type { AxiosStatic } from 'axios'
 import { DAO_TREASURY_ETHEREUM_MAINNET, DAO_TREASURY_OPTIMISM } from 'constants/treasury'
 
-import { ETH, FOX, OPTIMISM, RUNE, WETH } from '../../../utils/test-data/assets'
+import { FOX, WETH } from '../../../utils/test-data/assets'
 import { zrxServiceFactory } from '../zrxService'
 import { getTreasuryAddressForReceiveAsset, getUsdRate } from './helpers'
 
@@ -47,22 +48,22 @@ describe('utils', () => {
 
   describe('getTreasuryAddressForReceiveAsset', () => {
     it('gets the treasury address for an ERC20 asset', () => {
-      const treasuryAddress = getTreasuryAddressForReceiveAsset(FOX)
+      const treasuryAddress = getTreasuryAddressForReceiveAsset(foxAssetId)
       expect(treasuryAddress).toStrictEqual(DAO_TREASURY_ETHEREUM_MAINNET)
     })
 
     it('gets the treasury address for ETH asset', () => {
-      const treasuryAddress = getTreasuryAddressForReceiveAsset(ETH)
+      const treasuryAddress = getTreasuryAddressForReceiveAsset(ethAssetId)
       expect(treasuryAddress).toStrictEqual(DAO_TREASURY_ETHEREUM_MAINNET)
     })
 
     it('gets the treasury address for Optimism asset', () => {
-      const treasuryAddress = getTreasuryAddressForReceiveAsset(OPTIMISM)
+      const treasuryAddress = getTreasuryAddressForReceiveAsset(optimismAssetId)
       expect(treasuryAddress).toStrictEqual(DAO_TREASURY_OPTIMISM)
     })
 
     it('throws for unsupported chains', () => {
-      expect(() => getTreasuryAddressForReceiveAsset(RUNE)).toThrow(
+      expect(() => getTreasuryAddressForReceiveAsset(thorchainAssetId)).toThrow(
         '[getTreasuryAddressForReceiveAsset] - Unsupported chainId',
       )
     })

--- a/src/lib/swapper/swappers/ZrxSwapper/utils/helpers/helpers.test.ts
+++ b/src/lib/swapper/swappers/ZrxSwapper/utils/helpers/helpers.test.ts
@@ -1,9 +1,10 @@
 import { Ok } from '@sniptt/monads'
 import type { AxiosStatic } from 'axios'
+import { DAO_TREASURY_ETHEREUM_MAINNET, DAO_TREASURY_OPTIMISM } from 'constants/treasury'
 
-import { FOX, WETH } from '../../../utils/test-data/assets'
+import { ETH, FOX, OPTIMISM, RUNE, WETH } from '../../../utils/test-data/assets'
 import { zrxServiceFactory } from '../zrxService'
-import { getUsdRate } from './helpers'
+import { getTreasuryAddressForReceiveAsset, getUsdRate } from './helpers'
 
 jest.mock('lib/swapper/swappers/ZrxSwapper/utils/zrxService', () => {
   const axios: AxiosStatic = jest.createMockFromModule('axios')
@@ -41,6 +42,29 @@ describe('utils', () => {
         message: '[getUsdRate] - Failed to get price data',
         name: 'SwapError',
       })
+    })
+  })
+
+  describe('getTreasuryAddressForReceiveAsset', () => {
+    it('gets the treasury address for an ERC20 asset', () => {
+      const treasuryAddress = getTreasuryAddressForReceiveAsset(FOX)
+      expect(treasuryAddress).toStrictEqual(DAO_TREASURY_ETHEREUM_MAINNET)
+    })
+
+    it('gets the treasury address for ETH asset', () => {
+      const treasuryAddress = getTreasuryAddressForReceiveAsset(ETH)
+      expect(treasuryAddress).toStrictEqual(DAO_TREASURY_ETHEREUM_MAINNET)
+    })
+
+    it('gets the treasury address for Optimism asset', () => {
+      const treasuryAddress = getTreasuryAddressForReceiveAsset(OPTIMISM)
+      expect(treasuryAddress).toStrictEqual(DAO_TREASURY_OPTIMISM)
+    })
+
+    it('throws for unsupported chains', () => {
+      expect(() => getTreasuryAddressForReceiveAsset(RUNE)).toThrow(
+        '[getTreasuryAddressForReceiveAsset] - Unsupported chainId',
+      )
     })
   })
 })

--- a/src/lib/swapper/swappers/ZrxSwapper/utils/helpers/helpers.ts
+++ b/src/lib/swapper/swappers/ZrxSwapper/utils/helpers/helpers.ts
@@ -146,8 +146,8 @@ export const assertValidTradePair = ({
   )
 }
 
-export const getTreasuryAddressForReceiveAsset = (asset: Asset): string => {
-  const chainId = fromAssetId(asset.assetId).chainId
+export const getTreasuryAddressForReceiveAsset = (assetId: AssetId): string => {
+  const chainId = fromAssetId(assetId).chainId
   switch (chainId) {
     case KnownChainIds.EthereumMainnet:
       return DAO_TREASURY_ETHEREUM_MAINNET

--- a/src/lib/swapper/swappers/ZrxSwapper/utils/helpers/helpers.ts
+++ b/src/lib/swapper/swappers/ZrxSwapper/utils/helpers/helpers.ts
@@ -11,6 +11,13 @@ import {
 import { KnownChainIds } from '@shapeshiftoss/types'
 import type { Result } from '@sniptt/monads'
 import { Err, Ok } from '@sniptt/monads'
+import {
+  DAO_TREASURY_AVALANCHE,
+  DAO_TREASURY_BSC,
+  DAO_TREASURY_ETHEREUM_MAINNET,
+  DAO_TREASURY_OPTIMISM,
+  DAO_TREASURY_POLYGON,
+} from 'constants/treasury'
 import { bn, bnOrZero } from 'lib/bignumber/bignumber'
 import type { SwapErrorRight } from 'lib/swapper/api'
 import { makeSwapErrorRight, SwapError, SwapErrorType } from 'lib/swapper/api'
@@ -137,4 +144,22 @@ export const assertValidTradePair = ({
       },
     }),
   )
+}
+
+export const getTreasuryAddressForReceiveAsset = (asset: Asset): string => {
+  const chainId = fromAssetId(asset.assetId).chainId
+  switch (chainId) {
+    case KnownChainIds.EthereumMainnet:
+      return DAO_TREASURY_ETHEREUM_MAINNET
+    case KnownChainIds.AvalancheMainnet:
+      return DAO_TREASURY_AVALANCHE
+    case KnownChainIds.OptimismMainnet:
+      return DAO_TREASURY_OPTIMISM
+    case KnownChainIds.BnbSmartChainMainnet:
+      return DAO_TREASURY_BSC
+    case KnownChainIds.PolygonMainnet:
+      return DAO_TREASURY_POLYGON
+    default:
+      throw new Error(`[getTreasuryAddressForReceiveAsset] - Unsupported chainId: ${chainId}`)
+  }
 }

--- a/src/lib/swapper/swappers/ZrxSwapper/zrxBuildTrade/zrxBuildTrade.ts
+++ b/src/lib/swapper/swappers/ZrxSwapper/zrxBuildTrade/zrxBuildTrade.ts
@@ -1,6 +1,7 @@
 import type { Result } from '@sniptt/monads'
 import { Err, Ok } from '@sniptt/monads'
 import type { AxiosInstance } from 'axios'
+import { DAO_TREASURY_ETHEREUM_MAINNET } from 'constants/treasury'
 import * as rax from 'retry-axios'
 import { bnOrZero } from 'lib/bignumber/bignumber'
 import type { BuildTradeInput, SwapErrorRight } from 'lib/swapper/api'
@@ -12,11 +13,7 @@ import type {
   ZrxTrade,
 } from 'lib/swapper/swappers/ZrxSwapper/types'
 import { withAxiosRetry } from 'lib/swapper/swappers/ZrxSwapper/utils/applyAxiosRetry'
-import {
-  AFFILIATE_ADDRESS,
-  DEFAULT_SOURCE,
-  FEE_RECIPIENT,
-} from 'lib/swapper/swappers/ZrxSwapper/utils/constants'
+import { AFFILIATE_ADDRESS, DEFAULT_SOURCE } from 'lib/swapper/swappers/ZrxSwapper/utils/constants'
 import {
   assertValidTradePair,
   assetToToken,
@@ -72,7 +69,7 @@ export async function zrxBuildTrade<T extends ZrxSupportedChainId>(
       slippagePercentage: slippage ? bnOrZero(slippage).toString() : DEFAULT_SLIPPAGE,
       affiliateAddress: AFFILIATE_ADDRESS, // Used for 0x analytics
       skipValidation: false,
-      feeRecipient: FEE_RECIPIENT, // Where affiliate fees are sent
+      feeRecipient: DAO_TREASURY_ETHEREUM_MAINNET, // Where affiliate fees are sent
       buyTokenPercentageFee,
     },
   })

--- a/src/lib/swapper/swappers/ZrxSwapper/zrxBuildTrade/zrxBuildTrade.ts
+++ b/src/lib/swapper/swappers/ZrxSwapper/zrxBuildTrade/zrxBuildTrade.ts
@@ -1,7 +1,6 @@
 import type { Result } from '@sniptt/monads'
 import { Err, Ok } from '@sniptt/monads'
 import type { AxiosInstance } from 'axios'
-import { DAO_TREASURY_ETHEREUM_MAINNET } from 'constants/treasury'
 import * as rax from 'retry-axios'
 import { bnOrZero } from 'lib/bignumber/bignumber'
 import type { BuildTradeInput, SwapErrorRight } from 'lib/swapper/api'
@@ -18,6 +17,7 @@ import {
   assertValidTradePair,
   assetToToken,
   baseUrlFromChainId,
+  getTreasuryAddressForReceiveAsset,
 } from 'lib/swapper/swappers/ZrxSwapper/utils/helpers/helpers'
 import { zrxServiceFactory } from 'lib/swapper/swappers/ZrxSwapper/utils/zrxService'
 import type { ZrxSupportedChainId } from 'lib/swapper/swappers/ZrxSwapper/ZrxSwapper'
@@ -58,6 +58,7 @@ export async function zrxBuildTrade<T extends ZrxSupportedChainId>(
   })
 
   const buyTokenPercentageFee = convertBasisPointsToDecimalPercentage(affiliateBps).toNumber()
+  const feeRecipient = getTreasuryAddressForReceiveAsset(buyAsset.assetId)
 
   // https://docs.0x.org/0x-swap-api/api-references/get-swap-v1-quote
   const maybeQuoteResponse = await zrxService.get<ZrxQuoteResponse>('/swap/v1/quote', {
@@ -69,7 +70,7 @@ export async function zrxBuildTrade<T extends ZrxSupportedChainId>(
       slippagePercentage: slippage ? bnOrZero(slippage).toString() : DEFAULT_SLIPPAGE,
       affiliateAddress: AFFILIATE_ADDRESS, // Used for 0x analytics
       skipValidation: false,
-      feeRecipient: DAO_TREASURY_ETHEREUM_MAINNET, // Where affiliate fees are sent
+      feeRecipient, // Where affiliate fees are sent
       buyTokenPercentageFee,
     },
   })

--- a/src/state/zustand/swapperStore/amountSelectors.ts
+++ b/src/state/zustand/swapperStore/amountSelectors.ts
@@ -16,7 +16,7 @@ import {
   selectSlippage,
 } from 'state/zustand/swapperStore/selectors'
 import type { SwapperState } from 'state/zustand/swapperStore/types'
-import { convertBasisPointsToPercentage } from 'state/zustand/swapperStore/utils'
+import { convertBasisPointsToDecimalPercentage } from 'state/zustand/swapperStore/utils'
 
 const selectAssetPriceRatio = createSelector(
   selectBuyAssetFiatRate,
@@ -583,7 +583,7 @@ export const selectDonationAmountFiat = createSelector(
   selectSellAmountFiat,
   selectAffiliateBps,
   (sellAmountFiat, affiliateBps): string => {
-    const affiliatePercentage = convertBasisPointsToPercentage(affiliateBps)
+    const affiliatePercentage = convertBasisPointsToDecimalPercentage(affiliateBps)
     // The donation amount is a percentage of the sell amount
     return bnOrZero(sellAmountFiat).times(affiliatePercentage).toFixed()
   },

--- a/src/state/zustand/swapperStore/selectors.ts
+++ b/src/state/zustand/swapperStore/selectors.ts
@@ -92,10 +92,10 @@ export const selectSwapperDefaultAffiliateBps = (state: SwapperState): string =>
 
   switch (swapperName) {
     case SwapperName.Thorchain:
+    case SwapperName.Zrx:
       return '30'
     case SwapperName.Osmosis:
     case SwapperName.LIFI:
-    case SwapperName.Zrx:
     case SwapperName.CowSwap:
     case SwapperName.OneInch:
     case SwapperName.Test:

--- a/src/state/zustand/swapperStore/selectors.ts
+++ b/src/state/zustand/swapperStore/selectors.ts
@@ -44,6 +44,8 @@ export const selectAmount = (state: SwapperState) => state.amount
 export const selectReceiveAddress = (state: SwapperState) => state.receiveAddress
 export const selectFees = (state: SwapperState) => state.fees
 export const selectTrade = (state: SwapperState) => state.trade
+export const selectSwapperName = (state: SwapperState) =>
+  state.activeSwapperWithMetadata?.swapper.name
 export const selectActiveSwapperWithMetadata = (state: SwapperState) =>
   state.activeSwapperWithMetadata
 export const selectAvailableSwappersWithMetadata = (state: SwapperState) =>

--- a/src/state/zustand/swapperStore/utils.ts
+++ b/src/state/zustand/swapperStore/utils.ts
@@ -1,5 +1,5 @@
 // Helper function to convert basis points to percentage
 import { bnOrZero } from 'lib/bignumber/bignumber'
 
-export const convertBasisPointsToPercentage = (basisPoints: string) =>
+export const convertBasisPointsToDecimalPercentage = (basisPoints: string) =>
   bnOrZero(basisPoints).div(10000)


### PR DESCRIPTION
## Description

Adds donations to 0x swapper.

~First TX: https://bscscan.com/tx/0x54b77347e57622fdea28e62c1251446975306a64abd2804288fdd0d5ed39ab7d 🥳~
TX to new BSC Safe using dynamic treasury addresses: https://bscscan.com/tx/0xdacc529214b48a2b73fbf4a24b734437a10ca1461aada8b65fb26edaa249514b

TODO before opening from draft: add affiliate addresses for swaps into assets not supported by the DAO treasury address.
@willyogo to confirm these addresses.

## Pull Request Type

- [ ] :bug: Bug fix (Non-breaking Change: Fixes an issue)
- [ ] :hammer_and_wrench: Chore (Non-breaking Change: Doc updates, pkg upgrades, typos, etc..)
- [x] :nail_care: New Feature (Breaking/Non-breaking Change)

## Issue (if applicable)

N/A

## Risk

Small, though 0x trades should be tested/executed.

## Testing

Perform a 0x swap both with and without the donation checkbox checked.

When checked, we should collect a 30bps fee from the receive amount, which we recive in the recive asset.

### Engineering

☝️

### Operations

☝️

## Screenshots (if applicable)

N/A
