### PR TITLE
fix: clear wc state on wallet switch

### DIFF
--- a/src/context/WalletProvider/WalletProvider.tsx
+++ b/src/context/WalletProvider/WalletProvider.tsx
@@ -158,6 +158,11 @@ const reducer = (state: InitialState, action: ActionTypes): InitialState => {
     case WalletActions.SET_ADAPTERS:
       return { ...state, adapters: action.payload }
     case WalletActions.SET_WALLET:
+      const currentConnectedType = state.connectedType
+      if (currentConnectedType === 'walletconnectv2') {
+        state.wallet?.disconnect?.()
+        clearLocalWallet()
+      }
       const deviceId = action?.payload?.deviceId
       // set walletId in redux store
       const walletMeta = { walletId: deviceId, walletName: action?.payload?.name }
@@ -780,7 +785,6 @@ export const WalletProvider = ({ children }: { children: React.ReactNode }): JSX
   }, [isDarkMode, state.keyring])
 
   const connect = useCallback((type: KeyManager) => {
-    // remove existing dapp or wallet connections
     dispatch({ type: WalletActions.SET_CONNECTOR_TYPE, payload: type })
     const routeIndex = findIndex(SUPPORTED_WALLETS[type]?.routes, ({ path }) =>
       String(path).endsWith('connect'),


### PR DESCRIPTION
## Description

Clear wallet connect wallet state on wallet switch.

## Pull Request Type

- [x] :bug: Bug fix (Non-breaking Change: Fixes an issue)
- [ ] :hammer_and_wrench: Chore (Non-breaking Change: Doc updates, pkg upgrades, typos, etc..)
- [ ] :nail_care: New Feature (Breaking/Non-breaking Change)

## Issue (if applicable)

- Closes https://github.com/shapeshift/web/issues/5397
- Closes https://github.com/shapeshift/web/issues/5408

## Risk

Small - new code path only executes when switching from a wallet connect wallet.

## Testing

- Switch from a connected wallet connect wallet to any other wallet, and see that the previously connected wallet connect wallet (e.g. Trust) correctly receives the disconnect event (the wallet connect session should disappear).

- Switch from a connected wallet connect wallet to ShapeShift native wallet and see that the previously connected wallet connect wallet does not appear as a wallet connect connected dApp in the connected dApps dropdown.

### Engineering

☝️

### Operations

☝️

## Screenshots (if applicable)

N/A
