### PR TITLE
fix: disable gas estimation if approval is required

### DIFF
--- a/src/pages/ThorChainLP/components/AddLiquidity/AddLiquidityInput.tsx
+++ b/src/pages/ThorChainLP/components/AddLiquidity/AddLiquidityInput.tsx
@@ -653,7 +653,7 @@ export const AddLiquidityInput: React.FC<AddLiquidityInputProps> = ({
     memo: estimateFeesArgs?.memo ?? '',
     accountId: estimateFeesArgs?.accountId ?? '',
     contractAddress: estimateFeesArgs?.contractAddress ?? '',
-    enabled: !!estimateFeesArgs,
+    enabled: Boolean(estimateFeesArgs && !isApprovalRequired),
   })
 
   useEffect(() => {
@@ -1437,8 +1437,6 @@ export const AddLiquidityInput: React.FC<AddLiquidityInputProps> = ({
             !hasEnoughRuneBalance ||
             isApprovalTxPending ||
             (isSweepNeededEnabled && isSweepNeeded === undefined) ||
-            poolAssetTxFeeCryptoBaseUnit === undefined ||
-            runeTxFeeCryptoBaseUnit === undefined ||
             isSweepNeededError ||
             isEstimatedPoolAssetFeesDataError ||
             isEstimatedRuneFeesDataError ||


### PR DESCRIPTION
## Description

- Disable gas estimation if approval is required. The estimation will always revert if there is no allowance, so prevent this to allow user to perform the approval successfully and in turn, perform the rest of their deposit.
- Fix disable state regression related to undefined fee data (MM will never get rune fee data which was resulting in perma disable state)

## Pull Request Type

- [x] :bug: Bug fix (Non-breaking Change: Fixes an issue)
- [ ] :hammer_and_wrench: Chore (Non-breaking Change: Doc updates, pkg upgrades, typos, etc..)
- [ ] :nail_care: New Feature (Breaking/Non-breaking Change)

## Issue (if applicable)

<!-----------------------------------------------------------------------------
If applicable, please link to the github issue and put `closes #XXXX` in your comment to auto-close the issue that your PR fixes.
------------------------------------------------------------------------------>

closes https://github.com/shapeshift/web/issues/6441

## Risk
> High Risk PRs Require 2 approvals

<!-----------------------------------------------------------------------------
Outline the scope of your changes and the risk associated with them. You must use your discretion as an engineer to determine the potential impact of your changes.

WARNING: If your PR introduces a new on-chain transaction or modifies an existing one, please add the "High-Risk" label to this PR and ask for 2 reviewers to approve it before merging.

E.g. an upgrade to `hdwallet` or core state management would be considered higher risk, and might require a full regression test. UI or isolated view changes, or something behind a feature flag may have near zero risk. Small bug fixes might require testing isolated to the specific fix.
------------------------------------------------------------------------------>

Low/Med - affects enable/disable states so we want to make sure we got this right and don't get stuck in any flows

> What protocols, transaction types or contract interactions might be affected by this PR?

Thorchain LP deposits

## Testing

<!-----------------------------------------------------------------------------
We treat every PR to be merged with the same scrutiny as if we were merging directly to production.

Your PR will not be merged if you do not complete the sections below for our engineering and operations teams to test.
------------------------------------------------------------------------------>

- Ensure thorchain lp deposit approvals work for tokens and subsequently the rest of the deposit flow works as expected

### Engineering

<!-----------------------------------------------------------------------------
Include sufficient information here for an engineer to test your PR. This may include how to test locally, in a built environment, changes to infrastructure etc.
------------------------------------------------------------------------------>

:point_up: 

### Operations

<!-----------------------------------------------------------------------------
If your changes have a user-facing impact, describe how a non-technical QA team can functionally test your changes in a preview environment.

If they are not user-facing please describe how to test for any regressions that may occur.
------------------------------------------------------------------------------>

:point_up: 

- General regression test across assets native and token and wallets

## Screenshots (if applicable)

![image](https://github.com/shapeshift/web/assets/35275952/48ef32af-b3bb-4bbd-b5f9-ce960ba59435)
