### PR TITLE
fix: allow load more recent txs on wallet overview

### DIFF
--- a/src/components/TransactionHistory/TransactionHistoryList.tsx
+++ b/src/components/TransactionHistory/TransactionHistoryList.tsx
@@ -12,11 +12,12 @@ import { useAppSelector } from 'state/store'
 type TransactionHistoryListProps = {
   txIds: TxId[]
   useCompactMode?: boolean
+  initialTxsCount?: number
 }
 
 export const TransactionHistoryList: React.FC<TransactionHistoryListProps> = memo(
-  ({ txIds, useCompactMode = false }) => {
-    const { next, data, hasMore } = useInfiniteScroll(txIds)
+  ({ txIds, useCompactMode = false, initialTxsCount }) => {
+    const { next, data, hasMore } = useInfiniteScroll(txIds, initialTxsCount)
     const isAnyTxHistoryApiQueryPending = useAppSelector(selectIsAnyTxHistoryApiQueryPending)
     const translate = useTranslate()
 

--- a/src/hooks/useInfiniteScroll/useInfiniteScroll.tsx
+++ b/src/hooks/useInfiniteScroll/useInfiniteScroll.tsx
@@ -2,8 +2,8 @@ import { useCallback, useMemo, useState } from 'react'
 
 const defaultAmount = 20
 
-export const useInfiniteScroll = (array: any[]) => {
-  const [amount, setAmount] = useState(defaultAmount)
+export const useInfiniteScroll = (array: any[], initialTxsCount?: number) => {
+  const [amount, setAmount] = useState(initialTxsCount ?? defaultAmount)
 
   const next = useCallback(() => {
     setAmount(prevAmount => prevAmount + defaultAmount)

--- a/src/pages/Dashboard/RecentTransactions.tsx
+++ b/src/pages/Dashboard/RecentTransactions.tsx
@@ -27,7 +27,7 @@ export const RecentTransactions: React.FC<RecentTransactionProps> = memo(
             </Button>
           )}
         </CardHeader>
-        <TransactionHistoryList txIds={txIds} useCompactMode={true} />
+        <TransactionHistoryList txIds={txIds} useCompactMode={true} initialTxsCount={limit} />
       </Card>
     )
   },

--- a/src/pages/Dashboard/RecentTransactions.tsx
+++ b/src/pages/Dashboard/RecentTransactions.tsx
@@ -7,13 +7,13 @@ import { NavLink } from 'react-router-dom'
 import { Text } from 'components/Text'
 import { TransactionHistoryList } from 'components/TransactionHistory/TransactionHistoryList'
 import type { ReduxState } from 'state/reducer'
-import { selectLastNTxIds } from 'state/slices/selectors'
+import { selectTxIds } from 'state/slices/selectors'
 
 type RecentTransactionProps = { limit?: number; viewMoreLink?: boolean } & CardProps
 
 export const RecentTransactions: React.FC<RecentTransactionProps> = memo(
   ({ limit = 10, viewMoreLink, ...rest }) => {
-    const recentTxIds = useSelector((state: ReduxState) => selectLastNTxIds(state, limit))
+    const txIds = useSelector((state: ReduxState) => selectTxIds(state))
     const translate = useTranslate()
     return (
       <Card variant='dashboard' {...rest}>
@@ -27,7 +27,7 @@ export const RecentTransactions: React.FC<RecentTransactionProps> = memo(
             </Button>
           )}
         </CardHeader>
-        <TransactionHistoryList txIds={recentTxIds} useCompactMode={true} />
+        <TransactionHistoryList txIds={txIds} useCompactMode={true} />
       </Card>
     )
   },

--- a/src/pages/Dashboard/RecentTransactions.tsx
+++ b/src/pages/Dashboard/RecentTransactions.tsx
@@ -6,14 +6,13 @@ import { useSelector } from 'react-redux'
 import { NavLink } from 'react-router-dom'
 import { Text } from 'components/Text'
 import { TransactionHistoryList } from 'components/TransactionHistory/TransactionHistoryList'
-import type { ReduxState } from 'state/reducer'
 import { selectTxIds } from 'state/slices/selectors'
 
 type RecentTransactionProps = { limit?: number; viewMoreLink?: boolean } & CardProps
 
 export const RecentTransactions: React.FC<RecentTransactionProps> = memo(
   ({ limit = 10, viewMoreLink, ...rest }) => {
-    const txIds = useSelector((state: ReduxState) => selectTxIds(state))
+    const txIds = useSelector(selectTxIds)
     const translate = useTranslate()
     return (
       <Card variant='dashboard' {...rest}>


### PR DESCRIPTION
## Description

Allow "Load more" button to work on the "My Wallet" route, "Overview" tab.

We were previously passing the first n transactions (`8`), which limited the size of the list that could be "loaded".
Now with incremental load we can let this component work like the "Activity" tab, using the full TX history in the store.

## Pull Request Type

- [x] :bug: Bug fix (Non-breaking Change: Fixes an issue)
- [ ] :hammer_and_wrench: Chore (Non-breaking Change: Doc updates, pkg upgrades, typos, etc..)
- [ ] :nail_care: New Feature (Breaking/Non-breaking Change)

## Issue (if applicable)

Closes https://github.com/shapeshift/web/issues/6546

## Risk

Low

> What protocols, transaction types or contract interactions might be affected by this PR?

None.

## Testing

On the "My Wallet" route, "Overview" tab, the "Load more" button should now be enabled, and actually load more transactions.

### Engineering

☝️

### Operations

☝️

## Screenshots (if applicable)

<img width="750" alt="Screenshot 2024-03-25 at 12 42 16 PM" src="https://github.com/shapeshift/web/assets/97164662/1c16a3d4-a2d6-44c6-9612-c2edde09b597">
