### PR TITLE
fix: display FOXy "past" undelegations

### DIFF
--- a/src/features/defi/providers/foxy/components/FoxyManager/Overview/FoxyOverview.tsx
+++ b/src/features/defi/providers/foxy/components/FoxyManager/Overview/FoxyOverview.tsx
@@ -124,10 +124,8 @@ export const FoxyOverview: React.FC<FoxyOverviewProps> = ({
 
   const hasPendingUndelegation = Boolean(
     undelegations &&
-      undelegations.some(
-        undelegation =>
-          dayjs().isAfter(dayjs(undelegation.completionTime).unix()) &&
-          bnOrZero(undelegation.undelegationAmountCryptoBaseUnit).gt(0),
+      undelegations.some(undelegation =>
+        bnOrZero(undelegation.undelegationAmountCryptoBaseUnit).gt(0),
       ),
   )
 


### PR DESCRIPTION
## Description

- We currently have a check in place for `dayjs().isAfter(dayjs(undelegation.completionTime).unix())`, detecting undelegations as inactive in case the completionTime is in the past
- `completionTime` is set here, as a result of `withdrawInfo.releaseTime`:

https://github.com/shapeshift/web/blob/168ae9b862d2875a428a53bca4787132581484e4/src/state/slices/opportunitiesSlice/resolvers/foxy/index.ts#L150

- `releaseTime` is set here in investor-foxy:

https://github.com/shapeshift/web/blob/168ae9b862d2875a428a53bca4787132581484e4/src/lib/investor/investor-foxy/api/api.ts#L965-L970

As can be seen above, if there are no blocks until claimable, the `releaseTime` is effectively now, but by the time the modal is opened, "now" will be in the past, making the FOXy overview modal open in an empty state because of the condition above.

This PR makes it so the FOXy opportunity can be clicked, and pending undelegations actionned. 

NOTE: This may be wrong, as there are currently some shenanigans WRT FOXy claims/withdraws, and we may *not* want to show this as part of the regular flow? To be confirmed by @0xean 


## Pull Request Type

- [x] :bug: Bug fix (Non-breaking Change: Fixes an issue)
- [ ] :hammer_and_wrench: Chore (Non-breaking Change: Doc updates, pkg upgrades, typos, etc..)
- [ ] :nail_care: New Feature (Breaking/Non-breaking Change)

## Issue (if applicable)

<!-----------------------------------------------------------------------------
If applicable, please link to the github issue and put `closes #XXXX` in your comment to auto-close the issue that your PR fixes.
------------------------------------------------------------------------------>

- relates to https://github.com/shapeshift/web/issues/6279

## Risk
> High Risk PRs Require 2 approvals

<!-----------------------------------------------------------------------------
Outline the scope of your changes and the risk associated with them. You must use your discretion as an engineer to determine the potential impact of your changes.

WARNING: If your PR introduces a new on-chain transaction or modifies an existing one, please add the "High-Risk" label to this PR and ask for 2 reviewers to approve it before merging.

E.g. an upgrade to `hdwallet` or core state management would be considered higher risk, and might require a full regression test. UI or isolated view changes, or something behind a feature flag may have near zero risk. Small bug fixes might require testing isolated to the specific fix.
------------------------------------------------------------------------------>

Low but this may be wrong, as there are currently some shenanigans WRT FOXy claims/withdraws, and we may *not* want to show this as part of the regular flow? To be confirmed by @0xean 

> What protocols, transaction types or contract interactions might be affected by this PR?

## Testing

<!-----------------------------------------------------------------------------
We treat every PR to be merged with the same scrutiny as if we were merging directly to production.

Your PR will not be merged if you do not complete the sections below for our engineering and operations teams to test.
------------------------------------------------------------------------------>

- Connect to willy's frame-injected wallet
- Confirm you can open the FOXy modal and see pending undelegation, with actionable claim/withdraw

### Engineering

<!-----------------------------------------------------------------------------
Include sufficient information here for an engineer to test your PR. This may include how to test locally, in a built environment, changes to infrastructure etc.
------------------------------------------------------------------------------>

- ☝🏽 

### Operations

<!-----------------------------------------------------------------------------
If your changes have a user-facing impact, describe how a non-technical QA team can functionally test your changes in a preview environment.

If they are not user-facing please describe how to test for any regressions that may occur.
------------------------------------------------------------------------------>

- ☝🏽 

## Screenshots (if applicable)

<img width="497" alt="image" src="https://github.com/shapeshift/web/assets/17035424/1baee4be-eb22-4de0-8f86-a0ea9be3806a">