### PR TITLE
perf: conditionally mount trade input components

### DIFF
--- a/src/components/AssetHeader/AssetHeader.tsx
+++ b/src/components/AssetHeader/AssetHeader.tsx
@@ -9,7 +9,6 @@ import { useMemo } from 'react'
 import { useTranslate } from 'react-polyglot'
 import { AssetIcon } from 'components/AssetIcon'
 import { SEO } from 'components/Layout/Seo'
-import { useIsSnapInstalled } from 'hooks/useIsSnapInstalled/useIsSnapInstalled'
 import { useLocaleFormatter } from 'hooks/useLocaleFormatter/useLocaleFormatter'
 import { useWallet } from 'hooks/useWallet/useWallet'
 import { useWalletSupportsChain } from 'hooks/useWalletSupportsChain/useWalletSupportsChain'
@@ -57,8 +56,7 @@ export const AssetHeader: React.FC<AssetHeaderProps> = ({ assetId, accountId, ..
     state: { wallet },
   } = useWallet()
 
-  const isSnapInstalled = useIsSnapInstalled()
-  const walletSupportsChain = useWalletSupportsChain({ chainId, wallet, isSnapInstalled })
+  const walletSupportsChain = useWalletSupportsChain(chainId, wallet)
 
   const filter = useMemo(() => ({ assetId, accountId }), [assetId, accountId])
   const cryptoBalance =

--- a/src/components/MultiHopTrade/components/QuoteList/QuoteList.tsx
+++ b/src/components/MultiHopTrade/components/QuoteList/QuoteList.tsx
@@ -1,5 +1,6 @@
 import type { CardProps } from '@chakra-ui/react'
 import { Card, CardBody, CardHeader, Heading } from '@chakra-ui/react'
+import { useMemo } from 'react'
 import { Text } from 'components/Text'
 
 import { TradeQuotes } from '../TradeInput/components/TradeQuotes/TradeQuotes'
@@ -10,7 +11,18 @@ type QuoteListProps = {
   isLoading: boolean
 } & CardProps
 
-export const QuoteList: React.FC<QuoteListProps> = ({ onBack, isLoading, ...cardProps }) => {
+export const QuoteList: React.FC<QuoteListProps> = props => {
+  const { onBack, isLoading, cardProps } = useMemo(() => {
+    const { onBack, isLoading, ...cardProps } = props
+
+    return {
+      onBack,
+      isLoading,
+      cardProps,
+    }
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, [Object.values(props)])
+
   return (
     <Card {...cardProps}>
       <CardHeader px={6} pt={4}>

--- a/src/components/MultiHopTrade/components/TradeInput/TradeInput.tsx
+++ b/src/components/MultiHopTrade/components/TradeInput/TradeInput.tsx
@@ -94,6 +94,7 @@ import { HorizontalCollapse } from './components/HorizontalCollapse'
 import { RecipientAddress } from './components/RecipientAddress'
 import { SellAssetInput } from './components/SellAssetInput'
 import { CountdownSpinner } from './components/TradeQuotes/components/CountdownSpinner'
+import { WithLazyRender } from './components/WithLazyRender'
 import { getQuoteErrorTranslation } from './getQuoteErrorTranslation'
 import { getQuoteRequestErrorTranslation } from './getQuoteRequestErrorTranslation'
 import { useSharedHeight } from './hooks/useSharedHieght'
@@ -111,8 +112,12 @@ type TradeInputProps = {
   isCompact?: boolean
 }
 
-export const TradeInput = memo(({ isCompact }: TradeInputProps) => {
+const GetTradeQuotes = () => {
   useGetTradeQuotes()
+  return <></>
+}
+
+export const TradeInput = memo(({ isCompact }: TradeInputProps) => {
   const {
     state: { wallet },
   } = useWallet()
@@ -585,20 +590,23 @@ export const TradeInput = memo(({ isCompact }: TradeInputProps) => {
 
   return (
     <TradeSlideTransition>
+      <WithLazyRender shouldUse={hasUserEnteredAmount} component={GetTradeQuotes} />
       <MessageOverlay show={isKeplr} title={overlayTitle}>
         <Flex
           width='full'
           justifyContent='center'
           maxWidth={isCompact || isSmallerThanXl ? '500px' : undefined}
         >
-          <Center width='inherit' display={!isCompactQuoteListOpen ? 'none' : undefined}>
-            <QuoteList
-              onBack={handleCloseCompactQuoteList}
-              isLoading={isLoading}
-              height={tradeInputHeight ?? '500px'}
-              width={tradeInputRef.current?.offsetWidth ?? 'full'}
-            />
-          </Center>
+          {(isCompact || isSmallerThanXl) && (
+            <Center width='inherit' display={!isCompactQuoteListOpen ? 'none' : undefined}>
+              <QuoteList
+                onBack={handleCloseCompactQuoteList}
+                isLoading={isLoading}
+                height={tradeInputHeight ?? '500px'}
+                width={tradeInputRef.current?.offsetWidth ?? 'full'}
+              />
+            </Center>
+          )}
           <Center width='inherit'>
             <Card
               flex={1}

--- a/src/components/MultiHopTrade/components/TradeInput/TradeInput.tsx
+++ b/src/components/MultiHopTrade/components/TradeInput/TradeInput.tsx
@@ -90,7 +90,7 @@ import { breakpoints } from 'theme/theme'
 import { useAccountIds } from '../../hooks/useAccountIds'
 import { useSupportedAssets } from '../../hooks/useSupportedAssets'
 import { QuoteList } from '../QuoteList/QuoteList'
-import { HorizontalCollapse } from './components/HorizontalCollapse'
+import { CollapsibleQuoteList } from './components/CollapsibleQuoteList'
 import { RecipientAddress } from './components/RecipientAddress'
 import { SellAssetInput } from './components/SellAssetInput'
 import { CountdownSpinner } from './components/TradeQuotes/components/CountdownSpinner'
@@ -112,7 +112,7 @@ type TradeInputProps = {
   isCompact?: boolean
 }
 
-// dummy component to allow use to lazily mount this beast of a hook
+// dummy component to allow us to lazily mount this beast of a hook
 const GetTradeQuotes = () => {
   useGetTradeQuotes()
   return <></>
@@ -709,19 +709,15 @@ export const TradeInput = memo(({ isCompact }: TradeInputProps) => {
               </Stack>
             </Card>
 
-            <HorizontalCollapse
+            <WithLazyMount
+              shouldUse={!isCompact && !isSmallerThanXl}
+              component={CollapsibleQuoteList}
               isOpen={!isCompact && !isSmallerThanXl && hasUserEnteredAmount}
+              isLoading={isLoading}
               width={tradeInputRef.current?.offsetWidth ?? 'full'}
               height={tradeInputHeight ?? 'full'}
-            >
-              <WithLazyMount
-                shouldUse={!isCompact && !isSmallerThanXl && hasUserEnteredAmount}
-                component={QuoteList}
-                ml={4}
-                isLoading={isLoading}
-                height={tradeInputHeight ?? 'full'}
-              />
-            </HorizontalCollapse>
+              ml={4}
+            />
           </Center>
         </Flex>
       </MessageOverlay>

--- a/src/components/MultiHopTrade/components/TradeInput/TradeInput.tsx
+++ b/src/components/MultiHopTrade/components/TradeInput/TradeInput.tsx
@@ -112,6 +112,7 @@ type TradeInputProps = {
   isCompact?: boolean
 }
 
+// dummy component to allow use to lazily mount this beast of a hook
 const GetTradeQuotes = () => {
   useGetTradeQuotes()
   return <></>

--- a/src/components/MultiHopTrade/components/TradeInput/TradeInput.tsx
+++ b/src/components/MultiHopTrade/components/TradeInput/TradeInput.tsx
@@ -94,7 +94,7 @@ import { HorizontalCollapse } from './components/HorizontalCollapse'
 import { RecipientAddress } from './components/RecipientAddress'
 import { SellAssetInput } from './components/SellAssetInput'
 import { CountdownSpinner } from './components/TradeQuotes/components/CountdownSpinner'
-import { WithLazyRender } from './components/WithLazyRender'
+import { WithLazyMount } from './components/WithLazyMount'
 import { getQuoteErrorTranslation } from './getQuoteErrorTranslation'
 import { getQuoteRequestErrorTranslation } from './getQuoteRequestErrorTranslation'
 import { useSharedHeight } from './hooks/useSharedHieght'
@@ -503,8 +503,8 @@ export const TradeInput = memo(({ isCompact }: TradeInputProps) => {
           bg='background.surface.raised.accent'
           borderBottomRadius='xl'
         >
-          <WithLazyRender shouldUse={Boolean(receiveAddress)} component={RecipientAddress} />
-          <WithLazyRender
+          <WithLazyMount shouldUse={Boolean(receiveAddress)} component={RecipientAddress} />
+          <WithLazyMount
             shouldUse={hasUserEnteredAmount && !walletSupportsBuyAssetChain}
             component={ManualAddressEntry}
           />
@@ -595,7 +595,7 @@ export const TradeInput = memo(({ isCompact }: TradeInputProps) => {
 
   return (
     <TradeSlideTransition>
-      <WithLazyRender shouldUse={hasUserEnteredAmount} component={GetTradeQuotes} />
+      <WithLazyMount shouldUse={hasUserEnteredAmount} component={GetTradeQuotes} />
       <MessageOverlay show={isKeplr} title={overlayTitle}>
         <Flex
           width='full'
@@ -713,7 +713,7 @@ export const TradeInput = memo(({ isCompact }: TradeInputProps) => {
               width={tradeInputRef.current?.offsetWidth ?? 'full'}
               height={tradeInputHeight ?? 'full'}
             >
-              <WithLazyRender
+              <WithLazyMount
                 shouldUse={!isCompact && !isSmallerThanXl && hasUserEnteredAmount}
                 component={QuoteList}
                 ml={4}

--- a/src/components/MultiHopTrade/components/TradeInput/components/CollapsibleQuoteList.tsx
+++ b/src/components/MultiHopTrade/components/TradeInput/components/CollapsibleQuoteList.tsx
@@ -1,0 +1,25 @@
+import type { CardProps } from '@chakra-ui/react'
+
+import { QuoteList } from '../../QuoteList/QuoteList'
+import { HorizontalCollapse } from './HorizontalCollapse'
+
+export type CollapsibleQuoteListProps = {
+  isOpen: boolean
+  width: string | number
+  height: string | number
+  isLoading: boolean
+} & CardProps
+
+export const CollapsibleQuoteList = ({
+  isOpen,
+  width,
+  height,
+  isLoading,
+  ml,
+}: CollapsibleQuoteListProps) => {
+  return (
+    <HorizontalCollapse isOpen={isOpen} width={width} height={height}>
+      <QuoteList ml={ml} isLoading={isLoading} height={height} />
+    </HorizontalCollapse>
+  )
+}

--- a/src/components/MultiHopTrade/components/TradeInput/components/HorizontalCollapse.tsx
+++ b/src/components/MultiHopTrade/components/TradeInput/components/HorizontalCollapse.tsx
@@ -43,7 +43,7 @@ export const HorizontalCollapse = ({
       style={motionStyle}
     >
       <Box position='absolute' left={0} width={width} height={height}>
-        {children}
+        {!hidden ? children : null}
       </Box>
     </motion.div>
   )

--- a/src/components/MultiHopTrade/components/TradeInput/components/ManualAddressEntry.tsx
+++ b/src/components/MultiHopTrade/components/TradeInput/components/ManualAddressEntry.tsx
@@ -39,11 +39,7 @@ export const ManualAddressEntry: FC = memo((): JSX.Element | null => {
   const isYatSupported = isYatFeatureEnabled && isYatSupportedByReceiveChain
 
   const isSnapInstalled = useIsSnapInstalled()
-  const walletSupportsBuyAssetChain = useWalletSupportsChain({
-    chainId: buyAssetChainId,
-    wallet,
-    isSnapInstalled,
-  })
+  const walletSupportsBuyAssetChain = useWalletSupportsChain(buyAssetChainId, wallet)
   const activeQuote = useAppSelector(selectActiveQuote)
   const shouldShowManualReceiveAddressInput = useMemo(() => {
     // We want to display the manual address entry if the wallet doesn't support the buy asset chain,

--- a/src/components/MultiHopTrade/components/TradeInput/components/WithLazyMount.tsx
+++ b/src/components/MultiHopTrade/components/TradeInput/components/WithLazyMount.tsx
@@ -7,7 +7,7 @@ export type WithLazyRenderProps<T = {}> = { shouldUse: boolean; component: React
  * true. Used to mount hooks lazily where their initialization cost is non-trivial. `Component` is
  * an otherwise empty component containing the expensive initialization.
  */
-export const WithLazyRender = <T extends object = {}>(props: WithLazyRenderProps<T>) => {
+export const WithLazyMount = <T extends object = {}>(props: WithLazyRenderProps<T>) => {
   const persistentShouldUse = useRef(false)
   const {
     shouldUse,

--- a/src/components/MultiHopTrade/components/TradeInput/components/WithLazyRender.tsx
+++ b/src/components/MultiHopTrade/components/TradeInput/components/WithLazyRender.tsx
@@ -1,0 +1,24 @@
+import { useEffect, useRef } from 'react'
+
+export type WithLazyRenderProps = { shouldUse: boolean; component: React.FC }
+
+/**
+ * Higher-order component that avoids rendering a component passed via props until `shouldUse` is
+ * true. Used to mount hooks lazily where their initialization cost is non-trivial. `Component` is
+ * an otherwise empty component containing the expensive initialization.
+ */
+export const WithLazyRender = ({ shouldUse, component: Component }: WithLazyRenderProps) => {
+  const persistentShouldUse = useRef(false)
+
+  useEffect(() => {
+    if (!shouldUse || persistentShouldUse.current === true) {
+      return
+    }
+
+    persistentShouldUse.current = shouldUse
+  }, [shouldUse])
+
+  if (!persistentShouldUse.current) return null
+
+  return <Component />
+}

--- a/src/components/MultiHopTrade/components/TradeInput/components/WithLazyRender.tsx
+++ b/src/components/MultiHopTrade/components/TradeInput/components/WithLazyRender.tsx
@@ -1,14 +1,28 @@
-import { useEffect, useRef } from 'react'
+import { useEffect, useMemo, useRef } from 'react'
 
-export type WithLazyRenderProps = { shouldUse: boolean; component: React.FC }
+export type WithLazyRenderProps<T = {}> = { shouldUse: boolean; component: React.FC<T> } & T
 
 /**
  * Higher-order component that avoids rendering a component passed via props until `shouldUse` is
  * true. Used to mount hooks lazily where their initialization cost is non-trivial. `Component` is
  * an otherwise empty component containing the expensive initialization.
  */
-export const WithLazyRender = ({ shouldUse, component: Component }: WithLazyRenderProps) => {
+export const WithLazyRender = <T extends object = {}>(props: WithLazyRenderProps<T>) => {
   const persistentShouldUse = useRef(false)
+  const {
+    shouldUse,
+    component: Component,
+    componentProps,
+  } = useMemo(() => {
+    const { shouldUse, component, ...componentProps } = props
+
+    return {
+      shouldUse,
+      component,
+      componentProps,
+    }
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, [Object.values(props)])
 
   useEffect(() => {
     if (!shouldUse || persistentShouldUse.current === true) {
@@ -20,5 +34,5 @@ export const WithLazyRender = ({ shouldUse, component: Component }: WithLazyRend
 
   if (!persistentShouldUse.current) return null
 
-  return <Component />
+  return <Component {...(componentProps as T)} />
 }

--- a/src/components/MultiHopTrade/hooks/useGetTradeQuotes/useGetTradeQuotes.tsx
+++ b/src/components/MultiHopTrade/hooks/useGetTradeQuotes/useGetTradeQuotes.tsx
@@ -6,7 +6,6 @@ import { SwapperName } from '@shapeshiftoss/swapper'
 import { useEffect, useMemo, useState } from 'react'
 import { getTradeQuoteArgs } from 'components/MultiHopTrade/hooks/useGetTradeQuotes/getTradeQuoteArgs'
 import { useReceiveAddress } from 'components/MultiHopTrade/hooks/useReceiveAddress'
-import { useIsSnapInstalled } from 'hooks/useIsSnapInstalled/useIsSnapInstalled'
 import { useWallet } from 'hooks/useWallet/useWallet'
 import { useWalletSupportsChain } from 'hooks/useWalletSupportsChain/useWalletSupportsChain'
 import { bn, bnOrZero } from 'lib/bignumber/bignumber'
@@ -151,12 +150,7 @@ export const useGetTradeQuotes = () => {
     [isSnapshotApiQueriesPending, votingPower],
   )
 
-  const isSnapInstalled = useIsSnapInstalled()
-  const walletSupportsBuyAssetChain = useWalletSupportsChain({
-    chainId: buyAsset.chainId,
-    wallet,
-    isSnapInstalled,
-  })
+  const walletSupportsBuyAssetChain = useWalletSupportsChain(buyAsset.chainId, wallet)
   const isBuyAssetChainSupported = walletSupportsBuyAssetChain
 
   const shouldRefetchTradeQuotes = useMemo(

--- a/src/components/TransactionHistory/AssetTransactionHistory.tsx
+++ b/src/components/TransactionHistory/AssetTransactionHistory.tsx
@@ -6,7 +6,6 @@ import { useTranslate } from 'react-polyglot'
 import { useLocation } from 'react-router'
 import { NavLink } from 'react-router-dom'
 import { TransactionHistoryList } from 'components/TransactionHistory/TransactionHistoryList'
-import { useIsSnapInstalled } from 'hooks/useIsSnapInstalled/useIsSnapInstalled'
 import { useWallet } from 'hooks/useWallet/useWallet'
 import { useWalletSupportsChain } from 'hooks/useWalletSupportsChain/useWalletSupportsChain'
 import { selectAssetById, selectTxIdsByFilter } from 'state/slices/selectors'
@@ -38,8 +37,7 @@ export const AssetTransactionHistory: React.FC<AssetTransactionHistoryProps> = (
     return ''
   })()
 
-  const isSnapInstalled = useIsSnapInstalled()
-  const walletSupportsChain = useWalletSupportsChain({ chainId, wallet, isSnapInstalled })
+  const walletSupportsChain = useWalletSupportsChain(chainId, wallet)
 
   const filter = useMemo(() => ({ assetId, accountId }), [assetId, accountId])
   const txIds = useAppSelector(state => selectTxIdsByFilter(state, filter))

--- a/src/hooks/useWalletSupportsChain/useWalletSupportsChain.ts
+++ b/src/hooks/useWalletSupportsChain/useWalletSupportsChain.ts
@@ -30,6 +30,7 @@ import {
   supportsThorchain,
 } from '@shapeshiftoss/hdwallet-core'
 import { MetaMaskShapeShiftMultiChainHDWallet } from '@shapeshiftoss/hdwallet-shapeshift-multichain'
+import { useMemo } from 'react'
 import { useIsSnapInstalled } from 'hooks/useIsSnapInstalled/useIsSnapInstalled'
 
 type WalletSupportsChainArgs = {
@@ -92,5 +93,9 @@ export const useWalletSupportsChain = (
   // If this evaluates to false, the wallet feature detection will be short circuit in supportsBTC, supportsCosmos and supports Thorchain methods
   const isSnapInstalled = useIsSnapInstalled()
 
-  return walletSupportsChain({ isSnapInstalled, chainId, wallet })
+  const result = useMemo(() => {
+    return walletSupportsChain({ isSnapInstalled, chainId, wallet })
+  }, [chainId, isSnapInstalled, wallet])
+
+  return result
 }

--- a/src/hooks/useWalletSupportsChain/useWalletSupportsChain.ts
+++ b/src/hooks/useWalletSupportsChain/useWalletSupportsChain.ts
@@ -32,19 +32,18 @@ import {
 import { MetaMaskShapeShiftMultiChainHDWallet } from '@shapeshiftoss/hdwallet-shapeshift-multichain'
 import { useIsSnapInstalled } from 'hooks/useIsSnapInstalled/useIsSnapInstalled'
 
-type UseWalletSupportsChainArgs = {
+type WalletSupportsChainArgs = {
   isSnapInstalled: boolean | null
   chainId: ChainId
   wallet: HDWallet | null
 }
-type UseWalletSupportsChain = (args: UseWalletSupportsChainArgs) => boolean | null
 
 // use outside react
-export const walletSupportsChain: UseWalletSupportsChain = ({
+export const walletSupportsChain = ({
   chainId,
   wallet,
   isSnapInstalled,
-}) => {
+}: WalletSupportsChainArgs): boolean | null => {
   if (!wallet) return false
   const isMetaMaskMultichainWallet = wallet instanceof MetaMaskShapeShiftMultiChainHDWallet
   // Naming is slightly weird there, but the intent is if this evaluates to false, it acts as a short circuit
@@ -82,7 +81,10 @@ export const walletSupportsChain: UseWalletSupportsChain = ({
   }
 }
 
-export const useWalletSupportsChain: UseWalletSupportsChain = args => {
+export const useWalletSupportsChain = (
+  chainId: ChainId,
+  wallet: HDWallet | null,
+): boolean | null => {
   // We might be in a state where the wallet adapter is MetaMaskShapeShiftMultiChainHDWallet, but the actual underlying wallet
   // doesn't have multichain capabilities since snaps isn't installed
   // This should obviously belong at hdwallet-core, and feature detection should be made async, with hdwallet-shapeshift-multichain able to do feature detection
@@ -90,5 +92,5 @@ export const useWalletSupportsChain: UseWalletSupportsChain = args => {
   // If this evaluates to false, the wallet feature detection will be short circuit in supportsBTC, supportsCosmos and supports Thorchain methods
   const isSnapInstalled = useIsSnapInstalled()
 
-  return walletSupportsChain({ ...args, isSnapInstalled })
+  return walletSupportsChain({ isSnapInstalled, chainId, wallet })
 }


### PR DESCRIPTION
## Description

Adds a higher order component in specific locations in the trade input to avoid mounting heavy components until they are required. The aim here is to speed up boot time and offload mount cost to when a component is needed.

Includes a cleanup of `useWalletSupportsChain` to accept individual props rather than an object which was causing rerendering to occur.

## Pull Request Type

- [ ] :bug: Bug fix (Non-breaking Change: Fixes an issue)
- [x] :hammer_and_wrench: Chore (Non-breaking Change: Doc updates, pkg upgrades, typos, etc..)
- [ ] :nail_care: New Feature (Breaking/Non-breaking Change)

## Issue (if applicable)

closes #6307

## Risk
> High Risk PRs Require 2 approvals

Moderate risk of something breaking in the trade input interface, though this doesn't modify business logic.

> What protocols, transaction types or contract interactions might be affected by this PR?

## Testing

Ensure the trade input and quotes are working as intended.

### Engineering

<!-----------------------------------------------------------------------------
Include sufficient information here for an engineer to test your PR. This may include how to test locally, in a built environment, changes to infrastructure etc.
------------------------------------------------------------------------------>

### Operations

<!-----------------------------------------------------------------------------
If your changes have a user-facing impact, describe how a non-technical QA team can functionally test your changes in a preview environment.

If they are not user-facing please describe how to test for any regressions that may occur.
------------------------------------------------------------------------------>

## Screenshots (if applicable)
