### PR TITLE
fix: disable minOut check

### DIFF
--- a/src/lib/utils/thorchain/memo.ts
+++ b/src/lib/utils/thorchain/memo.ts
@@ -26,9 +26,10 @@ const assertMemoHasBasisPoints = (basisPoints: string, memo: string) => {
   if (!basisPoints) throw new Error(`basis points is required in memo: ${memo}`)
 }
 
-const assertMemoHasMinOut = (minOut: string, memo: string) => {
-  if (!minOut) throw new Error(`minOut is required in memo: ${memo}`)
-}
+// Disabling until we validate further, as :MINOUT is optional in the quote response
+// const assertMemoHasMinOut = (minOut: string, memo: string) => {
+//   if (!minOut) throw new Error(`minOut is required in memo: ${memo}`)
+// }
 
 const assertIsValidLimit = (limit: string, memo: string) => {
   assertMemoHasLimit(limit, memo)
@@ -47,12 +48,13 @@ const assertIsValidLimit = (limit: string, memo: string) => {
   if (!bn(limit).gt(0)) throw new Error(`positive limit is required in memo: ${memo}`)
 }
 
-const assertIsValidMinOut = (minOut: string, memo: string) => {
-  assertMemoHasMinOut(minOut, memo)
+// Disabling until we validate further, as :MINOUT is optional in the quote response
+// const assertIsValidMinOut = (minOut: string, memo: string) => {
+//   assertMemoHasMinOut(minOut, memo)
 
-  if (!bn(minOut).isInteger()) throw new Error(`minOut must be an integer in memo: ${memo}`)
-  if (!bn(minOut).gt(0)) throw new Error(`positive minOut is required in memo: ${memo}`)
-}
+//   if (!bn(minOut).isInteger()) throw new Error(`minOut must be an integer in memo: ${memo}`)
+//   if (!bn(minOut).gt(0)) throw new Error(`positive minOut is required in memo: ${memo}`)
+// }
 
 const assertIsValidBasisPoints = (basisPoints: string, memo: string) => {
   assertMemoHasBasisPoints(basisPoints, memo)

--- a/src/lib/utils/thorchain/memo.ts
+++ b/src/lib/utils/thorchain/memo.ts
@@ -133,7 +133,7 @@ export const assertAndProcessMemo = (memo: string): string => {
 
       assertMemoHasAsset(asset, memo)
       assertMemoHasDestAddr(destAddr, memo)
-      assertIsValidMinOut(minOut, memo)
+      // assertIsValidMinOut(minOut, memo) // Disabling until we validate further, as :MINOUT is optional in the quote response
 
       return `${_action}:${asset}:${destAddr}:${minOut}:${THORCHAIN_AFFILIATE_NAME}:${fee || 0}`
     }
@@ -144,7 +144,7 @@ export const assertAndProcessMemo = (memo: string): string => {
 
       assertMemoHasAsset(asset, memo)
       assertMemoHasDestAddr(destAddr, memo)
-      assertIsValidMinOut(minOut, memo)
+      // assertIsValidMinOut(minOut, memo) // Disabling until we validate further, as :MINOUT is optional in the quote response
 
       return `${_action}:${asset}:${destAddr}:${minOut}:${THORCHAIN_AFFILIATE_NAME}:0`
     }


### PR DESCRIPTION
Disables the `minOut` check for lending, as it's an optional value in the memo response from THORChain.
See https://dev.thorchain.org/concepts/memos.html#open-loan and https://dev.thorchain.org/concepts/memos.html#repay-loan.

This PR only aims to address the immediate blocker for the current release (https://github.com/shapeshift/web/pull/6804) introduced in https://github.com/shapeshift/web/pull/6791.