### PR TITLE
chore: add gnosis safe to CSP

### DIFF
--- a/react-app-rewired/headers/csps/plugins/walletConnectToDapps.ts
+++ b/react-app-rewired/headers/csps/plugins/walletConnectToDapps.ts
@@ -2,4 +2,7 @@ import type { Csp } from '../../types'
 
 export const csp: Csp = {
   'img-src': ['https://registry.walletconnect.com', 'https://explorer-api.walletconnect.com'],
+  'connect-src': [
+    'wss://safe-walletconnect.safe.global/', // Explicit whitelist required for this dApp to work
+  ],
 }


### PR DESCRIPTION
## Description

Gnosis Safe requires a websocket CSP whitelist to connect.

This PR adds that whitelist.

## Pull Request Type

- [ ] :bug: Bug fix (Non-breaking Change: Fixes an issue)
- [x] :hammer_and_wrench: Chore (Non-breaking Change: Doc updates, pkg upgrades, typos, etc..)
- [ ] :nail_care: New Feature (Breaking/Non-breaking Change)

## Issue (if applicable)

N/A - raised by @firebomb1.

## Risk

Minimal.

## Testing

Go to https://app.safe.global/ and connect via Wallet Connect, and ensure the pair completes.

As an added bonus, it looks like switch chain works flawlessly, too.

### Engineering

☝️

### Operations

☝️

## Screenshots (if applicable)

<img width="321" alt="Screenshot 2023-06-08 at 10 09 00 am" src="https://github.com/shapeshift/web/assets/97164662/936ff809-96ca-4657-8787-e552a446a6ea">

