### PR TITLE
fix: synchronize buyAssetAccountId to sellAssetAccountNumber on swapper mount

### DIFF
--- a/src/components/MultiHopTrade/components/TradeInput/TradeInput.tsx
+++ b/src/components/MultiHopTrade/components/TradeInput/TradeInput.tsx
@@ -242,14 +242,18 @@ export const TradeInput = memo(() => {
     [isSnapshotApiQueriesPending, votingPower],
   )
 
-  const { sellAssetAccountId, buyAssetAccountId, setSellAssetAccountId, setBuyAssetAccountId } =
-    useAccountIds()
+  const {
+    sellAssetAccountId: initialSellAssetAccountId,
+    buyAssetAccountId: initialBuyAssetAccountId,
+    setSellAssetAccountId,
+    setBuyAssetAccountId,
+  } = useAccountIds()
 
   const userAddress = useMemo(() => {
-    if (!sellAssetAccountId) return ''
+    if (!initialSellAssetAccountId) return ''
 
-    return fromAccountId(sellAssetAccountId).account
-  }, [sellAssetAccountId])
+    return fromAccountId(initialSellAssetAccountId).account
+  }, [initialSellAssetAccountId])
 
   const { data: _isSmartContractAddress, isLoading: isAddressByteCodeLoading } =
     useIsSmartContractAddress(userAddress)
