### PR TITLE
fix: bsc savers user staking data

### DIFF
--- a/src/context/AppProvider/AppContext.tsx
+++ b/src/context/AppProvider/AppContext.tsx
@@ -215,12 +215,6 @@ export const AppProvider = ({ children }: { children: React.ReactNode }) => {
           case bchChainId:
           case cosmosChainId:
           case bscChainId:
-            ;(async () => {
-              await fetchAllOpportunitiesIdsByChainId(chainId)
-              await fetchAllOpportunitiesMetadataByChainId(chainId)
-              await fetchAllOpportunitiesUserDataByAccountId(accountId)
-            })()
-            break
           case avalancheChainId:
             ;(async () => {
               await fetchAllOpportunitiesIdsByChainId(chainId)

--- a/src/context/AppProvider/AppContext.tsx
+++ b/src/context/AppProvider/AppContext.tsx
@@ -3,6 +3,7 @@ import type { AccountId, AssetId, ChainId } from '@shapeshiftoss/caip'
 import {
   avalancheChainId,
   bchChainId,
+  bscChainId,
   btcChainId,
   cosmosChainId,
   dogeChainId,
@@ -213,6 +214,13 @@ export const AppProvider = ({ children }: { children: React.ReactNode }) => {
           case dogeChainId:
           case bchChainId:
           case cosmosChainId:
+          case bscChainId:
+            ;(async () => {
+              await fetchAllOpportunitiesIdsByChainId(chainId)
+              await fetchAllOpportunitiesMetadataByChainId(chainId)
+              await fetchAllOpportunitiesUserDataByAccountId(accountId)
+            })()
+            break
           case avalancheChainId:
             ;(async () => {
               await fetchAllOpportunitiesIdsByChainId(chainId)

--- a/src/state/slices/opportunitiesSlice/mappings.ts
+++ b/src/state/slices/opportunitiesSlice/mappings.ts
@@ -1,6 +1,7 @@
 import {
   avalancheChainId,
   bchChainId,
+  bscChainId,
   btcChainId,
   cosmosChainId,
   dogeChainId,
@@ -173,6 +174,13 @@ export const CHAIN_ID_TO_SUPPORTED_DEFI_OPPORTUNITIES = {
       defiType: DefiType.Staking,
     },
   ],
+  [bscChainId]: [
+    {
+      defiProvider: DefiProvider.ThorchainSavers,
+      defiType: DefiType.Staking,
+    },
+  ],
+
   [cosmosChainId]: [
     {
       defiProvider: DefiProvider.CosmosSdk,


### PR DESCRIPTION
## Description

Makes sure BSC savers references are added everywhere, so that BSC user staking data is properly fetched - it accidentally works on deposit/withdraw currently, as we use `<TransactionProvider />` user-data fetching introspecting THOR Tx, but won't fetch the user staking data when importing a wallet.

## Pull Request Type

- [x] :bug: Bug fix (Non-breaking Change: Fixes an issue)
- [ ] :hammer_and_wrench: Chore (Non-breaking Change: Doc updates, pkg upgrades, typos, etc..)
- [ ] :nail_care: New Feature (Breaking/Non-breaking Change)

## Issue (if applicable)

<!-----------------------------------------------------------------------------
If applicable, please link to the github issue and put `closes #XXXX` in your comment to auto-close the issue that your PR fixes.
------------------------------------------------------------------------------>

closes https://github.com/shapeshift/web/issues/5415

## Risk

<!-----------------------------------------------------------------------------
Outline the scope of your changes and the risk associated with them. You must use your discretion as an engineer to determine the potential impact of your changes.

E.g. an upgrade to `hdwallet` or core state management would be considered higher risk, and might require a full regression test. UI or isolated view changes, or something behind a feature flag may have near zero risk. Small bug fixes might require testing isolated to the specific fix.
------------------------------------------------------------------------------>

None


## Testing

<!-----------------------------------------------------------------------------
We treat every PR to be merged with the same scrutiny as if we were merging directly to production.

Your PR will not be merged if you do not complete the sections below for our engineering and operations teams to test.
------------------------------------------------------------------------------>

- Have a wallet with a savers BNB active position (can use e.g a diff env for that, or deposit then clear your localForage)
- Savers user staking data for BNB on BSC is fetched on wallet import, without needing to do a deposit

### Engineering

<!-----------------------------------------------------------------------------
Include sufficient information here for an engineer to test your PR. This may include how to test locally, in a built environment, changes to infrastructure etc.
------------------------------------------------------------------------------>

- ☝🏽 

### Operations

<!-----------------------------------------------------------------------------
If your changes have a user-facing impact, describe how a non-technical QA team can functionally test your changes in a preview environment.

If they are not user-facing please describe how to test for any regressions that may occur.
------------------------------------------------------------------------------>

- ☝🏽 

## Screenshots (if applicable)

- Develop

<img width="1371" alt="Screenshot 2023-10-09 at 10 24 04" src="https://github.com/shapeshift/web/assets/17035424/544ebfea-3e90-4949-b099-a61cd5a0eaba">


- This diff

<img width="1367" alt="image" src="https://github.com/shapeshift/web/assets/17035424/09771bea-903e-4b2e-8001-f875e0187f37">
