### PR TITLE
fix: defi aggregated opportunities uniqBy id first

### DIFF
--- a/src/state/apis/zapper/validators.ts
+++ b/src/state/apis/zapper/validators.ts
@@ -13,6 +13,8 @@ import {
 import { invert } from 'lodash'
 import type { Infer, Type } from 'myzod'
 import z from 'myzod'
+import { zeroAddress } from 'viem'
+import { getChainAdapterManager } from 'context/PluginProvider/chainAdapterSingleton'
 import { isNonEmpty, isUrl } from 'lib/utils'
 
 export enum SupportedZapperNetwork {
@@ -242,6 +244,13 @@ export const zapperAssetToMaybeAssetId = (
 ): AssetId | undefined => {
   const chainId = zapperNetworkToChainId(asset.network as SupportedZapperNetwork)
   if (!chainId) return undefined
+  const isNativeAsset = asset.type === 'base-token' && asset.address === zeroAddress
+
+  if (isNativeAsset) {
+    const chainAdapterManager = getChainAdapterManager()
+    const nativeAssetId = chainAdapterManager.get(chainId)?.getFeeAssetId()
+    return nativeAssetId
+  }
   const assetNamespace = (() => {
     switch (true) {
       case chainId === bscChainId:

--- a/src/state/apis/zapper/validators.ts
+++ b/src/state/apis/zapper/validators.ts
@@ -13,8 +13,6 @@ import {
 import { invert } from 'lodash'
 import type { Infer, Type } from 'myzod'
 import z from 'myzod'
-import { zeroAddress } from 'viem'
-import { getChainAdapterManager } from 'context/PluginProvider/chainAdapterSingleton'
 import { isNonEmpty, isUrl } from 'lib/utils'
 
 export enum SupportedZapperNetwork {
@@ -244,13 +242,6 @@ export const zapperAssetToMaybeAssetId = (
 ): AssetId | undefined => {
   const chainId = zapperNetworkToChainId(asset.network as SupportedZapperNetwork)
   if (!chainId) return undefined
-  const isNativeAsset = asset.type === 'base-token' && asset.address === zeroAddress
-
-  if (isNativeAsset) {
-    const chainAdapterManager = getChainAdapterManager()
-    const nativeAssetId = chainAdapterManager.get(chainId)?.getFeeAssetId()
-    return nativeAssetId
-  }
   const assetNamespace = (() => {
     switch (true) {
       case chainId === bscChainId:

--- a/src/state/slices/opportunitiesSlice/selectors/stakingSelectors.ts
+++ b/src/state/slices/opportunitiesSlice/selectors/stakingSelectors.ts
@@ -527,7 +527,7 @@ export const selectAggregatedEarnUserStakingOpportunitiesIncludeEmpty =
       // Keep only the version with actual data if it exists, else keep the zero'd out version
       const aggregatedEarnUserStakingOpportunitiesIncludeEmpty = uniqBy(
         [...aggregatedEarnUserStakingOpportunities, ...emptyEarnOpportunitiesTypes],
-        ({ contractAddress, assetId, id }) => contractAddress ?? assetId ?? id,
+        ({ contractAddress, assetId, id }) => id ?? contractAddress ?? assetId,
       )
 
       const results = aggregatedEarnUserStakingOpportunitiesIncludeEmpty.filter(opportunity => {


### PR DESCRIPTION
## Description

By calling `uniqBy` by `id` `first`, we effectively fix the issue with opportunities having a wrong amount displayed - the issue was that multiple assets *can* have the same `assetId` / `contractAddres` (e.g `ethAssetId`), which means we would pick the first opportunity we find for said asset, which could yield unpredictable results.

## Pull Request Type

- [x] :bug: Bug fix (Non-breaking Change: Fixes an issue)
- [ ] :hammer_and_wrench: Chore (Non-breaking Change: Doc updates, pkg upgrades, typos, etc..)
- [ ] :nail_care: New Feature (Breaking/Non-breaking Change)

## Issue (if applicable)

<!-----------------------------------------------------------------------------
If applicable, please link to the github issue and put `closes #XXXX` in your comment to auto-close the issue that your PR fixes.
------------------------------------------------------------------------------>

- closes https://github.com/shapeshift/web/issues/6608

## Risk
> High Risk PRs Require 2 approvals

<!-----------------------------------------------------------------------------
Outline the scope of your changes and the risk associated with them. You must use your discretion as an engineer to determine the potential impact of your changes.

WARNING: If your PR introduces a new on-chain transaction or modifies an existing one, please add the "High-Risk" label to this PR and ask for 2 reviewers to approve it before merging.

E.g. an upgrade to `hdwallet` or core state management would be considered higher risk, and might require a full regression test. UI or isolated view changes, or something behind a feature flag may have near zero risk. Small bug fixes might require testing isolated to the specific fix.
------------------------------------------------------------------------------>

- Low - ensure opportunities meta/user data still looks sane

> What protocols, transaction types or contract interactions might be affected by this PR?

## Testing

<!-----------------------------------------------------------------------------
We treat every PR to be merged with the same scrutiny as if we were merging directly to production.

Your PR will not be merged if you do not complete the sections below for our engineering and operations teams to test.
------------------------------------------------------------------------------>

- Opportunity metadata still looks sane against develop
- Testing with willy's wallet, https://github.com/shapeshift/web/issues/6608 cannot be repro'd in this diff.

### Engineering

<!-----------------------------------------------------------------------------
Include sufficient information here for an engineer to test your PR. This may include how to test locally, in a built environment, changes to infrastructure etc.
------------------------------------------------------------------------------>

- ☝🏽 

### Operations

<!-----------------------------------------------------------------------------
If your changes have a user-facing impact, describe how a non-technical QA team can functionally test your changes in a preview environment.

If they are not user-facing please describe how to test for any regressions that may occur.
------------------------------------------------------------------------------>

- ☝🏽 

## Screenshots (if applicable)

<img width="873" alt="image" src="https://github.com/shapeshift/web/assets/17035424/010dc385-fd21-4c66-89a8-9dafa52500f8">
