### PR TITLE
fix: getAssetDescription infinite call stack

### DIFF
--- a/src/state/slices/assetsSlice/assetsSlice.ts
+++ b/src/state/slices/assetsSlice/assetsSlice.ts
@@ -181,10 +181,13 @@ export const assetApi = createApi({
           return { error }
         }
       },
-      onCacheEntryAdded: async (_args, { dispatch, cacheDataLoaded, getCacheEntry }) => {
-        await cacheDataLoaded
-        const data = getCacheEntry().data
-        data && dispatch(assets.actions.upsertAssets(data))
+      merge: (currentCache, newData) => {
+        Object.assign(currentCache.byId, newData.byId)
+        const mergedIds = new Set([...currentCache.ids, ...newData.ids])
+        return {
+          byId: currentCache.byId,
+          ids: Array.from(mergedIds),
+        }
       },
     }),
   }),


### PR DESCRIPTION
## Description

This PR fixes a "Maximum update depth exceeded" bug in the `assetsSlice` by using the RTK Query merge function to combine the incoming response with the current cache data, instead of dispatching an action to update the state manually.

## Pull Request Type

- [x] :bug: Bug fix (Non-breaking Change: Fixes an issue)
- [ ] :hammer_and_wrench: Chore (Non-breaking Change: Doc updates, pkg upgrades, typos, etc..)
- [ ] :nail_care: New Feature (Breaking/Non-breaking Change)

## Issue (if applicable)

N/A

## Risk

TODO

## Testing

TODO

### Engineering

☝️

### Operations

☝️

## Screenshots (if applicable)

<img width="767" alt="Screenshot 2023-05-29 at 5 05 55 pm" src="https://github.com/shapeshift/web/assets/97164662/37541bf0-b40b-4896-a356-ff70c16ac277">
