### PR TITLE
fix: handle no image in DappAvatar

### DIFF
--- a/src/plugins/walletConnectToDapps/components/header/DappAvatar.tsx
+++ b/src/plugins/walletConnectToDapps/components/header/DappAvatar.tsx
@@ -1,8 +1,9 @@
 import { Box, Image, useColorModeValue } from '@chakra-ui/react'
+import Placeholder from 'assets/placeholder.png'
 import { CircleIcon } from 'components/Icons/Circle'
 
 type DappAvatarProps = {
-  image: string
+  image?: string
   name: string
   connected: boolean
   size?: number
@@ -23,7 +24,7 @@ export const DappAvatar: React.FC<DappAvatarProps> = ({
 
   return (
     <Box position='relative'>
-      <Image boxSize={size} borderRadius='full' src={image} alt={name} />
+      <Image boxSize={size} borderRadius='full' src={image || Placeholder} alt={name} />
       {connected && (
         <CircleIcon
           color={connectedIconColor}

--- a/src/plugins/walletConnectToDapps/components/header/DappHeaderMenuSummary.tsx
+++ b/src/plugins/walletConnectToDapps/components/header/DappHeaderMenuSummary.tsx
@@ -36,7 +36,7 @@ export const DappHeaderMenuSummary = () => {
         <HStack spacing={4} px={3} py={1}>
           <DappAvatar
             name={walletConnect.dapp.name}
-            image={walletConnect.dapp.icons[0]}
+            image={walletConnect.dapp.icons?.[0]}
             connected={walletConnect.connector?.connected}
           />
           <Box fontWeight='medium'>

--- a/src/plugins/walletConnectToDapps/components/header/DappHeaderMenuSummaryV2.tsx
+++ b/src/plugins/walletConnectToDapps/components/header/DappHeaderMenuSummaryV2.tsx
@@ -65,7 +65,7 @@ export const DappHeaderMenuSummaryV2 = () => {
         <HStack spacing={4} px={4} py={1}>
           <DappAvatar
             name={session.peer.metadata.name}
-            image={session.peer.metadata.icons[0]}
+            image={session.peer.metadata.icons?.[0]}
             connected={session.acknowledged}
           />
           <Box fontWeight='medium'>


### PR DESCRIPTION
## Description

dApp icons can be an empty array for some dApps (e.g. https://thedapplist.com/).

This PR handles this, and displays a placeholder imaage instead of having our UI break.

## Pull Request Type

- [x] :bug: Bug fix (Non-breaking Change: Fixes an issue)
- [ ] :hammer_and_wrench: Chore (Non-breaking Change: Doc updates, pkg upgrades, typos, etc..)
- [ ] :nail_care: New Feature (Breaking/Non-breaking Change)

## Issue (if applicable)

N/A, raised by @firebomb1.

## Risk

Very small.

## Testing

Go to https://thedapplist.com/ and connect to ShapeShift via wallet connect.

We should now show our placeholder image instead of having our DOM break.

### Engineering

☝️

### Operations

☝️

## Screenshots (if applicable)

Before:

<img width="385" alt="Screenshot 2023-05-25 at 4 16 35 pm" src="https://github.com/shapeshift/web/assets/97164662/c4376f22-084d-41e1-b92a-f22167305532">

After:

<img width="359" alt="Screenshot 2023-05-25 at 4 15 32 pm" src="https://github.com/shapeshift/web/assets/97164662/e868d108-9ba1-42d3-8c7d-e3ad968bf6ca">
