### PR TITLE
chore: make account management toggles use toggle functions instead of setters

### DIFF
--- a/src/state/slices/portfolioSlice/portfolioSlice.ts
+++ b/src/state/slices/portfolioSlice/portfolioSlice.ts
@@ -137,8 +137,17 @@ export const portfolio = createSlice({
       // add the `action.meta[SHOULD_AUTOBATCH]` field the enhancer needs
       prepare: prepareAutoBatched<Portfolio>(),
     },
-    setHiddenAccountIds: (draftState, { payload }: { payload: AccountId[] }) => {
-      draftState.hiddenAccountIds = payload
+    toggleAccountIdHidden: (draftState, { payload: accountId }: { payload: AccountId }) => {
+      const hiddenAccountIdsSet = new Set(draftState.hiddenAccountIds)
+      const isHidden = hiddenAccountIdsSet.has(accountId)
+
+      if (!isHidden) {
+        hiddenAccountIdsSet.add(accountId)
+      } else {
+        hiddenAccountIdsSet.delete(accountId)
+      }
+
+      draftState.hiddenAccountIds = Array.from(hiddenAccountIdsSet)
     },
   },
   extraReducers: builder => builder.addCase(PURGE, () => initialState),


### PR DESCRIPTION
## Description

Refactor to make the import accounts drawer use toggle functions instead of setters. No functionality changes with this PR.

NOTE: A bug was identified while implementing this where the toggle state from a previous chain being managed appears on the current one - this will be fixed in a follow-up PR (https://github.com/shapeshift/web/pull/6817) as it's unrelated to this.

## Pull Request Type

- [ ] :bug: Bug fix (Non-breaking Change: Fixes an issue)
- [x] :hammer_and_wrench: Chore (Non-breaking Change: Doc updates, pkg upgrades, typos, etc..)
- [ ] :nail_care: New Feature (Breaking/Non-breaking Change)

## Issue (if applicable)

closes #6815

## Risk
> High Risk PRs Require 2 approvals

Low risk.

> What protocols, transaction types or contract interactions might be affected by this PR?

## Testing
Check account import toggles in the account management drawer functions as it did previously (including the toggle state bug identified above)

### Engineering

<!-----------------------------------------------------------------------------
Include sufficient information here for an engineer to test your PR. This may include how to test locally, in a built environment, changes to infrastructure etc.
------------------------------------------------------------------------------>

### Operations

<!-----------------------------------------------------------------------------
If your changes have a user-facing impact, describe how a non-technical QA team can functionally test your changes in a preview environment.

If they are not user-facing please describe how to test for any regressions that may occur.
------------------------------------------------------------------------------>

## Screenshots (if applicable)
