### PR TITLE
feat: multi-hop trade execution

### DIFF
--- a/src/components/MultiHopTrade/components/TradeConfirm/TradeConfirm.tsx
+++ b/src/components/MultiHopTrade/components/TradeConfirm/TradeConfirm.tsx
@@ -45,6 +45,7 @@ import { assertUnreachable } from 'lib/utils'
 import { selectManualReceiveAddress } from 'state/slices/swappersSlice/selectors'
 import {
   selectActiveQuote,
+  selectActiveStepOrDefault,
   selectActiveSwapperName,
   selectBuyAmountBeforeFeesCryptoPrecision,
   selectFirstHop,
@@ -89,6 +90,8 @@ export const TradeConfirm = () => {
     dispatch: walletDispatch,
   } = useWallet()
 
+  const activeStepOrDefault = useAppSelector(selectActiveStepOrDefault)
+
   useEffect(() => {
     // WARNING: do not remove.
     // clear the confirmed quote on dismount to prevent stale data affecting the selectors
@@ -97,8 +100,10 @@ export const TradeConfirm = () => {
       // This is due to the way those react-router routes work. This is actually fired on mount, voiding the stated guarantees.
       // We will most likely want to move all these "WARNING: do not remove" effects up to the router-level, so they are *actually* fired on trade routes unmount
       dispatch(tradeQuoteSlice.actions.resetConfirmedQuote())
+
+      if (activeStepOrDefault > 1) dispatch(tradeQuoteSlice.actions.resetActiveStep())
     }
-  }, [dispatch])
+  }, [activeStepOrDefault, dispatch])
 
   const tradeQuote = useAppSelector(selectActiveQuote)
 

--- a/src/components/MultiHopTrade/components/TradeConfirm/TradeConfirm.tsx
+++ b/src/components/MultiHopTrade/components/TradeConfirm/TradeConfirm.tsx
@@ -132,7 +132,11 @@ export const TradeConfirm = () => {
   const buyAsset = useAppSelector(selectLastHopBuyAsset)
   const maybeManualReceiveAddress = useAppSelector(selectManualReceiveAddress)
 
-  const { executeTrade, sellTxHash, status } = useTradeExecution({ tradeQuote, swapperName })
+  const {
+    executeTrade,
+    sellTxHash,
+    tradeStatus: status,
+  } = useTradeExecution({ tradeQuote, swapperName })
 
   const getSellTxLink = useCallback(
     (sellTxId: string) =>

--- a/src/components/MultiHopTrade/components/TradeConfirm/TradeConfirm.tsx
+++ b/src/components/MultiHopTrade/components/TradeConfirm/TradeConfirm.tsx
@@ -101,7 +101,7 @@ export const TradeConfirm = () => {
       // We will most likely want to move all these "WARNING: do not remove" effects up to the router-level, so they are *actually* fired on trade routes unmount
       dispatch(tradeQuoteSlice.actions.resetConfirmedQuote())
 
-      if (activeStepOrDefault > 1) dispatch(tradeQuoteSlice.actions.resetActiveStep())
+      if (activeStepOrDefault > 0) dispatch(tradeQuoteSlice.actions.resetActiveStep())
     }
   }, [activeStepOrDefault, dispatch])
 

--- a/src/components/MultiHopTrade/components/TradeConfirm/TradeConfirm.tsx
+++ b/src/components/MultiHopTrade/components/TradeConfirm/TradeConfirm.tsx
@@ -93,11 +93,24 @@ export const TradeConfirm = () => {
     // WARNING: do not remove.
     // clear the confirmed quote on dismount to prevent stale data affecting the selectors
     return () => {
+      // TODO(gomes): This is wrong. This isn't only working on unmount as the intent suggests.
+      // This is due to the way those react-router routes work. This is actually fired on mount, voiding the stated guarantees.
+      // We will most likely want to move all these "WARNING: do not remove" effects up to the router-level, so they are *actually* fired on trade routes unmount
       dispatch(tradeQuoteSlice.actions.resetConfirmedQuote())
     }
   }, [dispatch])
 
   const tradeQuote = useAppSelector(selectActiveQuote)
