### PR TITLE
chore: simplify useHasAppUpdated hook

### DIFF
--- a/src/hooks/useHasAppUpdated/useHasAppUpdated.test.ts
+++ b/src/hooks/useHasAppUpdated/useHasAppUpdated.test.ts
@@ -27,17 +27,7 @@ describe('useHasAppUpdated', () => {
       })
     })
 
-    it('should return false when env.json/asset-manifest.json is not updated', async () => {
-      mockAxios.get.mockImplementation(() => {
-        return Promise.resolve({ data: {} })
-      })
-
-      const { result } = renderHook(() => useHasAppUpdated())
-      await act(() => void 0)
-      expect(result.current).toBe(false)
-    })
-
-    it('should return true when env.json is updated', async () => {
+    it('should return true when metadata.json is updated', async () => {
       mockAxios.get.mockImplementation(() => {
         return Promise.resolve({ data: {} })
       })
@@ -45,40 +35,21 @@ describe('useHasAppUpdated', () => {
       const { result } = renderHook(() => useHasAppUpdated())
 
       mockAxios.get.mockImplementationOnce((url: string) => {
-        if (url.includes('env.json')) return Promise.resolve({ data: { change: true } })
+        if (url.includes('metadata.json')) return Promise.resolve({ data: { change: true } })
         else return Promise.resolve({ data: {} })
       })
 
-      await act(() => {
-        jest.advanceTimersByTime(APP_UPDATE_CHECK_INTERVAL)
-      })
-      /** without the `await` of previous act
-       * await waitFor(() => expect(result.current).toBe(false))
-       * will pass the test too.
-       */
       await waitFor(() => expect(result.current).toBe(true))
     })
 
-    it('should return true when asset-manifest.json is updated', async () => {
+    it('should return false when metadata.json is not updated', async () => {
       mockAxios.get.mockImplementation(() => {
         return Promise.resolve({ data: {} })
       })
 
       const { result } = renderHook(() => useHasAppUpdated())
 
-      mockAxios.get.mockImplementationOnce((url: string) => {
-        if (url.includes('asset-manifest.json')) return Promise.resolve({ data: { change: true } })
-        else return Promise.resolve({ data: {} })
-      })
-
-      await act(() => {
-        jest.advanceTimersByTime(APP_UPDATE_CHECK_INTERVAL)
-      })
-      /** without the `await` of previous act
-       * await waitFor(() => expect(result.current).toBe(false))
-       * will pass the test too.
-       */
-      await waitFor(() => expect(result.current).toBe(true))
+      await waitFor(() => expect(result.current).toBe(false))
     })
 
     it('should return false when axios fails', async () => {
@@ -90,12 +61,6 @@ describe('useHasAppUpdated', () => {
 
       mockAxios.get.mockImplementationOnce(() => {
         return Promise.reject({ error: {} })
-      })
-
-      // without the `await` keyword, following line will throw this warning:
-      // an update to TestComponent inside a test was not wrapped in act(...).
-      await act(() => {
-        jest.advanceTimersByTime(APP_UPDATE_CHECK_INTERVAL)
       })
 
       await waitFor(() => expect(result.current).toBe(false))
@@ -103,15 +68,6 @@ describe('useHasAppUpdated', () => {
   })
 
   describe('localhost', () => {
-    it('should return false when env.json/asset-manifest.json is not updated', async () => {
-      mockAxios.get.mockImplementation(() => {
-        return Promise.resolve({ data: {} })
-      })
-
-      const { result } = renderHook(() => useHasAppUpdated())
-      await waitFor(() => expect(result.current).toBe(false))
-    })
-
     beforeEach(() => {
       jest.spyOn(window, 'location', 'get').mockReturnValue({
         ...window.location,
@@ -119,60 +75,43 @@ describe('useHasAppUpdated', () => {
       })
     })
 
-    it('should return false when env.json updated', async () => {
+    it('should return false for localhost', async () => {
       mockAxios.get.mockImplementation(() => {
         return Promise.resolve({ data: {} })
       })
 
       const { result } = renderHook(() => useHasAppUpdated())
 
+      expect(mockAxios.get.mock.calls.length).toEqual(0)
+
       act(() => {
         jest.advanceTimersByTime(APP_UPDATE_CHECK_INTERVAL)
       })
 
+      expect(mockAxios.get.mock.calls.length).toEqual(0)
+
       mockAxios.get.mockImplementationOnce((url: string) => {
-        if (url.includes('env.json')) return Promise.resolve({ data: { change: true } })
+        if (url.includes('metadata.json')) return Promise.resolve({ data: { change: true } })
         else return Promise.resolve({ data: {} })
       })
 
       await waitFor(() => expect(result.current).toBe(false))
+      expect(mockAxios.get.mock.calls.length).toEqual(0)
     })
 
-    it('should return false when asset-manifest.json is updated', async () => {
+    it('should not make network requests on localhost', async () => {
       mockAxios.get.mockImplementation(() => {
         return Promise.resolve({ data: {} })
-      })
-
-      const { result } = renderHook(() => useHasAppUpdated())
-
-      act(() => {
-        jest.advanceTimersByTime(APP_UPDATE_CHECK_INTERVAL)
-      })
-
-      mockAxios.get.mockImplementationOnce((url: string) => {
-        if (url.includes('asset-manifest.json')) return Promise.resolve({ data: { change: true } })
-        else return Promise.resolve({ data: {} })
-      })
-
-      await waitFor(() => expect(result.current).toBe(false))
-    })
-
-    it('should return false when axios fails', async () => {
-      mockAxios.get.mockImplementation(() => {
-        return Promise.resolve({ data: {} })
-      })
-
-      const { result } = renderHook(useHasAppUpdated)
-
-      mockAxios.get.mockImplementationOnce(() => {
-        return Promise.reject({ error: {} })
       })
 
       act(() => {
         jest.advanceTimersByTime(APP_UPDATE_CHECK_INTERVAL)
       })
 
-      await waitFor(() => expect(result.current).toBe(false))
+      mockAxios.get.mockImplementationOnce(() => Promise.resolve({ data: {} }))
+
+      await waitFor(() => undefined)
+      expect(mockAxios.get.mock.calls.length).toEqual(0)
     })
   })
 })

--- a/src/hooks/useHasAppUpdated/useHasAppUpdated.ts
+++ b/src/hooks/useHasAppUpdated/useHasAppUpdated.ts
@@ -1,75 +1,63 @@
 import axios from 'axios'
 import isEqual from 'lodash/isEqual'
 import { useCallback, useEffect, useState } from 'react'
-import { useInterval } from 'hooks/useInterval/useInterval'
 import { logger } from 'lib/logger'
 
 const moduleLogger = logger.child({ namespace: ['useHasAppUpdated'] })
 
-export const APP_UPDATE_CHECK_INTERVAL = 1000 * 60
+export const APP_UPDATE_CHECK_INTERVAL = 1000 * 60 // one minute
 
 // Treat private IPs as local: 192.168.0.0/16, 10.0.0.0/16, 127.0.0.0/16, and 'localhost'
 const localhostRegEx = /(?:192\.168|10\.0|127\.0)\.\d{1,3}\.\d{1,3}|localhost/
 
-// 'asset-manifest.json' keeps track of the latest minified built files
-const assetManifestUrl = `/asset-manifest.json`
+type Metadata = {
+  latestTag: string
+  headShortCommitHash: string
+}
 
 export const useHasAppUpdated = () => {
   const [hasUpdated, setHasUpdated] = useState(false)
-  const [initialManifestMainJs, setInitialManifestMainJs] = useState<unknown>()
-  const [initialEnvMainJs, setInitialEnvMainJs] = useState<unknown>()
+
+  // 'metadata.json' keeps track of current commit hash and git tag
+  const metadataUrl = `/metadata.json`
+  const [initialMetadata, setInitialMetadata] = useState<Metadata | undefined>()
 
   const isLocalhost = localhostRegEx.test(window.location.hostname)
-  moduleLogger.trace({ isLocalhost }, 'isLocalhost?')
 
-  const fetchData = useCallback(async (url: string): Promise<unknown> => {
+  const fetchData = useCallback(async (url: string): Promise<Metadata | undefined> => {
     try {
       // dummy query param to bypass the browser cache.
       const { data } = await axios.get(`${url}?${new Date().valueOf()}`)
       return data
     } catch (e) {
       moduleLogger.error(e, `useHasAppUpdated: error fetching data from URL: ${url}`)
-      return null
     }
   }, [])
-
-  const storeMainManifestJs = useCallback(async () => {
-    const manifestMainJs = await fetchData(assetManifestUrl)
-    manifestMainJs && setInitialManifestMainJs(manifestMainJs)
-  }, [fetchData])
-
-  // 'asset-manifest.json' keeps track of the current environment variables
-  const envUrl = `/env.json`
-  const storeMainEnvJs = useCallback(async () => {
-    const envMainJs = await fetchData(envUrl)
-    envMainJs && setInitialEnvMainJs(envMainJs)
-  }, [envUrl, fetchData])
 
   // store initial values once
   useEffect(() => {
     if (isLocalhost) return
-    storeMainManifestJs()
-    storeMainEnvJs()
-  }, [isLocalhost, storeMainEnvJs, storeMainManifestJs])
+    fetchData(metadataUrl).then(setInitialMetadata).catch()
+  }, [fetchData, isLocalhost, metadataUrl])
 
-  useInterval(
-    async () => {
-      if (isLocalhost) return
-      const [currentManifestJs, currentEnvJs] = await Promise.all([
-        fetchData(assetManifestUrl),
-        fetchData(envUrl),
-      ])
-      if (currentEnvJs && currentManifestJs) {
-        const isExactAssetManifest = isEqual(initialManifestMainJs, currentManifestJs)
-        const isExactEnv = isEqual(initialEnvMainJs, currentEnvJs)
+  useEffect(() => {
+    if (isLocalhost) return
+    // don't erroneously compare if we failed to fetch the initial
+    if (!initialMetadata) return
 
-        const eitherHasChanged = !isExactAssetManifest || !isExactEnv
-        setHasUpdated(eitherHasChanged)
-      }
-    },
-    // Don't implement the interval check for local development
-    isLocalhost ? null : APP_UPDATE_CHECK_INTERVAL,
-  )
+    const fn = async () => {
+      const currentMetadata = await fetchData(metadataUrl)
+      // don't erroneously compare if we failed to fetch on the interval
+      if (!currentMetadata) return
+      const isDifferentMetadata = !isEqual(initialMetadata, currentMetadata)
+      setHasUpdated(isDifferentMetadata)
+    }
+    const interval = setInterval(fn, APP_UPDATE_CHECK_INTERVAL)
+    fn() // run this once, makes testing easier
+
+    // cleanup
+    return () => clearTimeout(interval)
+  }, [fetchData, initialMetadata, isLocalhost, metadataUrl])
 
   if (isLocalhost) return false // never return true on localhost
   return hasUpdated


### PR DESCRIPTION
## Description

<!-- Please describe your changes -->

for users with large tx history, this fails to make a network request then erroneously marks the app as updated

this PR also simplifies the hook to use the `metadata.json` file including the commit hash rather than checking against the `manifest.json` of the built files and `.env.json` of environment variables

even an environment variable change will change the `metadata.json` file as the commit hash will change

## Pull Request Type

- [x] :bug: Bug fix (Non-breaking Change: Fixes an issue)
- [ ] :hammer_and_wrench: Chore (Non-breaking Change: Doc updates, pkg upgrades, typos, etc..)
- [ ] :nail_care: New Feature (Breaking/Non-breaking Change)

## Issue (if applicable)

<!-----------------------------------------------------------------------------
If applicable, please link to the github issue and put `closes #XXXX` in your comment to auto-close the issue that your PR fixes.
------------------------------------------------------------------------------>

n/a

## Risk

low but annoying if i get this wrong - isolated to the app update notification

<!-----------------------------------------------------------------------------
Outline the scope of your changes and the risk associated with them. You must use your discretion as an engineer to determine the potential impact of your changes.

E.g. an upgrade to `hdwallet` or core state management would be considered higher risk, and might require a full regression test. UI or isolated view changes, or something behind a feature flag may have near zero risk. Small bug fixes might require testing isolated to the specific fix.
------------------------------------------------------------------------------>

## Testing

<!-----------------------------------------------------------------------------
We treat every PR to be merged with the same scrutiny as if we were merging directly to production.

Your PR will not be merged if you do not complete the sections below for our engineering and operations teams to test.
------------------------------------------------------------------------------>

### Engineering

* deploy to your own ephemeral environment
* pair willywonka.eth via frame wallet
* see that we don't get errenous app update notifications after 1 min
* push an empty commit to your ephemeral branch such that the commit hash changes
* see that you get an app updated notification after 1 min of deploy completing

<!-----------------------------------------------------------------------------
Include sufficient information here for an engineer to test your PR. This may include how to test locally, in a built environment, changes to infrastructure etc.
------------------------------------------------------------------------------>

### Operations

not testable by ops

<!-----------------------------------------------------------------------------
If your changes have a user-facing impact, describe how a non-technical QA team can functionally test your changes in a preview environment.

If they are not user-facing please describe how to test for any regressions that may occur.
------------------------------------------------------------------------------>

## Screenshots (if applicable)
