### PR TITLE
fix: incorrect currency used for market data in various parts of the app

### DIFF
--- a/src/components/AssetAccountDetails.tsx
+++ b/src/components/AssetAccountDetails.tsx
@@ -5,7 +5,7 @@ import { useMemo } from 'react'
 import type { Route } from 'Routes/helpers'
 import { MultiHopTrade } from 'components/MultiHopTrade/MultiHopTrade'
 import { AssetTransactionHistory } from 'components/TransactionHistory/AssetTransactionHistory'
-import { selectMarketDataById } from 'state/slices/selectors'
+import { selectMarketDataByAssetIdUserCurrency } from 'state/slices/selectors'
 import { useAppSelector } from 'state/store'
 
 import { AccountAssets } from './AccountAssets/AccountAssets'
@@ -31,7 +31,7 @@ const display = { base: 'none', md: 'block' }
 const contentPaddingY = { base: 0, md: 8 }
 
 export const AssetAccountDetails = ({ assetId, accountId }: AssetDetailsProps) => {
-  const marketData = useAppSelector(state => selectMarketDataById(state, assetId))
+  const marketData = useAppSelector(state => selectMarketDataByAssetIdUserCurrency(state, assetId))
   const assetIds = useMemo(() => [assetId], [assetId])
 
   const assetHeader = useMemo(

--- a/src/components/AssetHeader/AssetChart.tsx
+++ b/src/components/AssetHeader/AssetChart.tsx
@@ -16,7 +16,7 @@ import {
   selectAssetById,
   selectChartTimeframe,
   selectCryptoHumanBalanceIncludingStakingByFilter,
-  selectMarketDataById,
+  selectMarketDataByAssetIdUserCurrency,
 } from 'state/slices/selectors'
 import { useAppDispatch, useAppSelector } from 'state/store'
 import { breakpoints } from 'theme/theme'
@@ -55,7 +55,7 @@ export const AssetChart = ({ accountId, assetId, isLoaded }: AssetChartProps) =>
   const userChartTimeframe = useAppSelector(selectChartTimeframe)
   const [timeframe, setTimeframe] = useState<HistoryTimeframe>(userChartTimeframe)
   const asset = useAppSelector(state => selectAssetById(state, assetId))
-  const marketData = useAppSelector(state => selectMarketDataById(state, assetId))
+  const marketData = useAppSelector(state => selectMarketDataByAssetIdUserCurrency(state, assetId))
   const { price } = marketData || {}
   const assetPrice = toFiat(price) ?? 0
 

--- a/src/components/AssetHeader/AssetHeader.tsx
+++ b/src/components/AssetHeader/AssetHeader.tsx
@@ -16,7 +16,7 @@ import { middleEllipsis, tokenOrUndefined } from 'lib/utils'
 import {
   selectAccountIdsByAssetId,
   selectAssetById,
-  selectMarketDataById,
+  selectMarketDataByAssetIdUserCurrency,
   selectPortfolioCryptoPrecisionBalanceByFilter,
 } from 'state/slices/selectors'
 import { useAppSelector } from 'state/store'
@@ -39,7 +39,9 @@ export const AssetHeader: React.FC<AssetHeaderProps> = ({ assetId, accountId, ..
   const translate = useTranslate()
   const asset = useAppSelector(state => selectAssetById(state, assetId ?? ''))
   if (!asset) throw new Error(`Asset not found for AssetId ${assetId}`)
-  const marketData = useAppSelector(state => selectMarketDataById(state, assetId ?? ''))
+  const marketData = useAppSelector(state =>
+    selectMarketDataByAssetIdUserCurrency(state, assetId ?? ''),
+  )
   const {
     number: { toFiat },
   } = useLocaleFormatter()

--- a/src/components/AssetHeader/AssetMarketData.tsx
+++ b/src/components/AssetHeader/AssetMarketData.tsx
@@ -16,7 +16,7 @@ import { Amount } from 'components/Amount/Amount'
 import { Row } from 'components/Row/Row'
 import { Text } from 'components/Text'
 import { bnOrZero } from 'lib/bignumber/bignumber'
-import { selectMarketDataById } from 'state/slices/selectors'
+import { selectMarketDataByAssetIdUserCurrency } from 'state/slices/selectors'
 import { useAppSelector } from 'state/store'
 
 type AssetMarketDataProps = {
@@ -61,7 +61,7 @@ const StatValue = ({ isLoaded, ...rest }: StatProps) => (
 
 export const AssetMarketData: React.FC<AssetMarketDataProps> = ({ assetId }) => {
   const translate = useTranslate()
-  const marketData = useAppSelector(state => selectMarketDataById(state, assetId))
+  const marketData = useAppSelector(state => selectMarketDataByAssetIdUserCurrency(state, assetId))
   const percentChange = bnOrZero(marketData?.changePercent24Hr)
   const isLoaded = !!marketData
 

--- a/src/components/EarnDashboard/components/PositionDetails/LpPositionsByProvider.tsx
+++ b/src/components/EarnDashboard/components/PositionDetails/LpPositionsByProvider.tsx
@@ -22,7 +22,7 @@ import { getMetadataForProvider } from 'state/slices/opportunitiesSlice/utils/ge
 import {
   selectAggregatedEarnUserLpOpportunities,
   selectAssets,
-  selectCryptoMarketDataSortedByMarketCapUserCurrency,
+  selectCryptoMarketDataUserCurrency,
 } from 'state/slices/selectors'
 import { useAppSelector } from 'state/store'
 
@@ -50,7 +50,7 @@ export const LpPositionsByProvider: React.FC<LpPositionsByProviderProps> = ({ id
     dispatch,
   } = useWallet()
   const assets = useAppSelector(selectAssets)
-  const marketDataUserCurrency = useAppSelector(selectCryptoMarketDataSortedByMarketCapUserCurrency)
+  const marketDataUserCurrency = useAppSelector(selectCryptoMarketDataUserCurrency)
   const lpOpportunities = useAppSelector(selectAggregatedEarnUserLpOpportunities)
 
   const filteredDown = lpOpportunities.filter(

--- a/src/components/EarnDashboard/components/PositionDetails/LpPositionsByProvider.tsx
+++ b/src/components/EarnDashboard/components/PositionDetails/LpPositionsByProvider.tsx
@@ -22,7 +22,7 @@ import { getMetadataForProvider } from 'state/slices/opportunitiesSlice/utils/ge
 import {
   selectAggregatedEarnUserLpOpportunities,
   selectAssets,
-  selectCryptoMarketData,
+  selectCryptoMarketDataSortedByMarketCapUsd,
 } from 'state/slices/selectors'
 import { useAppSelector } from 'state/store'
 
@@ -50,7 +50,7 @@ export const LpPositionsByProvider: React.FC<LpPositionsByProviderProps> = ({ id
     dispatch,
   } = useWallet()
   const assets = useAppSelector(selectAssets)
-  const marketData = useAppSelector(selectCryptoMarketData)
+  const marketData = useAppSelector(selectCryptoMarketDataSortedByMarketCapUsd)
   const lpOpportunities = useAppSelector(selectAggregatedEarnUserLpOpportunities)
 
   const filteredDown = lpOpportunities.filter(

--- a/src/components/EarnDashboard/components/PositionDetails/LpPositionsByProvider.tsx
+++ b/src/components/EarnDashboard/components/PositionDetails/LpPositionsByProvider.tsx
@@ -22,7 +22,7 @@ import { getMetadataForProvider } from 'state/slices/opportunitiesSlice/utils/ge
 import {
   selectAggregatedEarnUserLpOpportunities,
   selectAssets,
-  selectCryptoMarketDataSortedByMarketCapUsd,
+  selectCryptoMarketDataSortedByMarketCapUserCurrency,
 } from 'state/slices/selectors'
 import { useAppSelector } from 'state/store'
 
@@ -50,7 +50,7 @@ export const LpPositionsByProvider: React.FC<LpPositionsByProviderProps> = ({ id
     dispatch,
   } = useWallet()
   const assets = useAppSelector(selectAssets)
-  const marketData = useAppSelector(selectCryptoMarketDataSortedByMarketCapUsd)
+  const marketDataUserCurrency = useAppSelector(selectCryptoMarketDataSortedByMarketCapUserCurrency)
   const lpOpportunities = useAppSelector(selectAggregatedEarnUserLpOpportunities)
 
   const filteredDown = lpOpportunities.filter(
@@ -148,7 +148,7 @@ export const LpPositionsByProvider: React.FC<LpPositionsByProviderProps> = ({ id
             underlyingAssetRatiosBaseUnit: row.original.underlyingAssetRatiosBaseUnit,
             cryptoAmountBaseUnit: row.original.cryptoAmountBaseUnit,
             assets,
-            marketData,
+            marketDataUserCurrency,
           })
           return (
             <Flex direction='column'>
@@ -200,7 +200,7 @@ export const LpPositionsByProvider: React.FC<LpPositionsByProviderProps> = ({ id
         ),
       },
     ],
-    [assetId, assets, handleClick, marketData, translate],
+    [assetId, assets, handleClick, marketDataUserCurrency, translate],
   )
 
   if (!filteredDown.length) return null

--- a/src/components/EarnDashboard/components/PositionDetails/StakingPositionsByProvider.tsx
+++ b/src/components/EarnDashboard/components/PositionDetails/StakingPositionsByProvider.tsx
@@ -28,7 +28,7 @@ import { getMetadataForProvider } from 'state/slices/opportunitiesSlice/utils/ge
 import {
   selectAggregatedEarnUserStakingOpportunitiesIncludeEmpty,
   selectAssets,
-  selectCryptoMarketData,
+  selectCryptoMarketDataSortedByMarketCapUsd,
 } from 'state/slices/selectors'
 import { useAppSelector } from 'state/store'
 
@@ -82,7 +82,7 @@ export const StakingPositionsByProvider: React.FC<StakingPositionsByProviderProp
     dispatch,
   } = useWallet()
   const assets = useAppSelector(selectAssets)
-  const marketData = useAppSelector(selectCryptoMarketData)
+  const marketData = useAppSelector(selectCryptoMarketDataSortedByMarketCapUsd)
   const stakingOpportunities = useAppSelector(
     selectAggregatedEarnUserStakingOpportunitiesIncludeEmpty,
   )

--- a/src/components/EarnDashboard/components/PositionDetails/StakingPositionsByProvider.tsx
+++ b/src/components/EarnDashboard/components/PositionDetails/StakingPositionsByProvider.tsx
@@ -28,7 +28,7 @@ import { getMetadataForProvider } from 'state/slices/opportunitiesSlice/utils/ge
 import {
   selectAggregatedEarnUserStakingOpportunitiesIncludeEmpty,
   selectAssets,
-  selectCryptoMarketDataSortedByMarketCapUserCurrency,
+  selectCryptoMarketDataUserCurrency,
 } from 'state/slices/selectors'
 import { useAppSelector } from 'state/store'
 
@@ -82,7 +82,7 @@ export const StakingPositionsByProvider: React.FC<StakingPositionsByProviderProp
     dispatch,
   } = useWallet()
   const assets = useAppSelector(selectAssets)
-  const marketDataUserCurrency = useAppSelector(selectCryptoMarketDataSortedByMarketCapUserCurrency)
+  const marketDataUserCurrency = useAppSelector(selectCryptoMarketDataUserCurrency)
   const stakingOpportunities = useAppSelector(
     selectAggregatedEarnUserStakingOpportunitiesIncludeEmpty,
   )

--- a/src/components/EarnDashboard/components/PositionDetails/StakingPositionsByProvider.tsx
+++ b/src/components/EarnDashboard/components/PositionDetails/StakingPositionsByProvider.tsx
@@ -28,7 +28,7 @@ import { getMetadataForProvider } from 'state/slices/opportunitiesSlice/utils/ge
 import {
   selectAggregatedEarnUserStakingOpportunitiesIncludeEmpty,
   selectAssets,
-  selectCryptoMarketDataSortedByMarketCapUsd,
+  selectCryptoMarketDataSortedByMarketCapUserCurrency,
 } from 'state/slices/selectors'
 import { useAppSelector } from 'state/store'
 
@@ -43,7 +43,7 @@ export type RowProps = Row<StakingEarnOpportunityType>
 
 type CalculateRewardFiatAmountArgs = {
   assets: Partial<Record<AssetId, Asset>>
-  marketData: Partial<Record<AssetId, MarketData>>
+  marketDataUserCurrency: Partial<Record<AssetId, MarketData>>
 } & Pick<StakingEarnOpportunityType, 'rewardAssetIds' | 'rewardsCryptoBaseUnit'>
 
 type CalculateRewardFiatAmount = (args: CalculateRewardFiatAmountArgs) => number
@@ -55,13 +55,13 @@ const calculateRewardFiatAmount: CalculateRewardFiatAmount = ({
   rewardsCryptoBaseUnit,
   rewardAssetIds,
   assets,
-  marketData,
+  marketDataUserCurrency,
 }) => {
   if (!rewardAssetIds) return 0
   return Array.from(rewardAssetIds).reduce((sum, assetId, index) => {
     const asset = assets[assetId]
     if (!asset) return sum
-    const marketDataPrice = bnOrZero(marketData[assetId]?.price)
+    const marketDataPrice = bnOrZero(marketDataUserCurrency[assetId]?.price)
     const cryptoAmountPrecision = bnOrZero(rewardsCryptoBaseUnit?.amounts[index]).div(
       bn(10).pow(asset?.precision),
     )
@@ -82,7 +82,7 @@ export const StakingPositionsByProvider: React.FC<StakingPositionsByProviderProp
     dispatch,
   } = useWallet()
   const assets = useAppSelector(selectAssets)
-  const marketData = useAppSelector(selectCryptoMarketDataSortedByMarketCapUsd)
+  const marketDataUserCurrency = useAppSelector(selectCryptoMarketDataSortedByMarketCapUserCurrency)
   const stakingOpportunities = useAppSelector(
     selectAggregatedEarnUserStakingOpportunitiesIncludeEmpty,
   )
@@ -190,7 +190,7 @@ export const StakingPositionsByProvider: React.FC<StakingPositionsByProviderProp
             underlyingAssetRatiosBaseUnit: opportunity.underlyingAssetRatiosBaseUnit,
             cryptoAmountBaseUnit: opportunity.stakedAmountCryptoBaseUnit ?? '0',
             assets,
-            marketData,
+            marketDataUserCurrency,
           })
 
           const cryptoAmountPrecision = isUnderlyingAsset
@@ -232,7 +232,7 @@ export const StakingPositionsByProvider: React.FC<StakingPositionsByProviderProp
             rewardAssetIds: row.original.rewardAssetIds,
             rewardsCryptoBaseUnit: row.original.rewardsCryptoBaseUnit,
             assets,
-            marketData,
+            marketDataUserCurrency,
           })
           const hasRewardsBalance = bnOrZero(fiatAmount).gt(0)
           return hasRewardsBalance && row.original.isClaimableRewards ? (
@@ -261,13 +261,13 @@ export const StakingPositionsByProvider: React.FC<StakingPositionsByProviderProp
             rewardAssetIds: a.original.rewardAssetIds,
             rewardsCryptoBaseUnit: a.original.rewardsCryptoBaseUnit,
             assets,
-            marketData,
+            marketDataUserCurrency,
           })
           const bFiatPrice = calculateRewardFiatAmount({
             rewardAssetIds: b.original.rewardAssetIds,
             rewardsCryptoBaseUnit: b.original.rewardsCryptoBaseUnit,
             assets,
-            marketData,
+            marketDataUserCurrency,
           })
           return aFiatPrice - bFiatPrice
         },
@@ -293,7 +293,7 @@ export const StakingPositionsByProvider: React.FC<StakingPositionsByProviderProp
         ),
       },
     ],
-    [assetId, assets, handleClick, marketData, translate],
+    [assetId, assets, handleClick, marketDataUserCurrency, translate],
   )
 
   if (!filteredDown.length) return null

--- a/src/components/EarnDashboard/components/ProviderDetails/NestedAsset.tsx
+++ b/src/components/EarnDashboard/components/ProviderDetails/NestedAsset.tsx
@@ -7,7 +7,7 @@ import { NestedListItem } from 'components/List/NestedListItem'
 import { AssetCell } from 'components/StakingVaults/Cells'
 import { RawText, Text } from 'components/Text'
 import type { UnderlyingAssetIdsBalances } from 'state/slices/opportunitiesSlice/utils'
-import { selectAssetById, selectMarketDataById } from 'state/slices/selectors'
+import { selectAssetById, selectMarketDataByAssetIdUserCurrency } from 'state/slices/selectors'
 import { useAppSelector } from 'state/store'
 
 import { opportunityRowGrid } from './OpportunityTableHeader'
@@ -34,7 +34,7 @@ export const NestedAsset: React.FC<NestedAssetProps> = ({
 }) => {
   const asset = useAppSelector(state => selectAssetById(state, assetId))
   const borderColor = useColorModeValue('gray.200', 'gray.700')
-  const marketData = useAppSelector(state => selectMarketDataById(state, assetId))
+  const marketData = useAppSelector(state => selectMarketDataByAssetIdUserCurrency(state, assetId))
 
   const subTextJoined = useMemo(() => {
     const typeElement = <RawText>{type}</RawText>

--- a/src/components/EarnDashboard/components/ProviderDetails/OpportunityRow.tsx
+++ b/src/components/EarnDashboard/components/ProviderDetails/OpportunityRow.tsx
@@ -19,7 +19,7 @@ import { getMetadataForProvider } from 'state/slices/opportunitiesSlice/utils/ge
 import {
   selectAssetById,
   selectAssets,
-  selectSelectedCurrencyMarketDataSortedByMarketCap,
+  selectCryptoMarketDataSortedByMarketCapUserCurrency,
 } from 'state/slices/selectors'
 import { useAppSelector } from 'state/store'
 
@@ -56,7 +56,7 @@ export const OpportunityRow: React.FC<
   const history = useHistory()
   const asset = useAppSelector(state => selectAssetById(state, underlyingAssetId))
   const assets = useAppSelector(selectAssets)
-  const marketData = useAppSelector(selectSelectedCurrencyMarketDataSortedByMarketCap)
+  const marketData = useAppSelector(selectCryptoMarketDataSortedByMarketCapUserCurrency)
 
   const rewardsBalances = useMemo(() => {
     if (!(opportunity as StakingEarnOpportunityType)?.rewardsCryptoBaseUnit) return []

--- a/src/components/EarnDashboard/components/ProviderDetails/OpportunityRow.tsx
+++ b/src/components/EarnDashboard/components/ProviderDetails/OpportunityRow.tsx
@@ -19,7 +19,7 @@ import { getMetadataForProvider } from 'state/slices/opportunitiesSlice/utils/ge
 import {
   selectAssetById,
   selectAssets,
-  selectCryptoMarketDataSortedByMarketCapUserCurrency,
+  selectCryptoMarketDataUserCurrency,
 } from 'state/slices/selectors'
 import { useAppSelector } from 'state/store'
 
@@ -56,7 +56,7 @@ export const OpportunityRow: React.FC<
   const history = useHistory()
   const asset = useAppSelector(state => selectAssetById(state, underlyingAssetId))
   const assets = useAppSelector(selectAssets)
-  const marketData = useAppSelector(selectCryptoMarketDataSortedByMarketCapUserCurrency)
+  const marketDataUserCurrency = useAppSelector(selectCryptoMarketDataUserCurrency)
 
   const rewardsBalances = useMemo(() => {
     if (!(opportunity as StakingEarnOpportunityType)?.rewardsCryptoBaseUnit) return []
@@ -66,9 +66,9 @@ export const OpportunityRow: React.FC<
       rewardAssetIds: earnOpportunity.rewardAssetIds,
       rewardsCryptoBaseUnit: earnOpportunity.rewardsCryptoBaseUnit,
       assets,
-      marketData,
+      marketDataUserCurrency,
     })
-  }, [assets, marketData, opportunity])
+  }, [assets, marketDataUserCurrency, opportunity])
 
   const underlyingAssetBalances = useMemo(() => {
     return getUnderlyingAssetIdsBalances({
@@ -77,13 +77,13 @@ export const OpportunityRow: React.FC<
       underlyingAssetRatiosBaseUnit,
       cryptoAmountBaseUnit,
       assets,
-      marketData,
+      marketDataUserCurrency,
     })
   }, [
     assetId,
     assets,
     cryptoAmountBaseUnit,
-    marketData,
+    marketDataUserCurrency,
     underlyingAssetIds,
     underlyingAssetRatiosBaseUnit,
   ])
@@ -239,7 +239,7 @@ export const OpportunityRow: React.FC<
               lineHeight='shorter'
             />
             <Amount.Percent
-              value={bnOrZero(marketData[asset.assetId]?.changePercent24Hr)
+              value={bnOrZero(marketDataUserCurrency[asset.assetId]?.changePercent24Hr)
                 .div(100)
                 .toString()}
               autoColor

--- a/src/components/Equity/EquityLpRow.tsx
+++ b/src/components/Equity/EquityLpRow.tsx
@@ -15,7 +15,7 @@ import {
   selectAllEarnUserLpOpportunitiesByFilter,
   selectAssetById,
   selectAssets,
-  selectCryptoMarketDataSortedByMarketCapUserCurrency,
+  selectCryptoMarketDataUserCurrency,
   selectOpportunityApiPending,
 } from 'state/slices/selectors'
 import { useAppSelector } from 'state/store'
@@ -44,7 +44,7 @@ export const EquityLpRow: React.FC<EquityLpRowProps> = ({
   const location = useLocation()
   const isLoading = useAppSelector(selectOpportunityApiPending)
   const assets = useAppSelector(selectAssets)
-  const marketData = useAppSelector(selectCryptoMarketDataSortedByMarketCapUserCurrency)
+  const marketDataUserCurrency = useAppSelector(selectCryptoMarketDataUserCurrency)
   const filter = useMemo(() => {
     return {
       assetId,
@@ -66,7 +66,7 @@ export const EquityLpRow: React.FC<EquityLpRowProps> = ({
     cryptoAmountBaseUnit: opportunity.cryptoAmountBaseUnit,
     assetId: opportunity.id,
     assets,
-    marketData,
+    marketDataUserCurrency,
   })
 
   const handleClick = useCallback(() => {

--- a/src/components/Equity/EquityLpRow.tsx
+++ b/src/components/Equity/EquityLpRow.tsx
@@ -15,8 +15,8 @@ import {
   selectAllEarnUserLpOpportunitiesByFilter,
   selectAssetById,
   selectAssets,
+  selectCryptoMarketDataSortedByMarketCapUserCurrency,
   selectOpportunityApiPending,
-  selectSelectedCurrencyMarketDataSortedByMarketCap,
 } from 'state/slices/selectors'
 import { useAppSelector } from 'state/store'
 
@@ -44,7 +44,7 @@ export const EquityLpRow: React.FC<EquityLpRowProps> = ({
   const location = useLocation()
   const isLoading = useAppSelector(selectOpportunityApiPending)
   const assets = useAppSelector(selectAssets)
-  const marketData = useAppSelector(selectSelectedCurrencyMarketDataSortedByMarketCap)
+  const marketData = useAppSelector(selectCryptoMarketDataSortedByMarketCapUserCurrency)
   const filter = useMemo(() => {
     return {
       assetId,

--- a/src/components/Equity/UnderlyingAsset.tsx
+++ b/src/components/Equity/UnderlyingAsset.tsx
@@ -4,7 +4,7 @@ import type { AssetWithBalance } from 'features/defi/components/Overview/Overvie
 import { useMemo } from 'react'
 import { Amount } from 'components/Amount/Amount'
 import { LazyLoadAvatar } from 'components/LazyLoadAvatar'
-import { selectAssetById, selectMarketDataById } from 'state/slices/selectors'
+import { selectAssetById, selectMarketDataByAssetIdUserCurrency } from 'state/slices/selectors'
 import { useAppSelector } from 'state/store'
 
 export const UnderlyingAsset: React.FC<AssetWithBalance> = ({
@@ -13,7 +13,7 @@ export const UnderlyingAsset: React.FC<AssetWithBalance> = ({
   icon,
 }) => {
   const asset = useAppSelector(state => selectAssetById(state, assetId))
-  const marketData = useAppSelector(state => selectMarketDataById(state, assetId))
+  const marketData = useAppSelector(state => selectMarketDataByAssetIdUserCurrency(state, assetId))
 
   const fiatAmount = useMemo(() => {
     return bnOrZero(cryptoBalancePrecision)

--- a/src/components/Modals/QrCode/Form.tsx
+++ b/src/components/Modals/QrCode/Form.tsx
@@ -13,7 +13,7 @@ import { parseAddressInputWithChainId, parseMaybeUrl } from 'lib/address/address
 import { bnOrZero } from 'lib/bignumber/bignumber'
 import {
   selectAssetById,
-  selectMarketDataById,
+  selectMarketDataByAssetIdUserCurrency,
   selectSelectedCurrency,
 } from 'state/slices/selectors'
 import { store, useAppSelector } from 'state/store'
@@ -103,7 +103,10 @@ export const Form: React.FC<QrCodeFormProps> = ({ accountId }) => {
           methods.setValue(SendFormFields.Input, address)
           methods.setValue(SendFormFields.AssetId, maybeUrlResult.assetId ?? '')
           if (maybeUrlResult.amountCryptoPrecision) {
-            const marketData = selectMarketDataById(store.getState(), maybeUrlResult.assetId ?? '')
+            const marketData = selectMarketDataByAssetIdUserCurrency(
+              store.getState(),
+              maybeUrlResult.assetId ?? '',
+            )
             methods.setValue(
               SendFormFields.AmountCryptoPrecision,
               maybeUrlResult.amountCryptoPrecision,

--- a/src/components/Modals/Send/Form.tsx
+++ b/src/components/Modals/Send/Form.tsx
@@ -9,7 +9,10 @@ import { QrCodeScanner } from 'components/QrCodeScanner/QrCodeScanner'
 import { SelectAssetRouter } from 'components/SelectAssets/SelectAssetRouter'
 import { parseAddressInputWithChainId, parseMaybeUrl } from 'lib/address/address'
 import { bnOrZero } from 'lib/bignumber/bignumber'
-import { selectMarketDataById, selectSelectedCurrency } from 'state/slices/selectors'
+import {
+  selectMarketDataByAssetIdUserCurrency,
+  selectSelectedCurrency,
+} from 'state/slices/selectors'
 import { store, useAppSelector } from 'state/store'
 
 import { useFormSend } from './hooks/useFormSend/useFormSend'
@@ -103,7 +106,10 @@ export const Form: React.FC<SendFormProps> = ({ initialAssetId, input = '', acco
         methods.setValue(SendFormFields.Input, address)
 
         if (maybeUrlResult.assetId && maybeUrlResult.amountCryptoPrecision) {
-          const marketData = selectMarketDataById(store.getState(), maybeUrlResult.assetId ?? '')
+          const marketData = selectMarketDataByAssetIdUserCurrency(
+            store.getState(),
+            maybeUrlResult.assetId ?? '',
+          )
           methods.setValue(
             SendFormFields.AmountCryptoPrecision,
             maybeUrlResult.amountCryptoPrecision,

--- a/src/components/Modals/Send/hooks/useFormSend/useFormSend.test.tsx
+++ b/src/components/Modals/Send/hooks/useFormSend/useFormSend.test.tsx
@@ -42,7 +42,7 @@ vi.mock('state/slices/selectors', async () => {
       },
     }),
     selectAssetById: vi.fn(() => mockEthereum),
-    selectMarketDataById: () => ({ price: '2000' }),
+    selectMarketDataByAssetIdUserCurrency: () => ({ price: '2000' }),
   }
 })
 

--- a/src/components/Modals/Send/hooks/useSendDetails/useSendDetails.test.tsx
+++ b/src/components/Modals/Send/hooks/useSendDetails/useSendDetails.test.tsx
@@ -59,7 +59,7 @@ vi.mock('state/slices/selectors', async () => {
     selectPortfolioCryptoPrecisionBalanceByFilter: vi.fn(),
     selectPortfolioCryptoBalanceBaseUnitByFilter: vi.fn(),
     selectPortfolioUserCurrencyBalanceByFilter: vi.fn(),
-    selectMarketDataById: vi.fn(() => ({
+    selectMarketDataByAssetIdUserCurrency: vi.fn(() => ({
       [ethAssetId]: { price: '2000' },
     })),
   }

--- a/src/components/Modals/Send/hooks/useSendDetails/useSendDetails.test.tsx
+++ b/src/components/Modals/Send/hooks/useSendDetails/useSendDetails.test.tsx
@@ -25,7 +25,7 @@ import { assertGetUtxoChainAdapter } from 'lib/utils/utxo'
 import type { AssetBalancesById } from 'state/slices/portfolioSlice/portfolioSliceCommon'
 import {
   selectFeeAssetById,
-  selectMarketDataById,
+  selectMarketDataByAssetIdUserCurrency,
   selectPortfolioCryptoBalanceBaseUnitByFilter,
   selectPortfolioCryptoPrecisionBalanceByFilter,
   selectPortfolioUserCurrencyBalanceByFilter,
@@ -102,7 +102,7 @@ const setup = ({
     }
   }) as any)
 
-  vi.mocked(selectMarketDataById).mockImplementation((_state, assetId) => {
+  vi.mocked(selectMarketDataByAssetIdUserCurrency).mockImplementation((_state, assetId) => {
     const fakeMarketData = {
       [mockEthereum.assetId]: {
         price: '3500',

--- a/src/components/Modals/Send/hooks/useSendDetails/useSendDetails.tsx
+++ b/src/components/Modals/Send/hooks/useSendDetails/useSendDetails.tsx
@@ -23,7 +23,7 @@ import { assertGetUtxoChainAdapter } from 'lib/utils/utxo'
 import {
   selectAssetById,
   selectFeeAssetById,
-  selectMarketDataById,
+  selectMarketDataByAssetIdUserCurrency,
   selectPortfolioCryptoBalanceBaseUnitByFilter,
   selectPortfolioCryptoPrecisionBalanceByFilter,
   selectPortfolioUserCurrencyBalanceByFilter,
@@ -64,7 +64,9 @@ export const useSendDetails = (): UseSendDetailsReturnType => {
     name: SendFormFields.AccountId,
   })
 
-  const price = bnOrZero(useAppSelector(state => selectMarketDataById(state, assetId)).price)
+  const price = bnOrZero(
+    useAppSelector(state => selectMarketDataByAssetIdUserCurrency(state, assetId)).price,
+  )
 
   const chainAdapterManager = getChainAdapterManager()
   const feeAssetId = chainAdapterManager.get(fromAssetId(assetId).chainId)?.getFeeAssetId()

--- a/src/components/Modals/Send/hooks/useSendFees/useSendFees.test.tsx
+++ b/src/components/Modals/Send/hooks/useSendFees/useSendFees.test.tsx
@@ -21,7 +21,7 @@ vi.mock('state/slices/selectors', () => ({
   ...vi.importActual('state/slices/selectors'),
   selectAssetById: (_state: ReduxState, _id: AssetId) => mockEthereum,
   selectFeeAssetById: (_state: ReduxState, _id: AssetId) => mockEthereum,
-  selectMarketDataById: () => ({ price: '3500' }),
+  selectMarketDataByAssetIdUserCurrency: () => ({ price: '3500' }),
   selectPortfolioAssetIds: () => [],
 }))
 

--- a/src/components/Modals/Send/hooks/useSendFees/useSendFees.tsx
+++ b/src/components/Modals/Send/hooks/useSendFees/useSendFees.tsx
@@ -6,7 +6,7 @@ import { useFormContext, useWatch } from 'react-hook-form'
 import { getChainAdapterManager } from 'context/PluginProvider/chainAdapterSingleton'
 import { useWallet } from 'hooks/useWallet/useWallet'
 import { bn, bnOrZero } from 'lib/bignumber/bignumber'
-import { selectFeeAssetById, selectMarketDataById } from 'state/slices/selectors'
+import { selectFeeAssetById, selectMarketDataByAssetIdUserCurrency } from 'state/slices/selectors'
 import { useAppSelector } from 'state/store'
 
 import type { SendInput } from '../../Form'
@@ -32,7 +32,7 @@ export const useSendFees = () => {
   } = useWallet()
 
   const price = bnOrZero(
-    useAppSelector(state => selectMarketDataById(state, feeAsset.assetId)).price,
+    useAppSelector(state => selectMarketDataByAssetIdUserCurrency(state, feeAsset.assetId)).price,
   )
 
   useEffect(() => {

--- a/src/components/MultiHopTrade/components/MultiHopTradeConfirm/components/AssetSummaryStep.tsx
+++ b/src/components/MultiHopTrade/components/MultiHopTradeConfirm/components/AssetSummaryStep.tsx
@@ -6,7 +6,7 @@ import { getChainAdapterManager } from 'context/PluginProvider/chainAdapterSingl
 import { useLocaleFormatter } from 'hooks/useLocaleFormatter/useLocaleFormatter'
 import { bn } from 'lib/bignumber/bignumber'
 import { fromBaseUnit } from 'lib/math'
-import { selectCryptoMarketDataSortedByMarketCapUsd } from 'state/slices/selectors'
+import { selectCryptoMarketDataSortedByMarketCapUserCurrency } from 'state/slices/selectors'
 import { useAppSelector } from 'state/store'
 
 import { StepperStep } from './StepperStep'
@@ -26,7 +26,9 @@ export const AssetSummaryStep = ({
   const {
     number: { toCrypto, toFiat },
   } = useLocaleFormatter()
-  const fiatPriceByAssetId = useAppSelector(selectCryptoMarketDataSortedByMarketCapUsd)
+  const cryptoMarketDataUserCurrency = useAppSelector(
+    selectCryptoMarketDataSortedByMarketCapUserCurrency,
+  )
 
   const sellAmountCryptoPrecision = useMemo(
     () => fromBaseUnit(amountCryptoBaseUnit, asset.precision),
@@ -39,9 +41,9 @@ export const AssetSummaryStep = ({
   )
 
   const amountFiatFormatted = useMemo(() => {
-    const sellAssetFiatRate = fiatPriceByAssetId[asset.assetId]?.price ?? '0'
-    return toFiat(bn(sellAmountCryptoPrecision).times(sellAssetFiatRate).toString())
-  }, [fiatPriceByAssetId, sellAmountCryptoPrecision, toFiat, asset.assetId])
+    const sellAssetRateUserCurrency = cryptoMarketDataUserCurrency[asset.assetId]?.price ?? '0'
+    return toFiat(bn(sellAmountCryptoPrecision).times(sellAssetRateUserCurrency).toString())
+  }, [cryptoMarketDataUserCurrency, sellAmountCryptoPrecision, toFiat, asset.assetId])
 
   const chainName = useMemo(() => {
     const chainAdapterManager = getChainAdapterManager()

--- a/src/components/MultiHopTrade/components/MultiHopTradeConfirm/components/AssetSummaryStep.tsx
+++ b/src/components/MultiHopTrade/components/MultiHopTradeConfirm/components/AssetSummaryStep.tsx
@@ -6,7 +6,7 @@ import { getChainAdapterManager } from 'context/PluginProvider/chainAdapterSingl
 import { useLocaleFormatter } from 'hooks/useLocaleFormatter/useLocaleFormatter'
 import { bn } from 'lib/bignumber/bignumber'
 import { fromBaseUnit } from 'lib/math'
-import { selectCryptoMarketDataSortedByMarketCapUserCurrency } from 'state/slices/selectors'
+import { selectCryptoMarketDataUserCurrency } from 'state/slices/selectors'
 import { useAppSelector } from 'state/store'
 
 import { StepperStep } from './StepperStep'
@@ -26,9 +26,7 @@ export const AssetSummaryStep = ({
   const {
     number: { toCrypto, toFiat },
   } = useLocaleFormatter()
-  const cryptoMarketDataUserCurrency = useAppSelector(
-    selectCryptoMarketDataSortedByMarketCapUserCurrency,
-  )
+  const marketDataUserCurrency = useAppSelector(selectCryptoMarketDataUserCurrency)
 
   const sellAmountCryptoPrecision = useMemo(
     () => fromBaseUnit(amountCryptoBaseUnit, asset.precision),
@@ -41,9 +39,9 @@ export const AssetSummaryStep = ({
   )
 
   const amountFiatFormatted = useMemo(() => {
-    const sellAssetRateUserCurrency = cryptoMarketDataUserCurrency[asset.assetId]?.price ?? '0'
+    const sellAssetRateUserCurrency = marketDataUserCurrency[asset.assetId]?.price ?? '0'
     return toFiat(bn(sellAmountCryptoPrecision).times(sellAssetRateUserCurrency).toString())
-  }, [cryptoMarketDataUserCurrency, sellAmountCryptoPrecision, toFiat, asset.assetId])
+  }, [marketDataUserCurrency, sellAmountCryptoPrecision, toFiat, asset.assetId])
 
   const chainName = useMemo(() => {
     const chainAdapterManager = getChainAdapterManager()

--- a/src/components/MultiHopTrade/components/MultiHopTradeConfirm/components/AssetSummaryStep.tsx
+++ b/src/components/MultiHopTrade/components/MultiHopTradeConfirm/components/AssetSummaryStep.tsx
@@ -6,7 +6,7 @@ import { getChainAdapterManager } from 'context/PluginProvider/chainAdapterSingl
 import { useLocaleFormatter } from 'hooks/useLocaleFormatter/useLocaleFormatter'
 import { bn } from 'lib/bignumber/bignumber'
 import { fromBaseUnit } from 'lib/math'
-import { selectCryptoMarketData } from 'state/slices/selectors'
+import { selectCryptoMarketDataSortedByMarketCapUsd } from 'state/slices/selectors'
 import { useAppSelector } from 'state/store'
 
 import { StepperStep } from './StepperStep'
@@ -26,7 +26,7 @@ export const AssetSummaryStep = ({
   const {
     number: { toCrypto, toFiat },
   } = useLocaleFormatter()
-  const fiatPriceByAssetId = useAppSelector(selectCryptoMarketData)
+  const fiatPriceByAssetId = useAppSelector(selectCryptoMarketDataSortedByMarketCapUsd)
 
   const sellAmountCryptoPrecision = useMemo(
     () => fromBaseUnit(amountCryptoBaseUnit, asset.precision),

--- a/src/components/MultiHopTrade/components/TradeAssetInput.tsx
+++ b/src/components/MultiHopTrade/components/TradeAssetInput.tsx
@@ -5,7 +5,7 @@ import type { TradeAmountInputProps } from 'components/MultiHopTrade/components/
 import { TradeAmountInput } from 'components/MultiHopTrade/components/TradeAmountInput'
 import { bnOrZero } from 'lib/bignumber/bignumber'
 import {
-  selectMarketDataById,
+  selectMarketDataByAssetIdUserCurrency,
   selectPortfolioCryptoPrecisionBalanceByFilter,
 } from 'state/slices/selectors'
 import { useAppSelector } from 'state/store'
@@ -32,7 +32,7 @@ type AssetInputLoadedProps = Omit<TradeAmountInputProps, 'onMaxClick'> & { asset
 
 const AssetInputWithAsset: React.FC<AssetInputLoadedProps> = memo(props => {
   const { assetId, accountId } = props
-  const marketData = useAppSelector(state => selectMarketDataById(state, assetId))
+  const marketData = useAppSelector(state => selectMarketDataByAssetIdUserCurrency(state, assetId))
 
   const filter = useMemo(
     () => ({

--- a/src/components/MultiHopTrade/components/TradeInput/components/TradeQuotes/TradeQuote.tsx
+++ b/src/components/MultiHopTrade/components/TradeInput/components/TradeQuotes/TradeQuote.tsx
@@ -19,8 +19,8 @@ import {
   selectInputBuyAsset,
   selectInputSellAmountCryptoPrecision,
   selectInputSellAsset,
+  selectMarketDataByAssetIdUserCurrency,
   selectMarketDataByFilter,
-  selectMarketDataById,
   selectUserSlippagePercentageDecimal,
 } from 'state/slices/selectors'
 import {
@@ -83,7 +83,7 @@ export const TradeQuote: FC<TradeQuoteProps> = memo(
     const userSlippagePercentageDecimal = useAppSelector(selectUserSlippagePercentageDecimal)
 
     const buyAssetMarketData = useAppSelector(state =>
-      selectMarketDataById(state, buyAsset.assetId ?? ''),
+      selectMarketDataByAssetIdUserCurrency(state, buyAsset.assetId ?? ''),
     )
 
     const sellAmountCryptoPrecision = useAppSelector(selectInputSellAmountCryptoPrecision)

--- a/src/components/StakingVaults/PositionTable.tsx
+++ b/src/components/StakingVaults/PositionTable.tsx
@@ -21,7 +21,7 @@ import type { AggregatedOpportunitiesByAssetIdReturn } from 'state/slices/opport
 import {
   selectAggregatedEarnOpportunitiesByAssetId,
   selectAssetById,
-  selectAssetsByMarketCap,
+  selectAssetsSortedByMarketCap,
   selectFeeAssetByChainId,
   selectOpportunityApiPending,
 } from 'state/slices/selectors'
@@ -71,7 +71,7 @@ export const PositionTable: React.FC<PositionTableProps> = ({
   searchQuery,
 }) => {
   const translate = useTranslate()
-  const assets = useAppSelector(selectAssetsByMarketCap)
+  const assets = useAppSelector(selectAssetsSortedByMarketCap)
   const isLoading = useAppSelector(selectOpportunityApiPending)
   const selectAggregatedEarnOpportunitiesByAssetIdParams = useMemo(
     () => ({

--- a/src/components/TransactionHistoryRows/TransactionDetails/ApprovalAmount.tsx
+++ b/src/components/TransactionHistoryRows/TransactionDetails/ApprovalAmount.tsx
@@ -3,7 +3,7 @@ import type { AssetId } from '@shapeshiftoss/caip'
 import type { TxMetadata } from '@shapeshiftoss/chain-adapters'
 import { useMemo } from 'react'
 import { useTranslate } from 'react-polyglot'
-import { selectAssetById, selectMarketDataById } from 'state/slices/selectors'
+import { selectAssetById, selectMarketDataByAssetIdUserCurrency } from 'state/slices/selectors'
 import { useAppSelector } from 'state/store'
 
 import { makeAmountOrDefault } from '../utils'
@@ -24,7 +24,9 @@ export const ApprovalAmount = ({
   const translate = useTranslate()
 
   const approvedAsset = useAppSelector(state => selectAssetById(state, assetId))
-  const approvedAssetMarketData = useAppSelector(state => selectMarketDataById(state, assetId))
+  const approvedAssetMarketData = useAppSelector(state =>
+    selectMarketDataByAssetIdUserCurrency(state, assetId),
+  )
   const amountOrDefault = useMemo(
     () => makeAmountOrDefault(value, approvedAssetMarketData, approvedAsset, parser),
     [parser, approvedAsset, approvedAssetMarketData, value],

--- a/src/features/defi/components/Deposit/PairDepositWithAllocation.tsx
+++ b/src/features/defi/components/Deposit/PairDepositWithAllocation.tsx
@@ -23,7 +23,7 @@ import type {
 } from 'state/slices/opportunitiesSlice/types'
 import {
   selectAssetById,
-  selectMarketDataById,
+  selectMarketDataByAssetIdUserCurrency,
   selectPortfolioCryptoBalanceBaseUnitByFilter,
 } from 'state/slices/selectors'
 import { useAppSelector } from 'state/store'
@@ -147,10 +147,10 @@ export const PairDepositWithAllocation = ({
     .toString()
 
   const asset0MarketData = useAppSelector(state =>
-    selectMarketDataById(state, asset0?.assetId ?? ''),
+    selectMarketDataByAssetIdUserCurrency(state, asset0?.assetId ?? ''),
   )
   const asset1MarketData = useAppSelector(state =>
-    selectMarketDataById(state, asset1?.assetId ?? ''),
+    selectMarketDataByAssetIdUserCurrency(state, asset1?.assetId ?? ''),
   )
 
   const icons = opportunity.icons

--- a/src/features/defi/providers/cosmos/components/CosmosManager/Claim/components/Confirm.tsx
+++ b/src/features/defi/providers/cosmos/components/CosmosManager/Claim/components/Confirm.tsx
@@ -27,7 +27,7 @@ import {
   selectAssetById,
   selectAssets,
   selectBIP44ParamsByAccountId,
-  selectMarketDataById,
+  selectMarketDataByAssetIdUserCurrency,
 } from 'state/slices/selectors'
 import { useAppSelector } from 'state/store'
 
@@ -54,7 +54,7 @@ export const Confirm: React.FC<ConfirmProps> = ({ accountId, onNext }) => {
   const assets = useAppSelector(selectAssets)
   const asset = useAppSelector(state => selectAssetById(state, opportunity?.assetId ?? ''))
   const assetMarketData = useAppSelector(state =>
-    selectMarketDataById(state, opportunity.assetId ?? ''),
+    selectMarketDataByAssetIdUserCurrency(state, opportunity.assetId ?? ''),
   )
   const feeAssetId = toAssetId({
     chainId,
@@ -62,7 +62,9 @@ export const Confirm: React.FC<ConfirmProps> = ({ accountId, onNext }) => {
     assetReference,
   })
   const feeAsset = useAppSelector(state => selectAssetById(state, feeAssetId))
-  const feeMarketData = useAppSelector(state => selectMarketDataById(state, feeAssetId))
+  const feeMarketData = useAppSelector(state =>
+    selectMarketDataByAssetIdUserCurrency(state, feeAssetId),
+  )
 
   const claimAmount = bnOrZero(opportunity?.rewardsCryptoBaseUnit?.amounts[0]).toString()
   const claimFiatAmount = useMemo(

--- a/src/features/defi/providers/cosmos/components/CosmosManager/Claim/components/Status.tsx
+++ b/src/features/defi/providers/cosmos/components/CosmosManager/Claim/components/Status.tsx
@@ -19,7 +19,11 @@ import { useBrowserRouter } from 'hooks/useBrowserRouter/useBrowserRouter'
 import { bn, bnOrZero } from 'lib/bignumber/bignumber'
 import { trackOpportunityEvent } from 'lib/mixpanel/helpers'
 import { MixPanelEvent } from 'lib/mixpanel/types'
-import { selectAssetById, selectAssets, selectMarketDataById } from 'state/slices/selectors'
+import {
+  selectAssetById,
+  selectAssets,
+  selectMarketDataByAssetIdUserCurrency,
+} from 'state/slices/selectors'
 import { useAppSelector } from 'state/store'
 
 import { TxStatus } from '../ClaimCommon'
@@ -57,7 +61,9 @@ export const Status: React.FC<StatusProps> = ({ accountId }) => {
   const assetId = toAssetId({ chainId, assetNamespace, assetReference })
   // Asset Info
   const asset = useAppSelector(state => selectAssetById(state, assetId)) // TODO: diff denom for rewards
-  const assetMarketData = useAppSelector(state => selectMarketDataById(state, assetId))
+  const assetMarketData = useAppSelector(state =>
+    selectMarketDataByAssetIdUserCurrency(state, assetId),
+  )
   if (!asset) throw new Error(`Asset not found for AssetId ${assetId}`)
   const userAddress: string | undefined = accountId && fromAccountId(accountId).account
 

--- a/src/features/defi/providers/cosmos/components/CosmosManager/Deposit/CosmosDeposit.tsx
+++ b/src/features/defi/providers/cosmos/components/CosmosManager/Deposit/CosmosDeposit.tsx
@@ -23,7 +23,7 @@ import { serializeUserStakingId, toValidatorId } from 'state/slices/opportunitie
 import {
   selectAssetById,
   selectEarnUserStakingOpportunityByUserStakingId,
-  selectMarketDataById,
+  selectMarketDataByAssetIdUserCurrency,
   selectPortfolioLoading,
 } from 'state/slices/selectors'
 import { useAppSelector } from 'state/store'
@@ -53,7 +53,7 @@ export const CosmosDeposit: React.FC<CosmosDepositProps> = ({
   const asset = useAppSelector(state => selectAssetById(state, assetId))
   if (!asset) throw new Error(`Asset not found for AssetId ${assetId}`)
 
-  const marketData = useAppSelector(state => selectMarketDataById(state, assetId))
+  const marketData = useAppSelector(state => selectMarketDataByAssetIdUserCurrency(state, assetId))
 
   // user info
   const { state: walletState } = useWallet()

--- a/src/features/defi/providers/cosmos/components/CosmosManager/Deposit/components/Confirm.tsx
+++ b/src/features/defi/providers/cosmos/components/CosmosManager/Deposit/components/Confirm.tsx
@@ -32,7 +32,7 @@ import {
   selectAssetById,
   selectAssets,
   selectBIP44ParamsByAccountId,
-  selectMarketDataById,
+  selectMarketDataByAssetIdUserCurrency,
   selectPortfolioCryptoPrecisionBalanceByFilter,
   selectStakingOpportunityByFilter,
 } from 'state/slices/selectors'
@@ -71,9 +71,13 @@ export const Confirm: React.FC<ConfirmProps> = ({ onNext, accountId }) => {
   const wallet = useWallet().state.wallet
 
   const asset = useAppSelector(state => selectAssetById(state, assetId))
-  const assetMarketData = useAppSelector(state => selectMarketDataById(state, assetId))
+  const assetMarketData = useAppSelector(state =>
+    selectMarketDataByAssetIdUserCurrency(state, assetId),
+  )
   const feeAsset = useAppSelector(state => selectAssetById(state, feeAssetId))
-  const feeMarketData = useAppSelector(state => selectMarketDataById(state, feeAssetId))
+  const feeMarketData = useAppSelector(state =>
+    selectMarketDataByAssetIdUserCurrency(state, feeAssetId),
+  )
 
   const cryptoAmount = useMemo(
     () => bnOrZero(state?.deposit.cryptoAmount).toString(),
@@ -101,7 +105,7 @@ export const Confirm: React.FC<ConfirmProps> = ({ onNext, accountId }) => {
     selectPortfolioCryptoPrecisionBalanceByFilter(state, filter),
   )
 
-  const marketData = useAppSelector(state => selectMarketDataById(state, assetId))
+  const marketData = useAppSelector(state => selectMarketDataByAssetIdUserCurrency(state, assetId))
 
   const { handleStakingAction } = useStakingAction()
 

--- a/src/features/defi/providers/cosmos/components/CosmosManager/Deposit/components/Deposit.tsx
+++ b/src/features/defi/providers/cosmos/components/CosmosManager/Deposit/components/Deposit.tsx
@@ -25,7 +25,7 @@ import { toValidatorId } from 'state/slices/opportunitiesSlice/utils'
 import {
   selectAssetById,
   selectAssets,
-  selectMarketDataById,
+  selectMarketDataByAssetIdUserCurrency,
   selectPortfolioCryptoBalanceBaseUnitByFilter,
   selectStakingOpportunityByFilter,
 } from 'state/slices/selectors'
@@ -66,7 +66,7 @@ export const Deposit: React.FC<DepositProps> = ({
   const asset = useAppSelector(state => selectAssetById(state, assetId))
   if (!asset) throw new Error(`Asset not found for AssetId ${assetId}`)
 
-  const marketData = useAppSelector(state => selectMarketDataById(state, assetId))
+  const marketData = useAppSelector(state => selectMarketDataByAssetIdUserCurrency(state, assetId))
 
   const apy = useMemo(() => state?.apy ?? '', [state])
 

--- a/src/features/defi/providers/cosmos/components/CosmosManager/Deposit/components/Status.tsx
+++ b/src/features/defi/providers/cosmos/components/CosmosManager/Deposit/components/Status.tsx
@@ -23,7 +23,7 @@ import { toValidatorId } from 'state/slices/opportunitiesSlice/utils'
 import {
   selectAssetById,
   selectAssets,
-  selectMarketDataById,
+  selectMarketDataByAssetIdUserCurrency,
   selectStakingOpportunityByFilter,
 } from 'state/slices/selectors'
 import { useAppSelector } from 'state/store'
@@ -43,7 +43,9 @@ export const Status = () => {
   const assetId = toAssetId({ chainId, assetNamespace, assetReference })
 
   const asset = useAppSelector(state => selectAssetById(state, assetId))
-  const assetMarketData = useAppSelector(state => selectMarketDataById(state, assetId))
+  const assetMarketData = useAppSelector(state =>
+    selectMarketDataByAssetIdUserCurrency(state, assetId),
+  )
   if (!asset) throw new Error(`Asset not found for AssetId ${assetId}`)
 
   const validatorId = toValidatorId({ chainId, account: contractAddress })

--- a/src/features/defi/providers/cosmos/components/CosmosManager/Overview/CosmosOverview.tsx
+++ b/src/features/defi/providers/cosmos/components/CosmosManager/Overview/CosmosOverview.tsx
@@ -34,7 +34,7 @@ import {
   selectAssets,
   selectHasClaimByUserStakingId,
   selectHighestBalanceAccountIdByStakingId,
-  selectMarketDataById,
+  selectMarketDataByAssetIdUserCurrency,
   selectSelectedLocale,
   selectStakingOpportunityByFilter,
   selectUserStakingOpportunityByUserStakingId,
@@ -132,7 +132,9 @@ export const CosmosOverview: React.FC<CosmosOverviewProps> = ({
     [userStakingOpportunity],
   )
 
-  const marketData = useAppSelector(state => selectMarketDataById(state, stakingAssetId))
+  const marketData = useAppSelector(state =>
+    selectMarketDataByAssetIdUserCurrency(state, stakingAssetId),
+  )
   const cryptoAmountAvailable = totalBondings.div(bn(10).pow(stakingAsset.precision))
   const fiatAmountAvailable = bnOrZero(cryptoAmountAvailable).times(marketData.price)
 

--- a/src/features/defi/providers/cosmos/components/CosmosManager/Withdraw/CosmosWithdraw.tsx
+++ b/src/features/defi/providers/cosmos/components/CosmosManager/Withdraw/CosmosWithdraw.tsx
@@ -23,7 +23,7 @@ import {
   selectAssetById,
   selectBIP44ParamsByAccountId,
   selectEarnUserStakingOpportunityByUserStakingId,
-  selectMarketDataById,
+  selectMarketDataByAssetIdUserCurrency,
 } from 'state/slices/selectors'
 import { useAppSelector } from 'state/store'
 
@@ -60,13 +60,15 @@ export const CosmosWithdraw: React.FC<CosmosWithdrawProps> = ({
   if (!asset) throw new Error(`Asset not found for AssetId ${assetId}`)
   if (!underlyingAsset) throw new Error(`Asset not found for AssetId ${underlyingAssetId}`)
 
-  const marketData = useAppSelector(state => selectMarketDataById(state, assetId))
+  const marketData = useAppSelector(state => selectMarketDataByAssetIdUserCurrency(state, assetId))
   const feeAssetId = toAssetId({
     chainId,
     assetNamespace,
     assetReference,
   })
-  const feeMarketData = useAppSelector(state => selectMarketDataById(state, feeAssetId))
+  const feeMarketData = useAppSelector(state =>
+    selectMarketDataByAssetIdUserCurrency(state, feeAssetId),
+  )
 
   // user info
   const chainAdapterManager = getChainAdapterManager()

--- a/src/features/defi/providers/cosmos/components/CosmosManager/Withdraw/components/Confirm.tsx
+++ b/src/features/defi/providers/cosmos/components/CosmosManager/Withdraw/components/Confirm.tsx
@@ -35,7 +35,7 @@ import {
   selectAssetById,
   selectAssets,
   selectBIP44ParamsByAccountId,
-  selectMarketDataById,
+  selectMarketDataByAssetIdUserCurrency,
   selectPortfolioCryptoPrecisionBalanceByFilter,
   selectStakingOpportunityByFilter,
 } from 'state/slices/selectors'
@@ -81,14 +81,18 @@ export const Confirm: React.FC<ConfirmProps> = ({ onNext, accountId }) => {
   const unbondingDays = useMemo(() => assetIdToUnbondingDays(assetId), [assetId])
   const assets = useAppSelector(selectAssets)
   const asset = useAppSelector(state => selectAssetById(state, assetId))
-  const assetMarketData = useAppSelector(state => selectMarketDataById(state, assetId))
+  const assetMarketData = useAppSelector(state =>
+    selectMarketDataByAssetIdUserCurrency(state, assetId),
+  )
   const feeAssetId = toAssetId({
     chainId,
     assetNamespace,
     assetReference,
   })
   const feeAsset = useAppSelector(state => selectAssetById(state, feeAssetId))
-  const feeMarketData = useAppSelector(state => selectMarketDataById(state, feeAssetId))
+  const feeMarketData = useAppSelector(state =>
+    selectMarketDataByAssetIdUserCurrency(state, feeAssetId),
+  )
 
   const fiatAmount = useMemo(
     () =>

--- a/src/features/defi/providers/cosmos/components/CosmosManager/Withdraw/components/Status.tsx
+++ b/src/features/defi/providers/cosmos/components/CosmosManager/Withdraw/components/Status.tsx
@@ -24,7 +24,7 @@ import { toValidatorId } from 'state/slices/opportunitiesSlice/utils'
 import {
   selectAssetById,
   selectAssets,
-  selectMarketDataById,
+  selectMarketDataByAssetIdUserCurrency,
   selectStakingOpportunityByFilter,
 } from 'state/slices/selectors'
 import { useAppSelector } from 'state/store'
@@ -59,7 +59,7 @@ export const Status: React.FC<StatusProps> = ({ accountId }) => {
   })
   const underlyingAsset = useAppSelector(state => selectAssetById(state, underlyingAssetId))
   const underlyingAssetMarketData = useAppSelector(state =>
-    selectMarketDataById(state, underlyingAssetId),
+    selectMarketDataByAssetIdUserCurrency(state, underlyingAssetId),
   )
   if (!underlyingAsset) throw new Error(`Asset not found for AssetId ${underlyingAssetId}`)
 

--- a/src/features/defi/providers/cosmos/components/CosmosManager/Withdraw/components/Withdraw.tsx
+++ b/src/features/defi/providers/cosmos/components/CosmosManager/Withdraw/components/Withdraw.tsx
@@ -24,7 +24,7 @@ import {
   selectAssetById,
   selectAssets,
   selectEarnUserStakingOpportunityByUserStakingId,
-  selectMarketDataById,
+  selectMarketDataByAssetIdUserCurrency,
 } from 'state/slices/selectors'
 import { useAppSelector } from 'state/store'
 
@@ -69,7 +69,7 @@ export const Withdraw: React.FC<WithdrawProps> = ({
   const asset = useAppSelector(state => selectAssetById(state, assetId))
   if (!asset) throw new Error(`Asset not found for AssetId ${assetId}`)
 
-  const marketData = useAppSelector(state => selectMarketDataById(state, assetId))
+  const marketData = useAppSelector(state => selectMarketDataByAssetIdUserCurrency(state, assetId))
 
   // Staking Asset Info
   const stakingAssetId = toAssetId({

--- a/src/features/defi/providers/fox-farming/components/FoxFarmingManager/Claim/ClaimConfirm.tsx
+++ b/src/features/defi/providers/fox-farming/components/FoxFarmingManager/Claim/ClaimConfirm.tsx
@@ -42,7 +42,7 @@ import {
   selectAssetById,
   selectAssets,
   selectEarnUserStakingOpportunityByUserStakingId,
-  selectMarketDataById,
+  selectMarketDataByAssetIdUserCurrency,
   selectPortfolioCryptoPrecisionBalanceByFilter,
 } from 'state/slices/selectors'
 import { useAppSelector } from 'state/store'
@@ -93,13 +93,17 @@ export const ClaimConfirm = ({ accountId, assetId, amount, onBack }: ClaimConfir
 
   // Asset Info
   const asset = useAppSelector(state => selectAssetById(state, assetId))
-  const assetMarketData = useAppSelector(state => selectMarketDataById(state, assetId))
+  const assetMarketData = useAppSelector(state =>
+    selectMarketDataByAssetIdUserCurrency(state, assetId),
+  )
   const feeAssetId = getChainAdapterManager().get(chainId)?.getFeeAssetId()
   if (!feeAssetId) throw new Error(`Cannot get fee AssetId not found for ChainId ${chainId}`)
   const feeAsset = useAppSelector(state => selectAssetById(state, feeAssetId))
   if (!feeAsset) throw new Error(`Fee asset not found for AssetId ${feeAssetId}`)
 
-  const feeMarketData = useAppSelector(state => selectMarketDataById(state, feeAssetId))
+  const feeMarketData = useAppSelector(state =>
+    selectMarketDataByAssetIdUserCurrency(state, feeAssetId),
+  )
 
   const claimFiatAmount = useMemo(
     () => bnOrZero(amount).times(assetMarketData.price).toString(),

--- a/src/features/defi/providers/fox-farming/components/FoxFarmingManager/Claim/ClaimStatus.tsx
+++ b/src/features/defi/providers/fox-farming/components/FoxFarmingManager/Claim/ClaimStatus.tsx
@@ -23,7 +23,7 @@ import {
   selectAssetById,
   selectAssets,
   selectEarnUserStakingOpportunityByUserStakingId,
-  selectMarketDataById,
+  selectMarketDataByAssetIdUserCurrency,
   selectTxById,
 } from 'state/slices/selectors'
 import { serializeTxIndex } from 'state/slices/txHistorySlice/utils'
@@ -99,13 +99,17 @@ export const ClaimStatus: React.FC<ClaimStatusProps> = ({ accountId }) => {
 
   // Asset Info
   const asset = useAppSelector(state => selectAssetById(state, assetId))
-  const assetMarketData = useAppSelector(state => selectMarketDataById(state, assetId))
+  const assetMarketData = useAppSelector(state =>
+    selectMarketDataByAssetIdUserCurrency(state, assetId),
+  )
   const feeAssetId = getChainAdapterManager().get(chainId)?.getFeeAssetId()
   if (!feeAssetId) throw new Error(`Cannot get fee AssetId not found for ChainId ${chainId}`)
   const feeAsset = useAppSelector(state => selectAssetById(state, feeAssetId))
   if (!feeAsset) throw new Error(`Fee asset not found for AssetId ${feeAssetId}`)
 
-  const feeMarketData = useAppSelector(state => selectMarketDataById(state, feeAssetId))
+  const feeMarketData = useAppSelector(state =>
+    selectMarketDataByAssetIdUserCurrency(state, feeAssetId),
+  )
 
   const accountAddress = useMemo(
     () => (accountId ? fromAccountId(accountId).account : null),

--- a/src/features/defi/providers/fox-farming/components/FoxFarmingManager/Deposit/FoxFarmingDeposit.tsx
+++ b/src/features/defi/providers/fox-farming/components/FoxFarmingManager/Deposit/FoxFarmingDeposit.tsx
@@ -21,7 +21,7 @@ import { useBrowserRouter } from 'hooks/useBrowserRouter/useBrowserRouter'
 import { toOpportunityId } from 'state/slices/opportunitiesSlice/utils'
 import {
   selectAggregatedEarnUserStakingOpportunityByStakingId,
-  selectMarketDataById,
+  selectMarketDataByAssetIdUserCurrency,
   selectPortfolioLoading,
 } from 'state/slices/selectors'
 import { useAppSelector } from 'state/store'
@@ -48,7 +48,7 @@ export const FoxFarmingDeposit: React.FC<FoxFarmingDepositProps> = ({
   const { assetNamespace, chainId, contractAddress, assetReference } = query
 
   const assetId = toAssetId({ chainId, assetNamespace, assetReference })
-  const marketData = useAppSelector(state => selectMarketDataById(state, assetId))
+  const marketData = useAppSelector(state => selectMarketDataByAssetIdUserCurrency(state, assetId))
 
   const { farmingAccountId } = useFoxEth()
 

--- a/src/features/defi/providers/fox-farming/components/FoxFarmingManager/Deposit/components/Approve.tsx
+++ b/src/features/defi/providers/fox-farming/components/FoxFarmingManager/Deposit/components/Approve.tsx
@@ -27,7 +27,7 @@ import {
   selectAggregatedEarnUserStakingOpportunityByStakingId,
   selectAssetById,
   selectAssets,
-  selectMarketDataById,
+  selectMarketDataByAssetIdUserCurrency,
 } from 'state/slices/selectors'
 import { useAppSelector } from 'state/store'
 
@@ -76,7 +76,9 @@ export const Approve: React.FC<FoxFarmingApproveProps> = ({ accountId, onNext })
   const asset = useAppSelector(state =>
     selectAssetById(state, foxFarmingOpportunity?.underlyingAssetId ?? ''),
   )
-  const feeMarketData = useAppSelector(state => selectMarketDataById(state, feeAssetId))
+  const feeMarketData = useAppSelector(state =>
+    selectMarketDataByAssetIdUserCurrency(state, feeAssetId),
+  )
 
   const handleApprove = useCallback(async () => {
     if (

--- a/src/features/defi/providers/fox-farming/components/FoxFarmingManager/Deposit/components/Confirm.tsx
+++ b/src/features/defi/providers/fox-farming/components/FoxFarmingManager/Deposit/components/Confirm.tsx
@@ -31,7 +31,7 @@ import {
   selectAggregatedEarnUserStakingOpportunityByStakingId,
   selectAssetById,
   selectAssets,
-  selectMarketDataById,
+  selectMarketDataByAssetIdUserCurrency,
   selectPortfolioCryptoPrecisionBalanceByFilter,
 } from 'state/slices/selectors'
 import { useAppSelector } from 'state/store'
@@ -80,7 +80,9 @@ export const Confirm: React.FC<StepComponentProps & { accountId: AccountId | und
     selectAssetById(state, foxFarmingOpportunity?.underlyingAssetId ?? ''),
   )
 
-  const feeMarketData = useAppSelector(state => selectMarketDataById(state, feeAssetId))
+  const feeMarketData = useAppSelector(state =>
+    selectMarketDataByAssetIdUserCurrency(state, feeAssetId),
+  )
 
   // user info
   const { state: walletState } = useWallet()

--- a/src/features/defi/providers/fox-farming/components/FoxFarmingManager/Deposit/components/Deposit.tsx
+++ b/src/features/defi/providers/fox-farming/components/FoxFarmingManager/Deposit/components/Deposit.tsx
@@ -28,7 +28,7 @@ import {
   selectAggregatedEarnUserStakingOpportunityByStakingId,
   selectAssetById,
   selectAssets,
-  selectMarketDataById,
+  selectMarketDataByAssetIdUserCurrency,
   selectPortfolioCryptoBalanceBaseUnitByFilter,
 } from 'state/slices/selectors'
 import { useAppSelector } from 'state/store'
@@ -112,7 +112,9 @@ export const Deposit: React.FC<DepositProps> = ({
   })
   const rewardAsset = useAppSelector(state => selectAssetById(state, rewardAssetId))
 
-  const marketData = useAppSelector(state => selectMarketDataById(state, underlyingAssetId ?? ''))
+  const marketData = useAppSelector(state =>
+    selectMarketDataByAssetIdUserCurrency(state, underlyingAssetId ?? ''),
+  )
 
   // notify
   const toast = useToast()

--- a/src/features/defi/providers/fox-farming/components/FoxFarmingManager/Deposit/components/Status.tsx
+++ b/src/features/defi/providers/fox-farming/components/FoxFarmingManager/Deposit/components/Status.tsx
@@ -27,7 +27,7 @@ import {
   selectAggregatedEarnUserStakingOpportunityByStakingId,
   selectAssetById,
   selectAssets,
-  selectMarketDataById,
+  selectMarketDataByAssetIdUserCurrency,
   selectTxById,
 } from 'state/slices/selectors'
 import { serializeTxIndex } from 'state/slices/txHistorySlice/utils'
@@ -71,7 +71,9 @@ export const Status: React.FC<StatusProps> = ({ accountId }) => {
   const asset = useAppSelector(state =>
     selectAssetById(state, foxFarmingOpportunity?.underlyingAssetId ?? ''),
   )
-  const feeMarketData = useAppSelector(state => selectMarketDataById(state, feeAssetId))
+  const feeMarketData = useAppSelector(state =>
+    selectMarketDataByAssetIdUserCurrency(state, feeAssetId),
+  )
 
   if (!asset)
     throw new Error(`Asset not found for AssetId ${foxFarmingOpportunity?.underlyingAssetId}`)

--- a/src/features/defi/providers/fox-farming/components/FoxFarmingManager/Overview/FoxFarmingOverview.tsx
+++ b/src/features/defi/providers/fox-farming/components/FoxFarmingManager/Overview/FoxFarmingOverview.tsx
@@ -30,7 +30,7 @@ import {
   selectAssets,
   selectFirstAccountIdByChainId,
   selectHighestBalanceAccountIdByStakingId,
-  selectSelectedCurrencyMarketDataSortedByMarketCap,
+  selectCryptoMarketDataSortedByMarketCapUserCurrency,
   selectUnderlyingStakingAssetsWithBalancesAndIcons,
   selectUserStakingOpportunityByUserStakingId,
 } from 'state/slices/selectors'
@@ -54,7 +54,7 @@ export const FoxFarmingOverview: React.FC<FoxFarmingOverviewProps> = ({
   const lpAsset = assets[foxEthLpAssetId]
   if (!lpAsset) throw new Error(`Asset not found for AssetId ${foxEthLpAssetId}`)
 
-  const marketData = useAppSelector(selectSelectedCurrencyMarketDataSortedByMarketCap)
+  const marketData = useAppSelector(selectCryptoMarketDataSortedByMarketCapUserCurrency)
   const { query, history, location } = useBrowserRouter<DefiQueryParams, DefiParams>()
   const { assetNamespace, chainId, contractAddress, rewardId } = query
 

--- a/src/features/defi/providers/fox-farming/components/FoxFarmingManager/Overview/FoxFarmingOverview.tsx
+++ b/src/features/defi/providers/fox-farming/components/FoxFarmingManager/Overview/FoxFarmingOverview.tsx
@@ -28,9 +28,9 @@ import {
 import {
   selectAssetById,
   selectAssets,
+  selectCryptoMarketDataUserCurrency,
   selectFirstAccountIdByChainId,
   selectHighestBalanceAccountIdByStakingId,
-  selectCryptoMarketDataSortedByMarketCapUserCurrency,
   selectUnderlyingStakingAssetsWithBalancesAndIcons,
   selectUserStakingOpportunityByUserStakingId,
 } from 'state/slices/selectors'
@@ -54,7 +54,7 @@ export const FoxFarmingOverview: React.FC<FoxFarmingOverviewProps> = ({
   const lpAsset = assets[foxEthLpAssetId]
   if (!lpAsset) throw new Error(`Asset not found for AssetId ${foxEthLpAssetId}`)
 
-  const marketData = useAppSelector(selectCryptoMarketDataSortedByMarketCapUserCurrency)
+  const marketDataUserCurrency = useAppSelector(selectCryptoMarketDataUserCurrency)
   const { query, history, location } = useBrowserRouter<DefiQueryParams, DefiParams>()
   const { assetNamespace, chainId, contractAddress, rewardId } = query
 
@@ -114,10 +114,11 @@ export const FoxFarmingOverview: React.FC<FoxFarmingOverviewProps> = ({
       bnOrZero(opportunityData?.stakedAmountCryptoBaseUnit),
       stakingAsset.precision,
     )
-    const foxEthLpFiatPrice = marketData?.[opportunityData?.underlyingAssetId ?? '']?.price ?? '0'
+    const foxEthLpFiatPrice =
+      marketDataUserCurrency?.[opportunityData?.underlyingAssetId ?? '']?.price ?? '0'
     return bnOrZero(cryptoAmount).times(foxEthLpFiatPrice).toString()
   }, [
-    marketData,
+    marketDataUserCurrency,
     opportunityData?.stakedAmountCryptoBaseUnit,
     opportunityData?.underlyingAssetId,
     stakingAsset,

--- a/src/features/defi/providers/fox-farming/components/FoxFarmingManager/Withdraw/components/Approve.tsx
+++ b/src/features/defi/providers/fox-farming/components/FoxFarmingManager/Withdraw/components/Approve.tsx
@@ -29,7 +29,7 @@ import {
   selectAssetById,
   selectAssets,
   selectEarnUserStakingOpportunityByUserStakingId,
-  selectMarketDataById,
+  selectMarketDataByAssetIdUserCurrency,
 } from 'state/slices/selectors'
 import { useAppSelector } from 'state/store'
 
@@ -80,7 +80,9 @@ export const Approve: React.FC<ApproveProps> = ({ accountId, onNext }) => {
   if (!feeAssetId) throw new Error(`Fee AssetId not found for ChainId ${chainId}`)
   const feeAsset = useAppSelector(state => selectAssetById(state, feeAssetId))
   if (!feeAsset) throw new Error(`Asset not found for AssetId ${feeAssetId}`)
-  const feeMarketData = useAppSelector(state => selectMarketDataById(state, feeAssetId))
+  const feeMarketData = useAppSelector(state =>
+    selectMarketDataByAssetIdUserCurrency(state, feeAssetId),
+  )
 
   // user info
   const {

--- a/src/features/defi/providers/fox-farming/components/FoxFarmingManager/Withdraw/components/Confirm.tsx
+++ b/src/features/defi/providers/fox-farming/components/FoxFarmingManager/Withdraw/components/Confirm.tsx
@@ -30,7 +30,7 @@ import {
   selectAssetById,
   selectAssets,
   selectEarnUserStakingOpportunityByUserStakingId,
-  selectMarketDataById,
+  selectMarketDataByAssetIdUserCurrency,
   selectPortfolioCryptoPrecisionBalanceByFilter,
 } from 'state/slices/selectors'
 import { useAppSelector } from 'state/store'
@@ -76,7 +76,9 @@ export const Confirm: React.FC<ConfirmProps> = ({ accountId, onNext }) => {
   const feeAsset = useAppSelector(state => selectAssetById(state, feeAssetId))
   if (!feeAsset) throw new Error(`Fee asset not found for AssetId ${feeAssetId}`)
 
-  const feeMarketData = useAppSelector(state => selectMarketDataById(state, feeAssetId))
+  const feeMarketData = useAppSelector(state =>
+    selectMarketDataByAssetIdUserCurrency(state, feeAssetId),
+  )
 
   // user info
   const { state: walletState } = useWallet()

--- a/src/features/defi/providers/fox-farming/components/FoxFarmingManager/Withdraw/components/ExpiredWithdraw.tsx
+++ b/src/features/defi/providers/fox-farming/components/FoxFarmingManager/Withdraw/components/ExpiredWithdraw.tsx
@@ -28,7 +28,7 @@ import {
   selectAssetById,
   selectAssets,
   selectEarnUserStakingOpportunityByUserStakingId,
-  selectMarketDataById,
+  selectMarketDataByAssetIdUserCurrency,
 } from 'state/slices/selectors'
 import { useAppSelector } from 'state/store'
 
@@ -85,7 +85,7 @@ export const ExpiredWithdraw: React.FC<ExpiredWithdrawProps> = ({
   if (!rewardAsset) throw new Error(`Asset not found for AssetId ${rewardAssetId}`)
 
   const lpMarketData = useAppSelector(state =>
-    selectMarketDataById(state, opportunity?.underlyingAssetId ?? ''),
+    selectMarketDataByAssetIdUserCurrency(state, opportunity?.underlyingAssetId ?? ''),
   )
 
   // user info

--- a/src/features/defi/providers/fox-farming/components/FoxFarmingManager/Withdraw/components/Status.tsx
+++ b/src/features/defi/providers/fox-farming/components/FoxFarmingManager/Withdraw/components/Status.tsx
@@ -26,7 +26,7 @@ import {
   selectAssetById,
   selectAssets,
   selectEarnUserStakingOpportunityByUserStakingId,
-  selectMarketDataById,
+  selectMarketDataByAssetIdUserCurrency,
   selectTxById,
 } from 'state/slices/selectors'
 import { serializeTxIndex } from 'state/slices/txHistorySlice/utils'
@@ -74,7 +74,9 @@ export const Status: React.FC<StatusProps> = ({ accountId }) => {
   const feeAsset = useAppSelector(state => selectAssetById(state, feeAssetId))
   if (!feeAsset) throw new Error(`Asset not found for AssetId ${feeAssetId}`)
 
-  const feeMarketData = useAppSelector(state => selectMarketDataById(state, feeAssetId))
+  const feeMarketData = useAppSelector(state =>
+    selectMarketDataByAssetIdUserCurrency(state, feeAssetId),
+  )
 
   if (!asset) throw new Error(`Asset not found for AssetId ${opportunity?.underlyingAssetId}`)
 

--- a/src/features/defi/providers/fox-farming/components/FoxFarmingManager/Withdraw/components/Withdraw.tsx
+++ b/src/features/defi/providers/fox-farming/components/FoxFarmingManager/Withdraw/components/Withdraw.tsx
@@ -23,7 +23,7 @@ import {
   selectAssetById,
   selectAssets,
   selectEarnUserStakingOpportunityByUserStakingId,
-  selectMarketDataById,
+  selectMarketDataByAssetIdUserCurrency,
 } from 'state/slices/selectors'
 import { useAppSelector } from 'state/store'
 
@@ -81,7 +81,7 @@ export const Withdraw: React.FC<WithdrawProps> = ({
   if (!feeAsset) throw new Error(`Asset not found for AssetId ${feeAssetId}`)
 
   const marketData = useAppSelector(state =>
-    selectMarketDataById(state, opportunity?.underlyingAssetId ?? ''),
+    selectMarketDataByAssetIdUserCurrency(state, opportunity?.underlyingAssetId ?? ''),
   )
 
   const amountAvailableCryptoPrecision = useMemo(

--- a/src/features/defi/providers/foxy/components/FoxyManager/Deposit/FoxyDeposit.tsx
+++ b/src/features/defi/providers/foxy/components/FoxyManager/Deposit/FoxyDeposit.tsx
@@ -27,7 +27,7 @@ import type { StakingId } from 'state/slices/opportunitiesSlice/types'
 import {
   selectAssetById,
   selectBIP44ParamsByAccountId,
-  selectMarketDataById,
+  selectMarketDataByAssetIdUserCurrency,
   selectPortfolioLoading,
   selectStakingOpportunityByFilter,
 } from 'state/slices/selectors'
@@ -67,7 +67,7 @@ export const FoxyDeposit: React.FC<{
   const stakingAsset = useAppSelector(state => selectAssetById(state, stakingAssetId))
   if (!stakingAsset) throw new Error(`Asset not found for AssetId ${stakingAssetId}`)
 
-  const marketData = useAppSelector(state => selectMarketDataById(state, assetId))
+  const marketData = useAppSelector(state => selectMarketDataByAssetIdUserCurrency(state, assetId))
   const accountFilter = useMemo(() => ({ accountId: accountId ?? '' }), [accountId])
   const bip44Params = useAppSelector(state => selectBIP44ParamsByAccountId(state, accountFilter))
 

--- a/src/features/defi/providers/foxy/components/FoxyManager/Deposit/components/Deposit.tsx
+++ b/src/features/defi/providers/foxy/components/FoxyManager/Deposit/components/Deposit.tsx
@@ -13,7 +13,7 @@ import type { StepComponentProps } from 'components/DeFi/components/Steps'
 import { BigNumber, bn, bnOrZero } from 'lib/bignumber/bignumber'
 import { getFoxyApi } from 'state/apis/foxy/foxyApiSingleton'
 import {
-  selectMarketDataById,
+  selectMarketDataByAssetIdUserCurrency,
   selectPortfolioCryptoBalanceBaseUnitByFilter,
 } from 'state/slices/selectors'
 import { useAppSelector } from 'state/store'
@@ -44,7 +44,7 @@ export const Deposit: React.FC<DepositProps> = ({
     stakingAsset: asset,
   } = useFoxyQuery()
 
-  const marketData = useAppSelector(state => selectMarketDataById(state, assetId))
+  const marketData = useAppSelector(state => selectMarketDataByAssetIdUserCurrency(state, assetId))
 
   const opportunity = useMemo(() => state?.foxyOpportunity, [state])
 

--- a/src/features/defi/providers/foxy/components/FoxyManager/Overview/Claim/ClaimConfirm.tsx
+++ b/src/features/defi/providers/foxy/components/FoxyManager/Overview/Claim/ClaimConfirm.tsx
@@ -35,7 +35,7 @@ import {
   selectAssetById,
   selectBIP44ParamsByAccountId,
   selectEarnUserStakingOpportunityByUserStakingId,
-  selectMarketDataById,
+  selectMarketDataByAssetIdUserCurrency,
 } from 'state/slices/selectors'
 import { useAppSelector } from 'state/store'
 
@@ -69,14 +69,18 @@ export const ClaimConfirm = ({
 
   // Asset Info
   const stakingAsset = useAppSelector(state => selectAssetById(state, stakingAssetId))
-  const assetMarketData = useAppSelector(state => selectMarketDataById(state, stakingAssetId))
+  const assetMarketData = useAppSelector(state =>
+    selectMarketDataByAssetIdUserCurrency(state, stakingAssetId),
+  )
   const feeAssetId = toAssetId({
     chainId,
     assetNamespace: 'slip44',
     assetReference: ASSET_REFERENCE.Ethereum,
   })
   const feeAsset = useAppSelector(state => selectAssetById(state, feeAssetId))
-  const feeMarketData = useAppSelector(state => selectMarketDataById(state, feeAssetId))
+  const feeMarketData = useAppSelector(state =>
+    selectMarketDataByAssetIdUserCurrency(state, feeAssetId),
+  )
 
   if (!stakingAsset) throw new Error(`Asset not found for AssetId ${stakingAssetId}`)
   if (!feeAsset) throw new Error(`Fee asset not found for AssetId ${feeAssetId}`)

--- a/src/features/defi/providers/foxy/components/FoxyManager/Overview/Claim/ClaimStatus.tsx
+++ b/src/features/defi/providers/foxy/components/FoxyManager/Overview/Claim/ClaimStatus.tsx
@@ -21,7 +21,7 @@ import { bnOrZero } from 'lib/bignumber/bignumber'
 import { getFoxyApi } from 'state/apis/foxy/foxyApiSingleton'
 import { opportunitiesApi } from 'state/slices/opportunitiesSlice/opportunitiesApiSlice'
 import { DefiProvider, DefiType } from 'state/slices/opportunitiesSlice/types'
-import { selectAssetById, selectMarketDataById } from 'state/slices/selectors'
+import { selectAssetById, selectMarketDataByAssetIdUserCurrency } from 'state/slices/selectors'
 import { useAppDispatch, useAppSelector } from 'state/store'
 
 interface ClaimStatusState {
@@ -91,7 +91,9 @@ export const ClaimStatus: React.FC<ClaimStatusProps> = ({ accountId }) => {
   const feeAsset = useAppSelector(state => selectAssetById(state, feeAssetId))
   if (!feeAsset) throw new Error(`Fee asset not found for AssetId ${feeAssetId}`)
 
-  const feeMarketData = useAppSelector(state => selectMarketDataById(state, feeAssetId))
+  const feeMarketData = useAppSelector(state =>
+    selectMarketDataByAssetIdUserCurrency(state, feeAssetId),
+  )
 
   const dispatch = useAppDispatch()
   // TODO: maybeRefetchOpportunities heuristics

--- a/src/features/defi/providers/foxy/components/FoxyManager/Overview/FoxyOverview.tsx
+++ b/src/features/defi/providers/foxy/components/FoxyManager/Overview/FoxyOverview.tsx
@@ -31,7 +31,7 @@ import {
   selectEarnUserStakingOpportunityByUserStakingId,
   selectFirstAccountIdByChainId,
   selectHighestBalanceAccountIdByStakingId,
-  selectMarketDataById,
+  selectMarketDataByAssetIdUserCurrency,
   selectSelectedLocale,
 } from 'state/slices/selectors'
 import { useAppSelector } from 'state/store'
@@ -116,7 +116,9 @@ export const FoxyOverview: React.FC<FoxyOverviewProps> = ({
     [foxyEarnOpportunityData],
   )
 
-  const marketData = useAppSelector(state => selectMarketDataById(state, stakingAssetId))
+  const marketData = useAppSelector(state =>
+    selectMarketDataByAssetIdUserCurrency(state, stakingAssetId),
+  )
   const cryptoAmountAvailablePrecision = bnOrZero(
     foxyEarnOpportunityData?.stakedAmountCryptoBaseUnit,
   ).div(bn(10).pow(stakingAsset?.precision ?? 0))

--- a/src/features/defi/providers/foxy/components/FoxyManager/Withdraw/FoxyWithdraw.tsx
+++ b/src/features/defi/providers/foxy/components/FoxyManager/Withdraw/FoxyWithdraw.tsx
@@ -25,7 +25,7 @@ import { bnOrZero } from 'lib/bignumber/bignumber'
 import { getFoxyApi } from 'state/apis/foxy/foxyApiSingleton'
 import {
   selectBIP44ParamsByAccountId,
-  selectMarketDataById,
+  selectMarketDataByAssetIdUserCurrency,
   selectPortfolioLoading,
 } from 'state/slices/selectors'
 import { useAppSelector } from 'state/store'
@@ -49,9 +49,13 @@ export const FoxyWithdraw: React.FC<{
   const { assetReference: foxyStakingContractAddress } = query
   const { feeAssetId, underlyingAsset, underlyingAssetId, stakingAsset } = useFoxyQuery()
 
-  const marketData = useAppSelector(state => selectMarketDataById(state, underlyingAssetId))
+  const marketData = useAppSelector(state =>
+    selectMarketDataByAssetIdUserCurrency(state, underlyingAssetId),
+  )
 
-  const feeMarketData = useAppSelector(state => selectMarketDataById(state, feeAssetId))
+  const feeMarketData = useAppSelector(state =>
+    selectMarketDataByAssetIdUserCurrency(state, feeAssetId),
+  )
   const accountFilter = useMemo(() => ({ accountId: accountId ?? '' }), [accountId])
   const bip44Params = useAppSelector(state => selectBIP44ParamsByAccountId(state, accountFilter))
 

--- a/src/features/defi/providers/foxy/components/FoxyManager/Withdraw/components/Withdraw.tsx
+++ b/src/features/defi/providers/foxy/components/FoxyManager/Withdraw/components/Withdraw.tsx
@@ -20,7 +20,7 @@ import { BigNumber, bn, bnOrZero } from 'lib/bignumber/bignumber'
 import { getFoxyApi } from 'state/apis/foxy/foxyApiSingleton'
 import {
   selectBIP44ParamsByAccountId,
-  selectMarketDataById,
+  selectMarketDataByAssetIdUserCurrency,
   selectPortfolioCryptoBalanceBaseUnitByFilter,
 } from 'state/slices/selectors'
 import { useAppSelector } from 'state/store'
@@ -61,7 +61,7 @@ export const Withdraw: React.FC<
 
   const withdrawTypeValue = watch(Field.WithdrawType)
 
-  const marketData = useAppSelector(state => selectMarketDataById(state, assetId))
+  const marketData = useAppSelector(state => selectMarketDataByAssetIdUserCurrency(state, assetId))
 
   // user info
   const filter = useMemo(() => ({ assetId, accountId: accountId ?? '' }), [assetId, accountId])

--- a/src/features/defi/providers/foxy/components/FoxyManager/useFoxyQuery.ts
+++ b/src/features/defi/providers/foxy/components/FoxyManager/useFoxyQuery.ts
@@ -6,7 +6,7 @@ import type {
 import { useMemo } from 'react'
 import { useBrowserRouter } from 'hooks/useBrowserRouter/useBrowserRouter'
 import { selectAssetById } from 'state/slices/assetsSlice/selectors'
-import { selectMarketDataById } from 'state/slices/marketDataSlice/selectors'
+import { selectMarketDataByAssetIdUserCurrency } from 'state/slices/marketDataSlice/selectors'
 import { selectStakingOpportunityByFilter } from 'state/slices/opportunitiesSlice/selectors'
 import type { StakingId } from 'state/slices/opportunitiesSlice/types'
 import { useAppSelector } from 'state/store'
@@ -38,7 +38,9 @@ export const useFoxyQuery = () => {
     assetReference: ASSET_REFERENCE.Ethereum,
   })
   const feeAsset = useAppSelector(state => selectAssetById(state, feeAssetId))
-  const feeMarketData = useAppSelector(state => selectMarketDataById(state, feeAssetId))
+  const feeMarketData = useAppSelector(state =>
+    selectMarketDataByAssetIdUserCurrency(state, feeAssetId),
+  )
 
   if (!stakingAsset) throw new Error(`Asset not found for AssetId ${stakingAssetId}`)
   if (!feeAsset) throw new Error(`Fee asset not found for AssetId ${feeAssetId}`)

--- a/src/features/defi/providers/thorchain-savers/components/ThorchainSaversManager/Deposit/ThorchainSaversDeposit.tsx
+++ b/src/features/defi/providers/thorchain-savers/components/ThorchainSaversManager/Deposit/ThorchainSaversDeposit.tsx
@@ -28,7 +28,7 @@ import {
   selectAssetById,
   selectEarnUserStakingOpportunityByUserStakingId,
   selectHighestBalanceAccountIdByStakingId,
-  selectMarketDataById,
+  selectMarketDataByAssetIdUserCurrency,
   selectPortfolioAccountMetadataByAccountId,
   selectPortfolioLoading,
 } from 'state/slices/selectors'
@@ -67,7 +67,7 @@ export const ThorchainSaversDeposit: React.FC<YearnDepositProps> = ({
     assetReference,
   })
   const asset = useAppSelector(state => selectAssetById(state, assetId))
-  const marketData = useAppSelector(state => selectMarketDataById(state, assetId))
+  const marketData = useAppSelector(state => selectMarketDataByAssetIdUserCurrency(state, assetId))
 
   // user info
   const loading = useSelector(selectPortfolioLoading)

--- a/src/features/defi/providers/thorchain-savers/components/ThorchainSaversManager/Deposit/components/Approve.tsx
+++ b/src/features/defi/providers/thorchain-savers/components/ThorchainSaversManager/Deposit/components/Approve.tsx
@@ -46,7 +46,7 @@ import {
   selectAssets,
   selectEarnUserStakingOpportunityByUserStakingId,
   selectFeeAssetById,
-  selectMarketDataById,
+  selectMarketDataByAssetIdUserCurrency,
 } from 'state/slices/selectors'
 import { useAppSelector } from 'state/store'
 
@@ -104,7 +104,7 @@ export const Approve: React.FC<ApproveProps> = ({ accountId, onNext }) => {
   const isTokenDeposit = isToken(assetReference)
 
   const feeMarketData = useAppSelector(state =>
-    selectMarketDataById(state, feeAsset?.assetId ?? ''),
+    selectMarketDataByAssetIdUserCurrency(state, feeAsset?.assetId ?? ''),
   )
 
   const { routerContractAddress: saversRouterContractAddress } = useRouterContractAddress({

--- a/src/features/defi/providers/thorchain-savers/components/ThorchainSaversManager/Deposit/components/Confirm.tsx
+++ b/src/features/defi/providers/thorchain-savers/components/ThorchainSaversManager/Deposit/components/Confirm.tsx
@@ -69,7 +69,7 @@ import {
   selectAssetById,
   selectAssets,
   selectFeeAssetById,
-  selectMarketDataById,
+  selectMarketDataByAssetIdUserCurrency,
   selectPortfolioAccountMetadataByAccountId,
   selectPortfolioCryptoBalanceBaseUnitByFilter,
   selectSelectedCurrency,
@@ -121,9 +121,11 @@ export const Confirm: React.FC<ConfirmProps> = ({ accountId, onNext }) => {
 
   const isTokenDeposit = isToken(fromAssetId(assetId).assetReference)
 
-  const marketData = useAppSelector(state => selectMarketDataById(state, assetId ?? ''))
+  const marketData = useAppSelector(state =>
+    selectMarketDataByAssetIdUserCurrency(state, assetId ?? ''),
+  )
   const feeMarketData = useAppSelector(state =>
-    selectMarketDataById(state, feeAsset?.assetId ?? ''),
+    selectMarketDataByAssetIdUserCurrency(state, feeAsset?.assetId ?? ''),
   )
 
   const accountFilter = useMemo(() => ({ accountId }), [accountId])

--- a/src/features/defi/providers/thorchain-savers/components/ThorchainSaversManager/Deposit/components/Deposit.tsx
+++ b/src/features/defi/providers/thorchain-savers/components/ThorchainSaversManager/Deposit/components/Deposit.tsx
@@ -73,7 +73,7 @@ import {
   selectEarnUserStakingOpportunityByUserStakingId,
   selectFeeAssetById,
   selectHighestBalanceAccountIdByStakingId,
-  selectMarketDataById,
+  selectMarketDataByAssetIdUserCurrency,
   selectPortfolioCryptoBalanceBaseUnitByFilter,
 } from 'state/slices/selectors'
 import { useAppSelector } from 'state/store'
@@ -160,7 +160,7 @@ export const Deposit: React.FC<DepositProps> = ({
   const asset: Asset | undefined = useAppSelector(state => selectAssetById(state, assetId))
   if (!asset) throw new Error(`Asset not found for AssetId ${assetId}`)
 
-  const marketData = useAppSelector(state => selectMarketDataById(state, assetId))
+  const marketData = useAppSelector(state => selectMarketDataByAssetIdUserCurrency(state, assetId))
 
   const userAddress: string | undefined = accountId && fromAccountId(accountId).account
   const balanceFilter = useMemo(() => ({ assetId, accountId }), [accountId, assetId])

--- a/src/features/defi/providers/thorchain-savers/components/ThorchainSaversManager/Deposit/components/Status.tsx
+++ b/src/features/defi/providers/thorchain-savers/components/ThorchainSaversManager/Deposit/components/Status.tsx
@@ -28,7 +28,7 @@ import {
   selectAssetById,
   selectAssets,
   selectFeeAssetById,
-  selectMarketDataById,
+  selectMarketDataByAssetIdUserCurrency,
   selectTxById,
 } from 'state/slices/selectors'
 import { serializeTxIndex } from 'state/slices/txHistorySlice/utils'
@@ -62,9 +62,11 @@ export const Status: React.FC<StatusProps> = ({ accountId }) => {
   if (!feeAsset) throw new Error(`Fee asset not found for AssetId ${assetId}`)
 
   const feeMarketData = useAppSelector(state =>
-    selectMarketDataById(state, feeAsset?.assetId ?? ''),
+    selectMarketDataByAssetIdUserCurrency(state, feeAsset?.assetId ?? ''),
   )
-  const marketData = useAppSelector(state => selectMarketDataById(state, assetId ?? ''))
+  const marketData = useAppSelector(state =>
+    selectMarketDataByAssetIdUserCurrency(state, assetId ?? ''),
+  )
 
   const accountAddress = useMemo(() => accountId && fromAccountId(accountId).account, [accountId])
   const userAddress = useMemo(

--- a/src/features/defi/providers/thorchain-savers/components/ThorchainSaversManager/Overview/ThorchainSaversOverview.tsx
+++ b/src/features/defi/providers/thorchain-savers/components/ThorchainSaversManager/Overview/ThorchainSaversOverview.tsx
@@ -55,7 +55,7 @@ import {
   selectEarnUserStakingOpportunityByUserStakingId,
   selectFirstAccountIdByChainId,
   selectHighestBalanceAccountIdByStakingId,
-  selectMarketDataById,
+  selectMarketDataByAssetIdUserCurrency,
   selectOpportunitiesApiQueriesByFilter,
   selectStakingOpportunityByFilter,
   selectTxsByFilter,
@@ -110,7 +110,7 @@ export const ThorchainSaversOverview: React.FC<OverviewProps> = ({
     })()
   }, [asset, assetId])
 
-  const marketData = useAppSelector(state => selectMarketDataById(state, assetId))
+  const marketData = useAppSelector(state => selectMarketDataByAssetIdUserCurrency(state, assetId))
 
   const opportunityId = useMemo(
     () => toOpportunityId({ chainId, assetNamespace, assetReference }),

--- a/src/features/defi/providers/thorchain-savers/components/ThorchainSaversManager/Withdraw/ThorchainSaversWithdraw.tsx
+++ b/src/features/defi/providers/thorchain-savers/components/ThorchainSaversManager/Withdraw/ThorchainSaversWithdraw.tsx
@@ -25,7 +25,7 @@ import {
   selectAssetById,
   selectEarnUserStakingOpportunityByUserStakingId,
   selectHighestBalanceAccountIdByStakingId,
-  selectMarketDataById,
+  selectMarketDataByAssetIdUserCurrency,
   selectPortfolioAccountMetadataByAccountId,
 } from 'state/slices/selectors'
 import { useAppSelector } from 'state/store'
@@ -57,7 +57,7 @@ export const ThorchainSaversWithdraw: React.FC<WithdrawProps> = ({ accountId }) 
   const asset = useAppSelector(state => selectAssetById(state, assetId))
   if (!asset) throw new Error(`Asset not found for AssetId ${assetId}`)
 
-  const marketData = useAppSelector(state => selectMarketDataById(state, assetId))
+  const marketData = useAppSelector(state => selectMarketDataByAssetIdUserCurrency(state, assetId))
 
   const opportunityId = useMemo(
     () => toOpportunityId({ chainId, assetNamespace, assetReference }),

--- a/src/features/defi/providers/thorchain-savers/components/ThorchainSaversManager/Withdraw/components/Confirm.tsx
+++ b/src/features/defi/providers/thorchain-savers/components/ThorchainSaversManager/Withdraw/components/Confirm.tsx
@@ -74,7 +74,7 @@ import {
   selectEarnUserStakingOpportunityByUserStakingId,
   selectFeeAssetById,
   selectHighestBalanceAccountIdByStakingId,
-  selectMarketDataById,
+  selectMarketDataByAssetIdUserCurrency,
   selectPortfolioCryptoBalanceBaseUnitByFilter,
   selectSelectedCurrency,
 } from 'state/slices/selectors'
@@ -144,9 +144,11 @@ export const Confirm: React.FC<ConfirmProps> = ({ accountId, onNext }) => {
 
   const asset = useAppSelector(state => selectAssetById(state, assetId ?? ''))
   const feeAsset = useAppSelector(state => selectFeeAssetById(state, assetId))
-  const marketData = useAppSelector(state => selectMarketDataById(state, assetId ?? ''))
+  const marketData = useAppSelector(state =>
+    selectMarketDataByAssetIdUserCurrency(state, assetId ?? ''),
+  )
   const feeMarketData = useAppSelector(state =>
-    selectMarketDataById(state, feeAsset?.assetId ?? ''),
+    selectMarketDataByAssetIdUserCurrency(state, feeAsset?.assetId ?? ''),
   )
 
   const accountFilter = useMemo(() => ({ accountId }), [accountId])

--- a/src/features/defi/providers/thorchain-savers/components/ThorchainSaversManager/Withdraw/components/Status.tsx
+++ b/src/features/defi/providers/thorchain-savers/components/ThorchainSaversManager/Withdraw/components/Status.tsx
@@ -28,7 +28,7 @@ import {
   selectAssetById,
   selectAssets,
   selectFeeAssetById,
-  selectMarketDataById,
+  selectMarketDataByAssetIdUserCurrency,
   selectTxById,
 } from 'state/slices/selectors'
 import { serializeTxIndex } from 'state/slices/txHistorySlice/utils'
@@ -63,9 +63,11 @@ export const Status: React.FC<StatusProps> = ({ accountId }) => {
   if (!feeAsset) throw new Error(`Fee asset not found for AssetId ${assetId}`)
 
   const feeMarketData = useAppSelector(state =>
-    selectMarketDataById(state, feeAsset?.assetId ?? ''),
+    selectMarketDataByAssetIdUserCurrency(state, feeAsset?.assetId ?? ''),
   )
-  const marketData = useAppSelector(state => selectMarketDataById(state, assetId ?? ''))
+  const marketData = useAppSelector(state =>
+    selectMarketDataByAssetIdUserCurrency(state, assetId ?? ''),
+  )
 
   const accountAddress = useMemo(() => accountId && fromAccountId(accountId).account, [accountId])
   const userAddress = useMemo(

--- a/src/features/defi/providers/thorchain-savers/components/ThorchainSaversManager/Withdraw/components/Withdraw.tsx
+++ b/src/features/defi/providers/thorchain-savers/components/ThorchainSaversManager/Withdraw/components/Withdraw.tsx
@@ -57,7 +57,7 @@ import {
   selectEarnUserStakingOpportunityByUserStakingId,
   selectFeeAssetById,
   selectHighestBalanceAccountIdByStakingId,
-  selectMarketDataById,
+  selectMarketDataByAssetIdUserCurrency,
   selectPortfolioCryptoBalanceBaseUnitByFilter,
 } from 'state/slices/selectors'
 import { useAppSelector } from 'state/store'
@@ -157,7 +157,9 @@ export const Withdraw: React.FC<WithdrawProps> = ({ accountId, fromAddress, onNe
     selectPortfolioCryptoBalanceBaseUnitByFilter(state, balanceFilter),
   )
 
-  const assetMarketData = useAppSelector(state => selectMarketDataById(state, assetId))
+  const assetMarketData = useAppSelector(state =>
+    selectMarketDataByAssetIdUserCurrency(state, assetId),
+  )
   const fiatAmountAvailable = useMemo(
     () => bnOrZero(amountAvailableCryptoPrecision).times(assetMarketData.price),
     [amountAvailableCryptoPrecision, assetMarketData.price],

--- a/src/features/defi/providers/univ2/components/UniV2Manager/Deposit/UniV2Deposit.tsx
+++ b/src/features/defi/providers/univ2/components/UniV2Manager/Deposit/UniV2Deposit.tsx
@@ -21,7 +21,7 @@ import type { LpId } from 'state/slices/opportunitiesSlice/types'
 import {
   selectAssetById,
   selectEarnUserLpOpportunity,
-  selectMarketDataById,
+  selectMarketDataByAssetIdUserCurrency,
   selectPortfolioLoading,
 } from 'state/slices/selectors'
 import { useAppSelector } from 'state/store'
@@ -69,7 +69,7 @@ export const UniV2Deposit: React.FC<UniV2DepositProps> = ({
   const marketData = useAppSelector(
     state =>
       earnUserLpOpportunity?.underlyingAssetId &&
-      selectMarketDataById(state, earnUserLpOpportunity?.underlyingAssetId),
+      selectMarketDataByAssetIdUserCurrency(state, earnUserLpOpportunity?.underlyingAssetId),
   )
 
   const loading = useSelector(selectPortfolioLoading)

--- a/src/features/defi/providers/univ2/components/UniV2Manager/Deposit/components/Approve.tsx
+++ b/src/features/defi/providers/univ2/components/UniV2Manager/Deposit/components/Approve.tsx
@@ -31,7 +31,7 @@ import {
   selectAssetById,
   selectAssets,
   selectEarnUserLpOpportunity,
-  selectMarketDataById,
+  selectMarketDataByAssetIdUserCurrency,
 } from 'state/slices/selectors'
 import { useAppSelector } from 'state/store'
 
@@ -125,7 +125,9 @@ export const Approve: React.FC<UniV2ApproveProps> = ({ accountId, onNext }) => {
   if (!asset1) throw new Error('Missing asset 1')
   if (!feeAsset) throw new Error('Missing fee asset')
 
-  const feeMarketData = useAppSelector(state => selectMarketDataById(state, ethAssetId))
+  const feeMarketData = useAppSelector(state =>
+    selectMarketDataByAssetIdUserCurrency(state, ethAssetId),
+  )
 
   // user info
   const {

--- a/src/features/defi/providers/univ2/components/UniV2Manager/Deposit/components/Confirm.tsx
+++ b/src/features/defi/providers/univ2/components/UniV2Manager/Deposit/components/Confirm.tsx
@@ -29,7 +29,7 @@ import {
   selectAssetById,
   selectAssets,
   selectEarnUserLpOpportunity,
-  selectMarketDataById,
+  selectMarketDataByAssetIdUserCurrency,
   selectPortfolioCryptoPrecisionBalanceByFilter,
 } from 'state/slices/selectors'
 import { useAppSelector } from 'state/store'
@@ -78,7 +78,9 @@ export const Confirm: React.FC<ConfirmProps> = ({ accountId, onNext }) => {
   const asset1 = useAppSelector(state => selectAssetById(state, assetId1))
   const asset0 = useAppSelector(state => selectAssetById(state, assetId0))
   const feeAsset = useAppSelector(state => selectAssetById(state, feeAssetId))
-  const feeMarketData = useAppSelector(state => selectMarketDataById(state, feeAssetId))
+  const feeMarketData = useAppSelector(state =>
+    selectMarketDataByAssetIdUserCurrency(state, feeAssetId),
+  )
   const assets = useAppSelector(selectAssets)
 
   if (!asset1) throw new Error(`Asset not found for AssetId ${assetId1}`)

--- a/src/features/defi/providers/univ2/components/UniV2Manager/Deposit/components/Deposit.tsx
+++ b/src/features/defi/providers/univ2/components/UniV2Manager/Deposit/components/Deposit.tsx
@@ -26,7 +26,7 @@ import {
   selectAssetById,
   selectAssets,
   selectEarnUserLpOpportunity,
-  selectMarketDataById,
+  selectMarketDataByAssetIdUserCurrency,
   selectPortfolioCryptoBalanceBaseUnitByFilter,
 } from 'state/slices/selectors'
 import { useAppSelector } from 'state/store'
@@ -84,8 +84,12 @@ export const Deposit: React.FC<DepositProps> = ({
   const feeAsset = useAppSelector(state => selectAssetById(state, feeAssetId))
   const asset0 = useAppSelector(state => selectAssetById(state, assetId0))
   const asset1 = useAppSelector(state => selectAssetById(state, assetId1))
-  const asset1MarketData = useAppSelector(state => selectMarketDataById(state, assetId1))
-  const asset0MarketData = useAppSelector(state => selectMarketDataById(state, assetId0))
+  const asset1MarketData = useAppSelector(state =>
+    selectMarketDataByAssetIdUserCurrency(state, assetId1),
+  )
+  const asset0MarketData = useAppSelector(state =>
+    selectMarketDataByAssetIdUserCurrency(state, assetId0),
+  )
   const assets = useAppSelector(selectAssets)
 
   if (!lpAsset) throw new Error(`Asset not found for AssetId ${lpAssetId}`)

--- a/src/features/defi/providers/univ2/components/UniV2Manager/Deposit/components/Status.tsx
+++ b/src/features/defi/providers/univ2/components/UniV2Manager/Deposit/components/Status.tsx
@@ -25,7 +25,7 @@ import {
   selectAssetById,
   selectAssets,
   selectEarnUserLpOpportunity,
-  selectMarketDataById,
+  selectMarketDataByAssetIdUserCurrency,
   selectTxById,
 } from 'state/slices/selectors'
 import { serializeTxIndex } from 'state/slices/txHistorySlice/utils'
@@ -79,7 +79,9 @@ export const Status: React.FC<StatusProps> = ({ accountId }) => {
   if (!asset0) throw new Error(`Asset not found for AssetId ${assetId0}`)
   if (!feeAsset) throw new Error(`Asset not found for AssetId ${feeAssetId}`)
 
-  const feeMarketData = useAppSelector(state => selectMarketDataById(state, feeAssetId))
+  const feeMarketData = useAppSelector(state =>
+    selectMarketDataByAssetIdUserCurrency(state, feeAssetId),
+  )
 
   const serializedTxIndex = useMemo(() => {
     if (!(state?.txid && accountAddress && accountId)) return ''

--- a/src/features/defi/providers/univ2/components/UniV2Manager/Withdraw/components/Approve.tsx
+++ b/src/features/defi/providers/univ2/components/UniV2Manager/Withdraw/components/Approve.tsx
@@ -31,7 +31,7 @@ import {
   selectAssetById,
   selectAssets,
   selectEarnUserLpOpportunity,
-  selectMarketDataById,
+  selectMarketDataByAssetIdUserCurrency,
 } from 'state/slices/selectors'
 import { useAppSelector } from 'state/store'
 
@@ -89,7 +89,9 @@ export const Approve: React.FC<UniV2ApproveProps> = ({ accountId, onNext }) => {
   if (!asset1) throw new Error('Asset 1 not found')
   if (!feeAsset) throw new Error('Fee asset not found')
 
-  const feeMarketData = useAppSelector(state => selectMarketDataById(state, ethAssetId))
+  const feeMarketData = useAppSelector(state =>
+    selectMarketDataByAssetIdUserCurrency(state, ethAssetId),
+  )
 
   // user info
   const {

--- a/src/features/defi/providers/univ2/components/UniV2Manager/Withdraw/components/Confirm.tsx
+++ b/src/features/defi/providers/univ2/components/UniV2Manager/Withdraw/components/Confirm.tsx
@@ -30,7 +30,7 @@ import {
   selectAssetById,
   selectAssets,
   selectEarnUserLpOpportunity,
-  selectMarketDataById,
+  selectMarketDataByAssetIdUserCurrency,
   selectPortfolioCryptoPrecisionBalanceByFilter,
 } from 'state/slices/selectors'
 import { useAppSelector } from 'state/store'
@@ -76,7 +76,9 @@ export const Confirm = ({ accountId, onNext }: ConfirmProps) => {
 
   const feeAsset = useAppSelector(state => selectAssetById(state, ethAssetId))
   const asset0 = useAppSelector(state => selectAssetById(state, assetId0))
-  const ethMarketData = useAppSelector(state => selectMarketDataById(state, ethAssetId))
+  const ethMarketData = useAppSelector(state =>
+    selectMarketDataByAssetIdUserCurrency(state, ethAssetId),
+  )
   const asset1 = useAppSelector(state => {
     return selectAssetById(state, assetId1)
   })

--- a/src/features/defi/providers/univ2/components/UniV2Manager/Withdraw/components/Status.tsx
+++ b/src/features/defi/providers/univ2/components/UniV2Manager/Withdraw/components/Status.tsx
@@ -26,7 +26,7 @@ import {
   selectAssetById,
   selectAssets,
   selectEarnUserLpOpportunity,
-  selectMarketDataById,
+  selectMarketDataByAssetIdUserCurrency,
   selectTxById,
 } from 'state/slices/selectors'
 import { serializeTxIndex } from 'state/slices/txHistorySlice/utils'
@@ -75,7 +75,9 @@ export const Status: React.FC<StatusProps> = ({ accountId }) => {
   if (!asset1) throw new Error(`Asset not found for AssetId ${assetId1}`)
   if (!lpAsset) throw new Error(`Asset not found for AssetId ${lpAssetId}`)
 
-  const ethMarketData = useAppSelector(state => selectMarketDataById(state, ethAssetId))
+  const ethMarketData = useAppSelector(state =>
+    selectMarketDataByAssetIdUserCurrency(state, ethAssetId),
+  )
 
   const accountAddress = useMemo(
     () => (accountId ? fromAccountId(accountId).account : null),

--- a/src/features/defi/providers/univ2/components/UniV2Manager/Withdraw/components/Withdraw.tsx
+++ b/src/features/defi/providers/univ2/components/UniV2Manager/Withdraw/components/Withdraw.tsx
@@ -27,7 +27,7 @@ import {
   selectEarnUserLpOpportunity,
   selectMarketDataById,
   selectPortfolioCryptoBalanceBaseUnitByFilter,
-  selectSelectedCurrencyMarketDataSortedByMarketCap,
+  selectCryptoMarketDataSortedByMarketCapUserCurrency,
 } from 'state/slices/selectors'
 import { useAppSelector } from 'state/store'
 
@@ -47,7 +47,7 @@ export const Withdraw: React.FC<WithdrawProps> = ({
   onAccountIdChange: handleAccountIdChange,
   onNext,
 }) => {
-  const marketData = useAppSelector(selectSelectedCurrencyMarketDataSortedByMarketCap)
+  const marketData = useAppSelector(selectCryptoMarketDataSortedByMarketCapUserCurrency)
   const { state, dispatch } = useContext(WithdrawContext)
   const { history: browserHistory } = useBrowserRouter<DefiQueryParams, DefiParams>()
   const { query } = useBrowserRouter<DefiQueryParams, DefiParams>()

--- a/src/features/defi/providers/univ2/components/UniV2Manager/Withdraw/components/Withdraw.tsx
+++ b/src/features/defi/providers/univ2/components/UniV2Manager/Withdraw/components/Withdraw.tsx
@@ -24,10 +24,10 @@ import type { LpId } from 'state/slices/opportunitiesSlice/types'
 import {
   selectAssetById,
   selectAssets,
+  selectCryptoMarketDataUserCurrency,
   selectEarnUserLpOpportunity,
-  selectMarketDataById,
+  selectMarketDataByAssetIdUserCurrency,
   selectPortfolioCryptoBalanceBaseUnitByFilter,
-  selectCryptoMarketDataSortedByMarketCapUserCurrency,
 } from 'state/slices/selectors'
 import { useAppSelector } from 'state/store'
 
@@ -47,7 +47,7 @@ export const Withdraw: React.FC<WithdrawProps> = ({
   onAccountIdChange: handleAccountIdChange,
   onNext,
 }) => {
-  const marketData = useAppSelector(selectCryptoMarketDataSortedByMarketCapUserCurrency)
+  const marketDataUserCurrency = useAppSelector(selectCryptoMarketDataUserCurrency)
   const { state, dispatch } = useContext(WithdrawContext)
   const { history: browserHistory } = useBrowserRouter<DefiQueryParams, DefiParams>()
   const { query } = useBrowserRouter<DefiQueryParams, DefiParams>()
@@ -103,9 +103,15 @@ export const Withdraw: React.FC<WithdrawProps> = ({
   if (!asset0) throw new Error(`Asset not found for AssetId ${assetId0}`)
   if (!asset1) throw new Error(`Asset not found for AssetId ${assetId1}`)
 
-  const assetMarketData = useAppSelector(state => selectMarketDataById(state, lpAsset?.assetId))
-  const asset0MarketData = useAppSelector(state => selectMarketDataById(state, assetId0))
-  const asset1MarketData = useAppSelector(state => selectMarketDataById(state, assetId1))
+  const assetMarketData = useAppSelector(state =>
+    selectMarketDataByAssetIdUserCurrency(state, lpAsset?.assetId),
+  )
+  const asset0MarketData = useAppSelector(state =>
+    selectMarketDataByAssetIdUserCurrency(state, assetId0),
+  )
+  const asset1MarketData = useAppSelector(state =>
+    selectMarketDataByAssetIdUserCurrency(state, assetId1),
+  )
 
   const asset1AmountCryptoPrecision = useMemo(
     () => fromBaseUnit(asset1AmountCryptoBaseUnit, asset1.precision),
@@ -118,7 +124,7 @@ export const Withdraw: React.FC<WithdrawProps> = ({
 
   const fiatAmountAvailable = bn(
     fromBaseUnit(bnOrZero(uniV2Opportunity?.cryptoAmountBaseUnit), lpAsset.precision),
-  ).times(marketData?.[lpAssetId]?.price ?? '0')
+  ).times(marketDataUserCurrency?.[lpAssetId]?.price ?? '0')
 
   // user info
   const filter = useMemo(

--- a/src/features/defi/providers/univ2/hooks/useUniV2LiquidityPool.ts
+++ b/src/features/defi/providers/univ2/hooks/useUniV2LiquidityPool.ts
@@ -25,7 +25,7 @@ import { uniswapV2Router02AssetId } from 'state/slices/opportunitiesSlice/consta
 import {
   selectAccountNumberByAccountId,
   selectAssetById,
-  selectMarketDataById,
+  selectMarketDataByAssetIdUserCurrency,
 } from 'state/slices/selectors'
 import { useAppSelector } from 'state/store'
 
@@ -69,7 +69,9 @@ export const useUniV2LiquidityPool = ({
   const filter = useMemo(() => ({ accountId }), [accountId])
   const accountNumber = useAppSelector(state => selectAccountNumberByAccountId(state, filter))
   const wallet = useWallet().state.wallet
-  const asset0Price = useAppSelector(state => selectMarketDataById(state, assetId0OrWeth)).price
+  const asset0Price = useAppSelector(state =>
+    selectMarketDataByAssetIdUserCurrency(state, assetId0OrWeth),
+  ).price
 
   const adapter = useMemo(() => assertGetEvmChainAdapter(ethChainId), [])
 

--- a/src/hooks/useTxDetails/useTxDetails.ts
+++ b/src/hooks/useTxDetails/useTxDetails.ts
@@ -9,8 +9,7 @@ import { defaultAsset } from 'state/slices/assetsSlice/assetsSlice'
 import { defaultMarketData } from 'state/slices/marketDataSlice/marketDataSlice'
 import {
   selectAssets,
-  selectAssets,
-  selectCryptoMarketDataSortedByMarketCapUserCurrency,
+  selectCryptoMarketDataUserCurrency,
   selectFeeAssetByChainId,
   selectTxById,
 } from 'state/slices/selectors'
@@ -108,18 +107,21 @@ export const getTransfers = (
 export const useTxDetails = (txId: string): TxDetails => {
   const tx = useAppSelector((state: ReduxState) => selectTxById(state, txId))
   const assets = useAppSelector(selectAssets)
-  const marketData = useAppSelector(selectCryptoMarketDataSortedByMarketCapUserCurrency)
+  const marketDataUserCurrency = useAppSelector(selectCryptoMarketDataUserCurrency)
 
-  const transfers = useMemo(() => getTransfers(tx, assets, marketData), [tx, assets, marketData])
+  const transfers = useMemo(
+    () => getTransfers(tx, assets, marketDataUserCurrency),
+    [tx, assets, marketDataUserCurrency],
+  )
 
   const fee = useMemo(() => {
     if (!tx.fee) return
     return {
       ...tx.fee,
       asset: assets[tx.fee.assetId] ?? defaultAsset,
-      marketData: marketData[tx.fee.assetId] ?? defaultMarketData,
+      marketData: marketDataUserCurrency[tx.fee.assetId] ?? defaultMarketData,
     }
-  }, [tx.fee, assets, marketData])
+  }, [tx.fee, assets, marketDataUserCurrency])
 
   const feeAsset = useAppSelector(state => selectFeeAssetByChainId(state, tx.chainId))
 

--- a/src/hooks/useTxDetails/useTxDetails.ts
+++ b/src/hooks/useTxDetails/useTxDetails.ts
@@ -9,8 +9,9 @@ import { defaultAsset } from 'state/slices/assetsSlice/assetsSlice'
 import { defaultMarketData } from 'state/slices/marketDataSlice/marketDataSlice'
 import {
   selectAssets,
+  selectAssets,
+  selectCryptoMarketDataSortedByMarketCapUserCurrency,
   selectFeeAssetByChainId,
-  selectSelectedCurrencyMarketDataSortedByMarketCap,
   selectTxById,
 } from 'state/slices/selectors'
 import type { Tx } from 'state/slices/txHistorySlice/txHistorySlice'
@@ -107,7 +108,7 @@ export const getTransfers = (
 export const useTxDetails = (txId: string): TxDetails => {
   const tx = useAppSelector((state: ReduxState) => selectTxById(state, txId))
   const assets = useAppSelector(selectAssets)
-  const marketData = useAppSelector(selectSelectedCurrencyMarketDataSortedByMarketCap)
+  const marketData = useAppSelector(selectCryptoMarketDataSortedByMarketCapUserCurrency)
 
   const transfers = useMemo(() => getTransfers(tx, assets, marketData), [tx, assets, marketData])
 

--- a/src/lib/swapper/swappers/utils/test-data/cryptoMarketDataById.ts
+++ b/src/lib/swapper/swappers/utils/test-data/cryptoMarketDataById.ts
@@ -13,7 +13,7 @@ import {
   WETH,
 } from 'lib/swapper/swappers/utils/test-data/assets'
 
-export const cryptoMarketDataById = {
+export const cryptoMarketDataByAssetIdUsd = {
   [FOX_MAINNET.assetId]: { price: '0.04' },
   [FOX_GNOSIS.assetId]: { price: '0.04' },
   [ETH.assetId]: { price: '1300' },

--- a/src/lib/utils/thorchain/balance.ts
+++ b/src/lib/utils/thorchain/balance.ts
@@ -10,7 +10,7 @@ import { queryFn as isSweepNeededQueryFn } from 'pages/Lending/hooks/useIsSweepN
 import { selectPortfolioCryptoBalanceBaseUnitByFilter } from 'state/slices/common-selectors'
 import type { ThorchainSaversWithdrawQuoteResponseSuccess } from 'state/slices/opportunitiesSlice/resolvers/thorchainsavers/types'
 import { isUtxoChainId } from 'state/slices/portfolioSlice/utils'
-import { selectMarketDataById } from 'state/slices/selectors'
+import { selectMarketDataByAssetIdUserCurrency } from 'state/slices/selectors'
 import { store } from 'state/store'
 
 import { fromThorBaseUnit } from '.'
@@ -95,7 +95,7 @@ export const fetchHasEnoughBalanceForTxPlusFeesPlusSweep = async ({
     assetId: asset.assetId,
     accountId,
   })
-  const assetMarketData = selectMarketDataById(store.getState(), asset.assetId)
+  const assetMarketData = selectMarketDataByAssetIdUserCurrency(store.getState(), asset.assetId)
   const quote = await (async () => {
     switch (type) {
       case 'withdraw': {

--- a/src/pages/Lending/Pool/components/Borrow/Borrow.tsx
+++ b/src/pages/Lending/Pool/components/Borrow/Borrow.tsx
@@ -6,7 +6,7 @@ import { MemoryRouter, Route, Switch, useLocation } from 'react-router'
 import { useRouteAssetId } from 'hooks/useRouteAssetId/useRouteAssetId'
 import { bn, bnOrZero } from 'lib/bignumber/bignumber'
 import type { LendingQuoteOpen } from 'lib/utils/thorchain/lending/types'
-import { selectMarketDataById } from 'state/slices/selectors'
+import { selectMarketDataByAssetIdUserCurrency } from 'state/slices/selectors'
 import { useAppSelector } from 'state/store'
 
 import { BorrowRoutePaths } from './types'
@@ -60,7 +60,7 @@ export const Borrow = ({
   const collateralAssetId = useRouteAssetId()
 
   const collateralAssetMarketData = useAppSelector(state =>
-    selectMarketDataById(state, collateralAssetId),
+    selectMarketDataByAssetIdUserCurrency(state, collateralAssetId),
   )
   const handleDepositAmountChange = useCallback(
     (value: string, isFiat?: boolean) => {

--- a/src/pages/Lending/Pool/components/Borrow/BorrowConfirm.tsx
+++ b/src/pages/Lending/Pool/components/Borrow/BorrowConfirm.tsx
@@ -53,7 +53,7 @@ import {
   selectAssetById,
   selectAssets,
   selectFeeAssetById,
-  selectMarketDataById,
+  selectMarketDataByAssetIdUserCurrency,
   selectPortfolioAccountMetadataByAccountId,
   selectSelectedCurrency,
 } from 'state/slices/selectors'
@@ -103,7 +103,7 @@ export const BorrowConfirm = ({
   )
 
   const collateralAssetMarketData = useAppSelector(state =>
-    selectMarketDataById(state, collateralAssetId),
+    selectMarketDataByAssetIdUserCurrency(state, collateralAssetId),
   )
   const { mutateAsync } = useMutation({
     mutationKey: [txId],

--- a/src/pages/Lending/hooks/useGetEstimatedFeesQuery.ts
+++ b/src/pages/Lending/hooks/useGetEstimatedFeesQuery.ts
@@ -5,7 +5,7 @@ import type { EstimateFeesInput } from 'components/Modals/Send/utils'
 import { estimateFees } from 'components/Modals/Send/utils'
 import { bn } from 'lib/bignumber/bignumber'
 import { fromBaseUnit } from 'lib/math'
-import { selectAssetById, selectMarketDataById } from 'state/slices/selectors'
+import { selectAssetById, selectMarketDataByAssetIdUserCurrency } from 'state/slices/selectors'
 import { useAppSelector } from 'state/store'
 
 // For use outside of react with queryClient.fetchQuery()
@@ -28,7 +28,7 @@ export const useGetEstimatedFeesQuery = ({
 }: EstimateFeesInput & { enabled: boolean; disableRefetch?: boolean }) => {
   const asset = useAppSelector(state => selectAssetById(state, estimateFeesInput.assetId))
   const assetMarketData = useAppSelector(state =>
-    selectMarketDataById(state, estimateFeesInput.assetId),
+    selectMarketDataByAssetIdUserCurrency(state, estimateFeesInput.assetId),
   )
 
   const estimatedFeesQueryKey: EstimatedFeesQueryKey = useMemo(

--- a/src/pages/Lending/hooks/useLendingCloseQuery.ts
+++ b/src/pages/Lending/hooks/useLendingCloseQuery.ts
@@ -17,7 +17,7 @@ import type {
 } from 'lib/utils/thorchain/lending/types'
 import { selectAssetById } from 'state/slices/assetsSlice/selectors'
 import {
-  selectMarketDataById,
+  selectMarketDataByAssetIdUserCurrency,
   selectUserCurrencyToUsdRate,
 } from 'state/slices/marketDataSlice/selectors'
 import { selectPortfolioAccountMetadataByAccountId } from 'state/slices/selectors'
@@ -196,11 +196,11 @@ export const useLendingQuoteCloseQuery = ({
   )
   const repaymentAsset = useAppSelector(state => selectAssetById(state, repaymentAssetId))
   const repaymentAssetMarketData = useAppSelector(state =>
-    selectMarketDataById(state, repaymentAssetId),
+    selectMarketDataByAssetIdUserCurrency(state, repaymentAssetId),
   )
 
   const collateralAssetMarketData = useAppSelector(state =>
-    selectMarketDataById(state, collateralAssetId),
+    selectMarketDataByAssetIdUserCurrency(state, collateralAssetId),
   )
 
   const query = useQuery({

--- a/src/pages/Lending/hooks/useLendingPositionData.tsx
+++ b/src/pages/Lending/hooks/useLendingPositionData.tsx
@@ -4,7 +4,7 @@ import { useMemo } from 'react'
 import { fromThorBaseUnit } from 'lib/utils/thorchain'
 import { getThorchainLendingPosition } from 'lib/utils/thorchain/lending'
 import {
-  selectMarketDataById,
+  selectMarketDataByAssetIdUserCurrency,
   selectUserCurrencyToUsdRate,
 } from 'state/slices/marketDataSlice/selectors'
 import { store, useAppSelector } from 'state/store'
@@ -29,7 +29,9 @@ export const useLendingPositionData = ({ accountId, assetId }: UseLendingPositio
     () => ['thorchainLendingPosition', { accountId, assetId }],
     [accountId, assetId],
   )
-  const poolAssetMarketData = useAppSelector(state => selectMarketDataById(state, assetId))
+  const poolAssetMarketData = useAppSelector(state =>
+    selectMarketDataByAssetIdUserCurrency(state, assetId),
+  )
 
   const lendingPositionData = useQuery({
     // This is on purpose. We want lending position data to be cached forever

--- a/src/pages/Lending/hooks/useLendingQuoteQuery.ts
+++ b/src/pages/Lending/hooks/useLendingQuoteQuery.ts
@@ -22,7 +22,7 @@ import type {
 } from 'lib/utils/thorchain/lending/types'
 import { selectAssetById } from 'state/slices/assetsSlice/selectors'
 import {
-  selectMarketDataById,
+  selectMarketDataByAssetIdUserCurrency,
   selectUserCurrencyToUsdRate,
 } from 'state/slices/marketDataSlice/selectors'
 import { selectPortfolioAccountMetadataByAccountId } from 'state/slices/selectors'
@@ -192,11 +192,13 @@ export const useLendingQuoteOpenQuery = ({
   )
   const collateralAsset = useAppSelector(state => selectAssetById(state, collateralAssetId))
   const collateralAssetMarketData = useAppSelector(state =>
-    selectMarketDataById(state, collateralAssetId),
+    selectMarketDataByAssetIdUserCurrency(state, collateralAssetId),
   )
 
   const borrowAsset = useAppSelector(state => selectAssetById(state, _borrowAssetId))
-  const borrowAssetMarketData = useAppSelector(state => selectMarketDataById(state, _borrowAssetId))
+  const borrowAssetMarketData = useAppSelector(state =>
+    selectMarketDataByAssetIdUserCurrency(state, _borrowAssetId),
+  )
 
   const getBorrowAssetReceiveAddress = useCallback(async () => {
     if (!wallet || !_borrowAccountId || !destinationAccountMetadata || !borrowAsset) return

--- a/src/pages/Lending/hooks/usePoolDataQuery.ts
+++ b/src/pages/Lending/hooks/usePoolDataQuery.ts
@@ -4,7 +4,10 @@ import { useMemo } from 'react'
 import { bn, bnOrZero } from 'lib/bignumber/bignumber'
 import { fromThorBaseUnit } from 'lib/utils/thorchain'
 import { getAllThorchainLendingPositions, getThorchainPoolInfo } from 'lib/utils/thorchain/lending'
-import { selectMarketDataById, selectUserCurrencyToUsdRate } from 'state/slices/selectors'
+import {
+  selectMarketDataByAssetIdUserCurrency,
+  selectUserCurrencyToUsdRate,
+} from 'state/slices/selectors'
 import { store, useAppSelector } from 'state/store'
 
 export const usePoolDataQuery = ({ poolAssetId }: { poolAssetId: string }) => {
@@ -13,7 +16,9 @@ export const usePoolDataQuery = ({ poolAssetId }: { poolAssetId: string }) => {
     [poolAssetId],
   )
 
-  const poolAssetMarketData = useAppSelector(state => selectMarketDataById(state, poolAssetId))
+  const poolAssetMarketData = useAppSelector(state =>
+    selectMarketDataByAssetIdUserCurrency(state, poolAssetId),
+  )
 
   const poolDataQuery = useQuery({
     // TODO(gomes): we may or may not want to change this, but this avoids spamming the API for the time being.

--- a/src/pages/ThorChainLP/AvailablePools.tsx
+++ b/src/pages/ThorChainLP/AvailablePools.tsx
@@ -11,7 +11,7 @@ import { Amount } from 'components/Amount/Amount'
 import { CircleIcon } from 'components/Icons/Circle'
 import { Main } from 'components/Layout/Main'
 import { RawText, Text } from 'components/Text'
-import { selectMarketDataById } from 'state/slices/selectors'
+import { selectMarketDataByAssetIdUserCurrency } from 'state/slices/selectors'
 import { useAppSelector } from 'state/store'
 
 import { PoolIcon } from './components/PoolIcon'
@@ -52,7 +52,9 @@ type PoolButtonProps = {
 
 const PoolButton = ({ pool }: PoolButtonProps) => {
   const history = useHistory()
-  const runeMarketData = useAppSelector(state => selectMarketDataById(state, thorchainAssetId))
+  const runeMarketData = useAppSelector(state =>
+    selectMarketDataByAssetIdUserCurrency(state, thorchainAssetId),
+  )
 
   const { data: swapsData } = useQuery({
     ...reactQueries.midgard.swapsData(pool.asset, 'hour', 7 * 24),

--- a/src/pages/ThorChainLP/Pool/components/PairRates.tsx
+++ b/src/pages/ThorChainLP/Pool/components/PairRates.tsx
@@ -5,7 +5,7 @@ import { useHistory } from 'react-router'
 import { Amount } from 'components/Amount/Amount'
 import { AssetIcon } from 'components/AssetIcon'
 import { bn } from 'lib/bignumber/bignumber'
-import { selectAssetById, selectMarketDataById } from 'state/slices/selectors'
+import { selectAssetById, selectMarketDataByAssetIdUserCurrency } from 'state/slices/selectors'
 import { useAppSelector } from 'state/store'
 
 type PairRatesProps = {
@@ -47,8 +47,12 @@ export const PairRates: React.FC<PairRatesProps> = ({ assetIds }) => {
   const history = useHistory()
   const asset0 = useAppSelector(state => selectAssetById(state, assetIds[0]))
   const asset1 = useAppSelector(state => selectAssetById(state, assetIds[1]))
-  const asset0MarketData = useAppSelector(state => selectMarketDataById(state, assetIds[0]))
-  const asset1MarketData = useAppSelector(state => selectMarketDataById(state, assetIds[1]))
+  const asset0MarketData = useAppSelector(state =>
+    selectMarketDataByAssetIdUserCurrency(state, assetIds[0]),
+  )
+  const asset1MarketData = useAppSelector(state =>
+    selectMarketDataByAssetIdUserCurrency(state, assetIds[1]),
+  )
 
   const asset0PricePerAsset1 = bn(asset1MarketData.price).div(asset0MarketData.price).toString()
   const asset1PricePerAsset0 = bn(asset0MarketData.price).div(asset1MarketData.price).toString()

--- a/src/pages/ThorChainLP/Position/Position.tsx
+++ b/src/pages/ThorChainLP/Position/Position.tsx
@@ -34,7 +34,7 @@ import { RawText, Text } from 'components/Text'
 import { poolAssetIdToAssetId } from 'lib/swapper/swappers/ThorchainSwapper/utils/poolAssetHelpers/poolAssetHelpers'
 import { calculateEarnings } from 'lib/utils/thorchain/lp'
 import { AsymSide } from 'lib/utils/thorchain/lp/types'
-import { selectMarketDataById } from 'state/slices/marketDataSlice/selectors'
+import { selectMarketDataByAssetIdUserCurrency } from 'state/slices/marketDataSlice/selectors'
 import { selectAssetById } from 'state/slices/selectors'
 import { useAppSelector } from 'state/store'
 
@@ -164,7 +164,9 @@ export const Position = () => {
 
   const asset = useAppSelector(state => selectAssetById(state, assetId ?? ''))
   const runeAsset = useAppSelector(state => selectAssetById(state, thorchainAssetId))
-  const runeMarketData = useAppSelector(state => selectMarketDataById(state, thorchainAssetId))
+  const runeMarketData = useAppSelector(state =>
+    selectMarketDataByAssetIdUserCurrency(state, thorchainAssetId),
+  )
 
   const { data: earnings, isLoading: isEarningsLoading } = useQuery({
     ...reactQueries.thorchainLp.earnings(position?.dateFirstAdded),

--- a/src/pages/ThorChainLP/YourPositions.tsx
+++ b/src/pages/ThorChainLP/YourPositions.tsx
@@ -14,7 +14,7 @@ import { bn } from 'lib/bignumber/bignumber'
 import { isSome } from 'lib/utils'
 import { calculateEarnings } from 'lib/utils/thorchain/lp'
 import type { UserLpDataPosition } from 'lib/utils/thorchain/lp/types'
-import { selectAssetById, selectMarketDataById } from 'state/slices/selectors'
+import { selectAssetById, selectMarketDataByAssetIdUserCurrency } from 'state/slices/selectors'
 import { useAppSelector } from 'state/store'
 
 import { PoolIcon } from './components/PoolIcon'
@@ -65,7 +65,9 @@ const PositionButton = ({ poolAssetId, position }: PositionButtonProps) => {
 
   const asset = useAppSelector(state => selectAssetById(state, assetId))
   const runeAsset = useAppSelector(state => selectAssetById(state, thorchainAssetId))
-  const runeMarketData = useAppSelector(state => selectMarketDataById(state, thorchainAssetId))
+  const runeMarketData = useAppSelector(state =>
+    selectMarketDataByAssetIdUserCurrency(state, thorchainAssetId),
+  )
 
   const poolAssetIds = useMemo(() => [assetId, thorchainAssetId], [assetId])
 

--- a/src/pages/ThorChainLP/components/AddLiquidity/AddLiquidityInput.tsx
+++ b/src/pages/ThorChainLP/components/AddLiquidity/AddLiquidityInput.tsx
@@ -82,7 +82,7 @@ import {
   selectAssetById,
   selectAssets,
   selectFeeAssetById,
-  selectMarketDataById,
+  selectMarketDataByAssetIdUserCurrency,
   selectPortfolioAccountIdsByAssetId,
   selectPortfolioAccountMetadataByAccountId,
   selectPortfolioCryptoBalanceBaseUnitByFilter,
@@ -273,7 +273,9 @@ export const AddLiquidityInput: React.FC<AddLiquidityInputProps> = ({
 
   useEffect(() => _poolAsset && setPoolAsset(_poolAsset), [_poolAsset])
 
-  const poolAssetMarketData = useAppSelector(state => selectMarketDataById(state, assetId ?? ''))
+  const poolAssetMarketData = useAppSelector(state =>
+    selectMarketDataByAssetIdUserCurrency(state, assetId ?? ''),
+  )
   const poolAssetAccountIds = useAppSelector(state =>
     selectAccountIdsByAssetId(state, { assetId: assetId ?? '' }),
   )
@@ -303,7 +305,7 @@ export const AddLiquidityInput: React.FC<AddLiquidityInputProps> = ({
 
   const poolAssetFeeAsset = useAppSelector(state => selectFeeAssetById(state, assetId ?? ''))
   const poolAssetFeeAssetMarktData = useAppSelector(state =>
-    selectMarketDataById(state, poolAssetFeeAsset?.assetId ?? ''),
+    selectMarketDataByAssetIdUserCurrency(state, poolAssetFeeAsset?.assetId ?? ''),
   )
   const poolAssetFeeAssetBalanceFilter = useMemo(() => {
     return { assetId: poolAssetFeeAsset?.assetId, accountId: poolAssetAccountId }
@@ -313,7 +315,9 @@ export const AddLiquidityInput: React.FC<AddLiquidityInputProps> = ({
   )
 
   const runeAsset = useAppSelector(state => selectAssetById(state, thorchainAssetId))
-  const runeMarketData = useAppSelector(state => selectMarketDataById(state, thorchainAssetId))
+  const runeMarketData = useAppSelector(state =>
+    selectMarketDataByAssetIdUserCurrency(state, thorchainAssetId),
+  )
   const runeAccountIds = useAppSelector(state =>
     selectAccountIdsByAssetId(state, { assetId: thorchainAssetId }),
   )

--- a/src/pages/ThorChainLP/components/PoolInfo.tsx
+++ b/src/pages/ThorChainLP/components/PoolInfo.tsx
@@ -9,7 +9,7 @@ import { AssetIcon } from 'components/AssetIcon'
 import { AssetSymbol } from 'components/AssetSymbol'
 import { Text } from 'components/Text'
 import { selectAssetById } from 'state/slices/assetsSlice/selectors'
-import { selectMarketDataById } from 'state/slices/marketDataSlice/selectors'
+import { selectMarketDataByAssetIdUserCurrency } from 'state/slices/marketDataSlice/selectors'
 import { useAppSelector } from 'state/store'
 
 type ChangeTagProps = {
@@ -64,8 +64,12 @@ export const PoolInfo = ({
 }: PoolInfoProps) => {
   const asset0 = useAppSelector(state => selectAssetById(state, assetIds[0]))
   const asset1 = useAppSelector(state => selectAssetById(state, assetIds[1]))
-  const asset0MarketData = useAppSelector(state => selectMarketDataById(state, assetIds[0]))
-  const asset1MarketData = useAppSelector(state => selectMarketDataById(state, assetIds[1]))
+  const asset0MarketData = useAppSelector(state =>
+    selectMarketDataByAssetIdUserCurrency(state, assetIds[0]),
+  )
+  const asset1MarketData = useAppSelector(state =>
+    selectMarketDataByAssetIdUserCurrency(state, assetIds[1]),
+  )
 
   const volumeChangeTag: JSX.Element = useMemo(() => {
     return <ChangeTag value={volume24hChange} />

--- a/src/pages/ThorChainLP/components/RemoveLiquidity/RemoveLiquidityInput.tsx
+++ b/src/pages/ThorChainLP/components/RemoveLiquidity/RemoveLiquidityInput.tsx
@@ -66,7 +66,7 @@ import {
   selectAccountIdsByAssetId,
   selectAssetById,
   selectFeeAssetById,
-  selectMarketDataById,
+  selectMarketDataByAssetIdUserCurrency,
   selectPortfolioAccountMetadataByAccountId,
 } from 'state/slices/selectors'
 import { useAppSelector } from 'state/store'
@@ -150,14 +150,18 @@ export const RemoveLiquidityInput: React.FC<RemoveLiquidityInputProps> = ({
     selectAccountIdsByAssetId(state, { assetId: thorchainAssetId }),
   )
   const poolAsset = useAppSelector(state => selectAssetById(state, assetId))
-  const poolAssetMarketData = useAppSelector(state => selectMarketDataById(state, assetId))
+  const poolAssetMarketData = useAppSelector(state =>
+    selectMarketDataByAssetIdUserCurrency(state, assetId),
+  )
   const poolAssetFeeAsset = useAppSelector(state => selectFeeAssetById(state, assetId))
   const poolAssetFeeAssetMarktData = useAppSelector(state =>
-    selectMarketDataById(state, poolAssetFeeAsset?.assetId ?? ''),
+    selectMarketDataByAssetIdUserCurrency(state, poolAssetFeeAsset?.assetId ?? ''),
   )
 
   const runeAsset = useAppSelector(state => selectAssetById(state, thorchainAssetId))
-  const runeMarketData = useAppSelector(state => selectMarketDataById(state, thorchainAssetId))
+  const runeMarketData = useAppSelector(state =>
+    selectMarketDataByAssetIdUserCurrency(state, thorchainAssetId),
+  )
 
   const { data: inboundAddressesData } = useQuery({
     ...reactQueries.thornode.inboundAddresses(),

--- a/src/pages/ThorChainLP/queries/hooks/useAllUserLpData.ts
+++ b/src/pages/ThorChainLP/queries/hooks/useAllUserLpData.ts
@@ -10,9 +10,9 @@ import type { Position, UserLpDataPosition } from 'lib/utils/thorchain/lp/types'
 import { findAccountsByAssetId } from 'state/slices/portfolioSlice/utils'
 import {
   selectAssets,
-  selectMarketDataById,
+  selectCryptoMarketDataUserCurrency,
+  selectMarketDataByAssetIdUserCurrency,
   selectPortfolioAccounts,
-  selectCryptoMarketDataSortedByMarketCapUserCurrency,
   selectWalletId,
 } from 'state/slices/selectors'
 import { useAppSelector } from 'state/store'
@@ -29,8 +29,10 @@ export const useAllUserLpData = (): UseQueryResult<UseAllUserLpDataReturn | null
   const assets = useAppSelector(selectAssets)
   const portfolioAccounts = useAppSelector(selectPortfolioAccounts)
   const runeAccountIds = findAccountsByAssetId(portfolioAccounts, thorchainAssetId)
-  const marketData = useAppSelector(selectCryptoMarketDataSortedByMarketCapUserCurrency)
-  const runeMarketData = useAppSelector(state => selectMarketDataById(state, thorchainAssetId))
+  const marketDataUserCurrency = useAppSelector(selectCryptoMarketDataUserCurrency)
+  const runeMarketDataUserCurrency = useAppSelector(state =>
+    selectMarketDataByAssetIdUserCurrency(state, thorchainAssetId),
+  )
   const currentWalletId = useAppSelector(selectWalletId)
 
   const { data: pools, isSuccess } = useQuery({
@@ -76,11 +78,11 @@ export const useAllUserLpData = (): UseQueryResult<UseAllUserLpDataReturn | null
               .map(position =>
                 getUserLpDataPosition({
                   assetId,
-                  assetPrice: marketData[assetId]?.price ?? '0',
+                  assetPrice: marketDataUserCurrency[assetId]?.price ?? '0',
                   assets,
                   pool,
                   position,
-                  runePrice: runeMarketData.price,
+                  runePrice: runeMarketDataUserCurrency.price,
                 }),
               )
               .filter(isSome),
@@ -95,8 +97,8 @@ export const useAllUserLpData = (): UseQueryResult<UseAllUserLpDataReturn | null
     pools,
     portfolioAccounts,
     queryClient,
-    marketData,
-    runeMarketData?.price,
+    marketDataUserCurrency,
+    runeMarketDataUserCurrency?.price,
     runeAccountIds,
   ])
   // We do not expose this as-is, but mapReduce the queries to massage *all* data, in addition to *each* query having its selector

--- a/src/pages/ThorChainLP/queries/hooks/useAllUserLpData.ts
+++ b/src/pages/ThorChainLP/queries/hooks/useAllUserLpData.ts
@@ -12,7 +12,7 @@ import {
   selectAssets,
   selectMarketDataById,
   selectPortfolioAccounts,
-  selectSelectedCurrencyMarketDataSortedByMarketCap,
+  selectCryptoMarketDataSortedByMarketCapUserCurrency,
   selectWalletId,
 } from 'state/slices/selectors'
 import { useAppSelector } from 'state/store'
@@ -29,7 +29,7 @@ export const useAllUserLpData = (): UseQueryResult<UseAllUserLpDataReturn | null
   const assets = useAppSelector(selectAssets)
   const portfolioAccounts = useAppSelector(selectPortfolioAccounts)
   const runeAccountIds = findAccountsByAssetId(portfolioAccounts, thorchainAssetId)
-  const marketData = useAppSelector(selectSelectedCurrencyMarketDataSortedByMarketCap)
+  const marketData = useAppSelector(selectCryptoMarketDataSortedByMarketCapUserCurrency)
   const runeMarketData = useAppSelector(state => selectMarketDataById(state, thorchainAssetId))
   const currentWalletId = useAppSelector(selectWalletId)
 

--- a/src/pages/ThorChainLP/queries/hooks/usePool.ts
+++ b/src/pages/ThorChainLP/queries/hooks/usePool.ts
@@ -13,7 +13,7 @@ import type {
   MidgardSwapHistoryResponse,
   MidgardTvlHistoryResponse,
 } from 'lib/utils/thorchain/lp/types'
-import { selectAssets, selectMarketDataById } from 'state/slices/selectors'
+import { selectAssets, selectMarketDataByAssetIdUserCurrency } from 'state/slices/selectors'
 import { useAppSelector } from 'state/store'
 
 export type Pool = MidgardPoolResponse & {
@@ -149,7 +149,9 @@ export const getVolumeStats = (
 
 export const usePool = (poolAssetId: string) => {
   const assets = useAppSelector(selectAssets)
-  const runeMarketData = useAppSelector(state => selectMarketDataById(state, thorchainAssetId))
+  const runeMarketData = useAppSelector(state =>
+    selectMarketDataByAssetIdUserCurrency(state, thorchainAssetId),
+  )
   const { midgard } = reactQueries
 
   const selectPoolData = useCallback(

--- a/src/pages/ThorChainLP/queries/hooks/usePools.ts
+++ b/src/pages/ThorChainLP/queries/hooks/usePools.ts
@@ -4,7 +4,7 @@ import { useCallback } from 'react'
 import { reactQueries } from 'react-queries'
 import { bn } from 'lib/bignumber/bignumber'
 import type { MidgardPoolResponse } from 'lib/swapper/swappers/ThorchainSwapper/types'
-import { selectAssets, selectMarketDataById } from 'state/slices/selectors'
+import { selectAssets, selectMarketDataByAssetIdUserCurrency } from 'state/slices/selectors'
 import { useAppSelector } from 'state/store'
 
 import type { Pool } from './usePool'
@@ -14,7 +14,9 @@ export type { Pool } from './usePool'
 
 export const usePools = () => {
   const assets = useAppSelector(selectAssets)
-  const runeMarketData = useAppSelector(state => selectMarketDataById(state, thorchainAssetId))
+  const runeMarketData = useAppSelector(state =>
+    selectMarketDataByAssetIdUserCurrency(state, thorchainAssetId),
+  )
 
   const selectPools = useCallback(
     (midgardPools: MidgardPoolResponse[]) => {

--- a/src/pages/ThorChainLP/queries/hooks/useUserLpData.ts
+++ b/src/pages/ThorChainLP/queries/hooks/useUserLpData.ts
@@ -11,7 +11,7 @@ import { fromThorBaseUnit } from 'lib/utils/thorchain'
 import { getPoolShare } from 'lib/utils/thorchain/lp'
 import type { Position, UserLpDataPosition } from 'lib/utils/thorchain/lp/types'
 import { AsymSide } from 'lib/utils/thorchain/lp/types'
-import { selectMarketDataById } from 'state/slices/marketDataSlice/selectors'
+import { selectMarketDataByAssetIdUserCurrency } from 'state/slices/marketDataSlice/selectors'
 import { selectAccountIdsByAssetId, selectAssets, selectWalletId } from 'state/slices/selectors'
 import { useAppSelector } from 'state/store'
 
@@ -99,8 +99,12 @@ export const useUserLpData = ({
   const accountIds = [...(accountId ? [accountId] : assetAccountIds), ...thorchainAccountIds]
   const currentWalletId = useAppSelector(selectWalletId)
 
-  const poolAssetMarketData = useAppSelector(state => selectMarketDataById(state, assetId))
-  const runeMarketData = useAppSelector(state => selectMarketDataById(state, thorchainAssetId))
+  const poolAssetMarketData = useAppSelector(state =>
+    selectMarketDataByAssetIdUserCurrency(state, assetId),
+  )
+  const runeMarketData = useAppSelector(state =>
+    selectMarketDataByAssetIdUserCurrency(state, thorchainAssetId),
+  )
 
   const { data: pool } = useQuery({
     ...reactQueries.thornode.poolData(assetId),

--- a/src/pages/TransactionHistory/DownloadButton.tsx
+++ b/src/pages/TransactionHistory/DownloadButton.tsx
@@ -10,7 +10,7 @@ import { bnOrZero } from 'lib/bignumber/bignumber'
 import { fromBaseUnit } from 'lib/math'
 import {
   selectAssets,
-  selectSelectedCurrencyMarketDataSortedByMarketCap,
+  selectCryptoMarketDataSortedByMarketCapUserCurrency,
   selectTxs,
 } from 'state/slices/selectors'
 import type { TxId } from 'state/slices/txHistorySlice/txHistorySlice'
@@ -48,7 +48,7 @@ export const DownloadButton = ({ txIds }: { txIds: TxId[] }) => {
   const [isLargerThanLg] = useMediaQuery(`(min-width: ${breakpoints['lg']})`, { ssr: false })
   const allTxs = useAppSelector(selectTxs)
   const assets = useAppSelector(selectAssets)
-  const marketData = useAppSelector(selectSelectedCurrencyMarketDataSortedByMarketCap)
+  const marketData = useAppSelector(selectCryptoMarketDataSortedByMarketCapUserCurrency)
   const translate = useTranslate()
   const fields = useMemo(
     () => ({

--- a/src/pages/TransactionHistory/DownloadButton.tsx
+++ b/src/pages/TransactionHistory/DownloadButton.tsx
@@ -8,11 +8,7 @@ import { Text } from 'components/Text'
 import { getTransfers, getTxType } from 'hooks/useTxDetails/useTxDetails'
 import { bnOrZero } from 'lib/bignumber/bignumber'
 import { fromBaseUnit } from 'lib/math'
-import {
-  selectAssets,
-  selectCryptoMarketDataSortedByMarketCapUserCurrency,
-  selectTxs,
-} from 'state/slices/selectors'
+import { selectAssets, selectCryptoMarketDataUserCurrency, selectTxs } from 'state/slices/selectors'
 import type { TxId } from 'state/slices/txHistorySlice/txHistorySlice'
 import { useAppSelector } from 'state/store'
 import { breakpoints } from 'theme/theme'
@@ -48,7 +44,7 @@ export const DownloadButton = ({ txIds }: { txIds: TxId[] }) => {
   const [isLargerThanLg] = useMediaQuery(`(min-width: ${breakpoints['lg']})`, { ssr: false })
   const allTxs = useAppSelector(selectTxs)
   const assets = useAppSelector(selectAssets)
-  const marketData = useAppSelector(selectCryptoMarketDataSortedByMarketCapUserCurrency)
+  const marketDataUserCurrency = useAppSelector(selectCryptoMarketDataUserCurrency)
   const translate = useTranslate()
   const fields = useMemo(
     () => ({
@@ -74,7 +70,7 @@ export const DownloadButton = ({ txIds }: { txIds: TxId[] }) => {
     const report: ReportRow[] = []
     for (const txId of txIds) {
       const tx = allTxs[txId]
-      const transfers = getTransfers(tx, assets, marketData)
+      const transfers = getTransfers(tx, assets, marketDataUserCurrency)
       const type = getTxType(tx, transfers)
       const feeAsset = tx.fee ? assets[tx.fee?.assetId] : undefined
 
@@ -126,7 +122,7 @@ export const DownloadButton = ({ txIds }: { txIds: TxId[] }) => {
     } finally {
       setIsLoading(false)
     }
-  }, [allTxs, assets, fields, marketData, translate, txIds])
+  }, [allTxs, assets, fields, marketDataUserCurrency, translate, txIds])
 
   return isLargerThanLg ? (
     <Button

--- a/src/plugins/walletConnectToDapps/hooks/useCallRequestEvmFees.ts
+++ b/src/plugins/walletConnectToDapps/hooks/useCallRequestEvmFees.ts
@@ -8,7 +8,7 @@ import type { FeePrice } from 'components/Modals/Send/views/Confirm'
 import { bn, bnOrZero } from 'lib/bignumber/bignumber'
 import { assertGetChainAdapter } from 'lib/utils'
 import { assertGetEvmChainAdapter } from 'lib/utils/evm'
-import { selectAssets, selectMarketDataById } from 'state/slices/selectors'
+import { selectAssets, selectMarketDataByAssetIdUserCurrency } from 'state/slices/selectors'
 import { useAppSelector } from 'state/store'
 
 export function useCallRequestEvmFees(state: WalletConnectState) {
@@ -28,7 +28,8 @@ export function useCallRequestEvmFees(state: WalletConnectState) {
     return feeAsset
   }, [assets, chainId])
   const feeAssetPrice =
-    useAppSelector(state => selectMarketDataById(state, feeAsset?.assetId ?? ''))?.price ?? '0'
+    useAppSelector(state => selectMarketDataByAssetIdUserCurrency(state, feeAsset?.assetId ?? ''))
+      ?.price ?? '0'
 
   useEffect(() => {
     if (!transaction || !accountId || !chainId) return

--- a/src/react-queries/hooks/useQuoteEstimatedFeesQuery.ts
+++ b/src/react-queries/hooks/useQuoteEstimatedFeesQuery.ts
@@ -12,7 +12,7 @@ import type {
   LpConfirmedDepositQuote,
   LpConfirmedWithdrawalQuote,
 } from 'lib/utils/thorchain/lp/types'
-import { selectFeeAssetById, selectMarketDataById } from 'state/slices/selectors'
+import { selectFeeAssetById, selectMarketDataByAssetIdUserCurrency } from 'state/slices/selectors'
 import { useAppSelector } from 'state/store'
 
 export type EstimatedFeesQueryKey = [
@@ -82,7 +82,9 @@ export const useQuoteEstimatedFeesQuery = ({
     [_repaymentAmountCryptoPrecision, confirmedQuote],
   )
   const feeAsset = useAppSelector(state => selectFeeAssetById(state, collateralAssetId))
-  const feeAssetMarketData = useAppSelector(state => selectMarketDataById(state, collateralAssetId))
+  const feeAssetMarketData = useAppSelector(state =>
+    selectMarketDataByAssetIdUserCurrency(state, collateralAssetId),
+  )
   const estimateFeesArgs = useMemo(() => {
     const supportedEvmChainIds = getSupportedEvmChainIds()
     const amountCryptoPrecision =

--- a/src/state/apis/fiatRamps/selectors.ts
+++ b/src/state/apis/fiatRamps/selectors.ts
@@ -8,7 +8,7 @@ import { selectAssetIdParamFromFilter } from 'state/selectors'
 import { defaultMarketData } from 'state/slices/marketDataSlice/marketDataSlice'
 import {
   selectAssets,
-  selectSelectedCurrencyMarketDataSortedByMarketCap,
+  selectCryptoMarketDataSortedByMarketCapUserCurrency,
 } from 'state/slices/selectors'
 
 import { fiatRampApi } from './fiatRamps'
@@ -35,7 +35,7 @@ type AssetWithMarketData = Asset & MarketData
 
 export const selectFiatRampBuyAssetsWithMarketData = createSelector(
   selectAssets,
-  selectSelectedCurrencyMarketDataSortedByMarketCap,
+  selectCryptoMarketDataSortedByMarketCapUserCurrency,
   selectFiatBuyAssetIds,
   (assetsById, cryptoMarketData, assetIds): AssetWithMarketData[] => {
     return assetIds.reduce<AssetWithMarketData[]>((acc, assetId) => {

--- a/src/state/apis/fiatRamps/selectors.ts
+++ b/src/state/apis/fiatRamps/selectors.ts
@@ -6,10 +6,7 @@ import { createSelector } from 'reselect'
 import { createDeepEqualOutputSelector } from 'state/selector-utils'
 import { selectAssetIdParamFromFilter } from 'state/selectors'
 import { defaultMarketData } from 'state/slices/marketDataSlice/marketDataSlice'
-import {
-  selectAssets,
-  selectCryptoMarketDataSortedByMarketCapUserCurrency,
-} from 'state/slices/selectors'
+import { selectAssets, selectCryptoMarketDataUserCurrency } from 'state/slices/selectors'
 
 import { fiatRampApi } from './fiatRamps'
 
@@ -35,7 +32,7 @@ type AssetWithMarketData = Asset & MarketData
 
 export const selectFiatRampBuyAssetsWithMarketData = createSelector(
   selectAssets,
-  selectCryptoMarketDataSortedByMarketCapUserCurrency,
+  selectCryptoMarketDataUserCurrency,
   selectFiatBuyAssetIds,
   (assetsById, cryptoMarketData, assetIds): AssetWithMarketData[] => {
     return assetIds.reduce<AssetWithMarketData[]>((acc, assetId) => {

--- a/src/state/apis/swapper/helpers/getInputOutputRatioFromQuote.test.ts
+++ b/src/state/apis/swapper/helpers/getInputOutputRatioFromQuote.test.ts
@@ -39,7 +39,7 @@ vi.mock('state/slices/marketDataSlice/selectors', async importActual => {
   const actual: Record<any, any> = await importActual()
   return {
     ...actual,
-    selectCryptoMarketData: vi.fn(() => ({
+    selectCryptoMarketDataUsd: vi.fn(() => ({
       [ethAssetId]: mockMarketData({ price: '1844' }),
       [foxAssetId]: mockMarketData({ price: '0.02' }),
       [usdcAssetId]: mockMarketData({ price: '1' }),

--- a/src/state/apis/swapper/helpers/getInputOutputRatioFromQuote.ts
+++ b/src/state/apis/swapper/helpers/getInputOutputRatioFromQuote.ts
@@ -7,7 +7,7 @@ import { fromBaseUnit } from 'lib/math'
 import type { ReduxState } from 'state/reducer'
 import { selectFeeAssetById } from 'state/slices/assetsSlice/selectors'
 import {
-  selectCryptoMarketData,
+  selectCryptoMarketDataSortedByMarketCapUsd,
   selectUsdRateByAssetId,
 } from 'state/slices/marketDataSlice/selectors'
 
@@ -52,7 +52,7 @@ const getTotalNetworkFeeFiatPrecisionWithGetFeeAssetRate = (
  * @returns The total network fee across all hops in USD precision
  */
 const _getTotalNetworkFeeUsdPrecision = (state: ReduxState, quote: TradeQuote): BigNumber => {
-  const cryptoMarketDataById = selectCryptoMarketData(state)
+  const cryptoMarketDataById = selectCryptoMarketDataSortedByMarketCapUsd(state)
 
   const getFeeAssetUsdRate = (feeAssetId: AssetId) => {
     const feeAsset = selectFeeAssetById(state, feeAssetId)

--- a/src/state/apis/swapper/helpers/getInputOutputRatioFromQuote.ts
+++ b/src/state/apis/swapper/helpers/getInputOutputRatioFromQuote.ts
@@ -52,12 +52,12 @@ const getTotalNetworkFeeFiatPrecisionWithGetFeeAssetRate = (
  * @returns The total network fee across all hops in USD precision
  */
 const _getTotalNetworkFeeUsdPrecision = (state: ReduxState, quote: TradeQuote): BigNumber => {
-  const cryptoMarketDataById = selectCryptoMarketDataSortedByMarketCapUsd(state)
+  const cryptoMarketDataSortedByMarketCapUsd = selectCryptoMarketDataSortedByMarketCapUsd(state)
 
   const getFeeAssetUsdRate = (feeAssetId: AssetId) => {
     const feeAsset = selectFeeAssetById(state, feeAssetId)
     if (feeAsset === undefined) throw Error(`missing fee asset for assetId ${feeAssetId}`)
-    const feeAssetMarketData = cryptoMarketDataById[feeAsset.assetId]
+    const feeAssetMarketData = cryptoMarketDataSortedByMarketCapUsd[feeAsset.assetId]
     if (feeAssetMarketData === undefined) throw Error(`missing fee asset for assetId ${feeAssetId}`)
     return feeAssetMarketData.price
   }

--- a/src/state/apis/swapper/helpers/getInputOutputRatioFromQuote.ts
+++ b/src/state/apis/swapper/helpers/getInputOutputRatioFromQuote.ts
@@ -7,7 +7,7 @@ import { fromBaseUnit } from 'lib/math'
 import type { ReduxState } from 'state/reducer'
 import { selectFeeAssetById } from 'state/slices/assetsSlice/selectors'
 import {
-  selectCryptoMarketDataSortedByMarketCapUsd,
+  selectCryptoMarketDataUsd,
   selectUsdRateByAssetId,
 } from 'state/slices/marketDataSlice/selectors'
 
@@ -52,12 +52,12 @@ const getTotalNetworkFeeFiatPrecisionWithGetFeeAssetRate = (
  * @returns The total network fee across all hops in USD precision
  */
 const _getTotalNetworkFeeUsdPrecision = (state: ReduxState, quote: TradeQuote): BigNumber => {
-  const cryptoMarketDataSortedByMarketCapUsd = selectCryptoMarketDataSortedByMarketCapUsd(state)
+  const cryptoMarketDataUsd = selectCryptoMarketDataUsd(state)
 
   const getFeeAssetUsdRate = (feeAssetId: AssetId) => {
     const feeAsset = selectFeeAssetById(state, feeAssetId)
     if (feeAsset === undefined) throw Error(`missing fee asset for assetId ${feeAssetId}`)
-    const feeAssetMarketData = cryptoMarketDataSortedByMarketCapUsd[feeAsset.assetId]
+    const feeAssetMarketData = cryptoMarketDataUsd[feeAsset.assetId]
     if (feeAssetMarketData === undefined) throw Error(`missing fee asset for assetId ${feeAssetId}`)
     return feeAssetMarketData.price
   }

--- a/src/state/apis/zapper/zapperApi.ts
+++ b/src/state/apis/zapper/zapperApi.ts
@@ -17,7 +17,7 @@ import { assets as assetsSlice, makeAsset } from 'state/slices/assetsSlice/asset
 import { selectAssets } from 'state/slices/assetsSlice/selectors'
 import { selectWalletAccountIds } from 'state/slices/common-selectors'
 import { marketData as marketDataSlice } from 'state/slices/marketDataSlice/marketDataSlice'
-import { selectMarketDataById } from 'state/slices/marketDataSlice/selectors'
+import { selectMarketDataByAssetIdUserCurrency } from 'state/slices/marketDataSlice/selectors'
 import { opportunities } from 'state/slices/opportunitiesSlice/opportunitiesSlice'
 import type {
   AssetIdsTuple,
@@ -520,7 +520,7 @@ export const zapper = createApi({
                     return underlyingAssetId!
                   }) as unknown as AssetIdsTuple
 
-                  const assetMarketData = selectMarketDataById(state, assetId)
+                  const assetMarketData = selectMarketDataByAssetIdUserCurrency(state, assetId)
                   const assetPrice =
                     // Claimable assets may not have a price, if that's the case, we use the price of the underlying asset they wrap
                     asset.groupId === 'claimable'
@@ -540,7 +540,10 @@ export const zapper = createApi({
                   }
 
                   underlyingAssetIds.forEach((underlyingAssetId, i) => {
-                    const marketData = selectMarketDataById(state, underlyingAssetId)
+                    const marketData = selectMarketDataByAssetIdUserCurrency(
+                      state,
+                      underlyingAssetId,
+                    )
                     if (marketData.price === '0') {
                       dispatch(
                         marketDataSlice.actions.setCryptoMarketData({

--- a/src/state/slices/assetsSlice/selectors.ts
+++ b/src/state/slices/assetsSlice/selectors.ts
@@ -9,7 +9,7 @@ import type { ReduxState } from 'state/reducer'
 import { createDeepEqualOutputSelector } from 'state/selector-utils'
 import { selectAssetIdParamFromFilter, selectSearchQueryFromFilter } from 'state/selectors'
 
-import { selectCryptoMarketDataIds } from '../marketDataSlice/selectors'
+import { selectCryptoMarketDataIdsSortedByMarketCapUsd } from '../marketDataSlice/selectors'
 import { assetIdToFeeAssetId } from '../portfolioSlice/utils'
 import { getFeeAssetByAssetId, getFeeAssetByChainId } from './utils'
 
@@ -65,7 +65,7 @@ export const selectAssetIds = (state: ReduxState) => state.assets.ids
 export const selectRelatedAssetIndex = (state: ReduxState) => state.assets.relatedAssetIndex
 
 export const selectAssetsByMarketCap = createDeepEqualOutputSelector(
-  selectCryptoMarketDataIds,
+  selectCryptoMarketDataIdsSortedByMarketCapUsd,
   selectAssets,
   (marketDataAssetIds, assets): Asset[] => {
     const sortedAssets = marketDataAssetIds.reduce<Asset[]>((acc, assetId) => {

--- a/src/state/slices/assetsSlice/selectors.ts
+++ b/src/state/slices/assetsSlice/selectors.ts
@@ -64,7 +64,7 @@ export const selectAssets = createDeepEqualOutputSelector(
 export const selectAssetIds = (state: ReduxState) => state.assets.ids
 export const selectRelatedAssetIndex = (state: ReduxState) => state.assets.relatedAssetIndex
 
-export const selectAssetsByMarketCap = createDeepEqualOutputSelector(
+export const selectAssetsSortedByMarketCap = createDeepEqualOutputSelector(
   selectCryptoMarketDataIdsSortedByMarketCapUsd,
   selectAssets,
   (marketDataAssetIds, assets): Asset[] => {
@@ -79,7 +79,7 @@ export const selectAssetsByMarketCap = createDeepEqualOutputSelector(
 )
 
 export const selectChainIdsByMarketCap = createDeepEqualOutputSelector(
-  selectAssetsByMarketCap,
+  selectAssetsSortedByMarketCap,
   (sortedAssets: Asset[]): ChainId[] =>
     sortedAssets.reduce<ChainId[]>((acc, { assetId }) => {
       const feeAssetId = assetIdToFeeAssetId(assetId)
@@ -106,7 +106,7 @@ export const selectFeeAssetById = createCachedSelector(
 ) => ReturnType<typeof getFeeAssetByAssetId>
 
 export const selectAssetsBySearchQuery = createDeepEqualOutputSelector(
-  selectAssetsByMarketCap,
+  selectAssetsSortedByMarketCap,
   selectSearchQueryFromFilter,
   (sortedAssets: Asset[], searchQuery?: string): Asset[] => {
     if (!searchQuery) return sortedAssets

--- a/src/state/slices/common-selectors.ts
+++ b/src/state/slices/common-selectors.ts
@@ -147,14 +147,14 @@ export const selectAssetsSortedByMarketCapUserCurrencyBalanceAndName =
     selectAssets,
     selectPortfolioUserCurrencyBalances,
     selectCryptoMarketDataSortedByMarketCapUsd,
-    (assets, portfolioUserCurrencyBalances, cryptoMarketData) => {
+    (assets, portfolioUserCurrencyBalances, cryptoMarketDataSortedByMarketCapUsd) => {
       const getAssetUserCurrencyBalance = (asset: Asset) =>
         bnOrZero(portfolioUserCurrencyBalances[asset.assetId]).toNumber()
 
       // This looks weird but isn't - looks like we could use the sorted selectAssetsByMarketCap instead of selectAssets
       // but we actually can't - this would rug the triple-sorting
       const getAssetMarketCap = (asset: Asset) =>
-        bnOrZero(cryptoMarketData[asset.assetId]?.marketCap).toNumber()
+        bnOrZero(cryptoMarketDataSortedByMarketCapUsd[asset.assetId]?.marketCap).toNumber()
       const getAssetName = (asset: Asset) => asset.name
 
       return orderBy(

--- a/src/state/slices/common-selectors.ts
+++ b/src/state/slices/common-selectors.ts
@@ -13,8 +13,8 @@ import { selectAccountIdParamFromFilter, selectAssetIdParamFromFilter } from 'st
 
 import { selectAssets } from './assetsSlice/selectors'
 import {
-  selectCryptoMarketData,
-  selectSelectedCurrencyMarketDataSortedByMarketCap,
+  selectCryptoMarketDataSortedByMarketCapUsd,
+  selectCryptoMarketDataSortedByMarketCapUserCurrency,
 } from './marketDataSlice/selectors'
 import type { PortfolioAccountBalancesById } from './portfolioSlice/portfolioSliceCommon'
 import { selectBalanceThreshold } from './preferencesSlice/selectors'
@@ -95,7 +95,7 @@ export const selectPortfolioCryptoPrecisionBalanceByFilter = createCachedSelecto
 
 export const selectPortfolioUserCurrencyBalances = createDeepEqualOutputSelector(
   selectAssets,
-  selectSelectedCurrencyMarketDataSortedByMarketCap,
+  selectCryptoMarketDataSortedByMarketCapUserCurrency,
   selectPortfolioAssetBalancesBaseUnit,
   selectBalanceThreshold,
   (assetsById, marketData, balances, balanceThreshold) =>
@@ -116,7 +116,7 @@ export const selectPortfolioUserCurrencyBalances = createDeepEqualOutputSelector
 export const selectPortfolioUserCurrencyBalancesByAccountId = createDeepEqualOutputSelector(
   selectAssets,
   selectPortfolioAccountBalancesBaseUnit,
-  selectSelectedCurrencyMarketDataSortedByMarketCap,
+  selectCryptoMarketDataSortedByMarketCapUserCurrency,
   (assetsById, accounts, marketData) => {
     return Object.entries(accounts).reduce(
       (acc, [accountId, balanceObj]) => {
@@ -146,7 +146,7 @@ export const selectAssetsSortedByMarketCapUserCurrencyBalanceAndName =
   createDeepEqualOutputSelector(
     selectAssets,
     selectPortfolioUserCurrencyBalances,
-    selectCryptoMarketData,
+    selectCryptoMarketDataSortedByMarketCapUsd,
     (assets, portfolioUserCurrencyBalances, cryptoMarketData) => {
       const getAssetUserCurrencyBalance = (asset: Asset) =>
         bnOrZero(portfolioUserCurrencyBalances[asset.assetId]).toNumber()

--- a/src/state/slices/common-selectors.ts
+++ b/src/state/slices/common-selectors.ts
@@ -13,8 +13,8 @@ import { selectAccountIdParamFromFilter, selectAssetIdParamFromFilter } from 'st
 
 import { selectAssets } from './assetsSlice/selectors'
 import {
-  selectCryptoMarketDataSortedByMarketCapUsd,
-  selectCryptoMarketDataSortedByMarketCapUserCurrency,
+  selectCryptoMarketDataUsd,
+  selectCryptoMarketDataUserCurrency,
 } from './marketDataSlice/selectors'
 import type { PortfolioAccountBalancesById } from './portfolioSlice/portfolioSliceCommon'
 import { selectBalanceThreshold } from './preferencesSlice/selectors'
@@ -95,7 +95,7 @@ export const selectPortfolioCryptoPrecisionBalanceByFilter = createCachedSelecto
 
 export const selectPortfolioUserCurrencyBalances = createDeepEqualOutputSelector(
   selectAssets,
-  selectCryptoMarketDataSortedByMarketCapUserCurrency,
+  selectCryptoMarketDataUserCurrency,
   selectPortfolioAssetBalancesBaseUnit,
   selectBalanceThreshold,
   (assetsById, marketData, balances, balanceThreshold) =>
@@ -116,7 +116,7 @@ export const selectPortfolioUserCurrencyBalances = createDeepEqualOutputSelector
 export const selectPortfolioUserCurrencyBalancesByAccountId = createDeepEqualOutputSelector(
   selectAssets,
   selectPortfolioAccountBalancesBaseUnit,
-  selectCryptoMarketDataSortedByMarketCapUserCurrency,
+  selectCryptoMarketDataUserCurrency,
   (assetsById, accounts, marketData) => {
     return Object.entries(accounts).reduce(
       (acc, [accountId, balanceObj]) => {
@@ -146,15 +146,15 @@ export const selectAssetsSortedByMarketCapUserCurrencyBalanceAndName =
   createDeepEqualOutputSelector(
     selectAssets,
     selectPortfolioUserCurrencyBalances,
-    selectCryptoMarketDataSortedByMarketCapUsd,
-    (assets, portfolioUserCurrencyBalances, cryptoMarketDataSortedByMarketCapUsd) => {
+    selectCryptoMarketDataUsd,
+    (assets, portfolioUserCurrencyBalances, cryptoMarketDataUsd) => {
       const getAssetUserCurrencyBalance = (asset: Asset) =>
         bnOrZero(portfolioUserCurrencyBalances[asset.assetId]).toNumber()
 
       // This looks weird but isn't - looks like we could use the sorted selectAssetsByMarketCap instead of selectAssets
       // but we actually can't - this would rug the triple-sorting
       const getAssetMarketCap = (asset: Asset) =>
-        bnOrZero(cryptoMarketDataSortedByMarketCapUsd[asset.assetId]?.marketCap).toNumber()
+        bnOrZero(cryptoMarketDataUsd[asset.assetId]?.marketCap).toNumber()
       const getAssetName = (asset: Asset) => asset.name
 
       return orderBy(

--- a/src/state/slices/marketDataSlice/selectors.ts
+++ b/src/state/slices/marketDataSlice/selectors.ts
@@ -140,8 +140,8 @@ export const selectFiatPriceHistoryTimeframe = createSelector(
 export const selectUsdRateByAssetId = createCachedSelector(
   selectCryptoMarketDataSortedByMarketCapUsd,
   selectAssetId,
-  (cryptoMarketData, assetId): string | undefined => {
-    return cryptoMarketData[assetId]?.price
+  (cryptoMarketDataSortedByMarketCapUsd, assetId): string | undefined => {
+    return cryptoMarketDataSortedByMarketCapUsd[assetId]?.price
   },
 )((_state: ReduxState, assetId?: AssetId): AssetId => assetId ?? 'assetId')
 
@@ -149,8 +149,8 @@ export const selectUserCurrencyRateByAssetId = createCachedSelector(
   selectCryptoMarketDataSortedByMarketCapUsd,
   selectUserCurrencyToUsdRate,
   selectAssetId,
-  (cryptoMarketData, userCurrencyToUsdRate, assetId): string => {
-    return bnOrZero(cryptoMarketData[assetId]?.price)
+  (cryptoMarketDataSortedByMarketCapUsd, userCurrencyToUsdRate, assetId): string => {
+    return bnOrZero(cryptoMarketDataSortedByMarketCapUsd[assetId]?.price)
       .times(userCurrencyToUsdRate)
       .toString()
   },

--- a/src/state/slices/opportunitiesSlice/resolvers/cosmosSdk/index.ts
+++ b/src/state/slices/opportunitiesSlice/resolvers/cosmosSdk/index.ts
@@ -5,7 +5,7 @@ import { assertGetCosmosSdkChainAdapter } from 'lib/utils/cosmosSdk'
 import type { ReduxState } from 'state/reducer'
 import { selectAssetById } from 'state/slices/assetsSlice/selectors'
 import { selectWalletAccountIds } from 'state/slices/common-selectors'
-import { selectMarketDataById } from 'state/slices/marketDataSlice/selectors'
+import { selectMarketDataByAssetIdUserCurrency } from 'state/slices/marketDataSlice/selectors'
 import { accountIdToFeeAssetId } from 'state/slices/portfolioSlice/utils'
 
 import type {
@@ -92,7 +92,7 @@ export const cosmosSdkStakingOpportunitiesMetadataResolver = async ({
 
         const asset = selectAssetById(state, assetId)
         if (!asset) throw new Error(`No asset found for AssetId: ${assetId}`)
-        const marketData = selectMarketDataById(state, assetId)
+        const marketData = selectMarketDataByAssetIdUserCurrency(state, assetId)
 
         const underlyingAssetRatioBaseUnit = bn(1).times(bn(10).pow(asset.precision)).toString()
 

--- a/src/state/slices/opportunitiesSlice/resolvers/ethFoxStaking/index.ts
+++ b/src/state/slices/opportunitiesSlice/resolvers/ethFoxStaking/index.ts
@@ -7,7 +7,7 @@ import { getAddress } from 'viem'
 import { bn, bnOrZero } from 'lib/bignumber/bignumber'
 import { toBaseUnit } from 'lib/math'
 import type { AssetsState } from 'state/slices/assetsSlice/assetsSlice'
-import { selectMarketDataById } from 'state/slices/marketDataSlice/selectors'
+import { selectMarketDataByAssetIdUserCurrency } from 'state/slices/marketDataSlice/selectors'
 
 import {
   assertIsFoxEthStakingContractAddress,
@@ -37,7 +37,10 @@ export const ethFoxStakingMetadataResolver = async ({
   const state: any = getState() // ReduxState causes circular dependency
   const assets: AssetsState = state.assets
   const lpAssetPrecision = assets.byId[foxEthLpAssetId]?.precision ?? 0
-  const lpTokenMarketData: MarketData = selectMarketDataById(state, foxEthLpAssetId)
+  const lpTokenMarketData: MarketData = selectMarketDataByAssetIdUserCurrency(
+    state,
+    foxEthLpAssetId,
+  )
   const lpTokenPrice = lpTokenMarketData?.price
 
   const { assetReference: contractAddress } = fromAssetId(opportunityId)
@@ -123,7 +126,10 @@ export const ethFoxStakingUserDataResolver = async ({
 }: OpportunityUserDataResolverInput): Promise<{ data: GetOpportunityUserStakingDataOutput }> => {
   const { getState } = reduxApi
   const state: any = getState() // ReduxState causes circular dependency
-  const lpTokenMarketData: MarketData = selectMarketDataById(state, foxEthLpAssetId)
+  const lpTokenMarketData: MarketData = selectMarketDataByAssetIdUserCurrency(
+    state,
+    foxEthLpAssetId,
+  )
   const lpTokenPrice = lpTokenMarketData?.price
 
   const { assetReference: contractAddress } = fromAssetId(opportunityId)

--- a/src/state/slices/opportunitiesSlice/resolvers/foxy/index.ts
+++ b/src/state/slices/opportunitiesSlice/resolvers/foxy/index.ts
@@ -6,7 +6,7 @@ import { foxyApi } from 'state/apis/foxy/foxyApi'
 import { getFoxyApi } from 'state/apis/foxy/foxyApiSingleton'
 import { selectAssetById } from 'state/slices/assetsSlice/selectors'
 import { selectPortfolioCryptoBalanceBaseUnitByFilter } from 'state/slices/common-selectors'
-import { selectMarketDataById } from 'state/slices/marketDataSlice/selectors'
+import { selectMarketDataByAssetIdUserCurrency } from 'state/slices/marketDataSlice/selectors'
 import { selectBIP44ParamsByAccountId } from 'state/slices/portfolioSlice/selectors'
 
 import type {
@@ -60,7 +60,7 @@ export const foxyStakingOpportunitiesMetadataResolver = async ({
     const assetId = toAssetId(toAssetIdParts)
     const opportunityId = toOpportunityId(toAssetIdParts)
     const underlyingAsset = selectAssetById(state, tokenAssetId)
-    const marketData = selectMarketDataById(state, tokenAssetId)
+    const marketData = selectMarketDataByAssetIdUserCurrency(state, tokenAssetId)
 
     if (!underlyingAsset) continue
 

--- a/src/state/slices/opportunitiesSlice/resolvers/thorchainsavers/index.ts
+++ b/src/state/slices/opportunitiesSlice/resolvers/thorchainsavers/index.ts
@@ -5,7 +5,7 @@ import { bn, bnOrZero } from 'lib/bignumber/bignumber'
 import { poolAssetIdToAssetId } from 'lib/swapper/swappers/ThorchainSwapper/utils/poolAssetHelpers/poolAssetHelpers'
 import { fromThorBaseUnit } from 'lib/utils/thorchain'
 import { selectAssetById } from 'state/slices/assetsSlice/selectors'
-import { selectMarketDataById } from 'state/slices/marketDataSlice/selectors'
+import { selectMarketDataByAssetIdUserCurrency } from 'state/slices/marketDataSlice/selectors'
 import { selectFeatureFlags } from 'state/slices/preferencesSlice/selectors'
 
 import type {
@@ -121,7 +121,7 @@ export const thorchainSaversStakingOpportunitiesMetadataResolver = async ({
     // we would need to revisit this by using generic keys as an opportunityId
     const asset = selectAssetById(state, assetId)
     const underlyingAsset = selectAssetById(state, assetId)
-    const marketData = selectMarketDataById(state, assetId)
+    const marketData = selectMarketDataByAssetIdUserCurrency(state, assetId)
 
     if (!asset || !underlyingAsset || !marketData) continue
 

--- a/src/state/slices/opportunitiesSlice/resolvers/uniV2/index.ts
+++ b/src/state/slices/opportunitiesSlice/resolvers/uniV2/index.ts
@@ -15,7 +15,7 @@ import type { ReduxState } from 'state/reducer'
 import type { AssetsState } from 'state/slices/assetsSlice/assetsSlice'
 import { selectPortfolioAccountBalancesBaseUnit } from 'state/slices/common-selectors'
 import { marketData } from 'state/slices/marketDataSlice/marketDataSlice'
-import { selectMarketDataById } from 'state/slices/marketDataSlice/selectors'
+import { selectMarketDataByAssetIdUserCurrency } from 'state/slices/marketDataSlice/selectors'
 import type { PortfolioAccountBalancesById } from 'state/slices/portfolioSlice/portfolioSliceCommon'
 import { selectPortfolioLoadingStatusGranular } from 'state/slices/portfolioSlice/selectors'
 import { selectFeatureFlags } from 'state/slices/preferencesSlice/selectors'
@@ -146,7 +146,7 @@ export const uniV2LpOpportunitiesMetadataResolver = async ({
     })()
 
     const { chainId } = fromAssetId(opportunityId)
-    const token0MarketData: MarketData = selectMarketDataById(
+    const token0MarketData: MarketData = selectMarketDataByAssetIdUserCurrency(
       state,
       token0Address === WETH_TOKEN_CONTRACT_ADDRESS
         ? ethAssetId

--- a/src/state/slices/opportunitiesSlice/selectors/combined.ts
+++ b/src/state/slices/opportunitiesSlice/selectors/combined.ts
@@ -27,7 +27,7 @@ import type {
 import { DefiProvider, DefiType } from '../types'
 import { getOpportunityAccessor, getUnderlyingAssetIdsBalances } from '../utils'
 import { selectAssets } from './../../assetsSlice/selectors'
-import { selectCryptoMarketDataSortedByMarketCapUserCurrency } from './../../marketDataSlice/selectors'
+import { selectCryptoMarketDataUserCurrency } from './../../marketDataSlice/selectors'
 import { selectAggregatedEarnUserLpOpportunities } from './lpSelectors'
 import {
   selectAggregatedEarnUserStakingOpportunitiesIncludeEmpty,
@@ -37,10 +37,10 @@ import {
 const makeClaimableStakingRewardsAmountUserCurrency = ({
   assets,
   maybeStakingOpportunity,
-  marketData,
+  marketDataUserCurrency,
 }: {
   assets: Partial<Record<AssetId, Asset>>
-  marketData: Partial<Record<AssetId, MarketData>>
+  marketDataUserCurrency: Partial<Record<AssetId, MarketData>>
   maybeStakingOpportunity: StakingEarnOpportunityType | LpEarnOpportunityType
 }): number => {
   if (maybeStakingOpportunity.type !== DefiType.Staking) return 0
@@ -51,7 +51,7 @@ const makeClaimableStakingRewardsAmountUserCurrency = ({
     (sum, assetId, index) => {
       const asset = assets[assetId]
       if (!asset) return sum
-      const marketDataPrice = marketData[assetId]?.price
+      const marketDataPrice = marketDataUserCurrency[assetId]?.price
       const amountCryptoBaseUnit = stakingOpportunity?.rewardsCryptoBaseUnit?.amounts[index]
       const cryptoAmountPrecision = bnOrZero(
         stakingOpportunity?.rewardsCryptoBaseUnit?.claimable ? amountCryptoBaseUnit : '0',
@@ -70,7 +70,7 @@ const makeClaimableStakingRewardsAmountUserCurrency = ({
 export const selectAggregatedEarnOpportunitiesByAssetId = createDeepEqualOutputSelector(
   selectAggregatedEarnUserStakingOpportunitiesIncludeEmpty,
   selectAggregatedEarnUserLpOpportunities,
-  selectCryptoMarketDataSortedByMarketCapUserCurrency,
+  selectCryptoMarketDataUserCurrency,
   selectAssets,
   selectIncludeEarnBalancesParamFromFilter,
   selectIncludeRewardsBalancesParamFromFilter,
@@ -78,7 +78,7 @@ export const selectAggregatedEarnOpportunitiesByAssetId = createDeepEqualOutputS
   (
     userStakingOpportunites,
     userLpOpportunities,
-    marketData,
+    marketDataUserCurrency,
     assets,
     includeEarnBalances,
     includeRewardsBalances,
@@ -98,7 +98,7 @@ export const selectAggregatedEarnOpportunitiesByAssetId = createDeepEqualOutputS
         const underlyingAssetBalances = getUnderlyingAssetIdsBalances({
           ...cur,
           assets,
-          marketData,
+          marketDataUserCurrency,
         })
 
         const amountFiat =
@@ -109,7 +109,7 @@ export const selectAggregatedEarnOpportunitiesByAssetId = createDeepEqualOutputS
         const maybeStakingRewardsAmountUserCurrency = makeClaimableStakingRewardsAmountUserCurrency(
           {
             maybeStakingOpportunity: cur,
-            marketData,
+            marketDataUserCurrency,
             assets,
           },
         )
@@ -154,7 +154,7 @@ export const selectAggregatedEarnOpportunitiesByAssetId = createDeepEqualOutputS
           const underlyingAssetBalances = getUnderlyingAssetIdsBalances({
             ...cur,
             assets,
-            marketData,
+            marketDataUserCurrency,
           })
 
           const amountFiat =
@@ -164,7 +164,7 @@ export const selectAggregatedEarnOpportunitiesByAssetId = createDeepEqualOutputS
 
           const maybeStakingRewardsAmountFiat = makeClaimableStakingRewardsAmountUserCurrency({
             maybeStakingOpportunity: cur,
-            marketData,
+            marketDataUserCurrency,
             assets,
           })
 
@@ -255,7 +255,7 @@ export const selectAggregatedEarnOpportunitiesByAssetId = createDeepEqualOutputS
 export const selectClaimableRewards = createDeepEqualOutputSelector(
   selectUserStakingOpportunitiesWithMetadataByFilter,
   selectAssets,
-  selectCryptoMarketDataSortedByMarketCapUserCurrency,
+  selectCryptoMarketDataUserCurrency,
   (userStakingOpportunitesWithMetadata, assets, marketData): string => {
     return userStakingOpportunitesWithMetadata
       .reduce<BN>((totalSum, stakingOpportunityWithMetadata) => {
@@ -291,7 +291,7 @@ export const selectOpportunityApiPending = (state: ReduxState) =>
 export const selectAggregatedEarnOpportunitiesByProvider = createDeepEqualOutputSelector(
   selectAggregatedEarnUserStakingOpportunitiesIncludeEmpty,
   selectAggregatedEarnUserLpOpportunities,
-  selectCryptoMarketDataSortedByMarketCapUserCurrency,
+  selectCryptoMarketDataUserCurrency,
   selectAssets,
   selectIncludeEarnBalancesParamFromFilter,
   selectIncludeRewardsBalancesParamFromFilter,
@@ -300,14 +300,14 @@ export const selectAggregatedEarnOpportunitiesByProvider = createDeepEqualOutput
   (
     userStakingOpportunites,
     userLpOpportunities,
-    marketData,
+    marketDataUserCurrency,
     assets,
     includeEarnBalances,
     includeRewardsBalances,
     chainId,
     searchQuery,
   ): AggregatedOpportunitiesByProviderReturn[] => {
-    if (isEmpty(marketData)) return []
+    if (isEmpty(marketDataUserCurrency)) return []
     const totalFiatAmountByProvider: Record<string, BN> = {}
     const projectedAnnualizedYieldByProvider: Record<string, BN> = {}
     const combined = userStakingOpportunites.concat(userLpOpportunities)
@@ -409,7 +409,7 @@ export const selectAggregatedEarnOpportunitiesByProvider = createDeepEqualOutput
 
         const maybeStakingRewardsAmountFiat = makeClaimableStakingRewardsAmountUserCurrency({
           maybeStakingOpportunity: cur,
-          marketData,
+          marketDataUserCurrency,
           assets,
         })
 
@@ -441,7 +441,7 @@ export const selectAggregatedEarnOpportunitiesByProvider = createDeepEqualOutput
         const maybeStakingRewardsAmountUserCurrency = makeClaimableStakingRewardsAmountUserCurrency(
           {
             maybeStakingOpportunity: cur,
-            marketData,
+            marketDataUserCurrency,
             assets,
           },
         )

--- a/src/state/slices/opportunitiesSlice/selectors/combined.ts
+++ b/src/state/slices/opportunitiesSlice/selectors/combined.ts
@@ -27,7 +27,7 @@ import type {
 import { DefiProvider, DefiType } from '../types'
 import { getOpportunityAccessor, getUnderlyingAssetIdsBalances } from '../utils'
 import { selectAssets } from './../../assetsSlice/selectors'
-import { selectSelectedCurrencyMarketDataSortedByMarketCap } from './../../marketDataSlice/selectors'
+import { selectCryptoMarketDataSortedByMarketCapUserCurrency } from './../../marketDataSlice/selectors'
 import { selectAggregatedEarnUserLpOpportunities } from './lpSelectors'
 import {
   selectAggregatedEarnUserStakingOpportunitiesIncludeEmpty,
@@ -70,7 +70,7 @@ const makeClaimableStakingRewardsAmountUserCurrency = ({
 export const selectAggregatedEarnOpportunitiesByAssetId = createDeepEqualOutputSelector(
   selectAggregatedEarnUserStakingOpportunitiesIncludeEmpty,
   selectAggregatedEarnUserLpOpportunities,
-  selectSelectedCurrencyMarketDataSortedByMarketCap,
+  selectCryptoMarketDataSortedByMarketCapUserCurrency,
   selectAssets,
   selectIncludeEarnBalancesParamFromFilter,
   selectIncludeRewardsBalancesParamFromFilter,
@@ -255,7 +255,7 @@ export const selectAggregatedEarnOpportunitiesByAssetId = createDeepEqualOutputS
 export const selectClaimableRewards = createDeepEqualOutputSelector(
   selectUserStakingOpportunitiesWithMetadataByFilter,
   selectAssets,
-  selectSelectedCurrencyMarketDataSortedByMarketCap,
+  selectCryptoMarketDataSortedByMarketCapUserCurrency,
   (userStakingOpportunitesWithMetadata, assets, marketData): string => {
     return userStakingOpportunitesWithMetadata
       .reduce<BN>((totalSum, stakingOpportunityWithMetadata) => {
@@ -291,7 +291,7 @@ export const selectOpportunityApiPending = (state: ReduxState) =>
 export const selectAggregatedEarnOpportunitiesByProvider = createDeepEqualOutputSelector(
   selectAggregatedEarnUserStakingOpportunitiesIncludeEmpty,
   selectAggregatedEarnUserLpOpportunities,
-  selectSelectedCurrencyMarketDataSortedByMarketCap,
+  selectCryptoMarketDataSortedByMarketCapUserCurrency,
   selectAssets,
   selectIncludeEarnBalancesParamFromFilter,
   selectIncludeRewardsBalancesParamFromFilter,

--- a/src/state/slices/opportunitiesSlice/selectors/lpSelectors.ts
+++ b/src/state/slices/opportunitiesSlice/selectors/lpSelectors.ts
@@ -21,7 +21,7 @@ import {
   selectPortfolioCryptoBalanceBaseUnitByFilter,
   selectPortfolioCryptoPrecisionBalanceByFilter,
 } from '../../common-selectors'
-import { selectSelectedCurrencyMarketDataSortedByMarketCap } from '../../marketDataSlice/selectors'
+import { selectCryptoMarketDataSortedByMarketCapUserCurrency } from '../../marketDataSlice/selectors'
 import { getUnderlyingAssetIdsBalances } from '../utils'
 import type { LpEarnOpportunityType } from './../types'
 
@@ -35,7 +35,7 @@ export const selectEarnUserLpOpportunity = createDeepEqualOutputSelector(
   selectLpIdParamFromFilter,
   selectPortfolioCryptoBalanceBaseUnitByFilter,
   selectAssets,
-  selectSelectedCurrencyMarketDataSortedByMarketCap,
+  selectCryptoMarketDataSortedByMarketCapUserCurrency,
   (
     lpOpportunitiesById,
     lpId,
@@ -110,7 +110,7 @@ export const selectAggregatedEarnUserLpOpportunity = createDeepEqualOutputSelect
   selectLpIdParamFromFilter,
   selectPortfolioCryptoPrecisionBalanceByFilter,
   selectAssets,
-  selectSelectedCurrencyMarketDataSortedByMarketCap,
+  selectCryptoMarketDataSortedByMarketCapUserCurrency,
   (
     lpOpportunitiesById,
     lpId,
@@ -192,7 +192,7 @@ export const selectUnderlyingLpAssetsWithBalancesAndIcons = createSelector(
   selectLpOpportunitiesById,
   selectPortfolioCryptoPrecisionBalanceByFilter,
   selectAssets,
-  selectSelectedCurrencyMarketDataSortedByMarketCap,
+  selectCryptoMarketDataSortedByMarketCapUserCurrency,
   (
     lpId,
     lpOpportunitiesById,
@@ -241,7 +241,7 @@ export const selectAggregatedEarnUserLpOpportunities = createDeepEqualOutputSele
   selectLpOpportunitiesById,
   selectPortfolioAssetBalancesBaseUnit,
   selectAssets,
-  selectSelectedCurrencyMarketDataSortedByMarketCap,
+  selectCryptoMarketDataSortedByMarketCapUserCurrency,
   (
     lpOpportunitiesById,
     portfolioAssetBalancesById,
@@ -326,7 +326,7 @@ export const selectAllEarnUserLpOpportunitiesByFilter = createDeepEqualOutputSel
   selectPortfolioAccountBalancesBaseUnit,
   selectPortfolioAssetBalancesBaseUnit,
   selectAssets,
-  selectSelectedCurrencyMarketDataSortedByMarketCap,
+  selectCryptoMarketDataSortedByMarketCapUserCurrency,
   selectAssetIdParamFromFilter,
   selectAccountIdParamFromFilter,
   (

--- a/src/state/slices/opportunitiesSlice/selectors/lpSelectors.ts
+++ b/src/state/slices/opportunitiesSlice/selectors/lpSelectors.ts
@@ -21,7 +21,7 @@ import {
   selectPortfolioCryptoBalanceBaseUnitByFilter,
   selectPortfolioCryptoPrecisionBalanceByFilter,
 } from '../../common-selectors'
-import { selectCryptoMarketDataSortedByMarketCapUserCurrency } from '../../marketDataSlice/selectors'
+import { selectCryptoMarketDataUserCurrency } from '../../marketDataSlice/selectors'
 import { getUnderlyingAssetIdsBalances } from '../utils'
 import type { LpEarnOpportunityType } from './../types'
 
@@ -35,18 +35,18 @@ export const selectEarnUserLpOpportunity = createDeepEqualOutputSelector(
   selectLpIdParamFromFilter,
   selectPortfolioCryptoBalanceBaseUnitByFilter,
   selectAssets,
-  selectCryptoMarketDataSortedByMarketCapUserCurrency,
+  selectCryptoMarketDataUserCurrency,
   (
     lpOpportunitiesById,
     lpId,
     lpAssetBalanceCryptoBaseUnit,
     assets,
-    marketData,
+    marketDataUserCurrency,
   ): LpEarnOpportunityType | undefined => {
     if (!lpId) return
 
     const lpAsset = assets[lpId as AssetId]
-    const marketDataPrice = marketData[lpId as AssetId]?.price
+    const marketDataPrice = marketDataUserCurrency[lpId as AssetId]?.price
     const opportunityMetadata = lpOpportunitiesById[lpId]
 
     if (!(opportunityMetadata && lpAsset)) return
@@ -110,17 +110,17 @@ export const selectAggregatedEarnUserLpOpportunity = createDeepEqualOutputSelect
   selectLpIdParamFromFilter,
   selectPortfolioCryptoPrecisionBalanceByFilter,
   selectAssets,
-  selectCryptoMarketDataSortedByMarketCapUserCurrency,
+  selectCryptoMarketDataUserCurrency,
   (
     lpOpportunitiesById,
     lpId,
     aggregatedLpAssetBalance,
     assets,
-    marketData,
+    marketDataUserCurrency,
   ): LpEarnOpportunityType | undefined => {
     if (!lpId || !aggregatedLpAssetBalance) return
 
-    const marketDataPrice = marketData[lpId as AssetId]?.price
+    const marketDataPrice = marketDataUserCurrency[lpId as AssetId]?.price
     const opportunityMetadata = lpOpportunitiesById[lpId]
 
     if (!opportunityMetadata) return
@@ -192,13 +192,13 @@ export const selectUnderlyingLpAssetsWithBalancesAndIcons = createSelector(
   selectLpOpportunitiesById,
   selectPortfolioCryptoPrecisionBalanceByFilter,
   selectAssets,
-  selectCryptoMarketDataSortedByMarketCapUserCurrency,
+  selectCryptoMarketDataUserCurrency,
   (
     lpId,
     lpOpportunitiesById,
     lpAssetBalancePrecision,
     assets,
-    marketData,
+    marketDataUserCurrency,
   ): AssetWithBalance[] | undefined => {
     if (!lpId) return
     const opportunityMetadata = lpOpportunitiesById[lpId]
@@ -215,7 +215,7 @@ export const selectUnderlyingLpAssetsWithBalancesAndIcons = createSelector(
       underlyingAssetRatiosBaseUnit: opportunityMetadata.underlyingAssetRatiosBaseUnit,
       assets,
       assetId: lpId,
-      marketData,
+      marketDataUserCurrency,
     })
     const underlyingAssetsIcons = opportunityMetadata.underlyingAssetIds
       .map(assetId => assets[assetId]?.icon)
@@ -241,12 +241,12 @@ export const selectAggregatedEarnUserLpOpportunities = createDeepEqualOutputSele
   selectLpOpportunitiesById,
   selectPortfolioAssetBalancesBaseUnit,
   selectAssets,
-  selectCryptoMarketDataSortedByMarketCapUserCurrency,
+  selectCryptoMarketDataUserCurrency,
   (
     lpOpportunitiesById,
     portfolioAssetBalancesById,
     assets,
-    marketData,
+    marketDataUserCurrency,
   ): LpEarnOpportunityType[] => {
     const opportunities: LpEarnOpportunityType[] = []
 
@@ -259,7 +259,7 @@ export const selectAggregatedEarnUserLpOpportunities = createDeepEqualOutputSele
 
       if (!lpAsset) continue
 
-      const marketDataPrice = marketData[lpId as AssetId]?.price
+      const marketDataPrice = marketDataUserCurrency[lpId as AssetId]?.price
       const aggregatedLpAssetBalance = portfolioAssetBalancesById[lpId]
 
       /* Get amounts of each underlying token (in base units, eg. wei) */
@@ -326,7 +326,7 @@ export const selectAllEarnUserLpOpportunitiesByFilter = createDeepEqualOutputSel
   selectPortfolioAccountBalancesBaseUnit,
   selectPortfolioAssetBalancesBaseUnit,
   selectAssets,
-  selectCryptoMarketDataSortedByMarketCapUserCurrency,
+  selectCryptoMarketDataUserCurrency,
   selectAssetIdParamFromFilter,
   selectAccountIdParamFromFilter,
   (
@@ -334,7 +334,7 @@ export const selectAllEarnUserLpOpportunitiesByFilter = createDeepEqualOutputSel
     portfolioAccountBalanceById,
     portfolioAssetBalancesById,
     assets,
-    marketData,
+    marketDataUserCurrency,
     assetId,
     accountId,
   ): LpEarnOpportunityType[] => {
@@ -342,7 +342,7 @@ export const selectAllEarnUserLpOpportunitiesByFilter = createDeepEqualOutputSel
     const opportunities: LpEarnOpportunityType[] = Object.entries(lpOpportunitiesById).reduce(
       (opportunities: LpEarnOpportunityType[], [lpId, opportunityMetadata]) => {
         if (!opportunityMetadata) return opportunities
-        const marketDataPrice = marketData[lpId as AssetId]?.price
+        const marketDataPrice = marketDataUserCurrency[lpId as AssetId]?.price
         let opportunityBalance = bnOrZero(portfolioAssetBalancesById[lpId]).toString()
         if (accountId) {
           opportunityBalance = bnOrZero(portfolioAccountBalanceById[accountId][lpId]).toString()

--- a/src/state/slices/opportunitiesSlice/selectors/stakingSelectors.ts
+++ b/src/state/slices/opportunitiesSlice/selectors/stakingSelectors.ts
@@ -28,8 +28,8 @@ import {
   selectWalletAccountIds,
 } from '../../common-selectors'
 import {
+  selectCryptoMarketDataSortedByMarketCapUserCurrency,
   selectMarketDataByFilter,
-  selectSelectedCurrencyMarketDataSortedByMarketCap,
 } from '../../marketDataSlice/selectors'
 import { foxEthLpAssetId } from '../constants'
 import type { CosmosSdkStakingSpecificUserStakingOpportunity } from '../resolvers/cosmosSdk/types'
@@ -338,7 +338,7 @@ export const selectAggregatedUserStakingOpportunityByStakingId = createDeepEqual
 
 export const selectAggregatedEarnUserStakingOpportunityByStakingId = createDeepEqualOutputSelector(
   selectAggregatedUserStakingOpportunityByStakingId,
-  selectSelectedCurrencyMarketDataSortedByMarketCap,
+  selectCryptoMarketDataSortedByMarketCapUserCurrency,
   selectAssets,
   (opportunity, marketData, assets): StakingEarnOpportunityType | undefined => {
     if (!opportunity) return
@@ -389,7 +389,7 @@ export const selectAggregatedUserStakingOpportunities = createDeepEqualOutputSel
 // TODO: testme
 export const selectAggregatedEarnUserStakingOpportunities = createDeepEqualOutputSelector(
   selectAggregatedUserStakingOpportunities,
-  selectSelectedCurrencyMarketDataSortedByMarketCap,
+  selectCryptoMarketDataSortedByMarketCapUserCurrency,
   selectAssets,
   (aggregatedUserStakingOpportunities, marketData, assets): StakingEarnOpportunityType[] =>
     aggregatedUserStakingOpportunities.map(opportunity => {
@@ -445,7 +445,7 @@ export const selectActiveAggregatedEarnUserStakingOpportunities = createDeepEqua
 export const selectActiveAggregatedEarnUserStakingOpportunitiesWithTotalFiatAmount =
   createDeepEqualOutputSelector(
     selectActiveAggregatedEarnUserStakingOpportunities,
-    selectSelectedCurrencyMarketDataSortedByMarketCap,
+    selectCryptoMarketDataSortedByMarketCapUserCurrency,
     selectAssets,
     (aggregatedUserStakingOpportunities, marketData, assets): StakingEarnOpportunityType[] =>
       aggregatedUserStakingOpportunities
@@ -464,7 +464,7 @@ export const selectActiveAggregatedEarnUserStakingOpportunitiesWithTotalFiatAmou
 // Also slaps in ETH/FOX balances which value lives in the portfolio vs. being an "upstream earn opportunity"
 export const selectEarnBalancesUserCurrencyAmountFull = createDeepEqualOutputSelector(
   selectAggregatedUserStakingOpportunities,
-  selectSelectedCurrencyMarketDataSortedByMarketCap,
+  selectCryptoMarketDataSortedByMarketCapUserCurrency,
   selectAssets,
   selectPortfolioUserCurrencyBalances,
   (aggregatedUserStakingOpportunities, marketData, assets, portfolioFiatBalances): BN =>
@@ -573,7 +573,7 @@ export const selectAggregatedEarnUserStakingOpportunitiesIncludeEmptyByStakingId
 // TODO: testme
 export const selectEarnUserStakingOpportunityByUserStakingId = createDeepEqualOutputSelector(
   selectUserStakingOpportunityByUserStakingId,
-  selectSelectedCurrencyMarketDataSortedByMarketCap,
+  selectCryptoMarketDataSortedByMarketCapUserCurrency,
   selectAssets,
   (userStakingOpportunity, marketData, assets): StakingEarnOpportunityType | undefined => {
     if (!userStakingOpportunity || !marketData) return
@@ -693,7 +693,7 @@ export const selectAllEarnUserStakingOpportunitiesByFilter = createDeepEqualOutp
   selectAggregatedEarnUserStakingOpportunitiesIncludeEmpty,
   selectUserStakingOpportunitiesById,
   selectAssets,
-  selectSelectedCurrencyMarketDataSortedByMarketCap,
+  selectCryptoMarketDataSortedByMarketCapUserCurrency,
   selectAssetIdParamFromFilter,
   selectAccountIdParamFromFilter,
   (

--- a/src/state/slices/opportunitiesSlice/selectors/stakingSelectors.ts
+++ b/src/state/slices/opportunitiesSlice/selectors/stakingSelectors.ts
@@ -28,7 +28,7 @@ import {
   selectWalletAccountIds,
 } from '../../common-selectors'
 import {
-  selectCryptoMarketDataSortedByMarketCapUserCurrency,
+  selectCryptoMarketDataUserCurrency,
   selectMarketDataByFilter,
 } from '../../marketDataSlice/selectors'
 import { foxEthLpAssetId } from '../constants'
@@ -338,7 +338,7 @@ export const selectAggregatedUserStakingOpportunityByStakingId = createDeepEqual
 
 export const selectAggregatedEarnUserStakingOpportunityByStakingId = createDeepEqualOutputSelector(
   selectAggregatedUserStakingOpportunityByStakingId,
-  selectCryptoMarketDataSortedByMarketCapUserCurrency,
+  selectCryptoMarketDataUserCurrency,
   selectAssets,
   (opportunity, marketData, assets): StakingEarnOpportunityType | undefined => {
     if (!opportunity) return
@@ -389,7 +389,7 @@ export const selectAggregatedUserStakingOpportunities = createDeepEqualOutputSel
 // TODO: testme
 export const selectAggregatedEarnUserStakingOpportunities = createDeepEqualOutputSelector(
   selectAggregatedUserStakingOpportunities,
-  selectCryptoMarketDataSortedByMarketCapUserCurrency,
+  selectCryptoMarketDataUserCurrency,
   selectAssets,
   (aggregatedUserStakingOpportunities, marketData, assets): StakingEarnOpportunityType[] =>
     aggregatedUserStakingOpportunities.map(opportunity => {
@@ -445,7 +445,7 @@ export const selectActiveAggregatedEarnUserStakingOpportunities = createDeepEqua
 export const selectActiveAggregatedEarnUserStakingOpportunitiesWithTotalFiatAmount =
   createDeepEqualOutputSelector(
     selectActiveAggregatedEarnUserStakingOpportunities,
-    selectCryptoMarketDataSortedByMarketCapUserCurrency,
+    selectCryptoMarketDataUserCurrency,
     selectAssets,
     (aggregatedUserStakingOpportunities, marketData, assets): StakingEarnOpportunityType[] =>
       aggregatedUserStakingOpportunities
@@ -464,7 +464,7 @@ export const selectActiveAggregatedEarnUserStakingOpportunitiesWithTotalFiatAmou
 // Also slaps in ETH/FOX balances which value lives in the portfolio vs. being an "upstream earn opportunity"
 export const selectEarnBalancesUserCurrencyAmountFull = createDeepEqualOutputSelector(
   selectAggregatedUserStakingOpportunities,
-  selectCryptoMarketDataSortedByMarketCapUserCurrency,
+  selectCryptoMarketDataUserCurrency,
   selectAssets,
   selectPortfolioUserCurrencyBalances,
   (aggregatedUserStakingOpportunities, marketData, assets, portfolioFiatBalances): BN =>
@@ -573,7 +573,7 @@ export const selectAggregatedEarnUserStakingOpportunitiesIncludeEmptyByStakingId
 // TODO: testme
 export const selectEarnUserStakingOpportunityByUserStakingId = createDeepEqualOutputSelector(
   selectUserStakingOpportunityByUserStakingId,
-  selectCryptoMarketDataSortedByMarketCapUserCurrency,
+  selectCryptoMarketDataUserCurrency,
   selectAssets,
   (userStakingOpportunity, marketData, assets): StakingEarnOpportunityType | undefined => {
     if (!userStakingOpportunity || !marketData) return
@@ -693,7 +693,7 @@ export const selectAllEarnUserStakingOpportunitiesByFilter = createDeepEqualOutp
   selectAggregatedEarnUserStakingOpportunitiesIncludeEmpty,
   selectUserStakingOpportunitiesById,
   selectAssets,
-  selectCryptoMarketDataSortedByMarketCapUserCurrency,
+  selectCryptoMarketDataUserCurrency,
   selectAssetIdParamFromFilter,
   selectAccountIdParamFromFilter,
   (

--- a/src/state/slices/opportunitiesSlice/utils/index.ts
+++ b/src/state/slices/opportunitiesSlice/utils/index.ts
@@ -70,7 +70,7 @@ type GetUnderlyingAssetIdsBalancesArgs = {
   assetId: AssetId
   cryptoAmountBaseUnit: string
   assets: Partial<Record<AssetId, Asset>>
-  marketData: Partial<Record<AssetId, MarketData>>
+  marketDataUserCurrency: Partial<Record<AssetId, MarketData>>
 } & Pick<OpportunityMetadataBase, 'underlyingAssetRatiosBaseUnit' | 'underlyingAssetIds'>
 
 export type UnderlyingAssetIdsBalances = { fiatAmount: string; cryptoBalancePrecision: string }
@@ -86,13 +86,13 @@ export const getUnderlyingAssetIdsBalances: GetUnderlyingAssetIdsBalances = ({
   cryptoAmountBaseUnit,
   assets,
   assetId,
-  marketData,
+  marketDataUserCurrency,
 }) => {
   return Object.values(underlyingAssetIds).reduce<GetUnderlyingAssetIdsBalancesReturn>(
     (acc, underlyingAssetId, index) => {
       const underlyingAsset = assets[underlyingAssetId]
       const asset = assets[assetId ?? '']
-      const marketDataPrice = marketData[underlyingAssetId]?.price
+      const marketDataPrice = marketDataUserCurrency[underlyingAssetId]?.price
 
       if (!(underlyingAsset && asset)) {
         acc[underlyingAssetId] = {
@@ -118,7 +118,7 @@ export const getUnderlyingAssetIdsBalances: GetUnderlyingAssetIdsBalances = ({
 }
 type GetRewardBalancesArgs = {
   assets: Partial<Record<AssetId, Asset>>
-  marketData: Partial<Record<AssetId, MarketData>>
+  marketDataUserCurrency: Partial<Record<AssetId, MarketData>>
 } & Pick<StakingEarnOpportunityType, 'rewardAssetIds' | 'rewardsCryptoBaseUnit'>
 
 type GetRewardBalances = (args: GetRewardBalancesArgs) => GetUnderlyingAssetIdsBalancesReturn
@@ -126,14 +126,14 @@ export const getRewardBalances: GetRewardBalances = ({
   rewardsCryptoBaseUnit,
   rewardAssetIds,
   assets,
-  marketData,
+  marketDataUserCurrency,
 }) => {
   if (!rewardAssetIds) return {}
   return Array.from(rewardAssetIds).reduce<GetUnderlyingAssetIdsBalancesReturn>(
     (acc, assetId, index) => {
       const rewardAsset = assets[assetId]
       if (!rewardAsset) return acc
-      const marketDataPrice = bnOrZero(marketData[assetId]?.price)
+      const marketDataPrice = bnOrZero(marketDataUserCurrency[assetId]?.price)
       const cryptoBalancePrecision = bnOrZero(rewardsCryptoBaseUnit?.amounts[index])
         .div(bn(10).pow(rewardAsset?.precision))
         .toString()

--- a/src/state/slices/portfolioSlice/selectors.ts
+++ b/src/state/slices/portfolioSlice/selectors.ts
@@ -33,7 +33,7 @@ import {
   selectChainIdParamFromFilter,
 } from 'state/selectors'
 import { selectAssets, selectRelatedAssetIdsInclusive } from 'state/slices/assetsSlice/selectors'
-import { selectCryptoMarketDataSortedByMarketCapUserCurrency } from 'state/slices/marketDataSlice/selectors'
+import { selectCryptoMarketDataUserCurrency } from 'state/slices/marketDataSlice/selectors'
 import { selectAllEarnUserLpOpportunitiesByFilter } from 'state/slices/opportunitiesSlice/selectors/lpSelectors'
 import {
   selectAggregatedEarnUserStakingOpportunities,
@@ -287,7 +287,7 @@ export const selectBalanceChartCryptoBalancesByAccountIdAboveThreshold =
     selectAssets,
     selectPortfolioAccountBalancesBaseUnit,
     selectPortfolioAssetBalancesBaseUnit,
-    selectCryptoMarketDataSortedByMarketCapUserCurrency,
+    selectCryptoMarketDataUserCurrency,
     selectBalanceThreshold,
     selectPortfolioAccounts,
     selectAggregatedEarnUserStakingOpportunities,
@@ -500,7 +500,7 @@ export const selectPortfolioAccountsCryptoHumanBalancesIncludingStaking =
 export const selectPortfolioAccountsUserCurrencyBalancesIncludingStaking =
   createDeepEqualOutputSelector(
     selectAssets,
-    selectCryptoMarketDataSortedByMarketCapUserCurrency,
+    selectCryptoMarketDataUserCurrency,
     selectPortfolioAccountsCryptoBalancesIncludingStaking,
     (assets, marketData, portfolioAccountsCryptoBalances): PortfolioAccountBalancesById => {
       const userCurrencyAccountEntries = Object.entries(portfolioAccountsCryptoBalances).reduce<{
@@ -740,7 +740,7 @@ export type AccountRowData = {
 
 export const selectPortfolioAccountRows = createDeepEqualOutputSelector(
   selectAssets,
-  selectCryptoMarketDataSortedByMarketCapUserCurrency,
+  selectCryptoMarketDataUserCurrency,
   selectPortfolioAssetBalancesBaseUnit,
   selectPortfolioTotalUserCurrencyBalance,
   selectBalanceThreshold,
@@ -879,7 +879,7 @@ export const selectAssetEquityItemsByFilter = createDeepEqualOutputSelector(
   selectAllEarnUserLpOpportunitiesByFilter,
   selectAllEarnUserStakingOpportunitiesByFilter,
   selectAssets,
-  selectCryptoMarketDataSortedByMarketCapUserCurrency,
+  selectCryptoMarketDataUserCurrency,
   selectAssetIdParamFromFilter,
   selectGetReadOnlyOpportunities,
   (
@@ -889,7 +889,7 @@ export const selectAssetEquityItemsByFilter = createDeepEqualOutputSelector(
     lpOpportunities,
     stakingOpportunities,
     assets,
-    marketData,
+    marketDataUserCurrency,
     assetId,
     readOnlyOpportunities,
   ): AssetEquityItem[] => {
@@ -950,7 +950,7 @@ export const selectAssetEquityItemsByFilter = createDeepEqualOutputSelector(
         cryptoAmountBaseUnit: lpOpportunity.cryptoAmountBaseUnit,
         assetId: lpOpportunity.id,
         assets,
-        marketData,
+        marketDataUserCurrency,
       })
       return {
         id: lpOpportunity.id,

--- a/src/state/slices/portfolioSlice/selectors.ts
+++ b/src/state/slices/portfolioSlice/selectors.ts
@@ -33,7 +33,7 @@ import {
   selectChainIdParamFromFilter,
 } from 'state/selectors'
 import { selectAssets, selectRelatedAssetIdsInclusive } from 'state/slices/assetsSlice/selectors'
-import { selectSelectedCurrencyMarketDataSortedByMarketCap } from 'state/slices/marketDataSlice/selectors'
+import { selectCryptoMarketDataSortedByMarketCapUserCurrency } from 'state/slices/marketDataSlice/selectors'
 import { selectAllEarnUserLpOpportunitiesByFilter } from 'state/slices/opportunitiesSlice/selectors/lpSelectors'
 import {
   selectAggregatedEarnUserStakingOpportunities,
@@ -287,7 +287,7 @@ export const selectBalanceChartCryptoBalancesByAccountIdAboveThreshold =
     selectAssets,
     selectPortfolioAccountBalancesBaseUnit,
     selectPortfolioAssetBalancesBaseUnit,
-    selectSelectedCurrencyMarketDataSortedByMarketCap,
+    selectCryptoMarketDataSortedByMarketCapUserCurrency,
     selectBalanceThreshold,
     selectPortfolioAccounts,
     selectAggregatedEarnUserStakingOpportunities,
@@ -500,7 +500,7 @@ export const selectPortfolioAccountsCryptoHumanBalancesIncludingStaking =
 export const selectPortfolioAccountsUserCurrencyBalancesIncludingStaking =
   createDeepEqualOutputSelector(
     selectAssets,
-    selectSelectedCurrencyMarketDataSortedByMarketCap,
+    selectCryptoMarketDataSortedByMarketCapUserCurrency,
     selectPortfolioAccountsCryptoBalancesIncludingStaking,
     (assets, marketData, portfolioAccountsCryptoBalances): PortfolioAccountBalancesById => {
       const userCurrencyAccountEntries = Object.entries(portfolioAccountsCryptoBalances).reduce<{
@@ -740,7 +740,7 @@ export type AccountRowData = {
 
 export const selectPortfolioAccountRows = createDeepEqualOutputSelector(
   selectAssets,
-  selectSelectedCurrencyMarketDataSortedByMarketCap,
+  selectCryptoMarketDataSortedByMarketCapUserCurrency,
   selectPortfolioAssetBalancesBaseUnit,
   selectPortfolioTotalUserCurrencyBalance,
   selectBalanceThreshold,
@@ -879,7 +879,7 @@ export const selectAssetEquityItemsByFilter = createDeepEqualOutputSelector(
   selectAllEarnUserLpOpportunitiesByFilter,
   selectAllEarnUserStakingOpportunitiesByFilter,
   selectAssets,
-  selectSelectedCurrencyMarketDataSortedByMarketCap,
+  selectCryptoMarketDataSortedByMarketCapUserCurrency,
   selectAssetIdParamFromFilter,
   selectGetReadOnlyOpportunities,
   (

--- a/src/state/slices/tradeInputSlice/selectors.ts
+++ b/src/state/slices/tradeInputSlice/selectors.ts
@@ -9,7 +9,10 @@ import {
   selectPortfolioCryptoBalanceBaseUnitByFilter,
   selectWalletAccountIds,
 } from '../common-selectors'
-import { selectCryptoMarketData, selectUserCurrencyToUsdRate } from '../marketDataSlice/selectors'
+import {
+  selectCryptoMarketDataSortedByMarketCapUsd,
+  selectUserCurrencyToUsdRate,
+} from '../marketDataSlice/selectors'
 import {
   selectAccountIdByAccountNumberAndChainId,
   selectPortfolioAccountMetadata,
@@ -34,7 +37,7 @@ export const selectInputSellAsset = createDeepEqualOutputSelector(
 
 export const selectInputSellAssetUsdRate = createSelector(
   selectInputSellAsset,
-  selectCryptoMarketData,
+  selectCryptoMarketDataSortedByMarketCapUsd,
   (sellAsset, cryptoMarketDataById) => {
     if (sellAsset === undefined) return
     return cryptoMarketDataById[sellAsset.assetId]?.price
@@ -43,7 +46,7 @@ export const selectInputSellAssetUsdRate = createSelector(
 
 export const selectInputBuyAssetUsdRate = createSelector(
   selectInputBuyAsset,
-  selectCryptoMarketData,
+  selectCryptoMarketDataSortedByMarketCapUsd,
   (buyAsset, cryptoMarketDataById) => {
     if (buyAsset === undefined) return
     return cryptoMarketDataById[buyAsset.assetId]?.price

--- a/src/state/slices/tradeInputSlice/selectors.ts
+++ b/src/state/slices/tradeInputSlice/selectors.ts
@@ -38,18 +38,18 @@ export const selectInputSellAsset = createDeepEqualOutputSelector(
 export const selectInputSellAssetUsdRate = createSelector(
   selectInputSellAsset,
   selectCryptoMarketDataSortedByMarketCapUsd,
-  (sellAsset, cryptoMarketDataById) => {
+  (sellAsset, cryptoMarketDataSortedByMarketCapUsd) => {
     if (sellAsset === undefined) return
-    return cryptoMarketDataById[sellAsset.assetId]?.price
+    return cryptoMarketDataSortedByMarketCapUsd[sellAsset.assetId]?.price
   },
 )
 
 export const selectInputBuyAssetUsdRate = createSelector(
   selectInputBuyAsset,
   selectCryptoMarketDataSortedByMarketCapUsd,
-  (buyAsset, cryptoMarketDataById) => {
+  (buyAsset, cryptoMarketDataSortedByMarketCapUsd) => {
     if (buyAsset === undefined) return
-    return cryptoMarketDataById[buyAsset.assetId]?.price
+    return cryptoMarketDataSortedByMarketCapUsd[buyAsset.assetId]?.price
   },
 )
 

--- a/src/state/slices/tradeInputSlice/selectors.ts
+++ b/src/state/slices/tradeInputSlice/selectors.ts
@@ -10,7 +10,7 @@ import {
   selectWalletAccountIds,
 } from '../common-selectors'
 import {
-  selectCryptoMarketDataSortedByMarketCapUsd,
+  selectCryptoMarketDataUsd,
   selectUserCurrencyToUsdRate,
 } from '../marketDataSlice/selectors'
 import {
@@ -37,19 +37,19 @@ export const selectInputSellAsset = createDeepEqualOutputSelector(
 
 export const selectInputSellAssetUsdRate = createSelector(
   selectInputSellAsset,
-  selectCryptoMarketDataSortedByMarketCapUsd,
-  (sellAsset, cryptoMarketDataSortedByMarketCapUsd) => {
+  selectCryptoMarketDataUsd,
+  (sellAsset, cryptoMarketDataUsd) => {
     if (sellAsset === undefined) return
-    return cryptoMarketDataSortedByMarketCapUsd[sellAsset.assetId]?.price
+    return cryptoMarketDataUsd[sellAsset.assetId]?.price
   },
 )
 
 export const selectInputBuyAssetUsdRate = createSelector(
   selectInputBuyAsset,
-  selectCryptoMarketDataSortedByMarketCapUsd,
-  (buyAsset, cryptoMarketDataSortedByMarketCapUsd) => {
+  selectCryptoMarketDataUsd,
+  (buyAsset, cryptoMarketDataUsd) => {
     if (buyAsset === undefined) return
-    return cryptoMarketDataSortedByMarketCapUsd[buyAsset.assetId]?.price
+    return cryptoMarketDataUsd[buyAsset.assetId]?.price
   },
 )
 

--- a/src/state/slices/tradeQuoteSlice/helpers.ts
+++ b/src/state/slices/tradeQuoteSlice/helpers.ts
@@ -47,10 +47,10 @@ export const getTotalNetworkFeeUserCurrencyPrecision = (
 export const getHopTotalProtocolFeesFiatPrecision = (
   tradeQuoteStep: TradeQuote['steps'][number],
   userCurrencyToUsdRate: string,
-  cryptoMarketDataById: Partial<Record<AssetId, MarketData>>,
+  cryptoMarketDataByAssetIdUsd: Partial<Record<AssetId, MarketData>>,
 ): string => {
   return sumProtocolFeesToDenom({
-    cryptoMarketDataById,
+    cryptoMarketDataByAssetIdUsd,
     protocolFees: tradeQuoteStep.feeData.protocolFees,
     outputExponent: 0,
     outputAssetPriceUsd: userCurrencyToUsdRate,

--- a/src/state/slices/tradeQuoteSlice/selectors.ts
+++ b/src/state/slices/tradeQuoteSlice/selectors.ts
@@ -262,12 +262,12 @@ export const selectHopTotalProtocolFeesFiatPrecision: Selector<ReduxState, strin
     selectUserCurrencyToUsdRate,
     selectCryptoMarketDataSortedByMarketCapUsd,
     (_state: ReduxState, step: number) => step,
-    (quote, userCurrencyToUsdRate, cryptoMarketDataById, step) =>
+    (quote, userCurrencyToUsdRate, cryptoMarketDataSortedByMarketCapUsd, step) =>
       quote && quote.steps[step]
         ? getHopTotalProtocolFeesFiatPrecision(
             quote.steps[step],
             userCurrencyToUsdRate,
-            cryptoMarketDataById,
+            cryptoMarketDataSortedByMarketCapUsd,
           )
         : undefined,
   )

--- a/src/state/slices/tradeQuoteSlice/selectors.ts
+++ b/src/state/slices/tradeQuoteSlice/selectors.ts
@@ -42,8 +42,8 @@ import { convertBasisPointsToDecimalPercentage } from 'state/slices/tradeQuoteSl
 
 import { selectIsWalletConnected, selectWalletSupportedChainIds } from '../common-selectors'
 import {
-  selectCryptoMarketDataSortedByMarketCapUsd,
-  selectCryptoMarketDataSortedByMarketCapUserCurrency,
+  selectCryptoMarketDataUsd,
+  selectCryptoMarketDataUserCurrency,
   selectUserCurrencyToUsdRate,
 } from '../marketDataSlice/selectors'
 import { selectFeatureFlags } from '../selectors'
@@ -260,14 +260,14 @@ export const selectHopTotalProtocolFeesFiatPrecision: Selector<ReduxState, strin
   createSelector(
     selectActiveQuote,
     selectUserCurrencyToUsdRate,
-    selectCryptoMarketDataSortedByMarketCapUsd,
+    selectCryptoMarketDataUsd,
     (_state: ReduxState, step: number) => step,
-    (quote, userCurrencyToUsdRate, cryptoMarketDataSortedByMarketCapUsd, step) =>
+    (quote, userCurrencyToUsdRate, cryptoMarketDataUsd, step) =>
       quote && quote.steps[step]
         ? getHopTotalProtocolFeesFiatPrecision(
             quote.steps[step],
             userCurrencyToUsdRate,
-            cryptoMarketDataSortedByMarketCapUsd,
+            cryptoMarketDataUsd,
           )
         : undefined,
   )
@@ -432,7 +432,7 @@ export const selectFirstHopNetworkFeeUserCurrencyPrecision: Selector<
 > = createSelector(
   selectFirstHop,
   selectFirstHopSellFeeAsset,
-  selectCryptoMarketDataSortedByMarketCapUserCurrency,
+  selectCryptoMarketDataUserCurrency,
   (tradeQuoteStep, feeAsset, cryptoMarketData) => {
     if (!tradeQuoteStep) return
 
@@ -458,7 +458,7 @@ export const selectSecondHopNetworkFeeUserCurrencyPrecision: Selector<
 > = createSelector(
   selectSecondHop,
   selectSecondHopSellFeeAsset,
-  selectCryptoMarketDataSortedByMarketCapUserCurrency,
+  selectCryptoMarketDataUserCurrency,
   (tradeQuoteStep, feeAsset, cryptoMarketData) => {
     if (!tradeQuoteStep) return
 

--- a/src/state/slices/tradeQuoteSlice/selectors.ts
+++ b/src/state/slices/tradeQuoteSlice/selectors.ts
@@ -42,8 +42,8 @@ import { convertBasisPointsToDecimalPercentage } from 'state/slices/tradeQuoteSl
 
 import { selectIsWalletConnected, selectWalletSupportedChainIds } from '../common-selectors'
 import {
-  selectCryptoMarketData,
-  selectSelectedCurrencyMarketDataSortedByMarketCap,
+  selectCryptoMarketDataSortedByMarketCapUsd,
+  selectCryptoMarketDataSortedByMarketCapUserCurrency,
   selectUserCurrencyToUsdRate,
 } from '../marketDataSlice/selectors'
 import { selectFeatureFlags } from '../selectors'
@@ -260,7 +260,7 @@ export const selectHopTotalProtocolFeesFiatPrecision: Selector<ReduxState, strin
   createSelector(
     selectActiveQuote,
     selectUserCurrencyToUsdRate,
-    selectCryptoMarketData,
+    selectCryptoMarketDataSortedByMarketCapUsd,
     (_state: ReduxState, step: number) => step,
     (quote, userCurrencyToUsdRate, cryptoMarketDataById, step) =>
       quote && quote.steps[step]
@@ -432,7 +432,7 @@ export const selectFirstHopNetworkFeeUserCurrencyPrecision: Selector<
 > = createSelector(
   selectFirstHop,
   selectFirstHopSellFeeAsset,
-  selectSelectedCurrencyMarketDataSortedByMarketCap,
+  selectCryptoMarketDataSortedByMarketCapUserCurrency,
   (tradeQuoteStep, feeAsset, cryptoMarketData) => {
     if (!tradeQuoteStep) return
 
@@ -458,7 +458,7 @@ export const selectSecondHopNetworkFeeUserCurrencyPrecision: Selector<
 > = createSelector(
   selectSecondHop,
   selectSecondHopSellFeeAsset,
-  selectSelectedCurrencyMarketDataSortedByMarketCap,
+  selectCryptoMarketDataSortedByMarketCapUserCurrency,
   (tradeQuoteStep, feeAsset, cryptoMarketData) => {
     if (!tradeQuoteStep) return
 

--- a/src/state/slices/tradeQuoteSlice/utils.test.ts
+++ b/src/state/slices/tradeQuoteSlice/utils.test.ts
@@ -4,7 +4,7 @@ import BigNumber from 'bignumber.js'
 import { describe, expect, it } from 'vitest'
 import { baseUnitToHuman, bn, convertPrecision } from 'lib/bignumber/bignumber'
 import { BTC, ETH, FOX_MAINNET } from 'lib/swapper/swappers/utils/test-data/assets'
-import { cryptoMarketDataById } from 'lib/swapper/swappers/utils/test-data/cryptoMarketDataById'
+import { cryptoMarketDataByAssetIdUsd } from 'lib/swapper/swappers/utils/test-data/cryptoMarketDataById'
 import {
   subtractBasisPointAmount,
   sumProtocolFeesToDenom,
@@ -15,9 +15,9 @@ describe('sumProtocolFeesToDenom', () => {
     const protocolFees: Record<AssetId, ProtocolFee> = {}
 
     const result = sumProtocolFeesToDenom({
-      cryptoMarketDataById,
+      cryptoMarketDataByAssetIdUsd,
       outputExponent: FOX_MAINNET.precision,
-      outputAssetPriceUsd: cryptoMarketDataById[FOX_MAINNET.assetId].price,
+      outputAssetPriceUsd: cryptoMarketDataByAssetIdUsd[FOX_MAINNET.assetId].price,
       protocolFees,
     })
 
@@ -39,17 +39,17 @@ describe('sumProtocolFeesToDenom', () => {
     }
 
     const result = sumProtocolFeesToDenom({
-      cryptoMarketDataById,
+      cryptoMarketDataByAssetIdUsd,
       outputExponent: FOX_MAINNET.precision,
-      outputAssetPriceUsd: cryptoMarketDataById[FOX_MAINNET.assetId].price,
+      outputAssetPriceUsd: cryptoMarketDataByAssetIdUsd[FOX_MAINNET.assetId].price,
       protocolFees,
     })
 
-    const btcToFoxPriceRatio = bn(cryptoMarketDataById[BTC.assetId].price).div(
-      cryptoMarketDataById[FOX_MAINNET.assetId].price,
+    const btcToFoxPriceRatio = bn(cryptoMarketDataByAssetIdUsd[BTC.assetId].price).div(
+      cryptoMarketDataByAssetIdUsd[FOX_MAINNET.assetId].price,
     )
-    const ethToFoxPriceRatio = bn(cryptoMarketDataById[ETH.assetId].price).div(
-      cryptoMarketDataById[FOX_MAINNET.assetId].price,
+    const ethToFoxPriceRatio = bn(cryptoMarketDataByAssetIdUsd[ETH.assetId].price).div(
+      cryptoMarketDataByAssetIdUsd[FOX_MAINNET.assetId].price,
     )
 
     expect(btcToFoxPriceRatio.gt(0)).toBe(true)
@@ -87,7 +87,7 @@ describe('sumProtocolFeesToDenom', () => {
     }
 
     const result = sumProtocolFeesToDenom({
-      cryptoMarketDataById,
+      cryptoMarketDataByAssetIdUsd,
       outputExponent: 0,
       outputAssetPriceUsd: '1',
       protocolFees,
@@ -96,12 +96,12 @@ describe('sumProtocolFeesToDenom', () => {
     const btcAmountInUsd = baseUnitToHuman({
       value: '3000000',
       inputExponent: BTC.precision,
-    }).times(cryptoMarketDataById[BTC.assetId].price)
+    }).times(cryptoMarketDataByAssetIdUsd[BTC.assetId].price)
 
     const ethAmountInUsd = baseUnitToHuman({
       value: '500000000000000000',
       inputExponent: ETH.precision,
-    }).times(cryptoMarketDataById[ETH.assetId].price)
+    }).times(cryptoMarketDataByAssetIdUsd[ETH.assetId].price)
 
     const expectation = btcAmountInUsd.plus(ethAmountInUsd).toString()
 

--- a/src/state/slices/tradeQuoteSlice/utils.ts
+++ b/src/state/slices/tradeQuoteSlice/utils.ts
@@ -15,7 +15,7 @@ export const convertBasisPointsToPercentage = (basisPoints: BigNumber.Value) =>
   bnOrZero(basisPoints).div(100)
 
 type SumProtocolFeesToDenomArgs = {
-  cryptoMarketDataById: Partial<Record<AssetId, Pick<MarketData, 'price'>>>
+  cryptoMarketDataByAssetIdUsd: Partial<Record<AssetId, Pick<MarketData, 'price'>>>
   outputAssetPriceUsd: BigNumber.Value
   outputExponent: number
   protocolFees: PartialRecord<AssetId, ProtocolFee>
@@ -72,7 +72,7 @@ export const addBasisPointAmount = (
 // this converts the collection of protocol fees denominated in various assets to the sum of all of
 // their values denominated in single asset and precision
 export const sumProtocolFeesToDenom = ({
-  cryptoMarketDataById,
+  cryptoMarketDataByAssetIdUsd,
   outputAssetPriceUsd,
   outputExponent,
   protocolFees,
@@ -81,7 +81,7 @@ export const sumProtocolFeesToDenom = ({
     .reduce((acc: BigNumber, [assetId, protocolFee]: [AssetId, ProtocolFee | undefined]) => {
       if (!protocolFee) return acc
       const inputExponent = protocolFee.asset.precision
-      const priceUsd = cryptoMarketDataById[assetId]?.price
+      const priceUsd = cryptoMarketDataByAssetIdUsd[assetId]?.price
 
       if (!inputExponent || !priceUsd) return acc
 


### PR DESCRIPTION
## Description

* Fixes 3 cases where we're using USD market data in place of user-currency market data
* Improves naming of market data related selectors to prevent confusion in the future

## Pull Request Type

- [x] :bug: Bug fix (Non-breaking Change: Fixes an issue)
- [ ] :hammer_and_wrench: Chore (Non-breaking Change: Doc updates, pkg upgrades, typos, etc..)
- [ ] :nail_care: New Feature (Breaking/Non-breaking Change)

## Issue (if applicable)

NA

## Risk
> High Risk PRs Require 2 approvals

Marking as high risk as an error in renaming here could have big consequences around the app. The changes in this PR are mostly renaming though, and the only logical changes are the 3 fixes marked.

> What protocols, transaction types or contract interactions might be affected by this PR?

## Testing

Check market data and prices around the app are looking correct in non-usd currencies, specifically:
* Trade confirm summary of asset amounts in non-USD fiat
* Staking positions  in non-USD fiat
* LP positions  in non-USD fiat

### Engineering

<!-----------------------------------------------------------------------------
Include sufficient information here for an engineer to test your PR. This may include how to test locally, in a built environment, changes to infrastructure etc.
------------------------------------------------------------------------------>

### Operations

<!-----------------------------------------------------------------------------
If your changes have a user-facing impact, describe how a non-technical QA team can functionally test your changes in a preview environment.

If they are not user-facing please describe how to test for any regressions that may occur.
------------------------------------------------------------------------------>

## Screenshots (if applicable)
