### PR TITLE
fix: do not render network filter over navbar

### DIFF
--- a/src/components/Nfts/NftNetworkFilter.tsx
+++ b/src/components/Nfts/NftNetworkFilter.tsx
@@ -81,7 +81,7 @@ export const NftNetworkFilter = ({
   }
 
   return (
-    <Popover closeOnBlur={false} isOpen={isOpen}>
+    <Popover closeOnBlur={false} isOpen={isOpen} placement='bottom-start'>
       <>
         <PopoverTrigger>
           <ButtonGroup isAttached variant='ghost-filled'>


### PR DESCRIPTION
## Description

Fixes a bug where the network filter was rendered over top of the nav bar, which looked bad because the nav bar has a higher z-index.

## Pull Request Type

- [x] :bug: Bug fix (Non-breaking Change: Fixes an issue)
- [ ] :hammer_and_wrench: Chore (Non-breaking Change: Doc updates, pkg upgrades, typos, etc..)
- [ ] :nail_care: New Feature (Breaking/Non-breaking Change)

## Issue (if applicable)

N/A

## Risk

Very small.

## Testing

Navigate to the NFT display, and ensure that when filtering by network, the popover does not render over the nav bar.

### Engineering

☝️

### Operations

☝️

## Screenshots (if applicable)
