### PR TITLE
fix: correction to walletconnect modal explorer links

### DIFF
--- a/src/plugins/walletConnectToDapps/components/modals/AddressSummaryCard.tsx
+++ b/src/plugins/walletConnectToDapps/components/modals/AddressSummaryCard.tsx
@@ -1,7 +1,6 @@
 import { Box, Card, HStack, useColorModeValue } from '@chakra-ui/react'
 import { CopyButton } from 'plugins/walletConnectToDapps/components/modals/CopyButton'
 import { ExternalLinkButton } from 'plugins/walletConnectToDapps/components/modals/ExternalLinkButtons'
-import { useWalletConnect } from 'plugins/walletConnectToDapps/v1/WalletConnectBridgeContext'
 import { MiddleEllipsis } from 'components/MiddleEllipsis/MiddleEllipsis'
 import { RawText } from 'components/Text'
 import { useWallet } from 'hooks/useWallet/useWallet'
@@ -9,19 +8,20 @@ import { useWallet } from 'hooks/useWallet/useWallet'
 type AddressSummaryCardProps = {
   address: string
   showWalletProviderName?: boolean
+  explorerAddressLink?: string
   icon?: React.ReactNode
 }
 
 export const AddressSummaryCard: React.FC<AddressSummaryCardProps> = ({
   address,
   icon,
+  explorerAddressLink,
   showWalletProviderName = true,
 }) => {
-  const { accountExplorerAddressLink } = useWalletConnect()
   const walletName = useWallet().state.walletInfo?.name ?? ''
   const bgColor = useColorModeValue('white', 'gray.850')
 
-  if (!accountExplorerAddressLink) return null
+  if (!explorerAddressLink) return null
 
   return (
     <Card bg={bgColor} py={4} pl={4} pr={2} borderRadius='md'>
@@ -40,7 +40,7 @@ export const AddressSummaryCard: React.FC<AddressSummaryCardProps> = ({
           )}
         </Box>
         <CopyButton value={address} />
-        <ExternalLinkButton href={`${accountExplorerAddressLink}${address}`} ariaLabel={address} />
+        <ExternalLinkButton href={`${explorerAddressLink}${address}`} ariaLabel={address} />
       </HStack>
     </Card>
   )

--- a/src/plugins/walletConnectToDapps/v2/components/modals/CosmosSignMessageConfirmation.tsx
+++ b/src/plugins/walletConnectToDapps/v2/components/modals/CosmosSignMessageConfirmation.tsx
@@ -23,12 +23,18 @@ import { useTranslate } from 'react-polyglot'
 import { FoxIcon } from 'components/Icons/FoxIcon'
 import { RawText, Text } from 'components/Text'
 import { useWallet } from 'hooks/useWallet/useWallet'
+import { selectFeeAssetByChainId } from 'state/slices/selectors'
+import { useAppSelector } from 'state/store'
 
 export const CosmosSignMessageConfirmationModal: FC<
   WalletConnectRequestModalProps<CosmosSignDirectCallRequest | CosmosSignAminoCallRequest>
 > = ({ onConfirm: handleConfirm, onReject: handleReject, state, topic }) => {
-  const { address } = useWalletConnectState(state)
+  const { address, chainId } = useWalletConnectState(state)
   const peerMetadata = state.sessionsByTopic[topic]?.peer.metadata
+
+  const connectedAccountFeeAsset = useAppSelector(state =>
+    selectFeeAssetByChainId(state, chainId ?? ''),
+  )
 
   const translate = useTranslate()
   const walletInfo = useWallet().state.walletInfo
@@ -124,7 +130,11 @@ export const CosmosSignMessageConfirmationModal: FC<
   return (
     <>
       <ModalSection title='plugins.walletConnectToDapps.modal.signMessage.signingFrom'>
-        <AddressSummaryCard address={address ?? ''} icon={<WalletIcon w='full' h='full' />} />
+        <AddressSummaryCard
+          address={address ?? ''}
+          icon={<WalletIcon w='full' h='full' />}
+          explorerAddressLink={connectedAccountFeeAsset?.explorerAddressLink}
+        />
       </ModalSection>
       <ModalSection title='plugins.walletConnectToDapps.modal.signMessage.requestFrom'>
         <Card bg={cardBg} borderRadius='md'>

--- a/src/plugins/walletConnectToDapps/v2/components/modals/EIP155SignMessageConfirmation.tsx
+++ b/src/plugins/walletConnectToDapps/v2/components/modals/EIP155SignMessageConfirmation.tsx
@@ -22,12 +22,18 @@ import { useTranslate } from 'react-polyglot'
 import { FoxIcon } from 'components/Icons/FoxIcon'
 import { RawText, Text } from 'components/Text'
 import { useWallet } from 'hooks/useWallet/useWallet'
+import { selectFeeAssetByChainId } from 'state/slices/selectors'
+import { useAppSelector } from 'state/store'
 
 export const EIP155SignMessageConfirmationModal: FC<
   WalletConnectRequestModalProps<EthSignCallRequest | EthPersonalSignCallRequest>
 > = ({ onConfirm: handleConfirm, onReject: handleReject, state, topic }) => {
-  const { address, message } = useWalletConnectState(state)
+  const { address, message, chainId } = useWalletConnectState(state)
   const peerMetadata = state.sessionsByTopic[topic]?.peer.metadata
+
+  const connectedAccountFeeAsset = useAppSelector(state =>
+    selectFeeAssetByChainId(state, chainId ?? ''),
+  )
 
   const translate = useTranslate()
   const walletInfo = useWallet().state.walletInfo
@@ -39,7 +45,11 @@ export const EIP155SignMessageConfirmationModal: FC<
   return (
     <>
       <ModalSection title='plugins.walletConnectToDapps.modal.signMessage.signingFrom'>
-        <AddressSummaryCard address={address ?? ''} icon={<WalletIcon w='full' h='full' />} />
+        <AddressSummaryCard
+          address={address ?? ''}
+          icon={<WalletIcon w='full' h='full' />}
+          explorerAddressLink={connectedAccountFeeAsset?.explorerAddressLink}
+        />
       </ModalSection>
       <ModalSection title='plugins.walletConnectToDapps.modal.signMessage.requestFrom'>
         <Card bg={cardBg} borderRadius='md'>

--- a/src/plugins/walletConnectToDapps/v2/components/modals/EIP155SignTypedDataConfirmation.tsx
+++ b/src/plugins/walletConnectToDapps/v2/components/modals/EIP155SignTypedDataConfirmation.tsx
@@ -11,12 +11,18 @@ import { FoxIcon } from 'components/Icons/FoxIcon'
 import { Text } from 'components/Text'
 import { useWallet } from 'hooks/useWallet/useWallet'
 import { assertIsDefined } from 'lib/utils'
+import { selectFeeAssetByChainId } from 'state/slices/selectors'
+import { useAppSelector } from 'state/store'
 
 export const EIP155SignTypedDataConfirmation: FC<
   WalletConnectRequestModalProps<EthSignTypedDataCallRequest>
 > = ({ onConfirm: handleConfirm, onReject: handleReject, state }) => {
-  const { address, message } = useWalletConnectState(state)
+  const { address, message, chainId } = useWalletConnectState(state)
   assertIsDefined(message)
+
+  const connectedAccountFeeAsset = useAppSelector(state =>
+    selectFeeAssetByChainId(state, chainId ?? ''),
+  )
 
   const translate = useTranslate()
   const walletInfo = useWallet().state.walletInfo
@@ -25,7 +31,11 @@ export const EIP155SignTypedDataConfirmation: FC<
   return (
     <>
       <ModalSection title='plugins.walletConnectToDapps.modal.signMessage.signingFrom'>
-        <AddressSummaryCard address={address ?? ''} icon={<WalletIcon w='full' h='full' />} />
+        <AddressSummaryCard
+          address={address ?? ''}
+          icon={<WalletIcon w='full' h='full' />}
+          explorerAddressLink={connectedAccountFeeAsset?.explorerAddressLink}
+        />
       </ModalSection>
       <TypedMessageInfo typedData={message} />
       <Text

--- a/src/plugins/walletConnectToDapps/v2/components/modals/EIP155TransactionConfirmation.tsx
+++ b/src/plugins/walletConnectToDapps/v2/components/modals/EIP155TransactionConfirmation.tsx
@@ -36,11 +36,18 @@ import { CircularProgress } from 'components/CircularProgress/CircularProgress'
 import { FoxIcon } from 'components/Icons/FoxIcon'
 import { Text } from 'components/Text'
 import { useWallet } from 'hooks/useWallet/useWallet'
+import { selectFeeAssetByChainId } from 'state/slices/selectors'
+import { useAppSelector } from 'state/store'
 
 export const EIP155TransactionConfirmation: FC<
   WalletConnectRequestModalProps<EthSendTransactionCallRequest | EthSignTransactionCallRequest>
 > = ({ onConfirm: handleConfirm, onReject: handleReject, state }) => {
-  const { address, transaction, isInteractingWithContract, method } = useWalletConnectState(state)
+  const { address, transaction, isInteractingWithContract, method, chainId } =
+    useWalletConnectState(state)
+
+  const connectedAccountFeeAsset = useAppSelector(state =>
+    selectFeeAssetByChainId(state, chainId ?? ''),
+  )
 
   transaction && assertIsTransactionParams(transaction)
 
@@ -79,7 +86,11 @@ export const EIP155TransactionConfirmation: FC<
   return (
     <FormProvider {...form}>
       <ModalSection title='plugins.walletConnectToDapps.modal.sendTransaction.sendingFrom'>
-        <AddressSummaryCard address={address ?? ''} icon={<WalletIcon w='full' h='full' />} />
+        <AddressSummaryCard
+          address={address ?? ''}
+          icon={<WalletIcon w='full' h='full' />}
+          explorerAddressLink={connectedAccountFeeAsset?.explorerAddressLink}
+        />
       </ModalSection>
       <ModalSection
         title={`plugins.walletConnectToDapps.modal.sendTransaction.${
@@ -90,6 +101,7 @@ export const EIP155TransactionConfirmation: FC<
           address={transaction.to}
           showWalletProviderName={false}
           icon={<Image borderRadius='full' w='full' h='full' src={feeAsset?.icon} />}
+          explorerAddressLink={feeAsset?.explorerAddressLink}
         />
       </ModalSection>
       {isInteractingWithContract ? (

--- a/src/plugins/walletConnectToDapps/v2/walletUtils.ts
+++ b/src/plugins/walletConnectToDapps/v2/walletUtils.ts
@@ -23,7 +23,7 @@ export const getWalletConnectCore = () => {
 export const getWalletConnectWallet = () => {
   if (!walletConnectWallet) {
     walletConnectWallet = Web3Wallet.init({
-      core, // <- pass the shared `core` instance
+      core: getWalletConnectCore(), // <- pass the shared `core` instance
       metadata: {
         name: 'ShapeShift',
         description:


### PR DESCRIPTION
## Description

Fixes explorer links for walletconnect v2.

## Pull Request Type

- [x] :bug: Bug fix (Non-breaking Change: Fixes an issue)
- [ ] :hammer_and_wrench: Chore (Non-breaking Change: Doc updates, pkg upgrades, typos, etc..)
- [ ] :nail_care: New Feature (Breaking/Non-breaking Change)

## Issue (if applicable)

NA

## Risk

* risk of (still) broken walletconnect v2 explorer links

## Testing

1. connect wallet connect to https://react-app.walletconnect.com/
2. click `eth_sendTransaction`
3. in the modal in web, click the explorer link - it should link to the correct explorer for the chain

### Engineering☝️



### Operations

☝️

## Screenshots (if applicable)
