### PR TITLE
feat: thorchain LP withdraw outbound fees

### DIFF
--- a/src/components/Sweep.tsx
+++ b/src/components/Sweep.tsx
@@ -194,7 +194,7 @@ export const Sweep = ({
             <Row.Value>
               <Skeleton isLoaded={isEstimatedFeesDataSuccess}>
                 <Box textAlign='right'>
-                  <Amount.Fiat value={estimatedFeesData?.txFeeFiat ?? '0'} />
+                  <Amount.Fiat value={estimatedFeesData?.txFeeFiatUserCurrency ?? '0'} />
                   <Amount.Crypto
                     color='text.subtle'
                     value={fromBaseUnit(

--- a/src/lib/utils/thorchain/lp/types.ts
+++ b/src/lib/utils/thorchain/lp/types.ts
@@ -219,6 +219,8 @@ export type LpConfirmedWithdrawalQuote = {
   assetWithdrawAmountFiatUserCurrency: string
   runeWithdrawAmountCryptoPrecision: string
   runeWithdrawAmountFiatUserCurrency: string
+  assetOutboundFeeFiatUserCurrency: string
+  assetOutboundFeeCryptoPrecision: string
   shareOfPoolDecimalPercent: string
   slippageFiatUserCurrency: string
   opportunityId: string

--- a/src/pages/Lending/Pool/components/Borrow/BorrowInput.tsx
+++ b/src/pages/Lending/Pool/components/Borrow/BorrowInput.tsx
@@ -564,7 +564,7 @@ export const BorrowInput = ({
                   <Skeleton
                     isLoaded={Boolean(isEstimatedSweepFeesDataSuccess && estimatedSweepFeesData)}
                   >
-                    <Amount.Fiat value={estimatedSweepFeesData?.txFeeFiat ?? '0'} />
+                    <Amount.Fiat value={estimatedSweepFeesData?.txFeeFiatUserCurrency ?? '0'} />
                   </Skeleton>
                 </Row.Value>
               </Row>

--- a/src/pages/ThorChainLP/components/RemoveLiquidity/RemoveLiquidityInput.tsx
+++ b/src/pages/ThorChainLP/components/RemoveLiquidity/RemoveLiquidityInput.tsx
@@ -955,7 +955,7 @@ export const RemoveLiquidityInput: React.FC<RemoveLiquidityInputProps> = ({
           <Row fontSize='sm' fontWeight='medium'>
             <Row.Label>{translate('trade.protocolFee')}</Row.Label>
             <Row.Value>
-              <Skeleton isLoaded={Boolean(confirmedQuote?.assetOutboundFeeFiatUserCurrency)}>
+              <Skeleton isLoaded={bnOrZero(confirmedQuote?.assetOutboundFeeFiatUserCurrency).gt(0)}>
                 <Amount.Fiat value={confirmedQuote?.assetOutboundFeeFiatUserCurrency ?? '0'} />
               </Skeleton>
             </Row.Value>

--- a/src/pages/ThorChainLP/components/RemoveLiquidity/RemoveLiquidityInput.tsx
+++ b/src/pages/ThorChainLP/components/RemoveLiquidity/RemoveLiquidityInput.tsx
@@ -954,7 +954,12 @@ export const RemoveLiquidityInput: React.FC<RemoveLiquidityInputProps> = ({
         <Row fontSize='sm' fontWeight='medium'>
           <Row.Label>{translate('trade.protocolFee')}</Row.Label>
           <Row.Value>
-            <Skeleton isLoaded={Boolean(confirmedQuote?.assetOutboundFeeFiatUserCurrency)}>
+            <Skeleton
+              isLoaded={Boolean(
+                opportunityType !== AsymSide.Rune &&
+                  confirmedQuote?.assetOutboundFeeFiatUserCurrency,
+              )}
+            >
               <Amount.Fiat value={confirmedQuote?.assetOutboundFeeFiatUserCurrency ?? '0'} />
             </Skeleton>
           </Row.Value>

--- a/src/pages/ThorChainLP/components/RemoveLiquidity/RemoveLiquidityInput.tsx
+++ b/src/pages/ThorChainLP/components/RemoveLiquidity/RemoveLiquidityInput.tsx
@@ -646,16 +646,12 @@ export const RemoveLiquidityInput: React.FC<RemoveLiquidityInputProps> = ({
       withdrawalBps: bnOrZero(percentageSelection).times(100).toString(),
       currentAccountIdByChainId,
       assetAddress: poolAssetAccountAddress,
-      // TODO(gomes): we probably want to store this as-is and only the *4 dance when adding the minimum flow
       assetOutboundFeeCryptoPrecision: fromBaseUnit(
-        bnOrZero(estimatedPoolAssetOutboundFeesData?.txFeeCryptoBaseUnit).times(4),
+        estimatedPoolAssetOutboundFeesData?.txFeeCryptoBaseUnit ?? '0',
         poolAssetFeeAsset.precision,
       ),
-      assetOutboundFeeFiatUserCurrency: bnOrZero(
-        estimatedPoolAssetOutboundFeesData?.txFeeFiatUserCurrency,
-      )
-        .times(4)
-        .toFixed(),
+      assetOutboundFeeFiatUserCurrency:
+        estimatedPoolAssetOutboundFeesData?.txFeeFiatUserCurrency ?? '0',
     })
   }, [
     actualAssetWithdrawAmountCryptoPrecision,

--- a/src/pages/ThorChainLP/components/RemoveLiquidity/RemoveLiquidityInput.tsx
+++ b/src/pages/ThorChainLP/components/RemoveLiquidity/RemoveLiquidityInput.tsx
@@ -951,19 +951,16 @@ export const RemoveLiquidityInput: React.FC<RemoveLiquidityInputProps> = ({
             </Skeleton>
           </Row.Value>
         </Row>
-        <Row fontSize='sm' fontWeight='medium'>
-          <Row.Label>{translate('trade.protocolFee')}</Row.Label>
-          <Row.Value>
-            <Skeleton
-              isLoaded={Boolean(
-                opportunityType !== AsymSide.Rune &&
-                  confirmedQuote?.assetOutboundFeeFiatUserCurrency,
-              )}
-            >
-              <Amount.Fiat value={confirmedQuote?.assetOutboundFeeFiatUserCurrency ?? '0'} />
-            </Skeleton>
-          </Row.Value>
-        </Row>
+        {opportunityType !== AsymSide.Rune && (
+          <Row fontSize='sm' fontWeight='medium'>
+            <Row.Label>{translate('trade.protocolFee')}</Row.Label>
+            <Row.Value>
+              <Skeleton isLoaded={Boolean(confirmedQuote?.assetOutboundFeeFiatUserCurrency)}>
+                <Amount.Fiat value={confirmedQuote?.assetOutboundFeeFiatUserCurrency ?? '0'} />
+              </Skeleton>
+            </Row.Value>
+          </Row>
+        )}
       </CardFooter>
       <CardFooter
         borderTopWidth={1}

--- a/src/pages/ThorChainLP/components/RemoveLiquidity/RemoveLiquidityInput.tsx
+++ b/src/pages/ThorChainLP/components/RemoveLiquidity/RemoveLiquidityInput.tsx
@@ -365,9 +365,8 @@ export const RemoveLiquidityInput: React.FC<RemoveLiquidityInputProps> = ({
   })
 
   // Estimates *pool asset* outbound fees only for now
-  // TODO(gomes) - For the sake of simplicity, RUNE is not included in the estimation, we assume outbound fees are free which they aren't
-  // But once I get this working, I'll add the RUNE fees estimation, assuming we can get the rotating addresses from the pool module
-  // and estimations works from them
+  // While RUNE outboundFee does exist, it's a constant 0.02 RUNE (0.2$ at the time of writing), so we simplify it
+  // as non-existent for the sake of simplicity
   const estimateOutboundFeesArgs = useMemo(() => {
     if (opportunityType === AsymSide.Rune) return undefined
     if (!assetId || !wallet || !poolAsset || !poolAssetAccountAddress) return undefined
@@ -629,7 +628,7 @@ export const RemoveLiquidityInput: React.FC<RemoveLiquidityInputProps> = ({
     if (!actualRuneWithdrawAmountFiatUserCurrency) return
     if (!shareOfPoolDecimalPercent) return
     if (!poolAssetInboundAddress) return
-    if (!estimatedPoolAssetOutboundFeesData || !poolAssetFeeAsset) return
+    if (!poolAssetFeeAsset) return
 
     setConfirmedQuote({
       assetWithdrawAmountCryptoPrecision: actualAssetWithdrawAmountCryptoPrecision,
@@ -649,10 +648,12 @@ export const RemoveLiquidityInput: React.FC<RemoveLiquidityInputProps> = ({
       assetAddress: poolAssetAccountAddress,
       // TODO(gomes): we probably want to store this as-is and only the *4 dance when adding the minimum flow
       assetOutboundFeeCryptoPrecision: fromBaseUnit(
-        bn(estimatedPoolAssetOutboundFeesData.txFeeCryptoBaseUnit).times(4),
+        bnOrZero(estimatedPoolAssetOutboundFeesData?.txFeeCryptoBaseUnit).times(4),
         poolAssetFeeAsset.precision,
       ),
-      assetOutboundFeeFiatUserCurrency: bn(estimatedPoolAssetOutboundFeesData.txFeeFiatUserCurrency)
+      assetOutboundFeeFiatUserCurrency: bnOrZero(
+        estimatedPoolAssetOutboundFeesData?.txFeeFiatUserCurrency,
+      )
         .times(4)
         .toFixed(),
     })


### PR DESCRIPTION
## Description

Adds withdraw outbound fees as protocol fees for pool assets, estimating the Tx cost of sending from THOR address (contract/inbound address) to the user's address.

Note: As explained in the comments, this does not take RUNE into account in this PR and only relates to the pool asset for now - RUNE has constant 0.02 RUNE fees and has not been implemented here for the sake of simplicity and avoiding branching. 

## Pull Request Type

- [ ] :bug: Bug fix (Non-breaking Change: Fixes an issue)
- [ ] :hammer_and_wrench: Chore (Non-breaking Change: Doc updates, pkg upgrades, typos, etc..)
- [x] :nail_care: New Feature (Breaking/Non-breaking Change)

## Issue (if applicable)

<!-----------------------------------------------------------------------------
If applicable, please link to the github issue and put `closes #XXXX` in your comment to auto-close the issue that your PR fixes.
------------------------------------------------------------------------------>

- relates to https://github.com/shapeshift/web/issues/6413, by having protocol fees (outbound fees), we can simply *4 said outbound fee which will give us the minimum withdraw amount. See https://gitlab.com/thorchain/thornode/-/blob/develop/x/thorchain/querier_quotes.go#L490

## Risk
> High Risk PRs Require 2 approvals

<!-----------------------------------------------------------------------------
Outline the scope of your changes and the risk associated with them. You must use your discretion as an engineer to determine the potential impact of your changes.

WARNING: If your PR introduces a new on-chain transaction or modifies an existing one, please add the "High-Risk" label to this PR and ask for 2 reviewers to approve it before merging.

E.g. an upgrade to `hdwallet` or core state management would be considered higher risk, and might require a full regression test. UI or isolated view changes, or something behind a feature flag may have near zero risk. Small bug fixes might require testing isolated to the specific fix.
------------------------------------------------------------------------------>

Low - ensure withdraws still behave as expected, there are no errors with estimations, and the user-currency fee looks sane

> What protocols, transaction types or contract interactions might be affected by this PR?

## Testing

<!-----------------------------------------------------------------------------
We treat every PR to be merged with the same scrutiny as if we were merging directly to production.

Your PR will not be merged if you do not complete the sections below for our engineering and operations teams to test.
------------------------------------------------------------------------------>

- When withdrawing RUNE asymetrically, there is no protocol fee row displayed
- When withdrawing either asset asym, or symetrically, the protocol fee looks sane as outbound fee (i.e a native/token send on the destination chain)

### Engineering

<!-----------------------------------------------------------------------------
Include sufficient information here for an engineer to test your PR. This may include how to test locally, in a built environment, changes to infrastructure etc.
------------------------------------------------------------------------------>

- ☝🏽 

### Operations

<!-----------------------------------------------------------------------------
If your changes have a user-facing impact, describe how a non-technical QA team can functionally test your changes in a preview environment.

If they are not user-facing please describe how to test for any regressions that may occur.
------------------------------------------------------------------------------>

- ☝🏽 

## Screenshots (if applicable)

- Native EVM assets

<img width="498" alt="Screenshot 2024-03-12 at 14 23 02" src="https://github.com/shapeshift/web/assets/17035424/a13e04e5-153f-4835-b086-aa4c24fb50c7">
<img width="507" alt="Screenshot 2024-03-12 at 14 22 45" src="https://github.com/shapeshift/web/assets/17035424/06212212-8ea6-45ec-8382-77e3ddcf4da9">

- Tokens

<img width="474" alt="Screenshot 2024-03-12 at 14 23 44" src="https://github.com/shapeshift/web/assets/17035424/d9fce1c0-6e43-46aa-af9d-93a7924258a7">

- UTXOs

<img width="497" alt="Screenshot 2024-03-12 at 14 23 14" src="https://github.com/shapeshift/web/assets/17035424/b4b6b87d-fc65-4deb-a38d-d08401906405">

- ATOM

<img width="479" alt="image" src="https://github.com/shapeshift/web/assets/17035424/32ed83e5-4cbf-4e7f-9f4c-ab04995fe227">
