### PR TITLE
feat: collect 0x trade surplus

### DIFF
--- a/src/lib/swapper/swappers/ZrxSwapper/utils/fetchFromZrx.ts
+++ b/src/lib/swapper/swappers/ZrxSwapper/utils/fetchFromZrx.ts
@@ -59,6 +59,7 @@ export const fetchFromZrx = async <T extends 'price' | 'quote'>({
         getDefaultSlippageDecimalPercentageForSwapper(SwapperName.Zrx),
       ...(maybeTreasuryAddress && {
         feeRecipient: maybeTreasuryAddress, // Where affiliate fees are sent
+        feeRecipientTradeSurplus: maybeTreasuryAddress, // Where trade surplus is sent
         buyTokenPercentageFee: convertBasisPointsToDecimalPercentage(affiliateBps).toNumber(),
       }),
     },


### PR DESCRIPTION
## Description

Collect trade surplus from 0x trades.

Any positive slippage amount will be sent to the buy assets corresponding treasury address (the same address that the affiliate fees are sent).

See https://0x.org/docs/0x-swap-api/guides/monetize-your-app-using-swap#option-2-collect-trade-surplus

## Pull Request Type

- [ ] :bug: Bug fix (Non-breaking Change: Fixes an issue)
- [ ] :hammer_and_wrench: Chore (Non-breaking Change: Doc updates, pkg upgrades, typos, etc..)
- [x] :nail_care: New Feature (Breaking/Non-breaking Change)

## Issue (if applicable)

N/A

## Risk

Low - additional arg on 0x quote requests.

> What protocols, transaction types or contract interactions might be affected by this PR?

0x trades.

## Testing

- Quotes from 0x should include a `feeRecipientTradeSurplus` key in the request payload.
- 0x quotes and trades should succeed

<img width="510" alt="Screenshot 2024-04-03 at 12 24 33 PM" src="https://github.com/shapeshift/web/assets/97164662/c64bce36-a58f-48c1-bd76-e5d57e23f9ba">

### Engineering

☝️

### Operations

☝️

## Screenshots (if applicable)

N/A