+
+  useEffect(() => {
+    if (!tradeQuote) return
+    // WARNING: do not remove.
+    // clear the confirmed quote on TradeInput unmount to prevent stale data affecting the selectors
+    // This sets it back as confirmedQuote, so tradeQuoteSlice action have access to the up-to-date quote
+    // TODO(gomes): this seems redundant if we're clearing it then setting it again here - can we remove both TradeInput unmount effect, and this one?
+    dispatch(tradeQuoteSlice.actions.setConfirmedQuote(tradeQuote))
+  }, [dispatch, tradeQuote])
+
   const tradeQuoteStep = useAppSelector(selectFirstHop)
   const swapperName = useAppSelector(selectActiveSwapperName)
   const defaultFeeAsset = useAppSelector(selectFirstHopSellFeeAsset)

--- a/src/components/MultiHopTrade/hooks/useTradeExecution/useTradeExecution.ts
+++ b/src/components/MultiHopTrade/hooks/useTradeExecution/useTradeExecution.ts
@@ -1,6 +1,6 @@
 import { supportsETH } from '@shapeshiftoss/hdwallet-core'
 import { TxStatus } from '@shapeshiftoss/unchained-client'
-import { useCallback, useEffect, useState } from 'react'
+import { useCallback, useEffect, useRef, useState } from 'react'
 import { getChainAdapterManager } from 'context/PluginProvider/chainAdapterSingleton'
 import { usePoll } from 'hooks/usePoll/usePoll'
 import { useWallet } from 'hooks/useWallet/useWallet'
