### PR TITLE
feat: use locked quote repayment amount on confirm

### DIFF
--- a/src/lib/utils/thorchain/lending/types.ts
+++ b/src/lib/utils/thorchain/lending/types.ts
@@ -111,8 +111,9 @@ export type LendingQuoteClose = {
   quoteOutboundDelayMs: number
   quoteInboundConfirmationMs: number
   quoteTotalTimeMs: number
-  repaymentAmountCryptoPrecision: string | null
   quoteExpiry: number
+  repaymentAmountCryptoPrecision: string | null
+  repaymentPercentOrDefault: number
 }
 
 export const isLendingQuoteOpen = (

--- a/src/pages/Lending/Pool/components/Repay/Repay.tsx
+++ b/src/pages/Lending/Pool/components/Repay/Repay.tsx
@@ -151,7 +151,6 @@ const RepayRoutes = memo(
       () => (
         <RepayConfirm
           collateralAssetId={collateralAssetId}
-          repaymentPercent={repaymentPercent}
           setRepaymentPercent={onRepaymentPercentChange}
           collateralAccountId={collateralAccountId}
           repaymentAccountId={repaymentAccountId}
@@ -164,7 +163,6 @@ const RepayRoutes = memo(
       ),
       [
         collateralAssetId,
-        repaymentPercent,
         onRepaymentPercentChange,
         collateralAccountId,
         repaymentAccountId,

--- a/src/pages/Lending/hooks/useLendingCloseQuery.ts
+++ b/src/pages/Lending/hooks/useLendingCloseQuery.ts
@@ -39,10 +39,12 @@ const selectLendingCloseQueryData = memoize(
     data,
     collateralAssetMarketData,
     repaymentAmountCryptoPrecision,
+    repaymentPercentOrDefault,
   }: {
     data: LendingWithdrawQuoteResponseSuccess
     collateralAssetMarketData: MarketData
     repaymentAmountCryptoPrecision: string | null
+    repaymentPercentOrDefault: number
   }): LendingQuoteClose => {
     const quote = data
 
@@ -109,6 +111,7 @@ const selectLendingCloseQueryData = memoize(
       quoteTotalTimeMs,
       quoteExpiry,
       repaymentAmountCryptoPrecision,
+      repaymentPercentOrDefault,
     }
   },
 )
@@ -224,6 +227,7 @@ export const useLendingQuoteCloseQuery = ({
         data,
         collateralAssetMarketData,
         repaymentAmountCryptoPrecision,
+        repaymentPercentOrDefault,
       }),
     // Do not refetch if consumers explicitly set enabled to false
     // They do so because the query should never run in the reactive react realm, but only programmatically with the refetch function


### PR DESCRIPTION
## Description

... and `repaymentPercentOrDefault` as well.

See https://github.com/shapeshift/web/pull/5795 for context. 

5798 ensured we use the proper buffer at confirm step too, but there's still a slim chance the amount we *eventually* send could change if the market data refetches. We do *not* refetch market data at interval currently but we will eventually do so:

https://github.com/shapeshift/web/blob/2f3f96b4e936a60bdae328c293bb97efecaf6fdd/src/context/AppProvider/AppContext.tsx#L251-L254

Having new market data would result in either higher or lower crypto amounts than the one we originally sent to get a quote. This ensures we use *locked* values instead.

While at it, also adds some extra paranoia safety WRT repaying 100/101% but not having a collateral decrease.

## Pull Request Type

- [ ] :bug: Bug fix (Non-breaking Change: Fixes an issue)
- [ ] :hammer_and_wrench: Chore (Non-breaking Change: Doc updates, pkg upgrades, typos, etc..)
- [x] :nail_care: New Feature (Breaking/Non-breaking Change)

## Issue (if applicable)

<!-----------------------------------------------------------------------------
If applicable, please link to the github issue and put `closes #XXXX` in your comment to auto-close the issue that your PR fixes.
------------------------------------------------------------------------------>

N/A

## Risk

<!-----------------------------------------------------------------------------
Outline the scope of your changes and the risk associated with them. You must use your discretion as an engineer to determine the potential impact of your changes.

E.g. an upgrade to `hdwallet` or core state management would be considered higher risk, and might require a full regression test. UI or isolated view changes, or something behind a feature flag may have near zero risk. Small bug fixes might require testing isolated to the specific fix.
------------------------------------------------------------------------------>

- None until we can test this obviously. Scrutinize this - we cannot test this at runtime yet but 100% repayments will be retested in 3 days.

## Testing

<!-----------------------------------------------------------------------------
We treat every PR to be merged with the same scrutiny as if we were merging directly to production.

Your PR will not be merged if you do not complete the sections below for our engineering and operations teams to test.
------------------------------------------------------------------------------>

- None for now

### Engineering

<!-----------------------------------------------------------------------------
Include sufficient information here for an engineer to test your PR. This may include how to test locally, in a built environment, changes to infrastructure etc.
------------------------------------------------------------------------------>

- Locked amounts being consumed look sane
- Ensure `<RepayConfirm />` *only* uses amounts from `confirmedQuote` and doesn't have its own programmatic repayment amount / percent

### Operations

<!-----------------------------------------------------------------------------
If your changes have a user-facing impact, describe how a non-technical QA team can functionally test your changes in a preview environment.

If they are not user-facing please describe how to test for any regressions that may occur.
------------------------------------------------------------------------------>

- None yet

## Screenshots (if applicable)
