### PR TITLE
chore: bump wagmi resolution to 1.4.12

### DIFF
--- a/package.json
+++ b/package.json
@@ -289,7 +289,7 @@
     "react-dev-utils/fork-ts-checker-webpack-plugin": "^6.5.3",
     "p-queue": "^6.6.2",
     "web3": "4.2.1-dev.a0d6730.0",
-    "@wherever/react-notification-feed/wagmi": "^0.10.9"
+    "@wherever/react-notification-feed/wagmi": "^0.10.12"
   },
   "jest": {
     "preset": "ts-jest",

--- a/yarn.lock
+++ b/yarn.lock
@@ -34749,7 +34749,7 @@ pvutils@latest:
   languageName: node
   linkType: hard
 
-"wagmi@npm:^0.10.9":
+"wagmi@npm:^0.10.12":
   version: 0.10.15
   resolution: "wagmi@npm:0.10.15"
   dependencies:


### PR DESCRIPTION
## Description

Bump `wagmi` resolution for the `@wherever/react-notification-feed` package to `1.4.12`.

https://github.com/wevm/wagmi/releases/tag/wagmi%401.4.12

## Pull Request Type

- [ ] :bug: Bug fix (Non-breaking Change: Fixes an issue)
- [x] :hammer_and_wrench: Chore (Non-breaking Change: Doc updates, pkg upgrades, typos, etc..)
- [ ] :nail_care: New Feature (Breaking/Non-breaking Change)

## Issue (if applicable)

N/A - improve security.

## Risk

Small, minor bump.

## Testing

Wherever should still work as expected.

### Engineering

☝️

### Operations

☝️

## Screenshots (if applicable)

N/A