### PR TITLE
feat: multi hop ui progression

### DIFF
--- a/src/components/MultiHopTrade/components/MultiHopTradeConfirm/components/Hop.tsx
+++ b/src/components/MultiHopTrade/components/MultiHopTradeConfirm/components/Hop.tsx
@@ -1,10 +1,15 @@
+import { ChevronDownIcon, ChevronUpIcon } from '@chakra-ui/icons'
 import {
   Box,
   Card,
   CardFooter,
+  Circle,
+  Collapse,
   Divider,
   Flex,
   HStack,
+  IconButton,
+  Spacer,
   Step,
   StepDescription,
   StepIndicator,
@@ -13,9 +18,12 @@ import {
   StepTitle,
   useColorModeValue,
 } from '@chakra-ui/react'
+import { TxStatus } from '@shapeshiftoss/unchained-client'
+import { useMemo } from 'react'
 import { FaAdjust, FaGasPump, FaProcedures } from 'react-icons/fa'
 import { Amount } from 'components/Amount/Amount'
 import type { StepperStep } from 'components/MultiHopTrade/types'
+import { RawText } from 'components/Text'
 
 const cardBorderRadius = { base: 'xl' }
 
@@ -25,15 +33,55 @@ export const Hop = ({
   slippageDecimalPercentage,
   networkFeeFiatPrecision,
   protocolFeeFiatPrecision,
+  title,
+  hopIndex,
+  txStatus,
+  isOpen,
+  onToggleIsOpen,
 }: {
   steps: StepperStep[]
   activeStep: number
   slippageDecimalPercentage: string
   networkFeeFiatPrecision: string
   protocolFeeFiatPrecision: string
+  title: string
+  hopIndex: number
+  txStatus?: TxStatus
+  isOpen: boolean
+  onToggleIsOpen: () => void
 }) => {
   const backgroundColor = useColorModeValue('gray.100', 'gray.750')
   const borderColor = useColorModeValue('gray.50', 'gray.650')
+
+  const timeEstimate = '4m'
+  const timeRemaining = '3:35'
+
+  const rightComponent = useMemo(() => {
+    switch (txStatus) {
+      case undefined:
+      case TxStatus.Unknown:
+        return <RawText>{timeEstimate}</RawText>
+      case TxStatus.Pending:
+        return <RawText>{timeRemaining}</RawText>
+      case TxStatus.Confirmed:
+        return (
+          <Box width='auto'>
+            <IconButton
+              aria-label='expand'
+              variant='link'
+              p={4}
+              borderTopRadius='none'
+              colorScheme='blue'
+              onClick={onToggleIsOpen}
+              width='full'
+              icon={isOpen ? <ChevronUpIcon boxSize='16px' /> : <ChevronDownIcon boxSize='16px' />}
+            />
+          </Box>
+        )
+      default:
+        return null
+    }
+  }, [isOpen, onToggleIsOpen, txStatus])
 
   return (
     <Card
@@ -43,26 +91,32 @@ export const Hop = ({
       backgroundColor={backgroundColor}
       borderColor={borderColor}
     >
-      <Stepper
-        index={activeStep}
-        orientation='vertical'
-        gap='0'
-        height={steps.length * 60}
-        margin={6}
-      >
-        {steps.map(({ title, stepIndicator, description, content, key }, index) => (
-          <Step key={key}>
-            <StepIndicator>{stepIndicator}</StepIndicator>
+      <HStack width='full' justifyContent='space-between' paddingLeft={6} marginTop={4}>
+        <HStack>
+          <Circle size={8} borderColor={borderColor} borderWidth={2}>
+            <RawText as='b'>{hopIndex + 1}</RawText>
+          </Circle>
+          <RawText as='b'>{title}</RawText>
+        </HStack>
+        {rightComponent}
+      </HStack>
+      <Collapse in={isOpen}>
+        <Stepper index={activeStep} orientation='vertical' gap='0' margin={6}>
+          {steps.map(({ title, stepIndicator, description, content, key }, index) => (
+            <Step key={key}>
+              <StepIndicator>{stepIndicator}</StepIndicator>
 
-            <Box flexShrink='0'>
-              <StepTitle>{title}</StepTitle>
-              {description && <StepDescription>{description}</StepDescription>}
-              {index === activeStep && content}
-            </Box>
-            <StepSeparator />
-          </Step>
-        ))}
-      </Stepper>
+              <Box flexShrink='0'>
+                <StepTitle>{title}</StepTitle>
+                {description && <StepDescription>{description}</StepDescription>}
+                {index === activeStep && content}
+                {index < steps.length - 1 && <Spacer height={6} />}
+              </Box>
+              <StepSeparator />
+            </Step>
+          ))}
+        </Stepper>
+      </Collapse>
       <Divider />
       <CardFooter>
         <HStack width='full' justifyContent='space-between'>

--- a/src/components/MultiHopTrade/components/MultiHopTradeConfirm/components/Hop.tsx
+++ b/src/components/MultiHopTrade/components/MultiHopTradeConfirm/components/Hop.tsx
@@ -50,8 +50,8 @@ export const Hop = ({
         height={steps.length * 60}
         margin={6}
       >
-        {steps.map(({ title, stepIndicator, description, content }, index) => (
-          <Step key={index}>
+        {steps.map(({ title, stepIndicator, description, content, key }, index) => (
+          <Step key={key}>
             <StepIndicator>{stepIndicator}</StepIndicator>
 
             <Box flexShrink='0'>

--- a/src/components/MultiHopTrade/components/MultiHopTradeConfirm/components/SecondHop.tsx
+++ b/src/components/MultiHopTrade/components/MultiHopTradeConfirm/components/SecondHop.tsx
@@ -29,15 +29,18 @@ import {
   getAssetSummaryStep,
   getDonationSummaryStep,
   getHopSummaryStep,
-  getTitleStep,
 } from './steps'
 
 export const SecondHop = ({
   swapperName,
   tradeQuoteStep,
+  isOpen,
+  onToggleIsOpen,
 }: {
   swapperName: SwapperName
   tradeQuoteStep: TradeQuoteStep
+  isOpen: boolean
+  onToggleIsOpen: () => void
 }) => {
   const {
     number: { toCrypto, toFiat },
@@ -54,7 +57,7 @@ export const SecondHop = ({
     approvalNetworkFeeCryptoBaseUnit,
   } = useAllowanceApproval(tradeQuoteStep, isExactAllowance)
   const shouldRenderDonation = true // TODO:
-  const { onRejectApproval, onSignTrade, onRejectTrade } = useTradeExecutooor()
+  const { onSignTrade } = useTradeExecutooor()
   const tradeExecutionStatus = useAppSelector(selectTradeExecutionStatus)
   const fiatPriceByAssetId = useAppSelector(selectCryptoMarketData)
 
@@ -80,13 +83,14 @@ export const SecondHop = ({
     }
   }, [tradeExecutionStatus, isApprovalNeeded])
 
+  const {
+    buyAsset,
+    sellAsset,
+    sellAmountIncludingProtocolFeesCryptoBaseUnit,
+    buyAmountBeforeFeesCryptoBaseUnit,
+  } = tradeQuoteStep
+
   const steps = useMemo(() => {
-    const {
-      buyAsset,
-      sellAsset,
-      sellAmountIncludingProtocolFeesCryptoBaseUnit,
-      buyAmountBeforeFeesCryptoBaseUnit,
-    } = tradeQuoteStep
     const sellAmountCryptoPrecision = fromBaseUnit(
       sellAmountIncludingProtocolFeesCryptoBaseUnit,
       sellAsset.precision,
@@ -109,12 +113,6 @@ export const SecondHop = ({
         : undefined
 
     const hopSteps = [
-      getTitleStep({
-        hopIndex: 1,
-        isHopComplete: tradeExecutionStatus === MultiHopExecutionStatus.TradeComplete,
-        swapperName,
-        tradeType: TradeType.Bridge,
-      }),
       getHopSummaryStep({
         swapperName,
         buyAssetChainId: buyAsset.chainId,
@@ -124,7 +122,6 @@ export const SecondHop = ({
         txHash: tradeTx,
         txStatus: TxStatus.Unknown,
         onSign: onSignTrade,
-        onReject: onRejectTrade,
       }),
     ].filter(isSome)
 
@@ -145,7 +142,6 @@ export const SecondHop = ({
           translate,
           toggleIsExactAllowance,
           onSign: executeAllowanceApproval,
-          onReject: onRejectApproval,
         }),
       )
     }
@@ -170,20 +166,24 @@ export const SecondHop = ({
   }, [
     approvalNetworkFeeCryptoBaseUnit,
     approvalTxId,
+    buyAmountBeforeFeesCryptoBaseUnit,
+    buyAsset,
     executeAllowanceApproval,
     fiatPriceByAssetId,
     isApprovalNeeded,
     isExactAllowance,
-    onRejectApproval,
-    onRejectTrade,
     onSignTrade,
+    sellAmountIncludingProtocolFeesCryptoBaseUnit,
+    sellAsset.assetId,
+    sellAsset.chainId,
+    sellAsset.precision,
+    sellAsset.symbol,
     shouldRenderDonation,
     swapperName,
     toCrypto,
     toFiat,
     toggleIsExactAllowance,
     tradeExecutionStatus,
-    tradeQuoteStep,
     translate,
   ])
 
@@ -195,6 +195,9 @@ export const SecondHop = ({
   const networkFeeFiatPrecision = selectHopTotalNetworkFeeFiatPrecision(store.getState(), 1)
   const protocolFeeFiatPrecision = selectHopTotalProtocolFeesFiatPrecision(store.getState(), 1)
 
+  const isBridge = buyAsset.chainId !== sellAsset.chainId
+  const tradeType = isBridge ? TradeType.Bridge : TradeType.Swap
+
   return (
     <Hop
       steps={steps}
@@ -202,6 +205,10 @@ export const SecondHop = ({
       slippageDecimalPercentage={slippageDecimalPercentage}
       networkFeeFiatPrecision={networkFeeFiatPrecision ?? '0'}
       protocolFeeFiatPrecision={protocolFeeFiatPrecision ?? '0'}
+      hopIndex={1}
+      title={`${tradeType} via ${swapperName}`}
+      isOpen={isOpen}
+      onToggleIsOpen={onToggleIsOpen}
     />
   )
 }

--- a/src/components/MultiHopTrade/components/MultiHopTradeConfirm/components/SecondHop.tsx
+++ b/src/components/MultiHopTrade/components/MultiHopTradeConfirm/components/SecondHop.tsx
@@ -30,7 +30,6 @@ import {
   getDonationSummaryStep,
   getHopSummaryStep,
   getTitleStep,
-  getTradeStep,
 } from './steps'
 
 export const SecondHop = ({
@@ -104,6 +103,11 @@ export const SecondHop = ({
       bn(buyAmountCryptoPrecision).times(buyAssetFiatRate).toString(),
     )
 
+    const tradeTx =
+      tradeExecutionStatus.valueOf() >= MultiHopExecutionStatus.Hop1AwaitingTradeExecution
+        ? '0x5678'
+        : undefined
+
     const hopSteps = [
       getTitleStep({
         hopIndex: 1,
@@ -117,6 +121,10 @@ export const SecondHop = ({
         sellAssetChainId: sellAsset.chainId,
         buyAmountCryptoFormatted,
         sellAmountCryptoFormatted,
+        txHash: tradeTx,
+        txStatus: TxStatus.Unknown,
+        onSign: onSignTrade,
+        onReject: onRejectTrade,
       }),
     ].filter(isSome)
 
@@ -141,19 +149,6 @@ export const SecondHop = ({
         }),
       )
     }
-
-    const tradeTx =
-      tradeExecutionStatus.valueOf() >= MultiHopExecutionStatus.Hop1AwaitingTradeExecution
-        ? '0x5678'
-        : undefined
-    hopSteps.push(
-      getTradeStep({
-        txHash: tradeTx,
-        txStatus: TxStatus.Unknown,
-        onSign: onSignTrade,
-        onReject: onRejectTrade,
-      }),
-    )
 
     if (shouldRenderDonation) {
       hopSteps.push(

--- a/src/components/MultiHopTrade/components/MultiHopTradeConfirm/components/steps.tsx
+++ b/src/components/MultiHopTrade/components/MultiHopTradeConfirm/components/steps.tsx
@@ -4,13 +4,9 @@ import {
   Button,
   Card,
   Circle,
-  HStack,
   Icon,
   Link,
   Spinner,
-  StepIcon,
-  StepNumber,
-  StepStatus,
   Switch,
   Tooltip,
   VStack,
@@ -31,9 +27,6 @@ import { assertUnreachable } from 'lib/utils'
 
 import { SwapperIcon } from '../../TradeInput/components/SwapperIcon/SwapperIcon'
 import { TradeType } from '../types'
-
-const stepIcon = <StepIcon />
-const spinner = <Spinner />
 
 const getStatusIcon = (txStatus: TxStatus) => {
   // TODO: proper light/dark mode colors here
@@ -101,31 +94,32 @@ const getChainShortName = (chainId: KnownChainIds) => {
 export const getApprovalStep = ({
   approvalNetworkFeeCryptoFormatted,
   txHash,
+  txStatus,
   isExactAllowance,
   toggleIsExactAllowance,
   translate,
   onSign,
-  onReject,
 }: {
   approvalNetworkFeeCryptoFormatted: string
   txHash?: string
+  txStatus?: TxStatus
   isExactAllowance: boolean
   toggleIsExactAllowance: () => void
   translate: ReturnType<typeof useTranslate>
   onSign: () => void
-  onReject: () => void
 }): StepperStep => {
+  const stepIndicator = txStatus !== undefined ? getStatusIcon(txStatus) : <></>
   return {
     title: 'Token allowance approval',
     description: txHash ?? `Approval gas fee ${approvalNetworkFeeCryptoFormatted}`,
-    stepIndicator: <StepStatus complete={stepIcon} active={txHash ? spinner : undefined} />,
+    stepIndicator,
     key: 'approval',
     content: (
       <Card p='2'>
         {txHash ? (
           <RawText>TX: {txHash}</RawText>
         ) : (
-          <HStack>
+          <VStack>
             <Row>
               <Row.Label display='flex' alignItems='center'>
                 <Text color='text.subtle' translation='trade.allowance' />
@@ -155,29 +149,10 @@ export const getApprovalStep = ({
               </Row.Value>
             </Row>
             <Button onClick={onSign}>Approve</Button>
-            <Button onClick={onReject}>Reject</Button>
-          </HStack>
+          </VStack>
         )}
       </Card>
     ),
-  }
-}
-
-export const getTitleStep = ({
-  hopIndex,
-  isHopComplete,
-  swapperName,
-  tradeType,
-}: {
-  hopIndex: number
-  isHopComplete: boolean
-  swapperName: SwapperName
-  tradeType: TradeType
-}): StepperStep => {
-  return {
-    title: `${tradeType} via ${swapperName}`,
-    stepIndicator: isHopComplete ? <StepIcon /> : <StepNumber>{hopIndex + 1}</StepNumber>,
-    key: 'title',
   }
 }
 
@@ -210,7 +185,6 @@ export const getHopSummaryStep = ({
   txLink,
   txStatus,
   onSign,
-  onReject,
 }: {
   swapperName: SwapperName
   buyAssetChainId: ChainId
@@ -221,7 +195,6 @@ export const getHopSummaryStep = ({
   txLink?: string
   txStatus?: TxStatus
   onSign: () => void
-  onReject: () => void
 }): StepperStep => {
   const chainAdapterManager = getChainAdapterManager()
   const sellChainName = chainAdapterManager.get(sellAssetChainId)?.getDisplayName()
@@ -232,15 +205,7 @@ export const getHopSummaryStep = ({
   const stepIndicator =
     txStatus !== undefined ? getStatusIcon(txStatus) : <SwapperIcon swapperName={swapperName} />
 
-  const content =
-    txStatus === undefined ? (
-      <HStack>
-        <Button onClick={onSign}>Sign message</Button>
-        <Button onClick={onReject}>Reject</Button>
-      </HStack>
-    ) : (
-      <></>
-    )
+  const content = txStatus === undefined ? <Button onClick={onSign}>Sign message</Button> : <></>
 
   const description = (
     <VStack>

--- a/src/components/MultiHopTrade/components/MultiHopTradeConfirm/components/steps.tsx
+++ b/src/components/MultiHopTrade/components/MultiHopTradeConfirm/components/steps.tsx
@@ -117,6 +117,7 @@ export const getApprovalStep = ({
     title: 'Token allowance approval',
     description: txHash ?? `Approval gas fee ${approvalNetworkFeeCryptoFormatted}`,
     stepIndicator: <StepStatus complete={stepIcon} active={txHash ? spinner : undefined} />,
+    key: 'approval',
     content: (
       <Card p='2'>
         {txHash ? (
@@ -175,6 +176,7 @@ export const getTradeStep = ({
   return {
     title: 'Sign transaction',
     stepIndicator: statusIcon,
+    key: 'trade',
     content: (
       <Card p='2'>
         {txHash ? (
@@ -204,6 +206,7 @@ export const getTitleStep = ({
   return {
     title: `${tradeType} via ${swapperName}`,
     stepIndicator: isHopComplete ? <StepIcon /> : <StepNumber>{hopIndex + 1}</StepNumber>,
+    key: 'title',
   }
 }
 
@@ -222,6 +225,7 @@ export const getAssetSummaryStep = ({
     title: amountCryptoFormatted,
     description: `${amountFiatFormatted} on ${chainName}`,
     stepIndicator: <AssetIcon src={asset.icon} boxSize='32px' />,
+    key: 'asset-summary',
   }
 }
 
@@ -251,6 +255,7 @@ export const getHopSummaryStep = ({
         : `${tradeType} from ${sellChainName} to ${buyChainName} via ${swapperName}`,
     description: `${sellAmountCryptoFormatted}.${sellChainSymbol} -> ${buyAmountCryptoFormatted}.${buyChainSymbol}`,
     stepIndicator: <SwapperIcon swapperName={swapperName} />,
+    key: 'hop-summary',
   }
 }
 
@@ -263,5 +268,6 @@ export const getDonationSummaryStep = ({
     title: donationAmountFiatFormatted,
     description: 'ShapeShift Donation',
     stepIndicator: <StarIcon />,
+    key: 'donation',
   }
 }

--- a/src/components/MultiHopTrade/hooks/useAllowanceApproval/useAllowanceApproval.tsx
+++ b/src/components/MultiHopTrade/hooks/useAllowanceApproval/useAllowanceApproval.tsx
@@ -18,8 +18,11 @@ export const useAllowanceApproval = (
     stopPolling: stopPollingBuildApprovalTx,
   } = useApprovalTx(tradeQuoteStep, isExactAllowance)
 
-  const { executeAllowanceApproval: _executeAllowanceApproval, txId: approvalTxId } =
-    useExecuteAllowanceApproval(tradeQuoteStep, buildCustomTxInput)
+  const {
+    executeAllowanceApproval: _executeAllowanceApproval,
+    txId: approvalTxId,
+    txStatus: approvalTxStatus,
+  } = useExecuteAllowanceApproval(tradeQuoteStep, buildCustomTxInput)
 
   const executeAllowanceApproval = useCallback(() => {
     stopPollingBuildApprovalTx()
@@ -42,5 +45,6 @@ export const useAllowanceApproval = (
     approvalTxId,
     approvalNetworkFeeCryptoBaseUnit,
     isLoading,
+    approvalTxStatus,
   }
 }

--- a/src/components/MultiHopTrade/types.ts
+++ b/src/components/MultiHopTrade/types.ts
@@ -11,6 +11,7 @@ export type StepperStep = {
   stepIndicator: JSX.Element
   content?: JSX.Element
   status?: MultiHopExecutionStatus
+  key: string
 }
 
 export enum ActiveQuoteStatus {

--- a/src/components/MultiHopTrade/types.ts
+++ b/src/components/MultiHopTrade/types.ts
@@ -3,14 +3,12 @@ import type { InterpolationOptions } from 'node-polyglot'
 import type { Asset } from 'lib/asset-service'
 import type { GetTradeQuoteInput, SwapErrorRight } from 'lib/swapper/types'
 import type { AccountMetadata } from 'state/slices/portfolioSlice/portfolioSliceCommon'
-import type { MultiHopExecutionStatus } from 'state/slices/swappersSlice/types'
 
 export type StepperStep = {
   title: string
-  description?: string
+  description?: string | JSX.Element
   stepIndicator: JSX.Element
   content?: JSX.Element
-  status?: MultiHopExecutionStatus
   key: string
 }
 

--- a/src/state/slices/swappersSlice/swappersSlice.ts
+++ b/src/state/slices/swappersSlice/swappersSlice.ts
@@ -90,6 +90,17 @@ export const swappers = createSlice({
     },
     incrementTradeExecutionState: state => {
       if (state.tradeExecutionStatus === MultiHopExecutionStatus.TradeComplete) return
+
+      // TODO: skip second hop states for single hop trades
+      // this requires moving tradeExecutionStatus into the trade quote slice
+      // const isMultiHopTrade = selectIsActiveQuoteMultiHop(state)
+      // if (
+      //   isMultiHopTrade &&
+      //   state.tradeExecutionStatus > MultiHopExecutionStatus.Hop1AwaitingTradeExecution
+      // ) {
+      //   state.tradeExecutionStatus = MultiHopExecutionStatus.TradeComplete
+      // }
+
       state.tradeExecutionStatus += 1 as MultiHopExecutionStatus
     },
     switchAssets: state => {


### PR DESCRIPTION
## Description

More changes to progress the implementation of multi hop trade UI WIP.

Includes changes to the `useAllowanceApproval` hook to output a `TxStatus` which is not used outside of multi-hop trades.

## Pull Request Type

- [ ] :bug: Bug fix (Non-breaking Change: Fixes an issue)
- [ ] :hammer_and_wrench: Chore (Non-breaking Change: Doc updates, pkg upgrades, typos, etc..)
- [x] :nail_care: New Feature (Breaking/Non-breaking Change)

## Issue (if applicable)

NA

## Risk

Changes to `useAllowanceApproval` though minor, pose a slight risk of broken allowance approvals and/or trades.

## Testing

Ensure ERC20 allowance approvals and trades work as expected with multi-hop ui disabled.

### Engineering

☝️

### Operations

☝️

## Screenshots (if applicable)
