### PR TITLE
fix: trades from native assets & utxos

### DIFF
--- a/src/components/MultiHopTrade/components/MultiHopTradeConfirm/hooks/useIsApprovalNeeded.tsx
+++ b/src/components/MultiHopTrade/components/MultiHopTradeConfirm/hooks/useIsApprovalNeeded.tsx
@@ -21,7 +21,7 @@ export const useIsApprovalNeeded = (
         ? bn(allowanceCryptoBaseUnit).lt(
             tradeQuoteStep.sellAmountIncludingProtocolFeesCryptoBaseUnit,
           )
-        : undefined
+        : false
     },
     [tradeQuoteStep],
   )


### PR DESCRIPTION
## Description

Fixes an issue in release which prevents trading from native assets or UTXOs.

Regression from https://github.com/shapeshift/web/pull/6217

Problem summary:

- `useIsApprovalNeeded` was returning `undefined` if `selectAllowanceCryptoBaseUnit` evaluated to `undefined` (which happens in the case of native fee assets or UTXOs
- This caused `isApprovalNeeded` to be `undefined` for these assets, causing the `isLoading` condition of `isApprovalNeeded === undefined` to be met

## Pull Request Type

- [x] :bug: Bug fix (Non-breaking Change: Fixes an issue)
- [ ] :hammer_and_wrench: Chore (Non-breaking Change: Doc updates, pkg upgrades, typos, etc..)
- [ ] :nail_care: New Feature (Breaking/Non-breaking Change)

## Issue (if applicable)

N/A - current release blocker.

See https://github.com/shapeshift/web/pull/6257#issuecomment-1953403818.

## Risk
> High Risk PRs Require 2 approvals

Medium. A small change, but does affect the approval checks of transactions.

> What protocols, transaction types or contract interactions might be affected by this PR?

Any transaction that requires an approval check (trades and LP deposits).

## Testing

- Trades from native assets should now work
- Trades from UTXOs should now work
- Trades from ERC tokens on an EVM should _still_ work

### Engineering

☝️

### Operations

☝️

## Screenshots (if applicable)

Infinite spinner state that this fixes:

<img width="494" alt="Screenshot 2024-02-20 at 5 28 05 pm" src="https://github.com/shapeshift/web/assets/97164662/75f6eb56-a2b0-4cbb-9f60-9481056a65ed">
