### PR TITLE
feat: opportunity thunks by ChainId

### DIFF
--- a/src/context/AppProvider/AppContext.tsx
+++ b/src/context/AppProvider/AppContext.tsx
@@ -39,8 +39,8 @@ import {
 } from 'state/slices/marketDataSlice/marketDataSlice'
 import { opportunitiesApi } from 'state/slices/opportunitiesSlice/opportunitiesSlice'
 import {
-  fetchAllOpportunitiesIds,
-  fetchAllOpportunitiesMetadata,
+  fetchAllOpportunitiesIdsByChainId,
+  fetchAllOpportunitiesMetadataByChainId,
   fetchAllOpportunitiesUserData,
 } from 'state/slices/opportunitiesSlice/thunks'
 import { portfolio, portfolioApi } from 'state/slices/portfolioSlice/portfolioSlice'
@@ -180,8 +180,6 @@ export const AppProvider = ({ children }: { children: React.ReactNode }) => {
         : () => setTimeoutAsync(0)
 
       await maybeFetchZapperData
-      await fetchAllOpportunitiesIds()
-      await fetchAllOpportunitiesMetadata()
 
       requestedAccountIds.forEach(accountId => {
         const { chainId } = fromAccountId(accountId)
@@ -190,19 +188,23 @@ export const AppProvider = ({ children }: { children: React.ReactNode }) => {
           case ltcChainId:
           case dogeChainId:
           case bchChainId:
-            fetchAllOpportunitiesUserData(accountId)
-            break
           case cosmosChainId:
           case osmosisChainId:
-            // Don't await me, we don't want to block execution while this resolves and populates the store
-            fetchAllOpportunitiesUserData(accountId)
-            break
           case avalancheChainId:
-            fetchAllOpportunitiesUserData(accountId)
+            ;(async () => {
+              await fetchAllOpportunitiesIdsByChainId(chainId)
+              // TODO: rm, metadata should also be by chainId
+              await fetchAllOpportunitiesMetadataByChainId(chainId)
+              await fetchAllOpportunitiesUserData(accountId)
+            })()
             break
           case ethChainId:
-            // Don't await me, we don't want to block execution while this resolves and populates the store
-            fetchAllOpportunitiesUserData(accountId)
+            ;(async () => {
+              await fetchAllOpportunitiesIdsByChainId(chainId)
+              // TODO: rm, metadata should also be by chainId
+              await fetchAllOpportunitiesMetadataByChainId(chainId)
+              await fetchAllOpportunitiesUserData(accountId)
+            })()
 
             /**
              * fetch all rebase history for foxy

--- a/src/context/AppProvider/AppContext.tsx
+++ b/src/context/AppProvider/AppContext.tsx
@@ -193,7 +193,6 @@ export const AppProvider = ({ children }: { children: React.ReactNode }) => {
           case avalancheChainId:
             ;(async () => {
               await fetchAllOpportunitiesIdsByChainId(chainId)
-              // TODO: rm, metadata should also be by chainId
               await fetchAllOpportunitiesMetadataByChainId(chainId)
               await fetchAllOpportunitiesUserDataByAccountId(accountId)
             })()
@@ -201,7 +200,6 @@ export const AppProvider = ({ children }: { children: React.ReactNode }) => {
           case ethChainId:
             ;(async () => {
               await fetchAllOpportunitiesIdsByChainId(chainId)
-              // TODO: rm, metadata should also be by chainId
               await fetchAllOpportunitiesMetadataByChainId(chainId)
               await fetchAllOpportunitiesUserDataByAccountId(accountId)
             })()

--- a/src/context/AppProvider/AppContext.tsx
+++ b/src/context/AppProvider/AppContext.tsx
@@ -41,7 +41,7 @@ import { opportunitiesApi } from 'state/slices/opportunitiesSlice/opportunitiesS
 import {
   fetchAllOpportunitiesIdsByChainId,
   fetchAllOpportunitiesMetadataByChainId,
-  fetchAllOpportunitiesUserData,
+  fetchAllOpportunitiesUserDataByAccountId,
 } from 'state/slices/opportunitiesSlice/thunks'
 import { portfolio, portfolioApi } from 'state/slices/portfolioSlice/portfolioSlice'
 import { preferences } from 'state/slices/preferencesSlice/preferencesSlice'
@@ -195,7 +195,7 @@ export const AppProvider = ({ children }: { children: React.ReactNode }) => {
               await fetchAllOpportunitiesIdsByChainId(chainId)
               // TODO: rm, metadata should also be by chainId
               await fetchAllOpportunitiesMetadataByChainId(chainId)
-              await fetchAllOpportunitiesUserData(accountId)
+              await fetchAllOpportunitiesUserDataByAccountId(accountId)
             })()
             break
           case ethChainId:
@@ -203,7 +203,7 @@ export const AppProvider = ({ children }: { children: React.ReactNode }) => {
               await fetchAllOpportunitiesIdsByChainId(chainId)
               // TODO: rm, metadata should also be by chainId
               await fetchAllOpportunitiesMetadataByChainId(chainId)
-              await fetchAllOpportunitiesUserData(accountId)
+              await fetchAllOpportunitiesUserDataByAccountId(accountId)
             })()
 
             /**

--- a/src/context/FoxEthProvider/FoxEthProvider.tsx
+++ b/src/context/FoxEthProvider/FoxEthProvider.tsx
@@ -5,7 +5,7 @@ import { DefiProvider, DefiType } from 'features/defi/contexts/DefiManagerProvid
 import React, { createContext, useCallback, useContext, useEffect, useMemo, useState } from 'react'
 import { logger } from 'lib/logger'
 import { opportunitiesApi } from 'state/slices/opportunitiesSlice/opportunitiesSlice'
-import { fetchAllStakingOpportunitiesUserData } from 'state/slices/opportunitiesSlice/thunks'
+import { fetchAllStakingOpportunitiesUserDataByAccountId } from 'state/slices/opportunitiesSlice/thunks'
 import { toOpportunityId } from 'state/slices/opportunitiesSlice/utils'
 import { selectAssetById, selectStakingAccountIds, selectTxById } from 'state/slices/selectors'
 import { serializeTxIndex } from 'state/slices/txHistorySlice/utils'
@@ -46,7 +46,7 @@ export const FoxEthProvider = ({ children }: FoxEthProviderProps) => {
     await Promise.all(
       stakingAccountIds.map(
         async accountId =>
-          await fetchAllStakingOpportunitiesUserData(accountId, { forceRefetch: true }),
+          await fetchAllStakingOpportunitiesUserDataByAccountId(accountId, { forceRefetch: true }),
       ),
     )
   }, [stakingAccountIds])
@@ -86,7 +86,6 @@ export const FoxEthProvider = ({ children }: FoxEthProviderProps) => {
                   chainId: ethChainId,
                   assetReference: ongoingTxContractAddress,
                 }),
-                opportunityType: DefiType.Staking,
                 defiType: DefiType.Staking,
                 defiProvider: DefiProvider.EthFoxStaking,
               },

--- a/src/context/TransactionsProvider/TransactionsProvider.tsx
+++ b/src/context/TransactionsProvider/TransactionsProvider.tsx
@@ -18,11 +18,7 @@ import {
   isSupportedThorchainSaversChainId,
   waitForSaversUpdate,
 } from 'state/slices/opportunitiesSlice/resolvers/thorchainsavers/utils'
-import {
-  fetchAllOpportunitiesIds,
-  fetchAllOpportunitiesMetadata,
-  fetchAllOpportunitiesUserData,
-} from 'state/slices/opportunitiesSlice/thunks'
+import { fetchAllOpportunitiesUserData } from 'state/slices/opportunitiesSlice/thunks'
 import { portfolioApi } from 'state/slices/portfolioSlice/portfolioSlice'
 import {
   selectPortfolioAccountMetadata,
@@ -106,9 +102,8 @@ export const TransactionsProvider: React.FC<TransactionsProviderProps> = ({ chil
           getOpportunitiesUserData.initiate(
             {
               accountId,
-              defiType: DefiType.Staking,
               defiProvider: DefiProvider.Idle,
-              opportunityType: DefiType.Staking,
+              defiType: DefiType.Staking,
             },
             { forceRefetch: true },
           ),
@@ -118,9 +113,8 @@ export const TransactionsProvider: React.FC<TransactionsProviderProps> = ({ chil
           getOpportunitiesUserData.initiate(
             {
               accountId,
-              defiType: DefiType.Staking,
               defiProvider: DefiProvider.CosmosSdk,
-              opportunityType: DefiType.Staking,
+              defiType: DefiType.Staking,
             },
             { forceRefetch: true },
           ),
@@ -133,9 +127,8 @@ export const TransactionsProvider: React.FC<TransactionsProviderProps> = ({ chil
             getOpportunitiesUserData.initiate(
               {
                 accountId,
-                defiType: DefiType.Staking,
                 defiProvider: DefiProvider.ThorchainSavers,
-                opportunityType: DefiType.Staking,
+                defiType: DefiType.Staking,
               },
               { forceRefetch: true },
             ),
@@ -143,8 +136,7 @@ export const TransactionsProvider: React.FC<TransactionsProviderProps> = ({ chil
         })
       } else if (shouldRefetchAllOpportunities) return
       ;(async () => {
-        await fetchAllOpportunitiesIds({ forceRefetch: true })
-        await fetchAllOpportunitiesMetadata({ forceRefetch: true })
+        // We don't know the chainId of the Tx, so we refetch all opportunities
         await fetchAllOpportunitiesUserData(accountId, { forceRefetch: true })
       })()
     },

--- a/src/context/TransactionsProvider/TransactionsProvider.tsx
+++ b/src/context/TransactionsProvider/TransactionsProvider.tsx
@@ -18,7 +18,7 @@ import {
   isSupportedThorchainSaversChainId,
   waitForSaversUpdate,
 } from 'state/slices/opportunitiesSlice/resolvers/thorchainsavers/utils'
-import { fetchAllOpportunitiesUserData } from 'state/slices/opportunitiesSlice/thunks'
+import { fetchAllOpportunitiesUserDataByAccountId } from 'state/slices/opportunitiesSlice/thunks'
 import { portfolioApi } from 'state/slices/portfolioSlice/portfolioSlice'
 import {
   selectPortfolioAccountMetadata,
@@ -137,7 +137,7 @@ export const TransactionsProvider: React.FC<TransactionsProviderProps> = ({ chil
       } else if (shouldRefetchAllOpportunities) return
       ;(async () => {
         // We don't know the chainId of the Tx, so we refetch all opportunities
-        await fetchAllOpportunitiesUserData(accountId, { forceRefetch: true })
+        await fetchAllOpportunitiesUserDataByAccountId(accountId, { forceRefetch: true })
       })()
     },
     // TODO: This is drunk and will evaluate stakingOpportunitiesById to an empty object despite not being empty when debugged in its outer scope

--- a/src/features/defi/providers/foxy/components/FoxyManager/Overview/Claim/ClaimStatus.tsx
+++ b/src/features/defi/providers/foxy/components/FoxyManager/Overview/Claim/ClaimStatus.tsx
@@ -108,7 +108,6 @@ export const ClaimStatus: React.FC<ClaimStatusProps> = ({ accountId }) => {
           accountId,
           defiType: DefiType.Staking,
           defiProvider: DefiProvider.ShapeShift,
-          opportunityType: DefiType.Staking,
         },
         { forceRefetch: true },
       ),

--- a/src/state/slices/opportunitiesSlice/opportunitiesSlice.ts
+++ b/src/state/slices/opportunitiesSlice/opportunitiesSlice.ts
@@ -126,6 +126,11 @@ export const opportunitiesApi = createApi({
             defiProvider,
             defiType,
           )
+
+          if (!resolver) {
+            throw new Error(`resolver for ${defiProvider}::${defiType} not implemented`)
+          }
+
           const resolved = await resolver({ reduxApi: { dispatch, getState } })
 
           return { data: resolved.data }
@@ -144,15 +149,17 @@ export const opportunitiesApi = createApi({
       },
     }),
     getOpportunityMetadata: build.query<GetOpportunityMetadataOutput, GetOpportunityMetadataInput>({
-      queryFn: async (
-        { opportunityId, opportunityType, defiType, defiProvider },
-        { dispatch, getState },
-      ) => {
+      queryFn: async ({ opportunityId, defiType, defiProvider }, { dispatch, getState }) => {
         try {
           const resolver = getMetadataResolversByDefiProviderAndDefiType(defiProvider, defiType)
+
+          if (!resolver) {
+            throw new Error(`resolver for ${defiProvider}::${defiType} not implemented`)
+          }
+
           const resolved = await resolver({
             opportunityId,
-            opportunityType,
+            defiType,
             reduxApi: { dispatch, getState },
           })
 
@@ -177,7 +184,7 @@ export const opportunitiesApi = createApi({
       GetOpportunityMetadataOutput,
       Omit<GetOpportunityMetadataInput, 'opportunityId'>
     >({
-      queryFn: async ({ opportunityType, defiType, defiProvider }, { dispatch, getState }) => {
+      queryFn: async ({ defiType, defiProvider }, { dispatch, getState }) => {
         try {
           const opportunityIds = getOpportunityIds({ defiProvider, defiType }, { getState })
 
@@ -185,9 +192,14 @@ export const opportunitiesApi = createApi({
             defiProvider,
             defiType,
           )
+
+          if (!resolver) {
+            throw new Error(`resolver for ${defiProvider}::${defiType} not implemented`)
+          }
+
           const resolved = await resolver({
             opportunityIds,
-            opportunityType,
+            defiType,
             reduxApi: { dispatch, getState },
           })
 
@@ -210,7 +222,7 @@ export const opportunitiesApi = createApi({
     }),
     getOpportunityUserData: build.query<GetOpportunityUserDataOutput, GetOpportunityUserDataInput>({
       queryFn: async (
-        { accountId, opportunityId, opportunityType, defiType, defiProvider },
+        { accountId, opportunityId, defiType, defiProvider },
         { dispatch, getState },
       ) => {
         try {
@@ -229,7 +241,7 @@ export const opportunitiesApi = createApi({
 
             const data = {
               byAccountId,
-              type: opportunityType,
+              type: defiType,
             }
 
             dispatch(opportunities.actions.upsertOpportunityAccounts(data))
@@ -238,7 +250,7 @@ export const opportunitiesApi = createApi({
 
           const resolved = await resolver({
             opportunityId,
-            opportunityType,
+            defiType,
             accountId,
             reduxApi: { dispatch, getState },
           })
@@ -254,7 +266,7 @@ export const opportunitiesApi = createApi({
 
           const data = {
             byAccountId,
-            type: opportunityType,
+            type: defiType,
           }
 
           dispatch(opportunities.actions.upsertOpportunityAccounts(data))
@@ -278,10 +290,7 @@ export const opportunitiesApi = createApi({
       GetOpportunityUserDataOutput,
       Omit<GetOpportunityUserDataInput, 'opportunityId'>
     >({
-      queryFn: async (
-        { accountId, opportunityType, defiType, defiProvider },
-        { dispatch, getState },
-      ) => {
+      queryFn: async ({ accountId, defiType, defiProvider }, { dispatch, getState }) => {
         try {
           const opportunityIds = getOpportunityIds(
             { accountId, defiProvider, defiType },
@@ -303,7 +312,7 @@ export const opportunitiesApi = createApi({
 
           const resolved = await resolver({
             opportunityIds,
-            opportunityType,
+            defiType,
             accountId,
             reduxApi: { dispatch, getState },
           })
@@ -320,7 +329,7 @@ export const opportunitiesApi = createApi({
 
           const data = {
             byAccountId,
-            type: opportunityType,
+            type: defiType,
           }
 
           dispatch(opportunities.actions.upsertOpportunityAccounts(data))

--- a/src/state/slices/opportunitiesSlice/resolvers/cosmosSdk/index.ts
+++ b/src/state/slices/opportunitiesSlice/resolvers/cosmosSdk/index.ts
@@ -85,7 +85,7 @@ export const cosmosSdkOpportunityIdsResolver = async ({
 
 export const cosmosSdkStakingOpportunitiesMetadataResolver = async ({
   opportunityIds: validatorIds = [],
-  opportunityType,
+  defiType,
   reduxApi,
 }: OpportunitiesMetadataResolverInput): Promise<{
   data: GetOpportunityMetadataOutput
@@ -171,14 +171,14 @@ export const cosmosSdkStakingOpportunitiesMetadataResolver = async ({
   )
   const data = {
     byId: metadataByValidatorId,
-    type: opportunityType,
+    type: defiType,
   }
 
   return { data }
 }
 export const cosmosSdkStakingOpportunitiesUserDataResolver = async ({
   opportunityIds: validatorIds,
-  opportunityType,
+  defiType,
   accountId,
   reduxApi,
 }: OpportunitiesUserDataResolverInput): Promise<{ data: GetOpportunityUserStakingDataOutput }> => {
@@ -192,7 +192,7 @@ export const cosmosSdkStakingOpportunitiesUserDataResolver = async ({
     const { account: pubKey, chainId } = fromAccountId(accountId)
     if (![cosmosChainId, osmosisChainId].includes(chainId)) {
       return Promise.resolve({
-        data: { byId: emptyStakingOpportunitiesUserDataByUserStakingId, type: opportunityType },
+        data: { byId: emptyStakingOpportunitiesUserDataByUserStakingId, type: defiType },
       })
     }
     const chainAdapters = getChainAdapterManager()
@@ -208,12 +208,12 @@ export const cosmosSdkStakingOpportunitiesUserDataResolver = async ({
 
     const byId = makeAccountUserData({ cosmosSdkAccount: cosmosAccount, validatorIds })
 
-    return Promise.resolve({ data: { byId, type: opportunityType } })
+    return Promise.resolve({ data: { byId, type: defiType } })
   } catch (e) {
     return Promise.resolve({
       data: {
         byId: emptyStakingOpportunitiesUserDataByUserStakingId,
-        type: opportunityType,
+        type: defiType,
       },
     })
   }

--- a/src/state/slices/opportunitiesSlice/resolvers/ethFoxStaking/index.ts
+++ b/src/state/slices/opportunitiesSlice/resolvers/ethFoxStaking/index.ts
@@ -1,4 +1,4 @@
-import { ethChainId, foxAssetId, fromAccountId, fromAssetId } from '@shapeshiftoss/caip'
+import { foxAssetId, fromAccountId, fromAssetId } from '@shapeshiftoss/caip'
 import type { MarketData } from '@shapeshiftoss/types'
 import { ETH_FOX_POOL_CONTRACT_ADDRESS } from 'contracts/constants'
 import { fetchUniV2PairData, getOrCreateContractByAddress } from 'contracts/contractManager'
@@ -27,7 +27,7 @@ import { makeTotalLpApr, rewardRatePerToken } from './utils'
 
 export const ethFoxStakingMetadataResolver = async ({
   opportunityId,
-  opportunityType,
+  defiType,
   reduxApi,
 }: OpportunityMetadataResolverInput): Promise<{
   data: GetOpportunityMetadataOutput
@@ -110,7 +110,7 @@ export const ethFoxStakingMetadataResolver = async ({
         isClaimableRewards: true,
       },
     },
-    type: opportunityType,
+    type: defiType,
   } as const
 
   return { data }
@@ -118,17 +118,9 @@ export const ethFoxStakingMetadataResolver = async ({
 
 export const ethFoxStakingUserDataResolver = async ({
   opportunityId,
-  opportunityType,
   accountId,
   reduxApi,
 }: OpportunityUserDataResolverInput): Promise<{ data: GetOpportunityUserStakingDataOutput }> => {
-  const { chainId: accountChainId } = fromAccountId(accountId)
-  if (accountChainId !== ethChainId)
-    return {
-      data: {
-        byId: {},
-      },
-    }
   const { getState } = reduxApi
   const state: any = getState() // ReduxState causes circular dependency
   const lpTokenMarketData: MarketData = selectMarketDataById(state, foxEthLpAssetId)
@@ -160,7 +152,7 @@ export const ethFoxStakingUserDataResolver = async ({
         rewardsCryptoBaseUnit,
       },
     },
-    type: opportunityType,
+    type: DefiType.Staking,
   }
 
   return { data }

--- a/src/state/slices/opportunitiesSlice/resolvers/foxy/index.ts
+++ b/src/state/slices/opportunitiesSlice/resolvers/foxy/index.ts
@@ -28,7 +28,7 @@ import type {
 } from '../types'
 
 export const foxyStakingOpportunitiesMetadataResolver = async ({
-  opportunityType,
+  defiType,
   reduxApi,
 }: OpportunitiesMetadataResolverInput): Promise<{ data: GetOpportunityMetadataOutput }> => {
   const allOpportunities = await getFoxyApi().getFoxyOpportunities()
@@ -93,7 +93,7 @@ export const foxyStakingOpportunitiesMetadataResolver = async ({
 
   const data = {
     byId: stakingOpportunitiesById,
-    type: opportunityType,
+    type: defiType,
   }
 
   return { data }
@@ -104,14 +104,6 @@ export const foxyStakingOpportunitiesUserDataResolver = async ({
   reduxApi,
   opportunityIds,
 }: OpportunitiesUserDataResolverInput): Promise<{ data: GetOpportunityUserStakingDataOutput }> => {
-  const { chainId: accountChainId } = fromAccountId(accountId)
-  if (accountChainId !== ethChainId)
-    return {
-      data: {
-        byId: {},
-      },
-    }
-
   const { getState } = reduxApi
   const state: any = getState() // ReduxState causes circular dependency
 

--- a/src/state/slices/opportunitiesSlice/resolvers/idle/index.ts
+++ b/src/state/slices/opportunitiesSlice/resolvers/idle/index.ts
@@ -1,5 +1,5 @@
 import type { ToAssetIdArgs } from '@shapeshiftoss/caip'
-import { ethChainId, fromAccountId, fromAssetId, toAssetId } from '@shapeshiftoss/caip'
+import { fromAccountId, fromAssetId, toAssetId } from '@shapeshiftoss/caip'
 import { bnOrZero } from '@shapeshiftoss/investor-foxy'
 import { DefiProvider, DefiType } from 'features/defi/contexts/DefiManagerProvider/DefiCommon'
 import { bn } from 'lib/bignumber/bignumber'
@@ -32,7 +32,7 @@ import { getIdleInvestor } from './idleInvestorSingleton'
 const moduleLogger = logger.child({ namespace: ['opportunities', 'resolvers', 'idle'] })
 
 export const idleStakingOpportunitiesMetadataResolver = async ({
-  opportunityType,
+  defiType,
   reduxApi,
 }: OpportunitiesMetadataResolverInput): Promise<{
   data: GetOpportunityMetadataOutput
@@ -54,7 +54,7 @@ export const idleStakingOpportunitiesMetadataResolver = async ({
     return {
       data: {
         byId: {},
-        type: opportunityType,
+        type: defiType,
       },
     }
   }
@@ -66,7 +66,7 @@ export const idleStakingOpportunitiesMetadataResolver = async ({
           { ...opportunityMetadata, apy: '0', tvl: '0' },
         ]),
       ),
-      type: opportunityType,
+      type: defiType,
     } as const
 
     return {
@@ -152,30 +152,28 @@ export const idleStakingOpportunitiesMetadataResolver = async ({
 
   const data = {
     byId: stakingOpportunitiesById,
-    type: opportunityType,
+    type: defiType,
   }
 
   return { data }
 }
 
 export const idleStakingOpportunitiesUserDataResolver = async ({
-  opportunityType,
+  defiType,
   accountId,
   reduxApi,
   opportunityIds,
 }: OpportunitiesUserDataResolverInput): Promise<{ data: GetOpportunityUserStakingDataOutput }> => {
-  const { chainId: accountChainId } = fromAccountId(accountId)
-
   const { getState } = reduxApi
   const state: any = getState() // ReduxState causes circular dependency
 
   const { IdleFinance } = selectFeatureFlags(state)
 
-  if (accountChainId !== ethChainId || !IdleFinance)
+  if (!IdleFinance)
     return Promise.resolve({
       data: {
         byId: {},
-        type: opportunityType,
+        type: defiType,
       },
     })
 
@@ -255,7 +253,7 @@ export const idleStakingOpportunitiesUserDataResolver = async ({
 
   const data = {
     byId: stakingOpportunitiesUserDataByUserStakingId,
-    type: opportunityType,
+    type: defiType,
   }
 
   return Promise.resolve({ data })

--- a/src/state/slices/opportunitiesSlice/resolvers/index.ts
+++ b/src/state/slices/opportunitiesSlice/resolvers/index.ts
@@ -1,3 +1,13 @@
+import {
+  avalancheChainId,
+  bchChainId,
+  btcChainId,
+  cosmosChainId,
+  dogeChainId,
+  ethChainId,
+  ltcChainId,
+  osmosisChainId,
+} from '@shapeshiftoss/caip'
 import { DefiProvider, DefiType } from 'features/defi/contexts/DefiManagerProvider/DefiCommon'
 
 import {
@@ -119,4 +129,79 @@ export const DefiProviderToUserDataResolverByDeFiType = {
   [`${DefiProvider.EthFoxStaking}`]: {
     [`${DefiType.Staking}`]: ethFoxStakingUserDataResolver,
   },
+}
+
+export const CHAIN_ID_TO_SUPPORTED_DEFI_OPPORTUNITIES = {
+  [avalancheChainId]: [
+    {
+      defiProvider: DefiProvider.ThorchainSavers,
+      defiType: DefiType.Staking,
+    },
+  ],
+  [ltcChainId]: [
+    {
+      defiProvider: DefiProvider.ThorchainSavers,
+      defiType: DefiType.Staking,
+    },
+  ],
+  [bchChainId]: [
+    {
+      defiProvider: DefiProvider.ThorchainSavers,
+      defiType: DefiType.Staking,
+    },
+  ],
+  [dogeChainId]: [
+    {
+      defiProvider: DefiProvider.ThorchainSavers,
+      defiType: DefiType.Staking,
+    },
+  ],
+  [btcChainId]: [
+    {
+      defiProvider: DefiProvider.ThorchainSavers,
+      defiType: DefiType.Staking,
+    },
+  ],
+  [ethChainId]: [
+    {
+      defiProvider: DefiProvider.UniV2,
+      defiType: DefiType.LiquidityPool,
+    },
+    {
+      defiProvider: DefiProvider.EthFoxStaking,
+      defiType: DefiType.Staking,
+    },
+    {
+      defiProvider: DefiProvider.Idle,
+      defiType: DefiType.Staking,
+    },
+    {
+      defiProvider: DefiProvider.Yearn,
+      defiType: DefiType.Staking,
+    },
+    {
+      defiProvider: DefiProvider.ThorchainSavers,
+      defiType: DefiType.Staking,
+    },
+    {
+      defiProvider: DefiProvider.ShapeShift,
+      defiType: DefiType.Staking,
+    },
+  ],
+  [cosmosChainId]: [
+    {
+      defiProvider: DefiProvider.CosmosSdk,
+      defiType: DefiType.Staking,
+    },
+    {
+      defiProvider: DefiProvider.ThorchainSavers,
+      defiType: DefiType.Staking,
+    },
+  ],
+  [osmosisChainId]: [
+    {
+      defiProvider: DefiProvider.OsmosisLp,
+      defiType: DefiType.LiquidityPool,
+    },
+  ],
 }

--- a/src/state/slices/opportunitiesSlice/resolvers/osmosis/index.ts
+++ b/src/state/slices/opportunitiesSlice/resolvers/osmosis/index.ts
@@ -17,7 +17,7 @@ import { generateAssetIdFromOsmosisDenom, getPools } from './utils'
 const OSMO_ATOM_LIQUIDITY_POOL_ID = '1'
 
 export const osmosisLpOpportunitiesMetadataResolver = async ({
-  opportunityType,
+  defiType,
   reduxApi,
 }: OpportunitiesMetadataResolverInput): Promise<{ data: GetOpportunityMetadataOutput }> => {
   const { getState } = reduxApi
@@ -77,7 +77,7 @@ export const osmosisLpOpportunitiesMetadataResolver = async ({
 
   const data = {
     byId: lpOpportunitiesById,
-    type: opportunityType,
+    type: defiType,
   }
 
   return { data }

--- a/src/state/slices/opportunitiesSlice/resolvers/thorchainsavers/index.ts
+++ b/src/state/slices/opportunitiesSlice/resolvers/thorchainsavers/index.ts
@@ -57,7 +57,7 @@ export const thorchainSaversOpportunityIdsResolver = async (): Promise<{
 
 export const thorchainSaversStakingOpportunitiesMetadataResolver = async ({
   opportunityIds,
-  opportunityType,
+  defiType,
   reduxApi,
 }: OpportunitiesMetadataResolverInput): Promise<{
   data: GetOpportunityMetadataOutput
@@ -71,7 +71,7 @@ export const thorchainSaversStakingOpportunitiesMetadataResolver = async ({
     return Promise.resolve({
       data: {
         byId: {},
-        type: opportunityType,
+        type: defiType,
       },
     })
   }
@@ -141,14 +141,14 @@ export const thorchainSaversStakingOpportunitiesMetadataResolver = async ({
 
   const data = {
     byId: stakingOpportunitiesById,
-    type: opportunityType,
+    type: defiType,
   }
 
   return { data }
 }
 
 export const thorchainSaversStakingOpportunitiesUserDataResolver = async ({
-  opportunityType,
+  defiType,
   accountId,
   reduxApi,
 }: OpportunitiesUserDataResolverInput): Promise<{ data: GetOpportunityUserStakingDataOutput }> => {
@@ -158,7 +158,7 @@ export const thorchainSaversStakingOpportunitiesUserDataResolver = async ({
   const stakingOpportunitiesUserDataByUserStakingId: OpportunitiesState['userStaking']['byId'] = {}
   const data = {
     byId: stakingOpportunitiesUserDataByUserStakingId,
-    type: opportunityType,
+    type: defiType,
   }
 
   try {
@@ -227,7 +227,7 @@ export const thorchainSaversStakingOpportunitiesUserDataResolver = async ({
     return Promise.resolve({
       data: {
         byId: stakingOpportunitiesUserDataByUserStakingId,
-        type: opportunityType,
+        type: defiType,
       },
     })
   }

--- a/src/state/slices/opportunitiesSlice/resolvers/types.ts
+++ b/src/state/slices/opportunitiesSlice/resolvers/types.ts
@@ -1,32 +1,33 @@
 import type { BaseQueryApi } from '@reduxjs/toolkit/dist/query/baseQueryTypes'
 import type { AccountId } from '@shapeshiftoss/caip'
+import type { DefiType } from 'features/defi/contexts/DefiManagerProvider/DefiCommon'
 
-import type { OpportunityDefiType, OpportunityId } from '../types'
+import type { OpportunityId } from '../types'
 
 export type ReduxApi = Pick<BaseQueryApi, 'dispatch' | 'getState'>
 
 export type OpportunitiesMetadataResolverInput = {
   opportunityIds?: OpportunityId[]
-  opportunityType: OpportunityDefiType
+  defiType: DefiType
   reduxApi: ReduxApi
 }
 
 export type OpportunityMetadataResolverInput = {
   opportunityId: OpportunityId
-  opportunityType: OpportunityDefiType
+  defiType: DefiType
   reduxApi: ReduxApi
 }
 
 export type OpportunityUserDataResolverInput = {
   opportunityId: OpportunityId
-  opportunityType: OpportunityDefiType
+  defiType: DefiType
   accountId: AccountId
   reduxApi: ReduxApi
 }
 
 export type OpportunitiesUserDataResolverInput = {
   opportunityIds: OpportunityId[]
-  opportunityType: OpportunityDefiType
+  defiType: DefiType
   accountId: AccountId
   reduxApi: ReduxApi
 }

--- a/src/state/slices/opportunitiesSlice/resolvers/uniV2/index.ts
+++ b/src/state/slices/opportunitiesSlice/resolvers/uniV2/index.ts
@@ -1,4 +1,4 @@
-import { ethAssetId, ethChainId, fromAccountId, fromAssetId, toAssetId } from '@shapeshiftoss/caip'
+import { ethAssetId, fromAssetId, toAssetId } from '@shapeshiftoss/caip'
 import type { MarketData } from '@shapeshiftoss/types'
 import type { TokenAmount } from '@uniswap/sdk'
 import { WETH_TOKEN_CONTRACT_ADDRESS } from 'contracts/constants'
@@ -49,7 +49,7 @@ const getBlockNumber = async () => {
 
 export const uniV2LpOpportunitiesMetadataResolver = async ({
   opportunityIds,
-  opportunityType,
+  defiType,
   reduxApi,
 }: OpportunitiesMetadataResolverInput): Promise<{
   data: GetOpportunityMetadataOutput
@@ -67,7 +67,7 @@ export const uniV2LpOpportunitiesMetadataResolver = async ({
     return Promise.resolve({
       data: {
         byId: {},
-        type: opportunityType,
+        type: defiType,
       },
     })
   }
@@ -245,7 +245,7 @@ export const uniV2LpOpportunitiesMetadataResolver = async ({
 
   const data = {
     byId: lpOpportunitiesById,
-    type: opportunityType,
+    type: defiType,
   }
 
   return { data }
@@ -253,14 +253,10 @@ export const uniV2LpOpportunitiesMetadataResolver = async ({
 
 export const uniV2LpUserDataResolver = ({
   opportunityId,
-  opportunityType: _opportunityType,
+  defiType: _defiType,
   accountId,
   reduxApi,
 }: OpportunityUserDataResolverInput): Promise<void> => {
-  const { chainId: accountChainId } = fromAccountId(accountId)
-  // Looks the same as the happy path but isn't, we won't hit this as a guard with non-Ethereum account ChainIds
-  if (accountChainId !== ethChainId) return Promise.resolve()
-
   const { getState } = reduxApi
   const state: ReduxState = getState() as any
   const portfolioLoadingStatusGranular = selectPortfolioLoadingStatusGranular(state)

--- a/src/state/slices/opportunitiesSlice/resolvers/yearn/index.ts
+++ b/src/state/slices/opportunitiesSlice/resolvers/yearn/index.ts
@@ -1,5 +1,5 @@
 import type { ToAssetIdArgs } from '@shapeshiftoss/caip'
-import { ethChainId, fromAccountId, fromAssetId, toAssetId } from '@shapeshiftoss/caip'
+import { fromAssetId, toAssetId } from '@shapeshiftoss/caip'
 import { bnOrZero } from '@shapeshiftoss/investor-foxy'
 import { USDC_PRECISION } from 'constants/constants'
 import { DefiProvider, DefiType } from 'features/defi/contexts/DefiManagerProvider/DefiCommon'
@@ -26,7 +26,7 @@ import type {
 } from '../types'
 
 export const yearnStakingOpportunitiesMetadataResolver = async ({
-  opportunityType,
+  defiType,
   reduxApi,
 }: OpportunitiesMetadataResolverInput): Promise<{
   data: GetOpportunityMetadataOutput
@@ -37,7 +37,7 @@ export const yearnStakingOpportunitiesMetadataResolver = async ({
   const { Yearn } = selectFeatureFlags(state)
 
   if (!Yearn) {
-    return { data: { byId: {}, type: opportunityType } }
+    return { data: { byId: {}, type: defiType } }
   }
   const opportunities = await (async () => {
     const maybeOpportunities = await getYearnInvestor().findAll()
@@ -82,14 +82,14 @@ export const yearnStakingOpportunitiesMetadataResolver = async ({
   }
   const data = {
     byId: stakingOpportunitiesById,
-    type: opportunityType,
+    type: defiType,
   }
 
   return { data }
 }
 
 export const yearnStakingOpportunitiesUserDataResolver = async ({
-  opportunityType,
+  defiType,
   accountId,
   reduxApi,
   opportunityIds,
@@ -98,9 +98,8 @@ export const yearnStakingOpportunitiesUserDataResolver = async ({
   const state: any = getState() // ReduxState causes circular dependency
 
   const { Yearn } = selectFeatureFlags(state)
-  const { chainId: accountChainId } = fromAccountId(accountId)
 
-  if (!Yearn || accountChainId !== ethChainId)
+  if (!Yearn)
     return {
       data: {
         byId: {},
@@ -158,7 +157,7 @@ export const yearnStakingOpportunitiesUserDataResolver = async ({
 
   const data = {
     byId: stakingOpportunitiesUserDataByUserStakingId,
-    type: opportunityType,
+    type: defiType,
   }
 
   return Promise.resolve({ data })

--- a/src/state/slices/opportunitiesSlice/thunks.ts
+++ b/src/state/slices/opportunitiesSlice/thunks.ts
@@ -149,7 +149,7 @@ export const fetchAllLpOpportunitiesUserdataByAccountId = (
   // User data for all our current LP opportunities is held as a portfolio balance, there's no need to fetch it
 ) => Promise.resolve()
 
-export const fetchAllOpportunitiesUserData = (
+export const fetchAllOpportunitiesUserDataByAccountId = (
   accountId: AccountId,
   options?: StartQueryActionCreatorOptions,
 ) =>

--- a/src/state/slices/opportunitiesSlice/types.ts
+++ b/src/state/slices/opportunitiesSlice/types.ts
@@ -8,8 +8,6 @@ import type { FoxySpecificUserStakingOpportunity } from './resolvers/foxy/types'
 import type { IdleStakingSpecificMetadata } from './resolvers/idle/types'
 import type { ThorchainSaversStakingSpecificMetadata } from './resolvers/thorchainsavers/types'
 
-export type OpportunityDefiType = DefiType.LiquidityPool | DefiType.Staking
-
 export type AssetIdsTuple =
   | readonly [AssetId, AssetId, AssetId]
   | readonly [AssetId, AssetId]
@@ -110,11 +108,10 @@ export type OpportunitiesState = {
   }
 }
 
-export type OpportunityDataById = OpportunitiesState[OpportunityDefiType]['byAccountId']
+export type OpportunityDataById = OpportunitiesState[DefiType]['byAccountId']
 
 export type GetOpportunityMetadataInput = {
   opportunityId: OpportunityId
-  opportunityType: OpportunityDefiType
   defiType: DefiType
   defiProvider: DefiProvider
 }
@@ -122,7 +119,6 @@ export type GetOpportunityMetadataInput = {
 export type GetOpportunityUserDataInput = {
   accountId: AccountId
   opportunityId: OpportunityId
-  opportunityType: OpportunityDefiType
   defiType: DefiType
   defiProvider: DefiProvider
 }
@@ -134,11 +130,11 @@ export type GetOpportunityIdsInput = {
 
 export type GetOpportunityMetadataOutput = {
   byId: Record<OpportunityId, OpportunityMetadata>
-  type: OpportunityDefiType
+  type: DefiType
 }
 export type GetOpportunityUserDataOutput = {
-  byAccountId: OpportunitiesState[OpportunityDefiType]['byAccountId']
-  type: OpportunityDefiType
+  byAccountId: OpportunitiesState[DefiType]['byAccountId']
+  type: DefiType
 }
 
 export type GetOpportunityUserStakingDataOutput = {
@@ -149,7 +145,7 @@ export type GetOpportunityIdsOutput = OpportunityId[]
 
 // TODO: This is not FDA-approved and should stop being consumed to make things a lot tidier without the added cholesterol
 // This is legacy from previous implementations, we should be able to consume the raw opportunitiesSlice data and derive the rest in-place
-type EarnOpportunityTypeBase = {
+type EarndefiTypeBase = {
   type: string
   provider: DefiProvider
   version?: string
@@ -178,13 +174,13 @@ type EarnOpportunityTypeBase = {
 export type StakingEarnOpportunityType = OpportunityMetadata &
   Partial<UserStakingOpportunityBase> & {
     isVisible?: boolean
-  } & EarnOpportunityTypeBase & { opportunityName: string | undefined } // overriding optional opportunityName property
+  } & EarndefiTypeBase & { opportunityName: string | undefined } // overriding optional opportunityName property
 
 export type LpEarnOpportunityType = OpportunityMetadataBase & {
   underlyingToken0AmountCryptoBaseUnit?: string
   underlyingToken1AmountCryptoBaseUnit?: string
   isVisible?: boolean
-} & EarnOpportunityTypeBase & { opportunityName: string | undefined } // overriding optional opportunityName property
+} & EarndefiTypeBase & { opportunityName: string | undefined } // overriding optional opportunityName property
 
 export type EarnOpportunityType = StakingEarnOpportunityType | LpEarnOpportunityType
 


### PR DESCRIPTION
## Description

This PR:

- Makes the opportunity thunks accept a `ChainId` and call queries for the matching ChainIds
- Removes the current `ChainId` checks in resolvers, that were effectively achieving the same
- removes the `opportunityType` property in resolver inputs, which was effectively a duplicate of `defiType`
- While at it, stop fetching IDs and metadata in `<TransactionProvider />` for unknown transactions, in profit of userdata only

## Pull Request Type

- [ ] :bug: Bug fix (Non-breaking Change: Fixes an issue)
- [ ] :hammer_and_wrench: Chore (Non-breaking Change: Doc updates, pkg upgrades, typos, etc..)
- [x] :nail_care: New Feature (Breaking/Non-breaking Change)

## Issue (if applicable)

N/A

## Risk

<!-----------------------------------------------------------------------------
Outline the scope of your changes and the risk associated with them. You must use your discretion as an engineer to determine the potential impact of your changes.

E.g. an upgrade to `hdwallet` or core state management would be considered higher risk, and might require a full regression test. UI or isolated view changes, or something behind a feature flag may have near zero risk. Small bug fixes might require testing isolated to the specific fix.
------------------------------------------------------------------------------>

- This may bring back a bit of console spew, as we now have a general notion of opportunities by ChainId, but no way yet to know whether or not these are for an `opportunity` or `opportunities` resolver, resulting in no-ops if you have debug log level enabled

## Testing

<!-----------------------------------------------------------------------------
We treat every PR to be merged with the same scrutiny as if we were merging directly to production.

Your PR will not be merged if you do not complete the sections below for our engineering and operations teams to test.
------------------------------------------------------------------------------>

- Clear your persisted redux store
- Ensure opportunities are still loading and working (try a few deposits/withdraws/claims) with MM, not confirming
- Test a confirmed Tx for any opportunity (i.e Cosmos Savers / SDK staking) and ensure we are still reactive on the opportunity update

### Engineering

<!-----------------------------------------------------------------------------
Include sufficient information here for an engineer to test your PR. This may include how to test locally, in a built environment, changes to infrastructure etc.
------------------------------------------------------------------------------>

- ☝🏽 
- Scrutinize `CHAIN_ID_TO_SUPPORTED_DEFI_OPPORTUNITIES` and ensure it looks sane

### Operations

<!-----------------------------------------------------------------------------
If your changes have a user-facing impact, describe how a non-technical QA team can functionally test your changes in a preview environment.

If they are not user-facing please describe how to test for any regressions that may occur.
------------------------------------------------------------------------------>

- ☝🏽 
## Screenshots (if applicable)
