### PR TITLE
fix: validate addresses during tx broadcast

### DIFF
--- a/.env.base
+++ b/.env.base
@@ -159,5 +159,3 @@ REACT_APP_EXPERIMENTAL_MM_SNAPPY_FINGERS=true
 
 # Experemental features (not production ready)
 REACT_APP_EXPERIMENTAL_CUSTOM_SEND_NONCE=false
-
-REACT_APP_TRM_LABS_API_URL=https://api.trmlabs.com/public/v1/sanctions/screening

--- a/packages/chain-adapters/src/api.ts
+++ b/packages/chain-adapters/src/api.ts
@@ -3,11 +3,13 @@ import type { BIP44Params, UtxoAccountType } from '@shapeshiftoss/types'
 
 import type {
   Account,
+  BroadcastTransactionInput,
   BuildSendTxInput,
   FeeDataEstimate,
   GetAddressInput,
   GetBIP44ParamsInput,
   GetFeeDataInput,
+  SignAndBroadcastTransactionInput,
   SignTx,
   SignTxInput,
   SubscribeError,
@@ -65,11 +67,11 @@ export type ChainAdapter<T extends ChainId> = {
 
   signTransaction(signTxInput: SignTxInput<SignTx<T>>): Promise<string>
 
-  signAndBroadcastTransaction?(signTxInput: SignTxInput<SignTx<T>>): Promise<string>
+  signAndBroadcastTransaction?(input: SignAndBroadcastTransactionInput<T>): Promise<string>
 
   getFeeData(input: Partial<GetFeeDataInput<T>>): Promise<FeeDataEstimate<T>>
 
-  broadcastTransaction(hex: string): Promise<string>
+  broadcastTransaction(input: BroadcastTransactionInput): Promise<string>
 
   validateAddress(address: string): Promise<ValidAddressResult>
 

--- a/packages/chain-adapters/src/cosmossdk/CosmosSdkBaseAdapter.ts
+++ b/packages/chain-adapters/src/cosmossdk/CosmosSdkBaseAdapter.ts
@@ -155,11 +155,7 @@ export abstract class CosmosSdkBaseAdapter<T extends CosmosSdkChainId> implement
   abstract getAddress(input: GetAddressInput): Promise<string>
   abstract getFeeData(input: Partial<GetFeeDataInput<T>>): Promise<FeeDataEstimate<T>>
   abstract signTransaction(signTxInput: SignTxInput<SignTx<T>>): Promise<string>
-  abstract signAndBroadcastTransaction({
-    from,
-    to,
-    signTxInput,
-  }: SignAndBroadcastTransactionInput<T>): Promise<string>
+  abstract signAndBroadcastTransaction(input: SignAndBroadcastTransactionInput<T>): Promise<string>
 
   getChainId(): ChainId {
     return this.chainId
@@ -336,8 +332,15 @@ export abstract class CosmosSdkBaseAdapter<T extends CosmosSdkChainId> implement
     return { txToSign }
   }
 
-  async broadcastTransaction({ from, to, hex }: BroadcastTransactionInput): Promise<string> {
-    await Promise.all([validateAddress(from), validateAddress(to)])
+  async broadcastTransaction({
+    senderAddress,
+    receiverAddress,
+    hex,
+  }: BroadcastTransactionInput): Promise<string> {
+    await Promise.all([
+      validateAddress(senderAddress),
+      receiverAddress !== undefined && validateAddress(receiverAddress),
+    ])
 
     try {
       return this.providers.http.sendTx({ body: { rawTx: hex } })

--- a/packages/chain-adapters/src/cosmossdk/cosmos/CosmosChainAdapter.ts
+++ b/packages/chain-adapters/src/cosmossdk/cosmos/CosmosChainAdapter.ts
@@ -283,11 +283,14 @@ export class ChainAdapter extends CosmosSdkBaseAdapter<KnownChainIds.CosmosMainn
   }
 
   async signAndBroadcastTransaction({
-    from,
-    to,
+    senderAddress,
+    receiverAddress,
     signTxInput,
   }: SignAndBroadcastTransactionInput<KnownChainIds.CosmosMainnet>): Promise<string> {
-    await Promise.all([validateAddress(from), validateAddress(to)])
+    await Promise.all([
+      validateAddress(senderAddress),
+      receiverAddress !== undefined && validateAddress(receiverAddress),
+    ])
 
     const { wallet } = signTxInput
     try {

--- a/packages/chain-adapters/src/cosmossdk/cosmos/CosmosChainAdapter.ts
+++ b/packages/chain-adapters/src/cosmossdk/cosmos/CosmosChainAdapter.ts
@@ -17,10 +17,12 @@ import type {
   FeeDataEstimate,
   GetAddressInput,
   GetFeeDataInput,
+  SignAndBroadcastTransactionInput,
   SignTxInput,
 } from '../../types'
 import { ChainAdapterDisplayName } from '../../types'
 import { bn, calcFee, toAddressNList } from '../../utils'
+import { validateAddress } from '../../utils/validateAddress'
 import type { ChainAdapterArgs } from '../CosmosSdkBaseAdapter'
 import { assertIsValidatorAddress, CosmosSdkBaseAdapter } from '../CosmosSdkBaseAdapter'
 import type { Message, ValidatorAction } from '../types'
@@ -280,7 +282,13 @@ export class ChainAdapter extends CosmosSdkBaseAdapter<KnownChainIds.CosmosMainn
     }
   }
 
-  async signAndBroadcastTransaction(signTxInput: SignTxInput<CosmosSignTx>): Promise<string> {
+  async signAndBroadcastTransaction({
+    from,
+    to,
+    signTxInput,
+  }: SignAndBroadcastTransactionInput<KnownChainIds.CosmosMainnet>): Promise<string> {
+    await Promise.all([validateAddress(from), validateAddress(to)])
+
     const { wallet } = signTxInput
     try {
       if (supportsCosmos(wallet)) {

--- a/packages/chain-adapters/src/cosmossdk/thorchain/ThorchainChainAdapter.ts
+++ b/packages/chain-adapters/src/cosmossdk/thorchain/ThorchainChainAdapter.ts
@@ -207,11 +207,14 @@ export class ChainAdapter extends CosmosSdkBaseAdapter<KnownChainIds.ThorchainMa
   }
 
   async signAndBroadcastTransaction({
-    from,
-    to,
+    senderAddress,
+    receiverAddress,
     signTxInput,
   }: SignAndBroadcastTransactionInput<KnownChainIds.ThorchainMainnet>): Promise<string> {
-    await Promise.all([validateAddress(from), validateAddress(to)])
+    await Promise.all([
+      validateAddress(senderAddress),
+      receiverAddress !== undefined && validateAddress(receiverAddress),
+    ])
 
     const { wallet } = signTxInput
 

--- a/packages/chain-adapters/src/cosmossdk/thorchain/ThorchainChainAdapter.ts
+++ b/packages/chain-adapters/src/cosmossdk/thorchain/ThorchainChainAdapter.ts
@@ -14,11 +14,13 @@ import type {
   FeeDataEstimate,
   GetAddressInput,
   GetFeeDataInput,
+  SignAndBroadcastTransactionInput,
   SignTxInput,
 } from '../../types'
 import { ChainAdapterDisplayName } from '../../types'
 import { toAddressNList } from '../../utils'
 import { bnOrZero } from '../../utils/bignumber'
+import { validateAddress } from '../../utils/validateAddress'
 import type { ChainAdapterArgs } from '../CosmosSdkBaseAdapter'
 import { CosmosSdkBaseAdapter } from '../CosmosSdkBaseAdapter'
 import type { Message } from '../types'
@@ -204,8 +206,15 @@ export class ChainAdapter extends CosmosSdkBaseAdapter<KnownChainIds.ThorchainMa
     }
   }
 
-  async signAndBroadcastTransaction(signTxInput: SignTxInput<ThorchainSignTx>): Promise<string> {
+  async signAndBroadcastTransaction({
+    from,
+    to,
+    signTxInput,
+  }: SignAndBroadcastTransactionInput<KnownChainIds.ThorchainMainnet>): Promise<string> {
+    await Promise.all([validateAddress(from), validateAddress(to)])
+
     const { wallet } = signTxInput
+
     try {
       if (supportsThorchain(wallet)) {
         const signedTx = await this.signTransaction(signTxInput)

--- a/packages/chain-adapters/src/evm/EvmBaseAdapter.ts
+++ b/packages/chain-adapters/src/evm/EvmBaseAdapter.ts
@@ -446,11 +446,14 @@ export abstract class EvmBaseAdapter<T extends EvmChainId> implements IChainAdap
   }
 
   async signAndBroadcastTransaction({
-    from,
-    to,
+    senderAddress,
+    receiverAddress,
     signTxInput,
   }: SignAndBroadcastTransactionInput<T>): Promise<string> {
-    await Promise.all([validateAddress(from), validateAddress(to)])
+    await Promise.all([
+      validateAddress(senderAddress),
+      receiverAddress !== undefined && validateAddress(receiverAddress),
+    ])
 
     try {
       const { txToSign, wallet } = signTxInput
@@ -470,8 +473,15 @@ export abstract class EvmBaseAdapter<T extends EvmChainId> implements IChainAdap
     }
   }
 
-  async broadcastTransaction({ from, to, hex }: BroadcastTransactionInput): Promise<string> {
-    await Promise.all([validateAddress(from), validateAddress(to)])
+  async broadcastTransaction({
+    senderAddress,
+    receiverAddress,
+    hex,
+  }: BroadcastTransactionInput): Promise<string> {
+    await Promise.all([
+      validateAddress(senderAddress),
+      receiverAddress !== undefined && validateAddress(receiverAddress),
+    ])
     return this.providers.http.sendTx({ sendTxBody: { hex } })
   }
 

--- a/packages/chain-adapters/src/evm/EvmBaseAdapter.ts
+++ b/packages/chain-adapters/src/evm/EvmBaseAdapter.ts
@@ -27,12 +27,14 @@ import type { ChainAdapter as IChainAdapter } from '../api'
 import { ErrorHandler } from '../error/ErrorHandler'
 import type {
   Account,
+  BroadcastTransactionInput,
   BuildSendApiTxInput,
   BuildSendTxInput,
   FeeDataEstimate,
   GetAddressInput,
   GetBIP44ParamsInput,
   GetFeeDataInput,
+  SignAndBroadcastTransactionInput,
   SignMessageInput,
   SignTx,
   SignTxInput,
@@ -47,6 +49,7 @@ import type {
 import { ValidAddressResultType } from '../types'
 import { getAssetNamespace, toAddressNList, toRootDerivationPath } from '../utils'
 import { bnOrZero } from '../utils/bignumber'
+import { validateAddress } from '../utils/validateAddress'
 import type { arbitrum, avalanche, bnbsmartchain, ethereum, gnosis, optimism, polygon } from '.'
 import type {
   BuildCustomApiTxInput,
@@ -442,7 +445,13 @@ export abstract class EvmBaseAdapter<T extends EvmChainId> implements IChainAdap
     }
   }
 
-  async signAndBroadcastTransaction(signTxInput: SignTxInput<ETHSignTx>): Promise<string> {
+  async signAndBroadcastTransaction({
+    from,
+    to,
+    signTxInput,
+  }: SignAndBroadcastTransactionInput<T>): Promise<string> {
+    await Promise.all([validateAddress(from), validateAddress(to)])
+
     try {
       const { txToSign, wallet } = signTxInput
 
@@ -461,7 +470,8 @@ export abstract class EvmBaseAdapter<T extends EvmChainId> implements IChainAdap
     }
   }
 
-  broadcastTransaction(hex: string): Promise<string> {
+  async broadcastTransaction({ from, to, hex }: BroadcastTransactionInput): Promise<string> {
+    await Promise.all([validateAddress(from), validateAddress(to)])
     return this.providers.http.sendTx({ sendTxBody: { hex } })
   }
 

--- a/packages/chain-adapters/src/evm/arbitrum/ArbitrumChainAdapter.test.ts
+++ b/packages/chain-adapters/src/evm/arbitrum/ArbitrumChainAdapter.test.ts
@@ -21,6 +21,10 @@ import { bn } from '../../utils/bignumber'
 import type { ChainAdapterArgs, EvmChainId } from '../EvmBaseAdapter'
 import * as arbitrum from './ArbitrumChainAdapter'
 
+jest.mock('../utils/validatePubkey', () => ({
+  validatePubkey: jest.fn(),
+}))
+
 const ZERO_ADDRESS = '0x0000000000000000000000000000000000000000'
 const EOA_ADDRESS = '0xd8dA6BF26964aF9D7eEd9e03E53415D37aA96045'
 
@@ -318,11 +322,11 @@ describe('ArbitrumChainAdapter', () => {
 
       wallet.ethSendTx = async () => await Promise.resolve(null)
 
-      const tx = { wallet, txToSign: {} } as unknown as SignTxInput<ETHSignTx>
+      const signTxInput = { wallet, txToSign: {} } as unknown as SignTxInput<ETHSignTx>
 
-      await expect(adapter.signAndBroadcastTransaction(tx)).rejects.toThrow(
-        /Error signing & broadcasting tx/,
-      )
+      await expect(
+        adapter.signAndBroadcastTransaction({ from: '0x1234', to: '0x1234', signTxInput }),
+      ).rejects.toThrow(/Error signing & broadcasting tx/)
     })
 
     it('should return the hash returned by wallet.ethSendTx', async () => {
@@ -334,11 +338,11 @@ describe('ArbitrumChainAdapter', () => {
           hash: '0xe670ec64341771606e55d6b4ca35a1a6b75ee3d5145a99d05921026d1527331',
         })
 
-      const tx = { wallet, txToSign: {} } as unknown as SignTxInput<ETHSignTx>
+      const signTxInput = { wallet, txToSign: {} } as unknown as SignTxInput<ETHSignTx>
 
-      await expect(adapter.signAndBroadcastTransaction(tx)).resolves.toEqual(
-        '0xe670ec64341771606e55d6b4ca35a1a6b75ee3d5145a99d05921026d1527331',
-      )
+      await expect(
+        adapter.signAndBroadcastTransaction({ from: '0x1234', to: '0x1234', signTxInput }),
+      ).resolves.toEqual('0xe670ec64341771606e55d6b4ca35a1a6b75ee3d5145a99d05921026d1527331')
     })
   })
 
@@ -392,7 +396,11 @@ describe('ArbitrumChainAdapter', () => {
       const adapter = new arbitrum.ChainAdapter(args)
 
       const mockTx = '0x123'
-      const result = await adapter.broadcastTransaction(mockTx)
+      const result = await adapter.broadcastTransaction({
+        from: '0x1234',
+        to: '0x1234',
+        hex: mockTx,
+      })
 
       expect(args.providers.http.sendTx).toHaveBeenCalledWith<any>({ sendTxBody: { hex: mockTx } })
       expect(result).toEqual(expectedResult)

--- a/packages/chain-adapters/src/evm/arbitrum/ArbitrumChainAdapter.test.ts
+++ b/packages/chain-adapters/src/evm/arbitrum/ArbitrumChainAdapter.test.ts
@@ -325,7 +325,11 @@ describe('ArbitrumChainAdapter', () => {
       const signTxInput = { wallet, txToSign: {} } as unknown as SignTxInput<ETHSignTx>
 
       await expect(
-        adapter.signAndBroadcastTransaction({ from: '0x1234', to: '0x1234', signTxInput }),
+        adapter.signAndBroadcastTransaction({
+          senderAddress: '0x1234',
+          receiverAddress: '0x1234',
+          signTxInput,
+        }),
       ).rejects.toThrow(/Error signing & broadcasting tx/)
     })
 
@@ -341,7 +345,11 @@ describe('ArbitrumChainAdapter', () => {
       const signTxInput = { wallet, txToSign: {} } as unknown as SignTxInput<ETHSignTx>
 
       await expect(
-        adapter.signAndBroadcastTransaction({ from: '0x1234', to: '0x1234', signTxInput }),
+        adapter.signAndBroadcastTransaction({
+          senderAddress: '0x1234',
+          receiverAddress: '0x1234',
+          signTxInput,
+        }),
       ).resolves.toEqual('0xe670ec64341771606e55d6b4ca35a1a6b75ee3d5145a99d05921026d1527331')
     })
   })
@@ -397,8 +405,8 @@ describe('ArbitrumChainAdapter', () => {
 
       const mockTx = '0x123'
       const result = await adapter.broadcastTransaction({
-        from: '0x1234',
-        to: '0x1234',
+        senderAddress: '0x1234',
+        receiverAddress: '0x1234',
         hex: mockTx,
       })
 

--- a/packages/chain-adapters/src/evm/arbitrum/ArbitrumChainAdapter.test.ts
+++ b/packages/chain-adapters/src/evm/arbitrum/ArbitrumChainAdapter.test.ts
@@ -21,8 +21,8 @@ import { bn } from '../../utils/bignumber'
 import type { ChainAdapterArgs, EvmChainId } from '../EvmBaseAdapter'
 import * as arbitrum from './ArbitrumChainAdapter'
 
-jest.mock('../utils/validatePubkey', () => ({
-  validatePubkey: jest.fn(),
+jest.mock('../../utils/validateAddress', () => ({
+  validateAddress: jest.fn(),
 }))
 
 const ZERO_ADDRESS = '0x0000000000000000000000000000000000000000'

--- a/packages/chain-adapters/src/evm/avalanche/AvalancheChainAdapter.test.ts
+++ b/packages/chain-adapters/src/evm/avalanche/AvalancheChainAdapter.test.ts
@@ -26,6 +26,10 @@ import { bn } from '../../utils/bignumber'
 import type { ChainAdapterArgs, EvmChainId } from '../EvmBaseAdapter'
 import * as avalanche from './AvalancheChainAdapter'
 
+jest.mock('../utils/validatePubkey', () => ({
+  validatePubkey: jest.fn(),
+}))
+
 const ZERO_ADDRESS = '0x0000000000000000000000000000000000000000'
 const EOA_ADDRESS = '0xd8dA6BF26964aF9D7eEd9e03E53415D37aA96045'
 
@@ -323,11 +327,11 @@ describe('AvalancheChainAdapter', () => {
 
       wallet.ethSendTx = async () => await Promise.resolve(null)
 
-      const tx = { wallet, txToSign: {} } as unknown as SignTxInput<ETHSignTx>
+      const signTxInput = { wallet, txToSign: {} } as unknown as SignTxInput<ETHSignTx>
 
-      await expect(adapter.signAndBroadcastTransaction(tx)).rejects.toThrow(
-        /Error signing & broadcasting tx/,
-      )
+      await expect(
+        adapter.signAndBroadcastTransaction({ from: '0x1234', to: '0x1234', signTxInput }),
+      ).rejects.toThrow(/Error signing & broadcasting tx/)
     })
 
     it('should return the hash returned by wallet.ethSendTx', async () => {
@@ -339,11 +343,11 @@ describe('AvalancheChainAdapter', () => {
           hash: '0xe670ec64341771606e55d6b4ca35a1a6b75ee3d5145a99d05921026d1527331',
         })
 
-      const tx = { wallet, txToSign: {} } as unknown as SignTxInput<ETHSignTx>
+      const signTxInput = { wallet, txToSign: {} } as unknown as SignTxInput<ETHSignTx>
 
-      await expect(adapter.signAndBroadcastTransaction(tx)).resolves.toEqual(
-        '0xe670ec64341771606e55d6b4ca35a1a6b75ee3d5145a99d05921026d1527331',
-      )
+      await expect(
+        adapter.signAndBroadcastTransaction({ from: '0x1234', to: '0x1234', signTxInput }),
+      ).resolves.toEqual('0xe670ec64341771606e55d6b4ca35a1a6b75ee3d5145a99d05921026d1527331')
     })
   })
 
@@ -397,7 +401,11 @@ describe('AvalancheChainAdapter', () => {
       const adapter = new avalanche.ChainAdapter(args)
 
       const mockTx = '0x123'
-      const result = await adapter.broadcastTransaction(mockTx)
+      const result = await adapter.broadcastTransaction({
+        from: '0x1234',
+        to: '0x1234',
+        hex: mockTx,
+      })
 
       expect(args.providers.http.sendTx).toHaveBeenCalledWith<any>({ sendTxBody: { hex: mockTx } })
       expect(result).toEqual(expectedResult)

--- a/packages/chain-adapters/src/evm/avalanche/AvalancheChainAdapter.test.ts
+++ b/packages/chain-adapters/src/evm/avalanche/AvalancheChainAdapter.test.ts
@@ -330,7 +330,11 @@ describe('AvalancheChainAdapter', () => {
       const signTxInput = { wallet, txToSign: {} } as unknown as SignTxInput<ETHSignTx>
 
       await expect(
-        adapter.signAndBroadcastTransaction({ from: '0x1234', to: '0x1234', signTxInput }),
+        adapter.signAndBroadcastTransaction({
+          senderAddress: '0x1234',
+          receiverAddress: '0x1234',
+          signTxInput,
+        }),
       ).rejects.toThrow(/Error signing & broadcasting tx/)
     })
 
@@ -346,7 +350,11 @@ describe('AvalancheChainAdapter', () => {
       const signTxInput = { wallet, txToSign: {} } as unknown as SignTxInput<ETHSignTx>
 
       await expect(
-        adapter.signAndBroadcastTransaction({ from: '0x1234', to: '0x1234', signTxInput }),
+        adapter.signAndBroadcastTransaction({
+          senderAddress: '0x1234',
+          receiverAddress: '0x1234',
+          signTxInput,
+        }),
       ).resolves.toEqual('0xe670ec64341771606e55d6b4ca35a1a6b75ee3d5145a99d05921026d1527331')
     })
   })
@@ -402,8 +410,8 @@ describe('AvalancheChainAdapter', () => {
 
       const mockTx = '0x123'
       const result = await adapter.broadcastTransaction({
-        from: '0x1234',
-        to: '0x1234',
+        senderAddress: '0x1234',
+        receiverAddress: '0x1234',
         hex: mockTx,
       })
 

--- a/packages/chain-adapters/src/evm/avalanche/AvalancheChainAdapter.test.ts
+++ b/packages/chain-adapters/src/evm/avalanche/AvalancheChainAdapter.test.ts
@@ -26,8 +26,8 @@ import { bn } from '../../utils/bignumber'
 import type { ChainAdapterArgs, EvmChainId } from '../EvmBaseAdapter'
 import * as avalanche from './AvalancheChainAdapter'
 
-jest.mock('../utils/validatePubkey', () => ({
-  validatePubkey: jest.fn(),
+jest.mock('../../utils/validateAddress', () => ({
+  validateAddress: jest.fn(),
 }))
 
 const ZERO_ADDRESS = '0x0000000000000000000000000000000000000000'

--- a/packages/chain-adapters/src/evm/bnbsmartchain/BscChainAdapter.test.ts
+++ b/packages/chain-adapters/src/evm/bnbsmartchain/BscChainAdapter.test.ts
@@ -21,8 +21,8 @@ import { bn } from '../../utils/bignumber'
 import type { ChainAdapterArgs, EvmChainId } from '../EvmBaseAdapter'
 import * as bsc from './BscChainAdapter'
 
-jest.mock('../utils/validatePubkey', () => ({
-  validatePubkey: jest.fn(),
+jest.mock('../../utils/validateAddress', () => ({
+  validateAddress: jest.fn(),
 }))
 
 const ZERO_ADDRESS = '0x0000000000000000000000000000000000000000'

--- a/packages/chain-adapters/src/evm/bnbsmartchain/BscChainAdapter.test.ts
+++ b/packages/chain-adapters/src/evm/bnbsmartchain/BscChainAdapter.test.ts
@@ -307,7 +307,11 @@ describe('BscChainAdapter', () => {
       const signTxInput = { wallet, txToSign: {} } as unknown as SignTxInput<ETHSignTx>
 
       await expect(
-        adapter.signAndBroadcastTransaction({ from: '0x1234', to: '0x1234', signTxInput }),
+        adapter.signAndBroadcastTransaction({
+          senderAddress: '0x1234',
+          receiverAddress: '0x1234',
+          signTxInput,
+        }),
       ).rejects.toThrow(/Error signing & broadcasting tx/)
     })
 
@@ -323,7 +327,11 @@ describe('BscChainAdapter', () => {
       const signTxInput = { wallet, txToSign: {} } as unknown as SignTxInput<ETHSignTx>
 
       await expect(
-        adapter.signAndBroadcastTransaction({ from: '0x1234', to: '0x1234', signTxInput }),
+        adapter.signAndBroadcastTransaction({
+          senderAddress: '0x1234',
+          receiverAddress: '0x1234',
+          signTxInput,
+        }),
       ).resolves.toEqual('0xe670ec64341771606e55d6b4ca35a1a6b75ee3d5145a99d05921026d1527331')
     })
   })
@@ -379,8 +387,8 @@ describe('BscChainAdapter', () => {
 
       const mockTx = '0x123'
       const result = await adapter.broadcastTransaction({
-        from: '0x1234',
-        to: '0x1234',
+        senderAddress: '0x1234',
+        receiverAddress: '0x1234',
         hex: mockTx,
       })
 

--- a/packages/chain-adapters/src/evm/bnbsmartchain/BscChainAdapter.test.ts
+++ b/packages/chain-adapters/src/evm/bnbsmartchain/BscChainAdapter.test.ts
@@ -21,6 +21,10 @@ import { bn } from '../../utils/bignumber'
 import type { ChainAdapterArgs, EvmChainId } from '../EvmBaseAdapter'
 import * as bsc from './BscChainAdapter'
 
+jest.mock('../utils/validatePubkey', () => ({
+  validatePubkey: jest.fn(),
+}))
+
 const ZERO_ADDRESS = '0x0000000000000000000000000000000000000000'
 const EOA_ADDRESS = '0xd8dA6BF26964aF9D7eEd9e03E53415D37aA96045'
 
@@ -300,11 +304,11 @@ describe('BscChainAdapter', () => {
 
       wallet.ethSendTx = async () => await Promise.resolve(null)
 
-      const tx = { wallet, txToSign: {} } as unknown as SignTxInput<ETHSignTx>
+      const signTxInput = { wallet, txToSign: {} } as unknown as SignTxInput<ETHSignTx>
 
-      await expect(adapter.signAndBroadcastTransaction(tx)).rejects.toThrow(
-        /Error signing & broadcasting tx/,
-      )
+      await expect(
+        adapter.signAndBroadcastTransaction({ from: '0x1234', to: '0x1234', signTxInput }),
+      ).rejects.toThrow(/Error signing & broadcasting tx/)
     })
 
     it('should return the hash returned by wallet.ethSendTx', async () => {
@@ -316,11 +320,11 @@ describe('BscChainAdapter', () => {
           hash: '0xe670ec64341771606e55d6b4ca35a1a6b75ee3d5145a99d05921026d1527331',
         })
 
-      const tx = { wallet, txToSign: {} } as unknown as SignTxInput<ETHSignTx>
+      const signTxInput = { wallet, txToSign: {} } as unknown as SignTxInput<ETHSignTx>
 
-      await expect(adapter.signAndBroadcastTransaction(tx)).resolves.toEqual(
-        '0xe670ec64341771606e55d6b4ca35a1a6b75ee3d5145a99d05921026d1527331',
-      )
+      await expect(
+        adapter.signAndBroadcastTransaction({ from: '0x1234', to: '0x1234', signTxInput }),
+      ).resolves.toEqual('0xe670ec64341771606e55d6b4ca35a1a6b75ee3d5145a99d05921026d1527331')
     })
   })
 
@@ -374,7 +378,11 @@ describe('BscChainAdapter', () => {
       const adapter = new bsc.ChainAdapter(args)
 
       const mockTx = '0x123'
-      const result = await adapter.broadcastTransaction(mockTx)
+      const result = await adapter.broadcastTransaction({
+        from: '0x1234',
+        to: '0x1234',
+        hex: mockTx,
+      })
 
       expect(args.providers.http.sendTx).toHaveBeenCalledWith<any>({ sendTxBody: { hex: mockTx } })
       expect(result).toEqual(expectedResult)

--- a/packages/chain-adapters/src/evm/ethereum/EthereumChainAdapter.test.ts
+++ b/packages/chain-adapters/src/evm/ethereum/EthereumChainAdapter.test.ts
@@ -21,6 +21,10 @@ import { bn } from '../../utils/bignumber'
 import type { ChainAdapterArgs, EvmChainId } from '../EvmBaseAdapter'
 import * as ethereum from './EthereumChainAdapter'
 
+jest.mock('../utils/validatePubkey', () => ({
+  validatePubkey: jest.fn(),
+}))
+
 const ZERO_ADDRESS = '0x0000000000000000000000000000000000000000'
 const EOA_ADDRESS = '0xd8dA6BF26964aF9D7eEd9e03E53415D37aA96045'
 const ENS_NAME = 'vitalik.eth'
@@ -357,11 +361,11 @@ describe('EthereumChainAdapter', () => {
 
       wallet.ethSendTx = async () => await Promise.resolve(null)
 
-      const tx = { wallet, txToSign: {} } as unknown as SignTxInput<ETHSignTx>
+      const signTxInput = { wallet, txToSign: {} } as unknown as SignTxInput<ETHSignTx>
 
-      await expect(adapter.signAndBroadcastTransaction(tx)).rejects.toThrow(
-        /Error signing & broadcasting tx/,
-      )
+      await expect(
+        adapter.signAndBroadcastTransaction({ from: '0x1234', to: '0x1234', signTxInput }),
+      ).rejects.toThrow(/Error signing & broadcasting tx/)
     })
 
     it('should return the hash returned by wallet.ethSendTx', async () => {
@@ -373,11 +377,11 @@ describe('EthereumChainAdapter', () => {
           hash: '0xe670ec64341771606e55d6b4ca35a1a6b75ee3d5145a99d05921026d1527331',
         })
 
-      const tx = { wallet, txToSign: {} } as unknown as SignTxInput<ETHSignTx>
+      const signTxInput = { wallet, txToSign: {} } as unknown as SignTxInput<ETHSignTx>
 
-      await expect(adapter.signAndBroadcastTransaction(tx)).resolves.toEqual(
-        '0xe670ec64341771606e55d6b4ca35a1a6b75ee3d5145a99d05921026d1527331',
-      )
+      await expect(
+        adapter.signAndBroadcastTransaction({ from: '0x1234', to: '0x1234', signTxInput }),
+      ).resolves.toEqual('0xe670ec64341771606e55d6b4ca35a1a6b75ee3d5145a99d05921026d1527331')
     })
   })
 
@@ -431,7 +435,11 @@ describe('EthereumChainAdapter', () => {
       const adapter = new ethereum.ChainAdapter(args)
 
       const mockTx = '0x123'
-      const result = await adapter.broadcastTransaction(mockTx)
+      const result = await adapter.broadcastTransaction({
+        from: '0x1234',
+        to: '0x1234',
+        hex: mockTx,
+      })
 
       expect(args.providers.http.sendTx).toHaveBeenCalledWith<any>({ sendTxBody: { hex: mockTx } })
       expect(result).toEqual(expectedResult)

--- a/packages/chain-adapters/src/evm/ethereum/EthereumChainAdapter.test.ts
+++ b/packages/chain-adapters/src/evm/ethereum/EthereumChainAdapter.test.ts
@@ -21,8 +21,8 @@ import { bn } from '../../utils/bignumber'
 import type { ChainAdapterArgs, EvmChainId } from '../EvmBaseAdapter'
 import * as ethereum from './EthereumChainAdapter'
 
-jest.mock('../utils/validatePubkey', () => ({
-  validatePubkey: jest.fn(),
+jest.mock('../../utils/validateAddress', () => ({
+  validateAddress: jest.fn(),
 }))
 
 const ZERO_ADDRESS = '0x0000000000000000000000000000000000000000'

--- a/packages/chain-adapters/src/evm/ethereum/EthereumChainAdapter.test.ts
+++ b/packages/chain-adapters/src/evm/ethereum/EthereumChainAdapter.test.ts
@@ -364,7 +364,11 @@ describe('EthereumChainAdapter', () => {
       const signTxInput = { wallet, txToSign: {} } as unknown as SignTxInput<ETHSignTx>
 
       await expect(
-        adapter.signAndBroadcastTransaction({ from: '0x1234', to: '0x1234', signTxInput }),
+        adapter.signAndBroadcastTransaction({
+          senderAddress: '0x1234',
+          receiverAddress: '0x1234',
+          signTxInput,
+        }),
       ).rejects.toThrow(/Error signing & broadcasting tx/)
     })
 
@@ -380,7 +384,11 @@ describe('EthereumChainAdapter', () => {
       const signTxInput = { wallet, txToSign: {} } as unknown as SignTxInput<ETHSignTx>
 
       await expect(
-        adapter.signAndBroadcastTransaction({ from: '0x1234', to: '0x1234', signTxInput }),
+        adapter.signAndBroadcastTransaction({
+          senderAddress: '0x1234',
+          receiverAddress: '0x1234',
+          signTxInput,
+        }),
       ).resolves.toEqual('0xe670ec64341771606e55d6b4ca35a1a6b75ee3d5145a99d05921026d1527331')
     })
   })
@@ -436,8 +444,8 @@ describe('EthereumChainAdapter', () => {
 
       const mockTx = '0x123'
       const result = await adapter.broadcastTransaction({
-        from: '0x1234',
-        to: '0x1234',
+        senderAddress: '0x1234',
+        receiverAddress: '0x1234',
         hex: mockTx,
       })
 

--- a/packages/chain-adapters/src/evm/gnosis/GnosisChainAdapter.test.ts
+++ b/packages/chain-adapters/src/evm/gnosis/GnosisChainAdapter.test.ts
@@ -325,7 +325,11 @@ describe('GnosisChainAdapter', () => {
       const signTxInput = { wallet, txToSign: {} } as unknown as SignTxInput<ETHSignTx>
 
       await expect(
-        adapter.signAndBroadcastTransaction({ from: '0x1234', to: '0x1234', signTxInput }),
+        adapter.signAndBroadcastTransaction({
+          senderAddress: '0x1234',
+          receiverAddress: '0x1234',
+          signTxInput,
+        }),
       ).rejects.toThrow(/Error signing & broadcasting tx/)
     })
 
@@ -341,7 +345,11 @@ describe('GnosisChainAdapter', () => {
       const signTxInput = { wallet, txToSign: {} } as unknown as SignTxInput<ETHSignTx>
 
       await expect(
-        adapter.signAndBroadcastTransaction({ from: '0x1234', to: '0x1234', signTxInput }),
+        adapter.signAndBroadcastTransaction({
+          senderAddress: '0x1234',
+          receiverAddress: '0x1234',
+          signTxInput,
+        }),
       ).resolves.toEqual('0xe670ec64341771606e55d6b4ca35a1a6b75ee3d5145a99d05921026d1527331')
     })
   })
@@ -397,8 +405,8 @@ describe('GnosisChainAdapter', () => {
 
       const mockTx = '0x123'
       const result = await adapter.broadcastTransaction({
-        from: '0x1234',
-        to: '0x1234',
+        senderAddress: '0x1234',
+        receiverAddress: '0x1234',
         hex: mockTx,
       })
 

--- a/packages/chain-adapters/src/evm/gnosis/GnosisChainAdapter.test.ts
+++ b/packages/chain-adapters/src/evm/gnosis/GnosisChainAdapter.test.ts
@@ -22,8 +22,8 @@ import { bn } from '../../utils/bignumber'
 import type { ChainAdapterArgs, EvmChainId } from '../EvmBaseAdapter'
 import * as gnosis from './GnosisChainAdapter'
 
-jest.mock('../utils/validatePubkey', () => ({
-  validatePubkey: jest.fn(),
+jest.mock('../../utils/validateAddress', () => ({
+  validateAddress: jest.fn(),
 }))
 
 const EOA_ADDRESS = '0xd8dA6BF26964aF9D7eEd9e03E53415D37aA96045'

--- a/packages/chain-adapters/src/evm/gnosis/GnosisChainAdapter.test.ts
+++ b/packages/chain-adapters/src/evm/gnosis/GnosisChainAdapter.test.ts
@@ -21,6 +21,11 @@ import { toAddressNList } from '../../utils'
 import { bn } from '../../utils/bignumber'
 import type { ChainAdapterArgs, EvmChainId } from '../EvmBaseAdapter'
 import * as gnosis from './GnosisChainAdapter'
+
+jest.mock('../utils/validatePubkey', () => ({
+  validatePubkey: jest.fn(),
+}))
+
 const EOA_ADDRESS = '0xd8dA6BF26964aF9D7eEd9e03E53415D37aA96045'
 
 const testMnemonic = 'alcohol woman abuse must during monitor noble actual mixed trade anger aisle'
@@ -317,11 +322,11 @@ describe('GnosisChainAdapter', () => {
 
       wallet.ethSendTx = async () => await Promise.resolve(null)
 
-      const tx = { wallet, txToSign: {} } as unknown as SignTxInput<ETHSignTx>
+      const signTxInput = { wallet, txToSign: {} } as unknown as SignTxInput<ETHSignTx>
 
-      await expect(adapter.signAndBroadcastTransaction(tx)).rejects.toThrow(
-        /Error signing & broadcasting tx/,
-      )
+      await expect(
+        adapter.signAndBroadcastTransaction({ from: '0x1234', to: '0x1234', signTxInput }),
+      ).rejects.toThrow(/Error signing & broadcasting tx/)
     })
 
     it('should return the hash returned by wallet.ethSendTx', async () => {
@@ -333,11 +338,11 @@ describe('GnosisChainAdapter', () => {
           hash: '0xe670ec64341771606e55d6b4ca35a1a6b75ee3d5145a99d05921026d1527331',
         })
 
-      const tx = { wallet, txToSign: {} } as unknown as SignTxInput<ETHSignTx>
+      const signTxInput = { wallet, txToSign: {} } as unknown as SignTxInput<ETHSignTx>
 
-      await expect(adapter.signAndBroadcastTransaction(tx)).resolves.toEqual(
-        '0xe670ec64341771606e55d6b4ca35a1a6b75ee3d5145a99d05921026d1527331',
-      )
+      await expect(
+        adapter.signAndBroadcastTransaction({ from: '0x1234', to: '0x1234', signTxInput }),
+      ).resolves.toEqual('0xe670ec64341771606e55d6b4ca35a1a6b75ee3d5145a99d05921026d1527331')
     })
   })
 
@@ -391,7 +396,11 @@ describe('GnosisChainAdapter', () => {
       const adapter = new gnosis.ChainAdapter(args)
 
       const mockTx = '0x123'
-      const result = await adapter.broadcastTransaction(mockTx)
+      const result = await adapter.broadcastTransaction({
+        from: '0x1234',
+        to: '0x1234',
+        hex: mockTx,
+      })
 
       expect(args.providers.http.sendTx).toHaveBeenCalledWith<any>({ sendTxBody: { hex: mockTx } })
       expect(result).toEqual(expectedResult)

--- a/packages/chain-adapters/src/evm/optimism/OptimismChainAdapter.test.ts
+++ b/packages/chain-adapters/src/evm/optimism/OptimismChainAdapter.test.ts
@@ -332,7 +332,11 @@ describe('OptimismChainAdapter', () => {
       const signTxInput = { wallet, txToSign: {} } as unknown as SignTxInput<ETHSignTx>
 
       await expect(
-        adapter.signAndBroadcastTransaction({ from: '0x1234', to: '0x1234', signTxInput }),
+        adapter.signAndBroadcastTransaction({
+          senderAddress: '0x1234',
+          receiverAddress: '0x1234',
+          signTxInput,
+        }),
       ).rejects.toThrow(/Error signing & broadcasting tx/)
     })
 
@@ -348,7 +352,11 @@ describe('OptimismChainAdapter', () => {
       const signTxInput = { wallet, txToSign: {} } as unknown as SignTxInput<ETHSignTx>
 
       await expect(
-        adapter.signAndBroadcastTransaction({ from: '0x1234', to: '0x1234', signTxInput }),
+        adapter.signAndBroadcastTransaction({
+          senderAddress: '0x1234',
+          receiverAddress: '0x1234',
+          signTxInput,
+        }),
       ).resolves.toEqual('0xe670ec64341771606e55d6b4ca35a1a6b75ee3d5145a99d05921026d1527331')
     })
   })
@@ -404,8 +412,8 @@ describe('OptimismChainAdapter', () => {
 
       const mockTx = '0x123'
       const result = await adapter.broadcastTransaction({
-        from: '0x1234',
-        to: '0x1234',
+        senderAddress: '0x1234',
+        receiverAddress: '0x1234',
         hex: mockTx,
       })
 

--- a/packages/chain-adapters/src/evm/optimism/OptimismChainAdapter.test.ts
+++ b/packages/chain-adapters/src/evm/optimism/OptimismChainAdapter.test.ts
@@ -329,11 +329,11 @@ describe('OptimismChainAdapter', () => {
 
       wallet.ethSendTx = async () => await Promise.resolve(null)
 
-      const tx = { wallet, txToSign: {} } as unknown as SignTxInput<ETHSignTx>
+      const signTxInput = { wallet, txToSign: {} } as unknown as SignTxInput<ETHSignTx>
 
-      await expect(adapter.signAndBroadcastTransaction(tx)).rejects.toThrow(
-        /Error signing & broadcasting tx/,
-      )
+      await expect(
+        adapter.signAndBroadcastTransaction({ from: '0x1234', to: '0x1234', signTxInput }),
+      ).rejects.toThrow(/Error signing & broadcasting tx/)
     })
 
     it('should return the hash returned by wallet.ethSendTx', async () => {
@@ -345,11 +345,11 @@ describe('OptimismChainAdapter', () => {
           hash: '0xe670ec64341771606e55d6b4ca35a1a6b75ee3d5145a99d05921026d1527331',
         })
 
-      const tx = { wallet, txToSign: {} } as unknown as SignTxInput<ETHSignTx>
+      const signTxInput = { wallet, txToSign: {} } as unknown as SignTxInput<ETHSignTx>
 
-      await expect(adapter.signAndBroadcastTransaction(tx)).resolves.toEqual(
-        '0xe670ec64341771606e55d6b4ca35a1a6b75ee3d5145a99d05921026d1527331',
-      )
+      await expect(
+        adapter.signAndBroadcastTransaction({ from: '0x1234', to: '0x1234', signTxInput }),
+      ).resolves.toEqual('0xe670ec64341771606e55d6b4ca35a1a6b75ee3d5145a99d05921026d1527331')
     })
   })
 
@@ -403,7 +403,11 @@ describe('OptimismChainAdapter', () => {
       const adapter = new optimism.ChainAdapter(args)
 
       const mockTx = '0x123'
-      const result = await adapter.broadcastTransaction(mockTx)
+      const result = await adapter.broadcastTransaction({
+        from: '0x1234',
+        to: '0x1234',
+        hex: mockTx,
+      })
 
       expect(args.providers.http.sendTx).toHaveBeenCalledWith<any>({ sendTxBody: { hex: mockTx } })
       expect(result).toEqual(expectedResult)

--- a/packages/chain-adapters/src/evm/polygon/PolygonChainAdapter.test.ts
+++ b/packages/chain-adapters/src/evm/polygon/PolygonChainAdapter.test.ts
@@ -21,6 +21,10 @@ import { bn } from '../../utils/bignumber'
 import type { ChainAdapterArgs, EvmChainId } from '../EvmBaseAdapter'
 import * as polygon from './PolygonChainAdapter'
 
+jest.mock('../utils/validatePubkey', () => ({
+  validatePubkey: jest.fn(),
+}))
+
 const ZERO_ADDRESS = '0x0000000000000000000000000000000000000000'
 const EOA_ADDRESS = '0xd8dA6BF26964aF9D7eEd9e03E53415D37aA96045'
 
@@ -318,11 +322,11 @@ describe('PolygonChainAdapter', () => {
 
       wallet.ethSendTx = async () => await Promise.resolve(null)
 
-      const tx = { wallet, txToSign: {} } as unknown as SignTxInput<ETHSignTx>
+      const signTxInput = { wallet, txToSign: {} } as unknown as SignTxInput<ETHSignTx>
 
-      await expect(adapter.signAndBroadcastTransaction(tx)).rejects.toThrow(
-        /Error signing & broadcasting tx/,
-      )
+      await expect(
+        adapter.signAndBroadcastTransaction({ from: '0x1234', to: '0x1234', signTxInput }),
+      ).rejects.toThrow(/Error signing & broadcasting tx/)
     })
 
     it('should return the hash returned by wallet.ethSendTx', async () => {
@@ -334,11 +338,11 @@ describe('PolygonChainAdapter', () => {
           hash: '0xe670ec64341771606e55d6b4ca35a1a6b75ee3d5145a99d05921026d1527331',
         })
 
-      const tx = { wallet, txToSign: {} } as unknown as SignTxInput<ETHSignTx>
+      const signTxInput = { wallet, txToSign: {} } as unknown as SignTxInput<ETHSignTx>
 
-      await expect(adapter.signAndBroadcastTransaction(tx)).resolves.toEqual(
-        '0xe670ec64341771606e55d6b4ca35a1a6b75ee3d5145a99d05921026d1527331',
-      )
+      await expect(
+        adapter.signAndBroadcastTransaction({ from: '0x1234', to: '0x1234', signTxInput }),
+      ).resolves.toEqual('0xe670ec64341771606e55d6b4ca35a1a6b75ee3d5145a99d05921026d1527331')
     })
   })
 
@@ -392,7 +396,11 @@ describe('PolygonChainAdapter', () => {
       const adapter = new polygon.ChainAdapter(args)
 
       const mockTx = '0x123'
-      const result = await adapter.broadcastTransaction(mockTx)
+      const result = await adapter.broadcastTransaction({
+        from: '0x1234',
+        to: '0x1234',
+        hex: mockTx,
+      })
 
       expect(args.providers.http.sendTx).toHaveBeenCalledWith<any>({ sendTxBody: { hex: mockTx } })
       expect(result).toEqual(expectedResult)

--- a/packages/chain-adapters/src/evm/polygon/PolygonChainAdapter.test.ts
+++ b/packages/chain-adapters/src/evm/polygon/PolygonChainAdapter.test.ts
@@ -21,8 +21,8 @@ import { bn } from '../../utils/bignumber'
 import type { ChainAdapterArgs, EvmChainId } from '../EvmBaseAdapter'
 import * as polygon from './PolygonChainAdapter'
 
-jest.mock('../utils/validatePubkey', () => ({
-  validatePubkey: jest.fn(),
+jest.mock('../../utils/validateAddress', () => ({
+  validateAddress: jest.fn(),
 }))
 
 const ZERO_ADDRESS = '0x0000000000000000000000000000000000000000'

--- a/packages/chain-adapters/src/evm/polygon/PolygonChainAdapter.test.ts
+++ b/packages/chain-adapters/src/evm/polygon/PolygonChainAdapter.test.ts
@@ -325,7 +325,11 @@ describe('PolygonChainAdapter', () => {
       const signTxInput = { wallet, txToSign: {} } as unknown as SignTxInput<ETHSignTx>
 
       await expect(
-        adapter.signAndBroadcastTransaction({ from: '0x1234', to: '0x1234', signTxInput }),
+        adapter.signAndBroadcastTransaction({
+          senderAddress: '0x1234',
+          receiverAddress: '0x1234',
+          signTxInput,
+        }),
       ).rejects.toThrow(/Error signing & broadcasting tx/)
     })
 
@@ -341,7 +345,11 @@ describe('PolygonChainAdapter', () => {
       const signTxInput = { wallet, txToSign: {} } as unknown as SignTxInput<ETHSignTx>
 
       await expect(
-        adapter.signAndBroadcastTransaction({ from: '0x1234', to: '0x1234', signTxInput }),
+        adapter.signAndBroadcastTransaction({
+          senderAddress: '0x1234',
+          receiverAddress: '0x1234',
+          signTxInput,
+        }),
       ).resolves.toEqual('0xe670ec64341771606e55d6b4ca35a1a6b75ee3d5145a99d05921026d1527331')
     })
   })
@@ -397,8 +405,8 @@ describe('PolygonChainAdapter', () => {
 
       const mockTx = '0x123'
       const result = await adapter.broadcastTransaction({
-        from: '0x1234',
-        to: '0x1234',
+        senderAddress: '0x1234',
+        receiverAddress: '0x1234',
         hex: mockTx,
       })
 

--- a/packages/chain-adapters/src/types.ts
+++ b/packages/chain-adapters/src/types.ts
@@ -316,3 +316,15 @@ export enum ChainAdapterDisplayName {
   Dogecoin = 'Dogecoin',
   Litecoin = 'Litecoin',
 }
+
+export type BroadcastTransactionInput = {
+  from: string
+  to: string
+  hex: string
+}
+
+export type SignAndBroadcastTransactionInput<T extends ChainId> = {
+  from: string
+  to: string
+  signTxInput: SignTxInput<SignTx<T>>
+}

--- a/packages/chain-adapters/src/types.ts
+++ b/packages/chain-adapters/src/types.ts
@@ -318,13 +318,13 @@ export enum ChainAdapterDisplayName {
 }
 
 export type BroadcastTransactionInput = {
-  from: string
-  to: string
+  senderAddress: string
+  receiverAddress: string | undefined // this is not defined for staking etc
   hex: string
 }
 
 export type SignAndBroadcastTransactionInput<T extends ChainId> = {
-  from: string
-  to: string
+  senderAddress: string
+  receiverAddress: string | undefined // this is not defined for staking etc
   signTxInput: SignTxInput<SignTx<T>>
 }

--- a/packages/chain-adapters/src/utils/validateAddress.ts
+++ b/packages/chain-adapters/src/utils/validateAddress.ts
@@ -1,0 +1,41 @@
+import axios from 'axios'
+
+const TRM_LABS_API_URL = 'https://api.trmlabs.com/public/v1/sanctions/screening'
+
+const cache: Record<string, Promise<boolean>> = {}
+
+const _validateAddress = async (address: string): Promise<boolean> => {
+  type trmResponse = [
+    {
+      address: string
+      isSanctioned: boolean
+    },
+  ]
+
+  const response = await axios.post<trmResponse>(
+    TRM_LABS_API_URL,
+    [
+      {
+        address,
+      },
+    ],
+    {
+      headers: {
+        Accept: 'application/json',
+      },
+    },
+  )
+
+  return response.data[0].isSanctioned
+}
+
+export const validateAddress = async (address: string): Promise<void> => {
+  // dedupe and cache promises in memory
+  if (cache[address] === undefined) {
+    const newEntry = _validateAddress(address)
+    cache[address] = newEntry
+  }
+
+  const result = cache[address]
+  if (await result) throw Error('Address not supported')
+}

--- a/packages/chain-adapters/src/utxo/UtxoBaseAdapter.ts
+++ b/packages/chain-adapters/src/utxo/UtxoBaseAdapter.ts
@@ -406,11 +406,15 @@ export abstract class UtxoBaseAdapter<T extends UtxoChainId> implements IChainAd
   }
 
   async signAndBroadcastTransaction({
-    from,
-    to,
+    senderAddress,
+    receiverAddress,
     signTxInput,
   }: SignAndBroadcastTransactionInput<T>): Promise<string> {
-    await Promise.all([validateAddress(from), validateAddress(to)])
+    await Promise.all([
+      validateAddress(senderAddress),
+      receiverAddress !== undefined && validateAddress(receiverAddress),
+    ])
+
     try {
       const { wallet } = signTxInput
 
@@ -419,7 +423,7 @@ export abstract class UtxoBaseAdapter<T extends UtxoChainId> implements IChainAd
       }
       const hex = await this.signTransaction(signTxInput)
 
-      return this.broadcastTransaction({ from, to, hex })
+      return this.broadcastTransaction({ senderAddress, receiverAddress, hex })
     } catch (err) {
       return ErrorHandler(err)
     }
@@ -494,8 +498,16 @@ export abstract class UtxoBaseAdapter<T extends UtxoChainId> implements IChainAd
     }
   }
 
-  async broadcastTransaction({ from, to, hex }: BroadcastTransactionInput): Promise<string> {
-    await Promise.all([validateAddress(from), validateAddress(to)])
+  async broadcastTransaction({
+    senderAddress,
+    receiverAddress,
+    hex,
+  }: BroadcastTransactionInput): Promise<string> {
+    await Promise.all([
+      validateAddress(senderAddress),
+      receiverAddress !== undefined && validateAddress(receiverAddress),
+    ])
+
     return this.providers.http.sendTx({ sendTxBody: { hex } })
   }
 

--- a/packages/chain-adapters/src/utxo/UtxoBaseAdapter.ts
+++ b/packages/chain-adapters/src/utxo/UtxoBaseAdapter.ts
@@ -19,10 +19,12 @@ import type { ChainAdapter as IChainAdapter } from '../api'
 import { ErrorHandler } from '../error/ErrorHandler'
 import type {
   Account,
+  BroadcastTransactionInput,
   BuildSendTxInput,
   FeeDataEstimate,
   GetBIP44ParamsInput,
   GetFeeDataInput,
+  SignAndBroadcastTransactionInput,
   SignTx,
   SignTxInput,
   SubscribeError,
@@ -43,6 +45,7 @@ import {
   toRootDerivationPath,
 } from '../utils'
 import { bnOrZero } from '../utils/bignumber'
+import { validateAddress } from '../utils/validateAddress'
 import type { bitcoin, bitcoincash, dogecoin, litecoin } from './'
 import type { GetAddressInput } from './types'
 import { utxoSelect } from './utxoSelect'
@@ -402,15 +405,21 @@ export abstract class UtxoBaseAdapter<T extends UtxoChainId> implements IChainAd
     }
   }
 
-  async signAndBroadcastTransaction(signTxInput: SignTxInput<SignTx<T>>): Promise<string> {
+  async signAndBroadcastTransaction({
+    from,
+    to,
+    signTxInput,
+  }: SignAndBroadcastTransactionInput<T>): Promise<string> {
+    await Promise.all([validateAddress(from), validateAddress(to)])
     try {
       const { wallet } = signTxInput
 
       if (!supportsBTC(wallet)) {
         throw new Error(`UtxoBaseAdapter: wallet does not support ${this.coinName}`)
       }
-      const signedTx = await this.signTransaction(signTxInput)
-      return this.broadcastTransaction(signedTx)
+      const hex = await this.signTransaction(signTxInput)
+
+      return this.broadcastTransaction({ from, to, hex })
     } catch (err) {
       return ErrorHandler(err)
     }
@@ -485,7 +494,8 @@ export abstract class UtxoBaseAdapter<T extends UtxoChainId> implements IChainAd
     }
   }
 
-  broadcastTransaction(hex: string): Promise<string> {
+  async broadcastTransaction({ from, to, hex }: BroadcastTransactionInput): Promise<string> {
+    await Promise.all([validateAddress(from), validateAddress(to)])
     return this.providers.http.sendTx({ sendTxBody: { hex } })
   }
 

--- a/packages/chain-adapters/src/utxo/bitcoin/BitcoinChainAdapter.test.ts
+++ b/packages/chain-adapters/src/utxo/bitcoin/BitcoinChainAdapter.test.ts
@@ -315,8 +315,8 @@ describe('BitcoinChainAdapter', () => {
       const adapter = new bitcoin.ChainAdapter(args)
       const mockTx = '0x123'
       const result = await adapter.broadcastTransaction({
-        from: '0x1234',
-        to: '0x1234',
+        senderAddress: '0x1234',
+        receiverAddress: '0x1234',
         hex: mockTx,
       })
       expect(args.providers.http.sendTx).toHaveBeenCalledWith<any>({ sendTxBody: { hex: mockTx } })

--- a/packages/chain-adapters/src/utxo/bitcoin/BitcoinChainAdapter.test.ts
+++ b/packages/chain-adapters/src/utxo/bitcoin/BitcoinChainAdapter.test.ts
@@ -16,8 +16,8 @@ import type { Account, BuildSendTxInput, GetFeeDataInput } from '../../types'
 import type { ChainAdapterArgs, UtxoChainId } from '../UtxoBaseAdapter'
 import * as bitcoin from './BitcoinChainAdapter'
 
-jest.mock('../utils/validatePubkey', () => ({
-  validatePubkey: jest.fn(),
+jest.mock('../../utils/validateAddress', () => ({
+  validateAddress: jest.fn(),
 }))
 
 const testMnemonic = 'alcohol woman abuse must during monitor noble actual mixed trade anger aisle'

--- a/packages/chain-adapters/src/utxo/bitcoin/BitcoinChainAdapter.test.ts
+++ b/packages/chain-adapters/src/utxo/bitcoin/BitcoinChainAdapter.test.ts
@@ -16,6 +16,10 @@ import type { Account, BuildSendTxInput, GetFeeDataInput } from '../../types'
 import type { ChainAdapterArgs, UtxoChainId } from '../UtxoBaseAdapter'
 import * as bitcoin from './BitcoinChainAdapter'
 
+jest.mock('../utils/validatePubkey', () => ({
+  validatePubkey: jest.fn(),
+}))
+
 const testMnemonic = 'alcohol woman abuse must during monitor noble actual mixed trade anger aisle'
 const VALID_CHAIN_ID = 'bip122:000000000019d6689c085ae165831e93'
 const VALID_ASSET_ID = 'bip122:000000000019d6689c085ae165831e93/slip44:0'
@@ -310,7 +314,11 @@ describe('BitcoinChainAdapter', () => {
       } as any
       const adapter = new bitcoin.ChainAdapter(args)
       const mockTx = '0x123'
-      const result = await adapter.broadcastTransaction(mockTx)
+      const result = await adapter.broadcastTransaction({
+        from: '0x1234',
+        to: '0x1234',
+        hex: mockTx,
+      })
       expect(args.providers.http.sendTx).toHaveBeenCalledWith<any>({ sendTxBody: { hex: mockTx } })
       expect(result).toEqual(sendDataResult)
     })

--- a/packages/chain-adapters/src/utxo/bitcoincash/BitcoinCashChainAdapter.test.ts
+++ b/packages/chain-adapters/src/utxo/bitcoincash/BitcoinCashChainAdapter.test.ts
@@ -22,8 +22,8 @@ import type { Account, BuildSendTxInput, GetFeeDataInput } from '../../types'
 import type { ChainAdapterArgs, UtxoChainId } from '../UtxoBaseAdapter'
 import * as bitcoincash from './BitcoinCashChainAdapter'
 
-jest.mock('../utils/validatePubkey', () => ({
-  validatePubkey: jest.fn(),
+jest.mock('../../utils/validateAddress', () => ({
+  validateAddress: jest.fn(),
 }))
 
 const testMnemonic = 'alcohol woman abuse must during monitor noble actual mixed trade anger aisle'

--- a/packages/chain-adapters/src/utxo/bitcoincash/BitcoinCashChainAdapter.test.ts
+++ b/packages/chain-adapters/src/utxo/bitcoincash/BitcoinCashChainAdapter.test.ts
@@ -22,6 +22,10 @@ import type { Account, BuildSendTxInput, GetFeeDataInput } from '../../types'
 import type { ChainAdapterArgs, UtxoChainId } from '../UtxoBaseAdapter'
 import * as bitcoincash from './BitcoinCashChainAdapter'
 
+jest.mock('../utils/validatePubkey', () => ({
+  validatePubkey: jest.fn(),
+}))
+
 const testMnemonic = 'alcohol woman abuse must during monitor noble actual mixed trade anger aisle'
 const VALID_CHAIN_ID = bchChainId
 const VALID_ASSET_ID = bchAssetId
@@ -329,7 +333,11 @@ describe('BitcoinCashChainAdapter', () => {
       } as any
       const adapter = new bitcoincash.ChainAdapter(args)
       const mockTx = '0x123'
-      const result = await adapter.broadcastTransaction(mockTx)
+      const result = await adapter.broadcastTransaction({
+        from: '0x1234',
+        to: '0x1234',
+        hex: mockTx,
+      })
       expect(args.providers.http.sendTx).toHaveBeenCalledWith<any>({ sendTxBody: { hex: mockTx } })
       expect(result).toEqual(sendDataResult)
     })

--- a/packages/chain-adapters/src/utxo/bitcoincash/BitcoinCashChainAdapter.test.ts
+++ b/packages/chain-adapters/src/utxo/bitcoincash/BitcoinCashChainAdapter.test.ts
@@ -334,8 +334,8 @@ describe('BitcoinCashChainAdapter', () => {
       const adapter = new bitcoincash.ChainAdapter(args)
       const mockTx = '0x123'
       const result = await adapter.broadcastTransaction({
-        from: '0x1234',
-        to: '0x1234',
+        senderAddress: '0x1234',
+        receiverAddress: '0x1234',
         hex: mockTx,
       })
       expect(args.providers.http.sendTx).toHaveBeenCalledWith<any>({ sendTxBody: { hex: mockTx } })

--- a/packages/chain-adapters/src/utxo/dogecoin/DogecoinChainAdapter.test.ts
+++ b/packages/chain-adapters/src/utxo/dogecoin/DogecoinChainAdapter.test.ts
@@ -16,8 +16,8 @@ import type { Account, BuildSendTxInput, GetFeeDataInput } from '../../types'
 import type { ChainAdapterArgs, UtxoChainId } from '../UtxoBaseAdapter'
 import * as dogecoin from './DogecoinChainAdapter'
 
-jest.mock('../utils/validatePubkey', () => ({
-  validatePubkey: jest.fn(),
+jest.mock('../../utils/validateAddress', () => ({
+  validateAddress: jest.fn(),
 }))
 
 const testMnemonic = 'alcohol woman abuse must during monitor noble actual mixed trade anger aisle'

--- a/packages/chain-adapters/src/utxo/dogecoin/DogecoinChainAdapter.test.ts
+++ b/packages/chain-adapters/src/utxo/dogecoin/DogecoinChainAdapter.test.ts
@@ -323,8 +323,8 @@ describe('DogecoinChainAdapter', () => {
       const adapter = new dogecoin.ChainAdapter(args)
       const mockTx = '0x123'
       const result = await adapter.broadcastTransaction({
-        from: '0x1234',
-        to: '0x1234',
+        senderAddress: '0x1234',
+        receiverAddress: '0x1234',
         hex: mockTx,
       })
       expect(args.providers.http.sendTx).toHaveBeenCalledWith<any>({ sendTxBody: { hex: mockTx } })

--- a/packages/chain-adapters/src/utxo/dogecoin/DogecoinChainAdapter.test.ts
+++ b/packages/chain-adapters/src/utxo/dogecoin/DogecoinChainAdapter.test.ts
@@ -16,6 +16,10 @@ import type { Account, BuildSendTxInput, GetFeeDataInput } from '../../types'
 import type { ChainAdapterArgs, UtxoChainId } from '../UtxoBaseAdapter'
 import * as dogecoin from './DogecoinChainAdapter'
 
+jest.mock('../utils/validatePubkey', () => ({
+  validatePubkey: jest.fn(),
+}))
+
 const testMnemonic = 'alcohol woman abuse must during monitor noble actual mixed trade anger aisle'
 const VALID_CHAIN_ID = 'bip122:00000000001a91e3dace36e2be3bf030'
 const VALID_ASSET_ID = 'bip122:00000000001a91e3dace36e2be3bf030/slip44:3'
@@ -318,7 +322,11 @@ describe('DogecoinChainAdapter', () => {
       } as any
       const adapter = new dogecoin.ChainAdapter(args)
       const mockTx = '0x123'
-      const result = await adapter.broadcastTransaction(mockTx)
+      const result = await adapter.broadcastTransaction({
+        from: '0x1234',
+        to: '0x1234',
+        hex: mockTx,
+      })
       expect(args.providers.http.sendTx).toHaveBeenCalledWith<any>({ sendTxBody: { hex: mockTx } })
       expect(result).toEqual(sendDataResult)
     })

--- a/packages/chain-adapters/src/utxo/litecoin/LitecoinChainAdapter.test.ts
+++ b/packages/chain-adapters/src/utxo/litecoin/LitecoinChainAdapter.test.ts
@@ -17,8 +17,8 @@ import type { Account, BuildSendTxInput, GetFeeDataInput } from '../../types'
 import type { ChainAdapterArgs, UtxoChainId } from '../UtxoBaseAdapter'
 import * as litecoin from './LitecoinChainAdapter'
 
-jest.mock('../utils/validatePubkey', () => ({
-  validatePubkey: jest.fn(),
+jest.mock('../../utils/validateAddress', () => ({
+  validateAddress: jest.fn(),
 }))
 
 const testMnemonic = 'alcohol woman abuse must during monitor noble actual mixed trade anger aisle'

--- a/packages/chain-adapters/src/utxo/litecoin/LitecoinChainAdapter.test.ts
+++ b/packages/chain-adapters/src/utxo/litecoin/LitecoinChainAdapter.test.ts
@@ -17,6 +17,10 @@ import type { Account, BuildSendTxInput, GetFeeDataInput } from '../../types'
 import type { ChainAdapterArgs, UtxoChainId } from '../UtxoBaseAdapter'
 import * as litecoin from './LitecoinChainAdapter'
 
+jest.mock('../utils/validatePubkey', () => ({
+  validatePubkey: jest.fn(),
+}))
+
 const testMnemonic = 'alcohol woman abuse must during monitor noble actual mixed trade anger aisle'
 const VALID_CHAIN_ID = ltcChainId
 const VALID_ASSET_ID = ltcAssetId
@@ -316,7 +320,11 @@ describe('LitecoinChainAdapter', () => {
       } as any
       const adapter = new litecoin.ChainAdapter(args)
       const mockTx = '0x123'
-      const result = await adapter.broadcastTransaction(mockTx)
+      const result = await adapter.broadcastTransaction({
+        from: '0x1234',
+        to: '0x1234',
+        hex: mockTx,
+      })
       expect(args.providers.http.sendTx).toHaveBeenCalledWith<any>({ sendTxBody: { hex: mockTx } })
       expect(result).toEqual(sendDataResult)
     })

--- a/packages/chain-adapters/src/utxo/litecoin/LitecoinChainAdapter.test.ts
+++ b/packages/chain-adapters/src/utxo/litecoin/LitecoinChainAdapter.test.ts
@@ -321,8 +321,8 @@ describe('LitecoinChainAdapter', () => {
       const adapter = new litecoin.ChainAdapter(args)
       const mockTx = '0x123'
       const result = await adapter.broadcastTransaction({
-        from: '0x1234',
-        to: '0x1234',
+        senderAddress: '0x1234',
+        receiverAddress: '0x1234',
         hex: mockTx,
       })
       expect(args.providers.http.sendTx).toHaveBeenCalledWith<any>({ sendTxBody: { hex: mockTx } })

--- a/src/components/Modals/Send/hooks/useFormSend/useFormSend.test.tsx
+++ b/src/components/Modals/Send/hooks/useFormSend/useFormSend.test.tsx
@@ -115,7 +115,9 @@ const formData: SendInput<KnownChainIds.EthereumMainnet> = {
 
 const formDataEnsAddress = { ...formData, [SendFormFields.To]: 'willywonka.eth' }
 
-const textTxToSign = {
+const testSendAddress = '0x3155ba85d5f96b2d030a4966af206230e46849cb'
+
+const testTxToSign = {
   addressNList: [2147483692, 2147483708, 2147483648, 0, 0],
   value: '0x0',
   to: '0x3155ba85d5f96b2d030a4966af206230e46849cb',
@@ -165,7 +167,8 @@ describe.each([
       }
     })
     const mockAdapter = {
-      buildSendTransaction: () => Promise.resolve(textTxToSign),
+      getAddress: () => Promise.resolve(testSendAddress),
+      buildSendTransaction: () => Promise.resolve(testTxToSign),
       signTransaction: () => Promise.resolve(testSignedTx),
       broadcastTransaction: () => Promise.resolve(expectedTx),
     }
@@ -229,7 +232,8 @@ describe.each([
       }
     })
     const mockAdapter = {
-      buildSendTransaction: () => Promise.resolve(textTxToSign),
+      getAddress: () => Promise.resolve(testSendAddress),
+      buildSendTransaction: () => Promise.resolve(testTxToSign),
       signTransaction: () => Promise.resolve(testSignedTx),
       broadcastTransaction: () => Promise.resolve(expectedTx),
     }
@@ -290,7 +294,8 @@ describe.each([
       }
     })
     const mockAdapter = {
-      buildSendTransaction: () => Promise.resolve(textTxToSign),
+      getAddress: () => Promise.resolve(testSendAddress),
+      buildSendTransaction: () => Promise.resolve(testTxToSign),
       signAndBroadcastTransaction,
     }
 
@@ -356,7 +361,8 @@ describe.each([
       }
     })
     const mockAdapter = {
-      buildSendTransaction: () => Promise.resolve(textTxToSign),
+      getAddress: () => Promise.resolve(testSendAddress),
+      buildSendTransaction: () => Promise.resolve(testTxToSign),
       signAndBroadcastTransaction,
     }
 
@@ -410,6 +416,7 @@ describe.each([
     })
 
     const mockAdapter = {
+      getAddress: () => Promise.resolve(testSendAddress),
       buildSendTransaction: () => Promise.reject('All these calls failed'),
       signTransaction: () => Promise.reject('All these calls failed'),
       broadcastTransaction: () => Promise.reject('All these calls failed'),

--- a/src/components/Modals/Send/hooks/useFormSend/useFormSend.test.tsx
+++ b/src/components/Modals/Send/hooks/useFormSend/useFormSend.test.tsx
@@ -110,7 +110,7 @@ const formData: SendInput<KnownChainIds.EthereumMainnet> = {
   [SendFormFields.FiatAmount]: '3500',
   [SendFormFields.FiatSymbol]: 'USD',
   [SendFormFields.SendMax]: false,
-  [SendFormFields.AccountId]: 'eip155:1/erc20:0x3155ba85d5f96b2d030a4966af206230e46849cb',
+  [SendFormFields.AccountId]: 'eip155:1:0x3155ba85d5f96b2d030a4966af206230e46849cb',
 }
 
 const formDataEnsAddress = { ...formData, [SendFormFields.To]: 'willywonka.eth' }

--- a/src/components/Modals/Send/utils.ts
+++ b/src/components/Modals/Send/utils.ts
@@ -129,7 +129,7 @@ export const handleSend = async ({
 
     const chainId = adapter.getChainId()
 
-    const { estimatedFees, feeType, to, memo, from } = sendInput
+    const { estimatedFees, feeType, to, memo, from, accountId } = sendInput
 
     if (!accountMetadata)
       throw new Error(`useFormSend: no accountMetadata for ${sendInput.accountId}`)
@@ -215,6 +215,8 @@ export const handleSend = async ({
 
     const txToSign = result.txToSign
 
+    const { account } = fromAccountId(accountId)
+
     const broadcastTXID = await (async () => {
       if (wallet.supportsOfflineSigning()) {
         const signedTx = await adapter.signTransaction({
@@ -222,7 +224,7 @@ export const handleSend = async ({
           wallet,
         })
         return adapter.broadcastTransaction({
-          senderAddress: from,
+          senderAddress: from ?? account,
           receiverAddress: to,
           hex: signedTx,
         })
@@ -235,7 +237,7 @@ export const handleSend = async ({
           throw new Error('signAndBroadcastTransaction undefined for wallet')
         }
         return adapter.signAndBroadcastTransaction({
-          senderAddress: from,
+          senderAddress: from ?? account,
           receiverAddress: to,
           signTxInput: { txToSign, wallet },
         })

--- a/src/components/Modals/Send/utils.ts
+++ b/src/components/Modals/Send/utils.ts
@@ -129,7 +129,7 @@ export const handleSend = async ({
 
     const chainId = adapter.getChainId()
 
-    const { estimatedFees, feeType, to, memo, from, accountId } = sendInput
+    const { estimatedFees, feeType, to, memo, from } = sendInput
 
     if (!accountMetadata)
       throw new Error(`useFormSend: no accountMetadata for ${sendInput.accountId}`)

--- a/src/components/Modals/Send/utils.ts
+++ b/src/components/Modals/Send/utils.ts
@@ -221,7 +221,11 @@ export const handleSend = async ({
           txToSign,
           wallet,
         })
-        return adapter.broadcastTransaction({ from, to, hex: signedTx })
+        return adapter.broadcastTransaction({
+          senderAddress: from,
+          receiverAddress: to,
+          hex: signedTx,
+        })
       } else if (wallet.supportsBroadcast()) {
         /**
          * signAndBroadcastTransaction is an optional method on the HDWallet interface.
@@ -230,7 +234,11 @@ export const handleSend = async ({
         if (!adapter.signAndBroadcastTransaction) {
           throw new Error('signAndBroadcastTransaction undefined for wallet')
         }
-        return adapter.signAndBroadcastTransaction({ from, to, signTxInput: { txToSign, wallet } })
+        return adapter.signAndBroadcastTransaction({
+          senderAddress: from,
+          receiverAddress: to,
+          signTxInput: { txToSign, wallet },
+        })
       } else {
         throw new Error('Bad hdwallet config')
       }

--- a/src/components/Modals/Send/utils.ts
+++ b/src/components/Modals/Send/utils.ts
@@ -1,20 +1,18 @@
 import type { AssetId, ChainId } from '@shapeshiftoss/caip'
 import { CHAIN_NAMESPACE, fromAccountId, fromAssetId, fromChainId } from '@shapeshiftoss/caip'
 import type {
+  ChainAdapter,
   CosmosSdkBaseAdapter,
   CosmosSdkChainId,
+  EvmBaseAdapter,
+  EvmChainId,
+  FeeData,
   FeeDataEstimate,
   GetFeeDataInput,
+  UtxoBaseAdapter,
+  UtxoChainId,
 } from '@shapeshiftoss/chain-adapters'
-import {
-  type ChainAdapter,
-  type EvmBaseAdapter,
-  type EvmChainId,
-  type FeeData,
-  type UtxoBaseAdapter,
-  type UtxoChainId,
-  utxoChainIds,
-} from '@shapeshiftoss/chain-adapters'
+import { utxoChainIds } from '@shapeshiftoss/chain-adapters'
 import type { HDWallet } from '@shapeshiftoss/hdwallet-core'
 import { supportsETH } from '@shapeshiftoss/hdwallet-core'
 import type { KnownChainIds } from '@shapeshiftoss/types'
@@ -223,7 +221,7 @@ export const handleSend = async ({
           txToSign,
           wallet,
         })
-        return adapter.broadcastTransaction(signedTx)
+        return adapter.broadcastTransaction({ from, to, hex: signedTx })
       } else if (wallet.supportsBroadcast()) {
         /**
          * signAndBroadcastTransaction is an optional method on the HDWallet interface.
@@ -232,7 +230,7 @@ export const handleSend = async ({
         if (!adapter.signAndBroadcastTransaction) {
           throw new Error('signAndBroadcastTransaction undefined for wallet')
         }
-        return adapter.signAndBroadcastTransaction?.({ txToSign, wallet })
+        return adapter.signAndBroadcastTransaction({ from, to, signTxInput: { txToSign, wallet } })
       } else {
         throw new Error('Bad hdwallet config')
       }

--- a/src/components/Modals/Send/utils.ts
+++ b/src/components/Modals/Send/utils.ts
@@ -215,7 +215,10 @@ export const handleSend = async ({
 
     const txToSign = result.txToSign
 
-    const { account } = fromAccountId(accountId)
+    const senderAddress = await adapter.getAddress({
+      accountNumber: accountMetadata.bip44Params.accountNumber,
+      wallet,
+    })
 
     const broadcastTXID = await (async () => {
       if (wallet.supportsOfflineSigning()) {
@@ -224,7 +227,7 @@ export const handleSend = async ({
           wallet,
         })
         return adapter.broadcastTransaction({
-          senderAddress: from ?? account,
+          senderAddress,
           receiverAddress: to,
           hex: signedTx,
         })
@@ -237,7 +240,7 @@ export const handleSend = async ({
           throw new Error('signAndBroadcastTransaction undefined for wallet')
         }
         return adapter.signAndBroadcastTransaction({
-          senderAddress: from ?? account,
+          senderAddress,
           receiverAddress: to,
           signTxInput: { txToSign, wallet },
         })

--- a/src/components/MultiHopTrade/hooks/useAllowanceApproval/hooks/useExecuteAllowanceApproval.tsx
+++ b/src/components/MultiHopTrade/hooks/useAllowanceApproval/hooks/useExecuteAllowanceApproval.tsx
@@ -36,7 +36,11 @@ export const useExecuteAllowanceApproval = (
     }
 
     try {
-      const txId = await buildAndBroadcast({ buildCustomTxInput, adapter })
+      const txId = await buildAndBroadcast({
+        adapter,
+        buildCustomTxInput,
+        receiverAddress: undefined, // no receiver for this contract call
+      })
 
       setTxId(txId)
 

--- a/src/components/MultiHopTrade/hooks/useTradeExecution/useTradeExecution.ts
+++ b/src/components/MultiHopTrade/hooks/useTradeExecution/useTradeExecution.ts
@@ -167,6 +167,7 @@ export const useTradeExecution = ({
           if (accountType === undefined) throw Error('Missing UTXO account type')
           const adapter = assertGetUtxoChainAdapter(chainId)
           const { xpub } = await adapter.getPublicKey(wallet, accountNumber, accountType)
+          const senderAddress = await adapter.getAddress({ accountNumber, wallet })
           const output = await execution.execUtxoTransaction({
             swapperName,
             tradeQuote,
@@ -180,7 +181,7 @@ export const useTradeExecution = ({
                 wallet,
               })
               return adapter.broadcastTransaction({
-                senderAddress: xpub,
+                senderAddress,
                 receiverAddress: tradeQuote.receiveAddress,
                 hex: signedTx,
               })

--- a/src/components/MultiHopTrade/hooks/useTradeExecution/useTradeExecution.ts
+++ b/src/components/MultiHopTrade/hooks/useTradeExecution/useTradeExecution.ts
@@ -151,7 +151,7 @@ export const useTradeExecution = ({
                 wallet,
                 accountNumber,
               } as BuildCustomTxInput)
-              return await signAndBroadcast({ adapter, txToSign, wallet })
+              return await signAndBroadcast({ adapter, txToSign, wallet, accountNumber })
             },
           })
           cancelPollingRef.current = output?.cancelPolling
@@ -173,7 +173,11 @@ export const useTradeExecution = ({
                 txToSign,
                 wallet,
               })
-              return adapter.broadcastTransaction(signedTx)
+              return adapter.broadcastTransaction({
+                from: xpub,
+                to: tradeQuote.receiveAddress,
+                hex: signedTx,
+              })
             },
           })
           cancelPollingRef.current = output?.cancelPolling
@@ -208,7 +212,11 @@ export const useTradeExecution = ({
                 txToSign,
                 wallet,
               })
-              return adapter.broadcastTransaction(signedTx)
+              return adapter.broadcastTransaction({
+                from,
+                to: tradeQuote.receiveAddress,
+                hex: signedTx,
+              })
             },
           })
           cancelPollingRef.current = output?.cancelPolling

--- a/src/components/MultiHopTrade/hooks/useTradeExecution/useTradeExecution.ts
+++ b/src/components/MultiHopTrade/hooks/useTradeExecution/useTradeExecution.ts
@@ -104,6 +104,7 @@ export const useTradeExecution = ({
       const { accountType, bip44Params } = accountMetadata
       const accountNumber = bip44Params.accountNumber
       const stepSellAssetChainId = tradeQuote.steps[activeStepOrDefault].sellAsset.chainId
+      const stepSellAssetAssetId = tradeQuote.steps[activeStepOrDefault].sellAsset.assetId
       const stepBuyAssetAssetId = tradeQuote.steps[activeStepOrDefault].buyAsset.assetId
 
       if (swapperName === SwapperName.CowSwap) {
@@ -174,7 +175,12 @@ export const useTradeExecution = ({
           if (accountType === undefined) throw Error('Missing UTXO account type')
           const adapter = assertGetUtxoChainAdapter(stepSellAssetChainId)
           const { xpub } = await adapter.getPublicKey(wallet, accountNumber, accountType)
-          const senderAddress = await adapter.getAddress({ accountNumber, wallet })
+          const _senderAddress = await adapter.getAddress({ accountNumber, wallet })
+          const senderAddress =
+            stepSellAssetAssetId === bchAssetId
+              ? _senderAddress.replace('bitcoincash:', '')
+              : _senderAddress
+
           const output = await execution.execUtxoTransaction({
             swapperName,
             tradeQuote,

--- a/src/components/MultiHopTrade/hooks/useTradeExecution/useTradeExecution.ts
+++ b/src/components/MultiHopTrade/hooks/useTradeExecution/useTradeExecution.ts
@@ -151,7 +151,13 @@ export const useTradeExecution = ({
                 wallet,
                 accountNumber,
               } as BuildCustomTxInput)
-              return await signAndBroadcast({ adapter, txToSign, wallet, accountNumber })
+              return await signAndBroadcast({
+                adapter,
+                txToSign,
+                wallet,
+                senderAddress: from,
+                receiverAddress: tradeQuote.receiveAddress,
+              })
             },
           })
           cancelPollingRef.current = output?.cancelPolling
@@ -174,8 +180,8 @@ export const useTradeExecution = ({
                 wallet,
               })
               return adapter.broadcastTransaction({
-                from: xpub,
-                to: tradeQuote.receiveAddress,
+                senderAddress: xpub,
+                receiverAddress: tradeQuote.receiveAddress,
                 hex: signedTx,
               })
             },
@@ -213,8 +219,8 @@ export const useTradeExecution = ({
                 wallet,
               })
               return adapter.broadcastTransaction({
-                from,
-                to: tradeQuote.receiveAddress,
+                senderAddress: from,
+                receiverAddress: tradeQuote.receiveAddress,
                 hex: signedTx,
               })
             },

--- a/src/config.ts
+++ b/src/config.ts
@@ -153,7 +153,6 @@ const validators = {
   REACT_APP_EXPERIMENTAL_MM_SNAPPY_FINGERS: bool({ default: false }),
   REACT_APP_SNAP_ID: str(),
   REACT_APP_FEATURE_FOX_DISCOUNTS: bool({ default: false }),
-  REACT_APP_TRM_LABS_API_URL: url(),
 }
 
 function reporter<T>({ errors }: envalid.ReporterOptions<T>) {

--- a/src/context/PluginProvider/PluginProvider.tsx
+++ b/src/context/PluginProvider/PluginProvider.tsx
@@ -62,7 +62,7 @@ export const PluginProvider = ({ children }: PluginProviderProps): JSX.Element =
     const newChainAdapters: { [k in ChainId]?: () => ChainAdapter<ChainId> } = {}
 
     // register providers from each plugin
-    for (const [, plugin] of pluginManager.entries()) {
+    for (const plugin of pluginManager.values()) {
       // Ignore plugins that have their feature flag disabled
       // If no featureFlag is present, then we assume it's enabled
       const featureFlagEnabled =

--- a/src/features/defi/providers/fox-farming/hooks/useFoxFarming.ts
+++ b/src/features/defi/providers/fox-farming/hooks/useFoxFarming.ts
@@ -74,7 +74,11 @@ export const useFoxFarming = (
           wallet,
         })
 
-        const txid = await buildAndBroadcast({ adapter, buildCustomTxInput })
+        const txid = await buildAndBroadcast({
+          adapter,
+          buildCustomTxInput,
+          receiverAddress: undefined, // no receiver for this contract call
+        })
 
         return txid
       } catch (err) {
@@ -115,7 +119,11 @@ export const useFoxFarming = (
           wallet,
         })
 
-        const txid = await buildAndBroadcast({ adapter, buildCustomTxInput })
+        const txid = await buildAndBroadcast({
+          adapter,
+          buildCustomTxInput,
+          receiverAddress: undefined, // no receiver for this contract call
+        })
 
         return txid
       } catch (err) {
@@ -236,6 +244,7 @@ export const useFoxFarming = (
 
     const txid = await buildAndBroadcast({
       adapter,
+      receiverAddress: undefined, // no receiver for this contract call
       buildCustomTxInput: {
         accountNumber,
         to: uniV2LPContract.address,
@@ -265,7 +274,11 @@ export const useFoxFarming = (
       wallet,
     })
 
-    const txid = await buildAndBroadcast({ adapter, buildCustomTxInput })
+    const txid = await buildAndBroadcast({
+      adapter,
+      buildCustomTxInput,
+      receiverAddress: undefined, // no receiver for this contract call
+    })
 
     return txid
   }, [accountNumber, adapter, ethAsset.chainId, contractAddress, foxFarmingContract, skip, wallet])

--- a/src/features/defi/providers/thorchain-savers/components/ThorchainSaversManager/Deposit/components/Approve.tsx
+++ b/src/features/defi/providers/thorchain-savers/components/ThorchainSaversManager/Deposit/components/Approve.tsx
@@ -161,7 +161,11 @@ export const Approve: React.FC<ApproveProps> = ({ accountId, onNext }) => {
         wallet,
       })
 
-      await buildAndBroadcast({ adapter, buildCustomTxInput })
+      await buildAndBroadcast({
+        adapter,
+        buildCustomTxInput,
+        receiverAddress: undefined, // no receiver for this contract call
+      })
       await poll({
         fn: () =>
           getErc20Allowance({

--- a/src/features/defi/providers/thorchain-savers/components/ThorchainSaversManager/Deposit/components/Confirm.tsx
+++ b/src/features/defi/providers/thorchain-savers/components/ThorchainSaversManager/Deposit/components/Confirm.tsx
@@ -557,15 +557,19 @@ export const Confirm: React.FC<ConfirmProps> = ({ accountId, onNext }) => {
   ])
 
   const handleCustomTx = useCallback(async (): Promise<string | undefined> => {
-    if (!wallet) return
+    if (!wallet || accountNumber === undefined) return
     const buildCustomTxInput = await getCustomTxInput()
     if (!buildCustomTxInput) return
 
     const adapter = assertGetEvmChainAdapter(chainId)
 
-    const txid = await buildAndBroadcast({ adapter, buildCustomTxInput })
+    const txid = await buildAndBroadcast({
+      adapter,
+      buildCustomTxInput,
+      receiverAddress: undefined, // no receiver for this contract call
+    })
     return txid
-  }, [wallet, getCustomTxInput, chainId])
+  }, [wallet, accountNumber, getCustomTxInput, chainId])
 
   const handleMultiTxSend = useCallback(async (): Promise<string | undefined> => {
     if (!wallet) return

--- a/src/features/defi/providers/thorchain-savers/components/ThorchainSaversManager/Withdraw/components/Confirm.tsx
+++ b/src/features/defi/providers/thorchain-savers/components/ThorchainSaversManager/Withdraw/components/Confirm.tsx
@@ -609,15 +609,19 @@ export const Confirm: React.FC<ConfirmProps> = ({ accountId, onNext }) => {
   ])
 
   const handleCustomTx = useCallback(async (): Promise<string | undefined> => {
-    if (!wallet) return
+    if (!wallet || accountNumber === undefined) return
     const buildCustomTxInput = await getCustomTxInput()
     if (!buildCustomTxInput) return
 
     const adapter = assertGetEvmChainAdapter(chainId)
 
-    const txid = await buildAndBroadcast({ adapter, buildCustomTxInput })
+    const txid = await buildAndBroadcast({
+      adapter,
+      buildCustomTxInput,
+      receiverAddress: undefined, // no receiver for this contract call
+    })
     return txid
-  }, [wallet, getCustomTxInput, chainId])
+  }, [wallet, accountNumber, getCustomTxInput, chainId])
 
   const handleMultiTxSend = useCallback(async (): Promise<string | undefined> => {
     if (!wallet) return

--- a/src/features/defi/providers/univ2/hooks/useUniV2LiquidityPool.ts
+++ b/src/features/defi/providers/univ2/hooks/useUniV2LiquidityPool.ts
@@ -199,7 +199,11 @@ export const useUniV2LiquidityPool = ({
           wallet,
         })
 
-        const txid = await buildAndBroadcast({ adapter, buildCustomTxInput })
+        const txid = await buildAndBroadcast({
+          adapter,
+          buildCustomTxInput,
+          receiverAddress: undefined, // no receiver
+        })
 
         return txid
       } catch (err) {
@@ -309,7 +313,11 @@ export const useUniV2LiquidityPool = ({
           wallet,
         })
 
-        const txid = await buildAndBroadcast({ adapter, buildCustomTxInput })
+        const txid = await buildAndBroadcast({
+          adapter,
+          buildCustomTxInput,
+          receiverAddress: undefined, // no receiver
+        })
 
         return txid
       } catch (err) {
@@ -577,6 +585,7 @@ export const useUniV2LiquidityPool = ({
 
       const txid = await buildAndBroadcast({
         adapter,
+        receiverAddress: undefined, // no receiver
         buildCustomTxInput: {
           accountNumber,
           to: contractAddress,

--- a/src/lib/investor/investor-foxy/api/api.ts
+++ b/src/lib/investor/investor-foxy/api/api.ts
@@ -143,7 +143,7 @@ export class FoxyApi {
       ...(shouldUseEIP1559Fees ? { maxFeePerGas, maxPriorityFeePerGas } : { gasPrice }),
     })
 
-    const from = await this.adapter.getAddress({
+    const senderAddress = await this.adapter.getAddress({
       accountNumber: payload.bip44Params.accountNumber,
       wallet,
     })
@@ -156,7 +156,11 @@ export class FoxyApi {
           const sendSignedTx = await this.provider.sendTransaction(signedTx)
           return sendSignedTx?.blockHash ?? ''
         }
-        return this.adapter.broadcastTransaction({ from, to: payload.to, hex: signedTx })
+        return this.adapter.broadcastTransaction({
+          senderAddress,
+          receiverAddress: undefined, // no receiver for this contract call
+          hex: signedTx,
+        })
       } catch (e) {
         throw new Error(`Failed to broadcast: ${e}`)
       }
@@ -165,8 +169,8 @@ export class FoxyApi {
         throw new Error(`Cannot perform a dry run with wallet of type ${wallet.getVendor()}`)
       }
       return this.adapter.signAndBroadcastTransaction({
-        from,
-        to: payload.to,
+        senderAddress,
+        receiverAddress: undefined, // no receiver for this contract call
         signTxInput: { txToSign, wallet },
       })
     } else {

--- a/src/lib/investor/investor-idle/IdleOpportunity.ts
+++ b/src/lib/investor/investor-idle/IdleOpportunity.ts
@@ -463,7 +463,7 @@ export class IdleOpportunity
       addressNList: toAddressNList(bip44Params),
     }
 
-    const from = await chainAdapter.getAddress({
+    const senderAddress = await chainAdapter.getAddress({
       accountNumber: bip44Params.accountNumber,
       wallet,
     })
@@ -471,14 +471,18 @@ export class IdleOpportunity
     if (wallet.supportsOfflineSigning()) {
       const signedTx = await chainAdapter.signTransaction({ txToSign, wallet })
       if (this.#internals.dryRun) return signedTx
-      return chainAdapter.broadcastTransaction({ from, to: tx.to, hex: signedTx })
+      return chainAdapter.broadcastTransaction({
+        senderAddress,
+        receiverAddress: undefined, // no receiver for this contract call
+        hex: signedTx,
+      })
     } else if (wallet.supportsBroadcast() && chainAdapter.signAndBroadcastTransaction) {
       if (this.#internals.dryRun) {
         throw new Error(`Cannot perform a dry run with wallet of type ${wallet.getVendor()}`)
       }
       return chainAdapter.signAndBroadcastTransaction({
-        from,
-        to: tx.to,
+        senderAddress,
+        receiverAddress: undefined, // no receiver for this contract call
         signTxInput: { txToSign, wallet },
       })
     } else {

--- a/src/lib/investor/investor-yearn/YearnOpportunity.ts
+++ b/src/lib/investor/investor-yearn/YearnOpportunity.ts
@@ -195,7 +195,7 @@ export class YearnOpportunity
       addressNList: toAddressNList(bip44Params),
     }
 
-    const from = await chainAdapter.getAddress({
+    const senderAddress = await chainAdapter.getAddress({
       accountNumber: bip44Params.accountNumber,
       wallet,
     })
@@ -203,14 +203,18 @@ export class YearnOpportunity
     if (wallet.supportsOfflineSigning()) {
       const signedTx = await chainAdapter.signTransaction({ txToSign, wallet })
       if (this.#internals.dryRun) return signedTx
-      return chainAdapter.broadcastTransaction({ from, to: tx.to, hex: signedTx })
+      return chainAdapter.broadcastTransaction({
+        senderAddress,
+        receiverAddress: undefined, // no receiver for this contract call
+        hex: signedTx,
+      })
     } else if (wallet.supportsBroadcast() && chainAdapter.signAndBroadcastTransaction) {
       if (this.#internals.dryRun) {
         throw new Error(`Cannot perform a dry run with wallet of type ${wallet.getVendor()}`)
       }
       return chainAdapter.signAndBroadcastTransaction({
-        from,
-        to: tx.to,
+        senderAddress,
+        receiverAddress: undefined, // no receiver for this contract call
         signTxInput: { txToSign, wallet },
       })
     } else {

--- a/src/lib/swapper/swapper.ts
+++ b/src/lib/swapper/swapper.ts
@@ -11,7 +11,6 @@ import type {
   SwapperName,
   TradeQuote,
 } from './types'
-import { isValidSwapAddress } from './utils'
 
 export const getTradeQuotes = async (
   getTradeQuoteInput: GetTradeQuoteInput,
@@ -19,24 +18,6 @@ export const getTradeQuotes = async (
 ): Promise<QuoteResult[]> => {
   if (bnOrZero(getTradeQuoteInput.affiliateBps).lt(0)) return []
   if (getTradeQuoteInput.sellAmountIncludingProtocolFeesCryptoBaseUnit === '0') return []
-
-  try {
-    if (getTradeQuoteInput.sendAddress !== undefined) {
-      const isSenderValid = await isValidSwapAddress(getTradeQuoteInput.sendAddress)
-      if (!isSenderValid) {
-        return [] // no quotes available for this address
-      }
-    }
-
-    if (getTradeQuoteInput.sendAddress !== getTradeQuoteInput.receiveAddress) {
-      const isReceiverValid = await isValidSwapAddress(getTradeQuoteInput.receiveAddress)
-      if (!isReceiverValid) {
-        return [] // no quotes available for this address
-      }
-    }
-  } catch (e) {
-    console.error(e) // log error but don't fail
-  }
 
   const quotes = await Promise.allSettled(
     swappers

--- a/src/lib/swapper/types.ts
+++ b/src/lib/swapper/types.ts
@@ -215,7 +215,8 @@ export type GetUnsignedCosmosSdkTransactionArgs = CommonGetUnsignedTransactionAr
 export type UnsignedTx = Nominal<Record<string, any>, 'UnsignedTx'>
 
 export type ExecuteTradeArgs = {
-  accountNumber: number
+  senderAddress: string
+  receiverAddress: string
   txToSign: UnsignedTx
   wallet: HDWallet
   chainId: ChainId

--- a/src/lib/swapper/types.ts
+++ b/src/lib/swapper/types.ts
@@ -215,6 +215,7 @@ export type GetUnsignedCosmosSdkTransactionArgs = CommonGetUnsignedTransactionAr
 export type UnsignedTx = Nominal<Record<string, any>, 'UnsignedTx'>
 
 export type ExecuteTradeArgs = {
+  accountNumber: number
   txToSign: UnsignedTx
   wallet: HDWallet
   chainId: ChainId

--- a/src/lib/swapper/utils.ts
+++ b/src/lib/swapper/utils.ts
@@ -2,10 +2,8 @@ import type { AssetId } from '@shapeshiftoss/caip'
 import type { Result } from '@sniptt/monads'
 import { Err, Ok } from '@sniptt/monads'
 import type { AxiosInstance, AxiosRequestConfig, AxiosResponse } from 'axios'
-import axios from 'axios'
 import type { ISetupCache } from 'axios-cache-adapter'
 import { setupCache } from 'axios-cache-adapter'
-import { getConfig } from 'config'
 import type { FeatureFlags } from 'state/slices/preferencesSlice/preferencesSlice'
 
 import { isCrossAccountTradeSupported } from '../../state/helpers'
@@ -135,27 +133,3 @@ export const createTradeAmountTooSmallErr = (details?: {
     message: 'Sell amount is too small',
     details,
   })
-
-export const isValidSwapAddress = async (address: string): Promise<boolean> => {
-  type trmResponse = [
-    {
-      address: string
-      isSanctioned: boolean
-    },
-  ]
-
-  const response = await axios.post<trmResponse>(
-    getConfig().REACT_APP_TRM_LABS_API_URL,
-    [
-      {
-        address,
-      },
-    ],
-    {
-      headers: {
-        Accept: 'application/json',
-      },
-    },
-  )
-  return !response.data[0].isSanctioned
-}

--- a/src/plugins/cosmos/hooks/useStakingAction/useStakingAction.tsx
+++ b/src/plugins/cosmos/hooks/useStakingAction/useStakingAction.tsx
@@ -93,10 +93,10 @@ export const useStakingAction = () => {
             throw new Error(`unsupported staking action: ${action}`)
         }
       })()
-      const from = await adapter.getAddress({ accountNumber, wallet })
+      const senderAddress = await adapter.getAddress({ accountNumber, wallet })
       return adapter.signAndBroadcastTransaction({
-        from,
-        to: validator,
+        senderAddress,
+        receiverAddress: undefined, // no receiver for this contract call
         signTxInput: { txToSign, wallet },
       })
     } catch (error) {

--- a/src/plugins/cosmos/hooks/useStakingAction/useStakingAction.tsx
+++ b/src/plugins/cosmos/hooks/useStakingAction/useStakingAction.tsx
@@ -60,8 +60,8 @@ export const useStakingAction = () => {
 
       const memo = shapeshiftValidators.includes(validator) ? 'Delegated with ShapeShift' : ''
 
+      const { accountNumber } = bip44Params
       const { txToSign } = await (() => {
-        const { accountNumber } = bip44Params
         switch (action) {
           case StakingAction.Claim:
             return adapter.buildClaimRewardsTransaction({
@@ -93,8 +93,12 @@ export const useStakingAction = () => {
             throw new Error(`unsupported staking action: ${action}`)
         }
       })()
-
-      return adapter.signAndBroadcastTransaction({ txToSign, wallet })
+      const from = await adapter.getAddress({ accountNumber, wallet })
+      return adapter.signAndBroadcastTransaction({
+        from,
+        to: validator,
+        signTxInput: { txToSign, wallet },
+      })
     } catch (error) {
       console.error(error)
     }

--- a/src/plugins/index.ts
+++ b/src/plugins/index.ts
@@ -20,4 +20,8 @@ export class PluginManager {
   keys() {
     return [...this.#pluginManager.keys()]
   }
+
+  values() {
+    return [...this.#pluginManager.values()]
+  }
 }

--- a/src/plugins/walletConnectToDapps/utils/EIP155RequestHandlerUtil.ts
+++ b/src/plugins/walletConnectToDapps/utils/EIP155RequestHandlerUtil.ts
@@ -88,7 +88,7 @@ export const approveEIP155Request = async ({
       const didUserChangeNonce =
         maybeAdvancedParamsNonce && maybeAdvancedParamsNonce !== sendTransaction.nonce
       const fees = await getFeesForTx(sendTransaction, chainAdapter, accountId)
-      const from = await chainAdapter.getAddress({ accountNumber, wallet })
+      const senderAddress = await chainAdapter.getAddress({ accountNumber, wallet })
       const gasData = getGasData(customTransactionData, fees)
       const { txToSign: txToSignWithPossibleWrongNonce } = await chainAdapter.buildCustomTx({
         wallet,
@@ -109,8 +109,8 @@ export const approveEIP155Request = async ({
         wallet,
       })
       const txHash = await chainAdapter.broadcastTransaction({
-        from,
-        to: txToSign.to,
+        senderAddress,
+        receiverAddress: txToSign.to,
         hex: signedTx,
       })
       return formatJsonRpcResult(id, txHash)

--- a/src/plugins/walletConnectToDapps/utils/EIP155RequestHandlerUtil.ts
+++ b/src/plugins/walletConnectToDapps/utils/EIP155RequestHandlerUtil.ts
@@ -88,6 +88,7 @@ export const approveEIP155Request = async ({
       const didUserChangeNonce =
         maybeAdvancedParamsNonce && maybeAdvancedParamsNonce !== sendTransaction.nonce
       const fees = await getFeesForTx(sendTransaction, chainAdapter, accountId)
+      const from = await chainAdapter.getAddress({ accountNumber, wallet })
       const gasData = getGasData(customTransactionData, fees)
       const { txToSign: txToSignWithPossibleWrongNonce } = await chainAdapter.buildCustomTx({
         wallet,
@@ -107,7 +108,11 @@ export const approveEIP155Request = async ({
         txToSign,
         wallet,
       })
-      const txHash = await chainAdapter.broadcastTransaction(signedTx)
+      const txHash = await chainAdapter.broadcastTransaction({
+        from,
+        to: txToSign.to,
+        hex: signedTx,
+      })
       return formatJsonRpcResult(id, txHash)
     }
 


### PR DESCRIPTION
## Description

Adds validation to TXs during broadcast. Includes in-memory caching and request deduplication to minimise impact of rate limits. Also removes initial implementation address validation. 

## Pull Request Type

- [x] :bug: Bug fix (Non-breaking Change: Fixes an issue)
- [ ] :hammer_and_wrench: Chore (Non-breaking Change: Doc updates, pkg upgrades, typos, etc..)
- [ ] :nail_care: New Feature (Breaking/Non-breaking Change)

## Issue (if applicable)

<!-----------------------------------------------------------------------------
If applicable, please link to the github issue and put `closes #XXXX` in your comment to auto-close the issue that your PR fixes.
------------------------------------------------------------------------------>

closes #5438

## Risk

<!-----------------------------------------------------------------------------
Outline the scope of your changes and the risk associated with them. You must use your discretion as an engineer to determine the potential impact of your changes.

E.g. an upgrade to `hdwallet` or core state management would be considered higher risk, and might require a full regression test. UI or isolated view changes, or something behind a feature flag may have near zero risk. Small bug fixes might require testing isolated to the specific fix.
------------------------------------------------------------------------------>

Risk of broken trades, staking, sends etc. Affects all chains. 

## Testing

<!-----------------------------------------------------------------------------
We treat every PR to be merged with the same scrutiny as if we were merging directly to production.

Your PR will not be merged if you do not complete the sections below for our engineering and operations teams to test.
------------------------------------------------------------------------------>

Check transactions are correctly transmitted across the app.

### Engineering

<!-----------------------------------------------------------------------------
Include sufficient information here for an engineer to test your PR. This may include how to test locally, in a built environment, changes to infrastructure etc.
------------------------------------------------------------------------------>

### Operations

<!-----------------------------------------------------------------------------
If your changes have a user-facing impact, describe how a non-technical QA team can functionally test your changes in a preview environment.

If they are not user-facing please describe how to test for any regressions that may occur.
------------------------------------------------------------------------------>

## Screenshots (if applicable)

Successful trade with single deduped validation request, not validating the contract address as though it's a receiver
![image](https://github.com/shapeshift/web/assets/125113430/fe4441ca-8587-44f7-af43-7178ca696369)

Successful trade for manual receive address, 2 validation requests - 1 for sender, 1 for receiver
![image](https://github.com/shapeshift/web/assets/125113430/564ad182-bfbc-4a92-8852-fd1a3ac70989)
