### PR TITLE
feat: make MM in-app mobile detection happy again (again) (again)

### DIFF
--- a/src/hooks/useIsSnapInstalled/useIsSnapInstalled.tsx
+++ b/src/hooks/useIsSnapInstalled/useIsSnapInstalled.tsx
@@ -15,12 +15,9 @@ const snapId = getConfig().REACT_APP_SNAP_ID
 // Many many user-agents to detect mobile MM and other in-app dApp browsers
 // https://github.com/MetaMask/metamask-mobile/issues/3920#issuecomment-1074188335
 const isBrowser = () => typeof window !== 'undefined'
-const hasEthereum = () => isBrowser() && window.ethereum !== undefined
-const isAndroid = () => /(Android)/i.test(window.navigator.userAgent ?? '')
-const isIOS = () => /(iPhone|iPod|iPad)/i.test(window.navigator.userAgent ?? '')
-const isMobile = () => isIOS() || isAndroid()
-// Is a mobile browser and has injected window.ethereum - we assume in-app dApp browser
-export const checkIsMetaMaskMobileWebView = () => isMobile() && hasEthereum()
+// Is a browser and has MetaMaskMobile user-agent
+export const checkIsMetaMaskMobileWebView = () =>
+  isBrowser() && /(MetaMaskMobile)/i.test(window.navigator.userAgent ?? '')
 
 // https://github.com/wevm/wagmi/blob/21245be51d7c6dff1c7b285226d0c89c4a9d8cac/packages/connectors/src/utils/getInjectedName.ts#L6-L56
 // This will need to be kept up-to-date with the latest list of impersonators


### PR DESCRIPTION
## Description

Simplifies the logic to react on the `MetamaskMobile` user-agent.

Note, this doesn't mean MM mobile will *always* be happy on Android. This now makes the *detection* accurate (i.e show Pair instead of Open) but `window.ethereum` injection is inherently unreliable on Android MM build. All we care about is MM mobile in-app browser being detected, but at this stage we can't do anything more if `window.ethereum` is rugged on a specific system.

## Pull Request Type

- [x] :bug: Bug fix (Non-breaking Change: Fixes an issue)
- [ ] :hammer_and_wrench: Chore (Non-breaking Change: Doc updates, pkg upgrades, typos, etc..)
- [ ] :nail_care: New Feature (Breaking/Non-breaking Change)

## Issue (if applicable)

<!-----------------------------------------------------------------------------
If applicable, please link to the github issue and put `closes #XXXX` in your comment to auto-close the issue that your PR fixes.
------------------------------------------------------------------------------>

closes https://github.com/shapeshift/web/issues/6334

## Risk
> High Risk PRs Require 2 approvals

<!-----------------------------------------------------------------------------
Outline the scope of your changes and the risk associated with them. You must use your discretion as an engineer to determine the potential impact of your changes.

WARNING: If your PR introduces a new on-chain transaction or modifies an existing one, please add the "High-Risk" label to this PR and ask for 2 reviewers to approve it before merging.

E.g. an upgrade to `hdwallet` or core state management would be considered higher risk, and might require a full regression test. UI or isolated view changes, or something behind a feature flag may have near zero risk. Small bug fixes might require testing isolated to the specific fix.
------------------------------------------------------------------------------>

> What protocols, transaction types or contract interactions might be affected by this PR?

None - `MetamaskMobile` is the latest user-agent from MM on in-app browser both in iOS and Android

## Testing

<!-----------------------------------------------------------------------------
We treat every PR to be merged with the same scrutiny as if we were merging directly to production.

Your PR will not be merged if you do not complete the sections below for our engineering and operations teams to test.
------------------------------------------------------------------------------>

- MM option shows "Pair" both on iOS and Android in-app MM browsers

### Engineering

<!-----------------------------------------------------------------------------
Include sufficient information here for an engineer to test your PR. This may include how to test locally, in a built environment, changes to infrastructure etc.
------------------------------------------------------------------------------>

- ☝🏽 

### Operations

<!-----------------------------------------------------------------------------
If your changes have a user-facing impact, describe how a non-technical QA team can functionally test your changes in a preview environment.

If they are not user-facing please describe how to test for any regressions that may occur.
------------------------------------------------------------------------------>

- ☝🏽 

## Screenshots (if applicable)

### iOS

![IMG_5794](https://github.com/shapeshift/web/assets/17035424/d2ae87a2-117f-40dd-9db9-5f7994d904f5)

### Android

Note, this is non-deterministic on Android so you may not necessarily get to a state where you're able to pair, but you'll at least see "Pair"

<img width="537" alt="Screenshot 2024-03-21 at 14 18 28" src="https://github.com/shapeshift/web/assets/17035424/b924759e-591b-4147-a568-4363d0bdadb6">

