### PR TITLE
feat: hide slippage for osmosis swapper

### DIFF
--- a/src/components/MultiHopTrade/components/TradeInput/TradeInput.tsx
+++ b/src/components/MultiHopTrade/components/TradeInput/TradeInput.tsx
@@ -39,6 +39,7 @@ import type { Asset } from 'lib/asset-service'
 import { bnOrZero, positiveOrZero } from 'lib/bignumber/bignumber'
 import { getMixPanel } from 'lib/mixpanel/mixPanelSingleton'
 import { MixPanelEvents } from 'lib/mixpanel/types'
+import { SwapperName } from 'lib/swapper/api'
 import {
   selectSwappersApiTradeQuotePending,
   selectSwappersApiTradeQuotes,
@@ -134,6 +135,7 @@ export const TradeInput = memo(() => {
   const activeQuote = useAppSelector(selectActiveQuote)
   const activeQuoteError = useAppSelector(selectActiveQuoteError)
   const activeSwapperName = useAppSelector(selectActiveSwapperName)
+  const isOsmosisSwapper = activeSwapperName === SwapperName.Osmosis
   const sortedQuotes = useAppSelector(selectSwappersApiTradeQuotes)
   const rate = activeQuote?.steps[0].rate
 
@@ -241,7 +243,7 @@ export const TradeInput = memo(() => {
             <Heading as='h5' fontSize='md'>
               {translate('navBar.trade')}
             </Heading>
-            <SlippagePopover />
+            {!isOsmosisSwapper && <SlippagePopover />}
           </Flex>
           <Stack spacing={2}>
             <Flex alignItems='center' flexDir={flexDir} width='full'>


### PR DESCRIPTION
## Description

The Osmosis swapper does not conceptually support slippage, and so the new slippage popover has no effect.

This PR hides the slippage button when the Osmosis swapper is selected. 

## Pull Request Type

- [ ] :bug: Bug fix (Non-breaking Change: Fixes an issue)
- [ ] :hammer_and_wrench: Chore (Non-breaking Change: Doc updates, pkg upgrades, typos, etc..)
- [x] :nail_care: New Feature (Breaking/Non-breaking Change)

## Issue (if applicable)

N/A

## Risk

Very small.

## Testing

Get a quote that can be performed by the Osmosis swapper. When this swapper is selected the button to open the slippage settings should not show.

### Engineering

☝️

### Operations

☝️

## Screenshots (if applicable)

<img width="485" alt="Screenshot 2023-08-07 at 10 09 25 am" src="https://github.com/shapeshift/web/assets/97164662/c9db1252-8490-40b0-8ba3-56a3996cd99f">
