### PR TITLE
fix: dont nuke trade input state when backing out of a trade preview

### DIFF
--- a/src/components/MultiHopTrade/components/MultiHopTradeConfirm/MultiHopTradeConfirm.tsx
+++ b/src/components/MultiHopTrade/components/MultiHopTradeConfirm/MultiHopTradeConfirm.tsx
@@ -5,7 +5,6 @@ import { WithBackButton } from 'components/MultiHopTrade/components/WithBackButt
 import { TradeRoutePaths } from 'components/MultiHopTrade/types'
 import { SlideTransition } from 'components/SlideTransition'
 import { Text } from 'components/Text'
-import { tradeInput as swappersSlice } from 'state/slices/tradeInputSlice/tradeInputSlice'
 import { selectTradeExecutionState } from 'state/slices/tradeQuoteSlice/selectors'
 import { tradeQuoteSlice } from 'state/slices/tradeQuoteSlice/tradeQuoteSlice'
 import { TradeExecutionState } from 'state/slices/tradeQuoteSlice/types'
@@ -33,7 +32,6 @@ export const MultiHopTradeConfirm = memo(() => {
   }, [dispatch, isLoading])
 
   const handleBack = useCallback(() => {
-    dispatch(swappersSlice.actions.clear())
     dispatch(tradeQuoteSlice.actions.clear())
     history.push(TradeRoutePaths.Input)
   }, [dispatch, history])

--- a/src/components/MultiHopTrade/components/TradeAmountInput.tsx
+++ b/src/components/MultiHopTrade/components/TradeAmountInput.tsx
@@ -24,7 +24,6 @@ import { Amount } from 'components/Amount/Amount'
 import { Balance } from 'components/DeFi/components/Balance'
 import { PercentOptionsButtonGroup } from 'components/DeFi/components/PercentOptionsButtonGroup'
 import { useLocaleFormatter } from 'hooks/useLocaleFormatter/useLocaleFormatter'
-import { useToggle } from 'hooks/useToggle/useToggle'
 import { bnOrZero } from 'lib/bignumber/bignumber'
 import { colors } from 'theme/colors'
 
@@ -81,6 +80,8 @@ export type TradeAmountInputProps = {
   hideAmounts?: boolean
   layout?: 'inline' | 'stacked'
   isAccountSelectionDisabled?: boolean
+  isInputtingFiatSellAmount?: boolean
+  handleIsInputtingFiatSellAmountChange?: (isInputtingFiatSellAmount: boolean) => void
 } & PropsWithChildren
 
 const defaultPercentOptions = [0.25, 0.5, 0.75, 1]
@@ -113,13 +114,14 @@ export const TradeAmountInput: React.FC<TradeAmountInputProps> = memo(
     labelPostFix,
     hideAmounts,
     layout = 'stacked',
+    isInputtingFiatSellAmount: isFiat,
+    handleIsInputtingFiatSellAmountChange,
   }) => {
     const {
       number: { localeParts },
     } = useLocaleFormatter()
     const translate = useTranslate()
     const amountRef = useRef<string | null>(null)
-    const [isFiat, toggleIsFiat] = useToggle(false)
     const [isFocused, setIsFocused] = useState(false)
     const borderColor = useColorModeValue('blackAlpha.100', 'whiteAlpha.100')
     const bgColor = useColorModeValue('white', 'gray.850')
@@ -155,6 +157,10 @@ export const TradeAmountInput: React.FC<TradeAmountInputProps> = memo(
       amountRef.current = values.value
     }, [])
 
