### PR TITLE
feat: add manual receive address to exchange swapper

### DIFF
--- a/src/assets/translations/en/main.json
+++ b/src/assets/translations/en/main.json
@@ -678,6 +678,7 @@
     "slowSwapBody": "This swap may take a few minutes to complete.",
     "updatingQuote": "Updating quote...",
     "intoAssetSymbolBody": "You can proceed with this trade, but transaction history for receiving %{assetSymbol} is temporarily unavailable",
+    "manualReceiveAddress": "Receive address",
     "tooltip": {
       "rate": "This is the expected rate for this trade pair.",
       "noRateAvailable": "This is often due to very limited or no liquidity on the trade pair.",
@@ -686,7 +687,8 @@
       "protocol": "This is the protocol where your trade is being routed.",
       "protocolLifi": "This is the protocol where your trade is being routed. LI.FI executes a series of intermediary trades under the hood for the best overall combination of price, safety and speed.",
       "protocolFee": "This is the fee charged by the protocol selected to process this transaction, this is not a fee charged by ShapeShift",
-      "shapeshiftFee": "ShapeShift does not add fees on trades 🎉"
+      "shapeshiftFee": "ShapeShift does not add fees on trades 🎉",
+      "manualReceiveAddress": "This is the address you will receive your funds to. It has been manually entered, please ensure it is correct."
     },
     "rates": {
       "tags": {

--- a/src/components/MultiHopTrade/components/TradeConfirm/TradeConfirm.tsx
+++ b/src/components/MultiHopTrade/components/TradeConfirm/TradeConfirm.tsx
@@ -42,6 +42,7 @@ import { getMixPanel } from 'lib/mixpanel/mixPanelSingleton'
 import { MixPanelEvents } from 'lib/mixpanel/types'
 import { SwapperName } from 'lib/swapper/api'
 import { assertUnreachable } from 'lib/utils'
+import { selectManualReceiveAddress } from 'state/slices/swappersSlice/selectors'
 import {
   selectActiveQuote,
   selectActiveSwapperName,
@@ -68,6 +69,7 @@ export const TradeConfirm = () => {
   const history = useHistory()
   const mixpanel = getMixPanel()
   const borderColor = useColorModeValue('gray.100', 'gray.750')
+  const alertColor = useColorModeValue('yellow.500', 'yellow.200')
   const warningColor = useColorModeValue('red.600', 'red.400')
   const {
     handleSubmit,
@@ -115,6 +117,7 @@ export const TradeConfirm = () => {
 
   const sellAsset = useAppSelector(selectFirstHopSellAsset)
   const buyAsset = useAppSelector(selectLastHopBuyAsset)
+  const maybeManualReceiveAddress = useAppSelector(selectManualReceiveAddress)
 
   const { executeTrade, sellTxHash, status } = useTradeExecution({ tradeQuote, swapperName })
 
@@ -397,6 +400,22 @@ export const TradeConfirm = () => {
                       )}`}
                   </Row.Value>
                 </Row>
+                {maybeManualReceiveAddress && (
+                  <Row>
+                    <HelperTooltip label={translate('trade.tooltip.manualReceiveAddress')}>
+                      <Row.Label>
+                        <Text translation='trade.manualReceiveAddress' />
+                      </Row.Label>
+                    </HelperTooltip>
+                    <Row.Value>
+                      <Row.Label>
+                        <RawText fontWeight='semibold' color={alertColor}>
+                          {maybeManualReceiveAddress}
+                        </RawText>
+                      </Row.Label>
+                    </Row.Value>
+                  </Row>
+                )}
                 {isFeeRatioOverThreshold && (
                   <Flex justifyContent='center' gap={4} alignItems='center'>
                     <WarningTwoIcon w={5} h={5} color={warningColor} />

--- a/src/components/MultiHopTrade/components/TradeInput/TradeInput.tsx
+++ b/src/components/MultiHopTrade/components/TradeInput/TradeInput.tsx
@@ -17,6 +17,7 @@ import type { CardProps } from 'components/Card/Card'
 import { Card } from 'components/Card/Card'
 import { MessageOverlay } from 'components/MessageOverlay/MessageOverlay'
 import { DonationCheckbox } from 'components/MultiHopTrade/components/TradeInput/components/DonationCheckbox'
+import { ManualAddressEntry } from 'components/MultiHopTrade/components/TradeInput/components/ManualAddressEntry'
 import { getMixpanelEventData } from 'components/MultiHopTrade/helpers'
 import { useActiveQuoteStatus } from 'components/MultiHopTrade/hooks/useActiveQuoteStatus'
 import { checkApprovalNeeded } from 'components/MultiHopTrade/hooks/useAllowanceApproval/helpers'
@@ -84,6 +85,7 @@ export const TradeInput = (props: CardProps) => {
   const buyAmountAfterFeesCryptoPrecision = useAppSelector(selectNetReceiveAmountCryptoPrecision)
   const buyAmountAfterFeesUserCurrency = useAppSelector(selectNetBuyAmountUserCurrency)
   const totalNetworkFeeFiatPrecision = useAppSelector(selectTotalNetworkFeeUserCurrencyPrecision)
+  const [isManualAddressEntryValidating, setIsManualAddressEntryValidating] = useState(false)
 
   const activeQuoteStatus = useActiveQuoteStatus()
   const setBuyAsset = useCallback(
@@ -288,14 +290,17 @@ export const TradeInput = (props: CardProps) => {
             </Stack>
             <Stack px={4}>
               <DonationCheckbox isLoading={isLoading} />
+              <ManualAddressEntry
+                setIsManualAddressEntryValidating={setIsManualAddressEntryValidating}
+              />
             </Stack>
-            <Tooltip label={activeQuoteStatus.error?.message}>
+            <Tooltip label={activeQuoteStatus.error?.message ?? activeQuoteStatus.quoteErrors[0]}>
               <Button
                 type='submit'
                 colorScheme={quoteHasError ? 'red' : 'blue'}
                 size='lg-multiline'
                 data-test='trade-form-preview-button'
-                isDisabled={quoteHasError}
+                isDisabled={quoteHasError || isManualAddressEntryValidating || isLoading}
                 isLoading={isLoading}
               >
                 <Text translation={activeQuoteStatus.quoteStatusTranslation} />

--- a/src/components/MultiHopTrade/components/TradeInput/TradeInput.tsx
+++ b/src/components/MultiHopTrade/components/TradeInput/TradeInput.tsx
@@ -39,7 +39,11 @@ import {
   selectSwappersApiTradeQuotePending,
   selectSwappersApiTradeQuotes,
 } from 'state/apis/swappers/selectors'
-import { selectBuyAsset, selectSellAsset } from 'state/slices/selectors'
+import {
+  selectBuyAsset,
+  selectManualReceiveAddressIsValidating,
+  selectSellAsset,
+} from 'state/slices/selectors'
 import { swappers } from 'state/slices/swappersSlice/swappersSlice'
 import {
   selectActiveQuote,
@@ -85,7 +89,7 @@ export const TradeInput = (props: CardProps) => {
   const buyAmountAfterFeesCryptoPrecision = useAppSelector(selectNetReceiveAmountCryptoPrecision)
   const buyAmountAfterFeesUserCurrency = useAppSelector(selectNetBuyAmountUserCurrency)
   const totalNetworkFeeFiatPrecision = useAppSelector(selectTotalNetworkFeeUserCurrencyPrecision)
-  const [isManualAddressEntryValidating, setIsManualAddressEntryValidating] = useState(false)
+  const manualReceiveAddressIsValidating = useAppSelector(selectManualReceiveAddressIsValidating)
 
   const activeQuoteStatus = useActiveQuoteStatus()
   const setBuyAsset = useCallback(
@@ -291,11 +295,7 @@ export const TradeInput = (props: CardProps) => {
             </Stack>
             <Stack px={4}>
               <DonationCheckbox isLoading={isLoading} />
-              {rate && (
-                <ManualAddressEntry
-                  setIsManualAddressEntryValidating={setIsManualAddressEntryValidating}
-                />
-              )}
+              {activeQuote && <ManualAddressEntry />}
             </Stack>
             <Tooltip label={activeQuoteStatus.error?.message ?? activeQuoteStatus.quoteErrors[0]}>
               <Button
@@ -303,7 +303,7 @@ export const TradeInput = (props: CardProps) => {
                 colorScheme={quoteHasError ? 'red' : 'blue'}
                 size='lg-multiline'
                 data-test='trade-form-preview-button'
-                isDisabled={quoteHasError || isManualAddressEntryValidating || isLoading}
+                isDisabled={quoteHasError || manualReceiveAddressIsValidating || isLoading}
                 isLoading={isLoading}
               >
                 <Text translation={activeQuoteStatus.quoteStatusTranslation} />

--- a/src/components/MultiHopTrade/components/TradeInput/TradeInput.tsx
+++ b/src/components/MultiHopTrade/components/TradeInput/TradeInput.tsx
@@ -112,6 +112,7 @@ export const TradeInput = (props: CardProps) => {
   const activeQuoteError = useAppSelector(selectActiveQuoteError)
   const activeSwapperName = useAppSelector(selectActiveSwapperName)
   const sortedQuotes = useAppSelector(selectSwappersApiTradeQuotes)
+  const rate = activeQuote?.steps[0].rate
 
   const isQuoteLoading = useAppSelector(selectSwappersApiTradeQuotePending)
   const isLoading = useMemo(
@@ -268,7 +269,7 @@ export const TradeInput = (props: CardProps) => {
                 sellSymbol={sellAsset.symbol}
                 buySymbol={buyAsset.symbol}
                 gasFee={totalNetworkFeeFiatPrecision ?? 'unknown'}
-                rate={activeQuote?.steps[0].rate}
+                rate={rate}
                 isLoading={isLoading}
                 isError={activeQuoteError !== undefined}
               />
@@ -290,9 +291,11 @@ export const TradeInput = (props: CardProps) => {
             </Stack>
             <Stack px={4}>
               <DonationCheckbox isLoading={isLoading} />
-              <ManualAddressEntry
-                setIsManualAddressEntryValidating={setIsManualAddressEntryValidating}
-              />
+              {rate && (
+                <ManualAddressEntry
+                  setIsManualAddressEntryValidating={setIsManualAddressEntryValidating}
+                />
+              )}
             </Stack>
             <Tooltip label={activeQuoteStatus.error?.message ?? activeQuoteStatus.quoteErrors[0]}>
               <Button

--- a/src/components/MultiHopTrade/components/TradeInput/components/ManualAddressEntry.tsx
+++ b/src/components/MultiHopTrade/components/TradeInput/components/ManualAddressEntry.tsx
@@ -1,6 +1,6 @@
 import { FormControl, FormLabel } from '@chakra-ui/react'
 import { ethChainId } from '@shapeshiftoss/caip'
-import type { Dispatch, FC, SetStateAction } from 'react'
+import type { FC } from 'react'
 import { useEffect, useMemo } from 'react'
 import { useFormContext } from 'react-hook-form'
 import { useTranslate } from 'react-polyglot'
@@ -16,7 +16,7 @@ import { swappers } from 'state/slices/swappersSlice/swappersSlice'
 import { useAppDispatch, useAppSelector } from 'state/store'
 
 type ManualAddressEntryProps = {
-  setIsManualAddressEntryValidating: Dispatch<SetStateAction<boolean>>
+  setIsManualAddressEntryValidating: (isManualAddressEntryValidating: boolean) => void
 }
 
 export const ManualAddressEntry: FC<ManualAddressEntryProps> = ({

--- a/src/components/MultiHopTrade/components/TradeInput/components/ManualAddressEntry.tsx
+++ b/src/components/MultiHopTrade/components/TradeInput/components/ManualAddressEntry.tsx
@@ -11,7 +11,6 @@ import { useFeatureFlag } from 'hooks/useFeatureFlag/useFeatureFlag'
 import { useWallet } from 'hooks/useWallet/useWallet'
 import { walletSupportsChain } from 'hooks/useWalletSupportsChain/useWalletSupportsChain'
 import { parseAddressInputWithChainId } from 'lib/address/address'
-import { selectSwappersApiTradeQuotePending } from 'state/apis/swappers/selectors'
 import { selectBuyAsset } from 'state/slices/swappersSlice/selectors'
 import { swappers } from 'state/slices/swappersSlice/swappersSlice'
 import { useAppDispatch, useAppSelector } from 'state/store'
@@ -24,7 +23,6 @@ export const ManualAddressEntry: FC<ManualAddressEntryProps> = ({
   setIsManualAddressEntryValidating,
 }): JSX.Element | null => {
   const dispatch = useAppDispatch()
-  const isQuoteLoading = useAppSelector(selectSwappersApiTradeQuotePending)
 
   const {
     formState: { isValid: isFormValid },
@@ -110,5 +108,5 @@ export const ManualAddressEntry: FC<ManualAddressEntryProps> = ({
     translate,
   ])
 
-  return shouldShowManualReceiveAddressInput && !isQuoteLoading ? ManualReceiveAddressEntry : null
+  return shouldShowManualReceiveAddressInput ? ManualReceiveAddressEntry : null
 }

--- a/src/components/MultiHopTrade/components/TradeInput/components/ManualAddressEntry.tsx
+++ b/src/components/MultiHopTrade/components/TradeInput/components/ManualAddressEntry.tsx
@@ -11,7 +11,7 @@ import { useFeatureFlag } from 'hooks/useFeatureFlag/useFeatureFlag'
 import { useWallet } from 'hooks/useWallet/useWallet'
 import { walletSupportsChain } from 'hooks/useWalletSupportsChain/useWalletSupportsChain'
 import { parseAddressInputWithChainId } from 'lib/address/address'
-import { selectBuyAsset } from 'state/slices/swappersSlice/selectors'
+import { selectBuyAsset, selectManualReceiveAddress } from 'state/slices/swappersSlice/selectors'
 import { swappers } from 'state/slices/swappersSlice/swappersSlice'
 import { useAppDispatch, useAppSelector } from 'state/store'
 
@@ -42,6 +42,7 @@ export const ManualAddressEntry: FC<ManualAddressEntryProps> = ({
 
   const chainAdapterManager = getChainAdapterManager()
   const buyAssetChainName = chainAdapterManager.get(buyAssetChainId)?.getDisplayName()
+  const manualReceiveAddress = useAppSelector(selectManualReceiveAddress)
 
   // Trigger re-validation of the manually entered receive address
   useEffect(() => {
@@ -50,8 +51,12 @@ export const ManualAddressEntry: FC<ManualAddressEntryProps> = ({
 
   // Reset the manual address input state when the user changes the buy asset
   useEffect(() => {
-    setFormValue(SendFormFields.Input, '')
-  }, [buyAssetAssetId, setFormValue])
+    dispatch(swappers.actions.setManualReceiveAddress(undefined))
+  }, [buyAssetAssetId, dispatch])
+
+  useEffect(() => {
+    setFormValue(SendFormFields.Input, manualReceiveAddress ?? '')
+  }, [dispatch, manualReceiveAddress, setFormValue])
 
   // For safety, ensure we never have a receive address in the store if the form is invalid
   useEffect(() => {

--- a/src/components/MultiHopTrade/components/TradeInput/components/ManualAddressEntry.tsx
+++ b/src/components/MultiHopTrade/components/TradeInput/components/ManualAddressEntry.tsx
@@ -15,17 +15,11 @@ import { selectBuyAsset, selectManualReceiveAddress } from 'state/slices/swapper
 import { swappers } from 'state/slices/swappersSlice/swappersSlice'
 import { useAppDispatch, useAppSelector } from 'state/store'
 
-type ManualAddressEntryProps = {
-  setIsManualAddressEntryValidating: (isManualAddressEntryValidating: boolean) => void
-}
-
-export const ManualAddressEntry: FC<ManualAddressEntryProps> = ({
-  setIsManualAddressEntryValidating,
-}): JSX.Element | null => {
+export const ManualAddressEntry: FC = (): JSX.Element | null => {
   const dispatch = useAppDispatch()
 
   const {
-    formState: { isValid: isFormValid },
+    formState: { isValid: isFormValid, isValidating },
     trigger: formTrigger,
     setValue: setFormValue,
   } = useFormContext()
@@ -58,6 +52,10 @@ export const ManualAddressEntry: FC<ManualAddressEntryProps> = ({
     setFormValue(SendFormFields.Input, manualReceiveAddress ?? '')
   }, [dispatch, manualReceiveAddress, setFormValue])
 
+  useEffect(() => {
+    dispatch(swappers.actions.setManualReceiveAddressIsValidating(isValidating))
+  }, [dispatch, isValidating])
+
   // For safety, ensure we never have a receive address in the store if the form is invalid
   useEffect(() => {
     !isFormValid && dispatch(swappers.actions.setManualReceiveAddress(undefined))
@@ -79,7 +77,6 @@ export const ManualAddressEntry: FC<ManualAddressEntryProps> = ({
               validateAddress: async (rawInput: string) => {
                 dispatch(swappers.actions.setManualReceiveAddress(undefined))
                 const value = rawInput.trim() // trim leading/trailing spaces
-                setIsManualAddressEntryValidating(true)
                 // this does not throw, everything inside is handled
                 const parseAddressInputWithChainIdArgs = {
                   assetId: buyAssetAssetId,
@@ -90,7 +87,6 @@ export const ManualAddressEntry: FC<ManualAddressEntryProps> = ({
                 const { address } = await parseAddressInputWithChainId(
                   parseAddressInputWithChainIdArgs,
                 )
-                setIsManualAddressEntryValidating(false)
                 dispatch(swappers.actions.setManualReceiveAddress(address || undefined))
                 const invalidMessage = isYatSupported
                   ? 'common.invalidAddressOrYat'
@@ -103,15 +99,7 @@ export const ManualAddressEntry: FC<ManualAddressEntryProps> = ({
         />
       </FormControl>
     )
-  }, [
-    buyAssetAssetId,
-    buyAssetChainId,
-    buyAssetChainName,
-    dispatch,
-    isYatSupported,
-    setIsManualAddressEntryValidating,
-    translate,
-  ])
+  }, [buyAssetAssetId, buyAssetChainId, buyAssetChainName, dispatch, isYatSupported, translate])
 
   return shouldShowManualReceiveAddressInput ? ManualReceiveAddressEntry : null
 }

--- a/src/components/MultiHopTrade/components/TradeInput/components/ManualAddressEntry.tsx
+++ b/src/components/MultiHopTrade/components/TradeInput/components/ManualAddressEntry.tsx
@@ -1,0 +1,114 @@
+import { FormControl, FormLabel } from '@chakra-ui/react'
+import { ethChainId } from '@shapeshiftoss/caip'
+import type { Dispatch, FC, SetStateAction } from 'react'
+import { useEffect, useMemo } from 'react'
+import { useFormContext } from 'react-hook-form'
+import { useTranslate } from 'react-polyglot'
+import { AddressInput } from 'components/Modals/Send/AddressInput/AddressInput'
+import { SendFormFields } from 'components/Modals/Send/SendCommon'
+import { getChainAdapterManager } from 'context/PluginProvider/chainAdapterSingleton'
+import { useFeatureFlag } from 'hooks/useFeatureFlag/useFeatureFlag'
+import { useWallet } from 'hooks/useWallet/useWallet'
+import { walletSupportsChain } from 'hooks/useWalletSupportsChain/useWalletSupportsChain'
+import { parseAddressInputWithChainId } from 'lib/address/address'
+import { selectSwappersApiTradeQuotePending } from 'state/apis/swappers/selectors'
+import { selectBuyAsset } from 'state/slices/swappersSlice/selectors'
+import { swappers } from 'state/slices/swappersSlice/swappersSlice'
+import { useAppDispatch, useAppSelector } from 'state/store'
+
+type ManualAddressEntryProps = {
+  setIsManualAddressEntryValidating: Dispatch<SetStateAction<boolean>>
+}
+
+export const ManualAddressEntry: FC<ManualAddressEntryProps> = ({
+  setIsManualAddressEntryValidating,
+}): JSX.Element | null => {
+  const dispatch = useAppDispatch()
+  const isQuoteLoading = useAppSelector(selectSwappersApiTradeQuotePending)
+
+  const {
+    formState: { isValid: isFormValid },
+    trigger: formTrigger,
+    setValue: setFormValue,
+  } = useFormContext()
+  const translate = useTranslate()
+  const isYatFeatureEnabled = useFeatureFlag('Yat')
+
+  const wallet = useWallet().state.wallet
+  const { chainId: buyAssetChainId, assetId: buyAssetAssetId } = useAppSelector(selectBuyAsset)
+  const isYatSupportedByReceiveChain = buyAssetChainId === ethChainId // yat only supports eth mainnet
+  const isYatSupported = isYatFeatureEnabled && isYatSupportedByReceiveChain
+
+  const walletSupportsBuyAssetChain = walletSupportsChain({ chainId: buyAssetChainId, wallet })
+  const shouldShowManualReceiveAddressInput = !walletSupportsBuyAssetChain
+
+  const chainAdapterManager = getChainAdapterManager()
+  const buyAssetChainName = chainAdapterManager.get(buyAssetChainId)?.getDisplayName()
+
+  // Trigger re-validation of the manually entered receive address
+  useEffect(() => {
+    formTrigger(SendFormFields.Input)
+  }, [formTrigger, shouldShowManualReceiveAddressInput])
+
+  // Reset the manual address input state when the user changes the buy asset
+  useEffect(() => {
+    setFormValue(SendFormFields.Input, '')
+  }, [buyAssetAssetId, setFormValue])
+
+  // For safety, ensure we never have a receive address in the store if the form is invalid
+  useEffect(() => {
+    !isFormValid && dispatch(swappers.actions.setManualReceiveAddress(undefined))
+  }, [isFormValid, dispatch])
+
+  const ManualReceiveAddressEntry: JSX.Element = useMemo(() => {
+    return (
+      <FormControl>
+        <FormLabel color='white.500' w='full' fontWeight='bold'>
+          {translate('trade.receiveAddress')}
+        </FormLabel>
+        <FormLabel color='yellow.400'>
+          {translate('trade.receiveAddressDescription', { chainName: buyAssetChainName })}
+        </FormLabel>
+        <AddressInput
+          rules={{
+            required: true,
+            validate: {
+              validateAddress: async (rawInput: string) => {
+                dispatch(swappers.actions.setManualReceiveAddress(undefined))
+                const value = rawInput.trim() // trim leading/trailing spaces
+                setIsManualAddressEntryValidating(true)
+                // this does not throw, everything inside is handled
+                const parseAddressInputWithChainIdArgs = {
+                  assetId: buyAssetAssetId,
+                  chainId: buyAssetChainId,
+                  urlOrAddress: value,
+                  disableUrlParsing: true,
+                }
+                const { address } = await parseAddressInputWithChainId(
+                  parseAddressInputWithChainIdArgs,
+                )
+                setIsManualAddressEntryValidating(false)
+                dispatch(swappers.actions.setManualReceiveAddress(address || undefined))
+                const invalidMessage = isYatSupported
+                  ? 'common.invalidAddressOrYat'
+                  : 'common.invalidAddress'
+                return address ? true : invalidMessage
+              },
+            },
+          }}
+          placeholder={translate('trade.addressPlaceholder', { chainName: buyAssetChainName })}
+        />
+      </FormControl>
+    )
+  }, [
+    buyAssetAssetId,
+    buyAssetChainId,
+    buyAssetChainName,
+    dispatch,
+    isYatSupported,
+    setIsManualAddressEntryValidating,
+    translate,
+  ])
+
+  return shouldShowManualReceiveAddressInput && !isQuoteLoading ? ManualReceiveAddressEntry : null
+}

--- a/src/components/MultiHopTrade/components/TradeInput/components/ManualAddressEntry.tsx
+++ b/src/components/MultiHopTrade/components/TradeInput/components/ManualAddressEntry.tsx
@@ -19,7 +19,7 @@ export const ManualAddressEntry: FC = (): JSX.Element | null => {
   const dispatch = useAppDispatch()
 
   const {
-    formState: { isValid: isFormValid, isValidating },
+    formState: { isValidating },
     trigger: formTrigger,
     setValue: setFormValue,
   } = useFormContext()
@@ -46,20 +46,17 @@ export const ManualAddressEntry: FC = (): JSX.Element | null => {
   // Reset the manual address input state when the user changes the buy asset
   useEffect(() => {
     dispatch(swappers.actions.setManualReceiveAddress(undefined))
-  }, [buyAssetAssetId, dispatch])
+    setFormValue(SendFormFields.Input, '')
+  }, [buyAssetAssetId, dispatch, setFormValue])
 
+  // If we have a valid manual receive address, set it in the form
   useEffect(() => {
-    setFormValue(SendFormFields.Input, manualReceiveAddress ?? '')
+    manualReceiveAddress && setFormValue(SendFormFields.Input, manualReceiveAddress)
   }, [dispatch, manualReceiveAddress, setFormValue])
 
   useEffect(() => {
     dispatch(swappers.actions.setManualReceiveAddressIsValidating(isValidating))
   }, [dispatch, isValidating])
-
-  // For safety, ensure we never have a receive address in the store if the form is invalid
-  useEffect(() => {
-    !isFormValid && dispatch(swappers.actions.setManualReceiveAddress(undefined))
-  }, [isFormValid, dispatch])
 
   const ManualReceiveAddressEntry: JSX.Element = useMemo(() => {
     return (

--- a/src/components/MultiHopTrade/hooks/useActiveQuoteStatus.tsx
+++ b/src/components/MultiHopTrade/hooks/useActiveQuoteStatus.tsx
@@ -5,13 +5,13 @@ import type { QuoteStatus } from 'components/MultiHopTrade/types'
 import { ActiveQuoteStatus } from 'components/MultiHopTrade/types'
 import { bnOrZero } from 'lib/bignumber/bignumber'
 import { SwapErrorType, SwapperName } from 'lib/swapper/api'
+import { selectBuyAsset } from 'state/slices/swappersSlice/selectors'
 import {
   selectActiveQuote,
   selectActiveQuoteError,
   selectActiveSwapperName,
   selectFirstHopSellAsset,
   selectFirstHopSellFeeAsset,
-  selectLastHopBuyAsset,
   selectLastHopSellFeeAsset,
   selectMinimumSellAmountCryptoHuman,
 } from 'state/slices/tradeQuoteSlice/selectors'
@@ -24,9 +24,9 @@ export const useActiveQuoteStatus = (): QuoteStatus => {
   const selectedSwapperName = useAppSelector(selectActiveSwapperName)
   const firstHopSellAsset = useAppSelector(selectFirstHopSellAsset)
   const firstHopSellFeeAsset = useAppSelector(selectFirstHopSellFeeAsset)
-  const lastHopBuyAsset = useAppSelector(selectLastHopBuyAsset)
   const lastHopSellFeeAsset = useAppSelector(selectLastHopSellFeeAsset)
   const minimumCryptoHuman = useAppSelector(selectMinimumSellAmountCryptoHuman)
+  const tradeBuyAsset = useAppSelector(selectBuyAsset)
 
   const activeQuote = useAppSelector(selectActiveQuote)
   const activeQuoteError = useAppSelector(selectActiveQuoteError)
@@ -97,7 +97,7 @@ export const useActiveQuoteStatus = (): QuoteStatus => {
             'trade.errors.noReceiveAddress',
             {
               assetSymbol:
-                lastHopBuyAsset?.symbol ?? translate('trade.errors.buyAssetMiddleSentence'),
+                tradeBuyAsset?.symbol ?? translate('trade.errors.buyAssetMiddleSentence'),
             },
           ]
         case ActiveQuoteStatus.BuyAssetNotNotSupportedByWallet: // TODO: add translation for manual receive address required once implemented
@@ -108,7 +108,7 @@ export const useActiveQuoteStatus = (): QuoteStatus => {
   }, [
     firstHopSellAsset?.symbol,
     firstHopSellFeeAsset?.symbol,
-    lastHopBuyAsset?.symbol,
+    tradeBuyAsset?.symbol,
     lastHopSellFeeAsset?.symbol,
     minimumAmountUserMessage,
     quoteErrors,

--- a/src/components/MultiHopTrade/hooks/useQuoteValidationErrors.tsx
+++ b/src/components/MultiHopTrade/hooks/useQuoteValidationErrors.tsx
@@ -6,6 +6,7 @@ import { useWallet } from 'hooks/useWallet/useWallet'
 import { walletSupportsChain } from 'hooks/useWalletSupportsChain/useWalletSupportsChain'
 import { bnOrZero } from 'lib/bignumber/bignumber'
 import { isTruthy } from 'lib/utils'
+import { selectManualReceiveAddress } from 'state/slices/swappersSlice/selectors'
 import {
   selectFirstHopNetworkFeeCryptoPrecision,
   selectFirstHopSellAsset,
@@ -36,6 +37,7 @@ export const useQuoteValidationErrors = (): ActiveQuoteStatus[] => {
   const firstHopSellAsset = useAppSelector(selectFirstHopSellAsset)
   const lastHopBuyAsset = useAppSelector(selectLastHopBuyAsset)
   const receiveAddress = useReceiveAddress()
+  const manualReceiveAddress = useAppSelector(selectManualReceiveAddress)
 
   const walletSupportsSellAssetChain =
     firstHopSellAsset &&
@@ -72,7 +74,9 @@ export const useQuoteValidationErrors = (): ActiveQuoteStatus[] => {
     !lastHopHasSufficientBalanceForGas && ActiveQuoteStatus.InsufficientLastHopFeeAssetBalance,
     isBelowMinimumSellAmount && ActiveQuoteStatus.SellAmountBelowMinimum,
     !walletSupportsSellAssetChain && ActiveQuoteStatus.SellAssetNotNotSupportedByWallet,
-    !walletSupportsBuyAssetChain && ActiveQuoteStatus.BuyAssetNotNotSupportedByWallet, // TODO: only show this if no manually entered receive address
+    !walletSupportsBuyAssetChain &&
+      !manualReceiveAddress &&
+      ActiveQuoteStatus.BuyAssetNotNotSupportedByWallet,
     !receiveAddress && ActiveQuoteStatus.NoReceiveAddress,
     !isTradingActiveOnSellPool && ActiveQuoteStatus.TradingInactiveOnSellChain,
     !isTradingActiveOnBuyPool && ActiveQuoteStatus.TradingInactiveOnBuyChain,

--- a/src/components/MultiHopTrade/hooks/useReceiveAddress.tsx
+++ b/src/components/MultiHopTrade/hooks/useReceiveAddress.tsx
@@ -5,7 +5,11 @@ import { useWallet } from 'hooks/useWallet/useWallet'
 import type { Asset } from 'lib/asset-service'
 import { selectPortfolioAccountMetadataByAccountId } from 'state/slices/portfolioSlice/selectors'
 import { isUtxoAccountId } from 'state/slices/portfolioSlice/utils'
-import { selectBuyAccountId, selectBuyAsset } from 'state/slices/swappersSlice/selectors'
+import {
+  selectBuyAccountId,
+  selectBuyAsset,
+  selectManualReceiveAddress,
+} from 'state/slices/swappersSlice/selectors'
 import { useAppDispatch, useAppSelector } from 'state/store'
 
 export const useReceiveAddress = () => {
@@ -21,6 +25,7 @@ export const useReceiveAddress = () => {
   const buyAccountMetadata = useAppSelector(state =>
     selectPortfolioAccountMetadataByAccountId(state, { accountId: buyAccountId }),
   )
+  const manualReceiveAddress = useAppSelector(selectManualReceiveAddress)
 
   const getReceiveAddressFromBuyAsset = useCallback(
     async (buyAsset: Asset) => {
@@ -59,5 +64,6 @@ export const useReceiveAddress = () => {
     })()
   }, [buyAsset, dispatch, getReceiveAddressFromBuyAsset, setReceiveAddress])
 
-  return receiveAddress
+  // Always use the manual receive address if it is set
+  return manualReceiveAddress ?? receiveAddress
 }

--- a/src/components/MultiHopTrade/hooks/useReceiveAddress.tsx
+++ b/src/components/MultiHopTrade/hooks/useReceiveAddress.tsx
@@ -65,5 +65,5 @@ export const useReceiveAddress = () => {
   }, [buyAsset, dispatch, getReceiveAddressFromBuyAsset, setReceiveAddress])
 
   // Always use the manual receive address if it is set
-  return manualReceiveAddress ?? receiveAddress
+  return manualReceiveAddress || receiveAddress
 }

--- a/src/state/apis/swappers/selectors.ts
+++ b/src/state/apis/swappers/selectors.ts
@@ -36,3 +36,8 @@ export const selectSwappersApiTradeQuotePending = createSelector(
   selectMostRecentTradeQuoteQuery,
   query => query?.status === QueryStatus.pending,
 )
+
+export const selectSwappersApiTradeQuoteUninitialized = createSelector(
+  selectMostRecentTradeQuoteQuery,
+  query => query?.status === QueryStatus.uninitialized,
+)

--- a/src/state/apis/swappers/selectors.ts
+++ b/src/state/apis/swappers/selectors.ts
@@ -36,8 +36,3 @@ export const selectSwappersApiTradeQuotePending = createSelector(
   selectMostRecentTradeQuoteQuery,
   query => query?.status === QueryStatus.pending,
 )
-
-export const selectSwappersApiTradeQuoteUninitialized = createSelector(
-  selectMostRecentTradeQuoteQuery,
-  query => query?.status === QueryStatus.uninitialized,
-)

--- a/src/state/slices/swappersSlice/selectors.ts
+++ b/src/state/slices/swappersSlice/selectors.ts
@@ -88,3 +88,8 @@ export const selectBuyAssetUsdRate = createSelector(
 )
 
 export const selectWillDonate = createSelector(selectSwappers, swappers => swappers.willDonate)
+
+export const selectManualReceiveAddress = createSelector(
+  selectSwappers,
+  swappers => swappers.manualReceiveAddress,
+)

--- a/src/state/slices/swappersSlice/selectors.ts
+++ b/src/state/slices/swappersSlice/selectors.ts
@@ -93,3 +93,8 @@ export const selectManualReceiveAddress = createSelector(
   selectSwappers,
   swappers => swappers.manualReceiveAddress,
 )
+
+export const selectManualReceiveAddressIsValidating = createSelector(
+  selectSwappers,
+  swappers => swappers.manualReceiveAddressIsValidating,
+)

--- a/src/state/slices/swappersSlice/swappersSlice.ts
+++ b/src/state/slices/swappersSlice/swappersSlice.ts
@@ -17,6 +17,7 @@ export type SwappersState = {
   sellAmountCryptoPrecision: string
   tradeExecutionStatus: MultiHopExecutionStatus
   willDonate: boolean
+  manualReceiveAddress: string | undefined
 }
 
 // Define the initial state:
@@ -28,6 +29,7 @@ const initialState: SwappersState = {
   sellAmountCryptoPrecision: '0',
   tradeExecutionStatus: MultiHopExecutionStatus.Hop1AwaitingApprovalConfirmation,
   willDonate: true,
+  manualReceiveAddress: undefined,
 }
 
 // Create the slice:
@@ -81,6 +83,9 @@ export const swappers = createSlice({
     },
     toggleWillDonate: state => {
       state.willDonate = !state.willDonate
+    },
+    setManualReceiveAddress: (state, action: PayloadAction<string | undefined>) => {
+      state.manualReceiveAddress = action.payload
     },
   },
 })

--- a/src/state/slices/swappersSlice/swappersSlice.ts
+++ b/src/state/slices/swappersSlice/swappersSlice.ts
@@ -18,6 +18,7 @@ export type SwappersState = {
   tradeExecutionStatus: MultiHopExecutionStatus
   willDonate: boolean
   manualReceiveAddress: string | undefined
+  manualReceiveAddressIsValidating: boolean
 }
 
 // Define the initial state:
@@ -30,6 +31,7 @@ const initialState: SwappersState = {
   tradeExecutionStatus: MultiHopExecutionStatus.Hop1AwaitingApprovalConfirmation,
   willDonate: true,
   manualReceiveAddress: undefined,
+  manualReceiveAddressIsValidating: false,
 }
 
 // Create the slice:
@@ -86,6 +88,9 @@ export const swappers = createSlice({
     },
     setManualReceiveAddress: (state, action: PayloadAction<string | undefined>) => {
       state.manualReceiveAddress = action.payload
+    },
+    setManualReceiveAddressIsValidating: (state, action: PayloadAction<boolean>) => {
+      state.manualReceiveAddressIsValidating = action.payload
     },
   },
 })

--- a/src/test/mocks/store.ts
+++ b/src/test/mocks/store.ts
@@ -171,6 +171,7 @@ export const mockStore: ReduxState = {
     tradeExecutionStatus: MultiHopExecutionStatus.Unknown,
     willDonate: true,
     manualReceiveAddress: undefined,
+    manualReceiveAddressIsValidating: false,
   },
   tradeQuoteSlice: {
     activeSwapperName: undefined,

--- a/src/test/mocks/store.ts
+++ b/src/test/mocks/store.ts
@@ -170,6 +170,7 @@ export const mockStore: ReduxState = {
     sellAmountCryptoPrecision: '0',
     tradeExecutionStatus: MultiHopExecutionStatus.Unknown,
     willDonate: true,
+    manualReceiveAddress: undefined,
   },
   tradeQuoteSlice: {
     activeSwapperName: undefined,


### PR DESCRIPTION
## Description

Adds manual receive address functionality to the new exchange swapper.

It's functionality is intended to match that in the production implementation.

## Pull Request Type

- [ ] :bug: Bug fix (Non-breaking Change: Fixes an issue)
- [ ] :hammer_and_wrench: Chore (Non-breaking Change: Doc updates, pkg upgrades, typos, etc..)
- [x] :nail_care: New Feature (Breaking/Non-breaking Change)

## Issue (if applicable)

Closes https://github.com/shapeshift/web/issues/4841

## Risk

Super high. Something going wrong here can mean user funds ending up at an address that they do not control. Test accordingly 🙏

## Testing

### Engineering

Ensure that the `manualReceiveAddress` value in the `swappersSlice` is always exactly what it is expected to be.

Play with supported and non-supported receive assets for the wallet.

### Operations

Not needed yet - will be tested as part of the full suite of testing for the new exchange swapper.

## Screenshots (if applicable)

<img width="480" alt="Screenshot 2023-07-10 at 4 59 16 pm" src="https://github.com/shapeshift/web/assets/97164662/ffecb605-bdc5-45fd-93b5-bf9eee4eeb36">

<img width="590" alt="Screenshot 2023-07-10 at 4 58 53 pm" src="https://github.com/shapeshift/web/assets/97164662/62f05a36-a64e-4251-8572-ae10e31dbbdf">

