### PR TITLE
fix: clear walletconnect v2 sessions when switching wallet

### DIFF
--- a/src/plugins/walletConnectToDapps/v2/utils/clearAllWalletConnectToDappsSessions.ts
+++ b/src/plugins/walletConnectToDapps/v2/utils/clearAllWalletConnectToDappsSessions.ts
@@ -1,0 +1,32 @@
+import { getSdkError } from '@walletconnect/utils'
+
+import { getWalletConnectWallet } from '../walletUtils'
+
+const clearWalletConnectLocalStorage = () => {
+  const keysToRemove: string[] = []
+
+  for (let i = 0; i < window.localStorage.length; i++) {
+    const key = window.localStorage.key(i) as string
+    if (key.startsWith('wc@2')) {
+      keysToRemove.push(key)
+    }
+  }
+
+  for (const key of keysToRemove) {
+    window.localStorage.removeItem(key)
+  }
+}
+
+export const clearAllWalletConnectToDappsSessions = async () => {
+  // fire disconnection events for all active sessions so other apps can disconnect
+  const web3wallet = await getWalletConnectWallet()
+  for (const session of Object.values(web3wallet.getActiveSessions())) {
+    void web3wallet.disconnectSession({
+      topic: session.topic,
+      reason: getSdkError('USER_DISCONNECTED'),
+    })
+  }
+
+  // catch-all, clear local storage
+  clearWalletConnectLocalStorage()
+}


### PR DESCRIPTION
## Description

Clears walletconnect v2 sessions when switching wallet.

## Pull Request Type

- [x] :bug: Bug fix (Non-breaking Change: Fixes an issue)
- [ ] :hammer_and_wrench: Chore (Non-breaking Change: Doc updates, pkg upgrades, typos, etc..)
- [ ] :nail_care: New Feature (Breaking/Non-breaking Change)

## Issue (if applicable)

closes #5269

## Risk

Risk of (even more) broken walletconnect v2

## Testing

NOTE: when testing, prefer you use https://react-app.walletconnect.com/ because most dApps have not implemented things on their side correctly which often throw testing off

NOTE: walletconnect v2 is known to be broken in several ways and this PR does not address that. Refer to #5285 for details.

1. connect walletconnect v2 session(s) https://react-app.walletconnect.com/
2. check refreshing page does not clear your sessions
3. check switching wallets clears your sessions

### Engineering

☝️

### Operations

☝️

## Screenshots (if applicable)
