### PR TITLE
chore: add LiFi SDK-specific mixpanel request data

### DIFF
--- a/src/lib/swapper/swappers/LifiSwapper/LifiSwapper.ts
+++ b/src/lib/swapper/swappers/LifiSwapper/LifiSwapper.ts
@@ -154,7 +154,12 @@ export class LifiSwapper implements Swapper<EvmChainId> {
       return Ok({ sellTxid: tradeResult.tradeId })
     }
 
-    getMixPanel()?.track(MixPanelEvents.SwapperApiRequest, { swapper: SwapperName.LIFI })
+    getMixPanel()?.track(MixPanelEvents.SwapperApiRequest, {
+      swapper: SwapperName.LIFI,
+      method: 'get',
+      // Note, this may change if the Li.Fi SDK changes
+      url: 'https://li.quest/v1/status',
+    })
     const statusResponse = await getLifi().getStatus(getStatusRequest)
 
     return Ok({

--- a/src/lib/swapper/swappers/LifiSwapper/endpoints.ts
+++ b/src/lib/swapper/swappers/LifiSwapper/endpoints.ts
@@ -99,7 +99,12 @@ export const lifiApi: Swapper2Api = {
       toChain: lifiRoute.toChainId,
     }
 
-    getMixPanel()?.track(MixPanelEvents.SwapperApiRequest, { swapper: SwapperName.LIFI })
+    getMixPanel()?.track(MixPanelEvents.SwapperApiRequest, {
+      swapper: SwapperName.LIFI,
+      method: 'get',
+      // Note, this may change if the Li.Fi SDK changes
+      url: 'https://li.quest/v1/status',
+    })
     const statusResponse = await getLifi().getStatus(getStatusRequest)
 
     const status = (() => {

--- a/src/lib/swapper/swappers/LifiSwapper/executeTrade/executeTrade.ts
+++ b/src/lib/swapper/swappers/LifiSwapper/executeTrade/executeTrade.ts
@@ -51,7 +51,12 @@ export const executeTrade = async ({
   const transactionRequest = await (async () => {
     try {
       if (startStep?.transactionRequest) return Ok(startStep.transactionRequest)
-      getMixPanel()?.track(MixPanelEvents.SwapperApiRequest, { swapper: SwapperName.LIFI })
+      getMixPanel()?.track(MixPanelEvents.SwapperApiRequest, {
+        swapper: SwapperName.LIFI,
+        method: 'get',
+        // Note, this may change if the Li.Fi SDK changes
+        url: 'https://li.quest/v1/advanced/stepTransaction',
+      })
       return Ok((await lifi.getStepTransaction(startStep)).transactionRequest)
     } catch (err) {
       return Err(

--- a/src/lib/swapper/swappers/LifiSwapper/getTradeQuote/getTradeQuote.ts
+++ b/src/lib/swapper/swappers/LifiSwapper/getTradeQuote/getTradeQuote.ts
@@ -90,7 +90,12 @@ export async function getTradeQuote(
       },
     }
 
-    getMixPanel()?.track(MixPanelEvents.SwapperApiRequest, { swapper: SwapperName.LIFI })
+    getMixPanel()?.track(MixPanelEvents.SwapperApiRequest, {
+      swapper: SwapperName.LIFI,
+      method: 'get',
+      // Note, this may change if the Li.Fi SDK changes
+      url: 'https://li.quest/v1/advanced/routes',
+    })
     const routesResponse = await lifi.getRoutes(routesRequest).catch((e: LifiError) => {
       const code = (() => {
         switch (e.code) {

--- a/src/lib/swapper/swappers/LifiSwapper/utils/getLifiChainMap.ts
+++ b/src/lib/swapper/swappers/LifiSwapper/utils/getLifiChainMap.ts
@@ -19,7 +19,12 @@ export const getLifiChainMap = async (): Promise<
     chainId => Number(fromChainId(chainId).chainReference) as LifiChainId,
   )
 
-  getMixPanel()?.track(MixPanelEvents.SwapperApiRequest, { swapper: SwapperName.LIFI })
+  getMixPanel()?.track(MixPanelEvents.SwapperApiRequest, {
+    swapper: SwapperName.LIFI,
+    method: 'get',
+    // Note, this may change if the Li.Fi SDK changes
+    url: 'https://li.quest/v1/chains',
+  })
   const { chains } = await getLifi().getPossibilities({
     include: ['chains'],
     chains: supportedChainRefs,

--- a/src/lib/swapper/swappers/LifiSwapper/utils/getUnsignedTx/getUnsignedTx.ts
+++ b/src/lib/swapper/swappers/LifiSwapper/utils/getUnsignedTx/getUnsignedTx.ts
@@ -22,7 +22,12 @@ const createBuildSendApiTxInput = async (
   const lifi = getLifi()
 
   const transactionRequest: providers.TransactionRequest = await (async () => {
-    getMixPanel()?.track(MixPanelEvents.SwapperApiRequest, { swapper: SwapperName.LIFI })
+    getMixPanel()?.track(MixPanelEvents.SwapperApiRequest, {
+      swapper: SwapperName.LIFI,
+      method: 'get',
+      // Note, this may change if the Li.Fi SDK changes
+      url: 'https://li.quest/v1/advanced/stepTransaction',
+    })
     const { transactionRequest: newTransactionRequest } = await lifi.getStepTransaction(lifiStep)
     return newTransactionRequest ?? {}
   })()


### PR DESCRIPTION
## Description

Add URL and method event data for Mixpanel events triggered by the LiFi SDK.

## Pull Request Type

- [ ] :bug: Bug fix (Non-breaking Change: Fixes an issue)
- [x] :hammer_and_wrench: Chore (Non-breaking Change: Doc updates, pkg upgrades, typos, etc..)
- [ ] :nail_care: New Feature (Breaking/Non-breaking Change)

## Issue (if applicable)

N/A

## Risk

Very small.

## Testing

Mixpanel events for `Swapper API request` where the swapper is LiFi should now have `method` and `url` properties. 

### Engineering

☝️

### Operations

N/A

## Screenshots (if applicable)

<img width="1537" alt="Screenshot 2023-07-26 at 10 03 52 am" src="https://github.com/shapeshift/web/assets/97164662/e0f00e8c-f61f-4f4f-9c67-9f60e323d19b">
