### PR TITLE
fix: incorrect asset reported for protocol fee insufficient balance warning

### DIFF
--- a/src/components/Trade/TradeInput.tsx
+++ b/src/components/Trade/TradeInput.tsx
@@ -441,6 +441,7 @@ export const TradeInput = () => {
 
     if (!insufficientBalanceProtocolFees[0]) return
 
+    // UI can currently only show one error message at a time, so we show the first
     const protocolFee = insufficientBalanceProtocolFees[0][1]
 
     return {


### PR DESCRIPTION
## Description

Fixes UI assuming the protocol fee is always the buy asset. This allows the UI to display the correct warning.

There is a limitation of our UI where we can only display 1 error message at a time, so this fix will show the first known asset with insufficient balance. 

## Pull Request Type

- [x] :bug: Bug fix (Non-breaking Change: Fixes an issue)
- [ ] :hammer_and_wrench: Chore (Non-breaking Change: Doc updates, pkg upgrades, typos, etc..)
- [ ] :nail_care: New Feature (Breaking/Non-breaking Change)

## Issue (if applicable)

## Risk

Low risk of this still being wrong

## Testing

- Test that trades with protocol fees payable with insufficient balance are displayed in UI as a warning (remember that only 1 warning can be displayed at a time)
- Test that trades with sufficient balance for fees go through

### Engineering

See above

### Operations

See above

## Screenshots (if applicable)

prod:
![image](https://github.com/shapeshift/web/assets/125113430/f0991b6a-7940-4a79-bf58-625b9240042c)

with fix:
![image](https://github.com/shapeshift/web/assets/125113430/4301d8de-ee8b-4e4e-92b1-36cf4b16a0bd)

quote from lifi with actual fee highlighted, proving fix matches the quote data:
![image](https://github.com/shapeshift/web/assets/125113430/e3c6314a-6bcd-42ae-99cc-39c65a467a92)
