### PR TITLE
feat: market data refactor to handle sorted market data IDs

### DIFF
--- a/src/components/AssetSearch/AssetSearch.tsx
+++ b/src/components/AssetSearch/AssetSearch.tsx
@@ -14,7 +14,10 @@ import { useSelector } from 'react-redux'
 import { useHistory } from 'react-router'
 import { Card } from 'components/Card/Card'
 import { logger } from 'lib/logger'
-import { selectChainIdsByMarketCap, selectSortedAssets } from 'state/slices/selectors'
+import {
+  selectAssetsSortedByMarketCapFiatBalanceAndName,
+  selectChainIdsByMarketCap,
+} from 'state/slices/selectors'
 import { useAppSelector } from 'state/store'
 
 import { AssetList } from './AssetList'
@@ -47,7 +50,9 @@ export const AssetSearch: FC<AssetSearchProps> = ({
 
   const chainIdsByMarketCap = useSelector(selectChainIdsByMarketCap)
   const [activeChain, setActiveChain] = useState<ChainId | 'All'>('All')
-  const assets = useAppSelector(state => selectedAssets ?? selectSortedAssets(state))
+  const assets = useAppSelector(
+    state => selectedAssets ?? selectAssetsSortedByMarketCapFiatBalanceAndName(state),
+  )
 
   /**
    * assets filtered by selected chain ids

--- a/src/components/EarnDashboard/components/ProviderDetails/OpportunityRow.tsx
+++ b/src/components/EarnDashboard/components/ProviderDetails/OpportunityRow.tsx
@@ -17,7 +17,7 @@ import {
 import {
   selectAssetById,
   selectAssets,
-  selectMarketDataSortedByMarketCap,
+  selectSelectedCurrencyMarketDataSortedByMarketCap,
 } from 'state/slices/selectors'
 import { useAppSelector } from 'state/store'
 
@@ -48,7 +48,7 @@ export const OpportunityRow: React.FC<
   const borderColor = useColorModeValue('blackAlpha.50', 'whiteAlpha.50')
   const asset = useAppSelector(state => selectAssetById(state, underlyingAssetId))
   const assets = useAppSelector(selectAssets)
-  const marketData = useAppSelector(selectMarketDataSortedByMarketCap)
+  const marketData = useAppSelector(selectSelectedCurrencyMarketDataSortedByMarketCap)
 
   const underlyingAssetLabel = useMemo(() => {
     if ((opportunity as StakingEarnOpportunityType)?.rewardsCryptoBaseUnit) {

--- a/src/components/Equity/EquityLpRow.tsx
+++ b/src/components/Equity/EquityLpRow.tsx
@@ -17,8 +17,8 @@ import {
   selectAllEarnUserLpOpportunitiesByFilter,
   selectAssetById,
   selectAssets,
-  selectMarketDataSortedByMarketCap,
   selectOpportunityApiPending,
+  selectSelectedCurrencyMarketDataSortedByMarketCap,
 } from 'state/slices/selectors'
 import { useAppSelector } from 'state/store'
 
@@ -46,7 +46,7 @@ export const EquityLpRow: React.FC<EquityLpRowProps> = ({
   const location = useLocation()
   const isLoading = useAppSelector(selectOpportunityApiPending)
   const assets = useAppSelector(selectAssets)
-  const marketData = useAppSelector(selectMarketDataSortedByMarketCap)
+  const marketData = useAppSelector(selectSelectedCurrencyMarketDataSortedByMarketCap)
   const filter = useMemo(() => {
     return {
       assetId,

--- a/src/components/Modals/FiatRamps/views/FiatForm.tsx
+++ b/src/components/Modals/FiatRamps/views/FiatForm.tsx
@@ -12,8 +12,8 @@ import { logger } from 'lib/logger'
 import type { PartialRecord } from 'lib/utils'
 import { useGetFiatRampsQuery } from 'state/apis/fiatRamps/fiatRamps'
 import {
+  selectAssetsSortedByMarketCapFiatBalanceAndName,
   selectPortfolioAccountMetadata,
-  selectSortedAssets,
   selectWalletAccountIds,
 } from 'state/slices/selectors'
 
@@ -39,7 +39,7 @@ export const FiatForm: React.FC<FiatFormProps> = ({
 }) => {
   const walletAccountIds = useSelector(selectWalletAccountIds)
   const portfolioAccountMetadata = useSelector(selectPortfolioAccountMetadata)
-  const sortedAssets = useSelector(selectSortedAssets)
+  const sortedAssets = useSelector(selectAssetsSortedByMarketCapFiatBalanceAndName)
   const [accountId, setAccountId] = useState<AccountId | undefined>(selectedAccountId)
   const [addressByAccountId, setAddressByAccountId] = useState<AddressesByAccountId>()
   const [selectedAssetId, setSelectedAssetId] = useState<AssetId>()

--- a/src/components/Trade/hooks/useSwapper/useSwapper.tsx
+++ b/src/components/Trade/hooks/useSwapper/useSwapper.tsx
@@ -8,10 +8,10 @@ import type { SwapperManager } from 'lib/swapper/manager/SwapperManager'
 import { selectFeatureFlags } from 'state/slices/preferencesSlice/selectors'
 import {
   selectAssetIds,
+  selectAssetsSortedByMarketCapFiatBalanceAndName,
   selectBIP44ParamsByAccountId,
   selectPortfolioAccountIdsByAssetId,
   selectPortfolioAccountMetadataByAccountId,
-  selectSortedAssets,
 } from 'state/slices/selectors'
 import { useAppSelector } from 'state/store'
 import {
@@ -44,7 +44,7 @@ export const useSwapper = () => {
   // Selectors
   const flags = useSelector(selectFeatureFlags)
   const assetIds = useSelector(selectAssetIds)
-  const sortedAssets = useSelector(selectSortedAssets)
+  const sortedAssets = useSelector(selectAssetsSortedByMarketCapFiatBalanceAndName)
 
   // Hooks
   const [swapperManager, setSwapperManager] = useState<SwapperManager>()

--- a/src/features/defi/providers/fox-farming/components/FoxFarmingManager/Overview/FoxFarmingOverview.tsx
+++ b/src/features/defi/providers/fox-farming/components/FoxFarmingManager/Overview/FoxFarmingOverview.tsx
@@ -29,7 +29,7 @@ import {
   selectAssets,
   selectFirstAccountIdByChainId,
   selectHighestBalanceAccountIdByStakingId,
-  selectMarketDataSortedByMarketCap,
+  selectSelectedCurrencyMarketDataSortedByMarketCap,
   selectUnderlyingStakingAssetsWithBalancesAndIcons,
   selectUserStakingOpportunityByUserStakingId,
 } from 'state/slices/selectors'
@@ -53,7 +53,7 @@ export const FoxFarmingOverview: React.FC<FoxFarmingOverviewProps> = ({
   const lpAsset = assets[foxEthLpAssetId]
   if (!lpAsset) throw new Error(`Asset not found for AssetId ${foxEthLpAssetId}`)
 
-  const marketData = useAppSelector(selectMarketDataSortedByMarketCap)
+  const marketData = useAppSelector(selectSelectedCurrencyMarketDataSortedByMarketCap)
   const { query, history, location } = useBrowserRouter<DefiQueryParams, DefiParams>()
   const { assetNamespace, chainId, contractAddress, rewardId } = query
 

--- a/src/features/defi/providers/idle/components/IdleManager/Claim/components/Confirm.tsx
+++ b/src/features/defi/providers/idle/components/IdleManager/Claim/components/Confirm.tsx
@@ -34,8 +34,8 @@ import {
   selectEarnUserStakingOpportunityByUserStakingId,
   selectHighestBalanceAccountIdByStakingId,
   selectMarketDataById,
-  selectMarketDataSortedByMarketCap,
   selectPortfolioCryptoPrecisionBalanceByFilter,
+  selectSelectedCurrencyMarketDataSortedByMarketCap,
 } from 'state/slices/selectors'
 import { useAppSelector } from 'state/store'
 
@@ -70,7 +70,9 @@ export const Confirm = ({ accountId, onNext }: ConfirmProps) => {
   const feeAssetId = chainAdapter?.getFeeAssetId()
   const feeAsset = useAppSelector(state => selectAssetById(state, feeAssetId ?? ''))
   const feeMarketData = useAppSelector(state => selectMarketDataById(state, feeAssetId ?? ''))
-  const marketData = useAppSelector(state => selectMarketDataSortedByMarketCap(state))
+  const marketData = useAppSelector(state =>
+    selectSelectedCurrencyMarketDataSortedByMarketCap(state),
+  )
 
   if (!feeAsset) throw new Error(`Fee asset not found for AssetId ${feeAssetId}`)
 

--- a/src/features/defi/providers/idle/components/IdleManager/Claim/components/Status.tsx
+++ b/src/features/defi/providers/idle/components/IdleManager/Claim/components/Status.tsx
@@ -28,7 +28,7 @@ import {
   selectFirstAccountIdByChainId,
   selectHighestBalanceAccountIdByStakingId,
   selectMarketDataById,
-  selectMarketDataSortedByMarketCap,
+  selectSelectedCurrencyMarketDataSortedByMarketCap,
   selectTxById,
 } from 'state/slices/selectors'
 import { serializeTxIndex } from 'state/slices/txHistorySlice/utils'
@@ -73,7 +73,9 @@ export const Status = () => {
   if (!feeAsset) throw new Error(`Fee asset not found for AssetId ${feeAssetId}`)
 
   const feeMarketData = useAppSelector(state => selectMarketDataById(state, feeAssetId))
-  const marketData = useAppSelector(state => selectMarketDataSortedByMarketCap(state))
+  const marketData = useAppSelector(state =>
+    selectSelectedCurrencyMarketDataSortedByMarketCap(state),
+  )
 
   const accountId = useAppSelector(state => selectFirstAccountIdByChainId(state, chainId))
 

--- a/src/features/defi/providers/osmosis/components/OsmosisManager/Lp/Deposit/components/Confirm.tsx
+++ b/src/features/defi/providers/osmosis/components/OsmosisManager/Lp/Deposit/components/Confirm.tsx
@@ -36,8 +36,8 @@ import {
   selectAssets,
   selectBIP44ParamsByAccountId,
   selectMarketDataById,
-  selectMarketDataSortedByMarketCap,
   selectPortfolioCryptoPrecisionBalanceByFilter,
+  selectSelectedCurrencyMarketDataSortedByMarketCap,
 } from 'state/slices/selectors'
 import { useAppSelector } from 'state/store'
 
@@ -61,7 +61,7 @@ export const Confirm: React.FC<ConfirmProps> = ({ onNext, accountId }) => {
   const chainAdapter = getChainAdapterManager().get(chainId) as unknown as osmosis.ChainAdapter
 
   const assets = useAppSelector(selectAssets)
-  const marketData = useAppSelector(selectMarketDataSortedByMarketCap)
+  const marketData = useAppSelector(selectSelectedCurrencyMarketDataSortedByMarketCap)
 
   const underlyingAssetBalances = useMemo(() => {
     if (!osmosisOpportunity || !state) return null

--- a/src/features/defi/providers/osmosis/components/OsmosisManager/Lp/Deposit/components/Status.tsx
+++ b/src/features/defi/providers/osmosis/components/OsmosisManager/Lp/Deposit/components/Status.tsx
@@ -25,7 +25,7 @@ import {
   selectAssetById,
   selectAssets,
   selectMarketDataById,
-  selectMarketDataSortedByMarketCap,
+  selectSelectedCurrencyMarketDataSortedByMarketCap,
   selectTxById,
 } from 'state/slices/selectors'
 import { serializeTxIndex } from 'state/slices/txHistorySlice/utils'
@@ -45,7 +45,7 @@ export const Status: React.FC<StatusProps> = ({ accountId }) => {
   const opportunity = state?.opportunity
 
   const assets = useAppSelector(selectAssets)
-  const marketData = useAppSelector(selectMarketDataSortedByMarketCap)
+  const marketData = useAppSelector(selectSelectedCurrencyMarketDataSortedByMarketCap)
 
   const feeAsset = useAppSelector(state => selectAssetById(state, osmosisAssetId))
   if (!feeAsset) throw new Error(`Fee asset not found for AssetId ${osmosisAssetId}`)

--- a/src/features/defi/providers/osmosis/components/OsmosisManager/Lp/Withdraw/components/Confirm.tsx
+++ b/src/features/defi/providers/osmosis/components/OsmosisManager/Lp/Withdraw/components/Confirm.tsx
@@ -36,8 +36,8 @@ import {
   selectAssets,
   selectBIP44ParamsByAccountId,
   selectMarketDataById,
-  selectMarketDataSortedByMarketCap,
   selectPortfolioCryptoPrecisionBalanceByFilter,
+  selectSelectedCurrencyMarketDataSortedByMarketCap,
 } from 'state/slices/selectors'
 import { useAppSelector } from 'state/store'
 
@@ -63,7 +63,7 @@ export const Confirm: React.FC<ConfirmProps> = ({ accountId, onNext }) => {
   const chainAdapter = getChainAdapterManager().get(chainId) as unknown as osmosis.ChainAdapter
 
   const assets = useAppSelector(selectAssets)
-  const marketData = useAppSelector(selectMarketDataSortedByMarketCap)
+  const marketData = useAppSelector(selectSelectedCurrencyMarketDataSortedByMarketCap)
 
   const underlyingAssetBalances = useMemo(() => {
     if (!osmosisOpportunity || !state) return null

--- a/src/features/defi/providers/osmosis/components/OsmosisManager/Lp/Withdraw/components/Status.tsx
+++ b/src/features/defi/providers/osmosis/components/OsmosisManager/Lp/Withdraw/components/Status.tsx
@@ -26,7 +26,7 @@ import {
   selectAssetById,
   selectAssets,
   selectMarketDataById,
-  selectMarketDataSortedByMarketCap,
+  selectSelectedCurrencyMarketDataSortedByMarketCap,
   selectTxById,
 } from 'state/slices/selectors'
 import { serializeTxIndex } from 'state/slices/txHistorySlice/utils'
@@ -44,7 +44,7 @@ export const Status: React.FC<StatusProps> = ({ accountId }) => {
   const osmosisOpportunity = state?.opportunity
 
   const assets = useAppSelector(selectAssets)
-  const marketData = useAppSelector(selectMarketDataSortedByMarketCap)
+  const marketData = useAppSelector(selectSelectedCurrencyMarketDataSortedByMarketCap)
   const feeAsset = useAppSelector(state => selectAssetById(state, osmosisAssetId))
   if (!feeAsset) throw new Error(`Fee asset not found for AssetId ${osmosisAssetId}`)
   const feeAssetMarketData = useAppSelector(state =>

--- a/src/features/defi/providers/osmosis/components/OsmosisManager/Lp/Withdraw/components/Withdraw.tsx
+++ b/src/features/defi/providers/osmosis/components/OsmosisManager/Lp/Withdraw/components/Withdraw.tsx
@@ -34,8 +34,8 @@ import { getUnderlyingAssetIdsBalances } from 'state/slices/opportunitiesSlice/u
 import {
   selectAssetById,
   selectAssets,
-  selectMarketDataSortedByMarketCap,
   selectPortfolioCryptoBalanceBaseUnitByFilter,
+  selectSelectedCurrencyMarketDataSortedByMarketCap,
 } from 'state/slices/selectors'
 import { useAppSelector } from 'state/store'
 
@@ -90,7 +90,7 @@ export const Withdraw: React.FC<WithdrawProps> = ({
   const { setValue } = methods
 
   const assets = useAppSelector(selectAssets)
-  const marketData = useAppSelector(selectMarketDataSortedByMarketCap)
+  const marketData = useAppSelector(selectSelectedCurrencyMarketDataSortedByMarketCap)
   const lpAsset: Asset | undefined = useAppSelector(state =>
     selectAssetById(state, osmosisOpportunity?.assetId ?? ''),
   )

--- a/src/features/defi/providers/univ2/components/UniV2Manager/Withdraw/components/Withdraw.tsx
+++ b/src/features/defi/providers/univ2/components/UniV2Manager/Withdraw/components/Withdraw.tsx
@@ -27,8 +27,8 @@ import {
   selectAssets,
   selectEarnUserLpOpportunity,
   selectMarketDataById,
-  selectMarketDataSortedByMarketCap,
   selectPortfolioCryptoBalanceBaseUnitByFilter,
+  selectSelectedCurrencyMarketDataSortedByMarketCap,
 } from 'state/slices/selectors'
 import { useAppSelector } from 'state/store'
 
@@ -47,7 +47,7 @@ export const Withdraw: React.FC<WithdrawProps> = ({
   onAccountIdChange: handleAccountIdChange,
   onNext,
 }) => {
-  const marketData = useAppSelector(selectMarketDataSortedByMarketCap)
+  const marketData = useAppSelector(selectSelectedCurrencyMarketDataSortedByMarketCap)
   const { state, dispatch } = useContext(WithdrawContext)
   const { history: browserHistory } = useBrowserRouter<DefiQueryParams, DefiParams>()
   const { query } = useBrowserRouter<DefiQueryParams, DefiParams>()

--- a/src/hooks/useTxDetails/useTxDetails.ts
+++ b/src/hooks/useTxDetails/useTxDetails.ts
@@ -12,7 +12,7 @@ import { defaultMarketData } from 'state/slices/marketDataSlice/marketDataSlice'
 import {
   selectAssets,
   selectFeeAssetByChainId,
-  selectMarketDataSortedByMarketCap,
+  selectSelectedCurrencyMarketDataSortedByMarketCap,
   selectTxById,
 } from 'state/slices/selectors'
 import type { Tx } from 'state/slices/txHistorySlice/txHistorySlice'
@@ -88,7 +88,7 @@ export const getTransfers = (
 export const useTxDetails = (txId: string): TxDetails => {
   const tx = useAppSelector((state: ReduxState) => selectTxById(state, txId))
   const assets = useAppSelector(selectAssets)
-  const marketData = useAppSelector(selectMarketDataSortedByMarketCap)
+  const marketData = useAppSelector(selectSelectedCurrencyMarketDataSortedByMarketCap)
   const transfers = useMemo(
     () => getTransfers(tx.transfers, assets, marketData),
     [tx.transfers, assets, marketData],

--- a/src/pages/TransactionHistory/DownloadButton.tsx
+++ b/src/pages/TransactionHistory/DownloadButton.tsx
@@ -9,7 +9,11 @@ import { getTransfers, getTxType } from 'hooks/useTxDetails/useTxDetails'
 import { bnOrZero } from 'lib/bignumber/bignumber'
 import { logger } from 'lib/logger'
 import { fromBaseUnit } from 'lib/math'
-import { selectAssets, selectMarketDataSortedByMarketCap, selectTxs } from 'state/slices/selectors'
+import {
+  selectAssets,
+  selectSelectedCurrencyMarketDataSortedByMarketCap,
+  selectTxs,
+} from 'state/slices/selectors'
 import type { TxId } from 'state/slices/txHistorySlice/txHistorySlice'
 import { useAppSelector } from 'state/store'
 import { breakpoints } from 'theme/theme'
@@ -45,7 +49,7 @@ export const DownloadButton = ({ txIds }: { txIds: TxId[] }) => {
   const [isLargerThanLg] = useMediaQuery(`(min-width: ${breakpoints['lg']})`, { ssr: false })
   const allTxs = useAppSelector(selectTxs)
   const assets = useAppSelector(selectAssets)
-  const marketData = useAppSelector(selectMarketDataSortedByMarketCap)
+  const marketData = useAppSelector(selectSelectedCurrencyMarketDataSortedByMarketCap)
   const translate = useTranslate()
   const fields = {
     txid: translate('transactionHistory.csv.txid'),

--- a/src/pages/TransactionHistory/TransactionHistory.tsx
+++ b/src/pages/TransactionHistory/TransactionHistory.tsx
@@ -24,6 +24,7 @@ export const TransactionHistory = () => {
   const { filters, setFilters, resetFilters } = useFilters()
   const selectorFilters = useMemo(
     () => ({
+      // TODO(gomes): This is wrong. We don't use anything Asset-y from this, only the AssetId
       matchingAssets: matchingAssets?.map(asset => asset.assetId) ?? null,
       ...filters,
     }),

--- a/src/pages/TransactionHistory/TransactionHistory.tsx
+++ b/src/pages/TransactionHistory/TransactionHistory.tsx
@@ -24,7 +24,6 @@ export const TransactionHistory = () => {
   const { filters, setFilters, resetFilters } = useFilters()
   const selectorFilters = useMemo(
     () => ({
-      // TODO(gomes): This is wrong. We don't use anything Asset-y from this, only the AssetId
       matchingAssets: matchingAssets?.map(asset => asset.assetId) ?? null,
       ...filters,
     }),

--- a/src/pages/TransactionHistory/hooks/useSearch.tsx
+++ b/src/pages/TransactionHistory/hooks/useSearch.tsx
@@ -1,12 +1,19 @@
 import type { Asset } from '@shapeshiftoss/asset-service'
 import debounce from 'lodash/debounce'
-import { useCallback, useState } from 'react'
+import { useCallback, useMemo, useState } from 'react'
 import { filterAssetsBySearchTerm } from 'components/AssetSearch/helpers/filterAssetsBySearchTerm/filterAssetsBySearchTerm'
-import { selectAssetsByMarketCapAndName } from 'state/slices/selectors'
+import { isSome } from 'lib/utils'
+import { selectAssets } from 'state/slices/selectors'
 import { useAppSelector } from 'state/store'
 
 export const useSearch = () => {
-  const assets = useAppSelector(selectAssetsByMarketCapAndName)
+  const assetsById = useAppSelector(selectAssets)
+  // TODO(gomes): This shouldn't be a view-layer concern. To be tackled in a follow-up PR not to tackle the diff of https://github.com/shapeshift/web/pull/4429
+  // - selectAssets will be LSP renamed to selectAssetsById
+  // - selectAssets will now be a selector that returns Asset[]
+  // We could use selectAssetsByMarketCap but this is wrong. We don't care about the market cap here.
+  // While at it, this shouldn't be selecting assets altogether, but AssetIds, see consumption in <TransactionHistory />
+  const assets = useMemo(() => Object.values(assetsById).filter(isSome), [assetsById])
   const [searchTerm, setSearchTerm] = useState('')
   const [matchingAssets, setMatchingAssets] = useState<Asset[] | null>(null)
   const handleInputChange = useCallback(

--- a/src/pages/TransactionHistory/hooks/useSearch.tsx
+++ b/src/pages/TransactionHistory/hooks/useSearch.tsx
@@ -8,11 +8,6 @@ import { useAppSelector } from 'state/store'
 
 export const useSearch = () => {
   const assetsById = useAppSelector(selectAssets)
-  // TODO(gomes): This shouldn't be a view-layer concern. To be tackled in a follow-up PR not to tackle the diff of https://github.com/shapeshift/web/pull/4429
-  // - selectAssets will be LSP renamed to selectAssetsById
-  // - selectAssets will now be a selector that returns Asset[]
-  // We could use selectAssetsByMarketCap but this is wrong. We don't care about the market cap here.
-  // While at it, this shouldn't be selecting assets altogether, but AssetIds, see consumption in <TransactionHistory />
   const assets = useMemo(() => Object.values(assetsById).filter(isSome), [assetsById])
   const [searchTerm, setSearchTerm] = useState('')
   const [matchingAssets, setMatchingAssets] = useState<Asset[] | null>(null)

--- a/src/pages/TransactionHistory/hooks/useSearch.tsx
+++ b/src/pages/TransactionHistory/hooks/useSearch.tsx
@@ -2,11 +2,11 @@ import type { Asset } from '@shapeshiftoss/asset-service'
 import debounce from 'lodash/debounce'
 import { useCallback, useState } from 'react'
 import { filterAssetsBySearchTerm } from 'components/AssetSearch/helpers/filterAssetsBySearchTerm/filterAssetsBySearchTerm'
-import { selectAssetsByMarketCap } from 'state/slices/selectors'
+import { selectAssetsByMarketCapAndName } from 'state/slices/selectors'
 import { useAppSelector } from 'state/store'
 
 export const useSearch = () => {
-  const assets = useAppSelector(selectAssetsByMarketCap)
+  const assets = useAppSelector(selectAssetsByMarketCapAndName)
   const [searchTerm, setSearchTerm] = useState('')
   const [matchingAssets, setMatchingAssets] = useState<Asset[] | null>(null)
   const handleInputChange = useCallback(

--- a/src/state/apis/fiatRamps/selectors.ts
+++ b/src/state/apis/fiatRamps/selectors.ts
@@ -6,7 +6,10 @@ import { createSelector } from 'reselect'
 import { createDeepEqualOutputSelector } from 'state/selector-utils'
 import { selectAssetIdParamFromFilter } from 'state/selectors'
 import { defaultMarketData } from 'state/slices/marketDataSlice/marketDataSlice'
-import { selectAssets, selectMarketDataSortedByMarketCap } from 'state/slices/selectors'
+import {
+  selectAssets,
+  selectSelectedCurrencyMarketDataSortedByMarketCap,
+} from 'state/slices/selectors'
 
 import { fiatRampApi } from './fiatRamps'
 
@@ -24,7 +27,7 @@ type AssetWithMarketData = Asset & MarketData
 
 export const selectFiatRampBuyAssetsWithMarketData = createSelector(
   selectAssets,
-  selectMarketDataSortedByMarketCap,
+  selectSelectedCurrencyMarketDataSortedByMarketCap,
   selectFiatBuyAssetIds,
   (assetsById, cryptoMarketData, assetIds): AssetWithMarketData[] => {
     return assetIds.reduce<AssetWithMarketData[]>((acc, assetId) => {

--- a/src/state/slices/assetsSlice/selectors.ts
+++ b/src/state/slices/assetsSlice/selectors.ts
@@ -2,7 +2,6 @@ import { createSelector } from '@reduxjs/toolkit'
 import type { Asset } from '@shapeshiftoss/asset-service'
 import type { AssetId, ChainId } from '@shapeshiftoss/caip'
 import { fromAssetId } from '@shapeshiftoss/caip'
-import orderBy from 'lodash/orderBy'
 import { matchSorter } from 'match-sorter'
 import createCachedSelector from 're-reselect'
 import type { ReduxState } from 'state/reducer'
@@ -48,12 +47,6 @@ export const selectAssetsByMarketCap = createDeepEqualOutputSelector(
 
     return sortedAssets
   },
-)
-
-export const selectAssetsByMarketCapAndName = createDeepEqualOutputSelector(
-  selectAssetsByMarketCap,
-  (sortedAssets: Asset[]): Asset[] =>
-    orderBy(sortedAssets, [asset => asset.name.toLowerCase()], ['asc']),
 )
 
 export const selectChainIdsByMarketCap = createDeepEqualOutputSelector(

--- a/src/state/slices/common-selectors.ts
+++ b/src/state/slices/common-selectors.ts
@@ -10,8 +10,8 @@ import type { ReduxState } from 'state/reducer'
 import { createDeepEqualOutputSelector } from 'state/selector-utils'
 import { selectAccountIdParamFromFilter, selectAssetIdParamFromFilter } from 'state/selectors'
 
-import { selectAssets } from './assetsSlice/selectors'
-import { selectMarketDataSortedByMarketCap } from './marketDataSlice/selectors'
+import { selectAssets, selectAssetsByMarketCap } from './assetsSlice/selectors'
+import { selectSelectedCurrencyMarketDataSortedByMarketCap } from './marketDataSlice/selectors'
 import type { PortfolioAccountBalancesById } from './portfolioSlice/portfolioSliceCommon'
 import { selectBalanceThreshold } from './preferencesSlice/selectors'
 
@@ -75,7 +75,7 @@ export const selectPortfolioCryptoPrecisionBalanceByFilter = createCachedSelecto
 
 export const selectPortfolioFiatBalances = createDeepEqualOutputSelector(
   selectAssets,
-  selectMarketDataSortedByMarketCap,
+  selectSelectedCurrencyMarketDataSortedByMarketCap,
   selectPortfolioAssetBalancesBaseUnit,
   selectBalanceThreshold,
   (assetsById, marketData, balances, balanceThreshold) =>
@@ -96,7 +96,7 @@ export const selectPortfolioFiatBalances = createDeepEqualOutputSelector(
 export const selectPortfolioFiatBalancesByAccountId = createDeepEqualOutputSelector(
   selectAssets,
   selectPortfolioAccountBalancesBaseUnit,
-  selectMarketDataSortedByMarketCap,
+  selectSelectedCurrencyMarketDataSortedByMarketCap,
   (assetsById, accounts, marketData) => {
     return Object.entries(accounts).reduce(
       (acc, [accountId, balanceObj]) => {
@@ -122,26 +122,18 @@ export const selectPortfolioFiatBalancesByAccountId = createDeepEqualOutputSelec
   },
 )
 
-export const selectSortedAssets = createDeepEqualOutputSelector(
-  selectAssets,
+export const selectAssetsSortedByMarketCapFiatBalanceAndName = createDeepEqualOutputSelector(
+  selectAssetsByMarketCap,
   selectPortfolioFiatBalances,
-  selectMarketDataSortedByMarketCap,
-  (assets, portfolioFiatBalances, cryptoMarketData) => {
+  (assets, portfolioFiatBalances) => {
     const getAssetFiatBalance = (asset: Asset) =>
       bnOrZero(portfolioFiatBalances[asset.assetId]).toNumber()
-    const getAssetMarketCap = (asset: Asset) =>
-      bnOrZero(cryptoMarketData[asset.assetId]?.marketCap).toNumber()
     const getAssetName = (asset: Asset) => asset.name
 
     return orderBy(
       Object.values(assets).filter(isSome),
-      [getAssetFiatBalance, getAssetMarketCap, getAssetName],
-      ['desc', 'desc', 'asc'],
+      [getAssetFiatBalance, getAssetName],
+      ['desc', 'asc'],
     )
   },
-)
-
-export const selectSortedAssetIds = createDeepEqualOutputSelector(
-  selectSortedAssets,
-  sortedAssets => sortedAssets.map(asset => asset.assetId),
 )

--- a/src/state/slices/marketDataSlice/selectors.ts
+++ b/src/state/slices/marketDataSlice/selectors.ts
@@ -81,12 +81,6 @@ export const selectMarketDataByFilter = createCachedSelector(
   },
 )((_s: ReduxState, filter) => filter?.assetId ?? 'assetId')
 
-// assets we have loaded market data for
-export const selectCryptoMarketDataIdsSortedByMarketCap = createDeepEqualOutputSelector(
-  selectSelectedCurrencyMarketDataSortedByMarketCap,
-  (marketData): AssetId[] => Object.keys(marketData),
-)
-
 export const selectCryptoPriceHistory = (state: ReduxState) => state.marketData.crypto.priceHistory
 export const selectFiatPriceHistory = (state: ReduxState) => state.marketData.fiat.priceHistory
 

--- a/src/state/slices/marketDataSlice/selectors.ts
+++ b/src/state/slices/marketDataSlice/selectors.ts
@@ -29,30 +29,24 @@ export const selectSelectedCurrencyMarketDataSortedByMarketCap = createDeepEqual
     selectedCurrency,
   ): MarketDataById<AssetId> => {
     const fiatPrice = bnOrZero(fiatMarketData[selectedCurrency]?.price ?? 1) // fallback to USD
-    return (
-      marketDataAssetIds
-        // apply fiat conversion
-        .reduce<MarketDataById<AssetId>>((acc, assetId) => {
+    // No conversion needed
+    return selectedCurrency === 'USD'
+      ? cryptoMarketData
+      : marketDataAssetIds.reduce<MarketDataById<AssetId>>((acc, assetId) => {
           const assetMarketData = cryptoMarketData[assetId]
-          // No conversion needed
-          if (selectedCurrency === 'USD') {
-            acc[assetId] = assetMarketData
-          } else {
-            // Market data massaged to the selected currency
-            const selectedCurrencyAssetMarketData = {
-              ...assetMarketData,
-              price: bnOrZero(assetMarketData?.price).times(fiatPrice).toString(),
-              marketCap: bnOrZero(assetMarketData?.marketCap).times(fiatPrice).toString(),
-              volume: bnOrZero(assetMarketData?.volume).times(fiatPrice).toString(),
-              changePercent24Hr: assetMarketData?.changePercent24Hr ?? 0,
-            }
-
-            acc[assetId] = selectedCurrencyAssetMarketData
+          // Market data massaged to the selected currency
+          const selectedCurrencyAssetMarketData = {
+            ...assetMarketData,
+            price: bnOrZero(assetMarketData?.price).times(fiatPrice).toString(),
+            marketCap: bnOrZero(assetMarketData?.marketCap).times(fiatPrice).toString(),
+            volume: bnOrZero(assetMarketData?.volume).times(fiatPrice).toString(),
+            changePercent24Hr: assetMarketData?.changePercent24Hr ?? 0,
           }
+
+          acc[assetId] = selectedCurrencyAssetMarketData
 
           return acc
         }, {})
-    )
   },
 )
 

--- a/src/state/slices/marketDataSlice/selectors.ts
+++ b/src/state/slices/marketDataSlice/selectors.ts
@@ -29,19 +29,18 @@ export const selectSelectedCurrencyMarketDataSortedByMarketCap = createDeepEqual
     selectedCurrency,
   ): MarketDataById<AssetId> => {
     const fiatPrice = bnOrZero(fiatMarketData[selectedCurrency]?.price ?? 1) // fallback to USD
-    // No conversion needed
+    // No currency conversion needed
     return selectedCurrency === 'USD'
       ? cryptoMarketData
       : marketDataAssetIds.reduce<MarketDataById<AssetId>>((acc, assetId) => {
           const assetMarketData = cryptoMarketData[assetId]
           // Market data massaged to the selected currency
-          const selectedCurrencyAssetMarketData = {
-            ...assetMarketData,
+          const selectedCurrencyAssetMarketData = Object.assign(assetMarketData ?? {}, {
             price: bnOrZero(assetMarketData?.price).times(fiatPrice).toString(),
             marketCap: bnOrZero(assetMarketData?.marketCap).times(fiatPrice).toString(),
             volume: bnOrZero(assetMarketData?.volume).times(fiatPrice).toString(),
             changePercent24Hr: assetMarketData?.changePercent24Hr ?? 0,
-          }
+          })
 
           acc[assetId] = selectedCurrencyAssetMarketData
 

--- a/src/state/slices/opportunitiesSlice/selectors/combined.ts
+++ b/src/state/slices/opportunitiesSlice/selectors/combined.ts
@@ -29,7 +29,7 @@ import type {
 } from '../types'
 import { getOpportunityAccessor, getUnderlyingAssetIdsBalances } from '../utils'
 import { selectAssets } from './../../assetsSlice/selectors'
-import { selectMarketDataSortedByMarketCap } from './../../marketDataSlice/selectors'
+import { selectSelectedCurrencyMarketDataSortedByMarketCap } from './../../marketDataSlice/selectors'
 import { selectAggregatedEarnUserLpOpportunities } from './lpSelectors'
 import {
   selectAggregatedEarnUserStakingOpportunitiesIncludeEmpty,
@@ -72,7 +72,7 @@ const makeClaimableStakingRewardsAmountFiat = ({
 export const selectAggregatedEarnOpportunitiesByAssetId = createDeepEqualOutputSelector(
   selectAggregatedEarnUserStakingOpportunitiesIncludeEmpty,
   selectAggregatedEarnUserLpOpportunities,
-  selectMarketDataSortedByMarketCap,
+  selectSelectedCurrencyMarketDataSortedByMarketCap,
   selectAssets,
   selectIncludeEarnBalancesParamFromFilter,
   selectIncludeRewardsBalancesParamFromFilter,
@@ -253,7 +253,7 @@ export const selectAggregatedEarnOpportunitiesByAssetId = createDeepEqualOutputS
 export const selectClaimableRewards = createDeepEqualOutputSelector(
   selectUserStakingOpportunitiesWithMetadataByFilter,
   selectAssets,
-  selectMarketDataSortedByMarketCap,
+  selectSelectedCurrencyMarketDataSortedByMarketCap,
   (userStakingOpportunitesWithMetadata, assets, marketData): string => {
     return userStakingOpportunitesWithMetadata
       .reduce<BN>((totalSum, stakingOpportunityWithMetadata) => {
@@ -289,7 +289,7 @@ export const selectOpportunityApiPending = (state: ReduxState) =>
 export const selectAggregatedEarnOpportunitiesByProvider = createDeepEqualOutputSelector(
   selectAggregatedEarnUserStakingOpportunitiesIncludeEmpty,
   selectAggregatedEarnUserLpOpportunities,
-  selectMarketDataSortedByMarketCap,
+  selectSelectedCurrencyMarketDataSortedByMarketCap,
   selectAssets,
   selectIncludeEarnBalancesParamFromFilter,
   selectIncludeRewardsBalancesParamFromFilter,

--- a/src/state/slices/opportunitiesSlice/selectors/lpSelectors.ts
+++ b/src/state/slices/opportunitiesSlice/selectors/lpSelectors.ts
@@ -21,7 +21,7 @@ import {
   selectPortfolioCryptoBalanceBaseUnitByFilter,
   selectPortfolioCryptoPrecisionBalanceByFilter,
 } from '../../common-selectors'
-import { selectMarketDataSortedByMarketCap } from '../../marketDataSlice/selectors'
+import { selectSelectedCurrencyMarketDataSortedByMarketCap } from '../../marketDataSlice/selectors'
 import { getUnderlyingAssetIdsBalances } from '../utils'
 import type { LpEarnOpportunityType, StakingEarnOpportunityType } from './../types'
 
@@ -36,7 +36,7 @@ export const selectEarnUserLpOpportunity = createDeepEqualOutputSelector(
   selectLpIdParamFromFilter,
   selectPortfolioCryptoBalanceBaseUnitByFilter,
   selectAssets,
-  selectMarketDataSortedByMarketCap,
+  selectSelectedCurrencyMarketDataSortedByMarketCap,
   (
     lpOpportunitiesById,
     lpId,
@@ -111,7 +111,7 @@ export const selectAggregatedEarnUserLpOpportunity = createDeepEqualOutputSelect
   selectLpIdParamFromFilter,
   selectPortfolioCryptoPrecisionBalanceByFilter,
   selectAssets,
-  selectMarketDataSortedByMarketCap,
+  selectSelectedCurrencyMarketDataSortedByMarketCap,
   (
     lpOpportunitiesById,
     lpId,
@@ -193,7 +193,7 @@ export const selectUnderlyingLpAssetsWithBalancesAndIcons = createSelector(
   selectLpOpportunitiesById,
   selectPortfolioCryptoPrecisionBalanceByFilter,
   selectAssets,
-  selectMarketDataSortedByMarketCap,
+  selectSelectedCurrencyMarketDataSortedByMarketCap,
   (
     lpId,
     lpOpportunitiesById,
@@ -242,7 +242,7 @@ export const selectAggregatedEarnUserLpOpportunities = createDeepEqualOutputSele
   selectLpOpportunitiesById,
   selectPortfolioAssetBalancesBaseUnit,
   selectAssets,
-  selectMarketDataSortedByMarketCap,
+  selectSelectedCurrencyMarketDataSortedByMarketCap,
   (
     lpOpportunitiesById,
     portfolioAssetBalancesById,
@@ -327,7 +327,7 @@ export const selectAllEarnUserLpOpportunitiesByFilter = createDeepEqualOutputSel
   selectPortfolioAccountBalancesBaseUnit,
   selectPortfolioAssetBalancesBaseUnit,
   selectAssets,
-  selectMarketDataSortedByMarketCap,
+  selectSelectedCurrencyMarketDataSortedByMarketCap,
   selectAssetIdParamFromFilter,
   selectAccountIdParamFromFilter,
   (

--- a/src/state/slices/opportunitiesSlice/selectors/stakingSelectors.ts
+++ b/src/state/slices/opportunitiesSlice/selectors/stakingSelectors.ts
@@ -30,7 +30,7 @@ import {
 } from '../../common-selectors'
 import {
   selectMarketDataByFilter,
-  selectMarketDataSortedByMarketCap,
+  selectSelectedCurrencyMarketDataSortedByMarketCap,
 } from '../../marketDataSlice/selectors'
 import { foxEthLpAssetId } from '../constants'
 import type { CosmosSdkStakingSpecificUserStakingOpportunity } from '../resolvers/cosmosSdk/types'
@@ -336,7 +336,7 @@ export const selectAggregatedUserStakingOpportunityByStakingId = createDeepEqual
 
 export const selectAggregatedEarnUserStakingOpportunityByStakingId = createDeepEqualOutputSelector(
   selectAggregatedUserStakingOpportunityByStakingId,
-  selectMarketDataSortedByMarketCap,
+  selectSelectedCurrencyMarketDataSortedByMarketCap,
   selectAssets,
   (opportunity, marketData, assets): StakingEarnOpportunityType | undefined => {
     if (!opportunity) return
@@ -386,7 +386,7 @@ export const selectAggregatedUserStakingOpportunities = createDeepEqualOutputSel
 // TODO: testme
 export const selectAggregatedEarnUserStakingOpportunities = createDeepEqualOutputSelector(
   selectAggregatedUserStakingOpportunities,
-  selectMarketDataSortedByMarketCap,
+  selectSelectedCurrencyMarketDataSortedByMarketCap,
   selectAssets,
   (aggregatedUserStakingOpportunities, marketData, assets): StakingEarnOpportunityType[] =>
     aggregatedUserStakingOpportunities.map(opportunity => {
@@ -443,7 +443,7 @@ export const selectActiveAggregatedEarnUserStakingOpportunities = createDeepEqua
 export const selectActiveAggregatedEarnUserStakingOpportunitiesWithTotalFiatAmount =
   createDeepEqualOutputSelector(
     selectActiveAggregatedEarnUserStakingOpportunities,
-    selectMarketDataSortedByMarketCap,
+    selectSelectedCurrencyMarketDataSortedByMarketCap,
     selectAssets,
     (aggregatedUserStakingOpportunities, marketData, assets): StakingEarnOpportunityType[] =>
       aggregatedUserStakingOpportunities
@@ -462,7 +462,7 @@ export const selectActiveAggregatedEarnUserStakingOpportunitiesWithTotalFiatAmou
 // Also slaps in ETH/FOX balances which value lives in the portfolio vs. being an "upstream earn opportunity"
 export const selectEarnBalancesFiatAmountFull = createDeepEqualOutputSelector(
   selectAggregatedUserStakingOpportunities,
-  selectMarketDataSortedByMarketCap,
+  selectSelectedCurrencyMarketDataSortedByMarketCap,
   selectAssets,
   selectPortfolioFiatBalances,
   (aggregatedUserStakingOpportunities, marketData, assets, portfolioFiatBalances): BN =>
@@ -567,7 +567,7 @@ export const selectAggregatedEarnUserStakingOpportunitiesIncludeEmptyByStakingId
 // TODO: testme
 export const selectEarnUserStakingOpportunityByUserStakingId = createDeepEqualOutputSelector(
   selectUserStakingOpportunityByUserStakingId,
-  selectMarketDataSortedByMarketCap,
+  selectSelectedCurrencyMarketDataSortedByMarketCap,
   selectAssets,
   (userStakingOpportunity, marketData, assets): StakingEarnOpportunityType | undefined => {
     if (!userStakingOpportunity || !marketData) return
@@ -687,7 +687,7 @@ export const selectAllEarnUserStakingOpportunitiesByFilter = createDeepEqualOutp
   selectAggregatedEarnUserStakingOpportunitiesIncludeEmpty,
   selectUserStakingOpportunitiesById,
   selectAssets,
-  selectMarketDataSortedByMarketCap,
+  selectSelectedCurrencyMarketDataSortedByMarketCap,
   selectAssetIdParamFromFilter,
   selectAccountIdParamFromFilter,
   (

--- a/src/state/slices/portfolioSlice/selectors.ts
+++ b/src/state/slices/portfolioSlice/selectors.ts
@@ -46,7 +46,7 @@ import {
   selectChainIdParamFromFilter,
 } from 'state/selectors'
 import { selectAssets } from 'state/slices/assetsSlice/selectors'
-import { selectMarketDataSortedByMarketCap } from 'state/slices/marketDataSlice/selectors'
+import { selectSelectedCurrencyMarketDataSortedByMarketCap } from 'state/slices/marketDataSlice/selectors'
 import {
   selectAggregatedEarnUserStakingOpportunities,
   selectAllEarnUserLpOpportunitiesByFilter,
@@ -256,7 +256,7 @@ export const selectBalanceChartCryptoBalancesByAccountIdAboveThreshold =
     selectAssets,
     selectPortfolioAccountBalancesBaseUnit,
     selectPortfolioAssetBalancesBaseUnit,
-    selectMarketDataSortedByMarketCap,
+    selectSelectedCurrencyMarketDataSortedByMarketCap,
     selectBalanceThreshold,
     selectPortfolioAccounts,
     selectAggregatedEarnUserStakingOpportunities,
@@ -469,7 +469,7 @@ export const selectPortfolioAccountsCryptoHumanBalancesIncludingStaking =
  */
 export const selectPortfolioAccountsFiatBalancesIncludingStaking = createDeepEqualOutputSelector(
   selectAssets,
-  selectMarketDataSortedByMarketCap,
+  selectSelectedCurrencyMarketDataSortedByMarketCap,
   selectPortfolioAccountsCryptoBalancesIncludingStaking,
   (assets, marketData, portfolioAccountsCryptoBalances): PortfolioAccountBalancesById => {
     const fiatAccountEntries = Object.entries(portfolioAccountsCryptoBalances).reduce<{
@@ -671,7 +671,7 @@ export type AccountRowData = {
 
 export const selectPortfolioAccountRows = createDeepEqualOutputSelector(
   selectAssets,
-  selectMarketDataSortedByMarketCap,
+  selectSelectedCurrencyMarketDataSortedByMarketCap,
   selectPortfolioAssetBalancesBaseUnit,
   selectPortfolioTotalFiatBalance,
   selectBalanceThreshold,
@@ -823,7 +823,7 @@ export const selectAssetEquityItemsByFilter = createDeepEqualOutputSelector(
   selectAllEarnUserLpOpportunitiesByFilter,
   selectAllEarnUserStakingOpportunitiesByFilter,
   selectAssets,
-  selectMarketDataSortedByMarketCap,
+  selectSelectedCurrencyMarketDataSortedByMarketCap,
   selectAssetIdParamFromFilter,
   (
     accountIds,


### PR DESCRIPTION
## Description

This PR improves both performance and heuristics after https://github.com/shapeshift/web/pull/4428 got in, sorting market data IDs (and `byId` entries) by market cap descending:

- renames `selectMarketDataSortedByMarketCap` to `selectSelectedCurrencyMarketDataSortedByMarketCap`. The name doesn't make sense anymore: the market data is now already sorted by market cap. The only thing this is really doing is massaging the market data to the selected user currency
  - simply returns the output of `selectCryptoMarketData` in case the selected currency is the default USD one
  - doesn't iterate over the `Object.entries()` of `cryptoMarketData`, but over the `marketDataAssetIds` instead, which are sorted so we can simply do a more efficient reduce over the IDs
  - switches the `.map().reduce()` call to a single `.reduce()` call
- makes `selectAssetsByMarketCap` a simplified "map over market data IDs (which are now sorted", lookup and return the `Asset` for it". While at it, removes the sorting by name, which was wrong according to the name intent. The sorting by name has been deleted, see 1dc15b1f17fe8486ed0a35e23d6d080b94ecc765 ~~This is now done in `selectAssetsByMarketCapAndName`, which itself consumes the refactored `selectAssetsByMarketCap`~~ 
- removes `getAssetMarketCap` sorting in `selectSortedAssets` and renames it to the very verbose, but very accurate `selectAssetsSortedByMarketCapFiatBalanceAndName` vernacular
- removes the unused `selectCryptoMarketDataIdsSortedByMarketCap` selector
- refactors `<TransactionHistory />`'s `useSearch` utility hook to use `selectAssets` instead of `selectAssetsByMarketCap` (we don't need any sorting there)

## Pull Request Type

- [ ] :bug: Bug fix (Non-breaking Change: Fixes an issue)
- [ ] :hammer_and_wrench: Chore (Non-breaking Change: Doc updates, pkg upgrades, typos, etc..)
- [x] :nail_care: New Feature (Breaking/Non-breaking Change)

## Issue (if applicable)

N/A

## Risk

<!-----------------------------------------------------------------------------
Outline the scope of your changes and the risk associated with them. You must use your discretion as an engineer to determine the potential impact of your changes.

E.g. an upgrade to `hdwallet` or core state management would be considered higher risk, and might require a full regression test. UI or isolated view changes, or something behind a feature flag may have near zero risk. Small bug fixes might require testing isolated to the specific fix.
------------------------------------------------------------------------------>

Theoretically, sorting by market data could be broken all around the app - realistically, this is mostly a name change and perf. improvement, there shouldn't be any change of flow


## Testing

<!-----------------------------------------------------------------------------
We treat every PR to be merged with the same scrutiny as if we were merging directly to production.

Your PR will not be merged if you do not complete the sections below for our engineering and operations teams to test.
------------------------------------------------------------------------------>

- Do a smoke test of assets sorting around the app
  - Asset Search in header, asset page, send/receive, trade and fiat ramps
  - DeFi section
  - Tx history (do we still need the `useSearch()` there doing any sorting at all anymore?)

### Engineering

<!-----------------------------------------------------------------------------
Include sufficient information here for an engineer to test your PR. This may include how to test locally, in a built environment, changes to infrastructure etc.
------------------------------------------------------------------------------>

- My renamy isn't too verbosy
- Scrutinize we are still getting the same sorted data as before

### Operations

<!-----------------------------------------------------------------------------
If your changes have a user-facing impact, describe how a non-technical QA team can functionally test your changes in a preview environment.

If they are not user-facing please describe how to test for any regressions that may occur.
------------------------------------------------------------------------------>

## Screenshots (if applicable)

### This diff

<img width="1276" alt="image" src="https://user-images.githubusercontent.com/17035424/236326192-95dd8fbe-ae57-40f6-bac0-d58451823587.png">
<img width="1289" alt="image" src="https://user-images.githubusercontent.com/17035424/236326303-1bd23079-fde7-49d9-a8e5-6435dd7364cf.png">
<img width="616" alt="image" src="https://user-images.githubusercontent.com/17035424/236326400-9ae0fc77-cffb-40cd-ba31-66ded9112322.png">
<img width="558" alt="image" src="https://user-images.githubusercontent.com/17035424/236326639-05b72d08-c49d-438f-bf28-392d015919a0.png">
<img width="1316" alt="image" src="https://user-images.githubusercontent.com/17035424/236326829-0d8b27a6-25f2-45d8-a3f0-6b1174d7d8c4.png">
<img width="1296" alt="image" src="https://user-images.githubusercontent.com/17035424/236326986-91abcca3-f376-44ed-abd1-7385149471c6.png">
<img width="1319" alt="image" src="https://user-images.githubusercontent.com/17035424/236327133-579234ce-68f7-448b-8cce-296fd8a8e420.png">


### Prod

<img width="1291" alt="image" src="https://user-images.githubusercontent.com/17035424/236326238-af996612-ff87-432b-a102-fd4f67f407b4.png">
<img width="1296" alt="image" src="https://user-images.githubusercontent.com/17035424/236326338-83e6ffb3-e447-4bd1-9da3-933de23225c6.png">
<img width="601" alt="image" src="https://user-images.githubusercontent.com/17035424/236326433-6125a922-3e86-4276-89b1-b0fc666cc76e.png">
<img width="539" alt="image" src="https://user-images.githubusercontent.com/17035424/236326692-2c8c6083-a1e9-4c36-8774-4ede1cc074ef.png">
<img width="1300" alt="image" src="https://user-images.githubusercontent.com/17035424/236326857-a209e749-de33-473f-8df0-0e33c857c6bb.png">
<img width="1298" alt="image" src="https://user-images.githubusercontent.com/17035424/236327006-ccd8f9cf-b2ff-44c5-91fb-47b528a470f1.png">
<img width="1308" alt="image" src="https://user-images.githubusercontent.com/17035424/236327154-ce264aa4-768d-49d3-aa57-e629e06167e6.png">