### PR TITLE
perf: dont process global search selectors when not searching

### DIFF
--- a/src/components/Layout/Header/GlobalSearch/GlobalSearchButton.tsx
+++ b/src/components/Layout/Header/GlobalSearch/GlobalSearchButton.tsx
@@ -1,89 +1,23 @@
 import { SearchIcon } from '@chakra-ui/icons'
-import {
-  Box,
-  Button,
-  IconButton,
-  Kbd,
-  Modal,
-  ModalBody,
-  ModalContent,
-  ModalHeader,
-  ModalOverlay,
-  useDisclosure,
-  useEventListener,
-  useUpdateEffect,
-} from '@chakra-ui/react'
-import { fromAssetId } from '@shapeshiftoss/caip'
-import { isEvmChainId } from '@shapeshiftoss/chain-adapters'
-import { DefiAction } from 'features/defi/contexts/DefiManagerProvider/DefiCommon'
-import { memo, useCallback, useEffect, useMemo, useRef, useState } from 'react'
-import MultiRef from 'react-multi-ref'
+import { Box, Button, IconButton, Kbd, useDisclosure, useEventListener } from '@chakra-ui/react'
+import { memo, useMemo } from 'react'
 import { useTranslate } from 'react-polyglot'
-import { generatePath, useHistory, useLocation } from 'react-router'
-import scrollIntoView from 'scroll-into-view-if-needed'
-import { GlobalFilter } from 'components/StakingVaults/GlobalFilter'
-import { getChainAdapterManager } from 'context/PluginProvider/chainAdapterSingleton'
-import { WalletActions } from 'context/WalletProvider/actions'
-import { useModal } from 'hooks/useModal/useModal'
-import { useWallet } from 'hooks/useWallet/useWallet'
-import { parseAddressInput } from 'lib/address/address'
 import { isMobile as isMobileApp } from 'lib/globals'
-import type { OpportunityId } from 'state/slices/opportunitiesSlice/types'
-import { DefiType } from 'state/slices/opportunitiesSlice/types'
-import type { GlobalSearchResult, SendResult } from 'state/slices/search-selectors'
-import { GlobalSearchResultType, selectGlobalItemsFromFilter } from 'state/slices/search-selectors'
-import {
-  selectAggregatedEarnUserLpOpportunities,
-  selectAggregatedEarnUserStakingOpportunitiesIncludeEmpty,
-  selectAssets,
-} from 'state/slices/selectors'
-import { useAppSelector } from 'state/store'
 
-import { SearchResults } from './SearchResults'
-import { makeOpportunityRouteDetails } from './utils'
+import { GlobalSearchModal } from './GlobalSearchModal'
 
 const mrProp = { base: 0, md: 'auto' }
 const widthProp = { base: 'auto', md: 'full' }
 const displayProp1 = { base: 'flex', md: 'none' }
 const displayProp2 = { base: 'none', md: 'flex' }
-const inputGroupProps = { size: 'xl' }
 const sxProp1 = { svg: { width: '18px', height: '18px' } }
