### PR TITLE
fix: generate:thor-asset-map, min diff

### DIFF
--- a/scripts/generateTradableThorAssetMap/utils.ts
+++ b/scripts/generateTradableThorAssetMap/utils.ts
@@ -29,6 +29,7 @@ import type { ThornodePoolResponse } from 'lib/swapper/swappers/ThorchainSwapper
 
 import type { AssetIdPair } from '.'
 
+// When this is updated, also update the instance in the ThorchainSwapper
 enum ThorchainChain {
   BTC = 'BTC',
   DOGE = 'DOGE',

--- a/scripts/generateTradableThorAssetMap/utils.ts
+++ b/scripts/generateTradableThorAssetMap/utils.ts
@@ -2,24 +2,62 @@ import type { AssetId, AssetNamespace, ChainId } from '@shapeshiftoss/caip'
 import {
   ASSET_NAMESPACE,
   avalancheAssetId,
+  avalancheChainId,
   bchAssetId,
+  bchChainId,
   binanceAssetId,
+  binanceChainId,
   bscAssetId,
+  bscChainId,
   btcAssetId,
+  btcChainId,
   cosmosAssetId,
+  cosmosChainId,
   dogeAssetId,
+  dogeChainId,
   ethAssetId,
+  ethChainId,
   ltcAssetId,
+  ltcChainId,
   thorchainAssetId,
+  thorchainChainId,
   toAssetId,
 } from '@shapeshiftoss/caip'
 import { KnownChainIds } from '@shapeshiftoss/types'
 import { getAddress, isAddress } from 'viem'
 import type { ThornodePoolResponse } from 'lib/swapper/swappers/ThorchainSwapper/types'
-import { ChainToChainIdMap, ThorchainChain } from 'lib/swapper/swappers/ThorchainSwapper/types'
-import { assertUnreachable } from 'lib/utils'
 
 import type { AssetIdPair } from '.'
+
+enum ThorchainChain {
+  BTC = 'BTC',
+  DOGE = 'DOGE',
+  LTC = 'LTC',
+  BCH = 'BCH',
+  ETH = 'ETH',
+  AVAX = 'AVAX',
+  BNB = 'BNB',
+  GAIA = 'GAIA',
+  THOR = 'THOR',
+  BSC = 'BSC',
+}
+
+const ChainToChainIdMap: Map<ThorchainChain, ChainId> = new Map([
+  [ThorchainChain.BTC, btcChainId],
+  [ThorchainChain.DOGE, dogeChainId],
+  [ThorchainChain.LTC, ltcChainId],
+  [ThorchainChain.BCH, bchChainId],
+  [ThorchainChain.ETH, ethChainId],
+  [ThorchainChain.AVAX, avalancheChainId],
+  [ThorchainChain.BNB, binanceChainId],
+  [ThorchainChain.GAIA, cosmosChainId],
+  [ThorchainChain.THOR, thorchainChainId],
+  [ThorchainChain.BSC, bscChainId],
+])
+
+function assertUnreachable(x: never): never {
+  throw Error(`unhandled case: ${x}`)
+}
 
 export const getFeeAssetFromThorchainChain = (chain: ThorchainChain): AssetId | undefined => {
   switch (chain) {

--- a/src/lib/swapper/swappers/ThorchainSwapper/types.ts
+++ b/src/lib/swapper/swappers/ThorchainSwapper/types.ts
@@ -1,16 +1,3 @@
-import type { ChainId } from '@shapeshiftoss/caip'
-import {
-  avalancheChainId,
-  bchChainId,
-  binanceChainId,
-  bscChainId,
-  btcChainId,
-  cosmosChainId,
-  dogeChainId,
-  ethChainId,
-  ltcChainId,
-  thorchainChainId,
-} from '@shapeshiftoss/caip'
 import type { KnownChainIds } from '@shapeshiftoss/types'
 
 export type MidgardPoolResponse = {
@@ -225,6 +212,7 @@ export type ThorNodeStatusResponseSuccess = {
 
 export type ThornodeStatusResponse = ThorNodeStatusResponseSuccess | ThornodeQuoteResponseError
 
+// When this is updated, also update the instance in generateTradableThorAssetMap
 export enum ThorchainChain {
   BTC = 'BTC',
   DOGE = 'DOGE',
@@ -237,16 +225,3 @@ export enum ThorchainChain {
   THOR = 'THOR',
   BSC = 'BSC',
 }
-
-export const ChainToChainIdMap: Map<ThorchainChain, ChainId> = new Map([
-  [ThorchainChain.BTC, btcChainId],
-  [ThorchainChain.DOGE, dogeChainId],
-  [ThorchainChain.LTC, ltcChainId],
-  [ThorchainChain.BCH, bchChainId],
-  [ThorchainChain.ETH, ethChainId],
-  [ThorchainChain.AVAX, avalancheChainId],
-  [ThorchainChain.BNB, binanceChainId],
-  [ThorchainChain.GAIA, cosmosChainId],
-  [ThorchainChain.THOR, thorchainChainId],
-  [ThorchainChain.BSC, bscChainId],
-])


### PR DESCRIPTION
## Description

This PR supersedes the original approach used in https://github.com/shapeshift/web/pull/6211 and instead copies the 2 duplicate constants and helpers to reduce the diff and keep THORChain specific logic out of the `@shapeshiftoss/types` package.

## Pull Request Type

- [ ] :bug: Bug fix (Non-breaking Change: Fixes an issue)
- [x] :hammer_and_wrench: Chore (Non-breaking Change: Doc updates, pkg upgrades, typos, etc..)
- [ ] :nail_care: New Feature (Breaking/Non-breaking Change)

## Issue (if applicable)

N/A

## Risk
> High Risk PRs Require 2 approvals

Small - at runtime this only changes imports.

> What protocols, transaction types or contract interactions might be affected by this PR?

## Testing

- Running `yarn generate:thor-asset-map` should work again
- Perform a general regression test on the app, specifically thorchain swapping.

### Engineering

☝️

### Operations

☝️

## Screenshots (if applicable)

N/A