### PR TITLE
fix: re-organise routes DOM

### DIFF
--- a/src/Routes/Routes.tsx
+++ b/src/Routes/Routes.tsx
@@ -88,38 +88,42 @@ export const Routes = () => {
   )
 
   return (
-    <Switch location={background || location}>
-      <Route path='/demo'>
-        {() => {
-          return shouldRedirectDemoRoute ? (
-            <Redirect
-              from='/'
-              to={
-                matchDemoPath?.params?.appRoute ? `/${matchDemoPath.params.appRoute}` : '/dashboard'
-              }
-            />
-          ) : null
-        }}
-      </Route>
+    <>
+      <Switch location={background || location}>
+        <Route path='/demo'>
+          {() => {
+            return shouldRedirectDemoRoute ? (
+              <Redirect
+                from='/'
+                to={
+                  matchDemoPath?.params?.appRoute
+                    ? `/${matchDemoPath.params.appRoute}`
+                    : '/dashboard'
+                }
+              />
+            ) : null
+          }}
+        </Route>
 
-      <Route path='/connect-wallet'>
-        <ConnectWallet />
-      </Route>
-      <Route path={'/legal/terms-of-service'}>
-        <Layout>
-          <TermsOfService />
-        </Layout>
-      </Route>
-      <Route path={'/legal/privacy-policy'}>
-        <Layout>
-          <PrivacyPolicy />
-        </Layout>
-      </Route>
-      <Route path='/flags'>
-        <Layout>
-          <Flags />
-        </Layout>
-      </Route>
+        <Route path='/connect-wallet'>
+          <ConnectWallet />
+        </Route>
+        <Route path={'/legal/terms-of-service'}>
+          <Layout>
+            <TermsOfService />
+          </Layout>
+        </Route>
+        <Route path={'/legal/privacy-policy'}>
+          <Layout>
+            <PrivacyPolicy />
+          </Layout>
+        </Route>
+        <Route path='/flags'>
+          <Layout>
+            <Flags />
+          </Layout>
+        </Route>
+      </Switch>
       <Layout>
         <Switch>
           {privateRoutesList}
@@ -129,6 +133,6 @@ export const Routes = () => {
           </Route>
         </Switch>
       </Layout>
-    </Switch>
+    </>
   )
 }


### PR DESCRIPTION
## Description

A Switch element can only have either Redirect or Route's as direct children.

Not doing so was causing ugly console errors.
This PR fixes that by rearranging the DOM.

<img width="793" alt="Screenshot 2023-05-02 at 5 00 48 pm" src="https://user-images.githubusercontent.com/97164662/235600713-3d029de0-69e7-459d-bdfd-05cabf242083.png">

## Pull Request Type

- [x] :bug: Bug fix (Non-breaking Change: Fixes an issue)
- [ ] :hammer_and_wrench: Chore (Non-breaking Change: Doc updates, pkg upgrades, typos, etc..)
- [ ] :nail_care: New Feature (Breaking/Non-breaking Change)

## Issue (if applicable)

N/A

## Risk

Small.

## Testing

- Ensure all routes still work as expected
- The error in the screenshot above should no longer appear

### Engineering

☝️

### Operations

☝️

## Screenshots (if applicable)

N/A
