### PR TITLE
fix: max trades for lifi swapper sending whole balance instead of minus fees

### DIFF
--- a/src/components/Trade/TradeConfirm/TradeConfirm.tsx
+++ b/src/components/Trade/TradeConfirm/TradeConfirm.tsx
@@ -318,8 +318,7 @@ export const TradeConfirm = () => {
         mixpanel.track(MixPanelEvents.TradeConfirm, eventData)
       }
 
-      // TODO(gomes): should we we throw so the catch clause handles this?
-      if (result.isErr()) return
+      if (result.isErr()) throw result.unwrapErr()
       setSellTradeId(result.unwrap().tradeId)
 
       // Poll until we have a "buy" txid

--- a/src/lib/swapper/swappers/LifiSwapper/getTradeQuote/getTradeQuote.ts
+++ b/src/lib/swapper/swappers/LifiSwapper/getTradeQuote/getTradeQuote.ts
@@ -13,7 +13,6 @@ import {
   MAX_LIFI_TRADE,
   SELECTED_ROUTE_INDEX,
 } from 'lib/swapper/swappers/LifiSwapper/utils/constants'
-import { getAssetBalance } from 'lib/swapper/swappers/LifiSwapper/utils/getAssetBalance/getAssetBalance'
 import { getIntermediaryTransactionOutputs } from 'lib/swapper/swappers/LifiSwapper/utils/getIntermediaryTransactionOutputs/getIntermediaryTransactionOutputs'
 import { getLifi } from 'lib/swapper/swappers/LifiSwapper/utils/getLifi'
 import { getLifiEvmAssetAddress } from 'lib/swapper/swappers/LifiSwapper/utils/getLifiEvmAssetAddress/getLifiEvmAssetAddress'
@@ -31,7 +30,6 @@ export async function getTradeQuote(
       sellAsset,
       buyAsset,
       sellAmountBeforeFeesCryptoBaseUnit,
-      sendMax,
       receiveAddress,
       accountNumber,
     } = input
@@ -59,13 +57,6 @@ export async function getTradeQuote(
       })
     }
 
-    const fromAmountCryptoBaseUnit: string = sendMax
-      ? getAssetBalance({
-          asset: sellAsset,
-          accountNumber,
-          chainId,
-        })
-      : sellAmountBeforeFeesCryptoBaseUnit
     const lifi = getLifi()
 
     const routesRequest: RoutesRequest = {
@@ -75,7 +66,7 @@ export async function getTradeQuote(
       toTokenAddress: getLifiEvmAssetAddress(buyAsset),
       fromAddress: receiveAddress,
       toAddress: receiveAddress,
-      fromAmount: fromAmountCryptoBaseUnit,
+      fromAmount: sellAmountBeforeFeesCryptoBaseUnit,
       // as recommended by lifi, dodo is denied until they fix their gas estimates
       // TODO: convert this config to .env variable
       options: {


### PR DESCRIPTION
## Description

Fixes max trades when using lifi swapper. The lifi swapper had logic bypassing our max sell logic where it would change the sell amount to the sell asset balance rather than using the adjusted value from the existing logic.

Also includes a fix to "dead click" where errors are not displayed on trade confirmation error. Screenshot of it working below.

## Pull Request Type

- [x] :bug: Bug fix (Non-breaking Change: Fixes an issue)
- [ ] :hammer_and_wrench: Chore (Non-breaking Change: Doc updates, pkg upgrades, typos, etc..)
- [ ] :nail_care: New Feature (Breaking/Non-breaking Change)

## Issue (if applicable)

NA

## Risk

Low risk

## Testing

keep in mind optimism trades on lifi still broken see #4580
- Test normal lifi trades work
- Test max lifi trade works

### Engineering

See above

### Operations

See above

## Screenshots (if applicable)

Toast correctly displaying on trade confirmation error:
![image](https://github.com/shapeshift/web/assets/125113430/7639078e-d9f5-48da-8374-0ea1e45d655e)
