### PR TITLE
feat: wire up multi hop quotes to trade UI

### DIFF
--- a/src/components/MultiHopTrade/components/MultiHopTradeConfirm/components/FirstHop.tsx
+++ b/src/components/MultiHopTrade/components/MultiHopTradeConfirm/components/FirstHop.tsx
@@ -212,6 +212,7 @@ export const FirstHop = ({
     sellAsset,
     sellAmountIncludingProtocolFeesCryptoBaseUnit,
     buyAmountBeforeFeesCryptoBaseUnit,
+    estimatedExecutionTimeMs,
   } = tradeQuoteStep
 
   // the txStatus needs to be undefined before the tx is executed to handle "ready" but not "executing" status
@@ -361,6 +362,8 @@ export const FirstHop = ({
       txStatus={txStatus}
       isOpen={isOpen}
       onToggleIsOpen={onToggleIsOpen}
+      estimatedExecutionTimeMs={estimatedExecutionTimeMs}
+      executionTimeRemainingMs={undefined} // TODO: implement this
     />
   )
 }

--- a/src/components/MultiHopTrade/components/MultiHopTradeConfirm/components/Hop.tsx
+++ b/src/components/MultiHopTrade/components/MultiHopTradeConfirm/components/Hop.tsx
@@ -19,6 +19,7 @@ import {
   useColorModeValue,
 } from '@chakra-ui/react'
 import { TxStatus } from '@shapeshiftoss/unchained-client'
+import prettyMilliseconds from 'pretty-ms'
 import { useMemo } from 'react'
 import { FaAdjust, FaGasPump, FaProcedures } from 'react-icons/fa'
 import { Amount } from 'components/Amount/Amount'
@@ -37,6 +38,8 @@ export const Hop = ({
   hopIndex,
   txStatus,
   isOpen,
+  estimatedExecutionTimeMs,
+  executionTimeRemainingMs,
   onToggleIsOpen,
 }: {
   steps: StepperStep[]
@@ -48,21 +51,28 @@ export const Hop = ({
   hopIndex: number
   txStatus?: TxStatus
   isOpen: boolean
+  estimatedExecutionTimeMs?: number
+  executionTimeRemainingMs?: number
   onToggleIsOpen: () => void
 }) => {
   const backgroundColor = useColorModeValue('gray.100', 'gray.750')
   const borderColor = useColorModeValue('gray.50', 'gray.650')
 
-  const timeEstimate = '4m'
-  const timeRemaining = '3:35'
-
   const rightComponent = useMemo(() => {
     switch (txStatus) {
       case undefined:
       case TxStatus.Unknown:
-        return <RawText>{timeEstimate}</RawText>
+        return (
+          estimatedExecutionTimeMs !== undefined && (
+            <RawText>{prettyMilliseconds(estimatedExecutionTimeMs)}</RawText>
+          )
+        )
       case TxStatus.Pending:
-        return <RawText>{timeRemaining}</RawText>
+        return (
+          executionTimeRemainingMs !== undefined && (
+            <RawText>{prettyMilliseconds(executionTimeRemainingMs)}</RawText>
+          )
+        )
       case TxStatus.Confirmed:
         return (
           <Box width='auto'>
@@ -81,7 +91,7 @@ export const Hop = ({
       default:
         return null
     }
-  }, [isOpen, onToggleIsOpen, txStatus])
+  }, [estimatedExecutionTimeMs, executionTimeRemainingMs, isOpen, onToggleIsOpen, txStatus])
 
   return (
     <Card

--- a/src/components/MultiHopTrade/components/TradeInput/components/TradeQuotes/TradeQuote.tsx
+++ b/src/components/MultiHopTrade/components/TradeInput/components/TradeQuotes/TradeQuote.tsx
@@ -183,6 +183,14 @@ export const TradeQuoteLoaded: FC<TradeQuoteProps> = ({
 
   const showSwapper = !!quote || showSwapperError
 
+  const totalEstimatedExecutionTimeMs = useMemo(
+    () =>
+      quote?.steps.reduce((acc, step) => {
+        return acc + (step.estimatedExecutionTimeMs ?? 0)
+      }, 0),
+    [quote?.steps],
+  )
+
   return showSwapper ? (
     <>
       <Card
@@ -256,17 +264,16 @@ export const TradeQuoteLoaded: FC<TradeQuoteProps> = ({
         {quote && (
           <CardFooter px={4} pb={4}>
             <Flex justifyContent='left' alignItems='left' gap={8}>
-              {quote.estimatedExecutionTimeMs !== undefined &&
-                quote.estimatedExecutionTimeMs > 0 && (
-                  <Skeleton isLoaded={!isLoading}>
-                    <Flex gap={2} alignItems='center'>
-                      <RawText color='text.subtle'>
-                        <FaRegClock />
-                      </RawText>
-                      {prettyMilliseconds(quote.estimatedExecutionTimeMs)}
-                    </Flex>
-                  </Skeleton>
-                )}
+              {totalEstimatedExecutionTimeMs !== undefined && totalEstimatedExecutionTimeMs > 0 && (
+                <Skeleton isLoaded={!isLoading}>
+                  <Flex gap={2} alignItems='center'>
+                    <RawText color='text.subtle'>
+                      <FaRegClock />
+                    </RawText>
+                    {prettyMilliseconds(totalEstimatedExecutionTimeMs)}
+                  </Flex>
+                </Skeleton>
+              )}
               <Skeleton isLoaded={!isLoading}>
                 <Flex gap={2} alignItems='center'>
                   <RawText color='text.subtle'>

--- a/src/components/MultiHopTrade/hooks/useHopHelper.tsx
+++ b/src/components/MultiHopTrade/hooks/useHopHelper.tsx
@@ -29,6 +29,9 @@ export const useHopHelper = () => {
     [sellAccountId, firstHopSellFeeAsset?.assetId],
   )
 
+  // TODO(woodenfurniture): sellAccountId should be specific to the second hop since it may be a different
+  // account to the first hop. This explains why multi hop quotes always have insufficient balance
+  // for gas.
   const lastHopFeeAssetBalanceFilter = useMemo(
     () => ({ assetId: lastHopSellFeeAsset?.assetId, accountId: sellAccountId ?? '' }),
     [sellAccountId, lastHopSellFeeAsset?.assetId],

--- a/src/lib/swapper/swappers/CowSwapper/getCowSwapTradeQuote/getCowSwapTradeQuote.test.ts
+++ b/src/lib/swapper/swappers/CowSwapper/getCowSwapTradeQuote/getCowSwapTradeQuote.test.ts
@@ -98,9 +98,9 @@ const expectedTradeQuoteWethToFox: TradeQuote = {
   receiveAddress: '0x0000000000000000000000000000000000000000',
   affiliateBps: undefined,
   rate: '14924.80846543344314936607', // 14942 FOX per WETH
-  estimatedExecutionTimeMs: undefined,
   steps: [
     {
+      estimatedExecutionTimeMs: undefined,
       allowanceContract: '0xc92e8bdf79f0507f65a392b0ab4667716bfe0110',
       rate: '14924.80846543344314936607', // 14942 FOX per WETH
       feeData: {
@@ -129,9 +129,9 @@ const expectedTradeQuoteFoxToEth: TradeQuote = {
   receiveAddress: '0x0000000000000000000000000000000000000000',
   affiliateBps: undefined,
   rate: '0.00004995640398295996',
-  estimatedExecutionTimeMs: undefined,
   steps: [
     {
+      estimatedExecutionTimeMs: undefined,
       allowanceContract: '0xc92e8bdf79f0507f65a392b0ab4667716bfe0110',
       rate: '0.00004995640398295996',
       feeData: {
@@ -160,11 +160,11 @@ const expectedTradeQuoteUsdcToXdai: TradeQuote = {
   receiveAddress: '0x0000000000000000000000000000000000000000',
   affiliateBps: undefined,
   rate: '1.0003121775396440882',
-  estimatedExecutionTimeMs: undefined,
   steps: [
     {
       allowanceContract: '0xc92e8bdf79f0507f65a392b0ab4667716bfe0110',
       rate: '1.0003121775396440882',
+      estimatedExecutionTimeMs: undefined,
       feeData: {
         protocolFees: {
           [USDC_GNOSIS.assetId]: {
@@ -191,9 +191,9 @@ const expectedTradeQuoteSmallAmountWethToFox: TradeQuote = {
   receiveAddress: '0x0000000000000000000000000000000000000000',
   affiliateBps: undefined,
   rate: '14716.04718939437523468382', // 14716 FOX per WETH
-  estimatedExecutionTimeMs: undefined,
   steps: [
     {
+      estimatedExecutionTimeMs: undefined,
       allowanceContract: '0xc92e8bdf79f0507f65a392b0ab4667716bfe0110',
       rate: '14716.04718939437523468382', // 14716 FOX per WETH
       feeData: {

--- a/src/lib/swapper/swappers/CowSwapper/getCowSwapTradeQuote/getCowSwapTradeQuote.ts
+++ b/src/lib/swapper/swappers/CowSwapper/getCowSwapTradeQuote/getCowSwapTradeQuote.ts
@@ -103,9 +103,9 @@ export async function getCowSwapTradeQuote(
     receiveAddress,
     affiliateBps: undefined,
     rate,
-    estimatedExecutionTimeMs: undefined,
     steps: [
       {
+        estimatedExecutionTimeMs: undefined,
         allowanceContract: COW_SWAP_VAULT_RELAYER_ADDRESS,
         rate,
         feeData: {

--- a/src/lib/swapper/swappers/LifiSwapper/getTradeQuote/getTradeQuote.ts
+++ b/src/lib/swapper/swappers/LifiSwapper/getTradeQuote/getTradeQuote.ts
@@ -4,6 +4,7 @@ import type { AssetId, ChainId } from '@shapeshiftoss/caip'
 import { fromChainId } from '@shapeshiftoss/caip'
 import type { Result } from '@sniptt/monads'
 import { Err, Ok } from '@sniptt/monads'
+import { getConfig } from 'config'
 import { getDefaultSlippageDecimalPercentageForSwapper } from 'constants/constants'
 import type { Asset } from 'lib/asset-service'
 import { bn, bnOrZero, convertPrecision } from 'lib/bignumber/bignumber'
@@ -16,9 +17,11 @@ import type { LifiTradeQuote } from 'lib/swapper/swappers/LifiSwapper/utils/type
 import type { GetEvmTradeQuoteInput, SwapErrorRight, SwapSource } from 'lib/swapper/types'
 import { SwapErrorType, SwapperName } from 'lib/swapper/types'
 import { makeSwapErrorRight } from 'lib/swapper/utils'
+import { isFulfilled } from 'lib/utils'
 import { convertBasisPointsToDecimalPercentage } from 'state/slices/tradeQuoteSlice/utils'
 
 import { getNetworkFeeCryptoBaseUnit } from '../utils/getNetworkFeeCryptoBaseUnit/getNetworkFeeCryptoBaseUnit'
+import { lifiTokenToAsset } from '../utils/lifiTokenToAsset/lifiTokenToAsset'
 
 export async function getTradeQuote(
   input: GetEvmTradeQuoteInput,
@@ -26,7 +29,6 @@ export async function getTradeQuote(
   assets: Partial<Record<AssetId, Asset>>,
 ): Promise<Result<LifiTradeQuote[], SwapErrorRight>> {
   const {
-    chainId,
     sellAsset,
     buyAsset,
     sellAmountIncludingProtocolFeesCryptoBaseUnit,
@@ -81,10 +83,7 @@ export async function getTradeQuote(
           getDefaultSlippageDecimalPercentageForSwapper(SwapperName.LIFI),
       ),
       exchanges: { deny: ['dodo'] },
-      // TODO(gomes): We don't currently handle trades that require a mid-trade user-initiated Tx on a different chain
-      // i.e we would theoretically handle the Tx itself, but not approvals on said chain if needed
-      // use the `allowSwitchChain` param above when implemented
-      allowSwitchChain: false,
+      allowSwitchChain: getConfig().REACT_APP_FEATURE_MULTI_HOP_TRADES,
       fee: convertBasisPointsToDecimalPercentage(affiliateBps).toNumber(),
     },
   }
@@ -131,112 +130,108 @@ export async function getTradeQuote(
     )
   }
 
-  return Ok(
-    await Promise.all(
-      routes.slice(0, 3).map(async selectedLifiRoute => {
-        // this corresponds to a "hop", so we could map the below code over selectedLifiRoute.steps to
-        // generate a multi-hop quote
-        const steps = await Promise.all(
-          selectedLifiRoute.steps.map(async lifiStep => {
-            // for the rate to be valid, both amounts must be converted to the same precision
-            const estimateRate = convertPrecision({
-              value: selectedLifiRoute.toAmountMin,
-              inputExponent: buyAsset.precision,
-              outputExponent: sellAsset.precision,
-            })
-              .dividedBy(bn(selectedLifiRoute.fromAmount))
-              .toString()
+  const promises = await Promise.allSettled(
+    routes.slice(0, 3).map(async selectedLifiRoute => {
+      // this corresponds to a "hop", so we could map the below code over selectedLifiRoute.steps to
+      // generate a multi-hop quote
+      const steps = await Promise.all(
+        selectedLifiRoute.steps.map(async lifiStep => {
+          const stepSellAsset = lifiTokenToAsset(lifiStep.action.fromToken, assets)
+          const stepChainId = stepSellAsset.chainId
+          const stepBuyAsset = lifiTokenToAsset(lifiStep.action.toToken, assets)
 
-            const protocolFees = transformLifiStepFeeData({
-              chainId,
-              lifiStep,
-              assets,
-            })
+          // for the rate to be valid, both amounts must be converted to the same precision
+          const estimateRate = convertPrecision({
+            value: selectedLifiRoute.toAmountMin,
+            inputExponent: stepBuyAsset.precision,
+            outputExponent: stepSellAsset.precision,
+          })
+            .dividedBy(bn(selectedLifiRoute.fromAmount))
+            .toString()
 
-            const sellAssetProtocolFee = protocolFees[sellAsset.assetId]
-            const buyAssetProtocolFee = protocolFees[buyAsset.assetId]
-            const sellSideProtocolFeeCryptoBaseUnit = bnOrZero(
-              sellAssetProtocolFee?.amountCryptoBaseUnit,
-            )
-            const sellSideProtocolFeeBuyAssetBaseUnit = bnOrZero(
-              convertPrecision({
-                value: sellSideProtocolFeeCryptoBaseUnit,
-                inputExponent: sellAsset.precision,
-                outputExponent: buyAsset.precision,
-              }),
-            ).times(estimateRate)
-            const buySideProtocolFeeCryptoBaseUnit = bnOrZero(
-              buyAssetProtocolFee?.amountCryptoBaseUnit,
-            )
+          const protocolFees = transformLifiStepFeeData({
+            chainId: stepChainId,
+            lifiStep,
+            assets,
+          })
 
-            const buyAmountAfterFeesCryptoBaseUnit = bnOrZero(
-              selectedLifiRoute.toAmount,
-            ).toPrecision()
+          const sellAssetProtocolFee = protocolFees[stepSellAsset.assetId]
+          const buyAssetProtocolFee = protocolFees[stepBuyAsset.assetId]
+          const sellSideProtocolFeeCryptoBaseUnit = bnOrZero(
+            sellAssetProtocolFee?.amountCryptoBaseUnit,
+          )
+          const sellSideProtocolFeeBuyAssetBaseUnit = bnOrZero(
+            convertPrecision({
+              value: sellSideProtocolFeeCryptoBaseUnit,
+              inputExponent: stepSellAsset.precision,
+              outputExponent: stepBuyAsset.precision,
+            }),
+          ).times(estimateRate)
+          const buySideProtocolFeeCryptoBaseUnit = bnOrZero(
+            buyAssetProtocolFee?.amountCryptoBaseUnit,
+          )
 
-            // TODO: Add buySideNetworkFeeCryptoBaseUnit when we implement multihop
-            const buyAmountBeforeFeesCryptoBaseUnit = bnOrZero(buyAmountAfterFeesCryptoBaseUnit)
-              .plus(sellSideProtocolFeeBuyAssetBaseUnit)
-              .plus(buySideProtocolFeeCryptoBaseUnit)
-              .toString()
+          const buyAmountAfterFeesCryptoBaseUnit = bnOrZero(
+            selectedLifiRoute.toAmount,
+          ).toPrecision()
 
-            const intermediaryTransactionOutputs = getIntermediaryTransactionOutputs(
-              assets,
-              lifiStep,
-            )
+          // TODO: Add buySideNetworkFeeCryptoBaseUnit when we implement multihop
+          const buyAmountBeforeFeesCryptoBaseUnit = bnOrZero(buyAmountAfterFeesCryptoBaseUnit)
+            .plus(sellSideProtocolFeeBuyAssetBaseUnit)
+            .plus(buySideProtocolFeeCryptoBaseUnit)
+            .toString()
 
-            const networkFeeCryptoBaseUnit = await getNetworkFeeCryptoBaseUnit({
-              chainId,
-              lifiStep,
-              supportsEIP1559,
-            })
+          const intermediaryTransactionOutputs = getIntermediaryTransactionOutputs(assets, lifiStep)
 
-            const source: SwapSource = `${SwapperName.LIFI} • ${lifiStep.toolDetails.name}`
+          const networkFeeCryptoBaseUnit = await getNetworkFeeCryptoBaseUnit({
+            chainId: stepChainId,
+            lifiStep,
+            supportsEIP1559,
+          })
 
-            return {
-              allowanceContract: lifiStep.estimate.approvalAddress,
-              accountNumber,
-              buyAmountBeforeFeesCryptoBaseUnit,
-              buyAmountAfterFeesCryptoBaseUnit,
-              buyAsset,
-              intermediaryTransactionOutputs,
-              feeData: {
-                protocolFees,
-                networkFeeCryptoBaseUnit,
-              },
-              // TODO(woodenfurniture):  this step-level key should be a step-level value, rather than the top-level rate.
-              // might be better replaced by inputOutputRatio downstream
-              rate: estimateRate,
-              sellAmountIncludingProtocolFeesCryptoBaseUnit,
-              sellAsset,
-              source,
-            }
-          }),
-        )
+          const source: SwapSource = `${SwapperName.LIFI} • ${lifiStep.toolDetails.name}`
 
-        // The rate for the entire multi-hop swap
-        const netRate = convertPrecision({
-          value: selectedLifiRoute.toAmountMin,
-          inputExponent: buyAsset.precision,
-          outputExponent: sellAsset.precision,
-        })
-          .dividedBy(bn(selectedLifiRoute.fromAmount))
-          .toString()
+          return {
+            allowanceContract: lifiStep.estimate.approvalAddress,
+            accountNumber,
+            buyAmountBeforeFeesCryptoBaseUnit,
+            buyAmountAfterFeesCryptoBaseUnit,
+            buyAsset: stepBuyAsset,
+            intermediaryTransactionOutputs,
+            feeData: {
+              protocolFees,
+              networkFeeCryptoBaseUnit,
+            },
+            // TODO(woodenfurniture):  this step-level key should be a step-level value, rather than the top-level rate.
+            // might be better replaced by inputOutputRatio downstream
+            rate: estimateRate,
+            sellAmountIncludingProtocolFeesCryptoBaseUnit,
+            sellAsset: stepSellAsset,
+            source,
+            estimatedExecutionTimeMs: 1000 * lifiStep.estimate.executionDuration,
+          }
+        }),
+      )
 
-        const estimatedExecutionTimeMs = selectedLifiRoute.steps.reduce(
-          (acc, step) => acc + 1000 * step.estimate.executionDuration,
-          0,
-        )
+      // The rate for the entire multi-hop swap
+      const netRate = convertPrecision({
+        value: selectedLifiRoute.toAmountMin,
+        inputExponent: buyAsset.precision,
+        outputExponent: sellAsset.precision,
+      })
+        .dividedBy(bn(selectedLifiRoute.fromAmount))
+        .toString()
 
-        return {
-          id: selectedLifiRoute.id,
-          receiveAddress,
-          affiliateBps,
-          steps,
-          rate: netRate,
-          estimatedExecutionTimeMs,
-          selectedLifiRoute,
-        }
-      }),
-    ),
+      return {
+        id: selectedLifiRoute.id,
+        receiveAddress,
+        affiliateBps,
+        steps,
+        rate: netRate,
+        selectedLifiRoute,
+      }
+    }),
   )
+
+  return Ok(promises.filter(isFulfilled).map(({ value }) => value))
 }

--- a/src/lib/swapper/swappers/LifiSwapper/utils/lifiTokenToAsset/lifiTokenToAsset.ts
+++ b/src/lib/swapper/swappers/LifiSwapper/utils/lifiTokenToAsset/lifiTokenToAsset.ts
@@ -1,0 +1,30 @@
+import type { Token } from '@lifi/sdk'
+import type { AssetId } from '@shapeshiftoss/caip'
+import type { Asset } from 'lib/asset-service'
+
+import { lifiChainIdToChainId } from '../lifiChainIdtoChainId/lifiChainIdToChainId'
+import { lifiTokenToAssetId } from '../lifiTokenToAssetId/lifiTokenToAssetId'
+
+export const lifiTokenToAsset = (
+  lifiToken: Token,
+  assets: Partial<Record<AssetId, Asset>>,
+): Asset => {
+  const assetId = lifiTokenToAssetId(lifiToken)
+  const maybeAsset = assets[assetId]
+  if (maybeAsset) return maybeAsset
+
+  // asset not known by shapeshift
+  // create a placeholder asset using the data we have
+  return {
+    assetId,
+    chainId: lifiChainIdToChainId(lifiToken.chainId),
+    name: lifiToken.name,
+    precision: lifiToken.decimals,
+    symbol: lifiToken.symbol,
+    color: '#000000',
+    icon: lifiToken.logoURI ?? '',
+    explorer: '',
+    explorerTxLink: '',
+    explorerAddressLink: '',
+  }
+}

--- a/src/lib/swapper/swappers/LifiSwapper/utils/lifiTokenToAssetId/lifiTokenToAssetId.ts
+++ b/src/lib/swapper/swappers/LifiSwapper/utils/lifiTokenToAssetId/lifiTokenToAssetId.ts
@@ -12,17 +12,24 @@ import {
 import { DEFAULT_LIFI_TOKEN_ADDRESS } from '../constants'
 
 export const lifiTokenToAssetId = (lifiToken: Token): AssetId => {
+  const chainReference = lifiToken.chainId.toString() as ChainReference
   const chainId = toChainId({
     chainNamespace: CHAIN_NAMESPACE.Evm,
-    chainReference: lifiToken.chainId.toString() as ChainReference,
+    chainReference,
   })
 
   const isDefaultAddress = lifiToken.address === DEFAULT_LIFI_TOKEN_ADDRESS
 
   const { assetReference, assetNamespace } = (() => {
     if (!isDefaultAddress)
-      return { assetReference: lifiToken.address, assetNamespace: ASSET_NAMESPACE.erc20 }
-    switch (lifiToken.chainId.toString()) {
+      return {
+        assetReference: lifiToken.address,
+        assetNamespace:
+          chainReference === CHAIN_REFERENCE.BnbSmartChainMainnet
+            ? ASSET_NAMESPACE.bep20
+            : ASSET_NAMESPACE.erc20,
+      }
+    switch (chainReference) {
       case CHAIN_REFERENCE.EthereumMainnet:
         return {
           assetReference: ASSET_REFERENCE.Ethereum,

--- a/src/lib/swapper/swappers/OneInchSwapper/getTradeQuote/getTradeQuote.ts
+++ b/src/lib/swapper/swappers/OneInchSwapper/getTradeQuote/getTradeQuote.ts
@@ -92,9 +92,9 @@ export async function getTradeQuote(
       receiveAddress,
       affiliateBps,
       rate,
-      estimatedExecutionTimeMs: undefined,
       steps: [
         {
+          estimatedExecutionTimeMs: undefined,
           allowanceContract,
           rate,
           buyAsset,

--- a/src/lib/swapper/swappers/ThorchainSwapper/getThorTradeQuote/getTradeQuote.test.ts
+++ b/src/lib/swapper/swappers/ThorchainSwapper/getThorTradeQuote/getTradeQuote.test.ts
@@ -51,10 +51,10 @@ const expectedQuoteResponse: Omit<ThorEvmTradeQuote, 'id'>[] = [
     rate: '137845.94361267605633802817',
     data: '0x',
     router: '0x3624525075b88B24ecc29CE226b0CEc1fFcB6976',
-    estimatedExecutionTimeMs: 1600000,
     memo: '=:ETH.ETH:0x32DBc9Cf9E8FbCebE1e0a2ecF05Ed86Ca3096Cb6:9360639:ss:0',
     steps: [
       {
+        estimatedExecutionTimeMs: 1600000,
         allowanceContract: '0x3624525075b88B24ecc29CE226b0CEc1fFcB6976',
         sellAmountIncludingProtocolFeesCryptoBaseUnit: '713014679420',
         buyAmountBeforeFeesCryptoBaseUnit: '114321610000000000',
@@ -84,10 +84,10 @@ const expectedQuoteResponse: Omit<ThorEvmTradeQuote, 'id'>[] = [
     rate: '151555.07377464788732394366',
     data: '0x',
     router: '0x3624525075b88B24ecc29CE226b0CEc1fFcB6976',
-    estimatedExecutionTimeMs: 1600000,
     memo: '=:ETH.ETH:0x32DBc9Cf9E8FbCebE1e0a2ecF05Ed86Ca3096Cb6:10291579/10/0:ss:0',
     steps: [
       {
+        estimatedExecutionTimeMs: 1600000,
         allowanceContract: '0x3624525075b88B24ecc29CE226b0CEc1fFcB6976',
         sellAmountIncludingProtocolFeesCryptoBaseUnit: '713014679420',
         buyAmountBeforeFeesCryptoBaseUnit: '124321610000000000',

--- a/src/lib/swapper/swappers/ThorchainSwapper/getThorTradeQuote/getTradeQuote.ts
+++ b/src/lib/swapper/swappers/ThorchainSwapper/getThorTradeQuote/getTradeQuote.ts
@@ -305,12 +305,12 @@ export const getThorTradeQuote = async (
               receiveAddress,
               affiliateBps,
               isStreaming,
-              estimatedExecutionTimeMs,
               rate,
               data,
               router,
               steps: [
                 {
+                  estimatedExecutionTimeMs,
                   rate,
                   sellAmountIncludingProtocolFeesCryptoBaseUnit: sellAmountCryptoBaseUnit,
                   buyAmountBeforeFeesCryptoBaseUnit,
@@ -398,10 +398,10 @@ export const getThorTradeQuote = async (
               receiveAddress,
               affiliateBps,
               isStreaming,
-              estimatedExecutionTimeMs,
               rate,
               steps: [
                 {
+                  estimatedExecutionTimeMs,
                   rate,
                   sellAmountIncludingProtocolFeesCryptoBaseUnit: sellAmountCryptoBaseUnit,
                   buyAmountBeforeFeesCryptoBaseUnit,
@@ -474,10 +474,10 @@ export const getThorTradeQuote = async (
               receiveAddress,
               affiliateBps,
               isStreaming,
-              estimatedExecutionTimeMs,
               rate,
               steps: [
                 {
+                  estimatedExecutionTimeMs,
                   rate,
                   sellAmountIncludingProtocolFeesCryptoBaseUnit: sellAmountCryptoBaseUnit,
                   buyAmountBeforeFeesCryptoBaseUnit,

--- a/src/lib/swapper/swappers/ZrxSwapper/getZrxTradeQuote/getZrxTradeQuote.ts
+++ b/src/lib/swapper/swappers/ZrxSwapper/getZrxTradeQuote/getZrxTradeQuote.ts
@@ -99,13 +99,13 @@ export async function getZrxTradeQuote(
 
     return Ok({
       id: uuid(),
-      estimatedExecutionTimeMs: undefined,
       receiveAddress,
       affiliateBps,
       slippageTolerancePercentage,
       rate,
       steps: [
         {
+          estimatedExecutionTimeMs: undefined,
           allowanceContract: allowanceTarget,
           buyAsset,
           sellAsset,

--- a/src/lib/swapper/swappers/utils/test-data/setupSwapQuote.ts
+++ b/src/lib/swapper/swappers/utils/test-data/setupSwapQuote.ts
@@ -14,9 +14,9 @@ export const setupQuote = () => {
     receiveAddress: '0x1234',
     affiliateBps: undefined,
     rate: '1',
-    estimatedExecutionTimeMs: undefined,
     steps: [
       {
+        estimatedExecutionTimeMs: undefined,
         allowanceContract: 'allowanceContractAddress',
         buyAmountBeforeFeesCryptoBaseUnit: '',
         buyAmountAfterFeesCryptoBaseUnit: '',

--- a/src/lib/swapper/types.ts
+++ b/src/lib/swapper/types.ts
@@ -94,10 +94,10 @@ export type TradeQuoteStep = {
   // execution failure
   intermediaryTransactionOutputs?: AmountDisplayMeta[]
   allowanceContract: string
+  estimatedExecutionTimeMs: number | undefined
 }
 
 export type TradeQuote = {
-  estimatedExecutionTimeMs: number | undefined
   id: string
   steps: TradeQuoteStep[]
   rate: string // top-level rate for all steps (i.e. output amount / input amount)

--- a/src/state/apis/swappers/helpers/testData.ts
+++ b/src/state/apis/swappers/helpers/testData.ts
@@ -6,9 +6,9 @@ export const lifiQuote: TradeQuote = {
   rate: '51.34579860391078801712',
   affiliateBps: undefined,
   receiveAddress: '0x31b5c4ab7d020de87901c736535aeb4769806947',
-  estimatedExecutionTimeMs: undefined,
   steps: [
     {
+      estimatedExecutionTimeMs: undefined,
       allowanceContract: '0x1231DEB6f5749EF6cE6943a275A1D3E7486F4EaE',
       accountNumber: 0,
       buyAmountBeforeFeesCryptoBaseUnit: '1.0269262412379365425e+21',
@@ -53,9 +53,9 @@ export const thorQuote: TradeQuote = {
   rate: '39.23942597524024759752',
   receiveAddress: '0x31b5c4ab7d020de87901c736535aeb4769806947',
   affiliateBps: '30',
-  estimatedExecutionTimeMs: undefined,
   steps: [
     {
+      estimatedExecutionTimeMs: undefined,
       rate: '39.23942597524024759752',
       sellAmountIncludingProtocolFeesCryptoBaseUnit: '20000200',
       buyAmountBeforeFeesCryptoBaseUnit: '1043948034150000000000',
@@ -133,9 +133,9 @@ export const oneInchQuote: TradeQuote = {
   rate: '51.63754486526613135844',
   affiliateBps: undefined,
   receiveAddress: '0x31b5c4ab7d020de87901c736535aeb4769806947',
-  estimatedExecutionTimeMs: undefined,
   steps: [
     {
+      estimatedExecutionTimeMs: undefined,
       allowanceContract: '0x1111111254eeb25477b68fb85ed929f73a960582',
       rate: '51.63754486526613135844',
       buyAsset: {
@@ -180,9 +180,9 @@ export const cowQuote: TradeQuote = {
   rate: '51.86127422365727736757',
   affiliateBps: undefined,
   receiveAddress: '0x31b5c4ab7d020de87901c736535aeb4769806947',
-  estimatedExecutionTimeMs: undefined,
   steps: [
     {
+      estimatedExecutionTimeMs: undefined,
       allowanceContract: '0xc92e8bdf79f0507f65a392b0ab4667716bfe0110',
       rate: '51.86127422365727736757',
       feeData: {
@@ -244,9 +244,9 @@ export const zrxQuote: TradeQuote = {
   rate: '51.603817692372651273',
   affiliateBps: undefined,
   receiveAddress: '0x31b5c4ab7d020de87901c736535aeb4769806947',
-  estimatedExecutionTimeMs: undefined,
   steps: [
     {
+      estimatedExecutionTimeMs: undefined,
       allowanceContract: '0xdef1c0ded9bec7f1a1670819833240f027b25eff',
       buyAsset: {
         assetId: 'eip155:1/erc20:0xc770eefad204b5180df6a14ee197d99d808ee52d',


### PR DESCRIPTION
## Description

Wires up multi hop quotes to the new multi hop ui. 

Includes a change to make execution time estimates per-hop so we can display the time estimate on each hop. Should not affect single hop trades as the total and the individual estimate is the same value.

Note that multi-hop quotes are still WIP because the app currently uses the wrong account for balances checks on the second hop.

## Pull Request Type

- [ ] :bug: Bug fix (Non-breaking Change: Fixes an issue)
- [ ] :hammer_and_wrench: Chore (Non-breaking Change: Doc updates, pkg upgrades, typos, etc..)
- [x] :nail_care: New Feature (Breaking/Non-breaking Change)

## Issue (if applicable)

NA

## Risk

Low risk - may affect single hop trades and time estimates.

## Testing

Check single hop trades and existing ui is unaffected.

### Engineering

☝️

### Operations

☝️

## Screenshots (if applicable)
