### PR TITLE
feat: account management wiring progression

### DIFF
--- a/src/components/ManageAccountsDrawer/components/ImportAccounts.tsx
+++ b/src/components/ManageAccountsDrawer/components/ImportAccounts.tsx
@@ -66,7 +66,7 @@ const TableRowAccount = forwardRef<TableRowAccountProps, 'div'>(({ asset, accoun
 
   const { data: account, isLoading } = useQuery(accountManagement.getAccount(accountId))
 
-  const assetBalancePrecision = useMemo(() => {
+  const assetBalanceCryptoPrecision = useMemo(() => {
     if (!account) return '0'
     return fromBaseUnit(account.balance, asset.precision)
   }, [account, asset.precision])
@@ -84,7 +84,7 @@ const TableRowAccount = forwardRef<TableRowAccountProps, 'div'>(({ asset, accoun
         {isLoading ? (
           <Skeleton height='24px' width='100%' />
         ) : (
-          <Amount.Crypto value={assetBalancePrecision} symbol={asset.symbol} />
+          <Amount.Crypto value={assetBalanceCryptoPrecision} symbol={asset.symbol} />
         )}
       </Td>
     </>

--- a/src/components/ManageAccountsDrawer/components/ImportAccounts.tsx
+++ b/src/components/ManageAccountsDrawer/components/ImportAccounts.tsx
@@ -172,7 +172,7 @@ export const ImportAccounts = ({ chainId, onClose }: ImportAccountsProps) => {
       predicate: query => {
         return (
           query.queryKey[0] === 'accountManagement' &&
-          ['accountIdWithActivityAndMetadata', 'allAccountIdsWithActivityAndMetadata'].some(
+          ['accountIdWithActivityAndMetadata', 'firstAccountIdsWithActivityAndMetadata'].some(
             str => str === query.queryKey[1],
           )
         )

--- a/src/components/ManageAccountsDrawer/components/ImportAccounts.tsx
+++ b/src/components/ManageAccountsDrawer/components/ImportAccounts.tsx
@@ -73,8 +73,8 @@ const TableRowAccount = forwardRef<TableRowAccountProps, 'div'>(({ asset, accoun
   }, [account, asset.precision])
 
   return (
-    <Tr>
-      <Td>
+    <>
+      <Td fontWeight='bold'>
         <Tooltip label={pubkey} isDisabled={isUtxoAccount}>
           <div ref={ref}>
             {isUtxoAccount ? (
@@ -85,14 +85,14 @@ const TableRowAccount = forwardRef<TableRowAccountProps, 'div'>(({ asset, accoun
           </div>
         </Tooltip>
       </Td>
-      <Td>
+      <Td textAlign='right'>
         {isLoading ? (
           <Skeleton height='24px' width='100%' />
         ) : (
           <Amount.Crypto value={assetBalancePrecision} symbol={asset.symbol} />
         )}
       </Td>
-    </Tr>
+    </>
   )
 })
 
@@ -108,20 +108,28 @@ const TableRow = forwardRef<TableRowProps, 'div'>(
       onAccountIdsActiveChange(accountIds, isAccountActive)
     }, [accountIds, isAccountActive, isAccountEnabledInRedux, onAccountIdsActiveChange])
 
+    const firstAccount = useMemo(() => accountIds[0], [accountIds])
+    const otherAccounts = useMemo(() => accountIds.slice(1), [accountIds])
+
     return (
-      <Tr>
-        <Td>
-          <RawText>{accountNumber}</RawText>
-        </Td>
-        <Td>
-          <Switch isChecked={isAccountActive} onChange={toggleIsAccountActive} />
-        </Td>
-        <Td>
-          {accountIds.map(accountId => (
+      <>
+        <Tr opacity={isAccountActive ? '1' : '0.5'}>
+          <Td>
+            <Switch size='lg' isChecked={isAccountActive} onChange={toggleIsAccountActive} />
+          </Td>
+          <Td>
+            <RawText color='text.subtle'>{accountNumber}</RawText>
+          </Td>
+
+          <TableRowAccount ref={ref} asset={asset} accountId={firstAccount} />
+        </Tr>
+        {otherAccounts.map(accountId => (
+          <Tr opacity={isAccountActive ? '1' : '0.5'}>
+            <Td colSpan={2} bg='background.surface.raised.base'></Td>
             <TableRowAccount key={accountId} ref={ref} asset={asset} accountId={accountId} />
-          ))}
-        </Td>
-      </Tr>
+          </Tr>
+        ))}
+      </>
     )
   },
 )

--- a/src/components/ManageAccountsDrawer/components/SelectChain.tsx
+++ b/src/components/ManageAccountsDrawer/components/SelectChain.tsx
@@ -1,19 +1,9 @@
-import { SearchIcon } from '@chakra-ui/icons'
-import {
-  Box,
-  Button,
-  Input,
-  InputGroup,
-  InputLeftElement,
-  SimpleGrid,
-  VStack,
-} from '@chakra-ui/react'
+import { Button, SimpleGrid, Stack, VStack } from '@chakra-ui/react'
 import type { ChainId } from '@shapeshiftoss/caip'
-import type { FormEvent } from 'react'
 import { useCallback, useEffect, useMemo, useState } from 'react'
-import { useForm } from 'react-hook-form'
 import { useTranslate } from 'react-polyglot'
 import { LazyLoadAvatar } from 'components/LazyLoadAvatar'
+import { GlobalFilter } from 'components/StakingVaults/GlobalFilter'
 import { RawText } from 'components/Text'
 import { assertGetChainAdapter, chainIdToFeeAssetId } from 'lib/utils'
 import { selectAssetById, selectWalletSupportedChainIds } from 'state/slices/selectors'
@@ -21,6 +11,8 @@ import { useAppSelector } from 'state/store'
 
 import { filterChainIdsBySearchTerm } from '../helpers'
 import { DrawerContentWrapper } from './DrawerContent'
+
+const inputGroupProps = { size: 'lg' }
 
 export type SelectChainProps = {
   onSelectChainId: (chainId: ChainId) => void
@@ -57,26 +49,17 @@ const ChainButton = ({
 export const SelectChain = ({ onSelectChainId, onClose }: SelectChainProps) => {
   const translate = useTranslate()
   const [searchTermChainIds, setSearchTermChainIds] = useState<ChainId[]>([])
+  const [searchQuery, setSearchQuery] = useState('')
 
   const walletSupportedChainIds = useAppSelector(selectWalletSupportedChainIds)
 
-  const handleSubmit = useCallback((e: FormEvent<unknown>) => e.preventDefault(), [])
-
-  const { register, watch } = useForm<{ search: string }>({
-    mode: 'onChange',
-    defaultValues: {
-      search: '',
-    },
-  })
-  const searchString = watch('search')
-
-  const searching = useMemo(() => searchString.length > 0, [searchString])
+  const searching = useMemo(() => searchQuery.length > 0, [searchQuery])
 
   useEffect(() => {
     if (!searching) return
 
-    setSearchTermChainIds(filterChainIdsBySearchTerm(searchString, walletSupportedChainIds))
-  }, [searchString, searching, walletSupportedChainIds])
+    setSearchTermChainIds(filterChainIdsBySearchTerm(searchQuery, walletSupportedChainIds))
+  }, [searchQuery, searching, walletSupportedChainIds])
 
   const chainButtons = useMemo(() => {
     const listChainIds = searching ? searchTermChainIds : walletSupportedChainIds
@@ -97,31 +80,19 @@ export const SelectChain = ({ onSelectChainId, onClose }: SelectChainProps) => {
 
   const body = useMemo(() => {
     return (
-      <>
-        <Box as='form' mb={3} px={4} visibility='visible' onSubmit={handleSubmit}>
-          <InputGroup size='lg'>
-            {/* Override zIndex to prevent element displaying on overlay components */}
-            <InputLeftElement pointerEvents='none' zIndex={1}>
-              <SearchIcon color='gray.300' />
-            </InputLeftElement>
-            <Input
-              {...register('search')}
-              type={'text'}
-              placeholder={translate('accountManagement.selectChain.searchChains')}
-              pl={10}
-              variant={'filled'}
-              autoComplete={'off'}
-              autoFocus={false}
-              transitionProperty={'none'}
-            />
-          </InputGroup>
-        </Box>
-        <SimpleGrid columns={3} spacing={6}>
+      <Stack spacing={4}>
+        <GlobalFilter
+          setSearchQuery={setSearchQuery}
+          searchQuery={searchQuery}
+          placeholder={translate('accountManagement.selectChain.searchChains')}
+          inputGroupProps={inputGroupProps}
+        />
+        <SimpleGrid columns={3} spacing={4}>
           {chainButtons}
         </SimpleGrid>
-      </>
+      </Stack>
     )
-  }, [chainButtons, handleSubmit, register, translate])
+  }, [chainButtons, searchQuery, translate])
 
   return (
     <DrawerContentWrapper

--- a/src/components/ManageAccountsDrawer/components/SelectChain.tsx
+++ b/src/components/ManageAccountsDrawer/components/SelectChain.tsx
@@ -53,20 +53,20 @@ export const SelectChain = ({ onSelectChainId, onClose }: SelectChainProps) => {
 
   const walletSupportedChainIds = useAppSelector(selectWalletSupportedChainIds)
 
-  const searching = useMemo(() => searchQuery.length > 0, [searchQuery])
+  const isSearching = useMemo(() => searchQuery.length > 0, [searchQuery])
 
   useEffect(() => {
-    if (!searching) return
+    if (!isSearching) return
 
     setSearchTermChainIds(filterChainIdsBySearchTerm(searchQuery, walletSupportedChainIds))
-  }, [searchQuery, searching, walletSupportedChainIds])
+  }, [searchQuery, isSearching, walletSupportedChainIds])
 
   const chainButtons = useMemo(() => {
-    const listChainIds = searching ? searchTermChainIds : walletSupportedChainIds
+    const listChainIds = isSearching ? searchTermChainIds : walletSupportedChainIds
     return listChainIds.map(chainId => {
       return <ChainButton key={chainId} chainId={chainId} onClick={onSelectChainId} />
     })
-  }, [onSelectChainId, searchTermChainIds, searching, walletSupportedChainIds])
+  }, [onSelectChainId, searchTermChainIds, isSearching, walletSupportedChainIds])
 
   const footer = useMemo(() => {
     return (

--- a/src/components/Modals/ManageAccounts/ManageAccountsModal.tsx
+++ b/src/components/Modals/ManageAccounts/ManageAccountsModal.tsx
@@ -1,6 +1,5 @@
 import { InfoIcon } from '@chakra-ui/icons'
 import {
-  Box,
   Button,
   Flex,
   HStack,
@@ -12,6 +11,7 @@ import {
   ModalFooter,
   ModalHeader,
   ModalOverlay,
+  Tag,
   useDisclosure,
   VStack,
 } from '@chakra-ui/react'
@@ -54,15 +54,13 @@ const ConnectedChain = ({
 
   if (numAccounts === 0 || !feeAsset) return null
   return (
-    <Button width='full' onClick={handleClick} p={2}>
+    <Button width='full' height='auto' onClick={handleClick} p={2} pr={3}>
       <Flex justifyContent='space-between' width='full' alignItems='center'>
         <HStack>
           <LazyLoadAvatar src={feeAsset.networkIcon ?? feeAsset.icon} size='sm' />
           <RawText>{chainAdapter.getDisplayName()}</RawText>
         </HStack>
-        <Box bgColor='gray.600' width='22px' p={1} borderRadius='8px' fontSize='xs'>
-          {numAccounts}
-        </Box>
+        <Tag>{numAccounts}</Tag>
       </Flex>
     </Button>
   )
@@ -115,12 +113,14 @@ export const ManageAccountsModal = ({
         onClose={handleDrawerClose}
         chainId={selectedChainId}
       />
-      <Modal isOpen={isOpen} onClose={close} isCentered size='sm'>
+      <Modal isOpen={isOpen} onClose={close} isCentered size='md'>
         <ModalOverlay />
-        <ModalContent borderRadius='xl' mx={3} maxW='400px'>
-          <ModalHeader textAlign='left' py={12}>
-            <RawText as='h3'>{translate(title)}</RawText>
-            <RawText color='text.subtle' fontSize='md'>
+        <ModalContent>
+          <ModalHeader textAlign='left' pt={14}>
+            <RawText as='h3' fontWeight='semibold'>
+              {translate(title)}
+            </RawText>
+            <RawText color='text.subtle' fontSize='md' fontWeight='normal'>
               {translate('accountManagement.manageAccounts.description')}
             </RawText>
           </ModalHeader>
@@ -146,12 +146,13 @@ export const ManageAccountsModal = ({
                 colorScheme='blue'
                 onClick={handleClickAddChain}
                 width='full'
+                size='lg'
                 isDisabled={disableAddChain}
                 _disabled={disabledProp}
               >
                 {translate('accountManagement.manageAccounts.addChain')}
               </Button>
-              <Button colorScheme='gray' onClick={close} width='full'>
+              <Button size='lg' colorScheme='gray' onClick={close} width='full'>
                 {translate('common.done')}
               </Button>
             </VStack>

--- a/src/react-queries/queries/accountManagement.ts
+++ b/src/react-queries/queries/accountManagement.ts
@@ -28,6 +28,15 @@ const getAccountIdsWithActivityAndMetadata = async (
 }
 
 export const accountManagement = createQueryKeys('accountManagement', {
+  getAccount: (accountId: AccountId) => ({
+    queryKey: ['getAccount', accountId],
+    queryFn: async () => {
+      const { chainId, account: pubkey } = fromAccountId(accountId)
+      const adapter = assertGetChainAdapter(chainId)
+      const account = await adapter.getAccount(pubkey)
+      return account
+    },
+  }),
   accountIdWithActivityAndMetadata: (
     accountNumber: number,
     chainId: ChainId,

--- a/src/react-queries/queries/accountManagement.ts
+++ b/src/react-queries/queries/accountManagement.ts
@@ -14,14 +14,17 @@ const getAccountIdsWithActivityAndMetadata = async (
 ) => {
   const input = { accountNumber, chainIds: [chainId], wallet }
   const accountIdsAndMetadata = await deriveAccountIdsAndMetadata(input)
-  const [[accountId, accountMetadata]] = Object.entries(accountIdsAndMetadata)
 
-  const { account: pubkey } = fromAccountId(accountId)
-  const adapter = assertGetChainAdapter(chainId)
-  const account = await adapter.getAccount(pubkey)
-  const hasActivity = checkAccountHasActivity(account)
+  return Promise.all(
+    Object.entries(accountIdsAndMetadata).map(async ([accountId, accountMetadata]) => {
+      const { account: pubkey } = fromAccountId(accountId)
+      const adapter = assertGetChainAdapter(chainId)
+      const account = await adapter.getAccount(pubkey)
+      const hasActivity = checkAccountHasActivity(account)
 
-  return { accountId, accountMetadata, hasActivity }
+      return { accountId, accountMetadata, hasActivity }
+    }),
+  )
 }
 
 export const accountManagement = createQueryKeys('accountManagement', {
@@ -55,27 +58,23 @@ export const accountManagement = createQueryKeys('accountManagement', {
         accountId: AccountId
         accountMetadata: AccountMetadata
         hasActivity: boolean
-      }[] = []
+      }[][] = []
 
       if (!wallet) return []
 
       while (true) {
         try {
-          const accountResult = await getAccountIdsWithActivityAndMetadata(
+          if (accountNumber >= accountNumberLimit) {
+            break
+          }
+
+          const accountResults = await getAccountIdsWithActivityAndMetadata(
             accountNumber,
             chainId,
             wallet,
           )
 
-          if (!accountResult) break
-
-          const { accountId, accountMetadata, hasActivity } = accountResult
-
-          if (accountNumber >= accountNumberLimit) {
-            break
-          }
-
-          accounts.push({ accountId, accountMetadata, hasActivity })
+          accounts.push(accountResults)
         } catch (error) {
           console.error(error)
           break

--- a/src/state/slices/portfolioSlice/selectors.ts
+++ b/src/state/slices/portfolioSlice/selectors.ts
@@ -101,7 +101,7 @@ export const selectIsAnyAccountIdEnabled = createCachedSelector(
   selectPortfolioAccounts,
   (_state: ReduxState, accountIds: AccountId[]) => accountIds,
   (accountsById, accountIds): boolean => {
-    if (accountIds === undefined) return false
+    if (accountIds.length === 0) return false
     return accountIds.some(accountId => accountsById[accountId] !== undefined)
   },
 )((_s: ReduxState, accountIds) => JSON.stringify(accountIds))

--- a/src/state/slices/portfolioSlice/selectors.ts
+++ b/src/state/slices/portfolioSlice/selectors.ts
@@ -101,7 +101,6 @@ export const selectIsAnyAccountIdEnabled = createCachedSelector(
   selectPortfolioAccounts,
   (_state: ReduxState, accountIds: AccountId[]) => accountIds,
   (accountsById, accountIds): boolean => {
-    console.log(accountIds)
     if (accountIds === undefined) return false
     return accountIds.some(accountId => accountsById[accountId] !== undefined)
   },

--- a/src/state/slices/portfolioSlice/selectors.ts
+++ b/src/state/slices/portfolioSlice/selectors.ts
@@ -97,6 +97,16 @@ export const selectIsAccountIdEnabled = createCachedSelector(
   },
 )((_s: ReduxState, filter) => filter?.accountId ?? 'accountId')
 
+export const selectIsAnyAccountIdEnabled = createCachedSelector(
+  selectPortfolioAccounts,
+  (_state: ReduxState, accountIds: AccountId[]) => accountIds,
+  (accountsById, accountIds): boolean => {
+    console.log(accountIds)
+    if (accountIds === undefined) return false
+    return accountIds.some(accountId => accountsById[accountId] !== undefined)
+  },
+)((_s: ReduxState, accountIds) => JSON.stringify(accountIds))
+
 export const selectPortfolioAssetIds = createDeepEqualOutputSelector(
   selectPortfolioAccountBalancesBaseUnit,
   (accountBalancesById): AssetId[] => {


### PR DESCRIPTION
## Description

* Fixes "Wrong account count in account management modal on UTXO chains" #6788 by displaying various UTXO account types, making it clear the account count is in fact correct.
* Displays all UXTO accounts (segwit native, segwit, legacy) #6789
* Loads native asset balances for all accounts so new ones are not zero if they have funds #6797

## Pull Request Type

- [ ] :bug: Bug fix (Non-breaking Change: Fixes an issue)
- [ ] :hammer_and_wrench: Chore (Non-breaking Change: Doc updates, pkg upgrades, typos, etc..)
- [x] :nail_care: New Feature (Breaking/Non-breaking Change)

## Issue (if applicable)

closes #6789
closes #6788
closes #6797

## Risk
> High Risk PRs Require 2 approvals

Low risk.

> What protocols, transaction types or contract interactions might be affected by this PR?

None of the above.

## Testing

* Check the account count on the manage accounts modal matches the number of accounts in the import accounts drawer. Note that it's very tricky to tell the difference between in inactive account and an active one if there is zero native asset balance on that account (see below for more info).

* Check that all UXTO account types `segwit native`, `segwit`, `legacy` appear for a given account number
* Check that native asset balances are loaded for accounts that are not auto-added (i.e there is an empty account in between 2 non-empty accounts - you can replicate this by adding 2 new accounts and transferring some coins into the second one - @MBMaria this is already set up on your native wallet for Ethereum). See below for more info.

### Engineering

<!-----------------------------------------------------------------------------
Include sufficient information here for an engineer to test your PR. This may include how to test locally, in a built environment, changes to infrastructure etc.
------------------------------------------------------------------------------>

### Operations

<!-----------------------------------------------------------------------------
If your changes have a user-facing impact, describe how a non-technical QA team can functionally test your changes in a preview environment.

If they are not user-facing please describe how to test for any regressions that may occur.
------------------------------------------------------------------------------>

## Screenshots (if applicable)

An ETH account may have some FOX but 0 ETH, so is active:
![image](https://github.com/shapeshift/web/assets/125113430/f9eef48e-fddd-4b4b-b457-a4f0ff514de2)
![image](https://github.com/shapeshift/web/assets/125113430/72a4ca25-6547-4a77-a2e0-71d7fb2eb70d)

Similarly, a BTC account may have 0 BTC balance but non-zero thorchain savers balance:
![image](https://github.com/shapeshift/web/assets/125113430/4e78e746-5e6a-4a44-bc56-ea2150a4e6ff)
![image](https://github.com/shapeshift/web/assets/125113430/d7323761-d4fc-4ac0-bd35-b7c76e23cf68)

Showing auto-detected accounts up to first empty one (it has 0ETH but has fox, so was detected. the second empty account is actually totally empty). The account after the 2 0ETH accounts has some eth, and the balance is loaded when viewed:

https://github.com/shapeshift/web/assets/125113430/eab0a622-4afe-437f-8547-b2a50a933523


