### PR TITLE
feat: remove thorchain deposit memo monkey patch

### DIFF
--- a/src/state/slices/opportunitiesSlice/resolvers/thorchainsavers/utils.test.ts
+++ b/src/state/slices/opportunitiesSlice/resolvers/thorchainsavers/utils.test.ts
@@ -52,7 +52,7 @@ const btcQuoteResponse = {
   slippage_bps: 2,
 }
 
-const thorchainSaversDepositQuote = Object.assign({}, btcQuoteResponse, { memo: '+:BTC/BTC::ss:0' })
+const thorchainSaversDepositQuote = btcQuoteResponse
 
 const thorchainErrorResponse = {
   error: 'Invalid pool',

--- a/src/state/slices/opportunitiesSlice/resolvers/thorchainsavers/utils.ts
+++ b/src/state/slices/opportunitiesSlice/resolvers/thorchainsavers/utils.ts
@@ -176,7 +176,6 @@ export const getMaybeThorchainSaversDepositQuote = async ({
 
   return Ok({
     ...quoteData,
-    memo: `${quoteData.memo}::${THORCHAIN_AFFILIATE_NAME}:${AFFILIATE_BPS}`,
   })
 }
 


### PR DESCRIPTION
## Description

Paranoia PR, honoring the THORChain deposit memo as-is from THOR, instead of adding `::ss:0` ss affiliate and 0 bps

See https://discord.com/channels/838986635756044328/929872517794000986/1205168906738597928 for more details:

```
Potential Loss of Funds for Savers Deposit w/ Affiliate Fee

If your UI is taking an affiliate fee on savers deposits, please continue reading. This is very important and could result in loss of customer funds.

A user makes a deposit and there is a thorname + affiliate fee set, e.g. +:BSC/BNB::mydex:10 : if you did not register an alias for that chain on your affiliate thorname, the affiliate fee is unable to be paid out. This will cause the transaction to fail, and due to some other bug in THORChain, the users funds will be swallowed. We hope to address the root cause in the next update, but all affiliates that are taking fees on savers deposit should immediately register aliases for all chains to avoid this happening.

And, it goes without saying, if you are going to use certain THORChain features, test them on mainnet for all possible routes, before turning them on for your customers.
```

## Pull Request Type

- [ ] :bug: Bug fix (Non-breaking Change: Fixes an issue)
- [ ] :hammer_and_wrench: Chore (Non-breaking Change: Doc updates, pkg upgrades, typos, etc..)
- [x] :nail_care: New Feature (Breaking/Non-breaking Change)

## Issue (if applicable)

<!-----------------------------------------------------------------------------
If applicable, please link to the github issue and put `closes #XXXX` in your comment to auto-close the issue that your PR fixes.
------------------------------------------------------------------------------>

N/A

## Risk
> High Risk PRs Require 2 approvals

<!-----------------------------------------------------------------------------
Outline the scope of your changes and the risk associated with them. You must use your discretion as an engineer to determine the potential impact of your changes.

WARNING: If your PR introduces a new on-chain transaction or modifies an existing one, please add the "High-Risk" label to this PR and ask for 2 reviewers to approve it before merging.

E.g. an upgrade to `hdwallet` or core state management would be considered higher risk, and might require a full regression test. UI or isolated view changes, or something behind a feature flag may have near zero risk. Small bug fixes might require testing isolated to the specific fix.
------------------------------------------------------------------------------>

None, we now literally author the memo as returned to us by THOR's API

> What protocols, transaction types or contract interactions might be affected by this PR?

## Testing

<!-----------------------------------------------------------------------------
We treat every PR to be merged with the same scrutiny as if we were merging directly to production.

Your PR will not be merged if you do not complete the sections below for our engineering and operations teams to test.
------------------------------------------------------------------------------>

### Engineering

<!-----------------------------------------------------------------------------
Include sufficient information here for an engineer to test your PR. This may include how to test locally, in a built environment, changes to infrastructure etc.
------------------------------------------------------------------------------>

### Operations

<!-----------------------------------------------------------------------------
If your changes have a user-facing impact, describe how a non-technical QA team can functionally test your changes in a preview environment.

If they are not user-facing please describe how to test for any regressions that may occur.
------------------------------------------------------------------------------>

## Screenshots (if applicable)

<img width="489" alt="image" src="https://github.com/shapeshift/web/assets/17035424/8f20dc02-327f-46c3-bd6f-10076395b045">
<img width="388" alt="image" src="https://github.com/shapeshift/web/assets/17035424/35381e21-c4e4-4dcc-a278-acd2bc00d105">

https://etherscan.io/tx/0x571a18cb4fd314b966f732e61016a4c4c4aa38ffb841ff42d3fce2d3db9ab700
