### PR TITLE
fix: missing NFTs in NFT tab

### DIFF
--- a/src/state/apis/nft/constants.ts
+++ b/src/state/apis/nft/constants.ts
@@ -41,8 +41,15 @@ const nftNameBlacklistRegex = new RegExp(
   NFT_NAME_BLACKLIST.map(term => term.replace(/[.*+?^${}()|[\]\\]/g, '\\$&')).join('|'),
   'i',
 )
-export const isSpammyNftText = (nftText: string) =>
-  nftText === '' || nftNameBlacklistRegex.test(nftText)
+export const isSpammyNftText = (nftText: string) => {
+  // TODO(gomes): since we iterate on collection description, NFT name, and NFT symbol running this check,
+  // one of the three with almost always be empty, resulting in it being wrongly flagged as spammy.
+  // We may want to revert this behavior if we can get more granular and only run this in specific cases
+  // const isEmptyText = nftText === ''
+  const isEmptyText = false
+  const isSpammyMatch = nftNameBlacklistRegex.test(nftText)
+  return isEmptyText || isSpammyMatch
+}
 export const isSpammyTokenText = (tokenText: string) =>
   TOKEN_TEXT_REGEX_BLACKLIST.some(regex => regex.test(tokenText))
 const isSpammyDomain = (domain: string) =>

--- a/src/state/apis/nft/nftApi.ts
+++ b/src/state/apis/nft/nftApi.ts
@@ -213,7 +213,11 @@ export const nftApi = createApi({
                 const { assetId } = item
                 if (item.collection.isSpam) return
                 if (hasSpammyMedias(item.medias)) return
-                if ([item.collection.description, item.name, item.symbol].some(isSpammyNftText))
+                if (
+                  [item.collection.description, item.collection.name, item.name, item.symbol].some(
+                    isSpammyNftText,
+                  )
+                )
                   return
                 const { assetReference, chainId } = fromAssetId(assetId)
 

--- a/src/state/migrations/index.ts
+++ b/src/state/migrations/index.ts
@@ -29,4 +29,7 @@ export const migrations = {
   20: clearTxHistory,
   21: clearAssets,
   22: clearTxHistory,
+  23: clearPortfolio,
+  24: clearTxHistory,
+  25: clearAssets,
 }


### PR DESCRIPTION
## Description

Makes the NFT tab great again. It is currently detecting all NFTs as spam.

## Pull Request Type

- [x] :bug: Bug fix (Non-breaking Change: Fixes an issue)
- [ ] :hammer_and_wrench: Chore (Non-breaking Change: Doc updates, pkg upgrades, typos, etc..)
- [ ] :nail_care: New Feature (Breaking/Non-breaking Change)

## Issue (if applicable)

<!-----------------------------------------------------------------------------
If applicable, please link to the github issue and put `closes #XXXX` in your comment to auto-close the issue that your PR fixes.
------------------------------------------------------------------------------>

N/A, spotted in https://github.com/shapeshift/web/pull/6118

## Risk
> High Risk PRs Require 2 approvals

<!-----------------------------------------------------------------------------
Outline the scope of your changes and the risk associated with them. You must use your discretion as an engineer to determine the potential impact of your changes.

WARNING: If your PR introduces a new on-chain transaction or modifies an existing one, please add the "High-Risk" label to this PR and ask for 2 reviewers to approve it before merging.

E.g. an upgrade to `hdwallet` or core state management would be considered higher risk, and might require a full regression test. UI or isolated view changes, or something behind a feature flag may have near zero risk. Small bug fixes might require testing isolated to the specific fix.
------------------------------------------------------------------------------>

Low, but now that we don't detect empty text as spammy anymore, Tx history / wallet NFTs may be a bit more spammy, give me a bit of a regression test

> What protocols, transaction types or contract interactions might be affected by this PR?

## Testing

<!-----------------------------------------------------------------------------
We treat every PR to be merged with the same scrutiny as if we were merging directly to production.

Your PR will not be merged if you do not complete the sections below for our engineering and operations teams to test.
------------------------------------------------------------------------------>

- Test both with demo wallet and frame-injected address of a known NFT degenerate fren
- NFTs in NFT tab are now happy and not too spammy
- Tx history / assets list still isn't too spammy

### Engineering

<!-----------------------------------------------------------------------------
Include sufficient information here for an engineer to test your PR. This may include how to test locally, in a built environment, changes to infrastructure etc.
------------------------------------------------------------------------------>

- ☝🏽 

### Operations

<!-----------------------------------------------------------------------------
If your changes have a user-facing impact, describe how a non-technical QA team can functionally test your changes in a preview environment.

If they are not user-facing please describe how to test for any regressions that may occur.
------------------------------------------------------------------------------>

- ☝🏽 

## Screenshots (if applicable)

### NFT Tab

- Develop

<img width="1428" alt="Screenshot 2024-02-02 at 14 18 31" src="https://github.com/shapeshift/web/assets/17035424/2ed3b336-59e1-4298-a48c-469a0a30465c">
<img width="1460" alt="Screenshot 2024-02-02 at 14 20 28" src="https://github.com/shapeshift/web/assets/17035424/2840186c-8371-42f0-9c62-00d48578c0c6">

- This diff

<img width="1456" alt="Screenshot 2024-02-02 at 14 18 12" src="https://github.com/shapeshift/web/assets/17035424/316c424e-928d-4ec0-8445-2db35c94caf6">
<img width="497" alt="Screenshot 2024-02-02 at 14 20 53" src="https://github.com/shapeshift/web/assets/17035424/6b51c131-ae4c-4500-bf81-2c2f27253bf2">

 ### Assets
 
 - Develop
 
<img width="1004" alt="image" src="https://github.com/shapeshift/web/assets/17035424/66eca4a0-31f0-4499-89ea-5d60f9633991">

- This diff

<img width="856" alt="image" src="https://github.com/shapeshift/web/assets/17035424/caa62085-b3b1-4bbb-aabe-d957eb6e2b01">

Note the additional N/A assets, which are not present in develop
