### PR TITLE
perf: optimise caip helpers and their usage

### DIFF
--- a/packages/caip/src/assetId/assetId.ts
+++ b/packages/caip/src/assetId/assetId.ts
@@ -9,11 +9,10 @@ import {
   assertIsChainNamespace,
   assertIsChainReference,
   assertValidChainPartsPair,
-  isAssetId,
+  isAssetIdParts,
   isAssetNamespace,
 } from '../typeGuards'
 import type { Nominal } from '../utils'
-import { parseAssetIdRegExp } from '../utils'
 
 export type AssetId = Nominal<string, 'AssetId'>
 
@@ -138,19 +137,20 @@ type FromAssetIdReturn = {
 
 export type FromAssetId = (assetId: AssetId) => FromAssetIdReturn
 
-export const fromAssetId: FromAssetId = assetId => {
-  if (!isAssetId(assetId)) throw new Error(`fromAssetId: invalid AssetId: ${assetId}`)
-  const matches = parseAssetIdRegExp.exec(assetId)
-  if (!matches) throw new Error(`fromAssetId: could not parse AssetId: ${assetId}`)
+// NOTE: perf critical - benchmark any changes
+export const fromAssetId: FromAssetId = (assetId: string) => {
+  const slashIdx = assetId.indexOf('/')
+  const chainId = assetId.substring(0, slashIdx)
+  const assetParts = assetId.substring(slashIdx + 1)
 
-  const { 1: chainNamespace, 2: chainReference, 3: assetNamespace, 4: assetReference } = matches
+  const { chainNamespace, chainReference } = fromChainId(chainId as ChainId)
 
-  // These should never throw because isAssetId() would have already caught it, but they help with type inference
-  assertIsChainNamespace(chainNamespace)
-  assertIsChainReference(chainReference)
-  assertIsAssetNamespace(assetNamespace)
+  const idx = assetParts.indexOf(':')
+  const assetNamespace = assetParts.substring(0, idx)
+  const assetReference = assetParts.substring(idx + 1)
 
-  const chainId = toChainId({ chainNamespace, chainReference })
+  if (!isAssetIdParts(chainNamespace, chainReference, assetNamespace))
+    throw new Error(`fromAssetId: invalid AssetId: ${assetId}`)
 
   const assetReferenceNormalized = (() => {
     switch (assetNamespace) {
@@ -168,23 +168,17 @@ export const fromAssetId: FromAssetId = assetId => {
 
   return {
     chainId,
-    chainReference,
-    chainNamespace,
-    assetNamespace,
+    chainNamespace: chainNamespace as ChainNamespace,
+    chainReference: chainReference as ChainReference,
+    assetNamespace: assetNamespace as AssetNamespace,
     assetReference: assetReferenceNormalized,
   }
 }
 
+// NOTE: perf critical - benchmark any changes
 export const isNft = (assetId: AssetId): boolean => {
-  switch (fromAssetId(assetId).assetNamespace) {
-    case 'erc721':
-    case 'erc1155':
-    case 'bep721':
-    case 'bep1155':
-      return true
-    default:
-      return false
-  }
+  const [, , assetNamespace] = assetId.split(':')
+  return ['erc721', 'erc1155', 'bep721', 'bep1155'].includes(assetNamespace)
 }
 
 export const deserializeNftAssetReference = (

--- a/packages/caip/src/assetId/assetId.ts
+++ b/packages/caip/src/assetId/assetId.ts
@@ -177,7 +177,10 @@ export const fromAssetId: FromAssetId = (assetId: string) => {
 
 // NOTE: perf critical - benchmark any changes
 export const isNft = (assetId: AssetId): boolean => {
-  const [, , assetNamespace] = assetId.split(':')
+  const slashIdx = assetId.indexOf('/')
+  const assetParts = assetId.substring(slashIdx + 1)
+  const idx = assetParts.indexOf(':')
+  const assetNamespace = assetParts.substring(0, idx)
   return ['erc721', 'erc1155', 'bep721', 'bep1155'].includes(assetNamespace)
 }
 

--- a/packages/caip/src/chainId/chainId.test.ts
+++ b/packages/caip/src/chainId/chainId.test.ts
@@ -90,20 +90,6 @@ describe('chainId', () => {
       expect(chainReference).toEqual(CHAIN_REFERENCE.BitcoinTestnet)
     })
 
-    it('throws with unsupported Bitcoin namespace ChainId', () => {
-      const badBitcoinChainId = 'bip999:000000000933ea01ad0ee984209779ba'
-      expect(() => fromChainId(badBitcoinChainId)).toThrow(
-        'assertIsChainNamespace: unsupported ChainNamespace: bip999',
-      )
-    })
-
-    it('throws with unsupported Bitcoin reference ChainId', () => {
-      const badBitcoinChainId = 'bip122:000000000xxxxxxxxxxxxxxxxxxxxxxx'
-      expect(() => fromChainId(badBitcoinChainId)).toThrow(
-        'assertIsChainReference: unsupported ChainReference: 000000000xxxxxxxxxxxxxxxxxxxxxxx',
-      )
-    })
-
     it('can turn CosmosHub mainnet to chain and network', () => {
       const cosmosHubChainId = 'cosmos:cosmoshub-4'
       const { chainNamespace, chainReference } = fromChainId(cosmosHubChainId)
@@ -116,20 +102,6 @@ describe('chainId', () => {
       const { chainNamespace, chainReference } = fromChainId(cosmosHubChainId)
       expect(chainNamespace).toEqual(CHAIN_NAMESPACE.CosmosSdk)
       expect(chainReference).toEqual(CHAIN_REFERENCE.CosmosHubVega)
-    })
-
-    it('throws with unsupported Cosmos namespace ChainId', () => {
-      const badCosmosChainId = 'cosmosssssssssss:cosmoshub-4'
-      expect(() => fromChainId(badCosmosChainId)).toThrow(
-        'assertIsChainNamespace: unsupported ChainNamespace: cosmosssssssssss',
-      )
-    })
-
-    it('throws with unsupported Cosmos reference ChainId', () => {
-      const badCosmosChainId = 'cosmos:kek-testnet'
-      expect(() => fromChainId(badCosmosChainId)).toThrow(
-        'assertIsChainReference: unsupported ChainReference: kek-testnet',
-      )
     })
 
     it('can turn Osmosis mainnet to chain and network', () => {
@@ -153,20 +125,6 @@ describe('chainId', () => {
       expect(chainReference).toEqual(CHAIN_REFERENCE.EthereumMainnet)
     })
 
-    it('throws with unsupported Ethereum namespace ChainId', () => {
-      const badEthereumChainId = 'eip123:1'
-      expect(() => fromChainId(badEthereumChainId)).toThrow(
-        'assertIsChainNamespace: unsupported ChainNamespace: eip123',
-      )
-    })
-
-    it('throws with unsupported Ethereum reference ChainId', () => {
-      const badEthereumChainId = 'eip155:999'
-      expect(() => fromChainId(badEthereumChainId)).toThrow(
-        'assertIsChainReference: unsupported ChainReference: 999',
-      )
-    })
-
     it('can turn Ethereum ropsten to chain and network', () => {
       const ethereumChainId = 'eip155:3'
       const { chainNamespace, chainReference } = fromChainId(ethereumChainId)
@@ -179,16 +137,6 @@ describe('chainId', () => {
       const { chainNamespace, chainReference } = fromChainId(ethereumChainId)
       expect(chainNamespace).toEqual(CHAIN_NAMESPACE.Evm)
       expect(chainReference).toEqual(CHAIN_REFERENCE.EthereumRinkeby)
-    })
-
-    it('should throw when there is no network reference', () => {
-      expect(() => fromChainId('bip122')).toThrow(
-        'assertIsChainReference: unsupported ChainReference: undefined',
-      )
-      expect(() => fromChainId(':1')).toThrow(
-        'assertIsChainNamespace: unsupported ChainNamespace: ',
-      )
-      expect(() => fromChainId(':')).toThrow('assertIsChainNamespace: unsupported ChainNamespace: ')
     })
   })
 })

--- a/packages/caip/src/chainId/chainId.ts
+++ b/packages/caip/src/chainId/chainId.ts
@@ -1,12 +1,7 @@
 // https://github.com/ChainAgnostic/CAIPs/blob/master/CAIPs/caip-2.md
 
 import type { CHAIN_NAMESPACE, CHAIN_REFERENCE } from '../constants'
-import {
-  assertIsChainId,
-  assertIsChainNamespace,
-  assertIsChainReference,
-  assertValidChainPartsPair,
-} from '../typeGuards'
+import { assertIsChainId } from '../typeGuards'
 import type { Nominal } from '../utils'
 
 export type ChainId = Nominal<string, 'ChainId'>
@@ -26,19 +21,21 @@ export const toChainId = (args: ToChainIdArgs): ChainId => {
   return maybeChainId
 }
 
-type FromChainIdReturn = {
+// NOTE: perf critical - benchmark any changes
+export const fromChainId = (
+  chainId: ChainId,
+): {
   chainNamespace: ChainNamespace
   chainReference: ChainReference
-}
+} => {
+  const idx = chainId.indexOf(':')
+  const chainNamespace = chainId.substring(0, idx)
+  const chainReference = chainId.substring(idx + 1)
 
-type FromChainId = (chainId: string) => FromChainIdReturn
-
-export const fromChainId: FromChainId = chainId => {
-  const [chainNamespace, chainReference] = chainId.split(':')
-  assertIsChainNamespace(chainNamespace)
-  assertIsChainReference(chainReference)
-  assertValidChainPartsPair(chainNamespace, chainReference)
-  return { chainNamespace, chainReference }
+  return {
+    chainNamespace: chainNamespace as ChainNamespace,
+    chainReference: chainReference as ChainReference,
+  }
 }
 
 export const toCAIP2 = toChainId

--- a/packages/caip/src/chainId/chainId.ts
+++ b/packages/caip/src/chainId/chainId.ts
@@ -1,5 +1,7 @@
 // https://github.com/ChainAgnostic/CAIPs/blob/master/CAIPs/caip-2.md
 
+import assert from 'assert'
+
 import type { CHAIN_NAMESPACE, CHAIN_REFERENCE } from '../constants'
 import { assertIsChainId } from '../typeGuards'
 import type { Nominal } from '../utils'

--- a/packages/caip/src/chainId/chainId.ts
+++ b/packages/caip/src/chainId/chainId.ts
@@ -1,7 +1,5 @@
 // https://github.com/ChainAgnostic/CAIPs/blob/master/CAIPs/caip-2.md
 
-import assert from 'assert'
-
 import type { CHAIN_NAMESPACE, CHAIN_REFERENCE } from '../constants'
 import { assertIsChainId } from '../typeGuards'
 import type { Nominal } from '../utils'

--- a/packages/caip/src/typeGuards.ts
+++ b/packages/caip/src/typeGuards.ts
@@ -64,7 +64,9 @@ export const isChainId = (maybeChainId: ChainId | string): maybeChainId is Chain
 }
 
 export const isChainIdParts = (chainNamespace: string, chainReference: string): boolean => {
-  return !!VALID_CHAIN_IDS[chainNamespace]?.includes(chainReference)
+  return !!VALID_CHAIN_IDS[chainNamespace as ChainNamespace]?.includes(
+    chainReference as ChainReference,
+  )
 }
 
 const getTypeGuardAssertion = <T>(

--- a/packages/caip/src/typeGuards.ts
+++ b/packages/caip/src/typeGuards.ts
@@ -31,9 +31,17 @@ export const isAssetReference = (
   Object.values(ASSET_REFERENCE).includes(maybeAssetReference as AssetReference)
 
 // NOTE: perf critical - benchmark any changes
-export const isAssetId = (maybeAssetId: AssetId | string): maybeAssetId is AssetReference => {
-  const [maybeChainNamespace, maybeChainReference, maybeAssetNamespace] = maybeAssetId.split(':')
-  return isAssetIdParts(maybeChainNamespace, maybeChainReference, maybeAssetNamespace)
+export const isAssetId = (maybeAssetId: AssetId | string): maybeAssetId is AssetId => {
+  const slashIdx = maybeAssetId.indexOf('/')
+  const chainId = maybeAssetId.substring(0, slashIdx)
+  const assetParts = maybeAssetId.substring(slashIdx + 1)
+
+  const { chainNamespace, chainReference } = fromChainId(chainId as ChainId)
+
+  const idx = assetParts.indexOf(':')
+  const assetNamespace = assetParts.substring(0, idx)
+
+  return isAssetIdParts(chainNamespace, chainReference, assetNamespace)
 }
 
 // NOTE: perf critical - benchmark any changes
@@ -52,6 +60,10 @@ export const isAssetIdParts = (
 // NOTE: perf critical - benchmark any changes
 export const isChainId = (maybeChainId: ChainId | string): maybeChainId is ChainId => {
   const { chainNamespace, chainReference } = fromChainId(maybeChainId as ChainId)
+  return !!VALID_CHAIN_IDS[chainNamespace]?.includes(chainReference)
+}
+
+export const isChainIdParts = (chainNamespace: string, chainReference: string): boolean => {
   return !!VALID_CHAIN_IDS[chainNamespace]?.includes(chainReference)
 }
 

--- a/packages/caip/src/utils.ts
+++ b/packages/caip/src/utils.ts
@@ -5,10 +5,6 @@ import { toAssetId } from './assetId/assetId'
 import type { ChainId, ChainNamespace, ChainReference } from './chainId/chainId'
 import * as constants from './constants'
 
-// https://regex101.com/r/xqVzV2/1
-export const parseAssetIdRegExp =
-  /([-a-z\d]{3,8}):([-a-zA-Z\d]{1,32})\/([-a-z\d]{3,8}):([-a-zA-Z/\d]+)/
-
 export const accountIdToChainId = (accountId: AccountId): ChainId =>
   fromAccountId(accountId).chainId
 

--- a/src/components/MultiHopTrade/hooks/useSupportedAssets.tsx
+++ b/src/components/MultiHopTrade/hooks/useSupportedAssets.tsx
@@ -7,12 +7,12 @@ import { osmosisSwapper } from 'lib/swapper/swappers/OsmosisSwapper/OsmosisSwapp
 import { thorchainSwapper } from 'lib/swapper/swappers/ThorchainSwapper/ThorchainSwapper2'
 import { zrxSwapper } from 'lib/swapper/swappers/ZrxSwapper/ZrxSwapper2'
 import { selectAssetsSortedByMarketCapUserCurrencyBalanceAndName } from 'state/slices/common-selectors'
-import { selectAssetIds, selectFeatureFlags, selectSellAsset } from 'state/slices/selectors'
+import { selectFeatureFlags, selectNonNftAssetIds, selectSellAsset } from 'state/slices/selectors'
 import { useAppSelector } from 'state/store'
 
 export const useSupportedAssets = () => {
   const sellAsset = useAppSelector(selectSellAsset)
-  const assetIds = useAppSelector(selectAssetIds)
+  const nonNftAssetIds = useAppSelector(selectNonNftAssetIds)
   const sortedAssets = useAppSelector(selectAssetsSortedByMarketCapUserCurrencyBalanceAndName)
   const { LifiSwap, ThorSwap, ZrxSwap, OneInch, Cowswap, OsmosisSwap } =
     useAppSelector(selectFeatureFlags)
@@ -35,24 +35,26 @@ export const useSupportedAssets = () => {
   useEffect(() => {
     ;(async () => {
       const supportedAssetIds = await Promise.all(
-        enabledSwappers.map(({ filterAssetIdsBySellable }) => filterAssetIdsBySellable(assetIds)),
+        enabledSwappers.map(({ filterAssetIdsBySellable }) =>
+          filterAssetIdsBySellable(nonNftAssetIds),
+        ),
       )
       const supportedAssetIdsSet = new Set(supportedAssetIds.flat())
       setSupportedSellAssets(sortedAssets.filter(asset => supportedAssetIdsSet.has(asset.assetId)))
     })()
-  }, [assetIds, enabledSwappers, sortedAssets])
+  }, [nonNftAssetIds, enabledSwappers, sortedAssets])
 
   useEffect(() => {
     ;(async () => {
       const supportedAssetIds = await Promise.all(
         enabledSwappers.map(({ filterBuyAssetsBySellAssetId }) =>
-          filterBuyAssetsBySellAssetId({ assetIds, sellAssetId: sellAsset.assetId }),
+          filterBuyAssetsBySellAssetId({ nonNftAssetIds, sellAssetId: sellAsset.assetId }),
         ),
       )
       const supportedAssetIdsSet = new Set(supportedAssetIds.flat())
       setSupportedBuyAssets(sortedAssets.filter(asset => supportedAssetIdsSet.has(asset.assetId)))
     })()
-  }, [assetIds, enabledSwappers, sellAsset.assetId, sortedAssets])
+  }, [nonNftAssetIds, enabledSwappers, sellAsset.assetId, sortedAssets])
 
   return {
     supportedSellAssets,

--- a/src/components/Trade/hooks/useSwapper/useSwapper.tsx
+++ b/src/components/Trade/hooks/useSwapper/useSwapper.tsx
@@ -28,9 +28,9 @@ import {
 } from 'lib/utils/evm'
 import { selectFeatureFlags } from 'state/slices/preferencesSlice/selectors'
 import {
-  selectAssetIds,
   selectAssetsSortedByMarketCapUserCurrencyBalanceAndName,
   selectBIP44ParamsByAccountId,
+  selectNonNftAssetIds,
   selectPortfolioAccountIdsByAssetId,
   selectPortfolioAccountMetadataByAccountId,
 } from 'state/slices/selectors'
@@ -69,7 +69,7 @@ export const useSwapper = () => {
 
   // Selectors
   const flags = useSelector(selectFeatureFlags)
-  const assetIds = useSelector(selectAssetIds)
+  const nonNftAssetIds = useSelector(selectNonNftAssetIds)
   const sortedAssets = useSelector(selectAssetsSortedByMarketCapUserCurrencyBalanceAndName)
 
   // Hooks
@@ -82,7 +82,7 @@ export const useSwapper = () => {
     if (!swapperManager) return []
 
     const sellableAssetIds = swapperManager.getSupportedSellableAssetIds({
-      assetIds,
+      nonNftAssetIds,
     })
 
     const sellableAssetIdsSet: Set<AssetId> = new Set(sellableAssetIds)
@@ -94,21 +94,21 @@ export const useSwapper = () => {
     )
 
     return walletSupportedAssets
-  }, [swapperManager, assetIds, sortedAssets, wallet])
+  }, [swapperManager, nonNftAssetIds, sortedAssets, wallet])
 
   const supportedBuyAssetsByMarketCap = useMemo(() => {
     const sellAssetId = sellAsset?.assetId
     if (sellAssetId === undefined || !swapperManager) return []
 
     const buyableAssetIds = swapperManager.getSupportedBuyAssetIdsFromSellId({
-      assetIds,
+      nonNftAssetIds,
       sellAssetId,
     })
 
     const buyableAssetIdsSet: Set<AssetId> = new Set(buyableAssetIds)
 
     return sortedAssets.filter(asset => buyableAssetIdsSet.has(asset.assetId))
-  }, [sortedAssets, sellAsset?.assetId, assetIds, swapperManager])
+  }, [sortedAssets, sellAsset?.assetId, nonNftAssetIds, swapperManager])
 
   const sellAssetAccountIds = useAppSelector(state =>
     selectPortfolioAccountIdsByAssetId(state, { assetId: sellAsset?.assetId ?? '' }),

--- a/src/lib/swapper/api.ts
+++ b/src/lib/swapper/api.ts
@@ -94,11 +94,11 @@ export type GetSwappersWithQuoteMetadataReturn = SwapperWithQuoteMetadata[]
 
 export type BuyAssetBySellIdInput = {
   sellAssetId: AssetId
-  assetIds: AssetId[]
+  nonNftAssetIds: AssetId[]
 }
 
 export type SupportedSellAssetsInput = {
-  assetIds: AssetId[]
+  nonNftAssetIds: AssetId[]
 }
 
 type CommonTradeInput = {
@@ -264,7 +264,7 @@ export interface Swapper<T extends ChainId> {
   /**
    * Get supported sell assetIds
    */
-  filterAssetIdsBySellable(assetIds: AssetId[]): AssetId[]
+  filterAssetIdsBySellable(nonNftAssetIds: AssetId[]): AssetId[]
 
   /**
    * Get transactions related to a trade

--- a/src/lib/swapper/manager/SwapperManager.test.ts
+++ b/src/lib/swapper/manager/SwapperManager.test.ts
@@ -65,47 +65,49 @@ describe('SwapperManager', () => {
 
   describe('getSupportedBuyAssetIdsFromSellId', () => {
     it('should return an array of supported buy assetIds given a sell asset Id', () => {
-      const assetIds = [BTC.assetId, WETH.assetId, FOX_MAINNET.assetId]
+      const nonNftAssetIds = [BTC.assetId, WETH.assetId, FOX_MAINNET.assetId]
 
       const sellAssetId = FOX_MAINNET.assetId
       const swapperManager = new SwapperManager()
       swapperManager.addSwapper(zrxSwapper)
 
       expect(
-        swapperManager.getSupportedBuyAssetIdsFromSellId({ sellAssetId, assetIds }),
+        swapperManager.getSupportedBuyAssetIdsFromSellId({ sellAssetId, nonNftAssetIds }),
       ).toStrictEqual([WETH.assetId, FOX_MAINNET.assetId])
     })
 
     it('should return unique assetIds', () => {
-      const assetIds = [BTC.assetId, WETH.assetId, WETH.assetId, FOX_MAINNET.assetId]
+      const nonNftAssetIds = [BTC.assetId, WETH.assetId, WETH.assetId, FOX_MAINNET.assetId]
 
       const sellAssetId = FOX_MAINNET.assetId
       const swapperManager = new SwapperManager()
       swapperManager.addSwapper(zrxSwapper)
 
       expect(
-        swapperManager.getSupportedBuyAssetIdsFromSellId({ sellAssetId, assetIds }),
+        swapperManager.getSupportedBuyAssetIdsFromSellId({ sellAssetId, nonNftAssetIds }),
       ).toStrictEqual([WETH.assetId, FOX_MAINNET.assetId])
     })
   })
 
   describe('getSupportedSellableAssets', () => {
     it('should return an array of supported sell assetIds', () => {
-      const assetIds = [BSC.assetId, BTC.assetId]
+      const nonNftAssetIds = [BSC.assetId, BTC.assetId]
 
       const swapperManager = new SwapperManager()
       swapperManager.addSwapper(zrxSwapper)
 
-      expect(swapperManager.getSupportedSellableAssetIds({ assetIds })).toStrictEqual([BSC.assetId])
+      expect(swapperManager.getSupportedSellableAssetIds({ nonNftAssetIds })).toStrictEqual([
+        BSC.assetId,
+      ])
     })
 
     it('should return unique assetIds', () => {
-      const assetIds = [BTC.assetId, WETH.assetId, FOX_MAINNET.assetId, FOX_GNOSIS.assetId]
+      const nonNftAssetIds = [BTC.assetId, WETH.assetId, FOX_MAINNET.assetId, FOX_GNOSIS.assetId]
 
       const swapperManager = new SwapperManager()
       swapperManager.addSwapper(zrxSwapper)
 
-      expect(swapperManager.getSupportedSellableAssetIds({ assetIds })).toStrictEqual([
+      expect(swapperManager.getSupportedSellableAssetIds({ nonNftAssetIds })).toStrictEqual([
         WETH.assetId,
         FOX_MAINNET.assetId,
       ])

--- a/src/lib/swapper/manager/SwapperManager.ts
+++ b/src/lib/swapper/manager/SwapperManager.ts
@@ -103,7 +103,7 @@ export class SwapperManager {
     const availableSwappers = Array.from(this.swappers.values())
     return availableSwappers.filter(
       (swapper: Swapper<ChainId>) =>
-        swapper.filterBuyAssetsBySellAssetId({ sellAssetId, assetIds: [buyAssetId] }).length,
+        swapper.filterBuyAssetsBySellAssetId({ sellAssetId, nonNftAssetIds: [buyAssetId] }).length,
     )
   }
 
@@ -116,11 +116,11 @@ export class SwapperManager {
   }
 
   getSupportedSellableAssetIds(args: SupportedSellAssetsInput) {
-    const { assetIds } = args
+    const { nonNftAssetIds } = args
 
     return uniq(
       Array.from(this.swappers.values()).flatMap((swapper: Swapper<ChainId>) =>
-        swapper.filterAssetIdsBySellable(assetIds),
+        swapper.filterAssetIdsBySellable(nonNftAssetIds),
       ),
     )
   }

--- a/src/lib/swapper/swappers/CowSwapper/CowSwapper.test.ts
+++ b/src/lib/swapper/swappers/CowSwapper/CowSwapper.test.ts
@@ -123,20 +123,20 @@ describe('CowSwapper', () => {
   describe('filterBuyAssetsBySellAssetId', () => {
     it('returns empty array when called with an empty assetIds array', () => {
       expect(
-        swapper.filterBuyAssetsBySellAssetId({ assetIds: [], sellAssetId: WETH.assetId }),
+        swapper.filterBuyAssetsBySellAssetId({ nonNftAssetIds: [], sellAssetId: WETH.assetId }),
       ).toEqual([])
     })
 
     it('returns empty array when called with sellAssetId that is not sellable', () => {
       expect(
         swapper.filterBuyAssetsBySellAssetId({
-          assetIds: ASSET_IDS,
+          nonNftAssetIds: ASSET_IDS,
           sellAssetId: ETH.assetId,
         }),
       ).toEqual([])
       expect(
         swapper.filterBuyAssetsBySellAssetId({
-          assetIds: ASSET_IDS,
+          nonNftAssetIds: ASSET_IDS,
           sellAssetId: 'eip155:1/erc20:0xdc49108ce5c57bc3408c3a5e95f3d864ec386ed3',
         }),
       ).toEqual([])
@@ -145,37 +145,37 @@ describe('CowSwapper', () => {
     it('returns array filtered out of non erc20 tokens when called with a sellable sellAssetId', () => {
       expect(
         swapper.filterBuyAssetsBySellAssetId({
-          assetIds: ASSET_IDS,
+          nonNftAssetIds: ASSET_IDS,
           sellAssetId: WETH.assetId,
         }),
       ).toEqual([ETH.assetId, WBTC.assetId, FOX_MAINNET.assetId])
       expect(
         swapper.filterBuyAssetsBySellAssetId({
-          assetIds: ASSET_IDS,
+          nonNftAssetIds: ASSET_IDS,
           sellAssetId: WBTC.assetId,
         }),
       ).toEqual([ETH.assetId, WETH.assetId, FOX_MAINNET.assetId])
       expect(
         swapper.filterBuyAssetsBySellAssetId({
-          assetIds: ASSET_IDS,
+          nonNftAssetIds: ASSET_IDS,
           sellAssetId: FOX_MAINNET.assetId,
         }),
       ).toEqual([ETH.assetId, WBTC.assetId, WETH.assetId])
     })
 
     it('returns array filtered out of unsupported tokens when called with a sellable sellAssetId', () => {
-      const assetIds = [
+      const nonNftAssetIds = [
         FOX_MAINNET.assetId,
         'eip155:1/erc20:0xdc49108ce5c57bc3408c3a5e95f3d864ec386ed3',
       ]
       expect(
         swapper.filterBuyAssetsBySellAssetId({
-          assetIds,
+          nonNftAssetIds,
           sellAssetId: WETH.assetId,
         }),
       ).toEqual([FOX_MAINNET.assetId])
       expect(
-        swapper.filterBuyAssetsBySellAssetId({ assetIds, sellAssetId: FOX_MAINNET.assetId }),
+        swapper.filterBuyAssetsBySellAssetId({ nonNftAssetIds, sellAssetId: FOX_MAINNET.assetId }),
       ).toEqual([])
     })
   })

--- a/src/lib/swapper/swappers/CowSwapper/filterAssetIdsBySellable/filterAssetIdsBySellable.ts
+++ b/src/lib/swapper/swappers/CowSwapper/filterAssetIdsBySellable/filterAssetIdsBySellable.ts
@@ -1,5 +1,4 @@
 import type { AssetId } from '@shapeshiftoss/caip'
-import { isNft } from '@shapeshiftoss/caip'
 import { selectAssets } from 'state/slices/selectors'
 import { store } from 'state/store'
 
@@ -7,18 +6,17 @@ import { isNativeEvmAsset } from '../../utils/helpers/helpers'
 import { COWSWAP_UNSUPPORTED_ASSETS } from '../utils/blacklist'
 import { getSupportedChainIds } from '../utils/helpers/helpers'
 
-export const filterAssetIdsBySellable = (assetIds: AssetId[]): AssetId[] => {
+export const filterAssetIdsBySellable = (nonNftAssetIds: AssetId[]): AssetId[] => {
   const supportedChainIds = getSupportedChainIds()
   const assets = selectAssets(store.getState())
-  return assetIds.filter(id => {
+  return nonNftAssetIds.filter(id => {
     const asset = assets[id]
     if (!asset) return false
 
     return (
       supportedChainIds.includes(asset.chainId) &&
       !COWSWAP_UNSUPPORTED_ASSETS.includes(id) &&
-      !isNativeEvmAsset(id) &&
-      !isNft(id)
+      !isNativeEvmAsset(id)
     )
   })
 }

--- a/src/lib/swapper/swappers/CowSwapper/filterBuyAssetsBySellAssetId/filterBuyAssetsBySellAssetId.ts
+++ b/src/lib/swapper/swappers/CowSwapper/filterBuyAssetsBySellAssetId/filterBuyAssetsBySellAssetId.ts
@@ -1,5 +1,4 @@
 import type { AssetId } from '@shapeshiftoss/caip'
-import { isNft } from '@shapeshiftoss/caip'
 import type { BuyAssetBySellIdInput } from 'lib/swapper/api'
 import { selectAssets } from 'state/slices/selectors'
 import { store } from 'state/store'
@@ -9,7 +8,7 @@ import { COWSWAP_UNSUPPORTED_ASSETS } from '../utils/blacklist'
 import { getSupportedChainIds } from '../utils/helpers/helpers'
 
 export const filterBuyAssetsBySellAssetId = ({
-  assetIds = [],
+  nonNftAssetIds = [],
   sellAssetId,
 }: BuyAssetBySellIdInput): AssetId[] => {
   const supportedChainIds = getSupportedChainIds()
@@ -24,15 +23,14 @@ export const filterBuyAssetsBySellAssetId = ({
   )
     return []
 
-  return assetIds.filter(id => {
+  return nonNftAssetIds.filter(id => {
     const asset = assets[id]
     if (!asset) return false
 
     return (
       id !== sellAssetId &&
       sellAsset.chainId === asset.chainId &&
-      !COWSWAP_UNSUPPORTED_ASSETS.includes(id) &&
-      !isNft(id)
+      !COWSWAP_UNSUPPORTED_ASSETS.includes(id)
     )
   })
 }

--- a/src/lib/swapper/swappers/OsmosisSwapper/filterBuyAssetsBySellAssetId/filterBuyAssetsBySellAssetId.ts
+++ b/src/lib/swapper/swappers/OsmosisSwapper/filterBuyAssetsBySellAssetId/filterBuyAssetsBySellAssetId.ts
@@ -3,10 +3,10 @@ import type { BuyAssetBySellIdInput } from 'lib/swapper/api'
 import { SUPPORTED_ASSET_IDS } from '../utils/constants'
 
 export const filterBuyAssetsBySellAssetId = (args: BuyAssetBySellIdInput): string[] => {
-  const { assetIds = [], sellAssetId } = args
+  const { nonNftAssetIds = [], sellAssetId } = args
   if (!SUPPORTED_ASSET_IDS.includes(sellAssetId)) return []
 
-  return assetIds.filter(
+  return nonNftAssetIds.filter(
     assetId => SUPPORTED_ASSET_IDS.includes(assetId) && assetId !== sellAssetId,
   )
 }

--- a/src/lib/swapper/swappers/ThorchainSwapper/ThorchainSwapper.ts
+++ b/src/lib/swapper/swappers/ThorchainSwapper/ThorchainSwapper.ts
@@ -123,9 +123,9 @@ export class ThorchainSwapper implements Swapper<ThorChainId> {
   }
 
   filterBuyAssetsBySellAssetId(args: BuyAssetBySellIdInput): AssetId[] {
-    const { assetIds = [], sellAssetId } = args
+    const { nonNftAssetIds, sellAssetId } = args
     if (!this.supportedSellAssetIds.includes(sellAssetId)) return []
-    return assetIds.filter(
+    return nonNftAssetIds.filter(
       assetId => this.supportedBuyAssetIds.includes(assetId) && assetId !== sellAssetId,
     )
   }

--- a/src/lib/swapper/swappers/utils/filterAssetIdsBySellable/filterAssetIdsBySellable.ts
+++ b/src/lib/swapper/swappers/utils/filterAssetIdsBySellable/filterAssetIdsBySellable.ts
@@ -1,5 +1,4 @@
 import type { AssetId } from '@shapeshiftoss/caip'
-import { isNft } from '@shapeshiftoss/caip'
 import type { EvmChainId } from '@shapeshiftoss/chain-adapters'
 import { evmChainIds } from '@shapeshiftoss/chain-adapters'
 import { selectAssets } from 'state/slices/selectors'
@@ -7,16 +6,16 @@ import { store } from 'state/store'
 
 // we dont perform a lookup to lifi's supported assets because they support far more assets than we do
 // so the overhead in performing the fetch to lifi isnt worth the time
-export function filterEvmAssetIdsBySellable(assetIds: AssetId[]): AssetId[] {
+export function filterEvmAssetIdsBySellable(nonNftAssetIds: AssetId[]): AssetId[] {
   const assets = selectAssets(store.getState())
-  const result = assetIds.filter(assetId => {
+  const result = nonNftAssetIds.filter(assetId => {
     const asset = assets[assetId]
 
     if (asset === undefined) return false
 
     const { chainId } = asset
 
-    return evmChainIds.includes(chainId as EvmChainId) && !isNft(assetId)
+    return evmChainIds.includes(chainId as EvmChainId)
   })
 
   return result

--- a/src/lib/swapper/swappers/utils/filterBuyAssetsBySellAssetId/filterBuyAssetsBySellAssetId.ts
+++ b/src/lib/swapper/swappers/utils/filterBuyAssetsBySellAssetId/filterBuyAssetsBySellAssetId.ts
@@ -1,5 +1,4 @@
 import type { AssetId, ChainId } from '@shapeshiftoss/caip'
-import { isNft } from '@shapeshiftoss/caip'
 import { isEvmChainId } from '@shapeshiftoss/chain-adapters'
 import type { BuyAssetBySellIdInput } from 'lib/swapper/api'
 import { selectAssets } from 'state/slices/selectors'
@@ -11,7 +10,7 @@ const _filterEvmBuyAssetsBySellAssetId = (
   input: BuyAssetBySellIdInput,
   chainIdPredicate: ChainIdPredicate,
 ): AssetId[] => {
-  const { assetIds = [], sellAssetId } = input
+  const { nonNftAssetIds = [], sellAssetId } = input
 
   const assets = selectAssets(store.getState())
   const sellAsset = assets[sellAssetId]
@@ -19,17 +18,13 @@ const _filterEvmBuyAssetsBySellAssetId = (
   // evm only
   if (sellAsset === undefined || !isEvmChainId(sellAsset.chainId)) return []
 
-  return assetIds.filter(buyAssetId => {
+  return nonNftAssetIds.filter(buyAssetId => {
     const buyAsset = assets[buyAssetId]
 
     if (buyAsset === undefined) return false
 
     // evm only AND chain id predicate
-    return (
-      isEvmChainId(buyAsset.chainId) &&
-      chainIdPredicate(buyAsset.chainId, sellAsset.chainId) &&
-      !isNft(buyAssetId)
-    )
+    return isEvmChainId(buyAsset.chainId) && chainIdPredicate(buyAsset.chainId, sellAsset.chainId)
   })
 }
 

--- a/src/state/slices/assetsSlice/selectors.ts
+++ b/src/state/slices/assetsSlice/selectors.ts
@@ -35,9 +35,14 @@ export const selectAssets = createDeepEqualOutputSelector(
 )
 export const selectAssetIds = (state: ReduxState) => state.assets.ids
 
-export const selectNftAssetIds = createDeepEqualOutputSelector(
-  selectAssetIds,
-  (assetIds): AssetId[] => assetIds.filter(assetId => isNft(assetId)),
+// not deep equal output selector for perf reasons - hashing more expensive than selecting
+export const selectNonNftAssetIds = createSelector(selectAssetIds, (assetIds): AssetId[] =>
+  assetIds.filter(assetId => !isNft(assetId)),
+)
+
+// not deep equal output selector for perf reasons - hashing more expensive than selecting
+export const selectNftAssetIds = createSelector(selectAssetIds, (assetIds): AssetId[] =>
+  assetIds.filter(assetId => isNft(assetId)),
 )
 
 export const selectAssetsByMarketCap = createDeepEqualOutputSelector(


### PR DESCRIPTION
## Description

- Optimises caip helpers to improve UX around the app.
- Some of the assertions in the `fromAssetId` and `fromChainId` utils have been removed as they seem to be duplicates of the `assertIsXyz` utils in `packages/caip/src/typeGuards.ts`, and the compute of re-checking everything affects performance quite a lot
- Swapper asset filtering has been changed to accept `nonAftAssetIds` to minimum duplicate compute.

## Pull Request Type

- [ ] :bug: Bug fix (Non-breaking Change: Fixes an issue)
- [x] :hammer_and_wrench: Chore (Non-breaking Change: Doc updates, pkg upgrades, typos, etc..)
- [ ] :nail_care: New Feature (Breaking/Non-breaking Change)

## Issue (if applicable)

NA

## Risk

High risk, this changes some of the most fundamental code in our platform, which means the impact of things being wrong is extremely high. 

This affects caip, which means everything relating to asset processing, trades, quotes, nfts, staking etc could be impacted.

## Testing

Check everything that uses assets and chain IDs. Be thorough, as this is a high risk change.

### Engineering

See above

### Operations

Please do a full regression test!

## Screenshots (if applicable)
