### PR TITLE
feat: savers handle not enough fee for withdraw

### DIFF
--- a/src/features/defi/providers/thorchain-savers/components/ThorchainSaversManager/Withdraw/components/Withdraw.tsx
+++ b/src/features/defi/providers/thorchain-savers/components/ThorchainSaversManager/Withdraw/components/Withdraw.tsx
@@ -155,7 +155,7 @@ export const Withdraw: React.FC<WithdrawProps> = ({ accountId, onNext }) => {
     if (!accountId) return null
 
     try {
-      // Attempt getting a quote with 100000 bps, i.e 100% withdraw
+      // Attempt getting a quote with 10000 bps, i.e 100% withdraw
       // - If this succeeds, this allows us to know the oubtound fee, which is always the same regarding of the withdraw bps
       // and will allow us to gracefully handle withdrawal amounts that are lower than the outbound fee
       // - If this fails, we know that the withdraw amount is too low anyway, regarding of how many bps are withdrawn

--- a/src/features/defi/providers/thorchain-savers/components/ThorchainSaversManager/Withdraw/components/Withdraw.tsx
+++ b/src/features/defi/providers/thorchain-savers/components/ThorchainSaversManager/Withdraw/components/Withdraw.tsx
@@ -157,7 +157,7 @@ export const Withdraw: React.FC<WithdrawProps> = ({ accountId, onNext }) => {
     try {
       // Attempt getting a quote with 100000 bps, i.e 100% withdraw
       // - If this succeeds, this allows us to know the oubtound fee, which is always the same regarding of the withdraw bps
-      // and will allow us to gracefully handle amounts that are lower than the outbound fee
+      // and will allow us to gracefully handle withdrawal amounts that are lower than the outbound fee
       // - If this fails, we know that the withdraw amount is too low anyway, regarding of how many bps are withdrawn
       const quote = await getThorchainSaversWithdrawQuote({ asset, accountId, bps: '10000' })
 

--- a/src/features/defi/providers/thorchain-savers/components/ThorchainSaversManager/Withdraw/components/Withdraw.tsx
+++ b/src/features/defi/providers/thorchain-savers/components/ThorchainSaversManager/Withdraw/components/Withdraw.tsx
@@ -210,10 +210,6 @@ export const Withdraw: React.FC<WithdrawProps> = ({ accountId, onNext }) => {
         })
 
         const quote = await getThorchainSaversWithdrawQuote({ asset, accountId, bps: withdrawBps })
-          // Rejections here indicate that the amount to withdraw is too small
-          // We don't want to re-throw
-          .catch(() => {})
-
         if (!quote) return
 
         const chainAdapters = getChainAdapterManager()

--- a/src/features/defi/providers/thorchain-savers/components/ThorchainSaversManager/Withdraw/components/Withdraw.tsx
+++ b/src/features/defi/providers/thorchain-savers/components/ThorchainSaversManager/Withdraw/components/Withdraw.tsx
@@ -161,9 +161,12 @@ export const Withdraw: React.FC<WithdrawProps> = ({ accountId, onNext }) => {
       // - If this fails, we know that the withdraw amount is too low anyway, regarding of how many bps are withdrawn
       const quote = await getThorchainSaversWithdrawQuote({ asset, accountId, bps: '10000' })
 
-      return Ok(
-        bnOrZero(toBaseUnit(fromThorBaseUnit(quote.fees.outbound), asset.precision)).toFixed(0),
+      const outboundFee = bnOrZero(
+        toBaseUnit(fromThorBaseUnit(quote.fees.outbound), asset.precision),
       )
+      const safeOutboundFee = bn(outboundFee).times(105).div(100).toFixed(0)
+      // Add 5% as as a safety factor since the dust threshold fee is not necessarily going to cut it
+      return Ok(safeOutboundFee)
     } catch (error) {
       console.error(error)
       return Err((error as Error).message)

--- a/src/state/slices/opportunitiesSlice/resolvers/thorchainsavers/utils.ts
+++ b/src/state/slices/opportunitiesSlice/resolvers/thorchainsavers/utils.ts
@@ -39,7 +39,7 @@ import type {
 
 const THOR_PRECISION = '8'
 export const BASE_BPS_POINTS = '10000'
-const SAVERS_UPDATE_TIME = 35000 // The time it takes for savers to be updated (currently ~15s + some 20s buffer)
+const SAVERS_UPDATE_TIME = 25000 // The time it takes for savers to be updated (currently ~15s + some 10s buffer)
 
 export const THORCHAIN_AFFILIATE_NAME = 'ss'
 // BPS are needed as part of the memo, but 0bps won't incur any fees, only used for tracking purposes for now

--- a/src/state/slices/opportunitiesSlice/resolvers/thorchainsavers/utils.ts
+++ b/src/state/slices/opportunitiesSlice/resolvers/thorchainsavers/utils.ts
@@ -39,7 +39,7 @@ import type {
 
 const THOR_PRECISION = '8'
 export const BASE_BPS_POINTS = '10000'
-const SAVERS_UPDATE_TIME = 25000 // The time it takes for savers to be updated (currently ~15s + some 10s buffer)
+const SAVERS_UPDATE_TIME = 35000 // The time it takes for savers to be updated (currently ~15s + some 20s buffer)
 
 export const THORCHAIN_AFFILIATE_NAME = 'ss'
 // BPS are needed as part of the memo, but 0bps won't incur any fees, only used for tracking purposes for now


### PR DESCRIPTION
## Description

This revamps our savers logic for detecting minimum for withdraw being met or not.

We were previously dealing with native assets only, meaning these were exclusively sends, hence the only thing that mattered in successfully getting a withdraw quote was the outbound fee for said *chain* being met. However, we're now dealing with token withdraws as well, which have an outbound fee denominated in a token.
This isn't exposed by the regular endpoints we would use to get an outbound fee, since inbound addresses data relates to chains and their *native assets*, not tokens.

This makes things more graceful by using a 100% withdraw quote as a way to get the outbound fees:

https://github.com/shapeshift/web/blob/b2af6922c22df7c5374806081df522887b35e839/src/features/defi/providers/thorchain-savers/components/ThorchainSaversManager/Withdraw/components/Withdraw.tsx#L150-L154


This way, we are able to gracefully handle the minimum amount not met both for token and native asset withdraws:
  - in case 100% bps would yield a happy quote, we're able to get the actual outbound amount users should meet to withdraws, and are able to display that
  - else if even 100%bps wouldn't be enough for us to get a happy quote, we aren't able to get the outbound fees. It means we don't know how much would be the minimum, but are still able to detect that the amount being withdrawn is too low.
  
## Pull Request Type

- [ ] :bug: Bug fix (Non-breaking Change: Fixes an issue)
- [ ] :hammer_and_wrench: Chore (Non-breaking Change: Doc updates, pkg upgrades, typos, etc..)
- [ ] :nail_care: New Feature (Breaking/Non-breaking Change)

## Issue (if applicable)

<!-----------------------------------------------------------------------------
If applicable, please link to the github issue and put `closes #XXXX` in your comment to auto-close the issue that your PR fixes.
------------------------------------------------------------------------------>

N/A, follow-up of https://github.com/shapeshift/web/pull/5206#issuecomment-1711430063

## Risk

<!-----------------------------------------------------------------------------
Outline the scope of your changes and the risk associated with them. You must use your discretion as an engineer to determine the potential impact of your changes.

E.g. an upgrade to `hdwallet` or core state management would be considered higher risk, and might require a full regression test. UI or isolated view changes, or something behind a feature flag may have near zero risk. Small bug fixes might require testing isolated to the specific fix.
------------------------------------------------------------------------------>

Current savers withdraw minimums could be borked, test accordingly

## Testing

<!-----------------------------------------------------------------------------
We treat every PR to be merged with the same scrutiny as if we were merging directly to production.

Your PR will not be merged if you do not complete the sections below for our engineering and operations teams to test.
------------------------------------------------------------------------------>

- Savers withdraws are happy when the minimum is met
- Savers withdraws of less than the minimum gracefully display the error as errored button state
  - either with the amount, if we can infer the minimum (meaning 100% withdraw would be successful)
  - or without the amount, in case we can't infer it (meaning 100% withdraw would still be too low)
  
### Engineering

<!-----------------------------------------------------------------------------
Include sufficient information here for an engineer to test your PR. This may include how to test locally, in a built environment, changes to infrastructure etc.
------------------------------------------------------------------------------>

### Operations

<!-----------------------------------------------------------------------------
If your changes have a user-facing impact, describe how a non-technical QA team can functionally test your changes in a preview environment.

If they are not user-facing please describe how to test for any regressions that may occur.
------------------------------------------------------------------------------>

## Screenshots (if applicable)

### USDC withdraw - amount too low, but enough in savers to detect oubtound fee

<img width="1545" alt="Screenshot 2023-09-08 at 13 23 07" src="https://github.com/shapeshift/web/assets/17035424/24be6969-3131-4eda-9dcc-a956d96f74de">

### USDC withdraw - amount is higher than oubtound fee

<img width="555" alt="Screenshot 2023-09-08 at 13 24 08" src="https://github.com/shapeshift/web/assets/17035424/3339025a-4799-441f-add7-cfac1c0565bc">
<img width="547" alt="Screenshot 2023-09-08 at 13 25 08" src="https://github.com/shapeshift/web/assets/17035424/743cf192-785a-4939-82f8-1ca8d7f862dd">

### USDC withdraw - total amount in savers is too low to get a quote, hence we don't know the minimum

<img width="562" alt="image" src="https://github.com/shapeshift/web/assets/17035424/800f2455-84d9-4541-a9d3-c30f45efc8f6">

### AVAX withdraw - total amount in savers is too low to get a quote, hence we don't know the minimum

<img width="550" alt="image" src="https://github.com/shapeshift/web/assets/17035424/23b2229e-0661-4fbe-848b-ec2296b76a44">

### AVAX withdraw - amount too low, but enough in savers to detect oubtound fee

<img width="1722" alt="Screenshot 2023-09-08 at 14 33 41" src="https://github.com/shapeshift/web/assets/17035424/acaf5070-415e-4cae-ac4d-387102c3320f">

### AVAX withdraw - amount is higher than oubtound fee

<img width="559" alt="Screenshot 2023-09-08 at 14 34 05" src="https://github.com/shapeshift/web/assets/17035424/5319a466-4437-433b-b05d-9fec81de82b0">
<img width="533" alt="image" src="https://github.com/shapeshift/web/assets/17035424/536546f0-5646-4737-8c38-d06117549a8c">

### DOGE withdraw - amount too low, but enough in savers to detect oubtound fee

<img width="558" alt="image" src="https://github.com/shapeshift/web/assets/17035424/fa0f4eca-e876-49eb-b9e4-4d534eaaf585">

### DOGE withdraw - amount is higher than oubtound fee

<img width="552" alt="image" src="https://github.com/shapeshift/web/assets/17035424/5138ae96-4a69-49a9-b33a-9603ff8913d9">
<img width="551" alt="image" src="https://github.com/shapeshift/web/assets/17035424/c202f79b-a1de-4136-8c32-129ab67aae1e">
<img width="545" alt="image" src="https://github.com/shapeshift/web/assets/17035424/8753f57b-f182-4bbc-96a0-0d030c7f5740">

### DOGE withdraw - total amount in savers is too low to get a quote, hence we don't know the minimum

<img width="547" alt="image" src="https://github.com/shapeshift/web/assets/17035424/121cde07-b335-4ff7-8e68-befd22c60095">