### PR TITLE
fix: broken trade quotes in exchange client

### DIFF
--- a/src/components/MultiHopTrade/MultiHopTrade.tsx
+++ b/src/components/MultiHopTrade/MultiHopTrade.tsx
@@ -76,7 +76,7 @@ export const MultiHopTrade = (props: CardProps) => {
   )
 
   const { supportedSellAssets, supportedBuyAssets } = useSupportedAssets()
-  const { selectedQuote } = useGetTradeQuotes()
+  const { selectedQuote, sortedQuotes } = useGetTradeQuotes()
 
   const isLoading = useMemo(() => selectedQuote?.isLoading, [selectedQuote?.isLoading])
   const quoteData = useMemo(
@@ -89,10 +89,7 @@ export const MultiHopTrade = (props: CardProps) => {
   )
 
   const { sellAssetAccountId, buyAssetAccountId, setSellAssetAccountId, setBuyAssetAccountId } =
-    useAccountIds({
-      buyAsset,
-      sellAsset,
-    })
+    useAccountIds()
   const translate = useTranslate()
   const overlayTitle = useMemo(
     () => translate('trade.swappingComingSoonForWallet', { walletName: 'Keplr' }),
@@ -199,7 +196,9 @@ export const MultiHopTrade = (props: CardProps) => {
                     )
                   }
                 >
-                  {quoteData && <TradeQuotes isOpen={showTradeQuotes} />}
+                  {quoteData && (
+                    <TradeQuotes isOpen={showTradeQuotes} sortedQuotes={sortedQuotes} />
+                  )}
                 </TradeAssetInput>
               </Stack>
               <Stack

--- a/src/components/MultiHopTrade/components/TradeQuotes/TradeQuotes.tsx
+++ b/src/components/MultiHopTrade/components/TradeQuotes/TradeQuotes.tsx
@@ -11,7 +11,7 @@ type TradeQuotesProps = {
 }
 
 export const TradeQuotes: React.FC<TradeQuotesProps> = ({ isOpen, sortedQuotes }) => {
-  const selectedSwapperName = useAppSelector(selectSelectedSwapperName)
+  const activeSwapperName = useAppSelector(selectSelectedSwapperName)
 
   const bestQuoteData = sortedQuotes[0]
 
@@ -23,7 +23,7 @@ export const TradeQuotes: React.FC<TradeQuotesProps> = ({ isOpen, sortedQuotes }
     if (!quote) return null
 
     // TODO(woodenfurniture): use quote ID when we want to support multiple quotes per swapper
-    const isActive = selectedSwapperName === swapperName
+    const isActive = activeSwapperName === swapperName
 
     return (
       <TradeQuote

--- a/src/components/MultiHopTrade/components/TradeQuotes/TradeQuotes.tsx
+++ b/src/components/MultiHopTrade/components/TradeQuotes/TradeQuotes.tsx
@@ -1,16 +1,18 @@
 import { Collapse, Flex } from '@chakra-ui/react'
-import { useGetTradeQuotes } from 'components/MultiHopTrade/hooks/useGetTradeQuotes'
+import type { TradeQuoteResult } from 'components/MultiHopTrade/types'
+import { selectSelectedSwapperName } from 'state/slices/tradeQuoteSlice/selectors'
+import { useAppSelector } from 'state/store'
 
 import { TradeQuote } from './TradeQuote'
 
 type TradeQuotesProps = {
   isOpen?: boolean
+  sortedQuotes: TradeQuoteResult[]
 }
 
-export const TradeQuotes: React.FC<TradeQuotesProps> = ({ isOpen }) => {
-  const { selectedQuote, sortedQuotes } = useGetTradeQuotes()
+export const TradeQuotes: React.FC<TradeQuotesProps> = ({ isOpen, sortedQuotes }) => {
+  const selectedSwapperName = useAppSelector(selectSelectedSwapperName)
 
-  const activeSwapperName = selectedQuote?.swapperName
   const bestQuoteData = sortedQuotes[0]
 
   const quotes = sortedQuotes.map((quoteData, i) => {
@@ -21,7 +23,7 @@ export const TradeQuotes: React.FC<TradeQuotesProps> = ({ isOpen }) => {
     if (!quote) return null
 
     // TODO(woodenfurniture): use quote ID when we want to support multiple quotes per swapper
-    const isActive = activeSwapperName === swapperName
+    const isActive = selectedSwapperName === swapperName
 
     return (
       <TradeQuote

--- a/src/components/MultiHopTrade/hooks/useAccountIds.tsx
+++ b/src/components/MultiHopTrade/hooks/useAccountIds.tsx
@@ -1,6 +1,6 @@
 import type { AccountId } from '@shapeshiftoss/caip'
 import { useCallback } from 'react'
-import { selectBuyAssetAccountId, selectSellAssetAccountId } from 'state/slices/selectors'
+import { selectBuyAccountId, selectSellAccountId } from 'state/slices/selectors'
 import { swappers } from 'state/slices/swappersSlice/swappersSlice'
 import { useAppDispatch, useAppSelector } from 'state/store'
 
@@ -11,8 +11,8 @@ export const useAccountIds = (): {
   setSellAssetAccountId: (accountId: AccountId) => void
 } => {
   const dispatch = useAppDispatch()
-  const sellAssetAccountId = useAppSelector(selectSellAssetAccountId)
-  const buyAssetAccountId = useAppSelector(selectBuyAssetAccountId)
+  const sellAssetAccountId = useAppSelector(selectSellAccountId)
+  const buyAssetAccountId = useAppSelector(selectBuyAccountId)
 
   const setSellAssetAccountId = useCallback(
     (accountId: AccountId | undefined) =>

--- a/src/components/MultiHopTrade/hooks/useAccountIds.tsx
+++ b/src/components/MultiHopTrade/hooks/useAccountIds.tsx
@@ -1,79 +1,35 @@
 import type { AccountId } from '@shapeshiftoss/caip'
-import { useEffect, useState } from 'react'
-import type { Asset } from 'lib/asset-service'
-import { selectHighestFiatBalanceAccountByAssetId } from 'state/slices/portfolioSlice/selectors'
-import { selectFirstAccountIdByChainId } from 'state/slices/selectors'
-import { selectSwapperSupportsCrossAccountTrade } from 'state/slices/tradeQuoteSlice/selectors'
-import { useAppSelector } from 'state/store'
+import { useCallback } from 'react'
+import { selectBuyAssetAccountId, selectSellAssetAccountId } from 'state/slices/selectors'
+import { swappers } from 'state/slices/swappersSlice/swappersSlice'
+import { useAppDispatch, useAppSelector } from 'state/store'
 
-export const useAccountIds = ({
-  buyAsset,
-  sellAsset,
-}: {
-  buyAsset?: Asset
-  sellAsset?: Asset
-}): {
+export const useAccountIds = (): {
   buyAssetAccountId?: AccountId
   sellAssetAccountId?: AccountId
   setBuyAssetAccountId: (accountId: AccountId) => void
   setSellAssetAccountId: (accountId: AccountId) => void
 } => {
-  const swapperSupportsCrossAccountTrade = useAppSelector(selectSwapperSupportsCrossAccountTrade)
+  const dispatch = useAppDispatch()
+  const sellAssetAccountId = useAppSelector(selectSellAssetAccountId)
+  const buyAssetAccountId = useAppSelector(selectBuyAssetAccountId)
 
-  const highestFiatBalanceSellAccountId = useAppSelector(state =>
-    selectHighestFiatBalanceAccountByAssetId(state, {
-      assetId: sellAsset?.assetId,
-    }),
-  )
-  const highestFiatBalanceBuyAccountId = useAppSelector(state =>
-    selectHighestFiatBalanceAccountByAssetId(state, {
-      assetId: buyAsset?.assetId,
-    }),
-  )
-  const firstSellAssetAccountId = useAppSelector(state =>
-    selectFirstAccountIdByChainId(state, sellAsset?.chainId ?? ''),
-  )
-  const firstBuyAssetAccountId = useAppSelector(state =>
-    selectFirstAccountIdByChainId(state, buyAsset?.chainId ?? ''),
+  const setSellAssetAccountId = useCallback(
+    (accountId: AccountId | undefined) =>
+      dispatch(swappers.actions.setSellAssetAccountId(accountId)),
+    [dispatch],
   )
 
-  const [selectedSellAssetAccountId, setSelectedSellAssetAccountId] = useState<
-    AccountId | undefined
-  >()
-  const [selectedBuyAssetAccountId, setSelectedBuyAssetAccountId] = useState<
-    AccountId | undefined
-  >()
-
-  useEffect(() => {
-    setSelectedSellAssetAccountId(highestFiatBalanceSellAccountId ?? firstSellAssetAccountId)
-  }, [highestFiatBalanceSellAccountId, firstSellAssetAccountId])
-
-  useEffect(() => {
-    setSelectedBuyAssetAccountId(highestFiatBalanceBuyAccountId ?? firstBuyAssetAccountId)
-  }, [firstBuyAssetAccountId, highestFiatBalanceBuyAccountId])
-
-  useEffect(() => {
-    /*
-      This is extremely dangerous. We only want to substitute the buyAssetAccountId with the sellAssetAccountId
-      if we have a swapper, and that swapper does not do either of:
-        - Trades between assets on the same chain but different accounts
-        - Trades between assets on different chains (and possibly different accounts)
-    */
-    switch (true) {
-      case swapperSupportsCrossAccountTrade === false: // force to same account ID
-        setSelectedBuyAssetAccountId(selectedSellAssetAccountId)
-        return
-      case swapperSupportsCrossAccountTrade === true: // no changes required
-      case swapperSupportsCrossAccountTrade === undefined: // no swapper
-      default:
-        return
-    }
-  }, [selectedSellAssetAccountId, swapperSupportsCrossAccountTrade])
+  const setBuyAssetAccountId = useCallback(
+    (accountId: AccountId | undefined) =>
+      dispatch(swappers.actions.setBuyAssetAccountId(accountId)),
+    [dispatch],
+  )
 
   return {
-    sellAssetAccountId: selectedSellAssetAccountId,
-    buyAssetAccountId: selectedBuyAssetAccountId,
-    setSellAssetAccountId: setSelectedSellAssetAccountId,
-    setBuyAssetAccountId: setSelectedBuyAssetAccountId,
+    sellAssetAccountId,
+    buyAssetAccountId,
+    setSellAssetAccountId,
+    setBuyAssetAccountId,
   }
 }

--- a/src/components/MultiHopTrade/hooks/useGetTradeQuotes.tsx
+++ b/src/components/MultiHopTrade/hooks/useGetTradeQuotes.tsx
@@ -110,7 +110,10 @@ export const useGetTradeQuotes = () => {
         swapperName: SwapperName.LIFI,
       },
     ]
-      .filter(result => !isCrossAccountTrade || isCrossAccountTradeSupported(result.swapperName))
+      .filter(result => {
+        const swapperSupportsCrossAccountTrade = isCrossAccountTradeSupported(result.swapperName)
+        return !isCrossAccountTrade || swapperSupportsCrossAccountTrade
+      })
       .map(result => {
         const quote = result.data && result.data.isOk() ? result.data.unwrap() : undefined
         const inputOutputRatio = quote

--- a/src/components/MultiHopTrade/hooks/useGetTradeQuotes.tsx
+++ b/src/components/MultiHopTrade/hooks/useGetTradeQuotes.tsx
@@ -12,13 +12,13 @@ import { isSkipToken } from 'lib/utils'
 import { useGetLifiTradeQuoteQuery } from 'state/apis/swappers/lifiSwapperApi'
 import { useGetThorTradeQuoteQuery } from 'state/apis/swappers/thorSwapperApi'
 import {
+  selectBuyAccountId,
   selectBuyAsset,
-  selectBuyAssetAccountId,
   selectFeatureFlags,
   selectPortfolioAccountMetadataByAccountId,
+  selectSellAccountId,
   selectSellAmountCryptoPrecision,
   selectSellAsset,
-  selectSellAssetAccountId,
 } from 'state/slices/selectors'
 import {
   getInputOutputRatioFromQuote,
@@ -40,18 +40,18 @@ export const useGetTradeQuotes = () => {
   const receiveAddress = useReceiveAddress()
   const sellAmountCryptoPrecision = useAppSelector(selectSellAmountCryptoPrecision)
 
-  const sellAssetAccountId = useAppSelector(selectSellAssetAccountId)
-  const buyAssetAccountId = useAppSelector(selectBuyAssetAccountId)
+  const sellAccountId = useAppSelector(selectSellAccountId)
+  const buyAccountId = useAppSelector(selectBuyAccountId)
   const isCrossAccountTrade = useMemo(
-    () => sellAssetAccountId !== buyAssetAccountId,
-    [buyAssetAccountId, sellAssetAccountId],
+    () => sellAccountId !== buyAccountId,
+    [buyAccountId, sellAccountId],
   )
 
   const sellAccountMetadata = useMemo(() => {
     return selectPortfolioAccountMetadataByAccountId(store.getState(), {
-      accountId: sellAssetAccountId,
+      accountId: sellAccountId,
     })
-  }, [sellAssetAccountId])
+  }, [sellAccountId])
 
   useEffect(() => {
     if (wallet && sellAccountMetadata && receiveAddress) {

--- a/src/components/MultiHopTrade/hooks/useHopHelper.tsx
+++ b/src/components/MultiHopTrade/hooks/useHopHelper.tsx
@@ -3,7 +3,7 @@ import {
   selectPortfolioCryptoBalanceBaseUnitByFilter,
   selectPortfolioCryptoPrecisionBalanceByFilter,
 } from 'state/slices/common-selectors'
-import { selectBuyAssetAccountId, selectSellAssetAccountId } from 'state/slices/selectors'
+import { selectSellAccountId } from 'state/slices/selectors'
 import {
   selectFirstHopSellAsset,
   selectFirstHopSellFeeAsset,
@@ -13,20 +13,25 @@ import { useAppSelector } from 'state/store'
 
 export const useHopHelper = () => {
   const firstHopSellAsset = useAppSelector(selectFirstHopSellAsset)
+
+  // the network fee asset for the first hop in the trade
   const firstHopSellFeeAsset = useAppSelector(selectFirstHopSellFeeAsset)
+
+  // the network fee asset for the last hop in the trade
   const lastHopSellFeeAsset = useAppSelector(selectLastHopSellFeeAsset)
 
-  const sellAssetAccountId = useAppSelector(selectSellAssetAccountId)
-  const buyAssetAccountId = useAppSelector(selectBuyAssetAccountId)
+  // this is the account we're selling from - in this implementation, network fees are always paid
+  // from the sell account regardless of how many hops we have (TODO: logic for osmo fees though)
+  const sellAccountId = useAppSelector(selectSellAccountId)
 
   const firstHopFeeAssetBalanceFilter = useMemo(
-    () => ({ assetId: firstHopSellFeeAsset?.assetId, accountId: sellAssetAccountId ?? '' }),
-    [sellAssetAccountId, firstHopSellFeeAsset?.assetId],
+    () => ({ assetId: firstHopSellFeeAsset?.assetId, accountId: sellAccountId ?? '' }),
+    [sellAccountId, firstHopSellFeeAsset?.assetId],
   )
 
   const lastHopFeeAssetBalanceFilter = useMemo(
-    () => ({ assetId: lastHopSellFeeAsset?.assetId, accountId: sellAssetAccountId ?? '' }),
-    [sellAssetAccountId, lastHopSellFeeAsset?.assetId],
+    () => ({ assetId: lastHopSellFeeAsset?.assetId, accountId: sellAccountId ?? '' }),
+    [sellAccountId, lastHopSellFeeAsset?.assetId],
   )
 
   const firstHopFeeAssetBalancePrecision = useAppSelector(s =>
@@ -38,8 +43,8 @@ export const useHopHelper = () => {
   )
 
   const sellAssetBalanceFilter = useMemo(
-    () => ({ accountId: buyAssetAccountId, assetId: firstHopSellAsset?.assetId ?? '' }),
-    [buyAssetAccountId, firstHopSellAsset?.assetId],
+    () => ({ accountId: sellAccountId, assetId: firstHopSellAsset?.assetId ?? '' }),
+    [sellAccountId, firstHopSellAsset?.assetId],
   )
 
   const sellAssetBalanceCryptoBaseUnit = useAppSelector(state =>

--- a/src/components/MultiHopTrade/hooks/useHopHelper.tsx
+++ b/src/components/MultiHopTrade/hooks/useHopHelper.tsx
@@ -1,48 +1,32 @@
 import { useMemo } from 'react'
-import { useAccountIds } from 'components/MultiHopTrade/hooks/useAccountIds'
 import {
   selectPortfolioCryptoBalanceBaseUnitByFilter,
   selectPortfolioCryptoPrecisionBalanceByFilter,
 } from 'state/slices/common-selectors'
+import { selectBuyAssetAccountId, selectSellAssetAccountId } from 'state/slices/selectors'
 import {
-  selectFirstHopBuyAsset,
   selectFirstHopSellAsset,
   selectFirstHopSellFeeAsset,
-  selectLastHopBuyAsset,
-  selectLastHopSellAsset,
   selectLastHopSellFeeAsset,
 } from 'state/slices/tradeQuoteSlice/selectors'
 import { useAppSelector } from 'state/store'
 
 export const useHopHelper = () => {
   const firstHopSellAsset = useAppSelector(selectFirstHopSellAsset)
-  const firstHopBuyAsset = useAppSelector(selectFirstHopBuyAsset)
-  const lastHopSellAsset = useAppSelector(selectLastHopSellAsset)
-  const lastHopBuyAsset = useAppSelector(selectLastHopBuyAsset)
   const firstHopSellFeeAsset = useAppSelector(selectFirstHopSellFeeAsset)
   const lastHopSellFeeAsset = useAppSelector(selectLastHopSellFeeAsset)
 
-  const { sellAssetAccountId: firstHopSellAssetAccountId } = useAccountIds({
-    buyAsset: firstHopBuyAsset,
-    sellAsset: firstHopSellAsset,
-  })
-
-  const {
-    sellAssetAccountId: lastHopSellAssetAccountId,
-    buyAssetAccountId: lastHopBuyAssetAccountId,
-  } = useAccountIds({
-    buyAsset: lastHopBuyAsset,
-    sellAsset: lastHopSellAsset,
-  })
+  const sellAssetAccountId = useAppSelector(selectSellAssetAccountId)
+  const buyAssetAccountId = useAppSelector(selectBuyAssetAccountId)
 
   const firstHopFeeAssetBalanceFilter = useMemo(
-    () => ({ assetId: firstHopSellFeeAsset?.assetId, accountId: firstHopSellAssetAccountId ?? '' }),
-    [firstHopSellAssetAccountId, firstHopSellFeeAsset?.assetId],
+    () => ({ assetId: firstHopSellFeeAsset?.assetId, accountId: sellAssetAccountId ?? '' }),
+    [sellAssetAccountId, firstHopSellFeeAsset?.assetId],
   )
 
   const lastHopFeeAssetBalanceFilter = useMemo(
-    () => ({ assetId: lastHopSellFeeAsset?.assetId, accountId: lastHopSellAssetAccountId ?? '' }),
-    [lastHopSellAssetAccountId, lastHopSellFeeAsset?.assetId],
+    () => ({ assetId: lastHopSellFeeAsset?.assetId, accountId: sellAssetAccountId ?? '' }),
+    [sellAssetAccountId, lastHopSellFeeAsset?.assetId],
   )
 
   const firstHopFeeAssetBalancePrecision = useAppSelector(s =>
@@ -54,8 +38,8 @@ export const useHopHelper = () => {
   )
 
   const sellAssetBalanceFilter = useMemo(
-    () => ({ accountId: firstHopSellAssetAccountId, assetId: firstHopSellAsset?.assetId ?? '' }),
-    [firstHopSellAssetAccountId, firstHopSellAsset?.assetId],
+    () => ({ accountId: buyAssetAccountId, assetId: firstHopSellAsset?.assetId ?? '' }),
+    [buyAssetAccountId, firstHopSellAsset?.assetId],
   )
 
   const sellAssetBalanceCryptoBaseUnit = useAppSelector(state =>
@@ -66,6 +50,5 @@ export const useHopHelper = () => {
     sellAssetBalanceCryptoBaseUnit,
     firstHopFeeAssetBalancePrecision,
     lastHopFeeAssetBalancePrecision,
-    lastHopBuyAssetAccountId,
   }
 }

--- a/src/components/MultiHopTrade/hooks/useReceiveAddress.tsx
+++ b/src/components/MultiHopTrade/hooks/useReceiveAddress.tsx
@@ -5,7 +5,7 @@ import { useWallet } from 'hooks/useWallet/useWallet'
 import type { Asset } from 'lib/asset-service'
 import { selectPortfolioAccountMetadataByAccountId } from 'state/slices/portfolioSlice/selectors'
 import { isUtxoAccountId } from 'state/slices/portfolioSlice/utils'
-import { selectBuyAsset, selectBuyAssetAccountId } from 'state/slices/swappersSlice/selectors'
+import { selectBuyAccountId, selectBuyAsset } from 'state/slices/swappersSlice/selectors'
 import { useAppDispatch, useAppSelector } from 'state/store'
 
 export const useReceiveAddress = () => {
@@ -17,19 +17,19 @@ export const useReceiveAddress = () => {
 
   // Selectors
   const buyAsset = useAppSelector(selectBuyAsset)
-  const buyAssetAccountId = useAppSelector(selectBuyAssetAccountId)
+  const buyAccountId = useAppSelector(selectBuyAccountId)
   const buyAccountMetadata = useAppSelector(state =>
-    selectPortfolioAccountMetadataByAccountId(state, { accountId: buyAssetAccountId }),
+    selectPortfolioAccountMetadataByAccountId(state, { accountId: buyAccountId }),
   )
 
   const getReceiveAddressFromBuyAsset = useCallback(
     async (buyAsset: Asset) => {
-      if (!buyAssetAccountId) return
+      if (!buyAccountId) return
       if (!buyAccountMetadata) return
-      if (isUtxoAccountId(buyAssetAccountId) && !buyAccountMetadata.accountType)
-        throw new Error(`Missing accountType for UTXO account ${buyAssetAccountId}`)
+      if (isUtxoAccountId(buyAccountId) && !buyAccountMetadata.accountType)
+        throw new Error(`Missing accountType for UTXO account ${buyAccountId}`)
       const buyAssetChainId = buyAsset.chainId
-      const buyAssetAccountChainId = fromAccountId(buyAssetAccountId).chainId
+      const buyAssetAccountChainId = fromAccountId(buyAccountId).chainId
       /**
        * do NOT remove
        * super dangerous - don't use the wrong bip44 params to generate receive addresses
@@ -42,7 +42,7 @@ export const useReceiveAddress = () => {
       })
       return receiveAddress
     },
-    [buyAssetAccountId, buyAccountMetadata, wallet],
+    [buyAccountId, buyAccountMetadata, wallet],
   )
 
   // Set the receiveAddress when the buy asset changes

--- a/src/components/MultiHopTrade/hooks/useReceiveAddress.tsx
+++ b/src/components/MultiHopTrade/hooks/useReceiveAddress.tsx
@@ -1,38 +1,25 @@
 import { fromAccountId } from '@shapeshiftoss/caip'
-import { useCallback, useEffect, useMemo, useState } from 'react'
-import { useAccountIds } from 'components/MultiHopTrade/hooks/useAccountIds'
+import { useCallback, useEffect, useState } from 'react'
 import { getReceiveAddress } from 'components/Trade/hooks/useSwapper/utils'
 import { useWallet } from 'hooks/useWallet/useWallet'
 import type { Asset } from 'lib/asset-service'
-import {
-  selectPortfolioAccountIdsByAssetId,
-  selectPortfolioAccountMetadataByAccountId,
-} from 'state/slices/portfolioSlice/selectors'
+import { selectPortfolioAccountMetadataByAccountId } from 'state/slices/portfolioSlice/selectors'
 import { isUtxoAccountId } from 'state/slices/portfolioSlice/utils'
-import { selectBuyAsset, selectSellAsset } from 'state/slices/swappersSlice/selectors'
+import { selectBuyAsset, selectBuyAssetAccountId } from 'state/slices/swappersSlice/selectors'
 import { useAppDispatch, useAppSelector } from 'state/store'
 
 export const useReceiveAddress = () => {
   // Hooks
   const wallet = useWallet().state.wallet
   const dispatch = useAppDispatch()
+  // TODO: this should live in redux
   const [receiveAddress, setReceiveAddress] = useState<string | undefined>(undefined)
 
   // Selectors
   const buyAsset = useAppSelector(selectBuyAsset)
-  const sellAsset = useAppSelector(selectSellAsset)
-  const { buyAssetAccountId } = useAccountIds({ sellAsset, buyAsset })
-  const buyAssetAccountIds = useAppSelector(state =>
-    selectPortfolioAccountIdsByAssetId(state, { assetId: buyAsset?.assetId ?? '' }),
-  )
-
-  const buyAccountFilter = useMemo(
-    () => ({ accountId: buyAssetAccountId ?? buyAssetAccountIds[0] }),
-    [buyAssetAccountId, buyAssetAccountIds],
-  )
-
+  const buyAssetAccountId = useAppSelector(selectBuyAssetAccountId)
   const buyAccountMetadata = useAppSelector(state =>
-    selectPortfolioAccountMetadataByAccountId(state, buyAccountFilter),
+    selectPortfolioAccountMetadataByAccountId(state, { accountId: buyAssetAccountId }),
   )
 
   const getReceiveAddressFromBuyAsset = useCallback(

--- a/src/components/MultiHopTrade/hooks/useSelectedQuoteStatus.tsx
+++ b/src/components/MultiHopTrade/hooks/useSelectedQuoteStatus.tsx
@@ -1,5 +1,4 @@
 import { useMemo } from 'react'
-import { useGetTradeQuotes } from 'components/MultiHopTrade/hooks/useGetTradeQuotes'
 import { useQuoteValidationPredicateObject } from 'components/MultiHopTrade/hooks/useQuoteValidationPredicateObject'
 import type { QuoteStatus } from 'components/MultiHopTrade/types'
 import { SelectedQuoteStatus } from 'components/MultiHopTrade/types'
@@ -7,6 +6,8 @@ import { SwapErrorType } from 'lib/swapper/api'
 import {
   selectFirstHopSellFeeAsset,
   selectLastHopSellFeeAsset,
+  selectSelectedQuote,
+  selectSelectedQuoteError,
 } from 'state/slices/tradeQuoteSlice/selectors'
 import { useAppSelector } from 'state/store'
 
@@ -20,28 +21,25 @@ export const useSelectedQuoteStatus = (): QuoteStatus => {
   const firstHopSellFeeAsset = useAppSelector(selectFirstHopSellFeeAsset)
   const lastHopSellFeeAsset = useAppSelector(selectLastHopSellFeeAsset)
 
-  const { selectedQuote } = useGetTradeQuotes()
-  const quoteData = useMemo(
-    () => (selectedQuote?.data?.isOk() ? selectedQuote.data.unwrap() : undefined),
-    [selectedQuote?.data],
-  )
-  const errorData = useMemo(
-    () => (selectedQuote?.data?.isErr() ? selectedQuote.data.unwrapErr() : undefined),
-    [selectedQuote?.data],
-  )
+  const selectedQuote = useAppSelector(selectSelectedQuote)
+  const selectedQuoteError = useAppSelector(selectSelectedQuoteError)
 
-  const isLoading = useMemo(() => selectedQuote?.isLoading, [selectedQuote?.isLoading])
+  // TODO: implement properly once we've got api loading state rigged up
+  const isLoading = useMemo(
+    () => !selectedQuote && !selectedQuoteError,
+    [selectedQuote, selectedQuoteError],
+  )
 
   const validationErrors: SelectedQuoteStatus[] = useMemo(() => {
     if (isLoading) return []
     const errors: SelectedQuoteStatus[] = []
-    if (errorData) {
+    if (selectedQuoteError) {
       // Map known swapper errors to quote status
-      if (errorData.code === SwapErrorType.UNSUPPORTED_PAIR)
+      if (selectedQuoteError.code === SwapErrorType.UNSUPPORTED_PAIR)
         errors.push(SelectedQuoteStatus.NoQuotesAvailableForTradePair)
       // We didn't recognize the error, use a generic error message
       if (errors.length === 0) errors.push(SelectedQuoteStatus.UnknownError)
-    } else if (quoteData) {
+    } else if (selectedQuote) {
       // We have a quote, but something might be wrong
       if (!hasSufficientSellAssetBalance)
         errors.push(SelectedQuoteStatus.InsufficientSellAssetBalance)
@@ -55,12 +53,12 @@ export const useSelectedQuoteStatus = (): QuoteStatus => {
     }
     return errors
   }, [
-    errorData,
+    selectedQuoteError,
     firstHopHasSufficientBalanceForGas,
     hasSufficientSellAssetBalance,
     isLoading,
     lastHopHasSufficientBalanceForGas,
-    quoteData,
+    selectedQuote,
   ])
 
   const quoteStatusTranslation: QuoteStatus['quoteStatusTranslation'] = useMemo(() => {
@@ -90,6 +88,6 @@ export const useSelectedQuoteStatus = (): QuoteStatus => {
   return {
     validationErrors,
     quoteStatusTranslation,
-    error: errorData,
+    error: selectedQuoteError,
   }
 }

--- a/src/state/slices/portfolioSlice/utils.ts
+++ b/src/state/slices/portfolioSlice/utils.ts
@@ -36,6 +36,7 @@ import {
 } from '@shapeshiftoss/hdwallet-core'
 import type { KnownChainIds } from '@shapeshiftoss/types'
 import cloneDeep from 'lodash/cloneDeep'
+import maxBy from 'lodash/maxBy'
 import { getChainAdapterManager } from 'context/PluginProvider/chainAdapterSingleton'
 import type { BigNumber } from 'lib/bignumber/bignumber'
 import { bn, bnOrZero } from 'lib/bignumber/bignumber'
@@ -303,3 +304,24 @@ export const genericBalanceIncludingStakingByFilter = (
     .reduce((acc, accountBalance) => acc.plus(accountBalance), bn(0))
     .toFixed()
 }
+
+export const getHighestFiatBalanceAccountByAssetId = (
+  accountIdAssetValues: PortfolioAccountBalancesById,
+  assetId?: AssetId,
+): AccountId | undefined => {
+  if (!assetId) return
+  const accountValueMap = Object.entries(accountIdAssetValues).reduce((acc, [k, v]) => {
+    const assetValue = v[assetId]
+    return assetValue ? acc.set(k, assetValue) : acc
+  }, new Map<AccountId, string>())
+  const highestBalanceAccountToAmount = maxBy([...accountValueMap], ([_, v]) =>
+    bnOrZero(v).toNumber(),
+  )
+  return highestBalanceAccountToAmount?.[0]
+}
+
+export const getFirstAccountIdByChainId = (
+  accountIds: AccountId[],
+  chainId: ChainId,
+): AccountId | undefined =>
+  accountIds.filter(accountId => fromAccountId(accountId).chainId === chainId)[0]

--- a/src/state/slices/swappersSlice/selectors.ts
+++ b/src/state/slices/swappersSlice/selectors.ts
@@ -3,6 +3,10 @@ import type { ReduxState } from 'state/reducer'
 import { createDeepEqualOutputSelector } from 'state/selector-utils'
 
 import { selectCryptoMarketData } from '../marketDataSlice/selectors'
+import {
+  selectFirstAccountIdByChainId,
+  selectHighestFiatBalanceAccountByAssetId,
+} from '../portfolioSlice/selectors'
 
 const selectSwappers = (state: ReduxState) => state.swappers
 
@@ -17,8 +21,29 @@ export const selectSellAsset = createDeepEqualOutputSelector(
 )
 
 export const selectSellAssetAccountId = createSelector(
+  (state: ReduxState) => state,
   selectSwappers,
-  swappers => swappers.sellAssetAccountId,
+  selectSellAsset,
+  (state, swappers, sellAsset) => {
+    const highestFiatBalanceSellAccountId = selectHighestFiatBalanceAccountByAssetId(state, {
+      assetId: sellAsset?.assetId,
+    })
+    const firstSellAssetAccountId = selectFirstAccountIdByChainId(state, sellAsset?.chainId ?? '')
+    return swappers.sellAssetAccountId ?? highestFiatBalanceSellAccountId ?? firstSellAssetAccountId
+  },
+)
+
+export const selectBuyAssetAccountId = createSelector(
+  (state: ReduxState) => state,
+  selectSwappers,
+  selectBuyAsset,
+  (state, swappers, buyAsset) => {
+    const highestFiatBalanceBuyAccountId = selectHighestFiatBalanceAccountByAssetId(state, {
+      assetId: buyAsset?.assetId,
+    })
+    const firstBuyAssetAccountId = selectFirstAccountIdByChainId(state, buyAsset?.chainId ?? '')
+    return swappers.buyAssetAccountId ?? highestFiatBalanceBuyAccountId ?? firstBuyAssetAccountId
+  },
 )
 
 export const selectSellAmountCryptoPrecision = createSelector(

--- a/src/state/slices/swappersSlice/selectors.ts
+++ b/src/state/slices/swappersSlice/selectors.ts
@@ -30,6 +30,7 @@ export const selectSellAccountId = createSelector(
   selectPortfolioAssetAccountBalancesSortedFiat,
   selectWalletAccountIds,
   (swappers, sellAsset, accountIdAssetValues, accountIds) => {
+    // return the users selection if it exists
     if (swappers.sellAssetAccountId) return swappers.sellAssetAccountId
 
     const highestFiatBalanceSellAccountId = getHighestFiatBalanceAccountByAssetId(
@@ -38,6 +39,7 @@ export const selectSellAccountId = createSelector(
     )
     const firstSellAssetAccountId = getFirstAccountIdByChainId(accountIds, sellAsset.chainId)
 
+    // otherwise return a sane default
     return highestFiatBalanceSellAccountId ?? firstSellAssetAccountId
   },
 )
@@ -50,6 +52,7 @@ export const selectBuyAccountId = createSelector(
   selectPortfolioAssetAccountBalancesSortedFiat,
   selectWalletAccountIds,
   (swappers, buyAsset, accountIdAssetValues, accountIds) => {
+    // return the users selection if it exists
     if (swappers.buyAssetAccountId) return swappers.buyAssetAccountId
 
     const highestFiatBalanceBuyAccountId = getHighestFiatBalanceAccountByAssetId(
@@ -58,6 +61,7 @@ export const selectBuyAccountId = createSelector(
     )
     const firstBuyAssetAccountId = getFirstAccountIdByChainId(accountIds, buyAsset.chainId)
 
+    // otherwise return a sane default
     return highestFiatBalanceBuyAccountId ?? firstBuyAssetAccountId
   },
 )

--- a/src/state/slices/swappersSlice/swappersSlice.ts
+++ b/src/state/slices/swappersSlice/swappersSlice.ts
@@ -1,7 +1,7 @@
 import type { PayloadAction } from '@reduxjs/toolkit'
 import { createSlice } from '@reduxjs/toolkit'
 import type { AccountId } from '@shapeshiftoss/caip'
-import { ethAssetId, foxAssetId } from '@shapeshiftoss/caip'
+import { ethAssetId, foxAssetId, fromAccountId } from '@shapeshiftoss/caip'
 import type { Asset } from 'lib/asset-service'
 import { localAssetData } from 'lib/asset-service'
 import { bnOrZero } from 'lib/bignumber/bignumber'
@@ -13,6 +13,7 @@ export type SwappersState = {
   buyAsset: Asset
   sellAsset: Asset
   sellAssetAccountId: AccountId | undefined
+  buyAssetAccountId: AccountId | undefined
   sellAmountCryptoPrecision: string
   tradeExecutionStatus: MultiHopExecutionStatus
 }
@@ -22,6 +23,7 @@ const initialState: SwappersState = {
   buyAsset: localAssetData[foxAssetId] ?? defaultAsset,
   sellAsset: localAssetData[ethAssetId] ?? defaultAsset,
   sellAssetAccountId: undefined,
+  buyAssetAccountId: undefined,
   sellAmountCryptoPrecision: '0',
   tradeExecutionStatus: MultiHopExecutionStatus.Hop1AwaitingApprovalConfirmation,
 }
@@ -34,12 +36,33 @@ export const swappers = createSlice({
     clear: () => initialState,
     setBuyAsset: (state, action: PayloadAction<Asset>) => {
       state.buyAsset = action.payload
+
+      const buyAssetChainId = state.buyAsset.chainId
+      const buyAssetAccountChainId = state.buyAssetAccountId
+        ? fromAccountId(state.buyAssetAccountId).chainId
+        : undefined
+
+      // reset user selection on mismatch
+      if (state.buyAssetAccountId && buyAssetChainId !== buyAssetAccountChainId)
+        state.buyAssetAccountId = undefined
     },
     setSellAsset: (state, action: PayloadAction<Asset>) => {
       state.sellAsset = action.payload
+
+      const sellAssetChainId = state.sellAsset.chainId
+      const sellAssetAccountChainId = state.sellAssetAccountId
+        ? fromAccountId(state.sellAssetAccountId).chainId
+        : undefined
+
+      // reset user selection on mismatch
+      if (state.sellAssetAccountId && sellAssetChainId !== sellAssetAccountChainId)
+        state.sellAssetAccountId = undefined
     },
     setSellAssetAccountId: (state, action: PayloadAction<AccountId | undefined>) => {
       state.sellAssetAccountId = action.payload
+    },
+    setBuyAssetAccountId: (state, action: PayloadAction<AccountId | undefined>) => {
+      state.buyAssetAccountId = action.payload
     },
     setSellAmountCryptoPrecision: (state, action: PayloadAction<string>) => {
       // dedupe 0, 0., 0.0, 0.00 etc

--- a/src/state/slices/tradeQuoteSlice/helpers.ts
+++ b/src/state/slices/tradeQuoteSlice/helpers.ts
@@ -4,7 +4,9 @@ import type { Asset } from 'lib/asset-service'
 import type { BigNumber } from 'lib/bignumber/bignumber'
 import { bn, bnOrZero } from 'lib/bignumber/bignumber'
 import { fromBaseUnit } from 'lib/math'
-import type { ProtocolFee, SwapperName, TradeQuote } from 'lib/swapper/api'
+import type { ProtocolFee, TradeQuote } from 'lib/swapper/api'
+import { SwapperName } from 'lib/swapper/api'
+import { assertUnreachable } from 'lib/utils'
 import { selectFeeAssetById } from 'state/slices/assetsSlice/selectors'
 import {
   selectCryptoMarketData,
@@ -272,3 +274,22 @@ export const getTotalProtocolFeeByAsset = (quote: TradeQuote): Record<AssetId, P
       acc,
     )
   }, {})
+
+export const isCrossAccountTradeSupported = (swapperName: SwapperName) => {
+  switch (swapperName) {
+    case SwapperName.Thorchain:
+    case SwapperName.Osmosis:
+      return true
+    // NOTE: Before enabling cross-account for LIFI and OneInch - we must pass the sending address
+    // to the swappers up so allowance checks work. They're currently using the receive address
+    // assuming it's the same address as the sending address.
+    case SwapperName.LIFI:
+    case SwapperName.OneInch:
+    case SwapperName.Zrx:
+    case SwapperName.CowSwap:
+    case SwapperName.Test:
+      return false
+    default:
+      assertUnreachable(swapperName)
+  }
+}

--- a/src/state/slices/tradeQuoteSlice/tradeQuoteSlice.ts
+++ b/src/state/slices/tradeQuoteSlice/tradeQuoteSlice.ts
@@ -1,10 +1,10 @@
 import type { PayloadAction } from '@reduxjs/toolkit'
 import { createSlice } from '@reduxjs/toolkit'
-import type { SwapErrorRight, SwapperName, TradeQuote } from 'lib/swapper/api'
+import type { SwapErrorRight, SwapperName, TradeQuote2 } from 'lib/swapper/api'
 
 export type TradeQuoteSliceState = {
   swapperName: SwapperName | undefined
-  quote: TradeQuote | undefined
+  quote: TradeQuote2 | undefined
   error: SwapErrorRight | undefined
 }
 
@@ -22,7 +22,7 @@ export const tradeQuoteSlice = createSlice({
     setSwapperName: (state, action: PayloadAction<SwapperName | undefined>) => {
       state.swapperName = action.payload
     },
-    setQuote: (state, action: PayloadAction<TradeQuote | undefined>) => {
+    setQuote: (state, action: PayloadAction<TradeQuote2 | undefined>) => {
       state.quote = action.payload
     },
     setError: (state, action: PayloadAction<SwapErrorRight | undefined>) => {

--- a/src/test/mocks/store.ts
+++ b/src/test/mocks/store.ts
@@ -166,6 +166,7 @@ export const mockStore: ReduxState = {
     buyAsset: defaultAsset,
     sellAsset: defaultAsset,
     sellAssetAccountId: undefined,
+    buyAssetAccountId: undefined,
     sellAmountCryptoPrecision: '0',
     tradeExecutionStatus: MultiHopExecutionStatus.Unknown,
   },


### PR DESCRIPTION
## Description

<!-- Please describe your changes -->
Fixes broken trade quotes in the new exchange client UI. Root cause of issue was circular dependency between the following:
- account ids
- receive address
- trade quotes

Account ids are moved into redux with high-risk logic contained in actions, with defaults contained in selectors. Zero logic relating to account ids in hooks.

Removed duplicate calls to fetch trade quotes.

## Pull Request Type

- [x] :bug: Bug fix (Non-breaking Change: Fixes an issue)
- [ ] :hammer_and_wrench: Chore (Non-breaking Change: Doc updates, pkg upgrades, typos, etc..)
- [ ] :nail_care: New Feature (Breaking/Non-breaking Change)

## Issue (if applicable)

<!-----------------------------------------------------------------------------
If applicable, please link to the github issue and put `closes #XXXX` in your comment to auto-close the issue that your PR fixes.
------------------------------------------------------------------------------>

NA

## Risk

Not user facing -> zero risk

BUT @engineers please review account ID logic and overall approach as this will need to be fit for purpose at a high level.

<!-----------------------------------------------------------------------------
Outline the scope of your changes and the risk associated with them. You must use your discretion as an engineer to determine the potential impact of your changes.

E.g. an upgrade to `hdwallet` or core state management would be considered higher risk, and might require a full regression test. UI or isolated view changes, or something behind a feature flag may have near zero risk. Small bug fixes might require testing isolated to the specific fix.
------------------------------------------------------------------------------>

## Testing

Trade quotes fetch with multi-hop flag enabled.

<!-----------------------------------------------------------------------------
We treat every PR to be merged with the same scrutiny as if we were merging directly to production.

Your PR will not be merged if you do not complete the sections below for our engineering and operations teams to test.
------------------------------------------------------------------------------>

### Engineering

See above, RE account ID logic.

<!-----------------------------------------------------------------------------
Include sufficient information here for an engineer to test your PR. This may include how to test locally, in a built environment, changes to infrastructure etc.
------------------------------------------------------------------------------>

### Operations

No action required.

<!-----------------------------------------------------------------------------
If your changes have a user-facing impact, describe how a non-technical QA team can functionally test your changes in a preview environment.

If they are not user-facing please describe how to test for any regressions that may occur.
------------------------------------------------------------------------------>

## Screenshots (if applicable)
