### PR TITLE
fix: lifi status polling broken due to caching in their sdk

### DIFF
--- a/src/lib/swapper/swappers/LifiSwapper/endpoints.ts
+++ b/src/lib/swapper/swappers/LifiSwapper/endpoints.ts
@@ -90,13 +90,6 @@ export const lifiApi: Swapper2Api = {
     const lifiRoute = tradeQuoteMetadata.get(quoteId)
     if (!lifiRoute) throw Error(`missing trade quote metadata for quoteId ${quoteId}`)
 
-    const getStatusRequest: GetStatusRequest = {
-      txHash,
-      bridge: lifiRoute.steps[0].tool,
-      fromChain: lifiRoute.fromChainId,
-      toChain: lifiRoute.toChainId,
-    }
-
     // getMixPanel()?.track(MixPanelEvents.SwapperApiRequest, {
     //   swapper: SwapperName.LIFI,
     //   method: 'get',
@@ -107,9 +100,13 @@ export const lifiApi: Swapper2Api = {
     // don't use lifi sdk here because all status responses are cached, negating the usefulness of polling
     // i.e don't do `await getLifi().getStatus(getStatusRequest)`
     const url = new URL('https://li.quest/v1/status')
-    url.search = new URLSearchParams(
-      getStatusRequest as unknown as Record<string, string>,
-    ).toString()
+    const getStatusRequestParams: { [Key in keyof GetStatusRequest]: string } = {
+      txHash,
+      bridge: lifiRoute.steps[0].tool,
+      fromChain: lifiRoute.fromChainId.toString(),
+      toChain: lifiRoute.toChainId.toString(),
+    }
+    url.search = new URLSearchParams(getStatusRequestParams).toString()
     const response = await fetch(url, { cache: 'no-store' }) // don't cache!
 
     if (!response.ok) return createDefaultStatusResponse()


### PR DESCRIPTION
## Description

Fixes infinite spinner for lifi trades. The issue turned out to be due to caching in their SDK, which I've bypassed for status polling.

## Pull Request Type

- [x] :bug: Bug fix (Non-breaking Change: Fixes an issue)
- [ ] :hammer_and_wrench: Chore (Non-breaking Change: Doc updates, pkg upgrades, typos, etc..)
- [ ] :nail_care: New Feature (Breaking/Non-breaking Change)

## Issue (if applicable)

closes #5049

## Risk

Extremely low risk, practically 0 as this only touches code for status polling for a spinner

## Testing

Do a same-chain swap with lifi

### Engineering

See above

### Operations

See above

## Screenshots (if applicable)

Lifi trade lifecycle working as intended
![image](https://github.com/shapeshift/web/assets/125113430/bc5fd125-5a91-4764-9ecd-6b148b3b21fd)
![image](https://github.com/shapeshift/web/assets/125113430/223dfe2e-c660-41ea-9f4f-cafb1d815c5a)

spinner show while status is not completed:
![image](https://github.com/shapeshift/web/assets/125113430/59b2d758-a870-419e-a8bc-8a4f06713d4c)
![image](https://github.com/shapeshift/web/assets/125113430/85e8b779-2dbd-4c6b-b278-fd39e736ea67)

Green tick appears when status is complete:
![image](https://github.com/shapeshift/web/assets/125113430/ccf6827c-5cfb-423d-b800-0f172b718ed5)
![image](https://github.com/shapeshift/web/assets/125113430/ba2d1a6e-4ed6-4923-9a7f-0be188a59236)


