### PR TITLE
chore: do not track api requests via MixPanel

### DIFF
--- a/src/lib/swapper/swappers/LifiSwapper/LifiSwapper.ts
+++ b/src/lib/swapper/swappers/LifiSwapper/LifiSwapper.ts
@@ -6,8 +6,6 @@ import type { Result } from '@sniptt/monads'
 import { Ok } from '@sniptt/monads'
 import { bnOrZero } from 'lib/bignumber/bignumber'
 import { toBaseUnit } from 'lib/math'
-import { getMixPanel } from 'lib/mixpanel/mixPanelSingleton'
-import { MixPanelEvents } from 'lib/mixpanel/types'
 import type {
   BuildTradeInput,
   BuyAssetBySellIdInput,
@@ -154,12 +152,12 @@ export class LifiSwapper implements Swapper<EvmChainId> {
       return Ok({ sellTxid: tradeResult.tradeId })
     }
 
-    getMixPanel()?.track(MixPanelEvents.SwapperApiRequest, {
-      swapper: SwapperName.LIFI,
-      method: 'get',
-      // Note, this may change if the Li.Fi SDK changes
-      url: 'https://li.quest/v1/status',
-    })
+    // getMixPanel()?.track(MixPanelEvents.SwapperApiRequest, {
+    //   swapper: SwapperName.LIFI,
+    //   method: 'get',
+    //   // Note, this may change if the Li.Fi SDK changes
+    //   url: 'https://li.quest/v1/status',
+    // })
     const statusResponse = await getLifi().getStatus(getStatusRequest)
 
     return Ok({

--- a/src/lib/swapper/swappers/LifiSwapper/endpoints.ts
+++ b/src/lib/swapper/swappers/LifiSwapper/endpoints.ts
@@ -5,8 +5,6 @@ import { TxStatus } from '@shapeshiftoss/unchained-client'
 import type { Result } from '@sniptt/monads/build'
 import { Err } from '@sniptt/monads/build'
 import type { Asset } from 'lib/asset-service'
-import { getMixPanel } from 'lib/mixpanel/mixPanelSingleton'
-import { MixPanelEvents } from 'lib/mixpanel/types'
 import type {
   GetEvmTradeQuoteInput,
   GetTradeQuoteInput,
@@ -15,7 +13,7 @@ import type {
   Swapper2Api,
   TradeQuote2,
 } from 'lib/swapper/api'
-import { makeSwapErrorRight, SwapErrorType, SwapperName } from 'lib/swapper/api'
+import { makeSwapErrorRight, SwapErrorType } from 'lib/swapper/api'
 import { getLifi } from 'lib/swapper/swappers/LifiSwapper/utils/getLifi'
 
 import { getTradeQuote } from './getTradeQuote/getTradeQuote'
@@ -99,12 +97,12 @@ export const lifiApi: Swapper2Api = {
       toChain: lifiRoute.toChainId,
     }
 
-    getMixPanel()?.track(MixPanelEvents.SwapperApiRequest, {
-      swapper: SwapperName.LIFI,
-      method: 'get',
-      // Note, this may change if the Li.Fi SDK changes
-      url: 'https://li.quest/v1/status',
-    })
+    // getMixPanel()?.track(MixPanelEvents.SwapperApiRequest, {
+    //   swapper: SwapperName.LIFI,
+    //   method: 'get',
+    //   // Note, this may change if the Li.Fi SDK changes
+    //   url: 'https://li.quest/v1/status',
+    // })
     const statusResponse = await getLifi().getStatus(getStatusRequest)
 
     const status = (() => {

--- a/src/lib/swapper/swappers/LifiSwapper/executeTrade/executeTrade.ts
+++ b/src/lib/swapper/swappers/LifiSwapper/executeTrade/executeTrade.ts
@@ -3,10 +3,8 @@ import type { Result } from '@sniptt/monads'
 import { Err, Ok } from '@sniptt/monads'
 import { getChainAdapterManager } from 'context/PluginProvider/chainAdapterSingleton'
 import { bn } from 'lib/bignumber/bignumber'
-import { getMixPanel } from 'lib/mixpanel/mixPanelSingleton'
-import { MixPanelEvents } from 'lib/mixpanel/types'
 import type { SwapErrorRight, TradeResult } from 'lib/swapper/api'
-import { makeSwapErrorRight, SwapErrorType, SwapperName } from 'lib/swapper/api'
+import { makeSwapErrorRight, SwapErrorType } from 'lib/swapper/api'
 import { getLifi } from 'lib/swapper/swappers/LifiSwapper/utils/getLifi'
 import type { LifiExecuteTradeInput } from 'lib/swapper/swappers/LifiSwapper/utils/types'
 import { buildAndBroadcast, createBuildCustomTxInput, isEvmChainAdapter } from 'lib/utils/evm'
@@ -51,12 +49,12 @@ export const executeTrade = async ({
   const transactionRequest = await (async () => {
     try {
       if (startStep?.transactionRequest) return Ok(startStep.transactionRequest)
-      getMixPanel()?.track(MixPanelEvents.SwapperApiRequest, {
-        swapper: SwapperName.LIFI,
-        method: 'get',
-        // Note, this may change if the Li.Fi SDK changes
-        url: 'https://li.quest/v1/advanced/stepTransaction',
-      })
+      // getMixPanel()?.track(MixPanelEvents.SwapperApiRequest, {
+      //   swapper: SwapperName.LIFI,
+      //   method: 'get',
+      //   // Note, this may change if the Li.Fi SDK changes
+      //   url: 'https://li.quest/v1/advanced/stepTransaction',
+      // })
       return Ok((await lifi.getStepTransaction(startStep)).transactionRequest)
     } catch (err) {
       return Err(

--- a/src/lib/swapper/swappers/LifiSwapper/getTradeQuote/getTradeQuote.ts
+++ b/src/lib/swapper/swappers/LifiSwapper/getTradeQuote/getTradeQuote.ts
@@ -8,8 +8,6 @@ import { Err, Ok } from '@sniptt/monads'
 import { getDefaultSlippagePercentageForSwapper } from 'constants/constants'
 import type { Asset } from 'lib/asset-service'
 import { bn, bnOrZero, convertPrecision } from 'lib/bignumber/bignumber'
-import { getMixPanel } from 'lib/mixpanel/mixPanelSingleton'
-import { MixPanelEvents } from 'lib/mixpanel/types'
 import type { GetEvmTradeQuoteInput, SwapErrorRight } from 'lib/swapper/api'
 import { makeSwapErrorRight, SwapError, SwapErrorType, SwapperName } from 'lib/swapper/api'
 import {
@@ -90,12 +88,12 @@ export async function getTradeQuote(
       },
     }
 
-    getMixPanel()?.track(MixPanelEvents.SwapperApiRequest, {
-      swapper: SwapperName.LIFI,
-      method: 'get',
-      // Note, this may change if the Li.Fi SDK changes
-      url: 'https://li.quest/v1/advanced/routes',
-    })
+    // getMixPanel()?.track(MixPanelEvents.SwapperApiRequest, {
+    //   swapper: SwapperName.LIFI,
+    //   method: 'get',
+    //   // Note, this may change if the Li.Fi SDK changes
+    //   url: 'https://li.quest/v1/advanced/routes',
+    // })
     const routesResponse = await lifi.getRoutes(routesRequest).catch((e: LifiError) => {
       const code = (() => {
         switch (e.code) {

--- a/src/lib/swapper/swappers/LifiSwapper/utils/getLifiChainMap.ts
+++ b/src/lib/swapper/swappers/LifiSwapper/utils/getLifiChainMap.ts
@@ -4,10 +4,8 @@ import { fromChainId } from '@shapeshiftoss/caip'
 import { evmChainIds } from '@shapeshiftoss/chain-adapters'
 import type { Result } from '@sniptt/monads/build'
 import { Err, Ok } from '@sniptt/monads/build'
-import { getMixPanel } from 'lib/mixpanel/mixPanelSingleton'
-import { MixPanelEvents } from 'lib/mixpanel/types'
 import type { SwapErrorRight } from 'lib/swapper/api'
-import { makeSwapErrorRight, SwapperName } from 'lib/swapper/api'
+import { makeSwapErrorRight } from 'lib/swapper/api'
 
 import { createLifiChainMap } from './createLifiChainMap/createLifiChainMap'
 import { getLifi } from './getLifi'
@@ -19,12 +17,12 @@ export const getLifiChainMap = async (): Promise<
     chainId => Number(fromChainId(chainId).chainReference) as LifiChainId,
   )
 
-  getMixPanel()?.track(MixPanelEvents.SwapperApiRequest, {
-    swapper: SwapperName.LIFI,
-    method: 'get',
-    // Note, this may change if the Li.Fi SDK changes
-    url: 'https://li.quest/v1/chains',
-  })
+  // getMixPanel()?.track(MixPanelEvents.SwapperApiRequest, {
+  //   swapper: SwapperName.LIFI,
+  //   method: 'get',
+  //   // Note, this may change if the Li.Fi SDK changes
+  //   url: 'https://li.quest/v1/chains',
+  // })
   const { chains } = await getLifi().getPossibilities({
     include: ['chains'],
     chains: supportedChainRefs,

--- a/src/lib/swapper/swappers/LifiSwapper/utils/getUnsignedTx/getUnsignedTx.ts
+++ b/src/lib/swapper/swappers/LifiSwapper/utils/getUnsignedTx/getUnsignedTx.ts
@@ -8,9 +8,7 @@ import type {
 import type { providers } from 'ethers'
 import { getChainAdapterManager } from 'context/PluginProvider/chainAdapterSingleton'
 import type { Asset } from 'lib/asset-service'
-import { getMixPanel } from 'lib/mixpanel/mixPanelSingleton'
-import { MixPanelEvents } from 'lib/mixpanel/types'
-import { SwapError, SwapErrorType, SwapperName } from 'lib/swapper/api'
+import { SwapError, SwapErrorType } from 'lib/swapper/api'
 import { getLifi } from 'lib/swapper/swappers/LifiSwapper/utils/getLifi'
 import { isEvmChainAdapter } from 'lib/utils/evm'
 
@@ -22,12 +20,12 @@ const createBuildSendApiTxInput = async (
   const lifi = getLifi()
 
   const transactionRequest: providers.TransactionRequest = await (async () => {
-    getMixPanel()?.track(MixPanelEvents.SwapperApiRequest, {
-      swapper: SwapperName.LIFI,
-      method: 'get',
-      // Note, this may change if the Li.Fi SDK changes
-      url: 'https://li.quest/v1/advanced/stepTransaction',
-    })
+    // getMixPanel()?.track(MixPanelEvents.SwapperApiRequest, {
+    //   swapper: SwapperName.LIFI,
+    //   method: 'get',
+    //   // Note, this may change if the Li.Fi SDK changes
+    //   url: 'https://li.quest/v1/advanced/stepTransaction',
+    // })
     const { transactionRequest: newTransactionRequest } = await lifi.getStepTransaction(lifiStep)
     return newTransactionRequest ?? {}
   })()

--- a/src/lib/swapper/utils.ts
+++ b/src/lib/swapper/utils.ts
@@ -4,8 +4,6 @@ import { AssertionError } from 'assert'
 import type { AxiosInstance, AxiosRequestConfig, AxiosResponse } from 'axios'
 import type { ISetupCache } from 'axios-cache-adapter'
 import { setupCache } from 'axios-cache-adapter'
-import { getMixPanel } from 'lib/mixpanel/mixPanelSingleton'
-import { MixPanelEvents } from 'lib/mixpanel/types'
 import { AsyncResultOf } from 'lib/utils'
 
 import type { SwapErrorRight, SwapperName } from './api'
@@ -44,7 +42,7 @@ interface ProxyConstructor {
 }
 declare var Proxy: ProxyConstructor
 
-export const makeSwapperAxiosServiceMonadic = (service: AxiosInstance, swapperName: SwapperName) =>
+export const makeSwapperAxiosServiceMonadic = (service: AxiosInstance, _swapperName: SwapperName) =>
   new Proxy<
     AxiosInstance,
     {
@@ -62,11 +60,11 @@ export const makeSwapperAxiosServiceMonadic = (service: AxiosInstance, swapperNa
     get: (trappedAxios, method: 'get' | 'post') => {
       const originalMethodPromise = trappedAxios[method]
       return async (...args: [url: string, dataOrConfig?: any, dataOrConfig?: any]) => {
-        getMixPanel()?.track(MixPanelEvents.SwapperApiRequest, {
-          swapper: swapperName,
-          url: args[0],
-          method,
-        })
+        // getMixPanel()?.track(MixPanelEvents.SwapperApiRequest, {
+        //   swapper: swapperName,
+        //   url: args[0],
+        //   method,
+        // })
         const result = await AsyncResultOf(originalMethodPromise(...args))
 
         return result


### PR DESCRIPTION
## Description

API tracking in Mixpanel is costly us a motza (Over $140 a day to track 1m+ requests). It's the wrong tool for the job.

Comments the logic out for now so we can pause and re-assess without totally removing the code. 

## Pull Request Type

- [ ] :bug: Bug fix (Non-breaking Change: Fixes an issue)
- [x] :hammer_and_wrench: Chore (Non-breaking Change: Doc updates, pkg upgrades, typos, etc..)
- [ ] :nail_care: New Feature (Breaking/Non-breaking Change)

## Issue (if applicable)

N/A

## Risk

Almost 0.

## Testing

`SwapperApiRequest` mixpanel events should stop being reported.

### Engineering

☝️

### Operations

☝️

## Screenshots (if applicable)

<img width="1243" alt="Screenshot 2023-07-27 at 10 58 46 am" src="https://github.com/shapeshift/web/assets/97164662/75ed275f-6cd4-4c82-b27f-a0b2fce5376f">
