### PR TITLE
fix: various exchange swapper fixes

### DIFF
--- a/src/components/MultiHopTrade/components/TradeConfirm/TradeConfirm.tsx
+++ b/src/components/MultiHopTrade/components/TradeConfirm/TradeConfirm.tsx
@@ -54,6 +54,7 @@ import {
   selectLastHopBuyAsset,
   selectNetBuyAmountCryptoPrecision,
   selectNetBuyAmountUserCurrency,
+  selectNetworkFeeRequiresBalance,
   selectQuoteDonationAmountUserCurrency,
   selectSellAmountBeforeFeesCryptoPrecision,
   selectSellAmountUserCurrency,

--- a/src/components/MultiHopTrade/components/TradeConfirm/TradeConfirm.tsx
+++ b/src/components/MultiHopTrade/components/TradeConfirm/TradeConfirm.tsx
@@ -54,7 +54,6 @@ import {
   selectLastHopBuyAsset,
   selectNetBuyAmountCryptoPrecision,
   selectNetBuyAmountUserCurrency,
-  selectNetworkFeeRequiresBalance,
   selectQuoteDonationAmountUserCurrency,
   selectSellAmountBeforeFeesCryptoPrecision,
   selectSellAmountUserCurrency,

--- a/src/components/MultiHopTrade/components/TradeInput/TradeInput.tsx
+++ b/src/components/MultiHopTrade/components/TradeInput/TradeInput.tsx
@@ -237,7 +237,6 @@ export const TradeInput = () => {
               accountId={sellAssetAccountId}
               asset={sellAsset}
               label={translate('trade.youPay')}
-              onClickSendMax={() => {}}
             />
             <TradeAssetInput
               isReadOnly={true}

--- a/src/components/MultiHopTrade/components/TradeInput/TradeInput.tsx
+++ b/src/components/MultiHopTrade/components/TradeInput/TradeInput.tsx
@@ -187,7 +187,6 @@ export const TradeInput = () => {
   }, [activeQuote, dispatch, history, mixpanel, showErrorToast, tradeQuoteStep, wallet])
 
   const isSellAmountEntered = bnOrZero(sellAmountCryptoPrecision).gt(0)
-  console.log('xxx isSellAmountEntered', { isSellAmountEntered, sellAmountCryptoPrecision })
 
   const shouldDisablePreviewButton = useMemo(() => {
     return quoteHasError || manualReceiveAddressIsValidating || isLoading || !isSellAmountEntered

--- a/src/components/MultiHopTrade/components/TradeInput/TradeInput.tsx
+++ b/src/components/MultiHopTrade/components/TradeInput/TradeInput.tsx
@@ -41,6 +41,7 @@ import {
 import {
   selectBuyAsset,
   selectManualReceiveAddressIsValidating,
+  selectSellAmountCryptoPrecision,
   selectSellAsset,
 } from 'state/slices/selectors'
 import { swappers } from 'state/slices/swappersSlice/swappersSlice'
@@ -52,7 +53,6 @@ import {
   selectFirstHop,
   selectNetBuyAmountUserCurrency,
   selectNetReceiveAmountCryptoPrecision,
-  selectSellAmountCryptoPrecision,
   selectSwapperSupportsCrossAccountTrade,
   selectTotalNetworkFeeUserCurrencyPrecision,
   selectTotalProtocolFeeByAsset,
@@ -186,10 +186,12 @@ export const TradeInput = () => {
     setIsConfirmationLoading(false)
   }, [activeQuote, dispatch, history, mixpanel, showErrorToast, tradeQuoteStep, wallet])
 
+  const isSellAmountEntered = bnOrZero(sellAmountCryptoPrecision).gt(0)
+  console.log('xxx isSellAmountEntered', { isSellAmountEntered, sellAmountCryptoPrecision })
+
   const shouldDisablePreviewButton = useMemo(() => {
-    const sellAmountEntered = bnOrZero(sellAmountCryptoPrecision).gt(0)
-    return quoteHasError || manualReceiveAddressIsValidating || isLoading || !sellAmountEntered
-  }, [isLoading, manualReceiveAddressIsValidating, quoteHasError, sellAmountCryptoPrecision])
+    return quoteHasError || manualReceiveAddressIsValidating || isLoading || !isSellAmountEntered
+  }, [isLoading, isSellAmountEntered, manualReceiveAddressIsValidating, quoteHasError])
 
   return (
     <MessageOverlay show={isKeplr} title={overlayTitle}>
@@ -243,8 +245,14 @@ export const TradeInput = () => {
               assetId={buyAsset.assetId}
               assetSymbol={buyAsset.symbol}
               assetIcon={buyAsset.icon}
-              cryptoAmount={positiveOrZero(buyAmountAfterFeesCryptoPrecision).toFixed()}
-              fiatAmount={positiveOrZero(buyAmountAfterFeesUserCurrency).toFixed()}
+              cryptoAmount={
+                isSellAmountEntered
+                  ? positiveOrZero(buyAmountAfterFeesCryptoPrecision).toFixed()
+                  : '0'
+              }
+              fiatAmount={
+                isSellAmountEntered ? positiveOrZero(buyAmountAfterFeesUserCurrency).toFixed() : '0'
+              }
               percentOptions={[1]}
               showInputSkeleton={isLoading}
               showFiatSkeleton={isLoading}

--- a/src/components/MultiHopTrade/components/TradeInput/components/SellAssetInput.tsx
+++ b/src/components/MultiHopTrade/components/TradeInput/components/SellAssetInput.tsx
@@ -11,15 +11,9 @@ export type SellAssetInputProps = {
   accountId?: AccountId
   label: string
   asset: Asset
-  onClickSendMax: () => void
 }
 
-export const SellAssetInput = ({
-  accountId,
-  asset,
-  label,
-  onClickSendMax,
-}: SellAssetInputProps) => {
+export const SellAssetInput = ({ accountId, asset, label }: SellAssetInputProps) => {
   const [sellAmountUserCurrencyHuman, setSellAmountUserCurrencyHuman] = useState('0')
   const [sellAmountCryptoPrecision, setSellAmountCryptoPrecision] = useState('0')
   const dispatch = useAppDispatch()
@@ -58,7 +52,6 @@ export const SellAssetInput = ({
       isSendMaxDisabled={false}
       onChange={handleSellAssetInputChange}
       percentOptions={[1]}
-      onPercentOptionClick={onClickSendMax}
       showInputSkeleton={false}
       showFiatSkeleton={false}
       label={label}

--- a/src/state/slices/swappersSlice/swappersSlice.ts
+++ b/src/state/slices/swappersSlice/swappersSlice.ts
@@ -41,7 +41,13 @@ export const swappers = createSlice({
   reducers: {
     clear: () => initialState,
     setBuyAsset: (state, action: PayloadAction<Asset>) => {
-      state.buyAsset = action.payload
+      const asset = action.payload
+
+      // Handle the user selecting the same asset for both buy and sell
+      const isSameAsSellAsset = asset.assetId === state.sellAsset.assetId
+      if (isSameAsSellAsset) state.sellAsset = state.buyAsset
+
+      state.buyAsset = asset
 
       const buyAssetChainId = state.buyAsset.chainId
       const buyAssetAccountChainId = state.buyAssetAccountId
@@ -53,6 +59,12 @@ export const swappers = createSlice({
         state.buyAssetAccountId = undefined
     },
     setSellAsset: (state, action: PayloadAction<Asset>) => {
+      const asset = action.payload
+
+      // Handle the user selecting the same asset for both buy and sell
+      const isSameAsBuyAsset = asset.assetId === state.buyAsset.assetId
+      if (isSameAsBuyAsset) state.buyAsset = state.sellAsset
+
       state.sellAsset = action.payload
 
       const sellAssetChainId = state.sellAsset.chainId

--- a/src/state/slices/tradeQuoteSlice/selectors.ts
+++ b/src/state/slices/tradeQuoteSlice/selectors.ts
@@ -188,7 +188,7 @@ export const selectFirstHopTradeDeductionCryptoPrecision: Selector<ReduxState, s
 // TODO(woodenfurniture): update swappers to specify this as with protocol fees
 export const selectNetworkFeeRequiresBalance: Selector<ReduxState, boolean> = createSelector(
   selectActiveSwapperName,
-  (swapperName): boolean => swapperName === SwapperName.CowSwap,
+  (swapperName): boolean => swapperName !== SwapperName.CowSwap,
 )
 
 export const selectFirstHopNetworkFeeCryptoBaseUnit: Selector<ReduxState, string | undefined> =


### PR DESCRIPTION
## Description

This fixes:

- If the input amount is 0, the 'you get' amount will now also be 0. This accommodates swappers that do an initial dummy quote to get the rate when no amount is entered.
- Send max button is now removed, as approved by Product. It's tricky and not a necessary problem to solve right now.
- Handles the same asset being selected for both the buy and the sell assets, gracefully swapping them in such cases.
- Fixes the crypto amount miner fee on the trade confirm by fixing the logic in `selectNetworkFeeRequiresBalance`

## Pull Request Type

- [x] :bug: Bug fix (Non-breaking Change: Fixes an issue)
- [ ] :hammer_and_wrench: Chore (Non-breaking Change: Doc updates, pkg upgrades, typos, etc..)
- [ ] :nail_care: New Feature (Breaking/Non-breaking Change)

## Issue (if applicable)

N/A

## Risk

## Testing

Ensure the scenarios listed in the PR description above are no longer issues.

### Engineering

☝️

### Operations

No testing needed at this time, this is all behind the multi-hop feature flag.

## Screenshots (if applicable)

N/A
