### PR TITLE
feat: enable optional chains for walletconnect

### DIFF
--- a/src/assets/translations/en/main.json
+++ b/src/assets/translations/en/main.json
@@ -1817,13 +1817,15 @@
         },
         "sessionProposal": {
           "dAppInfo": "dApp Info",
-          "permissions": "Permissions",
+          "permissions": "Required Permissions",
+          "optionalPermissions": "Optional Permissions",
           "accountSelection": "Choose accounts",
           "unsupportedChain": "Unsupported chain namespace in session proposal.",
           "methods": "Methods",
           "events": "Events",
           "selectedAccounts": "Selected Accounts",
-          "permissionMessage": "Please select at least one account per chain."
+          "permissionMessage": "Please select at least one account per chain.",
+          "optionalPermissionMessage": "The following permissions are optional."
         }
       },
       "registry": {

--- a/src/plugins/walletConnectToDapps/WalletConnectModalManager.tsx
+++ b/src/plugins/walletConnectToDapps/WalletConnectModalManager.tsx
@@ -1,6 +1,7 @@
 import {
   HStack,
   Modal,
+  ModalBody,
   ModalCloseButton,
   ModalContent,
   ModalHeader,
@@ -238,7 +239,13 @@ export const WalletConnectModalManager: FC<WalletConnectModalManagerProps> = ({
   if (modalContent === null) return null
 
   return (
-    <Modal isOpen={!!activeModal} onClose={handleClose} variant='header-nav'>
+    <Modal
+      isOpen={!!activeModal}
+      onClose={handleClose}
+      variant='header-nav'
+      scrollBehavior='inside'
+      preserveScrollBarGap={true}
+    >
       <ModalOverlay />
       <ModalContent
         width='full'
@@ -253,9 +260,11 @@ export const WalletConnectModalManager: FC<WalletConnectModalManagerProps> = ({
             <ModalCloseButton position='static' />
           </HStack>
         </ModalHeader>
-        <VStack p={6} spacing={6} alignItems='stretch'>
-          {modalContent}
-        </VStack>
+        <ModalBody p={0}>
+          <VStack p={6} spacing={6} alignItems='stretch'>
+            {modalContent}
+          </VStack>
+        </ModalBody>
       </ModalContent>
     </Modal>
   )

--- a/src/plugins/walletConnectToDapps/components/modals/SessionProposal.tsx
+++ b/src/plugins/walletConnectToDapps/components/modals/SessionProposal.tsx
@@ -209,12 +209,6 @@ const SessionProposal: FC<WalletConnectSessionModalProps> = ({
     translate,
   ])
 
-  console.log({
-    selectedAccountIds,
-    allNamespacesSupported,
-    allNamespacesHaveAccounts,
-  })
-
   return (
     <>
       <ModalSection title='plugins.walletConnectToDapps.modal.sessionProposal.dAppInfo'>

--- a/src/plugins/walletConnectToDapps/components/modals/SessionProposal.tsx
+++ b/src/plugins/walletConnectToDapps/components/modals/SessionProposal.tsx
@@ -10,24 +10,42 @@ import { Permissions } from 'plugins/walletConnectToDapps/components/Permissions
 import { WalletConnectActionType } from 'plugins/walletConnectToDapps/types'
 import type { WalletConnectSessionModalProps } from 'plugins/walletConnectToDapps/WalletConnectModalManager'
 import type { FC } from 'react'
-import { useCallback, useState } from 'react'
+import { useCallback, useMemo, useState } from 'react'
 import { useTranslate } from 'react-polyglot'
 import { RawText, Text } from 'components/Text'
 import { useWallet } from 'hooks/useWallet/useWallet'
 import { walletSupportsChain } from 'hooks/useWalletSupportsChain/useWalletSupportsChain'
 import { assertIsDefined } from 'lib/utils'
 
-const allNamespacesSupported = (
-  requiredNamespaces: ProposalTypes.RequiredNamespaces,
+const disabledProp = { opacity: 0.5, cursor: 'not-allowed', userSelect: 'none' }
+
+const checkAllNamespacesSupported = (
+  namespaces: ProposalTypes.RequiredNamespaces | ProposalTypes.OptionalNamespaces,
   wallet: HDWallet | null,
-): boolean =>
-  Object.values(requiredNamespaces).every(
-    requiredNamespace =>
-      requiredNamespace.chains?.every(chainId =>
+): boolean => {
+  return Object.values(namespaces).every(
+    namespace =>
+      namespace.chains?.every(chainId =>
         // TODO(gomes): fix this
         walletSupportsChain({ chainId, wallet, isSnapInstalled: false }),
       ),
   )
+}
+
+const checkAllNamespacesHaveAccounts = (
+  namespaces: ProposalTypes.RequiredNamespaces | ProposalTypes.OptionalNamespaces,
+  selectedAccountIds: AccountId[],
+): boolean => {
+  return Object.values(namespaces).every(
+    namespace =>
+      namespace.chains?.every(requiredChainId =>
+        selectedAccountIds.some(accountId => {
+          const { chainId: accountChainId } = fromAccountId(accountId)
+          return requiredChainId === accountChainId
+        }),
+      ),
+  )
+}
 
 const createApprovalNamespaces = (
   requiredNamespaces: ProposalTypes.RequiredNamespaces,
@@ -64,35 +82,55 @@ const SessionProposal: FC<WalletConnectSessionModalProps> = ({
   const translate = useTranslate()
 
   const { id, params } = proposal
-  const { proposer, requiredNamespaces } = params
+  const { proposer, requiredNamespaces, optionalNamespaces } = params
 
-  const [selectedAccountIds, setSelectedAccountIds] = useState<AccountId[]>(() => [])
-  const toggleAccountId = (accountId: string) =>
+  const [selectedAccountIds, setSelectedAccountIds] = useState<AccountId[]>([])
+  const toggleAccountId = useCallback((accountId: string) => {
     setSelectedAccountIds(previousState =>
       previousState.includes(accountId)
         ? previousState.filter(existingAccountId => existingAccountId !== accountId)
         : [...previousState, accountId],
     )
+  }, [])
 
   /*
   We need to pass an account for every supported namespace. If we can't, we cannot approve the session.
   https://docs.walletconnect.com/2.0/specs/clients/sign/session-namespaces#21-session-namespaces-must-not-have-accounts-empty
    */
-  const areAllNamespacesSupported = allNamespacesSupported(requiredNamespaces, wallet)
+  const allNamespacesSupported = useMemo(() => {
+    const allRequiredNamespacesSupported = checkAllNamespacesSupported(requiredNamespaces, wallet)
+    return allRequiredNamespacesSupported
+  }, [requiredNamespaces, wallet])
 
   /*
   All namespaces require at least one account in the response payload
   https://docs.walletconnect.com/2.0/specs/clients/sign/session-namespaces#24-session-namespaces-must-contain-at-least-one-account-in-requested-chains
    */
-  const allNamespacesHaveAccounts = Object.values(requiredNamespaces).every(
-    requiredNamespaces =>
-      requiredNamespaces.chains?.every(requiredChainId =>
-        selectedAccountIds.some(accountId => {
-          const { chainId: accountChainId } = fromAccountId(accountId)
-          return requiredChainId === accountChainId
+  const allNamespacesHaveAccounts = useMemo(() => {
+    const allRequiredNamespacesHaveAccounts = checkAllNamespacesHaveAccounts(
+      requiredNamespaces,
+      selectedAccountIds,
+    )
+    return allRequiredNamespacesHaveAccounts
+  }, [requiredNamespaces, selectedAccountIds])
+
+  const supportedOptionalNamespacesWithAccounts = useMemo(() => {
+    return Object.fromEntries(
+      Object.entries(optionalNamespaces)
+        .map(([key, namespace]): [string, ProposalTypes.BaseRequiredNamespace] => {
+          namespace.chains = namespace.chains?.filter(chainId => {
+            const isRequired = requiredNamespaces[key].chains?.includes(chainId)
+            const isSupported = walletSupportsChain({ chainId, wallet, isSnapInstalled: false })
+            return !isRequired && isSupported
+          })
+
+          return [key, namespace]
+        })
+        .filter(([_key, namespace]) => {
+          return namespace.chains && namespace.chains.length > 0
         }),
-      ),
-  )
+    )
+  }, [optionalNamespaces, requiredNamespaces, wallet])
 
   const approvalNamespaces: SessionTypes.Namespaces = createApprovalNamespaces(
     requiredNamespaces,
@@ -124,27 +162,58 @@ const SessionProposal: FC<WalletConnectSessionModalProps> = ({
     handleClose()
   }, [handleClose, id, web3wallet])
 
-  const modalBody: JSX.Element = areAllNamespacesSupported ? (
-    <>
-      <ModalSection title='plugins.walletConnectToDapps.modal.sessionProposal.permissions'>
-        <Alert status='warning' mb={4} mt={-2}>
-          <AlertIcon />
-          <AlertTitle>
-            <Text translation='plugins.walletConnectToDapps.modal.sessionProposal.permissionMessage' />
-          </AlertTitle>
-        </Alert>
-        <Permissions
-          requiredNamespaces={requiredNamespaces}
-          selectedAccountIds={selectedAccountIds}
-          toggleAccountId={toggleAccountId}
-        />
-      </ModalSection>
-    </>
-  ) : (
-    <RawText>
-      {translate('plugins.walletConnectToDapps.modal.sessionProposal.unsupportedChain')}
-    </RawText>
-  )
+  const modalBody: JSX.Element = useMemo(() => {
+    return allNamespacesSupported ? (
+      <>
+        <ModalSection title='plugins.walletConnectToDapps.modal.sessionProposal.permissions'>
+          <Alert status={allNamespacesHaveAccounts ? 'success' : 'warning'} mb={4} mt={-2}>
+            <AlertIcon />
+            <AlertTitle>
+              <Text translation='plugins.walletConnectToDapps.modal.sessionProposal.permissionMessage' />
+            </AlertTitle>
+          </Alert>
+          <Permissions
+            requiredNamespaces={requiredNamespaces}
+            selectedAccountIds={selectedAccountIds}
+            toggleAccountId={toggleAccountId}
+          />
+        </ModalSection>
+        {Object.keys(supportedOptionalNamespacesWithAccounts).length > 0 && (
+          <ModalSection title='plugins.walletConnectToDapps.modal.sessionProposal.optionalPermissions'>
+            <Alert status='info' mb={4} mt={-2}>
+              <AlertIcon />
+              <AlertTitle>
+                <Text translation='plugins.walletConnectToDapps.modal.sessionProposal.optionalPermissionMessage' />
+              </AlertTitle>
+            </Alert>
+            <Permissions
+              requiredNamespaces={supportedOptionalNamespacesWithAccounts}
+              selectedAccountIds={selectedAccountIds}
+              toggleAccountId={toggleAccountId}
+            />
+          </ModalSection>
+        )}
+      </>
+    ) : (
+      <RawText>
+        {translate('plugins.walletConnectToDapps.modal.sessionProposal.unsupportedChain')}
+      </RawText>
+    )
+  }, [
+    allNamespacesSupported,
+    requiredNamespaces,
+    selectedAccountIds,
+    toggleAccountId,
+    supportedOptionalNamespacesWithAccounts,
+    allNamespacesHaveAccounts,
+    translate,
+  ])
+
+  console.log({
+    selectedAccountIds,
+    allNamespacesSupported,
+    allNamespacesHaveAccounts,
+  })
 
   return (
     <>
@@ -160,11 +229,12 @@ const SessionProposal: FC<WalletConnectSessionModalProps> = ({
             colorScheme='blue'
             type='submit'
             onClick={handleApprove}
-            disabled={
+            isDisabled={
               selectedAccountIds.length === 0 ||
-              !areAllNamespacesSupported ||
+              !allNamespacesSupported ||
               !allNamespacesHaveAccounts
             }
+            _disabled={disabledProp}
           >
             {translate('plugins.walletConnectToDapps.modal.signMessage.confirm')}
           </Button>


### PR DESCRIPTION
## Description

Implements UI and connectivity for wallectconnect optional chains.

Includes the following:
* exclude required chains from optional chain list
* visually disable the"confirm" button when required chains are not approved by user (previously looked enabled)
* change warning text to success when user approves required chains
* info text for optional chains so user knows they are optional
* add scrolling for walletconnect modals
* filters out unsupported optional chains

## Pull Request Type

- [ ] :bug: Bug fix (Non-breaking Change: Fixes an issue)
- [ ] :hammer_and_wrench: Chore (Non-breaking Change: Doc updates, pkg upgrades, typos, etc..)
- [x] :nail_care: New Feature (Breaking/Non-breaking Change)

## Issue (if applicable)

closes #[5313](https://github.com/shapeshift/web/issues/5313)

## Risk

Risk of broken walletconnect for required or optional chains

## Testing

* Check user can connect, disconnect, trade etc from required chains only (i.e regression test from prod)
* Check user can connect, disconnect, trade etc with optional chains
* Generally check UI functionality for walletconnect

### Engineering

☝️

### Operations

☝️

## Screenshots (if applicable)

Optional chains now appearing in proposal modal - note disabled "confirm" button now looks disabled:
![image](https://github.com/shapeshift/web/assets/125113430/34a7babd-5484-4c50-8823-e9af6f906f06)

Approving the required chains makes warning go green and button enables:
![image](https://github.com/shapeshift/web/assets/125113430/c73b5755-f5bd-4ece-994a-ad950923acad)

Can also approve optional chains:
![image](https://github.com/shapeshift/web/assets/125113430/e094c6e2-4722-4a6a-99f9-4a0382ae311b)

Scrolling working:
![image](https://github.com/shapeshift/web/assets/125113430/684e6765-7523-4aec-9c32-e550adc4930b)

Connecting to optional chain works the same as a required chain:
![image](https://github.com/shapeshift/web/assets/125113430/6476969c-0513-4793-83e9-3f72b7924050)


