### PR TITLE
feat: lifi use common evm utils

### DIFF
--- a/src/lib/swapper/swappers/LifiSwapper/executeTrade/executeTrade.ts
+++ b/src/lib/swapper/swappers/LifiSwapper/executeTrade/executeTrade.ts
@@ -1,175 +1,106 @@
-import type Lifi from '@lifi/sdk/dist/Lifi'
-import type { GetStatusRequest, Route } from '@lifi/sdk/dist/types'
-import type { BuildSendTxInput, EvmChainId } from '@shapeshiftoss/chain-adapters'
-import type { HDWallet } from '@shapeshiftoss/hdwallet-core'
+import type { GetStatusRequest } from '@lifi/sdk/dist/types'
 import type { Result } from '@sniptt/monads'
 import { Err, Ok } from '@sniptt/monads'
-import type { providers } from 'ethers'
 import { getChainAdapterManager } from 'context/PluginProvider/chainAdapterSingleton'
+import { bn } from 'lib/bignumber/bignumber'
 import type { SwapErrorRight, TradeResult } from 'lib/swapper/api'
-import { makeSwapErrorRight, SwapError, SwapErrorType } from 'lib/swapper/api'
+import { makeSwapErrorRight, SwapErrorType } from 'lib/swapper/api'
 import { getLifi } from 'lib/swapper/swappers/LifiSwapper/utils/getLifi'
 import type { LifiExecuteTradeInput } from 'lib/swapper/swappers/LifiSwapper/utils/types'
-import { isEvmChainAdapter } from 'lib/utils/evm'
+import { buildAndBroadcast, createBuildCustomTxInput, isEvmChainAdapter } from 'lib/utils/evm'
 
