### PR TITLE
fix: approvals failing for non-eth EVM chains

### DIFF
--- a/src/components/MultiHopTrade/hooks/useAllowanceApproval/helpers.ts
+++ b/src/components/MultiHopTrade/hooks/useAllowanceApproval/helpers.ts
@@ -72,6 +72,7 @@ export const getApprovalTxData = async ({
     approvalAmountCryptoBaseUnit,
     spender: tradeQuoteStep.allowanceContract,
     to: assetReference,
+    chainId: tradeQuoteStep.sellAsset.chainId,
   })
 
   const { networkFeeCryptoBaseUnit, ...fees } = await getFees({

--- a/src/contracts/contractManager.ts
+++ b/src/contracts/contractManager.ts
@@ -1,7 +1,11 @@
 import type { AssetId, ChainId } from '@shapeshiftoss/caip'
 import { fromAssetId, toAssetId } from '@shapeshiftoss/caip'
+import type { EvmChainId } from '@shapeshiftoss/chain-adapters'
+import { KnownChainIds } from '@shapeshiftoss/types'
 import type { Token } from '@uniswap/sdk'
 import { Fetcher } from '@uniswap/sdk'
+import type { PublicClient } from '@wagmi/core'
+import assert from 'assert'
 import { erc20ABI } from 'contracts/abis/ERC20ABI'
 import { FarmingABI } from 'contracts/abis/farmingAbi'
 import { IUniswapV2Pair } from 'contracts/abis/IUniswapV2Pair'
@@ -12,7 +16,7 @@ import memoize from 'lodash/memoize'
 import type { Address } from 'viem'
 import { getContract } from 'viem'
 import { getEthersProvider } from 'lib/ethersProviderSingleton'
-import { viemEthMainnetClient } from 'lib/viem-client'
+import { viemClientByChainId, viemEthMainnetClient } from 'lib/viem-client'
 
 import {
   ETH_FOX_POOL_CONTRACT_ADDRESS,
@@ -78,20 +82,24 @@ export const getOrCreateContractByAddress = <T extends KnownContractAddress>(
 export const getOrCreateContractByType = <T extends ContractType>({
   address,
   type,
-  // TODO(gomes): viem client by ChainId
-  chainId: _chainId,
+  chainId,
 }: {
   address: string | `0x${string}`
   type: T
-  chainId?: ChainId
+  chainId: ChainId
 }): KnownContractByType<T> => {
   const definedContract = definedContracts.find(contract => contract.address === address)
   if (definedContract && definedContract.contract)
     return definedContract.contract as unknown as KnownContractByType<T>
+
+  const publicClient = viemClientByChainId[chainId as EvmChainId]
+  assert(publicClient !== undefined, `no public client found for chainId '${chainId}'`)
+
   const contract = getContract({
     abi: CONTRACT_TYPE_TO_ABI[type],
     address: address as Address,
-    publicClient: viemEthMainnetClient,
+
+    publicClient: publicClient as PublicClient,
   })
   definedContracts.push({
     contract,
@@ -107,6 +115,7 @@ export const fetchUniV2PairData = memoize(async (pairAssetId: AssetId) => {
   const pair = getOrCreateContractByType({
     address: contractAddress,
     type: ContractType.UniV2Pair,
+    chainId: KnownChainIds.EthereumMainnet,
   })
   const ethersProvider = getEthersProvider()
 

--- a/src/contracts/contractManager.ts
+++ b/src/contracts/contractManager.ts
@@ -4,7 +4,6 @@ import type { EvmChainId } from '@shapeshiftoss/chain-adapters'
 import { KnownChainIds } from '@shapeshiftoss/types'
 import type { Token } from '@uniswap/sdk'
 import { Fetcher } from '@uniswap/sdk'
-import type { PublicClient } from '@wagmi/core'
 import assert from 'assert'
 import { erc20ABI } from 'contracts/abis/ERC20ABI'
 import { FarmingABI } from 'contracts/abis/farmingAbi'
@@ -99,7 +98,7 @@ export const getOrCreateContractByType = <T extends ContractType>({
     abi: CONTRACT_TYPE_TO_ABI[type],
     address: address as Address,
 
-    publicClient: publicClient as PublicClient,
+    publicClient,
   })
   definedContracts.push({
     contract,

--- a/src/features/defi/providers/thorchain-savers/components/ThorchainSaversManager/Deposit/components/Approve.tsx
+++ b/src/features/defi/providers/thorchain-savers/components/ThorchainSaversManager/Deposit/components/Approve.tsx
@@ -1,5 +1,6 @@
 import type { AccountId } from '@shapeshiftoss/caip'
 import { fromAccountId, fromAssetId, toAssetId } from '@shapeshiftoss/caip'
+import { KnownChainIds } from '@shapeshiftoss/types'
 import { getConfig } from 'config'
 import { getOrCreateContractByType } from 'contracts/contractManager'
 import { ContractType } from 'contracts/types'
@@ -143,6 +144,7 @@ export const Approve: React.FC<ApproveProps> = ({ accountId, onNext }) => {
       const contract = getOrCreateContractByType({
         address: fromAssetId(assetId).assetReference,
         type: ContractType.ERC20,
+        chainId: KnownChainIds.EthereumMainnet,
       })
 
       const amountToApprove = state.isExactAllowance ? amountCryptoBaseUnit : MAX_ALLOWANCE

--- a/src/features/defi/providers/thorchain-savers/components/ThorchainSaversManager/Deposit/components/Approve.tsx
+++ b/src/features/defi/providers/thorchain-savers/components/ThorchainSaversManager/Deposit/components/Approve.tsx
@@ -1,6 +1,5 @@
 import type { AccountId } from '@shapeshiftoss/caip'
 import { fromAccountId, fromAssetId, toAssetId } from '@shapeshiftoss/caip'
-import { KnownChainIds } from '@shapeshiftoss/types'
 import { getConfig } from 'config'
 import { getOrCreateContractByType } from 'contracts/contractManager'
 import { ContractType } from 'contracts/types'
@@ -144,7 +143,7 @@ export const Approve: React.FC<ApproveProps> = ({ accountId, onNext }) => {
       const contract = getOrCreateContractByType({
         address: fromAssetId(assetId).assetReference,
         type: ContractType.ERC20,
-        chainId: KnownChainIds.EthereumMainnet,
+        chainId,
       })
 
       const amountToApprove = state.isExactAllowance ? amountCryptoBaseUnit : MAX_ALLOWANCE

--- a/src/features/defi/providers/univ2/hooks/useUniV2LiquidityPool.ts
+++ b/src/features/defi/providers/univ2/hooks/useUniV2LiquidityPool.ts
@@ -2,6 +2,7 @@ import { MaxUint256 } from '@ethersproject/constants'
 import type { AccountId, AssetId } from '@shapeshiftoss/caip'
 import { ethAssetId, ethChainId, fromAccountId, fromAssetId, toAssetId } from '@shapeshiftoss/caip'
 import type { ethereum } from '@shapeshiftoss/chain-adapters'
+import { KnownChainIds } from '@shapeshiftoss/types'
 import {
   UNISWAP_V2_ROUTER_02_CONTRACT_ADDRESS,
   WETH_TOKEN_CONTRACT_ADDRESS,
@@ -98,6 +99,7 @@ export const useUniV2LiquidityPool = ({
       : getOrCreateContractByType({
           address: asset0ContractAddress,
           type: ContractType.ERC20,
+          chainId: KnownChainIds.EthereumMainnet,
         })
   }, [asset0ContractAddress, skip])
 
@@ -107,6 +109,7 @@ export const useUniV2LiquidityPool = ({
       : getOrCreateContractByType({
           address: asset1ContractAddress,
           type: ContractType.ERC20,
+          chainId: KnownChainIds.EthereumMainnet,
         })
   }, [asset1ContractAddress, skip])
 
@@ -116,6 +119,7 @@ export const useUniV2LiquidityPool = ({
       : getOrCreateContractByType({
           address: lpContractAddress,
           type: ContractType.UniV2Pair,
+          chainId: KnownChainIds.EthereumMainnet,
         })
   }, [lpContractAddress, skip])
 
@@ -445,6 +449,7 @@ export const useUniV2LiquidityPool = ({
       const contract = getOrCreateContractByType({
         address: contractAddress,
         type: ContractType.ERC20,
+        chainId: KnownChainIds.EthereumMainnet,
       })
 
       if (!contract) return
@@ -606,6 +611,7 @@ export const useUniV2LiquidityPool = ({
       const contract = getOrCreateContractByType({
         address: contractAddress,
         type: ContractType.ERC20,
+        chainId: KnownChainIds.EthereumMainnet,
       })
 
       if (!contract) return

--- a/src/lib/utils/evm.ts
+++ b/src/lib/utils/evm.ts
@@ -9,7 +9,7 @@ import type {
 import { evmChainIds } from '@shapeshiftoss/chain-adapters'
 import type { ETHSignTx, HDWallet } from '@shapeshiftoss/hdwallet-core'
 import { supportsETH } from '@shapeshiftoss/hdwallet-core'
-import type { KnownChainIds } from '@shapeshiftoss/types'
+import { KnownChainIds } from '@shapeshiftoss/types'
 import { TxStatus } from '@shapeshiftoss/unchained-client'
 import { getTxStatus } from '@shapeshiftoss/unchained-client/dist/evm'
 import { getOrCreateContractByType } from 'contracts/contractManager'
@@ -226,7 +226,11 @@ export const getApproveContractData = ({
   spender,
 }: GetApproveContractDataArgs): string => {
   const address = ethers.utils.getAddress(to)
-  const contract = getOrCreateContractByType({ address, type: ContractType.ERC20 })
+  const contract = getOrCreateContractByType({
+    address,
+    type: ContractType.ERC20,
+    chainId: KnownChainIds.EthereumMainnet,
+  })
   const data = encodeFunctionData({
     abi: contract.abi,
     functionName: 'approve',

--- a/src/lib/utils/evm.ts
+++ b/src/lib/utils/evm.ts
@@ -9,7 +9,7 @@ import type {
 import { evmChainIds } from '@shapeshiftoss/chain-adapters'
 import type { ETHSignTx, HDWallet } from '@shapeshiftoss/hdwallet-core'
 import { supportsETH } from '@shapeshiftoss/hdwallet-core'
-import { KnownChainIds } from '@shapeshiftoss/types'
+import type { KnownChainIds } from '@shapeshiftoss/types'
 import { TxStatus } from '@shapeshiftoss/unchained-client'
 import { getTxStatus } from '@shapeshiftoss/unchained-client/dist/evm'
 import { getOrCreateContractByType } from 'contracts/contractManager'
@@ -28,6 +28,7 @@ type GetApproveContractDataArgs = {
   approvalAmountCryptoBaseUnit: string
   to: string
   spender: string
+  chainId: ChainId
 }
 
 type BuildArgs = {
@@ -224,12 +225,13 @@ export const getApproveContractData = ({
   approvalAmountCryptoBaseUnit,
   to,
   spender,
+  chainId,
 }: GetApproveContractDataArgs): string => {
   const address = ethers.utils.getAddress(to)
   const contract = getOrCreateContractByType({
     address,
     type: ContractType.ERC20,
-    chainId: KnownChainIds.EthereumMainnet,
+    chainId,
   })
   const data = encodeFunctionData({
     abi: contract.abi,

--- a/src/lib/viem-client.ts
+++ b/src/lib/viem-client.ts
@@ -1,6 +1,9 @@
+import type { EvmChainId } from '@shapeshiftoss/chain-adapters'
+import { KnownChainIds } from '@shapeshiftoss/types'
 import { getConfig } from 'config'
+import type { PublicClient } from 'viem'
 import { createPublicClient, http } from 'viem'
-import { arbitrum, avalanche, bsc, gnosis, mainnet, optimism } from 'viem/chains'
+import { arbitrum, avalanche, bsc, gnosis, mainnet, optimism, polygon } from 'viem/chains'
 
 export const viemEthMainnetClient = createPublicClient({
   chain: mainnet,
@@ -31,3 +34,20 @@ export const viemGnosisClient = createPublicClient({
   chain: gnosis,
   transport: http(getConfig().REACT_APP_GNOSIS_NODE_URL),
 })
+
+export const viemPolygonClient = createPublicClient({
+  chain: polygon,
+  transport: http(getConfig().REACT_APP_POLYGON_NODE_URL),
+})
+
+export const viemClientByChainId: Record<EvmChainId, PublicClient> = {
+  [KnownChainIds.EthereumMainnet]: viemEthMainnetClient,
+  [KnownChainIds.BnbSmartChainMainnet]: viemBscClient,
+  [KnownChainIds.AvalancheMainnet]: viemAvalancheClient,
+  [KnownChainIds.ArbitrumMainnet]: viemArbitrumClient,
+  [KnownChainIds.GnosisMainnet]: viemGnosisClient,
+  [KnownChainIds.PolygonMainnet]: viemPolygonClient,
+  // cast required due to typescript shenanigans
+  // https://github.com/wagmi-dev/viem/issues/1018
+  [KnownChainIds.OptimismMainnet]: viemOptimismClient as PublicClient,
+}

--- a/src/state/slices/opportunitiesSlice/resolvers/uniV2/index.ts
+++ b/src/state/slices/opportunitiesSlice/resolvers/uniV2/index.ts
@@ -1,5 +1,5 @@
 import { ethAssetId, fromAssetId, toAssetId } from '@shapeshiftoss/caip'
-import type { MarketData } from '@shapeshiftoss/types'
+import { KnownChainIds, type MarketData } from '@shapeshiftoss/types'
 import type { TokenAmount } from '@uniswap/sdk'
 import { WETH_TOKEN_CONTRACT_ADDRESS } from 'contracts/constants'
 import { fetchUniV2PairData, getOrCreateContractByType } from 'contracts/contractManager'
@@ -196,6 +196,7 @@ export const uniV2LpOpportunitiesMetadataResolver = async ({
     const uniV2LPContract = getOrCreateContractByType({
       address: contractAddress,
       type: ContractType.UniV2Pair,
+      chainId: KnownChainIds.EthereumMainnet,
     })
     const apy = bnOrZero(apr).div(100).toString()
 

--- a/src/state/slices/opportunitiesSlice/resolvers/uniV2/utils.test.ts
+++ b/src/state/slices/opportunitiesSlice/resolvers/uniV2/utils.test.ts
@@ -2,6 +2,7 @@
  * @jest-environment node
  */
 
+import { KnownChainIds } from '@shapeshiftoss/types'
 import { Token, TokenAmount } from '@uniswap/sdk'
 import BigNumber from 'bignumber.js'
 import type { IUniswapV2Pair } from 'contracts/abis/IUniswapV2Pair'
@@ -19,25 +20,27 @@ const mockAmount0In = '23000000000000000000000'
 const blockNumber = 5000000
 
 jest.mock('lib/viem-client', () => ({
-  viemEthMainnetClient: {
-    createEventFilter: jest.fn(() => ({})),
-    getFilterLogs: () =>
-      new Promise(resolve => {
-        resolve([
-          {
-            args: {
-              amount0Out: mockAmount0Out,
-              amount1In: '100000000000000000000',
+  viemClientByChainId: {
+    [KnownChainIds.EthereumMainnet]: {
+      createEventFilter: jest.fn(() => ({})),
+      getFilterLogs: () =>
+        new Promise(resolve => {
+          resolve([
+            {
+              args: {
+                amount0Out: mockAmount0Out,
+                amount1In: '100000000000000000000',
+              },
             },
-          },
-          {
-            args: {
-              amount0In: mockAmount0In,
-              amount1Out: '223100000000000000000',
+            {
+              args: {
+                amount0In: mockAmount0In,
+                amount1Out: '223100000000000000000',
+              },
             },
-          },
-        ])
-      }),
+          ])
+        }),
+    },
   },
 }))
 

--- a/src/state/slices/opportunitiesSlice/resolvers/uniV2/utils.test.ts
+++ b/src/state/slices/opportunitiesSlice/resolvers/uniV2/utils.test.ts
@@ -2,7 +2,6 @@
  * @jest-environment node
  */
 
-import { KnownChainIds } from '@shapeshiftoss/types'
 import { Token, TokenAmount } from '@uniswap/sdk'
 import BigNumber from 'bignumber.js'
 import type { IUniswapV2Pair } from 'contracts/abis/IUniswapV2Pair'
@@ -19,30 +18,35 @@ const mockAmount0Out = '97000000000000000000000'
 const mockAmount0In = '23000000000000000000000'
 const blockNumber = 5000000
 
-jest.mock('lib/viem-client', () => ({
-  viemClientByChainId: {
-    [KnownChainIds.EthereumMainnet]: {
-      createEventFilter: jest.fn(() => ({})),
-      getFilterLogs: () =>
-        new Promise(resolve => {
-          resolve([
-            {
-              args: {
-                amount0Out: mockAmount0Out,
-                amount1In: '100000000000000000000',
-              },
+jest.mock('lib/viem-client', () => {
+  const { KnownChainIds } = require('@shapeshiftoss/types')
+  const viemEthMainnetClient = {
+    createEventFilter: jest.fn(() => ({})),
+    getFilterLogs: () =>
+      new Promise(resolve => {
+        resolve([
+          {
+            args: {
+              amount0Out: mockAmount0Out,
+              amount1In: '100000000000000000000',
             },
-            {
-              args: {
-                amount0In: mockAmount0In,
-                amount1Out: '223100000000000000000',
-              },
+          },
+          {
+            args: {
+              amount0In: mockAmount0In,
+              amount1Out: '223100000000000000000',
             },
-          ])
-        }),
+          },
+        ])
+      }),
+  }
+  return {
+    viemEthMainnetClient,
+    viemClientByChainId: {
+      [KnownChainIds.EthereumMainnet]: viemEthMainnetClient,
     },
-  },
-}))
+  }
+})
 
 const mockContract = getContract({
   abi: [],

--- a/src/state/slices/opportunitiesSlice/resolvers/uniV2/utils.ts
+++ b/src/state/slices/opportunitiesSlice/resolvers/uniV2/utils.ts
@@ -1,5 +1,6 @@
 import type { AssetId } from '@shapeshiftoss/caip'
 import { fromAssetId } from '@shapeshiftoss/caip'
+import { KnownChainIds } from '@shapeshiftoss/types'
 import type { TokenAmount } from '@uniswap/sdk'
 import type { IUniswapV2Pair } from 'contracts/abis/IUniswapV2Pair'
 import { getOrCreateContractByType } from 'contracts/contractManager'
@@ -108,6 +109,7 @@ export const calculateAPRFromToken0 = memoize(
     const pair = getOrCreateContractByType({
       address: contractAddress,
       type: ContractType.UniV2Pair,
+      chainId: KnownChainIds.EthereumMainnet,
     })
 
     const token0Volume24Hr = await getToken0Volume24Hr({


### PR DESCRIPTION
## Description

Fixes broken ERC20 allowance approvals for non-eth EVM chains. 

## Pull Request Type

- [x] :bug: Bug fix (Non-breaking Change: Fixes an issue)
- [ ] :hammer_and_wrench: Chore (Non-breaking Change: Doc updates, pkg upgrades, typos, etc..)
- [ ] :nail_care: New Feature (Breaking/Non-breaking Change)

## Issue (if applicable)

<!-----------------------------------------------------------------------------
If applicable, please link to the github issue and put `closes #XXXX` in your comment to auto-close the issue that your PR fixes.
------------------------------------------------------------------------------>

closes #5571
closes #5573
closes #5574

## Risk

Risk of approvals still broken for EVM chains

## Testing

Check approvals work for all EVM chains

### Engineering

Note that this includes a fix to use the viem public client per chain, and I've hardcoded all other uses of the function to use ETH mainnet. Please double check this is correct for all cases where i've hardcoded it.

### Operations

<!-----------------------------------------------------------------------------
If your changes have a user-facing impact, describe how a non-technical QA team can functionally test your changes in a preview environment.

If they are not user-facing please describe how to test for any regressions that may occur.
------------------------------------------------------------------------------>

## Screenshots (if applicable)

FOX/ETH LP appearing also
![image](https://github.com/shapeshift/web/assets/125113430/04cd1de1-13c0-4ed1-8ade-91d372829b8c)
