### PR TITLE
fix: mission cards overflowing copies and duration locale

### DIFF
--- a/src/pages/Missions/Mission.tsx
+++ b/src/pages/Missions/Mission.tsx
@@ -85,6 +85,10 @@ export const Mission: React.FC<MissionProps> = ({
             onClick={handleClick}
             iconSpacing={3}
             className='mission-btn'
+            whiteSpace={'normal'}
+            display={'inline-flex'}
+            textAlign={'left'}
+            lineHeight={'none'}
             leftIcon={
               <IconCircle
                 bg='white'

--- a/src/pages/Missions/Mission.tsx
+++ b/src/pages/Missions/Mission.tsx
@@ -20,6 +20,8 @@ import { Card } from 'components/Card/Card'
 import { IconCircle } from 'components/IconCircle'
 import { RawText } from 'components/Text'
 import { getMixPanel } from 'lib/mixpanel/mixPanelSingleton'
+import { selectSelectedLocale } from 'state/slices/selectors'
+import { useAppSelector } from 'state/store'
 
 dayjs.extend(timezone)
 dayjs.extend(customParseFormat)
@@ -52,6 +54,7 @@ export const Mission: React.FC<MissionProps> = ({
 }) => {
   const [isActive, setIsActive] = useState(false)
   const translate = useTranslate()
+  const selectedLocale = useAppSelector(selectSelectedLocale)
   const handleClick = useCallback(
     (e: MouseEvent) => {
       if (e?.defaultPrevented) return
@@ -110,7 +113,9 @@ export const Mission: React.FC<MissionProps> = ({
             ) : (
               <RawText lineHeight='none'>
                 {endDate
-                  ? `${translate('missions.ends')} ${dayjs(endDate, dateFormat).fromNow()}`
+                  ? `${translate('missions.ends')} ${dayjs(endDate, dateFormat)
+                      .locale(selectedLocale)
+                      .fromNow()}`
                   : translate('missions.ongoing')}
               </RawText>
             )}
@@ -118,7 +123,7 @@ export const Mission: React.FC<MissionProps> = ({
         </>
       )
     }
-  }, [buttonText, endDate, handleClick, startDate, translate])
+  }, [buttonText, endDate, handleClick, selectedLocale, startDate, translate])
   return (
     <Card
       display='flex'


### PR DESCRIPTION
## Description

Minor tweak for the Missions cards for longer copies (translations), likely better if @reallybeard checks these changes visually.

- Fixes the overflowing texts to go on multiple lines and align correctly in the Mission cards.
- Use the user's locale in `dayjs` to display the correct language for duration of ongoing missions in Mission cards.
<!-- Please describe your changes -->

## Pull Request Type

- [x] :bug: Bug fix (Non-breaking Change: Fixes an issue)
- [ ] :hammer_and_wrench: Chore (Non-breaking Change: Doc updates, pkg upgrades, typos, etc..)
- [ ] :nail_care: New Feature (Breaking/Non-breaking Change)

## Risk

Low. Only minor visual fixes and correct usage of the user's language for duration.

<!-----------------------------------------------------------------------------
Outline the scope of your changes and the risk associated with them. You must use your discretion as an engineer to determine the potential impact of your changes.

E.g. an upgrade to `hdwallet` or core state management would be considered higher risk, and might require a full regression test. UI or isolated view changes, or something behind a feature flag may have near zero risk. Small bug fixes might require testing isolated to the specific fix.
------------------------------------------------------------------------------>

## Testing

Check the visual rendering of mission cards throughout the app in the supported languages. The should either be on a single line when the copy is short enough or span on multiple lines and not overflow above other elements if they are long.

<!-----------------------------------------------------------------------------
We treat every PR to be merged with the same scrutiny as if we were merging directly to production.

Your PR will not be merged if you do not complete the sections below for our engineering and operations teams to test.
------------------------------------------------------------------------------>

### Engineering
☝️ 
<!-----------------------------------------------------------------------------
Include sufficient information here for an engineer to test your PR. This may include how to test locally, in a built environment, changes to infrastructure etc.
------------------------------------------------------------------------------>

### Operations
☝️ 
<!-----------------------------------------------------------------------------
If your changes have a user-facing impact, describe how a non-technical QA team can functionally test your changes in a preview environment.

If they are not user-facing please describe how to test for any regressions that may occur.
------------------------------------------------------------------------------>

## Screenshots (if applicable)
Before (CTA in the right colum):
![image](https://github.com/shapeshift/web/assets/88804546/228f279b-10c9-4838-a995-6fad1476a43b)

Before Missions page (problem circled in red)
![image](https://github.com/shapeshift/web/assets/88804546/10323fde-d765-4870-b0c5-6ebc5d61f9d4)

After CTA (French)
![image](https://github.com/shapeshift/web/assets/88804546/a35091be-ca8c-4eb3-80e1-4225858f36bd)

After CTA (English) (same as before)
![image](https://github.com/shapeshift/web/assets/88804546/69c22741-73c4-4c72-8a4f-9b80c142ab7a)

After Missions page (see "days" replaced by "jours" in French, tested in other languages)
![image](https://github.com/shapeshift/web/assets/88804546/c73a9523-97b9-4935-aaca-78769c058f45)

After Missions page on Mobile
![image](https://github.com/shapeshift/web/assets/88804546/9523e77e-a599-49db-bafc-3a45299d78cf)
