### PR TITLE
feat: add mixpanel tracking to LP

### DIFF
--- a/src/lib/mixpanel/types.ts
+++ b/src/lib/mixpanel/types.ts
@@ -50,6 +50,14 @@ export enum MixPanelEvent {
   SnapInstalled = 'Snap Installed',
   StartAddSnap = 'Start Add Snap',
   NoActionableQuotes = 'No Actionable Quotes',
+  LpDepositConfirm = 'LP Deposit Confirm',
+  LpDepositInitiated = 'LP Deposit Initiated',
+  LpDepositSuccess = 'LP Deposit Success',
+  LpDepositFailed = 'LP Deposit Failed',
+  LpWithdrawConfirm = 'LP Withdraw Confirm',
+  LpWithdrawInitiated = 'LP Withdraw Initiated',
+  LpWithdrawSuccess = 'LP Withdraw Success',
+  LpWithdrawFailed = 'LP Withdraw Failed',
 }
 
 export type TrackOpportunityProps = {

--- a/src/pages/ThorChainLP/components/AddLiquidity/AddLiquidityConfirm.tsx
+++ b/src/pages/ThorChainLP/components/AddLiquidity/AddLiquidityConfirm.tsx
@@ -1,6 +1,8 @@
 import { thorchainAssetId } from '@shapeshiftoss/caip'
 import { useCallback } from 'react'
 import { useHistory } from 'react-router'
+import { getMixPanel } from 'lib/mixpanel/mixPanelSingleton'
+import { MixPanelEvent } from 'lib/mixpanel/types'
 import type { LpConfirmedDepositQuote } from 'lib/utils/thorchain/lp/types'
 
 import { ReusableLpConfirm } from '../ReusableLpConfirm'
@@ -12,6 +14,7 @@ type AddLiquidityConfirmProps = {
 
 export const AddLiquidityConfirm = ({ confirmedQuote }: AddLiquidityConfirmProps) => {
   const history = useHistory()
+  const mixpanel = getMixPanel()
 
   const handleBack = useCallback(() => {
     history.push(AddLiquidityRoutePaths.Input)
@@ -19,7 +22,8 @@ export const AddLiquidityConfirm = ({ confirmedQuote }: AddLiquidityConfirmProps
 
   const handleConfirm = useCallback(() => {
     history.push(AddLiquidityRoutePaths.Status)
-  }, [history])
+    mixpanel?.track(MixPanelEvent.LpDepositConfirm, confirmedQuote)
+  }, [confirmedQuote, history, mixpanel])
 
   return (
     <ReusableLpConfirm

--- a/src/pages/ThorChainLP/components/RemoveLiquidity/RemoveLiquidityConfirm.tsx
+++ b/src/pages/ThorChainLP/components/RemoveLiquidity/RemoveLiquidityConfirm.tsx
@@ -1,6 +1,8 @@
 import { thorchainAssetId } from '@shapeshiftoss/caip'
 import { useCallback } from 'react'
 import { useHistory } from 'react-router'
+import { getMixPanel } from 'lib/mixpanel/mixPanelSingleton'
+import { MixPanelEvent } from 'lib/mixpanel/types'
 import type { LpConfirmedWithdrawalQuote } from 'lib/utils/thorchain/lp/types'
 
 import { ReusableLpConfirm } from '../ReusableLpConfirm'
@@ -12,6 +14,7 @@ type RemoveLiquidityConfirmProps = {
 
 export const RemoveLiquidityConfirm = ({ confirmedQuote }: RemoveLiquidityConfirmProps) => {
   const history = useHistory()
+  const mixpanel = getMixPanel()
 
   const handleBack = useCallback(() => {
     history.push(RemoveLiquidityRoutePaths.Input)
@@ -19,7 +22,8 @@ export const RemoveLiquidityConfirm = ({ confirmedQuote }: RemoveLiquidityConfir
 
   const handleConfirm = useCallback(() => {
     history.push(RemoveLiquidityRoutePaths.Status)
-  }, [history])
+    mixpanel?.track(MixPanelEvent.LpWithdrawConfirm, confirmedQuote)
+  }, [confirmedQuote, history, mixpanel])
 
   return (
     <ReusableLpConfirm

--- a/src/pages/ThorChainLP/components/ReusableLpStatus/TransactionRow.tsx
+++ b/src/pages/ThorChainLP/components/ReusableLpStatus/TransactionRow.tsx
@@ -43,6 +43,8 @@ import { Row } from 'components/Row/Row'
 import { useWallet } from 'hooks/useWallet/useWallet'
 import { getTxLink } from 'lib/getTxLink'
 import { fromBaseUnit, toBaseUnit } from 'lib/math'
+import { getMixPanel } from 'lib/mixpanel/mixPanelSingleton'
+import { MixPanelEvent } from 'lib/mixpanel/types'
 import { sleep } from 'lib/poll/poll'
 import { assetIdToPoolAssetId } from 'lib/swapper/swappers/ThorchainSwapper/utils/poolAssetHelpers/poolAssetHelpers'
 import { assertUnreachable, isToken } from 'lib/utils'
@@ -105,6 +107,7 @@ export const TransactionRow: React.FC<TransactionRowProps> = ({
   const translate = useTranslate()
   const selectedCurrency = useAppSelector(selectSelectedCurrency)
   const wallet = useWallet().state.wallet
+  const mixpanel = getMixPanel()
 
   const [status, setStatus] = useState(TxStatus.Unknown)
   const [isSubmitting, setIsSubmitting] = useState(false)
@@ -437,6 +440,10 @@ export const TransactionRow: React.FC<TransactionRowProps> = ({
 
   const handleSignTx = useCallback(() => {
     setIsSubmitting(true)
+    mixpanel?.track(
+      isDeposit ? MixPanelEvent.LpDepositInitiated : MixPanelEvent.LpWithdrawInitiated,
+      confirmedQuote,
+    )
     if (
       !(
         assetId &&
@@ -605,6 +612,9 @@ export const TransactionRow: React.FC<TransactionRowProps> = ({
       onStart()
     })
   }, [
+    mixpanel,
+    isDeposit,
+    confirmedQuote,
     assetId,
     poolAssetId,
     asset,
@@ -613,16 +623,16 @@ export const TransactionRow: React.FC<TransactionRowProps> = ({
     wallet,
     memo,
     isRuneTx,
-    inboundAddressData,
+    inboundAddressData?.address,
+    inboundAddressData?.router,
     refetchIsTradingActive,
     runeAccountId,
     poolAssetAccountId,
     amountCryptoPrecision,
-    runeAccountNumber,
-    isDeposit,
-    poolAssetAccountNumber,
-    assetAddress,
     estimateFeesArgs,
+    runeAccountNumber,
+    assetAddress,
+    poolAssetAccountNumber,
     selectedCurrency,
     onStart,
   ])


### PR DESCRIPTION
## Description

Adds MixPanel tracking to THORChain LP transactions:

```
LP Deposit Confirm,
LP Deposit Initiated,
LP Deposit Success,
LP Deposit Failed,
LP Withdraw Confirm,
LP Withdraw Initiated,
LP Withdraw Success,
LP Withdraw Failed,
```

## Pull Request Type

- [ ] :bug: Bug fix (Non-breaking Change: Fixes an issue)
- [x] :hammer_and_wrench: Chore (Non-breaking Change: Doc updates, pkg upgrades, typos, etc..)
- [ ] :nail_care: New Feature (Breaking/Non-breaking Change)

## Issue (if applicable)

Contributes to https://github.com/shapeshift/web/pull/6344

## Risk

Small

> What protocols, transaction types or contract interactions might be affected by this PR?

In the domain of LPs, though nothing should be directly affected.

## Testing

Ensure events show up in MixPanel for both LP deposits and withdrawals.

<img width="1143" alt="Screenshot 2024-03-15 at 2 35 20 PM" src="https://github.com/shapeshift/web/assets/97164662/ec52868d-7701-46ac-b212-b2931d13fb16">

### Engineering

☝️

### Operations

☝️

## Screenshots (if applicable)

See testing notes.