### PR TITLE
fix: normalizeAmount should not round amounts up

### DIFF
--- a/src/lib/swapper/swappers/utils/helpers/helpers.test.ts
+++ b/src/lib/swapper/swappers/utils/helpers/helpers.test.ts
@@ -6,9 +6,39 @@ import { getTreasuryAddressFromChainId, normalizeAmount, normalizeIntegerAmount 
 
 describe('utils', () => {
   describe('normalizeAmount', () => {
-    it('should return a string number rounded to the 16th decimal place', () => {
-      const result = normalizeAmount('586084736227728377283728272309128120398')
-      expect(result).toEqual('586084736227728400000000000000000000000')
+    it('should preserve large numbers without rounding', () => {
+      const amount = '586084736227728377283728272309128120398'
+      const result = normalizeAmount(amount)
+      expect(result).toEqual(amount)
+    })
+    it('should handle large numbers without rounding', () => {
+      const amount = '1154718796212771995121'
+      const result = normalizeAmount(amount)
+      expect(result).toEqual(amount)
+    })
+
+    it('should handle BigNumber input correctly', () => {
+      const amount = bn('123456789.123456789')
+      const result = normalizeAmount(amount)
+      expect(result).toEqual('123456789.123456789')
+    })
+
+    it('should handle numbers input correctly', () => {
+      const amount = 123456
+      const result = normalizeAmount(amount)
+      expect(result).toEqual('123456')
+    })
+
+    it('should handle strings input correctly', () => {
+      const amount = '123456'
+      const result = normalizeAmount(amount)
+      expect(result).toEqual(amount)
+    })
+
+    it('should handle decimal numbers correctly', () => {
+      const amount = '123456.7890123456789'
+      const result = normalizeAmount(amount)
+      expect(result).toEqual(amount)
     })
   })
 })

--- a/src/lib/swapper/swappers/utils/helpers/helpers.ts
+++ b/src/lib/swapper/swappers/utils/helpers/helpers.ts
@@ -29,7 +29,7 @@ import type { GetTradeQuoteInput, TradeQuote } from 'lib/swapper/api'
  * @param amount
  */
 export const normalizeAmount = (amount: string | number | BigNumber): string => {
-  return bnOrZero(amount).toNumber().toLocaleString('fullwide', { useGrouping: false })
+  return bnOrZero(amount).toFixed()
 }
 
 export const normalizeIntegerAmount = (amount: string | number | BigNumber): string => {


### PR DESCRIPTION
## Description

Fixes `normalizeAmount` rounding inputs up and making ZRX XHRs potentially fail on ERC-20s send maxes, since, depending on the actual balance for that address, the sellAmount we might be requesting might be off by a few weis from the actual balance of the address.

Note, at this point, `normalizeAmount` doesn't do much anymore and the new tests have been added to validate the implementation - we might want to ditch it entirely.

## Pull Request Type

- [x] :bug: Bug fix (Non-breaking Change: Fixes an issue)
- [ ] :hammer_and_wrench: Chore (Non-breaking Change: Doc updates, pkg upgrades, typos, etc..)
- [ ] :nail_care: New Feature (Breaking/Non-breaking Change)

## Issue (if applicable)

<!-----------------------------------------------------------------------------
If applicable, please link to the github issue and put `closes #XXXX` in your comment to auto-close the issue that your PR fixes.
------------------------------------------------------------------------------>

closes https://github.com/shapeshift/web/issues/4879

## Risk

<!-----------------------------------------------------------------------------
Outline the scope of your changes and the risk associated with them. You must use your discretion as an engineer to determine the potential impact of your changes.

E.g. an upgrade to `hdwallet` or core state management would be considered higher risk, and might require a full regression test. UI or isolated view changes, or something behind a feature flag may have near zero risk. Small bug fixes might require testing isolated to the specific fix.
------------------------------------------------------------------------------>

None, does the same thing the original implementation intended to, minus the rounding.

## Testing

<!-----------------------------------------------------------------------------
We treat every PR to be merged with the same scrutiny as if we were merging directly to production.

Your PR will not be merged if you do not complete the sections below for our engineering and operations teams to test.
------------------------------------------------------------------------------>

- ZRX quotes are happy, including with max. trades
- 1inch quotes are happy, including with max. trades

### Engineering

<!-----------------------------------------------------------------------------
Include sufficient information here for an engineer to test your PR. This may include how to test locally, in a built environment, changes to infrastructure etc.
------------------------------------------------------------------------------>

- ☝🏽 

### Operations

<!-----------------------------------------------------------------------------
If your changes have a user-facing impact, describe how a non-technical QA team can functionally test your changes in a preview environment.

If they are not user-facing please describe how to test for any regressions that may occur.
------------------------------------------------------------------------------>

- ☝🏽 

## Screenshots (if applicable)

Postman replays have been redacted to keep only the `sellAmount` - note how the failing one on the current implementation rounds the amount up

### Develop/Prod

<img width="1579" alt="image" src="https://github.com/shapeshift/web/assets/17035424/3c01861e-1f34-4ec3-af24-9dd8b650072d">
<img width="1296" alt="image" src="https://github.com/shapeshift/web/assets/17035424/fbc47b01-02eb-453e-a210-798dd8ca1974">


### This diff

<img width="826" alt="image" src="https://github.com/shapeshift/web/assets/17035424/e2838307-8caa-422b-ba38-5d66bdbb6780">
<img width="1292" alt="image" src="https://github.com/shapeshift/web/assets/17035424/a08445ca-4b9e-4274-8566-72d08923358a">