### PR TITLE
perf: defer fiat ramps fetching to fiat ramps page

### DIFF
--- a/src/context/AppProvider/AppContext.tsx
+++ b/src/context/AppProvider/AppContext.tsx
@@ -28,7 +28,6 @@ import { deriveAccountIdsAndMetadata } from 'lib/account/account'
 import type { BN } from 'lib/bignumber/bignumber'
 import { bnOrZero } from 'lib/bignumber/bignumber'
 import { setTimeoutAsync } from 'lib/utils'
-import { useGetFiatRampsQuery } from 'state/apis/fiatRamps/fiatRamps'
 import { nftApi } from 'state/apis/nft/nftApi'
 import { snapshotApi } from 'state/apis/snapshot/snapshot'
 import { zapper } from 'state/apis/zapper/zapperApi'
@@ -86,9 +85,6 @@ export const AppProvider = ({ children }: { children: React.ReactNode }) => {
 
   // track anonymous portfolio
   useMixpanelPortfolioTracking()
-
-  // load fiat ramps
-  useGetFiatRampsQuery()
 
   // immediately load all assets, before the wallet is even connected,
   // so the app is functional and ready

--- a/src/pages/Buy/Buy.tsx
+++ b/src/pages/Buy/Buy.tsx
@@ -13,6 +13,7 @@ import { FiatForm } from 'components/Modals/FiatRamps/views/FiatForm'
 import { Text } from 'components/Text'
 import { WalletActions } from 'context/WalletProvider/actions'
 import { useWallet } from 'hooks/useWallet/useWallet'
+import { useGetFiatRampsQuery } from 'state/apis/fiatRamps/fiatRamps'
 import { useFetchFiatAssetMarketData } from 'state/apis/fiatRamps/hooks'
 import { selectFiatRampChainCount } from 'state/apis/fiatRamps/selectors'
 import { useAppSelector } from 'state/store'
@@ -26,6 +27,9 @@ type MatchParams = {
 }
 
 export const Buy = () => {
+  // load fiat ramps
+  useGetFiatRampsQuery()
+
   const { chainId, assetSubId } = useParams<MatchParams>()
   const [selectedAssetId, setSelectedAssetId] = useState<AssetId>(ethAssetId)
   const {


### PR DESCRIPTION
## Description

Fiat ramps take a long time to fetch over the network. This happens right when loading the app at the default dashboard route with a locked native wallet.

Not only are we making useless network requests, but there's also the upsertion happening, all of which we don't need until actually going to the fiat ramps page. This PR defers the fetching to the fiat ramps page.

<img width="542" alt="image" src="https://github.com/shapeshift/web/assets/17035424/7c5e5e9f-4462-4a06-a583-12a64c40de9b">
<img width="577" alt="image" src="https://github.com/shapeshift/web/assets/17035424/079eeca4-fb8b-4859-8c68-687636294cff">


## Pull Request Type

- [ ] :bug: Bug fix (Non-breaking Change: Fixes an issue)
- [ ] :hammer_and_wrench: Chore (Non-breaking Change: Doc updates, pkg upgrades, typos, etc..)
- [x] :nail_care: New Feature (Breaking/Non-breaking Change)

## Issue (if applicable)

<!-----------------------------------------------------------------------------
If applicable, please link to the github issue and put `closes #XXXX` in your comment to auto-close the issue that your PR fixes.
------------------------------------------------------------------------------>

- relates to https://github.com/shapeshift/web/issues/5451

## Risk

<!-----------------------------------------------------------------------------
Outline the scope of your changes and the risk associated with them. You must use your discretion as an engineer to determine the potential impact of your changes.

E.g. an upgrade to `hdwallet` or core state management would be considered higher risk, and might require a full regression test. UI or isolated view changes, or something behind a feature flag may have near zero risk. Small bug fixes might require testing isolated to the specific fix.
------------------------------------------------------------------------------>

## Testing

<!-----------------------------------------------------------------------------
We treat every PR to be merged with the same scrutiny as if we were merging directly to production.

Your PR will not be merged if you do not complete the sections below for our engineering and operations teams to test.
------------------------------------------------------------------------------>

- Fiat ramps page is still happy

### Engineering

<!-----------------------------------------------------------------------------
Include sufficient information here for an engineer to test your PR. This may include how to test locally, in a built environment, changes to infrastructure etc.
------------------------------------------------------------------------------>

- ☝🏽 
- Ensure the XHRs to fiat ramps (e.g onramper) aren't fired until going to the fiat ramps page
### Operations

<!-----------------------------------------------------------------------------
If your changes have a user-facing impact, describe how a non-technical QA team can functionally test your changes in a preview environment.

If they are not user-facing please describe how to test for any regressions that may occur.
------------------------------------------------------------------------------>

- ☝🏽 

## Screenshots (if applicable)

<img width="1395" alt="image" src="https://github.com/shapeshift/web/assets/17035424/439353e7-2b95-439f-97ed-f5016beb0cf6">
