### PR TITLE
feat: add fallback doge transaction fee

### DIFF
--- a/packages/chain-adapters/src/utxo/UtxoBaseAdapter.ts
+++ b/packages/chain-adapters/src/utxo/UtxoBaseAdapter.ts
@@ -402,16 +402,16 @@ export abstract class UtxoBaseAdapter<T extends UtxoChainId> implements IChainAd
     const { fee: slowFee } = utxoSelect({ ...utxoSelectInput, satoshiPerByte: slowPerByte })
 
     // Special, temporary case for DOGE to provide a workable fee value when the node is struggling
-    const isDoge = pubkey.startsWith('dpub')
+    const isDoge = pubkey.startsWith('dgub')
     const allFeesDefined =
       fastFee !== undefined && averageFee !== undefined && slowFee !== undefined
     if (isDoge && !allFeesDefined) {
-      const oneDogeInSatoshis = '100000000' // 1 DOGE in Satoshis
-      const fee = utxoSelect({ ...utxoSelectInput, satoshiPerByte: oneDogeInSatoshis }).fee
+      const satoshiPerByte = '20000'
+      const fee = utxoSelect({ ...utxoSelectInput, satoshiPerByte }).fee
       return {
-        fast: { txFee: String(fee), chainSpecific: { satoshiPerByte: oneDogeInSatoshis } },
-        average: { txFee: String(fee), chainSpecific: { satoshiPerByte: oneDogeInSatoshis } },
-        slow: { txFee: String(fee), chainSpecific: { satoshiPerByte: oneDogeInSatoshis } },
+        fast: { txFee: String(fee), chainSpecific: { satoshiPerByte } },
+        average: { txFee: String(fee), chainSpecific: { satoshiPerByte } },
+        slow: { txFee: String(fee), chainSpecific: { satoshiPerByte } },
       } as FeeDataEstimate<T>
     }
 


### PR DESCRIPTION
## Description

Adds a special case when calculating the network fees for DOGE to fallback on a hardcoded `satoshiPerByte` value that is high enough to go through (the number is a little over double the current "fast" value).

Note, https://api.dogecoin.shapeshift.com/api/v1/fees seems to be working fine now, so it won't actually change behaviour right now.

## Pull Request Type

- [x] :bug: Bug fix (Non-breaking Change: Fixes an issue)
- [ ] :hammer_and_wrench: Chore (Non-breaking Change: Doc updates, pkg upgrades, typos, etc..)
- [ ] :nail_care: New Feature (Breaking/Non-breaking Change)

## Issue (if applicable)

Closes https://github.com/shapeshift/web/issues/5822

## Risk

Small - user could pay more DOGE in transactions fees if this is not implemented correctly.

## Testing

Not currently possible without intercepting the response to https://api.dogecoin.shapeshift.com/api/v1/fees

### Engineering

Sanity check logic.

### Operations

DOGE sends should work.

## Screenshots (if applicable)

N/A