### PR TITLE
fix: temporarily disable eip-1559 for keepkey

### DIFF
--- a/src/components/Modals/Send/hooks/useFormSend/useFormSend.test.tsx
+++ b/src/components/Modals/Send/hooks/useFormSend/useFormSend.test.tsx
@@ -170,6 +170,7 @@ describe.each([
             wallet: {
               supportsOfflineSigning: vi.fn().mockReturnValue(true),
               ethSupportsEIP1559: vi.fn().mockReturnValue(walletSupportsEIP1559),
+              getVendor: vi.fn().mockReturnValue('Native'),
             },
           },
         }) as unknown as IWalletContext,
@@ -230,6 +231,7 @@ describe.each([
             wallet: {
               supportsOfflineSigning: vi.fn().mockReturnValue(true),
               ethSupportsEIP1559: vi.fn().mockReturnValue(walletSupportsEIP1559),
+              getVendor: vi.fn().mockReturnValue('Native'),
             },
           },
         }) as unknown as IWalletContext,
@@ -296,6 +298,7 @@ describe.each([
               supportsOfflineSigning: vi.fn().mockReturnValue(false),
               supportsBroadcast: vi.fn().mockReturnValue(true),
               ethSupportsEIP1559: vi.fn().mockReturnValue(walletSupportsEIP1559),
+              getVendor: vi.fn().mockReturnValue('Native'),
             },
           },
         }) as unknown as IWalletContext,
