### PR TITLE
feat: more account management wiring

### DIFF
--- a/src/components/ManageAccountsDrawer/components/ImportAccounts.tsx
+++ b/src/components/ManageAccountsDrawer/components/ImportAccounts.tsx
@@ -145,7 +145,7 @@ export const ImportAccounts = ({ chainId, onClose }: ImportAccountsProps) => {
 
   // initial fetch to detect the number of accounts based on the "first empty account" heuristic
   const { data: allAccountIdsWithActivity } = useQuery(
-    accountManagement.allAccountIdsWithActivityAndMetadata(
+    accountManagement.firstAccountIdsWithActivityAndMetadata(
       chainId,
       wallet,
       walletDeviceId,

--- a/src/components/ManageAccountsDrawer/components/ImportAccounts.tsx
+++ b/src/components/ManageAccountsDrawer/components/ImportAccounts.tsx
@@ -130,7 +130,7 @@ export const ImportAccounts = ({ chainId, onClose }: ImportAccountsProps) => {
   const asset = useAppSelector(state => selectFeeAssetByChainId(state, chainId))
   const chainNamespaceDisplayName = asset?.networkName ?? ''
   const [accounts, setAccounts] = useState<
-    { accountNumber: number; accountId: AccountId; accountMetadata: AccountMetadata }[]
+    { accountId: AccountId; accountMetadata: AccountMetadata; hasActivity: boolean }[]
   >([])
   const queryClient = useQueryClient()
   const isLoading = useIsFetching({ queryKey: ['accountManagement'] }) > 0
@@ -165,8 +165,8 @@ export const ImportAccounts = ({ chainId, onClose }: ImportAccountsProps) => {
     )
     if (!accountResult) return
     setAccounts(previousAccounts => {
-      const { accountId, accountMetadata } = accountResult
-      return [...previousAccounts, { accountNumber, accountId, accountMetadata }]
+      const { accountId, accountMetadata, hasActivity } = accountResult
+      return [...previousAccounts, { accountId, accountMetadata, hasActivity }]
     })
   }, [accounts, chainId, queryClient, wallet, walletDeviceId])
 
@@ -209,7 +209,7 @@ export const ImportAccounts = ({ chainId, onClose }: ImportAccountsProps) => {
 
   const accountRows = useMemo(() => {
     if (!asset) return null
-    return accounts.map(({ accountId, accountNumber }) => (
+    return accounts.map(({ accountId }, accountNumber) => (
       <TableRow
         key={accountId}
         accountId={accountId}

--- a/src/components/ManageAccountsDrawer/components/ImportAccounts.tsx
+++ b/src/components/ManageAccountsDrawer/components/ImportAccounts.tsx
@@ -205,11 +205,11 @@ export const ImportAccounts = ({ chainId, onClose }: ImportAccountsProps) => {
       }),
     )
 
-    const disabledAccountIds = Object.entries(accountIdActiveStateUpdate)
+    const hiddenAccountIds = Object.entries(accountIdActiveStateUpdate)
       .filter(([_, isActive]) => !isActive)
       .map(([accountId]) => accountId)
 
-    dispatch(portfolio.actions.setDisabledAccountIds(disabledAccountIds))
+    dispatch(portfolio.actions.setHiddenAccountIds(hiddenAccountIds))
 
     onClose()
   }, [accountIdActiveStateUpdate, accounts, dispatch, onClose, walletDeviceId])

--- a/src/components/ManageAccountsDrawer/components/ImportAccounts.tsx
+++ b/src/components/ManageAccountsDrawer/components/ImportAccounts.tsx
@@ -52,7 +52,7 @@ type TableRowProps = {
   onAccountIdActiveChange: (accountId: AccountId, isActive: boolean) => void
 }
 
-const disabledProp = { opacity: 0.5, cursor: 'not-allowed', userSelect: 'none' }
+const disabledProps = { opacity: 0.5, cursor: 'not-allowed', userSelect: 'none' }
 
 const TableRow = forwardRef<TableRowProps, 'div'>(
   ({ asset, accountId, accountNumber, onAccountIdActiveChange }, ref) => {
@@ -243,7 +243,7 @@ export const ImportAccounts = ({ chainId, onClose }: ImportAccountsProps) => {
             mr={3}
             onClick={onClose}
             isDisabled={isLoading}
-            _disabled={disabledProp}
+            _disabled={disabledProps}
           >
             {translate('common.cancel')}
           </Button>
@@ -251,7 +251,7 @@ export const ImportAccounts = ({ chainId, onClose }: ImportAccountsProps) => {
             colorScheme='blue'
             onClick={handleDone}
             isDisabled={isLoading}
-            _disabled={disabledProp}
+            _disabled={disabledProps}
           >
             {translate('common.done')}
           </Button>
@@ -271,7 +271,7 @@ export const ImportAccounts = ({ chainId, onClose }: ImportAccountsProps) => {
             colorScheme='gray'
             onClick={handleLoadMore}
             isDisabled={isLoading}
-            _disabled={disabledProp}
+            _disabled={disabledProps}
           >
             {translate('common.loadMore')}
           </Button>

--- a/src/components/ManageAccountsDrawer/components/ImportAccounts.tsx
+++ b/src/components/ManageAccountsDrawer/components/ImportAccounts.tsx
@@ -28,6 +28,7 @@ import { portfolio, portfolioApi } from 'state/slices/portfolioSlice/portfolioSl
 import { accountIdToLabel } from 'state/slices/portfolioSlice/utils'
 import {
   selectFeeAssetByChainId,
+  selectHighestAccountNumberForChainId,
   selectIsAccountIdEnabled,
   selectPortfolioCryptoPrecisionBalanceByFilter,
 } from 'state/slices/selectors'
@@ -128,6 +129,10 @@ export const ImportAccounts = ({ chainId, onClose }: ImportAccountsProps) => {
   const dispatch = useAppDispatch()
   const { wallet, deviceId: walletDeviceId } = useWallet().state
   const asset = useAppSelector(state => selectFeeAssetByChainId(state, chainId))
+  const highestAccountNumberForChainIdFilter = useMemo(() => ({ chainId }), [chainId])
+  const highestAccountNumber = useAppSelector(state =>
+    selectHighestAccountNumberForChainId(state, highestAccountNumberForChainIdFilter),
+  )
   const chainNamespaceDisplayName = asset?.networkName ?? ''
   const [accounts, setAccounts] = useState<
     { accountId: AccountId; accountMetadata: AccountMetadata; hasActivity: boolean }[]
@@ -144,7 +149,9 @@ export const ImportAccounts = ({ chainId, onClose }: ImportAccountsProps) => {
       chainId,
       wallet,
       walletDeviceId,
-      NUM_ADDITIONAL_EMPTY_ACCOUNTS,
+      // Account numbers are 0-indexed, so we need to add 1 to the highest account number.
+      // Add additional empty accounts to show more accounts without having to load more.
+      highestAccountNumber + 1 + NUM_ADDITIONAL_EMPTY_ACCOUNTS,
     ),
   )
 

--- a/src/components/ManageAccountsDrawer/components/ImportAccounts.tsx
+++ b/src/components/ManageAccountsDrawer/components/ImportAccounts.tsx
@@ -26,6 +26,7 @@ import { isUtxoAccountId } from 'lib/utils/utxo'
 import { accountIdToLabel } from 'state/slices/portfolioSlice/utils'
 import {
   selectFeeAssetByChainId,
+  selectPortfolioAccounts,
   selectPortfolioCryptoPrecisionBalanceByFilter,
 } from 'state/slices/selectors'
 import { useAppSelector } from 'state/store'
@@ -57,6 +58,11 @@ const TableRow = forwardRef<TableRowProps, 'div'>(
     const accountLabel = useMemo(() => accountIdToLabel(accountId), [accountId])
     const balanceFilter = useMemo(() => ({ assetId: asset.assetId, accountId }), [asset, accountId])
 
+    const portfolioAccounts = useAppSelector(selectPortfolioAccounts)
+    const isAccountActive = useMemo(() => {
+      return portfolioAccounts[accountId] !== undefined
+    }, [accountId, portfolioAccounts])
+
     const assetBalancePrecision = useAppSelector(s =>
       selectPortfolioCryptoPrecisionBalanceByFilter(s, balanceFilter),
     )
@@ -70,7 +76,7 @@ const TableRow = forwardRef<TableRowProps, 'div'>(
           <RawText>{accountNumber}</RawText>
         </Td>
         <Td>
-          <Switch onChange={handleChange} />
+          <Switch isChecked={isAccountActive} onChange={handleChange} />
         </Td>
         <Td>
           <Tooltip label={pubkey} isDisabled={isUtxoAccount}>

--- a/src/react-queries/queries/accountManagement.ts
+++ b/src/react-queries/queries/accountManagement.ts
@@ -36,13 +36,18 @@ export const accountManagement = createQueryKeys('accountManagement', {
       return getAccountIdsWithActivityAndMetadata(accountNumber, chainId, wallet)
     },
   }),
-  allAccountIdsWithActivityAndMetadata: (
+  firstAccountIdsWithActivityAndMetadata: (
     chainId: ChainId,
     wallet: HDWallet | null,
     walletDeviceId: string,
-    minResults: number,
+    accountNumberLimit: number,
   ) => ({
-    queryKey: ['allAccountIdsWithActivityAndMetadata', chainId, walletDeviceId, minResults],
+    queryKey: [
+      'firstAccountIdsWithActivityAndMetadata',
+      chainId,
+      walletDeviceId,
+      accountNumberLimit,
+    ],
     queryFn: async () => {
       let accountNumber = 0
 
@@ -66,7 +71,7 @@ export const accountManagement = createQueryKeys('accountManagement', {
 
           const { accountId, accountMetadata, hasActivity } = accountResult
 
-          if (accountNumber >= minResults) {
+          if (accountNumber >= accountNumberLimit) {
             break
           }
 

--- a/src/react-queries/queries/accountManagement.ts
+++ b/src/react-queries/queries/accountManagement.ts
@@ -40,21 +40,16 @@ export const accountManagement = createQueryKeys('accountManagement', {
     chainId: ChainId,
     wallet: HDWallet | null,
     walletDeviceId: string,
-    numEmptyAccountsToInclude: number,
+    minResults: number,
   ) => ({
-    queryKey: [
-      'allAccountIdsWithActivityAndMetadata',
-      chainId,
-      walletDeviceId,
-      numEmptyAccountsToInclude,
-    ],
+    queryKey: ['allAccountIdsWithActivityAndMetadata', chainId, walletDeviceId, minResults],
     queryFn: async () => {
       let accountNumber = 0
-      let emptyAccountCount = 0
+
       const accounts: {
-        accountNumber: number
         accountId: AccountId
         accountMetadata: AccountMetadata
+        hasActivity: boolean
       }[] = []
 
       if (!wallet) return []
@@ -71,13 +66,11 @@ export const accountManagement = createQueryKeys('accountManagement', {
 
           const { accountId, accountMetadata, hasActivity } = accountResult
 
-          if (!hasActivity) emptyAccountCount++
-
-          if (!hasActivity && emptyAccountCount > numEmptyAccountsToInclude) {
+          if (accountNumber >= minResults) {
             break
           }
 
-          accounts.push({ accountNumber, accountId, accountMetadata })
+          accounts.push({ accountId, accountMetadata, hasActivity })
         } catch (error) {
           console.error(error)
           break

--- a/src/state/migrations/index.ts
+++ b/src/state/migrations/index.ts
@@ -57,4 +57,5 @@ export const migrations = {
   47: clearAssets,
   48: clearAssets,
   49: clearAssets,
+  50: clearPortfolio,
 }

--- a/src/state/slices/common-selectors.ts
+++ b/src/state/slices/common-selectors.ts
@@ -26,10 +26,10 @@ export const selectWalletSupportedChainIds = (state: ReduxState) =>
 export const selectWalletAccountIds = createDeepEqualOutputSelector(
   selectWalletId,
   (state: ReduxState) => state.portfolio.wallet.byId,
-  (state: ReduxState) => state.portfolio.disabledAccountIds,
-  (walletId, walletById, disabledAccountIds): AccountId[] => {
+  (state: ReduxState) => state.portfolio.hiddenAccountIds,
+  (walletId, walletById, hiddenAccountIds): AccountId[] => {
     const walletAccountIds = (walletId && walletById[walletId]) ?? []
-    return walletAccountIds.filter(accountId => !disabledAccountIds.includes(accountId))
+    return walletAccountIds.filter(accountId => !hiddenAccountIds.includes(accountId))
   },
 )
 

--- a/src/state/slices/common-selectors.ts
+++ b/src/state/slices/common-selectors.ts
@@ -26,7 +26,11 @@ export const selectWalletSupportedChainIds = (state: ReduxState) =>
 export const selectWalletAccountIds = createDeepEqualOutputSelector(
   selectWalletId,
   (state: ReduxState) => state.portfolio.wallet.byId,
-  (walletId, walletById): AccountId[] => (walletId && walletById[walletId]) ?? [],
+  (state: ReduxState) => state.portfolio.disabledAccountIds,
+  (walletId, walletById, disabledAccountIds): AccountId[] => {
+    const walletAccountIds = (walletId && walletById[walletId]) ?? []
+    return walletAccountIds.filter(accountId => !disabledAccountIds.includes(accountId))
+  },
 )
 
 export const selectWalletChainIds = createDeepEqualOutputSelector(

--- a/src/state/slices/portfolioSlice/__snapshots__/portfolioSlice.test.ts.snap
+++ b/src/state/slices/portfolioSlice/__snapshots__/portfolioSlice.test.ts.snap
@@ -29,6 +29,7 @@ exports[`portfolioSlice > reducers > upsertPortfolio > Bitcoin > should update s
       "bip122:000000000019d6689c085ae165831e93:zpub6qk8s2NQsYG6X2Mm6iU2ii3yTAqDb2XqnMu9vo2WjvqwjSvjjiYQQveYXbPxrnRT5Yb5p0x934be745172066EDF795ffc5EA9F28f19b440c637BaBw1wowPwbS8fj7uCfj3UhqhD2LLbvY6Ni1w",
     ],
   },
+  "disabledAccountIds": [],
   "wallet": {
     "byId": {},
     "ids": [],
@@ -76,6 +77,7 @@ exports[`portfolioSlice > reducers > upsertPortfolio > Bitcoin > should update s
       "bip122:000000000019d6689c085ae165831e93:xpub6qk8s2NQsYG6X2Mm6iU2ii3yTAqDb2XqnMu9vo2WjvqwjSvjjiYQQveYXbPxrnRT5Yb5p0x934be745172066EDF795ffc5EA9F28f19b440c637BaBw1wowPwbS8fj7uCfj3UhqhD2LLbvY6Ni1w",
     ],
   },
+  "disabledAccountIds": [],
   "wallet": {
     "byId": {},
     "ids": [],
@@ -146,6 +148,7 @@ exports[`portfolioSlice > reducers > upsertPortfolio > Ethereum and bitcoin > sh
       "bip122:000000000019d6689c085ae165831e93:zpub6qk8s2NQsYG6X2Mm6iU2ii3yTAqDb2XqnMu9vo2WjvqwjSvjjiYQQveYXbPxrnRT5Yb5p0x934be745172066EDF795ffc5EA9F28f19b440c637BaBw1wowPwbS8fj7uCfj3UhqhD2LLbvY6Ni1w",
     ],
   },
+  "disabledAccountIds": [],
   "wallet": {
     "byId": {},
     "ids": [],
@@ -201,6 +204,7 @@ exports[`portfolioSlice > reducers > upsertPortfolio > Ethereum and bitcoin > sh
       "bip122:000000000019d6689c085ae165831e93:zpub6qk8s2NQsYG6X2Mm6iU2ii3yTAqDb2XqnMu9vo2WjvqwjSvjjiYQQveYXbPxrnRT5Yb5p0x934be745172066EDF795ffc5EA9F28f19b440c637BaBw1wowPwbS8fj7uCfj3UhqhD2LLbvY6Ni1w",
     ],
   },
+  "disabledAccountIds": [],
   "wallet": {
     "byId": {},
     "ids": [],
@@ -239,6 +243,7 @@ exports[`portfolioSlice > reducers > upsertPortfolio > ethereum > should update 
       "eip155:1:0x9a2d593725045d1727d525dd07a396f9ff079bb1",
     ],
   },
+  "disabledAccountIds": [],
   "wallet": {
     "byId": {},
     "ids": [],
@@ -290,6 +295,7 @@ exports[`portfolioSlice > reducers > upsertPortfolio > ethereum > should update 
       "eip155:1:0xea674fdde714fd979de3edf0f56aa9716b898ec8",
     ],
   },
+  "disabledAccountIds": [],
   "wallet": {
     "byId": {},
     "ids": [],

--- a/src/state/slices/portfolioSlice/__snapshots__/portfolioSlice.test.ts.snap
+++ b/src/state/slices/portfolioSlice/__snapshots__/portfolioSlice.test.ts.snap
@@ -29,7 +29,7 @@ exports[`portfolioSlice > reducers > upsertPortfolio > Bitcoin > should update s
       "bip122:000000000019d6689c085ae165831e93:zpub6qk8s2NQsYG6X2Mm6iU2ii3yTAqDb2XqnMu9vo2WjvqwjSvjjiYQQveYXbPxrnRT5Yb5p0x934be745172066EDF795ffc5EA9F28f19b440c637BaBw1wowPwbS8fj7uCfj3UhqhD2LLbvY6Ni1w",
     ],
   },
-  "disabledAccountIds": [],
+  "hiddenAccountIds": [],
   "wallet": {
     "byId": {},
     "ids": [],
@@ -77,7 +77,7 @@ exports[`portfolioSlice > reducers > upsertPortfolio > Bitcoin > should update s
       "bip122:000000000019d6689c085ae165831e93:xpub6qk8s2NQsYG6X2Mm6iU2ii3yTAqDb2XqnMu9vo2WjvqwjSvjjiYQQveYXbPxrnRT5Yb5p0x934be745172066EDF795ffc5EA9F28f19b440c637BaBw1wowPwbS8fj7uCfj3UhqhD2LLbvY6Ni1w",
     ],
   },
-  "disabledAccountIds": [],
+  "hiddenAccountIds": [],
   "wallet": {
     "byId": {},
     "ids": [],
@@ -148,7 +148,7 @@ exports[`portfolioSlice > reducers > upsertPortfolio > Ethereum and bitcoin > sh
       "bip122:000000000019d6689c085ae165831e93:zpub6qk8s2NQsYG6X2Mm6iU2ii3yTAqDb2XqnMu9vo2WjvqwjSvjjiYQQveYXbPxrnRT5Yb5p0x934be745172066EDF795ffc5EA9F28f19b440c637BaBw1wowPwbS8fj7uCfj3UhqhD2LLbvY6Ni1w",
     ],
   },
-  "disabledAccountIds": [],
+  "hiddenAccountIds": [],
   "wallet": {
     "byId": {},
     "ids": [],
@@ -204,7 +204,7 @@ exports[`portfolioSlice > reducers > upsertPortfolio > Ethereum and bitcoin > sh
       "bip122:000000000019d6689c085ae165831e93:zpub6qk8s2NQsYG6X2Mm6iU2ii3yTAqDb2XqnMu9vo2WjvqwjSvjjiYQQveYXbPxrnRT5Yb5p0x934be745172066EDF795ffc5EA9F28f19b440c637BaBw1wowPwbS8fj7uCfj3UhqhD2LLbvY6Ni1w",
     ],
   },
-  "disabledAccountIds": [],
+  "hiddenAccountIds": [],
   "wallet": {
     "byId": {},
     "ids": [],
@@ -243,7 +243,7 @@ exports[`portfolioSlice > reducers > upsertPortfolio > ethereum > should update 
       "eip155:1:0x9a2d593725045d1727d525dd07a396f9ff079bb1",
     ],
   },
-  "disabledAccountIds": [],
+  "hiddenAccountIds": [],
   "wallet": {
     "byId": {},
     "ids": [],
@@ -295,7 +295,7 @@ exports[`portfolioSlice > reducers > upsertPortfolio > ethereum > should update 
       "eip155:1:0xea674fdde714fd979de3edf0f56aa9716b898ec8",
     ],
   },
-  "disabledAccountIds": [],
+  "hiddenAccountIds": [],
   "wallet": {
     "byId": {},
     "ids": [],

--- a/src/state/slices/portfolioSlice/portfolioSlice.ts
+++ b/src/state/slices/portfolioSlice/portfolioSlice.ts
@@ -137,8 +137,8 @@ export const portfolio = createSlice({
       // add the `action.meta[SHOULD_AUTOBATCH]` field the enhancer needs
       prepare: prepareAutoBatched<Portfolio>(),
     },
-    setDisabledAccountIds: (draftState, { payload }: { payload: AccountId[] }) => {
-      draftState.disabledAccountIds = payload
+    setHiddenAccountIds: (draftState, { payload }: { payload: AccountId[] }) => {
+      draftState.hiddenAccountIds = payload
     },
   },
   extraReducers: builder => builder.addCase(PURGE, () => initialState),

--- a/src/state/slices/portfolioSlice/portfolioSlice.ts
+++ b/src/state/slices/portfolioSlice/portfolioSlice.ts
@@ -137,6 +137,9 @@ export const portfolio = createSlice({
       // add the `action.meta[SHOULD_AUTOBATCH]` field the enhancer needs
       prepare: prepareAutoBatched<Portfolio>(),
     },
+    setDisabledAccountIds: (draftState, { payload }: { payload: AccountId[] }) => {
+      draftState.disabledAccountIds = payload
+    },
   },
   extraReducers: builder => builder.addCase(PURGE, () => initialState),
 })

--- a/src/state/slices/portfolioSlice/portfolioSliceCommon.ts
+++ b/src/state/slices/portfolioSlice/portfolioSliceCommon.ts
@@ -61,6 +61,11 @@ export type Portfolio = {
   accounts: PortfolioAccounts
   accountBalances: PortfolioAccountBalances
   /**
+   * The `AccountId[]` that are disabled. Rather than removing the accounts and adding complexity
+   * to the actions and state management, we disable them here and filter them out in the selectors.
+   */
+  disabledAccountIds: AccountId[]
+  /**
    * 1:many mapping of a unique wallet id -> multiple account ids
    */
   wallet: PortfolioWallet
@@ -80,6 +85,7 @@ export const initialState: Portfolio = {
     byId: {},
     ids: [],
   },
+  disabledAccountIds: [],
   wallet: {
     byId: {},
     ids: [],

--- a/src/state/slices/portfolioSlice/portfolioSliceCommon.ts
+++ b/src/state/slices/portfolioSlice/portfolioSliceCommon.ts
@@ -64,7 +64,7 @@ export type Portfolio = {
    * The `AccountId[]` that are disabled. Rather than removing the accounts and adding complexity
    * to the actions and state management, we disable them here and filter them out in the selectors.
    */
-  disabledAccountIds: AccountId[]
+  hiddenAccountIds: AccountId[]
   /**
    * 1:many mapping of a unique wallet id -> multiple account ids
    */
@@ -85,7 +85,7 @@ export const initialState: Portfolio = {
     byId: {},
     ids: [],
   },
-  disabledAccountIds: [],
+  hiddenAccountIds: [],
   wallet: {
     byId: {},
     ids: [],

--- a/src/state/slices/portfolioSlice/selectors.ts
+++ b/src/state/slices/portfolioSlice/selectors.ts
@@ -89,6 +89,19 @@ export const selectPortfolioAccounts = createDeepEqualOutputSelector(
   },
 )
 
+export const selectIsAccountIdEnabled = createCachedSelector(
+  selectPortfolioAccounts,
+  (state: ReduxState) => state.portfolio.disabledAccountIds,
+  selectAccountIdParamFromFilter,
+  (accountsById, disabledAccountIds, accountId): boolean => {
+    return (
+      accountId !== undefined &&
+      accountsById[accountId] !== undefined &&
+      !disabledAccountIds.includes(accountId)
+    )
+  },
+)((_s: ReduxState, filter) => filter?.accountId ?? 'accountId')
+
 export const selectPortfolioAssetIds = createDeepEqualOutputSelector(
   selectPortfolioAccountBalancesBaseUnit,
   (accountBalancesById): AssetId[] => {

--- a/src/state/slices/portfolioSlice/selectors.ts
+++ b/src/state/slices/portfolioSlice/selectors.ts
@@ -79,8 +79,6 @@ import type {
 import { AssetEquityType } from './portfolioSliceCommon'
 import { findAccountsByAssetId } from './utils'
 
-const selectDisabledAccountIds = (state: ReduxState) => state.portfolio.disabledAccountIds
-
 export const selectPortfolioAccounts = createDeepEqualOutputSelector(
   selectWalletAccountIds,
   (state: ReduxState) => state.portfolio.accounts.byId,
@@ -93,14 +91,9 @@ export const selectPortfolioAccounts = createDeepEqualOutputSelector(
 
 export const selectIsAccountIdEnabled = createCachedSelector(
   selectPortfolioAccounts,
-  selectDisabledAccountIds,
   selectAccountIdParamFromFilter,
-  (accountsById, disabledAccountIds, accountId): boolean => {
-    return (
-      accountId !== undefined &&
-      accountsById[accountId] !== undefined &&
-      !disabledAccountIds.includes(accountId)
-    )
+  (accountsById, accountId): boolean => {
+    return accountId !== undefined && accountsById[accountId] !== undefined
   },
 )((_s: ReduxState, filter) => filter?.accountId ?? 'accountId')
 
@@ -123,9 +116,8 @@ export const selectPortfolioAccountMetadata = createDeepEqualOutputSelector(
 
 export const selectHighestAccountNumberForChainId = createCachedSelector(
   selectPortfolioAccountMetadata,
-  selectDisabledAccountIds,
   selectChainIdParamFromFilter,
-  (portfolioAccountMetadata, disabledAccountIds, filterChainId): number => {
+  (portfolioAccountMetadata, filterChainId): number => {
     if (!filterChainId) return 0
 
     return Math.max(
@@ -133,7 +125,7 @@ export const selectHighestAccountNumberForChainId = createCachedSelector(
       ...Object.entries(portfolioAccountMetadata)
         .filter(([accountId]) => {
           const { chainId } = fromAccountId(accountId)
-          return chainId === filterChainId && !disabledAccountIds.includes(accountId)
+          return chainId === filterChainId
         })
         .map(([_accountId, accountMetadata]) => accountMetadata.bip44Params.accountNumber),
     )

--- a/src/test/mocks/store.ts
+++ b/src/test/mocks/store.ts
@@ -55,7 +55,7 @@ export const mockStore: ReduxState = {
       byId: {},
       ids: [],
     },
-    disabledAccountIds: [],
+    hiddenAccountIds: [],
     wallet: {
       byId: {},
       ids: [],

--- a/src/test/mocks/store.ts
+++ b/src/test/mocks/store.ts
@@ -55,6 +55,7 @@ export const mockStore: ReduxState = {
       byId: {},
       ids: [],
     },
+    disabledAccountIds: [],
     wallet: {
       byId: {},
       ids: [],


### PR DESCRIPTION
## Description

Incremental progress on wiring up account management. This PR implements:
* Enabled accounts automatically appear as "toggled on" in the import accounts drawer
* Add and remove accounts and have them persist across page reloads
* Ability to toggle on accounts and click cancel and not have it persist
* Display all added accounts including disabled ones in between enabled ones

Fixes:
* Using `wallet.deviceId()` promise as a key in react query -> uses string from context instead

Excludes:
* Proper loading state for "Done" click where app is hydrating portfolio for imported accounts
* Anything wallet specific
* Anything feature specific outside of adding and removing accounts inside of account management (e.g probably broken for trades etc)
* Correct account balances for accounts yet to be imported - known issue TODO

## Pull Request Type

- [ ] :bug: Bug fix (Non-breaking Change: Fixes an issue)
- [ ] :hammer_and_wrench: Chore (Non-breaking Change: Doc updates, pkg upgrades, typos, etc..)
- [x] :nail_care: New Feature (Breaking/Non-breaking Change)

## Issue (if applicable)

Progresses #6722

## Risk
> High Risk PRs Require 2 approvals

High risk as it alters and adds selectors to the portfolio slice.

> What protocols, transaction types or contract interactions might be affected by this PR?

## Testing

NOTE: When comparing balances between tabs, keep in mind that balances displayed in USD$ fluctuate with market prices so will like not match exactly. Best option is to compare crypto amounts.

### With account management feature flag toggled off

* Initial load of portfolio from previous non-empty state works for various wallets (balances, assets etc correct for the account number)
* Initial load of portfolio from previous empty state works for various wallets (balances, assets etc correct for the account number)
* Trades to/from different accounts (0, 1, 2 etc) working as expected

### With account management feature flag toggled on

**Before disabling/enabling accounts via "manage accounts"**
* Initial load of portfolio from previous non-empty state works for various wallets (balances, assets etc correct for the account number)
* Initial load of portfolio from previous empty state works for various wallets (balances, assets etc correct for the account number)
* Trades to/from different accounts (0, 1, 2 etc) working as expected

**After disabling/enabling accounts via "manage accounts"**
* Initial load of portfolio from previous non-empty state works for various wallets (balances, assets etc correct for the account number)
* Initial load of portfolio from previous empty state works for various wallets (balances, assets etc correct for the account number)
* Trades to/from different accounts (0, 1, 2 etc) working as expected

### Engineering

A migration has been added to initialize the new `disabledAccountIds` for the portfolio slice. 

### Operations

<!-----------------------------------------------------------------------------
If your changes have a user-facing impact, describe how a non-technical QA team can functionally test your changes in a preview environment.

If they are not user-facing please describe how to test for any regressions that may occur.
------------------------------------------------------------------------------>

## Screenshots (if applicable)

Walkthru including a trade into a new account:


https://github.com/shapeshift/web/assets/125113430/fcaadd28-4374-45f0-8619-8e4b477a5d9b

