### PR TITLE
fix: regression of smart contract sell address checks on validateTradeQuote

### DIFF
--- a/src/state/apis/swapper/helpers/validateTradeQuote.ts
+++ b/src/state/apis/swapper/helpers/validateTradeQuote.ts
@@ -36,12 +36,16 @@ export const validateTradeQuote = async (
     error,
     isTradingActiveOnSellPool,
     isTradingActiveOnBuyPool,
+    sendAddress,
   }: {
     swapperName: SwapperName
     quote: TradeQuote | undefined
     error: SwapErrorRight | undefined
     isTradingActiveOnSellPool: boolean
     isTradingActiveOnBuyPool: boolean
+    // TODO(gomes): this should most likely live in the quote alongside the receiveAddress,
+    // summoning @woodenfurniture WRT implications of that, this works for now
+    sendAddress: string | undefined
   },
 ): Promise<{
   errors: ErrorWithMeta<TradeQuoteError>[]
@@ -100,6 +104,9 @@ export const validateTradeQuote = async (
 
     return { errors: [tradeQuoteError], warnings: [] }
   }
+
+  // This should really never happen but in case it does:
+  if (!sendAddress) throw new Error('sendAddress is required')
 
   const isMultiHopTrade = quote.steps.length > 1
   const firstHop = quote.steps[0]
@@ -215,7 +222,7 @@ export const validateTradeQuote = async (
     if (swapperName !== SwapperName.Thorchain) return false
 
     // This is either a smart contract address, or the bytecode is still loading - disable confirm
-    const _isSmartContractAddress = await isSmartContractAddress(quote.receiveAddress)
+    const _isSmartContractAddress = await isSmartContractAddress(sendAddress)
     if (_isSmartContractAddress !== false) return true
 
     // All checks passed - this is an EOA address

--- a/src/state/apis/swapper/helpers/validateTradeQuote.ts
+++ b/src/state/apis/swapper/helpers/validateTradeQuote.ts
@@ -221,7 +221,7 @@ export const validateTradeQuote = async (
     // Swappers other than THORChain shouldn't be affected by this limitation
     if (swapperName !== SwapperName.Thorchain) return false
 
-    // This is either a smart contract address, or the bytecode is still loading - disable confirm
+    // Sender is either a smart contract address, or the bytecode is still loading - disable confirm
     const _isSmartContractAddress = await isSmartContractAddress(sendAddress)
     if (_isSmartContractAddress !== false) return true
 

--- a/src/state/apis/swapper/swapperApi.ts
+++ b/src/state/apis/swapper/swapperApi.ts
@@ -164,6 +164,7 @@ export const swapperApi = swapperApiBase.injectEndpoints({
               error,
               isTradingActiveOnSellPool,
               isTradingActiveOnBuyPool,
+              sendAddress,
             })
             return {
               id: quoteSource,


### PR DESCRIPTION
## Description

Spotted in https://github.com/shapeshift/web/pull/5971/files#diff-b6f4d6672824399e71740531e3b09efe3ad3fabeb3ad6c4ce0763969f9d39ab7R210

see:

https://github.com/shapeshift/web/blob/3b9b81e29859ae6f60c2f21e7efc4ee0a527591c/src/state/apis/swappers/helpers/validateTradeQuote.ts#L210

vs. previous implementation:

https://github.com/shapeshift/web/blob/658137910d7d0e2d4ffae29aea16b256a50adaa4/src/components/MultiHopTrade/hooks/quoteValidation/useActiveQuoteStatus.tsx#L47-L53

This means that we effectively do *not* validate on the sell side anymore, but on the receive side instead, which is an extremely high-risk regression.
This however is mitigated by the fact we have a similar and correct check in-place at input step:

https://github.com/shapeshift/web/blob/255d8b7f4806b906365ec301ce2f4cb793eea088/src/components/MultiHopTrade/components/TradeInput/TradeInput.tsx#L209-L216

This PR reverts to the previous behavior.

## Pull Request Type

- [x] :bug: Bug fix (Non-breaking Change: Fixes an issue)
- [ ] :hammer_and_wrench: Chore (Non-breaking Change: Doc updates, pkg upgrades, typos, etc..)
- [ ] :nail_care: New Feature (Breaking/Non-breaking Change)

## Issue (if applicable)

<!-----------------------------------------------------------------------------
If applicable, please link to the github issue and put `closes #XXXX` in your comment to auto-close the issue that your PR fixes.
------------------------------------------------------------------------------>

closes N/A, spotted while working on another PR.

## Risk
> High Risk PRs Require 2 approvals

<!-----------------------------------------------------------------------------
Outline the scope of your changes and the risk associated with them. You must use your discretion as an engineer to determine the potential impact of your changes.

WARNING: If your PR introduces a new on-chain transaction or modifies an existing one, please add the "High-Risk" label to this PR and ask for 2 reviewers to approve it before merging.

E.g. an upgrade to `hdwallet` or core state management would be considered higher risk, and might require a full regression test. UI or isolated view changes, or something behind a feature flag may have near zero risk. Small bug fixes might require testing isolated to the specific fix.
------------------------------------------------------------------------------>

- Low to none as this *reverts* to the previous behavior. `high risk` tag becaue this fixes a high-risk regression.

## Testing

<!-----------------------------------------------------------------------------
We treat every PR to be merged with the same scrutiny as if we were merging directly to production.

Your PR will not be merged if you do not complete the sections below for our engineering and operations teams to test.
------------------------------------------------------------------------------>

- With an actual smart-contract wallet (e.g Gnosis Safe through WC) ensure you are blocked from trading on THOR
- With Frame-injected smart-contract wallet address,  ensure you are blocked from trading on THOR

### Engineering

<!-----------------------------------------------------------------------------
Include sufficient information here for an engineer to test your PR. This may include how to test locally, in a built environment, changes to infrastructure etc.
------------------------------------------------------------------------------>

- ☝🏽 

### Operations

<!-----------------------------------------------------------------------------
If your changes have a user-facing impact, describe how a non-technical QA team can functionally test your changes in a preview environment.

If they are not user-facing please describe how to test for any regressions that may occur.
------------------------------------------------------------------------------>

- ☝🏽 

## Screenshots (if applicable)

Tested with frame-injected user smart-contract wallet address

- Develop 

Note `isSmartContractAddress` returns false, since we're passing the receive DOGE address instead of the smart-contract wallet on the sell side

<img width="1054" alt="Screenshot 2024-01-25 at 11 14 35" src="https://github.com/shapeshift/web/assets/17035424/a41b9663-cc0a-4684-bb62-0d00d305fc9e">
<img width="535" alt="image" src="https://github.com/shapeshift/web/assets/17035424/a220b2dd-dcf5-46fb-b5cd-6bb3d8b7d5fd">

- This diff 

<img width="547" alt="image" src="https://github.com/shapeshift/web/assets/17035424/86b72599-d28b-43f1-9efa-407a88173af3">
<img width="524" alt="image" src="https://github.com/shapeshift/web/assets/17035424/1414ae36-9e5e-43b7-9af8-33c2ec192ecb">
