### PR TITLE
feat: warning ack for dangerous withdraw

### DIFF
--- a/src/assets/translations/en/main.json
+++ b/src/assets/translations/en/main.json
@@ -414,7 +414,7 @@
         },
         "cannotDepositWhilePendingTx": "Cannot deposit while Txs are pending",
         "cannotWithdrawWhilePendingTx": "Cannot withdraw while Txs are pending",
-        "dangerousWithdrawWarning": "Withdrawal disabled as the THORChain fee could result in the total loss of the funds being withdrawn. Consider withdrawing a higher amount to avoid this issue."
+        "dangerousWithdrawWarning": "THORChain fee could result in the total loss of the funds being withdrawn. Consider withdrawing a higher amount to avoid this issue."
       }
     },
     "memoNote": {


### PR DESCRIPTION
## Description

Add the `WarningAcknowledgement` component to the LP withdraw flow, replacing the existing `Alert` component.

Note, we still have the `incompletePositionWithdrawAlert` shown as an alert - awaiting input from @shapeshift/product on how to best handle multiple warnings (sequential acceptance?).

<img width="320" alt="Screenshot 2024-04-22 at 8 36 31 AM" src="https://github.com/shapeshift/web/assets/97164662/b58487c2-7c14-4c48-8ff7-28a9dfda5bac">
<img width="323" alt="Screenshot 2024-04-22 at 8 36 35 AM" src="https://github.com/shapeshift/web/assets/97164662/0d08c8ab-dcc2-406b-8ff7-274843c47e53">
<img width="314" alt="Screenshot 2024-04-22 at 8 36 40 AM" src="https://github.com/shapeshift/web/assets/97164662/35b69564-a243-4dcd-8f1b-dfb5b027d3dd">

## Pull Request Type

- [ ] :bug: Bug fix (Non-breaking Change: Fixes an issue)
- [ ] :hammer_and_wrench: Chore (Non-breaking Change: Doc updates, pkg upgrades, typos, etc..)
- [x] :nail_care: New Feature (Breaking/Non-breaking Change)

## Issue (if applicable)

Contributes to https://github.com/shapeshift/web/issues/6707

## Risk

Medium - getting it wrong could impact LP withdraws,  but the component pattern is well tested and in production already.

> What protocols, transaction types or contract interactions might be affected by this PR?

LP withdraws.

## Testing

Attempt to withdraw a small LP position and confirm that on click of "Remove liquidity" the `WarningAcknowledgement` is shown, and can be accepted.

### Engineering

☝️

### Operations

☝️

## Screenshots (if applicable)

See description above.