### PR TITLE
feat: actually lazy load hdwallet adapter modules

### DIFF
--- a/src/context/WalletProvider/Coinbase/components/Connect.tsx
+++ b/src/context/WalletProvider/Coinbase/components/Connect.tsx
@@ -1,4 +1,4 @@
-import React, { useEffect, useState } from 'react'
+import React, { useCallback, useEffect, useState } from 'react'
 import type { RouteComponentProps } from 'react-router-dom'
 import type { ActionTypes } from 'context/WalletProvider/actions'
 import { WalletActions } from 'context/WalletProvider/actions'
@@ -20,7 +20,7 @@ export interface CoinbaseSetupProps
 }
 
 export const CoinbaseConnect = ({ history }: CoinbaseSetupProps) => {
-  const { dispatch, state, onProviderChange } = useWallet()
+  const { dispatch, getAdapter, onProviderChange } = useWallet()
   const [loading, setLoading] = useState(false)
   const [error, setError] = useState<string | null>(null)
 
@@ -35,13 +35,14 @@ export const CoinbaseConnect = ({ history }: CoinbaseSetupProps) => {
     })()
   }, [onProviderChange])
 
-  const pairDevice = async () => {
+  const pairDevice = useCallback(async () => {
     setError(null)
     setLoading(true)
 
-    if (state.adapters && state.adapters?.has(KeyManager.Coinbase)) {
+    const adapter = await getAdapter(KeyManager.Coinbase)
+    if (adapter) {
       try {
-        const wallet = await state.adapters.get(KeyManager.Coinbase)?.[0].pairDevice()
+        const wallet = await adapter.pairDevice()
         if (!wallet) {
           setErrorLoading('walletProvider.errors.walletNotFound')
           throw new Error('Call to hdwallet-coinbase::pairDevice returned null or undefined')
@@ -65,7 +66,7 @@ export const CoinbaseConnect = ({ history }: CoinbaseSetupProps) => {
       }
     }
     setLoading(false)
-  }
+  }, [dispatch, getAdapter, history])
 
   return (
     <ConnectModal

--- a/src/context/WalletProvider/KeepKey/components/Connect.tsx
+++ b/src/context/WalletProvider/KeepKey/components/Connect.tsx
@@ -65,7 +65,7 @@ export const KeepKeyConnect = () => {
           return wallet
         } catch (e) {
           const secondAdapter = await getAdapter(KeyManager.KeepKey, 1)
-          const wallet = await secondAdapter?.pairDevice().catch(err => {
+          const wallet = await secondAdapter?.pairDevice().catch((err: Error) => {
             if (err.name === 'ConflictingApp') {
               setErrorLoading('walletProvider.keepKey.connect.conflictingApp')
               return

--- a/src/context/WalletProvider/KeepKey/components/Connect.tsx
+++ b/src/context/WalletProvider/KeepKey/components/Connect.tsx
@@ -37,7 +37,7 @@ const translateError = (event: Event) => {
 }
 
 export const KeepKeyConnect = () => {
-  const { dispatch, state } = useWallet()
+  const { dispatch, getAdapter, state } = useWallet()
   const [loading, setLoading] = useState(false)
   const [error, setError] = useState<string | null>(null)
 
@@ -51,20 +51,21 @@ export const KeepKeyConnect = () => {
   const pairDevice = async () => {
     setError(null)
     setLoading(true)
-    if (state.adapters) {
-      const adapters = state.adapters.get(KeyManager.KeepKey)
-      if (!adapters) return
+
+    const firstAdapter = await getAdapter(KeyManager.KeepKey)
+    if (firstAdapter) {
       const wallet = await (async () => {
         try {
           const sdk = await setupKeepKeySDK()
-          const wallet = await adapters[0]?.pairDevice(sdk)
+          const wallet = await firstAdapter.pairDevice(sdk)
           if (!wallet) {
             setErrorLoading('walletProvider.errors.walletNotFound')
             return
           }
           return wallet
         } catch (e) {
-          const wallet = await adapters[1]?.pairDevice().catch(err => {
+          const secondAdapter = await getAdapter(KeyManager.KeepKey, 1)
+          const wallet = await secondAdapter?.pairDevice().catch(err => {
             if (err.name === 'ConflictingApp') {
               setErrorLoading('walletProvider.keepKey.connect.conflictingApp')
               return

--- a/src/context/WalletProvider/Keplr/components/Connect.tsx
+++ b/src/context/WalletProvider/Keplr/components/Connect.tsx
@@ -18,7 +18,7 @@ export interface KeplrSetupProps
 }
 
 export const KeplrConnect = ({ history }: KeplrSetupProps) => {
-  const { dispatch, state } = useWallet()
+  const { dispatch, getAdapter } = useWallet()
   const [loading, setLoading] = useState(false)
   const [error, setError] = useState<string | null>(null)
 
@@ -28,8 +28,9 @@ export const KeplrConnect = ({ history }: KeplrSetupProps) => {
   const pairDevice = async () => {
     setError(null)
     setLoading(true)
-    if (state.adapters && state.adapters?.has(KeyManager.Keplr)) {
-      const wallet = await state.adapters.get(KeyManager.Keplr)?.[0].pairDevice()
+    const adapter = await getAdapter(KeyManager.Keplr)
+    if (adapter) {
+      const wallet = await adapter.pairDevice()
       if (!wallet) {
         setErrorLoading('walletProvider.errors.walletNotFound')
         throw new Error('Call to hdwallet-keplr::pairDevice returned null or undefined')

--- a/src/context/WalletProvider/Ledger/components/Chains.tsx
+++ b/src/context/WalletProvider/Ledger/components/Chains.tsx
@@ -55,7 +55,6 @@ export const LedgerChains = () => {
 
   const handleConnectClick = useCallback(
     async (chainId: ChainId) => {
-      if (!walletState.adapters) return
       if (!walletState?.wallet) return
 
       setLoadingChains(prevLoading => ({ ...prevLoading, [chainId]: true }))
@@ -115,7 +114,7 @@ export const LedgerChains = () => {
         setLoadingChains(prevLoading => ({ ...prevLoading, [chainId]: false }))
       }
     },
-    [availableChainIds, dispatch, walletState.adapters, walletState.wallet],
+    [availableChainIds, dispatch, walletState.wallet],
   )
 
   const chainsRows = useMemo(

--- a/src/context/WalletProvider/Ledger/components/Connect.tsx
+++ b/src/context/WalletProvider/Ledger/components/Connect.tsx
@@ -31,43 +31,41 @@ export const LedgerConnect = ({ history }: LedgerSetupProps) => {
   const pairDevice = useCallback(async () => {
     setError(null)
     setLoading(true)
-    if (state.adapters) {
-      const currentAdapters = state.adapters
-      // eslint is drunk, this isn't a hook
-      // eslint-disable-next-line react-hooks/rules-of-hooks
-      const ledgerAdapter = WebUSBLedgerAdapter.useKeyring(state.keyring)
-      // This is conventionally done in WalletProvider effect, but won't work here, as `requestDevice()` needs to be called from a user interaction
-      // So we do it in this pairDevice() method instead and set the adapters the same as we would do in WalletProvider
+    const currentAdapters = state.adapters ?? new Map()
+    // eslint is drunk, this isn't a hook
+    // eslint-disable-next-line react-hooks/rules-of-hooks
+    const ledgerAdapter = WebUSBLedgerAdapter.useKeyring(state.keyring)
+    // This is conventionally done in WalletProvider effect, but won't work here, as `requestDevice()` needs to be called from a user interaction
+    // So we do it in this pairDevice() method instead and set the adapters the same as we would do in WalletProvider
+    try {
+      const wallet = await ledgerAdapter.pairDevice()
       try {
-        const wallet = await ledgerAdapter.pairDevice()
-        try {
-          currentAdapters.set(KeyManager.Ledger, [ledgerAdapter])
-          walletDispatch({ type: WalletActions.SET_ADAPTERS, payload: currentAdapters })
-        } catch (e) {
-          console.error(e)
-        }
-
-        if (!wallet) {
-          setErrorLoading('walletProvider.errors.walletNotFound')
-          throw new Error('Call to hdwallet-ledger::pairDevice returned null or undefined')
-        }
-
-        const { name, icon } = LedgerConfig
-        // TODO(gomes): this is most likely wrong, all Ledger devices get the same device ID
-        const deviceId = await wallet.getDeviceID()
-
-        walletDispatch({
-          type: WalletActions.SET_WALLET,
-          payload: { wallet, name, icon, deviceId, connectedType: KeyManager.Ledger },
-        })
-        walletDispatch({ type: WalletActions.SET_IS_CONNECTED, payload: true })
-        setLocalWalletTypeAndDeviceId(KeyManager.Ledger, deviceId)
-        history.push('/ledger/chains')
-      } catch (e: any) {
+        currentAdapters.set(KeyManager.Ledger, [ledgerAdapter])
+        walletDispatch({ type: WalletActions.SET_ADAPTERS, payload: currentAdapters })
+      } catch (e) {
         console.error(e)
-        setErrorLoading(e?.message || 'walletProvider.ledger.errors.unknown')
-        history.push('/ledger/failure')
       }
+
+      if (!wallet) {
+        setErrorLoading('walletProvider.errors.walletNotFound')
+        throw new Error('Call to hdwallet-ledger::pairDevice returned null or undefined')
+      }
+
+      const { name, icon } = LedgerConfig
+      // TODO(gomes): this is most likely wrong, all Ledger devices get the same device ID
+      const deviceId = await wallet.getDeviceID()
+
+      walletDispatch({
+        type: WalletActions.SET_WALLET,
+        payload: { wallet, name, icon, deviceId, connectedType: KeyManager.Ledger },
+      })
+      walletDispatch({ type: WalletActions.SET_IS_CONNECTED, payload: true })
+      setLocalWalletTypeAndDeviceId(KeyManager.Ledger, deviceId)
+      history.push('/ledger/chains')
+    } catch (e: any) {
+      console.error(e)
+      setErrorLoading(e?.message || 'walletProvider.ledger.errors.unknown')
+      history.push('/ledger/failure')
     }
     setLoading(false)
   }, [history, setErrorLoading, state.adapters, state.keyring, walletDispatch])

--- a/src/context/WalletProvider/Ledger/components/Connect.tsx
+++ b/src/context/WalletProvider/Ledger/components/Connect.tsx
@@ -1,4 +1,3 @@
-import { WebUSBLedgerAdapter } from '@shapeshiftoss/hdwallet-ledger-webusb'
 import React, { useCallback, useState } from 'react'
 import type { RouteComponentProps } from 'react-router-dom'
 import type { ActionTypes } from 'context/WalletProvider/actions'
@@ -19,7 +18,7 @@ export interface LedgerSetupProps
 }
 
 export const LedgerConnect = ({ history }: LedgerSetupProps) => {
-  const { dispatch: walletDispatch, state, getAdapter } = useWallet()
+  const { dispatch: walletDispatch, getAdapter } = useWallet()
   const [loading, setLoading] = useState(false)
   const [error, setError] = useState<string | null>(null)
 

--- a/src/context/WalletProvider/Ledger/components/Connect.tsx
+++ b/src/context/WalletProvider/Ledger/components/Connect.tsx
@@ -19,7 +19,7 @@ export interface LedgerSetupProps
 }
 
 export const LedgerConnect = ({ history }: LedgerSetupProps) => {
-  const { dispatch: walletDispatch, state } = useWallet()
+  const { dispatch: walletDispatch, state, getAdapter } = useWallet()
   const [loading, setLoading] = useState(false)
   const [error, setError] = useState<string | null>(null)
 
@@ -31,44 +31,36 @@ export const LedgerConnect = ({ history }: LedgerSetupProps) => {
   const pairDevice = useCallback(async () => {
     setError(null)
     setLoading(true)
-    const currentAdapters = state.adapters ?? new Map()
-    // eslint is drunk, this isn't a hook
-    // eslint-disable-next-line react-hooks/rules-of-hooks
-    const ledgerAdapter = WebUSBLedgerAdapter.useKeyring(state.keyring)
-    // This is conventionally done in WalletProvider effect, but won't work here, as `requestDevice()` needs to be called from a user interaction
-    // So we do it in this pairDevice() method instead and set the adapters the same as we would do in WalletProvider
-    try {
-      const wallet = await ledgerAdapter.pairDevice()
+
+    const adapter = await getAdapter(KeyManager.Ledger)
+    if (adapter) {
       try {
-        currentAdapters.set(KeyManager.Ledger, [ledgerAdapter])
-        walletDispatch({ type: WalletActions.SET_ADAPTERS, payload: currentAdapters })
-      } catch (e) {
+        const wallet = await adapter.pairDevice()
+
+        if (!wallet) {
+          setErrorLoading('walletProvider.errors.walletNotFound')
+          throw new Error('Call to hdwallet-ledger::pairDevice returned null or undefined')
+        }
+
+        const { name, icon } = LedgerConfig
+        // TODO(gomes): this is most likely wrong, all Ledger devices get the same device ID
+        const deviceId = await wallet.getDeviceID()
+
+        walletDispatch({
+          type: WalletActions.SET_WALLET,
+          payload: { wallet, name, icon, deviceId, connectedType: KeyManager.Ledger },
+        })
+        walletDispatch({ type: WalletActions.SET_IS_CONNECTED, payload: true })
+        setLocalWalletTypeAndDeviceId(KeyManager.Ledger, deviceId)
+        history.push('/ledger/chains')
+      } catch (e: any) {
         console.error(e)
+        setErrorLoading(e?.message || 'walletProvider.ledger.errors.unknown')
+        history.push('/ledger/failure')
       }
-
-      if (!wallet) {
-        setErrorLoading('walletProvider.errors.walletNotFound')
-        throw new Error('Call to hdwallet-ledger::pairDevice returned null or undefined')
-      }
-
-      const { name, icon } = LedgerConfig
-      // TODO(gomes): this is most likely wrong, all Ledger devices get the same device ID
-      const deviceId = await wallet.getDeviceID()
-
-      walletDispatch({
-        type: WalletActions.SET_WALLET,
-        payload: { wallet, name, icon, deviceId, connectedType: KeyManager.Ledger },
-      })
-      walletDispatch({ type: WalletActions.SET_IS_CONNECTED, payload: true })
-      setLocalWalletTypeAndDeviceId(KeyManager.Ledger, deviceId)
-      history.push('/ledger/chains')
-    } catch (e: any) {
-      console.error(e)
-      setErrorLoading(e?.message || 'walletProvider.ledger.errors.unknown')
-      history.push('/ledger/failure')
     }
     setLoading(false)
-  }, [history, setErrorLoading, state.adapters, state.keyring, walletDispatch])
+  }, [getAdapter, history, setErrorLoading, walletDispatch])
 
   return (
     <ConnectModal

--- a/src/context/WalletProvider/MetaMask/components/Connect.tsx
+++ b/src/context/WalletProvider/MetaMask/components/Connect.tsx
@@ -26,7 +26,7 @@ export interface MetaMaskSetupProps
 }
 
 export const MetaMaskConnect = ({ history }: MetaMaskSetupProps) => {
-  const { dispatch, state, onProviderChange } = useWallet()
+  const { dispatch, state, getAdapter, onProviderChange } = useWallet()
   const [loading, setLoading] = useState(false)
   const [error, setError] = useState<string | null>(null)
   const showSnapModal = useSelector(selectShowSnapsModal)
@@ -50,8 +50,9 @@ export const MetaMaskConnect = ({ history }: MetaMaskSetupProps) => {
       throw new Error('walletProvider.metaMask.errors.connectFailure')
     }
 
-    if (state.adapters && state.adapters?.has(KeyManager.MetaMask)) {
-      const wallet = await state.adapters.get(KeyManager.MetaMask)?.[0].pairDevice()
+    const adapter = await getAdapter(KeyManager.MetaMask)
+    if (adapter) {
+      const wallet = await adapter.pairDevice()
       if (!wallet) {
         setErrorLoading('walletProvider.errors.walletNotFound')
         throw new Error('Call to hdwallet-metamask::pairDevice returned null or undefined')

--- a/src/context/WalletProvider/MobileWallet/components/MobileLoad.tsx
+++ b/src/context/WalletProvider/MobileWallet/components/MobileLoad.tsx
@@ -31,7 +31,7 @@ import { deleteWallet, getWallet, listWallets } from '../mobileMessageHandlers'
 import type { RevocableWallet } from '../RevocableWallet'
 
 export const MobileLoad = ({ history }: RouteComponentProps) => {
-  const { state, dispatch } = useWallet()
+  const { getAdapter, dispatch } = useWallet()
   const [error, setError] = useState<string | null>(null)
   const [wallets, setWallets] = useState<RevocableWallet[]>([])
   const translate = useTranslate()
@@ -55,15 +55,15 @@ export const MobileLoad = ({ history }: RouteComponentProps) => {
   }, [wallets])
 
   const handleWalletSelect = async (item: RevocableWallet) => {
-    const adapters = state.adapters?.get(KeyManager.Native)
+    const adapter = await getAdapter(KeyManager.Native)
     const deviceId = item?.id
-    if (adapters && deviceId) {
+    if (adapter && deviceId) {
       const { name, icon } = MobileConfig
       try {
         const revoker = await getWallet(deviceId)
         if (!revoker?.mnemonic) throw new Error(`Mobile wallet not found: ${deviceId}`)
 
-        const wallet = await adapters[0].pairDevice(revoker.id)
+        const wallet = await adapter.pairDevice(revoker.id)
         await wallet.loadDevice({ mnemonic: revoker.mnemonic })
         if (!(await wallet.isInitialized())) {
           await wallet.initialize()

--- a/src/context/WalletProvider/MobileWallet/components/MobileSuccess.tsx
+++ b/src/context/WalletProvider/MobileWallet/components/MobileSuccess.tsx
@@ -20,16 +20,17 @@ export const MobileSuccess = ({ location }: MobileSetupProps) => {
   const appDispatch = useAppDispatch()
   const { setWelcomeModal } = preferences.actions
   const [isSuccessful, setIsSuccessful] = useStateIfMounted<boolean | null>(null)
-  const { state, dispatch } = useWallet()
+  const { getAdapter, dispatch } = useWallet()
   const { vault } = location.state
 
   useEffect(() => {
     ;(async () => {
       if (!vault) return
-      const adapters = state.adapters?.get(KeyManager.Native)!
+      const adapter = await getAdapter(KeyManager.Native)
+      if (!adapter) throw new Error('Native adapter not found')
       try {
         const deviceId = vault.id ?? ''
-        const wallet = (await adapters[0].pairDevice(deviceId)) as NativeHDWallet
+        const wallet = (await adapter.pairDevice(deviceId)) as NativeHDWallet
         const mnemonic = vault.mnemonic
 
         if (mnemonic) {
@@ -64,7 +65,7 @@ export const MobileSuccess = ({ location }: MobileSetupProps) => {
       // Make sure the component is completely unmounted before we revoke the mnemonic
       setTimeout(() => vault?.revoke(), 500)
     }
-  }, [appDispatch, dispatch, setIsSuccessful, setWelcomeModal, state.adapters, vault])
+  }, [appDispatch, dispatch, getAdapter, setIsSuccessful, setWelcomeModal, vault])
 
   return (
     <>

--- a/src/context/WalletProvider/NativeWallet/components/NativeLoad.tsx
+++ b/src/context/WalletProvider/NativeWallet/components/NativeLoad.tsx
@@ -36,7 +36,7 @@ type VaultInfo = {
 }
 
 export const NativeLoad = ({ history }: RouteComponentProps) => {
-  const { state, dispatch } = useWallet()
+  const { getAdapter, dispatch } = useWallet()
   const [error, setError] = useState<string | null>(null)
   const [wallets, setWallets] = useState<VaultInfo[]>([])
   const translate = useTranslate()
@@ -69,40 +69,40 @@ export const NativeLoad = ({ history }: RouteComponentProps) => {
   }, [wallets])
 
   const handleWalletSelect = async (item: VaultInfo) => {
+    const adapter = await getAdapter(KeyManager.Native)
     const deviceId = item.id
-    const { name, icon } = NativeConfig
-    try {
-      const Adapter = await NativeConfig.adapters[0].loadAdapter()
-      // eslint is drunk, this isn't a hook
-      // eslint-disable-next-line react-hooks/rules-of-hooks
-      const adapter = Adapter.useKeyring(state.keyring)
-      // TODO(gomes): SET_ADAPTERS
-      const wallet = await adapter.pairDevice(deviceId)
-      if (!(await wallet.isInitialized())) {
-        // This will trigger the password modal and the modal will set the wallet on state
-        // after the wallet has been decrypted. If we set it now, `getPublicKeys` calls will
-        // return null, and we don't have a retry mechanism
-        await wallet.initialize()
-      } else {
-        dispatch({
-          type: WalletActions.SET_WALLET,
-          payload: {
-            wallet,
-            name,
-            icon,
-            deviceId,
-            meta: { label: item.name },
-            connectedType: KeyManager.Native,
-          },
-        })
-        dispatch({ type: WalletActions.SET_IS_CONNECTED, payload: true })
-        // The wallet is already initialized so we can close the modal
-        dispatch({ type: WalletActions.SET_WALLET_MODAL, payload: false })
-      }
+    if (adapter) {
+      const { name, icon } = NativeConfig
+      try {
+        const wallet = await adapter.pairDevice(deviceId)
+        if (!(await wallet.isInitialized())) {
+          // This will trigger the password modal and the modal will set the wallet on state
+          // after the wallet has been decrypted. If we set it now, `getPublicKeys` calls will
+          // return null, and we don't have a retry mechanism
+          await wallet.initialize()
+        } else {
+          dispatch({
+            type: WalletActions.SET_WALLET,
+            payload: {
+              wallet,
+              name,
+              icon,
+              deviceId,
+              meta: { label: item.name },
+              connectedType: KeyManager.Native,
+            },
+          })
+          dispatch({ type: WalletActions.SET_IS_CONNECTED, payload: true })
+          // The wallet is already initialized so we can close the modal
+          dispatch({ type: WalletActions.SET_WALLET_MODAL, payload: false })
+        }
 
-      setLocalWalletTypeAndDeviceId(KeyManager.Native, deviceId)
-      setLocalNativeWalletName(item.name)
-    } catch (e) {
+        setLocalWalletTypeAndDeviceId(KeyManager.Native, deviceId)
+        setLocalNativeWalletName(item.name)
+      } catch (e) {
+        setError('walletProvider.shapeShift.load.error.pair')
+      }
+    } else {
       setError('walletProvider.shapeShift.load.error.pair')
     }
   }

--- a/src/context/WalletProvider/NativeWallet/hooks/useNativeEventHandler.ts
+++ b/src/context/WalletProvider/NativeWallet/hooks/useNativeEventHandler.ts
@@ -31,6 +31,7 @@ export const useNativeEventHandler = (state: InitialState, dispatch: Dispatch<Ac
 
     /*
       Ideally we'd only listen to these events if modalType is KeyManager.Native or KeyManager.Mobile.
+      // TODO(gomes): is this comment still valid after the wallet.getAdapter() refactor
       Unfortunately, state.adapters is set in the React event loop via a useEffect, and so is null on initial load.
       This prevents SET_CONNECTOR_TYPE from being dispatched on the first WalletProvider.load() cycle, which means we'd
       miss the NativeEvents.MNEMONIC_REQUIRED event.

--- a/src/context/WalletProvider/NativeWallet/hooks/useNativeSuccess.ts
+++ b/src/context/WalletProvider/NativeWallet/hooks/useNativeSuccess.ts
@@ -20,17 +20,18 @@ export const useNativeSuccess = ({ vault }: UseNativeSuccessPropTypes) => {
   const [isSuccessful, setIsSuccessful] = useStateIfMounted<boolean | null>(null)
   const appDispatch = useAppDispatch()
   const { setWelcomeModal } = preferences.actions
-  const { state, dispatch } = useWallet()
+  const { getAdapter, dispatch } = useWallet()
 
   useEffect(() => {
     ;(async () => {
-      const adapters = state.adapters?.get(KeyManager.Native)
+      const adapter = await getAdapter(KeyManager.Native)
+      if (!adapter) throw new Error('Native adapter not found')
       try {
         await new Promise(resolve => setTimeout(resolve, 250))
         await Promise.all([navigator.storage?.persist?.(), vault.save()])
 
         const deviceId = vault.id
-        const wallet = (await adapters?.[0].pairDevice?.(deviceId)) as NativeHDWallet
+        const wallet = (await adapter.pairDevice?.(deviceId)) as NativeHDWallet
         const mnemonic = (await vault.get('#mnemonic')) as crypto.Isolation.Core.BIP39.Mnemonic
         mnemonic.addRevoker?.(() => vault.revoke())
         await wallet.loadDevice({ mnemonic, deviceId })

--- a/src/context/WalletProvider/SelectModal.tsx
+++ b/src/context/WalletProvider/SelectModal.tsx
@@ -99,7 +99,7 @@ const WalletSelectItem = ({
 
 export const SelectModal = () => {
   const {
-    state: { adapters, walletInfo },
+    state: { walletInfo },
     connect,
     create,
   } = useWallet()
@@ -123,7 +123,7 @@ export const SelectModal = () => {
       <ModalBody>
         <Text mb={6} color='text.subtle' translation={'walletProvider.selectModal.body'} />
         <Grid mb={6} gridTemplateColumns={gridTemplateColumnsProp} gridGap={4}>
-          {adapters &&
+          {
             // TODO: KeepKey adapter may fail due to the USB interface being in use by another tab
             // So not all of the supported wallets will have an initialized adapter
             wallets.map(walletType => (
@@ -133,7 +133,8 @@ export const SelectModal = () => {
                 walletInfo={walletInfo}
                 connect={connect}
               />
-            ))}
+            ))
+          }
         </Grid>
         <Flex direction={flexDirProp} mt={2} justifyContent='center' alignItems='center'>
           <Text

--- a/src/context/WalletProvider/WalletConnectV2/components/Connect.tsx
+++ b/src/context/WalletProvider/WalletConnectV2/components/Connect.tsx
@@ -39,7 +39,7 @@ export const WalletConnectV2Connect = ({ history }: WalletConnectSetupProps) => 
           setLoading(true)
 
           // trigger the web3 modal
-          const wallet = adapter.pairDevice()
+          const wallet = await adapter.pairDevice()
 
           if (!wallet) throw new WalletNotFoundError()
 

--- a/src/context/WalletProvider/WalletConnectV2/components/Connect.tsx
+++ b/src/context/WalletProvider/WalletConnectV2/components/Connect.tsx
@@ -23,7 +23,7 @@ export const WalletConnectV2Connect = ({ history }: WalletConnectSetupProps) => 
   // This is a bit blunt, and we might want to consider a more targeted approach.
   // https://github.com/orgs/WalletConnect/discussions/3010
   clearWalletConnectLocalStorage()
-  const { dispatch, state, onProviderChange } = useWallet()
+  const { dispatch, state, getAdapter, onProviderChange } = useWallet()
   const [loading, setLoading] = useState(false)
 
   const pairDevice = useCallback(async () => {
@@ -32,13 +32,14 @@ export const WalletConnectV2Connect = ({ history }: WalletConnectSetupProps) => 
 
     await onProviderChange(KeyManager.WalletConnectV2)
 
+    const adapter = await getAdapter(KeyManager.WalletConnectV2)
     try {
-      if (state.adapters && state.adapters?.has(KeyManager.WalletConnectV2)) {
+      if (adapter) {
         if (!state.wallet || !isWalletConnectWallet(state.wallet)) {
           setLoading(true)
 
           // trigger the web3 modal
-          const wallet = await state.adapters.get(KeyManager.WalletConnectV2)?.[0]?.pairDevice()
+          const wallet = adapter.pairDevice()
 
           if (!wallet) throw new WalletNotFoundError()
 
@@ -67,7 +68,7 @@ export const WalletConnectV2Connect = ({ history }: WalletConnectSetupProps) => 
         history.push('/walletconnect/failure')
       }
     }
-  }, [dispatch, history, onProviderChange, state])
+  }, [dispatch, getAdapter, history, onProviderChange, state.wallet])
 
   return (
     <ConnectModal

--- a/src/context/WalletProvider/WalletConnectV2/components/Connect.tsx
+++ b/src/context/WalletProvider/WalletConnectV2/components/Connect.tsx
@@ -30,9 +30,9 @@ export const WalletConnectV2Connect = ({ history }: WalletConnectSetupProps) => 
     setLoading(true)
     dispatch({ type: WalletActions.SET_WALLET_MODAL, payload: false })
 
+    const adapter = await getAdapter(KeyManager.WalletConnectV2)
     await onProviderChange(KeyManager.WalletConnectV2)
 
-    const adapter = await getAdapter(KeyManager.WalletConnectV2)
     try {
       if (adapter) {
         if (!state.wallet || !isWalletConnectWallet(state.wallet)) {

--- a/src/context/WalletProvider/WalletConnectV2/config.ts
+++ b/src/context/WalletProvider/WalletConnectV2/config.ts
@@ -1,10 +1,11 @@
 import { CHAIN_REFERENCE } from '@shapeshiftoss/caip'
-import type { EthereumProviderOptions } from '@walletconnect/ethereum-provider/dist/types/EthereumProvider'
 import { getConfig } from 'config'
 import type { Chain } from 'viem/chains'
 import { arbitrum, avalanche, bsc, gnosis, mainnet, optimism, polygon } from 'viem/chains'
 import { WalletConnectIcon } from 'components/Icons/WalletConnectIcon'
 import type { SupportedWalletInfo } from 'context/WalletProvider/config'
+
+import type { EthereumProviderOptions } from './constants'
 
 export const WalletConnectV2Config: Omit<SupportedWalletInfo, 'routes'> = {
   adapters: [

--- a/src/context/WalletProvider/WalletConnectV2/constants.ts
+++ b/src/context/WalletProvider/WalletConnectV2/constants.ts
@@ -1,0 +1,146 @@
+// All the types below are copied from @hdwallet/ethereum-provider so we don't have to import the whole package just for the sake of this type
+// and can lazy load it instead
+
+type MobileWallet = {
+  id: string
+  name: string
+  links: {
+    native: string
+    universal?: string
+  }
+}
+type DesktopWallet = {
+  id: string
+  name: string
+  links: {
+    native: string
+    universal?: string
+  }
+}
+
+type ConfigCtrlState = {
+  projectId: string
+  chains?: string[]
+  mobileWallets?: MobileWallet[]
+  desktopWallets?: DesktopWallet[]
+  walletImages?: Record<string, string>
+  enableAuthMode?: boolean
+  enableExplorer?: boolean
+  explorerRecommendedWalletIds?: string[] | 'NONE'
+  explorerExcludedWalletIds?: string[] | 'ALL'
+  termsOfServiceUrl?: string
+  privacyPolicyUrl?: string
+}
+
+type ThemeCtrlState = {
+  themeVariables?: {
+    '--wcm-z-index'?: string
+    '--wcm-accent-color'?: string
+    '--wcm-accent-fill-color'?: string
+    '--wcm-background-color'?: string
+    '--wcm-background-border-radius'?: string
+    '--wcm-container-border-radius'?: string
+    '--wcm-wallet-icon-border-radius'?: string
+    '--wcm-wallet-icon-large-border-radius'?: string
+    '--wcm-wallet-icon-small-border-radius'?: string
+    '--wcm-input-border-radius'?: string
+    '--wcm-notification-border-radius'?: string
+    '--wcm-button-border-radius'?: string
+    '--wcm-secondary-button-border-radius'?: string
+    '--wcm-icon-button-border-radius'?: string
+    '--wcm-button-hover-highlight-border-radius'?: string
+    '--wcm-font-family'?: string
+    '--wcm-font-feature-settings'?: string
+    '--wcm-text-big-bold-size'?: string
+    '--wcm-text-big-bold-weight'?: string
+    '--wcm-text-big-bold-line-height'?: string
+    '--wcm-text-big-bold-letter-spacing'?: string
+    '--wcm-text-big-bold-text-transform'?: string
+    '--wcm-text-big-bold-font-family'?: string
+    '--wcm-text-medium-regular-size'?: string
+    '--wcm-text-medium-regular-weight'?: string
+    '--wcm-text-medium-regular-line-height'?: string
+    '--wcm-text-medium-regular-letter-spacing'?: string
+    '--wcm-text-medium-regular-text-transform'?: string
+    '--wcm-text-medium-regular-font-family'?: string
+    '--wcm-text-small-regular-size'?: string
+    '--wcm-text-small-regular-weight'?: string
+    '--wcm-text-small-regular-line-height'?: string
+    '--wcm-text-small-regular-letter-spacing'?: string
+    '--wcm-text-small-regular-text-transform'?: string
+    '--wcm-text-small-regular-font-family'?: string
+    '--wcm-text-small-thin-size'?: string
+    '--wcm-text-small-thin-weight'?: string
+    '--wcm-text-small-thin-line-height'?: string
+    '--wcm-text-small-thin-letter-spacing'?: string
+    '--wcm-text-small-thin-text-transform'?: string
+    '--wcm-text-small-thin-font-family'?: string
+    '--wcm-text-xsmall-bold-size'?: string
+    '--wcm-text-xsmall-bold-weight'?: string
+    '--wcm-text-xsmall-bold-line-height'?: string
+    '--wcm-text-xsmall-bold-letter-spacing'?: string
+    '--wcm-text-xsmall-bold-text-transform'?: string
+    '--wcm-text-xsmall-bold-font-family'?: string
+    '--wcm-text-xsmall-regular-size'?: string
+    '--wcm-text-xsmall-regular-weight'?: string
+    '--wcm-text-xsmall-regular-line-height'?: string
+    '--wcm-text-xsmall-regular-letter-spacing'?: string
+    '--wcm-text-xsmall-regular-text-transform'?: string
+    '--wcm-text-xsmall-regular-font-family'?: string
+    '--wcm-overlay-background-color'?: string
+    '--wcm-overlay-backdrop-filter'?: string
+  }
+  themeMode?: 'dark' | 'light'
+}
+type WalletConnectModalConfig = ConfigCtrlState & ThemeCtrlState
+type QrModalOptions = Pick<
+  WalletConnectModalConfig,
+  | 'themeMode'
+  | 'themeVariables'
+  | 'desktopWallets'
+  | 'enableExplorer'
+  | 'explorerRecommendedWalletIds'
+  | 'explorerExcludedWalletIds'
+  | 'mobileWallets'
+  | 'privacyPolicyUrl'
+  | 'termsOfServiceUrl'
+  | 'walletImages'
+>
+
+type ArrayOneOrMore<T> = {
+  0: T
+} & T[]
+
+type EthereumRpcMap = {
+  [chainId: string]: string
+}
+
+type KeyValueStorageOptions = {
+  database?: string
+  table?: string
+}
+
+type ChainsProps =
+  | {
+      chains: ArrayOneOrMore<number>
+      optionalChains?: number[]
+    }
+  | {
+      chains?: number[]
+      optionalChains: ArrayOneOrMore<number>
+    }
+
+export type EthereumProviderOptions = {
+  projectId: string
+  methods?: string[]
+  optionalMethods?: string[]
+  events?: string[]
+  optionalEvents?: string[]
+  rpcMap?: EthereumRpcMap
+  metadata?: Metadata
+  showQrModal: boolean
+  qrModalOptions?: QrModalOptions
+  disableProviderPing?: boolean
+  relayUrl?: string
+  storageOptions?: KeyValueStorageOptions
+} & ChainsProps

--- a/src/context/WalletProvider/WalletContext.tsx
+++ b/src/context/WalletProvider/WalletContext.tsx
@@ -7,6 +7,7 @@ import type { DeviceState, InitialState, KeyManagerWithProvider } from './Wallet
 
 export interface IWalletContext {
   state: InitialState
+  getAdapter: (keyManager: KeyManager) => Promise<any>
   dispatch: React.Dispatch<ActionTypes>
   connect: (adapter: KeyManager) => void
   create: (adapter: KeyManager) => void

--- a/src/context/WalletProvider/WalletContext.tsx
+++ b/src/context/WalletProvider/WalletContext.tsx
@@ -7,7 +7,7 @@ import type { DeviceState, InitialState, KeyManagerWithProvider } from './Wallet
 
 export interface IWalletContext {
   state: InitialState
-  getAdapter: (keyManager: KeyManager) => Promise<any>
+  getAdapter: (keyManager: KeyManager, index?: number) => Promise<any>
   dispatch: React.Dispatch<ActionTypes>
   connect: (adapter: KeyManager) => void
   create: (adapter: KeyManager) => void

--- a/src/context/WalletProvider/WalletProvider.test.tsx
+++ b/src/context/WalletProvider/WalletProvider.test.tsx
@@ -63,12 +63,6 @@ const setup = async () => {
 
 describe('WalletProvider', () => {
   describe('dispatch', () => {
-    it('can SET_ADAPTERS on mount', async () => {
-      const result = await setup()
-
-      expect(result.current.state.adapters).toBeTruthy()
-    })
-
     it('can SET_WALLET sets a wallet in state', async () => {
       const result = await setup()
 

--- a/src/context/WalletProvider/WalletProvider.tsx
+++ b/src/context/WalletProvider/WalletProvider.tsx
@@ -373,7 +373,10 @@ export const WalletProvider = ({ children }: { children: React.ReactNode }): JSX
           const Adapter = await SUPPORTED_WALLETS[keyManager].adapters[index].loadAdapter()
           // eslint is drunk, this isn't a hook
           // eslint-disable-next-line react-hooks/rules-of-hooks
-          adapterInstance = Adapter.useKeyring(state.keyring, getKeyManagerOptions(keyManager))
+          adapterInstance = Adapter.useKeyring(
+            state.keyring,
+            getKeyManagerOptions(keyManager, isDarkMode),
+          )
 
           if (adapterInstance) {
             currentKeyManagerAdapters[index] = adapterInstance
@@ -389,7 +392,7 @@ export const WalletProvider = ({ children }: { children: React.ReactNode }): JSX
 
       return adapterInstance
     },
-    [state.adapters, state.keyring],
+    [isDarkMode, state.adapters, state.keyring],
   )
 
   const disconnect = useCallback(() => {
@@ -766,44 +769,6 @@ export const WalletProvider = ({ children }: { children: React.ReactNode }): JSX
       await onProviderChange(localWalletType)
     })()
   }, [state.wallet, onProviderChange])
-
-  // useEffect(() => {
-  // if (state.keyring) {
-  // ;(async () => {
-  // const adapters: Adapters = new Map()
-  // for (const keyManager of Object.values(KeyManager)) {
-  // try {
-  //
-  //
-  //
-  // const walletAdapters = await SUPPORTED_WALLETS[keyManager]?.adapters.reduce<
-  // Promise<GenericAdapter[]>
-  // >(async (acc, cur) => {
-  // const adapters = await acc
-  // const options = getKeyManagerOptions(keyManager)
-  // try {
-  // const { loadAdapter } = cur
-  // const Adapter = await loadAdapter()
-  // eslint is drunk, this isn't a hook
-  // eslint-disable-next-line react-hooks/rules-of-hooks
-  // const adapter = Adapter.useKeyring(state.keyring, options)
-  // adapters.push(adapter)
-  // } catch (e) {
-  // console.error(e)
-  // }
-  // return acc
-  // }, Promise.resolve([]))
-  //
-  // if (walletAdapters.length) adapters.set(keyManager, walletAdapters)
-  // } catch (e) {
-  // console.error(e)
-  // }
-  // }
-  //
-  // dispatch({ type: WalletActions.SET_ADAPTERS, payload: adapters })
-  // })()
-  // }
-  // }, [isDarkMode, state.keyring])
 
   const connect = useCallback((type: KeyManager) => {
     dispatch({ type: WalletActions.SET_CONNECTOR_TYPE, payload: type })

--- a/src/context/WalletProvider/WalletProvider.tsx
+++ b/src/context/WalletProvider/WalletProvider.tsx
@@ -385,7 +385,7 @@ export const WalletProvider = ({ children }: { children: React.ReactNode }): JSX
   const [walletType, setWalletType] = useState<KeyManagerWithProvider | null>(null)
 
   const getAdapter = useCallback(
-    async (keyManager: KeyManager) => {
+    async (keyManager: KeyManager, index: number = 0) => {
       let currentAdapters = state.adapters ?? new Map()
 
       // Check if adapter is already in the state
@@ -394,7 +394,7 @@ export const WalletProvider = ({ children }: { children: React.ReactNode }): JSX
       if (!adapterInstance) {
         // If not, create a new instance of the adapter
         try {
-          const Adapter = await SUPPORTED_WALLETS[keyManager].adapters[0].loadAdapter()
+          const Adapter = await SUPPORTED_WALLETS[keyManager].adapters[index].loadAdapter()
           // eslint is drunk, this isn't a hook
           // eslint-disable-next-line react-hooks/rules-of-hooks
           adapterInstance = Adapter.useKeyring(state.keyring)

--- a/src/context/WalletProvider/WalletProvider.tsx
+++ b/src/context/WalletProvider/WalletProvider.tsx
@@ -364,7 +364,7 @@ export const WalletProvider = ({ children }: { children: React.ReactNode }): JSX
       let currentAdapters = state.adapters ?? new Map()
 
       // Check if adapter is already in the state
-      let adapterInstance = currentAdapters.get(keyManager)?.[0]
+      let adapterInstance = currentAdapters.get(keyManager)?.[index]
 
       if (!adapterInstance) {
         // If not, create a new instance of the adapter

--- a/src/context/WalletProvider/WalletProvider.tsx
+++ b/src/context/WalletProvider/WalletProvider.tsx
@@ -1,18 +1,13 @@
 import type { ComponentWithAs, IconProps } from '@chakra-ui/react'
 import { useColorModeValue } from '@chakra-ui/react'
 import detectEthereumProvider from '@metamask/detect-provider'
-import type { CoinbaseProviderConfig } from '@shapeshiftoss/hdwallet-coinbase'
 import type { HDWallet } from '@shapeshiftoss/hdwallet-core'
 import { Keyring } from '@shapeshiftoss/hdwallet-core'
 import type { MetaMaskHDWallet } from '@shapeshiftoss/hdwallet-metamask'
 import type { NativeHDWallet } from '@shapeshiftoss/hdwallet-native'
 import { Dummy } from '@shapeshiftoss/hdwallet-native/dist/crypto/isolation/engines'
-import type {
-  EthereumProvider as EthereumProviderType,
-  EthereumProviderOptions,
-} from '@walletconnect/ethereum-provider/dist/types/EthereumProvider'
+import type { EthereumProvider as EthereumProviderType } from '@walletconnect/ethereum-provider/dist/types/EthereumProvider'
 import type WalletConnectProvider from '@walletconnect/web3-provider'
-import { getConfig } from 'config'
 import { PublicWalletXpubs } from 'constants/PublicWalletXpubs'
 import type { providers } from 'ethers'
 import findIndex from 'lodash/findIndex'
@@ -25,7 +20,6 @@ import { useKeepKeyEventHandler } from 'context/WalletProvider/KeepKey/hooks/use
 import { MobileConfig } from 'context/WalletProvider/MobileWallet/config'
 import { getWallet } from 'context/WalletProvider/MobileWallet/mobileMessageHandlers'
 import { KeepKeyRoutes } from 'context/WalletProvider/routes'
-import { walletConnectV2ProviderConfig } from 'context/WalletProvider/WalletConnectV2/config'
 import { useWalletConnectV2EventHandler } from 'context/WalletProvider/WalletConnectV2/useWalletConnectV2EventHandler'
 import { portfolio } from 'state/slices/portfolioSlice/portfolioSlice'
 import { store } from 'state/store'
@@ -139,25 +133,6 @@ const initialState: InitialState = {
   keepKeyPinRequestType: null,
   deviceState: initialDeviceState,
   disconnectOnCloseModal: false,
-}
-
-type KeyManagerOptions = undefined | CoinbaseProviderConfig | EthereumProviderOptions
-type GetKeyManagerOptions = (keyManager: KeyManager) => KeyManagerOptions
-export const getKeyManagerOptions: GetKeyManagerOptions = keyManager => {
-  switch (keyManager) {
-    case KeyManager.WalletConnectV2:
-      return walletConnectV2ProviderConfig
-    case KeyManager.Coinbase:
-      return {
-        appName: 'ShapeShift',
-        appLogoUrl: 'https://avatars.githubusercontent.com/u/52928763?s=50&v=4',
-        defaultJsonRpcUrl: getConfig().REACT_APP_ETHEREUM_NODE_URL,
-        defaultChainId: 1,
-        darkMode: isDarkMode,
-      }
-    default:
-      return undefined
-  }
 }
 
 export const isKeyManagerWithProvider = (

--- a/src/context/WalletProvider/WalletProvider.tsx
+++ b/src/context/WalletProvider/WalletProvider.tsx
@@ -411,14 +411,11 @@ export const WalletProvider = ({ children }: { children: React.ReactNode }): JSX
     if (localWalletType && localWalletDeviceId) {
       ;(async () => {
         const currentAdapters = state.adapters ?? new Map()
-        const Adapter = await SUPPORTED_WALLETS[localWalletType].adapters[0].loadAdapter()
-        // eslint is drunk, this isn't a hook
-        // eslint-disable-next-line react-hooks/rules-of-hooks
-        const adapterInstance = Adapter.useKeyring(state.keyring)
+        const adapter = await getAdapter(localWalletType)
 
-        if (adapterInstance) {
+        if (adapter) {
           try {
-            currentAdapters.set(localWalletType, [adapterInstance])
+            currentAdapters.set(localWalletType, [adapter])
             dispatch({ type: WalletActions.SET_ADAPTERS, payload: currentAdapters })
           } catch (e) {
             console.error(e)
@@ -431,7 +428,7 @@ export const WalletProvider = ({ children }: { children: React.ReactNode }): JSX
               try {
                 const w = await getWallet(localWalletDeviceId)
                 if (w && w.mnemonic && w.label) {
-                  const localMobileWallet = await adapterInstance.pairDevice(localWalletDeviceId)
+                  const localMobileWallet = await adapter.pairDevice(localWalletDeviceId)
 
                   if (localMobileWallet) {
                     localMobileWallet.loadDevice({ label: w.label, mnemonic: w.mnemonic })
@@ -463,7 +460,7 @@ export const WalletProvider = ({ children }: { children: React.ReactNode }): JSX
               }
               break
             case KeyManager.Native:
-              const localNativeWallet = await adapterInstance.pairDevice(localWalletDeviceId)
+              const localNativeWallet = await adapter.pairDevice(localWalletDeviceId)
               if (localNativeWallet) {
                 /**
                  * This will eventually fire an event, which the ShapeShift wallet
@@ -525,7 +522,7 @@ export const WalletProvider = ({ children }: { children: React.ReactNode }): JSX
               dispatch({ type: WalletActions.SET_LOCAL_WALLET_LOADING, payload: false })
               break
             case KeyManager.MetaMask:
-              const localMetaMaskWallet = await adapterInstance?.pairDevice()
+              const localMetaMaskWallet = await adapter?.pairDevice()
               if (localMetaMaskWallet) {
                 const { name, icon } = SUPPORTED_WALLETS[KeyManager.MetaMask]
                 try {
@@ -552,7 +549,7 @@ export const WalletProvider = ({ children }: { children: React.ReactNode }): JSX
               dispatch({ type: WalletActions.SET_LOCAL_WALLET_LOADING, payload: false })
               break
             case KeyManager.Coinbase:
-              const localCoinbaseWallet = await adapterInstance?.pairDevice()
+              const localCoinbaseWallet = await adapter?.pairDevice()
               if (localCoinbaseWallet) {
                 const { name, icon } = SUPPORTED_WALLETS[KeyManager.Coinbase]
                 try {
@@ -579,7 +576,7 @@ export const WalletProvider = ({ children }: { children: React.ReactNode }): JSX
               dispatch({ type: WalletActions.SET_LOCAL_WALLET_LOADING, payload: false })
               break
             case KeyManager.XDefi:
-              const localXDEFIWallet = await adapterInstance?.pairDevice()
+              const localXDEFIWallet = await adapter?.pairDevice()
               if (localXDEFIWallet) {
                 const { name, icon } = SUPPORTED_WALLETS[KeyManager.XDefi]
                 try {
@@ -605,7 +602,7 @@ export const WalletProvider = ({ children }: { children: React.ReactNode }): JSX
               dispatch({ type: WalletActions.SET_LOCAL_WALLET_LOADING, payload: false })
               break
             case KeyManager.Keplr:
-              const localKeplrWallet = await adapterInstance?.pairDevice()
+              const localKeplrWallet = await adapter?.pairDevice()
               if (localKeplrWallet) {
                 const { name, icon } = SUPPORTED_WALLETS[KeyManager.Keplr]
                 try {
@@ -633,7 +630,7 @@ export const WalletProvider = ({ children }: { children: React.ReactNode }): JSX
             case KeyManager.WalletConnectV2: {
               // Re-trigger the modal on refresh
               await onProviderChange(KeyManager.WalletConnectV2)
-              const localWalletConnectWallet = await adapterInstance?.pairDevice()
+              const localWalletConnectWallet = await adapter?.pairDevice()
               if (localWalletConnectWallet) {
                 const { name, icon } = SUPPORTED_WALLETS[KeyManager.WalletConnectV2]
                 try {

--- a/src/context/WalletProvider/WalletProvider.tsx
+++ b/src/context/WalletProvider/WalletProvider.tsx
@@ -361,10 +361,11 @@ export const WalletProvider = ({ children }: { children: React.ReactNode }): JSX
 
   const getAdapter = useCallback(
     async (keyManager: KeyManager, index: number = 0) => {
-      let currentAdapters = state.adapters ?? new Map()
+      let currentStateAdapters = state.adapters ?? new Map<KeyManager, any[]>()
 
       // Check if adapter is already in the state
-      let adapterInstance = currentAdapters.get(keyManager)?.[index]
+      let adapterInstance = currentStateAdapters.get(keyManager)?.[index]
+      const currentKeyManagerAdapters = currentStateAdapters.get(keyManager) ?? []
 
       if (!adapterInstance) {
         // If not, create a new instance of the adapter
@@ -375,9 +376,10 @@ export const WalletProvider = ({ children }: { children: React.ReactNode }): JSX
           adapterInstance = Adapter.useKeyring(state.keyring, getKeyManagerOptions(keyManager))
 
           if (adapterInstance) {
-            currentAdapters.set(keyManager, [adapterInstance])
+            currentKeyManagerAdapters[index] = adapterInstance
+            currentStateAdapters.set(keyManager, currentKeyManagerAdapters)
             // Set it in wallet state for later use
-            dispatch({ type: WalletActions.SET_ADAPTERS, payload: currentAdapters })
+            dispatch({ type: WalletActions.SET_ADAPTERS, payload: currentStateAdapters })
           }
         } catch (e) {
           console.error(e)

--- a/src/context/WalletProvider/WalletProvider.tsx
+++ b/src/context/WalletProvider/WalletProvider.tsx
@@ -26,7 +26,7 @@ import { store } from 'state/store'
 
 import type { ActionTypes } from './actions'
 import { WalletActions } from './actions'
-import { SUPPORTED_WALLETS } from './config'
+import { getKeyManagerOptions, SUPPORTED_WALLETS } from './config'
 import { useKeyringEventHandler } from './KeepKey/hooks/useKeyringEventHandler'
 import type { PinMatrixRequestType } from './KeepKey/KeepKeyTypes'
 import { setupKeepKeySDK } from './KeepKey/setupKeepKeySdk'
@@ -372,7 +372,7 @@ export const WalletProvider = ({ children }: { children: React.ReactNode }): JSX
           const Adapter = await SUPPORTED_WALLETS[keyManager].adapters[index].loadAdapter()
           // eslint is drunk, this isn't a hook
           // eslint-disable-next-line react-hooks/rules-of-hooks
-          adapterInstance = Adapter.useKeyring(state.keyring)
+          adapterInstance = Adapter.useKeyring(state.keyring, getKeyManagerOptions(keyManager))
 
           if (adapterInstance) {
             currentAdapters.set(keyManager, [adapterInstance])

--- a/src/context/WalletProvider/XDEFI/components/Connect.tsx
+++ b/src/context/WalletProvider/XDEFI/components/Connect.tsx
@@ -21,7 +21,7 @@ export interface XDEFISetupProps
 }
 
 export const XDEFIConnect = ({ history }: XDEFISetupProps) => {
-  const { dispatch, state, onProviderChange } = useWallet()
+  const { dispatch, state, getAdapter, onProviderChange } = useWallet()
   const [loading, setLoading] = useState(false)
   const [error, setError] = useState<string | null>(null)
 
@@ -38,11 +38,10 @@ export const XDEFIConnect = ({ history }: XDEFISetupProps) => {
     setError(null)
     setLoading(true)
 
-    if (state.adapters && state.adapters?.has(KeyManager.XDefi)) {
+    const adapter = await getAdapter(KeyManager.XDefi)
+    if (adapter) {
       try {
-        const wallet = (await state.adapters.get(KeyManager.XDefi)?.[0]?.pairDevice()) as
-          | XDEFIHDWallet
-          | undefined
+        const wallet = (await adapter.pairDevice()) as XDEFIHDWallet | undefined
         if (!wallet) {
           setErrorLoading('walletProvider.errors.walletNotFound')
           throw new Error('Call to hdwallet-xdefi::pairDevice returned null or undefined')
@@ -81,7 +80,7 @@ export const XDEFIConnect = ({ history }: XDEFISetupProps) => {
       }
     }
     setLoading(false)
-  }, [state.provider, state.adapters, dispatch, history])
+  }, [getAdapter, state.provider, dispatch, history])
 
   return (
     <ConnectModal

--- a/src/context/WalletProvider/config.ts
+++ b/src/context/WalletProvider/config.ts
@@ -1,4 +1,7 @@
 import type { ComponentWithAs, IconProps } from '@chakra-ui/react'
+import type { CoinbaseProviderConfig } from '@shapeshiftoss/hdwallet-coinbase'
+import type { EthereumProviderOptions } from '@walletconnect/ethereum-provider/dist/types/EthereumProvider'
+import { getConfig } from 'config'
 import type { RouteProps } from 'react-router-dom'
 import { WalletConnectedRoutes } from 'components/Layout/Header/NavBar/hooks/useMenuRoutes'
 import { ChangeLabel } from 'components/Layout/Header/NavBar/KeepKey/ChangeLabel'
@@ -8,6 +11,7 @@ import { ChangeTimeout } from 'components/Layout/Header/NavBar/KeepKey/ChangeTim
 import { KeepKeyMenu } from 'components/Layout/Header/NavBar/KeepKey/KeepKeyMenu'
 import { NativeMenu } from 'components/Layout/Header/NavBar/Native/NativeMenu'
 import { WalletConnectV2Connect } from 'context/WalletProvider/WalletConnectV2/components/Connect'
+import { walletConnectV2ProviderConfig } from 'context/WalletProvider/WalletConnectV2/config'
 
 import { CoinbaseConnect } from './Coinbase/components/Connect'
 import { CoinbaseFailure } from './Coinbase/components/Failure'
@@ -198,4 +202,26 @@ export const SUPPORTED_WALLETS: Record<KeyManager, SupportedWalletInfo> = {
       { path: '/walletconnectv2/create', component: WalletConnectV2Create },
     ],
   },
+}
+
+// TODO(gomes): these types are imported from HdWallet and should be lazy loaded as well
+// else, @shapeshiftoss/hdwallet-coinbase and @walletconnect/ethereum-provider will be imported every time we import from this module
+type KeyManagerOptions = undefined | CoinbaseProviderConfig | EthereumProviderOptions
+type GetKeyManagerOptions = (keyManager: KeyManager) => KeyManagerOptions
+
+export const getKeyManagerOptions: GetKeyManagerOptions = keyManager => {
+  switch (keyManager) {
+    case KeyManager.WalletConnectV2:
+      return walletConnectV2ProviderConfig
+    case KeyManager.Coinbase:
+      return {
+        appName: 'ShapeShift',
+        appLogoUrl: 'https://avatars.githubusercontent.com/u/52928763?s=50&v=4',
+        defaultJsonRpcUrl: getConfig().REACT_APP_ETHEREUM_NODE_URL,
+        defaultChainId: 1,
+        darkMode: isDarkMode,
+      }
+    default:
+      return undefined
+  }
 }

--- a/src/context/WalletProvider/config.ts
+++ b/src/context/WalletProvider/config.ts
@@ -207,9 +207,9 @@ export const SUPPORTED_WALLETS: Record<KeyManager, SupportedWalletInfo> = {
 // TODO(gomes): these types are imported from HdWallet and should be lazy loaded as well
 // else, @shapeshiftoss/hdwallet-coinbase and @walletconnect/ethereum-provider will be imported every time we import from this module
 type KeyManagerOptions = undefined | CoinbaseProviderConfig | EthereumProviderOptions
-type GetKeyManagerOptions = (keyManager: KeyManager) => KeyManagerOptions
+type GetKeyManagerOptions = (keyManager: KeyManager, isDarkMode: boolean) => KeyManagerOptions
 
-export const getKeyManagerOptions: GetKeyManagerOptions = keyManager => {
+export const getKeyManagerOptions: GetKeyManagerOptions = (keyManager, isDarkMode) => {
   switch (keyManager) {
     case KeyManager.WalletConnectV2:
       return walletConnectV2ProviderConfig

--- a/src/context/WalletProvider/config.ts
+++ b/src/context/WalletProvider/config.ts
@@ -1,6 +1,4 @@
 import type { ComponentWithAs, IconProps } from '@chakra-ui/react'
-import type { CoinbaseProviderConfig } from '@shapeshiftoss/hdwallet-coinbase'
-import type { EthereumProviderOptions } from '@walletconnect/ethereum-provider/dist/types/EthereumProvider'
 import { getConfig } from 'config'
 import type { RouteProps } from 'react-router-dom'
 import { WalletConnectedRoutes } from 'components/Layout/Header/NavBar/hooks/useMenuRoutes'
@@ -72,6 +70,7 @@ import { KeepKeyRoutes } from './routes'
 import { WalletConnectV2Create } from './WalletConnectV2/components/Create'
 import { WalletConnectV2Load } from './WalletConnectV2/components/Load'
 import { WalletConnectV2Config } from './WalletConnectV2/config'
+import type { EthereumProviderOptions } from './WalletConnectV2/constants'
 import { XDEFIConnect } from './XDEFI/components/Connect'
 import { XDEFIFailure } from './XDEFI/components/Failure'
 import { XDEFIConfig } from './XDEFI/config'
@@ -204,8 +203,16 @@ export const SUPPORTED_WALLETS: Record<KeyManager, SupportedWalletInfo> = {
   },
 }
 
-// TODO(gomes): these types are imported from HdWallet and should be lazy loaded as well
-// else, @shapeshiftoss/hdwallet-coinbase and @walletconnect/ethereum-provider will be imported every time we import from this module
+// Copied from hdwallet-coinbase so we don't have to import the whole package just for the sake of this type
+// and can lazy load it instead
+type CoinbaseProviderConfig = {
+  appName: string
+  appLogoUrl: string
+  defaultJsonRpcUrl: string
+  defaultChainId: number
+  darkMode: boolean
+}
+
 type KeyManagerOptions = undefined | CoinbaseProviderConfig | EthereumProviderOptions
 type GetKeyManagerOptions = (keyManager: KeyManager, isDarkMode: boolean) => KeyManagerOptions
 


### PR DESCRIPTION
## Description

Yo dawg, we heard you like wallets, so we put some lazy wallet loading in your wallet loading, so you can transact while you transact! 🚀 Welcome to our super-duper PR where we're turning sloth-mode ON to hit you up with the snazziest, laziest import of hdwallet npm packages that you've ever seen. 

Why, you ask? Because ain't nobody got time to wait for those hefty hdwallet bundles to load! 😴 By incorporating a luxuriously lazy loading mechanism, we make sure your user experience is smoother than a fresh jar of peanut butter. 🥜✨ Now you can keep your transactions and crypto dealings as swift as a ninja, all while our code does the heavy (or should we say, light?) lifting in the background.

In a nutshell:
- Maximize efficiency 🚀
- Minimize loading times ⏲️
- Optimize your chill while we work in the stealth 🐢👤

## Pull Request Type

- [ ] :bug: Bug fix (Non-breaking Change: Fixes an issue)
- [ ] :hammer_and_wrench: Chore (Non-breaking Change: Doc updates, pkg upgrades, typos, etc..)
- [x] :nail_care: New Feature (Breaking/Non-breaking Change)

## Issue (if applicable)

<!-----------------------------------------------------------------------------
If applicable, please link to the github issue and put `closes #XXXX` in your comment to auto-close the issue that your PR fixes.
------------------------------------------------------------------------------>

- tackles https://github.com/shapeshift/web/issues/5445 
 
## Risk

<!-----------------------------------------------------------------------------
Outline the scope of your changes and the risk associated with them. You must use your discretion as an engineer to determine the potential impact of your changes.

E.g. an upgrade to `hdwallet` or core state management would be considered higher risk, and might require a full regression test. UI or isolated view changes, or something behind a feature flag may have near zero risk. Small bug fixes might require testing isolated to the specific fix.
------------------------------------------------------------------------------>

Very high. Test all wallets connection and reconnection, in all states, e.g native wallet import, locked native unlock, MM in locked state, KK wallet import, KK unlock, app refresh, etc...
Test all states and ensure no regression against prod.

Tested with:
- KK ✅ 
- Native ✅ 
- MM ✅ 
- WCV2 ✅
- Keplr 🚫 borked, but also borked in prod (see https://github.com/shapeshift/hdwallet/pull/646 for fix)

## Testing

<!-----------------------------------------------------------------------------
We treat every PR to be merged with the same scrutiny as if we were merging directly to production.

Your PR will not be merged if you do not complete the sections below for our engineering and operations teams to test.
------------------------------------------------------------------------------>

- See risks - test all wallet states and ensure no regression against prod
- Ensure wallet/accounts switching is happy and has no regressions against prod

### Engineering

<!-----------------------------------------------------------------------------
Include sufficient information here for an engineer to test your PR. This may include how to test locally, in a built environment, changes to infrastructure etc.
------------------------------------------------------------------------------>

- ☝🏽 

### Operations

<!-----------------------------------------------------------------------------
If your changes have a user-facing impact, describe how a non-technical QA team can functionally test your changes in a preview environment.

If they are not user-facing please describe how to test for any regressions that may occur.
------------------------------------------------------------------------------>

- ☝🏽 

## Screenshots (if applicable)
