### PR TITLE
feat: improved lang selection and param

### DIFF
--- a/src/components/LanguageSelector.tsx
+++ b/src/components/LanguageSelector.tsx
@@ -22,7 +22,7 @@ export const LanguageSelector: React.FC<SelectProps> = props => {
   )
 
   return (
-    <Select onChange={handleLanguageChange} defaultValue={selectedLocale} {...props}>
+    <Select onChange={handleLanguageChange} value={selectedLocale} {...props}>
       {locales.map(locale => (
         <option key={locale.key} value={locale.key}>
           {locale.label}

--- a/src/context/AppProvider/AppContext.tsx
+++ b/src/context/AppProvider/AppContext.tsx
@@ -5,6 +5,7 @@ import type { AccountMetadataById } from '@shapeshiftoss/types'
 import { useQuery } from '@tanstack/react-query'
 import { knownChainIds } from 'constants/chains'
 import { DEFAULT_HISTORY_TIMEFRAME } from 'constants/Config'
+import { LanguageTypeEnum } from 'constants/LanguageTypeEnum'
 import difference from 'lodash/difference'
 import React, { useEffect } from 'react'
 import { useTranslate } from 'react-polyglot'
@@ -81,7 +82,9 @@ export const AppProvider = ({ children }: { children: React.ReactNode }) => {
 
   const selectedLocale = useAppSelector(selectSelectedLocale)
   useEffect(() => {
-    require(`dayjs/locale/${selectedLocale}.js`)
+    if (selectedLocale in LanguageTypeEnum ?? {}) {
+      require(`dayjs/locale/${selectedLocale}.js`)
+    }
   }, [selectedLocale])
 
   const accountIdsByChainId = useAppSelector(selectAccountIdsByChainId)


### PR DESCRIPTION
## Description

Improves few aspects of the current way we handle language selection:

 * The current language is now set in the `lang` attribute of the `<html>` tag to improve accessibility, as suggested in #5474
 * The `lang` URL parameter gets removed once the desired language is applied in the app. This also fixes a bug as it was not possible to change language from the one specified this way in the URL previously. Still defaults to "en" (English) if the language is not supported.
 * Only load the locale formatting if the selected locale exists in `LanguageTypeEnum`, avoiding an bug ("Oops" error) if someone tries to use an invalid `lang` URL parameter.
 * The value of the current language in the LanguageSelector is now set through `value` instead of `defaultValue`, so it gets updated when 
`selectedLanguage` changes. This fixes a bug in which changing the language through `lang` in the URL would not update the language selector on the Connect page.
 * Fixes a typo in a variable name  `selectedLocalteExists` -> `selectedLocaleExists`


<!-- Please describe your changes -->

## Pull Request Type

- [ ] :bug: Bug fix (Non-breaking Change: Fixes an issue)
- [ ] :hammer_and_wrench: Chore (Non-breaking Change: Doc updates, pkg upgrades, typos, etc..)
- [x] :nail_care: New Feature (Breaking/Non-breaking Change)

## Issue (if applicable)

<!-----------------------------------------------------------------------------
If applicable, please link to the github issue and put `closes #XXXX` in your comment to auto-close the issue that your PR fixes.
------------------------------------------------------------------------------>
Other parts of #5474 not related to language/translations should still be address, that's why the issue is not marked as closed by this PR.

## Risk
> High Risk PRs Require 2 approvals

Low Risk.

App behaviors remain the same for users (language set through UI or with a URL parameter).

<!-----------------------------------------------------------------------------
Outline the scope of your changes and the risk associated with them. You must use your discretion as an engineer to determine the potential impact of your changes.

WARNING: If your PR introduces a new on-chain transaction or modifies an existing one, please add the "High-Risk" label to this PR and ask for 2 reviewers to approve it before merging.

E.g. an upgrade to `hdwallet` or core state management would be considered higher risk, and might require a full regression test. UI or isolated view changes, or something behind a feature flag may have near zero risk. Small bug fixes might require testing isolated to the specific fix.
------------------------------------------------------------------------------>

> What protocols, transaction types or contract interactions might be affected by this PR?

None.


## Testing

* Language selector still works to switch languages
* Any way used to change language results in the HTML code first element, `<html>`, to see its attribute updated to the current language. Open the console and Inspect the HTML to see `<html lang="fr" [...]>` at the top when French is selected for example.
* Select a different language using the `lang` URL parameter (e.g. add `?lang=fr` to the URL while in the app or the connect page) still works.
* When setting the language using the `lang` URL parameter while on the Connect page updates the Language selector (top right drop down list).
* No more error if you use a non-supported language as `lang` URL parameter. Defaults to English.

<!-----------------------------------------------------------------------------
We treat every PR to be merged with the same scrutiny as if we were merging directly to production.

Your PR will not be merged if you do not complete the sections below for our engineering and operations teams to test.
------------------------------------------------------------------------------>

### Engineering
☝️ 
<!-----------------------------------------------------------------------------
Include sufficient information here for an engineer to test your PR. This may include how to test locally, in a built environment, changes to infrastructure etc.
------------------------------------------------------------------------------>

### Operations
☝️ 
<!-----------------------------------------------------------------------------
If your changes have a user-facing impact, describe how a non-technical QA team can functionally test your changes in a preview environment.

If they are not user-facing please describe how to test for any regressions that may occur.
------------------------------------------------------------------------------>