### PR TITLE
chore: release v1.380.0

### DIFF
--- a/src/components/AccountDetails.tsx
+++ b/src/components/AccountDetails.tsx
@@ -2,10 +2,13 @@ import { Flex, Stack } from '@chakra-ui/react'
 import type { AccountId, AssetId } from '@shapeshiftoss/caip'
 import { useTranslate } from 'react-polyglot'
 import type { Route } from 'Routes/helpers'
+import { MultiHopTrade } from 'components/MultiHopTrade/MultiHopTrade'
 import { AssetTransactionHistory } from 'components/TransactionHistory/AssetTransactionHistory'
 import { AccountBalance } from 'pages/Accounts/AccountToken/AccountBalance'
 import { TradeCard } from 'pages/Dashboard/TradeCard'
 import { isUtxoAccountId } from 'state/slices/portfolioSlice/utils'
+import { selectFeatureFlags } from 'state/slices/preferencesSlice/selectors'
+import { useAppSelector } from 'state/store'
 
 import { AccountAssets } from './AccountAssets/AccountAssets'
 import { AssetAccounts } from './AssetAccounts/AssetAccounts'
@@ -20,6 +23,7 @@ type AccountDetailsProps = {
 }
 
 export const AccountDetails = ({ assetId, accountId }: AccountDetailsProps) => {
+  const { MultiHopTrades } = useAppSelector(selectFeatureFlags)
   const translate = useTranslate()
   if (!accountId || !assetId) return null
   return (
@@ -51,7 +55,11 @@ export const AccountDetails = ({ assetId, accountId }: AccountDetailsProps) => {
         maxWidth={{ base: 'full', xl: 'md' }}
         gap={4}
       >
-        <TradeCard display={{ base: 'none', md: 'block' }} />
+        {MultiHopTrades ? (
+          <MultiHopTrade display={{ base: 'none', md: 'block' }} />
+        ) : (
+          <TradeCard display={{ base: 'none', md: 'block' }} />
+        )}
       </Flex>
     </Stack>
   )

--- a/src/components/AssetAccountDetails.tsx
+++ b/src/components/AssetAccountDetails.tsx
@@ -2,9 +2,10 @@ import { Flex, Stack } from '@chakra-ui/react'
 import type { AccountId, AssetId } from '@shapeshiftoss/caip'
 import { useMemo } from 'react'
 import type { Route } from 'Routes/helpers'
+import { MultiHopTrade } from 'components/MultiHopTrade/MultiHopTrade'
 import { AssetTransactionHistory } from 'components/TransactionHistory/AssetTransactionHistory'
 import { TradeCard } from 'pages/Dashboard/TradeCard'
-import { selectMarketDataById } from 'state/slices/selectors'
+import { selectFeatureFlags, selectMarketDataById } from 'state/slices/selectors'
 import { useAppSelector } from 'state/store'
 
 import { AccountAssets } from './AccountAssets/AccountAssets'
@@ -25,6 +26,7 @@ type AssetDetailsProps = {
 }
 
 export const AssetAccountDetails = ({ assetId, accountId }: AssetDetailsProps) => {
+  const { MultiHopTrades } = useAppSelector(selectFeatureFlags)
   const marketData = useAppSelector(state => selectMarketDataById(state, assetId))
   const assetIds = useMemo(() => [assetId], [assetId])
 
@@ -52,7 +54,11 @@ export const AssetAccountDetails = ({ assetId, accountId }: AssetDetailsProps) =
           maxWidth={{ base: 'full', xl: 'sm' }}
           gap={4}
         >
-          <TradeCard display={{ base: 'none', md: 'block' }} defaultBuyAssetId={assetId} />
+          {MultiHopTrades ? (
+            <MultiHopTrade display={{ base: 'none', md: 'block' }} defaultBuyAssetId={assetId} />
+          ) : (
+            <TradeCard display={{ base: 'none', md: 'block' }} defaultBuyAssetId={assetId} />
+          )}
           {marketData && <AssetMarketData assetId={assetId} />}
           <AssetDescription assetId={assetId} />
         </Flex>

--- a/src/components/AssetHeader/AccountLabel.tsx
+++ b/src/components/AssetHeader/AccountLabel.tsx
@@ -1,19 +1,16 @@
 import { HStack, Tag, TagLabel } from '@chakra-ui/react'
 import type { AccountId } from '@shapeshiftoss/caip'
 import { RawText } from 'components/Text'
-import { accountIdToFeeAssetId, accountIdToLabel } from 'state/slices/portfolioSlice/utils'
-import { selectAssetById } from 'state/slices/selectors'
-import { useAppSelector } from 'state/store'
+import { accountIdToChainDisplayName, accountIdToLabel } from 'state/slices/portfolioSlice/utils'
 
 type AccountLabelProps = { accountId: AccountId }
 export const AccountLabel: React.FC<AccountLabelProps> = ({ accountId }) => {
   const label = accountId ? accountIdToLabel(accountId) : null
-  const feeAssetId = accountIdToFeeAssetId(accountId)
-  const feeAsset = useAppSelector(state => selectAssetById(state, feeAssetId ?? ''))
-  if (!feeAsset) return null
+  const chainName = accountIdToChainDisplayName(accountId)
+  if (!chainName) return null
   return (
     <HStack fontSize='small' spacing={1}>
-      <RawText>{feeAsset.name}</RawText>
+      <RawText>{chainName}</RawText>
       <Tag
         whiteSpace='nowrap'
         colorScheme='blue'

--- a/src/components/Breadcrumbs/Breadcrumbs.tsx
+++ b/src/components/Breadcrumbs/Breadcrumbs.tsx
@@ -62,11 +62,11 @@ const GetAssetName = (props: {
 
 const routes: BreadcrumbsRoute[] = [
   {
-    path: '/accounts/:accountId',
+    path: '/dashboard/accounts/:accountId',
     breadcrumb: GetAccountName,
     routes: [
-      { path: '/accounts/:accountId/transactions' },
-      { path: '/accounts/:accountId/:assetId', breadcrumb: GetAssetName },
+      { path: '/dashboard/accounts/:accountId/transactions' },
+      { path: '/dashboard/accounts/:accountId/:assetId', breadcrumb: GetAssetName },
     ],
   },
   {

--- a/src/components/MultiHopTrade/MultiHopTrade.tsx
+++ b/src/components/MultiHopTrade/MultiHopTrade.tsx
@@ -1,10 +1,14 @@
+import type { AssetId } from '@shapeshiftoss/caip'
+import { ethAssetId, foxAssetId } from '@shapeshiftoss/caip'
 import { AnimatePresence } from 'framer-motion'
 import { useEffect } from 'react'
 import { FormProvider, useForm } from 'react-hook-form'
 import { MemoryRouter, Route, Switch, useLocation } from 'react-router-dom'
+import type { CardProps } from 'components/Card/Card'
 import { Card } from 'components/Card/Card'
+import { selectAssetById } from 'state/slices/assetsSlice/selectors'
 import { swappers } from 'state/slices/swappersSlice/swappersSlice'
-import { useAppDispatch } from 'state/store'
+import { useAppDispatch, useAppSelector } from 'state/store'
 
 import { Approval } from './components/Approval/Approval'
 import { TradeConfirm } from './components/TradeConfirm/TradeConfirm'
@@ -13,11 +17,30 @@ import { TradeRoutePaths } from './types'
 
 const MultiHopEntries = [TradeRoutePaths.Input, TradeRoutePaths.Approval, TradeRoutePaths.Confirm]
 
-export const MultiHopTrade = () => {
+export type TradeCardProps = {
+  defaultBuyAssetId?: AssetId
+  defaultSellAssetId?: AssetId
+} & CardProps
+
+export const MultiHopTrade = ({
+  defaultBuyAssetId = foxAssetId,
+  defaultSellAssetId = ethAssetId,
+  ...cardProps
+}: TradeCardProps) => {
+  const dispatch = useAppDispatch()
   const methods = useForm({ mode: 'onChange' })
 
+  const defaultBuyAsset = useAppSelector(state => selectAssetById(state, defaultBuyAssetId))
+  const defaultSellAsset = useAppSelector(state => selectAssetById(state, defaultSellAssetId))
+
+  useEffect(() => {
+    dispatch(swappers.actions.clear())
+    if (defaultSellAsset) dispatch(swappers.actions.setSellAsset(defaultSellAsset))
+    if (defaultBuyAsset) dispatch(swappers.actions.setBuyAsset(defaultBuyAsset))
+  }, [defaultBuyAsset, defaultSellAsset, dispatch])
+
   return (
-    <Card>
+    <Card {...cardProps}>
       <Card.Body py={6}>
         <FormProvider {...methods}>
           <MemoryRouter initialEntries={MultiHopEntries} initialIndex={0}>

--- a/src/components/MultiHopTrade/MultiHopTrade.tsx
+++ b/src/components/MultiHopTrade/MultiHopTrade.tsx
@@ -44,7 +44,7 @@ const MultiHopRoutes = () => {
 
   return (
     <AnimatePresence exitBeforeEnter initial={false}>
-      <Switch key={location.key} location={location}>
+      <Switch location={location}>
         <Route key={TradeRoutePaths.Input} path={TradeRoutePaths.Input}>
           <TradeInput />
         </Route>

--- a/src/components/MultiHopTrade/components/TradeInput/TradeInput.tsx
+++ b/src/components/MultiHopTrade/components/TradeInput/TradeInput.tsx
@@ -11,6 +11,7 @@ import {
 import { KeplrHDWallet } from '@shapeshiftoss/hdwallet-keplr/dist/keplr'
 import { getDefaultSlippagePercentageForSwapper } from 'constants/constants'
 import { useCallback, useEffect, useMemo, useState } from 'react'
+import { useFormContext } from 'react-hook-form'
 import { useTranslate } from 'react-polyglot'
 import { useHistory } from 'react-router'
 import { MessageOverlay } from 'components/MessageOverlay/MessageOverlay'
@@ -72,6 +73,7 @@ export const TradeInput = () => {
   const {
     state: { wallet },
   } = useWallet()
+  const { handleSubmit } = useFormContext()
   const dispatch = useAppDispatch()
   const mixpanel = getMixPanel()
   const history = useHistory()
@@ -195,7 +197,7 @@ export const TradeInput = () => {
   return (
     <MessageOverlay show={isKeplr} title={overlayTitle}>
       <SlideTransition>
-        <Stack spacing={6} as='form' onSubmit={onSubmit}>
+        <Stack spacing={6} as='form' onSubmit={handleSubmit(onSubmit)}>
           <Stack spacing={2}>
             <Flex alignItems='center' flexDir={{ base: 'column', md: 'row' }} width='full'>
               <TradeAssetSelect

--- a/src/components/MultiHopTrade/components/TradeInput/components/TradeQuotes/TradeQuote.tsx
+++ b/src/components/MultiHopTrade/components/TradeInput/components/TradeQuotes/TradeQuote.tsx
@@ -113,7 +113,8 @@ export const TradeQuoteLoaded: React.FC<TradeQuoteLoadedProps> = ({
   if (!feeAsset)
     throw new Error(`TradeQuoteLoaded: no fee asset found for chainId ${sellAsset?.chainId}!`)
 
-  const quoteDifferenceDecimalPercentage = quoteData.inputOutputRatio / bestInputOutputRatio - 1
+  const quoteDifferenceDecimalPercentage =
+    (quoteData.inputOutputRatio / bestInputOutputRatio - 1) * -1
 
   const isAmountEntered = bnOrZero(sellAmountCryptoPrecision).gt(0)
   const hasNegativeRatio =

--- a/src/lib/address/address.ts
+++ b/src/lib/address/address.ts
@@ -38,6 +38,10 @@ export const parseMaybeUrlWithChainId = ({
       try {
         const parsedUrl = parseEthUrl(urlOrAddress)
 
+        if (parsedUrl.parameters?.address) {
+          throw new Error('QR codes with address parameter are not supported')
+        }
+
         return {
           assetId,
           maybeAddress: parsedUrl.target_address ?? urlOrAddress,

--- a/src/lib/swapper/swappers/OsmosisSwapper/utils/helpers.ts
+++ b/src/lib/swapper/swappers/OsmosisSwapper/utils/helpers.ts
@@ -85,8 +85,8 @@ const findPool = async (
 
   return maybePoolsResponse.andThen<FindPoolOutput>(poolsResponse => {
     const foundPool = find(poolsResponse.data.pools, pool => {
-      const token0Denom = pool.pool_assets[0].token.denom
-      const token1Denom = pool.pool_assets[1].token.denom
+      const token0Denom = pool.pool_assets?.[0].token.denom
+      const token1Denom = pool.pool_assets?.[1].token.denom
       return (
         (token0Denom === sellAssetDenom && token1Denom === buyAssetDenom) ||
         (token0Denom === buyAssetDenom && token1Denom === sellAssetDenom)
@@ -99,7 +99,7 @@ const findPool = async (
       )
 
     const { sellAssetIndex, buyAssetIndex } = (() => {
-      if (foundPool.pool_assets[0].token.denom === sellAssetDenom) {
+      if (foundPool.pool_assets?.[0].token.denom === sellAssetDenom) {
         return { sellAssetIndex: 0, buyAssetIndex: 1 }
       } else {
         return { sellAssetIndex: 1, buyAssetIndex: 0 }
@@ -115,12 +115,12 @@ const getPoolRateInfo = (
   pool: PoolInfo,
   sellAssetIndex: number,
   buyAssetIndex: number,
-): PoolRateInfo => {
-  const constantProduct = bnOrZero(pool.pool_assets[0].token.amount).times(
-    pool.pool_assets[1].token.amount,
-  )
-  const sellAssetInitialPoolSize = bnOrZero(pool.pool_assets[sellAssetIndex].token.amount)
-  const buyAssetInitialPoolSize = bnOrZero(pool.pool_assets[buyAssetIndex].token.amount)
+): Result<PoolRateInfo, SwapErrorRight> => {
+  const poolAssets = pool.pool_assets
+  if (!poolAssets) return Err(makeSwapErrorRight({ message: 'pool assets not found' }))
+  const constantProduct = bnOrZero(poolAssets[0].token.amount).times(poolAssets[1].token.amount)
+  const sellAssetInitialPoolSize = bnOrZero(poolAssets[sellAssetIndex].token.amount)
+  const buyAssetInitialPoolSize = bnOrZero(poolAssets[buyAssetIndex].token.amount)
 
   const initialMarketPrice = sellAssetInitialPoolSize.dividedBy(buyAssetInitialPoolSize)
   const sellAssetFinalPoolSize = sellAssetInitialPoolSize.plus(sellAmount)
@@ -133,12 +133,12 @@ const getPoolRateInfo = (
     .times(bnOrZero(pool.pool_params.swap_fee))
     .toFixed(0)
 
-  return {
+  return Ok({
     rate,
     priceImpact,
     buyAssetTradeFeeCryptoBaseUnit,
     buyAmountCryptoBaseUnit,
-  }
+  })
 }
 
 export const getRateInfo = async (
@@ -149,9 +149,12 @@ export const getRateInfo = async (
 ): Promise<Result<PoolRateInfo, SwapErrorRight>> => {
   const sellAmountOrDefault = sellAmount === '0' ? '1' : sellAmount
   const maybePool = await findPool(sellAsset, buyAsset, osmoUrl)
-  return maybePool.andThen(({ pool, sellAssetIndex, buyAssetIndex }) =>
-    Ok(getPoolRateInfo(sellAmountOrDefault, pool, sellAssetIndex, buyAssetIndex)),
-  )
+  return maybePool.match({
+    ok: ({ pool, sellAssetIndex, buyAssetIndex }) => {
+      return getPoolRateInfo(sellAmountOrDefault, pool, sellAssetIndex, buyAssetIndex)
+    },
+    err: err => Err(err),
+  })
 }
 
 type PerformIbcTransferInput = {

--- a/src/lib/swapper/swappers/ThorchainSwapper/utils/getTradeRate/getTradeRate.ts
+++ b/src/lib/swapper/swappers/ThorchainSwapper/utils/getTradeRate/getTradeRate.ts
@@ -140,15 +140,27 @@ export const getTradeRate = async ({
 
 // getTradeRate gets an *actual* trade rate from quote
 // In case it fails, we handle the error on the consumer and call this guy instead, which returns a price ratio from THOR pools instead
-// TODO(gomes): should this return a Result also?
 export const getTradeRateBelowMinimum = ({
   sellAssetId,
   buyAssetId,
 }: {
   sellAssetId: AssetId
   buyAssetId: AssetId
-}) =>
-  getPriceRatio({
-    sellAssetId,
-    buyAssetId,
-  })
+}): Promise<Result<string, SwapErrorRight>> => {
+  try {
+    return getPriceRatio({
+      sellAssetId,
+      buyAssetId,
+    })
+  } catch {
+    return Promise.resolve(
+      Err(
+        makeSwapErrorRight({
+          message: `[getTradeRateBelowMinimum]: Could not get a trade rate from Thorchain.`,
+          code: SwapErrorType.TRADE_QUOTE_FAILED,
+          details: { sellAssetId, buyAssetId },
+        }),
+      ),
+    )
+  }
+}

--- a/src/pages/Accounts/AccountToken/AccountToken.tsx
+++ b/src/pages/Accounts/AccountToken/AccountToken.tsx
@@ -5,12 +5,15 @@ import { useSelector } from 'react-redux'
 import { Redirect, useParams } from 'react-router-dom'
 import { AssetAccounts } from 'components/AssetAccounts/AssetAccounts'
 import { Equity } from 'components/Equity/Equity'
+import { MultiHopTrade } from 'components/MultiHopTrade/MultiHopTrade'
 import { EarnOpportunities } from 'components/StakingVaults/EarnOpportunities'
 import { AssetTransactionHistory } from 'components/TransactionHistory/AssetTransactionHistory'
 import { TradeCard } from 'pages/Dashboard/TradeCard'
-import { selectWalletAccountIds } from 'state/slices/selectors'
+import { selectFeatureFlags, selectWalletAccountIds } from 'state/slices/selectors'
+import { useAppSelector } from 'state/store'
 
 import { AccountBalance } from './AccountBalance'
+
 export type MatchParams = {
   accountId: AccountId
   assetId: AssetId
@@ -18,6 +21,7 @@ export type MatchParams = {
 
 export const AccountToken = () => {
   const { accountId, assetId } = useParams<MatchParams>()
+  const { MultiHopTrades } = useAppSelector(selectFeatureFlags)
 
   /**
    * if the user switches the wallet while visiting this page,
@@ -53,7 +57,11 @@ export const AccountToken = () => {
         maxWidth={{ base: 'full', xl: 'sm' }}
         gap={4}
       >
-        <TradeCard display={{ base: 'none', md: 'block' }} />
+        {MultiHopTrades ? (
+          <MultiHopTrade display={{ base: 'none', md: 'block' }} />
+        ) : (
+          <TradeCard display={{ base: 'none', md: 'block' }} />
+        )}
       </Flex>
     </Stack>
   )

--- a/src/pages/Dashboard/DashboardSidebar.tsx
+++ b/src/pages/Dashboard/DashboardSidebar.tsx
@@ -3,10 +3,13 @@ import { btcAssetId, dogeAssetId, foxAssetId } from '@shapeshiftoss/caip'
 import OnRamperLogo from 'assets/on-ramper.png'
 import SaversVaultTop from 'assets/savers-vault-top.png'
 import { AssetIcon } from 'components/AssetIcon'
+import { MultiHopTrade } from 'components/MultiHopTrade/MultiHopTrade'
 import { PromoCard } from 'components/Promo/PromoCard'
 import type { PromoItem } from 'components/Promo/types'
 import { EligibleCarousel } from 'pages/Defi/components/EligibleCarousel'
 import { MissionSidebar } from 'pages/Missions/Missions'
+import { selectFeatureFlags } from 'state/slices/preferencesSlice/selectors'
+import { useAppSelector } from 'state/store'
 
 import { RecentTransactions } from './RecentTransactions'
 import { TradeCard } from './TradeCard'
@@ -66,10 +69,15 @@ const promoData: PromoItem[] = [
 ]
 
 export const DashboardSidebar = () => {
+  const { MultiHopTrades } = useAppSelector(selectFeatureFlags)
   return (
     <Flex width='full' flexDir='column' gap={6}>
       <PromoCard data={promoData} />
-      <TradeCard display={{ base: 'none', xl: 'block' }} />
+      {MultiHopTrades ? (
+        <MultiHopTrade display={{ base: 'none', xl: 'block' }} />
+      ) : (
+        <TradeCard display={{ base: 'none', xl: 'block' }} />
+      )}
       <MissionSidebar />
       <EligibleCarousel />
       <RecentTransactions limit={8} viewMoreLink />

--- a/src/plugins/foxPage/components/AssetActions.tsx
+++ b/src/plugins/foxPage/components/AssetActions.tsx
@@ -23,6 +23,7 @@ import { useTranslate } from 'react-polyglot'
 import { useHistory, useLocation } from 'react-router'
 import { AssetIcon } from 'components/AssetIcon'
 import { Card } from 'components/Card/Card'
+import { MultiHopTrade } from 'components/MultiHopTrade/MultiHopTrade'
 import { Text } from 'components/Text/Text'
 import { WalletActions } from 'context/WalletProvider/actions'
 import { useModal } from 'hooks/useModal/useModal'
@@ -33,7 +34,11 @@ import { MixPanelEvents } from 'lib/mixpanel/types'
 import { TradeCard } from 'pages/Dashboard/TradeCard'
 import { DefiProvider } from 'state/slices/opportunitiesSlice/types'
 import { trimWithEndEllipsis } from 'state/slices/portfolioSlice/utils'
-import { selectAccountIdsByAssetId, selectAssetById } from 'state/slices/selectors'
+import {
+  selectAccountIdsByAssetId,
+  selectAssetById,
+  selectFeatureFlags,
+} from 'state/slices/selectors'
 import { useAppSelector } from 'state/store'
 
 import { TrimmedDescriptionLength } from '../FoxCommon'
@@ -46,6 +51,7 @@ const BuyFoxCoinbaseUrl = 'https://www.coinbase.com/price/fox-token'
 const TradeFoxyElasticSwapUrl = `https://elasticswap.org/#/swap`
 
 export const AssetActions: React.FC<FoxTabProps> = ({ assetId }) => {
+  const { MultiHopTrades } = useAppSelector(selectFeatureFlags)
   const translate = useTranslate()
   const location = useLocation()
   const history = useHistory()
@@ -170,7 +176,11 @@ export const AssetActions: React.FC<FoxTabProps> = ({ assetId }) => {
               </Stack>
             </TabPanel>
             <TabPanel textAlign='center' p={0}>
-              {isFoxAsset && <TradeCard defaultBuyAssetId={assetId} />}
+              {isFoxAsset && MultiHopTrades ? (
+                <MultiHopTrade defaultBuyAssetId={assetId} />
+              ) : (
+                <TradeCard defaultBuyAssetId={assetId} />
+              )}
               {!isFoxAsset && (
                 <Stack width='full' p={6}>
                   <SkeletonText isLoaded={Boolean(description?.length)} noOfLines={3}>

--- a/src/state/slices/portfolioSlice/utils.ts
+++ b/src/state/slices/portfolioSlice/utils.ts
@@ -110,6 +110,9 @@ export const isUtxoChainId = (chainId: ChainId): boolean =>
 export const accountIdToFeeAssetId = (accountId: AccountId): AssetId | undefined =>
   getChainAdapterManager().get(accountIdToChainId(accountId))?.getFeeAssetId()
 
+export const accountIdToChainDisplayName = (accountId: AccountId): AssetId | undefined =>
+  getChainAdapterManager().get(accountIdToChainId(accountId))?.getDisplayName()
+
 export const chainIdToFeeAssetId = (chainId: ChainId): AssetId | undefined =>
   getChainAdapterManager().get(chainId)?.getFeeAssetId()
 

--- a/yarn.lock
+++ b/yarn.lock
@@ -28758,9 +28758,9 @@ pvutils@latest:
   linkType: hard
 
 "word-wrap@npm:^1.2.3, word-wrap@npm:~1.2.3":
-  version: 1.2.3
-  resolution: "word-wrap@npm:1.2.3"
-  checksum: 30b48f91fcf12106ed3186ae4fa86a6a1842416df425be7b60485de14bec665a54a68e4b5156647dec3a70f25e84d270ca8bc8cd23182ed095f5c7206a938c1f
+  version: 1.2.4
+  resolution: "word-wrap@npm:1.2.4"
+  checksum: 8f1f2e0a397c0e074ca225ba9f67baa23f99293bc064e31355d426ae91b8b3f6b5f6c1fc9ae5e9141178bb362d563f55e62fd8d5c31f2a77e3ade56cb3e35bd1
   languageName: node
   linkType: hard
 


### PR DESCRIPTION
fix: don't parse eth URLs with address parameter (#4953)
fix: accounts breadcrumbs with chain name (#4951)
chore: add exchange swapper to all routes (#4926)
chore(deps): bump word-wrap from 1.2.3 to 1.2.4 (#4949)
fix: invert "more expensive" label (#4948)
fix: chrome router hijack rug (#4950)
fix: thorswap error handling (#4945)
fix: osmosis error handling (#4944)
fix: remove key causing crash on confirm (#4947)