### PR TITLE
fix: cancel polling on component unmount

### DIFF
--- a/src/components/Trade/TradeConfirm/TradeConfirm.tsx
+++ b/src/components/Trade/TradeConfirm/TradeConfirm.tsx
@@ -331,7 +331,7 @@ export const TradeConfirm = () => {
         fn: () => swapper.getTradeTxs(result.unwrap()).catch(e => Err(e)),
         validate: txsResult => txsResult.isOk() && !!txsResult.unwrap().buyTxid,
         interval: 10000, // 10 seconds
-        maxAttempts: 300, // Lots of attempts because some trade are slow (thorchain to bitcoin)
+        maxAttempts: Infinity, // infinite attempts because some trade are verrry slow (hours, days, years?)
       })
       if (txs.isErr()) throw txs.unwrapErr()
       setBuyTxid(txs.unwrap().buyTxid ?? '')

--- a/src/components/Trade/TradeConfirm/TradeConfirm.tsx
+++ b/src/components/Trade/TradeConfirm/TradeConfirm.tsx
@@ -18,6 +18,7 @@ import {
 import type { ChainId } from '@shapeshiftoss/caip'
 import { fromAccountId, thorchainAssetId } from '@shapeshiftoss/caip'
 import { TxStatus } from '@shapeshiftoss/unchained-client'
+import type { Result } from '@sniptt/monads'
 import { Err } from '@sniptt/monads'
 import { useCallback, useEffect, useMemo, useState } from 'react'
 import { useFormContext } from 'react-hook-form'
@@ -34,6 +35,7 @@ import { useSwapper } from 'components/Trade/hooks/useSwapper/useSwapper'
 import { WalletActions } from 'context/WalletProvider/actions'
 import { useErrorHandler } from 'hooks/useErrorToast/useErrorToast'
 import { useLocaleFormatter } from 'hooks/useLocaleFormatter/useLocaleFormatter'
+import { usePoll } from 'hooks/usePoll/usePoll'
 import { useToggle } from 'hooks/useToggle/useToggle'
 import { useWallet } from 'hooks/useWallet/useWallet'
 import { bnOrZero, positiveOrZero } from 'lib/bignumber/bignumber'
@@ -42,8 +44,7 @@ import { firstNonZeroDecimal, fromBaseUnit } from 'lib/math'
 import { getMaybeCompositeAssetSymbol } from 'lib/mixpanel/helpers'
 import { getMixPanel } from 'lib/mixpanel/mixPanelSingleton'
 import { MixPanelEvents } from 'lib/mixpanel/types'
-import { poll } from 'lib/poll/poll'
-import type { Swapper } from 'lib/swapper/api'
+import type { SwapErrorRight, Swapper, TradeTxs } from 'lib/swapper/api'
 import { SwapperName } from 'lib/swapper/api'
 import { isRune } from 'lib/swapper/swappers/ThorchainSwapper/utils/isRune/isRune'
 import { assertUnreachable } from 'lib/utils'
@@ -81,6 +82,7 @@ import { AssetToAsset } from './AssetToAsset'
 import { ReceiveSummary } from './ReceiveSummary'
 
 export const TradeConfirm = () => {
+  const poll = usePoll<Result<TradeTxs, SwapErrorRight>>()
   const history = useHistory()
   const mixpanel = getMixPanel()
   const borderColor = useColorModeValue('gray.100', 'gray.750')

--- a/src/context/WalletProvider/KeepKey/hooks/useKeepKeyEventHandler.ts
+++ b/src/context/WalletProvider/KeepKey/hooks/useKeepKeyEventHandler.ts
@@ -7,7 +7,7 @@ import { useTranslate } from 'react-polyglot'
 import type { ActionTypes } from 'context/WalletProvider/actions'
 import { WalletActions } from 'context/WalletProvider/actions'
 import type { DeviceState, InitialState } from 'context/WalletProvider/WalletProvider'
-import { poll } from 'lib/poll/poll'
+import { usePoll } from 'hooks/usePoll/usePoll'
 
 import { ButtonRequestType, FailureType, Message, MessageType } from '../KeepKeyTypes'
 
@@ -25,6 +25,7 @@ export const useKeepKeyEventHandler = (
 
   const toast = useToast()
   const translate = useTranslate()
+  const poll = usePoll()
 
   useEffect(() => {
     const handleEvent = (e: [deviceId: string, message: Event]) => {
@@ -263,5 +264,6 @@ export const useKeepKeyEventHandler = (
     disposition,
     toast,
     translate,
+    poll,
   ])
 }

--- a/src/features/defi/providers/fox-farming/components/FoxFarmingManager/Deposit/components/Approve.tsx
+++ b/src/features/defi/providers/fox-farming/components/FoxFarmingManager/Deposit/components/Approve.tsx
@@ -14,11 +14,11 @@ import { useCallback, useContext, useMemo } from 'react'
 import { useTranslate } from 'react-polyglot'
 import { getChainAdapterManager } from 'context/PluginProvider/chainAdapterSingleton'
 import { useBrowserRouter } from 'hooks/useBrowserRouter/useBrowserRouter'
+import { usePoll } from 'hooks/usePoll/usePoll'
 import { useWallet } from 'hooks/useWallet/useWallet'
 import { bn, bnOrZero } from 'lib/bignumber/bignumber'
 import { trackOpportunityEvent } from 'lib/mixpanel/helpers'
 import { MixPanelEvents } from 'lib/mixpanel/types'
-import { poll } from 'lib/poll/poll'
 import { isSome } from 'lib/utils'
 import { assertIsFoxEthStakingContractAddress } from 'state/slices/opportunitiesSlice/constants'
 import { toOpportunityId } from 'state/slices/opportunitiesSlice/utils'
@@ -39,6 +39,7 @@ type FoxFarmingApproveProps = {
 }
 
 export const Approve: React.FC<FoxFarmingApproveProps> = ({ accountId, onNext }) => {
+  const poll = usePoll()
   const { state, dispatch } = useContext(DepositContext)
   const estimatedGasCryptoPrecision = state?.approve.estimatedGasCryptoPrecision
   const translate = useTranslate()
@@ -144,6 +145,7 @@ export const Approve: React.FC<FoxFarmingApproveProps> = ({ accountId, onNext })
     wallet,
     asset,
     approve,
+    poll,
     getStakeFeeData,
     feeAsset.precision,
     onNext,

--- a/src/features/defi/providers/fox-farming/components/FoxFarmingManager/Withdraw/components/Approve.tsx
+++ b/src/features/defi/providers/fox-farming/components/FoxFarmingManager/Withdraw/components/Approve.tsx
@@ -16,11 +16,11 @@ import { useTranslate } from 'react-polyglot'
 import type { StepComponentProps } from 'components/DeFi/components/Steps'
 import { getChainAdapterManager } from 'context/PluginProvider/chainAdapterSingleton'
 import { useBrowserRouter } from 'hooks/useBrowserRouter/useBrowserRouter'
+import { usePoll } from 'hooks/usePoll/usePoll'
 import { useWallet } from 'hooks/useWallet/useWallet'
 import { bn, bnOrZero } from 'lib/bignumber/bignumber'
 import { trackOpportunityEvent } from 'lib/mixpanel/helpers'
 import { MixPanelEvents } from 'lib/mixpanel/types'
-import { poll } from 'lib/poll/poll'
 import { isSome } from 'lib/utils'
 import { assertIsFoxEthStakingContractAddress } from 'state/slices/opportunitiesSlice/constants'
 import { serializeUserStakingId, toOpportunityId } from 'state/slices/opportunitiesSlice/utils'
@@ -38,6 +38,7 @@ import { WithdrawContext } from '../WithdrawContext'
 type ApproveProps = StepComponentProps & { accountId: AccountId | undefined }
 
 export const Approve: React.FC<ApproveProps> = ({ accountId, onNext }) => {
+  const poll = usePoll()
   const { state, dispatch } = useContext(WithdrawContext)
   const estimatedGasCryptoPrecision = state?.approve.estimatedGasCryptoPrecision
   const translate = useTranslate()
@@ -140,6 +141,7 @@ export const Approve: React.FC<ApproveProps> = ({ accountId, onNext }) => {
     opportunity,
     wallet,
     approve,
+    poll,
     getUnstakeFeeData,
     underlyingAsset?.precision,
     onNext,

--- a/src/features/defi/providers/foxy/components/FoxyManager/Deposit/components/Approve.tsx
+++ b/src/features/defi/providers/foxy/components/FoxyManager/Deposit/components/Approve.tsx
@@ -12,9 +12,9 @@ import { useCallback, useContext, useMemo } from 'react'
 import { useTranslate } from 'react-polyglot'
 import { useHistory } from 'react-router-dom'
 import type { StepComponentProps } from 'components/DeFi/components/Steps'
+import { usePoll } from 'hooks/usePoll/usePoll'
 import { useWallet } from 'hooks/useWallet/useWallet'
 import { bn, bnOrZero } from 'lib/bignumber/bignumber'
-import { poll } from 'lib/poll/poll'
 import { isSome } from 'lib/utils'
 import { getFoxyApi } from 'state/apis/foxy/foxyApiSingleton'
 import { DefiProvider } from 'state/slices/opportunitiesSlice/types'
@@ -27,6 +27,7 @@ import { DepositContext } from '../DepositContext'
 type ApproveProps = StepComponentProps & { accountId: AccountId | undefined }
 
 export const Approve: React.FC<ApproveProps> = ({ accountId, onNext }) => {
+  const poll = usePoll()
   const foxyApi = getFoxyApi()
   const { state, dispatch } = useContext(DepositContext)
   const estimatedGasCryptoBaseUnit = state?.approve.estimatedGasCryptoBaseUnit
@@ -153,19 +154,20 @@ export const Approve: React.FC<ApproveProps> = ({ accountId, onNext }) => {
       dispatch({ type: FoxyDepositActionType.SET_LOADING, payload: false })
     }
   }, [
-    accountAddress,
-    foxyApi,
-    asset.precision,
     assetReference,
-    bip44Params,
-    contractAddress,
+    accountAddress,
+    walletState.wallet,
+    foxyApi,
     dispatch,
+    bip44Params,
+    state,
+    contractAddress,
+    asset.precision,
+    poll,
     getDepositGasEstimateCryptoBaseUnit,
     onNext,
-    state,
     toast,
     translate,
-    walletState.wallet,
   ])
 
   const hasEnoughBalanceForGas = useMemo(

--- a/src/features/defi/providers/foxy/components/FoxyManager/Deposit/components/Confirm.tsx
+++ b/src/features/defi/providers/foxy/components/FoxyManager/Deposit/components/Confirm.tsx
@@ -15,9 +15,9 @@ import { AssetIcon } from 'components/AssetIcon'
 import type { StepComponentProps } from 'components/DeFi/components/Steps'
 import { Row } from 'components/Row/Row'
 import { RawText, Text } from 'components/Text'
+import { usePoll } from 'hooks/usePoll/usePoll'
 import { useWallet } from 'hooks/useWallet/useWallet'
 import { bn, bnOrZero } from 'lib/bignumber/bignumber'
-import { poll } from 'lib/poll/poll'
 import { getFoxyApi } from 'state/apis/foxy/foxyApiSingleton'
 import {
   selectBIP44ParamsByAccountId,
@@ -31,6 +31,7 @@ import { DepositContext } from '../DepositContext'
 type ConfirmProps = StepComponentProps & { accountId: AccountId | undefined }
 
 export const Confirm: React.FC<ConfirmProps> = ({ onNext, accountId }) => {
+  const poll = usePoll<ethers.providers.TransactionReceipt>()
   const foxyApi = getFoxyApi()
   const { state, dispatch } = useContext(DepositContext)
   const translate = useTranslate()
@@ -121,18 +122,19 @@ export const Confirm: React.FC<ConfirmProps> = ({ onNext, accountId }) => {
       dispatch({ type: FoxyDepositActionType.SET_LOADING, payload: false })
     }
   }, [
-    foxyApi,
-    asset.precision,
-    assetReference,
-    bip44Params,
-    contractAddress,
-    dispatch,
-    onNext,
-    state?.deposit.cryptoAmount,
     accountAddress,
+    assetReference,
+    walletState.wallet,
+    foxyApi,
+    bip44Params,
+    dispatch,
+    state?.deposit.cryptoAmount,
+    asset.precision,
+    contractAddress,
+    onNext,
+    poll,
     toast,
     translate,
-    walletState.wallet,
   ])
 
   if (!state || !dispatch) return null

--- a/src/features/defi/providers/foxy/components/FoxyManager/Overview/Claim/ClaimStatus.tsx
+++ b/src/features/defi/providers/foxy/components/FoxyManager/Overview/Claim/ClaimStatus.tsx
@@ -16,8 +16,8 @@ import { Row } from 'components/Row/Row'
 import { SlideTransition } from 'components/SlideTransition'
 import { RawText } from 'components/Text'
 import { useBrowserRouter } from 'hooks/useBrowserRouter/useBrowserRouter'
+import { usePoll } from 'hooks/usePoll/usePoll'
 import { bnOrZero } from 'lib/bignumber/bignumber'
-import { poll } from 'lib/poll/poll'
 import { getFoxyApi } from 'state/apis/foxy/foxyApiSingleton'
 import { opportunitiesApi } from 'state/slices/opportunitiesSlice/opportunitiesApiSlice'
 import { DefiProvider, DefiType } from 'state/slices/opportunitiesSlice/types'
@@ -68,6 +68,7 @@ type ClaimStatusProps = {
 }
 
 export const ClaimStatus: React.FC<ClaimStatusProps> = ({ accountId }) => {
+  const poll = usePoll<ethers.providers.TransactionReceipt>()
   const { history: browserHistory } = useBrowserRouter()
   const foxyApi = getFoxyApi()
   const translate = useTranslate()
@@ -140,7 +141,7 @@ export const ClaimStatus: React.FC<ClaimStatusProps> = ({ accountId }) => {
         })
       }
     })()
-  }, [refetchFoxyBalances, estimatedGas, foxyApi, state, txid])
+  }, [refetchFoxyBalances, estimatedGas, foxyApi, state, txid, poll])
 
   return (
     <SlideTransition>

--- a/src/features/defi/providers/foxy/components/FoxyManager/Withdraw/components/Approve.tsx
+++ b/src/features/defi/providers/foxy/components/FoxyManager/Withdraw/components/Approve.tsx
@@ -11,9 +11,9 @@ import { useFoxyQuery } from 'features/defi/providers/foxy/components/FoxyManage
 import { useCallback, useContext, useMemo } from 'react'
 import { useTranslate } from 'react-polyglot'
 import type { StepComponentProps } from 'components/DeFi/components/Steps'
+import { usePoll } from 'hooks/usePoll/usePoll'
 import { useWallet } from 'hooks/useWallet/useWallet'
 import { bn, bnOrZero } from 'lib/bignumber/bignumber'
-import { poll } from 'lib/poll/poll'
 import { isSome } from 'lib/utils'
 import { getFoxyApi } from 'state/apis/foxy/foxyApiSingleton'
 import { DefiProvider } from 'state/slices/opportunitiesSlice/types'
@@ -26,6 +26,7 @@ import { WithdrawContext } from '../WithdrawContext'
 type ApproveProps = StepComponentProps & { accountId: AccountId | undefined }
 
 export const Approve: React.FC<ApproveProps> = ({ accountId, onNext }) => {
+  const poll = usePoll()
   const foxyApi = getFoxyApi()
   const { state, dispatch } = useContext(WithdrawContext)
   const estimatedGasCryptoBaseUnit = state?.approve.estimatedGasCryptoBaseUnit
@@ -172,6 +173,7 @@ export const Approve: React.FC<ApproveProps> = ({ accountId, onNext }) => {
     foxyApi,
     getWithdrawGasEstimate,
     onNext,
+    poll,
     rewardId,
     state?.withdraw,
     toast,

--- a/src/features/defi/providers/foxy/components/FoxyManager/Withdraw/components/Confirm.tsx
+++ b/src/features/defi/providers/foxy/components/FoxyManager/Withdraw/components/Confirm.tsx
@@ -16,9 +16,9 @@ import { AssetIcon } from 'components/AssetIcon'
 import type { StepComponentProps } from 'components/DeFi/components/Steps'
 import { Row } from 'components/Row/Row'
 import { RawText, Text } from 'components/Text'
+import { usePoll } from 'hooks/usePoll/usePoll'
 import { useWallet } from 'hooks/useWallet/useWallet'
 import { bn, bnOrZero } from 'lib/bignumber/bignumber'
-import { poll } from 'lib/poll/poll'
 import { getFoxyApi } from 'state/apis/foxy/foxyApiSingleton'
 import {
   selectBIP44ParamsByAccountId,
@@ -33,6 +33,7 @@ export const Confirm: React.FC<StepComponentProps & { accountId?: AccountId | un
   onNext,
   accountId,
 }) => {
+  const poll = usePoll<ethers.providers.TransactionReceipt>()
   const foxyApi = getFoxyApi()
   const { state, dispatch } = useContext(WithdrawContext)
   const translate = useTranslate()
@@ -119,16 +120,17 @@ export const Confirm: React.FC<StepComponentProps & { accountId?: AccountId | un
       console.error(error)
     }
   }, [
+    state,
+    accountAddress,
+    rewardId,
+    walletState.wallet,
     foxyApi,
-    underlyingAsset.precision,
+    dispatch,
     bip44Params,
     contractAddress,
-    dispatch,
+    underlyingAsset.precision,
     onNext,
-    rewardId,
-    accountAddress,
-    state,
-    walletState.wallet,
+    poll,
   ])
 
   if (!state || !dispatch) return null

--- a/src/features/defi/providers/idle/components/IdleManager/Deposit/components/Approve.tsx
+++ b/src/features/defi/providers/idle/components/IdleManager/Deposit/components/Approve.tsx
@@ -16,6 +16,7 @@ import { useTranslate } from 'react-polyglot'
 import type { StepComponentProps } from 'components/DeFi/components/Steps'
 import { getChainAdapterManager } from 'context/PluginProvider/chainAdapterSingleton'
 import { useBrowserRouter } from 'hooks/useBrowserRouter/useBrowserRouter'
+import { usePoll } from 'hooks/usePoll/usePoll'
 import { useWallet } from 'hooks/useWallet/useWallet'
 import type { Asset } from 'lib/asset-service'
 import type { BigNumber } from 'lib/bignumber/bignumber'
@@ -23,7 +24,6 @@ import { bn, bnOrZero } from 'lib/bignumber/bignumber'
 import { ssRouterContractAddress } from 'lib/investor/constants'
 import { trackOpportunityEvent } from 'lib/mixpanel/helpers'
 import { MixPanelEvents } from 'lib/mixpanel/types'
-import { poll } from 'lib/poll/poll'
 import { isSome } from 'lib/utils'
 import { getIdleInvestor } from 'state/slices/opportunitiesSlice/resolvers/idle/idleInvestorSingleton'
 import {
@@ -40,6 +40,7 @@ import { DepositContext } from '../DepositContext'
 type IdleApproveProps = StepComponentProps & { accountId: AccountId | undefined }
 
 export const Approve: React.FC<IdleApproveProps> = ({ accountId, onNext }) => {
+  const poll = usePoll()
   const idleInvestor = useMemo(() => getIdleInvestor(), [])
   const { state, dispatch } = useContext(DepositContext)
   const estimatedGasCryptoBaseUnit = state?.approve.estimatedGasCryptoBaseUnit
@@ -188,6 +189,7 @@ export const Approve: React.FC<IdleApproveProps> = ({ accountId, onNext }) => {
     chainAdapter,
     underlyingAsset,
     idleInvestor,
+    poll,
     getDepositGasEstimateCryptoBaseUnit,
     state?.deposit,
     onNext,

--- a/src/features/defi/providers/univ2/components/UniV2Manager/Deposit/components/Approve.tsx
+++ b/src/features/defi/providers/univ2/components/UniV2Manager/Deposit/components/Approve.tsx
@@ -18,12 +18,12 @@ import { useTranslate } from 'react-polyglot'
 import type { Address } from 'viem'
 import type { StepComponentProps } from 'components/DeFi/components/Steps'
 import { useBrowserRouter } from 'hooks/useBrowserRouter/useBrowserRouter'
+import { usePoll } from 'hooks/usePoll/usePoll'
 import { useWallet } from 'hooks/useWallet/useWallet'
 import { bn, bnOrZero } from 'lib/bignumber/bignumber'
 import { trackOpportunityEvent } from 'lib/mixpanel/helpers'
 import { getMixPanel } from 'lib/mixpanel/mixPanelSingleton'
 import { MixPanelEvents } from 'lib/mixpanel/types'
-import { poll } from 'lib/poll/poll'
 import { isSome } from 'lib/utils'
 import type { LpId } from 'state/slices/opportunitiesSlice/types'
 import { getMetadataForProvider } from 'state/slices/opportunitiesSlice/utils/getMetadataForProvider'
@@ -44,6 +44,7 @@ type UniV2ApproveProps = StepComponentProps & {
 }
 
 export const Approve: React.FC<UniV2ApproveProps> = ({ accountId, onNext }) => {
+  const poll = usePoll()
   const { state, dispatch } = useContext(DepositContext)
   const approve0 = state?.approve0
   const approve1 = state?.approve1
@@ -189,6 +190,7 @@ export const Approve: React.FC<UniV2ApproveProps> = ({ accountId, onNext }) => {
       wallet,
       asset0ContractAddress,
       approveAsset,
+      poll,
       asset0Allowance,
       asset1Allowance,
       asset0.precision,

--- a/src/features/defi/providers/univ2/components/UniV2Manager/Withdraw/components/Approve.tsx
+++ b/src/features/defi/providers/univ2/components/UniV2Manager/Withdraw/components/Approve.tsx
@@ -17,12 +17,12 @@ import { useCallback, useContext, useEffect, useMemo } from 'react'
 import { useTranslate } from 'react-polyglot'
 import type { StepComponentProps } from 'components/DeFi/components/Steps'
 import { useBrowserRouter } from 'hooks/useBrowserRouter/useBrowserRouter'
+import { usePoll } from 'hooks/usePoll/usePoll'
 import { useWallet } from 'hooks/useWallet/useWallet'
 import { bn, bnOrZero } from 'lib/bignumber/bignumber'
 import { trackOpportunityEvent } from 'lib/mixpanel/helpers'
 import { getMixPanel } from 'lib/mixpanel/mixPanelSingleton'
 import { MixPanelEvents } from 'lib/mixpanel/types'
-import { poll } from 'lib/poll/poll'
 import { isSome } from 'lib/utils'
 import type { LpId } from 'state/slices/opportunitiesSlice/types'
 import { getMetadataForProvider } from 'state/slices/opportunitiesSlice/utils/getMetadataForProvider'
@@ -43,6 +43,7 @@ type UniV2ApproveProps = StepComponentProps & {
 }
 
 export const Approve: React.FC<UniV2ApproveProps> = ({ accountId, onNext }) => {
+  const poll = usePoll()
   const { state, dispatch } = useContext(WithdrawContext)
   const estimatedGasCryptoPrecision = state?.approve.estimatedGasCryptoPrecision
   const translate = useTranslate()
@@ -162,8 +163,9 @@ export const Approve: React.FC<UniV2ApproveProps> = ({ accountId, onNext }) => {
     state?.withdraw,
     lpOpportunity,
     wallet,
-    approveAsset,
     lpAssetId,
+    approveAsset,
+    poll,
     getWithdrawFeeData,
     feeAsset.precision,
     onNext,

--- a/src/hooks/usePoll/usePoll.tsx
+++ b/src/hooks/usePoll/usePoll.tsx
@@ -1,0 +1,28 @@
+import { useCallback, useEffect, useRef } from 'react'
+import type { PollArgs } from 'lib/poll/poll'
+import { poll as pollFn } from 'lib/poll/poll'
+
+/**
+ * Wraps `poll` for use in react components. Cancels polling on component unmount.
+ */
+export const usePoll = <T extends unknown>() => {
+  const cancelPollingRef = useRef<(() => void) | undefined>(undefined)
+
+  // cancel on component unmount so polling doesn't cause chaos after the component has unmounted
+  useEffect(() => {
+    return () => cancelPollingRef.current && cancelPollingRef.current()
+  }, [])
+
+  return useCallback((pollArgs: PollArgs<T>) => {
+    // cancel previous invocations
+    cancelPollingRef.current && cancelPollingRef.current()
+
+    // invoke
+    const { promise, cancelPolling } = pollFn(pollArgs)
+
+    // attach cancel callback
+    cancelPollingRef.current = cancelPolling
+
+    return promise
+  }, [])
+}

--- a/src/lib/poll/poll.test.ts
+++ b/src/lib/poll/poll.test.ts
@@ -1,0 +1,73 @@
+import { poll } from './poll' // Update this with your file path
+
+describe('poll', () => {
+  it('should resolve if validate returns true on first attempt', async () => {
+    const fn = jest.fn().mockResolvedValue('data')
+    const validate = jest.fn().mockReturnValue(true)
+
+    const { promise } = poll({ fn, validate, interval: 100, maxAttempts: 3 })
+    const result = await promise
+
+    expect(fn).toHaveBeenCalledTimes(1)
+    expect(validate).toHaveBeenCalledTimes(1)
+    expect(result).toBe('data')
+  })
+
+  it('should reject with "Exceeded max attempts" when maxAttempts is reached', async () => {
+    const fn = jest.fn().mockResolvedValue('data')
+    const validate = jest.fn().mockReturnValue(false)
+
+    const { promise } = poll({ fn, validate, interval: 100, maxAttempts: 3 })
+
+    await expect(promise).rejects.toThrow('Exceeded max attempts')
+    expect(fn).toHaveBeenCalledTimes(3)
+    expect(validate).toHaveBeenCalledTimes(3)
+  })
+
+  it('should stop polling and reject with "Polling cancelled" when cancelPolling is called', async () => {
+    const fn = jest.fn().mockResolvedValue('data')
+    const validate = jest.fn().mockReturnValue(false)
+
+    const { promise, cancelPolling } = poll({ fn, validate, interval: 100, maxAttempts: 3 })
+
+    setTimeout(cancelPolling, 150) // Cancel polling after 0.15 seconds
+    await expect(promise).rejects.toThrow('Polling cancelled')
+
+    expect(fn).toHaveBeenCalledTimes(2) // Should be called twice before cancelled
+    expect(validate).toHaveBeenCalledTimes(2)
+  })
+
+  it('should poll until validate function returns true', async () => {
+    const fn = jest
+      .fn()
+      .mockResolvedValueOnce('data1')
+      .mockResolvedValueOnce('data2')
+      .mockResolvedValueOnce('data3')
+      .mockResolvedValueOnce('data4')
+    const validate = jest
+      .fn()
+      .mockReturnValueOnce(false)
+      .mockReturnValueOnce(false)
+      .mockReturnValueOnce(false)
+      .mockReturnValueOnce(true)
+
+    const { promise } = poll({ fn, validate, interval: 100, maxAttempts: 10 })
+    const result = await promise
+
+    expect(fn).toHaveBeenCalledTimes(4)
+    expect(validate).toHaveBeenCalledTimes(4)
+    expect(result).toBe('data4')
+  })
+
+  it('should reject when the promise returned by fn rejects', async () => {
+    const error = new Error('Error in fn')
+    const fn = jest.fn().mockRejectedValue(error)
+    const validate = jest.fn().mockReturnValue(false)
+
+    const { promise } = poll({ fn, validate, interval: 100, maxAttempts: 3 })
+
+    await expect(promise).rejects.toThrow('Error in fn')
+    expect(fn).toHaveBeenCalledTimes(1)
+    expect(validate).toHaveBeenCalledTimes(0)
+  })
+})

--- a/src/lib/poll/poll.ts
+++ b/src/lib/poll/poll.ts
@@ -1,39 +1,57 @@
-type PollArgs<T> = {
+export type PollArgs<T> = {
   fn(): Promise<T>
   validate(result: Awaited<T>): boolean
   interval: number
   maxAttempts: number
 }
 
+const sleep = async (intervalMs: number) =>
+  await new Promise(resolve => setTimeout(resolve, intervalMs))
+
 /**
+ * WARNING: Do not use this in components directly unless you want polling to continue after the component unmounts
  *
  * @param fn async function that can be called that a consumer wants to monitor a result
  * @param validate validator to determine if the result of the `fn` has met a specific condition and polling can stop
  * @param interval frequency at which the `fn` is called
  * @param maxAttempts number of attempts before function rejects
- * @returns Promise<T>
+ * @returns object containing the promise to await and a callback to cancel polling
  *
  * Ex: poll every second for up to 10 tries or until api request returns a valid response
  *
+ * ```
  * poll({
  *   fn: () => axios.get('/endpoint-with-changing-data'),
  *   validate: (result) => result.status === 'active',
  *   maxAttempts: 10,
  *   interval: 1000
  * })
+ * ```
  */
-export function poll<T>({ fn, validate, interval, maxAttempts }: PollArgs<T>) {
-  let attempts = 0
-  const execute = async (resolve: (arg: T) => void, reject: (err: Error) => void) => {
-    const result = await fn()
-    attempts++
-    if (validate(result)) {
-      return resolve(result)
-    } else if (maxAttempts && attempts === maxAttempts) {
-      return reject(new Error('Exceeded max attempts'))
-    } else {
-      setTimeout(execute, interval, resolve, reject)
+export const poll = <T>({
+  fn,
+  validate,
+  interval,
+  maxAttempts,
+}: PollArgs<T>): {
+  promise: Promise<T>
+  cancelPolling: () => void
+} => {
+  let isCancelled = false
+  const promise = (async () => {
+    for (let attempts = 0; attempts < maxAttempts; attempts++) {
+      if (isCancelled) throw Error('Polling cancelled')
+      const result = await fn()
+      if (validate(result)) return result
+      await sleep(interval)
     }
+
+    throw Error('Exceeded max attempts')
+  })()
+
+  const cancelPolling = () => {
+    isCancelled = true
   }
-  return new Promise<T>(execute)
+
+  return { promise, cancelPolling }
 }


### PR DESCRIPTION
## Description

We've identified an issue regarding the polling mechanism used to fetch updates during transaction execution. In the current implementation, polling continues to take place even after the associated React component has been unmounted, resulting in shenanigans such as error toast and page redirects where for trades that exceed the maximum attempts. 

This issue was identified during testing today where a thorchain trade took longer than 50 minutes to execute. MBMaria was setting up a different trade and an error toast appeared, falsely indicating an error on the current page.

Two fixes are implemented in this PR:
1. cancel polling on unmount. This is abstracted with a hook
2. allow infinite polling for tx updates

## Pull Request Type

- [x] :bug: Bug fix (Non-breaking Change: Fixes an issue)
- [ ] :hammer_and_wrench: Chore (Non-breaking Change: Doc updates, pkg upgrades, typos, etc..)
- [ ] :nail_care: New Feature (Breaking/Non-breaking Change)

## Issue (if applicable)

NA

## Risk

Moderate risk for all pages using polling.

## Testing

Test usages of poll around the app, see code changes for details.

### Engineering

Would appreciate help in getting this one tested. Will require monkey patch to reach specific code paths in reasonable time.

### Operations

This one is best tested by engineering team as it will require code changes to test

## Screenshots (if applicable)
