### PR TITLE
perf: lazy load all pages

### DIFF
--- a/src/Routes/Routes.tsx
+++ b/src/Routes/Routes.tsx
@@ -3,7 +3,7 @@ import type { Location } from 'history'
 import { lazy, memo, useCallback, useEffect, useMemo, useState } from 'react'
 import { useDispatch } from 'react-redux'
 import { matchPath, Redirect, Route, Switch, useLocation } from 'react-router-dom'
-import { makeSuspsenseful } from 'utils/makeSuspenseful'
+import { makeSuspenseful } from 'utils/makeSuspenseful'
 import { Layout } from 'components/Layout/Layout'
 import { useBrowserRouter } from 'hooks/useBrowserRouter/useBrowserRouter'
 import { useQuery } from 'hooks/useQuery/useQuery'
@@ -14,30 +14,30 @@ import { useAppSelector } from 'state/store'
 
 import { PrivateRoute } from './PrivateRoute'
 
-const Flags = makeSuspsenseful(
+const Flags = makeSuspenseful(
   lazy(() => import('pages/Flags/Flags').then(({ Flags }) => ({ default: Flags }))),
 )
-const Yat = makeSuspsenseful(
+const Yat = makeSuspenseful(
   lazy(() => import('pages/Yat/Yat').then(({ Yat }) => ({ default: Yat }))),
 )
-const NotFound = makeSuspsenseful(
+const NotFound = makeSuspenseful(
   lazy(() => import('pages/NotFound/NotFound').then(({ NotFound }) => ({ default: NotFound }))),
 )
-const ConnectWallet = makeSuspsenseful(
+const ConnectWallet = makeSuspenseful(
   lazy(() =>
     import('pages/ConnectWallet/ConnectWallet').then(({ ConnectWallet }) => ({
       default: ConnectWallet,
     })),
   ),
 )
-const TermsOfService = makeSuspsenseful(
+const TermsOfService = makeSuspenseful(
   lazy(() =>
     import('pages/Legal/TermsOfService').then(({ TermsOfService }) => ({
       default: TermsOfService,
     })),
   ),
 )
-const PrivacyPolicy = makeSuspsenseful(
+const PrivacyPolicy = makeSuspenseful(
   lazy(() =>
     import('pages/Legal/PrivacyPolicy').then(({ PrivacyPolicy }) => ({ default: PrivacyPolicy })),
   ),

--- a/src/Routes/Routes.tsx
+++ b/src/Routes/Routes.tsx
@@ -1,23 +1,35 @@
 import { LanguageTypeEnum } from 'constants/LanguageTypeEnum'
 import type { Location } from 'history'
-import { memo, useCallback, useEffect, useMemo, useState } from 'react'
+import { lazy, memo, useCallback, useEffect, useMemo, useState } from 'react'
 import { useDispatch } from 'react-redux'
 import { matchPath, Redirect, Route, Switch, useLocation } from 'react-router-dom'
 import { Layout } from 'components/Layout/Layout'
 import { useBrowserRouter } from 'hooks/useBrowserRouter/useBrowserRouter'
 import { useQuery } from 'hooks/useQuery/useQuery'
 import { useWallet } from 'hooks/useWallet/useWallet'
-import { ConnectWallet } from 'pages/ConnectWallet/ConnectWallet'
-import { Flags } from 'pages/Flags/Flags'
-import { PrivacyPolicy } from 'pages/Legal/PrivacyPolicy'
-import { TermsOfService } from 'pages/Legal/TermsOfService'
-import { NotFound } from 'pages/NotFound/NotFound'
-import { Yat } from 'pages/Yat/Yat'
 import { preferences } from 'state/slices/preferencesSlice/preferencesSlice'
 import { selectSelectedLocale } from 'state/slices/selectors'
 import { useAppSelector } from 'state/store'
 
 import { PrivateRoute } from './PrivateRoute'
+
+const Flags = lazy(() => import('pages/Flags/Flags').then(({ Flags }) => ({ default: Flags })))
+const Yat = lazy(() => import('pages/Yat/Yat').then(({ Yat }) => ({ default: Yat })))
+const NotFound = lazy(() =>
+  import('pages/NotFound/NotFound').then(({ NotFound }) => ({ default: NotFound })),
+)
+const ConnectWallet = lazy(() =>
+  import('pages/ConnectWallet/ConnectWallet').then(({ ConnectWallet }) => ({
+    default: ConnectWallet,
+  })),
+)
+const TermsOfService = lazy(() =>
+  import('pages/Legal/TermsOfService').then(({ TermsOfService }) => ({ default: TermsOfService })),
+)
+const PrivacyPolicy = lazy(() =>
+  import('pages/Legal/PrivacyPolicy').then(({ PrivacyPolicy }) => ({ default: PrivacyPolicy })),
+)
+
 export const Routes = memo(() => {
   const dispatch = useDispatch()
   const location = useLocation<{ background: Location }>()

--- a/src/Routes/Routes.tsx
+++ b/src/Routes/Routes.tsx
@@ -3,6 +3,7 @@ import type { Location } from 'history'
 import { lazy, memo, useCallback, useEffect, useMemo, useState } from 'react'
 import { useDispatch } from 'react-redux'
 import { matchPath, Redirect, Route, Switch, useLocation } from 'react-router-dom'
+import { makeSuspsenseful } from 'utils/makeSuspenseful'
 import { Layout } from 'components/Layout/Layout'
 import { useBrowserRouter } from 'hooks/useBrowserRouter/useBrowserRouter'
 import { useQuery } from 'hooks/useQuery/useQuery'
@@ -13,21 +14,33 @@ import { useAppSelector } from 'state/store'
 
 import { PrivateRoute } from './PrivateRoute'
 
-const Flags = lazy(() => import('pages/Flags/Flags').then(({ Flags }) => ({ default: Flags })))
-const Yat = lazy(() => import('pages/Yat/Yat').then(({ Yat }) => ({ default: Yat })))
-const NotFound = lazy(() =>
-  import('pages/NotFound/NotFound').then(({ NotFound }) => ({ default: NotFound })),
+const Flags = makeSuspsenseful(
+  lazy(() => import('pages/Flags/Flags').then(({ Flags }) => ({ default: Flags }))),
 )
-const ConnectWallet = lazy(() =>
-  import('pages/ConnectWallet/ConnectWallet').then(({ ConnectWallet }) => ({
-    default: ConnectWallet,
-  })),
+const Yat = makeSuspsenseful(
+  lazy(() => import('pages/Yat/Yat').then(({ Yat }) => ({ default: Yat }))),
 )
-const TermsOfService = lazy(() =>
-  import('pages/Legal/TermsOfService').then(({ TermsOfService }) => ({ default: TermsOfService })),
+const NotFound = makeSuspsenseful(
+  lazy(() => import('pages/NotFound/NotFound').then(({ NotFound }) => ({ default: NotFound }))),
 )
-const PrivacyPolicy = lazy(() =>
-  import('pages/Legal/PrivacyPolicy').then(({ PrivacyPolicy }) => ({ default: PrivacyPolicy })),
+const ConnectWallet = makeSuspsenseful(
+  lazy(() =>
+    import('pages/ConnectWallet/ConnectWallet').then(({ ConnectWallet }) => ({
+      default: ConnectWallet,
+    })),
+  ),
+)
+const TermsOfService = makeSuspsenseful(
+  lazy(() =>
+    import('pages/Legal/TermsOfService').then(({ TermsOfService }) => ({
+      default: TermsOfService,
+    })),
+  ),
+)
+const PrivacyPolicy = makeSuspsenseful(
+  lazy(() =>
+    import('pages/Legal/PrivacyPolicy').then(({ PrivacyPolicy }) => ({ default: PrivacyPolicy })),
+  ),
 )
 
 export const Routes = memo(() => {

--- a/src/Routes/RoutesCommon.tsx
+++ b/src/Routes/RoutesCommon.tsx
@@ -1,10 +1,8 @@
-import { Box } from '@chakra-ui/react'
 import { getConfig } from 'config'
-import type { FC } from 'react'
-import { lazy, Suspense, useMemo } from 'react'
+import { lazy } from 'react'
 import { FaCreditCard, FaFlag } from 'react-icons/fa'
 import { RiExchangeFundsLine } from 'react-icons/ri'
-import { CircularProgress } from 'components/CircularProgress/CircularProgress'
+import { makeSuspsenseful } from 'utils/makeSuspenseful'
 import { AssetsIcon } from 'components/Icons/Assets'
 import { DashboardIcon } from 'components/Icons/Dashboard'
 import { DefiIcon } from 'components/Icons/DeFi'
@@ -15,34 +13,6 @@ import { assetIdPaths } from 'hooks/useRouteAssetId/useRouteAssetId'
 
 import type { Route as NestedRoute } from './helpers'
 import { RouteCategory } from './helpers'
-
-const suspenseSpinnerStyle = {
-  display: 'flex',
-  justifyContent: 'center',
-  alignItems: 'center',
-  top: 0,
-  width: '100%',
-  height: '100vh',
-}
-
-function makeSuspsenseful<Props extends {}>(Component: FC<Props>) {
-  return (props: Props) => {
-    const suspenseSpinner = useMemo(
-      () => (
-        <Box style={suspenseSpinnerStyle}>
-          <CircularProgress />
-        </Box>
-      ),
-      [],
-    )
-
-    return (
-      <Suspense fallback={suspenseSpinner}>
-        <Component {...props} />
-      </Suspense>
-    )
-  }
-}
 
 const Dashboard = makeSuspsenseful(
   lazy(() =>

--- a/src/Routes/RoutesCommon.tsx
+++ b/src/Routes/RoutesCommon.tsx
@@ -1,6 +1,10 @@
+import { Box } from '@chakra-ui/react'
 import { getConfig } from 'config'
+import type { FC } from 'react'
+import { lazy, Suspense, useMemo } from 'react'
 import { FaCreditCard, FaFlag } from 'react-icons/fa'
 import { RiExchangeFundsLine } from 'react-icons/ri'
+import { CircularProgress } from 'components/CircularProgress/CircularProgress'
 import { AssetsIcon } from 'components/Icons/Assets'
 import { DashboardIcon } from 'components/Icons/Dashboard'
 import { DefiIcon } from 'components/Icons/DeFi'
@@ -8,20 +12,125 @@ import { PoolsIcon } from 'components/Icons/Pools'
 import { SwapIcon } from 'components/Icons/SwapIcon'
 import { TxHistoryIcon } from 'components/Icons/TxHistory'
 import { assetIdPaths } from 'hooks/useRouteAssetId/useRouteAssetId'
-import { Asset } from 'pages/Assets/Asset'
-import { Assets } from 'pages/Assets/Assets'
-import { AssetTxHistory } from 'pages/Assets/AssetTxHistory'
-import { Buy } from 'pages/Buy/Buy'
-import { Dashboard } from 'pages/Dashboard/Dashboard'
-import { StakingVaults } from 'pages/Defi/views/StakingVaults'
-import { Flags } from 'pages/Flags/Flags'
-import { LendingPage } from 'pages/Lending/LendingPage'
-import { PoolsPage } from 'pages/ThorChainLP/PoolsPage'
-import { Trade } from 'pages/Trade/Trade'
-import { TransactionHistory } from 'pages/TransactionHistory/TransactionHistory'
 
 import type { Route as NestedRoute } from './helpers'
 import { RouteCategory } from './helpers'
+
+const suspenseSpinnerStyle = {
+  display: 'flex',
+  justifyContent: 'center',
+  alignItems: 'center',
+  top: 0,
+  width: '100%',
+  height: '100vh',
+}
+
+function makeSuspsenseful<Props extends {}>(Component: FC<Props>) {
+  return (props: Props) => {
+    const suspenseSpinner = useMemo(
+      () => (
+        <Box style={suspenseSpinnerStyle}>
+          <CircularProgress />
+        </Box>
+      ),
+      [],
+    )
+
+    return (
+      <Suspense fallback={suspenseSpinner}>
+        <Component {...props} />
+      </Suspense>
+    )
+  }
+}
+
+const Dashboard = makeSuspsenseful(
+  lazy(() =>
+    import('pages/Dashboard/Dashboard').then(({ Dashboard }) => ({
+      default: Dashboard,
+    })),
+  ),
+)
+
+const Asset = makeSuspsenseful(
+  lazy(() =>
+    import('pages/Assets/Asset').then(({ Asset }) => ({
+      default: Asset,
+    })),
+  ),
+)
+
+const Assets = makeSuspsenseful(
+  lazy(() =>
+    import('pages/Assets/Assets').then(({ Assets }) => ({
+      default: Assets,
+    })),
+  ),
+)
+
+const AssetTxHistory = makeSuspsenseful(
+  lazy(() =>
+    import('pages/Assets/AssetTxHistory').then(({ AssetTxHistory }) => ({
+      default: AssetTxHistory,
+    })),
+  ),
+)
+
+const Buy = makeSuspsenseful(
+  lazy(() =>
+    import('pages/Buy/Buy').then(({ Buy }) => ({
+      default: Buy,
+    })),
+  ),
+)
+
+const Flags = makeSuspsenseful(
+  lazy(() =>
+    import('pages/Flags/Flags').then(({ Flags }) => ({
+      default: Flags,
+    })),
+  ),
+)
+
+const StakingVaults = makeSuspsenseful(
+  lazy(() =>
+    import('pages/Defi/views/StakingVaults').then(({ StakingVaults }) => ({
+      default: StakingVaults,
+    })),
+  ),
+)
+
+const LendingPage = makeSuspsenseful(
+  lazy(() =>
+    import('pages/Lending/LendingPage').then(({ LendingPage }) => ({
+      default: LendingPage,
+    })),
+  ),
+)
+
+const PoolsPage = makeSuspsenseful(
+  lazy(() =>
+    import('pages/ThorChainLP/PoolsPage').then(({ PoolsPage }) => ({
+      default: PoolsPage,
+    })),
+  ),
+)
+
+const Trade = makeSuspsenseful(
+  lazy(() =>
+    import('pages/Trade/Trade').then(({ Trade }) => ({
+      default: Trade,
+    })),
+  ),
+)
+
+const TransactionHistory = makeSuspsenseful(
+  lazy(() =>
+    import('pages/TransactionHistory/TransactionHistory').then(({ TransactionHistory }) => ({
+      default: TransactionHistory,
+    })),
+  ),
+)
 
 /**
  * WARNING: whenever routes that contain user addresses are edited here, we need

--- a/src/Routes/RoutesCommon.tsx
+++ b/src/Routes/RoutesCommon.tsx
@@ -2,7 +2,7 @@ import { getConfig } from 'config'
 import { lazy } from 'react'
 import { FaCreditCard, FaFlag } from 'react-icons/fa'
 import { RiExchangeFundsLine } from 'react-icons/ri'
-import { makeSuspsenseful } from 'utils/makeSuspenseful'
+import { makeSuspenseful } from 'utils/makeSuspenseful'
 import { AssetsIcon } from 'components/Icons/Assets'
 import { DashboardIcon } from 'components/Icons/Dashboard'
 import { DefiIcon } from 'components/Icons/DeFi'
@@ -14,7 +14,7 @@ import { assetIdPaths } from 'hooks/useRouteAssetId/useRouteAssetId'
 import type { Route as NestedRoute } from './helpers'
 import { RouteCategory } from './helpers'
 
-const Dashboard = makeSuspsenseful(
+const Dashboard = makeSuspenseful(
   lazy(() =>
     import('pages/Dashboard/Dashboard').then(({ Dashboard }) => ({
       default: Dashboard,
@@ -22,7 +22,7 @@ const Dashboard = makeSuspsenseful(
   ),
 )
 
-const Asset = makeSuspsenseful(
+const Asset = makeSuspenseful(
   lazy(() =>
     import('pages/Assets/Asset').then(({ Asset }) => ({
       default: Asset,
@@ -30,7 +30,7 @@ const Asset = makeSuspsenseful(
   ),
 )
 
-const Assets = makeSuspsenseful(
+const Assets = makeSuspenseful(
   lazy(() =>
     import('pages/Assets/Assets').then(({ Assets }) => ({
       default: Assets,
@@ -38,7 +38,7 @@ const Assets = makeSuspsenseful(
   ),
 )
 
-const AssetTxHistory = makeSuspsenseful(
+const AssetTxHistory = makeSuspenseful(
   lazy(() =>
     import('pages/Assets/AssetTxHistory').then(({ AssetTxHistory }) => ({
       default: AssetTxHistory,
@@ -46,7 +46,7 @@ const AssetTxHistory = makeSuspsenseful(
   ),
 )
 
-const Buy = makeSuspsenseful(
+const Buy = makeSuspenseful(
   lazy(() =>
     import('pages/Buy/Buy').then(({ Buy }) => ({
       default: Buy,
@@ -54,7 +54,7 @@ const Buy = makeSuspsenseful(
   ),
 )
 
-const Flags = makeSuspsenseful(
+const Flags = makeSuspenseful(
   lazy(() =>
     import('pages/Flags/Flags').then(({ Flags }) => ({
       default: Flags,
@@ -62,7 +62,7 @@ const Flags = makeSuspsenseful(
   ),
 )
 
-const StakingVaults = makeSuspsenseful(
+const StakingVaults = makeSuspenseful(
   lazy(() =>
     import('pages/Defi/views/StakingVaults').then(({ StakingVaults }) => ({
       default: StakingVaults,
@@ -70,7 +70,7 @@ const StakingVaults = makeSuspsenseful(
   ),
 )
 
-const LendingPage = makeSuspsenseful(
+const LendingPage = makeSuspenseful(
   lazy(() =>
     import('pages/Lending/LendingPage').then(({ LendingPage }) => ({
       default: LendingPage,
@@ -78,7 +78,7 @@ const LendingPage = makeSuspsenseful(
   ),
 )
 
-const PoolsPage = makeSuspsenseful(
+const PoolsPage = makeSuspenseful(
   lazy(() =>
     import('pages/ThorChainLP/PoolsPage').then(({ PoolsPage }) => ({
       default: PoolsPage,
@@ -86,7 +86,7 @@ const PoolsPage = makeSuspsenseful(
   ),
 )
 
-const Trade = makeSuspsenseful(
+const Trade = makeSuspenseful(
   lazy(() =>
     import('pages/Trade/Trade').then(({ Trade }) => ({
       default: Trade,
@@ -94,7 +94,7 @@ const Trade = makeSuspsenseful(
   ),
 )
 
-const TransactionHistory = makeSuspsenseful(
+const TransactionHistory = makeSuspenseful(
   lazy(() =>
     import('pages/TransactionHistory/TransactionHistory').then(({ TransactionHistory }) => ({
       default: TransactionHistory,

--- a/src/components/Layout/Header/AppLoadingIcon.tsx
+++ b/src/components/Layout/Header/AppLoadingIcon.tsx
@@ -1,5 +1,6 @@
 import { Center, Image } from '@chakra-ui/react'
 import dayjs from 'dayjs'
+import isBetween from 'dayjs/plugin/isBetween'
 import { AnimatePresence, motion } from 'framer-motion'
 import { memo, useCallback, useMemo, useState } from 'react'
 import { Link } from 'react-router-dom'
@@ -8,6 +9,8 @@ import { CircularProgress } from 'components/CircularProgress/CircularProgress'
 import { FoxIcon } from 'components/Icons/FoxIcon'
 import { SlideTransitionY } from 'components/SlideTransitionY'
 import { useIsAnyApiFetching } from 'hooks/useIsAnyApiFetching/useIsAnyApiFetching'
+
+dayjs.extend(isBetween)
 
 const dogeVariants = {
   hidden: { rotate: 0, opacity: 0 },

--- a/src/components/Layout/Header/Header.tsx
+++ b/src/components/Layout/Header/Header.tsx
@@ -15,8 +15,7 @@ import {
 import { btcAssetId } from '@shapeshiftoss/caip'
 import { MetaMaskShapeShiftMultiChainHDWallet } from '@shapeshiftoss/hdwallet-shapeshift-multichain'
 import { useScroll } from 'framer-motion'
-import { WalletConnectToDappsHeaderButton } from 'plugins/walletConnectToDapps/components/header/WalletConnectToDappsHeaderButton'
-import { memo, useCallback, useEffect, useMemo, useRef, useState } from 'react'
+import { lazy, memo, Suspense, useCallback, useEffect, useMemo, useRef, useState } from 'react'
 import { useTranslate } from 'react-polyglot'
 import { useSelector } from 'react-redux'
 import { useHistory } from 'react-router-dom'
@@ -46,6 +45,12 @@ import { Notifications } from './NavBar/Notifications'
 import { UserMenu } from './NavBar/UserMenu'
 import { SideNavContent } from './SideNavContent'
 import { TxWindow } from './TxWindow/TxWindow'
+
+const WalletConnectToDappsHeaderButton = lazy(() =>
+  import('plugins/walletConnectToDapps/components/header/WalletConnectToDappsHeaderButton').then(
+    ({ WalletConnectToDappsHeaderButton }) => ({ default: WalletConnectToDappsHeaderButton }),
+  ),
+)
 
 const paddingBottomProp = { base: '0.5rem', md: 0 }
 const fontSizeProp = { base: 'sm', md: 'md' }
@@ -231,7 +236,9 @@ export const Header = memo(() => {
               <GlobalSeachButton />
               {isLargerThanMd && isDegradedState && <DegradedStateBanner />}
               {isLargerThanMd && isWalletConnectToDappsV2Enabled && (
-                <WalletConnectToDappsHeaderButton />
+                <Suspense>
+                  <WalletConnectToDappsHeaderButton />
+                </Suspense>
               )}
               {isLargerThanMd && <ChainMenu display={displayProp2} />}
               <TxWindow />

--- a/src/components/Layout/Header/SideNavContent.tsx
+++ b/src/components/Layout/Header/SideNavContent.tsx
@@ -1,8 +1,7 @@
 import { ChatIcon, CloseIcon, SettingsIcon } from '@chakra-ui/icons'
 import type { FlexProps } from '@chakra-ui/react'
 import { Box, Flex, IconButton, Stack, useMediaQuery } from '@chakra-ui/react'
-import { WalletConnectToDappsHeaderButton } from 'plugins/walletConnectToDapps/components/header/WalletConnectToDappsHeaderButton'
-import { memo, useCallback, useMemo } from 'react'
+import { lazy, memo, Suspense, useCallback, useMemo } from 'react'
 import { useTranslate } from 'react-polyglot'
 import { useHistory } from 'react-router'
 import { ArkeoIcon } from 'components/Icons/Arkeo'
@@ -14,6 +13,12 @@ import { ChainMenu } from './NavBar/ChainMenu'
 import { MainNavLink } from './NavBar/MainNavLink'
 import { NavBar } from './NavBar/NavBar'
 import { UserMenu } from './NavBar/UserMenu'
+
+const WalletConnectToDappsHeaderButton = lazy(() =>
+  import('plugins/walletConnectToDapps/components/header/WalletConnectToDappsHeaderButton').then(
+    ({ WalletConnectToDappsHeaderButton }) => ({ default: WalletConnectToDappsHeaderButton }),
+  ),
+)
 
 const spacing = { base: 6, md: 0 }
 
@@ -81,7 +86,9 @@ export const SideNavContent = memo(({ isCompact, onClose }: HeaderContentProps) 
           </Flex>
           {isWalletConnectToDappsV2Enabled && (
             <Box width='full'>
-              <WalletConnectToDappsHeaderButton />
+              <Suspense>
+                <WalletConnectToDappsHeaderButton />
+              </Suspense>
             </Box>
           )}
         </Flex>

--- a/src/components/Layout/Layout.tsx
+++ b/src/components/Layout/Layout.tsx
@@ -1,6 +1,6 @@
 import type { ContainerProps } from '@chakra-ui/react'
 import { Container, Flex } from '@chakra-ui/react'
-import React from 'react'
+import React, { Suspense } from 'react'
 
 import { Header } from './Header/Header'
 import { SideNav } from './Header/SideNav'
@@ -26,7 +26,7 @@ export const Layout: React.FC<ContainerProps> = ({ children, ...rest }) => {
         {...rest}
       >
         <Header />
-        {children}
+        <Suspense>{children}</Suspense>
       </Container>
     </Flex>
   )

--- a/src/components/Layout/Layout.tsx
+++ b/src/components/Layout/Layout.tsx
@@ -1,6 +1,6 @@
 import type { ContainerProps } from '@chakra-ui/react'
 import { Container, Flex } from '@chakra-ui/react'
-import React, { Suspense } from 'react'
+import React from 'react'
 
 import { Header } from './Header/Header'
 import { SideNav } from './Header/SideNav'
@@ -26,7 +26,7 @@ export const Layout: React.FC<ContainerProps> = ({ children, ...rest }) => {
         {...rest}
       >
         <Header />
-        <Suspense>{children}</Suspense>
+        {children}
       </Container>
     </Flex>
   )

--- a/src/components/MultiHopTrade/MultiHopTrade.tsx
+++ b/src/components/MultiHopTrade/MultiHopTrade.tsx
@@ -2,7 +2,7 @@ import type { CardProps } from '@chakra-ui/react'
 import { Card, CardBody } from '@chakra-ui/react'
 import type { AssetId } from '@shapeshiftoss/caip'
 import { AnimatePresence } from 'framer-motion'
-import { lazy, memo, Suspense, useEffect } from 'react'
+import { memo, useEffect } from 'react'
 import { FormProvider, useForm } from 'react-hook-form'
 import { MemoryRouter, Route, Switch, useLocation, useParams } from 'react-router-dom'
 import { selectAssetById } from 'state/slices/assetsSlice/selectors'
@@ -10,24 +10,10 @@ import { tradeInput } from 'state/slices/tradeInputSlice/tradeInputSlice'
 import { tradeQuoteSlice } from 'state/slices/tradeQuoteSlice/tradeQuoteSlice'
 import { useAppDispatch, useAppSelector } from 'state/store'
 
+import { MultiHopTradeConfirm } from './components/MultiHopTradeConfirm/MultiHopTradeConfirm'
+import { TradeInput } from './components/TradeInput/TradeInput'
+import { VerifyAddresses } from './components/VerifyAddresses/VerifyAddresses'
 import { TradeRoutePaths } from './types'
-
-const MultiHopTradeConfirm = lazy(() =>
-  import('./components/MultiHopTradeConfirm/MultiHopTradeConfirm').then(
-    ({ MultiHopTradeConfirm }) => ({
-      default: MultiHopTradeConfirm,
-    }),
-  ),
-)
-
-const TradeInput = lazy(() =>
-  import('./components/TradeInput/TradeInput').then(({ TradeInput }) => ({ default: TradeInput })),
-)
-const VerifyAddresses = lazy(() =>
-  import('./components/VerifyAddresses/VerifyAddresses').then(({ VerifyAddresses }) => ({
-    default: VerifyAddresses,
-  })),
-)
 
 const MultiHopEntries = [
   TradeRoutePaths.Input,
@@ -86,20 +72,18 @@ const MultiHopRoutes = memo(() => {
   }, [dispatch])
 
   return (
-    <Suspense>
-      <AnimatePresence mode='wait' initial={false}>
-        <Switch location={location}>
-          <Route key={TradeRoutePaths.Input} path={TradeRoutePaths.Input}>
-            <TradeInput />
-          </Route>
-          <Route key={TradeRoutePaths.Confirm} path={TradeRoutePaths.Confirm}>
-            <MultiHopTradeConfirm />
-          </Route>
-          <Route key={TradeRoutePaths.VerifyAddresses} path={TradeRoutePaths.VerifyAddresses}>
-            <VerifyAddresses />
-          </Route>
-        </Switch>
-      </AnimatePresence>
-    </Suspense>
+    <AnimatePresence mode='wait' initial={false}>
+      <Switch location={location}>
+        <Route key={TradeRoutePaths.Input} path={TradeRoutePaths.Input}>
+          <TradeInput />
+        </Route>
+        <Route key={TradeRoutePaths.Confirm} path={TradeRoutePaths.Confirm}>
+          <MultiHopTradeConfirm />
+        </Route>
+        <Route key={TradeRoutePaths.VerifyAddresses} path={TradeRoutePaths.VerifyAddresses}>
+          <VerifyAddresses />
+        </Route>
+      </Switch>
+    </AnimatePresence>
   )
 })

--- a/src/context/ModalProvider/ModalProvider.tsx
+++ b/src/context/ModalProvider/ModalProvider.tsx
@@ -1,26 +1,146 @@
-import React, { memo } from 'react'
-import { WipeModal } from 'components/Layout/Header/NavBar/KeepKey/Modals/Wipe'
-import { BackupPassphraseModal } from 'components/Layout/Header/NavBar/Native/BackupPassphraseModal/BackupPassphraseModal'
-import {
-  AssetSearchModal,
-  BuyAssetSearchModal,
-  SellAssetSearchModal,
-} from 'components/Modals/AssetSearch/AssetSearchModal'
-import { FeedbackAndSupport } from 'components/Modals/FeedbackSupport/FeedbackSupport'
-import { FiatRampsModal } from 'components/Modals/FiatRamps/FiatRampsModal'
-import { MobileWelcomeModal } from 'components/Modals/MobileWelcome/MobileWelcomeModal'
-import { NativeOnboarding } from 'components/Modals/NativeOnboarding/NativeOnboarding'
-import { NftModal } from 'components/Modals/Nfts/NftModal'
-import { PopupWindowModal } from 'components/Modals/PopupWindowModal'
-import { QrCodeModal } from 'components/Modals/QrCode/QrCode'
-import { ReceiveModal } from 'components/Modals/Receive/Receive'
-import { SendModal } from 'components/Modals/Send/Send'
-import { SettingsModal } from 'components/Modals/Settings/Settings'
-import { Snaps } from 'components/Modals/Snaps/Snaps'
-import { AddAccountModal } from 'pages/Accounts/AddAccountModal'
+import React, { lazy, memo } from 'react'
+import { makeSuspsenseful } from 'utils/makeSuspenseful'
 
 import { createModalProviderInner } from './ModalContainer'
 import type { Modals } from './types'
+
+const ReceiveModal = makeSuspsenseful(
+  lazy(() =>
+    import('components/Modals/Receive/Receive').then(({ ReceiveModal }) => ({
+      default: ReceiveModal,
+    })),
+  ),
+)
+
+const QrCodeModal = makeSuspsenseful(
+  lazy(() =>
+    import('components/Modals/QrCode/QrCode').then(({ QrCodeModal }) => ({
+      default: QrCodeModal,
+    })),
+  ),
+)
+
+const SendModal = makeSuspsenseful(
+  lazy(() =>
+    import('components/Modals/Send/Send').then(({ SendModal }) => ({
+      default: SendModal,
+    })),
+  ),
+)
+
+const PopupWindowModal = makeSuspsenseful(
+  lazy(() =>
+    import('components/Modals/PopupWindowModal').then(({ PopupWindowModal }) => ({
+      default: PopupWindowModal,
+    })),
+  ),
+)
+
+const FiatRampsModal = makeSuspsenseful(
+  lazy(() =>
+    import('components/Modals/FiatRamps/FiatRampsModal').then(({ FiatRampsModal }) => ({
+      default: FiatRampsModal,
+    })),
+  ),
+)
+
+const SettingsModal = makeSuspsenseful(
+  lazy(() =>
+    import('components/Modals/Settings/Settings').then(({ SettingsModal }) => ({
+      default: SettingsModal,
+    })),
+  ),
+)
+
+const WipeModal = makeSuspsenseful(
+  lazy(() =>
+    import('components/Layout/Header/NavBar/KeepKey/Modals/Wipe').then(({ WipeModal }) => ({
+      default: WipeModal,
+    })),
+  ),
+)
+
+const BackupPassphraseModal = makeSuspsenseful(
+  lazy(() =>
+    import(
+      'components/Layout/Header/NavBar/Native/BackupPassphraseModal/BackupPassphraseModal'
+    ).then(({ BackupPassphraseModal }) => ({
+      default: BackupPassphraseModal,
+    })),
+  ),
+)
+
+const MobileWelcomeModal = makeSuspsenseful(
+  lazy(() =>
+    import('components/Modals/MobileWelcome/MobileWelcomeModal').then(({ MobileWelcomeModal }) => ({
+      default: MobileWelcomeModal,
+    })),
+  ),
+)
+
+const AddAccountModal = makeSuspsenseful(
+  lazy(() =>
+    import('pages/Accounts/AddAccountModal').then(({ AddAccountModal }) => ({
+      default: AddAccountModal,
+    })),
+  ),
+)
+
+const AssetSearchModal = makeSuspsenseful(
+  lazy(() =>
+    import('components/Modals/AssetSearch/AssetSearchModal').then(({ AssetSearchModal }) => ({
+      default: AssetSearchModal,
+    })),
+  ),
+)
+
+const BuyAssetSearchModal = makeSuspsenseful(
+  lazy(() =>
+    import('components/Modals/AssetSearch/AssetSearchModal').then(({ BuyAssetSearchModal }) => ({
+      default: BuyAssetSearchModal,
+    })),
+  ),
+)
+
+const SellAssetSearchModal = makeSuspsenseful(
+  lazy(() =>
+    import('components/Modals/AssetSearch/AssetSearchModal').then(({ SellAssetSearchModal }) => ({
+      default: SellAssetSearchModal,
+    })),
+  ),
+)
+
+const NativeOnboarding = makeSuspsenseful(
+  lazy(() =>
+    import('components/Modals/NativeOnboarding/NativeOnboarding').then(({ NativeOnboarding }) => ({
+      default: NativeOnboarding,
+    })),
+  ),
+)
+
+const NftModal = makeSuspsenseful(
+  lazy(() =>
+    import('components/Modals/Nfts/NftModal').then(({ NftModal }) => ({
+      default: NftModal,
+    })),
+  ),
+)
+
+const FeedbackAndSupport = makeSuspsenseful(
+  lazy(() =>
+    import('components/Modals/FeedbackSupport/FeedbackSupport').then(({ FeedbackAndSupport }) => ({
+      default: FeedbackAndSupport,
+    })),
+  ),
+)
+
+const Snaps = makeSuspsenseful(
+  lazy(() =>
+    import('components/Modals/Snaps/Snaps').then(({ Snaps }) => ({
+      default: Snaps,
+    })),
+  ),
+)
 
 const MODALS: Modals = {
   receive: ReceiveModal,

--- a/src/context/ModalProvider/ModalProvider.tsx
+++ b/src/context/ModalProvider/ModalProvider.tsx
@@ -1,10 +1,10 @@
 import React, { lazy, memo } from 'react'
-import { makeSuspsenseful } from 'utils/makeSuspenseful'
+import { makeSuspenseful } from 'utils/makeSuspenseful'
 
 import { createModalProviderInner } from './ModalContainer'
 import type { Modals } from './types'
 
-const ReceiveModal = makeSuspsenseful(
+const ReceiveModal = makeSuspenseful(
   lazy(() =>
     import('components/Modals/Receive/Receive').then(({ ReceiveModal }) => ({
       default: ReceiveModal,
@@ -12,7 +12,7 @@ const ReceiveModal = makeSuspsenseful(
   ),
 )
 
-const QrCodeModal = makeSuspsenseful(
+const QrCodeModal = makeSuspenseful(
   lazy(() =>
     import('components/Modals/QrCode/QrCode').then(({ QrCodeModal }) => ({
       default: QrCodeModal,
@@ -20,7 +20,7 @@ const QrCodeModal = makeSuspsenseful(
   ),
 )
 
-const SendModal = makeSuspsenseful(
+const SendModal = makeSuspenseful(
   lazy(() =>
     import('components/Modals/Send/Send').then(({ SendModal }) => ({
       default: SendModal,
@@ -28,7 +28,7 @@ const SendModal = makeSuspsenseful(
   ),
 )
 
-const PopupWindowModal = makeSuspsenseful(
+const PopupWindowModal = makeSuspenseful(
   lazy(() =>
     import('components/Modals/PopupWindowModal').then(({ PopupWindowModal }) => ({
       default: PopupWindowModal,
@@ -36,7 +36,7 @@ const PopupWindowModal = makeSuspsenseful(
   ),
 )
 
-const FiatRampsModal = makeSuspsenseful(
+const FiatRampsModal = makeSuspenseful(
   lazy(() =>
     import('components/Modals/FiatRamps/FiatRampsModal').then(({ FiatRampsModal }) => ({
       default: FiatRampsModal,
@@ -44,7 +44,7 @@ const FiatRampsModal = makeSuspsenseful(
   ),
 )
 
-const SettingsModal = makeSuspsenseful(
+const SettingsModal = makeSuspenseful(
   lazy(() =>
     import('components/Modals/Settings/Settings').then(({ SettingsModal }) => ({
       default: SettingsModal,
@@ -52,7 +52,7 @@ const SettingsModal = makeSuspsenseful(
   ),
 )
 
-const WipeModal = makeSuspsenseful(
+const WipeModal = makeSuspenseful(
   lazy(() =>
     import('components/Layout/Header/NavBar/KeepKey/Modals/Wipe').then(({ WipeModal }) => ({
       default: WipeModal,
@@ -60,7 +60,7 @@ const WipeModal = makeSuspsenseful(
   ),
 )
 
-const BackupPassphraseModal = makeSuspsenseful(
+const BackupPassphraseModal = makeSuspenseful(
   lazy(() =>
     import(
       'components/Layout/Header/NavBar/Native/BackupPassphraseModal/BackupPassphraseModal'
@@ -70,7 +70,7 @@ const BackupPassphraseModal = makeSuspsenseful(
   ),
 )
 
-const MobileWelcomeModal = makeSuspsenseful(
+const MobileWelcomeModal = makeSuspenseful(
   lazy(() =>
     import('components/Modals/MobileWelcome/MobileWelcomeModal').then(({ MobileWelcomeModal }) => ({
       default: MobileWelcomeModal,
@@ -78,7 +78,7 @@ const MobileWelcomeModal = makeSuspsenseful(
   ),
 )
 
-const AddAccountModal = makeSuspsenseful(
+const AddAccountModal = makeSuspenseful(
   lazy(() =>
     import('pages/Accounts/AddAccountModal').then(({ AddAccountModal }) => ({
       default: AddAccountModal,
@@ -86,7 +86,7 @@ const AddAccountModal = makeSuspsenseful(
   ),
 )
 
-const AssetSearchModal = makeSuspsenseful(
+const AssetSearchModal = makeSuspenseful(
   lazy(() =>
     import('components/Modals/AssetSearch/AssetSearchModal').then(({ AssetSearchModal }) => ({
       default: AssetSearchModal,
@@ -94,7 +94,7 @@ const AssetSearchModal = makeSuspsenseful(
   ),
 )
 
-const BuyAssetSearchModal = makeSuspsenseful(
+const BuyAssetSearchModal = makeSuspenseful(
   lazy(() =>
     import('components/Modals/AssetSearch/AssetSearchModal').then(({ BuyAssetSearchModal }) => ({
       default: BuyAssetSearchModal,
@@ -102,7 +102,7 @@ const BuyAssetSearchModal = makeSuspsenseful(
   ),
 )
 
-const SellAssetSearchModal = makeSuspsenseful(
+const SellAssetSearchModal = makeSuspenseful(
   lazy(() =>
     import('components/Modals/AssetSearch/AssetSearchModal').then(({ SellAssetSearchModal }) => ({
       default: SellAssetSearchModal,
@@ -110,7 +110,7 @@ const SellAssetSearchModal = makeSuspsenseful(
   ),
 )
 
-const NativeOnboarding = makeSuspsenseful(
+const NativeOnboarding = makeSuspenseful(
   lazy(() =>
     import('components/Modals/NativeOnboarding/NativeOnboarding').then(({ NativeOnboarding }) => ({
       default: NativeOnboarding,
@@ -118,7 +118,7 @@ const NativeOnboarding = makeSuspsenseful(
   ),
 )
 
-const NftModal = makeSuspsenseful(
+const NftModal = makeSuspenseful(
   lazy(() =>
     import('components/Modals/Nfts/NftModal').then(({ NftModal }) => ({
       default: NftModal,
@@ -126,7 +126,7 @@ const NftModal = makeSuspsenseful(
   ),
 )
 
-const FeedbackAndSupport = makeSuspsenseful(
+const FeedbackAndSupport = makeSuspenseful(
   lazy(() =>
     import('components/Modals/FeedbackSupport/FeedbackSupport').then(({ FeedbackAndSupport }) => ({
       default: FeedbackAndSupport,
@@ -134,7 +134,7 @@ const FeedbackAndSupport = makeSuspsenseful(
   ),
 )
 
-const Snaps = makeSuspsenseful(
+const Snaps = makeSuspenseful(
   lazy(() =>
     import('components/Modals/Snaps/Snaps').then(({ Snaps }) => ({
       default: Snaps,

--- a/src/context/ModalProvider/types.ts
+++ b/src/context/ModalProvider/types.ts
@@ -12,23 +12,23 @@ import type { SnapsModalProps } from 'components/Modals/Snaps/Snaps'
 import type { CLOSE_MODAL, OPEN_MODAL } from './constants'
 
 export type Modals = {
-  receive: ({ asset, accountId }: ReceivePropsType) => JSX.Element
-  qrCode: ({ assetId, accountId }: QrCodeModalProps) => JSX.Element
-  send: ({ assetId, accountId, input }: SendModalProps) => JSX.Element
+  receive: FC<ReceivePropsType>
+  qrCode: FC<QrCodeModalProps>
+  send: FC<SendModalProps>
   fiatRamps: FC<FiatRampsModalProps>
-  settings: () => JSX.Element
-  keepKeyWipe: () => JSX.Element
+  settings: FC<{}>
+  keepKeyWipe: FC<{}>
   backupNativePassphrase: FC<BackupPassphraseModalProps>
-  mobileWelcomeModal: () => JSX.Element
-  addAccount: () => JSX.Element | null
+  mobileWelcomeModal: FC<{}>
+  addAccount: FC<{}>
   assetSearch: FC<AssetSearchModalProps>
   buyAssetSearch: FC<AssetSearchModalProps>
   sellAssetSearch: FC<AssetSearchModalProps>
-  popup: React.FC<PopupWindowModalProps>
-  nativeOnboard: () => JSX.Element
-  nft: React.FC<NftModalProps>
-  feedbackSupport: () => JSX.Element
-  snaps: React.FC<SnapsModalProps>
+  popup: FC<PopupWindowModalProps>
+  nativeOnboard: FC<{}>
+  nft: FC<NftModalProps>
+  feedbackSupport: FC<{}>
+  snaps: FC<SnapsModalProps>
 }
 
 export type ModalActions<T extends keyof Modals> = OpenModalType<T> | CloseModalType

--- a/src/utils/makeSuspenseful.tsx
+++ b/src/utils/makeSuspenseful.tsx
@@ -1,6 +1,7 @@
-import { Box, CircularProgress } from '@chakra-ui/react'
+import { Box } from '@chakra-ui/react'
 import type { ComponentProps, FC } from 'react'
 import { Suspense, useMemo } from 'react'
+import { CircularProgress } from 'components/CircularProgress/CircularProgress'
 
 const suspenseSpinnerStyle = {
   display: 'flex',

--- a/src/utils/makeSuspenseful.tsx
+++ b/src/utils/makeSuspenseful.tsx
@@ -1,0 +1,31 @@
+import { Box, CircularProgress } from '@chakra-ui/react'
+import type { ComponentProps, FC } from 'react'
+import { Suspense, useMemo } from 'react'
+
+const suspenseSpinnerStyle = {
+  display: 'flex',
+  justifyContent: 'center',
+  alignItems: 'center',
+  top: 0,
+  width: '100%',
+  height: '100vh',
+}
+
+export function makeSuspsenseful<T extends FC<any>>(Component: T) {
+  return (props: ComponentProps<T>) => {
+    const suspenseSpinner = useMemo(
+      () => (
+        <Box style={suspenseSpinnerStyle}>
+          <CircularProgress />
+        </Box>
+      ),
+      [],
+    )
+
+    return (
+      <Suspense fallback={suspenseSpinner}>
+        <Component {...props} />
+      </Suspense>
+    )
+  }
+}

--- a/src/utils/makeSuspenseful.tsx
+++ b/src/utils/makeSuspenseful.tsx
@@ -12,7 +12,7 @@ const suspenseSpinnerStyle = {
   height: '100vh',
 }
 
-export function makeSuspsenseful<T extends FC<any>>(Component: T) {
+export function makeSuspenseful<T extends FC<any>>(Component: T) {
   return (props: ComponentProps<T>) => {
     const suspenseSpinner = useMemo(
       () => (


### PR DESCRIPTION
## Description

Adds lazy loading to all pages and modals, with spinner so app doesn't look broken during load (as is currently with trade page).

Improves script eval marginally for faster time to interactive which is something that desperately needs improving for mobile devices.

## Pull Request Type

- [ ] :bug: Bug fix (Non-breaking Change: Fixes an issue)
- [x] :hammer_and_wrench: Chore (Non-breaking Change: Doc updates, pkg upgrades, typos, etc..)
- [ ] :nail_care: New Feature (Breaking/Non-breaking Change)

## Issue (if applicable)

NA

## Risk
> High Risk PRs Require 2 approvals

Low/moderate risk of pages or modals not displaying at all, or the spinner somehow appearing in an unexpected way.

> What protocols, transaction types or contract interactions might be affected by this PR?

## Testing

Check all pages and modals are loading and initially displaying as intended. Also check wallet connect dapps drop-down is loading. 

There will be a spinner on the first load which is expected - the idea here is we're moving the load time to when a page is first viewed rather than everything on app boot which improves load time for most users.

### Engineering

<!-----------------------------------------------------------------------------
Include sufficient information here for an engineer to test your PR. This may include how to test locally, in a built environment, changes to infrastructure etc.
------------------------------------------------------------------------------>

### Operations

<!-----------------------------------------------------------------------------
If your changes have a user-facing impact, describe how a non-technical QA team can functionally test your changes in a preview environment.

If they are not user-facing please describe how to test for any regressions that may occur.
------------------------------------------------------------------------------>

## Screenshots (if applicable)

Spinner during lazy load
https://github.com/shapeshift/web/assets/125113430/bbea3f98-d91c-418d-a5cc-4cd1ff5c4cdc

Before this PR - 1.51s to parse, DCL at ~2.4s
![image](https://github.com/shapeshift/web/assets/125113430/5c640346-5fb6-4346-b60d-ce573ba3530a)

This PR - 1.17s to parse, DCL at ~1.9s
![image](https://github.com/shapeshift/web/assets/125113430/375664fe-94ea-42bf-a797-e4d01f5221b1)
