### PR TITLE
fix: await tx indexing before completing a trade

### DIFF
--- a/src/assets/translations/en/main.json
+++ b/src/assets/translations/en/main.json
@@ -821,7 +821,11 @@
     "enableMetaMaskSnap": "use the multichain snap",
     "approvalGasFee": "Approval gas fee %{fee}",
     "approvalFailed": "A problem occurred during allowance approval",
-    "swapFailed": "A problem occurred executing the %{tradeType}"
+    "swapFailed": "A problem occurred executing the %{tradeType}",
+    "tradeComplete": "You now have %{cryptoAmountFormatted} in your wallet on %{chainName}.",
+    "doAnotherTrade": "Do another trade",
+    "showDetails": "Show Details",
+    "transactionSuccessful": "Transaction successful, waiting for confirmations"
   },
   "modals": {
     "popup": {

--- a/src/components/MultiHopTrade/components/MultiHopTradeConfirm/components/ApprovalStep.tsx
+++ b/src/components/MultiHopTrade/components/MultiHopTradeConfirm/components/ApprovalStep.tsx
@@ -1,7 +1,7 @@
 import { Box, Button, Card, Icon, Link, Switch, Tooltip, VStack } from '@chakra-ui/react'
 import type { TradeQuoteStep } from '@shapeshiftoss/swapper'
 import { useCallback, useMemo } from 'react'
-import { FaInfoCircle, FaThumbsUp } from 'react-icons/fa'
+import { FaInfoCircle } from 'react-icons/fa'
 import { useTranslate } from 'react-polyglot'
 import { MiddleEllipsis } from 'components/MiddleEllipsis/MiddleEllipsis'
 import { Row } from 'components/Row/Row'
@@ -11,11 +11,11 @@ import { useToggle } from 'hooks/useToggle/useToggle'
 import { fromBaseUnit } from 'lib/math'
 import { selectFeeAssetById } from 'state/slices/selectors'
 import { selectHopExecutionMetadata } from 'state/slices/tradeQuoteSlice/selectors'
-import { TransactionExecutionState } from 'state/slices/tradeQuoteSlice/types'
+import { HopExecutionState, TransactionExecutionState } from 'state/slices/tradeQuoteSlice/types'
 import { store, useAppSelector } from 'state/store'
 
 import { useAllowanceApproval } from '../hooks/useAllowanceApproval'
-import { StatusIcon } from './StatusIcon'
+import { ApprovalStatusIcon } from './StatusIcon'
 import { StepperStep } from './StepperStep'
 
 export type ApprovalStepProps = {
@@ -26,7 +26,46 @@ export type ApprovalStepProps = {
   isLoading?: boolean
 }
 
-export const ApprovalStep = ({
+type ApprovalDescriptionProps = {
+  tradeQuoteStep: TradeQuoteStep
+  isError: boolean
+  txHash: string | undefined
+  approvalNetworkFeeCryptoFormatted: string | undefined
+}
+
+const ApprovalDescription = ({
+  tradeQuoteStep,
+  isError,
+  txHash,
+  approvalNetworkFeeCryptoFormatted,
+}: ApprovalDescriptionProps) => {
+  const translate = useTranslate()
+  const errorMsg = isError ? (
+    <Text color='text.error' translation='trade.approvalFailed' fontWeight='bold' />
+  ) : null
+
+  if (!txHash) {
+    return (
+      <>
+        {errorMsg}
+        {translate('trade.approvalGasFee', { fee: approvalNetworkFeeCryptoFormatted ?? '' })}
+      </>
+    )
+  }
+
+  const href = `${tradeQuoteStep.sellAsset.explorerTxLink}${txHash}`
+
+  return (
+    <>
+      {errorMsg}
+      <Link isExternal href={href} color='text.link'>
+        <MiddleEllipsis value={txHash} />
+      </Link>
+    </>
+  )
+}
+
+const ApprovalStepPending = ({
   tradeQuoteStep,
   hopIndex,
   isActive,
@@ -40,7 +79,8 @@ export const ApprovalStep = ({
   const [isExactAllowance, toggleIsExactAllowance] = useToggle(false)
 
   const {
-    approval: { txHash, state: approvalTxState },
+    state,
+    approval: { state: approvalTxState },
   } = useAppSelector(state => selectHopExecutionMetadata(state, hopIndex))
 
   const isError = useMemo(
@@ -81,49 +121,25 @@ export const ApprovalStep = ({
       : ''
 
   const stepIndicator = useMemo(() => {
-    const defaultIcon = <FaThumbsUp />
-    // eslint too stoopid to realize this is inside the context of useMemo already
-    // eslint-disable-next-line react-memo/require-usememo
-    return <StatusIcon txStatus={approvalTxState} defaultIcon={defaultIcon} />
-  }, [approvalTxState])
+    return <ApprovalStatusIcon hopExecutionState={state} approvalTxState={approvalTxState} />
+  }, [approvalTxState, state])
 
   const translate = useTranslate()
 
   const description = useMemo(() => {
-    const errorMsg = isError ? (
-      <Text color='text.error' translation='trade.approvalFailed' fontWeight='bold' />
-    ) : null
-
-    if (!txHash) {
-      return (
-        <>
-          {errorMsg}
-          {translate('trade.approvalGasFee', { fee: approvalNetworkFeeCryptoFormatted })}
-        </>
-      )
-    }
-
-    const href = `${tradeQuoteStep.sellAsset.explorerTxLink}${txHash}`
-
     return (
-      <>
-        {errorMsg}
-        <Link isExternal href={href} color='text.link'>
-          <MiddleEllipsis value={txHash} />
-        </Link>
-      </>
+      <ApprovalDescription
+        tradeQuoteStep={tradeQuoteStep}
+        isError={isError}
+        txHash={undefined}
+        approvalNetworkFeeCryptoFormatted={approvalNetworkFeeCryptoFormatted}
+      />
     )
-  }, [
-    approvalNetworkFeeCryptoFormatted,
-    isError,
-    tradeQuoteStep.sellAsset.explorerTxLink,
-    translate,
-    txHash,
-  ])
+  }, [approvalNetworkFeeCryptoFormatted, isError, tradeQuoteStep])
 
   const content = useMemo(() => {
     // only render the approval button when the component is active and we don't yet have a tx hash
-    if (txHash !== undefined || !isActive) return
+    if (approvalTxState !== TransactionExecutionState.AwaitingConfirmation || !isActive) return
 
     return (
       <Card p='2' width='full'>
@@ -162,9 +178,7 @@ export const ApprovalStep = ({
             size='sm'
             colorScheme='blue'
             disabled={isAllowanceApprovalLoading || !canAttemptApproval}
-            isLoading={
-              isAllowanceApprovalLoading || approvalTxState === TransactionExecutionState.Pending
-            }
+            isLoading={isAllowanceApprovalLoading}
             onClick={handleSignAllowanceApproval}
           >
             {translate('common.approve')}
@@ -181,7 +195,6 @@ export const ApprovalStep = ({
     isExactAllowance,
     toggleIsExactAllowance,
     translate,
-    txHash,
   ])
 
   return (
@@ -194,6 +207,84 @@ export const ApprovalStep = ({
       isLoading={isLoading}
       isError={approvalTxState === TransactionExecutionState.Failed}
       isPending={approvalTxState === TransactionExecutionState.Pending}
+    />
+  )
+}
+
+const ApprovalStepComplete = ({
+  tradeQuoteStep,
+  hopIndex,
+  isLastStep,
+  isLoading,
+}: ApprovalStepProps) => {
+  const {
+    state,
+    approval: { txHash, state: approvalTxState },
+  } = useAppSelector(state => selectHopExecutionMetadata(state, hopIndex))
+
+  const isError = useMemo(
+    () => approvalTxState === TransactionExecutionState.Failed,
+    [approvalTxState],
+  )
+
+  const stepIndicator = useMemo(() => {
+    return <ApprovalStatusIcon hopExecutionState={state} approvalTxState={approvalTxState} />
+  }, [approvalTxState, state])
+
+  const description = useMemo(() => {
+    return (
+      <ApprovalDescription
+        tradeQuoteStep={tradeQuoteStep}
+        isError={isError}
+        txHash={txHash}
+        approvalNetworkFeeCryptoFormatted={undefined}
+      />
+    )
+  }, [isError, tradeQuoteStep, txHash])
+
+  return (
+    <StepperStep
+      title='Token allowance approval'
+      description={description}
+      stepIndicator={stepIndicator}
+      content={undefined}
+      isLastStep={isLastStep}
+      isLoading={isLoading}
+      isError={approvalTxState === TransactionExecutionState.Failed}
+      isPending={approvalTxState === TransactionExecutionState.Pending}
+    />
+  )
+}
+
+export const ApprovalStep = ({
+  tradeQuoteStep,
+  hopIndex,
+  isActive,
+  isLastStep,
+  isLoading,
+}: ApprovalStepProps) => {
+  const { state } = useAppSelector(state => selectHopExecutionMetadata(state, hopIndex))
+
+  // separate component for completed states to simplify hook dismount
+  if (state === HopExecutionState.AwaitingSwap || state === HopExecutionState.Complete) {
+    return (
+      <ApprovalStepComplete
+        tradeQuoteStep={tradeQuoteStep}
+        hopIndex={hopIndex}
+        isActive={isActive}
+        isLastStep={isLastStep}
+        isLoading={isLoading}
+      />
+    )
+  }
+
+  return (
+    <ApprovalStepPending
+      tradeQuoteStep={tradeQuoteStep}
+      hopIndex={hopIndex}
+      isActive={isActive}
+      isLastStep={isLastStep}
+      isLoading={isLoading}
     />
   )
 }

--- a/src/components/MultiHopTrade/components/MultiHopTradeConfirm/components/StatusIcon.tsx
+++ b/src/components/MultiHopTrade/components/MultiHopTradeConfirm/components/StatusIcon.tsx
@@ -1,8 +1,10 @@
 import { CheckCircleIcon, WarningIcon } from '@chakra-ui/icons'
 import { Circle } from '@chakra-ui/react'
+import { useMemo } from 'react'
+import { FaThumbsUp } from 'react-icons/fa'
 import { CircularProgress } from 'components/CircularProgress/CircularProgress'
 import { assertUnreachable } from 'lib/utils'
-import { TransactionExecutionState } from 'state/slices/tradeQuoteSlice/types'
+import { HopExecutionState, TransactionExecutionState } from 'state/slices/tradeQuoteSlice/types'
 
 export const StatusIcon = ({
   txStatus,
@@ -36,4 +38,34 @@ export const StatusIcon = ({
     default:
       assertUnreachable(txStatus)
   }
+}
+
+export const ApprovalStatusIcon = ({
+  hopExecutionState,
+  approvalTxState,
+}: {
+  hopExecutionState: HopExecutionState
+  approvalTxState: TransactionExecutionState
+}) => {
+  const defaultIcon = useMemo(() => <FaThumbsUp />, [])
+  const txStatus = useMemo(() => {
+    switch (hopExecutionState) {
+      case HopExecutionState.Pending:
+        return TransactionExecutionState.AwaitingConfirmation
+      case HopExecutionState.AwaitingApproval:
+        // override completed state to pending, isApprovalNeeded dictates this
+        if (approvalTxState === TransactionExecutionState.Complete) {
+          return TransactionExecutionState.Pending
+        }
+
+        return approvalTxState
+      // override approvalTxState if external approval triggered app to proceed to next step
+      case HopExecutionState.AwaitingSwap:
+      case HopExecutionState.Complete:
+        return TransactionExecutionState.Complete
+      default:
+        assertUnreachable(hopExecutionState)
+    }
+  }, [hopExecutionState, approvalTxState])
+  return <StatusIcon txStatus={txStatus} defaultIcon={defaultIcon} />
 }

--- a/src/components/MultiHopTrade/components/MultiHopTradeConfirm/hooks/useIsApprovalInitiallyNeeded.tsx
+++ b/src/components/MultiHopTrade/components/MultiHopTradeConfirm/hooks/useIsApprovalInitiallyNeeded.tsx
@@ -1,6 +1,7 @@
 import type { AccountId } from '@shapeshiftoss/caip'
+import { isEvmChainId } from '@shapeshiftoss/chain-adapters'
 import type { TradeQuoteStep } from '@shapeshiftoss/swapper'
-import { useEffect, useState } from 'react'
+import { useEffect, useMemo, useState } from 'react'
 import { selectFirstHopSellAccountId } from 'state/slices/selectors'
 import {
   selectFirstHop,
@@ -17,7 +18,18 @@ const useIsApprovalInitiallyNeededForHop = (
   tradeQuoteStep: TradeQuoteStep | undefined,
   sellAssetAccountId: AccountId | undefined,
 ) => {
-  const [watchIsApprovalNeeded, setWatchIsApprovalNeeded] = useState<boolean>(true)
+  const {
+    sellAsset: { chainId },
+  } = useMemo(
+    () =>
+      tradeQuoteStep ?? {
+        sellAsset: { chainId: undefined },
+      },
+    [tradeQuoteStep],
+  )
+  const [watchIsApprovalNeeded, setWatchIsApprovalNeeded] = useState<boolean>(
+    Boolean(chainId && isEvmChainId(chainId)),
+  )
   const [isApprovalInitiallyNeeded, setIsApprovalInitiallyNeeded] = useState<boolean | undefined>()
 
   const { isLoading, isApprovalNeeded } = useIsApprovalNeeded(

--- a/src/components/MultiHopTrade/components/MultiHopTradeConfirm/hooks/useTradeExecution.tsx
+++ b/src/components/MultiHopTrade/components/MultiHopTradeConfirm/hooks/useTradeExecution.tsx
@@ -24,7 +24,6 @@ import {
   selectTradeSlippagePercentageDecimal,
 } from 'state/slices/tradeQuoteSlice/selectors'
 import { tradeQuoteSlice } from 'state/slices/tradeQuoteSlice/tradeQuoteSlice'
-import { waitForTransactionHash } from 'state/slices/txHistorySlice/txHistorySlice'
 import { useAppDispatch, useAppSelector } from 'state/store'
 
 export const useTradeExecution = (hopIndex: number) => {
@@ -91,7 +90,7 @@ export const useTradeExecution = (hopIndex: number) => {
           tradeQuoteSlice.actions.setSwapBuyTxHash({ hopIndex, buyTxHash })
         }
       })
-      execution.on(TradeExecutionEvent.Success, async () => {
+      execution.on(TradeExecutionEvent.Success, () => {
         if (!txHash) {
           showErrorToast(Error('missing txHash'))
           resolve()
@@ -113,7 +112,10 @@ export const useTradeExecution = (hopIndex: number) => {
         // asset isn't supported by our asset service.
         const isBuyAssetSupported = supportedBuyAsset !== undefined
         if (isBuyAssetSupported) {
-          await dispatch(waitForTransactionHash(txHash)).unwrap()
+          // TODO: temporarily disabled until we circle back to implement this properly
+          // Temporary UI will be used to bypass balance display after a trade to sidestep the
+          // issue in the interim.
+          // await dispatch(waitForTransactionHash(txHash)).unwrap()
         }
         dispatch(tradeQuoteSlice.actions.setSwapTxComplete({ hopIndex }))
         resolve()

--- a/src/components/MultiHopTrade/components/MultiHopTradeConfirm/hooks/useTradeExecution.tsx
+++ b/src/components/MultiHopTrade/components/MultiHopTradeConfirm/hooks/useTradeExecution.tsx
@@ -52,8 +52,8 @@ export const useTradeExecution = (hopIndex: number) => {
     return cancelPollingRef.current
   }, [])
 
-  // The intermediary buy asset may not actually be supported. If it doesnt exist in the asset slice
-  // the it must be unsupported.
+  // The intermediary buy asset may not actually be supported. If it doesn't exist in the asset slice
+  // then it must be unsupported.
   const supportedBuyAsset = useAppSelector(state =>
     selectAssetById(state, tradeQuote?.steps[hopIndex].buyAsset.assetId ?? ''),
   )

--- a/src/components/MultiHopTrade/components/TradeSuccess/TradeSuccess.tsx
+++ b/src/components/MultiHopTrade/components/TradeSuccess/TradeSuccess.tsx
@@ -8,6 +8,7 @@ import {
   useDisclosure,
 } from '@chakra-ui/react'
 import { useMemo } from 'react'
+import { useTranslate } from 'react-polyglot'
 import { Amount } from 'components/Amount/Amount'
 import { AssetIcon } from 'components/AssetIcon'
 import { SlideTransition } from 'components/SlideTransition'
@@ -23,6 +24,7 @@ import { TwirlyToggle } from '../MultiHopTradeConfirm/components/TwirlyToggle'
 export type TradeSuccessProps = { handleBack: () => void; children: JSX.Element }
 
 export const TradeSuccess = ({ handleBack, children }: TradeSuccessProps) => {
+  const translate = useTranslate()
   const {
     number: { toCrypto },
   } = useLocaleFormatter()
@@ -54,8 +56,12 @@ export const TradeSuccess = ({ handleBack, children }: TradeSuccessProps) => {
 
     const cryptoAmountFormatted = toCrypto(totalCryptoHumanBalance, lastHop.buyAsset.symbol)
     const chainName = adapter.getDisplayName()
-    return `You now have ${cryptoAmountFormatted} in your wallet on ${chainName}.`
-  }, [lastHop, toCrypto, totalCryptoHumanBalance])
+
+    return translate('trade.tradeComplete', {
+      cryptoAmountFormatted,
+      chainName,
+    })
+  }, [lastHop, toCrypto, totalCryptoHumanBalance, translate])
 
   if (!lastHop) return null
 
@@ -81,11 +87,11 @@ export const TradeSuccess = ({ handleBack, children }: TradeSuccessProps) => {
       <CardFooter flexDir='column' gap={2} px={4}>
         <SlideTransition>
           <Button mt={4} size='lg' width='full' onClick={handleBack} colorScheme='blue'>
-            Do another trade
+            {translate('trade.doAnotherTrade')}
           </Button>
           <HStack width='full' justifyContent='space-between' mt={4}>
             <Button variant='link' onClick={onToggle} px={2}>
-              Show Details
+              {translate('trade.showDetails')}
             </Button>
             <TwirlyToggle isOpen={isOpen} onToggle={onToggle} />
           </HStack>

--- a/src/state/slices/tradeQuoteSlice/tradeQuoteSlice.ts
+++ b/src/state/slices/tradeQuoteSlice/tradeQuoteSlice.ts
@@ -114,6 +114,7 @@ export const tradeQuoteSlice = createSlice({
       if (isFirstHop) {
         // complete the first hop
         state.tradeExecution.firstHop.swap.state = TransactionExecutionState.Complete
+        state.tradeExecution.firstHop.swap.message = undefined
         state.tradeExecution.firstHop.state = HopExecutionState.Complete
 
         if (isMultiHopTrade) {
@@ -130,6 +131,7 @@ export const tradeQuoteSlice = createSlice({
       } else {
         // complete the second hop
         state.tradeExecution.secondHop.swap.state = TransactionExecutionState.Complete
+        state.tradeExecution.secondHop.swap.message = undefined
         state.tradeExecution.secondHop.state = HopExecutionState.Complete
 
         // second hop of multi-hop trade - trade complete

--- a/src/state/slices/txHistorySlice/txHistorySlice.ts
+++ b/src/state/slices/txHistorySlice/txHistorySlice.ts
@@ -1,4 +1,4 @@
-import { createSlice } from '@reduxjs/toolkit'
+import { createAsyncThunk, createSlice } from '@reduxjs/toolkit'
 import { createApi } from '@reduxjs/toolkit/dist/query/react'
 import type { AccountId, AssetId } from '@shapeshiftoss/caip'
 import { fromAccountId, gnosisChainId, isNft, polygonChainId } from '@shapeshiftoss/caip'
@@ -15,9 +15,10 @@ import {
   isSpammyTokenText,
 } from 'state/apis/nft/constants'
 import type { State } from 'state/apis/types'
+import type { ReduxState } from 'state/reducer'
 import type { Nominal } from 'types/common'
 
-import { getRelatedAssetIds, serializeTxIndex } from './utils'
+import { deserializeTxIndex, getRelatedAssetIds, serializeTxIndex } from './utils'
 
 export type TxId = Nominal<string, 'TxId'>
 export type Tx = Transaction & { accountType?: UtxoAccountType }
@@ -124,6 +125,26 @@ const updateOrInsertTx = (txHistory: TxHistory, tx: Tx, accountId: AccountId) =>
   )
 }
 
+// Resolves when a tx with a given txhash has been received. Used for signalling tx completion only.
+// Ignores the fact that there may be multiple txs received for a given txhash (thorchain swapper).
+export const waitForTransactionHash = createAsyncThunk<
+  void,
+  string,
+  { state: ReduxState; extra: { subscribe: (listener: (state: ReduxState) => void) => () => void } }
+>('txHistory/waitForTransaction', (txHash, { extra: { subscribe } }) => {
+  return new Promise(resolve => {
+    const unsubscribe = subscribe(state => {
+      const transactionReceived = state.txHistory.txs.ids.some(
+        txIndex => deserializeTxIndex(txIndex).txid === txHash,
+      )
+      if (transactionReceived) {
+        unsubscribe()
+        resolve()
+      }
+    })
+  })
+})
+
 export const txHistory = createSlice({
   name: 'txHistory',
   initialState,
@@ -141,7 +162,9 @@ export const txHistory = createSlice({
       }
     },
   },
-  extraReducers: builder => builder.addCase(PURGE, () => initialState),
+  extraReducers: builder => {
+    builder.addCase(PURGE, () => initialState)
+  },
 })
 
 export const txHistoryApi = createApi({

--- a/src/state/slices/txHistorySlice/utils.ts
+++ b/src/state/slices/txHistorySlice/utils.ts
@@ -3,7 +3,7 @@ import type { AccountId, AssetId } from '@shapeshiftoss/caip'
 import type { Tx } from './txHistorySlice'
 
 type TxIndex = string
-type TxDescriptor = {
+export type TxDescriptor = {
   accountId: AccountId
   txid: Tx['txid']
   address: Tx['address']

--- a/src/state/slices/txHistorySlice/utils.ts
+++ b/src/state/slices/txHistorySlice/utils.ts
@@ -3,7 +3,7 @@ import type { AccountId, AssetId } from '@shapeshiftoss/caip'
 import type { Tx } from './txHistorySlice'
 
 type TxIndex = string
-export type TxDescriptor = {
+type TxDescriptor = {
   accountId: AccountId
   txid: Tx['txid']
   address: Tx['address']

--- a/src/state/store.ts
+++ b/src/state/store.ts
@@ -25,6 +25,7 @@ import { opportunitiesApi } from './slices/opportunitiesSlice/opportunitiesApiSl
 import { portfolioApi } from './slices/portfolioSlice/portfolioSlice'
 import * as selectors from './slices/selectors'
 import { txHistoryApi } from './slices/txHistorySlice/txHistorySlice'
+import { createSubscriptionMiddleware } from './subscriptionMiddleware'
 import { updateWindowStoreMiddleware } from './windowMiddleware'
 
 const persistConfig = {
@@ -54,6 +55,8 @@ const apiMiddleware = [
   abiApi.middleware,
   zerionApi.middleware,
 ]
+
+const subscriptionMiddleware = createSubscriptionMiddleware()
 
 const persistedReducer = persistReducer(persistConfig, reducer)
 
@@ -145,8 +148,12 @@ export const createStore = () =>
           warnAfter: 128,
           ignoredActions: [PERSIST, PURGE],
         },
+        thunk: {
+          extraArgument: { subscribe: subscriptionMiddleware.subscribe },
+        },
       })
         .concat(apiMiddleware)
+        .concat(subscriptionMiddleware.middleware)
         .concat(getConfig().REACT_APP_REDUX_WINDOW ? [updateWindowStoreMiddleware] : []),
     devTools: {
       actionSanitizer,

--- a/src/state/subscriptionMiddleware.ts
+++ b/src/state/subscriptionMiddleware.ts
@@ -1,0 +1,25 @@
+import type { Middleware } from 'redux'
+
+import type { ReduxState } from './reducer'
+
+export const createSubscriptionMiddleware = (): {
+  middleware: Middleware
+  subscribe: (listener: (state: ReduxState) => void) => () => void
+} => {
+  let currentListeners: ((state: ReduxState) => void)[] = []
+
+  const middleware: Middleware = store => next => action => {
+    const result = next(action)
+    currentListeners.forEach(listener => listener(store.getState() as ReduxState))
+    return result
+  }
+
+  const subscribe = (listener: (state: ReduxState) => void) => {
+    currentListeners.push(listener)
+    return () => {
+      currentListeners = currentListeners.filter(l => l !== listener)
+    }
+  }
+
+  return { middleware, subscribe }
+}


### PR DESCRIPTION
## Description

Ooh wee this was a tricky one. 
<img src="https://github.com/shapeshift/web/assets/125113430/3420815c-89a5-4c65-bf5d-b0e5aadee56f" width="20">

We want to show the users balance immediately after a trade was completed. About half the time, the app sees the tx before blockbook, causing us to render the old balance. Result would be "WHERES MY MONEY" in discord.

- In the txHistory slice transactions are indexed by account ID, txhash, address and (in thorchain case) memo. We don't care about any of that (thankfully), we only need to know that a tx was transmitted to the app via WS so we are safe to call a tx complete. 
- The thunk resolves when the txhash exists in the slice.
- If a multi-hop trade has an intermediary asset that is not supported by our stack, the tx hash will never arrive. In this case we skip awaiting it because we cant show balance for an unsupported asset anyway.

## Pull Request Type

- [x] :bug: Bug fix (Non-breaking Change: Fixes an issue)
- [ ] :hammer_and_wrench: Chore (Non-breaking Change: Doc updates, pkg upgrades, typos, etc..)
- [ ] :nail_care: New Feature (Breaking/Non-breaking Change)

## Issue (if applicable)

https://discord.com/channels/554694662431178782/1183949817748140144/1185095410524639304

## Risk

Small risk that a trade will never show as completed in the multi-hop ui

## Testing

Check that the balance reported after a trade (with multi hop UI enabled) reflects the updated balance
Check that trades with various swappers and assets do eventually complete (with multi hop UI enabled)

### Engineering

### Operations


## Screenshots (if applicable)

Reported issue
![image](https://github.com/shapeshift/web/assets/125113430/bdf24d46-1b45-4e2e-a2b2-2558cc43ee51)

Fixed
![image](https://github.com/shapeshift/web/assets/125113430/83f58980-2f81-4e34-bb68-122966ad70e7)


