### PR TITLE
feat: added useTradeExecution hook for new Swapper2

### DIFF
--- a/src/components/MultiHopTrade/hooks/useTradeExecution.ts
+++ b/src/components/MultiHopTrade/hooks/useTradeExecution.ts
@@ -1,0 +1,114 @@
+import { supportsETH, supportsEthSwitchChain } from '@shapeshiftoss/hdwallet-core'
+import { TxStatus } from '@shapeshiftoss/unchained-client'
+import { useCallback, useState } from 'react'
+import { getChainAdapterManager } from 'context/PluginProvider/chainAdapterSingleton'
+import { usePoll } from 'hooks/usePoll/usePoll'
+import { useWallet } from 'hooks/useWallet/useWallet'
+import type { Swapper2, TradeQuote2 } from 'lib/swapper/api'
+import { SwapperName } from 'lib/swapper/api'
+import { lifi } from 'lib/swapper/swappers/LifiSwapper/LifiSwapper2'
+import { thorchain } from 'lib/swapper/swappers/ThorchainSwapper/ThorchainSwapper2'
+import { assertUnreachable, isEvmChainAdapter } from 'lib/utils'
+import { selectPortfolioAccountMetadataByAccountId } from 'state/slices/selectors'
+import { useAppSelector } from 'state/store'
+
+import { TRADE_POLL_INTERVAL_MILLISECONDS } from './constants'
+import { useAccountIds } from './useAccountIds'
+
+export const useTradeExecution = ({
+  swapperName,
+  tradeQuote,
+}: {
+  swapperName: SwapperName
+  tradeQuote: TradeQuote2
+}) => {
+  const [sellTxId, setSellTxId] = useState<string | undefined>()
+  const [buyTxId, setBuyTxId] = useState<string | undefined>()
+  const [message, setMessage] = useState<string | undefined>()
+  const [status, setStatus] = useState<TxStatus>(TxStatus.Unknown)
+  const { poll } = usePoll()
+  const wallet = useWallet().state.wallet
+
+  const { sellAssetAccountId } = useAccountIds({
+    sellAsset: tradeQuote.steps[0].sellAsset,
+  })
+
+  const sellAccountMetadata = useAppSelector(state =>
+    selectPortfolioAccountMetadataByAccountId(state, { accountId: sellAssetAccountId }),
+  )
+
+  const executeTrade = useCallback(async () => {
+    if (!wallet) throw Error('missing wallet')
+    if (!sellAccountMetadata) throw Error('missing sellAccountMetadata')
+
+    const {
+      bip44Params: { accountNumber },
+    } = sellAccountMetadata
+
+    const swapper: Swapper2 = (() => {
+      switch (swapperName) {
+        case SwapperName.LIFI:
+          return lifi
+        case SwapperName.Thorchain:
+          return thorchain
+        case SwapperName.Zrx:
+        case SwapperName.CowSwap:
+        case SwapperName.Osmosis:
+        case SwapperName.OneInch:
+        case SwapperName.Test:
+          throw Error('not implemented')
+        default:
+          assertUnreachable(swapperName)
+      }
+    })()
+
+    const stepIndex = 0 // TODO: multi-hop trades require this to be dynamic
+    const chainId = tradeQuote.steps[stepIndex].sellAsset.chainId
+
+    const sellAssetChainAdapter = getChainAdapterManager().get(chainId)
+
+    if (!sellAssetChainAdapter) throw Error(`missing sellAssetChainAdapter for chainId ${chainId}`)
+
+    if (isEvmChainAdapter(sellAssetChainAdapter)) {
+      if (!supportsEthSwitchChain(wallet)) throw Error(`wallet cannot switch to chainId ${chainId}`)
+      await sellAssetChainAdapter.assertSwitchChain(wallet)
+    }
+
+    const from = await sellAssetChainAdapter.getAddress({ wallet, accountNumber })
+    const supportsEIP1559 = supportsETH(wallet) && (await wallet.ethSupportsEIP1559())
+
+    const unsignedTxResult = await swapper.getUnsignedTx({
+      from,
+      tradeQuote,
+      chainId,
+      accountMetadata: sellAccountMetadata,
+      stepIndex,
+      supportsEIP1559,
+    })
+
+    const sellTxId = await swapper.executeTrade({
+      txToExecute: unsignedTxResult,
+      wallet,
+      chainId,
+    })
+
+    setSellTxId(sellTxId)
+
+    await poll({
+      fn: async () => {
+        const { status, message, buyTxId } = await swapper.checkTradeStatus(tradeQuote.id)
+
+        setMessage(message)
+        setBuyTxId(buyTxId)
+        setStatus(status)
+
+        return status
+      },
+      validate: status => status === TxStatus.Confirmed,
+      interval: TRADE_POLL_INTERVAL_MILLISECONDS,
+      maxAttempts: Infinity,
+    })
+  }, [poll, sellAccountMetadata, swapperName, tradeQuote, wallet])
+
+  return { executeTrade, sellTxId, buyTxId, message, status }
+}

