### PR TITLE
fix: remove key causing crash on confirm

### DIFF
--- a/src/components/MultiHopTrade/MultiHopTrade.tsx
+++ b/src/components/MultiHopTrade/MultiHopTrade.tsx
@@ -44,7 +44,7 @@ const MultiHopRoutes = () => {
 
   return (
     <AnimatePresence exitBeforeEnter initial={false}>
-      <Switch key={location.key} location={location}>
+      <Switch location={location}>
         <Route key={TradeRoutePaths.Input} path={TradeRoutePaths.Input}>
           <TradeInput />
         </Route>


### PR DESCRIPTION
## Description

<!-- Please describe your changes -->

bug was introduced here https://github.com/shapeshift/web/pull/4921

clicking the confirm button on the trade input screen would route to `?#/trade` causing a page refresh

this fixes it and correctly routes to `#/trade/confirm` (note the lack of `?`)

we're not really sure why this fixes it, but a key shouldn't be necessary on an only child component, as they don't have to compete with their siblings for their parents love.

## Pull Request Type

- [x] :bug: Bug fix (Non-breaking Change: Fixes an issue)
- [ ] :hammer_and_wrench: Chore (Non-breaking Change: Doc updates, pkg upgrades, typos, etc..)
- [ ] :nail_care: New Feature (Breaking/Non-breaking Change)

## Issue (if applicable)

<!-----------------------------------------------------------------------------
If applicable, please link to the github issue and put `closes #XXXX` in your comment to auto-close the issue that your PR fixes.
------------------------------------------------------------------------------>

closes #

## Risk

isolated to multi hop swapper

<!-----------------------------------------------------------------------------
Outline the scope of your changes and the risk associated with them. You must use your discretion as an engineer to determine the potential impact of your changes.

E.g. an upgrade to `hdwallet` or core state management would be considered higher risk, and might require a full regression test. UI or isolated view changes, or something behind a feature flag may have near zero risk. Small bug fixes might require testing isolated to the specific fix.
------------------------------------------------------------------------------>

## Testing

1. fresh load of the page, go to the trade route
2. setup a trade and click confirm
3. note the page does not refresh and the url takes you to `/trade/confirm`

<!-----------------------------------------------------------------------------
We treat every PR to be merged with the same scrutiny as if we were merging directly to production.

Your PR will not be merged if you do not complete the sections below for our engineering and operations teams to test.
------------------------------------------------------------------------------>

### Engineering

👆

<!-----------------------------------------------------------------------------
Include sufficient information here for an engineer to test your PR. This may include how to test locally, in a built environment, changes to infrastructure etc.
------------------------------------------------------------------------------>

### Operations

👆

<!-----------------------------------------------------------------------------
If your changes have a user-facing impact, describe how a non-technical QA team can functionally test your changes in a preview environment.

If they are not user-facing please describe how to test for any regressions that may occur.
------------------------------------------------------------------------------>

## Screenshots (if applicable)

n/a
