### PR TITLE
fix: thorchain transaction status polling for exchange client

### DIFF
--- a/package.json
+++ b/package.json
@@ -188,6 +188,7 @@
     "stream-browserify": "^3.0.0",
     "stream-http": "^3.2.0",
     "styled-components": "^5.3.6",
+    "uuid": "^9.0.0",
     "viem": "^0.3.3",
     "web-vitals": "^2.1.4",
     "web3": "1.7.4",

--- a/src/components/MultiHopTrade/hooks/useTradeExecution/useTradeExecution.ts
+++ b/src/components/MultiHopTrade/hooks/useTradeExecution/useTradeExecution.ts
@@ -99,7 +99,10 @@ export const useTradeExecution = ({
 
     await poll({
       fn: async () => {
-        const { status, message, buyTxId } = await swapper.checkTradeStatus(tradeQuote.id)
+        const { status, message, buyTxId } = await swapper.checkTradeStatus({
+          tradeId: tradeQuote.id,
+          txId: sellTxId,
+        })
 
         setMessage(message)
         setBuyTxId(buyTxId)

--- a/src/lib/swapper/api.ts
+++ b/src/lib/swapper/api.ts
@@ -302,6 +302,11 @@ export type ExecuteTradeArgs = {
   chainId: ChainId
 }
 
+export type CheckTradeStatusInput = {
+  tradeId: string
+  txId: string
+}
+
 export type Swapper2 = {
   filterAssetIdsBySellable: (assetIds: AssetId[]) => AssetId[]
   filterBuyAssetsBySellAssetId: (input: BuyAssetBySellIdInput) => AssetId[]
@@ -310,7 +315,7 @@ export type Swapper2 = {
 
 export type Swapper2Api = {
   checkTradeStatus: (
-    tradeId: string,
+    input: CheckTradeStatusInput,
   ) => Promise<{ status: TxStatus; buyTxId: string | undefined; message: string | undefined }>
   getTradeQuote: (
     input: GetTradeQuoteInput,

--- a/src/lib/swapper/swappers/LifiSwapper/endpoints.ts
+++ b/src/lib/swapper/swappers/LifiSwapper/endpoints.ts
@@ -77,9 +77,9 @@ export const lifiApi: Swapper2Api = {
     return unsignedTx
   },
 
-  checkTradeStatus: async (
-    tradeId: string,
-  ): Promise<{ status: TxStatus; buyTxId: string | undefined; message: string | undefined }> => {
+  checkTradeStatus: async ({
+    tradeId,
+  }): Promise<{ status: TxStatus; buyTxId: string | undefined; message: string | undefined }> => {
     const getStatusRequest = executedTrades.get(tradeId)
     if (getStatusRequest === undefined)
       throw Error(`missing getStatusRequest for tradeId ${tradeId}`)

--- a/src/lib/swapper/swappers/ThorchainSwapper/endpoints.ts
+++ b/src/lib/swapper/swappers/ThorchainSwapper/endpoints.ts
@@ -1,5 +1,6 @@
 import { TxStatus } from '@shapeshiftoss/unchained-client'
 import type { Result } from '@sniptt/monads/build'
+import { v4 as uuid } from 'uuid'
 import type {
   GetTradeQuoteInput,
   SwapErrorRight,
@@ -25,7 +26,7 @@ export const thorchainApi: Swapper2Api = {
 
     return tradeQuoteResult.map(tradeQuote => {
       const { receiveAddress, affiliateBps } = input
-      const id = String(Date.now()) // TODO: get thorchain quote ID or use uuid
+      const id = uuid()
 
       return { id, receiveAddress, affiliateBps, ...tradeQuote }
     })
@@ -76,11 +77,12 @@ export const thorchainApi: Swapper2Api = {
     })
   },
 
-  checkTradeStatus: async (
-    tradeId: string,
-  ): Promise<{ status: TxStatus; buyTxId: string | undefined; message: string | undefined }> => {
+  checkTradeStatus: async ({
+    txId,
+  }): Promise<{ status: TxStatus; buyTxId: string | undefined; message: string | undefined }> => {
     const thorchainSwapper = new ThorchainSwapper()
-    const txsResult = await thorchainSwapper.getTradeTxs({ tradeId })
+    // thorchain swapper uses txId to get tx status (not trade ID)
+    const txsResult = await thorchainSwapper.getTradeTxs({ tradeId: txId })
 
     const status = (() => {
       switch (true) {

--- a/yarn.lock
+++ b/yarn.lock
@@ -6377,6 +6377,7 @@ __metadata:
     ts-prune: ^0.10.3
     typechain: ^8.1.1
     typescript: ^4.9.0
+    uuid: ^9.0.0
     val-loader: ^4.0.0
     viem: ^0.3.3
     web-vitals: ^2.1.4
@@ -27832,6 +27833,15 @@ pvutils@latest:
   bin:
     uuid: ./bin/uuid
   checksum: 58de2feed61c59060b40f8203c0e4ed7fd6f99d42534a499f1741218a1dd0c129f4aa1de797bcf822c8ea5da7e4137aa3673431a96dae729047f7aca7b27866f
+  languageName: node
+  linkType: hard
+
+"uuid@npm:^9.0.0":
+  version: 9.0.0
+  resolution: "uuid@npm:9.0.0"
+  bin:
+    uuid: dist/bin/uuid
+  checksum: 8dd2c83c43ddc7e1c71e36b60aea40030a6505139af6bee0f382ebcd1a56f6cd3028f7f06ffb07f8cf6ced320b76aea275284b224b002b289f89fe89c389b028
   languageName: node
   linkType: hard
 


### PR DESCRIPTION
## Description

Fixes trade status polling in new implementation of exchange client.

Current implementation is using a timstamp as the txid when fetching the trade status. 

This PR introduces the ability to use either txId or tradeId when fetching trade status from the api. This is because lifi requires trade ID to fetch a preformed request from the database, while thor requires a txid to fetch from the api. The client shouldnt know which is used as this is swapper specific. Instead, both are submitted and the swapper will use one to fetch the status.

## Pull Request Type

- [x] :bug: Bug fix (Non-breaking Change: Fixes an issue)
- [ ] :hammer_and_wrench: Chore (Non-breaking Change: Doc updates, pkg upgrades, typos, etc..)
- [ ] :nail_care: New Feature (Breaking/Non-breaking Change)

## Issue (if applicable)

<!-----------------------------------------------------------------------------
If applicable, please link to the github issue and put `closes #XXXX` in your comment to auto-close the issue that your PR fixes.
------------------------------------------------------------------------------>

NA

## Risk

no risk, not user facing

<!-----------------------------------------------------------------------------
Outline the scope of your changes and the risk associated with them. You must use your discretion as an engineer to determine the potential impact of your changes.

E.g. an upgrade to `hdwallet` or core state management would be considered higher risk, and might require a full regression test. UI or isolated view changes, or something behind a feature flag may have near zero risk. Small bug fixes might require testing isolated to the specific fix.
------------------------------------------------------------------------------>

## Testing

Check thor trades complete in new exchange client (multi hop enabled)
<!-----------------------------------------------------------------------------
We treat every PR to be merged with the same scrutiny as if we were merging directly to production.

Your PR will not be merged if you do not complete the sections below for our engineering and operations teams to test.
------------------------------------------------------------------------------>

### Engineering

See above

<!-----------------------------------------------------------------------------
Include sufficient information here for an engineer to test your PR. This may include how to test locally, in a built environment, changes to infrastructure etc.
------------------------------------------------------------------------------>

### Operations

No action required
<!-----------------------------------------------------------------------------
If your changes have a user-facing impact, describe how a non-technical QA team can functionally test your changes in a preview environment.

If they are not user-facing please describe how to test for any regressions that may occur.
------------------------------------------------------------------------------>

## Screenshots (if applicable)

new swapper thor trades confirming in UI (dont mind the borked UI will fix in follow up)
![image](https://github.com/shapeshift/web/assets/125113430/944f583f-13b7-4806-9c0e-105448b86386)