@@ -27,6 +27,7 @@ import {
 import {
   selectActiveStepOrDefault,
   selectFirstHopSellFeeAsset,
+  selectIsLastStep,
   selectLastHopBuyAsset,
 } from 'state/slices/tradeQuoteSlice/selectors'
 import { tradeQuoteSlice } from 'state/slices/tradeQuoteSlice/tradeQuoteSlice'
@@ -48,7 +49,7 @@ export const useTradeExecution = ({
   const [sellTxHash, setSellTxHash] = useState<string | undefined>()
   const [buyTxHash, setBuyTxHash] = useState<string | undefined>()
   const [message, setMessage] = useState<string | undefined>()
-  const [status, setStatus] = useState<TxStatus>(TxStatus.Unknown)
+  const [tradeStatus, setTradeStatus] = useState<TxStatus>(TxStatus.Unknown)
   const { poll } = usePoll()
   const wallet = useWallet().state.wallet
 
@@ -70,10 +71,15 @@ export const useTradeExecution = ({
   )
 
   const activeStepOrDefault = useAppSelector(selectActiveStepOrDefault)
+  const isLastStep = useAppSelector(selectIsLastStep)
 
-  debugger
+  // This is ugly, but we need to use refs to get around the fact that the
+  // poll fn effectively creates a closure and will hold stale variables forever
+  // Unless we use refs or another way to get around the closure (e.g hijacking `this`, we are doomed)
+  const sellTxHashRef = useRef<string | undefined>()
+  const isLastStepRef = useRef<boolean>(false)
+
   const executeTrade = useCallback(async () => {
-    debugger
     if (!wallet) throw Error('missing wallet')
     if (!buyAssetUsdRate) throw Error('missing buyAssetUsdRate')
     if (!feeAssetUsdRate) throw Error('missing feeAssetUsdRate')
@@ -131,29 +137,44 @@ export const useTradeExecution = ({
       },
     )
 
-    const sellTxHash = await swapper.executeTrade({
+    sellTxHashRef.current = await swapper.executeTrade({
       txToSign: unsignedTxResult,
       wallet,
       chainId,
     })
 
-    setSellTxHash(sellTxHash)
+    setSellTxHash(sellTxHashRef.current)
 
     await poll({
+      // TODO(gomes): this is wrong. poll fn is a closure and will never use the latest references to the outer variables
       fn: async () => {
+        // This should never happen, but TS mang
+        if (!sellTxHashRef.current) return
         const { status, message, buyTxHash } = await swapper.checkTradeStatus({
           quoteId: tradeQuote.id,
-          txHash: sellTxHash,
+          txHash: sellTxHashRef.current,
           chainId,
         })
 
-        setMessage(message)
-        setBuyTxHash(buyTxHash)
-        setStatus(status)
+        // TODO(gomes): do we want to bring in the concept of watching for a step execution in addition to trade execution?
+        // useTradeExecution seems to revolve around the idea of a holistic trade execution i.e a sell/buy asset for the whole trade,
+        // but we may want to make this granular to the step level?
+        if (isLastStepRef.current || status === TxStatus.Failed) {
+          setMessage(message)
+          setBuyTxHash(buyTxHash)
+          setTradeStatus(status)
+        }
+
+        // Tx confirmed/pending for a mid-trade hop, meaning the trade is still pending holistically
+        else if (status === TxStatus.Confirmed || status === TxStatus.Pending) {
+          setTradeStatus(TxStatus.Pending)
+        }
 
         return status
       },
-      validate: status => status === TxStatus.Confirmed || status === TxStatus.Failed,
+      validate: status => {
+        return status === TxStatus.Confirmed || status === TxStatus.Failed
+      },
       interval: TRADE_POLL_INTERVAL_MILLISECONDS,
       maxAttempts: Infinity,
     })
@@ -172,6 +193,11 @@ export const useTradeExecution = ({
   ])
 
   useEffect(() => {
+    sellTxHashRef.current = sellTxHash
+    isLastStepRef.current = isLastStep
+  }, [sellTxHash, isLastStep])
+
+  useEffect(() => {
     // First step will always be ran from the executeTrade call fired by onSubmit()
     // Subsequent steps will be ran here, following incrementStep() after step completion
     if (activeStepOrDefault !== 0) {
@@ -179,5 +205,5 @@ export const useTradeExecution = ({
     }
   }, [activeStepOrDefault, executeTrade])
 
-  return { executeTrade, sellTxHash, buyTxHash, message, status }
+  return { executeTrade, sellTxHash, buyTxHash, message, tradeStatus }
 }

--- a/src/components/MultiHopTrade/hooks/useTradeExecution/useTradeExecution.ts
+++ b/src/components/MultiHopTrade/hooks/useTradeExecution/useTradeExecution.ts
@@ -146,7 +146,6 @@ export const useTradeExecution = ({
     setSellTxHash(sellTxHashRef.current)
 
     await poll({
-      // TODO(gomes): this is wrong. poll fn is a closure and will never use the latest references to the outer variables
       fn: async () => {
         // This should never happen, but TS mang
         if (!sellTxHashRef.current) return

--- a/src/lib/swapper/swappers/LifiSwapper/getTradeQuote/getTradeQuote.ts
+++ b/src/lib/swapper/swappers/LifiSwapper/getTradeQuote/getTradeQuote.ts
@@ -39,7 +39,6 @@ export async function getTradeQuote(
       sendAddress,
       receiveAddress,
       accountNumber,
-      // allowMultiHop,
       supportsEIP1559,
       wallet,
     } = input

--- a/src/lib/swapper/swappers/LifiSwapper/getTradeQuote/getTradeQuote.ts
+++ b/src/lib/swapper/swappers/LifiSwapper/getTradeQuote/getTradeQuote.ts
@@ -82,7 +82,10 @@ export async function getTradeQuote(
         integrator: LIFI_INTEGRATOR_ID,
         slippage: Number(defaultLifiSwapperSlippage),
         exchanges: { deny: ['dodo'] },
-        allowSwitchChain: allowMultiHop,
+        // TODO(gomes): We don't currently handle trades that require a mid-trade user-initiated Tx on a different chain
+        // i.e we would theoretically handle the Tx itself, but not approvals on said chain if needed
+        // use the `allowSwitchChain` param above when implemented
+        allowSwitchChain: false,
       },
     }
 

--- a/src/lib/swapper/swappers/LifiSwapper/getTradeQuote/getTradeQuote.ts
+++ b/src/lib/swapper/swappers/LifiSwapper/getTradeQuote/getTradeQuote.ts
@@ -39,7 +39,7 @@ export async function getTradeQuote(
       sendAddress,
       receiveAddress,
       accountNumber,
-      allowMultiHop,
+      // allowMultiHop,
       supportsEIP1559,
       wallet,
     } = input

--- a/src/lib/swapper/swappers/LifiSwapper/utils/constants.ts
+++ b/src/lib/swapper/swappers/LifiSwapper/utils/constants.ts
@@ -1,5 +1,4 @@
-// WIP: revert me when opening mutli-hop trade execution PR
-export const MIN_CROSS_CHAIN_AMOUNT_THRESHOLD_USD_HUMAN = '2' // arbitrary amount deemed by lifi devs to meet minimum amount across all brdiges
+export const MIN_CROSS_CHAIN_AMOUNT_THRESHOLD_USD_HUMAN = 20 // arbitrary amount deemed by lifi devs to meet minimum amount across all brdiges
 export const MIN_SAME_CHAIN_AMOUNT_THRESHOLD_USD_HUMAN = '0.01' // Same chain bridges can be of any amount, since fees are paid explicitly as miner fees in one chain
 export const SELECTED_ROUTE_INDEX = 0 // default to first route - this is the highest ranking according to the query we send
 export const LIFI_GAS_FEE_BASE = 16 // lifi gas feed are all in base 16

--- a/src/lib/swapper/swappers/LifiSwapper/utils/constants.ts
+++ b/src/lib/swapper/swappers/LifiSwapper/utils/constants.ts
@@ -1,4 +1,5 @@
-export const MIN_CROSS_CHAIN_AMOUNT_THRESHOLD_USD_HUMAN = 20 // arbitrary amount deemed by lifi devs to meet minimum amount across all brdiges
+// WIP: revert me when opening mutli-hop trade execution PR
+export const MIN_CROSS_CHAIN_AMOUNT_THRESHOLD_USD_HUMAN = '2' // arbitrary amount deemed by lifi devs to meet minimum amount across all brdiges
 export const MIN_SAME_CHAIN_AMOUNT_THRESHOLD_USD_HUMAN = '0.01' // Same chain bridges can be of any amount, since fees are paid explicitly as miner fees in one chain
 export const SELECTED_ROUTE_INDEX = 0 // default to first route - this is the highest ranking according to the query we send
 export const LIFI_GAS_FEE_BASE = 16 // lifi gas feed are all in base 16

--- a/src/state/slices/tradeQuoteSlice/selectors.ts
+++ b/src/state/slices/tradeQuoteSlice/selectors.ts
@@ -74,6 +74,12 @@ export const selectActiveQuote: Selector<ReduxState, TradeQuote2 | undefined> =
     },
   )
 
+export const selectIsLastStep: Selector<ReduxState, boolean> = createSelector(
+  selectActiveStepOrDefault,
+  selectActiveQuote,
+  (activeStep, tradeQuote) => Boolean(tradeQuote && tradeQuote.steps.length - 1 === activeStep),
+)
+
 export const selectActiveQuoteError: Selector<ReduxState, SwapErrorRight | undefined> =
   createDeepEqualOutputSelector(selectActiveSwapperApiResponse, response => response?.error)
 

--- a/src/state/slices/tradeQuoteSlice/selectors.ts
+++ b/src/state/slices/tradeQuoteSlice/selectors.ts
@@ -30,6 +30,11 @@ import { selectCryptoMarketData, selectUserCurrencyToUsdRate } from '../marketDa
 
 const selectTradeQuoteSlice = (state: ReduxState) => state.tradeQuoteSlice
 
+export const selectActiveStepOrDefault: Selector<ReduxState, number> = createSelector(
+  selectTradeQuoteSlice,
+  tradeQuote => tradeQuote.activeStep ?? 0,
+)
+
 const selectConfirmedQuote: Selector<ReduxState, TradeQuote2 | undefined> =
   createDeepEqualOutputSelector(selectTradeQuoteSlice, tradeQuote => tradeQuote.confirmedQuote)
 

--- a/src/state/slices/tradeQuoteSlice/tradeQuoteSlice.ts
+++ b/src/state/slices/tradeQuoteSlice/tradeQuoteSlice.ts
@@ -3,6 +3,7 @@ import { createSlice } from '@reduxjs/toolkit'
 import type { SwapperName, TradeQuote2 } from 'lib/swapper/api'
 
 export type TradeQuoteSliceState = {
+  activeStep: number | undefined // Make sure to actively check for undefined vs. falsy here. 0 is the first step, undefined means no active step yet
   activeSwapperName: SwapperName | undefined // the selected swapper used to find the active quote in the api response
   confirmedQuote: TradeQuote2 | undefined // the quote being executed
 }
@@ -10,6 +11,7 @@ export type TradeQuoteSliceState = {
 const initialState: TradeQuoteSliceState = {
   activeSwapperName: undefined,
   confirmedQuote: undefined,
+  activeStep: undefined,
 }
 
 export const tradeQuoteSlice = createSlice({
@@ -19,6 +21,16 @@ export const tradeQuoteSlice = createSlice({
     clear: () => initialState,
     setSwapperName: (state, action: PayloadAction<SwapperName | undefined>) => {
       state.activeSwapperName = action.payload
+    },
+    incrementStep: state => {
+      const activeQuote = state.confirmedQuote
+      const activeStepOrDefault = state.activeStep ?? 0
+      if (!activeQuote) return // This should never happen as we shouldn't call this without an active quote, but double wrap never hurts for swapper
+      if (activeStepOrDefault === activeQuote.steps.length - 1) return // No-op: we're on the last step - don't increment
+      state.activeStep = activeStepOrDefault + 1
+    },
+    resetActiveStep: state => {
+      state.activeStep = undefined
     },
     resetSwapperName: state => {
       state.activeSwapperName = undefined

--- a/src/test/mocks/store.ts
+++ b/src/test/mocks/store.ts
@@ -176,5 +176,6 @@ export const mockStore: ReduxState = {
   tradeQuoteSlice: {
     activeSwapperName: undefined,
     confirmedQuote: undefined,
+    activeStep: undefined,
   },
 }


### PR DESCRIPTION
## Description

This PR brings execution of multi-hop trades i.e keeping track of the current active step, and incrementing it as one step completes.

Note, this is a first implementation so we can toggle the multi-hop flag. Added a bunch of comments / renames to make it clearer we're currently missing the concept of step granularity, which we won't necessarily need for the exchange client, but will need for the fully fledged multi-hop swapper.

i.e `buyTxHash`, `sellTxHash`, and `status` (renamed to `tradeStatus`) currently refer to the first/last hop Txs, and status refers to the hollistic trade status, *not* the step one, see this bit:

https://github.com/shapeshift/web/blob/361912babf1f8e25a226259863ab81ce24ba9876/src/components/MultiHopTrade/hooks/useTradeExecution/useTradeExecution.ts#L158-L172

## Pull Request Type

- [ ] :bug: Bug fix (Non-breaking Change: Fixes an issue)
- [ ] :hammer_and_wrench: Chore (Non-breaking Change: Doc updates, pkg upgrades, typos, etc..)
- [x] :nail_care: New Feature (Breaking/Non-breaking Change)

## Issue (if applicable)

- Last bits of the closed https://github.com/shapeshift/web/issues/4776

## Risk

<!-----------------------------------------------------------------------------
Outline the scope of your changes and the risk associated with them. You must use your discretion as an engineer to determine the potential impact of your changes.

E.g. an upgrade to `hdwallet` or core state management would be considered higher risk, and might require a full regression test. UI or isolated view changes, or something behind a feature flag may have near zero risk. Small bug fixes might require testing isolated to the specific fix.
------------------------------------------------------------------------------>

High. Both multi-hop routes (e.g Osmosis) as well as single hop routes (ZRX, 1inch, same-chain Li.Fi swaps...) could be borked. This will require a full regression test.

## Testing

<!-----------------------------------------------------------------------------
We treat every PR to be merged with the same scrutiny as if we were merging directly to production.

Your PR will not be merged if you do not complete the sections below for our engineering and operations teams to test.
------------------------------------------------------------------------------>

- See risks.
- Ensure trade status detection is working

Note, Osmosis has been tested on the PR above - multi-hop Osmosis isn't yet implemented on this PR, meaning you won't be able to test it while testing this PR in isolation.

### Engineering

<!-----------------------------------------------------------------------------
Include sufficient information here for an engineer to test your PR. This may include how to test locally, in a built environment, changes to infrastructure etc.
------------------------------------------------------------------------------>

- ☝🏽 

### Operations

<!-----------------------------------------------------------------------------
If your changes have a user-facing impact, describe how a non-technical QA team can functionally test your changes in a preview environment.

If they are not user-facing please describe how to test for any regressions that may occur.
------------------------------------------------------------------------------>

- ☝🏽 

## Screenshots (if applicable)


https://github.com/shapeshift/web/assets/17035424/7eb0a5fe-73be-46ed-afe9-a067f81c3160

<img width="625" alt="image" src="https://github.com/shapeshift/web/assets/17035424/82ca73fb-e910-4be9-8a6e-52aeeea7c4bd">
<img width="619" alt="image" src="https://github.com/shapeshift/web/assets/17035424/9a846b2d-e6bb-4bb8-ba0f-916d5e14302a">
<img width="601" alt="image" src="https://github.com/shapeshift/web/assets/17035424/1dcf3f42-b1f7-48e7-a3fd-453ce6ca866b">
<img width="617" alt="image" src="https://github.com/shapeshift/web/assets/17035424/7db17020-3dc1-4589-88cf-792faddfe361">