### PR TITLE
feat: automatically progress trades when approvals are executed externally

### DIFF
--- a/src/components/MultiHopTrade/components/MultiHopTradeConfirm/components/ApprovalStep.tsx
+++ b/src/components/MultiHopTrade/components/MultiHopTradeConfirm/components/ApprovalStep.tsx
@@ -43,7 +43,7 @@ export const ApprovalStep = ({
 
   const {
     approval: { txHash, state: approvalTxState },
-  } = useAppSelector(selectHopExecutionMetadata)[hopIndex]
+  } = useAppSelector(state => selectHopExecutionMetadata(state, hopIndex))
 
   const isError = useMemo(
     () => approvalTxState === TransactionExecutionState.Failed,

--- a/src/components/MultiHopTrade/components/MultiHopTradeConfirm/components/Hop.tsx
+++ b/src/components/MultiHopTrade/components/MultiHopTradeConfirm/components/Hop.tsx
@@ -67,7 +67,7 @@ export const Hop = ({
     state: hopExecutionState,
     approval: { state: approvalTxState, isRequired: isApprovalInitiallyNeeded },
     swap: { state: swapTxState },
-  } = useAppSelector(selectHopExecutionMetadata)[hopIndex]
+  } = useAppSelector(state => selectHopExecutionMetadata(state, hopIndex))
 
   const isError = useMemo(
     () => [approvalTxState, swapTxState].includes(TransactionExecutionState.Failed),

--- a/src/components/MultiHopTrade/components/MultiHopTradeConfirm/components/HopTransactionStep.tsx
+++ b/src/components/MultiHopTrade/components/MultiHopTradeConfirm/components/HopTransactionStep.tsx
@@ -46,7 +46,7 @@ export const HopTransactionStep = ({
 
   const {
     swap: { state: swapTxState, sellTxHash, buyTxHash },
-  } = useAppSelector(selectHopExecutionMetadata)[hopIndex]
+  } = useAppSelector(state => selectHopExecutionMetadata(state, hopIndex))
 
   const isError = useMemo(() => swapTxState === TransactionExecutionState.Failed, [swapTxState])
 

--- a/src/components/MultiHopTrade/components/MultiHopTradeConfirm/hooks/useAllowance.tsx
+++ b/src/components/MultiHopTrade/components/MultiHopTradeConfirm/hooks/useAllowance.tsx
@@ -35,14 +35,11 @@ const queryKey = ({
     },
   ] as const
 
-export type UseAllowanceProps = {
-  sellAssetAccountId: AccountId | undefined
-  tradeQuoteStep: TradeQuoteStep | undefined
-  watch: boolean
-}
-
-// TODO: use this pattern for all allowance and trade execution hooks
-export function useAllowance({ sellAssetAccountId, tradeQuoteStep, watch }: UseAllowanceProps) {
+export function useAllowance(
+  tradeQuoteStep: TradeQuoteStep | undefined,
+  sellAssetAccountId: AccountId | undefined,
+  watch: boolean,
+) {
   const {
     state: { wallet },
   } = useWallet()

--- a/src/components/MultiHopTrade/components/MultiHopTradeConfirm/hooks/useAllowanceApproval.tsx
+++ b/src/components/MultiHopTrade/components/MultiHopTradeConfirm/hooks/useAllowanceApproval.tsx
@@ -1,13 +1,17 @@
-import { useCallback } from 'react'
+import { useCallback, useEffect } from 'react'
 import type { Hash } from 'viem'
 import { useApprovalTx } from 'components/MultiHopTrade/hooks/useAllowanceApproval/hooks/useApprovalTx'
 import { useErrorHandler } from 'hooks/useErrorToast/useErrorToast'
 import type { TradeQuoteStep } from 'lib/swapper/types'
 import { assertGetEvmChainAdapter, buildAndBroadcast } from 'lib/utils/evm'
 import { assertGetViemClient } from 'lib/viem-client'
+import { selectHopSellAccountId } from 'state/slices/tradeQuoteSlice/selectors'
 import { tradeQuoteSlice } from 'state/slices/tradeQuoteSlice/tradeQuoteSlice'
-import { useAppDispatch } from 'state/store'
+import { useAppDispatch, useAppSelector } from 'state/store'
 
+import { useIsApprovalNeeded } from './useIsApprovalNeeded'
+
+// handles allowance approval tx execution, fees, and state orchestration
 export const useAllowanceApproval = (
   tradeQuoteStep: TradeQuoteStep,
   hopIndex: number,
@@ -16,17 +20,34 @@ export const useAllowanceApproval = (
   const dispatch = useAppDispatch()
   const { showErrorToast } = useErrorHandler()
 
+  const sellAssetAccountId = useAppSelector(state => selectHopSellAccountId(state, hopIndex))
+
   const {
     approvalNetworkFeeCryptoBaseUnit,
     buildCustomTxInput,
     stopPolling: stopPollingBuildApprovalTx,
     isLoading,
-  } = useApprovalTx(tradeQuoteStep, hopIndex === 0, isExactAllowance)
+  } = useApprovalTx(tradeQuoteStep, hopIndex, isExactAllowance)
+
+  const { isLoading: isApprovalNeededLoading, isApprovalNeeded } = useIsApprovalNeeded(
+    tradeQuoteStep,
+    sellAssetAccountId,
+    true,
+  )
+
+  useEffect(() => {
+    // Mark the approval step complete if adequate allowance was found.
+    // This is deliberately disjoint to the approval transaction orchestration to allow users to
+    // complete an approval externally and have the app respond to the updated allowance on chain.
+    if (!isApprovalNeededLoading && !isApprovalNeeded) {
+      dispatch(tradeQuoteSlice.actions.setApprovalStepComplete({ hopIndex }))
+    }
+  }, [dispatch, hopIndex, isApprovalNeeded, isApprovalNeededLoading])
 
   const chainId = tradeQuoteStep.sellAsset.chainId
 
   const executeAllowanceApproval = useCallback(async () => {
-    if (isLoading) return
+    if (isLoading || !isApprovalNeeded) return
 
     stopPollingBuildApprovalTx()
     dispatch(tradeQuoteSlice.actions.setApprovalTxPending({ hopIndex }))
@@ -62,6 +83,7 @@ export const useAllowanceApproval = (
     chainId,
     dispatch,
     hopIndex,
+    isApprovalNeeded,
     isLoading,
     showErrorToast,
     stopPollingBuildApprovalTx,

--- a/src/components/MultiHopTrade/components/MultiHopTradeConfirm/hooks/useIsApprovalInitiallyNeeded.tsx
+++ b/src/components/MultiHopTrade/components/MultiHopTradeConfirm/hooks/useIsApprovalInitiallyNeeded.tsx
@@ -20,11 +20,11 @@ const useIsApprovalInitiallyNeededForHop = (
   const [watchIsApprovalNeeded, setWatchIsApprovalNeeded] = useState<boolean>(true)
   const [isApprovalInitiallyNeeded, setIsApprovalInitiallyNeeded] = useState<boolean | undefined>()
 
-  const { isLoading, isApprovalNeeded } = useIsApprovalNeeded({
+  const { isLoading, isApprovalNeeded } = useIsApprovalNeeded(
     tradeQuoteStep,
     sellAssetAccountId,
-    watch: watchIsApprovalNeeded,
-  })
+    watchIsApprovalNeeded,
+  )
 
   useEffect(() => {
     // stop polling on first result

--- a/src/components/MultiHopTrade/components/MultiHopTradeConfirm/hooks/useIsApprovalNeeded.tsx
+++ b/src/components/MultiHopTrade/components/MultiHopTradeConfirm/hooks/useIsApprovalNeeded.tsx
@@ -7,22 +7,12 @@ import { assertUnreachable } from 'lib/utils'
 
 import { GetAllowanceErr } from '../../../hooks/useAllowanceApproval/helpers'
 
-export type UseIsApprovalNeededProps = {
-  watch: boolean
-  tradeQuoteStep: TradeQuoteStep | undefined
-  sellAssetAccountId: AccountId | undefined
-}
-
-export const useIsApprovalNeeded = ({
-  watch,
-  tradeQuoteStep,
-  sellAssetAccountId,
-}: UseIsApprovalNeededProps) => {
-  const { isLoading, data } = useAllowance({
-    sellAssetAccountId,
-    tradeQuoteStep,
-    watch,
-  })
+export const useIsApprovalNeeded = (
+  tradeQuoteStep: TradeQuoteStep | undefined,
+  sellAssetAccountId: AccountId | undefined,
+  watch: boolean,
+) => {
+  const { isLoading, data } = useAllowance(tradeQuoteStep, sellAssetAccountId, watch)
 
   const isApprovalNeeded = useMemo(() => {
     if (tradeQuoteStep === undefined) return undefined

--- a/src/components/MultiHopTrade/components/MultiHopTradeConfirm/hooks/useThorStreamingProgress.tsx
+++ b/src/components/MultiHopTrade/components/MultiHopTradeConfirm/hooks/useThorStreamingProgress.tsx
@@ -68,7 +68,7 @@ export const useThorStreamingProgress = (
   const dispatch = useAppDispatch()
   const {
     swap: { sellTxHash, streamingSwap: streamingSwapMeta },
-  } = useAppSelector(selectHopExecutionMetadata)[hopIndex]
+  } = useAppSelector(state => selectHopExecutionMetadata(state, hopIndex))
 
   useEffect(() => {
     // don't start polling until we have a tx

--- a/src/components/MultiHopTrade/components/MultiHopTradeConfirm/hooks/useTradeExecution.tsx
+++ b/src/components/MultiHopTrade/components/MultiHopTradeConfirm/hooks/useTradeExecution.tsx
@@ -15,14 +15,11 @@ import { assertUnreachable } from 'lib/utils'
 import { assertGetCosmosSdkChainAdapter } from 'lib/utils/cosmosSdk'
 import { assertGetEvmChainAdapter, signAndBroadcast } from 'lib/utils/evm'
 import { assertGetUtxoChainAdapter } from 'lib/utils/utxo'
-import {
-  selectFirstHopSellAccountId,
-  selectPortfolioAccountMetadataByAccountId,
-} from 'state/slices/selectors'
+import { selectPortfolioAccountMetadataByAccountId } from 'state/slices/selectors'
 import {
   selectActiveQuote,
   selectActiveSwapperName,
-  selectSecondHopSellAccountId,
+  selectHopSellAccountId,
   selectTradeSlippagePercentageDecimal,
 } from 'state/slices/tradeQuoteSlice/selectors'
 import { tradeQuoteSlice } from 'state/slices/tradeQuoteSlice/tradeQuoteSlice'
@@ -34,9 +31,7 @@ export const useTradeExecution = (hopIndex: number) => {
   const slippageTolerancePercentageDecimal = useAppSelector(selectTradeSlippagePercentageDecimal)
   const { showErrorToast } = useErrorHandler()
 
-  const sellAssetAccountId = useAppSelector(
-    hopIndex === 0 ? selectFirstHopSellAccountId : selectSecondHopSellAccountId,
-  )
+  const sellAssetAccountId = useAppSelector(state => selectHopSellAccountId(state, hopIndex))
 
   const accountMetadata = useAppSelector(state =>
     selectPortfolioAccountMetadataByAccountId(state, { accountId: sellAssetAccountId }),

--- a/src/components/MultiHopTrade/hooks/useAllowanceApproval/hooks/useApprovalTx.tsx
+++ b/src/components/MultiHopTrade/hooks/useAllowanceApproval/hooks/useApprovalTx.tsx
@@ -6,8 +6,7 @@ import { usePoll } from 'hooks/usePoll/usePoll'
 import { useWallet } from 'hooks/useWallet/useWallet'
 import type { TradeQuoteStep } from 'lib/swapper/types'
 import { assertGetEvmChainAdapter } from 'lib/utils/evm'
-import { selectFirstHopSellAccountId } from 'state/slices/selectors'
-import { selectLastHopSellAccountId } from 'state/slices/tradeQuoteSlice/selectors'
+import { selectHopSellAccountId } from 'state/slices/tradeQuoteSlice/selectors'
 import { useAppSelector } from 'state/store'
 
 import { APPROVAL_POLL_INTERVAL_MILLISECONDS } from '../../constants'
@@ -15,7 +14,7 @@ import { getApprovalTxData } from '../helpers'
 
 export const useApprovalTx = (
   tradeQuoteStep: TradeQuoteStep,
-  isFirstHop: boolean,
+  hopIndex: number,
   isExactAllowance: boolean,
 ) => {
   const [approvalNetworkFeeCryptoBaseUnit, setApprovalNetworkFeeCryptoBaseUnit] = useState<
@@ -26,9 +25,8 @@ export const useApprovalTx = (
   const wallet = useWallet().state.wallet
   const { poll, cancelPolling: stopPolling } = usePoll()
 
-  const sellAssetAccountId = useAppSelector(
-    isFirstHop ? selectFirstHopSellAccountId : selectLastHopSellAccountId,
-  )
+  const sellAssetAccountId = useAppSelector(state => selectHopSellAccountId(state, hopIndex))
+
   // This accidentally works since all EVM chains share the same address, so there's no need
   // to call adapter.getAddress() later down the call stack
   const from = sellAssetAccountId ? fromAccountId(sellAssetAccountId).account : undefined

--- a/src/components/MultiHopTrade/hooks/useAllowanceApproval/hooks/useExecuteAllowanceApproval.tsx
+++ b/src/components/MultiHopTrade/hooks/useAllowanceApproval/hooks/useExecuteAllowanceApproval.tsx
@@ -8,8 +8,7 @@ import { usePoll } from 'hooks/usePoll/usePoll'
 import { useWallet } from 'hooks/useWallet/useWallet'
 import type { TradeQuoteStep } from 'lib/swapper/types'
 import { buildAndBroadcast, isEvmChainAdapter } from 'lib/utils/evm'
-import { selectFirstHopSellAccountId } from 'state/slices/selectors'
-import { selectLastHopSellAccountId } from 'state/slices/tradeQuoteSlice/selectors'
+import { selectHopSellAccountId } from 'state/slices/tradeQuoteSlice/selectors'
 import { useAppSelector } from 'state/store'
 
 import { APPROVAL_POLL_INTERVAL_MILLISECONDS } from '../../constants'
@@ -17,7 +16,7 @@ import { checkApprovalNeeded } from '../helpers'
 
 export const useExecuteAllowanceApproval = (
   tradeQuoteStep: TradeQuoteStep,
-  isFirstHop: boolean,
+  hopIndex: number,
   buildCustomTxInput?: evm.BuildCustomTxInput,
 ) => {
   const [txId, setTxId] = useState<string | undefined>()
@@ -26,9 +25,8 @@ export const useExecuteAllowanceApproval = (
   const { showErrorToast } = useErrorHandler()
   const wallet = useWallet().state.wallet
 
-  const sellAssetAccountId = useAppSelector(
-    isFirstHop ? selectFirstHopSellAccountId : selectLastHopSellAccountId,
-  )
+  const sellAssetAccountId = useAppSelector(state => selectHopSellAccountId(state, hopIndex))
+
   const executeAllowanceApproval = useCallback(async () => {
     setTxStatus(TxStatus.Pending)
 

--- a/src/components/MultiHopTrade/hooks/useAllowanceApproval/hooks/useIsApprovalNeeded.tsx
+++ b/src/components/MultiHopTrade/hooks/useAllowanceApproval/hooks/useIsApprovalNeeded.tsx
@@ -2,8 +2,7 @@ import { useEffect, useState } from 'react'
 import { usePoll } from 'hooks/usePoll/usePoll'
 import { useWallet } from 'hooks/useWallet/useWallet'
 import type { TradeQuoteStep } from 'lib/swapper/types'
-import { selectFirstHopSellAccountId } from 'state/slices/selectors'
-import { selectLastHopSellAccountId } from 'state/slices/tradeQuoteSlice/selectors'
+import { selectHopSellAccountId } from 'state/slices/tradeQuoteSlice/selectors'
 import { useAppSelector } from 'state/store'
 
 import { APPROVAL_POLL_INTERVAL_MILLISECONDS } from '../../constants'
@@ -13,8 +12,9 @@ export const useIsApprovalNeeded = (tradeQuoteStep: TradeQuoteStep, isFirstHop: 
   const [isApprovalNeeded, setIsApprovalNeeded] = useState<boolean | undefined>(undefined)
   const { poll } = usePoll()
   const wallet = useWallet().state.wallet
-  const sellAssetAccountId = useAppSelector(
-    isFirstHop ? selectFirstHopSellAccountId : selectLastHopSellAccountId,
+
+  const sellAssetAccountId = useAppSelector(state =>
+    selectHopSellAccountId(state, isFirstHop ? 0 : 1),
   )
 
   useEffect(() => {

--- a/src/components/MultiHopTrade/hooks/useAllowanceApproval/useAllowanceApproval.tsx
+++ b/src/components/MultiHopTrade/hooks/useAllowanceApproval/useAllowanceApproval.tsx
@@ -17,13 +17,13 @@ export const useAllowanceApproval = (
     approvalNetworkFeeCryptoBaseUnit,
     buildCustomTxInput,
     stopPolling: stopPollingBuildApprovalTx,
-  } = useApprovalTx(tradeQuoteStep, isFirstHop, isExactAllowance)
+  } = useApprovalTx(tradeQuoteStep, isFirstHop ? 0 : 1, isExactAllowance)
 
   const {
     executeAllowanceApproval: _executeAllowanceApproval,
     txId: approvalTxId,
     txStatus: approvalTxStatus,
-  } = useExecuteAllowanceApproval(tradeQuoteStep, isFirstHop, buildCustomTxInput)
+  } = useExecuteAllowanceApproval(tradeQuoteStep, isFirstHop ? 0 : 1, buildCustomTxInput)
 
   const executeAllowanceApproval = useCallback(() => {
     stopPollingBuildApprovalTx()

--- a/src/state/slices/tradeQuoteSlice/selectors.ts
+++ b/src/state/slices/tradeQuoteSlice/selectors.ts
@@ -509,20 +509,6 @@ export const selectFirstHopBuyAccountId = createSelector(
   },
 )
 
-// selects the account ID we're selling from for the last hop
-export const selectLastHopSellAccountId = createSelector(
-  selectIsActiveQuoteMultiHop,
-  selectFirstHopSellAccountId,
-  selectFirstHopBuyAccountId,
-  (isMultiHopTrade, firstHopSellAccountId, firstHopBuyAccountId) => {
-    // single hop trade - same as first hop sell account id
-    if (!isMultiHopTrade) return firstHopSellAccountId
-
-    // multi hop trade - the second hop sell account id is the same as the first hop buy account id
-    return firstHopBuyAccountId
-  },
-)
-
 // selects the account ID we're selling from for the second hop if it exists. This is different to "last hop"
 export const selectSecondHopSellAccountId = createSelector(
   selectIsActiveQuoteMultiHop,
@@ -536,9 +522,30 @@ export const selectSecondHopSellAccountId = createSelector(
   },
 )
 
+// selects the account ID we're selling from for the last hop
+export const selectLastHopSellAccountId = createSelector(
+  selectIsActiveQuoteMultiHop,
+  selectFirstHopSellAccountId,
+  selectSecondHopSellAccountId,
+  (isMultiHopTrade, firstHopSellAccountId, secondHopSellAccountId) => {
+    return isMultiHopTrade ? firstHopSellAccountId : secondHopSellAccountId
+  },
+)
+
+// selects the account ID we're selling from for the given hop
+export const selectHopSellAccountId = createSelector(
+  selectFirstHopSellAccountId,
+  selectSecondHopSellAccountId,
+  (_state: ReduxState, hopIndex: number) => hopIndex,
+  (firstHopSellAccountId, secondHopSellAccountId, hopIndex) => {
+    return hopIndex === 0 ? firstHopSellAccountId : secondHopSellAccountId
+  },
+)
+
 export const selectHopExecutionMetadata = createDeepEqualOutputSelector(
   selectTradeQuoteSlice,
-  swappers => {
-    return [swappers.tradeExecution.firstHop, swappers.tradeExecution.secondHop]
+  (_state: ReduxState, hopIndex: number) => hopIndex,
+  (swappers, hopIndex) => {
+    return hopIndex === 0 ? swappers.tradeExecution.firstHop : swappers.tradeExecution.secondHop
   },
 )

--- a/src/state/slices/tradeQuoteSlice/tradeQuoteSlice.ts
+++ b/src/state/slices/tradeQuoteSlice/tradeQuoteSlice.ts
@@ -75,10 +75,16 @@ export const tradeQuoteSlice = createSlice({
       const key = hopIndex === 0 ? 'firstHop' : 'secondHop'
       state.tradeExecution[key].approval.state = TransactionExecutionState.Failed
     },
+    // marks the approval tx as complete, but the allowance check needs to pass before proceeding to swap step
     setApprovalTxComplete: (state, action: PayloadAction<{ hopIndex: number }>) => {
       const { hopIndex } = action.payload
       const key = hopIndex === 0 ? 'firstHop' : 'secondHop'
       state.tradeExecution[key].approval.state = TransactionExecutionState.Complete
+    },
+    // progresses the hop to the swap step after the allowance check has passed
+    setApprovalStepComplete: (state, action: PayloadAction<{ hopIndex: number }>) => {
+      const { hopIndex } = action.payload
+      const key = hopIndex === 0 ? 'firstHop' : 'secondHop'
       state.tradeExecution[key].state = HopExecutionState.AwaitingSwap
     },
     setSwapTxPending: (state, action: PayloadAction<{ hopIndex: number }>) => {


### PR DESCRIPTION
## Description

Decouples approval tx completion from trade progression by allowing the trade to proceed if an allowance approval was executed external to this app (i.e approval was needed, and user did the approval elsewhere). Loading state is preserved while executing an approval, but is not required for the trade to progress as long as adequate allowance was found on-chain.

## Pull Request Type

- [ ] :bug: Bug fix (Non-breaking Change: Fixes an issue)
- [ ] :hammer_and_wrench: Chore (Non-breaking Change: Doc updates, pkg upgrades, typos, etc..)
- [x] :nail_care: New Feature (Breaking/Non-breaking Change)

## Issue (if applicable)

closes #3331

## Risk

Risk of allowance approvals broken in single-hop and multi-hop UIs.

## Testing

Check allowance approvals are working for the existing single-hop trade UI. Multi-hop approvals will be tested in an upcoming pre-release test.

### Engineering



### Operations



## Screenshots (if applicable)

On the left, the multi-hop ui is waiting for the user to execute the allowance approval, but is also checking on-chain in case the user approves in a different app. On the right, we're using prod to execute the allowance. Notice that as soon as the approval is see on-chain the multi-hop UI proceeds to the next step. Note the network polling based on new blocks, and note that polling stops when the approval is seen.

https://github.com/shapeshift/web/assets/125113430/3f2a106c-5b98-404f-981b-25781c008112




