### PR TITLE
fix: send change back to from address when outputs contain OP_RETURN_DATA

### DIFF
--- a/packages/chain-adapters/src/utxo/utxoSelect/index.ts
+++ b/packages/chain-adapters/src/utxo/utxoSelect/index.ts
@@ -64,17 +64,17 @@ export const utxoSelect = (input: UTXOSelectInput) => {
     return coinSelect<unchained.bitcoin.Utxo>(utxos, outputs, Number(input.satoshiPerByte))
   })()
 
-  /**
-   * note - the 0-indexed output is the `to` address, and if `input.from` is included as an argument, the
-   * 1-indexed output will be the change address, which we overwrite below
-   */
-  if (input.from && result?.outputs?.[1]?.value) {
+  // Finds the change output index (if present), so we can replace it with the from address in case from is provided
+  const changeOutputIndex = (result.outputs ?? []).findIndex(
+    o => o.value && !o.address && !o.script,
+  )
+  if (input.from && result.outputs && changeOutputIndex !== -1) {
     // If input contains a `from` param, inputs will be filtered to only keep UTXOs from that address
     // The change address will be set to this from address, so that it can be reused
     // Reusing addresses is an xpub antipattern and totally voids UTXO privacy guarantees, thus input.from should only be used
     // when dealing with destinations that expect address reuse e.g THORChain savers
-    const { value } = result.outputs[1]
-    result.outputs[1] = { address: input.from, value }
+    const { value } = result.outputs[changeOutputIndex]
+    result.outputs[changeOutputIndex] = { address: input.from, value }
   }
 
   return { ...result, outputs: result.outputs?.filter(o => !o.script) }


### PR DESCRIPTION
## Description

Ensures change is consistently sent to the `from` address is passed - regardless of whether or not the utxoSelect result outputs contain an `OP_RETURN_DATA` or not.

## Pull Request Type

- [x] :bug: Bug fix (Non-breaking Change: Fixes an issue)
- [ ] :hammer_and_wrench: Chore (Non-breaking Change: Doc updates, pkg upgrades, typos, etc..)
- [ ] :nail_care: New Feature (Breaking/Non-breaking Change)

## Issue (if applicable)

<!-----------------------------------------------------------------------------
If applicable, please link to the github issue and put `closes #XXXX` in your comment to auto-close the issue that your PR fixes.
------------------------------------------------------------------------------>

closes https://github.com/shapeshift/web/issues/5925

## Risk

<!-----------------------------------------------------------------------------
Outline the scope of your changes and the risk associated with them. You must use your discretion as an engineer to determine the potential impact of your changes.

E.g. an upgrade to `hdwallet` or core state management would be considered higher risk, and might require a full regression test. UI or isolated view changes, or something behind a feature flag may have near zero risk. Small bug fixes might require testing isolated to the specific fix.
------------------------------------------------------------------------------>

- Low to none. Changes the heuristics for change output detection to... actually detect the change output. Hardcoding it to first index was a mistake, so this is the same, but safer and consistently working.

## Testing

<!-----------------------------------------------------------------------------
We treat every PR to be merged with the same scrutiny as if we were merging directly to production.

Your PR will not be merged if you do not complete the sections below for our engineering and operations teams to test.
------------------------------------------------------------------------------>

- Savers UTXO deposit Txs have their change sent back to the same address
- Savers UTXO withdraw Txs *still* have their change sent back to the same address
- Lending UTXO loan open Txs have their change sent back to the same address

### Engineering

<!-----------------------------------------------------------------------------
Include sufficient information here for an engineer to test your PR. This may include how to test locally, in a built environment, changes to infrastructure etc.
------------------------------------------------------------------------------>

- ☝🏽 

### Operations

<!-----------------------------------------------------------------------------
If your changes have a user-facing impact, describe how a non-technical QA team can functionally test your changes in a preview environment.

If they are not user-facing please describe how to test for any regressions that may occur.
------------------------------------------------------------------------------>

- ☝🏽 

## Screenshots (if applicable)

### Savers Withdraw (no OP_RETURN_DATA)

<img width="610" alt="image" src="https://github.com/shapeshift/web/assets/17035424/7cf9a68e-6ea0-4861-91d4-f7f53368764c">

### Savers Deposit with OP_RETURN_DATA

<img width="1177" alt="image" src="https://github.com/shapeshift/web/assets/17035424/f0a0b057-bf44-4ccc-b7e0-3c4b35c6a4bb">
