### PR TITLE
perf: better asset filtering for faster page load on trade page

### DIFF
--- a/src/components/MultiHopTrade/hooks/useSupportedAssets.tsx
+++ b/src/components/MultiHopTrade/hooks/useSupportedAssets.tsx
@@ -3,32 +3,38 @@ import { useMemo } from 'react'
 import { useIsSnapInstalled } from 'hooks/useIsSnapInstalled/useIsSnapInstalled'
 import { useWallet } from 'hooks/useWallet/useWallet'
 import { walletSupportsChain } from 'hooks/useWalletSupportsChain/useWalletSupportsChain'
+import { isSome } from 'lib/utils'
 import { useGetSupportedAssetsQuery } from 'state/apis/swappers/swappersApi'
 import { selectAssetsSortedByMarketCapUserCurrencyBalanceAndName } from 'state/slices/common-selectors'
+import { selectAssets } from 'state/slices/selectors'
 import { useAppSelector } from 'state/store'
 
 export const useSupportedAssets = () => {
   const sortedAssets = useAppSelector(selectAssetsSortedByMarketCapUserCurrencyBalanceAndName)
+  const assets = useAppSelector(selectAssets)
   const wallet = useWallet().state.wallet
   const isSnapInstalled = useIsSnapInstalled()
 
-  const walletSupportedChains = useMemo(() => {
-    return Object.values(KnownChainIds).filter(chainId =>
-      walletSupportsChain({ chainId, wallet, isSnapInstalled }),
-    )
-  }, [isSnapInstalled, wallet])
+  const queryParams = useMemo(() => {
+    return {
+      walletSupportedChains: Object.values(KnownChainIds).filter(chainId =>
+        walletSupportsChain({ chainId, wallet, isSnapInstalled }),
+      ),
+      sortedAssetIds: sortedAssets.map(asset => asset.assetId),
+    }
+  }, [isSnapInstalled, sortedAssets, wallet])
 
-  const { data, isLoading } = useGetSupportedAssetsQuery(walletSupportedChains)
+  const { data, isLoading } = useGetSupportedAssetsQuery(queryParams)
 
   const supportedSellAssets = useMemo(() => {
-    if (data === undefined) return []
-    return sortedAssets.filter(asset => data.supportedSellAssetIds.includes(asset.assetId))
-  }, [data, sortedAssets])
+    if (!data) return []
+    return data.supportedSellAssetIds.map(assetId => assets[assetId]).filter(isSome)
+  }, [assets, data])
 
   const supportedBuyAssets = useMemo(() => {
-    if (data === undefined) return []
-    return sortedAssets.filter(asset => data.supportedBuyAssetsIds.includes(asset.assetId))
-  }, [data, sortedAssets])
+    if (!data) return []
+    return data.supportedBuyAssetIds.map(assetId => assets[assetId]).filter(isSome)
+  }, [assets, data])
 
   return {
     isLoading,


### PR DESCRIPTION
## Description

Improves trade page load/switch time by around 700ms on desktop (benched on m2 mac). Issue was O(n^2) filtering of supported assets, now O(n logn) through use of sets while avoiding serialization cost of passing complete asset structs into rtk query.

## Pull Request Type

- [ ] :bug: Bug fix (Non-breaking Change: Fixes an issue)
- [x] :hammer_and_wrench: Chore (Non-breaking Change: Doc updates, pkg upgrades, typos, etc..)
- [ ] :nail_care: New Feature (Breaking/Non-breaking Change)

## Issue (if applicable)

<!-----------------------------------------------------------------------------
If applicable, please link to the github issue and put `closes #XXXX` in your comment to auto-close the issue that your PR fixes.
------------------------------------------------------------------------------>

closes #5449

## Risk

Low risk of incorrect supported asset list on trade page (the asset list dropdowns).

## Testing

<!-----------------------------------------------------------------------------
We treat every PR to be merged with the same scrutiny as if we were merging directly to production.

Your PR will not be merged if you do not complete the sections below for our engineering and operations teams to test.
------------------------------------------------------------------------------>

Check supported assets are still correct.

### Engineering

<!-----------------------------------------------------------------------------
Include sufficient information here for an engineer to test your PR. This may include how to test locally, in a built environment, changes to infrastructure etc.
------------------------------------------------------------------------------>

### Operations

<!-----------------------------------------------------------------------------
If your changes have a user-facing impact, describe how a non-technical QA team can functionally test your changes in a preview environment.

If they are not user-facing please describe how to test for any regressions that may occur.
------------------------------------------------------------------------------>

## Screenshots (if applicable)

Develop branch - 789ms
![image](https://github.com/shapeshift/web/assets/125113430/82e9f95f-3884-4bb9-921f-615613d219a3)

This PR - 12ms
![image](https://github.com/shapeshift/web/assets/125113430/fbae480c-1349-413f-9e00-36b0fad8a895)
