### PR TITLE
feat: manual receive address

### DIFF
--- a/src/assets/translations/en/main.json
+++ b/src/assets/translations/en/main.json
@@ -738,7 +738,8 @@
     "lifiWarning": "This trade routes via LI.FI, which executes a series of intermediary trades to perform a swap. If any steps fail you'll receive the token for the last successful step in the sequence.",
     "or": "or",
     "onChainName": "on %{chainName}",
-    "unknownGas": "(unknown)"
+    "unknownGas": "(unknown)",
+    "receiveAddress": "Receive Address"
   },
   "modals": {
     "popup": {

--- a/src/assets/translations/en/main.json
+++ b/src/assets/translations/en/main.json
@@ -723,7 +723,6 @@
       "unsupportedChain": "This chain is not currently supported.",
       "rateError": "We're not able to get a quote for this pair",
       "assetNotSupportedByWallet": "%{assetSymbol} not supported by wallet",
-      "manualReceiveAddressRequired": "Manual receive address required for %{assetSymbol}",
       "noReceiveAddress": "No receive address for %{assetSymbol}",
       "tradingNotActive": "Trades temporarily halted for %{assetSymbol}",
       "signing": {
@@ -739,7 +738,9 @@
     "or": "or",
     "onChainName": "on %{chainName}",
     "unknownGas": "(unknown)",
-    "receiveAddress": "Receive Address"
+    "receiveAddress": "Receive Address",
+    "receiveAddressDescription": "No %{chainName} address found from connected wallet. Manually enter address to continue.",
+    "addressPlaceholder": "%{chainName} address"
   },
   "modals": {
     "popup": {

--- a/src/assets/translations/en/main.json
+++ b/src/assets/translations/en/main.json
@@ -723,6 +723,7 @@
       "unsupportedChain": "This chain is not currently supported.",
       "rateError": "We're not able to get a quote for this pair",
       "assetNotSupportedByWallet": "%{assetSymbol} not supported by wallet",
+      "manualReceiveAddressRequired": "Manual receive address required for %{assetSymbol}",
       "noReceiveAddress": "No receive address for %{assetSymbol}",
       "tradingNotActive": "Trades temporarily halted for %{assetSymbol}",
       "signing": {

--- a/src/components/Modals/Send/AddressInput/AddressInput.tsx
+++ b/src/components/Modals/Send/AddressInput/AddressInput.tsx
@@ -1,20 +1,23 @@
 import { IconButton, Input, InputGroup, InputRightElement } from '@chakra-ui/react'
 import type { ControllerProps } from 'react-hook-form'
-import { Controller } from 'react-hook-form'
+import { Controller, useFormContext } from 'react-hook-form'
 import { useTranslate } from 'react-polyglot'
 import { useHistory } from 'react-router-dom'
 import { QRCodeIcon } from 'components/Icons/QRCode'
+import type { SendInput } from 'components/Modals/Send/Form'
 
 import { SendFormFields, SendRoutes } from '../SendCommon'
 
 type AddressInputProps = {
   rules: ControllerProps['rules']
   isYatSupported: boolean
+  showQr?: boolean
 }
 
-export const AddressInput = ({ rules, isYatSupported }: AddressInputProps) => {
+export const AddressInput = ({ rules, isYatSupported, showQr = true }: AddressInputProps) => {
   const history = useHistory()
   const translate = useTranslate()
+  const isValid = useFormContext<SendInput>().formState.isValid
 
   const handleQrClick = () => {
     history.push(SendRoutes.Scan)
@@ -38,21 +41,24 @@ export const AddressInput = ({ rules, isYatSupported }: AddressInputProps) => {
             data-test='send-address-input'
             // Because the InputRightElement is hover the input, we need to let this space free
             pe={10}
+            isInvalid={!isValid}
           />
         )}
         name={SendFormFields.Input}
         rules={rules}
         defaultValue=''
       />
-      <InputRightElement>
-        <IconButton
-          aria-label={translate('modals.send.scanQrCode')}
-          icon={<QRCodeIcon />}
-          onClick={handleQrClick}
-          size='sm'
-          variant='ghost'
-        />
-      </InputRightElement>
+      {showQr && (
+        <InputRightElement>
+          <IconButton
+            aria-label={translate('modals.send.scanQrCode')}
+            icon={<QRCodeIcon />}
+            onClick={handleQrClick}
+            size='sm'
+            variant='ghost'
+          />
+        </InputRightElement>
+      )}
     </InputGroup>
   )
 }

--- a/src/components/Modals/Send/AddressInput/AddressInput.tsx
+++ b/src/components/Modals/Send/AddressInput/AddressInput.tsx
@@ -42,6 +42,7 @@ export const AddressInput = ({ rules, isYatSupported }: AddressInputProps) => {
         )}
         name={SendFormFields.Input}
         rules={rules}
+        defaultValue=''
       />
       <InputRightElement>
         <IconButton

--- a/src/components/Modals/Send/AddressInput/AddressInput.tsx
+++ b/src/components/Modals/Send/AddressInput/AddressInput.tsx
@@ -10,11 +10,11 @@ import { SendFormFields, SendRoutes } from '../SendCommon'
 
 type AddressInputProps = {
   rules: ControllerProps['rules']
-  isYatSupported: boolean
   enableQr?: boolean
+  placeholder?: string
 }
 
-export const AddressInput = ({ rules, isYatSupported, enableQr = false }: AddressInputProps) => {
+export const AddressInput = ({ rules, placeholder, enableQr = false }: AddressInputProps) => {
   const history = useHistory()
   const translate = useTranslate()
   const isValid = useFormContext<SendInput>().formState.isValid
@@ -32,9 +32,7 @@ export const AddressInput = ({ rules, isYatSupported, enableQr = false }: Addres
             autoFocus
             fontSize='sm'
             onChange={onChange}
-            placeholder={translate(
-              isYatSupported ? 'modals.send.addressInput' : 'modals.send.tokenAddress',
-            )}
+            placeholder={placeholder}
             size='lg'
             value={value}
             variant='filled'

--- a/src/components/Modals/Send/AddressInput/AddressInput.tsx
+++ b/src/components/Modals/Send/AddressInput/AddressInput.tsx
@@ -11,10 +11,10 @@ import { SendFormFields, SendRoutes } from '../SendCommon'
 type AddressInputProps = {
   rules: ControllerProps['rules']
   isYatSupported: boolean
-  showQr?: boolean
+  enableQr?: boolean
 }
 
-export const AddressInput = ({ rules, isYatSupported, showQr = true }: AddressInputProps) => {
+export const AddressInput = ({ rules, isYatSupported, enableQr = false }: AddressInputProps) => {
   const history = useHistory()
   const translate = useTranslate()
   const isValid = useFormContext<SendInput>().formState.isValid
@@ -48,7 +48,7 @@ export const AddressInput = ({ rules, isYatSupported, showQr = true }: AddressIn
         rules={rules}
         defaultValue=''
       />
-      {showQr && (
+      {enableQr && (
         <InputRightElement>
           <IconButton
             aria-label={translate('modals.send.scanQrCode')}

--- a/src/components/Modals/Send/AddressInput/AddressInput.tsx
+++ b/src/components/Modals/Send/AddressInput/AddressInput.tsx
@@ -1,30 +1,20 @@
 import { IconButton, Input, InputGroup, InputRightElement } from '@chakra-ui/react'
-import { ethChainId } from '@shapeshiftoss/caip'
 import type { ControllerProps } from 'react-hook-form'
-import { Controller, useWatch } from 'react-hook-form'
+import { Controller } from 'react-hook-form'
 import { useTranslate } from 'react-polyglot'
 import { useHistory } from 'react-router-dom'
 import { QRCodeIcon } from 'components/Icons/QRCode'
-import { useFeatureFlag } from 'hooks/useFeatureFlag/useFeatureFlag'
-import { selectAssetById } from 'state/slices/selectors'
-import { useAppSelector } from 'state/store'
 
-import type { SendInput } from '../Form'
 import { SendFormFields, SendRoutes } from '../SendCommon'
 
 type AddressInputProps = {
   rules: ControllerProps['rules']
+  isYatSupported: boolean
 }
 
-export const AddressInput = ({ rules }: AddressInputProps) => {
-  const assetId = useWatch<SendInput, SendFormFields.AssetId>({
-    name: SendFormFields.AssetId,
-  })
+export const AddressInput = ({ rules, isYatSupported }: AddressInputProps) => {
   const history = useHistory()
   const translate = useTranslate()
-  const isYatFeatureEnabled = useFeatureFlag('Yat')
-  const asset = useAppSelector(state => selectAssetById(state, assetId))
-  const isYatSupportedChain = asset?.chainId === ethChainId // yat only supports eth mainnet
 
   const handleQrClick = () => {
     history.push(SendRoutes.Scan)
@@ -40,9 +30,7 @@ export const AddressInput = ({ rules }: AddressInputProps) => {
             fontSize='sm'
             onChange={onChange}
             placeholder={translate(
-              isYatFeatureEnabled && isYatSupportedChain
-                ? 'modals.send.addressInput'
-                : 'modals.send.tokenAddress',
+              isYatSupported ? 'modals.send.addressInput' : 'modals.send.tokenAddress',
             )}
             size='lg'
             value={value}

--- a/src/components/Modals/Send/views/Address.tsx
+++ b/src/components/Modals/Send/views/Address.tsx
@@ -123,6 +123,7 @@ export const Address = () => {
               },
             }}
             isYatSupported={isYatSupported}
+            enableQr={true}
           />
         </FormControl>
         {isYatFeatureEnabled && isYatSupportedChain && <YatBanner mt={6} />}

--- a/src/components/Modals/Send/views/Address.tsx
+++ b/src/components/Modals/Send/views/Address.tsx
@@ -122,8 +122,10 @@ export const Address = () => {
                 },
               },
             }}
-            isYatSupported={isYatSupported}
             enableQr={true}
+            placeholder={translate(
+              isYatSupported ? 'modals.send.addressInput' : 'modals.send.tokenAddress',
+            )}
           />
         </FormControl>
         {isYatFeatureEnabled && isYatSupportedChain && <YatBanner mt={6} />}

--- a/src/components/Modals/Send/views/Address.tsx
+++ b/src/components/Modals/Send/views/Address.tsx
@@ -57,6 +57,7 @@ export const Address = () => {
   if (!asset) return null
   const { chainId } = asset
   const isYatSupportedChain = chainId === ethChainId // yat only supports eth mainnet
+  const isYatSupported = isYatFeatureEnabled && isYatSupportedChain
   const addressError = get(errors, `${SendFormFields.Input}.message`, null)
 
   return (
@@ -114,14 +115,14 @@ export const Address = () => {
                       bnOrZero(amountCryptoPrecision).times(marketData.price).toString(),
                     )
                   }
-                  const invalidMessage =
-                    isYatFeatureEnabled && isYatSupportedChain
-                      ? 'common.invalidAddressOrYat'
-                      : 'common.invalidAddress'
+                  const invalidMessage = isYatSupported
+                    ? 'common.invalidAddressOrYat'
+                    : 'common.invalidAddress'
                   return address ? true : invalidMessage
                 },
               },
             }}
+            isYatSupported={isYatSupported}
           />
         </FormControl>
         {isYatFeatureEnabled && isYatSupportedChain && <YatBanner mt={6} />}

--- a/src/components/Trade/TradeInput.tsx
+++ b/src/components/Trade/TradeInput.tsx
@@ -451,7 +451,10 @@ export const TradeInput = () => {
           assetSymbol: sellAsset?.symbol ?? translate('trade.errors.sellAssetStartSentence'),
         },
       ]
-    if (!walletSupportsBuyAssetChain && !receiveAddress)
+    if (
+      (!walletSupportsBuyAssetChain && !receiveAddress) ||
+      manualAddressEntryErrors?.input?.type?.toString() === 'required'
+    )
       return [
         'trade.errors.manualReceiveAddressRequired',
         {
@@ -507,7 +510,7 @@ export const TradeInput = () => {
           assetSymbol: buyAsset?.symbol ?? translate('trade.errors.buyAssetMiddleSentence'),
         },
       ]
-    if (manualAddressEntryErrors.input?.message) {
+    if (manualAddressEntryErrors.input?.message && !walletSupportsBuyAssetChain) {
       return manualAddressEntryErrors.input?.message.toString()
     }
 
@@ -527,13 +530,15 @@ export const TradeInput = () => {
     activeQuote?.feeData.networkFeeCryptoBaseUnit,
     activeQuote?.minimumCryptoHuman,
     activeQuote?.sellAsset.symbol,
-    manualAddressEntryErrors.input?.message,
     isSwapperApiPending,
     isSwapperApiInitiated,
     wallet,
     walletSupportsSellAssetChain,
     translate,
     walletSupportsBuyAssetChain,
+    receiveAddress,
+    manualAddressEntryErrors.input?.type,
+    manualAddressEntryErrors.input?.message,
     buyAsset.symbol,
     buyAsset.chainId,
     activeSwapper,
@@ -544,7 +549,6 @@ export const TradeInput = () => {
     feesExceedsSellAmount,
     isTradeQuotePending,
     quoteAvailableForCurrentAssetPair,
-    receiveAddress,
   ])
 
   const hasError = useMemo(() => {
@@ -738,7 +742,7 @@ export const TradeInput = () => {
                     const parseAddressInputArgs = { assetId, chainId, value }
                     const { address } = await parseAddressInput(parseAddressInputArgs)
                     setIsManualAddressEntryValidating(false)
-                    address && updateReceiveAddress(address)
+                    updateReceiveAddress(address || undefined)
                     const invalidMessage = isYatSupported
                       ? 'common.invalidAddressOrYat'
                       : 'common.invalidAddress'

--- a/src/components/Trade/TradeInput.tsx
+++ b/src/components/Trade/TradeInput.tsx
@@ -11,13 +11,14 @@ import {
 } from '@chakra-ui/react'
 import { ethAssetId, ethChainId } from '@shapeshiftoss/caip'
 import type { InterpolationOptions } from 'node-polyglot'
-import { useCallback, useMemo, useState } from 'react'
+import { useCallback, useEffect, useMemo, useState } from 'react'
 import { useFormContext } from 'react-hook-form'
 import { useTranslate } from 'react-polyglot'
 import { useSelector } from 'react-redux'
 import { useHistory } from 'react-router'
 import type { AccountDropdownProps } from 'components/AccountDropdown/AccountDropdown'
 import { AddressInput } from 'components/Modals/Send/AddressInput/AddressInput'
+import { SendFormFields } from 'components/Modals/Send/SendCommon'
 import { SlideTransition } from 'components/SlideTransition'
 import { Text } from 'components/Text'
 import { useIsTradingActive } from 'components/Trade/hooks/useIsTradingActive'
@@ -115,7 +116,12 @@ export const TradeInput = () => {
 
   const {
     formState: { errors: manualAddressEntryErrors },
+    trigger,
   } = useFormContext()
+
+  useEffect(() => {
+    trigger(SendFormFields.Input)
+  }, [trigger])
 
   const { isTradingActiveOnSellPool, isTradingActiveOnBuyPool } = useIsTradingActive()
 
@@ -501,6 +507,9 @@ export const TradeInput = () => {
           assetSymbol: buyAsset?.symbol ?? translate('trade.errors.buyAssetMiddleSentence'),
         },
       ]
+    if (manualAddressEntryErrors.input?.message) {
+      return manualAddressEntryErrors.input?.message.toString()
+    }
 
     return 'trade.previewTrade'
   }, [
@@ -518,7 +527,7 @@ export const TradeInput = () => {
     activeQuote?.feeData.networkFeeCryptoBaseUnit,
     activeQuote?.minimumCryptoHuman,
     activeQuote?.sellAsset.symbol,
-    manualAddressEntryErrors,
+    manualAddressEntryErrors.input?.message,
     isSwapperApiPending,
     isSwapperApiInitiated,
     wallet,
@@ -715,7 +724,7 @@ export const TradeInput = () => {
         {shouldShowManualReceiveAddressInput && (
           <FormControl>
             <FormLabel color='gray.500' w='full'>
-              {translate('modals.send.sendForm.sendTo')}
+              {translate('trade.receiveAddress')}
             </FormLabel>
             <AddressInput
               rules={{
@@ -729,7 +738,7 @@ export const TradeInput = () => {
                     const parseAddressInputArgs = { assetId, chainId, value }
                     const { address } = await parseAddressInput(parseAddressInputArgs)
                     setIsManualAddressEntryValidating(false)
-                    updateReceiveAddress(address)
+                    address && updateReceiveAddress(address)
                     const invalidMessage = isYatSupported
                       ? 'common.invalidAddressOrYat'
                       : 'common.invalidAddress'

--- a/src/components/Trade/TradeInput.tsx
+++ b/src/components/Trade/TradeInput.tsx
@@ -32,10 +32,7 @@ import { useFeatureFlag } from 'hooks/useFeatureFlag/useFeatureFlag'
 import { useModal } from 'hooks/useModal/useModal'
 import { useToggle } from 'hooks/useToggle/useToggle'
 import { useWallet } from 'hooks/useWallet/useWallet'
-import {
-  useWalletSupportsBuyAsset,
-  useWalletSupportsSellAsset,
-} from 'hooks/useWalletSupportsChain/useWalletSupportsChain'
+import { walletSupportsChain } from 'hooks/useWalletSupportsChain/useWalletSupportsChain'
 import { parseAddressInput } from 'lib/address/address'
 import type { Asset } from 'lib/asset-service'
 import { bn, bnOrZero, positiveOrZero } from 'lib/bignumber/bignumber'
@@ -147,6 +144,7 @@ export const TradeInput = () => {
   const buyAsset = useSwapperStore(selectBuyAsset)
   const sellAsset = useSwapperStore(selectSellAsset)
   const sellAssetChainId = sellAsset?.chainId
+  const buyAssetChainId = buyAsset?.chainId
   const feeAsset = useAppSelector(state => selectFeeAssetByChainId(state, sellAssetChainId ?? ''))
   const buyAmountCryptoPrecision = useSwapperStore(selectBuyAmountCryptoPrecision)
   const sellAmountCryptoPrecision = useSwapperStore(selectSellAmountCryptoPrecision)
@@ -234,8 +232,8 @@ export const TradeInput = () => {
     )
   }, [buyAsset?.assetId, activeQuote, sellAsset?.assetId])
 
-  const walletSupportsSellAssetChain = useWalletSupportsSellAsset()
-  const walletSupportsBuyAssetChain = useWalletSupportsBuyAsset()
+  const walletSupportsSellAssetChain = walletSupportsChain({ chainId: sellAssetChainId, wallet })
+  const walletSupportsBuyAssetChain = walletSupportsChain({ chainId: buyAssetChainId, wallet })
 
   // Constants
   const shouldShowManualReceiveAddressInput = !walletSupportsBuyAssetChain

--- a/src/components/Trade/TradeInput.tsx
+++ b/src/components/Trade/TradeInput.tsx
@@ -33,8 +33,7 @@ import { useModal } from 'hooks/useModal/useModal'
 import { useToggle } from 'hooks/useToggle/useToggle'
 import { useWallet } from 'hooks/useWallet/useWallet'
 import { walletSupportsChain } from 'hooks/useWalletSupportsChain/useWalletSupportsChain'
-import type { ParseAddressByChainIdInputArgs } from 'lib/address/address'
-import { parseAddressInput } from 'lib/address/address'
+import { parseAddressInputWithChainId } from 'lib/address/address'
 import type { Asset } from 'lib/asset-service'
 import { bn, bnOrZero, positiveOrZero } from 'lib/bignumber/bignumber'
 import { logger } from 'lib/logger'
@@ -643,13 +642,15 @@ export const TradeInput = () => {
                 setIsManualAddressEntryValidating(true)
                 const { assetId, chainId } = buyAsset
                 // this does not throw, everything inside is handled
-                const parseAddressInputArgs: ParseAddressByChainIdInputArgs = {
+                const parseAddressInputWithChainIdArgs = {
                   assetId,
                   chainId,
-                  value,
+                  urlOrAddress: value,
                   disableUrlParsing: true,
                 }
-                const { address } = await parseAddressInput(parseAddressInputArgs)
+                const { address } = await parseAddressInputWithChainId(
+                  parseAddressInputWithChainIdArgs,
+                )
                 setIsManualAddressEntryValidating(false)
                 updateReceiveAddress(address || undefined)
                 const invalidMessage = isYatSupported

--- a/src/components/Trade/TradeInput.tsx
+++ b/src/components/Trade/TradeInput.tsx
@@ -491,7 +491,11 @@ export const TradeInput = () => {
 
     if (!hasValidSellAssetBalance) return 'common.insufficientFunds'
     // TEMP: temporarily disable this logic for thor trades to allow them to work
-    if (!hasValidBuyAssetBalance && activeSwapper.name !== SwapperName.Thorchain) {
+    if (
+      !hasValidBuyAssetBalance &&
+      walletSupportsBuyAssetChain &&
+      activeSwapper.name !== SwapperName.Thorchain
+    ) {
       const chainAdapterManager = getChainAdapterManager()
       const chainName = chainAdapterManager.get(buyAsset.chainId)?.getDisplayName()
       return [

--- a/src/components/Trade/TradeInput.tsx
+++ b/src/components/Trade/TradeInput.tsx
@@ -33,6 +33,7 @@ import { useModal } from 'hooks/useModal/useModal'
 import { useToggle } from 'hooks/useToggle/useToggle'
 import { useWallet } from 'hooks/useWallet/useWallet'
 import { walletSupportsChain } from 'hooks/useWalletSupportsChain/useWalletSupportsChain'
+import type { ParseAddressByChainIdInputArgs } from 'lib/address/address'
 import { parseAddressInput } from 'lib/address/address'
 import type { Asset } from 'lib/asset-service'
 import { bn, bnOrZero, positiveOrZero } from 'lib/bignumber/bignumber'
@@ -645,7 +646,12 @@ export const TradeInput = () => {
                 setIsManualAddressEntryValidating(true)
                 const { assetId, chainId } = buyAsset
                 // this does not throw, everything inside is handled
-                const parseAddressInputArgs = { assetId, chainId, value }
+                const parseAddressInputArgs: ParseAddressByChainIdInputArgs = {
+                  assetId,
+                  chainId,
+                  value,
+                  disableUrlParsing: true,
+                }
                 const { address } = await parseAddressInput(parseAddressInputArgs)
                 setIsManualAddressEntryValidating(false)
                 updateReceiveAddress(address || undefined)

--- a/src/components/Trade/TradeInput.tsx
+++ b/src/components/Trade/TradeInput.tsx
@@ -760,7 +760,7 @@ export const TradeInput = () => {
             isLoading={tradeStateLoading}
             isError={!walletSupportsTradeAssetChains}
           />
-          {walletSupportsTradeAssetChains && !sellAmountTooSmall ? (
+          {walletSupportsSellAssetChain && !sellAmountTooSmall ? (
             <ReceiveSummary
               isLoading={tradeStateLoading}
               symbol={buyAsset?.symbol ?? ''}

--- a/src/components/Trade/TradeInput.tsx
+++ b/src/components/Trade/TradeInput.tsx
@@ -117,11 +117,8 @@ export const TradeInput = () => {
   const {
     formState: { errors: manualAddressEntryErrors },
     trigger,
+    setValue,
   } = useFormContext()
-
-  useEffect(() => {
-    trigger(SendFormFields.Input)
-  }, [trigger])
 
   const { isTradingActiveOnSellPool, isTradingActiveOnBuyPool } = useIsTradingActive()
 
@@ -174,6 +171,14 @@ export const TradeInput = () => {
   const wallet = useWallet().state.wallet
   const { assetSearch } = useModal()
   const { handleAssetClick } = useTradeRoutes()
+
+  useEffect(() => {
+    trigger(SendFormFields.Input)
+  }, [trigger])
+
+  useEffect(() => {
+    setValue(SendFormFields.Input, '')
+  }, [buyAsset])
 
   // Selectors
   const assets = useAppSelector(selectAssets)
@@ -451,9 +456,10 @@ export const TradeInput = () => {
           assetSymbol: sellAsset?.symbol ?? translate('trade.errors.sellAssetStartSentence'),
         },
       ]
+
     if (
-      (!walletSupportsBuyAssetChain && !receiveAddress) ||
-      manualAddressEntryErrors?.input?.type?.toString() === 'required'
+      !walletSupportsBuyAssetChain &&
+      (!receiveAddress || manualAddressEntryErrors?.input?.type?.toString() === 'required')
     )
       return [
         'trade.errors.manualReceiveAddressRequired',

--- a/src/components/Trade/TradeInput.tsx
+++ b/src/components/Trade/TradeInput.tsx
@@ -31,7 +31,10 @@ import { useFeatureFlag } from 'hooks/useFeatureFlag/useFeatureFlag'
 import { useModal } from 'hooks/useModal/useModal'
 import { useToggle } from 'hooks/useToggle/useToggle'
 import { useWallet } from 'hooks/useWallet/useWallet'
-import { walletSupportsChain } from 'hooks/useWalletSupportsChain/useWalletSupportsChain'
+import {
+  useWalletSupportsBuyAsset,
+  useWalletSupportsSellAsset,
+} from 'hooks/useWalletSupportsChain/useWalletSupportsChain'
 import { parseAddressInput } from 'lib/address/address'
 import type { Asset } from 'lib/asset-service'
 import { bn, bnOrZero, positiveOrZero } from 'lib/bignumber/bignumber'
@@ -218,12 +221,11 @@ export const TradeInput = () => {
     )
   }, [buyAsset?.assetId, activeQuote, sellAsset?.assetId])
 
+  const walletSupportsSellAssetChain = useWalletSupportsSellAsset()
+  const walletSupportsBuyAssetChain = useWalletSupportsBuyAsset()
+
   // Constants
-  const walletSupportsSellAssetChain = walletSupportsChain({ wallet, chainId: sellAsset?.chainId })
-
-  const walletSupportsBuyAssetChain = walletSupportsChain({ wallet, chainId: buyAsset?.chainId })
   const shouldShowManualReceiveAddressInput = !walletSupportsBuyAssetChain
-
   const walletSupportsTradeAssetChains = walletSupportsBuyAssetChain && walletSupportsSellAssetChain
 
   const gasFeeFiat = bnOrZero(fees?.networkFeeCryptoHuman)

--- a/src/components/Trade/TradeInput.tsx
+++ b/src/components/Trade/TradeInput.tsx
@@ -468,6 +468,13 @@ export const TradeInput = () => {
     if (formErrors.input?.message && !walletSupportsBuyAssetChain) {
       return formErrors.input?.message.toString()
     }
+    if (!receiveAddress)
+      return [
+        'trade.errors.noReceiveAddress',
+        {
+          assetSymbol: buyAsset?.symbol ?? translate('trade.errors.buyAssetMiddleSentence'),
+        },
+      ]
     if (!activeSwapper) return 'trade.errors.invalidTradePairBtnText'
     if (!isTradingActiveOnSellPool && activeSwapper.name === SwapperName.Thorchain) {
       return [
@@ -512,13 +519,6 @@ export const TradeInput = () => {
     }
     if (feesExceedsSellAmount) return 'trade.errors.sellAmountDoesNotCoverFee'
     if (isTradeQuotePending && quoteAvailableForCurrentAssetPair) return 'trade.updatingQuote'
-    if (!receiveAddress)
-      return [
-        'trade.errors.noReceiveAddress',
-        {
-          assetSymbol: buyAsset?.symbol ?? translate('trade.errors.buyAssetMiddleSentence'),
-        },
-      ]
 
     return 'trade.previewTrade'
   }, [

--- a/src/components/Trade/TradeInput.tsx
+++ b/src/components/Trade/TradeInput.tsx
@@ -654,7 +654,7 @@ export const TradeInput = () => {
               },
             },
           }}
-          isYatSupported={true}
+          isYatSupported={isYatSupported}
         />
       </FormControl>
     )

--- a/src/components/Trade/TradeInput.tsx
+++ b/src/components/Trade/TradeInput.tsx
@@ -112,9 +112,9 @@ export const TradeInput = () => {
   const isYatFeatureEnabled = useFeatureFlag('Yat')
 
   const {
-    formState: { errors: manualAddressEntryErrors },
-    trigger: manualAddressEntryValidationTrigger,
-    setValue: setManualReceiveAddressValue,
+    formState: { errors: formErrors },
+    trigger: formTrigger,
+    setValue: setFormValue,
   } = useFormContext()
 
   const { isTradingActiveOnSellPool, isTradingActiveOnBuyPool } = useIsTradingActive()
@@ -172,13 +172,13 @@ export const TradeInput = () => {
 
   // Trigger re-validation of the manually entered receive address
   useEffect(() => {
-    manualAddressEntryValidationTrigger(SendFormFields.Input)
-  }, [manualAddressEntryValidationTrigger])
+    formTrigger(SendFormFields.Input)
+  }, [formTrigger])
 
   // Reset the manual address input state when the user changes the buy asset
   useEffect(() => {
-    setManualReceiveAddressValue(SendFormFields.Input, '')
-  }, [buyAsset, setManualReceiveAddressValue])
+    setFormValue(SendFormFields.Input, '')
+  }, [buyAsset, setFormValue])
 
   // Selectors
   const assets = useAppSelector(selectAssets)
@@ -213,8 +213,8 @@ export const TradeInput = () => {
     selectPortfolioCryptoPrecisionBalanceByFilter(state, sellAssetBalanceFilter),
   )
 
-  const doesReceiveChainSupportYat = buyAsset.chainId === ethChainId // yat only supports eth mainnet
-  const isYatSupported = isYatFeatureEnabled && doesReceiveChainSupportYat
+  const isYatSupportedByReceiveChain = buyAsset.chainId === ethChainId // yat only supports eth mainnet
+  const isYatSupported = isYatFeatureEnabled && isYatSupportedByReceiveChain
 
   const buyAssetBalanceCryptoBaseUnit = useAppSelector(state =>
     selectPortfolioCryptoBalanceBaseUnitByFilter(state, buyAssetBalanceFilter),
@@ -457,13 +457,13 @@ export const TradeInput = () => {
         },
       ]
 
-    if (manualAddressEntryErrors.input?.message && !walletSupportsBuyAssetChain) {
-      return manualAddressEntryErrors.input?.message.toString()
+    if (formErrors.input?.message && !walletSupportsBuyAssetChain) {
+      return formErrors.input?.message.toString()
     }
 
     if (
       !walletSupportsBuyAssetChain &&
-      (!receiveAddress || manualAddressEntryErrors?.input?.type?.toString() === 'required')
+      (!receiveAddress || formErrors?.input?.type?.toString() === 'required')
     )
       return [
         'trade.errors.manualReceiveAddressRequired',
@@ -544,8 +544,8 @@ export const TradeInput = () => {
     translate,
     walletSupportsBuyAssetChain,
     receiveAddress,
-    manualAddressEntryErrors.input?.type,
-    manualAddressEntryErrors.input?.message,
+    formErrors.input?.type,
+    formErrors.input?.message,
     buyAsset.symbol,
     buyAsset.chainId,
     activeSwapper,
@@ -632,7 +632,6 @@ export const TradeInput = () => {
           {translate('trade.receiveAddress')}
         </FormLabel>
         <AddressInput
-          showQr={false}
           rules={{
             required: true,
             validate: {

--- a/src/components/Trade/TradeInput.tsx
+++ b/src/components/Trade/TradeInput.tsx
@@ -640,6 +640,7 @@ export const TradeInput = () => {
             required: true,
             validate: {
               validateAddress: async (rawInput: string) => {
+                updateReceiveAddress(undefined)
                 const value = rawInput.trim() // trim leading/trailing spaces
                 setIsManualAddressEntryValidating(true)
                 const { assetId, chainId } = buyAsset

--- a/src/components/Trade/TradeInput.tsx
+++ b/src/components/Trade/TradeInput.tsx
@@ -116,8 +116,8 @@ export const TradeInput = () => {
 
   const {
     formState: { errors: manualAddressEntryErrors },
-    trigger,
-    setValue,
+    trigger: manualAddressEntryValidationTrigger,
+    setValue: setManualReceiveAddressValue,
   } = useFormContext()
 
   const { isTradingActiveOnSellPool, isTradingActiveOnBuyPool } = useIsTradingActive()
@@ -174,13 +174,13 @@ export const TradeInput = () => {
 
   // Trigger re-validation of the manually entered receive address
   useEffect(() => {
-    trigger(SendFormFields.Input)
-  }, [trigger])
+    manualAddressEntryValidationTrigger(SendFormFields.Input)
+  }, [manualAddressEntryValidationTrigger])
 
   // Reset the manual address input state when the user changes the buy asset
   useEffect(() => {
-    setValue(SendFormFields.Input, '')
-  }, [buyAsset, setValue])
+    setManualReceiveAddressValue(SendFormFields.Input, '')
+  }, [buyAsset, setManualReceiveAddressValue])
 
   // Selectors
   const assets = useAppSelector(selectAssets)

--- a/src/components/Trade/TradeInput.tsx
+++ b/src/components/Trade/TradeInput.tsx
@@ -179,7 +179,7 @@ export const TradeInput = () => {
   // Reset the manual address input state when the user changes the buy asset
   useEffect(() => {
     setFormValue(SendFormFields.Input, '')
-  }, [buyAsset, setFormValue])
+  }, [buyAsset.assetId, setFormValue])
 
   // Selectors
   const assets = useAppSelector(selectAssets)

--- a/src/components/Trade/hooks/useSwapper/useSwapper.tsx
+++ b/src/components/Trade/hooks/useSwapper/useSwapper.tsx
@@ -4,7 +4,7 @@ import { useSelector } from 'react-redux'
 import { useDonationAmountBelowMinimum } from 'components/Trade/hooks/useDonationAmountBelowMinimum'
 import { getSwapperManager } from 'components/Trade/hooks/useSwapper/swapperManager'
 import { useWallet } from 'hooks/useWallet/useWallet'
-import { useWalletSupportsBuyAsset } from 'hooks/useWalletSupportsChain/useWalletSupportsChain'
+import { walletSupportsChain } from 'hooks/useWalletSupportsChain/useWalletSupportsChain'
 import type { SwapperManager } from 'lib/swapper/manager/SwapperManager'
 import { selectFeatureFlags } from 'state/slices/preferencesSlice/selectors'
 import {
@@ -41,7 +41,6 @@ export const useSwapper = () => {
   const sellAsset = useSwapperStore(selectSellAsset)
   const getTradeForWallet = useSwapperStore(selectGetTradeForWallet)
   const defaultAffiliateBps = useSwapperStore(selectSwapperDefaultAffiliateBps)
-  const walletSupportsBuyAsset = useWalletSupportsBuyAsset()
 
   // Selectors
   const flags = useSelector(selectFeatureFlags)
@@ -126,6 +125,7 @@ export const useSwapper = () => {
     async ({ affiliateBps }: { affiliateBps?: string } = {}) => {
       if (!wallet) throw new Error('no wallet available')
       if (!sellAccountBip44Params) throw new Error('Missing sellAccountBip44Params')
+      const walletSupportsBuyAsset = walletSupportsChain({ chainId: buyAsset.chainId, wallet })
       if (!buyAccountBip44Params && walletSupportsBuyAsset)
         throw new Error('Missing buyAccountBip44Params')
       if (!sellAccountMetadata) throw new Error('Missing sellAccountMetadata')
@@ -142,8 +142,8 @@ export const useSwapper = () => {
     [
       wallet,
       sellAccountBip44Params,
+      buyAsset.chainId,
       buyAccountBip44Params,
-      walletSupportsBuyAsset,
       sellAccountMetadata,
       getTradeForWallet,
       isDonationAmountBelowMinimum,

--- a/src/components/Trade/hooks/useSwapper/useSwapper.tsx
+++ b/src/components/Trade/hooks/useSwapper/useSwapper.tsx
@@ -4,6 +4,7 @@ import { useSelector } from 'react-redux'
 import { useDonationAmountBelowMinimum } from 'components/Trade/hooks/useDonationAmountBelowMinimum'
 import { getSwapperManager } from 'components/Trade/hooks/useSwapper/swapperManager'
 import { useWallet } from 'hooks/useWallet/useWallet'
+import { useWalletSupportsBuyAsset } from 'hooks/useWalletSupportsChain/useWalletSupportsChain'
 import type { SwapperManager } from 'lib/swapper/manager/SwapperManager'
 import { selectFeatureFlags } from 'state/slices/preferencesSlice/selectors'
 import {
@@ -40,6 +41,7 @@ export const useSwapper = () => {
   const sellAsset = useSwapperStore(selectSellAsset)
   const getTradeForWallet = useSwapperStore(selectGetTradeForWallet)
   const defaultAffiliateBps = useSwapperStore(selectSwapperDefaultAffiliateBps)
+  const walletSupportsBuyAsset = useWalletSupportsBuyAsset()
 
   // Selectors
   const flags = useSelector(selectFeatureFlags)
@@ -124,7 +126,8 @@ export const useSwapper = () => {
     async ({ affiliateBps }: { affiliateBps?: string } = {}) => {
       if (!wallet) throw new Error('no wallet available')
       if (!sellAccountBip44Params) throw new Error('Missing sellAccountBip44Params')
-      if (!buyAccountBip44Params) throw new Error('Missing buyAccountBip44Params')
+      if (!buyAccountBip44Params && walletSupportsBuyAsset)
+        throw new Error('Missing buyAccountBip44Params')
       if (!sellAccountMetadata) throw new Error('Missing sellAccountMetadata')
 
       const trade = await getTradeForWallet({
@@ -140,6 +143,7 @@ export const useSwapper = () => {
       wallet,
       sellAccountBip44Params,
       buyAccountBip44Params,
+      walletSupportsBuyAsset,
       sellAccountMetadata,
       getTradeForWallet,
       isDonationAmountBelowMinimum,

--- a/src/hooks/useWalletSupportsChain/useWalletSupportsChain.ts
+++ b/src/hooks/useWalletSupportsChain/useWalletSupportsChain.ts
@@ -25,10 +25,7 @@ import {
   supportsPolygon,
   supportsThorchain,
 } from '@shapeshiftoss/hdwallet-core'
-import { useWallet } from 'hooks/useWallet/useWallet'
 import { logger } from 'lib/logger'
-import { selectBuyAsset, selectSellAsset } from 'state/zustand/swapperStore/selectors'
-import { useSwapperStore } from 'state/zustand/swapperStore/useSwapperStore'
 
 const moduleLogger = logger.child({ namespace: ['useWalletSupportsChain'] })
 
@@ -65,18 +62,6 @@ export const walletSupportsChain: UseWalletSupportsChain = ({ chainId, wallet })
       return false
     }
   }
-}
-
-export const useWalletSupportsBuyAsset = () => {
-  const buyAssetChainId = useSwapperStore(selectBuyAsset).chainId
-  const wallet = useWallet().state.wallet
-  return walletSupportsChain({ chainId: buyAssetChainId, wallet })
-}
-
-export const useWalletSupportsSellAsset = () => {
-  const sellAssetChainId = useSwapperStore(selectSellAsset).chainId
-  const wallet = useWallet().state.wallet
-  return walletSupportsChain({ chainId: sellAssetChainId, wallet })
 }
 
 // TODO(0xdef1cafe): this whole thing should belong in chain adapters

--- a/src/hooks/useWalletSupportsChain/useWalletSupportsChain.ts
+++ b/src/hooks/useWalletSupportsChain/useWalletSupportsChain.ts
@@ -25,7 +25,11 @@ import {
   supportsPolygon,
   supportsThorchain,
 } from '@shapeshiftoss/hdwallet-core'
+import { useWallet } from 'hooks/useWallet/useWallet'
 import { logger } from 'lib/logger'
+import { selectBuyAsset, selectSellAsset } from 'state/zustand/swapperStore/selectors'
+import { useSwapperStore } from 'state/zustand/swapperStore/useSwapperStore'
+
 const moduleLogger = logger.child({ namespace: ['useWalletSupportsChain'] })
 
 type UseWalletSupportsChainArgs = { chainId: ChainId; wallet: HDWallet | null }
@@ -61,6 +65,18 @@ export const walletSupportsChain: UseWalletSupportsChain = ({ chainId, wallet })
       return false
     }
   }
+}
+
+export const useWalletSupportsBuyAsset = () => {
+  const buyAssetChainId = useSwapperStore(selectBuyAsset).chainId
+  const wallet = useWallet().state.wallet
+  return walletSupportsChain({ chainId: buyAssetChainId, wallet })
+}
+
+export const useWalletSupportsSellAsset = () => {
+  const sellAssetChainId = useSwapperStore(selectSellAsset).chainId
+  const wallet = useWallet().state.wallet
+  return walletSupportsChain({ chainId: sellAssetChainId, wallet })
 }
 
 // TODO(0xdef1cafe): this whole thing should belong in chain adapters

--- a/src/lib/address/address.ts
+++ b/src/lib/address/address.ts
@@ -263,7 +263,7 @@ type ParseAddressInputArgs = {
  * and a chainId, return an object containing and address and vanityAddress
  * which may both be empty strings, one may be empty, or both may be populated
  */
-export type ParseAddressByChainIdInputArgs = ParseAddressInputArgs & {
+type ParseAddressByChainIdInputArgs = ParseAddressInputArgs & {
   chainId: ChainId
 }
 

--- a/src/state/zustand/swapperStore/selectors.ts
+++ b/src/state/zustand/swapperStore/selectors.ts
@@ -121,7 +121,7 @@ export const selectCheckApprovalNeededForWallet = (
 type SelectGetTradeForWalletArgs = {
   wallet: HDWallet
   sellAccountBip44Params: BIP44Params
-  buyAccountBip44Params: BIP44Params
+  buyAccountBip44Params?: BIP44Params
   sellAccountMetadata: AccountMetadata
   affiliateBps: string
 }
@@ -194,7 +194,7 @@ export const selectGetTradeForWallet = (
         ...buildTradeCommonArgs,
         chainId: sellAsset.chainId,
         accountNumber: sellAccountBip44Params.accountNumber,
-        receiveAccountNumber: buyAccountBip44Params.accountNumber,
+        receiveAccountNumber: buyAccountBip44Params?.accountNumber,
       })
     } else {
       throw new Error('unsupported sellAsset.chainId')


### PR DESCRIPTION
## Description

- Adds the ability to manually enter a receive address when trading into an asset that is not supported by the connected wallet (e.g. ETH into DOGE on MetaMask)
- Validates that the receive asset is valid on the receiving chain
- Supports yatt addresses when the receiving chain is ETH (not a case we currently require, but it's there nonetheless)
- Supports ENS/unstoppable domain resolution

First successful TX with manual receive address: https://viewblock.io/thorchain/tx/1C9A199669FCD8D21F2EE20EFA91A6A20D5183A84749A96795E8F54BCC2A6C57

## Pull Request Type

- [ ] :bug: Bug fix (Non-breaking Change: Fixes an issue)
- [ ] :hammer_and_wrench: Chore (Non-breaking Change: Doc updates, pkg upgrades, typos, etc..)
- [x] :nail_care: New Feature (Breaking/Non-breaking Change)

## Issue (if applicable)

Closes https://github.com/shapeshift/web/issues/2168

## Risk

🌶️ Very high. 

It's a simple PR in many ways, but getting this wrong could mean loss of funds for the user if the funds are send to the wrong/invalid address.

## Testing

- Test sending into assets not supported by the connected wallet and ensure that the funds are received into the specified address.
- Ensure invalid addresses cannot be entered
- Ensure both ENS and unstoppable domain addresses work as expected

Try break it. Switch between supported and non-supported receive assets. Enter valid and invalid addresses.

Also sanity check regular asset sends still work, as I modified the send input component to make it more generic.

### Engineering

☝️

- Check that the `receiveAddress` in the Swapper Redux store is _always_ exactly what we expect.
- Check that the quote and trade requests are using the correct address in the "destination" address.

This is not a feature we can afford to get wrong - scrutinise the code accordingly.

### Operations

☝️

## Screenshots (if applicable)

<img width="473" alt="Screenshot 2023-05-11 at 3 17 33 pm" src="https://github.com/shapeshift/web/assets/97164662/a8360097-1616-45ba-8e0f-0ee5b6dee7c7">

<img width="480" alt="Screenshot 2023-05-11 at 3 19 41 pm" src="https://github.com/shapeshift/web/assets/97164662/ceeab702-cf5c-42da-9e98-b58288b53c71">

<img width="480" alt="Screenshot 2023-05-11 at 3 20 14 pm" src="https://github.com/shapeshift/web/assets/97164662/af24182f-7bf1-4b4d-b71f-8f2252bfde33">

