### PR TITLE
fix: lending first render

### DIFF
--- a/src/pages/Lending/AvailablePools.tsx
+++ b/src/pages/Lending/AvailablePools.tsx
@@ -13,6 +13,7 @@ import { RawText, Text } from 'components/Text'
 import type { Asset } from 'lib/asset-service'
 
 import { LendingHeader } from './components/LendingHeader'
+import { useAllLendingPositionsData } from './hooks/useAllLendingPositionsData'
 import { useLendingSupportedAssets } from './hooks/useLendingSupportedAssets'
 import { usePoolDataQuery } from './hooks/usePoolDataQuery'
 
@@ -29,6 +30,15 @@ type LendingPoolButtonProps = {
 const LendingPoolButton = ({ asset, onPoolClick }: LendingPoolButtonProps) => {
   const usePoolDataArgs = useMemo(() => ({ poolAssetId: asset.assetId }), [asset.assetId])
   const { data: poolData, isLoading: isPoolDataLoading } = usePoolDataQuery(usePoolDataArgs)
+
+  const { isLoading: isLendingPositionDataLoading } = useAllLendingPositionsData({
+    assetId: asset.assetId,
+  })
+
+  const isLoaded = useMemo(
+    () => !isPoolDataLoading && !isLendingPositionDataLoading,
+    [isLendingPositionDataLoading, isPoolDataLoading],
+  )
 
   const handlePoolClick = useCallback(() => {
     onPoolClick(asset.assetId)
@@ -48,7 +58,7 @@ const LendingPoolButton = ({ asset, onPoolClick }: LendingPoolButtonProps) => {
       onClick={handlePoolClick}
     >
       <AssetCell assetId={asset.assetId} />
-      <Skeleton isLoaded={!isPoolDataLoading}>
+      <Skeleton isLoaded={isLoaded}>
         <Flex>
           <Tag colorScheme='green'>
             <TagLeftIcon as={CheckCircleIcon} />
@@ -56,19 +66,19 @@ const LendingPoolButton = ({ asset, onPoolClick }: LendingPoolButtonProps) => {
           </Tag>
         </Flex>
       </Skeleton>
-      <Skeleton isLoaded={!isPoolDataLoading}>
+      <Skeleton isLoaded={isLoaded}>
         <Amount.Fiat value={poolData?.totalDebtUserCurrency ?? '0'} />
       </Skeleton>
-      <Skeleton isLoaded={!isPoolDataLoading}>
+      <Skeleton isLoaded={isLoaded}>
         <Amount.Crypto
           value={poolData?.totalCollateralCryptoPrecision ?? '0'}
           symbol={asset.symbol}
         />
       </Skeleton>
-      <Skeleton isLoaded={!isPoolDataLoading}>
+      <Skeleton isLoaded={isLoaded}>
         <Amount.Percent value={poolData?.collateralizationRatioPercentDecimal ?? '0'} />
       </Skeleton>
-      <Skeleton isLoaded={!isPoolDataLoading}>
+      <Skeleton isLoaded={isLoaded}>
         <RawText>{poolData?.totalBorrowers ?? '0'}</RawText>
       </Skeleton>
     </Button>

--- a/src/pages/Lending/Pool/Pool.tsx
+++ b/src/pages/Lending/Pool/Pool.tsx
@@ -111,10 +111,16 @@ export const Pool = () => {
   const translate = useTranslate()
 
   const useRepaymentLockDataArgs = useMemo(
-    () => ({ assetId: poolAssetId, accountId: poolAccountId }),
-    [poolAccountId, poolAssetId],
+    () => ({
+      assetId: poolAssetId,
+      accountId: collateralAccountId,
+      // When fetching position repayment lock, we want to ensure there's an AccountId and AssetId
+      // or we would fetch the default network's repayment lock instead
+      enabled: Boolean(poolAssetId && collateralAccountId),
+    }),
+    [collateralAccountId, poolAssetId],
   )
-  const { data: repaymentLock, isLoading: isRepaymentLockLoading } =
+  const { data: positionRepaymentLock, isSuccess: isPositionRepaymentLockSuccess } =
     useRepaymentLockData(useRepaymentLockDataArgs)
   const { data: defaultRepaymentLock, isSuccess: isDefaultRepaymentLockSuccess } =
     useRepaymentLockData({})
@@ -290,11 +296,11 @@ export const Pool = () => {
   const repaymentLockComponent = useMemo(
     () => (
       <RepaymentLockComponentWithValue
-        value={repaymentLock ?? '0'}
-        isLoaded={!isRepaymentLockLoading}
+        value={positionRepaymentLock ?? '0'}
+        isLoaded={isPositionRepaymentLockSuccess}
       />
     ),
-    [isRepaymentLockLoading, repaymentLock],
+    [isPositionRepaymentLockSuccess, positionRepaymentLock],
   )
 
   const newRepaymentLock = useMemo(() => {
@@ -348,7 +354,7 @@ export const Pool = () => {
                   label='lending.collateralValue'
                   toolTipLabel={translate('lending.collateralValueDescription')}
                   component={collateralValueComponent}
-                  isLoading={isRepaymentLockLoading}
+                  isLoading={isLendingPositionDataLoading}
                   flex={1}
                   {...newCollateralFiat}
                 />

--- a/src/pages/Lending/YourLoans.tsx
+++ b/src/pages/Lending/YourLoans.tsx
@@ -41,10 +41,17 @@ const LendingRowGrid = ({ asset, accountId, onPoolClick }: LendingRowGridProps) 
     })
 
   const useRepaymentLockDataArgs = useMemo(
-    () => ({ assetId: asset.assetId, accountId }),
+    () => ({
+      assetId: asset.assetId,
+      accountId,
+      // When fetching position repayment lock, we want to ensure there's an AccountId and AssetId
+      // or we would fetch the default network's repayment lock instead
+      // these should be defined according to types but you never know
+      enabled: Boolean(asset.assetId && accountId),
+    }),
     [asset.assetId, accountId],
   )
-  const { data: repaymentLockData, isLoading: isRepaymentLockDataLoading } =
+  const { data: repaymentLockData, isSuccess: isRepaymentLockSuccess } =
     useRepaymentLockData(useRepaymentLockDataArgs)
 
   const handlePoolClick = useCallback(() => {
@@ -110,7 +117,7 @@ const LendingRowGrid = ({ asset, accountId, onPoolClick }: LendingRowGridProps) 
             />
           </Stack>
         </Skeleton>
-        <Skeleton isLoaded={!isRepaymentLockDataLoading}>
+        <Skeleton isLoaded={isRepaymentLockSuccess}>
           <RawText color={isRepaymentLocked ? 'white' : 'green.500'}>
             {isRepaymentLocked ? `${repaymentLockData} days` : translate('lending.unlocked')}
           </RawText>

--- a/src/pages/Lending/hooks/useAllLendingPositionsData.tsx
+++ b/src/pages/Lending/hooks/useAllLendingPositionsData.tsx
@@ -9,8 +9,9 @@ import {
   selectAccountIdsByAssetId,
   selectUserCurrencyRateByAssetId,
   selectUserCurrencyToUsdRate,
+  selectWalletAccountIds,
 } from 'state/slices/selectors'
-import { store } from 'state/store'
+import { store, useAppSelector } from 'state/store'
 
 import { useLendingSupportedAssets } from './useLendingSupportedAssets'
 
@@ -21,6 +22,7 @@ type UseAllLendingPositionsDataProps = {
 export const useAllLendingPositionsData = ({ assetId }: UseAllLendingPositionsDataProps = {}) => {
   const { data: lendingSupportedAssets } = useLendingSupportedAssets({ type: 'collateral' })
 
+  const accountIds = useAppSelector(selectWalletAccountIds)
   const accounts = useMemo(
     () =>
       (lendingSupportedAssets ?? [])
@@ -32,7 +34,10 @@ export const useAllLendingPositionsData = ({ assetId }: UseAllLendingPositionsDa
           return _accountIds.map(accountId => ({ accountId, assetId: asset.assetId }))
         })
         .flat(),
-    [assetId, lendingSupportedAssets],
+    // We want to react on accountIds, since the portfolio may not be loaded in the useMemo() above,
+    // and we're iterating, meaning we cannot be reactive on selectAccountIdsByAssetId at hook scope
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+    [assetId, accountIds, lendingSupportedAssets],
   )
 
   const positions = useQueries({

--- a/src/pages/Lending/hooks/useLendingSupportedAssets/index.ts
+++ b/src/pages/Lending/hooks/useLendingSupportedAssets/index.ts
@@ -41,6 +41,7 @@ export const useLendingSupportedAssets = ({ type }: { type: 'collateral' | 'borr
     queryKey,
     queryFn: () => availablePools,
     select: selectSupportedAssets,
+    enabled: Boolean(availablePools?.length),
   })
 
   return lendingSupportedAssetsQuery


### PR DESCRIPTION
## Description

Fixes the data fetching bits of lending page on the first load, at "Available Pools" default route:

 - adds some additional dependency to the `accounts` memoized constant in `useAllLendingPositionsData`, for the precise reason mentioned in the comment, avoiding having no `availablePools` on first render, thus no available pools and no position data
 https://github.com/shapeshift/web/blob/5076849d5708562270fc638edbc9cdc86571878a/src/pages/Lending/hooks/useAllLendingPositionsData.tsx#L37-L40
 
 - consumes `useAllLendingPositionsData({assetId})` in `<LendingPoolButton />`, improving loading state while position(s) data is loading
 - adds some extra `enabled` safety to `useLendingSupportedAssets` to not run the query when there are no `availablePools`. Since queries are cached for 60 seconds, early "querying" (i.e `() => `availablePools`) without `availablePools` ready yet means the `undefined` response would be cached, and the query will not re-run.
 The selector would sure re-run, but it would re-run on `undefined` as data.

## Pull Request Type

- [x] :bug: Bug fix (Non-breaking Change: Fixes an issue)
- [ ] :hammer_and_wrench: Chore (Non-breaking Change: Doc updates, pkg upgrades, typos, etc..)
- [ ] :nail_care: New Feature (Breaking/Non-breaking Change)

## Issue (if applicable)

<!-----------------------------------------------------------------------------
If applicable, please link to the github issue and put `closes #XXXX` in your comment to auto-close the issue that your PR fixes.
------------------------------------------------------------------------------>

N/A

## Risk

<!-----------------------------------------------------------------------------
Outline the scope of your changes and the risk associated with them. You must use your discretion as an engineer to determine the potential impact of your changes.

E.g. an upgrade to `hdwallet` or core state management would be considered higher risk, and might require a full regression test. UI or isolated view changes, or something behind a feature flag may have near zero risk. Small bug fixes might require testing isolated to the specific fix.
------------------------------------------------------------------------------>

None

## Testing

<!-----------------------------------------------------------------------------
We treat every PR to be merged with the same scrutiny as if we were merging directly to production.

Your PR will not be merged if you do not complete the sections below for our engineering and operations teams to test.
------------------------------------------------------------------------------>

- Clear your cache fully (see screen recording)
- Ensure pools, and your pool data if active on some pools, is loaded and displayed
- Refresh the page and ensure the above is still true

### Engineering

<!-----------------------------------------------------------------------------
Include sufficient information here for an engineer to test your PR. This may include how to test locally, in a built environment, changes to infrastructure etc.
------------------------------------------------------------------------------>

- ☝🏽 

### Operations

<!-----------------------------------------------------------------------------
If your changes have a user-facing impact, describe how a non-technical QA team can functionally test your changes in a preview environment.

If they are not user-facing please describe how to test for any regressions that may occur.
------------------------------------------------------------------------------>

- ☝🏽 

## Screenshots (if applicable)


https://github.com/shapeshift/web/assets/17035424/d293e826-6c3e-436a-ab5b-fa8bf23fc998


https://github.com/shapeshift/web/assets/17035424/5ae30ef8-1de4-48db-a2f0-5a7a9787b1dc






