### PR TITLE
fix: handle unsupported intermediary assets in lifi swapper

### DIFF
--- a/src/lib/swapper/api.ts
+++ b/src/lib/swapper/api.ts
@@ -135,7 +135,10 @@ export type BuildTradeInput = GetTradeQuoteInput & {
 
 // describes intermediary asset and amount the user may end up with in the event of a trade
 // execution failure
-export type IntermediaryTransactionOutput = { asset: Asset; buyAmountCryptoBaseUnit: string }
+export type IntermediaryTransactionOutput = {
+  asset: Pick<Asset, 'chainId' | 'symbol' | 'precision'>
+  buyAmountCryptoBaseUnit: string
+}
 
 interface TradeBase<C extends ChainId> {
   buyAmountCryptoBaseUnit: string

--- a/src/lib/swapper/swappers/LifiSwapper/utils/getIntermediaryTransactionOutputs/getIntermediaryTransactionOutputs.ts
+++ b/src/lib/swapper/swappers/LifiSwapper/utils/getIntermediaryTransactionOutputs/getIntermediaryTransactionOutputs.ts
@@ -2,6 +2,7 @@ import type { IntermediaryTransactionOutput } from 'lib/swapper/api'
 import { selectAssets } from 'state/slices/selectors'
 import { store } from 'state/store'
 
+import { lifiChainIdToChainId } from '../lifiChainIdtoChainId/lifiChainIdToChainId'
 import { lifiTokenToAssetId } from '../lifiTokenToAssetId/lifiTokenToAssetId'
 import type { LifiStepSubset, StepSubset } from './types'
 
@@ -24,8 +25,15 @@ export const getIntermediaryTransactionOutputs = (
   return intermediaryTradeData
     .map(step => {
       const assetId = lifiTokenToAssetId(step.action.toToken)
+
+      const asset = assets[assetId] ?? {
+        chainId: lifiChainIdToChainId(step.action.toToken.chainId),
+        symbol: step.action.toToken.symbol,
+        precision: step.action.toToken.decimals,
+      }
+
       return {
-        asset: assets[assetId],
+        asset,
         buyAmountCryptoBaseUnit: step.estimate.toAmountMin,
       }
     })

--- a/src/lib/swapper/swappers/LifiSwapper/utils/lifiChainIdtoChainId/lifiChainIdToChainId.ts
+++ b/src/lib/swapper/swappers/LifiSwapper/utils/lifiChainIdtoChainId/lifiChainIdToChainId.ts
@@ -1,0 +1,9 @@
+import type { ChainId, ChainReference } from '@shapeshiftoss/caip'
+import { CHAIN_NAMESPACE, toChainId } from '@shapeshiftoss/caip'
+
+export const lifiChainIdToChainId = (lifiChainId: number): ChainId => {
+  return toChainId({
+    chainNamespace: CHAIN_NAMESPACE.Evm,
+    chainReference: lifiChainId.toString() as ChainReference,
+  })
+}


### PR DESCRIPTION
## Description

Fixes app crash when lifi swaps contain unsupported assets in the intermediary asset list.

## Pull Request Type

- [x] :bug: Bug fix (Non-breaking Change: Fixes an issue)
- [ ] :hammer_and_wrench: Chore (Non-breaking Change: Doc updates, pkg upgrades, typos, etc..)
- [ ] :nail_care: New Feature (Breaking/Non-breaking Change)

## Issue (if applicable)

NA

## Risk

Little to no risk.

## Testing

Check that reported pair works without crashing app.

### Engineering

See above

### Operations

See above

## Screenshots (if applicable)
