### PR TITLE
feat: lazy load hdwallet adapter modules part 1

### DIFF
--- a/src/context/WalletProvider/Coinbase/config.ts
+++ b/src/context/WalletProvider/Coinbase/config.ts
@@ -1,9 +1,12 @@
-import { CoinbaseAdapter } from '@shapeshiftoss/hdwallet-coinbase'
 import { CoinbaseIcon } from 'components/Icons/CoinbaseIcon'
 import type { SupportedWalletInfo } from 'context/WalletProvider/config'
 
 export const CoinbaseConfig: Omit<SupportedWalletInfo, 'routes'> = {
-  adapters: [CoinbaseAdapter],
+  adapters: [
+    {
+      loadAdapter: () => import('@shapeshiftoss/hdwallet-coinbase').then(m => m.CoinbaseAdapter),
+    },
+  ],
   supportsMobile: 'browser',
   icon: CoinbaseIcon,
   name: 'Coinbase',

--- a/src/context/WalletProvider/DemoWallet/config.ts
+++ b/src/context/WalletProvider/DemoWallet/config.ts
@@ -1,9 +1,12 @@
-import { NativeAdapter } from '@shapeshiftoss/hdwallet-native'
 import { FoxIcon } from 'components/Icons/FoxIcon'
 import type { SupportedWalletInfo } from 'context/WalletProvider/config'
 
 export const DemoConfig: Omit<SupportedWalletInfo, 'routes'> = {
-  adapters: [NativeAdapter],
+  adapters: [
+    {
+      loadAdapter: () => import('@shapeshiftoss/hdwallet-native').then(m => m.NativeAdapter),
+    },
+  ],
   supportsMobile: 'both',
   icon: FoxIcon,
   name: 'DemoWallet',

--- a/src/context/WalletProvider/KeepKey/config.ts
+++ b/src/context/WalletProvider/KeepKey/config.ts
@@ -1,11 +1,16 @@
-import { KkRestAdapter } from '@keepkey/hdwallet-keepkey-rest'
-import { WebUSBKeepKeyAdapter } from '@shapeshiftoss/hdwallet-keepkey-webusb'
 import { KeepKeyIcon } from 'components/Icons/KeepKeyIcon'
 import type { SupportedWalletInfo } from 'context/WalletProvider/config'
 
 export const KeepKeyConfig: Omit<SupportedWalletInfo, 'routes'> = {
-  // Allow multiple transports per wallet. order is in first attempt priority, with fail over to next transport
-  adapters: [KkRestAdapter, WebUSBKeepKeyAdapter],
+  adapters: [
+    {
+      loadAdapter: () => import('@keepkey/hdwallet-keepkey-rest').then(m => m.KkRestAdapter),
+    },
+    {
+      loadAdapter: () =>
+        import('@shapeshiftoss/hdwallet-keepkey-webusb').then(m => m.WebUSBKeepKeyAdapter),
+    },
+  ],
   icon: KeepKeyIcon,
   name: 'KeepKey',
 }

--- a/src/context/WalletProvider/Keplr/config.ts
+++ b/src/context/WalletProvider/Keplr/config.ts
@@ -1,9 +1,12 @@
-import { KeplrAdapter } from '@shapeshiftoss/hdwallet-keplr'
 import { KeplrIcon } from 'components/Icons/KeplrIcon'
 import type { SupportedWalletInfo } from 'context/WalletProvider/config'
 
 export const KeplrConfig: Omit<SupportedWalletInfo, 'routes'> = {
-  adapters: [KeplrAdapter],
+  adapters: [
+    {
+      loadAdapter: () => import('@shapeshiftoss/hdwallet-keplr').then(m => m.KeplrAdapter),
+    },
+  ],
   icon: KeplrIcon,
   name: 'Keplr',
 }

--- a/src/context/WalletProvider/Ledger/config.ts
+++ b/src/context/WalletProvider/Ledger/config.ts
@@ -1,9 +1,13 @@
-import { WebUSBLedgerAdapter } from '@shapeshiftoss/hdwallet-ledger-webusb'
 import { LedgerIcon } from 'components/Icons/LedgerIcon'
 import type { SupportedWalletInfo } from 'context/WalletProvider/config'
 
 export const LedgerConfig: Omit<SupportedWalletInfo, 'routes'> = {
-  adapters: [WebUSBLedgerAdapter],
+  adapters: [
+    {
+      loadAdapter: () =>
+        import('@shapeshiftoss/hdwallet-ledger-webusb').then(m => m.WebUSBLedgerAdapter),
+    },
+  ],
   icon: LedgerIcon,
   name: 'Ledger',
 }

--- a/src/context/WalletProvider/MetaMask/config.ts
+++ b/src/context/WalletProvider/MetaMask/config.ts
@@ -1,12 +1,15 @@
-import { MetaMaskAdapter } from '@shapeshiftoss/hdwallet-metamask'
-import { MetaMaskAdapter as MetaMaskSnapAdapter } from '@shapeshiftoss/hdwallet-shapeshift-multichain'
 import { getConfig } from 'config'
 import { MetaMaskIcon } from 'components/Icons/MetaMaskIcon'
 import type { SupportedWalletInfo } from 'context/WalletProvider/config'
 
 export const MetaMaskConfig: Omit<SupportedWalletInfo, 'routes'> = {
   adapters: [
-    getConfig().REACT_APP_EXPERIMENTAL_MM_SNAPPY_FINGERS ? MetaMaskSnapAdapter : MetaMaskAdapter,
+    {
+      loadAdapter: () =>
+        getConfig().REACT_APP_EXPERIMENTAL_MM_SNAPPY_FINGERS
+          ? import('@shapeshiftoss/hdwallet-shapeshift-multichain').then(m => m.MetaMaskAdapter)
+          : import('@shapeshiftoss/hdwallet-metamask').then(m => m.MetaMaskAdapter),
+    },
   ],
   supportsMobile: 'browser',
   icon: MetaMaskIcon,

--- a/src/context/WalletProvider/MobileWallet/config.ts
+++ b/src/context/WalletProvider/MobileWallet/config.ts
@@ -1,9 +1,13 @@
-import { NativeAdapter } from '@shapeshiftoss/hdwallet-native'
 import { FoxIcon } from 'components/Icons/FoxIcon'
 import type { SupportedWalletInfo } from 'context/WalletProvider/config'
 
 export const MobileConfig: Omit<SupportedWalletInfo, 'routes'> = {
-  adapters: [NativeAdapter],
+  adapters: [
+    {
+      loadAdapter: () => import('@shapeshiftoss/hdwallet-native').then(m => m.NativeAdapter),
+    },
+  ],
+
   supportsMobile: 'app',
   icon: FoxIcon,
   name: 'ShapeShift Mobile',

--- a/src/context/WalletProvider/NativeWallet/config.ts
+++ b/src/context/WalletProvider/NativeWallet/config.ts
@@ -1,9 +1,12 @@
-import { NativeAdapter } from '@shapeshiftoss/hdwallet-native'
-import { FoxIcon } from 'components/Icons/FoxIcon'
+import { FoxIcon } from 'components/Icons/FoxIcon' // Ensure the import path is correct
 import type { SupportedWalletInfo } from 'context/WalletProvider/config'
 
 export const NativeConfig: Omit<SupportedWalletInfo, 'routes'> = {
-  adapters: [NativeAdapter],
+  adapters: [
+    {
+      loadAdapter: () => import('@shapeshiftoss/hdwallet-native').then(m => m.NativeAdapter),
+    },
+  ],
   supportsMobile: 'browser',
   icon: FoxIcon,
   name: 'ShapeShift',

--- a/src/context/WalletProvider/WalletConnectV2/config.ts
+++ b/src/context/WalletProvider/WalletConnectV2/config.ts
@@ -1,5 +1,4 @@
 import { CHAIN_REFERENCE } from '@shapeshiftoss/caip'
-import { WalletConnectV2Adapter } from '@shapeshiftoss/hdwallet-walletconnectv2'
 import type { EthereumProviderOptions } from '@walletconnect/ethereum-provider/dist/types/EthereumProvider'
 import { getConfig } from 'config'
 import type { Chain } from 'viem/chains'
@@ -8,12 +7,16 @@ import { WalletConnectIcon } from 'components/Icons/WalletConnectIcon'
 import type { SupportedWalletInfo } from 'context/WalletProvider/config'
 
 export const WalletConnectV2Config: Omit<SupportedWalletInfo, 'routes'> = {
-  adapters: [WalletConnectV2Adapter],
+  adapters: [
+    {
+      loadAdapter: () =>
+        import('@shapeshiftoss/hdwallet-walletconnectv2').then(m => m.WalletConnectV2Adapter),
+    },
+  ],
   icon: WalletConnectIcon,
   name: 'WalletConnect',
   description: 'v2',
 }
-
 type ViemChain = Chain
 type AtLeastOneViemChain = [ViemChain, ...ViemChain[]]
 type AtLeastOneNumber = [number, ...number[]]

--- a/src/context/WalletProvider/XDEFI/config.ts
+++ b/src/context/WalletProvider/XDEFI/config.ts
@@ -1,9 +1,12 @@
-import { XDEFIAdapter } from '@shapeshiftoss/hdwallet-xdefi'
 import { XDEFIIcon } from 'components/Icons/XDEFIIcon'
 import type { SupportedWalletInfo } from 'context/WalletProvider/config'
 
 export const XDEFIConfig: Omit<SupportedWalletInfo, 'routes'> = {
-  adapters: [XDEFIAdapter],
+  adapters: [
+    {
+      loadAdapter: () => import('@shapeshiftoss/hdwallet-xdefi').then(m => m.XDEFIAdapter),
+    },
+  ],
   icon: XDEFIIcon,
   name: 'XDEFI',
 }

--- a/src/context/WalletProvider/config.ts
+++ b/src/context/WalletProvider/config.ts
@@ -73,7 +73,10 @@ import { XDEFIFailure } from './XDEFI/components/Failure'
 import { XDEFIConfig } from './XDEFI/config'
 
 export interface SupportedWalletInfo {
-  adapters: any[]
+  adapters: {
+    // TODO(gomes): can we type this?
+    loadAdapter: () => Promise<any>
+  }[]
   supportsMobile?: 'browser' | 'app' | 'both'
   icon: ComponentWithAs<'svg', IconProps>
   name: string
@@ -83,7 +86,6 @@ export interface SupportedWalletInfo {
   connectedWalletMenuInitialPath?: WalletConnectedRoutes
   connectedMenuComponent?: React.ComponentType<any>
 }
-
 export const SUPPORTED_WALLETS: Record<KeyManager, SupportedWalletInfo> = {
   [KeyManager.Mobile]: {
     ...MobileConfig,


### PR DESCRIPTION
## Description

i.e technically lazy loads said packages, but doesn't effectively do so for now, because of this bad boy:

https://github.com/shapeshift/web/blob/a5839be885a1f0aa8d35d7dda94d7a80e8f78de7/src/context/WalletProvider/WalletProvider.tsx#L767-L783

This however, puts us in a better position to get wallet adapters lazy loaded as a follow-up, the intent being to only populate (and by extension, import the npm packages) adapters when clicking on a wallet option.

## Pull Request Type

- [ ] :bug: Bug fix (Non-breaking Change: Fixes an issue)
- [ ] :hammer_and_wrench: Chore (Non-breaking Change: Doc updates, pkg upgrades, typos, etc..)
- [x] :nail_care: New Feature (Breaking/Non-breaking Change)

## Issue (if applicable)

<!-----------------------------------------------------------------------------
If applicable, please link to the github issue and put `closes #XXXX` in your comment to auto-close the issue that your PR fixes.
------------------------------------------------------------------------------>

- tackles https://github.com/shapeshift/web/issues/5445

## Risk

<!-----------------------------------------------------------------------------
Outline the scope of your changes and the risk associated with them. You must use your discretion as an engineer to determine the potential impact of your changes.

E.g. an upgrade to `hdwallet` or core state management would be considered higher risk, and might require a full regression test. UI or isolated view changes, or something behind a feature flag may have near zero risk. Small bug fixes might require testing isolated to the specific fix.
------------------------------------------------------------------------------>

- Moderate. Theoretically, the surface area brings huge regression risks for all wallets. In effect, the flow is effectively the same for the time being.

## Testing

<!-----------------------------------------------------------------------------
We treat every PR to be merged with the same scrutiny as if we were merging directly to production.

Your PR will not be merged if you do not complete the sections below for our engineering and operations teams to test.
------------------------------------------------------------------------------>

- All wallets are still displayed as option
- Wallet pairing still work

### Engineering

<!-----------------------------------------------------------------------------
Include sufficient information here for an engineer to test your PR. This may include how to test locally, in a built environment, changes to infrastructure etc.
------------------------------------------------------------------------------>

- ☝🏽 

### Operations

<!-----------------------------------------------------------------------------
If your changes have a user-facing impact, describe how a non-technical QA team can functionally test your changes in a preview environment.

If they are not user-facing please describe how to test for any regressions that may occur.
------------------------------------------------------------------------------>

- ☝🏽 

## Screenshots (if applicable)
