### PR TITLE
feat: sym & asym add LP quotes input and calcs

### DIFF
--- a/src/pages/ThorChainLP/components/AddLiquitity/AddLiquidityInput.tsx
+++ b/src/pages/ThorChainLP/components/AddLiquitity/AddLiquidityInput.tsx
@@ -147,6 +147,10 @@ export const AddLiquidityInput: React.FC<AddLiquidityProps> = ({
     string | undefined
   >()
   const [runeFiatLiquidityAmount, setRuneFiatLiquidityAmount] = React.useState<string | undefined>()
+  const runePerAsset = useMemo(() => {
+    if (!assetMarketData || !runeMarketData) return undefined
+    return bn(assetMarketData.price).div(bn(runeMarketData.price)).toFixed()
+  }, [assetMarketData, runeMarketData])
 
   const createHandleAddLiquidityInputChange = useCallback(
     (marketData: MarketData, isRune: boolean) => {
@@ -273,7 +277,7 @@ export const AddLiquidityInput: React.FC<AddLiquidityProps> = ({
           </Stack>
         </Stack>
         <Collapse in={true}>
-          <PoolSummary assetId={foundPool.assetId} />
+          <PoolSummary assetId={foundPool.assetId} runePerAsset={runePerAsset} />
         </Collapse>
       </Stack>
       <CardFooter

--- a/src/pages/ThorChainLP/components/AddLiquitity/AddLiquidityInput.tsx
+++ b/src/pages/ThorChainLP/components/AddLiquitity/AddLiquidityInput.tsx
@@ -170,11 +170,20 @@ export const AddLiquidityInput: React.FC<AddLiquidityProps> = ({
           return valueFiatUserCurrency
         })()
 
-        isRune ? setRuneCryptoLiquidityAmount(crypto) : setAssetCryptoLiquidityAmount(crypto)
-        isRune ? setRuneFiatLiquidityAmount(fiat) : setAssetFiatLiquidityAmount(fiat)
+        if (isRune && bnOrZero(runePerAsset).isGreaterThan(0)) {
+          setRuneCryptoLiquidityAmount(crypto)
+          setRuneFiatLiquidityAmount(fiat)
+          setAssetFiatLiquidityAmount(fiat)
+          setAssetCryptoLiquidityAmount(bn(crypto).times(bnOrZero(runePerAsset)).toFixed())
+        } else if (!isRune && bnOrZero(runePerAsset).isGreaterThan(0)) {
+          setAssetCryptoLiquidityAmount(crypto)
+          setAssetFiatLiquidityAmount(fiat)
+          setRuneFiatLiquidityAmount(fiat)
+          setRuneCryptoLiquidityAmount(bn(crypto).times(bnOrZero(runePerAsset)).toFixed())
+        }
       }
     },
-    [],
+    [runePerAsset],
   )
 
   const tradeAssetInputs = useMemo(() => {

--- a/src/pages/ThorChainLP/components/AddLiquitity/components/PoolSummary.tsx
+++ b/src/pages/ThorChainLP/components/AddLiquitity/components/PoolSummary.tsx
@@ -10,9 +10,14 @@ import { useAppSelector } from 'state/store'
 type PoolSummaryProps = {
   assetId: AssetId
   runePerAsset: string | undefined
+  shareOfPoolDecimalPercent: string | undefined
 }
 
-export const PoolSummary = ({ assetId, runePerAsset }: PoolSummaryProps) => {
+export const PoolSummary = ({
+  assetId,
+  runePerAsset,
+  shareOfPoolDecimalPercent,
+}: PoolSummaryProps) => {
   const translate = useTranslate()
   const asset = useAppSelector(state => selectAssetById(state, assetId))
 
@@ -32,7 +37,7 @@ export const PoolSummary = ({ assetId, runePerAsset }: PoolSummaryProps) => {
       <Row>
         <Row.Label>{translate('pools.shareOfPool')}</Row.Label>
         <Row.Value>
-          <Amount.Percent value='0.2' />
+          <Amount.Percent value={shareOfPoolDecimalPercent ?? '0'} />
         </Row.Value>
       </Row>
     </Stack>

--- a/src/pages/ThorChainLP/components/AddLiquitity/components/PoolSummary.tsx
+++ b/src/pages/ThorChainLP/components/AddLiquitity/components/PoolSummary.tsx
@@ -9,9 +9,10 @@ import { useAppSelector } from 'state/store'
 
 type PoolSummaryProps = {
   assetId: AssetId
+  runePerAsset: string | undefined
 }
 
-export const PoolSummary = ({ assetId }: PoolSummaryProps) => {
+export const PoolSummary = ({ assetId, runePerAsset }: PoolSummaryProps) => {
   const translate = useTranslate()
   const asset = useAppSelector(state => selectAssetById(state, assetId))
 
@@ -25,7 +26,7 @@ export const PoolSummary = ({ assetId }: PoolSummaryProps) => {
           {translate('pools.pricePerAsset', { from: 'RUNE', to: asset.symbol })}
         </Row.Label>
         <Row.Value>
-          <Amount value='5.39' />
+          <Amount value={runePerAsset} />
         </Row.Value>
       </Row>
       <Row>


### PR DESCRIPTION
## Description

- Wires up input and fiat fields for both symmetrical and asymmetrical LP quotes
- Adds the following add liquidity "quote" calculations to the UI:
  - Slippage (in RUNE)
  - Rune per asset
  - Share of the pool

## Pull Request Type

- [ ] :bug: Bug fix (Non-breaking Change: Fixes an issue)
- [ ] :hammer_and_wrench: Chore (Non-breaking Change: Doc updates, pkg upgrades, typos, etc..)
- [x] :nail_care: New Feature (Breaking/Non-breaking Change)

## Issue (if applicable)

Contributes to https://github.com/shapeshift/web/issues/6019

## Risk

Small - isolated to LP flag code paths.

## Testing

Play with the "Add Liquidity" inputs and see the data populate.

### Engineering

<!-----------------------------------------------------------------------------
Include sufficient information here for an engineer to test your PR. This may include how to test locally, in a built environment, changes to infrastructure etc.
------------------------------------------------------------------------------>

### Operations

Not yet required.

## Screenshots (if applicable)

<img width="359" alt="Screenshot 2024-01-17 at 6 03 42 pm" src="https://github.com/shapeshift/web/assets/97164662/c653dd7b-37fb-48eb-a169-13db254892da">

<img width="355" alt="Screenshot 2024-01-17 at 6 07 42 pm" src="https://github.com/shapeshift/web/assets/97164662/8728b81a-8257-44f0-ae1d-d2d25a926c1e">
