### PR TITLE
fix: isSnapinstalled console spew

### DIFF
--- a/src/hooks/useIsSnapInstalled/useIsSnapInstalled.tsx
+++ b/src/hooks/useIsSnapInstalled/useIsSnapInstalled.tsx
@@ -1,12 +1,21 @@
+import { MetaMaskShapeShiftMultiChainHDWallet } from '@shapeshiftoss/hdwallet-shapeshift-multichain'
 import { shapeShiftSnapInstalled } from '@shapeshiftoss/metamask-snaps-adapter'
 import { getConfig } from 'config'
 import { useEffect, useState } from 'react'
+import { useWallet } from 'hooks/useWallet/useWallet'
 
 export const useIsSnapInstalled = (): null | boolean => {
   const [isSnapInstalled, setIsSnapInstalled] = useState<null | boolean>(null)
   const POLL_INTERVAL = 3000 // tune me to make this "feel" right
 
+  const {
+    state: { wallet },
+  } = useWallet()
+
   useEffect(() => {
+    const isMetaMaskMultichainWallet = wallet instanceof MetaMaskShapeShiftMultiChainHDWallet
+    // We don't want to run this hook altogether if using any wallet other than MM
+    if (!isMetaMaskMultichainWallet) return
     const snapId = getConfig().REACT_APP_SNAP_ID
 
     const checkSnapInstallation = async () => {
@@ -22,7 +31,7 @@ export const useIsSnapInstalled = (): null | boolean => {
 
     // Clean up the interval when the component unmounts
     return () => clearInterval(intervalId)
-  }, [])
+  }, [wallet])
 
   return isSnapInstalled
 }


### PR DESCRIPTION
## Description

Gets reacty on `wallet` so that we don't run the `useIsSnapInstaller` effect altogether if the current HDWallet isn't a MM HDWallet.

This avoids:

1. Browsers without MM installed getting crazy console spew
2. Browsers without MM running an effect/interval they don't need to

## Pull Request Type

- [x] :bug: Bug fix (Non-breaking Change: Fixes an issue)
- [ ] :hammer_and_wrench: Chore (Non-breaking Change: Doc updates, pkg upgrades, typos, etc..)
- [ ] :nail_care: New Feature (Breaking/Non-breaking Change)

## Issue (if applicable)

<!-----------------------------------------------------------------------------
If applicable, please link to the github issue and put `closes #XXXX` in your comment to auto-close the issue that your PR fixes.
------------------------------------------------------------------------------>

closes #

## Risk

<!-----------------------------------------------------------------------------
Outline the scope of your changes and the risk associated with them. You must use your discretion as an engineer to determine the potential impact of your changes.

E.g. an upgrade to `hdwallet` or core state management would be considered higher risk, and might require a full regression test. UI or isolated view changes, or something behind a feature flag may have near zero risk. Small bug fixes might require testing isolated to the specific fix.
------------------------------------------------------------------------------>

- The snap installation detection might not run when it actually should. Test accordingly.

## Testing

<!-----------------------------------------------------------------------------
We treat every PR to be merged with the same scrutiny as if we were merging directly to production.

Your PR will not be merged if you do not complete the sections below for our engineering and operations teams to test.
------------------------------------------------------------------------------>

- Without MM installed, there is no snap installation checks console spew
- With MM installed, installation detection still works i.e:
  - Connecting the app to a MM with the snap installed detects the snap installation
  - Connecting the app to a MM without the snap installed correctly detect the snap isn't installed and prompt to install it
  -  Snap un/installation detection is still working
  
### Engineering

<!-----------------------------------------------------------------------------
Include sufficient information here for an engineer to test your PR. This may include how to test locally, in a built environment, changes to infrastructure etc.
------------------------------------------------------------------------------>

### Operations

<!-----------------------------------------------------------------------------
If your changes have a user-facing impact, describe how a non-technical QA team can functionally test your changes in a preview environment.

If they are not user-facing please describe how to test for any regressions that may occur.
------------------------------------------------------------------------------>

## Screenshots (if applicable)

- Connecting MM with the snap uninstalled

<img width="339" alt="image" src="https://github.com/shapeshift/web/assets/17035424/5629e962-cf6d-4ab4-88d5-55c524c8c5d3">
<img width="485" alt="image" src="https://github.com/shapeshift/web/assets/17035424/4eb643f0-955d-4206-b4df-023bf19b52e3">


- Connecting MM with the snap installed

<img width="342" alt="image" src="https://github.com/shapeshift/web/assets/17035424/a9e30cc4-b782-4e52-9f44-4d9350c61ca3">

- Snap installation detection

<img width="487" alt="image" src="https://github.com/shapeshift/web/assets/17035424/3df96312-830d-4a3d-a365-9bda79bf99ac">

- Snap uninstallation detection

<img width="521" alt="image" src="https://github.com/shapeshift/web/assets/17035424/4679d6be-70fe-43e2-890a-2307b6624374">