### PR TITLE
fix: thorchain LP add liquidity radio shenanigans

### DIFF
--- a/src/pages/ThorChainLP/components/LpType.tsx
+++ b/src/pages/ThorChainLP/components/LpType.tsx
@@ -2,7 +2,7 @@ import type { RadioProps } from '@chakra-ui/react'
 import { Box, Flex, HStack, useRadio, useRadioGroup } from '@chakra-ui/react'
 import type { AssetId } from '@shapeshiftoss/caip'
 import { thorchainAssetId } from '@shapeshiftoss/caip'
-import React, { useCallback, useMemo } from 'react'
+import React, { useCallback, useEffect, useMemo } from 'react'
 import { BiSolidBoltCircle } from 'react-icons/bi'
 import { AssetSymbol } from 'components/AssetSymbol'
 import { RawText } from 'components/Text'
@@ -94,11 +94,17 @@ export const LpType = ({ assetId, defaultOpportunityId, onAsymSideChange }: Depo
     [assetId, assetIds],
   )
 
-  const { getRootProps, getRadioProps } = useRadioGroup({
+  const { getRootProps, getRadioProps, setValue } = useRadioGroup({
     name: 'depositType',
     defaultValue: 'sym',
     onChange: onAsymSideChange,
   })
+
+  // Reset the radio state to sym on assetId change, meaning pool change
+  // This is to ensure the radio is synchronized with the actual default sym pool being selected on pool change
+  useEffect(() => {
+    setValue('sym')
+  }, [assetId, setValue])
 
   const radioOptions = useMemo(() => {
     const _options = defaultOpportunityId ? options : []


### PR DESCRIPTION
## Description

Fixes the current shenanigans WRT radio selection, where selecting an asym side then switching assets would select sym as a default under the hood, but whatever was the previously selected radio option will stay selected.

## Pull Request Type

- [x] :bug: Bug fix (Non-breaking Change: Fixes an issue)
- [ ] :hammer_and_wrench: Chore (Non-breaking Change: Doc updates, pkg upgrades, typos, etc..)
- [ ] :nail_care: New Feature (Breaking/Non-breaking Change)

## Issue (if applicable)

<!-----------------------------------------------------------------------------
If applicable, please link to the github issue and put `closes #XXXX` in your comment to auto-close the issue that your PR fixes.
------------------------------------------------------------------------------>

N/A

## Risk
> High Risk PRs Require 2 approvals

<!-----------------------------------------------------------------------------
Outline the scope of your changes and the risk associated with them. You must use your discretion as an engineer to determine the potential impact of your changes.

WARNING: If your PR introduces a new on-chain transaction or modifies an existing one, please add the "High-Risk" label to this PR and ask for 2 reviewers to approve it before merging.

E.g. an upgrade to `hdwallet` or core state management would be considered higher risk, and might require a full regression test. UI or isolated view changes, or something behind a feature flag may have near zero risk. Small bug fixes might require testing isolated to the specific fix.
------------------------------------------------------------------------------>

> What protocols, transaction types or contract interactions might be affected by this PR?

## Testing

<!-----------------------------------------------------------------------------
We treat every PR to be merged with the same scrutiny as if we were merging directly to production.

Your PR will not be merged if you do not complete the sections below for our engineering and operations teams to test.
------------------------------------------------------------------------------>

- Go to "Add Liquidity" page
- On the default pool, select either the AVAX or RUNE sym side
- Select another pool
- Ensure the radio selection is reset to the default sym side

### Engineering

<!-----------------------------------------------------------------------------
Include sufficient information here for an engineer to test your PR. This may include how to test locally, in a built environment, changes to infrastructure etc.
------------------------------------------------------------------------------>

### Operations

<!-----------------------------------------------------------------------------
If your changes have a user-facing impact, describe how a non-technical QA team can functionally test your changes in a preview environment.

If they are not user-facing please describe how to test for any regressions that may occur.
------------------------------------------------------------------------------>

## Screenshots (if applicable)

- develop


https://github.com/shapeshift/web/assets/17035424/649cf46f-6f37-4561-817b-71aa29b11828


- this diff

https://github.com/shapeshift/web/assets/17035424/e490f7e5-3169-4db6-a831-b2ce85085895


https://github.com/shapeshift/web/assets/17035424/8aa083ca-e52b-4fcf-bc10-3c9f85c24102

