### PR TITLE
fix: account route memoization

### DIFF
--- a/src/pages/Accounts/Accounts.tsx
+++ b/src/pages/Accounts/Accounts.tsx
@@ -68,7 +68,6 @@ export const Accounts = () => {
   const { path } = useRouteMatch()
   const blanks = Array(4).fill(0)
   const loading = useSelector(selectPortfolioLoading)
-  console.log({ loading })
   const portfolioChainIdsSortedUserCurrency = useSelector(selectPortfolioChainIdsSortedUserCurrency)
   const chainRows = useMemo(
     () =>

--- a/src/pages/Accounts/Accounts.tsx
+++ b/src/pages/Accounts/Accounts.tsx
@@ -11,7 +11,9 @@ import { useWallet } from 'hooks/useWallet/useWallet'
 import {
   selectPortfolioChainIdsSortedUserCurrency,
   selectPortfolioLoading,
+  selectWalletId,
 } from 'state/slices/selectors'
+import { useAppSelector } from 'state/store'
 
 import { Account } from './Account'
 import { ChainRow } from './components/ChainRow'
@@ -66,6 +68,7 @@ export const Accounts = () => {
   const { path } = useRouteMatch()
   const blanks = Array(4).fill(0)
   const loading = useSelector(selectPortfolioLoading)
+  console.log({ loading })
   const portfolioChainIdsSortedUserCurrency = useSelector(selectPortfolioChainIdsSortedUserCurrency)
   const chainRows = useMemo(
     () =>
@@ -74,6 +77,8 @@ export const Accounts = () => {
       )),
     [portfolioChainIdsSortedUserCurrency],
   )
+
+  const walletId = useAppSelector(selectWalletId)
 
   const blankRows = useMemo(() => {
     return blanks.map(index => (
@@ -87,7 +92,7 @@ export const Accounts = () => {
 
   return (
     <Switch>
-      <Route exact path={`${path}/`}>
+      <Route exact path={`${path}/`} key={`${walletId}-${loading}`}>
         <AccountHeader isLoading={loading} />
         <List ml={0} mt={0} spacing={4}>
           {renderRows}


### PR DESCRIPTION
## Description

This PR fixes the memoization of the account routes - currently, we're using a loading state to show skeletons, however, the route itself doesn't have a `key`, hence will lazily re-render childrens.

This is fine-ish for most cases, but being in the accounts route itself and having the `loading` reference/value (same thing since it's a boolean) change won't give us guarantees things will rerender e.g when un/installing snaps, meaning we can end up in a state of stale skeletons, which never disappear and are also weirdly reconciliated in the virtual DOM, meaning you get to see both skeletons rows *and* actual accounts rows, despite the logic being either one or the other is rendered.

This PR fixes it by giving the accounts route a composite key made of the current `WalletId` and the portfolio `loading` state.

## Pull Request Type

- [x] :bug: Bug fix (Non-breaking Change: Fixes an issue)
- [ ] :hammer_and_wrench: Chore (Non-breaking Change: Doc updates, pkg upgrades, typos, etc..)
- [ ] :nail_care: New Feature (Breaking/Non-breaking Change)

## Issue (if applicable)

N/A

## Risk

<!-----------------------------------------------------------------------------
Outline the scope of your changes and the risk associated with them. You must use your discretion as an engineer to determine the potential impact of your changes.

E.g. an upgrade to `hdwallet` or core state management would be considered higher risk, and might require a full regression test. UI or isolated view changes, or something behind a feature flag may have near zero risk. Small bug fixes might require testing isolated to the specific fix.
------------------------------------------------------------------------------>

None, same old routes key dance we've been doing

## Testing

<!-----------------------------------------------------------------------------
We treat every PR to be merged with the same scrutiny as if we were merging directly to production.

Your PR will not be merged if you do not complete the sections below for our engineering and operations teams to test.
------------------------------------------------------------------------------>

- Ensure installing the snap displays loading accounts skeletons (if you're fast enough to see it since you'll be routed to the BTC page) for a short while, disappearing after things are loaded
- Ensure uninstalling the snap either from the app itself, or re-opening the accounts page after installing the snap outside of the app, displays loading account skeletons for a short while, disappearing after things are loaded
- Ensure you never end up in a state with both skeleton rows and account rows visible. This isn't a feature, it is a VDOM reconciliation bug.

### Engineering

<!-----------------------------------------------------------------------------
Include sufficient information here for an engineer to test your PR. This may include how to test locally, in a built environment, changes to infrastructure etc.
------------------------------------------------------------------------------>

- :pointer_emoji:

### Operations

<!-----------------------------------------------------------------------------
If your changes have a user-facing impact, describe how a non-technical QA team can functionally test your changes in a preview environment.

If they are not user-facing please describe how to test for any regressions that may occur.
------------------------------------------------------------------------------>

- ☝🏽

## Screenshots (if applicable)


- This diff - happy skeletons

https://github.com/shapeshift/web/assets/17035424/c5d7665b-478e-4ba5-92f6-204bf94289a2

- The PR under this diff - sad skeletons that never disappear 👻 




https://github.com/shapeshift/web/assets/17035424/f10668e8-2925-4df3-bf9c-b676f904ad8f
