### PR TITLE
fix: race condition rendering/loading sellable assets

### DIFF
--- a/src/components/Trade/TradeInput.tsx
+++ b/src/components/Trade/TradeInput.tsx
@@ -157,6 +157,7 @@ export const TradeInput = () => {
     checkApprovalNeeded,
     supportedSellAssetsByMarketCap,
     supportedBuyAssetsByMarketCap,
+    isSwapperInitialized,
   } = useSwapper()
   const translate = useTranslate()
   const history = useHistory()
@@ -604,6 +605,9 @@ export const TradeInput = () => {
 
   const handleInputAssetClick = useCallback(
     (action: AssetClickAction) => {
+      // prevent opening the asset selection while they are being populated
+      if (!isSwapperInitialized) return
+
       assetSearch.open({
         onClick: action === AssetClickAction.Sell ? handleSellAssetClick : handleBuyAssetClick,
         title: action === AssetClickAction.Sell ? 'trade.tradeFrom' : 'trade.tradeTo',
@@ -615,6 +619,7 @@ export const TradeInput = () => {
     },
     [
       assetSearch,
+      isSwapperInitialized,
       supportedBuyAssetsByMarketCap,
       supportedSellAssetsByMarketCap,
       handleSellAssetClick,
@@ -623,8 +628,16 @@ export const TradeInput = () => {
   )
 
   const tradeStateLoading = useMemo(
-    () => (isSwapperApiPending && !quoteAvailableForCurrentAssetPair) || !isSwapperApiInitiated,
-    [isSwapperApiPending, quoteAvailableForCurrentAssetPair, isSwapperApiInitiated],
+    () =>
+      (isSwapperApiPending && !quoteAvailableForCurrentAssetPair) ||
+      !isSwapperApiInitiated ||
+      !isSwapperInitialized,
+    [
+      isSwapperApiPending,
+      quoteAvailableForCurrentAssetPair,
+      isSwapperApiInitiated,
+      isSwapperInitialized,
+    ],
   )
 
   const isSellAction = useMemo(() => {

--- a/src/components/Trade/hooks/useSwapper/swapperManager.ts
+++ b/src/components/Trade/hooks/useSwapper/swapperManager.ts
@@ -14,6 +14,7 @@ import type {
 } from '@shapeshiftoss/chain-adapters'
 import { KnownChainIds } from '@shapeshiftoss/types'
 import { getConfig } from 'config'
+import stableStringify from 'fast-json-stable-stringify'
 import { getChainAdapterManager } from 'context/PluginProvider/chainAdapterSingleton'
 import { SwapperManager } from 'lib/swapper/manager/SwapperManager'
 import { CowSwapper } from 'lib/swapper/swappers/CowSwapper/CowSwapper'
@@ -26,18 +27,15 @@ import { getWeb3InstanceByChainId } from 'lib/web3-instance'
 import type { FeatureFlags } from 'state/slices/preferencesSlice/preferencesSlice'
 
 // singleton - do not export me, use getSwapperManager
-let _swapperManager: SwapperManager | null = null
+let _swapperManager: Promise<SwapperManager> | undefined
+
 // singleton - do not export me
 // Used to short circuit calls to getSwapperManager if flags have not changed
 let previousFlags: string = ''
 
-export const getSwapperManager = async (flags: FeatureFlags): Promise<SwapperManager> => {
-  const flagsChanged = previousFlags !== JSON.stringify(flags)
-  if (_swapperManager && !flagsChanged) return _swapperManager
-  previousFlags = JSON.stringify(flags)
-
+export const _getSwapperManager = async (flags: FeatureFlags): Promise<SwapperManager> => {
   // instantiate if it doesn't already exist
-  _swapperManager = new SwapperManager()
+  const swapperManager = new SwapperManager()
 
   const adapterManager = getChainAdapterManager()
   const ethWeb3 = getWeb3InstanceByChainId(ethChainId)
@@ -54,7 +52,7 @@ export const getSwapperManager = async (flags: FeatureFlags): Promise<SwapperMan
       apiUrl: getConfig().REACT_APP_COWSWAP_HTTP_URL,
       web3: ethWeb3,
     })
-    _swapperManager.addSwapper(cowSwapper)
+    swapperManager.addSwapper(cowSwapper)
   }
 
   if (flags.ZrxEthereumSwap) {
@@ -62,7 +60,7 @@ export const getSwapperManager = async (flags: FeatureFlags): Promise<SwapperMan
       web3: ethWeb3,
       adapter: ethereumChainAdapter,
     })
-    _swapperManager.addSwapper(zrxEthereumSwapper)
+    swapperManager.addSwapper(zrxEthereumSwapper)
   }
 
   if (flags.ZrxAvalancheSwap) {
@@ -74,7 +72,7 @@ export const getSwapperManager = async (flags: FeatureFlags): Promise<SwapperMan
       web3: avaxWeb3,
       adapter: avalancheChainAdapter,
     })
-    _swapperManager.addSwapper(zrxAvalancheSwapper)
+    swapperManager.addSwapper(zrxAvalancheSwapper)
   }
 
   if (flags.ZrxOptimismSwap) {
@@ -86,7 +84,7 @@ export const getSwapperManager = async (flags: FeatureFlags): Promise<SwapperMan
       web3: optimismWeb3,
       adapter: optimismChainAdapter,
     })
-    _swapperManager.addSwapper(zrxOptimismSwapper)
+    swapperManager.addSwapper(zrxOptimismSwapper)
   }
 
   if (flags.ZrxBnbSmartChainSwap) {
@@ -100,7 +98,7 @@ export const getSwapperManager = async (flags: FeatureFlags): Promise<SwapperMan
       web3: bscWeb3,
       adapter: bscChainAdapter,
     })
