### PR TITLE
fix: use the outbound fee of the sell asset pool to decide whether to include affiliate fee

### DIFF
--- a/src/lib/swapper/swappers/ThorchainSwapper/constants.ts
+++ b/src/lib/swapper/swappers/ThorchainSwapper/constants.ts
@@ -1,10 +1,7 @@
 import { KnownChainIds } from '@shapeshiftoss/types'
-import { bn } from 'lib/bignumber/bignumber'
 import type { ThorChainId } from 'lib/swapper/swappers/ThorchainSwapper/types'
 import type { SwapSource } from 'lib/swapper/types'
 import { SwapperName } from 'lib/swapper/types'
-// TODO: read from https://daemon.thorchain.shapeshift.com/lcd/thorchain/constants
-export const RUNE_OUTBOUND_TRANSACTION_FEE_CRYPTO_HUMAN = bn('0.02')
 
 export const sellSupportedChainIds: Record<ThorChainId, boolean> = {
   [KnownChainIds.EthereumMainnet]: true,
@@ -32,4 +29,5 @@ export const THORCHAIN_STREAM_SWAP_SOURCE: SwapSource = `${SwapperName.Thorchain
 
 // https://dev.thorchain.org/thorchain-dev/interface-guide/fees#thorchain-native-rune
 // static automatic outbound fee as defined by: https://thornode.ninerealms.com/thorchain/constants
-export const THORCHAIN_OUTBOUND_FEE_RUNE = '2000000'
+// expressed in thor units (8 decimals of precision)
+export const THORCHAIN_OUTBOUND_FEE_RUNE_THOR_UNIT = '2000000'

--- a/src/lib/swapper/swappers/ThorchainSwapper/endpoints.ts
+++ b/src/lib/swapper/swappers/ThorchainSwapper/endpoints.ts
@@ -23,7 +23,7 @@ import type {
 import { assertGetUtxoChainAdapter } from 'lib/utils/utxo'
 
 import { isNativeEvmAsset } from '../utils/helpers/helpers'
-import { THORCHAIN_OUTBOUND_FEE_RUNE } from './constants'
+import { THORCHAIN_OUTBOUND_FEE_RUNE_THOR_UNIT } from './constants'
 import type { ThorEvmTradeQuote } from './getThorTradeQuote/getTradeQuote'
 import { getThorTradeQuote } from './getThorTradeQuote/getTradeQuote'
 import { getTradeTxs } from './getTradeTxs/getTradeTxs'
@@ -33,7 +33,7 @@ import { getInboundAddressDataForChain } from './utils/getInboundAddressDataForC
 const deductOutboundRuneFee = (fee: string): string => {
   // 0.02 RUNE is automatically charged on outbound transactions
   // the returned is the difference of any additional fee over the default 0.02 RUNE (ie. tx.fee >= 2000001)
-  const feeMinusAutomaticOutboundFee = bnOrZero(fee).minus(THORCHAIN_OUTBOUND_FEE_RUNE)
+  const feeMinusAutomaticOutboundFee = bnOrZero(fee).minus(THORCHAIN_OUTBOUND_FEE_RUNE_THOR_UNIT)
   return feeMinusAutomaticOutboundFee.gt(0) ? feeMinusAutomaticOutboundFee.toString() : '0'
 }
 

--- a/src/lib/swapper/swappers/ThorchainSwapper/types.ts
+++ b/src/lib/swapper/swappers/ThorchainSwapper/types.ts
@@ -1,5 +1,27 @@
 import type { KnownChainIds } from '@shapeshiftoss/types'
 
+export type MidgardPoolResponse = {
+  annualPercentageRate: string
+  asset: string
+  assetDepth: string
+  assetPrice: string
+  assetPriceUSD: string
+  liquidityUnits: string
+  nativeDecimal: string
+  poolAPY: string
+  runeDepth: string
+  saversAPR: string
+  saversDepth: string
+  saversUnits: string
+  status: string
+  synthSupply: string
+  synthUnits: string
+  totalCollateral: string
+  totalDebtTor: string
+  units: string
+  volume24h: string
+}
+
 export type ThornodePoolResponse = {
   LP_units: string
   asset: string

--- a/src/lib/swapper/swappers/ThorchainSwapper/utils/getQuote/getQuote.ts
+++ b/src/lib/swapper/swappers/ThorchainSwapper/utils/getQuote/getQuote.ts
@@ -5,7 +5,7 @@ import { Err, Ok } from '@sniptt/monads'
 import { getConfig } from 'config'
 import qs from 'qs'
 import type { Asset } from 'lib/asset-service'
-import { baseUnitToPrecision, bn, bnOrZero } from 'lib/bignumber/bignumber'
+import { baseUnitToPrecision, bn } from 'lib/bignumber/bignumber'
 import { toBaseUnit } from 'lib/math'
 import type {
   ThornodeQuoteResponse,
@@ -21,6 +21,7 @@ import type { SwapErrorRight } from 'lib/swapper/types'
 import { SwapErrorType } from 'lib/swapper/types'
 import { createTradeAmountTooSmallErr, makeSwapErrorRight } from 'lib/swapper/utils'
 
+import { getThresholdedAffiliateBps } from '../getThresholdedAffiliateBps/getThresholdedAffiliateBps'
 import { thorService } from '../thorService'
 
 type GetQuoteArgs = {
@@ -107,22 +108,14 @@ const _getQuote = async ({
 export const getQuote = async (
   input: GetQuoteArgs,
 ): Promise<Result<ThornodeQuoteResponseSuccess, SwapErrorRight>> => {
-  const initialQuoteResult = await _getQuote(input)
+  const { sellAsset, sellAmountCryptoBaseUnit, affiliateBps } = input
 
-  if (initialQuoteResult.isErr()) return initialQuoteResult
+  // don't apply an affiliate fee if it's below the outbound fee for the inbound pool
+  const thresholdedAffiliateBps = await getThresholdedAffiliateBps({
+    sellAsset,
+    sellAmountCryptoBaseUnit,
+    affiliateBps,
+  })
 
-  const initialQuote = initialQuoteResult.unwrap()
-
-  // add a buffer to the outbound fee to account for market shifts between quote and execution
-  const affiliateFeeThreshold = bnOrZero(initialQuote.fees.outbound).times(1.2)
-
-  // refetch quote without affiliate fee if it's less than the thorchain outbound fee
-  if (
-    bnOrZero(input.affiliateBps).gt(0) &&
-    bnOrZero(initialQuote.fees.affiliate).lte(affiliateFeeThreshold)
-  ) {
-    return _getQuote({ ...input, affiliateBps: '0' })
-  }
-
-  return Ok(initialQuote)
+  return _getQuote({ ...input, affiliateBps: thresholdedAffiliateBps })
 }

--- a/src/lib/swapper/swappers/ThorchainSwapper/utils/getQuote/getQuote.ts
+++ b/src/lib/swapper/swappers/ThorchainSwapper/utils/getQuote/getQuote.ts
@@ -113,10 +113,13 @@ export const getQuote = async (
 
   const initialQuote = initialQuoteResult.unwrap()
 
+  // add a buffer to the outbound fee to account for market shifts between quote and execution
+  const affiliateFeeThreshold = bnOrZero(initialQuote.fees.outbound).times(1.2)
+
   // refetch quote without affiliate fee if it's less than the thorchain outbound fee
   if (
     bnOrZero(input.affiliateBps).gt(0) &&
-    bnOrZero(initialQuote.fees.affiliate).lte(initialQuote.fees.outbound)
+    bnOrZero(initialQuote.fees.affiliate).lte(affiliateFeeThreshold)
   ) {
     return _getQuote({ ...input, affiliateBps: '0' })
   }

--- a/src/lib/swapper/swappers/ThorchainSwapper/utils/getThresholdedAffiliateBps/getThresholdedAffiliateBps.test.ts
+++ b/src/lib/swapper/swappers/ThorchainSwapper/utils/getThresholdedAffiliateBps/getThresholdedAffiliateBps.test.ts
@@ -1,0 +1,116 @@
+import { Ok } from '@sniptt/monads'
+import type { AxiosResponse, AxiosStatic } from 'axios'
+import { bn } from 'lib/bignumber/bignumber'
+import { ETH } from 'lib/swapper/swappers/utils/test-data/assets'
+
+import { THORCHAIN_OUTBOUND_FEE_RUNE_THOR_UNIT } from '../../constants'
+import type { MidgardPoolResponse } from '../../types'
+import { thorService } from '../thorService'
+import {
+  getExpectedAffiliateFeeSellAssetThorUnit,
+  getOutboundFeeInSellAssetThorBaseUnit,
+  getThresholdedAffiliateBps,
+} from './getThresholdedAffiliateBps'
+
+jest.mock('../thorService', () => {
+  const axios: AxiosStatic = jest.createMockFromModule('axios')
+  axios.create = jest.fn(() => axios)
+
+  return {
+    thorService: axios.create(),
+  }
+})
+
+describe('getOutboundFeeInSellAssetThorBaseUnit', () => {
+  it('should return 0.2 rune denominated in the target asset, in thor units', () => {
+    const assetPricePrecision = '4.00000' // 1 token is 4x as valuable as 1 rune
+    expect(getOutboundFeeInSellAssetThorBaseUnit(assetPricePrecision).toNumber()).toEqual(
+      Number(THORCHAIN_OUTBOUND_FEE_RUNE_THOR_UNIT) / 4,
+    )
+  })
+})
+
+describe('getExpectedAffiliateFeeSellAssetThorUnit', () => {
+  it('should return the correct affiliate fee in thor base units', () => {
+    const sellAmountCryptoBaseUnit = '1000000000000000000' // 1 eth
+    const affiliateBps = '35'
+    const sellAsset = ETH
+
+    const result = getExpectedAffiliateFeeSellAssetThorUnit(
+      sellAmountCryptoBaseUnit,
+      sellAsset,
+      affiliateBps,
+    )
+
+    const expectation = bn('100000000').times(0.0035).toFixed(0)
+
+    expect(result.toFixed(0)).toEqual(expectation)
+  })
+
+  it('returns 0 when affiliateBps is 0', () => {
+    const sellAmountCryptoBaseUnit = '1000000000000000000' // 1 eth
+    const affiliateBps = '0'
+    const sellAsset = ETH
+
+    const result = getExpectedAffiliateFeeSellAssetThorUnit(
+      sellAmountCryptoBaseUnit,
+      sellAsset,
+      affiliateBps,
+    )
+
+    const expectation = '0'
+
+    expect(result.toFixed(0)).toEqual(expectation)
+  })
+})
+
+describe('getThresholdedAffiliateBps', () => {
+  ;(thorService.get as unknown as jest.Mock<unknown>).mockImplementation(() => {
+    return Promise.resolve(
+      Ok({
+        data: {
+          assetPrice: '100', // 1 eth = 100 rune
+        },
+      } as unknown as AxiosResponse<MidgardPoolResponse>),
+    )
+  })
+
+  // outbound fee threshold is 0.02 rune.
+  // assuming eth price at 100 rune:
+  // 0.02 rune = 0.02 / 100 = 0.0002 eth
+
+  // give an affiliate bps of 50 (0.5%):
+  // min input amount = threshold eth / affiliate percentage = 0.0002 eth / 0.5% = 0.04 eth
+
+  it('should return 0 when the sell amount is less than or equal to the rune outbound fee', async () => {
+    const sellAmountCryptoBaseUnit = '40000000000000000' // 0.04 eth
+    const affiliateBps = '50' // 0.5%
+    const sellAsset = ETH
+
+    const result = await getThresholdedAffiliateBps({
+      sellAsset,
+      affiliateBps,
+      sellAmountCryptoBaseUnit,
+    })
+
+    const expectation = '0'
+
+    expect(result).toEqual(expectation)
+  })
+
+  it('should return input affiliate bps when the sell amount is greater than the rune outbound fee', async () => {
+    const sellAmountCryptoBaseUnit = '40000000000000001' // > 0.04 eth
+    const affiliateBps = '50' // 0.5%
+    const sellAsset = ETH
+
+    const result = await getThresholdedAffiliateBps({
+      sellAsset,
+      affiliateBps,
+      sellAmountCryptoBaseUnit,
+    })
+
+    const expectation = affiliateBps
+
+    expect(result).toEqual(expectation)
+  })
+})

--- a/src/lib/swapper/swappers/ThorchainSwapper/utils/getThresholdedAffiliateBps/getThresholdedAffiliateBps.test.ts
+++ b/src/lib/swapper/swappers/ThorchainSwapper/utils/getThresholdedAffiliateBps/getThresholdedAffiliateBps.test.ts
@@ -22,10 +22,10 @@ jest.mock('../thorService', () => {
 })
 
 describe('getOutboundFeeInSellAssetThorBaseUnit', () => {
-  it('should return 0.2 rune denominated in the target asset, in thor units', () => {
+  it('should return 0.02 rune denominated in the target asset, in thor units', () => {
     const assetPricePrecision = '4.00000' // 1 token is 4x as valuable as 1 rune
     expect(getOutboundFeeInSellAssetThorBaseUnit(assetPricePrecision).toNumber()).toEqual(
-      Number(THORCHAIN_OUTBOUND_FEE_RUNE_THOR_UNIT) / 4,
+      Number(THORCHAIN_OUTBOUND_FEE_RUNE_THOR_UNIT) / 4, // .005 of the sell asset in THOR base unit
     )
   })
 })
@@ -42,7 +42,7 @@ describe('getExpectedAffiliateFeeSellAssetThorUnit', () => {
       affiliateBps,
     )
 
-    const expectation = bn('100000000').times(0.0035).toFixed(0)
+    const expectation = bn('100000000').times('0.0035').toFixed(0)
 
     expect(result.toFixed(0)).toEqual(expectation)
   })

--- a/src/lib/swapper/swappers/ThorchainSwapper/utils/getThresholdedAffiliateBps/getThresholdedAffiliateBps.ts
+++ b/src/lib/swapper/swappers/ThorchainSwapper/utils/getThresholdedAffiliateBps/getThresholdedAffiliateBps.ts
@@ -10,8 +10,8 @@ import { isRune } from '../isRune/isRune'
 import { assetIdToPoolAssetId } from '../poolAssetHelpers/poolAssetHelpers'
 import { thorService } from '../thorService'
 
-export const getOutboundFeeInSellAssetThorBaseUnit = (assetPricePrecision: string) => {
-  return bn(THORCHAIN_OUTBOUND_FEE_RUNE_THOR_UNIT).dividedBy(assetPricePrecision)
+export const getOutboundFeeInSellAssetThorBaseUnit = (runePerAsset: string) => {
+  return bn(THORCHAIN_OUTBOUND_FEE_RUNE_THOR_UNIT).dividedBy(runePerAsset)
 }
 
 export const getExpectedAffiliateFeeSellAssetThorUnit = (

--- a/src/lib/swapper/swappers/ThorchainSwapper/utils/getThresholdedAffiliateBps/getThresholdedAffiliateBps.ts
+++ b/src/lib/swapper/swappers/ThorchainSwapper/utils/getThresholdedAffiliateBps/getThresholdedAffiliateBps.ts
@@ -1,0 +1,67 @@
+import { getConfig } from 'config'
+import type { Asset } from 'lib/asset-service'
+import { bn, convertPrecision } from 'lib/bignumber/bignumber'
+import { convertBasisPointsToDecimalPercentage } from 'state/slices/tradeQuoteSlice/utils'
+
+import { THORCHAIN_OUTBOUND_FEE_RUNE_THOR_UNIT } from '../../constants'
+import type { MidgardPoolResponse } from '../../types'
+import { THORCHAIN_FIXED_PRECISION } from '../constants'
+import { assetIdToPoolAssetId } from '../poolAssetHelpers/poolAssetHelpers'
+import { thorService } from '../thorService'
+
+export const getOutboundFeeInSellAssetThorBaseUnit = (assetPricePrecision: string) => {
+  return bn(THORCHAIN_OUTBOUND_FEE_RUNE_THOR_UNIT).dividedBy(assetPricePrecision)
+}
+
+export const getExpectedAffiliateFeeSellAssetThorUnit = (
+  sellAmountCryptoBaseUnit: string,
+  sellAsset: Asset,
+  affiliateBps: string,
+) => {
+  const sellAmountThorUnit = convertPrecision({
+    value: sellAmountCryptoBaseUnit,
+    inputExponent: sellAsset.precision,
+    outputExponent: THORCHAIN_FIXED_PRECISION,
+  })
+
+  const affiliatePercent = convertBasisPointsToDecimalPercentage(affiliateBps)
+
+  return sellAmountThorUnit.times(affiliatePercent)
+}
+
+// don't apply an affiliate fee if it's below the outbound fee for the inbound pool
+export const getThresholdedAffiliateBps = async ({
+  sellAsset,
+  affiliateBps,
+  sellAmountCryptoBaseUnit,
+}: {
+  sellAsset: Asset
+  affiliateBps: string
+  sellAmountCryptoBaseUnit: string
+}) => {
+  const midgardUrl = getConfig().REACT_APP_MIDGARD_URL
+  const sellPoolId = assetIdToPoolAssetId({ assetId: sellAsset.assetId })
+
+  // get pool data for the sell asset
+  const poolResult = await thorService.get<MidgardPoolResponse>(
+    `${midgardUrl}/v2/pool/${sellPoolId}`,
+  )
+  if (poolResult.isErr()) throw poolResult.unwrapErr()
+  const pool = poolResult.unwrap().data
+
+  // calculate the rune outbound fee denominated in the sell asset, in thor units
+  const outboundFeeSellAssetThorUnit = getOutboundFeeInSellAssetThorBaseUnit(pool.assetPrice)
+
+  // calculate the expected affiliate fee, in thor units
+  const expectedAffiliateFeeSellAssetThorUnit = getExpectedAffiliateFeeSellAssetThorUnit(
+    sellAmountCryptoBaseUnit,
+    sellAsset,
+    affiliateBps,
+  )
+
+  const isAffiliateFeeBelowOutboundFee = expectedAffiliateFeeSellAssetThorUnit.lte(
+    outboundFeeSellAssetThorUnit,
+  )
+
+  return isAffiliateFeeBelowOutboundFee ? '0' : affiliateBps
+}

--- a/src/lib/swapper/swappers/ThorchainSwapper/utils/getThresholdedAffiliateBps/getThresholdedAffiliateBps.ts
+++ b/src/lib/swapper/swappers/ThorchainSwapper/utils/getThresholdedAffiliateBps/getThresholdedAffiliateBps.ts
@@ -43,9 +43,7 @@ export const getThresholdedAffiliateBps = async ({
   const sellPoolId = assetIdToPoolAssetId({ assetId: sellAsset.assetId })
 
   // get pool data for the sell asset
-  const poolResult = await thorService.get<MidgardPoolResponse>(
-    `${midgardUrl}/v2/pool/${sellPoolId}`,
-  )
+  const poolResult = await thorService.get<MidgardPoolResponse>(`${midgardUrl}/pool/${sellPoolId}`)
   if (poolResult.isErr()) throw poolResult.unwrapErr()
   const pool = poolResult.unwrap().data
 

--- a/src/lib/swapper/swappers/ThorchainSwapper/utils/thorService.ts
+++ b/src/lib/swapper/swappers/ThorchainSwapper/utils/thorService.ts
@@ -8,8 +8,8 @@ const cachedUrls = [
   '/lcd/thorchain/pools',
   '/lcd/thorchain/inbound_addresses',
   '/lcd/thorchain/pool/',
-  '/v2/pools',
-  '/v2/pool/',
+  '/pools',
+  '/pool/',
 ]
 const cache = createCache(maxAge, cachedUrls)
 

--- a/src/lib/swapper/swappers/ThorchainSwapper/utils/thorService.ts
+++ b/src/lib/swapper/swappers/ThorchainSwapper/utils/thorService.ts
@@ -8,8 +8,8 @@ const cachedUrls = [
   '/lcd/thorchain/pools',
   '/lcd/thorchain/inbound_addresses',
   '/lcd/thorchain/pool/',
-  '/pools',
-  '/pool/',
+  '/v2/pools',
+  '/v2/pool/',
 ]
 const cache = createCache(maxAge, cachedUrls)
 

--- a/src/lib/swapper/swappers/ThorchainSwapper/utils/thorService.ts
+++ b/src/lib/swapper/swappers/ThorchainSwapper/utils/thorService.ts
@@ -8,6 +8,8 @@ const cachedUrls = [
   '/lcd/thorchain/pools',
   '/lcd/thorchain/inbound_addresses',
   '/lcd/thorchain/pool/',
+  '/v2/pools',
+  '/v2/pool/',
 ]
 const cache = createCache(maxAge, cachedUrls)
 


### PR DESCRIPTION
## Description

Thorchain swapper - Updates affiliate fee logic to check the outbound fee of the inbound pool rather than the outbound pool. Since affiliate fees are sent to us from the inbound pool in RUNE, we need to compare the potential affiliate fee of the RUNE outbound fee denominated in the sell asset, in thor precision.

The approach used here is to pull the sell asset pool information and do the calculations before getting the quote.

Unit tests included.

## Pull Request Type

- [x] :bug: Bug fix (Non-breaking Change: Fixes an issue)
- [ ] :hammer_and_wrench: Chore (Non-breaking Change: Doc updates, pkg upgrades, typos, etc..)
- [ ] :nail_care: New Feature (Breaking/Non-breaking Change)

## Issue (if applicable)

NA

## Risk

Very low risk of broken thorchain trades.

## Testing

Check thorchain trades are still working

### Engineering

☝️

### Operations

☝️

## Screenshots (if applicable)
