### PR TITLE
fix: search on substring, not simple match

### DIFF
--- a/src/components/AssetSearch/helpers/filterAssetsBySearchTerm/filterAssetsBySearchTerm.ts
+++ b/src/components/AssetSearch/helpers/filterAssetsBySearchTerm/filterAssetsBySearchTerm.ts
@@ -14,5 +14,8 @@ export const filterAssetsBySearchTerm = (search: string, assets: Asset[]) => {
     )
   }
 
-  return matchSorter(assets, search, { keys: ['name', 'symbol'] })
+  return matchSorter(assets, search, {
+    keys: ['name', 'symbol'],
+    threshold: matchSorter.rankings.CONTAINS,
+  })
 }

--- a/src/components/Nfts/NftTable.tsx
+++ b/src/components/Nfts/NftTable.tsx
@@ -63,7 +63,12 @@ export const NftTable = () => {
 
       // Don't use matchSorter if there is no need to - it's expensive, and will rug the initial sorting
       // resulting in perceived borked order when filtering by chain vs. no filter applied
-      return search ? matchSorter(maybeFilteredByChainId, search, { keys }) : maybeFilteredByChainId
+      return search
+        ? matchSorter(maybeFilteredByChainId, search, {
+            keys,
+            threshold: matchSorter.rankings.CONTAINS,
+          })
+        : maybeFilteredByChainId
     },
     [networkFilters],
   )

--- a/src/components/StakingVaults/PositionTable.tsx
+++ b/src/components/StakingVaults/PositionTable.tsx
@@ -182,9 +182,10 @@ export const PositionTable: React.FC<PositionTableProps> = ({
       }
       const assetIds = rows.map(row => row.assetId)
       const rowAssets = assets.filter(asset => assetIds.includes(asset.assetId))
-      const matchedAssets = matchSorter(rowAssets, search, { keys: ['name', 'symbol'] }).map(
-        asset => asset.assetId,
-      )
+      const matchedAssets = matchSorter(rowAssets, search, {
+        keys: ['name', 'symbol'],
+        threshold: matchSorter.rankings.CONTAINS,
+      }).map(asset => asset.assetId)
       const results = rows.filter(row => matchedAssets.includes(row.assetId))
       return results
     },

--- a/src/pages/Dashboard/components/ProfileAvatar/AvatarSelectModal.tsx
+++ b/src/pages/Dashboard/components/ProfileAvatar/AvatarSelectModal.tsx
@@ -69,7 +69,7 @@ export const AvatarSelectModal: React.FC<AvatarSelectModalProps> = props => {
     (data: NftItemWithCollection[], searchQuery: string) => {
       const search = searchQuery.trim().toLowerCase()
       const keys = ['name', 'collection.name', 'collection.assetId', 'assetId', 'id']
-      return matchSorter(data, search, { keys })
+      return matchSorter(data, search, { keys, threshold: matchSorter.rankings.CONTAINS })
     },
     [],
   )

--- a/src/state/slices/assetsSlice/selectors.ts
+++ b/src/state/slices/assetsSlice/selectors.ts
@@ -83,7 +83,7 @@ export const selectAssetsBySearchQuery = createDeepEqualOutputSelector(
     if (!searchQuery) return sortedAssets
     return matchSorter(sortedAssets, searchQuery ?? '', {
       keys: ['name', 'symbol', 'assetId'],
-      threshold: matchSorter.rankings.MATCHES,
+      threshold: matchSorter.rankings.CONTAINS,
     })
   },
 )


### PR DESCRIPTION
## Description

Fixes search bars returning irrelevant results. We're using https://www.npmjs.com/package/match-sorter for searching, which defaults to `SIMPLE MATCH`:
![image](https://github.com/shapeshift/web/assets/125113430/ee017c6d-c88e-4277-ba29-d573229db3d0)

The fix is to change the threshold to `CONTAINS`, which will only returns results containing your search term. This was already implemented in a few cases, so this PR updates the remaining instances to align with those.

## Pull Request Type

- [x] :bug: Bug fix (Non-breaking Change: Fixes an issue)
- [ ] :hammer_and_wrench: Chore (Non-breaking Change: Doc updates, pkg upgrades, typos, etc..)
- [ ] :nail_care: New Feature (Breaking/Non-breaking Change)

## Issue (if applicable)

closes #5630

## Risk

Risk of (still) broken searching across app.

## Testing

Check search boxes operate as expected, noting the change in functionality above.

### Engineering

<!-----------------------------------------------------------------------------
Include sufficient information here for an engineer to test your PR. This may include how to test locally, in a built environment, changes to infrastructure etc.
------------------------------------------------------------------------------>

### Operations

<!-----------------------------------------------------------------------------
If your changes have a user-facing impact, describe how a non-technical QA team can functionally test your changes in a preview environment.

If they are not user-facing please describe how to test for any regressions that may occur.
------------------------------------------------------------------------------>

## Screenshots (if applicable)

"BCH" now returning no results (expected as i have no BCH trades)
![image](https://github.com/shapeshift/web/assets/125113430/10a014eb-0ee9-4f14-94e5-d6b3410931c3)

"BNB" now returning results containing "BNB":
![image](https://github.com/shapeshift/web/assets/125113430/125fcf61-15ee-4ccc-9c43-498f3fb98fc5)

"B" returns all results containing "B":
![image](https://github.com/shapeshift/web/assets/125113430/e35b11f9-94be-45b0-965a-5ce43e9a55b3)
