### PR TITLE
perf: conditional keyring event listeners

### DIFF
--- a/src/components/Layout/Header/NavBar/Native/BackupPassphraseModal/BackupPassphraseStart.tsx
+++ b/src/components/Layout/Header/NavBar/Native/BackupPassphraseModal/BackupPassphraseStart.tsx
@@ -15,7 +15,7 @@ export const BackupPassphraseStart: React.FC<LocationState> = props => {
 
   useEffect(() => {
     ;(async () => {
-      switch (state.type) {
+      switch (state.connectingType) {
         case KeyManager.Native:
           // Native wallets require a password to decrypt
           history.push(BackupPassphraseRoutes.Password)
@@ -35,7 +35,7 @@ export const BackupPassphraseStart: React.FC<LocationState> = props => {
           break
       }
     })()
-  }, [history, revocableWallet, state.walletInfo, state.type])
+  }, [history, revocableWallet, state.walletInfo, state.connectingType])
 
   return error ? <div>{error}</div> : null
 }

--- a/src/components/Layout/Header/NavBar/Native/BackupPassphraseModal/BackupPassphraseStart.tsx
+++ b/src/components/Layout/Header/NavBar/Native/BackupPassphraseModal/BackupPassphraseStart.tsx
@@ -15,7 +15,7 @@ export const BackupPassphraseStart: React.FC<LocationState> = props => {
 
   useEffect(() => {
     ;(async () => {
-      switch (state.connectingType) {
+      switch (state.modalType) {
         case KeyManager.Native:
           // Native wallets require a password to decrypt
           history.push(BackupPassphraseRoutes.Password)
@@ -35,7 +35,7 @@ export const BackupPassphraseStart: React.FC<LocationState> = props => {
           break
       }
     })()
-  }, [history, revocableWallet, state.walletInfo, state.connectingType])
+  }, [history, revocableWallet, state.walletInfo, state.modalType])
 
   return error ? <div>{error}</div> : null
 }

