### PR TITLE
feat: assertAndProcessMemo leverage noUncheckedIndexedAccess strictness

### DIFF
--- a/src/lib/utils/thorchain/memo.ts
+++ b/src/lib/utils/thorchain/memo.ts
@@ -95,7 +95,9 @@ const assertIsValidBasisPoints = (
 export const assertAndProcessMemo = (memo: string): string => {
   const [action] = memo.split(':')
 
-  if (!assertMemoHasAction(action, memo)) throw new Error(`action is required in memo: ${memo}`)
+  // Note, this is an assertion - we only do the checks for type-narrowing purposes, it *will* throw if we don't have a memo
+  // so we'll never actually return the empty string below
+  if (!assertMemoHasAction(action, memo)) return ''
 
   switch (action.toLowerCase()) {
     case 'swap':
@@ -115,9 +117,9 @@ export const assertAndProcessMemo = (memo: string): string => {
     case 'a': {
       const [_action, pool, maybePairedAddr, , fee] = memo.split(':')
 
-      if (!pool) throw new Error(`pool is required in memo: ${memo}`)
-
-      assertMemoHasPool(pool, memo)
+      // Note, this is an assertion - we only do the checks for type-narrowing purposes, it *will* throw if we don't have a memo
+      // so we'll never actually return the empty string below
+      if (!assertMemoHasPool(pool, memo)) return ''
 
       // Add Liquidity - ADD:POOL:PAIREDADDR:AFFILIATE:FEE
       if (pool.includes('.')) {

--- a/src/lib/utils/thorchain/memo.ts
+++ b/src/lib/utils/thorchain/memo.ts
@@ -2,54 +2,50 @@ import { bn } from 'lib/bignumber/bignumber'
 
 import { THORCHAIN_AFFILIATE_NAME } from './constants'
 
-const assertMemoHasPool = (pool: string | undefined, memo: string): pool is string => {
+function assertMemoHasPool(pool: string | undefined, memo: string): asserts pool is string {
   if (!pool) throw new Error(`pool is required in memo: ${memo}`)
-  return true
 }
 
-const assertMemoHasAsset = (asset: string | undefined, memo: string): asset is string => {
+function assertMemoHasAsset(asset: string | undefined, memo: string): asserts asset is string {
   if (!asset) throw new Error(`asset is required in memo: ${memo}`)
-  return true
 }
 
-const assertMemoHasDestAddr = (destAddr: string | undefined, memo: string): destAddr is string => {
+function assertMemoHasDestAddr(
+  destAddr: string | undefined,
+  memo: string,
+): asserts destAddr is string {
   if (!destAddr) throw new Error(`destination address is required in memo: ${memo}`)
-  return true
 }
 
-const assertMemoHasPairedAddr = (
+function assertMemoHasPairedAddr(
   pairedAddr: string | undefined,
   memo: string,
-): pairedAddr is string => {
+): asserts pairedAddr is string {
   if (!pairedAddr) throw new Error(`paired address is required in memo: ${memo}`)
-  return true
 }
 
-const assertMemoHasLimit = (limit: string | undefined, memo: string): limit is string => {
+function assertMemoHasLimit(limit: string | undefined, memo: string): asserts limit is string {
   if (!limit) throw new Error(`limit is required in memo: ${memo}`)
-  return true
 }
 
-const assertMemoHasBasisPoints = (
+function assertMemoHasBasisPoints(
   basisPoints: string | undefined,
   memo: string,
-): basisPoints is string => {
+): asserts basisPoints is string {
   if (!basisPoints) throw new Error(`basis points is required in memo: ${memo}`)
-  return true
 }
 
-const assertMemoHasAction = (action: string | undefined, memo: string): action is string => {
+function assertMemoHasAction(action: string | undefined, memo: string): asserts action is string {
   if (!action) throw new Error(`action is required in memo: ${memo}`)
-  return true
 }
 
 // Disabling until we validate further, as :MINOUT is optional in the quote response
-// const assertMemoHasMinOut = (minOut: string, memo: string) => {
-//   if (!minOut) throw new Error(`minOut is required in memo: ${memo}`)
+// function assertMemoHasMinOut(minOut: string | undefined, memo: string): asserts minOut is string {
+// if (!minOut) throw new Error(`minOut is required in memo: ${memo}`)
 // }
 
 const assertIsValidLimit = (limit: string | undefined, memo: string) => {
-  if (!assertMemoHasLimit(limit, memo)) return
+  assertMemoHasLimit(limit, memo)
 
   const maybeStreamingSwap = limit.match(/\//g)
   const [lim, interval, quantity] = limit.split('/')
@@ -73,20 +69,16 @@ const assertIsValidLimit = (limit: string | undefined, memo: string) => {
 //   if (!bn(minOut).gt(0)) throw new Error(`positive minOut is required in memo: ${memo}`)
 // }
 
-const assertIsValidBasisPoints = (
+function assertIsValidBasisPoints(
   basisPoints: string | undefined,
   memo: string,
-): basisPoints is string => {
-  // Note, this is an assertion - we only do the checks for type-narrowing purposes, it *will* throw if we don't have a memo
-  // so we'll never actually return the empty string below
-  if (!assertMemoHasBasisPoints(basisPoints, memo)) return false
+): asserts basisPoints is string {
+  assertMemoHasBasisPoints(basisPoints, memo)
 
   if (!bn(basisPoints).isInteger())
     throw new Error(`basis points must be an integer in memo: ${memo}`)
   if (bn(basisPoints).lt(0) || bn(basisPoints).gt(10000))
     throw new Error(`basis points must be between 0-10000 in memo: ${memo}`)
-
-  return true
 }
 
 /**
@@ -95,9 +87,7 @@ const assertIsValidBasisPoints = (
 export const assertAndProcessMemo = (memo: string): string => {
   const [action] = memo.split(':')
 
-  // Note, this is an assertion - we only do the checks for type-narrowing purposes, it *will* throw if we don't have a memo
-  // so we'll never actually return the empty string below
-  if (!assertMemoHasAction(action, memo)) return ''
+  assertMemoHasAction(action, memo)
 
   switch (action.toLowerCase()) {
     case 'swap':
@@ -117,9 +107,7 @@ export const assertAndProcessMemo = (memo: string): string => {
     case 'a': {
       const [_action, pool, maybePairedAddr, , fee] = memo.split(':')
 
-      // Note, this is an assertion - we only do the checks for type-narrowing purposes, it *will* throw if we don't have a memo
-      // so we'll never actually return the empty string below
-      if (!assertMemoHasPool(pool, memo)) return ''
+      assertMemoHasPool(pool, memo)
 
       // Add Liquidity - ADD:POOL:PAIREDADDR:AFFILIATE:FEE
       if (pool.includes('.')) {
@@ -140,10 +128,8 @@ export const assertAndProcessMemo = (memo: string): string => {
     case 'wd': {
       const [_action, pool, basisPoints, maybeAsset] = memo.split(':')
 
-      // Note, these are assertions - we only do the checks for type-narrowing purposes, it *will* throw if we don't have a memo
-      // so we'll never actually return the empty strings below
-      if (!assertMemoHasPool(pool, memo)) return ''
-      if (!assertMemoHasBasisPoints(basisPoints, memo)) return ''
+      assertMemoHasPool(pool, memo)
+      assertMemoHasBasisPoints(basisPoints, memo)
 
       // Withdraw Liquidity - WITHDRAW:POOL:BASISPOINTS:ASSET
       if (pool.includes('.')) {

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -31,6 +31,7 @@
     "emitDecoratorMetadata": true,
     "experimentalDecorators": true,
     "jsx": "react-jsx",
+    "noUncheckedIndexedAccess": true,
   },
   "include": ["src/**/*", "src/**/*.json", "packages/**/*", "packages/**/*.json", "scripts/generateAssetData",
     "scripts/generateTradableThorAssetMap"

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -31,7 +31,6 @@
     "emitDecoratorMetadata": true,
     "experimentalDecorators": true,
     "jsx": "react-jsx",
-    "noUncheckedIndexedAccess": true,
   },
   "include": ["src/**/*", "src/**/*.json", "packages/**/*", "packages/**/*.json", "scripts/generateAssetData",
     "scripts/generateTradableThorAssetMap"


### PR DESCRIPTION
## Description

We've been burned in `assertAndProcessMemo` by `String.prototype.split()` returning an array of strings, while it's really returning `(string|undefined)[]`, see e.g https://github.com/shapeshift/web/pull/6809.

While adding `noUncheckedIndexedAccess` isn't a reasonable option (i.e `Found 556 errors in 119 files.`), we can at least add it temporary and add the required strictness to the offenders here, which this PR does.

## Pull Request Type

- [ ] :bug: Bug fix (Non-breaking Change: Fixes an issue)
- [ ] :hammer_and_wrench: Chore (Non-breaking Change: Doc updates, pkg upgrades, typos, etc..)
- [x] :nail_care: New Feature (Breaking/Non-breaking Change)

## Issue (if applicable)

<!-----------------------------------------------------------------------------
If applicable, please link to the github issue and put `closes #XXXX` in your comment to auto-close the issue that your PR fixes.
------------------------------------------------------------------------------>

N/A

## Risk
> High Risk PRs Require 2 approvals

<!-----------------------------------------------------------------------------
Outline the scope of your changes and the risk associated with them. You must use your discretion as an engineer to determine the potential impact of your changes.

WARNING: If your PR introduces a new on-chain transaction or modifies an existing one, please add the "High-Risk" label to this PR and ask for 2 reviewers to approve it before merging.

E.g. an upgrade to `hdwallet` or core state management would be considered higher risk, and might require a full regression test. UI or isolated view changes, or something behind a feature flag may have near zero risk. Small bug fixes might require testing isolated to the specific fix.
------------------------------------------------------------------------------>

Low, though being more strict comes with its own risks - confirm the checks are sane

> What protocols, transaction types or contract interactions might be affected by this PR?

## Testing

<!-----------------------------------------------------------------------------
We treat every PR to be merged with the same scrutiny as if we were merging directly to production.

Your PR will not be merged if you do not complete the sections below for our engineering and operations teams to test.
------------------------------------------------------------------------------>

- Do a sanity pass of THOR Txs and confirm they are happy (no need to broadcast - set a breakpoint in`useSendThorTx`'s `executeTransaction` at the very first line of its body and ensure memos still look sane

### Engineering

<!-----------------------------------------------------------------------------
Include sufficient information here for an engineer to test your PR. This may include how to test locally, in a built environment, changes to infrastructure etc.
------------------------------------------------------------------------------>

- Ensure checks are sane
- Revert the revert of the tsconfig option efa3b15657cafa6debfa27202962b2e64e91189c
- Ensure there are no TS errors in the `memo.ts` file

### Operations

<!-----------------------------------------------------------------------------
If your changes have a user-facing impact, describe how a non-technical QA team can functionally test your changes in a preview environment.

If they are not user-facing please describe how to test for any regressions that may occur.
------------------------------------------------------------------------------>

- ☝🏽 

## Screenshots (if applicable)

<!-- av pr metadata
This information is embedded by the av CLI when creating PRs to track the status of stacks when using Aviator. Please do not delete or edit this section of the PR.
```
{"parent":"develop","parentHead":"","trunk":""}
```
-->


<!-- av pr metadata
This information is embedded by the av CLI when creating PRs to track the status of stacks when using Aviator. Please do not delete or edit this section of the PR.
```
{"parent":"develop","parentHead":"","trunk":"develop"}
```
-->
