### PR TITLE
fix: infinite scroll for larger screens

### DIFF
--- a/src/components/Layout/Header/Header.tsx
+++ b/src/components/Layout/Header/Header.tsx
@@ -161,7 +161,7 @@ export const Header = memo(() => {
 
   return (
     <>
-      {isDemoWallet && (
+      {!isDemoWallet && (
         <Box
           bg='blue.500'
           width='full'

--- a/src/components/Layout/Header/Header.tsx
+++ b/src/components/Layout/Header/Header.tsx
@@ -161,7 +161,7 @@ export const Header = memo(() => {
 
   return (
     <>
-      {!isDemoWallet && (
+      {isDemoWallet && (
         <Box
           bg='blue.500'
           width='full'

--- a/src/components/Layout/Page.tsx
+++ b/src/components/Layout/Page.tsx
@@ -5,7 +5,7 @@ import type { Route } from 'Routes/helpers'
 import { CircularProgress } from 'components/CircularProgress/CircularProgress'
 import { Text } from 'components/Text'
 
-const pageHeight = { base: '100vh', md: 'calc(100% - 72px)' }
+const pageHeight = { base: '100dvh', md: 'calc(100% - 72px)' }
 
 type PageProps = {
   children: ReactNode

--- a/src/hooks/useInfiniteScroll/useInfiniteScroll.tsx
+++ b/src/hooks/useInfiniteScroll/useInfiniteScroll.tsx
@@ -1,6 +1,6 @@
 import { useCallback, useMemo, useState } from 'react'
 
-const defaultAmount = 10
+const defaultAmount = 20
 
 export const useInfiniteScroll = (array: any[]) => {
   const [amount, setAmount] = useState(defaultAmount)

--- a/src/pages/Dashboard/Dashboard.tsx
+++ b/src/pages/Dashboard/Dashboard.tsx
@@ -29,7 +29,7 @@ const maxWidth = { base: 'full', lg: 'full', xl: 'sm' }
 const mainPadding = { base: 0, md: 4 }
 const customTabActive = { color: 'text.base' }
 const customTabLast = { marginRight: 0 }
-const pageProps = { paddingTop: 0 }
+const pageProps = { paddingTop: 0, pb: 0 }
 const CustomTab = (props: TabProps) => (
   <Tab
     fontWeight='semibold'
@@ -49,7 +49,7 @@ const ScrollView = (props: FlexProps) => (
     width='100vw'
     pt='calc(var(--mobile-header-offset) + 1rem)'
     pb='var(--mobile-nav-offset)'
-    height='100vh'
+    height='100dvh'
     overflowY='auto'
     {...props}
   />


### PR DESCRIPTION
## Description

When you are on a larger screen, the infinite loader would not trigger, because it never went beyond the viewport. 

So to fix this, we've increased the amount of items we show per page on the infinite scroll from 10 to 20. This should give us lots of room for most normal sized monitors.

## Pull Request Type

- [x] :bug: Bug fix (Non-breaking Change: Fixes an issue)
- [ ] :hammer_and_wrench: Chore (Non-breaking Change: Doc updates, pkg upgrades, typos, etc..)
- [ ] :nail_care: New Feature (Breaking/Non-breaking Change)

## Issue (if applicable)

<!-----------------------------------------------------------------------------
If applicable, please link to the github issue and put `closes #XXXX` in your comment to auto-close the issue that your PR fixes.
------------------------------------------------------------------------------>

closes #6463 

## Risk
> High Risk PRs Require 2 approvals

<!-----------------------------------------------------------------------------
Outline the scope of your changes and the risk associated with them. You must use your discretion as an engineer to determine the potential impact of your changes.

WARNING: If your PR introduces a new on-chain transaction or modifies an existing one, please add the "High-Risk" label to this PR and ask for 2 reviewers to approve it before merging.

E.g. an upgrade to `hdwallet` or core state management would be considered higher risk, and might require a full regression test. UI or isolated view changes, or something behind a feature flag may have near zero risk. Small bug fixes might require testing isolated to the specific fix.
------------------------------------------------------------------------------>

Minimal risk

> What protocols, transaction types or contract interactions might be affected by this PR?

## Testing

<!-----------------------------------------------------------------------------
We treat every PR to be merged with the same scrutiny as if we were merging directly to production.

Your PR will not be merged if you do not complete the sections below for our engineering and operations teams to test.
------------------------------------------------------------------------------>

### Engineering

<!-----------------------------------------------------------------------------
Include sufficient information here for an engineer to test your PR. This may include how to test locally, in a built environment, changes to infrastructure etc.
------------------------------------------------------------------------------>

### Operations

<!-----------------------------------------------------------------------------
If your changes have a user-facing impact, describe how a non-technical QA team can functionally test your changes in a preview environment.

If they are not user-facing please describe how to test for any regressions that may occur.
------------------------------------------------------------------------------>

With a wallet connected, and on a larger size screen as you scroll the transaction history and the assets table on the dashboard should load in 20 rows at a time until it can't load anymore.

## Screenshots (if applicable)
