### PR TITLE
feat: make cow swapper wallet agnostic

### DIFF
--- a/src/lib/swapper/swappers/CowSwapper/types.ts
+++ b/src/lib/swapper/swappers/CowSwapper/types.ts
@@ -1,7 +1,4 @@
-import type { ETHSignMessage } from '@shapeshiftoss/hdwallet-core'
 import type { KnownChainIds } from '@shapeshiftoss/types'
-
-import type { CowSwapOrder } from './utils/helpers/helpers'
 
 export type CowSwapQuoteResponse = {
   quote: {
@@ -35,5 +32,3 @@ export type CowSwapGetTradesResponse = {
 export type CowSwapGetTransactionsResponse = {
   status: 'presignaturePending' | 'open' | 'fulfilled' | 'cancelled' | 'expired'
 }[]
-
-export type CowSignTx = { orderToSign: CowSwapOrder; messageToSign: ETHSignMessage }

--- a/src/lib/swapper/swappers/CowSwapper/utils/helpers/helpers.test.ts
+++ b/src/lib/swapper/swappers/CowSwapper/utils/helpers/helpers.test.ts
@@ -1,7 +1,7 @@
 import type { AxiosStatic } from 'axios'
+import type { CowSwapOrder } from 'lib/swapper/types'
 
 import { DEFAULT_APP_DATA } from '../constants'
-import type { CowSwapOrder } from './helpers'
 import { domain, getNowPlusThirtyMinutesTimestamp, hashOrder } from './helpers'
 
 jest.mock('../cowService', () => {

--- a/src/lib/swapper/swappers/CowSwapper/utils/helpers/helpers.ts
+++ b/src/lib/swapper/swappers/CowSwapper/utils/helpers/helpers.ts
@@ -9,7 +9,7 @@ import { ethers } from 'ethers'
 import type { Asset } from 'lib/asset-service'
 import { bnOrZero, convertPrecision } from 'lib/bignumber/bignumber'
 import { fromBaseUnit } from 'lib/math'
-import type { SwapErrorRight } from 'lib/swapper/types'
+import type { CowSwapOrder, SwapErrorRight } from 'lib/swapper/types'
 import { SwapErrorType } from 'lib/swapper/types'
 import { makeSwapErrorRight } from 'lib/swapper/utils'
 
@@ -35,22 +35,6 @@ export const ORDER_TYPE_FIELDS = [
  * EIP-712 typed data type definitions.
  */
 export declare type TypedDataTypes = Record<string, TypedDataField[]>
-
-export type CowSwapOrder = {
-  sellToken: string
-  buyToken: string
-  sellAmount: string
-  buyAmount: string
-  validTo: number
-  appData: string
-  feeAmount: string
-  kind: string
-  partiallyFillable: boolean
-  receiver: string
-  sellTokenBalance: string
-  buyTokenBalance: string
-  quoteId: number
-}
 
 export type CowSwapQuoteApiInputBase = {
   appData: string


### PR DESCRIPTION
## Description

Migrates cow swapper to wallet-agnostic pattern. Since cowswap uses an atypical execution flow with message signing and post to cow api, a separate interface to the common evm was created to prevent casting and generic hell.

Additionally as part of this, message creation for signing was moved into `executeTrade` such that only the cow order needs to be passed around (instead of the order to sign and the arrayified order to sign).

## Pull Request Type

- [ ] :bug: Bug fix (Non-breaking Change: Fixes an issue)
- [ ] :hammer_and_wrench: Chore (Non-breaking Change: Doc updates, pkg upgrades, typos, etc..)
- [x] :nail_care: New Feature (Breaking/Non-breaking Change)

## Issue (if applicable)

progresses #5024 (but doesnt close it)

## Risk

High risk of broken swappers, especially cowswap. Specifically trade execution.

## Testing

* Check all swappers still work
* Check cowswap trades still work

There should be no change from production whatsoever - this is intended to be a completely transparent change.

### Engineering

☝️

### Operations

☝️

## Screenshots (if applicable)

Successful cow trade
![image](https://github.com/shapeshift/web/assets/125113430/6525e68b-f735-456e-85d5-5a5621818c02)
![image](https://github.com/shapeshift/web/assets/125113430/2cde03f9-9c3f-4026-8bde-5d56db24a86b)
![image](https://github.com/shapeshift/web/assets/125113430/4ba8e2e5-766c-4681-b87c-ced7d52f2078)


