### PR TITLE
fix: temporarily patch UI to avoid showing balance on trade completed ui

### DIFF
--- a/src/assets/translations/en/main.json
+++ b/src/assets/translations/en/main.json
@@ -825,7 +825,11 @@
     "tradeComplete": "You now have %{cryptoAmountFormatted} in your wallet on %{chainName}.",
     "doAnotherTrade": "Do another trade",
     "showDetails": "Show Details",
-    "transactionSuccessful": "Transaction successful, waiting for confirmations"
+    "transactionSuccessful": "Transaction successful, waiting for confirmations",
+    "temp": {
+      "tradeSuccess": "Trade complete",
+      "tradeComplete": "Successfully received %{symbol} on %{chainName}."
+    }
   },
   "modals": {
     "popup": {

--- a/src/components/MultiHopTrade/components/MultiHopTradeConfirm/MultiHopTradeConfirm.tsx
+++ b/src/components/MultiHopTrade/components/MultiHopTradeConfirm/MultiHopTradeConfirm.tsx
@@ -11,7 +11,7 @@ import { tradeQuoteSlice } from 'state/slices/tradeQuoteSlice/tradeQuoteSlice'
 import { TradeExecutionState } from 'state/slices/tradeQuoteSlice/types'
 import { useAppDispatch, useAppSelector } from 'state/store'
 
-import { TradeSuccess } from '../TradeSuccess/TradeSuccess'
+import { TradeSuccessTemp } from '../TradeSuccess/TradeSuccessTemp'
 import { Footer } from './components/Footer'
 import { Hops } from './components/Hops'
 import { useIsApprovalInitiallyNeeded } from './hooks/useIsApprovalInitiallyNeeded'
@@ -88,9 +88,9 @@ export const MultiHopTradeConfirm = memo(() => {
           </WithBackButton>
         </CardHeader>
         {isTradeComplete ? (
-          <TradeSuccess handleBack={handleBack}>
+          <TradeSuccessTemp handleBack={handleBack}>
             <Hops isFirstHopOpen isSecondHopOpen />
-          </TradeSuccess>
+          </TradeSuccessTemp>
         ) : (
           <>
             <CardBody py={0} px={0}>

--- a/src/components/MultiHopTrade/components/TradeSuccess/TradeSuccessTemp.tsx
+++ b/src/components/MultiHopTrade/components/TradeSuccess/TradeSuccessTemp.tsx
@@ -1,0 +1,80 @@
+import {
+  Box,
+  Button,
+  CardBody,
+  CardFooter,
+  Collapse,
+  HStack,
+  useDisclosure,
+} from '@chakra-ui/react'
+import { useMemo } from 'react'
+import { useTranslate } from 'react-polyglot'
+import { AssetIcon } from 'components/AssetIcon'
+import { SlideTransition } from 'components/SlideTransition'
+import { RawText, Text } from 'components/Text'
+import { getChainAdapterManager } from 'context/PluginProvider/chainAdapterSingleton'
+import { selectLastHop } from 'state/slices/tradeQuoteSlice/selectors'
+import { useAppSelector } from 'state/store'
+
+import { TwirlyToggle } from '../MultiHopTradeConfirm/components/TwirlyToggle'
+import type { TradeSuccessProps } from './TradeSuccess'
+
+export const TradeSuccessTemp = ({ handleBack, children }: TradeSuccessProps) => {
+  const translate = useTranslate()
+
+  const { isOpen, onToggle } = useDisclosure({
+    defaultIsOpen: false,
+  })
+
+  const lastHop = useAppSelector(selectLastHop)
+
+  const subText = useMemo(() => {
+    if (!lastHop) return ''
+
+    const manager = getChainAdapterManager()
+    const adapter = manager.get(lastHop.buyAsset.chainId)
+
+    if (!adapter) return ''
+
+    const chainName = adapter.getDisplayName()
+
+    return translate('trade.temp.tradeComplete', {
+      symbol: lastHop.buyAsset.symbol,
+      chainName,
+    })
+  }, [lastHop, translate])
+
+  if (!lastHop) return null
+
+  return (
+    <>
+      <CardBody pb={0} px={0}>
+        <SlideTransition>
+          <Box textAlign='center' py={4}>
+            <AssetIcon assetId={lastHop.buyAsset.assetId} />
+            <Text translation='trade.temp.tradeSuccess' />
+            <RawText fontSize='md' color='gray.500' mt={2}>
+              {subText}
+            </RawText>
+          </Box>
+        </SlideTransition>
+      </CardBody>
+      <CardFooter flexDir='column' gap={2} px={4}>
+        <SlideTransition>
+          <Button mt={4} size='lg' width='full' onClick={handleBack} colorScheme='blue'>
+            {translate('trade.doAnotherTrade')}
+          </Button>
+          <HStack width='full' justifyContent='space-between' mt={4}>
+            <Button variant='link' onClick={onToggle} px={2}>
+              {translate('trade.showDetails')}
+            </Button>
+            <TwirlyToggle isOpen={isOpen} onToggle={onToggle} />
+          </HStack>
+          <Box mx={-4}>
+            <Collapse in={isOpen}>{children}</Collapse>
+          </Box>
+        </SlideTransition>
+      </CardFooter>
+    </>
+  )
+}


### PR DESCRIPTION
## Description

Temporarily patches the multi-hop "trade success" ui to not display balances. This sidesteps the race condition currently present where our app renders a successful trade summary before blockbook is able to index the transaction, resulting in "you now have 0 BTC in your wallet" text.

## Pull Request Type

- [x] :bug: Bug fix (Non-breaking Change: Fixes an issue)
- [ ] :hammer_and_wrench: Chore (Non-breaking Change: Doc updates, pkg upgrades, typos, etc..)
- [ ] :nail_care: New Feature (Breaking/Non-breaking Change)

## Issue (if applicable)

NA

## Risk

Low risk.

## Testing

Check multi-hop trades complete.

### Engineering

<!-----------------------------------------------------------------------------
Include sufficient information here for an engineer to test your PR. This may include how to test locally, in a built environment, changes to infrastructure etc.
------------------------------------------------------------------------------>

### Operations

<!-----------------------------------------------------------------------------
If your changes have a user-facing impact, describe how a non-technical QA team can functionally test your changes in a preview environment.

If they are not user-facing please describe how to test for any regressions that may occur.
------------------------------------------------------------------------------>

## Screenshots (if applicable)


https://github.com/shapeshift/web/assets/125113430/70dc7b8c-bcb5-45c7-860a-e2192ca1af8f


