### PR TITLE
fix: dont render loading placeholders for disabled swappers

### DIFF
--- a/src/components/MultiHopTrade/components/TradeInput/components/TradeQuotes/TradeQuotes.tsx
+++ b/src/components/MultiHopTrade/components/TradeInput/components/TradeQuotes/TradeQuotes.tsx
@@ -1,6 +1,6 @@
 import { ArrowDownIcon } from '@chakra-ui/icons'
 import { Box, Button, Flex, useColorModeValue } from '@chakra-ui/react'
-import { SwapperName } from '@shapeshiftoss/swapper'
+import type { SwapperName } from '@shapeshiftoss/swapper'
 import { AnimatePresence, LayoutGroup, motion } from 'framer-motion'
 import orderBy from 'lodash/orderBy'
 import { memo, useCallback, useEffect, useMemo, useState } from 'react'
@@ -136,8 +136,6 @@ export const TradeQuotes: React.FC<TradeQuotesProps> = memo(({ isLoading }) => {
     return Object.entries(isSwapperQuoteAvailable)
       .filter(
         ([swapperName, isQuoteAvailable]) =>
-          // don't render a loading placeholder for the test swapper
-          swapperName !== SwapperName.Test &&
           // only render loading placeholders for swappers that are still fetching data
           (!isQuoteAvailable || isTradeQuoteApiQueryPending[swapperName as SwapperName]) &&
           // filter out entries that already have a placeholder


### PR DESCRIPTION
## Description

1inch swapper has recently been toggled off, but loading state is still appearing for it. This PR addresses the issue by improving the logic in the redux selectors to exclude swappers that have been disabled.

## Pull Request Type

- [x] :bug: Bug fix (Non-breaking Change: Fixes an issue)
- [ ] :hammer_and_wrench: Chore (Non-breaking Change: Doc updates, pkg upgrades, typos, etc..)
- [ ] :nail_care: New Feature (Breaking/Non-breaking Change)

## Issue (if applicable)

NA

## Risk
> High Risk PRs Require 2 approvals

Low risk of broken trades or swappers not being enabled when they should be.

> What protocols, transaction types or contract interactions might be affected by this PR?

## Testing

Get a quote and ensure that 1inch swapper is not appearing in the quote list. Also check that other swappers do appear, and that trades and state is not somehow broken.

### Engineering

<!-----------------------------------------------------------------------------
Include sufficient information here for an engineer to test your PR. This may include how to test locally, in a built environment, changes to infrastructure etc.
------------------------------------------------------------------------------>

### Operations

<!-----------------------------------------------------------------------------
If your changes have a user-facing impact, describe how a non-technical QA team can functionally test your changes in a preview environment.

If they are not user-facing please describe how to test for any regressions that may occur.
------------------------------------------------------------------------------>

## Screenshots (if applicable)

Release:
![image](https://github.com/shapeshift/web/assets/125113430/51a69ff7-db30-43a1-8180-0f1f924fabaa)

This PR:
![image](https://github.com/shapeshift/web/assets/125113430/049c7bcb-98a4-4344-ba7e-603abfce5b13)

