### PR TITLE
feat: fox discounts use USD everywhere

### DIFF
--- a/src/components/FeeExplainer/FeeExplainer.tsx
+++ b/src/components/FeeExplainer/FeeExplainer.tsx
@@ -27,7 +27,6 @@ import { FEE_CURVE_PARAMETERS } from 'lib/fees/parameters'
 import type { ParameterModel } from 'lib/fees/parameters/types'
 import { isSome } from 'lib/utils'
 import { selectVotingPower } from 'state/apis/snapshot/selectors'
-import { selectUserCurrencyToUsdRate } from 'state/slices/selectors'
 import { useAppSelector } from 'state/store'
 
 import { CHART_TRADE_SIZE_MAX_USD } from './common'
@@ -271,22 +270,14 @@ export const FeeOutput: React.FC<FeeOutputProps> = ({ tradeSizeUSD, foxHolding, 
       feeModel,
     })
 
-  const userCurrencyToUsdRate = useAppSelector(selectUserCurrencyToUsdRate)
-
-  const feeUserCurrencyBeforeDiscount = useMemo(() => {
-    return feeUsdBeforeDiscount.times(userCurrencyToUsdRate)
-  }, [feeUsdBeforeDiscount, userCurrencyToUsdRate])
-
   const basedOnFeeTranslation: TextPropTypes['translation'] = useMemo(
     () => [
       'foxDiscounts.basedOnFee',
       {
-        fee: `$${feeUserCurrencyBeforeDiscount.toFixed(2)} (${feeBpsBeforeDiscount.toFixed(
-          0,
-        )} bps)`,
+        fee: `$${feeUsdBeforeDiscount.toFixed(2)} (${feeBpsBeforeDiscount.toFixed(0)} bps)`,
       },
     ],
-    [feeUserCurrencyBeforeDiscount, feeBpsBeforeDiscount],
+    [feeUsdBeforeDiscount, feeBpsBeforeDiscount],
   )
 
   const isFree = useMemo(() => bnOrZero(feeUsd).lte(0), [feeUsd])

