### PR TITLE
fix: thorchain streaming swaps quote

### DIFF
--- a/src/lib/swapper/swappers/ThorchainSwapper/getThorTradeQuote/getTradeQuote.test.ts
+++ b/src/lib/swapper/swappers/ThorchainSwapper/getThorTradeQuote/getTradeQuote.test.ts
@@ -139,24 +139,24 @@ describe('getTradeQuote', () => {
           const mockThorQuote: { data: ThornodeQuoteResponseSuccess } = {
             data: {
               expected_amount_out: '10232161',
-              expected_amount_out_streaming: '11232161',
               expiry: '1681132269',
               fees: {
                 affiliate: '0',
                 asset: 'ETH.ETH',
+                liquidity: '533215927',
                 outbound: '1200000',
+                slippage_bps: 435,
+                total: '534055927',
+                total_bps: 348,
               },
               inbound_address: 'bc1qucjrczghvwl5d66klz6npv7tshkpwpzlw0zzj8',
               notes:
                 'First output should be to inbound_address, second output should be change back to self, third output should be OP_RETURN, limited to 80 bytes. Do not send below the dust threshold. Do not use exotic spend scripts, locks or address formats (P2WSH with Bech32 address format preferred).',
               outbound_delay_blocks: 575,
               outbound_delay_seconds: 6900,
-              slippage_bps: 435,
-              streaming_slippage_bps: 420,
               warning: 'Do not cache this response. Do not send funds after the expiry.',
               memo: '=:ETH.ETH:0x32DBc9Cf9E8FbCebE1e0a2ecF05Ed86Ca3096Cb6::ss:0',
               router: '0x3624525075b88B24ecc29CE226b0CEc1fFcB6976',
-              streaming_swap_seconds: 400,
               total_swap_seconds: 1600,
               inbound_confirmation_seconds: 600,
               recommended_min_amount_in: '1',

--- a/src/lib/swapper/swappers/ThorchainSwapper/getThorTradeQuote/getTradeQuote.test.ts
+++ b/src/lib/swapper/swappers/ThorchainSwapper/getThorTradeQuote/getTradeQuote.test.ts
@@ -52,13 +52,13 @@ const expectedQuoteResponse: Omit<ThorEvmTradeQuote, 'id'>[] = [
     recommendedSlippage: '0.0435',
     data: '0x',
     router: '0x3624525075b88B24ecc29CE226b0CEc1fFcB6976',
-    estimatedExecutionTimeMs: 600000,
+    estimatedExecutionTimeMs: 1600000,
     memo: '=:ETH.ETH:0x32DBc9Cf9E8FbCebE1e0a2ecF05Ed86Ca3096Cb6:9360639:ss:0',
     steps: [
       {
         allowanceContract: '0x3624525075b88B24ecc29CE226b0CEc1fFcB6976',
         sellAmountIncludingProtocolFeesCryptoBaseUnit: '713014679420',
-        buyAmountBeforeFeesCryptoBaseUnit: '109870619965000000',
+        buyAmountBeforeFeesCryptoBaseUnit: '114321610000000000',
         buyAmountAfterFeesCryptoBaseUnit: '97870619965000000',
         feeData: {
           protocolFees: {
@@ -92,7 +92,7 @@ const expectedQuoteResponse: Omit<ThorEvmTradeQuote, 'id'>[] = [
       {
         allowanceContract: '0x3624525075b88B24ecc29CE226b0CEc1fFcB6976',
         sellAmountIncludingProtocolFeesCryptoBaseUnit: '713014679420',
-        buyAmountBeforeFeesCryptoBaseUnit: '119604102380000000',
+        buyAmountBeforeFeesCryptoBaseUnit: '124321610000000000',
         buyAmountAfterFeesCryptoBaseUnit: '107604102380000000',
         feeData: {
           protocolFees: {
@@ -134,7 +134,7 @@ describe('getTradeQuote', () => {
               InboundAddressResponse[]
             >),
           )
-        default:
+        default: {
           // '/lcd/thorchain/quote/swap/<swapQueryParams>' fallthrough
           const mockThorQuote: { data: ThornodeQuoteResponseSuccess } = {
             data: {
@@ -157,12 +157,20 @@ describe('getTradeQuote', () => {
               warning: 'Do not cache this response. Do not send funds after the expiry.',
               memo: '=:ETH.ETH:0x32DBc9Cf9E8FbCebE1e0a2ecF05Ed86Ca3096Cb6::ss:0',
               router: '0x3624525075b88B24ecc29CE226b0CEc1fFcB6976',
+              streaming_swap_seconds: 400,
               total_swap_seconds: 1600,
               inbound_confirmation_seconds: 600,
               recommended_min_amount_in: '1',
             },
           }
+
+          if ((url as string).includes('streaming_interval')) {
+            mockThorQuote.data.expected_amount_out = '11232161'
+            mockThorQuote.data.fees.slippage_bps = 420
+          }
+
           return Promise.resolve(Ok(mockThorQuote))
+        }
       }
     })
 

--- a/src/lib/swapper/swappers/ThorchainSwapper/types.ts
+++ b/src/lib/swapper/swappers/ThorchainSwapper/types.ts
@@ -18,28 +18,32 @@ export type ThornodePoolResponse = {
 }
 
 export type ThornodeQuoteResponseSuccess = {
-  recommended_min_amount_in: string | undefined
+  dust_threshold?: string
   expected_amount_out: string
-  expected_amount_out_streaming: string
   expiry: string
   fees: {
     affiliate: string
     asset: string
+    liquidity: string
     outbound: string
+    slippage_bps: number
+    total: string
+    total_bps: number
   }
   inbound_address: string
-  memo: string
+  inbound_confirmation_blocks?: number
+  inbound_confirmation_seconds?: number
+  max_streaming_quantity?: number
+  memo?: string
   notes: string
   outbound_delay_blocks: number
   outbound_delay_seconds: number
-  router: string
-  slippage_bps: number
-  streaming_slippage_bps: number
-  warning: string
-  streaming_swap_seconds: number | undefined
-  inbound_confirmation_seconds: number | undefined
+  recommended_min_amount_in?: string
+  router?: string
+  streaming_swap_blocks?: number
   // total number of seconds a swap is expected to take (inbound conf + streaming swap + outbound delay)
-  total_swap_seconds: number | undefined
+  total_swap_seconds?: number
+  warning: string
 }
 
 type ThornodeQuoteResponseError = { error: string }

--- a/src/lib/swapper/swappers/ThorchainSwapper/types.ts
+++ b/src/lib/swapper/swappers/ThorchainSwapper/types.ts
@@ -41,6 +41,7 @@ export type ThornodeQuoteResponseSuccess = {
   recommended_min_amount_in?: string
   router?: string
   streaming_swap_blocks?: number
+  streaming_swap_seconds?: number
   // total number of seconds a swap is expected to take (inbound conf + streaming swap + outbound delay)
   total_swap_seconds?: number
   warning: string

--- a/src/lib/swapper/swappers/ThorchainSwapper/utils/addSlippageToMemo.ts
+++ b/src/lib/swapper/swappers/ThorchainSwapper/utils/addSlippageToMemo.ts
@@ -12,7 +12,7 @@ import { assertIsValidMemo } from './makeSwapMemo/assertIsValidMemo'
 
 export const addSlippageToMemo = (
   expectedAmountOutThorBaseUnit: string,
-  quotedMemo = '',
+  quotedMemo: string | undefined,
   slippageBps: BigNumber.Value,
   isStreaming: boolean,
   chainId: ChainId,

--- a/src/lib/swapper/swappers/ThorchainSwapper/utils/addSlippageToMemo.ts
+++ b/src/lib/swapper/swappers/ThorchainSwapper/utils/addSlippageToMemo.ts
@@ -12,11 +12,13 @@ import { assertIsValidMemo } from './makeSwapMemo/assertIsValidMemo'
 
 export const addSlippageToMemo = (
   expectedAmountOutThorBaseUnit: string,
-  quotedMemo: string,
+  quotedMemo = '',
   slippageBps: BigNumber.Value,
   isStreaming: boolean,
   chainId: ChainId,
 ) => {
+  if (!quotedMemo) throw new Error('no memo provided')
+
   // the missing element is the original limit with (optional, missing) streaming parameters
   const [prefix, pool, address, , affiliate, affiliateBps] = quotedMemo.split(MEMO_PART_DELIMITER)
 

--- a/src/lib/swapper/swappers/ThorchainSwapper/utils/getQuote/getQuote.ts
+++ b/src/lib/swapper/swappers/ThorchainSwapper/utils/getQuote/getQuote.ts
@@ -28,6 +28,7 @@ export const getQuote = async ({
   buyAssetId,
   sellAmountCryptoBaseUnit,
   receiveAddress,
+  streaming,
   affiliateBps = '0',
 }: {
   sellAsset: Asset
@@ -35,6 +36,7 @@ export const getQuote = async ({
   sellAmountCryptoBaseUnit: string
   // Receive address is optional for THOR quotes, and will be in case we are getting a quote with a missing manual receive address
   receiveAddress: string | undefined
+  streaming: boolean
   affiliateBps: string
 }): Promise<Result<ThornodeQuoteResponseSuccess, SwapErrorRight>> => {
   const buyPoolId = assetIdToPoolAssetId({ assetId: buyAssetId })
@@ -62,7 +64,7 @@ export const getQuote = async ({
     destination: parsedReceiveAddress,
     affiliate_bps: affiliateBps,
     affiliate: THORCHAIN_AFFILIATE_NAME,
-    streaming_interval: DEFAULT_STREAMING_INTERVAL,
+    ...(streaming && { streaming_interval: DEFAULT_STREAMING_INTERVAL }),
   })
   const daemonUrl = getConfig().REACT_APP_THORCHAIN_NODE_URL
   const maybeData = (


### PR DESCRIPTION
## Description

The recent thorchain upgrade introduced breaking changes to the api resulting in the inability to get both a swap and streaming swap quote in the same quote. We will now fetch two quote, one regular swap quote and one streaming swap quote to fix the missing streaming swaps currently

## Pull Request Type

- [x] :bug: Bug fix (Non-breaking Change: Fixes an issue)
- [ ] :hammer_and_wrench: Chore (Non-breaking Change: Doc updates, pkg upgrades, typos, etc..)
- [ ] :nail_care: New Feature (Breaking/Non-breaking Change)

## Issue (if applicable)

<!-----------------------------------------------------------------------------
If applicable, please link to the github issue and put `closes #XXXX` in your comment to auto-close the issue that your PR fixes.
------------------------------------------------------------------------------>

closes #

## Risk

- Low: swaps should work as they were before the thorchain upgrade

## Testing

- Ensure streaming swap quotes are displaying
- Spot check accurate display of amount/fees in the modal

### Engineering

:point_up:

### Operations

:point_up:

## Screenshots (if applicable)

![image](https://github.com/shapeshift/web/assets/35275952/3c89898a-c4a9-4adc-a484-653f3240ff59)
