### PR TITLE
fix: broken fees on keepkey evm trades

### DIFF
--- a/packages/swapper/src/types.ts
+++ b/packages/swapper/src/types.ts
@@ -95,9 +95,6 @@ type CommonTradeInput = {
   affiliateBps: string
   allowMultiHop: boolean
   slippageTolerancePercentageDecimal?: string
-  // KeepKey is rugged and requires a bandaid to disable affiliate fee for EVM sell assets, see https://github.com/shapeshift/web/issues/4518
-  // Since we have a single shared input across all swappers, we need to pass this as feature detection to monkey patch affiliate bps to 0
-  isKeepKey: boolean
 }
 
 export type GetEvmTradeQuoteInput = CommonTradeInput & {

--- a/src/components/MultiHopTrade/hooks/useGetTradeQuotes/getTradeQuoteArgs.ts
+++ b/src/components/MultiHopTrade/hooks/useGetTradeQuotes/getTradeQuoteArgs.ts
@@ -30,9 +30,6 @@ export type GetTradeQuoteInputArgs = {
   affiliateBps: string
   isSnapInstalled?: boolean
   pubKey?: string | undefined
-  // KeepKey is rugged and requires a bandaid to disable affiliate fee for EVM sell assets, see https://github.com/shapeshift/web/issues/4518
-  // Since we have a single shared input across all swappers, we need to pass this as feature detection to monkey patch affiliate bps to 0
-  isKeepKey: boolean
 }
 
 export const getTradeQuoteArgs = async ({
@@ -49,7 +46,6 @@ export const getTradeQuoteArgs = async ({
   potentialAffiliateBps,
   slippageTolerancePercentageDecimal,
   pubKey,
-  isKeepKey,
 }: GetTradeQuoteInputArgs): Promise<GetTradeQuoteInput | undefined> => {
   if (!sellAsset || !buyAsset) return undefined
   const tradeQuoteInputCommonArgs: TradeQuoteInputCommonArgs = {
@@ -65,7 +61,6 @@ export const getTradeQuoteArgs = async ({
     potentialAffiliateBps: potentialAffiliateBps ?? '0',
     allowMultiHop,
     slippageTolerancePercentageDecimal,
-    isKeepKey,
   }
   if (isEvmSwap(sellAsset?.chainId) || isCosmosSdkSwap(sellAsset?.chainId)) {
     const supportsEIP1559 = supportsETH(wallet) && (await wallet.ethSupportsEIP1559())

--- a/src/components/MultiHopTrade/hooks/useGetTradeQuotes/useGetTradeQuotes.tsx
+++ b/src/components/MultiHopTrade/hooks/useGetTradeQuotes/useGetTradeQuotes.tsx
@@ -16,7 +16,7 @@ import { bnOrZero } from 'lib/bignumber/bignumber'
 import { calculateFees } from 'lib/fees/model'
 import { getMixPanel } from 'lib/mixpanel/mixPanelSingleton'
 import { MixPanelEvent } from 'lib/mixpanel/types'
-import { isKeepKeyHDWallet, isSkipToken, isSome } from 'lib/utils'
+import { isSkipToken, isSome } from 'lib/utils'
 import { selectIsSnapshotApiQueriesPending, selectVotingPower } from 'state/apis/snapshot/selectors'
 import type { ApiQuote } from 'state/apis/swappers'
 import {
@@ -198,7 +198,6 @@ export const useGetTradeQuotes = () => {
         const { accountNumber: sellAccountNumber } = sellAccountMetadata.bip44Params
         const receiveAssetBip44Params = receiveAccountMetadata?.bip44Params
         const receiveAccountNumber = receiveAssetBip44Params?.accountNumber
-        const walletIsKeepKey = wallet && isKeepKeyHDWallet(wallet)
 
         const tradeAmountUsd = bnOrZero(sellAssetUsdRate).times(debouncedSellAmountCryptoPrecision)
         const potentialAffiliateBps = DEFAULT_SWAPPER_AFFILIATE_BPS
@@ -229,7 +228,6 @@ export const useGetTradeQuotes = () => {
           // Pass in the user's slippage preference if it's set, else let the swapper use its default
           slippageTolerancePercentageDecimal: userslippageTolerancePercentageDecimal,
           pubKey: isLedger(wallet) ? fromAccountId(sellAccountId).account : undefined,
-          isKeepKey: walletIsKeepKey,
         })
 
         // if the quote input args changed, reset the selected swapper and update the trade quote args

--- a/src/components/MultiHopTrade/types.ts
+++ b/src/components/MultiHopTrade/types.ts
@@ -36,5 +36,4 @@ export type TradeQuoteInputCommonArgs = Pick<
   | 'potentialAffiliateBps'
   | 'allowMultiHop'
   | 'slippageTolerancePercentageDecimal'
-  | 'isKeepKey'
 >

--- a/src/lib/swapper/swappers/CowSwapper/getCowSwapTradeQuote/getCowSwapTradeQuote.test.ts
+++ b/src/lib/swapper/swappers/CowSwapper/getCowSwapTradeQuote/getCowSwapTradeQuote.test.ts
@@ -258,7 +258,6 @@ describe('getCowTradeQuote', () => {
       supportsEIP1559: false,
       allowMultiHop: false,
       slippageTolerancePercentageDecimal: '0.005', // 0.5%
-      isKeepKey: false,
     }
 
     const maybeTradeQuote = await getCowSwapTradeQuote(input)
@@ -285,7 +284,6 @@ describe('getCowTradeQuote', () => {
       supportsEIP1559: false,
       allowMultiHop: false,
       slippageTolerancePercentageDecimal: '0.005', // 0.5%
-      isKeepKey: false,
     }
 
     mockedCowService.post.mockReturnValue(
@@ -330,7 +328,6 @@ describe('getCowTradeQuote', () => {
       supportsEIP1559: false,
       allowMultiHop: false,
       slippageTolerancePercentageDecimal: '0.005', // 0.5%
-      isKeepKey: false,
     }
 
     mockedCowService.post.mockReturnValue(
@@ -375,7 +372,6 @@ describe('getCowTradeQuote', () => {
       supportsEIP1559: false,
       allowMultiHop: false,
       slippageTolerancePercentageDecimal: '0.005', // 0.5%
-      isKeepKey: false,
     }
 
     mockedCowService.post.mockReturnValue(
@@ -420,7 +416,6 @@ describe('getCowTradeQuote', () => {
       supportsEIP1559: false,
       allowMultiHop: false,
       slippageTolerancePercentageDecimal: '0.005', // 0.5%
-      isKeepKey: false,
     }
 
     mockedCowService.post.mockReturnValue(

--- a/src/lib/swapper/swappers/LifiSwapper/getTradeQuote/getTradeQuote.ts
+++ b/src/lib/swapper/swappers/LifiSwapper/getTradeQuote/getTradeQuote.ts
@@ -2,7 +2,6 @@ import type { ChainKey, LifiError, RoutesRequest } from '@lifi/sdk'
 import { LifiErrorCode } from '@lifi/sdk'
 import type { AssetId, ChainId } from '@shapeshiftoss/caip'
 import { fromChainId } from '@shapeshiftoss/caip'
-import { isEvmChainId } from '@shapeshiftoss/chain-adapters'
 import type { GetEvmTradeQuoteInput, SwapSource } from '@shapeshiftoss/swapper'
 import {
   makeSwapErrorRight,
@@ -41,14 +40,9 @@ export async function getTradeQuote(
     receiveAddress,
     accountNumber,
     supportsEIP1559,
-    affiliateBps: _affiliateBps,
-    potentialAffiliateBps: _potentialAffiliateBps,
-    isKeepKey,
+    affiliateBps,
+    potentialAffiliateBps,
   } = input
-
-  const isFromEvm = isEvmChainId(sellAsset.chainId)
-  const affiliateBps = isKeepKey && isFromEvm ? '0' : _affiliateBps
-  const potentialAffiliateBps = isKeepKey && isFromEvm ? '0' : _potentialAffiliateBps
 
   const slippageTolerancePercentageDecimal =
     input.slippageTolerancePercentageDecimal ??

--- a/src/lib/swapper/swappers/OneInchSwapper/getTradeQuote/getTradeQuote.ts
+++ b/src/lib/swapper/swappers/OneInchSwapper/getTradeQuote/getTradeQuote.ts
@@ -1,5 +1,4 @@
 import { fromChainId } from '@shapeshiftoss/caip'
-import { isEvmChainId } from '@shapeshiftoss/chain-adapters'
 import type { GetEvmTradeQuoteInput, TradeQuote } from '@shapeshiftoss/swapper'
 import {
   makeSwapErrorRight,
@@ -32,18 +31,13 @@ export async function getTradeQuote(
     sellAsset,
     buyAsset,
     accountNumber,
-    affiliateBps: _affiliateBps,
-    potentialAffiliateBps: _potentialAffiliateBps,
+    affiliateBps,
+    potentialAffiliateBps,
     supportsEIP1559,
     receiveAddress,
     sellAmountIncludingProtocolFeesCryptoBaseUnit,
-    isKeepKey,
   } = input
   const apiUrl = getConfig().REACT_APP_ONE_INCH_API_URL
-
-  const isFromEvm = isEvmChainId(sellAsset.chainId)
-  const affiliateBps = isKeepKey && isFromEvm ? '0' : _affiliateBps
-  const potentialAffiliateBps = isKeepKey && isFromEvm ? '0' : _potentialAffiliateBps
 
   const assertion = assertValidTrade({ buyAsset, sellAsset })
   if (assertion.isErr()) return Err(assertion.unwrapErr())

--- a/src/lib/swapper/swappers/ZrxSwapper/getZrxTradeQuote/getZrxTradeQuote.ts
+++ b/src/lib/swapper/swappers/ZrxSwapper/getZrxTradeQuote/getZrxTradeQuote.ts
@@ -1,4 +1,3 @@
-import { isEvmChainId } from '@shapeshiftoss/chain-adapters'
 import type { GetEvmTradeQuoteInput, TradeQuote } from '@shapeshiftoss/swapper'
 import {
   makeSwapErrorRight,
@@ -25,17 +24,12 @@ export async function getZrxTradeQuote(
     buyAsset,
     accountNumber,
     receiveAddress,
-    affiliateBps: _affiliateBps,
-    potentialAffiliateBps: _potentialAffiliateBps,
+    affiliateBps,
+    potentialAffiliateBps,
     chainId,
     supportsEIP1559,
     sellAmountIncludingProtocolFeesCryptoBaseUnit,
-    isKeepKey,
   } = input
-
-  const isFromEvm = isEvmChainId(sellAsset.chainId)
-  const affiliateBps = isKeepKey && isFromEvm ? '0' : _affiliateBps
-  const potentialAffiliateBps = isKeepKey && isFromEvm ? '0' : _potentialAffiliateBps
 
   const slippageTolerancePercentageDecimal =
     input.slippageTolerancePercentageDecimal ??

--- a/src/lib/swapper/swappers/utils/test-data/setupSwapQuote.ts
+++ b/src/lib/swapper/swappers/utils/test-data/setupSwapQuote.ts
@@ -43,7 +43,6 @@ export const setupQuote = () => {
     buyAsset,
     accountNumber: 0,
     receiveAddress: '0xc770eefad204b5180df6a14ee197d99d808ee52d',
-    isKeepKey: false,
     affiliateBps: '0',
     potentialAffiliateBps: '0',
     supportsEIP1559: false,


### PR DESCRIPTION
## Description

Removes monkey patch logic fixing broken trades on keepkey when donations were enabled. See original issue https://github.com/shapeshift/web/issues/4518

Verified this is no longer required by deploying this branch to `wood` and getting ops to test trades with fees on keepkey. Trades succeeded and fees appear to be received in our treasury address.

## Pull Request Type

- [x] :bug: Bug fix (Non-breaking Change: Fixes an issue)
- [ ] :hammer_and_wrench: Chore (Non-breaking Change: Doc updates, pkg upgrades, typos, etc..)
- [ ] :nail_care: New Feature (Breaking/Non-breaking Change)

## Issue (if applicable)

closes #5988

## Risk

This has already been tested, but still may be some risk of broken trades on keepkey where an affiliate fee is payable.

## Testing

Check trades are working (with and without affiliate fees) while connected to keepkey.

### Engineering

<!-----------------------------------------------------------------------------
Include sufficient information here for an engineer to test your PR. This may include how to test locally, in a built environment, changes to infrastructure etc.
------------------------------------------------------------------------------>

### Operations

<!-----------------------------------------------------------------------------
If your changes have a user-facing impact, describe how a non-technical QA team can functionally test your changes in a preview environment.

If they are not user-facing please describe how to test for any regressions that may occur.
------------------------------------------------------------------------------>

## Screenshots (if applicable)
