### PR TITLE
fix: eip155 wc isTransactionParams checks / gasLimit short-circuit

### DIFF
--- a/src/plugins/walletConnectToDapps/typeGuards.ts
+++ b/src/plugins/walletConnectToDapps/typeGuards.ts
@@ -52,4 +52,8 @@ export const isTransactionParams = (
   !!transaction.from &&
   !!transaction.to &&
   !!transaction.data &&
-  ((!!transaction.gasLimit && !!transaction.gasPrice) || !!transaction.gas)
+  Boolean(
+    (transaction.gasLimit !== undefined && transaction.gasPrice !== undefined) ||
+      transaction.gas !== undefined ||
+      (transaction.maxFeePerGas !== undefined && transaction.maxPriorityFeePerGas !== undefined),
+  )

--- a/src/plugins/walletConnectToDapps/types.ts
+++ b/src/plugins/walletConnectToDapps/types.ts
@@ -134,6 +134,8 @@ export type TransactionParams = {
   data: string
   gasLimit?: string
   gas?: string
+  maxFeePerGas?: string
+  maxPriorityFeePerGas?: string
   gasPrice?: string
   value?: string
   nonce?: string

--- a/src/plugins/walletConnectToDapps/utils/EIP155RequestHandlerUtil.ts
+++ b/src/plugins/walletConnectToDapps/utils/EIP155RequestHandlerUtil.ts
@@ -90,6 +90,11 @@ export const approveEIP155Request = async ({
       const fees = await getFeesForTx(sendTransaction, chainAdapter, accountId)
       const senderAddress = await chainAdapter.getAddress({ accountNumber, wallet })
       const gasData = getGasData(customTransactionData, fees)
+      const gasLimit = (() => {
+        if (customTransactionData.gasLimit) return customTransactionData.gasLimit
+        if (sendTransaction.gasLimit) return sendTransaction.gasLimit
+        return '90000' // https://docs.walletconnect.com/2.0/advanced/rpc-reference/ethereum-rpc#eth_sendtransaction
+      })()
       const { txToSign: txToSignWithPossibleWrongNonce } = await chainAdapter.buildCustomTx({
         wallet,
         accountNumber,
@@ -97,7 +102,7 @@ export const approveEIP155Request = async ({
         data: sendTransaction.data,
         value: sendTransaction.value ?? '0',
         // https://docs.walletconnect.com/2.0/advanced/rpc-reference/ethereum-rpc#eth_sendtransaction
-        gasLimit: customTransactionData.gasLimit ?? sendTransaction.gasLimit ?? '90000',
+        gasLimit,
         ...gasData,
       })
       const txToSign = {


### PR DESCRIPTION
## Description

Does what is says on the box:

- handles payloads with `maxFeePerGas` and `maxPriorityPerGas` but none of the other, as well as explicitly checking against undefined (some fields may be present but null, which is still valid as far as payloads go towards directing the gas scheme to be used) - https://github.com/shapeshift/web/pull/6364/commits/5b559ef049e7204ca672dcc3fd73a95d2ebe2822
- non-null assertion operator doesn't work on empty strings - meaning this guy would never work in case both `customTransactionData.gasLimit` and `sendTransaction.gasLimit` are empty strings:

https://github.com/shapeshift/web/blob/aff5d29808ff1bf29a9967c32d97f048319ff0d5/src/plugins/walletConnectToDapps/utils/EIP155RequestHandlerUtil.ts#L100
 

## Pull Request Type

- [x] :bug: Bug fix (Non-breaking Change: Fixes an issue)
- [ ] :hammer_and_wrench: Chore (Non-breaking Change: Doc updates, pkg upgrades, typos, etc..)
- [ ] :nail_care: New Feature (Breaking/Non-breaking Change)

## Issue (if applicable)

<!-----------------------------------------------------------------------------
If applicable, please link to the github issue and put `closes #XXXX` in your comment to auto-close the issue that your PR fixes.
------------------------------------------------------------------------------>

closes https://github.com/shapeshift/web/issues/6034

## Risk
> High Risk PRs Require 2 approvals

<!-----------------------------------------------------------------------------
Outline the scope of your changes and the risk associated with them. You must use your discretion as an engineer to determine the potential impact of your changes.

WARNING: If your PR introduces a new on-chain transaction or modifies an existing one, please add the "High-Risk" label to this PR and ask for 2 reviewers to approve it before merging.

E.g. an upgrade to `hdwallet` or core state management would be considered higher risk, and might require a full regression test. UI or isolated view changes, or something behind a feature flag may have near zero risk. Small bug fixes might require testing isolated to the specific fix.
------------------------------------------------------------------------------>

Small, though this may bork some other wc dApps Txs - test accordingly

> What protocols, transaction types or contract interactions might be affected by this PR?

WalletConnect

## Testing

<!-----------------------------------------------------------------------------
We treat every PR to be merged with the same scrutiny as if we were merging directly to production.

Your PR will not be merged if you do not complete the sections below for our engineering and operations teams to test.
------------------------------------------------------------------------------>

- Test with the same Etherscan revoke Tx as in https://github.com/shapeshift/web/issues/6008
- Ensure it is now happy at display-time, but also actually broadcasts and confirms

### Engineering

<!-----------------------------------------------------------------------------
Include sufficient information here for an engineer to test your PR. This may include how to test locally, in a built environment, changes to infrastructure etc.
------------------------------------------------------------------------------>

- ^

### Operations

<!-----------------------------------------------------------------------------
If your changes have a user-facing impact, describe how a non-technical QA team can functionally test your changes in a preview environment.

If they are not user-facing please describe how to test for any regressions that may occur.
------------------------------------------------------------------------------>

- ^

## Screenshots (if applicable)

- develop

<img width="516" alt="Screenshot 2024-03-05 at 17 21 06" src="https://github.com/shapeshift/web/assets/17035424/ac8cb1be-98ec-4074-8028-b93d71315d27">

- This diff

<img width="520" alt="Screenshot 2024-03-05 at 17 27 27" src="https://github.com/shapeshift/web/assets/17035424/573b82e6-d5a9-4c8b-b545-a7a53cb0c791">
<img width="297" alt="Screenshot 2024-03-05 at 18 31 10" src="https://github.com/shapeshift/web/assets/17035424/33f26048-1a8d-4371-8fd5-a3a8923a12af">
<img width="762" alt="Screenshot 2024-03-05 at 18 31 23" src="https://github.com/shapeshift/web/assets/17035424/56f48e7e-0dd2-4b7a-8f2e-f7e0bad201d2">

