### PR TITLE
feat: enable lifi donations

### DIFF
--- a/src/components/Trade/TradeConfirm/TradeConfirm.tsx
+++ b/src/components/Trade/TradeConfirm/TradeConfirm.tsx
@@ -422,7 +422,9 @@ export const TradeConfirm = () => {
     return (
       !isDonationAmountBelowMinimum &&
       swapperName &&
-      [SwapperName.Thorchain, SwapperName.Zrx, SwapperName.OneInch].includes(swapperName)
+      [SwapperName.Thorchain, SwapperName.Zrx, SwapperName.OneInch, SwapperName.LIFI].includes(
+        swapperName,
+      )
     )
   }, [swapperName, isDonationAmountBelowMinimum])
 

--- a/src/lib/swapper/swappers/LifiSwapper/getTradeQuote/getTradeQuote.ts
+++ b/src/lib/swapper/swappers/LifiSwapper/getTradeQuote/getTradeQuote.ts
@@ -5,11 +5,11 @@ import { fromChainId } from '@shapeshiftoss/caip'
 import type { Result } from '@sniptt/monads'
 import { Err, Ok } from '@sniptt/monads'
 import { getDefaultSlippagePercentageForSwapper } from 'constants/constants'
-import { DAO_TREASURY_ETHEREUM_MAINNET } from 'constants/treasury'
 import { BigNumber, bn, bnOrZero, convertPrecision } from 'lib/bignumber/bignumber'
 import type { GetEvmTradeQuoteInput, SwapErrorRight } from 'lib/swapper/api'
 import { makeSwapErrorRight, SwapError, SwapErrorType, SwapperName } from 'lib/swapper/api'
 import {
+  LIFI_INTEGRATOR_ID,
   MAX_LIFI_TRADE,
   SELECTED_ROUTE_INDEX,
 } from 'lib/swapper/swappers/LifiSwapper/utils/constants'
@@ -19,6 +19,7 @@ import { getLifiEvmAssetAddress } from 'lib/swapper/swappers/LifiSwapper/utils/g
 import { getMinimumCryptoHuman } from 'lib/swapper/swappers/LifiSwapper/utils/getMinimumCryptoHuman/getMinimumCryptoHuman'
 import { transformLifiFeeData } from 'lib/swapper/swappers/LifiSwapper/utils/transformLifiFeeData/transformLifiFeeData'
 import type { LifiTradeQuote } from 'lib/swapper/swappers/LifiSwapper/utils/types'
+import { convertBasisPointsToDecimalPercentage } from 'state/zustand/swapperStore/utils'
 
 export async function getTradeQuote(
   input: GetEvmTradeQuoteInput,
@@ -32,6 +33,7 @@ export async function getTradeQuote(
       sellAmountBeforeFeesCryptoBaseUnit,
       receiveAddress,
       accountNumber,
+      affiliateBps,
     } = input
 
     const sellLifiChainKey = lifiChainMap.get(sellAsset.chainId)
@@ -70,8 +72,9 @@ export async function getTradeQuote(
       // as recommended by lifi, dodo is denied until they fix their gas estimates
       // TODO: convert this config to .env variable
       options: {
-        // used for analytics - do not change this without considering impact
-        integrator: DAO_TREASURY_ETHEREUM_MAINNET,
+        // used for analytics and donations - do not change this without considering impact
+        integrator: LIFI_INTEGRATOR_ID,
+        fee: convertBasisPointsToDecimalPercentage(affiliateBps).toNumber(),
         slippage: Number(defaultLifiSwapperSlippage),
         exchanges: { deny: ['dodo'] },
         // as recommended by lifi, allowSwitchChain must be false to ensure single-hop transactions.

--- a/src/lib/swapper/swappers/LifiSwapper/utils/constants.ts
+++ b/src/lib/swapper/swappers/LifiSwapper/utils/constants.ts
@@ -3,3 +3,4 @@ export const SELECTED_ROUTE_INDEX = 0 // default to first route - this is the hi
 export const LIFI_GAS_FEE_BASE = 16 // lifi gas feed are all in base 16
 export const MAX_LIFI_TRADE = '100000000000000000000000000'
 export const DEFAULT_LIFI_TOKEN_ADDRESS = '0x0000000000000000000000000000000000000000'
+export const LIFI_INTEGRATOR_ID = 'shapeshift'

--- a/src/state/zustand/swapperStore/selectors.ts
+++ b/src/state/zustand/swapperStore/selectors.ts
@@ -104,9 +104,9 @@ export const selectSwapperDefaultAffiliateBps = createSelector(
       case SwapperName.Thorchain:
       case SwapperName.Zrx:
       case SwapperName.OneInch:
+      case SwapperName.LIFI:
         return '30'
       case SwapperName.Osmosis:
-      case SwapperName.LIFI:
       case SwapperName.CowSwap:
       case SwapperName.Test:
         return '0'


### PR DESCRIPTION
## Description

Enables optional donations for lifi trades.

Awaiting lifi team to enable our donations account:
![image](https://github.com/shapeshift/web/assets/125113430/4039e911-5b2c-4bef-b923-77cc1c665de8)

## Pull Request Type

- [ ] :bug: Bug fix (Non-breaking Change: Fixes an issue)
- [ ] :hammer_and_wrench: Chore (Non-breaking Change: Doc updates, pkg upgrades, typos, etc..)
- [x] :nail_care: New Feature (Breaking/Non-breaking Change)

## Issue (if applicable)

NA

## Risk

Low risk

## Testing

- Check lifi trades work with donations
- Check lifi trades workout with donations
- Fetch donation amount using docs here to check donations came thru https://apidocs.li.fi/reference/get_integrators-integratorid-1 (ask @woodenfurniture how to do this)
- Check that the additional gas is worth it for users. We may need to re-evaluate this and only enable it for specific pairs. So far it seems to have no effect on gas which is good.

### Engineering

See testing notes

### Operations

See testing notes

## Screenshots (if applicable)

Donation is appearing on lifi side after first attempt:
![image](https://github.com/shapeshift/web/assets/125113430/9ab06fcf-dd22-4944-a41c-f6e766e9834e)

https://polygonscan.com/tx/0xd4868210216aecceff821757c9d6bf0e9b21e8c7191f46eb1cdc995127263327
https://snowtrace.io/tx/0x9ad3c8e7c668ade9ad28b7207390c583fc2e5c041d02ccba31ecc24863ac59cb

![image](https://github.com/shapeshift/web/assets/125113430/dcc464f3-6e21-4e65-93a4-acd49213863b)
![image](https://github.com/shapeshift/web/assets/125113430/7b8b59d2-b895-4a7b-bc0c-0b74e766d492)

