### PR TITLE
fix: fee modal input should be usd

### DIFF
--- a/src/components/MultiHopTrade/components/TradeInput/components/ReceiveSummary.tsx
+++ b/src/components/MultiHopTrade/components/TradeInput/components/ReceiveSummary.tsx
@@ -24,6 +24,7 @@ import { selectInputSellAmountUsd } from 'state/slices/selectors'
 import {
   selectActiveQuoteAffiliateBps,
   selectQuoteAffiliateFeeUserCurrency,
+  selectQuoteFeeAmountUsd,
 } from 'state/slices/tradeQuoteSlice/selectors'
 import { useAppSelector } from 'state/store'
 
@@ -75,6 +76,7 @@ export const ReceiveSummary: FC<ReceiveSummaryProps> = memo(
     // use the fee data from the actual quote in case it varies from the theoretical calculation
     const affiliateBps = useAppSelector(selectActiveQuoteAffiliateBps)
     const amountAfterDiscountUserCurrency = useAppSelector(selectQuoteAffiliateFeeUserCurrency)
+    const amountAfterDiscountUsd = useAppSelector(selectQuoteFeeAmountUsd)
 
     const parseAmountDisplayMeta = useCallback((items: AmountDisplayMeta[]) => {
       return items
@@ -192,7 +194,7 @@ export const ReceiveSummary: FC<ReceiveSummaryProps> = memo(
         <FeeModal
           isOpen={showFeeModal}
           onClose={toggleFeeModal}
-          affiliateFeeAmountUsd={amountAfterDiscountUserCurrency}
+          affiliateFeeAmountUsd={amountAfterDiscountUsd}
           inputAmountUsd={inputAmountUsd}
           feeModel='SWAPPER'
         />


### PR DESCRIPTION
## Description

Fixes the `affiliateFeeAmountUsd` input to `FeeModal`, which should be a USD amount.

## Pull Request Type

- [x] :bug: Bug fix (Non-breaking Change: Fixes an issue)
- [ ] :hammer_and_wrench: Chore (Non-breaking Change: Doc updates, pkg upgrades, typos, etc..)
- [ ] :nail_care: New Feature (Breaking/Non-breaking Change)

## Issue (if applicable)

Fixes current release blocker: https://discord.com/channels/554694662431178782/1217256377030938754/1217310573667155979

## Risk

Small.

> What protocols, transaction types or contract interactions might be affected by this PR?

None.

## Testing

The Fee summary modal total should make sense when a user currency is selected.

<img width="394" alt="Screenshot 2024-03-13 at 3 20 07 PM" src="https://github.com/shapeshift/web/assets/97164662/38f59393-5388-4df1-8d4e-0b65ef8945a4">

### Engineering

☝️

### Operations

☝️

## Screenshots (if applicable)

See testing notes.