### PR TITLE
chore: wire up receive address

### DIFF
--- a/src/components/MultiHopTrade/MultiHopTrade.tsx
+++ b/src/components/MultiHopTrade/MultiHopTrade.tsx
@@ -49,6 +49,7 @@ export const MultiHopTrade = (props: CardProps) => {
   const {
     state: { wallet },
   } = useWallet()
+  const dispatch = useAppDispatch()
   const [showTradeQuotes, toggleShowTradeQuotes] = useToggle(false)
   const isKeplr = useMemo(() => wallet instanceof KeplrHDWallet, [wallet])
   const methods = useForm({ mode: 'onChange' })
@@ -61,7 +62,6 @@ export const MultiHopTrade = (props: CardProps) => {
   const buyAmountAfterFeesCryptoPrecision = useAppSelector(selectNetReceiveAmountCryptoPrecision)
 
   const selectedQuoteStatus = useSelectedQuoteStatus()
-  const dispatch = useAppDispatch()
   const setBuyAsset = useCallback(
     (asset: Asset) => dispatch(swappers.actions.setBuyAsset(asset)),
     [dispatch],

--- a/src/components/MultiHopTrade/hooks/useGetTradeQuotes.tsx
+++ b/src/components/MultiHopTrade/hooks/useGetTradeQuotes.tsx
@@ -1,6 +1,7 @@
 import { skipToken } from '@reduxjs/toolkit/dist/query'
 import { orderBy } from 'lodash'
 import { useEffect, useMemo, useState } from 'react'
+import { useReceiveAddress } from 'components/MultiHopTrade/hooks/useReceiveAddress'
 import type { TradeQuoteResult } from 'components/MultiHopTrade/types'
 import { getTradeQuoteArgs } from 'components/Trade/hooks/useSwapper/getTradeQuoteArgs'
 import { useDebounce } from 'hooks/useDebounce/useDebounce'
@@ -15,7 +16,6 @@ import {
   selectFeatureFlags,
   selectPortfolioAccountIdsByAssetId,
   selectPortfolioAccountMetadataByAccountId,
-  selectReceiveAddress,
   selectSellAmountCryptoPrecision,
   selectSellAsset,
   selectSellAssetAccountId,
@@ -35,7 +35,7 @@ export const useGetTradeQuotes = () => {
   const sellAsset = useAppSelector(selectSellAsset)
   const buyAsset = useAppSelector(selectBuyAsset)
   const sellAssetAccountId = useAppSelector(selectSellAssetAccountId)
-  const receiveAddress = useAppSelector(selectReceiveAddress)
+  const receiveAddress = useReceiveAddress()
   const sellAmountCryptoPrecision = useAppSelector(selectSellAmountCryptoPrecision)
 
   const sellAccountMetadata = useMemo(() => {

--- a/src/components/MultiHopTrade/hooks/useHopHelper.tsx
+++ b/src/components/MultiHopTrade/hooks/useHopHelper.tsx
@@ -27,7 +27,10 @@ export const useHopHelper = () => {
     sellAsset: firstHopSellAsset,
   })
 
-  const { sellAssetAccountId: lastHopSellAssetAccountId } = useAccountIds({
+  const {
+    sellAssetAccountId: lastHopSellAssetAccountId,
+    buyAssetAccountId: lastHopBuyAssetAccountId,
+  } = useAccountIds({
     buyAsset: lastHopBuyAsset,
     sellAsset: lastHopSellAsset,
   })
@@ -63,5 +66,6 @@ export const useHopHelper = () => {
     sellAssetBalanceCryptoBaseUnit,
     firstHopFeeAssetBalancePrecision,
     lastHopFeeAssetBalancePrecision,
+    lastHopBuyAssetAccountId,
   }
 }

--- a/src/components/MultiHopTrade/hooks/useReceiveAddress.tsx
+++ b/src/components/MultiHopTrade/hooks/useReceiveAddress.tsx
@@ -63,9 +63,10 @@ export const useReceiveAddress = () => {
     if (!buyAsset) return
     ;(async () => {
       try {
-        const _receiveAddress = await getReceiveAddressFromBuyAsset(buyAsset)
-        setReceiveAddress(_receiveAddress)
+        const updatedReceiveAddress = await getReceiveAddressFromBuyAsset(buyAsset)
+        setReceiveAddress(updatedReceiveAddress)
       } catch (e) {
+        console.error(e)
         setReceiveAddress(undefined)
       }
     })()

--- a/src/components/MultiHopTrade/hooks/useReceiveAddress.tsx
+++ b/src/components/MultiHopTrade/hooks/useReceiveAddress.tsx
@@ -1,0 +1,75 @@
+import { fromAccountId } from '@shapeshiftoss/caip'
+import { useCallback, useEffect, useMemo, useState } from 'react'
+import { useAccountIds } from 'components/MultiHopTrade/hooks/useAccountIds'
+import { getReceiveAddress } from 'components/Trade/hooks/useSwapper/utils'
+import { useWallet } from 'hooks/useWallet/useWallet'
+import type { Asset } from 'lib/asset-service'
+import {
+  selectPortfolioAccountIdsByAssetId,
+  selectPortfolioAccountMetadataByAccountId,
+} from 'state/slices/portfolioSlice/selectors'
+import { isUtxoAccountId } from 'state/slices/portfolioSlice/utils'
+import { selectBuyAsset, selectSellAsset } from 'state/slices/swappersSlice/selectors'
+import { useAppDispatch, useAppSelector } from 'state/store'
+
+export const useReceiveAddress = () => {
+  // Hooks
+  const wallet = useWallet().state.wallet
+  const dispatch = useAppDispatch()
+  const [receiveAddress, setReceiveAddress] = useState<string | undefined>(undefined)
+
+  // Selectors
+  const buyAsset = useAppSelector(selectBuyAsset)
+  const sellAsset = useAppSelector(selectSellAsset)
+  const { buyAssetAccountId } = useAccountIds({ sellAsset, buyAsset })
+  const buyAssetAccountIds = useAppSelector(state =>
+    selectPortfolioAccountIdsByAssetId(state, { assetId: buyAsset?.assetId ?? '' }),
+  )
+
+  const buyAccountFilter = useMemo(
+    () => ({ accountId: buyAssetAccountId ?? buyAssetAccountIds[0] }),
+    [buyAssetAccountId, buyAssetAccountIds],
+  )
+
+  const buyAccountMetadata = useAppSelector(state =>
+    selectPortfolioAccountMetadataByAccountId(state, buyAccountFilter),
+  )
+
+  const getReceiveAddressFromBuyAsset = useCallback(
+    async (buyAsset: Asset) => {
+      if (!buyAssetAccountId) return
+      if (!buyAccountMetadata) return
+      if (isUtxoAccountId(buyAssetAccountId) && !buyAccountMetadata.accountType)
+        throw new Error(`Missing accountType for UTXO account ${buyAssetAccountId}`)
+      const buyAssetChainId = buyAsset.chainId
+      const buyAssetAccountChainId = fromAccountId(buyAssetAccountId).chainId
+      /**
+       * do NOT remove
+       * super dangerous - don't use the wrong bip44 params to generate receive addresses
+       */
+      if (buyAssetChainId !== buyAssetAccountChainId) return
+      const receiveAddress = await getReceiveAddress({
+        asset: buyAsset,
+        wallet,
+        accountMetadata: buyAccountMetadata,
+      })
+      return receiveAddress
+    },
+    [buyAssetAccountId, buyAccountMetadata, wallet],
+  )
+
+  // Set the receiveAddress when the buy asset changes
+  useEffect(() => {
+    if (!buyAsset) return
+    ;(async () => {
+      try {
+        const _receiveAddress = await getReceiveAddressFromBuyAsset(buyAsset)
+        setReceiveAddress(_receiveAddress)
+      } catch (e) {
+        setReceiveAddress(undefined)
+      }
+    })()
+  }, [buyAsset, dispatch, getReceiveAddressFromBuyAsset, setReceiveAddress])
+
+  return receiveAddress
+}

--- a/src/state/slices/swappersSlice/selectors.ts
+++ b/src/state/slices/swappersSlice/selectors.ts
@@ -21,11 +21,6 @@ export const selectSellAssetAccountId = createSelector(
   swappers => swappers.sellAssetAccountId,
 )
 
-export const selectReceiveAddress = createSelector(
-  selectSwappers,
-  swappers => swappers.receiveAddress,
-)
-
 export const selectSellAmountCryptoPrecision = createSelector(
   selectSwappers,
   swappers => swappers.sellAmountCryptoPrecision,

--- a/src/state/slices/swappersSlice/swappersSlice.ts
+++ b/src/state/slices/swappersSlice/swappersSlice.ts
@@ -13,7 +13,6 @@ export type SwappersState = {
   buyAsset: Asset
   sellAsset: Asset
   sellAssetAccountId: AccountId | undefined
-  receiveAddress: string | undefined
   sellAmountCryptoPrecision: string
   tradeExecutionStatus: MultiHopExecutionStatus
 }
@@ -23,7 +22,6 @@ const initialState: SwappersState = {
   buyAsset: localAssetData[foxAssetId] ?? defaultAsset,
   sellAsset: localAssetData[ethAssetId] ?? defaultAsset,
   sellAssetAccountId: undefined,
-  receiveAddress: undefined,
   sellAmountCryptoPrecision: '0',
   tradeExecutionStatus: MultiHopExecutionStatus.Hop1AwaitingApprovalConfirmation,
 }
@@ -42,9 +40,6 @@ export const swappers = createSlice({
     },
     setSellAssetAccountId: (state, action: PayloadAction<AccountId | undefined>) => {
       state.sellAssetAccountId = action.payload
-    },
-    setReceiveAddress: (state, action: PayloadAction<string | undefined>) => {
-      state.receiveAddress = action.payload
     },
     setSellAmountCryptoPrecision: (state, action: PayloadAction<string>) => {
       // dedupe 0, 0., 0.0, 0.00 etc

--- a/src/test/mocks/store.ts
+++ b/src/test/mocks/store.ts
@@ -165,7 +165,6 @@ export const mockStore: ReduxState = {
     buyAsset: defaultAsset,
     sellAsset: defaultAsset,
     sellAssetAccountId: undefined,
-    receiveAddress: undefined,
     sellAmountCryptoPrecision: '0',
     tradeExecutionStatus: MultiHopExecutionStatus.Unknown,
   },


### PR DESCRIPTION
## Description

Wire up receive address for new swapper architecture.

Removes `receiveAddress` from the store, as there is no value gained by putting it into a slice and then getting it back out again.

## Pull Request Type

- [ ] :bug: Bug fix (Non-breaking Change: Fixes an issue)
- [x] :hammer_and_wrench: Chore (Non-breaking Change: Doc updates, pkg upgrades, typos, etc..)
- [ ] :nail_care: New Feature (Breaking/Non-breaking Change)

## Issue (if applicable)

N/A

## Risk

Small - does not affect any non-feature flagged code paths.

## Testing

### Engineering

We should now get quotes again with the multi hop flag on.

### Operations

N/A

## Screenshots (if applicable)

N/A
