### PR TITLE
feat: store streaming swap state in redux for multi-hop ui

### DIFF
--- a/src/components/MultiHopTrade/components/MultiHopTradeConfirm/components/HopTransactionStep.tsx
+++ b/src/components/MultiHopTrade/components/MultiHopTradeConfirm/components/HopTransactionStep.tsx
@@ -55,8 +55,8 @@ export const HopTransactionStep = ({
   const {
     state: hopExecutionState,
     swapState: txState,
-    swapSellTxHash: buyTxHash,
-    swapBuyTxHash: sellTxHash,
+    swapSellTxHash: sellTxHash,
+    swapBuyTxHash: buyTxHash,
   } = useAppSelector(selectHopExecutionMetadata)[hopIndex]
 
   const {
@@ -151,12 +151,21 @@ export const HopTransactionStep = ({
       return (
         <Card width='full'>
           <CardBody px={2} py={2}>
-            <StreamingSwap sellTxHash={sellTxHash} />
+            <StreamingSwap hopIndex={hopIndex} />
           </CardBody>
         </Card>
       )
     }
-  }, [handleSignTx, isActive, sellTxHash, signIcon, tradeQuoteStep, translate, txStatus])
+  }, [
+    handleSignTx,
+    hopIndex,
+    isActive,
+    sellTxHash,
+    signIcon,
+    tradeQuoteStep.source,
+    translate,
+    txStatus,
+  ])
 
   const errorTranslation = useMemo(
     (): [string, Polyglot.InterpolationOptions] => ['trade.swapFailed', { tradeType }],

--- a/src/components/MultiHopTrade/components/MultiHopTradeConfirm/components/StreamingSwap.tsx
+++ b/src/components/MultiHopTrade/components/MultiHopTradeConfirm/components/StreamingSwap.tsx
@@ -6,20 +6,16 @@ import { Row } from 'components/Row/Row'
 import { useMockThorStreamingProgress } from '../hooks/mockHooks'
 
 export type StreamingSwapProps = {
-  sellTxHash: string | undefined
+  hopIndex: number
 }
 
 export const StreamingSwap = (props: StreamingSwapProps) => {
-  const { sellTxHash } = props
+  const { hopIndex } = props
 
   const translate = useTranslate()
 
-  const {
-    attemptedSwapCount,
-    progressProps: thorStreamingSwapProgressProps,
-    totalSwapCount,
-    failedSwaps,
-  } = useMockThorStreamingProgress(sellTxHash, true)
+  const { totalSwapCount, attemptedSwapCount, isComplete, failedSwaps } =
+    useMockThorStreamingProgress(hopIndex)
 
   return (
     <Stack px={4}>
@@ -30,7 +26,17 @@ export const StreamingSwap = (props: StreamingSwapProps) => {
         )}
       </Row>
       <Row>
-        <Progress width='full' borderRadius='full' size='sm' {...thorStreamingSwapProgressProps} />
+        <Progress
+          width='full'
+          borderRadius='full'
+          size='sm'
+          min={0}
+          max={totalSwapCount}
+          value={attemptedSwapCount}
+          hasStripe
+          isAnimated={!isComplete}
+          colorScheme={isComplete ? 'green' : 'blue'}
+        />
       </Row>
       {failedSwaps.length > 0 && (
         <Row>

--- a/src/components/MultiHopTrade/hooks/useThorStreamingProgress/useThorStreamingProgress.tsx
+++ b/src/components/MultiHopTrade/hooks/useThorStreamingProgress/useThorStreamingProgress.tsx
@@ -3,6 +3,7 @@ import axios from 'axios'
 import { getConfig } from 'config'
 import { useEffect, useMemo, useRef, useState } from 'react'
 import { usePoll } from 'hooks/usePoll/usePoll'
+import type { StreamingSwapFailedSwap } from 'state/slices/tradeQuoteSlice/types'
 
 import type { ThornodeStreamingSwapResponse, ThornodeStreamingSwapResponseSuccess } from './types'
 const POLL_INTERVAL_MILLISECONDS = 30_000 // 30 seconds
@@ -24,11 +25,6 @@ export const getThorchainStreamingSwap = async (
   return streamingSwapData
 }
 
-export type FailedSwap = {
-  reason: string
-  swapIndex: number
-}
-
 export const useThorStreamingProgress = (
   txHash: string | undefined,
   isThorStreamingSwap: boolean,
@@ -36,7 +32,7 @@ export const useThorStreamingProgress = (
   progressProps: ProgressProps
   attemptedSwapCount: number
   totalSwapCount: number
-  failedSwaps: FailedSwap[]
+  failedSwaps: StreamingSwapFailedSwap[]
 } => {
   // a ref is used to allow updating and reading state without creating a dependency cycle
   const streamingSwapDataRef = useRef<ThornodeStreamingSwapResponseSuccess>()

--- a/src/state/slices/tradeQuoteSlice/selectors.ts
+++ b/src/state/slices/tradeQuoteSlice/selectors.ts
@@ -32,6 +32,7 @@ import {
 
 import { selectCryptoMarketData, selectUserCurrencyToUsdRate } from '../marketDataSlice/selectors'
 import { selectAccountIdByAccountNumberAndChainId } from '../portfolioSlice/selectors'
+import type { StreamingSwapMetadata } from './types'
 
 const selectTradeQuoteSlice = (state: ReduxState) => state.tradeQuoteSlice
 
@@ -487,3 +488,19 @@ export const selectSecondHopSellAccountId = createSelector(
 export const selectHopExecutionMetadata = createSelector(selectTradeQuoteSlice, swappers => {
   return [swappers.tradeExecution.firstHop, swappers.tradeExecution.secondHop]
 })
+
+export const selectHopStreamingSwapMetadata = createSelector(
+  selectHopExecutionMetadata,
+  (hopExecutionMetadata): StreamingSwapMetadata[] => {
+    const defaultValue = {
+      attemptedSwapCount: 0,
+      totalSwapCount: 0,
+      failedSwaps: [],
+    }
+
+    return [
+      hopExecutionMetadata[0].streamingSwap ?? defaultValue,
+      hopExecutionMetadata[1].streamingSwap ?? defaultValue,
+    ]
+  },
+)

--- a/src/state/slices/tradeQuoteSlice/selectors.ts
+++ b/src/state/slices/tradeQuoteSlice/selectors.ts
@@ -32,7 +32,6 @@ import {
 
 import { selectCryptoMarketData, selectUserCurrencyToUsdRate } from '../marketDataSlice/selectors'
 import { selectAccountIdByAccountNumberAndChainId } from '../portfolioSlice/selectors'
-import type { StreamingSwapMetadata } from './types'
 
 const selectTradeQuoteSlice = (state: ReduxState) => state.tradeQuoteSlice
 
@@ -485,22 +484,9 @@ export const selectSecondHopSellAccountId = createSelector(
   },
 )
 
-export const selectHopExecutionMetadata = createSelector(selectTradeQuoteSlice, swappers => {
-  return [swappers.tradeExecution.firstHop, swappers.tradeExecution.secondHop]
-})
-
-export const selectHopStreamingSwapMetadata = createSelector(
-  selectHopExecutionMetadata,
-  (hopExecutionMetadata): StreamingSwapMetadata[] => {
-    const defaultValue = {
-      attemptedSwapCount: 0,
-      totalSwapCount: 0,
-      failedSwaps: [],
-    }
-
-    return [
-      hopExecutionMetadata[0].streamingSwap ?? defaultValue,
-      hopExecutionMetadata[1].streamingSwap ?? defaultValue,
-    ]
+export const selectHopExecutionMetadata = createDeepEqualOutputSelector(
+  selectTradeQuoteSlice,
+  swappers => {
+    return [swappers.tradeExecution.firstHop, swappers.tradeExecution.secondHop]
   },
 )

--- a/src/state/slices/tradeQuoteSlice/tradeQuoteSlice.ts
+++ b/src/state/slices/tradeQuoteSlice/tradeQuoteSlice.ts
@@ -3,7 +3,7 @@ import { createSlice } from '@reduxjs/toolkit'
 import type { TxStatus } from '@shapeshiftoss/unchained-client'
 import type { TradeQuote } from 'lib/swapper/types'
 
-import type { HopExecutionMetadata } from './types'
+import type { HopExecutionMetadata, StreamingSwapMetadata } from './types'
 import { HopExecutionState, MultiHopExecutionState } from './types'
 import { getHopExecutionStates, getNextTradeExecutionState } from './utils'
 
@@ -125,6 +125,12 @@ export const tradeQuoteSlice = createSlice({
     },
     setSecondHopSwapBuyTxHash: (state, action: PayloadAction<string>) => {
       state.tradeExecution.secondHop.swapBuyTxHash = action.payload
+    },
+    setFirstHopStreamingSwapMeta: (state, action: PayloadAction<StreamingSwapMetadata>) => {
+      state.tradeExecution.firstHop.streamingSwap = action.payload
+    },
+    setSecondHopStreamingSwapMeta: (state, action: PayloadAction<StreamingSwapMetadata>) => {
+      state.tradeExecution.secondHop.streamingSwap = action.payload
     },
   },
 })

--- a/src/state/slices/tradeQuoteSlice/types.ts
+++ b/src/state/slices/tradeQuoteSlice/types.ts
@@ -44,6 +44,17 @@ export const MULTI_HOP_EXECUTION_STATE_ORDERED = [
   MultiHopExecutionState.TradeComplete,
 ]
 
+export type StreamingSwapFailedSwap = {
+  reason: string
+  swapIndex: number
+}
+
+export type StreamingSwapMetadata = {
+  attemptedSwapCount: number
+  totalSwapCount: number
+  failedSwaps: StreamingSwapFailedSwap[]
+}
+
 export type HopExecutionMetadata = {
   state: HopExecutionState
   approvalRequired?: boolean
@@ -52,4 +63,5 @@ export type HopExecutionMetadata = {
   swapState?: TxStatus
   swapSellTxHash?: string
   swapBuyTxHash?: string
+  streamingSwap?: StreamingSwapMetadata
 }


### PR DESCRIPTION
## Description

Stores the state of streaming swaps in redux to allow rendering across different UIs (i.e during trade execution, and the summary after the trade is completed), without re-executing requests.

## Pull Request Type

- [ ] :bug: Bug fix (Non-breaking Change: Fixes an issue)
- [ ] :hammer_and_wrench: Chore (Non-breaking Change: Doc updates, pkg upgrades, typos, etc..)
- [x] :nail_care: New Feature (Breaking/Non-breaking Change)

## Issue (if applicable)

<!-----------------------------------------------------------------------------
If applicable, please link to the github issue and put `closes #XXXX` in your comment to auto-close the issue that your PR fixes.
------------------------------------------------------------------------------>

closes #5710

## Risk

Not production facing, low risk.

## Testing

Not required

### Engineering

<!-----------------------------------------------------------------------------
Include sufficient information here for an engineer to test your PR. This may include how to test locally, in a built environment, changes to infrastructure etc.
------------------------------------------------------------------------------>

### Operations

<!-----------------------------------------------------------------------------
If your changes have a user-facing impact, describe how a non-technical QA team can functionally test your changes in a preview environment.

If they are not user-facing please describe how to test for any regressions that may occur.
------------------------------------------------------------------------------>

## Screenshots (if applicable)

Demo of trade completion summary with 2 mocked hops as streaming swaps
![image](https://github.com/shapeshift/web/assets/125113430/f67903ba-38e2-4b2f-91c1-8927492e97a6)

Demo of trade completion summary with 2 mocked hops as streaming swaps, including 1 failed swap each
![image](https://github.com/shapeshift/web/assets/125113430/9f9bbade-5df0-41dd-aa8c-1992cb259b24)

