### PR TITLE
feat: don't display portfolio balances if no asset data

### DIFF
--- a/src/state/slices/portfolioSlice/selectors.ts
+++ b/src/state/slices/portfolioSlice/selectors.ts
@@ -462,17 +462,22 @@ export const selectPortfolioAccountsUserCurrencyBalancesIncludingStaking =
       const userCurrencyAccountEntries = Object.entries(portfolioAccountsCryptoBalances).reduce<{
         [k: AccountId]: { [k: AssetId]: string }
       }>((acc, [accountId, account]) => {
-        const entries: [AssetId, BigNumber][] = Object.entries(account).map(
-          ([assetId, cryptoBalance]) => {
+        const entries: [AssetId, BigNumber][] = Object.entries(account).reduce(
+          (acc: [AssetId, BigNumber][], [assetId, cryptoBalance]) => {
             const asset = assets?.[assetId]
-            if (!asset) return [assetId, bn(0)]
+            if (!asset) return acc
+
             const { precision } = asset
             const price = marketData[assetId]?.price ?? 0
-            return [
+            const calculatedValue: [AssetId, BigNumber] = [
               assetId,
               bnOrZero(fromBaseUnit(bnOrZero(cryptoBalance), precision)).times(price),
             ]
+
+            acc.push(calculatedValue)
+            return acc
           },
+          [],
         )
 
         const fiatAccountSorted = Object.fromEntries(


### PR DESCRIPTION
## Description

What may have been an edge case before, i.e having portfolio balances, but no matching asset data, is now a common occurence with NFTs blacklist/filtering.

This PR ensures that when the matching asset data is missing for a given portfolio balance, we don't parse it in `selectPortfolioAccountsUserCurrencyBalancesIncludingStaking`, and consequentially don't display it as a wallet asset row.

## Pull Request Type

- [ ] :bug: Bug fix (Non-breaking Change: Fixes an issue)
- [ ] :hammer_and_wrench: Chore (Non-breaking Change: Doc updates, pkg upgrades, typos, etc..)
- [x] :nail_care: New Feature (Breaking/Non-breaking Change)
## Issue (if applicable)

<!-----------------------------------------------------------------------------
If applicable, please link to the github issue and put `closes #XXXX` in your comment to auto-close the issue that your PR fixes.
------------------------------------------------------------------------------>

contributes to the closed https://github.com/shapeshift/web/issues/5301

## Risk

<!-----------------------------------------------------------------------------
Outline the scope of your changes and the risk associated with them. You must use your discretion as an engineer to determine the potential impact of your changes.

E.g. an upgrade to `hdwallet` or core state management would be considered higher risk, and might require a full regression test. UI or isolated view changes, or something behind a feature flag may have near zero risk. Small bug fixes might require testing isolated to the specific fix.
------------------------------------------------------------------------------>

When developing e.g new chains, we might not be able to see portfolio asset rows until the integration is done e2e, including assets support.


## Testing

<!-----------------------------------------------------------------------------
We treat every PR to be merged with the same scrutiny as if we were merging directly to production.

Your PR will not be merged if you do not complete the sections below for our engineering and operations teams to test.
------------------------------------------------------------------------------>

- Ensure blacklisted jaypegs don't appear as empty wallet holdings (i.e rows with no name/symbol) under wallet.

### Engineering

<!-----------------------------------------------------------------------------
Include sufficient information here for an engineer to test your PR. This may include how to test locally, in a built environment, changes to infrastructure etc.
------------------------------------------------------------------------------>

- ☝🏽 

### Operations

<!-----------------------------------------------------------------------------
If your changes have a user-facing impact, describe how a non-technical QA team can functionally test your changes in a preview environment.

If they are not user-facing please describe how to test for any regressions that may occur.
------------------------------------------------------------------------------>

- ☝🏽 

## Screenshots (if applicable)

- This diff

<img width="483" alt="image" src="https://github.com/shapeshift/web/assets/17035424/b9788112-ce7b-4ce8-8b19-51ea1bc21516">

- Release

<img width="431" alt="image" src="https://github.com/shapeshift/web/assets/17035424/6dc9d27d-d21b-48e6-9bbb-9ad80d228a10">