### PR TITLE
fix: lp data on refresh/direct navigation

### DIFF
--- a/src/pages/ThorChainLP/queries/hooks/useUserLpData.ts
+++ b/src/pages/ThorChainLP/queries/hooks/useUserLpData.ts
@@ -106,7 +106,7 @@ export const useUserLpData = ({
     ...reactQueries.thorchainLp.userLpData(assetId),
     staleTime: Infinity,
     queryFn: async ({ queryKey }) => {
-      const [, , assetId] = queryKey
+      const [, , , { assetId }] = queryKey
 
       const allPositions = (
         await Promise.all(


### PR DESCRIPTION
## Description

Fixes `liquidityProviderPosition`'s `assetId` key, which was passed a hardcoded string instead of the assetId.

## Pull Request Type

- [x] :bug: Bug fix (Non-breaking Change: Fixes an issue)
- [ ] :hammer_and_wrench: Chore (Non-breaking Change: Doc updates, pkg upgrades, typos, etc..)
- [ ] :nail_care: New Feature (Breaking/Non-breaking Change)

## Issue (if applicable)

Closes https://github.com/shapeshift/web/issues/6091

## Risk

Small - change is behind a feature flag.

## Testing

Navigating directly to an LP position (e.g. `/pools/poolAccount/eip155:43114:0x32dbc9cf9e8fbcebe1e0a2ecf05ed86ca3096cb6/eip155:43114%2Fslip44:60*asset`) is great again.

### Engineering

☝️

### Operations

N/A

## Screenshots (if applicable)

N/A