### PR TITLE
feat: disable trade preview while custom recipient is editing

### DIFF
--- a/src/components/MultiHopTrade/components/TradeInput/TradeInput.tsx
+++ b/src/components/MultiHopTrade/components/TradeInput/TradeInput.tsx
@@ -56,6 +56,7 @@ import {
   selectInputBuyAsset,
   selectInputSellAmountCryptoPrecision,
   selectInputSellAsset,
+  selectManualReceiveAddressIsEditing,
   selectManualReceiveAddressIsValid,
   selectManualReceiveAddressIsValidating,
   selectWalletSupportedChainIds,
@@ -140,6 +141,7 @@ export const TradeInput = memo(() => {
   const buyAmountAfterFeesUserCurrency = useAppSelector(selectBuyAmountAfterFeesUserCurrency)
   const totalNetworkFeeFiatPrecision = useAppSelector(selectTotalNetworkFeeUserCurrencyPrecision)
   const manualReceiveAddressIsValidating = useAppSelector(selectManualReceiveAddressIsValidating)
+  const manualReceiveAddressIsEditing = useAppSelector(selectManualReceiveAddressIsEditing)
   const manualReceiveAddressIsValid = useAppSelector(selectManualReceiveAddressIsValid)
   const sellAmountCryptoPrecision = useAppSelector(selectInputSellAmountCryptoPrecision)
   const slippageDecimal = useAppSelector(selectTradeSlippagePercentageDecimal)
@@ -415,6 +417,7 @@ export const TradeInput = memo(() => {
       quoteHasError ||
       // don't execute trades while address is validating
       manualReceiveAddressIsValidating ||
+      manualReceiveAddressIsEditing ||
       manualReceiveAddressIsValid === false ||
       // don't execute trades while in loading state
       isLoading ||
@@ -432,6 +435,7 @@ export const TradeInput = memo(() => {
   }, [
     quoteHasError,
     manualReceiveAddressIsValidating,
+    manualReceiveAddressIsEditing,
     manualReceiveAddressIsValid,
     isLoading,
     hasUserEnteredAmount,

--- a/src/components/MultiHopTrade/components/TradeInput/components/RecipientAddress.tsx
+++ b/src/components/MultiHopTrade/components/TradeInput/components/RecipientAddress.tsx
@@ -120,11 +120,13 @@ export const RecipientAddress = () => {
   )
 
   const handleEditRecipientAddressClick = useCallback(() => {
+    dispatch(tradeInput.actions.setManualReceiveAddressIsEditing(true))
     setIsRecipientAddressEditing(true)
-  }, [])
+  }, [dispatch])
 
   const handleCancelClick = useCallback(() => {
     setIsRecipientAddressEditing(false)
+    dispatch(tradeInput.actions.setManualReceiveAddressIsEditing(false))
     // Reset form value and valid state on cancel so the valid check doesn't wrongly evaluate to false after bailing out of editing an invalid address
     setFormValue(SendFormFields.Input, '')
     dispatch(tradeInput.actions.setManualReceiveAddressIsValid(undefined))
@@ -147,6 +149,7 @@ export const RecipientAddress = () => {
       const address = values[SendFormFields.Input]
       dispatch(tradeInput.actions.setManualReceiveAddress(address))
       setIsRecipientAddressEditing(false)
+      dispatch(tradeInput.actions.setManualReceiveAddressIsEditing(false))
     },
     [dispatch],
   )

--- a/src/state/slices/tradeInputSlice/selectors.ts
+++ b/src/state/slices/tradeInputSlice/selectors.ts
@@ -147,6 +147,11 @@ export const selectManualReceiveAddressIsValidating = createSelector(
   tradeInput => tradeInput.manualReceiveAddressIsValidating,
 )
 
+export const selectManualReceiveAddressIsEditing = createSelector(
+  selectTradeInput,
+  tradeInput => tradeInput.manualReceiveAddressIsEditing,
+)
+
 export const selectManualReceiveAddressIsValid = createSelector(
   selectTradeInput,
   tradeInput => tradeInput.manualReceiveAddressIsValid,

--- a/src/state/slices/tradeInputSlice/tradeInputSlice.ts
+++ b/src/state/slices/tradeInputSlice/tradeInputSlice.ts
@@ -16,6 +16,7 @@ export type TradeInputState = {
   sellAmountCryptoPrecision: string
   manualReceiveAddress: string | undefined
   manualReceiveAddressIsValidating: boolean
+  manualReceiveAddressIsEditing: boolean
   manualReceiveAddressIsValid: boolean | undefined
   slippagePreferencePercentage: string | undefined
 }
@@ -30,6 +31,7 @@ const initialState: TradeInputState = {
   manualReceiveAddress: undefined,
   manualReceiveAddressIsValidating: false,
   manualReceiveAddressIsValid: undefined,
+  manualReceiveAddressIsEditing: false,
   slippagePreferencePercentage: undefined,
 }
 
@@ -77,6 +79,9 @@ export const tradeInput = createSlice({
     },
     setManualReceiveAddressIsValidating: (state, action: PayloadAction<boolean>) => {
       state.manualReceiveAddressIsValidating = action.payload
+    },
+    setManualReceiveAddressIsEditing: (state, action: PayloadAction<boolean>) => {
+      state.manualReceiveAddressIsEditing = action.payload
     },
     setManualReceiveAddressIsValid(state, action: PayloadAction<boolean | undefined>) {
       state.manualReceiveAddressIsValid = action.payload

--- a/src/test/mocks/store.ts
+++ b/src/test/mocks/store.ts
@@ -178,6 +178,7 @@ export const mockStore: ReduxState = {
     sellAmountCryptoPrecision: '0',
     manualReceiveAddress: undefined,
     manualReceiveAddressIsValidating: false,
+    manualReceiveAddressIsEditing: false,
     manualReceiveAddressIsValid: undefined,
     slippagePreferencePercentage: undefined,
   },


### PR DESCRIPTION
## Description

Follows-up on https://github.com/shapeshift/web/pull/6072, tackling the issue spotted by @0xApotheosis in https://github.com/shapeshift/web/pull/6072#pullrequestreview-1863934445:

> 🤔 Probably not a blocker, as we no longer crash in this state, but we still don't ensure the "Preview Trade" button is disabled whilst manually editing the address

## Pull Request Type

- [ ] :bug: Bug fix (Non-breaking Change: Fixes an issue)
- [ ] :hammer_and_wrench: Chore (Non-breaking Change: Doc updates, pkg upgrades, typos, etc..)
- [x] :nail_care: New Feature (Breaking/Non-breaking Change)

## Issue (if applicable)

<!-----------------------------------------------------------------------------
If applicable, please link to the github issue and put `closes #XXXX` in your comment to auto-close the issue that your PR fixes.
------------------------------------------------------------------------------>

- relates to https://github.com/shapeshift/web/issues/5883

## Risk
> High Risk PRs Require 2 approvals

<!-----------------------------------------------------------------------------
Outline the scope of your changes and the risk associated with them. You must use your discretion as an engineer to determine the potential impact of your changes.

WARNING: If your PR introduces a new on-chain transaction or modifies an existing one, please add the "High-Risk" label to this PR and ask for 2 reviewers to approve it before merging.

E.g. an upgrade to `hdwallet` or core state management would be considered higher risk, and might require a full regression test. UI or isolated view changes, or something behind a feature flag may have near zero risk. Small bug fixes might require testing isolated to the specific fix.
------------------------------------------------------------------------------>

Low to none, ensure it's still possible to continue to trade confirm both with the flag on and off

> What protocols, transaction types or contract interactions might be affected by this PR?

## Testing

<!-----------------------------------------------------------------------------
We treat every PR to be merged with the same scrutiny as if we were merging directly to production.

Your PR will not be merged if you do not complete the sections below for our engineering and operations teams to test.
------------------------------------------------------------------------------>

- See risks

### Engineering

<!-----------------------------------------------------------------------------
Include sufficient information here for an engineer to test your PR. This may include how to test locally, in a built environment, changes to infrastructure etc.
------------------------------------------------------------------------------>

- ☝🏽 

### Operations

<!-----------------------------------------------------------------------------
If your changes have a user-facing impact, describe how a non-technical QA team can functionally test your changes in a preview environment.

If they are not user-facing please describe how to test for any regressions that may occur.
------------------------------------------------------------------------------>

- ☝🏽 

## Screenshots (if applicable)

https://github.com/shapeshift/web/assets/17035424/dca1faab-12a8-4a07-a99b-fbaf3f92857a
