### PR TITLE
feat: thorchain streaming swap progress bar

### DIFF
--- a/src/assets/translations/en/main.json
+++ b/src/assets/translations/en/main.json
@@ -109,7 +109,8 @@
     "feedbackAndSupport": "Feedback & Support",
     "getSupport": "Get Support",
     "viewMyWallet": "View My Wallet",
-    "submitFeatureRequest": "Submit a Feature Request"
+    "submitFeatureRequest": "Submit a Feature Request",
+    "learnMore": "Learn more"
   },
   "consentBanner": {
     "body": {
@@ -676,6 +677,8 @@
     "approvingAsset": "Approving %{symbol}",
     "viewTransaction": "View Transaction",
     "unlimited": "Unlimited",
+    "streamStatus": "Stream Status",
+    "swapsFailed": "%{failedSwaps} swaps failed",
     "exact": "Exact",
     "expectedAmount": "Expected Amount",
     "beforeFees": "Before Fees",

--- a/src/assets/translations/en/main.json
+++ b/src/assets/translations/en/main.json
@@ -678,7 +678,6 @@
     "viewTransaction": "View Transaction",
     "unlimited": "Unlimited",
     "streamStatus": "Stream Status",
-    "fetchingStreamingSwapData": "Loading...",
     "swapsFailed": "%{failedSwaps} swaps failed",
     "exact": "Exact",
     "expectedAmount": "Expected Amount",

--- a/src/assets/translations/en/main.json
+++ b/src/assets/translations/en/main.json
@@ -678,6 +678,7 @@
     "viewTransaction": "View Transaction",
     "unlimited": "Unlimited",
     "streamStatus": "Stream Status",
+    "fetchingStreamingSwapData": "Loading...",
     "swapsFailed": "%{failedSwaps} swaps failed",
     "exact": "Exact",
     "expectedAmount": "Expected Amount",

--- a/src/components/MultiHopTrade/components/TradeConfirm/TradeConfirm.tsx
+++ b/src/components/MultiHopTrade/components/TradeConfirm/TradeConfirm.tsx
@@ -47,6 +47,7 @@ import { getTxLink } from 'lib/getTxLink'
 import { firstNonZeroDecimal } from 'lib/math'
 import { getMixPanel } from 'lib/mixpanel/mixPanelSingleton'
 import { MixPanelEvents } from 'lib/mixpanel/types'
+import { THORCHAIN_STREAM_SWAP_SOURCE } from 'lib/swapper/swappers/ThorchainSwapper/constants'
 import { SwapperName } from 'lib/swapper/types'
 import { assertUnreachable } from 'lib/utils'
 import { selectManualReceiveAddress } from 'state/slices/swappersSlice/selectors'
@@ -159,9 +160,8 @@ export const TradeConfirm = () => {
   const txHash = buyTxHash ?? sellTxHash
 
   const isThorStreamingSwap = useMemo(
-    // TEMP: monkey patch to preview UI changes
-    () => true, // tradeQuoteStep?.source === THORCHAIN_STREAM_SWAP_SOURCE,
-    [],
+    () => tradeQuoteStep?.source === THORCHAIN_STREAM_SWAP_SOURCE,
+    [tradeQuoteStep?.source],
   )
 
   const {
@@ -500,11 +500,13 @@ export const TradeConfirm = () => {
                       <WarningIcon />
                       {translate('trade.swapsFailed', { failedSwaps: failedSwaps.length })}
                     </Row.Value>
-                    <Row.Value>
-                      <Button variant='link' colorScheme='blue' fontSize='sm'>
-                        {translate('common.learnMore')}
-                      </Button>
-                    </Row.Value>
+                    {/* TODO: provide details of streaming swap failures - needs details modal
+                      <Row.Value>
+                        <Button variant='link' colorScheme='blue' fontSize='sm'>
+                          {translate('common.learnMore')}
+                        </Button>
+                      </Row.Value>
+                    */}
                   </Row>
                 )}
               </Stack>

--- a/src/components/MultiHopTrade/components/TradeConfirm/TradeConfirm.tsx
+++ b/src/components/MultiHopTrade/components/TradeConfirm/TradeConfirm.tsx
@@ -484,7 +484,11 @@ export const TradeConfirm = () => {
               <Stack px={4}>
                 <Row>
                   <Row.Label>{translate('trade.streamStatus')}</Row.Label>
-                  <Row.Value>{`${attemptedSwaps} of ${totalSwaps}`}</Row.Value>
+                  <Row.Value>
+                    {totalSwaps > 0
+                      ? `${attemptedSwaps} of ${totalSwaps}`
+                      : translate('trade.fetchingStreamingSwapData')}
+                  </Row.Value>
                 </Row>
                 <Row>
                   <Progress

--- a/src/components/MultiHopTrade/components/TradeConfirm/TradeConfirm.tsx
+++ b/src/components/MultiHopTrade/components/TradeConfirm/TradeConfirm.tsx
@@ -165,9 +165,9 @@ export const TradeConfirm = () => {
   )
 
   const {
+    attemptedSwapCount,
     progressProps: thorStreamingSwapProgressProps,
-    attemptedSwaps,
-    totalSwaps,
+    totalSwapCount,
     failedSwaps,
   } = useThorStreamingProgress(sellTxHash, isThorStreamingSwap)
 
@@ -484,11 +484,9 @@ export const TradeConfirm = () => {
               <Stack px={4}>
                 <Row>
                   <Row.Label>{translate('trade.streamStatus')}</Row.Label>
-                  <Row.Value>
-                    {totalSwaps > 0
-                      ? `${attemptedSwaps} of ${totalSwaps}`
-                      : translate('trade.fetchingStreamingSwapData')}
-                  </Row.Value>
+                  {totalSwapCount > 0 && (
+                    <Row.Value>{`${attemptedSwapCount} of ${totalSwapCount}`}</Row.Value>
+                  )}
                 </Row>
                 <Row>
                   <Progress

--- a/src/components/MultiHopTrade/components/TradeConfirm/TradeConfirm.tsx
+++ b/src/components/MultiHopTrade/components/TradeConfirm/TradeConfirm.tsx
@@ -1,3 +1,4 @@
+import { WarningIcon } from '@chakra-ui/icons'
 import {
   Alert,
   AlertDescription,
@@ -481,20 +482,31 @@ export const TradeConfirm = () => {
             />
             {isThorStreamingSwap && (
               <Stack px={4}>
-                <RawText>
-                  {totalSwaps > 0
-                    ? `Streaming - ${attemptedSwaps} of ${totalSwaps} swaps processed`
-                    : 'Streaming...'}
-                </RawText>
+                <Row>
+                  <Row.Label>{translate('trade.streamStatus')}</Row.Label>
+                  <Row.Value>{`${attemptedSwaps} of ${totalSwaps}`}</Row.Value>
+                </Row>
+                <Row>
+                  <Progress
+                    width='full'
+                    borderRadius='full'
+                    size='sm'
+                    {...thorStreamingSwapProgressProps}
+                  />
+                </Row>
                 {failedSwaps.length > 0 && (
-                  <Alert status='warning' size='sm'>
-                    <AlertIcon />
-                    <AlertDescription>
-                      <RawText>{`${failedSwaps.length} swaps failed - click here for details`}</RawText>
-                    </AlertDescription>
-                  </Alert>
+                  <Row>
+                    <Row.Value display='flex' alignItems='center' gap={1} color='text.warning'>
+                      <WarningIcon />
+                      {translate('trade.swapsFailed', { failedSwaps: failedSwaps.length })}
+                    </Row.Value>
+                    <Row.Value>
+                      <Button variant='link' colorScheme='blue' fontSize='sm'>
+                        {translate('common.learnMore')}
+                      </Button>
+                    </Row.Value>
+                  </Row>
                 )}
-                <Progress {...thorStreamingSwapProgressProps} />
               </Stack>
             )}
             <Stack px={4}>{sendReceiveSummary}</Stack>

--- a/src/components/MultiHopTrade/components/TradeConfirm/TradeConfirm.tsx
+++ b/src/components/MultiHopTrade/components/TradeConfirm/TradeConfirm.tsx
@@ -480,7 +480,7 @@ export const TradeConfirm = () => {
               isSubmitting={isSubmitting}
               px={4}
             />
-            {isThorStreamingSwap && (
+            {status !== TxStatus.Unknown && isThorStreamingSwap && (
               <Stack px={4}>
                 <Row>
                   <Row.Label>{translate('trade.streamStatus')}</Row.Label>

--- a/src/components/MultiHopTrade/hooks/useThorStreamingProgress/types.ts
+++ b/src/components/MultiHopTrade/hooks/useThorStreamingProgress/types.ts
@@ -1,0 +1,19 @@
+export type ThornodeStreamingSwapResponseSuccess = {
+  tx_id?: string
+  interval?: number
+  quantity?: number
+  count?: number
+  last_height?: number
+  trade_target?: string
+  deposit?: string
+  in?: string
+  out?: string
+  failed_swaps?: number[]
+  failed_swap_reasons?: string[]
+}
+
+export type ThornodeStreamingSwapResponseError = { error: string }
+
+export type ThornodeStreamingSwapResponse =
+  | ThornodeStreamingSwapResponseSuccess
+  | ThornodeStreamingSwapResponseError

--- a/src/components/MultiHopTrade/hooks/useThorStreamingProgress/useThorStreamingProgress.tsx
+++ b/src/components/MultiHopTrade/hooks/useThorStreamingProgress/useThorStreamingProgress.tsx
@@ -94,11 +94,16 @@ export const useThorStreamingProgress = (
 
   const { quantity, count } = streamingSwapData
 
+  const isComplete = count === quantity
+
   return {
     progressProps: {
       min: 0,
       max: quantity,
       value: count,
+      hasStripe: true,
+      isAnimated: !isComplete,
+      colorScheme: isComplete ? 'green' : 'blue',
     },
     attemptedSwaps: count ?? 0,
     totalSwaps: quantity ?? 0,

--- a/src/components/MultiHopTrade/hooks/useThorStreamingProgress/useThorStreamingProgress.tsx
+++ b/src/components/MultiHopTrade/hooks/useThorStreamingProgress/useThorStreamingProgress.tsx
@@ -60,12 +60,12 @@ export const useThorStreamingProgress = (
     poll({
       fn: async () => {
         const updatedStreamingSwapData = await getThorchainStreamingSwap(txHash)
-        if (!updatedStreamingSwapData) return
+        if (!updatedStreamingSwapData || !updatedStreamingSwapData.quantity) return
         setStreamingSwapData(updatedStreamingSwapData)
         return updatedStreamingSwapData
       },
       validate: streamingSwapData => {
-        if (!streamingSwapData) return false
+        if (!streamingSwapData || !streamingSwapData.quantity) return false
         return streamingSwapData.count === streamingSwapData.quantity
       },
       interval: POLL_INTERVAL_MILLISECONDS,

--- a/src/components/MultiHopTrade/hooks/useThorStreamingProgress/useThorStreamingProgress.tsx
+++ b/src/components/MultiHopTrade/hooks/useThorStreamingProgress/useThorStreamingProgress.tsx
@@ -37,7 +37,7 @@ type FailedSwap = {
 }
 
 export const useThorStreamingProgress = (
-  _txHash: string | undefined,
+  txHash: string | undefined,
   isThorTrade: boolean,
 ): {
   progressProps: ProgressProps
@@ -49,9 +49,6 @@ export const useThorStreamingProgress = (
     ThornodeStreamingSwapResponse | undefined
   >()
   const { poll } = usePoll<ThornodeStreamingSwapResponse | undefined>()
-
-  // TEMP: monkey patch to preview UI changes
-  const txHash = '0D5F2FBF5C5319CA2A20C801882C58E0055E1383AE4414BBC3B60C87D2BAE578?height=12374271'
 
   useEffect(() => {
     // exit if not a thor trade

--- a/src/components/MultiHopTrade/hooks/useThorStreamingProgress/useThorStreamingProgress.tsx
+++ b/src/components/MultiHopTrade/hooks/useThorStreamingProgress/useThorStreamingProgress.tsx
@@ -1,0 +1,107 @@
+import type { ProgressProps } from '@chakra-ui/progress'
+import axios from 'axios'
+import { getConfig } from 'config'
+import { useEffect, useMemo, useState } from 'react'
+import { usePoll } from 'hooks/usePoll/usePoll'
+const POLL_INTERVAL_MILLISECONDS = 30_000 // 30 seconds
+
+type ThornodeStreamingSwapResponse = {
+  tx_id?: string
+  interval?: number
+  quantity?: number
+  count?: number
+  last_height?: number
+  trade_target?: string
+  deposit?: string
+  in?: string
+  out?: string
+  failed_swaps?: number[]
+  failed_swap_reasons?: string[]
+}
+
+export const getThorchainStreamingSwap = async (
+  sellTxHash: string,
+): Promise<ThornodeStreamingSwapResponse | undefined> => {
+  const { data: streamingSwapData } = await axios.get<ThornodeStreamingSwapResponse>(
+    `${getConfig().REACT_APP_THORCHAIN_NODE_URL}/lcd/thorchain/swap/streaming/${sellTxHash}`,
+  )
+
+  if (!streamingSwapData) return
+
+  return streamingSwapData
+}
+
+type FailedSwap = {
+  reason: string
+  swapIndex: number
+}
+
+export const useThorStreamingProgress = (
+  _txHash: string | undefined,
+  isThorTrade: boolean,
+): {
+  progressProps: ProgressProps
+  attemptedSwaps: number
+  totalSwaps: number
+  failedSwaps: FailedSwap[]
+} => {
+  const [streamingSwapData, setStreamingSwapData] = useState<
+    ThornodeStreamingSwapResponse | undefined
+  >()
+  const { poll } = usePoll<ThornodeStreamingSwapResponse | undefined>()
+
+  // TEMP: monkey patch to preview UI changes
+  const txHash = '0D5F2FBF5C5319CA2A20C801882C58E0055E1383AE4414BBC3B60C87D2BAE578?height=12374271'
+
+  useEffect(() => {
+    // exit if not a thor trade
+    if (!isThorTrade) return
+
+    // don't start polling until we have a tx
+    if (!txHash) return
+
+    poll({
+      fn: async () => {
+        const updatedStreamingSwapData = await getThorchainStreamingSwap(txHash)
+        if (!updatedStreamingSwapData) return
+        setStreamingSwapData(updatedStreamingSwapData)
+        return updatedStreamingSwapData
+      },
+      validate: streamingSwapData => {
+        if (!streamingSwapData) return false
+        return streamingSwapData.count === streamingSwapData.quantity
+      },
+      interval: POLL_INTERVAL_MILLISECONDS,
+      maxAttempts: Infinity,
+    })
+  }, [isThorTrade, poll, txHash])
+
+  const failedSwaps = useMemo(() => {
+    if (!streamingSwapData) return []
+    const { failed_swap_reasons: failedSwapReasons, failed_swaps: failedSwaps } = streamingSwapData
+    return failedSwapReasons?.map((reason, i) => ({ reason, swapIndex: failedSwaps![i] })) ?? []
+  }, [streamingSwapData])
+
+  if (!streamingSwapData)
+    return {
+      progressProps: {
+        isIndeterminate: true,
+      },
+      attemptedSwaps: 0,
+      totalSwaps: 0,
+      failedSwaps,
+    }
+
+  const { quantity, count } = streamingSwapData
+
+  return {
+    progressProps: {
+      min: 0,
+      max: quantity,
+      value: count,
+    },
+    attemptedSwaps: count ?? 0,
+    totalSwaps: quantity ?? 0,
+    failedSwaps,
+  }
+}


### PR DESCRIPTION
## Description

This adds a progress bar to thorchain streaming swaps. 

Includes progress bar and ability to convey the concept of partial fulfilment with reasons for each failure - a value add over viewblock and other interfaces.

## Pull Request Type

- [ ] :bug: Bug fix (Non-breaking Change: Fixes an issue)
- [ ] :hammer_and_wrench: Chore (Non-breaking Change: Doc updates, pkg upgrades, typos, etc..)
- [x] :nail_care: New Feature (Breaking/Non-breaking Change)

## Issue (if applicable)

closes #5191

## Risk

Risk of broken trade confirmation UI

## Testing

* Test streaming swaps and ensure progress bar appears and works as expected
* Test non-streaming swaps and ensure progress bar does not appear

### Engineering

☝️

### Operations

☝️

## Screenshots (if applicable)

Before confirmation
![image](https://github.com/shapeshift/web/assets/125113430/7da582b7-d748-4516-a5c6-7a0e56dc55d3)

On confirmation
![image](https://github.com/shapeshift/web/assets/125113430/6b481793-5f6e-4f81-8f5d-6071fef98d69)

On streaming data loaded
![image](https://github.com/shapeshift/web/assets/125113430/6327ffad-a40b-46c7-bede-6783ec9a2e11)

On send tx confirmed
![image](https://github.com/shapeshift/web/assets/125113430/9b4e3dc2-880d-4c53-b812-7bd769dc1513)

Progress increasing, matches viewblock
![image](https://github.com/shapeshift/web/assets/125113430/79f1df98-1c2b-4e44-b98b-3d065e644ae1)
![image](https://github.com/shapeshift/web/assets/125113430/bb41f4f2-f632-4cfd-a411-7c60808951b9)

Streaming complete
![image](https://github.com/shapeshift/web/assets/125113430/60490893-7380-496c-a596-fb79adea9b26)
