### PR TITLE
fix: stream status displayed for non THOR streaming swaps

### DIFF
--- a/src/components/MultiHopTrade/components/MultiHopTradeConfirm/components/HopTransactionStep.tsx
+++ b/src/components/MultiHopTrade/components/MultiHopTradeConfirm/components/HopTransactionStep.tsx
@@ -113,9 +113,10 @@ export const HopTransactionStep = ({
       )
     }
 
-    const isThorStreamingSwap =
-      tradeQuoteStep.source === THORCHAIN_STREAM_SWAP_SOURCE ||
-      THORCHAIN_LONGTAIL_STREAMING_SWAP_SOURCE
+    const isThorStreamingSwap = [
+      THORCHAIN_STREAM_SWAP_SOURCE,
+      THORCHAIN_LONGTAIL_STREAMING_SWAP_SOURCE,
+    ].includes(tradeQuoteStep.source)
 
     if (sellTxHash !== undefined && isThorStreamingSwap) {
       return (


### PR DESCRIPTION
## Description

Fixes "Stream Status" progress bar being displayed for *all* swaps instead of streaming swaps only

## Pull Request Type

- [x] :bug: Bug fix (Non-breaking Change: Fixes an issue)
- [ ] :hammer_and_wrench: Chore (Non-breaking Change: Doc updates, pkg upgrades, typos, etc..)
- [ ] :nail_care: New Feature (Breaking/Non-breaking Change)

## Issue (if applicable)

<!-----------------------------------------------------------------------------
If applicable, please link to the github issue and put `closes #XXXX` in your comment to auto-close the issue that your PR fixes.
------------------------------------------------------------------------------>

N/A, this wasn't captured as an issue but spotted in https://github.com/shapeshift/web/pull/6051

## Risk
> High Risk PRs Require 2 approvals

<!-----------------------------------------------------------------------------
Outline the scope of your changes and the risk associated with them. You must use your discretion as an engineer to determine the potential impact of your changes.

WARNING: If your PR introduces a new on-chain transaction or modifies an existing one, please add the "High-Risk" label to this PR and ask for 2 reviewers to approve it before merging.

E.g. an upgrade to `hdwallet` or core state management would be considered higher risk, and might require a full regression test. UI or isolated view changes, or something behind a feature flag may have near zero risk. Small bug fixes might require testing isolated to the specific fix.
------------------------------------------------------------------------------>

- Low to none - we can ensure streaming swaps still have "Stream Status" displayed as a paranoia check, though if we can't test this because of funds required for streaming swaps testing, this has effectively 0 risk

## Testing

<!-----------------------------------------------------------------------------
We treat every PR to be merged with the same scrutiny as if we were merging directly to production.

Your PR will not be merged if you do not complete the sections below for our engineering and operations teams to test.
------------------------------------------------------------------------------>

- Non-streaming swaps do *not* have "Stream Status" displayed at swap progress and complete steps

### Engineering

<!-----------------------------------------------------------------------------
Include sufficient information here for an engineer to test your PR. This may include how to test locally, in a built environment, changes to infrastructure etc.
------------------------------------------------------------------------------>

- ☝🏽 

### Operations

<!-----------------------------------------------------------------------------
If your changes have a user-facing impact, describe how a non-technical QA team can functionally test your changes in a preview environment.

If they are not user-facing please describe how to test for any regressions that may occur.
------------------------------------------------------------------------------>

- ☝🏽 

## Screenshots (if applicable)

### Develop

<img width="657" alt="Screenshot 2024-01-23 at 14 24 04" src="https://github.com/shapeshift/web/assets/17035424/006b1a36-bf1f-4a03-842d-e0a8b8164074">
<img width="657" alt="Screenshot 2024-01-23 at 14 24 04" src="https://github.com/shapeshift/web/assets/17035424/7b81c1be-b8fa-434a-a96d-327a67fe8629">

### This diff

<img width="630" alt="image" src="https://github.com/shapeshift/web/assets/17035424/56a342df-370b-447a-bc61-670564532337">
<img width="605" alt="image" src="https://github.com/shapeshift/web/assets/17035424/d2c613f2-19df-47c0-8c91-d9fe7cc3437c">