+    const toggleIsFiat = useCallback(() => {
+      handleIsInputtingFiatSellAmountChange?.(!isFiat)
+    }, [handleIsInputtingFiatSellAmountChange, isFiat])
+
     const oppositeCurrency = useMemo(() => {
       return isFiat ? (
         <Amount.Crypto value={cryptoAmount ?? ''} symbol={assetSymbol} />
@@ -177,7 +183,7 @@ export const TradeAmountInput: React.FC<TradeAmountInputProps> = memo(
       [assetSymbol, balance, fiatBalance, isFiat, translate],
     )
 
-    const handleOnMaxClick = useMemo(() => () => onMaxClick(isFiat), [isFiat, onMaxClick])
+    const handleOnMaxClick = useMemo(() => () => onMaxClick(Boolean(isFiat)), [isFiat, onMaxClick])
 
     return (
       <FormControl

--- a/src/components/MultiHopTrade/components/TradeInput/components/SellAssetInput.tsx
+++ b/src/components/MultiHopTrade/components/TradeInput/components/SellAssetInput.tsx
@@ -1,11 +1,15 @@
 import type { AccountId } from '@shapeshiftoss/caip'
 import type { Asset } from '@shapeshiftoss/types'
-import { memo, useCallback, useEffect, useMemo, useState } from 'react'
+import { memo, useCallback } from 'react'
 import type { AccountDropdownProps } from 'components/AccountDropdown/AccountDropdown'
 import type { TradeAssetInputProps } from 'components/MultiHopTrade/components/TradeAssetInput'
 import { TradeAssetInput } from 'components/MultiHopTrade/components/TradeAssetInput'
 import { bnOrZero, positiveOrZero } from 'lib/bignumber/bignumber'
-import { selectMarketDataByFilter } from 'state/slices/selectors'
+import {
+  selectInputSellAmountCryptoPrecision,
+  selectInputSellAmountUserCurrency,
+  selectMarketDataByFilter,
+} from 'state/slices/selectors'
 import { tradeInput } from 'state/slices/tradeInputSlice/tradeInputSlice'
 import { useAppDispatch, useAppSelector } from 'state/store'
 
@@ -29,8 +33,9 @@ export const SellAssetInput = memo(
     percentOptions,
     ...rest
   }: SellAssetInputProps) => {
-    const [sellAmountUserCurrencyHuman, setSellAmountUserCurrencyHuman] = useState('0')
-    const [sellAmountCryptoPrecision, setSellAmountCryptoPrecision] = useState('0')
+    const sellAmountCryptoPrecision = useAppSelector(selectInputSellAmountCryptoPrecision)
+    const sellAmountUserCurrency = useAppSelector(selectInputSellAmountUserCurrency)
+
     const dispatch = useAppDispatch()
 
     const { price: sellAssetUserCurrencyRate } = useAppSelector(state =>
@@ -40,10 +45,7 @@ export const SellAssetInput = memo(
     // this is separated from handleSellAssetInputChange to prevent resetting the input value to 0
     // when the market data changes between keystrokes
     const handleSellAssetInputChangeInner = useCallback(
-      (sellAmountUserCurrencyHuman: string, sellAmountCryptoPrecision: string) => {
-        setSellAmountUserCurrencyHuman(sellAmountUserCurrencyHuman)
-        setSellAmountCryptoPrecision(sellAmountCryptoPrecision)
-
+      (sellAmountCryptoPrecision: string) => {
         dispatch(
           tradeInput.actions.setSellAmountCryptoPrecision(
             positiveOrZero(sellAmountCryptoPrecision).toString(),
@@ -55,32 +57,13 @@ export const SellAssetInput = memo(
 
     const handleSellAssetInputChange = useCallback(
       (value: string, isFiat: boolean | undefined) => {
-        const sellAmountUserCurrencyHuman = isFiat
-          ? value
-          : bnOrZero(value).times(sellAssetUserCurrencyRate).toFixed(2)
         const sellAmountCryptoPrecision = isFiat
           ? bnOrZero(value).div(sellAssetUserCurrencyRate).toFixed()
           : value
-        handleSellAssetInputChangeInner(sellAmountUserCurrencyHuman, sellAmountCryptoPrecision)
+        handleSellAssetInputChangeInner(sellAmountCryptoPrecision)
       },
       [handleSellAssetInputChangeInner, sellAssetUserCurrencyRate],
     )
-
-    // reset the input value to 0 when the asset changes
-    useEffect(() => {
-      handleSellAssetInputChangeInner('0', '0')
-    }, [asset, handleSellAssetInputChangeInner])
-
-    // Allow decimals to be entered in the form of . as the first character
-    const cryptoAmount = useMemo(() => {
-      if (sellAmountCryptoPrecision === '.') return sellAmountCryptoPrecision
-      return positiveOrZero(sellAmountCryptoPrecision).toString()
-    }, [sellAmountCryptoPrecision])
-
-    const fiatAmount = useMemo(() => {
-      if (sellAmountUserCurrencyHuman === '.') return sellAmountUserCurrencyHuman
-      return positiveOrZero(sellAmountUserCurrencyHuman).toString()
-    }, [sellAmountUserCurrencyHuman])
 
     return (
       <TradeAssetInput
@@ -88,8 +71,8 @@ export const SellAssetInput = memo(
         assetId={asset.assetId}
         assetSymbol={asset.symbol}
         assetIcon={asset.icon}
-        cryptoAmount={cryptoAmount}
-        fiatAmount={fiatAmount}
+        cryptoAmount={sellAmountCryptoPrecision}
+        fiatAmount={sellAmountUserCurrency}
         isSendMaxDisabled={false}
         onChange={handleSellAssetInputChange}
         percentOptions={percentOptions}

--- a/src/components/MultiHopTrade/components/TradeInput/components/SellAssetInput.tsx
+++ b/src/components/MultiHopTrade/components/TradeInput/components/SellAssetInput.tsx
@@ -8,6 +8,7 @@ import { bnOrZero, positiveOrZero } from 'lib/bignumber/bignumber'
 import {
   selectInputSellAmountCryptoPrecision,
   selectInputSellAmountUserCurrency,
+  selectIsInputtingFiatSellAmount,
   selectMarketDataByFilter,
 } from 'state/slices/selectors'
 import { tradeInput } from 'state/slices/tradeInputSlice/tradeInputSlice'
@@ -35,6 +36,7 @@ export const SellAssetInput = memo(
   }: SellAssetInputProps) => {
     const sellAmountCryptoPrecision = useAppSelector(selectInputSellAmountCryptoPrecision)
     const sellAmountUserCurrency = useAppSelector(selectInputSellAmountUserCurrency)
+    const isInputtingFiatSellAmount = useAppSelector(selectIsInputtingFiatSellAmount)
 
     const dispatch = useAppDispatch()
 
@@ -65,6 +67,13 @@ export const SellAssetInput = memo(
       [handleSellAssetInputChangeInner, sellAssetUserCurrencyRate],
     )
 
+    const handleIsInputtingFiatSellAmountChange = useCallback(
+      (isInputtingFiatSellAmount: boolean) => {
+        dispatch(tradeInput.actions.setIsInputtingFiatSellAmount(isInputtingFiatSellAmount))
+      },
+      [dispatch],
+    )
+
     return (
       <TradeAssetInput
         accountId={accountId}
@@ -73,6 +82,8 @@ export const SellAssetInput = memo(
         assetIcon={asset.icon}
         cryptoAmount={sellAmountCryptoPrecision}
         fiatAmount={sellAmountUserCurrency}
+        isInputtingFiatSellAmount={isInputtingFiatSellAmount}
+        handleIsInputtingFiatSellAmountChange={handleIsInputtingFiatSellAmountChange}
         isSendMaxDisabled={false}
         onChange={handleSellAssetInputChange}
         percentOptions={percentOptions}

--- a/src/state/slices/tradeInputSlice/selectors.ts
+++ b/src/state/slices/tradeInputSlice/selectors.ts
@@ -194,3 +194,8 @@ export const selectSellAssetBalanceCryptoBaseUnit = createSelector(
     }),
   sellAssetBalanceCryptoBaseUnit => sellAssetBalanceCryptoBaseUnit,
 )
+
+export const selectIsInputtingFiatSellAmount = createSelector(
+  selectTradeInput,
+  tradeInput => tradeInput.isInputtingFiatSellAmount,
+)

--- a/src/state/slices/tradeInputSlice/selectors.ts
+++ b/src/state/slices/tradeInputSlice/selectors.ts
@@ -166,6 +166,15 @@ export const selectInputSellAmountUsd = createSelector(
   },
 )
 
+export const selectInputSellAmountUserCurrency = createSelector(
+  selectInputSellAmountCryptoPrecision,
+  selectInputSellAssetUserCurrencyRate,
+  (sellAmountCryptoPrecision, sellAssetUserCurrencyRate) => {
+    if (!sellAssetUserCurrencyRate) return
+    return bn(sellAmountCryptoPrecision).times(sellAssetUserCurrencyRate).toFixed()
+  },
+)
+
 export const selectSellAssetBalanceFilter = createSelector(
   selectFirstHopSellAccountId,
   selectInputSellAsset,

--- a/src/state/slices/tradeInputSlice/tradeInputSlice.ts
+++ b/src/state/slices/tradeInputSlice/tradeInputSlice.ts
@@ -78,6 +78,7 @@ export const tradeInput = createSlice({
       const buyAsset = state.sellAsset
       state.sellAsset = state.buyAsset
       state.buyAsset = buyAsset
+      state.sellAmountCryptoPrecision = '0'
     },
     setManualReceiveAddress: (state, action: PayloadAction<string | undefined>) => {
       state.manualReceiveAddress = action.payload

--- a/src/state/slices/tradeInputSlice/tradeInputSlice.ts
+++ b/src/state/slices/tradeInputSlice/tradeInputSlice.ts
@@ -14,6 +14,7 @@ export type TradeInputState = {
   sellAssetAccountId: AccountId | undefined
   buyAssetAccountId: AccountId | undefined
   sellAmountCryptoPrecision: string
+  isInputtingFiatSellAmount: boolean
   manualReceiveAddress: string | undefined
   manualReceiveAddressIsValidating: boolean
   manualReceiveAddressIsEditing: boolean
@@ -28,6 +29,7 @@ const initialState: TradeInputState = {
   sellAssetAccountId: undefined,
   buyAssetAccountId: undefined,
   sellAmountCryptoPrecision: '0',
+  isInputtingFiatSellAmount: false,
   manualReceiveAddress: undefined,
   manualReceiveAddressIsValidating: false,
   manualReceiveAddressIsValid: undefined,
@@ -91,6 +93,9 @@ export const tradeInput = createSlice({
     },
     setSlippagePreferencePercentage: (state, action: PayloadAction<string | undefined>) => {
       state.slippagePreferencePercentage = action.payload
+    },
+    setIsInputtingFiatSellAmount: (state, action: PayloadAction<boolean>) => {
+      state.isInputtingFiatSellAmount = action.payload
     },
   },
 })

--- a/src/state/slices/tradeInputSlice/tradeInputSlice.ts
+++ b/src/state/slices/tradeInputSlice/tradeInputSlice.ts
@@ -57,6 +57,9 @@ export const tradeInput = createSlice({
       const isSameAsBuyAsset = asset.assetId === state.buyAsset.assetId
       if (isSameAsBuyAsset) state.buyAsset = state.sellAsset
 
+      // clear the sell amount
+      state.sellAmountCryptoPrecision = '0'
+
       state.sellAsset = action.payload
     },
     setSellAssetAccountNumber: (state, action: PayloadAction<AccountId | undefined>) => {

--- a/src/test/mocks/store.ts
+++ b/src/test/mocks/store.ts
@@ -175,6 +175,7 @@ export const mockStore: ReduxState = {
     sellAssetAccountId: undefined,
     buyAssetAccountId: undefined,
     sellAmountCryptoPrecision: '0',
+    isInputtingFiatSellAmount: false,
     manualReceiveAddress: undefined,
     manualReceiveAddressIsValidating: false,
     manualReceiveAddressIsEditing: false,


### PR DESCRIPTION
## Description

Prevents clearing trade input state when previewing a trade and clicking "back".

Includes changes to manage input sell amounts in redux.

## Pull Request Type

- [x] :bug: Bug fix (Non-breaking Change: Fixes an issue)
- [ ] :hammer_and_wrench: Chore (Non-breaking Change: Doc updates, pkg upgrades, typos, etc..)
- [ ] :nail_care: New Feature (Breaking/Non-breaking Change)

## Issue (if applicable)

closes #6109

## Risk
> High Risk PRs Require 2 approvals

Moderate risk as this changes the behavior of trade input state between routes for trade input/preview/execution.

> What protocols, transaction types or contract interactions might be affected by this PR?

All trades.

## Testing

Check trade input behaves as expected
Ensure clicking "back" when previewing a trade maintains the previous input state
Ensure there is no way of somehow executing a trade with stale quotes or incorrect input data

### Engineering

<!-----------------------------------------------------------------------------
Include sufficient information here for an engineer to test your PR. This may include how to test locally, in a built environment, changes to infrastructure etc.
------------------------------------------------------------------------------>

### Operations

<!-----------------------------------------------------------------------------
If your changes have a user-facing impact, describe how a non-technical QA team can functionally test your changes in a preview environment.

If they are not user-facing please describe how to test for any regressions that may occur.
------------------------------------------------------------------------------>

## Screenshots (if applicable)
