### PR TITLE
fix: repayment lock queries reactivity

### DIFF
--- a/src/pages/Lending/Pool/Pool.tsx
+++ b/src/pages/Lending/Pool/Pool.tsx
@@ -114,7 +114,7 @@ export const Pool = () => {
     () => ({ assetId: poolAssetId, accountId: poolAccountId }),
     [poolAccountId, poolAssetId],
   )
-  const { data: repaymentLock, isLoading: isRepaymentLockLoading } =
+  const { data: repaymentLock, isSuccess: isRepaymentLockSuccess } =
     useRepaymentLockData(useRepaymentLockDataArgs)
   const { data: defaultRepaymentLock, isSuccess: isDefaultRepaymentLockSuccess } =
     useRepaymentLockData({})
@@ -291,10 +291,10 @@ export const Pool = () => {
     () => (
       <RepaymentLockComponentWithValue
         value={repaymentLock ?? '0'}
-        isLoaded={!isRepaymentLockLoading}
+        isLoaded={isRepaymentLockSuccess}
       />
     ),
-    [isRepaymentLockLoading, repaymentLock],
+    [isRepaymentLockSuccess, repaymentLock],
   )
 
   const newRepaymentLock = useMemo(() => {
@@ -348,7 +348,7 @@ export const Pool = () => {
                   label='lending.collateralValue'
                   toolTipLabel={translate('lending.collateralValueDescription')}
                   component={collateralValueComponent}
-                  isLoading={isRepaymentLockLoading}
+                  isLoading={isLendingPositionDataLoading}
                   flex={1}
                   {...newCollateralFiat}
                 />

--- a/src/pages/Lending/Pool/Pool.tsx
+++ b/src/pages/Lending/Pool/Pool.tsx
@@ -114,11 +114,13 @@ export const Pool = () => {
     () => ({
       assetId: poolAssetId,
       accountId: collateralAccountId,
+      // When fetching position repayment lock, we want to ensure there's an AccountId and AssetId
+      // or we would fetch the default network's repayment lock instead
       enabled: Boolean(poolAssetId && collateralAccountId),
     }),
     [collateralAccountId, poolAssetId],
   )
-  const { data: repaymentLock, isSuccess: isRepaymentLockSuccess } =
+  const { data: positionRepaymentLock, isSuccess: isPositionRepaymentLockSuccess } =
     useRepaymentLockData(useRepaymentLockDataArgs)
   const { data: defaultRepaymentLock, isSuccess: isDefaultRepaymentLockSuccess } =
     useRepaymentLockData({})
@@ -294,11 +296,11 @@ export const Pool = () => {
   const repaymentLockComponent = useMemo(
     () => (
       <RepaymentLockComponentWithValue
-        value={repaymentLock ?? '0'}
-        isLoaded={isRepaymentLockSuccess}
+        value={positionRepaymentLock ?? '0'}
+        isLoaded={isPositionRepaymentLockSuccess}
       />
     ),
-    [isRepaymentLockSuccess, repaymentLock],
+    [isPositionRepaymentLockSuccess, positionRepaymentLock],
   )
 
   const newRepaymentLock = useMemo(() => {

--- a/src/pages/Lending/Pool/Pool.tsx
+++ b/src/pages/Lending/Pool/Pool.tsx
@@ -111,8 +111,12 @@ export const Pool = () => {
   const translate = useTranslate()
 
   const useRepaymentLockDataArgs = useMemo(
-    () => ({ assetId: poolAssetId, accountId: poolAccountId }),
-    [poolAccountId, poolAssetId],
+    () => ({
+      assetId: poolAssetId,
+      accountId: collateralAccountId,
+      enabled: Boolean(poolAssetId && collateralAccountId),
+    }),
+    [collateralAccountId, poolAssetId],
   )
   const { data: repaymentLock, isSuccess: isRepaymentLockSuccess } =
     useRepaymentLockData(useRepaymentLockDataArgs)

--- a/src/pages/Lending/YourLoans.tsx
+++ b/src/pages/Lending/YourLoans.tsx
@@ -41,7 +41,14 @@ const LendingRowGrid = ({ asset, accountId, onPoolClick }: LendingRowGridProps) 
     })
 
   const useRepaymentLockDataArgs = useMemo(
-    () => ({ assetId: asset.assetId, accountId }),
+    () => ({
+      assetId: asset.assetId,
+      accountId,
+      // When fetching position repayment lock, we want to ensure there's an AccountId and AssetId
+      // or we would fetch the default network's repayment lock instead
+      // these should be defined according to types but you never know
+      enabled: Boolean(asset.assetId && accountId),
+    }),
     [asset.assetId, accountId],
   )
   const { data: repaymentLockData, isSuccess: isRepaymentLockSuccess } =

--- a/src/pages/Lending/YourLoans.tsx
+++ b/src/pages/Lending/YourLoans.tsx
@@ -44,7 +44,7 @@ const LendingRowGrid = ({ asset, accountId, onPoolClick }: LendingRowGridProps) 
     () => ({ assetId: asset.assetId, accountId }),
     [asset.assetId, accountId],
   )
-  const { data: repaymentLockData, isLoading: isRepaymentLockDataLoading } =
+  const { data: repaymentLockData, isSuccess: isRepaymentLockSuccess } =
     useRepaymentLockData(useRepaymentLockDataArgs)
 
   const handlePoolClick = useCallback(() => {
@@ -110,7 +110,7 @@ const LendingRowGrid = ({ asset, accountId, onPoolClick }: LendingRowGridProps) 
             />
           </Stack>
         </Skeleton>
-        <Skeleton isLoaded={!isRepaymentLockDataLoading}>
+        <Skeleton isLoaded={isRepaymentLockSuccess}>
           <RawText color={isRepaymentLocked ? 'white' : 'green.500'}>
             {isRepaymentLocked ? `${repaymentLockData} days` : translate('lending.unlocked')}
           </RawText>

--- a/src/pages/Lending/hooks/useRepaymentLockData.tsx
+++ b/src/pages/Lending/hooks/useRepaymentLockData.tsx
@@ -1,4 +1,5 @@
 import type { AccountId, AssetId } from '@shapeshiftoss/caip'
+import type { QueryObserverOptions } from '@tanstack/react-query'
 import { useQuery } from '@tanstack/react-query'
 import axios from 'axios'
 import { getConfig } from 'config'
@@ -23,7 +24,13 @@ type ThorchainBlock = {
 const thorchainBlockTimeSeconds = '6.1'
 const thorchainBlockTimeMs = bn(thorchainBlockTimeSeconds).times(1000).toNumber()
 
-export const useRepaymentLockData = ({ accountId, assetId }: UseLendingPositionDataProps) => {
+export const useRepaymentLockData = ({
+  accountId,
+  assetId,
+  // Let the parent pass its own query options
+  // enabled will be used in conjunction with this hook's own isRepaymentLockQueryEnabled to determine whether or not to run the query
+  enabled = true,
+}: UseLendingPositionDataProps & QueryObserverOptions) => {
   const repaymentLockQueryKey = useMemo(
     () => ['thorchainLendingRepaymentLock', { accountId, assetId }],
     [accountId, assetId],
@@ -118,7 +125,7 @@ export const useRepaymentLockData = ({ accountId, assetId }: UseLendingPositionD
 
       return repaymentLock
     },
-    enabled: isRepaymentLockQueryEnabled,
+    enabled: Boolean(enabled && isRepaymentLockQueryEnabled),
   })
 
   return repaymentLockData

--- a/src/pages/Lending/hooks/useRepaymentLockData.tsx
+++ b/src/pages/Lending/hooks/useRepaymentLockData.tsx
@@ -90,7 +90,6 @@ export const useRepaymentLockData = ({
     return true
   }, [accountId, assetId, blockHeight, isPositionQuerySuccess, mimir])
 
-  console.log({ isEnabled: Boolean(enabled && isRepaymentLockQueryEnabled) })
   const repaymentLockData = useQuery({
     staleTime: Infinity,
     queryKey: repaymentLockQueryKey,

--- a/src/pages/Lending/hooks/useRepaymentLockData.tsx
+++ b/src/pages/Lending/hooks/useRepaymentLockData.tsx
@@ -32,8 +32,8 @@ export const useRepaymentLockData = ({
   enabled = true,
 }: UseLendingPositionDataProps & QueryObserverOptions) => {
   const repaymentLockQueryKey = useMemo(
-    () => ['thorchainLendingRepaymentLock', { accountId, assetId }],
-    [accountId, assetId],
+    () => ['thorchainLendingRepaymentLock', { accountId, assetId, enabled }],
+    [accountId, assetId, enabled],
   )
 
   const { data: blockHeight } = useQuery({
@@ -90,6 +90,7 @@ export const useRepaymentLockData = ({
     return true
   }, [accountId, assetId, blockHeight, isPositionQuerySuccess, mimir])
 
+  console.log({ isEnabled: Boolean(enabled && isRepaymentLockQueryEnabled) })
   const repaymentLockData = useQuery({
     staleTime: Infinity,
     queryKey: repaymentLockQueryKey,

--- a/src/pages/Lending/hooks/useRepaymentLockData.tsx
+++ b/src/pages/Lending/hooks/useRepaymentLockData.tsx
@@ -61,7 +61,7 @@ export const useRepaymentLockData = ({ accountId, assetId }: UseLendingPositionD
     [accountId, assetId],
   )
 
-  const { data: position } = useQuery({
+  const { data: position, isSuccess: isPositionQuerySuccess } = useQuery({
     // TODO(gomes): we may or may not want to change this, but this avoids spamming the API for the time being.
     // by default, there's a 5mn cache time, but a 0 stale time, meaning queries are considered stale immediately
     // Since react-query queries aren't persisted, and until we have an actual need for ensuring the data is fresh,
@@ -77,11 +77,11 @@ export const useRepaymentLockData = ({ accountId, assetId }: UseLendingPositionD
     // We always need the LOANREPAYMENTMATURITY value from the mimir query as repaymentMaturity
     if (!mimir) return false
     // We need position data to calculate the repayment lock for a specific account's position
-    if (!!accountId && !!assetId) return !!position && !!blockHeight
+    if (!!accountId && !!assetId) return isPositionQuerySuccess && !!blockHeight
 
     // We have a mimir, and we're not looking for a specific position's repayment lock, so we can proceed with the query
     return true
-  }, [accountId, assetId, blockHeight, mimir, position])
+  }, [accountId, assetId, blockHeight, isPositionQuerySuccess, mimir])
 
   const repaymentLockData = useQuery({
     staleTime: Infinity,


### PR DESCRIPTION
## Description

Fixes non-deterministic issues with repayment lock data.

As it currently stands, the repayment lock is dependant on a few things:

- `mimir` being fetched, to get `LOANREPAYMENTMATURITY`, used as `repaymentMaturity` i.e the number of blocks before repayments are unlocked, as set by the network, and independant on the current asset/position
- `position` and `blockHeight` being fetched, *only* in the case of fetching a *specific position*'s repayment lock

Same issue as the PR under this one, the reactivity was wrong here resulting in non-deterministic errors. Depending on how fast each request gets to respond, you may end up with the query running with or without the above.

While `mimir` and `blockHeight` tend to be fast to be fetched and I haven't noticed errors in getting the network's repayment lock, `position` definitely takes some more time, as it involves fetching all THOR lending positions for that asset, all addresses from the current `AccountId` from unchained, and parsing the position for the active address (if found).

This results in the repayment lock sometimes being correct for one account, sometimes for all, and othertimes for some only.

This PR fixes those non-deterministic issues by enforcing a `isRepaymentLockQueryEnabled` constant with the heuristics described above.

While at it, also adds a new concept to query hooks. `useRepaymentLockData` now takes the intersection of its own props and query options. This allows us to pass the `enabled` prop in an elegant way, so that parents also have control WRT the query enabled state, in addition to the hook itself having (in this case, but they may not) their own `enabled` logic. (https://github.com/shapeshift/web/pull/5721/commits/4496ef75fdfb34c509e6eca9b449b48a53c56971)

From a user perspective, this means this PR also fixes another sneaky bug of the repayment lock when accessing it from the "Available Pools" page: the correct repayment lock of the position matching the currently connected account is used vs. the network's repayment lock currently.

## Pull Request Type

- [x] :bug: Bug fix (Non-breaking Change: Fixes an issue)
- [ ] :hammer_and_wrench: Chore (Non-breaking Change: Doc updates, pkg upgrades, typos, etc..)
- [ ] :nail_care: New Feature (Breaking/Non-breaking Change)

## Issue (if applicable)

<!-----------------------------------------------------------------------------
If applicable, please link to the github issue and put `closes #XXXX` in your comment to auto-close the issue that your PR fixes.
------------------------------------------------------------------------------>

N/A

## Risk

<!-----------------------------------------------------------------------------
Outline the scope of your changes and the risk associated with them. You must use your discretion as an engineer to determine the potential impact of your changes.

E.g. an upgrade to `hdwallet` or core state management would be considered higher risk, and might require a full regression test. UI or isolated view changes, or something behind a feature flag may have near zero risk. Small bug fixes might require testing isolated to the specific fix.
------------------------------------------------------------------------------>

None

## Testing

<!-----------------------------------------------------------------------------
We treat every PR to be merged with the same scrutiny as if we were merging directly to production.

Your PR will not be merged if you do not complete the sections below for our engineering and operations teams to test.
------------------------------------------------------------------------------>

- Default repayment lock looks sane everywhere for accounts without an active position
  - Your loans
  - Pool accessed from "Available Pools"
- User repayment lock is fetched when within the context of an account with an active position
  - Pool accessed either from "Available Pools" (with default AccountId which has an active position, or with a default AccountId that doesn't have a position but switching to e.g Account 1 that has) or "Your loans"
  - Your loans repayment lock looks sane
- Refreshing the pool page accessed from "Available Pools", pool page accessed from loans, or "Your loans" page, doesn't produce any inconsistencies in the repayment lock displayed
- Loading states are sane and there is no flash of wrong lock on any of the places mentioned above

### Engineering

<!-----------------------------------------------------------------------------
Include sufficient information here for an engineer to test your PR. This may include how to test locally, in a built environment, changes to infrastructure etc.
------------------------------------------------------------------------------>

### Operations

<!-----------------------------------------------------------------------------
If your changes have a user-facing impact, describe how a non-technical QA team can functionally test your changes in a preview environment.

If they are not user-facing please describe how to test for any regressions that may occur.
------------------------------------------------------------------------------>

## Screenshots (if applicable)

### Correct "Your loans" repayment lock

- This diff ✅ 

<img width="596" alt="Screenshot 2023-11-29 at 13 07 54" src="https://github.com/shapeshift/web/assets/17035424/052c5065-7daa-4ec6-8b24-80f9e5394b8d">

- Develop 🚫 

<img width="588" alt="Screenshot 2023-11-29 at 13 08 09" src="https://github.com/shapeshift/web/assets/17035424/75571d56-5fcc-4b10-8802-4ce6318ae70b">

### Correct pool page repayment lock when accessed from "Your loans" page

- This diff ✅ 

<img width="584" alt="image" src="https://github.com/shapeshift/web/assets/17035424/16fde598-10b3-4054-a6d1-65dfed55f095">


- Develop 🚫 

<img width="599" alt="image" src="https://github.com/shapeshift/web/assets/17035424/ed7223ce-a294-4d96-90e2-d5ec6ffafbb2">

 ### Correct pool page repayment lock for the default AccountId accessed from "Available Pools" page

- This diff ✅ 

<img width="607" alt="image" src="https://github.com/shapeshift/web/assets/17035424/3679378a-2cf9-4eda-8341-fe6145c7674e">

- Develop 🚫 

<img width="588" alt="image" src="https://github.com/shapeshift/web/assets/17035424/665655da-8e78-4dbd-a59c-959460620326">

### Correct AccountId repayment lock on pool page

- This diff ✅ 

https://github.com/shapeshift/web/assets/17035424/71646226-c945-40d9-b22d-fdfb809d437c

- Develop 🚫 


https://github.com/shapeshift/web/assets/17035424/8c015827-97fd-4edf-b885-ed66f1d4c7a8

 
### Deterministic "Your loans" repayment locks


- This diff ✅ 


https://github.com/shapeshift/web/assets/17035424/d6b29d6b-9950-4f44-a33b-8ac48d1597ee



- Develop 🚫 

https://github.com/shapeshift/web/assets/17035424/61486554-f6a3-4664-898c-e6ea8c939a68


### Deterministic repayment lock for pool accessed from "Available Pools"

 - This diff ✅ 

https://github.com/shapeshift/web/assets/17035424/e0b29618-8846-4104-bbdc-2ed1eac874fe

- Develop 🚫 

https://github.com/shapeshift/web/assets/17035424/7978d3f9-2be3-48b7-bb77-5e88240970a4


### Deterministic repayment lock for pool accessed from "Your Loans" 

- This diff ✅ 


https://github.com/shapeshift/web/assets/17035424/d935c05c-e6cf-45cb-90a7-c9ade6d3fa10

- Develop 🚫 (oh noes, actually non-deterministically deterministically wrong for many tries)


https://github.com/shapeshift/web/assets/17035424/28c899bb-a0f6-488e-853f-7d474c7f290a