-const sxProp2 = { p: 0 }
 
 const searchIcon = <SearchIcon />
 
 export const GlobalSeachButton = memo(() => {
   const { isOpen, onClose, onOpen, onToggle } = useDisclosure()
-  const [sendResults, setSendResults] = useState<SendResult[]>([])
-  const [activeIndex, setActiveIndex] = useState(0)
-  const [searchQuery, setSearchQuery] = useState('')
-  const menuRef = useRef<HTMLDivElement>(null)
-  const [menuNodes] = useState(() => new MultiRef<number, HTMLElement>())
-  const eventRef = useRef<'mouse' | 'keyboard' | null>(null)
-  const history = useHistory()
-  const location = useLocation()
   const translate = useTranslate()
-  const {
-    state: { isConnected, isDemoWallet },
-    dispatch,
-  } = useWallet()
-
-  const assets = useAppSelector(selectAssets)
-  const stakingOpportunities = useAppSelector(
-    selectAggregatedEarnUserStakingOpportunitiesIncludeEmpty,
-  )
-  const lpOpportunities = useAppSelector(selectAggregatedEarnUserLpOpportunities)
-  const globalSearchFilter = useMemo(() => ({ searchQuery }), [searchQuery])
-  const results = useAppSelector(state => selectGlobalItemsFromFilter(state, globalSearchFilter))
-  const [assetResults, stakingResults, lpResults, txResults] = results
-  const flatResults = useMemo(() => [...results, sendResults].flat(), [results, sendResults])
-  const resultsCount = flatResults.length
   const isMac = useMemo(() => /Mac/.test(navigator.userAgent), [])
-
-  const send = useModal('send')
-  useEffect(() => {
-    if (!searchQuery) setActiveIndex(0)
-  }, [searchQuery])
 
   useEventListener('keydown', event => {
     const hotkey = isMac ? 'metaKey' : 'ctrlKey'
@@ -92,156 +26,6 @@ export const GlobalSeachButton = memo(() => {
       isOpen ? onClose() : onOpen()
     }
   })
-
-  useEffect(() => {
-    if (!searchQuery?.length) return
-
-    setSendResults([])
-    ;(async () => {
-      const parsed = await parseAddressInput({ urlOrAddress: searchQuery })
-      if (parsed) {
-        const { chainId, address, vanityAddress } = parsed
-        // Set the fee AssetId as a default - users can select their preferred token later during the flow
-        setSendResults([
-          {
-            type: GlobalSearchResultType.Send,
-            id: getChainAdapterManager().get(chainId)!.getFeeAssetId(),
-            address,
-            vanityAddress,
-          },
-        ])
-      }
-    })()
-  }, [searchQuery])
-
-  const handleClick = useCallback(
-    (item: GlobalSearchResult) => {
-      switch (item.type) {
-        case GlobalSearchResultType.Send: {
-          // We don't want to pre-select the asset for EVM ChainIds
-          const assetId = !isEvmChainId(fromAssetId(item.id).chainId) ? item.id : undefined
-          send.open({ assetId, input: searchQuery })
-          onToggle()
-          break
-        }
-        case GlobalSearchResultType.Asset: {
-          const url = `/assets/${item.id}`
-          history.push(url)
-          onToggle()
-          break
-        }
-        case GlobalSearchResultType.LpOpportunity:
-        case GlobalSearchResultType.StakingOpportunity: {
-          if (!isConnected && isDemoWallet) {
-            dispatch({ type: WalletActions.SET_WALLET_MODAL, payload: true })
-            return
-          }
-          const data = makeOpportunityRouteDetails({
-            opportunityId: item.id as OpportunityId,
-            opportunityType:
-              item.type === GlobalSearchResultType.StakingOpportunity
-                ? DefiType.Staking
-                : DefiType.LiquidityPool,
-            action: DefiAction.Overview,
-            location,
-            stakingOpportunities,
-            lpOpportunities,
-            assets,
-          })
-          if (!data) return
-          history.push(data)
-          onToggle()
-          break
-        }
-        case GlobalSearchResultType.Transaction: {
-          const path = generatePath('/dashboard/activity/transaction/:txId', {
-            txId: item.id,
-          })
-          history.push(path)
-          onToggle()
-          break
-        }
-        default:
-          break
-      }
-    },
-    [
-      assets,
-      dispatch,
-      history,
-      isConnected,
-      isDemoWallet,
-      location,
-      lpOpportunities,
-      onToggle,
-      searchQuery,
-      send,
-      stakingOpportunities,
-    ],
-  )
-
-  const onKeyDown = useCallback(
-    (e: React.KeyboardEvent) => {
-      eventRef.current = 'keyboard'
-      switch (e.key) {
-        case 'ArrowDown': {
-          e.preventDefault()
-          if (activeIndex && activeIndex === resultsCount - 1) {
-            setActiveIndex(0)
-          } else {
-            setActiveIndex((activeIndex ?? -1) + 1)
-          }
-          break
-        }
-        case 'ArrowUp': {
-          e.preventDefault()
-          if (!activeIndex) {
-            setActiveIndex(resultsCount - 1)
-          } else {
-            setActiveIndex(activeIndex - 1)
-          }
-          break
-        }
-        case 'Enter': {
-          handleClick(flatResults[activeIndex])
-          break
-        }
-        default:
-          break
-      }
-    },
-    [activeIndex, flatResults, handleClick, resultsCount],
-  )
-
-  useUpdateEffect(() => {
-    if (!menuRef.current || eventRef.current === 'mouse') return
-    const node = menuNodes.map.get(activeIndex)
-    if (!node) return
-    scrollIntoView(node, {
-      scrollMode: 'if-needed',
-      block: 'nearest',
-      inline: 'nearest',
-      boundary: menuRef.current,
-    })
-  }, [activeIndex])
-
-  useEffect(() => {
-    if (isOpen && searchQuery.length > 0) {
-      setSearchQuery('')
-    }
-    // eslint-disable-next-line react-hooks/exhaustive-deps
-  }, [isOpen])
-
-  const handleClose = useCallback(() => {
-    setSearchQuery('')
-    onClose()
-  }, [onClose])
-
-  useUpdateEffect(() => {
-    setActiveIndex(0)
-  }, [searchQuery])
-
-  const isSearching = useMemo(() => searchQuery.length > 0, [searchQuery])
 
   return (
     <>
@@ -271,40 +55,9 @@ export const GlobalSeachButton = memo(() => {
           )}
         </Button>
       </Box>
-      <Modal scrollBehavior='inside' isOpen={isOpen} onClose={handleClose} size='lg'>
-        <ModalOverlay />
-        <ModalContent overflow='hidden'>
-          <ModalHeader
-            position='sticky'
-            top={0}
-            sx={sxProp2}
-            borderBottomWidth={1}
-            borderColor='whiteAlpha.100'
-          >
-            <GlobalFilter
-              searchQuery={searchQuery}
-              setSearchQuery={setSearchQuery}
-              onKeyDown={onKeyDown}
-              inputGroupProps={inputGroupProps}
-              borderBottomRadius={0}
-              borderWidth={0}
-            />
-          </ModalHeader>
-          <ModalBody px={0} ref={menuRef}>
-            <SearchResults
-              assetResults={assetResults}
-              stakingResults={stakingResults}
-              lpResults={lpResults}
-              txResults={txResults}
-              sendResults={sendResults}
-              activeIndex={activeIndex}
-              searchQuery={searchQuery}
-              isSearching={isSearching}
-              onClickResult={handleClick}
-            />
-          </ModalBody>
-        </ModalContent>
-      </Modal>
+      {isOpen && (
+        <GlobalSearchModal isOpen={isOpen} onClose={onClose} onOpen={onOpen} onToggle={onToggle} />
+      )}
     </>
   )
 })

--- a/src/components/Layout/Header/GlobalSearch/GlobalSearchButton.tsx
+++ b/src/components/Layout/Header/GlobalSearch/GlobalSearchButton.tsx
@@ -4,7 +4,6 @@ import {
   Button,
   IconButton,
   Kbd,
-  List,
   Modal,
   ModalBody,
   ModalContent,
@@ -23,7 +22,6 @@ import { useTranslate } from 'react-polyglot'
 import { generatePath, useHistory, useLocation } from 'react-router'
 import scrollIntoView from 'scroll-into-view-if-needed'
 import { GlobalFilter } from 'components/StakingVaults/GlobalFilter'
-import { SearchEmpty } from 'components/StakingVaults/SearchEmpty'
 import { getChainAdapterManager } from 'context/PluginProvider/chainAdapterSingleton'
 import { WalletActions } from 'context/WalletProvider/actions'
 import { useModal } from 'hooks/useModal/useModal'
@@ -41,11 +39,7 @@ import {
 } from 'state/slices/selectors'
 import { useAppSelector } from 'state/store'
 
-import { ActionResults } from './ActionResults/ActionResults'
-import { AssetResults } from './AssetResults/AssetResults'
-import { LpResults } from './LpResults/LpResults'
-import { StakingResults } from './StakingResults/StakingResults'
-import { TxResults } from './TxResults/TxResults'
+import { SearchResults } from './SearchResults'
 import { makeOpportunityRouteDetails } from './utils'
 
 const mrProp = { base: 0, md: 'auto' }
@@ -248,66 +242,6 @@ export const GlobalSeachButton = memo(() => {
   }, [searchQuery])
 
   const isSearching = useMemo(() => searchQuery.length > 0, [searchQuery])
-  const renderResults = useMemo(() => {
-    return isSearching && !results?.length ? (
-      <SearchEmpty searchQuery={searchQuery} />
-    ) : (
-      <List>
-        <ActionResults
-          onClick={handleClick}
-          results={sendResults}
-          searchQuery={searchQuery}
-          activeIndex={activeIndex}
-          startingIndex={0}
-          menuNodes={menuNodes}
-        />
-        <AssetResults
-          onClick={handleClick}
-          results={assetResults}
-          activeIndex={activeIndex}
-          startingIndex={0}
-          searchQuery={searchQuery}
-          menuNodes={menuNodes}
-        />
-        <StakingResults
-          results={stakingResults}
-          onClick={handleClick}
-          activeIndex={activeIndex}
-          startingIndex={assetResults.length}
-          searchQuery={searchQuery}
-          menuNodes={menuNodes}
-        />
-        <LpResults
-          results={lpResults}
-          onClick={handleClick}
-          activeIndex={activeIndex}
-          startingIndex={assetResults.length + stakingResults.length}
-          searchQuery={searchQuery}
-          menuNodes={menuNodes}
-        />
-        <TxResults
-          results={txResults}
-          onClick={handleClick}
-          activeIndex={activeIndex}
-          startingIndex={assetResults.length + stakingResults.length + lpResults.length}
-          searchQuery={searchQuery}
-          menuNodes={menuNodes}
-        />
-      </List>
-    )
-  }, [
-    activeIndex,
-    assetResults,
-    handleClick,
-    isSearching,
-    lpResults,
-    menuNodes,
-    results?.length,
-    searchQuery,
-    sendResults,
-    stakingResults,
-    txResults,
-  ])
 
   return (
     <>
@@ -357,7 +291,17 @@ export const GlobalSeachButton = memo(() => {
             />
           </ModalHeader>
           <ModalBody px={0} ref={menuRef}>
-            {renderResults}
+            <SearchResults
+              assetResults={assetResults}
+              stakingResults={stakingResults}
+              lpResults={lpResults}
+              txResults={txResults}
+              sendResults={sendResults}
+              activeIndex={activeIndex}
+              searchQuery={searchQuery}
+              isSearching={isSearching}
+              onClickResult={handleClick}
+            />
           </ModalBody>
         </ModalContent>
       </Modal>

--- a/src/components/Layout/Header/GlobalSearch/GlobalSearchModal.tsx
+++ b/src/components/Layout/Header/GlobalSearch/GlobalSearchModal.tsx
@@ -1,0 +1,273 @@
+import type { UseDisclosureReturn } from '@chakra-ui/react'
+import {
+  Modal,
+  ModalBody,
+  ModalContent,
+  ModalHeader,
+  ModalOverlay,
+  useEventListener,
+  useUpdateEffect,
+} from '@chakra-ui/react'
+import { fromAssetId } from '@shapeshiftoss/caip'
+import { isEvmChainId } from '@shapeshiftoss/chain-adapters'
+import { DefiAction } from 'features/defi/contexts/DefiManagerProvider/DefiCommon'
+import { memo, useCallback, useEffect, useMemo, useRef, useState } from 'react'
+import MultiRef from 'react-multi-ref'
+import { generatePath, useHistory, useLocation } from 'react-router'
+import scrollIntoView from 'scroll-into-view-if-needed'
+import { GlobalFilter } from 'components/StakingVaults/GlobalFilter'
+import { getChainAdapterManager } from 'context/PluginProvider/chainAdapterSingleton'
+import { WalletActions } from 'context/WalletProvider/actions'
+import { useModal } from 'hooks/useModal/useModal'
+import { useWallet } from 'hooks/useWallet/useWallet'
+import { parseAddressInput } from 'lib/address/address'
+import type { OpportunityId } from 'state/slices/opportunitiesSlice/types'
+import { DefiType } from 'state/slices/opportunitiesSlice/types'
+import type { GlobalSearchResult, SendResult } from 'state/slices/search-selectors'
+import { GlobalSearchResultType, selectGlobalItemsFromFilter } from 'state/slices/search-selectors'
+import {
+  selectAggregatedEarnUserLpOpportunities,
+  selectAggregatedEarnUserStakingOpportunitiesIncludeEmpty,
+  selectAssets,
+} from 'state/slices/selectors'
+import { useAppSelector } from 'state/store'
+
+import { SearchResults } from './SearchResults'
+import { makeOpportunityRouteDetails } from './utils'
+
+const inputGroupProps = { size: 'xl' }
+const sxProp2 = { p: 0 }
+
+export const GlobalSearchModal = memo(
+  ({
+    isOpen,
+    onClose,
+    onOpen,
+    onToggle,
+  }: Pick<UseDisclosureReturn, 'isOpen' | 'onClose' | 'onOpen' | 'onToggle'>) => {
+    const [sendResults, setSendResults] = useState<SendResult[]>([])
+    const [activeIndex, setActiveIndex] = useState(0)
+    const [searchQuery, setSearchQuery] = useState('')
+    const menuRef = useRef<HTMLDivElement>(null)
+    const [menuNodes] = useState(() => new MultiRef<number, HTMLElement>())
+    const eventRef = useRef<'mouse' | 'keyboard' | null>(null)
+    const history = useHistory()
+    const location = useLocation()
+    const {
+      state: { isConnected, isDemoWallet },
+      dispatch,
+    } = useWallet()
+
+    const assets = useAppSelector(selectAssets)
+    const stakingOpportunities = useAppSelector(
+      selectAggregatedEarnUserStakingOpportunitiesIncludeEmpty,
+    )
+    const lpOpportunities = useAppSelector(selectAggregatedEarnUserLpOpportunities)
+    const globalSearchFilter = useMemo(() => ({ searchQuery }), [searchQuery])
+    const results = useAppSelector(state => selectGlobalItemsFromFilter(state, globalSearchFilter))
+    const [assetResults, stakingResults, lpResults, txResults] = results
+    const flatResults = useMemo(() => [...results, sendResults].flat(), [results, sendResults])
+    const resultsCount = flatResults.length
+    const isMac = useMemo(() => /Mac/.test(navigator.userAgent), [])
+
+    const send = useModal('send')
+    useEffect(() => {
+      if (!searchQuery) setActiveIndex(0)
+    }, [searchQuery])
+
+    useEventListener('keydown', event => {
+      const hotkey = isMac ? 'metaKey' : 'ctrlKey'
+      if (event?.key?.toLowerCase() === 'k' && event[hotkey]) {
+        event.preventDefault()
+        isOpen ? onClose() : onOpen()
+      }
+    })
+
+    useEffect(() => {
+      if (!searchQuery?.length) return
+
+      setSendResults([])
+      ;(async () => {
+        const parsed = await parseAddressInput({ urlOrAddress: searchQuery })
+        if (parsed) {
+          const { chainId, address, vanityAddress } = parsed
+          // Set the fee AssetId as a default - users can select their preferred token later during the flow
+          setSendResults([
+            {
+              type: GlobalSearchResultType.Send,
+              id: getChainAdapterManager().get(chainId)!.getFeeAssetId(),
+              address,
+              vanityAddress,
+            },
+          ])
+        }
+      })()
+    }, [searchQuery])
+
+    const handleClick = useCallback(
+      (item: GlobalSearchResult) => {
+        switch (item.type) {
+          case GlobalSearchResultType.Send: {
+            // We don't want to pre-select the asset for EVM ChainIds
+            const assetId = !isEvmChainId(fromAssetId(item.id).chainId) ? item.id : undefined
+            send.open({ assetId, input: searchQuery })
+            onToggle()
+            break
+          }
+          case GlobalSearchResultType.Asset: {
+            const url = `/assets/${item.id}`
+            history.push(url)
+            onToggle()
+            break
+          }
+          case GlobalSearchResultType.LpOpportunity:
+          case GlobalSearchResultType.StakingOpportunity: {
+            if (!isConnected && isDemoWallet) {
+              dispatch({ type: WalletActions.SET_WALLET_MODAL, payload: true })
+              return
+            }
+            const data = makeOpportunityRouteDetails({
+              opportunityId: item.id as OpportunityId,
+              opportunityType:
+                item.type === GlobalSearchResultType.StakingOpportunity
+                  ? DefiType.Staking
+                  : DefiType.LiquidityPool,
+              action: DefiAction.Overview,
+              location,
+              stakingOpportunities,
+              lpOpportunities,
+              assets,
+            })
+            if (!data) return
+            history.push(data)
+            onToggle()
+            break
+          }
+          case GlobalSearchResultType.Transaction: {
+            const path = generatePath('/dashboard/activity/transaction/:txId', {
+              txId: item.id,
+            })
+            history.push(path)
+            onToggle()
+            break
+          }
+          default:
+            break
+        }
+      },
+      [
+        assets,
+        dispatch,
+        history,
+        isConnected,
+        isDemoWallet,
+        location,
+        lpOpportunities,
+        onToggle,
+        searchQuery,
+        send,
+        stakingOpportunities,
+      ],
+    )
+
+    const onKeyDown = useCallback(
+      (e: React.KeyboardEvent) => {
+        eventRef.current = 'keyboard'
+        switch (e.key) {
+          case 'ArrowDown': {
+            e.preventDefault()
+            if (activeIndex && activeIndex === resultsCount - 1) {
+              setActiveIndex(0)
+            } else {
+              setActiveIndex((activeIndex ?? -1) + 1)
+            }
+            break
+          }
+          case 'ArrowUp': {
+            e.preventDefault()
+            if (!activeIndex) {
+              setActiveIndex(resultsCount - 1)
+            } else {
+              setActiveIndex(activeIndex - 1)
+            }
+            break
+          }
+          case 'Enter': {
+            handleClick(flatResults[activeIndex])
+            break
+          }
+          default:
+            break
+        }
+      },
+      [activeIndex, flatResults, handleClick, resultsCount],
+    )
+
+    useUpdateEffect(() => {
+      if (!menuRef.current || eventRef.current === 'mouse') return
+      const node = menuNodes.map.get(activeIndex)
+      if (!node) return
+      scrollIntoView(node, {
+        scrollMode: 'if-needed',
+        block: 'nearest',
+        inline: 'nearest',
+        boundary: menuRef.current,
+      })
+    }, [activeIndex])
+
+    useEffect(() => {
+      if (isOpen && searchQuery.length > 0) {
+        setSearchQuery('')
+      }
+      // eslint-disable-next-line react-hooks/exhaustive-deps
+    }, [isOpen])
+
+    const handleClose = useCallback(() => {
+      setSearchQuery('')
+      onClose()
+    }, [onClose])
+
+    useUpdateEffect(() => {
+      setActiveIndex(0)
+    }, [searchQuery])
+
+    const isSearching = useMemo(() => searchQuery.length > 0, [searchQuery])
+
+    return (
+      <Modal scrollBehavior='inside' isOpen={isOpen} onClose={handleClose} size='lg'>
+        <ModalOverlay />
+        <ModalContent overflow='hidden'>
+          <ModalHeader
+            position='sticky'
+            top={0}
+            sx={sxProp2}
+            borderBottomWidth={1}
+            borderColor='whiteAlpha.100'
+          >
+            <GlobalFilter
+              searchQuery={searchQuery}
+              setSearchQuery={setSearchQuery}
+              onKeyDown={onKeyDown}
+              inputGroupProps={inputGroupProps}
+              borderBottomRadius={0}
+              borderWidth={0}
+            />
+          </ModalHeader>
+          <ModalBody px={0} ref={menuRef}>
+            <SearchResults
+              assetResults={assetResults}
+              stakingResults={stakingResults}
+              lpResults={lpResults}
+              txResults={txResults}
+              sendResults={sendResults}
+              activeIndex={activeIndex}
+              searchQuery={searchQuery}
+              isSearching={isSearching}
+              onClickResult={handleClick}
+            />
+          </ModalBody>
+        </ModalContent>
+      </Modal>
+    )
+  },
+)

--- a/src/components/Layout/Header/GlobalSearch/SearchResults.tsx
+++ b/src/components/Layout/Header/GlobalSearch/SearchResults.tsx
@@ -1,0 +1,111 @@
+import { List } from '@chakra-ui/react'
+import { memo, useMemo } from 'react'
+import MultiRef from 'react-multi-ref'
+import { SearchEmpty } from 'components/StakingVaults/SearchEmpty'
+import type {
+  AssetSearchResult,
+  GlobalSearchResult,
+  OpportunitySearchResult,
+  SendResult,
+  TxSearchResult,
+} from 'state/slices/search-selectors'
+
+import { ActionResults } from './ActionResults/ActionResults'
+import { AssetResults } from './AssetResults/AssetResults'
+import { LpResults } from './LpResults/LpResults'
+import { StakingResults } from './StakingResults/StakingResults'
+import { TxResults } from './TxResults/TxResults'
+
+export type SearchResultsProps = {
+  assetResults: AssetSearchResult[]
+  stakingResults: OpportunitySearchResult[]
+  lpResults: OpportunitySearchResult[]
+  txResults: TxSearchResult[]
+  sendResults: SendResult[]
+  activeIndex: number
+  searchQuery: string
+  isSearching: boolean
+  onClickResult: (item: GlobalSearchResult) => void
+}
+
+export const SearchResults = memo(
+  ({
+    assetResults,
+    stakingResults,
+    lpResults,
+    txResults,
+    sendResults,
+    activeIndex,
+    searchQuery,
+    isSearching,
+    onClickResult,
+  }: SearchResultsProps) => {
+    const menuNodes = useMemo(() => new MultiRef<number, HTMLElement>(), [])
+
+    const noResults = useMemo(() => {
+      return (
+        !assetResults.length &&
+        !stakingResults.length &&
+        !lpResults.length &&
+        !txResults.length &&
+        !sendResults.length &&
+        !assetResults.length
+      )
+    }, [
+      assetResults.length,
+      lpResults.length,
+      sendResults.length,
+      stakingResults.length,
+      txResults.length,
+    ])
+
+    if (isSearching && noResults) {
+      return <SearchEmpty searchQuery={searchQuery} />
+    }
+
+    return (
+      <List>
+        <ActionResults
+          onClick={onClickResult}
+          results={sendResults}
+          searchQuery={searchQuery}
+          activeIndex={activeIndex}
+          startingIndex={0}
+          menuNodes={menuNodes}
+        />
+        <AssetResults
+          onClick={onClickResult}
+          results={assetResults}
+          activeIndex={activeIndex}
+          startingIndex={0}
+          searchQuery={searchQuery}
+          menuNodes={menuNodes}
+        />
+        <StakingResults
+          results={stakingResults}
+          onClick={onClickResult}
+          activeIndex={activeIndex}
+          startingIndex={assetResults.length}
+          searchQuery={searchQuery}
+          menuNodes={menuNodes}
+        />
+        <LpResults
+          results={lpResults}
+          onClick={onClickResult}
+          activeIndex={activeIndex}
+          startingIndex={assetResults.length + stakingResults.length}
+          searchQuery={searchQuery}
+          menuNodes={menuNodes}
+        />
+        <TxResults
+          results={txResults}
+          onClick={onClickResult}
+          activeIndex={activeIndex}
+          startingIndex={assetResults.length + stakingResults.length + lpResults.length}
+          searchQuery={searchQuery}
+          menuNodes={menuNodes}
+        />
+      </List>
+    )
+  },
+)


### PR DESCRIPTION
## Description

Prevents the global search modal from pulling large amounts of state from redux unless the user is actually searching. This improves boot time, especially on larger wallets.

Saves ~0.5s of boot time on large wallets locally. This time saving is much less on desktop prod builds, but is comparable on mobile devices.

## Pull Request Type

- [ ] :bug: Bug fix (Non-breaking Change: Fixes an issue)
- [x] :hammer_and_wrench: Chore (Non-breaking Change: Doc updates, pkg upgrades, typos, etc..)
- [ ] :nail_care: New Feature (Breaking/Non-breaking Change)

## Issue (if applicable)

<!-----------------------------------------------------------------------------
If applicable, please link to the github issue and put `closes #XXXX` in your comment to auto-close the issue that your PR fixes.
------------------------------------------------------------------------------>

relates to #6252

## Risk
> High Risk PRs Require 2 approvals

Low risk, as this is merely moving existing code into separate components without changes to business logic

> What protocols, transaction types or contract interactions might be affected by this PR?

## Testing

Ensure global search is working and loading as intended

### Engineering

<!-----------------------------------------------------------------------------
Include sufficient information here for an engineer to test your PR. This may include how to test locally, in a built environment, changes to infrastructure etc.
------------------------------------------------------------------------------>

### Operations

<!-----------------------------------------------------------------------------
If your changes have a user-facing impact, describe how a non-technical QA team can functionally test your changes in a preview environment.

If they are not user-facing please describe how to test for any regressions that may occur.
------------------------------------------------------------------------------>

## Screenshots (if applicable)
