### PR TITLE
chore: remove liquidity wiring

### DIFF
--- a/src/lib/utils/thorchain/lp.ts
+++ b/src/lib/utils/thorchain/lp.ts
@@ -311,7 +311,6 @@ export const estimateAddThorchainLiquidityPosition = async ({
 // https://dev.thorchain.org/concepts/math.html#lp-units-withdrawn
 export const estimateRemoveThorchainLiquidityPosition = async ({
   assetId,
-  // i.e the result of the liquidityProviderPosition({ accountId, assetId }) query
   userData,
   runeAmountCryptoThorPrecision,
   assetAmountCryptoThorPrecision,
@@ -332,9 +331,10 @@ export const estimateRemoveThorchainLiquidityPosition = async ({
   })
 
   const poolShare = getPoolShare(bnOrZero(liquidityUnitsCryptoThorPrecision), pool)
+
   const slip = getSlipOnLiquidity({
-    runeAmountCryptoThorPrecision: poolShare.runeShare.toString(),
-    assetAmountCryptoThorPrecision: poolShare.assetShare.toString(),
+    runeAmountCryptoThorPrecision,
+    assetAmountCryptoThorPrecision,
     pool,
   })
 

--- a/src/lib/utils/thorchain/lp.ts
+++ b/src/lib/utils/thorchain/lp.ts
@@ -1,5 +1,5 @@
 import type { ChainId } from '@shapeshiftoss/caip'
-import { type AccountId, type AssetId, cosmosChainId, thorchainChainId } from '@shapeshiftoss/caip'
+import { type AssetId, cosmosChainId, thorchainChainId } from '@shapeshiftoss/caip'
 import type { KnownChainIds } from '@shapeshiftoss/types'
 import axios from 'axios'
 import { getConfig } from 'config'
@@ -11,9 +11,8 @@ import { isUtxoChainId } from 'state/slices/portfolioSlice/utils'
 
 import { getSupportedEvmChainIds } from '../evm'
 import { fromThorBaseUnit } from '.'
-import type { AsymSide } from './lp/types'
+import type { UserLpDataPosition } from './lp/types'
 import {
-  type MidgardPool,
   type MidgardPoolStats,
   type MidgardSwapHistoryResponse,
   type MidgardTvlHistoryResponse,
@@ -312,25 +311,22 @@ export const estimateAddThorchainLiquidityPosition = async ({
 // TODO: add 'percentage' param
 // https://dev.thorchain.org/concepts/math.html#lp-units-withdrawn
 export const estimateRemoveThorchainLiquidityPosition = async ({
-  // i.e the result of the liquidityProviderPosition({ accountId, assetId }) query
-  lpPositions,
   assetId,
+  // i.e the result of the liquidityProviderPosition({ accountId, assetId }) query
+  userData,
 }: {
-  accountId: AccountId
   assetId: AssetId
-  assetAmountCryptoThorPrecision: string
-  lpPositions: (MidgardPool & { accountId: AccountId })[]
-  asymSide: AsymSide | null
+  // assetAmountCryptoThorPrecision: string
+  userData: UserLpDataPosition
 }) => {
   const poolAssetId = assetIdToPoolAssetId({ assetId })
   // TODO: this is wrong. Expose selectLiquidityPositionsData from useUserLpData , consume this instead of getThorchainLiquidityProviderPosition
   // and get the right position for the user depending on the asymSide
-  const lpPosition = lpPositions?.[0]
-  const liquidityUnitsCryptoThorPrecision = lpPosition?.liquidityUnits
   const poolResult = await thorService.get<MidgardPoolResponse>(`${midgardUrl}/pool/${poolAssetId}`)
   if (poolResult.isErr()) throw poolResult.unwrapErr()
   const pool = poolResult.unwrap().data
-  const poolShare = getPoolShare(bnOrZero(liquidityUnitsCryptoThorPrecision), pool)
+  // This assumes 100% removal. We need to add a percentage param or similar.
+  const poolShare = getPoolShare(bnOrZero(userData.liquidityUnits), pool)
   const slip = getSlipOnLiquidity({
     runeAmountCryptoThorPrecision: poolShare.runeShare.toString(),
     assetAmountCryptoThorPrecision: poolShare.assetShare.toString(),
@@ -347,7 +343,7 @@ export const estimateRemoveThorchainLiquidityPosition = async ({
     poolShareAssetCryptoThorPrecision: poolShare.assetShare.toFixed(),
     poolShareRuneCryptoThorPrecision: poolShare.runeShare.toFixed(),
     poolShareDecimalPercent: poolShare.poolShareDecimalPercent,
-    liquidityUnitsCryptoThorPrecision,
+    liquidityUnitsCryptoThorPrecision: userData.liquidityUnits,
     assetAmountCryptoThorPrecision: poolShare.assetShare.toFixed(),
     runeAmountCryptoThorPrecision: poolShare.runeShare.toFixed(),
     inbound: {

--- a/src/lib/utils/thorchain/lp.ts
+++ b/src/lib/utils/thorchain/lp.ts
@@ -308,25 +308,30 @@ export const estimateAddThorchainLiquidityPosition = async ({
   }
 }
 
-// TODO: add 'percentage' param
 // https://dev.thorchain.org/concepts/math.html#lp-units-withdrawn
 export const estimateRemoveThorchainLiquidityPosition = async ({
   assetId,
   // i.e the result of the liquidityProviderPosition({ accountId, assetId }) query
   userData,
+  runeAmountCryptoThorPrecision,
+  assetAmountCryptoThorPrecision,
 }: {
   assetId: AssetId
-  // assetAmountCryptoThorPrecision: string
   userData: UserLpDataPosition
+  runeAmountCryptoThorPrecision: string
+  assetAmountCryptoThorPrecision: string
 }) => {
   const poolAssetId = assetIdToPoolAssetId({ assetId })
-  // TODO: this is wrong. Expose selectLiquidityPositionsData from useUserLpData , consume this instead of getThorchainLiquidityProviderPosition
-  // and get the right position for the user depending on the asymSide
   const poolResult = await thorService.get<MidgardPoolResponse>(`${midgardUrl}/pool/${poolAssetId}`)
   if (poolResult.isErr()) throw poolResult.unwrapErr()
   const pool = poolResult.unwrap().data
-  // This assumes 100% removal. We need to add a percentage param or similar.
-  const poolShare = getPoolShare(bnOrZero(userData.liquidityUnits), pool)
+  const liquidityUnitsCryptoThorPrecision = getLiquidityUnits({
+    pool,
+    assetAmountCryptoThorPrecision,
+    runeAmountCryptoThorPrecision,
+  })
+
+  const poolShare = getPoolShare(bnOrZero(liquidityUnitsCryptoThorPrecision), pool)
   const slip = getSlipOnLiquidity({
     runeAmountCryptoThorPrecision: poolShare.runeShare.toString(),
     assetAmountCryptoThorPrecision: poolShare.assetShare.toString(),

--- a/src/pages/ThorChainLP/components/RemoveLiquidity/RemoveLiquidity.tsx
+++ b/src/pages/ThorChainLP/components/RemoveLiquidity/RemoveLiquidity.tsx
@@ -18,7 +18,6 @@ const AddLiquidityEntries = [
 export type RemoveLiquidityProps = {
   headerComponent?: JSX.Element
   opportunityId?: string
-  paramOpportunityId?: string
 }
 export const RemoveLiquidity: React.FC<RemoveLiquidityProps> = ({
   headerComponent,

--- a/src/pages/ThorChainLP/components/RemoveLiquidity/RemoveLiquidityInput.tsx
+++ b/src/pages/ThorChainLP/components/RemoveLiquidity/RemoveLiquidityInput.tsx
@@ -296,18 +296,6 @@ export const RemoveLiquidityInput: React.FC<RemoveLiquidityProps> = ({
     return virtualRuneCryptoLiquidityAmount
   }, [isAsymRuneSide, isAsymAssetSide, virtualRuneCryptoLiquidityAmount])
 
-  // const actualAssetFiatLiquidityAmount = useMemo(() => {
-  //   if (isAsymAssetSide) {
-  //     // In asym asset side pool, use the virtual fiat amount as is
-  //     return virtualAssetFiatLiquidityAmount
-  //   } else if (isAsymRuneSide) {
-  //     // In asym rune side pool, the asset fiat amount should be zero
-  //     return '0'
-  //   }
-  //   // For symmetrical pools, use the virtual fiat amount as is
-  //   return virtualAssetFiatLiquidityAmount
-  // }, [isAsymAssetSide, isAsymRuneSide, virtualAssetFiatLiquidityAmount])
-
   const actualRuneFiatLiquidityAmount = useMemo(() => {
     if (isAsymRuneSide) {
       // In asym rune side pool, use the virtual fiat amount as is

--- a/src/pages/ThorChainLP/components/RemoveLiquidity/RemoveLiquidityInput.tsx
+++ b/src/pages/ThorChainLP/components/RemoveLiquidity/RemoveLiquidityInput.tsx
@@ -116,11 +116,11 @@ export const RemoveLiquidityInput: React.FC<RemoveLiquidityProps> = ({
   useEffect(() => {
     if (!userData) return
     const _poolAssetUserlpData: UserLpDataPosition | undefined = userData.find(
-      data => data.assetId === poolAsset?.assetId,
+      data => data.opportunityId === activeOpportunityId,
     )
     if (!_poolAssetUserlpData) return
     setPoolAssetUserlpData(_poolAssetUserlpData)
-  }, [foundPoolAsset, poolAsset?.assetId, userData])
+  }, [activeOpportunityId, foundPoolAsset, poolAsset?.assetId, userData])
 
   useEffect(() => {
     if (!(poolAsset && parsedPools)) return
@@ -328,13 +328,13 @@ export const RemoveLiquidityInput: React.FC<RemoveLiquidityProps> = ({
       )
         return
 
-      const _runeAmountCryptoThorPrecision = convertPrecision({
+      const runeAmountCryptoThorPrecision = convertPrecision({
         value: actualRuneCryptoLiquidityAmount,
         inputExponent: 0,
         outputExponent: THOR_PRECISION,
       }).toFixed()
 
-      const _assetAmountCryptoThorPrecision = convertPrecision({
+      const assetAmountCryptoThorPrecision = convertPrecision({
         value: actualAssetCryptoLiquidityAmount,
         inputExponent: 0,
         outputExponent: THOR_PRECISION,
@@ -345,6 +345,8 @@ export const RemoveLiquidityInput: React.FC<RemoveLiquidityProps> = ({
       const estimate = await estimateRemoveThorchainLiquidityPosition({
         userData: poolAssetUserlpData,
         assetId: poolAsset.assetId,
+        runeAmountCryptoThorPrecision,
+        assetAmountCryptoThorPrecision,
       })
 
       console.log('xxx debug estimate', { estimate })

--- a/src/pages/ThorChainLP/components/RemoveLiquidity/RemoveLiquidityInput.tsx
+++ b/src/pages/ThorChainLP/components/RemoveLiquidity/RemoveLiquidityInput.tsx
@@ -112,7 +112,7 @@ export const RemoveLiquidityInput: React.FC<RemoveLiquidityProps> = ({
 
   const [poolAsset, setPoolAsset] = useState<Asset | undefined>(foundPoolAsset)
   const [poolAssetUserlpData, setPoolAssetUserlpData] = useState<UserLpDataPosition | undefined>()
-  const [percentageSelection, setPercentageSelection] = useState<number>(0.5)
+  const [percentageSelection, setPercentageSelection] = useState<number>(50)
 
   useEffect(() => {
     if (!userData) return
@@ -248,26 +248,30 @@ export const RemoveLiquidityInput: React.FC<RemoveLiquidityProps> = ({
         setVirtualRuneCryptoLiquidityAmount(
           bnOrZero(underlyingRuneAmountCryptoPrecision)
             .times(percentage / 100)
+            .times(isAsymAssetSide || isAsymRuneSide ? 2 : 1)
             .toFixed(),
         )
         setVirtualRuneFiatLiquidityAmount(
           bnOrZero(underlyingRuneValueFiatUserCurrency)
             .times(percentage / 100)
+            .times(isAsymAssetSide || isAsymRuneSide ? 2 : 1)
             .toFixed(),
         )
         setVirtualAssetFiatLiquidityAmount(
           bnOrZero(underlyingAssetValueFiatUserCurrency)
             .times(percentage / 100)
+            .times(isAsymAssetSide || isAsymRuneSide ? 2 : 1)
             .toFixed(),
         )
         setVirtualAssetCryptoLiquidityAmount(
           bnOrZero(underlyingAssetAmountCryptoPrecision)
             .times(percentage / 100)
+            .times(isAsymAssetSide || isAsymRuneSide ? 2 : 1)
             .toFixed(),
         )
       }
     },
-    [poolAssetUserlpData],
+    [isAsymAssetSide, isAsymRuneSide, poolAssetUserlpData],
   )
 
   const actualAssetCryptoLiquidityAmount = useMemo(() => {

--- a/src/pages/ThorChainLP/components/RemoveLiquidity/RemoveLiquidityInput.tsx
+++ b/src/pages/ThorChainLP/components/RemoveLiquidity/RemoveLiquidityInput.tsx
@@ -154,6 +154,48 @@ export const RemoveLiquidityInput: React.FC<RemoveLiquidityProps> = ({
     [setPercentageSelection],
   )
 
+  useEffect(() => {
+    if (!poolAssetUserlpData) return
+
+    const {
+      underlyingAssetAmountCryptoPrecision,
+      underlyingAssetValueFiatUserCurrency,
+      underlyingRuneAmountCryptoPrecision,
+      underlyingRuneValueFiatUserCurrency,
+    } = poolAssetUserlpData
+
+    setVirtualRuneCryptoLiquidityAmount(
+      bnOrZero(underlyingRuneAmountCryptoPrecision)
+        .times(percentageSelection / 100)
+        .times(isAsymAssetSide || isAsymRuneSide ? 2 : 1)
+        .toFixed(),
+    )
+    setVirtualRuneFiatLiquidityAmount(
+      bnOrZero(underlyingRuneValueFiatUserCurrency)
+        .times(percentageSelection / 100)
+        .times(isAsymAssetSide || isAsymRuneSide ? 2 : 1)
+        .toFixed(),
+    )
+    setVirtualAssetFiatLiquidityAmount(
+      bnOrZero(underlyingAssetValueFiatUserCurrency)
+        .times(percentageSelection / 100)
+        .times(isAsymAssetSide || isAsymRuneSide ? 2 : 1)
+        .toFixed(),
+    )
+    setVirtualAssetCryptoLiquidityAmount(
+      bnOrZero(underlyingAssetAmountCryptoPrecision)
+        .times(percentageSelection / 100)
+        .times(isAsymAssetSide || isAsymRuneSide ? 2 : 1)
+        .toFixed(),
+    )
+  }, [isAsymAssetSide, isAsymRuneSide, percentageSelection, poolAssetUserlpData])
+
+  const handlePercentageClick = useCallback((percentage: number) => {
+    return () => {
+      setPercentageSelection(percentage)
+    }
+  }, [])
+
   const handleAsymSideChange = useCallback(
     (asymSide: string | null) => {
       if (!(parsedPools && poolAsset)) return
@@ -229,50 +271,6 @@ export const RemoveLiquidityInput: React.FC<RemoveLiquidityProps> = ({
   const [virtualRuneFiatLiquidityAmount, setVirtualRuneFiatLiquidityAmount] = useState<
     string | undefined
   >()
-
-  const handlePercentageClick = useCallback(
-    (percentage: number) => {
-      return () => {
-        if (!poolAssetUserlpData) return
-        setPercentageSelection(percentage)
-        console.info('poolAssetUserlpData', poolAssetUserlpData)
-        console.info('Percentage:', percentage)
-
-        const {
-          underlyingAssetAmountCryptoPrecision,
-          underlyingAssetValueFiatUserCurrency,
-          underlyingRuneAmountCryptoPrecision,
-          underlyingRuneValueFiatUserCurrency,
-        } = poolAssetUserlpData
-
-        setVirtualRuneCryptoLiquidityAmount(
-          bnOrZero(underlyingRuneAmountCryptoPrecision)
-            .times(percentage / 100)
-            .times(isAsymAssetSide || isAsymRuneSide ? 2 : 1)
-            .toFixed(),
-        )
-        setVirtualRuneFiatLiquidityAmount(
-          bnOrZero(underlyingRuneValueFiatUserCurrency)
-            .times(percentage / 100)
-            .times(isAsymAssetSide || isAsymRuneSide ? 2 : 1)
-            .toFixed(),
-        )
-        setVirtualAssetFiatLiquidityAmount(
-          bnOrZero(underlyingAssetValueFiatUserCurrency)
-            .times(percentage / 100)
-            .times(isAsymAssetSide || isAsymRuneSide ? 2 : 1)
-            .toFixed(),
-        )
-        setVirtualAssetCryptoLiquidityAmount(
-          bnOrZero(underlyingAssetAmountCryptoPrecision)
-            .times(percentage / 100)
-            .times(isAsymAssetSide || isAsymRuneSide ? 2 : 1)
-            .toFixed(),
-        )
-      }
-    },
-    [isAsymAssetSide, isAsymRuneSide, poolAssetUserlpData],
-  )
 
   const actualAssetCryptoLiquidityAmount = useMemo(() => {
     if (isAsymAssetSide) {

--- a/src/pages/ThorChainLP/components/RemoveLiquidity/RemoveLiquidityInput.tsx
+++ b/src/pages/ThorChainLP/components/RemoveLiquidity/RemoveLiquidityInput.tsx
@@ -111,29 +111,17 @@ export const RemoveLiquidityInput: React.FC<RemoveLiquidityProps> = ({
   const rune = useAppSelector(state => selectAssetById(state, thorchainAssetId))
 
   const [poolAsset, setPoolAsset] = useState<Asset | undefined>(foundPoolAsset)
-  const [poolAssetUserlpData, setPoolAssetUserlpData] = useState<UserLpDataPosition | undefined>()
+  const [userlpData, setUserlpData] = useState<UserLpDataPosition | undefined>()
   const [percentageSelection, setPercentageSelection] = useState<number>(50)
 
   useEffect(() => {
     if (!userData) return
-    const _poolAssetUserlpData: UserLpDataPosition | undefined = userData.find(
+    const _UserlpData: UserLpDataPosition | undefined = userData.find(
       data => data.opportunityId === activeOpportunityId,
     )
-    if (!_poolAssetUserlpData) return
-    setPoolAssetUserlpData(_poolAssetUserlpData)
+    if (!_UserlpData) return
+    setUserlpData(_UserlpData)
   }, [activeOpportunityId, foundPoolAsset, poolAsset?.assetId, userData])
-
-  useEffect(() => {
-    if (!(poolAsset && parsedPools)) return
-    // We only want to run this effect in the standalone RemoveLiquidity page
-    if (!defaultOpportunityId) return
-
-    const foundOpportunityId = (parsedPools ?? []).find(
-      pool => pool.assetId === poolAsset.assetId && pool.asymSide === null,
-    )?.opportunityId
-    if (!foundOpportunityId) return
-    setActiveOpportunityId(foundOpportunityId)
-  }, [poolAsset, defaultOpportunityId, parsedPools])
 
   const handleBackClick = useCallback(() => {
     browserHistory.push('/pools')
@@ -155,14 +143,14 @@ export const RemoveLiquidityInput: React.FC<RemoveLiquidityProps> = ({
   )
 
   useEffect(() => {
-    if (!poolAssetUserlpData) return
+    if (!userlpData) return
 
     const {
       underlyingAssetAmountCryptoPrecision,
       underlyingAssetValueFiatUserCurrency,
       underlyingRuneAmountCryptoPrecision,
       underlyingRuneValueFiatUserCurrency,
-    } = poolAssetUserlpData
+    } = userlpData
 
     setVirtualRuneCryptoLiquidityAmount(
       bnOrZero(underlyingRuneAmountCryptoPrecision)
@@ -188,7 +176,7 @@ export const RemoveLiquidityInput: React.FC<RemoveLiquidityProps> = ({
         .times(isAsymAssetSide || isAsymRuneSide ? 2 : 1)
         .toFixed(),
     )
-  }, [isAsymAssetSide, isAsymRuneSide, percentageSelection, poolAssetUserlpData])
+  }, [isAsymAssetSide, isAsymRuneSide, percentageSelection, userlpData])
 
   const handlePercentageClick = useCallback((percentage: number) => {
     return () => {
@@ -362,7 +350,7 @@ export const RemoveLiquidityInput: React.FC<RemoveLiquidityProps> = ({
         !actualAssetCryptoLiquidityAmount ||
         !poolAsset ||
         !userData ||
-        !poolAssetUserlpData
+        !userlpData
       )
         return
 
@@ -381,7 +369,7 @@ export const RemoveLiquidityInput: React.FC<RemoveLiquidityProps> = ({
       setIsSlippageLoading(true)
 
       const estimate = await estimateRemoveThorchainLiquidityPosition({
-        userData: poolAssetUserlpData,
+        userData: userlpData,
         assetId: poolAsset.assetId,
         runeAmountCryptoThorPrecision,
         assetAmountCryptoThorPrecision,
@@ -411,7 +399,7 @@ export const RemoveLiquidityInput: React.FC<RemoveLiquidityProps> = ({
     isAsymRuneSide,
     virtualRuneFiatLiquidityAmount,
     userData,
-    poolAssetUserlpData,
+    userlpData,
   ])
 
   const tradeAssetInputs = useMemo(() => {

--- a/src/pages/ThorChainLP/components/RemoveLiquidity/RemoveLiquidityInput.tsx
+++ b/src/pages/ThorChainLP/components/RemoveLiquidity/RemoveLiquidityInput.tsx
@@ -112,6 +112,7 @@ export const RemoveLiquidityInput: React.FC<RemoveLiquidityProps> = ({
 
   const [poolAsset, setPoolAsset] = useState<Asset | undefined>(foundPoolAsset)
   const [poolAssetUserlpData, setPoolAssetUserlpData] = useState<UserLpDataPosition | undefined>()
+  const [percentageSelection, setPercentageSelection] = useState<number>(0.5)
 
   useEffect(() => {
     if (!userData) return
@@ -145,6 +146,13 @@ export const RemoveLiquidityInput: React.FC<RemoveLiquidityProps> = ({
   const handleSubmit = useCallback(() => {
     history.push(RemoveLiquidityRoutePaths.Confirm)
   }, [history])
+
+  const handlePercentageSliderChange = useCallback(
+    (percentage: number) => {
+      setPercentageSelection(percentage)
+    },
+    [setPercentageSelection],
+  )
 
   const handleAsymSideChange = useCallback(
     (asymSide: string | null) => {
@@ -223,9 +231,10 @@ export const RemoveLiquidityInput: React.FC<RemoveLiquidityProps> = ({
   >()
 
   const handlePercentageClick = useCallback(
-    (percentage: string) => {
+    (percentage: number) => {
       return () => {
         if (!poolAssetUserlpData) return
+        setPercentageSelection(percentage)
         console.info('poolAssetUserlpData', poolAssetUserlpData)
         console.info('Percentage:', percentage)
 
@@ -237,16 +246,24 @@ export const RemoveLiquidityInput: React.FC<RemoveLiquidityProps> = ({
         } = poolAssetUserlpData
 
         setVirtualRuneCryptoLiquidityAmount(
-          bnOrZero(underlyingRuneAmountCryptoPrecision).times(percentage).toFixed(),
+          bnOrZero(underlyingRuneAmountCryptoPrecision)
+            .times(percentage / 100)
+            .toFixed(),
         )
         setVirtualRuneFiatLiquidityAmount(
-          bnOrZero(underlyingRuneValueFiatUserCurrency).times(percentage).toFixed(),
+          bnOrZero(underlyingRuneValueFiatUserCurrency)
+            .times(percentage / 100)
+            .toFixed(),
         )
         setVirtualAssetFiatLiquidityAmount(
-          bnOrZero(underlyingAssetValueFiatUserCurrency).times(percentage).toFixed(),
+          bnOrZero(underlyingAssetValueFiatUserCurrency)
+            .times(percentage / 100)
+            .toFixed(),
         )
         setVirtualAssetCryptoLiquidityAmount(
-          bnOrZero(underlyingAssetAmountCryptoPrecision).times(percentage).toFixed(),
+          bnOrZero(underlyingAssetAmountCryptoPrecision)
+            .times(percentage / 100)
+            .toFixed(),
         )
       }
     },
@@ -485,24 +502,24 @@ export const RemoveLiquidityInput: React.FC<RemoveLiquidityProps> = ({
             defaultOpportunityId={defaultOpportunityId}
           />
           <Stack px={6} py={4} spacing={4}>
-            <Amount.Percent value='0.50' fontSize='2xl' />
-            <Slider>
+            <Amount.Percent value={percentageSelection / 100} fontSize='2xl' />
+            <Slider value={percentageSelection} onChange={handlePercentageSliderChange}>
               <SliderTrack>
                 <SliderFilledTrack />
               </SliderTrack>
               <SliderThumb />
             </Slider>
             <ButtonGroup size='sm' justifyContent='space-between'>
-              <Button onClick={handlePercentageClick('0.25')} flex={1}>
+              <Button onClick={handlePercentageClick(25)} flex={1}>
                 25%
               </Button>
-              <Button onClick={handlePercentageClick('0.50')} flex={1}>
+              <Button onClick={handlePercentageClick(50)} flex={1}>
                 50%
               </Button>
-              <Button onClick={handlePercentageClick('0.75')} flex={1}>
+              <Button onClick={handlePercentageClick(75)} flex={1}>
                 75%
               </Button>
-              <Button onClick={handlePercentageClick('1')} flex={1}>
+              <Button onClick={handlePercentageClick(100)} flex={1}>
                 Max
               </Button>
             </ButtonGroup>

--- a/src/pages/ThorChainLP/components/RemoveLiquidity/RemoveLiquidityInput.tsx
+++ b/src/pages/ThorChainLP/components/RemoveLiquidity/RemoveLiquidityInput.tsx
@@ -206,7 +206,7 @@ export const RemoveLiquidityInput: React.FC<RemoveLiquidityProps> = ({
   )
   const runeMarketData = useAppSelector(state => selectMarketDataById(state, rune?.assetId ?? ''))
 
-  // Virtual as in, these are the amounts if depositing symetrically. But a user may deposit asymetrically, so these are not the *actual* amounts
+  // Virtual as in, these are the amounts if removing symetrically. But a user may remove asymetrically, so these are not the *actual* amounts
   // Keeping these as virtual amounts is useful from a UI perspective, as it allows rebalancing to automagically work when switching from sym. type,
   // while using the *actual* amounts whenever we do things like checking for asset balance
   const [virtualAssetCryptoLiquidityAmount, setVirtualAssetCryptoLiquidityAmount] = useState<
@@ -221,6 +221,37 @@ export const RemoveLiquidityInput: React.FC<RemoveLiquidityProps> = ({
   const [virtualRuneFiatLiquidityAmount, setVirtualRuneFiatLiquidityAmount] = useState<
     string | undefined
   >()
+
+  const handlePercentageClick = useCallback(
+    (percentage: string) => {
+      return () => {
+        if (!poolAssetUserlpData) return
+        console.info('poolAssetUserlpData', poolAssetUserlpData)
+        console.info('Percentage:', percentage)
+
+        const {
+          underlyingAssetAmountCryptoPrecision,
+          underlyingAssetValueFiatUserCurrency,
+          underlyingRuneAmountCryptoPrecision,
+          underlyingRuneValueFiatUserCurrency,
+        } = poolAssetUserlpData
+
+        setVirtualRuneCryptoLiquidityAmount(
+          bnOrZero(underlyingRuneAmountCryptoPrecision).times(percentage).toFixed(),
+        )
+        setVirtualRuneFiatLiquidityAmount(
+          bnOrZero(underlyingRuneValueFiatUserCurrency).times(percentage).toFixed(),
+        )
+        setVirtualAssetFiatLiquidityAmount(
+          bnOrZero(underlyingAssetValueFiatUserCurrency).times(percentage).toFixed(),
+        )
+        setVirtualAssetCryptoLiquidityAmount(
+          bnOrZero(underlyingAssetAmountCryptoPrecision).times(percentage).toFixed(),
+        )
+      }
+    },
+    [poolAssetUserlpData],
+  )
 
   const actualAssetCryptoLiquidityAmount = useMemo(() => {
     if (isAsymAssetSide) {
@@ -462,10 +493,18 @@ export const RemoveLiquidityInput: React.FC<RemoveLiquidityProps> = ({
               <SliderThumb />
             </Slider>
             <ButtonGroup size='sm' justifyContent='space-between'>
-              <Button flex={1}>25%</Button>
-              <Button flex={1}>50%</Button>
-              <Button flex={1}>75%</Button>
-              <Button flex={1}>Max</Button>
+              <Button onClick={handlePercentageClick('0.25')} flex={1}>
+                25%
+              </Button>
+              <Button onClick={handlePercentageClick('0.50')} flex={1}>
+                50%
+              </Button>
+              <Button onClick={handlePercentageClick('0.75')} flex={1}>
+                75%
+              </Button>
+              <Button onClick={handlePercentageClick('1')} flex={1}>
+                Max
+              </Button>
             </ButtonGroup>
           </Stack>
           <Divider borderColor='border.base' />


### PR DESCRIPTION
## Description

Wires up "Remove liquidity" logic, including:

- pre-populate removal amount as 50% of position
- wire up sym and asym user inputs
- wire up percent slider and buttons
- wire up removal slippage

Still to do as follow-up PRs:

- [ ] Wire up gas fees
- [ ] Balance validation
- [ ] Account selection logic
- [ ] Confirm screen
- [ ] Actual removal TX logic

## Pull Request Type

- [ ] :bug: Bug fix (Non-breaking Change: Fixes an issue)
- [x] :hammer_and_wrench: Chore (Non-breaking Change: Doc updates, pkg upgrades, typos, etc..)
- [ ] :nail_care: New Feature (Breaking/Non-breaking Change)

## Issue (if applicable)

Contributes to https://github.com/shapeshift/web/issues/5960

## Risk

Small - only UI things behind a feature flag.

> What protocols, transaction types or contract interactions might be affected by this PR?

THORChain LP.

## Testing

TODO

### Engineering

Play around with the percentage options (the slider and the buttons) and ensure it feels right.

### Operations

N/A

## Screenshots (if applicable)

<img width="373" alt="Screenshot 2024-02-08 at 7 39 34 pm" src="https://github.com/shapeshift/web/assets/97164662/3494df75-04af-4135-93d3-4518b3f8e9aa">

