### PR TITLE
feat: added draft footer for multihop trade confirm

### DIFF
--- a/src/components/MultiHopTrade/components/MultiHopTradeConfirm/MultiHopTradeConfirm.tsx
+++ b/src/components/MultiHopTrade/components/MultiHopTradeConfirm/MultiHopTradeConfirm.tsx
@@ -1,27 +1,37 @@
 import { Card, CardBody, CardHeader, Heading, Stack } from '@chakra-ui/react'
 import { memo, useCallback } from 'react'
+import { useHistory } from 'react-router-dom'
 import { WithBackButton } from 'components/MultiHopTrade/components/WithBackButton'
+import { TradeRoutePaths } from 'components/MultiHopTrade/types'
 import { SlideTransition } from 'components/SlideTransition'
 import { Text } from 'components/Text'
+import { swappers as swappersSlice } from 'state/slices/swappersSlice/swappersSlice'
 import {
   selectActiveSwapperName,
   selectFirstHop,
   selectIsActiveQuoteMultiHop,
   selectLastHop,
 } from 'state/slices/tradeQuoteSlice/selectors'
-import { useAppSelector } from 'state/store'
+import { useAppDispatch, useAppSelector } from 'state/store'
 
 import { FirstHop } from './components/FirstHop'
+import { Footer } from './components/Footer'
 import { SecondHop } from './components/SecondHop'
 
 const cardBorderRadius = { base: 'xl' }
 
 export const MultiHopTradeConfirm = memo(() => {
-  const handleBack = useCallback(() => {}, [])
+  const dispatch = useAppDispatch()
   const swapperName = useAppSelector(selectActiveSwapperName)
   const firstHop = useAppSelector(selectFirstHop)
   const lastHop = useAppSelector(selectLastHop)
   const isMultiHopTrade = useAppSelector(selectIsActiveQuoteMultiHop)
+  const history = useHistory()
+
+  const handleBack = useCallback(() => {
+    dispatch(swappersSlice.actions.clear())
+    history.push(TradeRoutePaths.Input)
+  }, [dispatch, history])
 
   if (!firstHop || !swapperName) return null
 
@@ -48,6 +58,7 @@ export const MultiHopTradeConfirm = memo(() => {
           </Stack>
         </CardBody>
       </Card>
+      <Footer />
     </SlideTransition>
   )
 })

--- a/src/components/MultiHopTrade/components/MultiHopTradeConfirm/components/FirstHop.tsx
+++ b/src/components/MultiHopTrade/components/MultiHopTradeConfirm/components/FirstHop.tsx
@@ -59,6 +59,7 @@ export const FirstHop = ({
   const activeStep = useMemo(() => {
     switch (tradeExecutionStatus) {
       case MultiHopExecutionStatus.Unknown:
+      case MultiHopExecutionStatus.Previewing:
         return -Infinity
       case MultiHopExecutionStatus.Hop1AwaitingApprovalConfirmation:
       case MultiHopExecutionStatus.Hop1AwaitingApprovalExecution:

--- a/src/components/MultiHopTrade/components/MultiHopTradeConfirm/components/Footer.tsx
+++ b/src/components/MultiHopTrade/components/MultiHopTradeConfirm/components/Footer.tsx
@@ -1,0 +1,141 @@
+import {
+  Alert,
+  AlertDescription,
+  AlertIcon,
+  AlertTitle,
+  Button,
+  CardFooter,
+  Flex,
+  Stack,
+} from '@chakra-ui/react'
+import { useCallback, useMemo } from 'react'
+import { useTranslate } from 'react-polyglot'
+import { usePriceImpact } from 'components/MultiHopTrade/hooks/quoteValidation/usePriceImpact'
+import { chainSupportsTxHistory } from 'components/MultiHopTrade/utils'
+import { Text } from 'components/Text'
+import type { TextPropTypes } from 'components/Text/Text'
+import { bnOrZero } from 'lib/bignumber/bignumber'
+import { SwapperName } from 'lib/swapper/types'
+import { selectTradeExecutionStatus } from 'state/slices/swappersSlice/selectors'
+import { swappers as swappersSlice } from 'state/slices/swappersSlice/swappersSlice'
+import { MultiHopExecutionStatus } from 'state/slices/swappersSlice/types'
+import {
+  selectActiveSwapperName,
+  selectLastHopBuyAsset,
+  selectSellAmountUserCurrency,
+  selectTotalNetworkFeeUserCurrencyPrecision,
+} from 'state/slices/tradeQuoteSlice/selectors'
+import { useAppDispatch, useAppSelector } from 'state/store'
+
+export const Footer = () => {
+  const translate = useTranslate()
+  const dispatch = useAppDispatch()
+  const swapperName = useAppSelector(selectActiveSwapperName)
+  const lastHopBuyAsset = useAppSelector(selectLastHopBuyAsset)
+  const tradeExecutionStatus = useAppSelector(selectTradeExecutionStatus)
+  const networkFeeUserCurrency = useAppSelector(selectTotalNetworkFeeUserCurrencyPrecision)
+  const sellAmountBeforeFeesUserCurrency = useAppSelector(selectSellAmountUserCurrency)
+  const { isModeratePriceImpact } = usePriceImpact()
+
+  const handleConfirm = useCallback(() => {
+    dispatch(swappersSlice.actions.incrementTradeExecutionState())
+  }, [dispatch])
+
+  const networkFeeToTradeRatioPercentage = useMemo(
+    () =>
+      bnOrZero(networkFeeUserCurrency)
+        .dividedBy(sellAmountBeforeFeesUserCurrency ?? 1)
+        .times(100)
+        .toNumber(),
+    [networkFeeUserCurrency, sellAmountBeforeFeesUserCurrency],
+  )
+
+  // Ratio of the fiat value of the gas fee to the fiat value of the trade value express in percentage
+  const isFeeRatioOverThreshold = useMemo(() => {
+    const networkFeeToTradeRatioPercentageThreshold = 5
+    return networkFeeToTradeRatioPercentage > networkFeeToTradeRatioPercentageThreshold
+  }, [networkFeeToTradeRatioPercentage])
+
+  const gasFeeExceedsTradeAmountThresholdTranslation: TextPropTypes['translation'] = useMemo(
+    () => [
+      'trade.gasFeeExceedsTradeAmountThreshold',
+      { percentage: networkFeeToTradeRatioPercentage.toFixed(0) },
+    ],
+    [networkFeeToTradeRatioPercentage],
+  )
+
+  const tradeWarning: JSX.Element | null = useMemo(() => {
+    const isSlowSwapper =
+      swapperName &&
+      [SwapperName.Thorchain, SwapperName.CowSwap, SwapperName.LIFI].includes(swapperName)
+
+    const isTxHistorySupportedForChain =
+      lastHopBuyAsset && chainSupportsTxHistory(lastHopBuyAsset.chainId)
+
+    const shouldRenderWarnings = isSlowSwapper || !isTxHistorySupportedForChain
+
+    if (!shouldRenderWarnings) return null
+
+    return (
+      <Flex direction='column' gap={2}>
+        {isSlowSwapper && (
+          <Alert status='info' width='auto' fontSize='sm'>
+            <AlertIcon />
+            <Stack spacing={0}>
+              <AlertTitle>{translate('trade.slowSwapTitle', { protocol: swapperName })}</AlertTitle>
+              <AlertDescription lineHeight='short'>
+                {translate('trade.slowSwapBody')}
+              </AlertDescription>
+            </Stack>
+          </Alert>
+        )}
+        {!isTxHistorySupportedForChain && (
+          <Alert status='info' width='auto' mb={3} fontSize='sm'>
+            <AlertIcon />
+            <Stack spacing={0}>
+              <AlertDescription lineHeight='short'>
+                {translate('trade.intoAssetSymbolBody', {
+                  assetSymbol: lastHopBuyAsset?.symbol,
+                })}
+              </AlertDescription>
+            </Stack>
+          </Alert>
+        )}
+      </Flex>
+    )
+  }, [swapperName, lastHopBuyAsset, translate])
+
+  return (
+    <CardFooter flexDir='column' gap={2} px={4}>
+      {tradeExecutionStatus === MultiHopExecutionStatus.Previewing && (
+        <>
+          {tradeWarning}
+          {swapperName === SwapperName.LIFI && (
+            <Alert status='warning' size='sm'>
+              <AlertIcon />
+              <AlertDescription>{translate('trade.lifiWarning')}</AlertDescription>
+            </Alert>
+          )}
+          {isFeeRatioOverThreshold && (
+            <Alert status='warning' size='sm'>
+              <AlertIcon />
+              <AlertDescription>
+                <Text translation={gasFeeExceedsTradeAmountThresholdTranslation} />
+              </AlertDescription>
+            </Alert>
+          )}
+          <Button
+            colorScheme={isModeratePriceImpact ? 'red' : 'blue'}
+            size='lg'
+            width='full'
+            onClick={handleConfirm}
+          >
+            <Text
+              translation={isModeratePriceImpact ? 'trade.tradeAnyway' : 'trade.confirmAndTrade'}
+            />
+          </Button>
+        </>
+      )}
+    </CardFooter>
+  )
+}

--- a/src/components/MultiHopTrade/components/MultiHopTradeConfirm/components/SecondHop.tsx
+++ b/src/components/MultiHopTrade/components/MultiHopTradeConfirm/components/SecondHop.tsx
@@ -55,6 +55,7 @@ export const SecondHop = ({
   const activeStep = useMemo(() => {
     switch (tradeExecutionStatus) {
       case MultiHopExecutionStatus.Unknown:
+      case MultiHopExecutionStatus.Previewing:
       case MultiHopExecutionStatus.Hop1AwaitingApprovalConfirmation:
       case MultiHopExecutionStatus.Hop1AwaitingApprovalExecution:
       case MultiHopExecutionStatus.Hop1AwaitingTradeConfirmation:

--- a/src/state/slices/swappersSlice/swappersSlice.ts
+++ b/src/state/slices/swappersSlice/swappersSlice.ts
@@ -29,7 +29,7 @@ const initialState: SwappersState = {
   sellAssetAccountId: undefined,
   buyAssetAccountId: undefined,
   sellAmountCryptoPrecision: '0',
-  tradeExecutionStatus: MultiHopExecutionStatus.Hop1AwaitingApprovalConfirmation,
+  tradeExecutionStatus: MultiHopExecutionStatus.Previewing,
   willDonate: true,
   manualReceiveAddress: undefined,
   manualReceiveAddressIsValidating: false,

--- a/src/state/slices/swappersSlice/types.ts
+++ b/src/state/slices/swappersSlice/types.ts
@@ -1,12 +1,14 @@
+// NOTE: order here matters, and the values must be numeric.
 export enum MultiHopExecutionStatus {
   Unknown = 0,
-  Hop1AwaitingApprovalConfirmation = 1,
-  Hop1AwaitingApprovalExecution = 2,
-  Hop1AwaitingTradeConfirmation = 3,
-  Hop1AwaitingTradeExecution = 4,
-  Hop2AwaitingApprovalConfirmation = 5,
-  Hop2AwaitingApprovalExecution = 6,
-  Hop2AwaitingTradeConfirmation = 7,
-  Hop2AwaitingTradeExecution = 8,
-  TradeComplete = 9,
+  Previewing = 1,
+  Hop1AwaitingApprovalConfirmation = 2,
+  Hop1AwaitingApprovalExecution = 3,
+  Hop1AwaitingTradeConfirmation = 4,
+  Hop1AwaitingTradeExecution = 5,
+  Hop2AwaitingApprovalConfirmation = 6,
+  Hop2AwaitingApprovalExecution = 7,
+  Hop2AwaitingTradeConfirmation = 8,
+  Hop2AwaitingTradeExecution = 9,
+  TradeComplete = 10,
 }


### PR DESCRIPTION
## Description

Added draft footer component to multihop trade ui so we can interact with it during development. Behavior mirrors design to disappear when clicked to enable to execution flow.

Design can be found here
https://www.figma.com/file/OHbVrAVaV2xQWUsq0nKzGm/ShapeShift-Library?type=design&node-id=4645-14984&mode=design&t=CEw93wbn4uFvFCJe-0

## Pull Request Type

- [ ] :bug: Bug fix (Non-breaking Change: Fixes an issue)
- [ ] :hammer_and_wrench: Chore (Non-breaking Change: Doc updates, pkg upgrades, typos, etc..)
- [x] :nail_care: New Feature (Breaking/Non-breaking Change)

## Issue (if applicable)

NA

## Risk

Extremely low risk as is behind feature flag, however there are minor changes to redux slices so a quick test of trades may be pragmatic.

## Testing

☝️

### Engineering

☝️


### Operations

☝️


## Screenshots (if applicable)

The design
![image](https://github.com/shapeshift/web/assets/125113430/d962d13d-b8ad-4b59-8d2a-e3b48b7aec97)


Implemented - not exactly as designed which is fine for now
![image](https://github.com/shapeshift/web/assets/125113430/be467698-85bc-40cd-9c69-b052717761e0)
