### PR TITLE
feat: parse amounts on QR scan with regular send button

### DIFF
--- a/src/components/Modals/Send/Form.tsx
+++ b/src/components/Modals/Send/Form.tsx
@@ -97,12 +97,6 @@ export const Form: React.FC<SendFormProps> = ({ initialAssetId, accountId }) => 
         )
       }
 
-      // We don't parse EIP-681 URLs because they're unsafe
-      // Some wallets may be smart, like Trust just showing an address as a QR code to avoid dangerously unsafe parameters
-      // Others might do dangerous tricks in the way they represent an asset, using various parameters to do so
-      // There's also the fact that we will assume the AssetId to be the native one of the first chain we managed to validate the address
-      // Which may not be the chain the user wants to send, or they may want to send a token - so we should always ask the user to select the asset
-      if (maybeUrlResult.assetId === ethAssetId) return history.push(SendRoutes.Select)
       history.push(SendRoutes.Address)
     },
     [history, methods],

--- a/src/components/Modals/Send/Form.tsx
+++ b/src/components/Modals/Send/Form.tsx
@@ -1,5 +1,4 @@
 import type { AccountId, AssetId, ChainId } from '@shapeshiftoss/caip'
-import { ethAssetId } from '@shapeshiftoss/caip'
 import type { FeeDataEstimate } from '@shapeshiftoss/chain-adapters'
 import { FeeDataKey } from '@shapeshiftoss/chain-adapters'
 import { AnimatePresence } from 'framer-motion'

--- a/src/components/Modals/Send/Form.tsx
+++ b/src/components/Modals/Send/Form.tsx
@@ -1,4 +1,5 @@
 import type { AccountId, AssetId, ChainId } from '@shapeshiftoss/caip'
+import { ethAssetId } from '@shapeshiftoss/caip'
 import type { FeeDataEstimate } from '@shapeshiftoss/chain-adapters'
 import { FeeDataKey } from '@shapeshiftoss/chain-adapters'
 import { AnimatePresence } from 'framer-motion'
@@ -7,8 +8,10 @@ import { FormProvider, useForm } from 'react-hook-form'
 import { Redirect, Route, Switch, useHistory, useLocation } from 'react-router-dom'
 import { QrCodeScanner } from 'components/QrCodeScanner/QrCodeScanner'
 import { SelectAssetRouter } from 'components/SelectAssets/SelectAssetRouter'
-import { selectSelectedCurrency } from 'state/slices/selectors'
-import { useAppSelector } from 'state/store'
+import { parseMaybeUrl } from 'lib/address/address'
+import { bnOrZero } from 'lib/bignumber/bignumber'
+import { selectMarketDataById, selectSelectedCurrency } from 'state/slices/selectors'
+import { store, useAppSelector } from 'state/store'
 
 import { useFormSend } from './hooks/useFormSend/useFormSend'
 import { SendFormFields, SendRoutes } from './SendCommon'
@@ -81,8 +84,25 @@ export const Form: React.FC<SendFormProps> = ({ initialAssetId, accountId }) => 
   }, [])
 
   const handleQrSuccess = useCallback(
-    (decodedText: string) => {
+    async (decodedText: string) => {
       methods.setValue(SendFormFields.Input, decodedText.trim())
+
+      const maybeUrlResult = await parseMaybeUrl({ value: decodedText })
+      if (maybeUrlResult.assetId && maybeUrlResult.amountCryptoPrecision) {
+        const marketData = selectMarketDataById(store.getState(), maybeUrlResult.assetId ?? '')
+        methods.setValue(SendFormFields.CryptoAmount, maybeUrlResult.amountCryptoPrecision)
+        methods.setValue(
+          SendFormFields.FiatAmount,
+          bnOrZero(maybeUrlResult.amountCryptoPrecision).times(marketData.price).toString(),
+        )
+      }
+
+      // We don't parse EIP-681 URLs because they're unsafe
+      // Some wallets may be smart, like Trust just showing an address as a QR code to avoid dangerously unsafe parameters
+      // Others might do dangerous tricks in the way they represent an asset, using various parameters to do so
+      // There's also the fact that we will assume the AssetId to be the native one of the first chain we managed to validate the address
+      // Which may not be the chain the user wants to send, or they may want to send a token - so we should always ask the user to select the asset
+      if (maybeUrlResult.assetId === ethAssetId) return history.push(SendRoutes.Select)
       history.push(SendRoutes.Address)
     },
     [history, methods],

--- a/src/components/Modals/Send/hooks/useSendFees/useSendFees.tsx
+++ b/src/components/Modals/Send/hooks/useSendFees/useSendFees.tsx
@@ -13,7 +13,7 @@ import type { FeePrice } from '../../views/Confirm'
 export const useSendFees = () => {
   const [fees, setFees] = useState<FeePrice | null>(null)
   const { control } = useFormContext()
-  const { assetId, estimatedFees } = useWatch({
+  const { assetId, estimatedFees, cryptoAmount } = useWatch({
     control,
   })
   const feeAssetId = getChainAdapterManager().get(fromAssetId(assetId).chainId)?.getFeeAssetId()
@@ -59,9 +59,12 @@ export const useSendFees = () => {
       )
       setFees(txFees)
     }
-    // We only want this effect to run on mount or when the estimatedFees in state change
+    // We only want this effect to run on
+    // - mount
+    // - when the estimatedFees reference invalidates
+    // - when cryptoAmount reference invalidates, since this wouldn't invalidate in the context of QR codes with amounts otherwise
     // eslint-disable-next-line react-hooks/exhaustive-deps
-  }, [estimatedFees, assetId])
+  }, [estimatedFees, cryptoAmount, assetId])
 
   return { fees }
 }

