### PR TITLE
fix: useTradeFees infinite render

### DIFF
--- a/src/components/TransactionHistoryRows/hooks.tsx
+++ b/src/components/TransactionHistoryRows/hooks.tsx
@@ -1,7 +1,7 @@
 import { HistoryTimeframe } from '@shapeshiftoss/types'
 import { Dex, TransferType } from '@shapeshiftoss/unchained-client'
 import dayjs from 'dayjs'
-import { useEffect, useMemo, useState, useTransition } from 'react'
+import { useEffect, useMemo, useState } from 'react'
 import { useDispatch } from 'react-redux'
 import type { TxDetails } from 'hooks/useTxDetails/useTxDetails'
 import { marketApi } from 'state/slices/marketDataSlice/marketDataSlice'
@@ -13,7 +13,6 @@ import { getTradeFees } from './utils'
 
 export const useTradeFees = ({ txDetails }: { txDetails: TxDetails }) => {
   const dispatch = useDispatch()
-  const [, startTransition] = useTransition()
   const [tradeFees, setTradeFees] = useState<TradeFees | undefined>(undefined)
   const cryptoPriceHistoryData = useAppSelector(state =>
     selectCryptoPriceHistoryTimeframe(state, HistoryTimeframe.ALL),
@@ -36,25 +35,23 @@ export const useTradeFees = ({ txDetails }: { txDetails: TxDetails }) => {
     if (txDetails.tx.trade.dexName !== Dex.CowSwap) return
 
     if (!cryptoPriceHistoryData?.[buy.asset.assetId]) {
-      startTransition(() => {
-        dispatch(
-          findPriceHistoryByAssetId.initiate({
-            assetId: buy.asset.assetId,
-            timeframe: HistoryTimeframe.ALL,
-          }),
-        )
-      })
+      dispatch(
+        findPriceHistoryByAssetId.initiate({
+          assetId: buy.asset.assetId,
+          timeframe: HistoryTimeframe.ALL,
+        }),
+      )
+      return
     }
 
     if (!cryptoPriceHistoryData?.[sell.asset.assetId]) {
-      startTransition(() => {
-        dispatch(
-          findPriceHistoryByAssetId.initiate({
-            assetId: sell.asset.assetId,
-            timeframe: HistoryTimeframe.ALL,
-          }),
-        )
-      })
+      dispatch(
+        findPriceHistoryByAssetId.initiate({
+          assetId: sell.asset.assetId,
+          timeframe: HistoryTimeframe.ALL,
+        }),
+      )
+      return
     }
 
     const tradeFees = getTradeFees({


### PR DESCRIPTION
## Description

⚠️  I need to do more testing to confirm this fixes it, I'm not yet convinced.

Fixes an infinite loop in the `useTradeFees` hook, specifically, inside the `useEffect` that dispatches `findPriceHistoryByAssetId`.

`cryptoPriceHistoryData` is a dependency of the `useEffect`, and is set by an async dispatch, `findPriceHistoryByAssetId` (this also tells us that this method as incorrectly named, as it causes a side-effect, but that's not obvious from the "find" nomenclature.

This can put us in a state where calling `findPriceHistoryByAssetId` is causing itself to be called again by the `useEffect`, ad infinitum.

If we call the `dispatch` method, just return without setting trade fees.

## Pull Request Type

- [x] :bug: Bug fix (Non-breaking Change: Fixes an issue)
- [ ] :hammer_and_wrench: Chore (Non-breaking Change: Doc updates, pkg upgrades, typos, etc..)
- [ ] :nail_care: New Feature (Breaking/Non-breaking Change)

## Issue (if applicable)

N/A

## Risk

TODO

## Testing

TODO

### Engineering

☝️

### Operations

☝️

## Screenshots (if applicable)

<img width="777" alt="Screenshot 2023-05-29 at 11 41 52 am" src="https://github.com/shapeshift/web/assets/97164662/cdb17908-215f-4cde-ba2e-676ee8e4d68f">
