### PR TITLE
fix: active step indicator for hops without allowance approval

### DIFF
--- a/src/components/MultiHopTrade/components/MultiHopTradeConfirm/components/Hop.tsx
+++ b/src/components/MultiHopTrade/components/MultiHopTradeConfirm/components/Hop.tsx
@@ -107,17 +107,13 @@ export const Hop = ({
         return hopIndex === 0 ? 1 : 0
       case HopExecutionState.AwaitingTradeConfirmation:
       case HopExecutionState.AwaitingTradeExecution:
-        if (isApprovalInitiallyNeeded) {
-          return hopIndex === 0 ? 2 : 1
-        } else {
-          return hopIndex === 0 ? 1 : 0
-        }
+        return hopIndex === 0 ? 2 : 1
       case HopExecutionState.Complete:
         return Infinity
       default:
         assertUnreachable(hopExecutionState)
     }
-  }, [hopExecutionState, hopIndex, isApprovalInitiallyNeeded])
+  }, [hopExecutionState, hopIndex])
 
   const slippageDecimalPercentage = useMemo(
     () => getDefaultSlippageDecimalPercentageForSwapper(swapperName),


### PR DESCRIPTION
## Description

Fixes the blue border missing on the step indicator in the multi-hop UI for a swap/bridge step when there is no ERC20 token approval required.

## Pull Request Type

- [x] :bug: Bug fix (Non-breaking Change: Fixes an issue)
- [ ] :hammer_and_wrench: Chore (Non-breaking Change: Doc updates, pkg upgrades, typos, etc..)
- [ ] :nail_care: New Feature (Breaking/Non-breaking Change)

## Issue (if applicable)

closes #5670

## Risk

Low risk, behind feature flag.

## Testing

Not required.

### Engineering

<!-----------------------------------------------------------------------------
Include sufficient information here for an engineer to test your PR. This may include how to test locally, in a built environment, changes to infrastructure etc.
------------------------------------------------------------------------------>

### Operations

<!-----------------------------------------------------------------------------
If your changes have a user-facing impact, describe how a non-technical QA team can functionally test your changes in a preview environment.

If they are not user-facing please describe how to test for any regressions that may occur.
------------------------------------------------------------------------------>

## Screenshots (if applicable)

![image](https://github.com/shapeshift/web/assets/125113430/9522b71d-42de-4127-aff3-99627b66bd83)

