### PR TITLE
chore: use 0.01$ min. for CoW Gnosis trades

### DIFF
--- a/src/lib/swapper/swappers/CowSwapper/getCowSwapMinMax/getCowSwapMinMax.test.ts
+++ b/src/lib/swapper/swappers/CowSwapper/getCowSwapMinMax/getCowSwapMinMax.test.ts
@@ -33,7 +33,7 @@ describe('getCowSwapMinMax', () => {
     const maybeMinMax = getCowSwapMinMax(USDC_GNOSIS, XDAI, supportedChainIds)
     expect(maybeMinMax.isErr()).toBe(false)
     const minMax = maybeMinMax.unwrap()
-    expect(minMax.minimumAmountCryptoHuman).toBe('2')
+    expect(minMax.minimumAmountCryptoHuman).toBe('0.04')
     expect(minMax.maximumAmountCryptoHuman).toBe(MAX_COWSWAP_TRADE)
   })
 

--- a/src/lib/swapper/swappers/CowSwapper/getCowSwapMinMax/getCowSwapMinMax.test.ts
+++ b/src/lib/swapper/swappers/CowSwapper/getCowSwapMinMax/getCowSwapMinMax.test.ts
@@ -9,6 +9,7 @@ jest.mock('state/zustand/swapperStore/amountSelectors', () => ({
   ...jest.requireActual('state/zustand/swapperStore/amountSelectors'),
   selectSellAssetUsdRate: jest.fn(() => '0.25'),
 }))
