### PR TITLE
chore: cleanup signtx error handling

### DIFF
--- a/packages/chain-adapters/src/cosmossdk/cosmos/CosmosChainAdapter.ts
+++ b/packages/chain-adapters/src/cosmossdk/cosmos/CosmosChainAdapter.ts
@@ -255,7 +255,7 @@ export class ChainAdapter extends CosmosSdkBaseAdapter<KnownChainIds.CosmosMainn
       if (supportsCosmos(wallet)) {
         const signedTx = await wallet.cosmosSignTx(txToSign)
 
-        if (!signedTx) throw new Error('Error signing tx')
+        if (!signedTx?.serialized) throw new Error('Error signing tx')
 
         return signedTx.serialized
       } else {

--- a/packages/chain-adapters/src/cosmossdk/thorchain/ThorchainChainAdapter.ts
+++ b/packages/chain-adapters/src/cosmossdk/thorchain/ThorchainChainAdapter.ts
@@ -110,7 +110,7 @@ export class ChainAdapter extends CosmosSdkBaseAdapter<KnownChainIds.ThorchainMa
       if (supportsThorchain(wallet)) {
         const signedTx = await wallet.thorchainSignTx(txToSign)
 
-        if (!signedTx) throw new Error('Error signing tx')
+        if (!signedTx?.serialized) throw new Error('Error signing tx')
 
         return signedTx.serialized
       } else {

--- a/packages/chain-adapters/src/evm/EvmBaseAdapter.ts
+++ b/packages/chain-adapters/src/evm/EvmBaseAdapter.ts
@@ -454,7 +454,7 @@ export abstract class EvmBaseAdapter<T extends EvmChainId> implements IChainAdap
 
       const signedTx = await wallet.ethSignTx(txToSign)
 
-      if (!signedTx) throw new Error('Error signing tx')
+      if (!signedTx?.serialized) throw new Error('Error signing tx')
 
       return signedTx.serialized
     } catch (err) {

--- a/packages/chain-adapters/src/utxo/UtxoBaseAdapter.ts
+++ b/packages/chain-adapters/src/utxo/UtxoBaseAdapter.ts
@@ -415,7 +415,7 @@ export abstract class UtxoBaseAdapter<T extends UtxoChainId> implements IChainAd
 
       const signedTx = await wallet.btcSignTx(txToSign)
 
-      if (!signedTx) throw new Error('UtxoBaseAdapter: error signing tx')
+      if (!signedTx?.serializedTx) throw new Error('UtxoBaseAdapter: error signing tx')
 
       return signedTx.serializedTx
     } catch (err) {

--- a/src/components/Modals/Send/hooks/useFormSend/useFormSend.test.tsx
+++ b/src/components/Modals/Send/hooks/useFormSend/useFormSend.test.tsx
@@ -440,7 +440,7 @@ describe.each([
     )
 
     const { result } = renderHook(() => useFormSend())
-    await expect(result.current.handleFormSend(formData)).rejects.toThrow()
+    await result.current.handleFormSend(formData)
     expect(toaster).toHaveBeenCalledWith(expect.objectContaining({ status: 'error' }))
     expect(sendClose).toHaveBeenCalled()
     expect(qrClose).toHaveBeenCalled()

--- a/src/components/Modals/Send/hooks/useFormSend/useFormSend.tsx
+++ b/src/components/Modals/Send/hooks/useFormSend/useFormSend.tsx
@@ -66,8 +66,6 @@ export const useFormSend = () => {
           isClosable: true,
           position: 'top-right',
         })
-
-        throw e
       } finally {
         // Sends may be done from the context of a QR code modal, or a send modal, which are similar, but effectively diff. modal refs
         qrCode.close()

--- a/src/components/Modals/Send/utils.ts
+++ b/src/components/Modals/Send/utils.ts
@@ -105,158 +105,153 @@ export const handleSend = async ({
   const chainAdapterManager = getChainAdapterManager()
   const supportedEvmChainIds = getSupportedEvmChainIds()
 
-  try {
-    const state = store.getState()
-    const asset = selectAssetById(state, sendInput.assetId ?? '')
-    if (!asset) return ''
-    const acccountMetadataFilter = { accountId: sendInput.accountId }
-    const accountMetadata = selectPortfolioAccountMetadataByAccountId(state, acccountMetadataFilter)
-    const isMetaMask = await checkIsMetaMask(wallet)
-    if (
-      fromChainId(asset.chainId).chainNamespace === CHAIN_NAMESPACE.CosmosSdk &&
-      !wallet.supportsOfflineSigning() &&
-      (!isMetaMask || (isMetaMask && !(await checkIsSnapInstalled())))
-    ) {
-      throw new Error(`unsupported wallet: ${await wallet.getModel()}`)
-    }
-
-    const adapter = chainAdapterManager.get(asset.chainId) as ChainAdapter<KnownChainIds>
-    if (!adapter) throw new Error(`useFormSend: no adapter available for ${asset.chainId}`)
-
-    const value = bnOrZero(sendInput.cryptoAmount)
-      .times(bn(10).exponentiatedBy(asset.precision))
-      .toFixed(0)
-
-    const chainId = adapter.getChainId()
-
-    const { estimatedFees, feeType, to, memo, from } = sendInput
-
-    if (!accountMetadata)
-      throw new Error(`useFormSend: no accountMetadata for ${sendInput.accountId}`)
-    const { bip44Params, accountType } = accountMetadata
-    if (!bip44Params) {
-      throw new Error(`useFormSend: no bip44Params for accountId ${sendInput.accountId}`)
-    }
-
-    const result = await (async () => {
-      if (supportedEvmChainIds.includes(chainId)) {
-        if (!supportsETH(wallet)) throw new Error(`useFormSend: wallet does not support ethereum`)
-        const fees = estimatedFees[feeType] as FeeData<EvmChainId>
-        const {
-          chainSpecific: { gasPrice, gasLimit, maxFeePerGas, maxPriorityFeePerGas },
-        } = fees
-        const shouldUseEIP1559Fees =
-          (await wallet.ethSupportsEIP1559()) &&
-          maxFeePerGas !== undefined &&
-          maxPriorityFeePerGas !== undefined
-        if (!shouldUseEIP1559Fees && gasPrice === undefined) {
-          throw new Error(`useFormSend: missing gasPrice for non-EIP-1559 tx`)
-        }
-        const contractAddress = tokenOrUndefined(fromAssetId(asset.assetId).assetReference)
-        const { accountNumber } = bip44Params
-        return await (adapter as unknown as EvmBaseAdapter<EvmChainId>).buildSendTransaction({
-          to,
-          value,
-          wallet,
-          accountNumber,
-          chainSpecific: {
-            data: memo,
-            contractAddress,
-            gasLimit,
-            ...(shouldUseEIP1559Fees ? { maxFeePerGas, maxPriorityFeePerGas } : { gasPrice }),
-          },
-          sendMax: sendInput.sendMax,
-          customNonce: sendInput.customNonce,
-        })
-      }
-
-      if (utxoChainIds.some(utxoChainId => utxoChainId === chainId)) {
-        const fees = estimatedFees[feeType] as FeeData<UtxoChainId>
-
-        if (!accountType) {
-          throw new Error(
-            `useFormSend: no accountType for utxo from accountId: ${sendInput.accountId}`,
-          )
-        }
-        const { accountNumber } = bip44Params
-        return (adapter as unknown as UtxoBaseAdapter<UtxoChainId>).buildSendTransaction({
-          to,
-          value,
-          wallet,
-          accountNumber,
-          chainSpecific: {
-            from,
-            satoshiPerByte: fees.chainSpecific.satoshiPerByte,
-            accountType,
-            opReturnData: memo,
-          },
-          sendMax: sendInput.sendMax,
-        })
-      }
-
-      if (fromChainId(asset.chainId).chainNamespace === CHAIN_NAMESPACE.CosmosSdk) {
-        const fees = estimatedFees[feeType] as FeeData<CosmosSdkChainId>
-        const { accountNumber } = bip44Params
-        const params = {
-          to,
-          memo: (sendInput as SendInput<CosmosSdkChainId>).memo,
-          value,
-          wallet,
-          accountNumber,
-          chainSpecific: { gas: fees.chainSpecific.gasLimit, fee: fees.txFee },
-          sendMax: sendInput.sendMax,
-        }
-
-        return adapter.buildSendTransaction(params)
-      }
-
-      throw new Error(`${chainId} not supported`)
-    })()
-
-    const txToSign = result.txToSign
-
-    const senderAddress = await adapter.getAddress({
-      accountNumber: accountMetadata.bip44Params.accountNumber,
-      accountType: accountMetadata.accountType,
-      wallet,
-    })
-
-    const broadcastTXID = await (async () => {
-      if (wallet.supportsOfflineSigning()) {
-        const signedTx = await adapter.signTransaction({
-          txToSign,
-          wallet,
-        })
-        return adapter.broadcastTransaction({
-          senderAddress,
-          receiverAddress: to,
-          hex: signedTx,
-        })
-      } else if (wallet.supportsBroadcast()) {
-        /**
-         * signAndBroadcastTransaction is an optional method on the HDWallet interface.
-         * Check and see if it exists; if so, call and make sure a txhash is returned
-         */
-        if (!adapter.signAndBroadcastTransaction) {
-          throw new Error('signAndBroadcastTransaction undefined for wallet')
-        }
-        return adapter.signAndBroadcastTransaction({
-          senderAddress,
-          receiverAddress: to,
-          signTxInput: { txToSign, wallet },
-        })
-      } else {
-        throw new Error('Bad hdwallet config')
-      }
-    })()
-
-    if (!broadcastTXID) {
-      throw new Error('Broadcast failed')
-    }
-
-    return broadcastTXID
-  } catch (error) {
-    console.error(error)
-    throw error
+  const state = store.getState()
+  const asset = selectAssetById(state, sendInput.assetId ?? '')
+  if (!asset) return ''
+  const acccountMetadataFilter = { accountId: sendInput.accountId }
+  const accountMetadata = selectPortfolioAccountMetadataByAccountId(state, acccountMetadataFilter)
+  const isMetaMask = await checkIsMetaMask(wallet)
+  if (
+    fromChainId(asset.chainId).chainNamespace === CHAIN_NAMESPACE.CosmosSdk &&
+    !wallet.supportsOfflineSigning() &&
+    (!isMetaMask || (isMetaMask && !(await checkIsSnapInstalled())))
+  ) {
+    throw new Error(`unsupported wallet: ${await wallet.getModel()}`)
   }
+
+  const adapter = chainAdapterManager.get(asset.chainId) as ChainAdapter<KnownChainIds>
+  if (!adapter) throw new Error(`useFormSend: no adapter available for ${asset.chainId}`)
+
+  const value = bnOrZero(sendInput.cryptoAmount)
+    .times(bn(10).exponentiatedBy(asset.precision))
+    .toFixed(0)
+
+  const chainId = adapter.getChainId()
+
+  const { estimatedFees, feeType, to, memo, from } = sendInput
+
+  if (!accountMetadata)
+    throw new Error(`useFormSend: no accountMetadata for ${sendInput.accountId}`)
+  const { bip44Params, accountType } = accountMetadata
+  if (!bip44Params) {
+    throw new Error(`useFormSend: no bip44Params for accountId ${sendInput.accountId}`)
+  }
+
+  const result = await (async () => {
+    if (supportedEvmChainIds.includes(chainId)) {
+      if (!supportsETH(wallet)) throw new Error(`useFormSend: wallet does not support ethereum`)
+      const fees = estimatedFees[feeType] as FeeData<EvmChainId>
+      const {
+        chainSpecific: { gasPrice, gasLimit, maxFeePerGas, maxPriorityFeePerGas },
+      } = fees
+      const shouldUseEIP1559Fees =
+        (await wallet.ethSupportsEIP1559()) &&
+        maxFeePerGas !== undefined &&
+        maxPriorityFeePerGas !== undefined
+      if (!shouldUseEIP1559Fees && gasPrice === undefined) {
+        throw new Error(`useFormSend: missing gasPrice for non-EIP-1559 tx`)
+      }
+      const contractAddress = tokenOrUndefined(fromAssetId(asset.assetId).assetReference)
+      const { accountNumber } = bip44Params
+      return await (adapter as unknown as EvmBaseAdapter<EvmChainId>).buildSendTransaction({
+        to,
+        value,
+        wallet,
+        accountNumber,
+        chainSpecific: {
+          data: memo,
+          contractAddress,
+          gasLimit,
+          ...(shouldUseEIP1559Fees ? { maxFeePerGas, maxPriorityFeePerGas } : { gasPrice }),
+        },
+        sendMax: sendInput.sendMax,
+        customNonce: sendInput.customNonce,
+      })
+    }
+
+    if (utxoChainIds.some(utxoChainId => utxoChainId === chainId)) {
+      const fees = estimatedFees[feeType] as FeeData<UtxoChainId>
+
+      if (!accountType) {
+        throw new Error(
+          `useFormSend: no accountType for utxo from accountId: ${sendInput.accountId}`,
+        )
+      }
+      const { accountNumber } = bip44Params
+      return (adapter as unknown as UtxoBaseAdapter<UtxoChainId>).buildSendTransaction({
+        to,
+        value,
+        wallet,
+        accountNumber,
+        chainSpecific: {
+          from,
+          satoshiPerByte: fees.chainSpecific.satoshiPerByte,
+          accountType,
+          opReturnData: memo,
+        },
+        sendMax: sendInput.sendMax,
+      })
+    }
+
+    if (fromChainId(asset.chainId).chainNamespace === CHAIN_NAMESPACE.CosmosSdk) {
+      const fees = estimatedFees[feeType] as FeeData<CosmosSdkChainId>
+      const { accountNumber } = bip44Params
+      const params = {
+        to,
+        memo: (sendInput as SendInput<CosmosSdkChainId>).memo,
+        value,
+        wallet,
+        accountNumber,
+        chainSpecific: { gas: fees.chainSpecific.gasLimit, fee: fees.txFee },
+        sendMax: sendInput.sendMax,
+      }
+
+      return adapter.buildSendTransaction(params)
+    }
+
+    throw new Error(`${chainId} not supported`)
+  })()
+
+  const txToSign = result.txToSign
+
+  const senderAddress = await adapter.getAddress({
+    accountNumber: accountMetadata.bip44Params.accountNumber,
+    accountType: accountMetadata.accountType,
+    wallet,
+  })
+
+  const broadcastTXID = await (async () => {
+    if (wallet.supportsOfflineSigning()) {
+      const signedTx = await adapter.signTransaction({
+        txToSign,
+        wallet,
+      })
+      return adapter.broadcastTransaction({
+        senderAddress,
+        receiverAddress: to,
+        hex: signedTx,
+      })
+    } else if (wallet.supportsBroadcast()) {
+      /**
+       * signAndBroadcastTransaction is an optional method on the HDWallet interface.
+       * Check and see if it exists; if so, call and make sure a txhash is returned
+       */
+      if (!adapter.signAndBroadcastTransaction) {
+        throw new Error('signAndBroadcastTransaction undefined for wallet')
+      }
+      return adapter.signAndBroadcastTransaction({
+        senderAddress,
+        receiverAddress: to,
+        signTxInput: { txToSign, wallet },
+      })
+    } else {
+      throw new Error('Bad hdwallet config')
+    }
+  })()
+
+  if (!broadcastTXID) {
+    throw new Error('Broadcast failed')
+  }
+
+  return broadcastTXID
 }

--- a/src/lib/address/address.ts
+++ b/src/lib/address/address.ts
@@ -78,7 +78,6 @@ export const parseMaybeUrlWithChainId = ({
             : {}),
         }
       } catch (error) {
-        console.error(error)
         return {
           assetId,
           maybeAddress: urlOrAddress,

--- a/src/lib/address/address.ts
+++ b/src/lib/address/address.ts
@@ -57,8 +57,12 @@ export const parseMaybeUrlWithChainId = ({
               }
             : {}),
         }
-      } catch (error: any) {
-        if (error.message === DANGEROUS_ETH_URL_ERROR) throw error
+      } catch (error) {
+        if (error instanceof Error) {
+          if (error.message === DANGEROUS_ETH_URL_ERROR) throw error
+          // address, not url, don't log
+          if (error.message.includes('Not an Ethereum URI')) break
+        }
         console.error(error)
       }
       break
@@ -78,12 +82,13 @@ export const parseMaybeUrlWithChainId = ({
             : {}),
         }
       } catch (error) {
-        return {
-          assetId,
-          maybeAddress: urlOrAddress,
-          chainId,
+        if (error instanceof Error) {
+          // address, not url, don't log
+          if (error.message.includes('Invalid BIP21 URI')) break
         }
+        console.error(error)
       }
+      break
     default:
       return { assetId, chainId, maybeAddress: urlOrAddress }
   }


### PR DESCRIPTION
## Description

- Handle `signTransaction` response payload more explicitly, and allow error to bubble up and only log once. This prevents attempting to broadcast an empty payload on metamask sign error and reduces console error spew.
- Reduce log spew when parsing standard addresses with qr code decoding logic

## Pull Request Type

- [ ] :bug: Bug fix (Non-breaking Change: Fixes an issue)
- [x] :hammer_and_wrench: Chore (Non-breaking Change: Doc updates, pkg upgrades, typos, etc..)
- [ ] :nail_care: New Feature (Breaking/Non-breaking Change)

## Issue (if applicable)

N/A

## Risk

Low - should still see relevant errors

## Testing

- Send EVM or Utxo with metamask snap
  - Notice no errors in console upon inputting a regular address
  - Reject the transaction in metamask and note only seeing sign transaction error (no attempt to broadcast)

### Engineering

:point_up:

### Operations

:point_up:

## Screenshots (if applicable)

EVM (old):
![image](https://github.com/shapeshift/web/assets/35275952/b96c6663-1723-4570-890f-20fd502212be)

EVM (new): 
![image](https://github.com/shapeshift/web/assets/35275952/59402bbd-8efe-48ea-8837-ec71bc2fbd83)

UTXO (old):
![image](https://github.com/shapeshift/web/assets/35275952/1053688c-f48c-4094-8c25-c22a7a76e2f1)

UTXO (new):
![image](https://github.com/shapeshift/web/assets/35275952/31dce865-197f-447b-b954-87110d2aafaf)
