### PR TITLE
fix: lifi trades missing metadata to execute

### DIFF
--- a/src/lib/swapper/swappers/LifiSwapper/buildTrade/buildTrade.ts
+++ b/src/lib/swapper/swappers/LifiSwapper/buildTrade/buildTrade.ts
@@ -36,6 +36,7 @@ export const buildTrade = async (
   // to allow passing the existing quote in.
   return (await getTradeQuote(input, lifiChainMap)).map(tradeQuote => ({
     ...tradeQuote.steps[0],
+    selectedLifiRoute: tradeQuote.selectedLifiRoute,
     receiveAddress,
   }))
 }


### PR DESCRIPTION
## Description

Fixes lifi trades not executing due to missing metadata required to execute them.

## Pull Request Type

- [x] :bug: Bug fix (Non-breaking Change: Fixes an issue)
- [ ] :hammer_and_wrench: Chore (Non-breaking Change: Doc updates, pkg upgrades, typos, etc..)
- [ ] :nail_care: New Feature (Breaking/Non-breaking Change)

## Issue (if applicable)

https://discord.com/channels/554694662431178782/1115468766722142258/1115490314384310283

## Risk

Very low risk to lifi trade execution only.

## Testing

Test lifi trades to ensure they execute as expected.

### Engineering

See above.

### Operations

This should introduce no change from production, it fixes a release candidate only.

## Screenshots (if applicable)

successful trade execution
https://etherscan.io/tx/0x26f0104c27f7c31939c8025ed42859ef41b35ca0efdb2bf5d592f68f95e5583b

![image](https://github.com/shapeshift/web/assets/125113430/959f873f-805c-4d72-941e-27cc52022f76)
![image](https://github.com/shapeshift/web/assets/125113430/da70872f-5e2c-4230-9e55-dbf37e13847a)

