### PR TITLE
feat: thorchain LP deduct THOR outbound fees on max RUNE click

### DIFF
--- a/src/components/MultiHopTrade/components/TradeAssetInput.tsx
+++ b/src/components/MultiHopTrade/components/TradeAssetInput.tsx
@@ -28,7 +28,10 @@ const AssetInputAwaitingAsset = () => {
   )
 }
 
-type AssetInputLoadedProps = Omit<TradeAmountInputProps, 'onMaxClick'> & { assetId: AssetId }
+type AssetInputLoadedProps = Omit<TradeAmountInputProps, 'onMaxClick'> & {
+  assetId: AssetId
+  onMaxClick?: (isFiat: boolean) => Promise<void>
+}
 
 const AssetInputWithAsset: React.FC<AssetInputLoadedProps> = memo(props => {
   const { assetId, accountId } = props
@@ -48,6 +51,8 @@ const AssetInputWithAsset: React.FC<AssetInputLoadedProps> = memo(props => {
 
   const onMaxClick = useCallback(
     (isFiat: boolean) => {
+      if (props.onMaxClick) return props.onMaxClick(isFiat)
+
       const value = isFiat ? fiatBalance : balance
       if (props.onChange) props.onChange(value, isFiat)
       return Promise.resolve()
@@ -68,6 +73,7 @@ const AssetInputWithAsset: React.FC<AssetInputLoadedProps> = memo(props => {
 export type TradeAssetInputProps = {
   assetId?: AssetId
   hideAmounts?: boolean
+  onMaxClick?: (isFiat: boolean) => Promise<void>
 } & Omit<TradeAmountInputProps, 'onMaxClick'>
 
 export const TradeAssetInput: React.FC<TradeAssetInputProps> = memo(


### PR DESCRIPTION
## Description

Does what it says on the box.
While we can't *reliably* do this for other *native* assets (we could potentially reuse send fee-deduction logic for UTXOs, though given the possible reconciliation, that is not guaranteed to work and we would have to plan for some buffer there, but should be sane enough in most cases so worth a try IMO), we *can* do this for RUNE as it has as 0.02 RUNE hardcoded fee.

## Pull Request Type

- [ ] :bug: Bug fix (Non-breaking Change: Fixes an issue)
- [ ] :hammer_and_wrench: Chore (Non-breaking Change: Doc updates, pkg upgrades, typos, etc..)
- [x] :nail_care: New Feature (Breaking/Non-breaking Change)

## Issue (if applicable)

<!-----------------------------------------------------------------------------
If applicable, please link to the github issue and put `closes #XXXX` in your comment to auto-close the issue that your PR fixes.
------------------------------------------------------------------------------>

closes https://github.com/shapeshift/web/issues/6640

## Risk
> High Risk PRs Require 2 approvals

<!-----------------------------------------------------------------------------
Outline the scope of your changes and the risk associated with them. You must use your discretion as an engineer to determine the potential impact of your changes.

WARNING: If your PR introduces a new on-chain transaction or modifies an existing one, please add the "High-Risk" label to this PR and ask for 2 reviewers to approve it before merging.

E.g. an upgrade to `hdwallet` or core state management would be considered higher risk, and might require a full regression test. UI or isolated view changes, or something behind a feature flag may have near zero risk. Small bug fixes might require testing isolated to the specific fix.
------------------------------------------------------------------------------>

> What protocols, transaction types or contract interactions might be affected by this PR?

Low - ensure max is still happy regardless of the asset

## Testing

<!-----------------------------------------------------------------------------
We treat every PR to be merged with the same scrutiny as if we were merging directly to production.

Your PR will not be merged if you do not complete the sections below for our engineering and operations teams to test.
------------------------------------------------------------------------------>

- Max deposits are happy for assets other than RUNE
- Max RUNE deposits (either asym RUNE, or sym on the RUNE side) deducts the 0.02 constant RUNE fee of the max balance amount

### Engineering

<!-----------------------------------------------------------------------------
Include sufficient information here for an engineer to test your PR. This may include how to test locally, in a built environment, changes to infrastructure etc.
------------------------------------------------------------------------------>

- ^

### Operations

<!-----------------------------------------------------------------------------
If your changes have a user-facing impact, describe how a non-technical QA team can functionally test your changes in a preview environment.

If they are not user-facing please describe how to test for any regressions that may occur.
------------------------------------------------------------------------------>

- ^

## Screenshots (if applicable)


<img width="455" alt="Screenshot 2024-04-05 at 16 03 29" src="https://github.com/shapeshift/web/assets/17035424/6961d7fe-87bb-41f2-9d6d-f3a4cb77657f">

<!-- av pr metadata
This information is embedded by the av CLI when creating PRs to track the status of stacks when using Aviator. Please do not delete or edit this section of the PR.
```
{"parent":"develop","parentHead":"","trunk":"develop"}
```
-->
