### PR TITLE
feat: deserialized AccountIds input in Osmosis checkTradeStatus

### DIFF
--- a/src/lib/swapper/api.ts
+++ b/src/lib/swapper/api.ts
@@ -1,4 +1,4 @@
-import type { AccountId, AssetId, ChainId, Nominal } from '@shapeshiftoss/caip'
+import type { AssetId, ChainId, Nominal } from '@shapeshiftoss/caip'
 import type { CosmosSdkChainId, EvmChainId, UtxoChainId } from '@shapeshiftoss/chain-adapters'
 import { createErrorClass } from '@shapeshiftoss/errors'
 import type { HDWallet } from '@shapeshiftoss/hdwallet-core'
@@ -214,8 +214,8 @@ export type CheckTradeStatusInput = {
   txHash: string
   chainId: ChainId
   stepIndex: number
-  quoteSellAssetAccountId?: AccountId
-  quoteBuyAssetAccountId?: AccountId
+  sellAccount?: { chainId: ChainId; pubkey: string }
+  buyAccount?: { chainId: ChainId; pubkey: string }
 }
 
 // a result containing all routes that were successfully generated, or an error in the case where

--- a/src/lib/swapper/swappers/OsmosisSwapper/endpoints.ts
+++ b/src/lib/swapper/swappers/OsmosisSwapper/endpoints.ts
@@ -1,4 +1,4 @@
-import { cosmosChainId, fromAccountId, osmosisChainId } from '@shapeshiftoss/caip'
+import { cosmosChainId, fromAccountId, osmosisChainId, toAccountId } from '@shapeshiftoss/caip'
 import type { cosmos, GetFeeDataInput } from '@shapeshiftoss/chain-adapters'
 import { osmosis } from '@shapeshiftoss/chain-adapters'
 import type { CosmosSignTx } from '@shapeshiftoss/hdwallet-core'
@@ -192,10 +192,22 @@ export const osmosisApi: Swapper2Api = {
     txHash,
     quoteId,
     stepIndex,
-    quoteSellAssetAccountId,
-    quoteBuyAssetAccountId,
+    sellAccount,
+    buyAccount,
   }): Promise<{ status: TxStatus; buyTxHash: string | undefined; message: string | undefined }> => {
     try {
+      const quoteSellAssetAccountId = sellAccount
+        ? toAccountId({
+            chainId: sellAccount.chainId,
+            account: sellAccount.pubkey,
+          })
+        : undefined
+      const quoteBuyAssetAccountId = buyAccount
+        ? toAccountId({
+            chainId: buyAccount.chainId,
+            account: buyAccount.pubkey,
+          })
+        : undefined
       const quote = tradeQuoteMetadata.get(quoteId)
       const step = quote?.steps[stepIndex]
       if (!step) throw new Error('Step not found')

--- a/src/lib/swapper/tradeExecution.ts
+++ b/src/lib/swapper/tradeExecution.ts
@@ -1,3 +1,4 @@
+import { fromAccountId } from '@shapeshiftoss/caip'
 import { TxStatus } from '@shapeshiftoss/unchained-client'
 import EventEmitter from 'events'
 import { TRADE_POLL_INTERVAL_MILLISECONDS } from 'components/MultiHopTrade/hooks/constants'
@@ -92,8 +93,14 @@ export class TradeExecution {
             txHash: sellTxHash,
             chainId,
             stepIndex,
-            quoteSellAssetAccountId,
-            quoteBuyAssetAccountId,
+            sellAccount: {
+              chainId: fromAccountId(quoteSellAssetAccountId).chainId,
+              pubkey: fromAccountId(quoteSellAssetAccountId).account,
+            },
+            buyAccount: {
+              chainId: fromAccountId(quoteBuyAssetAccountId).chainId,
+              pubkey: fromAccountId(quoteBuyAssetAccountId).account,
+            },
           })
 
           const payload: StatusArgs = { stepIndex, status, message, buyTxHash }


### PR DESCRIPTION
## Description

Pass `sellAccount` and `buyAccount` as {chainId: ChainId; pubkey: string} instead of passing AccountIds around, effectively de-ShapeShifting things so that consumers don't have to know how to construct AccountIds.

## Pull Request Type

- [ ] :bug: Bug fix (Non-breaking Change: Fixes an issue)
- [ ] :hammer_and_wrench: Chore (Non-breaking Change: Doc updates, pkg upgrades, typos, etc..)
- [x] :nail_care: New Feature (Breaking/Non-breaking Change)

## Issue (if applicable)

<!-----------------------------------------------------------------------------
If applicable, please link to the github issue and put `closes #XXXX` in your comment to auto-close the issue that your PR fixes.
------------------------------------------------------------------------------>

closes https://github.com/shapeshift/web/issues/5097

## Risk

<!-----------------------------------------------------------------------------
Outline the scope of your changes and the risk associated with them. You must use your discretion as an engineer to determine the potential impact of your changes.

E.g. an upgrade to `hdwallet` or core state management would be considered higher risk, and might require a full regression test. UI or isolated view changes, or something behind a feature flag may have near zero risk. Small bug fixes might require testing isolated to the specific fix.
------------------------------------------------------------------------------>

None, we reserialize in checkTradeStatus body so no runtime change.

## Testing

<!-----------------------------------------------------------------------------
We treat every PR to be merged with the same scrutiny as if we were merging directly to production.

Your PR will not be merged if you do not complete the sections below for our engineering and operations teams to test.
------------------------------------------------------------------------------>

- Osmosis trade completion detection is still happy

### Engineering

<!-----------------------------------------------------------------------------
Include sufficient information here for an engineer to test your PR. This may include how to test locally, in a built environment, changes to infrastructure etc.
------------------------------------------------------------------------------>

- ☝🏽 

### Operations

<!-----------------------------------------------------------------------------
If your changes have a user-facing impact, describe how a non-technical QA team can functionally test your changes in a preview environment.

If they are not user-facing please describe how to test for any regressions that may occur.
------------------------------------------------------------------------------>

- ☝🏽 

## Screenshots (if applicable)


<img width="1036" alt="Screenshot 2023-08-21 at 11 10 27" src="https://github.com/shapeshift/web/assets/17035424/44f4d01e-52b8-4dce-b0d4-00aef8feab0a">
<img width="1483" alt="Screenshot 2023-08-21 at 11 11 25" src="https://github.com/shapeshift/web/assets/17035424/3bbafc71-07fa-423e-bd1d-09f3990b1819">