### PR TITLE
feat: wire-up confirmed "Add Liquidity" quote

### DIFF
--- a/src/lib/utils/thorchain/lp/types.ts
+++ b/src/lib/utils/thorchain/lp/types.ts
@@ -192,4 +192,5 @@ export type ConfirmedQuote = {
   runeFiatLiquidityAmount: string
   shareOfPoolDecimalPercent: string
   slippageRune: string
+  opportunityId: string
 }

--- a/src/lib/utils/thorchain/lp/types.ts
+++ b/src/lib/utils/thorchain/lp/types.ts
@@ -184,3 +184,12 @@ export type MidgardTvlHistoryResponse = {
   meta: MidgardTvlHistoryItem
   intervals: MidgardTvlHistoryItem[]
 }
+
+export type ConfirmedQuote = {
+  assetCryptoLiquidityAmount: string
+  assetFiatLiquidityAmount: string
+  runeCryptoLiquidityAmount: string
+  runeFiatLiquidityAmount: string
+  shareOfPoolDecimalPercent: string
+  slippageRune: string
+}

--- a/src/pages/ThorChainLP/components/AddLiquitity/AddLiquidity.tsx
+++ b/src/pages/ThorChainLP/components/AddLiquitity/AddLiquidity.tsx
@@ -22,7 +22,7 @@ export type AddLiquidityProps = {
 }
 
 export const AddLiquidity: React.FC<AddLiquidityProps> = ({ opportunityId, headerComponent }) => {
-  const [confirmedQuote, setConfirmedQuote] = useState<any>(null)
+  const [confirmedQuote, setConfirmedQuote] = useState<ConfirmedQuote | null>(null)
 
   return (
     <MemoryRouter initialEntries={AddLiquidityEntries} initialIndex={0}>
@@ -37,7 +37,7 @@ export const AddLiquidity: React.FC<AddLiquidityProps> = ({ opportunityId, heade
 }
 
 type AddLiquidityRoutesProps = AddLiquidityProps & {
-  confirmedQuote: ConfirmedQuote
+  confirmedQuote: ConfirmedQuote | null
   setConfirmedQuote: (quote: ConfirmedQuote) => void
 }
 
@@ -55,9 +55,10 @@ export const AddLiquidityRoutes: React.FC<AddLiquidityRoutesProps> = ({
         opportunityId={opportunityId}
         headerComponent={headerComponent}
         setConfirmedQuote={setConfirmedQuote}
+        confirmedQuote={confirmedQuote}
       />
     ),
-    [headerComponent, opportunityId, setConfirmedQuote],
+    [confirmedQuote, headerComponent, opportunityId, setConfirmedQuote],
   )
   const renderAddLiquidityConfirm = useCallback(
     () => <AddLiquidityConfirm opportunityId={opportunityId} confirmedQuote={confirmedQuote} />,

--- a/src/pages/ThorChainLP/components/AddLiquitity/AddLiquidity.tsx
+++ b/src/pages/ThorChainLP/components/AddLiquitity/AddLiquidity.tsx
@@ -19,15 +19,9 @@ const AddLiquidityEntries = [
 export type AddLiquidityProps = {
   headerComponent?: JSX.Element
   opportunityId?: string
-  setConfirmedQuote: (quote: ConfirmedQuote) => void
-  confirmedQuote: ConfirmedQuote
 }
 
-// TODO(gomes): yeah no this is wrong - split the router prop types from the exposed API prop types
-export const AddLiquidity: React.FC<Omit<AddLiquidityProps, 'setConfirmedQuote'>> = ({
-  opportunityId,
-  headerComponent,
-}) => {
+export const AddLiquidity: React.FC<AddLiquidityProps> = ({ opportunityId, headerComponent }) => {
   const [confirmedQuote, setConfirmedQuote] = useState<any>(null)
 
   return (
@@ -42,7 +36,12 @@ export const AddLiquidity: React.FC<Omit<AddLiquidityProps, 'setConfirmedQuote'>
   )
 }
 
-export const AddLiquidityRoutes: React.FC<AddLiquidityProps> = ({
+type AddLiquidityRoutesProps = AddLiquidityProps & {
+  confirmedQuote: ConfirmedQuote
+  setConfirmedQuote: (quote: ConfirmedQuote) => void
+}
+
+export const AddLiquidityRoutes: React.FC<AddLiquidityRoutesProps> = ({
   headerComponent,
   opportunityId,
   confirmedQuote,

--- a/src/pages/ThorChainLP/components/AddLiquitity/AddLiquidity.tsx
+++ b/src/pages/ThorChainLP/components/AddLiquitity/AddLiquidity.tsx
@@ -1,6 +1,7 @@
 import { AnimatePresence } from 'framer-motion'
-import React, { Suspense, useCallback } from 'react'
+import React, { Suspense, useCallback, useState } from 'react'
 import { MemoryRouter, Route, Switch, useLocation } from 'react-router'
+import type { ConfirmedQuote } from 'lib/utils/thorchain/lp/types'
 
 import { AddLiquidityConfirm } from './AddLiquidityConfirm'
 import { AddLiquidityInput } from './AddLiquidityInput'
@@ -18,12 +19,25 @@ const AddLiquidityEntries = [
 export type AddLiquidityProps = {
   headerComponent?: JSX.Element
   opportunityId?: string
+  setConfirmedQuote: (quote: ConfirmedQuote) => void
+  confirmedQuote: ConfirmedQuote
 }
 
-export const AddLiquidity: React.FC<AddLiquidityProps> = ({ opportunityId, headerComponent }) => {
+// TODO(gomes): yeah no this is wrong - split the router prop types from the exposed API prop types
+export const AddLiquidity: React.FC<Omit<AddLiquidityProps, 'setConfirmedQuote'>> = ({
+  opportunityId,
+  headerComponent,
+}) => {
+  const [confirmedQuote, setConfirmedQuote] = useState<any>(null)
+
   return (
     <MemoryRouter initialEntries={AddLiquidityEntries} initialIndex={0}>
-      <AddLiquidityRoutes opportunityId={opportunityId} headerComponent={headerComponent} />
+      <AddLiquidityRoutes
+        opportunityId={opportunityId}
+        headerComponent={headerComponent}
+        setConfirmedQuote={setConfirmedQuote}
+        confirmedQuote={confirmedQuote}
+      />
     </MemoryRouter>
   )
 }
@@ -31,21 +45,29 @@ export const AddLiquidity: React.FC<AddLiquidityProps> = ({ opportunityId, heade
 export const AddLiquidityRoutes: React.FC<AddLiquidityProps> = ({
   headerComponent,
   opportunityId,
+  confirmedQuote,
+  setConfirmedQuote,
 }) => {
   const location = useLocation()
 
   const renderAddLiquidityInput = useCallback(
-    () => <AddLiquidityInput opportunityId={opportunityId} headerComponent={headerComponent} />,
-    [headerComponent, opportunityId],
+    () => (
+      <AddLiquidityInput
+        opportunityId={opportunityId}
+        headerComponent={headerComponent}
+        setConfirmedQuote={setConfirmedQuote}
+      />
+    ),
+    [headerComponent, opportunityId, setConfirmedQuote],
   )
   const renderAddLiquidityConfirm = useCallback(
-    () => <AddLiquidityConfirm opportunityId={opportunityId} />,
-    [opportunityId],
+    () => <AddLiquidityConfirm opportunityId={opportunityId} confirmedQuote={confirmedQuote} />,
+    [confirmedQuote, opportunityId],
   )
 
   const renderAddLiquidityStatus = useCallback(
-    () => <AddLiquidityStatus opportunityId={opportunityId} />,
-    [opportunityId],
+    () => <AddLiquidityStatus opportunityId={opportunityId} confirmedQuote={confirmedQuote} />,
+    [confirmedQuote, opportunityId],
   )
 
   return (

--- a/src/pages/ThorChainLP/components/AddLiquitity/AddLiquidity.tsx
+++ b/src/pages/ThorChainLP/components/AddLiquitity/AddLiquidity.tsx
@@ -61,12 +61,18 @@ export const AddLiquidityRoutes: React.FC<AddLiquidityRoutesProps> = ({
     [confirmedQuote, headerComponent, opportunityId, setConfirmedQuote],
   )
   const renderAddLiquidityConfirm = useCallback(
-    () => <AddLiquidityConfirm opportunityId={opportunityId} confirmedQuote={confirmedQuote} />,
+    () =>
+      confirmedQuote ? (
+        <AddLiquidityConfirm opportunityId={opportunityId} confirmedQuote={confirmedQuote} />
+      ) : null,
     [confirmedQuote, opportunityId],
   )
 
   const renderAddLiquidityStatus = useCallback(
-    () => <AddLiquidityStatus opportunityId={opportunityId} confirmedQuote={confirmedQuote} />,
+    () =>
+      confirmedQuote ? (
+        <AddLiquidityStatus opportunityId={opportunityId} confirmedQuote={confirmedQuote} />
+      ) : null,
     [confirmedQuote, opportunityId],
   )
 

--- a/src/pages/ThorChainLP/components/AddLiquitity/AddLiquidity.tsx
+++ b/src/pages/ThorChainLP/components/AddLiquitity/AddLiquidity.tsx
@@ -61,19 +61,13 @@ export const AddLiquidityRoutes: React.FC<AddLiquidityRoutesProps> = ({
     [confirmedQuote, headerComponent, opportunityId, setConfirmedQuote],
   )
   const renderAddLiquidityConfirm = useCallback(
-    () =>
-      confirmedQuote ? (
-        <AddLiquidityConfirm opportunityId={opportunityId} confirmedQuote={confirmedQuote} />
-      ) : null,
-    [confirmedQuote, opportunityId],
+    () => (confirmedQuote ? <AddLiquidityConfirm confirmedQuote={confirmedQuote} /> : null),
+    [confirmedQuote],
   )
 
   const renderAddLiquidityStatus = useCallback(
-    () =>
-      confirmedQuote ? (
-        <AddLiquidityStatus opportunityId={opportunityId} confirmedQuote={confirmedQuote} />
-      ) : null,
-    [confirmedQuote, opportunityId],
+    () => (confirmedQuote ? <AddLiquidityStatus confirmedQuote={confirmedQuote} /> : null),
+    [confirmedQuote],
   )
 
   return (

--- a/src/pages/ThorChainLP/components/AddLiquitity/AddLiquidityConfirm.tsx
+++ b/src/pages/ThorChainLP/components/AddLiquitity/AddLiquidityConfirm.tsx
@@ -25,6 +25,7 @@ import { SlideTransition } from 'components/SlideTransition'
 import { RawText } from 'components/Text'
 import { Timeline, TimelineItem } from 'components/Timeline/Timeline'
 import { getChainAdapterManager } from 'context/PluginProvider/chainAdapterSingleton'
+import type { ConfirmedQuote } from 'lib/utils/thorchain/lp/types'
 import { usePools } from 'pages/ThorChainLP/hooks/usePools'
 import { AsymSide } from 'pages/ThorChainLP/hooks/useUserLpData'
 import { selectAssetById } from 'state/slices/assetsSlice/selectors'
@@ -46,7 +47,7 @@ const dividerStyle = {
 
 type AddLiquidityConfirmProps = {
   opportunityId?: string
-  confirmedQuote: any
+  confirmedQuote: ConfirmedQuote | null
 }
 
 export const AddLiquidityConfirm = ({

--- a/src/pages/ThorChainLP/components/AddLiquitity/AddLiquidityConfirm.tsx
+++ b/src/pages/ThorChainLP/components/AddLiquitity/AddLiquidityConfirm.tsx
@@ -54,7 +54,6 @@ export const AddLiquidityConfirm = ({
   confirmedQuote,
   opportunityId,
 }: AddLiquidityConfirmProps) => {
-  console.log({ confirmedQuote })
   const translate = useTranslate()
   const history = useHistory()
   const backIcon = useMemo(() => <ArrowBackIcon />, [])

--- a/src/pages/ThorChainLP/components/AddLiquitity/AddLiquidityConfirm.tsx
+++ b/src/pages/ThorChainLP/components/AddLiquitity/AddLiquidityConfirm.tsx
@@ -47,7 +47,7 @@ const dividerStyle = {
 
 type AddLiquidityConfirmProps = {
   opportunityId?: string
-  confirmedQuote: ConfirmedQuote | null
+  confirmedQuote: ConfirmedQuote
 }
 
 export const AddLiquidityConfirm = ({

--- a/src/pages/ThorChainLP/components/AddLiquitity/AddLiquidityConfirm.tsx
+++ b/src/pages/ThorChainLP/components/AddLiquitity/AddLiquidityConfirm.tsx
@@ -46,9 +46,14 @@ const dividerStyle = {
 
 type AddLiquidityConfirmProps = {
   opportunityId?: string
+  confirmedQuote: any
 }
 
-export const AddLiquidityConfirm = ({ opportunityId }: AddLiquidityConfirmProps) => {
+export const AddLiquidityConfirm = ({
+  confirmedQuote,
+  opportunityId,
+}: AddLiquidityConfirmProps) => {
+  console.log({ confirmedQuote })
   const translate = useTranslate()
   const history = useHistory()
   const backIcon = useMemo(() => <ArrowBackIcon />, [])
@@ -120,27 +125,51 @@ export const AddLiquidityConfirm = ({ opportunityId }: AddLiquidityConfirmProps)
 
     return (
       <Stack direction='row' divider={divider} position='relative'>
-        {assets.map(_asset => (
-          <Card
-            display='flex'
-            alignItems='center'
-            justifyContent='center'
-            flexDir='column'
-            gap={4}
-            py={6}
-            px={4}
-            flex={1}
-          >
-            <AssetIcon size='sm' assetId={_asset.assetId} />
-            <Stack textAlign='center' spacing={0}>
-              <Amount.Crypto fontWeight='bold' value='100' symbol={_asset.symbol} />
-              <Amount.Fiat fontSize='sm' color='text.subtle' value='100' />
-            </Stack>
-          </Card>
-        ))}
+        {assets.map(_asset => {
+          const amountCryptoPrecision =
+            _asset.assetId === thorchainAssetId
+              ? confirmedQuote.runeCryptoLiquidityAmount
+              : confirmedQuote.assetCryptoLiquidityAmount
+          const amountFiatUserCurrency =
+            _asset.assetId === thorchainAssetId
+              ? confirmedQuote.runeFiatLiquidityAmount
+              : confirmedQuote.assetFiatLiquidityAmount
+
+          return (
+            <Card
+              display='flex'
+              alignItems='center'
+              justifyContent='center'
+              flexDir='column'
+              gap={4}
+              py={6}
+              px={4}
+              flex={1}
+            >
+              <AssetIcon size='sm' assetId={_asset.assetId} />
+              <Stack textAlign='center' spacing={0}>
+                <Amount.Crypto
+                  fontWeight='bold'
+                  value={amountCryptoPrecision}
+                  symbol={_asset.symbol}
+                />
+                <Amount.Fiat fontSize='sm' color='text.subtle' value={amountFiatUserCurrency} />
+              </Stack>
+            </Card>
+          )
+        })}
       </Stack>
     )
-  }, [asset, divider, foundPool, rune])
+  }, [
+    asset,
+    confirmedQuote.assetCryptoLiquidityAmount,
+    confirmedQuote.assetFiatLiquidityAmount,
+    confirmedQuote.runeCryptoLiquidityAmount,
+    confirmedQuote.runeFiatLiquidityAmount,
+    divider,
+    foundPool,
+    rune,
+  ])
 
   if (!(foundPool && asset && rune)) return null
 
@@ -193,7 +222,7 @@ export const AddLiquidityConfirm = ({ opportunityId }: AddLiquidityConfirmProps)
               <Row fontSize='sm'>
                 <Row.Label>{translate('pools.shareOfPool')}</Row.Label>
                 <Row.Value>
-                  <Amount.Percent value='0.2' />
+                  <Amount.Percent value={confirmedQuote.shareOfPoolDecimalPercent} />
                 </Row.Value>
               </Row>
             </TimelineItem>
@@ -224,7 +253,10 @@ export const AddLiquidityConfirm = ({ opportunityId }: AddLiquidityConfirmProps)
           <Row.Label>{translate('common.slippage')}</Row.Label>
           <Row.Value>
             <Skeleton isLoaded={true}>
-              <Amount.Crypto value={'0'} symbol={asset.symbol} />
+              <Amount.Crypto
+                value={confirmedQuote.slippageRune ?? 'TODO - loading'}
+                symbol={rune.symbol}
+              />
             </Skeleton>
           </Row.Value>
         </Row>

--- a/src/pages/ThorChainLP/components/AddLiquitity/AddLiquidityConfirm.tsx
+++ b/src/pages/ThorChainLP/components/AddLiquitity/AddLiquidityConfirm.tsx
@@ -46,17 +46,15 @@ const dividerStyle = {
 }
 
 type AddLiquidityConfirmProps = {
-  opportunityId?: string
   confirmedQuote: ConfirmedQuote
 }
 
-export const AddLiquidityConfirm = ({
-  confirmedQuote,
-  opportunityId,
-}: AddLiquidityConfirmProps) => {
+export const AddLiquidityConfirm = ({ confirmedQuote }: AddLiquidityConfirmProps) => {
   const translate = useTranslate()
   const history = useHistory()
   const backIcon = useMemo(() => <ArrowBackIcon />, [])
+
+  const { opportunityId } = confirmedQuote
 
   const { data: parsedPools } = usePools()
 

--- a/src/pages/ThorChainLP/components/AddLiquitity/AddLiquidityInput.tsx
+++ b/src/pages/ThorChainLP/components/AddLiquitity/AddLiquidityInput.tsx
@@ -67,11 +67,13 @@ export type AddLiquidityInputProps = {
   headerComponent?: JSX.Element
   opportunityId?: string
   setConfirmedQuote: (quote: ConfirmedQuote) => void
+  confirmedQuote: ConfirmedQuote | null
 }
 
 export const AddLiquidityInput: React.FC<AddLiquidityInputProps> = ({
   headerComponent,
   opportunityId,
+  confirmedQuote,
   setConfirmedQuote,
 }) => {
   const translate = useTranslate()
@@ -194,12 +196,13 @@ export const AddLiquidityInput: React.FC<AddLiquidityInputProps> = ({
           variant='ghost'
           icon={backIcon}
           aria-label='go back'
+          disabled={!confirmedQuote}
         />
         {translate('pools.addLiquidity')}
         <SlippagePopover />
       </CardHeader>
     )
-  }, [backIcon, handleBackClick, headerComponent, translate])
+  }, [backIcon, confirmedQuote, handleBackClick, headerComponent, translate])
 
   const assetMarketData = useAppSelector(state => selectMarketDataById(state, asset?.assetId ?? ''))
   const runeMarketData = useAppSelector(state => selectMarketDataById(state, rune?.assetId ?? ''))

--- a/src/pages/ThorChainLP/components/AddLiquitity/AddLiquidityInput.tsx
+++ b/src/pages/ThorChainLP/components/AddLiquitity/AddLiquidityInput.tsx
@@ -37,12 +37,12 @@ import { bn, bnOrZero, convertPrecision } from 'lib/bignumber/bignumber'
 import { isSome } from 'lib/utils'
 import { THOR_PRECISION } from 'lib/utils/thorchain/constants'
 import { estimateAddThorchainLiquidityPosition } from 'lib/utils/thorchain/lp'
+import type { ConfirmedQuote } from 'lib/utils/thorchain/lp/types'
 import { usePools } from 'pages/ThorChainLP/hooks/usePools'
 import { AsymSide } from 'pages/ThorChainLP/hooks/useUserLpData'
 import { selectAssetById, selectAssets, selectMarketDataById } from 'state/slices/selectors'
 import { useAppSelector } from 'state/store'
 
-import type { AddLiquidityProps } from './AddLiquidity'
 import { DepositType } from './components/DepositType'
 import { PoolSummary } from './components/PoolSummary'
 import { ReadOnlyAsset } from './components/ReadOnlyAsset'
@@ -63,7 +63,13 @@ const dividerStyle = {
   marginTop: 12,
 }
 
-export const AddLiquidityInput: React.FC<AddLiquidityProps> = ({
+export type AddLiquidityInputProps = {
+  headerComponent?: JSX.Element
+  opportunityId?: string
+  setConfirmedQuote: (quote: ConfirmedQuote) => void
+}
+
+export const AddLiquidityInput: React.FC<AddLiquidityInputProps> = ({
   headerComponent,
   opportunityId,
   setConfirmedQuote,

--- a/src/pages/ThorChainLP/components/AddLiquitity/AddLiquidityInput.tsx
+++ b/src/pages/ThorChainLP/components/AddLiquitity/AddLiquidityInput.tsx
@@ -66,6 +66,7 @@ const dividerStyle = {
 export const AddLiquidityInput: React.FC<AddLiquidityProps> = ({
   headerComponent,
   opportunityId,
+  setConfirmedQuote,
 }) => {
   const translate = useTranslate()
   const { history: browserHistory } = useBrowserRouter()
@@ -197,20 +198,12 @@ export const AddLiquidityInput: React.FC<AddLiquidityProps> = ({
   const assetMarketData = useAppSelector(state => selectMarketDataById(state, asset?.assetId ?? ''))
   const runeMarketData = useAppSelector(state => selectMarketDataById(state, rune?.assetId ?? ''))
 
-  const [assetCryptoLiquidityAmount, setAssetCryptoLiquidityAmount] = React.useState<
-    string | undefined
-  >()
-  const [assetFiatLiquidityAmount, setAssetFiatLiquidityAmount] = React.useState<
-    string | undefined
-  >()
-  const [runeCryptoLiquidityAmount, setRuneCryptoLiquidityAmount] = React.useState<
-    string | undefined
-  >()
-  const [runeFiatLiquidityAmount, setRuneFiatLiquidityAmount] = React.useState<string | undefined>()
-  const [slippageRune, setSlippageRune] = React.useState<string | undefined>()
-  const [shareOfPoolDecimalPercent, setShareOfPoolDecimalPercent] = React.useState<
-    string | undefined
-  >()
+  const [assetCryptoLiquidityAmount, setAssetCryptoLiquidityAmount] = useState<string | undefined>()
+  const [assetFiatLiquidityAmount, setAssetFiatLiquidityAmount] = useState<string | undefined>()
+  const [runeCryptoLiquidityAmount, setRuneCryptoLiquidityAmount] = useState<string | undefined>()
+  const [runeFiatLiquidityAmount, setRuneFiatLiquidityAmount] = useState<string | undefined>()
+  const [slippageRune, setSlippageRune] = useState<string | undefined>()
+  const [shareOfPoolDecimalPercent, setShareOfPoolDecimalPercent] = useState<string | undefined>()
 
   const runePerAsset = useMemo(() => {
     if (!assetMarketData || !runeMarketData) return undefined
@@ -276,6 +269,37 @@ export const AddLiquidityInput: React.FC<AddLiquidityProps> = ({
       setShareOfPoolDecimalPercent(estimate.poolShareDecimalPercent)
     })()
   }, [asset, assetCryptoLiquidityAmount, runeCryptoLiquidityAmount])
+
+  useEffect(() => {
+    if (
+      !(
+        assetCryptoLiquidityAmount &&
+        assetFiatLiquidityAmount &&
+        runeCryptoLiquidityAmount &&
+        runeFiatLiquidityAmount &&
+        shareOfPoolDecimalPercent &&
+        slippageRune
+      )
+    )
+      return
+
+    setConfirmedQuote({
+      assetCryptoLiquidityAmount,
+      assetFiatLiquidityAmount,
+      runeCryptoLiquidityAmount,
+      runeFiatLiquidityAmount,
+      shareOfPoolDecimalPercent,
+      slippageRune,
+    })
+  }, [
+    assetCryptoLiquidityAmount,
+    assetFiatLiquidityAmount,
+    runeCryptoLiquidityAmount,
+    runeFiatLiquidityAmount,
+    setConfirmedQuote,
+    shareOfPoolDecimalPercent,
+    slippageRune,
+  ])
 
   const tradeAssetInputs = useMemo(() => {
     if (!(asset && rune && foundPool)) return null

--- a/src/pages/ThorChainLP/components/AddLiquitity/AddLiquidityInput.tsx
+++ b/src/pages/ThorChainLP/components/AddLiquitity/AddLiquidityInput.tsx
@@ -506,7 +506,13 @@ export const AddLiquidityInput: React.FC<AddLiquidityInputProps> = ({
         borderBottomRadius='xl'
       >
         {symAlert}
-        <Button mx={-2} size='lg' colorScheme='blue' onClick={handleSubmit}>
+        <Button
+          mx={-2}
+          size='lg'
+          colorScheme='blue'
+          isDisabled={!confirmedQuote}
+          onClick={handleSubmit}
+        >
           {translate('pools.addLiquidity')}
         </Button>
       </CardFooter>

--- a/src/pages/ThorChainLP/components/AddLiquitity/AddLiquidityInput.tsx
+++ b/src/pages/ThorChainLP/components/AddLiquitity/AddLiquidityInput.tsx
@@ -287,7 +287,8 @@ export const AddLiquidityInput: React.FC<AddLiquidityInputProps> = ({
         runeCryptoLiquidityAmount &&
         runeFiatLiquidityAmount &&
         shareOfPoolDecimalPercent &&
-        slippageRune
+        slippageRune &&
+        activeOpportunityId
       )
     )
       return
@@ -299,8 +300,10 @@ export const AddLiquidityInput: React.FC<AddLiquidityInputProps> = ({
       runeFiatLiquidityAmount,
       shareOfPoolDecimalPercent,
       slippageRune,
+      opportunityId: activeOpportunityId,
     })
   }, [
+    activeOpportunityId,
     assetCryptoLiquidityAmount,
     assetFiatLiquidityAmount,
     runeCryptoLiquidityAmount,

--- a/src/pages/ThorChainLP/components/AddLiquitity/AddLiquityStatus.tsx
+++ b/src/pages/ThorChainLP/components/AddLiquitity/AddLiquityStatus.tsx
@@ -34,7 +34,7 @@ import { AddLiquidityRoutePaths } from './types'
 
 type AddLiquidityStatusProps = {
   opportunityId?: string
-  confirmedQuote: ConfirmedQuote | null
+  confirmedQuote: ConfirmedQuote
 }
 
 export const AddLiquidityStatus = ({ confirmedQuote, opportunityId }: AddLiquidityStatusProps) => {

--- a/src/pages/ThorChainLP/components/AddLiquitity/AddLiquityStatus.tsx
+++ b/src/pages/ThorChainLP/components/AddLiquitity/AddLiquityStatus.tsx
@@ -34,7 +34,7 @@ import { AddLiquidityRoutePaths } from './types'
 
 type AddLiquidityStatusProps = {
   opportunityId?: string
-  confirmedQuote: ConfirmedQuote
+  confirmedQuote: ConfirmedQuote | null
 }
 
 export const AddLiquidityStatus = ({ confirmedQuote, opportunityId }: AddLiquidityStatusProps) => {

--- a/src/pages/ThorChainLP/components/AddLiquitity/AddLiquityStatus.tsx
+++ b/src/pages/ThorChainLP/components/AddLiquitity/AddLiquityStatus.tsx
@@ -33,16 +33,17 @@ import { useAppSelector } from 'state/store'
 import { AddLiquidityRoutePaths } from './types'
 
 type AddLiquidityStatusProps = {
-  opportunityId?: string
   confirmedQuote: ConfirmedQuote
 }
 
-export const AddLiquidityStatus = ({ confirmedQuote, opportunityId }: AddLiquidityStatusProps) => {
+export const AddLiquidityStatus = ({ confirmedQuote }: AddLiquidityStatusProps) => {
   const translate = useTranslate()
   const history = useHistory()
   const [firstTx, setFirstTx] = useState(TxStatus.Unknown)
   const [secondTx, setSecondTx] = useState(TxStatus.Pending)
   const [isComplete, setIsComplete] = useState(false)
+
+  const { opportunityId } = confirmedQuote
 
   const { data: parsedPools } = usePools()
 


### PR DESCRIPTION
## Description

Wires up the quote in confirm and status screens, bringing in the notion of "confirmed quote".

## Pull Request Type

- [ ] :bug: Bug fix (Non-breaking Change: Fixes an issue)
- [ ] :hammer_and_wrench: Chore (Non-breaking Change: Doc updates, pkg upgrades, typos, etc..)
- [x] :nail_care: New Feature (Breaking/Non-breaking Change)

## Issue (if applicable)

<!-----------------------------------------------------------------------------
If applicable, please link to the github issue and put `closes #XXXX` in your comment to auto-close the issue that your PR fixes.
------------------------------------------------------------------------------>

closes #6019

## Risk

<!-----------------------------------------------------------------------------
Outline the scope of your changes and the risk associated with them. You must use your discretion as an engineer to determine the potential impact of your changes.

E.g. an upgrade to `hdwallet` or core state management would be considered higher risk, and might require a full regression test. UI or isolated view changes, or something behind a feature flag may have near zero risk. Small bug fixes might require testing isolated to the specific fix.
------------------------------------------------------------------------------>

None

## Testing

<!-----------------------------------------------------------------------------
We treat every PR to be merged with the same scrutiny as if we were merging directly to production.

Your PR will not be merged if you do not complete the sections below for our engineering and operations teams to test.
------------------------------------------------------------------------------>

- Ensure the confirmed quote data is propagated over confirm and status screens

### Engineering

<!-----------------------------------------------------------------------------
Include sufficient information here for an engineer to test your PR. This may include how to test locally, in a built environment, changes to infrastructure etc.
------------------------------------------------------------------------------>

- ☝🏽 

### Operations

<!-----------------------------------------------------------------------------
If your changes have a user-facing impact, describe how a non-technical QA team can functionally test your changes in a preview environment.

If they are not user-facing please describe how to test for any regressions that may occur.
------------------------------------------------------------------------------>

- ☝🏽 

## Screenshots (if applicable)

### Pool Page

#### RUNE asym

<img width="417" alt="image" src="https://github.com/shapeshift/web/assets/17035424/015474b5-c1c1-4415-a5e5-34773d2c1d81">
<img width="413" alt="image" src="https://github.com/shapeshift/web/assets/17035424/dd5bc5f1-b505-49fd-93bc-a1859183fbdb">
<img width="417" alt="image" src="https://github.com/shapeshift/web/assets/17035424/a2258bec-7cc9-46bb-8340-1bcb88b32f95">
<img width="406" alt="image" src="https://github.com/shapeshift/web/assets/17035424/0793d3cd-efe8-4307-ad3a-8b64d9d0e2d6">

#### Asset asym

<img width="402" alt="image" src="https://github.com/shapeshift/web/assets/17035424/8e5dd934-b1e4-4454-9f14-0b5d95c48f7c">
<img width="418" alt="image" src="https://github.com/shapeshift/web/assets/17035424/e41ea298-dcbf-4e06-a1aa-6109576b63de">
<img width="421" alt="image" src="https://github.com/shapeshift/web/assets/17035424/0590860b-0894-4059-9e94-422287c640f2">

#### Symmetrical

<img width="416" alt="image" src="https://github.com/shapeshift/web/assets/17035424/874997e2-c1cb-4343-b42d-c0320babff02">
<img width="422" alt="image" src="https://github.com/shapeshift/web/assets/17035424/16c61c39-1620-4c24-9c95-b7e4414575a2">
<img width="420" alt="image" src="https://github.com/shapeshift/web/assets/17035424/82092772-d5e4-4be9-b704-fdf96ee10ac8">

### Add Liquidity Page

### RUNE asym

<img width="443" alt="image" src="https://github.com/shapeshift/web/assets/17035424/40d1b0f7-2c0f-472e-afd3-c34d770152a7">
<img width="452" alt="image" src="https://github.com/shapeshift/web/assets/17035424/cb51f241-11a1-4bb9-8d4b-0644d17b1b8c">

### Asset asym

<img width="447" alt="image" src="https://github.com/shapeshift/web/assets/17035424/e9c3ffdd-ae3f-432e-ab7a-19a32da8e0e2">
<img width="458" alt="image" src="https://github.com/shapeshift/web/assets/17035424/6c6aecb2-b820-4ff9-8c37-7179fb98e421">
<img width="437" alt="image" src="https://github.com/shapeshift/web/assets/17035424/0caa4cc3-b582-4228-a091-67b7c7d6000d">

### Symmetrical

<img width="439" alt="image" src="https://github.com/shapeshift/web/assets/17035424/0b25be67-4860-4642-9b7b-7ff80f742763">
<img width="458" alt="image" src="https://github.com/shapeshift/web/assets/17035424/9833f50f-8a26-41f8-b7fd-77ef7fad37a1">
<img width="426" alt="image" src="https://github.com/shapeshift/web/assets/17035424/8f84504b-613a-4d7d-9a53-f453fc205c23">
