### PR TITLE
chore: add wc verify url as frame-src

### DIFF
--- a/react-app-rewired/headers/csps/wallets/walletConnect.ts
+++ b/react-app-rewired/headers/csps/wallets/walletConnect.ts
@@ -4,9 +4,9 @@ export const csp: Csp = {
   'connect-src': [
     process.env.REACT_APP_WALLET_CONNECT_RELAY_URL!,
     'wss://*.bridge.walletconnect.org/',
-    'https://verify.walletconnect.com/',
     'https://registry.walletconnect.com/api/v2/wallets',
     'https://api.etherscan.io',
   ],
   'img-src': ['https://imagedelivery.net/', 'https://registry.walletconnect.com/api/v2/logo/', '*'],
+  'frame-src': ['https://verify.walletconnect.com/'],
 }


### PR DESCRIPTION
## Description

Correct the CSP key of `https://verify.walletconnect.com/` from `connect-src` to `frame-src`.

## Pull Request Type

- [ ] :bug: Bug fix (Non-breaking Change: Fixes an issue)
- [x] :hammer_and_wrench: Chore (Non-breaking Change: Doc updates, pkg upgrades, typos, etc..)
- [ ] :nail_care: New Feature (Breaking/Non-breaking Change)

## Issue (if applicable)

N/A

## Risk

Small.

## Testing

Ensure there are no CSP errors relating to `https://verify.walletconnect.com/` showing the console when loading the app. 

### Engineering

☝️

### Operations

☝️

## Screenshots (if applicable)

N/A