--- a/src/components/MultiHopTrade/hooks/useTradeExecution/helpers.ts
+++ b/src/components/MultiHopTrade/hooks/useTradeExecution/helpers.ts
@@ -2,6 +2,7 @@ import type { ChainId } from '@shapeshiftoss/caip'
 import type { UtxoChainAdapter } from '@shapeshiftoss/chain-adapters'
 import type { HDWallet } from '@shapeshiftoss/hdwallet-core'
 import { getChainAdapterManager } from 'context/PluginProvider/chainAdapterSingleton'
+import type { FromOrXpub } from 'lib/swapper/api'
 import type { AccountMetadata } from 'state/slices/portfolioSlice/portfolioSliceCommon'
 import { isUtxoChainId } from 'state/slices/portfolioSlice/utils'
 
@@ -13,9 +14,7 @@ export type WithFromOrXpubParams = {
 
 // Gets a from address / xpub depending on the chain
 export const withFromOrXpub =
-  <T, P extends { from: string } | { xpub: string }>(
-    wrappedFunction: (fnParams: P) => Promise<T>,
-  ) =>
+  <T, P extends FromOrXpub>(wrappedFunction: (fnParams: P) => Promise<T>) =>
   async (
     { chainId, accountMetadata, wallet }: WithFromOrXpubParams,
     fnParams: Omit<P, 'from' | 'xpub'>,

--- a/src/components/MultiHopTrade/hooks/useTradeExecution/helpers.ts
+++ b/src/components/MultiHopTrade/hooks/useTradeExecution/helpers.ts
@@ -1,0 +1,54 @@
+import type { ChainId } from '@shapeshiftoss/caip'
+import type { UtxoChainAdapter } from '@shapeshiftoss/chain-adapters'
+import type { HDWallet } from '@shapeshiftoss/hdwallet-core'
+import { getChainAdapterManager } from 'context/PluginProvider/chainAdapterSingleton'
+import type { AccountMetadata } from 'state/slices/portfolioSlice/portfolioSliceCommon'
+import { isUtxoChainId } from 'state/slices/portfolioSlice/utils'
+
+export type WithFromOrXpubParams = {
+  chainId?: ChainId
+  accountMetadata?: AccountMetadata
+  wallet?: HDWallet
+  from?: string
+  xpub?: string
+}
+
+// Gets a from address either
+// - derived from the input (for our own consumption with our AccountMetadata and ChainId structures)
+// - or simply falls the passed from address through, for external consumers
+export const withFromOrXpub =
+  <T, P>(wrappedFunction: (params: P & { from?: string; xpub?: string }) => Promise<T>) =>
+  async (params: WithFromOrXpubParams & P): Promise<T> => {
+    const { chainId, accountMetadata, wallet, from: inputFrom, xpub: inputXpub } = params
+
+    let from: string | undefined = inputFrom
+    let xpub: string | undefined = inputXpub
+
+    if (!from && !xpub) {
+      if (!wallet) throw new Error('Wallet required for getAddress and getPublicKey calls')
+
+      const chainAdapterManager = getChainAdapterManager()
+      if (!chainId) throw new Error('No chainId provided')
+      const adapter = chainAdapterManager.get(chainId)
+      if (!adapter) throw new Error(`No adapter for ChainId: ${chainId}`)
+
+      const accountNumber = accountMetadata?.bip44Params?.accountNumber
+      const accountType = accountMetadata?.accountType
+
+      if (!accountNumber) throw new Error('Account number required')
+      if (isUtxoChainId(chainId)) {
+        if (!accountType) throw new Error('Account number required')
+        xpub = (
+          await (adapter as unknown as UtxoChainAdapter).getPublicKey(
+            wallet,
+            accountNumber,
+            accountType,
+          )
+        ).xpub
+      } else {
+        from = await adapter.getAddress({ wallet, accountNumber })
+      }
+    }
+
+    return wrappedFunction({ ...params, from, xpub })
+  }

--- a/src/components/MultiHopTrade/hooks/useTradeExecution/helpers.ts
+++ b/src/components/MultiHopTrade/hooks/useTradeExecution/helpers.ts
@@ -35,8 +35,8 @@ export const withFromOrXpub =
       )
 
       return wrappedFunction({ ...fnParams, xpub } as P)
+    } else {
+      const from = await adapter.getAddress({ wallet, accountNumber })
+      return wrappedFunction({ ...fnParams, from } as P)
     }
