### PR TITLE
fix: state corruption of import accounts drawer

### DIFF
--- a/src/components/ManageAccountsDrawer/components/ImportAccounts.tsx
+++ b/src/components/ManageAccountsDrawer/components/ImportAccounts.tsx
@@ -163,6 +163,12 @@ export const ImportAccounts = ({ chainId, onClose }: ImportAccountsProps) => {
   const [autoFetching, setAutoFetching] = useState(true)
   const [toggledActiveAccountIds, setToggledActiveAccountIds] = useState<Set<AccountId>>(new Set())
 
+  // reset component state when chainId changes
+  useEffect(() => {
+    setAutoFetching(true)
+    setToggledActiveAccountIds(new Set())
+  }, [chainId])
+
   // initial fetch to detect the number of accounts based on the "first empty account" heuristic
   const {
     data: accounts,
@@ -261,9 +267,10 @@ export const ImportAccounts = ({ chainId, onClose }: ImportAccountsProps) => {
     if (!asset || !accounts) return null
     return accounts.pages.map(({ accountIdWithActivityAndMetadata }, accountNumber) => {
       const accountIds = accountIdWithActivityAndMetadata.map(({ accountId }) => accountId)
+      const key = accountIds.join('-')
       return (
         <TableRow
-          key={accountNumber}
+          key={key}
           accountNumber={accountNumber}
           accountIds={accountIds}
           asset={asset}

--- a/src/components/ManageAccountsDrawer/components/ImportAccounts.tsx
+++ b/src/components/ManageAccountsDrawer/components/ImportAccounts.tsx
@@ -12,11 +12,10 @@ import {
 } from '@chakra-ui/react'
 import type { ChainId } from '@shapeshiftoss/caip'
 import { type AccountId, fromAccountId } from '@shapeshiftoss/caip'
-import type { AccountMetadata, Asset } from '@shapeshiftoss/types'
-import { useIsFetching, useQuery, useQueryClient } from '@tanstack/react-query'
+import type { Asset } from '@shapeshiftoss/types'
+import { useInfiniteQuery, useQuery } from '@tanstack/react-query'
 import { useCallback, useEffect, useMemo, useState } from 'react'
 import { useTranslate } from 'react-polyglot'
-import { reactQueries } from 'react-queries'
 import { accountManagement } from 'react-queries/queries/accountManagement'
 import { Amount } from 'components/Amount/Amount'
 import { MiddleEllipsis } from 'components/MiddleEllipsis/MiddleEllipsis'
@@ -34,6 +33,7 @@ import {
 } from 'state/slices/selectors'
 import { store, useAppDispatch, useAppSelector } from 'state/store'
 
+import { getAccountIdsWithActivityAndMetadata } from '../helpers'
 import { DrawerContentWrapper } from './DrawerContent'
 
 // The number of additional empty accounts to include in the initial fetch
@@ -160,55 +160,52 @@ export const ImportAccounts = ({ chainId, onClose }: ImportAccountsProps) => {
     selectHighestAccountNumberForChainId(state, highestAccountNumberForChainIdFilter),
   )
   const chainNamespaceDisplayName = asset?.networkName ?? ''
-  const [accounts, setAccounts] = useState<
-    { accountId: AccountId; accountMetadata: AccountMetadata; hasActivity: boolean }[][]
-  >([])
-  const queryClient = useQueryClient()
-  const isLoading =
-    useIsFetching({
-      predicate: query => {
-        return (
-          query.queryKey[0] === 'accountManagement' &&
-          ['accountIdWithActivityAndMetadata', 'firstAccountIdsWithActivityAndMetadata'].some(
-            str => str === query.queryKey[1],
-          )
-        )
-      },
-    }) > 0
+  const [autoFetching, setAutoFetching] = useState(true)
   const [toggledActiveAccountIds, setToggledActiveAccountIds] = useState<Set<AccountId>>(new Set())
 
   // initial fetch to detect the number of accounts based on the "first empty account" heuristic
-  const { data: allAccountIdsWithActivity } = useQuery(
-    accountManagement.firstAccountIdsWithActivityAndMetadata(
-      chainId,
-      wallet,
-      walletDeviceId,
-      // Account numbers are 0-indexed, so we need to add 1 to the highest account number.
-      // Add additional empty accounts to show more accounts without having to load more.
-      highestAccountNumber + 1 + NUM_ADDITIONAL_EMPTY_ACCOUNTS,
-    ),
-  )
-
-  useEffect(() => {
-    setAccounts(allAccountIdsWithActivity ?? [])
-  }, [allAccountIdsWithActivity])
-
-  const handleLoadMore = useCallback(async () => {
-    if (!wallet) return
-    const accountNumber = accounts.length
-    const accountResults = await queryClient.fetchQuery(
-      reactQueries.accountManagement.accountIdWithActivityAndMetadata(
+  const {
+    data: accounts,
+    fetchNextPage,
+    isLoading,
+  } = useInfiniteQuery({
+    queryKey: ['accountIdWithActivityAndMetadata', chainId, walletDeviceId, wallet !== null],
+    queryFn: async ({ pageParam: accountNumber }) => {
+      return {
         accountNumber,
-        chainId,
-        wallet,
-        walletDeviceId,
-      ),
-    )
-    if (!accountResults.length) return
-    setAccounts(previousAccounts => {
-      return [...previousAccounts, accountResults]
-    })
-  }, [accounts, chainId, queryClient, wallet, walletDeviceId])
+        accountIdWithActivityAndMetadata: await getAccountIdsWithActivityAndMetadata(
+          accountNumber,
+          chainId,
+          wallet,
+        ),
+      }
+    },
+    initialPageParam: 0,
+    getNextPageParam: lastPage => {
+      return lastPage.accountNumber + 1
+    },
+  })
+
+  // Handle initial automatic loading
+  useEffect(() => {
+    if (!autoFetching || !accounts) return
+
+    // Account numbers are 0-indexed, so we need to add 1 to the highest account number.
+    // Add additional empty accounts to show more accounts without having to load more.
+    const numAccountsToLoad = highestAccountNumber + 1 + NUM_ADDITIONAL_EMPTY_ACCOUNTS
+
+    if (accounts.pages.length < numAccountsToLoad) {
+      fetchNextPage()
+    } else {
+      // Stop auto-fetching and switch to manual mode
+      setAutoFetching(false)
+    }
+  }, [accounts, highestAccountNumber, fetchNextPage, autoFetching])
+
+  const handleLoadMore = useCallback(() => {
+    if (autoFetching) return
+    fetchNextPage()
+  }, [autoFetching, fetchNextPage])
 
   const handleToggleAccountIds = useCallback((accountIds: AccountId[]) => {
     setToggledActiveAccountIds(previousState => {
@@ -234,10 +231,15 @@ export const ImportAccounts = ({ chainId, onClose }: ImportAccountsProps) => {
       await dispatch(portfolioApi.endpoints.getAccount.initiate({ accountId, upsertOnFetch: true }))
     }
 
-    const accountMetadataByAccountId = accounts.reduce((accumulator, accounts) => {
-      const obj = accounts.reduce((innerAccumulator, { accountId, accountMetadata }) => {
-        return { ...innerAccumulator, [accountId]: accountMetadata }
-      }, {})
+    if (!accounts) return
+
+    const accountMetadataByAccountId = accounts.pages.reduce((accumulator, accounts) => {
+      const obj = accounts.accountIdWithActivityAndMetadata.reduce(
+        (innerAccumulator, { accountId, accountMetadata }) => {
+          return { ...innerAccumulator, [accountId]: accountMetadata }
+        },
+        {},
+      )
       return { ...accumulator, ...obj }
     }, {})
 
@@ -256,9 +258,9 @@ export const ImportAccounts = ({ chainId, onClose }: ImportAccountsProps) => {
   }, [toggledActiveAccountIds, accounts, dispatch, onClose, walletDeviceId])
 
   const accountRows = useMemo(() => {
-    if (!asset) return null
-    return accounts.map((accountsForAccountNumber, accountNumber) => {
-      const accountIds = accountsForAccountNumber.map(({ accountId }) => accountId)
+    if (!asset || !accounts) return null
+    return accounts.pages.map(({ accountIdWithActivityAndMetadata }, accountNumber) => {
+      const accountIds = accountIdWithActivityAndMetadata.map(({ accountId }) => accountId)
       return (
         <TableRow
           key={accountNumber}

--- a/src/components/ManageAccountsDrawer/components/ImportAccounts.tsx
+++ b/src/components/ManageAccountsDrawer/components/ImportAccounts.tsx
@@ -209,9 +209,9 @@ export const ImportAccounts = ({ chainId, onClose }: ImportAccountsProps) => {
   }, [accounts, highestAccountNumber, fetchNextPage, autoFetching])
 
   const handleLoadMore = useCallback(() => {
-    if (autoFetching) return
+    if (isLoading || autoFetching) return
     fetchNextPage()
-  }, [autoFetching, fetchNextPage])
+  }, [autoFetching, isLoading, fetchNextPage])
 
   const handleToggleAccountIds = useCallback((accountIds: AccountId[]) => {
     setToggledActiveAccountIds(previousState => {
@@ -291,19 +291,13 @@ export const ImportAccounts = ({ chainId, onClose }: ImportAccountsProps) => {
       description={translate('accountManagement.importAccounts.description')}
       footer={
         <>
-          <Button
-            colorScheme='gray'
-            mr={3}
-            onClick={onClose}
-            isDisabled={isLoading}
-            _disabled={disabledProps}
-          >
+          <Button colorScheme='gray' mr={3} onClick={onClose}>
             {translate('common.cancel')}
           </Button>
           <Button
             colorScheme='blue'
             onClick={handleDone}
-            isDisabled={isLoading}
+            isDisabled={isLoading || autoFetching}
             _disabled={disabledProps}
           >
             {translate('common.done')}
@@ -316,14 +310,14 @@ export const ImportAccounts = ({ chainId, onClose }: ImportAccountsProps) => {
             <Table variant='simple'>
               <Tbody>
                 {accountRows}
-                {isLoading && <LoadingRow />}
+                {(isLoading || autoFetching) && <LoadingRow />}
               </Tbody>
             </Table>
           </TableContainer>
           <Button
             colorScheme='gray'
             onClick={handleLoadMore}
-            isDisabled={isLoading}
+            isDisabled={isLoading || autoFetching}
             _disabled={disabledProps}
           >
             {translate('common.loadMore')}

--- a/src/react-queries/queries/accountManagement.ts
+++ b/src/react-queries/queries/accountManagement.ts
@@ -1,31 +1,7 @@
 import { createQueryKeys } from '@lukemorales/query-key-factory'
 import type { AccountId } from '@shapeshiftoss/caip'
-import { type ChainId, fromAccountId } from '@shapeshiftoss/caip'
-import type { HDWallet } from '@shapeshiftoss/hdwallet-core'
-import type { AccountMetadata } from '@shapeshiftoss/types'
-import { deriveAccountIdsAndMetadata } from 'lib/account/account'
+import { fromAccountId } from '@shapeshiftoss/caip'
 import { assertGetChainAdapter } from 'lib/utils'
-import { checkAccountHasActivity } from 'state/slices/portfolioSlice/utils'
-
-const getAccountIdsWithActivityAndMetadata = async (
-  accountNumber: number,
-  chainId: ChainId,
-  wallet: HDWallet,
-) => {
-  const input = { accountNumber, chainIds: [chainId], wallet }
-  const accountIdsAndMetadata = await deriveAccountIdsAndMetadata(input)
-
-  return Promise.all(
-    Object.entries(accountIdsAndMetadata).map(async ([accountId, accountMetadata]) => {
-      const { account: pubkey } = fromAccountId(accountId)
-      const adapter = assertGetChainAdapter(chainId)
-      const account = await adapter.getAccount(pubkey)
-      const hasActivity = checkAccountHasActivity(account)
-
-      return { accountId, accountMetadata, hasActivity }
-    }),
-  )
-}
 
 export const accountManagement = createQueryKeys('accountManagement', {
   getAccount: (accountId: AccountId) => ({
@@ -35,64 +11,6 @@ export const accountManagement = createQueryKeys('accountManagement', {
       const adapter = assertGetChainAdapter(chainId)
       const account = await adapter.getAccount(pubkey)
       return account
-    },
-  }),
-  accountIdWithActivityAndMetadata: (
-    accountNumber: number,
-    chainId: ChainId,
-    wallet: HDWallet,
-    walletDeviceId: string,
-  ) => ({
-    queryKey: ['accountIdWithActivityAndMetadata', chainId, walletDeviceId, accountNumber],
-    queryFn: () => {
-      return getAccountIdsWithActivityAndMetadata(accountNumber, chainId, wallet)
-    },
-  }),
-  firstAccountIdsWithActivityAndMetadata: (
-    chainId: ChainId,
-    wallet: HDWallet | null,
-    walletDeviceId: string,
-    accountNumberLimit: number,
-  ) => ({
-    queryKey: [
-      'firstAccountIdsWithActivityAndMetadata',
-      chainId,
-      walletDeviceId,
-      accountNumberLimit,
-    ],
-    queryFn: async () => {
-      let accountNumber = 0
-
-      const accounts: {
-        accountId: AccountId
-        accountMetadata: AccountMetadata
-        hasActivity: boolean
-      }[][] = []
-
-      if (!wallet) return []
-
-      while (true) {
-        try {
-          if (accountNumber >= accountNumberLimit) {
-            break
-          }
-
-          const accountResults = await getAccountIdsWithActivityAndMetadata(
-            accountNumber,
-            chainId,
-            wallet,
-          )
-
-          accounts.push(accountResults)
-        } catch (error) {
-          console.error(error)
-          break
-        }
-
-        accountNumber++
-      }
-
-      return accounts
     },
   }),
 })


### PR DESCRIPTION
## Description

Addresses several state corruption issues related to import accounts drawer in account management, namely state being rendered for the previously opened chain.

Key changes:
1. Migrates the account import queries to `useInfiniteQuery` in order to simplify state management
2. Resets component state when a different chain is being managed
3. Uses an actually unique key for account rows (instead of account number which is shared across different chains)

## Pull Request Type

- [x] :bug: Bug fix (Non-breaking Change: Fixes an issue)
- [ ] :hammer_and_wrench: Chore (Non-breaking Change: Doc updates, pkg upgrades, typos, etc..)
- [ ] :nail_care: New Feature (Breaking/Non-breaking Change)

## Issue (if applicable)

<!-----------------------------------------------------------------------------
If applicable, please link to the github issue and put `closes #XXXX` in your comment to auto-close the issue that your PR fixes.
------------------------------------------------------------------------------>

NA

## Risk
> High Risk PRs Require 2 approvals

Low risk.

> What protocols, transaction types or contract interactions might be affected by this PR?

## Testing

Check that navigating to different chains in the "import accounts" drawer renders the correct toggled state of the accounts. 

### Engineering

<!-----------------------------------------------------------------------------
Include sufficient information here for an engineer to test your PR. This may include how to test locally, in a built environment, changes to infrastructure etc.
------------------------------------------------------------------------------>

### Operations

<!-----------------------------------------------------------------------------
If your changes have a user-facing impact, describe how a non-technical QA team can functionally test your changes in a preview environment.

If they are not user-facing please describe how to test for any regressions that may occur.
------------------------------------------------------------------------------>

## Screenshots (if applicable)

Demo showing corrected state where toggles are actually representative of chain being managed:

https://github.com/shapeshift/web/assets/125113430/e20f0b9c-cc6b-4dc7-ba23-5d147af39c9e

