### PR TITLE
feat: donation opt-out flag in mixpanel tracking

### DIFF
--- a/src/components/Trade/TradeConfirm/TradeConfirm.tsx
+++ b/src/components/Trade/TradeConfirm/TradeConfirm.tsx
@@ -272,6 +272,7 @@ export const TradeConfirm = () => {
       sellAsset: compositeSellAsset,
       fiatAmount: sellAmountBeforeFeesFiat,
       swapperName: swapper.name,
+      hasUserOptedOutOfDonation,
       donationAmountFiat,
       [compositeBuyAsset]: buyAmountCryptoPrecision,
       [compositeSellAsset]: sellAmountCryptoPrecision,
@@ -279,6 +280,7 @@ export const TradeConfirm = () => {
   }, [
     assets,
     buyAmountBeforeFeesBaseUnit,
+    hasUserOptedOutOfDonation,
     donationAmountFiat,
     sellAmountBeforeFeesBaseUnit,
     sellAmountBeforeFeesFiat,


### PR DESCRIPTION
## Description

Adds the flag `hasUserOptedOutOfDonation` to the event data tracked by Mixpanel for confirmed/failed/successful trades, so we can track more than just the total of fiat that potentially could/could not have been donated to the DAO.

<!-- Please describe your changes -->

## Pull Request Type

- [ ] :bug: Bug fix (Non-breaking Change: Fixes an issue)
- [ ] :hammer_and_wrench: Chore (Non-breaking Change: Doc updates, pkg upgrades, typos, etc..)
- [x] :nail_care: New Feature (Breaking/Non-breaking Change)

## Issue (if applicable)

<!-----------------------------------------------------------------------------
If applicable, please link to the github issue and put `closes #XXXX` in your comment to auto-close the issue that your PR fixes.
------------------------------------------------------------------------------>

closes #4655

## Risk
Low, no user facing change, just tracking data added for confirmed trades.

<!-----------------------------------------------------------------------------
Outline the scope of your changes and the risk associated with them. You must use your discretion as an engineer to determine the potential impact of your changes.

E.g. an upgrade to `hdwallet` or core state management would be considered higher risk, and might require a full regression test. UI or isolated view changes, or something behind a feature flag may have near zero risk. Small bug fixes might require testing isolated to the specific fix.
------------------------------------------------------------------------------>

## Testing

<!-----------------------------------------------------------------------------
We treat every PR to be merged with the same scrutiny as if we were merging directly to production.

Your PR will not be merged if you do not complete the sections below for our engineering and operations teams to test.
------------------------------------------------------------------------------>

### Engineering
Make a transaction with/without a donation to ShapeShift and check the network traffic for the Mixpanel requests or check the Mixpanel events to confirm the `hasUserOptedOutOfDonation` flag is set appropriately.

<!-----------------------------------------------------------------------------
Include sufficient information here for an engineer to test your PR. This may include how to test locally, in a built environment, changes to infrastructure etc.
------------------------------------------------------------------------------>

### Operations
N/A

<!-----------------------------------------------------------------------------
If your changes have a user-facing impact, describe how a non-technical QA team can functionally test your changes in a preview environment.

If they are not user-facing please describe how to test for any regressions that may occur.
------------------------------------------------------------------------------>

## Screenshots (if applicable)
N/A