### PR TITLE
feat: improve thorchain Txs failure detection

### DIFF
--- a/src/features/defi/providers/thorchain-savers/components/ThorchainSaversManager/Withdraw/components/Status.tsx
+++ b/src/features/defi/providers/thorchain-savers/components/ThorchainSaversManager/Withdraw/components/Status.tsx
@@ -2,6 +2,7 @@ import { CheckIcon, CloseIcon, ExternalLinkIcon } from '@chakra-ui/icons'
 import { Box, Button, Link, Stack } from '@chakra-ui/react'
 import type { AccountId } from '@shapeshiftoss/caip'
 import { fromAccountId } from '@shapeshiftoss/caip'
+import { TxStatus as TxStatusType } from '@shapeshiftoss/unchained-client'
 import { Summary } from 'features/defi/components/Summary'
 import { TxStatus } from 'features/defi/components/TxStatus/TxStatus'
 import type {
@@ -84,14 +85,17 @@ export const Status: React.FC<StatusProps> = ({ accountId }) => {
     if (confirmedTransaction && confirmedTransaction.status !== 'Pending' && contextDispatch) {
       ;(async () => {
         // Ensuring we wait for the outbound Tx to exist
-        await waitForThorchainUpdate({ txId: confirmedTransaction.txid, skipOutbound: false })
-          .promise
+        // Note, the transaction we wait for here is a Thorchain transaction, *not* the inbound Tx
+        const thorchainTxStatus = await waitForThorchainUpdate({
+          txId: confirmedTransaction.txid,
+          skipOutbound: false,
+        }).promise
 
-        if (confirmedTransaction.status === 'Confirmed') {
+        if ([TxStatusType.Confirmed, TxStatusType.Failed].includes(thorchainTxStatus)) {
           contextDispatch({
             type: ThorchainSaversWithdrawActionType.SET_WITHDRAW,
             payload: {
-              txStatus: confirmedTransaction.status === 'Confirmed' ? 'success' : 'failed',
+              txStatus: thorchainTxStatus === TxStatusType.Confirmed ? 'success' : 'failed',
             },
           })
         }

--- a/src/lib/swapper/swappers/ThorchainSwapper/types.ts
+++ b/src/lib/swapper/swappers/ThorchainSwapper/types.ts
@@ -79,6 +79,11 @@ type MidgardCoins = {
   asset: string
 }[]
 
+type MidgardActionIn = {
+  coins: MidgardCoins
+  txID: string
+}
+
 type MidgardActionOut = {
   coins: MidgardCoins
   txID: string
@@ -87,6 +92,7 @@ type MidgardActionOut = {
 type MidgardAction = {
   date: string
   height: string
+  in: MidgardActionIn[]
   out: MidgardActionOut[]
   status: string
   type: string

--- a/src/lib/utils/thorchain/index.ts
+++ b/src/lib/utils/thorchain/index.ts
@@ -84,7 +84,7 @@ export const waitForThorchainUpdate = ({
 }) =>
   poll({
     fn: () => getThorchainTransactionStatus(txId, skipOutbound),
-    validate: status => Boolean([TxStatus.Confirmed, TxStatus.Failed].includes(status)),
+    validate: status => [TxStatus.Confirmed, TxStatus.Failed].includes(status),
     interval: 60000,
     maxAttempts: 60,
   })


### PR DESCRIPTION
## Description

Relies on Midgard for failure and success detection in conjunction to our current `/tx/status` checks.

This allows us to more reliably detect success Txs when enforcing outbound checks by ensuring we have a succesful `out` Tx, as well as properly detect refunds, both succesful and failed.

## Pull Request Type

- [ ] :bug: Bug fix (Non-breaking Change: Fixes an issue)
- [ ] :hammer_and_wrench: Chore (Non-breaking Change: Doc updates, pkg upgrades, typos, etc..)
- [x] :nail_care: New Feature (Breaking/Non-breaking Change)

## Issue (if applicable)

<!-----------------------------------------------------------------------------
If applicable, please link to the github issue and put `closes #XXXX` in your comment to auto-close the issue that your PR fixes.
------------------------------------------------------------------------------>

closes https://github.com/shapeshift/web/issues/5702

## Risk

<!-----------------------------------------------------------------------------
Outline the scope of your changes and the risk associated with them. You must use your discretion as an engineer to determine the potential impact of your changes.

E.g. an upgrade to `hdwallet` or core state management would be considered higher risk, and might require a full regression test. UI or isolated view changes, or something behind a feature flag may have near zero risk. Small bug fixes might require testing isolated to the specific fix.
------------------------------------------------------------------------------>

- THOR Tx status detection is still happy for Txs skipping outbound checks (e.g savers deposits or loan repayment if available for your collateral)
- THOR Tx status detection is still happy for Txs enforcing outbound checks (e.g savers withdraws)

## Testing

<!-----------------------------------------------------------------------------
We treat every PR to be merged with the same scrutiny as if we were merging directly to production.

Your PR will not be merged if you do not complete the sections below for our engineering and operations teams to test.
------------------------------------------------------------------------------>

### Engineering

<!-----------------------------------------------------------------------------
Include sufficient information here for an engineer to test your PR. This may include how to test locally, in a built environment, changes to infrastructure etc.
------------------------------------------------------------------------------>

- ☝🏽 
- Remove the minimum checks in savers withdraw

https://github.com/shapeshift/web/blob/680c55051da5cb6db26340c2909027c924a37272/src/features/defi/providers/thorchain-savers/components/ThorchainSaversManager/Withdraw/components/Withdraw.tsx#L638-L646

- Try to withdraw a very small amount of a small position e.g 1bps, or anything small enough to be lesser than fees 
- Ensure the withdraw is displayed as failed after we fetch the failed refund from Midgard

### Operations

<!-----------------------------------------------------------------------------
If your changes have a user-facing impact, describe how a non-technical QA team can functionally test your changes in a preview environment.

If they are not user-facing please describe how to test for any regressions that may occur.
------------------------------------------------------------------------------>

- ☝🏽 

## Screenshots (if applicable)

- Outbound checks enforced - succesful outbound Tx on savers EVM withdraw

<img width="537" alt="Screenshot 2023-11-28 at 01 01 35" src="https://github.com/shapeshift/web/assets/17035424/e4b9708d-b5bf-4bda-8bf4-13ac2213b2e9">

- Outbound checks enforced - succesful outbound Tx on savers UTXO withdraw

<img width="509" alt="image" src="https://github.com/shapeshift/web/assets/17035424/607267c1-0c7e-4bd3-a58e-015ef5dcf80d">
<img width="522" alt="image" src="https://github.com/shapeshift/web/assets/17035424/bda28c66-11b5-494a-9c27-53bcd9d8b21c">


- Outbound checks enforced - failed refund

<img width="543" alt="Screenshot 2023-11-28 at 00 37 37" src="https://github.com/shapeshift/web/assets/17035424/e5ad9f23-f8de-4ffe-9440-18e789cc293d">

- Outbound checks skipped - succesful deposit (note, as we skip outbound checks, we do *not* check for failures here and are only relying on `swap_status.pending === false`

<img width="551" alt="image" src="https://github.com/shapeshift/web/assets/17035424/e99ddc7f-859e-4b5a-bcbd-958ca8759c07">
