### PR TITLE
chore: add pify types

### DIFF
--- a/package.json
+++ b/package.json
@@ -222,6 +222,7 @@
     "@types/mixpanel-browser": "^2.38.1",
     "@types/node": "^16.11.12",
     "@types/node-polyglot": "^2.4.2",
+    "@types/pify": "^5.0.4",
     "@types/qr-image": "^3.2.5",
     "@types/react": "^18.0.14",
     "@types/react-datepicker": "^4.4.2",

--- a/yarn.lock
+++ b/yarn.lock
@@ -9781,6 +9781,7 @@ __metadata:
     "@types/mixpanel-browser": ^2.38.1
     "@types/node": ^16.11.12
     "@types/node-polyglot": ^2.4.2
+    "@types/pify": ^5.0.4
     "@types/qr-image": ^3.2.5
     "@types/react": ^18.0.14
     "@types/react-datepicker": ^4.4.2
@@ -11577,6 +11578,13 @@ __metadata:
   dependencies:
     "@types/node": "*"
   checksum: d15024b1957c21cf3b8887329d9bd8dfde754cf13a09d76ae25f1391cfc62bb8b8d7b760773c5dbaa748172fba8b3e0c3dbe962af6ccbd69b76df12a48dfba40
+  languageName: node
+  linkType: hard
+
+"@types/pify@npm:^5.0.4":
+  version: 5.0.4
+  resolution: "@types/pify@npm:5.0.4"
+  checksum: 765a4f130fac9eb4ca2fb14d95a218d605f671ddd1ed4ebeb6ee0e0fa937ec59cf91fd55a9bb702c0472ca1296cb00ab081bdf9e908ee4abb8105068994f309f
   languageName: node
   linkType: hard
 


### PR DESCRIPTION
## Description

Re-adds `pify` types as a dependency, which are needed for the release script.

Removed in https://github.com/shapeshift/web/pull/5772, but are actually used.

## Pull Request Type

- [ ] :bug: Bug fix (Non-breaking Change: Fixes an issue)
- [x] :hammer_and_wrench: Chore (Non-breaking Change: Doc updates, pkg upgrades, typos, etc..)
- [ ] :nail_care: New Feature (Breaking/Non-breaking Change)

## Issue (if applicable)

N/A

## Risk

Almost literally none.

## Testing

`yarn release` should be great again.

### Engineering

☝️

### Operations

N/A

## Screenshots (if applicable)

N/A