### PR TITLE
fix: rarible not signing messages due to spurious empty string in their payload

### DIFF
--- a/src/plugins/walletConnectToDapps/hooks/useWalletConnectState.ts
+++ b/src/plugins/walletConnectToDapps/hooks/useWalletConnectState.ts
@@ -64,7 +64,7 @@ export const useWalletConnectState = (state: WalletConnectState) => {
 
   const message =
     request && (isSignRequest(request) || isSignTypedRequest(request))
-      ? getSignParamsMessage(request.params)
+      ? getSignParamsMessage(request.params, true)
       : undefined
   const method: KnownSigningMethod | undefined = requestEvent?.params.request.method
   const chainAdapter = chainId && getChainAdapterManager().get(chainId)

--- a/src/plugins/walletConnectToDapps/typeGuards.ts
+++ b/src/plugins/walletConnectToDapps/typeGuards.ts
@@ -8,18 +8,25 @@ import type {
   WalletConnectRequest,
 } from 'plugins/walletConnectToDapps/types'
 import { EIP155_SigningMethod } from 'plugins/walletConnectToDapps/types'
-import { getTypeGuardAssertion } from 'lib/utils'
+import { getTypeGuardAssertion, isTruthy } from 'lib/utils'
 
 export const isTransactionParamsArray = (
   transactions: RequestParams | undefined,
 ): transactions is TransactionParams[] =>
   (transactions as TransactionParams[])?.every?.(isTransactionParams)
 
-export const isEthSignParams = (requestParams: RequestParams): requestParams is EthSignParams =>
-  requestParams instanceof Array &&
-  requestParams.length === 2 &&
-  typeof requestParams[0] === 'string' &&
-  typeof requestParams[1] === 'string'
+export const isEthSignParams = (requestParams: RequestParams): requestParams is EthSignParams => {
+  if (!Array.isArray(requestParams)) return false
+
+  // some dapps (rarible) add a sneaky "" at the end of the array
+  const cleanedArray = requestParams.filter(isTruthy)
+
+  return (
+    cleanedArray.length === 2 &&
+    typeof cleanedArray[0] === 'string' &&
+    typeof cleanedArray[1] === 'string'
+  )
+}
 
 export const isSignRequest = (
   request: WalletConnectRequest,

--- a/src/plugins/walletConnectToDapps/utils.ts
+++ b/src/plugins/walletConnectToDapps/utils.ts
@@ -80,9 +80,9 @@ export const getGasData = (
  * a value that is not an address (thus is a message).
  * If it is a hex string, it gets converted to utf8 string
  */
-export const getSignParamsMessage = (params: [string, string]) => {
+export const getSignParamsMessage = (params: [string, string], toUtf8: boolean) => {
   const message = params.filter(p => !utils.isAddress(p))[0]
-  return maybeConvertHexEncodedMessageToUtf8(message)
+  return toUtf8 ? maybeConvertHexEncodedMessageToUtf8(message) : message
 }
 
 export const extractConnectedAccounts = (session: SessionTypes.Struct): AccountId[] => {

--- a/src/plugins/walletConnectToDapps/utils/EIP155RequestHandlerUtil.ts
+++ b/src/plugins/walletConnectToDapps/utils/EIP155RequestHandlerUtil.ts
@@ -55,7 +55,7 @@ export const approveEIP155Request = async ({
   switch (request.method) {
     case EIP155_SigningMethod.PERSONAL_SIGN:
     case EIP155_SigningMethod.ETH_SIGN: {
-      const message = getSignParamsMessage(request.params)
+      const message = getSignParamsMessage(request.params, false)
       const messageToSign = { addressNList, message }
       const input = { messageToSign, wallet }
       const signedMessage = await chainAdapter.signMessage(input)


### PR DESCRIPTION
## Description

Fixes inability to sign disclaimer on zapper login due to an additional `''` in the params array sent by rarible.

## Pull Request Type

- [x] :bug: Bug fix (Non-breaking Change: Fixes an issue)
- [ ] :hammer_and_wrench: Chore (Non-breaking Change: Doc updates, pkg upgrades, typos, etc..)
- [ ] :nail_care: New Feature (Breaking/Non-breaking Change)

## Issue (if applicable)

closes #5306

## Risk

Low risk.

## Testing

Check can log in to rarible and sign disclaimer

### Engineering

☝️

### Operations

☝️

## Screenshots (if applicable)

can sign disclaimer and log in
![image](https://github.com/shapeshift/web/assets/125113430/25d9dc6a-9f05-4272-abd4-20540c0b4d53)
![image](https://github.com/shapeshift/web/assets/125113430/f6d2ad7d-2139-419b-9d67-dac2ee9f1506)
![image](https://github.com/shapeshift/web/assets/125113430/62925ece-35e5-46d0-9eff-d9190e25293c)

