### PR TITLE
feat: cowswap honor slippage in signed order

### DIFF
--- a/src/lib/swapper/swappers/CowSwapper/endpoints.ts
+++ b/src/lib/swapper/swappers/CowSwapper/endpoints.ts
@@ -1,5 +1,5 @@
 import { fromAssetId } from '@shapeshiftoss/caip'
-import { type EvmChainId } from '@shapeshiftoss/chain-adapters'
+import type { EvmChainId } from '@shapeshiftoss/chain-adapters'
 import {
   type CowSwapOrder,
   type EvmMessageToSign,


### PR DESCRIPTION
## Description

Reported by CoW directly:

> Are you not subtracting the slippage tolerance from the quote in your code? If not, this leads to effectively 0 slippage being applied which can lead to orders taking a very long time to settle or not settling at all.

## Pull Request Type

- [ ] :bug: Bug fix (Non-breaking Change: Fixes an issue)
- [ ] :hammer_and_wrench: Chore (Non-breaking Change: Doc updates, pkg upgrades, typos, etc..)
- [x] :nail_care: New Feature (Breaking/Non-breaking Change)

## Issue (if applicable)

<!-----------------------------------------------------------------------------
If applicable, please link to the github issue and put `closes #XXXX` in your comment to auto-close the issue that your PR fixes.
------------------------------------------------------------------------------>

closes https://github.com/shapeshift/web/issues/6365

## Risk
> High Risk PRs Require 2 approvals

<!-----------------------------------------------------------------------------
Outline the scope of your changes and the risk associated with them. You must use your discretion as an engineer to determine the potential impact of your changes.

WARNING: If your PR introduces a new on-chain transaction or modifies an existing one, please add the "High-Risk" label to this PR and ask for 2 reviewers to approve it before merging.

E.g. an upgrade to `hdwallet` or core state management would be considered higher risk, and might require a full regression test. UI or isolated view changes, or something behind a feature flag may have near zero risk. Small bug fixes might require testing isolated to the specific fix.
------------------------------------------------------------------------------>

> What protocols, transaction types or contract interactions might be affected by this PR?

Low - ensure slippage is deducted in the buy amount in the quote to-be-signed

## Testing

<!-----------------------------------------------------------------------------
We treat every PR to be merged with the same scrutiny as if we were merging directly to production.

Your PR will not be merged if you do not complete the sections below for our engineering and operations teams to test.
------------------------------------------------------------------------------>

- The minimum buy amount in CoW is correctly slippage-deducted (both with default 50bip and custom slippage tolerance)
- CoW orders fill much faster 🎉 

### Engineering

<!-----------------------------------------------------------------------------
Include sufficient information here for an engineer to test your PR. This may include how to test locally, in a built environment, changes to infrastructure etc.
------------------------------------------------------------------------------>

- ^

### Operations

<!-----------------------------------------------------------------------------
If your changes have a user-facing impact, describe how a non-technical QA team can functionally test your changes in a preview environment.

If they are not user-facing please describe how to test for any regressions that may occur.
------------------------------------------------------------------------------>

- ^

## Screenshots (if applicable)

![Screenshot 2024-03-11 at 05.38.43.png](https://graphite-user-uploaded-assets-prod.s3.amazonaws.com/BpXudHfKodngd8bjaa8L/bedbe2c0-b967-4900-8ad7-e325e5f54e62.png)
![Screenshot 2024-03-11 at 05.39.44.png](https://graphite-user-uploaded-assets-prod.s3.amazonaws.com/BpXudHfKodngd8bjaa8L/075856df-879c-4417-afea-ff5467f26931.png)
![Screenshot 2024-03-11 at 05.40.48.png](https://graphite-user-uploaded-assets-prod.s3.amazonaws.com/BpXudHfKodngd8bjaa8L/dfd4bcec-6ebd-4a67-a0c5-df2ea005f746.png)
![image.png](https://graphite-user-uploaded-assets-prod.s3.amazonaws.com/BpXudHfKodngd8bjaa8L/1dcfed12-fff3-4fef-8a82-10f28d7b079a.png)

Note, quote with slightly different rate since I tested this after, but just a sanity check while at it to ensure custom slippage UI looks sane:


![Screenshot 2024-03-11 at 05.41.53.png](https://graphite-user-uploaded-assets-prod.s3.amazonaws.com/BpXudHfKodngd8bjaa8L/c67290c7-c47e-426a-a0d9-2c3393ef8813.png)

