### PR TITLE
fix: handle EIP-1967 proxy contracts in useGetABI for WalletConnect to dApps

### DIFF
--- a/src/plugins/walletConnectToDapps/hooks/useGetAbi.tsx
+++ b/src/plugins/walletConnectToDapps/hooks/useGetAbi.tsx
@@ -110,5 +110,5 @@ export const useGetAbi = (
     [contractImplementationRawAbiData],
   )
 
-  return proxyFunctionNameIfExists ? implementationContractInterface : rootContractInterface
+  return proxyContractImplementation ? implementationContractInterface : rootContractInterface
 }

--- a/src/plugins/walletConnectToDapps/hooks/useGetAbi.tsx
+++ b/src/plugins/walletConnectToDapps/hooks/useGetAbi.tsx
@@ -5,12 +5,26 @@ import type { TransactionParams } from 'plugins/walletConnectToDapps/types'
 import { useEffect, useMemo, useState } from 'react'
 import { useGetContractAbiQuery } from 'state/apis/abi/abiApi'
 
+/*
+  If the root contract is a proxy and you need its implementation contract ABI, we currently
+  look for 1 of 2 methods on the root contract to detect it's a proxy:
+  1) the ZeroEx (Exchange Proxy) Spec: `getFunctionImplementation(sighash: string)` (a public getter)
+  2) the EIP-1967 way: `_implementation()` (onlyAdmin)
+  TODO: add additional proxy methods, if any, and handle them
+*/
+enum PROXY_CONTRACT_METHOD_NAME {
+  ZeroEx = 'getFunctionImplementation',
+  EIP1967 = 'implementation',
+}
+const EIP1967_IMPLEMENTATION_SLOT =
+  '0x360894a13ba1a3210667c828492db98dca3e2076cc3735a920a3ca505d382bbc'
+
 export const useGetAbi = (
   transactionParams: TransactionParams,
 ): ethers.utils.Interface | undefined => {
-  const [proxyContractImplementation, setProxyContractImplementation] = useState<
-    string | undefined
-  >()
+  const [proxyContractImplementation, setProxyContractImplementation] = useState<string | null>(
+    null,
+  )
 
   const { to: contractAddress, data } = transactionParams
   const provider = useMemo(
@@ -24,7 +38,7 @@ export const useGetAbi = (
     [rootContractRawAbiData],
   )
 
-  const contractWithProvider = useMemo(
+  const rootContractWithProvider = useMemo(
     () =>
       rootContractInterface
         ? new ethers.Contract(contractAddress, rootContractInterface, provider)
@@ -34,28 +48,55 @@ export const useGetAbi = (
 
   const sighash = data.substring(0, 10).toLowerCase()
 
-  /*
-  We check to see if there is a proxy method on the root interface. Currently, we only look for getFunctionImplementation.
-  I expect there are more.
-  TODO: add additional proxy methods.
-   */
-  const proxyFunctions = new Set(['getFunctionImplementation'])
-  const isProxyContract = rootContractInterface
-    ? Object.values(rootContractInterface.functions).some(f => proxyFunctions.has(f.name))
-    : undefined
+  // check for proxy methods on the root interface
+  let proxyFunctionNameIfExists: string | undefined
+  if (rootContractInterface) {
+    const rootFunctions = Object.values(rootContractInterface.functions)
+    proxyFunctionNameIfExists = Object.values(PROXY_CONTRACT_METHOD_NAME).find(x =>
+      rootFunctions.find(y => y.name === x),
+    )
+  }
 
   useEffect(() => {
     ;(async () => {
-      const implementation = isProxyContract
-        ? /*
-        We currently only handle the getFunctionImplementation method.
-        TODO: add additional proxy methods, and handle them.
-         */
-          await contractWithProvider?.getFunctionImplementation(sighash)
-        : undefined
-      setProxyContractImplementation(implementation)
+      let implementationAddress: string | null
+      try {
+        switch (proxyFunctionNameIfExists) {
+          case PROXY_CONTRACT_METHOD_NAME.ZeroEx:
+            console.debug('proxyFunctionName is "getFunctionImplementation"')
+            implementationAddress =
+              await rootContractWithProvider?.getFunctionImplementation(sighash)
+            break
+          case PROXY_CONTRACT_METHOD_NAME.EIP1967:
+            console.debug('proxyFunctionName is "implementation"')
+            const paddedImplementationAddress = await provider.getStorageAt(
+              contractAddress,
+              EIP1967_IMPLEMENTATION_SLOT,
+            )
+            // Remove the first 26 chars (64 hex digits)
+            implementationAddress = ethers.utils.getAddress(
+              paddedImplementationAddress.substring(26),
+            )
+            break
+          default:
+            implementationAddress = null
+        }
+        setProxyContractImplementation(implementationAddress)
+      } catch (e) {
+        console.error('Error getting implementation contract', e)
+        // any non-proxy contract could coincidentally contain a method with a proxy-like name
+        // so in this case, fallback to using the root contract
+        setProxyContractImplementation(null)
+      }
     })()
-  }, [contractWithProvider, sighash, setProxyContractImplementation, provider, isProxyContract])
+  }, [
+    rootContractInterface,
+    rootContractWithProvider,
+    sighash,
+    provider,
+    proxyFunctionNameIfExists,
+    contractAddress,
+  ])
 
   const { data: contractImplementationRawAbiData } = useGetContractAbiQuery(
     proxyContractImplementation ?? skipToken,
@@ -69,5 +110,5 @@ export const useGetAbi = (
     [contractImplementationRawAbiData],
   )
 
-  return isProxyContract ? implementationContractInterface : rootContractInterface
+  return proxyFunctionNameIfExists ? implementationContractInterface : rootContractInterface
 }

--- a/src/plugins/walletConnectToDapps/utils/EIP155RequestHandlerUtil.ts
+++ b/src/plugins/walletConnectToDapps/utils/EIP155RequestHandlerUtil.ts
@@ -107,7 +107,8 @@ export const approveEIP155Request = async ({
         txToSign,
         wallet,
       })
-      return formatJsonRpcResult(id, signedTx)
+      const txHash = await chainAdapter.broadcastTransaction(signedTx)
+      return formatJsonRpcResult(id, txHash)
     }
 
     case EIP155_SigningMethod.ETH_SIGN_TRANSACTION: {


### PR DESCRIPTION
## Description
There was a TODO in the code comments: `TODO: add additional proxy methods.` I happened to need support for this popular proxy method when trying to mint domains using the UnstoppableDomains dApp + web + KeepKey. I tested this out with KeepKey and it works as intended; the only blockers are what other users have reported with invalid hash value errors thrown from the dApp side when it receives our final, signed `eth_sendTransaction` payload. You can tell from the screenshots below that the data we are sending them might need some tweaking, but that is an existing bug that I'm sure you all are aware of.

Hope this helps! I mostly did this just for fun and KeepKey Desktop will eventually need this functionality too!

## Pull Request Type

- [X] :bug: Bug fix (Non-breaking Change: Fixes an issue)
- [ ] :hammer_and_wrench: Chore (Non-breaking Change: Doc updates, pkg upgrades, typos, etc..)
- [ ] :nail_care: New Feature (Breaking/Non-breaking Change)

## Issue (if applicable)
closes #5054

## Risk
Zero immediate user impact, because the full user flow is still blocked by bug(s) that prevent the final tx being broadcasted. I have fully user-tested my changes with a KeepKey and it all works as expected.

## Testing
Connect your wallet to the Unstoppable Domains dApp using WalletConnect. It is a proxy contract, and when you go through a flow like bridging a Polygon domain to Ethereum, it will be able to fetch the API from the logic contract and display the relevant ABI methods and data for you to confirm in the web3modal.


### Engineering
See the testing notes above; the code changes are pretty self-explanatory and I left relevant comments too.

### Operations
For example you could, mint a Polygon domain like .crypto using the UnstoppableDomains WalletConnect feature in web and then use the UnstoppableDomains UI to bridge that domain to Ethereum. Or just interacting with any dApp that has a EIP-1967 proxy as its root contract address.

## Screenshots (if applicable)
<img width="512" alt="Screenshot 2023-09-27 at 11 44 03" src="https://github.com/shapeshift/web/assets/37815163/12d0f993-768c-4170-8e2e-8f99cde1a66a">
<img width="247" alt="Screenshot 2023-09-27 at 11 44 50" src="https://github.com/shapeshift/web/assets/37815163/f787bab9-5f47-4fa8-9c9e-3007b62a00ef">
<img width="247" alt="Screenshot 2023-09-27 at 11 45 12" src="https://github.com/shapeshift/web/assets/37815163/5e717ddf-c324-4c45-90f0-dc14775c6e04">
<img width="1081" alt="Screenshot 2023-09-27 at 12 50 14" src="https://github.com/shapeshift/web/assets/37815163/cacb62a1-fb48-4bf6-9713-41a315e261b7">
