### PR TITLE
feat: multi-hop component state

### DIFF
--- a/src/components/MultiHopTrade/components/TradeConfirm/TradeConfirm.tsx
+++ b/src/components/MultiHopTrade/components/TradeConfirm/TradeConfirm.tsx
@@ -187,16 +187,8 @@ const Hop = ({
       })
     }
 
-    console.log('xxx steps', { steps, activeStep, isFirstHop, isComplete, isApprovalRequired })
     return steps
-  }, [
-    isComplete,
-    isFirstHop,
-    isApprovalRequired,
-    shouldRenderDonation,
-    activeStep,
-    tradeExecutionStatus,
-  ])
+  }, [isComplete, isFirstHop, isApprovalRequired, shouldRenderDonation, tradeExecutionStatus])
 
   return (
     <Card

--- a/src/components/MultiHopTrade/index.ts
+++ b/src/components/MultiHopTrade/index.ts
@@ -1,0 +1,1 @@
+export * from './types'

--- a/src/components/MultiHopTrade/types.ts
+++ b/src/components/MultiHopTrade/types.ts
@@ -1,0 +1,21 @@
+export enum MultiHopExecutionStatus {
+  TradeFailed,
+  Hop1AwaitingApprovalConfirmation,
+  Hop1AwaitingApprovalExecution,
+  Hop1AwaitingTradeConfirmation,
+  Hop1AwaitingTradeExecution,
+  Hop2AwaitingApprovalConfirmation,
+  Hop2AwaitingApprovalExecution,
+  Hop2AwaitingTradeConfirmation,
+  Hop2AwaitingTradeExecution,
+  TradeComplete,
+  TradeCancelled,
+}
+
+export type StepperStep = {
+  title: string
+  description?: string
+  stepIndicator: JSX.Element
+  content?: JSX.Element
+  status?: MultiHopExecutionStatus
+}

--- a/src/components/MultiHopTrade/types.ts
+++ b/src/components/MultiHopTrade/types.ts
@@ -1,15 +1,15 @@
 export enum MultiHopExecutionStatus {
-  TradeFailed,
-  Hop1AwaitingApprovalConfirmation,
-  Hop1AwaitingApprovalExecution,
-  Hop1AwaitingTradeConfirmation,
-  Hop1AwaitingTradeExecution,
-  Hop2AwaitingApprovalConfirmation,
-  Hop2AwaitingApprovalExecution,
-  Hop2AwaitingTradeConfirmation,
-  Hop2AwaitingTradeExecution,
-  TradeComplete,
-  TradeCancelled,
+  TradeFailed = 0,
+  Hop1AwaitingApprovalConfirmation = 1,
+  Hop1AwaitingApprovalExecution = 2,
+  Hop1AwaitingTradeConfirmation = 3,
+  Hop1AwaitingTradeExecution = 4,
+  Hop2AwaitingApprovalConfirmation = 5,
+  Hop2AwaitingApprovalExecution = 6,
+  Hop2AwaitingTradeConfirmation = 7,
+  Hop2AwaitingTradeExecution = 8,
+  TradeComplete = 9,
+  TradeCancelled = 10,
 }
 
 export type StepperStep = {


### PR DESCRIPTION
## Description

Adds multi-hop component state logic.

Note, not wired up to any store, it currently just reflects the value hardcoded into the `tradeExecutionStatus` constatnt.

## Pull Request Type

- [ ] :bug: Bug fix (Non-breaking Change: Fixes an issue)
- [ ] :hammer_and_wrench: Chore (Non-breaking Change: Doc updates, pkg upgrades, typos, etc..)
- [x] :nail_care: New Feature (Breaking/Non-breaking Change)

## Issue (if applicable)

N/A

## Risk

Small - all code changes behind a feature flag.

## Testing

N/A

### Engineering

Woody: update `tradeExecutionStatus` to different states and confirm that the visual state matches the expected.

### Operations

N/A

## Screenshots (if applicable)

N/A
