### PR TITLE
fix: improve thor slippage

### DIFF
--- a/src/components/MultiHopTrade/components/MultiHopTradeConfirm/MultiHopTradeConfirm.tsx
+++ b/src/components/MultiHopTrade/components/MultiHopTradeConfirm/MultiHopTradeConfirm.tsx
@@ -407,8 +407,10 @@ const FirstHop = ({
   ])
 
   const slippageDecimalPercentage = useMemo(
-    () => tradeQuote.recommendedSlippage ?? getDefaultSlippagePercentageForSwapper(swapperName),
-    [swapperName, tradeQuote.recommendedSlippage],
+    () =>
+      tradeQuote.recommendedSlippageDecimalPercentage ??
+      getDefaultSlippagePercentageForSwapper(swapperName),
+    [swapperName, tradeQuote.recommendedSlippageDecimalPercentage],
   )
 
   const networkFeeFiatPrecision = selectHopTotalNetworkFeeFiatPrecision(store.getState(), 0)
@@ -572,8 +574,10 @@ const SecondHop = ({
   ])
 
   const slippageDecimalPercentage = useMemo(
-    () => tradeQuote.recommendedSlippage ?? getDefaultSlippagePercentageForSwapper(swapperName),
-    [swapperName, tradeQuote.recommendedSlippage],
+    () =>
+      tradeQuote.recommendedSlippageDecimalPercentage ??
+      getDefaultSlippagePercentageForSwapper(swapperName),
+    [swapperName, tradeQuote.recommendedSlippageDecimalPercentage],
   )
 
   const networkFeeFiatPrecision = selectHopTotalNetworkFeeFiatPrecision(store.getState(), 1)

