### PR TITLE
perf: make wherever notification imports lazy

### DIFF
--- a/src/components/Layout/Header/NavBar/Notifications.tsx
+++ b/src/components/Layout/Header/NavBar/Notifications.tsx
@@ -1,20 +1,32 @@
 import { Box, IconButton, useColorMode } from '@chakra-ui/react'
 import type { BIP32Path, ETHSignTypedData } from '@shapeshiftoss/hdwallet-core'
 import { supportsETH } from '@shapeshiftoss/hdwallet-core'
-import type { CustomTheme } from '@wherever/react-notification-feed'
-import {
-  NotificationBell,
-  NotificationFeed,
-  NotificationFeedProvider,
-  ThemeMode,
-} from '@wherever/react-notification-feed'
+import type { CustomTheme, ThemeMode as ThemeModeType } from '@wherever/react-notification-feed'
 import { getConfig } from 'config'
 import { utils } from 'ethers'
-import { memo, useCallback, useEffect, useMemo, useState } from 'react'
+import { lazy, memo, Suspense, useCallback, useEffect, useMemo, useState } from 'react'
 import { KeyManager } from 'context/WalletProvider/KeyManager'
 import { useFeatureFlag } from 'hooks/useFeatureFlag/useFeatureFlag'
 import { useWallet } from 'hooks/useWallet/useWallet'
 import { breakpoints, theme } from 'theme/theme'
+
+const NotificationBell = lazy(() =>
+  import('@wherever/react-notification-feed').then(({ NotificationBell }) => ({
+    default: NotificationBell,
+  })),
+)
+
+const NotificationFeed = lazy(() =>
+  import('@wherever/react-notification-feed').then(({ NotificationFeed }) => ({
+    default: NotificationFeed,
+  })),
+)
+
+const NotificationFeedProvider = lazy(() =>
+  import('@wherever/react-notification-feed').then(({ NotificationFeedProvider }) => ({
+    default: NotificationFeedProvider,
+  })),
+)
 
 const eip712SupportedWallets = [KeyManager.KeepKey, KeyManager.Native, KeyManager.Mobile]
 
@@ -36,7 +48,7 @@ export const Notifications = memo(() => {
     const baseTheme =
       colorMode === 'light'
         ? {
-            mode: ThemeMode.Light,
+            mode: 'light' as ThemeModeType,
             primaryColor: theme.colors.primary,
             backgroundColor: theme.colors.gray[100],
             textColor: theme.colors.gray[800],
@@ -128,18 +140,20 @@ export const Notifications = memo(() => {
 
   return (
     <Box>
-      <NotificationFeedProvider
-        customSigner={customSignerProp}
-        partnerKey={partnerKey}
-        theme={themeObj}
-        disableAnalytics={disableAnalytics}
-      >
-        <NotificationFeed gapFromBell={10} placement='bottom-end'>
-          <IconButton aria-label='Open notifications'>
-            <NotificationBell size={20} />
-          </IconButton>
-        </NotificationFeed>
-      </NotificationFeedProvider>
+      <Suspense fallback={<div />}>
+        <NotificationFeedProvider
+          customSigner={customSignerProp}
+          partnerKey={partnerKey}
+          theme={themeObj}
+          disableAnalytics={disableAnalytics}
+        >
+          <NotificationFeed gapFromBell={10} placement='bottom-end'>
+            <IconButton aria-label='Open notifications'>
+              <NotificationBell size={20} />
+            </IconButton>
+          </NotificationFeed>
+        </NotificationFeedProvider>
+      </Suspense>
     </Box>
   )
 })


### PR DESCRIPTION
## Description

Inspired by @gomesalexandre #5477 this makes wherever package load lazy so parsing is delayed until the user connects their wallet.

## Pull Request Type

- [ ] :bug: Bug fix (Non-breaking Change: Fixes an issue)
- [x] :hammer_and_wrench: Chore (Non-breaking Change: Doc updates, pkg upgrades, typos, etc..)
- [ ] :nail_care: New Feature (Breaking/Non-breaking Change)

## Issue (if applicable)

NA

## Risk

Risk of broken wherever notifications

## Testing

Check wherever notifications load and behave as intended.

### Engineering

<!-----------------------------------------------------------------------------
Include sufficient information here for an engineer to test your PR. This may include how to test locally, in a built environment, changes to infrastructure etc.
------------------------------------------------------------------------------>

### Operations

<!-----------------------------------------------------------------------------
If your changes have a user-facing impact, describe how a non-technical QA team can functionally test your changes in a preview environment.

If they are not user-facing please describe how to test for any regressions that may occur.
------------------------------------------------------------------------------>

## Screenshots (if applicable)

https://github.com/shapeshift/web/assets/125113430/8f9affeb-2508-4e44-867d-ac4252c6fd5a




