### PR TITLE
fix: reduce preview trade button state changes during load

### DIFF
--- a/src/components/MultiHopTrade/components/TradeInput/TradeInput.tsx
+++ b/src/components/MultiHopTrade/components/TradeInput/TradeInput.tsx
@@ -154,14 +154,14 @@ export const TradeInput = memo(() => {
     setIsQuoteRequestComplete(false)
   }, [sellAmountCryptoPrecision])
 
-  // when the a quote becomes available, set the quote state to fetched
+  // when a quote becomes available, set the quote states to fetched
   useEffect(() => {
     if (_isAnySwapperFetched) {
       setIsAnySwapperFetched(true)
     }
   }, [_isAnySwapperFetched])
 
-  // when the a quote is complete, mark it as complete
+  // when a quote request is complete, mark it as complete
   useEffect(() => {
     if (_isQuoteRequestComplete) {
       setIsQuoteRequestComplete(true)

--- a/src/state/slices/tradeQuoteSlice/tradeQuoteSlice.ts
+++ b/src/state/slices/tradeQuoteSlice/tradeQuoteSlice.ts
@@ -34,7 +34,7 @@ export const tradeQuoteSlice = createSlice({
       }>,
     ) => {
       const { swapperName, quotesById } = action.payload
-      state.tradeQuotes[swapperName] = quotesById
+      state.tradeQuotes[swapperName] = quotesById ?? {}
     },
     setActiveQuote: (state, action: PayloadAction<ApiQuote | undefined>) => {
       if (action.payload === undefined) {


### PR DESCRIPTION
## Description

Reduces the number of state changes on the preview button on the trade input component.

## Pull Request Type

- [x] :bug: Bug fix (Non-breaking Change: Fixes an issue)
- [ ] :hammer_and_wrench: Chore (Non-breaking Change: Doc updates, pkg upgrades, typos, etc..)
- [ ] :nail_care: New Feature (Breaking/Non-breaking Change)

## Issue (if applicable)

closes #6076

## Risk
> High Risk PRs Require 2 approvals

Moderate risk of incorrect text, loading state or error states being rendered on the preview trade button.
Moderate risk of selected trades being different to what you execute - pay special attention to issues like this when testing and reviewing.

## Testing

Check that trade input, quotes and loading state works correctly on the trade input.

### Engineering

<!-----------------------------------------------------------------------------
Include sufficient information here for an engineer to test your PR. This may include how to test locally, in a built environment, changes to infrastructure etc.
------------------------------------------------------------------------------>

### Operations

<!-----------------------------------------------------------------------------
If your changes have a user-facing impact, describe how a non-technical QA team can functionally test your changes in a preview environment.

If they are not user-facing please describe how to test for any regressions that may occur.
------------------------------------------------------------------------------>

## Screenshots (if applicable)


https://github.com/shapeshift/web/assets/125113430/9dc55a45-4551-4f48-a8f2-48519e9a3e31

