### PR TITLE
fix: better language selector default value

### DIFF
--- a/src/components/LanguageSelector.tsx
+++ b/src/components/LanguageSelector.tsx
@@ -19,9 +19,9 @@ export const LanguageSelector: React.FC<SelectProps> = props => {
   }
 
   return (
-    <Select onChange={handleLanguageChange} {...props}>
+    <Select onChange={handleLanguageChange} defaultValue={selectedLocale} {...props}>
       {locales.map(locale => (
-        <option key={locale.key} value={locale.key} selected={locale.key === selectedLocale}>
+        <option key={locale.key} value={locale.key}>
           {locale.label}
         </option>
       ))}


### PR DESCRIPTION
## Description

Noticed a warning on the welcome/connect page about the Language Selector, it should use `defaultValue` on the `<select>` instead of directly setting the `selected` value on `<option>`.

![image](https://github.com/shapeshift/web/assets/88804546/5fb800ad-5ca2-4e5d-b944-3ce6d6d43f8e)

This fixes it.

<!-- Please describe your changes -->

## Pull Request Type

- [x] :bug: Bug fix (Non-breaking Change: Fixes an issue)
- [ ] :hammer_and_wrench: Chore (Non-breaking Change: Doc updates, pkg upgrades, typos, etc..)
- [ ] :nail_care: New Feature (Breaking/Non-breaking Change)

## Issue (if applicable)

<!-----------------------------------------------------------------------------
If applicable, please link to the github issue and put `closes #XXXX` in your comment to auto-close the issue that your PR fixes.
------------------------------------------------------------------------------>

N/A

## Risk
Low.

<!-----------------------------------------------------------------------------
Outline the scope of your changes and the risk associated with them. You must use your discretion as an engineer to determine the potential impact of your changes.

E.g. an upgrade to `hdwallet` or core state management would be considered higher risk, and might require a full regression test. UI or isolated view changes, or something behind a feature flag may have near zero risk. Small bug fixes might require testing isolated to the specific fix.
------------------------------------------------------------------------------>

## Testing

Verify that the default (detected) language is reflected correctly in the Language selector on first visit (you can use the Clear Cache feature after adding different languages in the browser settings).

<!-----------------------------------------------------------------------------
We treat every PR to be merged with the same scrutiny as if we were merging directly to production.

Your PR will not be merged if you do not complete the sections below for our engineering and operations teams to test.
------------------------------------------------------------------------------>

### Engineering
☝️ 
<!-----------------------------------------------------------------------------
Include sufficient information here for an engineer to test your PR. This may include how to test locally, in a built environment, changes to infrastructure etc.
------------------------------------------------------------------------------>

### Operations
☝️ 
<!-----------------------------------------------------------------------------
If your changes have a user-facing impact, describe how a non-technical QA team can functionally test your changes in a preview environment.

If they are not user-facing please describe how to test for any regressions that may occur.
------------------------------------------------------------------------------>

## Screenshots (if applicable)

First load with French in browser settings:
![image](https://github.com/shapeshift/web/assets/88804546/952e4cbb-8725-438d-92df-71eae544b9d9)

First load with an unsupported language (e.g. nl) in the browser settings, default to English in localstorage settings and UI:
![image](https://github.com/shapeshift/web/assets/88804546/01b17f61-ffcf-42f2-aa11-f6e9ce784ad1)
