### PR TITLE
feat: allow users to connect multiple walletconnect client sessions to app

### DIFF
--- a/react-app-rewired/headers/csps/wallets/walletConnect.ts
+++ b/react-app-rewired/headers/csps/wallets/walletConnect.ts
@@ -8,6 +8,7 @@ export const csp: Csp = {
     'https://registry.walletconnect.com/api/v2/wallets',
     'https://api.etherscan.io',
     'https://verify.walletconnect.com/',
+    'https://verify.walletconnect.org/',
   ],
   'img-src': ['https://imagedelivery.net/', 'https://registry.walletconnect.com/api/v2/logo/', '*'],
   'frame-src': ['https://verify.walletconnect.com/'],

--- a/src/assets/translations/en/main.json
+++ b/src/assets/translations/en/main.json
@@ -1716,16 +1716,21 @@
       },
       "header": {
         "connectDapp": "Connect dApp",
+        "connectAnotherDapp": "Connect another dApp",
         "connectedDapp": "Connected dApp(s)",
+        "staleDapp": "Stale dApp(s)",
         "menu": {
           "disconnect": "Disconnect",
+          "reconnect": "Reconnect",
           "addresses": "Addresses",
           "address": "Address",
           "connected": "Connected",
           "networks": "Network(s)",
           "unsupportedNetwork": "Unsupported Network",
           "expiry": "Session expiry"
-        }
+        },
+        "multipleSessionsConnected": "%{count} dApps connected",
+        "clickToManage": "Click to manage"
       },
       "modal": {
         "title": "WalletConnect",

--- a/src/plugins/walletConnectToDapps/components/header/ConnectDapp.tsx
+++ b/src/plugins/walletConnectToDapps/components/header/ConnectDapp.tsx
@@ -1,0 +1,39 @@
+import { ChevronRightIcon } from '@chakra-ui/icons'
+import type { ButtonProps } from '@chakra-ui/react'
+import { Button, useDisclosure } from '@chakra-ui/react'
+import { ConnectModal } from 'plugins/walletConnectToDapps/components/modals/connect/Connect'
+import { useWalletConnectV2 } from 'plugins/walletConnectToDapps/v2/WalletConnectV2Provider'
+import { useMemo } from 'react'
+import { useTranslate } from 'react-polyglot'
+import { WalletConnectIcon } from 'components/Icons/WalletConnectIcon'
+import { isSome } from 'lib/utils'
+
+const widthProp = { base: 'full', md: 'auto' }
+
+export const WalletConnectButtons = (buttonProps?: ButtonProps) => {
+  const { isOpen, onClose: handleClose, onOpen: handleOpen } = useDisclosure()
+  const translate = useTranslate()
+  const { sessionsByTopic } = useWalletConnectV2()
+
+  const hasSessions = useMemo(
+    () => Object.values(sessionsByTopic).filter(isSome).length > 0,
+    [sessionsByTopic],
+  )
+
+  return (
+    <>
+      <Button
+        leftIcon={<WalletConnectIcon />}
+        rightIcon={<ChevronRightIcon />}
+        onClick={handleOpen}
+        width={widthProp}
+        {...buttonProps}
+      >
+        {hasSessions
+          ? translate('plugins.walletConnectToDapps.header.connectAnotherDapp')
+          : translate('plugins.walletConnectToDapps.header.connectDapp')}
+      </Button>
+      <ConnectModal isOpen={isOpen} onClose={handleClose} />
+    </>
+  )
+}

--- a/src/plugins/walletConnectToDapps/components/header/DappAvatar.tsx
+++ b/src/plugins/walletConnectToDapps/components/header/DappAvatar.tsx
@@ -1,32 +1,27 @@
-import type { BoxProps } from '@chakra-ui/react'
-import { Box, Image, useColorModeValue } from '@chakra-ui/react'
-import Placeholder from 'assets/placeholder.png'
+import { Avatar, useColorModeValue } from '@chakra-ui/react'
 import { CircleIcon } from 'components/Icons/Circle'
+import { FoxIcon } from 'components/Icons/FoxIcon'
 
 type DappAvatarProps = {
   image?: string
-  name: string
   connected: boolean
-  size?: number
+  size?: 'sm' | 'md' | 'lg' | 'xl' | '2xl' | '2xs' | 'xs' | 'full'
   connectedDotSize?: number
   borderWidth?: number
-} & BoxProps
+}
 
 export const DappAvatar: React.FC<DappAvatarProps> = ({
   image,
-  name,
   connected,
-  size = 8,
+  size,
   connectedDotSize = 3,
   borderWidth = 2,
-  ...rest
 }) => {
   const connectedIconColor = useColorModeValue('green.500', 'green.200')
   const menuBg = useColorModeValue('gray.100', 'gray.700')
 
   return (
-    <Box position='relative' {...rest}>
-      <Image boxSize={size} borderRadius='full' src={image || Placeholder} alt={name} />
+    <Avatar size={size} src={image} icon={<FoxIcon />}>
       {connected && (
         <CircleIcon
           color={connectedIconColor}
@@ -40,6 +35,6 @@ export const DappAvatar: React.FC<DappAvatarProps> = ({
           borderColor={menuBg}
         />
       )}
-    </Box>
+    </Avatar>
   )
 }

--- a/src/plugins/walletConnectToDapps/components/header/DappHeaderMenuSummary.tsx
+++ b/src/plugins/walletConnectToDapps/components/header/DappHeaderMenuSummary.tsx
@@ -34,7 +34,6 @@ export const DappHeaderMenuSummary = () => {
       >
         <HStack spacing={4} px={3} py={1}>
           <DappAvatar
-            name={walletConnect.dapp.name}
             image={walletConnect.dapp.icons?.[0]}
             connected={walletConnect.connector?.connected}
           />

--- a/src/plugins/walletConnectToDapps/components/header/DappHeaderMenuSummaryV2.tsx
+++ b/src/plugins/walletConnectToDapps/components/header/DappHeaderMenuSummaryV2.tsx
@@ -1,135 +1,72 @@
-import { SmallCloseIcon } from '@chakra-ui/icons'
-import {
-  Accordion,
-  AccordionButton,
-  AccordionIcon,
-  AccordionItem,
-  AccordionPanel,
-  Box,
-  Button,
-  HStack,
-  MenuGroup,
-  VStack,
-} from '@chakra-ui/react'
-import { getSdkError } from '@walletconnect/utils'
-import dayjs from 'dayjs'
-import { useWalletConnectState } from 'plugins/walletConnectToDapps/v2/hooks/useWalletConnectState'
-import { WalletConnectActionType } from 'plugins/walletConnectToDapps/v2/types'
+import { Accordion, MenuDivider, MenuGroup } from '@chakra-ui/react'
+import type { SessionTypes } from '@walletconnect/types'
 import { useWalletConnectV2 } from 'plugins/walletConnectToDapps/v2/WalletConnectV2Provider'
-import { useCallback } from 'react'
+import { useMemo } from 'react'
 import { useTranslate } from 'react-polyglot'
-import { RawText, Text } from 'components/Text'
-import { selectSelectedLocale } from 'state/slices/selectors'
-import { useAppSelector } from 'state/store'
 
-import { AddressLinks } from './AddressLinks'
-import { DappAvatar } from './DappAvatar'
-import { Networks } from './Networks'
+import { WalletConnectButtons } from './ConnectDapp'
+import { Session } from './Session'
 
 export const DappHeaderMenuSummaryV2 = () => {
-  const selectedLocale = useAppSelector(selectSelectedLocale)
-
   const translate = useTranslate()
 
   const { dispatch, ...state } = useWalletConnectV2()
-  const { session, web3wallet, core } = state
-  const { connectedAccounts } = useWalletConnectState(state)
+  const { sessionsByTopic, web3wallet } = state
 
-  const handleDisconnect = useCallback(async () => {
-    // Do this first - we want to always clear our session, even if the disconnect fails
-    dispatch({ type: WalletConnectActionType.DELETE_SESSION })
+  const sessions = useMemo(() => Object.values(sessionsByTopic), [sessionsByTopic])
 
-    if (!session || !web3wallet || !core) return
+  const { connectedSessions, expiredSessions } = useMemo(() => {
+    const nowTtl = Date.now() / 1000
+    return sessions.reduce<{
+      connectedSessions: SessionTypes.Struct[]
+      expiredSessions: SessionTypes.Struct[]
+    }>(
+      (acc, session) => {
+        if (!session) return acc
+        if (session.expiry < nowTtl) {
+          acc.expiredSessions.push(session)
+        } else {
+          acc.connectedSessions.push(session)
+        }
+        return acc
+      },
+      { connectedSessions: [], expiredSessions: [] },
+    )
+  }, [sessions])
 
-    /*
-     TODO: we only support one session at a time (the most recent)
-     In the future we want to support multiple pairings and sessions at once.
-     */
-    const activeTopics = Object.values(web3wallet.getActiveSessions()).map(session => session.topic)
-    const mostRecentTopic = activeTopics.slice(-1)[0]
-
-    try {
-      await web3wallet.disconnectSession({
-        topic: mostRecentTopic,
-        reason: getSdkError('USER_DISCONNECTED'),
-      })
-    } catch (e) {
-      throw new Error(`Error disconnecting session: ${e}, topic: ${mostRecentTopic}`)
-    }
-  }, [core, dispatch, session, web3wallet])
-
-  if (!session || !web3wallet) return null
+  if (!sessions.length || !web3wallet) return null
 
   return (
     <>
-      <MenuGroup
-        title={translate('plugins.walletConnectToDapps.header.connectedDapp')}
-        ml={3}
-        color='text.subtle'
-      >
-        <Accordion allowToggle defaultIndex={0} variant='default'>
-          <AccordionItem borderBottomWidth={0}>
-            <AccordionButton width='full'>
-              <HStack spacing={4} py={1} width='full'>
-                <DappAvatar
-                  name={session.peer.metadata.name}
-                  image={session.peer.metadata.icons?.[0]}
-                  connected={session.acknowledged}
-                  display={{ base: 'none', md: 'block' }}
-                />
-                <Box textAlign='left'>
-                  <RawText
-                    maxWidth='215px'
-                    overflow='hidden'
-                    textOverflow='ellipsis'
-                    whiteSpace='nowrap'
-                    fontWeight='medium'
-                    lineHeight='shorter'
-                  >
-                    {session.peer.metadata.name}
-                  </RawText>
-                  <RawText
-                    fontSize='sm'
-                    color='text.subtle'
-                    maxWidth='215px'
-                    overflow='hidden'
-                    textOverflow='ellipsis'
-                    whiteSpace='nowrap'
-                    lineHeight='shorter'
-                  >
-                    {session.peer.metadata.url.replace(/^https?:\/\//, '')}
-                  </RawText>
-                </Box>
-                <AccordionIcon ml='auto' />
-              </HStack>
-            </AccordionButton>
-            <AccordionPanel px={4} pt={0} pb={4}>
-              <VStack fontWeight='medium' spacing={2} alignItems='stretch' fontSize='sm'>
-                <HStack justifyContent='space-between' spacing={4}>
-                  <Text
-                    translation='plugins.walletConnectToDapps.header.menu.expiry'
-                    color='text.subtle'
-                  />
-                  <RawText>
-                    {dayjs.unix(session.expiry).locale(selectedLocale).format('ll LT')}
-                  </RawText>
-                </HStack>
-                <AddressLinks accountIds={connectedAccounts} />
-                <Networks accountIds={connectedAccounts} />
-                <Button
-                  colorScheme='red'
-                  size='sm'
-                  onClick={handleDisconnect}
-                  leftIcon={<SmallCloseIcon />}
-                  mt={2}
-                >
-                  <Text translation='plugins.walletConnectToDapps.header.menu.disconnect' />
-                </Button>
-              </VStack>
-            </AccordionPanel>
-          </AccordionItem>
-        </Accordion>
-      </MenuGroup>
+      {connectedSessions.length > 0 && (
+        <MenuGroup
+          title={translate('plugins.walletConnectToDapps.header.connectedDapp')}
+          ml={3}
+          color='text.subtle'
+        >
+          <Accordion allowToggle defaultIndex={0} variant='default'>
+            {connectedSessions.map(session => (
+              <Session key={session.topic} session={session} />
+            ))}
+          </Accordion>
+        </MenuGroup>
+      )}
+      {connectedSessions.length > 0 && expiredSessions.length > 0 && <MenuDivider />}
+      {expiredSessions.length > 0 && (
+        <MenuGroup
+          title={translate('plugins.walletConnectToDapps.header.staleDapp')}
+          ml={3}
+          color='text.subtle'
+        >
+          <Accordion allowToggle defaultIndex={0} variant='default'>
+            {expiredSessions.map(session => (
+              <Session key={session.topic} session={session} />
+            ))}
+          </Accordion>
+        </MenuGroup>
+      )}
+      <MenuDivider />
+      <WalletConnectButtons m={4} />
     </>
   )
 }

--- a/src/plugins/walletConnectToDapps/components/header/Session.tsx
+++ b/src/plugins/walletConnectToDapps/components/header/Session.tsx
@@ -1,0 +1,140 @@
+import { CheckIcon, SmallCloseIcon } from '@chakra-ui/icons'
+import {
+  AccordionButton,
+  AccordionIcon,
+  AccordionItem,
+  AccordionPanel,
+  Box,
+  Button,
+  HStack,
+  VStack,
+} from '@chakra-ui/react'
+import type { SessionTypes } from '@walletconnect/types'
+import { getSdkError } from '@walletconnect/utils'
+import dayjs from 'dayjs'
+import { extractConnectedAccounts } from 'plugins/walletConnectToDapps/utils'
+import { WalletConnectActionType } from 'plugins/walletConnectToDapps/v2/types'
+import { useWalletConnectV2 } from 'plugins/walletConnectToDapps/v2/WalletConnectV2Provider'
+import { useCallback, useMemo } from 'react'
+import { RawText, Text } from 'components/Text'
+import { selectSelectedLocale } from 'state/slices/selectors'
+import { useAppSelector } from 'state/store'
+
+import { AddressLinks } from './AddressLinks'
+import { DappAvatar } from './DappAvatar'
+import { Networks } from './Networks'
+
+export const Session = ({ session }: { session: SessionTypes.Struct }) => {
+  const selectedLocale = useAppSelector(selectSelectedLocale)
+
+  const { dispatch, ...state } = useWalletConnectV2()
+  const { web3wallet, core } = state
+  const connectedAccounts = useMemo(() => extractConnectedAccounts(session), [session])
+
+  const handleDisconnect = useCallback(() => {
+    // Do this first - we want to always clear our session, even if the disconnect fails
+    dispatch({ type: WalletConnectActionType.DELETE_SESSION, payload: session })
+
+    if (!web3wallet) return
+
+    void web3wallet.disconnectSession({
+      topic: session.topic,
+      reason: getSdkError('USER_DISCONNECTED'),
+    })
+  }, [dispatch, session, web3wallet])
+
+  const handleReconnect = useCallback(async () => {
+    if (!web3wallet || !core) return
+
+    // Reactivate the session then extend it - await is required to ensure execution order
+    await core.pairing.activate({ topic: session.pairingTopic })
+    await web3wallet.extendSession({ topic: session.topic })
+  }, [core, session, web3wallet])
+
+  const nowTtl = Date.now() / 1000
+  const isExpired = session.expiry < nowTtl
+
+  return (
+    <AccordionItem borderBottomWidth={0}>
+      <AccordionButton width='full'>
+        <HStack spacing={4} py={1} width='full'>
+          <DappAvatar
+            image={session.peer.metadata.icons?.[0]}
+            connected={session.acknowledged && !isExpired}
+            size='sm'
+          />
+          <Box textAlign='left'>
+            <RawText
+              maxWidth='200px'
+              overflow='hidden'
+              textOverflow='ellipsis'
+              whiteSpace='nowrap'
+              fontWeight='medium'
+              lineHeight='shorter'
+            >
+              {session.peer.metadata.name}
+            </RawText>
+            <RawText
+              fontSize='sm'
+              color='text.subtle'
+              maxWidth='200px'
+              overflow='hidden'
+              textOverflow='ellipsis'
+              whiteSpace='nowrap'
+              lineHeight='shorter'
+            >
+              {session.peer.metadata.url.replace(/^https?:\/\//, '')}
+            </RawText>
+          </Box>
+          <AccordionIcon ml='auto' />
+        </HStack>
+      </AccordionButton>
+      <AccordionPanel px={4} pt={0} pb={4}>
+        <VStack fontWeight='medium' spacing={2} alignItems='stretch' fontSize='sm'>
+          <HStack justifyContent='space-between' spacing={4}>
+            <Text
+              translation='plugins.walletConnectToDapps.header.menu.expiry'
+              color='text.subtle'
+            />
+            <RawText>{dayjs.unix(session.expiry).locale(selectedLocale).format('ll LT')}</RawText>
+          </HStack>
+          <AddressLinks accountIds={connectedAccounts} />
+          <Networks accountIds={connectedAccounts} />
+          {isExpired ? (
+            <HStack justifyContent='space-between'>
+              <Button
+                colorScheme='green'
+                size='sm'
+                onClick={handleReconnect}
+                leftIcon={<CheckIcon />}
+                mt={2}
+                variant={'outline'}
+              >
+                <Text translation='plugins.walletConnectToDapps.header.menu.reconnect' />
+              </Button>
+              <Button
+                colorScheme='red'
+                size='sm'
+                onClick={handleDisconnect}
+                leftIcon={<SmallCloseIcon />}
+                mt={2}
+              >
+                <Text translation='plugins.walletConnectToDapps.header.menu.disconnect' />
+              </Button>
+            </HStack>
+          ) : (
+            <Button
+              colorScheme='red'
+              size='sm'
+              onClick={handleDisconnect}
+              leftIcon={<SmallCloseIcon />}
+              mt={2}
+            >
+              <Text translation='plugins.walletConnectToDapps.header.menu.disconnect' />
+            </Button>
+          )}
+        </VStack>
+      </AccordionPanel>
+    </AccordionItem>
+  )
+}

--- a/src/plugins/walletConnectToDapps/v2/WalletConnectV2Provider.tsx
+++ b/src/plugins/walletConnectToDapps/v2/WalletConnectV2Provider.tsx
@@ -22,7 +22,7 @@ export const WalletConnectV2Provider: FC<PropsWithChildren> = ({ children }) => 
     pair: undefined,
     modalData: undefined,
     activeModal: undefined,
-    session: undefined,
+    sessionsByTopic: {},
   }
 
   const [state, dispatch] = useReducer(walletConnectReducer, initialState)
@@ -44,16 +44,8 @@ export const WalletConnectV2Provider: FC<PropsWithChildren> = ({ children }) => 
   useEffect(() => {
     const activeSessions = state.web3wallet?.getActiveSessions()
     const sessions = activeSessions ? Object.values(activeSessions) : []
-    if (sessions?.length) {
-      // Load the most recent session
-      const session = sessions[sessions.length - 1]
-      ;(async () => {
-        // Reactivate the session
-        await state.core?.pairing.activate({ topic: session.topic })
-        await state.web3wallet?.extendSession({ topic: session.topic })
-      })()
-      // TODO: handle multiple sessions
-      dispatch({ type: WalletConnectActionType.SET_SESSION, payload: session })
+    if (sessions.length) {
+      dispatch({ type: WalletConnectActionType.SET_SESSIONS, payload: sessions })
     }
   }, [state.core?.pairing, state.web3wallet])
 

--- a/src/plugins/walletConnectToDapps/v2/components/modals/EIP155SignMessageConfirmation.tsx
+++ b/src/plugins/walletConnectToDapps/v2/components/modals/EIP155SignMessageConfirmation.tsx
@@ -25,14 +25,16 @@ import { useWallet } from 'hooks/useWallet/useWallet'
 
 export const EIP155SignMessageConfirmationModal: FC<
   WalletConnectRequestModalProps<EthSignCallRequest | EthPersonalSignCallRequest>
-> = ({ onConfirm: handleConfirm, onReject: handleReject, state }) => {
+> = ({ onConfirm: handleConfirm, onReject: handleReject, state, topic }) => {
   const { address, message } = useWalletConnectState(state)
-  const peerMetadata = state.session.peer.metadata
+  const peerMetadata = state.sessionsByTopic[topic]?.peer.metadata
 
   const translate = useTranslate()
   const walletInfo = useWallet().state.walletInfo
   const WalletIcon = walletInfo?.icon ?? FoxIcon
   const cardBg = useColorModeValue('white', 'gray.850')
+
+  if (!peerMetadata) return null
 
   return (
     <>

--- a/src/plugins/walletConnectToDapps/v2/components/modals/SessionProposal.tsx
+++ b/src/plugins/walletConnectToDapps/v2/components/modals/SessionProposal.tsx
@@ -100,11 +100,19 @@ const SessionProposal: FC<WalletConnectSessionModalProps> = ({
   )
 
   const handleApprove = useCallback(async () => {
-    const session = await web3wallet?.approveSession({
+    // exit if the proposal was not found - likely duplicate call rerendering shenanigans
+    const pendingProposals = web3wallet.getPendingSessionProposals()
+    if (
+      !Object.values(pendingProposals).some(pendingProposal => pendingProposal.id === proposal.id)
+    ) {
+      return
+    }
+
+    const session = await web3wallet.approveSession({
       id: proposal.id,
       namespaces: approvalNamespaces,
     })
-    dispatch({ type: WalletConnectActionType.SET_SESSION, payload: session })
+    dispatch({ type: WalletConnectActionType.ADD_SESSION, payload: session })
     handleClose()
   }, [approvalNamespaces, dispatch, handleClose, proposal, web3wallet])
 

--- a/src/plugins/walletConnectToDapps/v2/hooks/useWalletConnectState.ts
+++ b/src/plugins/walletConnectToDapps/v2/hooks/useWalletConnectState.ts
@@ -1,7 +1,7 @@
 import { CHAIN_NAMESPACE, fromChainId } from '@shapeshiftoss/caip'
 import { useIsInteractingWithContract } from 'plugins/walletConnectToDapps/hooks/useIsInteractingWithContract'
 import {
-  extractConnectedAccounts,
+  extractAllConnectedAccounts,
   getSignParamsMessage,
   getWalletAccountFromCosmosParams,
   getWalletAccountFromEthParams,
@@ -22,7 +22,7 @@ import { useAppSelector } from 'state/store'
   A helper hook to derive commonly used information from the WalletConnectState
  */
 export const useWalletConnectState = (state: WalletConnectState) => {
-  const { modalData, session } = state
+  const { modalData, sessionsByTopic } = state
   const requestEvent = modalData?.requestEvent
 
   const params = requestEvent?.params
@@ -32,7 +32,7 @@ export const useWalletConnectState = (state: WalletConnectState) => {
   const requestParams = request?.params
   const transaction = isTransactionParamsArray(requestParams) ? requestParams?.[0] : undefined
 
-  const connectedAccounts = extractConnectedAccounts(session)
+  const connectedAccounts = extractAllConnectedAccounts(sessionsByTopic)
 
   const address = (() => {
     if (requestParams && isEthSignParams(requestParams))

--- a/src/plugins/walletConnectToDapps/v2/types.ts
+++ b/src/plugins/walletConnectToDapps/v2/types.ts
@@ -4,6 +4,7 @@ import type { PairingTypes } from '@walletconnect/types/dist/types/core/pairing'
 import type { IWeb3Wallet, Web3WalletTypes } from '@walletconnect/web3wallet'
 import type { WalletConnectFeeDataKey } from 'plugins/walletConnectToDapps/v1/components/modals/callRequest/CallRequestCommon'
 import type { Dispatch } from 'react'
+import type { PartialRecord } from 'lib/utils'
 
 export enum EIP155_SigningMethod {
   PERSONAL_SIGN = 'personal_sign',
@@ -35,15 +36,16 @@ export type WalletConnectState<T = WalletConnectRequest> = {
   pair?: (params: { uri: string }) => Promise<PairingTypes.Struct>
   modalData?: ModalData<T>
   activeModal?: WalletConnectModal
-  session?: SessionTypes.Struct
+  sessionsByTopic: PartialRecord<string, SessionTypes.Struct>
 }
 
 export enum WalletConnectActionType {
   SET_MODAL = 'SET_MODAL',
   CLEAR_MODAL = 'CLEAR_MODAL',
   INITIALIZE = 'INITIALIZE',
-  SET_SESSION = 'SET_SESSION',
+  SET_SESSIONS = 'SET_SESSIONS',
   DELETE_SESSION = 'DELETE_SESSION',
+  ADD_SESSION = 'ADD_SESSION',
   UPDATE_SESSION = 'UPDATE_SESSION',
 }
 
@@ -60,15 +62,20 @@ export type WalletConnectAction =
       payload: { core: ICore; web3wallet: IWeb3Wallet; pair: WalletConnectState['pair'] }
     }
   | {
-      type: WalletConnectActionType.SET_SESSION
-      payload: SessionTypes.Struct
+      type: WalletConnectActionType.SET_SESSIONS
+      payload: SessionTypes.Struct[]
     }
   | {
       type: WalletConnectActionType.DELETE_SESSION
+      payload: Pick<SessionTypes.Struct, 'topic'>
     }
   | {
       type: WalletConnectActionType.UPDATE_SESSION
-      payload: Partial<SessionTypes.Struct>
+      payload: Pick<SessionTypes.Struct, 'topic'> & Partial<Omit<SessionTypes.Struct, 'topic'>>
+    }
+  | {
+      type: WalletConnectActionType.ADD_SESSION
+      payload: SessionTypes.Struct
     }
 
 export type WalletConnectContextType = {

--- a/src/plugins/walletConnectToDapps/v2/walletConnectReducer.ts
+++ b/src/plugins/walletConnectToDapps/v2/walletConnectReducer.ts
@@ -1,5 +1,7 @@
+import type { SessionTypes } from '@walletconnect/types'
 import type { WalletConnectAction, WalletConnectState } from 'plugins/walletConnectToDapps/v2/types'
 import { WalletConnectActionType } from 'plugins/walletConnectToDapps/v2/types'
+import type { PartialRecord } from 'lib/utils'
 
 export const walletConnectReducer = (
   state: WalletConnectState,
@@ -12,15 +14,47 @@ export const walletConnectReducer = (
       return { ...state, activeModal: action.payload.modal, modalData: action.payload.data }
     case WalletConnectActionType.CLEAR_MODAL:
       return { ...state, activeModal: undefined, modalData: undefined }
-    case WalletConnectActionType.SET_SESSION:
-      return { ...state, session: action.payload }
-    case WalletConnectActionType.DELETE_SESSION:
+    case WalletConnectActionType.SET_SESSIONS: {
+      const sessionsByTopic = action.payload.reduce<PartialRecord<string, SessionTypes.Struct>>(
+        (acc, session) => {
+          acc[session.topic] = session
+          return acc
+        },
+        {},
+      )
+      return { ...state, sessionsByTopic }
+    }
+    case WalletConnectActionType.DELETE_SESSION: {
       // A modal can't exist without a session. Ensure it's closed when removing the session.
-      return { ...state, session: undefined, activeModal: undefined }
-    case WalletConnectActionType.UPDATE_SESSION:
-      const { session } = state
-      // A session cannot be updated if it is not initialized
-      return session ? { ...state, session: { ...session, ...action.payload } } : state
+      state.sessionsByTopic[action.payload.topic] = undefined
+      state.activeModal = undefined
+      return {
+        ...state,
+        sessionsByTopic: {
+          ...state.sessionsByTopic,
+          [action.payload.topic]: undefined,
+        },
+      }
+    }
+    case WalletConnectActionType.UPDATE_SESSION: {
+      const session = state.sessionsByTopic[action.payload.topic]
+
+      if (session === undefined) return state
+
+      return {
+        ...state,
+        sessionsByTopic: {
+          ...state.sessionsByTopic,
+          [session.topic]: { ...session, ...action.payload },
+        },
+      }
+    }
+    case WalletConnectActionType.ADD_SESSION: {
+      return {
+        ...state,
+        sessionsByTopic: { ...state.sessionsByTopic, [action.payload.topic]: action.payload },
+      }
+    }
     default:
       return state
   }


### PR DESCRIPTION
## Description

Implements multi-session for walletconnect v2. 

Features include:
* multiple sessions supported with UI to display them
* ability to delete sessions
* ability to reconnect stale sessions

## Pull Request Type

- [ ] :bug: Bug fix (Non-breaking Change: Fixes an issue)
- [ ] :hammer_and_wrench: Chore (Non-breaking Change: Doc updates, pkg upgrades, typos, etc..)
- [x] :nail_care: New Feature (Breaking/Non-breaking Change)

## Issue (if applicable)

closes #5236

## Risk

* Risk of broken existing basic single session walletconnectv2 functionality
* Risk of broken new walletconnect v2 functionality

## Testing

* Connect/disconnect individual sessions
* Data displayed about sessions works
* Address explorer links work
* Reloading page reconnects sessions
* Expired sessions can be reconnected (requires engineers to monkey patch if you dont want to wait 7 days)

### Engineering

☝️

### Operations

☝️

## Screenshots (if applicable)

Single dapp connected:
![image](https://github.com/shapeshift/web/assets/125113430/7873abdd-e8d3-43f4-a488-c76a06e01dbf)

Multiple dapps connected:
![image](https://github.com/shapeshift/web/assets/125113430/a191f773-a440-44e5-bf58-a4bf20537996)

Ability to "connect another dapp":
![image](https://github.com/shapeshift/web/assets/125113430/dcdc2019-fbec-4f97-b37b-15c5ea6f984c)

Display of stale and connected dapps (monkey patched):
![image](https://github.com/shapeshift/web/assets/125113430/a9482405-349c-4d92-8813-26f3a2dad31d)

