### PR TITLE
perf: general rendering improvements for trade input

### DIFF
--- a/src/components/AccountDropdown/AccountDropdown.tsx
+++ b/src/components/AccountDropdown/AccountDropdown.tsx
@@ -317,7 +317,7 @@ export const AccountDropdown: FC<AccountDropdownProps> = memo(
 
     return (
       <Box px={2} my={2} {...boxProps}>
-        <Menu closeOnSelect={true} autoSelect={false} flip>
+        <Menu isLazy closeOnSelect={true} autoSelect={false} flip>
           <MenuButton
             iconSpacing={1}
             as={Button}

--- a/src/components/AssetSelection/AssetSelection.tsx
+++ b/src/components/AssetSelection/AssetSelection.tsx
@@ -3,7 +3,7 @@ import type { ButtonProps, FlexProps } from '@chakra-ui/react'
 import { Flex } from '@chakra-ui/react'
 import type { AssetId } from '@shapeshiftoss/caip'
 import type { Asset } from '@shapeshiftoss/types'
-import { useCallback, useMemo } from 'react'
+import { memo, useCallback, useMemo } from 'react'
 import { Text } from 'components/Text'
 import { selectAssets } from 'state/slices/selectors'
 import { useAppSelector } from 'state/store'
@@ -34,16 +34,40 @@ type TradeAssetSelectEditableProps = {
 
 type TradeAssetSelectProps = TradeAssetSelectReadonlyProps | TradeAssetSelectEditableProps
 
-export const TradeAssetSelect: React.FC<TradeAssetSelectProps> = ({
-  onAssetClick,
-  onAssetChange,
-  assetId,
-  assetIds,
-  isReadOnly,
-  isLoading,
-  buttonProps,
-  ...rest
-}) => {
+export const TradeAssetSelect: React.FC<TradeAssetSelectProps> = memo(props => {
+  const {
+    onAssetClick,
+    onAssetChange,
+    assetId,
+    assetIds,
+    isReadOnly,
+    isLoading,
+    buttonProps,
+    flexProps,
+  } = useMemo(() => {
+    const {
+      onAssetClick,
+      onAssetChange,
+      assetId,
+      assetIds,
+      isReadOnly,
+      isLoading,
+      buttonProps,
+      ...flexProps
+    } = props
+    return {
+      onAssetClick,
+      onAssetChange,
+      assetId,
+      assetIds,
+      isReadOnly,
+      isLoading,
+      buttonProps,
+      flexProps,
+    }
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, [Object.values(props)])
+
   const assets = useAppSelector(selectAssets)
 
   const handleAssetChange = useCallback(
@@ -75,7 +99,7 @@ export const TradeAssetSelect: React.FC<TradeAssetSelectProps> = ({
   }, [rightIcon, buttonProps])
 
   return (
-    <Flex px={4} mb={4} alignItems='center' gap={2} {...rest}>
+    <Flex px={4} mb={4} alignItems='center' gap={2} {...flexProps}>
       <AssetMenuButton
         assetId={assetId}
         onAssetClick={onAssetClick}
@@ -93,4 +117,4 @@ export const TradeAssetSelect: React.FC<TradeAssetSelectProps> = ({
       />
     </Flex>
   )
-}
+})

--- a/src/components/AssetSelection/AssetSelection.tsx
+++ b/src/components/AssetSelection/AssetSelection.tsx
@@ -66,7 +66,7 @@ export const TradeAssetSelect: React.FC<TradeAssetSelectProps> = memo(props => {
       flexProps,
     }
     // eslint-disable-next-line react-hooks/exhaustive-deps
-  }, [Object.values(props)])
+  }, Object.values(props))
 
   const assets = useAppSelector(selectAssets)
 

--- a/src/components/AssetSelection/components/AssetChainDropdown/AssetChainDropdown.tsx
+++ b/src/components/AssetSelection/components/AssetChainDropdown/AssetChainDropdown.tsx
@@ -9,7 +9,7 @@ import {
   Tooltip,
 } from '@chakra-ui/react'
 import type { AssetId } from '@shapeshiftoss/caip'
-import { useCallback, useMemo } from 'react'
+import { memo, useCallback, useMemo } from 'react'
 import { useTranslate } from 'react-polyglot'
 import { useWallet } from 'hooks/useWallet/useWallet'
 import { isAssetSupportedByWallet } from 'state/slices/portfolioSlice/utils'
@@ -31,82 +31,77 @@ type AssetChainDropdownProps = {
   isError?: boolean
 }
 
-export const AssetChainDropdown: React.FC<AssetChainDropdownProps> = ({
-  assetId,
-  assetIds,
-  onChangeAsset,
-  buttonProps,
-  isLoading,
-  isError,
-}) => {
-  const {
-    state: { wallet },
-  } = useWallet()
-  const translate = useTranslate()
-  const chainDisplayName = useAppSelector(state =>
-    selectChainDisplayNameByAssetId(state, assetId ?? ''),
-  )
-  const relatedAssetIds = useAppSelector(state =>
-    selectRelatedAssetIdsInclusiveSorted(state, assetId ?? ''),
-  )
+export const AssetChainDropdown: React.FC<AssetChainDropdownProps> = memo(
+  ({ assetId, assetIds, onChangeAsset, buttonProps, isLoading, isError }) => {
+    const {
+      state: { wallet },
+    } = useWallet()
+    const translate = useTranslate()
+    const chainDisplayName = useAppSelector(state =>
+      selectChainDisplayNameByAssetId(state, assetId ?? ''),
+    )
+    const relatedAssetIds = useAppSelector(state =>
+      selectRelatedAssetIdsInclusiveSorted(state, assetId ?? ''),
+    )
 
-  const filteredRelatedAssetIds = useMemo(() => {
-    if (!assetIds?.length) return relatedAssetIds
-    return relatedAssetIds.filter(relatedAssetId => assetIds.includes(relatedAssetId))
-  }, [assetIds, relatedAssetIds])
+    const filteredRelatedAssetIds = useMemo(() => {
+      if (!assetIds?.length) return relatedAssetIds
+      return relatedAssetIds.filter(relatedAssetId => assetIds.includes(relatedAssetId))
+    }, [assetIds, relatedAssetIds])
 
-  const renderChains = useMemo(() => {
-    return filteredRelatedAssetIds.map(assetId => {
-      const isSupported = wallet && isAssetSupportedByWallet(assetId, wallet)
+    const renderChains = useMemo(() => {
+      return filteredRelatedAssetIds.map(assetId => {
+        const isSupported = wallet && isAssetSupportedByWallet(assetId, wallet)
 
-      return (
-        <MenuItemOption value={assetId} key={assetId} isDisabled={!isSupported}>
-          <AssetChainRow assetId={assetId} />
-        </MenuItemOption>
-      )
-    })
-  }, [filteredRelatedAssetIds, wallet])
+        return (
+          <MenuItemOption value={assetId} key={assetId} isDisabled={!isSupported}>
+            <AssetChainRow assetId={assetId} />
+          </MenuItemOption>
+        )
+      })
+    }, [filteredRelatedAssetIds, wallet])
 
-  const handleChangeAsset = useCallback(
-    (value: string | string[]) => {
-      // this should never happen, but in case it does...
-      if (typeof value !== 'string') {
-        console.error('expected string value')
-        return
-      }
-      onChangeAsset(value as AssetId)
-    },
-    [onChangeAsset],
-  )
+    const handleChangeAsset = useCallback(
+      (value: string | string[]) => {
+        // this should never happen, but in case it does...
+        if (typeof value !== 'string') {
+          console.error('expected string value')
+          return
+        }
+        onChangeAsset(value as AssetId)
+      },
+      [onChangeAsset],
+    )
 
-  const isDisabled = useMemo(() => {
-    return filteredRelatedAssetIds.length <= 1 || isLoading || isError
-  }, [filteredRelatedAssetIds, isError, isLoading])
+    const isDisabled = useMemo(() => {
+      return filteredRelatedAssetIds.length <= 1 || isLoading || isError
+    }, [filteredRelatedAssetIds, isError, isLoading])
 
-  const isTooltipDisabled = useMemo(() => {
-    // only render the tooltip when there are no other related assets and we're not loading and not
-    // errored
-    return filteredRelatedAssetIds.length > 1 || isLoading || isError
-  }, [filteredRelatedAssetIds, isError, isLoading])
+    const isTooltipDisabled = useMemo(() => {
+      // only render the tooltip when there are no other related assets and we're not loading and not
+      // errored
+      return filteredRelatedAssetIds.length > 1 || isLoading || isError
+    }, [filteredRelatedAssetIds, isError, isLoading])
 
-  const buttonTooltipText = useMemo(() => {
-    return translate('trade.tooltip.noRelatedAssets', { chainDisplayName })
-  }, [chainDisplayName, translate])
+    const buttonTooltipText = useMemo(() => {
+      return translate('trade.tooltip.noRelatedAssets', { chainDisplayName })
+    }, [chainDisplayName, translate])
 
-  if (!assetId || isLoading) return <AssetRowLoading {...buttonProps} />
+    if (!assetId || isLoading) return <AssetRowLoading {...buttonProps} />
 
-  return (
-    <Menu>
-      <Tooltip isDisabled={isTooltipDisabled} label={buttonTooltipText}>
-        <MenuButton as={Button} isDisabled={isDisabled} {...buttonProps}>
-          <AssetChainRow assetId={assetId} hideBalances />
-        </MenuButton>
-      </Tooltip>
-      <MenuList zIndex='banner'>
-        <MenuOptionGroup type='radio' value={assetId} onChange={handleChangeAsset}>
-          {renderChains}
-        </MenuOptionGroup>
-      </MenuList>
-    </Menu>
-  )
-}
+    return (
+      <Menu isLazy>
+        <Tooltip isDisabled={isTooltipDisabled} label={buttonTooltipText}>
+          <MenuButton as={Button} isDisabled={isDisabled} {...buttonProps}>
+            <AssetChainRow assetId={assetId} hideBalances />
+          </MenuButton>
+        </Tooltip>
+        <MenuList zIndex='banner'>
+          <MenuOptionGroup type='radio' value={assetId} onChange={handleChangeAsset}>
+            {renderChains}
+          </MenuOptionGroup>
+        </MenuList>
+      </Menu>
+    )
+  },
+)

--- a/src/components/MultiHopTrade/components/QuoteList/QuoteList.tsx
+++ b/src/components/MultiHopTrade/components/QuoteList/QuoteList.tsx
@@ -21,7 +21,7 @@ export const QuoteList: React.FC<QuoteListProps> = props => {
       cardProps,
     }
     // eslint-disable-next-line react-hooks/exhaustive-deps
-  }, [Object.values(props)])
+  }, Object.values(props))
 
   return (
     <Card {...cardProps}>

--- a/src/components/MultiHopTrade/components/SlippagePopover.tsx
+++ b/src/components/MultiHopTrade/components/SlippagePopover.tsx
@@ -114,7 +114,7 @@ export const SlippagePopover: FC = memo(() => {
   if (!isAdvancedSlippageEnabled) return null
 
   return (
-    <Popover placement='bottom-end' onClose={handleClose}>
+    <Popover isLazy placement='bottom-end' onClose={handleClose}>
       <PopoverTrigger>
         <IconButton aria-label={translate('trade.tradeSettings')} icon={faGear} variant='ghost' />
       </PopoverTrigger>

--- a/src/components/MultiHopTrade/components/TradeInput/components/TradeQuotes/TradeQuote.tsx
+++ b/src/components/MultiHopTrade/components/TradeInput/components/TradeQuotes/TradeQuote.tsx
@@ -3,7 +3,7 @@ import { Flex, Skeleton, Tag, Tooltip } from '@chakra-ui/react'
 import type { AssetId } from '@shapeshiftoss/caip'
 import { TradeQuoteError as SwapperTradeQuoteError } from '@shapeshiftoss/swapper'
 import type { FC } from 'react'
-import { useCallback, useMemo } from 'react'
+import { memo, useCallback, useMemo } from 'react'
 import { useTranslate } from 'react-polyglot'
 import { useIsTradingActive } from 'react-queries/hooks/useIsTradingActive'
 import { Amount } from 'components/Amount/Amount'
@@ -45,289 +45,293 @@ type TradeQuoteProps = {
   onBack?: () => void
 }
 
-export const TradeQuoteLoaded: FC<TradeQuoteProps> = ({
-  isActive,
-  isBest,
-  quoteData,
-  bestTotalReceiveAmountCryptoPrecision,
-  bestInputOutputRatio,
-  isLoading,
-  isRefetching,
-  onBack,
-}) => {
-  const { quote, errors, inputOutputRatio, swapperName } = quoteData
+export const TradeQuote: FC<TradeQuoteProps> = memo(
+  ({
+    isActive,
+    isBest,
+    quoteData,
+    bestTotalReceiveAmountCryptoPrecision,
+    bestInputOutputRatio,
+    isLoading,
+    isRefetching,
+    onBack,
+  }) => {
+    const { quote, errors, inputOutputRatio, swapperName } = quoteData
 
-  const dispatch = useAppDispatch()
-  const translate = useTranslate()
+    const dispatch = useAppDispatch()
+    const translate = useTranslate()
 
-  const {
-    number: { toPercent },
-  } = useLocaleFormatter()
+    const {
+      number: { toPercent },
+    } = useLocaleFormatter()
 
-  const buyAsset = useAppSelector(selectInputBuyAsset)
-  const sellAsset = useAppSelector(selectInputSellAsset)
-  const { isTradingActive: isTradingActiveOnBuyPool } = useIsTradingActive({
-    assetId: buyAsset.assetId,
-    swapperName,
-    enabled: true,
-  })
-  const { isTradingActive: isTradingActiveOnSellPool } = useIsTradingActive({
-    assetId: sellAsset.assetId,
-    swapperName,
-    enabled: true,
-  })
+    const buyAsset = useAppSelector(selectInputBuyAsset)
+    const sellAsset = useAppSelector(selectInputSellAsset)
+    const { isTradingActive: isTradingActiveOnBuyPool } = useIsTradingActive({
+      assetId: buyAsset.assetId,
+      swapperName,
+      enabled: true,
+    })
+    const { isTradingActive: isTradingActiveOnSellPool } = useIsTradingActive({
+      assetId: sellAsset.assetId,
+      swapperName,
+      enabled: true,
+    })
 
-  const isTradingActive = Boolean(isTradingActiveOnBuyPool && isTradingActiveOnSellPool)
+    const isTradingActive = Boolean(isTradingActiveOnBuyPool && isTradingActiveOnSellPool)
 
-  const userSlippagePercentageDecimal = useAppSelector(selectUserSlippagePercentageDecimal)
+    const userSlippagePercentageDecimal = useAppSelector(selectUserSlippagePercentageDecimal)
 
-  const buyAssetMarketData = useAppSelector(state =>
-    selectMarketDataById(state, buyAsset.assetId ?? ''),
-  )
+    const buyAssetMarketData = useAppSelector(state =>
+      selectMarketDataById(state, buyAsset.assetId ?? ''),
+    )
 
-  const sellAmountCryptoPrecision = useAppSelector(selectInputSellAmountCryptoPrecision)
+    const sellAmountCryptoPrecision = useAppSelector(selectInputSellAmountCryptoPrecision)
 
-  // NOTE: don't pull this from the slice - we're not displaying the active quote here
-  const networkFeeUserCurrencyPrecision = useMemo(() => {
-    if (!quote) return
-    const state = store.getState()
-    const getFeeAsset = (assetId: AssetId) => {
-      const feeAsset = selectFeeAssetById(state, assetId)
-      if (feeAsset === undefined) {
-        throw Error(`missing fee asset for assetId ${assetId}`)
+    // NOTE: don't pull this from the slice - we're not displaying the active quote here
+    const networkFeeUserCurrencyPrecision = useMemo(() => {
+      if (!quote) return
+      const state = store.getState()
+      const getFeeAsset = (assetId: AssetId) => {
+        const feeAsset = selectFeeAssetById(state, assetId)
+        if (feeAsset === undefined) {
+          throw Error(`missing fee asset for assetId ${assetId}`)
+        }
+        return feeAsset
       }
-      return feeAsset
-    }
-    const getFeeAssetUserCurrencyRate = (feeAssetId: AssetId) =>
-      selectMarketDataByFilter(state, {
-        assetId: feeAssetId,
-      }).price
+      const getFeeAssetUserCurrencyRate = (feeAssetId: AssetId) =>
+        selectMarketDataByFilter(state, {
+          assetId: feeAssetId,
+        }).price
 
-    return getTotalNetworkFeeUserCurrencyPrecision(
-      quote,
-      getFeeAsset,
-      getFeeAssetUserCurrencyRate,
-    ).toString()
-  }, [quote])
+      return getTotalNetworkFeeUserCurrencyPrecision(
+        quote,
+        getFeeAsset,
+        getFeeAssetUserCurrencyRate,
+      ).toString()
+    }, [quote])
 
-  // NOTE: don't pull this from the slice - we're not displaying the active quote here
-  const totalReceiveAmountCryptoPrecision = useMemo(
-    () =>
-      quote
-        ? getBuyAmountAfterFeesCryptoPrecision({
-            quote,
-          })
-        : '0',
-    [quote],
-  )
+    // NOTE: don't pull this from the slice - we're not displaying the active quote here
+    const totalReceiveAmountCryptoPrecision = useMemo(
+      () =>
+        quote
+          ? getBuyAmountAfterFeesCryptoPrecision({
+              quote,
+            })
+          : '0',
+      [quote],
+    )
 
-  const totalReceiveAmountFiatPrecision = useMemo(
-    () =>
-      bn(totalReceiveAmountCryptoPrecision)
-        .times(buyAssetMarketData.price ?? 0)
-        .toString(),
-    [buyAssetMarketData.price, totalReceiveAmountCryptoPrecision],
-  )
+    const totalReceiveAmountFiatPrecision = useMemo(
+      () =>
+        bn(totalReceiveAmountCryptoPrecision)
+          .times(buyAssetMarketData.price ?? 0)
+          .toString(),
+      [buyAssetMarketData.price, totalReceiveAmountCryptoPrecision],
+    )
 
-  const handleQuoteSelection = useCallback(() => {
-    if (!isActive) {
-      dispatch(tradeQuoteSlice.actions.setActiveQuote(quoteData))
-      onBack && onBack()
-    } else if (!isBest) {
-      // don't allow un-selecting of best quote as it gets re-selected in this case
-      dispatch(tradeQuoteSlice.actions.setActiveQuote(undefined))
-    }
-  }, [dispatch, isActive, isBest, onBack, quoteData])
+    const handleQuoteSelection = useCallback(() => {
+      if (!isActive) {
+        dispatch(tradeQuoteSlice.actions.setActiveQuote(quoteData))
+        onBack && onBack()
+      } else if (!isBest) {
+        // don't allow un-selecting of best quote as it gets re-selected in this case
+        dispatch(tradeQuoteSlice.actions.setActiveQuote(undefined))
+      }
+    }, [dispatch, isActive, isBest, onBack, quoteData])
 
-  const feeAsset = useAppSelector(state => selectFeeAssetByChainId(state, sellAsset.chainId ?? ''))
-  if (!feeAsset)
-    throw new Error(`TradeQuoteLoaded: no fee asset found for chainId ${sellAsset.chainId}!`)
+    const feeAsset = useAppSelector(state =>
+      selectFeeAssetByChainId(state, sellAsset.chainId ?? ''),
+    )
+    if (!feeAsset)
+      throw new Error(`TradeQuoteLoaded: no fee asset found for chainId ${sellAsset.chainId}!`)
 
-  // the difference percentage is on the receive amount only
-  const quoteAmountDifferenceDecimalPercentage = useMemo(() => {
-    if (!quote || !bestTotalReceiveAmountCryptoPrecision) return
-    return bn(1)
-      .minus(bn(totalReceiveAmountCryptoPrecision).dividedBy(bestTotalReceiveAmountCryptoPrecision))
-      .toNumber()
-  }, [bestTotalReceiveAmountCryptoPrecision, quote, totalReceiveAmountCryptoPrecision])
-
-  const quoteOverallDifferenceDecimalPercentage = useMemo(() => {
-    if (!quote || !bestInputOutputRatio) return
-    return -bn(1).minus(bn(inputOutputRatio).dividedBy(bestInputOutputRatio)).toNumber()
-  }, [bestInputOutputRatio, inputOutputRatio, quote])
-
-  const isAmountEntered = bnOrZero(sellAmountCryptoPrecision).gt(0)
-  const hasNegativeRatio =
-    inputOutputRatio !== undefined && isAmountEntered && inputOutputRatio <= 0
-
-  const hasAmountWithPositiveReceive =
-    isAmountEntered &&
-    !hasNegativeRatio &&
-    bnOrZero(totalReceiveAmountCryptoPrecision).isGreaterThan(0)
-
-  const tag: JSX.Element = useMemo(() => {
-    const error = errors?.[0]
-    const defaultError = { error: TradeQuoteValidationError.UnknownError }
-
-    switch (true) {
-      case !quote || error !== undefined:
-        const translationParams = getQuoteErrorTranslation(error ?? defaultError)
-        return (
-          <Tag size='sm' colorScheme='red'>
-            {translate(
-              ...(Array.isArray(translationParams) ? translationParams : [translationParams]),
-            )}
-          </Tag>
+    // the difference percentage is on the receive amount only
+    const quoteAmountDifferenceDecimalPercentage = useMemo(() => {
+      if (!quote || !bestTotalReceiveAmountCryptoPrecision) return
+      return bn(1)
+        .minus(
+          bn(totalReceiveAmountCryptoPrecision).dividedBy(bestTotalReceiveAmountCryptoPrecision),
         )
-      case !hasAmountWithPositiveReceive && isAmountEntered:
-        return (
-          <Tag size='sm' colorScheme='red'>
-            {translate('trade.rates.tags.negativeRatio')}
-          </Tag>
-        )
-      case isBest:
-        return (
-          <Tag size='sm' colorScheme='green'>
-            {translate('common.best')}
-          </Tag>
-        )
-      default:
-        return (
-          <Tooltip label={translate('trade.tooltip.overallPercentageDifference')}>
-            <Tag size='sm'>
-              {quoteOverallDifferenceDecimalPercentage !== undefined && (
-                <Amount.Percent
-                  value={quoteOverallDifferenceDecimalPercentage ?? 0}
-                  autoColor={false}
-                />
+        .toNumber()
+    }, [bestTotalReceiveAmountCryptoPrecision, quote, totalReceiveAmountCryptoPrecision])
+
+    const quoteOverallDifferenceDecimalPercentage = useMemo(() => {
+      if (!quote || !bestInputOutputRatio) return
+      return -bn(1).minus(bn(inputOutputRatio).dividedBy(bestInputOutputRatio)).toNumber()
+    }, [bestInputOutputRatio, inputOutputRatio, quote])
+
+    const isAmountEntered = bnOrZero(sellAmountCryptoPrecision).gt(0)
+    const hasNegativeRatio =
+      inputOutputRatio !== undefined && isAmountEntered && inputOutputRatio <= 0
+
+    const hasAmountWithPositiveReceive =
+      isAmountEntered &&
+      !hasNegativeRatio &&
+      bnOrZero(totalReceiveAmountCryptoPrecision).isGreaterThan(0)
+
+    const tag: JSX.Element = useMemo(() => {
+      const error = errors?.[0]
+      const defaultError = { error: TradeQuoteValidationError.UnknownError }
+
+      switch (true) {
+        case !quote || error !== undefined:
+          const translationParams = getQuoteErrorTranslation(error ?? defaultError)
+          return (
+            <Tag size='sm' colorScheme='red'>
+              {translate(
+                ...(Array.isArray(translationParams) ? translationParams : [translationParams]),
               )}
             </Tag>
-          </Tooltip>
-        )
-    }
-  }, [
-    errors,
-    quote,
-    translate,
-    hasAmountWithPositiveReceive,
-    isAmountEntered,
-    isBest,
-    quoteOverallDifferenceDecimalPercentage,
-  ])
+          )
+        case !hasAmountWithPositiveReceive && isAmountEntered:
+          return (
+            <Tag size='sm' colorScheme='red'>
+              {translate('trade.rates.tags.negativeRatio')}
+            </Tag>
+          )
+        case isBest:
+          return (
+            <Tag size='sm' colorScheme='green'>
+              {translate('common.best')}
+            </Tag>
+          )
+        default:
+          return (
+            <Tooltip label={translate('trade.tooltip.overallPercentageDifference')}>
+              <Tag size='sm'>
+                {quoteOverallDifferenceDecimalPercentage !== undefined && (
+                  <Amount.Percent
+                    value={quoteOverallDifferenceDecimalPercentage ?? 0}
+                    autoColor={false}
+                  />
+                )}
+              </Tag>
+            </Tooltip>
+          )
+      }
+    }, [
+      errors,
+      quote,
+      translate,
+      hasAmountWithPositiveReceive,
+      isAmountEntered,
+      isBest,
+      quoteOverallDifferenceDecimalPercentage,
+    ])
 
-  const isDisabled = !quote || isLoading
-  const showSwapperError = ![
-    TradeQuoteValidationError.UnknownError,
-    SwapperTradeQuoteError.UnknownError,
-  ].includes(errors?.[0]?.error)
-  const showSwapper = !!quote || showSwapperError
+    const isDisabled = !quote || isLoading
+    const showSwapperError = ![
+      TradeQuoteValidationError.UnknownError,
+      SwapperTradeQuoteError.UnknownError,
+    ].includes(errors?.[0]?.error)
+    const showSwapper = !!quote || showSwapperError
 
-  const totalEstimatedExecutionTimeMs = useMemo(
-    () =>
-      quote?.steps.reduce((acc, step) => {
-        return acc + (step.estimatedExecutionTimeMs ?? 0)
-      }, 0),
-    [quote?.steps],
-  )
+    const totalEstimatedExecutionTimeMs = useMemo(
+      () =>
+        quote?.steps.reduce((acc, step) => {
+          return acc + (step.estimatedExecutionTimeMs ?? 0)
+        }, 0),
+      [quote?.steps],
+    )
 
-  const slippage = useMemo(() => {
-    if (!quote) return
+    const slippage = useMemo(() => {
+      if (!quote) return
 
-    // user slippage setting was not applied if:
-    // - the user did not input a custom value
-    // - the slippage on the quote is different to the custom value
-    const isUserSlippageNotApplied =
-      userSlippagePercentageDecimal !== undefined &&
-      quote.slippageTolerancePercentageDecimal !== userSlippagePercentageDecimal
+      // user slippage setting was not applied if:
+      // - the user did not input a custom value
+      // - the slippage on the quote is different to the custom value
+      const isUserSlippageNotApplied =
+        userSlippagePercentageDecimal !== undefined &&
+        quote.slippageTolerancePercentageDecimal !== userSlippagePercentageDecimal
 
-    if (!isUserSlippageNotApplied && quote.slippageTolerancePercentageDecimal === undefined) {
-      return
-    }
-
-    const tooltip = (() => {
-      if (isUserSlippageNotApplied) {
-        return translate('trade.quote.cantSetSlippage', {
-          userSlippageFormatted: toPercent(userSlippagePercentageDecimal),
-          swapperName,
-        })
+      if (!isUserSlippageNotApplied && quote.slippageTolerancePercentageDecimal === undefined) {
+        return
       }
 
-      return translate('trade.quote.slippage', {
-        slippageFormatted: toPercent(quote.slippageTolerancePercentageDecimal ?? '0'),
-      })
-    })()
+      const tooltip = (() => {
+        if (isUserSlippageNotApplied) {
+          return translate('trade.quote.cantSetSlippage', {
+            userSlippageFormatted: toPercent(userSlippagePercentageDecimal),
+            swapperName,
+          })
+        }
 
-    return (
-      <Skeleton isLoaded={!isLoading}>
-        <Tooltip label={tooltip}>
-          <Flex gap={2} alignItems='center'>
-            <RawText color={isUserSlippageNotApplied ? 'text.error' : 'text.subtle'}>
-              <SlippageIcon />
-            </RawText>
-            {quote.slippageTolerancePercentageDecimal !== undefined && (
-              <RawText color={isUserSlippageNotApplied ? 'text.error' : undefined}>
-                {toPercent(quote.slippageTolerancePercentageDecimal)}
+        return translate('trade.quote.slippage', {
+          slippageFormatted: toPercent(quote.slippageTolerancePercentageDecimal ?? '0'),
+        })
+      })()
+
+      return (
+        <Skeleton isLoaded={!isLoading}>
+          <Tooltip label={tooltip}>
+            <Flex gap={2} alignItems='center'>
+              <RawText color={isUserSlippageNotApplied ? 'text.error' : 'text.subtle'}>
+                <SlippageIcon />
               </RawText>
-            )}
-            {isUserSlippageNotApplied && <WarningIcon color='text.error' />}
-          </Flex>
-        </Tooltip>
-      </Skeleton>
-    )
-  }, [isLoading, quote, swapperName, toPercent, translate, userSlippagePercentageDecimal])
+              {quote.slippageTolerancePercentageDecimal !== undefined && (
+                <RawText color={isUserSlippageNotApplied ? 'text.error' : undefined}>
+                  {toPercent(quote.slippageTolerancePercentageDecimal)}
+                </RawText>
+              )}
+              {isUserSlippageNotApplied && <WarningIcon color='text.error' />}
+            </Flex>
+          </Tooltip>
+        </Skeleton>
+      )
+    }, [isLoading, quote, swapperName, toPercent, translate, userSlippagePercentageDecimal])
 
-  const headerContent = useMemo(() => {
-    return (
-      <Flex gap={2} alignItems='center'>
-        <Skeleton isLoaded={!isLoading}>{tag}</Skeleton>
-        <CountdownSpinner isLoading={isLoading || isRefetching} />
-      </Flex>
-    )
-  }, [isLoading, isRefetching, tag])
+    const headerContent = useMemo(() => {
+      return (
+        <Flex gap={2} alignItems='center'>
+          <Skeleton isLoaded={!isLoading}>{tag}</Skeleton>
+          <CountdownSpinner isLoading={isLoading || isRefetching} />
+        </Flex>
+      )
+    }, [isLoading, isRefetching, tag])
 
-  const bodyContent = useMemo(() => {
-    return quote ? (
-      <TradeQuoteContent
-        isLoading={isLoading}
-        buyAsset={buyAsset}
-        isBest={isBest}
-        numHops={quote?.steps.length}
-        totalReceiveAmountFiatPrecision={totalReceiveAmountFiatPrecision}
-        hasAmountWithPositiveReceive={hasAmountWithPositiveReceive}
-        totalReceiveAmountCryptoPrecision={totalReceiveAmountCryptoPrecision}
-        quoteDifferenceDecimalPercentage={quoteAmountDifferenceDecimalPercentage}
-        networkFeeUserCurrencyPrecision={networkFeeUserCurrencyPrecision}
-        totalEstimatedExecutionTimeMs={totalEstimatedExecutionTimeMs}
-        slippage={slippage}
-        tradeQuote={quote}
+    const bodyContent = useMemo(() => {
+      return quote ? (
+        <TradeQuoteContent
+          isLoading={isLoading}
+          buyAsset={buyAsset}
+          isBest={isBest}
+          numHops={quote?.steps.length}
+          totalReceiveAmountFiatPrecision={totalReceiveAmountFiatPrecision}
+          hasAmountWithPositiveReceive={hasAmountWithPositiveReceive}
+          totalReceiveAmountCryptoPrecision={totalReceiveAmountCryptoPrecision}
+          quoteDifferenceDecimalPercentage={quoteAmountDifferenceDecimalPercentage}
+          networkFeeUserCurrencyPrecision={networkFeeUserCurrencyPrecision}
+          totalEstimatedExecutionTimeMs={totalEstimatedExecutionTimeMs}
+          slippage={slippage}
+          tradeQuote={quote}
+        />
+      ) : null
+    }, [
+      buyAsset,
+      hasAmountWithPositiveReceive,
+      isBest,
+      isLoading,
+      networkFeeUserCurrencyPrecision,
+      quote,
+      quoteAmountDifferenceDecimalPercentage,
+      slippage,
+      totalEstimatedExecutionTimeMs,
+      totalReceiveAmountCryptoPrecision,
+      totalReceiveAmountFiatPrecision,
+    ])
+
+    return showSwapper ? (
+      <TradeQuoteCard
+        title={quote?.steps[0].source ?? quoteData.swapperName}
+        swapperName={quoteData.swapperName}
+        headerContent={headerContent}
+        bodyContent={bodyContent}
+        onClick={handleQuoteSelection}
+        isActive={isActive}
+        isActionable={isTradingActive && hasAmountWithPositiveReceive && errors.length === 0}
+        isDisabled={isDisabled}
       />
     ) : null
-  }, [
-    buyAsset,
-    hasAmountWithPositiveReceive,
-    isBest,
-    isLoading,
-    networkFeeUserCurrencyPrecision,
-    quote,
-    quoteAmountDifferenceDecimalPercentage,
-    slippage,
-    totalEstimatedExecutionTimeMs,
-    totalReceiveAmountCryptoPrecision,
-    totalReceiveAmountFiatPrecision,
-  ])
-
-  return showSwapper ? (
-    <TradeQuoteCard
-      title={quote?.steps[0].source ?? quoteData.swapperName}
-      swapperName={quoteData.swapperName}
-      headerContent={headerContent}
-      bodyContent={bodyContent}
-      onClick={handleQuoteSelection}
-      isActive={isActive}
-      isActionable={isTradingActive && hasAmountWithPositiveReceive && errors.length === 0}
-      isDisabled={isDisabled}
-    />
-  ) : null
-}
-
-export const TradeQuote: FC<TradeQuoteProps> = props => <TradeQuoteLoaded {...props} />
+  },
+)

--- a/src/components/MultiHopTrade/components/TradeInput/components/WithLazyMount.tsx
+++ b/src/components/MultiHopTrade/components/TradeInput/components/WithLazyMount.tsx
@@ -22,7 +22,7 @@ export const WithLazyMount = <T extends object = {}>(props: WithLazyRenderProps<
       componentProps,
     }
     // eslint-disable-next-line react-hooks/exhaustive-deps
-  }, [Object.values(props)])
+  }, Object.values(props))
 
   useEffect(() => {
     if (!shouldUse || persistentShouldUse.current === true) {


### PR DESCRIPTION
## Description

General performance improvements to rendering for the trade input components:
* Add `isLazy` prop to menus to prevent them being rendered while closed
* Memoize `...rest` prop creation where applicable
* Wrap `memo()` around components where applicable

## Pull Request Type

- [ ] :bug: Bug fix (Non-breaking Change: Fixes an issue)
- [x] :hammer_and_wrench: Chore (Non-breaking Change: Doc updates, pkg upgrades, typos, etc..)
- [ ] :nail_care: New Feature (Breaking/Non-breaking Change)

## Issue (if applicable)

NA

## Risk
> High Risk PRs Require 2 approvals

Low risk of broken trade input. This PR doesn't modify business logic at all, so functionality should be unchanged.

> What protocols, transaction types or contract interactions might be affected by this PR?

## Testing

Ensure trade input and quotes are working as intended. This includes related asset dropdown, slippage popover, quotes, etc.

### Engineering

Recommend reviewing the code with whitespace disabled

### Operations

<!-----------------------------------------------------------------------------
If your changes have a user-facing impact, describe how a non-technical QA team can functionally test your changes in a preview environment.

If they are not user-facing please describe how to test for any regressions that may occur.
------------------------------------------------------------------------------>

## Screenshots (if applicable)
