### PR TITLE
feat: swapper safe debouncing

### DIFF
--- a/src/components/MultiHopTrade/hooks/useGetTradeQuotes/useGetTradeQuotes.tsx
+++ b/src/components/MultiHopTrade/hooks/useGetTradeQuotes/useGetTradeQuotes.tsx
@@ -126,8 +126,6 @@ export const useGetTradeQuotes = () => {
   const debouncedSellAmountCryptoPrecision = useDebounce(sellAmountCryptoPrecision, 500)
   const isDebouncing = debouncedSellAmountCryptoPrecision !== sellAmountCryptoPrecision
 
-  console.log({ isDebouncing })
-
   // User *may* donate if the fox discounts flag is off and they kept the donation checkbox on
   // or if the fox discounts flag is on and they don't hold enough fox to wave fees out fully
   const userMayDonate = useAppSelector(selectWillDonate) || isFoxDiscountsEnabled

--- a/src/components/MultiHopTrade/hooks/useGetTradeQuotes/useGetTradeQuotes.tsx
+++ b/src/components/MultiHopTrade/hooks/useGetTradeQuotes/useGetTradeQuotes.tsx
@@ -1,3 +1,4 @@
+import { usePrevious } from '@chakra-ui/react'
 import { skipToken } from '@reduxjs/toolkit/dist/query'
 import { fromAccountId } from '@shapeshiftoss/caip'
 import { isEvmChainId } from '@shapeshiftoss/chain-adapters'
@@ -109,6 +110,8 @@ export const useGetTradeQuotes = () => {
   const [tradeQuoteInput, setTradeQuoteInput] = useState<GetTradeQuoteInput | typeof skipToken>(
     skipToken,
   )
+  const previousTradeQuoteInput = usePrevious(tradeQuoteInput)
+  const isTradeQuoteUpdated = tradeQuoteInput !== previousTradeQuoteInput
   const [hasFocus, setHasFocus] = useState(document.hasFocus())
   const sellAsset = useAppSelector(selectSellAsset)
   const buyAsset = useAppSelector(selectBuyAsset)
@@ -120,6 +123,11 @@ export const useGetTradeQuotes = () => {
   )
   const receiveAddress = useReceiveAddress(useReceiveAddressArgs)
   const sellAmountCryptoPrecision = useAppSelector(selectSellAmountCryptoPrecision)
+  const debouncedSellAmountCryptoPrecision = useDebounce(sellAmountCryptoPrecision, 500)
+  const isDebouncing = debouncedSellAmountCryptoPrecision !== sellAmountCryptoPrecision
+
+  console.log({ isDebouncing })
+
   // User *may* donate if the fox discounts flag is off and they kept the donation checkbox on
   // or if the fox discounts flag is on and they don't hold enough fox to wave fees out fully
   const userMayDonate = useAppSelector(selectWillDonate) || isFoxDiscountsEnabled
@@ -163,14 +171,29 @@ export const useGetTradeQuotes = () => {
   const shouldRefetchTradeQuotes = useMemo(
     () =>
       Boolean(
-        wallet && sellAccountId && sellAccountMetadata && receiveAddress && !isVotingPowerLoading,
+        isTradeQuoteUpdated &&
+          wallet &&
+          !isDebouncing &&
+          sellAccountId &&
+          sellAccountMetadata &&
+          receiveAddress &&
+          !isVotingPowerLoading,
       ),
-    [wallet, sellAccountId, sellAccountMetadata, receiveAddress, isVotingPowerLoading],
+    [
+      isTradeQuoteUpdated,
+      wallet,
+      isDebouncing,
+      sellAccountId,
+      sellAccountMetadata,
+      receiveAddress,
+      isVotingPowerLoading,
+    ],
   )
 
-  const debouncedTradeQuoteInput = useDebounce(tradeQuoteInput, 500)
-
   useEffect(() => {
+    // Don't update tradeQuoteInput while we're still debouncing
+    if (isDebouncing) return
+
     // Always invalidate tags when this effect runs - args have changed, and whether we want to fetch an actual quote
     // or a "skipToken" no-op, we always want to ensure that the tags are invalidated before a new query is ran
     // That effectively means we'll unsubscribe to queries, considering them stale
@@ -186,7 +209,7 @@ export const useGetTradeQuotes = () => {
         // disable EVM donations on KeepKey until https://github.com/shapeshift/web/issues/4518 is resolved
         const mayDonate = walletIsKeepKey ? userMayDonate && !isFromEvm : userMayDonate
 
-        const tradeAmountUsd = bnOrZero(sellAssetUsdRate).times(sellAmountCryptoPrecision)
+        const tradeAmountUsd = bnOrZero(sellAssetUsdRate).times(debouncedSellAmountCryptoPrecision)
         const potentialAffiliateBps = mayDonate ? DEFAULT_SWAPPER_DONATION_BPS : '0'
         const affiliateBps = (() => {
           if (!isFoxDiscountsEnabled) return potentialAffiliateBps
@@ -260,6 +283,8 @@ export const useGetTradeQuotes = () => {
     sellAccountId,
     isVotingPowerLoading,
     isBuyAssetChainSupported,
+    debouncedSellAmountCryptoPrecision,
+    isDebouncing,
   ])
 
   useEffect(() => {
@@ -271,17 +296,15 @@ export const useGetTradeQuotes = () => {
 
   // NOTE: we're using currentData here, not data, see https://redux-toolkit.js.org/rtk-query/usage/conditional-fetching
   // This ensures we never return cached data, if skip has been set after the initial query load
-  const { currentData } = useGetTradeQuoteQuery(
-    shouldRefetchTradeQuotes ? debouncedTradeQuoteInput : skipToken,
-    {
-      pollingInterval: hasFocus ? GET_TRADE_QUOTE_POLLING_INTERVAL : undefined,
-      /*
+  const { currentData } = useGetTradeQuoteQuery(tradeQuoteInput, {
+    skip: !shouldRefetchTradeQuotes,
+    pollingInterval: hasFocus ? GET_TRADE_QUOTE_POLLING_INTERVAL : undefined,
+    /*
       If we don't refresh on arg change might select a cached result with an old "started_at" timestamp
       We can remove refetchOnMountOrArgChange if we want to make better use of the cache, and we have a better way to select from the cache.
      */
-      refetchOnMountOrArgChange: true,
-    },
-  )
+    refetchOnMountOrArgChange: true,
+  })
 
   useEffect(() => {
     if (currentData && mixpanel) {


### PR DESCRIPTION
## Description

... a.k.a have your cake and eat it.

The follow-up of https://github.com/shapeshift/web/pull/5839. See this comment from @0xApotheosis:

> Re-tested and confirming the previous debounce issue is resolved.

> It seems a bit bizarre to me though that we can't fix the additional request for the old quote whenever we start trying to get a new quote? That seems pretty wild...

This was caused by rugged debouncing. Fixed by only debouncing the sell amount instead of the whole input. By asking ourselves the question "Why are we debouncing?" (i.e, to avoid spamming endpoints as users are inputting a sell amount), the fix becomes a lot more straightforward: debouncing the whole input, as a non-immediate operation that requires some ms of computing becomes the obvious cause of previous quotes firing.

By only debouncing the sell amount and letting derivation reactivity do its magic in the `useEffect`, as well as checking for `previousSellAmount !== sellAmount`, we're able to have our cake (invalidating previous queries on queries fire to ensure safety and no stale quotes) and eat it (not have quotes firing for the previously leading debounce value).

While at it, ensures we don't display the unsupported wallet warning after a manual receive address is entered.

## Pull Request Type

- [ ] :bug: Bug fix (Non-breaking Change: Fixes an issue)
- [ ] :hammer_and_wrench: Chore (Non-breaking Change: Doc updates, pkg upgrades, typos, etc..)
- [x] :nail_care: New Feature (Breaking/Non-breaking Change)

## Issue (if applicable)

<!-----------------------------------------------------------------------------
If applicable, please link to the github issue and put `closes #XXXX` in your comment to auto-close the issue that your PR fixes.
------------------------------------------------------------------------------>

closes N/A

## Risk

<!-----------------------------------------------------------------------------
Outline the scope of your changes and the risk associated with them. You must use your discretion as an engineer to determine the potential impact of your changes.

E.g. an upgrade to `hdwallet` or core state management would be considered higher risk, and might require a full regression test. UI or isolated view changes, or something behind a feature flag may have near zero risk. Small bug fixes might require testing isolated to the specific fix.
------------------------------------------------------------------------------>

Quotes may be borked on args (input sell amount, buy/sell asset, and AccountId) change, test accordingly

## Testing

<!-----------------------------------------------------------------------------
We treat every PR to be merged with the same scrutiny as if we were merging directly to production.

Your PR will not be merged if you do not complete the sections below for our engineering and operations teams to test.
------------------------------------------------------------------------------>

- Quotes are still debounced (i.e, type 123456 and ensure on the default ETH/FOX, filter requests by `quote?from` and ensure only a single request is made for the final 123456 amount, not the previous values)
- When within the context a valid quote (i.e 123456 ETH/FOX), inputting a new amount (i.e 1, or 123456) doesn't fire a stale quote request for the previous amount. Can be tested with the same `quote?from` network tab filter.
- While within the context of a valid quote (e.g ETH/FOX), ensure switching to an unsupported asset still triggers the no receive address flow, and inputting an address allows to continue, with no stale quotes for the previous working pair

### Engineering

<!-----------------------------------------------------------------------------
Include sufficient information here for an engineer to test your PR. This may include how to test locally, in a built environment, changes to infrastructure etc.
------------------------------------------------------------------------------>

- ☝🏽 

### Operations

<!-----------------------------------------------------------------------------
If your changes have a user-facing impact, describe how a non-technical QA team can functionally test your changes in a preview environment.

If they are not user-facing please describe how to test for any regressions that may occur.
------------------------------------------------------------------------------>

- ☝🏽 

## Screenshots (if applicable)

### Full happy flow

https://github.com/shapeshift/web/assets/17035424/af456e4e-0312-4404-91b3-ef9955e2b405

### Manual receive address warning only displayed *if* user hasn't entered a manual, valid receive address

https://github.com/shapeshift/web/assets/17035424/707fefb0-49da-4d10-be90-6de699b127e5


