### PR TITLE
feat: enable opt-out donations for lifi swapper

### DIFF
--- a/src/components/MultiHopTrade/components/TradeInput/components/DonationCheckbox.tsx
+++ b/src/components/MultiHopTrade/components/TradeInput/components/DonationCheckbox.tsx
@@ -9,11 +9,13 @@ import { Row } from 'components/Row/Row'
 import { Text } from 'components/Text'
 import { useLocaleFormatter } from 'hooks/useLocaleFormatter/useLocaleFormatter'
 import { useWallet } from 'hooks/useWallet/useWallet'
+import { getIsDonationAmountBelowMinimum } from 'state/apis/swappers/helpers/getIsDonationAmountBelowMinimum'
+import { selectUsdRateByAssetId } from 'state/slices/marketDataSlice/selectors'
 import { selectSellAsset, selectWillDonate } from 'state/slices/swappersSlice/selectors'
 import { swappers } from 'state/slices/swappersSlice/swappersSlice'
 import {
-  selectActiveQuoteDonationBps,
   selectPotentialDonationAmountUserCurrency,
+  selectSellAmountIncludingProtocolFeesCryptoBaseUnit,
 } from 'state/slices/tradeQuoteSlice/selectors'
 import { useAppDispatch, useAppSelector } from 'state/store'
 
