### PR TITLE
fix: thorchain savers borked withdraws

### DIFF
--- a/src/features/defi/providers/thorchain-savers/components/ThorchainSaversManager/Deposit/components/Approve.tsx
+++ b/src/features/defi/providers/thorchain-savers/components/ThorchainSaversManager/Deposit/components/Approve.tsx
@@ -109,6 +109,7 @@ export const Approve: React.FC<ApproveProps> = ({ accountId, onNext }) => {
   const { routerContractAddress: saversRouterContractAddress } = useRouterContractAddress({
     feeAssetId: feeAsset?.assetId ?? '',
     skip: !isTokenDeposit || !feeAsset?.assetId,
+    excludeHalted: true,
   })
 
   const handleApprove = useCallback(async () => {

--- a/src/features/defi/providers/thorchain-savers/components/ThorchainSaversManager/Deposit/components/Approve.tsx
+++ b/src/features/defi/providers/thorchain-savers/components/ThorchainSaversManager/Deposit/components/Approve.tsx
@@ -106,7 +106,7 @@ export const Approve: React.FC<ApproveProps> = ({ accountId, onNext }) => {
     selectMarketDataById(state, feeAsset?.assetId ?? ''),
   )
 
-  const saversRouterContractAddress = useRouterContractAddress({
+  const { routerContractAddress: saversRouterContractAddress } = useRouterContractAddress({
     feeAssetId: feeAsset?.assetId ?? '',
     skip: !isTokenDeposit || !feeAsset?.assetId,
   })

--- a/src/features/defi/providers/thorchain-savers/components/ThorchainSaversManager/Deposit/components/Deposit.tsx
+++ b/src/features/defi/providers/thorchain-savers/components/ThorchainSaversManager/Deposit/components/Deposit.tsx
@@ -206,7 +206,10 @@ export const Deposit: React.FC<DepositProps> = ({
   // notify
   const toast = useToast()
 
-  const saversRouterContractAddress = useRouterContractAddress({
+  const {
+    routerContractAddress: saversRouterContractAddress,
+    isLoading: isSaversRouterContractAddressLoading,
+  } = useRouterContractAddress({
     feeAssetId: feeAsset?.assetId ?? '',
     skip: !isTokenDeposit || !feeAsset?.assetId,
   })
@@ -937,6 +940,7 @@ export const Deposit: React.FC<DepositProps> = ({
         isEstimatedFeesDataLoading ||
         isSweepNeededLoading ||
         isThorchainSaversDepositQuoteLoading ||
+        isSaversRouterContractAddressLoading ||
         state.loading
       }
     >

--- a/src/features/defi/providers/thorchain-savers/components/ThorchainSaversManager/Deposit/components/Deposit.tsx
+++ b/src/features/defi/providers/thorchain-savers/components/ThorchainSaversManager/Deposit/components/Deposit.tsx
@@ -212,6 +212,7 @@ export const Deposit: React.FC<DepositProps> = ({
   } = useRouterContractAddress({
     feeAssetId: feeAsset?.assetId ?? '',
     skip: !isTokenDeposit || !feeAsset?.assetId,
+    excludeHalted: true,
   })
 
   useEffect(() => {

--- a/src/features/defi/providers/thorchain-savers/components/ThorchainSaversManager/Withdraw/components/Withdraw.tsx
+++ b/src/features/defi/providers/thorchain-savers/components/ThorchainSaversManager/Withdraw/components/Withdraw.tsx
@@ -221,7 +221,10 @@ export const Withdraw: React.FC<WithdrawProps> = ({ accountId, fromAddress, onNe
 
   const supportedEvmChainIds = useMemo(() => getSupportedEvmChainIds(), [])
 
-  const saversRouterContractAddress = useRouterContractAddress({
+  const {
+    routerContractAddress: saversRouterContractAddress,
+    isLoading: isSaversRouterContractAddressLoading,
+  } = useRouterContractAddress({
     feeAssetId: feeAsset?.assetId ?? '',
     // We do NOT want to exclude halted chains, as we're stil able to withdraw from them
     excludeHalted: false,
@@ -791,6 +794,7 @@ export const Withdraw: React.FC<WithdrawProps> = ({ accountId, fromAddress, onNe
           isEstimatedFeesDataLoading ||
           isSweepNeededLoading ||
           isThorchainSaversWithdrawQuoteLoading ||
+          isSaversRouterContractAddressLoading ||
           state.loading
         }
         percentOptions={percentOptions}

--- a/src/features/defi/providers/thorchain-savers/components/ThorchainSaversManager/Withdraw/components/Withdraw.tsx
+++ b/src/features/defi/providers/thorchain-savers/components/ThorchainSaversManager/Withdraw/components/Withdraw.tsx
@@ -31,10 +31,7 @@ import { BigNumber, bn, bnOrZero } from 'lib/bignumber/bignumber'
 import { fromBaseUnit, toBaseUnit } from 'lib/math'
 import { trackOpportunityEvent } from 'lib/mixpanel/helpers'
 import { MixPanelEvents } from 'lib/mixpanel/types'
-import {
-  fetchRouterContractAddress,
-  useRouterContractAddress,
-} from 'lib/swapper/swappers/ThorchainSwapper/utils/useRouterContractAddress'
+import { fetchRouterContractAddress } from 'lib/swapper/swappers/ThorchainSwapper/utils/useRouterContractAddress'
 import { isToken } from 'lib/utils'
 import { assertGetEvmChainAdapter, createBuildCustomTxInput } from 'lib/utils/evm'
 import { fromThorBaseUnit } from 'lib/utils/thorchain'
@@ -223,14 +220,6 @@ export const Withdraw: React.FC<WithdrawProps> = ({ accountId, fromAddress, onNe
   )
 
   const supportedEvmChainIds = useMemo(() => getSupportedEvmChainIds(), [])
-
-  // Note, we only use it to get a loading state, but actually fire the query in a non-reactive way in callbacks
-  const { isLoading: isSaversRouterContractAddressLoading } = useRouterContractAddress({
-    feeAssetId: feeAsset?.assetId ?? '',
-    // We do NOT want to exclude halted chains, as we're stil able to withdraw from them
-    excludeHalted: false,
-    skip: !isTokenWithdraw || !feeAsset?.assetId,
-  })
 
   // TODO(gomes): use useGetEstimatedFeesQuery instead of this.
   // The logic of useGetEstimatedFeesQuery and its consumption will need some touching up to work with custom Txs
@@ -802,7 +791,6 @@ export const Withdraw: React.FC<WithdrawProps> = ({ accountId, fromAddress, onNe
           isEstimatedFeesDataLoading ||
           isSweepNeededLoading ||
           isThorchainSaversWithdrawQuoteLoading ||
-          isSaversRouterContractAddressLoading ||
           state.loading
         }
         percentOptions={percentOptions}

--- a/src/features/defi/providers/thorchain-savers/components/ThorchainSaversManager/Withdraw/components/Withdraw.tsx
+++ b/src/features/defi/providers/thorchain-savers/components/ThorchainSaversManager/Withdraw/components/Withdraw.tsx
@@ -223,6 +223,8 @@ export const Withdraw: React.FC<WithdrawProps> = ({ accountId, fromAddress, onNe
 
   const saversRouterContractAddress = useRouterContractAddress({
     feeAssetId: feeAsset?.assetId ?? '',
+    // We do NOT want to exclude halted chains, as we're stil able to withdraw from them
+    excludeHalted: false,
     skip: !isTokenWithdraw || !feeAsset?.assetId,
   })
 

--- a/src/lib/swapper/swappers/ThorchainSwapper/utils/useRouterContractAddress.ts
+++ b/src/lib/swapper/swappers/ThorchainSwapper/utils/useRouterContractAddress.ts
@@ -10,17 +10,23 @@ import { getInboundAddressDataForChain } from 'lib/utils/thorchain/getInboundAdd
 export const useRouterContractAddress = ({
   skip = false,
   feeAssetId: assetId,
+  excludeHalted,
 }: {
   skip?: boolean
   // A native EVM AssetId i.e ethAssetId and avalancheAssetId, the two supported EVM chains at the time of writing
   feeAssetId: AssetId
+  excludeHalted?: boolean
 }) => {
   const [routerContractAddress, setRouterContractAddress] = useState<string | null>(null)
 
   const fetchRouterContractAddress = useCallback(async () => {
     try {
       const daemonUrl = getConfig().REACT_APP_THORCHAIN_NODE_URL
-      const maybeInboundAddressData = await getInboundAddressDataForChain(daemonUrl, assetId)
+      const maybeInboundAddressData = await getInboundAddressDataForChain(
+        daemonUrl,
+        assetId,
+        excludeHalted,
+      )
 
       if (maybeInboundAddressData.isErr()) {
         throw new Error(maybeInboundAddressData.unwrapErr().message)
@@ -38,7 +44,7 @@ export const useRouterContractAddress = ({
       console.error(error)
       setRouterContractAddress(null)
     }
-  }, [assetId])
+  }, [assetId, excludeHalted])
 
   useEffect(() => {
     if (skip) return

--- a/src/lib/swapper/swappers/ThorchainSwapper/utils/useRouterContractAddress.ts
+++ b/src/lib/swapper/swappers/ThorchainSwapper/utils/useRouterContractAddress.ts
@@ -18,8 +18,10 @@ export const useRouterContractAddress = ({
   excludeHalted?: boolean
 }) => {
   const [routerContractAddress, setRouterContractAddress] = useState<string | null>(null)
+  const [isLoading, setIsLoading] = useState(false)
 
   const fetchRouterContractAddress = useCallback(async () => {
+    setIsLoading(true)
     try {
       const daemonUrl = getConfig().REACT_APP_THORCHAIN_NODE_URL
       const maybeInboundAddressData = await getInboundAddressDataForChain(
@@ -43,6 +45,8 @@ export const useRouterContractAddress = ({
     } catch (error) {
       console.error(error)
       setRouterContractAddress(null)
+    } finally {
+      setIsLoading(false)
     }
   }, [assetId, excludeHalted])
 
@@ -55,5 +59,5 @@ export const useRouterContractAddress = ({
     fetchRouterContractAddress()
   }, [skip, fetchRouterContractAddress, assetId])
 
-  return routerContractAddress
+  return { routerContractAddress, isLoading }
 }

--- a/src/lib/swapper/swappers/ThorchainSwapper/utils/useRouterContractAddress.ts
+++ b/src/lib/swapper/swappers/ThorchainSwapper/utils/useRouterContractAddress.ts
@@ -1,11 +1,32 @@
 import { type AssetId, fromAssetId } from '@shapeshiftoss/caip'
 import { isEvmChainId } from '@shapeshiftoss/chain-adapters'
+import { useQuery } from '@tanstack/react-query'
 import { getConfig } from 'config'
-import { useCallback, useEffect, useState } from 'react'
 import { getInboundAddressDataForChain } from 'lib/utils/thorchain/getInboundAddressDataForChain'
 
 // Fetches the THOR router contract address for a given feeAssetId
 // This is used to determine the correct router contract address for THOR contract approvals, swaps, and savers deposits/withdraws.
+
+export const fetchRouterContractAddress = async (assetId: AssetId, excludeHalted: boolean) => {
+  const daemonUrl = getConfig().REACT_APP_THORCHAIN_NODE_URL
+  const maybeInboundAddressData = await getInboundAddressDataForChain(
+    daemonUrl,
+    assetId,
+    excludeHalted,
+  )
+
+  if (maybeInboundAddressData.isErr()) {
+    throw new Error(maybeInboundAddressData.unwrapErr().message)
+  }
+
+  const inboundAddressData = maybeInboundAddressData.unwrap()
+
+  if (!inboundAddressData.router) {
+    throw new Error(`No router address found for feeAsset ${assetId}`)
+  }
+
+  return inboundAddressData.router
+}
 
 export const useRouterContractAddress = ({
   skip = false,
@@ -13,51 +34,18 @@ export const useRouterContractAddress = ({
   excludeHalted,
 }: {
   skip?: boolean
-  // A native EVM AssetId i.e ethAssetId and avalancheAssetId, the two supported EVM chains at the time of writing
   feeAssetId: AssetId
   excludeHalted?: boolean
 }) => {
-  const [routerContractAddress, setRouterContractAddress] = useState<string | null>(null)
-  const [isLoading, setIsLoading] = useState(false)
+  const { chainId } = fromAssetId(assetId)
+  const isEvmChain = isEvmChainId(chainId)
 
-  const fetchRouterContractAddress = useCallback(async () => {
-    setIsLoading(true)
-    try {
-      const daemonUrl = getConfig().REACT_APP_THORCHAIN_NODE_URL
-      const maybeInboundAddressData = await getInboundAddressDataForChain(
-        daemonUrl,
-        assetId,
-        excludeHalted,
-      )
-
-      if (maybeInboundAddressData.isErr()) {
-        throw new Error(maybeInboundAddressData.unwrapErr().message)
-      }
-
-      const inboundAddressData = maybeInboundAddressData.unwrap()
-
-      // This should never happen as we're passing EVM native AssetIds here, but it may
-      if (!inboundAddressData.router) {
-        throw new Error(`No router address found for feeAsset ${assetId}`)
-      }
-
-      setRouterContractAddress(inboundAddressData.router)
-    } catch (error) {
-      console.error(error)
-      setRouterContractAddress(null)
-    } finally {
-      setIsLoading(false)
-    }
-  }, [assetId, excludeHalted])
-
-  useEffect(() => {
-    if (skip) return
-
-    const { chainId } = fromAssetId(assetId)
-    if (!isEvmChainId(chainId)) return
-
-    fetchRouterContractAddress()
-  }, [skip, fetchRouterContractAddress, assetId])
+  const { data: routerContractAddress, isLoading } = useQuery({
+    queryKey: ['routerContractAddress', assetId, excludeHalted],
+    queryFn: () => fetchRouterContractAddress(assetId, Boolean(excludeHalted)),
+    enabled: !skip && isEvmChain,
+    staleTime: 120_000, // 2mn arbitrary staleTime to avoid refetching for the same args (assetId, excludeHalted)
+  })
 
   return { routerContractAddress, isLoading }
 }


### PR DESCRIPTION
## Description

We do *not* want to exclude halted pools when getting inbound addresses for withdraws, as halted pools can still be withdrawn from.

While at it, also ~~introduces a loading state so we do not react too early on missing inbound address for chain and throw~~ makes `useRouterContractAddress` expose a cached react-query, so we can leverage loading states and fire in a non-hook fashion in callbacks, ensuring we await the data.

## Pull Request Type

- [x] :bug: Bug fix (Non-breaking Change: Fixes an issue)
- [ ] :hammer_and_wrench: Chore (Non-breaking Change: Doc updates, pkg upgrades, typos, etc..)
- [ ] :nail_care: New Feature (Breaking/Non-breaking Change)

## Issue (if applicable)

<!-----------------------------------------------------------------------------
If applicable, please link to the github issue and put `closes #XXXX` in your comment to auto-close the issue that your PR fixes.
------------------------------------------------------------------------------>

closes N/A, see https://discord.com/channels/554694662431178782/1184599011349516418/1184599056815755294

## Risk

<!-----------------------------------------------------------------------------
Outline the scope of your changes and the risk associated with them. You must use your discretion as an engineer to determine the potential impact of your changes.

E.g. an upgrade to `hdwallet` or core state management would be considered higher risk, and might require a full regression test. UI or isolated view changes, or something behind a feature flag may have near zero risk. Small bug fixes might require testing isolated to the specific fix.
------------------------------------------------------------------------------>

Can't break this more than it was, i.e none

## Testing

<!-----------------------------------------------------------------------------
We treat every PR to be merged with the same scrutiny as if we were merging directly to production.

Your PR will not be merged if you do not complete the sections below for our engineering and operations teams to test.
------------------------------------------------------------------------------>

- Open an EVM token savers overview page and click withdraw
- Select an amount and ensure we do not see a `No router contract address found for feeAsset: {asset}` error

### Engineering

<!-----------------------------------------------------------------------------
Include sufficient information here for an engineer to test your PR. This may include how to test locally, in a built environment, changes to infrastructure etc.
------------------------------------------------------------------------------>

- ☝🏽 
- As an added bonus, note *inbound_addresses` XHRs now only fire once instead of multiple times

### Operations

<!-----------------------------------------------------------------------------
If your changes have a user-facing impact, describe how a non-technical QA team can functionally test your changes in a preview environment.

If they are not user-facing please describe how to test for any regressions that may occur.
------------------------------------------------------------------------------>

- ☝🏽 

## Screenshots (if applicable)

![image](https://github.com/shapeshift/web/assets/17035424/3d09b9cf-ea03-4714-8514-2f9c76cb3568)