### PR TITLE
feat: handle opportunities dupes between read-only and current opportunities

### DIFF
--- a/src/state/apis/zapper/zapperApi.ts
+++ b/src/state/apis/zapper/zapperApi.ts
@@ -29,7 +29,7 @@ import type {
   ReadOnlyOpportunityType,
   StakingId,
 } from 'state/slices/opportunitiesSlice/types'
-import { DefiType } from 'state/slices/opportunitiesSlice/types'
+import { DefiProvider, DefiType } from 'state/slices/opportunitiesSlice/types'
 import { serializeUserStakingId } from 'state/slices/opportunitiesSlice/utils'
 import { selectFeatureFlag } from 'state/slices/preferencesSlice/selectors'
 
@@ -376,6 +376,13 @@ export const zapper = createApi({
             (acc, appAccountBalance) => {
               const appId = appAccountBalance.appId
               const appName = appAccountBalance.appName
+
+              // Avoids duplicates from out full-fledged opportunities
+              // Note, this assumes our DefiProvider value is the same as the AppName
+              if (Object.values(DefiProvider).includes(appName as DefiProvider)) {
+                return acc
+              }
+
               const appImage = appAccountBalance.appImage
               const accountId = toAccountId({
                 chainId:

--- a/src/state/slices/opportunitiesSlice/types.ts
+++ b/src/state/slices/opportunitiesSlice/types.ts
@@ -13,7 +13,7 @@ export enum DefiType {
 }
 
 export enum DefiProvider {
-  Idle = 'idle',
+  Idle = 'Idle',
   ShapeShift = 'ShapeShift',
   EthFoxStaking = 'ETH/FOX Staking',
   UniV2 = 'Uniswap V2',


### PR DESCRIPTION
## Description

Does what it says on the box - if an opportunity `appName` (i.e what we use as both an enum key and value as a dynamic `DefiProvider` of sorts / primary key for metadata by provider) is one of our *static* `DefiProvider` values, we should bail, since we have an akschual full-fledged opportunity that's going to be fetched a few seconds after.

## Pull Request Type

- [ ] :bug: Bug fix (Non-breaking Change: Fixes an issue)
- [ ] :hammer_and_wrench: Chore (Non-breaking Change: Doc updates, pkg upgrades, typos, etc..)
- [x] :nail_care: New Feature (Breaking/Non-breaking Change)

## Issue (if applicable)

N/A

## Risk

<!-----------------------------------------------------------------------------
Outline the scope of your changes and the risk associated with them. You must use your discretion as an engineer to determine the potential impact of your changes.

E.g. an upgrade to `hdwallet` or core state management would be considered higher risk, and might require a full regression test. UI or isolated view changes, or something behind a feature flag may have near zero risk. Small bug fixes might require testing isolated to the specific fix.
------------------------------------------------------------------------------>

None

## Testing

<!-----------------------------------------------------------------------------
We treat every PR to be merged with the same scrutiny as if we were merging directly to production.

Your PR will not be merged if you do not complete the sections below for our engineering and operations teams to test.
------------------------------------------------------------------------------>

### Engineering

<!-----------------------------------------------------------------------------
Include sufficient information here for an engineer to test your PR. This may include how to test locally, in a built environment, changes to infrastructure etc.
------------------------------------------------------------------------------>

- Ensure UNi-V2 and Idle are still fetched, parsed and upserted by our regular abstraction, not the read-only one. This can be verified by ensuring there's no external link icon on the opportunity row.

Note, you will have to clear your persisted store to test this. Didn't author a migration since this isn't live yet and we'd only see this in develop builds.

### Operations

<!-----------------------------------------------------------------------------
If your changes have a user-facing impact, describe how a non-technical QA team can functionally test your changes in a preview environment.

If they are not user-facing please describe how to test for any regressions that may occur.
------------------------------------------------------------------------------>

## Screenshots (if applicable)

<img width="1320" alt="image" src="https://github.com/shapeshift/web/assets/17035424/7d79f4cf-c71f-4366-a27a-742d6592b137">
<img width="1301" alt="image" src="https://github.com/shapeshift/web/assets/17035424/419cea78-0a8a-485f-b62a-761710c114b8">