### PR TITLE
fix: unify affiliate fee calculations

### DIFF
--- a/src/components/FeeModal/FeeBreakdown.tsx
+++ b/src/components/FeeModal/FeeBreakdown.tsx
@@ -8,7 +8,7 @@ import { bnOrZero } from 'lib/bignumber/bignumber'
 import { FEE_MODEL_TO_FEATURE_NAME } from 'lib/fees/parameters'
 import type { ParameterModel } from 'lib/fees/parameters/types'
 import { selectVotingPower } from 'state/apis/snapshot/selectors'
-import { selectCalculatedFees } from 'state/slices/selectors'
+import { selectCalculatedFees } from 'state/slices/tradeQuoteSlice/selectors'
 import { useAppSelector } from 'state/store'
 
 const divider = <Divider />

--- a/src/components/FeeModal/FeeBreakdown.tsx
+++ b/src/components/FeeModal/FeeBreakdown.tsx
@@ -4,11 +4,11 @@ import { useTranslate } from 'react-polyglot'
 import { Amount } from 'components/Amount/Amount'
 import { Row } from 'components/Row/Row'
 import { RawText, Text } from 'components/Text'
-import { bn, bnOrZero } from 'lib/bignumber/bignumber'
-import { calculateFees } from 'lib/fees/model'
+import { bnOrZero } from 'lib/bignumber/bignumber'
 import { FEE_MODEL_TO_FEATURE_NAME } from 'lib/fees/parameters'
 import type { ParameterModel } from 'lib/fees/parameters/types'
 import { selectVotingPower } from 'state/apis/snapshot/selectors'
+import { selectCalculatedFees } from 'state/slices/tradeQuoteSlice/selectors'
 import { useAppSelector } from 'state/store'
 
 const divider = <Divider />
@@ -38,11 +38,7 @@ export const FeeBreakdown = ({ feeModel, inputAmountUsd }: FeeBreakdownProps) =>
     foxDiscountPercent,
     feeUsdBeforeDiscount,
     feeBpsBeforeDiscount,
-  } = calculateFees({
-    tradeAmountUsd: bnOrZero(inputAmountUsd),
-    foxHeld: votingPower !== undefined ? bn(votingPower) : undefined,
-    feeModel,
-  })
+  } = useAppSelector(state => selectCalculatedFees(state, { feeModel, inputAmountUsd }))
 
   const isFree = useMemo(() => bnOrZero(affiliateFeeAmountUsd).eq(0), [affiliateFeeAmountUsd])
 

--- a/src/components/FeeModal/FeeBreakdown.tsx
+++ b/src/components/FeeModal/FeeBreakdown.tsx
@@ -8,7 +8,7 @@ import { bnOrZero } from 'lib/bignumber/bignumber'
 import { FEE_MODEL_TO_FEATURE_NAME } from 'lib/fees/parameters'
 import type { ParameterModel } from 'lib/fees/parameters/types'
 import { selectVotingPower } from 'state/apis/snapshot/selectors'
-import { selectCalculatedFees } from 'state/slices/tradeQuoteSlice/selectors'
+import { selectCalculatedFees } from 'state/slices/selectors'
 import { useAppSelector } from 'state/store'
 
 const divider = <Divider />

--- a/src/components/MultiHopTrade/components/MultiHopTradeConfirm/components/FeeStep.tsx
+++ b/src/components/MultiHopTrade/components/MultiHopTradeConfirm/components/FeeStep.tsx
@@ -10,7 +10,7 @@ import { bnOrZero } from 'lib/bignumber/bignumber'
 import { selectInputSellAmountUsd } from 'state/slices/selectors'
 import {
   selectActiveQuoteAffiliateBps,
-  selectQuoteFeeAmountUsd,
+  selectCalculatedFees,
 } from 'state/slices/tradeQuoteSlice/selectors'
 import { useAppSelector } from 'state/store'
 
