### PR TITLE
perf: use a request queue and a concurrency of 2 to fetch tx history

### DIFF
--- a/package.json
+++ b/package.json
@@ -160,6 +160,7 @@
     "os-browserify": "^0.3.0",
     "p-debounce": "^4.0.0",
     "p-memoize": "^7.1.1",
+    "p-queue": "^8.0.1",
     "p-ratelimit": "^1.0.1",
     "pretty-ms": "^8.0.0",
     "qr-image": "^3.2.0",

--- a/packages/chain-adapters/package.json
+++ b/packages/chain-adapters/package.json
@@ -23,6 +23,7 @@
     "bech32": "^2.0.0",
     "coinselect": "^3.1.13",
     "multicoin-address-validator": "^0.5.12",
+    "p-queue": "^8.0.1",
     "web3-utils": "1.7.4"
   },
   "devDependencies": {

--- a/packages/chain-adapters/src/cosmossdk/CosmosSdkBaseAdapter.ts
+++ b/packages/chain-adapters/src/cosmossdk/CosmosSdkBaseAdapter.ts
@@ -4,6 +4,7 @@ import type { BIP44Params } from '@shapeshiftoss/types'
 import { KnownChainIds } from '@shapeshiftoss/types'
 import * as unchained from '@shapeshiftoss/unchained-client'
 import { bech32 } from 'bech32'
+import PQueue from 'p-queue'
 
 import type { ChainAdapter as IChainAdapter } from '../api'
 import { ErrorHandler } from '../error/ErrorHandler'
@@ -225,14 +226,19 @@ export abstract class CosmosSdkBaseAdapter<T extends CosmosSdkChainId> implement
   }
 
   async getTxHistory(input: TxHistoryInput): Promise<TxHistoryResponse> {
+    const requestQueue = input.requestQueue ?? new PQueue()
     try {
-      const data = await this.providers.http.getTxHistory({
-        pubkey: input.pubkey,
-        pageSize: input.pageSize,
-        cursor: input.cursor,
-      })
+      const data = await requestQueue.add(() =>
+        this.providers.http.getTxHistory({
+          pubkey: input.pubkey,
+          pageSize: input.pageSize,
+          cursor: input.cursor,
+        }),
+      )
 
-      const txs = await Promise.all(data.txs.map(tx => this.parseTx(tx, input.pubkey)))
+      const txs = await Promise.all(
+        data.txs.map(tx => requestQueue.add(() => this.parseTx(tx, input.pubkey))),
+      )
 
       return {
         cursor: data.cursor,

--- a/packages/chain-adapters/src/types.ts
+++ b/packages/chain-adapters/src/types.ts
@@ -8,6 +8,7 @@ import type {
 } from '@shapeshiftoss/hdwallet-core'
 import type { ChainSpecific, KnownChainIds, UtxoAccountType } from '@shapeshiftoss/types'
 import type * as unchained from '@shapeshiftoss/unchained-client'
+import type PQueue from 'p-queue'
 
 import * as cosmossdk from './cosmossdk/types'
 import * as evm from './evm/types'
@@ -242,6 +243,7 @@ export interface TxHistoryInput {
   readonly cursor?: string
   readonly pubkey: string
   readonly pageSize?: number
+  readonly requestQueue?: PQueue
 }
 
 export type GetAddressInputBase = {

--- a/packages/chain-adapters/src/utxo/UtxoBaseAdapter.ts
+++ b/packages/chain-adapters/src/utxo/UtxoBaseAdapter.ts
@@ -14,6 +14,7 @@ import type { BIP44Params } from '@shapeshiftoss/types'
 import { KnownChainIds, UtxoAccountType } from '@shapeshiftoss/types'
 import type * as unchained from '@shapeshiftoss/unchained-client'
 import WAValidator from 'multicoin-address-validator'
+import PQueue from 'p-queue'
 
 import type { ChainAdapter as IChainAdapter } from '../api'
 import { ErrorHandler } from '../error/ErrorHandler'
@@ -453,17 +454,23 @@ export abstract class UtxoBaseAdapter<T extends UtxoChainId> implements IChainAd
   }
 
   async getTxHistory(input: TxHistoryInput): Promise<TxHistoryResponse> {
+    const requestQueue = input.requestQueue ?? new PQueue()
+
     if (!this.accountAddresses[input.pubkey]) {
-      await this.getAccount(input.pubkey)
+      await requestQueue.add(() => this.getAccount(input.pubkey))
     }
 
-    const data = await this.providers.http.getTxHistory({
-      pubkey: input.pubkey,
-      pageSize: input.pageSize,
-      cursor: input.cursor,
-    })
+    const data = await requestQueue.add(() =>
+      this.providers.http.getTxHistory({
+        pubkey: input.pubkey,
+        pageSize: input.pageSize,
+        cursor: input.cursor,
+      }),
+    )
 
-    const transactions = await Promise.all(data.txs.map(tx => this.parseTx(tx, input.pubkey)))
+    const transactions = await Promise.all(
+      data.txs.map(tx => requestQueue.add(() => this.parseTx(tx, input.pubkey))),
+    )
 
     return {
       cursor: data.cursor ?? '',

--- a/src/state/slices/txHistorySlice/txHistorySlice.ts
+++ b/src/state/slices/txHistorySlice/txHistorySlice.ts
@@ -188,7 +188,7 @@ export const txHistoryApi = createApi({
   endpoints: build => ({
     getAllTxHistory: build.query<null, AccountId[]>({
       queryFn: async (accountIds, { dispatch, getState }) => {
-        const requestQueue = new PQueue({ concurrency: 1 })
+        const requestQueue = new PQueue({ concurrency: 2 })
         const results: TransactionsByAccountId = {}
         await Promise.all(
           accountIds.map(async accountId => {

--- a/src/state/slices/txHistorySlice/txHistorySlice.ts
+++ b/src/state/slices/txHistorySlice/txHistorySlice.ts
@@ -188,7 +188,7 @@ export const txHistoryApi = createApi({
   endpoints: build => ({
     getAllTxHistory: build.query<null, AccountId[]>({
       queryFn: async (accountIds, { dispatch, getState }) => {
-        const queue = new PQueue({ concurrency: 1 })
+        const requestQueue = new PQueue({ concurrency: 1 })
         const results: TransactionsByAccountId = {}
         await Promise.all(
           accountIds.map(async accountId => {
@@ -216,13 +216,12 @@ export const txHistoryApi = createApi({
                 })()
 
                 const requestCursor = currentCursor
-                const { cursor, transactions } = await queue.add(() =>
-                  adapter.getTxHistory({
-                    cursor: requestCursor,
-                    pubkey,
-                    pageSize,
-                  }),
-                )
+                const { cursor, transactions } = await adapter.getTxHistory({
+                  cursor: requestCursor,
+                  pubkey,
+                  pageSize,
+                  requestQueue,
+                })
 
                 const state = getState() as State
                 const txsById = state.txHistory.txs.byId

--- a/yarn.lock
+++ b/yarn.lock
@@ -10159,6 +10159,7 @@ __metadata:
     os-browserify: ^0.3.0
     p-debounce: ^4.0.0
     p-memoize: ^7.1.1
+    p-queue: ^8.0.1
     p-ratelimit: ^1.0.1
     patch-package: ^8.0.0
     path-browserify: ^1.0.1

--- a/yarn.lock
+++ b/yarn.lock
@@ -9526,6 +9526,7 @@ __metadata:
     bech32: ^2.0.0
     coinselect: ^3.1.13
     multicoin-address-validator: ^0.5.12
+    p-queue: ^8.0.1
     web3-utils: 1.7.4
   languageName: unknown
   linkType: soft


### PR DESCRIPTION
## Description

Improves boot performance of the application by limiting network concurrency of tx history to 2.

Context here
https://www.notion.so/shapeshift/Transaction-History-d656eb2ea4e244699fecb4c68eebfa45

## Pull Request Type

- [ ] :bug: Bug fix (Non-breaking Change: Fixes an issue)
- [x] :hammer_and_wrench: Chore (Non-breaking Change: Doc updates, pkg upgrades, typos, etc..)
- [ ] :nail_care: New Feature (Breaking/Non-breaking Change)

## Issue (if applicable)

<!-----------------------------------------------------------------------------
If applicable, please link to the github issue and put `closes #XXXX` in your comment to auto-close the issue that your PR fixes.
------------------------------------------------------------------------------>

Relates to #5676

## Risk
> High Risk PRs Require 2 approvals

Low risk, this only changes orchestration of tx history requests without logical changes.

> What protocols, transaction types or contract interactions might be affected by this PR?

## Testing

* Check tx history loads on a fresh connect (it will be slightly slower)

### Engineering

<!-----------------------------------------------------------------------------
Include sufficient information here for an engineer to test your PR. This may include how to test locally, in a built environment, changes to infrastructure etc.
------------------------------------------------------------------------------>

### Operations

<!-----------------------------------------------------------------------------
If your changes have a user-facing impact, describe how a non-technical QA team can functionally test your changes in a preview environment.

If they are not user-facing please describe how to test for any regressions that may occur.
------------------------------------------------------------------------------>

## Screenshots (if applicable)

TX history loaded after cache clear
![image](https://github.com/shapeshift/web/assets/125113430/f9cbeb48-dc12-4d63-b0a4-665ffc327f73)

