### PR TITLE
chore: consolidate swapper endpoints into one

### DIFF
--- a/src/components/MultiHopTrade/components/TradeInput/TradeInput.tsx
+++ b/src/components/MultiHopTrade/components/TradeInput/TradeInput.tsx
@@ -32,14 +32,17 @@ import { useWallet } from 'hooks/useWallet/useWallet'
 import type { Asset } from 'lib/asset-service'
 import { getMixPanel } from 'lib/mixpanel/mixPanelSingleton'
 import { MixPanelEvents } from 'lib/mixpanel/types'
+import { selectSwappersApiTradeQuotePending } from 'state/apis/swappers/selectors'
 import { selectBuyAsset, selectSellAsset } from 'state/slices/selectors'
 import { swappers } from 'state/slices/swappersSlice/swappersSlice'
 import {
   selectBuyAmountBeforeFeesCryptoPrecision,
   selectFirstHop,
   selectNetReceiveAmountCryptoPrecision,
+  selectQuotes,
   selectSelectedQuote,
   selectSelectedQuoteError,
+  selectSelectedSwapperName,
   selectSwapperSupportsCrossAccountTrade,
   selectTotalProtocolFeeByAsset,
 } from 'state/slices/tradeQuoteSlice/selectors'
@@ -54,6 +57,7 @@ import { SellAssetInput } from './components/SellAssetInput'
 import { TradeQuotes } from './components/TradeQuotes/TradeQuotes'
 
 export const TradeInput = (props: CardProps) => {
+  useGetTradeQuotes()
   const {
     state: { wallet },
   } = useWallet()
@@ -88,9 +92,11 @@ export const TradeInput = (props: CardProps) => {
   )
 
   const { supportedSellAssets, supportedBuyAssets } = useSupportedAssets()
-  const { selectedQuote, sortedQuotes } = useGetTradeQuotes()
+  const selectedQuote = useAppSelector(selectSelectedQuote)
+  const selectedSwapperName = useAppSelector(selectSelectedSwapperName)
+  const sortedQuotes = useAppSelector(selectQuotes)
 
-  const isQuoteLoading = useMemo(() => selectedQuote?.isLoading, [selectedQuote?.isLoading])
+  const isQuoteLoading = useAppSelector(selectSwappersApiTradeQuotePending)
   const isLoading = useMemo(
     () => isQuoteLoading || isConfirmationLoading,
     [isConfirmationLoading, isQuoteLoading],
@@ -228,7 +234,9 @@ export const TradeInput = (props: CardProps) => {
                   )
                 }
               >
-                {quoteData && <TradeQuotes isOpen={showTradeQuotes} sortedQuotes={sortedQuotes} />}
+                {quoteData && (
+                  <TradeQuotes isOpen={showTradeQuotes} sortedQuotes={sortedQuotes ?? []} />
+                )}
               </TradeAssetInput>
             </Stack>
             <Stack
@@ -256,9 +264,9 @@ export const TradeInput = (props: CardProps) => {
                   shapeShiftFee='0'
                   slippage={
                     quoteData.recommendedSlippage ??
-                    getDefaultSlippagePercentageForSwapper(selectedQuote.swapperName)
+                    getDefaultSlippagePercentageForSwapper(selectedSwapperName)
                   }
-                  swapperName={selectedQuote.swapperName}
+                  swapperName={selectedSwapperName ?? ''}
                 />
               ) : null}
             </Stack>

--- a/src/components/MultiHopTrade/components/TradeInput/components/TradeQuotes/TradeQuote.tsx
+++ b/src/components/MultiHopTrade/components/TradeInput/components/TradeQuotes/TradeQuote.tsx
@@ -30,6 +30,43 @@ type TradeQuoteLoadedProps = {
   bestInputOutputRatio: number
 }
 
