### PR TITLE
chore: add exchange swapper to all routes

### DIFF
--- a/src/components/AccountDetails.tsx
+++ b/src/components/AccountDetails.tsx
@@ -55,7 +55,11 @@ export const AccountDetails = ({ assetId, accountId }: AccountDetailsProps) => {
         maxWidth={{ base: 'full', xl: 'md' }}
         gap={4}
       >
-        {MultiHopTrades ? <MultiHopTrade /> : <TradeCard display={{ base: 'none', md: 'block' }} />}
+        {MultiHopTrades ? (
+          <MultiHopTrade display={{ base: 'none', md: 'block' }} />
+        ) : (
+          <TradeCard display={{ base: 'none', md: 'block' }} />
+        )}
       </Flex>
     </Stack>
   )

--- a/src/components/AccountDetails.tsx
+++ b/src/components/AccountDetails.tsx
@@ -2,10 +2,13 @@ import { Flex, Stack } from '@chakra-ui/react'
 import type { AccountId, AssetId } from '@shapeshiftoss/caip'
 import { useTranslate } from 'react-polyglot'
 import type { Route } from 'Routes/helpers'
+import { MultiHopTrade } from 'components/MultiHopTrade/MultiHopTrade'
 import { AssetTransactionHistory } from 'components/TransactionHistory/AssetTransactionHistory'
 import { AccountBalance } from 'pages/Accounts/AccountToken/AccountBalance'
 import { TradeCard } from 'pages/Dashboard/TradeCard'
 import { isUtxoAccountId } from 'state/slices/portfolioSlice/utils'
+import { selectFeatureFlags } from 'state/slices/preferencesSlice/selectors'
+import { useAppSelector } from 'state/store'
 
 import { AccountAssets } from './AccountAssets/AccountAssets'
 import { AssetAccounts } from './AssetAccounts/AssetAccounts'
