### PR TITLE
fix: qr back button

### DIFF
--- a/src/components/Modals/QrCode/Form.tsx
+++ b/src/components/Modals/QrCode/Form.tsx
@@ -157,7 +157,7 @@ export const Form: React.FC<QrCodeFormProps> = ({ accountId }) => {
             <Route path={SendRoutes.Scan}>
               <QrCodeScanner
                 onSuccess={handleQrSuccess}
-                onBack={handleBack}
+                onBack={handleClose}
                 addressError={addressError}
               />
             </Route>


### PR DESCRIPTION
## Description

When we have the standalone QR code scanner open (i.e. when it is not a part of the send form, or otherwise) we want the back button to close the modal and go back to the Dashboard.

Unblocks current release.

## Pull Request Type

- [x] :bug: Bug fix (Non-breaking Change: Fixes an issue)
- [ ] :hammer_and_wrench: Chore (Non-breaking Change: Doc updates, pkg upgrades, typos, etc..)
- [ ] :nail_care: New Feature (Breaking/Non-breaking Change)

## Issue (if applicable)

See https://discord.com/channels/554694662431178782/1227752157919580170/1227766068882309151 in the current release thread.

## Risk


Small

> What protocols, transaction types or contract interactions might be affected by this PR?

None.

## Testing

- Ensure that when the QR code scanner is opened from the Dashboard that the back button now closes the modal and we don't end up in an irrecoverable state.
- Ensure that all other instances of the QR code scanner go back to the expected screen, e.g. when in the send asset flow.

### Engineering

☝️

### Operations

☝️

## Screenshots (if applicable)

<img width="488" alt="Screenshot 2024-04-11 at 10 54 37 AM" src="https://github.com/shapeshift/web/assets/97164662/30f07b7a-8baa-4c17-b351-3c771cd3d644">
