### PR TITLE
perf: only upsert once when fetching accounts on app boot

### DIFF
--- a/src/state/apis/nft/nftApi.ts
+++ b/src/state/apis/nft/nftApi.ts
@@ -120,6 +120,8 @@ const upsertPortfolioAndAssets = createAsyncThunk<void, PortfolioAndAssetsUpsert
     })
 
     dispatch(assetsSlice.actions.upsertAssets(assetsToUpsert))
+
+    // TODO: combine responses and upsert once with `upsertPortfolios`
     dispatch(portfolioSlice.actions.upsertPortfolio(portfolio))
   },
 )

--- a/src/state/slices/portfolioSlice/portfolioSlice.ts
+++ b/src/state/slices/portfolioSlice/portfolioSlice.ts
@@ -101,6 +101,21 @@ export const portfolio = createSlice({
       // add the `action.meta[SHOULD_AUTOBATCH]` field the enhancer needs
       prepare: prepareAutoBatched<Portfolio>(),
     },
+
+    upsertPortfolios: (draftState, { payload }: { payload: Portfolio[] }) => {
+      // upsert all
+      draftState.accounts.byId = merge(
+        draftState.accounts.byId,
+        ...payload.map(portfolio => portfolio.accounts.byId),
+      )
+      draftState.accounts.ids = Object.keys(draftState.accounts.byId)
+
+      draftState.accountBalances.byId = merge(
+        draftState.accountBalances.byId,
+        ...payload.map(portfolio => portfolio.accountBalances.byId),
+      )
+      draftState.accountBalances.ids = Object.keys(draftState.accountBalances.byId)
+    },
   },
   extraReducers: builder => builder.addCase(PURGE, () => initialState),
 })


### PR DESCRIPTION
## Description

Reduces the number of redux state changes when loading the portfolios across all accounts for a given wallet.

## Pull Request Type

- [ ] :bug: Bug fix (Non-breaking Change: Fixes an issue)
- [x] :hammer_and_wrench: Chore (Non-breaking Change: Doc updates, pkg upgrades, typos, etc..)
- [ ] :nail_care: New Feature (Breaking/Non-breaking Change)

## Issue (if applicable)

NA

## Risk

High risk, may result in incorrect portfolio data being loaded at wallet load.

## Testing

Check the following:
* wallets not supporting multi-account only load single portfolio of data and correct balances for all chains
* wallets supporting multi-account load all accounts and correct balances for all chains
* correct account metadata is loaded for all accounts

### Engineering

High risk change, appreciate ultra high focus and rigor testing this one 🙏

### Operations

High risk change, appreciate ultra high focus and rigor testing this one 🙏

## Screenshots (if applicable)
