### PR TITLE
fix: consistently display THOR dangerous withdraw warning when applicable

### DIFF
--- a/src/features/defi/providers/thorchain-savers/components/ThorchainSaversManager/Withdraw/components/Confirm.tsx
+++ b/src/features/defi/providers/thorchain-savers/components/ThorchainSaversManager/Withdraw/components/Confirm.tsx
@@ -235,8 +235,10 @@ export const Confirm: React.FC<ConfirmProps> = ({ accountId, onNext }) => {
 
         setExpiry(expiry)
 
+        const _isDangerousWithdraw = bnOrZero(expected_amount_out).isZero()
+        setIsDangerousWithdraw(_isDangerousWithdraw)
         // If there's nothing being withdrawn, then the protocol fee is the entire amount
-        const protocolFeeCryptoThorBaseUnit = bnOrZero(expected_amount_out).isZero()
+        const protocolFeeCryptoThorBaseUnit = _isDangerousWithdraw
           ? amountCryptoThorBaseUnit
           : amountCryptoThorBaseUnit.minus(expected_amount_out)
         setProtocolFeeCryptoBaseUnit(
@@ -268,6 +270,7 @@ export const Confirm: React.FC<ConfirmProps> = ({ accountId, onNext }) => {
     opportunityData?.stakedAmountCryptoBaseUnit,
     state?.withdraw.cryptoAmount,
     protocolFeeCryptoBaseUnit,
+    isDangerousWithdraw,
   ])
 
   useEffect(() => {
@@ -326,7 +329,7 @@ export const Confirm: React.FC<ConfirmProps> = ({ accountId, onNext }) => {
       // If there's nothing being withdrawn, then the protocol fee is the entire amount
       const _isDangerousWithdraw = bnOrZero(expected_amount_out).isZero()
       setIsDangerousWithdraw(_isDangerousWithdraw)
-      const protocolFeeCryptoThorBaseUnit = isDangerousWithdraw
+      const protocolFeeCryptoThorBaseUnit = _isDangerousWithdraw
         ? amountCryptoThorBaseUnit
         : amountCryptoThorBaseUnit.minus(expected_amount_out)
       setProtocolFeeCryptoBaseUnit(
@@ -349,7 +352,6 @@ export const Confirm: React.FC<ConfirmProps> = ({ accountId, onNext }) => {
       asset,
       assetId,
       chainId,
-      isDangerousWithdraw,
       isTokenWithdraw,
       maybeFromUTXOAccountAddress,
       opportunityData?.rewardsCryptoBaseUnit?.amounts,


### PR DESCRIPTION
## Description

This should be set in the `useEffect` as well - this PR fixes it.

## Pull Request Type

- [x] :bug: Bug fix (Non-breaking Change: Fixes an issue)
- [ ] :hammer_and_wrench: Chore (Non-breaking Change: Doc updates, pkg upgrades, typos, etc..)
- [ ] :nail_care: New Feature (Breaking/Non-breaking Change)

## Issue (if applicable)

<!-----------------------------------------------------------------------------
If applicable, please link to the github issue and put `closes #XXXX` in your comment to auto-close the issue that your PR fixes.
------------------------------------------------------------------------------>

closes N/A

## Risk

<!-----------------------------------------------------------------------------
Outline the scope of your changes and the risk associated with them. You must use your discretion as an engineer to determine the potential impact of your changes.

E.g. an upgrade to `hdwallet` or core state management would be considered higher risk, and might require a full regression test. UI or isolated view changes, or something behind a feature flag may have near zero risk. Small bug fixes might require testing isolated to the specific fix.
------------------------------------------------------------------------------>

None, this feature is a smallish UX touchup and doesn't bring regression risks

## Testing

<!-----------------------------------------------------------------------------
We treat every PR to be merged with the same scrutiny as if we were merging directly to production.

Your PR will not be merged if you do not complete the sections below for our engineering and operations teams to test.
------------------------------------------------------------------------------>

- When applicable, the dangerous withdraw warning consistently displays, regardless of the asset/amount
- When *not* applicable (i.e a non-zero amount would be withdrawn), the warning does *not* show up

### Engineering

<!-----------------------------------------------------------------------------
Include sufficient information here for an engineer to test your PR. This may include how to test locally, in a built environment, changes to infrastructure etc.
------------------------------------------------------------------------------>

- ☝🏽 

### Operations

<!-----------------------------------------------------------------------------
If your changes have a user-facing impact, describe how a non-technical QA team can functionally test your changes in a preview environment.

If they are not user-facing please describe how to test for any regressions that may occur.
------------------------------------------------------------------------------>

- ☝🏽 

## Screenshots (if applicable)

### Develop

<img width="531" alt="image" src="https://github.com/shapeshift/web/assets/17035424/3c5f200c-9d44-40ba-a737-52ad5c85a863">
<img width="584" alt="image" src="https://github.com/shapeshift/web/assets/17035424/67226dbe-1ced-4afb-bcb6-b9dba097b4af">
<img width="547" alt="image" src="https://github.com/shapeshift/web/assets/17035424/e48e2d87-68b7-4795-b97e-d399ae35b9c6">
<img width="548" alt="image" src="https://github.com/shapeshift/web/assets/17035424/eb591cdc-18c7-4c0f-b219-8542a59b21b6">
<img width="560" alt="image" src="https://github.com/shapeshift/web/assets/17035424/67b20a44-4b04-43e2-b11a-40199dc6366a">

### This diff

<img width="548" alt="image" src="https://github.com/shapeshift/web/assets/17035424/0725e3bc-b49b-457c-b002-dffed8f3ba60">
<img width="562" alt="image" src="https://github.com/shapeshift/web/assets/17035424/58c25dc2-01e4-49cd-be04-5a4c7d92674f">
<img width="549" alt="image" src="https://github.com/shapeshift/web/assets/17035424/c85b703b-34de-4033-b53a-d9fb976f2e7e">
<img width="577" alt="image" src="https://github.com/shapeshift/web/assets/17035424/1a42bbb0-13a8-406e-9257-72bb43bba377">
<img width="537" alt="image" src="https://github.com/shapeshift/web/assets/17035424/12181481-23ac-404a-9ee6-99d1396fc8d3">
<img width="566" alt="image" src="https://github.com/shapeshift/web/assets/17035424/d30aa445-d6e5-4937-be01-e2408a70df75">
