### PR TITLE
fix: borked approval swapper step

### DIFF
--- a/src/components/MultiHopTrade/components/MultiHopTradeConfirm/components/ApprovalStep.tsx
+++ b/src/components/MultiHopTrade/components/MultiHopTradeConfirm/components/ApprovalStep.tsx
@@ -243,6 +243,9 @@ const ApprovalStepComplete = ({
     )
   }, [isError, tradeQuoteStep, txHash])
 
+  // This should never happen as this should be render for *complete* approvals - but it may
+  if (!txHash) return null
+
   return (
     <StepperStep
       title={translate('trade.approvalTitle')}

--- a/src/components/MultiHopTrade/components/MultiHopTradeConfirm/hooks/useIsApprovalInitiallyNeeded.tsx
+++ b/src/components/MultiHopTrade/components/MultiHopTradeConfirm/hooks/useIsApprovalInitiallyNeeded.tsx
@@ -21,11 +21,14 @@ const useIsApprovalInitiallyNeededForHop = (
   const { isLoading, isApprovalNeeded } = useIsApprovalNeeded(tradeQuoteStep, sellAssetAccountId)
 
   useEffect(() => {
+    // We already have *initial* approval requirements. The whole intent of this hook is to return initial allowance requirements,
+    // so we never want to overwrite them with subsequent allowance results.
+    if (isApprovalInitiallyNeeded !== undefined) return
     // stop polling on first result
     if (!isLoading && isApprovalNeeded !== undefined) {
       setIsApprovalInitiallyNeeded(isApprovalNeeded)
     }
-  }, [isApprovalNeeded, isLoading])
+  }, [isApprovalInitiallyNeeded, isApprovalNeeded, isLoading])
 
   return {
     isLoading: isApprovalInitiallyNeeded === undefined || isLoading,


### PR DESCRIPTION
## Description

~~Note, I wasn't able to repro https://github.com/shapeshift/web/issues/6581 after many many swaps so this PR is mostly paranoia - we're mostly concerned about approval step still being displayed for swappers when there *was* one, rather than hiding it when there *wasn't*~~

Disregard the above - the root cause was us being overly reactive in `useIsApprovalInitiallyNeededForHop`. As the name suggests, the intent of this hook is to detect *initial* allowance requirements and to never mutate said value after during its lifecycle (i.e until it's unmounted, since hooks aren't singletons, a new mounted instance on a diff swap will be a new reference and start again from `undefined` initial state, as it should).

As we were being overly reactive, we were detecting the newly-approved status of the token after approval, then firing this guy:

https://github.com/shapeshift/web/blob/599cac66eaf4ca39e711756f4d73b6ad19ea83a6/src/components/MultiHopTrade/components/MultiHopTradeConfirm/hooks/useIsApprovalInitiallyNeeded.tsx#L60-L63

In turn, consumers of `selectHopExecutionMetadata` (i.e `<Hop />` and `<Approval />` namely) were assuming approval was never needed in the first place, which resulted in the approval step disappearing entirely after succesful approval.

This PR now ensures alignment between the *originally needed* intent and actual behavior of this hook, making the approval swapper step sane again.
 

## Pull Request Type

- [ ] :bug: Bug fix (Non-breaking Change: Fixes an issue)
- [ ] :hammer_and_wrench: Chore (Non-breaking Change: Doc updates, pkg upgrades, typos, etc..)
- [x] :nail_care: New Feature (Breaking/Non-breaking Change)

## Issue (if applicable)

<!-----------------------------------------------------------------------------
If applicable, please link to the github issue and put `closes #XXXX` in your comment to auto-close the issue that your PR fixes.
------------------------------------------------------------------------------>

closes https://github.com/shapeshift/web/issues/6581

## Risk
> High Risk PRs Require 2 approvals

<!-----------------------------------------------------------------------------
Outline the scope of your changes and the risk associated with them. You must use your discretion as an engineer to determine the potential impact of your changes.

WARNING: If your PR introduces a new on-chain transaction or modifies an existing one, please add the "High-Risk" label to this PR and ask for 2 reviewers to approve it before merging.

E.g. an upgrade to `hdwallet` or core state management would be considered higher risk, and might require a full regression test. UI or isolated view changes, or something behind a feature flag may have near zero risk. Small bug fixes might require testing isolated to the specific fix.
------------------------------------------------------------------------------>

Low

> What protocols, transaction types or contract interactions might be affected by this PR?

## Testing

<!-----------------------------------------------------------------------------
We treat every PR to be merged with the same scrutiny as if we were merging directly to production.

Your PR will not be merged if you do not complete the sections below for our engineering and operations teams to test.
------------------------------------------------------------------------------>

- Approval step is rendered *both* before and after approval (with the presence of a Txid after) at swapper pending and complete stages
- Approval step is *not* rendered - either at swapper pending or complete stage - when no approval is needed

### Engineering

<!-----------------------------------------------------------------------------
Include sufficient information here for an engineer to test your PR. This may include how to test locally, in a built environment, changes to infrastructure etc.
------------------------------------------------------------------------------>

- ☝🏽 

### Operations

<!-----------------------------------------------------------------------------
If your changes have a user-facing impact, describe how a non-technical QA team can functionally test your changes in a preview environment.

If they are not user-facing please describe how to test for any regressions that may occur.
------------------------------------------------------------------------------>

- ☝🏽 

## Screenshots (if applicable)

### Develop

https://github.com/shapeshift/web/assets/17035424/3e77c345-5c50-4a19-839e-3d5b5365b35f

### This diff



https://github.com/shapeshift/web/assets/17035424/b3d7cfd8-37ed-4f07-8554-90bd3280385a


