### PR TITLE
fix: demo wallet balances

### DIFF
--- a/src/components/AssetSearch/AssetRow.tsx
+++ b/src/components/AssetSearch/AssetRow.tsx
@@ -75,7 +75,7 @@ export const AssetRow: FC<ListChildComponentProps<AssetData>> = memo(
             </Flex>
           </Box>
         </Flex>
-        {isConnected && !isDemoWallet && !hideAssetBalance && (
+        {(isConnected || isDemoWallet) && !hideAssetBalance && (
           <Flex flexDir='column' justifyContent='flex-end' alignItems='flex-end'>
             <Amount.Fiat
               color='var(--chakra-colors-chakra-body-text)'


### PR DESCRIPTION
## Description

Show balances on the `assets` route when connected to the demo wallet.

## Pull Request Type

- [ ] :bug: Bug fix (Non-breaking Change: Fixes an issue)
- [ ] :hammer_and_wrench: Chore (Non-breaking Change: Doc updates, pkg upgrades, typos, etc..)
- [ ] :nail_care: New Feature (Breaking/Non-breaking Change)

## Issue (if applicable)

Closes https://github.com/shapeshift/web/issues/6240

## Risk

Small

> What protocols, transaction types or contract interactions might be affected by this PR?

None.

## Testing

- The demo wallet should show balances on the `assets` route
- Other wallets should be unaffected by this change

### Engineering

☝️

### Operations

☝️

## Screenshots (if applicable)

<img width="1186" alt="Screenshot 2024-03-13 at 11 33 08 AM" src="https://github.com/shapeshift/web/assets/97164662/4d484dfc-143b-4526-a8e8-70964ae2d966">
