### PR TITLE
fix: only fire fail/success events once

### DIFF
--- a/src/components/MultiHopTrade/components/TradeConfirm/TradeConfirm.tsx
+++ b/src/components/MultiHopTrade/components/TradeConfirm/TradeConfirm.tsx
@@ -15,7 +15,7 @@ import {
   useColorModeValue,
 } from '@chakra-ui/react'
 import { TxStatus } from '@shapeshiftoss/unchained-client'
-import { useCallback, useEffect, useMemo } from 'react'
+import { useCallback, useEffect, useMemo, useState } from 'react'
 import { useFormContext } from 'react-hook-form'
 import { useTranslate } from 'react-polyglot'
 import { useHistory } from 'react-router-dom'
@@ -72,6 +72,7 @@ export const TradeConfirm = () => {
   const borderColor = useColorModeValue('gray.100', 'gray.750')
   const alertColor = useColorModeValue('yellow.500', 'yellow.200')
   const warningColor = useColorModeValue('red.600', 'red.400')
+  const [hasMixpanelFired, setHasMixpanelFired] = useState(false)
   const {
     handleSubmit,
     formState: { isSubmitting },
@@ -155,14 +156,16 @@ export const TradeConfirm = () => {
   )
 
   useEffect(() => {
-    if (!mixpanel || !eventData) return
+    if (!mixpanel || !eventData || hasMixpanelFired) return
     if (status === TxStatus.Confirmed) {
       mixpanel.track(MixPanelEvents.TradeSuccess, eventData)
+      setHasMixpanelFired(true)
     }
     if (status === TxStatus.Failed) {
       mixpanel.track(MixPanelEvents.TradeFailed, eventData)
+      setHasMixpanelFired(true)
     }
-  }, [eventData, mixpanel, status])
+  }, [eventData, hasMixpanelFired, mixpanel, status])
 
   const handleBack = useCallback(() => {
     if (sellTxHash) {


### PR DESCRIPTION
## Description

Fixes an issue where MixPanel trade success and fail events were being fired more than once due to reactivity of their containing useEvent.

Set a one-way switch to ensure this event is only fired once.

## Pull Request Type

- [x] :bug: Bug fix (Non-breaking Change: Fixes an issue)
- [ ] :hammer_and_wrench: Chore (Non-breaking Change: Doc updates, pkg upgrades, typos, etc..)
- [ ] :nail_care: New Feature (Breaking/Non-breaking Change)

## Issue (if applicable)

N/A, related Discord discussion: https://discord.com/channels/554694662431178782/885616186623148062/1134582539844067449

## Risk

Very small.

## Testing

When performing a trade, see that the TradeSuccess event is only being fired once if the trade is successful, or that the TradeFailed event is being fired only once if the trade is not successful.

### Engineering

☝️

### Operations

☝️

## Screenshots (if applicable)

N/A
