### PR TITLE
chore: enforce eth-only longtail to L1

### DIFF
--- a/src/lib/swapper/swappers/ThorchainSwapper/utils/getLongtailQuote.ts
+++ b/src/lib/swapper/swappers/ThorchainSwapper/utils/getLongtailQuote.ts
@@ -1,4 +1,4 @@
-import { avalancheChainId, ethChainId } from '@shapeshiftoss/caip'
+import { ethChainId } from '@shapeshiftoss/caip'
 import type { EvmChainId } from '@shapeshiftoss/chain-adapters'
 import { makeSwapErrorRight, type SwapErrorRight, SwapErrorType } from '@shapeshiftoss/swapper'
 import type { Result } from '@sniptt/monads'

--- a/src/lib/swapper/swappers/ThorchainSwapper/utils/getLongtailQuote.ts
+++ b/src/lib/swapper/swappers/ThorchainSwapper/utils/getLongtailQuote.ts
@@ -1,3 +1,4 @@
+import { avalancheChainId, ethChainId } from '@shapeshiftoss/caip'
 import type { EvmChainId } from '@shapeshiftoss/chain-adapters'
 import { makeSwapErrorRight, type SwapErrorRight, SwapErrorType } from '@shapeshiftoss/swapper'
 import type { Result } from '@sniptt/monads'
@@ -23,7 +24,20 @@ export const getLongtailToL1Quote = async (
   streamingInterval: number,
   assetsById: AssetsById,
 ): Promise<Result<ThorTradeQuote[], SwapErrorRight>> => {
-  // todo: early exit if Avalanche - UniV3 is only on Ethereum & BSC
+  /*
+    We only support ETH -> L1 for now.
+    We can later add BSC via UniV3, or Avalanche (e.g. via PancakeSwap)
+  */
+  if (input.sellAsset.chainId !== ethChainId) {
+    return Err(
+      makeSwapErrorRight({
+        message: `[getThorTradeQuote] - Unsupported chainId ${input.sellAsset.chainId}.`,
+        code: SwapErrorType.UNSUPPORTED_CHAIN,
+        details: { sellAssetChainId: input.sellAsset.chainId },
+      }),
+    )
+  }
+
   const chainAdapterManager = getChainAdapterManager()
   const sellChainId = input.sellAsset.chainId
   const nativeBuyAssetId = chainAdapterManager.get(sellChainId)?.getFeeAssetId()


### PR DESCRIPTION
## Description

The PoC implementation of longtail to L1 only supports swapping from longtail on Ethereum assets.
This PR ensures that we only get a longtail to L1 quote if the sell asset is on Ethereum.

## Pull Request Type

- [ ] :bug: Bug fix (Non-breaking Change: Fixes an issue)
- [x] :hammer_and_wrench: Chore (Non-breaking Change: Doc updates, pkg upgrades, typos, etc..)
- [ ] :nail_care: New Feature (Breaking/Non-breaking Change)

## Issue (if applicable)

N/A

## Risk

Small, this feature is still behind a flag, and this should only make the flagged feature safer.

## Testing

Nothing specific required at this time, only testing as part of the general release is fine.

### Engineering

☝️

### Operations

☝️

## Screenshots (if applicable)

N/A