### PR TITLE
fix: get sell asset price history when not defined

### DIFF
--- a/src/components/TransactionHistoryRows/hooks.tsx
+++ b/src/components/TransactionHistoryRows/hooks.tsx
@@ -46,7 +46,7 @@ export const useTradeFees = ({ txDetails }: { txDetails: TxDetails }) => {
     if (!cryptoPriceHistoryData?.[sell.asset.assetId]) {
       dispatch(
         findPriceHistoryByAssetId.initiate({
-          assetId: buy.asset.assetId,
+          assetId: sell.asset.assetId,
           timeframe: HistoryTimeframe.ALL,
         }),
       )


### PR DESCRIPTION
## Description

Fixes what I'm pretty sure is a copy pasta bug by using the correct `assetId` in the `findPriceHistoryByAssetId` dispatch call.

## Pull Request Type

- [x] :bug: Bug fix (Non-breaking Change: Fixes an issue)
- [ ] :hammer_and_wrench: Chore (Non-breaking Change: Doc updates, pkg upgrades, typos, etc..)
- [ ] :nail_care: New Feature (Breaking/Non-breaking Change)

## Issue (if applicable)

N/A, I just came across it in the codebase.

## Risk

Small.

## Testing

Asset price history in transaction rows should be no worse, and ideally slithgly better - we should now fetch sell asset data of a TX when it is missing.

### Engineering

☝️

### Operations

☝️

## Screenshots (if applicable)

N/A
