### PR TITLE
fix: cowswap minimum amounts

### DIFF
--- a/src/components/Trade/Components/TradeQuotes/TradeQuotes.tsx
+++ b/src/components/Trade/Components/TradeQuotes/TradeQuotes.tsx
@@ -1,5 +1,5 @@
 import { Collapse, Flex } from '@chakra-ui/react'
-import { DEFAULT_SLIPPAGE } from 'constants/constants'
+import { DEFAULT_SLIPPAGE_DECIMAL_PERCENTAGE } from 'constants/constants'
 import { bn, bnOrZero } from 'lib/bignumber/bignumber'
 import { fromBaseUnit } from 'lib/math'
 import { selectCryptoMarketData } from 'state/slices/selectors'
@@ -33,7 +33,9 @@ export const TradeQuotes: React.FC<TradeQuotesProps> = ({ isOpen, isLoading }) =
     bestQuote &&
     fromBaseUnit(bestQuote.buyAmountBeforeFeesCryptoBaseUnit, bestQuote.buyAsset.precision)
   const bestBuyAmountCryptoPrecisionAfterSlippage = bnOrZero(bestBuyAmountCryptoPrecision)
-    .times(bn(1).minus(bnOrZero(bestQuote?.recommendedSlippage ?? DEFAULT_SLIPPAGE)))
+    .times(
+      bn(1).minus(bnOrZero(bestQuote?.recommendedSlippage ?? DEFAULT_SLIPPAGE_DECIMAL_PERCENTAGE)),
+    )
     .toString()
 
   const bestTotalProtocolFeeCryptoPrecision =
@@ -74,7 +76,9 @@ export const TradeQuotes: React.FC<TradeQuotesProps> = ({ isOpen, isLoading }) =
 
         const totalReceiveAmountCryptoPrecision = bnOrZero(buyAmountBeforeFeesCryptoPrecision)
           .minus(totalProtocolFeeCryptoPrecision)
-          .times(bn(1).minus(bnOrZero(quote.recommendedSlippage ?? DEFAULT_SLIPPAGE)))
+          .times(
+            bn(1).minus(bnOrZero(quote.recommendedSlippage ?? DEFAULT_SLIPPAGE_DECIMAL_PERCENTAGE)),
+          )
           .toString()
 
         const isActive = activeSwapperName === swapperWithMetadata.swapper.name

--- a/src/components/Trade/Components/TradeQuotes/TradeQuotes.tsx
+++ b/src/components/Trade/Components/TradeQuotes/TradeQuotes.tsx
@@ -1,5 +1,5 @@
 import { Collapse, Flex } from '@chakra-ui/react'
-import { DEFAULT_SLIPPAGE_DECIMAL_PERCENTAGE } from 'constants/constants'
+import { getDefaultSlippagePercentageForSwapper } from 'constants/constants'
 import { bn, bnOrZero } from 'lib/bignumber/bignumber'
 import { fromBaseUnit } from 'lib/math'
 import { selectCryptoMarketData } from 'state/slices/selectors'
@@ -32,10 +32,11 @@ export const TradeQuotes: React.FC<TradeQuotesProps> = ({ isOpen, isLoading }) =
   const bestBuyAmountCryptoPrecision =
     bestQuote &&
     fromBaseUnit(bestQuote.buyAmountBeforeFeesCryptoBaseUnit, bestQuote.buyAsset.precision)
+  const slippageDecimalPercentage =
+    bestQuote?.recommendedSlippage ??
+    getDefaultSlippagePercentageForSwapper(availableSwappersWithMetadata?.[0]?.swapper.name)
   const bestBuyAmountCryptoPrecisionAfterSlippage = bnOrZero(bestBuyAmountCryptoPrecision)
-    .times(
-      bn(1).minus(bnOrZero(bestQuote?.recommendedSlippage ?? DEFAULT_SLIPPAGE_DECIMAL_PERCENTAGE)),
-    )
+    .times(bn(1).minus(bnOrZero(slippageDecimalPercentage)))
     .toString()
 
   const bestTotalProtocolFeeCryptoPrecision =
@@ -77,7 +78,12 @@ export const TradeQuotes: React.FC<TradeQuotesProps> = ({ isOpen, isLoading }) =
         const totalReceiveAmountCryptoPrecision = bnOrZero(buyAmountBeforeFeesCryptoPrecision)
           .minus(totalProtocolFeeCryptoPrecision)
           .times(
-            bn(1).minus(bnOrZero(quote.recommendedSlippage ?? DEFAULT_SLIPPAGE_DECIMAL_PERCENTAGE)),
+            bn(1).minus(
+              bnOrZero(
+                quote.recommendedSlippage ??
+                  getDefaultSlippagePercentageForSwapper(swapperWithMetadata.swapper.name),
+              ),
+            ),
           )
           .toString()
 

--- a/src/constants/constants.ts
+++ b/src/constants/constants.ts
@@ -2,8 +2,10 @@ import { SwapperName } from 'lib/swapper/api'
 import { assertUnreachable } from 'lib/utils'
 
 export const USDC_PRECISION = 6
