### PR TITLE
feat: read-only opportunities improve nested assets p1

### DIFF
--- a/src/state/apis/zapper/zapperApi.ts
+++ b/src/state/apis/zapper/zapperApi.ts
@@ -569,28 +569,17 @@ export const zapper = createApi({
                   const underlyingAssetRatiosBaseUnit = (() =>
                     (asset.dataProps?.reserves ?? [])
                       .map(reserve => {
-                        const reserveBaseUnit = bnOrZero(
-                          bnOrZero(bnOrZero(reserve).toFixed()).toString(),
-                        ).times(bn(10).pow(asset.decimals ?? 18))
-
-                        const totalSupplyBaseUnit =
-                          typeof asset.supply === 'number'
-                            ? bnOrZero(asset.supply)
-                                .times(bn(10).pow(asset.decimals ?? 18))
-                                .toString()
-                            : undefined
-
-                        const tokenPoolRatio =
-                          reserveBaseUnit && totalSupplyBaseUnit
-                            ? reserveBaseUnit.div(totalSupplyBaseUnit).toString()
-                            : undefined
-
-                        if (!tokenPoolRatio) return undefined
-                        const ratio = toBaseUnit(
-                          tokenPoolRatio.toString(),
-                          asset.tokens[0].decimals,
-                        )
-                        return ratio
+                      const reserveBaseUnit = toBaseUnit(reserve, asset.decimals ?? 18)
+                      const totalSupplyBaseUnit =
+                        typeof asset.supply === 'number'
+                          ? toBaseUnit(asset.supply, asset.decimals ?? 18)
+                          : undefined
+                      const tokenPoolRatio = totalSupplyBaseUnit
+                        ? bn(reserveBaseUnit).div(totalSupplyBaseUnit).toString()
+                        : undefined
+                      if (!tokenPoolRatio) return '0'
+                      const ratio = toBaseUnit(tokenPoolRatio, asset.tokens[0].decimals)
+                      return ratio
                       })
                       .filter(
                         isSome,

--- a/src/state/apis/zapper/zapperApi.ts
+++ b/src/state/apis/zapper/zapperApi.ts
@@ -567,23 +567,19 @@ export const zapper = createApi({
                   }
 
                   const underlyingAssetRatiosBaseUnit = (() =>
-                    (asset.dataProps?.reserves ?? [])
-                      .map(reserve => {
-                        const reserveBaseUnit = toBaseUnit(reserve, asset.decimals ?? 18)
-                        const totalSupplyBaseUnit =
-                          typeof asset.supply === 'number'
-                            ? toBaseUnit(asset.supply, asset.decimals ?? 18)
-                            : undefined
-                        const tokenPoolRatio = totalSupplyBaseUnit
-                          ? bn(reserveBaseUnit).div(totalSupplyBaseUnit).toString()
+                    (asset.dataProps?.reserves ?? []).map(reserve => {
+                      const reserveBaseUnit = toBaseUnit(reserve, asset.decimals ?? 18)
+                      const totalSupplyBaseUnit =
+                        typeof asset.supply === 'number'
+                          ? toBaseUnit(asset.supply, asset.decimals ?? 18)
                           : undefined
-                        if (!tokenPoolRatio) return '0'
-                        const ratio = toBaseUnit(tokenPoolRatio, asset.tokens[0].decimals)
-                        return ratio
-                      })
-                      .filter(
-                        isSome,
-                      ) as unknown as OpportunityMetadataBase['underlyingAssetRatiosBaseUnit'])()
+                      const tokenPoolRatio = totalSupplyBaseUnit
+                        ? bn(reserveBaseUnit).div(totalSupplyBaseUnit).toString()
+                        : undefined
+                      if (!tokenPoolRatio) return '0'
+                      const ratio = toBaseUnit(tokenPoolRatio, asset.tokens[0].decimals)
+                      return ratio
+                    }) as unknown as OpportunityMetadataBase['underlyingAssetRatiosBaseUnit'])()
 
                   if (!acc.opportunities[opportunityId]) {
                     acc.opportunities[opportunityId] = {

--- a/src/state/apis/zapper/zapperApi.ts
+++ b/src/state/apis/zapper/zapperApi.ts
@@ -427,6 +427,31 @@ export const zapper = createApi({
                     acc.push(rewardAssetId)
                     return acc
                   }, []) as unknown as AssetIdsTuple
+
+                  // Upsert rewardAssetIds if they don't exist in store
+                  const rewardAssetsToUpsert = rewardTokens.reduce<AssetsState>(
+                    (acc, token, i) => {
+                      const rewardAssetId = zapperAssetToMaybeAssetId(token)
+                      if (!rewardAssetId) return acc
+                      if (assets[rewardAssetId]) return acc
+
+                      acc.byId[rewardAssetId] = makeAsset({
+                        assetId: rewardAssetId,
+                        symbol: token.symbol,
+                        // No dice here, there's no name property
+                        name: token.symbol,
+                        precision: token.decimals,
+                        icon: token.displayProps?.images[i] ?? '',
+                      })
+                      acc.ids = acc.ids.concat(rewardAssetId)
+
+                      return acc
+                    },
+                    { byId: {}, ids: [] },
+                  )
+
+                  dispatch(assetsSlice.actions.upsertAssets(rewardAssetsToUpsert))
+
                   const rewardsCryptoBaseUnit = {
                     amounts: rewardTokens.map(token => token.balanceRaw),
                     claimable: true,
@@ -541,43 +566,35 @@ export const zapper = createApi({
                     dispatch(assetsSlice.actions.upsertAsset(underlyingAsset))
                   }
 
-                  const underlyingAssetRatiosBaseUnit = (() => {
-                    const token0ReservesCryptoPrecision = asset.dataProps?.reserves?.[0]
-                    const token1ReservesCryptoPrecision = asset.dataProps?.reserves?.[1]
-                    const token0ReservesBaseUnit =
-                      typeof token0ReservesCryptoPrecision === 'number'
-                        ? bnOrZero(
-                            bnOrZero(bnOrZero(token0ReservesCryptoPrecision.toFixed()).toString()),
-                          ).times(bn(10).pow(asset.decimals ?? 18))
-                        : undefined
-                    const token1ReservesBaseUnit =
-                      typeof token1ReservesCryptoPrecision === 'number'
-                        ? bnOrZero(
-                            bnOrZero(bnOrZero(token1ReservesCryptoPrecision.toFixed()).toString()),
-                          ).times(bn(10).pow(asset.decimals ?? 18))
-                        : undefined
-                    const totalSupplyBaseUnit =
-                      typeof asset.supply === 'number'
-                        ? bnOrZero(asset.supply)
-                            .times(bn(10).pow(asset.decimals ?? 18))
-                            .toString()
-                        : undefined
-                    const token0PoolRatio =
-                      token0ReservesBaseUnit && totalSupplyBaseUnit
-                        ? token0ReservesBaseUnit.div(totalSupplyBaseUnit).toString()
-                        : undefined
-                    const token1PoolRatio =
-                      token1ReservesBaseUnit && totalSupplyBaseUnit
-                        ? token1ReservesBaseUnit.div(totalSupplyBaseUnit).toString()
-                        : undefined
+                  const underlyingAssetRatiosBaseUnit = (() =>
+                    (asset.dataProps?.reserves ?? [])
+                      .map(reserve => {
+                        const reserveBaseUnit = bnOrZero(
+                          bnOrZero(bnOrZero(reserve).toFixed()).toString(),
+                        ).times(bn(10).pow(asset.decimals ?? 18))
 
-                    if (!(token0PoolRatio && token1PoolRatio)) return
+                        const totalSupplyBaseUnit =
+                          typeof asset.supply === 'number'
+                            ? bnOrZero(asset.supply)
+                                .times(bn(10).pow(asset.decimals ?? 18))
+                                .toString()
+                            : undefined
 
-                    return [
-                      toBaseUnit(token0PoolRatio.toString(), asset.tokens[0].decimals),
-                      toBaseUnit(token1PoolRatio.toString(), asset.tokens[1].decimals),
-                    ] as const
-                  })()
+                        const tokenPoolRatio =
+                          reserveBaseUnit && totalSupplyBaseUnit
+                            ? reserveBaseUnit.div(totalSupplyBaseUnit).toString()
+                            : undefined
+
+                        if (!tokenPoolRatio) return undefined
+                        const ratio = toBaseUnit(
+                          tokenPoolRatio.toString(),
+                          asset.tokens[0].decimals,
+                        )
+                        return ratio
+                      })
+                      .filter(
+                        isSome,
+                      ) as unknown as OpportunityMetadataBase['underlyingAssetRatiosBaseUnit'])()
 
                   if (!acc.opportunities[opportunityId]) {
                     acc.opportunities[opportunityId] = {

--- a/src/state/apis/zapper/zapperApi.ts
+++ b/src/state/apis/zapper/zapperApi.ts
@@ -569,17 +569,17 @@ export const zapper = createApi({
                   const underlyingAssetRatiosBaseUnit = (() =>
                     (asset.dataProps?.reserves ?? [])
                       .map(reserve => {
-                      const reserveBaseUnit = toBaseUnit(reserve, asset.decimals ?? 18)
-                      const totalSupplyBaseUnit =
-                        typeof asset.supply === 'number'
-                          ? toBaseUnit(asset.supply, asset.decimals ?? 18)
+                        const reserveBaseUnit = toBaseUnit(reserve, asset.decimals ?? 18)
+                        const totalSupplyBaseUnit =
+                          typeof asset.supply === 'number'
+                            ? toBaseUnit(asset.supply, asset.decimals ?? 18)
+                            : undefined
+                        const tokenPoolRatio = totalSupplyBaseUnit
+                          ? bn(reserveBaseUnit).div(totalSupplyBaseUnit).toString()
                           : undefined
-                      const tokenPoolRatio = totalSupplyBaseUnit
-                        ? bn(reserveBaseUnit).div(totalSupplyBaseUnit).toString()
-                        : undefined
-                      if (!tokenPoolRatio) return '0'
-                      const ratio = toBaseUnit(tokenPoolRatio, asset.tokens[0].decimals)
-                      return ratio
+                        if (!tokenPoolRatio) return '0'
+                        const ratio = toBaseUnit(tokenPoolRatio, asset.tokens[0].decimals)
+                        return ratio
                       })
                       .filter(
                         isSome,
@@ -591,7 +591,7 @@ export const zapper = createApi({
                       assetId,
                       underlyingAssetId,
                       underlyingAssetIds,
-                      underlyingAssetRatiosBaseUnit: underlyingAssetRatiosBaseUnit ?? ['0', '0'],
+                      underlyingAssetRatiosBaseUnit,
                       id: opportunityId,
                       icon,
                       name,

--- a/src/state/slices/opportunitiesSlice/types.ts
+++ b/src/state/slices/opportunitiesSlice/types.ts
@@ -62,7 +62,7 @@ export type OpportunityMetadataBase = {
   // For opportunities a la Idle, that's the asset the opportunity wraps
   underlyingAssetIds: AssetIdsTuple
   // The underlying amount of underlyingAssetId 0 and maybe 1 per 1 LP token, in base unit
-  underlyingAssetRatiosBaseUnit: readonly [string, string] | readonly [string]
+  underlyingAssetRatiosBaseUnit: readonly string[]
   // The reward assets this opportunity yields, typically 1/2 or 3 assets max.
   // Can also be empty in case there are no denominated rewards or we are unable to track them
   rewardAssetIds: AssetIdsTuple


### PR DESCRIPTION
## Description

This PR improves our heuristics for "nested assets" in read-only opportunities:

- doesn't assume underlying assets are always two - they can be one, or more than two, this makes it programmatic
- upserts reward assets if non-existing. We do so for top-level/underlying asset, but in case the rewards assets aren't part of these two and we don't have them in store, we will miss them in the assets slice

Note that this doesn't produce any visible change for now. The reason for this is this guy here:

https://github.com/shapeshift/web/blob/da01ef7988613ff80e36b9403cab020db38d920a/src/components/EarnDashboard/components/ProviderDetails/OpportunityRow.tsx#L90-L98

We assume an opportunity row can have rewards nested asset rows, *or* underlying asset rows, not the two together. This was perfectly valid previously, but now that we abuse the staking `DefiType` (and will most likely use it as our only `type` going forward, removing `DefiType` altogether) for the read-only opportunities, this makes us unable to see the underlying assets.
This will need to be tackled in a separate PR - once that's done, underlying holdings should work out-of-the-box.

## Pull Request Type

- [ ] :bug: Bug fix (Non-breaking Change: Fixes an issue)
- [ ] :hammer_and_wrench: Chore (Non-breaking Change: Doc updates, pkg upgrades, typos, etc..)
- [x] :nail_care: New Feature (Breaking/Non-breaking Change)

## Issue (if applicable)

N/A

## Risk

<!-----------------------------------------------------------------------------
Outline the scope of your changes and the risk associated with them. You must use your discretion as an engineer to determine the potential impact of your changes.

E.g. an upgrade to `hdwallet` or core state management would be considered higher risk, and might require a full regression test. UI or isolated view changes, or something behind a feature flag may have near zero risk. Small bug fixes might require testing isolated to the specific fix.
------------------------------------------------------------------------------>

None

## Testing

<!-----------------------------------------------------------------------------
We treat every PR to be merged with the same scrutiny as if we were merging directly to production.

Your PR will not be merged if you do not complete the sections below for our engineering and operations teams to test.
------------------------------------------------------------------------------>

- None, this is groundwork which comes with no visible changes

### Engineering

<!-----------------------------------------------------------------------------
Include sufficient information here for an engineer to test your PR. This may include how to test locally, in a built environment, changes to infrastructure etc.
------------------------------------------------------------------------------>

### Operations

<!-----------------------------------------------------------------------------
If your changes have a user-facing impact, describe how a non-technical QA team can functionally test your changes in a preview environment.

If they are not user-facing please describe how to test for any regressions that may occur.
------------------------------------------------------------------------------>

## Screenshots (if applicable)

Multiple underlyings assets (more than 2, our current assumed max.) :

<img width="311" alt="Screenshot 2023-06-08 at 14 51 34" src="https://github.com/shapeshift/web/assets/17035424/4d7e5484-db54-4769-9467-5c7031b3c9d3">

Single underlying:

<img width="309" alt="Screenshot 2023-06-08 at 14 51 15" src="https://github.com/shapeshift/web/assets/17035424/085e0878-540b-4792-ab39-abd8db799af4">