### PR TITLE
feat: hide receive account selection when manual address is set

### DIFF
--- a/src/components/MultiHopTrade/components/TradeAmountInput.tsx
+++ b/src/components/MultiHopTrade/components/TradeAmountInput.tsx
@@ -85,6 +85,7 @@ export type TradeAmountInputProps = {
   hideAmounts?: boolean
   layout?: 'inline' | 'stacked'
   isAccountSelectionDisabled?: boolean
+  isAccountSelectionHidden?: boolean
   isInputtingFiatSellAmount?: boolean
   handleIsInputtingFiatSellAmountChange?: (isInputtingFiatSellAmount: boolean) => void
 } & PropsWithChildren
@@ -102,6 +103,7 @@ export const TradeAmountInput: React.FC<TradeAmountInputProps> = memo(
     onPercentOptionClick,
     onAccountIdChange,
     isAccountSelectionDisabled,
+    isAccountSelectionHidden = false,
     cryptoAmount,
     isReadOnly,
     isSendMaxDisabled,
@@ -213,7 +215,7 @@ export const TradeAmountInput: React.FC<TradeAmountInputProps> = memo(
               </FormLabel>
             </Flex>
           )}
-          {balance && assetId && label && (
+          {balance && assetId && label && !isAccountSelectionHidden && (
             <AccountDropdown
               defaultAccountId={accountId}
               assetId={assetId}

--- a/src/components/MultiHopTrade/components/TradeInput/TradeInput.tsx
+++ b/src/components/MultiHopTrade/components/TradeInput/TradeInput.tsx
@@ -704,6 +704,8 @@ export const TradeInput = memo(({ isCompact }: TradeInputProps) => {
                     <Divider />
                   </Flex>
                   <TradeAssetInput
+                    // Disable account selection when user set a manual receive address
+                    isAccountSelectionHidden={Boolean(manualReceiveAddress)}
                     isReadOnly={true}
                     accountId={initialBuyAssetAccountId}
                     assetId={buyAsset.assetId}


### PR DESCRIPTION
## Description

Does what it says on the box - avoids confusion for users who set a custom receive address, where the account selection may be confusing and not reflect the actual receive address.

## Pull Request Type

- [ ] :bug: Bug fix (Non-breaking Change: Fixes an issue)
- [ ] :hammer_and_wrench: Chore (Non-breaking Change: Doc updates, pkg upgrades, typos, etc..)
- [x] :nail_care: New Feature (Breaking/Non-breaking Change)

## Issue (if applicable)

<!-----------------------------------------------------------------------------
If applicable, please link to the github issue and put `closes #XXXX` in your comment to auto-close the issue that your PR fixes.
------------------------------------------------------------------------------>

N/A

## Risk
> High Risk PRs Require 2 approvals

<!-----------------------------------------------------------------------------
Outline the scope of your changes and the risk associated with them. You must use your discretion as an engineer to determine the potential impact of your changes.

WARNING: If your PR introduces a new on-chain transaction or modifies an existing one, please add the "High-Risk" label to this PR and ask for 2 reviewers to approve it before merging.

E.g. an upgrade to `hdwallet` or core state management would be considered higher risk, and might require a full regression test. UI or isolated view changes, or something behind a feature flag may have near zero risk. Small bug fixes might require testing isolated to the specific fix.
------------------------------------------------------------------------------>

Low - this is only visual - as long as the account dropdown still shows up without a manual receive address, we're good

> What protocols, transaction types or contract interactions might be affected by this PR?

## Testing

<!-----------------------------------------------------------------------------
We treat every PR to be merged with the same scrutiny as if we were merging directly to production.

Your PR will not be merged if you do not complete the sections below for our engineering and operations teams to test.
------------------------------------------------------------------------------>

- When user set a manual receive address, receive account selection is hidden
- Receive account selection is still shown without a manual receive address

### Engineering

<!-----------------------------------------------------------------------------
Include sufficient information here for an engineer to test your PR. This may include how to test locally, in a built environment, changes to infrastructure etc.
------------------------------------------------------------------------------>

- ^

### Operations

<!-----------------------------------------------------------------------------
If your changes have a user-facing impact, describe how a non-technical QA team can functionally test your changes in a preview environment.

If they are not user-facing please describe how to test for any regressions that may occur.
------------------------------------------------------------------------------>

- ^

## Screenshots (if applicable)

![image.png](https://graphite-user-uploaded-assets-prod.s3.amazonaws.com/BpXudHfKodngd8bjaa8L/d11f7256-2dd0-42e6-ba61-f15cf84c3ebb.png)
![image.png](https://graphite-user-uploaded-assets-prod.s3.amazonaws.com/BpXudHfKodngd8bjaa8L/f36dd6d3-605e-400d-a9be-f4e2af5019c5.png)