@@ -351,6 +354,7 @@ describe.each([
       supportsOfflineSigning: vi.fn().mockReturnValue(false),
       supportsBroadcast: vi.fn().mockReturnValue(true),
       ethSupportsEIP1559: vi.fn().mockReturnValue(walletSupportsEIP1559),
+      getVendor: vi.fn().mockReturnValue('Native'),
     } as unknown as HDWallet
     const toaster = vi.fn() as unknown as CreateToastFnReturn
     const signAndBroadcastTransaction = vi.fn().mockResolvedValue('txid')

--- a/src/components/Modals/Send/utils.ts
+++ b/src/components/Modals/Send/utils.ts
@@ -18,7 +18,7 @@ import {
   checkIsSnapInstalled,
 } from 'hooks/useIsSnapInstalled/useIsSnapInstalled'
 import { bn, bnOrZero } from 'lib/bignumber/bignumber'
-import { assertGetChainAdapter, tokenOrUndefined } from 'lib/utils'
+import { assertGetChainAdapter, isKeepKeyHDWallet, tokenOrUndefined } from 'lib/utils'
 import { assertGetCosmosSdkChainAdapter } from 'lib/utils/cosmosSdk'
 import { assertGetEvmChainAdapter, getSupportedEvmChainIds } from 'lib/utils/evm'
 import { assertGetUtxoChainAdapter } from 'lib/utils/utxo'
@@ -141,6 +141,7 @@ export const handleSend = async ({
         chainSpecific: { gasPrice, gasLimit, maxFeePerGas, maxPriorityFeePerGas },
       } = fees
       const shouldUseEIP1559Fees =
+        !isKeepKeyHDWallet(wallet) &&
         (await wallet.ethSupportsEIP1559()) &&
         maxFeePerGas !== undefined &&
         maxPriorityFeePerGas !== undefined

--- a/src/components/MultiHopTrade/components/MultiHopTradeConfirm/hooks/useApprovalTx.tsx
+++ b/src/components/MultiHopTrade/components/MultiHopTradeConfirm/hooks/useApprovalTx.tsx
@@ -5,6 +5,7 @@ import type { TradeQuoteStep } from '@shapeshiftoss/swapper'
 import { useEffect, useState } from 'react'
 import { usePoll } from 'hooks/usePoll/usePoll'
 import { useWallet } from 'hooks/useWallet/useWallet'
+import { isKeepKeyHDWallet } from 'lib/utils'
 import { assertGetEvmChainAdapter } from 'lib/utils/evm'
 import { selectHopSellAccountId } from 'state/slices/tradeQuoteSlice/selectors'
 import { useAppSelector } from 'state/store'
@@ -38,7 +39,7 @@ export const useApprovalTx = (
         // This accidentally works since all EVM chains share the same address, so there's no need
         // to call adapter.getAddress() later down the call stack
         const from = fromAccountId(sellAssetAccountId).account
-        const supportsEIP1559 = await wallet.ethSupportsEIP1559()
+        const supportsEIP1559 = !isKeepKeyHDWallet(wallet) && (await wallet.ethSupportsEIP1559())
 
         const { buildCustomTxInput, networkFeeCryptoBaseUnit } = await getApprovalTxData({
           tradeQuoteStep,

--- a/src/components/MultiHopTrade/components/MultiHopTradeConfirm/hooks/useTradeExecution.tsx
+++ b/src/components/MultiHopTrade/components/MultiHopTradeConfirm/hooks/useTradeExecution.tsx
@@ -13,7 +13,7 @@ import { useErrorHandler } from 'hooks/useErrorToast/useErrorToast'
 import { useWallet } from 'hooks/useWallet/useWallet'
 import { MixPanelEvent } from 'lib/mixpanel/types'
 import { TradeExecution } from 'lib/swapper/tradeExecution'
-import { assertUnreachable } from 'lib/utils'
+import { assertUnreachable, isKeepKeyHDWallet } from 'lib/utils'
 import { assertGetCosmosSdkChainAdapter } from 'lib/utils/cosmosSdk'
 import { assertGetEvmChainAdapter, signAndBroadcast } from 'lib/utils/evm'
 import { assertGetUtxoChainAdapter } from 'lib/utils/utxo'
@@ -203,7 +203,8 @@ export const useTradeExecution = (hopIndex: number) => {
         case CHAIN_NAMESPACE.Evm: {
           const adapter = assertGetEvmChainAdapter(stepSellAssetChainId)
           const from = await adapter.getAddress({ accountNumber, wallet })
-          const supportsEIP1559 = supportsETH(wallet) && (await wallet.ethSupportsEIP1559())
+          const supportsEIP1559 =
+            !isKeepKeyHDWallet(wallet) && supportsETH(wallet) && (await wallet.ethSupportsEIP1559())
 
           const output = await execution.execEvmTransaction({
             swapperName,

--- a/src/components/MultiHopTrade/hooks/useGetTradeQuotes/getTradeQuoteArgs.ts
+++ b/src/components/MultiHopTrade/hooks/useGetTradeQuotes/getTradeQuoteArgs.ts
@@ -6,7 +6,7 @@ import type { GetTradeQuoteInput } from '@shapeshiftoss/swapper'
 import type { Asset, UtxoAccountType } from '@shapeshiftoss/types'
 import type { TradeQuoteInputCommonArgs } from 'components/MultiHopTrade/types'
 import { toBaseUnit } from 'lib/math'
-import { assertUnreachable } from 'lib/utils'
+import { assertUnreachable, isKeepKeyHDWallet } from 'lib/utils'
 import { assertGetCosmosSdkChainAdapter } from 'lib/utils/cosmosSdk'
 import { assertGetEvmChainAdapter } from 'lib/utils/evm'
 import { assertGetUtxoChainAdapter } from 'lib/utils/utxo'
@@ -65,7 +65,8 @@ export const getTradeQuoteArgs = async ({
 
   switch (chainNamespace) {
     case CHAIN_NAMESPACE.Evm: {
-      const supportsEIP1559 = supportsETH(wallet) && (await wallet.ethSupportsEIP1559())
+      const supportsEIP1559 =
+        !isKeepKeyHDWallet(wallet) && supportsETH(wallet) && (await wallet.ethSupportsEIP1559())
       const sellAssetChainAdapter = assertGetEvmChainAdapter(sellAsset.chainId)
       const sendAddress = await sellAssetChainAdapter.getAddress({
         accountNumber: sellAccountNumber,

--- a/src/features/defi/providers/fox-farming/hooks/useFoxFarming.ts
+++ b/src/features/defi/providers/fox-farming/hooks/useFoxFarming.ts
@@ -9,7 +9,7 @@ import { encodeFunctionData, getAddress } from 'viem'
 import { useFoxEth } from 'context/FoxEthProvider/FoxEthProvider'
 import { useWallet } from 'hooks/useWallet/useWallet'
 import { toBaseUnit } from 'lib/math'
-import { isValidAccountNumber } from 'lib/utils'
+import { isKeepKeyHDWallet, isValidAccountNumber } from 'lib/utils'
 import {
   assertGetEvmChainAdapter,
   buildAndBroadcast,
@@ -220,7 +220,8 @@ export const useFoxFarming = (
         from: userAddress,
         to: contractAddress,
         value: '0',
-        supportsEIP1559: supportsETH(wallet) && (await wallet.ethSupportsEIP1559()),
+        supportsEIP1559:
+          !isKeepKeyHDWallet(wallet) && supportsETH(wallet) && (await wallet.ethSupportsEIP1559()),
       })
     },
     [adapter, contractAddress, foxFarmingContract, wallet],

--- a/src/lib/investor/investor-foxy/api/api.ts
+++ b/src/lib/investor/investor-foxy/api/api.ts
@@ -14,6 +14,7 @@ import { ethers } from 'ethers'
 import { toLower } from 'lodash'
 import { bn, bnOrZero } from 'lib/bignumber/bignumber'
 import { MAX_ALLOWANCE } from 'lib/investor/constants'
+import { isKeepKeyHDWallet } from 'lib/utils'
 import { DefiType } from 'state/slices/opportunitiesSlice/types'
 
 import { erc20Abi } from '../abi/erc20-abi'
@@ -128,6 +129,7 @@ export class FoxyApi {
       chainSpecific: { gasPrice, gasLimit, maxFeePerGas, maxPriorityFeePerGas },
     } = payload.estimatedFees.fast
     const shouldUseEIP1559Fees =
+      !isKeepKeyHDWallet(wallet) &&
       (await wallet.ethSupportsEIP1559()) &&
       maxFeePerGas !== undefined &&
       maxPriorityFeePerGas !== undefined

--- a/src/lib/utils/evm.ts
+++ b/src/lib/utils/evm.ts
@@ -20,7 +20,7 @@ import { encodeFunctionData, getAddress } from 'viem'
 import { getChainAdapterManager } from 'context/PluginProvider/chainAdapterSingleton'
 import { bn, bnOrZero } from 'lib/bignumber/bignumber'
 
-import { getSupportedChainIdsByChainNamespace } from '.'
+import { getSupportedChainIdsByChainNamespace, isKeepKeyHDWallet } from '.'
 
 type GetApproveContractDataArgs = {
   approvalAmountCryptoBaseUnit: string
@@ -96,7 +96,8 @@ export const getFeesWithWallet = async (args: GetFeesWithWalletArgs): Promise<Fe
   const { accountNumber, adapter, wallet, ...rest } = args
 
   const from = await adapter.getAddress({ accountNumber, wallet })
-  const supportsEIP1559 = supportsETH(wallet) && (await wallet.ethSupportsEIP1559())
+  const supportsEIP1559 =
+    !isKeepKeyHDWallet(wallet) && supportsETH(wallet) && (await wallet.ethSupportsEIP1559())
 
   return getFees({ ...rest, adapter, from, supportsEIP1559 })
 }

--- a/src/react-queries/index.ts
+++ b/src/react-queries/index.ts
@@ -14,7 +14,7 @@ import type {
 } from 'lib/swapper/swappers/ThorchainSwapper/types'
 import { assetIdToPoolAssetId } from 'lib/swapper/swappers/ThorchainSwapper/utils/poolAssetHelpers/poolAssetHelpers'
 import { thorService } from 'lib/swapper/swappers/ThorchainSwapper/utils/thorService'
-import { isToken } from 'lib/utils'
+import { isKeepKeyHDWallet, isToken } from 'lib/utils'
 import {
   assertGetEvmChainAdapter,
   buildAndBroadcast,
@@ -98,7 +98,8 @@ const mutations = createMutationKeys('mutations', {
         value: '0',
         data: approvalCalldata,
         from,
-        supportsEIP1559: supportsETH(wallet) && (await wallet.ethSupportsEIP1559()),
+        supportsEIP1559:
+          !isKeepKeyHDWallet(wallet) && supportsETH(wallet) && (await wallet.ethSupportsEIP1559()),
       })
 
       const buildCustomTxInput = {


### PR DESCRIPTION
## Description

Disables EIP-1559 for keep key across the app to resolve issues interacting with EVM chains.

## Pull Request Type

- [x] :bug: Bug fix (Non-breaking Change: Fixes an issue)
- [ ] :hammer_and_wrench: Chore (Non-breaking Change: Doc updates, pkg upgrades, typos, etc..)
- [ ] :nail_care: New Feature (Breaking/Non-breaking Change)

## Issue (if applicable)

<!-----------------------------------------------------------------------------
If applicable, please link to the github issue and put `closes #XXXX` in your comment to auto-close the issue that your PR fixes.
------------------------------------------------------------------------------>

closes #6246

## Risk
> High Risk PRs Require 2 approvals

Moderate risk of broken EVM functionality for keep key wallets interacting with EVM chains across the app.

> What protocols, transaction types or contract interactions might be affected by this PR?

## Testing

Ensure EVM interactions with keep key across the app are working as intended.

### Engineering

<!-----------------------------------------------------------------------------
Include sufficient information here for an engineer to test your PR. This may include how to test locally, in a built environment, changes to infrastructure etc.
------------------------------------------------------------------------------>

### Operations

<!-----------------------------------------------------------------------------
If your changes have a user-facing impact, describe how a non-technical QA team can functionally test your changes in a preview environment.

If they are not user-facing please describe how to test for any regressions that may occur.
------------------------------------------------------------------------------>

## Screenshots (if applicable)
