### PR TITLE
fix: make WC2 safer

### DIFF
--- a/src/hooks/useWalletSupportsChain/useWalletSupportsChain.ts
+++ b/src/hooks/useWalletSupportsChain/useWalletSupportsChain.ts
@@ -62,7 +62,7 @@ export const walletSupportsChain: UseWalletSupportsChain = ({ chainId, wallet })
     case thorchainChainId:
       return supportsThorchain(wallet)
     default: {
-      moduleLogger.error(`useWalletSupportsChain: unknown chain id ${chainId}`)
+      moduleLogger.warn(`useWalletSupportsChain: unknown chain id ${chainId}`)
       return false
     }
   }

--- a/src/plugins/walletConnectToDapps/v2/components/DAppInfo.tsx
+++ b/src/plugins/walletConnectToDapps/v2/components/DAppInfo.tsx
@@ -4,16 +4,18 @@ import type { FC } from 'react'
 import { FoxIcon } from 'components/Icons/FoxIcon'
 
 interface IProps {
-  metadata: SignClientTypes.Metadata
+  // Override the icons type, as it's incorrect - "icons" can indeed be undefined in the wild.
+  metadata: Omit<SignClientTypes.Metadata, 'icons'> & { icons: string[] | undefined }
 }
 
 export const DAppInfo: FC<IProps> = ({ metadata }) => {
   const { icons, name, url, description } = metadata
+  const icon = icons && icons.length > 0 ? icons[0] : undefined
 
   return (
     <Grid templateRows='repeat(2, 1fr)' templateColumns='repeat(5, 1fr)' gap={4}>
       <GridItem rowSpan={3} colSpan={1}>
-        <Avatar src={icons[0]} icon={<FoxIcon boxSize='16px' />} />
+        {icon && <Avatar src={icon} icon={<FoxIcon boxSize='16px' />} />}
       </GridItem>
       <GridItem colSpan={4}>{name}</GridItem>
       <GridItem colSpan={4}>{url}</GridItem>


### PR DESCRIPTION
## Description

A small fix to make WalletConnect V2 safer.

- We used an error where we should have used a warning
- `@walletconnect/types` don't match what we see in the wild, so be extra safe

## Pull Request Type

- [x ] :bug: Bug fix (Non-breaking Change: Fixes an issue)
- [ ] :hammer_and_wrench: Chore (Non-breaking Change: Doc updates, pkg upgrades, typos, etc..)
- [ ] :nail_care: New Feature (Breaking/Non-breaking Change)

## Issue (if applicable)

N/A

## Risk

Small

## Testing

I found this when attempting to connect to https://magiceden.io/ on Polygno via WalletConnect.

Try it, and the app should no longer explode.

Note, we still can't actually connect, as it tries to use Solana, which we don't support - but now we handle it gracefully.

### Engineering

☝️

### Operations

☝️

## Screenshots (if applicable)

N/A
