### PR TITLE
fix: bch Ledger address verify

### DIFF
--- a/packages/chain-adapters/src/utxo/UtxoBaseAdapter.ts
+++ b/packages/chain-adapters/src/utxo/UtxoBaseAdapter.ts
@@ -11,6 +11,7 @@ import {
   BTCOutputAddressType,
   supportsBTC,
 } from '@shapeshiftoss/hdwallet-core'
+import { isLedger } from '@shapeshiftoss/hdwallet-ledger'
 import type { BIP44Params } from '@shapeshiftoss/types'
 import { KnownChainIds, UtxoAccountType } from '@shapeshiftoss/types'
 import type * as unchained from '@shapeshiftoss/unchained-client'
@@ -255,7 +256,7 @@ export abstract class UtxoBaseAdapter<T extends UtxoChainId> implements IChainAd
         addressNList: toAddressNList({ ...bip44Params, index: maybeNextIndex }),
         coin: this.coinName,
         scriptType:
-          this.coinName === 'BitcoinCash'
+          this.coinName === 'BitcoinCash' && isLedger(wallet)
             ? BTCInputScriptType.CashAddr
             : accountTypeToScriptType[accountType],
         showDisplay: showOnDevice,

--- a/packages/chain-adapters/src/utxo/UtxoBaseAdapter.ts
+++ b/packages/chain-adapters/src/utxo/UtxoBaseAdapter.ts
@@ -7,6 +7,7 @@ import type {
 } from '@shapeshiftoss/hdwallet-core'
 import {
   bip32ToAddressNList,
+  BTCInputScriptType,
   BTCOutputAddressType,
   supportsBTC,
 } from '@shapeshiftoss/hdwallet-core'
@@ -253,7 +254,10 @@ export abstract class UtxoBaseAdapter<T extends UtxoChainId> implements IChainAd
       const address = await wallet.btcGetAddress({
         addressNList: toAddressNList({ ...bip44Params, index: maybeNextIndex }),
         coin: this.coinName,
-        scriptType: accountTypeToScriptType[accountType],
+        scriptType:
+          this.coinName === 'BitcoinCash'
+            ? BTCInputScriptType.CashAddr
+            : accountTypeToScriptType[accountType],
         showDisplay: showOnDevice,
       })
 


### PR DESCRIPTION
## Description

Passes the correct `scriptType` for BitcoinCash in `getAddress` down the line, instead of having Ledger give us a Legacy address then converting it into a CashAddr. This works in most cases UX-wise, but won't cut it when actually verifying addresses on the device, since Legacy will be used, and users would be confused as to why verification passed despite address being different (or simply refuse continuing since, well those are different).


## Pull Request Type

- [x] :bug: Bug fix (Non-breaking Change: Fixes an issue)
- [ ] :hammer_and_wrench: Chore (Non-breaking Change: Doc updates, pkg upgrades, typos, etc..)
- [ ] :nail_care: New Feature (Breaking/Non-breaking Change)

## Issue (if applicable)

<!-----------------------------------------------------------------------------
If applicable, please link to the github issue and put `closes #XXXX` in your comment to auto-close the issue that your PR fixes.
------------------------------------------------------------------------------>

closes #

## Risk

<!-----------------------------------------------------------------------------
Outline the scope of your changes and the risk associated with them. You must use your discretion as an engineer to determine the potential impact of your changes.

E.g. an upgrade to `hdwallet` or core state management would be considered higher risk, and might require a full regression test. UI or isolated view changes, or something behind a feature flag may have near zero risk. Small bug fixes might require testing isolated to the specific fix.
------------------------------------------------------------------------------>

None - now in Ledger-land only (bec83f9fe3791d6ac141dc51801b441f07156d9f) since this was causing native regressions

~~Moderate - specifying a cashaddr `scriptType` should be a no-op, but receive address for all BCH-supporting wallets should be tested~~

## Testing

<!-----------------------------------------------------------------------------
We treat every PR to be merged with the same scrutiny as if we were merging directly to production.

Your PR will not be merged if you do not complete the sections below for our engineering and operations teams to test.
------------------------------------------------------------------------------>

- Verify your BCH address in Ledger
- Ensure the address you see is the same as the one on the device

- Ensure BCH addresses as well as address verification is showing no regression in native

### Engineering

<!-----------------------------------------------------------------------------
Include sufficient information here for an engineer to test your PR. This may include how to test locally, in a built environment, changes to infrastructure etc.
------------------------------------------------------------------------------>

 - ☝🏽 
 
### Operations

<!-----------------------------------------------------------------------------
If your changes have a user-facing impact, describe how a non-technical QA team can functionally test your changes in a preview environment.

If they are not user-facing please describe how to test for any regressions that may occur.
------------------------------------------------------------------------------>

 - ☝🏽 

## Screenshots (if applicable)

- Native

<img width="486" alt="image" src="https://github.com/shapeshift/web/assets/17035424/4eedb398-e768-4a08-810f-98066ba0b777">


- Ledger

<img width="479" alt="image" src="https://github.com/shapeshift/web/assets/17035424/30e1ba61-c828-446c-8cd1-a0efeead35fb">
<img width="496" alt="image" src="https://github.com/shapeshift/web/assets/17035424/69ece568-e8f7-4bc1-beac-f976ad21592d">
