### PR TITLE
fix: thorchain LP handle 0-value position page

### DIFF
--- a/src/pages/ThorChainLP/Position/Position.tsx
+++ b/src/pages/ThorChainLP/Position/Position.tsx
@@ -10,6 +10,7 @@ import {
   Flex,
   Heading,
   IconButton,
+  Skeleton,
   Stack,
   TabPanel,
   TabPanels,
@@ -141,7 +142,9 @@ export const Position = () => {
   }, [params.opportunityId])
 
   const { data: pool } = usePool(poolAssetId ?? '')
-  const { data: userLpData } = useUserLpData({ assetId: assetId ?? '' })
+  const { data: userLpData, isLoading: isUserLpDataLoading } = useUserLpData({
+    assetId: assetId ?? '',
+  })
 
   const position = useMemo(() => {
     if (!userLpData) return
@@ -161,7 +164,7 @@ export const Position = () => {
   const runeAsset = useAppSelector(state => selectAssetById(state, thorchainAssetId))
   const runeMarketData = useAppSelector(state => selectMarketDataById(state, thorchainAssetId))
 
-  const { data: earnings } = useQuery({
+  const { data: earnings, isLoading: isEarningsLoading } = useQuery({
     ...reactQueries.thorchainLp.earnings(position?.dateFirstAdded),
     enabled: Boolean(position),
     select: data => {
@@ -191,7 +194,8 @@ export const Position = () => {
     [stepIndex],
   )
 
-  if (!position) return null
+  console.log({ pool, position })
+  if (!pool) return null
 
   return (
     <Main headerComponent={headerComponent}>
@@ -201,7 +205,7 @@ export const Position = () => {
             <CardHeader px={8} py={8}>
               <Flex gap={4} alignItems='center'>
                 <PoolIcon assetIds={poolAssetIds} size='md' />
-                <Heading as='h3'>{position.name}</Heading>
+                <Heading as='h3'>{pool.name}</Heading>
                 <Tag size={'lg'}>
                   {position?.asym ? (
                     <Text
@@ -241,10 +245,12 @@ export const Position = () => {
                           <AssetIcon size='xs' assetId={poolAssetIds[0]} />
                           <RawText>{asset?.symbol ?? ''}</RawText>
                         </Flex>
-                        <Amount.Crypto
-                          value={position.underlyingAssetAmountCryptoPrecision}
-                          symbol={asset?.symbol ?? ''}
-                        />
+                        <Skeleton isLoaded={!isUserLpDataLoading}>
+                          <Amount.Crypto
+                            value={position?.underlyingAssetAmountCryptoPrecision ?? '0'}
+                            symbol={asset?.symbol ?? ''}
+                          />
+                        </Skeleton>
                       </Flex>
                       <Flex
                         fontSize='sm'
@@ -258,10 +264,12 @@ export const Position = () => {
                           <AssetIcon size='xs' assetId={poolAssetIds[1]} />
                           <RawText>{runeAsset?.symbol ?? ''}</RawText>
                         </Flex>
-                        <Amount.Crypto
-                          value={position.underlyingRuneAmountCryptoPrecision}
-                          symbol={runeAsset?.symbol ?? ''}
-                        />
+                        <Skeleton isLoaded={!isUserLpDataLoading}>
+                          <Amount.Crypto
+                            value={position?.underlyingRuneAmountCryptoPrecision ?? '0'}
+                            symbol={runeAsset?.symbol ?? ''}
+                          />
+                        </Skeleton>
                       </Flex>
                     </Stack>
                   </Card>
@@ -287,11 +295,13 @@ export const Position = () => {
                           <AssetIcon size='xs' assetId={poolAssetIds[0]} />
                           <RawText>{asset?.symbol ?? ''}</RawText>
                         </Flex>
-                        <Amount.Crypto
-                          value={earnings?.assetEarningsCryptoPrecision ?? '0'}
-                          symbol={asset?.symbol ?? ''}
-                          whiteSpace='nowrap'
-                        />
+                        <Skeleton isLoaded={!isEarningsLoading}>
+                          <Amount.Crypto
+                            value={earnings?.assetEarningsCryptoPrecision ?? '0'}
+                            symbol={asset?.symbol ?? ''}
+                            whiteSpace='nowrap'
+                          />
+                        </Skeleton>
                       </Flex>
                       <Flex
                         fontSize='sm'
@@ -305,10 +315,12 @@ export const Position = () => {
                           <AssetIcon size='xs' assetId={poolAssetIds[1]} />
                           <RawText>{runeAsset?.symbol ?? ''}</RawText>
                         </Flex>
-                        <Amount.Crypto
-                          value={earnings?.runeEarningsCryptoPrecision ?? '0'}
-                          symbol={runeAsset?.symbol ?? ''}
-                        />
+                        <Skeleton isLoaded={!isEarningsLoading}>
+                          <Amount.Crypto
+                            value={earnings?.runeEarningsCryptoPrecision ?? '0'}
+                            symbol={runeAsset?.symbol ?? ''}
+                          />
+                        </Skeleton>
                       </Flex>
                     </Stack>
                   </Card>

--- a/src/pages/ThorChainLP/Position/Position.tsx
+++ b/src/pages/ThorChainLP/Position/Position.tsx
@@ -220,7 +220,7 @@ export const Position = () => {
               <Flex gap={4} alignItems='center'>
                 <PoolIcon assetIds={poolAssetIds} size='md' />
                 <Skeleton isLoaded={Boolean(pool || position)}>
-                  <Heading as='h3'>{pool?.name ?? position?.name ?? ''}</Heading>
+                  <Heading as='h3'>{position?.name ?? pool?.name ?? ''}</Heading>
                 </Skeleton>
                 <Tag size={'lg'}>{poolTypeText}</Tag>
               </Flex>

--- a/src/pages/ThorChainLP/Position/Position.tsx
+++ b/src/pages/ThorChainLP/Position/Position.tsx
@@ -194,7 +194,6 @@ export const Position = () => {
     [stepIndex],
   )
 
-  console.log({ pool, position })
   if (!pool) return null
 
   return (


### PR DESCRIPTION
## Description

Spotted in https://github.com/shapeshift/web/pull/6373#pullrequestreview-1923174916:

> Withdraw succesful ✅ though noted that after a 100% withdraw, the pool page is gone and we're left with a big dark screen of void 😢 because we refetch user data, which is now none. Will tackle in a follow-up to handle 0'd out values on pool position page


## Pull Request Type

- [x] :bug: Bug fix (Non-breaking Change: Fixes an issue)
- [ ] :hammer_and_wrench: Chore (Non-breaking Change: Doc updates, pkg upgrades, typos, etc..)
- [ ] :nail_care: New Feature (Breaking/Non-breaking Change)

## Issue (if applicable)

<!-----------------------------------------------------------------------------
If applicable, please link to the github issue and put `closes #XXXX` in your comment to auto-close the issue that your PR fixes.
------------------------------------------------------------------------------>

N/A

## Risk
> High Risk PRs Require 2 approvals

<!-----------------------------------------------------------------------------
Outline the scope of your changes and the risk associated with them. You must use your discretion as an engineer to determine the potential impact of your changes.

WARNING: If your PR introduces a new on-chain transaction or modifies an existing one, please add the "High-Risk" label to this PR and ask for 2 reviewers to approve it before merging.

E.g. an upgrade to `hdwallet` or core state management would be considered higher risk, and might require a full regression test. UI or isolated view changes, or something behind a feature flag may have near zero risk. Small bug fixes might require testing isolated to the specific fix.
------------------------------------------------------------------------------>

> What protocols, transaction types or contract interactions might be affected by this PR?

None, only handles no position as valid and adds skeletons while at it

## Testing

<!-----------------------------------------------------------------------------
We treat every PR to be merged with the same scrutiny as if we were merging directly to production.

Your PR will not be merged if you do not complete the sections below for our engineering and operations teams to test.
------------------------------------------------------------------------------>

- Exit fully from a position
- After the Tx completes, ensure the position goes to a 0-value position instead of becoming empty

### Engineering

<!-----------------------------------------------------------------------------
Include sufficient information here for an engineer to test your PR. This may include how to test locally, in a built environment, changes to infrastructure etc.
------------------------------------------------------------------------------>

- ^

### Operations

<!-----------------------------------------------------------------------------
If your changes have a user-facing impact, describe how a non-technical QA team can functionally test your changes in a preview environment.

If they are not user-facing please describe how to test for any regressions that may occur.
------------------------------------------------------------------------------>

- ^

## Screenshots (if applicable)


<div class='graphite__hidden'>
          <div>🎥 Video uploaded on Graphite:</div>
            <a href="https://app.graphite.dev/media/video/BpXudHfKodngd8bjaa8L/6414e4fe-4a6a-47a5-bc63-f5949aae9de1.mov">
              <img src="https://app.graphite.dev/api/v1/graphite/video/thumbnail/BpXudHfKodngd8bjaa8L/6414e4fe-4a6a-47a5-bc63-f5949aae9de1.mov">
            </a>
          </div>
<video src="https://graphite-user-uploaded-assets-prod.s3.amazonaws.com/BpXudHfKodngd8bjaa8L/6414e4fe-4a6a-47a5-bc63-f5949aae9de1.mov">Screen Recording 2024-03-07 at 12.06.26.mov</video>
