### PR TITLE
fix: don't derive address on Ledger in Fiat Ramp

### DIFF
--- a/src/components/Modals/FiatRamps/views/FiatForm.tsx
+++ b/src/components/Modals/FiatRamps/views/FiatForm.tsx
@@ -1,5 +1,6 @@
 import type { AccountId, AssetId } from '@shapeshiftoss/caip'
 import { ethAssetId, fromAccountId } from '@shapeshiftoss/caip'
+import { isLedger } from '@shapeshiftoss/hdwallet-ledger'
 import type { Asset, PartialRecord } from '@shapeshiftoss/types'
 import { useCallback, useEffect, useMemo, useState } from 'react'
 import { useSelector } from 'react-redux'
@@ -84,7 +85,12 @@ export const FiatForm: React.FC<FiatFormProps> = ({
           const accountMetadata = portfolioAccountMetadata[accountId]
           const { accountType, bip44Params } = accountMetadata
           const { accountNumber } = bip44Params
-          const payload = { accountType, accountNumber, wallet }
+          const payload = {
+            accountType,
+            accountNumber,
+            wallet,
+            pubKey: isLedger(wallet) ? fromAccountId(accountId).account : undefined,
+          }
           const { chainId } = fromAccountId(accountId)
           const maybeAdapter = getChainAdapterManager().get(chainId)
           if (!maybeAdapter) return Promise.resolve(`no chain adapter for ${chainId}`)


### PR DESCRIPTION
## Description

Ensuring the cached AccountId's address is used, so users don't have to open the app, similar to swapper

## Pull Request Type

- [x] :bug: Bug fix (Non-breaking Change: Fixes an issue)
- [ ] :hammer_and_wrench: Chore (Non-breaking Change: Doc updates, pkg upgrades, typos, etc..)
- [ ] :nail_care: New Feature (Breaking/Non-breaking Change)

## Issue (if applicable)

<!-----------------------------------------------------------------------------
If applicable, please link to the github issue and put `closes #XXXX` in your comment to auto-close the issue that your PR fixes.
------------------------------------------------------------------------------>

closes https://github.com/shapeshift/web/issues/6318

## Risk
> High Risk PRs Require 2 approvals

<!-----------------------------------------------------------------------------
Outline the scope of your changes and the risk associated with them. You must use your discretion as an engineer to determine the potential impact of your changes.

WARNING: If your PR introduces a new on-chain transaction or modifies an existing one, please add the "High-Risk" label to this PR and ask for 2 reviewers to approve it before merging.

E.g. an upgrade to `hdwallet` or core state management would be considered higher risk, and might require a full regression test. UI or isolated view changes, or something behind a feature flag may have near zero risk. Small bug fixes might require testing isolated to the specific fix.
------------------------------------------------------------------------------>

> What protocols, transaction types or contract interactions might be affected by this PR?

Low to none, ensure fiat ramp receive address is still happy regardless of wallet being connected

## Testing

<!-----------------------------------------------------------------------------
We treat every PR to be merged with the same scrutiny as if we were merging directly to production.

Your PR will not be merged if you do not complete the sections below for our engineering and operations teams to test.
------------------------------------------------------------------------------>

- Connect Ledger to chain/s of your choice
- Ensure fiat ramp displays a receive address and doesn't error with an infinite loading state

### Engineering

<!-----------------------------------------------------------------------------
Include sufficient information here for an engineer to test your PR. This may include how to test locally, in a built environment, changes to infrastructure etc.
------------------------------------------------------------------------------>

- ☝🏽 

### Operations

<!-----------------------------------------------------------------------------
If your changes have a user-facing impact, describe how a non-technical QA team can functionally test your changes in a preview environment.

If they are not user-facing please describe how to test for any regressions that may occur.
------------------------------------------------------------------------------>

- ☝🏽 

## Screenshots (if applicable)

<img width="426" alt="image" src="https://github.com/shapeshift/web/assets/17035424/b0369542-8f2b-4710-8f4d-1e9355c75bb6">
<img width="438" alt="image" src="https://github.com/shapeshift/web/assets/17035424/c55d053b-b65e-4cd5-934e-2356bdc2b973">
