### PR TITLE
fix: handle wcv2 refresh

### DIFF
--- a/react-app-rewired/headers/csps/wallets/walletConnect.ts
+++ b/react-app-rewired/headers/csps/wallets/walletConnect.ts
@@ -5,6 +5,7 @@ export const csp: Csp = {
     process.env.REACT_APP_WALLET_CONNECT_RELAY_URL!,
     'wss://*.bridge.walletconnect.org/',
     'wss://*.relay.walletconnect.org/',
+    'wss://relay.walletconnect.org/',
     'https://registry.walletconnect.com/api/v2/wallets',
     'https://api.etherscan.io',
     'https://verify.walletconnect.com/',

--- a/src/context/WalletProvider/WalletProvider.tsx
+++ b/src/context/WalletProvider/WalletProvider.tsx
@@ -586,6 +586,8 @@ export const WalletProvider = ({ children }: { children: React.ReactNode }): JSX
               dispatch({ type: WalletActions.SET_LOCAL_WALLET_LOADING, payload: false })
               break
             case KeyManager.WalletConnectV2: {
+              // Re-trigger the modal on refresh
+              await onProviderChange(KeyManager.WalletConnectV2)
               const localWalletConnectWallet = await state.adapters
                 .get(KeyManager.WalletConnectV2)?.[0]
                 ?.pairDevice()

--- a/src/plugins/walletConnectToDapps/WalletConnectV2Provider.tsx
+++ b/src/plugins/walletConnectToDapps/WalletConnectV2Provider.tsx
@@ -58,6 +58,9 @@ export const WalletConnectV2Provider: FC<PropsWithChildren> = ({ children }) => 
   }, [state.core?.pairing, state.web3wallet])
 
   useEffect(() => {
+    // If we are connected to a wallet via wallet connect then this logic does not apply.
+    if (walletInfo?.name === 'WalletConnectV2') return
+
     // NOTE: don't use `useAppSelector(selectWalletId)` because it introduces a race condition
     const deviceId = walletInfo?.deviceId
 
@@ -71,7 +74,7 @@ export const WalletConnectV2Provider: FC<PropsWithChildren> = ({ children }) => 
       // update ref
       previousWalletId.current = deviceId
     }
-  }, [walletInfo?.deviceId])
+  }, [walletInfo?.deviceId, walletInfo?.name])
 
   const value: WalletConnectContextType = useMemo(() => ({ state, dispatch }), [state])
   return (


### PR DESCRIPTION
## Description

Handles refreshing the app whilst connected to a WC2 wallet by re-triggering the QR code modal.
Also prevents session clearing rug from wcToDapps logic.

## Pull Request Type

- [x] :bug: Bug fix (Non-breaking Change: Fixes an issue)
- [ ] :hammer_and_wrench: Chore (Non-breaking Change: Doc updates, pkg upgrades, typos, etc..)
- [ ] :nail_care: New Feature (Breaking/Non-breaking Change)

## Issue (if applicable)

N/A

## Risk

Small

## Testing

Refresh the screen when connected, to a WCV2 wallet and the modal should re-appear for reconnection.

### Engineering

☝️

### Operations

Don't worry about testing this yet, it's behind a flag.

## Screenshots (if applicable)

N/A
