### PR TITLE
fix: yarn dev log spew

### DIFF
--- a/package.json
+++ b/package.json
@@ -287,7 +287,8 @@
   "resolutions": {
     "@bithighlander/bitcoin-cash-js-lib@^5.2.1": "patch:@bithighlander/bitcoin-cash-js-lib@npm%3A5.2.1#./.yarn/patches/@bithighlander-bitcoin-cash-js-lib-npm-5.2.1-92e8f8436e.patch",
     "friendly-challenge@0.9.2": "patch:friendly-challenge@npm%3A0.9.2#./.yarn/patches/friendly-challenge-npm-0.9.2-db0cad46d3.patch",
-    "react-dom@^18.2.0": "patch:react-dom@npm%3A18.2.0#./.yarn/patches/react-dom-npm-18.2.0-dd675bca1c.patch"
+    "react-dom@^18.2.0": "patch:react-dom@npm%3A18.2.0#./.yarn/patches/react-dom-npm-18.2.0-dd675bca1c.patch",
+    "react-dev-utils/fork-ts-checker-webpack-plugin": "^6.5.3"
   },
   "jest": {
     "preset": "ts-jest",

--- a/yarn.lock
+++ b/yarn.lock
@@ -17717,9 +17717,9 @@ __metadata:
   languageName: node
   linkType: hard
 
-"fork-ts-checker-webpack-plugin@npm:^6.5.0":
-  version: 6.5.0
-  resolution: "fork-ts-checker-webpack-plugin@npm:6.5.0"
+"fork-ts-checker-webpack-plugin@npm:^6.5.3":
+  version: 6.5.3
+  resolution: "fork-ts-checker-webpack-plugin@npm:6.5.3"
   dependencies:
     "@babel/code-frame": ^7.8.3
     "@types/json-schema": ^7.0.5
@@ -17744,7 +17744,7 @@ __metadata:
       optional: true
     vue-template-compiler:
       optional: true
-  checksum: 95d145ab7936445f3a9bfa4116ef73537f97196cfaa3f5b24473dff36d034e839d3b0e034a23beefc9619eceb7a9866816bfd55afd1968e955eb3b3f8cfc35ed
+  checksum: 9732a49bfeed8fc23e6e8a59795fa7c238edeba91040a9b520db54b4d316dda27f9f1893d360e296fd0ad8930627d364417d28a8c7007fba60cc730ebfce4956
   languageName: node
   linkType: hard
 


### PR DESCRIPTION
## Description

Fixes log spew when running `yarn dev`, which started when we updated to TS5.

Achieves this by overriding the `react-dev-utils/fork-ts-checker-webpack-plugin` resolution, setting it to a minimum of `6.5.3`.

See https://github.com/TypeStrong/fork-ts-checker-webpack-plugin/releases/tag/v6.5.3.

## Pull Request Type

- [ ] :bug: Bug fix (Non-breaking Change: Fixes an issue)
- [x] :hammer_and_wrench: Chore (Non-breaking Change: Doc updates, pkg upgrades, typos, etc..)
- [ ] :nail_care: New Feature (Breaking/Non-breaking Change)

## Issue (if applicable)

N/A

## Risk

Small, no runtime changes.

## Testing

N/A

### Engineering

Running `yarn dev` should no longer spam the console with errors relating to `TypeError: Cannot set property mark of #<Object> which has only a getter`.

### Operations

Nothing to test.

## Screenshots (if applicable)

This is gone:

<img width="562" alt="Screenshot 2023-09-05 at 10 52 52 am" src="https://github.com/shapeshift/web/assets/97164662/8a607272-105b-4e04-b8ae-a185c34697ee">
