### PR TITLE
fix: lock axios to older, none esm version

### DIFF
--- a/packages/caip/package.json
+++ b/packages/caip/package.json
@@ -23,5 +23,8 @@
   },
   "devDependencies": {
     "@yfi/sdk": "^1.2.0"
+  },
+  "dependencies": {
+    "axios": "0.26.1"
   }
 }

--- a/packages/chain-adapters/package.json
+++ b/packages/chain-adapters/package.json
@@ -20,6 +20,7 @@
     "@shapeshiftoss/caip": "workspace:^",
     "@shapeshiftoss/types": "workspace:^",
     "@shapeshiftoss/unchained-client": "workspace:^",
+    "axios": "0.26.1",
     "bech32": "^2.0.0",
     "coinselect": "^3.1.13",
     "multicoin-address-validator": "^0.5.12",

--- a/yarn.lock
+++ b/yarn.lock
@@ -9466,6 +9466,7 @@ __metadata:
   resolution: "@shapeshiftoss/caip@workspace:packages/caip"
   dependencies:
     "@yfi/sdk": ^1.2.0
+    axios: 0.26.1
   languageName: unknown
   linkType: soft
 
@@ -9477,6 +9478,7 @@ __metadata:
     "@shapeshiftoss/types": "workspace:^"
     "@shapeshiftoss/unchained-client": "workspace:^"
     "@types/multicoin-address-validator": ^0.5.0
+    axios: 0.26.1
     bech32: ^2.0.0
     coinselect: ^3.1.13
     multicoin-address-validator: ^0.5.12


### PR DESCRIPTION
## Description

We have a webpack build issue with external `.cjs` packages that are used in workspace packages.
The recently updated `axios` package in https://github.com/shapeshift/web/pull/5943 exposed this issue.

This PR is a bandaid until we can work out how to support `.cjs` packages in our build pipeline.

## Pull Request Type

- [x] :bug: Bug fix (Non-breaking Change: Fixes an issue)
- [ ] :hammer_and_wrench: Chore (Non-breaking Change: Doc updates, pkg upgrades, typos, etc..)
- [ ] :nail_care: New Feature (Breaking/Non-breaking Change)

## Issue (if applicable)

N/A - release blocker.

## Risk

Medium - affects sends and swaps.

## Testing

Sends and swaps should be great again.

### Engineering

☝️

### Operations

☝️

## Screenshots (if applicable)

<img width="446" alt="Screenshot 2024-01-11 at 1 51 14 pm" src="https://github.com/shapeshift/web/assets/97164662/c6160f8b-40df-4f90-8075-bf5ba455c28b">
