### PR TITLE
fix: ledger notifications feed error spew

### DIFF
--- a/src/components/Layout/Header/NavBar/Notifications.tsx
+++ b/src/components/Layout/Header/NavBar/Notifications.tsx
@@ -1,6 +1,6 @@
 import { Box, IconButton, useColorMode } from '@chakra-ui/react'
-import type { BIP32Path, ETHSignTypedData } from '@shapeshiftoss/hdwallet-core'
-import { supportsETH } from '@shapeshiftoss/hdwallet-core'
+import { ethAssetId, ethChainId } from '@shapeshiftoss/caip'
+import type { BIP32Path, ETHSignTypedData, ETHWallet } from '@shapeshiftoss/hdwallet-core'
 import type { CustomTheme, ThemeMode as ThemeModeType } from '@wherever/react-notification-feed'
 import { getConfig } from 'config'
 import { lazy, memo, Suspense, useCallback, useEffect, useMemo, useState } from 'react'
@@ -8,7 +8,11 @@ import { useTranslate } from 'react-polyglot'
 import { toHex } from 'viem'
 import { KeyManager } from 'context/WalletProvider/KeyManager'
 import { useFeatureFlag } from 'hooks/useFeatureFlag/useFeatureFlag'
+import { useIsSnapInstalled } from 'hooks/useIsSnapInstalled/useIsSnapInstalled'
 import { useWallet } from 'hooks/useWallet/useWallet'