--- a/src/components/Modals/Send/views/Details.tsx
+++ b/src/components/Modals/Send/views/Details.tsx
@@ -14,6 +14,7 @@ import {
   ModalHeader,
   Stack,
   Tooltip,
+  usePrevious,
 } from '@chakra-ui/react'
 import type { AccountId } from '@shapeshiftoss/caip'
 import { fromAssetId } from '@shapeshiftoss/caip'
@@ -80,12 +81,16 @@ export const Details = () => {
     state: { wallet },
   } = useWallet()
 
+  const previousAccountId = usePrevious(accountId)
   useEffect(() => {
     // This component initially mounts without an accountId, because of how <AccountDropdown /> works
-    if (!accountId) return
-    // Initial setting of cryptoAmount in case of a QR-code set amount
-    handleInputChange(cryptoAmount ?? '0')
-    trigger(SendFormFields.CryptoAmount)
+    // Also turns out we don't handle re-validation in case of changing AccountIds
+    // This effect takes care of both the initial/account change cases
+    if (previousAccountId !== accountId) {
+      const inputAmount = fieldName === SendFormFields.CryptoAmount ? cryptoAmount : fiatAmount
+      handleInputChange(inputAmount ?? '0')
+      trigger(fieldName)
+    }
     // eslint-disable-next-line react-hooks/exhaustive-deps
   }, [accountId])
 

--- a/src/components/Modals/Send/views/Details.tsx
+++ b/src/components/Modals/Send/views/Details.tsx
@@ -44,7 +44,7 @@ import { SendMaxButton } from '../SendMaxButton/SendMaxButton'
 const MAX_COSMOS_SDK_MEMO_LENGTH = 256
 
 export const Details = () => {
-  const { control, setValue } = useFormContext<SendInput>()
+  const { control, setValue, trigger } = useFormContext<SendInput>()
   const history = useHistory()
   const translate = useTranslate()
 
@@ -81,10 +81,13 @@ export const Details = () => {
   } = useWallet()
 
   useEffect(() => {
+    // This component initially mounts without an accountId, because of how <AccountDropdown /> works
+    if (!accountId) return
     // Initial setting of cryptoAmount in case of a QR-code set amount
-    if (!cryptoAmount) handleInputChange(cryptoAmount ?? '0')
+    handleInputChange(cryptoAmount ?? '0')
+    trigger(SendFormFields.CryptoAmount)
     // eslint-disable-next-line react-hooks/exhaustive-deps
-  }, [handleInputChange])
+  }, [accountId])
 
   const asset = useAppSelector(state => selectAssetById(state, assetId ?? ''))
 


### PR DESCRIPTION
## Description

This PR:

- Adds support for amount parsing in the good ol' send button when clicking the QR scan icon
- Fixes the reactivity on amount/accountId over the send domain so that gas fees are now properly reacty and present on the last step of sends with amounts
- While at it, fixes the missing re-validation on `AccountId` change. Currently on prod, while account 0 has enough balance for gas/crypto but the newly selected account doesn't, no validation happens meaning that it will look as the newly selected account passed validation, while in reality no validation happened at all.

## Pull Request Type

- [ ] :bug: Bug fix (Non-breaking Change: Fixes an issue)
- [ ] :hammer_and_wrench: Chore (Non-breaking Change: Doc updates, pkg upgrades, typos, etc..)
- [x] :nail_care: New Feature (Breaking/Non-breaking Change)

## Issue (if applicable)

N/A

## Risk

<!-----------------------------------------------------------------------------
Outline the scope of your changes and the risk associated with them. You must use your discretion as an engineer to determine the potential impact of your changes.

E.g. an upgrade to `hdwallet` or core state management would be considered higher risk, and might require a full regression test. UI or isolated view changes, or something behind a feature flag may have near zero risk. Small bug fixes might require testing isolated to the specific fix.
------------------------------------------------------------------------------>

## Testing

<!-----------------------------------------------------------------------------
We treat every PR to be merged with the same scrutiny as if we were merging directly to production.

Your PR will not be merged if you do not complete the sections below for our engineering and operations teams to test.
------------------------------------------------------------------------------>

- Test both QRCode and send buttons end-to-end : all the way to Tx popup in MetaMask (without confirmation), and to an actual broadcast on native for cheaper UTXO/IBC chains
  - Test both with an URL containing an amount (you can use Trust wallet receive option, setting the "Amount" option) as well as with a regular address QR code (same thing in Trust but without using the "Set Amount" option)
- While sending from an account 0 with enough balance for gas / amount to send, ensure switching to another account without enough balance (e.g newly created account with 0 balance) triggers the insufficient balance error state

### Engineering

<!-----------------------------------------------------------------------------
Include sufficient information here for an engineer to test your PR. This may include how to test locally, in a built environment, changes to infrastructure etc.
------------------------------------------------------------------------------>

- Reactivity looks sane

### Operations

<!-----------------------------------------------------------------------------
If your changes have a user-facing impact, describe how a non-technical QA team can functionally test your changes in a preview environment.

If they are not user-facing please describe how to test for any regressions that may occur.
------------------------------------------------------------------------------>

- ☝🏽 

## Screenshots (if applicable)
