### PR TITLE
feat: cleanup fluff sendMax logic in EVM buildSendApiTransaction

### DIFF
--- a/packages/chain-adapters/src/evm/EvmBaseAdapter.ts
+++ b/packages/chain-adapters/src/evm/EvmBaseAdapter.ts
@@ -1,5 +1,5 @@
 import type { AssetId, ChainId } from '@shapeshiftoss/caip'
-import { fromAssetId, fromChainId, toAssetId } from '@shapeshiftoss/caip'
+import { fromChainId, toAssetId } from '@shapeshiftoss/caip'
 import type {
   ETHSignMessage,
   ETHSignTx,
@@ -330,22 +330,8 @@ export abstract class EvmBaseAdapter<T extends EvmChainId> implements IChainAdap
     to,
     value,
     chainSpecific: { contractAddress, from, data },
-    sendMax = false,
   }: GetFeeDataInput<T>): Promise<EstimateGasRequest> {
     const isTokenSend = !!contractAddress
-
-    // get the exact send max value for an erc20 send to ensure we have the correct input data when estimating fees
-    if (sendMax && isTokenSend) {
-      const account = await this.getAccount(from)
-      const tokenBalance = account.chainSpecific.tokens?.find(token => {
-        const { assetReference } = fromAssetId(token.assetId)
-        return assetReference === contractAddress.toLowerCase()
-      })?.balance
-
-      if (!tokenBalance) throw new Error('no balance')
-
-      value = tokenBalance
-    }
 
     return {
       from,

--- a/packages/chain-adapters/src/evm/arbitrum/ArbitrumChainAdapter.test.ts
+++ b/packages/chain-adapters/src/evm/arbitrum/ArbitrumChainAdapter.test.ts
@@ -12,7 +12,6 @@ import { numberToHex } from 'web3-utils'
 import type { BuildSendTxInput, GetFeeDataInput, SignMessageInput, SignTxInput } from '../../types'
 import { ValidAddressResultType } from '../../types'
 import { toAddressNList } from '../../utils'
-import { bn } from '../../utils/bignumber'
 import type { ChainAdapterArgs, EvmChainId } from '../EvmBaseAdapter'
 import * as arbitrum from './ArbitrumChainAdapter'
 
@@ -480,68 +479,6 @@ describe('ArbitrumChainAdapter', () => {
       expect(args.providers.http.getAccount).toHaveBeenCalledTimes(1)
     })
 
-    it('sendmax: true without chainSpecific.contractAddress should throw if balance is 0', async () => {
-      const httpProvider = {
-        getAccount: vi
-          .fn<any, any>()
-          .mockResolvedValue(makeGetAccountMockResponse({ balance: '0', tokenBalance: '424242' })),
-      } as unknown as unchained.arbitrum.V1Api
-
-      const args = makeChainAdapterArgs({ providers: { http: httpProvider } })
-      const adapter = new arbitrum.ChainAdapter(args)
-
-      const tx = {
-        wallet: await getWallet(),
-        accountNumber,
-        to: EOA_ADDRESS,
-        value,
-        chainSpecific: makeChainSpecific(),
-        sendMax: true,
-      } as unknown as BuildSendTxInput<KnownChainIds.ArbitrumMainnet>
-
-      await expect(adapter.buildSendTransaction(tx)).rejects.toThrow('no balance')
-      expect(args.providers.http.getAccount).toHaveBeenCalledTimes(1)
-    })
-
-    it('sendMax: true without chainSpecific.contractAddress - should build a tx with full account balance - gas fee', async () => {
-      const balance = '2500000'
-      const expectedValue = numberToHex(
-        bn(balance).minus(bn(gasLimit).multipliedBy(gasPrice)) as any,
-      )
-      const httpProvider = {
-        getAccount: vi
-          .fn<any, any>()
-          .mockResolvedValue(makeGetAccountMockResponse({ balance, tokenBalance: '424242' })),
-      } as unknown as unchained.arbitrum.V1Api
-
-      const args = makeChainAdapterArgs({ providers: { http: httpProvider } })
-      const adapter = new arbitrum.ChainAdapter(args)
-
-      const tx = {
-        wallet: await getWallet(),
-        accountNumber,
-        to: EOA_ADDRESS,
-        value,
-        chainSpecific: makeChainSpecific(),
-        sendMax: true,
-      } as unknown as BuildSendTxInput<KnownChainIds.ArbitrumMainnet>
-
-      await expect(adapter.buildSendTransaction(tx)).resolves.toStrictEqual({
-        txToSign: {
-          addressNList: toAddressNList(adapter.getBIP44Params({ accountNumber: 0 })),
-          chainId: Number(fromChainId(arbitrumChainId).chainReference),
-          data: '',
-          gasLimit: numberToHex(gasLimit),
-          gasPrice: numberToHex(gasPrice),
-          nonce: '0x2',
-          to: EOA_ADDRESS,
-          value: expectedValue,
-        },
-      })
-
-      expect(args.providers.http.getAccount).toHaveBeenCalledTimes(1)
-    })
-
     it("should build a tx with value: '0' for BEP20 txs without sendMax", async () => {
       const httpProvider = {
         getAccount: vi
@@ -574,69 +511,6 @@ describe('ArbitrumChainAdapter', () => {
           value: '0x0',
         },
       })
-
-      expect(args.providers.http.getAccount).toHaveBeenCalledTimes(1)
-    })
-
-    it('sendmax: true with chainSpecific.contractAddress should build a tx with full account balance - gas fee', async () => {
-      const httpProvider = {
-        getAccount: vi
-          .fn<any, any>()
-          .mockResolvedValue(
-            makeGetAccountMockResponse({ balance: '2500000', tokenBalance: '424242' }),
-          ),
-      } as unknown as unchained.arbitrum.V1Api
-
-      const args = makeChainAdapterArgs({ providers: { http: httpProvider } })
-      const adapter = new arbitrum.ChainAdapter(args)
-
-      const tx = {
-        wallet: await getWallet(),
-        accountNumber,
-        to: EOA_ADDRESS,
-        value,
-        chainSpecific: makeChainSpecific({ contractAddress }),
-        sendMax: true,
-      } as unknown as BuildSendTxInput<KnownChainIds.ArbitrumMainnet>
-
-      await expect(adapter.buildSendTransaction(tx)).resolves.toStrictEqual({
-        txToSign: {
-          addressNList: toAddressNList(adapter.getBIP44Params({ accountNumber: 0 })),
-          chainId: Number(fromChainId(arbitrumChainId).chainReference),
-          data: '0xa9059cbb000000000000000000000000d8da6bf26964af9d7eed9e03e53415d37aa960450000000000000000000000000000000000000000000000000000000000067932',
-          gasLimit: numberToHex(gasLimit),
-          gasPrice: numberToHex(gasPrice),
-          nonce: '0x2',
-          to: contractAddress,
-          value: '0x0',
-        },
-      })
-
-      expect(args.providers.http.getAccount).toHaveBeenCalledTimes(1)
-    })
-
-    it('sendmax: true with chainSpecific.contractAddress should throw if token balance is 0', async () => {
-      const httpProvider = {
-        getAccount: vi
-          .fn<any, any>()
-          .mockResolvedValue(
-            makeGetAccountMockResponse({ balance: '2500000', tokenBalance: undefined }),
-          ),
-      } as unknown as unchained.arbitrum.V1Api
-
-      const args = makeChainAdapterArgs({ providers: { http: httpProvider } })
-      const adapter = new arbitrum.ChainAdapter(args)
-
-      const tx = {
-        wallet: await getWallet(),
-        accountNumber,
-        to: EOA_ADDRESS,
-        value,
-        chainSpecific: makeChainSpecific({ contractAddress }),
-        sendMax: true,
-      } as unknown as BuildSendTxInput<KnownChainIds.ArbitrumMainnet>
-
-      await expect(adapter.buildSendTransaction(tx)).rejects.toThrow('no balance')
 
       expect(args.providers.http.getAccount).toHaveBeenCalledTimes(1)
     })

--- a/packages/chain-adapters/src/evm/arbitrumNova/ArbitrumNovaChainAdapter.test.ts
+++ b/packages/chain-adapters/src/evm/arbitrumNova/ArbitrumNovaChainAdapter.test.ts
@@ -17,7 +17,6 @@ import { numberToHex } from 'web3-utils'
 import type { BuildSendTxInput, GetFeeDataInput, SignMessageInput, SignTxInput } from '../../types'
 import { ValidAddressResultType } from '../../types'
 import { toAddressNList } from '../../utils'
-import { bn } from '../../utils/bignumber'
 import type { ChainAdapterArgs, EvmChainId } from '../EvmBaseAdapter'
 import * as arbitrumNova from './ArbitrumNovaChainAdapter'
 

--- a/packages/chain-adapters/src/evm/arbitrumNova/ArbitrumNovaChainAdapter.test.ts
+++ b/packages/chain-adapters/src/evm/arbitrumNova/ArbitrumNovaChainAdapter.test.ts
@@ -485,68 +485,6 @@ describe('ArbitrumNovaChainAdapter', () => {
       expect(args.providers.http.getAccount).toHaveBeenCalledTimes(1)
     })
 
-    it('sendmax: true without chainSpecific.contractAddress should throw if balance is 0', async () => {
-      const httpProvider = {
-        getAccount: vi
-          .fn<any, any>()
-          .mockResolvedValue(makeGetAccountMockResponse({ balance: '0', tokenBalance: '424242' })),
-      } as unknown as unchained.arbitrumNova.V1Api
-
-      const args = makeChainAdapterArgs({ providers: { http: httpProvider } })
-      const adapter = new arbitrumNova.ChainAdapter(args)
-
-      const tx = {
-        wallet: await getWallet(),
-        accountNumber,
-        to: EOA_ADDRESS,
-        value,
-        chainSpecific: makeChainSpecific(),
-        sendMax: true,
-      } as unknown as BuildSendTxInput<KnownChainIds.ArbitrumNovaMainnet>
-
-      await expect(adapter.buildSendTransaction(tx)).rejects.toThrow('no balance')
-      expect(args.providers.http.getAccount).toHaveBeenCalledTimes(1)
-    })
-
-    it('sendMax: true without chainSpecific.contractAddress - should build a tx with full account balance - gas fee', async () => {
-      const balance = '2500000'
-      const expectedValue = numberToHex(
-        bn(balance).minus(bn(gasLimit).multipliedBy(gasPrice)) as any,
-      )
-      const httpProvider = {
-        getAccount: vi
-          .fn<any, any>()
-          .mockResolvedValue(makeGetAccountMockResponse({ balance, tokenBalance: '424242' })),
-      } as unknown as unchained.arbitrumNova.V1Api
-
-      const args = makeChainAdapterArgs({ providers: { http: httpProvider } })
-      const adapter = new arbitrumNova.ChainAdapter(args)
-
-      const tx = {
-        wallet: await getWallet(),
-        accountNumber,
-        to: EOA_ADDRESS,
-        value,
-        chainSpecific: makeChainSpecific(),
-        sendMax: true,
-      } as unknown as BuildSendTxInput<KnownChainIds.ArbitrumNovaMainnet>
-
-      await expect(adapter.buildSendTransaction(tx)).resolves.toStrictEqual({
-        txToSign: {
-          addressNList: toAddressNList(adapter.getBIP44Params({ accountNumber: 0 })),
-          chainId: Number(fromChainId(arbitrumNovaChainId).chainReference),
-          data: '',
-          gasLimit: numberToHex(gasLimit),
-          gasPrice: numberToHex(gasPrice),
-          nonce: '0x2',
-          to: EOA_ADDRESS,
-          value: expectedValue,
-        },
-      })
-
-      expect(args.providers.http.getAccount).toHaveBeenCalledTimes(1)
-    })
-
     it("should build a tx with value: '0' for BEP20 txs without sendMax", async () => {
       const httpProvider = {
         getAccount: vi
@@ -579,69 +517,6 @@ describe('ArbitrumNovaChainAdapter', () => {
           value: '0x0',
         },
       })
-
-      expect(args.providers.http.getAccount).toHaveBeenCalledTimes(1)
-    })
-
-    it('sendmax: true with chainSpecific.contractAddress should build a tx with full account balance - gas fee', async () => {
-      const httpProvider = {
-        getAccount: vi
-          .fn<any, any>()
-          .mockResolvedValue(
-            makeGetAccountMockResponse({ balance: '2500000', tokenBalance: '424242' }),
-          ),
-      } as unknown as unchained.arbitrumNova.V1Api
-
-      const args = makeChainAdapterArgs({ providers: { http: httpProvider } })
-      const adapter = new arbitrumNova.ChainAdapter(args)
-
-      const tx = {
-        wallet: await getWallet(),
-        accountNumber,
-        to: EOA_ADDRESS,
-        value,
-        chainSpecific: makeChainSpecific({ contractAddress }),
-        sendMax: true,
-      } as unknown as BuildSendTxInput<KnownChainIds.ArbitrumNovaMainnet>
-
-      await expect(adapter.buildSendTransaction(tx)).resolves.toStrictEqual({
-        txToSign: {
-          addressNList: toAddressNList(adapter.getBIP44Params({ accountNumber: 0 })),
-          chainId: Number(fromChainId(arbitrumNovaChainId).chainReference),
-          data: '0xa9059cbb000000000000000000000000d8da6bf26964af9d7eed9e03e53415d37aa960450000000000000000000000000000000000000000000000000000000000067932',
-          gasLimit: numberToHex(gasLimit),
-          gasPrice: numberToHex(gasPrice),
-          nonce: '0x2',
-          to: contractAddress,
-          value: '0x0',
-        },
-      })
-
-      expect(args.providers.http.getAccount).toHaveBeenCalledTimes(1)
-    })
-
-    it('sendmax: true with chainSpecific.contractAddress should throw if token balance is 0', async () => {
-      const httpProvider = {
-        getAccount: vi
-          .fn<any, any>()
-          .mockResolvedValue(
-            makeGetAccountMockResponse({ balance: '2500000', tokenBalance: undefined }),
-          ),
-      } as unknown as unchained.arbitrumNova.V1Api
-
-      const args = makeChainAdapterArgs({ providers: { http: httpProvider } })
-      const adapter = new arbitrumNova.ChainAdapter(args)
-
-      const tx = {
-        wallet: await getWallet(),
-        accountNumber,
-        to: EOA_ADDRESS,
-        value,
-        chainSpecific: makeChainSpecific({ contractAddress }),
-        sendMax: true,
-      } as unknown as BuildSendTxInput<KnownChainIds.ArbitrumNovaMainnet>
-
-      await expect(adapter.buildSendTransaction(tx)).rejects.toThrow('no balance')
 
       expect(args.providers.http.getAccount).toHaveBeenCalledTimes(1)
     })

--- a/packages/chain-adapters/src/evm/avalanche/AvalancheChainAdapter.test.ts
+++ b/packages/chain-adapters/src/evm/avalanche/AvalancheChainAdapter.test.ts
@@ -17,7 +17,6 @@ import { numberToHex } from 'web3-utils'
 import type { BuildSendTxInput, GetFeeDataInput, SignMessageInput, SignTxInput } from '../../types'
 import { ValidAddressResultType } from '../../types'
 import { toAddressNList } from '../../utils'
-import { bn } from '../../utils/bignumber'
 import type { EvmChainId } from '../EvmBaseAdapter'
 import * as avalanche from './AvalancheChainAdapter'
 
@@ -486,68 +485,6 @@ describe('AvalancheChainAdapter', () => {
       expect(args.providers.http.getAccount).toHaveBeenCalledTimes(1)
     })
 
-    it('sendmax: true without chainSpecific.contractAddress should throw if balance is 0', async () => {
-      const httpProvider = {
-        getAccount: vi
-          .fn<any, any>()
-          .mockResolvedValue(makeGetAccountMockResponse({ balance: '0', tokenBalance: '424242' })),
-      } as unknown as unchained.avalanche.V1Api
-
-      const args = makeChainAdapterArgs({ providers: { http: httpProvider } })
-      const adapter = new avalanche.ChainAdapter(args)
-
-      const tx = {
-        wallet: await getWallet(),
-        accountNumber,
-        to: EOA_ADDRESS,
-        value,
-        chainSpecific: makeChainSpecific(),
-        sendMax: true,
-      } as unknown as BuildSendTxInput<KnownChainIds.AvalancheMainnet>
-
-      await expect(adapter.buildSendTransaction(tx)).rejects.toThrow('no balance')
-      expect(args.providers.http.getAccount).toHaveBeenCalledTimes(1)
-    })
-
-    it('sendMax: true without chainSpecific.contractAddress - should build a tx with full account balance - gas fee', async () => {
-      const balance = '2500000'
-      const expectedValue = numberToHex(
-        bn(balance).minus(bn(gasLimit).multipliedBy(gasPrice)) as any,
-      )
-      const httpProvider = {
-        getAccount: vi
-          .fn<any, any>()
-          .mockResolvedValue(makeGetAccountMockResponse({ balance, tokenBalance: '424242' })),
-      } as unknown as unchained.avalanche.V1Api
-
-      const args = makeChainAdapterArgs({ providers: { http: httpProvider } })
-      const adapter = new avalanche.ChainAdapter(args)
-
-      const tx = {
-        wallet: await getWallet(),
-        accountNumber,
-        to: EOA_ADDRESS,
-        value,
-        chainSpecific: makeChainSpecific(),
-        sendMax: true,
-      } as unknown as BuildSendTxInput<KnownChainIds.AvalancheMainnet>
-
-      await expect(adapter.buildSendTransaction(tx)).resolves.toStrictEqual({
-        txToSign: {
-          addressNList: toAddressNList(adapter.getBIP44Params({ accountNumber: 0 })),
-          chainId: Number(fromChainId(avalancheChainId).chainReference),
-          data: '',
-          gasLimit: numberToHex(gasLimit),
-          gasPrice: numberToHex(gasPrice),
-          nonce: '0x2',
-          to: EOA_ADDRESS,
-          value: expectedValue,
-        },
-      })
-
-      expect(args.providers.http.getAccount).toHaveBeenCalledTimes(1)
-    })
-
     it("should build a tx with value: '0' for ERC20 txs without sendMax", async () => {
       const httpProvider = {
         getAccount: vi
@@ -580,69 +517,6 @@ describe('AvalancheChainAdapter', () => {
           value: '0x0',
         },
       })
-
-      expect(args.providers.http.getAccount).toHaveBeenCalledTimes(1)
-    })
-
-    it('sendmax: true with chainSpecific.contractAddress should build a tx with full account balance - gas fee', async () => {
-      const httpProvider = {
-        getAccount: vi
-          .fn<any, any>()
-          .mockResolvedValue(
-            makeGetAccountMockResponse({ balance: '2500000', tokenBalance: '424242' }),
-          ),
-      } as unknown as unchained.avalanche.V1Api
-
-      const args = makeChainAdapterArgs({ providers: { http: httpProvider } })
-      const adapter = new avalanche.ChainAdapter(args)
-
-      const tx = {
-        wallet: await getWallet(),
-        accountNumber,
-        to: EOA_ADDRESS,
-        value,
-        chainSpecific: makeChainSpecific({ contractAddress }),
-        sendMax: true,
-      } as unknown as BuildSendTxInput<KnownChainIds.AvalancheMainnet>
-
-      await expect(adapter.buildSendTransaction(tx)).resolves.toStrictEqual({
-        txToSign: {
-          addressNList: toAddressNList(adapter.getBIP44Params({ accountNumber: 0 })),
-          chainId: Number(fromChainId(avalancheChainId).chainReference),
-          data: '0xa9059cbb000000000000000000000000d8da6bf26964af9d7eed9e03e53415d37aa960450000000000000000000000000000000000000000000000000000000000067932',
-          gasLimit: numberToHex(gasLimit),
-          gasPrice: numberToHex(gasPrice),
-          nonce: '0x2',
-          to: '0xc770eefad204b5180df6a14ee197d99d808ee52d',
-          value: '0x0',
-        },
-      })
-
-      expect(args.providers.http.getAccount).toHaveBeenCalledTimes(1)
-    })
-
-    it('sendmax: true with chainSpecific.contractAddress should throw if token balance is 0', async () => {
-      const httpProvider = {
-        getAccount: vi
-          .fn<any, any>()
-          .mockResolvedValue(
-            makeGetAccountMockResponse({ balance: '2500000', tokenBalance: undefined }),
-          ),
-      } as unknown as unchained.avalanche.V1Api
-
-      const args = makeChainAdapterArgs({ providers: { http: httpProvider } })
-      const adapter = new avalanche.ChainAdapter(args)
-
-      const tx = {
-        wallet: await getWallet(),
-        accountNumber,
-        to: EOA_ADDRESS,
-        value,
-        chainSpecific: makeChainSpecific({ contractAddress }),
-        sendMax: true,
-      } as unknown as BuildSendTxInput<KnownChainIds.AvalancheMainnet>
-
-      await expect(adapter.buildSendTransaction(tx)).rejects.toThrow('no balance')
 
       expect(args.providers.http.getAccount).toHaveBeenCalledTimes(1)
     })

--- a/packages/chain-adapters/src/evm/bnbsmartchain/BscChainAdapter.test.ts
+++ b/packages/chain-adapters/src/evm/bnbsmartchain/BscChainAdapter.test.ts
@@ -12,7 +12,6 @@ import { numberToHex } from 'web3-utils'
 import type { BuildSendTxInput, GetFeeDataInput, SignMessageInput, SignTxInput } from '../../types'
 import { ValidAddressResultType } from '../../types'
 import { toAddressNList } from '../../utils'
-import { bn } from '../../utils/bignumber'
 import type { EvmChainId } from '../EvmBaseAdapter'
 import * as bsc from './BscChainAdapter'
 
@@ -463,68 +462,6 @@ describe('BscChainAdapter', () => {
       expect(args.providers.http.getAccount).toHaveBeenCalledTimes(1)
     })
 
-    it('sendmax: true without chainSpecific.contractAddress should throw if balance is 0', async () => {
-      const httpProvider = {
-        getAccount: vi
-          .fn<any, any>()
-          .mockResolvedValue(makeGetAccountMockResponse({ balance: '0', tokenBalance: '424242' })),
-      } as unknown as unchained.bnbsmartchain.V1Api
-
-      const args = makeChainAdapterArgs({ providers: { http: httpProvider } })
-      const adapter = new bsc.ChainAdapter(args)
-
-      const tx = {
-        wallet: await getWallet(),
-        accountNumber,
-        to: EOA_ADDRESS,
-        value,
-        chainSpecific: makeChainSpecific(),
-        sendMax: true,
-      } as unknown as BuildSendTxInput<KnownChainIds.BnbSmartChainMainnet>
-
-      await expect(adapter.buildSendTransaction(tx)).rejects.toThrow('no balance')
-      expect(args.providers.http.getAccount).toHaveBeenCalledTimes(1)
-    })
-
-    it('sendMax: true without chainSpecific.contractAddress - should build a tx with full account balance - gas fee', async () => {
-      const balance = '2500000'
-      const expectedValue = numberToHex(
-        bn(balance).minus(bn(gasLimit).multipliedBy(gasPrice)) as any,
-      )
-      const httpProvider = {
-        getAccount: vi
-          .fn<any, any>()
-          .mockResolvedValue(makeGetAccountMockResponse({ balance, tokenBalance: '424242' })),
-      } as unknown as unchained.bnbsmartchain.V1Api
-
-      const args = makeChainAdapterArgs({ providers: { http: httpProvider } })
-      const adapter = new bsc.ChainAdapter(args)
-
-      const tx = {
-        wallet: await getWallet(),
-        accountNumber,
-        to: EOA_ADDRESS,
-        value,
-        chainSpecific: makeChainSpecific(),
-        sendMax: true,
-      } as unknown as BuildSendTxInput<KnownChainIds.BnbSmartChainMainnet>
-
-      await expect(adapter.buildSendTransaction(tx)).resolves.toStrictEqual({
-        txToSign: {
-          addressNList: toAddressNList(adapter.getBIP44Params({ accountNumber: 0 })),
-          chainId: Number(fromChainId(bscChainId).chainReference),
-          data: '',
-          gasLimit: numberToHex(gasLimit),
-          gasPrice: numberToHex(gasPrice),
-          nonce: '0x2',
-          to: EOA_ADDRESS,
-          value: expectedValue,
-        },
-      })
-
-      expect(args.providers.http.getAccount).toHaveBeenCalledTimes(1)
-    })
-
     it("should build a tx with value: '0' for BEP20 txs without sendMax", async () => {
       const httpProvider = {
         getAccount: vi
@@ -557,69 +494,6 @@ describe('BscChainAdapter', () => {
           value: '0x0',
         },
       })
-
-      expect(args.providers.http.getAccount).toHaveBeenCalledTimes(1)
-    })
-
-    it('sendmax: true with chainSpecific.contractAddress should build a tx with full account balance - gas fee', async () => {
-      const httpProvider = {
-        getAccount: vi
-          .fn<any, any>()
-          .mockResolvedValue(
-            makeGetAccountMockResponse({ balance: '2500000', tokenBalance: '424242' }),
-          ),
-      } as unknown as unchained.bnbsmartchain.V1Api
-
-      const args = makeChainAdapterArgs({ providers: { http: httpProvider } })
-      const adapter = new bsc.ChainAdapter(args)
-
-      const tx = {
-        wallet: await getWallet(),
-        accountNumber,
-        to: EOA_ADDRESS,
-        value,
-        chainSpecific: makeChainSpecific({ contractAddress }),
-        sendMax: true,
-      } as unknown as BuildSendTxInput<KnownChainIds.BnbSmartChainMainnet>
-
-      await expect(adapter.buildSendTransaction(tx)).resolves.toStrictEqual({
-        txToSign: {
-          addressNList: toAddressNList(adapter.getBIP44Params({ accountNumber: 0 })),
-          chainId: Number(fromChainId(bscChainId).chainReference),
-          data: '0xa9059cbb000000000000000000000000d8da6bf26964af9d7eed9e03e53415d37aa960450000000000000000000000000000000000000000000000000000000000067932',
-          gasLimit: numberToHex(gasLimit),
-          gasPrice: numberToHex(gasPrice),
-          nonce: '0x2',
-          to: contractAddress,
-          value: '0x0',
-        },
-      })
-
-      expect(args.providers.http.getAccount).toHaveBeenCalledTimes(1)
-    })
-
-    it('sendmax: true with chainSpecific.contractAddress should throw if token balance is 0', async () => {
-      const httpProvider = {
-        getAccount: vi
-          .fn<any, any>()
-          .mockResolvedValue(
-            makeGetAccountMockResponse({ balance: '2500000', tokenBalance: undefined }),
-          ),
-      } as unknown as unchained.bnbsmartchain.V1Api
-
-      const args = makeChainAdapterArgs({ providers: { http: httpProvider } })
-      const adapter = new bsc.ChainAdapter(args)
-
-      const tx = {
-        wallet: await getWallet(),
-        accountNumber,
-        to: EOA_ADDRESS,
-        value,
-        chainSpecific: makeChainSpecific({ contractAddress }),
-        sendMax: true,
-      } as unknown as BuildSendTxInput<KnownChainIds.BnbSmartChainMainnet>
-
-      await expect(adapter.buildSendTransaction(tx)).rejects.toThrow('no balance')
 
       expect(args.providers.http.getAccount).toHaveBeenCalledTimes(1)
     })

--- a/packages/chain-adapters/src/evm/ethereum/EthereumChainAdapter.test.ts
+++ b/packages/chain-adapters/src/evm/ethereum/EthereumChainAdapter.test.ts
@@ -12,7 +12,6 @@ import { numberToHex } from 'web3-utils'
 import type { BuildSendTxInput, GetFeeDataInput, SignMessageInput, SignTxInput } from '../../types'
 import { ValidAddressResultType } from '../../types'
 import { toAddressNList } from '../../utils'
-import { bn } from '../../utils/bignumber'
 import type { EvmChainId } from '../EvmBaseAdapter'
 import * as ethereum from './EthereumChainAdapter'
 
@@ -557,69 +556,6 @@ describe('EthereumChainAdapter', () => {
       expect(args.providers.http.getAccount).toHaveBeenCalledTimes(1)
     })
 
-    it('sendmax: true without chainSpecific.contractAddress should throw if balance is 0', async () => {
-      const httpProvider = {
-        getAccount: vi
-          .fn<any, any>()
-          .mockResolvedValue(makeGetAccountMockResponse({ balance: '0', tokenBalance: '424242' })),
-      } as unknown as unchained.ethereum.V1Api
-
-      const args = makeChainAdapterArgs({ providers: { http: httpProvider } })
-      const adapter = new ethereum.ChainAdapter(args)
-      const accountNumber = 0
-
-      const tx = {
-        accountNumber,
-        wallet: await getWallet(),
-        to: EOA_ADDRESS,
-        value,
-        chainSpecific: makeChainSpecific(),
-        sendMax: true,
-      } as unknown as BuildSendTxInput<KnownChainIds.EthereumMainnet>
-
-      await expect(adapter.buildSendTransaction(tx)).rejects.toThrow('no balance')
-      expect(args.providers.http.getAccount).toHaveBeenCalledTimes(1)
-    })
-    it('sendMax: true without chainSpecific.contractAddress - should build a tx with full account balance - gas fee', async () => {
-      const balance = '2500000'
-      const expectedValue = numberToHex(
-        bn(balance).minus(bn(gasLimit).multipliedBy(gasPrice)) as any,
-      )
-      const httpProvider = {
-        getAccount: vi
-          .fn<any, any>()
-          .mockResolvedValue(makeGetAccountMockResponse({ balance, tokenBalance: '424242' })),
-      } as unknown as unchained.ethereum.V1Api
-
-      const args = makeChainAdapterArgs({ providers: { http: httpProvider } })
-      const adapter = new ethereum.ChainAdapter(args)
-      const accountNumber = 0
-
-      const tx = {
-        accountNumber,
-        wallet: await getWallet(),
-        to: EOA_ADDRESS,
-        value,
-        chainSpecific: makeChainSpecific(),
-        sendMax: true,
-      } as unknown as BuildSendTxInput<KnownChainIds.EthereumMainnet>
-
-      await expect(adapter.buildSendTransaction(tx)).resolves.toStrictEqual({
-        txToSign: {
-          addressNList: toAddressNList(adapter.getBIP44Params({ accountNumber: 0 })),
-          chainId: Number(CHAIN_REFERENCE.EthereumMainnet),
-          data: '',
-          gasLimit: numberToHex(gasLimit),
-          gasPrice: numberToHex(gasPrice),
-          nonce: '0x2',
-          to: EOA_ADDRESS,
-          value: expectedValue,
-        },
-      })
-
-      expect(args.providers.http.getAccount).toHaveBeenCalledTimes(1)
-    })
-
     it("should build a tx with value: '0' for ERC20 txs without sendMax", async () => {
       const httpProvider = {
         getAccount: vi
@@ -653,71 +589,6 @@ describe('EthereumChainAdapter', () => {
           value: '0x0',
         },
       })
-
-      expect(args.providers.http.getAccount).toHaveBeenCalledTimes(1)
-    })
-
-    it('sendmax: true with chainSpecific.contractAddress should build a tx with full account balance - gas fee', async () => {
-      const httpProvider = {
-        getAccount: vi
-          .fn<any, any>()
-          .mockResolvedValue(
-            makeGetAccountMockResponse({ balance: '2500000', tokenBalance: '424242' }),
-          ),
-      } as unknown as unchained.ethereum.V1Api
-
-      const args = makeChainAdapterArgs({ providers: { http: httpProvider } })
-      const adapter = new ethereum.ChainAdapter(args)
-      const accountNumber = 0
-
-      const tx = {
-        accountNumber,
-        wallet: await getWallet(),
-        to: EOA_ADDRESS,
-        value,
-        chainSpecific: makeChainSpecific({ contractAddress }),
-        sendMax: true,
-      } as unknown as BuildSendTxInput<KnownChainIds.EthereumMainnet>
-
-      await expect(adapter.buildSendTransaction(tx)).resolves.toStrictEqual({
-        txToSign: {
-          addressNList: toAddressNList(adapter.getBIP44Params({ accountNumber: 0 })),
-          chainId: Number(CHAIN_REFERENCE.EthereumMainnet),
-          data: '0xa9059cbb000000000000000000000000d8da6bf26964af9d7eed9e03e53415d37aa960450000000000000000000000000000000000000000000000000000000000067932',
-          gasLimit: numberToHex(gasLimit),
-          gasPrice: numberToHex(gasPrice),
-          nonce: '0x2',
-          to: '0xc770eefad204b5180df6a14ee197d99d808ee52d',
-          value: '0x0',
-        },
-      })
-
-      expect(args.providers.http.getAccount).toHaveBeenCalledTimes(1)
-    })
-
-    it('sendmax: true with chainSpecific.contractAddress should throw if token balance is 0', async () => {
-      const httpProvider = {
-        getAccount: vi
-          .fn<any, any>()
-          .mockResolvedValue(
-            makeGetAccountMockResponse({ balance: '2500000', tokenBalance: undefined }),
-          ),
-      } as unknown as unchained.ethereum.V1Api
-
-      const args = makeChainAdapterArgs({ providers: { http: httpProvider } })
-      const adapter = new ethereum.ChainAdapter(args)
-      const accountNumber = 0
-
-      const tx = {
-        accountNumber,
-        wallet: await getWallet(),
-        to: EOA_ADDRESS,
-        value,
-        chainSpecific: makeChainSpecific({ contractAddress }),
-        sendMax: true,
-      } as unknown as BuildSendTxInput<KnownChainIds.EthereumMainnet>
-
-      await expect(adapter.buildSendTransaction(tx)).rejects.toThrow('no balance')
 
       expect(args.providers.http.getAccount).toHaveBeenCalledTimes(1)
     })

--- a/packages/chain-adapters/src/evm/optimism/OptimismChainAdapter.test.ts
+++ b/packages/chain-adapters/src/evm/optimism/OptimismChainAdapter.test.ts
@@ -12,7 +12,6 @@ import { numberToHex } from 'web3-utils'
 import type { BuildSendTxInput, GetFeeDataInput, SignMessageInput, SignTxInput } from '../../types'
 import { ValidAddressResultType } from '../../types'
 import { toAddressNList } from '../../utils'
-import { bn } from '../../utils/bignumber'
 import type { ChainAdapterArgs, EvmChainId } from '../EvmBaseAdapter'
 import * as optimism from './OptimismChainAdapter'
 
@@ -487,68 +486,6 @@ describe('OptimismChainAdapter', () => {
       expect(args.providers.http.getAccount).toHaveBeenCalledTimes(1)
     })
 
-    it('sendmax: true without chainSpecific.contractAddress should throw if balance is 0', async () => {
-      const httpProvider = {
-        getAccount: vi
-          .fn<any, any>()
-          .mockResolvedValue(makeGetAccountMockResponse({ balance: '0', tokenBalance: '424242' })),
-      } as unknown as unchained.optimism.V1Api
-
-      const args = makeChainAdapterArgs({ providers: { http: httpProvider } })
-      const adapter = new optimism.ChainAdapter(args)
-
-      const tx = {
-        wallet: await getWallet(),
-        accountNumber,
-        to: EOA_ADDRESS,
-        value,
-        chainSpecific: makeChainSpecific(),
-        sendMax: true,
-      } as unknown as BuildSendTxInput<KnownChainIds.OptimismMainnet>
-
-      await expect(adapter.buildSendTransaction(tx)).rejects.toThrow('no balance')
-      expect(args.providers.http.getAccount).toHaveBeenCalledTimes(1)
-    })
-
-    it('sendMax: true without chainSpecific.contractAddress - should build a tx with full account balance - gas fee', async () => {
-      const balance = '2500000'
-      const expectedValue = numberToHex(
-        bn(balance).minus(bn(gasLimit).multipliedBy(gasPrice)) as any,
-      )
-      const httpProvider = {
-        getAccount: vi
-          .fn<any, any>()
-          .mockResolvedValue(makeGetAccountMockResponse({ balance, tokenBalance: '424242' })),
-      } as unknown as unchained.optimism.V1Api
-
-      const args = makeChainAdapterArgs({ providers: { http: httpProvider } })
-      const adapter = new optimism.ChainAdapter(args)
-
-      const tx = {
-        wallet: await getWallet(),
-        accountNumber,
-        to: EOA_ADDRESS,
-        value,
-        chainSpecific: makeChainSpecific(),
-        sendMax: true,
-      } as unknown as BuildSendTxInput<KnownChainIds.OptimismMainnet>
-
-      await expect(adapter.buildSendTransaction(tx)).resolves.toStrictEqual({
-        txToSign: {
-          addressNList: toAddressNList(adapter.getBIP44Params({ accountNumber: 0 })),
-          chainId: Number(fromChainId(optimismChainId).chainReference),
-          data: '',
-          gasLimit: numberToHex(gasLimit),
-          gasPrice: numberToHex(gasPrice),
-          nonce: '0x2',
-          to: EOA_ADDRESS,
-          value: expectedValue,
-        },
-      })
-
-      expect(args.providers.http.getAccount).toHaveBeenCalledTimes(1)
-    })
-
     it("should build a tx with value: '0' for ERC20 txs without sendMax", async () => {
       const httpProvider = {
         getAccount: vi
@@ -581,69 +518,6 @@ describe('OptimismChainAdapter', () => {
           value: '0x0',
         },
       })
-
-      expect(args.providers.http.getAccount).toHaveBeenCalledTimes(1)
-    })
-
-    it('sendmax: true with chainSpecific.contractAddress should build a tx with full account balance - gas fee', async () => {
-      const httpProvider = {
-        getAccount: vi
-          .fn<any, any>()
-          .mockResolvedValue(
-            makeGetAccountMockResponse({ balance: '2500000', tokenBalance: '424242' }),
-          ),
-      } as unknown as unchained.optimism.V1Api
-
-      const args = makeChainAdapterArgs({ providers: { http: httpProvider } })
-      const adapter = new optimism.ChainAdapter(args)
-
-      const tx = {
-        wallet: await getWallet(),
-        accountNumber,
-        to: EOA_ADDRESS,
-        value,
-        chainSpecific: makeChainSpecific({ contractAddress }),
-        sendMax: true,
-      } as unknown as BuildSendTxInput<KnownChainIds.OptimismMainnet>
-
-      await expect(adapter.buildSendTransaction(tx)).resolves.toStrictEqual({
-        txToSign: {
-          addressNList: toAddressNList(adapter.getBIP44Params({ accountNumber: 0 })),
-          chainId: Number(fromChainId(optimismChainId).chainReference),
-          data: '0xa9059cbb000000000000000000000000d8da6bf26964af9d7eed9e03e53415d37aa960450000000000000000000000000000000000000000000000000000000000067932',
-          gasLimit: numberToHex(gasLimit),
-          gasPrice: numberToHex(gasPrice),
-          nonce: '0x2',
-          to: '0xc770eefad204b5180df6a14ee197d99d808ee52d',
-          value: '0x0',
-        },
-      })
-
-      expect(args.providers.http.getAccount).toHaveBeenCalledTimes(1)
-    })
-
-    it('sendmax: true with chainSpecific.contractAddress should throw if token balance is 0', async () => {
-      const httpProvider = {
-        getAccount: vi
-          .fn<any, any>()
-          .mockResolvedValue(
-            makeGetAccountMockResponse({ balance: '2500000', tokenBalance: undefined }),
-          ),
-      } as unknown as unchained.optimism.V1Api
-
-      const args = makeChainAdapterArgs({ providers: { http: httpProvider } })
-      const adapter = new optimism.ChainAdapter(args)
-
-      const tx = {
-        wallet: await getWallet(),
-        accountNumber,
-        to: EOA_ADDRESS,
-        value,
-        chainSpecific: makeChainSpecific({ contractAddress }),
-        sendMax: true,
-      } as unknown as BuildSendTxInput<KnownChainIds.OptimismMainnet>
-
-      await expect(adapter.buildSendTransaction(tx)).rejects.toThrow('no balance')
 
       expect(args.providers.http.getAccount).toHaveBeenCalledTimes(1)
     })

--- a/packages/chain-adapters/src/evm/polygon/PolygonChainAdapter.test.ts
+++ b/packages/chain-adapters/src/evm/polygon/PolygonChainAdapter.test.ts
@@ -12,7 +12,6 @@ import { numberToHex } from 'web3-utils'
 import type { BuildSendTxInput, GetFeeDataInput, SignMessageInput, SignTxInput } from '../../types'
 import { ValidAddressResultType } from '../../types'
 import { toAddressNList } from '../../utils'
-import { bn } from '../../utils/bignumber'
 import type { ChainAdapterArgs, EvmChainId } from '../EvmBaseAdapter'
 import * as polygon from './PolygonChainAdapter'
 
@@ -480,68 +479,6 @@ describe('PolygonChainAdapter', () => {
       expect(args.providers.http.getAccount).toHaveBeenCalledTimes(1)
     })
 
-    it('sendmax: true without chainSpecific.contractAddress should throw if balance is 0', async () => {
-      const httpProvider = {
-        getAccount: vi
-          .fn<any, any>()
-          .mockResolvedValue(makeGetAccountMockResponse({ balance: '0', tokenBalance: '424242' })),
-      } as unknown as unchained.polygon.V1Api
-
-      const args = makeChainAdapterArgs({ providers: { http: httpProvider } })
-      const adapter = new polygon.ChainAdapter(args)
-
-      const tx = {
-        wallet: await getWallet(),
-        accountNumber,
-        to: EOA_ADDRESS,
-        value,
-        chainSpecific: makeChainSpecific(),
-        sendMax: true,
-      } as unknown as BuildSendTxInput<KnownChainIds.PolygonMainnet>
-
-      await expect(adapter.buildSendTransaction(tx)).rejects.toThrow('no balance')
-      expect(args.providers.http.getAccount).toHaveBeenCalledTimes(1)
-    })
-
-    it('sendMax: true without chainSpecific.contractAddress - should build a tx with full account balance - gas fee', async () => {
-      const balance = '2500000'
-      const expectedValue = numberToHex(
-        bn(balance).minus(bn(gasLimit).multipliedBy(gasPrice)) as any,
-      )
-      const httpProvider = {
-        getAccount: vi
-          .fn<any, any>()
-          .mockResolvedValue(makeGetAccountMockResponse({ balance, tokenBalance: '424242' })),
-      } as unknown as unchained.polygon.V1Api
-
-      const args = makeChainAdapterArgs({ providers: { http: httpProvider } })
-      const adapter = new polygon.ChainAdapter(args)
-
-      const tx = {
-        wallet: await getWallet(),
-        accountNumber,
-        to: EOA_ADDRESS,
-        value,
-        chainSpecific: makeChainSpecific(),
-        sendMax: true,
-      } as unknown as BuildSendTxInput<KnownChainIds.PolygonMainnet>
-
-      await expect(adapter.buildSendTransaction(tx)).resolves.toStrictEqual({
-        txToSign: {
-          addressNList: toAddressNList(adapter.getBIP44Params({ accountNumber: 0 })),
-          chainId: Number(fromChainId(polygonChainId).chainReference),
-          data: '',
-          gasLimit: numberToHex(gasLimit),
-          gasPrice: numberToHex(gasPrice),
-          nonce: '0x2',
-          to: EOA_ADDRESS,
-          value: expectedValue,
-        },
-      })
-
-      expect(args.providers.http.getAccount).toHaveBeenCalledTimes(1)
-    })
-
     it("should build a tx with value: '0' for BEP20 txs without sendMax", async () => {
       const httpProvider = {
         getAccount: vi
@@ -574,69 +511,6 @@ describe('PolygonChainAdapter', () => {
           value: '0x0',
         },
       })
-
-      expect(args.providers.http.getAccount).toHaveBeenCalledTimes(1)
-    })
-
-    it('sendmax: true with chainSpecific.contractAddress should build a tx with full account balance - gas fee', async () => {
-      const httpProvider = {
-        getAccount: vi
-          .fn<any, any>()
-          .mockResolvedValue(
-            makeGetAccountMockResponse({ balance: '2500000', tokenBalance: '424242' }),
-          ),
-      } as unknown as unchained.polygon.V1Api
-
-      const args = makeChainAdapterArgs({ providers: { http: httpProvider } })
-      const adapter = new polygon.ChainAdapter(args)
-
-      const tx = {
-        wallet: await getWallet(),
-        accountNumber,
-        to: EOA_ADDRESS,
-        value,
-        chainSpecific: makeChainSpecific({ contractAddress }),
-        sendMax: true,
-      } as unknown as BuildSendTxInput<KnownChainIds.PolygonMainnet>
-
-      await expect(adapter.buildSendTransaction(tx)).resolves.toStrictEqual({
-        txToSign: {
-          addressNList: toAddressNList(adapter.getBIP44Params({ accountNumber: 0 })),
-          chainId: Number(fromChainId(polygonChainId).chainReference),
-          data: '0xa9059cbb000000000000000000000000d8da6bf26964af9d7eed9e03e53415d37aa960450000000000000000000000000000000000000000000000000000000000067932',
-          gasLimit: numberToHex(gasLimit),
-          gasPrice: numberToHex(gasPrice),
-          nonce: '0x2',
-          to: contractAddress,
-          value: '0x0',
-        },
-      })
-
-      expect(args.providers.http.getAccount).toHaveBeenCalledTimes(1)
-    })
-
-    it('sendmax: true with chainSpecific.contractAddress should throw if token balance is 0', async () => {
-      const httpProvider = {
-        getAccount: vi
-          .fn<any, any>()
-          .mockResolvedValue(
-            makeGetAccountMockResponse({ balance: '2500000', tokenBalance: undefined }),
-          ),
-      } as unknown as unchained.polygon.V1Api
-
-      const args = makeChainAdapterArgs({ providers: { http: httpProvider } })
-      const adapter = new polygon.ChainAdapter(args)
-
-      const tx = {
-        wallet: await getWallet(),
-        accountNumber,
-        to: EOA_ADDRESS,
-        value,
-        chainSpecific: makeChainSpecific({ contractAddress }),
-        sendMax: true,
-      } as unknown as BuildSendTxInput<KnownChainIds.PolygonMainnet>
-
-      await expect(adapter.buildSendTransaction(tx)).rejects.toThrow('no balance')
 
       expect(args.providers.http.getAccount).toHaveBeenCalledTimes(1)
     })

--- a/packages/chain-adapters/src/evm/types.ts
+++ b/packages/chain-adapters/src/evm/types.ts
@@ -31,6 +31,7 @@ export type BuildTxInput = {
   gasLimit: string
   contractAddress?: string
   data?: string
+  sendmax?: never
 } & Fees &
   OptimismL1FeeData
 
@@ -82,6 +83,7 @@ export type GetFeeDataInput = {
   contractAddress?: string
   from: string
   data?: string
+  sendMax?: never
 }
 
 export type TransactionMetadata = unchained.evm.TxMetadata


### PR DESCRIPTION
... and `buildEstimateGasRequest` too.

## Description

Fast follow of https://github.com/shapeshift/web/pull/6505 - we should have never gotten into a bug like https://github.com/shapeshift/web/issues/6312 in the first place. We already have the fee-deducted value, but are still deducting the value from the full balance, which is not only fluff, but also bugs prone if we get the logic wrong WRT fees, which we did for Arbitrum.

While at it, also removes `sendMax` tests which aren't valid anymore for EVM chains - first of all, there is no notion of `sendMax` anymore for EVM chains, but we're also more dumb now in taking an input and building signed calldata out of that - balance checks are now effectively a consumer, not chain-adapters concern.

## Pull Request Type

- [ ] :bug: Bug fix (Non-breaking Change: Fixes an issue)
- [ ] :hammer_and_wrench: Chore (Non-breaking Change: Doc updates, pkg upgrades, typos, etc..)
- [x] :nail_care: New Feature (Breaking/Non-breaking Change)

## Issue (if applicable)

<!-----------------------------------------------------------------------------
If applicable, please link to the github issue and put `closes #XXXX` in your comment to auto-close the issue that your PR fixes.
------------------------------------------------------------------------------>

- relates to the closed #6312

## Risk
> High Risk PRs Require 2 approvals

<!-----------------------------------------------------------------------------
Outline the scope of your changes and the risk associated with them. You must use your discretion as an engineer to determine the potential impact of your changes.

WARNING: If your PR introduces a new on-chain transaction or modifies an existing one, please add the "High-Risk" label to this PR and ask for 2 reviewers to approve it before merging.

E.g. an upgrade to `hdwallet` or core state management would be considered higher risk, and might require a full regression test. UI or isolated view changes, or something behind a feature flag may have near zero risk. Small bug fixes might require testing isolated to the specific fix.
------------------------------------------------------------------------------>

> What protocols, transaction types or contract interactions might be affected by this PR?

Low to none - ensure max token sends and native EVM asset sends are still happy

## Testing

<!-----------------------------------------------------------------------------
We treat every PR to be merged with the same scrutiny as if we were merging directly to production.

Your PR will not be merged if you do not complete the sections below for our engineering and operations teams to test.
------------------------------------------------------------------------------>

- EVM token sends are still happy (including on Arbitrum One)
- EVM native assets sends are still happy (including on Arbitrum One)

### Engineering

<!-----------------------------------------------------------------------------
Include sufficient information here for an engineer to test your PR. This may include how to test locally, in a built environment, changes to infrastructure etc.
------------------------------------------------------------------------------>

- ☝🏽 

### Operations

<!-----------------------------------------------------------------------------
If your changes have a user-facing impact, describe how a non-technical QA team can functionally test your changes in a preview environment.

If they are not user-facing please describe how to test for any regressions that may occur.
------------------------------------------------------------------------------>

- ☝🏽 

## Screenshots (if applicable)

### Tokens

<img width="537" alt="Screenshot 2024-03-20 at 18 45 16" src="https://github.com/shapeshift/web/assets/17035424/025c4746-6446-4cd4-b764-d3723a395ae0">
<img width="548" alt="Screenshot 2024-03-20 at 18 45 21" src="https://github.com/shapeshift/web/assets/17035424/b039d3e2-92a1-4c4c-82ac-226a8d518767">
<img width="424" alt="Screenshot 2024-03-20 at 18 45 38" src="https://github.com/shapeshift/web/assets/17035424/79116747-fcc9-4d43-9c1d-5638db750e00">

### Native assets

<img width="549" alt="Screenshot 2024-03-20 at 18 45 57" src="https://github.com/shapeshift/web/assets/17035424/1ace9316-c69b-4897-9a3f-a60c2616b48c">
<img width="579" alt="Screenshot 2024-03-20 at 18 46 03" src="https://github.com/shapeshift/web/assets/17035424/51ad7e4d-6d16-42d9-bef9-ac2981c26415">
<img width="532" alt="Screenshot 2024-03-20 at 18 46 18" src="https://github.com/shapeshift/web/assets/17035424/903973b9-f36e-4ffb-a98b-58b01a1d7833">
