### PR TITLE
feat: refetch market data at interval

### DIFF
--- a/src/AppProviders.tsx
+++ b/src/AppProviders.tsx
@@ -71,13 +71,13 @@ export function AppProviders({ children }: ProvidersProps) {
                           <ErrorBoundary FallbackComponent={ErrorPage} onError={handleError}>
                             <ModalProvider>
                               <TransactionsProvider>
-                                <AppProvider>
-                                  <FoxEthProvider>
-                                    <QueryClientProvider>
+                                <QueryClientProvider>
+                                  <AppProvider>
+                                    <FoxEthProvider>
                                       <DefiManagerProvider>{children}</DefiManagerProvider>
-                                    </QueryClientProvider>
-                                  </FoxEthProvider>
-                                </AppProvider>
+                                    </FoxEthProvider>
+                                  </AppProvider>
+                                </QueryClientProvider>
                               </TransactionsProvider>
                             </ModalProvider>
                           </ErrorBoundary>

--- a/src/context/AppProvider/AppContext.tsx
+++ b/src/context/AppProvider/AppContext.tsx
@@ -270,6 +270,8 @@ export const AppProvider = ({ children }: { children: React.ReactNode }) => {
       // used to trigger mixpanel init after load of market data
       dispatch(marketData.actions.setMarketDataLoaded())
 
+      // We *have* to return a value other than undefined from react-query queries, see
+      // https://tanstack.com/query/v4/docs/react/guides/migrating-to-react-query-4#undefined-is-an-illegal-cache-value-for-successful-queries
       return null
     },
     // once the portfolio is loaded, fetch market data for all portfolio assets

--- a/src/context/AppProvider/AppContext.tsx
+++ b/src/context/AppProvider/AppContext.tsx
@@ -270,7 +270,7 @@ export const AppProvider = ({ children }: { children: React.ReactNode }) => {
       // used to trigger mixpanel init after load of market data
       dispatch(marketData.actions.setMarketDataLoaded())
 
-      return
+      return null
     },
     // once the portfolio is loaded, fetch market data for all portfolio assets
     // and start refetch timer to keep market data up to date

--- a/src/context/AppProvider/AppContext.tsx
+++ b/src/context/AppProvider/AppContext.tsx
@@ -11,6 +11,7 @@ import {
   fromAccountId,
   ltcChainId,
 } from '@shapeshiftoss/caip'
+import { useQuery } from '@tanstack/react-query'
 import { DEFAULT_HISTORY_TIMEFRAME } from 'constants/Config'
 import difference from 'lodash/difference'
 import React, { useEffect } from 'react'
@@ -232,38 +233,54 @@ export const AppProvider = ({ children }: { children: React.ReactNode }) => {
     }),
   )
 
