### PR TITLE
chore: add fail-closed aggregator whitelist

### DIFF
--- a/react-app-rewired/headers/csps/chains/thorchain.ts
+++ b/react-app-rewired/headers/csps/chains/thorchain.ts
@@ -5,5 +5,6 @@ export const csp: Csp = {
     process.env.REACT_APP_UNCHAINED_THORCHAIN_HTTP_URL!,
     process.env.REACT_APP_UNCHAINED_THORCHAIN_WS_URL!,
     process.env.REACT_APP_THORCHAIN_NODE_URL!,
+    'https://gitlab.com/thorchain/thornode/-/raw/develop/x/thorchain/aggregators/dex_mainnet_current.go', // Required to check if aggregator is whitelisted for longtail swaps
   ],
 }

--- a/src/lib/swapper/swappers/ThorchainSwapper/utils/getLongtailQuote.ts
+++ b/src/lib/swapper/swappers/ThorchainSwapper/utils/getLongtailQuote.ts
@@ -16,6 +16,7 @@ import { QuoterAbi } from '../getThorTradeQuote/abis/QuoterAbi'
 import type { ThorTradeQuote } from '../getThorTradeQuote/getTradeQuote'
 import { getL1quote } from './getL1quote'
 import {
+  checkAggregatorWhitelisted,
   feeAmountToContractMap,
   generateV3PoolAddressesAcrossFeeRange,
   getContractDataByPool,
@@ -109,6 +110,19 @@ export const getLongtailToL1Quote = async (
     return Err(
       makeSwapErrorRight({
         message: `[getThorTradeQuote] - No best aggregator contract found.`,
+        code: SwapErrorType.UNSUPPORTED_PAIR,
+      }),
+    )
+  }
+
+  const isBestAggregatorWhitelisted = await checkAggregatorWhitelisted(bestAggregator)
+  if (!isBestAggregatorWhitelisted) {
+    console.error(
+      '[getThorTradeQuote] - Best aggregator contract is not whitelisted. Something has changed upsteam: rectify with priority.',
+    )
+    return Err(
+      makeSwapErrorRight({
+        message: `[getThorTradeQuote] - Best aggregator contract ${bestAggregator} is not whitelisted.`,
         code: SwapErrorType.UNSUPPORTED_PAIR,
       }),
     )


### PR DESCRIPTION
PoC to add a fail-closed aggregator whitelist to the longtail aggregator for safety.

Currently rugged by CORs allow origin response haeders from the gitlab URL.