### PR TITLE
fix: dangerous small amount warning

### DIFF
--- a/src/state/apis/swappers/helpers/validateTradeQuote.ts
+++ b/src/state/apis/swappers/helpers/validateTradeQuote.ts
@@ -23,10 +23,7 @@ import {
   selectSellAmountCryptoPrecision,
 } from 'state/slices/selectors'
 import { getTotalProtocolFeeByAssetForStep } from 'state/slices/tradeQuoteSlice/helpers'
-import {
-  selectSecondHopSellAccountId,
-  selectSellAmountCryptoBaseUnit,
-} from 'state/slices/tradeQuoteSlice/selectors'
+import { selectSecondHopSellAccountId } from 'state/slices/tradeQuoteSlice/selectors'
 
 import type { ErrorWithMeta } from '../types'
 import { type TradeQuoteError, TradeQuoteValidationError, TradeQuoteWarning } from '../types'

--- a/src/state/apis/swappers/helpers/validateTradeQuote.ts
+++ b/src/state/apis/swappers/helpers/validateTradeQuote.ts
@@ -110,7 +110,7 @@ export const validateTradeQuote = async (
   const lastHop = isMultiHopTrade ? secondHop : firstHop
   const walletSupportedChainIds = selectWalletSupportedChainIds(state)
   const sellAmountCryptoPrecision = selectSellAmountCryptoPrecision(state)
-  const sellAmountCryptoBaseUnit = selectSellAmountCryptoBaseUnit(state)
+  const sellAmountCryptoBaseUnit = firstHop.sellAmountIncludingProtocolFeesCryptoBaseUnit
   const buyAmountCryptoBaseUnit = lastHop.buyAmountBeforeFeesCryptoBaseUnit
 
   // the network fee asset for the first hop in the trade
@@ -206,10 +206,12 @@ export const validateTradeQuote = async (
 
   const recommendedMinimumCryptoBaseUnit = (quote as ThorTradeQuote)
     .recommendedMinimumCryptoBaseUnit
-  const isUnsafeQuote = !(
-    !recommendedMinimumCryptoBaseUnit ||
-    bnOrZero(sellAmountCryptoBaseUnit).gte(recommendedMinimumCryptoBaseUnit)
-  )
+  const isUnsafeQuote =
+    sellAmountCryptoBaseUnit &&
+    !(
+      !recommendedMinimumCryptoBaseUnit ||
+      bnOrZero(sellAmountCryptoBaseUnit).gte(recommendedMinimumCryptoBaseUnit)
+    )
 
   const disableSmartContractSwap = await (async () => {
     // Swappers other than THORChain shouldn't be affected by this limitation


### PR DESCRIPTION
## Description

Fixes a bug introduced in https://github.com/shapeshift/web/pull/5971/files#diff-b6f4d6672824399e71740531e3b09efe3ad3fabeb3ad6c4ce0763969f9d39ab7R104, where we try and select `selectSellAmountCryptoBaseUnit(state)`, which yields `undefined` because `firstHop` is undefined at that time:

<img width="1439" alt="image" src="https://github.com/shapeshift/web/assets/17035424/ed984c7d-732f-41a3-a5ef-dd028b05c9af">
<img width="1387" alt="image" src="https://github.com/shapeshift/web/assets/17035424/a6c33e52-bc77-4155-b09f-f4183edbe8c5">

Fixed by
1. using the correct `local` quote and running the same selector logic against it, instead of introspecting the not-yet-defined hop state
2. as a paranoia check, not assuming dangerous amount if `!sellAmountCryptoBaseUnit` which should not happen anymore, but in case it does, we are safu.

## Pull Request Type

- [x] :bug: Bug fix (Non-breaking Change: Fixes an issue)
- [ ] :hammer_and_wrench: Chore (Non-breaking Change: Doc updates, pkg upgrades, typos, etc..)
- [ ] :nail_care: New Feature (Breaking/Non-breaking Change)

## Issue (if applicable)

<!-----------------------------------------------------------------------------
If applicable, please link to the github issue and put `closes #XXXX` in your comment to auto-close the issue that your PR fixes.
------------------------------------------------------------------------------>

closes https://github.com/shapeshift/web/issues/6037

## Risk

This isn't high risk - while it *does* touch quote validation, it is moderate to low risk as we had all the logic baked in already for a long time and stable, but were reacting on the wrong value since  https://github.com/shapeshift/web/pull/5971 refactor

~~High Risk PRs Require 2 approvals~~

<!-----------------------------------------------------------------------------
Outline the scope of your changes and the risk associated with them. You must use your discretion as an engineer to determine the potential impact of your changes.

WARNING: If your PR introduces a new on-chain transaction or modifies an existing one, please add the "High-Risk" label to this PR and ask for 2 reviewers to approve it before merging.

E.g. an upgrade to `hdwallet` or core state management would be considered higher risk, and might require a full regression test. UI or isolated view changes, or something behind a feature flag may have near zero risk. Small bug fixes might require testing isolated to the specific fix.
------------------------------------------------------------------------------>

## Testing

<!-----------------------------------------------------------------------------
We treat every PR to be merged with the same scrutiny as if we were merging directly to production.

Your PR will not be merged if you do not complete the sections below for our engineering and operations teams to test.
------------------------------------------------------------------------------>

- Dangerous sell amount warning is still displayed for small amounts
- Dangerous sell amount warning isn't displayed when the amount is greater than or equal to the minimum THOR-recommended amount

### Engineering

<!-----------------------------------------------------------------------------
Include sufficient information here for an engineer to test your PR. This may include how to test locally, in a built environment, changes to infrastructure etc.
------------------------------------------------------------------------------>

☝🏽 


### Operations

<!-----------------------------------------------------------------------------
If your changes have a user-facing impact, describe how a non-technical QA team can functionally test your changes in a preview environment.

If they are not user-facing please describe how to test for any regressions that may occur.
------------------------------------------------------------------------------>

- ☝🏽 

## Screenshots (if applicable)

- Amount smaller than the recommended minimum

<img width="319" alt="Screenshot 2024-01-18 at 12 06 08" src="https://github.com/shapeshift/web/assets/17035424/332e07fb-d3b9-4728-a448-19219df9efec">
<img width="624" alt="Screenshot 2024-01-18 at 12 06 15" src="https://github.com/shapeshift/web/assets/17035424/c2f4a38f-759a-476f-9b8c-b59265e828a5">

- Amount equal to the recommended minimum

<img width="580" alt="Screenshot 2024-01-18 at 12 06 41" src="https://github.com/shapeshift/web/assets/17035424/78d8ced4-be61-4d67-a2b5-24fb24a6ac95">
<img width="592" alt="Screenshot 2024-01-18 at 12 06 49" src="https://github.com/shapeshift/web/assets/17035424/4de5268d-4074-4ee9-968b-6f7b788932ae">
