### PR TITLE
feat: enable lifi cross-account trades

### DIFF
--- a/src/lib/swapper/swappers/LifiSwapper/getTradeQuote/getTradeQuote.ts
+++ b/src/lib/swapper/swappers/LifiSwapper/getTradeQuote/getTradeQuote.ts
@@ -72,9 +72,6 @@ export async function getTradeQuote(
     toChainId: Number(fromChainId(buyAsset.chainId).chainReference),
     fromTokenAddress: getLifiEvmAssetAddress(sellAsset),
     toTokenAddress: getLifiEvmAssetAddress(buyAsset),
-    // HACK: use the receive address as the send address
-    // lifi's exchanges may use this to check allowance on their side
-    // this swapper is not cross-account so this works
     fromAddress: sendAddress,
     toAddress: receiveAddress,
     fromAmount: sellAmountIncludingProtocolFeesCryptoBaseUnit,

--- a/src/state/helpers.ts
+++ b/src/state/helpers.ts
@@ -5,11 +5,8 @@ import { assertUnreachable } from '../lib/utils'
 export const isCrossAccountTradeSupported = (swapperName: SwapperName) => {
   switch (swapperName) {
     case SwapperName.Thorchain:
-      return true
-    // NOTE: Before enabling cross-account for LIFI and OneInch - we must pass the sending address
-    // to the swappers up so allowance checks work. They're currently using the receive address
-    // assuming it's the same address as the sending address.
     case SwapperName.LIFI:
+      return true
     case SwapperName.OneInch:
     case SwapperName.Zrx:
     case SwapperName.CowSwap:


### PR DESCRIPTION
## Description

Add cross-account trading to LifI.

Cross-account LiFi transactions created from this branch:

- https://snowtrace.dev/tx/0x686bc6eb039a38b9c0fd5a5e8d03307a8256cffad042a82fe2128c31a73921d0

## Pull Request Type

- [ ] :bug: Bug fix (Non-breaking Change: Fixes an issue)
- [ ] :hammer_and_wrench: Chore (Non-breaking Change: Doc updates, pkg upgrades, typos, etc..)
- [x] :nail_care: New Feature (Breaking/Non-breaking Change)

## Issue (if applicable)

Relates to https://github.com/shapeshift/web/issues/4966

## Risk

Medium. It's a small change, but as always, touching account selection is risky as mistakes can mean lost funds.

## Testing

Confirm that Li.Fi quotes now show up when trading between accounts, and that they and sent and received from the correct accounts when executed.

### Engineering

Sanity check logic.

### Operations

☝️

## Screenshots (if applicable)

<img width="458" alt="Screenshot 2023-12-12 at 11 30 13 am" src="https://github.com/shapeshift/web/assets/97164662/76b8a7fb-6697-4bd4-b7f0-d96a46db5169">
