### PR TITLE
fix: use higher gas limit node vs zrx api

### DIFF
--- a/src/lib/swapper/swappers/ZrxSwapper/endpoints.ts
+++ b/src/lib/swapper/swappers/ZrxSwapper/endpoints.ts
@@ -68,6 +68,8 @@ export const zrxApi: SwapperApi = {
       value,
       data,
       chainId: Number(fromChainId(chainId).chainReference),
+      // Use the higher amount of the node or the API, as the node doesn't always provide enought gas padding for
+      // total gas used.
       gasLimit: BigNumber.max(gasLimit, estimatedGas).toFixed(),
       ...feeData,
     }

--- a/src/lib/swapper/swappers/ZrxSwapper/endpoints.ts
+++ b/src/lib/swapper/swappers/ZrxSwapper/endpoints.ts
@@ -9,6 +9,7 @@ import type {
   TradeQuote,
 } from '@shapeshiftoss/swapper'
 import type { Result } from '@sniptt/monads/build'
+import { BigNumber } from 'lib/bignumber/bignumber'
 import { assertGetEvmChainAdapter, checkEvmSwapStatus, getFees } from 'lib/utils/evm'
 
 import { getZrxTradeQuote } from './getZrxTradeQuote/getZrxTradeQuote'
@@ -50,9 +51,9 @@ export const zrxApi: SwapperApi = {
 
     if (zrxQuoteResponse.isErr()) throw zrxQuoteResponse.unwrapErr()
 
-    const { value, to, data } = zrxQuoteResponse.unwrap()
+    const { value, to, data, estimatedGas } = zrxQuoteResponse.unwrap()
 
-    const feeData = await getFees({
+    const { gasLimit, ...feeData } = await getFees({
       adapter: assertGetEvmChainAdapter(chainId),
       data,
       to,
@@ -67,6 +68,7 @@ export const zrxApi: SwapperApi = {
       value,
       data,
       chainId: Number(fromChainId(chainId).chainReference),
+      gasLimit: BigNumber.max(gasLimit, estimatedGas).toFixed(),
       ...feeData,
     }
   },


### PR DESCRIPTION
## Description

Current estimations from the node are not providing enough gas padding for `total gas used` even though it is enough to cover `actual gas used`. This change takes the higher gas limit value provided by either the node or api, while still estimating our own gas in every instance to catch any evm state errors (not enough allowance, etc) and still leverage eip1559 fees while ensuring tx doesn't revert on chain.

## Pull Request Type

- [x] :bug: Bug fix (Non-breaking Change: Fixes an issue)
- [ ] :hammer_and_wrench: Chore (Non-breaking Change: Doc updates, pkg upgrades, typos, etc..)
- [ ] :nail_care: New Feature (Breaking/Non-breaking Change)

## Issue (if applicable)

<!-----------------------------------------------------------------------------
If applicable, please link to the github issue and put `closes #XXXX` in your comment to auto-close the issue that your PR fixes.
------------------------------------------------------------------------------>

https://github.com/shapeshift/web/issues/6247

## Risk
> High Risk PRs Require 2 approvals

<!-----------------------------------------------------------------------------
Outline the scope of your changes and the risk associated with them. You must use your discretion as an engineer to determine the potential impact of your changes.

WARNING: If your PR introduces a new on-chain transaction or modifies an existing one, please add the "High-Risk" label to this PR and ask for 2 reviewers to approve it before merging.

E.g. an upgrade to `hdwallet` or core state management would be considered higher risk, and might require a full regression test. UI or isolated view changes, or something behind a feature flag may have near zero risk. Small bug fixes might require testing isolated to the specific fix.
------------------------------------------------------------------------------>

Low - can't make things worse by taking the more aggressive gas limit. there may still be issues with actual estimation that we can look into next and see if we want to short circuit our node estimation entirely.

> What protocols, transaction types or contract interactions might be affected by this PR?

## Testing

<!-----------------------------------------------------------------------------
We treat every PR to be merged with the same scrutiny as if we were merging directly to production.

Your PR will not be merged if you do not complete the sections below for our engineering and operations teams to test.
------------------------------------------------------------------------------>

- Ensure 0x trades are successful with no on chain reverts
    - native -> token, token -> native, token -> token
    - spot check supported chains

### Engineering

<!-----------------------------------------------------------------------------
Include sufficient information here for an engineer to test your PR. This may include how to test locally, in a built environment, changes to infrastructure etc.
------------------------------------------------------------------------------>

:point_up:

### Operations

<!-----------------------------------------------------------------------------
If your changes have a user-facing impact, describe how a non-technical QA team can functionally test your changes in a preview environment.

If they are not user-facing please describe how to test for any regressions that may occur.
------------------------------------------------------------------------------>

:point_up:

## Screenshots (if applicable)
