### PR TITLE
fix: use swapper default slippage

### DIFF
--- a/src/components/MultiHopTrade/hooks/useGetTradeQuotes/getTradeQuoteArgs.ts
+++ b/src/components/MultiHopTrade/hooks/useGetTradeQuotes/getTradeQuoteArgs.ts
@@ -20,7 +20,7 @@ export type GetTradeQuoteInputArgs = {
   sellAccountNumber: number
   wallet: HDWallet
   receiveAddress: string
-  slippageTolerancePercentage: string
+  slippageTolerancePercentage?: string
   // Required for Osmo trades
   receiveAccountNumber?: number
   sellAmountBeforeFeesCryptoPrecision: string

--- a/src/components/MultiHopTrade/hooks/useGetTradeQuotes/useGetTradeQuotes.tsx
+++ b/src/components/MultiHopTrade/hooks/useGetTradeQuotes/useGetTradeQuotes.tsx
@@ -22,13 +22,13 @@ import {
   selectSellAccountId,
   selectSellAmountCryptoPrecision,
   selectSellAsset,
+  selectSlippagePreferencePercentageDecimal,
   selectWillDonate,
 } from 'state/slices/selectors'
 import {
   selectFirstHopSellAsset,
   selectLastHopBuyAsset,
   selectSellAmountUsd,
-  selectTradeSlippagePercentageDecimal,
 } from 'state/slices/tradeQuoteSlice/selectors'
 import { tradeQuoteSlice } from 'state/slices/tradeQuoteSlice/tradeQuoteSlice'
 import { store, useAppDispatch, useAppSelector } from 'state/store'
@@ -103,7 +103,7 @@ export const useGetTradeQuotes = () => {
   const sellAccountId = useAppSelector(selectSellAccountId)
   const buyAccountId = useAppSelector(selectBuyAccountId)
 
-  const slippageTolerancePercentage = useAppSelector(selectTradeSlippagePercentageDecimal)
+  const userSlippageTolerancePercentage = useAppSelector(selectSlippagePreferencePercentageDecimal)
 
   const sellAccountMetadata = useMemo(() => {
     return selectPortfolioAccountMetadataByAccountId(store.getState(), {
@@ -141,7 +141,8 @@ export const useGetTradeQuotes = () => {
           sellAmountBeforeFeesCryptoPrecision: sellAmountCryptoPrecision,
           allowMultiHop: true,
           affiliateBps: willDonate ? DEFAULT_SWAPPER_DONATION_BPS : '0',
-          slippageTolerancePercentage,
+          // Pass in the user's slippage preference if it's set, else let the swapper use its default
+          slippageTolerancePercentage: userSlippageTolerancePercentage,
         })
 
         // if the quote input args changed, reset the selected swapper and update the trade quote args
@@ -150,7 +151,7 @@ export const useGetTradeQuotes = () => {
             ? setTradeQuoteInput(updatedTradeQuoteInput)
             : setTradeQuoteInput(skipToken)
 
-          // If only the affiliateBps or the slippageTolerancePercentage changed, we've either:
+          // If only the affiliateBps or the userSlippageTolerancePercentage changed, we've either:
           // - toggled the donation checkbox
           // - switched swappers where one has a different default slippageTolerancePercentage
           // In either case, we don't want to reset the selected swapper
@@ -179,7 +180,7 @@ export const useGetTradeQuotes = () => {
     wallet,
     userWillDonate,
     receiveAccountMetadata?.bip44Params,
-    slippageTolerancePercentage,
+    userSlippageTolerancePercentage,
   ])
 
   useEffect(() => {

--- a/src/lib/swapper/api.ts
+++ b/src/lib/swapper/api.ts
@@ -80,7 +80,7 @@ type CommonTradeInput = {
   receiveAccountNumber?: number
   affiliateBps: string
   allowMultiHop: boolean
-  slippageTolerancePercentage: string
+  slippageTolerancePercentage?: string
 }
 
 export type GetEvmTradeQuoteInput = CommonTradeInput & {

--- a/src/lib/swapper/swappers/LifiSwapper/getTradeQuote/getTradeQuote.ts
+++ b/src/lib/swapper/swappers/LifiSwapper/getTradeQuote/getTradeQuote.ts
@@ -5,6 +5,7 @@ import { fromChainId } from '@shapeshiftoss/caip'
 import type { HDWallet } from '@shapeshiftoss/hdwallet-core'
 import type { Result } from '@sniptt/monads'
 import { Err, Ok } from '@sniptt/monads'
+import { getDefaultSlippagePercentageForSwapper } from 'constants/constants'
 import type { Asset } from 'lib/asset-service'
 import { bn, bnOrZero, convertPrecision } from 'lib/bignumber/bignumber'
 import type { GetEvmTradeQuoteInput, SwapErrorRight } from 'lib/swapper/api'
@@ -76,7 +77,9 @@ export async function getTradeQuote(
       options: {
         // used for analytics and donations - do not change this without considering impact
         integrator: LIFI_INTEGRATOR_ID,
-        slippage: Number(slippageTolerancePercentage),
+        slippage: Number(
+          slippageTolerancePercentage ?? getDefaultSlippagePercentageForSwapper(SwapperName.LIFI),
+        ),
         exchanges: { deny: ['dodo'] },
         // TODO(gomes): We don't currently handle trades that require a mid-trade user-initiated Tx on a different chain
         // i.e we would theoretically handle the Tx itself, but not approvals on said chain if needed

--- a/src/lib/swapper/swappers/ThorchainSwapper/getThorTradeQuote/getTradeQuote.ts
+++ b/src/lib/swapper/swappers/ThorchainSwapper/getThorTradeQuote/getTradeQuote.ts
@@ -11,6 +11,7 @@ import type { HDWallet } from '@shapeshiftoss/hdwallet-core'
 import type { Result } from '@sniptt/monads'
 import { Err, Ok } from '@sniptt/monads'
 import { getConfig } from 'config'
+import { getDefaultSlippagePercentageForSwapper } from 'constants/constants'
 import { getChainAdapterManager } from 'context/PluginProvider/chainAdapterSingleton'
 import type { BigNumber } from 'lib/bignumber/bignumber'
 import { baseUnitToPrecision, bn, bnOrZero, convertPrecision } from 'lib/bignumber/bignumber'
@@ -70,6 +71,9 @@ export const getThorTradeQuote = async (
     affiliateBps,
     wallet,
   } = input
+
+  const slippageTolerance =
+    slippageTolerancePercentage ?? getDefaultSlippagePercentageForSwapper(SwapperName.Thorchain)
 
   const { sellAssetUsdRate, buyAssetUsdRate, feeAssetUsdRate } = rates
 
@@ -246,7 +250,7 @@ export const getThorTradeQuote = async (
           sellAsset,
           buyAsset,
           sellAmountCryptoBaseUnit,
-          slippageTolerance: slippageTolerancePercentage,
+          slippageTolerance,
           destinationAddress: receiveAddress,
           protocolFees,
           affiliateBps,
@@ -293,7 +297,7 @@ export const getThorTradeQuote = async (
           sellAsset,
           buyAsset,
           sellAmountCryptoBaseUnit,
-          slippageTolerance: slippageTolerancePercentage,
+          slippageTolerance,
           destinationAddress: receiveAddress,
           xpub: (input as GetUtxoTradeQuoteInput).xpub,
           protocolFees,

--- a/src/lib/swapper/swappers/ZrxSwapper/getZrxTradeQuote/getZrxTradeQuote.ts
+++ b/src/lib/swapper/swappers/ZrxSwapper/getZrxTradeQuote/getZrxTradeQuote.ts
@@ -1,9 +1,10 @@
 import type { Result } from '@sniptt/monads'
 import { Err, Ok } from '@sniptt/monads'
+import { getDefaultSlippagePercentageForSwapper } from 'constants/constants'
 import { bn, bnOrZero } from 'lib/bignumber/bignumber'
 import { toBaseUnit } from 'lib/math'
 import type { GetEvmTradeQuoteInput, SwapErrorRight, TradeQuote } from 'lib/swapper/api'
-import { makeSwapErrorRight, SwapErrorType } from 'lib/swapper/api'
+import { makeSwapErrorRight, SwapErrorType, SwapperName } from 'lib/swapper/api'
 import { getTreasuryAddressFromChainId } from 'lib/swapper/swappers/utils/helpers/helpers'
 import type { ZrxPriceResponse, ZrxSupportedChainId } from 'lib/swapper/swappers/ZrxSwapper/types'
 import {
@@ -66,7 +67,8 @@ export async function getZrxTradeQuote<T extends ZrxSupportedChainId>(
       takerAddress: receiveAddress,
       affiliateAddress: AFFILIATE_ADDRESS, // Used for 0x analytics
       skipValidation: true,
-      slippagePercentage: slippageTolerancePercentage,
+      slippagePercentage:
+        slippageTolerancePercentage ?? getDefaultSlippagePercentageForSwapper(SwapperName.Zrx),
       feeRecipient: getTreasuryAddressFromChainId(buyAsset.chainId), // Where affiliate fees are sent
       buyTokenPercentageFee: convertBasisPointsToDecimalPercentage(affiliateBps).toNumber(),
     },


### PR DESCRIPTION
## Description

Fixes the logic used in `useGetTradeQuotes.tsx`.

We can't use `selectTradeSlippagePercentageDecimal` because it relies on us having already selected a swapper, which can't occur until the quotes come back (quotes coming back was causing a active swapper update, triggering another network request).

We now instead handle this inside the swappers themselves when they are fetching quotes.

The current logic was causing us to double fetch qoutes when the first lot of quotes came back with a new best swapper, causing another network request to be triggered with the actual quote value.

Note, more changes are needed to support user selectable slippage, but this fix unrugs release with the flag off.

## Pull Request Type

- [x] :bug: Bug fix (Non-breaking Change: Fixes an issue)
- [ ] :hammer_and_wrench: Chore (Non-breaking Change: Doc updates, pkg upgrades, typos, etc..)
- [ ] :nail_care: New Feature (Breaking/Non-breaking Change)

## Issue (if applicable)

Unblocks release `1.394.0`.

## Risk

Small.

## Testing

Slippage values in all network requests should be the swapper defaults returned from `getDefaultSlippagePercentageForSwapper` (0.2% for all except LifI and CoW, which are 0.5%).

There should only be one network request per quote again.

### Engineering

☝️

### Operations

☝️

## Screenshots (if applicable)

N/A
