### PR TITLE
chore: use quote-specific terminology in types

### DIFF
--- a/src/lib/utils/thorchain/lp/types.ts
+++ b/src/lib/utils/thorchain/lp/types.ts
@@ -188,10 +188,10 @@ export type MidgardTvlHistoryResponse = {
 
 export type LpConfirmedDepositQuote = {
   totalAmountFiat: string
-  assetCryptoLiquidityAmount: string
-  assetFiatLiquidityAmount: string
-  runeCryptoLiquidityAmount: string
-  runeFiatLiquidityAmount: string
+  assetCryptoDepositAmount: string
+  assetFiatDepositAmount: string
+  runeCryptoDepositAmount: string
+  runeFiatDepositAmount: string
   shareOfPoolDecimalPercent: string
   slippageRune: string
   opportunityId: string
@@ -208,13 +208,14 @@ export type LpConfirmedDepositQuote = {
 
 export type LpConfirmedWithdrawalQuote = {
   totalAmountFiat: string
-  assetCryptoLiquidityAmount: string
-  assetFiatLiquidityAmount: string
-  runeCryptoLiquidityAmount: string
-  runeFiatLiquidityAmount: string
+  assetCryptoWithdrawAmount: string
+  assetFiatWithdrawAmount: string
+  runeCryptoWithdrawAmount: string
+  runeFiatWithdrawAmount: string
   shareOfPoolDecimalPercent: string
   slippageRune: string
   opportunityId: string
+  feeBps: string
   assetAddress?: string
   quoteInboundAddress: string
   // For informative purposes only at confirm step - to be recalculated before signing

--- a/src/pages/ThorChainLP/components/AddLiquitity/AddLiquidityInput.tsx
+++ b/src/pages/ThorChainLP/components/AddLiquitity/AddLiquidityInput.tsx
@@ -881,10 +881,10 @@ export const AddLiquidityInput: React.FC<AddLiquidityInputProps> = ({
     })
 
     setConfirmedQuote({
-      assetCryptoLiquidityAmount: actualAssetCryptoLiquidityAmount,
-      assetFiatLiquidityAmount: actualAssetFiatLiquidityAmount,
-      runeCryptoLiquidityAmount: actualRuneCryptoLiquidityAmount,
-      runeFiatLiquidityAmount: actualRuneFiatLiquidityAmount,
+      assetCryptoDepositAmount: actualAssetCryptoLiquidityAmount,
+      assetFiatDepositAmount: actualAssetFiatLiquidityAmount,
+      runeCryptoDepositAmount: actualRuneCryptoLiquidityAmount,
+      runeFiatDepositAmount: actualRuneFiatLiquidityAmount,
       shareOfPoolDecimalPercent,
       slippageRune,
       opportunityId: activeOpportunityId,

--- a/src/pages/ThorChainLP/components/RemoveLiquidity/RemoveLiquidityInput.tsx
+++ b/src/pages/ThorChainLP/components/RemoveLiquidity/RemoveLiquidityInput.tsx
@@ -512,10 +512,10 @@ export const RemoveLiquidityInput: React.FC<RemoveLiquidityInputProps> = ({
       .toFixed()
 
     setConfirmedQuote({
-      assetCryptoLiquidityAmount: actualAssetCryptoLiquidityAmount,
-      assetFiatLiquidityAmount: actualAssetFiatLiquidityAmount,
-      runeCryptoLiquidityAmount: actualRuneCryptoLiquidityAmount,
-      runeFiatLiquidityAmount: actualRuneFiatLiquidityAmount,
+      assetCryptoWithdrawAmount: actualAssetCryptoLiquidityAmount,
+      assetFiatWithdrawAmount: actualAssetFiatLiquidityAmount,
+      runeCryptoWithdrawAmount: actualRuneCryptoLiquidityAmount,
+      runeFiatWithdrawAmount: actualRuneFiatLiquidityAmount,
       shareOfPoolDecimalPercent,
       slippageRune,
       opportunityId,
@@ -524,6 +524,7 @@ export const RemoveLiquidityInput: React.FC<RemoveLiquidityInputProps> = ({
       runeGasFeeFiat: runeGasFeeFiat.toFixed(2),
       poolAssetGasFeeFiat: poolAssetGasFeeFiat.toFixed(2),
       totalGasFeeFiat,
+      feeBps: '0',
     })
   }, [
     actualAssetCryptoLiquidityAmount,

--- a/src/pages/ThorChainLP/components/ReusableLpConfirm.tsx
+++ b/src/pages/ThorChainLP/components/ReusableLpConfirm.tsx
@@ -136,14 +136,38 @@ export const ReusableLpConfirm: React.FC<ReusableLpConfirmProps> = ({
     return (
       <Stack direction='row' divider={divider} position='relative'>
         {assets.map(_asset => {
-          const amountCryptoPrecision =
-            _asset.assetId === thorchainAssetId
-              ? confirmedQuote.runeCryptoLiquidityAmount
-              : confirmedQuote.assetCryptoLiquidityAmount
-          const amountFiatUserCurrency =
-            _asset.assetId === thorchainAssetId
-              ? confirmedQuote.runeFiatLiquidityAmount
-              : confirmedQuote.assetFiatLiquidityAmount
+          const [amountCryptoPrecision, amountFiatUserCurrency] = (() => {
+            let cryptoAmount
+            let amountFiatUserCurrency
+
+            if ('runeCryptoDepositAmount' in confirmedQuote) {
+              // confirmedQuote is LpConfirmedDepositQuote
+              let depositQuote = confirmedQuote as LpConfirmedDepositQuote
+              cryptoAmount =
+                _asset.assetId === thorchainAssetId
+                  ? depositQuote.runeCryptoDepositAmount
+                  : depositQuote.assetCryptoDepositAmount
+              amountFiatUserCurrency =
+                _asset.assetId === thorchainAssetId
+                  ? depositQuote.runeFiatDepositAmount
+                  : depositQuote.assetFiatDepositAmount
+            } else if ('runeCryptoWithdrawAmount' in confirmedQuote) {
+              // confirmedQuote is LpConfirmedWithdrawalQuote
+              let withdrawalQuote = confirmedQuote as LpConfirmedWithdrawalQuote
+              cryptoAmount =
+                _asset.assetId === thorchainAssetId
+                  ? withdrawalQuote.runeCryptoWithdrawAmount
+                  : withdrawalQuote.assetCryptoWithdrawAmount
+              amountFiatUserCurrency =
+                _asset.assetId === thorchainAssetId
+                  ? withdrawalQuote.runeFiatWithdrawAmount
+                  : withdrawalQuote.assetFiatWithdrawAmount
+            }
+
+            return [cryptoAmount, amountFiatUserCurrency]
+          })()
+
+          if (!amountCryptoPrecision || !amountFiatUserCurrency) return null
 
           return (
             <Card
@@ -172,16 +196,7 @@ export const ReusableLpConfirm: React.FC<ReusableLpConfirmProps> = ({
         })}
       </Stack>
     )
-  }, [
-    asset,
-    baseAsset,
-    confirmedQuote.assetCryptoLiquidityAmount,
-    confirmedQuote.assetFiatLiquidityAmount,
-    confirmedQuote.runeCryptoLiquidityAmount,
-    confirmedQuote.runeFiatLiquidityAmount,
-    divider,
-    pool,
-  ])
+  }, [asset, baseAsset, confirmedQuote, divider, pool])
 
   const { isTradingActive, isLoading: isTradingActiveLoading } = useIsTradingActive({
     assetId: pool?.assetId,

--- a/src/pages/ThorChainLP/components/ReusableLpStatus/ReusableLpStatus.tsx
+++ b/src/pages/ThorChainLP/components/ReusableLpStatus/ReusableLpStatus.tsx
@@ -117,8 +117,8 @@ export const ReusableLpStatus: React.FC<ReusableLpStatusProps> = ({
     const supplyAssets = assets.map(_asset => {
       const amountCryptoPrecision =
         _asset.assetId === thorchainAssetId
-          ? confirmedQuote.runeCryptoLiquidityAmount
-          : confirmedQuote.assetCryptoLiquidityAmount
+          ? confirmedQuote.runeCryptoDepositAmount
+          : confirmedQuote.assetCryptoDepositAmount
       return (
         <Amount.Crypto
           key={`amount-${_asset.assetId}`}
@@ -159,8 +159,8 @@ export const ReusableLpStatus: React.FC<ReusableLpStatusProps> = ({
     activeStepIndex,
     translate,
     hStackDivider,
-    confirmedQuote.runeCryptoLiquidityAmount,
-    confirmedQuote.assetCryptoLiquidityAmount,
+    confirmedQuote.runeCryptoDepositAmount,
+    confirmedQuote.assetCryptoDepositAmount,
   ])
 
   const assetCards = useMemo(() => {
@@ -169,8 +169,8 @@ export const ReusableLpStatus: React.FC<ReusableLpStatusProps> = ({
         {assets.map((_asset, index) => {
           const amountCryptoPrecision =
             _asset.assetId === thorchainAssetId
-              ? confirmedQuote.runeCryptoLiquidityAmount
-              : confirmedQuote.assetCryptoLiquidityAmount
+              ? confirmedQuote.runeCryptoDepositAmount
+              : confirmedQuote.assetCryptoDepositAmount
           return (
             <TransactionRow
               key={_asset.assetId}


### PR DESCRIPTION
## Description

Update the LP confirmed quote types so we can discriminate on the keys.

## Pull Request Type

- [x] :bug: Bug fix (Non-breaking Change: Fixes an issue)
- [ ] :hammer_and_wrench: Chore (Non-breaking Change: Doc updates, pkg upgrades, typos, etc..)
- [ ] :nail_care: New Feature (Breaking/Non-breaking Change)

## Issue (if applicable)

Actions feedback given here: https://github.com/shapeshift/web/pull/6266#discussion_r1496769959

## Risk
Small - more of a refactor.

> What protocols, transaction types or contract interactions might be affected by this PR?

THORChain LP deposit and withdrawals quotes.

## Testing

We should still get quotes for LP deposits and withdrawals (as before), and we shouldn't throw attempting to access a field that doesn't exist on a confirmed quote.

### Engineering

☝️

### Operations

☝️

## Screenshots (if applicable)

N/A