### PR TITLE
fix: long tail explorer Tx link

### DIFF
--- a/src/lib/getTxLink.ts
+++ b/src/lib/getTxLink.ts
@@ -38,7 +38,14 @@ export const getTxLink = ({ name, defaultExplorerBaseUrl, txId, tradeId }: GetTx
   const isOrder = !!tradeId
   const baseUrl = getTxBaseUrl({ name, defaultExplorerBaseUrl, isOrder })
 
-  if ([SwapperName.Thorchain, THORCHAIN_STREAM_SWAP_SOURCE].includes(name as SwapSource)) {
+  if (
+    [
+      SwapperName.Thorchain,
+      THORCHAIN_STREAM_SWAP_SOURCE,
+      THORCHAIN_LONGTAIL_SWAP_SOURCE,
+      THORCHAIN_LONGTAIL_STREAMING_SWAP_SOURCE,
+    ].includes(name as SwapSource)
+  ) {
     return `${baseUrl}${id.replace(/^0x/, '')}`
   }
 


### PR DESCRIPTION
## Description

Fixes wrong Txid link for long-tail THOR Txs, following up on https://github.com/shapeshift/web/pull/6067

## Pull Request Type

- [x] :bug: Bug fix (Non-breaking Change: Fixes an issue)
- [ ] :hammer_and_wrench: Chore (Non-breaking Change: Doc updates, pkg upgrades, typos, etc..)
- [ ] :nail_care: New Feature (Breaking/Non-breaking Change)

## Issue (if applicable)

<!-----------------------------------------------------------------------------
If applicable, please link to the github issue and put `closes #XXXX` in your comment to auto-close the issue that your PR fixes.
------------------------------------------------------------------------------>

Relates to https://github.com/shapeshift/web/issues/6017

## Risk
> High Risk PRs Require 2 approvals

<!-----------------------------------------------------------------------------
Outline the scope of your changes and the risk associated with them. You must use your discretion as an engineer to determine the potential impact of your changes.

WARNING: If your PR introduces a new on-chain transaction or modifies an existing one, please add the "High-Risk" label to this PR and ask for 2 reviewers to approve it before merging.

E.g. an upgrade to `hdwallet` or core state management would be considered higher risk, and might require a full regression test. UI or isolated view changes, or something behind a feature flag may have near zero risk. Small bug fixes might require testing isolated to the specific fix.
------------------------------------------------------------------------------>

None

## Testing

<!-----------------------------------------------------------------------------
We treat every PR to be merged with the same scrutiny as if we were merging directly to production.

Your PR will not be merged if you do not complete the sections below for our engineering and operations teams to test.
------------------------------------------------------------------------------>

- Long-tail Tx links are happy i.e aren't prefixed with the EVM `0x` prefix

### Engineering

<!-----------------------------------------------------------------------------
Include sufficient information here for an engineer to test your PR. This may include how to test locally, in a built environment, changes to infrastructure etc.
------------------------------------------------------------------------------>

- ☝🏽 

### Operations

<!-----------------------------------------------------------------------------
If your changes have a user-facing impact, describe how a non-technical QA team can functionally test your changes in a preview environment.

If they are not user-facing please describe how to test for any regressions that may occur.
------------------------------------------------------------------------------>

- ☝🏽 

## Screenshots (if applicable)

- Develop

<img width="355" alt="Screenshot 2024-01-24 at 11 57 12" src="https://github.com/shapeshift/web/assets/17035424/61fab089-b6a4-4221-8fc7-3980d311d9ac">
<img width="837" alt="Screenshot 2024-01-24 at 11 57 32" src="https://github.com/shapeshift/web/assets/17035424/7af3d95f-4c18-4850-bf76-daa38112dfe6">

- This diff

Happy Tx link 🎉 

<img width="365" alt="image" src="https://github.com/shapeshift/web/assets/17035424/6c828314-f8ea-40db-b36a-5ae7a8e0ceb3">
<img width="462" alt="Screenshot 2024-01-24 at 11 57 46" src="https://github.com/shapeshift/web/assets/17035424/7b9be0b5-6eec-4a17-813c-1321f92fbbf3">
