### PR TITLE
perf: address rendering performance issues on trade input page

### DIFF
--- a/src/components/AssetSelection/components/AssetChainDropdown/AssetChainDropdown.tsx
+++ b/src/components/AssetSelection/components/AssetChainDropdown/AssetChainDropdown.tsx
@@ -1,4 +1,4 @@
-import type { ButtonProps, MenuProps } from '@chakra-ui/react'
+import type { ButtonProps } from '@chakra-ui/react'
 import {
   Button,
   Menu,
@@ -9,17 +9,13 @@ import {
   Tooltip,
 } from '@chakra-ui/react'
 import type { AssetId } from '@shapeshiftoss/caip'
-import { useCallback, useEffect, useMemo } from 'react'
+import { useCallback, useMemo } from 'react'
 import { useTranslate } from 'react-polyglot'
 import { useWallet } from 'hooks/useWallet/useWallet'
 import { isAssetSupportedByWallet } from 'state/slices/portfolioSlice/utils'
 import {
-  selectAssetById,
-  selectAssets,
   selectChainDisplayNameByAssetId,
-  selectRelatedAssetIdsInclusive,
   selectRelatedAssetIdsInclusiveSorted,
-  selectRelatedAssetIndex,
 } from 'state/slices/selectors'
 import { useAppSelector } from 'state/store'
 
@@ -53,46 +49,6 @@ export const AssetChainDropdown: React.FC<AssetChainDropdownProps> = ({
   const relatedAssetIds = useAppSelector(state =>
     selectRelatedAssetIdsInclusiveSorted(state, assetId ?? ''),
   )
-
-  const relatedAssetIdsInclusive = useAppSelector(state =>
-    selectRelatedAssetIdsInclusive(state, assetId ?? ''),
-  )
-
-  const relatedAssetIndex = useAppSelector(selectRelatedAssetIndex)
-
-  useEffect(() => {
-    console.log('assetId changed')
-  }, [assetId])
-  useEffect(() => {
-    console.log('assetIds changed')
-  }, [assetIds])
-  useEffect(() => {
-    console.log('onChangeAsset changed')
-  }, [onChangeAsset])
-  useEffect(() => {
-    console.log('buttonProps changed')
-  }, [buttonProps])
-  useEffect(() => {
-    console.log('isLoading changed')
-  }, [isLoading])
-  useEffect(() => {
-    console.log('isError changed')
-  }, [isError])
-  useEffect(() => {
-    console.log('relatedAssetIds changed')
-  }, [relatedAssetIds])
-  useEffect(() => {
-    console.log('wallet changed')
-  }, [wallet])
-  useEffect(() => {
-    console.log('chainDisplayName changed')
-  }, [chainDisplayName])
-  useEffect(() => {
-    console.log('relatedAssetIdsInclusive changed')
-  }, [relatedAssetIdsInclusive])
-  useEffect(() => {
-    console.log('relatedAssetIndex changed')
-  }, [relatedAssetIndex])
 
   const filteredRelatedAssetIds = useMemo(() => {
     if (!assetIds?.length) return relatedAssetIds

--- a/src/components/AssetSelection/components/AssetChainDropdown/AssetChainDropdown.tsx
+++ b/src/components/AssetSelection/components/AssetChainDropdown/AssetChainDropdown.tsx
@@ -9,13 +9,17 @@ import {
   Tooltip,
 } from '@chakra-ui/react'
 import type { AssetId } from '@shapeshiftoss/caip'
-import { useCallback, useMemo } from 'react'
+import { useCallback, useEffect, useMemo } from 'react'
 import { useTranslate } from 'react-polyglot'
 import { useWallet } from 'hooks/useWallet/useWallet'
 import { isAssetSupportedByWallet } from 'state/slices/portfolioSlice/utils'
 import {
+  selectAssetById,
+  selectAssets,
   selectChainDisplayNameByAssetId,
+  selectRelatedAssetIdsInclusive,
   selectRelatedAssetIdsInclusiveSorted,
+  selectRelatedAssetIndex,
 } from 'state/slices/selectors'
 import { useAppSelector } from 'state/store'
 
@@ -29,7 +33,7 @@ type AssetChainDropdownProps = {
   buttonProps?: ButtonProps
   isLoading?: boolean
   isError?: boolean
-} & Omit<MenuProps, 'children'>
+}
 
 export const AssetChainDropdown: React.FC<AssetChainDropdownProps> = ({
   assetId,
@@ -38,7 +42,6 @@ export const AssetChainDropdown: React.FC<AssetChainDropdownProps> = ({
   buttonProps,
   isLoading,
   isError,
-  ...menuProps
 }) => {
   const {
     state: { wallet },
@@ -50,6 +53,46 @@ export const AssetChainDropdown: React.FC<AssetChainDropdownProps> = ({
   const relatedAssetIds = useAppSelector(state =>
     selectRelatedAssetIdsInclusiveSorted(state, assetId ?? ''),
   )
+
+  const relatedAssetIdsInclusive = useAppSelector(state =>
+    selectRelatedAssetIdsInclusive(state, assetId ?? ''),
+  )
+
+  const relatedAssetIndex = useAppSelector(selectRelatedAssetIndex)
+
+  useEffect(() => {
+    console.log('assetId changed')
+  }, [assetId])
+  useEffect(() => {
+    console.log('assetIds changed')
+  }, [assetIds])
+  useEffect(() => {
+    console.log('onChangeAsset changed')
+  }, [onChangeAsset])
+  useEffect(() => {
+    console.log('buttonProps changed')
+  }, [buttonProps])
+  useEffect(() => {
+    console.log('isLoading changed')
+  }, [isLoading])
+  useEffect(() => {
+    console.log('isError changed')
+  }, [isError])
+  useEffect(() => {
+    console.log('relatedAssetIds changed')
+  }, [relatedAssetIds])
+  useEffect(() => {
+    console.log('wallet changed')
+  }, [wallet])
+  useEffect(() => {
+    console.log('chainDisplayName changed')
+  }, [chainDisplayName])
+  useEffect(() => {
+    console.log('relatedAssetIdsInclusive changed')
+  }, [relatedAssetIdsInclusive])
+  useEffect(() => {
+    console.log('relatedAssetIndex changed')
+  }, [relatedAssetIndex])
 
   const filteredRelatedAssetIds = useMemo(() => {
     if (!assetIds?.length) return relatedAssetIds
@@ -97,7 +140,7 @@ export const AssetChainDropdown: React.FC<AssetChainDropdownProps> = ({
   if (!assetId || isLoading) return <AssetRowLoading {...buttonProps} />
 
   return (
-    <Menu {...menuProps}>
+    <Menu>
       <Tooltip isDisabled={isTooltipDisabled} label={buttonTooltipText}>
         <MenuButton as={Button} isDisabled={isDisabled} {...buttonProps}>
           <AssetChainRow assetId={assetId} hideBalances />

--- a/src/components/MultiHopTrade/components/SlippagePopover.tsx
+++ b/src/components/MultiHopTrade/components/SlippagePopover.tsx
@@ -16,7 +16,7 @@ import {
 } from '@chakra-ui/react'
 import { bnOrZero } from '@shapeshiftoss/chain-adapters'
 import type { FC } from 'react'
-import { useCallback, useEffect, useMemo, useRef, useState } from 'react'
+import { memo, useCallback, useEffect, useMemo, useRef, useState } from 'react'
 import { FaGear } from 'react-icons/fa6'
 import { useTranslate } from 'react-polyglot'
 import { HelperTooltip } from 'components/HelperTooltip/HelperTooltip'
@@ -39,7 +39,7 @@ const focusStyle = { '&[aria-invalid=true]': { borderColor: 'red.500' } }
 
 const faGear = <FaGear />
 
-export const SlippagePopover: FC = () => {
+export const SlippagePopover: FC = memo(() => {
   const defaultSlippagePercentage = useAppSelector(selectDefaultSlippagePercentage)
   const userSlippagePercentage = useAppSelector(selectUserSlippagePercentage)
 
@@ -189,4 +189,4 @@ export const SlippagePopover: FC = () => {
       </PopoverContent>
     </Popover>
   )
-}
+})

--- a/src/components/MultiHopTrade/components/TradeAssetInput.tsx
+++ b/src/components/MultiHopTrade/components/TradeAssetInput.tsx
@@ -30,7 +30,7 @@ const AssetInputAwaitingAsset = () => {
 
 type AssetInputLoadedProps = Omit<TradeAmountInputProps, 'onMaxClick'> & { assetId: AssetId }
 
-const AssetInputWithAsset: React.FC<AssetInputLoadedProps> = props => {
+const AssetInputWithAsset: React.FC<AssetInputLoadedProps> = memo(props => {
   const { assetId, accountId } = props
   const marketData = useAppSelector(state => selectMarketDataById(state, assetId))
 
@@ -63,7 +63,7 @@ const AssetInputWithAsset: React.FC<AssetInputLoadedProps> = props => {
       {...props}
     />
   )
-}
+})
 
 export type TradeAssetInputProps = {
   assetId?: AssetId

--- a/src/components/MultiHopTrade/components/TradeInput/components/TradeQuotes/components/CountdownSpinner.tsx
+++ b/src/components/MultiHopTrade/components/TradeInput/components/TradeQuotes/components/CountdownSpinner.tsx
@@ -1,9 +1,9 @@
-import { useEffect } from 'react'
+import { memo, useEffect } from 'react'
 import { CircularProgress } from 'components/CircularProgress/CircularProgress'
 import { useCountdown } from 'components/MultiHopTrade/components/MultiHopTradeConfirm/hooks/useCountdown'
 import { GET_TRADE_QUOTE_POLLING_INTERVAL } from 'state/apis/swapper/swapperApi'
 
-export const CountdownSpinner = ({ isLoading }: { isLoading: boolean }) => {
+export const CountdownSpinner = memo(({ isLoading }: { isLoading: boolean }) => {
   const { timeRemainingMs, reset, start } = useCountdown({
     initialTimeMs: GET_TRADE_QUOTE_POLLING_INTERVAL,
     autoStart: false,
@@ -37,4 +37,4 @@ export const CountdownSpinner = ({ isLoading }: { isLoading: boolean }) => {
       isIndeterminate={isLoading}
     />
   )
-}
+})

--- a/src/state/slices/assetsSlice/selectors.ts
+++ b/src/state/slices/assetsSlice/selectors.ts
@@ -20,7 +20,7 @@ export const selectAssetById = createCachedSelector(
 )((_state: ReduxState, assetId: AssetId | undefined): AssetId => assetId ?? 'undefined')
 
 // selects all related assetIds, inclusive of the asset being queried
-export const selectRelatedAssetIdsInclusive = createDeepEqualOutputSelector(
+export const selectRelatedAssetIdsInclusive = createCachedSelector(
   (state: ReduxState) => state.assets.relatedAssetIndex,
   selectAssetById,
   (relatedAssetIndex, asset): AssetId[] => {
@@ -29,16 +29,16 @@ export const selectRelatedAssetIdsInclusive = createDeepEqualOutputSelector(
     if (!relatedAssetKey) return [asset.assetId]
     return [relatedAssetKey].concat(relatedAssetIndex[relatedAssetKey] ?? [])
   },
-)
+)((_state: ReduxState, assetId: AssetId | undefined): AssetId => assetId ?? 'undefined')
 
 // selects all related assetIds, exclusive of the asset being queried
-export const selectRelatedAssetIds = createDeepEqualOutputSelector(
+export const selectRelatedAssetIds = createCachedSelector(
   selectRelatedAssetIdsInclusive,
   selectAssetById,
   (relatedAssetIdsInclusive, asset): AssetId[] => {
     return relatedAssetIdsInclusive.filter(assetId => assetId !== asset?.assetId) ?? []
   },
-)
+)((_state: ReduxState, assetId: AssetId | undefined): AssetId => assetId ?? 'undefined')
 
 export const selectAssetByFilter = createCachedSelector(
   (state: ReduxState) => state.assets.byId,

--- a/src/state/slices/portfolioSlice/selectors.ts
+++ b/src/state/slices/portfolioSlice/selectors.ts
@@ -974,7 +974,7 @@ export const selectEquityTotalBalance = createDeepEqualOutputSelector(
   },
 )
 
-export const selectRelatedAssetIdsInclusiveSorted = createDeepEqualOutputSelector(
+export const selectRelatedAssetIdsInclusiveSorted = createCachedSelector(
   selectRelatedAssetIdsInclusive,
   selectPortfolioUserCurrencyBalances,
   (relatedAssetIds, portfolioUserCurrencyBalances) => {
@@ -992,4 +992,4 @@ export const selectRelatedAssetIdsInclusiveSorted = createDeepEqualOutputSelecto
       ['desc', 'asc'],
     ).map(({ assetId }) => assetId)
   },
-)
+)((_state: ReduxState, assetId: AssetId | undefined): AssetId => assetId ?? 'undefined')


### PR DESCRIPTION
## Description

Reduces the amount of repeat work done in the trade input, namely within the related asset selectors and the rendering around the trade input components in general.

Two insights when debugging performance issue on trade input:
1. selectors using a parameter e.g `const xyz = useAppSelector(state => myselector(state, myParam))` will recompute on every access even if the selector was implemented with `createDeepEqualOutputSelector`. Instead, `createCachedSelector` is required.
2. `{ propA, propB, ...rest } = props` pattern for props causes re-render on every parent component render. We should avoid this and instead pass the rest as field in the props. Example is instead of `type MyProps = { propA: number } & BoxProps`, we should do `type MyProps = { propA: number; boxProps: BoxProps }`

## Pull Request Type

- [ ] :bug: Bug fix (Non-breaking Change: Fixes an issue)
- [x] :hammer_and_wrench: Chore (Non-breaking Change: Doc updates, pkg upgrades, typos, etc..)
- [ ] :nail_care: New Feature (Breaking/Non-breaking Change)

## Issue (if applicable)

NA

## Risk
> High Risk PRs Require 2 approvals

Low risk of broken related asset selectors.

> What protocols, transaction types or contract interactions might be affected by this PR?

## Testing

Check the correctness of related assets in the asset page, and in the chain drop-down in the trade input page. Pay particular attention to asset balances in the chain drop-down.

### Engineering

Note the use of `createCachedSelector`. The previous implementation used `createDeepEqualOutputSelector` which recomputes every access due to the presence of the `assetId` parameter.

### Operations

<!-----------------------------------------------------------------------------
If your changes have a user-facing impact, describe how a non-technical QA team can functionally test your changes in a preview environment.

If they are not user-facing please describe how to test for any regressions that may occur.
------------------------------------------------------------------------------>

## Screenshots (if applicable)
