### PR TITLE
fix: don't render back button on modals initial routes

### DIFF
--- a/src/components/Modal/components/DialogBackButton.tsx
+++ b/src/components/Modal/components/DialogBackButton.tsx
@@ -9,6 +9,9 @@ type DialogBackButtonProps = Omit<IconButtonProps, 'aria-label'>
 
 export const DialogBackButton: React.FC<DialogBackButtonProps> = props => {
   const translate = useTranslate()
+
+  if (!props.onClick) return null
+
   return (
     <IconButton
       variant='ghost'

--- a/src/components/Modals/Receive/ReceiveRouter.tsx
+++ b/src/components/Modals/Receive/ReceiveRouter.tsx
@@ -29,10 +29,6 @@ export const ReceiveRouter = ({ assetId, accountId }: ReceiveRouterProps) => {
     [history],
   )
 
-  const handleSelectBack = useCallback(() => {
-    history.push(ReceiveRoutes.Info)
-  }, [history])
-
   useEffect(() => {
     if (!selectedAsset && !asset) {
       history.push(ReceiveRoutes.Select)
@@ -49,7 +45,7 @@ export const ReceiveRouter = ({ assetId, accountId }: ReceiveRouterProps) => {
           {selectedAsset ? <ReceiveInfo asset={selectedAsset} accountId={accountId} /> : null}
         </Route>
         <Route path={ReceiveRoutes.Select}>
-          <SelectAssetRouter onBack={handleSelectBack} onClick={handleAssetSelect} />
+          <SelectAssetRouter onClick={handleAssetSelect} />
         </Route>
       </Switch>
     </AnimatePresence>

--- a/src/components/Modals/Send/Form.tsx
+++ b/src/components/Modals/Send/Form.tsx
@@ -147,7 +147,7 @@ export const Form: React.FC<SendFormProps> = ({ initialAssetId, input = '', acco
         <AnimatePresence mode='wait' initial={false}>
           <Switch location={location} key={location.key}>
             <Route path={SendRoutes.Select}>
-              <SelectAssetRouter onBack={handleBack} onClick={handleAssetSelect} />
+              <SelectAssetRouter onClick={handleAssetSelect} />
             </Route>
             <Route path={SendRoutes.Address}>
               <Address />


### PR DESCRIPTION
## Description

... regardless of context, since asset selection is always the initial route for

- Sends (dashboard/asset page)
- Receives (dashboard/asset page)

Note, QRCode asset selection is a different variant which isn't affected by the removal of the button here, hence still keeps its back functionality unbroken. 

## Pull Request Type

- [ ] :bug: Bug fix (Non-breaking Change: Fixes an issue)
- [ ] :hammer_and_wrench: Chore (Non-breaking Change: Doc updates, pkg upgrades, typos, etc..)
- [x] :nail_care: New Feature (Breaking/Non-breaking Change)

## Issue (if applicable)

<!-----------------------------------------------------------------------------
If applicable, please link to the github issue and put `closes #XXXX` in your comment to auto-close the issue that your PR fixes.
------------------------------------------------------------------------------>

closes https://github.com/shapeshift/web/issues/6665

## Risk
> High Risk PRs Require 2 approvals

<!-----------------------------------------------------------------------------
Outline the scope of your changes and the risk associated with them. You must use your discretion as an engineer to determine the potential impact of your changes.

WARNING: If your PR introduces a new on-chain transaction or modifies an existing one, please add the "High-Risk" label to this PR and ask for 2 reviewers to approve it before merging.

E.g. an upgrade to `hdwallet` or core state management would be considered higher risk, and might require a full regression test. UI or isolated view changes, or something behind a feature flag may have near zero risk. Small bug fixes might require testing isolated to the specific fix.
------------------------------------------------------------------------------>

> What protocols, transaction types or contract interactions might be affected by this PR?

## Testing

<!-----------------------------------------------------------------------------
We treat every PR to be merged with the same scrutiny as if we were merging directly to production.

Your PR will not be merged if you do not complete the sections below for our engineering and operations teams to test.
------------------------------------------------------------------------------>

- Back button is gone from send modal asset selection step, both in dashboard and asset page
- Back button is gone from receive modal asset selection step, both in dashboard and asset page
- Back button is still present in the QR code variant of the asset selection step in dashboard e.g after scanning an EVM address

### Engineering

<!-----------------------------------------------------------------------------
Include sufficient information here for an engineer to test your PR. This may include how to test locally, in a built environment, changes to infrastructure etc.
------------------------------------------------------------------------------>

- ^

### Operations

<!-----------------------------------------------------------------------------
If your changes have a user-facing impact, describe how a non-technical QA team can functionally test your changes in a preview environment.

If they are not user-facing please describe how to test for any regressions that may occur.
------------------------------------------------------------------------------>

- ^

## Screenshots (if applicable)

<!-- av pr metadata
This information is embedded by the av CLI when creating PRs to track the status of stacks when using Aviator. Please do not delete or edit this section of the PR.
```
{"parent":"develop","parentHead":"","trunk":"develop"}
```
-->

### Send and Receive asset selection initial step

https://github.com/shapeshift/web/assets/17035424/0479c333-4d14-47da-9eed-5c094e442dc9

### QRCode variant

<img width="417" alt="image" src="https://github.com/shapeshift/web/assets/17035424/321e8331-7053-447a-a7e4-84aa60ddc3c0">
