### PR TITLE
chore: show both sym withdraw amounts

### DIFF
--- a/src/pages/ThorChainLP/components/ReusableLpStatus/ReusableLpStatus.tsx
+++ b/src/pages/ThorChainLP/components/ReusableLpStatus/ReusableLpStatus.tsx
@@ -197,6 +197,7 @@ export const ReusableLpStatus: React.FC<ReusableLpStatusProps> = ({
     return (
       <Stack mt={4}>
         {txAssets.map((_asset, index) => {
+          const isDeposit = isLpConfirmedDepositQuote(confirmedQuote)
           const amountCryptoPrecision =
             _asset.assetId === thorchainAssetId
               ? isLpConfirmedDepositQuote(confirmedQuote)
@@ -205,12 +206,22 @@ export const ReusableLpStatus: React.FC<ReusableLpStatusProps> = ({
               : isLpConfirmedDepositQuote(confirmedQuote)
               ? confirmedQuote.assetCryptoDepositAmount
               : confirmedQuote.assetCryptoWithdrawAmount
+          const isSymWithdraw = !isDeposit && opportunityType === 'sym'
+          /*
+            Symmetrical withdrawals withdraw both asset amounts in a single TX.
+            In this case, we want to provide the pool asset amount to TransactionRow in additional to the rune amount
+            so we render both for the user.
+          */
+          const poolAmountCryptoPrecision = isSymWithdraw
+            ? confirmedQuote.assetCryptoWithdrawAmount
+            : undefined
           return (
             <TransactionRow
               key={_asset.assetId}
               assetId={_asset.assetId}
               poolAssetId={poolAsset?.assetId}
               amountCryptoPrecision={amountCryptoPrecision}
+              poolAmountCryptoPrecision={poolAmountCryptoPrecision}
               onComplete={handleComplete}
               isActive={index === activeStepIndex}
               confirmedQuote={confirmedQuote}

--- a/src/pages/ThorChainLP/components/ReusableLpStatus/TransactionRow.tsx
+++ b/src/pages/ThorChainLP/components/ReusableLpStatus/TransactionRow.tsx
@@ -79,6 +79,7 @@ type TransactionRowProps = {
   assetId?: AssetId
   poolAssetId?: AssetId
   amountCryptoPrecision: string
+  poolAmountCryptoPrecision: string | undefined
   onComplete: () => void
   isActive?: boolean
   isLast?: boolean
@@ -90,6 +91,7 @@ export const TransactionRow: React.FC<TransactionRowProps> = ({
   assetId,
   poolAssetId,
   amountCryptoPrecision,
+  poolAmountCryptoPrecision,
   onComplete,
   isActive,
   confirmedQuote,
@@ -108,6 +110,7 @@ export const TransactionRow: React.FC<TransactionRowProps> = ({
   const [txId, setTxId] = useState<string | null>(null)
   const wallet = useWallet().state.wallet
   const isDeposit = isLpConfirmedDepositQuote(confirmedQuote)
+  const isSymWithdraw = poolAmountCryptoPrecision !== undefined
 
   const { currentAccountIdByChainId } = confirmedQuote
 
@@ -630,6 +633,16 @@ export const TransactionRow: React.FC<TransactionRowProps> = ({
       <CardHeader gap={2} display='flex' flexDir='row' alignItems='center'>
         <AssetIcon size='xs' assetId={asset.assetId} />
         <Amount.Crypto fontWeight='bold' value={amountCryptoPrecision} symbol={asset.symbol} />{' '}
+        {isSymWithdraw && (
+          <>
+            <AssetIcon size='xs' assetId={poolAsset?.assetId} />
+            <Amount.Crypto
+              fontWeight='bold'
+              value={poolAmountCryptoPrecision}
+              symbol={poolAsset?.symbol ?? ''}
+            />{' '}
+          </>
+        )}
         <Flex ml='auto' alignItems='center' gap={2}>
           {txId && (
             <Button as={Link} isExternal href={txIdLink} size='xs'>


### PR DESCRIPTION
## Description

Show the pool asset amount for symmetrical withdrawals.
We currently only show the RUNE amount.

This view might need some beard oil down the line.

## Pull Request Type

- [x] :bug: Bug fix (Non-breaking Change: Fixes an issue)
- [ ] :hammer_and_wrench: Chore (Non-breaking Change: Doc updates, pkg upgrades, typos, etc..)
- [ ] :nail_care: New Feature (Breaking/Non-breaking Change)

## Issue (if applicable)

N/A

## Risk

Small

> What protocols, transaction types or contract interactions might be affected by this PR?

None.

## Testing

Get to the signing view of a symmetrical withdrawal and confirm that both the expected RUNE and pool asset amounts (+ symbol and icons) are shown correctly.

### Engineering

☝️

### Operations

☝️

## Screenshots (if applicable)

Develop

<img width="352" alt="Screenshot 2024-03-04 at 8 10 30 am" src="https://github.com/shapeshift/web/assets/97164662/38020c4c-ac00-4976-ad37-8ffa1bae276a">

This branch

<img width="352" alt="Screenshot 2024-03-04 at 4 09 40 pm" src="https://github.com/shapeshift/web/assets/97164662/d49106e5-a04a-44d2-87cd-337336140914">
