### PR TITLE
fix: savers unreliable loading state

### DIFF
--- a/src/features/defi/providers/thorchain-savers/components/ThorchainSaversManager/Deposit/components/Deposit.tsx
+++ b/src/features/defi/providers/thorchain-savers/components/ThorchainSaversManager/Deposit/components/Deposit.tsx
@@ -474,9 +474,11 @@ export const Deposit: React.FC<DepositProps> = ({
 
   const validateCryptoAmount = useCallback(
     (value: string) => {
-      contextDispatch?.({ type: ThorchainSaversDepositActionType.SET_LOADING, payload: true })
+      if (!contextDispatch) return
+
+      contextDispatch({ type: ThorchainSaversDepositActionType.SET_LOADING, payload: true })
       return _validateCryptoAmount(value).finally(() => {
-        contextDispatch?.({ type: ThorchainSaversDepositActionType.SET_LOADING, payload: false })
+        contextDispatch({ type: ThorchainSaversDepositActionType.SET_LOADING, payload: false })
       })
     },
     [_validateCryptoAmount, contextDispatch],
@@ -550,9 +552,11 @@ export const Deposit: React.FC<DepositProps> = ({
 
   const validateFiatAmount = useCallback(
     (value: string) => {
-      contextDispatch?.({ type: ThorchainSaversDepositActionType.SET_LOADING, payload: true })
+      if (!contextDispatch) return
+
+      contextDispatch({ type: ThorchainSaversDepositActionType.SET_LOADING, payload: true })
       return _validateFiatAmount(value).finally(() => {
-        contextDispatch?.({ type: ThorchainSaversDepositActionType.SET_LOADING, payload: false })
+        contextDispatch({ type: ThorchainSaversDepositActionType.SET_LOADING, payload: false })
       })
     },
     [_validateFiatAmount, contextDispatch],

--- a/src/features/defi/providers/thorchain-savers/components/ThorchainSaversManager/Deposit/components/Deposit.tsx
+++ b/src/features/defi/providers/thorchain-savers/components/ThorchainSaversManager/Deposit/components/Deposit.tsx
@@ -13,6 +13,7 @@ import type {
 } from 'features/defi/contexts/DefiManagerProvider/DefiCommon'
 import { DefiAction, DefiStep } from 'features/defi/contexts/DefiManagerProvider/DefiCommon'
 import debounce from 'lodash/debounce'
+import pDebounce from 'p-debounce'
 import qs from 'qs'
 import { useCallback, useContext, useEffect, useMemo, useState } from 'react'
 import { useTranslate } from 'react-polyglot'
@@ -484,6 +485,11 @@ export const Deposit: React.FC<DepositProps> = ({
     [_validateCryptoAmount, contextDispatch],
   )
 
+  const validateCryptoAmountDebounced = useMemo(
+    () => pDebounce(validateCryptoAmount, 500),
+    [validateCryptoAmount],
+  )
+
   const _validateFiatAmount = useCallback(
     async (value: string) => {
       if (!accountId) return
@@ -560,6 +566,11 @@ export const Deposit: React.FC<DepositProps> = ({
       })
     },
     [_validateFiatAmount, contextDispatch],
+  )
+
+  const validateFiatAmountDebounced = useMemo(
+    () => pDebounce(validateFiatAmount, 500),
+    [validateFiatAmount],
   )
 
   const balanceCryptoPrecision = useMemo(
@@ -777,17 +788,17 @@ export const Deposit: React.FC<DepositProps> = ({
   const cryptoInputValidation = useMemo(
     () => ({
       required: true,
-      validate: { validateCryptoAmount },
+      validate: { validateCryptoAmountDebounced },
     }),
-    [validateCryptoAmount],
+    [validateCryptoAmountDebounced],
   )
 
   const fiatInputValidation = useMemo(
     () => ({
       required: true,
-      validate: { validateFiatAmount },
+      validate: { validateFiatAmountDebounced },
     }),
-    [validateFiatAmount],
+    [validateFiatAmountDebounced],
   )
 
   if (!state || !contextDispatch || !opportunityData) return null

--- a/src/features/defi/providers/thorchain-savers/components/ThorchainSaversManager/Withdraw/components/Withdraw.tsx
+++ b/src/features/defi/providers/thorchain-savers/components/ThorchainSaversManager/Withdraw/components/Withdraw.tsx
@@ -308,9 +308,8 @@ export const Withdraw: React.FC<WithdrawProps> = ({ accountId, fromAddress, onNe
     return bnOrZero(outboundFeeInAssetCryptoBaseUnit).times(1.05).toFixed()
   }, [outboundFeeInAssetCryptoBaseUnit])
 
-  const validateCryptoAmount = useCallback(
+  const _validateCryptoAmount = useCallback(
     async (value: string) => {
-      if (!dispatch) return false
       if (!accountId) return false
       if (!opportunityData) return false
       if (!safeOutboundFeeInAssetCryptoBaseUnit) return false
@@ -402,7 +401,6 @@ export const Withdraw: React.FC<WithdrawProps> = ({ accountId, fromAddress, onNe
         console.error(e)
       } finally {
         setQuoteLoading(false)
-        dispatch({ type: ThorchainSaversWithdrawActionType.SET_LOADING, payload: false })
       }
     },
     [
@@ -410,13 +408,22 @@ export const Withdraw: React.FC<WithdrawProps> = ({ accountId, fromAddress, onNe
       amountAvailableCryptoPrecision,
       asset,
       chainId,
-      dispatch,
       fromAddress,
       opportunityData,
       queryClient,
       safeOutboundFeeInAssetCryptoBaseUnit,
       translate,
     ],
+  )
+
+  const validateCryptoAmount = useCallback(
+    (value: string) => {
+      dispatch?.({ type: ThorchainSaversWithdrawActionType.SET_LOADING, payload: true })
+      return _validateCryptoAmount(value).finally(() => {
+        dispatch?.({ type: ThorchainSaversWithdrawActionType.SET_LOADING, payload: false })
+      })
+    },
+    [_validateCryptoAmount, dispatch],
   )
 
   const missingFundsForGasTranslation: TextPropTypes['translation'] = useMemo(
@@ -430,10 +437,9 @@ export const Withdraw: React.FC<WithdrawProps> = ({ accountId, fromAddress, onNe
     [missingFunds, feeAsset.symbol],
   )
 
-  const validateFiatAmount = useCallback(
+  const _validateFiatAmount = useCallback(
     async (value: string) => {
       if (!(opportunityData && accountId && dispatch)) return false
-      dispatch({ type: ThorchainSaversWithdrawActionType.SET_LOADING, payload: true })
 
       setMissingFunds(null)
       setQuoteLoading(true)
@@ -480,7 +486,6 @@ export const Withdraw: React.FC<WithdrawProps> = ({ accountId, fromAddress, onNe
         return translate('trade.errors.amountTooSmallUnknownMinimum')
       } finally {
         setQuoteLoading(false)
-        dispatch({ type: ThorchainSaversWithdrawActionType.SET_LOADING, payload: false })
       }
     },
     [
@@ -494,6 +499,16 @@ export const Withdraw: React.FC<WithdrawProps> = ({ accountId, fromAddress, onNe
       opportunityData,
       translate,
     ],
+  )
+
+  const validateFiatAmount = useCallback(
+    (value: string) => {
+      dispatch?.({ type: ThorchainSaversWithdrawActionType.SET_LOADING, payload: true })
+      return _validateFiatAmount(value).finally(() => {
+        dispatch?.({ type: ThorchainSaversWithdrawActionType.SET_LOADING, payload: false })
+      })
+    },
+    [_validateFiatAmount, dispatch],
   )
 
   const cryptoInputValidation = useMemo(

--- a/src/features/defi/providers/thorchain-savers/components/ThorchainSaversManager/Withdraw/components/Withdraw.tsx
+++ b/src/features/defi/providers/thorchain-savers/components/ThorchainSaversManager/Withdraw/components/Withdraw.tsx
@@ -418,9 +418,11 @@ export const Withdraw: React.FC<WithdrawProps> = ({ accountId, fromAddress, onNe
 
   const validateCryptoAmount = useCallback(
     (value: string) => {
-      dispatch?.({ type: ThorchainSaversWithdrawActionType.SET_LOADING, payload: true })
+      if (!dispatch) return
+
+      dispatch({ type: ThorchainSaversWithdrawActionType.SET_LOADING, payload: true })
       return _validateCryptoAmount(value).finally(() => {
-        dispatch?.({ type: ThorchainSaversWithdrawActionType.SET_LOADING, payload: false })
+        dispatch({ type: ThorchainSaversWithdrawActionType.SET_LOADING, payload: false })
       })
     },
     [_validateCryptoAmount, dispatch],
@@ -503,9 +505,11 @@ export const Withdraw: React.FC<WithdrawProps> = ({ accountId, fromAddress, onNe
 
   const validateFiatAmount = useCallback(
     (value: string) => {
-      dispatch?.({ type: ThorchainSaversWithdrawActionType.SET_LOADING, payload: true })
+      if (!dispatch) return
+
+      dispatch({ type: ThorchainSaversWithdrawActionType.SET_LOADING, payload: true })
       return _validateFiatAmount(value).finally(() => {
-        dispatch?.({ type: ThorchainSaversWithdrawActionType.SET_LOADING, payload: false })
+        dispatch({ type: ThorchainSaversWithdrawActionType.SET_LOADING, payload: false })
       })
     },
     [_validateFiatAmount, dispatch],

--- a/src/features/defi/providers/thorchain-savers/components/ThorchainSaversManager/Withdraw/components/Withdraw.tsx
+++ b/src/features/defi/providers/thorchain-savers/components/ThorchainSaversManager/Withdraw/components/Withdraw.tsx
@@ -11,6 +11,7 @@ import type {
   DefiQueryParams,
 } from 'features/defi/contexts/DefiManagerProvider/DefiCommon'
 import { DefiStep } from 'features/defi/contexts/DefiManagerProvider/DefiCommon'
+import pDebounce from 'p-debounce'
 import { useCallback, useContext, useMemo, useState } from 'react'
 import { FormProvider, useForm } from 'react-hook-form'
 import { useTranslate } from 'react-polyglot'
@@ -428,6 +429,11 @@ export const Withdraw: React.FC<WithdrawProps> = ({ accountId, fromAddress, onNe
     [_validateCryptoAmount, dispatch],
   )
 
+  const validateCryptoAmountDebounced = useMemo(
+    () => pDebounce(validateCryptoAmount, 500),
+    [validateCryptoAmount],
+  )
+
   const missingFundsForGasTranslation: TextPropTypes['translation'] = useMemo(
     () => [
       'modals.confirm.missingFundsForGas',
@@ -515,20 +521,25 @@ export const Withdraw: React.FC<WithdrawProps> = ({ accountId, fromAddress, onNe
     [_validateFiatAmount, dispatch],
   )
 
+  const validateFiatAmountDebounced = useMemo(
+    () => pDebounce(validateFiatAmount, 500),
+    [validateFiatAmount],
+  )
+
   const cryptoInputValidation = useMemo(
     () => ({
       required: true,
-      validate: { validateCryptoAmount },
+      validate: { validateCryptoAmountDebounced },
     }),
-    [validateCryptoAmount],
+    [validateCryptoAmountDebounced],
   )
 
   const fiatInputValidation = useMemo(
     () => ({
       required: true,
-      validate: { validateFiatAmount },
+      validate: { validateFiatAmountDebounced },
     }),
-    [validateFiatAmount],
+    [validateFiatAmountDebounced],
   )
 
   if (!state) return null

--- a/src/lib/utils/thorchain/balance.ts
+++ b/src/lib/utils/thorchain/balance.ts
@@ -184,6 +184,7 @@ export const fetchHasEnoughBalanceForTxPlusFeesPlusSweep = async ({
     ? await queryClient.fetchQuery({
         queryKey: isSweepNeededQueryKey,
         queryFn: isSweepNeededQueryFn,
+        staleTime: 60_000,
       })
     : undefined
 

--- a/src/pages/Lending/hooks/useGetEstimatedFeesQuery.ts
+++ b/src/pages/Lending/hooks/useGetEstimatedFeesQuery.ts
@@ -68,7 +68,7 @@ export const useGetEstimatedFeesQuery = ({
       ),
     // Ensures fees are refetched at an interval, including when the app is in the background
     refetchIntervalInBackground: true,
-    refetchInterval: estimateFeesInput.disableRefetch ? false : 5000,
+    refetchInterval: estimateFeesInput.disableRefetch ? false : 15_000,
   })
 
   return getEstimatedFeesQuery


### PR DESCRIPTION
## Description

This PR improves the loading state of savers at both deposit and withdraw steps.

This makes things more reliable, without the flash of loading states that was especially obvious in deposit, and makes the continue button click reliable.

## Pull Request Type

- [x] :bug: Bug fix (Non-breaking Change: Fixes an issue)
- [ ] :hammer_and_wrench: Chore (Non-breaking Change: Doc updates, pkg upgrades, typos, etc..)
- [ ] :nail_care: New Feature (Breaking/Non-breaking Change)

## Issue (if applicable)

<!-----------------------------------------------------------------------------
If applicable, please link to the github issue and put `closes #XXXX` in your comment to auto-close the issue that your PR fixes.
------------------------------------------------------------------------------>

closes https://github.com/shapeshift/web/issues/6750

## Risk
> High Risk PRs Require 2 approvals

<!-----------------------------------------------------------------------------
Outline the scope of your changes and the risk associated with them. You must use your discretion as an engineer to determine the potential impact of your changes.

WARNING: If your PR introduces a new on-chain transaction or modifies an existing one, please add the "High-Risk" label to this PR and ask for 2 reviewers to approve it before merging.

E.g. an upgrade to `hdwallet` or core state management would be considered higher risk, and might require a full regression test. UI or isolated view changes, or something behind a feature flag may have near zero risk. Small bug fixes might require testing isolated to the specific fix.
------------------------------------------------------------------------------>

Low - Really only touches loading states

> What protocols, transaction types or contract interactions might be affected by this PR?

## Testing

<!-----------------------------------------------------------------------------
We treat every PR to be merged with the same scrutiny as if we were merging directly to production.

Your PR will not be merged if you do not complete the sections below for our engineering and operations teams to test.
------------------------------------------------------------------------------>

- Savers deposit don't have a weird flash of loading/disabled state anymore with dead clicks
- Savers withdraw don't have a weird flash of loading/disabled state anymore with dead clicks

### Engineering

<!-----------------------------------------------------------------------------
Include sufficient information here for an engineer to test your PR. This may include how to test locally, in a built environment, changes to infrastructure etc.
------------------------------------------------------------------------------>

- ^

### Operations

<!-----------------------------------------------------------------------------
If your changes have a user-facing impact, describe how a non-technical QA team can functionally test your changes in a preview environment.

If they are not user-facing please describe how to test for any regressions that may occur.
------------------------------------------------------------------------------>

- ^

## Screenshots (if applicable)

<!-- av pr metadata
This information is embedded by the av CLI when creating PRs to track the status of stacks when using Aviator. Please do not delete or edit this section of the PR.
```
{"parent":"develop","parentHead":"","trunk":"develop"}
```
-->

### Deposits

- AVAX

https://github.com/shapeshift/web/assets/17035424/af5d2a0f-49d2-4bd5-9dfc-5efefbc567ea


- DOGE

https://github.com/shapeshift/web/assets/17035424/6c0a9c1b-efe5-4bd0-b55c-eaa543596eae


- USDC

https://github.com/shapeshift/web/assets/17035424/6dbb8280-a0ec-4800-93f5-cd7e7b2acb21

### Withdraws

- USDC 


https://github.com/shapeshift/web/assets/17035424/ecf9a966-c525-4ee2-a7a1-9e081a989c88

- DOGE


https://github.com/shapeshift/web/assets/17035424/4d173117-e887-469d-99b7-6a0129f2b5a7




<!-- av pr metadata
This information is embedded by the av CLI when creating PRs to track the status of stacks when using Aviator. Please do not delete or edit this section of the PR.
```
{"parent":"develop","parentHead":"","trunk":"develop"}
```
-->
