### PR TITLE
fix: walletconnect should reject requests on modal close

### DIFF
--- a/src/plugins/walletConnectToDapps/components/modals/SessionProposal.tsx
+++ b/src/plugins/walletConnectToDapps/components/modals/SessionProposal.tsx
@@ -7,10 +7,10 @@ import { getSdkError } from '@walletconnect/utils'
 import { DAppInfo } from 'plugins/walletConnectToDapps/components/DAppInfo'
 import { ModalSection } from 'plugins/walletConnectToDapps/components/modals/ModalSection'
 import { Permissions } from 'plugins/walletConnectToDapps/components/Permissions'
+import type { SessionProposalRef } from 'plugins/walletConnectToDapps/types'
 import { WalletConnectActionType } from 'plugins/walletConnectToDapps/types'
 import type { WalletConnectSessionModalProps } from 'plugins/walletConnectToDapps/WalletConnectModalManager'
-import type { FC } from 'react'
-import { useCallback, useMemo, useState } from 'react'
+import { forwardRef, useCallback, useImperativeHandle, useMemo, useState } from 'react'
 import { useTranslate } from 'react-polyglot'
 import { RawText, Text } from 'components/Text'
 import { useWallet } from 'hooks/useWallet/useWallet'
@@ -68,190 +68,203 @@ const createApprovalNamespaces = (
   )
 }
 
