### PR TITLE
feat: move from Object.keys(KnownChainIds) to safe knownChainIds array

### DIFF
--- a/packages/types/src/base.ts
+++ b/packages/types/src/base.ts
@@ -1,4 +1,4 @@
-import { type AccountId, type AssetId, type ChainId } from '@shapeshiftoss/caip'
+import type { AccountId, AssetId, ChainId } from '@shapeshiftoss/caip'
 
 import type { PartialRecord } from './utility'
 

--- a/packages/types/src/base.ts
+++ b/packages/types/src/base.ts
@@ -1,4 +1,4 @@
-import type { AccountId, AssetId, ChainId } from '@shapeshiftoss/caip'
+import { type AccountId, type AssetId, type ChainId } from '@shapeshiftoss/caip'
 
 import type { PartialRecord } from './utility'
 

--- a/src/components/Modals/Snaps/SnapIntro.tsx
+++ b/src/components/Modals/Snaps/SnapIntro.tsx
@@ -11,7 +11,7 @@ import {
   ModalHeader,
   Text,
 } from '@chakra-ui/react'
-import { KnownChainIds } from '@shapeshiftoss/types'
+import { knownChainIds } from 'constants/chains'
 import { useCallback, useMemo } from 'react'
 import { FaArrowRightArrowLeft } from 'react-icons/fa6'
 import { useTranslate } from 'react-polyglot'
