### PR TITLE
chore: release v1.554.0

### DIFF
--- a/package.json
+++ b/package.json
@@ -160,6 +160,7 @@
     "os-browserify": "^0.3.0",
     "p-debounce": "^4.0.0",
     "p-memoize": "^7.1.1",
+    "p-queue": "^8.0.1",
     "p-ratelimit": "^1.0.1",
     "pretty-ms": "^8.0.0",
     "qr-image": "^3.2.0",

--- a/packages/chain-adapters/package.json
+++ b/packages/chain-adapters/package.json
@@ -23,6 +23,7 @@
     "bech32": "^2.0.0",
     "coinselect": "^3.1.13",
     "multicoin-address-validator": "^0.5.12",
+    "p-queue": "^8.0.1",
     "web3-utils": "1.7.4"
   },
   "devDependencies": {

--- a/packages/chain-adapters/src/cosmossdk/CosmosSdkBaseAdapter.ts
+++ b/packages/chain-adapters/src/cosmossdk/CosmosSdkBaseAdapter.ts
@@ -4,6 +4,7 @@ import type { BIP44Params } from '@shapeshiftoss/types'
 import { KnownChainIds } from '@shapeshiftoss/types'
 import * as unchained from '@shapeshiftoss/unchained-client'
 import { bech32 } from 'bech32'
+import PQueue from 'p-queue'
 
 import type { ChainAdapter as IChainAdapter } from '../api'
 import { ErrorHandler } from '../error/ErrorHandler'
@@ -225,14 +226,19 @@ export abstract class CosmosSdkBaseAdapter<T extends CosmosSdkChainId> implement
   }
 
   async getTxHistory(input: TxHistoryInput): Promise<TxHistoryResponse> {
+    const requestQueue = input.requestQueue ?? new PQueue()
     try {
-      const data = await this.providers.http.getTxHistory({
-        pubkey: input.pubkey,
-        pageSize: input.pageSize,
-        cursor: input.cursor,
-      })
+      const data = await requestQueue.add(() =>
+        this.providers.http.getTxHistory({
+          pubkey: input.pubkey,
+          pageSize: input.pageSize,
+          cursor: input.cursor,
+        }),
+      )
 
-      const txs = await Promise.all(data.txs.map(tx => this.parseTx(tx, input.pubkey)))
+      const txs = await Promise.all(
+        data.txs.map(tx => requestQueue.add(() => this.parseTx(tx, input.pubkey))),
+      )
 
       return {
         cursor: data.cursor,

--- a/packages/chain-adapters/src/types.ts
+++ b/packages/chain-adapters/src/types.ts
@@ -8,6 +8,7 @@ import type {
 } from '@shapeshiftoss/hdwallet-core'
 import type { ChainSpecific, KnownChainIds, UtxoAccountType } from '@shapeshiftoss/types'
 import type * as unchained from '@shapeshiftoss/unchained-client'
+import type PQueue from 'p-queue'
 
 import * as cosmossdk from './cosmossdk/types'
 import * as evm from './evm/types'
@@ -242,6 +243,7 @@ export interface TxHistoryInput {
   readonly cursor?: string
   readonly pubkey: string
   readonly pageSize?: number
+  readonly requestQueue?: PQueue
 }
 
 export type GetAddressInputBase = {

--- a/packages/chain-adapters/src/utxo/UtxoBaseAdapter.ts
+++ b/packages/chain-adapters/src/utxo/UtxoBaseAdapter.ts
@@ -14,6 +14,7 @@ import type { BIP44Params } from '@shapeshiftoss/types'
 import { KnownChainIds, UtxoAccountType } from '@shapeshiftoss/types'
 import type * as unchained from '@shapeshiftoss/unchained-client'
 import WAValidator from 'multicoin-address-validator'
+import PQueue from 'p-queue'
 
 import type { ChainAdapter as IChainAdapter } from '../api'
 import { ErrorHandler } from '../error/ErrorHandler'
@@ -453,17 +454,23 @@ export abstract class UtxoBaseAdapter<T extends UtxoChainId> implements IChainAd
   }
 
   async getTxHistory(input: TxHistoryInput): Promise<TxHistoryResponse> {
+    const requestQueue = input.requestQueue ?? new PQueue()
+
     if (!this.accountAddresses[input.pubkey]) {
-      await this.getAccount(input.pubkey)
+      await requestQueue.add(() => this.getAccount(input.pubkey))
     }
 
-    const data = await this.providers.http.getTxHistory({
-      pubkey: input.pubkey,
-      pageSize: input.pageSize,
-      cursor: input.cursor,
-    })
+    const data = await requestQueue.add(() =>
+      this.providers.http.getTxHistory({
+        pubkey: input.pubkey,
+        pageSize: input.pageSize,
+        cursor: input.cursor,
+      }),
+    )
 
-    const transactions = await Promise.all(data.txs.map(tx => this.parseTx(tx, input.pubkey)))
+    const transactions = await Promise.all(
+      data.txs.map(tx => requestQueue.add(() => this.parseTx(tx, input.pubkey))),
+    )
 
     return {
       cursor: data.cursor ?? '',

--- a/src/assets/translations/en/main.json
+++ b/src/assets/translations/en/main.json
@@ -221,6 +221,7 @@
     "recentTransactions": {
       "recentTransactions": "Recent Transactions"
     },
+    "nfts": "NFTs",
     "tradeCard": {
       "trade": "Trade",
       "bridge": "Bridge",

--- a/src/components/FeeModal/FeeBreakdown.tsx
+++ b/src/components/FeeModal/FeeBreakdown.tsx
@@ -24,30 +24,30 @@ const AmountOrFree = ({ isFree, amountUSD }: { isFree: boolean; amountUSD: strin
 type FeeBreakdownProps = {
   feeModel: ParameterModel
   inputAmountUsd: string | undefined
-  affiliateFeeAmountUsd: string
 }
 
-export const FeeBreakdown = ({
-  feeModel,
-  inputAmountUsd,
-  affiliateFeeAmountUsd,
-}: FeeBreakdownProps) => {
+export const FeeBreakdown = ({ feeModel, inputAmountUsd }: FeeBreakdownProps) => {
   const translate = useTranslate()
   const feature = translate(FEE_MODEL_TO_FEATURE_NAME[feeModel])
   const featureFeeTranslation = translate('foxDiscounts.featureFee', { feature })
   const votingPowerParams: { feeModel: ParameterModel } = useMemo(() => ({ feeModel }), [feeModel])
   const votingPower = useAppSelector(state => selectVotingPower(state, votingPowerParams))
-  const { foxDiscountUsd, foxDiscountPercent, feeUsdBeforeDiscount, feeBpsBeforeDiscount } =
-    calculateFees({
-      tradeAmountUsd: bnOrZero(inputAmountUsd),
-      foxHeld: votingPower !== undefined ? bn(votingPower) : undefined,
-      feeModel,
-    })
+  const {
+    feeUsd: affiliateFeeAmountUsd,
+    foxDiscountUsd,
+    foxDiscountPercent,
+    feeUsdBeforeDiscount,
+    feeBpsBeforeDiscount,
+  } = calculateFees({
+    tradeAmountUsd: bnOrZero(inputAmountUsd),
+    foxHeld: votingPower !== undefined ? bn(votingPower) : undefined,
+    feeModel,
+  })
 
   const isFree = useMemo(() => bnOrZero(affiliateFeeAmountUsd).eq(0), [affiliateFeeAmountUsd])
 
   const isFeeUnsupported = useMemo(() => {
-    return affiliateFeeAmountUsd === '0' && bnOrZero(feeUsdBeforeDiscount).gt(0)
+    return affiliateFeeAmountUsd.isZero() && bnOrZero(feeUsdBeforeDiscount).gt(0)
   }, [affiliateFeeAmountUsd, feeUsdBeforeDiscount])
 
   const feeDiscountUsd = useMemo(() => {
@@ -105,7 +105,7 @@ export const FeeBreakdown = ({
           {translate('foxDiscounts.totalFeatureFee', { feature })}
         </Row.Label>
         <Row.Value fontSize='lg'>
-          <AmountOrFree isFree={isFree} amountUSD={affiliateFeeAmountUsd} />
+          <AmountOrFree isFree={isFree} amountUSD={affiliateFeeAmountUsd.toString()} />
         </Row.Value>
       </Row>
     </Stack>

--- a/src/components/FeeModal/FeeBreakdown.tsx
+++ b/src/components/FeeModal/FeeBreakdown.tsx
@@ -4,11 +4,11 @@ import { useTranslate } from 'react-polyglot'
 import { Amount } from 'components/Amount/Amount'
 import { Row } from 'components/Row/Row'
 import { RawText, Text } from 'components/Text'
-import { bn, bnOrZero } from 'lib/bignumber/bignumber'
-import { calculateFees } from 'lib/fees/model'
+import { bnOrZero } from 'lib/bignumber/bignumber'
 import { FEE_MODEL_TO_FEATURE_NAME } from 'lib/fees/parameters'
 import type { ParameterModel } from 'lib/fees/parameters/types'
 import { selectVotingPower } from 'state/apis/snapshot/selectors'
+import { selectCalculatedFees } from 'state/slices/tradeQuoteSlice/selectors'
 import { useAppSelector } from 'state/store'
 
 const divider = <Divider />
@@ -38,11 +38,7 @@ export const FeeBreakdown = ({ feeModel, inputAmountUsd }: FeeBreakdownProps) =>
     foxDiscountPercent,
     feeUsdBeforeDiscount,
     feeBpsBeforeDiscount,
-  } = calculateFees({
-    tradeAmountUsd: bnOrZero(inputAmountUsd),
-    foxHeld: votingPower !== undefined ? bn(votingPower) : undefined,
-    feeModel,
-  })
+  } = useAppSelector(state => selectCalculatedFees(state, { feeModel, inputAmountUsd }))
 
   const isFree = useMemo(() => bnOrZero(affiliateFeeAmountUsd).eq(0), [affiliateFeeAmountUsd])
 

--- a/src/components/FeeModal/FeeModal.tsx
+++ b/src/components/FeeModal/FeeModal.tsx
@@ -16,7 +16,6 @@ import type { ParameterModel } from 'lib/fees/parameters/types'
 import { FeeBreakdown } from './FeeBreakdown'
 
 export type FeeModalProps = {
-  affiliateFeeAmountUsd: string
   inputAmountUsd: string | undefined
   isOpen: boolean
   onClose: () => void
@@ -24,7 +23,6 @@ export type FeeModalProps = {
 }
 
 export const FeeModal = ({
-  affiliateFeeAmountUsd,
   inputAmountUsd,
   isOpen,
   onClose: handleClose,
@@ -44,11 +42,7 @@ export const FeeModal = ({
           </TabList>
           <TabPanels>
             <TabPanel p={0}>
-              <FeeBreakdown
-                feeModel={feeModel}
-                affiliateFeeAmountUsd={affiliateFeeAmountUsd}
-                inputAmountUsd={inputAmountUsd}
-              />
+              <FeeBreakdown feeModel={feeModel} inputAmountUsd={inputAmountUsd} />
             </TabPanel>
             <TabPanel px={0} py={0}>
               <FeeExplainer

--- a/src/components/Layout/Header/NavBar/KeepKey/ChangePassphrase.tsx
+++ b/src/components/Layout/Header/NavBar/KeepKey/ChangePassphrase.tsx
@@ -18,8 +18,13 @@ import type { AwaitKeepKeyProps } from 'components/Layout/Header/NavBar/KeepKey/
 import { AwaitKeepKey } from 'components/Layout/Header/NavBar/KeepKey/AwaitKeepKey'
 import { LastDeviceInteractionStatus } from 'components/Layout/Header/NavBar/KeepKey/LastDeviceInteractionStatus'
 import { SubmenuHeader } from 'components/Layout/Header/NavBar/SubmenuHeader'
+import { WalletActions } from 'context/WalletProvider/actions'
 import { useKeepKey } from 'context/WalletProvider/KeepKeyProvider'
+import { KeyManager } from 'context/WalletProvider/KeyManager'
 import { useWallet } from 'hooks/useWallet/useWallet'
+import { portfolio } from 'state/slices/portfolioSlice/portfolioSlice'
+import { selectWalletId } from 'state/slices/selectors'
+import { useAppDispatch, useAppSelector } from 'state/store'
 
 import { SubMenuBody } from '../SubMenuBody'
 import { SubMenuContainer } from '../SubMenuContainer'
@@ -31,6 +36,8 @@ const awaitKeepkeyButtonPromptTranslation: AwaitKeepKeyProps['translation'] = [
 ]
 
 export const ChangePassphrase = () => {
+  const appDispatch = useAppDispatch()
+  const walletId = useAppSelector(selectWalletId)
   const translate = useTranslate()
   const toast = useToast()
   const {
@@ -38,14 +45,19 @@ export const ChangePassphrase = () => {
     state: { hasPassphrase, keepKeyWallet },
   } = useKeepKey()
   const {
+    connect,
+    dispatch,
     state: {
       deviceState: { awaitingDeviceInteraction },
     },
   } = useWallet()
 
   const handleToggle = useCallback(async () => {
+    if (!walletId || !keepKeyWallet) return
+
     const currentValue = !!hasPassphrase
-    setHasPassphrase(!hasPassphrase)
+    const newHasPassphrase = !hasPassphrase
+    setHasPassphrase(newHasPassphrase)
     await keepKeyWallet?.applySettings({ usePassphrase: !currentValue }).catch(e => {
       console.error(e)
       toast({
@@ -55,7 +67,23 @@ export const ChangePassphrase = () => {
         isClosable: true,
       })
     })
-  }, [hasPassphrase, keepKeyWallet, setHasPassphrase, toast, translate])
+    // Clear all previous wallet meta
+    appDispatch(portfolio.actions.clearWalletMetadata(walletId))
+    // Trigger a refresh of the wallet metadata only once the settings have been applied
+    // and the previous wallet meta is gone from the store
+    dispatch({ type: WalletActions.SET_WALLET_MODAL, payload: true })
+    connect(KeyManager.KeepKey)
+  }, [
+    appDispatch,
+    connect,
+    dispatch,
+    hasPassphrase,
+    keepKeyWallet,
+    setHasPassphrase,
+    toast,
+    translate,
+    walletId,
+  ])
 
   const onCancel = useCallback(() => {
     setHasPassphrase(!hasPassphrase)

--- a/src/components/MultiHopTrade/components/MultiHopTradeConfirm/components/FeeStep.tsx
+++ b/src/components/MultiHopTrade/components/MultiHopTradeConfirm/components/FeeStep.tsx
@@ -82,7 +82,6 @@ export const FeeStep = ({ isLastStep }: FeeStepProps) => {
       <FeeModal
         isOpen={showFeeModal}
         onClose={handleCloseFeeModal}
-        affiliateFeeAmountUsd={amountAfterDiscountUsd}
         inputAmountUsd={inputAmountUsd}
         feeModel='SWAPPER'
       />

--- a/src/components/MultiHopTrade/components/MultiHopTradeConfirm/components/FeeStep.tsx
+++ b/src/components/MultiHopTrade/components/MultiHopTradeConfirm/components/FeeStep.tsx
@@ -10,7 +10,7 @@ import { bnOrZero } from 'lib/bignumber/bignumber'
 import { selectInputSellAmountUsd } from 'state/slices/selectors'
 import {
   selectActiveQuoteAffiliateBps,
-  selectQuoteFeeAmountUsd,
+  selectCalculatedFees,
 } from 'state/slices/tradeQuoteSlice/selectors'
 import { useAppSelector } from 'state/store'
 
@@ -32,7 +32,15 @@ export const FeeStep = ({ isLastStep }: FeeStepProps) => {
   const inputAmountUsd = useAppSelector(selectInputSellAmountUsd)
   // use the fee data from the actual quote in case it varies from the theoretical calculation
   const affiliateBps = useAppSelector(selectActiveQuoteAffiliateBps)
-  const amountAfterDiscountUsd = useAppSelector(selectQuoteFeeAmountUsd)
+
+  const feeModel = 'SWAPPER'
+  const calculatedFeesFilter = useMemo(
+    () => ({ feeModel, inputAmountUsd }),
+    [feeModel, inputAmountUsd],
+  )
+  const { feeUsd: amountAfterDiscountUsd } = useAppSelector(state =>
+    selectCalculatedFees(state, calculatedFeesFilter),
+  )
 
   const handleOpenFeeModal = useCallback(() => setShowFeeModal(true), [])
   const handleCloseFeeModal = useCallback(() => setShowFeeModal(false), [])
@@ -47,7 +55,7 @@ export const FeeStep = ({ isLastStep }: FeeStepProps) => {
 
   const { title, titleProps } = useMemo(() => {
     return bnOrZero(amountAfterDiscountUsd).gt(0)
-      ? { title: toFiat(amountAfterDiscountUsd) }
+      ? { title: toFiat(amountAfterDiscountUsd.toFixed()) }
       : { title: translate('trade.free'), titleProps: { color: 'text.success' } }
   }, [amountAfterDiscountUsd, toFiat, translate])
 

--- a/src/components/MultiHopTrade/components/TradeInput/TradeInput.tsx
+++ b/src/components/MultiHopTrade/components/TradeInput/TradeInput.tsx
@@ -77,6 +77,7 @@ import {
   selectBuyAmountBeforeFeesCryptoPrecision,
   selectFirstHop,
   selectIsAnyTradeQuoteLoaded,
+  selectIsTradeQuoteRequestAborted,
   selectIsUnsafeActiveQuote,
   selectTotalNetworkFeeUserCurrencyPrecision,
   selectTotalProtocolFeeByAsset,
@@ -162,6 +163,7 @@ export const TradeInput = memo(({ isCompact }: TradeInputProps) => {
   const isUnsafeQuote = useAppSelector(selectIsUnsafeActiveQuote)
   const isTradeQuoteApiQueryPending = useAppSelector(selectIsTradeQuoteApiQueryPending)
   const isAnyTradeQuoteLoaded = useAppSelector(selectIsAnyTradeQuoteLoaded)
+  const isTradeQuoteRequestAborted = useAppSelector(selectIsTradeQuoteRequestAborted)
   const hasUserEnteredAmount = useAppSelector(selectHasUserEnteredAmount)
 
   const quoteStatusTranslation = useMemo(() => {
@@ -292,7 +294,7 @@ export const TradeInput = memo(({ isCompact }: TradeInputProps) => {
 
   const isLoading = useMemo(
     () =>
-      !isAnyTradeQuoteLoaded ||
+      (!isAnyTradeQuoteLoaded && !isTradeQuoteRequestAborted) ||
       isConfirmationLoading ||
       isSupportedAssetsLoading ||
       isSellAddressByteCodeLoading ||
@@ -303,6 +305,7 @@ export const TradeInput = memo(({ isCompact }: TradeInputProps) => {
       isVotingPowerLoading,
     [
       isAnyTradeQuoteLoaded,
+      isTradeQuoteRequestAborted,
       isConfirmationLoading,
       isSupportedAssetsLoading,
       isSellAddressByteCodeLoading,

--- a/src/components/MultiHopTrade/components/TradeInput/components/ReceiveSummary.tsx
+++ b/src/components/MultiHopTrade/components/TradeInput/components/ReceiveSummary.tsx
@@ -24,7 +24,6 @@ import { selectInputSellAmountUsd } from 'state/slices/selectors'
 import {
   selectActiveQuoteAffiliateBps,
   selectQuoteAffiliateFeeUserCurrency,
-  selectQuoteFeeAmountUsd,
 } from 'state/slices/tradeQuoteSlice/selectors'
 import { useAppSelector } from 'state/store'
 
@@ -76,7 +75,6 @@ export const ReceiveSummary: FC<ReceiveSummaryProps> = memo(
     // use the fee data from the actual quote in case it varies from the theoretical calculation
     const affiliateBps = useAppSelector(selectActiveQuoteAffiliateBps)
     const amountAfterDiscountUserCurrency = useAppSelector(selectQuoteAffiliateFeeUserCurrency)
-    const amountAfterDiscountUsd = useAppSelector(selectQuoteFeeAmountUsd)
 
     const parseAmountDisplayMeta = useCallback((items: AmountDisplayMeta[]) => {
       return items
@@ -194,7 +192,6 @@ export const ReceiveSummary: FC<ReceiveSummaryProps> = memo(
         <FeeModal
           isOpen={showFeeModal}
           onClose={toggleFeeModal}
-          affiliateFeeAmountUsd={amountAfterDiscountUsd}
           inputAmountUsd={inputAmountUsd}
           feeModel='SWAPPER'
         />

--- a/src/components/MultiHopTrade/components/TradeInput/components/ReceiveSummary.tsx
+++ b/src/components/MultiHopTrade/components/TradeInput/components/ReceiveSummary.tsx
@@ -23,7 +23,7 @@ import { isSome } from 'lib/utils'
 import { selectInputSellAmountUsd } from 'state/slices/selectors'
 import {
   selectActiveQuoteAffiliateBps,
-  selectQuoteAffiliateFeeUserCurrency,
+  selectTradeQuoteAffiliateFeeAfterDiscountUserCurrency,
 } from 'state/slices/tradeQuoteSlice/selectors'
 import { useAppSelector } from 'state/store'
 
@@ -74,7 +74,9 @@ export const ReceiveSummary: FC<ReceiveSummaryProps> = memo(
     const inputAmountUsd = useAppSelector(selectInputSellAmountUsd)
     // use the fee data from the actual quote in case it varies from the theoretical calculation
     const affiliateBps = useAppSelector(selectActiveQuoteAffiliateBps)
-    const amountAfterDiscountUserCurrency = useAppSelector(selectQuoteAffiliateFeeUserCurrency)
+    const affiliateFeeAfterDiscountUserCurrency = useAppSelector(
+      selectTradeQuoteAffiliateFeeAfterDiscountUserCurrency,
+    )
 
     const parseAmountDisplayMeta = useCallback((items: AmountDisplayMeta[]) => {
       return items
@@ -168,15 +170,16 @@ export const ReceiveSummary: FC<ReceiveSummaryProps> = memo(
           <Row isLoading={isLoading}>
             <Row.Label display='flex'>
               <Text translation={tradeFeeSourceTranslation} />
-              {amountAfterDiscountUserCurrency !== '0' && (
+              {affiliateFeeAfterDiscountUserCurrency !== '0' && (
                 <RawText>&nbsp;{`(${affiliateBps} bps)`}</RawText>
               )}
             </Row.Label>
             <Row.Value onClick={toggleFeeModal} _hover={shapeShiftFeeModalRowHover}>
               <Flex alignItems='center' gap={2}>
-                {amountAfterDiscountUserCurrency !== '0' ? (
+                {!!affiliateFeeAfterDiscountUserCurrency &&
+                affiliateFeeAfterDiscountUserCurrency !== '0' ? (
                   <>
-                    <Amount.Fiat value={amountAfterDiscountUserCurrency} />
+                    <Amount.Fiat value={affiliateFeeAfterDiscountUserCurrency} />
                     <QuestionIcon />
                   </>
                 ) : (

--- a/src/components/MultiHopTrade/helpers.ts
+++ b/src/components/MultiHopTrade/helpers.ts
@@ -7,11 +7,11 @@ import {
   selectBuyAmountBeforeFeesCryptoPrecision,
   selectFirstHopSellAsset,
   selectLastHopBuyAsset,
-  selectQuoteAffiliateFeeUserCurrency,
-  selectQuoteFeeAmountUsd,
   selectQuoteSellAmountBeforeFeesCryptoPrecision,
   selectQuoteSellAmountUsd,
   selectQuoteSellAmountUserCurrency,
+  selectTradeQuoteAffiliateFeeAfterDiscountUsd,
+  selectTradeQuoteAffiliateFeeAfterDiscountUserCurrency,
 } from 'state/slices/tradeQuoteSlice/selectors'
 import { store } from 'state/store'
 
@@ -28,8 +28,8 @@ export const getMixpanelEventData = () => {
   if (!buyAsset?.precision) return
 
   const assets = selectAssets(state)
-  const shapeShiftFeeUserCurrency = selectQuoteAffiliateFeeUserCurrency(state)
-  const shapeshiftFeeUsd = selectQuoteFeeAmountUsd(state)
+  const shapeShiftFeeUserCurrency = selectTradeQuoteAffiliateFeeAfterDiscountUserCurrency(state)
+  const shapeshiftFeeUsd = selectTradeQuoteAffiliateFeeAfterDiscountUsd(state)
   const sellAmountBeforeFeesUsd = selectQuoteSellAmountUsd(state)
   const sellAmountBeforeFeesUserCurrency = selectQuoteSellAmountUserCurrency(state)
   const buyAmountBeforeFeesCryptoPrecision = selectBuyAmountBeforeFeesCryptoPrecision(state)

--- a/src/components/Nfts/NftTable.tsx
+++ b/src/components/Nfts/NftTable.tsx
@@ -3,7 +3,9 @@ import { Box, Flex, SimpleGrid } from '@chakra-ui/react'
 import type { ChainId } from '@shapeshiftoss/caip'
 import { matchSorter } from 'match-sorter'
 import { memo, useCallback, useMemo, useState } from 'react'
+import { useTranslate } from 'react-polyglot'
 import { NarwhalIcon } from 'components/Icons/Narwhal'
+import { SEO } from 'components/Layout/Seo'
 import { ResultsEmpty } from 'components/ResultsEmpty'
 import { GlobalFilter } from 'components/StakingVaults/GlobalFilter'
 import { SearchEmpty } from 'components/StakingVaults/SearchEmpty'
@@ -32,6 +34,7 @@ const NftGrid: React.FC<SimpleGridProps> = props => (
 const narwalIcon = <NarwhalIcon color='pink.200' />
 
 export const NftTable = memo(() => {
+  const translate = useTranslate()
   const [searchQuery, setSearchQuery] = useState('')
 
   const [networkFilters, setNetworkFilters] = useState<ChainId[]>([])
@@ -107,6 +110,7 @@ export const NftTable = memo(() => {
 
   return (
     <>
+      <SEO title={translate('dashboard.nfts')} />
       <Box mb={4} px={boxPaddingX}>
         <Flex gap={2}>
           <NftNetworkFilter

--- a/src/context/WalletProvider/KeepKey/components/Passphrase.tsx
+++ b/src/context/WalletProvider/KeepKey/components/Passphrase.tsx
@@ -11,6 +11,9 @@ import { useCallback, useRef, useState } from 'react'
 import { Text } from 'components/Text'
 import { WalletActions } from 'context/WalletProvider/actions'
 import { useWallet } from 'hooks/useWallet/useWallet'
+import { selectWalletId } from 'state/slices/common-selectors'
+import { portfolio } from 'state/slices/portfolioSlice/portfolioSlice'
+import { useAppDispatch, useAppSelector } from 'state/store'
 
 export const KeepKeyPassphrase = () => {
   const [error, setError] = useState<string | null>(null)
@@ -20,23 +23,28 @@ export const KeepKeyPassphrase = () => {
     dispatch,
   } = useWallet()
   const wallet = keyring.get(deviceId)
+  const walletId = useAppSelector(selectWalletId)
+  const appDispatch = useAppDispatch()
 
   const inputRef = useRef<HTMLInputElement | null>(null)
 
   const handleSubmit = useCallback(async () => {
+    if (!wallet || !walletId) return
     setLoading(true)
     const passphrase = inputRef.current?.value
     try {
       // The event handler will pick up the response to the sendPin request
       await wallet?.sendPassphrase(passphrase ?? '')
       setError(null)
+      // Clear all previous wallet meta
+      appDispatch(portfolio.actions.clearWalletMetadata(walletId))
       dispatch({ type: WalletActions.SET_WALLET_MODAL, payload: false })
     } catch (e) {
       setError('modals.keepKey.passphrase.error')
     } finally {
       setLoading(false)
     }
-  }, [dispatch, wallet])
+  }, [appDispatch, dispatch, wallet, walletId])
 
   return (
     <>

--- a/src/lib/fees/model.ts
+++ b/src/lib/fees/model.ts
@@ -21,7 +21,7 @@ type CalculateFeeBpsArgs = {
  * @property {BigNumber} feeUsdBeforeDiscount - The gross USD value of the fee (i.e., excluding the fox discount).
  * @property {BigNumber} feeBpsBeforeDiscount - The gross fee bps (i.e., excluding the fox discount).
  */
-type CalculateFeeBpsReturn = {
+export type CalculateFeeBpsReturn = {
   feeBps: BigNumber
   feeBpsFloat: BigNumber
   feeUsd: BigNumber

--- a/src/pages/Dashboard/EarnDashboard.tsx
+++ b/src/pages/Dashboard/EarnDashboard.tsx
@@ -3,6 +3,7 @@ import { Button, Flex, Heading } from '@chakra-ui/react'
 import { memo } from 'react'
 import { useTranslate } from 'react-polyglot'
 import { Link as NavLink } from 'react-router-dom'
+import { SEO } from 'components/Layout/Seo'
 import { DeFiEarn } from 'components/StakingVaults/DeFiEarn'
 import { RawText } from 'components/Text'
 
@@ -15,6 +16,7 @@ const EarnHeader = () => {
 
   return (
     <Flex alignItems={alignItems} px={padding} flexWrap='wrap'>
+      <SEO title={translate('navBar.defi')} />
       <Flex width='full' justifyContent='space-between' alignItems='center'>
         <Heading fontSize='xl'>{translate('defi.myPositions')}</Heading>
         <Button

--- a/src/pages/Dashboard/RewardsDashboard.tsx
+++ b/src/pages/Dashboard/RewardsDashboard.tsx
@@ -3,6 +3,7 @@ import { Button, Flex, Heading } from '@chakra-ui/react'
 import { memo } from 'react'
 import { useTranslate } from 'react-polyglot'
 import { Link as NavLink } from 'react-router-dom'
+import { SEO } from 'components/Layout/Seo'
 import { DeFiEarn } from 'components/StakingVaults/DeFiEarn'
 import { RawText } from 'components/Text'
 
@@ -13,22 +14,25 @@ const arrowForwardIcon = <ArrowForwardIcon />
 const RewardsHeader = () => {
   const translate = useTranslate()
   return (
-    <Flex alignItems={alignItems} px={padding} flexWrap='wrap'>
-      <Flex width='full' justifyContent='space-between' alignItems='center'>
-        <Heading fontSize='xl'>{translate('defi.myRewards')}</Heading>
-        <Button
-          colorScheme='purple'
-          variant='ghost'
-          as={NavLink}
-          to='/earn'
-          size='sm'
-          rightIcon={arrowForwardIcon}
-        >
-          {translate('defi.viewAllPositions')}
-        </Button>
+    <>
+      <SEO title={translate('navBar.rewards')} />
+      <Flex alignItems={alignItems} px={padding} flexWrap='wrap'>
+        <Flex width='full' justifyContent='space-between' alignItems='center'>
+          <Heading fontSize='xl'>{translate('defi.myRewards')}</Heading>
+          <Button
+            colorScheme='purple'
+            variant='ghost'
+            as={NavLink}
+            to='/earn'
+            size='sm'
+            rightIcon={arrowForwardIcon}
+          >
+            {translate('defi.viewAllPositions')}
+          </Button>
+        </Flex>
+        <RawText color='text.subtle'>{translate('defi.myRewardsBody')}</RawText>
       </Flex>
-      <RawText color='text.subtle'>{translate('defi.myRewardsBody')}</RawText>
-    </Flex>
+    </>
   )
 }
 

--- a/src/pages/Dashboard/components/DashboardHeader/DashboardHeader.tsx
+++ b/src/pages/Dashboard/components/DashboardHeader/DashboardHeader.tsx
@@ -9,7 +9,7 @@ import { useFeatureFlag } from 'hooks/useFeatureFlag/useFeatureFlag'
 import { useProfileAvatar } from 'hooks/useProfileAvatar/useProfileAvatar'
 import {
   selectClaimableRewards,
-  selectPortfolioTotalUserCurrencyBalanceExcludeEarnDupes,
+  selectTotalPortfolioBalanceIncludeStakingUserCurrency,
 } from 'state/slices/selectors'
 import { useAppSelector } from 'state/store'
 
@@ -51,7 +51,7 @@ export const DashboardHeader = memo(({ tabComponent }: { tabComponent?: React.Re
     selectClaimableRewards(state, claimableRewardsUserCurrencyBalanceFilter),
   )
   const portfolioTotalUserCurrencyBalance = useAppSelector(
-    selectPortfolioTotalUserCurrencyBalanceExcludeEarnDupes,
+    selectTotalPortfolioBalanceIncludeStakingUserCurrency,
   )
   const borderColor = useColorModeValue('gray.100', 'whiteAlpha.200')
 

--- a/src/pages/Dashboard/components/DashboardHeader/DashboardHeader.tsx
+++ b/src/pages/Dashboard/components/DashboardHeader/DashboardHeader.tsx
@@ -88,7 +88,7 @@ export const DashboardHeader = memo(({ tabComponent }: { tabComponent?: React.Re
         rightElement: <Amount.Fiat value={claimableRewardsUserCurrencyBalance} />,
       },
       {
-        label: 'NFTs',
+        label: 'dashboard.nfts',
         path: '/wallet/nfts',
         color: 'pink',
         rightElement: translate('common.new'),

--- a/src/pages/Lending/AvailablePools.tsx
+++ b/src/pages/Lending/AvailablePools.tsx
@@ -9,6 +9,7 @@ import { useHistory, useRouteMatch } from 'react-router'
 import { Amount } from 'components/Amount/Amount'
 import { HelperTooltip } from 'components/HelperTooltip/HelperTooltip'
 import { Main } from 'components/Layout/Main'
+import { SEO } from 'components/Layout/Seo'
 import { AssetCell } from 'components/StakingVaults/Cells'
 import { RawText, Text } from 'components/Text'
 
@@ -129,6 +130,7 @@ export const AvailablePools = () => {
 
   return (
     <Main headerComponent={headerComponent}>
+      <SEO title={translate('navBar.lending')} />
       <Stack>
         <SimpleGrid
           gridTemplateColumns={lendingRowGrid}

--- a/src/pages/Lending/YourLoans.tsx
+++ b/src/pages/Lending/YourLoans.tsx
@@ -8,6 +8,7 @@ import { generatePath, useHistory } from 'react-router'
 import { Amount } from 'components/Amount/Amount'
 import { HelperTooltip } from 'components/HelperTooltip/HelperTooltip'
 import { Main } from 'components/Layout/Main'
+import { SEO } from 'components/Layout/Seo'
 import { ResultsEmpty } from 'components/ResultsEmpty'
 import { AssetCell } from 'components/StakingVaults/Cells'
 import { RawText, Text } from 'components/Text'
@@ -273,6 +274,7 @@ export const YourLoans = () => {
 
   return (
     <Main headerComponent={lendingHeader}>
+      <SEO title={translate('lending.yourLoans.yourLoans')} />
       <Stack>
         {renderHeader}
         {lendingRowGrids}

--- a/src/pages/ThorChainLP/AvailablePools.tsx
+++ b/src/pages/ThorChainLP/AvailablePools.tsx
@@ -10,6 +10,7 @@ import type { Column, Row } from 'react-table'
 import { Amount } from 'components/Amount/Amount'
 import { CircleIcon } from 'components/Icons/Circle'
 import { Main } from 'components/Layout/Main'
+import { SEO } from 'components/Layout/Seo'
 import { ReactTable } from 'components/ReactTable/ReactTable'
 import { RawText, Text } from 'components/Text'
 
@@ -149,6 +150,7 @@ export const AvailablePools = () => {
 
   return (
     <Main headerComponent={headerComponent}>
+      <SEO title={translate('navBar.pools')} />
       <Stack px={stackPadding}>
         {isLoading || !pools ? (
           new Array(2).fill(null).map((_, i) => <Skeleton key={i} height={16} />)

--- a/src/pages/ThorChainLP/YourPositions.tsx
+++ b/src/pages/ThorChainLP/YourPositions.tsx
@@ -10,6 +10,7 @@ import type { Column, Row } from 'react-table'
 import { Amount } from 'components/Amount/Amount'
 import { PoolsIcon } from 'components/Icons/Pools'
 import { Main } from 'components/Layout/Main'
+import { SEO } from 'components/Layout/Seo'
 import { ReactTable } from 'components/ReactTable/ReactTable'
 import { ResultsEmpty } from 'components/ResultsEmpty'
 import { RawText, Text } from 'components/Text'
@@ -254,6 +255,7 @@ export const YourPositions = () => {
 
   return (
     <Main headerComponent={headerComponent}>
+      <SEO title={translate('pools.yourPositions.yourPositions')} />
       <Stack>
         {!positions ? (
           new Array(2).fill(null).map((_, i) => <Skeleton key={i} height={16} />)

--- a/src/pages/ThorChainLP/components/AddLiquidity/AddLiquidityInput.tsx
+++ b/src/pages/ThorChainLP/components/AddLiquidity/AddLiquidityInput.tsx
@@ -1504,7 +1504,6 @@ export const AddLiquidityInput: React.FC<AddLiquidityInputProps> = ({
         </Button>
       </CardFooter>
       <FeeModal
-        affiliateFeeAmountUsd={confirmedQuote?.feeAmountUSD ?? '0'}
         isOpen={showFeeModal}
         onClose={toggleFeeModal}
         inputAmountUsd={confirmedQuote?.totalAmountUsd}

--- a/src/pages/Trade/Trade.tsx
+++ b/src/pages/Trade/Trade.tsx
@@ -1,13 +1,17 @@
 import { Flex } from '@chakra-ui/react'
 import { memo } from 'react'
+import { useTranslate } from 'react-polyglot'
 import { Main } from 'components/Layout/Main'
+import { SEO } from 'components/Layout/Seo'
 import { MultiHopTrade } from 'components/MultiHopTrade/MultiHopTrade'
 
 const padding = { base: 0, md: 8 }
 
 export const Trade = memo(() => {
+  const translate = useTranslate()
   return (
     <Main pt='4.5rem' mt='-4.5rem' px={0} display='flex' flex={1} width='full' hideBreadcrumbs>
+      <SEO title={translate('navBar.trade')} />
       <Flex
         pt={12}
         px={padding}

--- a/src/state/slices/portfolioSlice/selectors.ts
+++ b/src/state/slices/portfolioSlice/selectors.ts
@@ -551,6 +551,23 @@ export const selectPortfolioAccountsUserCurrencyBalancesIncludingStaking =
     },
   )
 
+export const selectTotalPortfolioBalanceIncludeStakingUserCurrency = createCachedSelector(
+  selectPortfolioAccountsUserCurrencyBalancesIncludingStaking,
+  (userCurrencyAccountBalances): string =>
+    Object.values(userCurrencyAccountBalances)
+      .reduce(
+        (acc, accountBalances) =>
+          acc.plus(
+            Object.values(accountBalances).reduce(
+              (innerAcc, cur) => innerAcc.plus(bnOrZero(cur)),
+              bn(0),
+            ),
+          ),
+        bn(0),
+      )
+      .toFixed(2),
+)((_s: ReduxState, _filter) => 'totalPortfolioBalanceIncludeStakingUserCurrency')
+
 export const selectUserCurrencyBalanceIncludingStakingByFilter = createCachedSelector(
   selectPortfolioAccountsUserCurrencyBalancesIncludingStaking,
   selectAssetIdParamFromFilter,

--- a/yarn.lock
+++ b/yarn.lock
@@ -9526,6 +9526,7 @@ __metadata:
     bech32: ^2.0.0
     coinselect: ^3.1.13
     multicoin-address-validator: ^0.5.12
+    p-queue: ^8.0.1
     web3-utils: 1.7.4
   languageName: unknown
   linkType: soft
@@ -10159,6 +10160,7 @@ __metadata:
     os-browserify: ^0.3.0
     p-debounce: ^4.0.0
     p-memoize: ^7.1.1
+    p-queue: ^8.0.1
     p-ratelimit: ^1.0.1
     patch-package: ^8.0.0
     path-browserify: ^1.0.1


### PR DESCRIPTION
fix: allow manual address for unsupported buy asset (#6452)
feat: include defi opportunities in wallet total (#6494)
fix: consistent total FOX discounts model fee (#6493)
fix: clear previous wallet data on kk passphrase entry (#6490)
feat: make keepkey passphrases actually work (#6482)
perf: use a request queue and a concurrency of 2 to fetch tx history (#6483)
fix: missing page titles (#6479)