### PR TITLE
fix: thorswap supports cross account trades

### DIFF
--- a/src/lib/getTxLink.ts
+++ b/src/lib/getTxLink.ts
@@ -2,6 +2,8 @@ import { Dex } from '@shapeshiftoss/unchained-client'
 import type { SwapSource } from 'lib/swapper/api'
 import { SwapperName } from 'lib/swapper/api'
 
+import { THORCHAIN_STREAM_SWAP_SOURCE } from './swapper/swappers/ThorchainSwapper/constants'
+
 type GetBaseUrl = {
   name: SwapSource | Dex | undefined
   defaultExplorerBaseUrl: string
@@ -18,7 +20,8 @@ export const getTxBaseUrl = ({ name, defaultExplorerBaseUrl, isOrder }: GetBaseU
       return isOrder ? 'https://explorer.cow.fi/orders/' : 'https://explorer.cow.fi/tx/'
     case Dex.Thor:
     case SwapperName.Thorchain:
-      return isOrder ? defaultExplorerBaseUrl : 'https://viewblock.io/thorchain/tx/'
+    case THORCHAIN_STREAM_SWAP_SOURCE:
+      return 'https://viewblock.io/thorchain/tx/'
     default:
       return defaultExplorerBaseUrl
   }
@@ -28,5 +31,10 @@ export const getTxLink = ({ name, defaultExplorerBaseUrl, txId, tradeId }: GetTx
   const id = txId ?? tradeId
   const isOrder = !!tradeId
   const baseUrl = getTxBaseUrl({ name, defaultExplorerBaseUrl, isOrder })
+
+  if ([SwapperName.Thorchain, THORCHAIN_STREAM_SWAP_SOURCE].includes(name as SwapSource)) {
+    return `${baseUrl}${id.replace(/^0x/, '')}`
+  }
+
   return `${baseUrl}${id}`
 }

--- a/src/lib/swapper/swappers/ThorchainSwapper/constants.ts
+++ b/src/lib/swapper/swappers/ThorchainSwapper/constants.ts
@@ -1,5 +1,7 @@
 import { KnownChainIds } from '@shapeshiftoss/types'
 import { bn } from 'lib/bignumber/bignumber'
+import type { SwapSource } from 'lib/swapper/api'
+import { SwapperName } from 'lib/swapper/api'
 import type { ThorChainId } from 'lib/swapper/swappers/ThorchainSwapper/types'
 // TODO: read from https://daemon.thorchain.shapeshift.com/lcd/thorchain/constants
 export const RUNE_OUTBOUND_TRANSACTION_FEE_CRYPTO_HUMAN = bn('0.02')
@@ -25,3 +27,5 @@ export const buySupportedChainIds: Record<ThorChainId, boolean> = {
   [KnownChainIds.ThorchainMainnet]: true,
   [KnownChainIds.AvalancheMainnet]: true,
 }
+
+export const THORCHAIN_STREAM_SWAP_SOURCE: SwapSource = `${SwapperName.Thorchain} • Streaming`

--- a/src/lib/swapper/swappers/ThorchainSwapper/getThorTradeQuote/getTradeQuote.ts
+++ b/src/lib/swapper/swappers/ThorchainSwapper/getThorTradeQuote/getTradeQuote.ts
@@ -13,7 +13,6 @@ import type {
   GetUtxoTradeQuoteInput,
   ProtocolFee,
   SwapErrorRight,
-  SwapSource,
   TradeQuote,
 } from 'lib/swapper/api'
 import { makeSwapErrorRight, SwapErrorType, SwapperName } from 'lib/swapper/api'
@@ -37,6 +36,7 @@ import {
   convertDecimalPercentageToBasisPoints,
 } from 'state/slices/tradeQuoteSlice/utils'
 
+import { THORCHAIN_STREAM_SWAP_SOURCE } from '../constants'
 import { addSlippageToMemo } from '../utils/addSlippageToMemo'
 import { getEvmTxFees } from '../utils/txFeeHelpers/evmTxFees/getEvmTxFees'
 
@@ -147,7 +147,7 @@ export const getThorTradeQuote = async (
       ? [
           {
             // streaming swap
-            source: `${SwapperName.Thorchain} • Streaming` as SwapSource,
+            source: THORCHAIN_STREAM_SWAP_SOURCE,
             slippageBps: thornodeQuote.streaming_slippage_bps,
             expectedAmountOutThorBaseUnit: thornodeQuote.expected_amount_out_streaming,
             isStreaming: true,


### PR DESCRIPTION
## Description

Fixes tx links for thor trades when streaming swap.

Issue was due to us missing streaming swap in switch statement, but I've simplified the tx link logic such that thor trades always link to https://viewblock.io/thorchain/tx/ for consistency. It also provides a better summary of the thor trade because it includes links ot the receiving transaction and streaming tag where applicable. 

## Pull Request Type

- [x] :bug: Bug fix (Non-breaking Change: Fixes an issue)
- [ ] :hammer_and_wrench: Chore (Non-breaking Change: Doc updates, pkg upgrades, typos, etc..)
- [ ] :nail_care: New Feature (Breaking/Non-breaking Change)

## Issue (if applicable)

NA

## Risk

Low risk of tx links still broken.

## Testing

Check the tx link for thor trades (streaming and non-streaming) work.

NOTE remember that the link will be broken for the first couple of minutes while their website finds the tx also.
![image](https://github.com/shapeshift/web/assets/125113430/0586993f-4cf4-4ca3-a00b-663581ca2153)

### Engineering

☝️

### Operations

☝️

## Screenshots (if applicable)

Streaming swap:
![image](https://github.com/shapeshift/web/assets/125113430/1dee03e7-bbed-44e1-911a-824c7588af82)

Send tx link generated by our app:
https://viewblock.io/thorchain/tx/9202c07011c70de8393a62f965ba73a73dce0529787a860dd7e043a9277553fe

Receive tx link generated by our app:
https://viewblock.io/thorchain/tx/9202c07011c70de8393a62f965ba73a73dce0529787a860dd7e043a9277553fe

Viewblock shows streaming swap indication and other useful info:
![image](https://github.com/shapeshift/web/assets/125113430/fff420a1-1800-48f1-ab19-4559d64f0d7f)