--- a/src/components/FeeExplainer/FeeExplainer.tsx
+++ b/src/components/FeeExplainer/FeeExplainer.tsx
@@ -248,8 +248,8 @@ const FeeChart: React.FC<FeeChartProps> = ({ foxHolding, tradeSize, feeModel }) 
 }
 
 export type FeeSlidersProps = {
-  tradeSize: number
-  setTradeSize: (val: number) => void
+  tradeSizeUSD: number
+  setTradeSizeUSD: (val: number) => void
   foxHolding: number
   setFoxHolding: (val: number) => void
   currentFoxHoldings: string
@@ -258,24 +258,20 @@ export type FeeSlidersProps = {
 }
 
 type FeeOutputProps = {
-  tradeSize: number
+  tradeSizeUSD: number
   foxHolding: number
   feeModel: ParameterModel
 }
 
-export const FeeOutput: React.FC<FeeOutputProps> = ({ tradeSize, foxHolding, feeModel }) => {
+export const FeeOutput: React.FC<FeeOutputProps> = ({ tradeSizeUSD, foxHolding, feeModel }) => {
   const { feeUsd, feeBps, foxDiscountPercent, feeUsdBeforeDiscount, feeBpsBeforeDiscount } =
     calculateFees({
-      tradeAmountUsd: bn(tradeSize),
+      tradeAmountUsd: bn(tradeSizeUSD),
       foxHeld: bn(foxHolding),
       feeModel,
     })
 
   const userCurrencyToUsdRate = useAppSelector(selectUserCurrencyToUsdRate)
-
-  const feeUserCurrency = useMemo(() => {
-    return feeUsd.times(userCurrencyToUsdRate)
-  }, [feeUsd, userCurrencyToUsdRate])
 
   const feeUserCurrencyBeforeDiscount = useMemo(() => {
     return feeUsdBeforeDiscount.times(userCurrencyToUsdRate)
@@ -293,7 +289,7 @@ export const FeeOutput: React.FC<FeeOutputProps> = ({ tradeSize, foxHolding, fee
     [feeUserCurrencyBeforeDiscount, feeBpsBeforeDiscount],
   )
 
-  const isFree = useMemo(() => bnOrZero(feeUserCurrency).lte(0), [feeUserCurrency])
+  const isFree = useMemo(() => bnOrZero(feeUsd).lte(0), [feeUsd])
 
   return (
     <Flex fontWeight='medium' pb={0}>
@@ -306,8 +302,9 @@ export const FeeOutput: React.FC<FeeOutputProps> = ({ tradeSize, foxHolding, fee
             ) : (
               <Flex gap={2} align='center'>
                 <Amount.Fiat
+                  fiatType='USD'
                   fontSize='3xl'
-                  value={feeUserCurrency.toString()}
+                  value={feeUsd.toString()}
                   color={'green.500'}
                 />
                 <Amount
@@ -353,9 +350,10 @@ export const FeeExplainer: React.FC<FeeExplainerProps> = props => {
   const votingPowerParams = useMemo(() => ({ feeModel: props.feeModel }), [props.feeModel])
   const votingPower = useAppSelector(state => selectVotingPower(state, votingPowerParams))
 
-  const [tradeSize, setTradeSize] = useState(
+  const [tradeSizeUSD, setTradeSizeUSD] = useState(
     props.inputAmountUsd ? Number.parseFloat(props.inputAmountUsd) : FEE_CURVE_NO_FEE_THRESHOLD_USD,
   )
+
   const [foxHolding, setFoxHolding] = useState(bnOrZero(votingPower).toNumber())
   const translate = useTranslate()
 
@@ -368,8 +366,8 @@ export const FeeExplainer: React.FC<FeeExplainerProps> = props => {
           </Heading>
           <Text color='text.subtle' translation='foxDiscounts.simulateBody' />
           <FeeSliders
-            tradeSize={tradeSize}
-            setTradeSize={setTradeSize}
+            tradeSizeUSD={tradeSizeUSD}
+            setTradeSizeUSD={setTradeSizeUSD}
             foxHolding={foxHolding}
             setFoxHolding={setFoxHolding}
             currentFoxHoldings={votingPower ?? '0'}
@@ -379,8 +377,12 @@ export const FeeExplainer: React.FC<FeeExplainerProps> = props => {
       </Card>
       <Card borderTopRadius={0} borderTopWidth={1} borderColor='border.base' {...props}>
         <CardBody p={feeExplainerCardBody}>
-          <FeeOutput tradeSize={tradeSize} foxHolding={foxHolding} feeModel={props.feeModel} />
-          <FeeChart tradeSize={tradeSize} foxHolding={foxHolding} feeModel={props.feeModel} />
+          <FeeOutput
+            tradeSizeUSD={tradeSizeUSD}
+            foxHolding={foxHolding}
+            feeModel={props.feeModel}
+          />
+          <FeeChart tradeSize={tradeSizeUSD} foxHolding={foxHolding} feeModel={props.feeModel} />
         </CardBody>
       </Card>
     </Stack>

--- a/src/components/FeeExplainer/FeeSliders.tsx
+++ b/src/components/FeeExplainer/FeeSliders.tsx
@@ -22,8 +22,8 @@ import { CHART_TRADE_SIZE_MAX_FOX, CHART_TRADE_SIZE_MAX_USD, labelStyles } from 
 import type { FeeSlidersProps } from './FeeExplainer'
 
 export const FeeSliders: React.FC<FeeSlidersProps> = ({
-  tradeSize,
-  setTradeSize,
+  tradeSizeUSD,
+  setTradeSizeUSD,
   foxHolding,
   setFoxHolding,
   isLoading,
@@ -90,18 +90,27 @@ export const FeeSliders: React.FC<FeeSlidersProps> = ({
       <Stack width='full' spacing={4}>
         <Flex width='full' justifyContent='space-between' fontWeight='medium'>
           <Text translation='foxDiscounts.tradeSize' />
-          <Amount.Fiat value={tradeSize} fontWeight='bold' />
+          <Amount.Fiat fiatType='USD' value={tradeSizeUSD} fontWeight='bold' />
         </Flex>
         <Stack width='100%' pb={8}>
-          <Slider min={0} max={CHART_TRADE_SIZE_MAX_USD} value={tradeSize} onChange={setTradeSize}>
+          <Slider
+            min={0}
+            max={CHART_TRADE_SIZE_MAX_USD}
+            value={tradeSizeUSD}
+            onChange={setTradeSizeUSD}
+          >
             <SliderMark value={CHART_TRADE_SIZE_MAX_USD * 0.2} {...labelStyles}>
-              <Amount.Fiat value={CHART_TRADE_SIZE_MAX_USD * 0.2} abbreviated />
+              <Amount.Fiat fiatType='USD' value={CHART_TRADE_SIZE_MAX_USD * 0.2} abbreviated />
             </SliderMark>
             <SliderMark value={CHART_TRADE_SIZE_MAX_USD * 0.5} {...labelStyles}>
-              <Amount.Fiat value={CHART_TRADE_SIZE_MAX_USD * 0.5} abbreviated />
+              <Amount.Fiat fiatType='USD' value={CHART_TRADE_SIZE_MAX_USD * 0.5} abbreviated />
             </SliderMark>
             <SliderMark value={CHART_TRADE_SIZE_MAX_USD * 0.8} {...labelStyles}>
-              <Amount.Fiat value={CHART_TRADE_SIZE_MAX_USD * 0.8} abbreviated={true} />
+              <Amount.Fiat
+                fiatType='USD'
+                value={CHART_TRADE_SIZE_MAX_USD * 0.8}
+                abbreviated={true}
+              />
             </SliderMark>
             <SliderTrack>
               <SliderFilledTrack bg='blue.500' />
@@ -113,7 +122,7 @@ export const FeeSliders: React.FC<FeeSlidersProps> = ({
       <Flex alignItems='center' justifyContent='center' width='full' flexWrap='wrap' gap={2}>
         <RawText fontSize='sm'>
           {translate('foxDiscounts.freeUnderThreshold', {
-            threshold: toFiat(FEE_CURVE_NO_FEE_THRESHOLD_USD),
+            threshold: toFiat(FEE_CURVE_NO_FEE_THRESHOLD_USD, { fiatType: 'USD' }),
           })}
         </RawText>
         <Flex gap={2} alignItems='center' justifyContent='space-between' fontSize='sm'>

--- a/src/components/FeeModal/FeeModal.tsx
+++ b/src/components/FeeModal/FeeModal.tsx
@@ -16,7 +16,7 @@ import type { ParameterModel } from 'lib/fees/parameters/types'
 import { FeeBreakdown } from './FeeBreakdown'
 
 export type FeeModalProps = {
-  affiliateFeeAmountUserCurrency: string
+  affiliateFeeAmountUsd: string
   inputAmountUsd: string | undefined
   isOpen: boolean
   onClose: () => void
@@ -24,7 +24,7 @@ export type FeeModalProps = {
 }
 
 export const FeeModal = ({
-  affiliateFeeAmountUserCurrency,
+  affiliateFeeAmountUsd,
   inputAmountUsd,
   isOpen,
   onClose: handleClose,
@@ -46,7 +46,7 @@ export const FeeModal = ({
             <TabPanel p={0}>
               <FeeBreakdown
                 feeModel={feeModel}
-                affiliateFeeAmountUserCurrency={affiliateFeeAmountUserCurrency}
+                affiliateFeeAmountUsd={affiliateFeeAmountUsd}
                 inputAmountUsd={inputAmountUsd}
               />
             </TabPanel>

--- a/src/components/MultiHopTrade/components/MultiHopTradeConfirm/components/FeeStep.tsx
+++ b/src/components/MultiHopTrade/components/MultiHopTradeConfirm/components/FeeStep.tsx
@@ -10,7 +10,7 @@ import { bnOrZero } from 'lib/bignumber/bignumber'
 import { selectInputSellAmountUsd } from 'state/slices/selectors'
 import {
   selectActiveQuoteAffiliateBps,
-  selectQuoteAffiliateFeeUserCurrency,
+  selectQuoteFeeAmountUsd,
 } from 'state/slices/tradeQuoteSlice/selectors'
 import { useAppSelector } from 'state/store'
 
@@ -32,7 +32,7 @@ export const FeeStep = ({ isLastStep }: FeeStepProps) => {
   const inputAmountUsd = useAppSelector(selectInputSellAmountUsd)
   // use the fee data from the actual quote in case it varies from the theoretical calculation
   const affiliateBps = useAppSelector(selectActiveQuoteAffiliateBps)
-  const amountAfterDiscountUserCurrency = useAppSelector(selectQuoteAffiliateFeeUserCurrency)
+  const amountAfterDiscountUsd = useAppSelector(selectQuoteFeeAmountUsd)
 
   const handleOpenFeeModal = useCallback(() => setShowFeeModal(true), [])
   const handleCloseFeeModal = useCallback(() => setShowFeeModal(false), [])
@@ -46,10 +46,10 @@ export const FeeStep = ({ isLastStep }: FeeStepProps) => {
   }, [])
 
   const { title, titleProps } = useMemo(() => {
-    return bnOrZero(amountAfterDiscountUserCurrency).gt(0)
-      ? { title: toFiat(amountAfterDiscountUserCurrency) }
+    return bnOrZero(amountAfterDiscountUsd).gt(0)
+      ? { title: toFiat(amountAfterDiscountUsd) }
       : { title: translate('trade.free'), titleProps: { color: 'text.success' } }
-  }, [amountAfterDiscountUserCurrency, toFiat, translate])
+  }, [amountAfterDiscountUsd, toFiat, translate])
 
   const description = useMemo(() => {
     return (
@@ -82,7 +82,7 @@ export const FeeStep = ({ isLastStep }: FeeStepProps) => {
       <FeeModal
         isOpen={showFeeModal}
         onClose={handleCloseFeeModal}
-        affiliateFeeAmountUserCurrency={amountAfterDiscountUserCurrency}
+        affiliateFeeAmountUsd={amountAfterDiscountUsd}
         inputAmountUsd={inputAmountUsd}
         feeModel='SWAPPER'
       />

--- a/src/components/MultiHopTrade/components/TradeInput/components/ReceiveSummary.tsx
+++ b/src/components/MultiHopTrade/components/TradeInput/components/ReceiveSummary.tsx
@@ -23,7 +23,7 @@ import { isSome } from 'lib/utils'
 import { selectInputSellAmountUsd } from 'state/slices/selectors'
 import {
   selectActiveQuoteAffiliateBps,
-  selectQuoteAffiliateFeeUserCurrency,
+  selectQuoteFeeAmountUsd,
 } from 'state/slices/tradeQuoteSlice/selectors'
 import { useAppSelector } from 'state/store'
 
@@ -74,7 +74,7 @@ export const ReceiveSummary: FC<ReceiveSummaryProps> = memo(
     const inputAmountUsd = useAppSelector(selectInputSellAmountUsd)
     // use the fee data from the actual quote in case it varies from the theoretical calculation
     const affiliateBps = useAppSelector(selectActiveQuoteAffiliateBps)
-    const amountAfterDiscountUserCurrency = useAppSelector(selectQuoteAffiliateFeeUserCurrency)
+    const amountAfterDiscountUserCurrency = useAppSelector(selectQuoteFeeAmountUsd)
 
     const parseAmountDisplayMeta = useCallback((items: AmountDisplayMeta[]) => {
       return items
@@ -192,7 +192,7 @@ export const ReceiveSummary: FC<ReceiveSummaryProps> = memo(
         <FeeModal
           isOpen={showFeeModal}
           onClose={toggleFeeModal}
-          affiliateFeeAmountUserCurrency={amountAfterDiscountUserCurrency}
+          affiliateFeeAmountUsd={amountAfterDiscountUserCurrency}
           inputAmountUsd={inputAmountUsd}
           feeModel='SWAPPER'
         />

--- a/src/lib/utils/thorchain/lp/types.ts
+++ b/src/lib/utils/thorchain/lp/types.ts
@@ -205,6 +205,7 @@ export type LpConfirmedDepositQuote = {
   currentAccountIdByChainId: Record<ChainId, AccountId>
   feeBps: string
   feeAmountFiatUserCurrency: string
+  feeAmountUSD: string
   assetAddress?: string
   quoteInboundAddress: string
   // For informative purposes only at confirm step - to be recalculated before signing

--- a/src/pages/ThorChainLP/components/AddLiquidity/AddLiquidityInput.tsx
+++ b/src/pages/ThorChainLP/components/AddLiquidity/AddLiquidityInput.tsx
@@ -939,6 +939,7 @@ export const AddLiquidityInput: React.FC<AddLiquidityInputProps> = ({
       totalAmountUsd,
       feeBps: feeBps.toFixed(0),
       feeAmountFiatUserCurrency: feeUsd.times(userCurrencyToUsdRate).toFixed(2),
+      feeAmountUSD: feeUsd.toFixed(2),
       assetAddress: poolAssetAccountAddress,
       quoteInboundAddress: poolAssetInboundAddress,
       runeGasFeeFiatUserCurrency: runeGasFeeFiatUserCurrency.toFixed(2),
@@ -1441,7 +1442,7 @@ export const AddLiquidityInput: React.FC<AddLiquidityInputProps> = ({
         </Button>
       </CardFooter>
       <FeeModal
-        affiliateFeeAmountUserCurrency={confirmedQuote?.feeAmountFiatUserCurrency ?? '0'}
+        affiliateFeeAmountUsd={confirmedQuote?.feeAmountUSD ?? '0'}
         isOpen={showFeeModal}
         onClose={toggleFeeModal}
         inputAmountUsd={confirmedQuote?.totalAmountUsd}


### PR DESCRIPTION
## Description

Does what it says on the box - uses USD amounts for FOD discounts everywhere, or almost: note the receive summary fee is still denoted in user currency to be consistent with other amounts.

This is threefolds:

1. ensures USD amounts everywhere means proper calculation of the FOX discounts, without user currency used as USD for the calculation and vice-versa
2. ensures we never display USD amounts as user-currency
3. ensures visual consistency as well as consistency with our communication of the FOX discount in USD

## Pull Request Type

- [ ] :bug: Bug fix (Non-breaking Change: Fixes an issue)
- [ ] :hammer_and_wrench: Chore (Non-breaking Change: Doc updates, pkg upgrades, typos, etc..)
- [x] :nail_care: New Feature (Breaking/Non-breaking Change)

## Issue (if applicable)

<!-----------------------------------------------------------------------------
If applicable, please link to the github issue and put `closes #XXXX` in your comment to auto-close the issue that your PR fixes.
------------------------------------------------------------------------------>

closes https://github.com/shapeshift/web/issues/6390

## Risk
> High Risk PRs Require 2 approvals

<!-----------------------------------------------------------------------------
Outline the scope of your changes and the risk associated with them. You must use your discretion as an engineer to determine the potential impact of your changes.

WARNING: If your PR introduces a new on-chain transaction or modifies an existing one, please add the "High-Risk" label to this PR and ask for 2 reviewers to approve it before merging.

E.g. an upgrade to `hdwallet` or core state management would be considered higher risk, and might require a full regression test. UI or isolated view changes, or something behind a feature flag may have near zero risk. Small bug fixes might require testing isolated to the specific fix.
------------------------------------------------------------------------------>

> What protocols, transaction types or contract interactions might be affected by this PR?

Low - ensure amounts still look sane both in USD and user currency (should now be the exact same, except for the receive summary amount)

## Testing

<!-----------------------------------------------------------------------------
We treat every PR to be merged with the same scrutiny as if we were merging directly to production.

Your PR will not be merged if you do not complete the sections below for our engineering and operations teams to test.
------------------------------------------------------------------------------>

- FOX discount behaves the exact same as before with USD
- FOX discount while having user currency selected (open in a different tab/window and refresh the page to ensure user currency is reflected everywhere) has all values displayed in USD, except for the receive summary, which should still be prorated to user currency

### Engineering

<!-----------------------------------------------------------------------------
Include sufficient information here for an engineer to test your PR. This may include how to test locally, in a built environment, changes to infrastructure etc.
------------------------------------------------------------------------------>

- ^

### Operations

<!-----------------------------------------------------------------------------
If your changes have a user-facing impact, describe how a non-technical QA team can functionally test your changes in a preview environment.

If they are not user-facing please describe how to test for any regressions that may occur.
------------------------------------------------------------------------------>

- ^

## Screenshots (if applicable)

Tested on develop with USD vs. this diff with user currency (right)

### LP

![Screenshot 2024-03-11 at 04.54.16.png](https://graphite-user-uploaded-assets-prod.s3.amazonaws.com/BpXudHfKodngd8bjaa8L/75d97b53-2a92-42ff-a5da-061b89b65010.png)

![Screenshot 2024-03-11 at 04.54.29.png](https://graphite-user-uploaded-assets-prod.s3.amazonaws.com/BpXudHfKodngd8bjaa8L/8c608cf5-32f7-41b1-87dc-73a286e603d4.png)

![Screenshot 2024-03-11 at 04.54.42.png](https://graphite-user-uploaded-assets-prod.s3.amazonaws.com/BpXudHfKodngd8bjaa8L/032ebbc0-7267-4e0c-a37f-317fa5d09c27.png)

### Swapper

![Screenshot 2024-03-11 at 04.54.42.png](https://graphite-user-uploaded-assets-prod.s3.amazonaws.com/BpXudHfKodngd8bjaa8L/8be84490-62bb-4729-ad5c-c631ac8e698f.png)

![Screenshot 2024-03-11 at 04.57.00.png](https://graphite-user-uploaded-assets-prod.s3.amazonaws.com/BpXudHfKodngd8bjaa8L/cc261972-d2d9-485e-b559-a68ac711ffe1.png)

![Screenshot 2024-03-11 at 04.57.21.png](https://graphite-user-uploaded-assets-prod.s3.amazonaws.com/BpXudHfKodngd8bjaa8L/8d11efe7-36c9-4214-accb-70757e5fbbe0.png)