--- a/src/components/Layout/Header/NavBar/Notifications.tsx
+++ b/src/components/Layout/Header/NavBar/Notifications.tsx
@@ -21,7 +21,7 @@ export const Notifications = () => {
   const isWhereverEnabled = useFeatureFlag('Wherever')
   const { colorMode } = useColorMode()
   const {
-    state: { wallet, connectedType },
+    state: { wallet, connectingType },
   } = useWallet()
 
   const [addressNList, setAddressNList] = useState<BIP32Path>()
@@ -110,7 +110,7 @@ export const Notifications = () => {
     !isWhereverEnabled ||
     !ethAddress ||
     !wallet ||
-    !eip712SupportedWallets.includes(connectedType as KeyManager) ||
+    !eip712SupportedWallets.includes(connectingType as KeyManager) ||
     !supportsETH(wallet)
   )
     return null

--- a/src/components/Layout/Header/NavBar/Notifications.tsx
+++ b/src/components/Layout/Header/NavBar/Notifications.tsx
@@ -21,7 +21,7 @@ export const Notifications = () => {
   const isWhereverEnabled = useFeatureFlag('Wherever')
   const { colorMode } = useColorMode()
   const {
-    state: { wallet, type },
+    state: { wallet, connectedType },
   } = useWallet()
 
   const [addressNList, setAddressNList] = useState<BIP32Path>()
@@ -110,7 +110,7 @@ export const Notifications = () => {
     !isWhereverEnabled ||
     !ethAddress ||
     !wallet ||
-    !eip712SupportedWallets.includes(type as KeyManager) ||
+    !eip712SupportedWallets.includes(connectedType as KeyManager) ||
     !supportsETH(wallet)
   )
     return null

--- a/src/components/Layout/Header/NavBar/Notifications.tsx
+++ b/src/components/Layout/Header/NavBar/Notifications.tsx
@@ -21,7 +21,7 @@ export const Notifications = () => {
   const isWhereverEnabled = useFeatureFlag('Wherever')
   const { colorMode } = useColorMode()
   const {
-    state: { wallet, connectingType },
+    state: { wallet, modalType },
   } = useWallet()
 
   const [addressNList, setAddressNList] = useState<BIP32Path>()
@@ -110,7 +110,7 @@ export const Notifications = () => {
     !isWhereverEnabled ||
     !ethAddress ||
     !wallet ||
-    !eip712SupportedWallets.includes(connectingType as KeyManager) ||
+    !eip712SupportedWallets.includes(modalType as KeyManager) ||
     !supportsETH(wallet)
   )
     return null

--- a/src/components/Layout/Header/NavBar/UserMenu.tsx
+++ b/src/components/Layout/Header/NavBar/UserMenu.tsx
@@ -149,8 +149,6 @@ export const UserMenu: React.FC<{ onClick?: () => void }> = ({ onClick }) => {
   const { isConnected, isDemoWallet, walletInfo, connectedType, isLocked, isLoadingLocalWallet } =
     state
 
-  console.log('xxx state', { state, walletInfo, connectedType })
-
   if (isLocked) disconnect()
   const hasWallet = Boolean(walletInfo?.deviceId)
   const handleConnect = useCallback(() => {

--- a/src/components/Layout/Header/NavBar/UserMenu.tsx
+++ b/src/components/Layout/Header/NavBar/UserMenu.tsx
@@ -149,6 +149,8 @@ export const UserMenu: React.FC<{ onClick?: () => void }> = ({ onClick }) => {
   const { isConnected, isDemoWallet, walletInfo, connectedType, isLocked, isLoadingLocalWallet } =
     state
 
+  console.log('xxx state', { state, walletInfo, connectedType })
+
   if (isLocked) disconnect()
   const hasWallet = Boolean(walletInfo?.deviceId)
   const handleConnect = useCallback(() => {

--- a/src/components/Layout/Header/NavBar/UserMenu.tsx
+++ b/src/components/Layout/Header/NavBar/UserMenu.tsx
@@ -44,7 +44,7 @@ const NoWallet = ({ onClick }: { onClick: () => void }) => {
 export type WalletConnectedProps = {
   onDisconnect: () => void
   onSwitchProvider: () => void
-} & Pick<InitialState, 'walletInfo' | 'isConnected' | 'type'>
+} & Pick<InitialState, 'walletInfo' | 'isConnected' | 'connectedType'>
 
 export const WalletConnected = (props: WalletConnectedProps) => {
   return (
@@ -54,7 +54,7 @@ export const WalletConnected = (props: WalletConnectedProps) => {
         walletInfo={props.walletInfo}
         onDisconnect={props.onDisconnect}
         onSwitchProvider={props.onSwitchProvider}
-        type={props.type}
+        connectedType={props.connectedType}
       />
     </MemoryRouter>
   )
@@ -146,7 +146,8 @@ const WalletButton: FC<WalletButtonProps> = ({
 
 export const UserMenu: React.FC<{ onClick?: () => void }> = ({ onClick }) => {
   const { state, dispatch, disconnect } = useWallet()
-  const { isConnected, isDemoWallet, walletInfo, type, isLocked, isLoadingLocalWallet } = state
+  const { isConnected, isDemoWallet, walletInfo, connectedType, isLocked, isLoadingLocalWallet } =
+    state
 
   if (isLocked) disconnect()
   const hasWallet = Boolean(walletInfo?.deviceId)
@@ -178,7 +179,7 @@ export const UserMenu: React.FC<{ onClick?: () => void }> = ({ onClick }) => {
               walletInfo={walletInfo}
               onDisconnect={disconnect}
               onSwitchProvider={handleConnect}
-              type={type}
+              connectedType={connectedType}
             />
           ) : (
             <NoWallet onClick={handleConnect} />

--- a/src/components/Layout/Header/NavBar/WalletConnectedMenu.tsx
+++ b/src/components/Layout/Header/NavBar/WalletConnectedMenu.tsx
@@ -18,7 +18,7 @@ const ConnectedMenu = memo(
   ({
     connectedWalletMenuRoutes,
     isConnected,
-    type,
+    connectedType,
     walletInfo,
     onDisconnect,
     onSwitchProvider,
@@ -28,17 +28,17 @@ const ConnectedMenu = memo(
     const { navigateToRoute } = useMenuRoutes()
     const translate = useTranslate()
     const ConnectMenuComponent = useMemo(
-      () => type && SUPPORTED_WALLETS[type].connectedMenuComponent,
-      [type],
+      () => connectedType && SUPPORTED_WALLETS[connectedType].connectedMenuComponent,
+      [connectedType],
     )
 
     const handleClick = useCallback(() => {
       if (!connectedWalletMenuRoutes) return
       navigateToRoute(
-        (type && SUPPORTED_WALLETS[type])?.connectedWalletMenuInitialPath ??
+        (connectedType && SUPPORTED_WALLETS[connectedType])?.connectedWalletMenuInitialPath ??
           WalletConnectedRoutes.Connected,
       )
-    }, [connectedWalletMenuRoutes, navigateToRoute, type])
+    }, [connectedWalletMenuRoutes, navigateToRoute, connectedType])
 
     return (
       <MenuGroup title={translate('common.connectedWallet')} color='gray.500'>
@@ -84,13 +84,13 @@ export const WalletConnectedMenu = ({
   onSwitchProvider,
   walletInfo,
   isConnected,
-  type,
+  connectedType,
 }: WalletConnectedProps) => {
   const location = useLocation()
 
   const connectedWalletMenuRoutes = useMemo(
-    () => type && SUPPORTED_WALLETS[type].connectedWalletMenuRoutes,
-    [type],
+    () => connectedType && SUPPORTED_WALLETS[connectedType].connectedWalletMenuRoutes,
+    [connectedType],
   )
 
   return (
@@ -101,7 +101,7 @@ export const WalletConnectedMenu = ({
             <ConnectedMenu
               connectedWalletMenuRoutes={!!connectedWalletMenuRoutes}
               isConnected={isConnected}
-              type={type}
+              connectedType={connectedType}
               walletInfo={walletInfo}
               onDisconnect={onDisconnect}
               onSwitchProvider={onSwitchProvider}

--- a/src/context/WalletProvider/Coinbase/components/Connect.tsx
+++ b/src/context/WalletProvider/Coinbase/components/Connect.tsx
@@ -52,7 +52,7 @@ export const CoinbaseConnect = ({ history }: CoinbaseSetupProps) => {
         await wallet.initialize()
         dispatch({
           type: WalletActions.SET_WALLET,
-          payload: { wallet, name, icon, deviceId },
+          payload: { wallet, name, icon, deviceId, connectedType: KeyManager.Coinbase },
         })
         dispatch({ type: WalletActions.SET_IS_CONNECTED, payload: true })
         dispatch({ type: WalletActions.SET_IS_LOCKED, payload: isLocked })

--- a/src/context/WalletProvider/KeepKey/components/Connect.tsx
+++ b/src/context/WalletProvider/KeepKey/components/Connect.tsx
@@ -1,16 +1,23 @@
-import { Alert, AlertDescription, AlertIcon, Button, ModalBody, ModalHeader } from "@chakra-ui/react";
-import type { Event } from "@shapeshiftoss/hdwallet-core";
-import { useCallback, useState } from "react";
-import { CircularProgress } from "components/CircularProgress/CircularProgress";
-import { Text } from "components/Text";
-import { WalletActions } from "context/WalletProvider/actions";
-import { KeyManager } from "context/WalletProvider/KeyManager";
-import { setLocalWalletTypeAndDeviceId } from "context/WalletProvider/local-wallet";
-import { useWallet } from "hooks/useWallet/useWallet";
+import {
+  Alert,
+  AlertDescription,
+  AlertIcon,
+  Button,
+  ModalBody,
+  ModalHeader,
+} from '@chakra-ui/react'
+import type { Event } from '@shapeshiftoss/hdwallet-core'
+import { useCallback, useState } from 'react'
+import { CircularProgress } from 'components/CircularProgress/CircularProgress'
+import { Text } from 'components/Text'
+import { WalletActions } from 'context/WalletProvider/actions'
+import { KeyManager } from 'context/WalletProvider/KeyManager'
+import { setLocalWalletTypeAndDeviceId } from 'context/WalletProvider/local-wallet'
+import { useWallet } from 'hooks/useWallet/useWallet'
 
-import { KeepKeyConfig } from "../config";
-import { FailureType, MessageType } from "../KeepKeyTypes";
-import { setupKeepKeySDK } from "../setupKeepKeySdk";
+import { KeepKeyConfig } from '../config'
+import { FailureType, MessageType } from '../KeepKeyTypes'
+import { setupKeepKeySDK } from '../setupKeepKeySdk'
 
 const translateError = (event: Event) => {
   let t: string

--- a/src/context/WalletProvider/KeepKey/components/Connect.tsx
+++ b/src/context/WalletProvider/KeepKey/components/Connect.tsx
@@ -98,7 +98,14 @@ export const KeepKeyConnect = () => {
 
         dispatch({
           type: WalletActions.SET_WALLET,
-          payload: { wallet, name, icon, deviceId, meta: { label } },
+          payload: {
+            wallet,
+            name,
+            icon,
+            deviceId,
+            meta: { label },
+            connectedType: KeyManager.KeepKey,
+          },
         })
         dispatch({ type: WalletActions.SET_IS_CONNECTED, payload: true })
         /**

--- a/src/context/WalletProvider/KeepKey/components/Connect.tsx
+++ b/src/context/WalletProvider/KeepKey/components/Connect.tsx
@@ -1,23 +1,16 @@
-import {
-  Alert,
-  AlertDescription,
-  AlertIcon,
-  Button,
-  ModalBody,
-  ModalHeader,
-} from '@chakra-ui/react'
-import type { Event } from '@shapeshiftoss/hdwallet-core'
-import { useCallback, useState } from 'react'
-import { CircularProgress } from 'components/CircularProgress/CircularProgress'
-import { Text } from 'components/Text'
-import { WalletActions } from 'context/WalletProvider/actions'
-import { KeyManager } from 'context/WalletProvider/KeyManager'
-import { setLocalWalletTypeAndDeviceId } from 'context/WalletProvider/local-wallet'
-import { useWallet } from 'hooks/useWallet/useWallet'
+import { Alert, AlertDescription, AlertIcon, Button, ModalBody, ModalHeader } from "@chakra-ui/react";
+import type { Event } from "@shapeshiftoss/hdwallet-core";
+import { useCallback, useState } from "react";
+import { CircularProgress } from "components/CircularProgress/CircularProgress";
+import { Text } from "components/Text";
+import { WalletActions } from "context/WalletProvider/actions";
+import { KeyManager } from "context/WalletProvider/KeyManager";
+import { setLocalWalletTypeAndDeviceId } from "context/WalletProvider/local-wallet";
+import { useWallet } from "hooks/useWallet/useWallet";
 
-import { KeepKeyConfig } from '../config'
-import { FailureType, MessageType } from '../KeepKeyTypes'
-import { setupKeepKeySDK } from '../setupKeepKeySdk'
+import { KeepKeyConfig } from "../config";
+import { FailureType, MessageType } from "../KeepKeyTypes";
+import { setupKeepKeySDK } from "../setupKeepKeySdk";
 
 const translateError = (event: Event) => {
   let t: string
@@ -96,7 +89,6 @@ export const KeepKeyConnect = () => {
 
         await wallet.initialize()
 
-        console.log('xxx 2')
         dispatch({
           type: WalletActions.SET_WALLET,
           payload: {

--- a/src/context/WalletProvider/KeepKey/components/Connect.tsx
+++ b/src/context/WalletProvider/KeepKey/components/Connect.tsx
@@ -96,6 +96,7 @@ export const KeepKeyConnect = () => {
 
         await wallet.initialize()
 
+        console.log('xxx 2')
         dispatch({
           type: WalletActions.SET_WALLET,
           payload: {

--- a/src/context/WalletProvider/KeepKey/hooks/useKeepKeyEventHandler.ts
+++ b/src/context/WalletProvider/KeepKey/hooks/useKeepKeyEventHandler.ts
@@ -1,16 +1,16 @@
-import { useToast } from '@chakra-ui/react'
-import type { Event } from '@shapeshiftoss/hdwallet-core'
-import { Events } from '@shapeshiftoss/hdwallet-core'
-import type { Dispatch } from 'react'
-import { useEffect } from 'react'
-import { useTranslate } from 'react-polyglot'
-import type { ActionTypes } from 'context/WalletProvider/actions'
-import { WalletActions } from 'context/WalletProvider/actions'
-import { KeyManager } from 'context/WalletProvider/KeyManager'
-import type { DeviceState, InitialState } from 'context/WalletProvider/WalletProvider'
-import { usePoll } from 'hooks/usePoll/usePoll'
+import { useToast } from "@chakra-ui/react";
+import type { Event } from "@shapeshiftoss/hdwallet-core";
+import { Events } from "@shapeshiftoss/hdwallet-core";
+import type { Dispatch } from "react";
+import { useEffect } from "react";
+import { useTranslate } from "react-polyglot";
+import type { ActionTypes } from "context/WalletProvider/actions";
+import { WalletActions } from "context/WalletProvider/actions";
+import { KeyManager } from "context/WalletProvider/KeyManager";
+import type { DeviceState, InitialState } from "context/WalletProvider/WalletProvider";
+import { usePoll } from "hooks/usePoll/usePoll";
 
-import { ButtonRequestType, FailureType, Message, MessageType } from '../KeepKeyTypes'
+import { ButtonRequestType, FailureType, Message, MessageType } from "../KeepKeyTypes";
 
 export const useKeepKeyEventHandler = (
   state: InitialState,
@@ -193,8 +193,6 @@ export const useKeepKeyEventHandler = (
     const handleConnect = async (e: [deviceId: string, message: Event]) => {
       const [deviceId] = e
 
-      console.log('xxx handleConnect', e)
-
       /*
         Understanding KeepKey DeviceID aliases:
 
@@ -214,7 +212,6 @@ export const useKeepKeyEventHandler = (
           const name = (await wallet.getLabel()) || state.walletInfo.name
           // The keyring might have a new HDWallet instance for the device.
           // We'll replace the one we have in state with the new one
-          console.log('xxx 3')
           dispatch({
             type: WalletActions.SET_WALLET,
             payload: {

--- a/src/context/WalletProvider/KeepKey/hooks/useKeepKeyEventHandler.ts
+++ b/src/context/WalletProvider/KeepKey/hooks/useKeepKeyEventHandler.ts
@@ -6,6 +6,7 @@ import { useEffect } from 'react'
 import { useTranslate } from 'react-polyglot'
 import type { ActionTypes } from 'context/WalletProvider/actions'
 import { WalletActions } from 'context/WalletProvider/actions'
+import { KeyManager } from 'context/WalletProvider/KeyManager'
 import type { DeviceState, InitialState } from 'context/WalletProvider/WalletProvider'
 import { usePoll } from 'hooks/usePoll/usePoll'
 
@@ -216,6 +217,7 @@ export const useKeepKeyEventHandler = (
               name,
               deviceId: id,
               meta: { label: name },
+              connectedType: KeyManager.KeepKey,
               icon: state.walletInfo.icon, // We're reconnecting the same wallet so we can reuse the walletInfo
             },
           })

--- a/src/context/WalletProvider/KeepKey/hooks/useKeepKeyEventHandler.ts
+++ b/src/context/WalletProvider/KeepKey/hooks/useKeepKeyEventHandler.ts
@@ -1,16 +1,16 @@
-import { useToast } from "@chakra-ui/react";
-import type { Event } from "@shapeshiftoss/hdwallet-core";
-import { Events } from "@shapeshiftoss/hdwallet-core";
-import type { Dispatch } from "react";
-import { useEffect } from "react";
-import { useTranslate } from "react-polyglot";
-import type { ActionTypes } from "context/WalletProvider/actions";
-import { WalletActions } from "context/WalletProvider/actions";
-import { KeyManager } from "context/WalletProvider/KeyManager";
-import type { DeviceState, InitialState } from "context/WalletProvider/WalletProvider";
-import { usePoll } from "hooks/usePoll/usePoll";
+import { useToast } from '@chakra-ui/react'
+import type { Event } from '@shapeshiftoss/hdwallet-core'
+import { Events } from '@shapeshiftoss/hdwallet-core'
+import type { Dispatch } from 'react'
+import { useEffect } from 'react'
+import { useTranslate } from 'react-polyglot'
+import type { ActionTypes } from 'context/WalletProvider/actions'
+import { WalletActions } from 'context/WalletProvider/actions'
+import { KeyManager } from 'context/WalletProvider/KeyManager'
+import type { DeviceState, InitialState } from 'context/WalletProvider/WalletProvider'
+import { usePoll } from 'hooks/usePoll/usePoll'
 
-import { ButtonRequestType, FailureType, Message, MessageType } from "../KeepKeyTypes";
+import { ButtonRequestType, FailureType, Message, MessageType } from '../KeepKeyTypes'
 
 export const useKeepKeyEventHandler = (
   state: InitialState,

--- a/src/context/WalletProvider/KeepKey/hooks/useKeepKeyEventHandler.ts
+++ b/src/context/WalletProvider/KeepKey/hooks/useKeepKeyEventHandler.ts
@@ -246,8 +246,8 @@ export const useKeepKeyEventHandler = (
       }
     }
 
-    // check if keepkey
-    if (state.connectedType === KeyManager.KeepKey) {
+    // We only want to listen to these events if a KeepKey is actually connected, or we are showing a KeepKey modal
+    if ([state.connectedType, state.modalType].includes(KeyManager.KeepKey)) {
       // Handle all KeepKey events
       keyring.on(['KeepKey', '*', '*'], handleEvent)
       // HDWallet emits (DIS)CONNECT events as "KeepKey - {LABEL}" so we can't just listen for "KeepKey"
@@ -273,5 +273,6 @@ export const useKeepKeyEventHandler = (
     translate,
     poll,
     state.connectedType,
+    state.modalType,
   ])
 }

--- a/src/context/WalletProvider/KeepKey/hooks/useKeepKeyEventHandler.ts
+++ b/src/context/WalletProvider/KeepKey/hooks/useKeepKeyEventHandler.ts
@@ -190,7 +190,11 @@ export const useKeepKeyEventHandler = (
       }
     }
 
-    const handleConnect = async (deviceId: string) => {
+    const handleConnect = async (e: [deviceId: string, message: Event]) => {
+      const [deviceId] = e
+
+      console.log('xxx handleConnect', e)
+
       /*
         Understanding KeepKey DeviceID aliases:
 
@@ -210,6 +214,7 @@ export const useKeepKeyEventHandler = (
           const name = (await wallet.getLabel()) || state.walletInfo.name
           // The keyring might have a new HDWallet instance for the device.
           // We'll replace the one we have in state with the new one
+          console.log('xxx 3')
           dispatch({
             type: WalletActions.SET_WALLET,
             payload: {
@@ -244,11 +249,14 @@ export const useKeepKeyEventHandler = (
       }
     }
 
-    // Handle all KeepKey events
-    keyring.on(['KeepKey', '*', '*'], handleEvent)
-    // HDWallet emits (DIS)CONNECT events as "KeepKey - {LABEL}" so we can't just listen for "KeepKey"
-    keyring.on(['*', '*', Events.CONNECT], handleConnect)
-    keyring.on(['*', '*', Events.DISCONNECT], handleDisconnect)
+    // check if keepkey
+    if (state.connectedType === KeyManager.KeepKey) {
+      // Handle all KeepKey events
+      keyring.on(['KeepKey', '*', '*'], handleEvent)
+      // HDWallet emits (DIS)CONNECT events as "KeepKey - {LABEL}" so we can't just listen for "KeepKey"
+      keyring.on(['*', '*', Events.CONNECT], handleConnect)
+      keyring.on(['*', '*', Events.DISCONNECT], handleDisconnect)
+    }
 
     return () => {
       keyring.off(['KeepKey', '*', '*'], handleEvent)
@@ -267,5 +275,6 @@ export const useKeepKeyEventHandler = (
     toast,
     translate,
     poll,
+    state.connectedType,
   ])
 }

--- a/src/context/WalletProvider/Keplr/components/Connect.tsx
+++ b/src/context/WalletProvider/Keplr/components/Connect.tsx
@@ -48,7 +48,7 @@ export const KeplrConnect = ({ history }: KeplrSetupProps) => {
 
         dispatch({
           type: WalletActions.SET_WALLET,
-          payload: { wallet, name, icon, deviceId },
+          payload: { wallet, name, icon, deviceId, connectedType: KeyManager.Keplr },
         })
         dispatch({ type: WalletActions.SET_IS_CONNECTED, payload: true })
         setLocalWalletTypeAndDeviceId(KeyManager.Keplr, deviceId)

--- a/src/context/WalletProvider/MetaMask/components/Connect.tsx
+++ b/src/context/WalletProvider/MetaMask/components/Connect.tsx
@@ -60,7 +60,7 @@ export const MetaMaskConnect = ({ history }: MetaMaskSetupProps) => {
 
         dispatch({
           type: WalletActions.SET_WALLET,
-          payload: { wallet, name, icon, deviceId },
+          payload: { wallet, name, icon, deviceId, connectedType: KeyManager.MetaMask },
         })
         dispatch({ type: WalletActions.SET_IS_CONNECTED, payload: true })
         dispatch({ type: WalletActions.SET_IS_LOCKED, payload: isLocked })

--- a/src/context/WalletProvider/MobileWallet/components/MobileLoad.tsx
+++ b/src/context/WalletProvider/MobileWallet/components/MobileLoad.tsx
@@ -70,7 +70,14 @@ export const MobileLoad = ({ history }: RouteComponentProps) => {
         }
         dispatch({
           type: WalletActions.SET_WALLET,
-          payload: { wallet, name, icon, deviceId, meta: { label: item.label } },
+          payload: {
+            wallet,
+            name,
+            icon,
+            deviceId,
+            meta: { label: item.label },
+            connectedType: KeyManager.Mobile,
+          },
         })
         dispatch({ type: WalletActions.SET_IS_CONNECTED, payload: true })
         dispatch({ type: WalletActions.SET_WALLET_MODAL, payload: false })

--- a/src/context/WalletProvider/MobileWallet/components/MobileSuccess.tsx
+++ b/src/context/WalletProvider/MobileWallet/components/MobileSuccess.tsx
@@ -44,6 +44,7 @@ export const MobileSuccess = ({ location }: MobileSetupProps) => {
               icon,
               deviceId,
               meta: { label: walletLabel },
+              connectedType: KeyManager.Mobile,
             },
           })
           dispatch({ type: WalletActions.SET_IS_CONNECTED, payload: true })

--- a/src/context/WalletProvider/NativeWallet/components/EnterPassword.tsx
+++ b/src/context/WalletProvider/NativeWallet/components/EnterPassword.tsx
@@ -21,6 +21,7 @@ import { useTranslate } from 'react-polyglot'
 import { IconCircle } from 'components/IconCircle'
 import { RawText, Text } from 'components/Text'
 import { WalletActions } from 'context/WalletProvider/actions'
+import { KeyManager } from 'context/WalletProvider/KeyManager'
 import { getNativeLocalWalletName } from 'context/WalletProvider/local-wallet'
 import { NativeConfig } from 'context/WalletProvider/NativeWallet/config'
 import { useWallet } from 'hooks/useWallet/useWallet'
@@ -60,6 +61,7 @@ export const EnterPassword = () => {
           name,
           icon,
           deviceId,
+          connectedType: KeyManager.Native,
           meta: { label: vault.meta.get('name') as string },
         },
       })

--- a/src/context/WalletProvider/NativeWallet/components/NativeLoad.tsx
+++ b/src/context/WalletProvider/NativeWallet/components/NativeLoad.tsx
@@ -83,7 +83,14 @@ export const NativeLoad = ({ history }: RouteComponentProps) => {
         } else {
           dispatch({
             type: WalletActions.SET_WALLET,
-            payload: { wallet, name, icon, deviceId, meta: { label: item.name } },
+            payload: {
+              wallet,
+              name,
+              icon,
+              deviceId,
+              meta: { label: item.name },
+              connectedType: KeyManager.Native,
+            },
           })
           dispatch({ type: WalletActions.SET_IS_CONNECTED, payload: true })
           // The wallet is already initialized so we can close the modal

--- a/src/context/WalletProvider/NativeWallet/hooks/useNativeEventHandler.ts
+++ b/src/context/WalletProvider/NativeWallet/hooks/useNativeEventHandler.ts
@@ -4,12 +4,11 @@ import type { Dispatch } from 'react'
 import { useEffect } from 'react'
 import type { ActionTypes } from 'context/WalletProvider/actions'
 import { WalletActions } from 'context/WalletProvider/actions'
+import { KeyManager } from 'context/WalletProvider/KeyManager'
 import type { InitialState } from 'context/WalletProvider/WalletProvider'
 
-type KeyringState = Pick<InitialState, 'keyring' | 'walletInfo' | 'modal'>
-
-export const useNativeEventHandler = (state: KeyringState, dispatch: Dispatch<ActionTypes>) => {
-  const { keyring, modal } = state
+export const useNativeEventHandler = (state: InitialState, dispatch: Dispatch<ActionTypes>) => {
+  const { keyring, modal, modalType } = state
 
   useEffect(() => {
     const handleEvent = (e: [deviceId: string, message: Event]) => {
@@ -31,7 +30,7 @@ export const useNativeEventHandler = (state: KeyringState, dispatch: Dispatch<Ac
       }
     }
 
-    if (keyring) {
+    if (keyring && modalType && [KeyManager.Native, KeyManager.Mobile].includes(modalType)) {
       keyring.on(['Native', '*', NativeEvents.MNEMONIC_REQUIRED], handleEvent)
       keyring.on(['Native', '*', NativeEvents.READY], handleEvent)
     }
@@ -39,5 +38,5 @@ export const useNativeEventHandler = (state: KeyringState, dispatch: Dispatch<Ac
       keyring.off(['Native', '*', NativeEvents.MNEMONIC_REQUIRED], handleEvent)
       keyring.off(['Native', '*', NativeEvents.READY], handleEvent)
     }
-  }, [dispatch, keyring, modal])
+  }, [modalType, dispatch, keyring, modal])
 }

--- a/src/context/WalletProvider/NativeWallet/hooks/useNativeSuccess.ts
+++ b/src/context/WalletProvider/NativeWallet/hooks/useNativeSuccess.ts
@@ -44,6 +44,7 @@ export const useNativeSuccess = ({ vault }: UseNativeSuccessPropTypes) => {
             icon,
             deviceId,
             meta: { label: walletLabel },
+            connectedType: KeyManager.Native,
           },
         })
         dispatch({ type: WalletActions.SET_IS_CONNECTED, payload: true })

--- a/src/context/WalletProvider/WalletConnect/components/Connect.tsx
+++ b/src/context/WalletProvider/WalletConnect/components/Connect.tsx
@@ -69,7 +69,7 @@ export const WalletConnectConnect = ({ history }: WalletConnectSetupProps) => {
 
         dispatch({
           type: WalletActions.SET_WALLET,
-          payload: { wallet, name, icon, deviceId },
+          payload: { wallet, name, icon, deviceId, connectedType: KeyManager.WalletConnect },
         })
         dispatch({ type: WalletActions.SET_IS_CONNECTED, payload: true })
         setLocalWalletTypeAndDeviceId(KeyManager.WalletConnect, deviceId)

--- a/src/context/WalletProvider/WalletProvider.test.tsx
+++ b/src/context/WalletProvider/WalletProvider.test.tsx
@@ -69,7 +69,11 @@ describe('WalletProvider', () => {
       act(() => {
         result.current.dispatch({
           type: WalletActions.SET_WALLET,
-          payload: { wallet: {} as unknown as HDWallet, ...walletInfoPayload },
+          payload: {
+            wallet: {} as unknown as HDWallet,
+            connectedType: KeyManager.Demo,
+            ...walletInfoPayload,
+          },
         })
       })
 
@@ -154,6 +158,7 @@ describe('WalletProvider', () => {
           type: WalletActions.SET_WALLET,
           payload: {
             wallet: { disconnect: walletDisconnect } as unknown as HDWallet,
+            connectedType: KeyManager.Demo,
             ...walletInfoPayload,
           },
         })

--- a/src/context/WalletProvider/WalletProvider.test.tsx
+++ b/src/context/WalletProvider/WalletProvider.test.tsx
@@ -122,7 +122,7 @@ describe('WalletProvider', () => {
         result.current.connect(type)
       })
 
-      expect(result.current.state.connectingType).toBe(type)
+      expect(result.current.state.modalType).toBe(type)
       expect(result.current.state.initialRoute).toBe(SUPPORTED_WALLETS[type].routes[0].path)
     })
   })
@@ -139,7 +139,7 @@ describe('WalletProvider', () => {
         result.current.create(type)
       })
 
-      expect(result.current.state.connectingType).toBe(type)
+      expect(result.current.state.modalType).toBe(type)
       expect(result.current.state.initialRoute).toBe(SUPPORTED_WALLETS[type].routes[5].path)
     })
   })

--- a/src/context/WalletProvider/WalletProvider.test.tsx
+++ b/src/context/WalletProvider/WalletProvider.test.tsx
@@ -122,7 +122,7 @@ describe('WalletProvider', () => {
         result.current.connect(type)
       })
 
-      expect(result.current.state.type).toBe(type)
+      expect(result.current.state.connectingType).toBe(type)
       expect(result.current.state.initialRoute).toBe(SUPPORTED_WALLETS[type].routes[0].path)
     })
   })
@@ -139,7 +139,7 @@ describe('WalletProvider', () => {
         result.current.create(type)
       })
 
-      expect(result.current.state.type).toBe(type)
+      expect(result.current.state.connectingType).toBe(type)
       expect(result.current.state.initialRoute).toBe(SUPPORTED_WALLETS[type].routes[5].path)
     })
   })

--- a/src/context/WalletProvider/WalletProvider.tsx
+++ b/src/context/WalletProvider/WalletProvider.tsx
@@ -149,7 +149,7 @@ export const isKeyManagerWithProvider = (
       ].includes(keyManager),
   )
 
-const reducer = (state: InitialState, action: ActionTypes) => {
+const reducer = (state: InitialState, action: ActionTypes): InitialState => {
   switch (action.type) {
     case WalletActions.SET_ADAPTERS:
       return { ...state, adapters: action.payload }
@@ -180,7 +180,7 @@ const reducer = (state: InitialState, action: ActionTypes) => {
     case WalletActions.SET_IS_LOCKED:
       return { ...state, isLocked: action.payload }
     case WalletActions.SET_CONNECTOR_TYPE:
-      return { ...state, type: action.payload }
+      return { ...state, modalType: action.payload }
     case WalletActions.SET_INITIAL_ROUTE:
       return { ...state, initialRoute: action.payload }
     case WalletActions.SET_PIN_REQUEST_TYPE:
@@ -225,7 +225,7 @@ const reducer = (state: InitialState, action: ActionTypes) => {
       return {
         ...state,
         modal: action.payload.modal,
-        type: KeyManager.Native,
+        modalType: KeyManager.Native,
         showBackButton: !state.isLoadingLocalWallet,
         deviceId: action.payload.deviceId,
         initialRoute: '/native/enter-password',
@@ -235,7 +235,7 @@ const reducer = (state: InitialState, action: ActionTypes) => {
       return {
         ...state,
         modal: true,
-        type: KeyManager.KeepKey,
+        modalType: KeyManager.KeepKey,
         showBackButton: showBackButton ?? false,
         deviceId,
         keepKeyPinRequestType: pinRequestType ?? null,
@@ -249,7 +249,7 @@ const reducer = (state: InitialState, action: ActionTypes) => {
         ...state,
         modal: true,
         showBackButton: false,
-        type: KeyManager.KeepKey,
+        modalType: KeyManager.KeepKey,
         initialRoute: KeepKeyRoutes.RecoverySentenceEntry,
         deviceState: {
           ...deviceState,
@@ -262,7 +262,7 @@ const reducer = (state: InitialState, action: ActionTypes) => {
       return {
         ...state,
         modal: true,
-        type: KeyManager.KeepKey,
+        modalType: KeyManager.KeepKey,
         showBackButton: false,
         deviceId: action.payload.deviceId,
         initialRoute: KeepKeyRoutes.Passphrase,
@@ -273,7 +273,7 @@ const reducer = (state: InitialState, action: ActionTypes) => {
         modal: true,
         showBackButton: false,
         disconnectOnCloseModal: true,
-        type: KeyManager.KeepKey,
+        modalType: KeyManager.KeepKey,
         deviceId: action.payload.deviceId,
         initialRoute: KeepKeyRoutes.FactoryState,
       }
@@ -281,7 +281,7 @@ const reducer = (state: InitialState, action: ActionTypes) => {
       return {
         ...state,
         modal: true,
-        type: KeyManager.KeepKey,
+        modalType: KeyManager.KeepKey,
         deviceId: action.payload.deviceId,
         initialRoute: KeepKeyRoutes.NewRecoverySentence,
       }
@@ -289,7 +289,7 @@ const reducer = (state: InitialState, action: ActionTypes) => {
       return {
         ...state,
         modal: true,
-        type: KeyManager.KeepKey,
+        modalType: KeyManager.KeepKey,
         deviceId: action.payload.deviceId,
         initialRoute: KeepKeyRoutes.RecoverySentenceInvalid,
       }
@@ -317,7 +317,7 @@ const reducer = (state: InitialState, action: ActionTypes) => {
       return {
         ...state,
         modal: true,
-        type: KeyManager.KeepKey,
+        modalType: KeyManager.KeepKey,
         initialRoute: KeepKeyRoutes.DownloadUpdater,
       }
     case WalletActions.OPEN_KEEPKEY_DISCONNECT:
@@ -325,7 +325,7 @@ const reducer = (state: InitialState, action: ActionTypes) => {
         ...state,
         modal: true,
         showBackButton: false,
-        type: KeyManager.KeepKey,
+        modalType: KeyManager.KeepKey,
         initialRoute: KeepKeyRoutes.Disconnect,
       }
     default:
@@ -793,7 +793,7 @@ export const WalletProvider = ({ children }: { children: React.ReactNode }): JSX
   const connect = useCallback((type: KeyManager) => {
     // remove existing dapp or wallet connections
     if (type === KeyManager.WalletConnect) localStorage.removeItem('walletconnect')
-    dispatch({ type: WalletActions.SET_CONNECTOR_TYPE, payload: type }) // todo: what uses you?
+    dispatch({ type: WalletActions.SET_CONNECTOR_TYPE, payload: type })
     const routeIndex = findIndex(SUPPORTED_WALLETS[type]?.routes, ({ path }) =>
       String(path).endsWith('connect'),
     )

--- a/src/context/WalletProvider/WalletProvider.tsx
+++ b/src/context/WalletProvider/WalletProvider.tsx
@@ -98,7 +98,7 @@ export interface InitialState {
   keyring: Keyring
   adapters: Adapters | null
   wallet: HDWallet | null
-  connectingType: KeyManager | null
+  modalType: KeyManager | null
   connectedType: KeyManager | null
   initialRoute: string | null
   walletInfo: WalletInfo | null
@@ -119,7 +119,7 @@ const initialState: InitialState = {
   keyring: new Keyring(),
   adapters: null,
   wallet: null,
-  connectingType: null,
+  modalType: null,
   connectedType: null,
   initialRoute: null,
   walletInfo: null,
@@ -154,6 +154,7 @@ const reducer = (state: InitialState, action: ActionTypes) => {
     case WalletActions.SET_ADAPTERS:
       return { ...state, adapters: action.payload }
     case WalletActions.SET_WALLET:
+      console.log('xxx setting wallet', action.payload)
       const deviceId = action?.payload?.deviceId
       // set walletId in redux store
       const walletMeta = { walletId: deviceId, walletName: action?.payload?.name }
@@ -367,6 +368,7 @@ export const WalletProvider = ({ children }: { children: React.ReactNode }): JSX
 
   const load = useCallback(() => {
     const localWalletType = getLocalWalletType()
+    console.log('xxx localWalletType', localWalletType)
     const localWalletDeviceId = getLocalWalletDeviceId()
     if (localWalletType && localWalletDeviceId && state.adapters) {
       ;(async () => {
@@ -451,6 +453,7 @@ export const WalletProvider = ({ children }: { children: React.ReactNode }): JSX
 
                   await localKeepKeyWallet.initialize()
 
+                  console.log('xxx 1')
                   dispatch({
                     type: WalletActions.SET_WALLET,
                     payload: {

--- a/src/context/WalletProvider/WalletProvider.tsx
+++ b/src/context/WalletProvider/WalletProvider.tsx
@@ -98,7 +98,8 @@ export interface InitialState {
   keyring: Keyring
   adapters: Adapters | null
   wallet: HDWallet | null
-  type: KeyManager | null
+  type: KeyManager | null // todo: rename me. connectingType?
+  connectedType: KeyManager | null
   initialRoute: string | null
   walletInfo: WalletInfo | null
   isConnected: boolean
@@ -119,6 +120,7 @@ const initialState: InitialState = {
   adapters: null,
   wallet: null,
   type: null,
+  connectedType: null,
   initialRoute: null,
   walletInfo: null,
   isConnected: false,
@@ -160,6 +162,7 @@ const reducer = (state: InitialState, action: ActionTypes) => {
         ...state,
         isDemoWallet: Boolean(action.payload.isDemoWallet),
         wallet: action.payload.wallet,
+        connectedType: action.payload.connectedType,
         walletInfo: {
           name: action?.payload?.name,
           icon: action?.payload?.icon,
@@ -393,6 +396,7 @@ export const WalletProvider = ({ children }: { children: React.ReactNode }): JSX
                         icon,
                         deviceId: w.id || localWalletDeviceId,
                         meta: { label: w.label },
+                        connectedType: KeyManager.Mobile,
                       },
                     })
                     dispatch({ type: WalletActions.SET_IS_CONNECTED, payload: true })
@@ -455,6 +459,7 @@ export const WalletProvider = ({ children }: { children: React.ReactNode }): JSX
                       icon,
                       deviceId,
                       meta: { label },
+                      connectedType: KeyManager.KeepKey,
                     },
                   })
                   dispatch({ type: WalletActions.SET_IS_CONNECTED, payload: true })
@@ -482,6 +487,7 @@ export const WalletProvider = ({ children }: { children: React.ReactNode }): JSX
                       name,
                       icon,
                       deviceId,
+                      connectedType: KeyManager.MetaMask,
                     },
                   })
                   dispatch({ type: WalletActions.SET_IS_LOCKED, payload: false })
@@ -510,6 +516,7 @@ export const WalletProvider = ({ children }: { children: React.ReactNode }): JSX
                       name,
                       icon,
                       deviceId,
+                      connectedType: KeyManager.Coinbase,
                     },
                   })
                   dispatch({ type: WalletActions.SET_IS_LOCKED, payload: false })
@@ -536,6 +543,7 @@ export const WalletProvider = ({ children }: { children: React.ReactNode }): JSX
                       name,
                       icon,
                       deviceId,
+                      connectedType: KeyManager.XDefi,
                     },
                   })
                   dispatch({ type: WalletActions.SET_IS_CONNECTED, payload: true })
@@ -561,6 +569,7 @@ export const WalletProvider = ({ children }: { children: React.ReactNode }): JSX
                       name,
                       icon,
                       deviceId,
+                      connectedType: KeyManager.Keplr,
                     },
                   })
                   dispatch({ type: WalletActions.SET_IS_CONNECTED, payload: true })
@@ -588,6 +597,7 @@ export const WalletProvider = ({ children }: { children: React.ReactNode }): JSX
                       name,
                       icon,
                       deviceId,
+                      connectedType: KeyManager.WalletConnect,
                     },
                   })
                   dispatch({ type: WalletActions.SET_IS_LOCKED, payload: false })
@@ -635,6 +645,7 @@ export const WalletProvider = ({ children }: { children: React.ReactNode }): JSX
         name,
         icon,
         deviceId,
+        connectedType: walletType,
       },
     })
   }, [state, walletType])
@@ -782,7 +793,7 @@ export const WalletProvider = ({ children }: { children: React.ReactNode }): JSX
   const connect = useCallback((type: KeyManager) => {
     // remove existing dapp or wallet connections
     if (type === KeyManager.WalletConnect) localStorage.removeItem('walletconnect')
-    dispatch({ type: WalletActions.SET_CONNECTOR_TYPE, payload: type })
+    dispatch({ type: WalletActions.SET_CONNECTOR_TYPE, payload: type }) // todo: what uses you?
     const routeIndex = findIndex(SUPPORTED_WALLETS[type]?.routes, ({ path }) =>
       String(path).endsWith('connect'),
     )
@@ -818,6 +829,7 @@ export const WalletProvider = ({ children }: { children: React.ReactNode }): JSX
         icon,
         deviceId,
         meta: { label: name },
+        connectedType: KeyManager.Demo,
       },
     })
     dispatch({ type: WalletActions.SET_IS_CONNECTED, payload: false })

--- a/src/context/WalletProvider/WalletProvider.tsx
+++ b/src/context/WalletProvider/WalletProvider.tsx
@@ -154,7 +154,6 @@ const reducer = (state: InitialState, action: ActionTypes) => {
     case WalletActions.SET_ADAPTERS:
       return { ...state, adapters: action.payload }
     case WalletActions.SET_WALLET:
-      console.log('xxx setting wallet', action.payload)
       const deviceId = action?.payload?.deviceId
       // set walletId in redux store
       const walletMeta = { walletId: deviceId, walletName: action?.payload?.name }
@@ -368,7 +367,6 @@ export const WalletProvider = ({ children }: { children: React.ReactNode }): JSX
 
   const load = useCallback(() => {
     const localWalletType = getLocalWalletType()
-    console.log('xxx localWalletType', localWalletType)
     const localWalletDeviceId = getLocalWalletDeviceId()
     if (localWalletType && localWalletDeviceId && state.adapters) {
       ;(async () => {
@@ -453,7 +451,6 @@ export const WalletProvider = ({ children }: { children: React.ReactNode }): JSX
 
                   await localKeepKeyWallet.initialize()
 
-                  console.log('xxx 1')
                   dispatch({
                     type: WalletActions.SET_WALLET,
                     payload: {

--- a/src/context/WalletProvider/WalletProvider.tsx
+++ b/src/context/WalletProvider/WalletProvider.tsx
@@ -98,7 +98,7 @@ export interface InitialState {
   keyring: Keyring
   adapters: Adapters | null
   wallet: HDWallet | null
-  type: KeyManager | null // todo: rename me. connectingType?
+  connectingType: KeyManager | null
   connectedType: KeyManager | null
   initialRoute: string | null
   walletInfo: WalletInfo | null
@@ -119,7 +119,7 @@ const initialState: InitialState = {
   keyring: new Keyring(),
   adapters: null,
   wallet: null,
-  type: null,
+  connectingType: null,
   connectedType: null,
   initialRoute: null,
   walletInfo: null,

--- a/src/context/WalletProvider/WalletViewsSwitch.tsx
+++ b/src/context/WalletProvider/WalletViewsSwitch.tsx
@@ -32,7 +32,7 @@ export const WalletViewsSwitch = () => {
       modal,
       showBackButton,
       initialRoute,
-      connectingType,
+      modalType,
       disconnectOnCloseModal,
       deviceState: { disposition },
     },
@@ -92,8 +92,8 @@ export const WalletViewsSwitch = () => {
    */
   const walletRoutesList = useMemo(
     () =>
-      connectingType
-        ? SUPPORTED_WALLETS[connectingType].routes.map(route => {
+      modalType
+        ? SUPPORTED_WALLETS[modalType].routes.map(route => {
             const Component = route.component
             return !Component ? null : (
               <Route
@@ -105,7 +105,7 @@ export const WalletViewsSwitch = () => {
             )
           })
         : [],
-    [connectingType],
+    [modalType],
   )
 
   return (

--- a/src/context/WalletProvider/WalletViewsSwitch.tsx
+++ b/src/context/WalletProvider/WalletViewsSwitch.tsx
@@ -32,7 +32,7 @@ export const WalletViewsSwitch = () => {
       modal,
       showBackButton,
       initialRoute,
-      type,
+      connectingType,
       disconnectOnCloseModal,
       deviceState: { disposition },
     },
@@ -92,8 +92,8 @@ export const WalletViewsSwitch = () => {
    */
   const walletRoutesList = useMemo(
     () =>
-      type
-        ? SUPPORTED_WALLETS[type].routes.map(route => {
+      connectingType
+        ? SUPPORTED_WALLETS[connectingType].routes.map(route => {
             const Component = route.component
             return !Component ? null : (
               <Route
@@ -105,7 +105,7 @@ export const WalletViewsSwitch = () => {
             )
           })
         : [],
-    [type],
+    [connectingType],
   )
 
   return (

--- a/src/context/WalletProvider/XDEFI/components/Connect.tsx
+++ b/src/context/WalletProvider/XDEFI/components/Connect.tsx
@@ -60,7 +60,7 @@ export const XDEFIConnect = ({ history }: XDEFISetupProps) => {
 
         dispatch({
           type: WalletActions.SET_WALLET,
-          payload: { wallet, name, icon, deviceId },
+          payload: { wallet, name, icon, deviceId, connectedType: KeyManager.XDefi },
         })
         dispatch({ type: WalletActions.SET_IS_CONNECTED, payload: true })
         setLocalWalletTypeAndDeviceId(KeyManager.XDefi, deviceId)

--- a/src/context/WalletProvider/actions.ts
+++ b/src/context/WalletProvider/actions.ts
@@ -33,7 +33,11 @@ export type ActionTypes =
   | { type: WalletActions.SET_ADAPTERS; payload: Adapters }
   | {
       type: WalletActions.SET_WALLET
-      payload: WalletInfo & { isDemoWallet?: boolean; wallet: HDWallet | null }
+      payload: WalletInfo & {
+        isDemoWallet?: boolean
+        wallet: HDWallet | null
+        connectedType: KeyManager
+      }
     }
   | { type: WalletActions.SET_IS_CONNECTED; payload: boolean }
   | { type: WalletActions.SET_PROVIDER; payload: InitialState['provider'] }


### PR DESCRIPTION
## Description

This is both a performance optimization and a bug fix.
Recent performance improvements exposed a bug, that can actually be fixed by yet more performance improvements.

The bug (and perf issue): the KeepKey event handler would subscribe to events no matter what type of wallet was connected.

In one edge case it would cause MetaMask's connection event to fire KeepKey's `handleConnect` listener, which would update the wallet state's `type` value to `KeepKey`, which would break the connected wallet routing.

The fix is two-fold:

1. Only subscribe to KeepKey events if a KeepKey is connected (additionally, I applied the same logic to the Native event hook for good measure).

2. Decouple the "connected wallet" state from the "model flow type" (names are hard). The second bug that this fixes is, for e.g., if you clicked "Switch Wallet" and selected "KeepKey", the state would update such that the connected wallet gets set to KeepKey _before_ the connection took place. This meant that if you pressed "back" you'd be in a really weird place. 

A final note, I don't really know why the latest performance issues make all of this more apparent, because as far as I can tell this code was always logically flawed.

## Pull Request Type

- [x] :bug: Bug fix (Non-breaking Change: Fixes an issue)
- [ ] :hammer_and_wrench: Chore (Non-breaking Change: Doc updates, pkg upgrades, typos, etc..)
- [ ] :nail_care: New Feature (Breaking/Non-breaking Change)

## Issue (if applicable)

N/A, production issue.

## Risk

Medium - impacts wallet events (especially Native and KeepKey), switching wallet logic, and connected wallet functionality.

## Testing

Test:

- Switching between wallets, especially Native, KeepKey, and MetaMask
- Events from Native (password entry) and KeepKey (PIN entry, changing passwork, signing messages etc)

### Engineering

☝️

### Operations

☝️

## Screenshots (if applicable)

The bad state:

<img width="275" alt="Screenshot 2023-07-31 at 10 04 03 am" src="https://github.com/shapeshift/web/assets/97164662/c80d4cc9-f440-49a6-9e7e-7c64067d700e">
<img width="268" alt="Screenshot 2023-07-31 at 10 04 07 am" src="https://github.com/shapeshift/web/assets/97164662/8643d4bf-1aae-4bb6-8d4b-92a284ed6169">
<img width="812" alt="Screenshot 2023-07-31 at 10 05 07 am" src="https://github.com/shapeshift/web/assets/97164662/be400a33-1463-4506-9709-a245b38a5bf5">
