### PR TITLE
fix: swapper dot-first notation input

### DIFF
--- a/src/components/MultiHopTrade/components/TradeInput/components/SellAssetInput.tsx
+++ b/src/components/MultiHopTrade/components/TradeInput/components/SellAssetInput.tsx
@@ -1,6 +1,6 @@
 import type { AccountId } from '@shapeshiftoss/caip'
 import type { Asset } from '@shapeshiftoss/types'
-import { memo, useCallback, useEffect, useState } from 'react'
+import { memo, useCallback, useEffect, useMemo, useState } from 'react'
 import type { AccountDropdownProps } from 'components/AccountDropdown/AccountDropdown'
 import type { TradeAssetInputProps } from 'components/MultiHopTrade/components/TradeAssetInput'
 import { TradeAssetInput } from 'components/MultiHopTrade/components/TradeAssetInput'
@@ -37,7 +37,12 @@ export const SellAssetInput = memo(
       (sellAmountUserCurrencyHuman: string, sellAmountCryptoPrecision: string) => {
         setSellAmountUserCurrencyHuman(sellAmountUserCurrencyHuman)
         setSellAmountCryptoPrecision(sellAmountCryptoPrecision)
-        dispatch(swappers.actions.setSellAmountCryptoPrecision(sellAmountCryptoPrecision))
+
+        dispatch(
+          swappers.actions.setSellAmountCryptoPrecision(
+            positiveOrZero(sellAmountCryptoPrecision).toString(),
+          ),
+        )
       },
       [dispatch],
     )
@@ -60,14 +65,25 @@ export const SellAssetInput = memo(
       handleSellAssetInputChangeInner('0', '0')
     }, [asset, handleSellAssetInputChangeInner])
 
+    // Allow decimals to be entered in the form of . as the first character
+    const cryptoAmount = useMemo(() => {
+      if (sellAmountCryptoPrecision === '.') return sellAmountCryptoPrecision
+      return positiveOrZero(sellAmountCryptoPrecision).toString()
+    }, [sellAmountCryptoPrecision])
+
+    const fiatAmount = useMemo(() => {
+      if (sellAmountUserCurrencyHuman === '.') return sellAmountUserCurrencyHuman
+      return positiveOrZero(sellAmountUserCurrencyHuman).toString()
+    }, [sellAmountUserCurrencyHuman])
+
     return (
       <TradeAssetInput
         accountId={accountId}
         assetId={asset.assetId}
         assetSymbol={asset.symbol}
         assetIcon={asset.icon}
-        cryptoAmount={positiveOrZero(sellAmountCryptoPrecision).toString()}
-        fiatAmount={positiveOrZero(sellAmountUserCurrencyHuman).toString()}
+        cryptoAmount={cryptoAmount}
+        fiatAmount={fiatAmount}
         isSendMaxDisabled={false}
         onChange={handleSellAssetInputChange}
         percentOptions={percentOptions}


### PR DESCRIPTION
## Description

Does what it says on the box

## Pull Request Type

- [ ] :bug: Bug fix (Non-breaking Change: Fixes an issue)
- [ ] :hammer_and_wrench: Chore (Non-breaking Change: Doc updates, pkg upgrades, typos, etc..)
- [x] :nail_care: New Feature (Breaking/Non-breaking Change)

## Issue (if applicable)

<!-----------------------------------------------------------------------------
If applicable, please link to the github issue and put `closes #XXXX` in your comment to auto-close the issue that your PR fixes.
------------------------------------------------------------------------------>

closes https://github.com/shapeshift/web/issues/5818

## Risk

<!-----------------------------------------------------------------------------
Outline the scope of your changes and the risk associated with them. You must use your discretion as an engineer to determine the potential impact of your changes.

E.g. an upgrade to `hdwallet` or core state management would be considered higher risk, and might require a full regression test. UI or isolated view changes, or something behind a feature flag may have near zero risk. Small bug fixes might require testing isolated to the specific fix.
------------------------------------------------------------------------------>

Swapper input may be borked under certain scenarios?

## Testing

<!-----------------------------------------------------------------------------
We treat every PR to be merged with the same scrutiny as if we were merging directly to production.

Your PR will not be merged if you do not complete the sections below for our engineering and operations teams to test.
------------------------------------------------------------------------------>

- Dot notation input is happy as a first input
- Dot notation input is happy when inputting an integer/float *not* in the dot notation (i.e 0.1 or 1, but not .1), selecting all text, and inputting a dot notation number instead
- Input doesn't wrongly change to the wrong notation when the input loses focus (i.e click outside of swapper)

### Engineering

<!-----------------------------------------------------------------------------
Include sufficient information here for an engineer to test your PR. This may include how to test locally, in a built environment, changes to infrastructure etc.
------------------------------------------------------------------------------>

- ☝🏽 

### Operations

<!-----------------------------------------------------------------------------
If your changes have a user-facing impact, describe how a non-technical QA team can functionally test your changes in a preview environment.

If they are not user-facing please describe how to test for any regressions that may occur.
------------------------------------------------------------------------------>

- ☝🏽 

## Screenshots (if applicable)

https://github.com/shapeshift/web/assets/17035424/4598325c-dbb4-43af-9621-ef5a66b63611


