### PR TITLE
feat: add cross-account trading for 1inch

### DIFF
--- a/src/lib/swapper/swappers/OneInchSwapper/endpoints.ts
+++ b/src/lib/swapper/swappers/OneInchSwapper/endpoints.ts
@@ -53,6 +53,7 @@ export const oneInchApi: SwapperApi = {
       sellAmountIncludingProtocolFeesCryptoBaseUnit,
       sellAsset,
       maximumSlippageDecimalPercentage: slippageTolerancePercentageDecimal,
+      sendAddress: from,
     })
 
     return {

--- a/src/lib/swapper/swappers/OneInchSwapper/getTradeQuote/getTradeQuote.ts
+++ b/src/lib/swapper/swappers/OneInchSwapper/getTradeQuote/getTradeQuote.ts
@@ -52,6 +52,7 @@ export async function getTradeQuote(
   const params: OneInchQuoteApiInput = {
     fromTokenAddress: getOneInchTokenAddress(sellAsset),
     toTokenAddress: getOneInchTokenAddress(buyAsset),
+    receiver: receiveAddress,
     amount: sellAmountIncludingProtocolFeesCryptoBaseUnit,
     ...(maybeTreasuryAddress && {
       fee: buyTokenPercentageFee,

--- a/src/lib/swapper/swappers/OneInchSwapper/utils/fetchOneInchSwap.ts
+++ b/src/lib/swapper/swappers/OneInchSwapper/utils/fetchOneInchSwap.ts
@@ -16,6 +16,7 @@ export type FetchOneInchSwapInput = {
   sellAmountIncludingProtocolFeesCryptoBaseUnit: string
   sellAsset: Asset
   maximumSlippageDecimalPercentage: string
+  sendAddress: string
 }
 
 export const fetchOneInchSwap = async ({
@@ -25,6 +26,7 @@ export const fetchOneInchSwap = async ({
   sellAmountIncludingProtocolFeesCryptoBaseUnit,
   sellAsset,
   maximumSlippageDecimalPercentage,
+  sendAddress,
 }: FetchOneInchSwapInput) => {
   const apiUrl = getConfig().REACT_APP_ONE_INCH_API_URL
 
@@ -46,10 +48,8 @@ export const fetchOneInchSwap = async ({
   const params: OneInchSwapApiInput = {
     fromTokenAddress: getOneInchTokenAddress(sellAsset),
     toTokenAddress: getOneInchTokenAddress(buyAsset),
-    // HACK: use the receive address as the send address
-    // 1inch uses this to check allowance on their side
-    // this swapper is not cross-account so this works
-    fromAddress: receiveAddress,
+    receiver: receiveAddress,
+    fromAddress: sendAddress,
     amount: sellAmountIncludingProtocolFeesCryptoBaseUnit,
     slippage: maximumSlippagePercentage,
     allowPartialFill: false,

--- a/src/lib/swapper/swappers/OneInchSwapper/utils/types.ts
+++ b/src/lib/swapper/swappers/OneInchSwapper/utils/types.ts
@@ -15,6 +15,7 @@ export type OneInchQuoteApiInput = {
   fromTokenAddress: string
   toTokenAddress: string
   amount: string
+  receiver: string
   fee?: number // fee as a percentage, e.g. to set a fee to 1.5%: fee=1.5, paid to the referrerAddress
 }
 

--- a/src/state/helpers.ts
+++ b/src/state/helpers.ts
@@ -5,12 +5,12 @@ import { assertUnreachable } from '../lib/utils'
 export const isCrossAccountTradeSupported = (swapperName: SwapperName) => {
   switch (swapperName) {
     case SwapperName.Thorchain:
+    case SwapperName.OneInch:
       return true
     // NOTE: Before enabling cross-account for LIFI and OneInch - we must pass the sending address
     // to the swappers up so allowance checks work. They're currently using the receive address
     // assuming it's the same address as the sending address.
     case SwapperName.LIFI:
-    case SwapperName.OneInch:
     case SwapperName.Zrx:
     case SwapperName.CowSwap:
     case SwapperName.Test:


### PR DESCRIPTION
## Description

Enables cross-account trading for 1inch.

Cross-account 1inch transactions created from this branch:

1. Fee asset account 0 to ERC20 account 1: https://snowtrace.dev/tx/0x93dea99cfa2663635a6314e0340fd890404ed3d999c04862520e83dbbacdf95f
2. Approval from non-0 ERC20 account: https://snowtrace.dev/tx/0xff2c18378bd4fff274d471841a7d28d5d188d86c84866f420aa4677e52ec213b
3. ERC20 account 1 to fee asset account 0: https://snowtrace.dev/tx/0xa9b8cca119c09f3bd6c96f1b9eaea31b0119a71b537b7d592164154cde79c695

## Pull Request Type

- [ ] :bug: Bug fix (Non-breaking Change: Fixes an issue)
- [ ] :hammer_and_wrench: Chore (Non-breaking Change: Doc updates, pkg upgrades, typos, etc..)
- [x] :nail_care: New Feature (Breaking/Non-breaking Change)

## Issue (if applicable)

Closes https://github.com/shapeshift/web/issues/4966

## Risk

Medium. It's a small change, but as always, touching account selection is risky as mistakes can mean lost funds.

## Testing

Confirm that 1inch quotes now show up when trading between accounts, and that they and sent and received from the correct accounts when executed.

### Engineering

Sanity check logic.

### Operations

☝️

## Screenshots (if applicable)

<img width="567" alt="Screenshot 2023-12-12 at 11 09 58 am" src="https://github.com/shapeshift/web/assets/97164662/67846aad-a651-4b26-8cbc-a877693f4e69">
