### PR TITLE
chore: add 'remove liquidity' fees

### DIFF
--- a/src/lib/utils/thorchain/lp.ts
+++ b/src/lib/utils/thorchain/lp.ts
@@ -45,7 +45,7 @@ export const calculateTVL = (
   assetDepthCryptoBaseUnit: string,
   runeDepthCryptoBaseUnit: string,
   runePrice: string,
-): { tvl: string; assetAmountCrytoPrecision: string; runeAmountCryptoPrecision: string } => {
+): { tvl: string; assetAmountCryptoPrecision: string; runeAmountCryptoPrecision: string } => {
   const assetDepthCryptoPrecision = fromThorBaseUnit(assetDepthCryptoBaseUnit)
   const runeDepthCryptoPrecision = fromThorBaseUnit(runeDepthCryptoBaseUnit)
 
@@ -56,7 +56,7 @@ export const calculateTVL = (
 
   const result = {
     tvl: tvl.toFixed(),
-    assetAmountCrytoPrecision: assetDepthCryptoPrecision.toFixed(),
+    assetAmountCryptoPrecision: assetDepthCryptoPrecision.toFixed(),
     runeAmountCryptoPrecision: runeDepthCryptoPrecision.toFixed(),
   }
 

--- a/src/lib/utils/thorchain/lp/types.ts
+++ b/src/lib/utils/thorchain/lp/types.ts
@@ -205,6 +205,28 @@ export type LpConfirmedDepositQuote = {
   runeGasFeeFiat: string
   poolAssetGasFeeFiat: string
 }
+
+export type LpConfirmedWithdrawalQuote = {
+  repaymentAmountCryptoPrecision: string
+  totalAmountFiat: string
+  assetCryptoLiquidityAmount: string
+  assetFiatLiquidityAmount: string
+  runeCryptoLiquidityAmount: string
+  runeFiatLiquidityAmount: string
+  shareOfPoolDecimalPercent: string
+  slippageRune: string
+  opportunityId: string
+  accountIdsByChainId: Record<ChainId, AccountId>
+  // feeBps: string
+  // feeAmountFiat: string
+  assetAddress?: string
+  quoteInboundAddress: string
+  // For informative purposes only at confirm step - to be recalculated before signing
+  totalGasFeeFiat: string
+  runeGasFeeFiat: string
+  poolAssetGasFeeFiat: string
+}
+
 export enum AsymSide {
   Asset = 'asset',
   Rune = 'rune',

--- a/src/lib/utils/thorchain/lp/types.ts
+++ b/src/lib/utils/thorchain/lp/types.ts
@@ -216,9 +216,6 @@ export type LpConfirmedWithdrawalQuote = {
   shareOfPoolDecimalPercent: string
   slippageRune: string
   opportunityId: string
-  accountIdsByChainId: Record<ChainId, AccountId>
-  // feeBps: string
-  // feeAmountFiat: string
   assetAddress?: string
   quoteInboundAddress: string
   // For informative purposes only at confirm step - to be recalculated before signing

--- a/src/lib/utils/thorchain/lp/types.ts
+++ b/src/lib/utils/thorchain/lp/types.ts
@@ -207,7 +207,6 @@ export type LpConfirmedDepositQuote = {
 }
 
 export type LpConfirmedWithdrawalQuote = {
-  repaymentAmountCryptoPrecision: string
   totalAmountFiat: string
   assetCryptoLiquidityAmount: string
   assetFiatLiquidityAmount: string

--- a/src/pages/ThorChainLP/Pool/Pool.tsx
+++ b/src/pages/ThorChainLP/Pool/Pool.tsx
@@ -187,7 +187,7 @@ export const Pool = () => {
 
   const tvl = useMemo(() => {
     if (!foundPool)
-      return { tvl: '0', assetAmountCrytoPrecision: '0', runeAmountCryptoPrecision: '0' }
+      return { tvl: '0', assetAmountCryptoPrecision: '0', runeAmountCryptoPrecision: '0' }
 
     return calculateTVL(foundPool.assetDepth, foundPool.runeDepth, runeMarketData.price)
   }, [foundPool, runeMarketData.price])
@@ -244,7 +244,7 @@ export const Pool = () => {
                   apy={foundPool.poolAPY}
                   tvl={tvl.tvl}
                   runeTvl={tvl.runeAmountCryptoPrecision}
-                  assetTvl={tvl.assetAmountCrytoPrecision}
+                  assetTvl={tvl.assetAmountCryptoPrecision}
                   tvl24hChange={tvl24hChange ?? 0}
                   assetIds={poolAssetIds}
                   direction='column'

--- a/src/pages/ThorChainLP/Position/Position.tsx
+++ b/src/pages/ThorChainLP/Position/Position.tsx
@@ -406,15 +406,15 @@ export const Position = () => {
                     opportunityId={foundPool.opportunityId}
                   />
                 </TabPanel>
-                <TabPanel px={0} py={0}>
-                  {params.poolAccountId && (
+                {params.poolAccountId && (
+                  <TabPanel px={0} py={0}>
                     <RemoveLiquidity
                       headerComponent={TabHeader}
                       opportunityId={foundPool.opportunityId}
                       poolAccountId={params.poolAccountId}
                     />
-                  )}
-                </TabPanel>
+                  </TabPanel>
+                )}
               </TabPanels>
             </Tabs>
           </Card>

--- a/src/pages/ThorChainLP/Position/Position.tsx
+++ b/src/pages/ThorChainLP/Position/Position.tsx
@@ -260,7 +260,7 @@ export const Position = () => {
 
   const tvl = useMemo(() => {
     if (!foundPool)
-      return { tvl: '0', assetAmountCrytoPrecision: '0', runeAmountCryptoPrecision: '0' }
+      return { tvl: '0', assetAmountCryptoPrecision: '0', runeAmountCryptoPrecision: '0' }
 
     return calculateTVL(foundPool.assetDepth, foundPool.runeDepth, runeMarketData.price)
   }, [foundPool, runeMarketData.price])

--- a/src/pages/ThorChainLP/Position/Position.tsx
+++ b/src/pages/ThorChainLP/Position/Position.tsx
@@ -407,10 +407,13 @@ export const Position = () => {
                   />
                 </TabPanel>
                 <TabPanel px={0} py={0}>
-                  <RemoveLiquidity
-                    headerComponent={TabHeader}
-                    opportunityId={foundPool.opportunityId}
-                  />
+                  {params.poolAccountId && (
+                    <RemoveLiquidity
+                      headerComponent={TabHeader}
+                      opportunityId={foundPool.opportunityId}
+                      poolAccountId={params.poolAccountId}
+                    />
+                  )}
                 </TabPanel>
               </TabPanels>
             </Tabs>

--- a/src/pages/ThorChainLP/components/RemoveLiquidity/RemoveLiquidity.tsx
+++ b/src/pages/ThorChainLP/components/RemoveLiquidity/RemoveLiquidity.tsx
@@ -1,4 +1,4 @@
-import { type AccountId, type ChainId, fromAccountId } from '@shapeshiftoss/caip'
+import type { AccountId } from '@shapeshiftoss/caip'
 import { AnimatePresence } from 'framer-motion'
 import React, { Suspense, useCallback, useState } from 'react'
 import { MemoryRouter, Route, Switch, useLocation } from 'react-router'
@@ -20,6 +20,7 @@ const AddLiquidityEntries = [
 export type RemoveLiquidityProps = {
   headerComponent: JSX.Element
   opportunityId: string
+  poolAccountId: AccountId
 }
 
 export type RemoveLiquidityRoutesProps = RemoveLiquidityProps & {
@@ -30,6 +31,7 @@ export type RemoveLiquidityRoutesProps = RemoveLiquidityProps & {
 export const RemoveLiquidity: React.FC<RemoveLiquidityProps> = ({
   headerComponent,
   opportunityId,
+  poolAccountId,
 }) => {
   const [confirmedQuote, setConfirmedQuote] = useState<LpConfirmedWithdrawalQuote | null>(null)
 
@@ -40,6 +42,7 @@ export const RemoveLiquidity: React.FC<RemoveLiquidityProps> = ({
         opportunityId={opportunityId}
         setConfirmedQuote={setConfirmedQuote}
         confirmedQuote={confirmedQuote}
+        poolAccountId={poolAccountId}
       />
     </MemoryRouter>
   )
@@ -50,22 +53,9 @@ const RemoveLiquidityRoutes: React.FC<RemoveLiquidityRoutesProps> = ({
   opportunityId,
   confirmedQuote,
   setConfirmedQuote,
+  poolAccountId,
 }) => {
   const location = useLocation()
-
-  const [accountIdsByChainId, setAccountIdsByChainId] = useState<Record<ChainId, AccountId>>({})
-
-  // fixme
-  const _onAccountIdChange = useCallback(
-    (accountId: AccountId) => {
-      setAccountIdsByChainId(prev => {
-        const chainId = fromAccountId(accountId).chainId
-        return { ...prev, [chainId]: accountId }
-      })
-    },
-    [setAccountIdsByChainId],
-  )
-
   const renderRemoveLiquidityInput = useCallback(
     () => (
       <RemoveLiquidityInput
@@ -73,10 +63,10 @@ const RemoveLiquidityRoutes: React.FC<RemoveLiquidityRoutesProps> = ({
         opportunityId={opportunityId}
         confirmedQuote={confirmedQuote}
         setConfirmedQuote={setConfirmedQuote}
-        accountIdsByChainId={accountIdsByChainId}
+        poolAccountId={poolAccountId}
       />
     ),
-    [accountIdsByChainId, confirmedQuote, headerComponent, opportunityId, setConfirmedQuote],
+    [confirmedQuote, headerComponent, opportunityId, poolAccountId, setConfirmedQuote],
   )
   const renderRemoveLiquidityConfirm = useCallback(() => <RemoveLiquidityConfirm />, [])
   const renderRemoveLiquidityStatus = useCallback(() => <RemoveLiquidityStatus />, [])

--- a/src/pages/ThorChainLP/components/RemoveLiquidity/RemoveLiquidity.tsx
+++ b/src/pages/ThorChainLP/components/RemoveLiquidity/RemoveLiquidity.tsx
@@ -1,6 +1,8 @@
+import { type AccountId, type ChainId, fromAccountId } from '@shapeshiftoss/caip'
 import { AnimatePresence } from 'framer-motion'
-import React, { Suspense, useCallback } from 'react'
+import React, { Suspense, useCallback, useState } from 'react'
 import { MemoryRouter, Route, Switch, useLocation } from 'react-router'
+import type { LpConfirmedWithdrawalQuote } from 'lib/utils/thorchain/lp/types'
 
 import { RemoveLiquidityConfirm } from './RemoveLiquidityConfirm'
 import { RemoveLiquidityInput } from './RemoveLiquidityInput'
@@ -16,28 +18,65 @@ const AddLiquidityEntries = [
 ]
 
 export type RemoveLiquidityProps = {
-  headerComponent?: JSX.Element
-  opportunityId?: string
+  headerComponent: JSX.Element
+  opportunityId: string
 }
+
+export type RemoveLiquidityRoutesProps = RemoveLiquidityProps & {
+  confirmedQuote: LpConfirmedWithdrawalQuote | null
+  setConfirmedQuote: (quote: LpConfirmedWithdrawalQuote) => void
+}
+
 export const RemoveLiquidity: React.FC<RemoveLiquidityProps> = ({
   headerComponent,
   opportunityId,
 }) => {
+  const [confirmedQuote, setConfirmedQuote] = useState<LpConfirmedWithdrawalQuote | null>(null)
+
   return (
     <MemoryRouter initialEntries={AddLiquidityEntries} initialIndex={0}>
-      <RemoveLiquidityRoutes headerComponent={headerComponent} opportunityId={opportunityId} />
+      <RemoveLiquidityRoutes
+        headerComponent={headerComponent}
+        opportunityId={opportunityId}
+        setConfirmedQuote={setConfirmedQuote}
+        confirmedQuote={confirmedQuote}
+      />
     </MemoryRouter>
   )
 }
 
-const RemoveLiquidityRoutes: React.FC<RemoveLiquidityProps> = ({
+const RemoveLiquidityRoutes: React.FC<RemoveLiquidityRoutesProps> = ({
   headerComponent,
   opportunityId,
+  confirmedQuote,
+  setConfirmedQuote,
 }) => {
   const location = useLocation()
+
+  const [accountIdsByChainId, setAccountIdsByChainId] = useState<Record<ChainId, AccountId>>({})
+
+  // fixme
+  const _onAccountIdChange = useCallback(
+    (accountId: AccountId) => {
+      setAccountIdsByChainId(prev => {
+        const chainId = fromAccountId(accountId).chainId
+        return { ...prev, [chainId]: accountId }
+      })
+    },
+    [setAccountIdsByChainId],
+  )
+
   const renderRemoveLiquidityInput = useCallback(
-    () => <RemoveLiquidityInput headerComponent={headerComponent} opportunityId={opportunityId} />,
-    [headerComponent, opportunityId],
+    () => (
+      <RemoveLiquidityInput
+        headerComponent={headerComponent}
+        opportunityId={opportunityId}
+        confirmedQuote={confirmedQuote}
+        setConfirmedQuote={setConfirmedQuote}
+        accountIdsByChainId={accountIdsByChainId}
+      />
+    ),
+    [accountIdsByChainId, confirmedQuote, headerComponent, opportunityId, setConfirmedQuote],
   )
   const renderRemoveLiquidityConfirm = useCallback(() => <RemoveLiquidityConfirm />, [])
   const renderRemoveLiquidityStatus = useCallback(() => <RemoveLiquidityStatus />, [])

--- a/src/pages/ThorChainLP/components/RemoveLiquidity/RemoveLiquidityInput.tsx
+++ b/src/pages/ThorChainLP/components/RemoveLiquidity/RemoveLiquidityInput.tsx
@@ -251,25 +251,21 @@ export const RemoveLiquidityInput: React.FC<RemoveLiquidityInputProps> = ({
     setVirtualRuneCryptoLiquidityAmount(
       bnOrZero(underlyingRuneAmountCryptoPrecision)
         .times(percentageSelection / 100)
-        .times(isAsymAssetSide || isAsymRuneSide ? 2 : 1)
         .toFixed(),
     )
     setVirtualRuneFiatLiquidityAmount(
       bnOrZero(underlyingRuneValueFiatUserCurrency)
         .times(percentageSelection / 100)
-        .times(isAsymAssetSide || isAsymRuneSide ? 2 : 1)
         .toFixed(),
     )
     setVirtualAssetFiatLiquidityAmount(
       bnOrZero(underlyingAssetValueFiatUserCurrency)
         .times(percentageSelection / 100)
-        .times(isAsymAssetSide || isAsymRuneSide ? 2 : 1)
         .toFixed(),
     )
     setVirtualAssetCryptoLiquidityAmount(
       bnOrZero(underlyingAssetAmountCryptoPrecision)
         .times(percentageSelection / 100)
-        .times(isAsymAssetSide || isAsymRuneSide ? 2 : 1)
         .toFixed(),
     )
   }, [isAsymAssetSide, isAsymRuneSide, percentageSelection, userlpData])
@@ -561,23 +557,38 @@ export const RemoveLiquidityInput: React.FC<RemoveLiquidityInputProps> = ({
       <Stack divider={pairDivider} spacing={0}>
         {assets.map(asset => {
           const isRune = asset.assetId === rune.assetId
+          const isAsym = foundPool.isAsymmetric
+          console.log('xxx isAsym', isAsym)
           const marketData = isRune ? runeMarketData : assetMarketData
           const handleRemoveLiquidityInputChange = createHandleRemoveLiquidityInputChange(
             marketData,
             isRune,
           )
-          const cryptoAmount = isRune
-            ? virtualRuneCryptoLiquidityAmount
-            : virtualAssetCryptoLiquidityAmount
-          const fiatAmount = isRune
-            ? virtualRuneFiatLiquidityAmount
-            : virtualAssetFiatLiquidityAmount
-          const cryptoBalance = isRune
-            ? userlpData?.underlyingRuneAmountCryptoPrecision
-            : userlpData?.underlyingAssetAmountCryptoPrecision
-          const fiatBalance = isRune
-            ? userlpData?.underlyingRuneAmountCryptoPrecision
-            : userlpData?.underlyingRuneValueFiatUserCurrency
+          const cryptoAmount = bnOrZero(
+            isRune ? virtualRuneCryptoLiquidityAmount : virtualAssetCryptoLiquidityAmount,
+          )
+            .times(isAsym ? 2 : 1)
+            .toFixed()
+          const fiatAmount = bnOrZero(
+            isRune ? virtualRuneFiatLiquidityAmount : virtualAssetFiatLiquidityAmount,
+          )
+            .times(isAsym ? 2 : 1)
+            .toFixed()
+          const cryptoBalance = bnOrZero(
+            isRune
+              ? userlpData?.underlyingRuneAmountCryptoPrecision
+              : userlpData?.underlyingAssetAmountCryptoPrecision,
+          )
+            .times(isAsym ? 2 : 1)
+            .toFixed()
+
+          const fiatBalance = bnOrZero(
+            isRune
+              ? userlpData?.underlyingRuneValueFiatUserCurrency
+              : userlpData?.underlyingAssetValueFiatUserCurrency,
+          )
+            .times(isAsym ? 2 : 1)
+            .toFixed()
 
           return (
             <AssetInput
@@ -615,6 +626,7 @@ export const RemoveLiquidityInput: React.FC<RemoveLiquidityInputProps> = ({
     userlpData?.underlyingRuneAmountCryptoPrecision,
     userlpData?.underlyingAssetAmountCryptoPrecision,
     userlpData?.underlyingRuneValueFiatUserCurrency,
+    userlpData?.underlyingAssetValueFiatUserCurrency,
     poolAccountId,
     percentOptions,
   ])

--- a/src/pages/ThorChainLP/components/RemoveLiquidity/RemoveLiquidityInput.tsx
+++ b/src/pages/ThorChainLP/components/RemoveLiquidity/RemoveLiquidityInput.tsx
@@ -129,9 +129,9 @@ export const RemoveLiquidityInput: React.FC<RemoveLiquidityInputProps> = ({
   const [virtualRuneFiatLiquidityAmount, setVirtualRuneFiatLiquidityAmount] = useState<
     string | undefined
   >()
-  const [cryptoAssetBalance, setCrytoAssetBalance] = useState<string | undefined>()
+  const [cryptoAssetBalance, setCryptoAssetBalance] = useState<string | undefined>()
   const [fiatAssetBalance, setFiatAssetBalance] = useState<string | undefined>()
-  const [cryptoRuneBalance, setCrytoRuneBalance] = useState<string | undefined>()
+  const [cryptoRuneBalance, setCryptoRuneBalance] = useState<string | undefined>()
   const [fiatRuneBalance, setFiatRuneBalance] = useState<string | undefined>()
   const [slippageRune, setSlippageRune] = useState<string | undefined>()
   const [isSlippageLoading, setIsSlippageLoading] = useState(false)
@@ -213,12 +213,12 @@ export const RemoveLiquidityInput: React.FC<RemoveLiquidityInputProps> = ({
 
   useEffect(() => {
     if (!userData) return
-    const _UserlpData: UserLpDataPosition | undefined = userData.find(
+    const _userlpData: UserLpDataPosition | undefined = userData.find(
       data => data.opportunityId === opportunityId,
     )
-    if (!_UserlpData) return
-    setUserlpData(_UserlpData)
-    const runeAddress = _UserlpData?.runeAddress
+    if (!_userlpData) return
+    setUserlpData(_userlpData)
+    const runeAddress = _userlpData?.runeAddress
     if (!runeAddress) return
     const runeAccountId = toAccountId({
       chainId: thorchainChainId,
@@ -276,9 +276,9 @@ export const RemoveLiquidityInput: React.FC<RemoveLiquidityInputProps> = ({
         .times(isAsymAssetSide || isAsymRuneSide ? 2 : 1)
         .toFixed(),
     )
-    setCrytoAssetBalance(underlyingAssetAmountCryptoPrecision)
+    setCryptoAssetBalance(underlyingAssetAmountCryptoPrecision)
     setFiatAssetBalance(underlyingAssetValueFiatUserCurrency)
-    setCrytoRuneBalance(underlyingRuneAmountCryptoPrecision)
+    setCryptoRuneBalance(underlyingRuneAmountCryptoPrecision)
     setFiatRuneBalance(underlyingRuneValueFiatUserCurrency)
   }, [isAsymAssetSide, isAsymRuneSide, percentageSelection, userlpData])
 

--- a/src/pages/ThorChainLP/components/RemoveLiquidity/RemoveLiquidityInput.tsx
+++ b/src/pages/ThorChainLP/components/RemoveLiquidity/RemoveLiquidityInput.tsx
@@ -593,6 +593,7 @@ export const RemoveLiquidityInput: React.FC<RemoveLiquidityInputProps> = ({
 
           return (
             <AssetInput
+              key={asset.assetId}
               accountId={poolAccountId}
               cryptoAmount={cryptoAmount}
               onChange={handleRemoveLiquidityInputChange}
@@ -604,7 +605,7 @@ export const RemoveLiquidityInput: React.FC<RemoveLiquidityInputProps> = ({
               balance={cryptoBalance}
               fiatBalance={fiatBalance}
               percentOptions={percentOptions}
-              isReadOnly={false} // todo
+              isReadOnly={false}
               formControlProps={formControlProps}
             ></AssetInput>
           )

--- a/src/pages/ThorChainLP/components/RemoveLiquidity/RemoveLiquidityInput.tsx
+++ b/src/pages/ThorChainLP/components/RemoveLiquidity/RemoveLiquidityInput.tsx
@@ -129,10 +129,6 @@ export const RemoveLiquidityInput: React.FC<RemoveLiquidityInputProps> = ({
   const [virtualRuneFiatLiquidityAmount, setVirtualRuneFiatLiquidityAmount] = useState<
     string | undefined
   >()
-  const [cryptoAssetBalance, setCryptoAssetBalance] = useState<string | undefined>()
-  const [fiatAssetBalance, setFiatAssetBalance] = useState<string | undefined>()
-  const [cryptoRuneBalance, setCryptoRuneBalance] = useState<string | undefined>()
-  const [fiatRuneBalance, setFiatRuneBalance] = useState<string | undefined>()
   const [slippageRune, setSlippageRune] = useState<string | undefined>()
   const [isSlippageLoading, setIsSlippageLoading] = useState(false)
 
@@ -276,10 +272,6 @@ export const RemoveLiquidityInput: React.FC<RemoveLiquidityInputProps> = ({
         .times(isAsymAssetSide || isAsymRuneSide ? 2 : 1)
         .toFixed(),
     )
-    setCryptoAssetBalance(underlyingAssetAmountCryptoPrecision)
-    setFiatAssetBalance(underlyingAssetValueFiatUserCurrency)
-    setCryptoRuneBalance(underlyingRuneAmountCryptoPrecision)
-    setFiatRuneBalance(underlyingRuneValueFiatUserCurrency)
   }, [isAsymAssetSide, isAsymRuneSide, percentageSelection, userlpData])
 
   // We reuse lending utils here since all this does is estimating fees for a given withdrawal amount with a memo
@@ -580,8 +572,12 @@ export const RemoveLiquidityInput: React.FC<RemoveLiquidityInputProps> = ({
           const fiatAmount = isRune
             ? virtualRuneFiatLiquidityAmount
             : virtualAssetFiatLiquidityAmount
-          const cryptoBalance = isRune ? cryptoRuneBalance : cryptoAssetBalance
-          const fiatBalance = isRune ? fiatRuneBalance : fiatAssetBalance
+          const cryptoBalance = isRune
+            ? userlpData?.underlyingRuneAmountCryptoPrecision
+            : userlpData?.underlyingAssetAmountCryptoPrecision
+          const fiatBalance = isRune
+            ? userlpData?.underlyingRuneAmountCryptoPrecision
+            : userlpData?.underlyingRuneValueFiatUserCurrency
 
           return (
             <AssetInput
@@ -616,10 +612,9 @@ export const RemoveLiquidityInput: React.FC<RemoveLiquidityInputProps> = ({
     virtualAssetCryptoLiquidityAmount,
     virtualRuneFiatLiquidityAmount,
     virtualAssetFiatLiquidityAmount,
-    cryptoRuneBalance,
-    cryptoAssetBalance,
-    fiatRuneBalance,
-    fiatAssetBalance,
+    userlpData?.underlyingRuneAmountCryptoPrecision,
+    userlpData?.underlyingAssetAmountCryptoPrecision,
+    userlpData?.underlyingRuneValueFiatUserCurrency,
     poolAccountId,
     percentOptions,
   ])

--- a/src/pages/ThorChainLP/components/RemoveLiquidity/RemoveLiquidityInput.tsx
+++ b/src/pages/ThorChainLP/components/RemoveLiquidity/RemoveLiquidityInput.tsx
@@ -369,20 +369,19 @@ export const RemoveLiquidityInput: React.FC<RemoveLiquidityInputProps> = ({
     const transactionType = getThorchainLpTransactionType(poolAsset.chainId)
 
     switch (transactionType) {
-      case 'MsgDeposit': {
+      case 'MsgDeposit':
         return THORCHAIN_POOL_MODULE_ADDRESS
-      }
-      case 'EvmCustomTx': {
+
+      case 'EvmCustomTx':
         // TODO: this should really be inboundAddressData?.router, but useQuoteEstimatedFeesQuery doesn't yet handle contract calls
         // for the purpose of naively assuming a send, using the inbound address instead of the router is fine
         return inboundAddressesData?.address
-      }
-      case 'Send': {
+
+      case 'Send':
         return inboundAddressesData?.address
-      }
-      default: {
+
+      default:
         assertUnreachable(transactionType as never)
-      }
     }
   }, [poolAsset, inboundAddressesData?.address])
 
@@ -600,7 +599,7 @@ export const RemoveLiquidityInput: React.FC<RemoveLiquidityInputProps> = ({
               percentOptions={percentOptions}
               isReadOnly={false}
               formControlProps={formControlProps}
-            ></AssetInput>
+            />
           )
         })}
       </Stack>

--- a/src/pages/ThorChainLP/components/RemoveLiquidity/RemoveLiquidityInput.tsx
+++ b/src/pages/ThorChainLP/components/RemoveLiquidity/RemoveLiquidityInput.tsx
@@ -285,33 +285,25 @@ export const RemoveLiquidityInput: React.FC<RemoveLiquidityInputProps> = ({
   // We reuse lending utils here since all this does is estimating fees for a given deposit amount with a memo
   // It's not going to be 100% accurate for EVM chains as it doesn't calculate the cost of depositWithExpiry, but rather a simple send,
   // however that's fine for now until accurate fees estimation is implemented
-  const {
-    data: estimatedRuneFeesData,
-    isLoading: isEstimatedRuneFeesDataLoading,
-    // isError: isEstimatedRuneFeesDataError,
-    // isSuccess: isEstimatedRuneFeesDataSuccess,
-  } = useQuoteEstimatedFeesQuery({
-    collateralAssetId: thorchainAssetId,
-    collateralAccountId: runeAccountId ?? '', // fixme
-    repaymentAccountId: runeAccountId ?? '', // fixme
-    repaymentAsset: runeAsset ?? null,
-    repaymentAmountCryptoPrecision: actualRuneCryptoLiquidityAmount,
-    confirmedQuote,
-  })
+  const { data: estimatedRuneFeesData, isLoading: isEstimatedRuneFeesDataLoading } =
+    useQuoteEstimatedFeesQuery({
+      collateralAssetId: thorchainAssetId,
+      collateralAccountId: runeAccountId ?? '', // fixme
+      repaymentAccountId: runeAccountId ?? '', // fixme
+      repaymentAsset: runeAsset ?? null,
+      repaymentAmountCryptoPrecision: actualRuneCryptoLiquidityAmount,
+      confirmedQuote,
+    })
 
-  const {
-    data: estimatedPoolAssetFeesData,
-    isLoading: isEstimatedPoolAssetFeesDataLoading,
-    // isError: isEstimatedPoolAssetFeesDataError,
-    // isSuccess: isEstimatedPoolAssetFeesDataSuccess,
-  } = useQuoteEstimatedFeesQuery({
-    collateralAssetId: poolAsset?.assetId ?? '', // fixme
-    collateralAccountId: poolAccountId,
-    repaymentAccountId: poolAccountId,
-    repaymentAsset: poolAsset ?? null,
-    confirmedQuote,
-    repaymentAmountCryptoPrecision: actualAssetCryptoLiquidityAmount,
-  })
+  const { data: estimatedPoolAssetFeesData, isLoading: isEstimatedPoolAssetFeesDataLoading } =
+    useQuoteEstimatedFeesQuery({
+      collateralAssetId: poolAsset?.assetId ?? '', // fixme
+      collateralAccountId: poolAccountId,
+      repaymentAccountId: poolAccountId,
+      repaymentAsset: poolAsset ?? null,
+      confirmedQuote,
+      repaymentAmountCryptoPrecision: actualAssetCryptoLiquidityAmount,
+    })
 
   const poolAssetTxFeeCryptoPrecision = useMemo(
     () =>

--- a/src/pages/ThorChainLP/components/RemoveLiquidity/RemoveLiquidityInput.tsx
+++ b/src/pages/ThorChainLP/components/RemoveLiquidity/RemoveLiquidityInput.tsx
@@ -216,9 +216,10 @@ export const RemoveLiquidityInput: React.FC<RemoveLiquidityInputProps> = ({
     const _UserlpData: UserLpDataPosition | undefined = userData.find(
       data => data.opportunityId === opportunityId,
     )
-    const runeAddress = _UserlpData?.runeAddress
-    if (!_UserlpData || !runeAddress) return
+    if (!_UserlpData) return
     setUserlpData(_UserlpData)
+    const runeAddress = _UserlpData?.runeAddress
+    if (!runeAddress) return
     const runeAccountId = toAccountId({
       chainId: thorchainChainId,
       account: runeAddress,

--- a/src/pages/ThorChainLP/components/RemoveLiquidity/RemoveLiquidityInput.tsx
+++ b/src/pages/ThorChainLP/components/RemoveLiquidity/RemoveLiquidityInput.tsx
@@ -282,14 +282,14 @@ export const RemoveLiquidityInput: React.FC<RemoveLiquidityInputProps> = ({
     setFiatRuneBalance(underlyingRuneValueFiatUserCurrency)
   }, [isAsymAssetSide, isAsymRuneSide, percentageSelection, userlpData])
 
-  // We reuse lending utils here since all this does is estimating fees for a given deposit amount with a memo
+  // We reuse lending utils here since all this does is estimating fees for a given withdrawal amount with a memo
   // It's not going to be 100% accurate for EVM chains as it doesn't calculate the cost of depositWithExpiry, but rather a simple send,
   // however that's fine for now until accurate fees estimation is implemented
   const { data: estimatedRuneFeesData, isLoading: isEstimatedRuneFeesDataLoading } =
     useQuoteEstimatedFeesQuery({
       collateralAssetId: thorchainAssetId,
-      collateralAccountId: runeAccountId ?? '', // fixme
-      repaymentAccountId: runeAccountId ?? '', // fixme
+      collateralAccountId: runeAccountId ?? '', // This will be undefined for asym asset side LPs, and that's ok
+      repaymentAccountId: runeAccountId ?? '', // This will be undefined for asym asset side LPs, and that's ok
       repaymentAsset: runeAsset ?? null,
       repaymentAmountCryptoPrecision: actualRuneCryptoLiquidityAmount,
       confirmedQuote,
@@ -297,7 +297,7 @@ export const RemoveLiquidityInput: React.FC<RemoveLiquidityInputProps> = ({
 
   const { data: estimatedPoolAssetFeesData, isLoading: isEstimatedPoolAssetFeesDataLoading } =
     useQuoteEstimatedFeesQuery({
-      collateralAssetId: poolAsset?.assetId ?? '', // fixme
+      collateralAssetId: poolAsset?.assetId ?? '',
       collateralAccountId: poolAccountId,
       repaymentAccountId: poolAccountId,
       repaymentAsset: poolAsset ?? null,

--- a/src/react-queries/hooks/useQuoteEstimatedFeesQuery.ts
+++ b/src/react-queries/hooks/useQuoteEstimatedFeesQuery.ts
@@ -34,6 +34,7 @@ type UseQuoteEstimatedFeesProps = {
       depositAmountCryptoPrecision: string
       repaymentAccountId?: never
       repaymentAsset?: never
+      repaymentAmountCryptoPrecision?: never
     }
   | {
       confirmedQuote: LendingQuoteClose | null
@@ -41,6 +42,7 @@ type UseQuoteEstimatedFeesProps = {
       depositAmountCryptoPrecision?: never
       repaymentAccountId: AccountId
       repaymentAsset: Asset | null
+      repaymentAmountCryptoPrecision?: never
     }
   | {
       confirmedQuote: LpConfirmedDepositQuote | null
@@ -49,6 +51,7 @@ type UseQuoteEstimatedFeesProps = {
       depositAmountCryptoPrecision: string
       repaymentAccountId?: never
       repaymentAsset?: never
+      repaymentAmountCryptoPrecision?: never
     }
   | {
       confirmedQuote: LpConfirmedWithdrawalQuote | null
@@ -57,6 +60,7 @@ type UseQuoteEstimatedFeesProps = {
       depositAmountCryptoPrecision?: never
       repaymentAccountId: AccountId
       repaymentAsset: Asset | null
+      repaymentAmountCryptoPrecision: string | undefined
     }
 )
 
@@ -67,12 +71,13 @@ export const useQuoteEstimatedFeesQuery = ({
   repaymentAccountId,
   repaymentAsset,
   confirmedQuote,
+  repaymentAmountCryptoPrecision: _repaymentAmountCryptoPrecision,
 }: UseQuoteEstimatedFeesProps) => {
   const repaymentAmountCryptoPrecision = useMemo(
     () =>
-      (confirmedQuote as LendingQuoteClose | LpConfirmedWithdrawalQuote)
-        ?.repaymentAmountCryptoPrecision,
-    [confirmedQuote],
+      _repaymentAmountCryptoPrecision ??
+      (confirmedQuote as LendingQuoteClose)?.repaymentAmountCryptoPrecision,
+    [_repaymentAmountCryptoPrecision, confirmedQuote],
   )
   const feeAsset = useAppSelector(state => selectFeeAssetById(state, collateralAssetId))
   const feeAssetMarketData = useAppSelector(state => selectMarketDataById(state, collateralAssetId))

--- a/src/react-queries/hooks/useQuoteEstimatedFeesQuery.ts
+++ b/src/react-queries/hooks/useQuoteEstimatedFeesQuery.ts
@@ -8,7 +8,10 @@ import { estimateFees } from 'components/Modals/Send/utils'
 import { bn, bnOrZero } from 'lib/bignumber/bignumber'
 import { getSupportedEvmChainIds } from 'lib/utils/evm'
 import type { LendingQuoteClose, LendingQuoteOpen } from 'lib/utils/thorchain/lending/types'
-import type { LpConfirmedDepositQuote } from 'lib/utils/thorchain/lp/types'
+import type {
+  LpConfirmedDepositQuote,
+  LpConfirmedWithdrawalQuote,
+} from 'lib/utils/thorchain/lp/types'
 import { selectFeeAssetById, selectMarketDataById } from 'state/slices/selectors'
 import { useAppSelector } from 'state/store'
 
@@ -46,6 +49,14 @@ type UseQuoteEstimatedFeesProps = {
       depositAmountCryptoPrecision: string
       repaymentAccountId?: never
       repaymentAsset?: never
+    }
+  | {
+      confirmedQuote: LpConfirmedWithdrawalQuote | null
+      // Technically not a collateral, but this avoids weird branching, ternaries or ?? checks for now
+      collateralAccountId: AccountId
+      depositAmountCryptoPrecision?: never
+      repaymentAccountId: AccountId
+      repaymentAsset: Asset | null
     }
 )
 

--- a/src/react-queries/hooks/useQuoteEstimatedFeesQuery.ts
+++ b/src/react-queries/hooks/useQuoteEstimatedFeesQuery.ts
@@ -69,7 +69,9 @@ export const useQuoteEstimatedFeesQuery = ({
   confirmedQuote,
 }: UseQuoteEstimatedFeesProps) => {
   const repaymentAmountCryptoPrecision = useMemo(
-    () => (confirmedQuote as LendingQuoteClose)?.repaymentAmountCryptoPrecision,
+    () =>
+      (confirmedQuote as LendingQuoteClose | LpConfirmedWithdrawalQuote)
+        ?.repaymentAmountCryptoPrecision,
     [confirmedQuote],
   )
   const feeAsset = useAppSelector(state => selectFeeAssetById(state, collateralAssetId))


### PR DESCRIPTION
## Description

- Adds gas fees for remove liquidity estimates
- Uses the `AssetInput` component to display current LP asset balance

What this does not do:

- Handle clicking "Remove liquidity", and any subsequent flows

## Pull Request Type

- [ ] :bug: Bug fix (Non-breaking Change: Fixes an issue)
- [x] :hammer_and_wrench: Chore (Non-breaking Change: Doc updates, pkg upgrades, typos, etc..)
- [ ] :nail_care: New Feature (Breaking/Non-breaking Change)

## Issue (if applicable)

Contributes to https://github.com/shapeshift/web/issues/5960

## Risk

Small/medium - mainly UI related work, though has some account-related logic (primarily the derivation of account from quote params + lp pool data).

> What protocols, transaction types or contract interactions might be affected by this PR?

Related to THORChain LP withdrawal transactions, though does not execute them yet.

## Testing

For an existing position, enter an amount to remove and ensure that:

a) the gas fee value calculates correctly
b) the calculated fee is similar (the same as?) to that calculated in "Add Liquidity".

### Engineering

☝️

### Operations

☝️

## Screenshots (if applicable)

<img width="368" alt="Screenshot 2024-02-12 at 12 23 30 pm" src="https://github.com/shapeshift/web/assets/97164662/986c800f-6133-4f26-bd2d-aa47e9568ca0">