### PR TITLE
fix: thorchain savers shenanigans

### DIFF
--- a/src/state/slices/opportunitiesSlice/resolvers/thorchainsavers/types.ts
+++ b/src/state/slices/opportunitiesSlice/resolvers/thorchainsavers/types.ts
@@ -59,9 +59,7 @@ export type ThorchainSaverPositionResponse = {
 export type ThorchainSaversCommonQuoteResponseSuccess = {
   expiry: string // TODO(gomes): guard against expired quote
   dust_threshold: string
-  /** @deprecated use expected_amount_deposit instead */
   expected_amount_out: string
-  expected_amount_deposit: string
   fees: QuoteFees
   inbound_address: string
   memo: string
@@ -78,6 +76,9 @@ export type ThorchainSaversCommonQuoteResponseError = {
 export type ThorchainSaversDepositQuoteResponseSuccess =
   ThorchainSaversCommonQuoteResponseSuccess & {
     inbound_confirmation_blocks: number
+    expected_amount_deposit: string
+    /** @deprecated use expected_amount_deposit instead */
+    expected_amount_out: string
   }
 
 export type ThorchainSaversWithdrawQuoteResponseSuccess =


### PR DESCRIPTION
## Description

This PR fixes:

- broken protocol fees for withdraws, as `expected_amount_deposit` is incorrect for withdraws. There is some inconsistency in the THORNode API currently, where `expected_amount_out` is to-be-deprecated in favor of `expected_amount_deposit`, so we use the latter - however this is inconsistent with withdraws still using `expected_amount_out` with no sign of future deprecation. This means the protocol fees were always 0 for withdraws
- "insufficient funds" sometimes happening for EVM assets, as we try to estimate sweep + fees for them

While at it, also improves the protocol fee calculation for withdraws: if the `expected_amount_out` is `""`, then there is nothing being withdrawn, and the whole amount being withdrawn *is* effectively the fee. This surfaces it at view-layer.

## Pull Request Type

- [ ] :bug: Bug fix (Non-breaking Change: Fixes an issue)
- [ ] :hammer_and_wrench: Chore (Non-breaking Change: Doc updates, pkg upgrades, typos, etc..)
- [x] :nail_care: New Feature (Breaking/Non-breaking Change)

## Issue (if applicable)

<!-----------------------------------------------------------------------------
If applicable, please link to the github issue and put `closes #XXXX` in your comment to auto-close the issue that your PR fixes.
------------------------------------------------------------------------------>

- closes https://github.com/shapeshift/web/issues/5715
- closes https://github.com/shapeshift/web/issues/5743#

## Risk

<!-----------------------------------------------------------------------------
Outline the scope of your changes and the risk associated with them. You must use your discretion as an engineer to determine the potential impact of your changes.

E.g. an upgrade to `hdwallet` or core state management would be considered higher risk, and might require a full regression test. UI or isolated view changes, or something behind a feature flag may have near zero risk. Small bug fixes might require testing isolated to the specific fix.
------------------------------------------------------------------------------>

- EVM deposits/withdraws may still be borked, test accordingly

## Testing

<!-----------------------------------------------------------------------------
We treat every PR to be merged with the same scrutiny as if we were merging directly to production.

Your PR will not be merged if you do not complete the sections below for our engineering and operations teams to test.
------------------------------------------------------------------------------>

- EVM (native/tokens) deposit/withdraws are happy
- The protocol fee is displayed for withdraws
  - When withdrawing very small amounts effectively gifting the amount because of protocol fees, the amount being withdrawn is shown as "Protocol Fee", and the sign and broadcast button is disabled
  
### Engineering

<!-----------------------------------------------------------------------------
Include sufficient information here for an engineer to test your PR. This may include how to test locally, in a built environment, changes to infrastructure etc.
------------------------------------------------------------------------------>

- ☝🏽 

### Operations

<!-----------------------------------------------------------------------------
If your changes have a user-facing impact, describe how a non-technical QA team can functionally test your changes in a preview environment.

If they are not user-facing please describe how to test for any regressions that may occur.
------------------------------------------------------------------------------>

- ☝🏽 

## Screenshots (if applicable)

### Develop


<img width="524" alt="Screenshot 2023-11-30 at 16 45 58" src="https://github.com/shapeshift/web/assets/17035424/b2eb4329-a391-4b47-a581-2f7d0363b109">

### This diff

<img width="559" alt="Screenshot 2023-11-30 at 16 46 08" src="https://github.com/shapeshift/web/assets/17035424/b26bbd12-dfb2-4a6b-a11e-15e21e8661c1">
<img width="544" alt="Screenshot 2023-11-30 at 17 08 48" src="https://github.com/shapeshift/web/assets/17035424/d4d8513d-1689-489a-927d-a02e1a8d6372">
