### PR TITLE
chore: refactor multi-hop state tracking to avoid duplicate states and associated logic

### DIFF
--- a/src/components/MultiHopTrade/components/MultiHopTradeConfirm/MultiHopTradeConfirm.tsx
+++ b/src/components/MultiHopTrade/components/MultiHopTradeConfirm/MultiHopTradeConfirm.tsx
@@ -8,7 +8,7 @@ import { Text } from 'components/Text'
 import { swappers as swappersSlice } from 'state/slices/swappersSlice/swappersSlice'
 import { selectTradeExecutionState } from 'state/slices/tradeQuoteSlice/selectors'
 import { tradeQuoteSlice } from 'state/slices/tradeQuoteSlice/tradeQuoteSlice'
-import { MultiHopExecutionState } from 'state/slices/tradeQuoteSlice/types'
+import { TradeExecutionState } from 'state/slices/tradeQuoteSlice/types'
 import { useAppDispatch, useAppSelector } from 'state/store'
 
 import { TradeSuccess } from '../TradeSuccess/TradeSuccess'
@@ -50,7 +50,7 @@ export const MultiHopTradeConfirm = memo(() => {
   useEffect(() => {
     if (
       previousTradeExecutionState !== tradeExecutionState &&
-      previousTradeExecutionState === MultiHopExecutionState.FirstHopAwaitingTradeExecution
+      previousTradeExecutionState === TradeExecutionState.FirstHop
     ) {
       if (isFirstHopOpen) onToggleFirstHop()
       if (!isSecondHopOpen) onToggleSecondHop()
@@ -65,7 +65,7 @@ export const MultiHopTradeConfirm = memo(() => {
   ])
 
   const isTradeComplete = useMemo(
-    () => tradeExecutionState === MultiHopExecutionState.TradeComplete,
+    () => tradeExecutionState === TradeExecutionState.TradeComplete,
     [tradeExecutionState],
   )
 
@@ -77,7 +77,7 @@ export const MultiHopTradeConfirm = memo(() => {
             <Heading textAlign='center' fontSize='md'>
               <Text
                 translation={
-                  tradeExecutionState === MultiHopExecutionState.Previewing
+                  tradeExecutionState === TradeExecutionState.Previewing
                     ? 'trade.confirmDetails'
                     : 'trade.trade'
                 }

--- a/src/components/MultiHopTrade/components/MultiHopTradeConfirm/components/ApprovalStep.tsx
+++ b/src/components/MultiHopTrade/components/MultiHopTradeConfirm/components/ApprovalStep.tsx
@@ -1,7 +1,7 @@
 import { CheckCircleIcon } from '@chakra-ui/icons'
-import { Box, Button, Card, Center, Icon, Link, Switch, Tooltip, VStack } from '@chakra-ui/react'
+import { Box, Button, Card, Icon, Link, Switch, Tooltip, VStack } from '@chakra-ui/react'
 import { TxStatus } from '@shapeshiftoss/unchained-client'
-import { useCallback, useMemo, useState } from 'react'
+import { useCallback, useMemo } from 'react'
 import { FaInfoCircle, FaThumbsUp } from 'react-icons/fa'
 import { useTranslate } from 'react-polyglot'
 import { MiddleEllipsis } from 'components/MiddleEllipsis/MiddleEllipsis'
@@ -15,7 +15,7 @@ import type { TradeQuoteStep } from 'lib/swapper/types'
 import { selectFeeAssetById } from 'state/slices/selectors'
 import { selectHopExecutionMetadata } from 'state/slices/tradeQuoteSlice/selectors'
 import { tradeQuoteSlice } from 'state/slices/tradeQuoteSlice/tradeQuoteSlice'
-import { HOP_EXECUTION_STATE_ORDERED, HopExecutionState } from 'state/slices/tradeQuoteSlice/types'
+import { TransactionExecutionState } from 'state/slices/tradeQuoteSlice/types'
 import { store, useAppDispatch, useAppSelector } from 'state/store'
 
 import { useMockAllowanceApproval } from '../hooks/mockHooks'
@@ -28,7 +28,6 @@ export type ApprovalStepProps = {
   isActive: boolean
   isLastStep?: boolean
   isLoading?: boolean
-  onError: () => void
 }
 
 export const ApprovalStep = ({
@@ -37,20 +36,21 @@ export const ApprovalStep = ({
   isActive,
   isLastStep,
   isLoading,
-  onError: handleError,
 }: ApprovalStepProps) => {
   const {
     number: { toCrypto },
   } = useLocaleFormatter()
   const dispatch = useAppDispatch()
   const [isExactAllowance, toggleIsExactAllowance] = useToggle(false)
-  const [isError, setIsError] = useState<boolean>(false)
 
   const {
-    state: hopExecutionState,
-    approvalTxHash: txHash,
-    approvalState,
+    approval: { txHash, state: approvalTxState },
   } = useAppSelector(selectHopExecutionMetadata)[hopIndex]
+
+  const isError = useMemo(
+    () => approvalTxState === TransactionExecutionState.Failed,
+    [approvalTxState],
+  )
 
   const { executeAllowanceApproval, approvalNetworkFeeCryptoBaseUnit } = useMockAllowanceApproval(
     tradeQuoteStep,
@@ -59,20 +59,22 @@ export const ApprovalStep = ({
   ) // TODO: use the real hook here
 
   const handleSignAllowanceApproval = useCallback(async () => {
-    // next state
-    dispatch(tradeQuoteSlice.actions.incrementTradeExecutionState())
+    if (approvalTxState !== TransactionExecutionState.AwaitingConfirmation) {
+      console.error('attempted to execute in-progress allowance approval')
+      return
+    }
+
+    dispatch(tradeQuoteSlice.actions.setApprovalTxPending({ hopIndex }))
 
     // execute the allowance approval
     const finalTxStatus = await executeAllowanceApproval()
 
-    // next state if trade was successful
     if (finalTxStatus === TxStatus.Confirmed) {
-      dispatch(tradeQuoteSlice.actions.incrementTradeExecutionState())
+      dispatch(tradeQuoteSlice.actions.setApprovalTxComplete({ hopIndex }))
     } else if (finalTxStatus === TxStatus.Failed) {
-      setIsError(true)
-      handleError()
+      dispatch(tradeQuoteSlice.actions.setApprovalTxFailed({ hopIndex }))
     }
-  }, [dispatch, executeAllowanceApproval, handleError])
+  }, [approvalTxState, dispatch, executeAllowanceApproval, hopIndex])
 
   const feeAsset = selectFeeAssetById(store.getState(), tradeQuoteStep.sellAsset.assetId)
   const approvalNetworkFeeCryptoFormatted =
@@ -83,24 +85,12 @@ export const ApprovalStep = ({
         )
       : ''
 
-  // the txStatus needs to be undefined before the tx is executed to handle "ready" but not "executing" status
-  const txStatus =
-    HOP_EXECUTION_STATE_ORDERED.indexOf(hopExecutionState) >=
-    HOP_EXECUTION_STATE_ORDERED.indexOf(HopExecutionState.AwaitingApprovalExecution)
-      ? approvalState
-      : undefined
-
-  const stepIndicator = useMemo(
-    () =>
-      txStatus !== undefined ? (
-        <StatusIcon txStatus={txStatus} />
-      ) : (
-        <Center fontSize='sm'>
-          <FaThumbsUp />
-        </Center>
-      ),
-    [txStatus],
-  )
+  const stepIndicator = useMemo(() => {
+    const defaultIcon = <FaThumbsUp />
+    // eslint to stoopid to realize this is inside the context of useMemo already
+    // eslint-disable-next-line react-memo/require-usememo
+    return <StatusIcon txStatus={approvalTxState} defaultIcon={defaultIcon} />
+  }, [approvalTxState])
 
   const translate = useTranslate()
 
@@ -183,7 +173,7 @@ export const ApprovalStep = ({
             size='sm'
             leftIcon={leftIcon}
             colorScheme='blue'
-            isLoading={hopExecutionState === HopExecutionState.AwaitingApprovalExecution}
+            isLoading={approvalTxState === TransactionExecutionState.Pending}
             onClick={handleSignAllowanceApproval}
           >
             {translate('common.approve')}
@@ -192,8 +182,8 @@ export const ApprovalStep = ({
       </Card>
     )
   }, [
+    approvalTxState,
     handleSignAllowanceApproval,
-    hopExecutionState,
     isActive,
     isExactAllowance,
     leftIcon,
@@ -210,7 +200,7 @@ export const ApprovalStep = ({
       content={content}
       isLastStep={isLastStep}
       isLoading={isLoading}
-      isError={txStatus === TxStatus.Failed}
+      isError={approvalTxState === TransactionExecutionState.Failed}
     />
   )
 }

--- a/src/components/MultiHopTrade/components/MultiHopTradeConfirm/components/ApprovalStep.tsx
+++ b/src/components/MultiHopTrade/components/MultiHopTradeConfirm/components/ApprovalStep.tsx
@@ -54,7 +54,7 @@ export const ApprovalStep = ({
 
   const { executeAllowanceApproval, approvalNetworkFeeCryptoBaseUnit } = useMockAllowanceApproval(
     tradeQuoteStep,
-    hopIndex === 0,
+    hopIndex,
     isExactAllowance,
   ) // TODO: use the real hook here
 
@@ -87,7 +87,7 @@ export const ApprovalStep = ({
 
   const stepIndicator = useMemo(() => {
     const defaultIcon = <FaThumbsUp />
-    // eslint to stoopid to realize this is inside the context of useMemo already
+    // eslint too stoopid to realize this is inside the context of useMemo already
     // eslint-disable-next-line react-memo/require-usememo
     return <StatusIcon txStatus={approvalTxState} defaultIcon={defaultIcon} />
   }, [approvalTxState])

--- a/src/components/MultiHopTrade/components/MultiHopTradeConfirm/components/Footer.tsx
+++ b/src/components/MultiHopTrade/components/MultiHopTradeConfirm/components/Footer.tsx
@@ -24,7 +24,7 @@ import {
   selectTradeExecutionState,
 } from 'state/slices/tradeQuoteSlice/selectors'
 import { tradeQuoteSlice } from 'state/slices/tradeQuoteSlice/tradeQuoteSlice'
-import { MultiHopExecutionState } from 'state/slices/tradeQuoteSlice/types'
+import { TradeExecutionState } from 'state/slices/tradeQuoteSlice/types'
 import { useAppDispatch, useAppSelector } from 'state/store'
 
 export const Footer = () => {
@@ -38,7 +38,7 @@ export const Footer = () => {
   const { isModeratePriceImpact } = usePriceImpact()
 
   const handleConfirm = useCallback(() => {
-    dispatch(tradeQuoteSlice.actions.incrementTradeExecutionState())
+    dispatch(tradeQuoteSlice.actions.confirmTrade())
   }, [dispatch])
 
   const networkFeeToTradeRatioPercentage = useMemo(
@@ -105,7 +105,7 @@ export const Footer = () => {
     )
   }, [swapperName, lastHopBuyAsset, translate])
 
-  return tradeExecutionState === MultiHopExecutionState.Previewing ? (
+  return tradeExecutionState === TradeExecutionState.Previewing ? (
     <CardFooter
       flexDir='column'
       gap={2}

--- a/src/components/MultiHopTrade/components/MultiHopTradeConfirm/components/HopTransactionStep.tsx
+++ b/src/components/MultiHopTrade/components/MultiHopTradeConfirm/components/HopTransactionStep.tsx
@@ -57,7 +57,7 @@ export const HopTransactionStep = ({
     // TODO: use the message to better ux
     // message,
     executeTrade,
-  } = useMockTradeExecution(hopIndex === 0) // TODO: use the real hook here
+  } = useMockTradeExecution(hopIndex) // TODO: use the real hook here
 
   const handleSignTx = useCallback(async () => {
     if (swapTxState !== TransactionExecutionState.AwaitingConfirmation) {
@@ -110,7 +110,7 @@ export const HopTransactionStep = ({
 
   const stepIndicator = useMemo(() => {
     const defaultIcon = <SwapperIcon swapperName={swapperName} />
-    // eslint to stoopid to realize this is inside the context of useMemo already
+    // eslint too stoopid to realize this is inside the context of useMemo already
     // eslint-disable-next-line react-memo/require-usememo
     return <StatusIcon txStatus={swapTxState} defaultIcon={defaultIcon} />
   }, [swapTxState, swapperName])

--- a/src/components/MultiHopTrade/components/MultiHopTradeConfirm/components/HopTransactionStep.tsx
+++ b/src/components/MultiHopTrade/components/MultiHopTradeConfirm/components/HopTransactionStep.tsx
@@ -3,7 +3,7 @@ import { Button, Card, CardBody, Link, VStack } from '@chakra-ui/react'
 import type { KnownChainIds } from '@shapeshiftoss/types'
 import { TxStatus } from '@shapeshiftoss/unchained-client'
 import type Polyglot from 'node-polyglot'
-import { useCallback, useEffect, useMemo, useState } from 'react'
+import { useCallback, useMemo } from 'react'
 import { useTranslate } from 'react-polyglot'
 import { MiddleEllipsis } from 'components/MiddleEllipsis/MiddleEllipsis'
 import { RawText, Text } from 'components/Text'
@@ -15,7 +15,7 @@ import { THORCHAIN_STREAM_SWAP_SOURCE } from 'lib/swapper/swappers/ThorchainSwap
 import type { SwapperName, TradeQuoteStep } from 'lib/swapper/types'
 import { selectHopExecutionMetadata } from 'state/slices/tradeQuoteSlice/selectors'
 import { tradeQuoteSlice } from 'state/slices/tradeQuoteSlice/tradeQuoteSlice'
-import { HOP_EXECUTION_STATE_ORDERED, HopExecutionState } from 'state/slices/tradeQuoteSlice/types'
+import { TransactionExecutionState } from 'state/slices/tradeQuoteSlice/types'
 import { useAppDispatch, useAppSelector } from 'state/store'
 
 import { SwapperIcon } from '../../TradeInput/components/SwapperIcon/SwapperIcon'
@@ -32,8 +32,6 @@ export type HopTransactionStepProps = {
   isActive: boolean
   hopIndex: number
   isLastStep?: boolean
-  onTxStatusChange: (txStatus?: TxStatus) => void
-  onError: () => void
 }
 
 export const HopTransactionStep = ({
@@ -42,22 +40,18 @@ export const HopTransactionStep = ({
   isActive,
   hopIndex,
   isLastStep,
-  onTxStatusChange,
-  onError,
 }: HopTransactionStepProps) => {
   const {
     number: { toCrypto },
   } = useLocaleFormatter()
   const dispatch = useAppDispatch()
   const translate = useTranslate()
-  const [isError, setIsError] = useState<boolean>(false)
 
   const {
-    state: hopExecutionState,
-    swapState: txState,
-    swapSellTxHash: sellTxHash,
-    swapBuyTxHash: buyTxHash,
+    swap: { state: swapTxState, sellTxHash, buyTxHash },
   } = useAppSelector(selectHopExecutionMetadata)[hopIndex]
+
+  const isError = useMemo(() => swapTxState === TransactionExecutionState.Failed, [swapTxState])
 
   const {
     // TODO: use the message to better ux
@@ -66,19 +60,22 @@ export const HopTransactionStep = ({
   } = useMockTradeExecution(hopIndex === 0) // TODO: use the real hook here
 
   const handleSignTx = useCallback(async () => {
-    // next state
-    dispatch(tradeQuoteSlice.actions.incrementTradeExecutionState())
+    if (swapTxState !== TransactionExecutionState.AwaitingConfirmation) {
+      console.error('attempted to execute in-progress swap')
+      return
+    }
+
+    dispatch(tradeQuoteSlice.actions.setSwapTxPending({ hopIndex }))
 
     const finalTxStatus = await executeTrade()
 
     // next state if trade was successful
     if (finalTxStatus === TxStatus.Confirmed) {
-      dispatch(tradeQuoteSlice.actions.incrementTradeExecutionState())
+      dispatch(tradeQuoteSlice.actions.setSwapTxComplete({ hopIndex }))
     } else if (finalTxStatus === TxStatus.Failed) {
-      setIsError(true)
-      onError()
+      dispatch(tradeQuoteSlice.actions.setSwapTxFailed({ hopIndex }))
     }
-  }, [dispatch, executeTrade, onError])
+  }, [dispatch, executeTrade, hopIndex, swapTxState])
 
   const tradeType = useMemo(
     () =>
@@ -111,29 +108,17 @@ export const HopTransactionStep = ({
     return {}
   }, [buyTxHash, tradeQuoteStep.source, tradeQuoteStep.sellAsset.explorerTxLink, sellTxHash])
 
-  // the txStatus needs to be undefined before the tx is executed to handle "ready" but not "executing" status
-  const txStatus =
-    HOP_EXECUTION_STATE_ORDERED.indexOf(hopExecutionState) >=
-    HOP_EXECUTION_STATE_ORDERED.indexOf(HopExecutionState.AwaitingTradeExecution)
-      ? txState
-      : undefined
-
-  useEffect(() => onTxStatusChange(txStatus), [onTxStatusChange, txStatus])
-
-  const stepIndicator = useMemo(
-    () =>
-      txStatus !== undefined ? (
-        <StatusIcon txStatus={txStatus} />
-      ) : (
-        <SwapperIcon swapperName={swapperName} />
-      ),
-    [swapperName, txStatus],
-  )
+  const stepIndicator = useMemo(() => {
+    const defaultIcon = <SwapperIcon swapperName={swapperName} />
+    // eslint to stoopid to realize this is inside the context of useMemo already
+    // eslint-disable-next-line react-memo/require-usememo
+    return <StatusIcon txStatus={swapTxState} defaultIcon={defaultIcon} />
+  }, [swapTxState, swapperName])
 
   const signIcon = useMemo(() => <CheckCircleIcon />, [])
 
   const content = useMemo(() => {
-    if (isActive && txStatus === undefined) {
+    if (isActive && swapTxState === TransactionExecutionState.AwaitingConfirmation) {
       return (
         <Card width='full'>
           <CardBody px={2} py={2}>
@@ -162,9 +147,9 @@ export const HopTransactionStep = ({
     isActive,
     sellTxHash,
     signIcon,
+    swapTxState,
     tradeQuoteStep.source,
     translate,
-    txStatus,
   ])
 
   const errorTranslation = useMemo(
@@ -241,7 +226,7 @@ export const HopTransactionStep = ({
       stepIndicator={stepIndicator}
       content={content}
       isLastStep={isLastStep}
-      isError={txStatus === TxStatus.Failed}
+      isError={swapTxState === TransactionExecutionState.Failed}
     />
   )
 }

--- a/src/components/MultiHopTrade/components/MultiHopTradeConfirm/components/StatusIcon.tsx
+++ b/src/components/MultiHopTrade/components/MultiHopTradeConfirm/components/StatusIcon.tsx
@@ -1,31 +1,39 @@
 import { CheckCircleIcon, WarningIcon } from '@chakra-ui/icons'
 import { Circle } from '@chakra-ui/react'
-import { TxStatus } from '@shapeshiftoss/unchained-client'
 import { CircularProgress } from 'components/CircularProgress/CircularProgress'
+import { assertUnreachable } from 'lib/utils'
+import { TransactionExecutionState } from 'state/slices/tradeQuoteSlice/types'
 
-export const StatusIcon = (props: { txStatus: TxStatus }) => {
-  // TODO: proper light/dark mode colors here
-  switch (props.txStatus) {
-    case TxStatus.Confirmed:
+export const StatusIcon = ({
+  txStatus,
+  defaultIcon,
+}: {
+  txStatus: TransactionExecutionState
+  defaultIcon: JSX.Element
+}) => {
+  switch (txStatus) {
+    case TransactionExecutionState.Complete:
       return (
         <Circle size={8}>
           <CheckCircleIcon color='text.success' />
         </Circle>
       )
-    case TxStatus.Failed:
+    case TransactionExecutionState.Failed:
       return (
         <Circle size={8}>
           <WarningIcon color='text.error' />
         </Circle>
       )
     // when the trade is submitting, treat unknown status as pending so the spinner spins
-    case TxStatus.Pending:
-    case TxStatus.Unknown:
-    default:
+    case TransactionExecutionState.Pending:
       return (
         <Circle size={8}>
           <CircularProgress size={4} />
         </Circle>
       )
+    case TransactionExecutionState.AwaitingConfirmation:
+      return <Circle size={8}>{defaultIcon}</Circle>
+    default:
+      assertUnreachable(txStatus)
   }
 }

--- a/src/components/MultiHopTrade/components/MultiHopTradeConfirm/hooks/mockHooks.ts
+++ b/src/components/MultiHopTrade/components/MultiHopTradeConfirm/hooks/mockHooks.ts
@@ -1,12 +1,12 @@
-import { TxStatus } from '@shapeshiftoss/unchained-client'
 import { useCallback, useEffect } from 'react'
 import { sleep } from 'lib/poll/poll'
 import type { TradeQuoteStep } from 'lib/swapper/types'
 import { selectHopExecutionMetadata } from 'state/slices/tradeQuoteSlice/selectors'
 import { tradeQuoteSlice } from 'state/slices/tradeQuoteSlice/tradeQuoteSlice'
-import type {
-  StreamingSwapFailedSwap,
-  StreamingSwapMetadata,
+import {
+  type StreamingSwapFailedSwap,
+  type StreamingSwapMetadata,
+  TransactionExecutionState,
 } from 'state/slices/tradeQuoteSlice/types'
 import { useAppDispatch, useAppSelector } from 'state/store'
 
@@ -31,8 +31,12 @@ export const useMockAllowanceApproval = (
 
   const executeAllowanceApproval = useCallback(() => {
     isFirstHop
-      ? dispatch(tradeQuoteSlice.actions.setFirstHopApprovalState(TxStatus.Pending))
-      : dispatch(tradeQuoteSlice.actions.setSecondHopApprovalState(TxStatus.Pending))
+      ? dispatch(
+          tradeQuoteSlice.actions.setFirstHopApprovalState(TransactionExecutionState.Pending),
+        )
+      : dispatch(
+          tradeQuoteSlice.actions.setSecondHopApprovalState(TransactionExecutionState.Pending),
+        )
 
     const promise = new Promise((resolve, _reject) => {
       setTimeout(() => {
@@ -45,7 +49,9 @@ export const useMockAllowanceApproval = (
             )
       }, 2000)
       setTimeout(() => {
-        const finalStatus = MOCK_FAIL_APPROVAL ? TxStatus.Failed : TxStatus.Confirmed
+        const finalStatus = MOCK_FAIL_APPROVAL
+          ? TransactionExecutionState.Failed
+          : TransactionExecutionState.Complete
 
         isFirstHop
           ? dispatch(tradeQuoteSlice.actions.setFirstHopApprovalState(finalStatus))
@@ -71,8 +77,8 @@ export const useMockTradeExecution = (isFirstHop: boolean) => {
   const executeTrade = useCallback(() => {
     const promise = new Promise((resolve, _reject) => {
       isFirstHop
-        ? dispatch(tradeQuoteSlice.actions.setFirstHopSwapState(TxStatus.Pending))
-        : dispatch(tradeQuoteSlice.actions.setSecondHopSwapState(TxStatus.Pending))
+        ? dispatch(tradeQuoteSlice.actions.setFirstHopSwapState(TransactionExecutionState.Pending))
+        : dispatch(tradeQuoteSlice.actions.setSecondHopSwapState(TransactionExecutionState.Pending))
 
       setTimeout(() => {
         isFirstHop
@@ -80,7 +86,9 @@ export const useMockTradeExecution = (isFirstHop: boolean) => {
           : dispatch(tradeQuoteSlice.actions.setSecondHopSwapSellTxHash('second_hop_sell_tx_hash'))
       }, 2000)
       setTimeout(() => {
-        const finalStatus = MOCK_FAIL_SWAP ? TxStatus.Failed : TxStatus.Confirmed
+        const finalStatus = MOCK_FAIL_SWAP
+          ? TransactionExecutionState.Failed
+          : TransactionExecutionState.Complete
         isFirstHop
           ? dispatch(tradeQuoteSlice.actions.setFirstHopSwapState(finalStatus))
           : dispatch(tradeQuoteSlice.actions.setSecondHopSwapState(finalStatus))
@@ -106,9 +114,9 @@ export const useMockThorStreamingProgress = (
   failedSwaps: StreamingSwapFailedSwap[]
 } => {
   const dispatch = useAppDispatch()
-  const { swapSellTxHash: sellTxHash, streamingSwap: streamingSwapMeta } = useAppSelector(
-    selectHopExecutionMetadata,
-  )[hopIndex]
+  const {
+    swap: { sellTxHash, streamingSwap: streamingSwapMeta },
+  } = useAppSelector(selectHopExecutionMetadata)[hopIndex]
 
   const streamingSwapExecutionStarted = streamingSwapMeta !== undefined
 

--- a/src/state/slices/tradeQuoteSlice/constants.ts
+++ b/src/state/slices/tradeQuoteSlice/constants.ts
@@ -1,0 +1,25 @@
+import type { TradeQuoteSliceState } from './tradeQuoteSlice'
+import { HopExecutionState, TradeExecutionState, TransactionExecutionState } from './types'
+
+const initialTransactionState = {
+  state: TransactionExecutionState.AwaitingConfirmation,
+}
+
+const initialHopState = {
+  state: HopExecutionState.Pending,
+  approval: initialTransactionState,
+  swap: initialTransactionState,
+}
+
+export const initialTradeExecutionState = {
+  state: TradeExecutionState.Previewing,
+  firstHop: initialHopState,
+  secondHop: initialHopState,
+}
+
+export const initialState: TradeQuoteSliceState = {
+  activeQuoteIndex: undefined,
+  confirmedQuote: undefined,
+  activeStep: undefined,
+  tradeExecution: initialTradeExecutionState,
+}

--- a/src/state/slices/tradeQuoteSlice/types.ts
+++ b/src/state/slices/tradeQuoteSlice/types.ts
@@ -1,47 +1,29 @@
-import type { TxStatus } from '@shapeshiftoss/unchained-client'
+export enum TransactionExecutionState {
+  AwaitingConfirmation = 'AwaitingConfirmation',
+  Pending = 'Pending',
+  Complete = 'Complete',
+  Failed = 'Failed',
+}
 
 export enum HopExecutionState {
   Pending = 'Pending',
-  AwaitingApprovalConfirmation = 'AwaitingApprovalConfirmation',
-  AwaitingApprovalExecution = 'AwaitingApprovalExecution',
-  AwaitingTradeConfirmation = 'AwaitingTradeConfirmation',
-  AwaitingTradeExecution = 'AwaitingTradeExecution',
+  AwaitingApproval = 'AwaitingApproval',
+  AwaitingSwap = 'AwaitingSwap',
   Complete = 'Complete',
+}
+
+export enum TradeExecutionState {
+  Previewing = 'Previewing',
+  FirstHop = 'FirstHop',
+  SecondHop = 'SecondHop',
+  TradeComplete = 'Complete',
 }
 
 export const HOP_EXECUTION_STATE_ORDERED = [
   HopExecutionState.Pending,
-  HopExecutionState.AwaitingApprovalConfirmation,
-  HopExecutionState.AwaitingApprovalExecution,
-  HopExecutionState.AwaitingTradeConfirmation,
-  HopExecutionState.AwaitingTradeExecution,
+  HopExecutionState.AwaitingApproval,
+  HopExecutionState.AwaitingSwap,
   HopExecutionState.Complete,
-]
-
-export enum MultiHopExecutionState {
-  Previewing = 'Previewing',
-  FirstHopAwaitingApprovalConfirmation = `firstHop_${HopExecutionState.AwaitingApprovalConfirmation}`,
-  FirstHopAwaitingApprovalExecution = `firstHop_${HopExecutionState.AwaitingApprovalExecution}`,
-  FirstHopAwaitingTradeConfirmation = `firstHop_${HopExecutionState.AwaitingTradeConfirmation}`,
-  FirstHopAwaitingTradeExecution = `firstHop_${HopExecutionState.AwaitingTradeExecution}`,
-  SecondHopAwaitingApprovalConfirmation = `secondHop_${HopExecutionState.AwaitingApprovalConfirmation}`,
-  SecondHopAwaitingApprovalExecution = `secondHop_${HopExecutionState.AwaitingApprovalExecution}`,
-  SecondHopAwaitingTradeConfirmation = `secondHop_${HopExecutionState.AwaitingTradeConfirmation}`,
-  SeondHopAwaitingTradeExecution = `secondHop_${HopExecutionState.AwaitingTradeExecution}`,
-  TradeComplete = 'Complete',
-}
-
-export const MULTI_HOP_EXECUTION_STATE_ORDERED = [
-  MultiHopExecutionState.Previewing,
-  MultiHopExecutionState.FirstHopAwaitingApprovalConfirmation,
-  MultiHopExecutionState.FirstHopAwaitingApprovalExecution,
-  MultiHopExecutionState.FirstHopAwaitingTradeConfirmation,
-  MultiHopExecutionState.FirstHopAwaitingTradeExecution,
-  MultiHopExecutionState.SecondHopAwaitingApprovalConfirmation,
-  MultiHopExecutionState.SecondHopAwaitingApprovalExecution,
-  MultiHopExecutionState.SecondHopAwaitingTradeConfirmation,
-  MultiHopExecutionState.SeondHopAwaitingTradeExecution,
-  MultiHopExecutionState.TradeComplete,
 ]
 
 export type StreamingSwapFailedSwap = {
@@ -55,13 +37,27 @@ export type StreamingSwapMetadata = {
   failedSwaps: StreamingSwapFailedSwap[]
 }
 
+export type ApprovalExecutionMetadata = {
+  state: TransactionExecutionState
+  txHash?: string
+  isRequired?: boolean
+}
+
+export type SwapExecutionMetadata = {
+  state: TransactionExecutionState
+  sellTxHash?: string
+  buyTxHash?: string
+  streamingSwap?: StreamingSwapMetadata
+}
+
 export type HopExecutionMetadata = {
   state: HopExecutionState
-  approvalRequired?: boolean
-  approvalState?: TxStatus
-  approvalTxHash?: string
-  swapState?: TxStatus
-  swapSellTxHash?: string
-  swapBuyTxHash?: string
-  streamingSwap?: StreamingSwapMetadata
+  approval: ApprovalExecutionMetadata
+  swap: SwapExecutionMetadata
+}
+
+export type TradeExecutionMetadata = {
+  state: TradeExecutionState
+  firstHop: HopExecutionMetadata
+  secondHop: HopExecutionMetadata
 }

--- a/src/test/mocks/store.ts
+++ b/src/test/mocks/store.ts
@@ -2,7 +2,7 @@ import { DEFAULT_HISTORY_TIMEFRAME } from 'constants/Config'
 import type { ReduxState } from 'state/reducer'
 import { defaultAsset } from 'state/slices/assetsSlice/assetsSlice'
 import { CurrencyFormats } from 'state/slices/preferencesSlice/preferencesSlice'
-import { HopExecutionState, MultiHopExecutionState } from 'state/slices/tradeQuoteSlice/types'
+import { initialTradeExecutionState } from 'state/slices/tradeQuoteSlice/constants'
 
 const mockApiFactory = <T extends unknown>(reducerPath: T) => ({
   queries: {},
@@ -185,11 +185,7 @@ export const mockStore: ReduxState = {
     activeQuoteIndex: undefined,
     confirmedQuote: undefined,
     activeStep: undefined,
-    tradeExecution: {
-      state: MultiHopExecutionState.Previewing,
-      firstHop: { state: HopExecutionState.Pending },
-      secondHop: { state: HopExecutionState.Pending },
-    },
+    tradeExecution: initialTradeExecutionState,
   },
   snapshot: {
     votingPower: undefined,


### PR DESCRIPTION
## Description

Refactors the state management of multi-hop trade execution to remove duplicate and redundant states and the resulting logic required to keep them aligned. As a result, there is less responsibility of the view layer to manage and know about the working of trades at a higher level and allows them to dispatch narrow-context actions to redux.

- State is deduplicated to ensure state is unique and purpose specific
- State is nested to ensure the scope of each layer of nesting is easy to track and optional parts of trades (e.g the second hop and approvals) can be skipped without convoluted logic
  - callbacks to track error states of hooks owned by child components are now removed
  - state changes are dispatched on a per-step basis rather than using blanket incrementation, which simplifies logic at the cost of verbosity
- The numerous new redux actions ensure state is consistent and integrity is maintained to avoid corrupted state

## Pull Request Type

- [ ] :bug: Bug fix (Non-breaking Change: Fixes an issue)
- [x] :hammer_and_wrench: Chore (Non-breaking Change: Doc updates, pkg upgrades, typos, etc..)
- [ ] :nail_care: New Feature (Breaking/Non-breaking Change)

## Issue (if applicable)

closes #5740

## Risk

All of the work here is focused on multi-hop trades (behind feature flag), but there is a risk these changes could affect the functionality of the production trade and approval state management.

## Testing

Test trades and erc20 approvals are still working as expected.

### Engineering



### Operations



## Screenshots (if applicable)

Multi-hop UI still working correctly with mock hooks
![image](https://github.com/shapeshift/web/assets/125113430/e32d899f-199f-4ba6-a3bf-f84c25a576c6)

