### PR TITLE
chore: change default time frame from MONTH to DAY

### DIFF
--- a/src/constants/Config.ts
+++ b/src/constants/Config.ts
@@ -1,5 +1,5 @@
 import { HistoryTimeframe } from '@shapeshiftoss/types'
 
-export const DEFAULT_HISTORY_TIMEFRAME = HistoryTimeframe.MONTH
+export const DEFAULT_HISTORY_TIMEFRAME = HistoryTimeframe.DAY
 export const MINIMUM_KK_FIRMWARE_VERSION_SUPPORTING_LITECOIN = '7.4.0'
 export const MINIMUM_KK_FIRMWARE_VERSION_SUPPORTING_EIP712 = '7.6.0'


### PR DESCRIPTION
Changes default time frame on dashboard from MONTH to DAY

## Description
Changes default time frame on dashboard from MONTH to DAY
<!-- Please describe your changes -->

## Pull Request Type

- [ ] :bug: Bug fix (Non-breaking Change: Fixes an issue)
- [X] :hammer_and_wrench: Chore (Non-breaking Change: Doc updates, pkg upgrades, typos, etc..)
- [ ] :nail_care: New Feature (Breaking/Non-breaking Change)

## Risk

Changes default time frame on dashboard from MONTH to DAY

## Testing

Please check the default charts are defaulting to 1D, instead of 1M.

### Engineering

Please check the default charts are defaulting to 1D, instead of 1M.

### Operations
Please check the default charts are defaulting to 1D, instead of 1M.


## Screenshots (if applicable)
OLD:
![image](https://user-images.githubusercontent.com/94986227/236649773-f8cdb1ed-e4de-42bb-bf68-38c7a5b24cbb.png)
NEW: 
![image](https://user-images.githubusercontent.com/94986227/236649787-7fb4a30b-e0e5-4b47-82d2-84319e651421.png)
