### PR TITLE
fix: borked walletconnect v2 send transaction confirmation

### DIFF
--- a/src/plugins/walletConnectToDapps/utils.ts
+++ b/src/plugins/walletConnectToDapps/utils.ts
@@ -57,13 +57,15 @@ export const getGasData = (
   fees: FeeDataEstimate<EvmChainId>,
 ) => {
   const { speed, customFee } = customTransactionData
-  return speed === 'custom' && customFee?.baseFee && customFee?.baseFee
+  return speed === 'custom' &&
+    bnOrZero(customFee?.baseFee).gt(0) &&
+    bnOrZero(customFee?.priorityFee).gt(0)
     ? {
         maxPriorityFeePerGas: convertNumberToHex(
-          bnOrZero(customFee.priorityFee).times(1e9).toString(), // to wei
+          bnOrZero(customFee!.priorityFee).times(1e9).toString(), // to wei
         ),
         maxFeePerGas: convertNumberToHex(
-          bnOrZero(customFee.baseFee).times(1e9).toString(), // to wei
+          bnOrZero(customFee!.baseFee).times(1e9).toString(), // to wei
         ),
       }
     : {

--- a/src/plugins/walletConnectToDapps/v2/components/modals/EIP155TransactionConfirmation.tsx
+++ b/src/plugins/walletConnectToDapps/v2/components/modals/EIP155TransactionConfirmation.tsx
@@ -33,7 +33,8 @@ export const EIP155TransactionConfirmation: FC<
   WalletConnectRequestModalProps<EthSendTransactionCallRequest | EthSignTransactionCallRequest>
 > = ({ onConfirm: handleConfirm, onReject: handleReject, state }) => {
   const { address, transaction, isInteractingWithContract, method } = useWalletConnectState(state)
-  assertIsTransactionParams(transaction)
+
+  transaction && assertIsTransactionParams(transaction)
 
   const { feeAsset, fees, feeAssetPrice } = useCallRequestEvmFees(state)
 
@@ -46,10 +47,11 @@ export const EIP155TransactionConfirmation: FC<
 
   const form = useForm<CustomTransactionData>({
     defaultValues: {
-      nonce: transaction.nonce ? convertHexToNumber(transaction.nonce).toString() : undefined,
-      gasLimit: transaction.gasLimit
-        ? convertHexToNumber(transaction.gasLimit).toString()
-        : undefined,
+      nonce: transaction?.nonce ? convertHexToNumber(transaction.nonce).toString() : undefined,
+      gasLimit:
+        transaction?.gasLimit ?? transaction?.gas
+          ? convertHexToNumber((transaction?.gasLimit ?? transaction?.gas)!).toString()
+          : undefined,
       speed: FeeDataKey.Average,
       customFee: {
         baseFee: '0',
@@ -65,6 +67,7 @@ export const EIP155TransactionConfirmation: FC<
       </Center>
     )
 
+  if (!transaction) return null
   return (
     <FormProvider {...form}>
       <ModalSection title='plugins.walletConnectToDapps.modal.sendTransaction.sendingFrom'>

--- a/src/plugins/walletConnectToDapps/v2/typeGuards.ts
+++ b/src/plugins/walletConnectToDapps/v2/typeGuards.ts
@@ -44,10 +44,7 @@ export const isTransactionParams = (
   !!transaction?.from &&
   !!transaction?.to &&
   !!transaction?.data &&
-  !!transaction?.value &&
-  !!transaction?.gasLimit &&
-  !!transaction?.gasPrice &&
-  !!transaction?.nonce
+  ((!!transaction?.gasLimit && !!transaction?.gasPrice) || !!transaction?.gas)
 
 export const assertIsTransactionParams: (
   transaction: TransactionParams | string | undefined,

--- a/src/plugins/walletConnectToDapps/v2/types.ts
+++ b/src/plugins/walletConnectToDapps/v2/types.ts
@@ -87,6 +87,7 @@ export enum WalletConnectModal {
 
 export type CustomTransactionData = {
   nonce?: string
+  gas?: string
   gasLimit?: string
   speed: WalletConnectFeeDataKey
   customFee?: {
@@ -100,6 +101,7 @@ export type TransactionParams = {
   to: string
   data: string
   gasLimit?: string
+  gas?: string
   gasPrice?: string
   value?: string
   nonce?: string


### PR DESCRIPTION
## Description

Makes WalletConnect transaction confirmation modal happy again, though the actual broadcasting still seems to be broken, with no error nor failed (or successful) XHR 

tl;dr is we were too strict/not accurate on what makes a transaction a transaction, and throwing at `isTransactionParams` time.

## Pull Request Type

- [x] :bug: Bug fix (Non-breaking Change: Fixes an issue)
- [ ] :hammer_and_wrench: Chore (Non-breaking Change: Doc updates, pkg upgrades, typos, etc..)
- [ ] :nail_care: New Feature (Breaking/Non-breaking Change)

## Issue (if applicable)

<!-----------------------------------------------------------------------------
If applicable, please link to the github issue and put `closes #XXXX` in your comment to auto-close the issue that your PR fixes.
------------------------------------------------------------------------------>

tackles https://github.com/shapeshift/web/issues/4976

## Risk

<!-----------------------------------------------------------------------------
Outline the scope of your changes and the risk associated with them. You must use your discretion as an engineer to determine the potential impact of your changes.

E.g. an upgrade to `hdwallet` or core state management would be considered higher risk, and might require a full regression test. UI or isolated view changes, or something behind a feature flag may have near zero risk. Small bug fixes might require testing isolated to the specific fix.
------------------------------------------------------------------------------>

Transaction detection and gas params may be broken, though WalletConnect to dApps seems to be entirely broken at the moment so can't make it more broken?

## Testing

<!-----------------------------------------------------------------------------
We treat every PR to be merged with the same scrutiny as if we were merging directly to production.

Your PR will not be merged if you do not complete the sections below for our engineering and operations teams to test.
------------------------------------------------------------------------------>

- Connect to Uniswap through WalletConnect to dApps
- Initiate a transaction
- The confirm modal should be shown, vs. the app previously crashing

### Engineering

<!-----------------------------------------------------------------------------
Include sufficient information here for an engineer to test your PR. This may include how to test locally, in a built environment, changes to infrastructure etc.
------------------------------------------------------------------------------>

- ☝🏽
- The broadcast not working may or may not be caused by local shenanigans - if you managed to actually broadcast the transaction, change the issue section to `closes`

### Operations

<!-----------------------------------------------------------------------------
If your changes have a user-facing impact, describe how a non-technical QA team can functionally test your changes in a preview environment.

If they are not user-facing please describe how to test for any regressions that may occur.
------------------------------------------------------------------------------>

- ☝🏽 

## Screenshots (if applicable)

- This diff

<img width="516" alt="image" src="https://github.com/shapeshift/web/assets/17035424/18d1387d-5916-4022-b312-33624c229b29">

- Prod

App crashes