### PR TITLE
fix: show defi by provider skeletons only on actual load

### DIFF
--- a/src/components/StakingVaults/WalletProviderTable.tsx
+++ b/src/components/StakingVaults/WalletProviderTable.tsx
@@ -59,13 +59,10 @@ export const WalletProviderTable: React.FC<ProviderTableProps> = ({
         {rows.map((row, index) => (
           <ProviderCard key={`provider-${index}`} {...row} />
         ))}
-        {
+        {isLoading &&
           // Assume three max loading rows - that might not be true, but we don't want to collapse the
           // loaded rows too much and hinder visibility
-          Array.from({ length: 3 }).map((_, index) => (
-            <ProviderCardLoading key={index} />
-          ))
-        }
+          Array.from({ length: 3 }).map((_, index) => <ProviderCardLoading key={index} />)}
       </Flex>
     )
   }, [isLoading, rows, searchQuery])


### PR DESCRIPTION
## Description

Smallish derp fix - since the skeletons are at the very end of opportunities, we've never noticed that they're always present, even after loading of opportunities is finished.

## Pull Request Type

- [x] :bug: Bug fix (Non-breaking Change: Fixes an issue)
- [ ] :hammer_and_wrench: Chore (Non-breaking Change: Doc updates, pkg upgrades, typos, etc..)
- [ ] :nail_care: New Feature (Breaking/Non-breaking Change)

## Issue (if applicable)

N/A

## Risk

<!-----------------------------------------------------------------------------
Outline the scope of your changes and the risk associated with them. You must use your discretion as an engineer to determine the potential impact of your changes.

E.g. an upgrade to `hdwallet` or core state management would be considered higher risk, and might require a full regression test. UI or isolated view changes, or something behind a feature flag may have near zero risk. Small bug fixes might require testing isolated to the specific fix.
------------------------------------------------------------------------------>

None

## Testing

<!-----------------------------------------------------------------------------
We treat every PR to be merged with the same scrutiny as if we were merging directly to production.

Your PR will not be merged if you do not complete the sections below for our engineering and operations teams to test.
------------------------------------------------------------------------------>

- Go to the DeFi section and scroll to the very end (or press G if you're a 10x vimium user)
- Ensure the skeletons disappear once all opportunities are loaded

### Engineering

<!-----------------------------------------------------------------------------
Include sufficient information here for an engineer to test your PR. This may include how to test locally, in a built environment, changes to infrastructure etc.
------------------------------------------------------------------------------>

- ☝🏽 

### Operations

<!-----------------------------------------------------------------------------
If your changes have a user-facing impact, describe how a non-technical QA team can functionally test your changes in a preview environment.

If they are not user-facing please describe how to test for any regressions that may occur.
------------------------------------------------------------------------------>

- ☝🏽 

## Screenshots (if applicable)
