### PR TITLE
fix: dont display incorrect fee values for cowswap quotes in the fee explainer

### DIFF
--- a/src/components/MultiHopTrade/components/FeeModal/FeeBreakdown.tsx
+++ b/src/components/MultiHopTrade/components/FeeModal/FeeBreakdown.tsx
@@ -75,12 +75,7 @@ export const FeeBreakdown = () => {
         <Row>
           <Row.Label>{translate('foxDiscounts.currentFoxPower')}</Row.Label>
           <Row.Value textAlign='right'>
-            <Amount.Crypto
-              fontSize='sm'
-              value={votingPower ?? '0'}
-              symbol='FOX'
-              maximumFractionDigits={0}
-            />
+            <Amount.Crypto value={votingPower ?? '0'} symbol='FOX' maximumFractionDigits={0} />
           </Row.Value>
         </Row>
         {!isFeeUnsupported && (

--- a/src/components/MultiHopTrade/components/FeeModal/FeeBreakdown.tsx
+++ b/src/components/MultiHopTrade/components/FeeModal/FeeBreakdown.tsx
@@ -13,6 +13,14 @@ import { useAppSelector } from 'state/store'
 
 const divider = <Divider />
 
+const AmountOrFree = ({ isFree, amountFiat }: { isFree: boolean; amountFiat: string }) => {
+  return isFree ? (
+    <Text translation='common.free' color='text.success' />
+  ) : (
+    <Amount.Fiat value={amountFiat} />
+  )
+}
+
 export const FeeBreakdown = () => {
   const translate = useTranslate()
   const votingPower = useAppSelector(selectVotingPower)
@@ -29,10 +37,6 @@ export const FeeBreakdown = () => {
     return feeUsdBeforeDiscount.times(userCurrencyToUsdRate).toFixed(2)
   }, [feeUsdBeforeDiscount, userCurrencyToUsdRate])
 
-  const feeDiscountUserCurrency = useMemo(() => {
-    return foxDiscountUsd.times(userCurrencyToUsdRate).toFixed(2)
-  }, [foxDiscountUsd, userCurrencyToUsdRate])
-
   // use the fee from the actual quote in case it varies from the theoretical calculation
   const affiliateFeeAmountUserCurrency = useAppSelector(selectQuoteAffiliateFeeUserCurrency)
 
@@ -40,6 +44,14 @@ export const FeeBreakdown = () => {
     () => bnOrZero(affiliateFeeAmountUserCurrency).eq(0),
     [affiliateFeeAmountUserCurrency],
   )
+
+  const isFeeUnsupported = useMemo(() => {
+    return affiliateFeeAmountUserCurrency === '0' && bnOrZero(feeBeforeDiscountUserCurrency).gt(0)
+  }, [affiliateFeeAmountUserCurrency, feeBeforeDiscountUserCurrency])
+
+  const feeDiscountUserCurrency = useMemo(() => {
+    return isFeeUnsupported ? '0.00' : foxDiscountUsd.times(userCurrencyToUsdRate).toFixed(2)
+  }, [foxDiscountUsd, isFeeUnsupported, userCurrencyToUsdRate])
 
   return (
     <Stack spacing={0}>
@@ -51,31 +63,45 @@ export const FeeBreakdown = () => {
         <Row>
           <Row.Label>{translate('foxDiscounts.tradeFee')}</Row.Label>
           <Row.Value textAlign='right'>
-            <Amount.Fiat value={feeBeforeDiscountUserCurrency} />
-            <Amount color='text.subtle' fontSize='sm' value={feeBpsBeforeDiscount} suffix='bps' />
-          </Row.Value>
-        </Row>
-        <Row>
-          <Row.Label>{translate('foxDiscounts.foxPowerDiscount')}</Row.Label>
-          <Row.Value textAlign='right'>
-            <Amount.Fiat value={feeDiscountUserCurrency} />
-            <Amount.Percent
+            <AmountOrFree isFree={isFeeUnsupported} amountFiat={feeBeforeDiscountUserCurrency} />
+            <Amount
+              color='text.subtle'
               fontSize='sm'
-              value={isFree ? 1 : foxDiscountPercent.div(100).toNumber()}
-              color='text.success'
+              value={isFree ? '0' : feeBpsBeforeDiscount}
+              suffix='bps'
             />
           </Row.Value>
         </Row>
+        <Row>
+          <Row.Label>{translate('foxDiscounts.currentFoxPower')}</Row.Label>
+          <Row.Value textAlign='right'>
+            <Amount.Crypto
+              fontSize='sm'
+              value={votingPower ?? '0'}
+              symbol='FOX'
+              maximumFractionDigits={0}
+            />
+          </Row.Value>
+        </Row>
+        {!isFeeUnsupported && (
+          <Row>
+            <Row.Label>{translate('foxDiscounts.foxPowerDiscount')}</Row.Label>
+            <Row.Value textAlign='right'>
+              <Amount.Fiat value={feeDiscountUserCurrency} />
+              <Amount.Percent
+                fontSize='sm'
+                value={isFree ? 1 : foxDiscountPercent.div(100).toNumber()}
+                color='text.success'
+              />
+            </Row.Value>
+          </Row>
+        )}
       </Stack>
       <Divider />
       <Row px={8} py={4}>
         <Row.Label color='text.base'>{translate('foxDiscounts.totalTradeFee')}</Row.Label>
         <Row.Value fontSize='lg'>
-          {isFree ? (
-            <Text translation='common.free' color='text.success' />
-          ) : (
-            <Amount.Fiat value={affiliateFeeAmountUserCurrency} />
-          )}
+          <AmountOrFree isFree={isFree} amountFiat={affiliateFeeAmountUserCurrency} />
         </Row.Value>
       </Row>
     </Stack>


### PR DESCRIPTION
## Description

Fixes issue where we display fee breakdown data in the fee explainer for quotes that actually have no fee (cowswap quotes > $1000)

Changes include:
- Display fox power in fee explainer in all cases
- Hide "FOX Power Discount" row in fee explainer if the quote fee is 0 and the expected fee is not 0 (i.e the theoretical fee is some value but cowswap swapper forced it to 0)

## Pull Request Type

- [x] :bug: Bug fix (Non-breaking Change: Fixes an issue)
- [ ] :hammer_and_wrench: Chore (Non-breaking Change: Doc updates, pkg upgrades, typos, etc..)
- [ ] :nail_care: New Feature (Breaking/Non-breaking Change)

## Issue (if applicable)

<!-----------------------------------------------------------------------------
If applicable, please link to the github issue and put `closes #XXXX` in your comment to auto-close the issue that your PR fixes.
------------------------------------------------------------------------------>

closes #6180

## Risk
> High Risk PRs Require 2 approvals

Low risk, does not affect actual trades.

> What protocols, transaction types or contract interactions might be affected by this PR?

## Testing

Check the fee breakdown when clicking the fee in the trade input is correct in various situations:
- cowswap <$1000
- cowswap >$1000
- non-cowswap <$1000
- non-cowswap >$1000

The above with and without fox holdings.

### Engineering

<!-----------------------------------------------------------------------------
Include sufficient information here for an engineer to test your PR. This may include how to test locally, in a built environment, changes to infrastructure etc.
------------------------------------------------------------------------------>

### Operations

<!-----------------------------------------------------------------------------
If your changes have a user-facing impact, describe how a non-technical QA team can functionally test your changes in a preview environment.

If they are not user-facing please describe how to test for any regressions that may occur.
------------------------------------------------------------------------------>

## Screenshots (if applicable)

### Fee breakdown for cowswap >$1000
Prod
![image](https://github.com/shapeshift/web/assets/125113430/bd37f1b9-3995-40f8-8103-11b4cb25205b)

This PR
![image](https://github.com/shapeshift/web/assets/125113430/b8c5799f-738a-468f-a506-4e7e03595bdd)

