### PR TITLE
fix: show "Pool Halted" on withdraw

### DIFF
--- a/src/pages/ThorChainLP/components/RemoveLiquidity/RemoveLiquidityInput.tsx
+++ b/src/pages/ThorChainLP/components/RemoveLiquidity/RemoveLiquidityInput.tsx
@@ -890,6 +890,7 @@ export const RemoveLiquidityInput: React.FC<RemoveLiquidityInputProps> = ({
 
   const errorCopy = useMemo(() => {
     if (isUnsupportedSymWithdraw) return translate('common.unsupportedNetwork')
+    if (isTradingActive === false) return translate('common.poolHalted')
     if (poolAssetFeeAsset && !hasEnoughPoolAssetFeeAssetBalanceForTx)
       return translate('modals.send.errors.notEnoughNativeToken', {
         asset: poolAssetFeeAsset.symbol,
@@ -902,6 +903,7 @@ export const RemoveLiquidityInput: React.FC<RemoveLiquidityInputProps> = ({
   }, [
     hasEnoughPoolAssetFeeAssetBalanceForTx,
     hasEnoughRuneBalanceForTx,
+    isTradingActive,
     isUnsupportedSymWithdraw,
     poolAssetFeeAsset,
     runeAsset,


### PR DESCRIPTION
## Description

Show the "Pool Halted" error when attempting to withdraw from a halted pool.

We currently just disable the button with no explanation as to why, which is not ideal.

## Pull Request Type

- [x] :bug: Bug fix (Non-breaking Change: Fixes an issue)
- [ ] :hammer_and_wrench: Chore (Non-breaking Change: Doc updates, pkg upgrades, typos, etc..)
- [ ] :nail_care: New Feature (Breaking/Non-breaking Change)

## Issue (if applicable)

No ticket.

## Risk

Small.

> What protocols, transaction types or contract interactions might be affected by this PR?

LP withdraw UI.

## Testing

Attempt to withdraw from a halted pool.
The button should be both disabled, in the error state, and show "Pool Halted".

### Engineering

☝️

### Operations

☝️

## Screenshots (if applicable)

Develop:

<img width="353" alt="Screenshot 2024-03-14 at 10 17 56 AM" src="https://github.com/shapeshift/web/assets/97164662/c3fc1487-59ca-44fb-ae1f-4798ca7e63d3">

This branch:

<img width="352" alt="Screenshot 2024-03-14 at 10 21 04 AM" src="https://github.com/shapeshift/web/assets/97164662/1767fd3a-dc6f-4350-9463-4e24ba3b06ca">
