### PR TITLE
fix: empty my position pools page

### DIFF
--- a/src/pages/ThorChainLP/YourPositions.tsx
+++ b/src/pages/ThorChainLP/YourPositions.tsx
@@ -265,34 +265,35 @@ export const YourPositions = () => {
 
   const isEmpty = useMemo(() => allLoaded && !activePositions.length, [allLoaded, activePositions])
 
-  if (isEmpty) {
-    return (
-      <ResultsEmpty
-        title='pools.yourPositions.emptyTitle'
-        body='pools.yourPositions.emptyBody'
-        icon={emptyIcon}
+  const body = useMemo(() => {
+    if (isEmpty) {
+      return (
+        <ResultsEmpty
+          title='pools.yourPositions.emptyTitle'
+          body='pools.yourPositions.emptyBody'
+          icon={emptyIcon}
+        />
+      )
+    }
+    return positions.length ? (
+      <ReactTable
+        data={positions}
+        columns={columns}
+        initialState={reactTableInitialState}
+        onRowClick={handlePoolClick}
+        variant='clickable'
       />
+    ) : (
+      <Flex gap={4} alignItems='center' justifyContent='center'>
+        <Spinner />
+      </Flex>
     )
-  }
+  }, [columns, emptyIcon, handlePoolClick, isEmpty, positions])
 
   return (
     <Main headerComponent={headerComponent}>
       <SEO title={translate('pools.yourPositions.yourPositions')} />
-      <Stack>
-        {positions.length ? (
-          <ReactTable
-            data={positions}
-            columns={columns}
-            initialState={reactTableInitialState}
-            onRowClick={handlePoolClick}
-            variant='clickable'
-          />
-        ) : (
-          <Flex gap={4} alignItems='center' justifyContent='center'>
-            <Spinner />
-          </Flex>
-        )}
-      </Stack>
+      <Stack>{body}</Stack>
     </Main>
   )
 }


### PR DESCRIPTION
## Description

- We did an early return when is empty, this can cause users to be stuck on the page
- This now will return in the content keeping the navigation and header

## Pull Request Type

- [x] :bug: Bug fix (Non-breaking Change: Fixes an issue)
- [ ] :hammer_and_wrench: Chore (Non-breaking Change: Doc updates, pkg upgrades, typos, etc..)
- [ ] :nail_care: New Feature (Breaking/Non-breaking Change)

## Issue (if applicable)

<!-----------------------------------------------------------------------------
If applicable, please link to the github issue and put `closes #XXXX` in your comment to auto-close the issue that your PR fixes.
------------------------------------------------------------------------------>

closes #

## Risk
> High Risk PRs Require 2 approvals

<!-----------------------------------------------------------------------------
Outline the scope of your changes and the risk associated with them. You must use your discretion as an engineer to determine the potential impact of your changes.

WARNING: If your PR introduces a new on-chain transaction or modifies an existing one, please add the "High-Risk" label to this PR and ask for 2 reviewers to approve it before merging.

E.g. an upgrade to `hdwallet` or core state management would be considered higher risk, and might require a full regression test. UI or isolated view changes, or something behind a feature flag may have near zero risk. Small bug fixes might require testing isolated to the specific fix.
------------------------------------------------------------------------------>
low risk

> What protocols, transaction types or contract interactions might be affected by this PR?

## Testing

<!-----------------------------------------------------------------------------
We treat every PR to be merged with the same scrutiny as if we were merging directly to production.

Your PR will not be merged if you do not complete the sections below for our engineering and operations teams to test.
------------------------------------------------------------------------------>

### Engineering

<!-----------------------------------------------------------------------------
Include sufficient information here for an engineer to test your PR. This may include how to test locally, in a built environment, changes to infrastructure etc.
------------------------------------------------------------------------------>

### Operations

<!-----------------------------------------------------------------------------
If your changes have a user-facing impact, describe how a non-technical QA team can functionally test your changes in a preview environment.

If they are not user-facing please describe how to test for any regressions that may occur.
------------------------------------------------------------------------------>
If you go to pools, and your positions and you have none. You'll see the empty message under the tabs and header.

## Screenshots (if applicable)
![Screenshot 2024-04-09 at 4 13 47 PM](https://github.com/shapeshift/web/assets/89934888/1cdd84ab-ecea-4c74-b26e-e8489e9cada6)
