### PR TITLE
feat: handle 0x minimums monadically

### DIFF
--- a/src/lib/swapper/swappers/ZrxSwapper/getZrxTradeQuote/getZrxTradeQuote.ts
+++ b/src/lib/swapper/swappers/ZrxSwapper/getZrxTradeQuote/getZrxTradeQuote.ts
@@ -82,7 +82,17 @@ export async function getZrxTradeQuote<T extends ZrxSupportedChainId>(
 
   // don't show buy amount if less than min sell amount
   const isSellAmountBelowMinimum = bnOrZero(sellAmountCryptoBaseUnit).lt(minimumCryptoBaseUnit)
-  const buyAmountCryptoBaseUnit = isSellAmountBelowMinimum ? '0' : data.buyAmount
+
+  if (isSellAmountBelowMinimum)
+    return Err(
+      makeSwapErrorRight({
+        message: `[getTradeRate]: Sell amount is below the 0x minimum, cannot get a trade rate from 0x.`,
+        code: SwapErrorType.TRADE_BELOW_MINIMUM,
+        details: { sellAssetId: sellAsset.assetId, buyAssetId: buyAsset.assetId },
+      }),
+    )
+
+  const buyAmountCryptoBaseUnit = data.buyAmount
 
   // 0x approvals are cheaper than trades, but we don't have dynamic quote data for them.
   // Instead, we use a hardcoded gasLimit estimate in place of the estimatedGas in the 0x quote response.


### PR DESCRIPTION
## Description

Removes the hacky 0-amount quote we get when we are below the minimum for 0x and instead returns a monadic error.

Still to do (not in this PR) is display this on the interface.

This also fixes the data pollution in MixPanel where we were getting 0x quotes with a receive amount of 0, which made them "100% worse than the best trade".

## Pull Request Type

- [ ] :bug: Bug fix (Non-breaking Change: Fixes an issue)
- [x] :hammer_and_wrench: Chore (Non-breaking Change: Doc updates, pkg upgrades, typos, etc..)
- [ ] :nail_care: New Feature (Breaking/Non-breaking Change)

## Issue (if applicable)

N/A

## Risk

Small.

## Testing

See the screenshots below for the intended effect.

### Engineering

☝️

### Operations

☝️

## Screenshots (if applicable)

Prod:

<img width="478" alt="Screenshot 2023-08-15 at 8 00 53 pm" src="https://github.com/shapeshift/web/assets/97164662/c79a2779-4cda-4c53-a91c-460ee8fd96d9">

This PR:

<img width="469" alt="Screenshot 2023-08-15 at 8 01 17 pm" src="https://github.com/shapeshift/web/assets/97164662/954d1515-7cf3-427f-9c5c-14d07d0d003e">
