### PR TITLE
fix: dont refetch thor swapper quotes when building tx to prevent mismatch with UI

### DIFF
--- a/src/lib/swapper/swappers/ThorchainSwapper/getThorTradeQuote/getTradeQuote.test.ts
+++ b/src/lib/swapper/swappers/ThorchainSwapper/getThorTradeQuote/getTradeQuote.test.ts
@@ -53,6 +53,7 @@ const expectedQuoteResponse: Omit<ThorEvmTradeQuote, 'id'>[] = [
     data: '0x',
     router: '0x3624525075b88B24ecc29CE226b0CEc1fFcB6976',
     estimatedExecutionTimeMs: 600000,
+    memo: '=:ETH.ETH:0x32DBc9Cf9E8FbCebE1e0a2ecF05Ed86Ca3096Cb6:9786345:ss:0',
     steps: [
       {
         allowanceContract: '0x3624525075b88B24ecc29CE226b0CEc1fFcB6976',
@@ -86,6 +87,7 @@ const expectedQuoteResponse: Omit<ThorEvmTradeQuote, 'id'>[] = [
     data: '0x',
     router: '0x3624525075b88B24ecc29CE226b0CEc1fFcB6976',
     estimatedExecutionTimeMs: 1600000,
+    memo: '=:ETH.ETH:0x32DBc9Cf9E8FbCebE1e0a2ecF05Ed86Ca3096Cb6:10742775/10/0:ss:0',
     steps: [
       {
         allowanceContract: '0x3624525075b88B24ecc29CE226b0CEc1fFcB6976',

--- a/src/lib/swapper/swappers/ThorchainSwapper/getThorTradeQuote/getTradeQuote.ts
+++ b/src/lib/swapper/swappers/ThorchainSwapper/getThorTradeQuote/getTradeQuote.ts
@@ -36,10 +36,11 @@ import { THORCHAIN_STREAM_SWAP_SOURCE } from '../constants'
 import { addSlippageToMemo } from '../utils/addSlippageToMemo'
 import { getEvmTxFees } from '../utils/txFeeHelpers/evmTxFees/getEvmTxFees'
 
-export type ThorEvmTradeQuote = TradeQuote & {
-  router: string
-  data: string
-}
+export type ThorEvmTradeQuote = TradeQuote &
+  ThorTradeQuoteSpecificMetadata & {
+    router: string
+    data: string
+  }
 
 type ThorTradeQuoteSpecificMetadata = { isStreaming: boolean; memo: string }
 type ThorTradeQuoteBase = TradeQuote | ThorEvmTradeQuote

--- a/src/lib/swapper/swappers/ThorchainSwapper/getThorTradeQuote/getTradeQuote.ts
+++ b/src/lib/swapper/swappers/ThorchainSwapper/getThorTradeQuote/getTradeQuote.ts
@@ -41,7 +41,7 @@ export type ThorEvmTradeQuote = TradeQuote & {
   data: string
 }
 
-type ThorTradeQuoteSpecificMetadata = { isStreaming: boolean }
+type ThorTradeQuoteSpecificMetadata = { isStreaming: boolean; memo: string }
 type ThorTradeQuoteBase = TradeQuote | ThorEvmTradeQuote
 export type ThorTradeQuote = ThorTradeQuoteBase & ThorTradeQuoteSpecificMetadata
 
@@ -241,6 +241,7 @@ export const getThorTradeQuote = async (
 
             return {
               id: uuid(),
+              memo: updatedMemo,
               receiveAddress,
               affiliateBps,
               isStreaming,
@@ -335,6 +336,7 @@ export const getThorTradeQuote = async (
 
             return {
               id: uuid(),
+              memo: updatedMemo,
               receiveAddress,
               affiliateBps,
               isStreaming,
@@ -400,8 +402,16 @@ export const getThorTradeQuote = async (
               outputExponent: buyAsset.precision,
             }).toFixed()
 
+            const updatedMemo = addSlippageToMemo(
+              thornodeQuote,
+              inputSlippageBps,
+              isStreaming,
+              sellAsset.chainId,
+            )
+
             return {
               id: uuid(),
+              memo: updatedMemo,
               receiveAddress,
               affiliateBps,
               isStreaming,


### PR DESCRIPTION
## Description

Fixes issue where cosmos SDK and UTXO trades re-fetch the quote when executing the trade, resulting in the limit not matching the quote confirmed by the user.

## Pull Request Type

- [x] :bug: Bug fix (Non-breaking Change: Fixes an issue)
- [ ] :hammer_and_wrench: Chore (Non-breaking Change: Doc updates, pkg upgrades, typos, etc..)
- [ ] :nail_care: New Feature (Breaking/Non-breaking Change)

## Issue (if applicable)

NA

## Risk

Risk of broken thor swapper trades.

## Testing

Check thor swapper trades work on EVM, UTXO, cosmos SDK.

### Engineering

☝️

### Operations

☝️

## Screenshots (if applicable)
