### PR TITLE
chore: update thor slippage

### DIFF
--- a/src/constants/constants.ts
+++ b/src/constants/constants.ts
@@ -7,13 +7,13 @@ export const USDC_PRECISION = 6
 const DEFAULT_SLIPPAGE_DECIMAL_PERCENTAGE = '0.002' // .2%
 const DEFAULT_COWSWAP_SLIPPAGE_DECIMAL_PERCENTAGE = '0.005' // .5%
 const DEFAULT_LIFI_SLIPPAGE_DECIMAL_PERCENTAGE = '0.005' // .5%
+const DEFAULT_THOR_SLIPPAGE = '0.01' // 1%
 
 export const getDefaultSlippageDecimalPercentageForSwapper = (
   swapperName?: SwapperName,
 ): string => {
   if (swapperName === undefined) return DEFAULT_SLIPPAGE_DECIMAL_PERCENTAGE
   switch (swapperName) {
-    case SwapperName.Thorchain:
     case SwapperName.Zrx:
     case SwapperName.OneInch:
     case SwapperName.Test:
@@ -22,6 +22,8 @@ export const getDefaultSlippageDecimalPercentageForSwapper = (
       return DEFAULT_LIFI_SLIPPAGE_DECIMAL_PERCENTAGE
     case SwapperName.CowSwap:
       return DEFAULT_COWSWAP_SLIPPAGE_DECIMAL_PERCENTAGE
+    case SwapperName.Thorchain:
+      return DEFAULT_THOR_SLIPPAGE
     default:
       assertUnreachable(swapperName)
   }


### PR DESCRIPTION
## Description

Update the THORSwapper slippage from 0.2% to 1%.

This is to ensure streaming swaps go through when there is a small amount of market volatility.

We now have advanced slippage turned on, so our users can adjust this value if they choose.

## Pull Request Type

- [ ] :bug: Bug fix (Non-breaking Change: Fixes an issue)
- [x] :hammer_and_wrench: Chore (Non-breaking Change: Doc updates, pkg upgrades, typos, etc..)
- [ ] :nail_care: New Feature (Breaking/Non-breaking Change)

## Issue (if applicable)

N/A - improve UX of streaming swaps and thorswap trades

## Risk

Small.

## Testing

The max slippage (min amount received) should be using 1% (not 0.2%).

### Engineering

☝️

### Operations

☝️

## Screenshots (if applicable)

N/A
