### PR TITLE
fix: broken error message for savers withdrawls

### DIFF
--- a/src/features/defi/providers/thorchain-savers/components/ThorchainSaversManager/Withdraw/components/Withdraw.tsx
+++ b/src/features/defi/providers/thorchain-savers/components/ThorchainSaversManager/Withdraw/components/Withdraw.tsx
@@ -3,7 +3,7 @@ import { AddressZero } from '@ethersproject/constants'
 import type { AccountId } from '@shapeshiftoss/caip'
 import { fromAccountId, fromAssetId, toAssetId } from '@shapeshiftoss/caip'
 import type { GetFeeDataInput, UtxoChainId } from '@shapeshiftoss/chain-adapters'
-import type { Asset } from '@shapeshiftoss/types'
+import type { Asset, KnownChainIds } from '@shapeshiftoss/types'
 import { Err, Ok, type Result } from '@sniptt/monads'
 import { useQueryClient } from '@tanstack/react-query'
 import { getOrCreateContractByType } from 'contracts/contractManager'
@@ -21,6 +21,7 @@ import { useTranslate } from 'react-polyglot'
 import { encodeFunctionData, getAddress } from 'viem'
 import { Amount } from 'components/Amount/Amount'
 import type { StepComponentProps } from 'components/DeFi/components/Steps'
+import { getChainShortName } from 'components/MultiHopTrade/components/MultiHopTradeConfirm/utils/getChainShortName'
 import { Row } from 'components/Row/Row'
 import { Text } from 'components/Text'
 import type { TextPropTypes } from 'components/Text/Text'
@@ -325,7 +326,12 @@ export const Withdraw: React.FC<WithdrawProps> = ({ accountId, fromAddress, onNe
       } catch (error) {
         console.error(error)
         // Assume insufficient amount for gas if we've thrown on the try block above
-        return Err(translate('common.insufficientAmountForGas', { assetSymbol: feeAsset.symbol }))
+        return Err(
+          translate('common.insufficientAmountForGas', {
+            assetSymbol: feeAsset.symbol,
+            chainSymbol: getChainShortName(feeAsset.chainId as KnownChainIds),
+          }),
+        )
       }
     },
     [
@@ -341,8 +347,7 @@ export const Withdraw: React.FC<WithdrawProps> = ({ accountId, fromAddress, onNe
       chainId,
       supportedEvmChainIds,
       saversRouterContractAddress,
-      feeAsset.assetId,
-      feeAsset.symbol,
+      feeAsset,
       translate,
     ],
   )


### PR DESCRIPTION
## Description

Fixes broken error message for savers withdrawals where insufficient fee asset for gas.

## Pull Request Type

- [x] :bug: Bug fix (Non-breaking Change: Fixes an issue)
- [ ] :hammer_and_wrench: Chore (Non-breaking Change: Doc updates, pkg upgrades, typos, etc..)
- [ ] :nail_care: New Feature (Breaking/Non-breaking Change)

## Issue (if applicable)

NA

## Risk

Low risk

## Testing

Check error message on savers withdrawals is working as expected.

### Engineering

<!-----------------------------------------------------------------------------
Include sufficient information here for an engineer to test your PR. This may include how to test locally, in a built environment, changes to infrastructure etc.
------------------------------------------------------------------------------>

### Operations

<!-----------------------------------------------------------------------------
If your changes have a user-facing impact, describe how a non-technical QA team can functionally test your changes in a preview environment.

If they are not user-facing please describe how to test for any regressions that may occur.
------------------------------------------------------------------------------>

## Screenshots (if applicable)

Reported issue:
![image](https://github.com/shapeshift/web/assets/125113430/94c47179-55cb-43c3-9657-d600fc471f18)