+/*
+ TODO: Add loading skeleton - the below is an implementation for when trade quotes had separate loading states.
+ They are now unified.
+ */
+// const TradeQuoteLoading = () => {
+//   const borderColor = useColorModeValue('blackAlpha.100', 'whiteAlpha.100')
+//   return (
+//     <Stack
+//       borderWidth={1}
+//       cursor='not-allowed'
+//       borderColor={borderColor}
+//       borderRadius='xl'
+//       flexDir='column'
+//       spacing={2}
+//       width='full'
+//       px={4}
+//       py={2}
+//       fontSize='sm'
+//     >
+//       <Flex justifyContent='space-between'>
+//         <Stack direction='row' spacing={2}>
+//           <Skeleton height='20px' width='50px' />
+//           <Skeleton height='20px' width='50px' />
+//         </Stack>
+//         <Skeleton height='20px' width='80px' />
+//       </Flex>
+//       <Flex justifyContent='space-between'>
+//         <Stack direction='row' alignItems='center'>
+//           <SkeletonCircle height='24px' width='24px' />
+//           <Skeleton height='21px' width='50px' />
+//         </Stack>
+//         <Skeleton height='20px' width='100px' />
+//       </Flex>
+//     </Stack>
+//   )
+// }
+
 export const TradeQuoteLoaded: React.FC<TradeQuoteLoadedProps> = ({
   isActive,
   isBest,

--- a/src/components/MultiHopTrade/components/TradeInput/components/TradeQuotes/TradeQuote.tsx
+++ b/src/components/MultiHopTrade/components/TradeInput/components/TradeQuotes/TradeQuote.tsx
@@ -1,5 +1,4 @@
-import { Flex, Skeleton, SkeletonCircle, Stack, Tag, useColorModeValue } from '@chakra-ui/react'
-import type { Result } from '@sniptt/monads/build'
+import { Flex, Tag, useColorModeValue } from '@chakra-ui/react'
 import { useCallback, useMemo } from 'react'
 import { FaGasPump } from 'react-icons/fa'
 import { useTranslate } from 'react-polyglot'
@@ -7,8 +6,8 @@ import { Amount } from 'components/Amount/Amount'
 import { RawText } from 'components/Text'
 import { useIsTradingActive } from 'components/Trade/hooks/useIsTradingActive'
 import { bnOrZero } from 'lib/bignumber/bignumber'
-import type { SwapErrorRight, TradeQuote2 } from 'lib/swapper/api'
 import { SwapperName } from 'lib/swapper/api'
+import type { ApiQuote } from 'state/apis/swappers'
 import {
   selectBuyAsset,
   selectFeeAssetByChainId,
@@ -24,49 +23,10 @@ import { useAppDispatch, useAppSelector } from 'state/store'
 
 import { SwapperIcon } from '../SwapperIcon/SwapperIcon'
 
-const TradeQuoteLoading = () => {
-  const borderColor = useColorModeValue('blackAlpha.100', 'whiteAlpha.100')
-  return (
-    <Stack
-      borderWidth={1}
-      cursor='not-allowed'
-      borderColor={borderColor}
-      borderRadius='xl'
-      flexDir='column'
-      spacing={2}
-      width='full'
-      px={4}
-      py={2}
-      fontSize='sm'
-    >
-      <Flex justifyContent='space-between'>
-        <Stack direction='row' spacing={2}>
-          <Skeleton height='20px' width='50px' />
-          <Skeleton height='20px' width='50px' />
-        </Stack>
-        <Skeleton height='20px' width='80px' />
-      </Flex>
-      <Flex justifyContent='space-between'>
-        <Stack direction='row' alignItems='center'>
-          <SkeletonCircle height='24px' width='24px' />
-          <Skeleton height='21px' width='50px' />
-        </Stack>
-        <Skeleton height='20px' width='100px' />
-      </Flex>
-    </Stack>
-  )
-}
-
 type TradeQuoteLoadedProps = {
   isActive: boolean
   isBest: boolean
-  quoteData: {
-    isLoading: boolean
-    data: Result<TradeQuote2, SwapErrorRight> | undefined
-    error: unknown
-    swapperName: SwapperName
-    inputOutputRatio: number
-  }
+  quoteData: ApiQuote
   bestInputOutputRatio: number
 }
 
@@ -93,13 +53,9 @@ export const TradeQuoteLoaded: React.FC<TradeQuoteLoadedProps> = ({
   const networkFeeFiatPrecision = useAppSelector(selectTotalNetworkFeeFiatPrecision)
   const totalReceiveAmountCryptoPrecision = useAppSelector(selectNetReceiveAmountCryptoPrecision)
 
-  const quote = quoteData?.data?.isOk() ? quoteData.data.unwrap() : undefined
-
   const handleQuoteSelection = useCallback(() => {
     dispatch(tradeQuoteSlice.actions.setSwapperName(quoteData.swapperName))
-    dispatch(tradeQuoteSlice.actions.setQuote(quote))
-    dispatch(tradeQuoteSlice.actions.setError(undefined))
-  }, [dispatch, quote, quoteData.swapperName])
+  }, [dispatch, quoteData.swapperName])
 
   const feeAsset = useAppSelector(state => selectFeeAssetByChainId(state, sellAsset?.chainId ?? ''))
   if (!feeAsset)
@@ -198,6 +154,4 @@ export const TradeQuoteLoaded: React.FC<TradeQuoteLoadedProps> = ({
   ) : null
 }
 
-export const TradeQuote: React.FC<TradeQuoteLoadedProps> = props => {
-  return props.quoteData.isLoading ? <TradeQuoteLoading /> : <TradeQuoteLoaded {...props} />
-}
+export const TradeQuote: React.FC<TradeQuoteLoadedProps> = props => <TradeQuoteLoaded {...props} />

--- a/src/components/MultiHopTrade/components/TradeInput/components/TradeQuotes/TradeQuotes.tsx
+++ b/src/components/MultiHopTrade/components/TradeInput/components/TradeQuotes/TradeQuotes.tsx
@@ -1,5 +1,5 @@
 import { Collapse, Flex } from '@chakra-ui/react'
-import type { TradeQuoteResult } from 'components/MultiHopTrade/types'
+import type { ApiQuote } from 'state/apis/swappers'
 import { selectSelectedSwapperName } from 'state/slices/tradeQuoteSlice/selectors'
 import { useAppSelector } from 'state/store'
 
@@ -7,7 +7,7 @@ import { TradeQuote } from './TradeQuote'
 
 type TradeQuotesProps = {
   isOpen?: boolean
-  sortedQuotes: TradeQuoteResult[]
+  sortedQuotes: ApiQuote[]
 }
 
 export const TradeQuotes: React.FC<TradeQuotesProps> = ({ isOpen, sortedQuotes }) => {
@@ -16,8 +16,7 @@ export const TradeQuotes: React.FC<TradeQuotesProps> = ({ isOpen, sortedQuotes }
   const bestQuoteData = sortedQuotes[0]
 
   const quotes = sortedQuotes.map((quoteData, i) => {
-    const { data, swapperName } = quoteData
-    const quote = data?.isOk() ? data.unwrap() : undefined
+    const { quote, swapperName } = quoteData
 
     // TODO(woodenfurniture): we may want to display per-swapper errors here
     if (!quote) return null

--- a/src/components/MultiHopTrade/hooks/useGetTradeQuotes.tsx
+++ b/src/components/MultiHopTrade/hooks/useGetTradeQuotes.tsx
@@ -67,6 +67,5 @@ export const useGetTradeQuotes = () => {
     wallet,
   ])
 
-  const quotes = useGetTradeQuoteQuery(debouncedTradeQuoteInput, { pollingInterval: 5000 })
-  console.log('xxx quotes', quotes)
+  useGetTradeQuoteQuery(debouncedTradeQuoteInput, { pollingInterval: 10000 })
 }

--- a/src/components/MultiHopTrade/hooks/useGetTradeQuotes.tsx
+++ b/src/components/MultiHopTrade/hooks/useGetTradeQuotes.tsx
@@ -1,18 +1,12 @@
 import { skipToken } from '@reduxjs/toolkit/dist/query'
-import { orderBy } from 'lodash'
 import { useEffect, useMemo, useState } from 'react'
 import { useReceiveAddress } from 'components/MultiHopTrade/hooks/useReceiveAddress'
-import type { TradeQuoteResult } from 'components/MultiHopTrade/types'
 import { getTradeQuoteArgs } from 'components/Trade/hooks/useSwapper/getTradeQuoteArgs'
 import { useDebounce } from 'hooks/useDebounce/useDebounce'
 import { useWallet } from 'hooks/useWallet/useWallet'
 import type { GetTradeQuoteInput } from 'lib/swapper/api'
-import { SwapperName } from 'lib/swapper/api'
-import { isSkipToken } from 'lib/utils'
-import { useGetLifiTradeQuoteQuery } from 'state/apis/swappers/lifiSwapperApi'
-import { useGetThorTradeQuoteQuery } from 'state/apis/swappers/thorSwapperApi'
+import { useGetTradeQuoteQuery } from 'state/apis/swappers/swappersApi'
 import {
-  selectBuyAccountId,
   selectBuyAsset,
   selectFeatureFlags,
   selectPortfolioAccountMetadataByAccountId,
@@ -20,17 +14,11 @@ import {
   selectSellAmountCryptoPrecision,
   selectSellAsset,
 } from 'state/slices/selectors'
-import {
-  getInputOutputRatioFromQuote,
-  isCrossAccountTradeSupported,
-} from 'state/slices/tradeQuoteSlice/helpers'
-import { tradeQuoteSlice } from 'state/slices/tradeQuoteSlice/tradeQuoteSlice'
-import { store, useAppDispatch, useAppSelector } from 'state/store'
+import { store, useAppSelector } from 'state/store'
 
 export const useGetTradeQuotes = () => {
   const flags = useAppSelector(selectFeatureFlags)
   const wallet = useWallet().state.wallet
-  const dispatch = useAppDispatch()
   const [tradeQuoteInput, setTradeQuoteInput] = useState<GetTradeQuoteInput | typeof skipToken>(
     skipToken,
   )
@@ -41,11 +29,6 @@ export const useGetTradeQuotes = () => {
   const sellAmountCryptoPrecision = useAppSelector(selectSellAmountCryptoPrecision)
 
   const sellAccountId = useAppSelector(selectSellAccountId)
-  const buyAccountId = useAppSelector(selectBuyAccountId)
-  const isCrossAccountTrade = useMemo(
-    () => sellAccountId !== buyAccountId,
-    [buyAccountId, sellAccountId],
-  )
 
   const sellAccountMetadata = useMemo(() => {
     return selectPortfolioAccountMetadataByAccountId(store.getState(), {
@@ -84,67 +67,6 @@ export const useGetTradeQuotes = () => {
     wallet,
   ])
 
-  const lifiQuery = useGetLifiTradeQuoteQuery(debouncedTradeQuoteInput, {
-    skip: !flags.LifiSwap,
-  })
-
-  const thorQuery = useGetThorTradeQuoteQuery(debouncedTradeQuoteInput, {
-    skip: !flags.ThorSwap,
-  })
-
-  // TODO(woodenfurniture): quote selection
-  const sortedQuotes: TradeQuoteResult[] = useMemo(() => {
-    if (isSkipToken(debouncedTradeQuoteInput)) return []
-
-    const results = [
-      {
-        isLoading: thorQuery.isFetching,
-        data: thorQuery.data,
-        error: thorQuery.error,
-        swapperName: SwapperName.Thorchain,
-      },
-      {
-        isLoading: lifiQuery.isFetching,
-        data: lifiQuery.data,
-        error: lifiQuery.error,
-        swapperName: SwapperName.LIFI,
-      },
-    ]
-      .filter(result => {
-        const swapperSupportsCrossAccountTrade = isCrossAccountTradeSupported(result.swapperName)
-        return !isCrossAccountTrade || swapperSupportsCrossAccountTrade
-      })
-      .map(result => {
-        const quote = result.data && result.data.isOk() ? result.data.unwrap() : undefined
-        const inputOutputRatio = quote
-          ? getInputOutputRatioFromQuote({
-              quote,
-              swapperName: result.swapperName,
-            })
-          : -Infinity
-        return Object.assign(result, { inputOutputRatio })
-      })
-
-    return orderBy(results, ['inputOutputRatio', 'swapperName'], ['asc', 'asc'])
-  }, [
-    debouncedTradeQuoteInput,
-    thorQuery.isFetching,
-    thorQuery.data,
-    thorQuery.error,
-    lifiQuery.isFetching,
-    lifiQuery.data,
-    lifiQuery.error,
-    isCrossAccountTrade,
-  ])
-
-  const bestQuote: TradeQuoteResult = sortedQuotes[0]
-  const quote = bestQuote?.data && bestQuote.data.isOk() ? bestQuote.data.unwrap() : undefined
-  const error = bestQuote?.data && bestQuote.data.isErr() ? bestQuote.data.unwrapErr() : undefined
-  dispatch(tradeQuoteSlice.actions.setSwapperName(bestQuote?.swapperName))
-  dispatch(tradeQuoteSlice.actions.setQuote(quote))
-  dispatch(tradeQuoteSlice.actions.setError(error))
-  return {
-    sortedQuotes,
-    selectedQuote: sortedQuotes[0],
-  }
+  const quotes = useGetTradeQuoteQuery(debouncedTradeQuoteInput, { pollingInterval: 5000 })
+  console.log('xxx quotes', quotes)
 }

--- a/src/components/MultiHopTrade/hooks/useTradeExecution/useTradeExecution.ts
+++ b/src/components/MultiHopTrade/hooks/useTradeExecution/useTradeExecution.ts
@@ -1,3 +1,4 @@
+import type { AssetId } from '@shapeshiftoss/caip'
 import { supportsETH } from '@shapeshiftoss/hdwallet-core'
 import { TxStatus } from '@shapeshiftoss/unchained-client'
 import { useCallback, useState } from 'react'
@@ -11,7 +12,11 @@ import { lifi as lifiSwapper } from 'lib/swapper/swappers/LifiSwapper/LifiSwappe
 import { thorchainApi } from 'lib/swapper/swappers/ThorchainSwapper/endpoints'
 import { thorchain as thorchainSwapper } from 'lib/swapper/swappers/ThorchainSwapper/ThorchainSwapper2'
 import { assertUnreachable, isEvmChainAdapter } from 'lib/utils'
-import { selectPortfolioAccountMetadataByAccountId } from 'state/slices/selectors'
+import {
+  selectFeeAssetById,
+  selectPortfolioAccountMetadataByAccountId,
+  selectUsdRateByAssetId,
+} from 'state/slices/selectors'
 import { useAppSelector } from 'state/store'
 
 import { TRADE_POLL_INTERVAL_MILLISECONDS } from '../constants'
@@ -38,8 +43,21 @@ export const useTradeExecution = ({
     selectPortfolioAccountMetadataByAccountId(state, { accountId: sellAssetAccountId }),
   )
 
+  const buyAssetUsdRate = useAppSelector(state =>
+    selectUsdRateByAssetId(state, tradeQuote?.steps[0].buyAsset.assetId ?? ('' as AssetId)),
+  )
+
+  const feeAsset = useAppSelector(state =>
+    selectFeeAssetById(state, tradeQuote?.steps[0].sellAsset.assetId ?? ''),
+  )
+  const feeAssetUsdRate = useAppSelector(state =>
+    selectUsdRateByAssetId(state, feeAsset?.assetId ?? ('' as AssetId)),
+  )
+
   const executeTrade = useCallback(async () => {
     if (!wallet) throw Error('missing wallet')
+    if (!buyAssetUsdRate) throw Error('missing buyAssetUsdRate')
+    if (!feeAssetUsdRate) throw Error('missing feeAssetUsdRate')
     if (!accountMetadata) throw Error('missing accountMetadata')
     if (!tradeQuote) throw Error('missing tradeQuote')
     if (!swapperName) throw Error('missing swapperName')
@@ -86,6 +104,8 @@ export const useTradeExecution = ({
         accountMetadata,
         stepIndex,
         supportsEIP1559,
+        buyAssetUsdRate,
+        feeAssetUsdRate,
       },
     )
 
@@ -114,7 +134,7 @@ export const useTradeExecution = ({
       interval: TRADE_POLL_INTERVAL_MILLISECONDS,
       maxAttempts: Infinity,
     })
-  }, [poll, accountMetadata, swapperName, tradeQuote, wallet])
+  }, [wallet, buyAssetUsdRate, feeAssetUsdRate, accountMetadata, tradeQuote, swapperName, poll])
 
   return { executeTrade, sellTxId, buyTxId, message, status }
 }

--- a/src/components/MultiHopTrade/types.ts
+++ b/src/components/MultiHopTrade/types.ts
@@ -1,6 +1,5 @@
-import type { Result } from '@sniptt/monads'
 import type { InterpolationOptions } from 'node-polyglot'
-import type { SwapErrorRight, SwapperName, TradeQuote2 } from 'lib/swapper/api'
+import type { SwapErrorRight } from 'lib/swapper/api'
 import type { MultiHopExecutionStatus } from 'state/slices/swappersSlice/types'
 
 export type StepperStep = {
@@ -33,14 +32,6 @@ export type QuoteStatus = {
   validationErrors: SelectedQuoteStatus[]
   quoteStatusTranslation: string | [string, InterpolationOptions]
   error?: SwapErrorRight
-}
-
-export type TradeQuoteResult = {
-  isLoading: boolean
-  data: Result<TradeQuote2, SwapErrorRight> | undefined
-  swapperName: SwapperName
-  error: unknown
-  inputOutputRatio: number
 }
 
 export enum TradeRoutePaths {

--- a/src/lib/swapper/api.ts
+++ b/src/lib/swapper/api.ts
@@ -294,6 +294,8 @@ export type GetUnsignedTxArgs = {
   accountMetadata?: AccountMetadata
   stepIndex: number
   supportsEIP1559: boolean
+  buyAssetUsdRate: string
+  feeAssetUsdRate: string
 } & FromOrXpub
 
 export type ExecuteTradeArgs = {

--- a/src/lib/swapper/swappers/ThorchainSwapper/endpoints.ts
+++ b/src/lib/swapper/swappers/ThorchainSwapper/endpoints.ts
@@ -12,7 +12,6 @@ import type {
 
 import { getThorTradeQuote } from './getThorTradeQuote/getTradeQuote'
 import type { Rates, ThorUtxoSupportedChainId } from './ThorchainSwapper'
-import { ThorchainSwapper } from './ThorchainSwapper'
 import { getSignTxFromQuote } from './utils/getSignTxFromQuote'
 
 export const thorchainApi: Swapper2Api = {
@@ -66,30 +65,32 @@ export const thorchainApi: Swapper2Api = {
     })
   },
 
+  // FIXME: implement in a way that doesn't cause circular dependencies
+  // eslint-disable-next-line require-await
   checkTradeStatus: async ({
     txId,
   }): Promise<{ status: TxStatus; buyTxId: string | undefined; message: string | undefined }> => {
-    const thorchainSwapper = new ThorchainSwapper()
+    // const thorchainSwapper = new ThorchainSwapper()
     // thorchain swapper uses txId to get tx status (not trade ID)
-    const txsResult = await thorchainSwapper.getTradeTxs({ tradeId: txId })
-
-    const status = (() => {
-      switch (true) {
-        case txsResult.isOk() && !!txsResult.unwrap().buyTxid:
-          return TxStatus.Confirmed
-        case txsResult.isOk() && !txsResult.unwrap().buyTxid:
-          return TxStatus.Pending
-        case txsResult.isErr():
-          return TxStatus.Failed
-        default:
-          return TxStatus.Unknown
-      }
-    })()
-
-    return {
-      buyTxId: txsResult.isOk() ? txsResult.unwrap().buyTxid : undefined,
-      status,
-      message: undefined,
-    }
+    // const txsResult = await thorchainSwapper.getTradeTxs({ tradeId: txId })
+    // const status = (() => {
+    //   switch (true) {
+    //     case txsResult.isOk() && !!txsResult.unwrap().buyTxid:
+    //       return TxStatus.Confirmed
+    //     case txsResult.isOk() && !txsResult.unwrap().buyTxid:
+    //       return TxStatus.Pending
+    //     case txsResult.isErr():
+    //       return TxStatus.Failed
+    //     default:
+    //       return TxStatus.Unknown
+    //   }
+    // })()
+    //
+    // return {
+    //   buyTxId: txsResult.isOk() ? txsResult.unwrap().buyTxid : undefined,
+    //   status,
+    //   message: undefined,
+    // }
+    return Promise.resolve({ buyTxId: txId, message: txId, status: TxStatus.Unknown })
   },
 }

--- a/src/lib/swapper/swappers/ThorchainSwapper/endpoints.ts
+++ b/src/lib/swapper/swappers/ThorchainSwapper/endpoints.ts
@@ -9,8 +9,6 @@ import type {
   TradeQuote2,
   UnsignedTx,
 } from 'lib/swapper/api'
-import { selectFeeAssetById, selectUsdRateByAssetId } from 'state/slices/selectors'
-import { store } from 'state/store'
 
 import { getThorTradeQuote } from './getThorTradeQuote/getTradeQuote'
 import type { Rates, ThorUtxoSupportedChainId } from './ThorchainSwapper'
@@ -38,19 +36,10 @@ export const thorchainApi: Swapper2Api = {
     from,
     xpub,
     supportsEIP1559,
+    buyAssetUsdRate,
+    feeAssetUsdRate,
   }): Promise<UnsignedTx> => {
     const { receiveAddress, affiliateBps } = tradeQuote
-    const feeAsset = selectFeeAssetById(store.getState(), tradeQuote.steps[0].sellAsset.assetId)
-    const buyAssetUsdRate = selectUsdRateByAssetId(
-      store.getState(),
-      tradeQuote.steps[0].buyAsset.assetId,
-    )
-    const feeAssetUsdRate = feeAsset
-      ? selectUsdRateByAssetId(store.getState(), feeAsset.assetId)
-      : undefined
-
-    if (!buyAssetUsdRate) throw Error('missing buy asset usd rate')
-    if (!feeAssetUsdRate) throw Error('missing fee asset usd rate')
 
     const accountType = accountMetadata?.accountType
 

--- a/src/state/apis/swappers/helpers/getInputOutputRatioFromQuote.ts
+++ b/src/state/apis/swappers/helpers/getInputOutputRatioFromQuote.ts
@@ -1,0 +1,190 @@
+import type { AssetId } from '@shapeshiftoss/caip'
+import { getDefaultSlippagePercentageForSwapper } from 'constants/constants'
+import type { Asset } from 'lib/asset-service'
+import type { BigNumber } from 'lib/bignumber/bignumber'
+import { bn, bnOrZero } from 'lib/bignumber/bignumber'
+import { fromBaseUnit } from 'lib/math'
+import type { SwapperName, TradeQuote } from 'lib/swapper/api'
+import type { ReduxState } from 'state/reducer'
+import { selectFeeAssetById } from 'state/slices/assetsSlice/selectors'
+import {
+  selectCryptoMarketData,
+  selectUsdRateByAssetId,
+} from 'state/slices/marketDataSlice/selectors'
+import { sumProtocolFeesToDenom } from 'state/zustand/swapperStore/utils'
+
+const getHopTotalNetworkFeeFiatPrecisionWithGetFeeAssetFiatRate = (
+  state: ReduxState,
+  tradeQuoteStep: TradeQuote['steps'][number],
+  getFeeAssetRate: (feeAssetId: AssetId) => string,
+): BigNumber => {
+  // TODO(woodenfurniture): handle osmo swapper crazy network fee logic here
+  const feeAsset = selectFeeAssetById(state, tradeQuoteStep?.sellAsset.assetId)
+
+  if (feeAsset === undefined)
+    throw Error(`missing fee asset for assetId ${tradeQuoteStep.sellAsset.assetId}`)
+
+  const feeAssetFiatRate = getFeeAssetRate(feeAsset.assetId)
+
+  const networkFeeCryptoBaseUnit = tradeQuoteStep.feeData.networkFeeCryptoBaseUnit
+  const networkFeeFiatPrecision = bnOrZero(
+    fromBaseUnit(networkFeeCryptoBaseUnit, feeAsset.precision),
+  ).times(feeAssetFiatRate)
+
+  return networkFeeFiatPrecision
+}
+
+const getTotalNetworkFeeFiatPrecisionWithGetFeeAssetFiatRate = (
+  state: ReduxState,
+  quote: TradeQuote,
+  getFeeAssetRate: (feeAssetId: AssetId) => string,
+): BigNumber =>
+  quote.steps.reduce((acc, step) => {
+    const networkFeeFiatPrecision = getHopTotalNetworkFeeFiatPrecisionWithGetFeeAssetFiatRate(
+      state,
+      step,
+      getFeeAssetRate,
+    )
+    return acc.plus(networkFeeFiatPrecision)
+  }, bn(0))
+
+const _getTotalProtocolFeesUsdPrecision = (state: ReduxState, quote: TradeQuote): BigNumber => {
+  const cryptoMarketDataById = selectCryptoMarketData(state)
+  return quote.steps.reduce(
+    (acc, step) =>
+      acc.plus(
+        sumProtocolFeesToDenom({
+          cryptoMarketDataById,
+          protocolFees: step.feeData.protocolFees,
+          outputExponent: 0,
+          outputAssetPriceUsd: '1',
+        }),
+      ),
+    bn(0),
+  )
+}
+
+/**
+ * Computes the total network fee across all hops
+ * @param state
+ * @param quote The trade quote
+ * @returns The total network fee across all hops in USD precision
+ */
+const _getTotalNetworkFeeUsdPrecision = (state: ReduxState, quote: TradeQuote): BigNumber => {
+  const cryptoMarketDataById = selectCryptoMarketData(state)
+
+  const getFeeAssetUsdRate = (feeAssetId: AssetId) => {
+    const feeAsset = selectFeeAssetById(state, feeAssetId)
+    if (feeAsset === undefined) throw Error(`missing fee asset for assetId ${feeAssetId}`)
+    const feeAssetMarketData = cryptoMarketDataById[feeAsset.assetId]
+    if (feeAssetMarketData === undefined) throw Error(`missing fee asset for assetId ${feeAssetId}`)
+    return feeAssetMarketData.price
+  }
+
+  return getTotalNetworkFeeFiatPrecisionWithGetFeeAssetFiatRate(state, quote, getFeeAssetUsdRate)
+}
+
+// NOTE: "Receive side" refers to "last hop AND buy asset AND receive account".
+// TODO: we'll need a check to ensure any fees included here impact the final amount received in the
+// receive account
+const _getReceiveSideAmountsCryptoBaseUnit = ({
+  quote,
+  swapperName,
+}: {
+  quote: TradeQuote
+  swapperName: SwapperName
+}) => {
+  const lastStep = quote.steps[quote.steps.length - 1]
+  const slippageDecimalPercentage =
+    quote.recommendedSlippage ?? getDefaultSlippagePercentageForSwapper(swapperName)
+
+  const buyAmountCryptoBaseUnit = bn(lastStep.buyAmountBeforeFeesCryptoBaseUnit)
+  const slippageAmountCryptoBaseUnit = buyAmountCryptoBaseUnit.times(slippageDecimalPercentage)
+  const buySideNetworkFeeCryptoBaseUnit = bn(0) // TODO(woodenfurniture): handle osmo swapper crazy network fee logic here
+  const buySideProtocolFeeCryptoBaseUnit = bnOrZero(
+    lastStep.feeData.protocolFees[lastStep.buyAsset.assetId]?.amountCryptoBaseUnit,
+  )
+
+  const netReceiveAmountCryptoBaseUnit = buyAmountCryptoBaseUnit
+    .minus(slippageAmountCryptoBaseUnit)
+    .minus(buySideNetworkFeeCryptoBaseUnit)
+    .minus(buySideProtocolFeeCryptoBaseUnit)
+
+  return {
+    netReceiveAmountCryptoBaseUnit,
+    buySideNetworkFeeCryptoBaseUnit,
+    buySideProtocolFeeCryptoBaseUnit,
+    slippageAmountCryptoBaseUnit,
+  }
+}
+
+const _convertCryptoBaseUnitToUsdPrecision = (
+  state: ReduxState,
+  asset: Asset,
+  amountCryptoBaseUnit: BigNumber.Value,
+): BigNumber => {
+  const usdRate = selectUsdRateByAssetId(state, asset.assetId)
+  if (usdRate === undefined) throw Error(`missing usd rate for assetId ${asset.assetId}`)
+  return bnOrZero(fromBaseUnit(amountCryptoBaseUnit, asset.precision)).times(usdRate)
+}
+
+export const getInputOutputRatioFromQuote = ({
+  state,
+  quote,
+  swapperName,
+}: {
+  state: ReduxState
+  quote: TradeQuote
+  swapperName: SwapperName
+}): number => {
+  const totalProtocolFeeUsdPrecision = _getTotalProtocolFeesUsdPrecision(state, quote)
+  const totalNetworkFeeUsdPrecision = _getTotalNetworkFeeUsdPrecision(state, quote)
+  const { sellAmountBeforeFeesCryptoBaseUnit, sellAsset } = quote.steps[0]
+  const { buyAsset } = quote.steps[quote.steps.length - 1]
+
+  const {
+    netReceiveAmountCryptoBaseUnit,
+    buySideNetworkFeeCryptoBaseUnit,
+    buySideProtocolFeeCryptoBaseUnit,
+  } = _getReceiveSideAmountsCryptoBaseUnit({
+    quote,
+    swapperName,
+  })
+
+  const netReceiveAmountUsdPrecision = _convertCryptoBaseUnitToUsdPrecision(
+    state,
+    buyAsset,
+    netReceiveAmountCryptoBaseUnit,
+  )
+
+  const buySideNetworkFeeUsdPrecision = _convertCryptoBaseUnitToUsdPrecision(
+    state,
+    buyAsset,
+    buySideNetworkFeeCryptoBaseUnit,
+  )
+
+  const buySideProtocolFeeUsdPrecision = _convertCryptoBaseUnitToUsdPrecision(
+    state,
+    buyAsset,
+    buySideProtocolFeeCryptoBaseUnit,
+  )
+
+  const sellAmountCryptoBaseUnit = _convertCryptoBaseUnitToUsdPrecision(
+    state,
+    sellAsset,
+    sellAmountBeforeFeesCryptoBaseUnit,
+  )
+
+  const sellSideNetworkFeeUsdPrecision = totalNetworkFeeUsdPrecision.minus(
+    buySideNetworkFeeUsdPrecision,
+  )
+  const sellSideProtocolFeeUsdPrecision = totalProtocolFeeUsdPrecision.minus(
+    buySideProtocolFeeUsdPrecision,
+  )
+
+  const netSendAmountUsdPrecision = sellAmountCryptoBaseUnit
+    .plus(sellSideNetworkFeeUsdPrecision)
+    .plus(sellSideProtocolFeeUsdPrecision)
+
+  return netSendAmountUsdPrecision.div(netReceiveAmountUsdPrecision).toNumber()
+}

--- a/src/state/apis/swappers/helpers/getLifiTradeQuoteApiHelper.ts
+++ b/src/state/apis/swappers/helpers/getLifiTradeQuoteApiHelper.ts
@@ -1,0 +1,29 @@
+import type { AssetId } from '@shapeshiftoss/caip'
+import { Err } from '@sniptt/monads'
+import type { Asset } from 'lib/asset-service'
+import type { GetEvmTradeQuoteInput } from 'lib/swapper/api'
+import { makeSwapErrorRight, SwapErrorType } from 'lib/swapper/api'
+import { lifiApi } from 'lib/swapper/swappers/LifiSwapper/endpoints'
+import type { QuoteHelperType } from 'state/apis/swappers/types'
+import { selectAssets } from 'state/slices/assetsSlice/selectors'
+import { selectUsdRateByAssetId } from 'state/slices/marketDataSlice/selectors'
+
+export const getLifiTradeQuoteHelper: QuoteHelperType = async (getTradeQuoteInput, state) => {
+  const assets: Partial<Record<AssetId, Asset>> = selectAssets(state)
+  const sellAssetUsdRate = selectUsdRateByAssetId(state, getTradeQuoteInput.sellAsset.assetId)
+
+  if (!sellAssetUsdRate)
+    return Err(
+      makeSwapErrorRight({
+        message: '[THORSwapper: getThorTradeQuoteHelper] - missing sellAssetUsdRate',
+        code: SwapErrorType.TRADE_QUOTE_FAILED,
+      }),
+    )
+
+  const maybeQuote = await lifiApi.getTradeQuote(
+    getTradeQuoteInput as GetEvmTradeQuoteInput,
+    assets,
+    sellAssetUsdRate,
+  )
+  return maybeQuote
+}

--- a/src/state/apis/swappers/helpers/getThorTradeQuoteApiHelper.ts
+++ b/src/state/apis/swappers/helpers/getThorTradeQuoteApiHelper.ts
@@ -1,0 +1,45 @@
+import { Err } from '@sniptt/monads'
+import { makeSwapErrorRight, SwapErrorType } from 'lib/swapper/api'
+import { thorchainApi } from 'lib/swapper/swappers/ThorchainSwapper/endpoints'
+import type { QuoteHelperType } from 'state/apis/swappers/types'
+import { selectFeeAssetById } from 'state/slices/assetsSlice/selectors'
+import { selectUsdRateByAssetId } from 'state/slices/marketDataSlice/selectors'
+
+export const getThorTradeQuoteHelper: QuoteHelperType = async (getTradeQuoteInput, state) => {
+  const feeAsset = selectFeeAssetById(state, getTradeQuoteInput.sellAsset.assetId)
+
+  const sellAssetUsdRate = selectUsdRateByAssetId(state, getTradeQuoteInput.sellAsset.assetId)
+  const buyAssetUsdRate = selectUsdRateByAssetId(state, getTradeQuoteInput.buyAsset.assetId)
+  const feeAssetUsdRate = feeAsset ? selectUsdRateByAssetId(state, feeAsset.assetId) : undefined
+
+  if (!sellAssetUsdRate)
+    return Err(
+      makeSwapErrorRight({
+        message: '[THORSwapper: getThorTradeQuoteHelper] - missing sellAssetUsdRate',
+        code: SwapErrorType.TRADE_QUOTE_FAILED,
+      }),
+    )
+
+  if (!buyAssetUsdRate)
+    return Err(
+      makeSwapErrorRight({
+        message: '[THORSwapper: getThorTradeQuoteHelper] - missing buyAssetUsdRate',
+        code: SwapErrorType.TRADE_QUOTE_FAILED,
+      }),
+    )
+
+  if (!feeAssetUsdRate)
+    return Err(
+      makeSwapErrorRight({
+        message: '[THORSwapper: getThorTradeQuoteHelper] - missing feeAssetUsdRate',
+        code: SwapErrorType.TRADE_QUOTE_FAILED,
+      }),
+    )
+
+  const maybeQuote = await thorchainApi.getTradeQuote(getTradeQuoteInput, {
+    sellAssetUsdRate,
+    buyAssetUsdRate,
+    feeAssetUsdRate,
+  })
+  return maybeQuote
+}

--- a/src/state/apis/swappers/index.ts
+++ b/src/state/apis/swappers/index.ts
@@ -1,0 +1,1 @@
+export * from './types'

--- a/src/state/apis/swappers/selectors.ts
+++ b/src/state/apis/swappers/selectors.ts
@@ -1,0 +1,7 @@
+import { QueryStatus } from '@reduxjs/toolkit/query'
+import type { ReduxState } from 'state/reducer'
+
+export const selectSwappersApiTradeQuotePending = (state: ReduxState) =>
+  Object.values(state.swappersApi.queries).some(
+    query => query?.endpointName === 'getTradeQuote' && query?.status === QueryStatus.pending,
+  )

--- a/src/state/apis/swappers/selectors.ts
+++ b/src/state/apis/swappers/selectors.ts
@@ -2,7 +2,7 @@ import { createSelector } from '@reduxjs/toolkit'
 import { QueryStatus } from '@reduxjs/toolkit/query'
 import type { ReduxState } from 'state/reducer'
 
-const _selectMostRecentTradeQuoteQuery = (state: ReduxState) => {
+const selectMostRecentTradeQuoteQuery = (state: ReduxState) => {
   const getTradeQuoteQueries = Object.values(state.swappersApi.queries).filter(
     query => query?.endpointName === 'getTradeQuote',
   )
@@ -19,6 +19,6 @@ const _selectMostRecentTradeQuoteQuery = (state: ReduxState) => {
 }
 
 export const selectSwappersApiTradeQuotePending = createSelector(
-  _selectMostRecentTradeQuoteQuery,
+  selectMostRecentTradeQuoteQuery,
   query => query?.status === QueryStatus.pending,
 )

--- a/src/state/apis/swappers/selectors.ts
+++ b/src/state/apis/swappers/selectors.ts
@@ -1,7 +1,19 @@
+import { createSelector } from '@reduxjs/toolkit'
 import { QueryStatus } from '@reduxjs/toolkit/query'
 import type { ReduxState } from 'state/reducer'
 
-export const selectSwappersApiTradeQuotePending = (state: ReduxState) =>
-  Object.values(state.swappersApi.queries).some(
-    query => query?.endpointName === 'getTradeQuote' && query?.status === QueryStatus.pending,
-  )
+const _selectMostRecentTradeQuoteQuery = (state: ReduxState) =>
+  Object.values(state.swappersApi.queries)
+    .filter(query => query?.endpointName === 'getTradeQuote')
+    .reduce((mostRecentQuery, query) =>
+      query?.startedTimeStamp &&
+      mostRecentQuery?.startedTimeStamp &&
+      query?.startedTimeStamp > mostRecentQuery?.startedTimeStamp
+        ? query
+        : mostRecentQuery,
+    )
+
+export const selectSwappersApiTradeQuotePending = createSelector(
+  _selectMostRecentTradeQuoteQuery,
+  query => query?.status === QueryStatus.pending,
+)

--- a/src/state/apis/swappers/selectors.ts
+++ b/src/state/apis/swappers/selectors.ts
@@ -2,16 +2,21 @@ import { createSelector } from '@reduxjs/toolkit'
 import { QueryStatus } from '@reduxjs/toolkit/query'
 import type { ReduxState } from 'state/reducer'
 
-const _selectMostRecentTradeQuoteQuery = (state: ReduxState) =>
-  Object.values(state.swappersApi.queries)
-    .filter(query => query?.endpointName === 'getTradeQuote')
-    .reduce((mostRecentQuery, query) =>
-      query?.startedTimeStamp &&
-      mostRecentQuery?.startedTimeStamp &&
-      query?.startedTimeStamp > mostRecentQuery?.startedTimeStamp
-        ? query
-        : mostRecentQuery,
-    )
+const _selectMostRecentTradeQuoteQuery = (state: ReduxState) => {
+  const getTradeQuoteQueries = Object.values(state.swappersApi.queries).filter(
+    query => query?.endpointName === 'getTradeQuote',
+  )
+
+  if (!getTradeQuoteQueries.length) return undefined
+
+  return getTradeQuoteQueries.reduce((mostRecentQuery, query) =>
+    query?.startedTimeStamp &&
+    mostRecentQuery?.startedTimeStamp &&
+    query?.startedTimeStamp > mostRecentQuery?.startedTimeStamp
+      ? query
+      : mostRecentQuery,
+  )
+}
 
 export const selectSwappersApiTradeQuotePending = createSelector(
   _selectMostRecentTradeQuoteQuery,

--- a/src/state/apis/swappers/swappersApi.ts
+++ b/src/state/apis/swappers/swappersApi.ts
@@ -1,9 +1,78 @@
 import { createApi } from '@reduxjs/toolkit/dist/query/react'
+import type { Result } from '@sniptt/monads'
+import { orderBy } from 'lodash'
+import type { GetTradeQuoteInput, SwapErrorRight, TradeQuote2 } from 'lib/swapper/api'
+import { SwapperName } from 'lib/swapper/api'
+import { getInputOutputRatioFromQuote } from 'state/apis/swappers/helpers/getInputOutputRatioFromQuote'
+import { getLifiTradeQuoteHelper } from 'state/apis/swappers/helpers/getLifiTradeQuoteApiHelper'
+import { getThorTradeQuoteHelper } from 'state/apis/swappers/helpers/getThorTradeQuoteApiHelper'
+import type { ApiQuote } from 'state/apis/swappers/types'
+import type { ReduxState } from 'state/reducer'
+import type { FeatureFlags } from 'state/slices/preferencesSlice/preferencesSlice'
+import { selectFeatureFlags } from 'state/slices/selectors'
+import { tradeQuoteSlice } from 'state/slices/tradeQuoteSlice/tradeQuoteSlice'
 
 import { BASE_RTK_CREATE_API_CONFIG } from '../const'
 
+// TODO: handle race conditions by checking the `startedTimeStamp`
+// TODO: handle exceptions from individual swappers
 export const swappersApi = createApi({
   ...BASE_RTK_CREATE_API_CONFIG,
   reducerPath: 'swappersApi',
-  endpoints: _build => ({}),
+  endpoints: build => ({
+    getTradeQuote: build.query<ApiQuote[], GetTradeQuoteInput>({
+      queryFn: async (getTradeQuoteInput: GetTradeQuoteInput, { getState, dispatch }) => {
+        const state = getState() as ReduxState
+        const { LifiSwap, ThorSwap }: FeatureFlags = selectFeatureFlags(state)
+        const quotes: (Result<TradeQuote2, SwapErrorRight> & {
+          swapperName: SwapperName
+        })[] = []
+        const quoteHelperArgs = [getTradeQuoteInput, state] as const
+        if (LifiSwap)
+          quotes.push({
+            ...(await getLifiTradeQuoteHelper(...quoteHelperArgs)),
+            swapperName: SwapperName.LIFI,
+          })
+        if (ThorSwap)
+          quotes.push({
+            ...(await getThorTradeQuoteHelper(...quoteHelperArgs)),
+            swapperName: SwapperName.Thorchain,
+          })
+        const quotesWithInputOutputRatios = quotes.map(result => {
+          const quote = result && result.isOk() ? result.unwrap() : undefined
+          const error = result && result.isErr() ? result.unwrapErr() : undefined
+          const inputOutputRatio = quote
+            ? getInputOutputRatioFromQuote({
+                state,
+                quote,
+                swapperName: result.swapperName,
+              })
+            : -Infinity
+          return { quote, error, inputOutputRatio, swapperName: result.swapperName }
+        })
+        // fixme: filter supports cross-account
+        //   const isCrossAccountTrade = useMemo(
+        //     () => sellAccountId !== buyAccountId,
+        //     [buyAccountId, sellAccountId],
+        //   )
+        //   .filter(result => {
+        //     const swapperSupportsCrossAccountTrade = isCrossAccountTradeSupported(result.swapperName)
+        //     return !isCrossAccountTrade || swapperSupportsCrossAccountTrade
+        //   })
+        const orderedQuotes: ApiQuote[] = orderBy(
+          quotesWithInputOutputRatios,
+          ['inputOutputRatio', 'swapperName'],
+          ['asc', 'asc'],
+        )
+
+        const bestQuote = orderedQuotes[0]
+        dispatch(tradeQuoteSlice.actions.setSwapperName(bestQuote.swapperName))
+        dispatch(tradeQuoteSlice.actions.setQuotes(orderedQuotes))
+
+        return { data: orderedQuotes }
+      },
+    }),
+  }),
 })
+
+export const { useGetTradeQuoteQuery } = swappersApi

--- a/src/state/apis/swappers/swappersApi.ts
+++ b/src/state/apis/swappers/swappersApi.ts
@@ -15,7 +15,6 @@ import { tradeQuoteSlice } from 'state/slices/tradeQuoteSlice/tradeQuoteSlice'
 
 import { BASE_RTK_CREATE_API_CONFIG } from '../const'
 
-// TODO: handle race conditions by checking the `startedTimeStamp`
 export const swappersApi = createApi({
   ...BASE_RTK_CREATE_API_CONFIG,
   reducerPath: 'swappersApi',
@@ -79,7 +78,6 @@ export const swappersApi = createApi({
         )
 
         dispatch(tradeQuoteSlice.actions.setQuotes({ quotes: orderedQuotes, queryStartTime }))
-        console.log('xxx orderedQuotes', orderedQuotes)
 
         return { data: orderedQuotes }
       },

--- a/src/state/apis/swappers/swappersApi.ts
+++ b/src/state/apis/swappers/swappersApi.ts
@@ -19,7 +19,7 @@ export const swappersApi = createApi({
   ...BASE_RTK_CREATE_API_CONFIG,
   reducerPath: 'swappersApi',
   endpoints: build => ({
-    getTradeQuote: build.query<ApiQuote[], GetTradeQuoteInput>({
+    getTradeQuote: build.query<null, GetTradeQuoteInput>({
       queryFn: async (getTradeQuoteInput: GetTradeQuoteInput, { getState, dispatch }) => {
         const queryStartTime = Date.now()
         const state = getState() as ReduxState
@@ -79,7 +79,7 @@ export const swappersApi = createApi({
 
         dispatch(tradeQuoteSlice.actions.setQuotes({ quotes: orderedQuotes, queryStartTime }))
 
-        return { data: orderedQuotes }
+        return { data: null }
       },
     }),
   }),

--- a/src/state/apis/swappers/swappersApi.ts
+++ b/src/state/apis/swappers/swappersApi.ts
@@ -22,6 +22,7 @@ export const swappersApi = createApi({
   endpoints: build => ({
     getTradeQuote: build.query<ApiQuote[], GetTradeQuoteInput>({
       queryFn: async (getTradeQuoteInput: GetTradeQuoteInput, { getState, dispatch }) => {
+        const queryStartTime = Date.now()
         const state = getState() as ReduxState
         const { sendAddress, receiveAddress } = getTradeQuoteInput
         const isCrossAccountTrade = sendAddress !== receiveAddress
@@ -77,9 +78,7 @@ export const swappersApi = createApi({
           ['asc', 'asc'],
         )
 
-        const bestQuote = orderedQuotes[0]
-        bestQuote && dispatch(tradeQuoteSlice.actions.setSwapperName(bestQuote.swapperName))
-        dispatch(tradeQuoteSlice.actions.setQuotes(orderedQuotes))
+        dispatch(tradeQuoteSlice.actions.setQuotes({ quotes: orderedQuotes, queryStartTime }))
         console.log('xxx orderedQuotes', orderedQuotes)
 
         return { data: orderedQuotes }

--- a/src/state/apis/swappers/types.ts
+++ b/src/state/apis/swappers/types.ts
@@ -1,0 +1,15 @@
+import type { Result } from '@sniptt/monads'
+import type { GetTradeQuoteInput, SwapErrorRight, SwapperName, TradeQuote2 } from 'lib/swapper/api'
+import type { ReduxState } from 'state/reducer'
+
+export type QuoteHelperType = (
+  getTradeQuoteInput: GetTradeQuoteInput,
+  state: ReduxState,
+) => Promise<Result<TradeQuote2, SwapErrorRight>>
+
+export type ApiQuote = {
+  quote: TradeQuote2 | undefined
+  error: SwapErrorRight | undefined
+  swapperName: SwapperName
+  inputOutputRatio: number
+}

--- a/src/state/helpers.ts
+++ b/src/state/helpers.ts
@@ -1,0 +1,21 @@
+import { SwapperName } from 'lib/swapper/api'
+import { assertUnreachable } from 'lib/utils'
+
+export const isCrossAccountTradeSupported = (swapperName: SwapperName) => {
+  switch (swapperName) {
+    case SwapperName.Thorchain:
+    case SwapperName.Osmosis:
+      return true
+    // NOTE: Before enabling cross-account for LIFI and OneInch - we must pass the sending address
+    // to the swappers up so allowance checks work. They're currently using the receive address
+    // assuming it's the same address as the sending address.
+    case SwapperName.LIFI:
+    case SwapperName.OneInch:
+    case SwapperName.Zrx:
+    case SwapperName.CowSwap:
+    case SwapperName.Test:
+      return false
+    default:
+      assertUnreachable(swapperName)
+  }
+}

--- a/src/state/slices/tradeQuoteSlice/helpers.ts
+++ b/src/state/slices/tradeQuoteSlice/helpers.ts
@@ -3,9 +3,7 @@ import { getDefaultSlippagePercentageForSwapper } from 'constants/constants'
 import type { BigNumber } from 'lib/bignumber/bignumber'
 import { bn, bnOrZero } from 'lib/bignumber/bignumber'
 import { fromBaseUnit } from 'lib/math'
-import type { ProtocolFee, TradeQuote } from 'lib/swapper/api'
-import { SwapperName } from 'lib/swapper/api'
-import { assertUnreachable } from 'lib/utils'
+import type { ProtocolFee, SwapperName, TradeQuote } from 'lib/swapper/api'
 import { selectFeeAssetById } from 'state/slices/assetsSlice/selectors'
 import {
   selectCryptoMarketData,
@@ -172,22 +170,3 @@ export const getTotalProtocolFeeByAsset = (quote: TradeQuote): Record<AssetId, P
       acc,
     )
   }, {})
-
-export const isCrossAccountTradeSupported = (swapperName: SwapperName) => {
-  switch (swapperName) {
-    case SwapperName.Thorchain:
-    case SwapperName.Osmosis:
-      return true
-    // NOTE: Before enabling cross-account for LIFI and OneInch - we must pass the sending address
-    // to the swappers up so allowance checks work. They're currently using the receive address
-    // assuming it's the same address as the sending address.
-    case SwapperName.LIFI:
-    case SwapperName.OneInch:
-    case SwapperName.Zrx:
-    case SwapperName.CowSwap:
-    case SwapperName.Test:
-      return false
-    default:
-      assertUnreachable(swapperName)
-  }
-}

--- a/src/state/slices/tradeQuoteSlice/helpers.ts
+++ b/src/state/slices/tradeQuoteSlice/helpers.ts
@@ -1,6 +1,5 @@
 import type { AssetId } from '@shapeshiftoss/caip'
 import { getDefaultSlippagePercentageForSwapper } from 'constants/constants'
-import type { Asset } from 'lib/asset-service'
 import type { BigNumber } from 'lib/bignumber/bignumber'
 import { bn, bnOrZero } from 'lib/bignumber/bignumber'
 import { fromBaseUnit } from 'lib/math'
@@ -12,7 +11,6 @@ import {
   selectCryptoMarketData,
   selectFiatToUsdRate,
   selectMarketDataByFilter,
-  selectUsdRateByAssetId,
 } from 'state/slices/marketDataSlice/selectors'
 import { store } from 'state/store'
 import { sumProtocolFeesToDenom } from 'state/zustand/swapperStore/utils'
@@ -35,15 +33,6 @@ const getHopTotalNetworkFeeFiatPrecisionWithGetFeeAssetFiatRate = (
   ).times(feeAssetFiatRate)
 
   return networkFeeFiatPrecision
-}
-
-const _convertCryptoBaseUnitToUsdPrecision = (
-  asset: Asset,
-  amountCryptoBaseUnit: BigNumber.Value,
-): BigNumber => {
-  const usdRate = selectUsdRateByAssetId(store.getState(), asset.assetId)
-  if (usdRate === undefined) throw Error(`missing usd rate for assetId ${asset.assetId}`)
-  return bnOrZero(fromBaseUnit(amountCryptoBaseUnit, asset.precision)).times(usdRate)
 }
 
 // NOTE: "Receive side" refers to "last hop AND buy asset AND receive account".
@@ -91,97 +80,6 @@ const getTotalNetworkFeeFiatPrecisionWithGetFeeAssetFiatRate = (
     )
     return acc.plus(networkFeeFiatPrecision)
   }, bn(0))
-
-/**
- * Computes the total network fee across all hops
- * @param quote The trade quote
- * @returns The total network fee across all hops in USD precision
- */
-const _getTotalNetworkFeeUsdPrecision = (quote: TradeQuote): BigNumber => {
-  const state = store.getState()
-  const cryptoMarketDataById = selectCryptoMarketData(state)
-
-  const getFeeAssetUsdRate = (feeAssetId: AssetId) => {
-    const feeAsset = selectFeeAssetById(state, feeAssetId)
-    if (feeAsset === undefined) throw Error(`missing fee asset for assetId ${feeAssetId}`)
-    const feeAssetMarketData = cryptoMarketDataById[feeAsset.assetId]
-    if (feeAssetMarketData === undefined) throw Error(`missing fee asset for assetId ${feeAssetId}`)
-    return feeAssetMarketData.price
-  }
-
-  return getTotalNetworkFeeFiatPrecisionWithGetFeeAssetFiatRate(quote, getFeeAssetUsdRate)
-}
-
-const _getTotalProtocolFeesUsdPrecision = (quote: TradeQuote): BigNumber => {
-  const cryptoMarketDataById = selectCryptoMarketData(store.getState())
-  return quote.steps.reduce(
-    (acc, step) =>
-      acc.plus(
-        sumProtocolFeesToDenom({
-          cryptoMarketDataById,
-          protocolFees: step.feeData.protocolFees,
-          outputExponent: 0,
-          outputAssetPriceUsd: '1',
-        }),
-      ),
-    bn(0),
-  )
-}
-
-export const getInputOutputRatioFromQuote = ({
-  quote,
-  swapperName,
-}: {
-  quote: TradeQuote
-  swapperName: SwapperName
-}): number => {
-  const totalProtocolFeeUsdPrecision = _getTotalProtocolFeesUsdPrecision(quote)
-  const totalNetworkFeeUsdPrecision = _getTotalNetworkFeeUsdPrecision(quote)
-  const { sellAmountBeforeFeesCryptoBaseUnit, sellAsset } = quote.steps[0]
-  const { buyAsset } = quote.steps[quote.steps.length - 1]
-
-  const {
-    netReceiveAmountCryptoBaseUnit,
-    buySideNetworkFeeCryptoBaseUnit,
-    buySideProtocolFeeCryptoBaseUnit,
-  } = _getReceiveSideAmountsCryptoBaseUnit({
-    quote,
-    swapperName,
-  })
-
-  const netReceiveAmountUsdPrecision = _convertCryptoBaseUnitToUsdPrecision(
-    buyAsset,
-    netReceiveAmountCryptoBaseUnit,
-  )
-
-  const buySideNetworkFeeUsdPrecision = _convertCryptoBaseUnitToUsdPrecision(
-    buyAsset,
-    buySideNetworkFeeCryptoBaseUnit,
-  )
-
-  const buySideProtocolFeeUsdPrecision = _convertCryptoBaseUnitToUsdPrecision(
-    buyAsset,
-    buySideProtocolFeeCryptoBaseUnit,
-  )
-
-  const sellAmountCryptoBaseUnit = _convertCryptoBaseUnitToUsdPrecision(
-    sellAsset,
-    sellAmountBeforeFeesCryptoBaseUnit,
-  )
-
-  const sellSideNetworkFeeUsdPrecision = totalNetworkFeeUsdPrecision.minus(
-    buySideNetworkFeeUsdPrecision,
-  )
-  const sellSideProtocolFeeUsdPrecision = totalProtocolFeeUsdPrecision.minus(
-    buySideProtocolFeeUsdPrecision,
-  )
-
-  const netSendAmountUsdPrecision = sellAmountCryptoBaseUnit
-    .plus(sellSideNetworkFeeUsdPrecision)
-    .plus(sellSideProtocolFeeUsdPrecision)
-
-  return netSendAmountUsdPrecision.div(netReceiveAmountUsdPrecision).toNumber()
-}
 
 export const getHopTotalProtocolFeesFiatPrecision = (
   tradeQuoteStep: TradeQuote['steps'][number],

--- a/src/state/slices/tradeQuoteSlice/selectors.ts
+++ b/src/state/slices/tradeQuoteSlice/selectors.ts
@@ -31,23 +31,25 @@ const selectTradeQuoteSlice = (state: ReduxState) => state.tradeQuoteSlice
 export const selectSelectedSwapperName: Selector<ReduxState, SwapperName | undefined> =
   createSelector(selectTradeQuoteSlice, swappers => swappers.swapperName)
 
-export const selectQuotes: Selector<ReduxState, ApiQuote[] | undefined> =
-  createDeepEqualOutputSelector(selectTradeQuoteSlice, swappers => swappers.quotes)
+export const selectQuotes: Selector<ReduxState, ApiQuote[]> = createDeepEqualOutputSelector(
+  selectTradeQuoteSlice,
+  swappers => swappers.quotes,
+)
 
-export const selectSelectedQuoteApiResponse: Selector<ReduxState, ApiQuote | undefined> =
+export const selectSelectedSwapperApiResponse: Selector<ReduxState, ApiQuote | undefined> =
   createDeepEqualOutputSelector(
     selectQuotes,
     selectSelectedSwapperName,
     (quotes, selectedSwapperName) =>
-      quotes?.find(quote => quote.swapperName === selectedSwapperName),
+      quotes.find(quote => quote.swapperName === selectedSwapperName),
   )
 
 // TODO(apotheosis): Cache based on quote ID
 export const selectSelectedQuote: Selector<ReduxState, TradeQuote2 | undefined> =
-  createDeepEqualOutputSelector(selectSelectedQuoteApiResponse, response => response?.quote)
+  createDeepEqualOutputSelector(selectSelectedSwapperApiResponse, response => response?.quote)
 
 export const selectSelectedQuoteError: Selector<ReduxState, SwapErrorRight | undefined> =
-  createDeepEqualOutputSelector(selectSelectedQuoteApiResponse, response => response?.error)
+  createDeepEqualOutputSelector(selectSelectedSwapperApiResponse, response => response?.error)
 
 /*
   Cross-account trading means trades that are either:

--- a/src/state/slices/tradeQuoteSlice/selectors.ts
+++ b/src/state/slices/tradeQuoteSlice/selectors.ts
@@ -8,6 +8,7 @@ import { fromBaseUnit } from 'lib/math'
 import type { ProtocolFee, SwapErrorRight, TradeQuote2 } from 'lib/swapper/api'
 import { SwapperName } from 'lib/swapper/api'
 import type { ApiQuote } from 'state/apis/swappers'
+import { isCrossAccountTradeSupported } from 'state/helpers'
 import type { ReduxState } from 'state/reducer'
 import { createDeepEqualOutputSelector } from 'state/selector-utils'
 import { selectFeeAssetById } from 'state/slices/assetsSlice/selectors'
@@ -17,7 +18,6 @@ import {
   getNetReceiveAmountCryptoPrecision,
   getTotalNetworkFeeFiatPrecision,
   getTotalProtocolFeeByAsset,
-  isCrossAccountTradeSupported,
 } from 'state/slices/tradeQuoteSlice/helpers'
 import {
   convertBasisPointsToDecimalPercentage,

--- a/src/state/slices/tradeQuoteSlice/selectors.ts
+++ b/src/state/slices/tradeQuoteSlice/selectors.ts
@@ -7,6 +7,7 @@ import { bn, bnOrZero } from 'lib/bignumber/bignumber'
 import { fromBaseUnit } from 'lib/math'
 import type { ProtocolFee, SwapErrorRight, TradeQuote2 } from 'lib/swapper/api'
 import { SwapperName } from 'lib/swapper/api'
+import type { ApiQuote } from 'state/apis/swappers'
 import type { ReduxState } from 'state/reducer'
 import { createDeepEqualOutputSelector } from 'state/selector-utils'
 import { selectFeeAssetById } from 'state/slices/assetsSlice/selectors'
@@ -27,18 +28,26 @@ import { selectCryptoMarketData, selectFiatToUsdRate } from '../marketDataSlice/
 
 const selectTradeQuoteSlice = (state: ReduxState) => state.tradeQuoteSlice
 
-// TODO(apotheosis): Cache based on quote ID
-export const selectSelectedQuote: Selector<ReduxState, TradeQuote2 | undefined> =
-  createDeepEqualOutputSelector(
-    selectTradeQuoteSlice,
-    swappers => swappers.quote as TradeQuote2 | undefined,
-  )
-
-export const selectSelectedQuoteError: Selector<ReduxState, SwapErrorRight | undefined> =
-  createDeepEqualOutputSelector(selectTradeQuoteSlice, swappers => swappers.error)
-
 export const selectSelectedSwapperName: Selector<ReduxState, SwapperName | undefined> =
   createSelector(selectTradeQuoteSlice, swappers => swappers.swapperName)
+
+export const selectQuotes: Selector<ReduxState, ApiQuote[] | undefined> =
+  createDeepEqualOutputSelector(selectTradeQuoteSlice, swappers => swappers.quotes)
+
+export const selectSelectedQuoteApiResponse: Selector<ReduxState, ApiQuote | undefined> =
+  createDeepEqualOutputSelector(
+    selectQuotes,
+    selectSelectedSwapperName,
+    (quotes, selectedSwapperName) =>
+      quotes?.find(quote => quote.swapperName === selectedSwapperName),
+  )
+
+// TODO(apotheosis): Cache based on quote ID
+export const selectSelectedQuote: Selector<ReduxState, TradeQuote2 | undefined> =
+  createDeepEqualOutputSelector(selectSelectedQuoteApiResponse, response => response?.quote)
+
+export const selectSelectedQuoteError: Selector<ReduxState, SwapErrorRight | undefined> =
+  createDeepEqualOutputSelector(selectSelectedQuoteApiResponse, response => response?.error)
 
 /*
   Cross-account trading means trades that are either:

--- a/src/state/slices/tradeQuoteSlice/tradeQuoteSlice.ts
+++ b/src/state/slices/tradeQuoteSlice/tradeQuoteSlice.ts
@@ -1,17 +1,16 @@
 import type { PayloadAction } from '@reduxjs/toolkit'
 import { createSlice } from '@reduxjs/toolkit'
-import type { SwapErrorRight, SwapperName, TradeQuote2 } from 'lib/swapper/api'
+import type { SwapperName } from 'lib/swapper/api'
+import type { ApiQuote } from 'state/apis/swappers'
 
 export type TradeQuoteSliceState = {
   swapperName: SwapperName | undefined
-  quote: TradeQuote2 | undefined
-  error: SwapErrorRight | undefined
+  quotes: ApiQuote[]
 }
 
 const initialState: TradeQuoteSliceState = {
   swapperName: undefined,
-  quote: undefined,
-  error: undefined,
+  quotes: [],
 }
 
 export const tradeQuoteSlice = createSlice({
@@ -22,11 +21,8 @@ export const tradeQuoteSlice = createSlice({
     setSwapperName: (state, action: PayloadAction<SwapperName | undefined>) => {
       state.swapperName = action.payload
     },
-    setQuote: (state, action: PayloadAction<TradeQuote2 | undefined>) => {
-      state.quote = action.payload
-    },
-    setError: (state, action: PayloadAction<SwapErrorRight | undefined>) => {
-      state.error = action.payload
+    setQuotes: (state, action: PayloadAction<ApiQuote[]>) => {
+      state.quotes = action.payload
     },
   },
 })

--- a/src/state/slices/tradeQuoteSlice/tradeQuoteSlice.ts
+++ b/src/state/slices/tradeQuoteSlice/tradeQuoteSlice.ts
@@ -6,11 +6,13 @@ import type { ApiQuote } from 'state/apis/swappers'
 export type TradeQuoteSliceState = {
   swapperName: SwapperName | undefined
   quotes: ApiQuote[]
+  lastRequestStartTime: number | undefined
 }
 
 const initialState: TradeQuoteSliceState = {
   swapperName: undefined,
   quotes: [],
+  lastRequestStartTime: undefined,
 }
 
 export const tradeQuoteSlice = createSlice({
@@ -21,8 +23,15 @@ export const tradeQuoteSlice = createSlice({
     setSwapperName: (state, action: PayloadAction<SwapperName | undefined>) => {
       state.swapperName = action.payload
     },
-    setQuotes: (state, action: PayloadAction<ApiQuote[]>) => {
-      state.quotes = action.payload
+    setQuotes: (state, action: PayloadAction<{ quotes: ApiQuote[]; queryStartTime: number }>) => {
+      if (
+        !state.lastRequestStartTime ||
+        action.payload.queryStartTime > state.lastRequestStartTime
+      ) {
+        state.quotes = action.payload.quotes
+        state.swapperName = action.payload.quotes[0]?.swapperName
+        state.lastRequestStartTime = action.payload.queryStartTime
+      }
     },
   },
 })

--- a/src/test/mocks/store.ts
+++ b/src/test/mocks/store.ts
@@ -173,7 +173,6 @@ export const mockStore: ReduxState = {
   },
   tradeQuoteSlice: {
     swapperName: undefined,
-    quote: undefined,
-    error: undefined,
+    quotes: [],
   },
 }

--- a/src/test/mocks/store.ts
+++ b/src/test/mocks/store.ts
@@ -174,5 +174,6 @@ export const mockStore: ReduxState = {
   tradeQuoteSlice: {
     swapperName: undefined,
     quotes: [],
+    lastRequestStartTime: undefined,
   },
 }


### PR DESCRIPTION
## Description

Consolidates swapper endpoints into one.

- Handles race conditions by adding a `lastRequestStartTime` property to the `tradeQuoteSlice`, and checking/updating it's value in the `setQuotes` action. This is handled "client-side" and left out of the RTK endpoint to be more end-state ready.

- Stored quotes in the slice for now, will experiment with pulling directly from the cache in another PR.

## Pull Request Type

- [ ] :bug: Bug fix (Non-breaking Change: Fixes an issue)
- [x] :hammer_and_wrench: Chore (Non-breaking Change: Doc updates, pkg upgrades, typos, etc..)
- [ ] :nail_care: New Feature (Breaking/Non-breaking Change)

## Issue (if applicable)

N/A

## Risk

No risk to production, medium risk to the exchange architecture flagged code paths.

## Testing

N/A

### Engineering

Ensure we still get quotes as expected, and that the `tradeQuoteSlice` stores quotes under the `quotes` key.

Ensure that the race-condition handling functions as expected.

### Operations

N/A

## Screenshots (if applicable)

N/A
