### PR TITLE
feat: auto-expand routes

### DIFF
--- a/src/components/MultiHopTrade/components/TradeInput/TradeInput.tsx
+++ b/src/components/MultiHopTrade/components/TradeInput/TradeInput.tsx
@@ -91,7 +91,7 @@ export const TradeInput = memo(() => {
   const history = useHistory()
   const { showErrorToast } = useErrorHandler()
   const [isConfirmationLoading, setIsConfirmationLoading] = useState(false)
-  const [showTradeQuotes, toggleShowTradeQuotes] = useToggle(false)
+  const [showTradeQuotes, toggleShowTradeQuotes] = useToggle(true)
   const isKeplr = useMemo(() => wallet instanceof KeplrHDWallet, [wallet])
   const buyAssetSearch = useModal('buyAssetSearch')
   const sellAssetSearch = useModal('sellAssetSearch')

--- a/src/components/MultiHopTrade/components/TradeInput/TradeInput.tsx
+++ b/src/components/MultiHopTrade/components/TradeInput/TradeInput.tsx
@@ -222,7 +222,7 @@ export const TradeInput = memo(() => {
     )
   }, [activeQuote, isLoading, isSellAmountEntered, manualReceiveAddressIsValidating, quoteHasError])
 
-  const rightRegion = useMemo(
+  const RightRegion: JSX.Element = useMemo(
     () =>
       activeQuote && hasUserEnteredAmount ? (
         <IconButton
@@ -237,7 +237,7 @@ export const TradeInput = memo(() => {
     [activeQuote, hasUserEnteredAmount, showTradeQuotes, toggleShowTradeQuotes],
   )
 
-  const tradeQuotes = useMemo(
+  const MaybeRenderedTradeQuotes: JSX.Element | null = useMemo(
     () =>
       hasUserEnteredAmount ? (
         <TradeQuotes isOpen={showTradeQuotes} sortedQuotes={sortedQuotes} />
@@ -252,6 +252,94 @@ export const TradeInput = memo(() => {
 
     return { shapeShiftFee: undefined, donationAmount: quoteAffiliateFee }
   }, [activeSwapperName, quoteAffiliateFee, applyThorSwapAffiliateFees])
+
+  const ConfirmSummary: JSX.Element = useMemo(
+    () => (
+      <CardFooter
+        borderTopWidth={1}
+        borderColor='border.subtle'
+        flexDir='column'
+        gap={4}
+        px={6}
+        bg='background.surface.raised.accent'
+        borderBottomRadius='xl'
+      >
+        {hasUserEnteredAmount && (
+          <>
+            <RateGasRow
+              sellSymbol={sellAsset.symbol}
+              buySymbol={buyAsset.symbol}
+              gasFee={totalNetworkFeeFiatPrecision ?? 'unknown'}
+              rate={rate}
+              isLoading={isLoading}
+              isError={activeQuoteError !== undefined}
+            />
+
+            {activeQuote ? (
+              <ReceiveSummary
+                isLoading={isLoading}
+                symbol={buyAsset.symbol}
+                amountCryptoPrecision={buyAmountAfterFeesCryptoPrecision ?? '0'}
+                amountBeforeFeesCryptoPrecision={buyAmountBeforeFeesCryptoPrecision}
+                protocolFees={totalProtocolFees}
+                shapeShiftFee={shapeShiftFee}
+                donationAmount={donationAmount}
+                slippage={slippageDecimal}
+                swapperName={activeSwapperName ?? ''}
+              />
+            ) : null}
+            {isModeratePriceImpact && (
+              <PriceImpact impactPercentage={priceImpactPercentage.toFixed(2)} />
+            )}
+          </>
+        )}
+
+        <ManualAddressEntry />
+        <Tooltip label={activeQuoteStatus.error?.message ?? activeQuoteStatus.quoteErrors[0]}>
+          <Button
+            type='submit'
+            colorScheme={quoteHasError ? 'red' : 'blue'}
+            size='lg-multiline'
+            data-test='trade-form-preview-button'
+            isDisabled={shouldDisablePreviewButton}
+            isLoading={isLoading}
+            mx={-2}
+          >
+            <Text translation={activeQuoteStatus.quoteStatusTranslation} />
+          </Button>
+        </Tooltip>
+        {hasUserEnteredAmount &&
+          (!applyThorSwapAffiliateFees || activeSwapperName !== SwapperName.Thorchain) && (
+            <DonationCheckbox isLoading={isLoading} />
+          )}
+      </CardFooter>
+    ),
+    [
+      activeQuote,
+      activeQuoteError,
+      activeQuoteStatus.error?.message,
+      activeQuoteStatus.quoteErrors,
+      activeQuoteStatus.quoteStatusTranslation,
+      activeSwapperName,
+      applyThorSwapAffiliateFees,
+      buyAmountAfterFeesCryptoPrecision,
+      buyAmountBeforeFeesCryptoPrecision,
+      buyAsset.symbol,
+      donationAmount,
+      hasUserEnteredAmount,
+      isLoading,
+      isModeratePriceImpact,
+      priceImpactPercentage,
+      quoteHasError,
+      rate,
+      sellAsset.symbol,
+      shapeShiftFee,
+      shouldDisablePreviewButton,
+      slippageDecimal,
+      totalNetworkFeeFiatPrecision,
+      totalProtocolFees,
+    ],
+  )
 
   return (
     <MessageOverlay show={isKeplr} title={overlayTitle}>
@@ -315,7 +403,7 @@ export const TradeInput = memo(() => {
               showInputSkeleton={isLoading}
               showFiatSkeleton={isLoading}
               label={translate('trade.youGet')}
-              rightRegion={rightRegion}
+              rightRegion={RightRegion}
               onAccountIdChange={setBuyAssetAccountId}
               formControlProps={formControlProps}
               labelPostFix={
@@ -330,67 +418,10 @@ export const TradeInput = memo(() => {
                 />
               }
             >
-              {tradeQuotes}
+              {MaybeRenderedTradeQuotes}
             </TradeAssetInput>
           </Stack>
-          <CardFooter
-            borderTopWidth={1}
-            borderColor='border.subtle'
-            flexDir='column'
-            gap={4}
-            px={6}
-            bg='background.surface.raised.accent'
-            borderBottomRadius='xl'
-          >
-            {hasUserEnteredAmount && (
-              <>
-                <RateGasRow
-                  sellSymbol={sellAsset.symbol}
-                  buySymbol={buyAsset.symbol}
-                  gasFee={totalNetworkFeeFiatPrecision ?? 'unknown'}
-                  rate={rate}
-                  isLoading={isLoading}
-                  isError={activeQuoteError !== undefined}
-                />
-
-                {activeQuote ? (
-                  <ReceiveSummary
-                    isLoading={isLoading}
-                    symbol={buyAsset.symbol}
-                    amountCryptoPrecision={buyAmountAfterFeesCryptoPrecision ?? '0'}
-                    amountBeforeFeesCryptoPrecision={buyAmountBeforeFeesCryptoPrecision}
-                    protocolFees={totalProtocolFees}
-                    shapeShiftFee={shapeShiftFee}
-                    donationAmount={donationAmount}
-                    slippage={slippageDecimal}
-                    swapperName={activeSwapperName ?? ''}
-                  />
-                ) : null}
-                {isModeratePriceImpact && (
-                  <PriceImpact impactPercentage={priceImpactPercentage.toFixed(2)} />
-                )}
-              </>
-            )}
-
-            <ManualAddressEntry />
-            <Tooltip label={activeQuoteStatus.error?.message ?? activeQuoteStatus.quoteErrors[0]}>
-              <Button
-                type='submit'
-                colorScheme={quoteHasError ? 'red' : 'blue'}
-                size='lg-multiline'
-                data-test='trade-form-preview-button'
-                isDisabled={shouldDisablePreviewButton}
-                isLoading={isLoading}
-                mx={-2}
-              >
-                <Text translation={activeQuoteStatus.quoteStatusTranslation} />
-              </Button>
-            </Tooltip>
-            {hasUserEnteredAmount &&
-              (!applyThorSwapAffiliateFees || activeSwapperName !== SwapperName.Thorchain) && (
-                <DonationCheckbox isLoading={isLoading} />
-              )}
-          </CardFooter>
+          {ConfirmSummary}
         </Stack>
       </SlideTransition>
     </MessageOverlay>

--- a/src/components/MultiHopTrade/components/TradeInput/TradeInput.tsx
+++ b/src/components/MultiHopTrade/components/TradeInput/TradeInput.tsx
@@ -417,11 +417,10 @@ export const TradeInput = memo(() => {
                   onAssetChange={setBuyAsset}
                 />
               }
-            >
-              {MaybeRenderedTradeQuotes}
-            </TradeAssetInput>
+            ></TradeAssetInput>
           </Stack>
           {ConfirmSummary}
+          {MaybeRenderedTradeQuotes}
         </Stack>
       </SlideTransition>
     </MessageOverlay>


### PR DESCRIPTION
## Description

- Auto-expand routes in the trade widget
- Move the "Confirm" button, and associated rendered info to be _above_ the routes

## Pull Request Type

- [ ] :bug: Bug fix (Non-breaking Change: Fixes an issue)
- [x] :hammer_and_wrench: Chore (Non-breaking Change: Doc updates, pkg upgrades, typos, etc..)
- [ ] :nail_care: New Feature (Breaking/Non-breaking Change)

## Issue (if applicable)

As per conversation here: https://discord.com/channels/554694662431178782/554694662896615436/1144042614522380368

## Risk

Small risk UI doesn't work as expected.

## Testing

When fetching trade quotes, the "routes" toggle should be expanded by default.

The Confirm button, and associated info should now sit above the list of routes.

### Engineering

☝️

### Operations

☝️

## Screenshots (if applicable)

<img width="490" alt="Screenshot 2023-08-24 at 10 31 05 am" src="https://github.com/shapeshift/web/assets/97164662/813bc9c8-77ee-45ac-9534-f7984a3b74ac">

