### PR TITLE
fix: disconnect all wc dApps sessions on wcv2 connect

### DIFF
--- a/src/plugins/walletConnectToDapps/WalletConnectV2Provider.tsx
+++ b/src/plugins/walletConnectToDapps/WalletConnectV2Provider.tsx
@@ -58,9 +58,6 @@ export const WalletConnectV2Provider: FC<PropsWithChildren> = ({ children }) => 
   }, [state.core?.pairing, state.web3wallet])
 
   useEffect(() => {
-    // If we are connected to a wallet via wallet connect then this logic does not apply.
-    if (walletInfo?.name === 'WalletConnect') return
-
     // NOTE: don't use `useAppSelector(selectWalletId)` because it introduces a race condition
     const deviceId = walletInfo?.deviceId
 


### PR DESCRIPTION
## Description

Ensures we clear connected WalletConnect to dApps session when connecting a wallet via WalletConnectV2 wallet provider.

## Pull Request Type

- [x] :bug: Bug fix (Non-breaking Change: Fixes an issue)
- [ ] :hammer_and_wrench: Chore (Non-breaking Change: Doc updates, pkg upgrades, typos, etc..)
- [ ] :nail_care: New Feature (Breaking/Non-breaking Change)

## Issue (if applicable)

<!-----------------------------------------------------------------------------
If applicable, please link to the github issue and put `closes #XXXX` in your comment to auto-close the issue that your PR fixes.
------------------------------------------------------------------------------>

closes https://github.com/shapeshift/web/issues/5408

## Risk

<!-----------------------------------------------------------------------------
Outline the scope of your changes and the risk associated with them. You must use your discretion as an engineer to determine the potential impact of your changes.

E.g. an upgrade to `hdwallet` or core state management would be considered higher risk, and might require a full regression test. UI or isolated view changes, or something behind a feature flag may have near zero risk. Small bug fixes might require testing isolated to the specific fix.
------------------------------------------------------------------------------>

WCV2 wallet connection may be broken, test accordingly

## Testing

<!-----------------------------------------------------------------------------
We treat every PR to be merged with the same scrutiny as if we were merging directly to production.

Your PR will not be merged if you do not complete the sections below for our engineering and operations teams to test.
------------------------------------------------------------------------------>

- Connect to native or KK
- Connect to Uniswap as a dApp (preferred, as not all dApps seem to handle disconnections gracefully which can give false positives for testing this)
- Notice the dApp is connected in the WC dApps header menu, and your wallet EVM address displays as connected in Uniswap's header WC menu
- Connect a wallet via WalletConnect
- Ensure the wallet is properly shown as disconnected in Uniswap
- Reconnect to the same native wallet and notice dApp connection is gone

### Engineering

<!-----------------------------------------------------------------------------
Include sufficient information here for an engineer to test your PR. This may include how to test locally, in a built environment, changes to infrastructure etc.
------------------------------------------------------------------------------>

- ☝🏽 

### Operations

<!-----------------------------------------------------------------------------
If your changes have a user-facing impact, describe how a non-technical QA team can functionally test your changes in a preview environment.

If they are not user-facing please describe how to test for any regressions that may occur.
------------------------------------------------------------------------------>

- ☝🏽 

## Screenshots (if applicable)

- Native connected, no dApp connection to Uniswap just yet

<img width="443" alt="Screenshot 2023-12-14 at 13 24 22" src="https://github.com/shapeshift/web/assets/17035424/6d0b61c0-2f6e-4a00-9883-81a7c243f704">
<img width="158" alt="Screenshot 2023-12-14 at 13 24 55" src="https://github.com/shapeshift/web/assets/17035424/dfa4632a-ab3c-442c-9f41-8b9b88069356">

- Connected to Uni dApp, and ready to connect WCV2 as a wallet

<img width="807" alt="Screenshot 2023-12-14 at 13 25 41" src="https://github.com/shapeshift/web/assets/17035424/333cc67e-6b71-42fc-b51e-0bb027a0c0b0">

- WCV2 connected, and dApp is properly disconnected

<img width="173" alt="Screenshot 2023-12-14 at 13 26 07" src="https://github.com/shapeshift/web/assets/17035424/6353b70b-b9a0-406f-991c-2a7826871c22">

- Reconnect to native

<img width="447" alt="image" src="https://github.com/shapeshift/web/assets/17035424/d8912d32-6095-4f8e-9b4e-831c4bbee513">