### PR TITLE
perf: only upsert once when fetching asset price history

### DIFF
--- a/package.json
+++ b/package.json
@@ -121,6 +121,7 @@
     "allsettled-polyfill": "^1.0.4",
     "axios": "^0.26.1",
     "axios-cache-adapter": "^2.7.3",
+    "axios-cache-interceptor": "^1.3.0",
     "bignumber.js": "^9.1.1",
     "bip21": "^2.0.3",
     "bip39": "^3.0.4",

--- a/src/components/TransactionHistoryRows/hooks.tsx
+++ b/src/components/TransactionHistoryRows/hooks.tsx
@@ -18,7 +18,7 @@ export const useTradeFees = ({ txDetails }: { txDetails: TxDetails }) => {
     selectCryptoPriceHistoryTimeframe(state, HistoryTimeframe.ALL),
   )
 
-  const { findPriceHistoryByAssetId } = marketApi.endpoints
+  const { findPriceHistoryByAssetIds } = marketApi.endpoints
 
   const buy = useMemo(
     () => txDetails.transfers.find(transfer => transfer.type === TransferType.Receive),
@@ -34,19 +34,14 @@ export const useTradeFees = ({ txDetails }: { txDetails: TxDetails }) => {
     if (!(txDetails.tx.trade && buy && sell)) return
     if (txDetails.tx.trade.dexName !== Dex.CowSwap) return
 
-    if (!cryptoPriceHistoryData?.[buy.asset.assetId]) {
-      dispatch(
-        findPriceHistoryByAssetId.initiate({
-          assetId: buy.asset.assetId,
-          timeframe: HistoryTimeframe.ALL,
-        }),
-      )
-    }
+    const assetIds = []
+    if (!cryptoPriceHistoryData?.[buy.asset.assetId]) assetIds.push(buy.asset.assetId)
+    if (!cryptoPriceHistoryData?.[sell.asset.assetId]) assetIds.push(sell.asset.assetId)
 
-    if (!cryptoPriceHistoryData?.[sell.asset.assetId]) {
+    if (assetIds.length > 0) {
       dispatch(
-        findPriceHistoryByAssetId.initiate({
-          assetId: sell.asset.assetId,
+        findPriceHistoryByAssetIds.initiate({
+          assetIds,
           timeframe: HistoryTimeframe.ALL,
         }),
       )
@@ -60,7 +55,7 @@ export const useTradeFees = ({ txDetails }: { txDetails: TxDetails }) => {
     })
 
     setTradeFees(tradeFees)
-  }, [dispatch, buy, sell, cryptoPriceHistoryData, findPriceHistoryByAssetId, txDetails.tx])
+  }, [dispatch, buy, sell, cryptoPriceHistoryData, findPriceHistoryByAssetIds, txDetails.tx])
 
   return { tradeFees }
 }

--- a/src/context/AppProvider/AppContext.tsx
+++ b/src/context/AppProvider/AppContext.tsx
@@ -273,10 +273,14 @@ export const AppProvider = ({ children }: { children: React.ReactNode }) => {
     // const opts = { subscriptionOptions: { pollingInterval } }
     const timeframe = DEFAULT_HISTORY_TIMEFRAME
 
+    dispatch(
+      marketApi.endpoints.findPriceHistoryByAssetIds.initiate({
+        timeframe,
+        assetIds: portfolioAssetIdsExcludeNoMarketData,
+      }),
+    )
     portfolioAssetIdsExcludeNoMarketData.forEach(assetId => {
       dispatch(marketApi.endpoints.findByAssetId.initiate(assetId))
-      const payload = { assetId, timeframe }
-      dispatch(marketApi.endpoints.findPriceHistoryByAssetId.initiate(payload))
     })
   }, [dispatch, portfolioLoadingStatus, portfolioAssetIds, uniV2LpIdsData.data])
 

