### PR TITLE
fix: set wcv2 wallet mobile support to browser-only

### DIFF
--- a/src/context/WalletProvider/WalletConnectV2/config.ts
+++ b/src/context/WalletProvider/WalletConnectV2/config.ts
@@ -8,7 +8,7 @@ import type { SupportedWalletInfo } from 'context/WalletProvider/config'
 
 export const WalletConnectV2Config: Omit<SupportedWalletInfo, 'routes'> = {
   adapters: [WalletConnectV2Adapter],
-  supportsMobile: 'both',
+  supportsMobile: 'browser',
   icon: WalletConnectIcon,
   name: 'WalletConnect',
   description: 'v2',


### PR DESCRIPTION
## Description

Currently, the web3 modal does not work in the Native ShapeShift app (though it does when using a mobile browser).

Update the wallet configuration accordingly.

## Pull Request Type

- [x] :bug: Bug fix (Non-breaking Change: Fixes an issue)
- [ ] :hammer_and_wrench: Chore (Non-breaking Change: Doc updates, pkg upgrades, typos, etc..)
- [ ] :nail_care: New Feature (Breaking/Non-breaking Change)

## Issue (if applicable)

N/A

## Risk

## Testing

The WalletConnect wallet option should no longer appear as a wallet option in the native app.

### Engineering

☝️

### Operations

☝️

## Screenshots (if applicable)

N/A
