### PR TITLE
feat: lp UI & UX improvements

### DIFF
--- a/src/pages/ThorChainLP/components/AddLiquitity/AddLiquidityInput.tsx
+++ b/src/pages/ThorChainLP/components/AddLiquitity/AddLiquidityInput.tsx
@@ -294,7 +294,7 @@ export const AddLiquidityInput: React.FC<AddLiquidityInputProps> = ({
   }, [isAsymRuneSide, isAsymAssetSide, virtualRuneFiatLiquidityAmount])
 
   const [slippageRune, setSlippageRune] = useState<string | undefined>()
-  const [isEstimateLoading, setIsEstimateLoading] = useState(false)
+  const [isSlippageLoading, setIsSlippageLoading] = useState(false)
   const [shareOfPoolDecimalPercent, setShareOfPoolDecimalPercent] = useState<string | undefined>()
 
   const assetBalanceFilter = useMemo(
@@ -393,7 +393,7 @@ export const AddLiquidityInput: React.FC<AddLiquidityInputProps> = ({
         outputExponent: THOR_PRECISION,
       }).toFixed()
 
-      setIsEstimateLoading(true)
+      setIsSlippageLoading(true)
 
       const estimate = await estimateAddThorchainLiquidityPosition({
         runeAmountCryptoThorPrecision,
@@ -401,7 +401,7 @@ export const AddLiquidityInput: React.FC<AddLiquidityInputProps> = ({
         assetId: asset.assetId,
       })
 
-      setIsEstimateLoading(false)
+      setIsSlippageLoading(false)
 
       setSlippageRune(
         bnOrZero(estimate.slipPercent)
@@ -642,7 +642,7 @@ export const AddLiquidityInput: React.FC<AddLiquidityInputProps> = ({
             assetId={asset.assetId}
             runePerAsset={runePerAsset}
             shareOfPoolDecimalPercent={shareOfPoolDecimalPercent}
-            isLoading={isEstimateLoading}
+            isLoading={isSlippageLoading}
           />
         </Collapse>
       </Stack>
@@ -658,7 +658,7 @@ export const AddLiquidityInput: React.FC<AddLiquidityInputProps> = ({
         <Row fontSize='sm' fontWeight='medium'>
           <Row.Label>{translate('common.slippage')}</Row.Label>
           <Row.Value>
-            <Skeleton isLoaded={!isEstimateLoading}>
+            <Skeleton isLoaded={!isSlippageLoading}>
               <Amount.Crypto value={slippageRune ?? ''} symbol={rune.symbol} />
             </Skeleton>
           </Row.Value>

--- a/src/pages/ThorChainLP/components/AddLiquitity/AddLiquidityInput.tsx
+++ b/src/pages/ThorChainLP/components/AddLiquitity/AddLiquidityInput.tsx
@@ -614,6 +614,13 @@ export const AddLiquidityInput: React.FC<AddLiquidityInputProps> = ({
 
   if (!foundPool || !asset || !rune) return null
 
+  const hasUserEnteredValue = !!(
+    virtualAssetCryptoLiquidityAmount &&
+    virtualAssetFiatLiquidityAmount &&
+    virtualRuneCryptoLiquidityAmount &&
+    virtualRuneFiatLiquidityAmount
+  )
+
   return (
     <SlideTransition>
       {renderHeader}
@@ -630,7 +637,7 @@ export const AddLiquidityInput: React.FC<AddLiquidityInputProps> = ({
           />
           {tradeAssetInputs}
         </Stack>
-        <Collapse in={true}>
+        <Collapse in={hasUserEnteredValue}>
           <PoolSummary
             assetId={asset.assetId}
             runePerAsset={runePerAsset}

--- a/src/pages/ThorChainLP/components/AddLiquitity/AddLiquidityInput.tsx
+++ b/src/pages/ThorChainLP/components/AddLiquitity/AddLiquidityInput.tsx
@@ -504,6 +504,7 @@ export const AddLiquidityInput: React.FC<AddLiquidityInputProps> = ({
 
           return (
             <TradeAssetInput
+              key={_asset.assetId}
               assetId={_asset?.assetId}
               assetIcon={_asset?.icon ?? ''}
               assetSymbol={_asset?.symbol ?? ''}

--- a/src/pages/ThorChainLP/components/AddLiquitity/AddLiquidityInput.tsx
+++ b/src/pages/ThorChainLP/components/AddLiquitity/AddLiquidityInput.tsx
@@ -586,15 +586,20 @@ export const AddLiquidityInput: React.FC<AddLiquidityInputProps> = ({
     (asymSide: string | null) => {
       if (!(parsedPools && asset)) return
 
-      // The null option gets casted as an empty string by the radio component so we cast it back to null
-      const parsedAsymSide = (asymSide as AsymSide | '') || null
+      const parsedAsymSide = asymSide as AsymSide | 'sym'
+
+      if (parsedAsymSide === 'sym') {
+        setActiveOpportunityId(defaultOpportunityId)
+        return
+      }
+
       const assetPools = parsedPools.filter(pool => pool.assetId === asset.assetId)
       const foundPool = assetPools.find(pool => pool.asymSide === parsedAsymSide)
       if (!foundPool) return
 
       setActiveOpportunityId(foundPool.opportunityId)
     },
-    [asset, parsedPools],
+    [asset, defaultOpportunityId, parsedPools],
   )
 
   if (!foundPool || !asset || !rune) return null

--- a/src/pages/ThorChainLP/components/AddLiquitity/AddLiquidityInput.tsx
+++ b/src/pages/ThorChainLP/components/AddLiquitity/AddLiquidityInput.tsx
@@ -294,6 +294,7 @@ export const AddLiquidityInput: React.FC<AddLiquidityInputProps> = ({
   }, [isAsymRuneSide, isAsymAssetSide, virtualRuneFiatLiquidityAmount])
 
   const [slippageRune, setSlippageRune] = useState<string | undefined>()
+  const [isEstimateLoading, setIsEstimateLoading] = useState(false)
   const [shareOfPoolDecimalPercent, setShareOfPoolDecimalPercent] = useState<string | undefined>()
 
   const assetBalanceFilter = useMemo(
@@ -388,11 +389,15 @@ export const AddLiquidityInput: React.FC<AddLiquidityInputProps> = ({
         outputExponent: THOR_PRECISION,
       }).toFixed()
 
+      setIsEstimateLoading(true)
+
       const estimate = await estimateAddThorchainLiquidityPosition({
         runeAmountCryptoThorPrecision,
         assetAmountCryptoThorPrecision,
         assetId: asset.assetId,
       })
+
+      setIsEstimateLoading(false)
 
       setSlippageRune(
         bnOrZero(estimate.slipPercent)
@@ -625,6 +630,7 @@ export const AddLiquidityInput: React.FC<AddLiquidityInputProps> = ({
             assetId={asset.assetId}
             runePerAsset={runePerAsset}
             shareOfPoolDecimalPercent={shareOfPoolDecimalPercent}
+            isLoading={isEstimateLoading}
           />
         </Collapse>
       </Stack>
@@ -640,8 +646,8 @@ export const AddLiquidityInput: React.FC<AddLiquidityInputProps> = ({
         <Row fontSize='sm' fontWeight='medium'>
           <Row.Label>{translate('common.slippage')}</Row.Label>
           <Row.Value>
-            <Skeleton isLoaded={true}>
-              <Amount.Crypto value={slippageRune ?? 'TODO - loading'} symbol={rune.symbol} />
+            <Skeleton isLoaded={!isEstimateLoading}>
+              <Amount.Crypto value={slippageRune ?? ''} symbol={rune.symbol} />
             </Skeleton>
           </Row.Value>
         </Row>

--- a/src/pages/ThorChainLP/components/AddLiquitity/AddLiquidityInput.tsx
+++ b/src/pages/ThorChainLP/components/AddLiquitity/AddLiquidityInput.tsx
@@ -361,12 +361,16 @@ export const AddLiquidityInput: React.FC<AddLiquidityInputProps> = ({
           setVirtualRuneCryptoLiquidityAmount(crypto)
           setVirtualRuneFiatLiquidityAmount(fiat)
           setVirtualAssetFiatLiquidityAmount(fiat)
-          setVirtualAssetCryptoLiquidityAmount(bn(crypto).div(bnOrZero(runePerAsset)).toFixed())
+          setVirtualAssetCryptoLiquidityAmount(
+            bnOrZero(crypto).div(bnOrZero(runePerAsset)).toFixed(),
+          )
         } else if (!isRune && bnOrZero(runePerAsset).isGreaterThan(0)) {
           setVirtualAssetCryptoLiquidityAmount(crypto)
           setVirtualAssetFiatLiquidityAmount(fiat)
           setVirtualRuneFiatLiquidityAmount(fiat)
-          setVirtualRuneCryptoLiquidityAmount(bn(crypto).times(bnOrZero(runePerAsset)).toFixed())
+          setVirtualRuneCryptoLiquidityAmount(
+            bnOrZero(crypto).times(bnOrZero(runePerAsset)).toFixed(),
+          )
         }
       }
     },

--- a/src/pages/ThorChainLP/components/AddLiquitity/components/PoolSummary.tsx
+++ b/src/pages/ThorChainLP/components/AddLiquitity/components/PoolSummary.tsx
@@ -1,4 +1,4 @@
-import { Stack } from '@chakra-ui/react'
+import { Skeleton, Stack } from '@chakra-ui/react'
 import type { AssetId } from '@shapeshiftoss/caip'
 import { useTranslate } from 'react-polyglot'
 import { Amount } from 'components/Amount/Amount'
@@ -11,12 +11,14 @@ type PoolSummaryProps = {
   assetId: AssetId
   runePerAsset: string | undefined
   shareOfPoolDecimalPercent: string | undefined
+  isLoading: boolean
 }
 
 export const PoolSummary = ({
   assetId,
   runePerAsset,
   shareOfPoolDecimalPercent,
+  isLoading,
 }: PoolSummaryProps) => {
   const translate = useTranslate()
   const asset = useAppSelector(state => selectAssetById(state, assetId))
@@ -31,13 +33,17 @@ export const PoolSummary = ({
           {translate('pools.pricePerAsset', { from: 'RUNE', to: asset.symbol })}
         </Row.Label>
         <Row.Value>
-          <Amount value={runePerAsset} />
+          <Skeleton isLoaded={!isLoading}>
+            <Amount value={runePerAsset} />
+          </Skeleton>
         </Row.Value>
       </Row>
       <Row>
         <Row.Label>{translate('pools.shareOfPool')}</Row.Label>
         <Row.Value>
-          <Amount.Percent value={shareOfPoolDecimalPercent ?? '0'} />
+          <Skeleton isLoaded={!isLoading}>
+            <Amount.Percent value={shareOfPoolDecimalPercent ?? '0'} />
+          </Skeleton>
         </Row.Value>
       </Row>
     </Stack>

--- a/src/pages/ThorChainLP/components/LpType.tsx
+++ b/src/pages/ThorChainLP/components/LpType.tsx
@@ -96,7 +96,7 @@ export const LpType = ({ assetId, defaultOpportunityId, onAsymSideChange }: Depo
 
   const { getRootProps, getRadioProps } = useRadioGroup({
     name: 'depositType',
-    defaultValue: 'one',
+    defaultValue: 'sym',
     onChange: onAsymSideChange,
   })
 

--- a/src/pages/ThorChainLP/components/LpType.tsx
+++ b/src/pages/ThorChainLP/components/LpType.tsx
@@ -66,10 +66,10 @@ const options = [
     value: AsymSide.Asset,
   },
   {
-    value: AsymSide.Rune,
+    value: null,
   },
   {
-    value: null,
+    value: AsymSide.Rune,
   },
 ]
 

--- a/src/pages/ThorChainLP/components/LpType.tsx
+++ b/src/pages/ThorChainLP/components/LpType.tsx
@@ -66,7 +66,7 @@ const options = [
     value: AsymSide.Asset,
   },
   {
-    value: null,
+    value: 'sym',
   },
   {
     value: AsymSide.Rune,
@@ -84,8 +84,8 @@ export const LpType = ({ assetId, defaultOpportunityId, onAsymSideChange }: Depo
   }, [assetId])
 
   const makeAssetIdsOption = useCallback(
-    (value: AsymSide | null): AssetId[] => {
-      if (value === null) return assetIds
+    (value: AsymSide | 'sym'): AssetId[] => {
+      if (value === 'sym') return assetIds
       if (value === AsymSide.Rune) return [thorchainAssetId]
       if (value === AsymSide.Asset) return [assetId]
 
@@ -106,7 +106,7 @@ export const LpType = ({ assetId, defaultOpportunityId, onAsymSideChange }: Depo
     return _options.map((option, index) => {
       const radio = getRadioProps({ value: option.value })
 
-      const optionAssetIds = makeAssetIdsOption(option.value)
+      const optionAssetIds = makeAssetIdsOption(option.value as AsymSide | 'sym')
       return (
         <TypeRadio key={`type-${index}`} {...radio}>
           <PoolIcon assetIds={optionAssetIds} size='xs' />

--- a/src/pages/ThorChainLP/components/RemoveLiquidity/RemoveLiquidityInput.tsx
+++ b/src/pages/ThorChainLP/components/RemoveLiquidity/RemoveLiquidityInput.tsx
@@ -199,6 +199,7 @@ export const RemoveLiquidityInput: React.FC<RemoveLiquidityProps> = ({
         {assets.map(_asset => {
           return (
             <TradeAssetInput
+              key={_asset.assetId}
               assetId={_asset?.assetId}
               assetIcon={_asset?.icon ?? ''}
               assetSymbol={_asset?.symbol ?? ''}


### PR DESCRIPTION
## Description

This PR makes a number of improvements to the LP UI and UX:

- Moves the symmetrical radio box to be the middle option, with each asymmetrical option now on either side of it
- Fixes the symmetrical radio box highlighting so that it can now be checked (selected with a border) and is set as the default option on component load
- Adds loading skeletons for consumers of the async `estimateAddThorchainLiquidityPosition` function
- Fixes "NaN" from rendering when the opposite crypto field when the input amount is removed (i.e. becomes an empty string)
- Adds keys to `TradeAssetInput` to clean up console sadness when rendering `AddLiquidityInput` and `RemoveLiquidityInput`
- Hides `PoolSummary` when no input value is entered

## Pull Request Type

- [ ] :bug: Bug fix (Non-breaking Change: Fixes an issue)
- [ ] :hammer_and_wrench: Chore (Non-breaking Change: Doc updates, pkg upgrades, typos, etc..)
- [x] :nail_care: New Feature (Breaking/Non-breaking Change)

## Issue (if applicable)

Broadly contributes to https://github.com/shapeshift/web/issues/5940

## Risk

Small risk to the LP deposit/withdraw functionality with respect to selecting symmetrical and asymmetrical positions.

## Testing

Sanity check out of the dot points above, and the changes resulting in their implementation.

### Engineering

☝️

### Operations

N/A

## Screenshots (if applicable)

N/A