### PR TITLE
fix: lp data

### DIFF
--- a/src/pages/ThorChainLP/queries/hooks/useUserLpData.ts
+++ b/src/pages/ThorChainLP/queries/hooks/useUserLpData.ts
@@ -4,6 +4,7 @@ import type { UseQueryResult } from '@tanstack/react-query'
 import { useQuery, useQueryClient } from '@tanstack/react-query'
 import { reactQueries } from 'react-queries'
 import { bn } from 'lib/bignumber/bignumber'
+import { assetIdToPoolAssetId } from 'lib/swapper/swappers/ThorchainSwapper/utils/poolAssetHelpers/poolAssetHelpers'
 import { isSome } from 'lib/utils'
 import { calculatePoolOwnershipPercentage, getCurrentValue } from 'lib/utils/thorchain/lp'
 import type { Position, UserLpDataPosition } from 'lib/utils/thorchain/lp/types'
@@ -30,6 +31,7 @@ export const useUserLpData = ({
 
   const poolAssetMarketData = useAppSelector(state => selectMarketDataById(state, assetId))
   const runeMarketData = useAppSelector(state => selectMarketDataById(state, thorchainAssetId))
+  const poolAssetId = assetIdToPoolAssetId({ assetId })
 
   const { data: thornodePoolData } = useQuery({
     ...reactQueries.thornode.poolData(assetId),
@@ -41,7 +43,7 @@ export const useUserLpData = ({
   })
 
   const { data: midgardPoolData } = useQuery({
-    ...reactQueries.midgard.poolData(assetId),
+    ...reactQueries.midgard.poolData(poolAssetId ?? ''),
     // @lukemorales/query-key-factory only returns queryFn and queryKey - all others will be ignored in the returned object
     // 0 seconds garbage collect and stale times since this is used to get the current position value, we want this to always be cached-then-fresh
     staleTime: 0,


### PR DESCRIPTION
## Description

Fixes a regression in https://github.com/shapeshift/web/pull/6320 which caused `useUserLpData` to return `null`, breaking the position page and withdrawals.

## Pull Request Type

- [x] :bug: Bug fix (Non-breaking Change: Fixes an issue)
- [ ] :hammer_and_wrench: Chore (Non-breaking Change: Doc updates, pkg upgrades, typos, etc..)
- [ ] :nail_care: New Feature (Breaking/Non-breaking Change)

## Issue (if applicable)

N/A

## Risk

Small

> What protocols, transaction types or contract interactions might be affected by this PR?

None.

## Testing

LP position data should be great again (see screenshots).

### Engineering

☝️

### Operations

☝️

## Screenshots (if applicable)

Develop

<img width="677" alt="Screenshot 2024-02-29 at 5 20 45 pm" src="https://github.com/shapeshift/web/assets/97164662/e1f90f16-b24f-44d3-ab2b-0c39dc26c095">

This branch

<img width="673" alt="Screenshot 2024-02-29 at 5 19 58 pm" src="https://github.com/shapeshift/web/assets/97164662/497bebf6-888e-4263-b6d2-03e53d081cf5">
