### PR TITLE
perf: move supported asset fetch into rtk query endpoint

### DIFF
--- a/src/components/MultiHopTrade/hooks/useSupportedAssets.tsx
+++ b/src/components/MultiHopTrade/hooks/useSupportedAssets.tsx
@@ -1,59 +1,34 @@
-import type { AssetId } from '@shapeshiftoss/caip'
-import { fromAssetId } from '@shapeshiftoss/caip'
-import { useEffect, useMemo, useState } from 'react'
+import { KnownChainIds } from '@shapeshiftoss/types'
+import { useMemo } from 'react'
 import { useIsSnapInstalled } from 'hooks/useIsSnapInstalled/useIsSnapInstalled'
 import { useWallet } from 'hooks/useWallet/useWallet'
 import { walletSupportsChain } from 'hooks/useWalletSupportsChain/useWalletSupportsChain'
-import type { Asset } from 'lib/asset-service'
-import { getSupportedBuyAssetIds, getSupportedSellAssetIds } from 'lib/swapper/swapper'
-import { getEnabledSwappers } from 'lib/swapper/utils'
+import { useGetSupportedAssetsQuery } from 'state/apis/swappers/swappersApi'
 import { selectAssetsSortedByMarketCapUserCurrencyBalanceAndName } from 'state/slices/common-selectors'
-import { selectAssets, selectFeatureFlags, selectSellAsset } from 'state/slices/selectors'
 import { useAppSelector } from 'state/store'
 
 export const useSupportedAssets = () => {
-  const sellAsset = useAppSelector(selectSellAsset)
-  const assets = useAppSelector(selectAssets)
   const sortedAssets = useAppSelector(selectAssetsSortedByMarketCapUserCurrencyBalanceAndName)
-  const featureFlags = useAppSelector(selectFeatureFlags)
   const wallet = useWallet().state.wallet
-
-  const enabledSwappers = useMemo(() => getEnabledSwappers(featureFlags, false), [featureFlags])
-
-  const [supportedSellAssets, setSupportedSellAssets] = useState<Asset[]>([])
-  const [supportedSellAssetIds, setSupportedSellAssetIds] = useState<Set<AssetId>>(new Set())
-  const [supportedBuyAssets, setSupportedBuyAssets] = useState<Asset[]>([])
-  const [supportedBuyAssetsIds, setSupportedBuyAssetsIds] = useState<Set<AssetId>>(new Set())
-
   const isSnapInstalled = useIsSnapInstalled()
-  useEffect(() => {
-    ;(async () => {
-      const assetIds = await getSupportedSellAssetIds(enabledSwappers, assets)
-      const filteredAssetIds = new Set<AssetId>()
-      assetIds.forEach(assetId => {
-        const chainId = fromAssetId(assetId).chainId
-        if (walletSupportsChain({ chainId, wallet, isSnapInstalled })) {
-          filteredAssetIds.add(assetId)
-        }
-      })
-      setSupportedSellAssetIds(filteredAssetIds)
-    })()
-  }, [assets, enabledSwappers, isSnapInstalled, sortedAssets, wallet])
 
-  useEffect(() => {
-    ;(async () => {
-      const assetIds = await getSupportedBuyAssetIds(enabledSwappers, sellAsset, assets)
-      setSupportedBuyAssetsIds(assetIds)
-    })()
-  }, [assets, enabledSwappers, sellAsset, sortedAssets])
+  const walletSupportedChains = useMemo(() => {
+    return Object.values(KnownChainIds).filter(chainId =>
+      walletSupportsChain({ chainId, wallet, isSnapInstalled }),
+    )
+  }, [isSnapInstalled, wallet])
 
-  useEffect(() => {
-    setSupportedSellAssets(sortedAssets.filter(asset => supportedSellAssetIds.has(asset.assetId)))
-  }, [supportedSellAssetIds, enabledSwappers, sortedAssets])
+  const { data } = useGetSupportedAssetsQuery(walletSupportedChains)
 
-  useEffect(() => {
-    setSupportedBuyAssets(sortedAssets.filter(asset => supportedBuyAssetsIds.has(asset.assetId)))
-  }, [supportedBuyAssetsIds, enabledSwappers, sortedAssets])
+  const supportedSellAssets = useMemo(() => {
+    if (data === undefined) return []
+    return sortedAssets.filter(asset => data.supportedSellAssetIds.includes(asset.assetId))
+  }, [data, sortedAssets])
+
+  const supportedBuyAssets = useMemo(() => {
+    if (data === undefined) return []
+    return sortedAssets.filter(asset => data.supportedBuyAssetsIds.includes(asset.assetId))
+  }, [data, sortedAssets])
 
   return {
     supportedSellAssets,


### PR DESCRIPTION
## Description

Switching between pages and trade page triggers re-fetch of supported assets due to lack of caching as components unmount and remount. Each page switch was causing all swappers to fetch their supported asset list, resulting in 4 api calls made each time the trade input remounted.

This PR moves the concern of fetching supported assets into an RTK query endpoint so we can take advantage of caching.

## Pull Request Type

- [ ] :bug: Bug fix (Non-breaking Change: Fixes an issue)
- [x] :hammer_and_wrench: Chore (Non-breaking Change: Doc updates, pkg upgrades, typos, etc..)
- [ ] :nail_care: New Feature (Breaking/Non-breaking Change)

## Issue (if applicable)

Relates to (but doesnt close) #5449

## Risk

Risk of incorrect supported asset list in trade input

## Testing

Check asset list is correct between different page changes and different page reloads.

### Engineering

<!-----------------------------------------------------------------------------
Include sufficient information here for an engineer to test your PR. This may include how to test locally, in a built environment, changes to infrastructure etc.
------------------------------------------------------------------------------>

### Operations

<!-----------------------------------------------------------------------------
If your changes have a user-facing impact, describe how a non-technical QA team can functionally test your changes in a preview environment.

If they are not user-facing please describe how to test for any regressions that may occur.
------------------------------------------------------------------------------>

## Screenshots (if applicable)
