### PR TITLE
perf: fetch all staking opportunities metadata in a single rtk query request

### DIFF
--- a/src/context/AppProvider/AppContext.tsx
+++ b/src/context/AppProvider/AppContext.tsx
@@ -243,6 +243,10 @@ export const AppProvider = ({ children }: { children: React.ReactNode }) => {
           default:
         }
       })
+
+      // const uniqueChainIds = Array.from(
+      //   new Set(requestedAccountIds.map(accountId => fromAccountId(accountId).chainId)),
+      // )
     })()
   }, [
     portfolioLoadingStatus,

--- a/src/context/AppProvider/AppContext.tsx
+++ b/src/context/AppProvider/AppContext.tsx
@@ -37,6 +37,7 @@ import {
   marketData,
   useFindAllQuery,
 } from 'state/slices/marketDataSlice/marketDataSlice'
+import { foxEthLpAssetId } from 'state/slices/opportunitiesSlice/constants'
 import { opportunitiesApi } from 'state/slices/opportunitiesSlice/opportunitiesApiSlice'
 import {
   fetchAllOpportunitiesIdsByChainId,
@@ -48,6 +49,8 @@ import { portfolio, portfolioApi } from 'state/slices/portfolioSlice/portfolioSl
 import { preferences } from 'state/slices/preferencesSlice/preferencesSlice'
 import {
   selectAssetIds,
+  selectIsMarketDataLoaded,
+  selectMarketDataById,
   selectPortfolioAccounts,
   selectPortfolioAssetIds,
   selectPortfolioLoadingStatus,
@@ -82,6 +85,7 @@ export const AppProvider = ({ children }: { children: React.ReactNode }) => {
   const routeAssetId = useRouteAssetId()
   const DynamicLpAssets = useFeatureFlag('DynamicLpAssets')
   const isSnapInstalled = useIsSnapInstalled()
+  const isMarketDataLoaded = useAppSelector(selectIsMarketDataLoaded)
 
   // track anonymous portfolio
   useMixpanelPortfolioTracking()
@@ -188,10 +192,13 @@ export const AppProvider = ({ children }: { children: React.ReactNode }) => {
     })()
   }, [dispatch, requestedAccountIds, portfolioLoadingStatus])
 
+  const lpTokenMarketData = useAppSelector(state => selectMarketDataById(state, foxEthLpAssetId))
+  console.log(lpTokenMarketData)
+
   // once portfolio is loaded, fetch remaining chain specific data
   useEffect(() => {
     ;(async () => {
-      if (portfolioLoadingStatus === 'loading') return
+      if (portfolioLoadingStatus === 'loading' || !isMarketDataLoaded) return
 
       const { getFoxyRebaseHistoryByAccountId } = txHistoryApi.endpoints
 
@@ -251,6 +258,7 @@ export const AppProvider = ({ children }: { children: React.ReactNode }) => {
     dispatch,
     requestedAccountIds,
     portfolioAssetIds,
+    isMarketDataLoaded,
   ])
 
   const uniV2LpIdsData = useAppSelector(

--- a/src/context/AppProvider/AppContext.tsx
+++ b/src/context/AppProvider/AppContext.tsx
@@ -243,10 +243,6 @@ export const AppProvider = ({ children }: { children: React.ReactNode }) => {
           default:
         }
       })
-
-      // const uniqueChainIds = Array.from(
-      //   new Set(requestedAccountIds.map(accountId => fromAccountId(accountId).chainId)),
-      // )
     })()
   }, [
     portfolioLoadingStatus,

--- a/src/state/slices/opportunitiesSlice/mappings.ts
+++ b/src/state/slices/opportunitiesSlice/mappings.ts
@@ -7,7 +7,6 @@ import {
   ethChainId,
   ltcChainId,
 } from '@shapeshiftoss/caip'
-import pipe from 'lodash/flow'
 
 import {
   cosmosSdkOpportunityIdsResolver,
@@ -185,95 +184,47 @@ export const CHAIN_ID_TO_SUPPORTED_DEFI_OPPORTUNITIES = {
   ],
 }
 
-// Single opportunity metadata resolvers
-// "Give me the resolvers for a given DeFi provider"
-export const getDefiProviderMetadataResolvers = (defiProvider: DefiProvider) =>
-  DefiProviderToMetadataResolverByDeFiType[defiProvider]
-// "Give me the resolvers for a given DeFi type"
-export const getDefiTypeMetadataResolvers = (
-  defiType: DefiType,
-  resolversByType: ReturnType<typeof getDefiProviderMetadataResolvers>,
-) => resolversByType?.[defiType]
-
 export const getMetadataResolversByDefiProviderAndDefiType = (
   defiProvider: DefiProvider,
   defiType: DefiType,
-) =>
-  pipe(
-    getDefiProviderMetadataResolvers,
-    getDefiTypeMetadataResolvers.bind(this, defiType),
-  )(defiProvider)
-
-// Many opportunity metadata resolvers
-// "Give me the resolvers for a given DeFi provider"
-export const getDefiProviderOpportunitiesMetadataResolvers = (defiProvider: DefiProvider) =>
-  DefiProviderToOpportunitiesMetadataResolverByDeFiType[defiProvider]
-// "Give me the resolvers for a given DeFi type"
-export const getDefiTypeOpportunitiesMetadataResolvers = (
-  defiType: DefiType,
-  resolversByType: ReturnType<typeof getDefiProviderOpportunitiesMetadataResolvers>,
-) => resolversByType?.[defiType]
+) => {
+  const resolversByType = DefiProviderToMetadataResolverByDeFiType[defiProvider]
+  const resolver = resolversByType?.[defiType]
+  return resolver
+}
 
 export const getOpportunitiesMetadataResolversByDefiProviderAndDefiType = (
   defiProvider: DefiProvider,
   defiType: DefiType,
-) =>
-  pipe(
-    getDefiProviderOpportunitiesMetadataResolvers,
-    getDefiTypeOpportunitiesMetadataResolvers.bind(this, defiType),
-  )(defiProvider)
-
-// "Give me the resolvers for a given DeFi provider"
-export const getDefiProviderUserDataResolvers = (defiProvider: DefiProvider) =>
-  DefiProviderToUserDataResolverByDeFiType[defiProvider]
-// "Give me the resolvers for a given DeFi type"
-export const getDefiTypeUserDataResolvers = (
-  defiType: DefiType,
-  resolversByType: ReturnType<typeof getDefiProviderUserDataResolvers>,
-) => resolversByType?.[defiType]
+) => {
+  const resolversByType = DefiProviderToOpportunitiesMetadataResolverByDeFiType[defiProvider]
+  const resolver = resolversByType?.[defiType]
+  return resolver
+}
 
 export const getUserDataResolversByDefiProviderAndDefiType = (
   defiProvider: DefiProvider,
   defiType: DefiType,
-) =>
-  pipe(
-    getDefiProviderUserDataResolvers,
-    getDefiTypeUserDataResolvers.bind(this, defiType),
-  )(defiProvider)
-
-// "Give me the resolvers for a given DeFi provider"
-export const getDefiProviderOpportunitiesUserDataResolvers = (defiProvider: DefiProvider) =>
-  DefiProviderToOpportunitiesUserDataResolverByDeFiType[defiProvider]
-// "Give me the resolvers for a given DeFi type"
-export const getDefiTypeOpportunitiesUserDataResolvers = (
-  defiType: DefiType,
-  resolversByType: ReturnType<typeof getDefiProviderOpportunitiesUserDataResolvers>,
-) => resolversByType?.[defiType]
+) => {
+  const resolversByType = DefiProviderToUserDataResolverByDeFiType[defiProvider]
+  const resolver = resolversByType?.[defiType]
+  return resolver
+}
 
 export const getOpportunitiesUserDataResolversByDefiProviderAndDefiType = (
   defiProvider: DefiProvider,
   defiType: DefiType,
-) =>
-  pipe(
-    getDefiProviderOpportunitiesUserDataResolvers,
-    getDefiTypeOpportunitiesUserDataResolvers.bind(this, defiType),
-  )(defiProvider)
-
-// "Give me the resolvers for a given DeFi provider"
-export const getDefiProviderOpportunityIdsResolvers = (defiProvider: DefiProvider) =>
-  DefiProviderToOpportunityIdsResolverByDeFiType[defiProvider]
-
-// "Give me the resolvers for a given DeFi type"
-export const getDefiTypeOpportunityIdsResolvers = (
-  defiType: DefiType,
-  resolversByType: ReturnType<typeof getDefiProviderOpportunityIdsResolvers>,
-) => resolversByType?.[defiType]
+) => {
+  const resolversByType = DefiProviderToOpportunitiesUserDataResolverByDeFiType[defiProvider]
+  const resolver = resolversByType?.[defiType]
+  return resolver
+}
 
 export const getOpportunityIdsResolversByDefiProviderAndDefiType = (
   defiProvider: DefiProvider,
   defiType: DefiType,
-) =>
-  pipe(
-    getDefiProviderOpportunityIdsResolvers,
-    getDefiTypeOpportunityIdsResolvers.bind(this, defiType),
-  )(defiProvider)
+) => {
+  const resolversByType = DefiProviderToOpportunityIdsResolverByDeFiType[defiProvider]
+  const resolver = resolversByType?.[defiType]
+  return resolver
+}

