### PR TITLE
refactor: separate swapper api methods

### DIFF
--- a/src/components/MultiHopTrade/hooks/useTradeExecution/useTradeExecution.ts
+++ b/src/components/MultiHopTrade/hooks/useTradeExecution/useTradeExecution.ts
@@ -4,9 +4,11 @@ import { useCallback, useState } from 'react'
 import { getChainAdapterManager } from 'context/PluginProvider/chainAdapterSingleton'
 import { usePoll } from 'hooks/usePoll/usePoll'
 import { useWallet } from 'hooks/useWallet/useWallet'
-import type { Swapper2, TradeQuote2 } from 'lib/swapper/api'
+import type { Swapper2, Swapper2Api, TradeQuote2 } from 'lib/swapper/api'
 import { SwapperName } from 'lib/swapper/api'
+import { lifiApi } from 'lib/swapper/swappers/LifiSwapper/endpoints'
 import { lifi as lifiSwapper } from 'lib/swapper/swappers/LifiSwapper/LifiSwapper2'
+import { thorchainApi } from 'lib/swapper/swappers/ThorchainSwapper/endpoints'
 import { thorchain as thorchainSwapper } from 'lib/swapper/swappers/ThorchainSwapper/ThorchainSwapper2'
 import { assertUnreachable, isEvmChainAdapter } from 'lib/utils'
 import { selectPortfolioAccountMetadataByAccountId } from 'state/slices/selectors'
