### PR TITLE
fix: broken ledger chains connect

### DIFF
--- a/src/context/WalletProvider/WalletProvider.tsx
+++ b/src/context/WalletProvider/WalletProvider.tsx
@@ -182,6 +182,7 @@ const reducer = (state: InitialState, action: ActionTypes): InitialState => {
       store.dispatch(portfolio.actions.setWalletMeta(walletMeta))
       return {
         ...state,
+        deviceId,
         isDemoWallet: Boolean(isDemoWallet),
         wallet,
         connectedType,


### PR DESCRIPTION
## Description

tl;dr:

- #6156 brought over some changes in portfolio upserting, in particular having `walletId` in its `accountMetadataByAccountId` payload
- the `walletId` was gotten from `walletState`, i.e `walletState.deviceId`, this guy:

https://github.com/shapeshift/web/blob/fce52949f6b05ea3d24aa56d29a0eb892dd8c538/src/context/WalletProvider/WalletProvider.tsx#L120

- `SET_WALLET` action was setting `deviceId` in `walletInfo`, but not as a root property:

https://github.com/shapeshift/web/blob/fce52949f6b05ea3d24aa56d29a0eb892dd8c538/src/context/WalletProvider/WalletProvider.tsx#L183-L196

- Eventually,`selectWalletChainIds` wasn't able to detect the added account since the wrong `deviceId` was upserted while upserting portfolio:

https://github.com/shapeshift/web/blob/fce52949f6b05ea3d24aa56d29a0eb892dd8c538/src/context/WalletProvider/Ledger/components/Chains.tsx#L57

The reason why this looks like it worked for other wallets, is because while `SET_WALLET` itself doesn't set `deviceId` as a root property, other actions do e.g:

https://github.com/shapeshift/web/blob/fce52949f6b05ea3d24aa56d29a0eb892dd8c538/src/context/WalletProvider/WalletProvider.tsx#L246-L254

or

https://github.com/shapeshift/web/blob/fce52949f6b05ea3d24aa56d29a0eb892dd8c538/src/context/WalletProvider/WalletProvider.tsx#L255-L266

While this brings an immediate fix by properly setting `deviceId` as a root `state` property in `SET_WALLET`, this brings the questions of:

- Why do we have both `state.deviceId` and `state.walletInfo.deviceId`
- Can we remove one of the two safely?

## Pull Request Type

- [x] :bug: Bug fix (Non-breaking Change: Fixes an issue)
- [ ] :hammer_and_wrench: Chore (Non-breaking Change: Doc updates, pkg upgrades, typos, etc..)
- [ ] :nail_care: New Feature (Breaking/Non-breaking Change)

## Issue (if applicable)

<!-----------------------------------------------------------------------------
If applicable, please link to the github issue and put `closes #XXXX` in your comment to auto-close the issue that your PR fixes.
------------------------------------------------------------------------------>

N/A, spotted in https://discord.com/channels/554694662431178782/1205454458121617449

## Risk
> High Risk PRs Require 2 approvals

<!-----------------------------------------------------------------------------
Outline the scope of your changes and the risk associated with them. You must use your discretion as an engineer to determine the potential impact of your changes.

WARNING: If your PR introduces a new on-chain transaction or modifies an existing one, please add the "High-Risk" label to this PR and ask for 2 reviewers to approve it before merging.

E.g. an upgrade to `hdwallet` or core state management would be considered higher risk, and might require a full regression test. UI or isolated view changes, or something behind a feature flag may have near zero risk. Small bug fixes might require testing isolated to the specific fix.
------------------------------------------------------------------------------>

Theoretically none, the property was missing altogether, and didn't bring any obvious bugs as
1. other wallets either did set the `state.deviceId` property in other of their actions
2. regardless of the presence of `state.deviceId`, it wasn't consumed in other problematic places that would bring such issues

> What protocols, transaction types or contract interactions might be affected by this PR?

## Testing

<!-----------------------------------------------------------------------------
We treat every PR to be merged with the same scrutiny as if we were merging directly to production.

Your PR will not be merged if you do not complete the sections below for our engineering and operations teams to test.
------------------------------------------------------------------------------>

### Engineering

<!-----------------------------------------------------------------------------
Include sufficient information here for an engineer to test your PR. This may include how to test locally, in a built environment, changes to infrastructure etc.
------------------------------------------------------------------------------>

### Operations

<!-----------------------------------------------------------------------------
If your changes have a user-facing impact, describe how a non-technical QA team can functionally test your changes in a preview environment.

If they are not user-facing please describe how to test for any regressions that may occur.
------------------------------------------------------------------------------>

## Screenshots (if applicable)

### Develop

- Lending - broken supported assets

<img width="1394" alt="image" src="https://github.com/shapeshift/web/assets/17035424/a56bcae2-96e6-4f86-b3a4-ed03f1745e1e">

- Ledger chains connect - impossible to connect


https://github.com/shapeshift/web/assets/17035424/2009c521-8ed7-4334-b221-f4e0796ce040

### This diff

- Happy Ledger chains connect

https://github.com/shapeshift/web/assets/17035424/4da47bb7-6728-469c-83ab-c652218af75c

- Happy lending supported assets

https://github.com/shapeshift/web/assets/17035424/7be4d768-6ccb-4dd5-be32-b0d69a74a423


