### PR TITLE
feat: add slippage support to CoW

### DIFF
--- a/src/components/MultiHopTrade/components/TradeInput/getSwapperSupportsSlippage.ts
+++ b/src/components/MultiHopTrade/components/TradeInput/getSwapperSupportsSlippage.ts
@@ -8,10 +8,10 @@ export const getSwapperSupportsSlippage = (swapperName: SwapperName | undefined)
     case SwapperName.Zrx:
     case SwapperName.OneInch:
     case SwapperName.LIFI:
+    case SwapperName.CowSwap:
       return true
     case SwapperName.Osmosis:
     case SwapperName.Test:
-    case SwapperName.CowSwap:
       return false
     default:
       assertUnreachable(swapperName)

--- a/src/lib/swapper/swappers/CowSwapper/getCowSwapTradeQuote/getCowSwapTradeQuote.ts
+++ b/src/lib/swapper/swappers/CowSwapper/getCowSwapTradeQuote/getCowSwapTradeQuote.ts
@@ -2,6 +2,7 @@ import { fromAssetId } from '@shapeshiftoss/caip'
 import type { Result } from '@sniptt/monads'
 import { Err, Ok } from '@sniptt/monads'
 import type { AxiosError } from 'axios'
+import BigNumber from 'bignumber.js'
 import { getConfig } from 'config'
 import { bn } from 'lib/bignumber/bignumber'
 import type { GetTradeQuoteInput, SwapErrorRight, TradeQuote } from 'lib/swapper/api'
@@ -11,6 +12,7 @@ import {
   COW_SWAP_NATIVE_ASSET_MARKER_ADDRESS,
   COW_SWAP_VAULT_RELAYER_ADDRESS,
   DEFAULT_APP_DATA,
+  ORDER_KIND_BUY,
   ORDER_KIND_SELL,
 } from 'lib/swapper/swappers/CowSwapper/utils/constants'
 import { cowService } from 'lib/swapper/swappers/CowSwapper/utils/cowService'
@@ -26,11 +28,22 @@ import {
   normalizeIntegerAmount,
 } from 'lib/swapper/swappers/utils/helpers/helpers'
 import { createTradeAmountTooSmallErr } from 'lib/swapper/utils'
