### PR TITLE
fix: always listen to events

### DIFF
--- a/src/context/WalletProvider/KeepKey/hooks/useKeepKeyEventHandler.ts
+++ b/src/context/WalletProvider/KeepKey/hooks/useKeepKeyEventHandler.ts
@@ -246,14 +246,11 @@ export const useKeepKeyEventHandler = (
       }
     }
 
-    // We only want to listen to these events if a KeepKey is actually connected, or we are showing a KeepKey modal
-    if ([state.connectedType, state.modalType].includes(KeyManager.KeepKey)) {
-      // Handle all KeepKey events
-      keyring.on(['KeepKey', '*', '*'], handleEvent)
-      // HDWallet emits (DIS)CONNECT events as "KeepKey - {LABEL}" so we can't just listen for "KeepKey"
-      keyring.on(['*', '*', Events.CONNECT], handleConnect)
-      keyring.on(['*', '*', Events.DISCONNECT], handleDisconnect)
-    }
+    // Handle all KeepKey events
+    keyring.on(['KeepKey', '*', '*'], handleEvent)
+    // HDWallet emits (DIS)CONNECT events as "KeepKey - {LABEL}" so we can't just listen for "KeepKey"
+    keyring.on(['*', '*', Events.CONNECT], handleConnect)
+    keyring.on(['*', '*', Events.DISCONNECT], handleDisconnect)
 
     return () => {
       keyring.off(['KeepKey', '*', '*'], handleEvent)

--- a/src/context/WalletProvider/NativeWallet/hooks/useNativeEventHandler.ts
+++ b/src/context/WalletProvider/NativeWallet/hooks/useNativeEventHandler.ts
@@ -29,6 +29,12 @@ export const useNativeEventHandler = (state: InitialState, dispatch: Dispatch<Ac
       }
     }
 
+    /*
+      Ideally we'd only listen to these events if modalType is KeyManager.Native or KeyManager.Mobile.
+      Unfortunately, state.adapters is set in the React event loop via a useEffect, and so is null on initial load.
+      This prevents SET_CONNECTOR_TYPE from being dispatched on the first WalletProvider.load() cycle, which means we'd
+      miss the NativeEvents.MNEMONIC_REQUIRED event.
+     */
     if (keyring) {
       keyring.on(['Native', '*', NativeEvents.MNEMONIC_REQUIRED], handleEvent)
       keyring.on(['Native', '*', NativeEvents.READY], handleEvent)

--- a/src/context/WalletProvider/NativeWallet/hooks/useNativeEventHandler.ts
+++ b/src/context/WalletProvider/NativeWallet/hooks/useNativeEventHandler.ts
@@ -4,7 +4,6 @@ import type { Dispatch } from 'react'
 import { useEffect } from 'react'
 import type { ActionTypes } from 'context/WalletProvider/actions'
 import { WalletActions } from 'context/WalletProvider/actions'
-import { KeyManager } from 'context/WalletProvider/KeyManager'
 import type { InitialState } from 'context/WalletProvider/WalletProvider'
 
 export const useNativeEventHandler = (state: InitialState, dispatch: Dispatch<ActionTypes>) => {
@@ -30,7 +29,7 @@ export const useNativeEventHandler = (state: InitialState, dispatch: Dispatch<Ac
       }
     }
 
-    if (keyring && modalType && [KeyManager.Native, KeyManager.Mobile].includes(modalType)) {
+    if (keyring) {
       keyring.on(['Native', '*', NativeEvents.MNEMONIC_REQUIRED], handleEvent)
       keyring.on(['Native', '*', NativeEvents.READY], handleEvent)
     }


### PR DESCRIPTION
## Description

Brings back always-on event listeners, as we can't rely on values set in the React event loop to conditionally listen to events, as it causes some events to be missed.

## Pull Request Type

- [x] :bug: Bug fix (Non-breaking Change: Fixes an issue)
- [ ] :hammer_and_wrench: Chore (Non-breaking Change: Doc updates, pkg upgrades, typos, etc..)
- [ ] :nail_care: New Feature (Breaking/Non-breaking Change)

## Issue (if applicable)

Closes https://github.com/shapeshift/web/issues/5045

## Risk

Small.

## Testing

Refreshing on Native wallet should prompt for the password modal again, and KeepKey connections should be great.

### Engineering

☝️

### Operations

☝️

## Screenshots (if applicable)

N/A
