### PR TITLE
fix: send modal close

### DIFF
--- a/src/context/ModalProvider/ModalContainer.tsx
+++ b/src/context/ModalProvider/ModalContainer.tsx
@@ -46,7 +46,7 @@ export const createModalProviderInner = <T extends keyof Modals>({
     }, [close, open, state])
 
     return (
-      <Provider value={value}>
+      <Provider key={key} value={value}>
         {children}
         {/* @ts-ignore ts not smart enough to know React.ComponentProps<Modals[T]> are props for Modals[T] */}
         {state.isOpen && <Component {...state.props} />}

--- a/src/context/ModalProvider/ModalProvider.tsx
+++ b/src/context/ModalProvider/ModalProvider.tsx
@@ -41,20 +41,17 @@ const MODALS: Modals = {
 } as const
 
 export const createModalProvider = () => {
-  let CombinedProvider = ({ children }: { children: React.ReactNode }) => <>{children}</>
-
-  Object.entries(MODALS).forEach(([key, Component]) => {
-    const InnerProvider = createModalProviderInner({ key: key as keyof Modals, Component })
-
-    const CurrentProvider = CombinedProvider
-    CombinedProvider = ({ children }) => (
-      <InnerProvider>
-        <CurrentProvider>{children}</CurrentProvider>
-      </InnerProvider>
-    )
+  const providers = Object.entries(MODALS).map(([key, Component]) => {
+    return createModalProviderInner({ key: key as keyof Modals, Component })
   })
 
-  return CombinedProvider
+  return ({ children }: { children: React.ReactNode }) => (
+    <>
+      {providers.reduceRight((children, Provider, index) => {
+        return <Provider key={index}>{children}</Provider>
+      }, children)}
+    </>
+  )
 }
 
 export const ModalProvider = createModalProvider()


### PR DESCRIPTION
## Description

This fixes the send modal currently not closing after successful Tx.

short tl;dr:

This guy isn't defined and makes us throw, meaning the next line will never be evaluated, thus we will never close the modal.

https://github.com/shapeshift/web/blob/4dfb467f4a5886e33e1716c904066fdc298bc46d/src/components/Modals/Send/hooks/useFormSend/useFormSend.tsx#L73

Long tl;dr:

https://github.com/shapeshift/web/pull/4971 brought a refactor of modals, where in addition to perf. improvements, we nest all modal providers inside each other.

This theoretically works, but doesn't if you try and use `useModal()` twice within the same component, with two different modals. The reason for that is actually a missing key in `<Provider />`, meaning that each provider isn't properly identified, and calling `useModal()` twice will try and use the context of the previous `useModal('')`, resulting in an empty object context for the current modal, and `useModal('qrCode')` returning undefined, hence us throwing in the line mentioned above.

## Pull Request Type

- [x] :bug: Bug fix (Non-breaking Change: Fixes an issue)
- [ ] :hammer_and_wrench: Chore (Non-breaking Change: Doc updates, pkg upgrades, typos, etc..)
- [ ] :nail_care: New Feature (Breaking/Non-breaking Change)

## Issue (if applicable)

<!-----------------------------------------------------------------------------
If applicable, please link to the github issue and put `closes #XXXX` in your comment to auto-close the issue that your PR fixes.
------------------------------------------------------------------------------>

- closes https://github.com/shapeshift/web/issues/5001
- closes https://github.com/shapeshift/web/issues/4967


## Risk

<!-----------------------------------------------------------------------------
Outline the scope of your changes and the risk associated with them. You must use your discretion as an engineer to determine the potential impact of your changes.

E.g. an upgrade to `hdwallet` or core state management would be considered higher risk, and might require a full regression test. UI or isolated view changes, or something behind a feature flag may have near zero risk. Small bug fixes might require testing isolated to the specific fix.
------------------------------------------------------------------------------>

- None

## Testing

<!-----------------------------------------------------------------------------
We treat every PR to be merged with the same scrutiny as if we were merging directly to production.

Your PR will not be merged if you do not complete the sections below for our engineering and operations teams to test.
------------------------------------------------------------------------------>

- Do a send of any asset
- Ensure the send modal closes after send

### Engineering

<!-----------------------------------------------------------------------------
Include sufficient information here for an engineer to test your PR. This may include how to test locally, in a built environment, changes to infrastructure etc.
------------------------------------------------------------------------------>

- ☝🏽 

### Operations

<!-----------------------------------------------------------------------------
If your changes have a user-facing impact, describe how a non-technical QA team can functionally test your changes in a preview environment.

If they are not user-facing please describe how to test for any regressions that may occur.
------------------------------------------------------------------------------>

- ☝🏽 

## Screenshots (if applicable)