@@ -333,7 +337,7 @@ export const TradeInput = memo(() => {
         const isApprovalNeeded = await checkApprovalNeeded(
           tradeQuoteStep,
           wallet,
-          sellAssetAccountId ?? '',
+          initialSellAssetAccountId ?? '',
         )
 
         if (isApprovalNeeded) {
@@ -354,7 +358,7 @@ export const TradeInput = memo(() => {
     enableMultiHopTrades,
     history,
     mixpanel,
-    sellAssetAccountId,
+    initialSellAssetAccountId,
     showErrorToast,
     tradeQuoteStep,
     wallet,
@@ -609,7 +613,7 @@ export const TradeInput = memo(() => {
           </CardHeader>
           <Stack spacing={0}>
             <SellAssetInput
-              accountId={sellAssetAccountId}
+              accountId={initialSellAssetAccountId}
               asset={sellAsset}
               label={translate('trade.payWith')}
               onAccountIdChange={setSellAssetAccountId}
@@ -633,7 +637,7 @@ export const TradeInput = memo(() => {
             </Flex>
             <TradeAssetInput
               isReadOnly={true}
-              accountId={buyAssetAccountId}
+              accountId={initialBuyAssetAccountId}
               assetId={buyAsset.assetId}
               assetSymbol={buyAsset.symbol}
               assetIcon={buyAsset.icon}

--- a/src/components/MultiHopTrade/hooks/useAccountIds.tsx
+++ b/src/components/MultiHopTrade/hooks/useAccountIds.tsx
@@ -45,7 +45,7 @@ export const useAccountIds = (): {
     selectLastHopBuyAccountId(state, { accountId: maybeMatchingBuyAccountId }),
   )
 
-  // Setters - the selectors above only select a *default* value, but eventually onAccountIdChange may fire if the user changes the account
+  // Setters - the selectors above initially select a *default* value, but eventually onAccountIdChange may fire if the user changes the account
 
   const setSellAssetAccountId = useCallback(
     (accountId: AccountId | undefined) =>

--- a/src/components/MultiHopTrade/hooks/useGetTradeQuotes/useGetTradeQuotes.tsx
+++ b/src/components/MultiHopTrade/hooks/useGetTradeQuotes/useGetTradeQuotes.tsx
@@ -124,7 +124,10 @@ export const useGetTradeQuotes = () => {
   const isDebouncing = debouncedSellAmountCryptoPrecision !== sellAmountCryptoPrecision
 
   const sellAccountId = useAppSelector(selectFirstHopSellAccountId)
-  const buyAccountId = useAppSelector(selectLastHopBuyAccountId)
+  // No need to pass a sellAssetAccountId to synchronize the buy account here - by the time this is called, we already have a valid buyAccountId
+  const buyAccountId = useAppSelector(state =>
+    selectLastHopBuyAccountId(state, { accountId: undefined }),
+  )
 
   const userslippageTolerancePercentageDecimal = useAppSelector(selectUserSlippagePercentageDecimal)
 

--- a/src/components/MultiHopTrade/hooks/useReceiveAddress.tsx
+++ b/src/components/MultiHopTrade/hooks/useReceiveAddress.tsx
@@ -38,7 +38,10 @@ export const useReceiveAddress = ({
 
   // Selectors
   const buyAsset = useAppSelector(selectInputBuyAsset)
-  const buyAccountId = useAppSelector(selectLastHopBuyAccountId)
+  // No need to pass a sellAssetAccountId to synchronize the buy account here - by the time this is called, we already have a valid buyAccountId
+  const buyAccountId = useAppSelector(state =>
+    selectLastHopBuyAccountId(state, { accountId: undefined }),
+  )
   const buyAccountMetadata = useAppSelector(state =>
     selectPortfolioAccountMetadataByAccountId(state, { accountId: buyAccountId }),
   )

--- a/src/state/slices/tradeInputSlice/selectors.ts
+++ b/src/state/slices/tradeInputSlice/selectors.ts
@@ -4,6 +4,7 @@ import { bn } from 'lib/bignumber/bignumber'
 import { toBaseUnit } from 'lib/math'
 import type { ReduxState } from 'state/reducer'
 import { createDeepEqualOutputSelector } from 'state/selector-utils'
+import { selectAccountIdParamFromFilter } from 'state/selectors'
 
 import {
   selectPortfolioCryptoBalanceBaseUnitByFilter,
@@ -106,9 +107,12 @@ export const selectLastHopBuyAccountId = createSelector(
   selectInputBuyAsset,
   selectPortfolioAssetAccountBalancesSortedUserCurrency,
   selectWalletAccountIds,
-  (tradeInput, buyAsset, accountIdAssetValues, accountIds) => {
+  selectAccountIdParamFromFilter,
+  (tradeInput, buyAsset, accountIdAssetValues, accountIds, maybeMatchingBuyAccountId) => {
     // return the users selection if it exists
     if (tradeInput.buyAssetAccountId) return tradeInput.buyAssetAccountId
+    // an AccountId was found matching the sell asset's account number, return it
+    if (maybeMatchingBuyAccountId) return maybeMatchingBuyAccountId
 
     const highestFiatBalanceBuyAccountId = getHighestUserCurrencyBalanceAccountByAssetId(
       accountIdAssetValues,


### PR DESCRIPTION
## Description

Does what it says on the box - when the swapper originally mounts, the `buyAssetAccountId` should be synchronized with the `sellAssetAccountId`'s account number, *if* there is a matching account on that index on the buy side.

## Pull Request Type

- [x] :bug: Bug fix (Non-breaking Change: Fixes an issue)
- [ ] :hammer_and_wrench: Chore (Non-breaking Change: Doc updates, pkg upgrades, typos, etc..)
- [ ] :nail_care: New Feature (Breaking/Non-breaking Change)

## Issue (if applicable)

<!-----------------------------------------------------------------------------
If applicable, please link to the github issue and put `closes #XXXX` in your comment to auto-close the issue that your PR fixes.
------------------------------------------------------------------------------>

closes https://github.com/shapeshift/web/issues/6121

## Risk
> High Risk PRs Require 2 approvals

<!-----------------------------------------------------------------------------
Outline the scope of your changes and the risk associated with them. You must use your discretion as an engineer to determine the potential impact of your changes.

WARNING: If your PR introduces a new on-chain transaction or modifies an existing one, please add the "High-Risk" label to this PR and ask for 2 reviewers to approve it before merging.

E.g. an upgrade to `hdwallet` or core state management would be considered higher risk, and might require a full regression test. UI or isolated view changes, or something behind a feature flag may have near zero risk. Small bug fixes might require testing isolated to the specific fix.
------------------------------------------------------------------------------>

Theoretically low, effectively medium in terms of domain touched. While this technically brings back the behavior that was intended (see the removed/reworded comment), if we got this wrong, there is a risk of funds ending up in the wrong account

> What protocols, transaction types or contract interactions might be affected by this PR?

None

## Testing

<!-----------------------------------------------------------------------------
We treat every PR to be merged with the same scrutiny as if we were merging directly to production.

Your PR will not be merged if you do not complete the sections below for our engineering and operations teams to test.
------------------------------------------------------------------------------>

- Have a balance of buy asset that is higher on any 1+ account than on your 0th account
- On swapper original mount, ensure that the buy account number is matching the sell account number
- Ensure it is still possible to choose another account, both on the buy and the sell side, and that they do *not* synchronize after the original mount and synchronization

- Play around with account selection and ensure you're still getting quotes
- Ensure funds are landing in the right account

### Engineering

<!-----------------------------------------------------------------------------
Include sufficient information here for an engineer to test your PR. This may include how to test locally, in a built environment, changes to infrastructure etc.
------------------------------------------------------------------------------>

- ☝🏽 

### Operations

<!-----------------------------------------------------------------------------
If your changes have a user-facing impact, describe how a non-technical QA team can functionally test your changes in a preview environment.

If they are not user-facing please describe how to test for any regressions that may occur.
------------------------------------------------------------------------------>

- ☝🏽 

## Screenshots (if applicable)

### Default buy account

- Develop


https://github.com/shapeshift/web/assets/17035424/50e7c6c1-0b3b-4832-b936-99b010a5de6b

- This diff

https://github.com/shapeshift/web/assets/17035424/d746716a-1ad3-4702-91f9-fef6854963fa


### Quotes are happy, and funds are ending in the correct address


https://github.com/shapeshift/web/assets/17035424/0332ef2f-cb08-4a19-a88d-5d3c157ddbe4


