### PR TITLE
fix: accounts breadcrumbs with chain name

### DIFF
--- a/src/components/AssetHeader/AccountLabel.tsx
+++ b/src/components/AssetHeader/AccountLabel.tsx
@@ -1,19 +1,16 @@
 import { HStack, Tag, TagLabel } from '@chakra-ui/react'
 import type { AccountId } from '@shapeshiftoss/caip'
 import { RawText } from 'components/Text'
-import { accountIdToFeeAssetId, accountIdToLabel } from 'state/slices/portfolioSlice/utils'
-import { selectAssetById } from 'state/slices/selectors'
-import { useAppSelector } from 'state/store'
+import { accountIdToChainDisplayName, accountIdToLabel } from 'state/slices/portfolioSlice/utils'
 
 type AccountLabelProps = { accountId: AccountId }
 export const AccountLabel: React.FC<AccountLabelProps> = ({ accountId }) => {
   const label = accountId ? accountIdToLabel(accountId) : null
-  const feeAssetId = accountIdToFeeAssetId(accountId)
-  const feeAsset = useAppSelector(state => selectAssetById(state, feeAssetId ?? ''))
-  if (!feeAsset) return null
+  const chainName = accountIdToChainDisplayName(accountId)
+  if (!chainName) return null
   return (
     <HStack fontSize='small' spacing={1}>
-      <RawText>{feeAsset.name}</RawText>
+      <RawText>{chainName}</RawText>
       <Tag
         whiteSpace='nowrap'
         colorScheme='blue'

--- a/src/components/Breadcrumbs/Breadcrumbs.tsx
+++ b/src/components/Breadcrumbs/Breadcrumbs.tsx
@@ -62,11 +62,11 @@ const GetAssetName = (props: {
 
 const routes: BreadcrumbsRoute[] = [
   {
-    path: '/accounts/:accountId',
+    path: '/dashboard/accounts/:accountId',
     breadcrumb: GetAccountName,
     routes: [
-      { path: '/accounts/:accountId/transactions' },
-      { path: '/accounts/:accountId/:assetId', breadcrumb: GetAssetName },
+      { path: '/dashboard/accounts/:accountId/transactions' },
+      { path: '/dashboard/accounts/:accountId/:assetId', breadcrumb: GetAssetName },
     ],
   },
   {

--- a/src/state/slices/portfolioSlice/utils.ts
+++ b/src/state/slices/portfolioSlice/utils.ts
@@ -110,6 +110,9 @@ export const isUtxoChainId = (chainId: ChainId): boolean =>
 export const accountIdToFeeAssetId = (accountId: AccountId): AssetId | undefined =>
   getChainAdapterManager().get(accountIdToChainId(accountId))?.getFeeAssetId()
 
+export const accountIdToChainDisplayName = (accountId: AccountId): AssetId | undefined =>
+  getChainAdapterManager().get(accountIdToChainId(accountId))?.getDisplayName()
+
 export const chainIdToFeeAssetId = (chainId: ChainId): AssetId | undefined =>
   getChainAdapterManager().get(chainId)?.getFeeAssetId()
 


### PR DESCRIPTION
## Description

Fixes the Breadcrumbs string for Accounts Transaction History pages so they display the chain name. Previously they displayed the fee asset name (which can be different from the chain name) and also it had been broken (see before screenshot below) since #4339 (when the path to `/accounts/` changed to `/dashboard/accounts/`).

<!-- Please describe your changes -->

## Pull Request Type

- [x] :bug: Bug fix (Non-breaking Change: Fixes an issue)
- [ ] :hammer_and_wrench: Chore (Non-breaking Change: Doc updates, pkg upgrades, typos, etc..)
- [ ] :nail_care: New Feature (Breaking/Non-breaking Change)

## Issue (if applicable)

<!-----------------------------------------------------------------------------
If applicable, please link to the github issue and put `closes #XXXX` in your comment to auto-close the issue that your PR fixes.
------------------------------------------------------------------------------>

N/A

## Risk
Low.

<!-----------------------------------------------------------------------------
Outline the scope of your changes and the risk associated with them. You must use your discretion as an engineer to determine the potential impact of your changes.

E.g. an upgrade to `hdwallet` or core state management would be considered higher risk, and might require a full regression test. UI or isolated view changes, or something behind a feature flag may have near zero risk. Small bug fixes might require testing isolated to the specific fix.
------------------------------------------------------------------------------>

## Testing
Check the full transaction history for specific accounts on various chains. These pages are accessible only for assets which have a long enough history of transactions, you can access them by going in the Dashboard, then Wallet, then choose a chain, then expan the accounts, then click on the "..." icon and "View account" (or simply on the account for UTXO chains), then on the Account page scroll down to the Transaction History. If there are enough transaction a "See all" link will be available. You can manually access it if there are not enough transaction by going to the same Account page and add `/transactions/` at the end of the URL.

The breadcrumbs string should display the chain's name correctly.


<!-----------------------------------------------------------------------------
We treat every PR to be merged with the same scrutiny as if we were merging directly to production.

Your PR will not be merged if you do not complete the sections below for our engineering and operations teams to test.
------------------------------------------------------------------------------>

### Engineering
☝️ 
<!-----------------------------------------------------------------------------
Include sufficient information here for an engineer to test your PR. This may include how to test locally, in a built environment, changes to infrastructure etc.
------------------------------------------------------------------------------>

### Operations
☝️ 
<!-----------------------------------------------------------------------------
If your changes have a user-facing impact, describe how a non-technical QA team can functionally test your changes in a preview environment.

If they are not user-facing please describe how to test for any regressions that may occur.
------------------------------------------------------------------------------>

## Screenshots (if applicable)
Before:
![image](https://github.com/shapeshift/web/assets/88804546/91001c88-c54a-4c4c-93db-a1b475c7ea20)

After:
![image](https://github.com/shapeshift/web/assets/88804546/a8ad0385-d2fd-4e69-8ddb-7edc6203b07e)
![image](https://github.com/shapeshift/web/assets/88804546/3d89a3be-6ee0-4310-bdfe-38189923045f)
![image](https://github.com/shapeshift/web/assets/88804546/0aefcea7-c33d-4fce-a507-57dfde48bbed)
