### PR TITLE
fix: dont show snaps modal after user requested not to show it

### DIFF
--- a/src/assets/translations/en/main.json
+++ b/src/assets/translations/en/main.json
@@ -1292,7 +1292,8 @@
       "connectMetaMask": "Connect MetaMask",
       "andMore": "...and more",
       "snapInstalledToast": "ShapeShift Multichain MetaMask Snap Installed",
-      "snapUninstalledToast": "ShapeShift Multichain MetaMask Snap Uninstalled"
+      "snapUninstalledToast": "ShapeShift Multichain MetaMask Snap Uninstalled",
+      "dontAskAgain": "Don't ask again"
     },
     "metaMaskSnapConfirm": {
       "title": "Install Multichain Snap",

--- a/src/components/Modals/Snaps/SnapConfirm.tsx
+++ b/src/components/Modals/Snaps/SnapConfirm.tsx
@@ -34,6 +34,20 @@ export const SnapConfirm: React.FC<SnapConfirmProps> = ({ onClose }) => {
     getMixPanel()?.track(MixPanelEvents.SnapInstalled)
   }, [])
 
+  const handlePinkySwearSeedPhraseIsBackedUp = useCallback(
+    (event: React.ChangeEvent<HTMLInputElement>) =>
+      setHasPinkySworeSeedPhraseIsBackedUp(event.target.checked),
+    [],
+  )
+
+  const handleAgree = useCallback(
+    (event: React.ChangeEvent<HTMLInputElement>) => setHasAgreed(event.target.checked),
+    [],
+  )
+
+  // TODO: ackchually cancel, not use placebo
+  const handleCancel = useCallback(() => setIsInstalling(false), [])
+
   if (isInstalling) {
     return (
       <ModalBody
@@ -45,7 +59,8 @@ export const SnapConfirm: React.FC<SnapConfirmProps> = ({ onClose }) => {
         py={6}
       >
         <CircularProgress />
-        <Button variant='ghost' onClick={() => setIsInstalling(false)}>
+        {/* TODO: ackchually cancel, not use placebo - disabled for now */}
+        <Button variant='ghost' isDisabled={true} onClick={handleCancel}>
           {translate('common.cancel')}
         </Button>
       </ModalBody>
@@ -87,13 +102,10 @@ export const SnapConfirm: React.FC<SnapConfirmProps> = ({ onClose }) => {
           <ListItem>{translate('walletProvider.metaMaskSnapConfirm.agreeItem3')}</ListItem>
           <ListItem>{translate('walletProvider.metaMaskSnapConfirm.agreeItem4')}</ListItem>
         </UnorderedList>
-        <Checkbox onChange={e => setHasAgreed(e.target.checked)} fontWeight='bold'>
+        <Checkbox onChange={handleAgree} fontWeight='bold'>
           {translate('walletProvider.metaMaskSnapConfirm.readAndUnderstood')}
         </Checkbox>
-        <Checkbox
-          onChange={e => setHasPinkySworeSeedPhraseIsBackedUp(e.target.checked)}
-          fontWeight='bold'
-        >
+        <Checkbox onChange={handlePinkySwearSeedPhraseIsBackedUp} fontWeight='bold'>
           {translate('walletProvider.metaMaskSnapConfirm.seedBackedUp')}
         </Checkbox>
       </ModalBody>

--- a/src/components/Modals/Snaps/SnapIntro.tsx
+++ b/src/components/Modals/Snaps/SnapIntro.tsx
@@ -49,8 +49,8 @@ export const SnapIntro = ({ isRemoved }: { isRemoved?: boolean }) => {
       .filter(isSome)
   }, [])
 
-  const handleCheckboxChange = useCallback((value: boolean) => {
-    store.dispatch(preferences.actions.setShowSnapssModal(value))
+  const handleCheckboxChange = useCallback((event: React.ChangeEvent<HTMLInputElement>) => {
+    store.dispatch(preferences.actions.setShowSnapsModal(!event.target.checked))
   }, [])
 
   const renderChains = useMemo(() => {
@@ -108,7 +108,9 @@ export const SnapIntro = ({ isRemoved }: { isRemoved?: boolean }) => {
         </HStack>
       </ModalBody>
       <ModalFooter justifyContent='space-between' mt={4}>
-        <Checkbox onChange={e => handleCheckboxChange(e.target.checked)}>Don't ask again</Checkbox>
+        <Checkbox onChange={handleCheckboxChange}>
+          {translate('walletProvider.metaMaskSnap.dontAskAgain')}
+        </Checkbox>
         <HStack spacing={2}>
           <Button colorScheme='blue' onClick={handleNext}>
             {translate('walletProvider.metaMaskSnap.addSnap')}

--- a/src/components/Modals/Snaps/Snaps.tsx
+++ b/src/components/Modals/Snaps/Snaps.tsx
@@ -28,7 +28,7 @@ export const Snaps: React.FC<SnapsModalProps> = ({ isRemoved }) => {
   if (!isSnapsEnabled) return null
 
   return (
-    <Modal isOpen={isOpen} onClose={() => close()} isCentered size='sm'>
+    <Modal isOpen={isOpen} onClose={close} isCentered size='sm'>
       <ModalOverlay />
       <ModalContent minW='450px'>
         <ModalCloseButton />

--- a/src/state/slices/preferencesSlice/preferencesSlice.ts
+++ b/src/state/slices/preferencesSlice/preferencesSlice.ts
@@ -150,7 +150,7 @@ export const preferences = createSlice({
     setShowConsentBanner(state, { payload }: { payload: boolean }) {
       state.showConsentBanner = payload
     },
-    setShowSnapssModal(state, { payload }: { payload: boolean }) {
+    setShowSnapsModal(state, { payload }: { payload: boolean }) {
       state.showSnapsModal = payload
     },
     setSnapInstalled(state, { payload }: { payload: boolean }) {


### PR DESCRIPTION
## Description

Clicking Don't ask again and then closing the modal by clicking the X will result in the modal re-appearing on next app boot. This PR addresses this issue.

Includes translation fix, performance improvements.

## Pull Request Type

- [x] :bug: Bug fix (Non-breaking Change: Fixes an issue)
- [ ] :hammer_and_wrench: Chore (Non-breaking Change: Doc updates, pkg upgrades, typos, etc..)
- [ ] :nail_care: New Feature (Breaking/Non-breaking Change)

## Issue (if applicable)

<!-----------------------------------------------------------------------------
If applicable, please link to the github issue and put `closes #XXXX` in your comment to auto-close the issue that your PR fixes.
------------------------------------------------------------------------------>

closes #5418

## Risk

<!-----------------------------------------------------------------------------
Outline the scope of your changes and the risk associated with them. You must use your discretion as an engineer to determine the potential impact of your changes.

E.g. an upgrade to `hdwallet` or core state management would be considered higher risk, and might require a full regression test. UI or isolated view changes, or something behind a feature flag may have near zero risk. Small bug fixes might require testing isolated to the specific fix.
------------------------------------------------------------------------------>

Low risk.

## Testing

<!-----------------------------------------------------------------------------
We treat every PR to be merged with the same scrutiny as if we were merging directly to production.

Your PR will not be merged if you do not complete the sections below for our engineering and operations teams to test.
------------------------------------------------------------------------------>
1. App should remember your request to not ask again about adding a snap, even if you choose not to install it

### Engineering

<!-----------------------------------------------------------------------------
Include sufficient information here for an engineer to test your PR. This may include how to test locally, in a built environment, changes to infrastructure etc.
------------------------------------------------------------------------------>

### Operations

<!-----------------------------------------------------------------------------
If your changes have a user-facing impact, describe how a non-technical QA team can functionally test your changes in a preview environment.

If they are not user-facing please describe how to test for any regressions that may occur.
------------------------------------------------------------------------------>

## Screenshots (if applicable)
