### PR TITLE
chore: always allow account selection

### DIFF
--- a/src/components/MultiHopTrade/components/TradeInput/TradeInput.tsx
+++ b/src/components/MultiHopTrade/components/TradeInput/TradeInput.tsx
@@ -76,7 +76,6 @@ import {
   selectFirstHop,
   selectIsAnyTradeQuoteLoaded,
   selectIsUnsafeActiveQuote,
-  selectSwapperSupportsCrossAccountTrade,
   selectTotalNetworkFeeUserCurrencyPrecision,
   selectTotalProtocolFeeByAsset,
   selectTradeQuoteRequestErrors,
@@ -146,7 +145,6 @@ export const TradeInput = memo(({ isCompact }: TradeInputProps) => {
   const { priceImpactPercentage } = usePriceImpact(activeQuote)
 
   const tradeQuoteStep = useAppSelector(selectFirstHop)
-  const swapperSupportsCrossAccountTrade = useAppSelector(selectSwapperSupportsCrossAccountTrade)
   const totalProtocolFees = useAppSelector(selectTotalProtocolFeeByAsset)
   const buyAmountAfterFeesCryptoPrecision = useAppSelector(selectBuyAmountAfterFeesCryptoPrecision)
   const buyAmountAfterFeesUserCurrency = useAppSelector(selectBuyAmountAfterFeesUserCurrency)
@@ -699,7 +697,6 @@ export const TradeInput = memo(({ isCompact }: TradeInputProps) => {
                     showFiatSkeleton={isLoading}
                     label={translate('trade.youGet')}
                     onAccountIdChange={setBuyAssetAccountId}
-                    isAccountSelectionDisabled={!swapperSupportsCrossAccountTrade}
                     formControlProps={formControlProps}
                     labelPostFix={buyTradeAssetSelect}
                     priceImpactPercentage={priceImpactPercentage?.toString()}

--- a/src/state/slices/tradeQuoteSlice/selectors.ts
+++ b/src/state/slices/tradeQuoteSlice/selectors.ts
@@ -14,7 +14,6 @@ import type { ApiQuote, ErrorWithMeta, TradeQuoteError } from 'state/apis/swappe
 import { TradeQuoteRequestError, TradeQuoteWarning } from 'state/apis/swapper'
 import { validateQuoteRequest } from 'state/apis/swapper/helpers/validateQuoteRequest'
 import { selectIsTradeQuoteApiQueryPending } from 'state/apis/swapper/selectors'
-import { isCrossAccountTradeSupported } from 'state/helpers'
 import type { ReduxState } from 'state/reducer'
 import { createDeepEqualOutputSelector } from 'state/selector-utils'
 import { selectFeeAssetById } from 'state/slices/assetsSlice/selectors'
@@ -256,19 +255,6 @@ export const selectActiveQuoteWarnings: Selector<
   ReduxState,
   ErrorWithMeta<TradeQuoteWarning>[] | undefined
 > = createDeepEqualOutputSelector(selectActiveSwapperApiResponse, response => response?.warnings)
-
-/*
-  Cross-account trading means trades that are either:
-    - Trades between assets on the same chain but different accounts
-    - Trades between assets on different chains (and possibly different accounts)
-   When adding a new swapper, ensure that `true` is returned here if either of the above apply.
-   */
-export const selectSwapperSupportsCrossAccountTrade: Selector<ReduxState, boolean | undefined> =
-  createSelector(selectActiveSwapperName, activeSwapperName => {
-    if (activeSwapperName === undefined) return undefined
-
-    return isCrossAccountTradeSupported(activeSwapperName)
-  })
 
 export const selectHopTotalProtocolFeesFiatPrecision: Selector<ReduxState, string | undefined> =
   createSelector(


### PR DESCRIPTION
## Description

Always allow account selection, instead of only when we have a quote from a swapper that supports cross-account trades.

Ensures we do not get cross-account quotes from swappers that do not support cross-account trades as `getEnabledSwappers` will only return swappers that can handle the requested quote.

## Pull Request Type

- [ ] :bug: Bug fix (Non-breaking Change: Fixes an issue)
- [x] :hammer_and_wrench: Chore (Non-breaking Change: Doc updates, pkg upgrades, typos, etc..)
- [ ] :nail_care: New Feature (Breaking/Non-breaking Change)

## Issue (if applicable)

Closes https://github.com/shapeshift/web/issues/6262

## Risk
> High Risk PRs Require 2 approvals

Small risk. Swappers that do not support cross-account trading are not enabled, and won't give a quote when a cross-account receive account is selected.

> What protocols, transaction types or contract interactions might be affected by this PR?

Swapping on all swappers.

## Testing

We should be able to _always_ select a receive account regardless of whether or not we:

a) have a valid quote
a) have selected a swapper that does or does not support cross-account trading

### Engineering

☝️

### Operations

☝️

## Screenshots (if applicable)

**Develop**

No quote, can't select a receive account.

<img width="504" alt="Screenshot 2024-03-05 at 5 15 00 pm" src="https://github.com/shapeshift/web/assets/97164662/00014a1c-55f2-4b7a-9d5a-437070c98d9f">

Have quote with a swapper that does not support cross-account trading (0x), can't select a receive account.

<img width="780" alt="Screenshot 2024-03-05 at 5 15 37 pm" src="https://github.com/shapeshift/web/assets/97164662/0b1741eb-8a3b-4393-a32a-df5daa3d72e3">

**This branch**

No quote, _can_ select a receive account.

<img width="490" alt="Screenshot 2024-03-05 at 5 16 19 pm" src="https://github.com/shapeshift/web/assets/97164662/d44104b1-c0d2-4176-bbe0-4ade0d921b45">

Have quote with a swapper that does not support cross-account trading (0x), _can_ select a receive account.

<img width="799" alt="Screenshot 2024-03-05 at 5 23 35 pm" src="https://github.com/shapeshift/web/assets/97164662/775d40fb-22ff-47d4-aaf4-aae6e1a11dfc">
