### PR TITLE
chore: thorchain lp add/remove logic

### DIFF
--- a/src/lib/utils/thorchain/lp.ts
+++ b/src/lib/utils/thorchain/lp.ts
@@ -138,9 +138,7 @@ export const getPoolShare = (liquidityUnits: BN, pool: MidgardPoolResponse): Poo
   return {
     assetShare: asset,
     runeShare: rune,
-    poolShareDecimalPercent: liquidityUnits
-      .div(liquidityUnits.plus(pool.liquidityUnits))
-      .toString(),
+    poolShareDecimalPercent: liquidityUnits.div(liquidityUnits.plus(pool.liquidityUnits)).toFixed(),
   }
 }
 
@@ -243,6 +241,7 @@ export const estimateRemoveThorchainLiquidityPosition = async ({
     slipPercent: slip.times(100).toFixed(),
     poolShareAsset: poolShare.assetShare.toFixed(),
     poolShareRune: poolShare.runeShare.toFixed(),
+    poolShareDecimalPercent: poolShare.poolShareDecimalPercent,
     liquidityUnits,
     assetAmount: poolShare.assetShare.toFixed(),
     runeAmount: poolShare.runeShare.toFixed(),

--- a/src/lib/utils/thorchain/lp.ts
+++ b/src/lib/utils/thorchain/lp.ts
@@ -138,6 +138,9 @@ export const getPoolShare = (liquidityUnits: BN, pool: MidgardPoolResponse): Poo
   return {
     assetShare: asset,
     runeShare: rune,
+    poolShareDecimalPercent: liquidityUnits
+      .div(liquidityUnits.plus(pool.liquidityUnits))
+      .toString(),
   }
 }
 
@@ -194,14 +197,16 @@ export const estimateAddThorchainLiquidityPosition = async ({
 
   return {
     assetPool: pool.asset,
-    slipPercent: slip.times(100),
-    poolShare,
-    liquidityUnits,
+    slipPercent: slip.times(100).toFixed(),
+    poolShareAsset: poolShare.assetShare.toFixed(),
+    poolShareRune: poolShare.runeShare.toFixed(),
+    poolShareDecimalPercent: poolShare.poolShareDecimalPercent,
+    liquidityUnits: liquidityUnits.toFixed(),
     inbound: {
       fees: {
-        asset: assetInboundFee,
-        rune: runeInboundFee,
-        total: totalFees,
+        asset: assetInboundFee.toFixed(),
+        rune: runeInboundFee.toFixed(),
+        total: totalFees.toFixed(),
       },
     },
   }
@@ -235,16 +240,17 @@ export const estimateRemoveThorchainLiquidityPosition = async ({
 
   return {
     assetPool: pool.asset,
-    slipPercent: slip.times(100),
-    poolShare,
+    slipPercent: slip.times(100).toFixed(),
+    poolShareAsset: poolShare.assetShare.toFixed(),
+    poolShareRune: poolShare.runeShare.toFixed(),
     liquidityUnits,
-    assetAmount: poolShare.assetShare,
-    runeAmount: poolShare.runeShare,
+    assetAmount: poolShare.assetShare.toFixed(),
+    runeAmount: poolShare.runeShare.toFixed(),
     inbound: {
       fees: {
-        asset: assetInboundFee,
-        rune: runeInboundFee,
-        total: totalFees,
+        asset: assetInboundFee.toFixed(),
+        rune: runeInboundFee.toFixed(),
+        total: totalFees.toFixed(),
       },
     },
   }

--- a/src/lib/utils/thorchain/lp.ts
+++ b/src/lib/utils/thorchain/lp.ts
@@ -176,12 +176,12 @@ export const estimateAddThorchainLiquidityPosition = async ({
   const poolResult = await thorService.get<MidgardPoolResponse>(`${midgardUrl}/pool/${poolAssetId}`)
   if (poolResult.isErr()) throw poolResult.unwrapErr()
   const pool = poolResult.unwrap().data
-  const liquidityUnits = getLiquidityUnits({
+  const liquidityUnitsCryptoThorPrecision = getLiquidityUnits({
     pool,
     assetAmountCryptoThorPrecision,
     runeAmountCryptoThorPrecision,
   })
-  const poolShare = getPoolShare(liquidityUnits, pool)
+  const poolShare = getPoolShare(liquidityUnitsCryptoThorPrecision, pool)
 
   const assetInboundFee = bn(0) // TODO
   const runeInboundFee = bn(0) // TODO
@@ -199,7 +199,7 @@ export const estimateAddThorchainLiquidityPosition = async ({
     poolShareAsset: poolShare.assetShare.toFixed(),
     poolShareRune: poolShare.runeShare.toFixed(),
     poolShareDecimalPercent: poolShare.poolShareDecimalPercent,
-    liquidityUnits: liquidityUnits.toFixed(),
+    liquidityUnits: liquidityUnitsCryptoThorPrecision.toFixed(),
     inbound: {
       fees: {
         asset: assetInboundFee.toFixed(),
@@ -221,11 +221,11 @@ export const estimateRemoveThorchainLiquidityPosition = async ({
 }) => {
   const lpPosition = await getThorchainLiquidityProviderPosition({ accountId, assetId })
   const poolAssetId = assetIdToPoolAssetId({ assetId })
-  const liquidityUnits = lpPosition?.poolData.LP_units
+  const liquidityUnitsCryptoThorPrecision = lpPosition?.poolData.LP_units
   const poolResult = await thorService.get<MidgardPoolResponse>(`${midgardUrl}/pool/${poolAssetId}`)
   if (poolResult.isErr()) throw poolResult.unwrapErr()
   const pool = poolResult.unwrap().data
-  const poolShare = getPoolShare(bnOrZero(liquidityUnits), pool)
+  const poolShare = getPoolShare(bnOrZero(liquidityUnitsCryptoThorPrecision), pool)
   const slip = getSlipOnLiquidity({
     runeAmountCryptoThorPrecision: poolShare.runeShare.toString(),
     assetAmountCryptoThorPrecision: poolShare.assetShare.toString(),
@@ -239,12 +239,12 @@ export const estimateRemoveThorchainLiquidityPosition = async ({
   return {
     assetPool: pool.asset,
     slipPercent: slip.times(100).toFixed(),
-    poolShareAsset: poolShare.assetShare.toFixed(),
-    poolShareRune: poolShare.runeShare.toFixed(),
+    poolShareAssetCryptoThorPrecision: poolShare.assetShare.toFixed(),
+    poolShareRuneCryptoThorPrecision: poolShare.runeShare.toFixed(),
     poolShareDecimalPercent: poolShare.poolShareDecimalPercent,
-    liquidityUnits,
-    assetAmount: poolShare.assetShare.toFixed(),
-    runeAmount: poolShare.runeShare.toFixed(),
+    liquidityUnitsCryptoThorPrecision,
+    assetAmountCryptoThorPrecision: poolShare.assetShare.toFixed(),
+    runeAmountCryptoThorPrecision: poolShare.runeShare.toFixed(),
     inbound: {
       fees: {
         asset: assetInboundFee.toFixed(),

--- a/src/lib/utils/thorchain/lp.ts
+++ b/src/lib/utils/thorchain/lp.ts
@@ -1,16 +1,22 @@
 import { type AccountId, type AssetId, fromAccountId, fromAssetId } from '@shapeshiftoss/caip'
 import axios from 'axios'
 import { getConfig } from 'config'
+import { type BN, bn, bnOrZero } from 'lib/bignumber/bignumber'
+import type { MidgardPoolResponse } from 'lib/swapper/swappers/ThorchainSwapper/types'
 import { assetIdToPoolAssetId } from 'lib/swapper/swappers/ThorchainSwapper/utils/poolAssetHelpers/poolAssetHelpers'
+import { thorService } from 'lib/swapper/swappers/ThorchainSwapper/utils/thorService'
 import { isUtxoChainId } from 'state/slices/portfolioSlice/utils'
 
 import { getAccountAddresses } from '.'
 import type {
   MidgardLiquidityProvider,
   MidgardPool,
+  PoolShareDetail,
   ThorchainLiquidityProvidersResponseSuccess,
   ThorNodeLiquidityProvider,
 } from './lp/types'
+
+const midgardUrl = getConfig().REACT_APP_MIDGARD_URL
 
 export const getAllThorchainLiquidityProviderPositions = async (
   assetId: AssetId,
@@ -79,5 +85,109 @@ export const getThorchainLiquidityProviderPosition = async ({
   return {
     ...accountPosition,
     ...maybeMidgardMember,
+  }
+}
+
+// https://dev.thorchain.org/thorchain-dev/interface-guide/math#lp-units-add
+export const getLiquidityUnits = ({
+  pool,
+  assetAmountCryptoThorPrecision,
+  runeAmountCryptoThorPrecision,
+}: {
+  pool: MidgardPoolResponse
+  assetAmountCryptoThorPrecision: string
+  runeAmountCryptoThorPrecision: string
+}): BN => {
+  const P = pool.liquidityUnits
+  const a = assetAmountCryptoThorPrecision
+  const r = runeAmountCryptoThorPrecision
+  const R = pool.runeDepth
+  const A = pool.assetDepth
+  const part1 = bnOrZero(R).times(a)
+  const part2 = bnOrZero(r).times(A)
+
+  const numerator = bnOrZero(P).times(part1.plus(part2))
+  const denominator = bnOrZero(R).times(A).times(2)
+  const result = numerator.div(denominator)
+  return result
+}
+
+export const getPoolShare = (liquidityUnits: BN, pool: MidgardPoolResponse): PoolShareDetail => {
+  // formula: (rune * part) / total; (asset * part) / total
+  const units = liquidityUnits
+  const total = pool.liquidityUnits
+  const R = pool.runeDepth
+  const T = pool.assetDepth
+  const asset = bnOrZero(T).times(units).div(total)
+  const rune = bnOrZero(R).times(units).div(total)
+  return {
+    assetShare: asset,
+    runeShare: rune,
+  }
+}
+
+export const getSlipOnLiquidity = ({
+  runeAmountCryptoThorPrecision,
+  assetAmountCryptoThorPrecision,
+  pool,
+}: {
+  runeAmountCryptoThorPrecision: string
+  assetAmountCryptoThorPrecision: string
+  pool: MidgardPoolResponse
+}): BN => {
+  // formula: (t * R - T * r)/ (T*r + R*T)
+  const r = runeAmountCryptoThorPrecision
+  const t = assetAmountCryptoThorPrecision
+  const R = pool.runeDepth
+  const T = pool.assetDepth
+  const numerator = bnOrZero(t).times(R).minus(bnOrZero(T).times(r))
+  const denominator = bnOrZero(T).times(r).plus(bnOrZero(R).times(T))
+  const result = numerator.div(denominator).abs()
+  return result
+}
+
+// Estimates a liquidity position for given crypto amount value, both asymmetrical and symetrical
+export const estimateAddThorchainLiquidityPosition = async ({
+  runeAmountCryptoThorPrecision,
+  assetId,
+  assetAmountCryptoThorPrecision,
+}: {
+  runeAmountCryptoThorPrecision: string
+  assetId: AssetId
+  assetAmountCryptoThorPrecision: string
+}): Promise<{}> => {
+  const poolAssetId = assetIdToPoolAssetId({ assetId })
+  const poolResult = await thorService.get<MidgardPoolResponse>(`${midgardUrl}/pool/${poolAssetId}`)
+  if (poolResult.isErr()) throw poolResult.unwrapErr()
+  const pool = poolResult.unwrap().data
+  const liquidityUnits = getLiquidityUnits({
+    pool,
+    assetAmountCryptoThorPrecision,
+    runeAmountCryptoThorPrecision,
+  })
+  const poolShare = getPoolShare(liquidityUnits, pool)
+
+  const assetInboundFee = bn(0) // TODO
+  const runeInboundFee = bn(0) // TODO
+  const totalFees = assetInboundFee.plus(runeInboundFee)
+
+  const slip = getSlipOnLiquidity({
+    runeAmountCryptoThorPrecision,
+    assetAmountCryptoThorPrecision,
+    pool,
+  })
+
+  return {
+    assetPool: pool.asset,
+    slipPercent: slip.times(100),
+    poolShare,
+    liquidityUnits,
+    inbound: {
+      fees: {
+        asset: assetInboundFee,
+        rune: runeInboundFee,
+        total: totalFees,
+      },
+    },
   }
 }

--- a/src/lib/utils/thorchain/lp.ts
+++ b/src/lib/utils/thorchain/lp.ts
@@ -2,7 +2,10 @@ import { type AccountId, type AssetId, fromAccountId, fromAssetId } from '@shape
 import axios from 'axios'
 import { getConfig } from 'config'
 import { type BN, bn, bnOrZero } from 'lib/bignumber/bignumber'
-import type { MidgardPoolResponse } from 'lib/swapper/swappers/ThorchainSwapper/types'
+import type {
+  MidgardPoolResponse,
+  ThornodePoolResponse,
+} from 'lib/swapper/swappers/ThorchainSwapper/types'
 import { assetIdToPoolAssetId } from 'lib/swapper/swappers/ThorchainSwapper/utils/poolAssetHelpers/poolAssetHelpers'
 import { thorService } from 'lib/swapper/swappers/ThorchainSwapper/utils/thorService'
 import { isUtxoChainId } from 'state/slices/portfolioSlice/utils'
@@ -215,7 +218,7 @@ export const estimateRemoveThorchainLiquidityPosition = async ({
 }) => {
   const lpPosition = await getThorchainLiquidityProviderPosition({ accountId, assetId })
   const poolAssetId = assetIdToPoolAssetId({ assetId })
-  const liquidityUnits = lpPosition?.liquidityUnits
+  const liquidityUnits = lpPosition?.poolData.LP_units
   const poolResult = await thorService.get<MidgardPoolResponse>(`${midgardUrl}/pool/${poolAssetId}`)
   if (poolResult.isErr()) throw poolResult.unwrapErr()
   const pool = poolResult.unwrap().data

--- a/src/lib/utils/thorchain/lp/types.ts
+++ b/src/lib/utils/thorchain/lp/types.ts
@@ -52,4 +52,5 @@ export type ThorchainLiquidityProvidersResponseSuccess = ThorNodeLiquidityProvid
 export type PoolShareDetail = {
   assetShare: BN
   runeShare: BN
+  poolShareDecimalPercent: string
 }

--- a/src/lib/utils/thorchain/lp/types.ts
+++ b/src/lib/utils/thorchain/lp/types.ts
@@ -1,3 +1,5 @@
+import type { BN } from 'lib/bignumber/bignumber'
+
 export type ThorNodeLiquidityProvider = {
   asset: string
   asset_address?: string
@@ -44,3 +46,8 @@ export type ExtendedThorNodeLiquidityProvider = ThorNodeLiquidityProvider & {
 }
 
 export type ThorchainLiquidityProvidersResponseSuccess = ThorNodeLiquidityProvider[]
+
+export type PoolShareDetail = {
+  assetShare: BN
+  runeShare: BN
+}


### PR DESCRIPTION
## Description

Adds additional THORChain LP logic, including fns needed for `estimateAddThorchainLiquidityPosition`, which will then support `addThorchainLiquidityPosition`.

## Pull Request Type

- [ ] :bug: Bug fix (Non-breaking Change: Fixes an issue)
- [x] :hammer_and_wrench: Chore (Non-breaking Change: Doc updates, pkg upgrades, typos, etc..)
- [ ] :nail_care: New Feature (Breaking/Non-breaking Change)

## Issue (if applicable)

Relates to https://github.com/shapeshift/web/issues/5960

## Risk

Small - logic isolated to a helper file.

## Testing

N/A - if CI is green we are good to go.

### Engineering

☝️

Add to `PoolsPage.tsx`

```ts
useEffect(() => {
    const testAdd = estimateAddThorchainLiquidityPosition({
      runeAmountCryptoThorPrecision: '100000000', // 1 RUNE asym deposit
      assetId: btcAssetId,
      assetAmountCryptoThorPrecision: '0',
    })

    ;(async () => {
      console.log('xxx testAdd', await testAdd)
    })()
  }, [])
```

### Operations

☝️

## Screenshots (if applicable)

<img width="716" alt="Screenshot 2024-01-12 at 11 31 15 am" src="https://github.com/shapeshift/web/assets/97164662/6696541d-b5b0-4118-a7b2-5098f9dde9c5">

