### PR TITLE
feat: read-only opportunities negative amounts handling

### DIFF
--- a/src/components/EarnDashboard/components/PositionDetails/StakingPositionsByProvider.tsx
+++ b/src/components/EarnDashboard/components/PositionDetails/StakingPositionsByProvider.tsx
@@ -175,7 +175,7 @@ export const StakingPositionsByProvider: React.FC<StakingPositionsByProviderProp
           const opportunity = row.original
           const opportunityAssetId = opportunity.assetId
           const opportunityUnderlyingAssetId = opportunity.underlyingAssetId
-          const hasValue = bnOrZero(opportunity.fiatAmount).gt(0)
+          const hasValue = !bnOrZero(opportunity.fiatAmount).isZero()
           if (!opportunity.underlyingAssetIds.length) return null
           const isUnderlyingAsset = opportunity.underlyingAssetIds.includes(assetId)
           const underlyingAssetIndex = opportunity.underlyingAssetIds.indexOf(assetId)

--- a/src/components/EarnDashboard/components/ProviderDetails/OpportunityRow.tsx
+++ b/src/components/EarnDashboard/components/ProviderDetails/OpportunityRow.tsx
@@ -114,7 +114,7 @@ export const OpportunityRow: React.FC<
     const hasBalanceElement = <RawText textTransform='capitalize'>{type}</RawText>
     const subText = [
       aprElement,
-      ...(bnOrZero(cryptoAmountBaseUnit).gt(0) ? [hasBalanceElement] : []),
+      ...(!bnOrZero(cryptoAmountBaseUnit).isZero() ? [hasBalanceElement] : []),
     ]
 
     return subText.map((element, index) => (

--- a/src/components/EarnDashboard/components/ProviderDetails/StakingOpportunitiesByAsset.tsx
+++ b/src/components/EarnDashboard/components/ProviderDetails/StakingOpportunitiesByAsset.tsx
@@ -124,7 +124,7 @@ export const StakingPositionsByAsset: React.FC<StakingPositionsByAssetProps> = (
         accessor: 'fiatAmount',
         Cell: ({ row }: { row: RowProps }) => {
           const opportunity = row.original
-          const hasValue = bnOrZero(opportunity.fiatAmount).gt(0)
+          const hasValue = !bnOrZero(opportunity.fiatAmount).isZero()
           return hasValue ? (
             <Flex flexDir='column' alignItems={{ base: 'flex-end', md: 'flex-start' }}>
               <Amount.Fiat value={row.original.fiatAmount} />

--- a/src/components/EarnDashboard/components/ProviderDetails/WalletStakingByAsset.tsx
+++ b/src/components/EarnDashboard/components/ProviderDetails/WalletStakingByAsset.tsx
@@ -44,6 +44,8 @@ export const WalletStakingByAsset: React.FC<StakingPositionsByAssetProps> = ({ i
     selectAggregatedEarnUserStakingOpportunitiesIncludeEmpty,
   )
 
+  debugger
+
   const filteredDown = stakingOpportunities.filter(e => ids.includes(e.id as OpportunityId))
 
   const groupedItems = useMemo(() => {

--- a/src/components/EarnDashboard/components/ProviderDetails/WalletStakingByAsset.tsx
+++ b/src/components/EarnDashboard/components/ProviderDetails/WalletStakingByAsset.tsx
@@ -44,8 +44,6 @@ export const WalletStakingByAsset: React.FC<StakingPositionsByAssetProps> = ({ i
     selectAggregatedEarnUserStakingOpportunitiesIncludeEmpty,
   )
 
-  debugger
-
   const filteredDown = stakingOpportunities.filter(e => ids.includes(e.id as OpportunityId))
 
   const groupedItems = useMemo(() => {

--- a/src/components/Layout/Header/GlobalSearch/StakingResults/StakingResult.tsx
+++ b/src/components/Layout/Header/GlobalSearch/StakingResults/StakingResult.tsx
@@ -56,7 +56,7 @@ export const StakingResult = forwardRef<StakingResultProps, 'div'>(
       const hasBalanceElement = <RawText textTransform='capitalize'>{opportunity?.type}</RawText>
       const subText = [
         aprElement,
-        ...(bnOrZero(opportunity?.cryptoAmountBaseUnit).gt(0) ? [hasBalanceElement] : []),
+        ...(!bnOrZero(opportunity?.cryptoAmountBaseUnit).isZero() ? [hasBalanceElement] : []),
       ]
 
       return subText.map((element, index) => (
@@ -83,7 +83,7 @@ export const StakingResult = forwardRef<StakingResultProps, 'div'>(
             }
           />
         </Flex>
-        {bnOrZero(opportunity.fiatAmount).gt(0) && (
+        {!bnOrZero(opportunity.fiatAmount).isZero() && (
           <Flex flexDir='column' alignItems='flex-end'>
             <Amount.Fiat
               color='chakra-body-text'

--- a/src/components/StakingVaults/PositionTable.tsx
+++ b/src/components/StakingVaults/PositionTable.tsx
@@ -100,7 +100,8 @@ export const PositionTable: React.FC<PositionTableProps> = ({
         id: 'fiatAmount',
         accessor: 'fiatAmount',
         Cell: ({ row }: { row: RowProps }) => {
-          const hasValue = bnOrZero(row.original.fiatAmount).gt(0)
+          // A fiat amount can be positive or negative (debt) but not zero
+          const hasValue = !bnOrZero(row.original.fiatAmount).isZero()
           return hasValue ? (
             <Amount.Fiat value={row.original.fiatAmount} />
           ) : (

--- a/src/components/StakingVaults/StakingTable.tsx
+++ b/src/components/StakingVaults/StakingTable.tsx
@@ -115,7 +115,7 @@ export const StakingTable = ({ data, onClick, showTeaser }: StakingTableProps) =
         accessor: 'fiatAmount',
         Cell: ({ value, row }: { value: string; row: RowProps }) => (
           <Skeleton isLoaded={row.original.isLoaded}>
-            {bnOrZero(value).gt(0) ? (
+            {!bnOrZero(value).isZero() ? (
               <Amount.Fiat
                 value={value}
                 color={row.original.expired ? 'yellow.500' : 'green.500'}

--- a/src/state/apis/zapper/zapperApi.ts
+++ b/src/state/apis/zapper/zapperApi.ts
@@ -433,8 +433,15 @@ export const zapper = createApi({
                   // This is our best bet until we bring in the concept of an "DefiType.GenericOpportunity"
                   const defiType = DefiType.Staking
 
-                  // Actually defined because we pass networks in the query params
-                  const assetId = zapperAssetToMaybeAssetId(asset)
+                  const topLevelAsset = (() => {
+                    const maybeLpAsset = asset.tokens.find(
+                      token => token.metaType === 'supplied' || token.metaType === 'borrowed',
+                    )
+                    if (maybeLpAsset) return maybeLpAsset
+                    return asset
+                  })()
+
+                  const assetId = zapperAssetToMaybeAssetId(topLevelAsset)
 
                   if (!assetId) return undefined
 

--- a/src/state/apis/zapper/zapperApi.ts
+++ b/src/state/apis/zapper/zapperApi.ts
@@ -397,7 +397,7 @@ export const zapper = createApi({
                     if (maybeLpAcesssor?.balanceRaw) return maybeLpAcesssor
                     return asset
                   })()
-                  // The balance itself is a positive amount, but the USD valance is negative, so we need to check for that
+                  // The balance itself is a positive amount, but the USD balance is negative, so we need to check for that
                   const isNegativeStakedamount = bnOrZero(
                     stakedAmountCryptoBaseUnitAccessor?.balanceUSD,
                   ).isNegative()

--- a/src/state/apis/zapper/zapperApi.ts
+++ b/src/state/apis/zapper/zapperApi.ts
@@ -398,14 +398,14 @@ export const zapper = createApi({
                     return asset
                   })()
                   // The balance itself is a positive amount, but the USD balance is negative, so we need to check for that
-                  const isNegativeStakedamount = bnOrZero(
+                  const isNegativeStakedAmount = bnOrZero(
                     stakedAmountCryptoBaseUnitAccessor?.balanceUSD,
                   ).isNegative()
                   const stakedAmountCryptoBaseUnitBase = bnOrZero(
                     stakedAmountCryptoBaseUnitAccessor?.balanceRaw,
                   )
                   const stakedAmountCryptoBaseUnit = (
-                    isNegativeStakedamount
+                    isNegativeStakedAmount
                       ? stakedAmountCryptoBaseUnitBase.negated()
                       : stakedAmountCryptoBaseUnitBase
                   ).toFixed()

--- a/src/state/slices/opportunitiesSlice/selectors/combined.ts
+++ b/src/state/slices/opportunitiesSlice/selectors/combined.ts
@@ -115,8 +115,8 @@ export const selectAggregatedEarnOpportunitiesByAssetId = createDeepEqualOutputS
         })
 
         if (
-          (!includeEarnBalances && !includeRewardsBalances && bnOrZero(amountFiat).gt(0)) ||
-          (includeEarnBalances && bnOrZero(amountFiat).gt(0)) ||
+          (!includeEarnBalances && !includeRewardsBalances && !bnOrZero(amountFiat).isZero()) ||
+          (includeEarnBalances && !bnOrZero(amountFiat).isZero()) ||
           (includeRewardsBalances && bnOrZero(maybeStakingRewardsAmountFiat).gt(0))
         ) {
           acc[assetId] = true
@@ -170,7 +170,7 @@ export const selectAggregatedEarnOpportunitiesByAssetId = createDeepEqualOutputS
 
           const isActiveOpportunityByFilter =
             (!includeEarnBalances && !includeRewardsBalances) ||
-            (includeEarnBalances && bnOrZero(amountFiat).gt(0)) ||
+            (includeEarnBalances && !bnOrZero(amountFiat).isZero()) ||
             (includeRewardsBalances && bnOrZero(maybeStakingRewardsAmountFiat).gt(0))
 
           acc[assetId].fiatRewardsAmount = bnOrZero(maybeStakingRewardsAmountFiat)
@@ -230,7 +230,7 @@ export const selectAggregatedEarnOpportunitiesByAssetId = createDeepEqualOutputS
 
     const [activeOpportunities, inactiveOpportunities] = partition(
       sortedAggregatedEarnOpportunitiesByFiatAmount,
-      opportunity => bnOrZero(opportunity.fiatAmount).gt(0),
+      opportunity => !bnOrZero(opportunity.fiatAmount).isZero(),
     )
     inactiveOpportunities.sort((a, b) => (bnOrZero(a.apy).gte(bnOrZero(b.apy)) ? -1 : 1))
 
@@ -240,7 +240,7 @@ export const selectAggregatedEarnOpportunitiesByAssetId = createDeepEqualOutputS
       return sortedOpportunitiesByFiatAmountAndApy
 
     const withEarnBalances = aggregatedEarnOpportunitiesByAssetId.filter(opportunity =>
-      Boolean(includeEarnBalances && bnOrZero(opportunity.fiatAmount).gt(0)),
+      Boolean(includeEarnBalances && !bnOrZero(opportunity.fiatAmount).isZero()),
     )
     const withRewardsBalances = Object.values(byAssetId).filter(opportunity =>
       Boolean(includeRewardsBalances && bnOrZero(opportunity.fiatRewardsAmount).gt(0)),
@@ -414,8 +414,8 @@ export const selectAggregatedEarnOpportunitiesByProvider = createDeepEqualOutput
       })
 
       const isActiveOpportunityByFilter =
-        (!includeEarnBalances && !includeRewardsBalances && bnOrZero(cur.fiatAmount).gt(0)) ||
-        (includeEarnBalances && bnOrZero(cur.fiatAmount).gt(0)) ||
+        (!includeEarnBalances && !includeRewardsBalances && !bnOrZero(cur.fiatAmount).isZero()) ||
+        (includeEarnBalances && !bnOrZero(cur.fiatAmount).isZero()) ||
         (includeRewardsBalances && bnOrZero(maybeStakingRewardsAmountFiat).gt(0))
 
       if (isActiveOpportunityByFilter) {
@@ -444,7 +444,7 @@ export const selectAggregatedEarnOpportunitiesByProvider = createDeepEqualOutput
 
         const isActiveOpportunityByFilter =
           (!includeEarnBalances && !includeRewardsBalances) ||
-          (includeEarnBalances && bnOrZero(cur.fiatAmount).gt(0)) ||
+          (includeEarnBalances && !bnOrZero(cur.fiatAmount).isZero()) ||
           (includeRewardsBalances && bnOrZero(maybeStakingRewardsAmountFiat).gt(0))
         // No active staking for the current provider, show the highest APY
         if (!isActiveProvider) {
@@ -505,7 +505,7 @@ export const selectAggregatedEarnOpportunitiesByProvider = createDeepEqualOutput
 
     const [activeOpportunities, inactiveOpportunities] = partition(
       sortedListByFiatAmount,
-      opportunity => bnOrZero(opportunity.netProviderFiatAmount).gt(0),
+      opportunity => !bnOrZero(opportunity.netProviderFiatAmount).isZero(),
     )
     inactiveOpportunities.sort((a, b) => (bnOrZero(a.apy).gte(bnOrZero(b.apy)) ? -1 : 1))
 
@@ -515,7 +515,7 @@ export const selectAggregatedEarnOpportunitiesByProvider = createDeepEqualOutput
     if (!includeEarnBalances && !includeRewardsBalances) return sortedListByFiatAmountAndApy
 
     const withEarnBalances = Object.values(aggregatedEarnOpportunitiesByProvider).filter(
-      opportunity => Boolean(includeEarnBalances && bnOrZero(opportunity.fiatAmount).gt(0)),
+      opportunity => Boolean(includeEarnBalances && !bnOrZero(opportunity.fiatAmount).isZero()),
     )
     const withRewardsBalances = Object.values(aggregatedEarnOpportunitiesByProvider).filter(
       opportunity =>

--- a/src/state/slices/opportunitiesSlice/selectors/stakingSelectors.ts
+++ b/src/state/slices/opportunitiesSlice/selectors/stakingSelectors.ts
@@ -533,7 +533,7 @@ export const selectAggregatedEarnUserStakingOpportunitiesIncludeEmpty =
       const results = aggregatedEarnUserStakingOpportunitiesIncludeEmpty.filter(opportunity => {
         if (opportunity?.expired) {
           return (
-            bnOrZero(opportunity.stakedAmountCryptoBaseUnit).gt(0) ||
+            !bnOrZero(opportunity.stakedAmountCryptoBaseUnit).isZero() ||
             opportunity?.rewardsCryptoBaseUnit?.amounts.some(rewardsAmount =>
               bnOrZero(rewardsAmount).gt(0),
             )
@@ -547,8 +547,9 @@ export const selectAggregatedEarnUserStakingOpportunitiesIncludeEmpty =
         bnOrZero(a.fiatAmount).gte(bnOrZero(b.fiatAmount)) ? -1 : 1,
       )
 
-      const [activeResults, inactiveResults] = partition(sortedResultsByFiatAmount, opportunity =>
-        bnOrZero(opportunity.fiatAmount).gt(0),
+      const [activeResults, inactiveResults] = partition(
+        sortedResultsByFiatAmount,
+        opportunity => !bnOrZero(opportunity.fiatAmount).isZero(),
       )
       inactiveResults.sort((a, b) => (bnOrZero(a.apy).gte(bnOrZero(b.apy)) ? -1 : 1))
 
@@ -606,10 +607,10 @@ export const selectAggregatedEarnUserStakingEligibleOpportunities = createDeepEq
     const eligibleOpportunities = aggregatedEarnUserStakingOpportunities.reduce<
       StakingEarnOpportunityType[]
     >((acc, opportunity) => {
-      const hasBalance = opportunity.underlyingAssetIds.some(assetId =>
-        bnOrZero(assetBalances[assetId]).gt(0),
+      const hasBalance = opportunity.underlyingAssetIds.some(
+        assetId => !bnOrZero(assetBalances[assetId]).isZero(),
       )
-      const hasOpportunityBalance = bnOrZero(opportunity.fiatAmount).gt(0)
+      const hasOpportunityBalance = !bnOrZero(opportunity.fiatAmount).isZero()
       if (hasBalance && !opportunity.expired && !hasOpportunityBalance) acc.push(opportunity)
       return acc
     }, [])
@@ -726,7 +727,7 @@ export const selectAllEarnUserStakingOpportunitiesByFilter = createDeepEqualOutp
             .times(marketDataPrice ?? '0')
             .toString(),
         }
-        if (bnOrZero(opportunityBalance).gt(0)) {
+        if (!bnOrZero(opportunityBalance).isZero()) {
           opportunities.push(opportunity)
         }
       }


### PR DESCRIPTION
## Description

And fixes the top-level asset for borrowed/supplied opportunities while at it.

Note: The negative APY for providers containing debt opportunities issue is known and will be tackled in a [follow-up](https://github.com/shapeshift/web/pull/4690).
## Pull Request Type

- [ ] :bug: Bug fix (Non-breaking Change: Fixes an issue)
- [ ] :hammer_and_wrench: Chore (Non-breaking Change: Doc updates, pkg upgrades, typos, etc..)
- [x] :nail_care: New Feature (Breaking/Non-breaking Change)

## Issue (if applicable)

N/A

## Risk

<!-----------------------------------------------------------------------------
Outline the scope of your changes and the risk associated with them. You must use your discretion as an engineer to determine the potential impact of your changes.

E.g. an upgrade to `hdwallet` or core state management would be considered higher risk, and might require a full regression test. UI or isolated view changes, or something behind a feature flag may have near zero risk. Small bug fixes might require testing isolated to the specific fix.
------------------------------------------------------------------------------>

Low to none, though the heuristics for "has active balance" have been changed from "greater than 0" to "not zero" to handle negative amounts. There shouldn't be any user-facing changes, but if we ever had a wrong negative amount for some opportunity, somewhere, this would unveil it.

## Testing

<!-----------------------------------------------------------------------------
We treat every PR to be merged with the same scrutiny as if we were merging directly to production.

Your PR will not be merged if you do not complete the sections below for our engineering and operations teams to test.
------------------------------------------------------------------------------>

### Engineering

<!-----------------------------------------------------------------------------
Include sufficient information here for an engineer to test your PR. This may include how to test locally, in a built environment, changes to infrastructure etc.
------------------------------------------------------------------------------>

- Ensure negative amounts are handled in the nav earn tab, and matching fiat amounts look sane
- Ensure negative amounts rows are shown in the earn dashboard tab

### Operations

<!-----------------------------------------------------------------------------
If your changes have a user-facing impact, describe how a non-technical QA team can functionally test your changes in a preview environment.

If they are not user-facing please describe how to test for any regressions that may occur.
------------------------------------------------------------------------------>

- None

## Screenshots (if applicable)

<img width="1119" alt="Screenshot 2023-06-07 at 12 28 32" src="https://github.com/shapeshift/web/assets/17035424/76f44806-4cf2-43d6-83f0-21af759dbefc">
<img width="1105" alt="Screenshot 2023-06-07 at 12 28 27" src="https://github.com/shapeshift/web/assets/17035424/ef4199b0-8622-4ecd-832d-4d6976bf1a83">
<img width="1329" alt="Screenshot 2023-06-07 at 12 28 08" src="https://github.com/shapeshift/web/assets/17035424/6be04c28-4c96-4c18-a88e-6411d22f1cee">
<img width="1328" alt="Screenshot 2023-06-07 at 12 27 59" src="https://github.com/shapeshift/web/assets/17035424/b8639cb9-6044-4ebe-98dc-a5fcd700d3dd">