### PR TITLE
perf: api request optimisations

### DIFF
--- a/src/components/MultiHopTrade/hooks/quoteValidation/useActiveQuoteStatus.tsx
+++ b/src/components/MultiHopTrade/hooks/quoteValidation/useActiveQuoteStatus.tsx
@@ -6,7 +6,10 @@ import type { QuoteStatus } from 'components/MultiHopTrade/types'
 import { ActiveQuoteStatus } from 'components/MultiHopTrade/types'
 import { bnOrZero } from 'lib/bignumber/bignumber'
 import { SwapErrorType, SwapperName } from 'lib/swapper/api'
-import { selectBuyAsset } from 'state/slices/swappersSlice/selectors'
+import {
+  selectBuyAsset,
+  selectSellAmountCryptoPrecision,
+} from 'state/slices/swappersSlice/selectors'
 import {
   selectActiveQuote,
   selectActiveQuoteError,
@@ -28,11 +31,17 @@ export const useActiveQuoteStatus = (): QuoteStatus => {
   const lastHopSellFeeAsset = useAppSelector(selectLastHopSellFeeAsset)
   const minimumCryptoHuman = useAppSelector(selectMinimumSellAmountCryptoHuman)
   const tradeBuyAsset = useAppSelector(selectBuyAsset)
+  const sellAmountCryptoPrecision = useAppSelector(selectSellAmountCryptoPrecision)
 
   const insufficientBalanceProtocolFeeMeta = useInsufficientBalanceProtocolFeeMeta()
 
   const activeQuote = useAppSelector(selectActiveQuote)
   const activeQuoteError = useAppSelector(selectActiveQuoteError)
+
+  const hasUserEnteredAmount = useMemo(
+    () => bnOrZero(sellAmountCryptoPrecision).gt(0),
+    [sellAmountCryptoPrecision],
+  )
 
   // TODO: implement properly once we've got api loading state rigged up
   const isLoading = useMemo(
@@ -41,7 +50,7 @@ export const useActiveQuoteStatus = (): QuoteStatus => {
   )
 
   const quoteErrors: ActiveQuoteStatus[] = useMemo(() => {
-    if (isLoading) return []
+    if (isLoading || hasUserEnteredAmount) return []
     const errors: ActiveQuoteStatus[] = []
     if (activeQuoteError) {
       // Map known swapper errors to quote status

--- a/src/components/MultiHopTrade/hooks/quoteValidation/useActiveQuoteStatus.tsx
+++ b/src/components/MultiHopTrade/hooks/quoteValidation/useActiveQuoteStatus.tsx
@@ -83,7 +83,7 @@ export const useActiveQuoteStatus = (): QuoteStatus => {
         case ActiveQuoteStatus.NoConnectedWallet:
           return 'common.connectWallet'
         case ActiveQuoteStatus.BuyAssetNotNotSupportedByWallet:
-          return ['trade.quote.noReceiveAddress', { assetSymbol: tradeBuyAsset?.symbol }]
+          return ['trade.errors.noReceiveAddress', { assetSymbol: tradeBuyAsset?.symbol }]
         case ActiveQuoteStatus.InsufficientSellAssetBalance:
           return 'common.insufficientFunds'
         case ActiveQuoteStatus.InsufficientFirstHopFeeAssetBalance:

--- a/src/components/MultiHopTrade/hooks/quoteValidation/useActiveQuoteStatus.tsx
+++ b/src/components/MultiHopTrade/hooks/quoteValidation/useActiveQuoteStatus.tsx
@@ -66,7 +66,7 @@ export const useActiveQuoteStatus = (): QuoteStatus => {
       errors.push(ActiveQuoteStatus.NoQuotesAvailable)
     }
     return errors
-  }, [activeQuoteError, isLoading, activeQuote, validationErrors])
+  }, [isLoading, hasUserEnteredAmount, activeQuoteError, activeQuote, validationErrors])
 
   const minimumAmountUserMessage = `${bnOrZero(minimumCryptoHuman).decimalPlaces(6)} ${
     firstHopSellAsset?.symbol

--- a/src/components/MultiHopTrade/hooks/quoteValidation/useQuoteValidationErrors.tsx
+++ b/src/components/MultiHopTrade/hooks/quoteValidation/useQuoteValidationErrors.tsx
@@ -97,7 +97,9 @@ export const useQuoteValidationErrors = (): ActiveQuoteStatus[] => {
         !isTradingActiveOnBuyPool && ActiveQuoteStatus.TradingInactiveOnBuyChain,
         feesExceedsSellAmount && ActiveQuoteStatus.SellAmountBelowTradeFee,
         insufficientBalanceProtocolFeeMeta && ActiveQuoteStatus.InsufficientFundsForProtocolFee,
-        quotes.length === 0 && ActiveQuoteStatus.NoQuotesAvailable,
+        quotes.length === 0 &&
+          bnOrZero(sellAmountCryptoBaseUnit).gt(0) &&
+          ActiveQuoteStatus.NoQuotesAvailable,
       ].filter(isTruthy),
     [
       feesExceedsSellAmount,

--- a/src/components/MultiHopTrade/hooks/quoteValidation/useQuoteValidationErrors.tsx
+++ b/src/components/MultiHopTrade/hooks/quoteValidation/useQuoteValidationErrors.tsx
@@ -113,6 +113,7 @@ export const useQuoteValidationErrors = (): ActiveQuoteStatus[] => {
       manualReceiveAddress,
       quotes.length,
       receiveAddress,
+      sellAmountCryptoBaseUnit,
       wallet,
       walletSupportsBuyAssetChain,
       walletSupportsSellAssetChain,

--- a/src/components/MultiHopTrade/hooks/useGetTradeQuotes.tsx
+++ b/src/components/MultiHopTrade/hooks/useGetTradeQuotes.tsx
@@ -169,7 +169,6 @@ export const useGetTradeQuotes = () => {
 
   useEffect(() => {
     const interval = setInterval(() => {
-      console.log('document.hasFocus()', document.hasFocus())
       setHasFocus(document.hasFocus())
     }, 2000)
     return () => clearInterval(interval)

--- a/src/components/MultiHopTrade/hooks/useGetTradeQuotes.tsx
+++ b/src/components/MultiHopTrade/hooks/useGetTradeQuotes.tsx
@@ -83,6 +83,7 @@ export const useGetTradeQuotes = () => {
   const [tradeQuoteInput, setTradeQuoteInput] = useState<GetTradeQuoteInput | typeof skipToken>(
     skipToken,
   )
+  const [hasFocus, setHasFocus] = useState(document.hasFocus())
   const debouncedTradeQuoteInput = useDebounce(tradeQuoteInput, 500)
   const sellAsset = useAppSelector(selectSellAsset)
   const buyAsset = useAppSelector(selectBuyAsset)
@@ -166,8 +167,16 @@ export const useGetTradeQuotes = () => {
     receiveAccountMetadata?.bip44Params,
   ])
 
+  useEffect(() => {
+    const interval = setInterval(() => {
+      console.log('document.hasFocus()', document.hasFocus())
+      setHasFocus(document.hasFocus())
+    }, 2000)
+    return () => clearInterval(interval)
+  }, [])
+
   const { data } = useGetTradeQuoteQuery(debouncedTradeQuoteInput, {
-    pollingInterval: 20000,
+    pollingInterval: hasFocus ? 20000 : undefined,
     /*
       If we don't refresh on arg change might select a cached result with an old "started_at" timestamp
       We can remove refetchOnMountOrArgChange if we want to make better use of the cache, and we have a better way to select from the cache.

--- a/src/components/MultiHopTrade/hooks/useGetTradeQuotes.tsx
+++ b/src/components/MultiHopTrade/hooks/useGetTradeQuotes.tsx
@@ -8,6 +8,7 @@ import { useReceiveAddress } from 'components/MultiHopTrade/hooks/useReceiveAddr
 import { getTradeQuoteArgs } from 'components/Trade/hooks/useSwapper/getTradeQuoteArgs'
 import { useDebounce } from 'hooks/useDebounce/useDebounce'
 import { useWallet } from 'hooks/useWallet/useWallet'
+import { bnOrZero } from 'lib/bignumber/bignumber'
 import { getMixPanel } from 'lib/mixpanel/mixPanelSingleton'
 import { MixPanelEvents } from 'lib/mixpanel/types'
 import type { GetTradeQuoteInput, SwapperName } from 'lib/swapper/api'
@@ -132,7 +133,9 @@ export const useGetTradeQuotes = () => {
 
         // if the quote input args changed, reset the selected swapper and update the trade quote args
         if (!isEqual(tradeQuoteInput, updatedTradeQuoteInput ?? skipToken)) {
-          setTradeQuoteInput(updatedTradeQuoteInput ?? skipToken)
+          updatedTradeQuoteInput && bnOrZero(sellAmountCryptoPrecision).gt(0)
+            ? setTradeQuoteInput(updatedTradeQuoteInput)
+            : setTradeQuoteInput(skipToken)
 
           // If only the affiliateBps changed, we've toggled the donation checkbox - don't reset the swapper name
           if (isEqualExceptAffiliateBps(tradeQuoteInput, updatedTradeQuoteInput)) {


### PR DESCRIPTION
## Description

- No longer fetches quotes when the sell amount is 0, and updates UI to hide related elements when this is the case
- Updates polling for the `tradeQuoteQuery` to only poll if the window is currently in focus

Note to devs, we won't poll quotes now if you're focused on dev console.

## Pull Request Type

- [ ] :bug: Bug fix (Non-breaking Change: Fixes an issue)
- [x] :hammer_and_wrench: Chore (Non-breaking Change: Doc updates, pkg upgrades, typos, etc..)
- [ ] :nail_care: New Feature (Breaking/Non-breaking Change)

## Issue (if applicable)

Closes https://github.com/shapeshift/web/issues/4989

## Risk

- Risk that we don't get quotes whne we should
- Risk that we show/don't show UI when we should/shouldn't

## Testing

Check swapper for all combinations of:
- when a 0 sell amount is entered, and not entered
- when window is focused, and not focused

### Engineering

☝️

### Operations

☝️

## Screenshots (if applicable)

N/A
