### PR TITLE
fix: handle undefined SendFormFields.Input

### DIFF
--- a/src/components/MultiHopTrade/components/TradeInput/components/RecipientAddress.tsx
+++ b/src/components/MultiHopTrade/components/TradeInput/components/RecipientAddress.tsx
@@ -73,7 +73,7 @@ export const RecipientAddress = () => {
     if (!isRecipientAddressEditing) return
 
     // minLength should catch this and make isValid false, but doesn't seem to on mount, even when manually triggering validation.
-    if (!value.length) {
+    if (!value?.length) {
       dispatch(tradeInput.actions.setManualReceiveAddressIsValid(false))
       return
     }
@@ -179,7 +179,7 @@ export const RecipientAddress = () => {
               pointerEvents='auto'
               color='green.500'
               aria-label='Save'
-              isDisabled={!isValid || isValidating || !value.length}
+              isDisabled={!isValid || isValidating || !value?.length}
               size='xs'
               onClick={handleFormSubmit}
               icon={checkIcon}
@@ -196,7 +196,7 @@ export const RecipientAddress = () => {
             />
           </InputRightElement>
         </InputGroup>
-        {Boolean(value.length && !isValid) && (
+        {Boolean(value?.length && !isValid) && (
           <Text translation='common.invalidAddress' color='yellow.200' mt={2} />
         )}
       </FormControl>


### PR DESCRIPTION
## Description

Fixes application crash when attempting to enter a custom receive address.

## Pull Request Type

- [x] :bug: Bug fix (Non-breaking Change: Fixes an issue)
- [ ] :hammer_and_wrench: Chore (Non-breaking Change: Doc updates, pkg upgrades, typos, etc..)
- [ ] :nail_care: New Feature (Breaking/Non-breaking Change)

## Issue (if applicable)

Closes https://github.com/shapeshift/web/issues/6350

## Risk
> High Risk PRs Require 2 approvals

Medium. Relates to receive address, but changes no underlying logic.

> What protocols, transaction types or contract interactions might be affected by this PR?

All trades.

## Testing

- Using a custom receive address should now work
- Using the default receive address should still work

### Engineering

☝️

### Operations

☝️

## Screenshots (if applicable)

N/A