### PR TITLE
fix: unlimited erc20 appovals

### DIFF
--- a/src/lib/swapper/swappers/utils/constants.ts
+++ b/src/lib/swapper/swappers/utils/constants.ts
@@ -1,3 +1,8 @@
+import { maxUint256 } from 'viem'
+
 export const DEFAULT_SLIPPAGE = '0.002' // .2%
 export const ALLOWABLE_MARKET_MOVEMENT = '0.01' // 1%
-export const MAX_ALLOWANCE = '100000000000000000000000000'
+
+// In Solidity, the maximum value for uint256 is 2^256 - 1.
+// This is the maximum value that can be stored in a uint256 variable.
+export const MAX_ALLOWANCE = maxUint256.toString()


### PR DESCRIPTION
## Description

We currently have our "unlimited" approvals hardcoded to `100000000000000000000000000`, which is actually not the maximum possible value that can be spent, and so, is not unlimited.

Unlimited approvals for ERC20 tokens should be the maximum value that can be stored as a `uint256`.

## Pull Request Type

- [x] :bug: Bug fix (Non-breaking Change: Fixes an issue)
- [ ] :hammer_and_wrench: Chore (Non-breaking Change: Doc updates, pkg upgrades, typos, etc..)
- [ ] :nail_care: New Feature (Breaking/Non-breaking Change)

## Issue (if applicable)

Closes https://github.com/shapeshift/web/issues/6497

## Risk
> High Risk PRs Require 2 approvals

Small.

> What protocols, transaction types or contract interactions might be affected by this PR?

All ERC20 token approvals, and their subsequent trades.

## Testing

Perform an unlimited approval on an ERC20 token and confirm, using a block scan UI for simplicity, that the approval was indeed unlimited.

E.g. https://snowtrace.io/tokenapprovalchecker?search=0x32DBc9Cf9E8FbCebE1e0a2ecF05Ed86Ca3096Cb6 shows that approvals done before this change are set to `100000000000000000000000000` (not unlimited), and that the approval done on this branch (USDC on 0x: Exchange Proxy) is _actually_ unlimited (the largest possible value can be spent).

<img width="1406" alt="Screenshot 2024-03-20 at 9 42 51 AM" src="https://github.com/shapeshift/web/assets/97164662/33e9fb5b-933a-4ad7-8ac8-51290e2a4dbc">

### Engineering

☝️

### Operations

☝️

## Screenshots (if applicable)

See testing notes above.