### PR TITLE
fix: use default slippage value to display min expected after slippage

### DIFF
--- a/src/components/MultiHopTrade/components/MultiHopTradeConfirm/MultiHopTradeConfirm.tsx
+++ b/src/components/MultiHopTrade/components/MultiHopTradeConfirm/MultiHopTradeConfirm.tsx
@@ -26,7 +26,7 @@ import {
   useColorModeValue,
 } from '@chakra-ui/react'
 import type { ChainId } from '@shapeshiftoss/caip'
-import { getDefaultSlippagePercentageForSwapper } from 'constants/constants'
+import { getDefaultSlippageDecimalPercentageForSwapper } from 'constants/constants'
 import { useCallback, useMemo } from 'react'
 import { FaInfoCircle } from 'react-icons/fa'
 import { useTranslate } from 'react-polyglot'
@@ -407,7 +407,8 @@ const FirstHop = ({
   ])
 
   const slippageDecimalPercentage = useMemo(
-    () => tradeQuote.recommendedSlippage ?? getDefaultSlippagePercentageForSwapper(swapperName),
+    () =>
+      tradeQuote.recommendedSlippage ?? getDefaultSlippageDecimalPercentageForSwapper(swapperName),
     [swapperName, tradeQuote.recommendedSlippage],
   )
 
@@ -572,7 +573,8 @@ const SecondHop = ({
   ])
 
   const slippageDecimalPercentage = useMemo(
-    () => tradeQuote.recommendedSlippage ?? getDefaultSlippagePercentageForSwapper(swapperName),
+    () =>
+      tradeQuote.recommendedSlippage ?? getDefaultSlippageDecimalPercentageForSwapper(swapperName),
     [swapperName, tradeQuote.recommendedSlippage],
   )
 

--- a/src/components/MultiHopTrade/components/SlippagePopover.tsx
+++ b/src/components/MultiHopTrade/components/SlippagePopover.tsx
@@ -25,7 +25,7 @@ import { Text } from 'components/Text'
 import { useFeatureFlag } from 'hooks/useFeatureFlag/useFeatureFlag'
 import { selectUserSlippagePercentage } from 'state/slices/swappersSlice/selectors'
 import { swappers } from 'state/slices/swappersSlice/swappersSlice'