@@ -42,12 +44,12 @@ export const useTradeExecution = ({
     if (!tradeQuote) throw Error('missing tradeQuote')
     if (!swapperName) throw Error('missing swapperName')
 
-    const swapper: Swapper2 = (() => {
+    const swapper: Swapper2 & Swapper2Api = (() => {
       switch (swapperName) {
         case SwapperName.LIFI:
-          return lifiSwapper
+          return { ...lifiSwapper, ...lifiApi }
         case SwapperName.Thorchain:
-          return thorchainSwapper
+          return { ...thorchainSwapper, ...thorchainApi }
         case SwapperName.Zrx:
         case SwapperName.CowSwap:
         case SwapperName.Osmosis:

--- a/src/lib/swapper/api.ts
+++ b/src/lib/swapper/api.ts
@@ -303,15 +303,18 @@ export type ExecuteTradeArgs = {
 }
 
 export type Swapper2 = {
+  filterAssetIdsBySellable: (assetIds: AssetId[]) => AssetId[]
+  filterBuyAssetsBySellAssetId: (input: BuyAssetBySellIdInput) => AssetId[]
+  executeTrade: (executeTradeArgs: ExecuteTradeArgs) => Promise<string>
+}
+
+export type Swapper2Api = {
+  checkTradeStatus: (
+    tradeId: string,
+  ) => Promise<{ status: TxStatus; buyTxId: string | undefined; message: string | undefined }>
   getTradeQuote: (
     input: GetTradeQuoteInput,
     ...deps: any[]
   ) => Promise<Result<TradeQuote2, SwapErrorRight>>
   getUnsignedTx(input: GetUnsignedTxArgs): Promise<UnsignedTx>
-  executeTrade: (executeTradeArgs: ExecuteTradeArgs) => Promise<string>
-  checkTradeStatus: (
-    tradeId: string,
-  ) => Promise<{ status: TxStatus; buyTxId: string | undefined; message: string | undefined }>
-  filterAssetIdsBySellable: (assetIds: AssetId[]) => AssetId[]
-  filterBuyAssetsBySellAssetId: (input: BuyAssetBySellIdInput) => AssetId[]
 }

--- a/src/lib/swapper/swappers/LifiSwapper/LifiSwapper2.ts
+++ b/src/lib/swapper/swappers/LifiSwapper/LifiSwapper2.ts
@@ -1,122 +1,19 @@
-import type { ChainKey, GetStatusRequest, Route } from '@lifi/sdk/dist/types'
-import type { AssetId, ChainId } from '@shapeshiftoss/caip'
+import type { AssetId } from '@shapeshiftoss/caip'
 import type { EvmChainAdapter } from '@shapeshiftoss/chain-adapters'
 import type { ETHSignTx } from '@shapeshiftoss/hdwallet-core'
-import { TxStatus } from '@shapeshiftoss/unchained-client'
-import type { Result } from '@sniptt/monads/build'
-import { Err } from '@sniptt/monads/build'
 import { getChainAdapterManager } from 'context/PluginProvider/chainAdapterSingleton'
-import type { Asset } from 'lib/asset-service'
-import type {
-  BuyAssetBySellIdInput,
-  ExecuteTradeArgs,
-  GetEvmTradeQuoteInput,
-  GetTradeQuoteInput,
-  GetUnsignedTxArgs,
-  SwapErrorRight,
-  Swapper2,
-  TradeQuote2,
-} from 'lib/swapper/api'
-import { getLifi } from 'lib/swapper/swappers/LifiSwapper/utils/getLifi'
+import type { BuyAssetBySellIdInput, ExecuteTradeArgs, Swapper2 } from 'lib/swapper/api'
 import { signAndBroadcast } from 'lib/utils/evm'
 
 import { filterEvmAssetIdsBySellable } from '../utils/filterAssetIdsBySellable/filterAssetIdsBySellable'
 import { filterCrossChainEvmBuyAssetsBySellAssetId } from '../utils/filterBuyAssetsBySellAssetId/filterBuyAssetsBySellAssetId'
-import { getTradeQuote } from './getTradeQuote/getTradeQuote'
-import { getLifiChainMap } from './utils/getLifiChainMap'
-import { getUnsignedTx } from './utils/getUnsignedTx/getUnsignedTx'
-
-const executedTrades: Map<string, GetStatusRequest> = new Map()
-const tradeQuoteMetadata: Map<string, Route> = new Map()
-
-let lifiChainMapPromise: Promise<Result<Map<ChainId, ChainKey>, SwapErrorRight>> | undefined
 
 export const lifi: Swapper2 = {
-  getTradeQuote: async (
-    input: GetTradeQuoteInput,
-    assets: Partial<Record<AssetId, Asset>>,
-    sellAssetPriceUsdPrecision: string,
-  ): Promise<Result<TradeQuote2, SwapErrorRight>> => {
-    if (lifiChainMapPromise === undefined) lifiChainMapPromise = getLifiChainMap()
-
-    const maybeLifiChainMap = await lifiChainMapPromise
-
-    if (maybeLifiChainMap.isErr()) return Err(maybeLifiChainMap.unwrapErr())
-
-    const tradeQuoteResult = await getTradeQuote(
-      input as GetEvmTradeQuoteInput,
-      maybeLifiChainMap.unwrap(),
-      assets,
-      sellAssetPriceUsdPrecision,
-    )
-
-    return tradeQuoteResult.map(({ selectedLifiRoute, ...tradeQuote }) => {
-      const { receiveAddress, affiliateBps } = input
-
-      // TODO: quotes below the minimum arent valid and should not be processed as such
-      // selectedLifiRoute willbe missing for quotes below the minimum
-      if (!selectedLifiRoute) throw Error('missing selectedLifiRoute')
-
-      const id = selectedLifiRoute.id
-
-      // store the lifi quote metadata for transaction building later
-      tradeQuoteMetadata.set(id, selectedLifiRoute)
-
-      return { id, receiveAddress, affiliateBps, ...tradeQuote }
-    })
-  },
-
-  getUnsignedTx: async ({ from, tradeQuote, stepIndex }: GetUnsignedTxArgs): Promise<ETHSignTx> => {
-    const lifiRoute = tradeQuoteMetadata.get(tradeQuote.id)
-
-    if (!lifiRoute) throw Error('missing trade quote metadata')
-
-    const { accountNumber, sellAsset } = tradeQuote.steps[stepIndex]
-
-    const unsignedTx = await getUnsignedTx({
-      lifiStep: lifiRoute.steps[stepIndex],
-      accountNumber,
-      sellAsset,
-      // discriminated union between from or xpub in GetUnsignedTxArgs, but since Li.Fi only deals with EVMs, from is always going to be defined
-      from: from!,
-    })
-
-    return unsignedTx
-  },
-
   executeTrade: ({ txToSign, wallet, chainId }: ExecuteTradeArgs) => {
     const adapterManager = getChainAdapterManager()
     const adapter = adapterManager.get(chainId) as unknown as EvmChainAdapter
 
     return signAndBroadcast({ adapter, wallet, txToSign: txToSign as ETHSignTx })
-  },
-
-  checkTradeStatus: async (
-    tradeId: string,
-  ): Promise<{ status: TxStatus; buyTxId: string | undefined; message: string | undefined }> => {
-    const getStatusRequest = executedTrades.get(tradeId)
-    if (getStatusRequest === undefined)
-      throw Error(`missing getStatusRequest for tradeId ${tradeId}`)
-    const statusResponse = await getLifi().getStatus(getStatusRequest)
-
-    const status = (() => {
-      switch (statusResponse.status) {
-        case 'DONE':
-          return TxStatus.Confirmed
-        case 'PENDING':
-          return TxStatus.Pending
-        case 'FAILED':
-          return TxStatus.Failed
-        default:
-          return TxStatus.Unknown
-      }
-    })()
-
-    return {
-      status,
-      buyTxId: statusResponse.receiving?.txHash,
-      message: statusResponse.substatusMessage,
-    }
   },
 
   filterAssetIdsBySellable: (assetIds: AssetId[]): AssetId[] => {

--- a/src/lib/swapper/swappers/LifiSwapper/endpoints.ts
+++ b/src/lib/swapper/swappers/LifiSwapper/endpoints.ts
@@ -1,0 +1,107 @@
+import type { ChainKey, GetStatusRequest, Route } from '@lifi/sdk/dist/types'
+import type { AssetId, ChainId } from '@shapeshiftoss/caip'
+import type { ETHSignTx } from '@shapeshiftoss/hdwallet-core'
+import { TxStatus } from '@shapeshiftoss/unchained-client'
+import type { Result } from '@sniptt/monads/build'
+import { Err } from '@sniptt/monads/build'
+import type { Asset } from 'lib/asset-service'
+import type {
+  GetEvmTradeQuoteInput,
+  GetTradeQuoteInput,
+  GetUnsignedTxArgs,
+  SwapErrorRight,
+  Swapper2Api,
+  TradeQuote2,
+} from 'lib/swapper/api'
+import { getLifi } from 'lib/swapper/swappers/LifiSwapper/utils/getLifi'
+
+import { getTradeQuote } from './getTradeQuote/getTradeQuote'
+import { getLifiChainMap } from './utils/getLifiChainMap'
+import { getUnsignedTx } from './utils/getUnsignedTx/getUnsignedTx'
+
+const executedTrades: Map<string, GetStatusRequest> = new Map()
+const tradeQuoteMetadata: Map<string, Route> = new Map()
+
+let lifiChainMapPromise: Promise<Result<Map<ChainId, ChainKey>, SwapErrorRight>> | undefined
+
+export const lifiApi: Swapper2Api = {
+  getTradeQuote: async (
+    input: GetTradeQuoteInput,
+    assets: Partial<Record<AssetId, Asset>>,
+    sellAssetPriceUsdPrecision: string,
+  ): Promise<Result<TradeQuote2, SwapErrorRight>> => {
+    if (lifiChainMapPromise === undefined) lifiChainMapPromise = getLifiChainMap()
+
+    const maybeLifiChainMap = await lifiChainMapPromise
+
+    if (maybeLifiChainMap.isErr()) return Err(maybeLifiChainMap.unwrapErr())
+
+    const tradeQuoteResult = await getTradeQuote(
+      input as GetEvmTradeQuoteInput,
+      maybeLifiChainMap.unwrap(),
+      assets,
+      sellAssetPriceUsdPrecision,
+    )
+
+    return tradeQuoteResult.map(({ selectedLifiRoute, ...tradeQuote }) => {
+      const { receiveAddress, affiliateBps } = input
+
+      // TODO: quotes below the minimum arent valid and should not be processed as such
+      // selectedLifiRoute willbe missing for quotes below the minimum
+      if (!selectedLifiRoute) throw Error('missing selectedLifiRoute')
+
+      const id = selectedLifiRoute.id
+
+      // store the lifi quote metadata for transaction building later
+      tradeQuoteMetadata.set(id, selectedLifiRoute)
+
+      return { id, receiveAddress, affiliateBps, ...tradeQuote }
+    })
+  },
+
+  getUnsignedTx: async ({ from, tradeQuote, stepIndex }: GetUnsignedTxArgs): Promise<ETHSignTx> => {
+    const lifiRoute = tradeQuoteMetadata.get(tradeQuote.id)
+
+    if (!lifiRoute) throw Error('missing trade quote metadata')
+
+    const { accountNumber, sellAsset } = tradeQuote.steps[stepIndex]
+
+    const unsignedTx = await getUnsignedTx({
+      lifiStep: lifiRoute.steps[stepIndex],
+      accountNumber,
+      sellAsset,
+      // discriminated union between from or xpub in GetUnsignedTxArgs, but since Li.Fi only deals with EVMs, from is always going to be defined
+      from: from!,
+    })
+
+    return unsignedTx
+  },
+
+  checkTradeStatus: async (
+    tradeId: string,
+  ): Promise<{ status: TxStatus; buyTxId: string | undefined; message: string | undefined }> => {
+    const getStatusRequest = executedTrades.get(tradeId)
+    if (getStatusRequest === undefined)
+      throw Error(`missing getStatusRequest for tradeId ${tradeId}`)
+    const statusResponse = await getLifi().getStatus(getStatusRequest)
+
+    const status = (() => {
+      switch (statusResponse.status) {
+        case 'DONE':
+          return TxStatus.Confirmed
+        case 'PENDING':
+          return TxStatus.Pending
+        case 'FAILED':
+          return TxStatus.Failed
+        default:
+          return TxStatus.Unknown
+      }
+    })()
+
+    return {
+      status,
+      buyTxId: statusResponse.receiving?.txHash,
+      message: statusResponse.substatusMessage,
+    }
+  },
+}

--- a/src/lib/swapper/swappers/ThorchainSwapper/ThorchainSwapper2.ts
+++ b/src/lib/swapper/swappers/ThorchainSwapper/ThorchainSwapper2.ts
@@ -9,88 +9,13 @@ import type {
   UtxoChainId,
 } from '@shapeshiftoss/chain-adapters'
 import type { ThorchainSignTx } from '@shapeshiftoss/hdwallet-core'
-import { TxStatus } from '@shapeshiftoss/unchained-client'
-import type { Result } from '@sniptt/monads/build'
 import { getChainAdapterManager } from 'context/PluginProvider/chainAdapterSingleton'
-import type {
-  BuyAssetBySellIdInput,
-  ExecuteTradeArgs,
-  GetTradeQuoteInput,
-  SwapErrorRight,
-  Swapper2,
-  TradeQuote,
-  TradeQuote2,
-  UnsignedTx,
-} from 'lib/swapper/api'
+import type { BuyAssetBySellIdInput, ExecuteTradeArgs, Swapper2 } from 'lib/swapper/api'
 import { assertUnreachable, evm } from 'lib/utils'
-import { selectFeeAssetById, selectUsdRateByAssetId } from 'state/slices/selectors'
-import { store } from 'state/store'
 
-import { getThorTradeQuote } from './getThorTradeQuote/getTradeQuote'
-import type { Rates, ThorUtxoSupportedChainId } from './ThorchainSwapper'
 import { ThorchainSwapper } from './ThorchainSwapper'
-import { getSignTxFromQuote } from './utils/getSignTxFromQuote'
 
 export const thorchain: Swapper2 = {
-  getTradeQuote: async (
-    input: GetTradeQuoteInput,
-    rates: Rates,
-  ): Promise<Result<TradeQuote2, SwapErrorRight>> => {
-    const tradeQuoteResult = await getThorTradeQuote(input, rates)
-
-    return tradeQuoteResult.map(tradeQuote => {
-      const { receiveAddress, affiliateBps } = input
-      const id = String(Date.now()) // TODO: get thorchain quote ID or use uuid
-
-      return { id, receiveAddress, affiliateBps, ...tradeQuote }
-    })
-  },
-
-  getUnsignedTx: async ({
-    accountMetadata,
-    tradeQuote,
-    from,
-    xpub,
-    supportsEIP1559,
-  }): Promise<UnsignedTx> => {
-    const { receiveAddress, affiliateBps } = tradeQuote
-    const feeAsset = selectFeeAssetById(store.getState(), tradeQuote.steps[0].sellAsset.assetId)
-    const buyAssetUsdRate = selectUsdRateByAssetId(
-      store.getState(),
-      tradeQuote.steps[0].buyAsset.assetId,
-    )
-    const feeAssetUsdRate = feeAsset
-      ? selectUsdRateByAssetId(store.getState(), feeAsset.assetId)
-      : undefined
-
-    if (!buyAssetUsdRate) throw Error('missing buy asset usd rate')
-    if (!feeAssetUsdRate) throw Error('missing fee asset usd rate')
-
-    const accountType = accountMetadata?.accountType
-
-    const chainSpecific =
-      accountType && xpub
-        ? {
-            xpub,
-            accountType,
-            satoshiPerByte: (tradeQuote as TradeQuote<ThorUtxoSupportedChainId>).steps[0].feeData
-              .chainSpecific.satsPerByte,
-          }
-        : undefined
-
-    const fromOrXpub = from !== undefined ? { from } : { xpub }
-    return await getSignTxFromQuote({
-      tradeQuote,
-      receiveAddress,
-      affiliateBps,
-      chainSpecific,
-      buyAssetUsdRate,
-      ...fromOrXpub,
-      feeAssetUsdRate,
-      supportsEIP1559,
-    })
-  },
-
   executeTrade: async ({ txToSign, wallet, chainId }: ExecuteTradeArgs): Promise<string> => {
     const { chainNamespace } = fromChainId(chainId)
     const chainAdapterManager = getChainAdapterManager()
@@ -126,32 +51,6 @@ export const thorchain: Swapper2 = {
 
       default:
         assertUnreachable(chainNamespace)
-    }
-  },
-
-  checkTradeStatus: async (
-    tradeId: string,
-  ): Promise<{ status: TxStatus; buyTxId: string | undefined; message: string | undefined }> => {
-    const thorchainSwapper = new ThorchainSwapper()
-    const txsResult = await thorchainSwapper.getTradeTxs({ tradeId })
-
-    const status = (() => {
-      switch (true) {
-        case txsResult.isOk() && !!txsResult.unwrap().buyTxid:
-          return TxStatus.Confirmed
-        case txsResult.isOk() && !txsResult.unwrap().buyTxid:
-          return TxStatus.Pending
-        case txsResult.isErr():
-          return TxStatus.Failed
-        default:
-          return TxStatus.Unknown
-      }
-    })()
-
-    return {
-      buyTxId: txsResult.isOk() ? txsResult.unwrap().buyTxid : undefined,
-      status,
-      message: undefined,
     }
   },
 

--- a/src/lib/swapper/swappers/ThorchainSwapper/endpoints.ts
+++ b/src/lib/swapper/swappers/ThorchainSwapper/endpoints.ts
@@ -1,0 +1,104 @@
+import { TxStatus } from '@shapeshiftoss/unchained-client'
+import type { Result } from '@sniptt/monads/build'
+import type {
+  GetTradeQuoteInput,
+  SwapErrorRight,
+  Swapper2Api,
+  TradeQuote,
+  TradeQuote2,
+  UnsignedTx,
+} from 'lib/swapper/api'
+import { selectFeeAssetById, selectUsdRateByAssetId } from 'state/slices/selectors'
+import { store } from 'state/store'
+
+import { getThorTradeQuote } from './getThorTradeQuote/getTradeQuote'
+import type { Rates, ThorUtxoSupportedChainId } from './ThorchainSwapper'
+import { ThorchainSwapper } from './ThorchainSwapper'
+import { getSignTxFromQuote } from './utils/getSignTxFromQuote'
+
+export const thorchainApi: Swapper2Api = {
+  getTradeQuote: async (
+    input: GetTradeQuoteInput,
+    rates: Rates,
+  ): Promise<Result<TradeQuote2, SwapErrorRight>> => {
+    const tradeQuoteResult = await getThorTradeQuote(input, rates)
+
+    return tradeQuoteResult.map(tradeQuote => {
+      const { receiveAddress, affiliateBps } = input
+      const id = String(Date.now()) // TODO: get thorchain quote ID or use uuid
+
+      return { id, receiveAddress, affiliateBps, ...tradeQuote }
+    })
+  },
+
+  getUnsignedTx: async ({
+    accountMetadata,
+    tradeQuote,
+    from,
+    xpub,
+    supportsEIP1559,
+  }): Promise<UnsignedTx> => {
+    const { receiveAddress, affiliateBps } = tradeQuote
+    const feeAsset = selectFeeAssetById(store.getState(), tradeQuote.steps[0].sellAsset.assetId)
+    const buyAssetUsdRate = selectUsdRateByAssetId(
+      store.getState(),
+      tradeQuote.steps[0].buyAsset.assetId,
+    )
+    const feeAssetUsdRate = feeAsset
+      ? selectUsdRateByAssetId(store.getState(), feeAsset.assetId)
+      : undefined
+
+    if (!buyAssetUsdRate) throw Error('missing buy asset usd rate')
+    if (!feeAssetUsdRate) throw Error('missing fee asset usd rate')
+
+    const accountType = accountMetadata?.accountType
+
+    const chainSpecific =
+      accountType && xpub
+        ? {
+            xpub,
+            accountType,
+            satoshiPerByte: (tradeQuote as TradeQuote<ThorUtxoSupportedChainId>).steps[0].feeData
+              .chainSpecific.satsPerByte,
+          }
+        : undefined
+
+    const fromOrXpub = from !== undefined ? { from } : { xpub }
+    return await getSignTxFromQuote({
+      tradeQuote,
+      receiveAddress,
+      affiliateBps,
+      chainSpecific,
+      buyAssetUsdRate,
+      ...fromOrXpub,
+      feeAssetUsdRate,
+      supportsEIP1559,
+    })
+  },
+
+  checkTradeStatus: async (
+    tradeId: string,
+  ): Promise<{ status: TxStatus; buyTxId: string | undefined; message: string | undefined }> => {
+    const thorchainSwapper = new ThorchainSwapper()
+    const txsResult = await thorchainSwapper.getTradeTxs({ tradeId })
+
+    const status = (() => {
+      switch (true) {
+        case txsResult.isOk() && !!txsResult.unwrap().buyTxid:
+          return TxStatus.Confirmed
+        case txsResult.isOk() && !txsResult.unwrap().buyTxid:
+          return TxStatus.Pending
+        case txsResult.isErr():
+          return TxStatus.Failed
+        default:
+          return TxStatus.Unknown
+      }
+    })()
+
+    return {
+      buyTxId: txsResult.isOk() ? txsResult.unwrap().buyTxid : undefined,
+      status,
+      message: undefined,
+    }
+  },
+}

--- a/src/state/apis/swappers/lifiSwapperApi.ts
+++ b/src/state/apis/swappers/lifiSwapperApi.ts
@@ -7,7 +7,7 @@ import type {
   SwapErrorRight,
   TradeQuote2,
 } from 'lib/swapper/api'
-import { lifi } from 'lib/swapper/swappers/LifiSwapper/LifiSwapper2'
+import { lifiApi } from 'lib/swapper/swappers/LifiSwapper/endpoints'
 import type { ReduxState } from 'state/reducer'
 import { selectAssets } from 'state/slices/assetsSlice/selectors'
 import { selectUsdRateByAssetId } from 'state/slices/marketDataSlice/selectors'
@@ -25,7 +25,7 @@ export const lifiSwapperApi = swappersApi.injectEndpoints({
           return {
             error: `no market data available for assetId ${getTradeQuoteInput.sellAsset.assetId}`,
           }
-        const maybeQuote = await lifi.getTradeQuote(getTradeQuoteInput, assets, sellAssetUsdRate)
+        const maybeQuote = await lifiApi.getTradeQuote(getTradeQuoteInput, assets, sellAssetUsdRate)
         return { data: maybeQuote }
       },
     }),

--- a/src/state/apis/swappers/thorSwapperApi.ts
+++ b/src/state/apis/swappers/thorSwapperApi.ts
@@ -1,6 +1,6 @@
 import type { Result } from '@sniptt/monads/build'
 import type { GetTradeQuoteInput, SwapErrorRight, TradeQuote2 } from 'lib/swapper/api'
-import { thorchain } from 'lib/swapper/swappers/ThorchainSwapper/ThorchainSwapper2'
+import { thorchainApi } from 'lib/swapper/swappers/ThorchainSwapper/endpoints'
 import type { ReduxState } from 'state/reducer'
 import { selectFeeAssetById } from 'state/slices/assetsSlice/selectors'
 import { selectUsdRateByAssetId } from 'state/slices/marketDataSlice/selectors'
@@ -35,7 +35,7 @@ export const thorSwapperApi = swappersApi.injectEndpoints({
             error: `no usd rate available for assetId ${feeAsset?.assetId}`,
           }
 
-        const maybeQuote = await thorchain.getTradeQuote(getTradeQuoteInput, {
+        const maybeQuote = await thorchainApi.getTradeQuote(getTradeQuoteInput, {
           sellAssetUsdRate,
           buyAssetUsdRate,
           feeAssetUsdRate,


### PR DESCRIPTION
## Description

Separate swapper API methods to avoid the otherwise impending circular dependancies we'll get when we move these into a single RTK endpoint for API consolidation and end-state representation.

## Pull Request Type

- [ ] :bug: Bug fix (Non-breaking Change: Fixes an issue)
- [x] :hammer_and_wrench: Chore (Non-breaking Change: Doc updates, pkg upgrades, typos, etc..)
- [ ] :nail_care: New Feature (Breaking/Non-breaking Change)

## Issue (if applicable)

N/A

## Risk

Small - no logic changes, and all changes are behind a flag.

## Testing

Swapper behind flag should still get quotes.

### Engineering

☝️

### Operations

☝️

## Screenshots (if applicable)

N/A