### PR TITLE
feat: update fee model

### DIFF
--- a/src/lib/fees/model.test.ts
+++ b/src/lib/fees/model.test.ts
@@ -8,6 +8,7 @@ const {
   FEE_CURVE_FOX_MAX_DISCOUNT_THRESHOLD,
   FEE_CURVE_MIDPOINT_USD,
   FEE_CURVE_NO_FEE_THRESHOLD_USD,
+  FEE_CURVE_MAX_FEE_BPS,
 } = swapperParameters
 
 describe('calculateFees', () => {
@@ -90,7 +91,7 @@ describe('calculateFees', () => {
     expect(foxDiscountPercent).toEqual(bn(100))
   })
 
-  it('should return 0 bps for missing foxHeld and above no fee threshold', () => {
+  it('should return FEE_CURVE_MAX_FEE_BPS - 1 for missing foxHeld and above no fee threshold', () => {
     const tradeAmountUsd = bn(FEE_CURVE_NO_FEE_THRESHOLD_USD + 0.01)
     const foxHeld = undefined
     const { feeBps, foxDiscountPercent } = calculateFees({
@@ -98,7 +99,7 @@ describe('calculateFees', () => {
       foxHeld,
       feeModel: 'SWAPPER',
     })
-    expect(feeBps.toNumber()).toEqual(0)
-    expect(foxDiscountPercent).toEqual(bn(100))
+    expect(feeBps.toNumber()).toEqual(FEE_CURVE_MAX_FEE_BPS - 1)
+    expect(foxDiscountPercent).toEqual(bn(0))
   })
 })

--- a/src/lib/fees/model.test.ts
+++ b/src/lib/fees/model.test.ts
@@ -92,7 +92,7 @@ describe('calculateFees', () => {
     expect(foxDiscountPercent).toEqual(bn(100))
   })
 
-  it('should return FEE_CURVE_MAX_FEE_BPS - 1 for missing foxHeld and above no fee threshold', () => {
+  it('should return FEE_CURVE_MAX_FEE_BPS  for missing foxHeld and above no fee threshold', () => {
     const tradeAmountUsd = bn(FEE_CURVE_NO_FEE_THRESHOLD_USD + 0.01)
     const foxHeld = undefined
     const { feeBps, foxDiscountPercent } = calculateFees({
@@ -100,7 +100,7 @@ describe('calculateFees', () => {
       foxHeld,
       feeModel: 'SWAPPER',
     })
-    expect(feeBps.toNumber()).toEqual(FEE_CURVE_MAX_FEE_BPS - 1)
+    expect(feeBps.toNumber()).toEqual(FEE_CURVE_MAX_FEE_BPS)
     expect(foxDiscountPercent).toEqual(bn(0))
   })
 })

--- a/src/lib/fees/model.test.ts
+++ b/src/lib/fees/model.test.ts
@@ -23,7 +23,7 @@ describe('calculateFees', () => {
     expect(feeBps.toNumber()).toEqual(0)
   })
 
-  it('should return ~28bps for === no fee threshold', () => {
+  it('should return ~29bps for === no fee threshold', () => {
     const tradeAmountUsd = bn(FEE_CURVE_NO_FEE_THRESHOLD_USD)
     const foxHeld = bn(0)
     const { feeBps } = calculateFees({
@@ -31,7 +31,7 @@ describe('calculateFees', () => {
       foxHeld,
       feeModel: 'SWAPPER',
     })
-    expect(feeBps.toNumber()).toEqual(29)
+    expect(feeBps.toNumber()).toEqual(48)
   })
 
   it('should return close to max bps for slightly above no fee threshold', () => {
@@ -42,7 +42,7 @@ describe('calculateFees', () => {
       foxHeld,
       feeModel: 'SWAPPER',
     })
-    expect(feeBps.toNumber()).toEqual(29)
+    expect(feeBps.toNumber()).toEqual(48)
   })
 
   it('should return close to min bps for huge amounts', () => {
@@ -64,7 +64,7 @@ describe('calculateFees', () => {
       foxHeld,
       feeModel: 'SWAPPER',
     })
-    expect(feeBps.toNumber()).toEqual(20)
+    expect(feeBps.toNumber()).toEqual(30)
   })
 
   it('should discount fees by 50% holding at midpoint holding half max fox discount limit', () => {
@@ -75,7 +75,7 @@ describe('calculateFees', () => {
       foxHeld,
       feeModel: 'SWAPPER',
     })
-    expect(feeBps.toNumber()).toEqual(10)
+    expect(feeBps.toNumber()).toEqual(15)
     expect(foxDiscountPercent).toEqual(bn(50))
   })
 

--- a/src/lib/fees/model.test.ts
+++ b/src/lib/fees/model.test.ts
@@ -9,6 +9,7 @@ const {
   FEE_CURVE_MIDPOINT_USD,
   FEE_CURVE_NO_FEE_THRESHOLD_USD,
   FEE_CURVE_MAX_FEE_BPS,
+  FEE_CURVE_MIN_FEE_BPS,
 } = swapperParameters
 
 describe('calculateFees', () => {
@@ -23,7 +24,7 @@ describe('calculateFees', () => {
     expect(feeBps.toNumber()).toEqual(0)
   })
 
-  it('should return ~29bps for === no fee threshold', () => {
+  it('should return FEE_CURVE_MAX_FEE_BPS - 1 for === no fee threshold', () => {
     const tradeAmountUsd = bn(FEE_CURVE_NO_FEE_THRESHOLD_USD)
     const foxHeld = bn(0)
     const { feeBps } = calculateFees({
@@ -31,10 +32,10 @@ describe('calculateFees', () => {
       foxHeld,
       feeModel: 'SWAPPER',
     })
-    expect(feeBps.toNumber()).toEqual(48)
+    expect(feeBps.toNumber()).toEqual(FEE_CURVE_MAX_FEE_BPS - 1)
   })
 
-  it('should return close to max bps for slightly above no fee threshold', () => {
+  it('should return FEE_CURVE_MAX_FEE_BPS - 1 for slightly above no fee threshold', () => {
     const tradeAmountUsd = bn(FEE_CURVE_NO_FEE_THRESHOLD_USD + 0.01)
     const foxHeld = bn(0)
     const { feeBps } = calculateFees({
@@ -42,7 +43,7 @@ describe('calculateFees', () => {
       foxHeld,
       feeModel: 'SWAPPER',
     })
-    expect(feeBps.toNumber()).toEqual(48)
+    expect(feeBps.toNumber()).toEqual(FEE_CURVE_MAX_FEE_BPS - 1)
   })
 
   it('should return close to min bps for huge amounts', () => {
@@ -53,7 +54,7 @@ describe('calculateFees', () => {
       foxHeld,
       feeModel: 'SWAPPER',
     })
-    expect(feeBps.toNumber()).toEqual(10)
+    expect(feeBps.toNumber()).toEqual(FEE_CURVE_MIN_FEE_BPS)
   })
 
   it('should return close to midpoint for midpoint', () => {

--- a/src/lib/fees/model.ts
+++ b/src/lib/fees/model.ts
@@ -55,7 +55,7 @@ export const calculateFees: CalculateFeeBps = ({ tradeAmountUsd, foxHeld, feeMod
   // the fox discount before any other logic is applied
   const foxBaseDiscountPercent = (() => {
     if (isFree) return bn(100)
-    // No discount if we cannot fetch FOX holdings - apply fees as-is
+    // No discount if we cannot fetch FOX holdings
     if (isFallbackFees) return bn(0)
 
     return BigNumber.minimum(

--- a/src/lib/fees/model.ts
+++ b/src/lib/fees/model.ts
@@ -65,24 +65,28 @@ export const calculateFees: CalculateFeeBps = ({ tradeAmountUsd, foxHeld, feeMod
   })()
 
   // the fee bps before the fox discount is applied, as a floating point number
-  const feeBpsBeforeDiscountFloat = minFeeBps.plus(
-    maxFeeBps
-      .minus(minFeeBps)
-      .div(
-        bn(1).plus(
-          bn(
-            Math.exp(
-              bn(1).div(feeCurveSteepness).times(tradeAmountUsd.minus(midpointUsd)).toNumber(),
+  const feeBpsBeforeDiscountFloat = isFallbackFees
+    ? bn(FEE_CURVE_MAX_FEE_BPS)
+    : minFeeBps.plus(
+        maxFeeBps
+          .minus(minFeeBps)
+          .div(
+            bn(1).plus(
+              bn(
+                Math.exp(
+                  bn(1).div(feeCurveSteepness).times(tradeAmountUsd.minus(midpointUsd)).toNumber(),
+                ),
+              ),
             ),
           ),
-        ),
-      ),
-  )
+      )
 
-  const feeBpsFloat = BigNumber.maximum(
-    feeBpsBeforeDiscountFloat.multipliedBy(bn(1).minus(foxBaseDiscountPercent.div(100))),
-    bn(0),
-  )
+  const feeBpsFloat = isFallbackFees
+    ? bn(FEE_CURVE_MAX_FEE_BPS)
+    : BigNumber.maximum(
+        feeBpsBeforeDiscountFloat.multipliedBy(bn(1).minus(foxBaseDiscountPercent.div(100))),
+        bn(0),
+      )
 
   const feeBpsBeforeDiscount = feeBpsBeforeDiscountFloat.decimalPlaces(0)
   const feeBpsAfterDiscount = feeBpsFloat.decimalPlaces(0)

--- a/src/lib/fees/model.ts
+++ b/src/lib/fees/model.ts
@@ -47,14 +47,22 @@ export const calculateFees: CalculateFeeBps = ({ tradeAmountUsd, foxHeld, feeMod
   const midpointUsd = bn(FEE_CURVE_MIDPOINT_USD)
   const feeCurveSteepness = bn(FEE_CURVE_STEEPNESS_K)
 
-  // failure to fetch fox discount results in free trades.
   // trades below the fee threshold are free.
-  const isFree = foxHeld === undefined || tradeAmountUsd.lt(noFeeThresholdUsd)
+  const isFree = tradeAmountUsd.lt(noFeeThresholdUsd)
+  // failure to fetch fox discount results in free trades.
+  const isFallbackFees = foxHeld === undefined
 
   // the fox discount before any other logic is applied
-  const foxBaseDiscountPercent = isFree
-    ? bn(100)
-    : BigNumber.minimum(bn(100), foxHeld.times(100).div(bn(FEE_CURVE_FOX_MAX_DISCOUNT_THRESHOLD)))
+  const foxBaseDiscountPercent = (() => {
+    if (isFree) return bn(100)
+    // No discount if we cannot fetch FOX holdings - apply fees as-is
+    if (isFallbackFees) return bn(0)
+
+    return BigNumber.minimum(
+      bn(100),
+      foxHeld.times(100).div(bn(FEE_CURVE_FOX_MAX_DISCOUNT_THRESHOLD)),
+    )
+  })()
 
   // the fee bps before the fox discount is applied, as a floating point number
   const feeBpsBeforeDiscountFloat = minFeeBps.plus(

--- a/src/lib/fees/model.ts
+++ b/src/lib/fees/model.ts
@@ -65,28 +65,33 @@ export const calculateFees: CalculateFeeBps = ({ tradeAmountUsd, foxHeld, feeMod
   })()
 
   // the fee bps before the fox discount is applied, as a floating point number
-  const feeBpsBeforeDiscountFloat = isFallbackFees
-    ? bn(FEE_CURVE_MAX_FEE_BPS)
-    : minFeeBps.plus(
-        maxFeeBps
-          .minus(minFeeBps)
-          .div(
-            bn(1).plus(
-              bn(
-                Math.exp(
-                  bn(1).div(feeCurveSteepness).times(tradeAmountUsd.minus(midpointUsd)).toNumber(),
+  const feeBpsBeforeDiscountFloat =
+    isFallbackFees && !isFree
+      ? bn(FEE_CURVE_MAX_FEE_BPS)
+      : minFeeBps.plus(
+          maxFeeBps
+            .minus(minFeeBps)
+            .div(
+              bn(1).plus(
+                bn(
+                  Math.exp(
+                    bn(1)
+                      .div(feeCurveSteepness)
+                      .times(tradeAmountUsd.minus(midpointUsd))
+                      .toNumber(),
+                  ),
                 ),
               ),
             ),
-          ),
-      )
+        )
 
-  const feeBpsFloat = isFallbackFees
-    ? bn(FEE_CURVE_MAX_FEE_BPS)
-    : BigNumber.maximum(
-        feeBpsBeforeDiscountFloat.multipliedBy(bn(1).minus(foxBaseDiscountPercent.div(100))),
-        bn(0),
-      )
+  const feeBpsFloat =
+    isFallbackFees && !isFree
+      ? bn(FEE_CURVE_MAX_FEE_BPS)
+      : BigNumber.maximum(
+          feeBpsBeforeDiscountFloat.multipliedBy(bn(1).minus(foxBaseDiscountPercent.div(100))),
+          bn(0),
+        )
 
   const feeBpsBeforeDiscount = feeBpsBeforeDiscountFloat.decimalPlaces(0)
   const feeBpsAfterDiscount = feeBpsFloat.decimalPlaces(0)

--- a/src/lib/fees/parameters/swapper.ts
+++ b/src/lib/fees/parameters/swapper.ts
@@ -1,6 +1,6 @@
 import type { FeeCurveParameters } from './types'
 
-const FEE_CURVE_MAX_FEE_BPS = 29 // basis points
+const FEE_CURVE_MAX_FEE_BPS = 49 // basis points
 const FEE_CURVE_MIN_FEE_BPS = 10 // basis points
 const FEE_CURVE_NO_FEE_THRESHOLD_USD = 1_000 // usd
 const FEE_CURVE_FOX_MAX_DISCOUNT_THRESHOLD = 1_000_000 // fox

--- a/src/pages/ThorChainLP/components/AddLiquidity/AddLiquidityInput.tsx
+++ b/src/pages/ThorChainLP/components/AddLiquidity/AddLiquidityInput.tsx
@@ -897,7 +897,6 @@ export const AddLiquidityInput: React.FC<AddLiquidityInputProps> = ({
       ),
     )
 
-    if (!votingPower) return
     if (!slippageFiatUserCurrency) return
     if (!activeOpportunityId) return
     if (!poolAssetInboundAddress) return


### PR DESCRIPTION
## Description

Updates fee model following DFC decision:

- Swapper fee model is now bumped from 29 to 49 max bps
- We no longer default to free trades if failing to get voting power from snapshot, but rather default to the max bps as a static value
- Removes `votingPower` checks in THORChain LP to properly handle the case of undefined vp, which is now valid

## Pull Request Type

- [ ] :bug: Bug fix (Non-breaking Change: Fixes an issue)
- [ ] :hammer_and_wrench: Chore (Non-breaking Change: Doc updates, pkg upgrades, typos, etc..)
- [x] :nail_care: New Feature (Breaking/Non-breaking Change)

## Issue (if applicable)

<!-----------------------------------------------------------------------------
If applicable, please link to the github issue and put `closes #XXXX` in your comment to auto-close the issue that your PR fixes.
------------------------------------------------------------------------------>

N/A

## Risk
> High Risk PRs Require 2 approvals

<!-----------------------------------------------------------------------------
Outline the scope of your changes and the risk associated with them. You must use your discretion as an engineer to determine the potential impact of your changes.

WARNING: If your PR introduces a new on-chain transaction or modifies an existing one, please add the "High-Risk" label to this PR and ask for 2 reviewers to approve it before merging.

E.g. an upgrade to `hdwallet` or core state management would be considered higher risk, and might require a full regression test. UI or isolated view changes, or something behind a feature flag may have near zero risk. Small bug fixes might require testing isolated to the specific fix.
------------------------------------------------------------------------------>

Low, though ensure min amount before fees is still honoured, and bps are still happy when snapshot is happy

> What protocols, transaction types or contract interactions might be affected by this PR?

## Testing

<!-----------------------------------------------------------------------------
We treat every PR to be merged with the same scrutiny as if we were merging directly to production.

Your PR will not be merged if you do not complete the sections below for our engineering and operations teams to test.
------------------------------------------------------------------------------>

- When snapshot is happy, the current fee model is still used. 
- When snapshot is sad, we default to the max 49 bps (for swapper) or 50 (for LP).

### Engineering

<!-----------------------------------------------------------------------------
Include sufficient information here for an engineer to test your PR. This may include how to test locally, in a built environment, changes to infrastructure etc.
------------------------------------------------------------------------------>

- ☝🏽 

### Operations

<!-----------------------------------------------------------------------------
If your changes have a user-facing impact, describe how a non-technical QA team can functionally test your changes in a preview environment.

If they are not user-facing please describe how to test for any regressions that may occur.
------------------------------------------------------------------------------>

- ☝🏽 

## Screenshots (if applicable)

### Happy snapshot

#### Smol amounts are still free

- Swapper

<img width="938" alt="Screenshot 2024-03-08 at 17 09 10" src="https://github.com/shapeshift/web/assets/17035424/ce0c1387-c754-4e4d-ae56-c0a67fd918d9">

- THORCHain LP

<img width="886" alt="image" src="https://github.com/shapeshift/web/assets/17035424/6cb841c3-d1de-442c-871c-d6cf4f286e85">


#### Not so smol amounts still honour the fee curve

- Swapper

<img width="934" alt="Screenshot 2024-03-08 at 17 07 32" src="https://github.com/shapeshift/web/assets/17035424/2de6342a-7a2b-4624-9f49-ef46d8be8cfe">

- THORCHain LP

<img width="882" alt="image" src="https://github.com/shapeshift/web/assets/17035424/99131ea3-384e-465d-9e60-2ea322b742e2">

#### Size matters - bigly amounts are still bigly deducted if you got the FOX for it

- Swapper

<img width="888" alt="Screenshot 2024-03-08 at 17 08 15" src="https://github.com/shapeshift/web/assets/17035424/5a6f5475-893e-42e7-b38f-d4a3fbf3c208">

- THORCHain LP

<img width="888" alt="image" src="https://github.com/shapeshift/web/assets/17035424/319dd445-b1af-4ebe-b18f-ce61da803f66">

### Sad snapshot

#### Smol amounts use the max fee bps

- Swapper

<img width="920" alt="image" src="https://github.com/shapeshift/web/assets/17035424/1a4e48c4-192f-412d-ad28-904652d3877b">

- THORCHain LP

<img width="932" alt="image" src="https://github.com/shapeshift/web/assets/17035424/df2600fe-21aa-4f47-abdc-17f3ef0e1335">

#### Not so smol amounts use the max bps

- Swapper

<img width="952" alt="image" src="https://github.com/shapeshift/web/assets/17035424/f3f747e0-bb9f-4a0b-8bf5-3f53ae0dfbab">


- THORCHain LP

<img width="935" alt="image" src="https://github.com/shapeshift/web/assets/17035424/6d100360-8ddf-480a-8af8-edc5a5b061a2">

#### Size matters - bigly amounts use the max fee bps

- Swapper

<img width="929" alt="image" src="https://github.com/shapeshift/web/assets/17035424/13a1fb48-c8fe-4fa3-8d0b-cd0789dc29ee">

- THORCHain LP

<img width="880" alt="image" src="https://github.com/shapeshift/web/assets/17035424/8c205746-0dbd-4b88-91e6-8cd9da9a4d41">
