### PR TITLE
fix: more reliable savers completion update p2

### DIFF
--- a/src/lib/swapper/swappers/ThorchainSwapper/types.ts
+++ b/src/lib/swapper/swappers/ThorchainSwapper/types.ts
@@ -126,9 +126,35 @@ export type ThorChainId =
   | ThorUtxoSupportedChainId
 
 type ThorNodeStatusResponseSuccess = {
-  // Non-exhaustive, the 'done' status is all we care about here
-  observed_tx: {
-    status?: 'done' | 'incomplete'
+  // Non-exhaustive. https://thornode.ninerealms.com/thorchain/doc/ for the full response type.
+  tx?: {
+    id: string
+    memo: string
+    chain: string
+    from_address: string
+    to_address: string
+  }
+  stages: {
+    inbound_observed: {
+      started?: boolean
+      final_count: number
+      completed: boolean
+    }
+    inbound_confirmation_counted?: {
+      completed: boolean
+    }
+    inbound_finalised?: {
+      completed: boolean
+    }
+    swap_status?: {
+      pending: boolean
+    }
+    swap_finalised?: {
+      completed: boolean
+    }
+    outbound_signed?: {
+      completed: boolean
+    }
   }
 }
 

--- a/src/lib/swapper/swappers/ThorchainSwapper/types.ts
+++ b/src/lib/swapper/swappers/ThorchainSwapper/types.ts
@@ -149,9 +149,6 @@ type ThorNodeStatusResponseSuccess = {
     swap_status?: {
       pending: boolean
     }
-    swap_finalised?: {
-      completed: boolean
-    }
     outbound_signed?: {
       completed: boolean
     }

--- a/src/state/slices/opportunitiesSlice/resolvers/thorchainsavers/utils.ts
+++ b/src/state/slices/opportunitiesSlice/resolvers/thorchainsavers/utils.ts
@@ -339,15 +339,14 @@ export const isSupportedThorchainSaversAssetId = (assetId: AssetId) =>
 export const isSupportedThorchainSaversChainId = (chainId: ChainId) =>
   SUPPORTED_THORCHAIN_SAVERS_CHAIN_IDS.includes(chainId)
 
-export const waitForSaversUpdate = (txHash: string) => {
-  return poll({
+export const waitForSaversUpdate = (txHash: string) =>
+  poll({
     fn: () => getThorchainTransactionStatus(txHash),
     validate: status => Boolean(status && status === TxStatus.Confirmed),
     interval: 60000,
     // i.e max. 10mn from the first Tx confirmation
     maxAttempts: 10,
   })
-}
 
 export const makeDaysToBreakEven = ({
   expectedAmountOutThorBaseUnit,

--- a/src/state/slices/opportunitiesSlice/resolvers/thorchainsavers/utils.ts
+++ b/src/state/slices/opportunitiesSlice/resolvers/thorchainsavers/utils.ts
@@ -156,7 +156,6 @@ export const getThorchainTransactionStatus = async (txHash: string) => {
   // Tx has been observed, but swap/outbound Tx hasn't been completed yet
   if (
     // Despite the Tx being observed, things may be slow to be picked on the THOR node side of things i.e for swaps to/from BTC
-    !(thorTxData.stages.inbound_observed?.completed === true) ||
     !thorTxData.stages.inbound_finalised?.completed ||
     thorTxData.stages.swap_status?.pending === true ||
     // Note, this does not apply to all Txs, e.g savers deposit won't have this property

--- a/src/state/slices/opportunitiesSlice/resolvers/thorchainsavers/utils.ts
+++ b/src/state/slices/opportunitiesSlice/resolvers/thorchainsavers/utils.ts
@@ -156,7 +156,7 @@ export const getThorchainTransactionStatus = async (txHash: string) => {
   // Tx has been observed, but swap/outbound Tx hasn't been completed yet
   if (
     // Despite the Tx being observed, things may be slow to be picked on the THOR node side of things i.e for swaps to/from BTC
-    !thorTxData.stages.inbound_finalised?.completed ||
+    thorTxData.stages.inbound_finalised?.completed === false ||
     thorTxData.stages.swap_status?.pending === true ||
     // Note, this does not apply to all Txs, e.g savers deposit won't have this property
     // the *presence* of outbound_signed?.completed as false *will* indicate a pending outbound Tx, but the opposite is not neccessarily true

--- a/src/state/slices/opportunitiesSlice/resolvers/thorchainsavers/utils.ts
+++ b/src/state/slices/opportunitiesSlice/resolvers/thorchainsavers/utils.ts
@@ -154,7 +154,6 @@ export const getThorchainTransactionStatus = async (txHash: string) => {
 
   if ('error' in thorTxData || status === 404) return TxStatus.Unknown
   // Tx has been observed, but swap/outbound Tx hasn't been completed yet
-  debugger
   if (
     // Despite the Tx being observed, things may be slow to be picked on the THOR node side of things i.e for swaps to/from BTC
     !(thorTxData.stages.inbound_observed?.completed === true) ||
@@ -341,7 +340,6 @@ export const isSupportedThorchainSaversChainId = (chainId: ChainId) =>
   SUPPORTED_THORCHAIN_SAVERS_CHAIN_IDS.includes(chainId)
 
 export const waitForSaversUpdate = (txHash: string) => {
-  debugger
   return poll({
     fn: () => getThorchainTransactionStatus(txHash),
     validate: status => Boolean(status && status === TxStatus.Confirmed),


### PR DESCRIPTION
## Description

More reliability, relying on the `stages` data from the THOR midgard endpoint.
In effect, this allows us to really introspect THOR swaps status up to the most granular bits.

Note:

1. THOR granularity stops at the signed outbound Tx, which may not mean you have the funds in your wallet, and may not mean a withdraw has been updated on the THOR side either. We would be able to take over from there and introspect the outbound Tx, but this is out of the scope of this PR.
2. THOR node is extremely slow picking stage changes up. This is unfortunately the state of affairs and we're trading unreliable completion status for reliable, but slow status updates.

## Pull Request Type

- [x] :bug: Bug fix (Non-breaking Change: Fixes an issue)
- [ ] :hammer_and_wrench: Chore (Non-breaking Change: Doc updates, pkg upgrades, typos, etc..)
- [ ] :nail_care: New Feature (Breaking/Non-breaking Change)

## Issue (if applicable)

<!-----------------------------------------------------------------------------
If applicable, please link to the github issue and put `closes #XXXX` in your comment to auto-close the issue that your PR fixes.
------------------------------------------------------------------------------>

closes https://github.com/shapeshift/web/issues/5245

## Risk

<!-----------------------------------------------------------------------------
Outline the scope of your changes and the risk associated with them. You must use your discretion as an engineer to determine the potential impact of your changes.

E.g. an upgrade to `hdwallet` or core state management would be considered higher risk, and might require a full regression test. UI or isolated view changes, or something behind a feature flag may have near zero risk. Small bug fixes might require testing isolated to the specific fix.
------------------------------------------------------------------------------>

1. Things might get too slow, which is unavoidable here
2. As a result of the former, there might be some cases where things are *particularly* slow and 10mn doesn't cut it. From my testing, this seems to cut it even for BTC, but we may want to make the max. interval higher in the future if we ever see issues there again

## Testing

<!-----------------------------------------------------------------------------
We treat every PR to be merged with the same scrutiny as if we were merging directly to production.

Your PR will not be merged if you do not complete the sections below for our engineering and operations teams to test.
------------------------------------------------------------------------------>

- THORChain savers deposits/withdraws status updates are now reliable i.e do move to completion, and update your balance (though the latter might happen later, see testing steps for more details)

### Engineering

<!-----------------------------------------------------------------------------
Include sufficient information here for an engineer to test your PR. This may include how to test locally, in a built environment, changes to infrastructure etc.
------------------------------------------------------------------------------>

- ☝🏽 

### Operations

<!-----------------------------------------------------------------------------
If your changes have a user-facing impact, describe how a non-technical QA team can functionally test your changes in a preview environment.

If they are not user-facing please describe how to test for any regressions that may occur.
------------------------------------------------------------------------------>

- ☝🏽 

## Screenshots (if applicable)

### BTC - Deposit

- Starting deposited value

<img width="1350" alt="Screenshot 2023-09-12 at 14 35 11" src="https://github.com/shapeshift/web/assets/17035424/3b7010c9-f434-4615-8025-f59520e06cb7">
<img width="544" alt="Screenshot 2023-09-12 at 14 35 18" src="https://github.com/shapeshift/web/assets/17035424/a8ce9bc0-cfe1-41fc-a4a6-fc0d643188e1">

- Pending Deposit - 0 confirmations

<img width="549" alt="Screenshot 2023-09-12 at 14 35 28" src="https://github.com/shapeshift/web/assets/17035424/616d3b65-9a0a-4d1b-8f7b-72b7e62b986a">
<img width="546" alt="Screenshot 2023-09-12 at 14 36 01" src="https://github.com/shapeshift/web/assets/17035424/bd286488-a8f8-4b7a-81ba-84d028b9103b">
<img width="774" alt="image" src="https://github.com/shapeshift/web/assets/17035424/ebe6306c-7ccc-47a6-96eb-8e54d6746f20">


- Tx observed by THOR after 1 confirmation

<img width="1473" alt="image" src="https://github.com/shapeshift/web/assets/17035424/59187d67-3dfc-4599-a382-989d3993eb10">

- Finalized swap on the THOR side

<img width="1520" alt="Screenshot 2023-09-12 at 14 44 47" src="https://github.com/shapeshift/web/assets/17035424/6180409e-5d80-4197-b577-57d3f4b5dff8">
<img width="550" alt="Screenshot 2023-09-12 at 14 45 13" src="https://github.com/shapeshift/web/assets/17035424/9d133bce-4223-4d16-a591-be03cbdc173e">

- Updated deposit balance

<img width="762" alt="image" src="https://github.com/shapeshift/web/assets/17035424/264d28ec-6c57-487f-b428-5a2a4f8558cb">
<img width="762" alt="image" src="https://github.com/shapeshift/web/assets/17035424/2a5351b0-324e-41dd-9942-5f5b4260f6c0">

### BTC - Withdraw

- Starting withdraw value

<img width="762" alt="image" src="https://github.com/shapeshift/web/assets/17035424/264d28ec-6c57-487f-b428-5a2a4f8558cb">
<img width="762" alt="image" src="https://github.com/shapeshift/web/assets/17035424/2a5351b0-324e-41dd-9942-5f5b4260f6c0">

- Pending withdraw - 0 confirmations

<img width="426" alt="Screenshot 2023-09-12 at 14 51 57" src="https://github.com/shapeshift/web/assets/17035424/5674a3e8-d1b1-4dce-951f-affe65d4fe42">

- Finalized swap on the THOR side with signed outbound

<img width="416" alt="Screenshot 2023-09-12 at 15 03 46" src="https://github.com/shapeshift/web/assets/17035424/199773d5-43fb-4779-9f2f-f451a5e2b8ef">
<img width="542" alt="Screenshot 2023-09-12 at 15 04 02" src="https://github.com/shapeshift/web/assets/17035424/9d392d70-63f9-494e-be0f-de1817156f70">


Note @shapeshift/operations : the outbound being signed here does *not* mean the outbound Tx (i.e the Tx with your funds coming back to your wallet) has been completed, only signed. The savers balance will only update a few minutes later, after one confirmation. Unfortunately, this is as much data as THOR will give us and it does not go further into giving us an "outbound Tx complete" state.

Happy to investigate this as a follow-up: We have a `out_txs[0]` containing the Txid, which we could theoretically use to continue the polling on our end, but this goes outside the scope of this PR.

- Updated balance

<img width="764" alt="image" src="https://github.com/shapeshift/web/assets/17035424/4d2d1128-e081-4019-abfb-8c1ed5d22f81">
<img width="539" alt="image" src="https://github.com/shapeshift/web/assets/17035424/5060ac85-553f-4402-8e75-13d5d5029c91">

### USDC on Avalanche - Deposit

- Starting deposited value

<img width="747" alt="image" src="https://github.com/shapeshift/web/assets/17035424/c4cd77ae-262f-4d1a-87d5-224031ae7f11">
<img width="539" alt="image" src="https://github.com/shapeshift/web/assets/17035424/c1f85df0-f25c-4008-8fbe-d940644c5d79">

- Pending deposit

<img width="551" alt="image" src="https://github.com/shapeshift/web/assets/17035424/e91c5113-0426-463b-a86c-39f017261770">
<img width="540" alt="image" src="https://github.com/shapeshift/web/assets/17035424/b5590bab-48c1-4837-9909-2ffd3b877cae">

- Finalized swap on the THOR side

<img width="406" alt="image" src="https://github.com/shapeshift/web/assets/17035424/55157b5e-50bd-4c31-92ac-c7d28e7a6b48">
<img width="526" alt="image" src="https://github.com/shapeshift/web/assets/17035424/2fb822f7-fda3-49c7-94f7-f6493424d9af">

- Updated balance

<img width="770" alt="image" src="https://github.com/shapeshift/web/assets/17035424/a029c7fa-8398-4019-be0c-e92f1ca1d841">
<img width="533" alt="image" src="https://github.com/shapeshift/web/assets/17035424/673870e9-0624-44f9-906a-efa4d3354b68">


### USDC on Avalanche - Withdraw

- Starting deposited value

<img width="1352" alt="image" src="https://github.com/shapeshift/web/assets/17035424/f1060877-6c0d-4102-bd46-e61bbce9f04f">
<img width="551" alt="image" src="https://github.com/shapeshift/web/assets/17035424/eb0b971f-a760-4639-bd6c-6c9a69340617">

- Pending withdraw

<img width="528" alt="image" src="https://github.com/shapeshift/web/assets/17035424/348856f4-220e-4e65-ad78-a999cee040df">
<img width="541" alt="image" src="https://github.com/shapeshift/web/assets/17035424/14e28870-48bb-4a4b-bc44-393be68de0e7">
<img width="420" alt="image" src="https://github.com/shapeshift/web/assets/17035424/089bfb5f-636a-40bd-be07-fdd59d41776a">

- Completed withdraw

<img width="413" alt="image" src="https://github.com/shapeshift/web/assets/17035424/e0891b5a-e5fb-4662-98c4-55f383c8819d">
<img width="535" alt="image" src="https://github.com/shapeshift/web/assets/17035424/32a915a6-a6a3-4536-b14c-73e3ded539d5">

- Updated balance

<img width="747" alt="image" src="https://github.com/shapeshift/web/assets/17035424/c4cd77ae-262f-4d1a-87d5-224031ae7f11">
<img width="539" alt="image" src="https://github.com/shapeshift/web/assets/17035424/c1f85df0-f25c-4008-8fbe-d940644c5d79">