### PR TITLE
fix: asset transaction history

### DIFF
--- a/src/Routes/RoutesCommon.tsx
+++ b/src/Routes/RoutesCommon.tsx
@@ -43,6 +43,18 @@ export const routes: NestedRoute[] = [
     ],
   },
   {
+    path: '/assets/:chainId/:assetSubId/transactions',
+    label: 'navBar.transactions',
+    main: AssetTxHistory,
+    hide: true,
+  },
+  {
+    path: '/assets/:chainId/:assetSubId/:nftId/transactions',
+    label: 'navBar.transactions',
+    main: AssetTxHistory,
+    hide: true,
+  },
+  {
     path: '/assets',
     label: 'navBar.assets',
     main: Assets,
@@ -59,11 +71,6 @@ export const routes: NestedRoute[] = [
           path: '/',
           label: 'navBar.overview',
           main: Asset,
-        },
-        {
-          path: '/transactions',
-          label: 'navBar.transactions',
-          main: AssetTxHistory,
         },
       ],
     })),

--- a/src/components/Breadcrumbs/Breadcrumbs.tsx
+++ b/src/components/Breadcrumbs/Breadcrumbs.tsx
@@ -90,6 +90,8 @@ const options: Options = {
     '/assets/:chainId/ibc\\:gamm/pool',
     '/trade/:chainId/ibc\\:gamm',
     '/trade/:chainId/ibc\\:gamm/pool',
+    // Making /assets/<nftAssetId>/transactions happy
+    '/assets/:chainId/:assetSubId',
   ],
 }
 

--- a/src/hooks/useRouteAssetId/useRouteAssetId.ts
+++ b/src/hooks/useRouteAssetId/useRouteAssetId.ts
@@ -8,6 +8,8 @@ import { getChainAdapterManager } from 'context/PluginProvider/chainAdapterSingl
 // Make sure this array remains ordered from most to least specific to avoid early matching
 export const assetIdPaths = [
   '/:chainId/:assetSubId/pool/:poolId', // Osmosis LP token path template
+  '/:chainId/:assetSubId/:nftId/transactions', // DO NOT REMOVE - first match in case we're in a /transactions path, making sure the parsing is correct
+  '/:chainId/:assetSubId/transactions', // DO NOT REMOVE - first match in case we're in a /transactions path, making sure the parsing is correct
   '/:chainId/:assetSubId/:nftId', // NFT token path template
   '/:chainId/:assetSubId', // Standard asset path template
 ]


### PR DESCRIPTION
## Description

tl;dr /asset/<assetId>transactions (both for regular and NFT assets) got rugged since:

https://github.com/shapeshift/web/blob/0f969a3376d505347c8428c5485aa5057d6836ed/src/hooks/useRouteAssetId/useRouteAssetId.ts#L11

The reason for that is the path above is conflicting with `/:chainId/:assetSubId/transactions` subroute:

https://github.com/shapeshift/web/blob/999c31553b3bf684bc0487b86d0ff20bc5dc437a/src/Routes/RoutesCommon.tsx#L64

We cannot have transactions as a nested route anymore and need to lift it up as top-level routes for both the assetId and nftId flavors 

## Pull Request Type

- [x] :bug: Bug fix (Non-breaking Change: Fixes an issue)
- [ ] :hammer_and_wrench: Chore (Non-breaking Change: Doc updates, pkg upgrades, typos, etc..)
- [ ] :nail_care: New Feature (Breaking/Non-breaking Change)

## Issue (if applicable)

<!-----------------------------------------------------------------------------
If applicable, please link to the github issue and put `closes #XXXX` in your comment to auto-close the issue that your PR fixes.
------------------------------------------------------------------------------>

None, but see https://discord.com/channels/554694662431178782/1131323172369743884/1131336866315108554

## Risk

<!-----------------------------------------------------------------------------
Outline the scope of your changes and the risk associated with them. You must use your discretion as an engineer to determine the potential impact of your changes.

E.g. an upgrade to `hdwallet` or core state management would be considered higher risk, and might require a full regression test. UI or isolated view changes, or something behind a feature flag may have near zero risk. Small bug fixes might require testing isolated to the specific fix.
------------------------------------------------------------------------------>

/asset routing may be borked

## Testing

<!-----------------------------------------------------------------------------
We treat every PR to be merged with the same scrutiny as if we were merging directly to production.

Your PR will not be merged if you do not complete the sections below for our engineering and operations teams to test.
------------------------------------------------------------------------------>

- asset pages are happy
- account asset pages are happy
- asset transactions pages are happy
- account asset transactions pages are happy

### Engineering

<!-----------------------------------------------------------------------------
Include sufficient information here for an engineer to test your PR. This may include how to test locally, in a built environment, changes to infrastructure etc.
------------------------------------------------------------------------------>

- ☝🏽 

### Operations

<!-----------------------------------------------------------------------------
If your changes have a user-facing impact, describe how a non-technical QA team can functionally test your changes in a preview environment.

If they are not user-facing please describe how to test for any regressions that may occur.
------------------------------------------------------------------------------>

- ☝🏽 

## Screenshots (if applicable)

- Prod

<img width="1612" alt="Screenshot 2023-07-20 at 00 14 23" src="https://github.com/shapeshift/web/assets/17035424/49501ad8-1c08-4feb-bebc-0877a7bb45e5">

<img width="1614" alt="Screenshot 2023-07-20 at 00 14 07" src="https://github.com/shapeshift/web/assets/17035424/63c2f9ab-484e-4ed1-9acb-94145839c88d">

(Note how appending /transactions to the asset URL does nothing)

<img width="1390" alt="Screenshot 2023-07-20 at 00 13 29" src="https://github.com/shapeshift/web/assets/17035424/d3336a22-a6df-4eb4-bca0-2e6be278ca49">
<img width="1610" alt="Screenshot 2023-07-20 at 00 12 41" src="https://github.com/shapeshift/web/assets/17035424/c275be4a-e890-4242-afeb-775df8b315c8">

- This diff
<img width="1388" alt="Screenshot 2023-07-20 at 00 17 06" src="https://github.com/shapeshift/web/assets/17035424/2ba72f3a-7277-4a6b-a864-106d1105c6da">
<img width="1609" alt="Screenshot 2023-07-20 at 00 16 32" src="https://github.com/shapeshift/web/assets/17035424/3feaeb30-71c8-47c1-92c3-4d0d128059b2">
<img width="1378" alt="Screenshot 2023-07-20 at 00 15 59" src="https://github.com/shapeshift/web/assets/17035424/572e8e67-606d-479e-b617-8e3e13b1b47e">
<img width="1602" alt="Screenshot 2023-07-20 at 00 14 58" src="https://github.com/shapeshift/web/assets/17035424/e738ea6a-99c2-4b19-84a0-ed38b916a9f6">

