### PR TITLE
feat: wire up exchange UI

### DIFF
--- a/src/components/MultiHopTrade/components/TradeInput/TradeInput.tsx
+++ b/src/components/MultiHopTrade/components/TradeInput/TradeInput.tsx
@@ -45,8 +45,10 @@ import {
   selectActiveSwapperName,
   selectBuyAmountBeforeFeesCryptoPrecision,
   selectFirstHop,
+  selectNetBuyAmountFiat,
   selectNetReceiveAmountCryptoPrecision,
   selectSwapperSupportsCrossAccountTrade,
+  selectTotalNetworkFeeFiatPrecision,
   selectTotalProtocolFeeByAsset,
 } from 'state/slices/tradeQuoteSlice/selectors'
 import { tradeQuoteSlice } from 'state/slices/tradeQuoteSlice/tradeQuoteSlice'
@@ -79,6 +81,8 @@ export const TradeInput = (props: CardProps) => {
   const swapperSupportsCrossAccountTrade = useAppSelector(selectSwapperSupportsCrossAccountTrade)
   const totalProtocolFees = useAppSelector(selectTotalProtocolFeeByAsset)
   const buyAmountAfterFeesCryptoPrecision = useAppSelector(selectNetReceiveAmountCryptoPrecision)
+  const buyAmountAfterFeesFiat = useAppSelector(selectNetBuyAmountFiat)
+  const totalNetworkFeeFiatPrecision = useAppSelector(selectTotalNetworkFeeFiatPrecision)
 
   const activeQuoteStatus = useActiveQuoteStatus()
   const setBuyAsset = useCallback(
@@ -227,7 +231,7 @@ export const TradeInput = (props: CardProps) => {
                 assetSymbol={buyAsset.symbol}
                 assetIcon={buyAsset.icon}
                 cryptoAmount={buyAmountAfterFeesCryptoPrecision}
-                fiatAmount={'1.234'}
+                fiatAmount={buyAmountAfterFeesFiat}
                 percentOptions={[1]}
                 showInputSkeleton={isLoading}
                 showFiatSkeleton={isLoading}
@@ -258,10 +262,10 @@ export const TradeInput = (props: CardProps) => {
               borderWidth={1}
             >
               <RateGasRow
-                sellSymbol={''}
-                buySymbol={''}
-                gasFee={'0'}
-                rate={undefined}
+                sellSymbol={sellAsset.symbol}
+                buySymbol={buyAsset.symbol}
+                gasFee={totalNetworkFeeFiatPrecision ?? 'unknown'}
+                rate={activeQuote?.steps[0].rate}
                 isLoading={isLoading}
                 isError={activeQuoteError !== undefined}
               />

--- a/src/components/MultiHopTrade/components/TradeInput/components/SellAssetInput.tsx
+++ b/src/components/MultiHopTrade/components/TradeInput/components/SellAssetInput.tsx
@@ -1,5 +1,5 @@
 import type { AccountId } from '@shapeshiftoss/caip'
-import { useCallback, useState } from 'react'
+import { useCallback, useEffect, useState } from 'react'
 import { TradeAssetInput } from 'components/Trade/Components/TradeAssetInput'
 import type { Asset } from 'lib/asset-service'
 import { bnOrZero } from 'lib/bignumber/bignumber'
@@ -42,6 +42,10 @@ export const SellAssetInput = ({
     },
     [dispatch, sellAssetFiatRate],
   )
+
+  useEffect(() => {
+    handleSellAssetInputChange('0', undefined)
+  }, [asset, handleSellAssetInputChange])
 
   return (
     <TradeAssetInput


### PR DESCRIPTION
## Description

Wire up some of the missing/hardcoded fields in the exchange API.

- Gas for the selected swapper in the unexpanded view
- Fiat amount for the "You get" section
- Rate for the selected swapper in the unexpanded view

## Pull Request Type

- [ ] :bug: Bug fix (Non-breaking Change: Fixes an issue)
- [ ] :hammer_and_wrench: Chore (Non-breaking Change: Doc updates, pkg upgrades, typos, etc..)
- [x] :nail_care: New Feature (Breaking/Non-breaking Change)

## Issue (if applicable)

N/A

## Risk

Very small - all changes are behind the "multi-hop" feature flag.

## Testing

None needed by ops.

### Engineering

With the multi-hop flag enabled, we should now show:

- Gas for the selected swapper in the unexpanded view
- Fiat amount for the "You get" section
- Rate for the selected swapper in the unexpanded view

### Operations

N/A

## Screenshots (if applicable)

<img width="477" alt="Screenshot 2023-07-05 at 6 46 57 pm" src="https://github.com/shapeshift/web/assets/97164662/452f16f5-f6c8-4fe7-ab89-edea64817c52">