--- a/src/state/slices/opportunitiesSlice/opportunitiesApiSlice.ts
+++ b/src/state/slices/opportunitiesSlice/opportunitiesApiSlice.ts
@@ -90,7 +90,8 @@ export const opportunitiesApi = createApi({
               const resolver = getMetadataResolversByDefiProviderAndDefiType(defiProvider, defiType)
 
               if (!resolver) {
-                throw new Error(`resolver for ${defiProvider}::${defiType} not implemented`)
+                console.warn(`resolver for ${defiProvider}::${defiType} not implemented`)
+                return
               }
 
               const resolved = await resolver({
@@ -127,7 +128,8 @@ export const opportunitiesApi = createApi({
               )
 
               if (!resolver) {
-                throw new Error(`resolver for ${defiProvider}::${defiType} not implemented`)
+                console.warn(`resolver for ${defiProvider}::${defiType} not implemented`)
+                return
               }
 
               const resolved = await resolver({

--- a/src/state/slices/opportunitiesSlice/opportunitiesApiSlice.ts
+++ b/src/state/slices/opportunitiesSlice/opportunitiesApiSlice.ts
@@ -16,7 +16,6 @@ import type {
   GetOpportunityIdsInput,
   GetOpportunityIdsOutput,
   GetOpportunityMetadataInput,
-  GetOpportunityMetadataOutput,
   GetOpportunityUserDataInput,
   GetOpportunityUserDataOutput,
   OpportunityDataById,
@@ -83,70 +82,69 @@ export const opportunitiesApi = createApi({
         }
       },
     }),
-    getOpportunityMetadata: build.query<GetOpportunityMetadataOutput, GetOpportunityMetadataInput>({
-      queryFn: async ({ opportunityId, defiType, defiProvider }, { dispatch, getState }) => {
-        try {
-          const resolver = getMetadataResolversByDefiProviderAndDefiType(defiProvider, defiType)
+    getOpportunityMetadata: build.query<null, GetOpportunityMetadataInput[]>({
+      queryFn: async (queries, { dispatch, getState }) => {
+        await Promise.allSettled(
+          queries.map(async ({ opportunityId, defiType, defiProvider }) => {
+            try {
+              const resolver = getMetadataResolversByDefiProviderAndDefiType(defiProvider, defiType)
 
-          if (!resolver) {
-            throw new Error(`resolver for ${defiProvider}::${defiType} not implemented`)
-          }
+              if (!resolver) {
+                throw new Error(`resolver for ${defiProvider}::${defiType} not implemented`)
+              }
 
-          const resolved = await resolver({
-            opportunityId,
-            defiType,
-            reduxApi: { dispatch, getState },
-          })
+              const resolved = await resolver({
+                opportunityId,
+                defiType,
+                reduxApi: { dispatch, getState },
+              })
 
-          dispatch(opportunities.actions.upsertOpportunitiesMetadata(resolved.data))
+              dispatch(opportunities.actions.upsertOpportunitiesMetadata(resolved.data))
+            } catch (e) {
+              const message = e instanceof Error ? e.message : 'Error getting opportunity metadata'
+              console.error(message)
+            }
+          }),
+        )
 
-          return { data: resolved.data }
-        } catch (e) {
-          const message = e instanceof Error ? e.message : 'Error getting opportunity metadata'
-          return {
-            error: {
-              error: message,
-              status: 'CUSTOM_ERROR',
-            },
-          }
-        }
+        return { data: null }
       },
     }),
     getOpportunitiesMetadata: build.query<
-      GetOpportunityMetadataOutput,
-      Omit<GetOpportunityMetadataInput, 'opportunityId'>
+      null,
+      Omit<GetOpportunityMetadataInput, 'opportunityId'>[]
     >({
-      queryFn: async ({ defiType, defiProvider }, { dispatch, getState }) => {
-        try {
-          const opportunityIds = getOpportunityIds({ defiProvider, defiType }, { getState })
+      queryFn: async (queries, { dispatch, getState }) => {
+        await Promise.allSettled(
+          queries.map(async ({ defiType, defiProvider }) => {
+            try {
+              const opportunityIds = getOpportunityIds({ defiProvider, defiType }, { getState })
 
-          const resolver = getOpportunitiesMetadataResolversByDefiProviderAndDefiType(
-            defiProvider,
-            defiType,
-          )
+              const resolver = getOpportunitiesMetadataResolversByDefiProviderAndDefiType(
+                defiProvider,
+                defiType,
+              )
 
-          if (!resolver) {
-            throw new Error(`resolver for ${defiProvider}::${defiType} not implemented`)
-          }
+              if (!resolver) {
+                throw new Error(`resolver for ${defiProvider}::${defiType} not implemented`)
+              }
 
-          const resolved = await resolver({
-            opportunityIds,
-            defiType,
-            reduxApi: { dispatch, getState },
-          })
+              const resolved = await resolver({
+                opportunityIds,
+                defiType,
+                reduxApi: { dispatch, getState },
+              })
 
-          dispatch(opportunities.actions.upsertOpportunitiesMetadata(resolved.data))
+              dispatch(opportunities.actions.upsertOpportunitiesMetadata(resolved.data))
+            } catch (e) {
+              const message =
+                e instanceof Error ? e.message : 'Error getting opportunities metadata'
+              console.error(message)
+            }
+          }),
+        )
 
-          return { data: resolved.data }
-        } catch (e) {
-          const message = e instanceof Error ? e.message : 'Error getting opportunities metadata'
-          return {
-            error: {
-              error: message,
-              status: 'CUSTOM_ERROR',
-            },
-          }
-        }
+        return { data: null }
       },
     }),
     getOpportunityUserData: build.query<GetOpportunityUserDataOutput, GetOpportunityUserDataInput>({

--- a/src/state/slices/opportunitiesSlice/opportunitiesApiSlice.ts
+++ b/src/state/slices/opportunitiesSlice/opportunitiesApiSlice.ts
@@ -99,6 +99,7 @@ export const opportunitiesApi = createApi({
                 reduxApi: { dispatch, getState },
               })
 
+              // TODO: collect and dispatch once to improve perf locally
               dispatch(opportunities.actions.upsertOpportunitiesMetadata(resolved.data))
             } catch (e) {
               const message = e instanceof Error ? e.message : 'Error getting opportunity metadata'
@@ -135,6 +136,7 @@ export const opportunitiesApi = createApi({
                 reduxApi: { dispatch, getState },
               })
 
+              // TODO: collect and dispatch once to improve perf locally
               dispatch(opportunities.actions.upsertOpportunitiesMetadata(resolved.data))
             } catch (e) {
               const message =

--- a/src/state/slices/opportunitiesSlice/thunks.ts
+++ b/src/state/slices/opportunitiesSlice/thunks.ts
@@ -16,21 +16,14 @@ export const fetchAllLpOpportunitiesMetadataByChainId = async (
 
   const queries = CHAIN_ID_TO_SUPPORTED_DEFI_OPPORTUNITIES[chainId]
 
-  await Promise.allSettled(
-    queries
-      .filter(query => query.defiType === DefiType.LiquidityPool)
-      .map(query =>
-        store.dispatch(
-          getOpportunitiesMetadata.initiate(
-            {
-              defiType: query.defiType,
-              defiProvider: query.defiProvider,
-            },
-            // Any previous query without portfolio loaded will be rejected, the first successful one will be cached
-            { forceRefetch: false, ...options },
-          ),
-        ),
-      ),
+  const lpQueries = queries.filter(query => query.defiType === DefiType.LiquidityPool)
+
+  await store.dispatch(
+    getOpportunitiesMetadata.initiate(
+      lpQueries,
+      // Any previous query without portfolio loaded will be rejected, the first successful one will be cached
+      { forceRefetch: false, ...options },
+    ),
   )
 }
 
@@ -42,36 +35,31 @@ export const fetchAllStakingOpportunitiesMetadataByChainId = async (
 
   const queries = CHAIN_ID_TO_SUPPORTED_DEFI_OPPORTUNITIES[chainId]
 
-  const ethFoxStakingQueries = foxEthStakingIds.map(opportunityId =>
+  const stakingQueries = queries.filter(query => query.defiType === DefiType.Staking)
+  const ethFoxStakingQueries = foxEthStakingIds.map(opportunityId => {
+    return {
+      opportunityId,
+      defiType: DefiType.Staking,
+      defiProvider: DefiProvider.EthFoxStaking,
+    }
+  })
+
+  await Promise.allSettled([
     store.dispatch(
-      getOpportunityMetadata.initiate(
-        {
-          opportunityId,
-          defiType: DefiType.Staking,
-          defiProvider: DefiProvider.EthFoxStaking,
-        },
+      getOpportunitiesMetadata.initiate(
+        stakingQueries,
         // Any previous query without portfolio loaded will be rejected, the first successful one will be cached
         { forceRefetch: false, ...options },
       ),
     ),
-  )
-  await Promise.allSettled(
-    queries
-      .filter(query => query.defiType === DefiType.Staking)
-      .map(query =>
-        store.dispatch(
-          getOpportunitiesMetadata.initiate(
-            {
-              defiType: query.defiType,
-              defiProvider: query.defiProvider,
-            },
-            // Any previous query without portfolio loaded will be rejected, the first successful one will be cached
-            { forceRefetch: false, ...options },
-          ),
-        ),
-      )
-      .concat(ethFoxStakingQueries),
-  )
+    store.dispatch(
+      getOpportunityMetadata.initiate(
+        ethFoxStakingQueries,
+        // Any previous query without portfolio loaded will be rejected, the first successful one will be cached
+        { forceRefetch: false, ...options },
+      ),
+    ),
+  ])
 }
 
 export const fetchAllOpportunitiesIdsByChainId = async (


### PR DESCRIPTION
## Description

Fetches all related staking opportunities in a single RTK query request to improve performance of app in local environments.

## Pull Request Type

- [ ] :bug: Bug fix (Non-breaking Change: Fixes an issue)
- [x] :hammer_and_wrench: Chore (Non-breaking Change: Doc updates, pkg upgrades, typos, etc..)
- [ ] :nail_care: New Feature (Breaking/Non-breaking Change)

## Issue (if applicable)

NA

## Risk

Risk of broken fetching of staking and LP opportinities.

## Testing

Check staking and LP opportunities load correctly

### Engineering

☝️

### Operations

☝️

## Screenshots (if applicable)

Main local:
![image](https://github.com/shapeshift/web/assets/125113430/13d32447-1915-4ecd-82e3-f98c1ab330cb)

this PR local:
![image](https://github.com/shapeshift/web/assets/125113430/4f6edf6d-262f-4e5c-bf40-5b4059486db4)
