### PR TITLE
fix: quotes on missing receive address

### DIFF
--- a/src/components/Trade/hooks/useSwapper/getTradeQuoteArgs.tsx
+++ b/src/components/Trade/hooks/useSwapper/getTradeQuoteArgs.tsx
@@ -20,7 +20,7 @@ export type GetTradeQuoteInputArgs = {
   sellAccountType: UtxoAccountType | undefined
   sellAccountNumber: number
   wallet: HDWallet
-  receiveAddress: NonNullable<SwapperState['receiveAddress']>
+  receiveAddress: SwapperState['receiveAddress']
   sellAmountBeforeFeesCryptoPrecision: string
   isSendMax: boolean
 }

--- a/src/components/Trade/hooks/useTradeQuoteService.tsx
+++ b/src/components/Trade/hooks/useTradeQuoteService.tsx
@@ -51,14 +51,7 @@ export const useTradeQuoteService = () => {
   // Effects
   // Set trade quote args and trigger trade quote query
   useEffect(() => {
-    if (
-      sellAsset &&
-      buyAsset &&
-      wallet &&
-      sellAmountCryptoPrecision &&
-      receiveAddress &&
-      sellAccountMetadata
-    ) {
+    if (sellAsset && buyAsset && wallet && sellAmountCryptoPrecision && sellAccountMetadata) {
       ;(async () => {
         const { chainId: receiveAddressChainId } = fromAssetId(buyAsset.assetId)
         const chainAdapter = getChainAdapterManager().get(receiveAddressChainId)

--- a/src/lib/swapper/api.ts
+++ b/src/lib/swapper/api.ts
@@ -94,7 +94,7 @@ type CommonTradeInput = {
   buyAsset: Asset
   sellAmountBeforeFeesCryptoBaseUnit: string
   sendMax: boolean
-  receiveAddress: string
+  receiveAddress: string | undefined
   accountNumber: number
   receiveAccountNumber?: number
   affiliateBps: string

--- a/src/lib/swapper/swappers/CowSwapper/cowBuildTrade/cowBuildTrade.ts
+++ b/src/lib/swapper/swappers/CowSwapper/cowBuildTrade/cowBuildTrade.ts
@@ -27,6 +27,15 @@ export async function cowBuildTrade(
   input: BuildTradeInput,
 ): Promise<Result<CowTrade<KnownChainIds.EthereumMainnet>, SwapErrorRight>> {
   const { sellAsset, buyAsset, accountNumber, receiveAddress } = input
+
+  if (!receiveAddress)
+    return Err(
+      makeSwapErrorRight({
+        message: 'Receive address is required to build CoW trades',
+        code: SwapErrorType.MISSING_INPUT,
+      }),
+    )
+
   const sellAmountBeforeFeesCryptoBaseUnit = input.sellAmountBeforeFeesCryptoBaseUnit
 
   const { assetReference: sellAssetErc20Address, assetNamespace: sellAssetNamespace } = fromAssetId(

--- a/src/lib/swapper/swappers/LifiSwapper/buildTrade/buildTrade.ts
+++ b/src/lib/swapper/swappers/LifiSwapper/buildTrade/buildTrade.ts
@@ -23,10 +23,19 @@ export const buildTrade = async (
     )
   }
 
+  const { receiveAddress } = input
+
+  if (!receiveAddress)
+    return Err(
+      makeSwapErrorRight({
+        message: 'Receive address is required to build Li.Fi trades',
+        code: SwapErrorType.MISSING_INPUT,
+      }),
+    )
   // TODO: determine whether we should be fetching another quote like below or modify `executeTrade.ts`
   // to allow passing the existing quote in.
   return (await getTradeQuote(input, lifiChainMap)).map(tradeQuote => ({
     ...tradeQuote,
-    receiveAddress: input.receiveAddress,
+    receiveAddress,
   }))
 }

--- a/src/lib/swapper/swappers/OneInchSwapper/buildTrade/buildTrade.ts
+++ b/src/lib/swapper/swappers/OneInchSwapper/buildTrade/buildTrade.ts
@@ -70,6 +70,14 @@ export const buildTrade = async (
 
   const buyTokenPercentageFee = convertBasisPointsToPercentage(affiliateBps).toNumber()
 
+  if (!receiveAddress)
+    return Err(
+      makeSwapErrorRight({
+        message: 'Receive address is required to build Oneinch trades',
+        code: SwapErrorType.MISSING_INPUT,
+      }),
+    )
+
   const swapApiInput: OneInchSwapApiInput = {
     fromTokenAddress: fromAssetAddress,
     toTokenAddress: toAssetAddress,

--- a/src/lib/swapper/swappers/OsmosisSwapper/OsmosisSwapper.ts
+++ b/src/lib/swapper/swappers/OsmosisSwapper/OsmosisSwapper.ts
@@ -172,6 +172,14 @@ export class OsmosisSwapper implements Swapper<ChainId> {
     const feeData = await osmosisAdapter.getFeeData({})
     const fee = feeData.fast.txFee
 
+    if (!receiveAddress)
+      return Err(
+        makeSwapErrorRight({
+          message: 'Receive address is required to build Osmosis trades',
+          code: SwapErrorType.MISSING_INPUT,
+        }),
+      )
+
     return Ok({
       buyAmountBeforeFeesCryptoBaseUnit: buyAmountCryptoBaseUnit,
       buyAsset,

--- a/src/lib/swapper/swappers/ThorchainSwapper/buildThorTrade/buildThorTrade.ts
+++ b/src/lib/swapper/swappers/ThorchainSwapper/buildThorTrade/buildThorTrade.ts
@@ -63,6 +63,15 @@ export const buildTrade = async ({
 
   const quote = maybeQuote.unwrap()
 
+  // A THORChain quote can be gotten without a destinationAddress, but a trade cannot be built without one.
+  if (!destinationAddress)
+    return Err(
+      makeSwapErrorRight({
+        message: '[buildThorTrade]: destinationAddress is required',
+        code: SwapErrorType.MISSING_INPUT,
+      }),
+    )
+
   if (chainNamespace === CHAIN_NAMESPACE.Evm) {
     const maybeEthTradeTx = await makeTradeTx({
       wallet,

--- a/src/lib/swapper/swappers/ThorchainSwapper/utils/getLimit/getLimit.ts
+++ b/src/lib/swapper/swappers/ThorchainSwapper/utils/getLimit/getLimit.ts
@@ -24,7 +24,7 @@ import {
 import { swapperStore } from 'state/zustand/swapperStore/useSwapperStore'
 
 export type GetLimitArgs = {
-  receiveAddress: string
+  receiveAddress: string | undefined
   buyAssetId: string
   sellAsset: Asset
   sellAmountCryptoBaseUnit: string

--- a/src/lib/swapper/swappers/ThorchainSwapper/utils/getQuote/getQuote.ts
+++ b/src/lib/swapper/swappers/ThorchainSwapper/utils/getQuote/getQuote.ts
@@ -31,7 +31,8 @@ export const getQuote = async ({
   sellAsset: Asset
   buyAssetId: AssetId
   sellAmountCryptoBaseUnit: string
-  receiveAddress: string
+  // Receive address is optional for THOR quotes, and will be in case we are getting a quote with a missing manual receive address
+  receiveAddress: string | undefined
   affiliateBps: string
   deps: ThorchainSwapperDeps
 }): Promise<Result<ThornodeQuoteResponseSuccess, SwapErrorRight>> => {
@@ -49,7 +50,9 @@ export const getQuote = async ({
 
   // The THORChain swap endpoint expects BCH receiveAddress's to be stripped of the "bitcoincash:" prefix
   const parsedReceiveAddress =
-    buyAssetId === bchAssetId ? receiveAddress.replace('bitcoincash:', '') : receiveAddress
+    receiveAddress && buyAssetId === bchAssetId
+      ? receiveAddress.replace('bitcoincash:', '')
+      : receiveAddress
 
   const queryString = qs.stringify({
     amount: sellAmountCryptoThorBaseUnit.toString(),

--- a/src/lib/swapper/swappers/ThorchainSwapper/utils/getTradeRate/getTradeRate.ts
+++ b/src/lib/swapper/swappers/ThorchainSwapper/utils/getTradeRate/getTradeRate.ts
@@ -35,7 +35,7 @@ export const getTradeRate = async ({
   sellAsset: Asset
   buyAssetId: AssetId
   sellAmountCryptoBaseUnit: string
-  receiveAddress: string
+  receiveAddress: string | undefined
   affiliateBps: string
   deps: ThorchainSwapperDeps
 }): Promise<Result<string, SwapErrorRight>> => {
@@ -79,7 +79,9 @@ export const getTradeRate = async ({
 
   // The THORChain swap endpoint expects BCH receiveAddress's to be stripped of the "bitcoincash:" prefix
   const parsedReceiveAddress =
-    buyAssetId === bchAssetId ? receiveAddress.replace('bitcoincash:', '') : receiveAddress
+    receiveAddress && buyAssetId === bchAssetId
+      ? receiveAddress.replace('bitcoincash:', '')
+      : receiveAddress
 
   const queryString = qs.stringify({
     amount: sellAmountCryptoThorBaseUnit.toString(),

--- a/src/lib/swapper/swappers/ThorchainSwapper/utils/makeSwapMemo/makeSwapMemo.ts
+++ b/src/lib/swapper/swappers/ThorchainSwapper/utils/makeSwapMemo/makeSwapMemo.ts
@@ -41,7 +41,7 @@ export const abbreviateThorAssetId = (fullThorAssetId: string): string => {
 
 type MakeSwapMemoArgs = {
   buyAssetId: string
-  destinationAddress: string
+  destinationAddress: string | undefined
   limit: string
   affiliateBps: string
 }
@@ -74,9 +74,10 @@ export const makeSwapMemo: MakeSwapMemo = ({
   // Our bitcoin cash addresses are prefixed with `bitcoincash:`
   // But thorchain memos need to be short (under 80 bytes for utxo)
   // For this reason thorchain doesnt allow / need bitcoincash: in the memo
-  const parsedDestinationAddress = destinationAddress.includes('bitcoincash:')
-    ? destinationAddress.replace('bitcoincash:', '')
-    : destinationAddress
+  const parsedDestinationAddress =
+    destinationAddress && destinationAddress.includes('bitcoincash:')
+      ? destinationAddress.replace('bitcoincash:', '')
+      : destinationAddress
 
   const abbreviatedThorAssetId = abbreviateThorAssetId(fullThorAssetId)
 

--- a/src/lib/swapper/swappers/ThorchainSwapper/utxo/utils/getThorTxData.ts
+++ b/src/lib/swapper/swappers/ThorchainSwapper/utxo/utils/getThorTxData.ts
@@ -13,7 +13,7 @@ type GetThorTxInfoArgs = {
   buyAsset: Asset
   sellAmountCryptoBaseUnit: string
   slippageTolerance: string
-  destinationAddress: string
+  destinationAddress: string | undefined
   xpub: string
   buyAssetTradeFeeUsd: string
   affiliateBps: string

--- a/src/lib/swapper/swappers/ZrxSwapper/zrxBuildTrade/zrxBuildTrade.ts
+++ b/src/lib/swapper/swappers/ZrxSwapper/zrxBuildTrade/zrxBuildTrade.ts
@@ -4,6 +4,7 @@ import type { AxiosInstance } from 'axios'
 import * as rax from 'retry-axios'
 import { bnOrZero } from 'lib/bignumber/bignumber'
 import type { BuildTradeInput, SwapErrorRight } from 'lib/swapper/api'
+import { makeSwapErrorRight, SwapErrorType } from 'lib/swapper/api'
 import { DEFAULT_SLIPPAGE } from 'lib/swapper/swappers/utils/constants'
 import { normalizeAmount } from 'lib/swapper/swappers/utils/helpers/helpers'
 import type {
@@ -77,6 +78,14 @@ export async function zrxBuildTrade<T extends ZrxSupportedChainId>(
 
   if (maybeQuoteResponse.isErr()) return Err(maybeQuoteResponse.unwrapErr())
   const { data: quote } = maybeQuoteResponse.unwrap()
+
+  if (!receiveAddress)
+    return Err(
+      makeSwapErrorRight({
+        message: 'Receive address is required for ZRX trades',
+        code: SwapErrorType.MISSING_INPUT,
+      }),
+    )
 
   const { average } = await adapter.getFeeData({
     to: quote.to,


### PR DESCRIPTION
## Description

This PR fixes the THOR quotes that are currently rugged on missing manual receive addresses, see

https://discord.com/channels/554694662431178782/1109095039239462933/1110104478390165664

The reason why this was borked was because of our `if (receiveAddress)` check in `useTradeQuoteService`, never fetching a quote in case we don't have a receive address.

## Pull Request Type

- [x] :bug: Bug fix (Non-breaking Change: Fixes an issue)
- [ ] :hammer_and_wrench: Chore (Non-breaking Change: Doc updates, pkg upgrades, typos, etc..)
- [ ] :nail_care: New Feature (Breaking/Non-breaking Change)

## Issue (if applicable)

N/A

## Risk

<!-----------------------------------------------------------------------------
Outline the scope of your changes and the risk associated with them. You must use your discretion as an engineer to determine the potential impact of your changes.

E.g. an upgrade to `hdwallet` or core state management would be considered higher risk, and might require a full regression test. UI or isolated view changes, or something behind a feature flag may have near zero risk. Small bug fixes might require testing isolated to the specific fix.
------------------------------------------------------------------------------>

Theoretically medium/high, in reality, this brings more runtime safety in, throwing in case of undefined receive address whenever applicable.

## Testing

<!-----------------------------------------------------------------------------
We treat every PR to be merged with the same scrutiny as if we were merging directly to production.

Your PR will not be merged if you do not complete the sections below for our engineering and operations teams to test.
------------------------------------------------------------------------------>

- With MM connected, ensure you can get quotes to UTXOs without a receive address entered
- Ensure send max is working without a receive address entered
- Ensure the swapper is in an error-ed state, pending receive address input

- Ensure inputting a receive address allows to continue with the flow
- As a paranoia check, ensure it is still possible to complete an EVM -> UTXO swap end-to-end, **both with a manual receive address (MM) and without (native)**

### Engineering

<!-----------------------------------------------------------------------------
Include sufficient information here for an engineer to test your PR. This may include how to test locally, in a built environment, changes to infrastructure etc.
------------------------------------------------------------------------------>

- Error-handling is exhaustive and sane

### Operations

<!-----------------------------------------------------------------------------
If your changes have a user-facing impact, describe how a non-technical QA team can functionally test your changes in a preview environment.

If they are not user-facing please describe how to test for any regressions that may occur.
------------------------------------------------------------------------------>

- ☝🏽 
## Screenshots (if applicable)

<img width="379" alt="image" src="https://github.com/shapeshift/web/assets/17035424/890285fd-8414-4251-9a91-174c0d08b1db">
<img width="380" alt="image" src="https://github.com/shapeshift/web/assets/17035424/3cd72716-eef2-4a82-8882-14f46f588cbb">
<img width="399" alt="image" src="https://github.com/shapeshift/web/assets/17035424/980ecdba-54f8-426d-b993-6f361a39fd85">
<img width="378" alt="image" src="https://github.com/shapeshift/web/assets/17035424/6c6c84eb-2c13-4d83-9d7a-8af9696c2d0b">
<img width="375" alt="image" src="https://github.com/shapeshift/web/assets/17035424/71c6ae95-5b16-47a4-a006-6e3e9bce3820">
<img width="374" alt="image" src="https://github.com/shapeshift/web/assets/17035424/ef35002f-7497-4aca-bf9e-098e9b19bd51">