### PR TITLE
feat: untangle the KK spaghetti

### DIFF
--- a/src/context/WalletProvider/KeepKey/components/Connect.tsx
+++ b/src/context/WalletProvider/KeepKey/components/Connect.tsx
@@ -69,17 +69,19 @@ export const KeepKeyConnect = () => {
           // @ts-ignore TODO(gomes): FIXME, most likely borked because of WebUSBKeepKeyAdapter
           return await secondAdapter?.pairDevice()
         }
-      } catch (e) {
-        console.error(e)
+      } catch (err) {
+        console.error(err)
+        if (err.name === 'ConflictingApp') {
+          setErrorLoading('walletProvider.keepKey.connect.conflictingApp')
+          return
+        }
+
+        console.error(err)
+        setErrorLoading('walletProvider.errors.walletNotFound')
       }
     })()
 
-    if (!wallet) {
-      setErrorLoading('walletProvider.errors.walletNotFound')
-      setLoading(false)
-      return
-    }
-
+    if (!wallet) return
     try {
       const { name, icon } = KeepKeyConfig
       const deviceId = await wallet.getDeviceID()

--- a/src/context/WalletProvider/KeepKey/components/Connect.tsx
+++ b/src/context/WalletProvider/KeepKey/components/Connect.tsx
@@ -7,7 +7,7 @@ import {
   ModalHeader,
 } from '@chakra-ui/react'
 import type { KkRestAdapter } from '@keepkey/hdwallet-keepkey-rest'
-import type { Event } from '@shapeshiftoss/hdwallet-core'
+import type { Event, HDWalletError } from '@shapeshiftoss/hdwallet-core'
 import { useCallback, useState } from 'react'
 import { CircularProgress } from 'components/CircularProgress/CircularProgress'
 import { Text } from 'components/Text'
@@ -71,13 +71,14 @@ export const KeepKeyConnect = () => {
         }
       } catch (err) {
         console.error(err)
-        if (err.name === 'ConflictingApp') {
+        if ((err as HDWalletError).name === 'ConflictingApp') {
           setErrorLoading('walletProvider.keepKey.connect.conflictingApp')
           return
         }
 
         console.error(err)
         setErrorLoading('walletProvider.errors.walletNotFound')
+        return
       }
     })()
 

--- a/src/context/WalletProvider/WalletProvider.tsx
+++ b/src/context/WalletProvider/WalletProvider.tsx
@@ -481,8 +481,11 @@ export const WalletProvider = ({ children }: { children: React.ReactNode }): JSX
               const localKeepKeyWallet = await (async () => {
                 const maybeWallet = state.keyring.get(localWalletDeviceId)
                 if (maybeWallet) return maybeWallet
+                const sdk = await setupKeepKeySDK()
                 // Get the adapter again in each switch case to narrow down the adapter type
-                const keepKeyAdapter = await getAdapter(KeyManager.KeepKey)
+                // If the SDK is defined, we're in the context of KK desktop and should load the first (REST) adapter
+                // Else we should load the second adapter i.e the regular KK WebUSB one
+                const keepKeyAdapter = await getAdapter(KeyManager.KeepKey, sdk ? 0 : 1)
                 if (!keepKeyAdapter) return
 
                 currentAdapters[localWalletType] = keepKeyAdapter
@@ -490,7 +493,6 @@ export const WalletProvider = ({ children }: { children: React.ReactNode }): JSX
                 // Fixes issue with wallet `type` being null when the wallet is loaded from state
                 dispatch({ type: WalletActions.SET_CONNECTOR_TYPE, payload: localWalletType })
 
-                const sdk = await setupKeepKeySDK()
                 // @ts-ignore TODO(gomes): FIXME, most likely borked because of WebUSBKeepKeyAdapter
                 return await keepKeyAdapter.pairDevice(sdk)
               })()


### PR DESCRIPTION
## Description

While this was previously benign spaghetti code which wouldn't cause any harm except for the eyes, the refactor of `WalletProvider` to only have one adapter per KeyManager makes the `try { firstAdapter.pairDevice() } catch () { secondAdapter.pairDevice() }` flow wrong and inherently borked for KK, since calling `getAdapter()` on the first adapter will set it in state and keep it cached.

https://github.com/shapeshift/web/blob/06dd95458aa699bcce94682b48fcaea7506cbfcd/src/context/WalletProvider/WalletProvider.tsx#L360-L361

This untangles the KeepKey `<Connect />` spaghetti and ensure we never attempt getting the first KeepKey rest adapter in case we have no `sdk`, meaning we're not the context of KK desktop, and don't need this adapter at all.

## Pull Request Type

- [ ] :bug: Bug fix (Non-breaking Change: Fixes an issue)
- [ ] :hammer_and_wrench: Chore (Non-breaking Change: Doc updates, pkg upgrades, typos, etc..)
- [x] :nail_care: New Feature (Breaking/Non-breaking Change)

## Issue (if applicable)

N/A, though relates to the recent hdwallet perf. refactor

## Risk

<!-----------------------------------------------------------------------------
Outline the scope of your changes and the risk associated with them. You must use your discretion as an engineer to determine the potential impact of your changes.

E.g. an upgrade to `hdwallet` or core state management would be considered higher risk, and might require a full regression test. UI or isolated view changes, or something behind a feature flag may have near zero risk. Small bug fixes might require testing isolated to the specific fix.
------------------------------------------------------------------------------>

Theoretically low, this should fix things, not bring regressions - ensure KK is happy against prod

## Testing

<!-----------------------------------------------------------------------------
We treat every PR to be merged with the same scrutiny as if we were merging directly to production.

Your PR will not be merged if you do not complete the sections below for our engineering and operations teams to test.
------------------------------------------------------------------------------>

- Ensure KK connection shows no regressions against prod

### Engineering

<!-----------------------------------------------------------------------------
Include sufficient information here for an engineer to test your PR. This may include how to test locally, in a built environment, changes to infrastructure etc.
------------------------------------------------------------------------------>

- ☝🏽 

### Operations

<!-----------------------------------------------------------------------------
If your changes have a user-facing impact, describe how a non-technical QA team can functionally test your changes in a preview environment.

If they are not user-facing please describe how to test for any regressions that may occur.
------------------------------------------------------------------------------>

- ☝🏽 

## Screenshots (if applicable)

<img width="1114" alt="Screenshot 2023-10-19 at 18 40 30" src="https://github.com/shapeshift/web/assets/17035424/5304b476-d627-4e3d-9e9a-7c3bc719fd5d">
<img width="1126" alt="Screenshot 2023-10-19 at 18 37 06" src="https://github.com/shapeshift/web/assets/17035424/9bdc6a14-ae0b-447b-8615-2e0f39be2101">