@@ -40,7 +40,7 @@ export const SnapIntro = ({ isRemoved }: { isRemoved?: boolean }) => {
     : 'walletProvider.metaMaskSnap.subtitle'
 
   const allNativeAssets = useMemo(() => {
-    return Object.values(KnownChainIds)
+    return knownChainIds
       .map(knownChainId => {
         const assetId = getChainAdapterManager().get(knownChainId)?.getFeeAssetId()!
         const asset = selectAssetById(store.getState(), assetId)

--- a/src/components/MultiHopTrade/hooks/useSupportedAssets.tsx
+++ b/src/components/MultiHopTrade/hooks/useSupportedAssets.tsx
@@ -1,4 +1,4 @@
-import { KnownChainIds } from '@shapeshiftoss/types'
+import { knownChainIds } from 'constants/chains'
 import { useMemo } from 'react'
 import { useIsSnapInstalled } from 'hooks/useIsSnapInstalled/useIsSnapInstalled'
 import { useWallet } from 'hooks/useWallet/useWallet'
@@ -18,7 +18,7 @@ export const useSupportedAssets = () => {
   const accountIdsByChainId = useAppSelector(selectAccountIdsByChainId)
   const queryParams = useMemo(() => {
     return {
-      walletSupportedChainIds: Object.values(KnownChainIds).filter(chainId => {
+      walletSupportedChainIds: knownChainIds.filter(chainId => {
         const chainAccountIds = accountIdsByChainId[chainId] ?? []
         return walletSupportsChain({ chainId, wallet, isSnapInstalled, chainAccountIds })
       }),

--- a/src/components/TradeAssetSearch/TradeAssetSearch.tsx
+++ b/src/components/TradeAssetSearch/TradeAssetSearch.tsx
@@ -3,6 +3,7 @@ import type { BoxProps, InputProps } from '@chakra-ui/react'
 import { Flex, Input, InputGroup, InputLeftElement, Stack } from '@chakra-ui/react'
 import type { AssetId, ChainId } from '@shapeshiftoss/caip'
 import { type Asset, KnownChainIds } from '@shapeshiftoss/types'
+import { knownChainIds } from 'constants/chains'
 import type { FC, FormEvent } from 'react'
 import { useCallback, useMemo, useState } from 'react'
 import { useForm } from 'react-hook-form'
@@ -134,7 +135,7 @@ export const TradeAssetSearch: FC<TradeAssetSearchProps> = ({
   const chainIds: (ChainId | 'All')[] = useMemo(() => {
     const unsortedChainIds = (() => {
       if (allowWalletUnsupportedAssets) {
-        return Object.values(KnownChainIds)
+        return knownChainIds
       }
 
       return walletSupportedChainIds

--- a/src/constants/chains.ts
+++ b/src/constants/chains.ts
@@ -1,4 +1,3 @@
-import { arbitrumNovaChainId, gnosisChainId } from '@shapeshiftoss/caip'
 import { KnownChainIds } from '@shapeshiftoss/types'
 import { selectFeatureFlag } from 'state/slices/selectors'
 import { store } from 'state/store'
@@ -9,9 +8,9 @@ export const knownChainIds = Object.values(KnownChainIds).filter(chainId => {
   const isGnosisEnabled = selectFeatureFlag(store.getState(), 'Gnosis')
   const isPolygonEnabled = selectFeatureFlag(store.getState(), 'Polygon')
   const isOptimismEnabled = selectFeatureFlag(store.getState(), 'Optimism')
-  if (chainId === arbitrumNovaChainId && !isArbitrumNovaEnabled) return false
+  if (chainId === KnownChainIds.ArbitrumNovaMainnet && !isArbitrumNovaEnabled) return false
   if (chainId === KnownChainIds.ArbitrumMainnet && !isArbitrumEnabled) return false
-  if (chainId === gnosisChainId && !isGnosisEnabled) return false
+  if (chainId === KnownChainIds.GnosisMainnet && !isGnosisEnabled) return false
   if (chainId === KnownChainIds.PolygonMainnet && !isPolygonEnabled) return false
   if (chainId === KnownChainIds.OptimismMainnet && !isOptimismEnabled) return false
 

--- a/src/constants/chains.ts
+++ b/src/constants/chains.ts
@@ -1,0 +1,19 @@
+import { arbitrumNovaChainId, gnosisChainId } from '@shapeshiftoss/caip'
+import { KnownChainIds } from '@shapeshiftoss/types'
+import { selectFeatureFlag } from 'state/slices/selectors'
+import { store } from 'state/store'
+// returns known ChainIds as an array, excludingg the ones that are currently flagged off
+export const knownChainIds = Object.values(KnownChainIds).filter(chainId => {
+  const isArbitrumEnabled = selectFeatureFlag(store.getState(), 'Arbitrum')
+  const isArbitrumNovaEnabled = selectFeatureFlag(store.getState(), 'ArbitrumNova')
+  const isGnosisEnabled = selectFeatureFlag(store.getState(), 'Gnosis')
+  const isPolygonEnabled = selectFeatureFlag(store.getState(), 'Polygon')
+  const isOptimismEnabled = selectFeatureFlag(store.getState(), 'Optimism')
+  if (chainId === arbitrumNovaChainId && !isArbitrumNovaEnabled) return false
+  if (chainId === KnownChainIds.ArbitrumMainnet && !isArbitrumEnabled) return false
+  if (chainId === gnosisChainId && !isGnosisEnabled) return false
+  if (chainId === KnownChainIds.PolygonMainnet && !isPolygonEnabled) return false
+  if (chainId === KnownChainIds.OptimismMainnet && !isOptimismEnabled) return false
+
+  return true
+})

--- a/src/constants/chains.ts
+++ b/src/constants/chains.ts
@@ -1,18 +1,16 @@
 import { KnownChainIds } from '@shapeshiftoss/types'
-import { selectFeatureFlag } from 'state/slices/selectors'
+import { selectFeatureFlags } from 'state/slices/selectors'
 import { store } from 'state/store'
+
+const enabledFlags = selectFeatureFlags(store.getState())
+
 // returns known ChainIds as an array, excluding the ones that are currently flagged off
 export const knownChainIds = Object.values(KnownChainIds).filter(chainId => {
-  const isArbitrumEnabled = selectFeatureFlag(store.getState(), 'Arbitrum')
-  const isArbitrumNovaEnabled = selectFeatureFlag(store.getState(), 'ArbitrumNova')
-  const isGnosisEnabled = selectFeatureFlag(store.getState(), 'Gnosis')
-  const isPolygonEnabled = selectFeatureFlag(store.getState(), 'Polygon')
-  const isOptimismEnabled = selectFeatureFlag(store.getState(), 'Optimism')
-  if (chainId === KnownChainIds.ArbitrumNovaMainnet && !isArbitrumNovaEnabled) return false
-  if (chainId === KnownChainIds.ArbitrumMainnet && !isArbitrumEnabled) return false
-  if (chainId === KnownChainIds.GnosisMainnet && !isGnosisEnabled) return false
-  if (chainId === KnownChainIds.PolygonMainnet && !isPolygonEnabled) return false
-  if (chainId === KnownChainIds.OptimismMainnet && !isOptimismEnabled) return false
+  if (chainId === KnownChainIds.ArbitrumNovaMainnet && enabledFlags.ArbitrumNova) return false
+  if (chainId === KnownChainIds.ArbitrumMainnet && !enabledFlags.Arbitrum) return false
+  if (chainId === KnownChainIds.GnosisMainnet && !enabledFlags.Gnosis) return false
+  if (chainId === KnownChainIds.PolygonMainnet && !enabledFlags.Polygon) return false
+  if (chainId === KnownChainIds.OptimismMainnet && !enabledFlags.Optimism) return false
 
   return true
 })

--- a/src/constants/chains.ts
+++ b/src/constants/chains.ts
@@ -2,7 +2,7 @@ import { arbitrumNovaChainId, gnosisChainId } from '@shapeshiftoss/caip'
 import { KnownChainIds } from '@shapeshiftoss/types'
 import { selectFeatureFlag } from 'state/slices/selectors'
 import { store } from 'state/store'
-// returns known ChainIds as an array, excludingg the ones that are currently flagged off
+// returns known ChainIds as an array, excluding the ones that are currently flagged off
 export const knownChainIds = Object.values(KnownChainIds).filter(chainId => {
   const isArbitrumEnabled = selectFeatureFlag(store.getState(), 'Arbitrum')
   const isArbitrumNovaEnabled = selectFeatureFlag(store.getState(), 'ArbitrumNova')

--- a/src/context/AppProvider/AppContext.tsx
+++ b/src/context/AppProvider/AppContext.tsx
@@ -1,7 +1,7 @@
 import { useToast } from '@chakra-ui/react'
 import type { AssetId } from '@shapeshiftoss/caip'
 import { fromAccountId } from '@shapeshiftoss/caip'
-import { type AccountMetadataById } from '@shapeshiftoss/types'
+import type { AccountMetadataById } from '@shapeshiftoss/types'
 import { useQuery } from '@tanstack/react-query'
 import { knownChainIds } from 'constants/chains'
 import { DEFAULT_HISTORY_TIMEFRAME } from 'constants/Config'

--- a/src/context/AppProvider/AppContext.tsx
+++ b/src/context/AppProvider/AppContext.tsx
@@ -1,8 +1,9 @@
 import { useToast } from '@chakra-ui/react'
 import type { AssetId } from '@shapeshiftoss/caip'
 import { fromAccountId } from '@shapeshiftoss/caip'
-import { type AccountMetadataById, KnownChainIds } from '@shapeshiftoss/types'
+import { type AccountMetadataById } from '@shapeshiftoss/types'
 import { useQuery } from '@tanstack/react-query'
+import { knownChainIds } from 'constants/chains'
 import { DEFAULT_HISTORY_TIMEFRAME } from 'constants/Config'
 import difference from 'lodash/difference'
 import React, { useEffect } from 'react'
@@ -86,7 +87,7 @@ export const AppProvider = ({ children }: { children: React.ReactNode }) => {
   const accountIdsByChainId = useAppSelector(selectAccountIdsByChainId)
   useEffect(() => {
     if (!wallet) return
-    const walletSupportedChainIds = Object.values(KnownChainIds).filter(chainId => {
+    const walletSupportedChainIds = knownChainIds.filter(chainId => {
       const chainAccountIds = accountIdsByChainId[chainId] ?? []
       return walletSupportsChain({ chainId, wallet, isSnapInstalled, chainAccountIds })
     })

--- a/src/lib/address/address.ts
+++ b/src/lib/address/address.ts
@@ -1,7 +1,7 @@
 import type { AssetId, ChainId } from '@shapeshiftoss/caip'
 import { bchChainId, btcChainId, dogeChainId, ethChainId, ltcChainId } from '@shapeshiftoss/caip'
-import { KnownChainIds } from '@shapeshiftoss/types'
 import bip21 from 'bip21'
+import { knownChainIds } from 'constants/chains'
 import { parse as parseEthUrl } from 'eth-url-parser'
 import type { Address } from 'viem'
 import { getChainAdapterManager } from 'context/PluginProvider/chainAdapterSingleton'
@@ -102,7 +102,7 @@ export const parseMaybeUrl = async ({
   urlOrAddress: string
 }): Promise<ParseMaybeUrlResult> => {
   // Iterate over supportedChainIds
-  for (const chainId of Object.values(KnownChainIds)) {
+  for (const chainId of knownChainIds) {
     try {
       const maybeUrl = parseMaybeUrlWithChainId({ chainId, urlOrAddress })
       const isValidUrl = maybeUrl.maybeAddress !== urlOrAddress
@@ -341,7 +341,7 @@ export const parseAddressInputWithChainId: ParseAddressByChainIdInput = async ar
 
 // Parses an address or vanity address for an **unknown** ChainId, exhausting known ChainIds until we maybe find a match
 export const parseAddressInput: ParseAddressInput = async args => {
-  for (const chainId of Object.values(KnownChainIds)) {
+  for (const chainId of knownChainIds) {
     const parsedArgs = parseMaybeUrlWithChainId(Object.assign(args, { chainId }))
 
     const isValidAddress = await validateAddress(parsedArgs)

--- a/src/pages/ConnectWallet/ConnectWallet.tsx
+++ b/src/pages/ConnectWallet/ConnectWallet.tsx
@@ -13,6 +13,7 @@ import {
 } from '@chakra-ui/react'
 import { isEvmChainId } from '@shapeshiftoss/chain-adapters'
 import { KnownChainIds } from '@shapeshiftoss/types'
+import { knownChainIds } from 'constants/chains'
 import { useCallback, useEffect, useMemo } from 'react'
 import { useTranslate } from 'react-polyglot'
 import { generatePath, matchPath, useHistory } from 'react-router-dom'
@@ -66,7 +67,7 @@ export const ConnectWallet = () => {
   const isSnapEnabled = useFeatureFlag('Snaps')
 
   const allNativeAssets = useMemo(() => {
-    return Object.values(KnownChainIds)
+    return knownChainIds
       .filter(chainId => IncludeChains.includes(chainId))
       .map(knownChainId => {
         const assetId = getChainAdapterManager().get(knownChainId)?.getFeeAssetId()!
@@ -77,7 +78,7 @@ export const ConnectWallet = () => {
   }, [])
 
   const evmChains = useMemo(() => {
-    return Object.values(KnownChainIds)
+    return knownChainIds
       .filter(isEvmChainId)
       .map(knownChainId => {
         const assetId = getChainAdapterManager().get(knownChainId)?.getFeeAssetId()!

--- a/src/pages/Lending/hooks/useLendingSupportedAssets/index.ts
+++ b/src/pages/Lending/hooks/useLendingSupportedAssets/index.ts
@@ -1,7 +1,8 @@
 import { fromAssetId, thorchainAssetId, thorchainChainId } from '@shapeshiftoss/caip'
 import { supportsThorchain } from '@shapeshiftoss/hdwallet-core'
-import { KnownChainIds } from '@shapeshiftoss/types'
+import type { KnownChainIds } from '@shapeshiftoss/types'
 import { useQuery } from '@tanstack/react-query'
+import { knownChainIds } from 'constants/chains'
 import { useCallback, useMemo } from 'react'
 import { reactQueries } from 'react-queries'
 import { useSelector } from 'react-redux'
@@ -36,7 +37,7 @@ export const useLendingSupportedAssets = ({ type }: { type: 'collateral' | 'borr
   const accountIdsByChainId = useAppSelector(selectAccountIdsByChainId)
   const walletSupportChains = useMemo(
     () =>
-      Object.values(KnownChainIds).filter(chainId => {
+      knownChainIds.filter(chainId => {
         const chainAccountIds = accountIdsByChainId[chainId] ?? []
         return walletSupportsChain({ chainId, wallet, isSnapInstalled, chainAccountIds })
       }),

--- a/src/plugins/walletConnectToDapps/components/modals/SessionProposal.tsx
+++ b/src/plugins/walletConnectToDapps/components/modals/SessionProposal.tsx
@@ -2,9 +2,10 @@ import { Alert, AlertIcon, AlertTitle, Button, VStack } from '@chakra-ui/react'
 import type { AccountId } from '@shapeshiftoss/caip'
 import { fromAccountId } from '@shapeshiftoss/caip'
 import type { HDWallet } from '@shapeshiftoss/hdwallet-core'
-import { KnownChainIds } from '@shapeshiftoss/types'
+import type { KnownChainIds } from '@shapeshiftoss/types'
 import type { ProposalTypes, SessionTypes } from '@walletconnect/types'
 import { getSdkError } from '@walletconnect/utils'
+import { knownChainIds } from 'constants/chains'
 import { mergeWith } from 'lodash'
 import { DAppInfo } from 'plugins/walletConnectToDapps/components/DAppInfo'
 import { ModalSection } from 'plugins/walletConnectToDapps/components/modals/ModalSection'
@@ -160,7 +161,7 @@ const SessionProposal = forwardRef<SessionProposalRef, WalletConnectSessionModal
               const chainAccountIds = accountIdsByChainId[chainId] ?? []
               const isRequired = requiredNamespaces[key]?.chains?.includes(chainId)
               const isSupported =
-                Object.values(KnownChainIds).includes(chainId as KnownChainIds) &&
+                knownChainIds.includes(chainId as KnownChainIds) &&
                 walletSupportsChain({ chainId, wallet, isSnapInstalled: false, chainAccountIds })
               return !isRequired && isSupported
             })

--- a/src/state/migrations/index.ts
+++ b/src/state/migrations/index.ts
@@ -51,4 +51,5 @@ export const migrations = {
   41: clearAssets,
   42: clearAssets,
   43: clearAssets,
+  44: clearAssets,
 }


### PR DESCRIPTION
## Description

... i.e without ChainIds that are currently flagged off. This is in response to the following from @MbMaria https://github.com/shapeshift/web/pull/6667#issuecomment-2058170776:

> This is fixed on the trade from asset drop down but the icon still appears in the trade to menu

And indeed, with the current assumptions that KnownChainIds is static, and the many many consumptions of it, it's not sane to expect tackling all the feature-flags detection.

By having a static knownChainIds array that checks whether the feature-flag is enabled/disabled for it at module evaluation time, we ensure *all* consumoors don't run the chance of exposing ChainIds which
are currently flagged off.

For completeness, added all chains that we currently have flags for.

## Pull Request Type

- [ ] :bug: Bug fix (Non-breaking Change: Fixes an issue)
- [ ] :hammer_and_wrench: Chore (Non-breaking Change: Doc updates, pkg upgrades, typos, etc..)
- [x] :nail_care: New Feature (Breaking/Non-breaking Change)

## Issue (if applicable)

<!-----------------------------------------------------------------------------
If applicable, please link to the github issue and put `closes #XXXX` in your comment to auto-close the issue that your PR fixes.
------------------------------------------------------------------------------>

- relates to the closed https://github.com/shapeshift/web/issues/6664

## Risk
> High Risk PRs Require 2 approvals

<!-----------------------------------------------------------------------------
Outline the scope of your changes and the risk associated with them. You must use your discretion as an engineer to determine the potential impact of your changes.

WARNING: If your PR introduces a new on-chain transaction or modifies an existing one, please add the "High-Risk" label to this PR and ask for 2 reviewers to approve it before merging.

E.g. an upgrade to `hdwallet` or core state management would be considered higher risk, and might require a full regression test. UI or isolated view changes, or something behind a feature flag may have near zero risk. Small bug fixes might require testing isolated to the specific fix.
------------------------------------------------------------------------------>

> What protocols, transaction types or contract interactions might be affected by this PR?

Low - ensure all chains are looking the sain as in develop currently without turning any flag on or off

## Testing

<!-----------------------------------------------------------------------------
We treat every PR to be merged with the same scrutiny as if we were merging directly to production.

Your PR will not be merged if you do not complete the sections below for our engineering and operations teams to test.
------------------------------------------------------------------------------>

- See risks

### Engineering

<!-----------------------------------------------------------------------------
Include sufficient information here for an engineer to test your PR. This may include how to test locally, in a built environment, changes to infrastructure etc.
------------------------------------------------------------------------------>

- ^

### Operations

<!-----------------------------------------------------------------------------
If your changes have a user-facing impact, describe how a non-technical QA team can functionally test your changes in a preview environment.

If they are not user-facing please describe how to test for any regressions that may occur.
------------------------------------------------------------------------------>

- ^

## Screenshots (if applicable)


### Swapper buy and sell chain selection - this diff vs. develop (right)

<!-- av pr metadata
This information is embedded by the av CLI when creating PRs to track the status of stacks when using Aviator. Please do not delete or edit this section of the PR.
```
{"parent":"develop","parentHead":"","trunk":"develop"}
```
-->

https://github.com/shapeshift/web/assets/17035424/d5c94f1d-4ac8-416f-a067-f31f23d05ad4



