### PR TITLE
fix: patch for 0 oneinch swapper network fee

### DIFF
--- a/src/lib/swapper/swappers/OneInchSwapper/getTradeQuote/getTradeQuote.ts
+++ b/src/lib/swapper/swappers/OneInchSwapper/getTradeQuote/getTradeQuote.ts
@@ -27,7 +27,6 @@ export async function getTradeQuote(
     sellAmountBeforeFeesCryptoBaseUnit,
     accountNumber,
     affiliateBps,
-    eip1559Support,
   } = input
 
   if (sellAmountBeforeFeesCryptoBaseUnit === '0') {
@@ -82,10 +81,10 @@ export async function getTradeQuote(
   }
 
   const gasFeeData: GasFeeDataEstimate = await adapter.getGasFeeData()
+
+  // TODO(woodenfurniture): l1 fees for optimism and eip-1551 gas estimation
   const fee = bnOrZero(quoteResponse.data.estimatedGas)
-    .multipliedBy(
-      eip1559Support ? bnOrZero(gasFeeData.average.maxFeePerGas) : gasFeeData.average.gasPrice,
-    )
+    .multipliedBy(gasFeeData.average.gasPrice)
     .toString()
 
   return maybeMinimumAmountCryptoHuman.andThen(minimumAmountCryptoHuman =>


### PR DESCRIPTION
## Description

Patches one inch swapper to use non-eip-1551 gas estimation without l1 fees on optimism. This is because the initial implementation was incorrect and more work is required to provide this.

With this in mind, for 1inch trades, network fee estimation will be incorrect and gas estimation will be generally inaccurate until the follow-up fix is live.

## Pull Request Type

- [x] :bug: Bug fix (Non-breaking Change: Fixes an issue)
- [ ] :hammer_and_wrench: Chore (Non-breaking Change: Doc updates, pkg upgrades, typos, etc..)
- [ ] :nail_care: New Feature (Breaking/Non-breaking Change)

## Issue (if applicable)

NA

## Risk

Low risk, no change to swapper logic aside from network fee calculation

## Testing

Check 1inch swapper network fees are somewhat accurate keeping in mind description above.

### Engineering

See above.

### Operations

See above.

## Screenshots (if applicable)
