### PR TITLE
fix: handle upsertion more gracefully in getNftUserTokens

### DIFF
--- a/src/state/apis/nft/nftApi.ts
+++ b/src/state/apis/nft/nftApi.ts
@@ -2,6 +2,7 @@ import type { PayloadAction } from '@reduxjs/toolkit'
 import { createSlice, prepareAutoBatched } from '@reduxjs/toolkit'
 import { createApi } from '@reduxjs/toolkit/dist/query/react'
 import type { AccountId, AssetId } from '@shapeshiftoss/caip'
+import { deserializeNftAssetReference, fromAssetId } from '@shapeshiftoss/caip'
 import { PURGE } from 'redux-persist'
 import type { PartialRecord } from 'lib/utils'
 import { isRejected, isSome } from 'lib/utils'
@@ -137,11 +138,23 @@ export const nftApi = createApi({
 
             data.forEach(item => {
               const { assetId } = item
+              const { assetReference, chainId } = fromAssetId(assetId)
 
-              if (!acc[assetId]) {
+              const [contractAddress, id] = deserializeNftAssetReference(assetReference)
+
+              const foundNftAssetId = Object.keys(acc).find(accAssetId => {
+                const { assetReference: accAssetReference, chainId: accChainId } =
+                  fromAssetId(accAssetId)
+                const [accContractAddress, accId] = deserializeNftAssetReference(accAssetReference)
+                return (
+                  accContractAddress === contractAddress && accId === id && accChainId === chainId
+                )
+              })
+
+              if (!foundNftAssetId) {
                 acc[assetId] = item
               } else {
-                acc[assetId] = updateNftItem(acc[assetId], item)
+                acc[assetId] = updateNftItem(acc[foundNftAssetId], item)
               }
             })
             // An actual RTK error, different from a rejected promise i.e getAlchemyNftData rejecting

--- a/src/state/migrations/index.ts
+++ b/src/state/migrations/index.ts
@@ -28,4 +28,5 @@ export const migrations = {
   22: clearOpportunities,
   23: clearNfts,
   24: clearNfts,
+  25: clearNfts,
 }


### PR DESCRIPTION
## Description

This PR makes `getNftUserTokens` more graceful in the way it checks for existing items in the `results.reduce<Record<AssetId, NftItemWithCollection>>()` acc.

We are currently doing triple-equality check on the acc's key (an `Assetid`):

https://github.com/shapeshift/web/blob/08611f1914603d637cf80dd87d5f1eaabdf41cf3/src/state/apis/nft/nftApi.ts#L141

This is fine if the data we get upstream is correct, but we can't assume all services will return us the correct standard (which in the case of Zapper, seems to assume ERC-721 for most). This means we're making multiple entries of what's actually one, since an `AssetId` contains an `assetNamespace` part and would effectively consider two of the "same" NFTs with diff asset namespaces different.

Fixed by checking in a more granular fashion for `ChainId`, and deserialized assetReference' address and ID.

## Pull Request Type

- [x] :bug: Bug fix (Non-breaking Change: Fixes an issue)
- [ ] :hammer_and_wrench: Chore (Non-breaking Change: Doc updates, pkg upgrades, typos, etc..)
- [ ] :nail_care: New Feature (Breaking/Non-breaking Change)

## Issue (if applicable)

<!-----------------------------------------------------------------------------
If applicable, please link to the github issue and put `closes #XXXX` in your comment to auto-close the issue that your PR fixes.
------------------------------------------------------------------------------>

closes https://github.com/shapeshift/web/issues/4708

## Risk

<!-----------------------------------------------------------------------------
Outline the scope of your changes and the risk associated with them. You must use your discretion as an engineer to determine the potential impact of your changes.

E.g. an upgrade to `hdwallet` or core state management would be considered higher risk, and might require a full regression test. UI or isolated view changes, or something behind a feature flag may have near zero risk. Small bug fixes might require testing isolated to the specific fix.
------------------------------------------------------------------------------>

## Testing

<!-----------------------------------------------------------------------------
We treat every PR to be merged with the same scrutiny as if we were merging directly to production.

Your PR will not be merged if you do not complete the sections below for our engineering and operations teams to test.
------------------------------------------------------------------------------>

- NFT collection still looks sane
- Dupes are gone

### Engineering

<!-----------------------------------------------------------------------------
Include sufficient information here for an engineer to test your PR. This may include how to test locally, in a built environment, changes to infrastructure etc.
------------------------------------------------------------------------------>

- ☝🏽 

### Operations

<!-----------------------------------------------------------------------------
If your changes have a user-facing impact, describe how a non-technical QA team can functionally test your changes in a preview environment.

If they are not user-facing please describe how to test for any regressions that may occur.
------------------------------------------------------------------------------>

- ☝🏽 

## Screenshots (if applicable)

### This diff

<img width="1070" alt="Screenshot 2023-06-09 at 10 49 04" src="https://github.com/shapeshift/web/assets/17035424/c5e81184-65de-4c7b-ac01-508003313eb2">
<img width="1084" alt="Screenshot 2023-06-09 at 10 48 58" src="https://github.com/shapeshift/web/assets/17035424/c26e2a5f-ac4a-4032-8d27-235526d4b033">
<img width="966" alt="Screenshot 2023-06-09 at 10 48 50" src="https://github.com/shapeshift/web/assets/17035424/6ec081b1-7ed5-4986-b6c9-49f9f4fce5d4">

### Develop/ Prod

<img width="951" alt="Screenshot 2023-06-09 at 10 49 19" src="https://github.com/shapeshift/web/assets/17035424/af1b27e4-39a5-4e59-9aa6-d8b4924de95a">

Second "upserted" (actually inserted) NFT, which also turns out to be in an incorrect format

<img width="1068" alt="Screenshot 2023-06-09 at 10 49 35" src="https://github.com/shapeshift/web/assets/17035424/b95c5e00-d829-41d7-88bf-0034fc1a809c">
<img width="1053" alt="Screenshot 2023-06-09 at 10 49 29" src="https://github.com/shapeshift/web/assets/17035424/7feee9fd-f3c7-464b-bb89-30afe1f11d6c">

First inserted NFT, which is correct

<img width="1056" alt="Screenshot 2023-06-09 at 10 49 48" src="https://github.com/shapeshift/web/assets/17035424/d7526c5f-17b3-4558-8340-5c2b8d1831dd">
<img width="1082" alt="Screenshot 2023-06-09 at 10 49 42" src="https://github.com/shapeshift/web/assets/17035424/13b3c3d1-8b4b-4dd7-87c1-9809260716bc">