### PR TITLE
fix: invalidate stale cosmos SDK userStakingData

### DIFF
--- a/src/features/defi/providers/cosmos/components/CosmosManager/Overview/WithdrawCard.tsx
+++ b/src/features/defi/providers/cosmos/components/CosmosManager/Overview/WithdrawCard.tsx
@@ -44,7 +44,12 @@ export const WithdrawCard = ({ asset, accountId: routeAccountId }: WithdrawCardP
 
   const undelegationEntries = useMemo(() => {
     if (!opportunityData) return []
-    if (supportsUndelegations(opportunityData) && opportunityData.undelegations.length) {
+    if (
+      supportsUndelegations(opportunityData) &&
+      opportunityData.undelegations.some(undelegation =>
+        dayjs().isBefore(dayjs(undelegation.completionTime).unix()),
+      )
+    ) {
       return opportunityData.undelegations
     }
     return []

--- a/src/state/slices/opportunitiesSlice/opportunitiesSlice.ts
+++ b/src/state/slices/opportunitiesSlice/opportunitiesSlice.ts
@@ -320,11 +320,15 @@ export const opportunitiesApi = createApi({
             throw new Error(`resolver for ${defiProvider}::${defiType} not implemented`)
           }
 
+          const onInvalidate = (userStakingId: UserStakingId) =>
+            dispatch(opportunities.actions.invalidateUserStakingOpportunity(userStakingId))
+
           const resolved = await resolver({
             opportunityIds,
             defiType,
             accountId,
             reduxApi: { dispatch, getState },
+            onInvalidate,
           })
 
           if (resolved?.data) {

--- a/src/state/slices/opportunitiesSlice/opportunitiesSlice.ts
+++ b/src/state/slices/opportunitiesSlice/opportunitiesSlice.ts
@@ -110,6 +110,16 @@ export const opportunities = createSlice({
       // add the `action.meta[SHOULD_AUTOBATCH]` field the enhancer needs
       prepare: prepareAutoBatched<GetOpportunityUserStakingDataOutput>(),
     },
+    invalidateUserStakingOpportunity: {
+      reducer: (draftState, { payload }: { payload: UserStakingId }) => {
+        const userStakingId = payload
+        delete draftState.userStaking.byId[userStakingId]
+      },
+
+      // Use the `prepareAutoBatched` utility to automatically
+      // add the `action.meta[SHOULD_AUTOBATCH]` field the enhancer needs
+      prepare: prepareAutoBatched<UserStakingId>(),
+    },
   },
   extraReducers: builder => builder.addCase(PURGE, () => initialState),
 })

--- a/src/state/slices/opportunitiesSlice/resolvers/cosmosSdk/index.ts
+++ b/src/state/slices/opportunitiesSlice/resolvers/cosmosSdk/index.ts
@@ -206,7 +206,7 @@ export const cosmosSdkStakingOpportunitiesUserDataResolver = async ({
     const asset = selectAssetById(state, assetId)
     if (!asset) throw new Error(`Cannot get asset for AssetId: ${assetId}`)
 
-    const byId = makeAccountUserData({ cosmosSdkAccount: cosmosAccount, validatorIds })
+    const byId = makeAccountUserData({ cosmosSdkAccount: cosmosAccount, validatorIds, reduxApi })
 
     return Promise.resolve({ data: { byId, type: defiType } })
   } catch (e) {

--- a/src/state/slices/opportunitiesSlice/resolvers/cosmosSdk/index.ts
+++ b/src/state/slices/opportunitiesSlice/resolvers/cosmosSdk/index.ts
@@ -181,6 +181,7 @@ export const cosmosSdkStakingOpportunitiesUserDataResolver = async ({
   defiType,
   accountId,
   reduxApi,
+  onInvalidate,
 }: OpportunitiesUserDataResolverInput): Promise<{ data: GetOpportunityUserStakingDataOutput }> => {
   const { getState } = reduxApi
   const state: any = getState() // ReduxState causes circular dependency
@@ -206,7 +207,11 @@ export const cosmosSdkStakingOpportunitiesUserDataResolver = async ({
     const asset = selectAssetById(state, assetId)
     if (!asset) throw new Error(`Cannot get asset for AssetId: ${assetId}`)
 
-    const byId = makeAccountUserData({ cosmosSdkAccount: cosmosAccount, validatorIds, reduxApi })
+    const byId = makeAccountUserData({
+      cosmosSdkAccount: cosmosAccount,
+      validatorIds,
+      onInvalidate,
+    })
 
     return Promise.resolve({ data: { byId, type: defiType } })
   } catch (e) {

--- a/src/state/slices/opportunitiesSlice/resolvers/cosmosSdk/utils.ts
+++ b/src/state/slices/opportunitiesSlice/resolvers/cosmosSdk/utils.ts
@@ -11,7 +11,6 @@ import type { BN } from 'lib/bignumber/bignumber'
 import { bn, bnOrZero } from 'lib/bignumber/bignumber'
 import { isSome } from 'lib/utils'
 
-import { opportunities } from '../../opportunitiesSlice'
 import type {
   OpportunitiesState,
   StakingEarnOpportunityType,
@@ -21,7 +20,6 @@ import type {
   ValidatorId,
 } from '../../types'
 import { serializeUserStakingId, supportsUndelegations, toValidatorId } from '../../utils'
-import type { ReduxApi } from '../types'
 import {
   SHAPESHIFT_COSMOS_VALIDATOR_ADDRESS,
   SHAPESHIFT_OSMOSIS_VALIDATOR_ADDRESS,
@@ -67,11 +65,11 @@ export const makeUniqueValidatorAccountIds = ({
 export const makeAccountUserData = ({
   cosmosSdkAccount,
   validatorIds,
-  reduxApi,
+  onInvalidate,
 }: {
   cosmosSdkAccount: Account<CosmosSdkChainId>
   validatorIds: ValidatorId[]
-  reduxApi: ReduxApi
+  onInvalidate: (userStakingId: UserStakingId) => void
 }): OpportunitiesState['userStaking']['byId'] => {
   const delegations = cosmosSdkAccount.chainSpecific.delegations
   const undelegations = cosmosSdkAccount.chainSpecific.undelegations
@@ -125,7 +123,7 @@ export const makeAccountUserData = ({
       }
     } else {
       // UserStakingOpportunity invalidation
-      reduxApi.dispatch(opportunities.actions.invalidateUserStakingOpportunity(userStakingId))
+      onInvalidate(userStakingId)
     }
 
     return acc

--- a/src/state/slices/opportunitiesSlice/resolvers/types.ts
+++ b/src/state/slices/opportunitiesSlice/resolvers/types.ts
@@ -2,7 +2,7 @@ import type { BaseQueryApi } from '@reduxjs/toolkit/dist/query/baseQueryTypes'
 import type { AccountId } from '@shapeshiftoss/caip'
 import type { DefiType } from 'features/defi/contexts/DefiManagerProvider/DefiCommon'
 
-import type { OpportunityId } from '../types'
+import type { OpportunityId, UserStakingId } from '../types'
 
 export type ReduxApi = Pick<BaseQueryApi, 'dispatch' | 'getState'>
 
@@ -30,6 +30,7 @@ export type OpportunitiesUserDataResolverInput = {
   defiType: DefiType
   accountId: AccountId
   reduxApi: ReduxApi
+  onInvalidate: (userStakingId: UserStakingId) => void
 }
 
 export type OpportunityIdsResolverInput = {


### PR DESCRIPTION
## Description

Tackles https://discord.com/channels/554694662431178782/1108429698494640188/1108429700386263071 - we were never invalidating old opportunities. This PR:

- adds a new `invalidateUserStakingOpportunity` action to `opportunities`, to handle one of the two hard things in software engineering
- adds paranoia `dayjs().isBefore()` checks in `<WithdrawCard />` and in Cosmos SDK resolver utils to ensure the current date is before the completion time i.e the undelegation is *actually* valid

## Pull Request Type

- [x] :bug: Bug fix (Non-breaking Change: Fixes an issue)
- [ ] :hammer_and_wrench: Chore (Non-breaking Change: Doc updates, pkg upgrades, typos, etc..)
- [ ] :nail_care: New Feature (Breaking/Non-breaking Change)

## Issue (if applicable)

N/A

## Risk

<!-----------------------------------------------------------------------------
Outline the scope of your changes and the risk associated with them. You must use your discretion as an engineer to determine the potential impact of your changes.

E.g. an upgrade to `hdwallet` or core state management would be considered higher risk, and might require a full regression test. UI or isolated view changes, or something behind a feature flag may have near zero risk. Small bug fixes might require testing isolated to the specific fix.
------------------------------------------------------------------------------>

Note this is untested as I couldn't reproduce this bug, would have to wait 21 days to do so.
User data resolution for Cosmos SDK opportunities might be borked, clear your persisted store and confirm you can still see your user data

## Testing

<!-----------------------------------------------------------------------------
We treat every PR to be merged with the same scrutiny as if we were merging directly to production.

Your PR will not be merged if you do not complete the sections below for our engineering and operations teams to test.
------------------------------------------------------------------------------>

- If you can repro this in prod, ensure you don't see your stale undelegation anymore
- Whether or not you can repro this, ensure you can still see your Cosmos SDK user data after clearing your persisted store

### Engineering

<!-----------------------------------------------------------------------------
Include sufficient information here for an engineer to test your PR. This may include how to test locally, in a built environment, changes to infrastructure etc.
------------------------------------------------------------------------------>

- ☝🏽 

### Operations

<!-----------------------------------------------------------------------------
If your changes have a user-facing impact, describe how a non-technical QA team can functionally test your changes in a preview environment.

If they are not user-facing please describe how to test for any regressions that may occur.
------------------------------------------------------------------------------>

- ☝🏽 

## Screenshots (if applicable)

![Uploading image.png…]()
