### PR TITLE
chore: add TradeConfirm event to exchange swapper

### DIFF
--- a/src/components/MultiHopTrade/components/TradeConfirm/TradeConfirm.tsx
+++ b/src/components/MultiHopTrade/components/TradeConfirm/TradeConfirm.tsx
@@ -80,6 +80,7 @@ export const TradeConfirm = () => {
   const dispatch = useAppDispatch()
 
   const { showErrorToast } = useErrorHandler()
+  const eventData = getMixpanelEventData()
 
   const {
     number: { toFiat },
@@ -154,8 +155,6 @@ export const TradeConfirm = () => {
   )
 
   useEffect(() => {
-    const eventData = getMixpanelEventData()
-
     if (!mixpanel || !eventData) return
     if (status === TxStatus.Confirmed) {
       mixpanel.track(MixPanelEvents.TradeSuccess, eventData)
@@ -163,7 +162,7 @@ export const TradeConfirm = () => {
     if (status === TxStatus.Failed) {
       mixpanel.track(MixPanelEvents.TradeFailed, eventData)
     }
-  }, [mixpanel, status])
+  }, [eventData, mixpanel, status])
 
   const handleBack = useCallback(() => {
     if (sellTxHash) {
@@ -185,6 +184,11 @@ export const TradeConfirm = () => {
       }
 
       await executeTrade()
+      // only track after swapper successfully executes trade
+      // otherwise unsigned txs will be tracked as confirmed trades
+      if (mixpanel && eventData) {
+        mixpanel.track(MixPanelEvents.TradeConfirm, eventData)
+      }
     } catch (e) {
       showErrorToast(e)
       dispatch(tradeQuoteSlice.actions.clear())
@@ -192,10 +196,12 @@ export const TradeConfirm = () => {
     }
   }, [
     dispatch,
+    eventData,
     executeTrade,
     handleBack,
     history,
     isConnected,
+    mixpanel,
     showErrorToast,
     wallet,
     walletDispatch,


### PR DESCRIPTION
## Description

Add the `TradeConfirm` Mixpanel event to the exchange swapper.

## Pull Request Type

- [ ] :bug: Bug fix (Non-breaking Change: Fixes an issue)
- [x] :hammer_and_wrench: Chore (Non-breaking Change: Doc updates, pkg upgrades, typos, etc..)
- [ ] :nail_care: New Feature (Breaking/Non-breaking Change)

## Issue (if applicable)

N/A

## Risk

Very small.

## Testing

`Daily Trade Volume (before currency tracking)` and `Daily Trade Donation Volume ($USD)`, among other reports that relied on the TradeConfirm JSON, should be great again.

### Engineering

☝️

### Operations

☝️

## Screenshots (if applicable)

N/A
