### PR TITLE
feat: use loading state on multi-hop trade confirm button

### DIFF
--- a/src/components/MultiHopTrade/components/MultiHopTradeConfirm/MultiHopTradeConfirm.tsx
+++ b/src/components/MultiHopTrade/components/MultiHopTradeConfirm/MultiHopTradeConfirm.tsx
@@ -24,7 +24,13 @@ export const MultiHopTradeConfirm = memo(() => {
   const previousTradeExecutionState = usePrevious(tradeExecutionState)
   const history = useHistory()
 
-  useIsApprovalInitiallyNeeded()
+  const { isLoading } = useIsApprovalInitiallyNeeded()
+
+  useEffect(() => {
+    if (isLoading) return
+
+    dispatch(tradeQuoteSlice.actions.setTradeInitialized())
+  }, [dispatch, isLoading])
 
   const handleBack = useCallback(() => {
     dispatch(swappersSlice.actions.clear())
@@ -71,7 +77,9 @@ export const MultiHopTradeConfirm = memo(() => {
             <Heading textAlign='center' fontSize='md'>
               <Text
                 translation={
-                  tradeExecutionState === TradeExecutionState.Previewing
+                  [TradeExecutionState.Initializing, TradeExecutionState.Previewing].includes(
+                    tradeExecutionState,
+                  )
                     ? 'trade.confirmDetails'
                     : 'trade.trade'
                 }

--- a/src/components/MultiHopTrade/components/MultiHopTradeConfirm/components/Footer.tsx
+++ b/src/components/MultiHopTrade/components/MultiHopTradeConfirm/components/Footer.tsx
@@ -105,7 +105,14 @@ export const Footer = () => {
     )
   }, [swapperName, lastHopBuyAsset, translate])
 
-  return tradeExecutionState === TradeExecutionState.Previewing ? (
+  const isLoading = useMemo(
+    () => tradeExecutionState === TradeExecutionState.Initializing,
+    [tradeExecutionState],
+  )
+
+  return [TradeExecutionState.Initializing, TradeExecutionState.Previewing].includes(
+    tradeExecutionState,
+  ) ? (
     <CardFooter
       flexDir='column'
       gap={2}
@@ -135,6 +142,7 @@ export const Footer = () => {
         size='lg'
         width='full'
         onClick={handleConfirm}
+        isLoading={isLoading}
       >
         <Text translation={isModeratePriceImpact ? 'trade.tradeAnyway' : 'trade.confirmAndTrade'} />
       </Button>

--- a/src/components/MultiHopTrade/components/MultiHopTradeConfirm/hooks/useAllowance.tsx
+++ b/src/components/MultiHopTrade/components/MultiHopTradeConfirm/hooks/useAllowance.tsx
@@ -28,7 +28,7 @@ const queryKey = ({
     {
       accountNumber,
       allowanceContract,
-      blockNumber,
+      blockNumber: blockNumber?.toString(), // manual stringify of bigint since it's not JSON serializable by default
       chainId,
       assetId,
       accountId,

--- a/src/components/MultiHopTrade/components/MultiHopTradeConfirm/hooks/useIsApprovalInitiallyNeeded.tsx
+++ b/src/components/MultiHopTrade/components/MultiHopTradeConfirm/hooks/useIsApprovalInitiallyNeeded.tsx
@@ -43,18 +43,18 @@ export const useIsApprovalInitiallyNeeded = () => {
   const dispatch = useAppDispatch()
   const firstHop = useAppSelector(selectFirstHop)
   const secondHop = useAppSelector(selectSecondHop)
-  const FirstHopSellAssetAccountId = useAppSelector(selectFirstHopSellAccountId)
-  const SecondHopSellAssetAccountId = useAppSelector(selectSecondHopSellAccountId)
+  const firstHopSellAssetAccountId = useAppSelector(selectFirstHopSellAccountId)
+  const secondHopSellAssetAccountId = useAppSelector(selectSecondHopSellAccountId)
 
   const {
     isLoading: isFirstHopLoading,
     isApprovalInitiallyNeeded: isApprovalInitiallyNeededForFirstHop,
-  } = useIsApprovalInitiallyNeededForHop(firstHop, FirstHopSellAssetAccountId)
+  } = useIsApprovalInitiallyNeededForHop(firstHop, firstHopSellAssetAccountId)
 
   const {
     isLoading: isSecondHopLoading,
     isApprovalInitiallyNeeded: isApprovalInitiallyNeededForSecondHop,
-  } = useIsApprovalInitiallyNeededForHop(secondHop, SecondHopSellAssetAccountId)
+  } = useIsApprovalInitiallyNeededForHop(secondHop, secondHopSellAssetAccountId)
 
   useEffect(() => {
     if (isFirstHopLoading || (secondHop !== undefined && isSecondHopLoading)) return
@@ -72,4 +72,6 @@ export const useIsApprovalInitiallyNeeded = () => {
     isSecondHopLoading,
     secondHop,
   ])
+
+  return { isLoading: isFirstHopLoading || isSecondHopLoading }
 }

--- a/src/state/slices/tradeQuoteSlice/constants.ts
+++ b/src/state/slices/tradeQuoteSlice/constants.ts
@@ -12,7 +12,7 @@ const initialHopState = {
 }
 
 export const initialTradeExecutionState = {
-  state: TradeExecutionState.Previewing,
+  state: TradeExecutionState.Initializing,
   firstHop: initialHopState,
   secondHop: initialHopState,
 }

--- a/src/state/slices/tradeQuoteSlice/tradeQuoteSlice.ts
+++ b/src/state/slices/tradeQuoteSlice/tradeQuoteSlice.ts
@@ -47,9 +47,16 @@ export const tradeQuoteSlice = createSlice({
       state.confirmedQuote = undefined
       state.tradeExecution = initialTradeExecutionState
     },
+    setTradeInitialized: state => {
+      state.tradeExecution.state = TradeExecutionState.Previewing
+    },
     confirmTrade: state => {
       if (state.tradeExecution.state !== TradeExecutionState.Previewing) {
-        console.error('attempted to confirm an in-progress trade')
+        if (state.tradeExecution.state === TradeExecutionState.Initializing) {
+          console.error('attempted to confirm an uninitialized trade')
+        } else {
+          console.error('attempted to confirm an in-progress trade')
+        }
         return
       }
       state.tradeExecution.state = TradeExecutionState.FirstHop

--- a/src/state/slices/tradeQuoteSlice/types.ts
+++ b/src/state/slices/tradeQuoteSlice/types.ts
@@ -13,6 +13,7 @@ export enum HopExecutionState {
 }
 
 export enum TradeExecutionState {
+  Initializing = 'Initializing',
   Previewing = 'Previewing',
   FirstHop = 'FirstHop',
   SecondHop = 'SecondHop',


### PR DESCRIPTION
## Description

Fixes ability to proceed with a trade while approval requirements are still being fetched by applying a loading state to the button until everything is initialized.

## Pull Request Type

- [ ] :bug: Bug fix (Non-breaking Change: Fixes an issue)
- [ ] :hammer_and_wrench: Chore (Non-breaking Change: Doc updates, pkg upgrades, typos, etc..)
- [x] :nail_care: New Feature (Breaking/Non-breaking Change)

## Issue (if applicable)

NA

## Risk

Not production facing - low risk.

## Testing

Not required.

### Engineering

<!-----------------------------------------------------------------------------
Include sufficient information here for an engineer to test your PR. This may include how to test locally, in a built environment, changes to infrastructure etc.
------------------------------------------------------------------------------>

### Operations

<!-----------------------------------------------------------------------------
If your changes have a user-facing impact, describe how a non-technical QA team can functionally test your changes in a preview environment.

If they are not user-facing please describe how to test for any regressions that may occur.
------------------------------------------------------------------------------>

## Screenshots (if applicable)

Loading state while approvals are being checked
![image](https://github.com/shapeshift/web/assets/125113430/c6f1cb29-a86d-42c8-a223-737591983358)

Once approvals are loaded, loading state is cleared
![image](https://github.com/shapeshift/web/assets/125113430/4dc53c3d-9f26-469b-960b-002c1d5682c6)


