### PR TITLE
feat: cow affiliate fees

### DIFF
--- a/src/lib/swapper/swappers/CowSwapper/endpoints.ts
+++ b/src/lib/swapper/swappers/CowSwapper/endpoints.ts
@@ -34,6 +34,7 @@ import {
 } from './utils/constants'
 import { cowService } from './utils/cowService'
 import {
+  getAffiliateAppDataFragmentByChainId,
   getCowswapNetwork,
   getFullAppData,
   getNowPlusThirtyMinutesTimestamp,
@@ -79,7 +80,14 @@ export const cowApi: SwapperApi = {
     const network = maybeNetwork.unwrap()
     const baseUrl = getConfig().REACT_APP_COWSWAP_BASE_URL
 
-    const { appData, appDataHash } = await getFullAppData(slippageTolerancePercentageDecimal)
+    const affiliateAppDataFragment = getAffiliateAppDataFragmentByChainId({
+      affiliateBps: tradeQuote.affiliateBps,
+      chainId: sellAsset.chainId,
+    })
+    const { appData, appDataHash } = await getFullAppData(
+      slippageTolerancePercentageDecimal,
+      affiliateAppDataFragment,
+    )
     // https://api.cow.fi/docs/#/default/post_api_v1_quote
     const maybeQuoteResponse = await cowService.post<CowSwapQuoteResponse>(
       `${baseUrl}/${network}/api/v1/quote/`,

--- a/src/lib/swapper/swappers/CowSwapper/endpoints.ts
+++ b/src/lib/swapper/swappers/CowSwapper/endpoints.ts
@@ -126,7 +126,9 @@ export const cowApi: SwapperApi = {
     const buyAmountAfterAffiliateFeesAndSlippageCryptoBaseUnit = bn(
       buyAmountAfterAffiliateFeesCryptoBaseUnit,
     )
-      .minus(bn(quoteBuyAmount).times(slippageTolerancePercentageDecimal))
+      .minus(
+        bn(buyAmountAfterAffiliateFeesCryptoBaseUnit).times(slippageTolerancePercentageDecimal),
+      )
       .toFixed(0)
 
     // CoW API and flow is weird - same idea as the mutation above, we need to incorporate protocol fees into the order

--- a/src/lib/swapper/swappers/CowSwapper/endpoints.ts
+++ b/src/lib/swapper/swappers/CowSwapper/endpoints.ts
@@ -117,7 +117,9 @@ export const cowApi: SwapperApi = {
       : quoteBuyAmount
     const buyAmountAfterAffiliateFeesAndSlippageCryptoBaseUnit = bn(
       buyAmountAfterAffiliateFeesCryptoBaseUnit,
-    ).minus(bn(quoteBuyAmount).times(slippageTolerancePercentageDecimal))
+    )
+      .minus(bn(quoteBuyAmount).times(slippageTolerancePercentageDecimal))
+      .toFixed(0)
 
     // CoW API and flow is weird - same idea as the mutation above, we need to incorporate protocol fees into the order
     // This was previously working as-is with fees being deducted from the sell amount at protocol-level, but we now we need to add them into the order
@@ -131,7 +133,7 @@ export const cowApi: SwapperApi = {
       // Another mutation from the original quote to go around the fact that CoW API flow is weird
       // they return us a quote with fees, but we have to zero them out when sending the order
       feeAmount: '0',
-      buyAmount: buyAmountAfterAffiliateFeesAndSlippageCryptoBaseUnit.toFixed(0),
+      buyAmount: buyAmountAfterAffiliateFeesAndSlippageCryptoBaseUnit,
       sellAmount: sellAmountPlusProtocolFees.toFixed(0),
       // from,
       sellTokenBalance: ERC20_TOKEN_BALANCE,

--- a/src/lib/swapper/swappers/CowSwapper/endpoints.ts
+++ b/src/lib/swapper/swappers/CowSwapper/endpoints.ts
@@ -16,7 +16,7 @@ import type { Result } from '@sniptt/monads/build'
 import { getConfig } from 'config'
 import { getDefaultSlippageDecimalPercentageForSwapper } from 'constants/constants'
 import { v4 as uuid } from 'uuid'
-import { bn } from 'lib/bignumber/bignumber'
+import { bn, bnOrZero } from 'lib/bignumber/bignumber'
 import { createDefaultStatusResponse } from 'lib/utils/evm'
 import { convertBasisPointsToDecimalPercentage } from 'state/slices/tradeQuoteSlice/utils'
 
@@ -115,7 +115,7 @@ export const cowApi: SwapperApi = {
     // Failure to do so means orders may take forever to be filled, or never be filled at all.
     const quoteBuyAmount = quote.buyAmount
 
-    const hasAffiliateFee = bn(tradeQuote.affiliateBps).gt(0)
+    const hasAffiliateFee = bnOrZero(tradeQuote.affiliateBps).gt(0)
 
     // Remove affiliate fees off the buyAmount to get the amount after affiliate fees, but before slippage bips
     const buyAmountAfterAffiliateFeesCryptoBaseUnit = hasAffiliateFee

--- a/src/lib/swapper/swappers/CowSwapper/getCowSwapTradeQuote/getCowSwapTradeQuote.ts
+++ b/src/lib/swapper/swappers/CowSwapper/getCowSwapTradeQuote/getCowSwapTradeQuote.ts
@@ -113,10 +113,8 @@ export async function getCowSwapTradeQuote(
   const quote: TradeQuote = {
     id: data.id.toString(),
     receiveAddress,
-    // CowSwap does not support affiliate bps
-    // But we still need to return them as 0, so they are properly displayed as such at view-layer
-    affiliateBps: '0',
-    potentialAffiliateBps: '0',
+    affiliateBps,
+    potentialAffiliateBps,
     rate,
     slippageTolerancePercentageDecimal,
     steps: [

--- a/src/lib/swapper/swappers/CowSwapper/getCowSwapTradeQuote/getCowSwapTradeQuote.ts
+++ b/src/lib/swapper/swappers/CowSwapper/getCowSwapTradeQuote/getCowSwapTradeQuote.ts
@@ -38,8 +38,6 @@ export async function getCowSwapTradeQuote(
     affiliateBps,
   } = input
 
-  console.log({ potentialAffiliateBps, affiliateBps })
-
   const slippageTolerancePercentageDecimal =
     input.slippageTolerancePercentageDecimal ??
     getDefaultSlippageDecimalPercentageForSwapper(SwapperName.CowSwap)

--- a/src/lib/swapper/swappers/CowSwapper/getCowSwapTradeQuote/getCowSwapTradeQuote.ts
+++ b/src/lib/swapper/swappers/CowSwapper/getCowSwapTradeQuote/getCowSwapTradeQuote.ts
@@ -99,16 +99,15 @@ export async function getCowSwapTradeQuote(
 
   const { data } = maybeQuoteResponse.unwrap()
 
-  const {
-    feeAmount: feeAmountInSellTokenCryptoBaseUnit,
-    buyAmount: buyAmountAfterFeesCryptoBaseUnit,
-  } = data.quote
+  const { feeAmount: feeAmountInSellTokenCryptoBaseUnit } = data.quote
 
-  const { rate, buyAmountBeforeFeesCryptoBaseUnit } = getValuesFromQuoteResponse({
-    buyAsset,
-    sellAsset,
-    response: data,
-  })
+  const { rate, buyAmountAfterFeesCryptoBaseUnit, buyAmountBeforeFeesCryptoBaseUnit } =
+    getValuesFromQuoteResponse({
+      buyAsset,
+      sellAsset,
+      response: data,
+      affiliateBps,
+    })
 
   const quote: TradeQuote = {
     id: data.id.toString(),

--- a/src/lib/swapper/swappers/CowSwapper/getCowSwapTradeQuote/getCowSwapTradeQuote.ts
+++ b/src/lib/swapper/swappers/CowSwapper/getCowSwapTradeQuote/getCowSwapTradeQuote.ts
@@ -34,7 +34,11 @@ export async function getCowSwapTradeQuote(
     chainId,
     receiveAddress,
     sellAmountIncludingProtocolFeesCryptoBaseUnit,
+    potentialAffiliateBps,
+    affiliateBps,
   } = input
+
+  console.log({ potentialAffiliateBps, affiliateBps })
 
   const slippageTolerancePercentageDecimal =
     input.slippageTolerancePercentageDecimal ??

--- a/src/lib/swapper/swappers/CowSwapper/getCowSwapTradeQuote/getCowSwapTradeQuote.ts
+++ b/src/lib/swapper/swappers/CowSwapper/getCowSwapTradeQuote/getCowSwapTradeQuote.ts
@@ -17,6 +17,7 @@ import {
 import { cowService } from 'lib/swapper/swappers/CowSwapper/utils/cowService'
 import {
   assertValidTrade,
+  getAffiliateAppDataFragmentByChainId,
   getCowswapNetwork,
   getFullAppData,
   getNowPlusThirtyMinutesTimestamp,
@@ -59,7 +60,15 @@ export async function getCowSwapTradeQuote(
   const network = maybeNetwork.unwrap()
   const baseUrl = getConfig().REACT_APP_COWSWAP_BASE_URL
 
-  const { appData, appDataHash } = await getFullAppData(slippageTolerancePercentageDecimal)
+  const affiliateAppDataFragment = getAffiliateAppDataFragmentByChainId({
+    affiliateBps,
+    chainId: sellAsset.chainId,
+  })
+
+  const { appData, appDataHash } = await getFullAppData(
+    slippageTolerancePercentageDecimal,
+    affiliateAppDataFragment,
+  )
 
   // https://api.cow.fi/docs/#/default/post_api_v1_quote
   const maybeQuoteResponse = await cowService.post<CowSwapQuoteResponse>(

--- a/src/lib/swapper/swappers/CowSwapper/types.ts
+++ b/src/lib/swapper/swappers/CowSwapper/types.ts
@@ -49,7 +49,7 @@ export type CowSwapGetTransactionsResponse = {
 export type AffiliateAppDataFragment =
   | {
       partnerFee: {
-        bps: string
+        bps: number
         recipient: string
       }
     }

--- a/src/lib/swapper/swappers/CowSwapper/types.ts
+++ b/src/lib/swapper/swappers/CowSwapper/types.ts
@@ -45,3 +45,12 @@ export type CowSwapGetTradesResponse = {
 export type CowSwapGetTransactionsResponse = {
   status: 'presignaturePending' | 'open' | 'fulfilled' | 'cancelled' | 'expired'
 }[]
+
+export type AffiliateAppDataFragment =
+  | {
+      partnerFee: {
+        bps: string
+        recipient: string
+      }
+    }
+  | { partnerFee?: never }

--- a/src/lib/swapper/swappers/CowSwapper/types.ts
+++ b/src/lib/swapper/swappers/CowSwapper/types.ts
@@ -46,11 +46,9 @@ export type CowSwapGetTransactionsResponse = {
   status: 'presignaturePending' | 'open' | 'fulfilled' | 'cancelled' | 'expired'
 }[]
 
-export type AffiliateAppDataFragment =
-  | {
-      partnerFee: {
-        bps: number
-        recipient: string
-      }
-    }
-  | { partnerFee?: never }
+export type AffiliateAppDataFragment = {
+  partnerFee?: {
+    bps: number
+    recipient: string
+  }
+}

--- a/src/lib/swapper/swappers/CowSwapper/utils/helpers/helpers.ts
+++ b/src/lib/swapper/swappers/CowSwapper/utils/helpers/helpers.ts
@@ -264,7 +264,7 @@ export const getAffiliateAppDataFragmentByChainId = ({
 
   return {
     partnerFee: {
-      bps: convertBasisPointsToDecimalPercentage(affiliateBps).times(100).toFixed(),
+      bps: Number(affiliateBps),
       recipient: getTreasuryAddressFromChainId(chainId),
     },
   }

--- a/src/lib/swapper/swappers/CowSwapper/utils/helpers/helpers.ts
+++ b/src/lib/swapper/swappers/CowSwapper/utils/helpers/helpers.ts
@@ -177,7 +177,7 @@ export const getValuesFromQuoteResponse = ({
     buyAmount,
   } = response.quote
 
-  const hasAffiliateFee = bn(affiliateBps).gt(0)
+  const hasAffiliateFee = bnOrZero(affiliateBps).gt(0)
   // Remove affiliate fees off the buyAmount to get the amount after affiliate fees, but before slippage bips
   const buyAmountAfterFeesCryptoBaseUnit = hasAffiliateFee
     ? bn(buyAmount)
@@ -259,7 +259,7 @@ export const getAffiliateAppDataFragmentByChainId = ({
   affiliateBps: string
   chainId: ChainId
 }): AffiliateAppDataFragment => {
-  const hasAffiliateFee = bn(affiliateBps).gt(0)
+  const hasAffiliateFee = bnOrZero(affiliateBps).gt(0)
   if (!hasAffiliateFee) return {}
 
   return {

--- a/src/lib/swapper/swappers/CowSwapper/utils/helpers/helpers.ts
+++ b/src/lib/swapper/swappers/CowSwapper/utils/helpers/helpers.ts
@@ -184,8 +184,6 @@ export const getValuesFromQuoteResponse = ({
         .toFixed(0)
     : buyAmount
 
-  debugger
-
   const buyAmountAfterFeesCryptoPrecision = fromBaseUnit(
     buyAmountAfterFeesCryptoBaseUnit,
     buyAsset.precision,


### PR DESCRIPTION
## Description

This PR:

- Calculates the amount after fees including affiliate fees
- Ensure the buyAmount in appData is *first* affiliate-fee deducted (if applicable) before being slippage deducted
- Constructs appData with recipient and bps as a percentage (0-100) according to CoW's AppData spec

## Pull Request Type

- [ ] :bug: Bug fix (Non-breaking Change: Fixes an issue)
- [ ] :hammer_and_wrench: Chore (Non-breaking Change: Doc updates, pkg upgrades, typos, etc..)
- [x] :nail_care: New Feature (Breaking/Non-breaking Change)

## Issue (if applicable)

<!-----------------------------------------------------------------------------
If applicable, please link to the github issue and put `closes #XXXX` in your comment to auto-close the issue that your PR fixes.
------------------------------------------------------------------------------>

closes https://github.com/shapeshift/web/issues/6610

## Risk
> High Risk PRs Require 2 approvals

<!-----------------------------------------------------------------------------
Outline the scope of your changes and the risk associated with them. You must use your discretion as an engineer to determine the potential impact of your changes.

WARNING: If your PR introduces a new on-chain transaction or modifies an existing one, please add the "High-Risk" label to this PR and ask for 2 reviewers to approve it before merging.

E.g. an upgrade to `hdwallet` or core state management would be considered higher risk, and might require a full regression test. UI or isolated view changes, or something behind a feature flag may have near zero risk. Small bug fixes might require testing isolated to the specific fix.
------------------------------------------------------------------------------>

Low, though if we get this wrong, solvers won't process the order and it may be stuck forever

> What protocols, transaction types or contract interactions might be affected by this PR?

## Testing

<!-----------------------------------------------------------------------------
We treat every PR to be merged with the same scrutiny as if we were merging directly to production.

Your PR will not be merged if you do not complete the sections below for our engineering and operations teams to test.
------------------------------------------------------------------------------>

- CoW orders are still happy without affiliate fees
- CoW quotes now have affiliate fees if applicable (higher than the minimum no-fees threshold, and not enough FOX held for full fees waiving)
- Fees are deducted at receive amount time (compare against prod with a similar quote)
- CoW orders with fees still execute properly

### Engineering

<!-----------------------------------------------------------------------------
Include sufficient information here for an engineer to test your PR. This may include how to test locally, in a built environment, changes to infrastructure etc.
------------------------------------------------------------------------------>

- ☝🏽 
- Test with the monkey patch below to get fees even on smaller swaps

```diff
diff --git a/src/lib/fees/parameters/swapper.ts b/src/lib/fees/parameters/swapper.ts
index 00c8e46ce1..a65bdc854d 100644
--- a/src/lib/fees/parameters/swapper.ts
+++ b/src/lib/fees/parameters/swapper.ts
@@ -2,7 +2,7 @@ import type { FeeCurveParameters } from './types'
 
 const FEE_CURVE_MAX_FEE_BPS = 49 // basis points
 const FEE_CURVE_MIN_FEE_BPS = 10 // basis points
-const FEE_CURVE_NO_FEE_THRESHOLD_USD = 1_000 // usd
+const FEE_CURVE_NO_FEE_THRESHOLD_USD = 1 // usd
 const FEE_CURVE_FOX_MAX_DISCOUNT_THRESHOLD = 300_000 // fox
 const FEE_CURVE_MIDPOINT_USD = 150_000 // usd
 const FEE_CURVE_STEEPNESS_K = 40_000 // unitless
```
### Operations

<!-----------------------------------------------------------------------------
If your changes have a user-facing impact, describe how a non-technical QA team can functionally test your changes in a preview environment.

If they are not user-facing please describe how to test for any regressions that may occur.
------------------------------------------------------------------------------>

## Screenshots (if applicable)

### Prod (left) vs this diff (right)

#### Bigly swap

<img width="1726" alt="image" src="https://github.com/shapeshift/web/assets/17035424/ce469d19-ca47-4ee1-b07e-db892fc9bc66">

Note this now makes the protocol fee actually correct - 0bps previously should obviously be 0$

#### Smallish swap

<img width="1728" alt="image" src="https://github.com/shapeshift/web/assets/17035424/d48fcf41-d0dc-4a39-abd8-3e280fcc32f7">

Notice no difference against prod here since affiliate fees are waived by small trade threshold

### E2E swap with the monkey-patch above


<img width="969" alt="image" src="https://github.com/shapeshift/web/assets/17035424/ce4a7df6-b89a-4b25-bb3c-727a28e2b3cc">
<img width="514" alt="image" src="https://github.com/shapeshift/web/assets/17035424/81138822-b6f6-4a95-beff-b0a733a73092">
<img width="482" alt="image" src="https://github.com/shapeshift/web/assets/17035424/fc393905-455b-4863-9758-1879b6a46cc5">
<img width="544" alt="image" src="https://github.com/shapeshift/web/assets/17035424/195880c7-b4ef-400a-a38c-a0257ce67603">
<img width="1430" alt="image" src="https://github.com/shapeshift/web/assets/17035424/ec377f4a-7f2a-47f8-a954-c03f54d8f817">


https://explorer.cow.fi/gc/orders/0x9c3f70e49560ec1868754b30061de1cdea6872462bf7328e75d0d615f32f62225daf465a9ccf64deb146eeae9e7bd40d6761c986660d5420?tab=overview
https://gnosisscan.io/tx/0x5db39bc658e7e66f21a3a5a4212227bc6d86f43b5b67c58c28942e4995081602

<!-- av pr metadata
This information is embedded by the av CLI when creating PRs to track the status of stacks when using Aviator. Please do not delete or edit this section of the PR.
```
{"parent":"develop","parentHead":"","trunk":"develop"}
```
-->
