### PR TITLE
feat: use loading state on all modal submit buttons

### DIFF
--- a/src/plugins/walletConnectToDapps/components/Account.tsx
+++ b/src/plugins/walletConnectToDapps/components/Account.tsx
@@ -1,6 +1,6 @@
 import { Checkbox, Flex } from '@chakra-ui/react'
 import type { AccountId } from '@shapeshiftoss/caip'
-import type { FC } from 'react'
+import { type FC, useCallback } from 'react'
 import { MiddleEllipsis } from 'components/MiddleEllipsis/MiddleEllipsis'
 import { RawText } from 'components/Text'
 import { accountIdToLabel } from 'state/slices/portfolioSlice/utils'
@@ -13,8 +13,10 @@ interface IProps {
 }
 
 export const Account: FC<IProps> = ({ accountId, isSelected, toggleAccountId, accountNumber }) => {
+  const handleChange = useCallback(() => toggleAccountId(accountId), [accountId, toggleAccountId])
+
   return (
-    <Checkbox isChecked={isSelected} onChange={() => toggleAccountId(accountId)} width='full'>
+    <Checkbox isChecked={isSelected} onChange={handleChange} width='full'>
       <Flex gap={2} justifyContent='space-between'>
         <RawText fontWeight='bold'>Account #{accountNumber}</RawText>
         <MiddleEllipsis value={accountIdToLabel(accountId)} color='text.subtle' />

--- a/src/plugins/walletConnectToDapps/components/AccountSelectionByChainId.tsx
+++ b/src/plugins/walletConnectToDapps/components/AccountSelectionByChainId.tsx
@@ -22,16 +22,22 @@ export const AccountSelectionByChainId: FC<IProps> = ({
 }) => {
   const translate = useTranslate()
   const [allChecked, setAllChecked] = useState(false)
-  const translateKey = (key: string) => `plugins.walletConnectToDapps.modal.sessionProposal.${key}`
+  const translateKey = useCallback(
+    (key: string) => `plugins.walletConnectToDapps.modal.sessionProposal.${key}`,
+    [],
+  )
   const filter = useMemo(() => ({ chainId }), [chainId])
   const accountIdsByAccountNumberChainId = useAppSelector(s =>
     selectPortfolioAccountsGroupedByNumberByChainId(s, filter),
   )
-  const accountIds = Object.entries(accountIdsByAccountNumberChainId).flatMap(
-    ([_, accountIds]) => accountIds,
+  const accountIds = useMemo(
+    () => Object.entries(accountIdsByAccountNumberChainId).flatMap(([_, accountIds]) => accountIds),
+    [accountIdsByAccountNumberChainId],
   )
-  const selectedAccountIdsByChainId = accountIds.filter(accountId =>
-    selectedAccountIds.includes(accountId),
+
+  const selectedAccountIdsByChainId = useMemo(
+    () => accountIds.filter(accountId => selectedAccountIds.includes(accountId)),
+    [accountIds, selectedAccountIds],
   )
 
   const renderAccounts = useMemo(() => {

--- a/src/plugins/walletConnectToDapps/components/ChainReferenceCard.tsx
+++ b/src/plugins/walletConnectToDapps/components/ChainReferenceCard.tsx
@@ -14,7 +14,7 @@ import {
 import { Tag } from '@chakra-ui/tag'
 import { AccountSelectionByChainId } from 'plugins/walletConnectToDapps/components/AccountSelectionByChainId'
 import type { FC } from 'react'
-import { useMemo } from 'react'
+import { useCallback, useMemo } from 'react'
 import { useTranslate } from 'react-polyglot'
 import { AssetIcon } from 'components/AssetIcon'
 import { Row } from 'components/Row/Row'
@@ -30,6 +30,10 @@ type ChainReferenceCardProps = {
   toggleAccountId: (accountId: string) => void
 }
 
+const borderRadiusProp = { base: 'lg', md: 'xl' }
+const pxProp = { base: 4, md: 4 }
+const pProp = { base: 0, md: 0 }
+
 export const ChainReferenceCard: FC<ChainReferenceCardProps> = ({
   methods,
   events,
@@ -42,7 +46,10 @@ export const ChainReferenceCard: FC<ChainReferenceCardProps> = ({
   const translate = useTranslate()
   const asset = useAppSelector(s => selectFeeAssetByChainId(s, chainId))
   const borderColor = useColorModeValue('blackAlpha.100', 'whiteAlpha.200')
-  const translateKey = (key: string) => `plugins.walletConnectToDapps.modal.sessionProposal.${key}`
+  const translateKey = useCallback(
+    (key: string) => `plugins.walletConnectToDapps.modal.sessionProposal.${key}`,
+    [],
+  )
 
   const renderEvents = useMemo(() => {
     return events.map(event => (
@@ -59,21 +66,20 @@ export const ChainReferenceCard: FC<ChainReferenceCardProps> = ({
       </Tag>
     ))
   }, [methods])
+
+  const hoverBg = useColorModeValue('blackAlpha.50', 'whiteAlpha.50')
+  const hoverProp = useMemo(() => ({ bg: hoverBg }), [hoverBg])
+
   return (
-    <Card
-      borderColor={borderColor}
-      overflow='hidden'
-      width='full'
-      borderRadius={{ base: 'lg', md: 'xl' }}
-    >
+    <Card borderColor={borderColor} overflow='hidden' width='full' borderRadius={borderRadiusProp}>
       <CardHeader
-        px={{ base: 4, md: 4 }}
+        px={pxProp}
         display='flex'
         alignItems='center'
         justifyContent='space-between'
         onClick={onToggle}
         cursor='pointer'
-        _hover={{ bg: useColorModeValue('blackAlpha.50', 'whiteAlpha.50') }}
+        _hover={hoverProp}
       >
         <Heading display='flex' alignItems='center' gap={2}>
           <AssetIcon src={asset?.networkIcon ?? asset?.icon} size='xs' />
@@ -85,7 +91,7 @@ export const ChainReferenceCard: FC<ChainReferenceCardProps> = ({
         </Flex>
       </CardHeader>
       <Collapse in={isOpen}>
-        <CardBody p={{ base: 0, md: 0 }} bg='whiteAlpha.50'>
+        <CardBody p={pProp} bg='whiteAlpha.50'>
           <Stack spacing={0} divider={<Divider />}>
             <Row gap={4} variant='gutter' py={3}>
               <Row.Label>{translate(translateKey('methods'))}</Row.Label>

--- a/src/plugins/walletConnectToDapps/components/modals/ContractInteractionBreakdown.tsx
+++ b/src/plugins/walletConnectToDapps/components/modals/ContractInteractionBreakdown.tsx
@@ -7,7 +7,7 @@ import { ModalCollapsableSection } from 'plugins/walletConnectToDapps/components
 import { useGetAbi } from 'plugins/walletConnectToDapps/hooks/useGetAbi'
 import type { EthSendTransactionCallRequest } from 'plugins/walletConnectToDapps/types'
 import type { FC } from 'react'
-import { Fragment, useMemo } from 'react'
+import { Fragment, useCallback, useMemo } from 'react'
 import { FaCode } from 'react-icons/fa'
 import { Amount } from 'components/Amount/Amount'
 import { MiddleEllipsis } from 'components/MiddleEllipsis/MiddleEllipsis'
@@ -45,35 +45,38 @@ export const ContractInteractionBreakdown: FC<ContractInteractionBreakdownProps>
 
   const addressColor = useColorModeValue('blue.500', 'blue.200')
 
-  const renderAbiInput = (input: ParamType, index: number): JSX.Element => {
-    const inputValue = transaction?.args[index].toString()
-    switch (input.type) {
-      case 'bytes[]':
-        return <EncodedText value={inputValue} />
-      case 'address':
-        return (
-          <HStack>
-            <Box flex={1} fontFamily='monospace' fontSize='md'>
-              <MiddleEllipsis color={addressColor} value={inputValue} />
-            </Box>
-            <CopyButton value={inputValue} />
-            {feeAsset && (
-              <ExternalLinkButton
-                href={`${feeAsset.explorerAddressLink}${inputValue}`}
-                ariaLabel={inputValue}
-              />
-            )}
-          </HStack>
-        )
-      case 'tuple':
-      default:
-        return (
-          <RawText fontWeight='normal' fontSize='md'>
-            {inputValue}
-          </RawText>
-        )
-    }
-  }
+  const renderAbiInput = useCallback(
+    (input: ParamType, index: number): JSX.Element => {
+      const inputValue = transaction?.args[index].toString()
+      switch (input.type) {
+        case 'bytes[]':
+          return <EncodedText value={inputValue} />
+        case 'address':
+          return (
+            <HStack>
+              <Box flex={1} fontFamily='monospace' fontSize='md'>
+                <MiddleEllipsis color={addressColor} value={inputValue} />
+              </Box>
+              <CopyButton value={inputValue} />
+              {feeAsset && (
+                <ExternalLinkButton
+                  href={`${feeAsset.explorerAddressLink}${inputValue}`}
+                  ariaLabel={inputValue}
+                />
+              )}
+            </HStack>
+          )
+        case 'tuple':
+        default:
+          return (
+            <RawText fontWeight='normal' fontSize='md'>
+              {inputValue}
+            </RawText>
+          )
+      }
+    },
+    [addressColor, feeAsset, transaction?.args],
+  )
 
   return (
     <ModalCollapsableSection

--- a/src/plugins/walletConnectToDapps/components/modals/EIP155SignTypedDataConfirmation.tsx
+++ b/src/plugins/walletConnectToDapps/components/modals/EIP155SignTypedDataConfirmation.tsx
@@ -5,7 +5,7 @@ import { TypedMessageInfo } from 'plugins/walletConnectToDapps/components/modals
 import { useWalletConnectState } from 'plugins/walletConnectToDapps/hooks/useWalletConnectState'
 import type { EthSignTypedDataCallRequest } from 'plugins/walletConnectToDapps/types'
 import type { WalletConnectRequestModalProps } from 'plugins/walletConnectToDapps/WalletConnectModalManager'
-import type { FC } from 'react'
+import { type FC, useCallback, useState } from 'react'
 import { useTranslate } from 'react-polyglot'
 import { FoxIcon } from 'components/Icons/FoxIcon'
 import { Text } from 'components/Text'
@@ -14,9 +14,12 @@ import { assertIsDefined } from 'lib/utils'
 import { selectFeeAssetByChainId } from 'state/slices/selectors'
 import { useAppSelector } from 'state/store'
 
+const disabledProp = { opacity: 0.5, cursor: 'not-allowed', userSelect: 'none' }
+
 export const EIP155SignTypedDataConfirmation: FC<
   WalletConnectRequestModalProps<EthSignTypedDataCallRequest>
-> = ({ onConfirm: handleConfirm, onReject: handleReject, state }) => {
+> = ({ onConfirm, onReject, state }) => {
+  const [isLoading, setIsLoading] = useState<boolean>(false)
   const { address, message, chainId } = useWalletConnectState(state)
   assertIsDefined(message)
 
@@ -27,6 +30,18 @@ export const EIP155SignTypedDataConfirmation: FC<
   const translate = useTranslate()
   const walletInfo = useWallet().state.walletInfo
   const WalletIcon = walletInfo?.icon ?? FoxIcon
+
+  const handleConfirm = useCallback(async () => {
+    setIsLoading(true)
+    await onConfirm()
+    setIsLoading(false)
+  }, [onConfirm])
+
+  const handleReject = useCallback(async () => {
+    setIsLoading(true)
+    await onReject()
+    setIsLoading(false)
+  }, [onReject])
 
   return (
     <>
@@ -44,10 +59,24 @@ export const EIP155SignTypedDataConfirmation: FC<
         translation='plugins.walletConnectToDapps.modal.signMessage.description'
       />
       <VStack spacing={4}>
-        <Button size='lg' width='full' colorScheme='blue' type='submit' onClick={handleConfirm}>
+        <Button
+          size='lg'
+          width='full'
+          colorScheme='blue'
+          type='submit'
+          onClick={handleConfirm}
+          _disabled={disabledProp}
+          isLoading={isLoading}
+        >
           {translate('plugins.walletConnectToDapps.modal.signMessage.confirm')}
         </Button>
-        <Button size='lg' width='full' onClick={handleReject}>
+        <Button
+          size='lg'
+          width='full'
+          onClick={handleReject}
+          isDisabled={isLoading}
+          _disabled={disabledProp}
+        >
           {translate('plugins.walletConnectToDapps.modal.signMessage.reject')}
         </Button>
       </VStack>

--- a/src/plugins/walletConnectToDapps/components/modals/SessionProposal.tsx
+++ b/src/plugins/walletConnectToDapps/components/modals/SessionProposal.tsx
@@ -84,6 +84,7 @@ const SessionProposal: FC<WalletConnectSessionModalProps> = ({
   const { id, params } = proposal
   const { proposer, requiredNamespaces, optionalNamespaces } = params
 
+  const [isLoading, setIsLoading] = useState<boolean>(false)
   const [selectedAccountIds, setSelectedAccountIds] = useState<AccountId[]>([])
   const toggleAccountId = useCallback((accountId: string) => {
     setSelectedAccountIds(previousState =>
@@ -146,6 +147,8 @@ const SessionProposal: FC<WalletConnectSessionModalProps> = ({
       return
     }
 
+    setIsLoading(true)
+
     const session = await web3wallet.approveSession({
       id: proposal.id,
       namespaces: approvalNamespaces,
@@ -155,10 +158,13 @@ const SessionProposal: FC<WalletConnectSessionModalProps> = ({
   }, [approvalNamespaces, dispatch, handleClose, proposal, web3wallet])
 
   const handleReject = useCallback(async () => {
+    setIsLoading(true)
+
     await web3wallet.rejectSession({
       id,
       reason: getSdkError('USER_REJECTED_METHODS'),
     })
+
     handleClose()
   }, [handleClose, id, web3wallet])
 
@@ -229,10 +235,17 @@ const SessionProposal: FC<WalletConnectSessionModalProps> = ({
               !allNamespacesHaveAccounts
             }
             _disabled={disabledProp}
+            isLoading={isLoading}
           >
             {translate('plugins.walletConnectToDapps.modal.signMessage.confirm')}
           </Button>
-          <Button size='lg' width='full' onClick={handleReject}>
+          <Button
+            size='lg'
+            width='full'
+            onClick={handleReject}
+            isDisabled={isLoading}
+            _disabled={disabledProp}
+          >
             {translate('plugins.walletConnectToDapps.modal.signMessage.reject')}
           </Button>
         </VStack>

--- a/src/plugins/walletConnectToDapps/components/modals/connect/ConnectContent.tsx
+++ b/src/plugins/walletConnectToDapps/components/modals/connect/ConnectContent.tsx
@@ -12,7 +12,7 @@ import {
   VStack,
 } from '@chakra-ui/react'
 import { isWalletConnectV2Uri } from 'plugins/walletConnectToDapps/components/modals/connect/utils'
-import { useCallback, useState } from 'react'
+import { useCallback, useMemo, useState } from 'react'
 import { useForm, useWatch } from 'react-hook-form'
 import { useTranslate } from 'react-polyglot'
 import { QRCodeIcon } from 'components/Icons/QRCode'
@@ -36,7 +36,7 @@ export const ConnectContent: React.FC<ConnectContentProps> = ({
   const [isQrCodeView, setIsQrCodeView] = useState<boolean>(false)
   const toggleQrCodeView = useCallback(() => setIsQrCodeView(v => !v), [])
 
-  const handleForm = (values: FormValues) => handleConnect(values.uri)
+  const handleForm = useCallback((values: FormValues) => handleConnect(values.uri), [handleConnect])
 
   const { register, handleSubmit, control, formState, setValue } = useForm<FormValues>({
     mode: 'onChange',
@@ -54,10 +54,7 @@ export const ConnectContent: React.FC<ConnectContentProps> = ({
   const uri = useWatch({ control, name: 'uri' })
   const isValidUri = isWalletConnectV2Uri(uri)
 
-  if (isQrCodeView)
-    return <QrCodeScanner onSuccess={handleQrScanSuccess} onBack={toggleQrCodeView} />
-
-  const connectTranslation = (() => {
+  const connectTranslation = useMemo(() => {
     const commonString = 'plugins.walletConnectToDapps.modal.connect'
     switch (true) {
       case uri === '':
@@ -67,7 +64,11 @@ export const ConnectContent: React.FC<ConnectContentProps> = ({
       default:
         return `${commonString}.connect`
     }
-  })()
+  }, [isValidUri, uri])
+
+  if (isQrCodeView) {
+    return <QrCodeScanner onSuccess={handleQrScanSuccess} onBack={toggleQrCodeView} />
+  }
 
   return (
     <Box p={8}>

--- a/src/plugins/walletConnectToDapps/hooks/useGetAbi.tsx
+++ b/src/plugins/walletConnectToDapps/hooks/useGetAbi.tsx
@@ -48,27 +48,25 @@ export const useGetAbi = (
 
   const sighash = data.substring(0, 10).toLowerCase()
 
-  // check for proxy methods on the root interface
-  let proxyFunctionNameIfExists: string | undefined
-  if (rootContractInterface) {
-    const rootFunctions = Object.values(rootContractInterface.functions)
-    proxyFunctionNameIfExists = Object.values(PROXY_CONTRACT_METHOD_NAME).find(x =>
-      rootFunctions.find(y => y.name === x),
-    )
-  }
-
   useEffect(() => {
+    // check for proxy methods on the root interface
+    let proxyFunctionNameIfExists: string | undefined
+    if (rootContractInterface) {
+      const rootFunctions = Object.values(rootContractInterface.functions)
+      proxyFunctionNameIfExists = Object.values(PROXY_CONTRACT_METHOD_NAME).find(x =>
+        rootFunctions.find(y => y.name === x),
+      )
+    }
+
     ;(async () => {
       let implementationAddress: string | null
       try {
         switch (proxyFunctionNameIfExists) {
           case PROXY_CONTRACT_METHOD_NAME.ZeroEx:
-            console.debug('proxyFunctionName is "getFunctionImplementation"')
             implementationAddress =
               await rootContractWithProvider?.getFunctionImplementation(sighash)
             break
           case PROXY_CONTRACT_METHOD_NAME.EIP1967:
-            console.debug('proxyFunctionName is "implementation"')
             const paddedImplementationAddress = await provider.getStorageAt(
               contractAddress,
               EIP1967_IMPLEMENTATION_SLOT,
@@ -89,14 +87,7 @@ export const useGetAbi = (
         setProxyContractImplementation(null)
       }
     })()
-  }, [
-    rootContractInterface,
-    rootContractWithProvider,
-    sighash,
-    provider,
-    proxyFunctionNameIfExists,
-    contractAddress,
-  ])
+  }, [rootContractInterface, rootContractWithProvider, sighash, provider, contractAddress])
 
   const { data: contractImplementationRawAbiData } = useGetContractAbiQuery(
     proxyContractImplementation ?? skipToken,

--- a/src/plugins/walletConnectToDapps/hooks/useIsInteractingWithContract.ts
+++ b/src/plugins/walletConnectToDapps/hooks/useIsInteractingWithContract.ts
@@ -8,7 +8,7 @@ export const useIsInteractingWithContract = ({
 }: {
   evmChainId: ChainId | undefined
   address: string | undefined
-}): { isInteractingWithContract: boolean | null } => {
+}): boolean | null => {
   const [isInteractingWithContract, setIsInteractingWithContract] = useState<boolean | null>(null)
   useEffect(() => {
     ;(async () => {
@@ -19,5 +19,5 @@ export const useIsInteractingWithContract = ({
     })()
   }, [address, evmChainId])
 
-  return { isInteractingWithContract }
+  return isInteractingWithContract
 }

--- a/src/plugins/walletConnectToDapps/hooks/useWalletConnectState.ts
+++ b/src/plugins/walletConnectToDapps/hooks/useWalletConnectState.ts
@@ -14,6 +14,7 @@ import {
   getWalletAccountFromEthParams,
   getWalletAddressFromEthSignParams,
 } from 'plugins/walletConnectToDapps/utils'
+import { useMemo } from 'react'
 import { getChainAdapterManager } from 'context/PluginProvider/chainAdapterSingleton'
 import { selectPortfolioAccountMetadata } from 'state/slices/portfolioSlice/selectors'
 import { useAppSelector } from 'state/store'
@@ -34,17 +35,17 @@ export const useWalletConnectState = (state: WalletConnectState) => {
 
   const connectedAccounts = extractAllConnectedAccounts(sessionsByTopic)
 
-  const address = (() => {
+  const address = useMemo(() => {
     if (requestParams && isEthSignParams(requestParams))
       return getWalletAddressFromEthSignParams(connectedAccounts, requestParams)
     if (requestParams && isTransactionParamsArray(requestParams)) return requestParams[0].from
     if (requestParams) return requestParams.signerAddress
     else return undefined
-  })()
+  }, [connectedAccounts, requestParams])
 
   const accountMetadataById = useAppSelector(selectPortfolioAccountMetadata)
 
-  const accountId = (() => {
+  const accountId = useMemo(() => {
     if (
       requestParams &&
       (isEthSignParams(requestParams) || isTransactionParamsArray(requestParams))
@@ -52,7 +53,7 @@ export const useWalletConnectState = (state: WalletConnectState) => {
       return getWalletAccountFromEthParams(connectedAccounts, requestParams)
     if (requestParams) return getWalletAccountFromCosmosParams(connectedAccounts, requestParams)
     else return undefined
-  })()
+  }, [connectedAccounts, requestParams])
 
   const accountMetadata = accountId ? accountMetadataById[accountId] : undefined
 

--- a/src/plugins/walletConnectToDapps/typeGuards.ts
+++ b/src/plugins/walletConnectToDapps/typeGuards.ts
@@ -8,7 +8,7 @@ import type {
   WalletConnectRequest,
 } from 'plugins/walletConnectToDapps/types'
 import { EIP155_SigningMethod } from 'plugins/walletConnectToDapps/types'
-import { getTypeGuardAssertion, isTruthy } from 'lib/utils'
+import { isTruthy } from 'lib/utils'
 
 export const isTransactionParamsArray = (
   transactions: RequestParams | undefined,
@@ -48,14 +48,8 @@ export const isTransactionParams = (
   transaction: TransactionParams | string | undefined,
 ): transaction is TransactionParams =>
   typeof transaction === 'object' &&
-  !!transaction?.from &&
-  !!transaction?.to &&
-  !!transaction?.data &&
-  ((!!transaction?.gasLimit && !!transaction?.gasPrice) || !!transaction?.gas)
-
-export const assertIsTransactionParams: (
-  transaction: TransactionParams | string | undefined,
-) => asserts transaction is TransactionParams = getTypeGuardAssertion(
-  isTransactionParams,
-  'Transaction has no transaction params',
-)
+  transaction !== null &&
+  !!transaction.from &&
+  !!transaction.to &&
+  !!transaction.data &&
+  ((!!transaction.gasLimit && !!transaction.gasPrice) || !!transaction.gas)


### PR DESCRIPTION
## Description

Implements a loading state for WalletConnect modals to address the current issue where modals do not provide user feedback upon confirmation, leading to user confusion.

* Includes some rendering performance tweaks
* Includes a fix where components were consuming the output of `src/plugins/walletConnectToDapps/hooks/useIsInteractingWithContract.ts` as a `string|null` there it was outputting an object

## Pull Request Type

- [ ] :bug: Bug fix (Non-breaking Change: Fixes an issue)
- [ ] :hammer_and_wrench: Chore (Non-breaking Change: Doc updates, pkg upgrades, typos, etc..)
- [x] :nail_care: New Feature (Breaking/Non-breaking Change)

## Issue (if applicable)

closes #5377

## Risk

Low risk of walletconnect modals unable to confirm or reject.

## Testing

* Check all walletconnect requests are able to confirm and reject
* Check users cannot click reject while confirm is loading

### Engineering

☝️

### Operations

☝️

## Screenshots (if applicable)

### connecting dapp
![image](https://github.com/shapeshift/web/assets/125113430/7a7ba6ca-2987-43bd-bd90-8845c4f27dad)
![image](https://github.com/shapeshift/web/assets/125113430/5ba0a6f5-6457-4e04-afd1-a4c531ed5100)

### personal sign
![image](https://github.com/shapeshift/web/assets/125113430/216e840e-e1c0-4283-85d7-7da31aa4d553)
![image](https://github.com/shapeshift/web/assets/125113430/9008dec4-7ad0-4f35-8ff6-54376d34b75a)

### send transaction
note loading state while fees are fetching
![image](https://github.com/shapeshift/web/assets/125113430/9820906d-32f5-44ad-a8b4-c483214cbb3a)
![image](https://github.com/shapeshift/web/assets/125113430/9bca02ab-26c1-4c0a-a4a0-9b1b0d2c1a1d)
![image](https://github.com/shapeshift/web/assets/125113430/55a8b01b-4431-49e7-b6c7-bd2d80b0309c)

