### PR TITLE
feat: search entire UniswapV3 fee range for longtail swaps

### DIFF
--- a/src/lib/swapper/swappers/ThorchainSwapper/utils/getLongtailQuote.ts
+++ b/src/lib/swapper/swappers/ThorchainSwapper/utils/getLongtailQuote.ts
@@ -109,7 +109,7 @@ export const getLongtailToL1Quote = async (
     return Err(
       makeSwapErrorRight({
         message: `[getThorTradeQuote] - No best aggregator contract found.`,
-        code: SwapErrorType.TRADE_QUOTE_FAILED,
+        code: SwapErrorType.UNSUPPORTED_PAIR,
       }),
     )
   }

--- a/src/lib/swapper/swappers/ThorchainSwapper/utils/getLongtailQuote.ts
+++ b/src/lib/swapper/swappers/ThorchainSwapper/utils/getLongtailQuote.ts
@@ -129,7 +129,7 @@ export const getLongtailToL1Quote = async (
   return thorchainQuotes.andThen(quotes => {
     const updatedQuotes: ThorTradeQuote[] = quotes.map(q => ({
       ...q,
-      router: bestPool,
+      router: bestAggregator,
       steps: q.steps.map(s => ({
         ...s,
         // This logic will need to be updated to support multi-hop, if that's ever implemented for THORChain

--- a/src/lib/swapper/swappers/ThorchainSwapper/utils/longTailHelpers.ts
+++ b/src/lib/swapper/swappers/ThorchainSwapper/utils/longTailHelpers.ts
@@ -165,7 +165,8 @@ export const selectBestRate = (
       addressWithHighestAmount: [Address, bigint] | undefined,
       [poolAddress, amount]: [Address, bigint],
     ) => {
-      return amount > (addressWithHighestAmount?.[1] ?? BigInt(0))
+      if (addressWithHighestAmount === undefined) return [poolAddress, amount]
+      return amount > addressWithHighestAmount?.[1]
         ? [poolAddress, amount]
         : addressWithHighestAmount
     },

--- a/src/lib/swapper/swappers/ThorchainSwapper/utils/longTailHelpers.ts
+++ b/src/lib/swapper/swappers/ThorchainSwapper/utils/longTailHelpers.ts
@@ -74,6 +74,13 @@ export const contractToFeeAmountMap: Record<AggregatorContract, FeeAmount> = {
   [AggregatorContract.TSAggregatorUniswapV3_10000]: FeeAmount.HIGH,
 }
 
+export const feeAmountToContractMap: Record<FeeAmount, AggregatorContract> = Object.entries(
+  contractToFeeAmountMap,
+).reduce(
+  (acc, [key, value]) => ({ ...acc, [value]: key }),
+  {} as Record<FeeAmount, AggregatorContract>,
+)
+
 export const generateV3PoolAddressesAcrossFeeRange = (
   factoryAddress: string,
   tokenA: Token,
@@ -100,7 +107,7 @@ type ContractData = {
   tokenOut: Address
 }
 
-export const getPoolContractData = async (
+export const getContractDataByPool = async (
   poolAddresses: Map<Address, FeeAmount>,
   publicClient: PublicClient,
   tokenAAddress: string,
@@ -133,7 +140,7 @@ export const getPoolContractData = async (
   return poolContracts
 }
 
-export const getQuotedAmountOuts = (
+export const getQuotedAmountOutByPool = (
   poolContracts: Map<Address, ContractData>,
   sellAmount: bigint,
   quoterContract: GetContractReturnType<typeof QuoterAbi, PublicClient, WalletClient>,
@@ -156,10 +163,10 @@ export const selectBestRate = (
   return Array.from(quotedAmounts.entries()).reduce(
     (
       addressWithHighestAmount: [Address, bigint] | undefined,
-      [address, amount]: [Address, bigint],
+      [poolAddress, amount]: [Address, bigint],
     ) => {
       return amount > (addressWithHighestAmount?.[1] ?? BigInt(0))
-        ? [address, amount]
+        ? [poolAddress, amount]
         : addressWithHighestAmount
     },
     undefined,


### PR DESCRIPTION
## Description

Adds UniswapV3 pool optimization to long-tail swaps, enabling more assets and better rates.

This PR adds the ability to search all fee ranges for a given asset pair's available pools, get a quote for each, and transact against the contract resulting in the best rate. In particular, we'll get better rates for assets with tight liquidity pools.

Also adds support for additional assets that did not have pools for the `3000` fee range of UniswapV3.

An example to see this working: compare the rate between this branch and prod for LINK to DOGE.

## Pull Request Type

- [ ] :bug: Bug fix (Non-breaking Change: Fixes an issue)
- [ ] :hammer_and_wrench: Chore (Non-breaking Change: Doc updates, pkg upgrades, typos, etc..)
- [x] :nail_care: New Feature (Breaking/Non-breaking Change)

## Issue (if applicable)

Closes https://github.com/shapeshift/web/issues/5878

## Risk

High risk to long-tail swaps - we'll want to test these again, as messing up the contracts here (e.g. using a non-whitelisted  contract) could lead to funds landing in a black hole.

## Testing

Perform longtail swaps on a range of assets (the sell asset is important, not so much the buy asset - so just use the cheapest).

### Engineering

Sanity check the contract selection logic - using the wrong aggregator contract will cause lost funds.

### Operations

☝️

## Screenshots (if applicable)

N/A