### PR TITLE
feat: ignore donation amounts below minimum

### DIFF
--- a/src/components/Trade/TradeConfirm/TradeConfirm.tsx
+++ b/src/components/Trade/TradeConfirm/TradeConfirm.tsx
@@ -29,6 +29,7 @@ import { HelperTooltip } from 'components/HelperTooltip/HelperTooltip'
 import { Row } from 'components/Row/Row'
 import { SlideTransition } from 'components/SlideTransition'
 import { RawText, Text } from 'components/Text'
+import { useDonationAmountBelowMinimum } from 'components/Trade/hooks/useDonationAmountBelowMinimum'
 import { useSwapper } from 'components/Trade/hooks/useSwapper/useSwapper'
 import { WalletActions } from 'context/WalletProvider/actions'
 import { useErrorHandler } from 'hooks/useErrorToast/useErrorToast'
@@ -100,6 +101,8 @@ export const TradeConfirm = () => {
     state: { isConnected, wallet },
     dispatch: walletDispatch,
   } = useWallet()
+
+  const isDonationAmountBelowMinimum = useDonationAmountBelowMinimum()
 
   const { getTrade } = useSwapper()
 

--- a/src/components/Trade/TradeConfirm/TradeConfirm.tsx
+++ b/src/components/Trade/TradeConfirm/TradeConfirm.tsx
@@ -415,7 +415,9 @@ export const TradeConfirm = () => {
     [fees?.tradeFeeSource],
   )
 
-  const shouldShowDonationOption = isTHORChainSwap
+  const shouldShowDonationOption = useMemo(() => {
+    return isTHORChainSwap && !isDonationAmountBelowMinimum
+  }, [isDonationAmountBelowMinimum, isTHORChainSwap])
 
   const tradeWarning: JSX.Element | null = useMemo(() => {
     if (!trade) return null

--- a/src/components/Trade/hooks/useDonationAmountBelowMinimum.tsx
+++ b/src/components/Trade/hooks/useDonationAmountBelowMinimum.tsx
@@ -1,0 +1,30 @@
+import { thorchainAssetId } from '@shapeshiftoss/caip'
+import { useMemo } from 'react'
+import { bnOrZero } from 'lib/bignumber/bignumber'
+import { SwapperName } from 'lib/swapper/api'
+import { RUNE_OUTBOUND_TRANSACTION_FEE_CRYPTO_HUMAN } from 'lib/swapper/swappers/ThorchainSwapper/constants'
+import { selectMarketDataById } from 'state/slices/marketDataSlice/selectors'
+import { useAppSelector } from 'state/store'
+import { selectDonationAmountFiat } from 'state/zustand/swapperStore/amountSelectors'
+import { useSwapperStore } from 'state/zustand/swapperStore/useSwapperStore'
+
+export const useDonationAmountBelowMinimum = () => {
+  const runePrice = useAppSelector(state => selectMarketDataById(state, thorchainAssetId)).price
+  const donationAmountFiat = useSwapperStore(selectDonationAmountFiat)
+  const activeSwapperName = useSwapperStore(state => state.activeSwapperWithMetadata?.swapper.name)
+
+  // Some swappers have a minimum donation amount, whereby collecting below that amount will result in the donated amount being lost
+  const isDonationAmountBelowMinimum = useMemo(() => {
+    switch (activeSwapperName) {
+      case SwapperName.Thorchain: {
+        return bnOrZero(donationAmountFiat)
+          .div(runePrice)
+          .lte(RUNE_OUTBOUND_TRANSACTION_FEE_CRYPTO_HUMAN)
+      }
+      default:
+        return false
+    }
+  }, [activeSwapperName, donationAmountFiat, runePrice])
+
+  return isDonationAmountBelowMinimum
+}

--- a/src/components/Trade/hooks/useSwapper/useSwapper.tsx
+++ b/src/components/Trade/hooks/useSwapper/useSwapper.tsx
@@ -1,6 +1,7 @@
 import type { AssetId } from '@shapeshiftoss/caip'
 import { useCallback, useEffect, useMemo, useState } from 'react'
 import { useSelector } from 'react-redux'
+import { useDonationAmountBelowMinimum } from 'components/Trade/hooks/useDonationAmountBelowMinimum'
 import { getSwapperManager } from 'components/Trade/hooks/useSwapper/swapperManager'
 import { useWallet } from 'hooks/useWallet/useWallet'
 import type { SwapperManager } from 'lib/swapper/manager/SwapperManager'
@@ -48,6 +49,7 @@ export const useSwapper = () => {
   // Hooks
   const [swapperManager, setSwapperManager] = useState<SwapperManager>()
   const wallet = useWallet().state.wallet
+  const isDonationAmountBelowMinimum = useDonationAmountBelowMinimum()
 
   // Selectors
   const supportedSellAssetsByMarketCap = useMemo(() => {
@@ -130,7 +132,7 @@ export const useSwapper = () => {
         sellAccountBip44Params,
         sellAccountMetadata,
         buyAccountBip44Params,
-        affiliateBps: affiliateBps ?? defaultAffiliateBps,
+        affiliateBps: isDonationAmountBelowMinimum ? '0' : affiliateBps ?? defaultAffiliateBps,
       })
       return trade
     },
@@ -140,6 +142,7 @@ export const useSwapper = () => {
       buyAccountBip44Params,
       sellAccountMetadata,
       getTradeForWallet,
+      isDonationAmountBelowMinimum,
       defaultAffiliateBps,
     ],
   )


### PR DESCRIPTION
## Description

For low-value trades the affiliate fee we collect is lower than the gas fee requried to get it to our wallet.

For 0x it's included in the gas fee the user pays.
For THORChain we lose 0.02 RUNE worth of the affiliate fee to get it to our affilite wallet. Affiliate amounts lower than that are lost, so we shouldn't bother collecting them.

This PR hides the donation UX, and removes affiliate fees from THORSwaps where the affiliate fee collected would be at or below 0.02 RUNE.

## Pull Request Type

- [ ] :bug: Bug fix (Non-breaking Change: Fixes an issue)
- [ ] :hammer_and_wrench: Chore (Non-breaking Change: Doc updates, pkg upgrades, typos, etc..)
- [x] :nail_care: New Feature (Breaking/Non-breaking Change)

## Issue (if applicable)

N/A

## Risk

Small.

## Testing

Test that small THORTrades do not show the donation UI or include an affiliate fee in the memo.

Test that 0x donations are unaffected by this PR.

### Engineering

☝️

### Operations

☝️

## Screenshots (if applicable)

N/A
