### PR TITLE
fix: replace deprecated disabled prop

### DIFF
--- a/src/components/Modals/Settings/CurrencyFormat.tsx
+++ b/src/components/Modals/Settings/CurrencyFormat.tsx
@@ -50,7 +50,7 @@ export const CurrencyFormat = () => {
             const active = currencyFormat === currentCurrencyFormat
             const buttonProps = active
               ? {
-                  disabled: true,
+                  isDisabled: true,
                   _disabled: { opacity: 1 },
                 }
               : {

--- a/src/components/Modals/Settings/FiatCurrencies.tsx
+++ b/src/components/Modals/Settings/FiatCurrencies.tsx
@@ -54,7 +54,7 @@ export const FiatCurrencies = () => {
             const active = currency === selectedCurrency
             const buttonProps = active
               ? {
-                  disabled: true,
+                  isDisabled: true,
                   _disabled: { opacity: 1 },
                 }
               : {

--- a/src/context/WalletProvider/KeepKey/components/Connect.tsx
+++ b/src/context/WalletProvider/KeepKey/components/Connect.tsx
@@ -123,7 +123,7 @@ export const KeepKeyConnect = () => {
       </ModalHeader>
       <ModalBody>
         <Text mb={4} color='gray.500' translation={'walletProvider.keepKey.connect.body'} />
-        <Button width='full' colorScheme='blue' onClick={pairDevice} disabled={loading}>
+        <Button width='full' colorScheme='blue' onClick={pairDevice} isDisabled={loading}>
           {loading ? (
             <CircularProgress size='5' />
           ) : (

--- a/src/context/WalletProvider/KeepKey/components/FactoryState.tsx
+++ b/src/context/WalletProvider/KeepKey/components/FactoryState.tsx
@@ -42,7 +42,7 @@ export const KeepKeyFactoryState = () => {
           size='lg'
           colorScheme='blue'
           onClick={handleCreateWalletPress}
-          disabled={loading}
+          isDisabled={loading}
           mb={3}
         >
           <Text translation={'modals.keepKey.factoryState.createButton'} />
@@ -51,7 +51,7 @@ export const KeepKeyFactoryState = () => {
           width='full'
           size='lg'
           onClick={handleRecoverWalletPress}
-          disabled={loading}
+          isDisabled={loading}
           variant='outline'
           border='none'
         >

--- a/src/context/WalletProvider/KeepKey/components/Label.tsx
+++ b/src/context/WalletProvider/KeepKey/components/Label.tsx
@@ -64,7 +64,7 @@ export const KeepKeyLabel = () => {
           size='lg'
           colorScheme='blue'
           onClick={disposition === 'initializing' ? handleInitializeSubmit : handleRecoverSubmit}
-          disabled={loading}
+          isDisabled={loading}
           mb={3}
         >
           <Text

--- a/src/context/WalletProvider/KeepKey/components/Passphrase.tsx
+++ b/src/context/WalletProvider/KeepKey/components/Passphrase.tsx
@@ -59,7 +59,13 @@ export const KeepKeyPassphrase = ({ deviceId }: { deviceId: string }) => {
             </AlertDescription>
           </Alert>
         )}
-        <Button width='full' size='lg' colorScheme='blue' onClick={handleSubmit} disabled={loading}>
+        <Button
+          width='full'
+          size='lg'
+          colorScheme='blue'
+          onClick={handleSubmit}
+          isDisabled={loading}
+        >
           <Text translation={'modals.keepKey.passphrase.button'} />
         </Button>
       </ModalBody>

--- a/src/context/WalletProvider/KeepKey/components/Pin.tsx
+++ b/src/context/WalletProvider/KeepKey/components/Pin.tsx
@@ -196,7 +196,7 @@ export const KeepKeyPin = ({
         size={confirmButtonSize ?? 'lg'}
         colorScheme='blue'
         onClick={handleSubmit}
-        disabled={loading || isPinEmpty}
+        isDisabled={loading || isPinEmpty}
       >
         <Text translation={`walletProvider.keepKey.${translationType}.button`} />
       </Button>

--- a/src/context/WalletProvider/KeepKey/components/RecoverySentenceEntry.tsx
+++ b/src/context/WalletProvider/KeepKey/components/RecoverySentenceEntry.tsx
@@ -278,7 +278,7 @@ export const KeepKeyRecoverySentenceEntry = () => {
               type='submit'
               onClick={handleWordSubmit}
               mb={3}
-              disabled={recoveryCharacterIndex ? recoveryCharacterIndex < 3 : true}
+              isDisabled={recoveryCharacterIndex ? recoveryCharacterIndex < 3 : true}
             >
               <Text translation={'modals.keepKey.recoverySentenceEntry.button'} />
             </Button>

--- a/src/context/WalletProvider/KeepKey/components/RecoverySentenceInvalid.tsx
+++ b/src/context/WalletProvider/KeepKey/components/RecoverySentenceInvalid.tsx
@@ -29,7 +29,7 @@ export const KeepKeyRecoverySentenceInvalid = () => {
       <ModalBody textAlign='center'>
         <WarningTwoIcon color='yellow.500' boxSize={20} mb={6} />
         <Text color='gray.500' translation={'modals.keepKey.recoveryInvalid.body'} mb={4} />
-        <Button width='full' colorScheme='blue' disabled={loading} onClick={handleRetryClick}>
+        <Button width='full' colorScheme='blue' isDisabled={loading} onClick={handleRetryClick}>
           <Text translation={'modals.keepKey.recoveryInvalid.button'} />
         </Button>
       </ModalBody>

--- a/src/context/WalletProvider/MobileWallet/components/MobileCreate.tsx
+++ b/src/context/WalletProvider/MobileWallet/components/MobileCreate.tsx
@@ -146,7 +146,7 @@ export const MobileCreate: React.FC<MobileCreateProps> = props => {
           colorScheme='blue'
           size='lg'
           isLoading={isSaving}
-          disabled={isSaving || !(words && revealedOnce.current && label)}
+          isDisabled={isSaving || !(words && revealedOnce.current && label)}
           onClick={() => {
             if (vault?.mnemonic && label) {
               try {

--- a/src/context/WalletProvider/MobileWallet/components/MobileStart.tsx
+++ b/src/context/WalletProvider/MobileWallet/components/MobileStart.tsx
@@ -40,7 +40,7 @@ export const MobileStart = ({ history }: RouteComponentProps) => {
             py={4}
             justifyContent='space-between'
             rightIcon={<ArrowForwardIcon />}
-            disabled={!hasLocalWallet}
+            isDisabled={!hasLocalWallet}
             onClick={() => history.push('/mobile/load')}
             data-test='wallet-native-load-button'
           >

--- a/src/context/WalletProvider/NativeWallet/components/LegacyMigration/LegacyLogin.tsx
+++ b/src/context/WalletProvider/NativeWallet/components/LegacyMigration/LegacyLogin.tsx
@@ -232,7 +232,7 @@ export const LegacyLogin: React.FC<LegacyLoginProps> = ({ onLoginSuccess }) => {
           )}
 
           <Button
-            disabled={!captchaSolution}
+            isDisabled={!captchaSolution}
             colorScheme='blue'
             width='full'
             size='lg'

--- a/src/context/WalletProvider/NativeWallet/components/NativeCreate.tsx
+++ b/src/context/WalletProvider/NativeWallet/components/NativeCreate.tsx
@@ -164,7 +164,7 @@ export const NativeCreate = () => {
         <Button
           colorScheme='blue'
           size='lg'
-          disabled={!(vault && words && revealedOnce.current)}
+          isDisabled={!(vault && words && revealedOnce.current)}
           onClick={handleClick}
         >
           <Text translation={'walletProvider.shapeShift.create.button'} />

--- a/src/context/WalletProvider/NativeWallet/components/NativeStart.tsx
+++ b/src/context/WalletProvider/NativeWallet/components/NativeStart.tsx
@@ -40,7 +40,7 @@ export const NativeStart = ({ history }: RouteComponentProps) => {
             py={4}
             justifyContent='space-between'
             rightIcon={<ArrowForwardIcon />}
-            disabled={!hasLocalWallet}
+            isDisabled={!hasLocalWallet}
             onClick={() => history.push('/native/load')}
             data-test='wallet-native-load-button'
           >

--- a/src/context/WalletProvider/components/ConnectModal.tsx
+++ b/src/context/WalletProvider/components/ConnectModal.tsx
@@ -42,7 +42,7 @@ export const ConnectModal: React.FC<ConnectModalProps> = ({
             isLoading
             loadingText='Pairing Wallet'
             spinner={<Spinner color='white' />}
-            disabled={loading}
+            isDisabled={loading}
           >
             <Text translation={buttonText || 'walletProvider.keepKey.connect.button'} />
           </Button>
@@ -51,7 +51,7 @@ export const ConnectModal: React.FC<ConnectModalProps> = ({
             width='full'
             colorScheme='blue'
             onClick={handlePairDeviceClick}
-            disabled={loading}
+            isDisabled={loading}
             data-test='wallet-pair-button'
           >
             <Text translation={buttonText || 'walletProvider.keepKey.connect.button'} />

--- a/src/context/WalletProvider/components/RedirectModal.tsx
+++ b/src/context/WalletProvider/components/RedirectModal.tsx
@@ -31,7 +31,7 @@ export const RedirectModal: React.FC<RedirectModalProps> = props => {
           width='full'
           colorScheme='blue'
           onClick={props.onClickAction}
-          disabled={props.loading}
+          isDisabled={props.loading}
         >
           <Text translation={props.buttonText || 'walletProvider.keepKey.connect.button'} />
         </Button>

--- a/src/pages/Accounts/AddAccountModal.tsx
+++ b/src/pages/Accounts/AddAccountModal.tsx
@@ -137,7 +137,7 @@ export const AddAccountModal = () => {
           <Button
             colorScheme='blue'
             width='full'
-            disabled={!isAbleToAddAccount}
+            isDisabled={!isAbleToAddAccount}
             onClick={handleAddAccount}
           >
             {translate('accounts.addAccount')}

--- a/src/plugins/walletConnectToDapps/v1/components/modals/callRequest/methods/SendTransactionConfirmation.tsx
+++ b/src/plugins/walletConnectToDapps/v1/components/modals/callRequest/methods/SendTransactionConfirmation.tsx
@@ -131,7 +131,7 @@ export const SendTransactionConfirmation = ({ request, onConfirm, onReject }: Pr
             type='submit'
             onClick={form.handleSubmit(onConfirm)}
             isLoading={form.formState.isSubmitting}
-            disabled={!fees}
+            isDisabled={!fees}
           >
             {translate('plugins.walletConnectToDapps.modal.signMessage.confirm')}
           </Button>

--- a/src/plugins/walletConnectToDapps/v1/components/modals/callRequest/methods/SignTransactionConfirmation.tsx
+++ b/src/plugins/walletConnectToDapps/v1/components/modals/callRequest/methods/SignTransactionConfirmation.tsx
@@ -131,7 +131,7 @@ export const SignTransactionConfirmation = ({ request, onConfirm, onReject }: Pr
             type='submit'
             onClick={form.handleSubmit(onConfirm)}
             isLoading={form.formState.isSubmitting}
-            disabled={!fees}
+            isDisabled={!fees}
           >
             {translate('plugins.walletConnectToDapps.modal.signMessage.confirm')}
           </Button>

--- a/src/plugins/walletConnectToDapps/v2/components/modals/CosmosSignMessageConfirmation.tsx
+++ b/src/plugins/walletConnectToDapps/v2/components/modals/CosmosSignMessageConfirmation.tsx
@@ -139,7 +139,7 @@ export const CosmosSignMessageConfirmationModal: FC<
           colorScheme='blue'
           type='submit'
           onClick={handleConfirm}
-          disabled={true}
+          isDisabled={true}
         >
           {translate('plugins.walletConnectToDapps.modal.signMessage.comingSoon')}
         </Button>

--- a/src/plugins/walletConnectToDapps/v2/components/modals/EIP155TransactionConfirmation.tsx
+++ b/src/plugins/walletConnectToDapps/v2/components/modals/EIP155TransactionConfirmation.tsx
@@ -132,7 +132,7 @@ export const EIP155TransactionConfirmation: FC<
           type='submit'
           onClick={form.handleSubmit(handleConfirm)}
           isLoading={form.formState.isSubmitting}
-          disabled={!fees}
+          isDisabled={!fees}
         >
           {translate('plugins.walletConnectToDapps.modal.signMessage.confirm')}
         </Button>


### PR DESCRIPTION
## Description

We recently updated Chakra to a version that dropped legacy support for the `disabled` prop on Buttons, which should now be `isDisabled`.

## Pull Request Type

- [x] :bug: Bug fix (Non-breaking Change: Fixes an issue)
- [ ] :hammer_and_wrench: Chore (Non-breaking Change: Doc updates, pkg upgrades, typos, etc..)
- [ ] :nail_care: New Feature (Breaking/Non-breaking Change)

## Issue (if applicable)

N/A - unblocks current release.

## Risk

Small.

## Testing

Ensure buttons are disabled when they are meant to be.

### Engineering

### Operations

Side not, sanity check UI to ensure everything still looks and works the same in case there are any other breaking changes that we missed.

## Screenshots (if applicable)

N/A
