### PR TITLE
fix: walletconnect singletons should be instantiated once

### DIFF
--- a/src/plugins/walletConnectToDapps/v2/walletUtils.ts
+++ b/src/plugins/walletConnectToDapps/v2/walletUtils.ts
@@ -4,23 +4,25 @@ import type { IWeb3Wallet } from '@walletconnect/web3wallet'
 import { Web3Wallet } from '@walletconnect/web3wallet'
 import { getConfig } from 'config'
 
-let walletConnectWallet: IWeb3Wallet
+let walletConnectWallet: Promise<IWeb3Wallet>
 let core: ICore
 
 // WalletConnect Core singleton
 export const getWalletConnectCore = () => {
-  const walletConnectProjectId = getConfig().REACT_APP_WALLET_CONNECT_PROJECT_ID
-  core = new Core({
-    projectId: walletConnectProjectId,
-  })
+  if (!core) {
+    const walletConnectProjectId = getConfig().REACT_APP_WALLET_CONNECT_PROJECT_ID
+    core = new Core({
+      projectId: walletConnectProjectId,
+    })
+  }
 
   return core
 }
 
 // WalletConnect Web3Wallet singleton
-export const getWalletConnectWallet = async () => {
-  try {
-    walletConnectWallet = await Web3Wallet.init({
+export const getWalletConnectWallet = () => {
+  if (!walletConnectWallet) {
+    walletConnectWallet = Web3Wallet.init({
       core, // <- pass the shared `core` instance
       metadata: {
         name: 'ShapeShift',
@@ -30,13 +32,7 @@ export const getWalletConnectWallet = async () => {
         icons: ['https://app.shapeshift.com/icon-512x512.png'],
       },
     })
-  } catch (e) {
-    console.error(e)
   }
 
   return walletConnectWallet
-}
-
-export async function pair(params: { uri: string }) {
-  return await core.pairing.pair({ uri: params.uri })
 }


### PR DESCRIPTION
## Description

Ensures walletconnect v2 singletons are only instantiated once.

## Pull Request Type

- [x] :bug: Bug fix (Non-breaking Change: Fixes an issue)
- [ ] :hammer_and_wrench: Chore (Non-breaking Change: Doc updates, pkg upgrades, typos, etc..)
- [ ] :nail_care: New Feature (Breaking/Non-breaking Change)

## Issue (if applicable)

NA

## Risk

Risk of (even more) broken walletconnect v2

## Testing

NOTE: when testing, prefer you use https://react-app.walletconnect.com/ because most dApps have not implemented things on their side correctly which often throw testing off

NOTE: walletconnect v2 is known to be broken in several ways and this PR does not address that. Refer to #5285 for details.

* Check no changes in functionality from previous commit.

### Engineering

☝️

### Operations

☝️

## Screenshots (if applicable)

