### PR TITLE
fix: ensure wallet connected when wallectconnect receives a request

### DIFF
--- a/src/plugins/walletConnectToDapps/WalletConnectModalManager.tsx
+++ b/src/plugins/walletConnectToDapps/WalletConnectModalManager.tsx
@@ -77,7 +77,7 @@ export const WalletConnectModalManager: FC<WalletConnectModalManagerProps> = ({
   state,
   dispatch,
 }) => {
-  const wallet = useWallet().state.wallet
+  const { wallet, isConnected } = useWallet().state
   const sessionProposalRef = useRef<SessionProposalRef>(null)
   const { chainAdapter, requestEvent, accountMetadata, accountId } = useWalletConnectState(state)
 
@@ -264,6 +264,12 @@ export const WalletConnectModalManager: FC<WalletConnectModalManagerProps> = ({
     topic,
     web3wallet,
   ])
+
+  // automatically reject requests that are received without wallet connected
+  if (!isConnected) {
+    void handleRejectRequestAndClose()
+    return null
+  }
 
   if (modalContent === null) return null
 

--- a/src/plugins/walletConnectToDapps/WalletConnectModalManager.tsx
+++ b/src/plugins/walletConnectToDapps/WalletConnectModalManager.tsx
@@ -266,7 +266,7 @@ export const WalletConnectModalManager: FC<WalletConnectModalManagerProps> = ({
   ])
 
   // automatically reject requests that are received without wallet connected
-  if (!isConnected) {
+  if (activeModal !== undefined && !isConnected) {
     void handleRejectRequestAndClose()
     return null
   }


### PR DESCRIPTION
## Description

Reopens #5387 

## Pull Request Type

- [x] :bug: Bug fix (Non-breaking Change: Fixes an issue)
- [ ] :hammer_and_wrench: Chore (Non-breaking Change: Doc updates, pkg upgrades, typos, etc..)
- [ ] :nail_care: New Feature (Breaking/Non-breaking Change)

## Issue (if applicable)

Closes https://github.com/shapeshift/web/issues/5378

## Risk

Risk of inability to connect or disconnect wallet via WalletConnect or receive and approve incoming WalletConnect requests.

## Testing

1. Connect a WalletConnect dApp to the wallet to inaugurate a WalletConnect-connected state (ensuring a supported wallet is used to connect, since WalletConnect only supports connecting to specific wallets)
2. Execute a WalletConnect wallet request to the connected wallet app modal (via WalletConnect demo wallet connector dApp or similar dApp which can connect to the wallet via WalletConnect)
3. Refresh the WalletConnect-connected wallet application.
4. Check that any previous WalletConnect requests to connect or use the wallet do not appear.

### Engineering

<!-----------------------------------------------------------------------------
Include sufficient information here for an engineer to test your PR. This may include how to test locally, in a built environment, changes to infrastructure etc.
------------------------------------------------------------------------------>

### Operations

<!-----------------------------------------------------------------------------
If your changes have a user-facing impact, describe how a non-technical QA team can functionally test your changes in a preview environment.

If they are not user-facing please describe how to test for any regressions that may occur.
------------------------------------------------------------------------------>

## Screenshots (if applicable)
