### PR TITLE
fix: show thorchain error on longtail to l1

### DIFF
--- a/src/lib/swapper/swappers/ThorchainSwapper/utils/getLongtailQuote.ts
+++ b/src/lib/swapper/swappers/ThorchainSwapper/utils/getLongtailQuote.ts
@@ -115,22 +115,20 @@ export const getLongtailToL1Quote = async (
     TradeType.LongTailToL1,
   )
 
-  return thorchainQuotes
-    .mapErr(e => e) // getL1quote already returns a useful error, return that if it exists
-    .andThen(quotes => {
-      const updatedQuotes: ThorTradeQuote[] = quotes.map(q => ({
-        ...q,
-        router: AGGREGATOR_CONTRACT,
-        steps: q.steps.map(s => ({
-          ...s,
-          // This logic will need to be updated to support multi-hop, if that's ever implemented for THORChain
-          sellAmountIncludingProtocolFeesCryptoBaseUnit:
-            input.sellAmountIncludingProtocolFeesCryptoBaseUnit,
-          sellAsset: input.sellAsset,
-          allowanceContract: ALLOWANCE_CONTRACT,
-        })),
-      }))
+  return thorchainQuotes.andThen(quotes => {
+    const updatedQuotes: ThorTradeQuote[] = quotes.map(q => ({
+      ...q,
+      router: AGGREGATOR_CONTRACT,
+      steps: q.steps.map(s => ({
+        ...s,
+        // This logic will need to be updated to support multi-hop, if that's ever implemented for THORChain
+        sellAmountIncludingProtocolFeesCryptoBaseUnit:
+          input.sellAmountIncludingProtocolFeesCryptoBaseUnit,
+        sellAsset: input.sellAsset,
+        allowanceContract: ALLOWANCE_CONTRACT,
+      })),
+    }))
 
-      return Ok(updatedQuotes)
-    })
+    return Ok(updatedQuotes)
+  })
 }

--- a/src/lib/swapper/swappers/ThorchainSwapper/utils/getLongtailQuote.ts
+++ b/src/lib/swapper/swappers/ThorchainSwapper/utils/getLongtailQuote.ts
@@ -116,14 +116,7 @@ export const getLongtailToL1Quote = async (
   )
 
   return thorchainQuotes
-    .mapErr(e => {
-      console.error(e)
-      return makeSwapErrorRight({
-        message: 'makeSwapperAxiosServiceMonadic',
-        cause: e,
-        code: SwapErrorType.QUERY_FAILED,
-      })
-    })
+    .mapErr(e => e) // getL1quote already returns a useful error, return that if it exists
     .andThen(quotes => {
       const updatedQuotes: ThorTradeQuote[] = quotes.map(q => ({
         ...q,


### PR DESCRIPTION
## Description

For longtail to L1 swaps, passes through the error returned from `getL1quote`, if it exists, instead of returning a generic error.

This results in us correctly alerting the user that the sell amount is too low for longtail swaps.

## Pull Request Type

- [x] :bug: Bug fix (Non-breaking Change: Fixes an issue)
- [ ] :hammer_and_wrench: Chore (Non-breaking Change: Doc updates, pkg upgrades, typos, etc..)
- [ ] :nail_care: New Feature (Breaking/Non-breaking Change)

## Issue (if applicable)

N/A

## Risk

Small.

## Testing

When quoting a longtail swap we should now show the "Amount too small" error when the sell amount is not large enough.

### Engineering

☝️

### Operations

☝️

## Screenshots (if applicable)

<img width="438" alt="Screenshot 2023-12-11 at 10 30 11 am" src="https://github.com/shapeshift/web/assets/97164662/8db29e61-1765-4674-9e99-cb2e1e161316">

