### PR TITLE
feat: savers withdraw where is my money safeguard

### DIFF
--- a/src/assets/translations/en/main.json
+++ b/src/assets/translations/en/main.json
@@ -380,7 +380,8 @@
           "tooltip": "Estimated time to cover deposit fees and earnings."
         },
         "cannotDepositWhilePendingTx": "Cannot deposit while Txs are pending",
-        "cannotWithdrawWhilePendingTx": "Cannot withdraw while Txs are pending"
+        "cannotWithdrawWhilePendingTx": "Cannot withdraw while Txs are pending",
+        "dangerousWithdrawWarning": "Withdrawal disabled as the THORChain fee could result in the total loss of the funds being withdrawn. Consider withdrawing a higher amount to avoid this issue."
       }
     },
     "memoNote": {

--- a/src/features/defi/providers/thorchain-savers/components/ThorchainSaversManager/Withdraw/components/Confirm.tsx
+++ b/src/features/defi/providers/thorchain-savers/components/ThorchainSaversManager/Withdraw/components/Confirm.tsx
@@ -353,6 +353,11 @@ export const Confirm: React.FC<ConfirmProps> = ({ accountId, onNext }) => {
       state?.withdraw.cryptoAmount,
     ])
 
+  const isDangerousWithdraw = useMemo(() => {
+    const amountCryptoBaseUnit = toBaseUnit(state?.withdraw.cryptoAmount, asset.precision)
+    return amountCryptoBaseUnit === protocolFeeCryptoBaseUnit
+  }, [asset.precision, protocolFeeCryptoBaseUnit, state?.withdraw.cryptoAmount])
+
   const getCustomTxInput: () => Promise<BuildCustomTxInput | undefined> = useCallback(async () => {
     if (!contextDispatch || !opportunityData?.stakedAmountCryptoBaseUnit) return
     if (!(accountId && assetId && feeAsset && accountNumber !== undefined && wallet)) return
@@ -912,6 +917,12 @@ export const Confirm: React.FC<ConfirmProps> = ({ accountId, onNext }) => {
               </Box>
             </Row.Value>
           </Row>
+        )}
+        {isDangerousWithdraw && (
+          <Alert status='warning' borderRadius='lg'>
+            <AlertIcon />
+            <Text translation={'defi.modals.saversVaults.dangerousWithdrawWarning'} />
+          </Alert>
         )}
         {!hasEnoughBalanceForGas && (
           <Alert status='error' borderRadius='lg'>


### PR DESCRIPTION
## Description

Simple few LoC low hanging fruit warning against users thinking their funds are lost because they can't withdraw, by explaining that the quoted fees would eat their withdraw amount.

## Pull Request Type

- [ ] :bug: Bug fix (Non-breaking Change: Fixes an issue)
- [ ] :hammer_and_wrench: Chore (Non-breaking Change: Doc updates, pkg upgrades, typos, etc..)
- [x] :nail_care: New Feature (Breaking/Non-breaking Change)

## Issue (if applicable)

<!-----------------------------------------------------------------------------
If applicable, please link to the github issue and put `closes #XXXX` in your comment to auto-close the issue that your PR fixes.
------------------------------------------------------------------------------>

N/A

## Risk

<!-----------------------------------------------------------------------------
Outline the scope of your changes and the risk associated with them. You must use your discretion as an engineer to determine the potential impact of your changes.

E.g. an upgrade to `hdwallet` or core state management would be considered higher risk, and might require a full regression test. UI or isolated view changes, or something behind a feature flag may have near zero risk. Small bug fixes might require testing isolated to the specific fix.
------------------------------------------------------------------------------>

- This could be displayed when it shouldn't, and vice-versa, test accordingly

## Testing

<!-----------------------------------------------------------------------------
We treat every PR to be merged with the same scrutiny as if we were merging directly to production.

Your PR will not be merged if you do not complete the sections below for our engineering and operations teams to test.
------------------------------------------------------------------------------>

- When the protocol fee *is* the amount being withdrawn, the warning is displayed
- When the protocol fee is anything else (i.e fees don't eat the whole amount), the warning isn't displayed

### Engineering

<!-----------------------------------------------------------------------------
Include sufficient information here for an engineer to test your PR. This may include how to test locally, in a built environment, changes to infrastructure etc.
------------------------------------------------------------------------------>

- Ensure this only displays when the quoted expected_amount_out is `""`

### Operations

<!-----------------------------------------------------------------------------
If your changes have a user-facing impact, describe how a non-technical QA team can functionally test your changes in a preview environment.

If they are not user-facing please describe how to test for any regressions that may occur.
------------------------------------------------------------------------------>

- ☝🏽 

## Screenshots (if applicable)

<img width="545" alt="Screenshot 2023-12-20 at 21 18 41" src="https://github.com/shapeshift/web/assets/17035424/0f46f76d-8560-484f-a937-25dc150782be">