-export const DEFAULT_SLIPPAGE_DECIMAL_PERCENTAGE = '0.002' // .2%
-export const DEFAULT_COWSWAP_SLIPPAGE_DECIMAL_PERCENTAGE = '0.005' // .5%
+
+// Slippage defaults. Don't export these to ensure the getDefaultSlippagePercentageForSwapper helper function is used.
+const DEFAULT_SLIPPAGE_DECIMAL_PERCENTAGE = '0.002' // .2%
+const DEFAULT_COWSWAP_SLIPPAGE_DECIMAL_PERCENTAGE = '0.005' // .5%
 
 export const getDefaultSlippagePercentageForSwapper = (swapperName?: SwapperName): string => {
   if (swapperName === undefined) return DEFAULT_SLIPPAGE_DECIMAL_PERCENTAGE

--- a/src/constants/constants.ts
+++ b/src/constants/constants.ts
@@ -1,2 +1,23 @@
+import { SwapperName } from 'lib/swapper/api'
+import { assertUnreachable } from 'lib/utils'
+
 export const USDC_PRECISION = 6
-export const DEFAULT_SLIPPAGE = '0.002' // .2%
+export const DEFAULT_SLIPPAGE_DECIMAL_PERCENTAGE = '0.002' // .2%
+export const DEFAULT_COWSWAP_SLIPPAGE_DECIMAL_PERCENTAGE = '0.005' // .5%
+
+export const getDefaultSlippagePercentageForSwapper = (swapperName?: SwapperName): string => {
+  if (swapperName === undefined) return DEFAULT_SLIPPAGE_DECIMAL_PERCENTAGE
+  switch (swapperName) {
+    case SwapperName.Thorchain:
+    case SwapperName.Zrx:
+    case SwapperName.OneInch:
+    case SwapperName.Osmosis:
+    case SwapperName.LIFI:
+    case SwapperName.Test:
+      return DEFAULT_SLIPPAGE_DECIMAL_PERCENTAGE
+    case SwapperName.CowSwap:
+      return DEFAULT_COWSWAP_SLIPPAGE_DECIMAL_PERCENTAGE
+    default:
+      assertUnreachable(swapperName)
+  }
+}

--- a/src/lib/swapper/api.ts
+++ b/src/lib/swapper/api.ts
@@ -155,6 +155,7 @@ export interface TradeQuote<C extends ChainId, UnknownNetworkFee extends boolean
   minimumCryptoHuman: string
   maximumCryptoHuman: string
   recommendedSlippage?: string
+  id?: string
 }
 
 export interface Trade<C extends ChainId> extends TradeBase<C, false> {

--- a/src/lib/swapper/swappers/CowSwapper/CowSwapper.test.ts
+++ b/src/lib/swapper/swappers/CowSwapper/CowSwapper.test.ts
@@ -182,6 +182,7 @@ describe('CowSwapper', () => {
           networkFeeCryptoBaseUnit: '14557942658757988',
         },
         sellAmountDeductFeeCryptoBaseUnit: '985442057341242012',
+        id: '1',
       }
       const args = { trade: cowSwapTrade, wallet }
       await swapper.executeTrade(args)

--- a/src/lib/swapper/swappers/CowSwapper/CowSwapper.test.ts
+++ b/src/lib/swapper/swappers/CowSwapper/CowSwapper.test.ts
@@ -183,6 +183,7 @@ describe('CowSwapper', () => {
         },
         sellAmountDeductFeeCryptoBaseUnit: '985442057341242012',
         id: '1',
+        minimumBuyAmountAfterFeesCryptoBaseUnit: '14501811818247595090576',
       }
       const args = { trade: cowSwapTrade, wallet }
       await swapper.executeTrade(args)

--- a/src/lib/swapper/swappers/CowSwapper/cowBuildTrade/cowBuildTrade.test.ts
+++ b/src/lib/swapper/swappers/CowSwapper/cowBuildTrade/cowBuildTrade.test.ts
@@ -9,7 +9,7 @@ import * as selectors from 'state/zustand/swapperStore/amountSelectors'
 import type { BuildTradeInput } from '../../../api'
 import { SwapperName } from '../../../api'
 import { ETH, FOX, WBTC, WETH } from '../../utils/test-data/assets'
-import type { CowSwapperDeps } from '../CowSwapper'
+import type { CowSwapperDeps, CowSwapQuoteResponse } from '../CowSwapper'
 import type { CowTrade } from '../types'
 import { DEFAULT_ADDRESS, DEFAULT_APP_DATA } from '../utils/constants'
 import { cowService } from '../utils/cowService'
@@ -134,6 +134,7 @@ const expectedTradeWethToFox: CowTrade<KnownChainIds.EthereumMainnet> = {
   feeAmountInSellTokenCryptoBaseUnit: '14557942658757988',
   sellAmountDeductFeeCryptoBaseUnit: '985442057341242012',
   id: '1',
+  minimumBuyAmountAfterFeesCryptoBaseUnit: '14429302759156357115123.12',
 }
 
 const expectedTradeQuoteWbtcToWethWithApprovalFeeCryptoBaseUnit: CowTrade<KnownChainIds.EthereumMainnet> =
@@ -159,6 +160,7 @@ const expectedTradeQuoteWbtcToWethWithApprovalFeeCryptoBaseUnit: CowTrade<KnownC
     feeAmountInSellTokenCryptoBaseUnit: '17238',
     sellAmountDeductFeeCryptoBaseUnit: '99982762',
     id: '1',
+    minimumBuyAmountAfterFeesCryptoBaseUnit: '19043335024346774036.605',
   }
 
 const expectedTradeQuoteFoxToEth: CowTrade<KnownChainIds.EthereumMainnet> = {
@@ -183,6 +185,7 @@ const expectedTradeQuoteFoxToEth: CowTrade<KnownChainIds.EthereumMainnet> = {
   feeAmountInSellTokenCryptoBaseUnit: '61804771879693983744',
   sellAmountDeductFeeCryptoBaseUnit: '938195228120306016256',
   id: '1',
+  minimumBuyAmountAfterFeesCryptoBaseUnit: '51242479117266593',
 }
 
 const deps: CowSwapperDeps = {
@@ -210,6 +213,7 @@ describe('cowBuildTrade', () => {
       receiveAddress: DEFAULT_ADDRESS,
       affiliateBps: '0',
       eip1559Support: false,
+      slippage: '50',
     }
 
     const maybeCowBuildTrade = await cowBuildTrade(deps, tradeInput)
@@ -238,21 +242,22 @@ describe('cowBuildTrade', () => {
       receiveAddress: DEFAULT_ADDRESS,
       affiliateBps: '0',
       eip1559Support: false,
+      slippage: '50',
     }
 
     ;(cowService.post as jest.Mock<unknown>).mockReturnValue(
       Promise.resolve(
-        Ok({
+        Ok<{ data: CowSwapQuoteResponse }>({
           data: {
             quote: {
               ...expectedApiInputWethToFox,
-              sellAmountBeforeFee: undefined,
               sellAmount: '985442057341242012',
               buyAmount: '14501811818247595090576',
               feeAmount: '14557942658757988',
-              sellTokenBalance: 'erc20',
-              buyTokenBalance: 'erc20',
             },
+            from: '0x32DBc9Cf9E8FbCebE1e0a2ecF05Ed86Ca3096Cb6',
+            expiration: '1684901061',
+            id: '1',
           },
         }),
       ),
@@ -283,21 +288,22 @@ describe('cowBuildTrade', () => {
       receiveAddress: DEFAULT_ADDRESS,
       affiliateBps: '0',
       eip1559Support: false,
+      slippage: '50',
     }
 
     ;(cowService.post as jest.Mock<unknown>).mockReturnValue(
       Promise.resolve(
-        Ok({
+        Ok<{ data: CowSwapQuoteResponse }>({
           data: {
             quote: {
               ...expectedApiInputWbtcToWeth,
-              sellAmountBeforeFee: undefined,
               sellAmount: '99982762',
               buyAmount: '19139030175222888479',
               feeAmount: '17238',
-              sellTokenBalance: 'erc20',
-              buyTokenBalance: 'erc20',
             },
+            from: '0x32DBc9Cf9E8FbCebE1e0a2ecF05Ed86Ca3096Cb6',
+            expiration: '1684901061',
+            id: '1',
           },
         }),
       ),
@@ -334,17 +340,17 @@ describe('cowBuildTrade', () => {
 
     ;(cowService.post as jest.Mock<unknown>).mockReturnValue(
       Promise.resolve(
-        Ok({
+        Ok<{ data: CowSwapQuoteResponse }>({
           data: {
             quote: {
               ...expectedApiInputFoxToEth,
-              sellAmountBeforeFee: undefined,
               sellAmount: '938195228120306016256',
               buyAmount: '51242479117266593',
               feeAmount: '61804771879693983744',
-              sellTokenBalance: 'erc20',
-              buyTokenBalance: 'erc20',
             },
+            from: '0x32DBc9Cf9E8FbCebE1e0a2ecF05Ed86Ca3096Cb6',
+            expiration: '1684901061',
+            id: '1',
           },
         }),
       ),

--- a/src/lib/swapper/swappers/CowSwapper/cowBuildTrade/cowBuildTrade.test.ts
+++ b/src/lib/swapper/swappers/CowSwapper/cowBuildTrade/cowBuildTrade.test.ts
@@ -3,6 +3,7 @@ import type { HDWallet } from '@shapeshiftoss/hdwallet-core'
 import { KnownChainIds } from '@shapeshiftoss/types'
 import { Ok } from '@sniptt/monads'
 import type { AxiosStatic } from 'axios'
+import { getDefaultSlippagePercentageForSwapper } from 'constants/constants'
 import type Web3 from 'web3'
 import * as selectors from 'state/zustand/swapperStore/amountSelectors'
 
@@ -134,7 +135,7 @@ const expectedTradeWethToFox: CowTrade<KnownChainIds.EthereumMainnet> = {
   feeAmountInSellTokenCryptoBaseUnit: '14557942658757988',
   sellAmountDeductFeeCryptoBaseUnit: '985442057341242012',
   id: '1',
-  minimumBuyAmountAfterFeesCryptoBaseUnit: '14429302759156357115123.12',
+  minimumBuyAmountAfterFeesCryptoBaseUnit: '14472808194611099900395',
 }
 
 const expectedTradeQuoteWbtcToWethWithApprovalFeeCryptoBaseUnit: CowTrade<KnownChainIds.EthereumMainnet> =
@@ -160,7 +161,7 @@ const expectedTradeQuoteWbtcToWethWithApprovalFeeCryptoBaseUnit: CowTrade<KnownC
     feeAmountInSellTokenCryptoBaseUnit: '17238',
     sellAmountDeductFeeCryptoBaseUnit: '99982762',
     id: '1',
-    minimumBuyAmountAfterFeesCryptoBaseUnit: '19043335024346774036.605',
+    minimumBuyAmountAfterFeesCryptoBaseUnit: '19100752114872442703',
   }
 
 const expectedTradeQuoteFoxToEth: CowTrade<KnownChainIds.EthereumMainnet> = {
@@ -213,7 +214,7 @@ describe('cowBuildTrade', () => {
       receiveAddress: DEFAULT_ADDRESS,
       affiliateBps: '0',
       eip1559Support: false,
-      slippage: '50',
+      slippage: getDefaultSlippagePercentageForSwapper(SwapperName.Test),
     }
 
     const maybeCowBuildTrade = await cowBuildTrade(deps, tradeInput)
@@ -242,7 +243,7 @@ describe('cowBuildTrade', () => {
       receiveAddress: DEFAULT_ADDRESS,
       affiliateBps: '0',
       eip1559Support: false,
-      slippage: '50',
+      slippage: getDefaultSlippagePercentageForSwapper(SwapperName.Test),
     }
 
     ;(cowService.post as jest.Mock<unknown>).mockReturnValue(
@@ -288,7 +289,7 @@ describe('cowBuildTrade', () => {
       receiveAddress: DEFAULT_ADDRESS,
       affiliateBps: '0',
       eip1559Support: false,
-      slippage: '50',
+      slippage: getDefaultSlippagePercentageForSwapper(SwapperName.Test),
     }
 
     ;(cowService.post as jest.Mock<unknown>).mockReturnValue(

--- a/src/lib/swapper/swappers/CowSwapper/cowBuildTrade/cowBuildTrade.test.ts
+++ b/src/lib/swapper/swappers/CowSwapper/cowBuildTrade/cowBuildTrade.test.ts
@@ -133,6 +133,7 @@ const expectedTradeWethToFox: CowTrade<KnownChainIds.EthereumMainnet> = {
   receiveAddress: DEFAULT_ADDRESS,
   feeAmountInSellTokenCryptoBaseUnit: '14557942658757988',
   sellAmountDeductFeeCryptoBaseUnit: '985442057341242012',
+  id: '1',
 }
 
 const expectedTradeQuoteWbtcToWethWithApprovalFeeCryptoBaseUnit: CowTrade<KnownChainIds.EthereumMainnet> =
@@ -157,6 +158,7 @@ const expectedTradeQuoteWbtcToWethWithApprovalFeeCryptoBaseUnit: CowTrade<KnownC
     receiveAddress: DEFAULT_ADDRESS,
     feeAmountInSellTokenCryptoBaseUnit: '17238',
     sellAmountDeductFeeCryptoBaseUnit: '99982762',
+    id: '1',
   }
 
 const expectedTradeQuoteFoxToEth: CowTrade<KnownChainIds.EthereumMainnet> = {
@@ -180,6 +182,7 @@ const expectedTradeQuoteFoxToEth: CowTrade<KnownChainIds.EthereumMainnet> = {
   receiveAddress: DEFAULT_ADDRESS,
   feeAmountInSellTokenCryptoBaseUnit: '61804771879693983744',
   sellAmountDeductFeeCryptoBaseUnit: '938195228120306016256',
+  id: '1',
 }
 
 const deps: CowSwapperDeps = {

--- a/src/lib/swapper/swappers/CowSwapper/cowBuildTrade/cowBuildTrade.ts
+++ b/src/lib/swapper/swappers/CowSwapper/cowBuildTrade/cowBuildTrade.ts
@@ -94,8 +94,6 @@ export async function cowBuildTrade(
   const {
     data: {
       quote: {
-        // fixme: this is the minimum ("To at least") amount, which is currently the before fees amount
-        // it should be the amount after fees, that comes back from the quote
         buyAmount: buyAmountAfterFeesCryptoBaseUnit,
         sellAmount: quoteSellAmountExcludeFeeCryptoBaseUnit,
         feeAmount: feeAmountInSellTokenCryptoBaseUnit,

--- a/src/lib/swapper/swappers/CowSwapper/cowBuildTrade/cowBuildTrade.ts
+++ b/src/lib/swapper/swappers/CowSwapper/cowBuildTrade/cowBuildTrade.ts
@@ -21,7 +21,10 @@ import {
   selectSellAssetUsdRate,
 } from 'state/zustand/swapperStore/amountSelectors'
 import { swapperStore } from 'state/zustand/swapperStore/useSwapperStore'
-import { subtractBasisPoints } from 'state/zustand/swapperStore/utils'
+import {
+  convertDecimalPercentageToBasisPoints,
+  subtractBasisPointAmount,
+} from 'state/zustand/swapperStore/utils'
 
 export async function cowBuildTrade(
   deps: CowSwapperDeps,
@@ -132,9 +135,12 @@ export async function cowBuildTrade(
     .div(quoteSellAmountCryptoPrecision)
     .toString()
 
-  const minimumBuyAmountAfterFeesCryptoBaseUnit = subtractBasisPoints(
+  const slippageBps = convertDecimalPercentageToBasisPoints(slippage ?? '0').toString()
+
+  const minimumBuyAmountAfterFeesCryptoBaseUnit = subtractBasisPointAmount(
     buyAmountAfterFeesCryptoBaseUnit,
-    slippage ?? '0',
+    slippageBps,
+    true,
   )
 
   const trade: CowTrade<KnownChainIds.EthereumMainnet> = {

--- a/src/lib/swapper/swappers/CowSwapper/cowBuildTrade/cowBuildTrade.ts
+++ b/src/lib/swapper/swappers/CowSwapper/cowBuildTrade/cowBuildTrade.ts
@@ -94,6 +94,7 @@ export async function cowBuildTrade(
         sellAmount: quoteSellAmountExcludeFeeCryptoBaseUnit,
         feeAmount: feeAmountInSellTokenCryptoBaseUnit,
       },
+      id,
     },
   } = maybeQuoteResponse.unwrap()
 
@@ -149,6 +150,7 @@ export async function cowBuildTrade(
     receiveAddress,
     feeAmountInSellTokenCryptoBaseUnit,
     sellAmountDeductFeeCryptoBaseUnit: quoteSellAmountExcludeFeeCryptoBaseUnit,
+    id,
   }
 
   return Ok(trade)

--- a/src/lib/swapper/swappers/CowSwapper/cowExecuteTrade/cowExecuteTrade.test.ts
+++ b/src/lib/swapper/swappers/CowSwapper/cowExecuteTrade/cowExecuteTrade.test.ts
@@ -75,6 +75,7 @@ const cowTradeEthToFox: CowTrade<KnownChainIds.EthereumMainnet> = {
   receiveAddress: 'address11',
   feeAmountInSellTokenCryptoBaseUnit: '14557942658757988',
   sellAmountDeductFeeCryptoBaseUnit: '111111',
+  id: '1',
 }
 
 const cowTradeWethToFox: CowTrade<KnownChainIds.EthereumMainnet> = {
@@ -92,6 +93,7 @@ const cowTradeWethToFox: CowTrade<KnownChainIds.EthereumMainnet> = {
   receiveAddress: 'address11',
   feeAmountInSellTokenCryptoBaseUnit: '3514395197690019',
   sellAmountDeductFeeCryptoBaseUnit: '16685605000000000',
+  id: '1',
 }
 
 const cowTradeFoxToEth: CowTrade<KnownChainIds.EthereumMainnet> = {
@@ -115,6 +117,7 @@ const cowTradeFoxToEth: CowTrade<KnownChainIds.EthereumMainnet> = {
   receiveAddress: 'address11',
   feeAmountInSellTokenCryptoBaseUnit: '61804771879693983744',
   sellAmountDeductFeeCryptoBaseUnit: '938195228120306016256',
+  id: '1',
 }
 
 const expectedWethToFoxOrderToSign: CowSwapOrder = {
@@ -130,6 +133,7 @@ const expectedWethToFoxOrderToSign: CowSwapOrder = {
   receiver: 'address11',
   sellTokenBalance: ERC20_TOKEN_BALANCE,
   buyTokenBalance: ERC20_TOKEN_BALANCE,
+  quoteId: '1',
 }
 
 const expectedFoxToEthOrderToSign: CowSwapOrder = {
@@ -145,6 +149,7 @@ const expectedFoxToEthOrderToSign: CowSwapOrder = {
   receiver: 'address11',
   sellTokenBalance: ERC20_TOKEN_BALANCE,
   buyTokenBalance: ERC20_TOKEN_BALANCE,
+  quoteId: '1',
 }
 
 const deps: CowSwapperDeps = {

--- a/src/lib/swapper/swappers/CowSwapper/cowExecuteTrade/cowExecuteTrade.test.ts
+++ b/src/lib/swapper/swappers/CowSwapper/cowExecuteTrade/cowExecuteTrade.test.ts
@@ -76,6 +76,7 @@ const cowTradeEthToFox: CowTrade<KnownChainIds.EthereumMainnet> = {
   feeAmountInSellTokenCryptoBaseUnit: '14557942658757988',
   sellAmountDeductFeeCryptoBaseUnit: '111111',
   id: '1',
+  minimumBuyAmountAfterFeesCryptoBaseUnit: '14501811818247595090576',
 }
 
 const cowTradeWethToFox: CowTrade<KnownChainIds.EthereumMainnet> = {
@@ -94,6 +95,7 @@ const cowTradeWethToFox: CowTrade<KnownChainIds.EthereumMainnet> = {
   feeAmountInSellTokenCryptoBaseUnit: '3514395197690019',
   sellAmountDeductFeeCryptoBaseUnit: '16685605000000000',
   id: '1',
+  minimumBuyAmountAfterFeesCryptoBaseUnit: '272522025311597443544',
 }
 
 const cowTradeFoxToEth: CowTrade<KnownChainIds.EthereumMainnet> = {
@@ -118,6 +120,7 @@ const cowTradeFoxToEth: CowTrade<KnownChainIds.EthereumMainnet> = {
   feeAmountInSellTokenCryptoBaseUnit: '61804771879693983744',
   sellAmountDeductFeeCryptoBaseUnit: '938195228120306016256',
   id: '1',
+  minimumBuyAmountAfterFeesCryptoBaseUnit: '46868859830863283',
 }
 
 const expectedWethToFoxOrderToSign: CowSwapOrder = {

--- a/src/lib/swapper/swappers/CowSwapper/cowExecuteTrade/cowExecuteTrade.ts
+++ b/src/lib/swapper/swappers/CowSwapper/cowExecuteTrade/cowExecuteTrade.ts
@@ -38,6 +38,7 @@ export async function cowExecuteTrade(
     sellAmountDeductFeeCryptoBaseUnit: sellAmountWithoutFee,
     accountNumber,
     id,
+    minimumBuyAmountAfterFeesCryptoBaseUnit,
   } = cowTrade
 
   const { assetReference: sellAssetErc20Address, assetNamespace: sellAssetNamespace } = fromAssetId(
@@ -74,7 +75,7 @@ export async function cowExecuteTrade(
     sellToken: sellAssetErc20Address,
     buyToken,
     sellAmount: sellAmountWithoutFee,
-    buyAmount: trade.buyAmountBeforeFeesCryptoBaseUnit,
+    buyAmount: minimumBuyAmountAfterFeesCryptoBaseUnit, // this is used as the minimum accepted receive amount before the trade will execute
     validTo: getNowPlusThirtyMinutesTimestamp(),
     appData: DEFAULT_APP_DATA,
     feeAmount: feeAmountInSellToken,

--- a/src/lib/swapper/swappers/CowSwapper/cowExecuteTrade/cowExecuteTrade.ts
+++ b/src/lib/swapper/swappers/CowSwapper/cowExecuteTrade/cowExecuteTrade.ts
@@ -37,6 +37,7 @@ export async function cowExecuteTrade(
     feeAmountInSellTokenCryptoBaseUnit: feeAmountInSellToken,
     sellAmountDeductFeeCryptoBaseUnit: sellAmountWithoutFee,
     accountNumber,
+    id,
   } = cowTrade
 
   const { assetReference: sellAssetErc20Address, assetNamespace: sellAssetNamespace } = fromAssetId(
@@ -82,6 +83,7 @@ export async function cowExecuteTrade(
     receiver: trade.receiveAddress,
     sellTokenBalance: ERC20_TOKEN_BALANCE,
     buyTokenBalance: ERC20_TOKEN_BALANCE,
+    quoteId: id,
   }
 
   // We need to construct orderDigest, sign it and send it to cowSwap API, in order to submit a trade
@@ -122,6 +124,7 @@ export async function cowExecuteTrade(
    * signingScheme: the signing scheme used for the signature
    * signature: a signed message specific to cowswap for this order
    * from: same as receiver address in our case
+   * orderId: Orders can optionally include a quote ID. This way the order can be linked to a quote and enable providing more metadata when analyzing order slippage.
    * }
    */
   const maybeOrdersResponse = await cowService.post<string>(`${apiUrl}/v1/orders/`, {

--- a/src/lib/swapper/swappers/CowSwapper/getCowSwapTradeQuote/getCowSwapTradeQuote.ts
+++ b/src/lib/swapper/swappers/CowSwapper/getCowSwapTradeQuote/getCowSwapTradeQuote.ts
@@ -103,6 +103,7 @@ export async function getCowSwapTradeQuote(
         sellAmount: sellAmountCryptoBaseUnit,
         feeAmount: feeAmountInSellTokenCryptoBaseUnit,
       },
+      id,
     },
   } = maybeQuoteResponse.unwrap()
 
@@ -155,7 +156,7 @@ export async function getCowSwapTradeQuote(
     ? '0'
     : buyAmountBeforeFeesCryptoBaseUnit
 
-  const quote = {
+  const quote: TradeQuote<KnownChainIds.EthereumMainnet> = {
     rate,
     minimumCryptoHuman: minimumAmountCryptoHuman,
     maximumCryptoHuman: maximumAmountCryptoHuman,
@@ -176,6 +177,7 @@ export async function getCowSwapTradeQuote(
     buyAsset,
     sellAsset,
     accountNumber,
+    id,
   }
 
   return Ok(quote)

--- a/src/lib/swapper/swappers/CowSwapper/types.ts
+++ b/src/lib/swapper/swappers/CowSwapper/types.ts
@@ -16,6 +16,7 @@ export type CowSwapQuoteResponse = {
   }
   from: string
   expiration: string
+  id: string
 }
 
 export type CowSwapGetOrdersResponse = {
@@ -31,4 +32,5 @@ export type CowSwapGetTradesResponse = CowSwapGetTradesElement[]
 export interface CowTrade<C extends ChainId> extends Trade<C> {
   feeAmountInSellTokenCryptoBaseUnit: string
   sellAmountDeductFeeCryptoBaseUnit: string
+  id: string
 }

--- a/src/lib/swapper/swappers/CowSwapper/types.ts
+++ b/src/lib/swapper/swappers/CowSwapper/types.ts
@@ -32,5 +32,6 @@ export type CowSwapGetTradesResponse = CowSwapGetTradesElement[]
 export interface CowTrade<C extends ChainId> extends Trade<C> {
   feeAmountInSellTokenCryptoBaseUnit: string
   sellAmountDeductFeeCryptoBaseUnit: string
+  minimumBuyAmountAfterFeesCryptoBaseUnit: string
   id: string
 }

--- a/src/lib/swapper/swappers/CowSwapper/utils/helpers/helpers.test.ts
+++ b/src/lib/swapper/swappers/CowSwapper/utils/helpers/helpers.test.ts
@@ -46,6 +46,7 @@ describe('utils', () => {
         receiver: '0xFc81A7B9f715A344A7c4ABFc444A774c3E9BA42D',
         sellTokenBalance: 'erc20',
         buyTokenBalance: 'erc20',
+        quoteId: '1',
       }
 
       const orderDigest = hashOrder(domain(1, '0x9008D19f58AAbD9eD0D60971565AA8510560ab41'), order)

--- a/src/lib/swapper/swappers/CowSwapper/utils/helpers/helpers.ts
+++ b/src/lib/swapper/swappers/CowSwapper/utils/helpers/helpers.ts
@@ -34,6 +34,7 @@ export type CowSwapOrder = {
   receiver: string
   sellTokenBalance: string
   buyTokenBalance: string
+  quoteId: string
 }
 
 export type CowSwapQuoteApiInputBase = {

--- a/src/lib/swapper/swappers/LifiSwapper/getTradeQuote/getTradeQuote.ts
+++ b/src/lib/swapper/swappers/LifiSwapper/getTradeQuote/getTradeQuote.ts
@@ -4,7 +4,7 @@ import type { ChainId } from '@shapeshiftoss/caip'
 import { fromChainId } from '@shapeshiftoss/caip'
 import type { Result } from '@sniptt/monads'
 import { Err, Ok } from '@sniptt/monads'
-import { DEFAULT_SLIPPAGE_DECIMAL_PERCENTAGE } from 'constants/constants'
+import { getDefaultSlippagePercentageForSwapper } from 'constants/constants'
 import { DAO_TREASURY_ETHEREUM_MAINNET } from 'constants/treasury'
 import { BigNumber, bn, bnOrZero, convertPrecision } from 'lib/bignumber/bignumber'
 import type { GetEvmTradeQuoteInput, SwapErrorRight } from 'lib/swapper/api'
@@ -38,6 +38,8 @@ export async function getTradeQuote(
 
     const sellLifiChainKey = lifiChainMap.get(sellAsset.chainId)
     const buyLifiChainKey = lifiChainMap.get(buyAsset.chainId)
+
+    const defaultLifiSwapperSlippage = getDefaultSlippagePercentageForSwapper(SwapperName.LIFI)
 
     if (sellLifiChainKey === undefined) {
       throw new SwapError(
@@ -79,7 +81,7 @@ export async function getTradeQuote(
       options: {
         // used for analytics - do not change this without considering impact
         integrator: DAO_TREASURY_ETHEREUM_MAINNET,
-        slippage: Number(DEFAULT_SLIPPAGE_DECIMAL_PERCENTAGE),
+        slippage: Number(defaultLifiSwapperSlippage),
         exchanges: { deny: ['dodo'] },
         // as recommended by lifi, allowSwitchChain must be false to ensure single-hop transactions.
         // This must remain disabled until our application supports multi-hop swaps

--- a/src/lib/swapper/swappers/LifiSwapper/getTradeQuote/getTradeQuote.ts
+++ b/src/lib/swapper/swappers/LifiSwapper/getTradeQuote/getTradeQuote.ts
@@ -4,7 +4,7 @@ import type { ChainId } from '@shapeshiftoss/caip'
 import { fromChainId } from '@shapeshiftoss/caip'
 import type { Result } from '@sniptt/monads'
 import { Err, Ok } from '@sniptt/monads'
-import { DEFAULT_SLIPPAGE } from 'constants/constants'
+import { DEFAULT_SLIPPAGE_DECIMAL_PERCENTAGE } from 'constants/constants'
 import { DAO_TREASURY_ETHEREUM_MAINNET } from 'constants/treasury'
 import { BigNumber, bn, bnOrZero, convertPrecision } from 'lib/bignumber/bignumber'
 import type { GetEvmTradeQuoteInput, SwapErrorRight } from 'lib/swapper/api'
@@ -79,7 +79,7 @@ export async function getTradeQuote(
       options: {
         // used for analytics - do not change this without considering impact
         integrator: DAO_TREASURY_ETHEREUM_MAINNET,
-        slippage: Number(DEFAULT_SLIPPAGE),
+        slippage: Number(DEFAULT_SLIPPAGE_DECIMAL_PERCENTAGE),
         exchanges: { deny: ['dodo'] },
         // as recommended by lifi, allowSwitchChain must be false to ensure single-hop transactions.
         // This must remain disabled until our application supports multi-hop swaps

--- a/src/lib/swapper/swappers/utils/test-data/setupSwapQuote.ts
+++ b/src/lib/swapper/swappers/utils/test-data/setupSwapQuote.ts
@@ -52,6 +52,7 @@ export const setupBuildTrade = () => {
     receiveAddress: '',
     affiliateBps: '0',
     eip1559Support: false,
+    slippage: '50',
   }
   return { buildTradeInput, buyAsset, sellAsset }
 }

--- a/src/lib/swapper/swappers/utils/test-data/setupSwapQuote.ts
+++ b/src/lib/swapper/swappers/utils/test-data/setupSwapQuote.ts
@@ -1,7 +1,9 @@
 import type { HDWallet } from '@shapeshiftoss/hdwallet-core'
 import { KnownChainIds } from '@shapeshiftoss/types'
+import { getDefaultSlippagePercentageForSwapper } from 'constants/constants'
 import type { Asset } from 'lib/asset-service'
 import type { BuildTradeInput, GetTradeQuoteInput, TradeQuote } from 'lib/swapper/api'
+import { SwapperName } from 'lib/swapper/api'
 import { FOX, WETH } from 'lib/swapper/swappers/utils/test-data/assets'
 
 export const setupQuote = () => {
@@ -52,7 +54,7 @@ export const setupBuildTrade = () => {
     receiveAddress: '',
     affiliateBps: '0',
     eip1559Support: false,
-    slippage: '50',
+    slippage: getDefaultSlippagePercentageForSwapper(SwapperName.Test),
   }
   return { buildTradeInput, buyAsset, sellAsset }
 }

--- a/src/state/zustand/swapperStore/selectors.ts
+++ b/src/state/zustand/swapperStore/selectors.ts
@@ -4,7 +4,7 @@ import type { HDWallet } from '@shapeshiftoss/hdwallet-core'
 import { supportsETH } from '@shapeshiftoss/hdwallet-core'
 import type { BIP44Params } from '@shapeshiftoss/types'
 import type { Result } from '@sniptt/monads'
-import { DEFAULT_SLIPPAGE } from 'constants/constants'
+import { getDefaultSlippagePercentageForSwapper } from 'constants/constants'
 import {
   isCosmosSdkSwap,
   isEvmSwap,
@@ -49,7 +49,8 @@ export const selectActiveSwapperWithMetadata = (state: SwapperState) =>
 export const selectAvailableSwappersWithMetadata = (state: SwapperState) =>
   state.availableSwappersWithMetadata
 export const selectSlippage = (state: SwapperState): string =>
-  state.activeSwapperWithMetadata?.quote.recommendedSlippage ?? DEFAULT_SLIPPAGE
+  state.activeSwapperWithMetadata?.quote.recommendedSlippage ??
+  getDefaultSlippagePercentageForSwapper(state.activeSwapperWithMetadata?.swapper.name)
 
 export const selectQuote = (state: SwapperState): TradeQuote<ChainId> | undefined =>
   state.activeSwapperWithMetadata?.quote

--- a/src/state/zustand/swapperStore/utils.test.ts
+++ b/src/state/zustand/swapperStore/utils.test.ts
@@ -4,7 +4,7 @@ import type { ProtocolFee } from 'lib/swapper/api'
 import { BTC, ETH, FOX } from 'lib/swapper/swappers/utils/test-data/assets'
 import { cryptoMarketDataById } from 'lib/swapper/swappers/utils/test-data/cryptoMarketDataById'
 
-import { sumProtocolFeesToDenom } from './utils'
+import { subtractBasisPoints, sumProtocolFeesToDenom } from './utils'
 
 describe('sumProtocolFeesToDenom', () => {
   it("returns '0' for empty object", () => {
@@ -102,5 +102,27 @@ describe('sumProtocolFeesToDenom', () => {
     const expectation = btcAmountInUsd.plus(ethAmountInUsd).toString()
 
     expect(result).toEqual(expectation)
+  })
+})
+
+describe('subtractBasisPoints', () => {
+  test('should subtract 100 basis points correctly', () => {
+    const result = subtractBasisPoints('100', '100')
+    expect(result).toBe('99')
+  })
+
+  test('should subtract 0 basis points correctly', () => {
+    const result = subtractBasisPoints('100', '0')
+    expect(result).toBe('100')
+  })
+
+  test('should subtract 10000 basis points correctly', () => {
+    const result = subtractBasisPoints('100', '10000')
+    expect(result).toBe('0')
+  })
+
+  test('should handle very large numbers correctly', () => {
+    const result = subtractBasisPoints('123456789012345678901234567890', '100')
+    expect(result).toBe('122222221122222222112222222211.1')
   })
 })

--- a/src/state/zustand/swapperStore/utils.test.ts
+++ b/src/state/zustand/swapperStore/utils.test.ts
@@ -4,7 +4,7 @@ import type { ProtocolFee } from 'lib/swapper/api'
 import { BTC, ETH, FOX } from 'lib/swapper/swappers/utils/test-data/assets'
 import { cryptoMarketDataById } from 'lib/swapper/swappers/utils/test-data/cryptoMarketDataById'
 
-import { subtractBasisPoints, sumProtocolFeesToDenom } from './utils'
+import { subtractBasisPointAmount, sumProtocolFeesToDenom } from './utils'
 
 describe('sumProtocolFeesToDenom', () => {
   it("returns '0' for empty object", () => {
@@ -107,22 +107,22 @@ describe('sumProtocolFeesToDenom', () => {
 
 describe('subtractBasisPoints', () => {
   test('should subtract 100 basis points correctly', () => {
-    const result = subtractBasisPoints('100', '100')
+    const result = subtractBasisPointAmount('100', '100')
     expect(result).toBe('99')
   })
 
   test('should subtract 0 basis points correctly', () => {
-    const result = subtractBasisPoints('100', '0')
+    const result = subtractBasisPointAmount('100', '0')
     expect(result).toBe('100')
   })
 
   test('should subtract 10000 basis points correctly', () => {
-    const result = subtractBasisPoints('100', '10000')
+    const result = subtractBasisPointAmount('100', '10000')
     expect(result).toBe('0')
   })
 
   test('should handle very large numbers correctly', () => {
-    const result = subtractBasisPoints('123456789012345678901234567890', '100')
+    const result = subtractBasisPointAmount('123456789012345678901234567890', '100')
     expect(result).toBe('122222221122222222112222222211.1')
   })
 })

--- a/src/state/zustand/swapperStore/utils.test.ts
+++ b/src/state/zustand/swapperStore/utils.test.ts
@@ -121,8 +121,18 @@ describe('subtractBasisPoints', () => {
     expect(result).toBe('0')
   })
 
+  test('should subtract 20000 basis points correctly', () => {
+    const result = subtractBasisPointAmount('100', '20000')
+    expect(result).toBe('-100')
+  })
+
   test('should handle very large numbers correctly', () => {
     const result = subtractBasisPointAmount('123456789012345678901234567890', '100')
     expect(result).toBe('122222221122222222112222222211.1')
+  })
+
+  test('should round up correctly', () => {
+    const result = subtractBasisPointAmount('123456789012345678901234567890', '100', true)
+    expect(result).toBe('122222221122222222112222222212')
   })
 })

--- a/src/state/zustand/swapperStore/utils.ts
+++ b/src/state/zustand/swapperStore/utils.ts
@@ -1,8 +1,7 @@
 // Helper function to convert basis points to percentage
 import type { AssetId } from '@shapeshiftoss/caip'
 import type { MarketData } from '@shapeshiftoss/types'
-import type { BigNumber } from 'lib/bignumber/bignumber'
-import { bn, bnOrZero, convertPrecision } from 'lib/bignumber/bignumber'
+import { BigNumber, bn, bnOrZero, convertPrecision } from 'lib/bignumber/bignumber'
 import type { ProtocolFee } from 'lib/swapper/api'
 
 export const convertBasisPointsToDecimalPercentage = (basisPoints: string) =>
@@ -42,7 +41,7 @@ export const subtractBasisPointAmount = (
 
   // Subtract basis points from the original value
   const resultValue = bigNumValue.minus(subtractValue)
-  return roundUp ? resultValue.toFixed(0, 0) : resultValue.toFixed()
+  return roundUp ? resultValue.toFixed(0, BigNumber.ROUND_UP) : resultValue.toFixed()
 }
 
 // this converts the collection of protocol fees denominated in various assets to the sum of all of

--- a/src/state/zustand/swapperStore/utils.ts
+++ b/src/state/zustand/swapperStore/utils.ts
@@ -8,6 +8,9 @@ import type { ProtocolFee } from 'lib/swapper/api'
 export const convertBasisPointsToDecimalPercentage = (basisPoints: string) =>
   bnOrZero(basisPoints).div(10000)
 
+export const convertDecimalPercentageToBasisPoints = (decimalPercentage: string) =>
+  bnOrZero(decimalPercentage).times(10000)
+
 export const convertBasisPointsToPercentage = (basisPoints: string) =>
   bnOrZero(basisPoints).div(100)
 
@@ -19,14 +22,18 @@ type SumProtocolFeesToDenomArgs = {
 }
 
 /**
- * Subtracts basis points from a given value.
+ * Subtracts basis point amount from a given value.
  *
  * @param value The value to subtract basis points from.
  * @param basisPoints The number of basis points to subtract.
+ * @param roundUp Round up the result to the nearest integer.
  * @returns The new number that is the input value minus the basis points of the value.
  */
-export const subtractBasisPoints = (value: string, basisPoints: string): string => {
-  // Convert input to a BigNumber instance
+export const subtractBasisPointAmount = (
+  value: string,
+  basisPoints: string,
+  roundUp?: boolean,
+): string => {
   const bigNumValue = bn(value)
 
   // Basis point is 1/100th of a percent
@@ -35,7 +42,7 @@ export const subtractBasisPoints = (value: string, basisPoints: string): string 
 
   // Subtract basis points from the original value
   const resultValue = bigNumValue.minus(subtractValue)
-  return resultValue.toFixed()
+  return roundUp ? resultValue.toFixed(0, 0) : resultValue.toFixed()
 }
 
 // this converts the collection of protocol fees denominated in various assets to the sum of all of

--- a/src/state/zustand/swapperStore/utils.ts
+++ b/src/state/zustand/swapperStore/utils.ts
@@ -18,6 +18,26 @@ type SumProtocolFeesToDenomArgs = {
   protocolFees: Record<AssetId, ProtocolFee>
 }
 
+/**
+ * Subtracts basis points from a given value.
+ *
+ * @param value The value to subtract basis points from.
+ * @param basisPoints The number of basis points to subtract.
+ * @returns The new number that is the input value minus the basis points of the value.
+ */
+export const subtractBasisPoints = (value: string, basisPoints: string): string => {
+  // Convert input to a BigNumber instance
+  const bigNumValue = bn(value)
+
+  // Basis point is 1/100th of a percent
+  const percentValue = convertBasisPointsToDecimalPercentage(basisPoints)
+  const subtractValue = bigNumValue.times(percentValue)
+
+  // Subtract basis points from the original value
+  const resultValue = bigNumValue.minus(subtractValue)
+  return resultValue.toFixed()
+}
+
 // this converts the collection of protocol fees denominated in various assets to the sum of all of
 // their values denominated in single asset and precision
 export const sumProtocolFeesToDenom = ({


### PR DESCRIPTION
## Description

Fixes the value of `buyAmount`, which represents the minimum amount that we will accept, when executing a CoW Swap trade.

Previously, we were using the amount amount including fees as the minimum receive amount, which was always going to fail.

Now, we use the `buyAmount` return value of the CoW to estimate how much we can actually expect to get, and then deduct appropriate slippage (0.5%).

This PR also links the trade to the trade quote by passing through the `id`, which conforms with CoW Swap best practice, and gives us additional metadata on the CoW Swap explorer.

## Pull Request Type

- [x] :bug: Bug fix (Non-breaking Change: Fixes an issue)
- [ ] :hammer_and_wrench: Chore (Non-breaking Change: Doc updates, pkg upgrades, typos, etc..)
- [ ] :nail_care: New Feature (Breaking/Non-breaking Change)

## Issue (if applicable)

Closes https://github.com/shapeshift/web/issues/4497

## Risk

Medium risk to CoW Swap trades, though the logic changes in this PR are contained to the CoW Swapper.

## Testing

Perform a CoW Swap trade and:

1. Ensure that the amount that we show as the expected amount after slippage is the value used in the "To at least" section of a the trade (visible on explorer.cow.fi)

2. Ensure that the trade completes as expected

### Engineering

☝️

Side note, I want to migrate `slippage` to be `slippageBps` for better consistency, but that's for another PR.

### Operations

☝️

## Screenshots (if applicable)

https://explorer.cow.fi/orders/0xf7d50af88ac5f85d7ac83aef72806fae9343906943e0c7838c524d24750bd99932dbc9cf9e8fbcebe1e0a2ecf05ed86ca3096cb6646eaea7?tab=overview

<img width="837" alt="Screenshot 2023-05-25 at 11 22 28 am" src="https://github.com/shapeshift/web/assets/97164662/97105a3c-b29a-404c-b424-2f909c7711ea">

