### PR TITLE
feat: remember charts timeframe

### DIFF
--- a/src/components/AssetHeader/AssetChart.tsx
+++ b/src/components/AssetHeader/AssetChart.tsx
@@ -15,7 +15,6 @@ import {
 } from '@chakra-ui/react'
 import type { AccountId, AssetId } from '@shapeshiftoss/caip'
 import type { HistoryTimeframe } from '@shapeshiftoss/types'
-import { DEFAULT_HISTORY_TIMEFRAME } from 'constants/Config'
 import { useEffect, useMemo, useState } from 'react'
 import NumberFormat from 'react-number-format'
 import { useTranslate } from 'react-polyglot'
@@ -28,10 +27,12 @@ import { StakingUpArrowIcon } from 'components/Icons/StakingUpArrow'
 import { PriceChart } from 'components/PriceChart/PriceChart'
 import { RawText, Text } from 'components/Text'
 import { useLocaleFormatter } from 'hooks/useLocaleFormatter/useLocaleFormatter'
+import { useTimeframeChange } from 'hooks/useTimeframeChange/useTimeframeChange'
 import { bn, bnOrZero } from 'lib/bignumber/bignumber'
 import { isSome } from 'lib/utils'
 import {
   selectAssetById,
+  selectChartTimeframe,
   selectCryptoHumanBalanceIncludingStakingByFilter,
   selectFiatBalanceIncludingStakingByFilter,
   selectMarketDataById,
@@ -60,7 +61,9 @@ export const AssetChart = ({ accountId, assetId, isLoaded }: AssetChartProps) =>
   } = useLocaleFormatter()
   const [percentChange, setPercentChange] = useState(0)
   const alertIconColor = useColorModeValue('blue.500', 'blue.200')
-  const [timeframe, setTimeframe] = useState<HistoryTimeframe>(DEFAULT_HISTORY_TIMEFRAME)
+  const userChartTimeframe = useAppSelector(selectChartTimeframe)
+  const [timeframe, setTimeframe] = useState<HistoryTimeframe>(userChartTimeframe)
+  const handleTimeframeChange = useTimeframeChange(setTimeframe)
   const assetIds = useMemo(() => [assetId].filter(isSome), [assetId])
   const asset = useAppSelector(state => selectAssetById(state, assetId))
   const marketData = useAppSelector(state => selectMarketDataById(state, assetId))
@@ -115,7 +118,7 @@ export const AssetChart = ({ accountId, assetId, isLoaded }: AssetChartProps) =>
           </Skeleton>
 
           <Skeleton isLoaded={isLoaded} display={{ base: 'none', md: 'block' }}>
-            <TimeControls onChange={setTimeframe} defaultTime={timeframe} />
+            <TimeControls onChange={handleTimeframeChange} defaultTime={timeframe} />
           </Skeleton>
         </Flex>
         <Box width='full' alignItems='center' display='flex' flexDir='column' mt={6}>
@@ -204,7 +207,7 @@ export const AssetChart = ({ accountId, assetId, isLoaded }: AssetChartProps) =>
       )}
       <Skeleton isLoaded={isLoaded} display={{ base: 'block', md: 'none' }}>
         <TimeControls
