### PR TITLE
feat: hide insufficient amount when no amount entered

### DIFF
--- a/src/components/Trade/Components/TradeQuotes/TradeQuote.tsx
+++ b/src/components/Trade/Components/TradeQuotes/TradeQuote.tsx
@@ -152,7 +152,7 @@ export const TradeQuoteLoaded: React.FC<TradeQuoteLoadedProps> = ({
       default:
         return <Tag size='sm'>{translate('common.alternative')}</Tag>
     }
-  }, [isBest, hasAmountWithPositiveReceive, translate])
+  }, [hasAmountWithPositiveReceive, isAmountEntered, translate, isBest])
 
   const activeSwapperColor = (() => {
     if (!isTradingActive) return redColor

--- a/src/components/Trade/Components/TradeQuotes/TradeQuote.tsx
+++ b/src/components/Trade/Components/TradeQuotes/TradeQuote.tsx
@@ -137,7 +137,7 @@ export const TradeQuoteLoaded: React.FC<TradeQuoteLoadedProps> = ({
     bnOrZero(totalReceiveAmountCryptoPrecision).isGreaterThan(0)
   const tag: JSX.Element = useMemo(() => {
     switch (true) {
-      case !hasAmountWithPositiveReceive:
+      case !hasAmountWithPositiveReceive && isAmountEntered:
         return (
           <Tag size='sm' colorScheme='red'>
             {translate('trade.rates.tags.negativeRatio')}


### PR DESCRIPTION
## Description

Hide the "Insufficient sell amount" label when no amount has been entered yet.

## Pull Request Type

- [ ] :bug: Bug fix (Non-breaking Change: Fixes an issue)
- [ ] :hammer_and_wrench: Chore (Non-breaking Change: Doc updates, pkg upgrades, typos, etc..)
- [x] :nail_care: New Feature (Breaking/Non-breaking Change)

## Issue (if applicable)

N/A

## Risk

Small.

## Testing

When no amount has been entered in the trade widget we should not show the "Insufficient sell amount" label.

### Engineering

☝️

### Operations

☝️

## Screenshots (if applicable)

As-is:

<img width="467" alt="Screenshot 2023-05-08 at 12 16 22 pm" src="https://user-images.githubusercontent.com/97164662/236719451-5aff9ec0-8253-4bb3-9f6c-416320e6bc7d.png">

This PR:

<img width="471" alt="Screenshot 2023-05-08 at 12 14 10 pm" src="https://user-images.githubusercontent.com/97164662/236719478-9cba6dba-0d68-4c9c-9179-bacb43d57a68.png">
