### PR TITLE
fix: filter sell assets by walletSupportsChain

### DIFF
--- a/src/components/MultiHopTrade/hooks/useSupportedAssets.tsx
+++ b/src/components/MultiHopTrade/hooks/useSupportedAssets.tsx
@@ -26,11 +26,14 @@ export const useSupportedAssets = () => {
   useEffect(() => {
     ;(async () => {
       const assetIds = await getSupportedSellAssetIds(enabledSwappers)
-      const filteredAssetIds = [...assetIds].filter(assetId => {
+      const filteredAssetIds = new Set<AssetId>()
+      assetIds.forEach(assetId => {
         const chainId = fromAssetId(assetId).chainId
-        return walletSupportsChain({ chainId, wallet })
+        if (walletSupportsChain({ chainId, wallet })) {
+          filteredAssetIds.add(assetId)
+        }
       })
-      setSupportedSellAssetIds(new Set(filteredAssetIds))
+      setSupportedSellAssetIds(filteredAssetIds)
     })()
   }, [enabledSwappers, sortedAssets, wallet])
 


### PR DESCRIPTION
## Description

Filter sell assets by those supported by the connected wallet.

## Pull Request Type

- [x] :bug: Bug fix (Non-breaking Change: Fixes an issue)
- [ ] :hammer_and_wrench: Chore (Non-breaking Change: Doc updates, pkg upgrades, typos, etc..)
- [ ] :nail_care: New Feature (Breaking/Non-breaking Change)

## Issue (if applicable)

Current production issue.

## Risk

Risk that we don't show sell assets when we should.

## Testing

When connecting with MetaMask we should now correctly filter out the unsupported assets (UTXO).

We should also be unable to get into the state with stale quotes.

### Engineering

☝️

### Operations

☝️

## Screenshots (if applicable)

N/A
