### PR TITLE
feat: switch ethers JSON-RPC provider to StaticJsonRpcProvider

### DIFF
--- a/__mocks__/ethers.ts
+++ b/__mocks__/ethers.ts
@@ -15,7 +15,7 @@ const ethersMock = {
   ...ethers,
   providers: {
     JsonRpcProvider: vi.fn(),
-    JsonRpcBatchProvider: vi.fn(),
+    StaticJsonRpcProvider: vi.fn(),
   },
   Contract: vi.fn().mockImplementation(address => ({
     decimals: () => {

--- a/packages/caip/src/adapters/yearn/utils.ts
+++ b/packages/caip/src/adapters/yearn/utils.ts
@@ -10,7 +10,7 @@ import { toChainId } from '../../chainId/chainId'
 import { CHAIN_NAMESPACE, CHAIN_REFERENCE } from '../../constants'
 
 const network = 1 // 1 for mainnet
-const provider = new ethers.providers.JsonRpcBatchProvider(process.env.REACT_APP_ETHEREUM_NODE_URL)
+const provider = new ethers.providers.StaticJsonRpcProvider(process.env.REACT_APP_ETHEREUM_NODE_URL)
 const yearnSdk = new Yearn(network, { provider })
 
 export const writeFiles = async (data: Record<string, Record<string, string>>) => {

--- a/packages/unchained-client/src/evm/bnbsmartchain/parser/bep20.ts
+++ b/packages/unchained-client/src/evm/bnbsmartchain/parser/bep20.ts
@@ -16,11 +16,11 @@ export interface TxMetadata extends BaseTxMetadata {
 
 interface ParserArgs {
   chainId: ChainId
-  provider: ethers.providers.JsonRpcBatchProvider
+  provider: ethers.providers.StaticJsonRpcProvider
 }
 
 export class Parser<T extends Tx> implements SubParser<T> {
-  provider: ethers.providers.JsonRpcBatchProvider
+  provider: ethers.providers.StaticJsonRpcProvider
 
   readonly chainId: ChainId
   readonly abiInterface = new ethers.utils.Interface(bep20)

--- a/packages/unchained-client/src/evm/ethereum/parser/uniV2.ts
+++ b/packages/unchained-client/src/evm/ethereum/parser/uniV2.ts
@@ -23,11 +23,11 @@ export interface TxMetadata extends BaseTxMetadata {
 
 export interface ParserArgs {
   chainId: ChainId
-  provider: ethers.providers.JsonRpcBatchProvider
+  provider: ethers.providers.StaticJsonRpcProvider
 }
 
 export class Parser implements SubParser<Tx> {
-  provider: ethers.providers.JsonRpcBatchProvider
+  provider: ethers.providers.StaticJsonRpcProvider
   readonly chainId: ChainId
   readonly wethContract: string
   readonly abiInterface = new ethers.utils.Interface(UNIV2_ABI)

--- a/packages/unchained-client/src/evm/ethereum/parser/weth.ts
+++ b/packages/unchained-client/src/evm/ethereum/parser/weth.ts
@@ -16,11 +16,11 @@ export interface TxMetadata extends BaseTxMetadata {
 
 export interface ParserArgs {
   chainId: ChainId
-  provider: ethers.providers.JsonRpcBatchProvider
+  provider: ethers.providers.StaticJsonRpcProvider
 }
 
 export class Parser implements SubParser<Tx> {
-  provider: ethers.providers.JsonRpcBatchProvider
+  provider: ethers.providers.StaticJsonRpcProvider
   readonly chainId: ChainId
   readonly wethContract: string
   readonly abiInterface = new ethers.utils.Interface(WETH_ABI)

--- a/packages/unchained-client/src/evm/parser/erc20.ts
+++ b/packages/unchained-client/src/evm/parser/erc20.ts
@@ -16,11 +16,11 @@ export interface TxMetadata extends BaseTxMetadata {
 
 interface ParserArgs {
   chainId: ChainId
-  provider: ethers.providers.JsonRpcBatchProvider
+  provider: ethers.providers.StaticJsonRpcProvider
 }
 
 export class Parser<T extends Tx> implements SubParser<T> {
-  provider: ethers.providers.JsonRpcBatchProvider
+  provider: ethers.providers.StaticJsonRpcProvider
 
   readonly chainId: ChainId
   readonly abiInterface = new ethers.utils.Interface(ERC20_ABI)

--- a/packages/unchained-client/src/evm/parser/index.ts
+++ b/packages/unchained-client/src/evm/parser/index.ts
@@ -26,7 +26,7 @@ export class BaseTransactionParser<T extends Tx> {
   assetId: AssetId
 
   protected readonly api: Api
-  protected readonly provider: ethers.providers.JsonRpcBatchProvider
+  protected readonly provider: ethers.providers.StaticJsonRpcProvider
 
   private parsers: SubParser<T>[] = []
 
@@ -34,7 +34,7 @@ export class BaseTransactionParser<T extends Tx> {
     this.chainId = args.chainId
     this.assetId = args.assetId
     this.api = args.api
-    this.provider = new ethers.providers.JsonRpcBatchProvider(args.rpcUrl)
+    this.provider = new ethers.providers.StaticJsonRpcProvider(args.rpcUrl)
   }
 
   /**

--- a/packages/unchained-client/src/evm/parser/nft.ts
+++ b/packages/unchained-client/src/evm/parser/nft.ts
@@ -18,13 +18,13 @@ export interface TxMetadata extends BaseTxMetadata {
 interface ParserArgs {
   chainId: ChainId
   api: Api
-  provider: ethers.providers.JsonRpcBatchProvider
+  provider: ethers.providers.StaticJsonRpcProvider
 }
 
 const supportedTokenTypes = ['ERC721', 'ERC1155', 'BEP721', 'BEP1155']
 
 export class Parser<T extends Tx> implements SubParser<T> {
-  provider: ethers.providers.JsonRpcBatchProvider
+  provider: ethers.providers.StaticJsonRpcProvider
 
   readonly chainId: ChainId
   readonly api: Api

--- a/scripts/generateAssetData/ethereum/yearnVaults.ts
+++ b/scripts/generateAssetData/ethereum/yearnVaults.ts
@@ -9,7 +9,7 @@ import { ethereum } from '../baseAssets'
 import { colorMap } from '../colorMap'
 
 const network = 1 // 1 for mainnet
-const provider = new ethers.providers.JsonRpcBatchProvider(process.env.ETHEREUM_NODE_URL)
+const provider = new ethers.providers.StaticJsonRpcProvider(process.env.ETHEREUM_NODE_URL)
 export const yearnSdk = new Yearn(network, { provider })
 
 const explorerData = {

--- a/src/lib/ethersProviderSingleton.ts
+++ b/src/lib/ethersProviderSingleton.ts
@@ -29,13 +29,13 @@ export const rpcUrlByChainId = (chainId: EvmChainId): string => {
   }
 }
 
-const ethersProviders: Map<ChainId, providers.JsonRpcBatchProvider> = new Map()
+const ethersProviders: Map<ChainId, providers.StaticJsonRpcProvider> = new Map()
 
 export const getEthersProvider = (
   chainId: EvmChainId = KnownChainIds.EthereumMainnet,
-): providers.JsonRpcBatchProvider => {
+): providers.StaticJsonRpcProvider => {
   if (!ethersProviders.has(chainId)) {
-    const provider = new providers.JsonRpcBatchProvider(rpcUrlByChainId(chainId))
+    const provider = new providers.StaticJsonRpcProvider(rpcUrlByChainId(chainId))
     ethersProviders.set(chainId, provider)
     return provider
   } else {

--- a/src/lib/investor/investor-foxy/api/api.ts
+++ b/src/lib/investor/investor-foxy/api/api.ts
@@ -60,6 +60,7 @@ type EthereumChainReference =
 export type ConstructorArgs = {
   adapter: EvmBaseAdapter<KnownChainIds.EthereumMainnet>
   providerUrl: string
+  provider: ethers.providers.StaticJsonRpcProvider
   foxyAddresses: FoxyAddressesType
   chainReference?: EthereumChainReference
 }
@@ -85,7 +86,6 @@ export class FoxyApi {
   public adapter: EvmBaseAdapter<KnownChainIds.EthereumMainnet>
   public provider: ethers.providers.StaticJsonRpcProvider
   private providerUrl: string
-  public jsonRpcProvider: ethers.providers.StaticJsonRpcProvider
   private foxyStakingContracts: ethers.Contract[]
   private liquidityReserveContracts: ethers.Contract[]
   private readonly ethereumChainReference: ChainReference
@@ -96,10 +96,10 @@ export class FoxyApi {
     providerUrl,
     foxyAddresses,
     chainReference = CHAIN_REFERENCE.EthereumMainnet,
+    provider,
   }: ConstructorArgs) {
     this.adapter = adapter
-    this.provider = new ethers.providers.StaticJsonRpcProvider(providerUrl)
-    this.jsonRpcProvider = new ethers.providers.StaticJsonRpcProvider(providerUrl)
+    this.provider = provider
     this.foxyStakingContracts = foxyAddresses.map(
       addresses => new ethers.Contract(addresses.staking, foxyStakingAbi, this.provider),
     )

--- a/src/lib/investor/investor-foxy/api/api.ts
+++ b/src/lib/investor/investor-foxy/api/api.ts
@@ -83,9 +83,9 @@ const TOKE_IPFS_URL = 'https://ipfs.tokemaklabs.xyz/ipfs'
 
 export class FoxyApi {
   public adapter: EvmBaseAdapter<KnownChainIds.EthereumMainnet>
-  public provider: ethers.providers.JsonRpcBatchProvider
+  public provider: ethers.providers.StaticJsonRpcProvider
   private providerUrl: string
-  public jsonRpcProvider: ethers.providers.JsonRpcBatchProvider
+  public jsonRpcProvider: ethers.providers.StaticJsonRpcProvider
   private foxyStakingContracts: ethers.Contract[]
   private liquidityReserveContracts: ethers.Contract[]
   private readonly ethereumChainReference: ChainReference
@@ -98,8 +98,8 @@ export class FoxyApi {
     chainReference = CHAIN_REFERENCE.EthereumMainnet,
   }: ConstructorArgs) {
     this.adapter = adapter
-    this.provider = new ethers.providers.JsonRpcBatchProvider(providerUrl)
-    this.jsonRpcProvider = new ethers.providers.JsonRpcBatchProvider(providerUrl)
+    this.provider = new ethers.providers.StaticJsonRpcProvider(providerUrl)
+    this.jsonRpcProvider = new ethers.providers.StaticJsonRpcProvider(providerUrl)
     this.foxyStakingContracts = foxyAddresses.map(
       addresses => new ethers.Contract(addresses.staking, foxyStakingAbi, this.provider),
     )

--- a/src/lib/investor/investor-foxy/foxycli.ts
+++ b/src/lib/investor/investor-foxy/foxycli.ts
@@ -4,6 +4,7 @@ import { NativeHDWallet } from '@shapeshiftoss/hdwallet-native'
 import { WithdrawType } from '@shapeshiftoss/types'
 import * as unchained from '@shapeshiftoss/unchained-client'
 import dotenv from 'dotenv'
+import { ethers } from 'ethers'
 import readline from 'readline-sync'
 import { bnOrZero } from 'lib/bignumber/bignumber'
 
@@ -54,6 +55,9 @@ const main = async (): Promise<void> => {
     adapter: ethChainAdapter,
     providerUrl: process.env.ARCHIVE_NODE || 'http://127.0.0.1:8545/',
     foxyAddresses,
+    provider: new ethers.providers.StaticJsonRpcProvider(
+      process.env.ARCHIVE_NODE || 'http://127.0.0.1:8545/',
+    ),
   })
 
   const accountNumber = 0

--- a/src/lib/market-service/foxy/foxy.test.ts
+++ b/src/lib/market-service/foxy/foxy.test.ts
@@ -1,5 +1,6 @@
 import { HistoryTimeframe } from '@shapeshiftoss/types'
 import type { AxiosInstance } from 'axios'
+import { ethers } from 'ethers'
 import { beforeAll, describe, expect, it, vi } from 'vitest'
 import { bn } from 'lib/bignumber/bignumber'
 
@@ -7,6 +8,7 @@ import { FOXY_ASSET_ID, FoxyMarketService } from './foxy'
 import { fox, mockFoxyMarketData } from './foxyMockData'
 
 const foxyMarketService = new FoxyMarketService({
+  provider: new ethers.providers.StaticJsonRpcProvider(''),
   providerUrls: {
     jsonRpcProviderUrl: 'dummy',
     unchainedEthereumHttpUrl: '',

--- a/src/lib/market-service/foxy/foxy.ts
+++ b/src/lib/market-service/foxy/foxy.ts
@@ -7,6 +7,7 @@ import type {
   PriceHistoryArgs,
 } from '@shapeshiftoss/types'
 import * as unchained from '@shapeshiftoss/unchained-client'
+import type { ethers } from 'ethers'
 import { foxyAddresses, FoxyApi } from 'lib/investor/investor-foxy'
 
 import type { MarketService } from '../api'
@@ -19,11 +20,19 @@ const FOXY_ASSET_PRECISION = '18'
 
 export class FoxyMarketService extends CoinGeckoMarketService implements MarketService {
   providerUrls: ProviderUrls
+  provider: ethers.providers.StaticJsonRpcProvider
 
-  constructor({ providerUrls }: { providerUrls: ProviderUrls }) {
+  constructor({
+    providerUrls,
+    provider,
+  }: {
+    providerUrls: ProviderUrls
+    provider: ethers.providers.StaticJsonRpcProvider
+  }) {
     super()
 
     this.providerUrls = providerUrls
+    this.provider = provider
   }
 
   async findAll() {
@@ -71,6 +80,7 @@ export class FoxyMarketService extends CoinGeckoMarketService implements MarketS
         adapter: ethChainAdapter,
         providerUrl: this.providerUrls.jsonRpcProviderUrl,
         foxyAddresses,
+        provider: this.provider,
       })
 
       const tokenContractAddress = foxyAddresses[0].foxy

--- a/src/lib/market-service/market-service-manager.ts
+++ b/src/lib/market-service/market-service-manager.ts
@@ -6,6 +6,7 @@ import type {
   MarketDataArgs,
   PriceHistoryArgs,
 } from '@shapeshiftoss/types'
+import type { ethers } from 'ethers'
 import { AssetService } from 'lib/asset-service'
 
 // import { Yearn } from '@yfi/sdk'
@@ -25,6 +26,7 @@ export type ProviderUrls = {
 export type MarketServiceManagerArgs = {
   yearnChainReference: 1 | 250 | 1337 | 42161 // from @yfi/sdk
   providerUrls: ProviderUrls
+  provider: ethers.providers.StaticJsonRpcProvider
 }
 
 export class MarketServiceManager {
@@ -32,7 +34,7 @@ export class MarketServiceManager {
   assetService: AssetService
 
   constructor(args: MarketServiceManagerArgs) {
-    const { providerUrls } = args
+    const { providerUrls, provider } = args
 
     // TODO(0xdef1cafe): after chain agnosticism, we need to dependency inject a chainReference here
     // YearnVaultMarketCapService deps
@@ -48,7 +50,7 @@ export class MarketServiceManager {
       // Yearn is currently borked upstream
       // new YearnVaultMarketCapService({ yearnSdk }),
       // new YearnTokenMarketCapService({ yearnSdk }),
-      new FoxyMarketService({ providerUrls }),
+      new FoxyMarketService({ providerUrls, provider }),
     ]
 
     this.assetService = new AssetService()

--- a/src/lib/market-service/market-service.test.ts
+++ b/src/lib/market-service/market-service.test.ts
@@ -1,4 +1,5 @@
 import { HistoryTimeframe } from '@shapeshiftoss/types'
+import { ethers } from 'ethers'
 import { describe, expect, it, vi } from 'vitest'
 
 import { CoinGeckoMarketService } from './coingecko/coingecko'
@@ -99,6 +100,7 @@ describe('market service', () => {
   const marketServiceManagerArgs = {
     coinGeckoAPIKey: 'dummyCoingeckoApiKey',
     yearnChainReference: 1 as const,
+    provider: new ethers.providers.StaticJsonRpcProvider(''),
     providerUrls: {
       jsonRpcProviderUrl: '',
       unchainedEthereumWsUrl: '',

--- a/src/plugins/walletConnectToDapps/hooks/useGetAbi.tsx
+++ b/src/plugins/walletConnectToDapps/hooks/useGetAbi.tsx
@@ -28,7 +28,7 @@ export const useGetAbi = (
 
   const { to: contractAddress, data } = transactionParams
   const provider = useMemo(
-    () => new ethers.providers.JsonRpcBatchProvider(getConfig().REACT_APP_ETHEREUM_NODE_URL),
+    () => new ethers.providers.StaticJsonRpcProvider(getConfig().REACT_APP_ETHEREUM_NODE_URL),
     [],
   )
 

--- a/src/state/apis/foxy/foxyApiSingleton.ts
+++ b/src/state/apis/foxy/foxyApiSingleton.ts
@@ -1,6 +1,7 @@
 import type { EvmBaseAdapter } from '@shapeshiftoss/chain-adapters'
 import { KnownChainIds } from '@shapeshiftoss/types'
 import { getConfig } from 'config'
+import { getEthersProvider } from 'lib/ethersProviderSingleton'
 import { foxyAddresses, FoxyApi } from 'lib/investor/investor-foxy'
 import { assertGetEvmChainAdapter } from 'lib/utils/evm'
 
@@ -19,6 +20,7 @@ export const getFoxyApi = (): FoxyApi => {
     ) as EvmBaseAdapter<KnownChainIds.EthereumMainnet>,
     providerUrl: getConfig()[RPC_PROVIDER_ENV],
     foxyAddresses,
+    provider: getEthersProvider(KnownChainIds.EthereumMainnet),
   })
 
   _foxyApi = foxyApi

--- a/src/state/slices/marketDataSlice/marketServiceManagerSingleton.ts
+++ b/src/state/slices/marketDataSlice/marketServiceManagerSingleton.ts
@@ -1,5 +1,7 @@
 // do not directly use or export, singleton
+import { KnownChainIds } from '@shapeshiftoss/types'
 import { getConfig } from 'config'
+import { getEthersProvider } from 'lib/ethersProviderSingleton'
 import { MarketServiceManager } from 'lib/market-service'
 
 let _marketServiceManager: MarketServiceManager | undefined
@@ -11,6 +13,7 @@ export const getMarketServiceManager: GetMarketServiceManager = () => {
   if (!_marketServiceManager) {
     _marketServiceManager = new MarketServiceManager({
       yearnChainReference: 1, // CHAIN_REFERENCE.EthereumMainnet is '1', yearn requires strict number union
+      provider: getEthersProvider(KnownChainIds.EthereumMainnet),
       providerUrls: {
         jsonRpcProviderUrl: config.REACT_APP_ETHEREUM_NODE_URL,
         unchainedEthereumHttpUrl: config.REACT_APP_UNCHAINED_ETHEREUM_HTTP_URL,


### PR DESCRIPTION
## Description

... and inject it to `MarketServiceManager` and `investor-foxy`, to avoid multiple instantiations that trigger calls to `eth_chainId`.
No batching, but less requests in the end, which means things are effectively faster *and* more performant.  

## Pull Request Type

- [ ] :bug: Bug fix (Non-breaking Change: Fixes an issue)
- [ ] :hammer_and_wrench: Chore (Non-breaking Change: Doc updates, pkg upgrades, typos, etc..)
- [x] :nail_care: New Feature (Breaking/Non-breaking Change)

## Issue (if applicable)

<!-----------------------------------------------------------------------------
If applicable, please link to the github issue and put `closes #XXXX` in your comment to auto-close the issue that your PR fixes.
------------------------------------------------------------------------------>

- relates to https://github.com/shapeshift/web/issues/6193

## Risk
> High Risk PRs Require 2 approvals

<!-----------------------------------------------------------------------------
Outline the scope of your changes and the risk associated with them. You must use your discretion as an engineer to determine the potential impact of your changes.

WARNING: If your PR introduces a new on-chain transaction or modifies an existing one, please add the "High-Risk" label to this PR and ask for 2 reviewers to approve it before merging.

E.g. an upgrade to `hdwallet` or core state management would be considered higher risk, and might require a full regression test. UI or isolated view changes, or something behind a feature flag may have near zero risk. Small bug fixes might require testing isolated to the specific fix.
------------------------------------------------------------------------------>

> What protocols, transaction types or contract interactions might be affected by this PR?

## Testing

<!-----------------------------------------------------------------------------
We treat every PR to be merged with the same scrutiny as if we were merging directly to production.

Your PR will not be merged if you do not complete the sections below for our engineering and operations teams to test.
------------------------------------------------------------------------------>

### Engineering

<!-----------------------------------------------------------------------------
Include sufficient information here for an engineer to test your PR. This may include how to test locally, in a built environment, changes to infrastructure etc.
------------------------------------------------------------------------------>

- Compare network tab against develop
- Ensure we don't spam `eth_chainId` payloads aymore

### Operations

<!-----------------------------------------------------------------------------
If your changes have a user-facing impact, describe how a non-technical QA team can functionally test your changes in a preview environment.

If they are not user-facing please describe how to test for any regressions that may occur.
------------------------------------------------------------------------------>

## Screenshots (if applicable)

### Develop

- 113 daemon.ethereum XHRs

<img width="111" alt="Screenshot 2024-02-15 at 15 27 22" src="https://github.com/shapeshift/web/assets/17035424/32ddc534-21ee-4b06-8eee-15bb6bfad856">

- Chatty `eth_chainId`

<img width="763" alt="image" src="https://github.com/shapeshift/web/assets/17035424/9d2c9a45-6f8b-4cee-8121-0f32434bc2dc">
<img width="723" alt="image" src="https://github.com/shapeshift/web/assets/17035424/4810ad88-996b-477f-9772-2cf9f79a2a8c">
<img width="698" alt="image" src="https://github.com/shapeshift/web/assets/17035424/48f80dab-f301-4607-83d4-1cbc783263e3">
<img width="719" alt="image" src="https://github.com/shapeshift/web/assets/17035424/3b0f8e11-aa09-4b12-8098-ff612891e9cd">
<img width="717" alt="image" src="https://github.com/shapeshift/web/assets/17035424/2a105871-d703-43ae-ac99-5e2f628b6b16">

And many, many more

### This diff

- 95 daemon.ethereum XHRs

<img width="125" alt="Screenshot 2024-02-15 at 15 23 42" src="https://github.com/shapeshift/web/assets/17035424/09cd031f-06d0-4ebd-bf4a-2d6f7f0df375">

- Not-so-chatty `eth_chainId`

Now only called once by `BaseTransactionParser`

<img width="741" alt="image" src="https://github.com/shapeshift/web/assets/17035424/14d81033-a68a-4cf9-9d12-fd5fd21f2a2d">
<img width="623" alt="image" src="https://github.com/shapeshift/web/assets/17035424/13780264-3dbf-4388-a29e-311973fb9dd7">
