### PR TITLE
feat: fallback of the fallback for IPNS gateway URLs

### DIFF
--- a/react-app-rewired/headers/csps/alchemy.ts
+++ b/react-app-rewired/headers/csps/alchemy.ts
@@ -8,5 +8,7 @@ export const csp: Csp = {
     'https://eth-mainnet.g.alchemy.com/nft/v2/',
     // Alchemy SDK NFT resolution on Optimism mainnet
     'https://opt-mainnet.g.alchemy.com/nft/v2/',
+    // Mercle IPNS gateway for NFT resolution
+    'https://backend.mercle.xyz/ipns/',
   ],
 }

--- a/src/state/apis/nft/nftApi.ts
+++ b/src/state/apis/nft/nftApi.ts
@@ -194,17 +194,28 @@ export const nftApi = createApi({
     }),
     getNft: build.query<NftItemWithCollection, GetNftInput>({
       queryFn: async ({ assetId }, { dispatch }) => {
-        const { data: nftDataWithCollection } = await getAlchemyNftData(assetId)
+        try {
+          const { data: nftDataWithCollection } = await getAlchemyNftData(assetId)
 
-        const { collection, ...nftItemWithoutId } = nftDataWithCollection
-        const nftItem: NftItem = {
-          ...nftItemWithoutId,
-          collectionId: nftDataWithCollection.collection.assetId,
+          const { collection, ...nftItemWithoutId } = nftDataWithCollection
+          const nftItem: NftItem = {
+            ...nftItemWithoutId,
+            collectionId: nftDataWithCollection.collection.assetId,
+          }
+
+          dispatch(nft.actions.upsertNft(nftItem))
+
+          return { data: nftDataWithCollection }
+        } catch (error) {
+          return {
+            error: {
+              status: 500,
+              data: {
+                message: 'Failed to fetch nft data',
+              },
+            },
+          }
         }
-
-        dispatch(nft.actions.upsertNft(nftItem))
-
-        return { data: nftDataWithCollection }
       },
     }),
 

--- a/src/state/apis/nft/types.ts
+++ b/src/state/apis/nft/types.ts
@@ -38,3 +38,12 @@ export type NftItem = {
 export type NftItemWithCollection = Omit<NftItem, 'collectionId'> & {
   collection: NftCollectionType
 }
+
+// Standard ERC721 Metadata JSON Schema
+// This is the very base from EIP-721, without extensions nor Opensea/LooksRare specific e.g animation_url
+// https://eips.ethereum.org/EIPS/eip-721
+export type ERC721Metadata = {
+  name: string
+  description: string
+  image: string
+}


### PR DESCRIPTION
## Description

https://github.com/shapeshift/web/pull/4639 (as https://github.com/shapeshift/web/pull/4646 in this stack) introduced the concept of a NFT refresh button and fetching the media from unchained, which we're able to do when we have an IPNS gateway URL, which unchained introspects to get the latest updated media.

This works when unchained is happy, but in case it isn't, what we thought was "graceful error-handling" i.e getting medias from alchemy's `medias` turns out to be *too* graceful: alchemy `medias` is rugged and often stale, and more often than not never updates and has the original media.

This means that when starting from fresh NFT media (which was gotten from unchained) and clicking the refresh button, it will revert to the original state of the NFT in case Alchemy is down.

This PR fixes it by adding a fallback to the fallback:

- try fetching the media from unchained if we are within the criteria for it (Polygon Chain ID and IPNS URL) or else return Alchemy medias if we're not
- If we're unable to get a media URL from unchained, introspect the image URL from Mercle meta instead, and use IPFS official gateway for it
- in case the flow above fails for getting a media from Unchained/Mercle IPNS, throw and bail out from Alchemy parsing - we're unable to get a media altogether, and don't want to rug the current media by upserting rugged data

## Pull Request Type

- [ ] :bug: Bug fix (Non-breaking Change: Fixes an issue)
- [ ] :hammer_and_wrench: Chore (Non-breaking Change: Doc updates, pkg upgrades, typos, etc..)
- [x] :nail_care: New Feature (Breaking/Non-breaking Change)

## Issue (if applicable)

N/A

## Risk

<!-----------------------------------------------------------------------------
Outline the scope of your changes and the risk associated with them. You must use your discretion as an engineer to determine the potential impact of your changes.

E.g. an upgrade to `hdwallet` or core state management would be considered higher risk, and might require a full regression test. UI or isolated view changes, or something behind a feature flag may have near zero risk. Small bug fixes might require testing isolated to the specific fix.
------------------------------------------------------------------------------>

Low to none, this makes us *actually* graceful

## Testing

<!-----------------------------------------------------------------------------
We treat every PR to be merged with the same scrutiny as if we were merging directly to production.

Your PR will not be merged if you do not complete the sections below for our engineering and operations teams to test.
------------------------------------------------------------------------------>

- Update your Mercle NFT
- Click the refresh button and ensure it is updated - doesn't matter whether unchained is down or not
- Ensure current NFT metadata fetching - medias in particular - is still working as before

### Engineering

<!-----------------------------------------------------------------------------
Include sufficient information here for an engineer to test your PR. This may include how to test locally, in a built environment, changes to infrastructure etc.
------------------------------------------------------------------------------>

- ☝🏽 

### Operations

<!-----------------------------------------------------------------------------
If your changes have a user-facing impact, describe how a non-technical QA team can functionally test your changes in a preview environment.

If they are not user-facing please describe how to test for any regressions that may occur.
------------------------------------------------------------------------------>

- ☝🏽 

## Screenshots (if applicable)

Note how unchained XHR is failing (noted failing as CORS error, though this is how it is often shown as when Unchained is down) and as a fallback we're fetching the IPNS JSON meta, then the IPFS gateway image URL we've introspected from it

https://github.com/shapeshift/web/assets/17035424/a9bed7a0-c9d9-456b-b022-1fc02fe4bf3c