### PR TITLE
fix: consistently use hardcoded doge sats per byte

### DIFF
--- a/packages/chain-adapters/src/utxo/UtxoBaseAdapter.ts
+++ b/packages/chain-adapters/src/utxo/UtxoBaseAdapter.ts
@@ -406,27 +406,35 @@ export abstract class UtxoBaseAdapter<T extends UtxoChainId> implements IChainAd
     const isDoge = pubkey.startsWith('dgub')
 
     if (isDoge) {
-      // 1 DOGE per byte
-      const satoshiPerByte = '100000000'
+      const satoshiPerByte = '500000'
 
-      // Use hardcoded 1 DOGE per kilobyte if the current sats per byte is negative or missing
-      const _fastFee =
+      // Use hardcoded sats per byte if the current sats per byte is negative or missing
+      const fast =
         !fastFee || !data.fast?.satsPerKiloByte || data.fast.satsPerKiloByte < 0
-          ? satoshiPerByte
-          : fastFee
-      const _averageFee =
+          ? {
+              txFee: utxoSelect({ ...utxoSelectInput, satoshiPerByte }).fee,
+              chainSpecific: { satoshiPerByte },
+            }
+          : { txFee: String(fastFee), chainSpecific: { satoshiPerByte: fastPerByte } }
+      const average =
         !averageFee || !data.average?.satsPerKiloByte || data.average.satsPerKiloByte < 0
-          ? satoshiPerByte
-          : averageFee
-      const _slowFee =
+          ? {
+              txFee: utxoSelect({ ...utxoSelectInput, satoshiPerByte }).fee,
+              chainSpecific: { satoshiPerByte },
+            }
+          : { txFee: String(averageFee), chainSpecific: { satoshiPerByte: averagePerByte } }
+      const slow =
         !slowFee || !data.slow?.satsPerKiloByte || data.slow.satsPerKiloByte < 0
-          ? satoshiPerByte
-          : slowFee
+          ? {
+              txFee: utxoSelect({ ...utxoSelectInput, satoshiPerByte }).fee,
+              chainSpecific: { satoshiPerByte },
+            }
+          : { txFee: String(slowFee), chainSpecific: { satoshiPerByte: slowPerByte } }
 
       return {
-        fast: { txFee: String(_fastFee), chainSpecific: { satoshiPerByte } },
-        average: { txFee: String(_averageFee), chainSpecific: { satoshiPerByte } },
-        slow: { txFee: String(_slowFee), chainSpecific: { satoshiPerByte } },
+        fast,
+        average,
+        slow,
       } as FeeDataEstimate<T>
     }
 


### PR DESCRIPTION
## Description

Follows up on https://github.com/shapeshift/web/pull/5844
This ensures we consistently default to hardcoded DOGE fees (500000 sats per byte) in case fees are missing.

The only reason why DOGE sends are happy at the moment in the PR above is because they're also happy on develop/prod as a result of the average fee being defined. Average being defined is accidental and non-deterministic, this may not hold true the next block.

Tested with the monkey patch below, since average fees are currently happy, and we currently default to it for the fast fee in case fast fee is missing:

```diff
diff --git a/packages/chain-adapters/src/utxo/UtxoBaseAdapter.ts b/packages/chain-adapters/src/utxo/UtxoBaseAdapter.ts
index 3328fc8b5f..5e6b2429e5 100644
--- a/packages/chain-adapters/src/utxo/UtxoBaseAdapter.ts
+++ b/packages/chain-adapters/src/utxo/UtxoBaseAdapter.ts
@@ -385,7 +385,8 @@ export abstract class UtxoBaseAdapter<T extends UtxoChainId> implements IChainAd
 
     // TODO: when does this happen and why?
     if (!data.fast?.satsPerKiloByte || data.fast.satsPerKiloByte < 0) {
-      data.fast = data.average
+      // TODO(gomes): monkey patch while average fees are happy, remove me
+      if (false) data.fast = data.average
     }
 
     const utxos = await this.providers.http.getUtxos({ pubkey })
```

