### PR TITLE
fix: receive amount on confirm screen

### DIFF
--- a/src/components/MultiHopTrade/components/MultiHopTradeConfirm/components/Hop.tsx
+++ b/src/components/MultiHopTrade/components/MultiHopTradeConfirm/components/Hop.tsx
@@ -192,7 +192,7 @@ export const Hop = ({
           {shouldRenderFinalSteps && (
             <AssetSummaryStep
               asset={tradeQuoteStep.buyAsset}
-              amountCryptoBaseUnit={tradeQuoteStep.buyAmountBeforeFeesCryptoBaseUnit}
+              amountCryptoBaseUnit={tradeQuoteStep.buyAmountAfterFeesCryptoBaseUnit}
               isLastStep={shouldRenderFinalSteps}
             />
           )}


### PR DESCRIPTION
## Description

Fixes the receive amount on the confirm screen showing the _before_ fees receive amount, instead of the _after_ fees receive amount we show on the quote screen.

## Pull Request Type

- [x] :bug: Bug fix (Non-breaking Change: Fixes an issue)
- [ ] :hammer_and_wrench: Chore (Non-breaking Change: Doc updates, pkg upgrades, typos, etc..)
- [ ] :nail_care: New Feature (Breaking/Non-breaking Change)

## Issue (if applicable)

Closes https://github.com/shapeshift/web/issues/6065

## Risk

Small

## Testing

For all swaps, particularly those using THORChain, the amount shown on on the quote screen should match the amount shown on the confirm screen.

### Engineering

☝️

### Operations

☝️

## Screenshots (if applicable)

Note that the values now match:


<img width="458" alt="Screenshot 2024-01-24 at 1 27 17 pm" src="https://github.com/shapeshift/web/assets/97164662/4b70fadd-68e9-4903-9022-cc0f0568d950">

<img width="473" alt="Screenshot 2024-01-24 at 1 27 24 pm" src="https://github.com/shapeshift/web/assets/97164662/74fac3e9-efb3-4810-815a-23c55117b36e">