--- a/src/hooks/useFetchPriceHistories/useFetchPriceHistories.ts
+++ b/src/hooks/useFetchPriceHistories/useFetchPriceHistories.ts
@@ -16,12 +16,11 @@ export const useFetchPriceHistories: UseFetchPriceHistories = ({ assetIds, timef
   const dispatch = useAppDispatch()
   const symbol = useAppSelector(selectSelectedCurrency)
 
-  const { findPriceHistoryByAssetId, findPriceHistoryByFiatSymbol } = marketApi.endpoints
+  const { findPriceHistoryByAssetIds, findPriceHistoryByFiatSymbol } = marketApi.endpoints
   useEffect(
-    () =>
-      assetIds.forEach(assetId =>
-        dispatch(findPriceHistoryByAssetId.initiate({ assetId, timeframe })),
-      ),
+    () => {
+      dispatch(findPriceHistoryByAssetIds.initiate({ assetIds, timeframe }))
+    },
     // assetIds ref changes, prevent infinite render
     // eslint-disable-next-line react-hooks/exhaustive-deps
     [assetIds, dispatch, timeframe],

--- a/src/lib/account/account.ts
+++ b/src/lib/account/account.ts
@@ -24,7 +24,7 @@ export type DeriveAccountIdsAndMetadata = (
   args: DeriveAccountIdsAndMetadataArgs,
 ) => DeriveAccountIdsAndMetadataReturn
 
-export const deriveAccountIdsAndMetadata: DeriveAccountIdsAndMetadata = async args => {
+export const deriveAccountIdsAndMetadata: DeriveAccountIdsAndMetadata = args => {
   const { accountNumber, chainIds, wallet } = args
   if (!Number.isInteger(accountNumber) || accountNumber < 0)
     throw new Error('invalid accountNumber')
@@ -45,14 +45,13 @@ export const deriveAccountIdsAndMetadata: DeriveAccountIdsAndMetadata = async ar
     return acc
   }, initial)
 
-  const result = await Promise.all(
-    Object.entries(chainIdsByChainNamespace).map(([chainNamespace, chainIds]) =>
-      deriveAccountIdsAndMetadataForChainNamespace[chainNamespace as ChainNamespaceKey]({
-        accountNumber,
-        chainIds,
-        wallet,
-      }),
-    ),
+  const result = Object.entries(chainIdsByChainNamespace).map(([chainNamespace, chainIds]) =>
+    deriveAccountIdsAndMetadataForChainNamespace[chainNamespace as ChainNamespaceKey]({
+      accountNumber,
+      chainIds,
+      wallet,
+    }),
   )
+
   return merge({}, ...result)
 }

--- a/src/lib/market-service/coincap/coincap.ts
+++ b/src/lib/market-service/coincap/coincap.ts
@@ -19,7 +19,7 @@ import { DEFAULT_CACHE_TTL_MS } from '../config'
 import { isValidDate } from '../utils/isValidDate'
 import type { CoinCapMarketCap } from './coincap-types'
 
-const axios = setupCache(Axios.create(), { ttl: DEFAULT_CACHE_TTL_MS })
+const axios = setupCache(Axios.create(), { ttl: DEFAULT_CACHE_TTL_MS, cacheTakeover: false })
 
 export class CoinCapMarketService implements MarketService {
   baseUrl = 'https://api.coincap.io/v2'

--- a/src/lib/market-service/coincap/coincap.ts
+++ b/src/lib/market-service/coincap/coincap.ts
@@ -8,14 +8,18 @@ import type {
   PriceHistoryArgs,
 } from '@shapeshiftoss/types'
 import { HistoryTimeframe } from '@shapeshiftoss/types'
-import axios from 'axios'
+import Axios from 'axios'
+import { setupCache } from 'axios-cache-interceptor'
 import dayjs from 'dayjs'
 import omit from 'lodash/omit'
 import { bn, bnOrZero } from 'lib/bignumber/bignumber'
 
 import type { MarketService } from '../api'
+import { DEFAULT_CACHE_TTL_MS } from '../config'
 import { isValidDate } from '../utils/isValidDate'
 import type { CoinCapMarketCap } from './coincap-types'
+
+const axios = setupCache(Axios.create(), { ttl: DEFAULT_CACHE_TTL_MS })
 
 export class CoinCapMarketService implements MarketService {
   baseUrl = 'https://api.coincap.io/v2'

--- a/src/lib/market-service/coingecko/coingecko.ts
+++ b/src/lib/market-service/coingecko/coingecko.ts
@@ -28,7 +28,7 @@ type CoinGeckoHistoryData = {
   prices: [number, number][]
 }
 
-const axios = setupCache(Axios.create(), { ttl: DEFAULT_CACHE_TTL_MS })
+const axios = setupCache(Axios.create(), { ttl: DEFAULT_CACHE_TTL_MS, cacheTakeover: false })
 
 export class CoinGeckoMarketService implements MarketService {
   private readonly maxPerPage = 250

--- a/src/lib/market-service/coingecko/coingecko.ts
+++ b/src/lib/market-service/coingecko/coingecko.ts
@@ -8,11 +8,13 @@ import type {
   PriceHistoryArgs,
 } from '@shapeshiftoss/types'
 import { HistoryTimeframe } from '@shapeshiftoss/types'
-import axios from 'axios'
+import Axios from 'axios'
+import { setupCache } from 'axios-cache-interceptor'
 import dayjs from 'dayjs'
 import { bn, bnOrZero } from 'lib/bignumber/bignumber'
 
 import type { MarketService } from '../api'
+import { DEFAULT_CACHE_TTL_MS } from '../config'
 import { isValidDate } from '../utils/isValidDate'
 import type { CoinGeckoMarketCap, CoinGeckoMarketData } from './coingecko-types'
 
@@ -25,6 +27,8 @@ type CoinGeckoAssetData = {
 type CoinGeckoHistoryData = {
   prices: [number, number][]
 }
+
+const axios = setupCache(Axios.create(), { ttl: DEFAULT_CACHE_TTL_MS })
 
 export class CoinGeckoMarketService implements MarketService {
   private readonly maxPerPage = 250

--- a/src/lib/market-service/config.ts
+++ b/src/lib/market-service/config.ts
@@ -5,3 +5,4 @@ export const RATE_LIMIT_THRESHOLDS_PER_MINUTE = {
 }
 
 export const DEFAULT_RATE_LIMITER_INTERVAL_IN_MS = 60000
+export const DEFAULT_CACHE_TTL_MS = 1000 * 5 // 5 seconds

--- a/src/lib/market-service/exchange-rates-host/exchange-rates-host.ts
+++ b/src/lib/market-service/exchange-rates-host/exchange-rates-host.ts
@@ -1,11 +1,13 @@
 import type { HistoryData, MarketData } from '@shapeshiftoss/types'
 import { HistoryTimeframe } from '@shapeshiftoss/types'
-import axios from 'axios'
+import Axios from 'axios'
+import { setupCache } from 'axios-cache-interceptor'
 import type { Dayjs } from 'dayjs'
 import dayjs from 'dayjs'
 import { bnOrZero } from 'lib/bignumber/bignumber'
 
 import type { FiatMarketService } from '../api'
+import { DEFAULT_CACHE_TTL_MS } from '../config'
 import type {
   FiatMarketDataArgs,
   FiatPriceHistoryArgs,
@@ -14,6 +16,8 @@ import type {
 import type { ExchangeRateHostHistoryData, ExchangeRateHostRate } from './exchange-rates-host-types'
 
 const baseCurrency = 'USD'
+
+const axios = setupCache(Axios.create(), { ttl: DEFAULT_CACHE_TTL_MS })
 
 export const makeExchangeRateRequestUrls = (
   start: Dayjs,

--- a/src/lib/market-service/exchange-rates-host/exchange-rates-host.ts
+++ b/src/lib/market-service/exchange-rates-host/exchange-rates-host.ts
@@ -17,7 +17,7 @@ import type { ExchangeRateHostHistoryData, ExchangeRateHostRate } from './exchan
 
 const baseCurrency = 'USD'
 
-const axios = setupCache(Axios.create(), { ttl: DEFAULT_CACHE_TTL_MS })
+const axios = setupCache(Axios.create(), { ttl: DEFAULT_CACHE_TTL_MS, cacheTakeover: false })
 
 export const makeExchangeRateRequestUrls = (
   start: Dayjs,

--- a/src/state/apis/fiatRamps/hooks.ts
+++ b/src/state/apis/fiatRamps/hooks.ts
@@ -11,9 +11,13 @@ export const useFetchFiatAssetMarketData = (): void => {
   useEffect(() => {
     const timeframe = HistoryTimeframe.DAY
     const assetIds = Object.keys(data?.byAssetId ?? {})
+
+    if (assetIds.length > 0) {
+      dispatch(marketApi.endpoints.findPriceHistoryByAssetIds.initiate({ assetIds, timeframe }))
+    }
+
     assetIds.forEach(assetId => {
       dispatch(marketApi.endpoints.findByAssetId.initiate(assetId))
-      dispatch(marketApi.endpoints.findPriceHistoryByAssetId.initiate({ assetId, timeframe }))
     })
   }, [data, dispatch])
 }

--- a/src/state/slices/marketDataSlice/marketDataSlice.tsx
+++ b/src/state/slices/marketDataSlice/marketDataSlice.tsx
@@ -185,6 +185,7 @@ export const marketApi = createApi({
 
               return { assetId, historyData }
             } catch (e) {
+              console.error(e)
               return { assetId, historyData: [] }
             }
           }),

--- a/src/state/slices/marketDataSlice/marketDataSlice.tsx
+++ b/src/state/slices/marketDataSlice/marketDataSlice.tsx
@@ -92,9 +92,12 @@ export const marketData = createSlice({
     },
     setCryptoPriceHistory: {
       reducer: (state, { payload }: { payload: CryptoPriceHistoryPayload }) => {
+        const { timeframe, historyDataByAssetId } = payload
         const incoming = {
           crypto: {
-            priceHistory: payload,
+            priceHistory: {
+              [timeframe]: historyDataByAssetId,
+            },
           },
         }
         merge(state, incoming)

--- a/src/state/slices/marketDataSlice/types.ts
+++ b/src/state/slices/marketDataSlice/types.ts
@@ -22,4 +22,4 @@ export type MarketDataState = {
   fiat: FiatMarketDataState
 }
 
-export type FindPriceHistoryByAssetIdArgs = { assetId: AssetId; timeframe: HistoryTimeframe }
+export type FindPriceHistoryByAssetIdArgs = { assetIds: AssetId[]; timeframe: HistoryTimeframe }

--- a/yarn.lock
+++ b/yarn.lock
@@ -8087,6 +8087,7 @@ __metadata:
     assert: ^2.0.0
     axios: ^0.26.1
     axios-cache-adapter: ^2.7.3
+    axios-cache-interceptor: ^1.3.0
     bignumber.js: ^9.1.1
     bip21: ^2.0.3
     bip39: ^3.0.4
@@ -12397,6 +12398,19 @@ __metadata:
   languageName: node
   linkType: hard
 
+"axios-cache-interceptor@npm:^1.3.0":
+  version: 1.3.0
+  resolution: "axios-cache-interceptor@npm:1.3.0"
+  dependencies:
+    cache-parser: ^1.2.4
+    fast-defer: ^1.1.7
+    object-code: ^1.3.0
+  peerDependencies:
+    axios: ^1
+  checksum: 000138670d97a9bcddf996a4c1b87f186712c9bd4a1ac2ef7a0d49ee1965110923343226596e7419f153945f46ab1aece6fef64aca53836312f3949f4a674aca
+  languageName: node
+  linkType: hard
+
 "axios@npm:0.21.1":
   version: 0.21.1
   resolution: "axios@npm:0.21.1"
@@ -13557,6 +13571,13 @@ __metadata:
   version: 1.0.0
   resolution: "cache-control-esm@npm:1.0.0"
   checksum: 4f8c8399f2b15ad43c635d14b80aadd9de039f09fa56c4686aca828f82e57c1fc479026db1786dea1ba1026415dab0fe463938be4a6110874d3bf3aa7a60d0f3
+  languageName: node
+  linkType: hard
+
+"cache-parser@npm:^1.2.4":
+  version: 1.2.4
+  resolution: "cache-parser@npm:1.2.4"
+  checksum: de9fc4ab7af318109f1e53474e674d43997bc7b8676157e4f28e7dc60fda2f434ee138aa9d9abb9f849c55e73202ee74865afaa4e00298de70c4326510680c19
   languageName: node
   linkType: hard
 
@@ -18093,6 +18114,13 @@ __metadata:
   version: 3.1.3
   resolution: "fast-deep-equal@npm:3.1.3"
   checksum: e21a9d8d84f53493b6aa15efc9cfd53dd5b714a1f23f67fb5dc8f574af80df889b3bce25dc081887c6d25457cce704e636395333abad896ccdec03abaf1f3f9d
+  languageName: node
+  linkType: hard
+
+"fast-defer@npm:^1.1.7":
+  version: 1.1.7
+  resolution: "fast-defer@npm:1.1.7"
+  checksum: c0f816fe3f83ca7e12c56a6631c6819a50349fb7e1931cec88e883168b523c65605e6e0df32c8fba6c341860c29ecc6fe2531ba8a418d27d31da6544ad1bf45b
   languageName: node
   linkType: hard
 
@@ -23707,6 +23735,13 @@ __metadata:
   version: 4.1.1
   resolution: "object-assign@npm:4.1.1"
   checksum: fcc6e4ea8c7fe48abfbb552578b1c53e0d194086e2e6bbbf59e0a536381a292f39943c6e9628af05b5528aa5e3318bb30d6b2e53cadaf5b8fe9e12c4b69af23f
+  languageName: node
+  linkType: hard
+
+"object-code@npm:^1.3.0":
+  version: 1.3.0
+  resolution: "object-code@npm:1.3.0"
+  checksum: bc5e3df85ac54785b3d1d9b8a9b2e168eb5f69e02be3c958fc05aebaa85ec659c55903852bf15ebf44e98053212f88eb7d3a9e28a50f10c4d60d820f80aa8d64
   languageName: node
   linkType: hard
 


### PR DESCRIPTION
## Description

Improves local app performance by minimizing the number of redux state updates during app boot.

## Pull Request Type

- [ ] :bug: Bug fix (Non-breaking Change: Fixes an issue)
- [x] :hammer_and_wrench: Chore (Non-breaking Change: Doc updates, pkg upgrades, typos, etc..)
- [ ] :nail_care: New Feature (Breaking/Non-breaking Change)

## Issue (if applicable)

NA

## Risk

Moderate risk change affecting how asset price history is loaded during app boot.

## Testing

Clear cache and check that asset prices are loaded correctly.

### Engineering

☝️

### Operations

☝️

## Screenshots (if applicable)

The following shows performance improvement locally. Please note that the performance improvement in production will be far less noticeable.

Develop (local) - 1.43s:
![image](https://github.com/shapeshift/web/assets/125113430/567c0bf7-5dd1-41a3-8c51-9645645a1773)

This Pr (local) - 0.75s:
![image](https://github.com/shapeshift/web/assets/125113430/59686288-7b8e-4c09-b1de-ec85588f0f85)