--- a/src/components/MultiHopTrade/hooks/useGetTradeQuotes/getTradeQuoteArgs.ts
+++ b/src/components/MultiHopTrade/hooks/useGetTradeQuotes/getTradeQuoteArgs.ts
@@ -52,7 +52,7 @@ export const getTradeQuoteArgs = async ({
     accountNumber: sellAccountNumber,
     affiliateBps: affiliateBps ?? '0',
     allowMultiHop,
-    slippageTolerancePercentage,
+    userSpecifiedSlippageTolerancePercentage: slippageTolerancePercentage,
   }
   if (isEvmSwap(sellAsset?.chainId) || isCosmosSdkSwap(sellAsset?.chainId)) {
     const supportsEIP1559 = supportsETH(wallet) && (await wallet.ethSupportsEIP1559())

--- a/src/components/MultiHopTrade/hooks/useGetTradeQuotes/useGetTradeQuotes.tsx
+++ b/src/components/MultiHopTrade/hooks/useGetTradeQuotes/useGetTradeQuotes.tsx
@@ -77,13 +77,13 @@ const isEqualExceptAffiliateBpsAndSlippage = (
   if (!isSkipToken(a) && b) {
     const {
       affiliateBps: _affiliateBps,
-      slippageTolerancePercentage: _slippageTolerancePercentage,
+      userSpecifiedSlippageTolerancePercentage: _slippageTolerancePercentage,
       ...aWithoutAffiliateBpsAndSlippage
     } = a
 
     const {
       affiliateBps: _updatedAffiliateBps,
-      slippageTolerancePercentage: _updatedSlippageTolerancePercentage,
+      userSpecifiedSlippageTolerancePercentage: _updatedSlippageTolerancePercentage,
       ...bWithoutAffiliateBpsAndSlippage
     } = b
 

--- a/src/components/MultiHopTrade/types.ts
+++ b/src/components/MultiHopTrade/types.ts
@@ -59,5 +59,5 @@ export type TradeQuoteInputCommonArgs = Pick<
   | 'accountNumber'
   | 'affiliateBps'
   | 'allowMultiHop'
-  | 'slippageTolerancePercentage'
+  | 'userSpecifiedSlippageTolerancePercentage'
 >

--- a/src/lib/swapper/swappers/CowSwapper/getCowSwapTradeQuote/getCowSwapTradeQuote.test.ts
+++ b/src/lib/swapper/swappers/CowSwapper/getCowSwapTradeQuote/getCowSwapTradeQuote.test.ts
@@ -222,7 +222,7 @@ describe('getCowTradeQuote', () => {
       affiliateBps: '0',
       supportsEIP1559: false,
       allowMultiHop: false,
-      slippageTolerancePercentage: '0.005', // 0.5%
+      userSpecifiedSlippageTolerancePercentage: '0.005', // 0.5%
     }
 
     const maybeTradeQuote = await getCowSwapTradeQuote(input)
@@ -247,7 +247,7 @@ describe('getCowTradeQuote', () => {
       affiliateBps: '0',
       supportsEIP1559: false,
       allowMultiHop: false,
-      slippageTolerancePercentage: '0.005', // 0.5%
+      userSpecifiedSlippageTolerancePercentage: '0.005', // 0.5%
     }
 
     ;(cowService.post as jest.Mock<unknown>).mockReturnValue(
@@ -290,7 +290,7 @@ describe('getCowTradeQuote', () => {
       affiliateBps: '0',
       supportsEIP1559: false,
       allowMultiHop: false,
-      slippageTolerancePercentage: '0.005', // 0.5%
+      userSpecifiedSlippageTolerancePercentage: '0.005', // 0.5%
     }
 
     ;(cowService.post as jest.Mock<unknown>).mockReturnValue(
@@ -333,7 +333,7 @@ describe('getCowTradeQuote', () => {
       affiliateBps: '0',
       supportsEIP1559: false,
       allowMultiHop: false,
-      slippageTolerancePercentage: '0.005', // 0.5%
+      userSpecifiedSlippageTolerancePercentage: '0.005', // 0.5%
     }
 
     ;(cowService.post as jest.Mock<unknown>).mockReturnValue(
@@ -376,7 +376,7 @@ describe('getCowTradeQuote', () => {
       affiliateBps: '0',
       supportsEIP1559: false,
       allowMultiHop: false,
-      slippageTolerancePercentage: '0.005', // 0.5%
+      userSpecifiedSlippageTolerancePercentage: '0.005', // 0.5%
     }
 
     ;(cowService.post as jest.Mock<unknown>).mockReturnValue(

--- a/src/lib/swapper/swappers/LifiSwapper/getTradeQuote/getTradeQuote.ts
+++ b/src/lib/swapper/swappers/LifiSwapper/getTradeQuote/getTradeQuote.ts
@@ -33,7 +33,7 @@ export async function getTradeQuote(
     sendAddress,
     receiveAddress,
     accountNumber,
-    slippageTolerancePercentage,
+    userSpecifiedSlippageTolerancePercentage,
     supportsEIP1559,
     affiliateBps,
   } = input
@@ -77,7 +77,8 @@ export async function getTradeQuote(
       // used for analytics and donations - do not change this without considering impact
       integrator: LIFI_INTEGRATOR_ID,
       slippage: Number(
-        slippageTolerancePercentage ?? getDefaultSlippagePercentageForSwapper(SwapperName.LIFI),
+        userSpecifiedSlippageTolerancePercentage ??
+          getDefaultSlippagePercentageForSwapper(SwapperName.LIFI),
       ),
       exchanges: { deny: ['dodo'] },
       // TODO(gomes): We don't currently handle trades that require a mid-trade user-initiated Tx on a different chain

--- a/src/lib/swapper/swappers/ThorchainSwapper/constants.ts
+++ b/src/lib/swapper/swappers/ThorchainSwapper/constants.ts
@@ -5,6 +5,7 @@ import type { SwapSource } from 'lib/swapper/types'
 import { SwapperName } from 'lib/swapper/types'
 // TODO: read from https://daemon.thorchain.shapeshift.com/lcd/thorchain/constants
 export const RUNE_OUTBOUND_TRANSACTION_FEE_CRYPTO_HUMAN = bn('0.02')
+export const THORSWAP_ALLOWABLE_MARKET_MOVEMENT_BPS = 100
 
 export const sellSupportedChainIds: Record<ThorChainId, boolean> = {
   [KnownChainIds.EthereumMainnet]: true,

--- a/src/lib/swapper/swappers/ThorchainSwapper/cosmossdk/getCosmosTxData.ts
+++ b/src/lib/swapper/swappers/ThorchainSwapper/cosmossdk/getCosmosTxData.ts
@@ -19,7 +19,7 @@ type GetCosmosTxDataInput = {
   sellAmountCryptoBaseUnit: string
   sellAsset: Asset
   buyAsset: Asset
-  slippageTolerance: string
+  slippageDecimalPercentage: string
   from: string
   quote: TradeQuote
   chainId: ChainId

--- a/src/lib/swapper/swappers/ThorchainSwapper/endpoints.ts
+++ b/src/lib/swapper/swappers/ThorchainSwapper/endpoints.ts
@@ -60,7 +60,7 @@ export const thorchainApi: SwapperApi = {
       chainSpecific,
       ...fromOrXpub,
       supportsEIP1559,
-      slippageTolerancePercentage: slippageTolerancePercentageDecimal,
+      userSpecifiedSlippageTolerancePercentage: slippageTolerancePercentageDecimal,
     })
   },
 

--- a/src/lib/swapper/swappers/ThorchainSwapper/getThorTradeQuote/getTradeQuote.test.ts
+++ b/src/lib/swapper/swappers/ThorchainSwapper/getThorTradeQuote/getTradeQuote.test.ts
@@ -49,7 +49,7 @@ const expectedQuoteResponse: Omit<ThorEvmTradeQuote, 'id'>[] = [
     affiliateBps: '0',
     isStreaming: false,
     rate: '144114.94366197183098591549',
-    recommendedSlippage: '0.0435',
+    recommendedSlippageDecimalPercentage: '0.0435',
     data: '0x',
     router: '0x3624525075b88B24ecc29CE226b0CEc1fFcB6976',
     estimatedExecutionTimeMs: 600000,
@@ -82,7 +82,7 @@ const expectedQuoteResponse: Omit<ThorEvmTradeQuote, 'id'>[] = [
     affiliateBps: '0',
     isStreaming: true,
     rate: '158199.45070422535211267606',
-    recommendedSlippage: '0.042',
+    recommendedSlippageDecimalPercentage: '0.042',
     data: '0x',
     router: '0x3624525075b88B24ecc29CE226b0CEc1fFcB6976',
     estimatedExecutionTimeMs: 1600000,
@@ -169,7 +169,7 @@ describe('getTradeQuote', () => {
       sellAmountIncludingProtocolFeesCryptoBaseUnit: '713014679420',
       buyAsset: ETH,
       sellAsset: FOX_MAINNET,
-      slippageTolerancePercentage: '0.04357',
+      userSpecifiedSlippageTolerancePercentage: '0.04357',
     }
 
     const maybeTradeQuote = await getThorTradeQuote(input)

--- a/src/lib/swapper/swappers/ThorchainSwapper/getThorTradeQuote/getTradeQuote.ts
+++ b/src/lib/swapper/swappers/ThorchainSwapper/getThorTradeQuote/getTradeQuote.ts
@@ -211,7 +211,7 @@ export const getThorTradeQuote = async (
             expectedAmountOutThorBaseUnit,
             isStreaming,
             estimatedExecutionTimeMs,
-          }) => {
+          }): Promise<ThorTradeQuote> => {
             /*
              We start with the expected slippage amount, as given to us by the THORSwap API for the current quote.
               We then add 1% to allow for market movement, which prevents failed/refunded trades.
@@ -251,7 +251,7 @@ export const getThorTradeQuote = async (
               affiliateBps,
               isStreaming,
               estimatedExecutionTimeMs,
-              recommendedSlippage:
+              recommendedSlippageDecimalPercentage:
                 convertBasisPointsToDecimalPercentage(estimatedSlippageBps).toString(),
               rate,
               data,
@@ -303,7 +303,7 @@ export const getThorTradeQuote = async (
             expectedAmountOutThorBaseUnit,
             isStreaming,
             estimatedExecutionTimeMs,
-          }) => {
+          }): Promise<ThorTradeQuote> => {
             /*
              We start with the expected slippage amount, as given to us by the THORSwap API for the current quote.
               We then add 1% to allow for market movement, which prevents failed/refunded trades.
@@ -356,7 +356,7 @@ export const getThorTradeQuote = async (
               affiliateBps,
               isStreaming,
               estimatedExecutionTimeMs,
-              recommendedSlippage:
+              recommendedSlippageDecimalPercentage:
                 convertBasisPointsToDecimalPercentage(estimatedSlippageBps).toString(),
               rate,
               steps: [
@@ -406,7 +406,7 @@ export const getThorTradeQuote = async (
             expectedAmountOutThorBaseUnit,
             isStreaming,
             estimatedExecutionTimeMs,
-          }) => {
+          }): ThorTradeQuote => {
             /*
              We start with the expected slippage amount, as given to us by the THORSwap API for the current quote.
               We then add 1% to allow for market movement, which prevents failed/refunded trades.

--- a/src/lib/swapper/swappers/ThorchainSwapper/getThorTradeQuote/getTradeQuote.ts
+++ b/src/lib/swapper/swappers/ThorchainSwapper/getThorTradeQuote/getTradeQuote.ts
@@ -212,16 +212,9 @@ export const getThorTradeQuote = async (
             isStreaming,
             estimatedExecutionTimeMs,
           }): Promise<ThorTradeQuote> => {
-            /*
-             We start with the expected slippage amount, as given to us by the THORSwap API for the current quote.
-              We then add 1% to allow for market movement, which prevents failed/refunded trades.
-            */
-            const recommendedSlippageBps = bnOrZero(estimatedSlippageBps)
-              .plus(THORSWAP_ALLOWABLE_MARKET_MOVEMENT_BPS)
-              .toFixed()
             const slippageBps = userSpecifiedSlippageTolerancePercentage
               ? convertDecimalPercentageToBasisPoints(userSpecifiedSlippageTolerancePercentage)
-              : recommendedSlippageBps
+              : estimatedSlippageBps
             const rate = getRouteRate(expectedAmountOutThorBaseUnit)
             const buyAmountBeforeFeesCryptoBaseUnit = getRouteBuyAmount(
               expectedAmountOutThorBaseUnit,
@@ -304,16 +297,9 @@ export const getThorTradeQuote = async (
             isStreaming,
             estimatedExecutionTimeMs,
           }): Promise<ThorTradeQuote> => {
-            /*
-             We start with the expected slippage amount, as given to us by the THORSwap API for the current quote.
-              We then add 1% to allow for market movement, which prevents failed/refunded trades.
-            */
-            const recommendedSlippageBps = bnOrZero(estimatedSlippageBps)
-              .plus(THORSWAP_ALLOWABLE_MARKET_MOVEMENT_BPS)
-              .toFixed()
             const slippageBps = userSpecifiedSlippageTolerancePercentage
               ? convertDecimalPercentageToBasisPoints(userSpecifiedSlippageTolerancePercentage)
-              : recommendedSlippageBps
+              : estimatedSlippageBps
             const rate = getRouteRate(expectedAmountOutThorBaseUnit)
             const buyAmountBeforeFeesCryptoBaseUnit = getRouteBuyAmount(
               expectedAmountOutThorBaseUnit,

--- a/src/lib/swapper/swappers/ThorchainSwapper/getThorTradeQuote/getTradeQuote.ts
+++ b/src/lib/swapper/swappers/ThorchainSwapper/getThorTradeQuote/getTradeQuote.ts
@@ -3,7 +3,6 @@ import { CHAIN_NAMESPACE, fromAssetId } from '@shapeshiftoss/caip'
 import type { Result } from '@sniptt/monads'
 import { Err, Ok } from '@sniptt/monads'
 import { getConfig } from 'config'
-import { getDefaultSlippagePercentageForSwapper } from 'constants/constants'
 import { v4 as uuid } from 'uuid'
 import { getChainAdapterManager } from 'context/PluginProvider/chainAdapterSingleton'
 import { baseUnitToPrecision, bn, bnOrZero, convertPrecision } from 'lib/bignumber/bignumber'
@@ -62,10 +61,6 @@ export const getThorTradeQuote = async (
   const { chainNamespace } = fromAssetId(sellAsset.assetId)
 
   const { chainId: buyAssetChainId } = fromAssetId(buyAsset.assetId)
-  const userSpecifiedSlippageOrDefaultDecimalPercentage = convertDecimalPercentageToBasisPoints(
-    userSpecifiedSlippageTolerancePercentage ??
-      getDefaultSlippagePercentageForSwapper(SwapperName.Thorchain),
-  ).toString()
 
   const chainAdapterManager = getChainAdapterManager()
   const sellAdapter = chainAdapterManager.get(chainId)
@@ -224,10 +219,9 @@ export const getThorTradeQuote = async (
             const recommendedSlippageBps = bnOrZero(estimatedSlippageBps)
               .plus(THORSWAP_ALLOWABLE_MARKET_MOVEMENT_BPS)
               .toFixed()
-            const slippageBps =
-              convertDecimalPercentageToBasisPoints(
-                userSpecifiedSlippageOrDefaultDecimalPercentage,
-              ) ?? recommendedSlippageBps
+            const slippageBps = userSpecifiedSlippageTolerancePercentage
+              ? convertDecimalPercentageToBasisPoints(userSpecifiedSlippageTolerancePercentage)
+              : recommendedSlippageBps
             const rate = getRouteRate(expectedAmountOutThorBaseUnit)
             const buyAmountBeforeFeesCryptoBaseUnit = getRouteBuyAmount(
               expectedAmountOutThorBaseUnit,
@@ -317,10 +311,9 @@ export const getThorTradeQuote = async (
             const recommendedSlippageBps = bnOrZero(estimatedSlippageBps)
               .plus(THORSWAP_ALLOWABLE_MARKET_MOVEMENT_BPS)
               .toFixed()
-            const slippageBps =
-              convertDecimalPercentageToBasisPoints(
-                userSpecifiedSlippageOrDefaultDecimalPercentage,
-              ) ?? recommendedSlippageBps
+            const slippageBps = userSpecifiedSlippageTolerancePercentage
+              ? convertDecimalPercentageToBasisPoints(userSpecifiedSlippageTolerancePercentage)
+              : recommendedSlippageBps
             const rate = getRouteRate(expectedAmountOutThorBaseUnit)
             const buyAmountBeforeFeesCryptoBaseUnit = getRouteBuyAmount(
               expectedAmountOutThorBaseUnit,

--- a/src/lib/swapper/swappers/ThorchainSwapper/utils/getSignTxFromQuote.ts
+++ b/src/lib/swapper/swappers/ThorchainSwapper/utils/getSignTxFromQuote.ts
@@ -31,7 +31,7 @@ type GetSignTxFromQuoteArgs = {
   affiliateBps?: string
   chainSpecific?: utxo.BuildTxInput
   supportsEIP1559: boolean
-  slippageTolerancePercentage: string
+  userSpecifiedSlippageTolerancePercentage: string
 } & ({ from: string; xpub?: never } | { from?: never; xpub: string })
 
 export const getSignTxFromQuote = async ({
@@ -42,14 +42,15 @@ export const getSignTxFromQuote = async ({
   from,
   xpub,
   supportsEIP1559,
-  slippageTolerancePercentage,
+  userSpecifiedSlippageTolerancePercentage,
 }: GetSignTxFromQuoteArgs): Promise<UnsignedTx> => {
   // TODO(gomes): TradeQuote<C> should have a chainId property so we can easily discriminate
   // on ChainId to define additional metadata for a chain-specific TradeQuote
-  const { isStreaming, recommendedSlippage } = quote as ThorTradeQuote
+  const { isStreaming, recommendedSlippageDecimalPercentage } = quote as ThorTradeQuote
 
-  const slippageTolerance = slippageTolerancePercentage ?? recommendedSlippage
-  const slippageBps = convertDecimalPercentageToBasisPoints(slippageTolerance).toString()
+  const slippageDecimalPercentage =
+    userSpecifiedSlippageTolerancePercentage ?? recommendedSlippageDecimalPercentage
+  const slippageBps = convertDecimalPercentageToBasisPoints(slippageDecimalPercentage).toString()
 
   const {
     buyAsset,
@@ -102,7 +103,7 @@ export const getSignTxFromQuote = async ({
         sellAdapter: cosmosSdkChainAdapter,
         sellAmountCryptoBaseUnit,
         sellAsset,
-        slippageTolerance,
+        slippageDecimalPercentage,
         chainId: sellAsset.chainId,
         buyAsset,
         from: from!,

--- a/src/lib/swapper/swappers/ZrxSwapper/getZrxTradeQuote/getZrxTradeQuote.ts
+++ b/src/lib/swapper/swappers/ZrxSwapper/getZrxTradeQuote/getZrxTradeQuote.ts
@@ -33,7 +33,7 @@ export async function getZrxTradeQuote(
     affiliateBps,
     chainId,
     supportsEIP1559,
-    slippageTolerancePercentage,
+    userSpecifiedSlippageTolerancePercentage,
     sellAmountIncludingProtocolFeesCryptoBaseUnit,
   } = input
 
@@ -58,7 +58,8 @@ export async function getZrxTradeQuote(
       affiliateAddress: AFFILIATE_ADDRESS, // Used for 0x analytics
       skipValidation: true,
       slippagePercentage:
-        slippageTolerancePercentage ?? getDefaultSlippagePercentageForSwapper(SwapperName.Zrx),
+        userSpecifiedSlippageTolerancePercentage ??
+        getDefaultSlippagePercentageForSwapper(SwapperName.Zrx),
       feeRecipient: getTreasuryAddressFromChainId(buyAsset.chainId), // Where affiliate fees are sent
       buyTokenPercentageFee: convertBasisPointsToDecimalPercentage(affiliateBps).toNumber(),
     },

--- a/src/lib/swapper/swappers/utils/test-data/setupSwapQuote.ts
+++ b/src/lib/swapper/swappers/utils/test-data/setupSwapQuote.ts
@@ -44,7 +44,7 @@ export const setupQuote = () => {
     affiliateBps: '0',
     supportsEIP1559: false,
     allowMultiHop: false,
-    slippageTolerancePercentage: DEFAULT_SLIPPAGE,
+    userSpecifiedSlippageTolerancePercentage: DEFAULT_SLIPPAGE,
   }
   return { quoteInput, tradeQuote, buyAsset, sellAsset }
 }

--- a/src/lib/swapper/types.ts
+++ b/src/lib/swapper/types.ts
@@ -49,7 +49,7 @@ type CommonTradeInput = {
   receiveAccountNumber?: number
   affiliateBps: string
   allowMultiHop: boolean
-  slippageTolerancePercentage?: string
+  userSpecifiedSlippageTolerancePercentage?: string
 }
 
 export type GetEvmTradeQuoteInput = CommonTradeInput & {
@@ -95,7 +95,7 @@ export type TradeQuoteStep = {
 }
 
 export type TradeQuote = {
-  recommendedSlippage?: string
+  recommendedSlippageDecimalPercentage?: string
   estimatedExecutionTimeMs: number | undefined
   id: string
   steps: TradeQuoteStep[]

--- a/src/state/apis/swappers/helpers/testData.ts
+++ b/src/state/apis/swappers/helpers/testData.ts
@@ -53,7 +53,7 @@ export const thorQuote: TradeQuote = {
   rate: '39.23942597524024759752',
   receiveAddress: '0x31b5c4ab7d020de87901c736535aeb4769806947',
   affiliateBps: '30',
-  recommendedSlippage: '0.00001',
+  recommendedSlippageDecimalPercentage: '0.00001',
   estimatedExecutionTimeMs: undefined,
   steps: [
     {

--- a/src/state/slices/tradeQuoteSlice/selectors.ts
+++ b/src/state/slices/tradeQuoteSlice/selectors.ts
@@ -238,7 +238,8 @@ export const selectQuoteOrDefaultSlippagePercentageDecimal: Selector<ReduxState,
     selectActiveQuote,
     selectActiveSwapperName,
     (activeQuote, activeSwapperName) =>
-      activeQuote?.recommendedSlippage ?? getDefaultSlippagePercentageForSwapper(activeSwapperName),
+      activeQuote?.recommendedSlippageDecimalPercentage ??
+      getDefaultSlippagePercentageForSwapper(activeSwapperName),
   )
 
 export const selectQuoteOrDefaultSlippagePercentage: Selector<ReduxState, string> = createSelector(


### PR DESCRIPTION
## Description

Use the recommended slippage from the thor quote endpoint when calculating the memo.

This feeds into the limit value.

## Pull Request Type

- [x] :bug: Bug fix (Non-breaking Change: Fixes an issue)
- [ ] :hammer_and_wrench: Chore (Non-breaking Change: Doc updates, pkg upgrades, typos, etc..)
- [ ] :nail_care: New Feature (Breaking/Non-breaking Change)

## Issue (if applicable)

N/A - prod issue

## Risk

High - touches memos!

## Testing

Ensure that the amount we show the user in the "amount after slippage part of the UI", and the slippage used to calculate the memo is the one returned from the thor quote endpoint. It is also a function of if it was a streaming swap or not.

The limit is calculated by: expected amount - recommended slippage.

### Engineering

Check the actual memo that we put into the TX.

### Operations

☝️

## Screenshots (if applicable)

N/A