### PR TITLE
fix: don't subtract APY from negative opportunities in blended APY

### DIFF
--- a/src/state/slices/opportunitiesSlice/selectors/combined.ts
+++ b/src/state/slices/opportunitiesSlice/selectors/combined.ts
@@ -193,11 +193,11 @@ export const selectAggregatedEarnOpportunitiesByAssetId = createDeepEqualOutputS
             acc[assetId].apy = BigNumber.maximum(acc[assetId].apy, cur.apy).toFixed()
           } else if (isActiveOpportunityByFilter) {
             totalFiatAmountByAssetId[assetId] = bnOrZero(totalFiatAmountByAssetId[assetId]).plus(
-              amountFiat,
+              BigNumber.max(amountFiat, 0),
             )
             projectedAnnualizedYieldByAssetId[assetId] = bnOrZero(
               projectedAnnualizedYieldByAssetId[assetId],
-            ).plus(bnOrZero(amountFiat).times(cur.apy))
+            ).plus(BigNumber.max(amountFiat, 0).times(cur.apy))
           }
 
           acc[assetId].cryptoBalancePrecision = bnOrZero(acc[assetId].cryptoBalancePrecision)
@@ -450,11 +450,11 @@ export const selectAggregatedEarnOpportunitiesByProvider = createDeepEqualOutput
           acc[provider].apy = BigNumber.maximum(acc[provider].apy, cur.apy).toFixed()
         } else if (isActiveOpportunityByFilter) {
           totalFiatAmountByProvider[provider] = bnOrZero(totalFiatAmountByProvider[provider]).plus(
-            cur.fiatAmount,
+            BigNumber.max(cur.fiatAmount, 0),
           )
           projectedAnnualizedYieldByProvider[provider] = bnOrZero(
             projectedAnnualizedYieldByProvider[provider],
-          ).plus(bnOrZero(cur.fiatAmount).times(cur.apy))
+          ).plus(BigNumber.max(cur.fiatAmount, 0).times(cur.apy))
         }
 
         if (cur.type === DefiType.LiquidityPool) {


### PR DESCRIPTION
## Description

This PR zero's out the virtual fiat amount for negative amounts - if an opportunity has a negative (debt) fiat amount, we shouldn't take its fiat amount into account and sum it (effectively making the blended APY lower) but simply zero it out. That is because debt opportunities don't earn yield, so their APY is irrelevant and shouldn't be accounted for in the blended total.

## Pull Request Type

- [x] :bug: Bug fix (Non-breaking Change: Fixes an issue)
- [ ] :hammer_and_wrench: Chore (Non-breaking Change: Doc updates, pkg upgrades, typos, etc..)
- [ ] :nail_care: New Feature (Breaking/Non-breaking Change)

## Issue (if applicable)

N/A

## Risk

<!-----------------------------------------------------------------------------
Outline the scope of your changes and the risk associated with them. You must use your discretion as an engineer to determine the potential impact of your changes.

E.g. an upgrade to `hdwallet` or core state management would be considered higher risk, and might require a full regression test. UI or isolated view changes, or something behind a feature flag may have near zero risk. Small bug fixes might require testing isolated to the specific fix.
------------------------------------------------------------------------------>

None

## Testing

<!-----------------------------------------------------------------------------
We treat every PR to be merged with the same scrutiny as if we were merging directly to production.

Your PR will not be merged if you do not complete the sections below for our engineering and operations teams to test.
------------------------------------------------------------------------------>

- Blended APYs aren't accounting for negative fiat amounts i.e there are no negative blended APY totals. Test with frame injected willy's wallet and ensure Agave/Compound blended APYs are happy

### Engineering

<!-----------------------------------------------------------------------------
Include sufficient information here for an engineer to test your PR. This may include how to test locally, in a built environment, changes to infrastructure etc.
------------------------------------------------------------------------------>

### Operations

<!-----------------------------------------------------------------------------
If your changes have a user-facing impact, describe how a non-technical QA team can functionally test your changes in a preview environment.

If they are not user-facing please describe how to test for any regressions that may occur.
------------------------------------------------------------------------------>


## Screenshots (if applicable)

See https://github.com/shapeshift/web/pull/4679 for current

<img width="1295" alt="Screenshot 2023-06-08 at 10 27 55" src="https://github.com/shapeshift/web/assets/17035424/3b7b9e5b-7bdb-40b0-a9fa-098ee9e02411">
<img width="1310" alt="Screenshot 2023-06-08 at 10 26 41" src="https://github.com/shapeshift/web/assets/17035424/245fd6dd-ccf1-4eee-8557-c21f97e3e35c">
<img width="1324" alt="image" src="https://github.com/shapeshift/web/assets/17035424/6a27c688-2ab5-44f5-b103-e37c544a8b4b">
<img width="1297" alt="image" src="https://github.com/shapeshift/web/assets/17035424/a3a1ce73-573c-4e03-b941-6589ba392f3a">