-const createBuildSendTxInput = async (
-  lifi: Lifi,
-  wallet: HDWallet,
-  accountNumber: number,
-  selectedLifiRoute: Route,
-): Promise<Result<BuildSendTxInput<EvmChainId>, SwapErrorRight>> => {
-  // the 0th step is used because its the first in the route, and this must be signed by the owner
-  const startStep = selectedLifiRoute.steps[0]
-
-  const transactionRequest: providers.TransactionRequest = await (async () => {
-    const transactionRequest = startStep?.transactionRequest
-
-    if (transactionRequest !== undefined) return transactionRequest
-
-    // if transactionRequest is not present, request it
-    const { transactionRequest: newTransactionRequest } = await lifi.getStepTransaction(startStep)
-    return newTransactionRequest ?? {}
-  })()
-
-  const { value, to, gasPrice, gasLimit, data } = transactionRequest
-
-  if (
-    transactionRequest === undefined ||
-    value === undefined ||
-    to === undefined ||
-    gasPrice === undefined ||
-    gasLimit === undefined ||
-    data === undefined
-  ) {
-    return Err(
-      makeSwapErrorRight({
-        message: '[createBuildSendTxInput] - incomplete or undefined transaction request',
-        code: SwapErrorType.EXECUTE_TRADE_FAILED,
-        details: { transactionRequest },
-      }),
-    )
-  }
-
-  return Ok({
-    value: value.toString(),
-    wallet,
-    to,
-    chainSpecific: {
-      gasPrice: gasPrice.toString(),
-      gasLimit: gasLimit.toString(),
-      maxFeePerGas: undefined,
-      maxPriorityFeePerGas: undefined,
-      data: data.toString(),
-    },
-    accountNumber,
-  })
+type ExecuteTradeResult = {
+  tradeResult: TradeResult
+  getStatusRequest: GetStatusRequest
 }
 
 export const executeTrade = async ({
   trade,
   wallet,
-}: LifiExecuteTradeInput): Promise<
-  Result<
-    {
-      tradeResult: TradeResult
-      getStatusRequest: GetStatusRequest
-    },
-    SwapErrorRight
-  >
-> => {
-  try {
-    const lifi = getLifi()
+}: LifiExecuteTradeInput): Promise<Result<ExecuteTradeResult, SwapErrorRight>> => {
+  const { accountNumber, sellAsset, selectedLifiRoute } = trade
 
-    const { accountNumber, sellAsset, selectedLifiRoute } = trade
-
-    const chainId = sellAsset.chainId
-    const adapterManager = getChainAdapterManager()
-    const adapter = adapterManager.get(chainId)
-
-    if (adapter === undefined) {
-      throw new SwapError('[executeTrade] - getChainAdapterManager returned undefined', {
-        code: SwapErrorType.UNSUPPORTED_CHAIN,
-        details: { chainId },
-      })
-    }
-
-    if (selectedLifiRoute === undefined) {
-      throw new SwapError('[executeTrade] - no selected route was provided', {
-        code: SwapErrorType.EXECUTE_TRADE_FAILED,
-      })
-    }
-
-    if (!isEvmChainAdapter(adapter)) {
-      throw new SwapError('[executeTrade] - non-EVM chain adapter detected', {
-        code: SwapErrorType.EXECUTE_TRADE_FAILED,
-        details: {
-          chainAdapterName: adapter.getDisplayName(),
-          chainId: adapter.getChainId(),
-        },
-      })
-    }
-
-    const buildSendTxInput = await createBuildSendTxInput(
-      lifi,
-      wallet,
-      accountNumber,
-      selectedLifiRoute,
-    )
-
-    if (buildSendTxInput.isErr()) return Err(buildSendTxInput.unwrapErr())
-
-    const { txToSign } = await adapter.buildSendTransaction(buildSendTxInput.unwrap())
-
-    const maybeTxHash: Result<string, SwapErrorRight> = await (async () => {
-      if (wallet.supportsOfflineSigning()) {
-        const signedTx = await adapter.signTransaction({ txToSign, wallet })
-
-        const txid = await adapter.broadcastTransaction(signedTx)
-
-        return Ok(txid)
-      }
-
-      if (wallet.supportsBroadcast() && adapter.signAndBroadcastTransaction) {
-        const txid = await adapter.signAndBroadcastTransaction?.({
-          txToSign,
-          wallet,
-        })
-
-        return Ok(txid)
-      }
-
-      return Err(
-        makeSwapErrorRight({
-          message: '[executeTrade] - sign and broadcast failed',
-          code: SwapErrorType.SIGN_AND_BROADCAST_FAILED,
-        }),
-      )
-    })()
-
-    return maybeTxHash.map(txHash => {
-      const getStatusRequest: GetStatusRequest = {
-        txHash,
-        bridge: selectedLifiRoute.steps[0].tool,
-        fromChain: selectedLifiRoute.fromChainId,
-        toChain: selectedLifiRoute.toChainId,
-      }
-
-      return { tradeResult: { tradeId: txHash }, getStatusRequest }
-    })
-  } catch (e) {
-    if (e instanceof SwapError)
-      return Err(
-        makeSwapErrorRight({
-          message: e.message,
-          code: e.code,
-          details: e.details,
-        }),
-      )
+  if (!selectedLifiRoute) {
     return Err(
       makeSwapErrorRight({
-        message: '[executeTrade]',
-        cause: e,
+        message: '[executeTrade] - no selected route was provided',
+        code: SwapErrorType.MISSING_INPUT,
+      }),
+    )
+  }
+
+  const adapter = getChainAdapterManager().get(sellAsset.chainId)
+
+  if (!isEvmChainAdapter(adapter)) {
+    return Err(
+      makeSwapErrorRight({
+        message: '[executeTrade] - unsupported chain adapter',
+        code: SwapErrorType.UNSUPPORTED_CHAIN,
+        details: { chainId: sellAsset.chainId },
+      }),
+    )
+  }
+
+  const lifi = getLifi()
+
+  // the 0th step is used because its the first in the route, and this must be signed by the owner
+  const startStep = selectedLifiRoute.steps[0]
+
+  const transactionRequest = await (async () => {
+    try {
+      if (startStep?.transactionRequest) return Ok(startStep.transactionRequest)
+      return Ok((await lifi.getStepTransaction(startStep)).transactionRequest)
+    } catch (err) {
+      return Err(
+        makeSwapErrorRight({
+          message: '[executeTrade] - failed to get transactionRequest',
+          cause: err,
+          code: SwapErrorType.RESPONSE_ERROR,
+        }),
+      )
+    }
+  })()
+
+  if (transactionRequest.isErr()) return Err(transactionRequest.unwrapErr())
+
+  const { value, to, data } = transactionRequest.unwrap() ?? {}
+
+  if (!value || !to || !data) {
+    return Err(
+      makeSwapErrorRight({
+        message: '[executeTrade] - invalid transaction request',
+        code: SwapErrorType.VALIDATION_FAILED,
+        details: { transactionRequest },
+      }),
+    )
+  }
+
+  try {
+    const buildCustomTxInput = await createBuildCustomTxInput({
+      accountNumber,
+      adapter,
+      data: data.toString(),
+      to,
+      value: bn(value.toString()).toFixed(),
+      wallet,
+    })
+
+    const txid = await buildAndBroadcast({ adapter, buildCustomTxInput })
+
+    const getStatusRequest: GetStatusRequest = {
+      txHash: txid,
+      bridge: selectedLifiRoute.steps[0].tool,
+      fromChain: selectedLifiRoute.fromChainId,
+      toChain: selectedLifiRoute.toChainId,
+    }
+
+    return Ok({ tradeResult: { tradeId: txid }, getStatusRequest })
+  } catch (err) {
+    return Err(
+      makeSwapErrorRight({
+        message: '[executeTrade] - failed to build and broadcast transaction',
         code: SwapErrorType.EXECUTE_TRADE_FAILED,
+        cause: err,
       }),
     )
   }

--- a/src/lib/swapper/swappers/LifiSwapper/getTradeQuote/getTradeQuote.ts
+++ b/src/lib/swapper/swappers/LifiSwapper/getTradeQuote/getTradeQuote.ts
@@ -2,6 +2,7 @@ import type { ChainKey, LifiError, RoutesRequest } from '@lifi/sdk'
 import { LifiErrorCode } from '@lifi/sdk'
 import type { AssetId, ChainId } from '@shapeshiftoss/caip'
 import { fromChainId } from '@shapeshiftoss/caip'
+import type { HDWallet } from '@shapeshiftoss/hdwallet-core'
 import type { Result } from '@sniptt/monads'
 import { Err, Ok } from '@sniptt/monads'
 import { getDefaultSlippagePercentageForSwapper } from 'constants/constants'
@@ -24,7 +25,7 @@ import { getLifiChainMap } from '../utils/getLifiChainMap'
 import { getNetworkFeeCryptoBaseUnit } from '../utils/getNetworkFeeCryptoBaseUnit/getNetworkFeeCryptoBaseUnit'
 
 export async function getTradeQuote(
-  input: GetEvmTradeQuoteInput,
+  input: GetEvmTradeQuoteInput & { wallet?: HDWallet },
   lifiChainMap: Map<ChainId, ChainKey>,
   assets: Partial<Record<AssetId, Asset>>,
   sellAssetPriceUsdPrecision: string,
@@ -39,6 +40,8 @@ export async function getTradeQuote(
       receiveAddress,
       accountNumber,
       allowMultiHop,
+      supportsEIP1559,
+      wallet,
     } = input
 
     const sellLifiChainKey = lifiChainMap.get(sellAsset.chainId)
@@ -134,8 +137,11 @@ export async function getTradeQuote(
         const intermediaryTransactionOutputs = getIntermediaryTransactionOutputs(assets, lifiStep)
 
         const networkFeeCryptoBaseUnit = await getNetworkFeeCryptoBaseUnit({
+          accountNumber,
           chainId,
           lifiStep,
+          supportsEIP1559,
+          wallet,
         })
 
         return {

--- a/src/lib/swapper/swappers/LifiSwapper/utils/getNetworkFeeCryptoBaseUnit/getNetworkFeeCryptoBaseUnit.ts
+++ b/src/lib/swapper/swappers/LifiSwapper/utils/getNetworkFeeCryptoBaseUnit/getNetworkFeeCryptoBaseUnit.ts
@@ -1,70 +1,96 @@
 import type { Step } from '@lifi/sdk'
 import type { ChainId } from '@shapeshiftoss/caip'
+import type { HDWallet } from '@shapeshiftoss/hdwallet-core'
 import { KnownChainIds } from '@shapeshiftoss/types'
 import type { BigNumber } from 'ethers'
 import { ethers } from 'ethers'
 import { getChainAdapterManager } from 'context/PluginProvider/chainAdapterSingleton'
-import { bn, bnOrZero } from 'lib/bignumber/bignumber'
+import { bn } from 'lib/bignumber/bignumber'
 import { getEthersProvider } from 'lib/ethersProviderSingleton'
 import { SwapError, SwapErrorType } from 'lib/swapper/api'
-import { isEvmChainAdapter } from 'lib/utils/evm'
+import { calcNetworkFeeCryptoBaseUnit, getFees, isEvmChainAdapter } from 'lib/utils/evm'
 
 import { OPTIMISM_GAS_ORACLE_ADDRESS } from '../constants'
 import { getLifi } from '../getLifi'
 
-export const getNetworkFeeCryptoBaseUnit = async ({
-  chainId,
-  lifiStep,
-}: {
+type GetNetworkFeeArgs = {
+  accountNumber: number
   chainId: ChainId
   lifiStep: Step
-}) => {
+  supportsEIP1559: boolean
+  wallet?: HDWallet
+}
+
+export const getNetworkFeeCryptoBaseUnit = async ({
+  accountNumber,
+  chainId,
+  lifiStep,
+  supportsEIP1559,
+  wallet,
+}: GetNetworkFeeArgs) => {
   const lifi = getLifi()
   const adapter = getChainAdapterManager().get(chainId)
 
-  if (adapter === undefined || !isEvmChainAdapter(adapter)) {
-    throw new SwapError('[getNetworkFeeCryptoBaseUnit] invalid chain adapter', {
-      code: SwapErrorType.TRADE_QUOTE_FAILED,
+  if (!isEvmChainAdapter(adapter)) {
+    throw new SwapError('[getNetworkFeeCryptoBaseUnit] - unsupported chain adapter', {
+      code: SwapErrorType.VALIDATION_FAILED,
       details: { chainId },
     })
   }
 
   const { transactionRequest } = await lifi.getStepTransaction(lifiStep)
-  const { value, from, to, data, gasLimit, gasPrice, maxFeePerGas } = transactionRequest ?? {}
+  const { value, to, data, gasLimit } = transactionRequest ?? {}
 
-  if (value === undefined || from === undefined || to === undefined || data === undefined) {
+  if (!value || !to || !data || !gasLimit) {
     throw new SwapError('[getNetworkFeeCryptoBaseUnit] getStepTransaction failed', {
-      code: SwapErrorType.TRADE_QUOTE_FAILED,
+      code: SwapErrorType.VALIDATION_FAILED,
     })
   }
 
-  const gasFee = maxFeePerGas
-    ? bn(maxFeePerGas as string)
-    : bnOrZero(gasLimit as string).times(gasPrice as string)
+  // if we have a wallet, we are trying to build the actual trade, get accurate gas estimation
+  if (wallet) {
+    const { networkFeeCryptoBaseUnit } = await getFees({
+      accountNumber,
+      adapter,
+      to,
+      data: data.toString(),
+      value: bn(value.toString()).toFixed(),
+      wallet,
+    })
 
-  // TEMP: this is necessary because infura currently cannot estimate gas for some lifi contract
-  // interactions, so instead of calling our existing stack which relies on infura we call the
-  // optimism gas oracle directly.
-  if (chainId === KnownChainIds.OptimismMainnet) {
-    const optimismGasOracleAbi: ethers.ContractInterface = [
+    return networkFeeCryptoBaseUnit
+  }
+
+  const { average } = await adapter.getGasFeeData()
+
+  const l1GasLimit = await (async () => {
+    if (chainId !== KnownChainIds.OptimismMainnet) return
+
+    const provider = getEthersProvider(chainId)
+
+    const abi = [
       {
         inputs: [{ internalType: 'bytes', name: '_data', type: 'bytes' }],
-        name: 'getL1Fee',
+        name: 'getL1GasUsed',
         outputs: [{ internalType: 'uint256', name: '', type: 'uint256' }],
         stateMutability: 'view',
         type: 'function',
       },
     ]
 
-    const tokenContract = new ethers.Contract(
-      OPTIMISM_GAS_ORACLE_ADDRESS,
-      optimismGasOracleAbi,
-      getEthersProvider(chainId),
-    )
+    const contract = new ethers.Contract(OPTIMISM_GAS_ORACLE_ADDRESS, abi, provider)
 
-    const l1Fee = (await tokenContract.getL1Fee(data)) as BigNumber
-    return gasFee.plus(l1Fee.toString()).toString()
-  }
+    const l1GasUsed = (await contract.getL1GasUsed(data)) as BigNumber
 
-  return gasFee.toString()
+    return l1GasUsed.toString()
+  })()
+
+  const networkFeeCryptoBaseUnit = calcNetworkFeeCryptoBaseUnit({
+    ...average,
+    supportsEIP1559,
+    gasLimit: gasLimit?.toString(),
+    l1GasLimit,
+  })
+
+  return networkFeeCryptoBaseUnit
 }

--- a/src/lib/utils/evm.ts
+++ b/src/lib/utils/evm.ts
@@ -104,15 +104,17 @@ export const getFees = async (args: GetFeesArgs): Promise<Fees> => {
     average: { chainSpecific: feeData },
   } = await adapter.getFeeData(getFeeDataInput)
 
+  const _supportsEIP1559 =
+    supportsEIP1559 ?? (supportsETH(wallet) && (await wallet.ethSupportsEIP1559()))
+
   const networkFeeCryptoBaseUnit = calcNetworkFeeCryptoBaseUnit({
     ...feeData,
-    supportsEIP1559:
-      supportsEIP1559 ?? (supportsETH(wallet) && (await wallet.ethSupportsEIP1559())),
+    supportsEIP1559: _supportsEIP1559,
   })
 
   const { gasLimit, gasPrice, maxFeePerGas, maxPriorityFeePerGas } = feeData
 
-  if (supportsEIP1559 && maxFeePerGas && maxPriorityFeePerGas) {
+  if (_supportsEIP1559 && maxFeePerGas && maxPriorityFeePerGas) {
     return { networkFeeCryptoBaseUnit, gasLimit, maxFeePerGas, maxPriorityFeePerGas }
   }
 


### PR DESCRIPTION
## Description

lifi fees were broken upstream and lifi swapper has not been update to use common evm utils, update and use our own gas estimations

## Pull Request Type

- [ ] :bug: Bug fix (Non-breaking Change: Fixes an issue)
- [ ] :hammer_and_wrench: Chore (Non-breaking Change: Doc updates, pkg upgrades, typos, etc..)
- [x] :nail_care: New Feature (Breaking/Non-breaking Change)

## Issue (if applicable)

https://discord.com/channels/554694662431178782/1124366018337320990/1124366021407559803

## Risk

Med

## Testing

- validate working lifi swaps across supported evm chains (no stuck txs)
- verify the estimated gas shown on the trade confirm screen is close in value to the gas shown on the broadcasted transaction in etherscan
- ensure eip1559 fees are being used now if the wallet supports it

### Engineering

:point_up: 

### Operations

:point_up: 

## Screenshots (if applicable)
