### PR TITLE
feat: more selectAssetEquityItemsByFilter selectors safety

### DIFF
--- a/src/components/StakingVaults/EarnOpportunities.tsx
+++ b/src/components/StakingVaults/EarnOpportunities.tsx
@@ -3,7 +3,7 @@ import { Box, Button, HStack } from '@chakra-ui/react'
 import type { AccountId, AssetId } from '@shapeshiftoss/caip'
 import { foxAssetId, foxyAssetId, fromAssetId } from '@shapeshiftoss/caip'
 import qs from 'qs'
-import { useEffect } from 'react'
+import { useEffect, useMemo } from 'react'
 import { NavLink, useHistory, useLocation } from 'react-router-dom'
 import { Card } from 'components/Card/Card'
 import { Text } from 'components/Text'
@@ -51,12 +51,16 @@ export const EarnOpportunities = ({ assetId, accountId }: EarnOpportunitiesProps
     }
   }, [setFarmingAccountId, accountId])
 
-  const allRows = [...lpOpportunities, ...stakingOpportunities].filter(
-    row =>
-      row.assetId.toLowerCase() === asset.assetId.toLowerCase() ||
-      (row.underlyingAssetIds.length && row.underlyingAssetIds.includes(asset.assetId)) ||
-      // show foxy opportunity in the foxy asset page
-      (row.assetId === foxAssetId && asset.assetId === foxyAssetId),
+  const allRows = useMemo(
+    () =>
+      lpOpportunities.concat(stakingOpportunities).filter(
+        row =>
+          row.assetId.toLowerCase() === asset.assetId.toLowerCase() ||
+          (row.underlyingAssetIds.length && row.underlyingAssetIds.includes(asset.assetId)) ||
+          // show foxy opportunity in the foxy asset page
+          (row.assetId === foxAssetId && asset.assetId === foxyAssetId),
+      ),
+    [asset.assetId, lpOpportunities, stakingOpportunities],
   )
 
   const handleClick = (opportunity: EarnOpportunityType) => {

--- a/src/state/slices/portfolioSlice/selectors.ts
+++ b/src/state/slices/portfolioSlice/selectors.ts
@@ -891,8 +891,9 @@ export const selectAssetEquityItemsByFilter = createDeepEqualOutputSelector(
       return {
         id: lpOpportunity.id,
         type: AssetEquityType.LP,
-        fiatAmount: underlyingBalances[assetId].fiatAmount,
-        amountCryptoPrecision: underlyingBalances[assetId].cryptoBalancePrecision,
+        // This should never happen but it may whilst data is loading
+        fiatAmount: underlyingBalances[assetId]?.fiatAmount ?? '0',
+        amountCryptoPrecision: underlyingBalances[assetId]?.cryptoBalancePrecision ?? '0',
         provider: lpOpportunity.provider,
         color: DefiProviderMetadata[lpOpportunity.provider].color,
       }


### PR DESCRIPTION
## Description

This PR:

- Memoizes `allRows` in [StakingVaults/EarnOpportunities.tsx](https://github.com/shapeshift/web/pull/4435/files#diff-0b963dadaf0975d79998a2e9abd8a23d3317e272fdb8f7bc3a4622e29d8ee69c) - I believe this shouldn't be a view-layer concern still, but lowest lift to fix the spotted regression in https://github.com/shapeshift/web/pull/4397#issuecomment-1535612679
- Opt-chain accessooors of `underlyingBalances[assetId]` in `selectAssetEquityItemsByFilter`. Same issue as spotted previously, this should not happen, but it looks like it may during loading states

## Pull Request Type

- [ ] :bug: Bug fix (Non-breaking Change: Fixes an issue)
- [ ] :hammer_and_wrench: Chore (Non-breaking Change: Doc updates, pkg upgrades, typos, etc..)
- [x] :nail_care: New Feature (Breaking/Non-breaking Change)

## Issue (if applicable)

N/A

## Risk

<!-----------------------------------------------------------------------------
Outline the scope of your changes and the risk associated with them. You must use your discretion as an engineer to determine the potential impact of your changes.

E.g. an upgrade to `hdwallet` or core state management would be considered higher risk, and might require a full regression test. UI or isolated view changes, or something behind a feature flag may have near zero risk. Small bug fixes might require testing isolated to the specific fix.
------------------------------------------------------------------------------>

None, more safety

## Testing

<!-----------------------------------------------------------------------------
We treat every PR to be merged with the same scrutiny as if we were merging directly to production.

Your PR will not be merged if you do not complete the sections below for our engineering and operations teams to test.
------------------------------------------------------------------------------>

- Go to assets
- Open an asset
- Asset properly opens, and opportunities are still displayed with no regressions after opportunities are loaded / reconciliated from persisted store (this should work with and without clearing your cache)
- Try with a few assets, both with and without earn opportunities e.g ETH, RUNE (no opportunities), DOGE, mainnet USDC
- Ensures reloading an asset page shows no regressions

### Engineering

<!-----------------------------------------------------------------------------
Include sufficient information here for an engineer to test your PR. This may include how to test locally, in a built environment, changes to infrastructure etc.
------------------------------------------------------------------------------>

- ☝🏽

### Operations

<!-----------------------------------------------------------------------------
If your changes have a user-facing impact, describe how a non-technical QA team can functionally test your changes in a preview environment.

If they are not user-facing please describe how to test for any regressions that may occur.
------------------------------------------------------------------------------>

- ☝🏽

## Screenshots (if applicable)

<img width="1056" alt="image" src="https://user-images.githubusercontent.com/17035424/236399654-02b34bd8-3b8e-4cb4-bfae-53fef3ee8dec.png">
<img width="1031" alt="image" src="https://user-images.githubusercontent.com/17035424/236399509-d33c22a3-17a9-4f8f-924e-9ff8244867d6.png">
<img width="1022" alt="image" src="https://user-images.githubusercontent.com/17035424/236399713-ae046013-ccae-4479-82e7-534c96ba0bc2.png">