### PR TITLE
fix: invert error logic

### DIFF
--- a/src/components/MultiHopTrade/hooks/quoteValidation/useActiveQuoteStatus.tsx
+++ b/src/components/MultiHopTrade/hooks/quoteValidation/useActiveQuoteStatus.tsx
@@ -50,7 +50,7 @@ export const useActiveQuoteStatus = (): QuoteStatus => {
   )
 
   const quoteErrors: ActiveQuoteStatus[] = useMemo(() => {
-    if (isLoading || hasUserEnteredAmount) return []
+    if (isLoading || !hasUserEnteredAmount) return []
     const errors: ActiveQuoteStatus[] = []
     if (activeQuoteError) {
       // Map known swapper errors to quote status


### PR DESCRIPTION
## Description

Fix a very silly logic error 🤦‍♂️ where `hasUserEnteredAmount` was not inverted when it should have been, causing us to never validate quote inputs.

## Pull Request Type

- [x] :bug: Bug fix (Non-breaking Change: Fixes an issue)
- [ ] :hammer_and_wrench: Chore (Non-breaking Change: Doc updates, pkg upgrades, typos, etc..)
- [ ] :nail_care: New Feature (Breaking/Non-breaking Change)

## Issue (if applicable)

## Risk

Small.

## Testing

Quote validation input should be great again.

### Engineering

☝️

### Operations

☝️

## Screenshots (if applicable)

N/A
