### PR TITLE
fix: reimplement checkTradeStatus for thorchain swapper

### DIFF
--- a/src/lib/swapper/swappers/ThorchainSwapper/endpoints.ts
+++ b/src/lib/swapper/swappers/ThorchainSwapper/endpoints.ts
@@ -11,6 +11,7 @@ import type {
 } from 'lib/swapper/api'
 
 import { getThorTradeQuote } from './getThorTradeQuote/getTradeQuote'
+import { getTradeTxs } from './getTradeTxs/getTradeTxs'
 import type { Rates, ThorUtxoSupportedChainId } from './ThorchainSwapper'
 import { getSignTxFromQuote } from './utils/getSignTxFromQuote'
 
@@ -65,32 +66,26 @@ export const thorchainApi: Swapper2Api = {
     })
   },
 
-  // FIXME: implement in a way that doesn't cause circular dependencies
-  // eslint-disable-next-line require-await
   checkTradeStatus: async ({
     txId,
   }): Promise<{ status: TxStatus; buyTxId: string | undefined; message: string | undefined }> => {
-    // const thorchainSwapper = new ThorchainSwapper()
-    // thorchain swapper uses txId to get tx status (not trade ID)
-    // const txsResult = await thorchainSwapper.getTradeTxs({ tradeId: txId })
-    // const status = (() => {
-    //   switch (true) {
-    //     case txsResult.isOk() && !!txsResult.unwrap().buyTxid:
-    //       return TxStatus.Confirmed
-    //     case txsResult.isOk() && !txsResult.unwrap().buyTxid:
-    //       return TxStatus.Pending
-    //     case txsResult.isErr():
-    //       return TxStatus.Failed
-    //     default:
-    //       return TxStatus.Unknown
-    //   }
-    // })()
-    //
-    // return {
-    //   buyTxId: txsResult.isOk() ? txsResult.unwrap().buyTxid : undefined,
-    //   status,
-    //   message: undefined,
-    // }
-    return Promise.resolve({ buyTxId: txId, message: txId, status: TxStatus.Unknown })
+    try {
+      // thorchain swapper uses txId to get tx status (not trade ID)
+      const { buyTxId } = await getTradeTxs({ tradeId: txId })
+      const status = buyTxId ? TxStatus.Confirmed : TxStatus.Pending
+
+      return {
+        buyTxId,
+        status,
+        message: undefined,
+      }
+    } catch (e) {
+      console.error(e)
+      return {
+        buyTxId: undefined,
+        status: TxStatus.Failed,
+        message: undefined,
+      }
+    }
   },
 }

--- a/src/lib/swapper/swappers/ThorchainSwapper/getTradeTxs/getTradeTxs.ts
+++ b/src/lib/swapper/swappers/ThorchainSwapper/getTradeTxs/getTradeTxs.ts
@@ -1,0 +1,43 @@
+import { getConfig } from 'config'
+import type { TradeResult } from 'lib/swapper/api'
+
+import type { MidgardActionsResponse } from '../ThorchainSwapper'
+import { thorService } from '../utils/thorService'
+
+export const getTradeTxs = async (
+  tradeResult: TradeResult,
+): Promise<{ sellTxId: string; buyTxId?: string }> => {
+  const midgardTxid = tradeResult.tradeId.startsWith('0x')
+    ? tradeResult.tradeId.slice(2)
+    : tradeResult.tradeId
+
+  const midgardUrl = getConfig().REACT_APP_MIDGARD_URL
+
+  const result = await thorService.get<MidgardActionsResponse>(
+    `${midgardUrl}/actions?txid=${midgardTxid}`,
+  )
+
+  if (result.isErr()) throw result.unwrapErr()
+
+  const { data } = result.unwrap()
+  // https://gitlab.com/thorchain/thornode/-/blob/develop/common/tx.go#L22
+  // responseData?.actions[0].out[0].txID should be the txId for consistency, but the outbound Tx for Thor rune swaps is actually a BlankTxId
+  // so we use the buyTxId for completion detection
+  const buyTxId =
+    data?.actions[0]?.status === 'success' && data?.actions[0]?.type === 'swap' ? midgardTxid : ''
+
+  // This will detect all the errors I have seen.
+  if (data?.actions[0]?.status === 'success' && data?.actions[0]?.type !== 'swap')
+    throw Error('[getTradeTxs]: trade failed')
+
+  const standardBuyTxid = (() => {
+    const outCoinAsset = data?.actions[0]?.out[0]?.coins[0]?.asset
+    const isEvmCoinAsset = outCoinAsset?.startsWith('ETH.') || outCoinAsset?.startsWith('AVAX.')
+    return isEvmCoinAsset ? `0x${buyTxId}` : buyTxId
+  })().toLowerCase()
+
+  return {
+    sellTxId: tradeResult.tradeId,
+    buyTxId: standardBuyTxid,
+  }
+}


### PR DESCRIPTION
## Description

Reimplements `checkTradeStatus` for thorchain `Swapper2` to resolv circular dependincy caused by original implementation importing rest of legacy swapper.

Opted to create a fresh implementation based on ThorChainSwapper class method to ensure zero change to production facing code. 

Monads not used as they are for user facing error messages in quotes, and this has special error handling inside the poller.

## Pull Request Type

- [x] :bug: Bug fix (Non-breaking Change: Fixes an issue)
- [ ] :hammer_and_wrench: Chore (Non-breaking Change: Doc updates, pkg upgrades, typos, etc..)
- [ ] :nail_care: New Feature (Breaking/Non-breaking Change)

## Issue (if applicable)

NA

## Risk

No risk, not user facing

## Testing

Check thor trades complete (green check mark) using new swapper

### Engineering

See above

### Operations

No action required

## Screenshots (if applicable)
