### PR TITLE
fix: override hdwallet ethers version in vitest

### DIFF
--- a/package.json
+++ b/package.json
@@ -271,6 +271,7 @@
     "jscodeshift": "^0.15.2",
     "limiter": "^2.1.0",
     "lit-html": "^2.6.1",
+    "module-alias": "^2.2.3",
     "msw": "^0.36.5",
     "multiformats": "^9.6.3",
     "patch-package": "^8.0.0",

--- a/src/setupVitest.ts
+++ b/src/setupVitest.ts
@@ -1,4 +1,16 @@
+import 'module-alias/register'
+
+import moduleAlias from 'module-alias'
+import path from 'path'
 import { beforeAll, vi } from 'vitest'
+
+// Redirect 'ethers' imports to 'ethers5' only for specific modules
+moduleAlias.addAlias('ethers', (fromPath: string) => {
+  if (fromPath.includes('/node_modules/@shapeshiftoss/hdwallet-shapeshift-multichain')) {
+    return path.resolve(__dirname, '../node_modules/ethers5')
+  }
+  return 'ethers'
+})
 
 vi.hoisted(() => {
   vi.stubEnv('REACT_APP_FEATURE_MIXPANEL', 'false')

--- a/src/types/module-alias.d.ts
+++ b/src/types/module-alias.d.ts
@@ -1,0 +1,6 @@
+declare module 'module-alias' {
+  declare namespace register {}
+
+  // Manually declaring this as @types/module-alias is several version behind and doesn't have this variant
+  export function addAlias(alias: string, path: (path: string) => void): void
+}

--- a/yarn.lock
+++ b/yarn.lock
@@ -10856,6 +10856,7 @@ __metadata:
     lodash: ^4.17.21
     match-sorter: ^6.3.0
     mixpanel-browser: ^2.45.0
+    module-alias: ^2.2.3
     msw: ^0.36.5
     multiformats: ^9.6.3
     myzod: ^1.10.1
@@ -27975,6 +27976,13 @@ __metadata:
     _mocha: bin/_mocha
     mocha: bin/mocha
   checksum: c069edeffb4bfd0cdfbe21d11c2f93e44ab75440d6b4b20fe9d357e0eb92c4e921fb38175093d3242a9577155eece4c337d0aae5b3ffc3d65959ea01c3d552a6
+  languageName: node
+  linkType: hard
+
+"module-alias@npm:^2.2.3":
+  version: 2.2.3
+  resolution: "module-alias@npm:2.2.3"
+  checksum: 6169187f69de8dcf8af8fab4d9e53ada6338a43f7670d38d0b27a089c28f9eb18d85a6fd46f11b54c63079a68449b85d071d7db0ac067f9f7faedbcd6231456d
   languageName: node
   linkType: hard
 


### PR DESCRIPTION
## Description

Fixes tests failing due to ethers version conflict between web and hdwallet.

## Pull Request Type

- [x] :bug: Bug fix (Non-breaking Change: Fixes an issue)
- [ ] :hammer_and_wrench: Chore (Non-breaking Change: Doc updates, pkg upgrades, typos, etc..)
- [ ] :nail_care: New Feature (Breaking/Non-breaking Change)

## Issue (if applicable)

NA

## Risk
> High Risk PRs Require 2 approvals

Low risk.

> What protocols, transaction types or contract interactions might be affected by this PR?

## Testing

Run `yarn test` -> all tests should pass.

### Engineering

<!-----------------------------------------------------------------------------
Include sufficient information here for an engineer to test your PR. This may include how to test locally, in a built environment, changes to infrastructure etc.
------------------------------------------------------------------------------>

### Operations

<!-----------------------------------------------------------------------------
If your changes have a user-facing impact, describe how a non-technical QA team can functionally test your changes in a preview environment.

If they are not user-facing please describe how to test for any regressions that may occur.
------------------------------------------------------------------------------>

## Screenshots (if applicable)

![image](https://github.com/shapeshift/web/assets/125113430/0ef15fdb-924e-4b7b-bc50-e02d04d6e405)
