### PR TITLE
feat: fetch market data at quote time

### DIFF
--- a/src/lib/market-service/market-service-manager.ts
+++ b/src/lib/market-service/market-service-manager.ts
@@ -88,6 +88,7 @@ export class MarketServiceManager {
     for (let i = 0; i < this.marketProviders.length && !result; i++) {
       try {
         result = await this.marketProviders[i].findByAssetId({ assetId })
+        if (result) break
       } catch (e) {
         // Swallow error, not every asset will be with every provider.
       }


### PR DESCRIPTION
## Description

Does what it says on the box - ensures we don't bail out on missing market data, making us currently unable to get quotes except for the initially fetched market data assets.

## Pull Request Type

- [ ] :bug: Bug fix (Non-breaking Change: Fixes an issue)
- [ ] :hammer_and_wrench: Chore (Non-breaking Change: Doc updates, pkg upgrades, typos, etc..)
- [x] :nail_care: New Feature (Breaking/Non-breaking Change)

## Issue (if applicable)

N/A

## Risk

<!-----------------------------------------------------------------------------
Outline the scope of your changes and the risk associated with them. You must use your discretion as an engineer to determine the potential impact of your changes.

E.g. an upgrade to `hdwallet` or core state management would be considered higher risk, and might require a full regression test. UI or isolated view changes, or something behind a feature flag may have near zero risk. Small bug fixes might require testing isolated to the specific fix.
------------------------------------------------------------------------------>

We might be overfetching market data, though if we do, we have bigger problems - market-service should be cached

## Testing

<!-----------------------------------------------------------------------------
We treat every PR to be merged with the same scrutiny as if we were merging directly to production.

Your PR will not be merged if you do not complete the sections below for our engineering and operations teams to test.
------------------------------------------------------------------------------>

- Open Chrome devtools network tab
- Select an asset that is not included in the originally fetched set i.e FOX on Optimism, as either buy or sell asset
- Input some amount to fire a quote
- Ensure the network request/s are going through for said asset market data

### Engineering

<!-----------------------------------------------------------------------------
Include sufficient information here for an engineer to test your PR. This may include how to test locally, in a built environment, changes to infrastructure etc.
------------------------------------------------------------------------------>

- ☝🏽 

### Operations

<!-----------------------------------------------------------------------------
If your changes have a user-facing impact, describe how a non-technical QA team can functionally test your changes in a preview environment.

If they are not user-facing please describe how to test for any regressions that may occur.
------------------------------------------------------------------------------>

- ☝🏽 

## Screenshots (if applicable)
