### PR TITLE
fix: global search leaking Tx history

### DIFF
--- a/src/state/slices/txHistorySlice/selectors.ts
+++ b/src/state/slices/txHistorySlice/selectors.ts
@@ -234,7 +234,6 @@ export const selectTxsByQuery = createDeepEqualOutputSelector(
       threshold: matchSorter.rankings.CONTAINS,
     })
 
-    // Return the sorted TxIds
     return results.map(result => result[0])
   },
 )


### PR DESCRIPTION
## Description

Two birds one stone:

- ensures we only select *wallet* Tx history
- ensures we honor the order of `txIds` instead of relying on unordered `txs` , making the results sane and ordered

## Pull Request Type

- [x] :bug: Bug fix (Non-breaking Change: Fixes an issue)
- [ ] :hammer_and_wrench: Chore (Non-breaking Change: Doc updates, pkg upgrades, typos, etc..)
- [ ] :nail_care: New Feature (Breaking/Non-breaking Change)

## Issue (if applicable)

<!-----------------------------------------------------------------------------
If applicable, please link to the github issue and put `closes #XXXX` in your comment to auto-close the issue that your PR fixes.
------------------------------------------------------------------------------>

closes https://github.com/shapeshift/web/issues/4589

## Risk

<!-----------------------------------------------------------------------------
Outline the scope of your changes and the risk associated with them. You must use your discretion as an engineer to determine the potential impact of your changes.

E.g. an upgrade to `hdwallet` or core state management would be considered higher risk, and might require a full regression test. UI or isolated view changes, or something behind a feature flag may have near zero risk. Small bug fixes might require testing isolated to the specific fix.
------------------------------------------------------------------------------>

None?

## Testing

<!-----------------------------------------------------------------------------
We treat every PR to be merged with the same scrutiny as if we were merging directly to production.

Your PR will not be merged if you do not complete the sections below for our engineering and operations teams to test.
------------------------------------------------------------------------------>

- Global search Txs do not leak cross-wallets
- Global search Txs are properly ordered, including when searching i.e latest come first. No search input means most recent transactions displayed, similar to the Activity tab.

### Engineering

<!-----------------------------------------------------------------------------
Include sufficient information here for an engineer to test your PR. This may include how to test locally, in a built environment, changes to infrastructure etc.
------------------------------------------------------------------------------>

- ☝🏽 

### Operations

<!-----------------------------------------------------------------------------
If your changes have a user-facing impact, describe how a non-technical QA team can functionally test your changes in a preview environment.

If they are not user-facing please describe how to test for any regressions that may occur.
------------------------------------------------------------------------------>

- ☝🏽 

## Screenshots (if applicable)

Three wallets connected: Two MM ones, and an empty native one

- MM wallet 1

<img width="1105" alt="Screenshot 2023-12-18 at 17 41 51" src="https://github.com/shapeshift/web/assets/17035424/9a35e66e-e6eb-450b-a025-d7d3543f7c48">
<img width="533" alt="Screenshot 2023-12-18 at 17 42 38" src="https://github.com/shapeshift/web/assets/17035424/ca7b47df-221b-45a9-9287-3a1c11b31feb">

- Native empty wallet

<img width="1100" alt="Screenshot 2023-12-18 at 17 44 07" src="https://github.com/shapeshift/web/assets/17035424/a2e1874c-c2cc-416f-b530-6a3f7a1178ce">
<img width="549" alt="Screenshot 2023-12-18 at 17 44 15" src="https://github.com/shapeshift/web/assets/17035424/391c6b7a-61d9-4585-a6c1-c26a58828c3e">
<img width="549" alt="Screenshot 2023-12-18 at 17 44 15" src="https://github.com/shapeshift/web/assets/17035424/204fd392-00fc-4cab-a213-9fc0f8bfb57f">

- MM wallet 2

<img width="1110" alt="Screenshot 2023-12-18 at 17 44 46" src="https://github.com/shapeshift/web/assets/17035424/5c87a746-00f3-4530-a541-7a700070905b">
<img width="556" alt="Screenshot 2023-12-18 at 17 45 09" src="https://github.com/shapeshift/web/assets/17035424/f7f34955-8772-4428-9848-06f995d6bf12">
