### PR TITLE
fix: demo wallet and upsert

### DIFF
--- a/src/context/AppProvider/AppContext.tsx
+++ b/src/context/AppProvider/AppContext.tsx
@@ -107,7 +107,6 @@ export const AppProvider = ({ children }: { children: React.ReactNode }) => {
         walletSupportsChain({ chainId, wallet, isSnapInstalled }),
       )
 
-      const accountMetadataByAccountId: AccountMetadataById = {}
       const isMultiAccountWallet = wallet.supportsBip44Accounts()
       for (let accountNumber = 0; chainIds.length > 0; accountNumber++) {
         // only some wallets support multi account
@@ -116,8 +115,6 @@ export const AppProvider = ({ children }: { children: React.ReactNode }) => {
         const input = { accountNumber, chainIds, wallet }
         const accountIdsAndMetadata = await deriveAccountIdsAndMetadata(input)
         const accountIds = Object.keys(accountIdsAndMetadata)
-
-        Object.assign(accountMetadataByAccountId, accountIdsAndMetadata)
 
         const { getAccount } = portfolioApi.endpoints
         const accountPromises = accountIds.map(accountId =>
@@ -138,7 +135,7 @@ export const AppProvider = ({ children }: { children: React.ReactNode }) => {
           const { hasActivity } = account.accounts.byId[accountId]
 
           // don't add accounts with no activity past account 0
-          if (accountNumber > 0 && !hasActivity) return delete accountMetadataByAccountId[accountId]
+          if (accountNumber > 0 && !hasActivity) return
 
           // unique set to handle utxo chains with multiple account types per account
           chainIdsWithActivity = Array.from(new Set([...chainIdsWithActivity, chainId]))
@@ -147,9 +144,8 @@ export const AppProvider = ({ children }: { children: React.ReactNode }) => {
         })
 
         chainIds = chainIdsWithActivity
+        dispatch(portfolio.actions.upsertAccountMetadata(accountIdsAndMetadata))
       }
-
-      dispatch(portfolio.actions.upsertAccountMetadata(accountMetadataByAccountId))
     })()
   }, [dispatch, wallet, supportedChains, isSnapInstalled])
 

--- a/src/context/AppProvider/AppContext.tsx
+++ b/src/context/AppProvider/AppContext.tsx
@@ -42,7 +42,6 @@ import {
 } from 'state/slices/opportunitiesSlice/thunks'
 import { DefiProvider, DefiType } from 'state/slices/opportunitiesSlice/types'
 import { portfolio, portfolioApi } from 'state/slices/portfolioSlice/portfolioSlice'
-import type { AccountMetadataById } from 'state/slices/portfolioSlice/portfolioSliceCommon'
 import { preferences } from 'state/slices/preferencesSlice/preferencesSlice'
 import {
   selectAssetIds,


### PR DESCRIPTION
## Description

Fixes a regression caused in https://github.com/shapeshift/web/pull/5673 where `dispatch(portfolio.actions.upsertAccountMetadata(accountIdsAndMetadata))` was never actually called due to early returns in the above `forEach` loop.

This was observed and easily replicated on the demo wallet, where no accounts were shown once the cache is cleared. I'm not sure of the impact outside of the demo wallet though I suspect it caused issues there, too.

Note, this is not as performant is the original PR intended, as it calls `upsertAccountMetadata` for every account number (but not every account! 🙏 ).

## Pull Request Type

- [x] :bug: Bug fix (Non-breaking Change: Fixes an issue)
- [ ] :hammer_and_wrench: Chore (Non-breaking Change: Doc updates, pkg upgrades, typos, etc..)
- [ ] :nail_care: New Feature (Breaking/Non-breaking Change)

## Issue (if applicable)

Noted in release thread after release had hit production: https://discord.com/channels/554694662431178782/1178487848312242216/1178546667583193158

## Risk

Medium - touches account loading.

## Testing

Confirm all accounts still load as expected with demo and regular wallets, before and after clearing cache.

### Engineering

☝️

### Operations

☝️

## Screenshots (if applicable)

N/A