### PR TITLE
perf: load primary/rainbow chart components lazily

### DIFF
--- a/src/components/Graph/Graph.tsx
+++ b/src/components/Graph/Graph.tsx
@@ -2,12 +2,17 @@ import { Center, Fade } from '@chakra-ui/react'
 import { ParentSize } from '@visx/responsive'
 import type { ParentSizeProvidedProps } from '@visx/responsive/lib/components/ParentSize'
 import { isEmpty } from 'lodash'
-import { useCallback } from 'react'
+import { lazy, Suspense, useCallback } from 'react'
 import type { BalanceChartData } from 'hooks/useBalanceChartData/useBalanceChartData'
 
 import { GraphLoading } from './GraphLoading'
-import { PrimaryChart } from './PrimaryChart/PrimaryChart'
-import { RainbowChart } from './RainbowChart/RainbowChart'
+
+const RainbowChart = lazy(() =>
+  import('./RainbowChart/RainbowChart').then(({ RainbowChart }) => ({ default: RainbowChart })),
+)
+const PrimaryChart = lazy(() =>
+  import('./PrimaryChart/PrimaryChart').then(({ PrimaryChart }) => ({ default: PrimaryChart })),
+)
 
 type GraphProps = {
   data: BalanceChartData
@@ -44,13 +49,15 @@ export const Graph: React.FC<GraphProps> = ({
         </Fade>
       ) : !isEmpty(data) ? (
         isRainbowChart ? (
-          <RainbowChart
-            height={height}
-            width={width}
-            color={color}
-            margin={margin}
-            data={rainbow}
-          />
+          <Suspense fallback={<div />}>
+            <RainbowChart
+              height={height}
+              width={width}
+              color={color}
+              margin={margin}
+              data={rainbow}
+            />
+          </Suspense>
         ) : (
           <PrimaryChart
             height={height}

--- a/src/components/Graph/PrimaryChart/PrimaryChart.tsx
+++ b/src/components/Graph/PrimaryChart/PrimaryChart.tsx
@@ -2,15 +2,14 @@ import { useColorModeValue } from '@chakra-ui/color-mode'
 import { Stack as CStack } from '@chakra-ui/react'
 import { useToken } from '@chakra-ui/system'
 import type { HistoryData } from '@shapeshiftoss/types'
-import { LinearGradient } from '@visx/gradient'
-import { ScaleSVG } from '@visx/responsive'
 import { scaleLinear } from '@visx/scale'
-import { AnimatedAreaSeries, AnimatedAxis, Tooltip, XYChart } from '@visx/xychart'
-import type { RenderTooltipParams } from '@visx/xychart/lib/components/Tooltip'
+import type { AxisScale } from '@visx/xychart'
+import type { BaseAreaSeriesProps } from '@visx/xychart/lib/components/series/private/BaseAreaSeries'
+import type { RenderTooltipParams, TooltipProps } from '@visx/xychart/lib/components/Tooltip'
 import type { Numeric } from 'd3-array'
 import { extent, max, min } from 'd3-array'
 import dayjs from 'dayjs'
-import { useCallback, useMemo } from 'react'
+import { lazy, useCallback, useMemo } from 'react'
 import { Amount } from 'components/Amount/Amount'
 import { RawText } from 'components/Text'
 import { useLocaleFormatter } from 'hooks/useLocaleFormatter/useLocaleFormatter'
@@ -20,6 +19,28 @@ import { colors } from 'theme/colors'
 
 import { MaxPrice } from '../MaxPrice'
 import { MinPrice } from '../MinPrice'
+
+const LinearGradient = lazy(() =>
+  import('@visx/gradient').then(({ LinearGradient }) => ({ default: LinearGradient })),
+)
+const ScaleSVG = lazy(() =>
+  import('@visx/responsive').then(({ ScaleSVG }) => ({ default: ScaleSVG })),
+)
+
+type AnimatedAreaSeriesType = React.ComponentType<
+  BaseAreaSeriesProps<AxisScale, AxisScale, HistoryData>
+>
+const AnimatedAreaSeries = lazy<AnimatedAreaSeriesType>(() =>
+  import('@visx/xychart').then(({ AnimatedAreaSeries }) => ({ default: AnimatedAreaSeries })),
+)
+const AnimatedAxis = lazy(() =>
+  import('@visx/xychart').then(({ AnimatedAxis }) => ({ default: AnimatedAxis })),
+)
+type TooltipType = React.ComponentType<TooltipProps<HistoryData>>
+const Tooltip = lazy<TooltipType>(() =>
+  import('@visx/xychart').then(({ Tooltip }) => ({ default: Tooltip })),
+)
+const XYChart = lazy(() => import('@visx/xychart').then(({ XYChart }) => ({ default: XYChart })))
 
 export interface PrimaryChartProps {
   data: HistoryData[]


### PR DESCRIPTION
## Description

And consequently, all imports of `<PrimaryChart />` and `<RainbowChart />` including the heavy @visx packages will be lazily *ran* (not loaded).

## Pull Request Type

- [ ] :bug: Bug fix (Non-breaking Change: Fixes an issue)
- [ ] :hammer_and_wrench: Chore (Non-breaking Change: Doc updates, pkg upgrades, typos, etc..)
- [x] :nail_care: New Feature (Breaking/Non-breaking Change)

## Issue (if applicable)

<!-----------------------------------------------------------------------------
If applicable, please link to the github issue and put `closes #XXXX` in your comment to auto-close the issue that your PR fixes.
------------------------------------------------------------------------------>

Relates to https://github.com/shapeshift/web/issues/5445

## Risk

<!-----------------------------------------------------------------------------
Outline the scope of your changes and the risk associated with them. You must use your discretion as an engineer to determine the potential impact of your changes.

E.g. an upgrade to `hdwallet` or core state management would be considered higher risk, and might require a full regression test. UI or isolated view changes, or something behind a feature flag may have near zero risk. Small bug fixes might require testing isolated to the specific fix.
------------------------------------------------------------------------------>

Low, if balance and rainbow charts load in dashboard, we're gucci

## Testing

<!-----------------------------------------------------------------------------
We treat every PR to be merged with the same scrutiny as if we were merging directly to production.

Your PR will not be merged if you do not complete the sections below for our engineering and operations teams to test.
------------------------------------------------------------------------------>

- Balance chart still loads in dashboard
- Switching back and forth from primary to rainbow chart is working

### Engineering

<!-----------------------------------------------------------------------------
Include sufficient information here for an engineer to test your PR. This may include how to test locally, in a built environment, changes to infrastructure etc.
------------------------------------------------------------------------------>

- When the balance chart is in a loaded state for the first time, the chunk for `<PrimaryChart />` is lazily loaded over the network
- When the rainbow chart is in a loaded state for the first time, the chunk for `<RainbowChart />` is lazily loaded over the network

### Operations

<!-----------------------------------------------------------------------------
If your changes have a user-facing impact, describe how a non-technical QA team can functionally test your changes in a preview environment.

If they are not user-facing please describe how to test for any regressions that may occur.
------------------------------------------------------------------------------>

- ☝🏽 

## Screenshots (if applicable)

https://github.com/shapeshift/web/assets/17035424/3a2278ac-91f5-4b26-a69e-d704e730ed72

