### PR TITLE
chore: release v1.435.0

### DIFF
--- a/src/assets/translations/en/main.json
+++ b/src/assets/translations/en/main.json
@@ -1288,6 +1288,23 @@
       "connectMetaMask": "Connect MetaMask",
       "andMore": "...and more"
     },
+    "metaMaskSnapConfirm":{
+      "title": "Install Multichain Snap",
+      "warningExperimental": "The ShapeShift Multichain Snap is a new, experimental feature, provided \"as is\"",
+      "warningBackup": "Ensure you have backed up your MetaMask seed phrase. Any funds you send to non-EVM chains using this Snap will be directed to the default account you set up with MetaMask.",
+      "agreeIntro": "Before continuing please read the following:",
+      "agreeItem1Parts": {
+        "1": "Hardware wallets are",
+        "2": "NOT",
+        "3": "supported"
+      },
+      "agreeItem2": "Only Account #1 in MetaMask is supported for the extra chains the ShapeShift Multichain Snap provides",
+      "agreeItem3": "To use the existing Ethereum chains provided by MetaMask, you must connect Account #1 to ShapeShift in MetaMask",
+      "agreeItem4": "By enabling the ShapeShift Multichain Snap, you acknowledge you are using it at your own risk",
+      "readAndUnderstood": "I have read and understand",
+      "seedBackedUp": "I have backed up my MetaMask seed phrase",
+      "acceptInstall": "Confirm & Install"
+    },
     "coinbase": {
       "errors": {
         "unknown": "An unexpected error occurred communicating with Coinbase",

--- a/src/components/Modals/Snaps/SnapConfirm.tsx
+++ b/src/components/Modals/Snaps/SnapConfirm.tsx
@@ -26,6 +26,7 @@ type SnapConfirmProps = {
 export const SnapConfirm: React.FC<SnapConfirmProps> = ({ onClose }) => {
   const [isInstalling, setIsInstalling] = useState(false)
   const [hasAgreed, setHasAgreed] = useState(false)
+  const [hasPinkySworeSeedPhraseIsBackedUp, setHasPinkySworeSeedPhraseIsBackedUp] = useState(false)
   const translate = useTranslate()
   const handleAddSnap = useCallback(() => {
     setIsInstalling(true)
@@ -53,44 +54,57 @@ export const SnapConfirm: React.FC<SnapConfirmProps> = ({ onClose }) => {
   return (
     <>
       <ModalHeader textAlign='center'>
-        <Heading as='h4'>Install Multichain Snap</Heading>
+        <Heading as='h4'>{translate('walletProvider.metaMaskSnapConfirm.title')}</Heading>
       </ModalHeader>
       <ModalBody>
         <Alert status='warning' borderRadius='lg' mb={4}>
           <AlertIcon />
           <AlertDescription>
-            The ShapeShift Multichain Snap is a new, experimental feature, provided "as is"
+            {translate('walletProvider.metaMaskSnapConfirm.warningExperimental')}
           </AlertDescription>
         </Alert>
-        <RawText fontWeight='bold'>Before continuing please read the following:</RawText>
+        <Alert status='error' borderRadius='lg' mb={4}>
+          <AlertIcon />
+          <AlertDescription>
+            {translate('walletProvider.metaMaskSnapConfirm.warningBackup')}
+          </AlertDescription>
+        </Alert>
+        <RawText fontWeight='bold'>
+          {translate('walletProvider.metaMaskSnapConfirm.agreeIntro')}
+        </RawText>
         <UnorderedList spacing={2} my={4}>
           <ListItem>
-            Hardware wallets are <strong>NOT</strong> supported
+            {translate('walletProvider.metaMaskSnapConfirm.agreeItem1Parts.1')}{' '}
+            <strong>{translate('walletProvider.metaMaskSnapConfirm.agreeItem1Parts.2')}</strong>{' '}
+            {translate('walletProvider.metaMaskSnapConfirm.agreeItem1Parts.3')}
           </ListItem>
           <ListItem>
-            Only Account #1 in MetaMask is supported for the extra chains the ShapeShift Multichain
-            Snap provides{' '}
+            {translate('walletProvider.metaMaskSnapConfirm.agreeItem2')}{' '}
             <RawText as='span' color='text.subtle'>
               (Bitcoin, Bitcoin Cash, Litecoin, Dogecoin, THORChain, Cosmos)
             </RawText>
           </ListItem>
-          <ListItem>
-            To use the existing Ethereum chains provided by MetaMask, you must connect Account #1 to
-            ShapeShift in MetaMask
-          </ListItem>
-          <ListItem>
-            By enabling the ShapeShift Multichain Snap, you acknowledge you are using it at your own
-            risk
-          </ListItem>
+          <ListItem>{translate('walletProvider.metaMaskSnapConfirm.agreeItem3')}</ListItem>
+          <ListItem>{translate('walletProvider.metaMaskSnapConfirm.agreeItem4')}</ListItem>
         </UnorderedList>
         <Checkbox onChange={e => setHasAgreed(e.target.checked)} fontWeight='bold'>
-          I have read and understand
+          {translate('walletProvider.metaMaskSnapConfirm.readAndUnderstood')}
+        </Checkbox>
+        <Checkbox
+          onChange={e => setHasPinkySworeSeedPhraseIsBackedUp(e.target.checked)}
+          fontWeight='bold'
+        >
+          {translate('walletProvider.metaMaskSnapConfirm.seedBackedUp')}
         </Checkbox>
       </ModalBody>
       <ModalFooter gap={2}>
-        <Button onClick={onClose}>Cancel</Button>
-        <Button colorScheme='blue' isDisabled={!hasAgreed} onClick={handleAddSnap}>
-          Confirm & Install
+        <Button onClick={onClose}>{translate('common.cancel')}</Button>
+        <Button
+          colorScheme='blue'
+          isDisabled={!(hasAgreed && hasPinkySworeSeedPhraseIsBackedUp)}
+          onClick={handleAddSnap}
+        >
+          {translate('walletProvider.metaMaskSnapConfirm.acceptInstall')}
         </Button>
       </ModalFooter>
     </>

--- a/src/features/defi/providers/thorchain-savers/components/ThorchainSaversManager/Withdraw/components/Confirm.tsx
+++ b/src/features/defi/providers/thorchain-savers/components/ThorchainSaversManager/Withdraw/components/Confirm.tsx
@@ -565,7 +565,7 @@ export const Confirm: React.FC<ConfirmProps> = ({ accountId, onNext }) => {
         bps: withdrawBps,
       })
 
-      if (!maybeQuote.isErr()) throw new Error(maybeQuote.unwrapErr())
+      if (maybeQuote.isErr()) throw new Error(maybeQuote.unwrapErr())
       const quote = maybeQuote.unwrap()
 
       const { dust_amount } = quote

--- a/src/features/defi/providers/thorchain-savers/components/ThorchainSaversManager/Withdraw/components/Confirm.tsx
+++ b/src/features/defi/providers/thorchain-savers/components/ThorchainSaversManager/Withdraw/components/Confirm.tsx
@@ -202,9 +202,15 @@ export const Confirm: React.FC<ConfirmProps> = ({ accountId, onNext }) => {
 
         if (bn(withdrawBps).isZero()) return
 
-        const quote = await getThorchainSaversWithdrawQuote({ asset, accountId, bps: withdrawBps })
+        const maybeQuote = await getThorchainSaversWithdrawQuote({
+          asset,
+          accountId,
+          bps: withdrawBps,
+        })
 
-        const { expiry, dust_amount, expected_amount_out, slippage_bps } = quote
+        if (maybeQuote.isErr()) throw new Error(maybeQuote.unwrapErr())
+
+        const { expiry, dust_amount, expected_amount_out, slippage_bps } = maybeQuote.unwrap()
 
         setExpiry(expiry)
 
@@ -266,6 +272,8 @@ export const Confirm: React.FC<ConfirmProps> = ({ accountId, onNext }) => {
       if (!(accountId && opportunityData?.stakedAmountCryptoBaseUnit?.[0]))
         throw new Error('accountId is undefined')
 
+      if (bnOrZero(state?.withdraw.cryptoAmount).isZero()) return
+
       const amountCryptoBaseUnit = toBaseUnit(state?.withdraw.cryptoAmount, asset.precision)
 
       const withdrawBps = getWithdrawBps({
@@ -273,12 +281,18 @@ export const Confirm: React.FC<ConfirmProps> = ({ accountId, onNext }) => {
         stakedAmountCryptoBaseUnit: opportunityData?.stakedAmountCryptoBaseUnit,
         rewardsAmountCryptoBaseUnit: opportunityData?.rewardsCryptoBaseUnit?.amounts[0] ?? '0',
       })
-      const quote = await getThorchainSaversWithdrawQuote({ asset, accountId, bps: withdrawBps })
+      const maybeQuote = await getThorchainSaversWithdrawQuote({
+        asset,
+        accountId,
+        bps: withdrawBps,
+      })
 
       if (isUtxoChainId(chainId) && !maybeFromUTXOAccountAddress) {
         throw new Error('Account address required to withdraw from THORChain savers')
       }
 
+      if (maybeQuote.isErr()) throw new Error(maybeQuote.unwrapErr())
+      const quote = maybeQuote.unwrap()
       const { expiry, expected_amount_out, dust_amount } = quote
 
       const amountCryptoThorBaseUnit = toThorBaseUnit({
@@ -293,7 +307,7 @@ export const Confirm: React.FC<ConfirmProps> = ({ accountId, onNext }) => {
         ),
       )
 
-      if (!quote) throw new Error('Cannot get THORCHain savers withdraw quote')
+      if (!maybeQuote) throw new Error('Cannot get THORCHain savers withdraw quote')
 
       return {
         from: maybeFromUTXOAccountAddress,
@@ -334,7 +348,15 @@ export const Confirm: React.FC<ConfirmProps> = ({ accountId, onNext }) => {
       })
 
       if (bn(withdrawBps).isZero()) return
-      const quote = await getThorchainSaversWithdrawQuote({ asset, accountId, bps: withdrawBps })
+      const maybeQuote = await getThorchainSaversWithdrawQuote({
+        asset,
+        accountId,
+        bps: withdrawBps,
+      })
+
+      if (maybeQuote.isErr()) throw new Error(maybeQuote.unwrapErr())
+
+      const quote = maybeQuote.unwrap()
 
       const daemonUrl = getConfig().REACT_APP_THORCHAIN_NODE_URL
       const maybeInboundAddressData = await getInboundAddressDataForChain(
@@ -468,7 +490,10 @@ export const Confirm: React.FC<ConfirmProps> = ({ accountId, onNext }) => {
         rewardsAmountCryptoBaseUnit: opportunityData?.rewardsCryptoBaseUnit?.amounts[0] ?? '0',
       })
 
-      const quote = await getThorchainSaversWithdrawQuote({ asset, accountId, bps })
+      const maybeQuote = await getThorchainSaversWithdrawQuote({ asset, accountId, bps })
+
+      if (maybeQuote.isErr()) throw new Error(maybeQuote.unwrapErr())
+      const quote = maybeQuote.unwrap()
 
       if (isUtxoChainId(chainId) && !maybeFromUTXOAccountAddress) {
         throw new Error('Account address required to withdraw from THORChain savers')
@@ -534,9 +559,14 @@ export const Confirm: React.FC<ConfirmProps> = ({ accountId, onNext }) => {
 
       if (bn(withdrawBps).isZero()) return
 
-      const quote = await getThorchainSaversWithdrawQuote({ asset, accountId, bps: withdrawBps })
+      const maybeQuote = await getThorchainSaversWithdrawQuote({
+        asset,
+        accountId,
+        bps: withdrawBps,
+      })
 
-      if (!quote) throw new Error('Error getting THORChain savers withdraw quote')
+      if (!maybeQuote.isErr()) throw new Error(maybeQuote.unwrapErr())
+      const quote = maybeQuote.unwrap()
 
       const { dust_amount } = quote
 

--- a/src/lib/swapper/swappers/ThorchainSwapper/types.ts
+++ b/src/lib/swapper/swappers/ThorchainSwapper/types.ts
@@ -126,9 +126,32 @@ export type ThorChainId =
   | ThorUtxoSupportedChainId
 
 type ThorNodeStatusResponseSuccess = {
-  // Non-exhaustive, the 'done' status is all we care about here
-  observed_tx: {
-    status?: 'done' | 'incomplete'
+  // Non-exhaustive. https://thornode.ninerealms.com/thorchain/doc/ for the full response type.
+  tx?: {
+    id: string
+    memo: string
+    chain: string
+    from_address: string
+    to_address: string
+  }
+  stages: {
+    inbound_observed: {
+      started?: boolean
+      final_count: number
+      completed: boolean
+    }
+    inbound_confirmation_counted?: {
+      completed: boolean
+    }
+    inbound_finalised?: {
+      completed: boolean
+    }
+    swap_status?: {
+      pending: boolean
+    }
+    outbound_signed?: {
+      completed: boolean
+    }
   }
 }
 

--- a/src/pages/Accounts/Accounts.tsx
+++ b/src/pages/Accounts/Accounts.tsx
@@ -11,7 +11,9 @@ import { useWallet } from 'hooks/useWallet/useWallet'
 import {
   selectPortfolioChainIdsSortedUserCurrency,
   selectPortfolioLoading,
+  selectWalletId,
 } from 'state/slices/selectors'
+import { useAppSelector } from 'state/store'
 
 import { Account } from './Account'
 import { ChainRow } from './components/ChainRow'
@@ -75,6 +77,8 @@ export const Accounts = () => {
     [portfolioChainIdsSortedUserCurrency],
   )
 
+  const walletId = useAppSelector(selectWalletId)
+
   const blankRows = useMemo(() => {
     return blanks.map(index => (
       <Skeleton key={`chain-${index}`} height='82px' width='full' borderRadius='2xl' />
@@ -87,7 +91,7 @@ export const Accounts = () => {
 
   return (
     <Switch>
-      <Route exact path={`${path}/`}>
+      <Route exact path={`${path}/`} key={`${walletId}-${loading}`}>
         <AccountHeader isLoading={loading} />
         <List ml={0} mt={0} spacing={4}>
           {renderRows}

--- a/src/state/slices/opportunitiesSlice/resolvers/thorchainsavers/utils.ts
+++ b/src/state/slices/opportunitiesSlice/resolvers/thorchainsavers/utils.ts
@@ -239,24 +239,24 @@ export const getThorchainSaversWithdrawQuote = async ({
   asset: Asset
   accountId: AccountId
   bps: string
-}): Promise<ThorchainSaversWithdrawQuoteResponseSuccess> => {
+}): Promise<Result<ThorchainSaversWithdrawQuoteResponseSuccess, string>> => {
   const poolId = assetIdToPoolAssetId({ assetId: asset.assetId })
 
-  if (!poolId) throw new Error(`Invalid assetId for THORCHain savers: ${asset.assetId}`)
+  if (!poolId) return Err(`Invalid assetId for THORCHain savers: ${asset.assetId}`)
 
   const accountAddresses = await getAccountAddresses(accountId)
 
   const allPositions = await getAllThorchainSaversPositions(asset.assetId)
 
   if (!allPositions.length)
-    throw new Error(`Error fetching THORCHain savers positions for assetId: ${asset.assetId}`)
+    return Err(`Error fetching THORCHain savers positions for assetId: ${asset.assetId}`)
 
   const accountPosition = allPositions.find(
     ({ asset_address }) =>
       asset_address === accountAddresses.find(accountAddress => accountAddress === asset_address),
   )
 
-  if (!accountPosition) throw new Error('No THORChain savers position found')
+  if (!accountPosition) return Err('No THORChain savers position found')
 
   const { asset_address } = accountPosition
 
@@ -267,9 +267,9 @@ export const getThorchainSaversWithdrawQuote = async ({
   )
 
   if (!quoteData || 'error' in quoteData)
-    throw new Error(`Error fetching THORChain savers quote: ${quoteData?.error}`)
+    return Err(`Error fetching THORChain savers quote: ${quoteData?.error}`)
 
-  return quoteData
+  return Ok(quoteData)
 }
 
 export const getMidgardPools = async (

--- a/src/state/slices/opportunitiesSlice/resolvers/thorchainsavers/utils.ts
+++ b/src/state/slices/opportunitiesSlice/resolvers/thorchainsavers/utils.ts
@@ -147,15 +147,27 @@ export const getAllThorchainSaversPositions = async (
 export const getThorchainTransactionStatus = async (txHash: string) => {
   const thorTxHash = txHash.replace(/^0x/, '')
   const { data: thorTxData, status } = await axios.get<ThornodeStatusResponse>(
-    `${getConfig().REACT_APP_THORCHAIN_NODE_URL}/lcd/thorchain/tx/${thorTxHash}`,
+    `${getConfig().REACT_APP_THORCHAIN_NODE_URL}/lcd/thorchain/tx/status/${thorTxHash}`,
     // We don't want to throw on 404s, we're parsing these ourselves
     { validateStatus: () => true },
   )
 
   if ('error' in thorTxData || status === 404) return TxStatus.Unknown
-  if (!thorTxData.observed_tx.status || thorTxData.observed_tx.status === 'incomplete')
+  // Tx has been observed, but swap/outbound Tx hasn't been completed yet
+  if (
+    // Despite the Tx being observed, things may be slow to be picked on the THOR node side of things i.e for swaps to/from BTC
+    thorTxData.stages.inbound_finalised?.completed === false ||
+    thorTxData.stages.swap_status?.pending === true ||
+    // Note, this does not apply to all Txs, e.g savers deposit won't have this property
+    // the *presence* of outbound_signed?.completed as false *will* indicate a pending outbound Tx, but the opposite is not neccessarily true
+    // i.e a succesful end-to-end "swap" might be succesful despite the *absence* of outbound_signed property
+    thorTxData.stages.outbound_signed?.completed === false
+  )
     return TxStatus.Pending
-  if (thorTxData.observed_tx.status === 'done') return TxStatus.Confirmed
+  if (thorTxData.stages.swap_status?.pending === false) return TxStatus.Confirmed
+
+  // We shouldn't end up here, but just in case
+  return TxStatus.Unknown
 }
 
 export const getThorchainSaversPosition = async ({
@@ -330,7 +342,8 @@ export const waitForSaversUpdate = (txHash: string) =>
   poll({
     fn: () => getThorchainTransactionStatus(txHash),
     validate: status => Boolean(status && status === TxStatus.Confirmed),
-    interval: 30000,
+    interval: 60000,
+    // i.e max. 10mn from the first Tx confirmation
     maxAttempts: 10,
   })
 

--- a/src/state/slices/opportunitiesSlice/resolvers/thorchainsavers/utils.ts
+++ b/src/state/slices/opportunitiesSlice/resolvers/thorchainsavers/utils.ts
@@ -51,8 +51,7 @@ const AFFILIATE_BPS = 0
 const usdcEthereumAssetId: AssetId = 'eip155:1/erc20:0xa0b86991c6218b36c1d19d4a2e9eb0ce3606eb48'
 const usdcAvalancheAssetId: AssetId =
   'eip155:43114/erc20:0xb97ef9ef8734c71904d8002f8b6bc66dd9c48a6e'
-export const usdtEthereumAssetId: AssetId =
-  'eip155:1/erc20:0xdac17f958d2ee523a2206206994597c13d831ec7'
+const usdtEthereumAssetId: AssetId = 'eip155:1/erc20:0xdac17f958d2ee523a2206206994597c13d831ec7'
 
 // The minimum amount to be sent both for deposit and withdraws
 // else it will be considered a dust attack and gifted to the network
@@ -66,6 +65,7 @@ export const THORCHAIN_SAVERS_DUST_THRESHOLDS = {
   [cosmosAssetId]: '0',
   [binanceAssetId]: '0',
   [usdcEthereumAssetId]: '0',
+  [usdtEthereumAssetId]: '0',
   [usdcAvalancheAssetId]: '0',
 }
 
@@ -78,6 +78,7 @@ const SUPPORTED_THORCHAIN_SAVERS_ASSET_IDS = [
   ltcAssetId,
   dogeAssetId,
   usdcEthereumAssetId,
+  usdtEthereumAssetId,
   usdcAvalancheAssetId,
 ]
 


### PR DESCRIPTION
fix: thorchain savers withdraw confirm (#5275)
feat: move from reacty to lazy savers withdraw input step (#5272)
feat: add USDT on Ethereum as supported savers AssetId (#5271)
feat: clear wallet AccountIds when uninstalling MM snap outside of the app (#5257)
fix: more reliable savers completion update p2 (#5255)
feat: pinky swear seed phrase is backed up on snap warning modal (#5260)