### PR TITLE
fix: hide unsupported assets in fiat page asset search

### DIFF
--- a/src/components/AssetSearch/AssetSearch.tsx
+++ b/src/components/AssetSearch/AssetSearch.tsx
@@ -20,14 +20,12 @@ import { AssetList } from './components/AssetList'
 export type AssetSearchProps = {
   assets: Asset[]
   onAssetClick?: (asset: Asset) => void
-  disableUnsupported?: boolean
   formProps?: BoxProps
   allowWalletUnsupportedAssets?: boolean
 }
 export const AssetSearch: FC<AssetSearchProps> = ({
   assets,
   onAssetClick,
-  disableUnsupported,
   formProps,
   allowWalletUnsupportedAssets,
 }) => {
@@ -132,7 +130,7 @@ export const AssetSearch: FC<AssetSearchProps> = ({
           mb='10'
           assets={listAssets}
           handleClick={handleClick}
-          disableUnsupported={disableUnsupported}
+          disableUnsupported={!allowWalletUnsupportedAssets}
         />
       </Box>
     </>

--- a/src/components/Modals/FiatRamps/views/FiatForm.tsx
+++ b/src/components/Modals/FiatRamps/views/FiatForm.tsx
@@ -63,7 +63,7 @@ export const FiatForm: React.FC<FiatFormProps> = ({
       assetSearch.open({
         onAssetClick: (asset: Asset) => setSelectedAssetId(asset.assetId),
         assets: fiatRampAction === FiatRampAction.Buy ? buyAssets : sellAssets,
-        disableUnsupported: true,
+        allowWalletUnsupportedAssets: false,
       })
     },
     [wallet, assetSearch, buyAssets, sellAssets],


### PR DESCRIPTION
## Description

Fixes issue where users can select assets which are unsupported by the wallet on the fiat page.

## Pull Request Type

- [x] :bug: Bug fix (Non-breaking Change: Fixes an issue)
- [ ] :hammer_and_wrench: Chore (Non-breaking Change: Doc updates, pkg upgrades, typos, etc..)
- [ ] :nail_care: New Feature (Breaking/Non-breaking Change)

## Issue (if applicable)

NA

## Risk
> High Risk PRs Require 2 approvals

 Low risk.

> What protocols, transaction types or contract interactions might be affected by this PR?

## Testing

Check that only assets supported by the wallet are able to be selected on the fiat page (e.g all assets for native, only EVMs for metamask without snap)

### Engineering

<!-----------------------------------------------------------------------------
Include sufficient information here for an engineer to test your PR. This may include how to test locally, in a built environment, changes to infrastructure etc.
------------------------------------------------------------------------------>

### Operations

<!-----------------------------------------------------------------------------
If your changes have a user-facing impact, describe how a non-technical QA team can functionally test your changes in a preview environment.

If they are not user-facing please describe how to test for any regressions that may occur.
------------------------------------------------------------------------------>

## Screenshots (if applicable)
