### PR TITLE
fix: disabled trade button after manual receive address

### DIFF
--- a/src/components/Trade/TradeInput.tsx
+++ b/src/components/Trade/TradeInput.tsx
@@ -173,10 +173,14 @@ export const TradeInput = () => {
   const { assetSearch } = useModal()
   const { handleAssetClick } = useTradeRoutes()
 
+  const walletSupportsSellAssetChain = walletSupportsChain({ chainId: sellAssetChainId, wallet })
+  const walletSupportsBuyAssetChain = walletSupportsChain({ chainId: buyAssetChainId, wallet })
+  const shouldShowManualReceiveAddressInput = !walletSupportsBuyAssetChain
+
   // Trigger re-validation of the manually entered receive address
   useEffect(() => {
     formTrigger(SendFormFields.Input)
-  }, [formTrigger])
+  }, [formTrigger, shouldShowManualReceiveAddressInput])
 
   // Reset the manual address input state when the user changes the buy asset
   useEffect(() => {
@@ -239,12 +243,6 @@ export const TradeInput = () => {
       activeQuote.sellAsset?.assetId === sellAsset?.assetId
     )
   }, [buyAsset?.assetId, activeQuote, sellAsset?.assetId])
-
-  const walletSupportsSellAssetChain = walletSupportsChain({ chainId: sellAssetChainId, wallet })
-  const walletSupportsBuyAssetChain = walletSupportsChain({ chainId: buyAssetChainId, wallet })
-
-  // Constants
-  const shouldShowManualReceiveAddressInput = !walletSupportsBuyAssetChain
 
   const chainAdapterManager = getChainAdapterManager()
   const buyAssetChainName = chainAdapterManager.get(buyAsset.chainId)?.getDisplayName()


### PR DESCRIPTION
## Description

Fix issue where "preview trade" button is permanently disabled (until reload) after manual receive address is rendered.

## Pull Request Type

- [x] :bug: Bug fix (Non-breaking Change: Fixes an issue)
- [ ] :hammer_and_wrench: Chore (Non-breaking Change: Doc updates, pkg upgrades, typos, etc..)
- [ ] :nail_care: New Feature (Breaking/Non-breaking Change)

## Issue (if applicable)

closes #4540

## Risk

very low risk

## Testing

See linked issue for testing

### Engineering

The fix is to force `react-hook-form` to revalidate after hiding manual receive address.

### Operations

See #4540

## Screenshots (if applicable)