-import { selectQuoteOrDefaultSlippagePercentage } from 'state/slices/tradeQuoteSlice/selectors'
+import { selectDefaultSlippagePercentage } from 'state/slices/tradeQuoteSlice/selectors'
 import { useAppDispatch, useAppSelector } from 'state/store'
 
 enum SlippageType {
@@ -38,7 +38,7 @@ const maxSlippagePercentage = '30'
 const focusStyle = { '&[aria-invalid=true]': { borderColor: 'red.500' } }
 
 export const SlippagePopover: FC = () => {
-  const defaultSlippagePercentage = useAppSelector(selectQuoteOrDefaultSlippagePercentage)
+  const defaultSlippagePercentage = useAppSelector(selectDefaultSlippagePercentage)
   const userSlippagePercentage = useAppSelector(selectUserSlippagePercentage)
 
   const [slippageType, setSlippageType] = useState<SlippageType>(SlippageType.Auto)

--- a/src/constants/constants.ts
+++ b/src/constants/constants.ts
@@ -3,12 +3,14 @@ import { assertUnreachable } from 'lib/utils'
 
 export const USDC_PRECISION = 6
 
-// Slippage defaults. Don't export these to ensure the getDefaultSlippagePercentageForSwapper helper function is used.
+// Slippage defaults. Don't export these to ensure the getDefaultSlippageDecimalPercentageForSwapper helper function is used.
 const DEFAULT_SLIPPAGE_DECIMAL_PERCENTAGE = '0.002' // .2%
 const DEFAULT_COWSWAP_SLIPPAGE_DECIMAL_PERCENTAGE = '0.005' // .5%
 const DEFAULT_LIFI_SLIPPAGE_DECIMAL_PERCENTAGE = '0.005' // .5%
 
-export const getDefaultSlippagePercentageForSwapper = (swapperName?: SwapperName): string => {
+export const getDefaultSlippageDecimalPercentageForSwapper = (
+  swapperName?: SwapperName,
+): string => {
   if (swapperName === undefined) return DEFAULT_SLIPPAGE_DECIMAL_PERCENTAGE
   switch (swapperName) {
     case SwapperName.Thorchain:

--- a/src/lib/swapper/swappers/LifiSwapper/getTradeQuote/getTradeQuote.ts
+++ b/src/lib/swapper/swappers/LifiSwapper/getTradeQuote/getTradeQuote.ts
@@ -4,7 +4,7 @@ import type { AssetId, ChainId } from '@shapeshiftoss/caip'
 import { fromChainId } from '@shapeshiftoss/caip'
 import type { Result } from '@sniptt/monads'
 import { Err, Ok } from '@sniptt/monads'
-import { getDefaultSlippagePercentageForSwapper } from 'constants/constants'
+import { getDefaultSlippageDecimalPercentageForSwapper } from 'constants/constants'
 import type { Asset } from 'lib/asset-service'
 import { bn, bnOrZero, convertPrecision } from 'lib/bignumber/bignumber'
 import { LIFI_INTEGRATOR_ID } from 'lib/swapper/swappers/LifiSwapper/utils/constants'
@@ -77,7 +77,8 @@ export async function getTradeQuote(
       // used for analytics and donations - do not change this without considering impact
       integrator: LIFI_INTEGRATOR_ID,
       slippage: Number(
-        slippageTolerancePercentage ?? getDefaultSlippagePercentageForSwapper(SwapperName.LIFI),
+        slippageTolerancePercentage ??
+          getDefaultSlippageDecimalPercentageForSwapper(SwapperName.LIFI),
       ),
       exchanges: { deny: ['dodo'] },
       // TODO(gomes): We don't currently handle trades that require a mid-trade user-initiated Tx on a different chain

--- a/src/lib/swapper/swappers/ThorchainSwapper/getThorTradeQuote/getTradeQuote.ts
+++ b/src/lib/swapper/swappers/ThorchainSwapper/getThorTradeQuote/getTradeQuote.ts
@@ -3,7 +3,7 @@ import { CHAIN_NAMESPACE, fromAssetId } from '@shapeshiftoss/caip'
 import type { Result } from '@sniptt/monads'
 import { Err, Ok } from '@sniptt/monads'
 import { getConfig } from 'config'
-import { getDefaultSlippagePercentageForSwapper } from 'constants/constants'
+import { getDefaultSlippageDecimalPercentageForSwapper } from 'constants/constants'
 import { v4 as uuid } from 'uuid'
 import { getChainAdapterManager } from 'context/PluginProvider/chainAdapterSingleton'
 import { baseUnitToPrecision, bn, bnOrZero, convertPrecision } from 'lib/bignumber/bignumber'
@@ -63,7 +63,8 @@ export const getThorTradeQuote = async (
 
   const { chainId: buyAssetChainId } = fromAssetId(buyAsset.assetId)
   const inputSlippageBps = convertDecimalPercentageToBasisPoints(
-    slippageTolerancePercentage ?? getDefaultSlippagePercentageForSwapper(SwapperName.Thorchain),
+    slippageTolerancePercentage ??
+      getDefaultSlippageDecimalPercentageForSwapper(SwapperName.Thorchain),
   ).toString()
 
   const chainAdapterManager = getChainAdapterManager()

--- a/src/lib/swapper/swappers/ZrxSwapper/getZrxTradeQuote/getZrxTradeQuote.ts
+++ b/src/lib/swapper/swappers/ZrxSwapper/getZrxTradeQuote/getZrxTradeQuote.ts
@@ -1,6 +1,6 @@
 import type { Result } from '@sniptt/monads'
 import { Err, Ok } from '@sniptt/monads'
-import { getDefaultSlippagePercentageForSwapper } from 'constants/constants'
+import { getDefaultSlippageDecimalPercentageForSwapper } from 'constants/constants'
 import { v4 as uuid } from 'uuid'
 import { bn, bnOrZero } from 'lib/bignumber/bignumber'
 import { getTreasuryAddressFromChainId } from 'lib/swapper/swappers/utils/helpers/helpers'
@@ -58,7 +58,8 @@ export async function getZrxTradeQuote(
       affiliateAddress: AFFILIATE_ADDRESS, // Used for 0x analytics
       skipValidation: true,
       slippagePercentage:
-        slippageTolerancePercentage ?? getDefaultSlippagePercentageForSwapper(SwapperName.Zrx),
+        slippageTolerancePercentage ??
+        getDefaultSlippageDecimalPercentageForSwapper(SwapperName.Zrx),
       feeRecipient: getTreasuryAddressFromChainId(buyAsset.chainId), // Where affiliate fees are sent
       buyTokenPercentageFee: convertBasisPointsToDecimalPercentage(affiliateBps).toNumber(),
     },

--- a/src/state/slices/tradeQuoteSlice/selectors.ts
+++ b/src/state/slices/tradeQuoteSlice/selectors.ts
@@ -1,6 +1,6 @@
 import { createSelector } from '@reduxjs/toolkit'
 import type { AssetId } from '@shapeshiftoss/caip'
-import { getDefaultSlippagePercentageForSwapper } from 'constants/constants'
+import { getDefaultSlippageDecimalPercentageForSwapper } from 'constants/constants'
 import type { Selector } from 'reselect'
 import type { Asset } from 'lib/asset-service'
 import { bn, bnOrZero } from 'lib/bignumber/bignumber'
@@ -236,14 +236,17 @@ export const selectLastHopNetworkFeeCryptoPrecision: Selector<ReduxState, string
 export const selectDefaultSlippagePercentage: Selector<ReduxState, string> = createSelector(
   selectActiveSwapperName,
   activeSwapperName =>
-    bn(getDefaultSlippagePercentageForSwapper(activeSwapperName)).times(100).toString(),
+    bn(getDefaultSlippageDecimalPercentageForSwapper(activeSwapperName)).times(100).toString(),
 )
 
 export const selectTradeSlippagePercentageDecimal: Selector<ReduxState, string> = createSelector(
   selectActiveSwapperName,
   selectUserSlippagePercentageDecimal,
   (activeSwapperName, slippagePreferencePercentage) => {
-    return slippagePreferencePercentage ?? getDefaultSlippagePercentageForSwapper(activeSwapperName)
+    return (
+      slippagePreferencePercentage ??
+      getDefaultSlippageDecimalPercentageForSwapper(activeSwapperName)
+    )
   },
 )
 

--- a/src/state/slices/tradeQuoteSlice/selectors.ts
+++ b/src/state/slices/tradeQuoteSlice/selectors.ts
@@ -233,24 +233,17 @@ export const selectLastHopNetworkFeeCryptoPrecision: Selector<ReduxState, string
       : bn(0).toFixed(),
 )
 
-export const selectQuoteOrDefaultSlippagePercentageDecimal: Selector<ReduxState, string> =
-  createSelector(
-    selectActiveQuote,
-    selectActiveSwapperName,
-    (activeQuote, activeSwapperName) =>
-      activeQuote?.recommendedSlippage ?? getDefaultSlippagePercentageForSwapper(activeSwapperName),
-  )
-
-export const selectQuoteOrDefaultSlippagePercentage: Selector<ReduxState, string> = createSelector(
-  selectQuoteOrDefaultSlippagePercentageDecimal,
-  slippagePercentageDecimal => bn(slippagePercentageDecimal).times(100).toString(),
+export const selectDefaultSlippagePercentage: Selector<ReduxState, string> = createSelector(
+  selectActiveSwapperName,
+  activeSwapperName =>
+    bn(getDefaultSlippagePercentageForSwapper(activeSwapperName)).times(100).toString(),
 )
 
 export const selectTradeSlippagePercentageDecimal: Selector<ReduxState, string> = createSelector(
-  selectQuoteOrDefaultSlippagePercentageDecimal,
+  selectActiveSwapperName,
   selectUserSlippagePercentageDecimal,
-  (quoteOrDefaultSlippagePercentage, slippagePreferencePercentage) => {
-    return slippagePreferencePercentage ?? quoteOrDefaultSlippagePercentage
+  (activeSwapperName, slippagePreferencePercentage) => {
+    return slippagePreferencePercentage ?? getDefaultSlippagePercentageForSwapper(activeSwapperName)
   },
 )
 


### PR DESCRIPTION
## Description

Fixes incorrect amount displayed in UI for "min expected after slippage".

Previously we were subtracting the thor "recommended slippage" from the expected receive amount in the UI, which resulted in a different value appearing on the tx.

The issue:
![image](https://github.com/shapeshift/web/assets/125113430/8b2c1441-bc1d-42f9-9283-2eb4d0adf8dc)
![image](https://github.com/shapeshift/web/assets/125113430/77a71e41-6d81-4f64-89e4-80dc95f580f9)

## Pull Request Type

- [x] :bug: Bug fix (Non-breaking Change: Fixes an issue)
- [ ] :hammer_and_wrench: Chore (Non-breaking Change: Doc updates, pkg upgrades, typos, etc..)
- [ ] :nail_care: New Feature (Breaking/Non-breaking Change)

## Issue (if applicable)

NA

## Risk

Risk of broken thor trades

## Testing

Test thor trades

### Engineering

<!-----------------------------------------------------------------------------
Include sufficient information here for an engineer to test your PR. This may include how to test locally, in a built environment, changes to infrastructure etc.
------------------------------------------------------------------------------>

### Operations

<!-----------------------------------------------------------------------------
If your changes have a user-facing impact, describe how a non-technical QA team can functionally test your changes in a preview environment.

If they are not user-facing please describe how to test for any regressions that may occur.
------------------------------------------------------------------------------>

## Screenshots (if applicable)

![image](https://github.com/shapeshift/web/assets/125113430/8f8839be-a012-47c6-81f0-4ab6097fe57f)
![image](https://github.com/shapeshift/web/assets/125113430/280f81a6-be33-40e3-9bab-4fd19568c144)

amount in memo includes 0.2% as expected
![image](https://github.com/shapeshift/web/assets/125113430/c92c8a8b-52ef-41b1-add4-6ee64b62448f)

test tx proves the memo is correct
https://viewblock.io/thorchain/tx/8c1ba9b49bb00f0b927cf0d733dce3c9d1b49a2a806387e2dbc808f897e79b7d

min amount in tx matches UI now
![image](https://github.com/shapeshift/web/assets/125113430/f3512980-55fc-4e1c-a5e8-fa8425f6e267)

