### PR TITLE
fix: trade quote fee currency

### DIFF
--- a/src/components/MultiHopTrade/components/TradeInput/components/ReceiveSummary.tsx
+++ b/src/components/MultiHopTrade/components/TradeInput/components/ReceiveSummary.tsx
@@ -23,7 +23,7 @@ import { isSome } from 'lib/utils'
 import { selectInputSellAmountUsd } from 'state/slices/selectors'
 import {
   selectActiveQuoteAffiliateBps,
-  selectQuoteFeeAmountUsd,
+  selectQuoteAffiliateFeeUserCurrency,
 } from 'state/slices/tradeQuoteSlice/selectors'
 import { useAppSelector } from 'state/store'
 
@@ -74,7 +74,7 @@ export const ReceiveSummary: FC<ReceiveSummaryProps> = memo(
     const inputAmountUsd = useAppSelector(selectInputSellAmountUsd)
     // use the fee data from the actual quote in case it varies from the theoretical calculation
     const affiliateBps = useAppSelector(selectActiveQuoteAffiliateBps)
-    const amountAfterDiscountUserCurrency = useAppSelector(selectQuoteFeeAmountUsd)
+    const amountAfterDiscountUserCurrency = useAppSelector(selectQuoteAffiliateFeeUserCurrency)
 
     const parseAmountDisplayMeta = useCallback((items: AmountDisplayMeta[]) => {
       return items


### PR DESCRIPTION
## Description

Uses the correct selector to ensure we show the receive summary fee in the user's selected currency.

## Pull Request Type

- [x] :bug: Bug fix (Non-breaking Change: Fixes an issue)
- [ ] :hammer_and_wrench: Chore (Non-breaking Change: Doc updates, pkg upgrades, typos, etc..)
- [ ] :nail_care: New Feature (Breaking/Non-breaking Change)

## Issue (if applicable)

Fixes https://github.com/shapeshift/web/pull/6424 release blocker noted here https://github.com/shapeshift/web/pull/6424#issuecomment-1992928368.

## Risk

Small - UI only.

> What protocols, transaction types or contract interactions might be affected by this PR?

UI only, but related to trading.

## Testing

The "ShapeShift fee" should be in the user's selected currency.

### Engineering

☝️

### Operations

☝️

## Screenshots (if applicable)

<img width="783" alt="Screenshot 2024-03-13 at 12 38 53 PM" src="https://github.com/shapeshift/web/assets/97164662/aab1f8ba-1275-4fc9-a9d0-adec1526c645">
