### PR TITLE
fix: handle insufficient balance on receiving chain (for protocol fees)

### DIFF
--- a/src/assets/translations/en/main.json
+++ b/src/assets/translations/en/main.json
@@ -732,10 +732,8 @@
     "swappingComingSoonForWallet": "Swapping for %{walletName} is coming soon",
     "recentTrades": "Recent Trades",
     "lifiWarning": "This trade routes via LI.FI, which executes a series of intermediary trades to perform a swap. If any steps fail you'll receive the token for the last successful step in the sequence.",
-    "intermediaryTransactionOutputs": {
-      "prefix": "or",
-      "suffix": "on %{chainName}"
-    },
+    "or": "or",
+    "onChainName": "on %{chainName}",
     "unknownGas": "(unknown)"
   },
   "modals": {

--- a/src/assets/translations/en/main.json
+++ b/src/assets/translations/en/main.json
@@ -695,6 +695,7 @@
       "broadcastFailed": "An error occurred while broadcasting the transaction",
       "insufficientFundsForLimit": "Insufficient funds. The minimum trade amount for this pair is %{minLimit}",
       "insufficientFundsForAmount": "Insufficient funds. Your %{symbol} balance is less than the selected amount",
+      "insufficientFundsForProtocolFee": "Insufficient %{symbol} on %{chainName} for fees",
       "invalidTradePair": "Invalid trade pair: %{sellAssetName} and %{buyAssetName}",
       "invalidTradePairBtnText": "Invalid Trade Pair",
       "noLiquidityError": "Not enough liquidity available",

--- a/src/components/Trade/Components/TradeQuotes/TradeQuotes.tsx
+++ b/src/components/Trade/Components/TradeQuotes/TradeQuotes.tsx
@@ -37,6 +37,7 @@ export const TradeQuotes: React.FC<TradeQuotesProps> = ({ isOpen, isLoading }) =
       : undefined
   const bestTotalReceiveAmountCryptoPrecision = bestBuyAssetTradeFeeCryptoPrecision
     ? bnOrZero(bestBuyAmountCryptoPrecisionAfterSlippage)
+        // TODO: determine why not subtracting bestSelllAssetTradeFeeCryptoPrecision
         .minus(bestBuyAssetTradeFeeCryptoPrecision)
         .toString()
     : undefined

--- a/src/components/Trade/TradeConfirm/ReceiveSummary.tsx
+++ b/src/components/Trade/TradeConfirm/ReceiveSummary.tsx
@@ -7,7 +7,6 @@ import {
   useColorModeValue,
   useDisclosure,
 } from '@chakra-ui/react'
-import type { ChainAdapterManager } from '@shapeshiftoss/chain-adapters'
 import { type FC, useMemo } from 'react'
 import { useTranslate } from 'react-polyglot'
 import { Amount } from 'components/Amount/Amount'
@@ -33,13 +32,11 @@ type ReceiveSummaryProps = {
   swapperName: string
 } & RowProps
 
-const parseAmountDisplayMeta =
-  (chainAdapterManager: ChainAdapterManager) =>
-  ({ amountCryptoBaseUnit, asset }: AmountDisplayMeta) => ({
-    symbol: asset.symbol,
-    chainName: chainAdapterManager.get(asset.chainId)?.getDisplayName(),
-    amountCryptoPrecision: fromBaseUnit(amountCryptoBaseUnit, asset.precision),
-  })
+const parseAmountDisplayMeta = ({ amountCryptoBaseUnit, asset }: AmountDisplayMeta) => ({
+  symbol: asset.symbol,
+  chainName: getChainAdapterManager().get(asset.chainId)?.getDisplayName(),
+  amountCryptoPrecision: fromBaseUnit(amountCryptoBaseUnit, asset.precision),
+})
 
 export const ReceiveSummary: FC<ReceiveSummaryProps> = ({
   symbol,
@@ -63,8 +60,6 @@ export const ReceiveSummary: FC<ReceiveSummaryProps> = ({
   const greenColor = useColorModeValue('green.600', 'green.200')
   const textColor = useColorModeValue('gray.800', 'whiteAlpha.900')
 
-  const chainAdapterManager = getChainAdapterManager()
-
   const slippageAsPercentageString = bnOrZero(slippage).times(100).toString()
   const isAmountPositive = bnOrZero(amountCryptoPrecision).gt(0)
 
@@ -72,16 +67,16 @@ export const ReceiveSummary: FC<ReceiveSummaryProps> = ({
     () =>
       protocolFees
         ?.filter(({ amountCryptoBaseUnit }) => bnOrZero(amountCryptoBaseUnit).gt(0))
-        .map(parseAmountDisplayMeta(chainAdapterManager)),
-    [chainAdapterManager, protocolFees],
+        .map(parseAmountDisplayMeta),
+    [protocolFees],
   )
 
   const intermediaryTransactionOutputsParsed = useMemo(
     () =>
       intermediaryTransactionOutputs
         ?.filter(({ amountCryptoBaseUnit }) => bnOrZero(amountCryptoBaseUnit).gt(0))
-        .map(parseAmountDisplayMeta(chainAdapterManager)),
-    [chainAdapterManager, intermediaryTransactionOutputs],
+        .map(parseAmountDisplayMeta),
+    [intermediaryTransactionOutputs],
   )
 
   const hasProtocolFees = useMemo(

--- a/src/components/Trade/TradeConfirm/ReceiveSummary.tsx
+++ b/src/components/Trade/TradeConfirm/ReceiveSummary.tsx
@@ -35,10 +35,10 @@ type ReceiveSummaryProps = {
 
 const parseAmountDisplayMeta =
   (chainAdapterManager: ChainAdapterManager) =>
-  ({ amountCryptoBaseUnit, symbol, chainId, precision }: AmountDisplayMeta) => ({
-    symbol,
-    chainName: chainAdapterManager.get(chainId)?.getDisplayName(),
-    amountCryptoPrecision: fromBaseUnit(amountCryptoBaseUnit, precision),
+  ({ amountCryptoBaseUnit, asset }: AmountDisplayMeta) => ({
+    symbol: asset.symbol,
+    chainName: chainAdapterManager.get(asset.chainId)?.getDisplayName(),
+    amountCryptoPrecision: fromBaseUnit(amountCryptoBaseUnit, asset.precision),
   })
 
 export const ReceiveSummary: FC<ReceiveSummaryProps> = ({

--- a/src/components/Trade/TradeConfirm/TradeConfirm.tsx
+++ b/src/components/Trade/TradeConfirm/TradeConfirm.tsx
@@ -31,7 +31,6 @@ import { SlideTransition } from 'components/SlideTransition'
 import { RawText, Text } from 'components/Text'
 import { useDonationAmountBelowMinimum } from 'components/Trade/hooks/useDonationAmountBelowMinimum'
 import { useSwapper } from 'components/Trade/hooks/useSwapper/useSwapper'
-import { getChainAdapterManager } from 'context/PluginProvider/chainAdapterSingleton'
 import { WalletActions } from 'context/WalletProvider/actions'
 import { useErrorHandler } from 'hooks/useErrorToast/useErrorToast'
 import { useLocaleFormatter } from 'hooks/useLocaleFormatter/useLocaleFormatter'
@@ -56,10 +55,10 @@ import {
   selectDonationAmountFiat,
   selectFeeAssetFiatRate,
   selectIntermediaryTransactionOutputs,
+  selectProtocolFees,
   selectQuoteBuyAmountCryptoPrecision,
   selectSellAmountBeforeFeesBaseUnitByAction,
   selectSellAmountBeforeFeesFiat,
-  selectTotalTradeFeeBuyAssetCryptoPrecision,
 } from 'state/zustand/swapperStore/amountSelectors'
 import {
   selectBuyAmountCryptoPrecision,
@@ -117,16 +116,14 @@ export const TradeConfirm = () => {
   const buyAssetAccountId = useSwapperStore(selectBuyAssetAccountId)
   const sellAssetAccountId = useSwapperStore(selectSellAssetAccountId)
   const buyAmountCryptoPrecision = useSwapperStore(selectBuyAmountCryptoPrecision)
-  const intermediaryTransactionOutputsCryptoPrecision = useSwapperStore(
+  const intermediaryTransactionOutputsCryptoBaseUnit = useSwapperStore(
     selectIntermediaryTransactionOutputs,
   )
   const updateTrade = useSwapperStore(state => state.updateTrade)
   const sellAmountBeforeFeesBaseUnit = useSwapperStore(selectSellAmountBeforeFeesBaseUnitByAction)
   const sellAmountBeforeFeesFiat = useSwapperStore(selectSellAmountBeforeFeesFiat)
   const quoteBuyAmountCryptoPrecision = useSwapperStore(selectQuoteBuyAmountCryptoPrecision)
-  const totalTradeFeeBuyAssetCryptoPrecision = useSwapperStore(
-    selectTotalTradeFeeBuyAssetCryptoPrecision,
-  )
+  const protocolFees = useSwapperStore(selectProtocolFees)
   const fiatBuyAmount = useSwapperStore(selectBuyAmountFiat)
   const buyAmountBeforeFeesBaseUnit = useSwapperStore(selectBuyAmountBeforeFeesBaseUnit)
 
@@ -247,17 +244,6 @@ export const TradeConfirm = () => {
         tradeId: sellTradeId,
       }),
     [sellTradeId, trade],
-  )
-
-  const chainAdapterManager = getChainAdapterManager()
-  const intermediaryTransactionOutputs = useMemo(
-    () =>
-      intermediaryTransactionOutputsCryptoPrecision?.map(({ buyAmountCryptoBaseUnit, asset }) => ({
-        amount: fromBaseUnit(buyAmountCryptoBaseUnit, asset.precision),
-        symbol: asset.symbol,
-        chainName: chainAdapterManager.get(asset.chainId)?.getDisplayName(),
-      })),
-    [intermediaryTransactionOutputsCryptoPrecision, chainAdapterManager],
   )
 
   const { showErrorToast } = useErrorHandler()
@@ -502,15 +488,15 @@ export const TradeConfirm = () => {
           </Row>
           <ReceiveSummary
             symbol={trade.buyAsset.symbol ?? ''}
-            amount={buyAmountCryptoPrecision ?? ''}
-            beforeFees={quoteBuyAmountCryptoPrecision ?? ''}
-            protocolFee={totalTradeFeeBuyAssetCryptoPrecision ?? ''}
+            amountCryptoPrecision={buyAmountCryptoPrecision ?? ''}
+            amountBeforeFeesCryptoPrecision={quoteBuyAmountCryptoPrecision ?? ''}
+            protocolFees={protocolFees}
             shapeShiftFee='0'
             slippage={slippage}
             fiatAmount={positiveOrZero(fiatBuyAmount).toFixed(2)}
             swapperName={swapper?.name ?? ''}
             isLoading={isReloadingTrade}
-            intermediaryTransactionOutputs={intermediaryTransactionOutputs}
+            intermediaryTransactionOutputs={intermediaryTransactionOutputsCryptoBaseUnit}
           />
         </Stack>
       ) : null,
@@ -521,12 +507,12 @@ export const TradeConfirm = () => {
       sellAmountBeforeFeesFiat,
       buyAmountCryptoPrecision,
       quoteBuyAmountCryptoPrecision,
-      totalTradeFeeBuyAssetCryptoPrecision,
+      protocolFees,
       slippage,
       fiatBuyAmount,
       swapper?.name,
       isReloadingTrade,
-      intermediaryTransactionOutputs,
+      intermediaryTransactionOutputsCryptoBaseUnit,
     ],
   )
 

--- a/src/components/Trade/TradeInput.tsx
+++ b/src/components/Trade/TradeInput.tsx
@@ -48,9 +48,9 @@ import { useAppDispatch, useAppSelector } from 'state/store'
 import {
   selectBuyAssetFiatRate,
   selectFeeAssetFiatRate,
+  selectProtocolFees,
   selectQuoteBuyAmountCryptoPrecision,
   selectSellAssetFiatRate,
-  selectTotalTradeFeeBuyAssetCryptoPrecision,
 } from 'state/zustand/swapperStore/amountSelectors'
 import {
   selectAction,
@@ -131,9 +131,7 @@ export const TradeInput = () => {
   const handleSwitchAssets = useSwapperStore(state => state.handleSwitchAssets)
   const handleInputAmountChange = useSwapperStore(state => state.handleInputAmountChange)
   const quoteBuyAmountCryptoPrecision = useSwapperStore(selectQuoteBuyAmountCryptoPrecision)
-  const totalTradeFeeBuyAssetCryptoPrecision = useSwapperStore(
-    selectTotalTradeFeeBuyAssetCryptoPrecision,
-  )
+  const protocolFees = useSwapperStore(selectProtocolFees)
   const action = useSwapperStore(selectAction)
   const amount = useSwapperStore(selectAmount)
   const isSendMax = useSwapperStore(selectIsSendMax)
@@ -654,9 +652,9 @@ export const TradeInput = () => {
             <ReceiveSummary
               isLoading={tradeStateLoading}
               symbol={buyAsset?.symbol ?? ''}
-              amount={buyAmountCryptoPrecision ?? ''}
-              beforeFees={quoteBuyAmountCryptoPrecision ?? ''}
-              protocolFee={totalTradeFeeBuyAssetCryptoPrecision ?? ''}
+              amountCryptoPrecision={buyAmountCryptoPrecision ?? ''}
+              amountBeforeFeesCryptoPrecision={quoteBuyAmountCryptoPrecision ?? ''}
+              protocolFees={protocolFees}
               shapeShiftFee='0'
               slippage={slippage}
               swapperName={swapperName}

--- a/src/lib/swapper/api.ts
+++ b/src/lib/swapper/api.ts
@@ -138,8 +138,9 @@ export type BuildTradeInput = GetTradeQuoteInput & {
   wallet: HDWallet
 }
 
-export type AmountDisplayMeta = Pick<Asset, 'assetId' | 'symbol' | 'chainId' | 'precision'> & {
+export type AmountDisplayMeta = {
   amountCryptoBaseUnit: string
+  asset: Pick<Asset, 'symbol' | 'chainId' | 'precision'>
 }
 
 interface TradeBase<C extends ChainId, MissingNetworkFee extends boolean = false> {

--- a/src/lib/swapper/api.ts
+++ b/src/lib/swapper/api.ts
@@ -138,11 +138,8 @@ export type BuildTradeInput = GetTradeQuoteInput & {
   wallet: HDWallet
 }
 
-// describes intermediary asset and amount the user may end up with in the event of a trade
-// execution failure
-export type IntermediaryTransactionOutput = {
-  asset: Pick<Asset, 'chainId' | 'symbol' | 'precision'>
-  buyAmountCryptoBaseUnit: string
+export type AmountDisplayMeta = Pick<Asset, 'assetId' | 'symbol' | 'chainId' | 'precision'> & {
+  amountCryptoBaseUnit: string
 }
 
 interface TradeBase<C extends ChainId, MissingNetworkFee extends boolean = false> {
@@ -154,7 +151,9 @@ interface TradeBase<C extends ChainId, MissingNetworkFee extends boolean = false
   buyAsset: Asset
   sellAsset: Asset
   accountNumber: number
-  intermediaryTransactionOutputs?: IntermediaryTransactionOutput[]
+  // describes intermediary asset and amount the user may end up with in the event of a trade
+  // execution failure
+  intermediaryTransactionOutputs?: AmountDisplayMeta[]
 }
 
 export interface TradeQuote<C extends ChainId, UnknownNetworkFee extends boolean = false>

--- a/src/lib/swapper/swappers/LifiSwapper/utils/getIntermediaryTransactionOutputs/getIntermediaryTransactionOutputs.test.ts
+++ b/src/lib/swapper/swappers/LifiSwapper/utils/getIntermediaryTransactionOutputs/getIntermediaryTransactionOutputs.test.ts
@@ -27,8 +27,8 @@ describe('getIntermediaryTransactionOutputs', () => {
     expect(usdcOnOptimism).not.toBe(undefined)
 
     const expectation: AmountDisplayMeta[] = [
-      { ...usdcOnEthereum, amountCryptoBaseUnit: '120527596' },
-      { ...usdcOnOptimism, amountCryptoBaseUnit: '120328249' },
+      { asset: usdcOnEthereum, amountCryptoBaseUnit: '120527596' },
+      { asset: usdcOnOptimism, amountCryptoBaseUnit: '120328249' },
     ]
 
     expect(result).toEqual(expectation)

--- a/src/lib/swapper/swappers/LifiSwapper/utils/getIntermediaryTransactionOutputs/getIntermediaryTransactionOutputs.test.ts
+++ b/src/lib/swapper/swappers/LifiSwapper/utils/getIntermediaryTransactionOutputs/getIntermediaryTransactionOutputs.test.ts
@@ -1,6 +1,6 @@
 import type { Asset } from 'lib/asset-service'
 import { localAssetData } from 'lib/asset-service'
-import type { IntermediaryTransactionOutput } from 'lib/swapper/api'
+import type { AmountDisplayMeta } from 'lib/swapper/api'
 
 import { getIntermediaryTransactionOutputs } from './getIntermediaryTransactionOutputs'
 import { emptyLifiRouteSteps, multiStepLifiRouteSteps, singleStepLifiRouteSteps } from './testData'
@@ -26,9 +26,9 @@ describe('getIntermediaryTransactionOutputs', () => {
     expect(usdcOnEthereum).not.toBe(undefined)
     expect(usdcOnOptimism).not.toBe(undefined)
 
-    const expectation: IntermediaryTransactionOutput[] = [
-      { asset: usdcOnEthereum, buyAmountCryptoBaseUnit: '120527596' },
-      { asset: usdcOnOptimism, buyAmountCryptoBaseUnit: '120328249' },
+    const expectation: AmountDisplayMeta[] = [
+      { ...usdcOnEthereum, amountCryptoBaseUnit: '120527596' },
+      { ...usdcOnOptimism, amountCryptoBaseUnit: '120328249' },
     ]
 
     expect(result).toEqual(expectation)

--- a/src/lib/swapper/swappers/LifiSwapper/utils/getIntermediaryTransactionOutputs/getIntermediaryTransactionOutputs.ts
+++ b/src/lib/swapper/swappers/LifiSwapper/utils/getIntermediaryTransactionOutputs/getIntermediaryTransactionOutputs.ts
@@ -1,4 +1,5 @@
 import type { AmountDisplayMeta } from 'lib/swapper/api'
+import { isSome } from 'lib/utils'
 import { selectAssets } from 'state/slices/selectors'
 import { store } from 'state/store'
 
@@ -37,5 +38,5 @@ export const getIntermediaryTransactionOutputs = (
         amountCryptoBaseUnit: step.estimate.toAmountMin,
       }
     })
-    .filter((item): item is AmountDisplayMeta => item !== undefined)
+    .filter(isSome)
 }

--- a/src/lib/swapper/swappers/LifiSwapper/utils/getIntermediaryTransactionOutputs/getIntermediaryTransactionOutputs.ts
+++ b/src/lib/swapper/swappers/LifiSwapper/utils/getIntermediaryTransactionOutputs/getIntermediaryTransactionOutputs.ts
@@ -33,7 +33,7 @@ export const getIntermediaryTransactionOutputs = (
       }
 
       return {
-        ...asset,
+        asset,
         amountCryptoBaseUnit: step.estimate.toAmountMin,
       }
     })

--- a/src/lib/swapper/swappers/LifiSwapper/utils/getIntermediaryTransactionOutputs/getIntermediaryTransactionOutputs.ts
+++ b/src/lib/swapper/swappers/LifiSwapper/utils/getIntermediaryTransactionOutputs/getIntermediaryTransactionOutputs.ts
@@ -1,4 +1,4 @@
-import type { IntermediaryTransactionOutput } from 'lib/swapper/api'
+import type { AmountDisplayMeta } from 'lib/swapper/api'
 import { selectAssets } from 'state/slices/selectors'
 import { store } from 'state/store'
 
@@ -10,7 +10,7 @@ const isLifiStep = (step: StepSubset): step is LifiStepSubset => step.type === '
 
 export const getIntermediaryTransactionOutputs = (
   selectedLifiRouteSteps: StepSubset[],
-): IntermediaryTransactionOutput[] | undefined => {
+): AmountDisplayMeta[] | undefined => {
   const tradeSteps = selectedLifiRouteSteps.flatMap(step =>
     isLifiStep(step) ? step.includedSteps : step,
   )
@@ -33,9 +33,9 @@ export const getIntermediaryTransactionOutputs = (
       }
 
       return {
-        asset,
-        buyAmountCryptoBaseUnit: step.estimate.toAmountMin,
+        ...asset,
+        amountCryptoBaseUnit: step.estimate.toAmountMin,
       }
     })
-    .filter((item): item is IntermediaryTransactionOutput => item !== undefined)
+    .filter((item): item is AmountDisplayMeta => item !== undefined)
 }

--- a/src/state/zustand/swapperStore/amountSelectors.ts
+++ b/src/state/zustand/swapperStore/amountSelectors.ts
@@ -3,7 +3,7 @@ import { createSelector } from 'reselect'
 import { TradeAmountInputField } from 'components/Trade/types'
 import { bn, bnOrZero } from 'lib/bignumber/bignumber'
 import { fromBaseUnit, toBaseUnit } from 'lib/math'
-import type { IntermediaryTransactionOutput } from 'lib/swapper/api'
+import type { AmountDisplayMeta } from 'lib/swapper/api'
 import { createDeepEqualOutputSelector } from 'state/selector-utils'
 import { getFeeAssetByAssetId } from 'state/slices/assetsSlice/utils'
 import { selectAssets, selectCryptoMarketData, selectFiatToUsdRate } from 'state/slices/selectors'
@@ -165,7 +165,7 @@ export const selectBuyAmountBeforeFeesBuyAssetCryptoPrecision = createSelector(
   },
 )
 
-export const selectSellAssetTradeFeeSellAssetBaseUnit = createSelector(
+export const selectSellAssetTradeFeeCryptoBaseUnit = createSelector(
   selectSellAssetFiatRate,
   selectSelectedCurrencyToUsdRate,
   (state: SwapperState) => state.fees?.sellAssetTradeFeeUsd,
@@ -182,7 +182,7 @@ export const selectSellAssetTradeFeeSellAssetBaseUnit = createSelector(
   },
 )
 
-export const selectBuyAssetTradeFeeBuyAssetBaseUnit = createSelector(
+export const selectBuyAssetTradeFeeCryptoBaseUnit = createSelector(
   selectBuyAssetFiatRate,
   selectSelectedCurrencyToUsdRate,
   (state: SwapperState) => state.fees?.buyAssetTradeFeeUsd,
@@ -199,8 +199,39 @@ export const selectBuyAssetTradeFeeBuyAssetBaseUnit = createSelector(
   },
 )
 
+export const selectProtocolFees = createDeepEqualOutputSelector(
+  selectSellAsset,
+  selectBuyAsset,
+  selectSellAssetTradeFeeCryptoBaseUnit,
+  selectBuyAssetTradeFeeCryptoBaseUnit,
+  (
+    sellAsset,
+    buyAsset,
+    sellAssetTradeFeeCryptoBaseUnit,
+    buyAssetTradeFeeCryptoBaseUnit,
+  ): AmountDisplayMeta[] => {
+    const result = []
+
+    if (sellAssetTradeFeeCryptoBaseUnit) {
+      result.push({
+        ...sellAsset,
+        amountCryptoBaseUnit: sellAssetTradeFeeCryptoBaseUnit,
+      })
+    }
+
+    if (buyAssetTradeFeeCryptoBaseUnit) {
+      result.push({
+        ...buyAsset,
+        amountCryptoBaseUnit: buyAssetTradeFeeCryptoBaseUnit,
+      })
+    }
+
+    return result
+  },
+)
+
 export const selectSellAssetTradeFeeBuyAssetBaseUnit = createSelector(
-  selectSellAssetTradeFeeSellAssetBaseUnit,
+  selectSellAssetTradeFeeCryptoBaseUnit,
   selectAssetPriceRatio,
   (state: SwapperState) => state.sellAsset?.precision,
   (state: SwapperState) => state.buyAsset?.precision,
@@ -223,7 +254,7 @@ export const selectSellAssetTradeFeeBuyAssetBaseUnit = createSelector(
 )
 
 export const selectBuyAssetTradeFeeSellAssetBaseUnit = createSelector(
-  selectBuyAssetTradeFeeBuyAssetBaseUnit,
+  selectBuyAssetTradeFeeCryptoBaseUnit,
   selectAssetPriceRatio,
   (state: SwapperState) => state.sellAsset?.precision,
   (state: SwapperState) => state.buyAsset?.precision,
@@ -246,7 +277,7 @@ export const selectBuyAssetTradeFeeSellAssetBaseUnit = createSelector(
 )
 
 export const selectTotalTradeFeeSellAssetBaseUnit = createSelector(
-  selectSellAssetTradeFeeSellAssetBaseUnit,
+  selectSellAssetTradeFeeCryptoBaseUnit,
   selectBuyAssetTradeFeeSellAssetBaseUnit,
   (sellAssetTradeFeeSellAssetBaseUnit, buyAssetTradeFeeSellAssetBaseUnit): string | undefined => {
     if (!sellAssetTradeFeeSellAssetBaseUnit || !buyAssetTradeFeeSellAssetBaseUnit) return undefined
@@ -258,7 +289,7 @@ export const selectTotalTradeFeeSellAssetBaseUnit = createSelector(
 
 export const selectTotalTradeFeeBuyAssetBaseUnit = createSelector(
   selectSellAssetTradeFeeBuyAssetBaseUnit,
-  selectBuyAssetTradeFeeBuyAssetBaseUnit,
+  selectBuyAssetTradeFeeCryptoBaseUnit,
   (sellAssetTradeFeeBuyAssetBaseUnit, buyAssetTradeFeeBuyAssetBaseUnit): string | undefined => {
     if (!sellAssetTradeFeeBuyAssetBaseUnit || !buyAssetTradeFeeBuyAssetBaseUnit) return undefined
     return bnOrZero(sellAssetTradeFeeBuyAssetBaseUnit)
@@ -341,7 +372,7 @@ export const selectTradeOrQuoteBuyAmountCryptoBaseUnit = createSelector(
 
 export const selectQuoteSellAmountPlusFeesBaseUnit = createSelector(
   selectTradeOrQuoteSellAmountBeforeFeesCryptoBaseUnit,
-  selectSellAssetTradeFeeSellAssetBaseUnit,
+  selectSellAssetTradeFeeCryptoBaseUnit,
   (
     quoteSellAmountBeforeFeesSellAssetBaseUnit,
     sellAssetTradeFeeSellAssetBaseUnit,
@@ -496,7 +527,7 @@ export const selectTradeAmountsByActionAndAmount: Selector<
 )
 
 export const selectQuoteBuyAmountAfterFeesBaseUnit = createSelector(
-  selectBuyAssetTradeFeeBuyAssetBaseUnit,
+  selectBuyAssetTradeFeeCryptoBaseUnit,
   selectSellAssetTradeFeeBuyAssetBaseUnit,
   selectQuoteBuyAmountCryptoPrecision,
   (state: SwapperState) => state.buyAsset?.precision,
@@ -652,7 +683,7 @@ export const selectIntermediaryTransactionOutputs = createDeepEqualOutputSelecto
   (
     quoteIntermediaryTransactionOutputs,
     tradeIntermediaryTransactionOutputs,
-  ): IntermediaryTransactionOutput[] | undefined =>
+  ): AmountDisplayMeta[] | undefined =>
     // Use the trade amount if we have it, otherwise use the quote amount
     tradeIntermediaryTransactionOutputs ?? quoteIntermediaryTransactionOutputs,
 )

--- a/src/state/zustand/swapperStore/amountSelectors.ts
+++ b/src/state/zustand/swapperStore/amountSelectors.ts
@@ -214,14 +214,14 @@ export const selectProtocolFees = createDeepEqualOutputSelector(
 
     if (sellAssetTradeFeeCryptoBaseUnit) {
       result.push({
-        ...sellAsset,
+        asset: sellAsset,
         amountCryptoBaseUnit: sellAssetTradeFeeCryptoBaseUnit,
       })
     }
 
     if (buyAssetTradeFeeCryptoBaseUnit) {
       result.push({
-        ...buyAsset,
+        asset: buyAsset,
         amountCryptoBaseUnit: buyAssetTradeFeeCryptoBaseUnit,
       })
     }


### PR DESCRIPTION
## Description

Fixes dead click when attempting trades with insufficient balance for protocol fees on receiving chain.

## Pull Request Type

- [x] :bug: Bug fix (Non-breaking Change: Fixes an issue)
- [ ] :hammer_and_wrench: Chore (Non-breaking Change: Doc updates, pkg upgrades, typos, etc..)
- [ ] :nail_care: New Feature (Breaking/Non-breaking Change)

## Issue (if applicable)

closes #4350

## Risk

low risk of trades breaking.

## Testing

- check trades are unaffected
- check fee amounts are still correct
- check general warnings about invalid trade states are still correct
- check 2nd protocol fee is correct for `any -> matic on polygon` trades
- check insufficient balance warning is correct for protocol fees on receiving chain

### Engineering

Note that this is as pragmatic a solution as I could push without boiling the ocean. When we support multi-hop we'll need to remove the concept of `buyAssetTradeFeeUsd` and `sellAssetTradeFeeUsd` and instead return an array of fees since there will be intermediary fees in other tokens. This will be a fairly heavy lift in thor swapper but is pretty straight forwards otherwise.

### Operations

Please check #4350 to verify the issue is resolved.

## Screenshots (if applicable)
case with 2 protocol fees:
![image](https://github.com/shapeshift/web/assets/125113430/85179cb0-1d49-484a-babd-45e601e52a38)

sometimes there is only protocol fee:
![image](https://github.com/shapeshift/web/assets/125113430/63ec9b49-81af-4db4-8850-430a2f0df8ac)
