### PR TITLE
fix: slider debounce

### DIFF
--- a/src/pages/ThorChainLP/components/RemoveLiquidity/RemoveLiquidityInput.tsx
+++ b/src/pages/ThorChainLP/components/RemoveLiquidity/RemoveLiquidityInput.tsx
@@ -550,7 +550,7 @@ export const RemoveLiquidityInput: React.FC<RemoveLiquidityInputProps> = ({
 
       const estimate = await estimateRemoveThorchainLiquidityPosition({
         liquidityUnits: position?.liquidityUnits,
-        bps: bnOrZero(sliderValue).times(100).toFixed(),
+        bps: bnOrZero(percentageSelection).times(100).toFixed(),
         assetId: poolAsset.assetId,
         runeAmountThorBaseUnit,
         assetAmountThorBaseUnit,
@@ -567,10 +567,10 @@ export const RemoveLiquidityInput: React.FC<RemoveLiquidityInputProps> = ({
   }, [
     position,
     poolAsset,
-    sliderValue,
     runeMarketData.price,
     actualAssetWithdrawAmountCryptoPrecision,
     actualRuneWithdrawAmountCryptoPrecision,
+    percentageSelection,
   ])
 
   useEffect(() => {


### PR DESCRIPTION
## Description

Fixes a regression that caused the LP removal percentage slider's debounce to break.

## Pull Request Type

- [x] :bug: Bug fix (Non-breaking Change: Fixes an issue)
- [ ] :hammer_and_wrench: Chore (Non-breaking Change: Doc updates, pkg upgrades, typos, etc..)
- [ ] :nail_care: New Feature (Breaking/Non-breaking Change)

## Issue (if applicable)

Closes https://github.com/shapeshift/web/issues/6422

## Risk

Small

> What protocols, transaction types or contract interactions might be affected by this PR?

None.

## Testing

Network requests should only fire once the slider is released, but the UI should still be buttery smooth whilst sliding.

### Engineering

☝️

### Operations

☝️

Network requests are found in the network tab.

## Screenshots (if applicable)

N/A