### PR TITLE
fix: osmosis error handling

### DIFF
--- a/src/lib/swapper/swappers/OsmosisSwapper/utils/helpers.ts
+++ b/src/lib/swapper/swappers/OsmosisSwapper/utils/helpers.ts
@@ -85,8 +85,8 @@ const findPool = async (
 
   return maybePoolsResponse.andThen<FindPoolOutput>(poolsResponse => {
     const foundPool = find(poolsResponse.data.pools, pool => {
-      const token0Denom = pool.pool_assets[0].token.denom
-      const token1Denom = pool.pool_assets[1].token.denom
+      const token0Denom = pool.pool_assets?.[0].token.denom
+      const token1Denom = pool.pool_assets?.[1].token.denom
       return (
         (token0Denom === sellAssetDenom && token1Denom === buyAssetDenom) ||
         (token0Denom === buyAssetDenom && token1Denom === sellAssetDenom)
@@ -99,7 +99,7 @@ const findPool = async (
       )
 
     const { sellAssetIndex, buyAssetIndex } = (() => {
-      if (foundPool.pool_assets[0].token.denom === sellAssetDenom) {
+      if (foundPool.pool_assets?.[0].token.denom === sellAssetDenom) {
         return { sellAssetIndex: 0, buyAssetIndex: 1 }
       } else {
         return { sellAssetIndex: 1, buyAssetIndex: 0 }
@@ -115,12 +115,12 @@ const getPoolRateInfo = (
   pool: PoolInfo,
   sellAssetIndex: number,
   buyAssetIndex: number,
-): PoolRateInfo => {
-  const constantProduct = bnOrZero(pool.pool_assets[0].token.amount).times(
-    pool.pool_assets[1].token.amount,
-  )
-  const sellAssetInitialPoolSize = bnOrZero(pool.pool_assets[sellAssetIndex].token.amount)
-  const buyAssetInitialPoolSize = bnOrZero(pool.pool_assets[buyAssetIndex].token.amount)
+): Result<PoolRateInfo, SwapErrorRight> => {
+  const poolAssets = pool.pool_assets
+  if (!poolAssets) return Err(makeSwapErrorRight({ message: 'pool assets not found' }))
+  const constantProduct = bnOrZero(poolAssets[0].token.amount).times(poolAssets[1].token.amount)
+  const sellAssetInitialPoolSize = bnOrZero(poolAssets[sellAssetIndex].token.amount)
+  const buyAssetInitialPoolSize = bnOrZero(poolAssets[buyAssetIndex].token.amount)
 
   const initialMarketPrice = sellAssetInitialPoolSize.dividedBy(buyAssetInitialPoolSize)
   const sellAssetFinalPoolSize = sellAssetInitialPoolSize.plus(sellAmount)
@@ -133,12 +133,12 @@ const getPoolRateInfo = (
     .times(bnOrZero(pool.pool_params.swap_fee))
     .toFixed(0)
 
-  return {
+  return Ok({
     rate,
     priceImpact,
     buyAssetTradeFeeCryptoBaseUnit,
     buyAmountCryptoBaseUnit,
-  }
+  })
 }
 
 export const getRateInfo = async (
@@ -149,9 +149,12 @@ export const getRateInfo = async (
 ): Promise<Result<PoolRateInfo, SwapErrorRight>> => {
   const sellAmountOrDefault = sellAmount === '0' ? '1' : sellAmount
   const maybePool = await findPool(sellAsset, buyAsset, osmoUrl)
-  return maybePool.andThen(({ pool, sellAssetIndex, buyAssetIndex }) =>
-    Ok(getPoolRateInfo(sellAmountOrDefault, pool, sellAssetIndex, buyAssetIndex)),
-  )
+  return maybePool.match({
+    ok: ({ pool, sellAssetIndex, buyAssetIndex }) => {
+      return getPoolRateInfo(sellAmountOrDefault, pool, sellAssetIndex, buyAssetIndex)
+    },
+    err: err => Err(err),
+  })
 }
 
 type PerformIbcTransferInput = {


### PR DESCRIPTION
## Description

Handle calling Osmosis's `getTradeQuote` on unsupported assets by using monadic error handling to gracefully catch.
See screenshots below for console errors.

## Pull Request Type

- [x] :bug: Bug fix (Non-breaking Change: Fixes an issue)
- [ ] :hammer_and_wrench: Chore (Non-breaking Change: Doc updates, pkg upgrades, typos, etc..)
- [ ] :nail_care: New Feature (Breaking/Non-breaking Change)

## Issue (if applicable)

N/A

## Risk

Small risk to Osmosis quotes/trades.

## Testing

Osmosis swapper should still get quotes and execute trades as expected.

### Engineering

We were only throwing when the multi-hop flag was on. The console errors should now be gone.

### Operations

Osmosis swaps should work as expected.

## Screenshots (if applicable)

<img width="992" alt="Screenshot 2023-07-18 at 1 16 10 pm" src="https://github.com/shapeshift/web/assets/97164662/3e0c4356-9336-4d09-9605-f568e2c66125">
<img width="995" alt="Screenshot 2023-07-18 at 1 20 31 pm" src="https://github.com/shapeshift/web/assets/97164662/3bc5007b-5750-418c-8532-e7b9439ff5d6">

