### PR TITLE
feat: increase thor polling delay when enforcing outbound checks

### DIFF
--- a/src/features/defi/providers/thorchain-savers/components/ThorchainSaversManager/Deposit/components/Status.tsx
+++ b/src/features/defi/providers/thorchain-savers/components/ThorchainSaversManager/Deposit/components/Status.tsx
@@ -2,6 +2,7 @@ import { CheckIcon, CloseIcon, ExternalLinkIcon } from '@chakra-ui/icons'
 import { Box, Button, Link, Stack } from '@chakra-ui/react'
 import type { AccountId } from '@shapeshiftoss/caip'
 import { fromAccountId } from '@shapeshiftoss/caip'
+import { TxStatus as TxStatusType } from '@shapeshiftoss/unchained-client'
 import { Summary } from 'features/defi/components/Summary'
 import { TxStatus } from 'features/defi/components/TxStatus/TxStatus'
 import type {
@@ -85,14 +86,16 @@ export const Status: React.FC<StatusProps> = ({ accountId }) => {
     if (confirmedTransaction && confirmedTransaction.status !== 'Pending' && contextDispatch) {
       ;(async () => {
         // Skipping outbound detection since there's no outbound tx involved here - as long as the inner swap is confirmed, we're gucci
-        await waitForThorchainUpdate({ txId: confirmedTransaction.txid, skipOutbound: true })
-          .promise
+        const thorchainTxStatus = await waitForThorchainUpdate({
+          txId: confirmedTransaction.txid,
+          skipOutbound: true,
+        }).promise
 
-        if (confirmedTransaction.status === 'Confirmed') {
+        if ([TxStatusType.Confirmed, TxStatusType.Failed].includes(thorchainTxStatus)) {
           contextDispatch({
             type: ThorchainSaversDepositActionType.SET_DEPOSIT,
             payload: {
-              txStatus: confirmedTransaction.status === 'Confirmed' ? 'success' : 'failed',
+              txStatus: thorchainTxStatus === TxStatusType.Confirmed ? 'success' : 'failed',
             },
           })
         }


### PR DESCRIPTION
## Description

THOR Txs for which we enforce outbound checks (e.g 100% loan repayments, borrows, savers withdraws) can take a very long time to complete. We currently poll every 60 second, 60 times, i.e for a total of 1 hour.

This changes the heuristics of polling by making us polls less, and less frequently, when enforcing outbound checks. Enforcing outbound checks means that those Txs will inherently take a lot longer to complete, hence polling every 60 seconds is guaranteed overfetching, and having a max polling time of 1 hour isn't going to necessarily cut it.

## Pull Request Type

- [ ] :bug: Bug fix (Non-breaking Change: Fixes an issue)
- [ ] :hammer_and_wrench: Chore (Non-breaking Change: Doc updates, pkg upgrades, typos, etc..)
- [x] :nail_care: New Feature (Breaking/Non-breaking Change)

## Issue (if applicable)

<!-----------------------------------------------------------------------------
If applicable, please link to the github issue and put `closes #XXXX` in your comment to auto-close the issue that your PR fixes.
------------------------------------------------------------------------------>

N/A

## Risk

<!-----------------------------------------------------------------------------
Outline the scope of your changes and the risk associated with them. You must use your discretion as an engineer to determine the potential impact of your changes.

E.g. an upgrade to `hdwallet` or core state management would be considered higher risk, and might require a full regression test. UI or isolated view changes, or something behind a feature flag may have near zero risk. Small bug fixes might require testing isolated to the specific fix.
------------------------------------------------------------------------------>

Low - this makes things *more* reliable for outbound checks enforced, but doesn't change anything when they're skipped

## Testing

<!-----------------------------------------------------------------------------
We treat every PR to be merged with the same scrutiny as if we were merging directly to production.

Your PR will not be merged if you do not complete the sections below for our engineering and operations teams to test.
------------------------------------------------------------------------------>

- Ensure outbound checks skipped are still happy e.g savers deposit are still reflected fast
- Ensure outbound checks enforced are happy (this will require leaving the tab open for the 1+ hour that the outbound Tx may take to be signed)

### Engineering

<!-----------------------------------------------------------------------------
Include sufficient information here for an engineer to test your PR. This may include how to test locally, in a built environment, changes to infrastructure etc.
------------------------------------------------------------------------------>

- ☝🏽 

### Operations

<!-----------------------------------------------------------------------------
If your changes have a user-facing impact, describe how a non-technical QA team can functionally test your changes in a preview environment.

If they are not user-facing please describe how to test for any regressions that may occur.
------------------------------------------------------------------------------>

- ☝🏽 

## Screenshots (if applicable)


- Outbound skipped is still happy

https://github.com/shapeshift/web/assets/17035424/c14fb9a8-843d-433a-afb1-6b81a9d14759

- Outbound checks enforced now poll every 5mn

![image](https://github.com/shapeshift/web/assets/17035424/0c9d137b-0428-493e-8875-b2bbfae27702)
![image](https://github.com/shapeshift/web/assets/17035424/11af9460-078b-4930-bcb0-07b7082586c3)

- Tx status detection working after outbound complete of the Tx above (expected delay = 4050 seconds / 1h08)


https://github.com/shapeshift/web/assets/17035424/5d05d290-df8b-47d7-9cf2-e513a25a7465

