### PR TITLE
fix: only track confirmed trades after sign and broadcast

### DIFF
--- a/src/components/Trade/TradeConfirm/TradeConfirm.tsx
+++ b/src/components/Trade/TradeConfirm/TradeConfirm.tsx
@@ -307,11 +307,14 @@ export const TradeConfirm = () => {
         return
       }
 
+      const result = await swapper.executeTrade({ trade, wallet })
+
+      // only track after swapper successfully executes trade
+      // otherwise unsigned txs will be tracked as confirmed trades
       if (mixpanel && eventData) {
         mixpanel.track(MixPanelEvents.TradeConfirm, eventData)
       }
 
-      const result = await swapper.executeTrade({ trade, wallet })
       // TODO(gomes): should we we throw so the catch clause handles this?
       if (result.isErr()) return
       setSellTradeId(result.unwrap().tradeId)


### PR DESCRIPTION
## Description

<!-- Please describe your changes -->

small fix - put the mixpanel trade confirm tracking after the swapper executes the trade

## Pull Request Type

- [x] :bug: Bug fix (Non-breaking Change: Fixes an issue)
- [ ] :hammer_and_wrench: Chore (Non-breaking Change: Doc updates, pkg upgrades, typos, etc..)
- [ ] :nail_care: New Feature (Breaking/Non-breaking Change)

## Issue (if applicable)

<!-----------------------------------------------------------------------------
If applicable, please link to the github issue and put `closes #XXXX` in your comment to auto-close the issue that your PR fixes.
------------------------------------------------------------------------------>

n/a - related to erroneous mixpanel trade data

## Risk

extremely low

<!-----------------------------------------------------------------------------
Outline the scope of your changes and the risk associated with them. You must use your discretion as an engineer to determine the potential impact of your changes.

E.g. an upgrade to `hdwallet` or core state management would be considered higher risk, and might require a full regression test. UI or isolated view changes, or something behind a feature flag may have near zero risk. Small bug fixes might require testing isolated to the specific fix.
------------------------------------------------------------------------------>

## Testing

<!-----------------------------------------------------------------------------
We treat every PR to be merged with the same scrutiny as if we were merging directly to production.

Your PR will not be merged if you do not complete the sections below for our engineering and operations teams to test.
------------------------------------------------------------------------------>

### Engineering

read my code plz

<!-----------------------------------------------------------------------------
Include sufficient information here for an engineer to test your PR. This may include how to test locally, in a built environment, changes to infrastructure etc.
------------------------------------------------------------------------------>

### Operations

not testable by ops

<!-----------------------------------------------------------------------------
If your changes have a user-facing impact, describe how a non-technical QA team can functionally test your changes in a preview environment.

If they are not user-facing please describe how to test for any regressions that may occur.
------------------------------------------------------------------------------>

## Screenshots (if applicable)
