### PR TITLE
fix: staking opportunities app rug

### DIFF
--- a/src/state/slices/opportunitiesSlice/selectors/stakingSelectors.ts
+++ b/src/state/slices/opportunitiesSlice/selectors/stakingSelectors.ts
@@ -348,7 +348,7 @@ export const selectAggregatedEarnUserStakingOpportunityByStakingId = createDeepE
       {},
       isFoxEthStakingAssetId(opportunity.assetId)
         ? {
-            contractAddress: fromAssetId(opportunity.id).assetReference,
+            contractAddress: fromAssetId(opportunity.assetId).assetReference,
             rewardAddress: fromAssetId(foxAssetId).assetReference,
           }
         : {},
@@ -403,7 +403,7 @@ export const selectAggregatedEarnUserStakingOpportunities = createDeepEqualOutpu
 
           if (isFoxEthStakingAssetId(opportunity.assetId))
             return {
-              contractAddress: fromAssetId(opportunity.id).assetReference,
+              contractAddress: fromAssetId(opportunity.assetId).assetReference,
               rewardAddress: fromAssetId(foxAssetId).assetReference,
             }
 
@@ -496,7 +496,7 @@ export const selectAggregatedEarnUserStakingOpportunitiesIncludeEmpty =
               if (isFoxEthStakingAssetId(opportunity.assetId))
                 return {
                   rewardAddress: fromAssetId(foxAssetId).assetReference,
-                  contractAddress: fromAssetId(opportunity.id).assetReference,
+                  contractAddress: fromAssetId(opportunity.assetId).assetReference,
                 }
 
               if (isToken(fromAssetId(opportunity.underlyingAssetId).assetReference))


### PR DESCRIPTION
## Description

In the opportunities slice, we index staking opportunities by `StakingId`. This value is often, though not always the same shape as an `AssetId`.

When it isn't the same shape, the app currently crashes, as we have a number of selectors that attempt to use the `id` as if it is an `AssetId`.

This PR updates those selectors to use the opportunity's `assetId` value, which actually _is_ an `AssetId`, and makes my test account load again.

Examples of keys that are not `AssetId`s: `0x24fd7fb95dc742e23dc3829d3e656feeb5f67fa0#1170050076`, `0x5274891bec421b39d23760c04a6755ecb444797c#240877749` etc.

## Pull Request Type

- [x] :bug: Bug fix (Non-breaking Change: Fixes an issue)
- [ ] :hammer_and_wrench: Chore (Non-breaking Change: Doc updates, pkg upgrades, typos, etc..)
- [ ] :nail_care: New Feature (Breaking/Non-breaking Change)

## Issue (if applicable)

N/A - current production issue.

## Risk

Small.

## Testing

Loading an account with a non-assetId stakingId, e.g. `eip155:1:0x32dbc9cf9e8fbcebe1e0a2ecf05ed86ca3096cb6`, should no longer crash.

This should be testable via frame.

### Engineering

☝️

### Operations

☝️

## Screenshots (if applicable)

<img width="727" alt="Screenshot 2023-06-02 at 4 17 59 pm" src="https://github.com/shapeshift/web/assets/97164662/91c82521-ffce-493b-ae76-118224596a48">
