### PR TITLE
feat: don't await foxy rebase history

### DIFF
--- a/src/context/AppProvider/AppContext.tsx
+++ b/src/context/AppProvider/AppContext.tsx
@@ -175,10 +175,6 @@ export const AppProvider = ({ children }: { children: React.ReactNode }) => {
 
       const { getFoxyRebaseHistoryByAccountId } = txHistoryApi.endpoints
 
-      // forceRefetch is enabled here to make sure that we always have the latest state from chain
-      // and ensure the queryFn runs resulting in dispatches occuring to update client state
-      const options = { forceRefetch: true }
-
       const maybeFetchZapperData = DynamicLpAssets
         ? dispatch(zapper.endpoints.getZapperUniV2PoolAssetIds.initiate())
         : () => setTimeoutAsync(0)
@@ -219,9 +215,7 @@ export const AppProvider = ({ children }: { children: React.ReactNode }) => {
              * stop, and make a getRebaseHistoryByAccountId that takes
              * an accountId and assetId[] in the txHistoryApi
              */
-            dispatch(
-              getFoxyRebaseHistoryByAccountId.initiate({ accountId, portfolioAssetIds }, options),
-            )
+            dispatch(getFoxyRebaseHistoryByAccountId.initiate({ accountId, portfolioAssetIds }))
             break
           default:
         }

--- a/src/state/slices/txHistorySlice/txHistorySlice.ts
+++ b/src/state/slices/txHistorySlice/txHistorySlice.ts
@@ -1,7 +1,7 @@
 import { createSlice } from '@reduxjs/toolkit'
 import { createApi } from '@reduxjs/toolkit/dist/query/react'
 import type { AccountId, AssetId } from '@shapeshiftoss/caip'
-import { ethChainId, fromAccountId, toAssetId } from '@shapeshiftoss/caip'
+import { ASSET_NAMESPACE, ethChainId, fromAccountId, toAssetId } from '@shapeshiftoss/caip'
 import type { Transaction } from '@shapeshiftoss/chain-adapters'
 import type { RebaseHistory } from '@shapeshiftoss/investor-foxy'
 import { foxyAddresses } from '@shapeshiftoss/investor-foxy'
@@ -202,36 +202,26 @@ export const txHistoryApi = createApi({
         // foxy is only on eth mainnet, and [] is a valid return type and won't upsert anything
         if (chainId !== ethChainId) return { data: [] }
         // foxy contract address, note not assetIds
-        const foxyTokenContractAddressWithBalances = foxyAddresses.reduce<string[]>(
-          (acc, { foxy }) => {
-            const contractAddress = foxy.toLowerCase()
-            portfolioAssetIds.some(id => id.includes(contractAddress)) && acc.push(contractAddress)
-            return acc
-          },
-          [],
-        )
+        const foxyTokenContractAddress = (() => {
+          const contractAddress = foxyAddresses[0].foxy.toLowerCase()
+          if (portfolioAssetIds.some(id => id.includes(contractAddress))) return contractAddress
+        })()
 
-        // don't do anything below if we don't hold a version of foxy
-        if (!foxyTokenContractAddressWithBalances.length) return { data: [] }
+        // don't do anything below if we don't have FOXy as a portfolio AssetId
+        if (!foxyTokenContractAddress) return { data: [] }
 
         // setup foxy api
         const foxyApi = getFoxyApi()
 
-        Promise.all(
-          foxyTokenContractAddressWithBalances.map(async tokenContractAddress => {
-            const rebaseHistoryArgs = { userAddress, tokenContractAddress }
-            const data = await foxyApi.getRebaseHistory(rebaseHistoryArgs)
-            const assetReference = tokenContractAddress
-            const assetNamespace = 'erc20'
-            const assetId = toAssetId({ chainId, assetNamespace, assetReference })
-            const upsertPayload = { accountId, assetId, data }
-            if (data.length) dispatch(txHistory.actions.upsertRebaseHistory(upsertPayload))
-          }),
-          // we don't really care about the caching of this, we're dispatching
-          // into another part of the portfolio above, we kind of abuse RTK query,
-          // and we're always force refetching these anyway
-        )
-        // We don't need to catch, since foxyApi.getRebaseHistory has dumb error-handling and doesn't throw
+        ;(async () => {
+          const rebaseHistoryArgs = { userAddress, tokenContractAddress: foxyTokenContractAddress }
+          const data = await foxyApi.getRebaseHistory(rebaseHistoryArgs)
+          const assetReference = foxyTokenContractAddress
+          const assetNamespace = ASSET_NAMESPACE.erc20
+          const assetId = toAssetId({ chainId, assetNamespace, assetReference })
+          const upsertPayload = { accountId, assetId, data }
+          if (data.length) dispatch(txHistory.actions.upsertRebaseHistory(upsertPayload))
+        })()
         return { data: [] }
       },
     }),

