### PR TITLE
fix: thorchain limit account for liquidity fees

### DIFF
--- a/src/lib/swapper/swappers/ThorchainSwapper/getThorTradeQuote/getTradeQuote.test.ts
+++ b/src/lib/swapper/swappers/ThorchainSwapper/getThorTradeQuote/getTradeQuote.test.ts
@@ -51,7 +51,7 @@ const expectedQuoteResponse: Omit<ThorEvmTradeQuote, 'id'>[] = [
     rate: '137845.94361267605633802817',
     data: '0x',
     router: '0x3624525075b88B24ecc29CE226b0CEc1fFcB6976',
-    memo: '=:ETH.ETH:0x32DBc9Cf9E8FbCebE1e0a2ecF05Ed86Ca3096Cb6:9360639:ss:0',
+    memo: '=:ETH.ETH:0x32DBc9Cf9E8FbCebE1e0a2ecF05Ed86Ca3096Cb6:9360638:ss:0',
     steps: [
       {
         estimatedExecutionTimeMs: 1600000,
@@ -84,7 +84,7 @@ const expectedQuoteResponse: Omit<ThorEvmTradeQuote, 'id'>[] = [
     rate: '151555.07377464788732394366',
     data: '0x',
     router: '0x3624525075b88B24ecc29CE226b0CEc1fFcB6976',
-    memo: '=:ETH.ETH:0x32DBc9Cf9E8FbCebE1e0a2ecF05Ed86Ca3096Cb6:10291579/10/0:ss:0',
+    memo: '=:ETH.ETH:0x32DBc9Cf9E8FbCebE1e0a2ecF05Ed86Ca3096Cb6:10291578/10/0:ss:0',
     steps: [
       {
         estimatedExecutionTimeMs: 1600000,

--- a/src/lib/swapper/swappers/ThorchainSwapper/getThorTradeQuote/getTradeQuote.ts
+++ b/src/lib/swapper/swappers/ThorchainSwapper/getThorTradeQuote/getTradeQuote.ts
@@ -280,6 +280,7 @@ export const getThorTradeQuote = async (
             const updatedMemo = addSlippageToMemo({
               expectedAmountOutThorBaseUnit,
               quotedMemo: quote.memo,
+              affiliateFeesThorBaseUnit: quote.fees.affiliate,
               slippageBps: inputSlippageBps,
               chainId: sellAsset.chainId,
               affiliateBps,
@@ -363,6 +364,7 @@ export const getThorTradeQuote = async (
 
             const updatedMemo = addSlippageToMemo({
               expectedAmountOutThorBaseUnit,
+              affiliateFeesThorBaseUnit: quote.fees.affiliate,
               quotedMemo: quote.memo,
               slippageBps: inputSlippageBps,
               isStreaming,
@@ -459,6 +461,7 @@ export const getThorTradeQuote = async (
             }).toFixed()
 
             const updatedMemo = addSlippageToMemo({
+              affiliateFeesThorBaseUnit: quote.fees.affiliate,
               expectedAmountOutThorBaseUnit,
               quotedMemo: quote.memo,
               slippageBps: inputSlippageBps,

--- a/src/lib/swapper/swappers/ThorchainSwapper/utils/addSlippageToMemo.ts
+++ b/src/lib/swapper/swappers/ThorchainSwapper/utils/addSlippageToMemo.ts
@@ -1,5 +1,5 @@
 import type { ChainId } from '@shapeshiftoss/caip'
-import { BigNumber } from 'lib/bignumber/bignumber'
+import { BigNumber, bn } from 'lib/bignumber/bignumber'
 import { subtractBasisPointAmount } from 'state/slices/tradeQuoteSlice/utils'
 
 import { DEFAULT_STREAMING_NUM_SWAPS, LIMIT_PART_DELIMITER, MEMO_PART_DELIMITER } from './constants'
@@ -7,6 +7,7 @@ import { assertIsValidMemo } from './makeSwapMemo/assertIsValidMemo'
 
 export const addSlippageToMemo = ({
   expectedAmountOutThorBaseUnit,
+  affiliateFeesThorBaseUnit,
   quotedMemo,
   slippageBps,
   isStreaming,
@@ -15,6 +16,7 @@ export const addSlippageToMemo = ({
   streamingInterval,
 }: {
   expectedAmountOutThorBaseUnit: string
+  affiliateFeesThorBaseUnit: string
   quotedMemo: string | undefined
   slippageBps: BigNumber.Value
   chainId: ChainId
@@ -29,7 +31,9 @@ export const addSlippageToMemo = ({
     quotedMemo.split(MEMO_PART_DELIMITER)
 
   const limitWithManualSlippage = subtractBasisPointAmount(
-    expectedAmountOutThorBaseUnit,
+    bn(expectedAmountOutThorBaseUnit)
+      .minus(affiliateFeesThorBaseUnit)
+      .toFixed(0, BigNumber.ROUND_DOWN),
     slippageBps,
     BigNumber.ROUND_DOWN,
   )


### PR DESCRIPTION
## Description

Does what it says in the title - accounts for the liquidity fees before deducting the affiliate bps, so that the limit we get is actually reliable. It previously working was mostly out of luck because the network state was not so crazy and liquidity fees were less than currently, but we absolutely need to account for it.

## Pull Request Type

- [x] :bug: Bug fix (Non-breaking Change: Fixes an issue)
- [ ] :hammer_and_wrench: Chore (Non-breaking Change: Doc updates, pkg upgrades, typos, etc..)
- [ ] :nail_care: New Feature (Breaking/Non-breaking Change)

## Issue (if applicable)

<!-----------------------------------------------------------------------------
If applicable, please link to the github issue and put `closes #XXXX` in your comment to auto-close the issue that your PR fixes.
------------------------------------------------------------------------------>

closes https://github.com/shapeshift/web/issues/5635

## Risk

<!-----------------------------------------------------------------------------
Outline the scope of your changes and the risk associated with them. You must use your discretion as an engineer to determine the potential impact of your changes.

E.g. an upgrade to `hdwallet` or core state management would be considered higher risk, and might require a full regression test. UI or isolated view changes, or something behind a feature flag may have near zero risk. Small bug fixes might require testing isolated to the specific fix.
------------------------------------------------------------------------------>

None?

## Testing

<!-----------------------------------------------------------------------------
We treat every PR to be merged with the same scrutiny as if we were merging directly to production.

Your PR will not be merged if you do not complete the sections below for our engineering and operations teams to test.
------------------------------------------------------------------------------>

- THOR Txs are going through and aren't refunded

### Engineering

<!-----------------------------------------------------------------------------
Include sufficient information here for an engineer to test your PR. This may include how to test locally, in a built environment, changes to infrastructure etc.
------------------------------------------------------------------------------>

- ☝🏽 

### Operations

<!-----------------------------------------------------------------------------
If your changes have a user-facing impact, describe how a non-technical QA team can functionally test your changes in a preview environment.

If they are not user-facing please describe how to test for any regressions that may occur.
------------------------------------------------------------------------------>

- ☝🏽 
- Do an ETH -> RUNE swap and ensure it is not refunded
- Do an FOX -> ETH swap and ensure it is not refunded

## Screenshots (if applicable)

- Failed Tx

https://runescan.io/tx/4D43F7A16A02CF549FC6918F872884BBB13CE28F85A01C47FB5498BC70DCCA2F notice how there's ~0.2 ROON missing in the outbound, resulting in a refunded Tx

- Happy Tx

https://runescan.io/tx/ceff15a9a95e587372d5c8b170592a1d6e24eabbeeb137f2bd62b830fc5aa3ce