-const SessionProposal: FC<WalletConnectSessionModalProps> = ({
-  onClose: handleClose,
-  state: {
-    modalData: { proposal },
-    web3wallet,
-  },
-  dispatch,
-}) => {
-  assertIsDefined(proposal)
+const SessionProposal = forwardRef<SessionProposalRef, WalletConnectSessionModalProps>(
+  (
+    {
+      onClose: handleClose,
+      state: {
+        modalData: { proposal },
+        web3wallet,
+      },
+      dispatch,
+    }: WalletConnectSessionModalProps,
+    ref,
+  ) => {
+    assertIsDefined(proposal)
 
-  const wallet = useWallet().state.wallet
-  const translate = useTranslate()
+    const wallet = useWallet().state.wallet
+    const translate = useTranslate()
 
-  const { id, params } = proposal
-  const { proposer, requiredNamespaces, optionalNamespaces } = params
+    const { id, params } = proposal
+    const { proposer, requiredNamespaces, optionalNamespaces } = params
 
-  const [isLoading, setIsLoading] = useState<boolean>(false)
-  const [selectedAccountIds, setSelectedAccountIds] = useState<AccountId[]>([])
-  const toggleAccountId = useCallback((accountId: string) => {
-    setSelectedAccountIds(previousState =>
-      previousState.includes(accountId)
-        ? previousState.filter(existingAccountId => existingAccountId !== accountId)
-        : [...previousState, accountId],
-    )
-  }, [])
+    const [isLoading, setIsLoading] = useState<boolean>(false)
+    const [selectedAccountIds, setSelectedAccountIds] = useState<AccountId[]>([])
+    const toggleAccountId = useCallback((accountId: string) => {
+      setSelectedAccountIds(previousState =>
+        previousState.includes(accountId)
+          ? previousState.filter(existingAccountId => existingAccountId !== accountId)
+          : [...previousState, accountId],
+      )
+    }, [])
 
-  /*
+    /*
   We need to pass an account for every supported namespace. If we can't, we cannot approve the session.
   https://docs.walletconnect.com/2.0/specs/clients/sign/session-namespaces#21-session-namespaces-must-not-have-accounts-empty
    */
-  const allNamespacesSupported = useMemo(() => {
-    const allRequiredNamespacesSupported = checkAllNamespacesSupported(requiredNamespaces, wallet)
-    return allRequiredNamespacesSupported
-  }, [requiredNamespaces, wallet])
+    const allNamespacesSupported = useMemo(() => {
+      const allRequiredNamespacesSupported = checkAllNamespacesSupported(requiredNamespaces, wallet)
+      return allRequiredNamespacesSupported
+    }, [requiredNamespaces, wallet])
 
-  /*
+    /*
   All namespaces require at least one account in the response payload
   https://docs.walletconnect.com/2.0/specs/clients/sign/session-namespaces#24-session-namespaces-must-contain-at-least-one-account-in-requested-chains
    */
-  const allNamespacesHaveAccounts = useMemo(() => {
-    const allRequiredNamespacesHaveAccounts = checkAllNamespacesHaveAccounts(
+    const allNamespacesHaveAccounts = useMemo(() => {
+      const allRequiredNamespacesHaveAccounts = checkAllNamespacesHaveAccounts(
+        requiredNamespaces,
+        selectedAccountIds,
+      )
+      return allRequiredNamespacesHaveAccounts
+    }, [requiredNamespaces, selectedAccountIds])
+
+    const supportedOptionalNamespacesWithAccounts = useMemo(() => {
+      return Object.fromEntries(
+        Object.entries(optionalNamespaces)
+          .map(([key, namespace]): [string, ProposalTypes.BaseRequiredNamespace] => {
+            namespace.chains = namespace.chains?.filter(chainId => {
+              const isRequired = requiredNamespaces[key].chains?.includes(chainId)
+              const isSupported = walletSupportsChain({ chainId, wallet, isSnapInstalled: false })
+              return !isRequired && isSupported
+            })
+
+            return [key, namespace]
+          })
+          .filter(([_key, namespace]) => {
+            return namespace.chains && namespace.chains.length > 0
+          }),
+      )
+    }, [optionalNamespaces, requiredNamespaces, wallet])
+
+    const approvalNamespaces: SessionTypes.Namespaces = createApprovalNamespaces(
       requiredNamespaces,
       selectedAccountIds,
     )
-    return allRequiredNamespacesHaveAccounts
-  }, [requiredNamespaces, selectedAccountIds])
 
-  const supportedOptionalNamespacesWithAccounts = useMemo(() => {
-    return Object.fromEntries(
-      Object.entries(optionalNamespaces)
-        .map(([key, namespace]): [string, ProposalTypes.BaseRequiredNamespace] => {
-          namespace.chains = namespace.chains?.filter(chainId => {
-            const isRequired = requiredNamespaces[key].chains?.includes(chainId)
-            const isSupported = walletSupportsChain({ chainId, wallet, isSnapInstalled: false })
-            return !isRequired && isSupported
-          })
+    const handleApprove = useCallback(async () => {
+      // exit if the proposal was not found - likely duplicate call rerendering shenanigans
+      const pendingProposals = web3wallet.getPendingSessionProposals()
+      if (
+        !Object.values(pendingProposals).some(pendingProposal => pendingProposal.id === proposal.id)
+      ) {
+        return
+      }
 
-          return [key, namespace]
-        })
-        .filter(([_key, namespace]) => {
-          return namespace.chains && namespace.chains.length > 0
-        }),
-    )
-  }, [optionalNamespaces, requiredNamespaces, wallet])
+      setIsLoading(true)
 
-  const approvalNamespaces: SessionTypes.Namespaces = createApprovalNamespaces(
-    requiredNamespaces,
-    selectedAccountIds,
-  )
+      const session = await web3wallet.approveSession({
+        id: proposal.id,
+        namespaces: approvalNamespaces,
+      })
+      dispatch({ type: WalletConnectActionType.ADD_SESSION, payload: session })
+      handleClose()
+    }, [approvalNamespaces, dispatch, handleClose, proposal, web3wallet])
 
-  const handleApprove = useCallback(async () => {
-    // exit if the proposal was not found - likely duplicate call rerendering shenanigans
-    const pendingProposals = web3wallet.getPendingSessionProposals()
-    if (
-      !Object.values(pendingProposals).some(pendingProposal => pendingProposal.id === proposal.id)
-    ) {
-      return
-    }
+    const handleReject = useCallback(async () => {
+      setIsLoading(true)
 
-    setIsLoading(true)
+      await web3wallet.rejectSession({
+        id,
+        reason: getSdkError('USER_REJECTED_METHODS'),
+      })
+    }, [id, web3wallet])
 
-    const session = await web3wallet.approveSession({
-      id: proposal.id,
-      namespaces: approvalNamespaces,
-    })
-    dispatch({ type: WalletConnectActionType.ADD_SESSION, payload: session })
-    handleClose()
-  }, [approvalNamespaces, dispatch, handleClose, proposal, web3wallet])
+    const handleRejectAndClose = useCallback(async () => {
+      await handleReject()
+      handleClose()
+    }, [handleClose, handleReject])
 
-  const handleReject = useCallback(async () => {
-    setIsLoading(true)
+    // pass a reference to the reject function to the modal manager so it can reject on close
+    useImperativeHandle(ref, () => ({
+      handleReject,
+    }))
 
-    await web3wallet.rejectSession({
-      id,
-      reason: getSdkError('USER_REJECTED_METHODS'),
-    })
-
-    handleClose()
-  }, [handleClose, id, web3wallet])
-
-  const modalBody: JSX.Element = useMemo(() => {
-    return allNamespacesSupported ? (
-      <>
-        <ModalSection title='plugins.walletConnectToDapps.modal.sessionProposal.permissions'>
-          <Alert status={allNamespacesHaveAccounts ? 'success' : 'warning'} mb={4} mt={-2}>
-            <AlertIcon />
-            <AlertTitle>
-              <Text translation='plugins.walletConnectToDapps.modal.sessionProposal.permissionMessage' />
-            </AlertTitle>
-          </Alert>
-          <Permissions
-            requiredNamespaces={requiredNamespaces}
-            selectedAccountIds={selectedAccountIds}
-            toggleAccountId={toggleAccountId}
-          />
-        </ModalSection>
-        {Object.keys(supportedOptionalNamespacesWithAccounts).length > 0 && (
-          <ModalSection title='plugins.walletConnectToDapps.modal.sessionProposal.optionalPermissions'>
-            <Alert status='info' mb={4} mt={-2}>
+    const modalBody: JSX.Element = useMemo(() => {
+      return allNamespacesSupported ? (
+        <>
+          <ModalSection title='plugins.walletConnectToDapps.modal.sessionProposal.permissions'>
+            <Alert status={allNamespacesHaveAccounts ? 'success' : 'warning'} mb={4} mt={-2}>
               <AlertIcon />
               <AlertTitle>
-                <Text translation='plugins.walletConnectToDapps.modal.sessionProposal.optionalPermissionMessage' />
+                <Text translation='plugins.walletConnectToDapps.modal.sessionProposal.permissionMessage' />
               </AlertTitle>
             </Alert>
             <Permissions
-              requiredNamespaces={supportedOptionalNamespacesWithAccounts}
+              requiredNamespaces={requiredNamespaces}
               selectedAccountIds={selectedAccountIds}
               toggleAccountId={toggleAccountId}
             />
           </ModalSection>
-        )}
-      </>
-    ) : (
-      <RawText>
-        {translate('plugins.walletConnectToDapps.modal.sessionProposal.unsupportedChain')}
-      </RawText>
-    )
-  }, [
-    allNamespacesSupported,
-    requiredNamespaces,
-    selectedAccountIds,
-    toggleAccountId,
-    supportedOptionalNamespacesWithAccounts,
-    allNamespacesHaveAccounts,
-    translate,
-  ])
+          {Object.keys(supportedOptionalNamespacesWithAccounts).length > 0 && (
+            <ModalSection title='plugins.walletConnectToDapps.modal.sessionProposal.optionalPermissions'>
+              <Alert status='info' mb={4} mt={-2}>
+                <AlertIcon />
+                <AlertTitle>
+                  <Text translation='plugins.walletConnectToDapps.modal.sessionProposal.optionalPermissionMessage' />
+                </AlertTitle>
+              </Alert>
+              <Permissions
+                requiredNamespaces={supportedOptionalNamespacesWithAccounts}
+                selectedAccountIds={selectedAccountIds}
+                toggleAccountId={toggleAccountId}
+              />
+            </ModalSection>
+          )}
+        </>
+      ) : (
+        <RawText>
+          {translate('plugins.walletConnectToDapps.modal.sessionProposal.unsupportedChain')}
+        </RawText>
+      )
+    }, [
+      allNamespacesSupported,
+      requiredNamespaces,
+      selectedAccountIds,
+      toggleAccountId,
+      supportedOptionalNamespacesWithAccounts,
+      allNamespacesHaveAccounts,
+      translate,
+    ])
 
-  return (
-    <>
-      <ModalSection title='plugins.walletConnectToDapps.modal.sessionProposal.dAppInfo'>
-        <DAppInfo metadata={proposer.metadata} />
-      </ModalSection>
-      {modalBody}
-      <ModalSection title={''}>
-        <VStack spacing={4}>
-          <Button
-            size='lg'
-            width='full'
-            colorScheme='blue'
-            type='submit'
-            onClick={handleApprove}
-            isDisabled={
-              selectedAccountIds.length === 0 ||
-              !allNamespacesSupported ||
-              !allNamespacesHaveAccounts
-            }
-            _disabled={disabledProp}
-            isLoading={isLoading}
-          >
-            {translate('plugins.walletConnectToDapps.modal.signMessage.confirm')}
-          </Button>
-          <Button
-            size='lg'
-            width='full'
-            onClick={handleReject}
-            isDisabled={isLoading}
-            _disabled={disabledProp}
-          >
-            {translate('plugins.walletConnectToDapps.modal.signMessage.reject')}
-          </Button>
-        </VStack>
-      </ModalSection>
-    </>
-  )
-}
+    return (
+      <>
+        <ModalSection title='plugins.walletConnectToDapps.modal.sessionProposal.dAppInfo'>
+          <DAppInfo metadata={proposer.metadata} />
+        </ModalSection>
+        {modalBody}
+        <ModalSection title={''}>
+          <VStack spacing={4}>
+            <Button
+              size='lg'
+              width='full'
+              colorScheme='blue'
+              type='submit'
+              onClick={handleApprove}
+              isDisabled={
+                selectedAccountIds.length === 0 ||
+                !allNamespacesSupported ||
+                !allNamespacesHaveAccounts
+              }
+              _disabled={disabledProp}
+              isLoading={isLoading}
+            >
+              {translate('plugins.walletConnectToDapps.modal.signMessage.confirm')}
+            </Button>
+            <Button
+              size='lg'
+              width='full'
+              onClick={handleRejectAndClose}
+              isDisabled={isLoading}
+              _disabled={disabledProp}
+            >
+              {translate('plugins.walletConnectToDapps.modal.signMessage.reject')}
+            </Button>
+          </VStack>
+        </ModalSection>
+      </>
+    )
+  },
+)
 
 export const SessionProposalModal = SessionProposal

--- a/src/plugins/walletConnectToDapps/types.ts
+++ b/src/plugins/walletConnectToDapps/types.ts
@@ -240,3 +240,7 @@ export type ConfirmData = {
     priorityFee: string
   }
 }
+
+export type SessionProposalRef = {
+  handleReject: () => Promise<void>
+}


### PR DESCRIPTION
## Description

Resolves the issue where closing a WalletConnect modal leaves a pending request, which prevents subsequent requests from appearing in the application.

## Pull Request Type

- [x] :bug: Bug fix (Non-breaking Change: Fixes an issue)
- [ ] :hammer_and_wrench: Chore (Non-breaking Change: Doc updates, pkg upgrades, typos, etc..)
- [ ] :nail_care: New Feature (Breaking/Non-breaking Change)

## Issue (if applicable)

solves first part of #5378 

## Risk

Risk of walletconnect requests (sessions, transactions etc) broken

## Testing

The application should automatically reject a pending request when:

The user closes the modal by clicking the close icon
The user closes the modal by clicking outside of it

### Engineering

☝️

### Operations

☝️

## Screenshots (if applicable)
