### PR TITLE
feat: add hotfix script

### DIFF
--- a/scripts/release.ts
+++ b/scripts/release.ts
@@ -97,6 +97,10 @@ async function updateReleaseBranch() {
   console.log(chalk.green('Pulling develop...'))
   await git().pull()
   console.log(chalk.green('Resetting release to develop...'))
+  // **note** - most devs are familiar with lowercase -b to check out a new branch
+  // capital -B will checkout and reset the branch to the current HEAD
+  // so we can reuse the release branch, and force push over it
+  // this is required as the fleek environment is pointed at this specific branch
   await git().checkout(['-B', 'release'])
   console.log(chalk.green('Force pushing release branch...'))
   await git().push(['--force', 'origin', 'release'])


### PR DESCRIPTION
## Description

Implements a hotfix path to our release script, allowing us to interactiely select specific commits in `develop` from the CLI to put into a release.

## Pull Request Type

- [ ] :bug: Bug fix (Non-breaking Change: Fixes an issue)
- [x] :hammer_and_wrench: Chore (Non-breaking Change: Doc updates, pkg upgrades, typos, etc..)
- [ ] :nail_care: New Feature (Breaking/Non-breaking Change)

## Issue (if applicable)

N/A - quality of life.

## Risk

Small, no runtime codepaths.

## Testing

Run `yarn release` and select the `Hotfix` option.
You'll now be able to specify which commits to put into a hotfix release.

### Engineering

☝️

### Operations

N/A

## Screenshots (if applicable)

<img width="248" alt="Screenshot 2023-12-20 at 1 18 45 pm" src="https://github.com/shapeshift/web/assets/97164662/19610417-62ca-4001-8a49-6c1eb22dfebd">
<img width="988" alt="Screenshot 2023-12-20 at 1 18 56 pm" src="https://github.com/shapeshift/web/assets/97164662/72e81d06-f7c5-4afc-9715-764d71eaa565">
