### PR TITLE
chore: remove redundant throw

### DIFF
--- a/src/lib/swapper/swappers/ThorchainSwapper/endpoints.ts
+++ b/src/lib/swapper/swappers/ThorchainSwapper/endpoints.ts
@@ -12,17 +12,15 @@ import {
   type GetUnsignedCosmosSdkTransactionArgs,
   type GetUnsignedEvmTransactionArgs,
   type GetUnsignedUtxoTransactionArgs,
-  makeSwapErrorRight,
   type SwapErrorRight,
   type SwapperApi,
   type TradeQuote,
-  TradeQuoteError,
   type UtxoFeeData,
 } from '@shapeshiftoss/swapper'
 import type { AssetsByIdPartial } from '@shapeshiftoss/types'
 import { KnownChainIds } from '@shapeshiftoss/types'
 import { cosmossdk, evm, TxStatus } from '@shapeshiftoss/unchained-client'
-import { Err, type Result } from '@sniptt/monads/build'
+import { type Result } from '@sniptt/monads/build'
 import assert from 'assert'
 import axios from 'axios'
 import { getConfig } from 'config'

--- a/src/lib/swapper/swappers/ThorchainSwapper/endpoints.ts
+++ b/src/lib/swapper/swappers/ThorchainSwapper/endpoints.ts
@@ -169,15 +169,6 @@ export const thorchainApi: SwapperApi = {
             .toFixed(0, BigNumber.ROUND_UP),
         )
 
-        if (amountOutMin <= 0n) {
-          throw Err(
-            makeSwapErrorRight({
-              code: TradeQuoteError.SellAmountBelowMinimum,
-              message: 'Sell amount is too small',
-            }),
-          )
-        }
-
         // Paranoia: ensure we have this to prevent sandwich attacks on the first step of a LongtailToL1 trade.
         assert(amountOutMin > 0n, 'expected expectedAmountOut to be a positive amount')
 


### PR DESCRIPTION
## Description

I added this in https://github.com/shapeshift/web/pull/6052/commits/3c5c907403bda0f1fe7547a3eda5942c08de5ee3, but it's actually redundant and already covered by the line:

```ts
assert(amountOutMin > 0n, 'expected expectedAmountOut to be be a positive amount')
```

## Pull Request Type

- [ ] :bug: Bug fix (Non-breaking Change: Fixes an issue)
- [x] :hammer_and_wrench: Chore (Non-breaking Change: Doc updates, pkg upgrades, typos, etc..)
- [ ] :nail_care: New Feature (Breaking/Non-breaking Change)

## Issue (if applicable)

Related to https://github.com/shapeshift/web/issues/6017

## Risk

Low

## Testing

THORChain quotes and error messages for longtail and non-longtail should still work as expected.

### Engineering

☝️

### Operations

☝️

## Screenshots (if applicable)

N/A