### PR TITLE
fix: borked 0x pairs

### DIFF
--- a/src/lib/swapper/swappers/ZrxSwapper/getZrxTradeQuote/getZrxTradeQuote.ts
+++ b/src/lib/swapper/swappers/ZrxSwapper/getZrxTradeQuote/getZrxTradeQuote.ts
@@ -60,7 +60,7 @@ export async function getZrxTradeQuote(
   }
 
   const maybeZrxPriceResponse = await fetchFromZrx({
-    priceOrQuote: 'price',
+    priceOrQuote: 'quote',
     buyAsset,
     sellAsset,
     sellAmountIncludingProtocolFeesCryptoBaseUnit,

--- a/src/lib/swapper/swappers/ZrxSwapper/utils/fetchFromZrx.ts
+++ b/src/lib/swapper/swappers/ZrxSwapper/utils/fetchFromZrx.ts
@@ -52,7 +52,9 @@ export const fetchFromZrx = async <T extends 'price' | 'quote'>({
       sellAmount: sellAmountIncludingProtocolFeesCryptoBaseUnit,
       takerAddress: receiveAddress,
       affiliateAddress: AFFILIATE_ADDRESS, // Used for 0x analytics
-      skipValidation: priceOrQuote === 'price', // don't validate allowances for price queries
+      // Always skips allowance validation. i.e we want to get a quote regardless of validation, and when
+      // getting a final quote before broadcasting, we're already in a state with allowance granted
+      skipValidation: true,
       slippagePercentage:
         slippageTolerancePercentage ??
         getDefaultSlippageDecimalPercentageForSwapper(SwapperName.Zrx),


### PR DESCRIPTION
## Description

Fixes (some) borked 0x pairs. For some reason, using the price endpoint with no validation to get a quote, then using the quote endpoint with validation is causing the latter (i.e the pre-broadcast quote) to respond with 400.

Fixed by consistently using the `/quote` endpoint, and consistently skipping validation - as our flow makes it so that by the time of `<TradeConfirm />`, we are already in a state where allowance is granted.

## Pull Request Type

- [x] :bug: Bug fix (Non-breaking Change: Fixes an issue)
- [ ] :hammer_and_wrench: Chore (Non-breaking Change: Doc updates, pkg upgrades, typos, etc..)
- [ ] :nail_care: New Feature (Breaking/Non-breaking Change)

## Issue (if applicable)

<!-----------------------------------------------------------------------------
If applicable, please link to the github issue and put `closes #XXXX` in your comment to auto-close the issue that your PR fixes.
------------------------------------------------------------------------------>

closes https://github.com/shapeshift/web/issues/5598

## Risk

<!-----------------------------------------------------------------------------
Outline the scope of your changes and the risk associated with them. You must use your discretion as an engineer to determine the potential impact of your changes.

E.g. an upgrade to `hdwallet` or core state management would be considered higher risk, and might require a full regression test. UI or isolated view changes, or something behind a feature flag may have near zero risk. Small bug fixes might require testing isolated to the specific fix.
------------------------------------------------------------------------------>

- 0x quotes could be broken, test you're still able to get 0x quotes against develop

## Testing

<!-----------------------------------------------------------------------------
We treat every PR to be merged with the same scrutiny as if we were merging directly to production.

Your PR will not be merged if you do not complete the sections below for our engineering and operations teams to test.
------------------------------------------------------------------------------>

- 0x quotes are happy
- XRP20 -> ETH using ZRX is happy at pre-broadcast quote time (ping myself or @MBMaria for the address to use in Frame)

### Engineering

<!-----------------------------------------------------------------------------
Include sufficient information here for an engineer to test your PR. This may include how to test locally, in a built environment, changes to infrastructure etc.
------------------------------------------------------------------------------>

- ☝🏽 

### Operations

<!-----------------------------------------------------------------------------
If your changes have a user-facing impact, describe how a non-technical QA team can functionally test your changes in a preview environment.

If they are not user-facing please describe how to test for any regressions that may occur.
------------------------------------------------------------------------------>

- ☝🏽 

## Screenshots (if applicable)

<img width="1168" alt="image" src="https://github.com/shapeshift/web/assets/17035424/df5926c6-ffcf-4027-b4e8-4f8ccbb993be">