This means DOGE is effectively working in develop/prod with average/fast fees at the moment, but *only* because average fees are happy, which is not a given, again, they may break at anytime (i.e when testing yesterday, slow fee was the only one with an actual positive number)

Confirmed average (and hence, fast) fee is currently happy on develop:

![image](https://github.com/shapeshift/web/assets/17035424/64303ed0-faae-48e4-a675-a0b05dc9d1f5)

And confirmed negative fast fees, using hardcoded fees, is happy with this diff, see screenshots below.


## Pull Request Type

- [x] :bug: Bug fix (Non-breaking Change: Fixes an issue)
- [ ] :hammer_and_wrench: Chore (Non-breaking Change: Doc updates, pkg upgrades, typos, etc..)
- [ ] :nail_care: New Feature (Breaking/Non-breaking Change)

## Issue (if applicable)

<!-----------------------------------------------------------------------------
If applicable, please link to the github issue and put `closes #XXXX` in your comment to auto-close the issue that your PR fixes.
------------------------------------------------------------------------------>

- relates to the closed https://github.com/shapeshift/web/issues/5822

## Risk

<!-----------------------------------------------------------------------------
Outline the scope of your changes and the risk associated with them. You must use your discretion as an engineer to determine the potential impact of your changes.

E.g. an upgrade to `hdwallet` or core state management would be considered higher risk, and might require a full regression test. UI or isolated view changes, or something behind a feature flag may have near zero risk. Small bug fixes might require testing isolated to the specific fix.
------------------------------------------------------------------------------>

None

## Testing

<!-----------------------------------------------------------------------------
We treat every PR to be merged with the same scrutiny as if we were merging directly to production.

Your PR will not be merged if you do not complete the sections below for our engineering and operations teams to test.
------------------------------------------------------------------------------>

- Open your network tab and filter by "doge"
- Input some DOGE to send e.g 1 DOGE, and notice a `fees` request fires immediately - click on it and click "Preview"
- Notice some speeds may hold negative values. If all are positive, we're in a rare lucky state where all fee speeds are happy, and there's no need to test any further - continue with the DOGE send as a sanity check and ensure it is broadcasted and confirmed within a sane timeframe (i.e, isn't stuck in the mempool)

If some amounts are negative, continue testing:

- If any of the amounts is negative, we use the hardcoded sats per byte instead. Note, that's only testable by engineering, as the final fee will be variable. @shapeshift/operations - as a user-facing change, this means fees are displayed for all speeds.
- Ensure Txs is able to get broadcasted for all speeds and isn't stuck in the mempool

### Engineering

<!-----------------------------------------------------------------------------
Include sufficient information here for an engineer to test your PR. This may include how to test locally, in a built environment, changes to infrastructure etc.
------------------------------------------------------------------------------>

### Operations

<!-----------------------------------------------------------------------------
If your changes have a user-facing impact, describe how a non-technical QA team can functionally test your changes in a preview environment.

If they are not user-facing please describe how to test for any regressions that may occur.
------------------------------------------------------------------------------>

## Screenshots (if applicable)

- Estimated fees

<img width="361" alt="image" src="https://github.com/shapeshift/web/assets/17035424/b26580b8-a4c2-4ea6-b655-c409651e6faf">


- Hardcoded sats per byte used in case of negative speeds, i.e fast here (~1.13 DOGE for my current UTXO set, but this will be a different number when you test this, and after every time you broadcast a Tx/receive DOGE, since your UTXO set will be different)

<img width="541" alt="image" src="https://github.com/shapeshift/web/assets/17035424/e3b3cf4d-4f03-45c0-bed7-19889a80d3df">

- Tx is broadcasted

<img width="356" alt="image" src="https://github.com/shapeshift/web/assets/17035424/33ee9232-e886-4c23-8f48-be161240ec2f">

- Tx isn't stuck in the mempool

<img width="965" alt="image" src="https://github.com/shapeshift/web/assets/17035424/722d8fd5-d0c0-43d2-9378-7ec7bac23a30">