### PR TITLE
chore: add back button to ReusableLpStatus

### DIFF
--- a/src/pages/ThorChainLP/components/AddLiquidity/AddLiquityStatus.tsx
+++ b/src/pages/ThorChainLP/components/AddLiquidity/AddLiquityStatus.tsx
@@ -14,7 +14,7 @@ export const AddLiquidityStatus = ({ confirmedQuote }: AddLiquidityStatusProps) 
   const history = useHistory()
 
   const handleGoBack = useCallback(() => {
-    history.push(AddLiquidityRoutePaths.Input)
+    history.push(AddLiquidityRoutePaths.Confirm)
   }, [history])
 
   return (

--- a/src/pages/ThorChainLP/components/RemoveLiquidity/RemoveLiquidityStatus.tsx
+++ b/src/pages/ThorChainLP/components/RemoveLiquidity/RemoveLiquidityStatus.tsx
@@ -14,7 +14,7 @@ export const RemoveLiquidityStatus = ({ confirmedQuote }: RemoveLiquidityStatusP
   const history = useHistory()
 
   const handleGoBack = useCallback(() => {
-    history.push(RemoveLiquidityRoutePaths.Input)
+    history.push(RemoveLiquidityRoutePaths.Confirm)
   }, [history])
 
   return (

--- a/src/pages/ThorChainLP/components/ReusableLpStatus/ReusableLpStatus.tsx
+++ b/src/pages/ThorChainLP/components/ReusableLpStatus/ReusableLpStatus.tsx
@@ -2,6 +2,7 @@ import {
   Button,
   CardBody,
   CardFooter,
+  CardHeader,
   Center,
   CircularProgress,
   CircularProgressLabel,
@@ -18,6 +19,7 @@ import { Fragment, useCallback, useMemo, useState } from 'react'
 import { FaCheck } from 'react-icons/fa'
 import { useTranslate } from 'react-polyglot'
 import { Amount } from 'components/Amount/Amount'
+import { WithBackButton } from 'components/MultiHopTrade/components/WithBackButton'
 import { SlideTransition } from 'components/SlideTransition'
 import { RawText, Text } from 'components/Text'
 import { assertUnreachable } from 'lib/utils'
@@ -250,6 +252,13 @@ export const ReusableLpStatus: React.FC<ReusableLpStatusProps> = ({
 
   return (
     <SlideTransition>
+      <CardHeader>
+        <WithBackButton onBack={handleBack}>
+          <Heading as='h5' textAlign='center'>
+            <Text translation='Confirm' />
+          </Heading>
+        </WithBackButton>
+      </CardHeader>
       {renderBody}
       <CardFooter flexDir='column' px={4}>
         {assetCards}


### PR DESCRIPTION
## Description

Add back button to the `ReusableLpStatus` component (the confirm step of an LP deposit/withdraw).

<img width="367" alt="Screenshot 2024-03-11 at 3 28 44 PM" src="https://github.com/shapeshift/web/assets/97164662/8c40eea3-f596-4ac8-b251-ba99bba3d9fb">

## Pull Request Type

- [ ] :bug: Bug fix (Non-breaking Change: Fixes an issue)
- [x] :hammer_and_wrench: Chore (Non-breaking Change: Doc updates, pkg upgrades, typos, etc..)
- [ ] :nail_care: New Feature (Breaking/Non-breaking Change)

## Issue (if applicable)

Contributes to unblocking https://github.com/shapeshift/web/pull/6344.

## Risk

Low

> What protocols, transaction types or contract interactions might be affected by this PR?

None

## Testing

Ensure the back button renders, and works, on both the deposit and withdraw confirmation.

### Engineering

☝️

### Operations

☝️

## Screenshots (if applicable)

See description for the expected state.