### PR TITLE
fix: do not hardcode thorchain on trading active check

### DIFF
--- a/src/state/apis/swapper/swapperApi.ts
+++ b/src/state/apis/swapper/swapperApi.ts
@@ -1,7 +1,6 @@
 import { createApi } from '@reduxjs/toolkit/dist/query/react'
 import type { ChainId } from '@shapeshiftoss/caip'
 import { type AssetId, fromAssetId } from '@shapeshiftoss/caip'
-import { SwapperName } from '@shapeshiftoss/swapper'
 import { reactQueries } from 'react-queries'
 import { selectInboundAddressData, selectIsTradingActive } from 'react-queries/selectors'
 import { queryClient } from 'context/QueryClientProvider/queryClient'

--- a/src/state/apis/swapper/swapperApi.ts
+++ b/src/state/apis/swapper/swapperApi.ts
@@ -127,7 +127,7 @@ export const swapperApi = createApi({
                   return selectIsTradingActive({
                     assetId,
                     inboundAddressResponse,
-                    swapperName: SwapperName.Thorchain,
+                    swapperName,
                     mimir,
                   })
                 }),


### PR DESCRIPTION
## Description

Use the _actual_ swapper name when checking if trading is active.

## Pull Request Type

- [x] :bug: Bug fix (Non-breaking Change: Fixes an issue)
- [ ] :hammer_and_wrench: Chore (Non-breaking Change: Doc updates, pkg upgrades, typos, etc..)
- [ ] :nail_care: New Feature (Breaking/Non-breaking Change)

## Issue (if applicable)

N/A - fixes regression caused by https://github.com/shapeshift/web/pull/6168.

## Risk
> High Risk PRs Require 2 approvals

Small

> What protocols, transaction types or contract interactions might be affected by this PR?

In theory all swappers are affected by this change - we need to ensure we can still trade with them without misleading halted flags.

## Testing

- Halt flags should only apply to THORChain
- The current issue in release where 0x quotes on Arbitrum are showing as halted should be resolved

### Engineering

☝️

### Operations

☝️

## Screenshots (if applicable)

N/A