### PR TITLE
fix: lending repay fees off by order of magnitude

### DIFF
--- a/src/components/Sweep.tsx
+++ b/src/components/Sweep.tsx
@@ -9,7 +9,7 @@ import { fromBaseUnit } from 'lib/math'
 import { sleep } from 'lib/poll/poll'
 import { assertGetUtxoChainAdapter } from 'lib/utils/utxo'
 import { useGetEstimatedFeesQuery } from 'pages/Lending/hooks/useGetEstimatedFeesQuery'
-import { selectAssetById } from 'state/slices/selectors'
+import { selectAssetById, selectFeeAssetById } from 'state/slices/selectors'
 import { useAppSelector } from 'state/store'
 
 import { Amount } from './Amount/Amount'
@@ -41,6 +41,7 @@ export const Sweep = ({
   } = useWallet()
   const translate = useTranslate()
   const asset = useAppSelector(state => selectAssetById(state, assetId))
+  const feeAsset = useAppSelector(state => selectFeeAssetById(state, assetId))
 
   const {
     data: estimatedFeesData,
@@ -48,12 +49,13 @@ export const Sweep = ({
     isSuccess: isEstimatedFeesDataSuccess,
   } = useGetEstimatedFeesQuery({
     amountCryptoPrecision: '0',
+    feeAssetId: feeAsset?.assetId ?? '',
     assetId,
     to: fromAddress ?? '',
     sendMax: true,
     accountId: accountId ?? '',
     contractAddress: undefined,
-    enabled: Boolean(accountId),
+    enabled: Boolean(feeAsset?.assetId && accountId),
   })
 
   const handleSweep = useCallback(async () => {

--- a/src/features/defi/providers/thorchain-savers/components/ThorchainSaversManager/Deposit/components/Deposit.tsx
+++ b/src/features/defi/providers/thorchain-savers/components/ThorchainSaversManager/Deposit/components/Deposit.tsx
@@ -580,7 +580,7 @@ export const Deposit: React.FC<DepositProps> = ({
           accountId: accountId ?? '',
           contractAddress: undefined,
         },
-        asset,
+        feeAsset,
         assetMarketData,
         enabled: Boolean(accountId && isUtxoChainId(asset.chainId)),
       }
@@ -621,7 +621,7 @@ export const Deposit: React.FC<DepositProps> = ({
         _isSweepNeeded && accountId && isUtxoChainId(asset.chainId),
       )
       const estimatedSweepFeesQueryArgs = {
-        asset,
+        feeAsset,
         assetMarketData,
         estimateFeesInput: {
           amountCryptoPrecision: '0',
@@ -659,15 +659,17 @@ export const Deposit: React.FC<DepositProps> = ({
       }
     },
     [
-      accountId,
-      asset,
-      assetId,
+      asset.chainId,
+      asset.precision,
       contextDispatch,
+      setIsSendMax,
       balanceCryptoPrecision,
       fromAddress,
+      accountId,
+      assetId,
+      feeAsset,
       assetMarketData,
       queryClient,
-      setIsSendMax,
     ],
   )
 

--- a/src/lib/utils/thorchain/balance.ts
+++ b/src/lib/utils/thorchain/balance.ts
@@ -9,7 +9,7 @@ import type { IsSweepNeededQueryKey } from 'pages/Lending/hooks/useIsSweepNeeded
 import { queryFn as isSweepNeededQueryFn } from 'pages/Lending/hooks/useIsSweepNeededQuery'
 import { selectPortfolioCryptoBalanceBaseUnitByFilter } from 'state/slices/common-selectors'
 import type { ThorchainSaversWithdrawQuoteResponseSuccess } from 'state/slices/opportunitiesSlice/resolvers/thorchainsavers/types'
-import { selectMarketDataByAssetIdUserCurrency } from 'state/slices/selectors'
+import { selectFeeAssetById, selectMarketDataByAssetIdUserCurrency } from 'state/slices/selectors'
 import { store } from 'state/store'
 
 import { isUtxoChainId } from '../utxo'
@@ -95,6 +95,7 @@ export const fetchHasEnoughBalanceForTxPlusFeesPlusSweep = async ({
     assetId: asset.assetId,
     accountId,
   })
+  const feeAsset = selectFeeAssetById(store.getState(), asset.assetId)
   const assetMarketData = selectMarketDataByAssetIdUserCurrency(store.getState(), asset.assetId)
   const quote = await (async () => {
     switch (type) {
@@ -146,9 +147,9 @@ export const fetchHasEnoughBalanceForTxPlusFeesPlusSweep = async ({
       accountId: accountId ?? '',
       contractAddress: undefined,
     },
-    asset,
+    feeAsset,
     assetMarketData,
-    enabled: estimateFeesQueryEnabled,
+    enabled: Boolean(feeAsset && estimateFeesQueryEnabled),
   }
 
   const estimatedFeesQueryKey: EstimatedFeesQueryKey = ['estimateFees', estimatedFeesQueryArgs]
@@ -190,7 +191,7 @@ export const fetchHasEnoughBalanceForTxPlusFeesPlusSweep = async ({
   const isEstimateSweepFeesQueryEnabled = Boolean(_isSweepNeeded && accountId && isUtxoChain)
 
   const estimatedSweepFeesQueryArgs = {
-    asset,
+    feeAsset,
     assetMarketData,
     estimateFeesInput: {
       amountCryptoPrecision: '0',

--- a/src/lib/utils/thorchain/hooks/useSendThorTx.tsx
+++ b/src/lib/utils/thorchain/hooks/useSendThorTx.tsx
@@ -177,6 +177,7 @@ export const useSendThorTx = ({
         return {
           amountCryptoPrecision: fromBaseUnit(amountOrDustCryptoBaseUnit, asset.precision),
           assetId: asset.assetId,
+          feeAssetId: feeAsset.assetId,
           memo,
           to: THORCHAIN_POOL_MODULE_ADDRESS,
           sendMax: false,
@@ -194,6 +195,7 @@ export const useSendThorTx = ({
               ? fromBaseUnit(amountOrDustCryptoBaseUnit, feeAsset.precision)
               : '0',
           assetId: shouldUseDustAmount ? feeAsset.assetId : asset.assetId,
+          feeAssetId: feeAsset.assetId,
           to: inboundAddressData.router,
           from: account,
           sendMax: false,
@@ -211,6 +213,7 @@ export const useSendThorTx = ({
         return {
           amountCryptoPrecision: fromBaseUnit(amountOrDustCryptoBaseUnit, asset.precision),
           assetId,
+          feeAssetId: feeAsset.assetId,
           to: inboundAddressData.address,
           from: fromAddress,
           sendMax: false,
@@ -244,6 +247,7 @@ export const useSendThorTx = ({
   } = useGetEstimatedFeesQuery({
     amountCryptoPrecision: estimateFeesArgs?.amountCryptoPrecision ?? '0',
     assetId: estimateFeesArgs?.assetId ?? '',
+    feeAssetId: estimateFeesArgs?.feeAssetId ?? '',
     to: estimateFeesArgs?.to ?? '',
     sendMax: estimateFeesArgs?.sendMax ?? false,
     memo: estimateFeesArgs?.memo ?? '',

--- a/src/pages/Lending/Pool/components/Borrow/BorrowInput.tsx
+++ b/src/pages/Lending/Pool/components/Borrow/BorrowInput.tsx
@@ -276,11 +276,12 @@ export const BorrowInput = ({
   } = useGetEstimatedFeesQuery({
     amountCryptoPrecision: '0',
     assetId: collateralAssetId,
+    feeAssetId: collateralFeeAsset?.assetId!,
     to: fromAddress ?? '',
     sendMax: true,
     accountId: collateralAccountId,
     contractAddress: undefined,
-    enabled: isSweepNeededSuccess,
+    enabled: Boolean(collateralFeeAsset && isSweepNeededSuccess),
   })
 
   const hasEnoughBalanceForTxPlusSweep = useMemo(() => {


### PR DESCRIPTION
## Description

...for USDC and similar precision assets, as well as potentially a bunch of other places in the future as well if we kept this as-is.

This PR:

1. Adds a required `feeAssetId` param to `useGetEstimatedFeesQuery` args
2. Renames `asset` to `feeAsset` in its queryFn

<!-- Please describe your changes -->

## Pull Request Type

- [x] :bug: Bug fix (Non-breaking Change: Fixes an issue)
- [ ] :hammer_and_wrench: Chore (Non-breaking Change: Doc updates, pkg upgrades, typos, etc..)
- [ ] :nail_care: New Feature (Breaking/Non-breaking Change)

## Issue (if applicable)

<!-----------------------------------------------------------------------------
If applicable, please link to the github issue and put `closes #XXXX` in your comment to auto-close the issue that your PR fixes.
------------------------------------------------------------------------------>

N/A, fast follow on #6800 targeted one visual bug spotted in release

## Risk
> High Risk PRs Require 2 approvals

<!-----------------------------------------------------------------------------
Outline the scope of your changes and the risk associated with them. You must use your discretion as an engineer to determine the potential impact of your changes.

WARNING: If your PR introduces a new on-chain transaction or modifies an existing one, please add the "High-Risk" label to this PR and ask for 2 reviewers to approve it before merging.

E.g. an upgrade to `hdwallet` or core state management would be considered higher risk, and might require a full regression test. UI or isolated view changes, or something behind a feature flag may have near zero risk. Small bug fixes might require testing isolated to the specific fix.
------------------------------------------------------------------------------>

> What protocols, transaction types or contract interactions might be affected by this PR?

Low - see testing

## Testing

<!-----------------------------------------------------------------------------
We treat every PR to be merged with the same scrutiny as if we were merging directly to production.

Your PR will not be merged if you do not complete the sections below for our engineering and operations teams to test.
------------------------------------------------------------------------------>

- Gas estimations for repay using USDC or USDT looks sane i.e working, and not off by orders of magnitude
- Gas estimations for ETH, AVAX, and non-EVM native assets still looks good

### Engineering

<!-----------------------------------------------------------------------------
Include sufficient information here for an engineer to test your PR. This may include how to test locally, in a built environment, changes to infrastructure etc.
------------------------------------------------------------------------------>

- Ensure `feeAsset` (previously named `asset`) isn't used for anything else than precision exponentiation in `useGetEstimatedFeesQuery` queryFn
- Ensure consumption of the added `feeAssetId` is sane everywhere

### Operations

<!-----------------------------------------------------------------------------
If your changes have a user-facing impact, describe how a non-technical QA team can functionally test your changes in a preview environment.

If they are not user-facing please describe how to test for any regressions that may occur.
------------------------------------------------------------------------------>

## Screenshots (if applicable)

<!-- av pr metadata
This information is embedded by the av CLI when creating PRs to track the status of stacks when using Aviator. Please do not delete or edit this section of the PR.
```
{"parent":"develop","parentHead":"","trunk":""}
```
-->
