### PR TITLE
feat: thorchain use max_streaming_quantity quantity in memos

### DIFF
--- a/src/lib/swapper/swappers/ThorchainSwapper/getThorTradeQuote/getTradeQuote.ts
+++ b/src/lib/swapper/swappers/ThorchainSwapper/getThorTradeQuote/getTradeQuote.ts
@@ -11,6 +11,7 @@ import { assertUnreachable } from 'lib/utils'
 import type { AssetsById } from 'state/slices/assetsSlice/assetsSlice'
 
 import type { ThornodePoolResponse } from '../types'
+import { DEFAULT_STREAMING_NUM_SWAPS } from '../utils/constants'
 import { getL1quote } from '../utils/getL1quote'
 import { getLongtailToL1Quote } from '../utils/getLongtailQuote'
 import { getTradeType, TradeType } from '../utils/longTailHelpers'
@@ -95,12 +96,20 @@ export const getThorTradeQuote = async (
         })()
       : // TODO: One of the pools is RUNE - use the as-is 10 until we work out how best to handle this
         10
+  // Let the network decide the internal number of swaps
+  // Note, this gets overriden in addSlippageToMemo and uses the max_max_streaming_quantity instead
+  const defaultStreamingQuantity = DEFAULT_STREAMING_NUM_SWAPS
 
   switch (tradeType) {
     case TradeType.L1ToL1:
-      return getL1quote(input, streamingInterval)
+      return getL1quote({ input, streamingInterval, streamingQuantity: defaultStreamingQuantity })
     case TradeType.LongTailToL1:
-      return getLongtailToL1Quote(input, streamingInterval, assetsById)
+      return getLongtailToL1Quote({
+        input,
+        streamingInterval,
+        assetsById,
+        streamingQuantity: defaultStreamingQuantity,
+      })
     case TradeType.LongTailToLongTail:
     case TradeType.L1ToLongTail:
       return Err(makeSwapErrorRight({ message: 'Not implemented yet' }))

--- a/src/lib/swapper/swappers/ThorchainSwapper/utils/addSlippageToMemo.ts
+++ b/src/lib/swapper/swappers/ThorchainSwapper/utils/addSlippageToMemo.ts
@@ -61,4 +61,3 @@ export const addSlippageToMemo = ({
   assertIsValidMemo(memo, chainId, affiliateBps)
   return memo
 }
-

--- a/src/lib/swapper/swappers/ThorchainSwapper/utils/getL1quote.ts
+++ b/src/lib/swapper/swappers/ThorchainSwapper/utils/getL1quote.ts
@@ -36,10 +36,15 @@ import { getQuote } from './getQuote/getQuote'
 import { getEvmTxFees } from './txFeeHelpers/evmTxFees/getEvmTxFees'
 import { getUtxoTxFees } from './txFeeHelpers/utxoTxFees/getUtxoTxFees'
 
-export const getL1quote = async (
-  input: GetTradeQuoteInput,
-  streamingInterval: number,
-): Promise<Result<ThorTradeQuote[], SwapErrorRight>> => {
+export const getL1quote = async ({
+  input,
+  streamingInterval,
+  streamingQuantity,
+}: {
+  input: GetTradeQuoteInput
+  streamingInterval: number
+  streamingQuantity: number
+}): Promise<Result<ThorTradeQuote[], SwapErrorRight>> => {
   const {
     sellAsset,
     buyAsset,
@@ -200,6 +205,8 @@ export const getL1quote = async (
               affiliateBps,
               isStreaming,
               streamingInterval,
+              defaultStreamingQuantity: streamingQuantity,
+              streamingQuantity: quote.max_streaming_quantity ?? 0,
             })
             const { data, router } = await getEvmThorTxInfo({
               sellAsset,
@@ -285,6 +292,8 @@ export const getL1quote = async (
               chainId: sellAsset.chainId,
               affiliateBps,
               streamingInterval,
+              defaultStreamingQuantity: streamingQuantity,
+              streamingQuantity: quote.max_streaming_quantity ?? 0,
             })
             const { vault, opReturnData, pubkey } = await getUtxoThorTxInfo({
               sellAsset,
@@ -383,6 +392,8 @@ export const getL1quote = async (
               chainId: sellAsset.chainId,
               affiliateBps,
               streamingInterval,
+              defaultStreamingQuantity: streamingQuantity,
+              streamingQuantity: quote.max_streaming_quantity ?? 0,
             })
 
             return {

--- a/src/lib/swapper/swappers/ThorchainSwapper/utils/getLongtailQuote.ts
+++ b/src/lib/swapper/swappers/ThorchainSwapper/utils/getLongtailQuote.ts
@@ -17,11 +17,17 @@ import type { ThorTradeQuote } from '../getThorTradeQuote/getTradeQuote'
 import { getL1quote } from './getL1quote'
 import { getTokenFromAsset, getWrappedToken } from './longTailHelpers'
 
-export const getLongtailToL1Quote = async (
-  input: GetTradeQuoteInput,
-  streamingInterval: number,
-  assetsById: AssetsById,
-): Promise<Result<ThorTradeQuote[], SwapErrorRight>> => {
+export const getLongtailToL1Quote = async ({
+  input,
+  streamingInterval,
+  streamingQuantity,
+  assetsById,
+}: {
+  input: GetTradeQuoteInput
+  streamingInterval: number
+  streamingQuantity: number
+  assetsById: AssetsById
+}): Promise<Result<ThorTradeQuote[], SwapErrorRight>> => {
   const chainAdapterManager = getChainAdapterManager()
   const sellChainId = input.sellAsset.chainId
   const nativeBuyAssetId = chainAdapterManager.get(sellChainId)?.getFeeAssetId()
@@ -87,6 +93,10 @@ export const getLongtailToL1Quote = async (
     sellAmountIncludingProtocolFeesCryptoBaseUnit: quotedAmountOut.toString(),
   }
 
-  const thorchainQuote = await getL1quote(l1Tol1QuoteInput, streamingInterval)
+  const thorchainQuote = await getL1quote({
+    input: l1Tol1QuoteInput,
+    streamingInterval,
+    streamingQuantity,
+  })
   return thorchainQuote
 }


### PR DESCRIPTION
## Description

See https://github.com/shapeshift/web/issues/5733#issuecomment-1832907626 for reference - this tackles part of our problem by ensuring our streaming quantity conforms to the one returned by the quote as `max_streaming_quantity`.
This does *not* yet tackle the issue of 0 limit memos returned by THOR we then ignore and set our own limit instead.

## Pull Request Type

- [ ] :bug: Bug fix (Non-breaking Change: Fixes an issue)
- [ ] :hammer_and_wrench: Chore (Non-breaking Change: Doc updates, pkg upgrades, typos, etc..)
- [x] :nail_care: New Feature (Breaking/Non-breaking Change)

## Issue (if applicable)

<!-----------------------------------------------------------------------------
If applicable, please link to the github issue and put `closes #XXXX` in your comment to auto-close the issue that your PR fixes.
------------------------------------------------------------------------------>

- tackles https://github.com/shapeshift/web/issues/5733

## Risk

<!-----------------------------------------------------------------------------
Outline the scope of your changes and the risk associated with them. You must use your discretion as an engineer to determine the potential impact of your changes.

E.g. an upgrade to `hdwallet` or core state management would be considered higher risk, and might require a full regression test. UI or isolated view changes, or something behind a feature flag may have near zero risk. Small bug fixes might require testing isolated to the specific fix.
------------------------------------------------------------------------------>

- At worst, this should come as no change to our current logic, as `0` indicates `let the network decide the best streaming quantity`. Meaning that would be explicit instead of implicit here, but the actual limit used by THOR would be the same
- At best, using an explicit quantity would make some current failing trades go through, if the 0 limit doesn't automagically work as it should

## Testing

<!-----------------------------------------------------------------------------
We treat every PR to be merged with the same scrutiny as if we were merging directly to production.

Your PR will not be merged if you do not complete the sections below for our engineering and operations teams to test.
------------------------------------------------------------------------------>

- do a streaming swap and ensure it is still going through

### Engineering

<!-----------------------------------------------------------------------------
Include sufficient information here for an engineer to test your PR. This may include how to test locally, in a built environment, changes to infrastructure etc.
------------------------------------------------------------------------------>

- Ensure the interval we use for streaming swaps is the one we're getting from the quote as `max_streaming_interval`

### Operations

<!-----------------------------------------------------------------------------
If your changes have a user-facing impact, describe how a non-technical QA team can functionally test your changes in a preview environment.

If they are not user-facing please describe how to test for any regressions that may occur.
------------------------------------------------------------------------------>

## Screenshots (if applicable)

Tested with two pairs/amounts as the quantity may differ depending on the pairs/amounts

### 10,000 USDT -> DAI

- Develop - `0` quantity

<img width="123" alt="Screenshot 2023-11-30 at 11 38 01" src="https://github.com/shapeshift/web/assets/17035424/2dd27055-8ccf-45df-ac46-3f141b4e117d">

- This diff - `53` streaming quantity

<img width="101" alt="image" src="https://github.com/shapeshift/web/assets/17035424/57feab19-acd3-49da-a890-de8a3f1afc87">

### 0.08 BTC -> DOGE

- Develop - `0` quantity

<img width="97" alt="image" src="https://github.com/shapeshift/web/assets/17035424/5cfa02a7-17a9-4260-a34c-a5d797d13655">

- This diff - `2` quantity

<img width="94" alt="image" src="https://github.com/shapeshift/web/assets/17035424/2570adca-03b6-48a3-8564-5bd31ee48b8a">
