### PR TITLE
perf: make supported asset list use static list of chains

### DIFF
--- a/src/lib/swapper/constants.ts
+++ b/src/lib/swapper/constants.ts
@@ -11,6 +11,13 @@ import { thorchainSwapper } from 'lib/swapper/swappers/ThorchainSwapper/Thorchai
 import { zrxApi } from 'lib/swapper/swappers/ZrxSwapper/endpoints'
 import { zrxSwapper } from 'lib/swapper/swappers/ZrxSwapper/ZrxSwapper'
 
+import { COW_SWAP_SUPPORTED_CHAIN_IDS } from './swappers/CowSwapper/utils/constants'
+import { LIFI_SUPPORTED_CHAIN_IDS } from './swappers/LifiSwapper/utils/constants'
+import { ONE_INCH_SUPPORTED_CHAIN_IDS } from './swappers/OneInchSwapper/utils/constants'
+import { THORCHAIN_SUPPORTED_CHAIN_IDS } from './swappers/ThorchainSwapper/constants'
+import { ZRX_SUPPORTED_CHAIN_IDS } from './swappers/ZrxSwapper/utils/constants'
+import type { SupportedChainIds } from './types'
+
 export const QUOTE_TIMEOUT_MS = 60_000
 
 export const QUOTE_TIMEOUT_ERROR = makeSwapErrorRight({
@@ -18,11 +25,30 @@ export const QUOTE_TIMEOUT_ERROR = makeSwapErrorRight({
 })
 
 // PartialRecord not used to ensure exhaustiveness
-export const swappers: Record<SwapperName, (SwapperApi & Swapper) | undefined> = {
-  [SwapperName.LIFI]: { ...lifiSwapper, ...lifiApi },
-  [SwapperName.Thorchain]: { ...thorchainSwapper, ...thorchainApi },
-  [SwapperName.Zrx]: { ...zrxSwapper, ...zrxApi },
-  [SwapperName.CowSwap]: { ...cowSwapper, ...cowApi },
-  [SwapperName.OneInch]: { ...oneInchSwapper, ...oneInchApi },
+export const swappers: Record<
+  SwapperName,
+  (SwapperApi & Swapper & { supportedChainIds: SupportedChainIds }) | undefined
+> = {
+  [SwapperName.LIFI]: {
+    ...lifiSwapper,
+    ...lifiApi,
+    supportedChainIds: LIFI_SUPPORTED_CHAIN_IDS,
+  },
+  [SwapperName.Thorchain]: {
+    ...thorchainSwapper,
+    ...thorchainApi,
+    supportedChainIds: THORCHAIN_SUPPORTED_CHAIN_IDS,
+  },
+  [SwapperName.Zrx]: { ...zrxSwapper, ...zrxApi, supportedChainIds: ZRX_SUPPORTED_CHAIN_IDS },
+  [SwapperName.CowSwap]: {
+    ...cowSwapper,
+    ...cowApi,
+    supportedChainIds: COW_SWAP_SUPPORTED_CHAIN_IDS,
+  },
+  [SwapperName.OneInch]: {
+    ...oneInchSwapper,
+    ...oneInchApi,
+    supportedChainIds: ONE_INCH_SUPPORTED_CHAIN_IDS,
+  },
   [SwapperName.Test]: undefined,
 }

--- a/src/lib/swapper/swappers/CowSwapper/filterAssetIdsBySellable/filterAssetIdsBySellable.ts
+++ b/src/lib/swapper/swappers/CowSwapper/filterAssetIdsBySellable/filterAssetIdsBySellable.ts
@@ -3,14 +3,13 @@ import type { Asset } from '@shapeshiftoss/types'
 
 import { isNativeEvmAsset } from '../../utils/helpers/helpers'
 import { COWSWAP_UNSUPPORTED_ASSETS } from '../utils/blacklist'
-import { getSupportedChainIds } from '../utils/helpers/helpers'
+import { SUPPORTED_CHAIN_IDS } from '../utils/constants'
 
 export const filterAssetIdsBySellable = (assets: Asset[]): AssetId[] => {
-  const supportedChainIds = getSupportedChainIds()
   return assets
     .filter(asset => {
       return (
-        supportedChainIds.includes(asset.chainId) &&
+        SUPPORTED_CHAIN_IDS.includes(asset.chainId) &&
         !COWSWAP_UNSUPPORTED_ASSETS.includes(asset.assetId) &&
         !isNativeEvmAsset(asset.assetId)
       )

--- a/src/lib/swapper/swappers/CowSwapper/filterBuyAssetsBySellAssetId/filterBuyAssetsBySellAssetId.ts
+++ b/src/lib/swapper/swappers/CowSwapper/filterBuyAssetsBySellAssetId/filterBuyAssetsBySellAssetId.ts
@@ -3,17 +3,15 @@ import type { BuyAssetBySellIdInput } from '@shapeshiftoss/swapper'
 
 import { isNativeEvmAsset } from '../../utils/helpers/helpers'
 import { COWSWAP_UNSUPPORTED_ASSETS } from '../utils/blacklist'
-import { getSupportedChainIds } from '../utils/helpers/helpers'
+import { SUPPORTED_CHAIN_IDS } from '../utils/constants'
 
 export const filterBuyAssetsBySellAssetId = ({
   assets,
   sellAsset,
 }: BuyAssetBySellIdInput): AssetId[] => {
-  const supportedChainIds = getSupportedChainIds()
-
   if (
     sellAsset === undefined ||
-    !supportedChainIds.includes(sellAsset.chainId) ||
+    !SUPPORTED_CHAIN_IDS.includes(sellAsset.chainId) ||
     isNativeEvmAsset(sellAsset.assetId) ||
     COWSWAP_UNSUPPORTED_ASSETS.includes(sellAsset.assetId)
   ) {

--- a/src/lib/swapper/swappers/CowSwapper/getCowSwapTradeQuote/getCowSwapTradeQuote.ts
+++ b/src/lib/swapper/swappers/CowSwapper/getCowSwapTradeQuote/getCowSwapTradeQuote.ts
@@ -12,6 +12,7 @@ import {
   COW_SWAP_NATIVE_ASSET_MARKER_ADDRESS,
   COW_SWAP_VAULT_RELAYER_ADDRESS,
   ORDER_KIND_SELL,
+  SUPPORTED_CHAIN_IDS,
 } from 'lib/swapper/swappers/CowSwapper/utils/constants'
 import { cowService } from 'lib/swapper/swappers/CowSwapper/utils/cowService'
 import {
@@ -19,7 +20,6 @@ import {
   getCowswapNetwork,
   getFullAppData,
   getNowPlusThirtyMinutesTimestamp,
-  getSupportedChainIds,
   getValuesFromQuoteResponse,
 } from 'lib/swapper/swappers/CowSwapper/utils/helpers/helpers'
 import { isNativeEvmAsset } from 'lib/swapper/swappers/utils/helpers/helpers'
@@ -40,9 +40,11 @@ export async function getCowSwapTradeQuote(
     input.slippageTolerancePercentageDecimal ??
     getDefaultSlippageDecimalPercentageForSwapper(SwapperName.CowSwap)
 
-  const supportedChainIds = getSupportedChainIds()
-
-  const assertion = assertValidTrade({ buyAsset, sellAsset, supportedChainIds })
+  const assertion = assertValidTrade({
+    buyAsset,
+    sellAsset,
+    supportedChainIds: SUPPORTED_CHAIN_IDS,
+  })
   if (assertion.isErr()) return Err(assertion.unwrapErr())
 
   const buyToken = !isNativeEvmAsset(buyAsset.assetId)

--- a/src/lib/swapper/swappers/CowSwapper/utils/constants.ts
+++ b/src/lib/swapper/swappers/CowSwapper/utils/constants.ts
@@ -1,7 +1,9 @@
 import { KnownChainIds } from '@shapeshiftoss/types'
 import { zeroAddress } from 'viem'
+import type { SupportedChainIds } from 'lib/swapper/types'
 
 import type { CowChainId } from '../types'
+import { getSupportedChainIds } from './helpers/helpers'
 
 export const MIN_COWSWAP_USD_TRADE_VALUES_BY_CHAIN_ID: Record<CowChainId, string> = {
   [KnownChainIds.EthereumMainnet]: '20',
@@ -20,3 +22,8 @@ export const ERC20_TOKEN_BALANCE = 'erc20'
 // Address used by CowSwap to buy ETH
 // See https://github.com/gnosis/gp-v2-contracts/commit/821b5a8da213297b0f7f1d8b17c893c5627020af#diff-12bbbe13cd5cf42d639e34a39d8795021ba40d3ee1e1a8282df652eb161a11d6R13
 export const COW_SWAP_NATIVE_ASSET_MARKER_ADDRESS = '0xEeeeeEeeeEeEeeEeEeEeeEEEeeeeEeeeeeeeEEeE'
+
+export const COW_SWAP_SUPPORTED_CHAIN_IDS: SupportedChainIds = {
+  sell: getSupportedChainIds(),
+  buy: getSupportedChainIds(),
+}

--- a/src/lib/swapper/swappers/CowSwapper/utils/constants.ts
+++ b/src/lib/swapper/swappers/CowSwapper/utils/constants.ts
@@ -1,9 +1,9 @@
+import type { ChainId } from '@shapeshiftoss/caip'
 import { KnownChainIds } from '@shapeshiftoss/types'
 import { zeroAddress } from 'viem'
 import type { SupportedChainIds } from 'lib/swapper/types'
 
 import type { CowChainId } from '../types'
-import { getSupportedChainIds } from './helpers/helpers'
 
 export const MIN_COWSWAP_USD_TRADE_VALUES_BY_CHAIN_ID: Record<CowChainId, string> = {
   [KnownChainIds.EthereumMainnet]: '20',
@@ -23,7 +23,12 @@ export const ERC20_TOKEN_BALANCE = 'erc20'
 // See https://github.com/gnosis/gp-v2-contracts/commit/821b5a8da213297b0f7f1d8b17c893c5627020af#diff-12bbbe13cd5cf42d639e34a39d8795021ba40d3ee1e1a8282df652eb161a11d6R13
 export const COW_SWAP_NATIVE_ASSET_MARKER_ADDRESS = '0xEeeeeEeeeEeEeeEeEeEeeEEEeeeeEeeeeeeeEEeE'
 
+export const SUPPORTED_CHAIN_IDS: ChainId[] = [
+  KnownChainIds.GnosisMainnet,
+  KnownChainIds.EthereumMainnet,
+]
+
 export const COW_SWAP_SUPPORTED_CHAIN_IDS: SupportedChainIds = {
-  sell: getSupportedChainIds(),
-  buy: getSupportedChainIds(),
+  sell: SUPPORTED_CHAIN_IDS,
+  buy: SUPPORTED_CHAIN_IDS,
 }

--- a/src/lib/swapper/swappers/CowSwapper/utils/helpers/helpers.ts
+++ b/src/lib/swapper/swappers/CowSwapper/utils/helpers/helpers.ts
@@ -9,7 +9,6 @@ import type { Asset } from '@shapeshiftoss/types'
 import { KnownChainIds } from '@shapeshiftoss/types'
 import type { Result } from '@sniptt/monads'
 import { Err, Ok } from '@sniptt/monads'
-import { getConfig } from 'config'
 import type { TypedDataDomain, TypedDataField } from 'ethers'
 import { TypedDataEncoder } from 'ethers'
 import { keccak256, stringToBytes } from 'viem'
@@ -196,13 +195,6 @@ export const getValuesFromQuoteResponse = ({
     .toFixed(0)
 
   return { rate, buyAmountBeforeFeesCryptoBaseUnit, buyAmountAfterFeesCryptoBaseUnit }
-}
-
-export const getSupportedChainIds = (): ChainId[] => {
-  const isGnosisEnabled = getConfig().REACT_APP_FEATURE_COWSWAP_GNOSIS
-  return isGnosisEnabled
-    ? [KnownChainIds.GnosisMainnet, KnownChainIds.EthereumMainnet]
-    : [KnownChainIds.EthereumMainnet]
 }
 
 type AppDataInfo = {

--- a/src/lib/swapper/swappers/LifiSwapper/utils/constants.ts
+++ b/src/lib/swapper/swappers/LifiSwapper/utils/constants.ts
@@ -1,3 +1,7 @@
+import type { ChainId } from '@shapeshiftoss/caip'
+import { evmChainIds } from '@shapeshiftoss/chain-adapters'
+import type { SupportedChainIds } from 'lib/swapper/types'
+
 export const MIN_CROSS_CHAIN_AMOUNT_THRESHOLD_USD_HUMAN = 20 // arbitrary amount deemed by lifi devs to meet minimum amount across all brdiges
 export const MIN_SAME_CHAIN_AMOUNT_THRESHOLD_USD_HUMAN = '0.01' // Same chain bridges can be of any amount, since fees are paid explicitly as miner fees in one chain
 export const SELECTED_ROUTE_INDEX = 0 // default to first route - this is the highest ranking according to the query we send
@@ -6,3 +10,8 @@ export const OPTIMISM_GAS_ORACLE_ADDRESS = '0x4200000000000000000000000000000000
 
 // used for analytics and affiliate fee - do not change this without considering impact
 export const LIFI_INTEGRATOR_ID = 'shapeshift'
+
+export const LIFI_SUPPORTED_CHAIN_IDS: SupportedChainIds = {
+  sell: evmChainIds as unknown as ChainId[],
+  buy: evmChainIds as unknown as ChainId[],
+}

--- a/src/lib/swapper/swappers/OneInchSwapper/utils/constants.ts
+++ b/src/lib/swapper/swappers/OneInchSwapper/utils/constants.ts
@@ -1,2 +1,12 @@
+import type { ChainId } from '@shapeshiftoss/caip'
+import type { SupportedChainIds } from 'lib/swapper/types'
+
+import { oneInchSupportedChainIds } from './types'
+
 // Address used by 1inch for any native asset (ETH, AVAX, etc)
 export const ONE_INCH_NATIVE_ASSET_ADDRESS = '0xeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeee'
+
+export const ONE_INCH_SUPPORTED_CHAIN_IDS: SupportedChainIds = {
+  sell: oneInchSupportedChainIds as unknown as ChainId[],
+  buy: oneInchSupportedChainIds as unknown as ChainId[],
+}

--- a/src/lib/swapper/swappers/ThorchainSwapper/constants.ts
+++ b/src/lib/swapper/swappers/ThorchainSwapper/constants.ts
@@ -2,6 +2,7 @@ import type { ChainId } from '@shapeshiftoss/caip'
 import type { SwapSource } from '@shapeshiftoss/swapper'
 import { SwapperName } from '@shapeshiftoss/swapper'
 import { KnownChainIds } from '@shapeshiftoss/types'
+import type { SupportedChainIds } from 'lib/swapper/types'
 
 export const sellSupportedChainIds: Record<ChainId, boolean> = {
   [KnownChainIds.EthereumMainnet]: true,
@@ -25,6 +26,11 @@ export const buySupportedChainIds: Record<ChainId, boolean> = {
   [KnownChainIds.ThorchainMainnet]: true,
   [KnownChainIds.AvalancheMainnet]: true,
   [KnownChainIds.BnbSmartChainMainnet]: true,
+}
+
+export const THORCHAIN_SUPPORTED_CHAIN_IDS: SupportedChainIds = {
+  sell: Object.keys(sellSupportedChainIds),
+  buy: Object.keys(buySupportedChainIds),
 }
 
 export const THORCHAIN_STREAM_SWAP_SOURCE: SwapSource = `${SwapperName.Thorchain} • Streaming`

--- a/src/lib/swapper/swappers/ZrxSwapper/utils/constants.ts
+++ b/src/lib/swapper/swappers/ZrxSwapper/utils/constants.ts
@@ -1,12 +1,13 @@
+import type { ChainId } from '@shapeshiftoss/caip'
 import { KnownChainIds } from '@shapeshiftoss/types'
 import type { SupportedChainIds } from 'lib/swapper/types'
 
 export const AFFILIATE_ADDRESS = '0xc770eefad204b5180df6a14ee197d99d808ee52d'
 export const OPTIMISM_L1_SWAP_GAS_LIMIT = '50000'
 
-// Zrx doesnt have an easily accessible master assets list.
+// Zrx doesn't have an easily accessible master assets list.
 
-// We assume all erc20's are supported and remove these explicitely unsupported assets
+// We assume all erc20's are supported and remove these explicitly unsupported assets
 export const ZRX_UNSUPPORTED_ASSETS = Object.freeze([
   // Foxy token unsupported by zrx
   'eip155:1/erc20:0xdc49108ce5c57bc3408c3a5e95f3d864ec386ed3',
@@ -27,6 +28,6 @@ export const ZRX_SUPPORTED_CHAINIDS = Object.freeze([
 ])
 
 export const ZRX_SUPPORTED_CHAIN_IDS: SupportedChainIds = {
-  sell: Object.keys(ZRX_SUPPORTED_CHAINIDS),
-  buy: Object.keys(ZRX_SUPPORTED_CHAINIDS),
+  sell: ZRX_SUPPORTED_CHAINIDS as ChainId[],
+  buy: ZRX_SUPPORTED_CHAINIDS as ChainId[],
 }

--- a/src/lib/swapper/swappers/ZrxSwapper/utils/constants.ts
+++ b/src/lib/swapper/swappers/ZrxSwapper/utils/constants.ts
@@ -1,4 +1,5 @@
 import { KnownChainIds } from '@shapeshiftoss/types'
+import type { SupportedChainIds } from 'lib/swapper/types'
 
 export const AFFILIATE_ADDRESS = '0xc770eefad204b5180df6a14ee197d99d808ee52d'
 export const OPTIMISM_L1_SWAP_GAS_LIMIT = '50000'
@@ -24,3 +25,8 @@ export const ZRX_SUPPORTED_CHAINIDS = Object.freeze([
   KnownChainIds.PolygonMainnet,
   KnownChainIds.ArbitrumMainnet,
 ])
+
+export const ZRX_SUPPORTED_CHAIN_IDS: SupportedChainIds = {
+  sell: Object.keys(ZRX_SUPPORTED_CHAINIDS),
+  buy: Object.keys(ZRX_SUPPORTED_CHAINIDS),
+}

--- a/src/lib/swapper/types.ts
+++ b/src/lib/swapper/types.ts
@@ -1,3 +1,4 @@
+import type { ChainId } from '@shapeshiftoss/caip'
 import type { HDWallet } from '@shapeshiftoss/hdwallet-core'
 import type { SwapperName, TradeQuote } from '@shapeshiftoss/swapper'
 import type { AccountMetadata } from '@shapeshiftoss/types'
@@ -12,4 +13,9 @@ export type TradeExecutionInput = {
   supportsEIP1559: boolean
   slippageTolerancePercentageDecimal: string
   getState: () => ReduxState
+}
+
+export type SupportedChainIds = {
+  buy: ChainId[]
+  sell: ChainId[]
 }


### PR DESCRIPTION
## Description

Pushes the responsibility of knowing what specific assets are supported to the swppers at query time, and instead uses a combination of a static list of supported chains (for buy and sell side) with the wallet supported chains (for sell side).

For the sake of performance gains in the trade interface, it's now possible to select pairs which are not supported by swappers, although in production this should already already the case. We do still filter based on wallet support though.

## Pull Request Type

- [ ] :bug: Bug fix (Non-breaking Change: Fixes an issue)
- [x] :hammer_and_wrench: Chore (Non-breaking Change: Doc updates, pkg upgrades, typos, etc..)
- [ ] :nail_care: New Feature (Breaking/Non-breaking Change)

## Issue (if applicable)

closes #6328

## Risk
> High Risk PRs Require 2 approvals

Moderate risk of broken trade quotes.

> What protocols, transaction types or contract interactions might be affected by this PR?

All swappers affected.

## Testing

Should not introduce a functional change to the app, and should match production.

Check the asset list on the trade input page and ensure it behaves as intended. Also check that quotes are still working for all swappers.

### Engineering

<!-----------------------------------------------------------------------------
Include sufficient information here for an engineer to test your PR. This may include how to test locally, in a built environment, changes to infrastructure etc.
------------------------------------------------------------------------------>

### Operations

<!-----------------------------------------------------------------------------
If your changes have a user-facing impact, describe how a non-technical QA team can functionally test your changes in a preview environment.

If they are not user-facing please describe how to test for any regressions that may occur.
------------------------------------------------------------------------------>

## Screenshots (if applicable)
