### PR TITLE
fix: portfolio empty loading state

### DIFF
--- a/src/state/slices/portfolioSlice/selectors.ts
+++ b/src/state/slices/portfolioSlice/selectors.ts
@@ -138,6 +138,8 @@ export const selectPortfolioLoadingStatus = createSelector(
   selectPortfolioLoadingStatusGranular,
   (portfolioLoadingStatusGranular): PortfolioLoadingStatus => {
     const vals = values(portfolioLoadingStatusGranular)
+
+    if (!vals.length) return 'loading'
     if (vals.some(val => val === 'loading')) return 'loading'
     if (vals.some(val => val === 'error')) return 'error'
     return 'success'


### PR DESCRIPTION
## Description

Ensures we requested AccountIds as a loading state vs. complete state currently, ensuring we don't run effects reacting on `portolioLoadingStatus` unless we *actually* have a loaded portfolio

## Pull Request Type

- [ ] :bug: Bug fix (Non-breaking Change: Fixes an issue)
- [ ] :hammer_and_wrench: Chore (Non-breaking Change: Doc updates, pkg upgrades, typos, etc..)
- [x] :nail_care: New Feature (Breaking/Non-breaking Change)

## Issue (if applicable)

<!-----------------------------------------------------------------------------
If applicable, please link to the github issue and put `closes #XXXX` in your comment to auto-close the issue that your PR fixes.
------------------------------------------------------------------------------>

closes N/A

## Risk

<!-----------------------------------------------------------------------------
Outline the scope of your changes and the risk associated with them. You must use your discretion as an engineer to determine the potential impact of your changes.

E.g. an upgrade to `hdwallet` or core state management would be considered higher risk, and might require a full regression test. UI or isolated view changes, or something behind a feature flag may have near zero risk. Small bug fixes might require testing isolated to the specific fix.
------------------------------------------------------------------------------>

- None from a functional standpoint

## Testing

<!-----------------------------------------------------------------------------
We treat every PR to be merged with the same scrutiny as if we were merging directly to production.

Your PR will not be merged if you do not complete the sections below for our engineering and operations teams to test.
------------------------------------------------------------------------------>

### Engineering

<!-----------------------------------------------------------------------------
Include sufficient information here for an engineer to test your PR. This may include how to test locally, in a built environment, changes to infrastructure etc.
------------------------------------------------------------------------------>

- Put breakpoints in `<AppContext />` effects relying on `portfolioLoadingStatus` and ensure those don't load until we actually have `requestedAccountIds` i.e this guy:

https://github.com/shapeshift/web/blob/1eaa190ef658cf48337fdcaa76503befbb331f4e/src/state/slices/portfolioSlice/selectors.ts#L127


### Operations

<!-----------------------------------------------------------------------------
If your changes have a user-facing impact, describe how a non-technical QA team can functionally test your changes in a preview environment.

If they are not user-facing please describe how to test for any regressions that may occur.
------------------------------------------------------------------------------>

None

## Screenshots (if applicable)
