### PR TITLE
feat: additional Array.prototype.split() safety

### DIFF
--- a/scripts/generateTradableThorAssetMap/utils.ts
+++ b/scripts/generateTradableThorAssetMap/utils.ts
@@ -107,7 +107,7 @@ export const getTokenStandardFromChainId = (chainId: ChainId): AssetNamespace | 
  */
 export const getAssetIdPairFromPool = (pool: ThornodePoolResponse): AssetIdPair | undefined => {
   const thorchainAsset = pool.asset
-  const [chain, symbol] = thorchainAsset.split('.')
+  const [chain, symbol = ''] = thorchainAsset.split('.')
   const [, id] = symbol.split('-')
   const chainId = ChainToChainIdMap.get(chain as ThorchainChain)
   const isFeeAsset =

--- a/src/components/Layout/Header/NavBar/Native/BackupPassphraseModal/BackupPassphraseInfo.tsx
+++ b/src/components/Layout/Header/NavBar/Native/BackupPassphraseModal/BackupPassphraseInfo.tsx
@@ -56,7 +56,7 @@ export const BackupPassphraseInfo: React.FC<LocationState> = props => {
 
     try {
       return (
-        revocableWallet.getWords()?.map((word: string, index: number) =>
+        revocableWallet.getWords()?.map((word: string | undefined, index: number) =>
           revocable(
             <Tag
               p={2}

--- a/src/components/Layout/Header/NavBar/Native/BackupPassphraseModal/BackupPassphraseTest.tsx
+++ b/src/components/Layout/Header/NavBar/Native/BackupPassphraseModal/BackupPassphraseTest.tsx
@@ -64,10 +64,10 @@ export const BackupPassphraseTest: React.FC<LocationState> = props => {
       if (!words || words.length < 12) {
         return setError('walletProvider.shapeShift.create.error')
       }
-      let randomWords = uniq(bip39.generateMnemonic(256).split(' '))
+      let randomWords = uniq(bip39.generateMnemonic(256).split(' ')) as string[]
 
       const targetWordIndex = shuffledNumbers[testCount]
-      const targetWord = words[targetWordIndex]
+      const targetWord = words[targetWordIndex]!
       randomWords = randomWords.filter(x => x !== targetWord).slice(0, 14)
       randomWords.push(targetWord)
       randomWords = shuffle(randomWords)

--- a/src/context/WalletProvider/MobileWallet/components/MobileCreate.tsx
+++ b/src/context/WalletProvider/MobileWallet/components/MobileCreate.tsx
@@ -79,7 +79,7 @@ export const MobileCreate: React.FC<MobileCreateProps> = props => {
 
     try {
       setWords(
-        vault.getWords()?.map((word: string, index: number) =>
+        vault.getWords()?.map((word: string | undefined, index: number) =>
           revocable(
             <Tag
               p={2}

--- a/src/context/WalletProvider/MobileWallet/components/MobileCreateTest.tsx
+++ b/src/context/WalletProvider/MobileWallet/components/MobileCreateTest.tsx
@@ -65,10 +65,10 @@ export const MobileCreateTest = ({ history, location }: MobileSetupProps) => {
     if (testCount >= TEST_COUNT_REQUIRED || !vault) return
     try {
       const words = vault.getWords() ?? []
-      let randomWords = uniq(bip39.generateMnemonic(256).split(' '))
+      let randomWords = uniq(bip39.generateMnemonic(256).split(' ')) as string[]
 
       const targetWordIndex = shuffledNumbers[testCount]
-      const targetWord = words[targetWordIndex]
+      const targetWord = words[targetWordIndex] ?? ''
       randomWords = randomWords.filter(x => x !== targetWord).slice(0, 14)
       randomWords.push(targetWord)
       randomWords = shuffle(randomWords)

--- a/src/context/WalletProvider/NativeWallet/components/NativeTestPhrase.tsx
+++ b/src/context/WalletProvider/NativeWallet/components/NativeTestPhrase.tsx
@@ -49,7 +49,7 @@ export const NativeTestPhrase = ({ history, location }: NativeSetupProps) => {
     try {
       const mnemonic = await vault.unwrap().get('#mnemonic')
       const words = mnemonic.split(' ')
-      let randomWords = uniq(bip39.generateMnemonic(256).split(' '))
+      let randomWords = uniq(bip39.generateMnemonic(256).split(' ')) as string[]
 
       const targetWordIndex = shuffledNumbers[testCount]
       const targetWord = words[targetWordIndex]

--- a/src/lib/globals.ts
+++ b/src/lib/globals.ts
@@ -5,6 +5,12 @@ declare global {
       postMessage: (msg: string) => void
     }
   }
+  interface String {
+    split<Separator extends string | RegExp, Limit extends number>(
+      separator: Separator,
+      limit?: Limit,
+    ): (string | undefined)[]
+  }
 }
 
 export const isMobile = Boolean(window?.isShapeShiftMobile)

--- a/src/lib/utils/index.ts
+++ b/src/lib/utils/index.ts
@@ -177,7 +177,7 @@ export function assertIsDefined<T>(x: T | undefined | null): asserts x is T {
 export const hashCode = (str: string): string =>
   str
     .split('')
-    .reduce((s, c) => (Math.imul(31, s) + c.charCodeAt(0)) | 0, 0)
+    .reduce((s, c = '') => (Math.imul(31, s) + c.charCodeAt(0)) | 0, 0)
     .toString()
 
 export const sha256 = (input: string): string =>

--- a/src/pages/ThorChainLP/utils.ts
+++ b/src/pages/ThorChainLP/utils.ts
@@ -12,7 +12,7 @@ export type Opportunity = {
 export const fromOpportunityId = (opportunityId: string): Opportunity => {
   const [assetId, type] = opportunityId.split('*')
 
-  if (!assetId) throw new Error(`Invalid opportunityId: ${opportunityId}`)
+  if (!assetId || !type) throw new Error(`Invalid opportunityId: ${opportunityId}`)
 
   try {
     fromAssetId(assetId)

--- a/src/pages/ThorChainLP/utils.ts
+++ b/src/pages/ThorChainLP/utils.ts
@@ -11,6 +11,9 @@ export type Opportunity = {
 
 export const fromOpportunityId = (opportunityId: string): Opportunity => {
   const [assetId, type] = opportunityId.split('*')
+
+  if (!assetId) throw new Error(`Invalid opportunityId: ${opportunityId}`)
+
   try {
     fromAssetId(assetId)
   } catch (e) {

--- a/src/state/slices/txHistorySlice/utils.ts
+++ b/src/state/slices/txHistorySlice/utils.ts
@@ -58,17 +58,30 @@ export const deserializeTxIndex = (txIndex: TxIndex): TxDescriptor => {
   // Split the serialized index back into its components
   const parts = txIndex.split(UNIQUE_TX_ID_DELIMITER)
 
+  const accountId = parts[0]
+  const txid = parts[1]
+  const pubkey = parts[2]
+
+  if (!(accountId && txid && pubkey)) {
+    throw new Error(`Invalid tx index: ${txIndex}`)
+  }
+
   const result: TxDescriptor = {
-    accountId: parts[0],
-    txid: parts[1],
-    pubkey: parts[2],
+    accountId,
+    txid,
+    pubkey,
   }
 
   // If there are four parts, the fourth is the data, and we know it's a thorchain transaction with a memo
   if (parts.length === 4) {
+    const memo = parts[3]
+
+    if (!memo) {
+      throw new Error(`Invalid tx index: ${txIndex}`)
+    }
     result.data = {
       parser: 'thorchain',
-      memo: parts[3],
+      memo,
     }
   }
 

--- a/src/utils/sentry/httpclient.ts
+++ b/src/utils/sentry/httpclient.ts
@@ -226,11 +226,17 @@ function _getResponseSizeFromHeaders(headers?: Record<string, string>): number |
  * @returns The parsed cookies
  */
 function _parseCookieString(cookieString: string): Record<string, string> {
-  return cookieString.split('; ').reduce((acc: Record<string, string>, cookie: string) => {
-    const [key, value] = cookie.split('=')
-    acc[key] = value
-    return acc
-  }, {})
+  return cookieString.split('; ').reduce(
+    (acc, cookie: string | undefined) => {
+      const [key, value] = (cookie ?? '').split('=')
+
+      if (!key || !value) return acc
+
+      acc[key] = value
+      return acc
+    },
+    {} as Record<string, string>,
+  )
 }
 
 /**
@@ -262,11 +268,17 @@ function _getXHRResponseHeaders(xhr: XMLHttpRequest): Record<string, string> {
     return {}
   }
 
-  return headers.split('\r\n').reduce((acc: Record<string, string>, line: string) => {
-    const [key, value] = line.split(': ')
-    acc[key] = value
-    return acc
-  }, {})
+  return headers.split('\r\n').reduce(
+    (acc, line: string | undefined) => {
+      const [key, value] = (line ?? '').split(': ')
+
+      if (!key || !value) return acc
+
+      acc[key] = value
+      return acc
+    },
+    {} as Record<string, string>,
+  )
 }
 
 /**


### PR DESCRIPTION
## Description

<!-- Please describe your changes -->

follows-up on https://github.com/shapeshift/web/pull/6810 - since we can't do the `noUncheckedIndexedAccess` dance without having 500+ errors, this at least brings strictness for the specific
case of `Array.prototype.split()` returning `(string | undefined)[]` vs. `string` with our current compiler options.

Note that this aims to be a non-breaking change - while the strictness is now present, all type violations have been tackled in a way that should be non-breaking, with either:

- nullish coalescing to `''` (i.e no different than before, since we were assuming a string)
- throwing exceptions when applicable, for the specific cases where this doesn't change the flow and things would already fail as-is

## Pull Request Type

- [ ] :bug: Bug fix (Non-breaking Change: Fixes an issue)
- [ ] :hammer_and_wrench: Chore (Non-breaking Change: Doc updates, pkg upgrades, typos, etc..)
- [x] :nail_care: New Feature (Breaking/Non-breaking Change)

## Issue (if applicable)

<!-----------------------------------------------------------------------------
If applicable, please link to the github issue and put `closes #XXXX` in your comment to auto-close the issue that your PR fixes.
------------------------------------------------------------------------------>

N/A, follows-up on https://github.com/shapeshift/web/pull/6810 

## Risk
> High Risk PRs Require 2 approvals

<!-----------------------------------------------------------------------------
Outline the scope of your changes and the risk associated with them. You must use your discretion as an engineer to determine the potential impact of your changes.

WARNING: If your PR introduces a new on-chain transaction or modifies an existing one, please add the "High-Risk" label to this PR and ask for 2 reviewers to approve it before merging.

E.g. an upgrade to `hdwallet` or core state management would be considered higher risk, and might require a full regression test. UI or isolated view changes, or something behind a feature flag may have near zero risk. Small bug fixes might require testing isolated to the specific fix.
------------------------------------------------------------------------------>

> What protocols, transaction types or contract interactions might be affected by this PR?

Low but not nil by definition - see testing steps

## Testing

<!-----------------------------------------------------------------------------
We treat every PR to be merged with the same scrutiny as if we were merging directly to production.

Your PR will not be merged if you do not complete the sections below for our engineering and operations teams to test.
------------------------------------------------------------------------------>

- THOR swaps are still happy with no error thrown and with slippage still applied in the memo as before

The two above don't require new Tx - just do a full cache clear and ensure Txs look sane against develop

- THOR Txs with a memo are still parsed in Tx history without errors thrown (e.g swaps)
- THOR Txs without a memo are still parsed in Tx history without errors thrown (e.g sends)

- Wallet creation is still happy on mobile (PR deployed to gome, just point your mobile app to gome and test it out)
- Backup passphrase is still happy (test on either desktop or mobile)

### Engineering

<!-----------------------------------------------------------------------------
Include sufficient information here for an engineer to test your PR. This may include how to test locally, in a built environment, changes to infrastructure etc.
------------------------------------------------------------------------------>

- ☝🏽 
- Confirm the non-breaking change nature of this conceptually


### Operations

<!-----------------------------------------------------------------------------
If your changes have a user-facing impact, describe how a non-technical QA team can functionally test your changes in a preview environment.

If they are not user-facing please describe how to test for any regressions that may occur.
------------------------------------------------------------------------------>

- ☝🏽 

## Screenshots (if applicable)

<!-- av pr metadata
This information is embedded by the av CLI when creating PRs to track the status of stacks when using Aviator. Please do not delete or edit this section of the PR.
```
{"parent":"feat_memo_safety_more_safety","parentHead":"b181da2a1e77fbd0dbae85bacd2840ecb77e7d59","parentPull":6810,"trunk":"develop"}
```
-->

### Txs look sane after a cache clear (left: develop, right: this diff with cleared cache)

 
<img width="1725" alt="image" src="https://github.com/shapeshift/web/assets/17035424/de47f917-c905-4e86-9551-4747df19e879">


- THOR swaps are still happy with no error thrown and with slippage still applied in the memo as before

<img width="118" alt="image" src="https://github.com/shapeshift/web/assets/17035424/c6af32c1-8bc7-4693-8162-b3b2cb3df684">
<img width="952" alt="image" src="https://github.com/shapeshift/web/assets/17035424/b5026306-eee0-4e8c-bf23-8f37fd614104">

- Wallet creation is still happy on mobile (tested on linked upstream gome in the Android app)

  - Wrong word
  <img width="366" alt="image" src="https://github.com/shapeshift/web/assets/17035424/872b90bd-c227-4003-9f5a-79db5cd611c5">
 - Correct words
 
<img width="544" alt="image" src="https://github.com/shapeshift/web/assets/17035424/dc29e06f-e396-4f59-acec-70565d3f238d">
<img width="436" alt="image" src="https://github.com/shapeshift/web/assets/17035424/2817263d-fb60-4b16-a7e8-65c3f5c2c24c">

- Backup passphrase is still happy

<img width="449" alt="image" src="https://github.com/shapeshift/web/assets/17035424/3a6ab7f5-7244-4507-961f-1a39a8d5fc28">
<img width="533" alt="image" src="https://github.com/shapeshift/web/assets/17035424/0fd77190-6327-4b58-8fbd-c627eefb056c">


<!-- av pr metadata
This information is embedded by the av CLI when creating PRs to track the status of stacks when using Aviator. Please do not delete or edit this section of the PR.
```
{"parent":"develop","parentHead":"","trunk":"develop"}
```
-->
