### PR TITLE
fix: chrome router hijack rug

### DIFF
--- a/src/components/MultiHopTrade/components/TradeInput/TradeInput.tsx
+++ b/src/components/MultiHopTrade/components/TradeInput/TradeInput.tsx
@@ -11,6 +11,7 @@ import {
 import { KeplrHDWallet } from '@shapeshiftoss/hdwallet-keplr/dist/keplr'
 import { getDefaultSlippagePercentageForSwapper } from 'constants/constants'
 import { useCallback, useEffect, useMemo, useState } from 'react'
+import { useFormContext } from 'react-hook-form'
 import { useTranslate } from 'react-polyglot'
 import { useHistory } from 'react-router'
 import { MessageOverlay } from 'components/MessageOverlay/MessageOverlay'
@@ -72,6 +73,7 @@ export const TradeInput = () => {
   const {
     state: { wallet },
   } = useWallet()
+  const { handleSubmit } = useFormContext()
   const dispatch = useAppDispatch()
   const mixpanel = getMixPanel()
   const history = useHistory()
@@ -195,7 +197,7 @@ export const TradeInput = () => {
   return (
     <MessageOverlay show={isKeplr} title={overlayTitle}>
       <SlideTransition>
-        <Stack spacing={6} as='form' onSubmit={onSubmit}>
+        <Stack spacing={6} as='form' onSubmit={handleSubmit(onSubmit)}>
           <Stack spacing={2}>
             <Flex alignItems='center' flexDir={{ base: 'column', md: 'row' }} width='full'>
               <TradeAssetSelect


### PR DESCRIPTION
## Description

_Actually_ fixes the router rug on clicking trade preview.

tl;dr, chrome thinks the form submission is a GET request if the `onSubmit` isn't wrapped in it's special helper.

## Pull Request Type

- [x] :bug: Bug fix (Non-breaking Change: Fixes an issue)
- [ ] :hammer_and_wrench: Chore (Non-breaking Change: Doc updates, pkg upgrades, typos, etc..)
- [ ] :nail_care: New Feature (Breaking/Non-breaking Change)

## Issue (if applicable)

N/A, but fixes what https://github.com/shapeshift/web/pull/4947 tried to fix.

## Risk

Small.

## Testing

With the multi-hop flag on, select a non-fee EVM asset, get a quote, and click "Preview Trade". It should no lnoger change routes and re-render.

### Engineering

☝️

### Operations

☝️

## Screenshots (if applicable)

N/A