+
 const supportedChainIds: CowChainId[] = [KnownChainIds.EthereumMainnet, KnownChainIds.GnosisMainnet]
 
 describe('getCowSwapMinMax', () => {
@@ -32,7 +33,7 @@ describe('getCowSwapMinMax', () => {
     const maybeMinMax = getCowSwapMinMax(USDC_GNOSIS, XDAI, supportedChainIds)
     expect(maybeMinMax.isErr()).toBe(false)
     const minMax = maybeMinMax.unwrap()
-    expect(minMax.minimumAmountCryptoHuman).toBe('80')
+    expect(minMax.minimumAmountCryptoHuman).toBe('2')
     expect(minMax.maximumAmountCryptoHuman).toBe(MAX_COWSWAP_TRADE)
   })
 
@@ -44,6 +45,7 @@ describe('getCowSwapMinMax', () => {
       message: '[getCowSwapMinMax]',
       name: 'SwapError',
     }
+
     expect(getCowSwapMinMax(ETH, WETH, supportedChainIds).unwrapErr()).toMatchObject(expectedError)
     expect(getCowSwapMinMax(FOX_MAINNET, BTC, supportedChainIds).unwrapErr()).toMatchObject(
       expectedError,

--- a/src/lib/swapper/swappers/CowSwapper/getCowSwapMinMax/getCowSwapMinMax.ts
+++ b/src/lib/swapper/swappers/CowSwapper/getCowSwapMinMax/getCowSwapMinMax.ts
@@ -9,8 +9,8 @@ import type { MinMaxOutput, SwapErrorRight } from 'lib/swapper/api'
 import { makeSwapErrorRight, SwapErrorType } from 'lib/swapper/api'
 import {
   MAX_COWSWAP_TRADE,
-  MIN_COWSWAP_ETH_TRADE_VALUE_USD,
-  MIN_COWSWAP_XDAI_TRADE_VALUE_USD,
+  MIN_COWSWAP_ETHEREUM_TRADE_VALUE_USD,
+  MIN_COWSWAP_GNOSIS_TRADE_VALUE_USD,
 } from 'lib/swapper/swappers/CowSwapper/utils/constants'
 import { selectSellAssetUsdRate } from 'state/zustand/swapperStore/amountSelectors'
 import { swapperStore } from 'state/zustand/swapperStore/useSwapperStore'
@@ -38,9 +38,9 @@ export const getCowSwapMinMax = (
   const getMinCowSwapValueUsd = (chainId: CowChainId): BigNumber.Value => {
     switch (chainId) {
       case KnownChainIds.EthereumMainnet:
-        return MIN_COWSWAP_ETH_TRADE_VALUE_USD
+        return MIN_COWSWAP_ETHEREUM_TRADE_VALUE_USD
       case KnownChainIds.GnosisMainnet:
-        return MIN_COWSWAP_XDAI_TRADE_VALUE_USD
+        return MIN_COWSWAP_GNOSIS_TRADE_VALUE_USD
       default:
         throw new Error(`[getCowSwapMinMax] Unsupported chainId: ${buyAssetChainId}`)
     }

--- a/src/lib/swapper/swappers/CowSwapper/getCowSwapMinMax/getCowSwapMinMax.ts
+++ b/src/lib/swapper/swappers/CowSwapper/getCowSwapMinMax/getCowSwapMinMax.ts
@@ -3,6 +3,7 @@ import { KnownChainIds } from '@shapeshiftoss/types'
 import type { Result } from '@sniptt/monads'
 import { Err, Ok } from '@sniptt/monads'
 import type { Asset } from 'lib/asset-service'
+import type { BigNumber } from 'lib/bignumber/bignumber'
 import { bn, bnOrZero } from 'lib/bignumber/bignumber'
 import type { MinMaxOutput, SwapErrorRight } from 'lib/swapper/api'
 import { makeSwapErrorRight, SwapErrorType } from 'lib/swapper/api'
@@ -34,7 +35,7 @@ export const getCowSwapMinMax = (
     )
   }
 
-  const getMinCowSwapValueUsd = (chainId: CowChainId): number => {
+  const getMinCowSwapValueUsd = (chainId: CowChainId): BigNumber.Value => {
     switch (chainId) {
       case KnownChainIds.EthereumMainnet:
         return MIN_COWSWAP_ETH_TRADE_VALUE_USD

--- a/src/lib/swapper/swappers/CowSwapper/utils/constants.ts
+++ b/src/lib/swapper/swappers/CowSwapper/utils/constants.ts
@@ -2,8 +2,8 @@ import { AddressZero } from '@ethersproject/constants'
 import { SwapperName } from 'lib/swapper/api'
 
 export const MAX_COWSWAP_TRADE = '100000000000000000000000000'
-export const MIN_COWSWAP_ETH_TRADE_VALUE_USD = 20
-export const MIN_COWSWAP_XDAI_TRADE_VALUE_USD = 0.5
+export const MIN_COWSWAP_ETH_TRADE_VALUE_USD = '20'
+export const MIN_COWSWAP_XDAI_TRADE_VALUE_USD = '0.01'
 export const DEFAULT_SOURCE = [{ name: SwapperName.CowSwap, proportion: '1' }]
 export const DEFAULT_ADDRESS = AddressZero
 export const DEFAULT_APP_DATA = '0x68a7b5781dfe48bd5d7aeb11261c17517f5c587da682e4fade9b6a00a59b8970'

--- a/src/lib/swapper/swappers/CowSwapper/utils/constants.ts
+++ b/src/lib/swapper/swappers/CowSwapper/utils/constants.ts
@@ -2,7 +2,8 @@ import { AddressZero } from '@ethersproject/constants'
 import { SwapperName } from 'lib/swapper/api'
 
 export const MAX_COWSWAP_TRADE = '100000000000000000000000000'
-export const MIN_COWSWAP_VALUE_USD = 20
+export const MIN_COWSWAP_ETH_TRADE_VALUE_USD = 20
+export const MIN_COWSWAP_XDAI_TRADE_VALUE_USD = 0.5
 export const DEFAULT_SOURCE = [{ name: SwapperName.CowSwap, proportion: '1' }]
 export const DEFAULT_ADDRESS = AddressZero
 export const DEFAULT_APP_DATA = '0x68a7b5781dfe48bd5d7aeb11261c17517f5c587da682e4fade9b6a00a59b8970'

--- a/src/lib/swapper/swappers/CowSwapper/utils/constants.ts
+++ b/src/lib/swapper/swappers/CowSwapper/utils/constants.ts
@@ -2,8 +2,8 @@ import { AddressZero } from '@ethersproject/constants'
 import { SwapperName } from 'lib/swapper/api'
 
 export const MAX_COWSWAP_TRADE = '100000000000000000000000000'
-export const MIN_COWSWAP_ETH_TRADE_VALUE_USD = '20'
-export const MIN_COWSWAP_XDAI_TRADE_VALUE_USD = '0.01'
+export const MIN_COWSWAP_ETHEREUM_TRADE_VALUE_USD = '20'
+export const MIN_COWSWAP_GNOSIS_TRADE_VALUE_USD = '0.01'
 export const DEFAULT_SOURCE = [{ name: SwapperName.CowSwap, proportion: '1' }]
 export const DEFAULT_ADDRESS = AddressZero
 export const DEFAULT_APP_DATA = '0x68a7b5781dfe48bd5d7aeb11261c17517f5c587da682e4fade9b6a00a59b8970'


### PR DESCRIPTION
## Description

The required trade minimum for ETH on CowSwap is too high for Gnosis chain, as the cost of transactions is significantly lower. This PR keeps the minimum tx value for ETH as is (20$), while setting the minimum tx for Gnosis to 0.5$. 

## Pull Request Type

- [ ] :bug: Bug fix (Non-breaking Change: Fixes an issue)
- [ ] :hammer_and_wrench: Chore (Non-breaking Change: Doc updates, pkg upgrades, typos, etc..)
- [x] :nail_care: New Feature (Breaking/Non-breaking Change)

## Risk

We might not be handling CoW minimums correctly anymore, or may not be handling it correctly per chain

## Testing

- Ethereum CoW swaps still have a 20$ minimum, both with the `CowswapGnosis` flag on and off
- Gnosis CoW swaps (assuming the flag is on) have a 0.01$ minimum

### Engineering

- ☝🏽 

### Operations

<!-----------------------------------------------------------------------------
If your changes have a user-facing impact, describe how a non-technical QA team can functionally test your changes in a preview environment.

If they are not user-facing please describe how to test for any regressions that may occur.
------------------------------------------------------------------------------>

- ☝🏽 

## Screenshots (if applicable)


### CoW

- Minimum not met

<img width="416" alt="image" src="https://github.com/shapeshift/web/assets/17035424/4821409a-8f33-40c4-99e9-3c92f9444fc8">

- Minimum met

<img width="415" alt="image" src="https://github.com/shapeshift/web/assets/17035424/ef70c46a-1466-4998-b320-176f0a1a3e17">


### Ethereum

- Minimum not met

<img width="406" alt="image" src="https://github.com/shapeshift/web/assets/17035424/ac6d881a-5bd6-4ad4-a3d1-9711755c9ef9">

- Minimum met

<img width="417" alt="image" src="https://github.com/shapeshift/web/assets/17035424/7daeb8e7-7274-4e69-a879-06570d62a08b">