### PR TITLE
fix: always show donation if default donations > min

### DIFF
--- a/src/components/Trade/TradeConfirm/TradeConfirm.tsx
+++ b/src/components/Trade/TradeConfirm/TradeConfirm.tsx
@@ -410,7 +410,7 @@ export const TradeConfirm = () => {
               <Checkbox
                 isChecked={!hasUserOptedOutOfDonation}
                 onChange={handleDonationToggle}
-                isDisabled={isSubmitting || isReloadingTrade}
+                isDisabled={isSubmitting || isReloadingTrade || tradeStatus === TxStatus.Confirmed}
               >
                 <Text translation='trade.donation' />
               </Checkbox>

--- a/src/components/Trade/TradeConfirm/TradeConfirm.tsx
+++ b/src/components/Trade/TradeConfirm/TradeConfirm.tsx
@@ -427,6 +427,7 @@ export const TradeConfirm = () => {
       isReloadingTrade,
       isSubmitting,
       toFiat,
+      tradeStatus,
       translate,
     ],
   )

--- a/src/state/zustand/swapperStore/amountSelectors.ts
+++ b/src/state/zustand/swapperStore/amountSelectors.ts
@@ -7,7 +7,6 @@ import type { IntermediaryTransactionOutput } from 'lib/swapper/api'
 import { createDeepEqualOutputSelector } from 'state/selector-utils'
 import {
   selectAction,
-  selectAffiliateBps,
   selectAmount,
   selectBuyAsset,
   selectBuyAssetFiatRate,
@@ -16,6 +15,7 @@ import {
   selectSellAsset,
   selectSellAssetFiatRate,
   selectSlippage,
+  selectSwapperDefaultAffiliateBps,
 } from 'state/zustand/swapperStore/selectors'
 import type { SwapperState } from 'state/zustand/swapperStore/types'
 import { convertBasisPointsToDecimalPercentage } from 'state/zustand/swapperStore/utils'
@@ -583,9 +583,9 @@ export const selectTradeAmountsByActionAndAmountFromQuote: Selector<
 
 export const selectDonationAmountFiat = createSelector(
   selectSellAmountFiat,
-  selectAffiliateBps,
-  (sellAmountFiat, affiliateBps): string => {
-    const affiliatePercentage = convertBasisPointsToDecimalPercentage(affiliateBps)
+  selectSwapperDefaultAffiliateBps,
+  (sellAmountFiat, defaultAffiliateBps): string => {
+    const affiliatePercentage = convertBasisPointsToDecimalPercentage(defaultAffiliateBps)
     // The donation amount is a percentage of the sell amount
     return bnOrZero(sellAmountFiat).times(affiliatePercentage).toFixed()
   },


### PR DESCRIPTION
## Description

Fixes a bug where the donation toggle would disapear on toggle for THORSwaps, as the expected donation amount fell below the minimum.

To fix this, we want to continue showing the donation toggle if the donation amount, assumming the default swapper bps is used, is above the minimum, regardless of the "active" donation amount. 

## Pull Request Type

- [x] :bug: Bug fix (Non-breaking Change: Fixes an issue)
- [ ] :hammer_and_wrench: Chore (Non-breaking Change: Doc updates, pkg upgrades, typos, etc..)
- [ ] :nail_care: New Feature (Breaking/Non-breaking Change)

## Issue (if applicable)

N/A

## Risk

Small.

## Testing

Toggle the donation amount for a THORSwap trade. The donation toggle should stay visible.

### Engineering

☝️

### Operations

☝️

## Screenshots (if applicable)

N/A
