### PR TITLE
fix: make trade component eager

### DIFF
--- a/src/Routes/RoutesCommon.tsx
+++ b/src/Routes/RoutesCommon.tsx
@@ -10,6 +10,7 @@ import { PoolsIcon } from 'components/Icons/Pools'
 import { SwapIcon } from 'components/Icons/SwapIcon'
 import { TxHistoryIcon } from 'components/Icons/TxHistory'
 import { assetIdPaths } from 'hooks/useRouteAssetId/useRouteAssetId'
+import { Trade } from 'pages/Trade/Trade'
 
 import type { Route as NestedRoute } from './helpers'
 import { RouteCategory } from './helpers'
@@ -82,14 +83,6 @@ const PoolsPage = makeSuspenseful(
   lazy(() =>
     import('pages/ThorChainLP/PoolsPage').then(({ PoolsPage }) => ({
       default: PoolsPage,
-    })),
-  ),
-)
-
-const Trade = makeSuspenseful(
-  lazy(() =>
-    import('pages/Trade/Trade').then(({ Trade }) => ({
-      default: Trade,
     })),
   ),
 )


### PR DESCRIPTION
## Description

Fixes a nasty receive address regression caused by https://github.com/shapeshift/web/pull/6130 by reverting the change to make the `Trade` component lazy.

## Pull Request Type

- [x] :bug: Bug fix (Non-breaking Change: Fixes an issue)
- [ ] :hammer_and_wrench: Chore (Non-breaking Change: Doc updates, pkg upgrades, typos, etc..)
- [ ] :nail_care: New Feature (Breaking/Non-breaking Change)

## Issue (if applicable)

N/A - production issue.

## Risk
> High Risk PRs Require 2 approvals

High risk in a sense because it inadvertently touches accounts, though in actuality likely medium as it brings back the previous working state.

> What protocols, transaction types or contract interactions might be affected by this PR?

N/A

## Testing

Get a quote and confirm that the receive address tag is the same as the auto-selected receive address.

Good (this PR):

<img width="577" alt="Screenshot 2024-02-16 at 10 44 59 am" src="https://github.com/shapeshift/web/assets/97164662/12b9b363-1f83-4ac5-8796-9d472d8a6e30">

Bad (develop):

<img width="577" alt="Screenshot 2024-02-16 at 10 24 08 am" src="https://github.com/shapeshift/web/assets/97164662/4704a28e-01a5-4396-9ae8-383da7d9b62f">

### Engineering

☝️

### Operations

☝️

## Screenshots (if applicable)

See above.