### PR TITLE
fix: clear previous wallet data on kk passphrase entry

### DIFF
--- a/src/context/WalletProvider/KeepKey/components/Passphrase.tsx
+++ b/src/context/WalletProvider/KeepKey/components/Passphrase.tsx
@@ -11,6 +11,9 @@ import { useCallback, useRef, useState } from 'react'
 import { Text } from 'components/Text'
 import { WalletActions } from 'context/WalletProvider/actions'
 import { useWallet } from 'hooks/useWallet/useWallet'
+import { selectWalletId } from 'state/slices/common-selectors'
+import { portfolio } from 'state/slices/portfolioSlice/portfolioSlice'
+import { useAppDispatch, useAppSelector } from 'state/store'
 
 export const KeepKeyPassphrase = () => {
   const [error, setError] = useState<string | null>(null)
@@ -20,23 +23,28 @@ export const KeepKeyPassphrase = () => {
     dispatch,
   } = useWallet()
   const wallet = keyring.get(deviceId)
+  const walletId = useAppSelector(selectWalletId)
+  const appDispatch = useAppDispatch()
 
   const inputRef = useRef<HTMLInputElement | null>(null)
 
   const handleSubmit = useCallback(async () => {
+    if (!wallet || !walletId) return
     setLoading(true)
     const passphrase = inputRef.current?.value
     try {
       // The event handler will pick up the response to the sendPin request
       await wallet?.sendPassphrase(passphrase ?? '')
       setError(null)
+      // Clear all previous wallet meta
+      appDispatch(portfolio.actions.clearWalletMetadata(walletId))
       dispatch({ type: WalletActions.SET_WALLET_MODAL, payload: false })
     } catch (e) {
       setError('modals.keepKey.passphrase.error')
     } finally {
       setLoading(false)
     }
-  }, [dispatch, wallet])
+  }, [appDispatch, dispatch, wallet, walletId])
 
   return (
     <>


### PR DESCRIPTION
## Description

As a follow-up to https://github.com/shapeshift/web/pull/6482, this PR makes KeepKey passphrases _actually_ actually work.

Currently we'll correctly reset and show the correct accounts/balances when initially enabling and disabling the passphrase functionality on a KeepKey, but subsequent connections will always initially show the empty passphrase state after a passphrase is entered.

## Pull Request Type

- [x] :bug: Bug fix (Non-breaking Change: Fixes an issue)
- [ ] :hammer_and_wrench: Chore (Non-breaking Change: Doc updates, pkg upgrades, typos, etc..)
- [ ] :nail_care: New Feature (Breaking/Non-breaking Change)

## Issue (if applicable)

Closes https://github.com/shapeshift/web/pull/6482

## Risk
> High Risk PRs Require 2 approvals

Low

> What protocols, transaction types or contract interactions might be affected by this PR?

Connectivity and accounts relating to KeepKey's with passphrase enabled.

## Testing

Connect a KeepKey with a passphrase enabled, and enter a passphrase. Ensure that we load and show balances and accounts corresponding to the passphrase, and do not show any stale data.

This includes accounts, balances, and generating a receive address.

### Engineering

☝️

### Operations

☝️

## Screenshots (if applicable)

N/A