-          onChange={setTimeframe}
+          onChange={handleTimeframeChange}
           defaultTime={timeframe}
           buttonGroupProps={{
             display: 'flex',

--- a/src/hooks/useTimeframeChange/useTimeframeChange.ts
+++ b/src/hooks/useTimeframeChange/useTimeframeChange.ts
@@ -3,7 +3,7 @@ import { useCallback } from 'react'
 import { useDispatch } from 'react-redux'
 import { preferences } from 'state/slices/preferencesSlice/preferencesSlice'
 
-export const useTimeframeChange = (callback: Function) => {
+export const useTimeframeChange = (callback: (timeframe: HistoryTimeframe) => void) => {
   const dispatch = useDispatch()
   const handleTimeframeChange = useCallback(
     (newTimeframe: HistoryTimeframe) => {

--- a/src/hooks/useTimeframeChange/useTimeframeChange.ts
+++ b/src/hooks/useTimeframeChange/useTimeframeChange.ts
@@ -1,0 +1,19 @@
+import type { HistoryTimeframe } from '@shapeshiftoss/types'
+import { useCallback } from 'react'
+import { useDispatch } from 'react-redux'
+import { preferences } from 'state/slices/preferencesSlice/preferencesSlice'
+
+export const useTimeframeChange = (callback: Function) => {
+  const dispatch = useDispatch()
+  const handleTimeframeChange = useCallback(
+    (newTimeframe: HistoryTimeframe) => {
+      // Usually used to set the component state to the new timeframe
+      callback(newTimeframe)
+      // Save the new timeframe in the user perferences
+      dispatch(preferences.actions.setChartTimeframe({ timeframe: newTimeframe }))
+    },
+    [callback, dispatch],
+  )
+
+  return handleTimeframeChange
+}

--- a/src/pages/Dashboard/Portfolio.tsx
+++ b/src/pages/Dashboard/Portfolio.tsx
@@ -9,7 +9,6 @@ import {
   Switch,
 } from '@chakra-ui/react'
 import type { HistoryTimeframe } from '@shapeshiftoss/types'
-import { DEFAULT_HISTORY_TIMEFRAME } from 'constants/Config'
 import { useCallback, useMemo, useState } from 'react'
 import { Amount } from 'components/Amount/Amount'
 import { BalanceChart } from 'components/BalanceChart/BalanceChart'
@@ -17,9 +16,11 @@ import { Card } from 'components/Card/Card'
 import { TimeControls } from 'components/Graph/TimeControls'
 import { MaybeChartUnavailable } from 'components/MaybeChartUnavailable'
 import { Text } from 'components/Text'
+import { useTimeframeChange } from 'hooks/useTimeframeChange/useTimeframeChange'
 import { bnOrZero } from 'lib/bignumber/bignumber'
 import { EligibleCarousel } from 'pages/Defi/components/EligibleCarousel'
 import {
+  selectChartTimeframe,
   selectClaimableRewards,
   selectEarnBalancesFiatAmountFull,
   selectPortfolioAssetIds,
@@ -32,7 +33,10 @@ import { AccountTable } from './components/AccountList/AccountTable'
 import { PortfolioBreakdown } from './PortfolioBreakdown'
 
 export const Portfolio = () => {
-  const [timeframe, setTimeframe] = useState<HistoryTimeframe>(DEFAULT_HISTORY_TIMEFRAME)
+  const userChartTimeframe = useAppSelector(selectChartTimeframe)
+  const [timeframe, setTimeframe] = useState<HistoryTimeframe>(userChartTimeframe)
+  const handleTimeframeChange = useTimeframeChange(setTimeframe)
+
   const [percentChange, setPercentChange] = useState(0)
 
   const assetIds = useAppSelector(selectPortfolioAssetIds)
@@ -75,7 +79,7 @@ export const Portfolio = () => {
             <Text translation='dashboard.portfolio.rainbowChart' />
           </Button>
           <Skeleton isLoaded={isLoaded} display={{ base: 'none', md: 'block' }}>
-            <TimeControls defaultTime={timeframe} onChange={time => setTimeframe(time)} />
+            <TimeControls defaultTime={timeframe} onChange={handleTimeframeChange} />
           </Skeleton>
         </Card.Header>
         <Flex flexDir='column' justifyContent='center' alignItems='center'>
@@ -108,7 +112,7 @@ export const Portfolio = () => {
         />
         <Skeleton isLoaded={isLoaded} display={{ base: 'block', md: 'none' }}>
           <TimeControls
-            onChange={setTimeframe}
+            onChange={handleTimeframeChange}
             defaultTime={timeframe}
             buttonGroupProps={{
               display: 'flex',

--- a/src/plugins/foxPage/components/FoxChart.tsx
+++ b/src/plugins/foxPage/components/FoxChart.tsx
@@ -1,5 +1,5 @@
 import { Box, Stat, StatArrow, StatNumber, Text } from '@chakra-ui/react'
-import { HistoryTimeframe } from '@shapeshiftoss/types'
+import type { HistoryTimeframe } from '@shapeshiftoss/types'
 import { useState } from 'react'
 import NumberFormat from 'react-number-format'
 import { useTranslate } from 'react-polyglot'
@@ -8,7 +8,8 @@ import { TimeControls } from 'components/Graph/TimeControls'
 import { PriceChart } from 'components/PriceChart/PriceChart'
 import { RawText } from 'components/Text/Text'
 import { useLocaleFormatter } from 'hooks/useLocaleFormatter/useLocaleFormatter'
-import { selectMarketDataById } from 'state/slices/selectors'
+import { useTimeframeChange } from 'hooks/useTimeframeChange/useTimeframeChange'
+import { selectChartTimeframe, selectMarketDataById } from 'state/slices/selectors'
 import { useAppSelector } from 'state/store'
 
 type FoxChartProps = {
@@ -16,7 +17,9 @@ type FoxChartProps = {
 }
 
 export const FoxChart: React.FC<FoxChartProps> = ({ assetId }) => {
-  const [timeframe, setTimeframe] = useState(HistoryTimeframe.MONTH)
+  const userChartTimeframe = useAppSelector(selectChartTimeframe)
+  const [timeframe, setTimeframe] = useState<HistoryTimeframe>(userChartTimeframe)
+  const handleTimeframeChange = useTimeframeChange(setTimeframe)
   const [percentChange, setPercentChange] = useState(0)
   const {
     number: { toFiat },
@@ -64,7 +67,7 @@ export const FoxChart: React.FC<FoxChartProps> = ({ assetId }) => {
       />
       <Card.Footer>
         <TimeControls
-          onChange={setTimeframe}
+          onChange={handleTimeframeChange}
           defaultTime={timeframe}
           buttonGroupProps={{
             display: 'flex',

--- a/src/state/slices/preferencesSlice/preferencesSlice.ts
+++ b/src/state/slices/preferencesSlice/preferencesSlice.ts
@@ -1,6 +1,8 @@
 import { createSlice } from '@reduxjs/toolkit'
 import type { SupportedFiatCurrencies } from '@shapeshiftoss/market-service'
+import type { HistoryTimeframe } from '@shapeshiftoss/types'
 import { getConfig } from 'config'
+import { DEFAULT_HISTORY_TIMEFRAME } from 'constants/Config'
 import dayjs from 'dayjs'
 import localizedFormat from 'dayjs/plugin/localizedFormat'
 import { simpleLocale } from 'lib/browserLocale'
@@ -55,6 +57,7 @@ export type Preferences = {
   balanceThreshold: string
   selectedCurrency: SupportedFiatCurrencies
   currencyFormat: CurrencyFormats
+  chartTimeframe: HistoryTimeframe
   showWelcomeModal: boolean
   showConsentBanner: boolean
 }
@@ -98,6 +101,7 @@ const initialState: Preferences = {
   balanceThreshold: '0',
   selectedCurrency: 'USD',
   currencyFormat: CurrencyFormats.DotDecimal,
+  chartTimeframe: DEFAULT_HISTORY_TIMEFRAME,
   showWelcomeModal: false,
   showConsentBanner: true,
 }
@@ -123,6 +127,9 @@ export const preferences = createSlice({
     },
     setCurrencyFormat(state, { payload }: { payload: { currencyFormat: CurrencyFormats } }) {
       state.currencyFormat = payload.currencyFormat
+    },
+    setChartTimeframe(state, { payload }: { payload: { timeframe: HistoryTimeframe } }) {
+      state.chartTimeframe = payload.timeframe
     },
     setWelcomeModal(state, { payload }: { payload: { show: boolean } }) {
       state.showWelcomeModal = payload.show

--- a/src/state/slices/preferencesSlice/selectors.ts
+++ b/src/state/slices/preferencesSlice/selectors.ts
@@ -16,6 +16,7 @@ export const selectSelectedLocale = (state: ReduxState) => state.preferences.sel
 export const selectSelectedCurrency = (state: ReduxState) => state.preferences.selectedCurrency
 export const selectBalanceThreshold = (state: ReduxState) => state.preferences.balanceThreshold
 export const selectCurrencyFormat = (state: ReduxState) => state.preferences.currencyFormat
+export const selectChartTimeframe = (state: ReduxState) => state.preferences.chartTimeframe
 export const selectShowWelcomeModal = (state: ReduxState) => state.preferences.showWelcomeModal
 export const selectShowConsentBanner = (state: ReduxState) => {
   const consentEnabled = selectFeatureFlag(state, 'Mixpanel')

--- a/src/test/mocks/store.ts
+++ b/src/test/mocks/store.ts
@@ -1,3 +1,4 @@
+import { DEFAULT_HISTORY_TIMEFRAME } from 'constants/Config'
 import type { ReduxState } from 'state/reducer'
 import { CurrencyFormats } from 'state/slices/preferencesSlice/preferencesSlice'
 
@@ -88,6 +89,7 @@ export const mockStore: ReduxState = {
     balanceThreshold: '0',
     selectedCurrency: 'USD',
     currencyFormat: CurrencyFormats.DotDecimal,
+    chartTimeframe: DEFAULT_HISTORY_TIMEFRAME,
     showWelcomeModal: false,
     showConsentBanner: true,
     // the following object is required by redux-persist


### PR DESCRIPTION
## Description

The goal is to preserve the last timeframe a user has chosen in a chart to all the other current charts in the apps, and restore it also if they close the app, instead of resetting it to the default app value each time.

The rationale for applying it to all the charts: in my opinion users will generally check multiple charts with the same timeframe, be it their portfolio or different assets, having to reselect the timeframe each time they load a new chart/asset is tedious, this solves it.

- Adds a hidden keypair preference to remember the last timeframe used by the current user on charts.
- Uses this keypair and updates it for all the charts. By default it uses `DEFAULT_HISTORY_TIMEFRAME` if it is unset.

<!-- Please describe your changes -->

## Pull Request Type

- [ ] :bug: Bug fix (Non-breaking Change: Fixes an issue)
- [ ] :hammer_and_wrench: Chore (Non-breaking Change: Doc updates, pkg upgrades, typos, etc..)
- [x] :nail_care: New Feature (Breaking/Non-breaking Change)

## Risk
None.
<!-----------------------------------------------------------------------------
Outline the scope of your changes and the risk associated with them. You must use your discretion as an engineer to determine the potential impact of your changes.

E.g. an upgrade to `hdwallet` or core state management would be considered higher risk, and might require a full regression test. UI or isolated view changes, or something behind a feature flag may have near zero risk. Small bug fixes might require testing isolated to the specific fix.
------------------------------------------------------------------------------>

## Testing

<!-----------------------------------------------------------------------------
We treat every PR to be merged with the same scrutiny as if we were merging directly to production.

Your PR will not be merged if you do not complete the sections below for our engineering and operations teams to test.
------------------------------------------------------------------------------>

Change the timeframe of a chart (e.g. on "My Wallet") and go to an "Asset" details or the "FOX Opportunities" page, the same timeframe should be applied to the charts on these pages. If you change timeframe on any of these charts it should also be the new timeframe on the other pages.

### Engineering
☝️ 
<!-----------------------------------------------------------------------------
Include sufficient information here for an engineer to test your PR. This may include how to test locally, in a built environment, changes to infrastructure etc.
------------------------------------------------------------------------------>

### Operations
☝️ 
<!-----------------------------------------------------------------------------
If your changes have a user-facing impact, describe how a non-technical QA team can functionally test your changes in a preview environment.

If they are not user-facing please describe how to test for any regressions that may occur.
------------------------------------------------------------------------------>

## Screenshots (if applicable)
N/A