### PR TITLE
fix: display positive percentage differences on trade quotes

### DIFF
--- a/src/components/MultiHopTrade/components/TradeInput/components/TradeQuotes/TradeQuote.tsx
+++ b/src/components/MultiHopTrade/components/TradeInput/components/TradeQuotes/TradeQuote.tsx
@@ -231,7 +231,7 @@ export const TradeQuoteLoaded: React.FC<TradeQuoteLoadedProps> = ({
               symbol={buyAsset?.symbol ?? ''}
               color={isBest ? greenColor : 'inherit'}
             />
-            {!isBest && hasAmountWithPositiveReceive && quoteDifferenceDecimalPercentage > 0 && (
+            {!isBest && hasAmountWithPositiveReceive && quoteDifferenceDecimalPercentage !== 0 && (
               <Amount.Percent
                 value={-quoteDifferenceDecimalPercentage}
                 prefix='('


### PR DESCRIPTION
## Description

Fix to display positive percentage differences on trade quotes

## Pull Request Type

- [x] :bug: Bug fix (Non-breaking Change: Fixes an issue)
- [ ] :hammer_and_wrench: Chore (Non-breaking Change: Doc updates, pkg upgrades, typos, etc..)
- [ ] :nail_care: New Feature (Breaking/Non-breaking Change)

## Issue (if applicable)

NA

## Risk

None

## Testing

Check positive percentage values appear on trade quotes as green.

### Engineering

NA

### Operations
See above

## Screenshots (if applicable)