--- a/src/state/slices/txHistorySlice/txHistorySlice.ts
+++ b/src/state/slices/txHistorySlice/txHistorySlice.ts
@@ -197,7 +197,7 @@ export const txHistoryApi = createApi({
   reducerPath: 'txHistoryApi',
   endpoints: build => ({
     getFoxyRebaseHistoryByAccountId: build.query<RebaseHistory[], RebaseTxHistoryArgs>({
-      queryFn: async ({ accountId, portfolioAssetIds }, { dispatch }) => {
+      queryFn: ({ accountId, portfolioAssetIds }, { dispatch }) => {
         const { chainId, account: userAddress } = fromAccountId(accountId)
         // foxy is only on eth mainnet, and [] is a valid return type and won't upsert anything
         if (chainId !== ethChainId) return { data: [] }
@@ -217,7 +217,7 @@ export const txHistoryApi = createApi({
         // setup foxy api
         const foxyApi = getFoxyApi()
 
-        await Promise.all(
+        Promise.all(
           foxyTokenContractAddressWithBalances.map(async tokenContractAddress => {
             const rebaseHistoryArgs = { userAddress, tokenContractAddress }
             const data = await foxyApi.getRebaseHistory(rebaseHistoryArgs)
@@ -227,11 +227,11 @@ export const txHistoryApi = createApi({
             const upsertPayload = { accountId, assetId, data }
             if (data.length) dispatch(txHistory.actions.upsertRebaseHistory(upsertPayload))
           }),
+          // we don't really care about the caching of this, we're dispatching
+          // into another part of the portfolio above, we kind of abuse RTK query,
+          // and we're always force refetching these anyway
         )
-
-        // we don't really care about the caching of this, we're dispatching
-        // into another part of the portfolio above, we kind of abuse RTK query,
-        // and we're always force refetching these anyway
+        // We don't need to catch, since foxyApi.getRebaseHistory has dumb error-handling and doesn't throw
         return { data: [] }
       },
     }),


### PR DESCRIPTION
## Description

This PR:

- Doesn't await for FOXy rebase history in `getFoxyRebaseHistoryByAccountId`, making it resolve immediately
- Doesn't `forceRefetch` getFoxyRebaseHistoryByAccountId - currently being tested to ensure this doesn't break anything. The reason for that is there will currently be many query thunks being dispatched, always force refetching FOXy rebase history, making a ton of requests and the DeFi section / the app overall slower.
- Removes the assumption of "FOXy contract addresses". This is wrong and because of how the types were originally written in `investor-foxy`. There's only one contract - not only don't we need to `await Promise.all()`, we don't need to map over contract addresses at all since there's only one

## Pull Request Type

- [ ] :bug: Bug fix (Non-breaking Change: Fixes an issue)
- [ ] :hammer_and_wrench: Chore (Non-breaking Change: Doc updates, pkg upgrades, typos, etc..)
- [x] :nail_care: New Feature (Breaking/Non-breaking Change)

## Issue (if applicable)

N/A

## Risk

<!-----------------------------------------------------------------------------
Outline the scope of your changes and the risk associated with them. You must use your discretion as an engineer to determine the potential impact of your changes.

E.g. an upgrade to `hdwallet` or core state management would be considered higher risk, and might require a full regression test. UI or isolated view changes, or something behind a feature flag may have near zero risk. Small bug fixes might require testing isolated to the specific fix.
------------------------------------------------------------------------------>

FOXy data may be wrong/missing if we don't have FOXy as a portfolio asset yet, since we will only refetch on args change.


## Testing

<!-----------------------------------------------------------------------------
We treat every PR to be merged with the same scrutiny as if we were merging directly to production.

Your PR will not be merged if you do not complete the sections below for our engineering and operations teams to test.
------------------------------------------------------------------------------>

- FOXy data is matching the one on prod - APY, claims, available to withdraw
- Ensure switching wallets still shows the balance for the currently connected wallet. Note we do not force refetch now, so in an effort to make less requests, switching back to a previous wallet you had connected during the same session won't refetch data, so you will notice discrepencies against prod while testing the wallet switch flow, which is expected. Switching wallets in this diff should be tested against the same wallet you're switching to in prod (without a wallet switch)

### Engineering

<!-----------------------------------------------------------------------------
Include sufficient information here for an engineer to test your PR. This may include how to test locally, in a built environment, changes to infrastructure etc.
------------------------------------------------------------------------------>

- ☝🏽

### Operations

<!-----------------------------------------------------------------------------
If your changes have a user-facing impact, describe how a non-technical QA team can functionally test your changes in a preview environment.

If they are not user-facing please describe how to test for any regressions that may occur.
------------------------------------------------------------------------------>

- ☝🏽

## Screenshots (if applicable)

### This diff

<img width="170" alt="image" src="https://user-images.githubusercontent.com/17035424/236056958-4fb7ecc5-3d0a-42c4-a803-81c70188824e.png">
<img width="1315" alt="image" src="https://user-images.githubusercontent.com/17035424/236056919-0d3d14ef-4e8e-45d1-8ac4-370cc29b6e9d.png">
<img width="564" alt="image" src="https://user-images.githubusercontent.com/17035424/236056984-5169873c-5c96-4172-81a1-01c4df3a3190.png">
<img width="523" alt="image" src="https://user-images.githubusercontent.com/17035424/236057176-8dfced29-6547-4149-88d0-aaf6d24bbd86.png">

<img width="227" alt="image" src="https://user-images.githubusercontent.com/17035424/236057640-7f010f93-97eb-4324-9586-243fad29537f.png">
<img width="1300" alt="image" src="https://user-images.githubusercontent.com/17035424/236057669-22613c8e-64a3-4d87-8820-c4b52e391aea.png">
<img width="540" alt="image" src="https://user-images.githubusercontent.com/17035424/236057907-6f0017ba-feec-49ad-b4d7-e87c9fb182db.png">
<img width="551" alt="image" src="https://user-images.githubusercontent.com/17035424/236057928-09333aae-f95a-4aae-a0f7-fb4ee531665b.png">


### Prod

<img width="170" alt="image" src="https://user-images.githubusercontent.com/17035424/236056958-4fb7ecc5-3d0a-42c4-a803-81c70188824e.png">
<img width="1311" alt="image" src="https://user-images.githubusercontent.com/17035424/236057228-240deddc-b164-40ef-aee2-1a42dc4d6dea.png">
<img width="531" alt="image" src="https://user-images.githubusercontent.com/17035424/236057259-b0dcfa59-0f19-4ad9-8318-959598602d4b.png">
<img width="537" alt="image" src="https://user-images.githubusercontent.com/17035424/236057196-c70ca203-6656-466e-bfff-7179b04a7082.png">

<img width="227" alt="image" src="https://user-images.githubusercontent.com/17035424/236057635-bdcad900-65df-4ece-a9b9-0d27e2508839.png">
<img width="1300" alt="image" src="https://user-images.githubusercontent.com/17035424/236057665-5543559d-96ef-4f9d-980d-e471dac5d092.png">
<img width="539" alt="image" src="https://user-images.githubusercontent.com/17035424/236057769-a9228b57-b002-4d58-8197-bd022ea3bdb3.png">
<img width="547" alt="image" src="https://user-images.githubusercontent.com/17035424/236057817-427ab517-dac6-49f1-abb3-2e54943231c3.png">