### PR TITLE
chore: display outbound fee lp withdraw

### DIFF
--- a/src/pages/ThorChainLP/components/AddLiquidity/AddLiquidityInput.tsx
+++ b/src/pages/ThorChainLP/components/AddLiquidity/AddLiquidityInput.tsx
@@ -566,8 +566,6 @@ export const AddLiquidityInput: React.FC<AddLiquidityInputProps> = ({
     [estimatedPoolAssetFeesData?.txFeeCryptoBaseUnit, poolAssetFeeAsset?.precision],
   )
 
-  console.log({ poolAssetTxFeeCryptoPrecision })
-
   // Checks if there's enough fee asset balance to cover the transaction fees
   const hasEnoughPoolAssetFeeAssetBalanceForTx = useMemo(() => {
     if (bnOrZero(actualAssetDepositAmountCryptoPrecision).isZero()) return true
@@ -1188,14 +1186,21 @@ export const AddLiquidityInput: React.FC<AddLiquidityInputProps> = ({
     )
   }, [backIcon, confirmedQuote, handleBackClick, headerComponent, translate])
 
-  if (!poolAsset || !runeAsset) return null
+  const hasUserEnteredValue = useMemo(() => {
+    return Boolean(
+      virtualAssetDepositAmountCryptoPrecision &&
+        virtualAssetDepositAmountFiatUserCurrency &&
+        virtualRuneDepositAmountCryptoPrecision &&
+        virtualRuneDepositAmountFiatUserCurrency,
+    )
+  }, [
+    virtualAssetDepositAmountCryptoPrecision,
+    virtualAssetDepositAmountFiatUserCurrency,
+    virtualRuneDepositAmountCryptoPrecision,
+    virtualRuneDepositAmountFiatUserCurrency,
+  ])
 
-  const hasUserEnteredValue = !!(
-    virtualAssetDepositAmountCryptoPrecision &&
-    virtualAssetDepositAmountFiatUserCurrency &&
-    virtualRuneDepositAmountCryptoPrecision &&
-    virtualRuneDepositAmountFiatUserCurrency
-  )
+  if (!poolAsset || !runeAsset) return null
 
   return (
     <SlideTransition>

--- a/src/pages/ThorChainLP/components/RemoveLiquidity/RemoveLiquidityInput.tsx
+++ b/src/pages/ThorChainLP/components/RemoveLiquidity/RemoveLiquidityInput.tsx
@@ -41,7 +41,7 @@ import { bn, bnOrZero, convertPrecision } from 'lib/bignumber/bignumber'
 import { fromBaseUnit, toBaseUnit } from 'lib/math'
 import { THORCHAIN_FIXED_PRECISION } from 'lib/swapper/swappers/ThorchainSwapper/utils/constants'
 import { assertUnreachable } from 'lib/utils'
-import { getThorchainFromAddress } from 'lib/utils/thorchain'
+import { fromThorBaseUnit, getThorchainFromAddress } from 'lib/utils/thorchain'
 import { THOR_PRECISION, THORCHAIN_POOL_MODULE_ADDRESS } from 'lib/utils/thorchain/constants'
 import {
   estimateRemoveThorchainLiquidityPosition,
@@ -394,6 +394,13 @@ export const RemoveLiquidityInput: React.FC<RemoveLiquidityInputProps> = ({
     () => poolAssetGasFeeFiatUserCurrency.plus(runeGasFeeFiatUserCurrency),
     [poolAssetGasFeeFiatUserCurrency, runeGasFeeFiatUserCurrency],
   )
+
+  const protocolFeeFiatUserCurrency = useMemo(() => {
+    if (opportunityType === AsymSide.Rune) return '0'
+    return fromThorBaseUnit(inboundAddressesData?.outbound_fee ?? 0)
+      .times(poolAssetMarketData.price)
+      .toFixed()
+  }, [inboundAddressesData?.outbound_fee, poolAssetMarketData.price, opportunityType])
 
   const handlePercentageClick = useCallback((percentage: number) => {
     return () => {
@@ -836,8 +843,7 @@ export const RemoveLiquidityInput: React.FC<RemoveLiquidityInputProps> = ({
           <Row.Label>{translate('common.fees')}</Row.Label>
           <Row.Value>
             <Skeleton isLoaded={true}>
-              {/* There are no protocol fees when removing liquidity */}
-              <Amount.Fiat value={'0'} />
+              <Amount.Fiat value={protocolFeeFiatUserCurrency} />
             </Skeleton>
           </Row.Value>
         </Row>


### PR DESCRIPTION
## Description

A user will pay for the outbound fee to withdraw from an LP position (excluding asym rune). Display this value as the protocol fee.

## Pull Request Type

- [ ] :bug: Bug fix (Non-breaking Change: Fixes an issue)
- [ ] :hammer_and_wrench: Chore (Non-breaking Change: Doc updates, pkg upgrades, typos, etc..)
- [x] :nail_care: New Feature (Breaking/Non-breaking Change)

## Issue (if applicable)

<!-----------------------------------------------------------------------------
If applicable, please link to the github issue and put `closes #XXXX` in your comment to auto-close the issue that your PR fixes.
------------------------------------------------------------------------------>

N/A

## Risk
> High Risk PRs Require 2 approvals

<!-----------------------------------------------------------------------------
Outline the scope of your changes and the risk associated with them. You must use your discretion as an engineer to determine the potential impact of your changes.

WARNING: If your PR introduces a new on-chain transaction or modifies an existing one, please add the "High-Risk" label to this PR and ask for 2 reviewers to approve it before merging.

E.g. an upgrade to `hdwallet` or core state management would be considered higher risk, and might require a full regression test. UI or isolated view changes, or something behind a feature flag may have near zero risk. Small bug fixes might require testing isolated to the specific fix.
------------------------------------------------------------------------------>

Low

> What protocols, transaction types or contract interactions might be affected by this PR?

Thorchain LP withdrawal (Symmetric and Asym Asset)

## Testing

<!-----------------------------------------------------------------------------
We treat every PR to be merged with the same scrutiny as if we were merging directly to production.

Your PR will not be merged if you do not complete the sections below for our engineering and operations teams to test.
------------------------------------------------------------------------------>

- ensure the protocol fee is being displayed on withdraw for symmetric and asym asset withdraw
- ensure the protocol fee is $0 for asym rune withdraw

### Engineering

<!-----------------------------------------------------------------------------
Include sufficient information here for an engineer to test your PR. This may include how to test locally, in a built environment, changes to infrastructure etc.
------------------------------------------------------------------------------>

:point_up: 

### Operations

<!-----------------------------------------------------------------------------
If your changes have a user-facing impact, describe how a non-technical QA team can functionally test your changes in a preview environment.

If they are not user-facing please describe how to test for any regressions that may occur.
------------------------------------------------------------------------------>

:point_up: 

## Screenshots (if applicable)

Asym Rune (no protocol fee)
![image](https://github.com/shapeshift/web/assets/35275952/d886d3fa-2a9f-4474-89ef-95e58beff191)

Asym Asset (protocol fee)
![image](https://github.com/shapeshift/web/assets/35275952/24e7aa4c-1245-42ca-9a6b-9925004c3757)
