### PR TITLE
fix: savers fromAddress account type reactivity

### DIFF
--- a/src/features/defi/components/Deposit/Deposit.tsx
+++ b/src/features/defi/components/Deposit/Deposit.tsx
@@ -46,7 +46,7 @@ type DepositProps = {
   onContinue(values: DepositValues): void
   onBack?(): void
   onCancel(): void
-  onChange?(fiatAmount: string, cryptoAmount: string): void
+  onChange?({ fiatAmount, cryptoAmount }: { fiatAmount: string; cryptoAmount: string }): void
   inputIcons?: string[]
 } & PropsWithChildren
 
@@ -130,7 +130,7 @@ export const Deposit = ({
         setValue(Field.CryptoAmount, cryptoAmount, {
           shouldValidate: true,
         })
-        onChange && onChange(value, cryptoAmount)
+        onChange && onChange({ cryptoAmount, fiatAmount: value })
       } else {
         const fiatAmount = bnOrZero(value).times(marketData.price).toString()
         setValue(Field.FiatAmount, fiatAmount, {
@@ -139,7 +139,7 @@ export const Deposit = ({
         setValue(Field.CryptoAmount, value, {
           shouldValidate: true,
         })
-        onChange && onChange(fiatAmount, value)
+        onChange && onChange({ fiatAmount, cryptoAmount: value })
       }
     },
     [marketData.price, onChange, setValue],
@@ -176,7 +176,11 @@ export const Deposit = ({
       setValue(Field.CryptoAmount, percentageCryptoAmount.toFixed(), {
         shouldValidate: true,
       })
-      onChange && onChange(percentageFiatAmount.toString(), percentageFiatAmount)
+      onChange &&
+        onChange({
+          fiatAmount: percentageFiatAmount.toString(),
+          cryptoAmount: percentageCryptoAmount.toString(),
+        })
     },
     [asset.precision, cryptoAmountAvailable, marketData.price, onChange, onPercentClick, setValue],
   )

--- a/src/features/defi/providers/thorchain-savers/components/ThorchainSaversManager/Deposit/ThorchainSaversDeposit.tsx
+++ b/src/features/defi/providers/thorchain-savers/components/ThorchainSaversManager/Deposit/ThorchainSaversDeposit.tsx
@@ -128,7 +128,6 @@ export const ThorchainSaversDeposit: React.FC<YearnDepositProps> = ({
 
   useEffect(() => {
     if (!(accountId && wallet && accountMetadata)) return
-    if (fromAddress) return
     ;(async () => {
       const _fromAddress = await getThorchainFromAddress({
         accountId,

--- a/src/features/defi/providers/thorchain-savers/components/ThorchainSaversManager/Deposit/components/Deposit.tsx
+++ b/src/features/defi/providers/thorchain-savers/components/ThorchainSaversManager/Deposit/components/Deposit.tsx
@@ -860,9 +860,12 @@ export const Deposit: React.FC<DepositProps> = ({
     thorchainSaversDepositQuoteError?.message,
   ])
 
-  const handleInputChange = useCallback((fiatAmount: string, cryptoAmount: string) => {
-    setInputValues({ fiatAmount, cryptoAmount })
-  }, [])
+  const handleInputChange = useCallback(
+    ({ fiatAmount, cryptoAmount }: { fiatAmount: string; cryptoAmount: string }) => {
+      setInputValues({ fiatAmount, cryptoAmount })
+    },
+    [],
+  )
 
   const handleBack = useCallback(() => {
     history.push({

--- a/src/features/defi/providers/thorchain-savers/components/ThorchainSaversManager/Withdraw/ThorchainSaversWithdraw.tsx
+++ b/src/features/defi/providers/thorchain-savers/components/ThorchainSaversManager/Withdraw/ThorchainSaversWithdraw.tsx
@@ -100,7 +100,6 @@ export const ThorchainSaversWithdraw: React.FC<WithdrawProps> = ({ accountId }) 
 
   useEffect(() => {
     if (!(accountId && wallet && accountMetadata)) return
-    if (fromAddress) return
     ;(async () => {
       const _fromAddress = await getThorchainFromAddress({
         accountId,


### PR DESCRIPTION
## Description

... and updates the signature of `onChange` in the reusable `<Deposit />` to be sane. 

Two birds one stone:

1. This fixes the reactivity of `fromAddress` to handle `accountId` (thus, `accountType` changes) when getting the first/active THOR savers address. Currently, there is a `if (fromAddress) return` early return, meaning that changing your account type at overview/deposit input/withdraw input step will still yield your first/active address from your previously selected accountType. This means the consolidation step would send your funds to a different accountType, making you unable to continue with the deposit after the reconciliation
2. `onChange` signature was rugged in the shared `<Deposit />` component. There was no notion of "isFiat" in the `onChange` prop `<ReusableDeposit />` and it assumes a single `onChange?(fiatAmount: string, cryptoAmount: string): void` arity  (which is wrong, as it may be `cryptoAmount: string, fiatAmount: string` while using crypto input, meaning the amounts we'd be checking against at input step when doing balance/fees/sweep fees deduction would be wrong, resulting in checks seemingly passing, but the actual Tx failing. Fixed by using a sane destructured object signature

## Pull Request Type

- [x] :bug: Bug fix (Non-breaking Change: Fixes an issue)
- [ ] :hammer_and_wrench: Chore (Non-breaking Change: Doc updates, pkg upgrades, typos, etc..)
- [ ] :nail_care: New Feature (Breaking/Non-breaking Change)

## Issue (if applicable)

<!-----------------------------------------------------------------------------
If applicable, please link to the github issue and put `closes #XXXX` in your comment to auto-close the issue that your PR fixes.
------------------------------------------------------------------------------>

closes https://github.com/shapeshift/web/issues/5688

## Risk

<!-----------------------------------------------------------------------------
Outline the scope of your changes and the risk associated with them. You must use your discretion as an engineer to determine the potential impact of your changes.

E.g. an upgrade to `hdwallet` or core state management would be considered higher risk, and might require a full regression test. UI or isolated view changes, or something behind a feature flag may have near zero risk. Small bug fixes might require testing isolated to the specific fix.
------------------------------------------------------------------------------>

None, this was rugged, and the `onChange` common prop is only consumed by savers deposit

## Testing

<!-----------------------------------------------------------------------------
We treat every PR to be merged with the same scrutiny as if we were merging directly to production.

Your PR will not be merged if you do not complete the sections below for our engineering and operations teams to test.
------------------------------------------------------------------------------>

### Account type fix

- Open UTXO savers with the default selected account type
- Change your account type to another e.g SegWit -> Legacy  and ensure reconciliation sends your funds to the same account type
- Ensure the deposit succeeds after the reconciliation

### Fee deduction

- Test this end-to-end (with the default or after changing your account type), ensuring that the fee deduction is properly applied. This can be tested by ensuring that the sweep/Tx fees are deducted when clicking max (note, we use 99% when clicking "Max" to account for max sends possibly being cheaper), but manually inputing the *actual* max - a few sats (meaning there won't be enough for Tx fees + sweep fees) yields an "Insufficient Balance" state

### Engineering

<!-----------------------------------------------------------------------------
Include sufficient information here for an engineer to test your PR. This may include how to test locally, in a built environment, changes to infrastructure etc.
------------------------------------------------------------------------------>

- ☝🏽 

### Operations

<!-----------------------------------------------------------------------------
If your changes have a user-facing impact, describe how a non-technical QA team can functionally test your changes in a preview environment.

If they are not user-facing please describe how to test for any regressions that may occur.
------------------------------------------------------------------------------>

- ☝🏽 

## Screenshots (if applicable)

- Reconciliation

<img width="527" alt="Screenshot 2023-11-27 at 16 32 22" src="https://github.com/shapeshift/web/assets/17035424/77952765-e5a0-4c54-aefc-85b83288dfde">
<img width="118" alt="Screenshot 2023-11-27 at 16 33 10" src="https://github.com/shapeshift/web/assets/17035424/777cb70a-da7b-48a1-8aa2-3b2e24b5a500">

Note funds are sent to LVUVD, which previously had a 0 balance

- Deposit

<img width="538" alt="Screenshot 2023-11-27 at 16 32 36" src="https://github.com/shapeshift/web/assets/17035424/fb689421-cc6f-4aa4-99ea-04e2813208d4">
<img width="82" alt="image" src="https://github.com/shapeshift/web/assets/17035424/a51688dc-75ac-4dc4-abed-38c8cff0151d">

LVUVD is used as an UTXO input, with the correct amount sent to THOR

- Updated balance after succesful deposit

<img width="847" alt="image" src="https://github.com/shapeshift/web/assets/17035424/1f717137-7985-481b-b91b-d41ed12b574d">

- Balance checks

<img width="525" alt="image" src="https://github.com/shapeshift/web/assets/17035424/44418a66-9689-456b-8993-10af7f6b3c77">
<img width="537" alt="image" src="https://github.com/shapeshift/web/assets/17035424/abc21887-2f1f-4fae-87e3-46cebbfb80e7">
