### PR TITLE
fix: fire useReceiveAddress() hook only on last step stepper

### DIFF
--- a/src/components/MultiHopTrade/components/MultiHopTradeConfirm/components/StepperStep.tsx
+++ b/src/components/MultiHopTrade/components/MultiHopTradeConfirm/components/StepperStep.tsx
@@ -1,6 +1,7 @@
 import type { BoxProps, StepTitleProps, SystemStyleObject } from '@chakra-ui/react'
 import {
   Box,
+  Skeleton,
   SkeletonCircle,
   SkeletonText,
   Spacer,
@@ -33,6 +34,26 @@ export type StepperStepProps = {
   isPending?: boolean
 }
 
+const LastStepTag = () => {
+  const wallet = useWallet().state.wallet
+  const useReceiveAddressArgs = useMemo(
+    () => ({
+      fetchUnchainedAddress: Boolean(wallet && isLedger(wallet)),
+    }),
+    [wallet],
+  )
+
+  const { manualReceiveAddress, walletReceiveAddress } = useReceiveAddress(useReceiveAddressArgs)
+  const receiveAddress = manualReceiveAddress ?? walletReceiveAddress
+
+  return (
+    <Skeleton isLoaded={!!receiveAddress}>
+      <Tag size='md' colorScheme='blue'>
+        <MiddleEllipsis value={receiveAddress ?? ''} />
+      </Tag>
+    </Skeleton>
+  )
+}
 export const StepperStep = ({
   title,
   stepIndicator,
@@ -48,18 +69,6 @@ export const StepperStep = ({
   const { indicator: styles } = useStyleConfig('Stepper', {
     variant: isError ? 'error' : 'default',
   }) as { indicator: SystemStyleObject }
-
-  const wallet = useWallet().state.wallet
-  const useReceiveAddressArgs = useMemo(
-    () => ({
-      fetchUnchainedAddress: Boolean(wallet && isLedger(wallet)),
-    }),
-    [wallet],
-  )
-  const { manualReceiveAddress, walletReceiveAddress } = useReceiveAddress(useReceiveAddressArgs)
-  const receiveAddress = manualReceiveAddress ?? walletReceiveAddress
-
-  if (!receiveAddress) return null
 
   return (
     <Step style={width}>
@@ -82,11 +91,7 @@ export const StepperStep = ({
                 description
               )}
             </StepDescription>
-            {isLastStep ? (
-              <Tag size='md' colorScheme='blue'>
-                <MiddleEllipsis value={receiveAddress} />
-              </Tag>
-            ) : null}
+            {isLastStep ? <LastStepTag /> : null}
           </>
         )}
         {content !== undefined && <Box mt={2}>{content}</Box>}


### PR DESCRIPTION
## Description

i.e something something hooks not singletons, only the last stepper's step needs `receiveAddress`, but all instances were calling it, resulting in very slow swapper confirm step, each step fetching the receive address and being effectively loaded sequentially.

Moved the last step's tag to its own component consuming said hook and while at it, added a skeleton while `receiveAddress` is loading.

## Pull Request Type

- [x] :bug: Bug fix (Non-breaking Change: Fixes an issue)
- [ ] :hammer_and_wrench: Chore (Non-breaking Change: Doc updates, pkg upgrades, typos, etc..)
- [ ] :nail_care: New Feature (Breaking/Non-breaking Change)

## Issue (if applicable)

<!-----------------------------------------------------------------------------
If applicable, please link to the github issue and put `closes #XXXX` in your comment to auto-close the issue that your PR fixes.
------------------------------------------------------------------------------>

closes https://github.com/shapeshift/web/issues/6142

## Risk
> High Risk PRs Require 2 approvals

<!-----------------------------------------------------------------------------
Outline the scope of your changes and the risk associated with them. You must use your discretion as an engineer to determine the potential impact of your changes.

WARNING: If your PR introduces a new on-chain transaction or modifies an existing one, please add the "High-Risk" label to this PR and ask for 2 reviewers to approve it before merging.

E.g. an upgrade to `hdwallet` or core state management would be considered higher risk, and might require a full regression test. UI or isolated view changes, or something behind a feature flag may have near zero risk. Small bug fixes might require testing isolated to the specific fix.
------------------------------------------------------------------------------>

> What protocols, transaction types or contract interactions might be affected by this PR?

## Testing

<!-----------------------------------------------------------------------------
We treat every PR to be merged with the same scrutiny as if we were merging directly to production.

Your PR will not be merged if you do not complete the sections below for our engineering and operations teams to test.
------------------------------------------------------------------------------>

- Swapper confirm step is great again

### Engineering

<!-----------------------------------------------------------------------------
Include sufficient information here for an engineer to test your PR. This may include how to test locally, in a built environment, changes to infrastructure etc.
------------------------------------------------------------------------------>

- ☝🏽 

### Operations

<!-----------------------------------------------------------------------------
If your changes have a user-facing impact, describe how a non-technical QA team can functionally test your changes in a preview environment.

If they are not user-facing please describe how to test for any regressions that may occur.
------------------------------------------------------------------------------>

- ☝🏽 

## Screenshots (if applicable)

Spot the 4 differences, can you guess which one is develop and which one is this diff?

https://github.com/shapeshift/web/assets/17035424/db56eaf9-8a30-4121-98f5-dcfc8cd79e10


