### PR TITLE
feat: wire-up thorchain lending multi-account

### DIFF
--- a/src/hooks/useRouteAssetId/useRouteAssetId.ts
+++ b/src/hooks/useRouteAssetId/useRouteAssetId.ts
@@ -29,7 +29,12 @@ const getRouteAssetId = (pathname: string) => {
     chainNamespace?: ChainNamespace
     chainReference?: ChainReference
   }>(pathname, {
-    path: ['/accounts/:accountId/:assetId', '/accounts/:chainNamespace\\::chainReference\\:(.+)'],
+    path: [
+      '/accounts/:accountId/:assetId',
+      '/accounts/:chainNamespace\\::chainReference\\:(.+)',
+      `/lending/poolAccount/:accountId/:assetId`,
+      '/lending/poolAccount/:chainNamespace\\::chainReference\\:(.+)',
+    ],
   })
 
   if (assetIdAssetsPathMatch?.params) {
@@ -62,7 +67,7 @@ export const useRouteAssetId = () => {
     const routeAssetId = getRouteAssetId(location.pathname)
     const foxPageRouteAssetId = getFoxPageRouteAssetId(location.pathname)
 
-    return routeAssetId ?? foxPageRouteAssetId
+    return decodeURIComponent(routeAssetId ?? foxPageRouteAssetId)
   }, [location.pathname])
 
   return assetId

