### PR TITLE
chore: add more isStreaming to MixPanel

### DIFF
--- a/src/components/MultiHopTrade/helpers.ts
+++ b/src/components/MultiHopTrade/helpers.ts
@@ -2,6 +2,7 @@ import { getMaybeCompositeAssetSymbol } from 'lib/mixpanel/helpers'
 import type { ReduxState } from 'state/reducer'
 import { selectAssets, selectWillDonate } from 'state/slices/selectors'
 import {
+  selectActiveQuote,
   selectActiveQuoteIndex,
   selectBuyAmountBeforeFeesCryptoPrecision,
   selectFirstHopSellAsset,
@@ -33,6 +34,7 @@ export const getMixpanelEventData = () => {
   const sellAmountBeforeFeesCryptoPrecision = selectSellAmountBeforeFeesCryptoPrecision(state)
   const willDonate = selectWillDonate(state)
   const swapperName = selectActiveQuoteIndex(state)
+  const activeQuote = selectActiveQuote(state)
 
   const compositeBuyAsset = getMaybeCompositeAssetSymbol(buyAsset.assetId, assets)
   const compositeSellAsset = getMaybeCompositeAssetSymbol(sellAsset.assetId, assets)
@@ -48,5 +50,6 @@ export const getMixpanelEventData = () => {
     donationAmountUserCurrency,
     [compositeBuyAsset]: buyAmountBeforeFeesCryptoPrecision,
     [compositeSellAsset]: sellAmountBeforeFeesCryptoPrecision,
+    isStreaming: activeQuote?.isStreaming ?? false,
   }
 }


### PR DESCRIPTION
## Description

Add `isStreaming` to `TradeSuccess`, `TradeFailed`, and `TradePreview` MixPanel events.

## Pull Request Type

- [ ] :bug: Bug fix (Non-breaking Change: Fixes an issue)
- [x] :hammer_and_wrench: Chore (Non-breaking Change: Doc updates, pkg upgrades, typos, etc..)
- [ ] :nail_care: New Feature (Breaking/Non-breaking Change)

## Issue (if applicable)

N/A

## Risk

Small

## Testing

`TradeSuccess`, `TradeFailed`, and `TradePreview` MixPane
l events should now have an `isStreaming` boolean.

### Engineering

☝️

### Operations

☝️

## Screenshots (if applicable)

N/A
