### PR TITLE
perf: only upsert once when fetching asset market data

### DIFF
--- a/src/context/AppProvider/AppContext.tsx
+++ b/src/context/AppProvider/AppContext.tsx
@@ -287,7 +287,7 @@ export const AppProvider = ({ children }: { children: React.ReactNode }) => {
 
       // used to trigger mixpanel init after load of market data
       dispatch(marketData.actions.setMarketDataLoaded())
-    })
+    })()
   }, [dispatch, portfolioLoadingStatus, portfolioAssetIds, uniV2LpIdsData.data])
 
   /**

--- a/src/hooks/useMixpanelPortfolioTracking/useMixpanelPortfolioTracking.tsx
+++ b/src/hooks/useMixpanelPortfolioTracking/useMixpanelPortfolioTracking.tsx
@@ -1,38 +1,21 @@
-import { QueryStatus } from '@reduxjs/toolkit/dist/query'
 import { useEffect, useState } from 'react'
-import { createSelector } from 'reselect'
 import { useWallet } from 'hooks/useWallet/useWallet'
 import { getMixPanel } from 'lib/mixpanel/mixPanelSingleton'
-import type { ReduxState } from 'state/reducer'
 import { selectWalletId } from 'state/slices/common-selectors'
-import { marketApi } from 'state/slices/marketDataSlice/marketDataSlice'
+import { selectIsMarketDataLoaded } from 'state/slices/marketDataSlice/selectors'
 import {
   selectCurrencyFormat,
   selectPortfolioAnonymized,
-  selectPortfolioAssetIds,
   selectSelectedCurrency,
   selectSelectedLocale,
 } from 'state/slices/selectors'
 import { useAppSelector } from 'state/store'
 
-// define selector here to avoid circular imports, specific to this hook below
-const selectMarketDataLoaded = createSelector(
-  (s: ReduxState) => s,
-  selectPortfolioAssetIds,
-  (state, assetIds): boolean => {
-    if (!assetIds.length) return false
-    // for every asset in the portfolio, has market data loaded, either fulfilled or rejected
-    return assetIds
-      .map(assetId => marketApi.endpoints.findByAssetId.select(assetId)(state))
-      .every(result => [QueryStatus.fulfilled, QueryStatus.rejected].includes(result.status))
-  },
-)
-
 export const useMixpanelPortfolioTracking = () => {
   const anonymizedPortfolio = useAppSelector(selectPortfolioAnonymized)
   const [isTracked, setIsTracked] = useState(false)
   const { isDemoWallet } = useWallet().state
-  const isMarketDataLoaded = useAppSelector(selectMarketDataLoaded)
+  const isMarketDataLoaded = useAppSelector(selectIsMarketDataLoaded)
   const walletId = useAppSelector(selectWalletId)
   const selectedLocale = useAppSelector(selectSelectedLocale)
   const selectedCurrency = useAppSelector(selectSelectedCurrency)

--- a/src/state/apis/fiatRamps/hooks.ts
+++ b/src/state/apis/fiatRamps/hooks.ts
@@ -14,10 +14,7 @@ export const useFetchFiatAssetMarketData = (): void => {
 
     if (assetIds.length > 0) {
       dispatch(marketApi.endpoints.findPriceHistoryByAssetIds.initiate({ assetIds, timeframe }))
+      dispatch(marketApi.endpoints.findByAssetIds.initiate(assetIds))
     }
-
-    assetIds.forEach(assetId => {
-      dispatch(marketApi.endpoints.findByAssetId.initiate(assetId))
-    })
   }, [data, dispatch])
 }

--- a/src/state/apis/swappers/swappersApi.ts
+++ b/src/state/apis/swappers/swappersApi.ts
@@ -42,8 +42,9 @@ export const swappersApi = createApi({
         if (!sellAssetUsdRate) throw Error('missing sellAssetUsdRate')
 
         // Await market data fetching thunk, to ensure we can display some USD rate and don't bail in getDependencies above
-        await dispatch(marketApi.endpoints.findByAssetId.initiate(sellAsset.assetId))
-        await dispatch(marketApi.endpoints.findByAssetId.initiate(buyAsset.assetId))
+        await dispatch(
+          marketApi.endpoints.findByAssetIds.initiate([sellAsset.assetId, buyAsset.assetId]),
+        )
 
         // We use the sell amount so we don't have to make 2 network requests, as the receive amount requires a quote
         const isDonationAmountBelowMinimum = getIsDonationAmountBelowMinimum(

--- a/src/state/slices/marketDataSlice/marketDataSlice.tsx
+++ b/src/state/slices/marketDataSlice/marketDataSlice.tsx
@@ -36,6 +36,7 @@ const initialState: MarketDataState = {
     ids: [],
     priceHistory: {},
   },
+  isMarketDataLoaded: false,
 }
 
 const shouldIgnoreAsset = (assetId: AssetId | string): boolean => {
@@ -63,6 +64,9 @@ export const marketData = createSlice({
   initialState,
   reducers: {
     clear: () => initialState,
+    setMarketDataLoaded: state => {
+      state.isMarketDataLoaded = true
+    },
     setCryptoMarketData: {
       reducer: (state, { payload }: { payload: MarketDataById<AssetId> }) => {
         state.crypto.byId = Object.assign(state.crypto.byId, payload) // upsert
@@ -153,22 +157,38 @@ export const marketApi = createApi({
         }
       },
     }),
-    findByAssetId: build.query<MarketCapResult, AssetId>({
-      queryFn: async (assetId: AssetId, { dispatch }) => {
-        try {
-          const currentMarketData = await getMarketServiceManager().findByAssetId({ assetId })
-          if (!currentMarketData) throw new Error()
-          const data = { [assetId]: currentMarketData }
-          dispatch(marketData.actions.setCryptoMarketData(data))
-          return { data }
-        } catch (e) {
-          const error = { data: `findByAssetId: no market data for ${assetId}`, status: 404 }
-          return { error }
-        }
+    findByAssetIds: build.query<null, AssetId[]>({
+      // named function for profiling+debugging purposes
+      queryFn: async function findByAssetIds(assetIds: AssetId[], { dispatch }) {
+        if (assetIds.length === 0) return { data: null }
+
+        const responseData = await Promise.all(
+          assetIds.map(async assetId => {
+            try {
+              const currentMarketData = await getMarketServiceManager().findByAssetId({ assetId })
+              return { assetId, currentMarketData }
+            } catch (e) {
+              return { assetId, currentMarketData: null }
+            }
+          }),
+        )
+
+        const payload = responseData.reduce<MarketCapResult>(
+          (acc, { assetId, currentMarketData }) => {
+            if (currentMarketData) acc[assetId] = currentMarketData
+            return acc
+          },
+          {},
+        )
+
+        dispatch(marketData.actions.setCryptoMarketData(payload))
+
+        return { data: null }
       },
       keepUnusedDataFor: 5, // Invalidate cached asset market data after 5 seconds.
     }),
     findPriceHistoryByAssetIds: build.query<null, FindPriceHistoryByAssetIdArgs>({
+      // named function for profiling+debugging purposes
       queryFn: async function findPriceHistoryByAssetIds(args, { dispatch }) {
         const { assetIds, timeframe } = args
 
@@ -247,7 +267,7 @@ export const marketApi = createApi({
 })
 
 export const {
-  useFindByAssetIdQuery,
+  useFindByAssetIdsQuery,
   useFindAllQuery,
   useFindByFiatSymbolQuery,
   useFindPriceHistoryByFiatSymbolQuery,

--- a/src/state/slices/marketDataSlice/marketDataSlice.tsx
+++ b/src/state/slices/marketDataSlice/marketDataSlice.tsx
@@ -168,6 +168,7 @@ export const marketApi = createApi({
               const currentMarketData = await getMarketServiceManager().findByAssetId({ assetId })
               return { assetId, currentMarketData }
             } catch (e) {
+              console.error(e)
               return { assetId, currentMarketData: null }
             }
           }),

--- a/src/state/slices/marketDataSlice/selectors.ts
+++ b/src/state/slices/marketDataSlice/selectors.ts
@@ -86,6 +86,7 @@ export const selectMarketDataByFilter = createCachedSelector(
 
 export const selectCryptoPriceHistory = (state: ReduxState) => state.marketData.crypto.priceHistory
 export const selectFiatPriceHistory = (state: ReduxState) => state.marketData.fiat.priceHistory
+export const selectIsMarketDataLoaded = (state: ReduxState) => state.marketData.isMarketDataLoaded
 
 export const selectPriceHistoryByAssetTimeframe = createCachedSelector(
   selectCryptoPriceHistory,

--- a/src/state/slices/marketDataSlice/types.ts
+++ b/src/state/slices/marketDataSlice/types.ts
@@ -20,6 +20,7 @@ export type CryptoMarketDataState = MarketDataStateVariant<AssetId>
 export type MarketDataState = {
   crypto: CryptoMarketDataState
   fiat: FiatMarketDataState
+  isMarketDataLoaded: boolean
 }
 
 export type FindPriceHistoryByAssetIdArgs = { assetIds: AssetId[]; timeframe: HistoryTimeframe }

--- a/src/test/mocks/store.ts
+++ b/src/test/mocks/store.ts
@@ -122,6 +122,7 @@ export const mockStore: ReduxState = {
       ids: [],
       priceHistory: {},
     },
+    isMarketDataLoaded: false,
   },
   txHistory: {
     txs: {


### PR DESCRIPTION
## Description

Improves local app performance by minimizing the number of redux state updates during app boot.
## Pull Request Type

- [ ] :bug: Bug fix (Non-breaking Change: Fixes an issue)
- [x] :hammer_and_wrench: Chore (Non-breaking Change: Doc updates, pkg upgrades, typos, etc..)
- [ ] :nail_care: New Feature (Breaking/Non-breaking Change)

## Issue (if applicable)

NA

## Risk

Moderate risk change affecting how asset prices are loaded during app boot.

## Testing

Clear cache and check that asset prices are loaded correctly.

### Engineering

☝️

### Operations

☝️

## Screenshots (if applicable)

The following shows performance improvement locally. Please note that the performance improvement in production will be far less noticeable.

Develop (local) - 1.43s:
![image](https://github.com/shapeshift/web/assets/125113430/55b88854-aeb9-49ee-a779-04ae53efd6b8)

This PR (local) - 0.04s:
![image](https://github.com/shapeshift/web/assets/125113430/91c2d169-03ea-4d19-ab34-2c61e244bc06)


