### PR TITLE
feat: language selector on connect page

### DIFF
--- a/src/components/LanguageSelector.tsx
+++ b/src/components/LanguageSelector.tsx
@@ -1,0 +1,28 @@
+import type { SelectProps } from '@chakra-ui/react'
+import { Select } from '@chakra-ui/react'
+import React from 'react'
+import { preferences } from 'state/slices/preferencesSlice/preferencesSlice'
+import { selectSelectedLocale } from 'state/slices/selectors'
+import { useAppDispatch, useAppSelector } from 'state/store'
+
+import { locales } from '../assets/translations/constants'
+
+export const LanguageSelector: React.FC<SelectProps> = props => {
+  const dispatch = useAppDispatch()
+  const selectedLocale = useAppSelector(selectSelectedLocale)
+
+  const handleLanguageChange = (event: React.ChangeEvent<HTMLSelectElement>) => {
+    const selectedLanguage = event.target.value
+    dispatch(preferences.actions.setSelectedLocale({ locale: selectedLanguage }))
+  }
+
+  return (
+    <Select onChange={handleLanguageChange} {...props}>
+      {locales.map(locale => (
+        <option key={locale.key} value={locale.key} selected={locale.key === selectedLocale}>
+          {locale.label}
+        </option>
+      ))}
+    </Select>
+  )
+}

--- a/src/components/LanguageSelector.tsx
+++ b/src/components/LanguageSelector.tsx
@@ -1,6 +1,8 @@
 import type { SelectProps } from '@chakra-ui/react'
 import { Select } from '@chakra-ui/react'
 import React from 'react'
+import { getMixPanel } from 'lib/mixpanel/mixPanelSingleton'
+import { MixPanelEvents } from 'lib/mixpanel/types'
 import { preferences } from 'state/slices/preferencesSlice/preferencesSlice'
 import { selectSelectedLocale } from 'state/slices/selectors'
 import { useAppDispatch, useAppSelector } from 'state/store'
@@ -13,6 +15,7 @@ export const LanguageSelector: React.FC<SelectProps> = props => {
 
   const handleLanguageChange = (event: React.ChangeEvent<HTMLSelectElement>) => {
     const selectedLanguage = event.target.value
+    getMixPanel()?.track(MixPanelEvents.Click, { element: 'Language Selector', selectedLanguage })
     dispatch(preferences.actions.setSelectedLocale({ locale: selectedLanguage }))
   }
 

--- a/src/pages/ConnectWallet/ConnectWallet.tsx
+++ b/src/pages/ConnectWallet/ConnectWallet.tsx
@@ -6,6 +6,7 @@ import { generatePath, matchPath, useHistory } from 'react-router-dom'
 import AuroraBg from 'assets/aurorabg.jpg'
 import { AuroraBackground } from 'components/AuroraBackground'
 import { FoxIcon } from 'components/Icons/FoxIcon'
+import { LanguageSelector } from 'components/LanguageSelector'
 import { Page } from 'components/Layout/Page'
 import { SEO } from 'components/Layout/Seo'
 import { RawText, Text } from 'components/Text'
@@ -49,8 +50,12 @@ export const ConnectWallet = () => {
         width='100vw'
         alignItems='center'
         justifyContent='center'
+        position={'relative'}
       >
         <Flex flexDir='column' zIndex={4} width='full'>
+          <Flex position={'absolute'} top={6} right={6}>
+            <LanguageSelector size={'sm'} />
+          </Flex>
           <Center flexDir='column' height='100vh' px={6}>
             <Circle size='100px' mb={6}>
               <FoxIcon boxSize='100%' color='white' />


### PR DESCRIPTION
## Description

- Adds a language selector dropdown menu on the top right of the Connect page. For cases where the language detection fails/is not accurate, allows the user to choose their language from the start.
- Adds tracking for that language selector under the `Click` event element `Language Selector` and records the selected language in the `selectedLanguage` property.

<!-- Please describe your changes -->

## Pull Request Type

- [ ] :bug: Bug fix (Non-breaking Change: Fixes an issue)
- [ ] :hammer_and_wrench: Chore (Non-breaking Change: Doc updates, pkg upgrades, typos, etc..)
- [x] :nail_care: New Feature (Breaking/Non-breaking Change)

## Issue (if applicable)

<!-----------------------------------------------------------------------------
If applicable, please link to the github issue and put `closes #XXXX` in your comment to auto-close the issue that your PR fixes.
------------------------------------------------------------------------------>

N/A

## Risk

Low. Adds an element on the Connect page, so test for visual changes.

<!-----------------------------------------------------------------------------
Outline the scope of your changes and the risk associated with them. You must use your discretion as an engineer to determine the potential impact of your changes.

E.g. an upgrade to `hdwallet` or core state management would be considered higher risk, and might require a full regression test. UI or isolated view changes, or something behind a feature flag may have near zero risk. Small bug fixes might require testing isolated to the specific fix.
------------------------------------------------------------------------------>

## Testing
- Access the Connect page as a first time user or existing user and verify that the default language or user's lanague is selected.
- Attempt to change the language and connect, language must be preserved based on the user's selection. 
 
<!-----------------------------------------------------------------------------
We treat every PR to be merged with the same scrutiny as if we were merging directly to production.

Your PR will not be merged if you do not complete the sections below for our engineering and operations teams to test.
------------------------------------------------------------------------------>

### Engineering
☝️ 
<!-----------------------------------------------------------------------------
Include sufficient information here for an engineer to test your PR. This may include how to test locally, in a built environment, changes to infrastructure etc.
------------------------------------------------------------------------------>

### Operations
☝️ 
<!-----------------------------------------------------------------------------
If your changes have a user-facing impact, describe how a non-technical QA team can functionally test your changes in a preview environment.

If they are not user-facing please describe how to test for any regressions that may occur.
------------------------------------------------------------------------------>

## Screenshots (if applicable)
Desktop resolution:
![image](https://github.com/shapeshift/web/assets/88804546/15d4be4f-d9d3-48d3-ad84-1db549bef869)
Mobile (default detection to French (Français):
![image](https://github.com/shapeshift/web/assets/88804546/4c735412-2fbc-42bc-be23-9aa254d8b93a)
Mobile while changing language:
![image](https://github.com/shapeshift/web/assets/88804546/8a35aaea-d1f2-4d31-86b3-454beb7cf22a)
Mobile after consent and language change to English:
![image](https://github.com/shapeshift/web/assets/88804546/296d0992-7d5c-4c24-8213-7a94a691534c)
Mobile landscape:
![image](https://github.com/shapeshift/web/assets/88804546/0863e66a-a8eb-42a3-b9b7-8f6fbb33302b)
