### PR TITLE
fix: claimable assets as opportunities

### DIFF
--- a/src/state/slices/opportunitiesSlice/selectors/stakingSelectors.ts
+++ b/src/state/slices/opportunitiesSlice/selectors/stakingSelectors.ts
@@ -549,7 +549,11 @@ export const selectAggregatedEarnUserStakingOpportunitiesIncludeEmpty =
 
       const [activeResults, inactiveResults] = partition(
         sortedResultsByFiatAmount,
-        opportunity => !bnOrZero(opportunity.fiatAmount).isZero(),
+        opportunity =>
+          bnOrZero(opportunity.fiatAmount).gt(0) ||
+          opportunity.rewardsCryptoBaseUnit?.amounts.some(rewardsAmount =>
+            bnOrZero(rewardsAmount).gt(0),
+          ),
       )
       inactiveResults.sort((a, b) => (bnOrZero(a.apy).gte(bnOrZero(b.apy)) ? -1 : 1))
 


### PR DESCRIPTION
## Description

This PR refactors the read-only opportunities to bring in the concept of claimable assets, which exist as their own asset e.g claimable TOKE, which exists as its own asset, and thus, opportunity, see:

https://etherscan.io/address/0x79dd22579112d8a5f7347c5ed7e609e60da713c5

- Upserts claimable assets as a wrapped asset into the portfolio if applicable
- Fixes incorrect `underlyingAssetId` for these, which were making us ditch these assets in `selectAggregatedEarnUserStakingOpportunitiesIncludeEmpty` `uniqBy`, since we use the wrong underlying AssetId for these i.e the one of their wrapped asset, which may also exist as its own opportunity
- While at it, improves the `activeResults` / `inactiveResults` heuristics in `selectAggregatedEarnUserStakingOpportunitiesIncludeEmpty` to consider opportunities with rewards as active

## Pull Request Type

- [x] :bug: Bug fix (Non-breaking Change: Fixes an issue)
- [ ] :hammer_and_wrench: Chore (Non-breaking Change: Doc updates, pkg upgrades, typos, etc..)
- [ ] :nail_care: New Feature (Breaking/Non-breaking Change)

## Issue (if applicable)

N/A

## Risk

<!-----------------------------------------------------------------------------
Outline the scope of your changes and the risk associated with them. You must use your discretion as an engineer to determine the potential impact of your changes.

E.g. an upgrade to `hdwallet` or core state management would be considered higher risk, and might require a full regression test. UI or isolated view changes, or something behind a feature flag may have near zero risk. Small bug fixes might require testing isolated to the specific fix.
------------------------------------------------------------------------------>

Low but not none - very low risk of regressions in the opportunities we display, even with the flag off.
We've changed the heuristics of what it means for an opportunity to be in/active here, do a quick sanity check to ensure opportunities still look sane in DeFi, and dashboard wallet/earn.

## Testing

<!-----------------------------------------------------------------------------
We treat every PR to be merged with the same scrutiny as if we were merging directly to production.

Your PR will not be merged if you do not complete the sections below for our engineering and operations teams to test.
------------------------------------------------------------------------------>

- Missing claimable tokens (e.g claimable TOKE as spotted by ops) are now visible
- Other tokens, which were already shown previously but now shown as "Claimable XYZ" e.g `Claimable WMATIC` or `Claimable FARM` look sane
- Asset exist for said claimable tokens and has market data price

### Engineering

<!-----------------------------------------------------------------------------
Include sufficient information here for an engineer to test your PR. This may include how to test locally, in a built environment, changes to infrastructure etc.
------------------------------------------------------------------------------>

- ☝🏽 

### Operations

<!-----------------------------------------------------------------------------
If your changes have a user-facing impact, describe how a non-technical QA team can functionally test your changes in a preview environment.

If they are not user-facing please describe how to test for any regressions that may occur.
------------------------------------------------------------------------------>

- ☝🏽 

## Screenshots (if applicable)

- This diff

<img width="1281" alt="image" src="https://github.com/shapeshift/web/assets/17035424/15390fb0-a04d-4702-a94e-b4e604100642">
<img width="923" alt="image" src="https://github.com/shapeshift/web/assets/17035424/0c205ced-b448-4b48-8d4c-d26ab03467e2">
<img width="568" alt="image" src="https://github.com/shapeshift/web/assets/17035424/1b66b74a-006b-41eb-a31e-78270eb766a8">
<img width="1298" alt="image" src="https://github.com/shapeshift/web/assets/17035424/67a81e2d-a68f-42f9-9c0e-9ff327c27ecf">
<img width="1318" alt="image" src="https://github.com/shapeshift/web/assets/17035424/799fb19b-5226-4866-9fe2-a4a3b2f4fb86">

- Develop

<img width="1294" alt="image" src="https://github.com/shapeshift/web/assets/17035424/1720273d-0cab-40b9-8902-91aa88c06740">
<img width="586" alt="image" src="https://github.com/shapeshift/web/assets/17035424/6516580b-2238-4bff-893c-34ca0d2d6bab">
<img width="1278" alt="image" src="https://github.com/shapeshift/web/assets/17035424/52655648-78f0-490a-90b7-b7ea0fe1eab7">
<img width="1330" alt="image" src="https://github.com/shapeshift/web/assets/17035424/74f0a93f-d38d-4fd8-a6c2-c7ede159d48a">
