### PR TITLE
fix: display correct error message if pool not found

### DIFF
--- a/src/assets/translations/en/main.json
+++ b/src/assets/translations/en/main.json
@@ -2279,6 +2279,7 @@
         "title": "Risks and Considerations",
         "body": "While liquidity pools offer earning opportunities, it's important to be aware of the risks involved, including impermanent loss, smart contract vulnerabilities, and market volatility. Users should conduct thorough research before participating."
       }
-    }
+    },
+    "poolMissing": "Pool not available"
   }
 }

--- a/src/pages/ThorChainLP/components/AddLiquidity/AddLiquidityInput.tsx
+++ b/src/pages/ThorChainLP/components/AddLiquidity/AddLiquidityInput.tsx
@@ -455,6 +455,14 @@ export const AddLiquidityInput: React.FC<AddLiquidityInputProps> = ({
     refetchInterval: 60_000,
   })
 
+  const poolMissing = useMemo(() => {
+    if (poolAsset === undefined || pools === undefined) {
+      return false
+    }
+
+    return !pools.some(pool => pool.assetId === poolAsset.assetId)
+  }, [poolAsset, pools])
+
   const { isTradingActive, isLoading: isTradingActiveLoading } = useIsTradingActive({
     assetId: poolAsset?.assetId,
     enabled: Boolean(poolAsset?.assetId),
@@ -1293,14 +1301,16 @@ export const AddLiquidityInput: React.FC<AddLiquidityInputProps> = ({
   const errorCopy = useMemo(() => {
     // Order matters here. Since we're dealing with two assets potentially, we want to show the most relevant error message possible i.e
     // 1. Asset unsupported by wallet
-    // 2. pool halted
-    // 3. smart contract deposits disabled
-    // 4. pool asset balance
-    // 5. pool asset fee balance, since gas would usually be more expensive on the pool asset fee side vs. RUNE side
-    // 6. RUNE balance
-    // 7. RUNE fee balance
+    // 2. pool missing
+    // 3. pool halted
+    // 4. smart contract deposits disabled
+    // 5. pool asset balance
+    // 6. pool asset fee balance, since gas would usually be more expensive on the pool asset fee side vs. RUNE side
+    // 7. RUNE balance
+    // 8. RUNE fee balance
     // Not enough *pool* asset, but possibly enough *fee* asset
     if (!walletSupportsOpportunity) return translate('common.unsupportedNetwork')
+    if (poolMissing) return translate('pools.poolMissing')
     if (isTradingActive === false) return translate('common.poolHalted')
     if (isSmartContractAccountAddress === true)
       return translate('trade.errors.smartContractWalletNotSupported')
@@ -1321,6 +1331,7 @@ export const AddLiquidityInput: React.FC<AddLiquidityInputProps> = ({
     return null
   }, [
     isSmartContractAccountAddress,
+    poolMissing,
     isTradingActive,
     notEnoughFeeAssetError,
     notEnoughPoolAssetError,


### PR DESCRIPTION
## Description

Displays a specific error message "Pool not available" if our system is not able to find the selected pool. This fix was raised originally in #6382 but is no longer relevant to that PR. At this point this fix is purely theoretical and not likely to manifest in production, but paranoia.

## Pull Request Type

(marked as but, but this fix is theoretical) 

- [x] :bug: Bug fix (Non-breaking Change: Fixes an issue)
- [ ] :hammer_and_wrench: Chore (Non-breaking Change: Doc updates, pkg upgrades, typos, etc..)
- [ ] :nail_care: New Feature (Breaking/Non-breaking Change)

## Issue (if applicable)

Addresses https://github.com/shapeshift/web/pull/6382/files#r1529279931

## Risk
> High Risk PRs Require 2 approvals

Very low risk.

> What protocols, transaction types or contract interactions might be affected by this PR?

## Testing

Engineers test copy and logic with monkey patch.
Ops check that LP add liquidity is still working as expected.

### Engineering

<!-----------------------------------------------------------------------------
Include sufficient information here for an engineer to test your PR. This may include how to test locally, in a built environment, changes to infrastructure etc.
------------------------------------------------------------------------------>

### Operations

<!-----------------------------------------------------------------------------
If your changes have a user-facing impact, describe how a non-technical QA team can functionally test your changes in a preview environment.

If they are not user-facing please describe how to test for any regressions that may occur.
------------------------------------------------------------------------------>

## Screenshots (if applicable)

When happy
![image](https://github.com/shapeshift/web/assets/125113430/39d046db-77bb-4459-8d34-6b981c81524e)

When sad
![image](https://github.com/shapeshift/web/assets/125113430/7244aea7-2f8b-4759-a51f-c60024c92d02)