-    _swapperManager.addSwapper(zrxBscSwapper)
+    swapperManager.addSwapper(zrxBscSwapper)
   }
 
   if (flags.ZrxPolygonSwap) {
@@ -114,41 +112,49 @@ export const getSwapperManager = async (flags: FeatureFlags): Promise<SwapperMan
       web3: polygonWeb3,
       adapter: polygonChainAdatper,
     })
-    _swapperManager.addSwapper(zrxPolygonSwapper)
+    swapperManager.addSwapper(zrxPolygonSwapper)
   }
 
   if (flags.ThorSwap) {
-    await (async () => {
-      const midgardUrl = getConfig().REACT_APP_MIDGARD_URL
-      const daemonUrl = getConfig().REACT_APP_THORCHAIN_NODE_URL
-      const thorSwapper = new ThorchainSwapper({
-        daemonUrl,
-        midgardUrl,
-        adapterManager,
-        web3: ethWeb3,
-      })
-      await thorSwapper.initialize()
-      _swapperManager.addSwapper(thorSwapper)
-    })()
+    const midgardUrl = getConfig().REACT_APP_MIDGARD_URL
+    const daemonUrl = getConfig().REACT_APP_THORCHAIN_NODE_URL
+    const thorSwapper = new ThorchainSwapper({
+      daemonUrl,
+      midgardUrl,
+      adapterManager,
+      web3: ethWeb3,
+    })
+    await thorSwapper.initialize()
+    swapperManager.addSwapper(thorSwapper)
   }
 
   if (flags.OsmosisSwap) {
     const osmoUrl = `${getConfig().REACT_APP_OSMOSIS_NODE_URL}/lcd`
     const cosmosUrl = `${getConfig().REACT_APP_COSMOS_NODE_URL}/lcd`
     const osmoSwapper = new OsmosisSwapper({ adapterManager, osmoUrl, cosmosUrl })
-    _swapperManager.addSwapper(osmoSwapper)
+    swapperManager.addSwapper(osmoSwapper)
   }
 
   if (flags.LifiSwap) {
     const lifiSwapper = new LifiSwapper()
     await lifiSwapper.initialize()
-    _swapperManager.addSwapper(lifiSwapper)
+    swapperManager.addSwapper(lifiSwapper)
   }
 
   if (flags.OneInch) {
     const oneInchApiUrl = getConfig().REACT_APP_ONE_INCH_API_URL
     const oneInchSwapper = new OneInchSwapper({ apiUrl: oneInchApiUrl })
-    _swapperManager.addSwapper(oneInchSwapper)
+    swapperManager.addSwapper(oneInchSwapper)
+  }
+
+  return swapperManager
+}
+
+export const getSwapperManager = (flags: FeatureFlags): Promise<SwapperManager> => {
+  const flagsChanged = previousFlags !== stableStringify(flags)
+  if (!_swapperManager || flagsChanged) {
+    _swapperManager = _getSwapperManager(flags)
+    previousFlags = stableStringify(flags)
   }
 
   return _swapperManager

--- a/src/components/Trade/hooks/useSwapper/useSwapper.tsx
+++ b/src/components/Trade/hooks/useSwapper/useSwapper.tsx
@@ -273,5 +273,6 @@ export const useSwapper = () => {
     approve,
     getApprovalTxData,
     checkApprovalNeeded,
+    isSwapperInitialized: swapperManager !== undefined,
   }
 }


### PR DESCRIPTION
## Description

Fixes semmingly random issue where ETH mainnet was displaying as the only buyable chain in trade input.

## Pull Request Type

- [x] :bug: Bug fix (Non-breaking Change: Fixes an issue)
- [ ] :hammer_and_wrench: Chore (Non-breaking Change: Doc updates, pkg upgrades, typos, etc..)
- [ ] :nail_care: New Feature (Breaking/Non-breaking Change)

## Issue (if applicable)

closes #4547

## Risk

Very low risk of app loading state causing asset selection being stuck disabled.

## Testing

1. open app on trade page
2. while app is loading, try to open the buy asset selection
3. app will (possibly) render only ETH as the old available chain - this PR should fix that

### Engineering

This includes a few fixes - comments below

### Operations

See able

## Screenshots (if applicable)

Before fix:
![image](https://github.com/shapeshift/web/assets/125113430/40c08443-015f-4e81-bd37-80120c33c306)

All available chains rendered after fix:
![image](https://github.com/shapeshift/web/assets/125113430/33b9dc9c-ec1b-4fa2-bbe5-61429e0437f4)

