### PR TITLE
chore: cleanup unknown double assertions relating to chain adapters

### DIFF
--- a/packages/chain-adapters/src/api.ts
+++ b/packages/chain-adapters/src/api.ts
@@ -1,5 +1,5 @@
 import type { AssetId, ChainId } from '@shapeshiftoss/caip'
-import type { BIP44Params, UtxoAccountType } from '@shapeshiftoss/types'
+import type { BIP44Params, KnownChainIds, UtxoAccountType } from '@shapeshiftoss/types'
 
 import type {
   Account,
@@ -23,7 +23,7 @@ import type {
 /**
  * Type alias for a Map that can be used to manage instances of ChainAdapters
  */
-export type ChainAdapterManager = Map<ChainId, ChainAdapter<ChainId>>
+export type ChainAdapterManager = Map<ChainId, ChainAdapter<KnownChainIds>>
 
 export type ChainAdapter<T extends ChainId> = {
   /**

--- a/src/components/AuroraBackground.tsx
+++ b/src/components/AuroraBackground.tsx
@@ -38,7 +38,7 @@ const canvasStyle: CSSProperties = {
 }
 
 export const AuroraBackground: React.FC = props => {
-  const canvasRefB = useRef(null)
+  const canvasRefB = useRef<HTMLCanvasElement>(null)
 
   useEffect(() => {
     let center = [0, 0]
@@ -47,9 +47,12 @@ export const AuroraBackground: React.FC = props => {
     let rayProps: Float32Array
     let animationFrameId: number
     const canvasA = document.createElement('canvas')
-    const canvasB: HTMLCanvasElement = canvasRefB.current as unknown as HTMLCanvasElement
-    const ctxA = canvasA.getContext('2d') as unknown as CanvasRenderingContext2D
-    const ctxB = canvasB.getContext('2d') as unknown as CanvasRenderingContext2D
+    const canvasB: HTMLCanvasElement | null = canvasRefB.current
+    const ctxA: CanvasRenderingContext2D | null = canvasA.getContext('2d')
+    const ctxB: CanvasRenderingContext2D | null =
+      canvasB !== null ? canvasB.getContext('2d') : canvasB
+
+    if (canvasB === null || ctxA === null || ctxB === null) return
 
     const setup = () => {
       resize()

--- a/src/components/Layout/Header/NavBar/ChainMenu.tsx
+++ b/src/components/Layout/Header/NavBar/ChainMenu.tsx
@@ -15,7 +15,6 @@ import {
 } from '@chakra-ui/react'
 import type { ChainId } from '@shapeshiftoss/caip'
 import { fromChainId, gnosisChainId } from '@shapeshiftoss/caip'
-import type { EvmBaseAdapter, EvmChainId } from '@shapeshiftoss/chain-adapters'
 import type { ETHWallet } from '@shapeshiftoss/hdwallet-core'
 import { supportsEthSwitchChain } from '@shapeshiftoss/hdwallet-core'
 import { utils } from 'ethers'
@@ -26,6 +25,7 @@ import { CircleIcon } from 'components/Icons/Circle'
 import { getChainAdapterManager } from 'context/PluginProvider/chainAdapterSingleton'
 import { useEvm } from 'hooks/useEvm/useEvm'
 import { useWallet } from 'hooks/useWallet/useWallet'
+import { assertGetEvmChainAdapter } from 'lib/utils/evm'
 import { selectAssetById, selectAssets } from 'state/slices/selectors'
 import { useAppSelector } from 'state/store'
 
@@ -92,13 +92,7 @@ export const ChainMenu = memo((props: ChainMenuProps) => {
           throw new Error(`Unsupported EVM network: ${requestedEthNetwork}`)
         }
 
-        const requestedChainChainAdapter = chainAdapterManager.get(requestedChainId) as unknown as
-          | EvmBaseAdapter<EvmChainId>
-          | undefined
-
-        if (!requestedChainChainAdapter) {
-          throw new Error(`No chain adapter found for: ${requestedChainId}`)
-        }
+        const requestedChainChainAdapter = assertGetEvmChainAdapter(requestedChainId)
 
         const requestedChainFeeAssetId = requestedChainChainAdapter.getFeeAssetId()
         const requestedChainFeeAsset = assets[requestedChainFeeAssetId]
@@ -128,7 +122,7 @@ export const ChainMenu = memo((props: ChainMenuProps) => {
         console.error(e)
       }
     },
-    [assets, chainAdapterManager, getChainIdFromEthNetwork, load, setEthNetwork, state.wallet],
+    [assets, getChainIdFromEthNetwork, load, setEthNetwork, state.wallet],
   )
 
   const currentChainNativeAssetId = useMemo(

--- a/src/components/MultiHopTrade/hooks/useGetTradeQuotes/getTradeQuoteArgs.ts
+++ b/src/components/MultiHopTrade/hooks/useGetTradeQuotes/getTradeQuoteArgs.ts
@@ -1,4 +1,3 @@
-import type { EvmChainAdapter, UtxoChainAdapter } from '@shapeshiftoss/chain-adapters'
 import type { HDWallet } from '@shapeshiftoss/hdwallet-core'
 import { supportsETH } from '@shapeshiftoss/hdwallet-core'
 import type { GetTradeQuoteInput } from '@shapeshiftoss/swapper'
@@ -9,8 +8,9 @@ import {
   isUtxoSwap,
 } from 'components/MultiHopTrade/hooks/useGetTradeQuotes/typeGuards'
 import type { TradeQuoteInputCommonArgs } from 'components/MultiHopTrade/types'
-import { getChainAdapterManager } from 'context/PluginProvider/chainAdapterSingleton'
 import { toBaseUnit } from 'lib/math'
+import { assertGetEvmChainAdapter } from 'lib/utils/evm'
+import { assertGetUtxoChainAdapter } from 'lib/utils/utxo'
 
 export type GetTradeQuoteInputArgs = {
   sellAsset: Asset
@@ -64,9 +64,7 @@ export const getTradeQuoteArgs = async ({
   }
   if (isEvmSwap(sellAsset?.chainId) || isCosmosSdkSwap(sellAsset?.chainId)) {
     const supportsEIP1559 = supportsETH(wallet) && (await wallet.ethSupportsEIP1559())
-    const sellAssetChainAdapter = getChainAdapterManager().get(
-      sellAsset.chainId,
-    ) as unknown as EvmChainAdapter
+    const sellAssetChainAdapter = assertGetEvmChainAdapter(sellAsset.chainId)
     const sendAddress = await sellAssetChainAdapter.getAddress({
       accountNumber: sellAccountNumber,
       wallet,
@@ -81,9 +79,7 @@ export const getTradeQuoteArgs = async ({
     }
   } else if (isUtxoSwap(sellAsset?.chainId)) {
     if (!sellAccountType) return
-    const sellAssetChainAdapter = getChainAdapterManager().get(
-      sellAsset.chainId,
-    ) as unknown as UtxoChainAdapter
+    const sellAssetChainAdapter = assertGetUtxoChainAdapter(sellAsset.chainId)
     const sendAddress = await sellAssetChainAdapter.getAddress({
       accountNumber: sellAccountNumber,
       wallet,

--- a/src/components/MultiHopTrade/hooks/useTradeExecution/helpers.ts
+++ b/src/components/MultiHopTrade/hooks/useTradeExecution/helpers.ts
@@ -1,9 +1,9 @@
 import type { ChainId } from '@shapeshiftoss/caip'
-import type { UtxoChainAdapter } from '@shapeshiftoss/chain-adapters'
 import type { HDWallet } from '@shapeshiftoss/hdwallet-core'
 import type { FromOrXpub } from '@shapeshiftoss/swapper'
 import type { AccountMetadata } from '@shapeshiftoss/types'
-import { getChainAdapterManager } from 'context/PluginProvider/chainAdapterSingleton'
+import { assertGetChainAdapter } from 'lib/utils'
+import { assertGetUtxoChainAdapter } from 'lib/utils/utxo'
 import { isUtxoChainId } from 'state/slices/portfolioSlice/utils'
 
 export type WithFromOrXpubParams = {
@@ -19,23 +19,17 @@ export const withFromOrXpub =
     { chainId, accountMetadata, wallet }: WithFromOrXpubParams,
     fnParams: Omit<P, 'from' | 'xpub'>,
   ): Promise<T> => {
-    const chainAdapterManager = getChainAdapterManager()
-    const adapter = chainAdapterManager.get(chainId)
-    if (!adapter) throw new Error(`No adapter for ChainId: ${chainId}`)
-
     const accountNumber = accountMetadata.bip44Params.accountNumber
 
     if (isUtxoChainId(chainId)) {
       const accountType = accountMetadata.accountType
       if (!accountType) throw new Error('Account number required')
-      const { xpub } = await (adapter as unknown as UtxoChainAdapter).getPublicKey(
-        wallet,
-        accountNumber,
-        accountType,
-      )
+      const adapter = assertGetUtxoChainAdapter(chainId)
+      const { xpub } = await adapter.getPublicKey(wallet, accountNumber, accountType)
 
       return wrappedFunction({ ...fnParams, xpub } as P)
     } else {
+      const adapter = assertGetChainAdapter(chainId)
       const from = await adapter.getAddress({ wallet, accountNumber })
       return wrappedFunction({ ...fnParams, from } as P)
     }

--- a/src/components/Sweep.tsx
+++ b/src/components/Sweep.tsx
@@ -1,14 +1,13 @@
 import { Box, Button, Divider, Flex, Skeleton, Stack, Text as CText } from '@chakra-ui/react'
 import { type AccountId, type AssetId, fromAssetId } from '@shapeshiftoss/caip'
-import type { UtxoBaseAdapter, UtxoChainId } from '@shapeshiftoss/chain-adapters'
 import { FeeDataKey } from '@shapeshiftoss/chain-adapters'
 import { useCallback, useEffect, useState } from 'react'
 import { useTranslate } from 'react-polyglot'
 import { Row } from 'components/Row/Row'
-import { getChainAdapterManager } from 'context/PluginProvider/chainAdapterSingleton'
 import { useWallet } from 'hooks/useWallet/useWallet'
 import { fromBaseUnit } from 'lib/math'
 import { sleep } from 'lib/poll/poll'
+import { assertGetUtxoChainAdapter } from 'lib/utils/utxo'
 import { useGetEstimatedFeesQuery } from 'pages/Lending/hooks/useGetEstimatedFeesQuery'
 import { selectAssetById } from 'state/slices/selectors'
 import { useAppSelector } from 'state/store'
@@ -90,7 +89,7 @@ export const Sweep = ({
     }
   }, [accountId, assetId, estimatedFeesData, fromAddress, wallet])
 
-  const adapter = getChainAdapterManager().get(fromAssetId(assetId).chainId)
+  const adapter = assertGetUtxoChainAdapter(fromAssetId(assetId).chainId)
 
   useEffect(() => {
     if (!adapter || !fromAddress) return
@@ -99,7 +98,7 @@ export const Sweep = ({
     if (!txId) return
     ;(async () => {
       await sleep(15_000)
-      const utxos = await (adapter as unknown as UtxoBaseAdapter<UtxoChainId>).getUtxos({
+      const utxos = await adapter.getUtxos({
         pubkey: fromAddress,
       })
       if (utxos.some(utxo => utxo.txid === txId)) handleSwepSeen()

--- a/src/context/PluginProvider/PluginProvider.tsx
+++ b/src/context/PluginProvider/PluginProvider.tsx
@@ -59,7 +59,7 @@ export const PluginProvider = ({ children }: PluginProviderProps): JSX.Element =
     let pluginRoutes: Route[] = []
 
     // newly registered will be default + what comes from plugins
-    const newChainAdapters: { [k in ChainId]?: () => ChainAdapter<ChainId> } = {}
+    const newChainAdapters: { [k in ChainId]?: () => ChainAdapter<KnownChainIds> } = {}
 
     // register providers from each plugin
     for (const plugin of pluginManager.values()) {

--- a/src/features/defi/providers/cosmos/components/CosmosManager/Claim/CosmosClaim.tsx
+++ b/src/features/defi/providers/cosmos/components/CosmosManager/Claim/CosmosClaim.tsx
@@ -1,7 +1,6 @@
 import { Center, CircularProgress } from '@chakra-ui/react'
 import type { AccountId } from '@shapeshiftoss/caip'
 import { toAssetId } from '@shapeshiftoss/caip'
-import type { CosmosSdkBaseAdapter, CosmosSdkChainId } from '@shapeshiftoss/chain-adapters'
 import { DefiModalContent } from 'features/defi/components/DefiModal/DefiModalContent'
 import { DefiModalHeader } from 'features/defi/components/DefiModal/DefiModalHeader'
 import type {
@@ -15,9 +14,9 @@ import { useTranslate } from 'react-polyglot'
 import type { AccountDropdownProps } from 'components/AccountDropdown/AccountDropdown'
 import type { DefiStepProps } from 'components/DeFi/components/Steps'
 import { Steps } from 'components/DeFi/components/Steps'
-import { getChainAdapterManager } from 'context/PluginProvider/chainAdapterSingleton'
 import { useBrowserRouter } from 'hooks/useBrowserRouter/useBrowserRouter'
 import { useWallet } from 'hooks/useWallet/useWallet'
+import { assertGetCosmosSdkChainAdapter } from 'lib/utils/cosmosSdk'
 import { serializeUserStakingId, toValidatorId } from 'state/slices/opportunitiesSlice/utils'
 import {
   selectAssetById,
@@ -69,10 +68,7 @@ export const CosmosClaim: React.FC<CosmosClaimProps> = ({
     try {
       if (!earnOpportunityData) return
 
-      const chainAdapterManager = getChainAdapterManager()
-      const chainAdapter = chainAdapterManager.get(
-        chainId,
-      ) as unknown as CosmosSdkBaseAdapter<CosmosSdkChainId>
+      const chainAdapter = assertGetCosmosSdkChainAdapter(chainId)
       if (!(walletState.wallet && validatorAddress && chainAdapter)) return
       dispatch({
         type: CosmosClaimActionType.SET_OPPORTUNITY,

--- a/src/lib/account/cosmosSdk.ts
+++ b/src/lib/account/cosmosSdk.ts
@@ -1,9 +1,7 @@
 import { CHAIN_REFERENCE, fromChainId, toAccountId } from '@shapeshiftoss/caip'
-import type { CosmosSdkChainId } from '@shapeshiftoss/chain-adapters'
-import { cosmosSdkChainIds } from '@shapeshiftoss/chain-adapters'
 import { supportsCosmos, supportsThorchain } from '@shapeshiftoss/hdwallet-core'
 import type { AccountMetadataById } from '@shapeshiftoss/types'
-import { getChainAdapterManager } from 'context/PluginProvider/chainAdapterSingleton'
+import { assertGetCosmosSdkChainAdapter } from 'lib/utils/cosmosSdk'
 
 import type { DeriveAccountIdsAndMetadata } from './account'
 
@@ -12,10 +10,8 @@ export const deriveCosmosSdkAccountIdsAndMetadata: DeriveAccountIdsAndMetadata =
   const result = await (async () => {
     let acc: AccountMetadataById = {}
     for (const chainId of chainIds) {
-      if (!cosmosSdkChainIds.includes(chainId as CosmosSdkChainId))
-        throw new Error(`${chainId} does not exist in ${cosmosSdkChainIds}`)
       const { chainReference } = fromChainId(chainId)
-      const adapter = getChainAdapterManager().get(chainId)!
+      const adapter = assertGetCosmosSdkChainAdapter(chainId)
       if (chainReference === CHAIN_REFERENCE.CosmosHubMainnet) {
         if (!supportsCosmos(wallet)) continue
       }

--- a/src/lib/account/evm.ts
+++ b/src/lib/account/evm.ts
@@ -1,6 +1,4 @@
 import { CHAIN_REFERENCE, fromChainId, toAccountId } from '@shapeshiftoss/caip'
-import type { EvmChainId } from '@shapeshiftoss/chain-adapters'
-import { evmChainIds } from '@shapeshiftoss/chain-adapters'
 import {
   supportsArbitrum,
   supportsArbitrumNova,
@@ -12,7 +10,7 @@ import {
   supportsPolygon,
 } from '@shapeshiftoss/hdwallet-core'
 import type { AccountMetadataById } from '@shapeshiftoss/types'
-import { getChainAdapterManager } from 'context/PluginProvider/chainAdapterSingleton'
+import { assertGetEvmChainAdapter } from 'lib/utils/evm'
 
 import type { DeriveAccountIdsAndMetadata } from './account'
 
@@ -22,11 +20,8 @@ export const deriveEvmAccountIdsAndMetadata: DeriveAccountIdsAndMetadata = async
   const result = await (async () => {
     let acc: AccountMetadataById = {}
     for (const chainId of chainIds) {
-      if (!evmChainIds.includes(chainId as EvmChainId))
-        throw new Error(`${chainId} does not exist in ${evmChainIds}`)
-
       const { chainReference } = fromChainId(chainId)
-      const adapter = getChainAdapterManager().get(chainId)!
+      const adapter = assertGetEvmChainAdapter(chainId)
 
       if (chainReference === CHAIN_REFERENCE.EthereumMainnet) {
         if (!supportsETH(wallet)) continue

--- a/src/lib/account/utxo.ts
+++ b/src/lib/account/utxo.ts
@@ -1,5 +1,5 @@
 import { toAccountId } from '@shapeshiftoss/caip'
-import type { UtxoBaseAdapter, UtxoChainId } from '@shapeshiftoss/chain-adapters'
+import type { UtxoChainId } from '@shapeshiftoss/chain-adapters'
 import {
   convertXpubVersion,
   toRootDerivationPath,
@@ -10,7 +10,7 @@ import { bip32ToAddressNList, supportsBTC } from '@shapeshiftoss/hdwallet-core'
 import { MetaMaskShapeShiftMultiChainHDWallet } from '@shapeshiftoss/hdwallet-shapeshift-multichain'
 import type { AccountMetadataById } from '@shapeshiftoss/types'
 import { UtxoAccountType } from '@shapeshiftoss/types'
-import { getChainAdapterManager } from 'context/PluginProvider/chainAdapterSingleton'
+import { assertGetUtxoChainAdapter } from 'lib/utils/utxo'
 
 import type { DeriveAccountIdsAndMetadata } from './account'
 
@@ -22,9 +22,7 @@ export const deriveUtxoAccountIdsAndMetadata: DeriveAccountIdsAndMetadata = asyn
     for (const chainId of chainIds) {
       if (!utxoChainIds.includes(chainId as UtxoChainId))
         throw new Error(`${chainId} does not exist in ${utxoChainIds}`)
-      const adapter = getChainAdapterManager().get(
-        chainId,
-      ) as unknown as UtxoBaseAdapter<UtxoChainId>
+      const adapter = assertGetUtxoChainAdapter(chainId)
 
       let supportedAccountTypes = adapter.getSupportedAccountTypes()
       if (wallet instanceof MetaMaskShapeShiftMultiChainHDWallet) {

--- a/src/lib/swapper/swappers/ThorchainSwapper/utils/test-data/setupThorswapDeps.ts
+++ b/src/lib/swapper/swappers/ThorchainSwapper/utils/test-data/setupThorswapDeps.ts
@@ -38,6 +38,6 @@ export const mockChainAdapterManager: ChainAdapterManager = new Map([
           },
         }),
       ),
-    } as unknown as ChainAdapter<'eip155'>,
+    } as unknown as ChainAdapter<KnownChainIds.EthereumMainnet>,
   ],
 ])

--- a/src/lib/utils/cosmosSdk.ts
+++ b/src/lib/utils/cosmosSdk.ts
@@ -1,7 +1,11 @@
 import type { ChainId } from '@shapeshiftoss/caip'
-import type { CosmosSdkChainAdapter, CosmosSdkChainId } from '@shapeshiftoss/chain-adapters'
+import type {
+  CosmosSdkChainAdapter,
+  CosmosSdkChainId,
+  thorchain,
+} from '@shapeshiftoss/chain-adapters'
 import { cosmosSdkChainIds } from '@shapeshiftoss/chain-adapters'
-import type { KnownChainIds } from '@shapeshiftoss/types'
+import { KnownChainIds } from '@shapeshiftoss/types'
 import { getChainAdapterManager } from 'context/PluginProvider/chainAdapterSingleton'
 
 export const isCosmosSdkChainAdapter = (
@@ -23,4 +27,8 @@ export const assertGetCosmosSdkChainAdapter = (
   }
 
   return adapter
+}
+
+export const assertGetThorchainChainAdapter = (): thorchain.ChainAdapter => {
+  return assertGetCosmosSdkChainAdapter(KnownChainIds.ThorchainMainnet) as thorchain.ChainAdapter
 }

--- a/src/lib/utils/evm.ts
+++ b/src/lib/utils/evm.ts
@@ -7,13 +7,9 @@ import type {
   SignTx,
 } from '@shapeshiftoss/chain-adapters'
 import { evmChainIds } from '@shapeshiftoss/chain-adapters'
-import type { ETHSignTx, HDWallet } from '@shapeshiftoss/hdwallet-core'
+import type { HDWallet } from '@shapeshiftoss/hdwallet-core'
 import { supportsETH } from '@shapeshiftoss/hdwallet-core'
-import type {
-  EvmTransactionExecutionProps,
-  EvmTransactionRequest,
-  ExecuteTradeArgs,
-} from '@shapeshiftoss/swapper'
+import type { EvmTransactionExecutionProps, EvmTransactionRequest } from '@shapeshiftoss/swapper'
 import type { KnownChainIds } from '@shapeshiftoss/types'
 import { TxStatus } from '@shapeshiftoss/unchained-client'
 import { getTxStatus } from '@shapeshiftoss/unchained-client/dist/evm'
@@ -270,23 +266,6 @@ export const assertGetEvmChainAdapter = (chainId: ChainId | KnownChainIds): EvmC
   }
 
   return adapter
-}
-
-export const executeEvmTrade = ({
-  txToSign,
-  wallet,
-  chainId,
-  senderAddress,
-  receiverAddress,
-}: ExecuteTradeArgs) => {
-  const adapter = assertGetEvmChainAdapter(chainId)
-  return signAndBroadcast({
-    adapter,
-    wallet,
-    txToSign: txToSign as ETHSignTx,
-    senderAddress,
-    receiverAddress,
-  })
 }
 
 export const executeEvmTransaction = (

--- a/src/lib/utils/index.ts
+++ b/src/lib/utils/index.ts
@@ -1,12 +1,13 @@
 import { skipToken } from '@reduxjs/toolkit/dist/query'
-import type { AssetReference } from '@shapeshiftoss/caip'
-import { ASSET_REFERENCE } from '@shapeshiftoss/caip'
+import type { AssetReference, ChainId, ChainNamespace } from '@shapeshiftoss/caip'
+import { ASSET_REFERENCE, fromChainId } from '@shapeshiftoss/caip'
+import type { ChainAdapter } from '@shapeshiftoss/chain-adapters'
 import type { HDWallet } from '@shapeshiftoss/hdwallet-core'
 import type { KeepKeyHDWallet } from '@shapeshiftoss/hdwallet-keepkey'
 import type { KeplrHDWallet } from '@shapeshiftoss/hdwallet-keplr'
 import type { NativeHDWallet } from '@shapeshiftoss/hdwallet-native'
 import type { WalletConnectV2HDWallet } from '@shapeshiftoss/hdwallet-walletconnectv2'
-import type { NestedArray } from '@shapeshiftoss/types'
+import type { KnownChainIds, NestedArray } from '@shapeshiftoss/types'
 import type { Result } from '@sniptt/monads'
 import { Err, Ok } from '@sniptt/monads'
 import crypto from 'crypto-browserify'
@@ -15,6 +16,7 @@ import difference from 'lodash/difference'
 import intersection from 'lodash/intersection'
 import isUndefined from 'lodash/isUndefined'
 import union from 'lodash/union'
+import { getChainAdapterManager } from 'context/PluginProvider/chainAdapterSingleton'
 
 export const isKeepKeyHDWallet = (wallet: HDWallet): wallet is KeepKeyHDWallet => {
   return wallet.getVendor() === 'KeepKey'
@@ -216,4 +218,29 @@ export const timeout = <Left, Right>(
       }, timeoutMs),
     ),
   ])
+}
+
+export const getSupportedChainIdsByChainNamespace = () => {
+  return Array.from(getChainAdapterManager().keys()).reduce<Record<ChainNamespace, ChainId[]>>(
+    (acc, chainId) => {
+      const { chainNamespace } = fromChainId(chainId)
+      if (!acc[chainNamespace]) acc[chainNamespace] = []
+      acc[chainNamespace].push(chainId)
+      return acc
+    },
+    {} as Record<ChainNamespace, ChainId[]>,
+  )
+}
+
+export const assertGetChainAdapter = (
+  chainId: ChainId | KnownChainIds,
+): ChainAdapter<KnownChainIds> => {
+  const chainAdapterManager = getChainAdapterManager()
+  const adapter = chainAdapterManager.get(chainId)
+
+  if (adapter === undefined) {
+    throw Error(`chain adapter not found for chain id ${chainId}`)
+  }
+
+  return adapter as unknown as ChainAdapter<KnownChainIds>
 }

--- a/src/lib/utils/index.ts
+++ b/src/lib/utils/index.ts
@@ -242,5 +242,5 @@ export const assertGetChainAdapter = (
     throw Error(`chain adapter not found for chain id ${chainId}`)
   }
 
-  return adapter as unknown as ChainAdapter<KnownChainIds>
+  return adapter
 }

--- a/src/lib/utils/thorchain/index.ts
+++ b/src/lib/utils/thorchain/index.ts
@@ -1,6 +1,5 @@
 import type { AccountId } from '@shapeshiftoss/caip'
 import { type AssetId, bchChainId, fromAccountId, fromAssetId } from '@shapeshiftoss/caip'
-import type { UtxoBaseAdapter, UtxoChainId } from '@shapeshiftoss/chain-adapters'
 import type { HDWallet } from '@shapeshiftoss/hdwallet-core'
 import type { AccountMetadata, Asset } from '@shapeshiftoss/types'
 import { TxStatus } from '@shapeshiftoss/unchained-client'
@@ -21,6 +20,7 @@ import { thorService } from 'lib/swapper/swappers/ThorchainSwapper/utils/thorSer
 import type { getThorchainSaversPosition } from 'state/slices/opportunitiesSlice/resolvers/thorchainsavers/utils'
 import { isUtxoAccountId, isUtxoChainId } from 'state/slices/portfolioSlice/utils'
 
+import { assertGetUtxoChainAdapter } from '../utxo'
 import { THOR_PRECISION } from './constants'
 import type { getThorchainLendingPosition } from './lending'
 
@@ -185,9 +185,7 @@ const getAccountAddressesWithBalances = async (
 ): Promise<{ address: string; balance: string }[]> => {
   if (isUtxoAccountId(accountId)) {
     const { chainId, account: pubkey } = fromAccountId(accountId)
-    const chainAdapters = getChainAdapterManager()
-    const adapter = chainAdapters.get(chainId) as unknown as UtxoBaseAdapter<UtxoChainId>
-    if (!adapter) throw new Error(`no adapter for ${chainId} not available`)
+    const adapter = assertGetUtxoChainAdapter(chainId)
 
     const {
       chainSpecific: { addresses },

--- a/src/pages/Lending/Pool/components/Repay/RepayConfirm.tsx
+++ b/src/pages/Lending/Pool/components/Repay/RepayConfirm.tsx
@@ -12,7 +12,7 @@ import {
 } from '@chakra-ui/react'
 import type { AccountId, AssetId } from '@shapeshiftoss/caip'
 import { fromAccountId, fromAssetId, thorchainAssetId } from '@shapeshiftoss/caip'
-import type { FeeDataEstimate, thorchain } from '@shapeshiftoss/chain-adapters'
+import type { FeeDataEstimate } from '@shapeshiftoss/chain-adapters'
 import { FeeDataKey } from '@shapeshiftoss/chain-adapters'
 import type { Asset, KnownChainIds } from '@shapeshiftoss/types'
 import { TxStatus } from '@shapeshiftoss/unchained-client'
@@ -37,6 +37,7 @@ import { queryClient } from 'context/QueryClientProvider/queryClient'
 import { getSupportedEvmChainIds } from 'hooks/useEvm/useEvm'
 import { useWallet } from 'hooks/useWallet/useWallet'
 import { bn, bnOrZero } from 'lib/bignumber/bignumber'
+import { assertGetThorchainChainAdapter } from 'lib/utils/cosmosSdk'
 import { waitForThorchainUpdate } from 'lib/utils/thorchain'
 import type { LendingQuoteClose } from 'lib/utils/thorchain/lending/types'
 import { useLendingQuoteCloseQuery } from 'pages/Lending/hooks/useLendingCloseQuery'
@@ -236,7 +237,7 @@ export const RepayConfirm = ({
         return (async () => {
           const { account } = fromAccountId(repaymentAccountId)
 
-          const adapter = chainAdapter as unknown as thorchain.ChainAdapter
+          const adapter = assertGetThorchainChainAdapter()
 
           // repayment using THOR is a MsgDeposit tx
           const { txToSign } = await adapter.buildDepositTransaction({

--- a/src/plugins/arbitrum/index.ts
+++ b/src/plugins/arbitrum/index.ts
@@ -1,5 +1,3 @@
-import type { ChainId } from '@shapeshiftoss/caip'
-import type { ChainAdapter } from '@shapeshiftoss/chain-adapters'
 import { arbitrum } from '@shapeshiftoss/chain-adapters'
 import { KnownChainIds } from '@shapeshiftoss/types'
 import * as unchained from '@shapeshiftoss/unchained-client'
@@ -34,7 +32,7 @@ export default function register(): Plugins {
                 return new arbitrum.ChainAdapter({
                   providers: { http, ws },
                   rpcUrl: getConfig().REACT_APP_ARBITRUM_NODE_URL,
-                }) as unknown as ChainAdapter<ChainId> // FIXME: this is silly
+                })
               },
             ],
           ],

--- a/src/plugins/arbitrumNova/index.ts
+++ b/src/plugins/arbitrumNova/index.ts
@@ -1,5 +1,3 @@
-import type { ChainId } from '@shapeshiftoss/caip'
-import type { ChainAdapter } from '@shapeshiftoss/chain-adapters'
 import { arbitrumNova } from '@shapeshiftoss/chain-adapters'
 import { KnownChainIds } from '@shapeshiftoss/types'
 import * as unchained from '@shapeshiftoss/unchained-client'
@@ -34,7 +32,7 @@ export default function register(): Plugins {
                 return new arbitrumNova.ChainAdapter({
                   providers: { http, ws },
                   rpcUrl: getConfig().REACT_APP_ARBITRUM_NOVA_NODE_URL,
-                }) as unknown as ChainAdapter<ChainId> // FIXME: this is silly
+                })
               },
             ],
           ],

--- a/src/plugins/avalanche/index.tsx
+++ b/src/plugins/avalanche/index.tsx
@@ -1,5 +1,3 @@
-import type { ChainId } from '@shapeshiftoss/caip'
-import type { ChainAdapter } from '@shapeshiftoss/chain-adapters'
 import { avalanche } from '@shapeshiftoss/chain-adapters'
 import { KnownChainIds } from '@shapeshiftoss/types'
 import * as unchained from '@shapeshiftoss/unchained-client'
@@ -33,7 +31,7 @@ export default function register(): Plugins {
                 return new avalanche.ChainAdapter({
                   providers: { http, ws },
                   rpcUrl: getConfig().REACT_APP_AVALANCHE_NODE_URL,
-                }) as unknown as ChainAdapter<ChainId> // FIXME: this is silly
+                })
               },
             ],
           ],

--- a/src/plugins/bitcoin/index.tsx
+++ b/src/plugins/bitcoin/index.tsx
@@ -1,5 +1,3 @@
-import type { ChainId } from '@shapeshiftoss/caip'
-import type { ChainAdapter } from '@shapeshiftoss/chain-adapters'
 import { bitcoin } from '@shapeshiftoss/chain-adapters'
 import { KnownChainIds } from '@shapeshiftoss/types'
 import * as unchained from '@shapeshiftoss/unchained-client'
@@ -31,7 +29,7 @@ export default function register(): Plugins {
                 return new bitcoin.ChainAdapter({
                   providers: { http, ws },
                   coinName: 'Bitcoin',
-                }) as unknown as ChainAdapter<ChainId> // FIXME: this is silly
+                })
               },
             ],
           ],

--- a/src/plugins/bitcoincash/index.tsx
+++ b/src/plugins/bitcoincash/index.tsx
@@ -1,5 +1,3 @@
-import type { ChainId } from '@shapeshiftoss/caip'
-import type { ChainAdapter } from '@shapeshiftoss/chain-adapters'
 import { bitcoincash } from '@shapeshiftoss/chain-adapters'
 import { KnownChainIds } from '@shapeshiftoss/types'
 import * as unchained from '@shapeshiftoss/unchained-client'
@@ -31,7 +29,7 @@ export default function register(): Plugins {
                 return new bitcoincash.ChainAdapter({
                   providers: { http, ws },
                   coinName: 'BitcoinCash',
-                }) as unknown as ChainAdapter<ChainId> // FIXME: this is silly
+                })
               },
             ],
           ],

--- a/src/plugins/bnbsmartchain/index.tsx
+++ b/src/plugins/bnbsmartchain/index.tsx
@@ -1,5 +1,3 @@
-import type { ChainId } from '@shapeshiftoss/caip'
-import type { ChainAdapter } from '@shapeshiftoss/chain-adapters'
 import { bnbsmartchain } from '@shapeshiftoss/chain-adapters'
 import { KnownChainIds } from '@shapeshiftoss/types'
 import * as unchained from '@shapeshiftoss/unchained-client'
@@ -34,7 +32,7 @@ export default function register(): Plugins {
                 return new bnbsmartchain.ChainAdapter({
                   providers: { http, ws },
                   rpcUrl: getConfig().REACT_APP_BNBSMARTCHAIN_NODE_URL,
-                }) as unknown as ChainAdapter<ChainId> // FIXME: this is silly
+                })
               },
             ],
           ],

--- a/src/plugins/cosmos/index.tsx
+++ b/src/plugins/cosmos/index.tsx
@@ -1,5 +1,3 @@
-import type { ChainId } from '@shapeshiftoss/caip'
-import type { ChainAdapter } from '@shapeshiftoss/chain-adapters'
 import { cosmos } from '@shapeshiftoss/chain-adapters'
 import { KnownChainIds } from '@shapeshiftoss/types'
 import * as unchained from '@shapeshiftoss/unchained-client'
@@ -33,7 +31,7 @@ export default function register(): Plugins {
                 return new cosmos.ChainAdapter({
                   providers: { http, ws },
                   coinName: 'Cosmos',
-                }) as unknown as ChainAdapter<ChainId> // FIXME: this is silly
+                })
               },
             ],
           ],

--- a/src/plugins/cosmos/utils.ts
+++ b/src/plugins/cosmos/utils.ts
@@ -1,14 +1,13 @@
 import { fromAssetId } from '@shapeshiftoss/caip'
 import type {
   cosmossdk,
-  CosmosSdkBaseAdapter,
   CosmosSdkChainId,
   FeeDataKey,
   GetFeeDataInput,
 } from '@shapeshiftoss/chain-adapters'
 import type { Asset } from '@shapeshiftoss/types'
-import { getChainAdapterManager } from 'context/PluginProvider/chainAdapterSingleton'
 import { bnOrZero } from 'lib/bignumber/bignumber'
+import { assertGetCosmosSdkChainAdapter } from 'lib/utils/cosmosSdk'
 
 export type FeePriceValueHuman = {
   fiatFee: string
@@ -45,10 +44,7 @@ export const getFormFees = async (asset: Asset, userCurrencyRate: string) => {
     },
   }
 
-  const chainAdapterManager = getChainAdapterManager()
-  const adapter = chainAdapterManager.get(
-    fromAssetId(asset.assetId).chainId,
-  ) as unknown as CosmosSdkBaseAdapter<CosmosSdkChainId>
+  const adapter = assertGetCosmosSdkChainAdapter(fromAssetId(asset.assetId).chainId)
 
   const getFeeDataInput: Partial<GetFeeDataInput<CosmosSdkChainId>> = {}
   const feeData = await adapter.getFeeData(getFeeDataInput)

--- a/src/plugins/dogecoin/index.tsx
+++ b/src/plugins/dogecoin/index.tsx
@@ -1,5 +1,3 @@
-import type { ChainId } from '@shapeshiftoss/caip'
-import type { ChainAdapter } from '@shapeshiftoss/chain-adapters'
 import { dogecoin } from '@shapeshiftoss/chain-adapters'
 import { KnownChainIds } from '@shapeshiftoss/types'
 import * as unchained from '@shapeshiftoss/unchained-client'
@@ -31,7 +29,7 @@ export default function register(): Plugins {
                 return new dogecoin.ChainAdapter({
                   providers: { http, ws },
                   coinName: 'Dogecoin',
-                }) as unknown as ChainAdapter<ChainId>
+                })
               },
             ],
           ],

--- a/src/plugins/ethereum/index.tsx
+++ b/src/plugins/ethereum/index.tsx
@@ -1,5 +1,3 @@
-import type { ChainId } from '@shapeshiftoss/caip'
-import type { ChainAdapter } from '@shapeshiftoss/chain-adapters'
 import { ethereum } from '@shapeshiftoss/chain-adapters'
 import { KnownChainIds } from '@shapeshiftoss/types'
 import * as unchained from '@shapeshiftoss/unchained-client'
@@ -33,7 +31,7 @@ export default function register(): Plugins {
                 return new ethereum.ChainAdapter({
                   providers: { http, ws },
                   rpcUrl: getConfig().REACT_APP_ETHEREUM_NODE_URL,
-                }) as unknown as ChainAdapter<ChainId> // FIXME: this is silly
+                })
               },
             ],
           ],

--- a/src/plugins/gnosis/index.tsx
+++ b/src/plugins/gnosis/index.tsx
@@ -1,5 +1,3 @@
-import type { ChainId } from '@shapeshiftoss/caip'
-import type { ChainAdapter } from '@shapeshiftoss/chain-adapters'
 import { gnosis } from '@shapeshiftoss/chain-adapters'
 import { KnownChainIds } from '@shapeshiftoss/types'
 import * as unchained from '@shapeshiftoss/unchained-client'
@@ -33,7 +31,7 @@ export default function register(): Plugins {
                 return new gnosis.ChainAdapter({
                   providers: { http, ws },
                   rpcUrl: getConfig().REACT_APP_GNOSIS_NODE_URL,
-                }) as unknown as ChainAdapter<ChainId> // FIXME: this is silly
+                })
               },
             ],
           ],

--- a/src/plugins/litecoin/index.tsx
+++ b/src/plugins/litecoin/index.tsx
@@ -1,5 +1,3 @@
-import type { ChainId } from '@shapeshiftoss/caip'
-import type { ChainAdapter } from '@shapeshiftoss/chain-adapters'
 import { litecoin } from '@shapeshiftoss/chain-adapters'
 import { KnownChainIds } from '@shapeshiftoss/types'
 import * as unchained from '@shapeshiftoss/unchained-client'
@@ -31,7 +29,7 @@ export default function register(): Plugins {
                 return new litecoin.ChainAdapter({
                   providers: { http, ws },
                   coinName: 'Litecoin',
-                }) as unknown as ChainAdapter<ChainId> // FIXME: this is silly
+                })
               },
             ],
           ],

--- a/src/plugins/optimism/index.tsx
+++ b/src/plugins/optimism/index.tsx
@@ -1,5 +1,3 @@
-import type { ChainId } from '@shapeshiftoss/caip'
-import type { ChainAdapter } from '@shapeshiftoss/chain-adapters'
 import { optimism } from '@shapeshiftoss/chain-adapters'
 import { KnownChainIds } from '@shapeshiftoss/types'
 import * as unchained from '@shapeshiftoss/unchained-client'
@@ -34,7 +32,7 @@ export default function register(): Plugins {
                 return new optimism.ChainAdapter({
                   providers: { http, ws },
                   rpcUrl: getConfig().REACT_APP_OPTIMISM_NODE_URL,
-                }) as unknown as ChainAdapter<ChainId> // FIXME: this is silly
+                })
               },
             ],
           ],

--- a/src/plugins/polygon/index.ts
+++ b/src/plugins/polygon/index.ts
@@ -1,5 +1,3 @@
-import type { ChainId } from '@shapeshiftoss/caip'
-import type { ChainAdapter } from '@shapeshiftoss/chain-adapters'
 import { polygon } from '@shapeshiftoss/chain-adapters'
 import { KnownChainIds } from '@shapeshiftoss/types'
 import * as unchained from '@shapeshiftoss/unchained-client'
@@ -34,7 +32,7 @@ export default function register(): Plugins {
                 return new polygon.ChainAdapter({
                   providers: { http, ws },
                   rpcUrl: getConfig().REACT_APP_POLYGON_NODE_URL,
-                }) as unknown as ChainAdapter<ChainId> // FIXME: this is silly
+                })
               },
             ],
           ],

--- a/src/plugins/thorchain/index.tsx
+++ b/src/plugins/thorchain/index.tsx
@@ -1,5 +1,3 @@
-import type { ChainId } from '@shapeshiftoss/caip'
-import type { ChainAdapter } from '@shapeshiftoss/chain-adapters'
 import { thorchain } from '@shapeshiftoss/chain-adapters'
 import { KnownChainIds } from '@shapeshiftoss/types'
 import * as unchained from '@shapeshiftoss/unchained-client'
@@ -31,7 +29,7 @@ export default function register(): Plugins {
                 return new thorchain.ChainAdapter({
                   providers: { http, ws },
                   coinName: 'Thorchain',
-                }) as unknown as ChainAdapter<ChainId> // FIXME: this is silly
+                })
               },
             ],
           ],

--- a/src/plugins/types.ts
+++ b/src/plugins/types.ts
@@ -1,5 +1,6 @@
 import type { ChainId } from '@shapeshiftoss/caip'
 import type { ChainAdapter } from '@shapeshiftoss/chain-adapters'
+import type { KnownChainIds } from '@shapeshiftoss/types'
 import type { Route } from 'Routes/helpers'
 import type { FeatureFlags } from 'state/slices/preferencesSlice/preferencesSlice'
 
@@ -11,7 +12,7 @@ export interface Plugin {
   featureFlag?: (keyof FeatureFlags)[]
   onLoad?: () => void
   providers?: {
-    chainAdapters?: [ChainId, () => ChainAdapter<ChainId>][]
+    chainAdapters?: [ChainId, () => ChainAdapter<KnownChainIds>][]
   }
   routes?: Route[]
 }

--- a/src/plugins/walletConnectToDapps/hooks/useWalletConnectState.ts
+++ b/src/plugins/walletConnectToDapps/hooks/useWalletConnectState.ts
@@ -15,7 +15,6 @@ import {
   getWalletAddressFromEthSignParams,
 } from 'plugins/walletConnectToDapps/utils'
 import { useMemo } from 'react'
-import { getChainAdapterManager } from 'context/PluginProvider/chainAdapterSingleton'
 import { selectPortfolioAccountMetadata } from 'state/slices/portfolioSlice/selectors'
 import { useAppSelector } from 'state/store'
 
@@ -68,7 +67,6 @@ export const useWalletConnectState = (state: WalletConnectState) => {
       ? getSignParamsMessage(request.params, true)
       : undefined
   const method: KnownSigningMethod | undefined = requestEvent?.params.request.method
-  const chainAdapter = chainId && getChainAdapterManager().get(chainId)
 
   return {
     isInteractingWithContract,
@@ -76,7 +74,6 @@ export const useWalletConnectState = (state: WalletConnectState) => {
     transaction,
     message,
     method,
-    chainAdapter,
     requestEvent,
     connectedAccounts,
     accountId,

--- a/src/state/apis/foxy/foxyApiSingleton.ts
+++ b/src/state/apis/foxy/foxyApiSingleton.ts
@@ -1,8 +1,8 @@
 import type { EvmBaseAdapter } from '@shapeshiftoss/chain-adapters'
 import { KnownChainIds } from '@shapeshiftoss/types'
 import { getConfig } from 'config'
-import { getChainAdapterManager } from 'context/PluginProvider/chainAdapterSingleton'
 import { foxyAddresses, FoxyApi } from 'lib/investor/investor-foxy'
+import { assertGetEvmChainAdapter } from 'lib/utils/evm'
 
 // don't export me, access me through the getter
 let _foxyApi: FoxyApi | undefined = undefined
@@ -14,9 +14,9 @@ export const getFoxyApi = (): FoxyApi => {
   if (_foxyApi) return _foxyApi
 
   const foxyApi = new FoxyApi({
-    adapter: getChainAdapterManager().get(
+    adapter: assertGetEvmChainAdapter(
       KnownChainIds.EthereumMainnet,
-    ) as unknown as EvmBaseAdapter<KnownChainIds.EthereumMainnet>,
+    ) as EvmBaseAdapter<KnownChainIds.EthereumMainnet>,
     providerUrl: getConfig()[RPC_PROVIDER_ENV],
     foxyAddresses,
   })


### PR DESCRIPTION
## Description

Removes most instances of double assertions `.. as unknown as ChainAdapter<ChainId>`.

Includes some cleanup of the aurora background (the loading screen).

## Pull Request Type

- [ ] :bug: Bug fix (Non-breaking Change: Fixes an issue)
- [x] :hammer_and_wrench: Chore (Non-breaking Change: Doc updates, pkg upgrades, typos, etc..)
- [ ] :nail_care: New Feature (Breaking/Non-breaking Change)

## Issue (if applicable)

<!-----------------------------------------------------------------------------
If applicable, please link to the github issue and put `closes #XXXX` in your comment to auto-close the issue that your PR fixes.
------------------------------------------------------------------------------>

relates to https://github.com/shapeshift/web/pull/5454#issuecomment-1850896756

## Risk

Risk of broken foxy, sends, savers, fox farming, lending, trades, etc as this is widespread across the app

## Testing

Quick check of foxy, sends, savers, fox farming, lending, trades, etc to ensure nothing is broken.

### Engineering

<!-----------------------------------------------------------------------------
Include sufficient information here for an engineer to test your PR. This may include how to test locally, in a built environment, changes to infrastructure etc.
------------------------------------------------------------------------------>

### Operations

<!-----------------------------------------------------------------------------
If your changes have a user-facing impact, describe how a non-technical QA team can functionally test your changes in a preview environment.

If they are not user-facing please describe how to test for any regressions that may occur.
------------------------------------------------------------------------------>

## Screenshots (if applicable)
