### PR TITLE
fix: handle various memo lengths per chain family for thorchain swapper

### DIFF
--- a/src/lib/swapper/swappers/ThorchainSwapper/utils/addSlippageToMemo.ts
+++ b/src/lib/swapper/swappers/ThorchainSwapper/utils/addSlippageToMemo.ts
@@ -15,7 +15,7 @@ export const addSlippageToMemo = (
   { memo: quotedMemo, expected_amount_out: expectedAmountOut }: ThornodeQuoteResponseSuccess,
   slippageBps: BigNumber.Value,
   isStreaming: boolean,
-  _chainId: ChainId,
+  chainId: ChainId,
 ) => {
   // the missing element is the original limit with (optional, missing) streaming parameters
   const [prefix, pool, address, , affiliate, affiliateBps] = quotedMemo.split(MEMO_PART_DELIMITER)
@@ -36,6 +36,6 @@ export const addSlippageToMemo = (
     MEMO_PART_DELIMITER,
   )
 
-  assertIsValidMemo(memo)
+  assertIsValidMemo(memo, chainId)
   return memo
 }

--- a/src/lib/swapper/swappers/ThorchainSwapper/utils/makeSwapMemo/assertIsValidMemo.test.ts
+++ b/src/lib/swapper/swappers/ThorchainSwapper/utils/makeSwapMemo/assertIsValidMemo.test.ts
@@ -1,4 +1,4 @@
-import { bchChainId, ethChainId, thorchainChainId } from '@shapeshiftoss/caip'
+import { bchChainId, btcChainId, ethChainId, thorchainChainId } from '@shapeshiftoss/caip'
 
 import { assertIsValidMemo, isValidMemoAddress } from './assertIsValidMemo'
 
@@ -59,39 +59,66 @@ describe('isValidMemoAddress', () => {
 describe('assertIsValidMemo', () => {
   it('should assert memo is valid', () => {
     expect(() =>
-      assertIsValidMemo('s:BTC.BTC:bc1qkw9g3tgv6m2gwc4x4hvdefcwt0uxeedfgag27h:420:ss:0'),
+      assertIsValidMemo(
+        's:BTC.BTC:bc1qkw9g3tgv6m2gwc4x4hvdefcwt0uxeedfgag27h:420:ss:0',
+        btcChainId,
+      ),
     ).not.toThrow()
 
     expect(() =>
-      assertIsValidMemo('s:ETH.ETH:0x8a65ac0E23F31979db06Ec62Af62b132a6dF4741:420:ss:0'),
+      assertIsValidMemo(
+        's:ETH.ETH:0x8a65ac0E23F31979db06Ec62Af62b132a6dF4741:420:ss:0',
+        btcChainId,
+      ),
     ).not.toThrow()
 
     expect(() =>
-      assertIsValidMemo('s:ETH.USDC-B48:0x8a65ac0E23F31979db06Ec62Af62b132a6dF4741:420:ss:0'),
+      assertIsValidMemo(
+        's:ETH.USDC-B48:0x8a65ac0E23F31979db06Ec62Af62b132a6dF4741:420:ss:0',
+        btcChainId,
+      ),
     ).not.toThrow()
 
     expect(() =>
-      assertIsValidMemo('s:ETH.USDC-B48:0x8a65ac0E23F31979db06Ec62Af62b132a6dF4741:420:ss:300'),
+      assertIsValidMemo(
+        's:ETH.USDC-B48:0x8a65ac0E23F31979db06Ec62Af62b132a6dF4741:420:ss:300',
+        btcChainId,
+      ),
     ).not.toThrow()
   })
 
   it('should throw on invalid memo', () => {
     expect(() =>
-      assertIsValidMemo('s:BTC.BTC:zc1qkw9g3tgv6m2gwc4x4hvdefcwt0uxeedfgag27h:420:ss:0'),
+      assertIsValidMemo(
+        's:BTC.BTC:zc1qkw9g3tgv6m2gwc4x4hvdefcwt0uxeedfgag27h:420:ss:0',
+        btcChainId,
+      ),
     ).toThrow()
 
     expect(() =>
-      assertIsValidMemo('s:RUNE.BTC:Bc1qkw9g3tgv6m2gwc4x4hvdefcwt0uxeedfgag27h:420:ss:0'),
+      assertIsValidMemo(
+        's:RUNE.BTC:Bc1qkw9g3tgv6m2gwc4x4hvdefcwt0uxeedfgag27h:420:ss:0',
+        btcChainId,
+      ),
     ).toThrow()
 
     expect(() =>
-      assertIsValidMemo('s:BTC.BTC:0x8a65ac0E23F31979db06Ec62Af62b132a6dF4741:420:ss:0'),
+      assertIsValidMemo(
+        's:BTC.BTC:0x8a65ac0E23F31979db06Ec62Af62b132a6dF4741:420:ss:0',
+        btcChainId,
+      ),
     ).toThrow()
     expect(() =>
-      assertIsValidMemo('s:ETH.USDC-B48:0x8a65ac0E23F31979db06Ec62Af62b132a6dF4741:420:ss:9999'),
+      assertIsValidMemo(
+        's:ETH.USDC-B48:0x8a65ac0E23F31979db06Ec62Af62b132a6dF4741:420:ss:9999',
+        btcChainId,
+      ),
     ).toThrow()
     expect(() =>
-      assertIsValidMemo('s:ETH.USDC-B48:0x8a65ac0E23F31979db06Ec62Af62b132a6dF4741:420:xx:10'),
+      assertIsValidMemo(
+        's:ETH.USDC-B48:0x8a65ac0E23F31979db06Ec62Af62b132a6dF4741:420:xx:10',
+        btcChainId,
+      ),
     ).toThrow()
   })
 })


### PR DESCRIPTION
## Description

Adds logic to allow different memo lengths depending on the sending chain. Fixes invalid memo length assertion when sending from cosmos chain.

## Pull Request Type

- [x] :bug: Bug fix (Non-breaking Change: Fixes an issue)
- [ ] :hammer_and_wrench: Chore (Non-breaking Change: Doc updates, pkg upgrades, typos, etc..)
- [ ] :nail_care: New Feature (Breaking/Non-breaking Change)

## Issue (if applicable)

NA

## Risk

Low risk of broken thor trades.

## Testing

Check trades for each chain type (utxo, evm, cosmos sdk).

### Engineering

☝️

### Operations

☝️

## Screenshots (if applicable)
