### PR TITLE
fix: dont display degraded balance history accounts for other wallets

### DIFF
--- a/src/state/slices/txHistorySlice/selectors.ts
+++ b/src/state/slices/txHistorySlice/selectors.ts
@@ -314,9 +314,11 @@ export const selectIsTxHistoryAvailableByFilter = createCachedSelector(
 
 export const selectErroredTxHistoryAccounts = createDeepEqualOutputSelector(
   (state: ReduxState) => state.txHistory.hydrationMeta,
-  hydrationMeta => {
+  selectWalletAccountIds,
+  (hydrationMeta, walletAccountIds) => {
     return Object.entries(hydrationMeta)
       .filter(([_accountId, hydrationMetaForAccountId]) => hydrationMetaForAccountId?.isErrored)
       .map(([accountId, _hydrationMetaForAccountId]) => accountId)
+      .filter(accountId => walletAccountIds.includes(accountId))
   },
 )


### PR DESCRIPTION
## Description

Fixes issue where the "Transaction history degraded" acocunt list will display accounts for a previously connected wallet.

## Pull Request Type

- [x] :bug: Bug fix (Non-breaking Change: Fixes an issue)
- [ ] :hammer_and_wrench: Chore (Non-breaking Change: Doc updates, pkg upgrades, typos, etc..)
- [ ] :nail_care: New Feature (Breaking/Non-breaking Change)

## Issue (if applicable)
NA

## Risk
> High Risk PRs Require 2 approvals

Low risk, the issue is very easily reproducible and simple to identify issues with.

> What protocols, transaction types or contract interactions might be affected by this PR?

## Testing

1. Open app on a large wallet. Let it load until there are some failed requests (gnosis will fail since the node is down)
2. Switch wallet. Let it load also.
3. Open the "Transaction history degraded" popover. There should be only accounts for the currently connected wallet listed.

### Engineering

<!-----------------------------------------------------------------------------
Include sufficient information here for an engineer to test your PR. This may include how to test locally, in a built environment, changes to infrastructure etc.
------------------------------------------------------------------------------>

### Operations

<!-----------------------------------------------------------------------------
If your changes have a user-facing impact, describe how a non-technical QA team can functionally test your changes in a preview environment.

If they are not user-facing please describe how to test for any regressions that may occur.
------------------------------------------------------------------------------>

## Screenshots (if applicable)

Develop:
![image](https://github.com/shapeshift/web/assets/125113430/259afadc-6570-4cd2-b48c-fbddc764862c)
![image](https://github.com/shapeshift/web/assets/125113430/2a4e4ff2-8821-44db-93d4-bfe85303de6b)

This PR:
![image](https://github.com/shapeshift/web/assets/125113430/98e76349-1d48-4afa-84a4-00b760b178c3)
![image](https://github.com/shapeshift/web/assets/125113430/8c24b0ef-f516-4aac-905b-e265f3991eae)

