### PR TITLE
chore: rename cryptoAmount to amountCryptoPrecision

### DIFF
--- a/src/components/Modals/QrCode/Form.tsx
+++ b/src/components/Modals/QrCode/Form.tsx
@@ -48,7 +48,7 @@ export const Form: React.FC<QrCodeFormProps> = ({ accountId }) => {
       vanityAddress: '',
       assetId: '',
       feeType: FeeDataKey.Average,
-      cryptoAmount: '',
+      amountCryptoPrecision: '',
       fiatAmount: '',
       fiatSymbol: selectedCurrency,
     },
@@ -104,7 +104,7 @@ export const Form: React.FC<QrCodeFormProps> = ({ accountId }) => {
           methods.setValue(SendFormFields.AssetId, maybeUrlResult.assetId ?? '')
           if (maybeUrlResult.amountCryptoPrecision) {
             const marketData = selectMarketDataById(store.getState(), maybeUrlResult.assetId ?? '')
-            methods.setValue(SendFormFields.CryptoAmount, maybeUrlResult.amountCryptoPrecision)
+            methods.setValue(SendFormFields.AmountCryptoPrecision, maybeUrlResult.amountCryptoPrecision)
             methods.setValue(
               SendFormFields.FiatAmount,
               bnOrZero(maybeUrlResult.amountCryptoPrecision).times(marketData.price).toString(),

--- a/src/components/Modals/Send/Form.tsx
+++ b/src/components/Modals/Send/Form.tsx
@@ -24,7 +24,7 @@ export type SendInput<T extends ChainId = ChainId> = {
   [SendFormFields.From]: string
   [SendFormFields.AmountFieldError]: string | [string, { asset: string }]
   [SendFormFields.AssetId]: AssetId
-  [SendFormFields.CryptoAmount]: string
+  [SendFormFields.AmountCryptoPrecision]: string
   [SendFormFields.EstimatedFees]: FeeDataEstimate<T>
   [SendFormFields.FeeType]: FeeDataKey
   [SendFormFields.FiatAmount]: string
@@ -59,7 +59,7 @@ export const Form: React.FC<SendFormProps> = ({ initialAssetId, input = '', acco
       vanityAddress: '',
       assetId: initialAssetId,
       feeType: FeeDataKey.Average,
-      cryptoAmount: '',
+      amountCryptoPrecision: '',
       fiatAmount: '',
       fiatSymbol: selectedCurrency,
     },
@@ -69,7 +69,7 @@ export const Form: React.FC<SendFormProps> = ({ initialAssetId, input = '', acco
     (assetId: AssetId) => {
       methods.setValue(SendFormFields.AssetId, assetId)
       methods.setValue(SendFormFields.AccountId, '')
-      methods.setValue(SendFormFields.CryptoAmount, '')
+      methods.setValue(SendFormFields.AmountCryptoPrecision, '')
       methods.setValue(SendFormFields.FiatAmount, '')
       methods.setValue(SendFormFields.FiatSymbol, selectedCurrency)
 
@@ -104,7 +104,10 @@ export const Form: React.FC<SendFormProps> = ({ initialAssetId, input = '', acco
 
         if (maybeUrlResult.assetId && maybeUrlResult.amountCryptoPrecision) {
           const marketData = selectMarketDataById(store.getState(), maybeUrlResult.assetId ?? '')
-          methods.setValue(SendFormFields.CryptoAmount, maybeUrlResult.amountCryptoPrecision)
+          methods.setValue(
+            SendFormFields.AmountCryptoPrecision,
+            maybeUrlResult.amountCryptoPrecision,
+          )
           methods.setValue(
             SendFormFields.FiatAmount,
             bnOrZero(maybeUrlResult.amountCryptoPrecision).times(marketData.price).toString(),

--- a/src/components/Modals/Send/SendCommon.tsx
+++ b/src/components/Modals/Send/SendCommon.tsx
@@ -16,7 +16,7 @@ export enum SendFormFields {
   AssetId = 'assetId',
   FeeType = 'feeType',
   EstimatedFees = 'estimatedFees',
-  CryptoAmount = 'cryptoAmount',
+  AmountCryptoPrecision = 'amountCryptoPrecision',
   CryptoSymbol = 'cryptoSymbol',
   FiatAmount = 'fiatAmount',
   FiatSymbol = 'fiatSymbol',

--- a/src/components/Modals/Send/hooks/useFormSend/useFormSend.test.tsx
+++ b/src/components/Modals/Send/hooks/useFormSend/useFormSend.test.tsx
@@ -127,7 +127,7 @@ const formData: SendInput<KnownChainIds.EthereumMainnet> = {
       },
     },
   },
-  [SendFormFields.CryptoAmount]: '1',
+  [SendFormFields.AmountCryptoPrecision]: '1',
   [SendFormFields.FiatAmount]: '3500',
   [SendFormFields.FiatSymbol]: 'USD',
   [SendFormFields.SendMax]: false,

--- a/src/components/Modals/Send/hooks/useFormSend/useFormSend.tsx
+++ b/src/components/Modals/Send/hooks/useFormSend/useFormSend.tsx
@@ -35,7 +35,7 @@ export const useFormSend = () => {
               <Text>
                 <Text>
                   {translate('modals.send.youHaveSent', {
-                    amount: sendInput.cryptoAmount,
+                    amount: sendInput.amountCryptoPrecision,
                     symbol: asset.symbol,
                   })}
                 </Text>

--- a/src/components/Modals/Send/hooks/useSendDetails/useSendDetails.tsx
+++ b/src/components/Modals/Send/hooks/useSendDetails/useSendDetails.tsx
@@ -33,7 +33,7 @@ import { useAppSelector } from 'state/store'
 import type { SendInput } from '../../Form'
 import { SendFormFields, SendRoutes } from '../../SendCommon'
 
-type AmountFieldName = SendFormFields.FiatAmount | SendFormFields.CryptoAmount
+type AmountFieldName = SendFormFields.FiatAmount | SendFormFields.AmountCryptoPrecision
 
 type UseSendDetailsReturnType = {
   balancesLoading: boolean
@@ -50,7 +50,7 @@ type UseSendDetailsReturnType = {
 // TODO(0xdef1cafe): this whole thing needs to be refactored to be account focused, not asset focused
 // i.e. you don't send from an asset, you send from an account containing an asset
 export const useSendDetails = (): UseSendDetailsReturnType => {
-  const [fieldName, setFieldName] = useState<AmountFieldName>(SendFormFields.CryptoAmount)
+  const [fieldName, setFieldName] = useState<AmountFieldName>(SendFormFields.AmountCryptoPrecision)
   const [loading, setLoading] = useState<boolean>(false)
   const history = useHistory()
   const { getValues, setValue } = useFormContext<SendInput>()
@@ -113,15 +113,15 @@ export const useSendDetails = (): UseSendDetailsReturnType => {
   const estimateFormFees = useCallback((): Promise<FeeDataEstimate<ChainId>> => {
     if (!asset) throw new Error('No asset found')
 
-    const { assetId, cryptoAmount, to, sendMax } = getValues()
+    const { assetId, amountCryptoPrecision: cryptoAmount, to, sendMax } = getValues()
     if (!wallet) throw new Error('No wallet connected')
-    return estimateFees({ cryptoAmount, assetId, to, sendMax, accountId, contractAddress })
+    return estimateFees({ amountCryptoPrecision: cryptoAmount, assetId, to, sendMax, accountId, contractAddress })
   }, [accountId, asset, contractAddress, getValues, wallet])
 
   const debouncedSetEstimatedFormFees = useMemo(() => {
     return debounce(
       async () => {
-        const { cryptoAmount } = getValues()
+        const { amountCryptoPrecision: cryptoAmount } = getValues()
         if (cryptoAmount === '') return
         if (!asset || !accountId) return
         const estimatedFees = await estimateFormFees()
@@ -196,7 +196,7 @@ export const useSendDetails = (): UseSendDetailsReturnType => {
     setValue(SendFormFields.AmountFieldError, '')
 
     if (feeAsset.assetId !== assetId) {
-      setValue(SendFormFields.CryptoAmount, cryptoHumanBalance.toPrecision())
+      setValue(SendFormFields.AmountCryptoPrecision, cryptoHumanBalance.toPrecision())
       setValue(SendFormFields.FiatAmount, userCurrencyBalance.toFixed(2))
       setLoading(true)
 
@@ -286,7 +286,7 @@ export const useSendDetails = (): UseSendDetailsReturnType => {
           ])
         }
 
-        setValue(SendFormFields.CryptoAmount, maxCrypto.toPrecision())
+        setValue(SendFormFields.AmountCryptoPrecision, maxCrypto.toPrecision())
         setValue(SendFormFields.FiatAmount, maxFiat.toFixed(2))
         setLoading(false)
       } catch (e) {
@@ -313,7 +313,7 @@ export const useSendDetails = (): UseSendDetailsReturnType => {
       const otherField =
         fieldName !== SendFormFields.FiatAmount
           ? SendFormFields.FiatAmount
-          : SendFormFields.CryptoAmount
+          : SendFormFields.AmountCryptoPrecision
 
       try {
         if (inputValue === '') {
@@ -361,7 +361,7 @@ export const useSendDetails = (): UseSendDetailsReturnType => {
   const toggleCurrency = () => {
     setFieldName(
       fieldName === SendFormFields.FiatAmount
-        ? SendFormFields.CryptoAmount
+        ? SendFormFields.AmountCryptoPrecision
         : SendFormFields.FiatAmount,
     )
   }

--- a/src/components/Modals/Send/utils.ts
+++ b/src/components/Modals/Send/utils.ts
@@ -28,7 +28,7 @@ import { store } from 'state/store'
 import type { SendInput } from './Form'
 
 export type EstimateFeesInput = {
-  cryptoAmount: string
+  amountCryptoPrecision: string
   assetId: AssetId
   // Optional hex-encoded calldata
   // for ERC-20s, use me in place of `data`
@@ -41,7 +41,7 @@ export type EstimateFeesInput = {
 }
 
 export const estimateFees = ({
-  cryptoAmount,
+  amountCryptoPrecision: cryptoAmount,
   assetId,
   from,
   memo,
@@ -118,7 +118,7 @@ export const handleSend = async ({
     throw new Error(`unsupported wallet: ${await wallet.getModel()}`)
   }
 
-  const value = bnOrZero(sendInput.cryptoAmount)
+  const value = bnOrZero(sendInput.amountCryptoPrecision)
     .times(bn(10).exponentiatedBy(asset.precision))
     .toFixed(0)
 

--- a/src/components/Modals/Send/views/Confirm.tsx
+++ b/src/components/Modals/Send/views/Confirm.tsx
@@ -58,7 +58,7 @@ export const Confirm = () => {
   } = useFormContext<SendInput>()
   const history = useHistory()
   const translate = useTranslate()
-  const { accountId, to, assetId, cryptoAmount, feeType, fiatAmount, memo, vanityAddress } =
+  const { accountId, to, assetId, amountCryptoPrecision: cryptoAmount, feeType, fiatAmount, memo, vanityAddress } =
     useWatch({
       control,
     }) as Partial<SendInput>

--- a/src/components/Modals/Send/views/Details.tsx
+++ b/src/components/Modals/Send/views/Details.tsx
@@ -64,7 +64,7 @@ export const Details = () => {
   const history = useHistory()
   const translate = useTranslate()
 
-  const { accountId, amountFieldError, assetId, cryptoAmount, fiatAmount, fiatSymbol, memo } =
+  const { accountId, amountFieldError, assetId, amountCryptoPrecision: cryptoAmount, fiatAmount, fiatSymbol, memo } =
     useWatch({
       control,
     }) as Partial<SendInput>
@@ -75,7 +75,7 @@ export const Details = () => {
     (accountId: AccountId) => {
       setValue(SendFormFields.AccountId, accountId)
       if (!previousAccountId) return
-      if (!cryptoAmount) setValue(SendFormFields.CryptoAmount, '')
+      if (!cryptoAmount) setValue(SendFormFields.AmountCryptoPrecision, '')
       if (!fiatAmount) setValue(SendFormFields.FiatAmount, '')
     },
     [cryptoAmount, fiatAmount, previousAccountId, setValue],
@@ -103,7 +103,7 @@ export const Details = () => {
     // Also turns out we don't handle re-validation in case of changing AccountIds
     // This effect takes care of both the initial/account change cases
     if ((previousAccountId ?? '') !== accountId) {
-      const inputAmount = fieldName === SendFormFields.CryptoAmount ? cryptoAmount : fiatAmount
+      const inputAmount = fieldName === SendFormFields.AmountCryptoPrecision ? cryptoAmount : fiatAmount
       handleInputChange(inputAmount ?? '0')
       trigger(fieldName)
     }
@@ -221,7 +221,7 @@ export const Details = () => {
           isLoaded={!balancesLoading}
           cryptoAmountAvailable={cryptoHumanBalance.toString()}
           fiatAmountAvailable={fiatBalance.toString()}
-          showCrypto={fieldName === SendFormFields.CryptoAmount}
+          showCrypto={fieldName === SendFormFields.AmountCryptoPrecision}
           onClick={handleAccountCardClick}
           mb={2}
         />
@@ -250,10 +250,10 @@ export const Details = () => {
               )}
             </FormHelperText>
           </Box>
-          {fieldName === SendFormFields.CryptoAmount && (
+          {fieldName === SendFormFields.AmountCryptoPrecision && (
             <TokenRow
               control={control}
-              fieldName={SendFormFields.CryptoAmount}
+              fieldName={SendFormFields.AmountCryptoPrecision}
               onInputChange={handleInputChange}
               inputLeftElement={cryptoTokenRowInputLeftElement}
               inputRightElement={tokenRowInputRightElement}

--- a/src/components/Sweep.tsx
+++ b/src/components/Sweep.tsx
@@ -47,7 +47,7 @@ export const Sweep = ({
     isLoading: isEstimatedFeesDataLoading,
     isSuccess: isEstimatedFeesDataSuccess,
   } = useGetEstimatedFeesQuery({
-    cryptoAmount: '0',
+    amountCryptoPrecision: '0',
     assetId,
     to: fromAddress ?? '',
     sendMax: true,
@@ -72,7 +72,7 @@ export const Sweep = ({
         input: fromAddress,
         assetId,
         from: '',
-        cryptoAmount: '0',
+        amountCryptoPrecision: '0',
         sendMax: true,
         estimatedFees: estimatedFeesData.estimatedFees,
         amountFieldError: '',

--- a/src/features/defi/providers/cosmos/components/CosmosManager/Deposit/components/Deposit.tsx
+++ b/src/features/defi/providers/cosmos/components/CosmosManager/Deposit/components/Deposit.tsx
@@ -92,7 +92,7 @@ export const Deposit: React.FC<DepositProps> = ({
     async (setValue: UseFormSetValue<DepositValues>) => {
       if (!accountId) return
       const estimatedFees = await estimateFees({
-        cryptoAmount: cryptoAmountAvailable.toString(),
+        amountCryptoPrecision: cryptoAmountAvailable.toString(),
         assetId,
         to: '',
         sendMax: true,

--- a/src/features/defi/providers/thorchain-savers/components/ThorchainSaversManager/Deposit/components/Confirm.tsx
+++ b/src/features/defi/providers/thorchain-savers/components/ThorchainSaversManager/Deposit/components/Confirm.tsx
@@ -253,7 +253,7 @@ export const Confirm: React.FC<ConfirmProps> = ({ accountId, onNext }) => {
 
       const memoUtf8 = quote.memo
       return {
-        cryptoAmount: state.deposit.cryptoAmount,
+        amountCryptoPrecision: state.deposit.cryptoAmount,
         assetId,
         from: maybeFromUTXOAccountAddress,
         to: quote.inbound_address,
@@ -470,7 +470,8 @@ export const Confirm: React.FC<ConfirmProps> = ({ accountId, onNext }) => {
       const memoUtf8 = quote.memo
 
       const sendInput: SendInput = {
-        cryptoAmount: maybeGasDeductedCryptoAmountCryptoPrecision || state.deposit.cryptoAmount,
+        amountCryptoPrecision:
+          maybeGasDeductedCryptoAmountCryptoPrecision || state.deposit.cryptoAmount,
         assetId,
         to: quote.inbound_address,
         from: maybeFromUTXOAccountAddress,

--- a/src/features/defi/providers/thorchain-savers/components/ThorchainSaversManager/Deposit/components/Deposit.tsx
+++ b/src/features/defi/providers/thorchain-savers/components/ThorchainSaversManager/Deposit/components/Deposit.tsx
@@ -314,7 +314,7 @@ export const Deposit: React.FC<DepositProps> = ({
             contractAddress: undefined,
             assetId,
             sendMax: false,
-            cryptoAmount: '0',
+            amountCryptoPrecision: '0',
             to: customTxInput.to,
             from: fromAccountId(accountId).account,
             memo: customTxInput.data,
@@ -380,7 +380,7 @@ export const Deposit: React.FC<DepositProps> = ({
     isLoading: isEstimatedFeesDataLoading,
     isSuccess: isEstimatedFeesDataSuccess,
   } = useGetEstimatedFeesQuery({
-    cryptoAmount: inputValues?.cryptoAmount ?? '0',
+    amountCryptoPrecision: inputValues?.cryptoAmount ?? '0',
     assetId,
     to: thorchainSaversDepositQuote?.inbound_address ?? '',
     sendMax: false,
@@ -729,7 +729,7 @@ export const Deposit: React.FC<DepositProps> = ({
       )
       const estimatedFeesQueryArgs = {
         estimateFeesInput: {
-          cryptoAmount: _percentageCryptoAmountPrecisionBeforeTxFees.toFixed(),
+          amountCryptoPrecision: _percentageCryptoAmountPrecisionBeforeTxFees.toFixed(),
           assetId,
           to: fromAddress ?? '',
           sendMax: false,
@@ -780,7 +780,7 @@ export const Deposit: React.FC<DepositProps> = ({
         asset,
         assetMarketData: marketData,
         estimateFeesInput: {
-          cryptoAmount: '0',
+          amountCryptoPrecision: '0',
           assetId,
           to: fromAddress ?? '',
           sendMax: true,

--- a/src/features/defi/providers/thorchain-savers/components/ThorchainSaversManager/Withdraw/components/Confirm.tsx
+++ b/src/features/defi/providers/thorchain-savers/components/ThorchainSaversManager/Withdraw/components/Confirm.tsx
@@ -339,7 +339,7 @@ export const Confirm: React.FC<ConfirmProps> = ({ accountId, onNext }) => {
 
       return {
         from: maybeFromUTXOAccountAddress,
-        cryptoAmount: fromThorBaseUnit(dust_amount).toFixed(asset.precision),
+        amountCryptoPrecision: fromThorBaseUnit(dust_amount).toFixed(asset.precision),
         assetId,
         to: quote.inbound_address,
         sendMax: false,
@@ -532,7 +532,7 @@ export const Confirm: React.FC<ConfirmProps> = ({ accountId, onNext }) => {
       }
 
       const sendInput: SendInput = {
-        cryptoAmount: fromThorBaseUnit(dust_amount).toFixed(asset.precision),
+        amountCryptoPrecision: fromThorBaseUnit(dust_amount).toFixed(asset.precision),
         assetId,
         to: quote.inbound_address,
         from: maybeFromUTXOAccountAddress,

--- a/src/features/defi/providers/thorchain-savers/components/ThorchainSaversManager/Withdraw/components/Withdraw.tsx
+++ b/src/features/defi/providers/thorchain-savers/components/ThorchainSaversManager/Withdraw/components/Withdraw.tsx
@@ -405,7 +405,7 @@ export const Withdraw: React.FC<WithdrawProps> = ({ accountId, fromAddress, onNe
     isLoading: isEstimatedFeesDataLoading,
     isSuccess: isEstimatedFeesDataSuccess,
   } = useGetEstimatedFeesQuery({
-    cryptoAmount: dustAmountCryptoBaseUnit,
+    amountCryptoPrecision: dustAmountCryptoBaseUnit,
     assetId,
     to: thorchainSaversWithdrawQuote?.inbound_address ?? '',
     sendMax: false,

--- a/src/lib/utils/thorchain/balance.ts
+++ b/src/lib/utils/thorchain/balance.ts
@@ -139,7 +139,7 @@ export const fetchHasEnoughBalanceForTxPlusFeesPlusSweep = async ({
   const amountCryptoBaseUnit = toBaseUnit(amountCryptoPrecision, asset.precision)
   const estimatedFeesQueryArgs = {
     estimateFeesInput: {
-      cryptoAmount: amountCryptoPrecision,
+      amountCryptoPrecision,
       assetId: asset.assetId,
       to: quote?.inbound_address ?? '',
       sendMax: false,
@@ -193,7 +193,7 @@ export const fetchHasEnoughBalanceForTxPlusFeesPlusSweep = async ({
     asset,
     assetMarketData,
     estimateFeesInput: {
-      cryptoAmount: '0',
+      amountCryptoPrecision: '0',
       assetId: asset.assetId,
       to: fromAddress ?? '',
       sendMax: true,

--- a/src/pages/Lending/Pool/components/Borrow/BorrowConfirm.tsx
+++ b/src/pages/Lending/Pool/components/Borrow/BorrowConfirm.tsx
@@ -292,7 +292,7 @@ export const BorrowConfirm = ({
     const maybeTxId = await (() => {
       // TODO(gomes): isTokenDeposit. This doesn't exist yet but may in the future.
       const sendInput: SendInput = {
-        cryptoAmount: depositAmount ?? '0',
+        amountCryptoPrecision: depositAmount ?? '0',
         assetId: collateralAssetId,
         to: confirmedQuote.quoteInboundAddress,
         from,

--- a/src/pages/Lending/Pool/components/Borrow/BorrowInput.tsx
+++ b/src/pages/Lending/Pool/components/Borrow/BorrowInput.tsx
@@ -263,7 +263,7 @@ export const BorrowInput = ({
     isLoading: isEstimatedSweepFeesDataLoading,
     isSuccess: isEstimatedSweepFeesDataSuccess,
   } = useGetEstimatedFeesQuery({
-    cryptoAmount: '0',
+    amountCryptoPrecision: '0',
     assetId: collateralAssetId,
     to: fromAddress ?? '',
     sendMax: true,

--- a/src/pages/Lending/Pool/components/Repay/RepayConfirm.tsx
+++ b/src/pages/Lending/Pool/components/Repay/RepayConfirm.tsx
@@ -285,7 +285,7 @@ export const RepayConfirm = ({
     const supportedEvmChainIds = getSupportedEvmChainIds()
 
     const estimatedFees = await estimateFees({
-      cryptoAmount: confirmedQuote.repaymentAmountCryptoPrecision,
+      amountCryptoPrecision: confirmedQuote.repaymentAmountCryptoPrecision,
       assetId: repaymentAsset.assetId,
       memo: supportedEvmChainIds.includes(
         fromAssetId(repaymentAsset.assetId).chainId as KnownChainIds,
@@ -333,7 +333,7 @@ export const RepayConfirm = ({
 
       // TODO(gomes): isTokenDeposit. This doesn't exist yet but may in the future.
       const sendInput: SendInput = {
-        cryptoAmount: confirmedQuote.repaymentAmountCryptoPrecision,
+        amountCryptoPrecision: confirmedQuote.repaymentAmountCryptoPrecision,
         assetId: repaymentAsset.assetId,
         from: '',
         to: confirmedQuote.quoteInboundAddress,

--- a/src/pages/ThorChainLP/components/ReusableLpStatus/TransactionRow.tsx
+++ b/src/pages/ThorChainLP/components/ReusableLpStatus/TransactionRow.tsx
@@ -282,7 +282,7 @@ export const TransactionRow: React.FC<TransactionRowProps> = ({
           ? `+:${thorchainNotationAssetId}:${otherAssetAddress ?? ''}:ss:${confirmedQuote.feeBps}`
           : `-:${thorchainNotationAssetId}:${confirmedQuote.withdrawalBps}`
         return {
-          cryptoAmount: isDeposit ? toBaseUnit(amountCryptoPrecision, asset.precision) : '0',
+          cryptoAmount: isDeposit ? amountCryptoPrecision : '0',
           assetId: asset.assetId,
           memo,
           to: THORCHAIN_POOL_MODULE_ADDRESS,
@@ -443,7 +443,7 @@ export const TransactionRow: React.FC<TransactionRowProps> = ({
               : `-:${thorchainNotationAssetId}:${confirmedQuote.withdrawalBps}`
 
             const estimatedFees = await estimateFees({
-              cryptoAmount: isDeposit ? toBaseUnit(amountCryptoPrecision, asset.precision) : '0',
+              cryptoAmount: isDeposit ? amountCryptoPrecision : '0',
               assetId: asset.assetId,
               memo,
               to: THORCHAIN_POOL_MODULE_ADDRESS,

--- a/src/pages/ThorChainLP/components/ReusableLpStatus/TransactionRow.tsx
+++ b/src/pages/ThorChainLP/components/ReusableLpStatus/TransactionRow.tsx
@@ -282,7 +282,7 @@ export const TransactionRow: React.FC<TransactionRowProps> = ({
           ? `+:${thorchainNotationAssetId}:${otherAssetAddress ?? ''}:ss:${confirmedQuote.feeBps}`
           : `-:${thorchainNotationAssetId}:${confirmedQuote.withdrawalBps}`
         return {
-          cryptoAmount: isDeposit ? amountCryptoPrecision : '0',
+          cryptoAmount: isDeposit ? toBaseUnit(amountCryptoPrecision, asset.precision) : '0',
           assetId: asset.assetId,
           memo,
           to: THORCHAIN_POOL_MODULE_ADDRESS,
@@ -443,7 +443,7 @@ export const TransactionRow: React.FC<TransactionRowProps> = ({
               : `-:${thorchainNotationAssetId}:${confirmedQuote.withdrawalBps}`
 
             const estimatedFees = await estimateFees({
-              cryptoAmount: isDeposit ? amountCryptoPrecision : '0',
+              cryptoAmount: isDeposit ? toBaseUnit(amountCryptoPrecision, asset.precision) : '0',
               assetId: asset.assetId,
               memo,
               to: THORCHAIN_POOL_MODULE_ADDRESS,

--- a/src/pages/ThorChainLP/components/ReusableLpStatus/TransactionRow.tsx
+++ b/src/pages/ThorChainLP/components/ReusableLpStatus/TransactionRow.tsx
@@ -277,13 +277,14 @@ export const TransactionRow: React.FC<TransactionRowProps> = ({
   }, [asset, poolAsset, isRuneTx])
 
   const memo = useMemo(() => {
+    if (thorchainNotationAssetId === undefined) return undefined
     return isDeposit
       ? `+:${thorchainNotationAssetId}:${otherAssetAddress ?? ''}:ss:${confirmedQuote.feeBps}`
       : `-:${thorchainNotationAssetId}:${confirmedQuote.withdrawalBps}`
   }, [isDeposit, thorchainNotationAssetId, otherAssetAddress, confirmedQuote])
 
   const estimateFeesArgs = useMemo(() => {
-    if (!assetId || !wallet || !asset || !poolAsset) return undefined
+    if (!assetId || !wallet || !asset || !poolAsset || !memo) return undefined
     const transactionType = getThorchainLpTransactionType(asset.chainId)
     const amountCryptoBaseUnit = toBaseUnit(amountCryptoPrecision, asset.precision)
 
@@ -404,6 +405,7 @@ export const TransactionRow: React.FC<TransactionRowProps> = ({
         asset &&
         poolAsset &&
         wallet &&
+        memo &&
         (isRuneTx || inboundAddressData?.address)
       )
     ) {

--- a/src/pages/ThorChainLP/components/ReusableLpStatus/TransactionRow.tsx
+++ b/src/pages/ThorChainLP/components/ReusableLpStatus/TransactionRow.tsx
@@ -305,7 +305,7 @@ export const TransactionRow: React.FC<TransactionRowProps> = ({
         const assetAddress = isToken(fromAssetId(assetId).assetReference)
           ? getAddress(fromAssetId(assetId).assetReference)
           : AddressZero
-        const amount = BigInt(toBaseUnit(amountCryptoPrecision, asset.precision).toString())
+        const amount = BigInt(isDeposit ? amountCryptoBaseUnit : '0')
 
         const args = (() => {
           const expiry = BigInt(dayjs().add(15, 'minute').unix())
@@ -315,8 +315,6 @@ export const TransactionRow: React.FC<TransactionRowProps> = ({
             : // Native EVM assets use the 0 address as the asset address
               // https://dev.thorchain.org/concepts/sending-transactions.html#admonition-info-1
               AddressZero
-
-          const amount = BigInt(amountCryptoBaseUnit.toString())
 
           return { memo, amount, expiry, vault, asset }
         })()
@@ -343,14 +341,15 @@ export const TransactionRow: React.FC<TransactionRowProps> = ({
       }
       case 'Send': {
         if (!inboundAddressData || !accountAssetAddress) return undefined
+        const amountCryptoPrecisionWithMaybeDust = isDeposit
+          ? amountCryptoPrecision
+          : // Reuse the savers util as a sane amount for the dust threshold
+            fromBaseUnit(
+              THORCHAIN_SAVERS_DUST_THRESHOLDS_CRYPTO_BASE_UNIT[assetId],
+              asset.precision,
+            ) ?? '0'
         return {
-          amountCryptoPrecision: isDeposit
-            ? amountCryptoPrecision
-            : // Reuse the savers util as a sane amount for the dust threshold
-              fromBaseUnit(
-                THORCHAIN_SAVERS_DUST_THRESHOLDS_CRYPTO_BASE_UNIT[assetId],
-                asset.precision,
-              ) ?? '0',
+          amountCryptoPrecision: amountCryptoPrecisionWithMaybeDust,
           assetId,
           to: inboundAddressData.address,
           from: accountAssetAddress,
@@ -476,6 +475,7 @@ export const TransactionRow: React.FC<TransactionRowProps> = ({
           case 'EvmCustomTx': {
             if (!inboundAddressData?.router) return
             if (assetAccountNumber === undefined) return
+            const amount = BigInt(isDeposit ? amountCryptoBaseUnit : '0')
 
             const args = (() => {
               const expiry = BigInt(dayjs().add(15, 'minute').unix())
@@ -485,8 +485,6 @@ export const TransactionRow: React.FC<TransactionRowProps> = ({
                 : // Native EVM assets use the 0 address as the asset address
                   // https://dev.thorchain.org/concepts/sending-transactions.html#admonition-info-1
                   AddressZero
-
-              const amount = BigInt(amountCryptoBaseUnit.toString())
 
               return { memo, amount, expiry, vault, asset }
             })()
@@ -505,9 +503,7 @@ export const TransactionRow: React.FC<TransactionRowProps> = ({
               accountNumber: assetAccountNumber,
               adapter,
               data,
-              value: isToken(fromAssetId(assetId).assetReference)
-                ? '0'
-                : amountCryptoBaseUnit.toString(),
+              value: isToken(fromAssetId(assetId).assetReference) ? '0' : amount.toString(),
               to: inboundAddressData.router,
               wallet,
             })

--- a/src/pages/ThorChainLP/components/ReusableLpStatus/TransactionRow.tsx
+++ b/src/pages/ThorChainLP/components/ReusableLpStatus/TransactionRow.tsx
@@ -527,14 +527,15 @@ export const TransactionRow: React.FC<TransactionRowProps> = ({
             if (!inboundAddressData) throw new Error('No inboundAddressData found')
             // ATOM/RUNE/ UTXOs- obviously make me a switch case for things to be cleaner
             if (!accountAssetAddress) throw new Error('No accountAddress found')
+            const _amountCryptoPrecision = isDeposit
+              ? amountCryptoPrecision
+              : // Reuse the savers util as a sane amount for the dust threshold
+                fromBaseUnit(
+                  THORCHAIN_SAVERS_DUST_THRESHOLDS_CRYPTO_BASE_UNIT[assetId],
+                  asset.precision,
+                ) ?? '0'
             const estimateFeesArgs = {
-              amountCryptoPrecision: isDeposit
-                ? amountCryptoPrecision
-                : // Reuse the savers util as a sane amount for the dust threshold
-                  fromBaseUnit(
-                    THORCHAIN_SAVERS_DUST_THRESHOLDS_CRYPTO_BASE_UNIT[assetId],
-                    asset.precision,
-                  ) ?? '0',
+              amountCryptoPrecision: _amountCryptoPrecision,
               assetId,
               to: inboundAddressData?.address,
               from: accountAssetAddress,
@@ -545,13 +546,7 @@ export const TransactionRow: React.FC<TransactionRowProps> = ({
             }
             const estimatedFees = await estimateFees(estimateFeesArgs)
             const sendInput: SendInput = {
-              amountCryptoPrecision: isDeposit
-                ? amountCryptoPrecision
-                : // Reuse the savers util as a sane amount for the dust threshold
-                  fromBaseUnit(
-                    THORCHAIN_SAVERS_DUST_THRESHOLDS_CRYPTO_BASE_UNIT[assetId],
-                    asset.precision,
-                  ) ?? '0',
+              amountCryptoPrecision: _amountCryptoPrecision,
               assetId,
               to: inboundAddressData?.address,
               from: accountAssetAddress,

--- a/src/pages/ThorChainLP/components/ReusableLpStatus/TransactionRow.tsx
+++ b/src/pages/ThorChainLP/components/ReusableLpStatus/TransactionRow.tsx
@@ -282,7 +282,7 @@ export const TransactionRow: React.FC<TransactionRowProps> = ({
           ? `+:${thorchainNotationAssetId}:${otherAssetAddress ?? ''}:ss:${confirmedQuote.feeBps}`
           : `-:${thorchainNotationAssetId}:${confirmedQuote.withdrawalBps}`
         return {
-          cryptoAmount: isDeposit ? amountCryptoPrecision : '0',
+          amountCryptoPrecision: isDeposit ? amountCryptoPrecision : '0',
           assetId: asset.assetId,
           memo,
           to: THORCHAIN_POOL_MODULE_ADDRESS,
@@ -324,7 +324,7 @@ export const TransactionRow: React.FC<TransactionRowProps> = ({
         })
 
         return {
-          cryptoAmount: amount.toString(),
+          amountCryptoPrecision: amount.toString(),
           assetId: asset.assetId,
           to: inboundAddressData.router,
           from: accountAssetAddress,
@@ -342,7 +342,7 @@ export const TransactionRow: React.FC<TransactionRowProps> = ({
           : `-:${thorchainNotationAssetId}:${confirmedQuote.withdrawalBps}`
 
         return {
-          cryptoAmount: isDeposit
+          amountCryptoPrecision: isDeposit
             ? amountCryptoPrecision
             : // Reuse the savers util as a sane amount for the dust threshold
               fromBaseUnit(
@@ -379,7 +379,7 @@ export const TransactionRow: React.FC<TransactionRowProps> = ({
 
   const { data: estimatedFeesData, isLoading: isEstimatedFeesDataLoading } =
     useGetEstimatedFeesQuery({
-      cryptoAmount: estimateFeesArgs?.cryptoAmount ?? '0',
+      amountCryptoPrecision: estimateFeesArgs?.amountCryptoPrecision ?? '0',
       assetId: estimateFeesArgs?.assetId ?? '',
       to: estimateFeesArgs?.to ?? '',
       sendMax: estimateFeesArgs?.sendMax ?? false,
@@ -443,7 +443,7 @@ export const TransactionRow: React.FC<TransactionRowProps> = ({
               : `-:${thorchainNotationAssetId}:${confirmedQuote.withdrawalBps}`
 
             const estimatedFees = await estimateFees({
-              cryptoAmount: isDeposit ? amountCryptoPrecision : '0',
+              amountCryptoPrecision: isDeposit ? amountCryptoPrecision : '0',
               assetId: asset.assetId,
               memo,
               to: THORCHAIN_POOL_MODULE_ADDRESS,
@@ -546,7 +546,7 @@ export const TransactionRow: React.FC<TransactionRowProps> = ({
               : `-:${thorchainNotationAssetId}:${confirmedQuote.withdrawalBps}`
 
             const estimateFeesArgs = {
-              cryptoAmount: isDeposit
+              amountCryptoPrecision: isDeposit
                 ? amountCryptoPrecision
                 : // Reuse the savers util as a sane amount for the dust threshold
                   fromBaseUnit(
@@ -563,7 +563,7 @@ export const TransactionRow: React.FC<TransactionRowProps> = ({
             }
             const estimatedFees = await estimateFees(estimateFeesArgs)
             const sendInput: SendInput = {
-              cryptoAmount: isDeposit
+              amountCryptoPrecision: isDeposit
                 ? amountCryptoPrecision
                 : // Reuse the savers util as a sane amount for the dust threshold
                   fromBaseUnit(

--- a/src/react-queries/hooks/useQuoteEstimatedFeesQuery.ts
+++ b/src/react-queries/hooks/useQuoteEstimatedFeesQuery.ts
@@ -83,7 +83,8 @@ export const useQuoteEstimatedFeesQuery = ({
   const feeAssetMarketData = useAppSelector(state => selectMarketDataById(state, collateralAssetId))
   const estimateFeesArgs = useMemo(() => {
     const supportedEvmChainIds = getSupportedEvmChainIds()
-    const cryptoAmount = depositAmountCryptoPrecision ?? repaymentAmountCryptoPrecision ?? '0'
+    const amountCryptoPrecision =
+      depositAmountCryptoPrecision ?? repaymentAmountCryptoPrecision ?? '0'
     const assetId = repaymentAsset?.assetId ?? collateralAssetId
     const quoteMemo =
       confirmedQuote && 'quoteMemo' in confirmedQuote ? confirmedQuote.quoteMemo : ''
@@ -98,7 +99,7 @@ export const useQuoteEstimatedFeesQuery = ({
     const accountId = repaymentAccountId ?? collateralAccountId
 
     return {
-      cryptoAmount,
+      amountCryptoPrecision,
       assetId,
       memo,
       to,


### PR DESCRIPTION
## Description

Mitigate confusion by renaming `cryptoAmount` to `amountCryptoPrecision`, aligning with our internal practice of specifying the units/precision in naming.

## Pull Request Type

- [ ] :bug: Bug fix (Non-breaking Change: Fixes an issue)
- [x] :hammer_and_wrench: Chore (Non-breaking Change: Doc updates, pkg upgrades, typos, etc..)
- [ ] :nail_care: New Feature (Breaking/Non-breaking Change)

## Issue (if applicable)

N/A

## Risk

Small, rename only.

> What protocols, transaction types or contract interactions might be affected by this PR?

None.

## Testing

A general regression test of sends, fee and gas estimates should show no changes.

### Engineering

☝️

### Operations

☝️

## Screenshots (if applicable)

N/A