### PR TITLE
feat: slippage improvements

### DIFF
--- a/src/components/MultiHopTrade/components/SlippagePopover.tsx
+++ b/src/components/MultiHopTrade/components/SlippagePopover.tsx
@@ -62,7 +62,6 @@ export const SlippagePopover: FC = () => {
   }, [])
 
   const handleChange = useCallback((value: string) => {
-    console.log('xxx handleChange', value)
     if (bnOrZero(value).gt(maxSlippagePercentage)) {
       setIsInvalid(true)
     } else {
@@ -97,8 +96,6 @@ export const SlippagePopover: FC = () => {
   const isLowSlippage = useMemo(() => bnOrZero(slippageAmount).lt(0.05), [slippageAmount])
 
   if (!isAdvancedSlippageEnabled) return null
-
-  console.log('xxx handleChange', { slippageAmount, isInvalid })
 
   return (
     <Popover placement='bottom-end' onClose={handleClose}>

--- a/src/components/MultiHopTrade/components/SlippagePopover.tsx
+++ b/src/components/MultiHopTrade/components/SlippagePopover.tsx
@@ -15,7 +15,6 @@ import {
   PopoverTrigger,
 } from '@chakra-ui/react'
 import { bnOrZero } from '@shapeshiftoss/chain-adapters'
-import { debounce } from 'lodash'
 import type { FC } from 'react'
 import { useCallback, useEffect, useMemo, useRef, useState } from 'react'
 import { FaSlidersH } from 'react-icons/fa'
@@ -24,7 +23,7 @@ import { HelperTooltip } from 'components/HelperTooltip/HelperTooltip'
 import { Row } from 'components/Row/Row'
 import { Text } from 'components/Text'
 import { useFeatureFlag } from 'hooks/useFeatureFlag/useFeatureFlag'
-import { selectSlippagePreferencePercentage } from 'state/slices/swappersSlice/selectors'
+import { selectUserSlippagePercentage } from 'state/slices/swappersSlice/selectors'
 import { swappers } from 'state/slices/swappersSlice/swappersSlice'
 import { selectQuoteOrDefaultSlippagePercentage } from 'state/slices/tradeQuoteSlice/selectors'
 import { useAppDispatch, useAppSelector } from 'state/store'
@@ -40,10 +39,12 @@ const focusStyle = { '&[aria-invalid=true]': { borderColor: 'red.500' } }
 
 export const SlippagePopover: FC = () => {
   const defaultSlippagePercentage = useAppSelector(selectQuoteOrDefaultSlippagePercentage)
-  const userSlippagePercentage = useAppSelector(selectSlippagePreferencePercentage)
+  const userSlippagePercentage = useAppSelector(selectUserSlippagePercentage)
 
   const [slippageType, setSlippageType] = useState<SlippageType>(SlippageType.Auto)
-  const [slippageAmount, setSlippageAmount] = useState(defaultSlippagePercentage)
+  const [slippageAmount, setSlippageAmount] = useState<string | undefined>(
+    defaultSlippagePercentage,
+  )
   const [isInvalid, setIsInvalid] = useState(false)
   const translate = useTranslate()
   const inputRef = useRef<HTMLInputElement>(null)
@@ -52,41 +53,31 @@ export const SlippagePopover: FC = () => {
 
   useEffect(() => {
     // Handles re-opening the slippage popover and/or going back to input step
-    if (userSlippagePercentage) setSlippageType(SlippageType.Custom)
-    else setSlippageType(SlippageType.Auto)
+    if (userSlippagePercentage) {
+      setSlippageType(SlippageType.Custom)
+      setSlippageAmount(userSlippagePercentage)
+    } else setSlippageType(SlippageType.Auto)
     // We only want this to run on mount, not to be reactive
     // eslint-disable-next-line react-hooks/exhaustive-deps
   }, [])
-  const handleDebounce = useCallback(
-    (value: string) => {
-      setSlippageAmount(value)
-      dispatch(swappers.actions.setSlippagePreferencePercentage(value))
-    },
-    [dispatch],
-  )
-  const debounceFnc = useMemo(() => debounce(handleDebounce, 100), [handleDebounce])
 
-  const handleChange = useCallback(
-    (value: string) => {
-      if (bnOrZero(value).gt(maxSlippagePercentage)) {
-        setIsInvalid(true)
-      } else {
-        debounceFnc(value)
-        setIsInvalid(false)
-      }
-      dispatch(swappers.actions.setSlippagePreferencePercentage(value))
-      setSlippageType(SlippageType.Custom)
-    },
-    [debounceFnc, dispatch],
-  )
-
-  useEffect(() => {
-    if (slippageType === SlippageType.Auto) {
-      setSlippageAmount(defaultSlippagePercentage)
+  const handleChange = useCallback((value: string) => {
+    console.log('xxx handleChange', value)
+    if (bnOrZero(value).gt(maxSlippagePercentage)) {
+      setIsInvalid(true)
     } else {
-      setSlippageAmount(userSlippagePercentage ?? defaultSlippagePercentage)
+      setIsInvalid(false)
     }
-  }, [defaultSlippagePercentage, slippageType, userSlippagePercentage])
+    setSlippageAmount(value)
+    setSlippageType(SlippageType.Custom)
+  }, [])
+
+  const handleClose = useCallback(() => {
+    if (slippageType === SlippageType.Custom && !isInvalid)
+      dispatch(swappers.actions.setSlippagePreferencePercentage(slippageAmount))
+    else if (slippageType === SlippageType.Auto)
+      dispatch(swappers.actions.setSlippagePreferencePercentage(undefined))
+  }, [dispatch, isInvalid, slippageAmount, slippageType])
 
   const handleSlippageTypeChange = useCallback(
     (type: SlippageType) => {
@@ -95,10 +86,11 @@ export const SlippagePopover: FC = () => {
         setIsInvalid(false)
       } else {
         inputRef && inputRef.current && inputRef.current.focus()
+        setSlippageAmount(slippageAmount)
       }
       setSlippageType(type)
     },
-    [defaultSlippagePercentage],
+    [defaultSlippagePercentage, slippageAmount],
   )
 
   const isHighSlippage = useMemo(() => bnOrZero(slippageAmount).gt(1), [slippageAmount])
@@ -106,8 +98,10 @@ export const SlippagePopover: FC = () => {
 
   if (!isAdvancedSlippageEnabled) return null
 
+  console.log('xxx handleChange', { slippageAmount, isInvalid })
+
   return (
-    <Popover placement='bottom-end'>
+    <Popover placement='bottom-end' onClose={handleClose}>
       <PopoverTrigger>
         <IconButton aria-label='Trade Settings' icon={<FaSlidersH />} variant='ghost' />
       </PopoverTrigger>
@@ -150,9 +144,7 @@ export const SlippagePopover: FC = () => {
                 <InputGroup variant='filled'>
                   <Input
                     placeholder={slippageAmount}
-                    value={
-                      slippageType === SlippageType.Auto ? slippageAmount : userSlippagePercentage
-                    }
+                    value={slippageAmount}
                     type='number'
                     _focus={focusStyle}
                     onChange={e => handleChange(e.target.value)}

--- a/src/components/MultiHopTrade/components/TradeInput/TradeInput.tsx
+++ b/src/components/MultiHopTrade/components/TradeInput/TradeInput.tsx
@@ -270,7 +270,7 @@ export const TradeInput = memo(() => {
             <Heading as='h5' fontSize='md'>
               {translate('navBar.trade')}
             </Heading>
-            {activeSwapperSupportsSlippage && <SlippagePopover />}
+            {(activeSwapperSupportsSlippage || sortedQuotes.length === 0) && <SlippagePopover />}
           </Flex>
           <Stack spacing={2}>
             <Flex alignItems='center' flexDir={flexDir} width='full'>

--- a/src/lib/swapper/swappers/ThorchainSwapper/getThorTradeQuote/getTradeQuote.test.ts
+++ b/src/lib/swapper/swappers/ThorchainSwapper/getThorTradeQuote/getTradeQuote.test.ts
@@ -49,7 +49,7 @@ const expectedQuoteResponse: ThorEvmTradeQuote = {
     {
       allowanceContract: '0x3624525075b88B24ecc29CE226b0CEc1fFcB6976',
       sellAmountIncludingProtocolFeesCryptoBaseUnit: '713014679420',
-      buyAmountBeforeFeesCryptoBaseUnit: '114321610000000000',
+      buyAmountBeforeFeesCryptoBaseUnit: '114116966780000000',
       feeData: {
         protocolFees: {
           [ETH.assetId]: {

--- a/src/state/slices/swappersSlice/selectors.ts
+++ b/src/state/slices/swappersSlice/selectors.ts
@@ -24,12 +24,12 @@ export const selectSellAsset = createDeepEqualOutputSelector(
   swappers => swappers.sellAsset,
 )
 
-export const selectSlippagePreferencePercentage: Selector<ReduxState, string | undefined> =
+export const selectUserSlippagePercentage: Selector<ReduxState, string | undefined> =
   createSelector(selectSwappers, swappers => swappers.slippagePreferencePercentage)
 
 // User input comes in as an actual percentage e.g 1 for 1%, so we need to convert it to a decimal e.g 0.01 for 1%
 export const selectSlippagePreferencePercentageDecimal: Selector<ReduxState, string | undefined> =
-  createSelector(selectSlippagePreferencePercentage, slippagePercentage => {
+  createSelector(selectUserSlippagePercentage, slippagePercentage => {
     if (!slippagePercentage) return
     return bn(slippagePercentage).div(100).toString()
   })


### PR DESCRIPTION
## Description

- Updates logic to only update the user's specified slippage amount on popover close
- Fixes "auto" slippage setting
- Updates 0x and Thor quote logic to show the receive amount after slippage, making it consistent with other swappers that support slippage. That said, if we actually want to do this or not depends on the product response to the question raised in the Notion doc below
- Shows slippage button when no quotes are available to prevent getting stuck in a bad state, unable to change slippage

Pending Product thoughts on https://www.notion.so/shapeshift/Swapper-trade-settings-slippage-9a6167959d70415681a46c4aafb2d143

## Pull Request Type

- [ ] :bug: Bug fix (Non-breaking Change: Fixes an issue)
- [ ] :hammer_and_wrench: Chore (Non-breaking Change: Doc updates, pkg upgrades, typos, etc..)
- [x] :nail_care: New Feature (Breaking/Non-breaking Change)

## Issue (if applicable)

N/A

## Risk

Small, should have no effect when slippage feature flag is off.

## Testing

Not required at this time.

### Engineering

☝️ 

### Operations

☝️

## Screenshots (if applicable)

N/A