### PR TITLE
feat: standalone "Add Liquidity"

### DIFF
--- a/src/pages/ThorChainLP/components/AddLiquitity/AddLiquidityInput.tsx
+++ b/src/pages/ThorChainLP/components/AddLiquitity/AddLiquidityInput.tsx
@@ -95,8 +95,9 @@ export const AddLiquidityInput: React.FC<AddLiquidityProps> = ({
     if (!parsedPools) return undefined
     if (opportunityId) return undefined
 
-    // since we do asset/rune/sym ordering, we can assume the the third item is sym
-    return parsedPools[2].opportunityId
+    const firstAsymOpportunityId = parsedPools.find(pool => pool.asymSide === null)?.opportunityId
+
+    return firstAsymOpportunityId
   }, [opportunityId, parsedPools])
 
   const [activeOpportunityId, setActiveOpportunityId] = useState(
@@ -117,9 +118,10 @@ export const AddLiquidityInput: React.FC<AddLiquidityProps> = ({
   useEffect(() => {
     if (!(asset && parsedPools)) return
 
-    const filteredPools = parsedPools?.filter(pool => pool.assetId === asset.assetId)
-    // since we do asset/rune/sym ordering, we can assume the the third item is sym
-    const foundOpportunityId = filteredPools[2].opportunityId
+    const foundOpportunityId = (parsedPools ?? []).find(
+      pool => pool.assetId === asset.assetId && pool.asymSide === null,
+    )?.opportunityId
+    if (!foundOpportunityId) return
     setActiveOpportunityId(foundOpportunityId)
   }, [asset, parsedPools])
 

--- a/src/pages/ThorChainLP/components/AddLiquitity/AddLiquidityInput.tsx
+++ b/src/pages/ThorChainLP/components/AddLiquitity/AddLiquidityInput.tsx
@@ -104,7 +104,6 @@ export const AddLiquidityInput: React.FC<AddLiquidityProps> = ({
     opportunityId ?? defaultOpportunityId,
   )
 
-  // TODO(gomes): find the *right* pool type depending on asym type when standalone
   const foundPool = useMemo(() => {
     if (!parsedPools) return undefined
 

--- a/src/pages/ThorChainLP/components/AddLiquitity/AddLiquidityInput.tsx
+++ b/src/pages/ThorChainLP/components/AddLiquitity/AddLiquidityInput.tsx
@@ -362,11 +362,11 @@ export const AddLiquidityInput: React.FC<AddLiquidityProps> = ({
   }, [asset?.assetId, defaultOpportunityId, handleAssetChange, handlePoolAssetClick])
 
   const handleAsymSideChange = useCallback(
-    (asymSide: AsymSide | null) => {
+    (asymSide: string | null) => {
       if (!(parsedPools && asset)) return
 
       // The null option gets casted as an empty string by the radio component so we cast it back to null
-      const parsedAsymSide = asymSide || null
+      const parsedAsymSide = (asymSide as AsymSide | '') || null
       const assetPools = parsedPools.filter(pool => pool.assetId === asset.assetId)
       const foundPool = assetPools.find(pool => pool.asymSide === parsedAsymSide)
       if (!foundPool) return
@@ -394,7 +394,6 @@ export const AddLiquidityInput: React.FC<AddLiquidityProps> = ({
           </FormLabel>
           <DepositType
             assetId={asset.assetId}
-            asymSide={foundPool.asymSide}
             defaultOpportunityId={defaultOpportunityId}
             onAsymSideChange={handleAsymSideChange}
           />

--- a/src/pages/ThorChainLP/components/AddLiquitity/AddLiquidityInput.tsx
+++ b/src/pages/ThorChainLP/components/AddLiquitity/AddLiquidityInput.tsx
@@ -128,13 +128,15 @@ export const AddLiquidityInput: React.FC<AddLiquidityProps> = ({
 
   useEffect(() => {
     if (!(asset && parsedPools)) return
+    // We only want to run this effect in the standalone AddLiquidity page
+    if (!defaultOpportunityId) return
 
     const foundOpportunityId = (parsedPools ?? []).find(
       pool => pool.assetId === asset.assetId && pool.asymSide === null,
     )?.opportunityId
     if (!foundOpportunityId) return
     setActiveOpportunityId(foundOpportunityId)
-  }, [asset, parsedPools])
+  }, [asset, defaultOpportunityId, parsedPools])
 
   const handleAssetChange = useCallback((asset: Asset) => {
     console.info(asset)

--- a/src/pages/ThorChainLP/components/AddLiquitity/AddLiquidityInput.tsx
+++ b/src/pages/ThorChainLP/components/AddLiquitity/AddLiquidityInput.tsx
@@ -328,12 +328,11 @@ export const AddLiquidityInput: React.FC<AddLiquidityProps> = ({
     )
   }, [asset, foundPool, rune, translate])
 
-  // TODO(gomes): obviously wrong
-  const buyAssetSearch = useModal('buyAssetSearch')
+  const buyAssetSearch = useModal('sellAssetSearch')
   const handlePoolAssetClick = useCallback(() => {
     buyAssetSearch.open({
       onClick: setAsset,
-      title: 'lending.borrow',
+      title: 'pools.pool',
       assets: poolAssets,
     })
   }, [buyAssetSearch, poolAssets])

--- a/src/pages/ThorChainLP/components/AddLiquitity/AddLiquidityInput.tsx
+++ b/src/pages/ThorChainLP/components/AddLiquitity/AddLiquidityInput.tsx
@@ -354,6 +354,9 @@ export const AddLiquidityInput: React.FC<AddLiquidityProps> = ({
     if (!defaultOpportunityId) return null
     return (
       <>
+        <FormLabel px={6} mb={0} fontSize='sm'>
+          {translate('pools.selectPair')}
+        </FormLabel>
         <TradeAssetSelect
           assetId={asset?.assetId}
           onAssetClick={handlePoolAssetClick}
@@ -371,7 +374,7 @@ export const AddLiquidityInput: React.FC<AddLiquidityProps> = ({
         />
       </>
     )
-  }, [asset?.assetId, defaultOpportunityId, handleAssetChange, handlePoolAssetClick])
+  }, [asset?.assetId, defaultOpportunityId, handleAssetChange, handlePoolAssetClick, translate])
 
   const handleAsymSideChange = useCallback(
     (asymSide: string | null) => {
@@ -394,12 +397,7 @@ export const AddLiquidityInput: React.FC<AddLiquidityProps> = ({
     <SlideTransition>
       {renderHeader}
       <Stack divider={divider} spacing={4} pb={4}>
-        <Stack>
-          <FormLabel px={6} mb={0} fontSize='sm'>
-            {translate('pools.selectPair')}
-          </FormLabel>
-          {pairSelect}
-        </Stack>
+        <Stack>{pairSelect}</Stack>
         <Stack>
           <FormLabel mb={0} px={6} fontSize='sm'>
             {translate('pools.depositAmounts')}

--- a/src/pages/ThorChainLP/components/AddLiquitity/AddLiquidityInput.tsx
+++ b/src/pages/ThorChainLP/components/AddLiquitity/AddLiquidityInput.tsx
@@ -359,9 +359,20 @@ export const AddLiquidityInput: React.FC<AddLiquidityProps> = ({
     )
   }, [asset?.assetId, handleAssetChange, handlePoolAssetClick])
 
-  const handleAsymSideChange = useCallback((asymSide: AsymSide | null) => {
-    console.log('TODO', { asymSide })
-  }, [])
+  const handleAsymSideChange = useCallback(
+    (asymSide: AsymSide | null) => {
+      if (!(parsedPools && asset)) return
+
+      // The null option gets casted as an empty string by the radio component so we cast it back to null
+      const parsedAsymSide = asymSide || null
+      const assetPools = parsedPools.filter(pool => pool.assetId === asset.assetId)
+      const foundPool = assetPools.find(pool => pool.asymSide === parsedAsymSide)
+      if (!foundPool) return
+
+      setActiveOpportunityId(foundPool.opportunityId)
+    },
+    [asset, parsedPools],
+  )
 
   if (!foundPool || !asset || !rune) return null
 

--- a/src/pages/ThorChainLP/components/AddLiquitity/AddLiquidityInput.tsx
+++ b/src/pages/ThorChainLP/components/AddLiquitity/AddLiquidityInput.tsx
@@ -338,6 +338,8 @@ export const AddLiquidityInput: React.FC<AddLiquidityProps> = ({
   }, [buyAssetSearch, poolAssets])
 
   const pairSelect = useMemo(() => {
+    // We only want to show the pair select on standalone "Add Liquidity" - not on the pool page
+    if (!defaultOpportunityId) return null
     return (
       <>
         <TradeAssetSelect
@@ -357,7 +359,7 @@ export const AddLiquidityInput: React.FC<AddLiquidityProps> = ({
         />
       </>
     )
-  }, [asset?.assetId, handleAssetChange, handlePoolAssetClick])
+  }, [asset?.assetId, defaultOpportunityId, handleAssetChange, handlePoolAssetClick])
 
   const handleAsymSideChange = useCallback(
     (asymSide: AsymSide | null) => {

--- a/src/pages/ThorChainLP/components/AddLiquitity/AddLiquidityInput.tsx
+++ b/src/pages/ThorChainLP/components/AddLiquitity/AddLiquidityInput.tsx
@@ -342,7 +342,7 @@ export const AddLiquidityInput: React.FC<AddLiquidityProps> = ({
     )
   }, [asset, foundPool, rune, translate])
 
-  const buyAssetSearch = useModal('sellAssetSearch')
+  const buyAssetSearch = useModal('buyAssetSearch')
   const handlePoolAssetClick = useCallback(() => {
     buyAssetSearch.open({
       onClick: setAsset,

--- a/src/pages/ThorChainLP/components/AddLiquitity/AddLiquidityInput.tsx
+++ b/src/pages/ThorChainLP/components/AddLiquitity/AddLiquidityInput.tsx
@@ -104,6 +104,12 @@ export const AddLiquidityInput: React.FC<AddLiquidityProps> = ({
     opportunityId ?? defaultOpportunityId,
   )
 
+  useEffect(() => {
+    if (!(opportunityId || defaultOpportunityId)) return
+
+    setActiveOpportunityId(opportunityId ?? defaultOpportunityId)
+  }, [defaultOpportunityId, opportunityId])
+
   const foundPool = useMemo(() => {
     if (!parsedPools) return undefined
 
@@ -111,7 +117,13 @@ export const AddLiquidityInput: React.FC<AddLiquidityProps> = ({
   }, [activeOpportunityId, parsedPools])
 
   const _asset = useAppSelector(state => selectAssetById(state, foundPool?.assetId ?? ''))
+  useEffect(() => {
+    if (!_asset) return
+    setAsset(_asset)
+  }, [_asset])
+
   const rune = useAppSelector(state => selectAssetById(state, thorchainAssetId))
+
   const [asset, setAsset] = useState<Asset | undefined>(_asset)
 
   useEffect(() => {

--- a/src/pages/ThorChainLP/components/AddLiquitity/AddLiquidityInput.tsx
+++ b/src/pages/ThorChainLP/components/AddLiquitity/AddLiquidityInput.tsx
@@ -393,6 +393,7 @@ export const AddLiquidityInput: React.FC<AddLiquidityProps> = ({
           <DepositType
             assetId={asset.assetId}
             asymSide={foundPool.asymSide}
+            defaultOpportunityId={defaultOpportunityId}
             onAsymSideChange={handleAsymSideChange}
           />
           <Stack divider={pairDivider} spacing={0}>

--- a/src/pages/ThorChainLP/components/AddLiquitity/components/DepositType.tsx
+++ b/src/pages/ThorChainLP/components/AddLiquitity/components/DepositType.tsx
@@ -79,8 +79,9 @@ type DepositTypeProps = {
   // If null, user can only deposit symmetrical
   // If AsymSide, user can only deposit asymmetrical on said Asymside
   asymSide?: AsymSide | null
+  onAsymSideChange: (asymSide: AsymSide | null) => void
 }
-export const DepositType = ({ assetId, asymSide }: DepositTypeProps) => {
+export const DepositType = ({ assetId, asymSide, onAsymSideChange }: DepositTypeProps) => {
   const assetIds = useMemo(() => {
     return [assetId, thorchainAssetId]
   }, [assetId])
@@ -99,7 +100,7 @@ export const DepositType = ({ assetId, asymSide }: DepositTypeProps) => {
   const { getRootProps, getRadioProps } = useRadioGroup({
     name: 'depositType',
     defaultValue: 'one',
-    onChange: console.log,
+    onChange: onAsymSideChange,
   })
 
   const radioOptions = useMemo(() => {

--- a/src/pages/ThorChainLP/components/AddLiquitity/components/DepositType.tsx
+++ b/src/pages/ThorChainLP/components/AddLiquitity/components/DepositType.tsx
@@ -110,8 +110,7 @@ export const DepositType = ({
   })
 
   const radioOptions = useMemo(() => {
-    const _options = asymSide && !defaultOpportunityId ? [{ value: asymSide }] : options
-    if (_options.length === 1) return null
+    const _options = defaultOpportunityId ? options : []
 
     return _options.map((option, index) => {
       const radio = getRadioProps({ value: option.value })
@@ -131,7 +130,7 @@ export const DepositType = ({
         </TypeRadio>
       )
     })
-  }, [asymSide, defaultOpportunityId, getRadioProps, makeAssetIdsOption])
+  }, [defaultOpportunityId, getRadioProps, makeAssetIdsOption])
 
   const group = getRootProps()
   return (

--- a/src/pages/ThorChainLP/components/AddLiquitity/components/DepositType.tsx
+++ b/src/pages/ThorChainLP/components/AddLiquitity/components/DepositType.tsx
@@ -80,8 +80,14 @@ type DepositTypeProps = {
   // If AsymSide, user can only deposit asymmetrical on said Asymside
   asymSide?: AsymSide | null
   onAsymSideChange: (asymSide: AsymSide | null) => void
+  defaultOpportunityId?: string
 }
-export const DepositType = ({ assetId, asymSide, onAsymSideChange }: DepositTypeProps) => {
+export const DepositType = ({
+  assetId,
+  defaultOpportunityId,
+  asymSide,
+  onAsymSideChange,
+}: DepositTypeProps) => {
   const assetIds = useMemo(() => {
     return [assetId, thorchainAssetId]
   }, [assetId])
@@ -104,7 +110,7 @@ export const DepositType = ({ assetId, asymSide, onAsymSideChange }: DepositType
   })
 
   const radioOptions = useMemo(() => {
-    const _options = asymSide ? [{ value: asymSide }] : options
+    const _options = asymSide && !defaultOpportunityId ? [{ value: asymSide }] : options
     if (_options.length === 1) return null
 
     return _options.map((option, index) => {
@@ -125,7 +131,7 @@ export const DepositType = ({ assetId, asymSide, onAsymSideChange }: DepositType
         </TypeRadio>
       )
     })
-  }, [asymSide, getRadioProps, makeAssetIdsOption])
+  }, [asymSide, defaultOpportunityId, getRadioProps, makeAssetIdsOption])
 
   const group = getRootProps()
   return (

--- a/src/pages/ThorChainLP/components/AddLiquitity/components/DepositType.tsx
+++ b/src/pages/ThorChainLP/components/AddLiquitity/components/DepositType.tsx
@@ -75,17 +75,12 @@ const options = [
 
 type DepositTypeProps = {
   assetId: AssetId
-  // If undefined/not passed, we're not locking the user in any kind of symmetrical/asymmetrical deposit type, i.e they can choose any of the three
-  // If null, user can only deposit symmetrical
-  // If AsymSide, user can only deposit asymmetrical on said Asymside
-  asymSide?: AsymSide | null
-  onAsymSideChange: (asymSide: AsymSide | null) => void
+  onAsymSideChange: (asymSide: string | null) => void
   defaultOpportunityId?: string
 }
 export const DepositType = ({
   assetId,
   defaultOpportunityId,
-  asymSide,
   onAsymSideChange,
 }: DepositTypeProps) => {
   const assetIds = useMemo(() => {


### PR DESCRIPTION
## Description

Wires-up "Add Liquidity" as a standalone page.

## Pull Request Type

- [ ] :bug: Bug fix (Non-breaking Change: Fixes an issue)
- [ ] :hammer_and_wrench: Chore (Non-breaking Change: Doc updates, pkg upgrades, typos, etc..)
- [x] :nail_care: New Feature (Breaking/Non-breaking Change)

## Issue (if applicable)

<!-----------------------------------------------------------------------------
If applicable, please link to the github issue and put `closes #XXXX` in your comment to auto-close the issue that your PR fixes.
------------------------------------------------------------------------------>

- closes https://github.com/shapeshift/web/issues/6018

## Risk

<!-----------------------------------------------------------------------------
Outline the scope of your changes and the risk associated with them. You must use your discretion as an engineer to determine the potential impact of your changes.

E.g. an upgrade to `hdwallet` or core state management would be considered higher risk, and might require a full regression test. UI or isolated view changes, or something behind a feature flag may have near zero risk. Small bug fixes might require testing isolated to the specific fix.
------------------------------------------------------------------------------>

Low - ensure everything behaves as expected. This is under feature-flag, however something something caution consider PR as if it was to land in prod

## Testing

<!-----------------------------------------------------------------------------
We treat every PR to be merged with the same scrutiny as if we were merging directly to production.

Your PR will not be merged if you do not complete the sections below for our engineering and operations teams to test.
------------------------------------------------------------------------------>

- The "Add Liquidity" component looks sane both on click, and on page refresh
- It is possible to select any supported pool asset
- The component behaves the same as in the pool view except for two differences:
  - The pair selection is only possible when in standalone mode
  - The "Deposit Amounts" radio options are only displayed when in standalone mode
  
The reason for these two discrepancies is in a pool page view, you're already in the context of an asset + a/sym and can't change it


### Engineering

<!-----------------------------------------------------------------------------
Include sufficient information here for an engineer to test your PR. This may include how to test locally, in a built environment, changes to infrastructure etc.
------------------------------------------------------------------------------>

- ☝🏽 

### Operations

<!-----------------------------------------------------------------------------
If your changes have a user-facing impact, describe how a non-technical QA team can functionally test your changes in a preview environment.

If they are not user-facing please describe how to test for any regressions that may occur.
------------------------------------------------------------------------------>

- ☝🏽 

## Screenshots (if applicable)

<img width="507" alt="image" src="https://github.com/shapeshift/web/assets/17035424/abb2a5b1-059d-4e5b-b25d-79f199de1982">
<img width="469" alt="image" src="https://github.com/shapeshift/web/assets/17035424/f14cff6d-81b7-4e76-979e-e8b4b34ff9d8">
<img width="429" alt="image" src="https://github.com/shapeshift/web/assets/17035424/7939eae2-b357-4af6-a550-8ae03ab97fed">

