### PR TITLE
fix: consistent total FOX discounts model fee

### DIFF
--- a/src/components/FeeModal/FeeBreakdown.tsx
+++ b/src/components/FeeModal/FeeBreakdown.tsx
@@ -24,30 +24,30 @@ const AmountOrFree = ({ isFree, amountUSD }: { isFree: boolean; amountUSD: strin
 type FeeBreakdownProps = {
   feeModel: ParameterModel
   inputAmountUsd: string | undefined
-  affiliateFeeAmountUsd: string
 }
 
-export const FeeBreakdown = ({
-  feeModel,
-  inputAmountUsd,
-  affiliateFeeAmountUsd,
-}: FeeBreakdownProps) => {
+export const FeeBreakdown = ({ feeModel, inputAmountUsd }: FeeBreakdownProps) => {
   const translate = useTranslate()
   const feature = translate(FEE_MODEL_TO_FEATURE_NAME[feeModel])
   const featureFeeTranslation = translate('foxDiscounts.featureFee', { feature })
   const votingPowerParams: { feeModel: ParameterModel } = useMemo(() => ({ feeModel }), [feeModel])
   const votingPower = useAppSelector(state => selectVotingPower(state, votingPowerParams))
-  const { foxDiscountUsd, foxDiscountPercent, feeUsdBeforeDiscount, feeBpsBeforeDiscount } =
-    calculateFees({
-      tradeAmountUsd: bnOrZero(inputAmountUsd),
-      foxHeld: votingPower !== undefined ? bn(votingPower) : undefined,
-      feeModel,
-    })
+  const {
+    feeUsd: affiliateFeeAmountUsd,
+    foxDiscountUsd,
+    foxDiscountPercent,
+    feeUsdBeforeDiscount,
+    feeBpsBeforeDiscount,
+  } = calculateFees({
+    tradeAmountUsd: bnOrZero(inputAmountUsd),
+    foxHeld: votingPower !== undefined ? bn(votingPower) : undefined,
+    feeModel,
+  })
 
   const isFree = useMemo(() => bnOrZero(affiliateFeeAmountUsd).eq(0), [affiliateFeeAmountUsd])
 
   const isFeeUnsupported = useMemo(() => {
-    return affiliateFeeAmountUsd === '0' && bnOrZero(feeUsdBeforeDiscount).gt(0)
+    return affiliateFeeAmountUsd.isZero() && bnOrZero(feeUsdBeforeDiscount).gt(0)
   }, [affiliateFeeAmountUsd, feeUsdBeforeDiscount])
 
   const feeDiscountUsd = useMemo(() => {
@@ -105,7 +105,7 @@ export const FeeBreakdown = ({
           {translate('foxDiscounts.totalFeatureFee', { feature })}
         </Row.Label>
         <Row.Value fontSize='lg'>
-          <AmountOrFree isFree={isFree} amountUSD={affiliateFeeAmountUsd} />
+          <AmountOrFree isFree={isFree} amountUSD={affiliateFeeAmountUsd.toString()} />
         </Row.Value>
       </Row>
     </Stack>

--- a/src/components/FeeModal/FeeModal.tsx
+++ b/src/components/FeeModal/FeeModal.tsx
@@ -16,7 +16,6 @@ import type { ParameterModel } from 'lib/fees/parameters/types'
 import { FeeBreakdown } from './FeeBreakdown'
 
 export type FeeModalProps = {
-  affiliateFeeAmountUsd: string
   inputAmountUsd: string | undefined
   isOpen: boolean
   onClose: () => void
@@ -24,7 +23,6 @@ export type FeeModalProps = {
 }
 
 export const FeeModal = ({
-  affiliateFeeAmountUsd,
   inputAmountUsd,
   isOpen,
   onClose: handleClose,
@@ -44,11 +42,7 @@ export const FeeModal = ({
           </TabList>
           <TabPanels>
             <TabPanel p={0}>
-              <FeeBreakdown
-                feeModel={feeModel}
-                affiliateFeeAmountUsd={affiliateFeeAmountUsd}
-                inputAmountUsd={inputAmountUsd}
-              />
+              <FeeBreakdown feeModel={feeModel} inputAmountUsd={inputAmountUsd} />
             </TabPanel>
             <TabPanel px={0} py={0}>
               <FeeExplainer

--- a/src/components/MultiHopTrade/components/MultiHopTradeConfirm/components/FeeStep.tsx
+++ b/src/components/MultiHopTrade/components/MultiHopTradeConfirm/components/FeeStep.tsx
@@ -82,7 +82,6 @@ export const FeeStep = ({ isLastStep }: FeeStepProps) => {
       <FeeModal
         isOpen={showFeeModal}
         onClose={handleCloseFeeModal}
-        affiliateFeeAmountUsd={amountAfterDiscountUsd}
         inputAmountUsd={inputAmountUsd}
         feeModel='SWAPPER'
       />

--- a/src/components/MultiHopTrade/components/TradeInput/components/ReceiveSummary.tsx
+++ b/src/components/MultiHopTrade/components/TradeInput/components/ReceiveSummary.tsx
@@ -24,7 +24,6 @@ import { selectInputSellAmountUsd } from 'state/slices/selectors'
 import {
   selectActiveQuoteAffiliateBps,
   selectQuoteAffiliateFeeUserCurrency,
-  selectQuoteFeeAmountUsd,
 } from 'state/slices/tradeQuoteSlice/selectors'
 import { useAppSelector } from 'state/store'
 
@@ -76,7 +75,6 @@ export const ReceiveSummary: FC<ReceiveSummaryProps> = memo(
     // use the fee data from the actual quote in case it varies from the theoretical calculation
     const affiliateBps = useAppSelector(selectActiveQuoteAffiliateBps)
     const amountAfterDiscountUserCurrency = useAppSelector(selectQuoteAffiliateFeeUserCurrency)
-    const amountAfterDiscountUsd = useAppSelector(selectQuoteFeeAmountUsd)
 
     const parseAmountDisplayMeta = useCallback((items: AmountDisplayMeta[]) => {
       return items
@@ -194,7 +192,6 @@ export const ReceiveSummary: FC<ReceiveSummaryProps> = memo(
         <FeeModal
           isOpen={showFeeModal}
           onClose={toggleFeeModal}
-          affiliateFeeAmountUsd={amountAfterDiscountUsd}
           inputAmountUsd={inputAmountUsd}
           feeModel='SWAPPER'
         />

--- a/src/pages/ThorChainLP/components/AddLiquidity/AddLiquidityInput.tsx
+++ b/src/pages/ThorChainLP/components/AddLiquidity/AddLiquidityInput.tsx
@@ -1504,7 +1504,6 @@ export const AddLiquidityInput: React.FC<AddLiquidityInputProps> = ({
         </Button>
       </CardFooter>
       <FeeModal
-        affiliateFeeAmountUsd={confirmedQuote?.feeAmountUSD ?? '0'}
         isOpen={showFeeModal}
         onClose={toggleFeeModal}
         inputAmountUsd={confirmedQuote?.totalAmountUsd}


### PR DESCRIPTION
## Description

Does what it says on the box - consumes the `feeUsd` property holistically and removes dupes, which were resulting in a discrepancy between the total trade fee in the fee modal.

## Pull Request Type

- [x] :bug: Bug fix (Non-breaking Change: Fixes an issue)
- [ ] :hammer_and_wrench: Chore (Non-breaking Change: Doc updates, pkg upgrades, typos, etc..)
- [ ] :nail_care: New Feature (Breaking/Non-breaking Change)

## Issue (if applicable)

<!-----------------------------------------------------------------------------
If applicable, please link to the github issue and put `closes #XXXX` in your comment to auto-close the issue that your PR fixes.
------------------------------------------------------------------------------>

closes https://github.com/shapeshift/web/issues/6429

## Risk
> High Risk PRs Require 2 approvals

<!-----------------------------------------------------------------------------
Outline the scope of your changes and the risk associated with them. You must use your discretion as an engineer to determine the potential impact of your changes.

WARNING: If your PR introduces a new on-chain transaction or modifies an existing one, please add the "High-Risk" label to this PR and ask for 2 reviewers to approve it before merging.

E.g. an upgrade to `hdwallet` or core state management would be considered higher risk, and might require a full regression test. UI or isolated view changes, or something behind a feature flag may have near zero risk. Small bug fixes might require testing isolated to the specific fix.
------------------------------------------------------------------------------>

None

> What protocols, transaction types or contract interactions might be affected by this PR?

## Testing

<!-----------------------------------------------------------------------------
We treat every PR to be merged with the same scrutiny as if we were merging directly to production.

Your PR will not be merged if you do not complete the sections below for our engineering and operations teams to test.
------------------------------------------------------------------------------>

- Total trade fee is the same in both tabs of the fee modal

### Engineering

<!-----------------------------------------------------------------------------
Include sufficient information here for an engineer to test your PR. This may include how to test locally, in a built environment, changes to infrastructure etc.
------------------------------------------------------------------------------>

- ☝🏽 

### Operations

<!-----------------------------------------------------------------------------
If your changes have a user-facing impact, describe how a non-technical QA team can functionally test your changes in a preview environment.

If they are not user-facing please describe how to test for any regressions that may occur.
------------------------------------------------------------------------------>

- ☝🏽 

## Screenshots (if applicable)

Develop (right) vs this diff (left)

<img width="1401" alt="Screenshot 2024-03-19 at 15 46 08" src="https://github.com/shapeshift/web/assets/17035424/8cd50723-889e-41f8-b4c3-3f4f1db4240f">
<img width="1394" alt="Screenshot 2024-03-19 at 15 46 19" src="https://github.com/shapeshift/web/assets/17035424/2c8e363f-b31a-48a3-bb1d-cf175fde4e58">

 
<img width="1415" alt="Screenshot 2024-03-19 at 15 46 52" src="https://github.com/shapeshift/web/assets/17035424/02be410a-db97-400d-af8e-6b1432aaac34">
<img width="1394" alt="Screenshot 2024-03-19 at 15 47 03" src="https://github.com/shapeshift/web/assets/17035424/a7fda63f-1e28-45ba-add0-1c098dfeb6e4">
