### PR TITLE
chore: change lifi default slippage to 0.5%

### DIFF
--- a/src/constants/constants.ts
+++ b/src/constants/constants.ts
@@ -6,6 +6,7 @@ export const USDC_PRECISION = 6
 // Slippage defaults. Don't export these to ensure the getDefaultSlippagePercentageForSwapper helper function is used.
 const DEFAULT_SLIPPAGE_DECIMAL_PERCENTAGE = '0.002' // .2%
 const DEFAULT_COWSWAP_SLIPPAGE_DECIMAL_PERCENTAGE = '0.005' // .5%
+const DEFAULT_LIFI_SLIPPAGE_DECIMAL_PERCENTAGE = '0.005' // .5%
 
 export const getDefaultSlippagePercentageForSwapper = (swapperName?: SwapperName): string => {
   if (swapperName === undefined) return DEFAULT_SLIPPAGE_DECIMAL_PERCENTAGE
@@ -14,9 +15,10 @@ export const getDefaultSlippagePercentageForSwapper = (swapperName?: SwapperName
     case SwapperName.Zrx:
     case SwapperName.OneInch:
     case SwapperName.Osmosis:
-    case SwapperName.LIFI:
     case SwapperName.Test:
       return DEFAULT_SLIPPAGE_DECIMAL_PERCENTAGE
+    case SwapperName.LIFI:
+      return DEFAULT_LIFI_SLIPPAGE_DECIMAL_PERCENTAGE
     case SwapperName.CowSwap:
       return DEFAULT_COWSWAP_SLIPPAGE_DECIMAL_PERCENTAGE
     default:


### PR DESCRIPTION
## Description

Changes lifi default slippage to 0.5% (up from 0.2%) to reduce the likelihood of slow trade execution. 0.5% is the default specified in the the lifi API documentation.

See this thread for context:
https://discord.com/channels/554694662431178782/1111090473344442489/1111090475244470322

## Pull Request Type

- [ ] :bug: Bug fix (Non-breaking Change: Fixes an issue)
- [x] :hammer_and_wrench: Chore (Non-breaking Change: Doc updates, pkg upgrades, typos, etc..)
- [ ] :nail_care: New Feature (Breaking/Non-breaking Change)

## Issue (if applicable)

## Risk

no risk

## Testing

NA

### Engineering

See above

### Operations

See above

## Screenshots (if applicable)