--- a/src/pages/Lending/LendingPage.tsx
+++ b/src/pages/Lending/LendingPage.tsx
@@ -21,6 +21,9 @@ export const LendingPage = () => {
       <Route exact path={`${path}/loans`}>
         <YourLoans />
       </Route>
+      <Route path={`${path}/poolAccount/:poolAccountId/:poolAssetId`}>
+        <Pool />
+      </Route>
       <Route path={`${path}/pool/:poolAssetId`}>
         <Pool />
       </Route>

--- a/src/pages/Lending/Pool/Pool.tsx
+++ b/src/pages/Lending/Pool/Pool.tsx
@@ -24,7 +24,7 @@ import { getConfig } from 'config'
 import type { Property } from 'csstype'
 import { useCallback, useMemo, useState } from 'react'
 import { useTranslate } from 'react-polyglot'
-import { useHistory } from 'react-router'
+import { useHistory, useParams } from 'react-router'
 import { Amount } from 'components/Amount/Amount'
 import { AssetIcon } from 'components/AssetIcon'
 import { Main } from 'components/Layout/Main'
@@ -63,8 +63,12 @@ const PoolHeader = () => {
 
 const flexDirPool: ResponsiveValue<Property.FlexDirection> = { base: 'column', lg: 'row' }
 
+type MatchParams = {
+  poolAccountId?: AccountId
+}
 export const Pool = () => {
-  const [collateralAccountId, setCollateralAccountId] = useState<AccountId>('')
+  const { poolAccountId } = useParams<MatchParams>()
+  const [collateralAccountId, setCollateralAccountId] = useState<AccountId>(poolAccountId ?? '')
   const [borrowAccountId, setBorrowAccountId] = useState<AccountId>('')
   const [repaymentAccountId, setRepaymentAccountId] = useState<AccountId>('')
 

--- a/src/pages/Lending/Pool/components/Borrow/BorrowInput.tsx
+++ b/src/pages/Lending/Pool/components/Borrow/BorrowInput.tsx
@@ -183,6 +183,7 @@ export const BorrowInput = ({
     <SlideTransition>
       <Stack spacing={0}>
         <TradeAssetInput
+          accountId={collateralAccountId}
           assetId={collateralAssetId}
           assetSymbol={collateralAsset.symbol}
           assetIcon={collateralAsset.icon}

--- a/src/pages/Lending/Pool/components/Repay/RepayInput.tsx
+++ b/src/pages/Lending/Pool/components/Repay/RepayInput.tsx
@@ -58,13 +58,16 @@ type RepayInputProps = {
   repaymentAsset: Asset | null
   setRepaymentAsset: (asset: Asset) => void
 }
+
+// no-op, this is read-only
+const handleCollateralAccountIdChange = () => {}
+
 export const RepayInput = ({
   collateralAssetId,
   repaymentPercent,
   onRepaymentPercentChange,
   collateralAccountId,
   repaymentAccountId,
-  onCollateralAccountIdChange: handleCollateralAccountIdChange,
   onRepaymentAccountIdChange: handleRepaymentAccountIdChange,
   repaymentAsset,
   setRepaymentAsset,
@@ -162,7 +165,7 @@ export const RepayInput = ({
         assetId={collateralAssetId}
         onAssetClick={handleRepaymentAssetClick}
         onAccountIdChange={handleAccountIdChange}
-        accountSelectionDisabled={false}
+        accountSelectionDisabled
         label={'uhh'}
         onAssetChange={handleAssetChange}
         isReadOnly

--- a/src/pages/Lending/YourLoans.tsx
+++ b/src/pages/Lending/YourLoans.tsx
@@ -1,6 +1,5 @@
 import { Button, type GridProps, SimpleGrid, Skeleton, Stack } from '@chakra-ui/react'
-import type { AssetId } from '@shapeshiftoss/caip'
-import { fromAssetId } from '@shapeshiftoss/caip'
+import type { AccountId, AssetId } from '@shapeshiftoss/caip'
 import { useCallback, useMemo } from 'react'
 import { useTranslate } from 'react-polyglot'
 import { useHistory } from 'react-router'
@@ -11,10 +10,10 @@ import { AssetCell } from 'components/StakingVaults/Cells'
 import { RawText, Text } from 'components/Text'
 import type { Asset } from 'lib/asset-service'
 import { bnOrZero } from 'lib/bignumber/bignumber'
-import { selectFirstAccountIdByChainId } from 'state/slices/selectors'
-import { useAppSelector } from 'state/store'
+import { isSome } from 'lib/utils'
 
 import { LendingHeader } from './components/LendingHeader'
+import { useAllLendingPositionsData } from './hooks/useAllLendingPositionsData'
 import { useLendingPositionData } from './hooks/useLendingPositionData'
 import { useLendingSupportedAssets } from './hooks/useLendingSupportedAssets'
 
@@ -25,18 +24,11 @@ export const lendingRowGrid: GridProps['gridTemplateColumns'] = {
 
 type LendingRowGridProps = {
   asset: Asset
+  accountId: AccountId
   onPoolClick: (assetId: AssetId) => void
 }
 
-const LendingRowGrid = ({ asset, onPoolClick }: LendingRowGridProps) => {
-  // TODO(gomes): this only handles displaying positions of account 0 for now - we may want to make this component accomodate positions over all accounts
-  // however, this would rug the "Repayment Lock" data, so we need to figure out a UX way around this
-
-  const accountId =
-    useAppSelector(state =>
-      selectFirstAccountIdByChainId(state, fromAssetId(asset.assetId).chainId),
-    ) ?? ''
-
+const LendingRowGrid = ({ asset, accountId, onPoolClick }: LendingRowGridProps) => {
   const { data: lendingPositionData, isLoading: isLendingPositionDataLoading } =
     useLendingPositionData({
       assetId: asset.assetId,
@@ -98,6 +90,35 @@ const LendingRowGrid = ({ asset, onPoolClick }: LendingRowGridProps) => {
   )
 }
 
+const LendingRowAssetAccountsGrids = ({
+  asset,
+  onPoolClick: handlePoolClick,
+}: Omit<LendingRowGridProps, 'accountId'>) => {
+  const {
+    isLoading: isAllLendingPositionsDataLoading,
+    positions,
+    isActive,
+  } = useAllLendingPositionsData({
+    assetId: asset.assetId,
+  })
+
+  const grids = useMemo(() => {
+    if (!isActive && !isAllLendingPositionsDataLoading) return null
+    return positions
+      .map(({ data }) => data)
+      .filter(isSome)
+      .map(position => (
+        <LendingRowGrid
+          asset={asset}
+          accountId={position.accountId}
+          onPoolClick={handlePoolClick}
+        />
+      ))
+  }, [asset, handlePoolClick, isActive, isAllLendingPositionsDataLoading, positions])
+
+  return <>{grids}</>
+}
+
 export const YourLoans = () => {
   const translate = useTranslate()
   const lendingHeader = useMemo(() => <LendingHeader />, [])
@@ -115,8 +136,9 @@ export const YourLoans = () => {
 
   const lendingRowGrids = useMemo(() => {
     if (!lendingSupportedAssets) return new Array(2).fill(null).map(() => <Skeleton height={16} />)
+
     return lendingSupportedAssets.map(asset => (
-      <LendingRowGrid asset={asset} onPoolClick={handlePoolClick} />
+      <LendingRowAssetAccountsGrids asset={asset} onPoolClick={handlePoolClick} />
     ))
   }, [handlePoolClick, lendingSupportedAssets])
 

--- a/src/pages/Lending/YourLoans.tsx
+++ b/src/pages/Lending/YourLoans.tsx
@@ -2,7 +2,7 @@ import { Button, type GridProps, SimpleGrid, Skeleton, Stack } from '@chakra-ui/
 import type { AccountId, AssetId } from '@shapeshiftoss/caip'
 import { useCallback, useMemo } from 'react'
 import { useTranslate } from 'react-polyglot'
-import { useHistory } from 'react-router'
+import { generatePath, useHistory } from 'react-router'
 import { Amount } from 'components/Amount/Amount'
 import { HelperTooltip } from 'components/HelperTooltip/HelperTooltip'
 import { Main } from 'components/Layout/Main'
@@ -25,7 +25,7 @@ export const lendingRowGrid: GridProps['gridTemplateColumns'] = {
 type LendingRowGridProps = {
   asset: Asset
   accountId: AccountId
-  onPoolClick: (assetId: AssetId) => void
+  onPoolClick: (assetId: AssetId, accountId: AccountId) => void
 }
 
 const LendingRowGrid = ({ asset, accountId, onPoolClick }: LendingRowGridProps) => {
@@ -36,8 +36,8 @@ const LendingRowGrid = ({ asset, accountId, onPoolClick }: LendingRowGridProps) 
     })
 
   const handlePoolClick = useCallback(() => {
-    onPoolClick(asset.assetId)
-  }, [asset.assetId, onPoolClick])
+    onPoolClick(asset.assetId, accountId)
+  }, [accountId, asset.assetId, onPoolClick])
 
   if (
     lendingPositionData &&
@@ -128,8 +128,8 @@ export const YourLoans = () => {
   const history = useHistory()
 
   const handlePoolClick = useCallback(
-    (assetId: AssetId) => {
-      history.push(`/lending/pool/${assetId}`)
+    (assetId: AssetId, accountId: AccountId) => {
+      history.push(generatePath('/lending/poolAccount/:accountId/:assetId', { accountId, assetId }))
     },
     [history],
   )


### PR DESCRIPTION
## Description

This PR adds multi-account support for THORChain lending, i.e the opportunity for opportunities over multiple accounts to be reflected as individual entries, as well as the pool page being programmatic and displaying the right position - or the first account one if there's no current position.

## Pull Request Type

- [ ] :bug: Bug fix (Non-breaking Change: Fixes an issue)
- [ ] :hammer_and_wrench: Chore (Non-breaking Change: Doc updates, pkg upgrades, typos, etc..)
- [x] :nail_care: New Feature (Breaking/Non-breaking Change)

## Issue (if applicable)

<!-----------------------------------------------------------------------------
If applicable, please link to the github issue and put `closes #XXXX` in your comment to auto-close the issue that your PR fixes.
------------------------------------------------------------------------------>

closes N/A

## Risk

<!-----------------------------------------------------------------------------
Outline the scope of your changes and the risk associated with them. You must use your discretion as an engineer to determine the potential impact of your changes.

E.g. an upgrade to `hdwallet` or core state management would be considered higher risk, and might require a full regression test. UI or isolated view changes, or something behind a feature flag may have near zero risk. Small bug fixes might require testing isolated to the specific fix.
------------------------------------------------------------------------------>

None, under flag

## Testing

<!-----------------------------------------------------------------------------
We treat every PR to be merged with the same scrutiny as if we were merging directly to production.

Your PR will not be merged if you do not complete the sections below for our engineering and operations teams to test.
------------------------------------------------------------------------------>

- Multi account selection for the collateral asset shows no regression in lending
- Having lending positions over multiple AccountIds is reflected with multiple entries
  - Clicking said position in "Your Loans" will automagically select the right account when lending
- Clicking a non-yet active lending opportunity in "Available Pools" uses default AccountId

### Engineering

<!-----------------------------------------------------------------------------
Include sufficient information here for an engineer to test your PR. This may include how to test locally, in a built environment, changes to infrastructure etc.
------------------------------------------------------------------------------>

- ☝🏽 

### Operations

<!-----------------------------------------------------------------------------
If your changes have a user-facing impact, describe how a non-technical QA team can functionally test your changes in a preview environment.

If they are not user-facing please describe how to test for any regressions that may occur.
------------------------------------------------------------------------------>

- ☝🏽 

## Screenshots (if applicable)

- Develop

<img width="842" alt="Screenshot 2023-11-09 at 20 38 15" src="https://github.com/shapeshift/web/assets/17035424/ce9776f9-d4a6-48fc-ba8e-2d5e508fa129">

- This diff

<img width="855" alt="Screenshot 2023-11-09 at 20 37 56" src="https://github.com/shapeshift/web/assets/17035424/4d2ffdc9-966f-4d57-bd19-c61d8673aed7">