### PR TITLE
fix: disable unused languages

### DIFF
--- a/src/Routes/Routes.tsx
+++ b/src/Routes/Routes.tsx
@@ -34,6 +34,9 @@ export const Routes = memo(() => {
   useEffect(() => {
     if (lang && LanguageTypeEnum[lang as LanguageTypeEnum] && selectedLocale !== lang) {
       dispatch(preferences.actions.setSelectedLocale({ locale: lang }))
+    } else if (!LanguageTypeEnum[selectedLocale as LanguageTypeEnum]) {
+      // Set default language if locale in settings is not supported
+      dispatch(preferences.actions.setSelectedLocale({ locale: 'en' }))
     }
   }, [lang, dispatch, selectedLocale])
 

--- a/src/Routes/Routes.tsx
+++ b/src/Routes/Routes.tsx
@@ -32,9 +32,10 @@ export const Routes = memo(() => {
   })
 
   useEffect(() => {
-    if (lang && LanguageTypeEnum[lang as LanguageTypeEnum] && selectedLocale !== lang) {
+    const selectedLocalteExists = selectedLocale in LanguageTypeEnum ?? {}
+    if (lang && selectedLocalteExists && selectedLocale !== lang) {
       dispatch(preferences.actions.setSelectedLocale({ locale: lang }))
-    } else if (!LanguageTypeEnum[selectedLocale as LanguageTypeEnum]) {
+    } else if (!selectedLocalteExists) {
       // Set default language if locale in settings is not supported
       dispatch(preferences.actions.setSelectedLocale({ locale: 'en' }))
     }

--- a/src/assets/translations/index.ts
+++ b/src/assets/translations/index.ts
@@ -3,12 +3,12 @@ import en from './en/main.json'
 import es from './es/main.json'
 import de from './de/main.json'
 import fr from './fr/main.json'
-import id from './id/main.json'
-import ko from './ko/main.json'
+// import id from './id/main.json'
+// import ko from './ko/main.json'
 import pt from './pt/main.json'
 import ru from './ru/main.json'
 import tr from './tr/main.json'
 import uk from './uk/main.json'
 import zh from './zh/main.json'
 
-export const translations: any = { en, es, de, fr, id, ko, pt, ru, tr, uk, zh }
+export const translations: any = { en, es, de, fr, pt, ru, tr, uk, zh }

--- a/src/constants/LanguageTypeEnum.ts
+++ b/src/constants/LanguageTypeEnum.ts
@@ -6,9 +6,9 @@ export enum LanguageTypeEnum {
   /** українська */
   uk = 'uk',
   /** हिंदी */
-  hi = 'hi',
+  // hi = 'hi',
   /** 日本語 */
-  jp = 'jp',
+  // jp = 'jp',
   /** Deutsch */
   de = 'de',
   /** русский */
@@ -20,13 +20,13 @@ export enum LanguageTypeEnum {
   /** Français */
   fr = 'fr',
   /** 한국어 */
-  ko = 'ko',
+  // ko = 'ko',
   /** Türkçe */
   tr = 'tr',
   /** Bahasa Indonesia */
-  id = 'id',
+  // id = 'id',
   /** Tiếng Việt */
-  vi = 'vi',
+  // vi = 'vi',
   /** Italiano */
-  it = 'it',
+  // it = 'it',
 }


### PR DESCRIPTION
## Description

I've noticed that we are actually serving incomplete translations for languages that aren't actively maintained (e.g. `id`/Indonesian and `ko`/Korean). I always assumed those were loaded but unused, but after testing as a new user with their browser default language as one of these I am being served incomplete translations (and a lot of untranslated English strings). We also currently display an empty option in the Settings as seen here: 

![image](https://github.com/shapeshift/web/assets/88804546/20d41cfe-71d1-4397-adad-7ee333f3fe6b)

This PR:
- Disables the unused languages until they are (maybe in the future) actively maintained, it also avoids loading these unmaintained language files.
- Corrects the disabled/unused locales in user Settings to the default `en` locale (for users who had one set prior to this fix).
- Will help us track the language used in Mixpanel more accurately, as these unmaintained languages shouldn't be reported as used by our users (a lot of strings are missing and present English to them actually).

<!-- Please describe your changes -->

## Pull Request Type

- [x] :bug: Bug fix (Non-breaking Change: Fixes an issue)
- [ ] :hammer_and_wrench: Chore (Non-breaking Change: Doc updates, pkg upgrades, typos, etc..)
- [ ] :nail_care: New Feature (Breaking/Non-breaking Change)

## Issue (if applicable)

<!-----------------------------------------------------------------------------
If applicable, please link to the github issue and put `closes #XXXX` in your comment to auto-close the issue that your PR fixes.
------------------------------------------------------------------------------>

N/A

## Risk

<!-----------------------------------------------------------------------------
Outline the scope of your changes and the risk associated with them. You must use your discretion as an engineer to determine the potential impact of your changes.

E.g. an upgrade to `hdwallet` or core state management would be considered higher risk, and might require a full regression test. UI or isolated view changes, or something behind a feature flag may have near zero risk. Small bug fixes might require testing isolated to the specific fix.
------------------------------------------------------------------------------>

## Testing

<!-----------------------------------------------------------------------------
We treat every PR to be merged with the same scrutiny as if we were merging directly to production.

Your PR will not be merged if you do not complete the sections below for our engineering and operations teams to test.
------------------------------------------------------------------------------>

### Engineering

Check that a user who previously had `ko` and `id` (or any non-supported language) set in their Settings get their language changed/forced to English. It is a bit trickier to test as the setting is currently set programmatically, not in the UI, in previous versions.
You can test this by starting a previous session with the app without this fix using `ko` (for example) as the highest priority language in the Browser, then close the tab, then load the fix and load the app again in a new tab, if you check the IndexDB `keyvaluepairs` the `persist:preferences` pair should have in its values `selectedLocale` set as `ko` before the fix, and first load with the fix it gets updated to `en`. This does NOT get forced for supported/enabled languages (so users preserve their current valid settings).

<!-----------------------------------------------------------------------------
Include sufficient information here for an engineer to test your PR. This may include how to test locally, in a built environment, changes to infrastructure etc.
------------------------------------------------------------------------------>

### Operations

Check that the default language based on browser settings is still applied correctly, for `ko` and `id` it should default to English now, and there should not be an empty option in the Settings modal.

<!-----------------------------------------------------------------------------
If your changes have a user-facing impact, describe how a non-technical QA team can functionally test your changes in a preview environment.

If they are not user-facing please describe how to test for any regressions that may occur.
------------------------------------------------------------------------------>

## Screenshots (if applicable)
