### PR TITLE
fix: dont request lifi quotes with 0 amount

### DIFF
--- a/src/lib/swapper/swappers/LifiSwapper/endpoints.ts
+++ b/src/lib/swapper/swappers/LifiSwapper/endpoints.ts
@@ -13,6 +13,7 @@ import type {
   Swapper2Api,
   TradeQuote2,
 } from 'lib/swapper/api'
+import { makeSwapErrorRight, SwapErrorType } from 'lib/swapper/api'
 import { getLifi } from 'lib/swapper/swappers/LifiSwapper/utils/getLifi'
 
 import { getTradeQuote } from './getTradeQuote/getTradeQuote'
@@ -29,6 +30,14 @@ export const lifiApi: Swapper2Api = {
     assets: Partial<Record<AssetId, Asset>>,
     sellAssetPriceUsdPrecision: string,
   ): Promise<Result<TradeQuote2, SwapErrorRight>> => {
+    if (input.sellAmountBeforeFeesCryptoBaseUnit === '0') {
+      return Err(
+        makeSwapErrorRight({
+          message: 'sell amount too low',
+          code: SwapErrorType.TRADE_QUOTE_AMOUNT_TOO_SMALL,
+        }),
+      )
+    }
     if (lifiChainMapPromise === undefined) lifiChainMapPromise = getLifiChainMap()
 
     const maybeLifiChainMap = await lifiChainMapPromise


### PR DESCRIPTION
## Description

We were contacted by lifi to notify us of 100 req/s with zero sell amount. They have requested that we dont request quotes with a zero amount, which makes sense to prevent.

## Pull Request Type

- [x] :bug: Bug fix (Non-breaking Change: Fixes an issue)
- [ ] :hammer_and_wrench: Chore (Non-breaking Change: Doc updates, pkg upgrades, typos, etc..)
- [ ] :nail_care: New Feature (Breaking/Non-breaking Change)

## Issue (if applicable)

NA

## Risk

Low risk

## Testing

Check lifi quotes still work

### Engineering

See above

### Operations

See above

## Screenshots (if applicable)
