### PR TITLE
fix: hide CoW Swapper slippage

### DIFF
--- a/src/components/MultiHopTrade/components/TradeInput/TradeInput.tsx
+++ b/src/components/MultiHopTrade/components/TradeInput/TradeInput.tsx
@@ -24,6 +24,7 @@ import { TradeAssetInput } from 'components/MultiHopTrade/components/TradeAssetI
 import { ReceiveSummary } from 'components/MultiHopTrade/components/TradeConfirm/ReceiveSummary'
 import { DonationCheckbox } from 'components/MultiHopTrade/components/TradeInput/components/DonationCheckbox'
 import { ManualAddressEntry } from 'components/MultiHopTrade/components/TradeInput/components/ManualAddressEntry'
+import { getSwapperSupportsSlippage } from 'components/MultiHopTrade/components/TradeInput/getSwapperSupportsSlippage'
 import { getMixpanelEventData } from 'components/MultiHopTrade/helpers'
 import { useActiveQuoteStatus } from 'components/MultiHopTrade/hooks/quoteValidation/useActiveQuoteStatus'
 import { checkApprovalNeeded } from 'components/MultiHopTrade/hooks/useAllowanceApproval/helpers'
@@ -39,7 +40,6 @@ import type { Asset } from 'lib/asset-service'
 import { bnOrZero, positiveOrZero } from 'lib/bignumber/bignumber'
 import { getMixPanel } from 'lib/mixpanel/mixPanelSingleton'
 import { MixPanelEvents } from 'lib/mixpanel/types'
-import { SwapperName } from 'lib/swapper/api'
 import {
   selectSwappersApiTradeQuotePending,
   selectSwappersApiTradeQuotes,
@@ -135,7 +135,7 @@ export const TradeInput = memo(() => {
   const activeQuote = useAppSelector(selectActiveQuote)
   const activeQuoteError = useAppSelector(selectActiveQuoteError)
   const activeSwapperName = useAppSelector(selectActiveSwapperName)
-  const isOsmosisSwapper = activeSwapperName === SwapperName.Osmosis
+  const activeSwapperSupportsSlippage = getSwapperSupportsSlippage(activeSwapperName)
   const sortedQuotes = useAppSelector(selectSwappersApiTradeQuotes)
   const rate = activeQuote?.steps[0].rate
 
@@ -243,7 +243,7 @@ export const TradeInput = memo(() => {
             <Heading as='h5' fontSize='md'>
               {translate('navBar.trade')}
             </Heading>
-            {!isOsmosisSwapper && <SlippagePopover />}
+            {activeSwapperSupportsSlippage && <SlippagePopover />}
           </Flex>
           <Stack spacing={2}>
             <Flex alignItems='center' flexDir={flexDir} width='full'>

--- a/src/components/MultiHopTrade/components/TradeInput/getSwapperSupportsSlippage.ts
+++ b/src/components/MultiHopTrade/components/TradeInput/getSwapperSupportsSlippage.ts
@@ -1,0 +1,19 @@
+import { SwapperName } from 'lib/swapper/api'
+import { assertUnreachable } from 'lib/utils'
+
+export const getSwapperSupportsSlippage = (swapperName: SwapperName | undefined) => {
+  if (swapperName === undefined) return false
+  switch (swapperName) {
+    case SwapperName.Thorchain:
+    case SwapperName.Zrx:
+    case SwapperName.OneInch:
+    case SwapperName.LIFI:
+      return true
+    case SwapperName.Osmosis:
+    case SwapperName.Test:
+    case SwapperName.CowSwap:
+      return false
+    default:
+      assertUnreachable(swapperName)
+  }
+}


### PR DESCRIPTION
## Description

CoW Swap doesn't support slippage via their API, as swaps are MEV protected.
Orders are already submitted with a 0.1% spread on chain.

The CoW Swap app's UI does have a concept of slippage, but they handle this at a client level by resubmitting a user's order if marked conditions change (a paradigm we do not have).

Also extracts related logic to a helper function.

## Pull Request Type

- [ ] :bug: Bug fix (Non-breaking Change: Fixes an issue)
- [x] :hammer_and_wrench: Chore (Non-breaking Change: Doc updates, pkg upgrades, typos, etc..)
- [ ] :nail_care: New Feature (Breaking/Non-breaking Change)

## Issue (if applicable)

N/A

## Risk

Small.

## Testing

The slippage opion should only be shown on the quotes screen if the selected swapper supports slippage.

### Engineering

☝️

### Operations

☝️

## Screenshots (if applicable)

N/A
