### PR TITLE
chore: release v1.379.0

### DIFF
--- a/src/components/AssetIcon.tsx
+++ b/src/components/AssetIcon.tsx
@@ -28,24 +28,34 @@ const AssetWithNetwork: React.FC<AssetWithNetworkProps> = ({ assetId, icon, src,
   const asset = useAppSelector(state => selectAssetById(state, assetId ?? ''))
   const feeAsset = useAppSelector(state => selectFeeAssetById(state, assetId))
   const showNetwork = feeAsset?.networkIcon || asset?.assetId !== feeAsset?.assetId
-  const boxShadow = useColorModeValue(
-    `0 0 0 0.2em ${feeAsset?.color ?? 'black'}35, 0 0 0.5em 2px rgba(255,255,255,.5)`,
-    `0 0 0 0.2em ${feeAsset?.color ?? 'white'}50, 0 0 0.5em 2px rgba(0,0,0,.5)`,
-  )
+  const iconSrc = src ?? asset?.icon
+
   return (
-    <Avatar src={src ?? asset?.icon} icon={icon} border={0} bg='none' {...rest}>
+    <Avatar src={iconSrc} icon={icon} border={0} bg='none' {...rest}>
       {showNetwork && (
         <Avatar
-          boxSize='0.85em'
+          boxSize='50%'
           zIndex={2}
           position='absolute'
-          right='-0.15em'
-          top='-0.15em'
+          right={0}
+          bottom='0'
           border={0}
+          icon={icon}
           bg='none'
           fontSize='inherit'
           src={feeAsset?.networkIcon ?? feeAsset?.icon}
-          boxShadow={boxShadow}
+          _before={{
+            content: '""',
+            width: '115%',
+            height: '115%',
+            backgroundColor: 'var(--chakra-colors-chakra-body-bg)',
+            borderRadius: 'full',
+            position: 'absolute',
+            left: '50%',
+            top: '50%',
+            transform: 'translate(-50%, -50%)',
+            zIndex: -1,
+          }}
         />
       )}
     </Avatar>
@@ -77,9 +87,8 @@ export const AssetIcon = ({ assetId, showNetworkIcon, src, ...rest }: AssetIconP
       return (
         <Flex flexDirection='row' alignItems='center'>
           {asset.icons.map((iconSrc, i) => (
-            <AssetWithNetwork
+            <Avatar
               key={i}
-              assetId={assetId}
               src={iconSrc}
               ml={i === 0 ? '0' : '-2.5'}
               icon={<FoxIcon boxSize='16px' color={assetIconColor} />}

--- a/src/components/Layout/Header/GlobalSearch/AssetResults/AssetResult.tsx
+++ b/src/components/Layout/Header/GlobalSearch/AssetResults/AssetResult.tsx
@@ -2,7 +2,7 @@ import { Flex, forwardRef } from '@chakra-ui/react'
 import type { AssetId } from '@shapeshiftoss/caip'
 import { useMemo } from 'react'
 import { Amount } from 'components/Amount/Amount'
-import { LazyLoadAvatar } from 'components/LazyLoadAvatar'
+import { AssetIcon } from 'components/AssetIcon'
 import { RawText } from 'components/Text'
 import { bnOrZero } from 'lib/bignumber/bignumber'
 import { middleEllipsis } from 'lib/utils'
@@ -42,7 +42,7 @@ export const AssetResult = forwardRef<AssetResultProps, 'div'>(
         onClick={() => onClick({ type: GlobalSearchResultType.Asset, id: assetId })}
       >
         <Flex gap={2} flex={1}>
-          <LazyLoadAvatar src={asset.icon} />
+          <AssetIcon assetId={asset.assetId} size='sm' />
           <Flex flexDir='column' alignItems='flex-start' textAlign='left'>
             <RawText
               color='chakra-body-text'

--- a/src/components/MultiHopTrade/components/Approval/Approval.tsx
+++ b/src/components/MultiHopTrade/components/Approval/Approval.tsx
@@ -137,11 +137,13 @@ const ApprovalInner = ({
   // proceed to trade confirmation when approval is no longer needed
   // this is managed async to approveContract so that approvals done external to this app propagate
   useEffect(() => {
+    // Wait for the form submit to be false before pushing the confirm route
+    if (isSubmitting) return
     // explicitly check for false as undefined indicates an unknown state
     if (isApprovalNeeded === false) {
       history.push({ pathname: TradeRoutePaths.Confirm })
     }
-  }, [history, isApprovalNeeded])
+  }, [history, isApprovalNeeded, isSubmitting])
 
   return (
     <SlideTransition>

--- a/src/components/MultiHopTrade/components/TradeInput/TradeInput.tsx
+++ b/src/components/MultiHopTrade/components/TradeInput/TradeInput.tsx
@@ -228,7 +228,7 @@ export const TradeInput = () => {
                 assetId={buyAsset.assetId}
                 onAssetClick={handleBuyAssetClick}
                 onAccountIdChange={setBuyAssetAccountId}
-                accountSelectionDisabled={swapperSupportsCrossAccountTrade}
+                accountSelectionDisabled={!swapperSupportsCrossAccountTrade}
                 label={translate('trade.to')}
               />
             </Flex>

--- a/src/components/MultiHopTrade/components/TradeInput/TradeInput.tsx
+++ b/src/components/MultiHopTrade/components/TradeInput/TradeInput.tsx
@@ -41,6 +41,7 @@ import {
 import {
   selectBuyAsset,
   selectManualReceiveAddressIsValidating,
+  selectSellAmountCryptoPrecision,
   selectSellAsset,
 } from 'state/slices/selectors'
 import { swappers } from 'state/slices/swappersSlice/swappersSlice'
@@ -52,7 +53,6 @@ import {
   selectFirstHop,
   selectNetBuyAmountUserCurrency,
   selectNetReceiveAmountCryptoPrecision,
-  selectSellAmountCryptoPrecision,
   selectSwapperSupportsCrossAccountTrade,
   selectTotalNetworkFeeUserCurrencyPrecision,
   selectTotalProtocolFeeByAsset,
@@ -186,10 +186,11 @@ export const TradeInput = () => {
     setIsConfirmationLoading(false)
   }, [activeQuote, dispatch, history, mixpanel, showErrorToast, tradeQuoteStep, wallet])
 
+  const isSellAmountEntered = bnOrZero(sellAmountCryptoPrecision).gt(0)
+
   const shouldDisablePreviewButton = useMemo(() => {
-    const sellAmountEntered = bnOrZero(sellAmountCryptoPrecision).gt(0)
-    return quoteHasError || manualReceiveAddressIsValidating || isLoading || !sellAmountEntered
-  }, [isLoading, manualReceiveAddressIsValidating, quoteHasError, sellAmountCryptoPrecision])
+    return quoteHasError || manualReceiveAddressIsValidating || isLoading || !isSellAmountEntered
+  }, [isLoading, isSellAmountEntered, manualReceiveAddressIsValidating, quoteHasError])
 
   return (
     <MessageOverlay show={isKeplr} title={overlayTitle}>
@@ -235,7 +236,6 @@ export const TradeInput = () => {
               accountId={sellAssetAccountId}
               asset={sellAsset}
               label={translate('trade.youPay')}
-              onClickSendMax={() => {}}
             />
             <TradeAssetInput
               isReadOnly={true}
@@ -243,8 +243,14 @@ export const TradeInput = () => {
               assetId={buyAsset.assetId}
               assetSymbol={buyAsset.symbol}
               assetIcon={buyAsset.icon}
-              cryptoAmount={positiveOrZero(buyAmountAfterFeesCryptoPrecision).toFixed()}
-              fiatAmount={positiveOrZero(buyAmountAfterFeesUserCurrency).toFixed()}
+              cryptoAmount={
+                isSellAmountEntered
+                  ? positiveOrZero(buyAmountAfterFeesCryptoPrecision).toFixed()
+                  : '0'
+              }
+              fiatAmount={
+                isSellAmountEntered ? positiveOrZero(buyAmountAfterFeesUserCurrency).toFixed() : '0'
+              }
               percentOptions={[1]}
               showInputSkeleton={isLoading}
               showFiatSkeleton={isLoading}

--- a/src/components/MultiHopTrade/components/TradeInput/components/SellAssetInput.tsx
+++ b/src/components/MultiHopTrade/components/TradeInput/components/SellAssetInput.tsx
@@ -11,15 +11,9 @@ export type SellAssetInputProps = {
   accountId?: AccountId
   label: string
   asset: Asset
-  onClickSendMax: () => void
 }
 
-export const SellAssetInput = ({
-  accountId,
-  asset,
-  label,
-  onClickSendMax,
-}: SellAssetInputProps) => {
+export const SellAssetInput = ({ accountId, asset, label }: SellAssetInputProps) => {
   const [sellAmountUserCurrencyHuman, setSellAmountUserCurrencyHuman] = useState('0')
   const [sellAmountCryptoPrecision, setSellAmountCryptoPrecision] = useState('0')
   const dispatch = useAppDispatch()
@@ -58,7 +52,6 @@ export const SellAssetInput = ({
       isSendMaxDisabled={false}
       onChange={handleSellAssetInputChange}
       percentOptions={[1]}
-      onPercentOptionClick={onClickSendMax}
       showInputSkeleton={false}
       showFiatSkeleton={false}
       label={label}

--- a/src/components/StakingVaults/Cells.tsx
+++ b/src/components/StakingVaults/Cells.tsx
@@ -15,7 +15,7 @@ import { PairIcons } from 'features/defi/components/PairIcons/PairIcons'
 import { debounce } from 'lodash'
 import { isValidElement, useState } from 'react'
 import { FaInfoCircle } from 'react-icons/fa'
-import { LazyLoadAvatar } from 'components/LazyLoadAvatar'
+import { AssetIcon } from 'components/AssetIcon'
 import { RawText } from 'components/Text'
 import type { Asset } from 'lib/asset-service'
 import { selectAssetById } from 'state/slices/selectors'
@@ -87,10 +87,10 @@ export const AssetCell = ({
       )}
       <HStack flex={1}>
         <SkeletonCircle isLoaded={!!asset} mr={2} width='auto'>
-          {icons ? (
+          {icons && icons.length > 1 ? (
             <PairIcons icons={icons} iconSize='sm' bg='none' />
           ) : (
-            <LazyLoadAvatar src={asset.icon} size='sm' />
+            <AssetIcon assetId={asset.assetId} size='sm' />
           )}
         </SkeletonCircle>
         <SkeletonText noOfLines={2} isLoaded={!!asset} flex={1}>

--- a/src/components/TransactionHistoryRows/components/AssetTransfer.tsx
+++ b/src/components/TransactionHistoryRows/components/AssetTransfer.tsx
@@ -40,7 +40,7 @@ export const AssetTransfer: React.FC<AssetTransferProps> = ({ index, compactMode
       <AssetIcon
         src={transfer.asset.icon}
         assetId={transfer.asset?.assetId}
-        boxSize={{ base: '24px', lg: compactMode ? '24px' : '40px' }}
+        size={{ base: 'sm', lg: compactMode ? 'sm' : 'md' }}
       />
       <Box flex={1}>
         <Amount.Crypto

--- a/src/features/defi/components/Approve/PairIcons.tsx
+++ b/src/features/defi/components/Approve/PairIcons.tsx
@@ -5,7 +5,13 @@ export const PairIcons = ({ icons }: { icons: string[] }) => {
   return (
     <Flex flexDirection='row' alignItems='center'>
       {icons.map((iconSrc, i) => (
-        <AssetIcon key={iconSrc} src={iconSrc} boxSize='14' ml={i === 0 ? '0' : '-2.5'} />
+        <AssetIcon
+          showNetworkIcon={false}
+          key={iconSrc}
+          src={iconSrc}
+          boxSize='14'
+          ml={i === 0 ? '0' : '-2.5'}
+        />
       ))}
     </Flex>
   )

--- a/src/features/defi/components/PairIcons/PairIcons.tsx
+++ b/src/features/defi/components/PairIcons/PairIcons.tsx
@@ -21,6 +21,7 @@ export const PairIcons = ({
           src={iconSrc}
           boxSize={iconBoxSize}
           size={iconSize}
+          showNetworkIcon={i === 0}
           ml={i === 0 ? '0' : '-2.5'}
         />
       ))}

--- a/src/lib/swapper/swappers/LifiSwapper/LifiSwapper.ts
+++ b/src/lib/swapper/swappers/LifiSwapper/LifiSwapper.ts
@@ -70,7 +70,8 @@ export class LifiSwapper implements Swapper<EvmChainId> {
       store.getState(),
       input.sellAsset.assetId,
     )
-    const minimumCryptoHuman = getMinimumCryptoHuman(sellAssetPriceUsdPrecision)
+    const isSameChainSwap = input.buyAsset.chainId === input.sellAsset.chainId
+    const minimumCryptoHuman = getMinimumCryptoHuman(sellAssetPriceUsdPrecision, isSameChainSwap)
     const minimumSellAmountBaseUnit = toBaseUnit(minimumCryptoHuman, input.sellAsset.precision)
     const isBelowMinSellAmount = bnOrZero(input.sellAmountBeforeFeesCryptoBaseUnit).lt(
       minimumSellAmountBaseUnit,

--- a/src/lib/swapper/swappers/LifiSwapper/getTradeQuote/getTradeQuote.ts
+++ b/src/lib/swapper/swappers/LifiSwapper/getTradeQuote/getTradeQuote.ts
@@ -161,9 +161,13 @@ export async function getTradeQuote(
       }),
     )
 
+    const isSameChainSwap = sellAsset.chainId === buyAsset.chainId
     // TODO(gomes): intermediary error-handling within this module function calls
     return Ok({
-      minimumCryptoHuman: getMinimumCryptoHuman(sellAssetPriceUsdPrecision).toString(),
+      minimumCryptoHuman: getMinimumCryptoHuman(
+        sellAssetPriceUsdPrecision,
+        isSameChainSwap,
+      ).toString(),
       steps,
       selectedLifiRoute,
     })

--- a/src/lib/swapper/swappers/LifiSwapper/utils/constants.ts
+++ b/src/lib/swapper/swappers/LifiSwapper/utils/constants.ts
@@ -1,4 +1,5 @@
-export const MIN_AMOUNT_THRESHOLD_USD_HUMAN = 20 // arbitrary amount deemed by lifi devs to meet minimum amount across all brdiges
+export const MIN_CROSS_CHAIN_AMOUNT_THRESHOLD_USD_HUMAN = 20 // arbitrary amount deemed by lifi devs to meet minimum amount across all brdiges
+export const MIN_SAME_CHAIN_AMOUNT_THRESHOLD_USD_HUMAN = '0.01' // Same chain bridges can be of any amount, since fees are paid explicitly as miner fees in one chain
 export const SELECTED_ROUTE_INDEX = 0 // default to first route - this is the highest ranking according to the query we send
 export const LIFI_GAS_FEE_BASE = 16 // lifi gas feed are all in base 16
 export const DEFAULT_LIFI_TOKEN_ADDRESS = '0x0000000000000000000000000000000000000000'

--- a/src/lib/swapper/swappers/LifiSwapper/utils/getMinimumCryptoHuman/getMinimumCryptoHuman.ts
+++ b/src/lib/swapper/swappers/LifiSwapper/utils/getMinimumCryptoHuman/getMinimumCryptoHuman.ts
@@ -1,9 +1,19 @@
 import type { BigNumber } from 'lib/bignumber/bignumber'
 import { bn } from 'lib/bignumber/bignumber'
-import { MIN_AMOUNT_THRESHOLD_USD_HUMAN } from 'lib/swapper/swappers/LifiSwapper/utils/constants'
+import {
+  MIN_CROSS_CHAIN_AMOUNT_THRESHOLD_USD_HUMAN,
+  MIN_SAME_CHAIN_AMOUNT_THRESHOLD_USD_HUMAN,
+} from 'lib/swapper/swappers/LifiSwapper/utils/constants'
 
 // TEMP: use a hardcoded minimum until we implement monadic error handling for swapper
 // https://github.com/shapeshift/web/issues/4237
-export const getMinimumCryptoHuman = (sellAssetPriceUsdPrecision: string): BigNumber => {
-  return bn(MIN_AMOUNT_THRESHOLD_USD_HUMAN).dividedBy(sellAssetPriceUsdPrecision)
+export const getMinimumCryptoHuman = (
+  sellAssetPriceUsdPrecision: string,
+  isSameChainSwap: boolean,
+): BigNumber => {
+  return bn(
+    isSameChainSwap
+      ? MIN_SAME_CHAIN_AMOUNT_THRESHOLD_USD_HUMAN
+      : MIN_CROSS_CHAIN_AMOUNT_THRESHOLD_USD_HUMAN,
+  ).dividedBy(sellAssetPriceUsdPrecision)
 }

--- a/src/pages/Missions/Mission.tsx
+++ b/src/pages/Missions/Mission.tsx
@@ -20,6 +20,8 @@ import { Card } from 'components/Card/Card'
 import { IconCircle } from 'components/IconCircle'
 import { RawText } from 'components/Text'
 import { getMixPanel } from 'lib/mixpanel/mixPanelSingleton'
+import { selectSelectedLocale } from 'state/slices/selectors'
+import { useAppSelector } from 'state/store'
 
 dayjs.extend(timezone)
 dayjs.extend(customParseFormat)
@@ -52,6 +54,7 @@ export const Mission: React.FC<MissionProps> = ({
 }) => {
   const [isActive, setIsActive] = useState(false)
   const translate = useTranslate()
+  const selectedLocale = useAppSelector(selectSelectedLocale)
   const handleClick = useCallback(
     (e: MouseEvent) => {
       if (e?.defaultPrevented) return
@@ -85,6 +88,10 @@ export const Mission: React.FC<MissionProps> = ({
             onClick={handleClick}
             iconSpacing={3}
             className='mission-btn'
+            whiteSpace={'normal'}
+            display={'inline-flex'}
+            textAlign={'left'}
+            lineHeight={'none'}
             leftIcon={
               <IconCircle
                 bg='white'
@@ -106,7 +113,9 @@ export const Mission: React.FC<MissionProps> = ({
             ) : (
               <RawText lineHeight='none'>
                 {endDate
-                  ? `${translate('missions.ends')} ${dayjs(endDate, dateFormat).fromNow()}`
+                  ? `${translate('missions.ends')} ${dayjs(endDate, dateFormat)
+                      .locale(selectedLocale)
+                      .fromNow()}`
                   : translate('missions.ongoing')}
               </RawText>
             )}
@@ -114,7 +123,7 @@ export const Mission: React.FC<MissionProps> = ({
         </>
       )
     }
-  }, [buttonText, endDate, handleClick, startDate, translate])
+  }, [buttonText, endDate, handleClick, selectedLocale, startDate, translate])
   return (
     <Card
       display='flex'

--- a/src/pages/Missions/Missions.tsx
+++ b/src/pages/Missions/Missions.tsx
@@ -79,7 +79,6 @@ export const useGetMissions = () => {
             'https://x.postmint.xyz/community/64665c31a6c1394b3a35be58/64997a2a590fc8641c50f51a',
           ),
         startDate: '2023-06-26 7:00 AM',
-        endDate: '2023-07-03 7:00 AM',
       },
       {
         title: translate('missions.yat.title'),

--- a/src/state/slices/swappersSlice/swappersSlice.ts
+++ b/src/state/slices/swappersSlice/swappersSlice.ts
@@ -41,7 +41,13 @@ export const swappers = createSlice({
   reducers: {
     clear: () => initialState,
     setBuyAsset: (state, action: PayloadAction<Asset>) => {
-      state.buyAsset = action.payload
+      const asset = action.payload
+
+      // Handle the user selecting the same asset for both buy and sell
+      const isSameAsSellAsset = asset.assetId === state.sellAsset.assetId
+      if (isSameAsSellAsset) state.sellAsset = state.buyAsset
+
+      state.buyAsset = asset
 
       const buyAssetChainId = state.buyAsset.chainId
       const buyAssetAccountChainId = state.buyAssetAccountId
@@ -53,6 +59,12 @@ export const swappers = createSlice({
         state.buyAssetAccountId = undefined
     },
     setSellAsset: (state, action: PayloadAction<Asset>) => {
+      const asset = action.payload
+
+      // Handle the user selecting the same asset for both buy and sell
+      const isSameAsBuyAsset = asset.assetId === state.buyAsset.assetId
+      if (isSameAsBuyAsset) state.buyAsset = state.sellAsset
+
       state.sellAsset = action.payload
 
       const sellAssetChainId = state.sellAsset.chainId

--- a/src/state/slices/tradeQuoteSlice/selectors.ts
+++ b/src/state/slices/tradeQuoteSlice/selectors.ts
@@ -188,7 +188,7 @@ export const selectFirstHopTradeDeductionCryptoPrecision: Selector<ReduxState, s
 // TODO(woodenfurniture): update swappers to specify this as with protocol fees
 export const selectNetworkFeeRequiresBalance: Selector<ReduxState, boolean> = createSelector(
   selectActiveSwapperName,
-  (swapperName): boolean => swapperName === SwapperName.CowSwap,
+  (swapperName): boolean => swapperName !== SwapperName.CowSwap,
 )
 
 export const selectFirstHopNetworkFeeCryptoBaseUnit: Selector<ReduxState, string | undefined> =


### PR DESCRIPTION
fix: mission cards overflowing copies and duration locale (#4935)
feat: add network icons (#4933)
fix: readd fox army card as ongoing mission (#4932)
feat: 0 minimum for same-chain Li.Fi swaps (#4928)
fix: disable account selection on no cross-account trade support for multi-hop <TradeInput /> (#4929)
fix: wait for form submission before approve to confirm routing in multi-hop (#4927)
fix: various exchange swapper fixes (#4924)