### PR TITLE
fix: move key prop to top-level element

### DIFF
--- a/src/pages/ConnectWallet/ConnectWallet.tsx
+++ b/src/pages/ConnectWallet/ConnectWallet.tsx
@@ -112,9 +112,9 @@ export const ConnectWallet = () => {
 
   const renderChains = useMemo(() => {
     return allNativeAssets.map(asset => (
-      <Tooltip label={asset.networkName}>
+      <Tooltip key={asset.assetId} label={asset.networkName}>
         <span>
-          <AssetIcon key={asset.assetId} src={asset.networkIcon ?? asset.icon} size='sm' />
+          <AssetIcon src={asset.networkIcon ?? asset.icon} size='sm' />
         </span>
       </Tooltip>
     ))


### PR DESCRIPTION
## Description

Move key to top-level element, preventing React unique key error from logging.

## Pull Request Type

- [x] :bug: Bug fix (Non-breaking Change: Fixes an issue)
- [ ] :hammer_and_wrench: Chore (Non-breaking Change: Doc updates, pkg upgrades, typos, etc..)
- [ ] :nail_care: New Feature (Breaking/Non-breaking Change)

## Issue (if applicable)

N/A

## Risk

Very small.

## Testing

This should have no impact, with nothing to test.

### Engineering

☝️

### Operations

☝️

## Screenshots (if applicable)

<img width="806" alt="Screenshot 2023-09-20 at 9 43 25 am" src="https://github.com/shapeshift/web/assets/97164662/f9b5b5a0-9360-4b14-933b-98f48f489ff2">
