### PR TITLE
feat: don't initialize ethersProvider in module scope

### DIFF
--- a/src/state/slices/opportunitiesSlice/resolvers/uniV2/index.ts
+++ b/src/state/slices/opportunitiesSlice/resolvers/uniV2/index.ts
@@ -35,10 +35,9 @@ import type {
 } from '../types'
 import { calculateAPRFromToken0 } from './utils'
 
-const ethersProvider = getEthersProvider()
-
 let _blockNumber: number | null = null
 const getBlockNumber = async () => {
+  const ethersProvider = getEthersProvider()
   if (_blockNumber) return _blockNumber
   const blockNumber = await ethersProvider.getBlockNumber()
   _blockNumber = blockNumber


### PR DESCRIPTION
## Description

Shaves off one request off daemon.* calls, mostly here for posteriority - since the `resolvers/univ2` is evaluated on splash screen, this means there is effectively a network request to the daemon while still in splash screen, which could be avoided.
Stretching the idea some more, as we get more and more lazy with loading, we should ensure there are no requests being made to endpoints at module-scope level.

## Pull Request Type

- [ ] :bug: Bug fix (Non-breaking Change: Fixes an issue)
- [ ] :hammer_and_wrench: Chore (Non-breaking Change: Doc updates, pkg upgrades, typos, etc..)
- [x] :nail_care: New Feature (Breaking/Non-breaking Change)

## Issue (if applicable)

<!-----------------------------------------------------------------------------
If applicable, please link to the github issue and put `closes #XXXX` in your comment to auto-close the issue that your PR fixes.
------------------------------------------------------------------------------>

relates to #6193

## Risk
> High Risk PRs Require 2 approvals

<!-----------------------------------------------------------------------------
Outline the scope of your changes and the risk associated with them. You must use your discretion as an engineer to determine the potential impact of your changes.

WARNING: If your PR introduces a new on-chain transaction or modifies an existing one, please add the "High-Risk" label to this PR and ask for 2 reviewers to approve it before merging.

E.g. an upgrade to `hdwallet` or core state management would be considered higher risk, and might require a full regression test. UI or isolated view changes, or something behind a feature flag may have near zero risk. Small bug fixes might require testing isolated to the specific fix.
------------------------------------------------------------------------------>

Low to none

> What protocols, transaction types or contract interactions might be affected by this PR?

## Testing

<!-----------------------------------------------------------------------------
We treat every PR to be merged with the same scrutiny as if we were merging directly to production.

Your PR will not be merged if you do not complete the sections below for our engineering and operations teams to test.
------------------------------------------------------------------------------>

### Engineering

<!-----------------------------------------------------------------------------
Include sufficient information here for an engineer to test your PR. This may include how to test locally, in a built environment, changes to infrastructure etc.
------------------------------------------------------------------------------>

- Ensure `getBlockNumber` initiator doesn't fire daemon.* requests at splash-screen level, but only after that

### Operations

<!-----------------------------------------------------------------------------
If your changes have a user-facing impact, describe how a non-technical QA team can functionally test your changes in a preview environment.

If they are not user-facing please describe how to test for any regressions that may occur.
------------------------------------------------------------------------------>

None

## Screenshots (if applicable)