+import { walletSupportsChain } from 'hooks/useWalletSupportsChain/useWalletSupportsChain'
+import { selectAccountIdsByAssetId } from 'state/slices/selectors'
+import { useAppSelector } from 'state/store'
 import { breakpoints, theme } from 'theme/theme'
 
 const NotificationBell = lazy(() =>
@@ -40,6 +44,11 @@ export const Notifications = memo(() => {
   const {
     state: { wallet, modalType },
   } = useWallet()
+  const isSnapInstalled = useIsSnapInstalled()
+
+  const ethAccountIds = useAppSelector(state =>
+    selectAccountIdsByAssetId(state, { assetId: ethAssetId }),
+  )
 
   const [addressNList, setAddressNList] = useState<BIP32Path>()
   const [ethAddress, setEthAddress] = useState<string | null>()
@@ -68,29 +77,43 @@ export const Notifications = memo(() => {
     }
   }, [colorMode, mobileBreakpoint])
 
+  const walletSupportsEth = useMemo(
+    () =>
+      walletSupportsChain({
+        chainId: ethChainId,
+        wallet,
+        isSnapInstalled,
+        chainAccountIds: ethAccountIds,
+      }),
+    [ethAccountIds, isSnapInstalled, wallet],
+  )
+
   useEffect(() => {
-    if (!wallet || !supportsETH(wallet)) return
+    if (!(wallet && walletSupportsEth)) return
     ;(async () => {
-      const { addressNList } = wallet.ethGetAccountPaths({
+      const { addressNList } = (wallet as ETHWallet).ethGetAccountPaths({
         coin: 'Ethereum',
         accountIdx: 0,
       })[0]
 
-      const ethAddress = await wallet.ethGetAddress({ addressNList, showDisplay: false })
+      const ethAddress = await (wallet as ETHWallet).ethGetAddress({
+        addressNList,
+        showDisplay: false,
+      })
 
       setEthAddress(ethAddress)
       setAddressNList(addressNList)
     })()
-  }, [wallet])
+  }, [wallet, walletSupportsEth])
 
   const signMessage = useCallback(
     async (message: string) => {
-      if (!addressNList || !wallet || !supportsETH(wallet)) {
+      if (!addressNList || !wallet || !walletSupportsEth) {
         return
       }
 
       try {
-        const signedMsg = await wallet.ethSignMessage({
+        const signedMsg = await (wallet as ETHWallet).ethSignMessage({
           addressNList,
           message: toHex(message),
         })
@@ -100,17 +123,17 @@ export const Notifications = memo(() => {
         console.error(e)
       }
     },
-    [wallet, addressNList],
+    [addressNList, wallet, walletSupportsEth],
   )
 
   const signTypedData = useCallback(
     async (typedData: ETHSignTypedData['typedData']) => {
-      if (!addressNList || !wallet || !supportsETH(wallet)) {
+      if (!addressNList || !wallet || !walletSupportsEth) {
         return
       }
 
       try {
-        const signedMsg = await wallet.ethSignTypedData?.({
+        const signedMsg = await (wallet as ETHWallet).ethSignTypedData?.({
           addressNList,
           typedData,
         })
@@ -120,7 +143,7 @@ export const Notifications = memo(() => {
         console.error(e)
       }
     },
-    [wallet, addressNList],
+    [addressNList, wallet, walletSupportsEth],
   )
 
   const customSignerProp = useMemo(
@@ -138,7 +161,7 @@ export const Notifications = memo(() => {
     !ethAddress ||
     !wallet ||
     !eip712SupportedWallets.includes(modalType as KeyManager) ||
-    !supportsETH(wallet)
+    !walletSupportsEth
   )
     return null
 

--- a/src/components/Layout/Header/NavBar/Notifications.tsx
+++ b/src/components/Layout/Header/NavBar/Notifications.tsx
@@ -89,7 +89,8 @@ export const Notifications = memo(() => {
   )
 
   useEffect(() => {
-    if (!(wallet && walletSupportsEth)) return
+    if (!(wallet && walletSupportsEth && eip712SupportedWallets.includes(modalType as KeyManager)))
+      return
     ;(async () => {
       const { addressNList } = (wallet as ETHWallet).ethGetAccountPaths({
         coin: 'Ethereum',
@@ -104,11 +105,16 @@ export const Notifications = memo(() => {
       setEthAddress(ethAddress)
       setAddressNList(addressNList)
     })()
-  }, [wallet, walletSupportsEth])
+  }, [modalType, wallet, walletSupportsEth])
 
   const signMessage = useCallback(
     async (message: string) => {
-      if (!addressNList || !wallet || !walletSupportsEth) {
+      if (
+        !addressNList ||
+        !wallet ||
+        !walletSupportsEth ||
+        !eip712SupportedWallets.includes(modalType as KeyManager)
+      ) {
         return
       }
 
@@ -123,12 +129,17 @@ export const Notifications = memo(() => {
         console.error(e)
       }
     },
-    [addressNList, wallet, walletSupportsEth],
+    [addressNList, modalType, wallet, walletSupportsEth],
   )
 
   const signTypedData = useCallback(
     async (typedData: ETHSignTypedData['typedData']) => {
-      if (!addressNList || !wallet || !walletSupportsEth) {
+      if (
+        !addressNList ||
+        !wallet ||
+        !walletSupportsEth ||
+        !eip712SupportedWallets.includes(modalType as KeyManager)
+      ) {
         return
       }
 
@@ -143,7 +154,7 @@ export const Notifications = memo(() => {
         console.error(e)
       }
     },
-    [addressNList, wallet, walletSupportsEth],
+    [addressNList, modalType, wallet, walletSupportsEth],
   )
 
   const customSignerProp = useMemo(


### PR DESCRIPTION
## Description

Does what it says on the box - as soon as we have `useWallet().state.wallet` (i.e on Ledger connect click) the `<Notifications />` component becomes reactive and attemps fetching Ethereum address,
which it can't, as the wallet doesn't support Ethereum right out the gate without it being explicitly added as a chain.

## Pull Request Type

- [x] :bug: Bug fix (Non-breaking Change: Fixes an issue)
- [ ] :hammer_and_wrench: Chore (Non-breaking Change: Doc updates, pkg upgrades, typos, etc..)
- [ ] :nail_care: New Feature (Breaking/Non-breaking Change)

## Issue (if applicable)

<!-----------------------------------------------------------------------------
If applicable, please link to the github issue and put `closes #XXXX` in your comment to auto-close the issue that your PR fixes.
------------------------------------------------------------------------------>

closes #6713

## Risk
> High Risk PRs Require 2 approvals

<!-----------------------------------------------------------------------------
Outline the scope of your changes and the risk associated with them. You must use your discretion as an engineer to determine the potential impact of your changes.

WARNING: If your PR introduces a new on-chain transaction or modifies an existing one, please add the "High-Risk" label to this PR and ask for 2 reviewers to approve it before merging.

E.g. an upgrade to `hdwallet` or core state management would be considered higher risk, and might require a full regression test. UI or isolated view changes, or something behind a feature flag may have near zero risk. Small bug fixes might require testing isolated to the specific fix.
------------------------------------------------------------------------------>

> What protocols, transaction types or contract interactions might be affected by this PR?

Low - this brings *more* safety, ensure notifications feed still work properly for native

## Testing

<!-----------------------------------------------------------------------------
We treat every PR to be merged with the same scrutiny as if we were merging directly to production.

Your PR will not be merged if you do not complete the sections below for our engineering and operations teams to test.
------------------------------------------------------------------------------>

- Ensure notifications feed still work properly for native

### Engineering

<!-----------------------------------------------------------------------------
Include sufficient information here for an engineer to test your PR. This may include how to test locally, in a built environment, changes to infrastructure etc.
------------------------------------------------------------------------------>

- ^

### Operations

<!-----------------------------------------------------------------------------
If your changes have a user-facing impact, describe how a non-technical QA team can functionally test your changes in a preview environment.

If they are not user-facing please describe how to test for any regressions that may occur.
------------------------------------------------------------------------------>

- ^

## Screenshots (if applicable)

<!-- av pr metadata
This information is embedded by the av CLI when creating PRs to track the status of stacks when using Aviator. Please do not delete or edit this section of the PR.
```
{"parent":"develop","parentHead":"","trunk":"develop"}
```
-->
