### PR TITLE
fix: lending use safe buffer at repay confirm step

### DIFF
--- a/src/pages/Lending/Pool/components/Repay/RepayConfirm.tsx
+++ b/src/pages/Lending/Pool/components/Repay/RepayConfirm.tsx
@@ -83,6 +83,13 @@ export const RepayConfirm = ({
     state: { wallet },
   } = useWallet()
 
+  const repaymentPercentOrDefault = useMemo(() => {
+    const repaymentPercentBn = bnOrZero(repaymentPercent)
+    // 1% buffer in case our market data differs from THOR's, to ensure 100% loan repays are actually 100% repays
+    if (!repaymentPercentBn.eq(100)) return repaymentPercent
+    return repaymentPercentBn.plus('1').toNumber()
+  }, [repaymentPercent])
+
   const [isLoanPending, setIsLoanPending] = useState(false)
   const [isQuoteExpired, setIsQuoteExpired] = useState(false)
   const [elapsedTime, setElapsedTime] = useState(0)
@@ -105,7 +112,7 @@ export const RepayConfirm = ({
       // which we *want* to wait for before considering the repay as complete
       await waitForThorchainUpdate({
         txId: _txId,
-        skipOutbound: bn(repaymentPercent).lt(100),
+        skipOutbound: bn(repaymentPercentOrDefault).lt(101),
         expectedCompletionTime,
       }).promise
       queryClient.invalidateQueries({ queryKey: ['thorchainLendingPosition'], exact: false })
@@ -153,12 +160,12 @@ export const RepayConfirm = ({
   const repaymentAmountFiatUserCurrency = useMemo(() => {
     if (!lendingPositionData?.debtBalanceFiatUserCurrency) return null
 
-    const proratedCollateralFiatUserCurrency = bnOrZero(repaymentPercent)
+    const proratedCollateralFiatUserCurrency = bnOrZero(repaymentPercentOrDefault)
       .times(lendingPositionData.debtBalanceFiatUserCurrency)
       .div(100)
 
     return proratedCollateralFiatUserCurrency.toFixed()
-  }, [lendingPositionData, repaymentPercent])
+  }, [lendingPositionData, repaymentPercentOrDefault])
 
   const repaymentAssetMarketData = useAppSelector(state =>
     selectMarketDataById(state, repaymentAsset?.assetId ?? ''),
@@ -502,7 +509,7 @@ export const RepayConfirm = ({
             confirmedQuote={confirmedQuote}
             repaymentAsset={repaymentAsset}
             collateralAssetId={collateralAssetId}
-            repaymentPercent={repaymentPercent ?? 0}
+            repaymentPercent={repaymentPercentOrDefault ?? 0}
             repayAmountCryptoPrecision={repaymentAmountCryptoPrecision ?? '0'}
             collateralDecreaseAmountCryptoPrecision={
               confirmedQuote?.quoteLoanCollateralDecreaseCryptoPrecision ?? '0'


### PR DESCRIPTION
## Description

see testing thread starting at https://discord.com/channels/554694662431178782/1174550133770301480/1182073567333072967

We're currently getting quotes with a buffer of 1% for THORChain lending 100% repayments, for the precise case of 100% not being 100% because of THOR market data discrepencies.
However, we do not use that amount when building the actual send input, resulting in collateral repayments not being triggered, and only a small amount of dust left in the loan instead.

## Pull Request Type

- [x] :bug: Bug fix (Non-breaking Change: Fixes an issue)
- [ ] :hammer_and_wrench: Chore (Non-breaking Change: Doc updates, pkg upgrades, typos, etc..)
- [ ] :nail_care: New Feature (Breaking/Non-breaking Change)

## Issue (if applicable)

<!-----------------------------------------------------------------------------
If applicable, please link to the github issue and put `closes #XXXX` in your comment to auto-close the issue that your PR fixes.
------------------------------------------------------------------------------>

N/A

## Risk

<!-----------------------------------------------------------------------------
Outline the scope of your changes and the risk associated with them. You must use your discretion as an engineer to determine the potential impact of your changes.

E.g. an upgrade to `hdwallet` or core state management would be considered higher risk, and might require a full regression test. UI or isolated view changes, or something behind a feature flag may have near zero risk. Small bug fixes might require testing isolated to the specific fix.
------------------------------------------------------------------------------>

None, this was inconsistent and wrong previously

## Testing

<!-----------------------------------------------------------------------------
We treat every PR to be merged with the same scrutiny as if we were merging directly to production.

Your PR will not be merged if you do not complete the sections below for our engineering and operations teams to test.
------------------------------------------------------------------------------>

- None if you don't have repayment unlocked
- If your repayment is unlocked, ensure you get your collateral back when doing a 100% repayment

### Engineering

<!-----------------------------------------------------------------------------
Include sufficient information here for an engineer to test your PR. This may include how to test locally, in a built environment, changes to infrastructure etc.
------------------------------------------------------------------------------>

- ☝🏽 

### Operations

<!-----------------------------------------------------------------------------
If your changes have a user-facing impact, describe how a non-technical QA team can functionally test your changes in a preview environment.

If they are not user-facing please describe how to test for any regressions that may occur.
------------------------------------------------------------------------------>

- ☝🏽 

## Screenshots (if applicable)
