### PR TITLE
fix: use cosmos branch

### DIFF
--- a/packages/unchained-client/openapitools.json
+++ b/packages/unchained-client/openapitools.json
@@ -58,7 +58,7 @@
         }
       },
       "cosmos": {
-        "inputSpec": "https://raw.githubusercontent.com/shapeshift/unchained/develop/go/coinstacks/cosmos/api/swagger.json",
+        "inputSpec": "https://raw.githubusercontent.com/shapeshift/unchained/cosmos/go/coinstacks/cosmos/api/swagger.json",
         "generatorName": "typescript-fetch",
         "output": "#{cwd}/src/generated/cosmos",
         "enablePostProcessFile": true,


### PR DESCRIPTION
## Description

Use the `cosmos` unchained branch to source the cosmos swagger file.

Looks necessary based on comment in https://github.com/shapeshift/unchained/pull/980, and the changes in https://github.com/shapeshift/unchained/pull/980/commits/dc4e5d44453daee76b7f31f0a1dee62a0145d044 to remove the cosmos directory.

## Pull Request Type

- [x] :bug: Bug fix (Non-breaking Change: Fixes an issue)
- [ ] :hammer_and_wrench: Chore (Non-breaking Change: Doc updates, pkg upgrades, typos, etc..)
- [ ] :nail_care: New Feature (Breaking/Non-breaking Change)

## Issue (if applicable)

Unblocks current release.

## Risk

Small

> What protocols, transaction types or contract interactions might be affected by this PR?

Cosmos chain.

## Testing

Cosmos-related functionality should work as expected.

### Engineering

☝️

### Operations

☝️

## Screenshots (if applicable)

N/A