### PR TITLE
feat: chain-adapters `getAddress()` from unchained

### DIFF
--- a/packages/chain-adapters/src/evm/EvmBaseAdapter.ts
+++ b/packages/chain-adapters/src/evm/EvmBaseAdapter.ts
@@ -527,6 +527,11 @@ export abstract class EvmBaseAdapter<T extends EvmChainId> implements IChainAdap
   async getAddress(input: GetAddressInput): Promise<string> {
     const { accountNumber, wallet, showOnDevice = false } = input
     const bip44Params = this.getBIP44Params({ accountNumber })
+
+    if (input.pubKey) {
+      return input.pubKey
+    }
+
     const address = await (wallet as ETHWallet).ethGetAddress({
       addressNList: toAddressNList(bip44Params),
       showDisplay: showOnDevice,

--- a/packages/chain-adapters/src/types.ts
+++ b/packages/chain-adapters/src/types.ts
@@ -238,6 +238,7 @@ export type GetAddressInputBase = {
    * Request that the address be shown to the user by the device, if supported
    */
   showOnDevice?: boolean
+  pubKey?: string
 }
 
 export type GetAddressInput = GetAddressInputBase | utxo.GetAddressInput

--- a/packages/chain-adapters/src/types.ts
+++ b/packages/chain-adapters/src/types.ts
@@ -238,6 +238,10 @@ export type GetAddressInputBase = {
    * Request that the address be shown to the user by the device, if supported
    */
   showOnDevice?: boolean
+  /**
+   * An optional public key to be passed, which will bypass the HD wallet derivation
+   * and instead use unchained to "derive" the address from the public key
+   */
   pubKey?: string
 }
 

--- a/packages/chain-adapters/src/utxo/UtxoBaseAdapter.ts
+++ b/packages/chain-adapters/src/utxo/UtxoBaseAdapter.ts
@@ -231,9 +231,7 @@ export abstract class UtxoBaseAdapter<T extends UtxoChainId> implements IChainAd
 
         if (index === undefined)
           throw new Error(`UtxoBaseAdapter: Could not fetch address index from unchained`)
-        if (!account.chainSpecific.addresses)
-          throw new Error(`UtxoBaseAdapter: Could not fetch addresses from unchained`)
-        const address = account.chainSpecific.addresses[index].pubkey
+        const address = account.chainSpecific.addresses?.[index]?.pubkey
         if (!address)
           throw new Error(
             `UtxoBaseAdapter: Could not fetch address from unchained at index ${index}`,

--- a/packages/chain-adapters/src/utxo/UtxoBaseAdapter.ts
+++ b/packages/chain-adapters/src/utxo/UtxoBaseAdapter.ts
@@ -230,7 +230,7 @@ export abstract class UtxoBaseAdapter<T extends UtxoChainId> implements IChainAd
           : account.chainSpecific.nextReceiveAddressIndex
 
         if (index === undefined)
-          throw new Error(`UtxoBaseAdapter: Could not fetch nextReceiveIndex from unchained`)
+          throw new Error(`UtxoBaseAdapter: Could not fetch address index from unchained`)
         if (!account.chainSpecific.addresses)
           throw new Error(`UtxoBaseAdapter: Could not fetch addresses from unchained`)
         const address = account.chainSpecific.addresses[index].pubkey

--- a/packages/chain-adapters/src/utxo/UtxoBaseAdapter.ts
+++ b/packages/chain-adapters/src/utxo/UtxoBaseAdapter.ts
@@ -225,15 +225,18 @@ export abstract class UtxoBaseAdapter<T extends UtxoChainId> implements IChainAd
 
       if (pubKey) {
         const account = await this.getAccount(pubKey)
-        const nextReceiveIndex = account.chainSpecific.nextReceiveAddressIndex
-        if (!nextReceiveIndex)
+        const index = bip44Params.isChange
+          ? account.chainSpecific.nextChangeAddressIndex
+          : account.chainSpecific.nextReceiveAddressIndex
+
+        if (index === undefined)
           throw new Error(`UtxoBaseAdapter: Could not fetch nextReceiveIndex from unchained`)
         if (!account.chainSpecific.addresses)
           throw new Error(`UtxoBaseAdapter: Could not fetch addresses from unchained`)
-        const address = account.chainSpecific.addresses[nextReceiveIndex].pubkey
+        const address = account.chainSpecific.addresses[index].pubkey
         if (!address)
           throw new Error(
-            `UtxoBaseAdapter: Could not fetch address from unchained at index ${nextReceiveIndex}`,
+            `UtxoBaseAdapter: Could not fetch address from unchained at index ${index}`,
           )
 
         return address

--- a/src/assets/translations/en/main.json
+++ b/src/assets/translations/en/main.json
@@ -1278,7 +1278,8 @@
       "failure": {
         "header": "Error",
         "body": "Unable to connect Ledger wallet"
-      }
+      },
+      "connectWarning": "Before connecting a chain, make sure you have the app open on your device."
     },
     "metaMask": {
       "errors": {

--- a/src/components/Icons/LedgerIcon.tsx
+++ b/src/components/Icons/LedgerIcon.tsx
@@ -7,18 +7,10 @@ import { createIcon } from '@chakra-ui/react'
 export const LedgerIcon = createIcon({
   displayName: 'LedgerIcon',
   path: (
-    <svg
-      width='147'
-      height='128'
-      viewBox='0 0 147 128'
-      fill='none'
-      xmlns='http://www.w3.org/2000/svg'
-    >
-      <path
-        d='M0 91.6548V128H55.293V119.94H8.05631V91.6548H0ZM138.944 91.6548V119.94H91.707V127.998H147V91.6548H138.944ZM55.3733 36.3452V91.6529H91.707V84.3842H63.4296V36.3452H55.3733ZM0 0V36.3452H8.05631V8.05844H55.293V0H0ZM91.707 0V8.05844H138.944V36.3452H147V0H91.707Z'
-        fill='black'
-      />
-    </svg>
+    <path
+      d='M0 91.6548V128H55.293V119.94H8.05631V91.6548H0ZM138.944 91.6548V119.94H91.707V127.998H147V91.6548H138.944ZM55.3733 36.3452V91.6529H91.707V84.3842H63.4296V36.3452H55.3733ZM0 0V36.3452H8.05631V8.05844H55.293V0H0ZM91.707 0V8.05844H138.944V36.3452H147V0H91.707Z'
+      fill='currentColor'
+    />
   ),
-  viewBox: '0 0 200 200',
+  viewBox: '0 0 147 129',
 })

--- a/src/components/Modals/Receive/ReceiveInfo.tsx
+++ b/src/components/Modals/Receive/ReceiveInfo.tsx
@@ -69,17 +69,15 @@ export const ReceiveInfo = ({ asset, accountId }: ReceivePropsType) => {
     ;(async () => {
       if (!accountMetadata) return
       if (!wallet) return
-      const maybePubKey = (() => {
-        if (!isLedger(wallet)) return {}
-        if (!selectedAccountId) return {}
-        return { pubKey: fromAccountId(selectedAccountId as AccountId).account }
-      })()
       const selectedAccountAddress = await getReceiveAddress({
         asset,
         wallet,
         deviceId: await wallet.getDeviceID(),
         accountMetadata,
-        ...maybePubKey,
+        pubKey:
+          isLedger(wallet) && selectedAccountId
+            ? fromAccountId(selectedAccountId as AccountId).account
+            : undefined,
       })
       setReceiveAddress(selectedAccountAddress)
     })()

--- a/src/components/Modals/Receive/ReceiveInfo.tsx
+++ b/src/components/Modals/Receive/ReceiveInfo.tsx
@@ -21,7 +21,8 @@ import {
   useToast,
 } from '@chakra-ui/react'
 import type { AccountId } from '@shapeshiftoss/caip'
-import { CHAIN_NAMESPACE, fromChainId } from '@shapeshiftoss/caip'
+import { CHAIN_NAMESPACE, fromAccountId, fromChainId } from '@shapeshiftoss/caip'
+import { isLedger } from '@shapeshiftoss/hdwallet-ledger'
 import { KnownChainIds } from '@shapeshiftoss/types'
 import { useCallback, useEffect, useMemo, useState } from 'react'
 import { useTranslate } from 'react-polyglot'
@@ -68,11 +69,17 @@ export const ReceiveInfo = ({ asset, accountId }: ReceivePropsType) => {
     ;(async () => {
       if (!accountMetadata) return
       if (!wallet) return
+      const maybePubKey = (() => {
+        if (!isLedger(wallet)) return {}
+        if (!selectedAccountId) return {}
+        return { pubKey: fromAccountId(selectedAccountId as AccountId).account }
+      })()
       const selectedAccountAddress = await getReceiveAddress({
         asset,
         wallet,
         deviceId: await wallet.getDeviceID(),
         accountMetadata,
+        ...maybePubKey,
       })
       setReceiveAddress(selectedAccountAddress)
     })()
@@ -85,6 +92,7 @@ export const ReceiveInfo = ({ asset, accountId }: ReceivePropsType) => {
     chainAdapter,
     bip44Params,
     accountMetadata,
+    selectedAccountId,
   ])
 
   useEffect(() => {

--- a/src/components/MultiHopTrade/hooks/useGetTradeQuotes/getTradeQuoteArgs.ts
+++ b/src/components/MultiHopTrade/hooks/useGetTradeQuotes/getTradeQuoteArgs.ts
@@ -26,6 +26,7 @@ export type GetTradeQuoteInputArgs = {
   allowMultiHop: boolean
   affiliateBps?: string
   isSnapInstalled?: boolean
+  pubKey?: string | undefined
 }
 
 export const getTradeQuoteArgs = async ({
@@ -40,6 +41,7 @@ export const getTradeQuoteArgs = async ({
   allowMultiHop,
   affiliateBps,
   slippageTolerancePercentage,
+  pubKey,
 }: GetTradeQuoteInputArgs): Promise<GetTradeQuoteInput | undefined> => {
   if (!sellAsset || !buyAsset) return undefined
   const tradeQuoteInputCommonArgs: TradeQuoteInputCommonArgs = {
@@ -63,6 +65,7 @@ export const getTradeQuoteArgs = async ({
     const sendAddress = await sellAssetChainAdapter.getAddress({
       accountNumber: sellAccountNumber,
       wallet,
+      pubKey,
     })
     return {
       ...tradeQuoteInputCommonArgs,

--- a/src/components/MultiHopTrade/hooks/useGetTradeQuotes/useGetTradeQuotes.tsx
+++ b/src/components/MultiHopTrade/hooks/useGetTradeQuotes/useGetTradeQuotes.tsx
@@ -141,6 +141,10 @@ export const useGetTradeQuotes = () => {
         const isFromEvm = isEvmChainId(sellAsset.chainId)
         // disable EVM donations on KeepKey until https://github.com/shapeshift/web/issues/4518 is resolved
         const willDonate = walletIsKeepKey ? userWillDonate && !isFromEvm : userWillDonate
+        const maybePubKey = (() => {
+          if (!isLedger(wallet)) return {}
+          return { pubKey: fromAccountId(sellAccountId).account }
+        })()
 
         const updatedTradeQuoteInput: GetTradeQuoteInput | undefined = await getTradeQuoteArgs({
           sellAsset,
@@ -155,7 +159,7 @@ export const useGetTradeQuotes = () => {
           affiliateBps: willDonate ? DEFAULT_SWAPPER_DONATION_BPS : '0',
           // Pass in the user's slippage preference if it's set, else let the swapper use its default
           slippageTolerancePercentage: userSlippageTolerancePercentage,
-          pubKey: fromAccountId(sellAccountId).account,
+          ...maybePubKey,
         })
 
         // if the quote input args changed, reset the selected swapper and update the trade quote args

--- a/src/components/MultiHopTrade/hooks/useGetTradeQuotes/useGetTradeQuotes.tsx
+++ b/src/components/MultiHopTrade/hooks/useGetTradeQuotes/useGetTradeQuotes.tsx
@@ -1,5 +1,6 @@
 import { skipToken } from '@reduxjs/toolkit/dist/query'
 import { isEvmChainId } from '@shapeshiftoss/chain-adapters'
+import { isLedger } from '@shapeshiftoss/hdwallet-ledger'
 import { isEqual } from 'lodash'
 import { useEffect, useMemo, useState } from 'react'
 import { DEFAULT_SWAPPER_DONATION_BPS } from 'components/MultiHopTrade/constants'
@@ -100,7 +101,13 @@ export const useGetTradeQuotes = () => {
   const debouncedTradeQuoteInput = useDebounce(tradeQuoteInput, 500)
   const sellAsset = useAppSelector(selectSellAsset)
   const buyAsset = useAppSelector(selectBuyAsset)
-  const receiveAddress = useReceiveAddress()
+  const useReceiveAddressArgs = useMemo(
+    () => ({
+      useUnchained: Boolean(wallet && isLedger(wallet)),
+    }),
+    [wallet],
+  )
+  const receiveAddress = useReceiveAddress(useReceiveAddressArgs)
   const sellAmountCryptoPrecision = useAppSelector(selectSellAmountCryptoPrecision)
   const userWillDonate = useAppSelector(selectWillDonate)
 

--- a/src/components/MultiHopTrade/hooks/useGetTradeQuotes/useGetTradeQuotes.tsx
+++ b/src/components/MultiHopTrade/hooks/useGetTradeQuotes/useGetTradeQuotes.tsx
@@ -104,7 +104,7 @@ export const useGetTradeQuotes = () => {
   const buyAsset = useAppSelector(selectBuyAsset)
   const useReceiveAddressArgs = useMemo(
     () => ({
-      useUnchained: Boolean(wallet && isLedger(wallet)),
+      fetchUnchainedAddress: Boolean(wallet && isLedger(wallet)),
     }),
     [wallet],
   )

--- a/src/components/MultiHopTrade/hooks/useGetTradeQuotes/useGetTradeQuotes.tsx
+++ b/src/components/MultiHopTrade/hooks/useGetTradeQuotes/useGetTradeQuotes.tsx
@@ -1,4 +1,5 @@
 import { skipToken } from '@reduxjs/toolkit/dist/query'
+import { fromAccountId } from '@shapeshiftoss/caip'
 import { isEvmChainId } from '@shapeshiftoss/chain-adapters'
 import { isLedger } from '@shapeshiftoss/hdwallet-ledger'
 import { isEqual } from 'lodash'
@@ -131,7 +132,7 @@ export const useGetTradeQuotes = () => {
   const mixpanel = getMixPanel()
 
   useEffect(() => {
-    if (wallet && sellAccountMetadata && receiveAddress) {
+    if (wallet && sellAccountId && sellAccountMetadata && receiveAddress) {
       ;(async () => {
         const { accountNumber: sellAccountNumber } = sellAccountMetadata.bip44Params
         const receiveAssetBip44Params = receiveAccountMetadata?.bip44Params
@@ -154,6 +155,7 @@ export const useGetTradeQuotes = () => {
           affiliateBps: willDonate ? DEFAULT_SWAPPER_DONATION_BPS : '0',
           // Pass in the user's slippage preference if it's set, else let the swapper use its default
           slippageTolerancePercentage: userSlippageTolerancePercentage,
+          pubKey: fromAccountId(sellAccountId).account,
         })
 
         // if the quote input args changed, reset the selected swapper and update the trade quote args

--- a/src/components/MultiHopTrade/hooks/useGetTradeQuotes/useGetTradeQuotes.tsx
+++ b/src/components/MultiHopTrade/hooks/useGetTradeQuotes/useGetTradeQuotes.tsx
@@ -141,10 +141,6 @@ export const useGetTradeQuotes = () => {
         const isFromEvm = isEvmChainId(sellAsset.chainId)
         // disable EVM donations on KeepKey until https://github.com/shapeshift/web/issues/4518 is resolved
         const willDonate = walletIsKeepKey ? userWillDonate && !isFromEvm : userWillDonate
-        const maybePubKey = (() => {
-          if (!isLedger(wallet)) return {}
-          return { pubKey: fromAccountId(sellAccountId).account }
-        })()
 
         const updatedTradeQuoteInput: GetTradeQuoteInput | undefined = await getTradeQuoteArgs({
           sellAsset,
@@ -159,7 +155,7 @@ export const useGetTradeQuotes = () => {
           affiliateBps: willDonate ? DEFAULT_SWAPPER_DONATION_BPS : '0',
           // Pass in the user's slippage preference if it's set, else let the swapper use its default
           slippageTolerancePercentage: userSlippageTolerancePercentage,
-          ...maybePubKey,
+          pubKey: isLedger(wallet) ? fromAccountId(sellAccountId).account : undefined,
         })
 
         // if the quote input args changed, reset the selected swapper and update the trade quote args
@@ -198,6 +194,7 @@ export const useGetTradeQuotes = () => {
     userWillDonate,
     receiveAccountMetadata?.bip44Params,
     userSlippageTolerancePercentage,
+    sellAccountId,
   ])
 
   useEffect(() => {

--- a/src/components/MultiHopTrade/hooks/useReceiveAddress.tsx
+++ b/src/components/MultiHopTrade/hooks/useReceiveAddress.tsx
@@ -20,13 +20,14 @@ export const getReceiveAddress = pMemoize(
     asset,
     wallet,
     accountMetadata,
+    pubKey,
   }: GetReceiveAddressArgs): Promise<string | undefined> => {
     const { chainId } = fromAssetId(asset.assetId)
     const { accountType, bip44Params } = accountMetadata
     const chainAdapter = getChainAdapterManager().get(chainId)
     if (!(chainAdapter && wallet)) return
     const { accountNumber } = bip44Params
-    const address = await chainAdapter.getAddress({ wallet, accountNumber, accountType })
+    const address = await chainAdapter.getAddress({ wallet, accountNumber, accountType, pubKey })
     return address
   },
   {
@@ -40,7 +41,8 @@ export const getReceiveAddress = pMemoize(
   },
 )
 
-export const useReceiveAddress = () => {
+// TODO(gomes): give these args a better name
+export const useReceiveAddress = ({ useUnchained }: { useUnchained?: boolean } = {}) => {
   // Hooks
   const wallet = useWallet().state.wallet
   // TODO: this should live in redux
@@ -73,10 +75,11 @@ export const useReceiveAddress = () => {
         wallet,
         accountMetadata: buyAccountMetadata,
         deviceId: await wallet.getDeviceID(),
+        ...(useUnchained && { pubKey: fromAccountId(buyAccountId).account }),
       })
       return receiveAddress
     },
-    [buyAccountId, buyAccountMetadata, wallet],
+    [buyAccountId, buyAccountMetadata, useUnchained, wallet],
   )
 
   // Set the receiveAddress when the buy asset changes

--- a/src/components/MultiHopTrade/hooks/useReceiveAddress.tsx
+++ b/src/components/MultiHopTrade/hooks/useReceiveAddress.tsx
@@ -76,7 +76,7 @@ export const useReceiveAddress = ({
         wallet,
         accountMetadata: buyAccountMetadata,
         deviceId: await wallet.getDeviceID(),
-        ...(fetchUnchainedAddress && { pubKey: fromAccountId(buyAccountId).account }),
+        pubKey: fetchUnchainedAddress ? fromAccountId(buyAccountId).account : undefined,
       })
       return receiveAddress
     },

--- a/src/components/MultiHopTrade/hooks/useReceiveAddress.tsx
+++ b/src/components/MultiHopTrade/hooks/useReceiveAddress.tsx
@@ -41,8 +41,9 @@ export const getReceiveAddress = pMemoize(
   },
 )
 
-// TODO(gomes): give these args a better name
-export const useReceiveAddress = ({ useUnchained }: { useUnchained?: boolean } = {}) => {
+export const useReceiveAddress = ({
+  fetchUnchainedAddress,
+}: { fetchUnchainedAddress?: boolean } = {}) => {
   // Hooks
   const wallet = useWallet().state.wallet
   // TODO: this should live in redux
@@ -75,11 +76,11 @@ export const useReceiveAddress = ({ useUnchained }: { useUnchained?: boolean } =
         wallet,
         accountMetadata: buyAccountMetadata,
         deviceId: await wallet.getDeviceID(),
-        ...(useUnchained && { pubKey: fromAccountId(buyAccountId).account }),
+        ...(fetchUnchainedAddress && { pubKey: fromAccountId(buyAccountId).account }),
       })
       return receiveAddress
     },
-    [buyAccountId, buyAccountMetadata, useUnchained, wallet],
+    [buyAccountId, buyAccountMetadata, fetchUnchainedAddress, wallet],
   )
 
   // Set the receiveAddress when the buy asset changes

--- a/src/components/MultiHopTrade/types.ts
+++ b/src/components/MultiHopTrade/types.ts
@@ -49,6 +49,7 @@ export type GetReceiveAddressArgs = {
   wallet: HDWallet
   deviceId: string
   accountMetadata: AccountMetadata
+  pubKey?: string
 }
 
 export type TradeQuoteInputCommonArgs = Pick<

--- a/src/context/WalletProvider/Ledger/components/Chains.tsx
+++ b/src/context/WalletProvider/Ledger/components/Chains.tsx
@@ -1,4 +1,5 @@
-import { Box, Button, Flex, ModalBody, Spinner, Text as CText } from '@chakra-ui/react'
+import { CheckCircleIcon } from '@chakra-ui/icons'
+import { Alert, AlertDescription, AlertIcon, Box, Button, Flex, ModalBody } from '@chakra-ui/react'
 import type { ChainId } from '@shapeshiftoss/caip'
 import {
   bchAssetId,
@@ -17,7 +18,7 @@ import {
 import pull from 'lodash/pull'
 import { useCallback, useMemo, useState } from 'react'
 import { AssetIcon } from 'components/AssetIcon'
-import { Text } from 'components/Text'
+import { RawText, Text } from 'components/Text'
 import { getSupportedEvmChainIds } from 'hooks/useEvm/useEvm'
 import { useWallet } from 'hooks/useWallet/useWallet'
 import { deriveAccountIdsAndMetadataForChainNamespace } from 'lib/account/account'
@@ -119,23 +120,29 @@ export const LedgerChains = () => {
 
   const chainsRows = useMemo(
     () =>
-      availableAssets.map(asset => (
-        <Flex alignItems='center' justifyContent='space-between' mb={4} key={asset.assetId}>
-          <Flex alignItems='center'>
-            <AssetIcon assetId={asset.assetId} mr={2} />
-            <CText>{asset.name}</CText>
-          </Flex>
-          {walletChainIds.includes(asset.chainId) ? (
-            <CText>Added</CText>
-          ) : loadingChains[asset.chainId] ? (
-            <Spinner />
-          ) : (
-            <Button colorScheme='blue' onClick={() => handleConnectClick(asset.chainId)}>
-              Connect
-            </Button>
-          )}
-        </Flex>
-      )),
+      availableAssets
+        .sort(a => (walletChainIds.includes(a.chainId) ? 1 : -1))
+        .map(asset => {
+          return (
+            <Flex alignItems='center' justifyContent='space-between' mb={4} key={asset.assetId}>
+              <Flex alignItems='center' gap={2}>
+                <AssetIcon assetId={asset.assetId} size='sm' />
+                <RawText fontWeight='bold'>{asset.name}</RawText>
+              </Flex>
+              <Button
+                isLoading={loadingChains[asset.chainId]}
+                onClick={() => handleConnectClick(asset.chainId)}
+                colorScheme={walletChainIds.includes(asset.chainId) ? 'green' : 'gray'}
+                isDisabled={walletChainIds.includes(asset.chainId)}
+                {...(walletChainIds.includes(asset.chainId)
+                  ? { leftIcon: <CheckCircleIcon /> }
+                  : {})}
+              >
+                {walletChainIds.includes(asset.chainId) ? 'Added' : 'Connect'}
+              </Button>
+            </Flex>
+          )
+        }),
     [availableAssets, handleConnectClick, loadingChains, walletChainIds],
   )
 
@@ -151,6 +158,12 @@ export const LedgerChains = () => {
           />
           <Text color='text.subtle' translation={'walletProvider.ledger.chains.body'} />
         </Box>
+        <Alert status='info' mb={4}>
+          <AlertIcon />
+          <AlertDescription>
+            <Text translation='walletProvider.ledger.connectWarning' />
+          </AlertDescription>
+        </Alert>
         <Box mb={4}>
           <Text
             fontSize='md'

--- a/src/context/WalletProvider/Ledger/components/Chains.tsx
+++ b/src/context/WalletProvider/Ledger/components/Chains.tsx
@@ -120,29 +120,25 @@ export const LedgerChains = () => {
 
   const chainsRows = useMemo(
     () =>
-      availableAssets
-        .sort(a => (walletChainIds.includes(a.chainId) ? 1 : -1))
-        .map(asset => {
-          return (
-            <Flex alignItems='center' justifyContent='space-between' mb={4} key={asset.assetId}>
-              <Flex alignItems='center' gap={2}>
-                <AssetIcon assetId={asset.assetId} size='sm' />
-                <RawText fontWeight='bold'>{asset.name}</RawText>
-              </Flex>
-              <Button
-                isLoading={loadingChains[asset.chainId]}
-                onClick={() => handleConnectClick(asset.chainId)}
-                colorScheme={walletChainIds.includes(asset.chainId) ? 'green' : 'gray'}
-                isDisabled={walletChainIds.includes(asset.chainId)}
-                {...(walletChainIds.includes(asset.chainId)
-                  ? { leftIcon: <CheckCircleIcon /> }
-                  : {})}
-              >
-                {walletChainIds.includes(asset.chainId) ? 'Added' : 'Connect'}
-              </Button>
+      availableAssets.map(asset => {
+        return (
+          <Flex alignItems='center' justifyContent='space-between' mb={4} key={asset.assetId}>
+            <Flex alignItems='center' gap={2}>
+              <AssetIcon assetId={asset.assetId} size='sm' />
+              <RawText fontWeight='bold'>{asset.name}</RawText>
             </Flex>
-          )
-        }),
+            <Button
+              isLoading={loadingChains[asset.chainId]}
+              onClick={() => handleConnectClick(asset.chainId)}
+              colorScheme={walletChainIds.includes(asset.chainId) ? 'green' : 'gray'}
+              isDisabled={walletChainIds.includes(asset.chainId)}
+              leftIcon={walletChainIds.includes(asset.chainId) ? <CheckCircleIcon /> : undefined}
+            >
+              {walletChainIds.includes(asset.chainId) ? 'Added' : 'Connect'}
+            </Button>
+          </Flex>
+        )
+      }),
     [availableAssets, handleConnectClick, loadingChains, walletChainIds],
   )
 


### PR DESCRIPTION
## Description

With a new `pubKey` param - indicating public key should be used to fetch the address from unchained and bypass wallet fetching.

This allows us to effectively unrug cross-chain trades (can't have two apps open at the same time to get each address) as well as make the UX smoother, not requiring users to open the relevant app when they're getting an address i.e receive modal, trade etc. If we have xpubs / address identifiers, we can use those to either do an Identity on them (return self), or for xpubs, use unchained to get the receive address.

## Pull Request Type

- [ ] :bug: Bug fix (Non-breaking Change: Fixes an issue)
- [ ] :hammer_and_wrench: Chore (Non-breaking Change: Doc updates, pkg upgrades, typos, etc..)
- [x] :nail_care: New Feature (Breaking/Non-breaking Change)

## Issue (if applicable)

<!-----------------------------------------------------------------------------
If applicable, please link to the github issue and put `closes #XXXX` in your comment to auto-close the issue that your PR fixes.
------------------------------------------------------------------------------>

closes #

## Risk

<!-----------------------------------------------------------------------------
Outline the scope of your changes and the risk associated with them. You must use your discretion as an engineer to determine the potential impact of your changes.

E.g. an upgrade to `hdwallet` or core state management would be considered higher risk, and might require a full regression test. UI or isolated view changes, or something behind a feature flag may have near zero risk. Small bug fixes might require testing isolated to the specific fix.
------------------------------------------------------------------------------>

Moderate/high, but effectively close to zero given this is isolated to Ledger. 
**Ensure that all code paths related to this are guarded against wallets other than ledger**. This param should *never* be passed to `adapter.getAddress()` for other wallets.

## Testing

<!-----------------------------------------------------------------------------
We treat every PR to be merged with the same scrutiny as if we were merging directly to production.

Your PR will not be merged if you do not complete the sections below for our engineering and operations teams to test.
------------------------------------------------------------------------------>

### Engineering

<!-----------------------------------------------------------------------------
Include sufficient information here for an engineer to test your PR. This may include how to test locally, in a built environment, changes to infrastructure etc.
------------------------------------------------------------------------------>

- ☝🏽 
- Put a breakpoint in chain-adapters `getAddress()` methods
- Ensure the branch never gets hit unless the current wallet is Ledger

### Operations

<!-----------------------------------------------------------------------------
If your changes have a user-facing impact, describe how a non-technical QA team can functionally test your changes in a preview environment.

If they are not user-facing please describe how to test for any regressions that may occur.
------------------------------------------------------------------------------>

#### Ledger flag on

- Connect your Ledger accounts
- Go to an EVM / UTXO account and click "Receive" either with the wrong app open or while on the Ledger homescreen and confirm the receive address is still working and the correct one (can be tested by importing the same seed as native in your Ledger and ensuring the receive address is the same)
  - Make sure to test with UTXO accounts that have some Tx history, i.e where the next receive/change address is *not* the zero'th 
- Cross-chain quotes are working with a Ledger connected

#### Ledger flag off

- Ensure the receive addresses aren't showing any regression. Test with native and/or KK, in particular with UTXOs and ATOM/RUNE

## Screenshots (if applicable)

<img width="1411" alt="image" src="https://github.com/shapeshift/web/assets/17035424/d07ad2d3-cf9f-4f83-aea7-4af6f69c759c">