### PR TITLE
fix: disable donation toggle on trade completion

### DIFF
--- a/src/components/Trade/TradeConfirm/TradeConfirm.tsx
+++ b/src/components/Trade/TradeConfirm/TradeConfirm.tsx
@@ -410,7 +410,7 @@ export const TradeConfirm = () => {
               <Checkbox
                 isChecked={!hasUserOptedOutOfDonation}
                 onChange={handleDonationToggle}
-                isDisabled={isSubmitting || isReloadingTrade}
+                isDisabled={isSubmitting || isReloadingTrade || tradeStatus === TxStatus.Confirmed}
               >
                 <Text translation='trade.donation' />
               </Checkbox>

--- a/src/components/Trade/TradeConfirm/TradeConfirm.tsx
+++ b/src/components/Trade/TradeConfirm/TradeConfirm.tsx
@@ -427,6 +427,7 @@ export const TradeConfirm = () => {
       isReloadingTrade,
       isSubmitting,
       toFiat,
+      tradeStatus,
       translate,
     ],
   )


### PR DESCRIPTION
## Description

Fixes a bug where the donation toggle would become re-enabled after a trade TX completes.

## Pull Request Type

- [x] :bug: Bug fix (Non-breaking Change: Fixes an issue)
- [ ] :hammer_and_wrench: Chore (Non-breaking Change: Doc updates, pkg upgrades, typos, etc..)
- [ ] :nail_care: New Feature (Breaking/Non-breaking Change)

## Issue (if applicable)

Closes https://github.com/shapeshift/web/issues/4438

## Risk

Small.

## Testing

When a trade TX completes, the donation toggle should still be disabled.

### Engineering

☝️

### Operations

☝️

## Screenshots (if applicable)

<img width="473" alt="Screenshot 2023-05-08 at 11 35 24 am" src="https://user-images.githubusercontent.com/97164662/236716714-40ca9a99-3583-476c-9e70-48f795271657.png">
<img width="482" alt="Screenshot 2023-05-08 at 11 35 31 am" src="https://user-images.githubusercontent.com/97164662/236716719-bff6c2db-9759-4ef8-82ac-6fc0053688dd.png">
<img width="463" alt="Screenshot 2023-05-08 at 11 39 26 am" src="https://user-images.githubusercontent.com/97164662/236716725-74b674c1-dd00-4efb-8787-1839f9291e05.png">
