### PR TITLE
fix: receive address for BCH

### DIFF
--- a/src/lib/swapper/swappers/ThorchainSwapper/utils/getQuote/getQuote.ts
+++ b/src/lib/swapper/swappers/ThorchainSwapper/utils/getQuote/getQuote.ts
@@ -1,5 +1,5 @@
 import type { AssetId } from '@shapeshiftoss/caip'
-import { adapters } from '@shapeshiftoss/caip'
+import { adapters, bchAssetId } from '@shapeshiftoss/caip'
 import type { Result } from '@sniptt/monads'
 import { Err, Ok } from '@sniptt/monads'
 import qs from 'qs'
@@ -47,11 +47,15 @@ export const getQuote = async ({
     toBaseUnit(sellAmountCryptoPrecision, THORCHAIN_FIXED_PRECISION),
   )
 
+  // The THORChain swap endpoint expects BCH receiveAddress's to be stripped of the "bitcoincash:" prefix
+  const parsedReceiveAddress =
+    buyAssetId === bchAssetId ? receiveAddress.replace('bitcoincash:', '') : receiveAddress
+
   const queryString = qs.stringify({
     amount: sellAmountCryptoThorBaseUnit.toString(),
     from_asset: sellPoolId,
     to_asset: buyPoolId,
-    destination: receiveAddress,
+    destination: parsedReceiveAddress,
     affiliate_bps: affiliateBps,
     affiliate: THORCHAIN_AFFILIATE_NAME,
   })

--- a/src/lib/swapper/swappers/ThorchainSwapper/utils/getTradeRate/getTradeRate.ts
+++ b/src/lib/swapper/swappers/ThorchainSwapper/utils/getTradeRate/getTradeRate.ts
@@ -1,5 +1,5 @@
 import type { AssetId } from '@shapeshiftoss/caip'
-import { adapters } from '@shapeshiftoss/caip'
+import { adapters, bchAssetId } from '@shapeshiftoss/caip'
 import type { Result } from '@sniptt/monads'
 import { Err, Ok } from '@sniptt/monads'
 import qs from 'qs'
@@ -91,11 +91,15 @@ export const getTradeRate = async ({
     toBaseUnit(sellAmountCryptoPrecision, THORCHAIN_FIXED_PRECISION),
   )
 
+  // The THORChain swap endpoint expects BCH receiveAddress's to be stripped of the "bitcoincash:" prefix
+  const parsedReceiveAddress =
+    buyAssetId === bchAssetId ? receiveAddress.replace('bitcoincash:', '') : receiveAddress
+
   const queryString = qs.stringify({
     amount: sellAmountCryptoThorBaseUnit.toString(),
     from_asset: sellPoolId,
     to_asset: buyPoolId,
-    destination: receiveAddress,
+    destination: parsedReceiveAddress,
     affiliate_bps: affiliateBps,
     affiliate: THORCHAIN_AFFILIATE_NAME,
   })


### PR DESCRIPTION
## Description

The THORSwap quote endpoints appears to no longer accept the `bitcoincash:` prefix on addresses, as quote requests containing it are now rejected.

This PR updates the logic inside THORSwapper (without touching any address logic outside of it, as this is a THOR-specific thing) to strip the prefix from the address when getting quotes and building trades for THORSwap trades.

## Pull Request Type

- [x] :bug: Bug fix (Non-breaking Change: Fixes an issue)
- [ ] :hammer_and_wrench: Chore (Non-breaking Change: Doc updates, pkg upgrades, typos, etc..)
- [ ] :nail_care: New Feature (Breaking/Non-breaking Change)

## Issue (if applicable)

Closes https://github.com/shapeshift/web/issues/4382

## Risk

Higher than it seems, as this touches receive addresses for trades - we want to be super careful that this logic makes sense. Scrutinize the diff accordingly.

## Testing

Do a THORSwap trade into BCH and confirm that the address in the request and response payloads look correct.

Execute the transaction and confirm the funds are received as expected in the BCH account.

TX I did to confirm this is now working as expected: https://live.blockcypher.com/doge/tx/e74bd687cf165bf9b5fa74ea432b4c0fd0e38134979b5685a93dcf499159fcdd/

https://viewblock.io/thorchain/tx/E74BD687CF165BF9B5FA74EA432B4C0FD0E38134979B5685A93DCF499159FCDD

### Engineering

Give this another mental sanity check for good measure, please.

### Operations

☝️

## Screenshots (if applicable)

<img width="679" alt="Screenshot 2023-05-09 at 5 28 43 pm" src="https://user-images.githubusercontent.com/97164662/237025353-71539c23-b19f-4caf-8742-ae517ffb6c23.png">

<img width="477" alt="Screenshot 2023-05-09 at 5 30 24 pm" src="https://user-images.githubusercontent.com/97164662/237025738-ef6ea2a8-a188-48a1-b25e-0526605cc105.png">
