### PR TITLE
fix: nullish coalescing in savers memo

### DIFF
--- a/src/lib/utils/thorchain/memo.ts
+++ b/src/lib/utils/thorchain/memo.ts
@@ -137,7 +137,9 @@ export const assertAndProcessMemo = (memo: string): string => {
       assertMemoHasDestAddr(destAddr, memo)
       // assertIsValidMinOut(minOut, memo) // Disabling until we validate further, as :MINOUT is optional in the quote response
 
-      return `${_action}:${asset}:${destAddr}:${minOut}:${THORCHAIN_AFFILIATE_NAME}:${fee || 0}`
+      return `${_action}:${asset}:${destAddr}:${minOut ?? ''}:${THORCHAIN_AFFILIATE_NAME}:${
+        fee || 0
+      }`
     }
     // LOAN-:ASSET:DESTADDR:MINOUT
     case '$-':
@@ -148,7 +150,7 @@ export const assertAndProcessMemo = (memo: string): string => {
       assertMemoHasDestAddr(destAddr, memo)
       // assertIsValidMinOut(minOut, memo) // Disabling until we validate further, as :MINOUT is optional in the quote response
 
-      return `${_action}:${asset}:${destAddr}:${minOut}:${THORCHAIN_AFFILIATE_NAME}:0`
+      return `${_action}:${asset}:${destAddr}:${minOut ?? ''}:${THORCHAIN_AFFILIATE_NAME}:0`
     }
     default:
       throw new Error(`unsupported memo: ${memo}`)


### PR DESCRIPTION
## Description

Fixes regression in https://github.com/shapeshift/web/pull/6755 where `undefined` was present in the memo for savers withdraws and deposits, which cannot be parsed by THORChain.

## Pull Request Type

- [x] :bug: Bug fix (Non-breaking Change: Fixes an issue)
- [ ] :hammer_and_wrench: Chore (Non-breaking Change: Doc updates, pkg upgrades, typos, etc..)
- [ ] :nail_care: New Feature (Breaking/Non-breaking Change)

## Issue (if applicable)

N/A

## Risk
> High Risk PRs Require 2 approvals

Theoretically high as it touches memos, but practically low as it fixes a known issue.

> What protocols, transaction types or contract interactions might be affected by this PR?

Thorchain savers deposits and withdraw.

## Testing

Complete a savers deposit or withdraw and confirm that the `minOut` field of the memo is an empty string and not `undefined`.

### Engineering

☝️

### Operations

☝️

## Screenshots (if applicable)

N/A