### PR TITLE
fix: thorchain LP withdraw outbound fee is denominated in outbound fee asset

### DIFF
--- a/src/pages/ThorChainLP/components/RemoveLiquidity/RemoveLiquidityInput.tsx
+++ b/src/pages/ThorChainLP/components/RemoveLiquidity/RemoveLiquidityInput.tsx
@@ -410,8 +410,8 @@ export const RemoveLiquidityInput: React.FC<RemoveLiquidityInputProps> = ({
   }, [inboundAddressesData?.outbound_fee, opportunityType])
 
   const poolAssetProtocolFeeFiatUserCurrency = useMemo(() => {
-    return poolAssetProtocolFeeCryptoPrecision.times(poolAssetMarketData.price)
-  }, [poolAssetMarketData, poolAssetProtocolFeeCryptoPrecision])
+    return poolAssetProtocolFeeCryptoPrecision.times(poolAssetFeeAssetMarketData.price)
+  }, [poolAssetFeeAssetMarketData.price, poolAssetProtocolFeeCryptoPrecision])
 
   const poolAssetTxFeeCryptoPrecision = useMemo(
     () =>


### PR DESCRIPTION
## Description

Ensures we properly set minimums for token withdraws.

The outbound fee coming from the `inbound_addresses` endpoint is the outbound fee for the *chain*, not the asset - in other words, it represents the native asset gas fee for the outbound fee.


## Pull Request Type

- [ ] :bug: Bug fix (Non-breaking Change: Fixes an issue)
- [ ] :hammer_and_wrench: Chore (Non-breaking Change: Doc updates, pkg upgrades, typos, etc..)
- [x] :nail_care: New Feature (Breaking/Non-breaking Change)

## Issue (if applicable)

<!-----------------------------------------------------------------------------
If applicable, please link to the github issue and put `closes #XXXX` in your comment to auto-close the issue that your PR fixes.
------------------------------------------------------------------------------>

N/A

## Risk
> High Risk PRs Require 2 approvals

<!-----------------------------------------------------------------------------
Outline the scope of your changes and the risk associated with them. You must use your discretion as an engineer to determine the potential impact of your changes.

WARNING: If your PR introduces a new on-chain transaction or modifies an existing one, please add the "High-Risk" label to this PR and ask for 2 reviewers to approve it before merging.

E.g. an upgrade to `hdwallet` or core state management would be considered higher risk, and might require a full regression test. UI or isolated view changes, or something behind a feature flag may have near zero risk. Small bug fixes might require testing isolated to the specific fix.
------------------------------------------------------------------------------>

> What protocols, transaction types or contract interactions might be affected by this PR?

None, this was obviously wrong

## Testing

<!-----------------------------------------------------------------------------
We treat every PR to be merged with the same scrutiny as if we were merging directly to production.

Your PR will not be merged if you do not complete the sections below for our engineering and operations teams to test.
------------------------------------------------------------------------------>

See screenshots - minimums should be properly detected

- Inspect the `inbound_addresses` call in the network requests tab


![image.png](https://graphite-user-uploaded-assets-prod.s3.amazonaws.com/BpXudHfKodngd8bjaa8L/e18e7793-412a-49fa-b970-bf743cc0efc5.png)


- Note the inbound address for the chain and convert the precision from THOR precision, by shifting the decimal point 8 digits, e.g 1649190 -> 0.01649190
- You now have the outbound fee for the pool asset chain, i.e 0.01649190 AVAX ~= 1 USD here
- Try to do either an asym *asset*, or sym withdraw, for a pool which is a token, not a native asset e.g USDC on AVAX
- The minimum should properly account for (pool asset fee asset * 4) for asym asset withdraws, and the same + an additional 0.02 RUNE (~0.1738 at the time of writing) for sym withdraws.


 
### Engineering

<!-----------------------------------------------------------------------------
Include sufficient information here for an engineer to test your PR. This may include how to test locally, in a built environment, changes to infrastructure etc.
------------------------------------------------------------------------------>

### Operations

<!-----------------------------------------------------------------------------
If your changes have a user-facing impact, describe how a non-technical QA team can functionally test your changes in a preview environment.

If they are not user-facing please describe how to test for any regressions that may occur.
------------------------------------------------------------------------------>

## Screenshots (if applicable)

Develop (right) vs. this diff (left)

- Note a ~0.8 USD withdraw was previously possible, but is now blocked, since the total outbound fee in fiat would be 4ish USD

![image.png](https://graphite-user-uploaded-assets-prod.s3.amazonaws.com/BpXudHfKodngd8bjaa8L/1ffaf055-0033-4f6c-89c4-59e6b85acd7b.png)

![image.png](https://graphite-user-uploaded-assets-prod.s3.amazonaws.com/BpXudHfKodngd8bjaa8L/c130cecd-64d8-4067-afc4-fc93f4523be9.png)

![image.png](https://graphite-user-uploaded-assets-prod.s3.amazonaws.com/BpXudHfKodngd8bjaa8L/c69eb199-95ff-46c4-b574-d19d2a78e296.png)

