### PR TITLE
feat: fox discount block improvements

### DIFF
--- a/src/lib/fees/utils.test.ts
+++ b/src/lib/fees/utils.test.ts
@@ -1,0 +1,118 @@
+import type { Block } from 'ethers'
+import { beforeEach, describe, expect, it, vi } from 'vitest'
+import { getEthersProvider } from 'lib/ethersProviderSingleton'
+
+import { findClosestFoxDiscountDelayBlockNumber } from './utils'
+
+vi.unmock('ethers')
+
+const getBlockSpy = vi.spyOn(getEthersProvider(), 'getBlock')
+
+describe('findClosestFoxDiscountDelayBlockNumber', () => {
+  beforeEach(() => {
+    vi.clearAllMocks()
+  })
+
+  it('should return the latest block number with no delay hours', async () => {
+    const latestBlockNumber = 19377703
+
+    // latestBlock
+    getBlockSpy.mockImplementationOnce(() =>
+      Promise.resolve({
+        number: latestBlockNumber,
+      } as Block),
+    )
+
+    // stub out further calls to getBlock
+    getBlockSpy.mockImplementation(() => Promise.resolve(null))
+
+    const actual = await findClosestFoxDiscountDelayBlockNumber(0)
+
+    expect(actual).toEqual(latestBlockNumber)
+    expect(getBlockSpy.mock.calls.length).toEqual(1)
+  })
+
+  it('should return the latest block number with delay hours (first hit)', async () => {
+    // latestBlock
+    getBlockSpy.mockImplementationOnce(() =>
+      Promise.resolve({
+        number: 19377703,
+        timestamp: 1709747075,
+      } as Block),
+    )
+
+    // historicalBlock
+    getBlockSpy.mockImplementationOnce(() =>
+      Promise.resolve({
+        number: 19376703,
+        timestamp: 1709735003,
+      } as Block),
+    )
+
+    // targetBlock
+    getBlockSpy.mockImplementationOnce(() =>
+      Promise.resolve({
+        number: 19376212,
+        timestamp: 1709729075,
+      } as Block),
+    )
+
+    // stub out further calls to getBlock
+    getBlockSpy.mockImplementation(() => Promise.resolve(null))
+
+    const actual = await findClosestFoxDiscountDelayBlockNumber(5)
+
+    expect(actual).toEqual(19376212)
+    expect(getBlockSpy.mock.calls.length).toEqual(3)
+  })
+
+  it('should return the latest block number with delay hours', async () => {
+    // latestBlock
+    getBlockSpy.mockImplementationOnce(() =>
+      Promise.resolve({
+        number: 19377703,
+        timestamp: 1709747075,
+      } as Block),
+    )
+
+    // historicalBlock (fake timestamp to modify averageBlockTimeSeconds)
+    getBlockSpy.mockImplementationOnce(() =>
+      Promise.resolve({
+        number: 19376703,
+        timestamp: 1709734503,
+      } as Block),
+    )
+
+    // targetBlock 1
+    getBlockSpy.mockImplementationOnce(() =>
+      Promise.resolve({
+        number: 19376272,
+        timestamp: 1709729807,
+      } as Block),
+    )
+
+    // targetBlock 2
+    getBlockSpy.mockImplementationOnce(() =>
+      Promise.resolve({
+        number: 19376213,
+        timestamp: 1709729087,
+      } as Block),
+    )
+
+    // targetBlock 3
+    getBlockSpy.mockImplementationOnce(() =>
+      Promise.resolve({
+        number: 19376212,
+        timestamp: 1709729075,
+      } as Block),
+    )
+
+    // stub out further calls to getBlock
+    getBlockSpy.mockImplementation(() => Promise.resolve(null))
+
+    const actual = await findClosestFoxDiscountDelayBlockNumber(5)
+
+    expect(actual).toEqual(19376212)
+    expect(getBlockSpy.mock.calls.length).toEqual(5)
+  })
+})


### PR DESCRIPTION
## Description

These changes make a few improvements:
- Dynamic average block time seconds based on 1k block range
- Explicit unix timestamp math only (no dayjs and possible timezone edge cases)
- Use latest block timestamp as the starting point instead of current timestamp (this will ensure we can at least get an out of date fox discount block even if the node is behind by a bit worst case instead of fail)
- Use the block 1 block before the target timestamp instead of before OR after the target timestamp
- Add unit tests

## Pull Request Type

- [ ] :bug: Bug fix (Non-breaking Change: Fixes an issue)
- [ ] :hammer_and_wrench: Chore (Non-breaking Change: Doc updates, pkg upgrades, typos, etc..)
- [x] :nail_care: New Feature (Breaking/Non-breaking Change)

## Issue (if applicable)

<!-----------------------------------------------------------------------------
If applicable, please link to the github issue and put `closes #XXXX` in your comment to auto-close the issue that your PR fixes.
------------------------------------------------------------------------------>

N/A

## Risk
> High Risk PRs Require 2 approvals

<!-----------------------------------------------------------------------------
Outline the scope of your changes and the risk associated with them. You must use your discretion as an engineer to determine the potential impact of your changes.

WARNING: If your PR introduces a new on-chain transaction or modifies an existing one, please add the "High-Risk" label to this PR and ask for 2 reviewers to approve it before merging.

E.g. an upgrade to `hdwallet` or core state management would be considered higher risk, and might require a full regression test. UI or isolated view changes, or something behind a feature flag may have near zero risk. Small bug fixes might require testing isolated to the specific fix.
------------------------------------------------------------------------------>

Low/Med - this does change behavior slightly (block before timestamp only) and updates average block time and timestamp math, but unit tests provide confidence in change

> What protocols, transaction types or contract interactions might be affected by this PR?

## Testing

<!-----------------------------------------------------------------------------
We treat every PR to be merged with the same scrutiny as if we were merging directly to production.

Your PR will not be merged if you do not complete the sections below for our engineering and operations teams to test.
------------------------------------------------------------------------------>

- Ensure accurate fox discount block is selected for lp fox discounts with 7 hour block delay

### Engineering

<!-----------------------------------------------------------------------------
Include sufficient information here for an engineer to test your PR. This may include how to test locally, in a built environment, changes to infrastructure etc.
------------------------------------------------------------------------------>

:point_up: 

### Operations

<!-----------------------------------------------------------------------------
If your changes have a user-facing impact, describe how a non-technical QA team can functionally test your changes in a preview environment.

If they are not user-facing please describe how to test for any regressions that may occur.
------------------------------------------------------------------------------>

:point_up: 

## Screenshots (if applicable)
