### PR TITLE
chore: release v1.422.0

### DIFF
--- a/src/lib/swapper/swappers/ThorchainSwapper/getThorTradeQuote/getTradeQuote.test.ts
+++ b/src/lib/swapper/swappers/ThorchainSwapper/getThorTradeQuote/getTradeQuote.test.ts
@@ -48,18 +48,18 @@ const expectedQuoteResponse: Omit<ThorEvmTradeQuote, 'id'>[] = [
     receiveAddress: '0xc770eefad204b5180df6a14ee197d99d808ee52d',
     affiliateBps: '0',
     isStreaming: false,
-    rate: '144114.94366197183098591549',
+    rate: '137845.94361267605633802817',
     recommendedSlippage: '0.0435',
     data: '0x',
     router: '0x3624525075b88B24ecc29CE226b0CEc1fFcB6976',
     estimatedExecutionTimeMs: 600000,
-    memo: '=:ETH.ETH:0x32DBc9Cf9E8FbCebE1e0a2ecF05Ed86Ca3096Cb6:9786345:ss:0',
+    memo: '=:ETH.ETH:0x32DBc9Cf9E8FbCebE1e0a2ecF05Ed86Ca3096Cb6:9360639:ss:0',
     steps: [
       {
         allowanceContract: '0x3624525075b88B24ecc29CE226b0CEc1fFcB6976',
         sellAmountIncludingProtocolFeesCryptoBaseUnit: '713014679420',
-        buyAmountBeforeFeesCryptoBaseUnit: '114321610000000000',
-        buyAmountAfterFeesCryptoBaseUnit: '102321610000000000',
+        buyAmountBeforeFeesCryptoBaseUnit: '109870619965000000',
+        buyAmountAfterFeesCryptoBaseUnit: '97870619965000000',
         feeData: {
           protocolFees: {
             [ETH.assetId]: {
@@ -70,7 +70,7 @@ const expectedQuoteResponse: Omit<ThorEvmTradeQuote, 'id'>[] = [
           },
           networkFeeCryptoBaseUnit: '400000',
         },
-        rate: '144114.94366197183098591549',
+        rate: '137845.94361267605633802817',
         source: SwapperName.Thorchain,
         buyAsset: ETH,
         sellAsset: FOX_MAINNET,
@@ -82,18 +82,18 @@ const expectedQuoteResponse: Omit<ThorEvmTradeQuote, 'id'>[] = [
     receiveAddress: '0xc770eefad204b5180df6a14ee197d99d808ee52d',
     affiliateBps: '0',
     isStreaming: true,
-    rate: '158199.45070422535211267606',
+    rate: '151555.07377464788732394366',
     recommendedSlippage: '0.042',
     data: '0x',
     router: '0x3624525075b88B24ecc29CE226b0CEc1fFcB6976',
     estimatedExecutionTimeMs: 1600000,
-    memo: '=:ETH.ETH:0x32DBc9Cf9E8FbCebE1e0a2ecF05Ed86Ca3096Cb6:10742775/10/0:ss:0',
+    memo: '=:ETH.ETH:0x32DBc9Cf9E8FbCebE1e0a2ecF05Ed86Ca3096Cb6:10291579/10/0:ss:0',
     steps: [
       {
         allowanceContract: '0x3624525075b88B24ecc29CE226b0CEc1fFcB6976',
         sellAmountIncludingProtocolFeesCryptoBaseUnit: '713014679420',
-        buyAmountBeforeFeesCryptoBaseUnit: '124321610000000000',
-        buyAmountAfterFeesCryptoBaseUnit: '112321610000000000',
+        buyAmountBeforeFeesCryptoBaseUnit: '119604102380000000',
+        buyAmountAfterFeesCryptoBaseUnit: '107604102380000000',
         feeData: {
           protocolFees: {
             [ETH.assetId]: {
@@ -104,7 +104,7 @@ const expectedQuoteResponse: Omit<ThorEvmTradeQuote, 'id'>[] = [
           },
           networkFeeCryptoBaseUnit: '400000',
         },
-        rate: '158199.45070422535211267606',
+        rate: '151555.07377464788732394366',
         source: `${SwapperName.Thorchain} • Streaming`,
         buyAsset: ETH,
         sellAsset: FOX_MAINNET,

--- a/src/lib/swapper/swappers/ThorchainSwapper/utils/addSlippageToMemo.ts
+++ b/src/lib/swapper/swappers/ThorchainSwapper/utils/addSlippageToMemo.ts
@@ -2,7 +2,6 @@ import type { ChainId } from '@shapeshiftoss/caip'
 import { BigNumber } from 'lib/bignumber/bignumber'
 import { subtractBasisPointAmount } from 'state/slices/tradeQuoteSlice/utils'
 
-import type { ThornodeQuoteResponseSuccess } from '../types'
 import {
   DEFAULT_STREAMING_INTERVAL,
   DEFAULT_STREAMING_NUM_SWAPS,
@@ -12,11 +11,8 @@ import {
 import { assertIsValidMemo } from './makeSwapMemo/assertIsValidMemo'
 
 export const addSlippageToMemo = (
-  {
-    memo: quotedMemo,
-    expected_amount_out: expectedAmountOut,
-    expected_amount_out_streaming: expectedAmountOutStreaming,
-  }: ThornodeQuoteResponseSuccess,
+  expectedAmountOutThorBaseUnit: string,
+  quotedMemo: string,
   slippageBps: BigNumber.Value,
   isStreaming: boolean,
   chainId: ChainId,
@@ -25,7 +21,7 @@ export const addSlippageToMemo = (
   const [prefix, pool, address, , affiliate, affiliateBps] = quotedMemo.split(MEMO_PART_DELIMITER)
 
   const limitWithManualSlippage = subtractBasisPointAmount(
-    isStreaming ? expectedAmountOutStreaming : expectedAmountOut,
+    expectedAmountOutThorBaseUnit,
     slippageBps,
     BigNumber.ROUND_DOWN,
   )


### PR DESCRIPTION
fix: expected_amount_out 👏 does not 👏 include slippage (#5195)