### PR TITLE
fix: yat invoke mobile handler

### DIFF
--- a/src/Routes/Routes.tsx
+++ b/src/Routes/Routes.tsx
@@ -12,6 +12,7 @@ import { Flags } from 'pages/Flags/Flags'
 import { PrivacyPolicy } from 'pages/Legal/PrivacyPolicy'
 import { TermsOfService } from 'pages/Legal/TermsOfService'
 import { NotFound } from 'pages/NotFound/NotFound'
+import { Yat } from 'pages/Yat/Yat'
 import { preferences } from 'state/slices/preferencesSlice/preferencesSlice'
 import { selectSelectedLocale } from 'state/slices/selectors'
 import { useAppSelector } from 'state/store'
@@ -95,7 +96,9 @@ export const Routes = memo(() => {
   return (
     <Switch location={locationProps}>
       <Route path='/demo'>{renderRedirect}</Route>
-
+      <Route path='/yat/:eid'>
+        <Yat />
+      </Route>
       <Route path='/connect-wallet'>
         <ConnectWallet />
       </Route>

--- a/src/Routes/RoutesCommon.tsx
+++ b/src/Routes/RoutesCommon.tsx
@@ -17,7 +17,6 @@ import { Flags } from 'pages/Flags/Flags'
 import { Missions } from 'pages/Missions/Missions'
 import { Trade } from 'pages/Trade/Trade'
 import { TransactionHistory } from 'pages/TransactionHistory/TransactionHistory'
-import { Yat } from 'pages/Yat/Yat'
 
 import type { Route as NestedRoute } from './helpers'
 import { RouteCategory } from './helpers'
@@ -140,11 +139,5 @@ export const routes: NestedRoute[] = [
       window.location.hostname !== 'localhost' &&
       window.location.hostname !== getConfig().REACT_APP_LOCAL_IP,
     main: Flags,
-  },
-  {
-    path: '/yat',
-    label: 'Yat',
-    hide: true,
-    main: Yat,
   },
 ]

--- a/src/pages/Yat/Yat.tsx
+++ b/src/pages/Yat/Yat.tsx
@@ -3,13 +3,16 @@ import type { AssetId } from '@shapeshiftoss/caip'
 import { ethAssetId } from '@shapeshiftoss/caip'
 import { Summary } from 'features/defi/components/Summary'
 import { useEffect, useState } from 'react'
+import { isMobile } from 'react-device-detect'
 import { useTranslate } from 'react-polyglot'
-import { matchPath, useHistory, useLocation } from 'react-router'
+import { matchPath, useLocation } from 'react-router'
 import { NavLink } from 'react-router-dom'
 import { YatIcon } from 'components/Icons/YatIcon'
 import { usdcAssetId } from 'components/Modals/FiatRamps/config'
 import { Row } from 'components/Row/Row'
+import { useBrowserRouter } from 'hooks/useBrowserRouter/useBrowserRouter'
 import { resolveYat, validateYat } from 'lib/address/yat'
+import { isMobile as isMobileApp } from 'lib/globals'
 
 /**
  * see https://github.com/shapeshift/web/issues/4604
@@ -29,8 +32,20 @@ export const Yat: React.FC = () => {
   const translate = useTranslate()
   const [maybeYatEthAddress, setMaybeYatEthAddress] = useState<string | null>(null)
   const [maybeYatUsdcAddress, setMaybeYatUsdcAddress] = useState<string | null>(null)
-  const history = useHistory()
+  const { history } = useBrowserRouter()
   const { pathname } = useLocation()
+
+  /**
+   * yat can't, or doesn't want to do device detection on their
+   * successful payment page to link back to shapeshift
+   *
+   * the user will be in a browser to buy a yat, not on the mobile app.
+   * hence, when yat sends them back to the app.shapeshift.com/#/yat/eid
+   * link, we detect if they're on a mobile device, but not the app,
+   * and invoke the handler to open the mobile app, otherwise link back to desktop
+   */
+
+  const showMobileHandler = isMobile && !isMobileApp
 
   useEffect(() => {
     const eidMatch = matchPath<{ eid?: string }>(pathname, {
@@ -102,9 +117,9 @@ export const Yat: React.FC = () => {
             <Row.Label>{translate('features.yat.usdcAddress')}</Row.Label>
             <Row.Value wordBreak='break-all'>
               {maybeYatUsdcAddress === null
-                ? 'loading'
+                ? 'Loading...'
                 : maybeYatUsdcAddress === ''
-                ? 'no usdc addy'
+                ? 'No USDC Address Found'
                 : maybeYatUsdcAddress}
             </Row.Value>
           </Row>
@@ -112,16 +127,28 @@ export const Yat: React.FC = () => {
             <Row.Label>{translate('features.yat.ethAddress')}</Row.Label>
             <Row.Value wordBreak='break-all'>
               {maybeYatEthAddress === null
-                ? 'loading'
+                ? 'Loading...'
                 : maybeYatEthAddress === ''
-                ? 'no eth addy'
+                ? 'No ETH Address Found'
                 : maybeYatEthAddress}
             </Row.Value>
           </Row>
         </Summary>
-        <Button as={NavLink} to='/dashboard' colorScheme='blue' size='lg' mt={6}>
-          {translate('common.viewMyWallet')}
-        </Button>
+        {showMobileHandler ? (
+          <Button
+            as='a'
+            href={'shapeshift://yat/%F0%9F%A6%8A%F0%9F%9A%80%F0%9F%8C%88'}
+            colorScheme='blue'
+            size='lg'
+            mt={6}
+          >
+            View in ShapeShift mobile app
+          </Button>
+        ) : (
+          <Button as={NavLink} to='/dashboard' colorScheme='blue' size='lg' mt={6}>
+            {translate('common.viewMyWallet')}
+          </Button>
+        )}
       </Card>
     </Center>
   )


### PR DESCRIPTION
## Description

<!-- Please describe your changes -->

we partner with yat, sending users to their site to purchase a yat.

after a user has completed the purchase flow, *in their browser*, yat includes a link back to shapeshift.

on the vendor site, they did not want to do device detection to use separate links.

after conversations with yat, and as of writing, they now always link back to `https://app.shapeshift.com/#/yat/:eid`, where `:eid` is the purchased yat, in URL-encoded form.

accordingly, this PR

* makes the `/yat/:eid` route public, making it work with or without a wallet connected, e.g. i have purchased a yat on my mobile device in a browser, clicked the link in my browser, which takes me to a shapeshift look and feel page, which then...
* makes the button route to `/dashboard` on desktop
* makes the button route to the `shapeshift://yat/:eid` mobile app handler if the user is on a mobile device, but not in the mobile app

if a users wallet it not connected, on desktop the router will kick them to the connect wallet page. on mobile, biometrics will authenticate them and bring them back into the app.

## Pull Request Type

- [ ] :bug: Bug fix (Non-breaking Change: Fixes an issue)
- [ ] :hammer_and_wrench: Chore (Non-breaking Change: Doc updates, pkg upgrades, typos, etc..)
- [x] :nail_care: New Feature (Breaking/Non-breaking Change)

## Issue (if applicable)

<!-----------------------------------------------------------------------------
If applicable, please link to the github issue and put `closes #XXXX` in your comment to auto-close the issue that your PR fixes.
------------------------------------------------------------------------------>

finally closes #4604 (again?)

## Risk

low

<!-----------------------------------------------------------------------------
Outline the scope of your changes and the risk associated with them. You must use your discretion as an engineer to determine the potential impact of your changes.

E.g. an upgrade to `hdwallet` or core state management would be considered higher risk, and might require a full regression test. UI or isolated view changes, or something behind a feature flag may have near zero risk. Small bug fixes might require testing isolated to the specific fix.
------------------------------------------------------------------------------>

## Testing

http://release.shapeshift.com/#/yat/%F0%9F%A6%8A%F0%9F%9A%80%F0%9F%8C%88

### on desktop

* disconnect your wallet
* navigate to the url above. note we're using the yat associated with willywonka.eth for testing purposes. for users, this will be populated with the yat they've purchased

* note that you're able to view this link without a connected wallet
* note that the button will link to `/dashboard`

### on mobile

* navigate to the link above, notice it will open in a browser
* click the button, it will prompt you to open the mobile app
* the yat page will then open within the mobile app
* the button will then take you back to the dashboard

<!-----------------------------------------------------------------------------
We treat every PR to be merged with the same scrutiny as if we were merging directly to production.

Your PR will not be merged if you do not complete the sections below for our engineering and operations teams to test.
------------------------------------------------------------------------------>

### Engineering

<!-----------------------------------------------------------------------------
Include sufficient information here for an engineer to test your PR. This may include how to test locally, in a built environment, changes to infrastructure etc.
------------------------------------------------------------------------------>

### Operations

<!-----------------------------------------------------------------------------
If your changes have a user-facing impact, describe how a non-technical QA team can functionally test your changes in a preview environment.

If they are not user-facing please describe how to test for any regressions that may occur.
------------------------------------------------------------------------------>

## Screenshots (if applicable)

incoming
