### PR TITLE
fix: revert donations bandaid for 0x, 1inch, and LiFi

### DIFF
--- a/packages/swapper/src/types.ts
+++ b/packages/swapper/src/types.ts
@@ -101,6 +101,9 @@ type CommonTradeInput = {
   affiliateBps: string
   allowMultiHop: boolean
   slippageTolerancePercentageDecimal?: string
+  // KeepKey is rugged and requires a bandaid to disable affiliate fee for EVM sell assets, see https://github.com/shapeshift/web/issues/4518
+  // Since we have a single shared input across all swappers, we need to pass this as feature detection to monkey patch affiliate bps to 0
+  isKeepKey: boolean
 }
 
 export type GetEvmTradeQuoteInput = CommonTradeInput & {

--- a/src/components/MultiHopTrade/hooks/useGetTradeQuotes/getTradeQuoteArgs.ts
+++ b/src/components/MultiHopTrade/hooks/useGetTradeQuotes/getTradeQuoteArgs.ts
@@ -30,6 +30,9 @@ export type GetTradeQuoteInputArgs = {
   affiliateBps: string
   isSnapInstalled?: boolean
   pubKey?: string | undefined
+  // KeepKey is rugged and requires a bandaid to disable affiliate fee for EVM sell assets, see https://github.com/shapeshift/web/issues/4518
+  // Since we have a single shared input across all swappers, we need to pass this as feature detection to monkey patch affiliate bps to 0
+  isKeepKey: boolean
 }
 
 export const getTradeQuoteArgs = async ({
@@ -46,6 +49,7 @@ export const getTradeQuoteArgs = async ({
   potentialAffiliateBps,
   slippageTolerancePercentageDecimal,
   pubKey,
+  isKeepKey,
 }: GetTradeQuoteInputArgs): Promise<GetTradeQuoteInput | undefined> => {
   if (!sellAsset || !buyAsset) return undefined
   const tradeQuoteInputCommonArgs: TradeQuoteInputCommonArgs = {
@@ -61,6 +65,7 @@ export const getTradeQuoteArgs = async ({
     potentialAffiliateBps: potentialAffiliateBps ?? '0',
     allowMultiHop,
     slippageTolerancePercentageDecimal,
+    isKeepKey,
   }
   if (isEvmSwap(sellAsset?.chainId) || isCosmosSdkSwap(sellAsset?.chainId)) {
     const supportsEIP1559 = supportsETH(wallet) && (await wallet.ethSupportsEIP1559())

--- a/src/components/MultiHopTrade/types.ts
+++ b/src/components/MultiHopTrade/types.ts
@@ -65,4 +65,5 @@ export type TradeQuoteInputCommonArgs = Pick<
   | 'potentialAffiliateBps'
   | 'allowMultiHop'
   | 'slippageTolerancePercentageDecimal'
+  | 'isKeepKey'
 >

--- a/src/lib/swapper/swappers/CowSwapper/getCowSwapTradeQuote/getCowSwapTradeQuote.test.ts
+++ b/src/lib/swapper/swappers/CowSwapper/getCowSwapTradeQuote/getCowSwapTradeQuote.test.ts
@@ -258,6 +258,7 @@ describe('getCowTradeQuote', () => {
       supportsEIP1559: false,
       allowMultiHop: false,
       slippageTolerancePercentageDecimal: '0.005', // 0.5%
+      isKeepKey: false,
     }
 
     const maybeTradeQuote = await getCowSwapTradeQuote(input)
@@ -284,6 +285,7 @@ describe('getCowTradeQuote', () => {
       supportsEIP1559: false,
       allowMultiHop: false,
       slippageTolerancePercentageDecimal: '0.005', // 0.5%
+      isKeepKey: false,
     }
 
     mockedCowService.post.mockReturnValue(
@@ -328,6 +330,7 @@ describe('getCowTradeQuote', () => {
       supportsEIP1559: false,
       allowMultiHop: false,
       slippageTolerancePercentageDecimal: '0.005', // 0.5%
+      isKeepKey: false,
     }
 
     mockedCowService.post.mockReturnValue(
@@ -372,6 +375,7 @@ describe('getCowTradeQuote', () => {
       supportsEIP1559: false,
       allowMultiHop: false,
       slippageTolerancePercentageDecimal: '0.005', // 0.5%
+      isKeepKey: false,
     }
 
     mockedCowService.post.mockReturnValue(
@@ -416,6 +420,7 @@ describe('getCowTradeQuote', () => {
       supportsEIP1559: false,
       allowMultiHop: false,
       slippageTolerancePercentageDecimal: '0.005', // 0.5%
+      isKeepKey: false,
     }
 
     mockedCowService.post.mockReturnValue(

--- a/src/lib/swapper/swappers/LifiSwapper/getTradeQuote/getTradeQuote.ts
+++ b/src/lib/swapper/swappers/LifiSwapper/getTradeQuote/getTradeQuote.ts
@@ -2,6 +2,7 @@ import type { ChainKey, LifiError, RoutesRequest } from '@lifi/sdk'
 import { LifiErrorCode } from '@lifi/sdk'
 import type { AssetId, ChainId } from '@shapeshiftoss/caip'
 import { fromChainId } from '@shapeshiftoss/caip'
+import { isEvmChainId } from '@shapeshiftoss/chain-adapters'
 import type { GetEvmTradeQuoteInput, SwapSource } from '@shapeshiftoss/swapper'
 import {
   makeSwapErrorRight,
@@ -40,9 +41,14 @@ export async function getTradeQuote(
     receiveAddress,
     accountNumber,
     supportsEIP1559,
-    affiliateBps,
-    potentialAffiliateBps,
+    affiliateBps: _affiliateBps,
+    potentialAffiliateBps: _potentialAffiliateBps,
+    isKeepKey,
   } = input
+
+  const isFromEvm = isEvmChainId(sellAsset.chainId)
+  const affiliateBps = isKeepKey && isFromEvm ? '0' : _affiliateBps
+  const potentialAffiliateBps = isKeepKey && isFromEvm ? '0' : _potentialAffiliateBps
 
   const slippageTolerancePercentageDecimal =
     input.slippageTolerancePercentageDecimal ??

--- a/src/lib/swapper/swappers/OneInchSwapper/getTradeQuote/getTradeQuote.ts
+++ b/src/lib/swapper/swappers/OneInchSwapper/getTradeQuote/getTradeQuote.ts
@@ -1,4 +1,5 @@
 import { fromChainId } from '@shapeshiftoss/caip'
+import { isEvmChainId } from '@shapeshiftoss/chain-adapters'
 import type { GetEvmTradeQuoteInput, TradeQuote } from '@shapeshiftoss/swapper'
 import {
   makeSwapErrorRight,
@@ -31,13 +32,18 @@ export async function getTradeQuote(
     sellAsset,
     buyAsset,
     accountNumber,
-    affiliateBps,
-    potentialAffiliateBps,
+    affiliateBps: _affiliateBps,
+    potentialAffiliateBps: _potentialAffiliateBps,
     supportsEIP1559,
     receiveAddress,
     sellAmountIncludingProtocolFeesCryptoBaseUnit,
+    isKeepKey,
   } = input
   const apiUrl = getConfig().REACT_APP_ONE_INCH_API_URL
+
+  const isFromEvm = isEvmChainId(sellAsset.chainId)
+  const affiliateBps = isKeepKey && isFromEvm ? '0' : _affiliateBps
+  const potentialAffiliateBps = isKeepKey && isFromEvm ? '0' : _potentialAffiliateBps
 
   const assertion = assertValidTrade({ buyAsset, sellAsset, receiveAddress })
   if (assertion.isErr()) return Err(assertion.unwrapErr())

--- a/src/lib/swapper/swappers/ZrxSwapper/getZrxTradeQuote/getZrxTradeQuote.ts
+++ b/src/lib/swapper/swappers/ZrxSwapper/getZrxTradeQuote/getZrxTradeQuote.ts
@@ -1,3 +1,4 @@
+import { isEvmChainId } from '@shapeshiftoss/chain-adapters'
 import type { GetEvmTradeQuoteInput, TradeQuote } from '@shapeshiftoss/swapper'
 import {
   makeSwapErrorRight,
@@ -24,12 +25,17 @@ export async function getZrxTradeQuote(
     buyAsset,
     accountNumber,
     receiveAddress,
-    affiliateBps,
-    potentialAffiliateBps,
+    affiliateBps: _affiliateBps,
+    potentialAffiliateBps: _potentialAffiliateBps,
     chainId,
     supportsEIP1559,
     sellAmountIncludingProtocolFeesCryptoBaseUnit,
+    isKeepKey,
   } = input
+
+  const isFromEvm = isEvmChainId(sellAsset.chainId)
+  const affiliateBps = isKeepKey && isFromEvm ? '0' : _affiliateBps
+  const potentialAffiliateBps = isKeepKey && isFromEvm ? '0' : _potentialAffiliateBps
 
   const slippageTolerancePercentageDecimal =
     input.slippageTolerancePercentageDecimal ??

--- a/src/lib/swapper/swappers/utils/test-data/setupSwapQuote.ts
+++ b/src/lib/swapper/swappers/utils/test-data/setupSwapQuote.ts
@@ -43,6 +43,7 @@ export const setupQuote = () => {
     buyAsset,
     accountNumber: 0,
     receiveAddress: '0xc770eefad204b5180df6a14ee197d99d808ee52d',
+    isKeepKey: false,
     affiliateBps: '0',
     potentialAffiliateBps: '0',
     supportsEIP1559: false,


### PR DESCRIPTION
## Description

Reverts to the original behavior of https://github.com/shapeshift/web/pull/4539, disabling affiliate fee for 0x, 1inch, and Li.Fi (@woodenfurniture to confirm the latter).

tl;dr of this is we lost the granularity of disabling EVM KK donations (now affiliate fees) with https://github.com/shapeshift/web/pull/5403, so this brings it back.

To be followed-up with:

- Removing the donation feature entirely and its flag to keep things simple and make debugging easier without the donation/FOX discounts branching
- A draft PR removing the monkey patch entirely, to be opened after extensive testing and confirming with operations EVM "donations" (affiliate fees) aren't affected by this bug anymore on KK


## Pull Request Type

- [x] :bug: Bug fix (Non-breaking Change: Fixes an issue)
- [ ] :hammer_and_wrench: Chore (Non-breaking Change: Doc updates, pkg upgrades, typos, etc..)
- [ ] :nail_care: New Feature (Breaking/Non-breaking Change)

## Issue (if applicable)

<!-----------------------------------------------------------------------------
If applicable, please link to the github issue and put `closes #XXXX` in your comment to auto-close the issue that your PR fixes.
------------------------------------------------------------------------------>

closes https://github.com/shapeshift/web/issues/596

## Risk

<!-----------------------------------------------------------------------------
Outline the scope of your changes and the risk associated with them. You must use your discretion as an engineer to determine the potential impact of your changes.

E.g. an upgrade to `hdwallet` or core state management would be considered higher risk, and might require a full regression test. UI or isolated view changes, or something behind a feature flag may have near zero risk. Small bug fixes might require testing isolated to the specific fix.
------------------------------------------------------------------------------>

Theoretically low to none but effectively given the diffed domain. Getting this wrong means we would potentially not have affiliate fees anymore when applicable - see testing

## Testing

<!-----------------------------------------------------------------------------
We treat every PR to be merged with the same scrutiny as if we were merging directly to production.

Your PR will not be merged if you do not complete the sections below for our engineering and operations teams to test.
------------------------------------------------------------------------------>

- When KeepKey is connected, EVM donations are disabled for 1inch, ZRX, and Li.Fi, meaning the ShapeShift fee is effectively free.
- When another wallet is connected, donations are enabled and match the ShapeShift discount (i.e free, reducted, or full fee depending on trade size and FOX power)
- THOR EVM sell asset Txs are succesful, both with and without an affiliate fee
### Engineering

<!-----------------------------------------------------------------------------
Include sufficient information here for an engineer to test your PR. This may include how to test locally, in a built environment, changes to infrastructure etc.
------------------------------------------------------------------------------>

- ☝🏽 
- Note the temporary addition of `isKeepKey` - to be reverted after confirming https://github.com/shapeshift/web/issues/4518 is a non-issue
 
### Operations

<!-----------------------------------------------------------------------------
If your changes have a user-facing impact, describe how a non-technical QA team can functionally test your changes in a preview environment.

If they are not user-facing please describe how to test for any regressions that may occur.
------------------------------------------------------------------------------>

## Screenshots (if applicable)

### KK affiliate fee and FOX discounts enabled for THOR

<img width="992" alt="Screenshot 2024-01-09 at 13 14 17" 
src="https://github.com/shapeshift/web/assets/17035424/4509c9ea-0588-49fb-9b43-70bc6a785949">

## KK affiliate fee and FOX discounts disabled for 1inch, ZRX, and Li.Fi

<img width="983" alt="Screenshot 2024-01-09 at 13 14 53" src="https://github.com/shapeshift/web/assets/17035424/ce8c8b3e-944e-4fe3-8920-a5fac99166e5">
<img width="990" alt="Screenshot 2024-01-09 at 13 15 05" src="https://github.com/shapeshift/web/assets/17035424/e92c3a91-1488-4182-ad71-a37f72694b88">
<img width="976" alt="Screenshot 2024-01-09 at 13 15 21" src="https://github.com/shapeshift/web/assets/17035424/15885eb3-d92e-4f2c-84ba-6d6e53fc47ec">

## Native affiliate fees and FOX discounts enabled across swappers

<img width="1023" alt="Screenshot 2024-01-09 at 13 26 52" src="https://github.com/shapeshift/web/assets/17035424/e0f37400-a14f-4242-9ef3-354ccc81d996">
<img width="987" alt="Screenshot 2024-01-09 at 13 27 08" src="https://github.com/shapeshift/web/assets/17035424/0d997344-47c8-46b5-a56e-881074b18711">