### PR TITLE
chore: add validation for quotes with incorrect sell amount

### DIFF
--- a/src/components/MultiHopTrade/components/TradeInput/getQuoteErrorTranslation.ts
+++ b/src/components/MultiHopTrade/components/TradeInput/getQuoteErrorTranslation.ts
@@ -48,6 +48,7 @@ export const getQuoteErrorTranslation = (
       case SwapperTradeQuoteError.InternalError:
       case TradeQuoteValidationError.QueryFailed:
       case SwapperTradeQuoteError.QueryFailed:
+      case TradeQuoteValidationError.QuoteSellAmountInvalid:
         return 'trade.errors.quoteError'
       default:
         assertUnreachable(error)

--- a/src/state/apis/swapper/helpers/validateTradeQuote.ts
+++ b/src/state/apis/swapper/helpers/validateTradeQuote.ts
@@ -42,6 +42,7 @@ export const validateTradeQuote = async (
     isTradingActiveOnSellPool,
     isTradingActiveOnBuyPool,
     sendAddress,
+    inputSellAmountCryptoBaseUnit,
   }: {
     swapperName: SwapperName
     quote: TradeQuote | undefined
@@ -51,6 +52,7 @@ export const validateTradeQuote = async (
     // TODO(gomes): this should most likely live in the quote alongside the receiveAddress,
     // summoning @woodenfurniture WRT implications of that, this works for now
     sendAddress: string | undefined
+    inputSellAmountCryptoBaseUnit: string
   },
 ): Promise<{
   errors: ErrorWithMeta<TradeQuoteError>[]
@@ -252,6 +254,10 @@ export const validateTradeQuote = async (
     return false
   })()
 
+  // ensure the trade is not selling an amount higher than the user input
+  const invalidQuoteSellAmount =
+    inputSellAmountCryptoBaseUnit !== firstHop.sellAmountIncludingProtocolFeesCryptoBaseUnit
+
   return {
     errors: [
       !!disableSmartContractSwap && {
@@ -300,6 +306,7 @@ export const validateTradeQuote = async (
         },
       },
       feesExceedsSellAmount && { error: TradeQuoteValidationError.SellAmountBelowTradeFee },
+      invalidQuoteSellAmount && { error: TradeQuoteValidationError.QuoteSellAmountInvalid },
 
       ...insufficientBalanceForProtocolFeesErrors,
     ].filter(isTruthy),

--- a/src/state/apis/swapper/swapperApi.ts
+++ b/src/state/apis/swapper/swapperApi.ts
@@ -37,8 +37,15 @@ export const swapperApi = createApi({
     getTradeQuote: build.query<Record<string, ApiQuote>, TradeQuoteRequest>({
       queryFn: async (tradeQuoteInput: TradeQuoteRequest, { dispatch, getState }) => {
         const state = getState() as ReduxState
-        const { swapperName, sendAddress, receiveAddress, sellAsset, buyAsset, affiliateBps } =
-          tradeQuoteInput
+        const {
+          swapperName,
+          sendAddress,
+          receiveAddress,
+          sellAsset,
+          buyAsset,
+          affiliateBps,
+          sellAmountIncludingProtocolFeesCryptoBaseUnit,
+        } = tradeQuoteInput
 
         const isCrossAccountTrade = sendAddress !== receiveAddress
         const featureFlags: FeatureFlags = selectFeatureFlags(state)
@@ -159,6 +166,7 @@ export const swapperApi = createApi({
               isTradingActiveOnSellPool,
               isTradingActiveOnBuyPool,
               sendAddress,
+              inputSellAmountCryptoBaseUnit: sellAmountIncludingProtocolFeesCryptoBaseUnit,
             })
             return {
               id: quoteSource,

--- a/src/state/apis/swapper/types.ts
+++ b/src/state/apis/swapper/types.ts
@@ -35,6 +35,7 @@ export enum TradeQuoteValidationError {
   InsufficientSecondHopFeeAssetBalance = 'InsufficientSecondHopFeeAssetBalance',
   InsufficientFundsForProtocolFee = 'InsufficientFundsForProtocolFee',
   IntermediaryAssetNotNotSupportedByWallet = 'IntermediaryAssetNotNotSupportedByWallet',
+  QuoteSellAmountInvalid = 'QuoteSellAmountInvalid',
   QueryFailed = 'QueryFailed',
   UnknownError = 'UnknownError',
 }


### PR DESCRIPTION
## Description

Prevents a quote being marked as valid (and therefore executable) when the sell amount isn't exactly the same as the sell amount the user inputted.

## Pull Request Type

- [ ] :bug: Bug fix (Non-breaking Change: Fixes an issue)
- [ ] :hammer_and_wrench: Chore (Non-breaking Change: Doc updates, pkg upgrades, typos, etc..)
- [ ] :nail_care: New Feature (Breaking/Non-breaking Change)

## Issue (if applicable)

closes #5723 specifically point `create sanity check that we never ask a user to sign a transaction that is larger than what a user input`

## Risk
> High Risk PRs Require 2 approvals

Low risk as this prevents invalid trades. This check failing or being incorrectly implemented could have 2 possible outcomes
- Prevent valid trades going through. Simple to check and validate by testing trades
- Allow invalid quotes with bad sell amounts though. Very unlikely these quotes ever appear at all after resolving the other issues detailed in #5723. Testable with a monkey patch by eng team

> What protocols, transaction types or contract interactions might be affected by this PR?

LiFi trades specifically, though theoretically any protocol used in trades

## Testing

Check trades are working as normal.

### Engineering

Worth monkey patching to ensure a quote with mismatching sell amount results in a generic quote error.

### Operations

<!-----------------------------------------------------------------------------
If your changes have a user-facing impact, describe how a non-technical QA team can functionally test your changes in a preview environment.

If they are not user-facing please describe how to test for any regressions that may occur.
------------------------------------------------------------------------------>

## Screenshots (if applicable)
