### PR TITLE
fix: maintain multi-hop metadata and state to render in completion summary

### DIFF
--- a/src/components/MultiHopTrade/components/MultiHopTradeConfirm/MultiHopTradeConfirm.tsx
+++ b/src/components/MultiHopTrade/components/MultiHopTradeConfirm/MultiHopTradeConfirm.tsx
@@ -1,5 +1,5 @@
 import { Card, CardBody, CardHeader, Heading, useDisclosure, usePrevious } from '@chakra-ui/react'
-import { memo, useCallback, useEffect, useRef } from 'react'
+import { memo, useCallback, useEffect, useMemo, useRef } from 'react'
 import { useHistory } from 'react-router-dom'
 import { WithBackButton } from 'components/MultiHopTrade/components/WithBackButton'
 import { TradeRoutePaths } from 'components/MultiHopTrade/types'
@@ -30,11 +30,13 @@ export const MultiHopTradeConfirm = memo(() => {
   // internal state. If we decide this approach isn't suitable we'll need to rewrite the trade
   // execution hooks and components to store state and metadata inside redux
   const containerRef = useRef<HTMLDivElement>(null)
-  const targetRef1 = useRef<HTMLDivElement>(null)
-  const targetRef2 = useRef<HTMLDivElement>(null)
+  const tradeCompleteSummaryRef = useRef<HTMLDivElement>(null)
+  const tradeExecutionRef = useRef<HTMLDivElement>(null)
   useEffect(() => {
     const currentTargetRef =
-      tradeExecutionState === MultiHopExecutionState.TradeComplete ? targetRef1 : targetRef2
+      tradeExecutionState === MultiHopExecutionState.TradeComplete
+        ? tradeCompleteSummaryRef
+        : tradeExecutionRef
 
     if (containerRef.current && currentTargetRef.current) {
       currentTargetRef.current.appendChild(containerRef.current)
@@ -79,6 +81,11 @@ export const MultiHopTradeConfirm = memo(() => {
     tradeExecutionState,
   ])
 
+  const isTradeComplete = useMemo(
+    () => tradeExecutionState === MultiHopExecutionState.TradeComplete,
+    [tradeExecutionState],
+  )
+
   return (
     <>
       <SlideTransition>
@@ -96,14 +103,14 @@ export const MultiHopTradeConfirm = memo(() => {
               </Heading>
             </WithBackButton>
           </CardHeader>
-          {tradeExecutionState === MultiHopExecutionState.TradeComplete ? (
+          {isTradeComplete ? (
             <TradeSuccess handleBack={handleBack}>
-              <div ref={targetRef1} />
+              <div ref={tradeCompleteSummaryRef} />
             </TradeSuccess>
           ) : (
             <>
               <CardBody py={0} px={0}>
-                <div ref={targetRef2} />
+                <div ref={tradeExecutionRef} />
               </CardBody>
               <Footer />
             </>
@@ -112,22 +119,10 @@ export const MultiHopTradeConfirm = memo(() => {
       </SlideTransition>
       <div ref={containerRef}>
         <Hops
-          isFirstHopOpen={
-            tradeExecutionState === MultiHopExecutionState.TradeComplete || isFirstHopOpen
-          }
-          isSecondHopOpen={
-            tradeExecutionState === MultiHopExecutionState.TradeComplete || isSecondHopOpen
-          }
-          onToggleFirstHop={
-            tradeExecutionState === MultiHopExecutionState.TradeComplete
-              ? undefined
-              : onToggleFirstHop
-          }
-          onToggleSecondHop={
-            tradeExecutionState === MultiHopExecutionState.TradeComplete
-              ? undefined
-              : onToggleSecondHop
-          }
+          isFirstHopOpen={isTradeComplete || isFirstHopOpen}
+          isSecondHopOpen={isTradeComplete || isSecondHopOpen}
+          onToggleFirstHop={isTradeComplete ? undefined : onToggleFirstHop}
+          onToggleSecondHop={isTradeComplete ? undefined : onToggleSecondHop}
         />
       </div>
     </>

--- a/src/components/MultiHopTrade/components/MultiHopTradeConfirm/MultiHopTradeConfirm.tsx
+++ b/src/components/MultiHopTrade/components/MultiHopTradeConfirm/MultiHopTradeConfirm.tsx
@@ -1,5 +1,5 @@
 import { Card, CardBody, CardHeader, Heading, useDisclosure, usePrevious } from '@chakra-ui/react'
-import { memo, useCallback, useEffect } from 'react'
+import { memo, useCallback, useEffect, useRef } from 'react'
 import { useHistory } from 'react-router-dom'
 import { WithBackButton } from 'components/MultiHopTrade/components/WithBackButton'
 import { TradeRoutePaths } from 'components/MultiHopTrade/types'
@@ -25,6 +25,21 @@ export const MultiHopTradeConfirm = memo(() => {
   const history = useHistory()
 
   const { isApprovalInitiallyNeeded, isLoading } = useIsApprovalInitiallyNeeded()
+
+  // NOTE: we use dom manipulation to move the component around without losing the component
+  // internal state. If we decide this approach isn't suitable we'll need to rewrite the trade
+  // execution hooks and components to store state and metadata inside redux
+  const containerRef = useRef<HTMLDivElement>(null)
+  const targetRef1 = useRef<HTMLDivElement>(null)
+  const targetRef2 = useRef<HTMLDivElement>(null)
+  useEffect(() => {
+    const currentTargetRef =
+      tradeExecutionState === MultiHopExecutionState.TradeComplete ? targetRef1 : targetRef2
+
+    if (containerRef.current && currentTargetRef.current) {
+      currentTargetRef.current.appendChild(containerRef.current)
+    }
+  }, [tradeExecutionState]) // Rerun when tradeExecutionState changes
 
   // set initial approval requirements
   useEffect(() => {
@@ -65,39 +80,56 @@ export const MultiHopTradeConfirm = memo(() => {
   ])
 
   return (
-    <SlideTransition>
-      <Card flex={1} borderRadius={cardBorderRadius} width='full' variant='dashboard'>
-        <CardHeader px={6} pt={4}>
-          <WithBackButton handleBack={handleBack}>
-            <Heading textAlign='center' fontSize='md'>
-              <Text
-                translation={
-                  tradeExecutionState === MultiHopExecutionState.Previewing
-                    ? 'trade.confirmDetails'
-                    : 'trade.trade'
-                }
-              />
-            </Heading>
-          </WithBackButton>
-        </CardHeader>
-        {tradeExecutionState === MultiHopExecutionState.TradeComplete ? (
-          <TradeSuccess handleBack={handleBack}>
-            <Hops isFirstHopOpen isSecondHopOpen />
-          </TradeSuccess>
-        ) : (
-          <>
-            <CardBody py={0} px={0}>
-              <Hops
-                isFirstHopOpen={isFirstHopOpen}
-                isSecondHopOpen={isSecondHopOpen}
-                onToggleFirstHop={onToggleFirstHop}
-                onToggleSecondHop={onToggleSecondHop}
-              />
-            </CardBody>
-            <Footer />
-          </>
-        )}
-      </Card>
-    </SlideTransition>
+    <>
+      <SlideTransition>
+        <Card flex={1} borderRadius={cardBorderRadius} width='full' variant='dashboard'>
+          <CardHeader px={6} pt={4}>
+            <WithBackButton handleBack={handleBack}>
+              <Heading textAlign='center' fontSize='md'>
+                <Text
+                  translation={
+                    tradeExecutionState === MultiHopExecutionState.Previewing
+                      ? 'trade.confirmDetails'
+                      : 'trade.trade'
+                  }
+                />
+              </Heading>
+            </WithBackButton>
+          </CardHeader>
+          {tradeExecutionState === MultiHopExecutionState.TradeComplete ? (
+            <TradeSuccess handleBack={handleBack}>
+              <div ref={targetRef1} />
+            </TradeSuccess>
+          ) : (
+            <>
+              <CardBody py={0} px={0}>
+                <div ref={targetRef2} />
+              </CardBody>
+              <Footer />
+            </>
+          )}
+        </Card>
+      </SlideTransition>
+      <div ref={containerRef}>
+        <Hops
+          isFirstHopOpen={
+            tradeExecutionState === MultiHopExecutionState.TradeComplete || isFirstHopOpen
+          }
+          isSecondHopOpen={
+            tradeExecutionState === MultiHopExecutionState.TradeComplete || isSecondHopOpen
+          }
+          onToggleFirstHop={
+            tradeExecutionState === MultiHopExecutionState.TradeComplete
+              ? undefined
+              : onToggleFirstHop
+          }
+          onToggleSecondHop={
+            tradeExecutionState === MultiHopExecutionState.TradeComplete
+              ? undefined
+              : onToggleSecondHop
+          }
+        />
+      </div>
+    </>
   )
 })


### PR DESCRIPTION
## Description

Fixes issue where a trade is completed, the summary is rendered without all of the metadata that was generated during execution. This pr addresses the issue by rendering the UI in a div and passing it around the the various components as required such that no state is lost.


https://github.com/shapeshift/web/assets/125113430/013eafdb-a948-43b9-bdef-c5690e980b3e

A note has been added with next course of action should this approach become unmaintainable. 

## Pull Request Type

- [x] :bug: Bug fix (Non-breaking Change: Fixes an issue)
- [ ] :hammer_and_wrench: Chore (Non-breaking Change: Doc updates, pkg upgrades, typos, etc..)
- [ ] :nail_care: New Feature (Breaking/Non-breaking Change)

## Issue (if applicable)

closes #5668

## Risk

Low risk, not user facing.

## Testing

Not required.

### Engineering

<!-----------------------------------------------------------------------------
Include sufficient information here for an engineer to test your PR. This may include how to test locally, in a built environment, changes to infrastructure etc.
------------------------------------------------------------------------------>

### Operations

<!-----------------------------------------------------------------------------
If your changes have a user-facing impact, describe how a non-technical QA team can functionally test your changes in a preview environment.

If they are not user-facing please describe how to test for any regressions that may occur.
------------------------------------------------------------------------------>

## Screenshots (if applicable)

Trade metadata, e.g txids now appearing on the completion summary:
![image](https://github.com/shapeshift/web/assets/125113430/383c3089-33a1-4ac4-8268-72c585e5ccc4)

Before the fix:
![image](https://github.com/shapeshift/web/assets/125113430/cfaa4d21-287a-4f7d-82d9-01bcde93a590)

