### PR TITLE
fix: dont render network fees for previous quote when current pair is unsupported

### DIFF
--- a/src/components/Trade/Components/RateGasRow.tsx
+++ b/src/components/Trade/Components/RateGasRow.tsx
@@ -24,6 +24,7 @@ export const RateGasRow: FC<RateGasRowProps> = ({
   rate,
   gasFee,
   isLoading,
+  isError,
 }) => {
   const translate = useTranslate()
   switch (true) {
@@ -34,7 +35,7 @@ export const RateGasRow: FC<RateGasRowProps> = ({
           <Text translation={'trade.searchingRate'} />
         </Stack>
       )
-    case !rate:
+    case !rate || isError:
       return (
         <Stack direction='row' alignItems='center' fontSize='sm'>
           <HelperTooltip

--- a/src/components/Trade/TradeInput.tsx
+++ b/src/components/Trade/TradeInput.tsx
@@ -242,7 +242,6 @@ export const TradeInput = () => {
 
   // Constants
   const shouldShowManualReceiveAddressInput = !walletSupportsBuyAssetChain
-  const walletSupportsTradeAssetChains = walletSupportsBuyAssetChain && walletSupportsSellAssetChain
 
   const chainAdapterManager = getChainAdapterManager()
   const buyAssetChainName = chainAdapterManager.get(buyAsset.chainId)?.getDisplayName()
@@ -734,7 +733,7 @@ export const TradeInput = () => {
             showFiatSkeleton={receiveAmountLoading}
             label={translate('trade.youGet')}
             rightRegion={
-              isTradeRatesEnabled ? (
+              isTradeRatesEnabled && walletSupportsSellAssetChain ? (
                 <IconButton
                   size='sm'
                   icon={showQuotes ? <ArrowUpIcon /> : <ArrowDownIcon />}
@@ -746,7 +745,7 @@ export const TradeInput = () => {
               )
             }
           >
-            {isTradeRatesEnabled && (
+            {isTradeRatesEnabled && walletSupportsSellAssetChain && (
               <TradeQuotes isOpen={showQuotes} isLoading={tradeStateLoading} />
             )}
           </TradeAssetInput>
@@ -758,7 +757,7 @@ export const TradeInput = () => {
             gasFee={gasFeeFiat}
             rate={activeQuote?.rate}
             isLoading={tradeStateLoading}
-            isError={!walletSupportsTradeAssetChains}
+            isError={!walletSupportsSellAssetChain}
           />
           {walletSupportsSellAssetChain && !sellAmountTooSmall ? (
             <ReceiveSummary


### PR DESCRIPTION
## Description

Fixes network fee appearing as several billion dollars when the sell asset is unsupported by the connected wallet. 

The fix was to simply NOT render any available swappers or network fees when the sell asset was unsupported since it was never possible to use them anyway.

## Pull Request Type

- [x] :bug: Bug fix (Non-breaking Change: Fixes an issue)
- [ ] :hammer_and_wrench: Chore (Non-breaking Change: Doc updates, pkg upgrades, typos, etc..)
- [ ] :nail_care: New Feature (Breaking/Non-breaking Change)

## Issue (if applicable)

closes #4499 

## Risk

virtually no risk.

## Testing

- check that unsupported sell assets do not display billion dollar network fees
- check that supported pairs display the correct network fee

### Engineering

This was caused by the `TradeInput` UI using the previous quote to display network fees with the precision of the selected network fee. In the examples shown, gas fee with ETH precision (18) was rendered using BCH precision (8).

### Operations

See above

## Screenshots (if applicable)

before fix
![image](https://github.com/shapeshift/web/assets/125113430/9262cc4d-8e28-4417-a78b-f00aa19eed3b)

after fix
![image](https://github.com/shapeshift/web/assets/125113430/c14664c1-6b0a-4de0-93c9-8ebd766e20af)