+import {
+  convertDecimalPercentageToBasisPoints,
+  subtractBasisPointAmount,
+} from 'state/slices/tradeQuoteSlice/utils'
 
 export async function getCowSwapTradeQuote(
   input: GetTradeQuoteInput,
 ): Promise<Result<TradeQuote<CowChainId>, SwapErrorRight>> {
-  const { sellAsset, buyAsset, accountNumber, chainId, receiveAddress } = input
+  const {
+    sellAsset,
+    buyAsset,
+    accountNumber,
+    chainId,
+    receiveAddress,
+    slippageTolerancePercentage,
+  } = input
   const supportedChainIds = getSupportedChainIds()
   const sellAmount = input.sellAmountIncludingProtocolFeesCryptoBaseUnit
 
@@ -85,16 +98,63 @@ export async function getCowSwapTradeQuote(
 
   const { data } = maybeQuoteResponse.unwrap()
 
-  const { feeAmount: feeAmountInSellTokenCryptoBaseUnit } = data.quote
+  const { rate, buyAmountBeforeFeesCryptoBaseUnit, buyAmountAfterFeesCryptoBaseUnit } =
+    getValuesFromQuoteResponse({
+      buyAsset,
+      sellAsset,
+      response: data,
+    })
 
-  const { rate, buyAmountBeforeFeesCryptoBaseUnit } = getValuesFromQuoteResponse({
-    buyAsset,
-    sellAsset,
-    response: data,
-  })
+  const slippageBps = slippageTolerancePercentage
+    ? convertDecimalPercentageToBasisPoints(slippageTolerancePercentage)
+    : undefined
+
+  // If user has specified slippage, we need to get a second quote using the buyAmount from the quote (which includes fees)
+  // So it's (buyAmount - fees) - slippage, which will be the buyAmountAfterFees to use to get the new quote
+  const maybeQuoteWithSlippageResponse = slippageBps
+    ? await cowService.post<CowSwapQuoteResponse>(`${baseUrl}/${network}/api/v1/quote/`, {
+        sellToken: fromAssetId(sellAsset.assetId).assetReference,
+        buyToken,
+        receiver: receiveAddress,
+        validTo: getNowPlusThirtyMinutesTimestamp(),
+        appData: DEFAULT_APP_DATA,
+        partiallyFillable: false,
+        from: receiveAddress,
+        kind: ORDER_KIND_BUY,
+        buyAmountAfterFee: subtractBasisPointAmount(
+          buyAmountAfterFeesCryptoBaseUnit,
+          slippageBps,
+          BigNumber.ROUND_DOWN,
+        ),
+      })
+    : undefined
+
+  if (maybeQuoteWithSlippageResponse?.isErr()) {
+    const err = maybeQuoteWithSlippageResponse.unwrapErr()
+    const errData = (err.cause as AxiosError)?.response?.data
+    if (
+      (err.cause as AxiosError)?.isAxiosError &&
+      errData?.errorType === 'SellAmountDoesNotCoverFee'
+    ) {
+      return Err(
+        createTradeAmountTooSmallErr({
+          assetId: sellAsset.assetId,
+          minAmountCryptoBaseUnit: bn(errData?.data.fee_amount ?? '0x0', 16).toFixed(),
+        }),
+      )
+    }
+    return Err(maybeQuoteWithSlippageResponse.unwrapErr())
+  }
+
+  // If we have a quote with slippage, use that data, otherwise use the original quote data
+  const responseData =
+    maybeQuoteWithSlippageResponse && maybeQuoteWithSlippageResponse?.isOk()
+      ? maybeQuoteWithSlippageResponse.unwrap().data
+      : data
+  const { feeAmount: feeAmountInSellTokenCryptoBaseUnit } = responseData.quote
 
   const quote: TradeQuote<CowChainId> = {
-    id: data.id.toString(),
+    id: responseData.id.toString(),
     rate,
     estimatedExecutionTimeMs: undefined,
     steps: [

--- a/src/lib/swapper/swappers/CowSwapper/utils/constants.ts
+++ b/src/lib/swapper/swappers/CowSwapper/utils/constants.ts
@@ -1,12 +1,4 @@
 import { AddressZero } from '@ethersproject/constants'
-import { KnownChainIds } from '@shapeshiftoss/types'
-
-import type { CowChainId } from '../types'
-
-export const MIN_COWSWAP_USD_TRADE_VALUES_BY_CHAIN_ID: Record<CowChainId, string> = {
-  [KnownChainIds.EthereumMainnet]: '20',
-  [KnownChainIds.GnosisMainnet]: '0.01',
-}
 
 export const DEFAULT_ADDRESS = AddressZero
 export const DEFAULT_APP_DATA = '0x68a7b5781dfe48bd5d7aeb11261c17517f5c587da682e4fade9b6a00a59b8970'
@@ -14,6 +6,7 @@ export const COW_SWAP_VAULT_RELAYER_ADDRESS = '0xc92e8bdf79f0507f65a392b0ab46677
 export const COW_SWAP_SETTLEMENT_ADDRESS = '0x9008D19f58AAbD9eD0D60971565AA8510560ab41'
 
 export const ORDER_KIND_SELL = 'sell'
+export const ORDER_KIND_BUY = 'buy'
 export const SIGNING_SCHEME = 'ethsign'
 export const ERC20_TOKEN_BALANCE = 'erc20'
 


### PR DESCRIPTION
## Description

Add slippage support to CoW Swap.

CoW swap doesn't have the concept of slippage at an API level, but we can instead specify the `buyAmountAfterFee` as an amount that includes slippage.

Unfortunately this requries two network requests as we don't know what the trade fee (to deduct from the buy amount) is until we get the first quote. Looking at the network requests on the CoW Swap app, they seem to do something similar.

## Pull Request Type

- [ ] :bug: Bug fix (Non-breaking Change: Fixes an issue)
- [ ] :hammer_and_wrench: Chore (Non-breaking Change: Doc updates, pkg upgrades, typos, etc..)
- [x] :nail_care: New Feature (Breaking/Non-breaking Change)

## Issue (if applicable)

Closes https://github.com/shapeshift/web/issues/5116

## Risk

Medium - the biggest risk here is that the `buyAmountAfterFee` amount fee use is too small, and a user gets arbed.

The next, less significant risk is that trades won't go through because the calcultation is wrong and the resulting buy amount specified is too high.

## Testing

Perform CoW swap trades with and without slippage (using the advanced slippage feature flag). Both trades should go through, and when specifying slippage the minimum amount should be lower (by the % amount specified). 

### Engineering

☝️

### Operations

☝️

## Screenshots (if applicable)

N/A