-  // once the portfolio is loaded, fetch market data for all portfolio assets
-  // start refetch timer to keep market data up to date
-  useEffect(() => {
-    if (portfolioLoadingStatus === 'loading') return
+  const marketDataPollingInterval = 60 * 15 * 1000 // refetch data every 15 minutes
+  useQuery({
+    queryKey: ['marketData', {}],
+    queryFn: async () => {
+      // Exclude assets for which we are unable to get market data
+      // We would fire query thunks / XHRs that would slow down the app
+      // We insert price data for these as resolver-level, and are unable to get market data
+      const excluded: AssetId[] = uniV2LpIdsData.data ?? []
+      const portfolioAssetIdsExcludeNoMarketData = difference(portfolioAssetIds, excluded)
 
-    // Exclude assets for which we are unable to get market data
-    // We would fire query thunks / XHRs that would slow down the app
-    // We insert price data for these as resolver-level, and are unable to get market data
-    const excluded: AssetId[] = uniV2LpIdsData.data ?? []
-    const portfolioAssetIdsExcludeNoMarketData = difference(portfolioAssetIds, excluded)
+      // Only commented out to make it clear we do NOT want to use RTK options here
+      // We use react-query as a wrapper because it allows us to disable refetch for background tabs
+      // const opts = { subscriptionOptions: { pollingInterval: marketDataPollingInterval } }
+      const timeframe = DEFAULT_HISTORY_TIMEFRAME
 
-    // https://redux-toolkit.js.org/rtk-query/api/created-api/endpoints#initiate
-    // TODO(0xdef1cafe): bring polling back once we point at markets.shapeshift.com
-    // const pollingInterval = 1000 * 2 * 60 // refetch data every two minutes
-    // const opts = { subscriptionOptions: { pollingInterval } }
-    const timeframe = DEFAULT_HISTORY_TIMEFRAME
-
-    void (async () => {
       await Promise.all([
         dispatch(
-          marketApi.endpoints.findPriceHistoryByAssetIds.initiate({
-            timeframe,
-            assetIds: portfolioAssetIdsExcludeNoMarketData,
+          marketApi.endpoints.findPriceHistoryByAssetIds.initiate(
+            {
+              timeframe,
+              assetIds: portfolioAssetIdsExcludeNoMarketData,
+            },
+            // Since we use react-query as a polling wrapper, every initiate call *is* a force refetch here
+            { forceRefetch: true },
+          ),
+        ),
+        dispatch(
+          marketApi.endpoints.findByAssetIds.initiate(portfolioAssetIdsExcludeNoMarketData, {
+            // Since we use react-query as a polling wrapper, every initiate call *is* a force refetch here
+            forceRefetch: true,
           }),
         ),
-        dispatch(marketApi.endpoints.findByAssetIds.initiate(portfolioAssetIdsExcludeNoMarketData)),
       ])
 
       // used to trigger mixpanel init after load of market data
       dispatch(marketData.actions.setMarketDataLoaded())
-    })()
-  }, [dispatch, portfolioLoadingStatus, portfolioAssetIds, uniV2LpIdsData.data])
+
+      return
+    },
+    // once the portfolio is loaded, fetch market data for all portfolio assets
+    // and start refetch timer to keep market data up to date
+    enabled: portfolioLoadingStatus !== 'loading',
+    refetchInterval: marketDataPollingInterval,
+    // Do NOT refetch market data in background to avoid spamming coingecko
+    refetchIntervalInBackground: false,
+    // Do NOT refetch market data on window focus to avoid spamming coingecko
+    refetchOnWindowFocus: false,
+  })
 
   /**
    * fetch forex spot and history for user's selected currency


### PR DESCRIPTION
## Description

Refetches market data every 15 minutes, *if* the window/tab is active only.


See https://stackoverflow.com/questions/69982787/refetchintervalinbackground-does-not-stop-a-query-with-refetchinterval-from-refe for what it means for a window to be active according to react-query's `FocusManager`'s:

```
we use the provided focusManager, which listens to the visibilitychange and focus events of the browser. The browser emits those if you switch to a different tab. But I've seen these events not being emitted when I have two windows next to each other and I just focus the other window, because then it's not in the "background".
```

i.e only switching to a different window/tab while still having the app tab opened will *not* toggle the background state to true, it's only triggered when you have another window/tab active *and* the app tab isn't visible.

## Pull Request Type

- [ ] :bug: Bug fix (Non-breaking Change: Fixes an issue)
- [ ] :hammer_and_wrench: Chore (Non-breaking Change: Doc updates, pkg upgrades, typos, etc..)
- [x] :nail_care: New Feature (Breaking/Non-breaking Change)

## Issue (if applicable)

<!-----------------------------------------------------------------------------
If applicable, please link to the github issue and put `closes #XXXX` in your comment to auto-close the issue that your PR fixes.
------------------------------------------------------------------------------>

closes https://github.com/shapeshift/web/issues/5802

## Risk

<!-----------------------------------------------------------------------------
Outline the scope of your changes and the risk associated with them. You must use your discretion as an engineer to determine the potential impact of your changes.

E.g. an upgrade to `hdwallet` or core state management would be considered higher risk, and might require a full regression test. UI or isolated view changes, or something behind a feature flag may have near zero risk. Small bug fixes might require testing isolated to the specific fix.
------------------------------------------------------------------------------>

- We may be failing to fetch, or fetch too much, test according to description, testing steps, and screenshots

## Testing

<!-----------------------------------------------------------------------------
We treat every PR to be merged with the same scrutiny as if we were merging directly to production.

Your PR will not be merged if you do not complete the sections below for our engineering and operations teams to test.
------------------------------------------------------------------------------>

- When having the app tab active **and visible**, ensure requests to markets.shapeshift.com refetch every 15 minutes
- Note, only inspecting the network requests will inherently make things slightly inaccurate, since there's a bit more happening in the RTK actions than just data fetching - realistically, you should expect a few more seconds before the last markets.shapeshift.com request before seeing the next one in 15mn

- When having the app tab *non active* (i.e, another window/tab selected) *and non visible* in your screen (i.e minimized down for Windows, or in another desktop for OSX), ensure there's no refetching happening after the 15mn interval

### Engineering

<!-----------------------------------------------------------------------------
Include sufficient information here for an engineer to test your PR. This may include how to test locally, in a built environment, changes to infrastructure etc.
------------------------------------------------------------------------------>

- Monkey patch the above to e.g 1mn for easier testing

### Operations

<!-----------------------------------------------------------------------------
If your changes have a user-facing impact, describe how a non-technical QA team can functionally test your changes in a preview environment.

If they are not user-facing please describe how to test for any regressions that may occur.
------------------------------------------------------------------------------>

- Note, you'll have to set your developer tools to detached mode, see https://stackoverflow.com/questions/23668827/how-to-open-the-chrome-developer-tools-in-a-new-window

## Screenshots (if applicable)

Note, interval was set to 1mn for testing

### Refetch when active

https://github.com/shapeshift/web/assets/17035424/88ecbe86-0661-49d9-9279-ff953269559b


### Does *not* refetch when inactive

https://github.com/shapeshift/web/assets/17035424/ff2ea08e-3c2e-4733-9013-4f8d730c9f30



