### PR TITLE
feat: lending touchups

### DIFF
--- a/src/pages/Lending/Pool/Pool.tsx
+++ b/src/pages/Lending/Pool/Pool.tsx
@@ -121,18 +121,26 @@ export const Pool = () => {
 
   const headerComponent = useMemo(() => <PoolHeader />, [])
 
-  const lendingMutationStatus = useMutationState({
+  const borrowMutationStatus = useMutationState({
     filters: { mutationKey: [borrowTxid] },
     select: mutation => mutation.state.status,
   })
-  const isLoanPending = lendingMutationStatus?.[0] === 'pending'
-  const isLoanUpdated = lendingMutationStatus?.[0] === 'success'
+  const isBorrowPending = borrowMutationStatus?.[0] === 'pending'
+  const isBorrowUpdated = borrowMutationStatus?.[0] === 'success'
+
+  const repayMutationStatus = useMutationState({
+    filters: { mutationKey: [repayTxid] },
+    select: mutation => mutation.state.status,
+  })
+
+  const isRepayPending = repayMutationStatus?.[0] === 'pending'
+  const isRepayUpdated = repayMutationStatus?.[0] === 'success'
 
   const { data: lendingPositionData, isLoading: isLendingPositionDataLoading } =
     useLendingPositionData({
       assetId: poolAssetId,
       accountId: collateralAccountId,
-      skip: isLoanPending,
+      skip: isBorrowPending || isRepayPending,
     })
 
   const useLendingQuoteQueryArgs = useMemo(
@@ -187,7 +195,7 @@ export const Pool = () => {
     [asset?.symbol, lendingPositionData?.collateralBalanceCryptoPrecision],
   )
   const newCollateralCrypto = useMemo(() => {
-    if (isLoanUpdated) return {}
+    if (isBorrowUpdated || isRepayUpdated) return {}
 
     if (stepIndex === 0 && isLendingQuoteSuccess && lendingQuoteOpenData)
       return {
@@ -207,13 +215,14 @@ export const Pool = () => {
       }
     return {}
   }, [
-    isLendingQuoteCloseSuccess,
-    isLendingQuoteSuccess,
-    isLoanUpdated,
-    lendingPositionData?.collateralBalanceCryptoPrecision,
-    lendingQuoteCloseData,
-    lendingQuoteOpenData,
+    isBorrowUpdated,
+    isRepayUpdated,
     stepIndex,
+    isLendingQuoteSuccess,
+    lendingQuoteOpenData,
+    lendingPositionData?.collateralBalanceCryptoPrecision,
+    isLendingQuoteCloseSuccess,
+    lendingQuoteCloseData,
   ])
 
   const collateralValueComponent = useMemo(
@@ -228,7 +237,7 @@ export const Pool = () => {
   )
 
   const newCollateralFiat = useMemo(() => {
-    if (isLoanUpdated) return {}
+    if (isBorrowUpdated || isRepayUpdated) return {}
 
     if (stepIndex === 0 && lendingQuoteOpenData && lendingPositionData)
       return {
@@ -248,7 +257,14 @@ export const Pool = () => {
       }
 
     return {}
-  }, [isLoanUpdated, lendingPositionData, lendingQuoteCloseData, lendingQuoteOpenData, stepIndex])
+  }, [
+    isBorrowUpdated,
+    isRepayUpdated,
+    lendingPositionData,
+    lendingQuoteCloseData,
+    lendingQuoteOpenData,
+    stepIndex,
+  ])
 
   const debtBalanceComponent = useMemo(
     () => (
@@ -262,7 +278,7 @@ export const Pool = () => {
   )
 
   const newDebt = useMemo(() => {
-    if (isLoanUpdated) return {}
+    if (isBorrowUpdated || isRepayUpdated) return {}
 
     if (stepIndex === 0 && lendingQuoteOpenData && lendingPositionData)
       return {
@@ -285,7 +301,14 @@ export const Pool = () => {
       }
 
     return {}
-  }, [isLoanUpdated, lendingPositionData, lendingQuoteCloseData, lendingQuoteOpenData, stepIndex])
+  }, [
+    isBorrowUpdated,
+    isRepayUpdated,
+    lendingPositionData,
+    lendingQuoteCloseData,
+    lendingQuoteOpenData,
+    stepIndex,
+  ])
 
   const repaymentLockComponent = useMemo(
     () => (
@@ -298,7 +321,7 @@ export const Pool = () => {
   )
 
   const newRepaymentLock = useMemo(() => {
-    if (isLoanUpdated) return {}
+    if (isBorrowUpdated || isRepayUpdated) return {}
 
     if (
       stepIndex === 0 &&
@@ -314,7 +337,8 @@ export const Pool = () => {
       }
     return {}
   }, [
-    isLoanUpdated,
+    isBorrowUpdated,
+    isRepayUpdated,
     stepIndex,
     isLendingQuoteSuccess,
     lendingQuoteOpenData,

--- a/src/pages/Lending/Pool/components/Borrow/BorrowConfirm.tsx
+++ b/src/pages/Lending/Pool/components/Borrow/BorrowConfirm.tsx
@@ -14,7 +14,7 @@ import { FeeDataKey } from '@shapeshiftoss/chain-adapters'
 import { TxStatus } from '@shapeshiftoss/unchained-client'
 import { useMutation, useMutationState } from '@tanstack/react-query'
 import { utils } from 'ethers'
-import { useCallback, useEffect, useMemo } from 'react'
+import { useCallback, useEffect, useMemo, useState } from 'react'
 import { useTranslate } from 'react-polyglot'
 import { useHistory } from 'react-router'
 import { Amount } from 'components/Amount/Amount'
@@ -85,6 +85,7 @@ export const BorrowConfirm = ({
       waitForThorchainUpdate({ txId: _txId, skipOutbound: false }).promise,
   })
 
+  const [isLoanPending, setIsLoanPending] = useState(false)
   const lendingMutationStatus = useMutationState({
     filters: { mutationKey: [txId] },
     select: mutation => mutation.state.status,
@@ -97,6 +98,7 @@ export const BorrowConfirm = ({
     if (!txId) return
     ;(async () => {
       await mutateAsync(txId)
+      setIsLoanPending(false)
     })()
   }, [mutateAsync, txId])
 
@@ -165,6 +167,8 @@ export const BorrowConfirm = ({
       )
     )
       return
+
+    setIsLoanPending(true)
 
     const from = await getThorchainFromAddress({
       accountId: collateralAccountId,
@@ -330,6 +334,7 @@ export const BorrowConfirm = ({
               }
               disabled={
                 loanTxStatus === 'pending' ||
+                isLoanPending ||
                 isEstimatedFeesDataLoading ||
                 isEstimatedFeesDataError ||
                 isLendingQuoteLoading ||

--- a/src/pages/Lending/Pool/components/Repay/RepayConfirm.tsx
+++ b/src/pages/Lending/Pool/components/Repay/RepayConfirm.tsx
@@ -14,7 +14,7 @@ import { FeeDataKey } from '@shapeshiftoss/chain-adapters'
 import { TxStatus } from '@shapeshiftoss/unchained-client'
 import { useMutation, useMutationState } from '@tanstack/react-query'
 import { utils } from 'ethers'
-import { useCallback, useEffect, useMemo } from 'react'
+import { useCallback, useEffect, useMemo, useState } from 'react'
 import { useTranslate } from 'react-polyglot'
 import { useHistory } from 'react-router'
 import { Amount } from 'components/Amount/Amount'
@@ -69,6 +69,8 @@ export const RepayConfirm = ({
     state: { wallet },
   } = useWallet()
 
+  const [isLoanPending, setIsLoanPending] = useState(false)
+
   const { refetch: refetchLendingPositionData } = useLendingPositionData({
     assetId: collateralAssetId,
     accountId: collateralAccountId,
@@ -96,6 +98,7 @@ export const RepayConfirm = ({
     if (!txId) return
     ;(async () => {
       await mutateAsync(txId)
+      setIsLoanPending(false)
     })()
   }, [mutateAsync, refetchLendingPositionData, txId])
 
@@ -181,6 +184,8 @@ export const RepayConfirm = ({
       )
     )
       return
+
+    setIsLoanPending(true)
 
     const supportedEvmChainIds = getSupportedEvmChainIds()
     const estimatedFees = await estimateFees({
@@ -369,7 +374,8 @@ export const RepayConfirm = ({
               isLoading={
                 isLendingQuoteCloseLoading ||
                 isEstimatedFeesDataLoading ||
-                loanTxStatus === 'pending'
+                loanTxStatus === 'pending' ||
+                isLoanPending
               }
               disabled={loanTxStatus === 'pending'}
               onClick={handleConfirm}

--- a/src/pages/Lending/Pool/components/Repay/RepayConfirm.tsx
+++ b/src/pages/Lending/Pool/components/Repay/RepayConfirm.tsx
@@ -318,7 +318,7 @@ export const RepayConfirm = ({
                       value={
                         lendingQuoteCloseData?.quoteLoanCollateralDecreaseCryptoPrecision ?? '0'
                       }
-                      symbol={repaymentAsset?.symbol ?? ''}
+                      symbol={collateralAsset?.symbol ?? ''}
                     />
                     <Amount.Fiat
                       color='text.subtle'

--- a/src/pages/Lending/Pool/components/Repay/RepayInput.tsx
+++ b/src/pages/Lending/Pool/components/Repay/RepayInput.tsx
@@ -374,7 +374,8 @@ export const RepayInput = ({
         label={translate('lending.unlockedCollateral')}
         onAccountIdChange={handleCollateralAccountIdChange}
         isReadOnly
-        hideAmounts
+        // When repaying 100% of the loan, the user gets their collateral back
+        hideAmounts={bn(repaymentPercent).lt(100)}
         formControlProps={formControlProps}
         layout='inline'
         labelPostFix={collateralAssetSelectComponent}

--- a/src/pages/Lending/hooks/useLendingCloseQuery.ts
+++ b/src/pages/Lending/hooks/useLendingCloseQuery.ts
@@ -31,12 +31,10 @@ const selectLendingCloseQueryData = memoize(
   ({
     data,
     collateralAssetMarketData,
-    repaymentAssetMarketData,
     repaymentAmountCryptoPrecision,
   }: {
     data: LendingWithdrawQuoteResponseSuccess
     collateralAssetMarketData: MarketData
-    repaymentAssetMarketData: MarketData
     repaymentAmountCryptoPrecision: string | null
   }) => {
     const quote = data
@@ -47,7 +45,7 @@ const selectLendingCloseQueryData = memoize(
     const quoteLoanCollateralDecreaseFiatUserCurrency = fromThorBaseUnit(
       quote.expected_collateral_withdrawn,
     )
-      .times(repaymentAssetMarketData.price)
+      .times(collateralAssetMarketData.price)
       .toString()
     const quoteDebtRepaidAmountUsd = fromThorBaseUnit(quote.expected_debt_repaid).toString()
     const quoteWithdrawnAmountAfterFeesCryptoPrecision = fromThorBaseUnit(
@@ -203,7 +201,6 @@ export const useLendingQuoteCloseQuery = ({
       selectLendingCloseQueryData({
         data,
         collateralAssetMarketData,
-        repaymentAssetMarketData,
         repaymentAmountCryptoPrecision,
       }),
     enabled: Boolean(
@@ -214,7 +211,6 @@ export const useLendingQuoteCloseQuery = ({
         collateralAssetId &&
         collateralAccountMetadata &&
         repaymentAsset &&
-        repaymentAssetMarketData.price !== '0' &&
         bnOrZero(repaymentPercent).gt(0) &&
         repaymentAmountCryptoPrecision,
     ),


### PR DESCRIPTION
## Description

Actioned following review with @reallybeard:

- fixes wrong asset used as "Receive" asset for repayments
- fixes wrong asset used to calculate collateral decrease
- makes the borrows/repay spin as soon as the confirm button is clicked, *not* on Tx broadcasted, which produces a delay between the click and the spin when using native, and nothing until you confirm the Tx if using MM
- doesn't hide the collateral amount in `<AssetInput />` when withdrawing 100%

## Pull Request Type

- [ ] :bug: Bug fix (Non-breaking Change: Fixes an issue)
- [ ] :hammer_and_wrench: Chore (Non-breaking Change: Doc updates, pkg upgrades, typos, etc..)
- [x] :nail_care: New Feature (Breaking/Non-breaking Change)

## Issue (if applicable)

<!-----------------------------------------------------------------------------
If applicable, please link to the github issue and put `closes #XXXX` in your comment to auto-close the issue that your PR fixes.
------------------------------------------------------------------------------>

N/A

## Risk

<!-----------------------------------------------------------------------------
Outline the scope of your changes and the risk associated with them. You must use your discretion as an engineer to determine the potential impact of your changes.

E.g. an upgrade to `hdwallet` or core state management would be considered higher risk, and might require a full regression test. UI or isolated view changes, or something behind a feature flag may have near zero risk. Small bug fixes might require testing isolated to the specific fix.
------------------------------------------------------------------------------>

None

## Testing

<!-----------------------------------------------------------------------------
We treat every PR to be merged with the same scrutiny as if we were merging directly to production.

Your PR will not be merged if you do not complete the sections below for our engineering and operations teams to test.
------------------------------------------------------------------------------>

### Repayments

- Frame-inject a position that has repayment unlocked (ask beard for the address)

- Ensure the "Receive" asset in repayment confirm is your collateral
- Ensure the collateral deduction (see screenshots) looks good when repaying 100%
- Ensure the confirm button starts spinning on click (you obviously won't be able to sign the Tx, which is fine)
- Ensures the collateral withdrawn is shown in the "Unlocked Collateral" section at input time

### Borrows

- Do a new borrow open or add some collateral to your existing position
- Ensure the confirm button starts spinning on click

### Engineering

<!-----------------------------------------------------------------------------
Include sufficient information here for an engineer to test your PR. This may include how to test locally, in a built environment, changes to infrastructure etc.
------------------------------------------------------------------------------>

- ☝🏽 

### Operations

<!-----------------------------------------------------------------------------
If your changes have a user-facing impact, describe how a non-technical QA team can functionally test your changes in a preview environment.

If they are not user-facing please describe how to test for any regressions that may occur.
------------------------------------------------------------------------------>

- ☝🏽 

## Screenshots (if applicable)

### Collateral withdrawn amount 

- Develop

<img width="454" alt="Screenshot 2023-11-30 at 00 01 53" src="https://github.com/shapeshift/web/assets/17035424/431db8bb-3d6c-42ab-a56e-2c3e54c728ef">


- This diff

<img width="454" alt="Screenshot 2023-11-30 at 00 01 53" src="https://github.com/shapeshift/web/assets/17035424/6ecd0b6d-3af6-4ade-8c36-0bdff4324b21">


### Collateral decrease

- Develop

<img width="454" alt="Screenshot 2023-11-30 at 00 01 53" src="https://github.com/shapeshift/web/assets/17035424/848b89bd-1813-4c79-bef4-e7412cb646e7">

- This diff

<img width="454" alt="Screenshot 2023-11-30 at 00 01 53" src="https://github.com/shapeshift/web/assets/17035424/bd3e461c-349b-499a-a626-f51adf47eead">

### Confirm step receive asset

- Develop

<img width="1029" alt="Screenshot 2023-11-30 at 00 07 45" src="https://github.com/shapeshift/web/assets/17035424/ae54f6de-30ae-4999-9c38-2656735cf5b1">

- This diff

<img width="1047" alt="Screenshot 2023-11-30 at 00 07 51" src="https://github.com/shapeshift/web/assets/17035424/07ac8eab-89e8-4d44-9ba1-dada35ee135c">

 