### PR TITLE
fix: replace viem getFilterLogs with getLogs

### DIFF
--- a/src/state/slices/opportunitiesSlice/resolvers/uniV2/utils.test.ts
+++ b/src/state/slices/opportunitiesSlice/resolvers/uniV2/utils.test.ts
@@ -22,7 +22,7 @@ jest.mock('lib/viem-client', () => {
   const { KnownChainIds } = require('@shapeshiftoss/types')
   const viemEthMainnetClient = {
     createEventFilter: jest.fn(() => ({})),
-    getFilterLogs: () =>
+    getLogs: () =>
       new Promise(resolve => {
         resolve([
           {


### PR DESCRIPTION
## Description

Use `getLogs` instead of `getFilterLogs` to fetch. This avoids the scenario where an event filter is created on one of many replicated nodes and the subsequent fetch for filtered logs is not routed to the same node that contains the event filter.

We are able to get the exact same data in a single call to the node when using `getLogs` instead.

This PR can replace https://github.com/shapeshift/web/pull/5592.

## Pull Request Type

- [x] :bug: Bug fix (Non-breaking Change: Fixes an issue)
- [ ] :hammer_and_wrench: Chore (Non-breaking Change: Doc updates, pkg upgrades, typos, etc..)
- [ ] :nail_care: New Feature (Breaking/Non-breaking Change)

## Issue (if applicable)

closes: https://github.com/shapeshift/web/issues/5574

## Risk

Low - should behave the same without needing to worry about network routing

## Testing

- Should see the correct price and apy for uniswap v2 positions
- Should not see any network errors surrounding `eth_getLogs`

### Engineering

:point_up: 

### Operations

:point_up: 

## Screenshots (if applicable)
