### PR TITLE
feat: use proxy validation endpoint

### DIFF
--- a/packages/chain-adapters/src/cosmossdk/CosmosSdkBaseAdapter.ts
+++ b/packages/chain-adapters/src/cosmossdk/CosmosSdkBaseAdapter.ts
@@ -30,7 +30,7 @@ import type {
 import { CONTRACT_INTERACTION, ValidAddressResultType } from '../types'
 import { toAddressNList, toRootDerivationPath } from '../utils'
 import { bnOrZero } from '../utils/bignumber'
-import { validateAddress } from '../utils/validateAddress'
+import { assertAddressNotSanctioned } from '../utils/validateAddress'
 import type { cosmos, thorchain } from './'
 import type {
   BuildTransactionInput,
@@ -320,8 +320,8 @@ export abstract class CosmosSdkBaseAdapter<T extends CosmosSdkChainId> implement
     hex,
   }: BroadcastTransactionInput): Promise<string> {
     await Promise.all([
-      validateAddress(senderAddress),
-      receiverAddress !== CONTRACT_INTERACTION && validateAddress(receiverAddress),
+      assertAddressNotSanctioned(senderAddress),
+      receiverAddress !== CONTRACT_INTERACTION && assertAddressNotSanctioned(receiverAddress),
     ])
 
     try {

--- a/packages/chain-adapters/src/cosmossdk/cosmos/CosmosChainAdapter.ts
+++ b/packages/chain-adapters/src/cosmossdk/cosmos/CosmosChainAdapter.ts
@@ -22,7 +22,7 @@ import type {
 } from '../../types'
 import { ChainAdapterDisplayName, CONTRACT_INTERACTION } from '../../types'
 import { bn, calcFee, toAddressNList } from '../../utils'
-import { validateAddress } from '../../utils/validateAddress'
+import { assertAddressNotSanctioned } from '../../utils/validateAddress'
 import type { ChainAdapterArgs as BaseChainAdapterArgs } from '../CosmosSdkBaseAdapter'
 import { assertIsValidatorAddress, CosmosSdkBaseAdapter } from '../CosmosSdkBaseAdapter'
 import type {
@@ -305,8 +305,8 @@ export class ChainAdapter extends CosmosSdkBaseAdapter<KnownChainIds.CosmosMainn
     signTxInput,
   }: SignAndBroadcastTransactionInput<KnownChainIds.CosmosMainnet>): Promise<string> {
     await Promise.all([
-      validateAddress(senderAddress),
-      receiverAddress !== CONTRACT_INTERACTION && validateAddress(receiverAddress),
+      assertAddressNotSanctioned(senderAddress),
+      receiverAddress !== CONTRACT_INTERACTION && assertAddressNotSanctioned(receiverAddress),
     ])
 
     const { wallet } = signTxInput

--- a/packages/chain-adapters/src/cosmossdk/thorchain/ThorchainChainAdapter.ts
+++ b/packages/chain-adapters/src/cosmossdk/thorchain/ThorchainChainAdapter.ts
@@ -20,7 +20,7 @@ import type {
 import { ChainAdapterDisplayName, CONTRACT_INTERACTION } from '../../types'
 import { toAddressNList } from '../../utils'
 import { bnOrZero } from '../../utils/bignumber'
-import { validateAddress } from '../../utils/validateAddress'
+import { assertAddressNotSanctioned } from '../../utils/validateAddress'
 import type { ChainAdapterArgs as BaseChainAdapterArgs } from '../CosmosSdkBaseAdapter'
 import { CosmosSdkBaseAdapter } from '../CosmosSdkBaseAdapter'
 import type { ThorchainMsgSend } from '../types'
@@ -220,8 +220,8 @@ export class ChainAdapter extends CosmosSdkBaseAdapter<KnownChainIds.ThorchainMa
     signTxInput,
   }: SignAndBroadcastTransactionInput<KnownChainIds.ThorchainMainnet>): Promise<string> {
     await Promise.all([
-      validateAddress(senderAddress),
-      receiverAddress !== CONTRACT_INTERACTION && validateAddress(receiverAddress),
+      assertAddressNotSanctioned(senderAddress),
+      receiverAddress !== CONTRACT_INTERACTION && assertAddressNotSanctioned(receiverAddress),
     ])
 
     const { wallet } = signTxInput

--- a/packages/chain-adapters/src/evm/EvmBaseAdapter.ts
+++ b/packages/chain-adapters/src/evm/EvmBaseAdapter.ts
@@ -50,7 +50,7 @@ import type {
 import { CONTRACT_INTERACTION, ValidAddressResultType } from '../types'
 import { getAssetNamespace, toAddressNList, toRootDerivationPath } from '../utils'
 import { bnOrZero } from '../utils/bignumber'
-import { validateAddress } from '../utils/validateAddress'
+import { assertAddressNotSanctioned } from '../utils/validateAddress'
 import type {
   arbitrum,
   arbitrumNova,
@@ -417,8 +417,8 @@ export abstract class EvmBaseAdapter<T extends EvmChainId> implements IChainAdap
     signTxInput,
   }: SignAndBroadcastTransactionInput<T>): Promise<string> {
     await Promise.all([
-      validateAddress(senderAddress),
-      receiverAddress !== CONTRACT_INTERACTION && validateAddress(receiverAddress),
+      assertAddressNotSanctioned(senderAddress),
+      receiverAddress !== CONTRACT_INTERACTION && assertAddressNotSanctioned(receiverAddress),
     ])
 
     try {
@@ -445,8 +445,8 @@ export abstract class EvmBaseAdapter<T extends EvmChainId> implements IChainAdap
     hex,
   }: BroadcastTransactionInput): Promise<string> {
     await Promise.all([
-      validateAddress(senderAddress),
-      receiverAddress !== CONTRACT_INTERACTION && validateAddress(receiverAddress),
+      assertAddressNotSanctioned(senderAddress),
+      receiverAddress !== CONTRACT_INTERACTION && assertAddressNotSanctioned(receiverAddress),
     ])
     return this.providers.http.sendTx({ sendTxBody: { hex } })
   }

--- a/packages/chain-adapters/src/evm/arbitrum/ArbitrumChainAdapter.test.ts
+++ b/packages/chain-adapters/src/evm/arbitrum/ArbitrumChainAdapter.test.ts
@@ -16,7 +16,7 @@ import type { ChainAdapterArgs, EvmChainId } from '../EvmBaseAdapter'
 import * as arbitrum from './ArbitrumChainAdapter'
 
 vi.mock('../../utils/validateAddress', () => ({
-  validateAddress: vi.fn(),
+  assertAddressNotSanctioned: vi.fn(),
 }))
 
 const ZERO_ADDRESS = '0x0000000000000000000000000000000000000000'

--- a/packages/chain-adapters/src/evm/arbitrumNova/ArbitrumNovaChainAdapter.test.ts
+++ b/packages/chain-adapters/src/evm/arbitrumNova/ArbitrumNovaChainAdapter.test.ts
@@ -21,7 +21,7 @@ import type { ChainAdapterArgs, EvmChainId } from '../EvmBaseAdapter'
 import * as arbitrumNova from './ArbitrumNovaChainAdapter'
 
 vi.mock('../../utils/validateAddress', () => ({
-  validateAddress: vi.fn(),
+  assertAddressNotSanctioned: vi.fn(),
 }))
 
 const ZERO_ADDRESS = '0x0000000000000000000000000000000000000000'

--- a/packages/chain-adapters/src/evm/avalanche/AvalancheChainAdapter.test.ts
+++ b/packages/chain-adapters/src/evm/avalanche/AvalancheChainAdapter.test.ts
@@ -21,7 +21,7 @@ import type { EvmChainId } from '../EvmBaseAdapter'
 import * as avalanche from './AvalancheChainAdapter'
 
 vi.mock('../../utils/validateAddress', () => ({
-  validateAddress: vi.fn(),
+  assertAddressNotSanctioned: vi.fn(),
 }))
 
 const ZERO_ADDRESS = '0x0000000000000000000000000000000000000000'

--- a/packages/chain-adapters/src/evm/bnbsmartchain/BscChainAdapter.test.ts
+++ b/packages/chain-adapters/src/evm/bnbsmartchain/BscChainAdapter.test.ts
@@ -16,7 +16,7 @@ import type { EvmChainId } from '../EvmBaseAdapter'
 import * as bsc from './BscChainAdapter'
 
 vi.mock('../../utils/validateAddress', () => ({
-  validateAddress: vi.fn(),
+  assertAddressNotSanctioned: vi.fn(),
 }))
 
 const ZERO_ADDRESS = '0x0000000000000000000000000000000000000000'

--- a/packages/chain-adapters/src/evm/ethereum/EthereumChainAdapter.test.ts
+++ b/packages/chain-adapters/src/evm/ethereum/EthereumChainAdapter.test.ts
@@ -16,7 +16,7 @@ import type { EvmChainId } from '../EvmBaseAdapter'
 import * as ethereum from './EthereumChainAdapter'
 
 vi.mock('../../utils/validateAddress', () => ({
-  validateAddress: vi.fn(),
+  assertAddressNotSanctioned: vi.fn(),
 }))
 
 const ZERO_ADDRESS = '0x0000000000000000000000000000000000000000'

--- a/packages/chain-adapters/src/evm/gnosis/GnosisChainAdapter.test.ts
+++ b/packages/chain-adapters/src/evm/gnosis/GnosisChainAdapter.test.ts
@@ -22,7 +22,7 @@ import type { ChainAdapterArgs, EvmChainId } from '../EvmBaseAdapter'
 import * as gnosis from './GnosisChainAdapter'
 
 vi.mock('../../utils/validateAddress', () => ({
-  validateAddress: vi.fn(),
+  assertAddressNotSanctioned: vi.fn(),
 }))
 
 const EOA_ADDRESS = '0xd8dA6BF26964aF9D7eEd9e03E53415D37aA96045'

--- a/packages/chain-adapters/src/evm/polygon/PolygonChainAdapter.test.ts
+++ b/packages/chain-adapters/src/evm/polygon/PolygonChainAdapter.test.ts
@@ -16,7 +16,7 @@ import type { ChainAdapterArgs, EvmChainId } from '../EvmBaseAdapter'
 import * as polygon from './PolygonChainAdapter'
 
 vi.mock('../../utils/validateAddress', () => ({
-  validateAddress: vi.fn(),
+  assertAddressNotSanctioned: vi.fn(),
 }))
 
 const ZERO_ADDRESS = '0x0000000000000000000000000000000000000000'

--- a/packages/chain-adapters/src/utils/validateAddress.ts
+++ b/packages/chain-adapters/src/utils/validateAddress.ts
@@ -13,7 +13,7 @@ const checkIsSanctioned = async (address: string): Promise<boolean> => {
   return response.data.valid
 }
 
-export const validateAddress = async (address: string): Promise<void> => {
+export const assertAddressNotSanctioned = async (address: string): Promise<void> => {
   // dedupe and cache promises in memory
   if (cache[address] === undefined) {
     const newEntry = checkIsSanctioned(address)

--- a/packages/chain-adapters/src/utils/validateAddress.ts
+++ b/packages/chain-adapters/src/utils/validateAddress.ts
@@ -1,32 +1,16 @@
 import axios from 'axios'
 
-const TRM_LABS_API_URL = 'https://api.trmlabs.com/public/v1/sanctions/screening'
+const ADDRESS_VALIDATION_URL = 'https://proxy.shapeshift.com/validate'
 
 const cache: Record<string, Promise<boolean>> = {}
 
 const checkIsSanctioned = async (address: string): Promise<boolean> => {
-  type trmResponse = [
-    {
-      address: string
-      isSanctioned: boolean
-    },
-  ]
+  type validationResponse = {
+    valid: boolean
+  }
 
-  const response = await axios.post<trmResponse>(
-    TRM_LABS_API_URL,
-    [
-      {
-        address,
-      },
-    ],
-    {
-      headers: {
-        Accept: 'application/json',
-      },
-    },
-  )
-
-  return response.data[0].isSanctioned
+  const response = await axios.get<validationResponse>(`${ADDRESS_VALIDATION_URL}/${address}`)
+  return response.data.valid
 }
 
 export const validateAddress = async (address: string): Promise<void> => {
@@ -36,7 +20,7 @@ export const validateAddress = async (address: string): Promise<void> => {
     cache[address] = newEntry
   }
 
-  const isSanctionedPromise = cache[address]
-  const isSanctioned = await isSanctionedPromise
-  if (isSanctioned) throw Error('Address not supported')
+  const isValidPromise = cache[address]
+  const isValid = await isValidPromise
+  if (!isValid) throw Error('Address not supported')
 }

--- a/packages/chain-adapters/src/utils/validateAddress.ts
+++ b/packages/chain-adapters/src/utils/validateAddress.ts
@@ -14,13 +14,18 @@ const checkIsSanctioned = async (address: string): Promise<boolean> => {
 }
 
 export const assertAddressNotSanctioned = async (address: string): Promise<void> => {
-  // dedupe and cache promises in memory
-  if (cache[address] === undefined) {
-    const newEntry = checkIsSanctioned(address)
-    cache[address] = newEntry
-  }
+  try {
+    // dedupe and cache promises in memory
+    if (cache[address] === undefined) {
+      const newEntry = checkIsSanctioned(address)
+      cache[address] = newEntry
+    }
 
-  const isValidPromise = cache[address]
-  const isValid = await isValidPromise
-  if (!isValid) throw Error('Address not supported')
+    const isValidPromise = cache[address]
+    const isValid = await isValidPromise
+    if (!isValid) throw Error('Address not supported')
+  } catch (error) {
+    // Log the error for debugging purposes
+    console.error(`Error validating address: ${address}. Defaulting to valid.`, error)
+  }
 }

--- a/packages/chain-adapters/src/utils/validateAddress.ts
+++ b/packages/chain-adapters/src/utils/validateAddress.ts
@@ -1,6 +1,6 @@
 import axios from 'axios'
 
-const ADDRESS_VALIDATION_URL = 'https://proxy.shapeshift.com/validate'
+const ADDRESS_VALIDATION_URL = 'https://api.proxy.shapeshift.com/api/v1/validate'
 
 const cache: Record<string, Promise<boolean>> = {}
 

--- a/packages/chain-adapters/src/utxo/UtxoBaseAdapter.ts
+++ b/packages/chain-adapters/src/utxo/UtxoBaseAdapter.ts
@@ -48,7 +48,7 @@ import {
   toRootDerivationPath,
 } from '../utils'
 import { bn, bnOrZero } from '../utils/bignumber'
-import { validateAddress } from '../utils/validateAddress'
+import { assertAddressNotSanctioned } from '../utils/validateAddress'
 import type { bitcoin, bitcoincash, dogecoin, litecoin } from './'
 import type { GetAddressInput, GetUtxosInput } from './types'
 import { getAddresses } from './utils'
@@ -310,7 +310,7 @@ export abstract class UtxoBaseAdapter<T extends UtxoChainId> implements IChainAd
 
       const uniqueAddresses = [...new Set(addresses)]
 
-      await Promise.all(uniqueAddresses.map(validateAddress))
+      await Promise.all(uniqueAddresses.map(assertAddressNotSanctioned))
 
       const signTxInputs: BTCSignTxInput[] = []
       for (const input of inputs) {
@@ -444,7 +444,7 @@ export abstract class UtxoBaseAdapter<T extends UtxoChainId> implements IChainAd
     receiverAddress,
     signTxInput,
   }: SignAndBroadcastTransactionInput<T>): Promise<string> {
-    await (receiverAddress !== CONTRACT_INTERACTION && validateAddress(receiverAddress))
+    await (receiverAddress !== CONTRACT_INTERACTION && assertAddressNotSanctioned(receiverAddress))
 
     try {
       const { wallet } = signTxInput
@@ -487,7 +487,7 @@ export abstract class UtxoBaseAdapter<T extends UtxoChainId> implements IChainAd
   }
 
   async broadcastTransaction({ receiverAddress, hex }: BroadcastTransactionInput): Promise<string> {
-    await (receiverAddress !== CONTRACT_INTERACTION && validateAddress(receiverAddress))
+    await (receiverAddress !== CONTRACT_INTERACTION && assertAddressNotSanctioned(receiverAddress))
 
     return this.providers.http.sendTx({ sendTxBody: { hex } })
   }

--- a/packages/chain-adapters/src/utxo/bitcoin/BitcoinChainAdapter.test.ts
+++ b/packages/chain-adapters/src/utxo/bitcoin/BitcoinChainAdapter.test.ts
@@ -28,7 +28,7 @@ import singleInputsSingleOutputSendNoChange from './mockData/singleInputSingleOu
 import singleInputsSingleOutputSendWithChange from './mockData/singleInputSingleOutputSendWithChange'
 
 vi.mock('../../utils/validateAddress', () => ({
-  validateAddress: vi.fn(),
+  assertAddressNotSanctioned: vi.fn(),
 }))
 
 const testMnemonic = 'alcohol woman abuse must during monitor noble actual mixed trade anger aisle'

--- a/packages/chain-adapters/src/utxo/bitcoincash/BitcoinCashChainAdapter.test.ts
+++ b/packages/chain-adapters/src/utxo/bitcoincash/BitcoinCashChainAdapter.test.ts
@@ -16,7 +16,7 @@ import type { ChainAdapterArgs, UtxoChainId } from '../UtxoBaseAdapter'
 import * as bitcoincash from './BitcoinCashChainAdapter'
 
 vi.mock('../../utils/validateAddress', () => ({
-  validateAddress: vi.fn(),
+  assertAddressNotSanctioned: vi.fn(),
 }))
 
 const testMnemonic = 'alcohol woman abuse must during monitor noble actual mixed trade anger aisle'

--- a/packages/chain-adapters/src/utxo/dogecoin/DogecoinChainAdapter.test.ts
+++ b/packages/chain-adapters/src/utxo/dogecoin/DogecoinChainAdapter.test.ts
@@ -10,7 +10,7 @@ import type { ChainAdapterArgs, UtxoChainId } from '../UtxoBaseAdapter'
 import * as dogecoin from './DogecoinChainAdapter'
 
 vi.mock('../../utils/validateAddress', () => ({
-  validateAddress: vi.fn(),
+  assertAddressNotSanctioned: vi.fn(),
 }))
 
 const testMnemonic = 'alcohol woman abuse must during monitor noble actual mixed trade anger aisle'

--- a/packages/chain-adapters/src/utxo/litecoin/LitecoinChainAdapter.test.ts
+++ b/packages/chain-adapters/src/utxo/litecoin/LitecoinChainAdapter.test.ts
@@ -11,7 +11,7 @@ import type { ChainAdapterArgs, UtxoChainId } from '../UtxoBaseAdapter'
 import * as litecoin from './LitecoinChainAdapter'
 
 vi.mock('../../utils/validateAddress', () => ({
-  validateAddress: vi.fn(),
+  assertAddressNotSanctioned: vi.fn(),
 }))
 
 const testMnemonic = 'alcohol woman abuse must during monitor noble actual mixed trade anger aisle'

--- a/react-app-rewired/headers/csps/addressValidation.ts
+++ b/react-app-rewired/headers/csps/addressValidation.ts
@@ -1,5 +1,5 @@
 import type { Csp } from '../types'
 
 export const csp: Csp = {
-  'connect-src': ['https://proxy.shapeshift.com/validate/'],
+  'connect-src': ['https://api.proxy.shapeshift.com/api/v1/validate/'],
 }

--- a/react-app-rewired/headers/csps/addressValidation.ts
+++ b/react-app-rewired/headers/csps/addressValidation.ts
@@ -1,0 +1,5 @@
+import type { Csp } from '../types'
+
+export const csp: Csp = {
+  'connect-src': ['https://proxy.shapeshift.com/validate/'],
+}

--- a/react-app-rewired/headers/csps/addressValidation.ts
+++ b/react-app-rewired/headers/csps/addressValidation.ts
@@ -1,5 +1,0 @@
-import type { Csp } from '../types'
-
-export const csp: Csp = {
-  'connect-src': ['https://api.proxy.shapeshift.com/api/v1/validate/'],
-}

--- a/react-app-rewired/headers/csps/shapeshiftProxy.ts
+++ b/react-app-rewired/headers/csps/shapeshiftProxy.ts
@@ -1,0 +1,5 @@
+import type { Csp } from '../types'
+
+export const csp: Csp = {
+  'connect-src': ['https://api.proxy.shapeshift.com/api/v1/'],
+}

--- a/react-app-rewired/headers/csps/trmLabs.ts
+++ b/react-app-rewired/headers/csps/trmLabs.ts
@@ -1,5 +1,0 @@
-import type { Csp } from '../types'
-
-export const csp: Csp = {
-  'connect-src': ['https://api.trmlabs.com/public/v1/sanctions/screening'],
-}


### PR DESCRIPTION
## Description

Use proxy address validation endpoint.

## Pull Request Type

- [ ] :bug: Bug fix (Non-breaking Change: Fixes an issue)
- [x] :hammer_and_wrench: Chore (Non-breaking Change: Doc updates, pkg upgrades, typos, etc..)
- [ ] :nail_care: New Feature (Breaking/Non-breaking Change)

## Issue (if applicable)

N/A

## Risk
> High Risk PRs Require 2 approvals

High - getting this wrong could inadvertently prevent all transactions.

> What protocols, transaction types or contract interactions might be affected by this PR?

All transactions within the app. This sounds scarier than it is though, we are using a single hook to manage address validation, so if it works for one type it should work for all.

## Testing

Ensure we can still trade, interact with savers and LPs, and send assets.
Check against both EVM and UTXO assets.

### Engineering

☝️

### Operations

☝️ 

## Screenshots (if applicable)

N/A