### PR TITLE
feat: improve thorchain savers JIT halted checks

### DIFF
--- a/src/features/defi/providers/thorchain-savers/components/ThorchainSaversManager/Deposit/components/Confirm.tsx
+++ b/src/features/defi/providers/thorchain-savers/components/ThorchainSaversManager/Deposit/components/Confirm.tsx
@@ -540,12 +540,21 @@ export const Confirm: React.FC<ConfirmProps> = ({ accountId, onNext }) => {
     })()
   }, [accountId, accountMetadata, accountType, assetId, bip44Params, chainAdapter, wallet])
 
-  const { data: isTradingActive, refetch: refetchIsTradingActive } = useQuery(
-    reactQueries.common.isTradingActive({
+  const { data: isTradingActive, refetch: refetchIsTradingActive } = useQuery({
+    ...reactQueries.common.isTradingActive({
       assetId,
       swapperName: SwapperName.Thorchain,
     }),
-  )
+    // @lukemorales/query-key-factory only returns queryFn and queryKey - all others will be ignored in the returned object
+    enabled: Boolean(assetId),
+    // Go stale instantly
+    staleTime: 0,
+    // Never store queries in cache since we always want fresh data
+    gcTime: 0,
+    refetchOnWindowFocus: true,
+    refetchOnMount: true,
+    refetchInterval: 60_000,
+  })
 
   const handleDeposit = useCallback(async () => {
     if (!contextDispatch || !bip44Params || !accountId || !assetId) return

--- a/src/features/defi/providers/thorchain-savers/components/ThorchainSaversManager/Deposit/components/Confirm.tsx
+++ b/src/features/defi/providers/thorchain-savers/components/ThorchainSaversManager/Deposit/components/Confirm.tsx
@@ -721,7 +721,12 @@ export const Confirm: React.FC<ConfirmProps> = ({ accountId, onNext }) => {
       onCancel={handleCancel}
       onConfirm={handleDeposit}
       preFooter={preFooter}
-      isDisabled={!hasEnoughBalanceForGas || !userAddress || disableSmartContractDeposit}
+      isDisabled={
+        !hasEnoughBalanceForGas ||
+        !userAddress ||
+        disableSmartContractDeposit ||
+        isTradingActive === false
+      }
       loading={state.loading || !userAddress || isAddressByteCodeLoading}
       loadingText={translate('common.confirm')}
       headerText='modals.confirm.deposit.header'

--- a/src/features/defi/providers/thorchain-savers/components/ThorchainSaversManager/Overview/ThorchainSaversOverview.tsx
+++ b/src/features/defi/providers/thorchain-savers/components/ThorchainSaversManager/Overview/ThorchainSaversOverview.tsx
@@ -17,6 +17,7 @@ import { toAssetId } from '@shapeshiftoss/caip'
 import { SwapperName } from '@shapeshiftoss/swapper'
 import type { Asset } from '@shapeshiftoss/types'
 import { TxStatus } from '@shapeshiftoss/unchained-client'
+import { useQuery } from '@tanstack/react-query'
 import BigNumber from 'bignumber.js'
 import type { DefiButtonProps } from 'features/defi/components/DefiActionButtons'
 import { Overview } from 'features/defi/components/Overview/Overview'
@@ -28,6 +29,7 @@ import { DefiAction } from 'features/defi/contexts/DefiManagerProvider/DefiCommo
 import { useCallback, useEffect, useMemo, useState } from 'react'
 import { FaTwitter } from 'react-icons/fa'
 import { useTranslate } from 'react-polyglot'
+import { reactQueries } from 'react-queries'
 import type { AccountDropdownProps } from 'components/AccountDropdown/AccountDropdown'
 import { Amount } from 'components/Amount/Amount'
 import { CircularProgress } from 'components/CircularProgress/CircularProgress'
@@ -36,7 +38,6 @@ import { Text } from 'components/Text'
 import { useBrowserRouter } from 'hooks/useBrowserRouter/useBrowserRouter'
 import { bnOrZero } from 'lib/bignumber/bignumber'
 import { fromBaseUnit, toBaseUnit } from 'lib/math'
-import { useGetIsTradingActiveQuery } from 'state/apis/swapper/swapperApi'
 import type { ThorchainSaversStakingSpecificMetadata } from 'state/slices/opportunitiesSlice/resolvers/thorchainsavers/types'
 import {
   getMaybeThorchainSaversDepositQuote,
@@ -129,11 +130,12 @@ export const ThorchainSaversOverview: React.FC<OverviewProps> = ({
     [accountId, defaultAccountId, highestBalanceAccountId],
   )
 
-  const { data: isTradingActive, isFetching: isTradingActiveQueryPending } =
-    useGetIsTradingActiveQuery({
+  const { data: isTradingActive, isLoading: isTradingActiveLoading } = useQuery(
+    reactQueries.common.isTradingActive({
       assetId,
       swapperName: SwapperName.Thorchain,
-    })
+    }),
+  )
 
   useEffect(() => {
     if (!maybeAccountId) return
@@ -272,7 +274,7 @@ export const ThorchainSaversOverview: React.FC<OverviewProps> = ({
       isFull: opportunityMetadata?.isFull || isHardCapReached,
       hasPendingTxs,
       hasPendingQueries,
-      isHalted: !isTradingActive,
+      isHalted: isTradingActive === false,
     })
   }, [
     earnOpportunityData,
@@ -355,7 +357,7 @@ export const ThorchainSaversOverview: React.FC<OverviewProps> = ({
 
   const handleThorchainSaversEmptyClick = useCallback(() => setHideEmptyState(true), [])
 
-  if (!earnOpportunityData || isTradingActiveQueryPending) {
+  if (!earnOpportunityData || isTradingActiveLoading) {
     return (
       <Center minW='500px' minH='350px'>
         <CircularProgress />

--- a/src/features/defi/providers/thorchain-savers/components/ThorchainSaversManager/Overview/ThorchainSaversOverview.tsx
+++ b/src/features/defi/providers/thorchain-savers/components/ThorchainSaversManager/Overview/ThorchainSaversOverview.tsx
@@ -130,12 +130,21 @@ export const ThorchainSaversOverview: React.FC<OverviewProps> = ({
     [accountId, defaultAccountId, highestBalanceAccountId],
   )
 
-  const { data: isTradingActive, isLoading: isTradingActiveLoading } = useQuery(
-    reactQueries.common.isTradingActive({
+  const { data: isTradingActive, isLoading: isTradingActiveLoading } = useQuery({
+    ...reactQueries.common.isTradingActive({
       assetId,
       swapperName: SwapperName.Thorchain,
     }),
-  )
+    // @lukemorales/query-key-factory only returns queryFn and queryKey - all others will be ignored in the returned object
+    enabled: Boolean(assetId),
+    // Go stale instantly
+    staleTime: 0,
+    // Never store queries in cache since we always want fresh data
+    gcTime: 0,
+    refetchOnWindowFocus: true,
+    refetchOnMount: true,
+    refetchInterval: 60_000,
+  })
 
   useEffect(() => {
     if (!maybeAccountId) return

--- a/src/features/defi/providers/thorchain-savers/components/ThorchainSaversManager/Withdraw/components/Confirm.tsx
+++ b/src/features/defi/providers/thorchain-savers/components/ThorchainSaversManager/Withdraw/components/Confirm.tsx
@@ -16,6 +16,7 @@ import { FeeDataKey } from '@shapeshiftoss/chain-adapters'
 import type { BuildCustomTxInput } from '@shapeshiftoss/chain-adapters/src/evm/types'
 import { supportsETH } from '@shapeshiftoss/hdwallet-core'
 import { SwapperName } from '@shapeshiftoss/swapper'
+import { useQuery } from '@tanstack/react-query'
 import { getConfig } from 'config'
 import { getOrCreateContractByType } from 'contracts/contractManager'
 import { ContractType } from 'contracts/types'
@@ -29,6 +30,7 @@ import type {
 import { DefiStep } from 'features/defi/contexts/DefiManagerProvider/DefiCommon'
 import { useCallback, useContext, useEffect, useMemo, useState } from 'react'
 import { useTranslate } from 'react-polyglot'
+import { reactQueries } from 'react-queries'
 import { encodeFunctionData, getAddress } from 'viem'
 import { Amount } from 'components/Amount/Amount'
 import { AssetIcon } from 'components/AssetIcon'
@@ -58,7 +60,6 @@ import {
 import { fromThorBaseUnit, toThorBaseUnit } from 'lib/utils/thorchain'
 import { BASE_BPS_POINTS } from 'lib/utils/thorchain/constants'
 import { getInboundAddressDataForChain } from 'lib/utils/thorchain/getInboundAddressDataForChain'
-import { swapperApi } from 'state/apis/swapper/swapperApi'
 import {
   getThorchainSaversPosition,
   getThorchainSaversWithdrawQuote,
@@ -79,7 +80,7 @@ import {
   selectPortfolioCryptoBalanceBaseUnitByFilter,
   selectSelectedCurrency,
 } from 'state/slices/selectors'
-import { useAppDispatch, useAppSelector } from 'state/store'
+import { useAppSelector } from 'state/store'
 
 import { ThorchainSaversWithdrawActionType } from '../WithdrawCommon'
 import { WithdrawContext } from '../WithdrawContext'
@@ -98,7 +99,6 @@ export const Confirm: React.FC<ConfirmProps> = ({ accountId, onNext }) => {
     null,
   )
   const { state, dispatch: contextDispatch } = useContext(WithdrawContext)
-  const appDispatch = useAppDispatch()
   const translate = useTranslate()
   const mixpanel = getMixPanel()
   const { query } = useBrowserRouter<DefiQueryParams, DefiParams>()
@@ -594,6 +594,13 @@ export const Confirm: React.FC<ConfirmProps> = ({ accountId, onNext }) => {
     return txId
   }, [getWithdrawInput, wallet])
 
+  const { data: isTradingActive, refetch: refetchIsTradingActive } = useQuery(
+    reactQueries.common.isTradingActive({
+      assetId,
+      swapperName: SwapperName.Thorchain,
+    }),
+  )
+
   const handleConfirm = useCallback(async () => {
     if (!contextDispatch || !bip44Params || !accountId || !assetId || !opportunityData) return
     try {
@@ -625,15 +632,15 @@ export const Confirm: React.FC<ConfirmProps> = ({ accountId, onNext }) => {
         return
       }
 
-      const { getIsTradingActive } = swapperApi.endpoints
-      const { data: isTradingActive } = await appDispatch(
-        getIsTradingActive.initiate({
-          assetId,
-          swapperName: SwapperName.Thorchain,
-        }),
-      )
+      // Was the pool active when it was fetched at the time of the component mount
+      if (isTradingActive === false) {
+        throw new Error(`THORChain pool halted for assetId: ${assetId}`)
+      }
 
-      if (!isTradingActive) {
+      // Refetch the trading active state JIT to ensure the pool didn't just become halted
+      const { data: isTradingActiveData } = await refetchIsTradingActive()
+
+      if (!isTradingActiveData) {
         throw new Error(`THORChain pool halted for assetId: ${assetId}`)
       }
 
@@ -701,8 +708,8 @@ export const Confirm: React.FC<ConfirmProps> = ({ accountId, onNext }) => {
     state?.withdraw.cryptoAmount,
     state?.withdraw.fiatAmount,
     expiry,
-    appDispatch,
-    getWithdrawInput,
+    isTradingActive,
+    refetchIsTradingActive,
     dustAmountCryptoBaseUnit,
     protocolFeeCryptoBaseUnit,
     onNext,
@@ -710,6 +717,7 @@ export const Confirm: React.FC<ConfirmProps> = ({ accountId, onNext }) => {
     toast,
     translate,
     isTokenWithdraw,
+    getWithdrawInput,
     handleMultiTxSend,
     handleCustomTx,
   ])

--- a/src/features/defi/providers/thorchain-savers/components/ThorchainSaversManager/Withdraw/components/Confirm.tsx
+++ b/src/features/defi/providers/thorchain-savers/components/ThorchainSaversManager/Withdraw/components/Confirm.tsx
@@ -826,7 +826,11 @@ export const Confirm: React.FC<ConfirmProps> = ({ accountId, onNext }) => {
       preFooter={preFooter}
       headerText='modals.confirm.withdraw.header'
       isDisabled={
-        !hasEnoughBalanceForGas || !userAddress || disableSmartContractWithdraw || !canWithdraw
+        !hasEnoughBalanceForGas ||
+        !userAddress ||
+        disableSmartContractWithdraw ||
+        !canWithdraw ||
+        isTradingActive === false
       }
       loading={quoteLoading || state.loading || !userAddress || isAddressByteCodeLoading}
       loadingText={translate('common.confirm')}

--- a/src/features/defi/providers/thorchain-savers/components/ThorchainSaversManager/Withdraw/components/Confirm.tsx
+++ b/src/features/defi/providers/thorchain-savers/components/ThorchainSaversManager/Withdraw/components/Confirm.tsx
@@ -594,12 +594,21 @@ export const Confirm: React.FC<ConfirmProps> = ({ accountId, onNext }) => {
     return txId
   }, [getWithdrawInput, wallet])
 
-  const { data: isTradingActive, refetch: refetchIsTradingActive } = useQuery(
-    reactQueries.common.isTradingActive({
+  const { data: isTradingActive, refetch: refetchIsTradingActive } = useQuery({
+    ...reactQueries.common.isTradingActive({
       assetId,
       swapperName: SwapperName.Thorchain,
     }),
-  )
+    // @lukemorales/query-key-factory only returns queryFn and queryKey - all others will be ignored in the returned object
+    enabled: Boolean(assetId),
+    // Go stale instantly
+    staleTime: 0,
+    // Never store queries in cache since we always want fresh data
+    gcTime: 0,
+    refetchOnWindowFocus: true,
+    refetchOnMount: true,
+    refetchInterval: 60_000,
+  })
 
   const handleConfirm = useCallback(async () => {
     if (!contextDispatch || !bip44Params || !accountId || !assetId || !opportunityData) return

--- a/src/pages/ThorChainLP/AvailablePools.tsx
+++ b/src/pages/ThorChainLP/AvailablePools.tsx
@@ -51,12 +51,20 @@ type PoolButtonProps = {
 const PoolButton = ({ pool }: PoolButtonProps) => {
   const history = useHistory()
 
-  const { data: isTradingActive, isLoading: isTradingActiveLoading } = useQuery(
-    reactQueries.common.isTradingActive({
+  const { data: isTradingActive, isLoading: isTradingActiveLoading } = useQuery({
+    ...reactQueries.common.isTradingActive({
       assetId: pool.assetId,
       swapperName: SwapperName.Thorchain,
     }),
-  )
+    // @lukemorales/query-key-factory only returns queryFn and queryKey - all others will be ignored in the returned object
+    // Go stale instantly
+    staleTime: 0,
+    // Never store queries in cache since we always want fresh data
+    gcTime: 0,
+    refetchOnWindowFocus: true,
+    refetchOnMount: true,
+    refetchInterval: 60_000,
+  })
 
   const handlePoolClick = useCallback(() => {
     const { opportunityId } = pool

--- a/src/pages/ThorChainLP/Pool/Pool.tsx
+++ b/src/pages/ThorChainLP/Pool/Pool.tsx
@@ -102,12 +102,21 @@ export const Pool = () => {
     return parsedPools.find(pool => pool.opportunityId === routeOpportunityId)
   }, [params, parsedPools])
 
-  const { data: isTradingActive, isLoading: isTradingActiveLoading } = useQuery(
-    reactQueries.common.isTradingActive({
+  const { data: isTradingActive, isLoading: isTradingActiveLoading } = useQuery({
+    ...reactQueries.common.isTradingActive({
       assetId: foundPool?.assetId,
       swapperName: SwapperName.Thorchain,
     }),
-  )
+    // @lukemorales/query-key-factory only returns queryFn and queryKey - all others will be ignored in the returned object
+    enabled: Boolean(foundPool?.assetId),
+    // Go stale instantly
+    staleTime: 0,
+    // Never store queries in cache since we always want fresh data
+    gcTime: 0,
+    refetchOnWindowFocus: true,
+    refetchOnMount: true,
+    refetchInterval: 60_000,
+  })
 
   const poolAssetIds = useMemo(() => {
     if (!foundPool) return []

--- a/src/pages/ThorChainLP/components/AddLiquitity/AddLiquidityInput.tsx
+++ b/src/pages/ThorChainLP/components/AddLiquitity/AddLiquidityInput.tsx
@@ -36,8 +36,10 @@ import { TradeAssetInput } from 'components/MultiHopTrade/components/TradeAssetI
 import { Row } from 'components/Row/Row'
 import { SlideTransition } from 'components/SlideTransition'
 import { useBrowserRouter } from 'hooks/useBrowserRouter/useBrowserRouter'
+import { useIsSnapInstalled } from 'hooks/useIsSnapInstalled/useIsSnapInstalled'
 import { useModal } from 'hooks/useModal/useModal'
 import { useWallet } from 'hooks/useWallet/useWallet'
+import { walletSupportsChain } from 'hooks/useWalletSupportsChain/useWalletSupportsChain'
 import { bn, bnOrZero, convertPrecision } from 'lib/bignumber/bignumber'
 import { calculateFees } from 'lib/fees/model'
 import { fromBaseUnit, toBaseUnit } from 'lib/math'
@@ -55,6 +57,7 @@ import { usePools } from 'pages/ThorChainLP/queries/hooks/usePools'
 import { getThorchainLpPosition } from 'pages/ThorChainLP/queries/queries'
 import { selectIsSnapshotApiQueriesPending, selectVotingPower } from 'state/apis/snapshot/selectors'
 import {
+  selectAccountIdsByAssetId,
   selectAccountNumberByAccountId,
   selectAssetById,
   selectAssets,
@@ -144,6 +147,8 @@ export const AddLiquidityInput: React.FC<AddLiquidityInputProps> = ({
     if (opportunityId) return undefined
     if (paramOpportunityId) return paramOpportunityId
 
+    // This may be wrong if the asset doesn't support said opportunity in an asym way, but this is only used to indicate the default pool really
+    // Trying to fix this to be semantically correct will result in circular dependencies madness, don't try this if you value your sanity
     const firstAsymOpportunityId = parsedPools.find(pool => pool.asymSide === null)?.opportunityId
 
     return firstAsymOpportunityId
@@ -184,6 +189,26 @@ export const AddLiquidityInput: React.FC<AddLiquidityInputProps> = ({
 
   const [poolAsset, setPoolAsset] = useState<Asset | undefined>(foundPoolAsset)
 
+  const thorchainAccountIds = useAppSelector(state =>
+    selectAccountIdsByAssetId(state, { assetId: thorchainAssetId }),
+  )
+  const poolAssetAccountIds = useAppSelector(state =>
+    selectAccountIdsByAssetId(state, { assetId: poolAsset?.assetId ?? '' }),
+  )
+
+  const isSnapInstalled = useIsSnapInstalled()
+  const walletSupportsRune =
+    walletSupportsChain({ chainId: thorchainChainId, wallet, isSnapInstalled }) &&
+    thorchainAccountIds.length > 0
+  const walletSupportsAsset =
+    poolAsset &&
+    walletSupportsChain({
+      chainId: fromAssetId(poolAsset.assetId).chainId,
+      wallet,
+      isSnapInstalled,
+    }) &&
+    poolAssetAccountIds.length > 0
+
   const { data: isTradingActive, isLoading: isTradingActiveLoading } = useQuery(
     reactQueries.common.isTradingActive({
       assetId: poolAsset?.assetId,
@@ -196,12 +221,15 @@ export const AddLiquidityInput: React.FC<AddLiquidityInputProps> = ({
     // We only want to run this effect in the standalone AddLiquidity page
     if (!defaultOpportunityId) return
 
-    const foundOpportunityId = (parsedPools ?? []).find(
-      pool => pool.assetId === poolAsset.assetId && pool.asymSide === null,
-    )?.opportunityId
+    const foundOpportunityId = parsedPools.find(pool => {
+      if (walletSupportsRune && walletSupportsAsset) return pool.asymSide === null
+      if (walletSupportsAsset) return pool.asymSide === AsymSide.Asset
+      if (walletSupportsRune) return pool.asymSide === AsymSide.Rune
+      return false
+    })?.opportunityId
     if (!foundOpportunityId) return
     setActiveOpportunityId(foundOpportunityId)
-  }, [poolAsset, defaultOpportunityId, parsedPools])
+  }, [poolAsset, defaultOpportunityId, parsedPools, walletSupportsAsset, walletSupportsRune])
 
   const handleAssetChange = useCallback((asset: Asset) => {
     console.info(asset)

--- a/src/pages/ThorChainLP/components/AddLiquitity/AddLiquidityInput.tsx
+++ b/src/pages/ThorChainLP/components/AddLiquitity/AddLiquidityInput.tsx
@@ -209,12 +209,21 @@ export const AddLiquidityInput: React.FC<AddLiquidityInputProps> = ({
     }) &&
     poolAssetAccountIds.length > 0
 
-  const { data: isTradingActive, isLoading: isTradingActiveLoading } = useQuery(
-    reactQueries.common.isTradingActive({
+  const { data: isTradingActive, isLoading: isTradingActiveLoading } = useQuery({
+    ...reactQueries.common.isTradingActive({
       assetId: poolAsset?.assetId,
       swapperName: SwapperName.Thorchain,
     }),
-  )
+    // @lukemorales/query-key-factory only returns queryFn and queryKey - all others will be ignored in the returned object
+    enabled: Boolean(poolAsset?.assetId),
+    // Go stale instantly
+    staleTime: 0,
+    // Never store queries in cache since we always want fresh data
+    gcTime: 0,
+    refetchOnWindowFocus: true,
+    refetchOnMount: true,
+    refetchInterval: 60_000,
+  })
 
   useEffect(() => {
     if (!(poolAsset && parsedPools)) return

--- a/src/pages/ThorChainLP/components/LpType.tsx
+++ b/src/pages/ThorChainLP/components/LpType.tsx
@@ -1,12 +1,17 @@
 import type { RadioProps } from '@chakra-ui/react'
 import { Box, Flex, HStack, useRadio, useRadioGroup } from '@chakra-ui/react'
 import type { AssetId } from '@shapeshiftoss/caip'
-import { thorchainAssetId } from '@shapeshiftoss/caip'
+import { fromAssetId, thorchainAssetId, thorchainChainId } from '@shapeshiftoss/caip'
 import React, { useCallback, useEffect, useMemo } from 'react'
 import { BiSolidBoltCircle } from 'react-icons/bi'
 import { AssetSymbol } from 'components/AssetSymbol'
 import { RawText } from 'components/Text'
+import { useIsSnapInstalled } from 'hooks/useIsSnapInstalled/useIsSnapInstalled'
+import { useWallet } from 'hooks/useWallet/useWallet'
+import { walletSupportsChain } from 'hooks/useWalletSupportsChain/useWalletSupportsChain'
 import { AsymSide } from 'lib/utils/thorchain/lp/types'
+import { selectAccountIdsByAssetId } from 'state/slices/selectors'
+import { useAppSelector } from 'state/store'
 
 import { PoolIcon } from './PoolIcon'
 
@@ -19,6 +24,11 @@ const checked = {
 }
 const hover = {
   borderColor: 'border.hover',
+}
+
+const disabled = {
+  opacity: 0.4,
+  cursor: 'not-allowed',
 }
 
 const TypeLabel: React.FC<{ assetIds: AssetId[] }> = ({ assetIds }) => {
@@ -53,6 +63,7 @@ const TypeRadio: React.FC<RadioProps> = props => {
         transitionDuration='normal'
         _hover={hover}
         _checked={checked}
+        _disabled={disabled}
         {...checkbox}
       >
         {props.children}
@@ -79,6 +90,14 @@ type DepositTypeProps = {
   defaultOpportunityId?: string
 }
 export const LpType = ({ assetId, defaultOpportunityId, onAsymSideChange }: DepositTypeProps) => {
+  const wallet = useWallet().state.wallet
+  const isSnapInstalled = useIsSnapInstalled()
+
+  const thorchainAccountIds = useAppSelector(state =>
+    selectAccountIdsByAssetId(state, { assetId: thorchainAssetId }),
+  )
+  const poolAssetAccountIds = useAppSelector(state => selectAccountIdsByAssetId(state, { assetId }))
+
   const assetIds = useMemo(() => {
     return [assetId, thorchainAssetId]
   }, [assetId])
@@ -94,17 +113,49 @@ export const LpType = ({ assetId, defaultOpportunityId, onAsymSideChange }: Depo
     [assetId, assetIds],
   )
 
+  const supportsRune = useMemo(() => {
+    const walletSupportsRune = walletSupportsChain({
+      chainId: thorchainChainId,
+      wallet,
+      isSnapInstalled,
+    })
+
+    return walletSupportsRune && thorchainAccountIds.length > 0
+  }, [isSnapInstalled, thorchainAccountIds.length, wallet])
+
+  const supportsAsset = useMemo(() => {
+    const walletSupportsAsset = walletSupportsChain({
+      chainId: fromAssetId(assetId).chainId,
+      wallet,
+      isSnapInstalled,
+    })
+
+    return walletSupportsAsset && poolAssetAccountIds.length > 0
+  }, [assetId, isSnapInstalled, poolAssetAccountIds.length, wallet])
+
+  const defaultValue = useMemo(() => {
+    if (supportsRune && supportsAsset) return 'sym'
+    if (supportsAsset) return AsymSide.Asset
+    if (supportsRune) return AsymSide.Rune
+  }, [supportsAsset, supportsRune])
+
   const { getRootProps, getRadioProps, setValue } = useRadioGroup({
     name: 'depositType',
-    defaultValue: 'sym',
+    defaultValue,
     onChange: onAsymSideChange,
   })
 
-  // Reset the radio state to sym on assetId change, meaning pool change
-  // This is to ensure the radio is synchronized with the actual default sym pool being selected on pool change
   useEffect(() => {
-    setValue('sym')
-  }, [assetId, setValue])
+    if (!defaultValue) {
+      // We've switched to an asset for which none of the a/sym types are supported, make sure the previously selected value is cleared
+      setValue('')
+      return
+    }
+
+    // Reset the radio state to default pool type on assetId change, meaning pool change
+    // This is to ensure the radio is synchronized with the actual default sym pool being selected on pool change
+    setValue(defaultValue)
+  }, [assetId, defaultValue, setValue])
 
   const radioOptions = useMemo(() => {
     const _options = defaultOpportunityId ? options : []
@@ -113,8 +164,15 @@ export const LpType = ({ assetId, defaultOpportunityId, onAsymSideChange }: Depo
       const radio = getRadioProps({ value: option.value })
 
       const optionAssetIds = makeAssetIdsOption(option.value as AsymSide | 'sym')
+      const walletSupportsOption = optionAssetIds.every(assetId => {
+        const isRune = assetId === thorchainAssetId
+
+        return isRune ? supportsRune : supportsAsset
+      })
+
+      const isDisabled = !walletSupportsOption
       return (
-        <TypeRadio key={`type-${index}`} {...radio}>
+        <TypeRadio key={`type-${index}`} {...radio} isDisabled={isDisabled}>
           <PoolIcon assetIds={optionAssetIds} size='xs' />
           <Flex mt={4} fontSize='sm' justifyContent='space-between' alignItems='center'>
             <TypeLabel assetIds={optionAssetIds} />
@@ -127,7 +185,7 @@ export const LpType = ({ assetId, defaultOpportunityId, onAsymSideChange }: Depo
         </TypeRadio>
       )
     })
-  }, [defaultOpportunityId, getRadioProps, makeAssetIdsOption])
+  }, [defaultOpportunityId, getRadioProps, makeAssetIdsOption, supportsAsset, supportsRune])
 
   const group = getRootProps()
   return (

--- a/src/pages/ThorChainLP/components/ReusableLpStatus/TransactionRow.tsx
+++ b/src/pages/ThorChainLP/components/ReusableLpStatus/TransactionRow.tsx
@@ -105,12 +105,21 @@ export const TransactionRow: React.FC<TransactionRowProps> = ({
     isLoading: isTradingActiveLoading,
     isRefetching: isTradingActiveRefetching,
     refetch: refetchIsTradingActive,
-  } = useQuery(
-    reactQueries.common.isTradingActive({
+  } = useQuery({
+    ...reactQueries.common.isTradingActive({
       assetId: poolAssetId,
       swapperName: SwapperName.Thorchain,
     }),
-  )
+    // @lukemorales/query-key-factory only returns queryFn and queryKey - all others will be ignored in the returned object
+    enabled: Boolean(poolAssetId),
+    // Go stale instantly
+    staleTime: 0,
+    // Never store queries in cache since we always want fresh data
+    gcTime: 0,
+    refetchOnWindowFocus: true,
+    refetchOnMount: true,
+    refetchInterval: 60_000,
+  })
 
   const runeAccountId = accountIdsByChainId[thorchainChainId]
   const poolAssetAccountId =

--- a/src/react-queries/index.ts
+++ b/src/react-queries/index.ts
@@ -82,14 +82,6 @@ const common = createQueryKeys('common', {
       if (maybeIsTradingActive.isErr()) throw maybeIsTradingActive.unwrapErr()
       return maybeIsTradingActive.unwrap()
     },
-    enabled: Boolean(assetId),
-    // Go stale instantly
-    staleTime: 0,
-    // Never store queries in cache since we always want fresh data
-    gcTime: 0,
-    refetchOnWindowFocus: true,
-    refetchOnMount: true,
-    refetchInterval: 60_000,
   }),
 })
 

--- a/src/state/apis/swapper/swapperApi.ts
+++ b/src/state/apis/swapper/swapperApi.ts
@@ -244,5 +244,4 @@ export const swapperApi = swapperApiBase.injectEndpoints({
   }),
 })
 
-export const { useGetTradeQuoteQuery, useGetSupportedAssetsQuery, useGetIsTradingActiveQuery } =
-  swapperApi
+export const { useGetTradeQuoteQuery, useGetSupportedAssetsQuery } = swapperApi


### PR DESCRIPTION
## Description

This PR brings in improvements in JIT halted state fetching for savers

- uses the new `isTradingActive` react-query in the PR underneath this one in the stack to ensure fresh halted data at
  - overview
  - confirm *component*
  - confirm *signing* (i.e with a refetch)
  
Most importantly, this fixes some found "issue" (apparently a feature, though the types didn't reflect this) found within `@lukemorales/query-key-factory`: it only returns `queryFn` and `queryKey` - all other defaults defined in the queries will be ommitted.
This effectively meant we were ditching all the options of `isTradingActive`, such as `gcTime`, which is the guts of `isTradingActive` always getting fresh data. In other words, we thought we were getting fresh data everytime with this hook, but were really using the default 5mn garbage collect time of react-query.

To be followed-up with another PR doing the same for all other queries. 

## Pull Request Type

- [ ] :bug: Bug fix (Non-breaking Change: Fixes an issue)
- [ ] :hammer_and_wrench: Chore (Non-breaking Change: Doc updates, pkg upgrades, typos, etc..)
- [x] :nail_care: New Feature (Breaking/Non-breaking Change)

## Issue (if applicable)

<!-----------------------------------------------------------------------------
If applicable, please link to the github issue and put `closes #XXXX` in your comment to auto-close the issue that your PR fixes.
------------------------------------------------------------------------------>

- relates to https://github.com/shapeshift/web/issues/6108

## Risk
> High Risk PRs Require 2 approvals

<!-----------------------------------------------------------------------------
Outline the scope of your changes and the risk associated with them. You must use your discretion as an engineer to determine the potential impact of your changes.

WARNING: If your PR introduces a new on-chain transaction or modifies an existing one, please add the "High-Risk" label to this PR and ask for 2 reviewers to approve it before merging.

E.g. an upgrade to `hdwallet` or core state management would be considered higher risk, and might require a full regression test. UI or isolated view changes, or something behind a feature flag may have near zero risk. Small bug fixes might require testing isolated to the specific fix.
------------------------------------------------------------------------------>

Theoretically, low to none - effectively, since we now leverage fresh data, things could look borked visually as we won't leverage caching and buttons may be disabled - as if the pool was halted - for a few seconds.

> What protocols, transaction types or contract interactions might be affected by this PR?

## Testing

<!-----------------------------------------------------------------------------
We treat every PR to be merged with the same scrutiny as if we were merging directly to production.

Your PR will not be merged if you do not complete the sections below for our engineering and operations teams to test.
------------------------------------------------------------------------------>

- Halted pool checks are still working as before - i.e an halted pool (DOGE currently) is still properly detected as before
- Ensure that the overview modal promptly reflects the actual halted status of pools without incorrectly showing a pool as halted (disabled buttons) for too long due to fresh data fetching.

### Engineering

<!-----------------------------------------------------------------------------
Include sufficient information here for an engineer to test your PR. This may include how to test locally, in a built environment, changes to infrastructure etc.
------------------------------------------------------------------------------>

- ☝🏽 
- Ensure fresh data is fetched (i.e a call to `inbound_addresses) at savers overview mount, confirm mount, and also at signing time.
- Note when testing the above, you probably want to use native asset pools. Testing this with other pools is also possible, though you'll have to go to initiators to ensure the request is made from the `isTradingActive`, as other calls to `inbound_addresses` are made by `getInboundAddressDataForChain`

### Operations

<!-----------------------------------------------------------------------------
If your changes have a user-facing impact, describe how a non-technical QA team can functionally test your changes in a preview environment.

If they are not user-facing please describe how to test for any regressions that may occur.
------------------------------------------------------------------------------>

- ☝🏽 

## Screenshots (if applicable)

### Savers overview - now always getting fresh trading active data

https://github.com/shapeshift/web/assets/17035424/ec314117-1459-4bbc-af92-5b4489e3c044

### Savers deposit - fresh data on overview, then at confirm *component* and finally a refetch at signing time 

https://github.com/shapeshift/web/assets/17035424/402b9c02-a975-4805-bfa0-4532806f2b27

### Savers withdraw - fresh data on overview, then at confirm *component* and finally a refetch at signing time 


https://github.com/shapeshift/web/assets/17035424/77bac3d3-b0c8-4ca5-9bb7-8b03dbb0449c


