### PR TITLE
fix: completely borked quote percentage differences

### DIFF
--- a/src/assets/translations/en/main.json
+++ b/src/assets/translations/en/main.json
@@ -805,6 +805,7 @@
     "onChainName": "on %{chainName}",
     "unknownGas": "(unknown)",
     "numHops": "This trade includes %{numHops} hops",
+    "percentageDifferenceTooltip": "This is the percentage difference in the total amount of %{buyAssetSymbol} you will receive, compared to the best quote",
     "receiveAddress": "Receive Address",
     "receiveAddressDescription": "No %{chainName} address found from connected wallet. Manually enter an address or",
     "toContinue": "to continue.",

--- a/src/components/MultiHopTrade/components/TradeInput/components/TradeQuotes/TradeQuote.tsx
+++ b/src/components/MultiHopTrade/components/TradeInput/components/TradeQuotes/TradeQuote.tsx
@@ -37,7 +37,7 @@ type TradeQuoteProps = {
   isActive: boolean
   isBest: boolean
   quoteData: ApiQuote
-  bestBuyAmountBeforeFeesCryptoBaseUnit: string
+  bestTotalReceiveAmountCryptoPrecision: string | undefined
   isLoading: boolean
 }
 
@@ -45,7 +45,7 @@ export const TradeQuoteLoaded: FC<TradeQuoteProps> = ({
   isActive,
   isBest,
   quoteData,
-  bestBuyAmountBeforeFeesCryptoBaseUnit,
+  bestTotalReceiveAmountCryptoPrecision,
   isLoading,
 }) => {
   const { quote, errors } = quoteData
@@ -124,13 +124,11 @@ export const TradeQuoteLoaded: FC<TradeQuoteProps> = ({
 
   // the difference percentage is on the gross receive amount only
   const quoteDifferenceDecimalPercentage = useMemo(() => {
-    if (!quote) return Infinity
-    const lastStep = quote.steps[quote.steps.length - 1]
-    return bn(bestBuyAmountBeforeFeesCryptoBaseUnit)
-      .minus(lastStep.buyAmountBeforeFeesCryptoBaseUnit)
-      .dividedBy(bestBuyAmountBeforeFeesCryptoBaseUnit)
+    if (!quote || !bestTotalReceiveAmountCryptoPrecision) return
+    return bn(1)
+      .minus(bn(totalReceiveAmountCryptoPrecision).dividedBy(bestTotalReceiveAmountCryptoPrecision))
       .toNumber()
-  }, [bestBuyAmountBeforeFeesCryptoBaseUnit, quote])
+  }, [bestTotalReceiveAmountCryptoPrecision, quote, totalReceiveAmountCryptoPrecision])
 
   const isAmountEntered = bnOrZero(sellAmountCryptoPrecision).gt(0)
   const hasNegativeRatio =

--- a/src/components/MultiHopTrade/components/TradeInput/components/TradeQuotes/components/TradeQuoteContent.tsx
+++ b/src/components/MultiHopTrade/components/TradeInput/components/TradeQuotes/components/TradeQuoteContent.tsx
@@ -1,4 +1,4 @@
-import { CardBody, CardFooter, Flex, Skeleton, Tooltip } from '@chakra-ui/react'
+import { Box, CardBody, CardFooter, Flex, Skeleton, Tooltip } from '@chakra-ui/react'
 import type { Asset } from '@shapeshiftoss/types'
 import prettyMilliseconds from 'pretty-ms'
 import { useMemo } from 'react'
@@ -55,6 +55,10 @@ export const TradeQuoteContent = ({
     return parsedValue !== 0
   }, [quoteDifferenceDecimalPercentage, toPercent])
 
+  const percentageDifferenceTooltipText = useMemo(() => {
+    return translate('trade.percentageDifferenceTooltip', { buyAssetSymbol: buyAsset.symbol })
+  }, [buyAsset, translate])
+
   return (
     <>
       <CardBody py={2} px={4} display='flex' alignItems='center' justifyContent='space-between'>
@@ -63,19 +67,23 @@ export const TradeQuoteContent = ({
             <Skeleton isLoaded={!isLoading}>
               <Amount.Crypto
                 value={hasAmountWithPositiveReceive ? totalReceiveAmountCryptoPrecision : '0'}
-                symbol={buyAsset?.symbol ?? ''}
+                symbol={buyAsset.symbol}
                 fontSize='xl'
                 lineHeight={1}
               />
             </Skeleton>
             {!isBest && hasAmountWithPositiveReceive && shouldRenderPercentageDiff && (
               <Skeleton isLoaded={!isLoading}>
-                <Amount.Percent
-                  value={quoteDifferenceDecimalPercentage ?? 0}
-                  prefix='('
-                  suffix=')'
-                  autoColor
-                />
+                <Tooltip label={percentageDifferenceTooltipText}>
+                  <Box>
+                    <Amount.Percent
+                      value={quoteDifferenceDecimalPercentage ?? 0}
+                      prefix='('
+                      suffix=')'
+                      autoColor
+                    />
+                  </Box>
+                </Tooltip>
               </Skeleton>
             )}
           </Flex>


### PR DESCRIPTION
## Description

Fixes completely incorrect percentage difference values on quotes:
1. should not show 0.00% differences
2. should show the percentage difference between rendered receive amounts on quotes

## Pull Request Type

- [x] :bug: Bug fix (Non-breaking Change: Fixes an issue)
- [ ] :hammer_and_wrench: Chore (Non-breaking Change: Doc updates, pkg upgrades, typos, etc..)
- [ ] :nail_care: New Feature (Breaking/Non-breaking Change)

## Issue (if applicable)

NA

## Risk
> High Risk PRs Require 2 approvals

Low risk as this was broken to start with.

## Testing

Check that the reported percentage differences are correct compared to the best quote.

### Engineering

<!-----------------------------------------------------------------------------
Include sufficient information here for an engineer to test your PR. This may include how to test locally, in a built environment, changes to infrastructure etc.
------------------------------------------------------------------------------>

### Operations

<!-----------------------------------------------------------------------------
If your changes have a user-facing impact, describe how a non-technical QA team can functionally test your changes in a preview environment.

If they are not user-facing please describe how to test for any regressions that may occur.
------------------------------------------------------------------------------>

## Screenshots (if applicable)

Develop:
![image](https://github.com/shapeshift/web/assets/125113430/f166069a-f8d2-40fe-9479-4b9567a3e2d5)

This PR:
![image](https://github.com/shapeshift/web/assets/125113430/d4d4ba29-1b7d-4288-876d-d704098b1477)

