### PR TITLE
fix: const ZapperDisplayPropsSchema

### DIFF
--- a/src/state/apis/zapper/validators.ts
+++ b/src/state/apis/zapper/validators.ts
@@ -90,12 +90,15 @@ const ZapperDisplayPropsSchema = z.union([
   z.object({
     label: z.string(),
     images: z.array(z.string()),
-    statsItems: z.array(
-      z.object({
-        label: z.string(),
-        value: ZapperDisplayValue,
-      }),
-    ),
+    statsItems: z
+      .array(
+        z.object({
+          label: z.string(),
+          value: ZapperDisplayValue,
+        }),
+      )
+      .nullable()
+      .optional(),
     secondaryLabel: ZapperDisplayValue.optional(),
     tertiaryLabel: ZapperDisplayValue.optional(),
     balanceDisplayMode: z.string().optional(),


### PR DESCRIPTION
## Description

Makes `statsItems` of `ZapperDisplayPropsSchema` `.nullable().optional()`.

Fixes the console error:

<img width="797" alt="Screenshot 2023-10-27 at 3 21 39 pm" src="https://github.com/shapeshift/web/assets/97164662/ed057819-41e2-4787-98c4-50fb391e04c9">

## Pull Request Type

- [x] :bug: Bug fix (Non-breaking Change: Fixes an issue)
- [ ] :hammer_and_wrench: Chore (Non-breaking Change: Doc updates, pkg upgrades, typos, etc..)
- [ ] :nail_care: New Feature (Breaking/Non-breaking Change)

## Issue (if applicable)

N/A

## Risk

Small 

## Testing

We shouldn't see the error above in the console..

### Engineering

☝️

### Operations

☝️

## Screenshots (if applicable)

N/A