### PR TITLE
fix: add a loading state to the asset dropdown

### DIFF
--- a/src/components/MultiHopTrade/components/AssetChainDropdown.tsx
+++ b/src/components/MultiHopTrade/components/AssetChainDropdown.tsx
@@ -94,7 +94,8 @@ export const AssetChainDropdown: React.FC<ChainDropdownProps> = ({
         borderRadius='full'
         color='text.base'
         isDisabled
-        variant='ghost'
+        isLoading={isLoading}
+        variant={!isLoading ? 'ghost' : undefined}
         _disabled={disabled}
         _hover={hover}
         {...buttonProps}

--- a/src/components/MultiHopTrade/components/AssetSelection.tsx
+++ b/src/components/MultiHopTrade/components/AssetSelection.tsx
@@ -31,6 +31,7 @@ const TradeAssetAwaitingAsset = () => {
 type TradeAssetSelectProps = {
   assetId?: AssetId
   isReadOnly?: boolean
+  isLoading: boolean
   onAssetClick?: () => void
   onAssetChange: (asset: Asset) => void
 }
@@ -40,11 +41,16 @@ export const TradeAssetSelectWithAsset: React.FC<TradeAssetSelectProps> = ({
   onAssetChange,
   assetId,
   isReadOnly,
+  isLoading,
 }) => {
   const assets = useAppSelector(selectAssets)
   const asset = useAppSelector(state => selectAssetById(state, assetId ?? ''))
 
-  const { data, isLoading, isError } = useGetRelatedAssetIdsQuery(assetId ?? '')
+  const {
+    data,
+    isLoading: isRelatedAssetsLoading,
+    isError,
+  } = useGetRelatedAssetIdsQuery(assetId ?? '')
 
   const handleAssetChange = useCallback(
     (assetId: AssetId) => {
@@ -80,6 +86,7 @@ export const TradeAssetSelectWithAsset: React.FC<TradeAssetSelectProps> = ({
         isDisabled={isReadOnly}
         _disabled={disabledStyle}
         rightIcon={rightIcon}
+        isLoading={isLoading || isRelatedAssetsLoading}
       >
         {icon}
         {asset?.symbol}
@@ -89,7 +96,7 @@ export const TradeAssetSelectWithAsset: React.FC<TradeAssetSelectProps> = ({
         assetIds={data}
         assetId={assetId}
         onClick={handleAssetChange}
-        isLoading={isLoading}
+        isLoading={isLoading || isRelatedAssetsLoading}
         isError={isError}
       />
     </Flex>

--- a/src/components/MultiHopTrade/components/TradeInput/TradeInput.tsx
+++ b/src/components/MultiHopTrade/components/TradeInput/TradeInput.tsx
@@ -557,9 +557,10 @@ export const TradeInput = memo(() => {
         assetId={sellAsset.assetId}
         onAssetClick={handleSellAssetClick}
         onAssetChange={setSellAsset}
+        isLoading={isSupportedAssetsLoading}
       />
     ),
-    [handleSellAssetClick, sellAsset.assetId, setSellAsset],
+    [handleSellAssetClick, isSupportedAssetsLoading, sellAsset.assetId, setSellAsset],
   )
 
   const buyTradeAssetSelect = useMemo(
@@ -568,9 +569,10 @@ export const TradeInput = memo(() => {
         assetId={buyAsset.assetId}
         onAssetClick={handleBuyAssetClick}
         onAssetChange={setBuyAsset}
+        isLoading={isSupportedAssetsLoading}
       />
     ),
-    [buyAsset.assetId, handleBuyAssetClick, setBuyAsset],
+    [buyAsset.assetId, handleBuyAssetClick, isSupportedAssetsLoading, setBuyAsset],
   )
 
   return (

--- a/src/pages/Lending/Pool/components/Borrow/BorrowInput.tsx
+++ b/src/pages/Lending/Pool/components/Borrow/BorrowInput.tsx
@@ -95,7 +95,8 @@ export const BorrowInput = ({
   const translate = useTranslate()
   const history = useHistory()
 
-  const { data: borrowAssets } = useLendingSupportedAssets({ type: 'borrow' })
+  const { data: borrowAssets, isLoading: isLendingSupportedAssetsLoading } =
+    useLendingSupportedAssets({ type: 'borrow' })
 
   const collateralAsset = useAppSelector(state => selectAssetById(state, collateralAssetId))
 
@@ -346,9 +347,10 @@ export const BorrowInput = ({
         onAssetClick={noop}
         onAssetChange={handleAssetChange}
         isReadOnly
+        isLoading={isLendingSupportedAssetsLoading}
       />
     )
-  }, [collateralAssetId, handleAssetChange])
+  }, [collateralAssetId, handleAssetChange, isLendingSupportedAssetsLoading])
 
   const borrowAssetSelectComponent = useMemo(() => {
     return (
@@ -356,9 +358,15 @@ export const BorrowInput = ({
         assetId={borrowAsset?.assetId ?? ''}
         onAssetClick={handleBorrowAssetClick}
         onAssetChange={handleAssetChange}
+        isLoading={isLendingSupportedAssetsLoading}
       />
     )
-  }, [borrowAsset?.assetId, handleAssetChange, handleBorrowAssetClick])
+  }, [
+    borrowAsset?.assetId,
+    handleAssetChange,
+    handleBorrowAssetClick,
+    isLendingSupportedAssetsLoading,
+  ])
 
   const quoteErrorTranslation = useMemo(() => {
     if (_isSmartContractAddress) return 'trade.errors.smartContractWalletNotSupported'

--- a/src/pages/Lending/Pool/components/Repay/RepayInput.tsx
+++ b/src/pages/Lending/Pool/components/Repay/RepayInput.tsx
@@ -126,7 +126,8 @@ export const RepayInput = ({
 
   const swapIcon = useMemo(() => <ArrowDownIcon />, [])
 
-  const { data: lendingSupportedAssets } = useLendingSupportedAssets({ type: 'borrow' })
+  const { data: lendingSupportedAssets, isLoading: isLendingSupportedAssetsLoading } =
+    useLendingSupportedAssets({ type: 'borrow' })
 
   useEffect(() => {
     if (!(lendingSupportedAssets && collateralAsset)) return
@@ -159,9 +160,15 @@ export const RepayInput = ({
         // Users have the possibility to repay in any supported asset, not only their collateral/borrowed asset
         // https://docs.thorchain.org/thorchain-finance/lending#loan-repayment-closeflow
         isReadOnly={false}
+        isLoading={isLendingSupportedAssetsLoading}
       />
     )
-  }, [handleAssetChange, handleRepaymentAssetClick, repaymentAsset?.assetId])
+  }, [
+    handleAssetChange,
+    handleRepaymentAssetClick,
+    isLendingSupportedAssetsLoading,
+    repaymentAsset?.assetId,
+  ])
 
   const collateralAssetSelectComponent = useMemo(() => {
     return (
@@ -170,9 +177,15 @@ export const RepayInput = ({
         onAssetClick={handleRepaymentAssetClick}
         onAssetChange={handleAssetChange}
         isReadOnly
+        isLoading={isLendingSupportedAssetsLoading}
       />
     )
-  }, [collateralAssetId, handleAssetChange, handleRepaymentAssetClick])
+  }, [
+    collateralAssetId,
+    handleAssetChange,
+    handleRepaymentAssetClick,
+    isLendingSupportedAssetsLoading,
+  ])
 
   const handleSeenNotice = useCallback(() => setSeenNotice(true), [])
 


### PR DESCRIPTION
## Description

Fixes the ability to open the asset selection modal/dropdown while assets are still being loaded, resulting in an empty list. The solution was to trigger the build-in loading state to the button while assets are loading.

## Pull Request Type

- [x] :bug: Bug fix (Non-breaking Change: Fixes an issue)
- [ ] :hammer_and_wrench: Chore (Non-breaking Change: Doc updates, pkg upgrades, typos, etc..)
- [ ] :nail_care: New Feature (Breaking/Non-breaking Change)

## Issue (if applicable)

NA

## Risk

Low risk.

## Testing

check asset selection still works
check loading state stops when app is loaded (this may happen too quickly to see if your internet connection is fast)

### Engineering

<!-----------------------------------------------------------------------------
Include sufficient information here for an engineer to test your PR. This may include how to test locally, in a built environment, changes to infrastructure etc.
------------------------------------------------------------------------------>

### Operations

<!-----------------------------------------------------------------------------
If your changes have a user-facing impact, describe how a non-technical QA team can functionally test your changes in a preview environment.

If they are not user-facing please describe how to test for any regressions that may occur.
------------------------------------------------------------------------------>

## Screenshots (if applicable)

Loading state look like this
![image](https://github.com/shapeshift/web/assets/125113430/66a2e70d-ca14-4d69-b677-b43f27491419)

