### PR TITLE
chore: break out chain menu component from metamask chain select

### DIFF
--- a/src/components/ChainMenu.tsx
+++ b/src/components/ChainMenu.tsx
@@ -160,5 +160,9 @@ const GenericChainMenu = <T extends ChainId | 'All'>({
   )
 }
 
-export const ChainMenu = GenericChainMenu<ChainId>
-export const AllChainMenu = GenericChainMenu<ChainId | 'All'>
+export const ChainMenu = (props: ChainMenuProps<ChainId>) => (
+  <GenericChainMenu<ChainId> {...props} />
+)
+export const AllChainMenu = (props: ChainMenuProps<ChainId | 'All'>) => (
+  <GenericChainMenu<ChainId | 'All'> {...props} />
+)

--- a/src/components/ChainMenu.tsx
+++ b/src/components/ChainMenu.tsx
@@ -116,7 +116,7 @@ const MenuIcon = <T extends ChainId | 'All'>({
   return <ChainIcon chainId={activeChainId} width='6' height='auto' />
 }
 
-export const ChainMenu = <T extends ChainId | 'All'>({
+const GenericChainMenu = <T extends ChainId | 'All'>({
   chainIds,
   activeChainId,
   isActiveChainIdSupported,
@@ -159,3 +159,6 @@ export const ChainMenu = <T extends ChainId | 'All'>({
     </Menu>
   )
 }
+
+export const ChainMenu = GenericChainMenu<ChainId>
+export const AllChainMenu = GenericChainMenu<ChainId | 'All'>

--- a/src/components/ChainMenu.tsx
+++ b/src/components/ChainMenu.tsx
@@ -1,0 +1,119 @@
+import { WarningIcon } from '@chakra-ui/icons'
+import type { ButtonProps } from '@chakra-ui/react'
+import {
+  Box,
+  Button,
+  Flex,
+  Menu,
+  MenuButton,
+  MenuGroup,
+  MenuItem,
+  MenuList,
+  Text,
+  Tooltip,
+  useColorModeValue,
+} from '@chakra-ui/react'
+import { type ChainId } from '@shapeshiftoss/caip'
+import { useCallback, useMemo } from 'react'
+import { useTranslate } from 'react-polyglot'
+import { AssetIcon } from 'components/AssetIcon'
+import { CircleIcon } from 'components/Icons/Circle'
+import { getChainAdapterManager } from 'context/PluginProvider/chainAdapterSingleton'
+import { selectAssetById } from 'state/slices/selectors'
+import { useAppSelector } from 'state/store'
+
+export type ChainMenuProps<T extends string> = {
+  chainIds: T[]
+  activeChainId: T | undefined
+  isActiveChainIdSupported: boolean
+  isDisabled: boolean
+  buttonProps?: ButtonProps
+  onMenuOptionClick: (chainId: ChainId) => void
+}
+
+const ChainMenuItem: React.FC<{
+  chainId: ChainId
+  onClick: (chainId: ChainId) => void
+  isConnected: boolean
+}> = ({ chainId, onClick, isConnected }) => {
+  const { nativeAssetId, chainName } = useMemo(() => {
+    const chainAdapterManager = getChainAdapterManager()
+    const adapter = chainAdapterManager.get(chainId)
+    return { chainName: adapter?.getDisplayName(), nativeAssetId: adapter?.getFeeAssetId() }
+  }, [chainId])
+
+  const nativeAsset = useAppSelector(state => selectAssetById(state, nativeAssetId ?? ''))
+  const connectedIconColor = useColorModeValue('green.500', 'green.200')
+  const connectedChainBgColor = useColorModeValue('blackAlpha.100', 'whiteAlpha.50')
+  const assetIcon = useMemo(
+    () => <AssetIcon assetId={nativeAssetId} showNetworkIcon width='6' height='auto' />,
+    [nativeAssetId],
+  )
+  const handleClick = useCallback(() => onClick(chainId), [chainId, onClick])
+
+  if (!nativeAsset) return null
+
+  return (
+    <MenuItem
+      icon={assetIcon}
+      backgroundColor={isConnected ? connectedChainBgColor : undefined}
+      onClick={handleClick}
+      borderRadius='lg'
+    >
+      <Flex justifyContent={'space-between'}>
+        <Text>{chainName}</Text>
+        <Box>{isConnected && <CircleIcon color={connectedIconColor} w={2} />}</Box>
+      </Flex>
+    </MenuItem>
+  )
+}
+
+export const ChainMenu = <T extends string>({
+  chainIds,
+  activeChainId,
+  isActiveChainIdSupported,
+  onMenuOptionClick,
+  isDisabled,
+  buttonProps,
+}: ChainMenuProps<T>) => {
+  const translate = useTranslate()
+
+  const activeChainFeeAssetId = useMemo(() => {
+    const chainAdapterManager = getChainAdapterManager()
+    return chainAdapterManager.get(activeChainId ?? '')?.getFeeAssetId()
+  }, [activeChainId])
+
+  return (
+    <Menu autoSelect={false}>
+      <Tooltip
+        label={translate(
+          isActiveChainIdSupported ? 'common.switchNetwork' : 'common.unsupportedNetwork',
+        )}
+        isDisabled={isDisabled}
+      >
+        <MenuButton as={Button} {...buttonProps}>
+          <Flex alignItems='center' justifyContent='center'>
+            {isActiveChainIdSupported ? (
+              <AssetIcon assetId={activeChainFeeAssetId} showNetworkIcon size='xs' />
+            ) : (
+              <WarningIcon color='yellow.300' boxSize='4' />
+            )}
+          </Flex>
+        </MenuButton>
+      </Tooltip>
+
+      <MenuList p='10px' zIndex={2}>
+        <MenuGroup title={translate('common.selectNetwork')} ml={3} color='text.subtle'>
+          {chainIds.map(chainId => (
+            <ChainMenuItem
+              isConnected={chainId === activeChainId}
+              key={chainId}
+              chainId={chainId}
+              onClick={onMenuOptionClick}
+            />
+          ))}
+        </MenuGroup>
+      </MenuList>
+    </Menu>
+  )
+}

--- a/src/components/Layout/Header/NavBar/ChainMenu.tsx
+++ b/src/components/Layout/Header/NavBar/ChainMenu.tsx
@@ -6,7 +6,7 @@ import type { ETHWallet } from '@shapeshiftoss/hdwallet-core'
 import { supportsEthSwitchChain } from '@shapeshiftoss/hdwallet-core'
 import { memo, useCallback, useMemo } from 'react'
 import { toHex } from 'viem'
-import { ChainMenu as GenericChainMenu } from 'components/ChainMenu'
+import { ChainMenu as BasicChainMenu } from 'components/ChainMenu'
 import { getChainAdapterManager } from 'context/PluginProvider/chainAdapterSingleton'
 import { useEvm } from 'hooks/useEvm/useEvm'
 import { useWallet } from 'hooks/useWallet/useWallet'
@@ -91,7 +91,7 @@ export const ChainMenu = memo((props: ChainMenuProps) => {
 
   return (
     <Box {...props}>
-      <GenericChainMenu<ChainId>
+      <BasicChainMenu
         activeChainId={connectedEvmChainId}
         chainIds={supportedEvmChainIds}
         isActiveChainIdSupported={currentChainNativeAsset !== undefined}

--- a/src/components/Layout/Header/NavBar/ChainMenu.tsx
+++ b/src/components/Layout/Header/NavBar/ChainMenu.tsx
@@ -1,7 +1,7 @@
 import type { BoxProps, ButtonProps } from '@chakra-ui/react'
 import { Box } from '@chakra-ui/react'
 import type { ChainId } from '@shapeshiftoss/caip'
-import { fromChainId, gnosisChainId } from '@shapeshiftoss/caip'
+import { fromChainId } from '@shapeshiftoss/caip'
 import type { ETHWallet } from '@shapeshiftoss/hdwallet-core'
 import { supportsEthSwitchChain } from '@shapeshiftoss/hdwallet-core'
 import { memo, useCallback, useMemo } from 'react'
@@ -44,11 +44,6 @@ export const ChainMenu = memo((props: ChainMenuProps) => {
         if (!requestedChainFeeAsset)
           throw new Error(`Asset not found for AssetId ${requestedChainFeeAssetId}`)
 
-        // Temporary hack to add the official Gnosis RPC to wallets until stabilized - we don't want to bork users' wallets
-        // https://docs.metamask.io/wallet/reference/rpc-api/#parameters-1
-        // "rpcUrls - An array of RPC URL strings. At least one item is required, and only the first item is used."
-        const maybeGnosisOfficialRpcUrl =
-          requestedChainId === gnosisChainId ? ['https://rpc.gnosischain.com'] : []
         const requestedChainRpcUrl = requestedChainChainAdapter.getRpcUrl()
         await (state.wallet as ETHWallet).ethSwitchChain?.({
           chainId: toHex(Number(fromChainId(requestedChainId).chainReference)),
@@ -58,7 +53,7 @@ export const ChainMenu = memo((props: ChainMenuProps) => {
             symbol: requestedChainFeeAsset.symbol,
             decimals: 18,
           },
-          rpcUrls: [...maybeGnosisOfficialRpcUrl, requestedChainRpcUrl],
+          rpcUrls: [requestedChainRpcUrl],
           blockExplorerUrls: [requestedChainFeeAsset.explorer],
         })
         setChainId(requestedChainId)

--- a/src/components/Layout/Header/NavBar/ChainMenu.tsx
+++ b/src/components/Layout/Header/NavBar/ChainMenu.tsx
@@ -24,7 +24,7 @@ type ChainMenuProps = BoxProps
 
 export const ChainMenu = memo((props: ChainMenuProps) => {
   const { state, load } = useWallet()
-  const { connectedEvmChainId, isEvmChainId, isLoading, setEthNetwork, supportedEvmChainIds } =
+  const { connectedEvmChainId, isEvmChainId, isLoading, setChainId, supportedEvmChainIds } =
     useEvm()
   const chainAdapterManager = getChainAdapterManager()
 
@@ -61,13 +61,13 @@ export const ChainMenu = memo((props: ChainMenuProps) => {
           rpcUrls: [...maybeGnosisOfficialRpcUrl, requestedChainRpcUrl],
           blockExplorerUrls: [requestedChainFeeAsset.explorer],
         })
-        setEthNetwork(requestedChainId)
+        setChainId(requestedChainId)
         load()
       } catch (e) {
         console.error(e)
       }
     },
-    [assets, isEvmChainId, load, setEthNetwork, state.wallet],
+    [assets, isEvmChainId, load, setChainId, state.wallet],
   )
 
   const currentChainNativeAssetId = useMemo(

--- a/src/components/Layout/Header/NavBar/ChainMenu.tsx
+++ b/src/components/Layout/Header/NavBar/ChainMenu.tsx
@@ -24,8 +24,13 @@ type ChainMenuProps = BoxProps
 
 export const ChainMenu = memo((props: ChainMenuProps) => {
   const { state, load } = useWallet()
-  const { connectedEvmChainId, isEvmChainId, isLoading, setChainId, supportedEvmChainIds } =
-    useEvm()
+  const {
+    connectedEvmChainId,
+    isSupportedEvmChainId,
+    isLoading,
+    setChainId,
+    supportedEvmChainIds,
+  } = useEvm()
   const chainAdapterManager = getChainAdapterManager()
 
   const assets = useAppSelector(selectAssets)
@@ -33,7 +38,7 @@ export const ChainMenu = memo((props: ChainMenuProps) => {
   const handleChainClick = useCallback(
     async (requestedChainId: ChainId) => {
       try {
-        if (!isEvmChainId(requestedChainId)) {
+        if (!isSupportedEvmChainId(requestedChainId)) {
           throw new Error(`Unsupported EVM network: ${requestedChainId}`)
         }
 
@@ -62,7 +67,7 @@ export const ChainMenu = memo((props: ChainMenuProps) => {
         console.error(e)
       }
     },
-    [assets, isEvmChainId, load, setChainId, state.wallet],
+    [assets, isSupportedEvmChainId, load, setChainId, state.wallet],
   )
 
   const currentChainNativeAssetId = useMemo(

--- a/src/hooks/useEvm/useEvm.ts
+++ b/src/hooks/useEvm/useEvm.ts
@@ -62,7 +62,7 @@ export const useEvm = () => {
       connectedEvmChainId,
       isEvmChainId,
       isLoading,
-      setEthNetwork: setChainId,
+      setChainId,
       supportedEvmChainIds,
     }),
     [connectedEvmChainId, isEvmChainId, isLoading, supportedEvmChainIds],


### PR DESCRIPTION
## Description

In preparation for #6289, this PR breaks out the UI components of the chain menu used for metamask chain selection so we can reuse it for the asset selection modal.

## Pull Request Type

- [ ] :bug: Bug fix (Non-breaking Change: Fixes an issue)
- [x] :hammer_and_wrench: Chore (Non-breaking Change: Doc updates, pkg upgrades, typos, etc..)
- [ ] :nail_care: New Feature (Breaking/Non-breaking Change)

## Issue (if applicable)

Relates to #6289

## Risk
> High Risk PRs Require 2 approvals

Moderate risk as this could potentially break the ability to switch chain on metamask.

> What protocols, transaction types or contract interactions might be affected by this PR?

## Testing

This should have no functional change from production.

* Ensure switching chain on metamask is working
* Ensure Native wallet doesnt show this menu
* Ensure metamask cannot connect to invalid chains (e.g UTXO without snap installed)

### Engineering

This includes a change to the menu to use actual caip chain IDs rather than chain references, which is the mostly likely part of this to break. 

### Operations

<!-----------------------------------------------------------------------------
If your changes have a user-facing impact, describe how a non-technical QA team can functionally test your changes in a preview environment.

If they are not user-facing please describe how to test for any regressions that may occur.
------------------------------------------------------------------------------>

## Screenshots (if applicable)
