### PR TITLE
feat: filter NFT spammy domains

### DIFF
--- a/src/state/apis/nft/constants.ts
+++ b/src/state/apis/nft/constants.ts
@@ -1,7 +1,6 @@
-// List of domains to check for
-
 import type { NftItem } from './types'
 
+// List of domains to check for
 // Try to be as broad as possible vs. specific here to accommodate for diff. TLDs and subdomains
 const NFT_DOMAINS_BLACKLIST = ['ethercb']
 const NFT_NAME_BLACKLIST = [

--- a/src/state/apis/nft/constants.ts
+++ b/src/state/apis/nft/constants.ts
@@ -1,3 +1,9 @@
+// List of domains to check for
+
+import type { NftItem } from './types'
+
+// Try to be as broad as possible vs. specific here to accommodate for diff. TLDs and subdomains
+const NFT_DOMAINS_BLACKLIST = ['ethercb']
 const NFT_NAME_BLACKLIST = [
   'voucher',
   'airdrop',
@@ -26,6 +32,10 @@ const nftNameBlacklistRegex = new RegExp(
   'i',
 )
 export const isSpammyNftText = (nftText: string) => nftNameBlacklistRegex.test(nftText)
+const isSpammyDomain = (domain: string) =>
+  NFT_DOMAINS_BLACKLIST.some(blacklistedDomain => domain.includes(blacklistedDomain))
+export const hasSpammyMedias = (medias: NftItem['medias']) =>
+  medias.some(media => isSpammyDomain(media.originalUrl))
 export const BLACKLISTED_COLLECTION_IDS = [
   'eip155:137/erc1155:0x30825b65e775678997c7fbc5831ab492c697448e',
   'eip155:137/erc1155:0x4217495f2a128da8d6122d120a1657753823721a',

--- a/src/state/apis/nft/nftApi.ts
+++ b/src/state/apis/nft/nftApi.ts
@@ -175,7 +175,7 @@ export const nftApi = createApi({
   reducerPath: 'nftApi',
   endpoints: build => ({
     getNftUserTokens: build.query<NftItem[], GetNftUserTokensInput>({
-      queryFn: async ({ accountIds }, { dispatch, getState }) => {
+      queryFn: async ({ accountIds }, { dispatch }) => {
         const services = [
           getAlchemyNftsUserData,
           (accountIds: AccountId[]) =>

--- a/src/state/apis/nft/nftApi.ts
+++ b/src/state/apis/nft/nftApi.ts
@@ -258,14 +258,8 @@ export const nftApi = createApi({
         dispatch(nft.actions.upsertNfts({ byId: nftsById, ids: Object.keys(nftsById) }))
 
         const collectionsById = nftsWithCollection.reduce<NftState['collections']['byId']>(
-          (acc, _item) => {
-            const item = cloneDeep(_item)
+          (acc, item) => {
             if (!item.collection.assetId) return acc
-            const cachedCollection = selectNftCollectionById(state, item.collection.assetId)
-            if (cachedCollection?.isSpam) item.collection.isSpam = true
-            if (hasSpammyMedias(item.medias)) item.collection.isSpam = true
-            if ([item.description, item.name, item.symbol].some(isSpammyNftText))
-              item.collection.isSpam = true
             acc[item.collection.assetId] = item.collection
             return acc
           },

--- a/src/state/apis/nft/nftApi.ts
+++ b/src/state/apis/nft/nftApi.ts
@@ -7,7 +7,6 @@ import cloneDeep from 'lodash/cloneDeep'
 import { PURGE } from 'redux-persist'
 import type { PartialRecord } from 'lib/utils'
 import { isRejected } from 'lib/utils'
-import type { ReduxState } from 'state/reducer'
 import type { AssetsState } from 'state/slices/assetsSlice/assetsSlice'
 import { assets as assetsSlice, makeAsset } from 'state/slices/assetsSlice/assetsSlice'
 import { portfolio as portfolioSlice } from 'state/slices/portfolioSlice/portfolioSlice'
@@ -18,7 +17,6 @@ import { BASE_RTK_CREATE_API_CONFIG } from '../const'
 import { covalentApi } from '../covalent/covalentApi'
 import { zapperApi } from '../zapper/zapperApi'
 import { BLACKLISTED_COLLECTION_IDS, hasSpammyMedias, isSpammyNftText } from './constants'
-import { selectNftCollectionById } from './selectors'
 import type { NftCollectionType, NftItem, NftItemWithCollection } from './types'
 import {
   getAlchemyCollectionData,
@@ -178,8 +176,6 @@ export const nftApi = createApi({
   endpoints: build => ({
     getNftUserTokens: build.query<NftItem[], GetNftUserTokensInput>({
       queryFn: async ({ accountIds }, { dispatch, getState }) => {
-        const state = getState() as ReduxState
-
         const services = [
           getAlchemyNftsUserData,
           (accountIds: AccountId[]) =>

--- a/src/state/apis/nft/nftApi.ts
+++ b/src/state/apis/nft/nftApi.ts
@@ -17,7 +17,7 @@ import { initialState as initialPortfolioState } from 'state/slices/portfolioSli
 import { BASE_RTK_CREATE_API_CONFIG } from '../const'
 import { covalentApi } from '../covalent/covalentApi'
 import { zapperApi } from '../zapper/zapperApi'
-import { BLACKLISTED_COLLECTION_IDS, isSpammyNftText } from './constants'
+import { BLACKLISTED_COLLECTION_IDS, hasSpammyMedias, isSpammyNftText } from './constants'
 import { selectNftCollectionById } from './selectors'
 import type { NftCollectionType, NftItem, NftItemWithCollection } from './types'
 import {
@@ -210,6 +210,7 @@ export const nftApi = createApi({
               data.forEach(item => {
                 const { assetId } = item
                 if (item.collection.isSpam) return
+                if (hasSpammyMedias(item.medias)) return
                 if ([item.collection.description, item.name, item.symbol].some(isSpammyNftText))
                   return
                 const { assetReference, chainId } = fromAssetId(assetId)
@@ -262,6 +263,7 @@ export const nftApi = createApi({
             if (!item.collection.assetId) return acc
             const cachedCollection = selectNftCollectionById(state, item.collection.assetId)
             if (cachedCollection?.isSpam) item.collection.isSpam = true
+            if (hasSpammyMedias(item.medias)) item.collection.isSpam = true
             if ([item.description, item.name, item.symbol].some(isSpammyNftText))
               item.collection.isSpam = true
             acc[item.collection.assetId] = item.collection


### PR DESCRIPTION
## Description


This PR filters NFTs which have spammy domains medias, to avoid encountering the Chrome red security screen when images are fetched for NFTs/assets.

## Pull Request Type

- [ ] :bug: Bug fix (Non-breaking Change: Fixes an issue)
- [ ] :hammer_and_wrench: Chore (Non-breaking Change: Doc updates, pkg upgrades, typos, etc..)
- [x] :nail_care: New Feature (Breaking/Non-breaking Change)

## Issue (if applicable)

<!-----------------------------------------------------------------------------
If applicable, please link to the github issue and put `closes #XXXX` in your comment to auto-close the issue that your PR fixes.
------------------------------------------------------------------------------>

contributes to the closed https://github.com/shapeshift/web/issues/5301

## Risk

<!-----------------------------------------------------------------------------
Outline the scope of your changes and the risk associated with them. You must use your discretion as an engineer to determine the potential impact of your changes.

E.g. an upgrade to `hdwallet` or core state management would be considered higher risk, and might require a full regression test. UI or isolated view changes, or something behind a feature flag may have near zero risk. Small bug fixes might require testing isolated to the specific fix.
------------------------------------------------------------------------------>

None

## Testing

<!-----------------------------------------------------------------------------
We treat every PR to be merged with the same scrutiny as if we were merging directly to production.

Your PR will not be merged if you do not complete the sections below for our engineering and operations teams to test.
------------------------------------------------------------------------------>

- Apply the diff below to disable the current filtering of spammy NFTs

```diff
diff --git a/src/state/apis/nft/constants.ts b/src/state/apis/nft/constants.ts
index 85d1454752..a7e3eb8170 100644
--- a/src/state/apis/nft/constants.ts
+++ b/src/state/apis/nft/constants.ts
@@ -4,26 +4,7 @@ import type { NftItem } from './types'
 
 // Try to be as broad as possible vs. specific here to accommodate for diff. TLDs and subdomains
 const NFT_DOMAINS_BLACKLIST = ['ethercb']
-const NFT_NAME_BLACKLIST = [
-  'voucher',
-  'airdrop',
-  'giveaway',
-  'promo',
-  'airdrop',
-  'rewards',
-  'ticket',
-  'winner',
-  '$',
-  'pirategirls',
-  'USDC',
-  'USDT',
-  'calim cryptopunk',
-  'coupon',
-  'bonus',
-  'claim',
-  'etherscan',
-  'shibarium',
-]
+const NFT_NAME_BLACKLIST = ['nothingtoseehere']
 
 // This escapes special characters we may encounter in NFTS, so we can add them to the blacklist
 // e.g "$9999+ free giveaway *limited time only*" would not work without it
@@ -36,25 +17,4 @@ const isSpammyDomain = (domain: string) =>
   NFT_DOMAINS_BLACKLIST.some(blacklistedDomain => domain.includes(blacklistedDomain))
 export const hasSpammyMedias = (medias: NftItem['medias']) =>
   medias.some(media => isSpammyDomain(media.originalUrl))
-export const BLACKLISTED_COLLECTION_IDS = [
-  'eip155:137/erc1155:0x30825b65e775678997c7fbc5831ab492c697448e',
-  'eip155:137/erc1155:0x4217495f2a128da8d6122d120a1657753823721a',
-  'eip155:137/erc1155:0x54e75b47353a5ded078d8eb6ba67ff01a2a18ef7',
-  'eip155:137/erc1155:0x7d33048b74c24d695d349e73a59b7de3ed50c4c0',
-  'eip155:137/erc1155:0xb1cfea0eb0f67a50b896985bda6368fc1c21907b',
-  'eip155:137/erc1155:0xc165d899628c5fd74e19c91de596a9ea2f3599ec',
-  'eip155:137/erc1155:0xcf2576238640a3a232fa6046d549dfb753a805f4',
-  'eip155:137/erc1155:0xcf63b89da7c6ada007fbef13fa1e8453756ba7a6',
-  'eip155:137/erc1155:0xda8091a96aefcc2bec5ed64eb2e18008ebf7806c',
-  'eip155:137/erc1155:0xe0b7dafe2eb86ad56386676a61781d863144db1e',
-  'eip155:137/erc1155:0xed13387ea51efb26b1281bd6decc352141fd312a',
-  'eip155:137/erc1155:0xf02521228c6250b255abbc4ea66fd5aa86aa2ce0',
-  'eip155:137/erc1155:0xf30437ad7d081046b4931e29460fcb0d7bbaca46',
-  'eip155:137/erc1155:0xfd920bd499511d0f5e37b4405a7986a4d6f1abe3',
-  'eip155:137/erc1155:0x55d50a035bc5830dac9f1a42b71c48cbad568d60',
-  'eip155:137/erc1155:0x5620a667cbe1eb7e1e27087d135881a546456ebb',
-  'eip155:137/erc1155:0x1b6ff968f954fef75a82c0f47364eb00c3643d17',
-  'eip155:137/erc1155:0x5df82d6f8dc0a697d2785953a40735b33e3b1f50',
-  'eip155:137/erc1155:0x71c7c713aaf6b129ebeb29d00647b6cc39e4f9f9',
-  'eip155:137/erc1155:0xabda1f46fe8ad6b08aa9505702144522c511038f',
-]
+export const BLACKLISTED_COLLECTION_IDS = []
```

- Ensure the $ETH NFT is filtered and we're not hitting the scammy domain

### Engineering

<!-----------------------------------------------------------------------------
Include sufficient information here for an engineer to test your PR. This may include how to test locally, in a built environment, changes to infrastructure etc.
------------------------------------------------------------------------------>

- ☝🏽 

### Operations

<!-----------------------------------------------------------------------------
If your changes have a user-facing impact, describe how a non-technical QA team can functionally test your changes in a preview environment.

If they are not user-facing please describe how to test for any regressions that may occur.
------------------------------------------------------------------------------>

- Ensure you still can't see the $ETH scammy NFT that's causing red chrome

## Screenshots (if applicable)

- With the diff above applied, and without this PR diff

<img width="345" alt="Screenshot 2023-09-19 at 14 19 04" src="https://github.com/shapeshift/web/assets/17035424/0a7ec6d2-1eab-4980-ae9c-7d200623e158">
<img width="1017" alt="Screenshot 2023-09-19 at 14 18 57" src="https://github.com/shapeshift/web/assets/17035424/209648b0-cf0b-49f9-a1db-927e08de494a">

- With this diff, as well as the diff above applied

<img width="270" alt="Screenshot 2023-09-19 at 14 23 14" src="https://github.com/shapeshift/web/assets/17035424/2c1c1aed-2489-4b34-829d-d3c6e56bdf79">
<img width="1392" alt="Screenshot 2023-09-19 at 14 22 51" src="https://github.com/shapeshift/web/assets/17035424/37bcab39-3850-4d03-bf75-2cdecf2cc3fb">