@@ -29,11 +31,26 @@ export const DonationCheckbox: FC<DonationCheckboxProps> = memo(
     const wallet = useWallet().state.wallet
     const walletIsKeepKey = wallet && isKeepKey(wallet)
     const sellAsset = useAppSelector(selectSellAsset)
+    const sellAssetUsdRate = useAppSelector(state =>
+      selectUsdRateByAssetId(state, sellAsset.assetId),
+    )
+    const sellAmountIncludingProtocolFeesCryptoBaseUnit = useAppSelector(
+      selectSellAmountIncludingProtocolFeesCryptoBaseUnit,
+    )
     const isFromEvm = isEvmChainId(sellAsset.chainId)
-    const affiliateBps = useAppSelector(selectActiveQuoteDonationBps)
+
+    const isDonationAmountBelowMinimum = useMemo(() => {
+      if (!sellAmountIncludingProtocolFeesCryptoBaseUnit || !sellAssetUsdRate) return true
+      return getIsDonationAmountBelowMinimum(
+        sellAmountIncludingProtocolFeesCryptoBaseUnit,
+        sellAsset,
+        sellAssetUsdRate,
+      )
+    }, [sellAmountIncludingProtocolFeesCryptoBaseUnit, sellAsset, sellAssetUsdRate])
+
     // disable EVM donations on KeepKey until https://github.com/shapeshift/web/issues/4518 is resolved
     const showDonationOption =
-      (walletIsKeepKey ? !isFromEvm : true) && affiliateBps !== undefined && affiliateBps !== '0'
+      (walletIsKeepKey ? !isFromEvm : true) && !isDonationAmountBelowMinimum
 
     const {
       number: { toFiat },

--- a/src/components/MultiHopTrade/components/TradeInput/components/DonationCheckbox.tsx
+++ b/src/components/MultiHopTrade/components/TradeInput/components/DonationCheckbox.tsx
@@ -32,7 +32,8 @@ export const DonationCheckbox: FC<DonationCheckboxProps> = memo(
     const isFromEvm = isEvmChainId(sellAsset.chainId)
     const affiliateBps = useAppSelector(selectActiveQuoteDonationBps)
     // disable EVM donations on KeepKey until https://github.com/shapeshift/web/issues/4518 is resolved
-    const showDonationOption = (walletIsKeepKey ? !isFromEvm : true) && affiliateBps !== undefined
+    const showDonationOption =
+      (walletIsKeepKey ? !isFromEvm : true) && affiliateBps !== undefined && affiliateBps !== '0'
 
     const {
       number: { toFiat },

--- a/src/lib/swapper/swappers/LifiSwapper/endpoints.ts
+++ b/src/lib/swapper/swappers/LifiSwapper/endpoints.ts
@@ -50,7 +50,7 @@ export const lifiApi: Swapper2Api = {
       lifiChainMap,
       assetsById,
     )
-    const { receiveAddress } = input
+    const { affiliateBps, receiveAddress } = input
 
     return tradeQuoteResult.map(quote =>
       quote.map(({ selectedLifiRoute, ...tradeQuote }) => {
@@ -66,7 +66,7 @@ export const lifiApi: Swapper2Api = {
         return {
           id,
           receiveAddress,
-          affiliateBps: undefined,
+          affiliateBps,
           ...tradeQuote,
         }
       }),

--- a/src/lib/swapper/swappers/LifiSwapper/getTradeQuote/getTradeQuote.ts
+++ b/src/lib/swapper/swappers/LifiSwapper/getTradeQuote/getTradeQuote.ts
@@ -16,6 +16,7 @@ import { getLifi } from 'lib/swapper/swappers/LifiSwapper/utils/getLifi'
 import { getLifiEvmAssetAddress } from 'lib/swapper/swappers/LifiSwapper/utils/getLifiEvmAssetAddress/getLifiEvmAssetAddress'
 import { transformLifiStepFeeData } from 'lib/swapper/swappers/LifiSwapper/utils/transformLifiFeeData/transformLifiFeeData'
 import type { LifiTradeQuote } from 'lib/swapper/swappers/LifiSwapper/utils/types'
+import { convertBasisPointsToDecimalPercentage } from 'state/slices/tradeQuoteSlice/utils'
 
 import { getNetworkFeeCryptoBaseUnit } from '../utils/getNetworkFeeCryptoBaseUnit/getNetworkFeeCryptoBaseUnit'
 
@@ -35,6 +36,7 @@ export async function getTradeQuote(
     slippageTolerancePercentage,
     supportsEIP1559,
     wallet,
+    affiliateBps,
   } = input
 
   const sellLifiChainKey = lifiChainMap.get(sellAsset.chainId)
@@ -83,6 +85,7 @@ export async function getTradeQuote(
       // i.e we would theoretically handle the Tx itself, but not approvals on said chain if needed
       // use the `allowSwitchChain` param above when implemented
       allowSwitchChain: false,
+      fee: convertBasisPointsToDecimalPercentage(affiliateBps).toNumber(),
     },
   }
 

--- a/src/state/apis/swappers/helpers/getIsDonationAmountBelowMinimum.ts
+++ b/src/state/apis/swappers/helpers/getIsDonationAmountBelowMinimum.ts
@@ -1,0 +1,20 @@
+import type { Asset } from 'lib/asset-service'
+import { bnOrZero } from 'lib/bignumber/bignumber'
+import { fromBaseUnit } from 'lib/math'
+import { getMinimumDonationUsdSellAmountByChainId } from 'lib/swapper/swappers/utils/getMinimumDonationUsdSellAmountByChainId'
+
+export const getIsDonationAmountBelowMinimum = (
+  sellAmountIncludingProtocolFeesCryptoBaseUnit: string,
+  sellAsset: Asset,
+  sellAssetUsdRate: string,
+) => {
+  const sellAmountBeforeFeesCryptoPrecision = fromBaseUnit(
+    sellAmountIncludingProtocolFeesCryptoBaseUnit,
+    sellAsset.precision,
+  )
+  const sellAmountBeforeFeesUsd = bnOrZero(sellAmountBeforeFeesCryptoPrecision).times(
+    sellAssetUsdRate,
+  )
+  // We use the sell amount so we don't have to make 2 network requests, as the receive amount requires a quote
+  return sellAmountBeforeFeesUsd.lt(getMinimumDonationUsdSellAmountByChainId(sellAsset.chainId))
+}

--- a/src/state/apis/swappers/helpers/getIsDonationAmountBelowMinimum.ts
+++ b/src/state/apis/swappers/helpers/getIsDonationAmountBelowMinimum.ts
@@ -8,11 +8,11 @@ export const getIsDonationAmountBelowMinimum = (
   sellAsset: Asset,
   sellAssetUsdRate: string,
 ) => {
-  const sellAmountBeforeFeesCryptoPrecision = fromBaseUnit(
+  const sellAmountIncludingFeesCryptoPrecision = fromBaseUnit(
     sellAmountIncludingProtocolFeesCryptoBaseUnit,
     sellAsset.precision,
   )
-  const sellAmountBeforeFeesUsd = bnOrZero(sellAmountBeforeFeesCryptoPrecision).times(
+  const sellAmountBeforeFeesUsd = bnOrZero(sellAmountIncludingFeesCryptoPrecision).times(
     sellAssetUsdRate,
   )
   // We use the sell amount so we don't have to make 2 network requests, as the receive amount requires a quote

--- a/src/state/apis/swappers/swappersApi.ts
+++ b/src/state/apis/swappers/swappersApi.ts
@@ -17,6 +17,9 @@ import { selectFeatureFlags } from 'state/slices/selectors'
 
 import { BASE_RTK_CREATE_API_CONFIG } from '../const'
 
+// these are the swappers with special logic regarding minimum donations
+const evmDonationSwappers = [SwapperName.OneInch, SwapperName.Zrx, SwapperName.LIFI]
+
 export const swappersApi = createApi({
   ...BASE_RTK_CREATE_API_CONFIG,
   reducerPath: 'swappersApi',
@@ -62,15 +65,11 @@ export const swappersApi = createApi({
               ...getTradeQuoteInput,
               affiliateBps: isDonationAmountBelowMinimum ? '0' : affiliateBps,
             },
-            enabledSwappers.filter(swapperName =>
-              [SwapperName.OneInch, SwapperName.Zrx].includes(swapperName),
-            ),
+            enabledSwappers.filter(swapperName => evmDonationSwappers.includes(swapperName)),
           ),
           getTradeQuotes(
             getTradeQuoteInput,
-            enabledSwappers.filter(
-              swapperName => ![SwapperName.OneInch, SwapperName.Zrx].includes(swapperName),
-            ),
+            enabledSwappers.filter(swapperName => !evmDonationSwappers.includes(swapperName)),
           ),
         ])
 

--- a/src/state/apis/swappers/swappersApi.ts
+++ b/src/state/apis/swappers/swappersApi.ts
@@ -1,11 +1,8 @@
 import { createApi } from '@reduxjs/toolkit/dist/query/react'
 import orderBy from 'lodash/orderBy'
-import { bnOrZero } from 'lib/bignumber/bignumber'
-import { fromBaseUnit } from 'lib/math'
 import type { GetTradeQuoteInput } from 'lib/swapper/api'
 import { SwapperName } from 'lib/swapper/api'
 import { getTradeQuotes } from 'lib/swapper/swapper'
-import { getMinimumDonationUsdSellAmountByChainId } from 'lib/swapper/swappers/utils/getMinimumDonationUsdSellAmountByChainId'
 import { getEnabledSwappers } from 'lib/swapper/utils'
 import { getInputOutputRatioFromQuote } from 'state/apis/swappers/helpers/getInputOutputRatioFromQuote'
 import type { ApiQuote } from 'state/apis/swappers/types'
@@ -16,6 +13,7 @@ import type { FeatureFlags } from 'state/slices/preferencesSlice/preferencesSlic
 import { selectFeatureFlags } from 'state/slices/selectors'
 
 import { BASE_RTK_CREATE_API_CONFIG } from '../const'
+import { getIsDonationAmountBelowMinimum } from './helpers/getIsDonationAmountBelowMinimum'
 
 // these are the swappers with special logic regarding minimum donations
 const evmDonationSwappers = [SwapperName.OneInch, SwapperName.Zrx, SwapperName.LIFI]
@@ -47,16 +45,11 @@ export const swappersApi = createApi({
         await dispatch(marketApi.endpoints.findByAssetId.initiate(sellAsset.assetId))
         await dispatch(marketApi.endpoints.findByAssetId.initiate(buyAsset.assetId))
 
-        const sellAmountBeforeFeesCryptoPrecision = fromBaseUnit(
-          sellAmountIncludingProtocolFeesCryptoBaseUnit,
-          sellAsset.precision,
-        )
-        const sellAmountBeforeFeesUsd = bnOrZero(sellAmountBeforeFeesCryptoPrecision).times(
-          sellAssetUsdRate,
-        )
         // We use the sell amount so we don't have to make 2 network requests, as the receive amount requires a quote
-        const isDonationAmountBelowMinimum = sellAmountBeforeFeesUsd.lt(
-          getMinimumDonationUsdSellAmountByChainId(sellAsset.chainId),
+        const isDonationAmountBelowMinimum = getIsDonationAmountBelowMinimum(
+          sellAmountIncludingProtocolFeesCryptoBaseUnit,
+          sellAsset,
+          sellAssetUsdRate,
         )
 
         const quoteResults = await Promise.all([

--- a/src/state/slices/tradeQuoteSlice/selectors.ts
+++ b/src/state/slices/tradeQuoteSlice/selectors.ts
@@ -2,7 +2,6 @@ import { createSelector } from '@reduxjs/toolkit'
 import type { AssetId } from '@shapeshiftoss/caip'
 import { getDefaultSlippagePercentageForSwapper } from 'constants/constants'
 import type { Selector } from 'reselect'
-import { DEFAULT_SWAPPER_DONATION_BPS } from 'components/MultiHopTrade/constants'
 import type { Asset } from 'lib/asset-service'
 import { bn, bnOrZero } from 'lib/bignumber/bignumber'
 import { fromBaseUnit } from 'lib/math'
@@ -394,7 +393,7 @@ export const selectPotentialDonationAmountUserCurrency: Selector<ReduxState, str
       if (activeQuote?.affiliateBps === undefined) return undefined
       else {
         const affiliatePercentage = convertBasisPointsToDecimalPercentage(
-          DEFAULT_SWAPPER_DONATION_BPS,
+          activeQuote.affiliateBps ?? '0',
         )
         // The donation amount is a percentage of the sell amount
         return bnOrZero(sellAmountUserCurrency).times(affiliatePercentage).toFixed()


### PR DESCRIPTION
## Description

Enables opt-out donations for lifi trades. Uses same minimum donation logic as zrx and 1inch swappers to minimise wastefulness when donating on ethereum network.

Fixes incorrect donation amounts for thorchain quotes (showing 30bps when thorchain is 25).

## Pull Request Type

- [ ] :bug: Bug fix (Non-breaking Change: Fixes an issue)
- [ ] :hammer_and_wrench: Chore (Non-breaking Change: Doc updates, pkg upgrades, typos, etc..)
- [x] :nail_care: New Feature (Breaking/Non-breaking Change)

## Issue (if applicable)

NA

## Risk

Risk of incorrect or broken lifi trades.

## Testing

Check lifi trades are still working. We need to contact lifi to check donations are working but if trades are not broken by this we should do it async to releasing this.

### Engineering

☝️

### Operations

☝️

## Screenshots (if applicable)

![image](https://github.com/shapeshift/web/assets/125113430/12b3fa96-a8bc-49de-b74c-12f2cefa5dd6)
