### PR TITLE
chore: adding canny link to support modal

### DIFF
--- a/src/assets/translations/en/main.json
+++ b/src/assets/translations/en/main.json
@@ -107,6 +107,7 @@
     "wallet": "Wallet",
     "action": "Action",
     "feedbackAndSupport": "Feedback & Support",
+    "submitFeatureRequest": "Submit a Feature Request",
     "getSupport": "Get Support"
   },
   "consentBanner": {

--- a/src/components/Modals/FeedbackSupport/FeedbackSupport.tsx
+++ b/src/components/Modals/FeedbackSupport/FeedbackSupport.tsx
@@ -57,9 +57,9 @@ export const FeedbackAndSupport = () => {
               leftIcon={<EditIcon />}
               as={Link}
               size='sm'
-              label={translate('common.submitFeedback')}
+              label={translate('common.submitFeatureRequest')}
               isExternal
-              href='https://shapeshift.notion.site/Submit-Feedback-or-a-Feature-Request-af48a25fea574da4a05a980c347c055b'
+              href='https://shapeshift.canny.io/feature-requests'
             />
           </Stack>
         </ModalBody>


### PR DESCRIPTION
## Description

Now that canny.io has some traction this PR adds it to the feedback modal.

## Pull Request Type

- [ ] :bug: Bug fix (Non-breaking Change: Fixes an issue)
- [x] :hammer_and_wrench: Chore (Non-breaking Change: Doc updates, pkg upgrades, typos, etc..)
- [ ] :nail_care: New Feature (Breaking/Non-breaking Change)




## Testing


### Engineering

<!-----------------------------------------------------------------------------
Include sufficient information here for an engineer to test your PR. This may include how to test locally, in a built environment, changes to infrastructure etc.
------------------------------------------------------------------------------>

### Operations

Click link and make sure it goes to canny. 

<!-----------------------------------------------------------------------------
If your changes have a user-facing impact, describe how a non-technical QA team can functionally test your changes in a preview environment.

If they are not user-facing please describe how to test for any regressions that may occur.
------------------------------------------------------------------------------>

## Screenshots (if applicable)
