### PR TITLE
fix: accounts/accounts metadata mismatch

### DIFF
--- a/src/lib/account/account.ts
+++ b/src/lib/account/account.ts
@@ -55,15 +55,17 @@ export const deriveAccountIdsAndMetadata: DeriveAccountIdsAndMetadata = async ar
     ),
   )
 
-  const fulfilledAccountIdsAndMetadata = settledAccountIdsAndMetadata
-    .filter(result => {
+  const fulfilledAccountIdsAndMetadata = settledAccountIdsAndMetadata.reduce<AccountMetadataById[]>(
+    (acc, result) => {
       if (isRejected(result)) {
         console.error(result.reason)
-        return false
+      } else if (isFulfilled(result)) {
+        acc.push(result.value)
       }
-      return isFulfilled(result)
-    })
-    .map(result => (result as PromiseFulfilledResult<AccountMetadataById>).value)
+      return acc
+    },
+    [],
+  )
 
   return merge({}, ...fulfilledAccountIdsAndMetadata)
 }

--- a/src/lib/account/account.ts
+++ b/src/lib/account/account.ts
@@ -55,7 +55,7 @@ export const deriveAccountIdsAndMetadata: DeriveAccountIdsAndMetadata = async ar
     ),
   )
 
-  const fulfilledValues = settledAccountIdsAndMetadata
+  const fulfilledAccountIdsAndMetadata = settledAccountIdsAndMetadata
     .filter(result => {
       if (isRejected(result)) {
         console.error(result.reason)
@@ -65,5 +65,5 @@ export const deriveAccountIdsAndMetadata: DeriveAccountIdsAndMetadata = async ar
     })
     .map(result => (result as PromiseFulfilledResult<AccountMetadataById>).value)
 
-  return merge({}, ...fulfilledValues)
+  return merge({}, ...fulfilledAccountIdsAndMetadata)
 }