@@ -20,6 +23,7 @@ type AccountDetailsProps = {
 }
 
 export const AccountDetails = ({ assetId, accountId }: AccountDetailsProps) => {
+  const { MultiHopTrades } = useAppSelector(selectFeatureFlags)
   const translate = useTranslate()
   if (!accountId || !assetId) return null
   return (
@@ -51,7 +55,7 @@ export const AccountDetails = ({ assetId, accountId }: AccountDetailsProps) => {
         maxWidth={{ base: 'full', xl: 'md' }}
         gap={4}
       >
-        <TradeCard display={{ base: 'none', md: 'block' }} />
+        {MultiHopTrades ? <MultiHopTrade /> : <TradeCard display={{ base: 'none', md: 'block' }} />}
       </Flex>
     </Stack>
   )

--- a/src/components/AssetAccountDetails.tsx
+++ b/src/components/AssetAccountDetails.tsx
@@ -56,7 +56,7 @@ export const AssetAccountDetails = ({ assetId, accountId }: AssetDetailsProps) =
         >
           {MultiHopTrades ? (
             // TODO: Handle defaultBuyAssetId
-            <MultiHopTrade />
+            <MultiHopTrade display={{ base: 'none', md: 'block' }} />
           ) : (
             <TradeCard display={{ base: 'none', md: 'block' }} defaultBuyAssetId={assetId} />
           )}

--- a/src/components/AssetAccountDetails.tsx
+++ b/src/components/AssetAccountDetails.tsx
@@ -55,8 +55,7 @@ export const AssetAccountDetails = ({ assetId, accountId }: AssetDetailsProps) =
           gap={4}
         >
           {MultiHopTrades ? (
-            // TODO: Handle defaultBuyAssetId
-            <MultiHopTrade display={{ base: 'none', md: 'block' }} />
+            <MultiHopTrade display={{ base: 'none', md: 'block' }} defaultBuyAssetId={assetId} />
           ) : (
             <TradeCard display={{ base: 'none', md: 'block' }} defaultBuyAssetId={assetId} />
           )}

--- a/src/components/AssetAccountDetails.tsx
+++ b/src/components/AssetAccountDetails.tsx
@@ -2,9 +2,10 @@ import { Flex, Stack } from '@chakra-ui/react'
 import type { AccountId, AssetId } from '@shapeshiftoss/caip'
 import { useMemo } from 'react'
 import type { Route } from 'Routes/helpers'
+import { MultiHopTrade } from 'components/MultiHopTrade/MultiHopTrade'
 import { AssetTransactionHistory } from 'components/TransactionHistory/AssetTransactionHistory'
 import { TradeCard } from 'pages/Dashboard/TradeCard'
-import { selectMarketDataById } from 'state/slices/selectors'
+import { selectFeatureFlags, selectMarketDataById } from 'state/slices/selectors'
 import { useAppSelector } from 'state/store'
 
 import { AccountAssets } from './AccountAssets/AccountAssets'
@@ -25,6 +26,7 @@ type AssetDetailsProps = {
 }
 
 export const AssetAccountDetails = ({ assetId, accountId }: AssetDetailsProps) => {
+  const { MultiHopTrades } = useAppSelector(selectFeatureFlags)
   const marketData = useAppSelector(state => selectMarketDataById(state, assetId))
   const assetIds = useMemo(() => [assetId], [assetId])
 
@@ -52,7 +54,12 @@ export const AssetAccountDetails = ({ assetId, accountId }: AssetDetailsProps) =
           maxWidth={{ base: 'full', xl: 'sm' }}
           gap={4}
         >
-          <TradeCard display={{ base: 'none', md: 'block' }} defaultBuyAssetId={assetId} />
+          {MultiHopTrades ? (
+            // TODO: Handle defaultBuyAssetId
+            <MultiHopTrade />
+          ) : (
+            <TradeCard display={{ base: 'none', md: 'block' }} defaultBuyAssetId={assetId} />
+          )}
           {marketData && <AssetMarketData assetId={assetId} />}
           <AssetDescription assetId={assetId} />
         </Flex>

--- a/src/components/MultiHopTrade/MultiHopTrade.tsx
+++ b/src/components/MultiHopTrade/MultiHopTrade.tsx
@@ -1,11 +1,14 @@
+import type { AssetId } from '@shapeshiftoss/caip'
+import { ethAssetId, foxAssetId } from '@shapeshiftoss/caip'
 import { AnimatePresence } from 'framer-motion'
 import { useEffect } from 'react'
 import { FormProvider, useForm } from 'react-hook-form'
 import { MemoryRouter, Route, Switch, useLocation } from 'react-router-dom'
 import type { CardProps } from 'components/Card/Card'
 import { Card } from 'components/Card/Card'
+import { selectAssetById } from 'state/slices/assetsSlice/selectors'
 import { swappers } from 'state/slices/swappersSlice/swappersSlice'
-import { useAppDispatch } from 'state/store'
+import { useAppDispatch, useAppSelector } from 'state/store'
 
 import { Approval } from './components/Approval/Approval'
 import { TradeConfirm } from './components/TradeConfirm/TradeConfirm'
@@ -14,8 +17,27 @@ import { TradeRoutePaths } from './types'
 
 const MultiHopEntries = [TradeRoutePaths.Input, TradeRoutePaths.Approval, TradeRoutePaths.Confirm]
 
-export const MultiHopTrade = ({ ...cardProps }: CardProps) => {
+export type TradeCardProps = {
+  defaultBuyAssetId?: AssetId
+  defaultSellAssetId?: AssetId
+} & CardProps
+
+export const MultiHopTrade = ({
+  defaultBuyAssetId = foxAssetId,
+  defaultSellAssetId = ethAssetId,
+  ...cardProps
+}: TradeCardProps) => {
+  const dispatch = useAppDispatch()
   const methods = useForm({ mode: 'onChange' })
+
+  const defaultBuyAsset = useAppSelector(state => selectAssetById(state, defaultBuyAssetId))
+  const defaultSellAsset = useAppSelector(state => selectAssetById(state, defaultSellAssetId))
+
+  useEffect(() => {
+    dispatch(swappers.actions.clear())
+    if (defaultSellAsset) dispatch(swappers.actions.setSellAsset(defaultSellAsset))
+    if (defaultBuyAsset) dispatch(swappers.actions.setBuyAsset(defaultBuyAsset))
+  }, [defaultBuyAsset, defaultSellAsset, dispatch])
 
   return (
     <Card {...cardProps}>

--- a/src/components/MultiHopTrade/MultiHopTrade.tsx
+++ b/src/components/MultiHopTrade/MultiHopTrade.tsx
@@ -2,6 +2,7 @@ import { AnimatePresence } from 'framer-motion'
 import { useEffect } from 'react'
 import { FormProvider, useForm } from 'react-hook-form'
 import { MemoryRouter, Route, Switch, useLocation } from 'react-router-dom'
+import type { CardProps } from 'components/Card/Card'
 import { Card } from 'components/Card/Card'
 import { swappers } from 'state/slices/swappersSlice/swappersSlice'
 import { useAppDispatch } from 'state/store'
@@ -13,11 +14,11 @@ import { TradeRoutePaths } from './types'
 
 const MultiHopEntries = [TradeRoutePaths.Input, TradeRoutePaths.Approval, TradeRoutePaths.Confirm]
 
-export const MultiHopTrade = () => {
+export const MultiHopTrade = ({ ...cardProps }: CardProps) => {
   const methods = useForm({ mode: 'onChange' })
 
   return (
-    <Card>
+    <Card {...cardProps}>
       <Card.Body py={6}>
         <FormProvider {...methods}>
           <MemoryRouter initialEntries={MultiHopEntries} initialIndex={0}>

--- a/src/pages/Accounts/AccountToken/AccountToken.tsx
+++ b/src/pages/Accounts/AccountToken/AccountToken.tsx
@@ -5,12 +5,15 @@ import { useSelector } from 'react-redux'
 import { Redirect, useParams } from 'react-router-dom'
 import { AssetAccounts } from 'components/AssetAccounts/AssetAccounts'
 import { Equity } from 'components/Equity/Equity'
+import { MultiHopTrade } from 'components/MultiHopTrade/MultiHopTrade'
 import { EarnOpportunities } from 'components/StakingVaults/EarnOpportunities'
 import { AssetTransactionHistory } from 'components/TransactionHistory/AssetTransactionHistory'
 import { TradeCard } from 'pages/Dashboard/TradeCard'
-import { selectWalletAccountIds } from 'state/slices/selectors'
+import { selectFeatureFlags, selectWalletAccountIds } from 'state/slices/selectors'
+import { useAppSelector } from 'state/store'
 
 import { AccountBalance } from './AccountBalance'
+
 export type MatchParams = {
   accountId: AccountId
   assetId: AssetId
@@ -18,6 +21,7 @@ export type MatchParams = {
 
 export const AccountToken = () => {
   const { accountId, assetId } = useParams<MatchParams>()
+  const { MultiHopTrades } = useAppSelector(selectFeatureFlags)
 
   /**
    * if the user switches the wallet while visiting this page,
@@ -53,7 +57,7 @@ export const AccountToken = () => {
         maxWidth={{ base: 'full', xl: 'sm' }}
         gap={4}
       >
-        <TradeCard display={{ base: 'none', md: 'block' }} />
+        {MultiHopTrades ? <MultiHopTrade /> : <TradeCard display={{ base: 'none', md: 'block' }} />}
       </Flex>
     </Stack>
   )

--- a/src/pages/Accounts/AccountToken/AccountToken.tsx
+++ b/src/pages/Accounts/AccountToken/AccountToken.tsx
@@ -57,7 +57,11 @@ export const AccountToken = () => {
         maxWidth={{ base: 'full', xl: 'sm' }}
         gap={4}
       >
-        {MultiHopTrades ? <MultiHopTrade /> : <TradeCard display={{ base: 'none', md: 'block' }} />}
+        {MultiHopTrades ? (
+          <MultiHopTrade display={{ base: 'none', md: 'block' }} />
+        ) : (
+          <TradeCard display={{ base: 'none', md: 'block' }} />
+        )}
       </Flex>
     </Stack>
   )

--- a/src/pages/Dashboard/DashboardSidebar.tsx
+++ b/src/pages/Dashboard/DashboardSidebar.tsx
@@ -73,7 +73,11 @@ export const DashboardSidebar = () => {
   return (
     <Flex width='full' flexDir='column' gap={6}>
       <PromoCard data={promoData} />
-      {MultiHopTrades ? <MultiHopTrade /> : <TradeCard display={{ base: 'none', xl: 'block' }} />}
+      {MultiHopTrades ? (
+        <MultiHopTrade display={{ base: 'none', xl: 'block' }} />
+      ) : (
+        <TradeCard display={{ base: 'none', xl: 'block' }} />
+      )}
       <MissionSidebar />
       <EligibleCarousel />
       <RecentTransactions limit={8} viewMoreLink />

--- a/src/pages/Dashboard/DashboardSidebar.tsx
+++ b/src/pages/Dashboard/DashboardSidebar.tsx
@@ -3,10 +3,13 @@ import { btcAssetId, dogeAssetId, foxAssetId } from '@shapeshiftoss/caip'
 import OnRamperLogo from 'assets/on-ramper.png'
 import SaversVaultTop from 'assets/savers-vault-top.png'
 import { AssetIcon } from 'components/AssetIcon'
+import { MultiHopTrade } from 'components/MultiHopTrade/MultiHopTrade'
 import { PromoCard } from 'components/Promo/PromoCard'
 import type { PromoItem } from 'components/Promo/types'
 import { EligibleCarousel } from 'pages/Defi/components/EligibleCarousel'
 import { MissionSidebar } from 'pages/Missions/Missions'
+import { selectFeatureFlags } from 'state/slices/preferencesSlice/selectors'
+import { useAppSelector } from 'state/store'
 
 import { RecentTransactions } from './RecentTransactions'
 import { TradeCard } from './TradeCard'
@@ -66,10 +69,11 @@ const promoData: PromoItem[] = [
 ]
 
 export const DashboardSidebar = () => {
+  const { MultiHopTrades } = useAppSelector(selectFeatureFlags)
   return (
     <Flex width='full' flexDir='column' gap={6}>
       <PromoCard data={promoData} />
-      <TradeCard display={{ base: 'none', xl: 'block' }} />
+      {MultiHopTrades ? <MultiHopTrade /> : <TradeCard display={{ base: 'none', xl: 'block' }} />}
       <MissionSidebar />
       <EligibleCarousel />
       <RecentTransactions limit={8} viewMoreLink />

--- a/src/plugins/foxPage/components/AssetActions.tsx
+++ b/src/plugins/foxPage/components/AssetActions.tsx
@@ -177,8 +177,7 @@ export const AssetActions: React.FC<FoxTabProps> = ({ assetId }) => {
             </TabPanel>
             <TabPanel textAlign='center' p={0}>
               {isFoxAsset && MultiHopTrades ? (
-                // TODO: Handle defaultBuyAssetId
-                <MultiHopTrade />
+                <MultiHopTrade defaultBuyAssetId={assetId} />
               ) : (
                 <TradeCard defaultBuyAssetId={assetId} />
               )}

--- a/src/plugins/foxPage/components/AssetActions.tsx
+++ b/src/plugins/foxPage/components/AssetActions.tsx
@@ -23,6 +23,7 @@ import { useTranslate } from 'react-polyglot'
 import { useHistory, useLocation } from 'react-router'
 import { AssetIcon } from 'components/AssetIcon'
 import { Card } from 'components/Card/Card'
+import { MultiHopTrade } from 'components/MultiHopTrade/MultiHopTrade'
 import { Text } from 'components/Text/Text'
 import { WalletActions } from 'context/WalletProvider/actions'
 import { useModal } from 'hooks/useModal/useModal'
@@ -33,7 +34,11 @@ import { MixPanelEvents } from 'lib/mixpanel/types'
 import { TradeCard } from 'pages/Dashboard/TradeCard'
 import { DefiProvider } from 'state/slices/opportunitiesSlice/types'
 import { trimWithEndEllipsis } from 'state/slices/portfolioSlice/utils'
-import { selectAccountIdsByAssetId, selectAssetById } from 'state/slices/selectors'
+import {
+  selectAccountIdsByAssetId,
+  selectAssetById,
+  selectFeatureFlags,
+} from 'state/slices/selectors'
 import { useAppSelector } from 'state/store'
 
 import { TrimmedDescriptionLength } from '../FoxCommon'
@@ -46,6 +51,7 @@ const BuyFoxCoinbaseUrl = 'https://www.coinbase.com/price/fox-token'
 const TradeFoxyElasticSwapUrl = `https://elasticswap.org/#/swap`
 
 export const AssetActions: React.FC<FoxTabProps> = ({ assetId }) => {
+  const { MultiHopTrades } = useAppSelector(selectFeatureFlags)
   const translate = useTranslate()
   const location = useLocation()
   const history = useHistory()
@@ -170,7 +176,12 @@ export const AssetActions: React.FC<FoxTabProps> = ({ assetId }) => {
               </Stack>
             </TabPanel>
             <TabPanel textAlign='center' p={0}>
-              {isFoxAsset && <TradeCard defaultBuyAssetId={assetId} />}
+              {isFoxAsset && MultiHopTrades ? (
+                // TODO: Handle defaultBuyAssetId
+                <MultiHopTrade />
+              ) : (
+                <TradeCard defaultBuyAssetId={assetId} />
+              )}
               {!isFoxAsset && (
                 <Stack width='full' p={6}>
                   <SkeletonText isLoaded={Boolean(description?.length)} noOfLines={3}>


### PR DESCRIPTION
## Description

Add exchange swapper to all routes (though still behind a feature flag).

This means that when the multi-hop fuature flag is enabled, all instaces of the existing swapper will be replaced by the exchange version.

Still do to:

- [x] Handle default asset setting
- [x] Match styling to existing

## Pull Request Type

- [ ] :bug: Bug fix (Non-breaking Change: Fixes an issue)
- [x] :hammer_and_wrench: Chore (Non-breaking Change: Doc updates, pkg upgrades, typos, etc..)
- [ ] :nail_care: New Feature (Breaking/Non-breaking Change)

## Issue (if applicable)

N/A

## Risk

Small

## Testing

Check all places that the swap widget is shown, and ensure it looks and behaves as expected.

- Dashboard sidebar
- Account details
- Asset account details
- Account token
- Trade page
- Fox page

### Engineering

☝️

### Operations

N/A

## Screenshots (if applicable)

N/A
