### PR TITLE
fix: initialise selectedBuyAssetAccountId & selectedSellAssetAccountId

### DIFF
--- a/src/components/Trade/hooks/useAccountsService.tsx
+++ b/src/components/Trade/hooks/useAccountsService.tsx
@@ -26,6 +26,12 @@ export const useAccountsService = () => {
   const updateSellAssetAccountId = useSwapperStore(state => state.updateSellAssetAccountId)
   const selectedBuyAssetAccountId = useSwapperStore(selectSelectedBuyAssetAccountId)
   const selectedSellAssetAccountId = useSwapperStore(selectSelectedSellAssetAccountId)
+  const updateSelectedBuyAssetAccountId = useSwapperStore(
+    state => state.updateSelectedBuyAssetAccountId,
+  )
+  const updateSelectedSellAssetAccountId = useSwapperStore(
+    state => state.updateSelectedSellAssetAccountId,
+  )
   const activeSwapper = useSwapperStore(state => selectActiveSwapperWithMetadata(state)?.swapper)
   const buyAsset = useSwapperStore(selectBuyAsset)
   const sellAsset = useSwapperStore(selectSellAsset)
@@ -63,9 +69,18 @@ export const useAccountsService = () => {
 
   // Set sellAssetAccountId
   useEffect(
-    () => updateSellAssetAccountId(sellAssetAccountId),
+    () => {
+      updateSellAssetAccountId(sellAssetAccountId)
+      !selectedSellAssetAccountId && updateSelectedSellAssetAccountId(sellAssetAccountId)
+    },
     // stateSellAssetAccountId is important here as it ensures this useEffect re-runs when the form value is cleared
-    [sellAssetAccountId, stateSellAssetAccountId, updateSellAssetAccountId],
+    [
+      selectedSellAssetAccountId,
+      sellAssetAccountId,
+      stateSellAssetAccountId,
+      updateSelectedSellAssetAccountId,
+      updateSellAssetAccountId,
+    ],
   )
 
   // Set buyAssetAccountId
@@ -79,6 +94,9 @@ export const useAccountsService = () => {
     const buyAssetAccountIdToSet =
       swapperSupportsCrossAccountTrade || !activeSwapper ? buyAssetAccountId : sellAssetAccountId
     updateBuyAssetAccountId(buyAssetAccountIdToSet)
+
+    !selectedBuyAssetAccountId && updateSelectedBuyAssetAccountId(buyAssetAccountIdToSet)
+
     // stateBuyAssetAccountId is important here as it ensures this useEffect re-runs when the form value is cleared
   }, [
     buyAssetAccountId,
@@ -87,5 +105,7 @@ export const useAccountsService = () => {
     stateBuyAssetAccountId,
     activeSwapper,
     updateBuyAssetAccountId,
+    selectedBuyAssetAccountId,
+    updateSelectedBuyAssetAccountId,
   ])
 }


### PR DESCRIPTION
## Description

Fixes the "no receive address" bug in production.

Issue is caused by the `updateSelectedSellAssetAccountId` and `updateSelectedBuyAssetAccountId` reducers not firing again after being cleared by changing assets.

## Pull Request Type

- [x] :bug: Bug fix (Non-breaking Change: Fixes an issue)
- [ ] :hammer_and_wrench: Chore (Non-breaking Change: Doc updates, pkg upgrades, typos, etc..)
- [ ] :nail_care: New Feature (Breaking/Non-breaking Change)

## Issue (if applicable)

Closes https://github.com/shapeshift/web/issues/4850

## Risk

Small surface area, but this impact of us getting anything related to accounts wrong is substantial.

## Testing

Attempt to trade into ETH by switching assets on initial load. It should no longer say "no receive address".

### Engineering

Check that the seleted account id values in the redux swapper store are _always_ what we expect when changing assets, swappers etc.

### Operations

☝️

## Screenshots (if applicable)

N/A