@@ -32,7 +32,11 @@ export const FeeStep = ({ isLastStep }: FeeStepProps) => {
   const inputAmountUsd = useAppSelector(selectInputSellAmountUsd)
   // use the fee data from the actual quote in case it varies from the theoretical calculation
   const affiliateBps = useAppSelector(selectActiveQuoteAffiliateBps)
-  const amountAfterDiscountUsd = useAppSelector(selectQuoteFeeAmountUsd)
+
+  const feeModel = 'SWAPPER'
+  const { feeUsd: amountAfterDiscountUsd } = useAppSelector(state =>
+    selectCalculatedFees(state, { feeModel, inputAmountUsd }),
+  )
 
   const handleOpenFeeModal = useCallback(() => setShowFeeModal(true), [])
   const handleCloseFeeModal = useCallback(() => setShowFeeModal(false), [])
@@ -47,7 +51,7 @@ export const FeeStep = ({ isLastStep }: FeeStepProps) => {
 
   const { title, titleProps } = useMemo(() => {
     return bnOrZero(amountAfterDiscountUsd).gt(0)
-      ? { title: toFiat(amountAfterDiscountUsd) }
+      ? { title: toFiat(amountAfterDiscountUsd.toString()) }
       : { title: translate('trade.free'), titleProps: { color: 'text.success' } }
   }, [amountAfterDiscountUsd, toFiat, translate])
 

--- a/src/components/MultiHopTrade/components/MultiHopTradeConfirm/components/FeeStep.tsx
+++ b/src/components/MultiHopTrade/components/MultiHopTradeConfirm/components/FeeStep.tsx
@@ -7,8 +7,11 @@ import { FeeModal } from 'components/FeeModal/FeeModal'
 import { RawText } from 'components/Text'
 import { useLocaleFormatter } from 'hooks/useLocaleFormatter/useLocaleFormatter'
 import { bnOrZero } from 'lib/bignumber/bignumber'
-import { selectCalculatedFees, selectInputSellAmountUsd } from 'state/slices/selectors'
-import { selectActiveQuoteAffiliateBps } from 'state/slices/tradeQuoteSlice/selectors'
+import { selectInputSellAmountUsd } from 'state/slices/selectors'
+import {
+  selectActiveQuoteAffiliateBps,
+  selectCalculatedFees,
+} from 'state/slices/tradeQuoteSlice/selectors'
 import { useAppSelector } from 'state/store'
 
 import { StepperStep } from './StepperStep'

--- a/src/components/MultiHopTrade/components/MultiHopTradeConfirm/components/FeeStep.tsx
+++ b/src/components/MultiHopTrade/components/MultiHopTradeConfirm/components/FeeStep.tsx
@@ -34,8 +34,12 @@ export const FeeStep = ({ isLastStep }: FeeStepProps) => {
   const affiliateBps = useAppSelector(selectActiveQuoteAffiliateBps)
 
   const feeModel = 'SWAPPER'
+  const calculatedFeesFilter = useMemo(
+    () => ({ feeModel, inputAmountUsd }),
+    [feeModel, inputAmountUsd],
+  )
   const { feeUsd: amountAfterDiscountUsd } = useAppSelector(state =>
-    selectCalculatedFees(state, { feeModel, inputAmountUsd }),
+    selectCalculatedFees(state, calculatedFeesFilter),
   )
 
   const handleOpenFeeModal = useCallback(() => setShowFeeModal(true), [])

--- a/src/components/MultiHopTrade/components/MultiHopTradeConfirm/components/FeeStep.tsx
+++ b/src/components/MultiHopTrade/components/MultiHopTradeConfirm/components/FeeStep.tsx
@@ -51,7 +51,7 @@ export const FeeStep = ({ isLastStep }: FeeStepProps) => {
 
   const { title, titleProps } = useMemo(() => {
     return bnOrZero(amountAfterDiscountUsd).gt(0)
-      ? { title: toFiat(amountAfterDiscountUsd.toString()) }
+      ? { title: toFiat(amountAfterDiscountUsd.toFixed()) }
       : { title: translate('trade.free'), titleProps: { color: 'text.success' } }
   }, [amountAfterDiscountUsd, toFiat, translate])
 

--- a/src/components/MultiHopTrade/components/MultiHopTradeConfirm/components/FeeStep.tsx
+++ b/src/components/MultiHopTrade/components/MultiHopTradeConfirm/components/FeeStep.tsx
@@ -7,11 +7,8 @@ import { FeeModal } from 'components/FeeModal/FeeModal'
 import { RawText } from 'components/Text'
 import { useLocaleFormatter } from 'hooks/useLocaleFormatter/useLocaleFormatter'
 import { bnOrZero } from 'lib/bignumber/bignumber'
-import { selectInputSellAmountUsd } from 'state/slices/selectors'
-import {
-  selectActiveQuoteAffiliateBps,
-  selectCalculatedFees,
-} from 'state/slices/tradeQuoteSlice/selectors'
+import { selectCalculatedFees, selectInputSellAmountUsd } from 'state/slices/selectors'
+import { selectActiveQuoteAffiliateBps } from 'state/slices/tradeQuoteSlice/selectors'
 import { useAppSelector } from 'state/store'
 
 import { StepperStep } from './StepperStep'

--- a/src/components/MultiHopTrade/components/TradeInput/components/ReceiveSummary.tsx
+++ b/src/components/MultiHopTrade/components/TradeInput/components/ReceiveSummary.tsx
@@ -23,7 +23,7 @@ import { isSome } from 'lib/utils'
 import { selectInputSellAmountUsd } from 'state/slices/selectors'
 import {
   selectActiveQuoteAffiliateBps,
-  selectQuoteAffiliateFeeUserCurrency,
+  selectTradeAffiliateFeeAfterDiscountUserCurrency,
 } from 'state/slices/tradeQuoteSlice/selectors'
 import { useAppSelector } from 'state/store'
 
@@ -74,7 +74,9 @@ export const ReceiveSummary: FC<ReceiveSummaryProps> = memo(
     const inputAmountUsd = useAppSelector(selectInputSellAmountUsd)
     // use the fee data from the actual quote in case it varies from the theoretical calculation
     const affiliateBps = useAppSelector(selectActiveQuoteAffiliateBps)
-    const amountAfterDiscountUserCurrency = useAppSelector(selectQuoteAffiliateFeeUserCurrency)
+    const affiliateFeeAfterDiscountUserCurrency = useAppSelector(
+      selectTradeAffiliateFeeAfterDiscountUserCurrency,
+    )
 
     const parseAmountDisplayMeta = useCallback((items: AmountDisplayMeta[]) => {
       return items
@@ -168,15 +170,16 @@ export const ReceiveSummary: FC<ReceiveSummaryProps> = memo(
           <Row isLoading={isLoading}>
             <Row.Label display='flex'>
               <Text translation={tradeFeeSourceTranslation} />
-              {amountAfterDiscountUserCurrency !== '0' && (
+              {affiliateFeeAfterDiscountUserCurrency !== '0' && (
                 <RawText>&nbsp;{`(${affiliateBps} bps)`}</RawText>
               )}
             </Row.Label>
             <Row.Value onClick={toggleFeeModal} _hover={shapeShiftFeeModalRowHover}>
               <Flex alignItems='center' gap={2}>
-                {amountAfterDiscountUserCurrency !== '0' ? (
+                {!!affiliateFeeAfterDiscountUserCurrency &&
+                affiliateFeeAfterDiscountUserCurrency !== '0' ? (
                   <>
-                    <Amount.Fiat value={amountAfterDiscountUserCurrency} />
+                    <Amount.Fiat value={affiliateFeeAfterDiscountUserCurrency} />
                     <QuestionIcon />
                   </>
                 ) : (

--- a/src/components/MultiHopTrade/components/TradeInput/components/ReceiveSummary.tsx
+++ b/src/components/MultiHopTrade/components/TradeInput/components/ReceiveSummary.tsx
@@ -23,7 +23,7 @@ import { isSome } from 'lib/utils'
 import { selectInputSellAmountUsd } from 'state/slices/selectors'
 import {
   selectActiveQuoteAffiliateBps,
-  selectTradeAffiliateFeeAfterDiscountUserCurrency,
+  selectTradeQuoteAffiliateFeeAfterDiscountUserCurrency,
 } from 'state/slices/tradeQuoteSlice/selectors'
 import { useAppSelector } from 'state/store'
 
@@ -75,7 +75,7 @@ export const ReceiveSummary: FC<ReceiveSummaryProps> = memo(
     // use the fee data from the actual quote in case it varies from the theoretical calculation
     const affiliateBps = useAppSelector(selectActiveQuoteAffiliateBps)
     const affiliateFeeAfterDiscountUserCurrency = useAppSelector(
-      selectTradeAffiliateFeeAfterDiscountUserCurrency,
+      selectTradeQuoteAffiliateFeeAfterDiscountUserCurrency,
     )
 
     const parseAmountDisplayMeta = useCallback((items: AmountDisplayMeta[]) => {

--- a/src/components/MultiHopTrade/helpers.ts
+++ b/src/components/MultiHopTrade/helpers.ts
@@ -10,8 +10,8 @@ import {
   selectQuoteSellAmountBeforeFeesCryptoPrecision,
   selectQuoteSellAmountUsd,
   selectQuoteSellAmountUserCurrency,
-  selectTradeAffiliateFeeAfterDiscountUsd,
-  selectTradeAffiliateFeeAfterDiscountUserCurrency,
+  selectTradeQuoteAffiliateFeeAfterDiscountUsd,
+  selectTradeQuoteAffiliateFeeAfterDiscountUserCurrency,
 } from 'state/slices/tradeQuoteSlice/selectors'
 import { store } from 'state/store'
 
@@ -28,8 +28,8 @@ export const getMixpanelEventData = () => {
   if (!buyAsset?.precision) return
 
   const assets = selectAssets(state)
-  const shapeShiftFeeUserCurrency = selectTradeAffiliateFeeAfterDiscountUserCurrency(state)
-  const shapeshiftFeeUsd = selectTradeAffiliateFeeAfterDiscountUsd(state)
+  const shapeShiftFeeUserCurrency = selectTradeQuoteAffiliateFeeAfterDiscountUserCurrency(state)
+  const shapeshiftFeeUsd = selectTradeQuoteAffiliateFeeAfterDiscountUsd(state)
   const sellAmountBeforeFeesUsd = selectQuoteSellAmountUsd(state)
   const sellAmountBeforeFeesUserCurrency = selectQuoteSellAmountUserCurrency(state)
   const buyAmountBeforeFeesCryptoPrecision = selectBuyAmountBeforeFeesCryptoPrecision(state)

--- a/src/components/MultiHopTrade/helpers.ts
+++ b/src/components/MultiHopTrade/helpers.ts
@@ -7,11 +7,11 @@ import {
   selectBuyAmountBeforeFeesCryptoPrecision,
   selectFirstHopSellAsset,
   selectLastHopBuyAsset,
-  selectQuoteAffiliateFeeUserCurrency,
-  selectQuoteFeeAmountUsd,
   selectQuoteSellAmountBeforeFeesCryptoPrecision,
   selectQuoteSellAmountUsd,
   selectQuoteSellAmountUserCurrency,
+  selectTradeAffiliateFeeAfterDiscountUsd,
+  selectTradeAffiliateFeeAfterDiscountUserCurrency,
 } from 'state/slices/tradeQuoteSlice/selectors'
 import { store } from 'state/store'
 
@@ -28,8 +28,8 @@ export const getMixpanelEventData = () => {
   if (!buyAsset?.precision) return
 
   const assets = selectAssets(state)
-  const shapeShiftFeeUserCurrency = selectQuoteAffiliateFeeUserCurrency(state)
-  const shapeshiftFeeUsd = selectQuoteFeeAmountUsd(state)
+  const shapeShiftFeeUserCurrency = selectTradeAffiliateFeeAfterDiscountUserCurrency(state)
+  const shapeshiftFeeUsd = selectTradeAffiliateFeeAfterDiscountUsd(state)
   const sellAmountBeforeFeesUsd = selectQuoteSellAmountUsd(state)
   const sellAmountBeforeFeesUserCurrency = selectQuoteSellAmountUserCurrency(state)
   const buyAmountBeforeFeesCryptoPrecision = selectBuyAmountBeforeFeesCryptoPrecision(state)

--- a/src/lib/fees/model.ts
+++ b/src/lib/fees/model.ts
@@ -21,7 +21,7 @@ type CalculateFeeBpsArgs = {
  * @property {BigNumber} feeUsdBeforeDiscount - The gross USD value of the fee (i.e., excluding the fox discount).
  * @property {BigNumber} feeBpsBeforeDiscount - The gross fee bps (i.e., excluding the fox discount).
  */
-type CalculateFeeBpsReturn = {
+export type CalculateFeeBpsReturn = {
   feeBps: BigNumber
   feeBpsFloat: BigNumber
   feeUsd: BigNumber

--- a/src/state/slices/common-selectors.ts
+++ b/src/state/slices/common-selectors.ts
@@ -4,14 +4,9 @@ import type { Asset } from '@shapeshiftoss/types'
 import orderBy from 'lodash/orderBy'
 import pickBy from 'lodash/pickBy'
 import createCachedSelector from 're-reselect'
-import type { Selector } from 'reselect'
 import { bn, bnOrZero } from 'lib/bignumber/bignumber'
-import type { CalculateFeeBpsReturn } from 'lib/fees/model'
-import { calculateFees } from 'lib/fees/model'
-import type { ParameterModel } from 'lib/fees/parameters/types'
 import { fromBaseUnit } from 'lib/math'
 import { isSome } from 'lib/utils'
-import { selectVotingPower } from 'state/apis/snapshot/selectors'
 import type { ReduxState } from 'state/reducer'
 import { createDeepEqualOutputSelector } from 'state/selector-utils'
 import { selectAccountIdParamFromFilter, selectAssetIdParamFromFilter } from 'state/selectors'
@@ -171,25 +166,3 @@ export const selectAssetsSortedByName = createDeepEqualOutputSelector(selectAsse
   const getAssetName = (asset: Asset) => asset.name
   return orderBy(Object.values(assets).filter(isSome), [getAssetName], ['asc'])
 })
-
-type AffiliateFeesProps = {
-  feeModel: ParameterModel
-  inputAmountUsd: string | undefined
-}
-
-export const selectCalculatedFees: Selector<ReduxState, CalculateFeeBpsReturn> =
-  createCachedSelector(
-    (_state: ReduxState, { feeModel }: AffiliateFeesProps) => feeModel,
-    (_state: ReduxState, { inputAmountUsd }: AffiliateFeesProps) => inputAmountUsd,
-    selectVotingPower,
-
-    (feeModel, inputAmountUsd, votingPower) => {
-      const fees: CalculateFeeBpsReturn = calculateFees({
-        tradeAmountUsd: bnOrZero(inputAmountUsd),
-        foxHeld: votingPower !== undefined ? bn(votingPower) : undefined,
-        feeModel,
-      })
-
-      return fees
-    },
-  )((_state, { feeModel, inputAmountUsd }) => `${feeModel}-${inputAmountUsd}`)

--- a/src/state/slices/common-selectors.ts
+++ b/src/state/slices/common-selectors.ts
@@ -179,12 +179,10 @@ type AffiliateFeesProps = {
 
 export const selectCalculatedFees: Selector<ReduxState, CalculateFeeBpsReturn> =
   createCachedSelector(
-    [
-      (_state: ReduxState, { feeModel }: AffiliateFeesProps) => feeModel,
-      (_state: ReduxState, { inputAmountUsd }: AffiliateFeesProps) => inputAmountUsd,
-      (state: ReduxState, { feeModel }: AffiliateFeesProps) =>
-        selectVotingPower(state, { feeModel }),
-    ],
+    (_state: ReduxState, { feeModel }: AffiliateFeesProps) => feeModel,
+    (_state: ReduxState, { inputAmountUsd }: AffiliateFeesProps) => inputAmountUsd,
+    selectVotingPower,
+
     (feeModel, inputAmountUsd, votingPower) => {
       const fees: CalculateFeeBpsReturn = calculateFees({
         tradeAmountUsd: bnOrZero(inputAmountUsd),

--- a/src/state/slices/tradeQuoteSlice/selectors.ts
+++ b/src/state/slices/tradeQuoteSlice/selectors.ts
@@ -588,7 +588,7 @@ export const selectActiveQuoteAffiliateBps: Selector<ReduxState, string | undefi
     return activeQuote.affiliateBps
   })
 
-export const selectTradeAffiliateFeeAfterDiscountUsd = createSelector(
+export const selectTradeQuoteAffiliateFeeAfterDiscountUsd = createSelector(
   (state: ReduxState) =>
     selectCalculatedFees(state, {
       feeModel: 'SWAPPER',
@@ -601,8 +601,8 @@ export const selectTradeAffiliateFeeAfterDiscountUsd = createSelector(
   },
 )
 
-export const selectTradeAffiliateFeeAfterDiscountUserCurrency = createSelector(
-  selectTradeAffiliateFeeAfterDiscountUsd,
+export const selectTradeQuoteAffiliateFeeAfterDiscountUserCurrency = createSelector(
+  selectTradeQuoteAffiliateFeeAfterDiscountUsd,
   selectUserCurrencyToUsdRate,
   (tradeAffiliateFeeAfterDiscountUsd, sellUserCurrencyRate) => {
     if (!tradeAffiliateFeeAfterDiscountUsd || !sellUserCurrencyRate) return

--- a/src/state/slices/tradeQuoteSlice/selectors.ts
+++ b/src/state/slices/tradeQuoteSlice/selectors.ts
@@ -5,11 +5,16 @@ import { SwapperName } from '@shapeshiftoss/swapper'
 import type { Asset } from '@shapeshiftoss/types'
 import { getDefaultSlippageDecimalPercentageForSwapper } from 'constants/constants'
 import { identity } from 'lodash'
+import createCachedSelector from 're-reselect'
 import type { Selector } from 'reselect'
 import { bn, bnOrZero } from 'lib/bignumber/bignumber'
+import type { CalculateFeeBpsReturn } from 'lib/fees/model'
+import { calculateFees } from 'lib/fees/model'
+import type { ParameterModel } from 'lib/fees/parameters/types'
 import { fromBaseUnit } from 'lib/math'
 import { getEnabledSwappers } from 'lib/swapper/utils'
 import { isSome } from 'lib/utils'
+import { selectVotingPower } from 'state/apis/snapshot/selectors'
 import type { ApiQuote, ErrorWithMeta, TradeQuoteError } from 'state/apis/swapper'
 import { TradeQuoteRequestError, TradeQuoteWarning } from 'state/apis/swapper'
 import { validateQuoteRequest } from 'state/apis/swapper/helpers/validateQuoteRequest'
@@ -39,11 +44,7 @@ import {
   sortQuotes,
 } from 'state/slices/tradeQuoteSlice/helpers'
 
-import {
-  selectCalculatedFees,
-  selectIsWalletConnected,
-  selectWalletSupportedChainIds,
-} from '../common-selectors'
+import { selectIsWalletConnected, selectWalletSupportedChainIds } from '../common-selectors'
 import {
   selectMarketDataUsd,
   selectMarketDataUserCurrency,
@@ -587,6 +588,28 @@ export const selectActiveQuoteAffiliateBps: Selector<ReduxState, string | undefi
     if (!activeQuote) return
     return activeQuote.affiliateBps
   })
+
+type AffiliateFeesProps = {
+  feeModel: ParameterModel
+  inputAmountUsd: string | undefined
+}
+
+export const selectCalculatedFees: Selector<ReduxState, CalculateFeeBpsReturn> =
+  createCachedSelector(
+    (_state: ReduxState, { feeModel }: AffiliateFeesProps) => feeModel,
+    (_state: ReduxState, { inputAmountUsd }: AffiliateFeesProps) => inputAmountUsd,
+    selectVotingPower,
+
+    (feeModel, inputAmountUsd, votingPower) => {
+      const fees: CalculateFeeBpsReturn = calculateFees({
+        tradeAmountUsd: bnOrZero(inputAmountUsd),
+        foxHeld: votingPower !== undefined ? bn(votingPower) : undefined,
+        feeModel,
+      })
+
+      return fees
+    },
+  )((_state, { feeModel, inputAmountUsd }) => `${feeModel}-${inputAmountUsd}`)
 
 export const selectTradeQuoteAffiliateFeeAfterDiscountUsd = createSelector(
   (state: ReduxState) =>

--- a/src/state/slices/tradeQuoteSlice/selectors.ts
+++ b/src/state/slices/tradeQuoteSlice/selectors.ts
@@ -7,9 +7,13 @@ import { getDefaultSlippageDecimalPercentageForSwapper } from 'constants/constan
 import { identity } from 'lodash'
 import type { Selector } from 'reselect'
 import { bn, bnOrZero } from 'lib/bignumber/bignumber'
+import type { CalculateFeeBpsReturn } from 'lib/fees/model'
+import { calculateFees } from 'lib/fees/model'
+import type { ParameterModel } from 'lib/fees/parameters/types'
 import { fromBaseUnit } from 'lib/math'
 import { getEnabledSwappers } from 'lib/swapper/utils'
 import { isSome } from 'lib/utils'
+import { selectVotingPower } from 'state/apis/snapshot/selectors'
 import type { ApiQuote, ErrorWithMeta, TradeQuoteError } from 'state/apis/swapper'
 import { TradeQuoteRequestError, TradeQuoteWarning } from 'state/apis/swapper'
 import { validateQuoteRequest } from 'state/apis/swapper/helpers/validateQuoteRequest'
@@ -38,7 +42,6 @@ import {
   getTotalProtocolFeeByAsset,
   sortQuotes,
 } from 'state/slices/tradeQuoteSlice/helpers'
-import { convertBasisPointsToDecimalPercentage } from 'state/slices/tradeQuoteSlice/utils'
 
 import { selectIsWalletConnected, selectWalletSupportedChainIds } from '../common-selectors'
 import {
@@ -585,24 +588,47 @@ export const selectActiveQuoteAffiliateBps: Selector<ReduxState, string | undefi
     return activeQuote.affiliateBps
   })
 
-export const selectQuoteAffiliateFeeUserCurrency = createSelector(
-  selectActiveQuote,
-  selectQuoteSellAmountUserCurrency,
-  selectActiveQuoteAffiliateBps,
-  (activeQuote, sellAmountUserCurrency, affiliateBps) => {
-    if (!activeQuote) return '0'
-    const affiliatePercentage = affiliateBps
-      ? convertBasisPointsToDecimalPercentage(affiliateBps)
-      : 0
-    // The affiliate fee amount is a percentage of the sell amount
-    return bnOrZero(sellAmountUserCurrency).times(affiliatePercentage).toFixed()
+type AffiliateFeesProps = {
+  feeModel: ParameterModel
+  inputAmountUsd: string | undefined
+}
+
+export const selectCalculatedFees: Selector<ReduxState, CalculateFeeBpsReturn> = createSelector(
+  [
+    (_state: ReduxState, { feeModel }: AffiliateFeesProps) => feeModel,
+    (_state: ReduxState, { inputAmountUsd }: AffiliateFeesProps) => inputAmountUsd,
+    (state: ReduxState, { feeModel }: AffiliateFeesProps) => selectVotingPower(state, { feeModel }),
+  ],
+  (feeModel, inputAmountUsd, votingPower) => {
+    const fees: CalculateFeeBpsReturn = calculateFees({
+      tradeAmountUsd: bnOrZero(inputAmountUsd),
+      foxHeld: votingPower !== undefined ? bn(votingPower) : undefined,
+      feeModel,
+    })
+
+    return fees
   },
 )
-export const selectQuoteFeeAmountUsd = createSelector(
-  selectQuoteAffiliateFeeUserCurrency,
+
+export const selectTradeAffiliateFeeAfterDiscountUsd = createSelector(
+  (state: ReduxState) =>
+    selectCalculatedFees(state, {
+      feeModel: 'SWAPPER',
+      inputAmountUsd: selectQuoteSellAmountUsd(state),
+    }),
+  selectActiveQuoteAffiliateBps,
+  (calculatedFees, affiliateBps) => {
+    if (!affiliateBps) return
+    return calculatedFees.feeUsd
+  },
+)
+
+export const selectTradeAffiliateFeeAfterDiscountUserCurrency = createSelector(
+  selectTradeAffiliateFeeAfterDiscountUsd,
   selectUserCurrencyToUsdRate,
-  (feeAmountUserCurrency, userCurrencyToUsdRate) => {
-    return bnOrZero(feeAmountUserCurrency).div(userCurrencyToUsdRate).toFixed()
+  (tradeAffiliateFeeAfterDiscountUsd, sellUserCurrencyRate) => {
+    if (!tradeAffiliateFeeAfterDiscountUsd || !sellUserCurrencyRate) return
+    return bn(tradeAffiliateFeeAfterDiscountUsd).times(sellUserCurrencyRate).toFixed()
   },
 )
 


### PR DESCRIPTION
## Description

Fix the discrepancy between the ShapeShift fee shown by the `ReceiveSummary` component and the fee modal.

They are using different calculations to derive the values. This PR unifies the calculation logic by putting the `calculateFees` logic into a selector (`selectCalculatedFees`), and then consuming that in all of the `FeeBreakdown` modal logic, the `FeeStep`, and the `ReceiveSummary` components.

## Pull Request Type

- [x] :bug: Bug fix (Non-breaking Change: Fixes an issue)
- [ ] :hammer_and_wrench: Chore (Non-breaking Change: Doc updates, pkg upgrades, typos, etc..)
- [ ] :nail_care: New Feature (Breaking/Non-breaking Change)

## Issue (if applicable)

Fixes release-blocking regression caused by https://github.com/shapeshift/web/pull/6493 in https://github.com/shapeshift/web/pull/6499.

## Risk

Medium. Should just be UI changes (so small), but if I broke something that causes us to stop charging fees that's bad (so medium).

> What protocols, transaction types or contract interactions might be affected by this PR?

Trades and LP deposits.

## Testing

Ensure that:

- The ShapeShift fee shown on the receive amount and that show in the fee modal is the same for both LP deposits and trades (note, tiny rounding error somewhere in screenshots, won't fix in this PR):

<img width="312" alt="Screenshot 2024-03-20 at 11 27 18 AM" src="https://github.com/shapeshift/web/assets/97164662/84e352aa-3067-40e8-9720-f07bf022563c">

<img width="374" alt="Screenshot 2024-03-20 at 11 27 59 AM" src="https://github.com/shapeshift/web/assets/97164662/cfd3bf8f-002e-4640-83aa-f4692e947874">

- Also ensure that the `ReceiveSummary` component shows the expected fee when a user selected currency is used.

### Engineering

☝️

### Operations

☝️

## Screenshots (if applicable)

See testing steps above.