### PR TITLE
feat: move from reacty to lazy savers withdraw input step

### DIFF
--- a/src/features/defi/providers/thorchain-savers/components/ThorchainSaversManager/Withdraw/components/Confirm.tsx
+++ b/src/features/defi/providers/thorchain-savers/components/ThorchainSaversManager/Withdraw/components/Confirm.tsx
@@ -272,6 +272,8 @@ export const Confirm: React.FC<ConfirmProps> = ({ accountId, onNext }) => {
       if (!(accountId && opportunityData?.stakedAmountCryptoBaseUnit?.[0]))
         throw new Error('accountId is undefined')
 
+      if (bnOrZero(state?.withdraw.cryptoAmount).isZero()) return
+
       const amountCryptoBaseUnit = toBaseUnit(state?.withdraw.cryptoAmount, asset.precision)
 
       const withdrawBps = getWithdrawBps({

--- a/src/features/defi/providers/thorchain-savers/components/ThorchainSaversManager/Withdraw/components/Confirm.tsx
+++ b/src/features/defi/providers/thorchain-savers/components/ThorchainSaversManager/Withdraw/components/Confirm.tsx
@@ -202,9 +202,15 @@ export const Confirm: React.FC<ConfirmProps> = ({ accountId, onNext }) => {
 
         if (bn(withdrawBps).isZero()) return
 
-        const quote = await getThorchainSaversWithdrawQuote({ asset, accountId, bps: withdrawBps })
+        const maybeQuote = await getThorchainSaversWithdrawQuote({
+          asset,
+          accountId,
+          bps: withdrawBps,
+        })
 
-        const { expiry, dust_amount, expected_amount_out, slippage_bps } = quote
+        if (maybeQuote.isErr()) throw new Error(maybeQuote.unwrapErr())
+
+        const { expiry, dust_amount, expected_amount_out, slippage_bps } = maybeQuote.unwrap()
 
         setExpiry(expiry)
 
@@ -273,12 +279,18 @@ export const Confirm: React.FC<ConfirmProps> = ({ accountId, onNext }) => {
         stakedAmountCryptoBaseUnit: opportunityData?.stakedAmountCryptoBaseUnit,
         rewardsAmountCryptoBaseUnit: opportunityData?.rewardsCryptoBaseUnit?.amounts[0] ?? '0',
       })
-      const quote = await getThorchainSaversWithdrawQuote({ asset, accountId, bps: withdrawBps })
+      const maybeQuote = await getThorchainSaversWithdrawQuote({
+        asset,
+        accountId,
+        bps: withdrawBps,
+      })
 
       if (isUtxoChainId(chainId) && !maybeFromUTXOAccountAddress) {
         throw new Error('Account address required to withdraw from THORChain savers')
       }
 
+      if (maybeQuote.isErr()) throw new Error(maybeQuote.unwrapErr())
+      const quote = maybeQuote.unwrap()
       const { expiry, expected_amount_out, dust_amount } = quote
 
       const amountCryptoThorBaseUnit = toThorBaseUnit({
@@ -293,7 +305,7 @@ export const Confirm: React.FC<ConfirmProps> = ({ accountId, onNext }) => {
         ),
       )
 
-      if (!quote) throw new Error('Cannot get THORCHain savers withdraw quote')
+      if (!maybeQuote) throw new Error('Cannot get THORCHain savers withdraw quote')
 
       return {
         from: maybeFromUTXOAccountAddress,
@@ -334,7 +346,15 @@ export const Confirm: React.FC<ConfirmProps> = ({ accountId, onNext }) => {
       })
 
       if (bn(withdrawBps).isZero()) return
-      const quote = await getThorchainSaversWithdrawQuote({ asset, accountId, bps: withdrawBps })
+      const maybeQuote = await getThorchainSaversWithdrawQuote({
+        asset,
+        accountId,
+        bps: withdrawBps,
+      })
+
+      if (maybeQuote.isErr()) throw new Error(maybeQuote.unwrapErr())
+
+      const quote = maybeQuote.unwrap()
 
       const daemonUrl = getConfig().REACT_APP_THORCHAIN_NODE_URL
       const maybeInboundAddressData = await getInboundAddressDataForChain(
@@ -468,7 +488,10 @@ export const Confirm: React.FC<ConfirmProps> = ({ accountId, onNext }) => {
         rewardsAmountCryptoBaseUnit: opportunityData?.rewardsCryptoBaseUnit?.amounts[0] ?? '0',
       })
 
-      const quote = await getThorchainSaversWithdrawQuote({ asset, accountId, bps })
+      const maybeQuote = await getThorchainSaversWithdrawQuote({ asset, accountId, bps })
+
+      if (maybeQuote.isErr()) throw new Error(maybeQuote.unwrapErr())
+      const quote = maybeQuote.unwrap()
 
       if (isUtxoChainId(chainId) && !maybeFromUTXOAccountAddress) {
         throw new Error('Account address required to withdraw from THORChain savers')
@@ -534,9 +557,14 @@ export const Confirm: React.FC<ConfirmProps> = ({ accountId, onNext }) => {
 
       if (bn(withdrawBps).isZero()) return
 
-      const quote = await getThorchainSaversWithdrawQuote({ asset, accountId, bps: withdrawBps })
+      const maybeQuote = await getThorchainSaversWithdrawQuote({
+        asset,
+        accountId,
+        bps: withdrawBps,
+      })
 
-      if (!quote) throw new Error('Error getting THORChain savers withdraw quote')
+      if (!maybeQuote.isErr()) throw new Error(maybeQuote.unwrapErr())
+      const quote = maybeQuote.unwrap()
 
       const { dust_amount } = quote
 

--- a/src/features/defi/providers/thorchain-savers/components/ThorchainSaversManager/Withdraw/components/Withdraw.tsx
+++ b/src/features/defi/providers/thorchain-savers/components/ThorchainSaversManager/Withdraw/components/Withdraw.tsx
@@ -260,7 +260,8 @@ export const Withdraw: React.FC<WithdrawProps> = ({ accountId, onNext }) => {
           return Ok(bnOrZero(fastFeeCryptoBaseUnit).toString())
         }
 
-        // TODO(gomes): error-handling
+        // Quote errors aren't necessarily user-friendly, we don't want to return them
+        if (maybeQuote.isErr()) throw new Error(maybeQuote.unwrapErr())
         const quote = maybeQuote.unwrap()
         // We're lying to Ts, this isn't always an UtxoBaseAdapter
         // But typing this as any chain-adapter won't narrow down its type and we'll have errors at `chainSpecific` property
@@ -311,7 +312,6 @@ export const Withdraw: React.FC<WithdrawProps> = ({ accountId, onNext }) => {
       dispatch({ type: ThorchainSaversWithdrawActionType.SET_WITHDRAW, payload: formValues })
       dispatch({ type: ThorchainSaversWithdrawActionType.SET_LOADING, payload: true })
       try {
-        // TODO(gomes): maybe start extract this logit into its own if it ends up being repeated too much
         const { cryptoAmount } = inputValues
         const amountCryptoBaseUnit = toBaseUnit(cryptoAmount, asset.precision)
         const withdrawBps = getWithdrawBps({
@@ -323,7 +323,7 @@ export const Withdraw: React.FC<WithdrawProps> = ({ accountId, onNext }) => {
         const _quote = await getThorchainSaversWithdrawQuote({ asset, accountId, bps: withdrawBps })
         setQuoteLoading(false)
 
-        // TODO(gomes): error-handling
+        if (_quote.isErr()) throw new Error(_quote.unwrapErr())
         const quote = _quote.unwrap()
         const { dust_amount } = quote
         const _dustAmountCryptoBaseUnit = toBaseUnit(fromThorBaseUnit(dust_amount), asset.precision)
@@ -336,7 +336,6 @@ export const Withdraw: React.FC<WithdrawProps> = ({ accountId, onNext }) => {
         if (maybeWithdrawGasEstimateCryptoBaseUnit.isErr()) return
 
         const estimatedGasCryptoBaseUnit = maybeWithdrawGasEstimateCryptoBaseUnit.unwrap()
-        // TODO(gomes): maybe end extract logic
         dispatch({
           type: ThorchainSaversWithdrawActionType.SET_WITHDRAW,
           payload: { estimatedGasCryptoBaseUnit },
@@ -403,7 +402,6 @@ export const Withdraw: React.FC<WithdrawProps> = ({ accountId, onNext }) => {
       if (!dispatch) return false
 
       try {
-        // TODO(gomes): maybe start extract this logit into its own if it ends up being repeated too much
         const cryptoAmount = value
         const amountCryptoBaseUnit = toBaseUnit(cryptoAmount, asset.precision)
         const withdrawBps = getWithdrawBps({
@@ -431,8 +429,6 @@ export const Withdraw: React.FC<WithdrawProps> = ({ accountId, onNext }) => {
           _quote,
           _dustAmountCryptoBaseUnit,
         )
-
-        // TODO(gomes): maybe end extract logic
 
         if (!maybeOutboundFeeCryptoBaseUnit) return false
         if (!maybeWithdrawGasEstimateCryptoBaseUnit) return false

--- a/src/features/defi/providers/thorchain-savers/components/ThorchainSaversManager/Withdraw/components/Withdraw.tsx
+++ b/src/features/defi/providers/thorchain-savers/components/ThorchainSaversManager/Withdraw/components/Withdraw.tsx
@@ -343,7 +343,6 @@ export const Withdraw: React.FC<WithdrawProps> = ({ accountId, onNext }) => {
 
         onNext(DefiStep.Confirm)
 
-        dispatch({ type: ThorchainSaversWithdrawActionType.SET_LOADING, payload: false })
         trackOpportunityEvent(
           MixPanelEvents.WithdrawContinue,
           {
@@ -361,6 +360,7 @@ export const Withdraw: React.FC<WithdrawProps> = ({ accountId, onNext }) => {
           title: translate('common.somethingWentWrong'),
           status: 'error',
         })
+      } finally {
         dispatch({ type: ThorchainSaversWithdrawActionType.SET_LOADING, payload: false })
       }
     },

--- a/src/features/defi/providers/thorchain-savers/components/ThorchainSaversManager/Withdraw/components/Withdraw.tsx
+++ b/src/features/defi/providers/thorchain-savers/components/ThorchainSaversManager/Withdraw/components/Withdraw.tsx
@@ -318,16 +318,20 @@ export const Withdraw: React.FC<WithdrawProps> = ({ accountId, onNext }) => {
           rewardsAmountCryptoBaseUnit: opportunityData.rewardsCryptoBaseUnit?.amounts[0] ?? '0',
         })
         setQuoteLoading(true)
-        const _quote = await getThorchainSaversWithdrawQuote({ asset, accountId, bps: withdrawBps })
+        const maybeQuote = await getThorchainSaversWithdrawQuote({
+          asset,
+          accountId,
+          bps: withdrawBps,
+        })
         setQuoteLoading(false)
 
-        if (_quote.isErr()) throw new Error(_quote.unwrapErr())
-        const quote = _quote.unwrap()
+        if (maybeQuote.isErr()) throw new Error(maybeQuote.unwrapErr())
+        const quote = maybeQuote.unwrap()
         const { dust_amount } = quote
         const _dustAmountCryptoBaseUnit = toBaseUnit(fromThorBaseUnit(dust_amount), asset.precision)
 
         const maybeWithdrawGasEstimateCryptoBaseUnit = await getWithdrawGasEstimateCryptoBaseUnit(
-          _quote,
+          maybeQuote,
           _dustAmountCryptoBaseUnit,
         )
         if (!maybeWithdrawGasEstimateCryptoBaseUnit) return
@@ -409,11 +413,15 @@ export const Withdraw: React.FC<WithdrawProps> = ({ accountId, onNext }) => {
         })
 
         setQuoteLoading(true)
-        const _quote = await getThorchainSaversWithdrawQuote({ asset, accountId, bps: withdrawBps })
+        const maybeQuote = await getThorchainSaversWithdrawQuote({
+          asset,
+          accountId,
+          bps: withdrawBps,
+        })
 
-        const maybeOutboundFeeCryptoBaseUnit = await getOutboundFeeCryptoBaseUnit(_quote)
-        if (_quote.isErr()) return translate('trade.errors.amountTooSmallUnknownMinimum')
-        const quote = _quote.unwrap()
+        const maybeOutboundFeeCryptoBaseUnit = await getOutboundFeeCryptoBaseUnit(maybeQuote)
+        if (maybeQuote.isErr()) return translate('trade.errors.amountTooSmallUnknownMinimum')
+        const quote = maybeQuote.unwrap()
         const { slippage_bps, dust_amount } = quote
 
         const percentage = bnOrZero(slippage_bps).div(BASE_BPS_POINTS).times(100)
@@ -424,7 +432,7 @@ export const Withdraw: React.FC<WithdrawProps> = ({ accountId, onNext }) => {
         const _dustAmountCryptoBaseUnit = toBaseUnit(fromThorBaseUnit(dust_amount), asset.precision)
 
         const maybeWithdrawGasEstimateCryptoBaseUnit = await getWithdrawGasEstimateCryptoBaseUnit(
-          _quote,
+          maybeQuote,
           _dustAmountCryptoBaseUnit,
         )
 

--- a/src/state/slices/opportunitiesSlice/resolvers/thorchainsavers/utils.ts
+++ b/src/state/slices/opportunitiesSlice/resolvers/thorchainsavers/utils.ts
@@ -238,24 +238,24 @@ export const getThorchainSaversWithdrawQuote = async ({
   asset: Asset
   accountId: AccountId
   bps: string
-}): Promise<ThorchainSaversWithdrawQuoteResponseSuccess> => {
+}): Promise<Result<ThorchainSaversWithdrawQuoteResponseSuccess, string>> => {
   const poolId = assetIdToPoolAssetId({ assetId: asset.assetId })
 
-  if (!poolId) throw new Error(`Invalid assetId for THORCHain savers: ${asset.assetId}`)
+  if (!poolId) return Err(`Invalid assetId for THORCHain savers: ${asset.assetId}`)
 
   const accountAddresses = await getAccountAddresses(accountId)
 
   const allPositions = await getAllThorchainSaversPositions(asset.assetId)
 
   if (!allPositions.length)
-    throw new Error(`Error fetching THORCHain savers positions for assetId: ${asset.assetId}`)
+    return Err(`Error fetching THORCHain savers positions for assetId: ${asset.assetId}`)
 
   const accountPosition = allPositions.find(
     ({ asset_address }) =>
       asset_address === accountAddresses.find(accountAddress => accountAddress === asset_address),
   )
 
-  if (!accountPosition) throw new Error('No THORChain savers position found')
+  if (!accountPosition) return Err('No THORChain savers position found')
 
   const { asset_address } = accountPosition
 
@@ -266,9 +266,9 @@ export const getThorchainSaversWithdrawQuote = async ({
   )
 
   if (!quoteData || 'error' in quoteData)
-    throw new Error(`Error fetching THORChain savers quote: ${quoteData?.error}`)
+    return Err(`Error fetching THORChain savers quote: ${quoteData?.error}`)
 
-  return quoteData
+  return Ok(quoteData)
 }
 
 export const getMidgardPools = async (


### PR DESCRIPTION
## Description

Effectively the part 2 of https://github.com/shapeshift/web/pull/5253. https://github.com/shapeshift/web/pull/5253 made the function signatures more sane and pave the way for things being done lazy vs. eager, which this PR is now doing. More context below.

### Problem

Currently, the withdraw form validates input based on state values reactively.
This reactive approach results in validation being the earliest process triggered on input change.
Asynchronous operations that lead to state field updates (i.e `maybeOutboundFeeCryptoBaseUnit` and `maybeWithdrawGasEstimateCryptoBaseUnit`) happen subsequently, with the callbacks already having been executed by the time they complete. This premature execution causes potential inconsistencies and inefficiencies, and a deterministic failure of the first percent option click - see https://github.com/shapeshift/web/issues/5265.

Furthermore, there's duplication of logic in `validateCryptoAmount` and `validateFiatAmount.`
With the former validation logic being executed after the latter, the new lazy and asynchronous nature means more network requests and double the time spent, leading to inefficiencies and potential bottlenecks.

### Solution
    The withdraw input component was transitioned to a lazy evaluation model. Instead of relying on state fields, the necessary actions are now called asynchronously in-place (i.e lazy), ensuring that validation and logic execution align more closely with data availability.
    We have removed the redundant logic in `validateCryptoAmount` and `validateFiatAmount`. By testing and ensuring that `validateFiatAmount` executes first, and with the async logic now happening in `validateCryptoAmount` only, we significantly reduce the number of network requests. This prevents us from doubling the time for validation, making sure things now deterministically work while keeping fast.

## Pull Request Type

- [ ] :bug: Bug fix (Non-breaking Change: Fixes an issue)
- [ ] :hammer_and_wrench: Chore (Non-breaking Change: Doc updates, pkg upgrades, typos, etc..)
- [ ] :nail_care: New Feature (Breaking/Non-breaking Change)

## Issue (if applicable)

<!-----------------------------------------------------------------------------
If applicable, please link to the github issue and put `closes #XXXX` in your comment to auto-close the issue that your PR fixes.
------------------------------------------------------------------------------>

closes https://github.com/shapeshift/web/issues/5265

## Risk

<!-----------------------------------------------------------------------------
Outline the scope of your changes and the risk associated with them. You must use your discretion as an engineer to determine the potential impact of your changes.

E.g. an upgrade to `hdwallet` or core state management would be considered higher risk, and might require a full regression test. UI or isolated view changes, or something behind a feature flag may have near zero risk. Small bug fixes might require testing isolated to the specific fix.
------------------------------------------------------------------------------>

## Testing

<!-----------------------------------------------------------------------------
We treat every PR to be merged with the same scrutiny as if we were merging directly to production.

Your PR will not be merged if you do not complete the sections below for our engineering and operations teams to test.
------------------------------------------------------------------------------>

### Engineering

<!-----------------------------------------------------------------------------
Include sufficient information here for an engineer to test your PR. This may include how to test locally, in a built environment, changes to infrastructure etc.
------------------------------------------------------------------------------>

### Operations

<!-----------------------------------------------------------------------------
If your changes have a user-facing impact, describe how a non-technical QA team can functionally test your changes in a preview environment.

If they are not user-facing please describe how to test for any regressions that may occur.
------------------------------------------------------------------------------>

## Screenshots (if applicable)

- Native asset - withdraw amount lower than outbound fee

https://github.com/shapeshift/web/assets/17035424/a0ba5246-0e88-4025-b1ac-aa4dbcaba7e4

- Native asset - not enough balance for gas

https://github.com/shapeshift/web/assets/17035424/43e85120-7d00-467f-9d01-72be6e9a224d

- Token - withdraw amount lower than outbound fee


https://github.com/shapeshift/web/assets/17035424/7b34dfe5-356c-4427-9339-6fd899c51578


- Token - enough native asset balance for gas and amount higher than outbound fee 


https://github.com/shapeshift/web/assets/17035424/161f8f98-6224-4184-8a0c-74e1ed463e0c



- Native asset - enough balance for gas and amount higher than outbound fee


https://github.com/shapeshift/web/assets/17035424/b9e36c14-c7cf-4243-ac14-3dc875bc2c4e