--- a/src/state/slices/portfolioSlice/selectors.ts
+++ b/src/state/slices/portfolioSlice/selectors.ts
@@ -91,11 +91,8 @@ export const selectPortfolioAssetIds = createDeepEqualOutputSelector(
 export const selectPortfolioAccountMetadata = createDeepEqualOutputSelector(
   (state: ReduxState): AccountMetadataById => state.portfolio.accountMetadata.byId,
   selectWalletAccountIds,
-  (accountMetadata, walletAccountIds): AccountMetadataById => {
-    return pickBy(accountMetadata, (_, accountId: AccountId) =>
-      walletAccountIds.includes(accountId),
-    )
-  },
+  (accountMetadata, walletAccountIds): AccountMetadataById =>
+    pickBy(accountMetadata, (_, accountId: AccountId) => walletAccountIds.includes(accountId)),
 )
 
 export const selectPortfolioAccountMetadataByAccountId = createCachedSelector(

--- a/src/state/slices/portfolioSlice/selectors.ts
+++ b/src/state/slices/portfolioSlice/selectors.ts
@@ -91,8 +91,11 @@ export const selectPortfolioAssetIds = createDeepEqualOutputSelector(
 export const selectPortfolioAccountMetadata = createDeepEqualOutputSelector(
   (state: ReduxState): AccountMetadataById => state.portfolio.accountMetadata.byId,
   selectWalletAccountIds,
-  (accountMetadata, walletAccountIds): AccountMetadataById =>
-    pickBy(accountMetadata, (_, accountId: AccountId) => walletAccountIds.includes(accountId)),
+  (accountMetadata, walletAccountIds): AccountMetadataById => {
+    return pickBy(accountMetadata, (_, accountId: AccountId) =>
+      walletAccountIds.includes(accountId),
+    )
+  },
 )
 
 export const selectPortfolioAccountMetadataByAccountId = createCachedSelector(


### PR DESCRIPTION
## Description

Fixes a bug introduced in https://github.com/shapeshift/web/pull/5693 which fixed a regression introduced in https://github.com/shapeshift/web/pull/5693 but brought a smolish mismatch 🤯 

tl;dr:

- the accounts metadata now has *too many* accounts, including for accounts without Tx history
- the accounts slice however, has just the right amount of accounts. This results in this guy never returning anything else than `loading`:

https://github.com/shapeshift/web/blob/4a36aa55527500bc7863ae93c325dd4d8eabf54d/src/state/slices/portfolioSlice/selectors.ts#L137-L143

This is explained by l.130 here:

https://github.com/shapeshift/web/blob/4a36aa55527500bc7863ae93c325dd4d8eabf54d/src/state/slices/portfolioSlice/selectors.ts#L123-L130

Given we react on a different `accountsById` and `accountMetadata` set, the account will always be undefined - as it should - for accounts without history, but the metadata will be wrongly defined, resulting in the portfolio state being set as `loading`.

This introduces a bunch of bugs, mostly related to the now lack of reactivity in `<AppContext />`: since we're always in a `portfolioLoading` state, we never run the effects related to e.g fetching DeFi meta/user/data.

While this bug may be invisible when clearing the cache (there will be one render where the portfolio state is indeed "success"), having existing accounts and refreshing the app will make it obvious these effects are never ran, and DeFi data isn't fetched.

## Pull Request Type

- [x] :bug: Bug fix (Non-breaking Change: Fixes an issue)
- [ ] :hammer_and_wrench: Chore (Non-breaking Change: Doc updates, pkg upgrades, typos, etc..)
- [ ] :nail_care: New Feature (Breaking/Non-breaking Change)

## Issue (if applicable)

<!-----------------------------------------------------------------------------
If applicable, please link to the github issue and put `closes #XXXX` in your comment to auto-close the issue that your PR fixes.
------------------------------------------------------------------------------>

closes https://github.com/shapeshift/web/issues/5692

## Risk

<!-----------------------------------------------------------------------------
Outline the scope of your changes and the risk associated with them. You must use your discretion as an engineer to determine the potential impact of your changes.

E.g. an upgrade to `hdwallet` or core state management would be considered higher risk, and might require a full regression test. UI or isolated view changes, or something behind a feature flag may have near zero risk. Small bug fixes might require testing isolated to the specific fix.
------------------------------------------------------------------------------>

- Accounts may be borked, test accordingly

## Testing

<!-----------------------------------------------------------------------------
We treat every PR to be merged with the same scrutiny as if we were merging directly to production.

Your PR will not be merged if you do not complete the sections below for our engineering and operations teams to test.
------------------------------------------------------------------------------>

- Demo wallet is still happy
- DeFi data is still displayed
- Accounts 0+ are still properly fetched when using native/KK
- The number of accounts for other EVM chains isn't inherited from the Ethereum account

### Engineering

<!-----------------------------------------------------------------------------
Include sufficient information here for an engineer to test your PR. This may include how to test locally, in a built environment, changes to infrastructure etc.
------------------------------------------------------------------------------>

- ☝🏽 
- Run a breakpoint in `portfolioLoadingStatus` in `<AppContext />` and ensure we continue the execution after it

### Operations

<!-----------------------------------------------------------------------------
If your changes have a user-facing impact, describe how a non-technical QA team can functionally test your changes in a preview environment.

If they are not user-facing please describe how to test for any regressions that may occur.
------------------------------------------------------------------------------>

- ☝🏽 

## Screenshots (if applicable)

### Account with DeFi position

- Prod *without* a cache clear

<img width="1381" alt="image" src="https://github.com/shapeshift/web/assets/17035424/8715b6ff-aab1-4e7c-b67f-74b5c4ccd5c4">

- Prod after a cache clear

<img width="849" alt="Screenshot 2023-11-27 at 15 19 59" src="https://github.com/shapeshift/web/assets/17035424/00c2397e-667c-4042-b286-87083546eebd">

- This diff

<img width="854" alt="Screenshot 2023-11-27 at 15 20 10" src="https://github.com/shapeshift/web/assets/17035424/0afe2285-91a7-41d1-896e-4dd87b93509a">

### Accounts

- Prod

<img width="1366" alt="Screenshot 2023-11-27 at 15 21 13" src="https://github.com/shapeshift/web/assets/17035424/8dc3b3fc-9510-4e78-8c2d-4eb9671263f4">


- This diff

<img width="1352" alt="Screenshot 2023-11-27 at 15 21 26" src="https://github.com/shapeshift/web/assets/17035424/e70efb7e-951b-4b79-b2b0-b23dbe311c7d">

### Portfolio loading status

<img width="383" alt="Screenshot 2023-11-27 at 15 22 00" src="https://github.com/shapeshift/web/assets/17035424/cf9f6e78-b84a-45e7-8c9a-c95b24c072e1">

### Other EVM accounts do *not* inherit the number of Ethereum accounts

<img width="846" alt="image" src="https://github.com/shapeshift/web/assets/17035424/ded51200-0ec5-4d9e-a605-8685c2c8630a">
<img width="839" alt="image" src="https://github.com/shapeshift/web/assets/17035424/fd0c73c8-b260-4455-9c1e-8e7aaa373bae">
