### PR TITLE
fix: prevent render loops due to use of uncached useErrorHandler hook

### DIFF
--- a/src/hooks/useErrorToast/useErrorToast.ts
+++ b/src/hooks/useErrorToast/useErrorToast.ts
@@ -1,5 +1,6 @@
 import { useToast } from '@chakra-ui/react'
 import { get, isError } from 'lodash'
+import { useCallback } from 'react'
 import { useTranslate } from 'react-polyglot'
 import { logger } from 'lib/logger'
 import { SwapErrorType } from 'lib/swapper/api'
@@ -39,20 +40,23 @@ export const useErrorHandler = () => {
   const toast = useToast()
   const translate = useTranslate()
 
-  const showErrorToast = (error: unknown) => {
-    const description = translate(getTranslationFromError(error))
+  const showErrorToast = useCallback(
+    (error: unknown) => {
+      const description = translate(getTranslationFromError(error))
 
-    moduleLogger.error(error, description)
+      moduleLogger.error(error, description)
 
-    toast({
-      title: translate('trade.errors.title'),
-      description,
-      status: 'error',
-      duration: 9000,
-      isClosable: true,
-      position: 'top-right',
-    })
-  }
+      toast({
+        title: translate('trade.errors.title'),
+        description,
+        status: 'error',
+        duration: 9000,
+        isClosable: true,
+        position: 'top-right',
+      })
+    },
+    [toast, translate],
+  )
 
   return {
     showErrorToast,


### PR DESCRIPTION
## Description

Prevents render loops due to the creation of an uncached function in the react render context.

## Pull Request Type

- [x] :bug: Bug fix (Non-breaking Change: Fixes an issue)
- [ ] :hammer_and_wrench: Chore (Non-breaking Change: Doc updates, pkg upgrades, typos, etc..)
- [ ] :nail_care: New Feature (Breaking/Non-breaking Change)

## Issue (if applicable)

NA

## Risk

No risk, just wraps a function in useCallback

## Testing

Check that error toast still works

### Engineering

See above

### Operations

See above

## Screenshots (if applicable)
