### PR TITLE
feat: thorchain LP deposit don't autoselect highest balance

### DIFF
--- a/src/components/MultiHopTrade/components/TradeAmountInput.tsx
+++ b/src/components/MultiHopTrade/components/TradeAmountInput.tsx
@@ -56,6 +56,7 @@ const CryptoInput = (props: InputProps) => {
 }
 
 export type TradeAmountInputProps = {
+  autoSelectHighestBalance?: boolean
   assetId?: AssetId
   accountId?: AccountId
   assetSymbol: string
@@ -95,6 +96,7 @@ export const TradeAmountInput: React.FC<TradeAmountInputProps> = memo(
     assetId,
     accountId,
     assetSymbol,
+    autoSelectHighestBalance = true,
     onChange,
     onMaxClick,
     onPercentOptionClick,
@@ -217,7 +219,7 @@ export const TradeAmountInput: React.FC<TradeAmountInputProps> = memo(
               assetId={assetId}
               onChange={onAccountIdChange}
               disabled={isAccountSelectionDisabled}
-              autoSelectHighestBalance
+              autoSelectHighestBalance={autoSelectHighestBalance}
               buttonProps={buttonProps}
               boxProps={boxProps}
               showLabel={false}
@@ -315,7 +317,7 @@ export const TradeAmountInput: React.FC<TradeAmountInputProps> = memo(
                   assetId={assetId}
                   onChange={onAccountIdChange}
                   disabled={isAccountSelectionDisabled}
-                  autoSelectHighestBalance
+                  autoSelectHighestBalance={autoSelectHighestBalance}
                   buttonProps={buttonProps}
                   boxProps={boxProps}
                   showLabel={false}

--- a/src/pages/ThorChainLP/components/AddLiquidity/AddLiquidityInput.tsx
+++ b/src/pages/ThorChainLP/components/AddLiquidity/AddLiquidityInput.tsx
@@ -1015,9 +1015,11 @@ export const AddLiquidityInput: React.FC<AddLiquidityInputProps> = ({
             : virtualAssetDepositAmountFiatUserCurrency
 
           const accountId = currentAccountIdByChainId[asset.chainId]
+          console.log({ accountId })
 
           return (
             <TradeAssetInput
+              autoSelectHighestBalance={false}
               isAccountSelectionDisabled
               accountId={accountId}
               key={asset.assetId}
@@ -1026,6 +1028,7 @@ export const AddLiquidityInput: React.FC<AddLiquidityInputProps> = ({
               assetSymbol={asset?.symbol ?? ''}
               // eslint-disable-next-line react-memo/require-usememo
               onAccountIdChange={(accountId: AccountId) => {
+                console.log({ accountId })
                 handleAccountIdChange(accountId, asset?.assetId)
               }}
               percentOptions={percentOptions}

--- a/src/pages/ThorChainLP/components/AddLiquidity/AddLiquidityInput.tsx
+++ b/src/pages/ThorChainLP/components/AddLiquidity/AddLiquidityInput.tsx
@@ -1015,7 +1015,6 @@ export const AddLiquidityInput: React.FC<AddLiquidityInputProps> = ({
             : virtualAssetDepositAmountFiatUserCurrency
 
           const accountId = currentAccountIdByChainId[asset.chainId]
-          console.log({ accountId })
 
           return (
             <TradeAssetInput

--- a/src/pages/ThorChainLP/components/AddLiquidity/AddLiquidityInput.tsx
+++ b/src/pages/ThorChainLP/components/AddLiquidity/AddLiquidityInput.tsx
@@ -1028,7 +1028,6 @@ export const AddLiquidityInput: React.FC<AddLiquidityInputProps> = ({
               assetSymbol={asset?.symbol ?? ''}
               // eslint-disable-next-line react-memo/require-usememo
               onAccountIdChange={(accountId: AccountId) => {
-                console.log({ accountId })
                 handleAccountIdChange(accountId, asset?.assetId)
               }}
               percentOptions={percentOptions}


### PR DESCRIPTION
## Description

Since multi-account is disabled, we should not auto-select highest balances, but only assume account 0 for now to avoid deposits from account 1 for the time being.

Since the underlying `<TradeAmountInput />` component always passed `autoSelectHighestBalance` down to `<AccountDropdown />`, this was impossible to achieve - fixed by making optional, but defaulted to true to ensure we keep the previous behavior.

## Pull Request Type

- [ ] :bug: Bug fix (Non-breaking Change: Fixes an issue)
- [ ] :hammer_and_wrench: Chore (Non-breaking Change: Doc updates, pkg upgrades, typos, etc..)
- [x] :nail_care: New Feature (Breaking/Non-breaking Change)

## Issue (if applicable)

<!-----------------------------------------------------------------------------
If applicable, please link to the github issue and put `closes #XXXX` in your comment to auto-close the issue that your PR fixes.
------------------------------------------------------------------------------>

N/A

## Risk
> High Risk PRs Require 2 approvals

<!-----------------------------------------------------------------------------
Outline the scope of your changes and the risk associated with them. You must use your discretion as an engineer to determine the potential impact of your changes.

WARNING: If your PR introduces a new on-chain transaction or modifies an existing one, please add the "High-Risk" label to this PR and ask for 2 reviewers to approve it before merging.

E.g. an upgrade to `hdwallet` or core state management would be considered higher risk, and might require a full regression test. UI or isolated view changes, or something behind a feature flag may have near zero risk. Small bug fixes might require testing isolated to the specific fix.
------------------------------------------------------------------------------>

> What protocols, transaction types or contract interactions might be affected by this PR?

Low since we keep the previous behaviour by defaulting to true when destructuring- though as a paranoia test, check trade amount account selection is still happy

## Testing

<!-----------------------------------------------------------------------------
We treat every PR to be merged with the same scrutiny as if we were merging directly to production.

Your PR will not be merged if you do not complete the sections below for our engineering and operations teams to test.
------------------------------------------------------------------------------>

- THORCHain LP Add Liquidity input doesn't autoselect accounts 0+

### Engineering

<!-----------------------------------------------------------------------------
Include sufficient information here for an engineer to test your PR. This may include how to test locally, in a built environment, changes to infrastructure etc.
------------------------------------------------------------------------------>

- ^ 

### Operations

<!-----------------------------------------------------------------------------
If your changes have a user-facing impact, describe how a non-technical QA team can functionally test your changes in a preview environment.

If they are not user-facing please describe how to test for any regressions that may occur.
------------------------------------------------------------------------------>

- ^ 

## Screenshots (if applicable)
