### PR TITLE
feat: handle multi hop account ids automatically

### DIFF
--- a/src/components/MultiHopTrade/components/Approval/Approval.tsx
+++ b/src/components/MultiHopTrade/components/Approval/Approval.tsx
@@ -33,7 +33,7 @@ import { useLocaleFormatter } from 'hooks/useLocaleFormatter/useLocaleFormatter'
 import { useToggle } from 'hooks/useToggle/useToggle'
 import { useWallet } from 'hooks/useWallet/useWallet'
 import { baseUnitToHuman } from 'lib/bignumber/bignumber'
-import type { SwapperName, TradeQuote } from 'lib/swapper/types'
+import type { SwapperName, TradeQuoteStep } from 'lib/swapper/types'
 import { selectUserCurrencyRateByAssetId } from 'state/slices/marketDataSlice/selectors'
 import {
   selectActiveSwapperName,
@@ -52,7 +52,7 @@ const ApprovalInner = ({
   tradeQuoteStep,
 }: {
   swapperName: SwapperName
-  tradeQuoteStep: TradeQuote['steps'][number]
+  tradeQuoteStep: TradeQuoteStep
 }) => {
   const history = useHistory()
   const translate = useTranslate()
@@ -94,7 +94,7 @@ const ApprovalInner = ({
     approvalTxId,
     approvalNetworkFeeCryptoBaseUnit,
     isLoading: isAllowanceApprovalHookLoading,
-  } = useAllowanceApproval(tradeQuoteStep, isExactAllowance)
+  } = useAllowanceApproval(tradeQuoteStep, true, isExactAllowance)
 
   const approvalNetworkFeeCryptoHuman = useMemo(() => {
     if (!approvalNetworkFeeCryptoBaseUnit || !sellFeeAsset) return

--- a/src/components/MultiHopTrade/components/AssetSelection.tsx
+++ b/src/components/MultiHopTrade/components/AssetSelection.tsx
@@ -1,9 +1,8 @@
 import { ChevronDownIcon } from '@chakra-ui/icons'
 import { Button, Flex, Skeleton, SkeletonCircle, Stack, useColorModeValue } from '@chakra-ui/react'
-import type { AccountId, AssetId } from '@shapeshiftoss/caip'
+import type { AssetId } from '@shapeshiftoss/caip'
 import { PairIcons } from 'features/defi/components/PairIcons/PairIcons'
 import { memo, useCallback, useMemo } from 'react'
-import type { AccountDropdownProps } from 'components/AccountDropdown/AccountDropdown'
 import { AssetIcon } from 'components/AssetIcon'
 import { Text } from 'components/Text'
 import type { Asset } from 'lib/asset-service'
@@ -31,14 +30,9 @@ const TradeAssetAwaitingAsset = () => {
 
 type TradeAssetSelectProps = {
   assetId?: AssetId
-  onAccountIdChange: AccountDropdownProps['onChange']
-  accountId?: AccountId | undefined
-  accountSelectionDisabled?: boolean
+  isReadOnly?: boolean
   onAssetClick?: () => void
   onAssetChange: (asset: Asset) => void
-  label: string
-  align?: 'left' | 'right'
-  isReadOnly?: boolean
 }
 
 export const TradeAssetSelectWithAsset: React.FC<TradeAssetSelectProps> = ({
@@ -103,9 +97,9 @@ export const TradeAssetSelectWithAsset: React.FC<TradeAssetSelectProps> = ({
 }
 
 export const TradeAssetSelect: React.FC<TradeAssetSelectProps> = memo(
-  ({ assetId, accountId, ...restAssetInputProps }) => {
+  ({ assetId, ...restAssetInputProps }) => {
     return assetId ? (
-      <TradeAssetSelectWithAsset assetId={assetId} accountId={accountId} {...restAssetInputProps} />
+      <TradeAssetSelectWithAsset assetId={assetId} {...restAssetInputProps} />
     ) : (
       <TradeAssetAwaitingAsset />
     )

--- a/src/components/MultiHopTrade/components/MultiHopTradeConfirm/components/FirstHop.tsx
+++ b/src/components/MultiHopTrade/components/MultiHopTradeConfirm/components/FirstHop.tsx
@@ -29,7 +29,11 @@ import {
   getHopSummaryStep,
 } from './steps'
 
-const useMockAllowanceApproval = (_tradeQuoteStep: TradeQuoteStep, _isExactAllowance: boolean) => {
+const useMockAllowanceApproval = (
+  _tradeQuoteStep: TradeQuoteStep,
+  _isFirstHop: boolean,
+  _isExactAllowance: boolean,
+) => {
   const [approvalTxId, setApprovalTxId] = useState<string>()
   const [approvalTxStatus, setApprovalTxStatus] = useState<TxStatus>(TxStatus.Unknown)
   const executeAllowanceApproval = useCallback(() => {
@@ -114,7 +118,7 @@ export const FirstHop = ({
     approvalTxId,
     approvalTxStatus: _approvalTxStatus,
     approvalNetworkFeeCryptoBaseUnit,
-  } = useMockAllowanceApproval(tradeQuoteStep, isExactAllowance) // TODO: use the real hook here
+  } = useMockAllowanceApproval(tradeQuoteStep, true, isExactAllowance) // TODO: use the real hook here
 
   const handleSignTx = useCallback(async () => {
     // next state

--- a/src/components/MultiHopTrade/components/MultiHopTradeConfirm/components/SecondHop.tsx
+++ b/src/components/MultiHopTrade/components/MultiHopTradeConfirm/components/SecondHop.tsx
@@ -56,7 +56,7 @@ export const SecondHop = ({
     executeAllowanceApproval,
     approvalTxId,
     approvalNetworkFeeCryptoBaseUnit,
-  } = useAllowanceApproval(tradeQuoteStep, isExactAllowance)
+  } = useAllowanceApproval(tradeQuoteStep, false, isExactAllowance)
 
   const shouldRenderDonation = bnOrZero(donationAmountUsd).gt(0)
 

--- a/src/components/MultiHopTrade/components/TradeAmountInput.tsx
+++ b/src/components/MultiHopTrade/components/TradeAmountInput.tsx
@@ -79,6 +79,7 @@ export type TradeAmountInputProps = {
   labelPostFix?: JSX.Element
   hideAmounts?: boolean
   layout?: 'inline' | 'stacked'
+  isAccountSelectionDisabled?: boolean
 } & PropsWithChildren
 
 const defaultPercentOptions = [0.25, 0.5, 0.75, 1]
@@ -92,6 +93,7 @@ export const TradeAmountInput: React.FC<TradeAmountInputProps> = memo(
     onMaxClick,
     onPercentOptionClick,
     onAccountIdChange,
+    isAccountSelectionDisabled,
     cryptoAmount,
     isReadOnly,
     isSendMaxDisabled,
@@ -197,7 +199,7 @@ export const TradeAmountInput: React.FC<TradeAmountInputProps> = memo(
               defaultAccountId={accountId}
               assetId={assetId}
               onChange={onAccountIdChange}
-              disabled={false}
+              disabled={isAccountSelectionDisabled}
               autoSelectHighestBalance
               buttonProps={buttonProps}
               boxProps={boxProps}

--- a/src/components/MultiHopTrade/components/TradeInput/TradeInput.tsx
+++ b/src/components/MultiHopTrade/components/TradeInput/TradeInput.tsx
@@ -391,45 +391,23 @@ export const TradeInput = memo(() => {
   const sellTradeAssetSelect = useMemo(
     () => (
       <TradeAssetSelect
-        accountId={sellAssetAccountId}
-        onAccountIdChange={setSellAssetAccountId}
         assetId={sellAsset.assetId}
         onAssetClick={handleSellAssetClick}
-        label={translate('trade.from')}
         onAssetChange={setSellAsset}
       />
     ),
-    [
-      handleSellAssetClick,
-      sellAsset.assetId,
-      sellAssetAccountId,
-      setSellAsset,
-      setSellAssetAccountId,
-      translate,
-    ],
+    [handleSellAssetClick, sellAsset.assetId, setSellAsset],
   )
 
   const buyTradeAssetSelect = useMemo(
     () => (
       <TradeAssetSelect
-        accountId={buyAssetAccountId}
         assetId={buyAsset.assetId}
         onAssetClick={handleBuyAssetClick}
-        onAccountIdChange={setBuyAssetAccountId}
-        accountSelectionDisabled={!swapperSupportsCrossAccountTrade}
-        label={translate('trade.to')}
         onAssetChange={setBuyAsset}
       />
     ),
-    [
-      buyAsset.assetId,
-      buyAssetAccountId,
-      handleBuyAssetClick,
-      setBuyAsset,
-      setBuyAssetAccountId,
-      swapperSupportsCrossAccountTrade,
-      translate,
-    ],
+    [buyAsset.assetId, handleBuyAssetClick, setBuyAsset],
   )
 
   return (
@@ -503,6 +481,7 @@ export const TradeInput = memo(() => {
               showFiatSkeleton={isLoading}
               label={translate('trade.youGet')}
               onAccountIdChange={setBuyAssetAccountId}
+              isAccountSelectionDisabled={!swapperSupportsCrossAccountTrade}
               formControlProps={formControlProps}
               labelPostFix={buyTradeAssetSelect}
             >

--- a/src/components/MultiHopTrade/hooks/quoteValidation/useInsufficientBalanceProtocolFeeMeta.tsx
+++ b/src/components/MultiHopTrade/hooks/quoteValidation/useInsufficientBalanceProtocolFeeMeta.tsx
@@ -11,7 +11,10 @@ import {
   selectAccountNumberByAccountId,
   selectPortfolioAccountIdByNumberByChainId,
 } from 'state/slices/portfolioSlice/selectors'
-import { selectBuyAccountId, selectSellAccountId } from 'state/slices/swappersSlice/selectors'
+import {
+  selectFirstHopSellAccountId,
+  selectLastHopBuyAccountId,
+} from 'state/slices/swappersSlice/selectors'
 import {
   selectLastHopBuyAsset,
   selectTotalProtocolFeeByAsset,
@@ -21,8 +24,8 @@ import { useAppSelector } from 'state/store'
 export const useInsufficientBalanceProtocolFeeMeta = () => {
   const wallet = useWallet().state.wallet
 
-  const sellAssetAccountId = useAppSelector(selectSellAccountId)
-  const buyAssetAccountId = useAppSelector(selectBuyAccountId)
+  const sellAssetAccountId = useAppSelector(selectFirstHopSellAccountId)
+  const buyAssetAccountId = useAppSelector(selectLastHopBuyAccountId)
   const sellAssetAccountNumber = useAppSelector(state =>
     selectAccountNumberByAccountId(state, { accountId: sellAssetAccountId }),
   )

--- a/src/components/MultiHopTrade/hooks/useAccountIds.tsx
+++ b/src/components/MultiHopTrade/hooks/useAccountIds.tsx
@@ -1,6 +1,6 @@
 import type { AccountId } from '@shapeshiftoss/caip'
 import { useCallback } from 'react'
-import { selectBuyAccountId, selectSellAccountId } from 'state/slices/selectors'
+import { selectFirstHopSellAccountId, selectLastHopBuyAccountId } from 'state/slices/selectors'
 import { swappers } from 'state/slices/swappersSlice/swappersSlice'
 import { useAppDispatch, useAppSelector } from 'state/store'
 
@@ -11,18 +11,21 @@ export const useAccountIds = (): {
   setSellAssetAccountId: (accountId: AccountId) => void
 } => {
   const dispatch = useAppDispatch()
-  const sellAssetAccountId = useAppSelector(selectSellAccountId)
-  const buyAssetAccountId = useAppSelector(selectBuyAccountId)
+
+  // currently, a multi-hop trade will be automagically routed though the accountId corresponding to
+  // the accountNumber for the first hop.
+  const sellAssetAccountId = useAppSelector(selectFirstHopSellAccountId)
+  const buyAssetAccountId = useAppSelector(selectLastHopBuyAccountId)
 
   const setSellAssetAccountId = useCallback(
     (accountId: AccountId | undefined) =>
-      dispatch(swappers.actions.setSellAssetAccountId(accountId)),
+      dispatch(swappers.actions.setSellAssetAccountNumber(accountId)),
     [dispatch],
   )
 
   const setBuyAssetAccountId = useCallback(
     (accountId: AccountId | undefined) =>
-      dispatch(swappers.actions.setBuyAssetAccountId(accountId)),
+      dispatch(swappers.actions.setBuyAssetAccountNumber(accountId)),
     [dispatch],
   )
 

--- a/src/components/MultiHopTrade/hooks/useAllowanceApproval/hooks/useApprovalTx.tsx
+++ b/src/components/MultiHopTrade/hooks/useAllowanceApproval/hooks/useApprovalTx.tsx
@@ -5,16 +5,18 @@ import { useEffect, useState } from 'react'
 import { getChainAdapterManager } from 'context/PluginProvider/chainAdapterSingleton'
 import { usePoll } from 'hooks/usePoll/usePoll'
 import { useWallet } from 'hooks/useWallet/useWallet'
-import type { TradeQuote } from 'lib/swapper/types'
+import type { TradeQuoteStep } from 'lib/swapper/types'
 import { isEvmChainAdapter } from 'lib/utils/evm'
-import { selectSellAccountId } from 'state/slices/selectors'
+import { selectFirstHopSellAccountId } from 'state/slices/selectors'
+import { selectLastHopSellAccountId } from 'state/slices/tradeQuoteSlice/selectors'
 import { useAppSelector } from 'state/store'
 
 import { APPROVAL_POLL_INTERVAL_MILLISECONDS } from '../../constants'
 import { getApprovalTxData } from '../helpers'
 
 export const useApprovalTx = (
-  tradeQuoteStep: TradeQuote['steps'][number],
+  tradeQuoteStep: TradeQuoteStep,
+  isFirstHop: boolean,
   isExactAllowance: boolean,
 ) => {
   const [approvalNetworkFeeCryptoBaseUnit, setApprovalNetworkFeeCryptoBaseUnit] = useState<
@@ -24,7 +26,9 @@ export const useApprovalTx = (
   const wallet = useWallet().state.wallet
   const { poll, cancelPolling: stopPolling } = usePoll()
 
-  const sellAssetAccountId = useAppSelector(selectSellAccountId)
+  const sellAssetAccountId = useAppSelector(
+    isFirstHop ? selectFirstHopSellAccountId : selectLastHopSellAccountId,
+  )
   // This accidentally works since all EVM chains share the same address, so there's no need
   // to call adapter.getAddress() later down the call stack
   const from = sellAssetAccountId ? fromAccountId(sellAssetAccountId).account : undefined

--- a/src/components/MultiHopTrade/hooks/useAllowanceApproval/hooks/useExecuteAllowanceApproval.tsx
+++ b/src/components/MultiHopTrade/hooks/useAllowanceApproval/hooks/useExecuteAllowanceApproval.tsx
@@ -6,16 +6,18 @@ import { getChainAdapterManager } from 'context/PluginProvider/chainAdapterSingl
 import { useErrorHandler } from 'hooks/useErrorToast/useErrorToast'
 import { usePoll } from 'hooks/usePoll/usePoll'
 import { useWallet } from 'hooks/useWallet/useWallet'
-import type { TradeQuote } from 'lib/swapper/types'
+import type { TradeQuoteStep } from 'lib/swapper/types'
 import { buildAndBroadcast, isEvmChainAdapter } from 'lib/utils/evm'
-import { selectSellAccountId } from 'state/slices/selectors'
+import { selectFirstHopSellAccountId } from 'state/slices/selectors'
+import { selectLastHopSellAccountId } from 'state/slices/tradeQuoteSlice/selectors'
 import { useAppSelector } from 'state/store'
 
 import { APPROVAL_POLL_INTERVAL_MILLISECONDS } from '../../constants'
 import { checkApprovalNeeded } from '../helpers'
 
 export const useExecuteAllowanceApproval = (
-  tradeQuoteStep: TradeQuote['steps'][number],
+  tradeQuoteStep: TradeQuoteStep,
+  isFirstHop: boolean,
   buildCustomTxInput?: evm.BuildCustomTxInput,
 ) => {
   const [txId, setTxId] = useState<string | undefined>()
@@ -24,7 +26,9 @@ export const useExecuteAllowanceApproval = (
   const { showErrorToast } = useErrorHandler()
   const wallet = useWallet().state.wallet
 
-  const sellAssetAccountId = useAppSelector(selectSellAccountId)
+  const sellAssetAccountId = useAppSelector(
+    isFirstHop ? selectFirstHopSellAccountId : selectLastHopSellAccountId,
+  )
   const executeAllowanceApproval = useCallback(async () => {
     setTxStatus(TxStatus.Pending)
 

--- a/src/components/MultiHopTrade/hooks/useAllowanceApproval/hooks/useIsApprovalNeeded.tsx
+++ b/src/components/MultiHopTrade/hooks/useAllowanceApproval/hooks/useIsApprovalNeeded.tsx
@@ -1,18 +1,21 @@
 import { useEffect, useState } from 'react'
 import { usePoll } from 'hooks/usePoll/usePoll'
 import { useWallet } from 'hooks/useWallet/useWallet'
-import type { TradeQuote } from 'lib/swapper/types'
-import { selectSellAccountId } from 'state/slices/selectors'
+import type { TradeQuoteStep } from 'lib/swapper/types'
+import { selectFirstHopSellAccountId } from 'state/slices/selectors'
+import { selectLastHopSellAccountId } from 'state/slices/tradeQuoteSlice/selectors'
 import { useAppSelector } from 'state/store'
 
 import { APPROVAL_POLL_INTERVAL_MILLISECONDS } from '../../constants'
 import { checkApprovalNeeded } from '../helpers'
 
-export const useIsApprovalNeeded = (tradeQuoteStep: TradeQuote['steps'][number]) => {
+export const useIsApprovalNeeded = (tradeQuoteStep: TradeQuoteStep, isFirstHop: boolean) => {
   const [isApprovalNeeded, setIsApprovalNeeded] = useState<boolean | undefined>(undefined)
   const { poll } = usePoll()
   const wallet = useWallet().state.wallet
-  const sellAssetAccountId = useAppSelector(selectSellAccountId)
+  const sellAssetAccountId = useAppSelector(
+    isFirstHop ? selectFirstHopSellAccountId : selectLastHopSellAccountId,
+  )
 
   useEffect(() => {
     poll({

--- a/src/components/MultiHopTrade/hooks/useAllowanceApproval/useAllowanceApproval.tsx
+++ b/src/components/MultiHopTrade/hooks/useAllowanceApproval/useAllowanceApproval.tsx
@@ -1,28 +1,29 @@
 import { useCallback, useEffect, useState } from 'react'
-import type { TradeQuote } from 'lib/swapper/types'
+import type { TradeQuoteStep } from 'lib/swapper/types'
 
 import { useApprovalTx } from './hooks/useApprovalTx'
 import { useExecuteAllowanceApproval } from './hooks/useExecuteAllowanceApproval'
 import { useIsApprovalNeeded } from './hooks/useIsApprovalNeeded'
 
 export const useAllowanceApproval = (
-  tradeQuoteStep: TradeQuote['steps'][number],
+  tradeQuoteStep: TradeQuoteStep,
+  isFirstHop: boolean,
   isExactAllowance: boolean,
 ) => {
   const [isLoading, setIsLoading] = useState<boolean>(true)
 
-  const { isApprovalNeeded } = useIsApprovalNeeded(tradeQuoteStep)
+  const { isApprovalNeeded } = useIsApprovalNeeded(tradeQuoteStep, isFirstHop)
   const {
     approvalNetworkFeeCryptoBaseUnit,
     buildCustomTxInput,
     stopPolling: stopPollingBuildApprovalTx,
-  } = useApprovalTx(tradeQuoteStep, isExactAllowance)
+  } = useApprovalTx(tradeQuoteStep, isFirstHop, isExactAllowance)
 
   const {
     executeAllowanceApproval: _executeAllowanceApproval,
     txId: approvalTxId,
     txStatus: approvalTxStatus,
-  } = useExecuteAllowanceApproval(tradeQuoteStep, buildCustomTxInput)
+  } = useExecuteAllowanceApproval(tradeQuoteStep, isFirstHop, buildCustomTxInput)
 
   const executeAllowanceApproval = useCallback(() => {
     stopPollingBuildApprovalTx()

--- a/src/components/MultiHopTrade/hooks/useGetTradeQuotes/useGetTradeQuotes.tsx
+++ b/src/components/MultiHopTrade/hooks/useGetTradeQuotes/useGetTradeQuotes.tsx
@@ -17,10 +17,10 @@ import { isKeepKeyHDWallet, isSkipToken, isSome } from 'lib/utils'
 import type { ApiQuote } from 'state/apis/swappers'
 import { useGetTradeQuoteQuery } from 'state/apis/swappers/swappersApi'
 import {
-  selectBuyAccountId,
   selectBuyAsset,
+  selectFirstHopSellAccountId,
+  selectLastHopBuyAccountId,
   selectPortfolioAccountMetadataByAccountId,
-  selectSellAccountId,
   selectSellAmountCryptoPrecision,
   selectSellAsset,
   selectUserSlippagePercentageDecimal,
@@ -112,8 +112,8 @@ export const useGetTradeQuotes = () => {
   const sellAmountCryptoPrecision = useAppSelector(selectSellAmountCryptoPrecision)
   const userWillDonate = useAppSelector(selectWillDonate)
 
-  const sellAccountId = useAppSelector(selectSellAccountId)
-  const buyAccountId = useAppSelector(selectBuyAccountId)
+  const sellAccountId = useAppSelector(selectFirstHopSellAccountId)
+  const buyAccountId = useAppSelector(selectLastHopBuyAccountId)
 
   const userSlippageTolerancePercentage = useAppSelector(selectUserSlippagePercentageDecimal)
 

--- a/src/components/MultiHopTrade/hooks/useHopHelper.tsx
+++ b/src/components/MultiHopTrade/hooks/useHopHelper.tsx
@@ -3,10 +3,11 @@ import {
   selectPortfolioCryptoBalanceBaseUnitByFilter,
   selectPortfolioCryptoPrecisionBalanceByFilter,
 } from 'state/slices/common-selectors'
-import { selectSellAccountId } from 'state/slices/selectors'
+import { selectFirstHopSellAccountId } from 'state/slices/selectors'
 import {
   selectFirstHopSellAsset,
   selectFirstHopSellFeeAsset,
+  selectLastHopSellAccountId,
   selectLastHopSellFeeAsset,
 } from 'state/slices/tradeQuoteSlice/selectors'
 import { useAppSelector } from 'state/store'
@@ -20,21 +21,18 @@ export const useHopHelper = () => {
   // the network fee asset for the last hop in the trade
   const lastHopSellFeeAsset = useAppSelector(selectLastHopSellFeeAsset)
 
-  // this is the account we're selling from - in this implementation, network fees are always paid
-  // from the sell account regardless of how many hops we have
-  const sellAccountId = useAppSelector(selectSellAccountId)
+  // this is the account we're selling from - network fees are paid from the sell account for the current hop
+  const firstHopSellAccountId = useAppSelector(selectFirstHopSellAccountId)
+  const lastHopSellAccountId = useAppSelector(selectLastHopSellAccountId)
 
   const firstHopFeeAssetBalanceFilter = useMemo(
-    () => ({ assetId: firstHopSellFeeAsset?.assetId, accountId: sellAccountId ?? '' }),
-    [sellAccountId, firstHopSellFeeAsset?.assetId],
+    () => ({ assetId: firstHopSellFeeAsset?.assetId, accountId: firstHopSellAccountId ?? '' }),
+    [firstHopSellAccountId, firstHopSellFeeAsset?.assetId],
   )
 
-  // TODO(woodenfurniture): sellAccountId should be specific to the second hop since it may be a different
-  // account to the first hop. This explains why multi hop quotes always have insufficient balance
-  // for gas.
   const lastHopFeeAssetBalanceFilter = useMemo(
-    () => ({ assetId: lastHopSellFeeAsset?.assetId, accountId: sellAccountId ?? '' }),
-    [sellAccountId, lastHopSellFeeAsset?.assetId],
+    () => ({ assetId: lastHopSellFeeAsset?.assetId, accountId: lastHopSellAccountId ?? '' }),
+    [lastHopSellAccountId, lastHopSellFeeAsset?.assetId],
   )
 
   const firstHopFeeAssetBalancePrecision = useAppSelector(s =>
@@ -46,8 +44,8 @@ export const useHopHelper = () => {
   )
 
   const sellAssetBalanceFilter = useMemo(
-    () => ({ accountId: sellAccountId, assetId: firstHopSellAsset?.assetId ?? '' }),
-    [sellAccountId, firstHopSellAsset?.assetId],
+    () => ({ accountId: firstHopSellAccountId, assetId: firstHopSellAsset?.assetId ?? '' }),
+    [firstHopSellAccountId, firstHopSellAsset?.assetId],
   )
 
   const sellAssetBalanceCryptoBaseUnit = useAppSelector(state =>

--- a/src/components/MultiHopTrade/hooks/useReceiveAddress.tsx
+++ b/src/components/MultiHopTrade/hooks/useReceiveAddress.tsx
@@ -7,7 +7,7 @@ import type { Asset } from 'lib/asset-service'
 import { selectPortfolioAccountMetadataByAccountId } from 'state/slices/portfolioSlice/selectors'
 import { isUtxoAccountId } from 'state/slices/portfolioSlice/utils'
 import {
-  selectBuyAccountId,
+  selectLastHopBuyAccountId,
   selectBuyAsset,
   selectManualReceiveAddress,
 } from 'state/slices/swappersSlice/selectors'
@@ -38,7 +38,7 @@ export const useReceiveAddress = ({
 
   // Selectors
   const buyAsset = useAppSelector(selectBuyAsset)
-  const buyAccountId = useAppSelector(selectBuyAccountId)
+  const buyAccountId = useAppSelector(selectLastHopBuyAccountId)
   const buyAccountMetadata = useAppSelector(state =>
     selectPortfolioAccountMetadataByAccountId(state, { accountId: buyAccountId }),
   )

--- a/src/components/MultiHopTrade/hooks/useReceiveAddress.tsx
+++ b/src/components/MultiHopTrade/hooks/useReceiveAddress.tsx
@@ -7,8 +7,8 @@ import type { Asset } from 'lib/asset-service'
 import { selectPortfolioAccountMetadataByAccountId } from 'state/slices/portfolioSlice/selectors'
 import { isUtxoAccountId } from 'state/slices/portfolioSlice/utils'
 import {
-  selectLastHopBuyAccountId,
   selectBuyAsset,
+  selectLastHopBuyAccountId,
   selectManualReceiveAddress,
 } from 'state/slices/swappersSlice/selectors'
 import { useAppSelector } from 'state/store'

--- a/src/pages/Lending/Pool/components/Borrow/Borrow.tsx
+++ b/src/pages/Lending/Pool/components/Borrow/Borrow.tsx
@@ -107,7 +107,6 @@ const BorrowRoutes = memo(
               cryptoDepositAmount={cryptoDepositAmount}
               fiatDepositAmount={fiatDepositAmount}
               collateralAccountId={collateralAccountId}
-              borrowAccountId={borrowAccountId}
               onCollateralAccountIdChange={handleCollateralAccountIdChange}
               onBorrowAccountIdChange={handleBorrowAccountIdChange}
               onDepositAmountChange={onDepositAmountChange}

--- a/src/pages/Lending/Pool/components/Borrow/BorrowInput.tsx
+++ b/src/pages/Lending/Pool/components/Borrow/BorrowInput.tsx
@@ -44,15 +44,11 @@ type BorrowInputProps = {
   fiatDepositAmount: string | null
   onDepositAmountChange: (value: string, isFiat?: boolean) => void
   collateralAccountId: AccountId
-  borrowAccountId: AccountId
   onCollateralAccountIdChange: (accountId: AccountId) => void
   onBorrowAccountIdChange: (accountId: AccountId) => void
   borrowAsset: Asset | null
   setBorrowAsset: (asset: Asset) => void
 }
-
-// no-op for TradeAssetSelect components
-const handleAccountIdChange = () => {}
 
 export const BorrowInput = ({
   collateralAssetId,
@@ -60,7 +56,6 @@ export const BorrowInput = ({
   fiatDepositAmount,
   onDepositAmountChange,
   collateralAccountId,
-  borrowAccountId,
   onCollateralAccountIdChange: handleCollateralAccountIdChange,
   onBorrowAccountIdChange: handleBorrowAccountIdChange,
   borrowAsset,
@@ -133,31 +128,23 @@ export const BorrowInput = ({
   const depositAssetSelectComponent = useMemo(() => {
     return (
       <TradeAssetSelect
-        accountId={collateralAccountId}
         assetId={collateralAssetId}
         onAssetClick={handleBorrowAssetClick}
-        onAccountIdChange={handleAccountIdChange}
-        accountSelectionDisabled={false}
-        label={'Collateral Asset'}
         onAssetChange={handleAssetChange}
         isReadOnly
       />
     )
-  }, [collateralAccountId, collateralAssetId, handleAssetChange, handleBorrowAssetClick])
+  }, [collateralAssetId, handleAssetChange, handleBorrowAssetClick])
 
   const borrowAssetSelectComponent = useMemo(() => {
     return (
       <TradeAssetSelect
-        accountId={borrowAccountId}
         assetId={borrowAsset?.assetId ?? ''}
         onAssetClick={handleBorrowAssetClick}
-        onAccountIdChange={handleAccountIdChange}
-        accountSelectionDisabled={false}
-        label={'Borrow Asset'}
         onAssetChange={handleAssetChange}
       />
     )
-  }, [borrowAccountId, borrowAsset?.assetId, handleAssetChange, handleBorrowAssetClick])
+  }, [borrowAsset?.assetId, handleAssetChange, handleBorrowAssetClick])
 
   const useLendingQuoteQueryArgs = useMemo(
     () => ({

--- a/src/pages/Lending/Pool/components/Repay/RepayInput.tsx
+++ b/src/pages/Lending/Pool/components/Repay/RepayInput.tsx
@@ -139,39 +139,29 @@ export const RepayInput = ({
     return console.info(asset)
   }, [])
 
-  const handleAccountIdChange = useCallback((_accountId: AccountId) => {}, [])
-
   const repaymentAssetSelectComponent = useMemo(() => {
     return (
       <TradeAssetSelect
-        accountId={''}
         assetId={repaymentAsset?.assetId ?? ''}
         onAssetClick={handleRepaymentAssetClick}
-        onAccountIdChange={handleAccountIdChange}
-        accountSelectionDisabled={false}
-        label={'uhh'}
         onAssetChange={handleAssetChange}
         // Users have the possibility to repay in any supported asset, not only their collateral/borrowed asset
         // https://docs.thorchain.org/thorchain-finance/lending#loan-repayment-closeflow
         isReadOnly={false}
       />
     )
-  }, [handleAccountIdChange, handleAssetChange, handleRepaymentAssetClick, repaymentAsset?.assetId])
+  }, [handleAssetChange, handleRepaymentAssetClick, repaymentAsset?.assetId])
 
   const collateralAssetSelectComponent = useMemo(() => {
     return (
       <TradeAssetSelect
-        accountId={''}
         assetId={collateralAssetId}
         onAssetClick={handleRepaymentAssetClick}
-        onAccountIdChange={handleAccountIdChange}
-        accountSelectionDisabled
-        label={'uhh'}
         onAssetChange={handleAssetChange}
         isReadOnly
       />
     )
-  }, [collateralAssetId, handleAccountIdChange, handleAssetChange, handleRepaymentAssetClick])
+  }, [collateralAssetId, handleAssetChange, handleRepaymentAssetClick])
 
   const handleSeenNotice = useCallback(() => setSeenNotice(true), [])
 

--- a/src/state/slices/portfolioSlice/selectors.ts
+++ b/src/state/slices/portfolioSlice/selectors.ts
@@ -17,6 +17,7 @@ import { isMobile } from 'lib/globals'
 import { fromBaseUnit } from 'lib/math'
 import { getMaybeCompositeAssetSymbol } from 'lib/mixpanel/helpers'
 import type { AnonymizedPortfolio } from 'lib/mixpanel/types'
+import type { PartialRecord } from 'lib/utils'
 import { hashCode, isValidAccountNumber } from 'lib/utils'
 import type { ReduxState } from 'state/reducer'
 import { createDeepEqualOutputSelector } from 'state/selector-utils'
@@ -801,18 +802,23 @@ export const selectPortfolioAnonymized = createDeepEqualOutputSelector(
 export const selectAccountIdByAccountNumberAndChainId = createSelector(
   selectWalletAccountIds,
   selectPortfolioAccountMetadata,
-  selectAccountNumberParamFromFilter,
-  selectChainIdParamFromFilter,
-  (walletAccountIds, accountMetadata, accountNumber, chainId): AccountId | undefined => {
-    if (!isValidAccountNumber(accountNumber))
-      throw new Error(`invalid account number: ${accountNumber}`)
-    if (chainId === undefined) throw new Error('undefined chain id')
+  (walletAccountIds, accountMetadata): PartialRecord<number, PartialRecord<ChainId, AccountId>> => {
+    const result: PartialRecord<number, PartialRecord<ChainId, AccountId>> = {}
 
-    return walletAccountIds.find(accountId => {
-      if (fromAccountId(accountId).chainId !== chainId) return false
-      if (accountNumber !== accountMetadata[accountId].bip44Params.accountNumber) return false
-      return true
-    })
+    for (const accountId of walletAccountIds) {
+      const { chainId } = fromAccountId(accountId)
+      const { accountNumber } = accountMetadata[accountId].bip44Params
+
+      const entry = result[accountNumber]
+
+      if (entry === undefined) {
+        result[accountNumber] = { [chainId]: accountId }
+      } else {
+        entry[chainId] = accountId
+      }
+    }
+
+    return result
   },
 )
 

--- a/src/state/slices/swappersSlice/selectors.ts
+++ b/src/state/slices/swappersSlice/selectors.ts
@@ -34,9 +34,8 @@ export const selectUserSlippagePercentageDecimal: Selector<ReduxState, string | 
     return bn(slippagePercentage).div(100).toString()
   })
 
-// selects the account ID we're selling from
-// note lack of "asset" and "hop" vernacular - this is deliberate
-export const selectSellAccountId = createSelector(
+// selects the account ID we're selling from for the first hop
+export const selectFirstHopSellAccountId = createSelector(
   selectSwappers,
   selectSellAsset,
   selectPortfolioAssetAccountBalancesSortedUserCurrency,
@@ -56,9 +55,8 @@ export const selectSellAccountId = createSelector(
   },
 )
 
-// selects the account ID we're buying into
-// note lack of "asset" and "hop" vernacular - this is deliberate
-export const selectBuyAccountId = createSelector(
+// selects the account ID we're buying into for the first hop
+export const selectLastHopBuyAccountId = createSelector(
   selectSwappers,
   selectBuyAsset,
   selectPortfolioAssetAccountBalancesSortedUserCurrency,

--- a/src/state/slices/swappersSlice/swappersSlice.ts
+++ b/src/state/slices/swappersSlice/swappersSlice.ts
@@ -1,7 +1,7 @@
 import type { PayloadAction } from '@reduxjs/toolkit'
 import { createSlice } from '@reduxjs/toolkit'
 import type { AccountId } from '@shapeshiftoss/caip'
-import { ethAssetId, foxAssetId, fromAccountId } from '@shapeshiftoss/caip'
+import { ethAssetId, foxAssetId } from '@shapeshiftoss/caip'
 import type { Asset } from 'lib/asset-service'
 import { localAssetData } from 'lib/asset-service'
 import { bnOrZero } from 'lib/bignumber/bignumber'
@@ -47,15 +47,6 @@ export const swappers = createSlice({
       if (isSameAsSellAsset) state.sellAsset = state.buyAsset
 
       state.buyAsset = asset
-
-      const buyAssetChainId = state.buyAsset.chainId
-      const buyAssetAccountChainId = state.buyAssetAccountId
-        ? fromAccountId(state.buyAssetAccountId).chainId
-        : undefined
-
-      // reset user selection on mismatch
-      if (state.buyAssetAccountId && buyAssetChainId !== buyAssetAccountChainId)
-        state.buyAssetAccountId = undefined
     },
     setSellAsset: (state, action: PayloadAction<Asset>) => {
       const asset = action.payload
@@ -65,20 +56,11 @@ export const swappers = createSlice({
       if (isSameAsBuyAsset) state.buyAsset = state.sellAsset
 
       state.sellAsset = action.payload
-
-      const sellAssetChainId = state.sellAsset.chainId
-      const sellAssetAccountChainId = state.sellAssetAccountId
-        ? fromAccountId(state.sellAssetAccountId).chainId
-        : undefined
-
-      // reset user selection on mismatch
-      if (state.sellAssetAccountId && sellAssetChainId !== sellAssetAccountChainId)
-        state.sellAssetAccountId = undefined
     },
-    setSellAssetAccountId: (state, action: PayloadAction<AccountId | undefined>) => {
+    setSellAssetAccountNumber: (state, action: PayloadAction<AccountId | undefined>) => {
       state.sellAssetAccountId = action.payload
     },
-    setBuyAssetAccountId: (state, action: PayloadAction<AccountId | undefined>) => {
+    setBuyAssetAccountNumber: (state, action: PayloadAction<AccountId | undefined>) => {
       state.buyAssetAccountId = action.payload
     },
     setSellAmountCryptoPrecision: (state, action: PayloadAction<string>) => {

--- a/src/state/slices/tradeQuoteSlice/selectors.ts
+++ b/src/state/slices/tradeQuoteSlice/selectors.ts
@@ -13,7 +13,11 @@ import { isCrossAccountTradeSupported } from 'state/helpers'
 import type { ReduxState } from 'state/reducer'
 import { createDeepEqualOutputSelector } from 'state/selector-utils'
 import { selectFeeAssetById } from 'state/slices/assetsSlice/selectors'
-import { selectUserSlippagePercentageDecimal } from 'state/slices/swappersSlice/selectors'
+import {
+  selectFirstHopSellAccountId,
+  selectLastHopBuyAccountId,
+  selectUserSlippagePercentageDecimal,
+} from 'state/slices/swappersSlice/selectors'
 import {
   getBuyAmountAfterFeesCryptoPrecision,
   getHopTotalNetworkFeeFiatPrecision,
@@ -27,6 +31,7 @@ import {
 } from 'state/slices/tradeQuoteSlice/utils'
 
 import { selectCryptoMarketData, selectUserCurrencyToUsdRate } from '../marketDataSlice/selectors'
+import { selectAccountIdByAccountNumberAndChainId } from '../portfolioSlice/selectors'
 
 const selectTradeQuoteSlice = (state: ReduxState) => state.tradeQuoteSlice
 
@@ -423,4 +428,41 @@ export const selectQuoteDonationAmountUsd = createSelector(
 export const selectTradeExecutionStatus = createSelector(
   selectTradeQuoteSlice,
   swappers => swappers.tradeExecutionStatus,
+)
+
+// selects the account ID we're buying into for the first hop
+export const selectFirstHopBuyAccountId = createSelector(
+  selectIsActiveQuoteMultiHop,
+  selectLastHopBuyAccountId,
+  selectFirstHop,
+  selectFirstHopSellAsset,
+  selectAccountIdByAccountNumberAndChainId,
+  (
+    isMultiHopTrade,
+    lastHopBuyAccountId,
+    firstHop,
+    sellAsset,
+    accountIdByAccountNumberAndChainId,
+  ) => {
+    // single hop trade - same as last hop
+    if (!isMultiHopTrade) return lastHopBuyAccountId
+
+    return sellAsset !== undefined && firstHop !== undefined
+      ? accountIdByAccountNumberAndChainId[firstHop.accountNumber]?.[sellAsset.chainId]
+      : undefined
+  },
+)
+
+// selects the account ID we're selling from for the last hop
+export const selectLastHopSellAccountId = createSelector(
+  selectIsActiveQuoteMultiHop,
+  selectFirstHopSellAccountId,
+  selectFirstHopBuyAccountId,
+  (isMultiHopTrade, firstHopSellAccountId, firstHopBuyAccountId) => {
+    // single hop trade - same as first hop sell account id
+    if (!isMultiHopTrade) return firstHopSellAccountId
+
+    // multi hop trade - the second hop sell account id is the same as the first hop buy account id
+    return firstHopBuyAccountId
+  },
 )

--- a/src/state/slices/tradeQuoteSlice/selectors.ts
+++ b/src/state/slices/tradeQuoteSlice/selectors.ts
@@ -435,20 +435,20 @@ export const selectFirstHopBuyAccountId = createSelector(
   selectIsActiveQuoteMultiHop,
   selectLastHopBuyAccountId,
   selectFirstHop,
-  selectFirstHopSellAsset,
+  selectFirstHopBuyAsset,
   selectAccountIdByAccountNumberAndChainId,
   (
     isMultiHopTrade,
     lastHopBuyAccountId,
     firstHop,
-    sellAsset,
+    buyAsset,
     accountIdByAccountNumberAndChainId,
   ) => {
     // single hop trade - same as last hop
     if (!isMultiHopTrade) return lastHopBuyAccountId
 
-    return sellAsset !== undefined && firstHop !== undefined
-      ? accountIdByAccountNumberAndChainId[firstHop.accountNumber]?.[sellAsset.chainId]
+    return buyAsset !== undefined && firstHop !== undefined
+      ? accountIdByAccountNumberAndChainId[firstHop.accountNumber]?.[buyAsset.chainId]
       : undefined
   },
 )


### PR DESCRIPTION
## Description

Adds new selectors to automatically select the correct account ID for multi-hop trades.

---

Single hop trades have the following account flow (existing in prod):
`account A -> account C`

Multi hop trades have the following account flow - Note that account B is used twice, once for receiving on first hop, and again when sending on the second hop:
```
account A -> account B
account B -> account C
````

Our UI supports selecting the buy and sell accounts, but the intermediary account must be inferred.

To solve this for multi-hop trades, we assume account B could be on a different chain to account A, but will always flow through the same account number as account A. Hence the following was implemented:

**first hop buy account ID**
1. if this is a single hop trade, return the last hop buy account ID as they are the same (and this is already implemented in a different selector)
2. otherwise, use the account number from the first hop sell account and find the account ID for the buy asset chainID

**last hop sell account ID**
1. if this is a single hop trade, return the first hop sell account ID as they are the same (and this is already implemented in a different selector)
2. otherwise, use the account number from the first hop buy account ID as they are the same (from the steps above)

---

Includes removal of dead code relating to account selection in `TradeAssetSelect`.

## Pull Request Type

- [ ] :bug: Bug fix (Non-breaking Change: Fixes an issue)
- [ ] :hammer_and_wrench: Chore (Non-breaking Change: Doc updates, pkg upgrades, typos, etc..)
- [x] :nail_care: New Feature (Breaking/Non-breaking Change)

## Issue (if applicable)

NA

## Risk

Very high risk - affects what account funds land in.

## Testing

<!-----------------------------------------------------------------------------
We treat every PR to be merged with the same scrutiny as if we were merging directly to production.

Your PR will not be merged if you do not complete the sections below for our engineering and operations teams to test.
------------------------------------------------------------------------------>

### Engineering

<!-----------------------------------------------------------------------------
Include sufficient information here for an engineer to test your PR. This may include how to test locally, in a built environment, changes to infrastructure etc.
------------------------------------------------------------------------------>

### Operations

<!-----------------------------------------------------------------------------
If your changes have a user-facing impact, describe how a non-technical QA team can functionally test your changes in a preview environment.

If they are not user-facing please describe how to test for any regressions that may occur.
------------------------------------------------------------------------------>

## Screenshots (if applicable)

Successful trade to manually selected account - selected LTC segwit account and the funds landed there as expected
![image](https://github.com/shapeshift/web/assets/125113430/a21c78fb-8f5d-4f62-a70a-65b37848721c)
![image](https://github.com/shapeshift/web/assets/125113430/6310eb2e-a547-453f-b2b2-8140669c573c)
![image](https://github.com/shapeshift/web/assets/125113430/5cc0ac02-d55c-4685-b49e-a419810172fa)


