### PR TITLE
fix: quote loading state

### DIFF
--- a/src/components/MultiHopTrade/components/TradeInput/TradeInput.tsx
+++ b/src/components/MultiHopTrade/components/TradeInput/TradeInput.tsx
@@ -104,6 +104,7 @@ export const TradeInput = memo(() => {
     isQuoteRequestUninitialized,
     isSwapperFetching,
     didQuoteRequestFail,
+    isAnySwapperFetching,
   } = useGetTradeQuotes()
   const {
     state: { wallet },
@@ -268,6 +269,7 @@ export const TradeInput = memo(() => {
   const isLoading = useMemo(
     () =>
       !isAnySwapperFetched ||
+      isAnySwapperFetching ||
       isConfirmationLoading ||
       isSupportedAssetsLoading ||
       isAddressByteCodeLoading ||
@@ -277,6 +279,7 @@ export const TradeInput = memo(() => {
       isVotingPowerLoading,
     [
       isAddressByteCodeLoading,
+      isAnySwapperFetching,
       isConfirmationLoading,
       isAnySwapperFetched,
       isSupportedAssetsLoading,

--- a/src/components/MultiHopTrade/components/TradeInput/TradeInput.tsx
+++ b/src/components/MultiHopTrade/components/TradeInput/TradeInput.tsx
@@ -104,7 +104,7 @@ export const TradeInput = memo(() => {
     isQuoteRequestUninitialized,
     isSwapperFetching,
     didQuoteRequestFail,
-    isAnySwapperFetching,
+    isQuoteRequestIncomplete,
   } = useGetTradeQuotes()
   const {
     state: { wallet },
@@ -269,7 +269,7 @@ export const TradeInput = memo(() => {
   const isLoading = useMemo(
     () =>
       !isAnySwapperFetched ||
-      isAnySwapperFetching ||
+      isQuoteRequestIncomplete ||
       isConfirmationLoading ||
       isSupportedAssetsLoading ||
       isAddressByteCodeLoading ||
@@ -279,7 +279,7 @@ export const TradeInput = memo(() => {
       isVotingPowerLoading,
     [
       isAddressByteCodeLoading,
-      isAnySwapperFetching,
+      isQuoteRequestIncomplete,
       isConfirmationLoading,
       isAnySwapperFetched,
       isSupportedAssetsLoading,

--- a/src/components/MultiHopTrade/hooks/useGetTradeQuotes/useGetTradeQuotes.tsx
+++ b/src/components/MultiHopTrade/hooks/useGetTradeQuotes/useGetTradeQuotes.tsx
@@ -289,6 +289,12 @@ export const useGetTradeQuotes = () => {
     )
   }, [combinedQuoteMeta, isDebouncing, isFetchingInput])
 
+  const isAnySwapperFetching = useMemo(() => {
+    return (
+      isDebouncing || isFetchingInput || combinedQuoteMeta.some(quoteMeta => quoteMeta.isFetching)
+    )
+  }, [combinedQuoteMeta, isDebouncing, isFetchingInput])
+
   // true if any debounce, input or swapper is fetching
   const isQuoteRequestIncomplete = useMemo(() => {
     return (
@@ -360,5 +366,6 @@ export const useGetTradeQuotes = () => {
     isQuoteRequestComplete: !isQuoteRequestIncomplete,
     isSwapperFetching,
     didQuoteRequestFail,
+    isAnySwapperFetching,
   }
 }

--- a/src/components/MultiHopTrade/hooks/useGetTradeQuotes/useGetTradeQuotes.tsx
+++ b/src/components/MultiHopTrade/hooks/useGetTradeQuotes/useGetTradeQuotes.tsx
@@ -289,12 +289,6 @@ export const useGetTradeQuotes = () => {
     )
   }, [combinedQuoteMeta, isDebouncing, isFetchingInput])
 
-  const isAnySwapperFetching = useMemo(() => {
-    return (
-      isDebouncing || isFetchingInput || combinedQuoteMeta.some(quoteMeta => quoteMeta.isFetching)
-    )
-  }, [combinedQuoteMeta, isDebouncing, isFetchingInput])
-
   // true if any debounce, input or swapper is fetching
   const isQuoteRequestIncomplete = useMemo(() => {
     return (
@@ -366,6 +360,6 @@ export const useGetTradeQuotes = () => {
     isQuoteRequestComplete: !isQuoteRequestIncomplete,
     isSwapperFetching,
     didQuoteRequestFail,
-    isAnySwapperFetching,
+    isQuoteRequestIncomplete,
   }
 }


### PR DESCRIPTION
## Description

Fixes the quote loading state so we don't show "No rate available" while we are still looking for quotes.

Develop:

https://github.com/shapeshift/web/assets/97164662/fec4b0c0-f810-4328-a73f-5e88b6d9fc30

This branch:

https://github.com/shapeshift/web/assets/97164662/a6e6016b-8efb-4bc2-af58-ba44ca8cb265

Note, we still get a small flash of "No rate available", but that is not intended to be fixed in this PR.

## Pull Request Type

- [x] :bug: Bug fix (Non-breaking Change: Fixes an issue)
- [ ] :hammer_and_wrench: Chore (Non-breaking Change: Doc updates, pkg upgrades, typos, etc..)
- [ ] :nail_care: New Feature (Breaking/Non-breaking Change)

## Issue (if applicable)

N/A

## Risk

Small

## Testing

The issue usually occurs when fetching the first quote after a refresh/initial load.

Get a quote and confirm the loading state shows for the rate whilst the quotes are loading.

### Engineering

☝️

### Operations

☝️

## Screenshots (if applicable)

N/A