-
-    const from = await adapter.getAddress({ wallet, accountNumber })
-    return wrappedFunction({ ...fnParams, from } as P)
   }

--- a/src/components/MultiHopTrade/hooks/useTradeExecution/useTradeExecution.ts
+++ b/src/components/MultiHopTrade/hooks/useTradeExecution/useTradeExecution.ts
@@ -30,9 +30,7 @@ export const useTradeExecution = ({
   const { poll } = usePoll()
   const wallet = useWallet().state.wallet
 
-  const { sellAssetAccountId } = useAccountIds({
-    sellAsset: tradeQuote.steps[0].sellAsset,
-  })
+  const { sellAssetAccountId } = useAccountIds()
 
   const accountMetadata = useAppSelector(state =>
     selectPortfolioAccountMetadataByAccountId(state, { accountId: sellAssetAccountId }),
@@ -88,7 +86,7 @@ export const useTradeExecution = ({
     )
 
     const sellTxId = await swapper.executeTrade({
-      txToExecute: unsignedTxResult,
+      txToSign: unsignedTxResult,
       wallet,
       chainId,
     })

--- a/src/components/MultiHopTrade/hooks/useTradeExecution/useTradeExecution.ts
+++ b/src/components/MultiHopTrade/hooks/useTradeExecution/useTradeExecution.ts
@@ -6,8 +6,8 @@ import { usePoll } from 'hooks/usePoll/usePoll'
 import { useWallet } from 'hooks/useWallet/useWallet'
 import type { Swapper2, TradeQuote2 } from 'lib/swapper/api'
 import { SwapperName } from 'lib/swapper/api'
-import { lifi } from 'lib/swapper/swappers/LifiSwapper/LifiSwapper2'
-import { thorchain } from 'lib/swapper/swappers/ThorchainSwapper/ThorchainSwapper2'
+import { lifi as lifiSwapper } from 'lib/swapper/swappers/LifiSwapper/LifiSwapper2'
+import { thorchain as thorchainSwapper } from 'lib/swapper/swappers/ThorchainSwapper/ThorchainSwapper2'
 import { assertUnreachable, isEvmChainAdapter } from 'lib/utils'
 import { selectPortfolioAccountMetadataByAccountId } from 'state/slices/selectors'
 import { useAppSelector } from 'state/store'
@@ -43,9 +43,9 @@ export const useTradeExecution = ({
     const swapper: Swapper2 = (() => {
       switch (swapperName) {
         case SwapperName.LIFI:
-          return lifi
+          return lifiSwapper
         case SwapperName.Thorchain:
-          return thorchain
+          return thorchainSwapper
         case SwapperName.Zrx:
         case SwapperName.CowSwap:
         case SwapperName.Osmosis:

--- a/src/components/MultiHopTrade/hooks/useTradeExecution/useTradeExecution.ts
+++ b/src/components/MultiHopTrade/hooks/useTradeExecution/useTradeExecution.ts
@@ -12,8 +12,9 @@ import { assertUnreachable, isEvmChainAdapter } from 'lib/utils'
 import { selectPortfolioAccountMetadataByAccountId } from 'state/slices/selectors'
 import { useAppSelector } from 'state/store'
 
-import { TRADE_POLL_INTERVAL_MILLISECONDS } from './constants'
-import { useAccountIds } from './useAccountIds'
+import { TRADE_POLL_INTERVAL_MILLISECONDS } from '../constants'
+import { useAccountIds } from '../useAccountIds'
+import { withFromOrXpub } from './helpers'
 
 export const useTradeExecution = ({
   swapperName,
@@ -77,7 +78,7 @@ export const useTradeExecution = ({
     const from = await sellAssetChainAdapter.getAddress({ wallet, accountNumber })
     const supportsEIP1559 = supportsETH(wallet) && (await wallet.ethSupportsEIP1559())
 
-    const unsignedTxResult = await swapper.getUnsignedTx({
+    const unsignedTxResult = await withFromOrXpub(swapper.getUnsignedTx)({
       from,
       tradeQuote,
       chainId,

--- a/src/lib/swapper/api.ts
+++ b/src/lib/swapper/api.ts
@@ -14,6 +14,7 @@ import type {
   MarketData,
   UtxoAccountType,
 } from '@shapeshiftoss/types'
+import type { TxStatus } from '@shapeshiftoss/unchained-client'
 import type { Result } from '@sniptt/monads'
 import type { Asset } from 'lib/asset-service'
 import type { AccountMetadata } from 'state/slices/portfolioSlice/portfolioSliceCommon'
@@ -306,7 +307,9 @@ export type Swapper2 = {
   ) => Promise<Result<TradeQuote2, SwapErrorRight>>
   getUnsignedTx(input: GetUnsignedTxArgs): Promise<UnsignedTx>
   executeTrade: (executeTradeArgs: ExecuteTradeArgs) => Promise<string>
-  checkTradeStatus: (tradeId: string) => Promise<{ isComplete: boolean; message?: string }>
+  checkTradeStatus: (
+    tradeId: string,
+  ) => Promise<{ status: TxStatus; buyTxId: string | undefined; message: string | undefined }>
   filterAssetIdsBySellable: (assetIds: AssetId[]) => AssetId[]
   filterBuyAssetsBySellAssetId: (input: BuyAssetBySellIdInput) => AssetId[]
 }

--- a/src/lib/swapper/api.ts
+++ b/src/lib/swapper/api.ts
@@ -286,13 +286,15 @@ export type UnsignedTx = SignTx<keyof ChainSignTx>
 
 export type TradeQuote2 = TradeQuote & { id: string; receiveAddress: string; affiliateBps: string }
 
+export type FromOrXpub = { from: string; xpub?: never } | { from?: never; xpub: string }
+
 export type GetUnsignedTxArgs = {
   tradeQuote: TradeQuote2
   chainId: ChainId
   accountMetadata?: AccountMetadata
   stepIndex: number
   supportsEIP1559: boolean
-} & ({ from: string; xpub?: never } | { from?: never; xpub: string })
+} & FromOrXpub
 
 export type ExecuteTradeArgs = {
   txToSign: UnsignedTx

--- a/src/lib/swapper/swappers/ThorchainSwapper/ThorchainSwapper2.ts
+++ b/src/lib/swapper/swappers/ThorchainSwapper/ThorchainSwapper2.ts
@@ -78,7 +78,7 @@ export const thorchain: Swapper2 = {
           }
         : undefined
 
-    const fromOrXpub = from ? { from } : { xpub: xpub! }
+    const fromOrXpub = from !== undefined ? { from } : { xpub }
     return await getSignTxFromQuote({
       tradeQuote,
       receiveAddress,

--- a/src/lib/swapper/swappers/ThorchainSwapper/ThorchainSwapper2.ts
+++ b/src/lib/swapper/swappers/ThorchainSwapper/ThorchainSwapper2.ts
@@ -1,7 +1,6 @@
-import type { AssetId, ChainId } from '@shapeshiftoss/caip'
+import type { AssetId } from '@shapeshiftoss/caip'
 import { CHAIN_NAMESPACE, fromChainId, thorchainAssetId } from '@shapeshiftoss/caip'
 import type {
-  ChainAdapter,
   CosmosSdkChainAdapter,
   EvmChainAdapter,
   EvmChainId,
@@ -9,7 +8,7 @@ import type {
   UtxoChainAdapter,
   UtxoChainId,
 } from '@shapeshiftoss/chain-adapters'
-import type { HDWallet, ThorchainSignTx } from '@shapeshiftoss/hdwallet-core'
+import type { ThorchainSignTx } from '@shapeshiftoss/hdwallet-core'
 import { TxStatus } from '@shapeshiftoss/unchained-client'
 import type { Result } from '@sniptt/monads/build'
 import { getChainAdapterManager } from 'context/PluginProvider/chainAdapterSingleton'
@@ -24,60 +23,13 @@ import type {
   UnsignedTx,
 } from 'lib/swapper/api'
 import { assertUnreachable, evm } from 'lib/utils'
-import type { AccountMetadata } from 'state/slices/portfolioSlice/portfolioSliceCommon'
-import { isUtxoChainId } from 'state/slices/portfolioSlice/utils'
 import { selectFeeAssetById, selectUsdRateByAssetId } from 'state/slices/selectors'
 import { store } from 'state/store'
 
 import { getThorTradeQuote } from './getThorTradeQuote/getTradeQuote'
-import type { Rates, ThorChainId, ThorUtxoSupportedChainId } from './ThorchainSwapper'
+import type { Rates, ThorUtxoSupportedChainId } from './ThorchainSwapper'
 import { ThorchainSwapper } from './ThorchainSwapper'
 import { getSignTxFromQuote } from './utils/getSignTxFromQuote'
-
-// Gets a from address either
-// - derived from the input (for our own consumption with our AccountMetadata and ChainId structures)
-// - or simply falls the passed from address through, for external consumers
-
-type WithFromOrXpubParams = {
-  chainId?: ChainId
-  accountMetadata?: AccountMetadata
-  wallet?: HDWallet
-  from?: string
-  xpub?: string
-}
-
-const withFromOrXpub =
-  <T, P>(wrappedFunction: (params: P & { from?: string; xpub?: string }) => Promise<T>) =>
-  async (params: WithFromOrXpubParams & P): Promise<T> => {
-    const { chainId, accountMetadata, wallet, from: inputFrom, xpub: inputXpub } = params
-
-    let from: string | undefined = inputFrom
-    let xpub: string | undefined = inputXpub
-
-    if (!from && !xpub) {
-      if (!wallet) throw new Error('Wallet required for getAddress and getPublicKey calls')
-
-      const chainAdapterManager = getChainAdapterManager()
-      if (!chainId) throw new Error('No chainId provided')
-      const adapter = chainAdapterManager.get(chainId) as ChainAdapter<ThorChainId>
-      if (!adapter) throw new Error(`No adapter for ChainId: ${chainId}`)
-
-      const accountNumber = accountMetadata?.bip44Params?.accountNumber
-      const accountType = accountMetadata?.accountType
-
-      if (!accountNumber) throw new Error('Account number required')
-      if (isUtxoChainId(chainId)) {
-        if (!accountType) throw new Error('Account number required')
-        xpub = (
-          await (adapter as UtxoChainAdapter).getPublicKey(wallet, accountNumber, accountType)
-        ).xpub
-      } else {
-        from = await adapter.getAddress({ wallet, accountNumber })
-      }
-    }
-
-    return wrappedFunction({ ...params, from, xpub })
-  }
 
 export const thorchain: Swapper2 = {
   getTradeQuote: async (
@@ -94,47 +46,50 @@ export const thorchain: Swapper2 = {
     })
   },
 
-  // TODO: getUnsignedTx isn't consumed anywhere yet. When it is, move the HOF to the caller, so we keep the inner function pure
-  getUnsignedTx: withFromOrXpub(
-    async ({ accountMetadata, tradeQuote, from, xpub, supportsEIP1559 }): Promise<UnsignedTx> => {
-      const { receiveAddress, affiliateBps } = tradeQuote
-      const feeAsset = selectFeeAssetById(store.getState(), tradeQuote.steps[0].sellAsset.assetId)
-      const buyAssetUsdRate = selectUsdRateByAssetId(
-        store.getState(),
-        tradeQuote.steps[0].buyAsset.assetId,
-      )
-      const feeAssetUsdRate = feeAsset
-        ? selectUsdRateByAssetId(store.getState(), feeAsset.assetId)
+  getUnsignedTx: async ({
+    accountMetadata,
+    tradeQuote,
+    from,
+    xpub,
+    supportsEIP1559,
+  }): Promise<UnsignedTx> => {
+    const { receiveAddress, affiliateBps } = tradeQuote
+    const feeAsset = selectFeeAssetById(store.getState(), tradeQuote.steps[0].sellAsset.assetId)
+    const buyAssetUsdRate = selectUsdRateByAssetId(
+      store.getState(),
+      tradeQuote.steps[0].buyAsset.assetId,
+    )
+    const feeAssetUsdRate = feeAsset
+      ? selectUsdRateByAssetId(store.getState(), feeAsset.assetId)
+      : undefined
+
+    if (!buyAssetUsdRate) throw Error('missing buy asset usd rate')
+    if (!feeAssetUsdRate) throw Error('missing fee asset usd rate')
+
+    const accountType = accountMetadata?.accountType
+
+    const chainSpecific =
+      accountType && xpub
+        ? {
+            xpub,
+            accountType,
+            satoshiPerByte: (tradeQuote as TradeQuote<ThorUtxoSupportedChainId>).steps[0].feeData
+              .chainSpecific.satsPerByte,
+          }
         : undefined
 
-      if (!buyAssetUsdRate) throw Error('missing buy asset usd rate')
-      if (!feeAssetUsdRate) throw Error('missing fee asset usd rate')
-
-      const accountType = accountMetadata?.accountType
-
-      const chainSpecific =
-        accountType && xpub
-          ? {
-              xpub,
-              accountType,
-              satoshiPerByte: (tradeQuote as TradeQuote<ThorUtxoSupportedChainId>).steps[0].feeData
-                .chainSpecific.satsPerByte,
-            }
-          : undefined
-
-      const fromOrXpub = from ? { from } : { xpub: xpub! }
-      return await getSignTxFromQuote({
-        tradeQuote,
-        receiveAddress,
-        affiliateBps,
-        chainSpecific,
-        buyAssetUsdRate,
-        ...fromOrXpub,
-        feeAssetUsdRate,
-        supportsEIP1559,
-      })
-    },
-  ),
+    const fromOrXpub = from ? { from } : { xpub: xpub! }
+    return await getSignTxFromQuote({
+      tradeQuote,
+      receiveAddress,
+      affiliateBps,
+      chainSpecific,
+      buyAssetUsdRate,
+      ...fromOrXpub,
+      feeAssetUsdRate,
+      supportsEIP1559,
+    })
+  },
 
   executeTrade: async ({ txToSign, wallet, chainId }: ExecuteTradeArgs): Promise<string> => {
     const { chainNamespace } = fromChainId(chainId)


### PR DESCRIPTION
## Description

Re-adds useTradeExecution hook for new swapper architecture. Currently a placeholder implementation while we implement a ui to make this testable.

Includes updates to `checkTradeStatus` which were identified when building the trade confirmation UI. Again, not testable yet and not user facing.

## Pull Request Type

- [ ] :bug: Bug fix (Non-breaking Change: Fixes an issue)
- [ ] :hammer_and_wrench: Chore (Non-breaking Change: Doc updates, pkg upgrades, typos, etc..)
- [x] :nail_care: New Feature (Breaking/Non-breaking Change)

## Issue (if applicable)

closes #4776

## Risk

no risk, not user facing

## Testing

Not testable currently, this needs to be merged to facilitate building the UI to test this :P

### Engineering

See above

### Operations

See above

## Screenshots (if applicable)
