### PR TITLE
fix: allow quote sell amounts to be lower than user input sell amount

### DIFF
--- a/src/state/apis/swapper/helpers/validateTradeQuote.ts
+++ b/src/state/apis/swapper/helpers/validateTradeQuote.ts
@@ -255,8 +255,9 @@ export const validateTradeQuote = async (
   })()
 
   // ensure the trade is not selling an amount higher than the user input
-  const invalidQuoteSellAmount =
-    inputSellAmountCryptoBaseUnit !== firstHop.sellAmountIncludingProtocolFeesCryptoBaseUnit
+  const invalidQuoteSellAmount = bn(inputSellAmountCryptoBaseUnit).gte(
+    firstHop.sellAmountIncludingProtocolFeesCryptoBaseUnit,
+  )
 
   return {
     errors: [

--- a/src/state/apis/swapper/helpers/validateTradeQuote.ts
+++ b/src/state/apis/swapper/helpers/validateTradeQuote.ts
@@ -254,10 +254,11 @@ export const validateTradeQuote = async (
     return false
   })()
 
-  // ensure the trade is not selling an amount higher than the user input
-  const invalidQuoteSellAmount = bn(inputSellAmountCryptoBaseUnit).gte(
-    firstHop.sellAmountIncludingProtocolFeesCryptoBaseUnit,
-  )
+  // Ensure the trade is not selling an amount higher than the user input, within a very safe threshold.
+  // Threshold is required because cowswap sometimes quotes a sell amount a teeny-tiny bit more than you input.
+  const invalidQuoteSellAmount = bn(inputSellAmountCryptoBaseUnit)
+    .times('1.0000000000001')
+    .lt(firstHop.sellAmountIncludingProtocolFeesCryptoBaseUnit)
 
   return {
     errors: [


### PR DESCRIPTION
## Description

Fixes issue where quotes with a sell amount LOWER than user input are marked as invalid (namely cowswap quotes). We need to allow this case, and only mark quotes selling an amount HIGHER than the user inputted value as invalid.

## Pull Request Type

- [x] :bug: Bug fix (Non-breaking Change: Fixes an issue)
- [ ] :hammer_and_wrench: Chore (Non-breaking Change: Doc updates, pkg upgrades, typos, etc..)
- [ ] :nail_care: New Feature (Breaking/Non-breaking Change)

## Issue (if applicable)

NA

## Risk
> High Risk PRs Require 2 approvals

Low risk of broken trade qutoes.

> What protocols, transaction types or contract interactions might be affected by this PR?

## Testing

Check quotes are working generally
Check CowSwap quotes are working (e.g FOX -> ETH $30)

### Engineering

<!-----------------------------------------------------------------------------
Include sufficient information here for an engineer to test your PR. This may include how to test locally, in a built environment, changes to infrastructure etc.
------------------------------------------------------------------------------>

### Operations

<!-----------------------------------------------------------------------------
If your changes have a user-facing impact, describe how a non-technical QA team can functionally test your changes in a preview environment.

If they are not user-facing please describe how to test for any regressions that may occur.
------------------------------------------------------------------------------>

## Screenshots (if applicable)

Before fix
![image](https://github.com/shapeshift/web/assets/125113430/98df2695-6010-4f09-aa56-fa2c9765041a)

After fix
![image](https://github.com/shapeshift/web/assets/125113430/0a52a788-8701-4b74-862c-3a01524e39a9)
