### PR TITLE
fix: import accounts requiring 2 attempts for account to persist

### DIFF
--- a/src/assets/translations/en/main.json
+++ b/src/assets/translations/en/main.json
@@ -1794,7 +1794,9 @@
     "manageAccounts": {
       "title": "Manage Accounts",
       "description": "These are the chains you have connected and the number of accounts you have imported.",
-      "addChain": "Add another chain"
+      "emptyList": "You have no accounts connected yet. Add a chain to get started.",
+      "addChain": "Add a chain",
+      "addAnotherChain": "Add another chain"
     },
     "selectChain": {
       "title": "Select Chain",

--- a/src/components/Modals/ManageAccounts/ManageAccountsModal.tsx
+++ b/src/components/Modals/ManageAccounts/ManageAccountsModal.tsx
@@ -137,7 +137,7 @@ export const ManageAccountsModal = ({
           />
           <ModalCloseButton position='absolute' top={3} right={3} />
           {walletConnectedChainIds.length > 0 && (
-            <ModalBody maxH='400px' overflow='scroll'>
+            <ModalBody maxH='400px' overflowY='auto'>
               <VStack spacing={2} width='full'>
                 {connectedChains}
               </VStack>

--- a/src/components/Modals/ManageAccounts/ManageAccountsModal.tsx
+++ b/src/components/Modals/ManageAccounts/ManageAccountsModal.tsx
@@ -23,7 +23,7 @@ import { ManageAccountsDrawer } from 'components/ManageAccountsDrawer/ManageAcco
 import { RawText } from 'components/Text'
 import { useModal } from 'hooks/useModal/useModal'
 import { assertGetChainAdapter, chainIdToFeeAssetId } from 'lib/utils'
-import { selectWalletSupportedChainIds } from 'state/slices/common-selectors'
+import { selectWalletChainIds } from 'state/slices/common-selectors'
 import { selectAccountIdsByChainId, selectAssetById } from 'state/slices/selectors'
 import { useAppSelector } from 'state/store'
 
@@ -82,8 +82,7 @@ export const ManageAccountsModal = ({
     console.log('info clicked')
   }, [])
 
-  // TODO: redux will have to be updated to use the selected chains from this flow
-  const walletSupportedChainIds = useAppSelector(selectWalletSupportedChainIds)
+  const walletConnectedChainIds = useAppSelector(selectWalletChainIds)
 
   const handleClickChain = useCallback(
     (chainId: ChainId) => {
@@ -99,10 +98,10 @@ export const ManageAccountsModal = ({
   }, [handleDrawerOpen])
 
   const connectedChains = useMemo(() => {
-    return walletSupportedChainIds.map(chainId => {
+    return walletConnectedChainIds.map(chainId => {
       return <ConnectedChain key={chainId} chainId={chainId} onClick={handleClickChain} />
     })
-  }, [handleClickChain, walletSupportedChainIds])
+  }, [handleClickChain, walletConnectedChainIds])
 
   const disableAddChain = false // FIXME: walletSupportedChainIds.length === connectedChains.length - blocked on Redux PR
 
@@ -121,7 +120,9 @@ export const ManageAccountsModal = ({
               {translate(title)}
             </RawText>
             <RawText color='text.subtle' fontSize='md' fontWeight='normal'>
-              {translate('accountManagement.manageAccounts.description')}
+              {walletConnectedChainIds.length === 0
+                ? translate('accountManagement.manageAccounts.emptyList')
+                : translate('accountManagement.manageAccounts.description')}
             </RawText>
           </ModalHeader>
           <IconButton
@@ -135,11 +136,13 @@ export const ManageAccountsModal = ({
             onClick={handleInfoClick}
           />
           <ModalCloseButton position='absolute' top={3} right={3} />
-          <ModalBody maxH='400px' overflow='scroll'>
-            <VStack spacing={2} width='full'>
-              {connectedChains}
-            </VStack>
-          </ModalBody>
+          {walletConnectedChainIds.length > 0 && (
+            <ModalBody maxH='400px' overflow='scroll'>
+              <VStack spacing={2} width='full'>
+                {connectedChains}
+              </VStack>
+            </ModalBody>
+          )}
           <ModalFooter justifyContent='center' pb={6}>
             <VStack spacing={2} width='full'>
               <Button
@@ -150,7 +153,9 @@ export const ManageAccountsModal = ({
                 isDisabled={disableAddChain}
                 _disabled={disabledProp}
               >
-                {translate('accountManagement.manageAccounts.addChain')}
+                {walletConnectedChainIds.length === 0
+                  ? translate('accountManagement.manageAccounts.addChain')
+                  : translate('accountManagement.manageAccounts.addAnotherChain')}
               </Button>
               <Button size='lg' colorScheme='gray' onClick={close} width='full'>
                 {translate('common.done')}

--- a/src/context/AppProvider/AppContext.tsx
+++ b/src/context/AppProvider/AppContext.tsx
@@ -143,7 +143,6 @@ export const AppProvider = ({ children }: { children: React.ReactNode }) => {
           chainIdsWithActivity = Array.from(new Set([...chainIdsWithActivity, chainId]))
 
           dispatch(portfolio.actions.upsertPortfolio(account))
-          dispatch(portfolio.actions.toggleAccountIdEnabled(accountId))
         })
 
         chainIds = chainIdsWithActivity
@@ -155,6 +154,10 @@ export const AppProvider = ({ children }: { children: React.ReactNode }) => {
           walletId: await wallet.getDeviceID(),
         }),
       )
+
+      for (const accountId of Object.keys(accountMetadataByAccountId)) {
+        dispatch(portfolio.actions.enableAccountId(accountId))
+      }
     })()
   }, [dispatch, wallet, supportedChains, isSnapInstalled])
 

--- a/src/context/AppProvider/AppContext.tsx
+++ b/src/context/AppProvider/AppContext.tsx
@@ -143,6 +143,7 @@ export const AppProvider = ({ children }: { children: React.ReactNode }) => {
           chainIdsWithActivity = Array.from(new Set([...chainIdsWithActivity, chainId]))
 
           dispatch(portfolio.actions.upsertPortfolio(account))
+          dispatch(portfolio.actions.toggleAccountIdEnabled(accountId))
         })
 
         chainIds = chainIdsWithActivity

--- a/src/pages/Accounts/AddAccountModal.tsx
+++ b/src/pages/Accounts/AddAccountModal.tsx
@@ -89,9 +89,10 @@ export const AddAccountModal = () => {
         }),
       )
       const accountIds = Object.keys(accountMetadataByAccountId)
-      accountIds.forEach(accountId =>
-        dispatch(getAccount.initiate({ accountId, upsertOnFetch: true }, opts)),
-      )
+      accountIds.forEach(accountId => {
+        dispatch(getAccount.initiate({ accountId, upsertOnFetch: true }, opts))
+        dispatch(portfolio.actions.enableAccountId(accountId))
+      })
       const assetId = getChainAdapterManager().get(selectedChainId)!.getFeeAssetId()
       const { name } = assets[assetId] ?? {}
       toast({

--- a/src/state/migrations/index.ts
+++ b/src/state/migrations/index.ts
@@ -59,4 +59,5 @@ export const migrations = {
   49: clearAssets,
   50: clearPortfolio,
   51: clearAssets,
+  52: clearPortfolio,
 }

--- a/src/state/slices/common-selectors.ts
+++ b/src/state/slices/common-selectors.ts
@@ -29,7 +29,7 @@ export const selectWalletAccountIds = createDeepEqualOutputSelector(
   (state: ReduxState) => state.portfolio.enabledAccountIds,
   (walletId, walletById, enabledAccountIds): AccountId[] => {
     const walletAccountIds = (walletId && walletById[walletId]) ?? []
-    return walletAccountIds.filter(accountId => enabledAccountIds.includes(accountId))
+    return walletAccountIds.filter(accountId => (enabledAccountIds ?? []).includes(accountId))
   },
 )
 

--- a/src/state/slices/common-selectors.ts
+++ b/src/state/slices/common-selectors.ts
@@ -26,10 +26,10 @@ export const selectWalletSupportedChainIds = (state: ReduxState) =>
 export const selectWalletAccountIds = createDeepEqualOutputSelector(
   selectWalletId,
   (state: ReduxState) => state.portfolio.wallet.byId,
-  (state: ReduxState) => state.portfolio.hiddenAccountIds,
-  (walletId, walletById, hiddenAccountIds): AccountId[] => {
+  (state: ReduxState) => state.portfolio.enabledAccountIds,
+  (walletId, walletById, enabledAccountIds): AccountId[] => {
     const walletAccountIds = (walletId && walletById[walletId]) ?? []
-    return walletAccountIds.filter(accountId => !hiddenAccountIds.includes(accountId))
+    return walletAccountIds.filter(accountId => enabledAccountIds.includes(accountId))
   },
 )
 

--- a/src/state/slices/opportunitiesSlice/selectors/selectors.test.ts
+++ b/src/state/slices/opportunitiesSlice/selectors/selectors.test.ts
@@ -47,6 +47,7 @@ describe('opportunitiesSlice selectors', () => {
         supportedChainIds: [],
       },
       wallet,
+      enabledAccountIds: [gomesAccountId, fauxmesAccountId, catpuccinoAccountId],
     },
   }
   describe('selects ID/s', () => {
@@ -65,6 +66,7 @@ describe('opportunitiesSlice selectors', () => {
       },
       ids: [gomesAccountId, fauxmesAccountId],
     }
+    const enabledAccountIds = [gomesAccountId, fauxmesAccountId]
     const lp = {
       ...initialState.lp,
       byAccountId: {
@@ -116,6 +118,7 @@ describe('opportunitiesSlice selectors', () => {
         ...mockBaseState.portfolio,
         accountBalances,
         accountMetadata,
+        enabledAccountIds,
       },
       opportunities: {
         ...initialState,

--- a/src/state/slices/portfolioSlice/__snapshots__/portfolioSlice.test.ts.snap
+++ b/src/state/slices/portfolioSlice/__snapshots__/portfolioSlice.test.ts.snap
@@ -29,7 +29,9 @@ exports[`portfolioSlice > reducers > upsertPortfolio > Bitcoin > should update s
       "bip122:000000000019d6689c085ae165831e93:zpub6qk8s2NQsYG6X2Mm6iU2ii3yTAqDb2XqnMu9vo2WjvqwjSvjjiYQQveYXbPxrnRT5Yb5p0x934be745172066EDF795ffc5EA9F28f19b440c637BaBw1wowPwbS8fj7uCfj3UhqhD2LLbvY6Ni1w",
     ],
   },
-  "hiddenAccountIds": [],
+  "enabledAccountIds": [
+    "bip122:000000000019d6689c085ae165831e93:zpub6qk8s2NQsYG6X2Mm6iU2ii3yTAqDb2XqnMu9vo2WjvqwjSvjjiYQQveYXbPxrnRT5Yb5p0x934be745172066EDF795ffc5EA9F28f19b440c637BaBw1wowPwbS8fj7uCfj3UhqhD2LLbvY6Ni1w"
+  ],
   "wallet": {
     "byId": {},
     "ids": [],
@@ -77,7 +79,10 @@ exports[`portfolioSlice > reducers > upsertPortfolio > Bitcoin > should update s
       "bip122:000000000019d6689c085ae165831e93:xpub6qk8s2NQsYG6X2Mm6iU2ii3yTAqDb2XqnMu9vo2WjvqwjSvjjiYQQveYXbPxrnRT5Yb5p0x934be745172066EDF795ffc5EA9F28f19b440c637BaBw1wowPwbS8fj7uCfj3UhqhD2LLbvY6Ni1w",
     ],
   },
-  "hiddenAccountIds": [],
+  "enabledAccountIds": [
+    "bip122:000000000019d6689c085ae165831e93:zpub6qk8s2NQsYG6X2Mm6iU2ii3yTAqDb2XqnMu9vo2WjvqwjSvjjiYQQveYXbPxrnRT5Yb5p0x934be745172066EDF795ffc5EA9F28f19b440c637BaBw1wowPwbS8fj7uCfj3UhqhD2LLbvY6Ni1w",
+    "bip122:000000000019d6689c085ae165831e93:xpub6qk8s2NQsYG6X2Mm6iU2ii3yTAqDb2XqnMu9vo2WjvqwjSvjjiYQQveYXbPxrnRT5Yb5p0x934be745172066EDF795ffc5EA9F28f19b440c637BaBw1wowPwbS8fj7uCfj3UhqhD2LLbvY6Ni1w",
+  ],
   "wallet": {
     "byId": {},
     "ids": [],
@@ -148,7 +153,11 @@ exports[`portfolioSlice > reducers > upsertPortfolio > Ethereum and bitcoin > sh
       "bip122:000000000019d6689c085ae165831e93:zpub6qk8s2NQsYG6X2Mm6iU2ii3yTAqDb2XqnMu9vo2WjvqwjSvjjiYQQveYXbPxrnRT5Yb5p0x934be745172066EDF795ffc5EA9F28f19b440c637BaBw1wowPwbS8fj7uCfj3UhqhD2LLbvY6Ni1w",
     ],
   },
-  "hiddenAccountIds": [],
+  "enabledAccountIds": [
+    "eip155:1:0x9a2d593725045d1727d525dd07a396f9ff079bb1",
+    "eip155:1:0xea674fdde714fd979de3edf0f56aa9716b898ec8",
+    "bip122:000000000019d6689c085ae165831e93:zpub6qk8s2NQsYG6X2Mm6iU2ii3yTAqDb2XqnMu9vo2WjvqwjSvjjiYQQveYXbPxrnRT5Yb5p0x934be745172066EDF795ffc5EA9F28f19b440c637BaBw1wowPwbS8fj7uCfj3UhqhD2LLbvY6Ni1w",
+  ],
   "wallet": {
     "byId": {},
     "ids": [],
@@ -204,7 +213,10 @@ exports[`portfolioSlice > reducers > upsertPortfolio > Ethereum and bitcoin > sh
       "bip122:000000000019d6689c085ae165831e93:zpub6qk8s2NQsYG6X2Mm6iU2ii3yTAqDb2XqnMu9vo2WjvqwjSvjjiYQQveYXbPxrnRT5Yb5p0x934be745172066EDF795ffc5EA9F28f19b440c637BaBw1wowPwbS8fj7uCfj3UhqhD2LLbvY6Ni1w",
     ],
   },
-  "hiddenAccountIds": [],
+  "enabledAccountIds": [
+    "eip155:1:0x6c8a778ef52e121b7dff1154c553662306a970e9",
+    "bip122:000000000019d6689c085ae165831e93:zpub6qk8s2NQsYG6X2Mm6iU2ii3yTAqDb2XqnMu9vo2WjvqwjSvjjiYQQveYXbPxrnRT5Yb5p0x934be745172066EDF795ffc5EA9F28f19b440c637BaBw1wowPwbS8fj7uCfj3UhqhD2LLbvY6Ni1w",
+  ],
   "wallet": {
     "byId": {},
     "ids": [],
@@ -243,7 +255,9 @@ exports[`portfolioSlice > reducers > upsertPortfolio > ethereum > should update 
       "eip155:1:0x9a2d593725045d1727d525dd07a396f9ff079bb1",
     ],
   },
-  "hiddenAccountIds": [],
+  "enabledAccountIds": [
+    "eip155:1:0x9a2d593725045d1727d525dd07a396f9ff079bb1",
+  ],
   "wallet": {
     "byId": {},
     "ids": [],
@@ -295,7 +309,10 @@ exports[`portfolioSlice > reducers > upsertPortfolio > ethereum > should update 
       "eip155:1:0xea674fdde714fd979de3edf0f56aa9716b898ec8",
     ],
   },
-  "hiddenAccountIds": [],
+  "enabledAccountIds": [
+    "eip155:1:0x9a2d593725045d1727d525dd07a396f9ff079bb1",
+    "eip155:1:0xea674fdde714fd979de3edf0f56aa9716b898ec8",
+  ],
   "wallet": {
     "byId": {},
     "ids": [],

--- a/src/state/slices/portfolioSlice/__snapshots__/portfolioSlice.test.ts.snap
+++ b/src/state/slices/portfolioSlice/__snapshots__/portfolioSlice.test.ts.snap
@@ -30,7 +30,7 @@ exports[`portfolioSlice > reducers > upsertPortfolio > Bitcoin > should update s
     ],
   },
   "enabledAccountIds": [
-    "bip122:000000000019d6689c085ae165831e93:zpub6qk8s2NQsYG6X2Mm6iU2ii3yTAqDb2XqnMu9vo2WjvqwjSvjjiYQQveYXbPxrnRT5Yb5p0x934be745172066EDF795ffc5EA9F28f19b440c637BaBw1wowPwbS8fj7uCfj3UhqhD2LLbvY6Ni1w"
+    "bip122:000000000019d6689c085ae165831e93:zpub6qk8s2NQsYG6X2Mm6iU2ii3yTAqDb2XqnMu9vo2WjvqwjSvjjiYQQveYXbPxrnRT5Yb5p0x934be745172066EDF795ffc5EA9F28f19b440c637BaBw1wowPwbS8fj7uCfj3UhqhD2LLbvY6Ni1w",
   ],
   "wallet": {
     "byId": {},

--- a/src/state/slices/portfolioSlice/portfolioSlice.test.ts
+++ b/src/state/slices/portfolioSlice/portfolioSlice.test.ts
@@ -63,9 +63,11 @@ describe('portfolioSlice', () => {
             },
           })
 
-          store.dispatch(
-            portfolioSlice.actions.upsertPortfolio(mockUpsertPortfolio([ethAccount], assetIds)),
-          )
+          const portfolio = mockUpsertPortfolio([ethAccount], assetIds)
+          store.dispatch(portfolioSlice.actions.upsertPortfolio(portfolio))
+          for (const accountId of portfolio.accounts.ids) {
+            store.dispatch(portfolioSlice.actions.enableAccountId(accountId))
+          }
 
           expect(store.getState().portfolio).toMatchSnapshot()
         })
@@ -88,11 +90,11 @@ describe('portfolioSlice', () => {
             },
           })
 
-          store.dispatch(
-            portfolioSlice.actions.upsertPortfolio(
-              mockUpsertPortfolio([ethAccount, ethAccount2], assetIds),
-            ),
-          )
+          const portfolio = mockUpsertPortfolio([ethAccount, ethAccount2], assetIds)
+          store.dispatch(portfolioSlice.actions.upsertPortfolio(portfolio))
+          for (const accountId of portfolio.accounts.ids) {
+            store.dispatch(portfolioSlice.actions.enableAccountId(accountId))
+          }
 
           expect(store.getState().portfolio).toMatchSnapshot()
         })
@@ -107,9 +109,11 @@ describe('portfolioSlice', () => {
             },
           })
 
-          store.dispatch(
-            portfolioSlice.actions.upsertPortfolio(mockUpsertPortfolio([btcAccount], assetIds)),
-          )
+          const portfolio = mockUpsertPortfolio([btcAccount], assetIds)
+          store.dispatch(portfolioSlice.actions.upsertPortfolio(portfolio))
+          for (const accountId of portfolio.accounts.ids) {
+            store.dispatch(portfolioSlice.actions.enableAccountId(accountId))
+          }
 
           expect(store.getState().portfolio).toMatchSnapshot()
         })
@@ -129,11 +133,11 @@ describe('portfolioSlice', () => {
             },
           })
 
-          store.dispatch(
-            portfolioSlice.actions.upsertPortfolio(
-              mockUpsertPortfolio([btcAccount, btcAccount2], assetIds),
-            ),
-          )
+          const portfolio = mockUpsertPortfolio([btcAccount, btcAccount2], assetIds)
+          store.dispatch(portfolioSlice.actions.upsertPortfolio(portfolio))
+          for (const accountId of portfolio.accounts.ids) {
+            store.dispatch(portfolioSlice.actions.enableAccountId(accountId))
+          }
 
           expect(store.getState().portfolio).toMatchSnapshot()
         })
@@ -180,11 +184,11 @@ describe('portfolioSlice', () => {
             },
           })
 
-          store.dispatch(
-            portfolioSlice.actions.upsertPortfolio(
-              mockUpsertPortfolio([ethAccount, ethAccount2, btcAccount], assetIds),
-            ),
-          )
+          const portfolio = mockUpsertPortfolio([ethAccount, ethAccount2, btcAccount], assetIds)
+          store.dispatch(portfolioSlice.actions.upsertPortfolio(portfolio))
+          for (const accountId of portfolio.accounts.ids) {
+            store.dispatch(portfolioSlice.actions.enableAccountId(accountId))
+          }
 
           expect(store.getState().portfolio).toMatchSnapshot()
         })
@@ -221,11 +225,11 @@ describe('portfolioSlice', () => {
             },
           })
 
-          store.dispatch(
-            portfolioSlice.actions.upsertPortfolio(
-              mockUpsertPortfolio([ethAccount, btcAccount], assetIds),
-            ),
-          )
+          const portfolio = mockUpsertPortfolio([ethAccount, btcAccount], assetIds)
+          store.dispatch(portfolioSlice.actions.upsertPortfolio(portfolio))
+          for (const accountId of portfolio.accounts.ids) {
+            store.dispatch(portfolioSlice.actions.enableAccountId(accountId))
+          }
 
           expect(store.getState().portfolio).toMatchSnapshot()
         })
@@ -258,11 +262,11 @@ describe('portfolioSlice', () => {
         )
 
         // dispatch portfolio data
-        store.dispatch(
-          portfolioSlice.actions.upsertPortfolio(
-            mockUpsertPortfolio([ethAccount, ethAccount2, btcAccount], assetIds),
-          ),
-        )
+        const portfolio = mockUpsertPortfolio([ethAccount, ethAccount2, btcAccount], assetIds)
+        store.dispatch(portfolioSlice.actions.upsertPortfolio(portfolio))
+        for (const accountId of portfolio.accounts.ids) {
+          store.dispatch(portfolioSlice.actions.enableAccountId(accountId))
+        }
 
         const ethMarketData = mockMarketData()
         const foxMarketData = mockMarketData({ price: '1' })
@@ -311,11 +315,12 @@ describe('portfolioSlice', () => {
         )
 
         // dispatch portfolio data
-        store.dispatch(
-          portfolioSlice.actions.upsertPortfolio(
-            mockUpsertPortfolio([ethAccount, ethAccount2, btcAccount], assetIds),
-          ),
-        )
+        const portfolio = mockUpsertPortfolio([ethAccount, ethAccount2, btcAccount], assetIds)
+        store.dispatch(portfolioSlice.actions.upsertPortfolio(portfolio))
+        for (const accountId of portfolio.accounts.ids) {
+          store.dispatch(portfolioSlice.actions.enableAccountId(accountId))
+        }
+
         const ethMarketData = mockMarketData({ price: null })
         const foxMarketData = mockMarketData({ price: null })
 
@@ -365,11 +370,11 @@ describe('portfolioSlice', () => {
       )
 
       // dispatch portfolio data
-      store.dispatch(
-        portfolioSlice.actions.upsertPortfolio(
-          mockUpsertPortfolio([ethAccount, ethAccount2], assetIds),
-        ),
-      )
+      const portfolio = mockUpsertPortfolio([ethAccount, ethAccount2], assetIds)
+      store.dispatch(portfolioSlice.actions.upsertPortfolio(portfolio))
+      for (const accountId of portfolio.accounts.ids) {
+        store.dispatch(portfolioSlice.actions.enableAccountId(accountId))
+      }
 
       it('can select crypto fiat account balance', () => {
         // dispatch market data
@@ -450,11 +455,11 @@ describe('portfolioSlice', () => {
       )
 
       // dispatch portfolio data
-      store.dispatch(
-        portfolioSlice.actions.upsertPortfolio(
-          mockUpsertPortfolio([btcAccount, btcAccount2, btcAccount3], assetIds),
-        ),
-      )
+      const portfolio = mockUpsertPortfolio([btcAccount, btcAccount2, btcAccount3], assetIds)
+      store.dispatch(portfolioSlice.actions.upsertPortfolio(portfolio))
+      for (const accountId of portfolio.accounts.ids) {
+        store.dispatch(portfolioSlice.actions.enableAccountId(accountId))
+      }
 
       // dispatch market data
       const btcMarketData = mockMarketData({ price: '10000' })
@@ -495,11 +500,11 @@ describe('portfolioSlice', () => {
         }),
       )
       // dispatch portfolio data
-      store.dispatch(
-        portfolioSlice.actions.upsertPortfolio(
-          mockUpsertPortfolio([ethAccount, ethAccount2], assetIds),
-        ),
-      )
+      const portfolio = mockUpsertPortfolio([ethAccount, ethAccount2], assetIds)
+      store.dispatch(portfolioSlice.actions.upsertPortfolio(portfolio))
+      for (const accountId of portfolio.accounts.ids) {
+        store.dispatch(portfolioSlice.actions.enableAccountId(accountId))
+      }
 
       store.dispatch(
         portfolioSlice.actions.upsertAccountMetadata({
@@ -574,11 +579,11 @@ describe('portfolioSlice', () => {
       )
 
       // dispatch portfolio data
-      store.dispatch(
-        portfolioSlice.actions.upsertPortfolio(
-          mockUpsertPortfolio([ethAccount, ethAccount2], assetIds),
-        ),
-      )
+      const portfolio = mockUpsertPortfolio([ethAccount, ethAccount2], assetIds)
+      store.dispatch(portfolioSlice.actions.upsertPortfolio(portfolio))
+      for (const accountId of portfolio.accounts.ids) {
+        store.dispatch(portfolioSlice.actions.enableAccountId(accountId))
+      }
 
       // dispatch market data
       const ethMarketData = mockMarketData({ price: '1000' })
@@ -646,11 +651,11 @@ describe('portfolioSlice', () => {
       )
 
       // dispatch portfolio data
-      store.dispatch(
-        portfolioSlice.actions.upsertPortfolio(
-          mockUpsertPortfolio([ethAccount, ethAccount2], assetIds),
-        ),
-      )
+      const portfolio = mockUpsertPortfolio([ethAccount, ethAccount2], assetIds)
+      store.dispatch(portfolioSlice.actions.upsertPortfolio(portfolio))
+      for (const accountId of portfolio.accounts.ids) {
+        store.dispatch(portfolioSlice.actions.enableAccountId(accountId))
+      }
 
       // dispatch market data
       const ethMarketData = mockMarketData({ price: '1000' })
@@ -697,9 +702,11 @@ describe('portfolioSlice', () => {
       })
 
       // dispatch portfolio data
-      store.dispatch(
-        portfolioSlice.actions.upsertPortfolio(mockUpsertPortfolio([ethAccount], assetIds)),
-      )
+      const portfolio = mockUpsertPortfolio([ethAccount], assetIds)
+      store.dispatch(portfolioSlice.actions.upsertPortfolio(portfolio))
+      for (const accountId of portfolio.accounts.ids) {
+        store.dispatch(portfolioSlice.actions.enableAccountId(accountId))
+      }
 
       // dispatch market data
       const ethMarketData = mockMarketData({ price: '1000' })

--- a/src/state/slices/portfolioSlice/portfolioSlice.ts
+++ b/src/state/slices/portfolioSlice/portfolioSlice.ts
@@ -137,19 +137,17 @@ export const portfolio = createSlice({
       // add the `action.meta[SHOULD_AUTOBATCH]` field the enhancer needs
       prepare: prepareAutoBatched<Portfolio>(),
     },
-    toggleAccountIdHidden: (draftState, { payload: accountId }: { payload: AccountId }) => {
-      const hiddenAccountIdsSet = new Set(draftState.hiddenAccountIds)
-      const isHidden = hiddenAccountIdsSet.has(accountId)
+    toggleAccountIdEnabled: (draftState, { payload: accountId }: { payload: AccountId }) => {
+      const enabledAccountIdsSet = new Set(draftState.enabledAccountIds)
+      const isEnabled = enabledAccountIdsSet.has(accountId)
 
-      console.log(`toggling ${accountId}, isHidden: ${isHidden}`)
-
-      if (!isHidden) {
-        hiddenAccountIdsSet.add(accountId)
+      if (isEnabled) {
+        enabledAccountIdsSet.delete(accountId)
       } else {
-        hiddenAccountIdsSet.delete(accountId)
+        enabledAccountIdsSet.add(accountId)
       }
 
-      draftState.hiddenAccountIds = Array.from(hiddenAccountIdsSet)
+      draftState.enabledAccountIds = Array.from(enabledAccountIdsSet)
     },
   },
   extraReducers: builder => builder.addCase(PURGE, () => initialState),

--- a/src/state/slices/portfolioSlice/portfolioSlice.ts
+++ b/src/state/slices/portfolioSlice/portfolioSlice.ts
@@ -141,6 +141,8 @@ export const portfolio = createSlice({
       const hiddenAccountIdsSet = new Set(draftState.hiddenAccountIds)
       const isHidden = hiddenAccountIdsSet.has(accountId)
 
+      console.log(`toggling ${accountId}, isHidden: ${isHidden}`)
+
       if (!isHidden) {
         hiddenAccountIdsSet.add(accountId)
       } else {

--- a/src/state/slices/portfolioSlice/portfolioSlice.ts
+++ b/src/state/slices/portfolioSlice/portfolioSlice.ts
@@ -137,6 +137,15 @@ export const portfolio = createSlice({
       // add the `action.meta[SHOULD_AUTOBATCH]` field the enhancer needs
       prepare: prepareAutoBatched<Portfolio>(),
     },
+    /**
+     * Explicitly enable an account by its `AccountId`. Necessary where `use-strict` toggles twice
+     * during initial load, leading to all auto-detected accounts being disabled.
+     */
+    enableAccountId: (draftState, { payload: accountId }: { payload: AccountId }) => {
+      const enabledAccountIdsSet = new Set(draftState.enabledAccountIds)
+      enabledAccountIdsSet.add(accountId)
+      draftState.enabledAccountIds = Array.from(enabledAccountIdsSet)
+    },
     toggleAccountIdEnabled: (draftState, { payload: accountId }: { payload: AccountId }) => {
       const enabledAccountIdsSet = new Set(draftState.enabledAccountIds)
       const isEnabled = enabledAccountIdsSet.has(accountId)

--- a/src/state/slices/portfolioSlice/portfolioSliceCommon.ts
+++ b/src/state/slices/portfolioSlice/portfolioSliceCommon.ts
@@ -61,10 +61,10 @@ export type Portfolio = {
   accounts: PortfolioAccounts
   accountBalances: PortfolioAccountBalances
   /**
-   * The `AccountId[]` that are disabled. Rather than removing the accounts and adding complexity
-   * to the actions and state management, we disable them here and filter them out in the selectors.
+   * The `AccountId[]` that are enabled. Rather than removing the accounts and adding complexity
+   * to the actions and state management, we enable them here and filter them out in the selectors.
    */
-  hiddenAccountIds: AccountId[]
+  enabledAccountIds: AccountId[]
   /**
    * 1:many mapping of a unique wallet id -> multiple account ids
    */
@@ -85,7 +85,7 @@ export const initialState: Portfolio = {
     byId: {},
     ids: [],
   },
-  hiddenAccountIds: [],
+  enabledAccountIds: [],
   wallet: {
     byId: {},
     ids: [],

--- a/src/state/slices/portfolioSlice/selectors.ts
+++ b/src/state/slices/portfolioSlice/selectors.ts
@@ -89,24 +89,6 @@ export const selectPortfolioAccounts = createDeepEqualOutputSelector(
   },
 )
 
-/**
- * Returns a boolean indicating if the account is exists in the store. Bypasses `hiddenAccountIds`.
- * This is used to determine whether or not to toggle the account during import, since we should
- * not toggle the account when it's first imported.
- */
-export const selectAccountIdExistsInStore = createCachedSelector(
-  selectWalletId,
-  (state: ReduxState) => state.portfolio.wallet.byId,
-  selectAccountIdParamFromFilter,
-  (walletId, unfilteredAccountsById, accountIdParam): boolean => {
-    return Boolean(
-      walletId !== undefined &&
-        accountIdParam !== undefined &&
-        unfilteredAccountsById[walletId]?.some(accountId => accountId === accountIdParam),
-    )
-  },
-)((_s: ReduxState, filter) => filter?.accountId ?? 'accountId')
-
 export const selectIsAccountIdEnabled = createCachedSelector(
   selectPortfolioAccounts,
   selectAccountIdParamFromFilter,

--- a/src/state/slices/portfolioSlice/selectors.ts
+++ b/src/state/slices/portfolioSlice/selectors.ts
@@ -89,6 +89,24 @@ export const selectPortfolioAccounts = createDeepEqualOutputSelector(
   },
 )
 
+/**
+ * Returns a boolean indicating if the account is exists in the store. Bypasses `hiddenAccountIds`.
+ * This is used to determine whether or not to toggle the account during import, since we should
+ * not toggle the account when it's first imported.
+ */
+export const selectAccountIdExistsInStore = createCachedSelector(
+  selectWalletId,
+  (state: ReduxState) => state.portfolio.wallet.byId,
+  selectAccountIdParamFromFilter,
+  (walletId, unfilteredAccountsById, accountIdParam): boolean => {
+    return Boolean(
+      walletId !== undefined &&
+        accountIdParam !== undefined &&
+        unfilteredAccountsById[walletId]?.some(accountId => accountId === accountIdParam),
+    )
+  },
+)((_s: ReduxState, filter) => filter?.accountId ?? 'accountId')
+
 export const selectIsAccountIdEnabled = createCachedSelector(
   selectPortfolioAccounts,
   selectAccountIdParamFromFilter,

--- a/src/test/mocks/store.ts
+++ b/src/test/mocks/store.ts
@@ -55,7 +55,7 @@ export const mockStore: ReduxState = {
       byId: {},
       ids: [],
     },
-    hiddenAccountIds: [],
+    enabledAccountIds: [],
     wallet: {
       byId: {},
       ids: [],


### PR DESCRIPTION
## Description

This PR includes the following changes:
1. Fixes issue where importing an account via account management requires 2 attempts in order for the new account to persist in redux.
2. A simplification of state management where we track `enabledAccountIds` rather than `hiddenAccountIds`, negating the need to check the existence of an account in state management before fetching it and toggling it (which created a race condition).
3. Improved handling of no accounts yet connected in the UI (see screenshots below)

Not included known issues to be followed up on:
* loading state during initial wallet connection briefly shows empty "add a chain to get started" 
* loading state of import accounts drawer borked, which is already raised in upstream PR and will be resolved
* loading state when clicking "done" does not exist yet

## Pull Request Type

- [x] :bug: Bug fix (Non-breaking Change: Fixes an issue)
- [ ] :hammer_and_wrench: Chore (Non-breaking Change: Doc updates, pkg upgrades, typos, etc..)
- [ ] :nail_care: New Feature (Breaking/Non-breaking Change)

## Issue (if applicable)

closes #6818

## Risk
> High Risk PRs Require 2 approvals

High risk as it changes state management of portfolio and the logic of initial load of portfolio data.

> What protocols, transaction types or contract interactions might be affected by this PR?

## Testing

Check loading app from `previous session` and then `empty cache` both load portfolio as intended. Should be no functional change from prod.

Check importing an account doesn't require 2 attempts for your selection to persist in the account management drawer (see linked issue for video demonstrating the original issue)

### Engineering

<!-----------------------------------------------------------------------------
Include sufficient information here for an engineer to test your PR. This may include how to test locally, in a built environment, changes to infrastructure etc.
------------------------------------------------------------------------------>

### Operations

<!-----------------------------------------------------------------------------
If your changes have a user-facing impact, describe how a non-technical QA team can functionally test your changes in a preview environment.

If they are not user-facing please describe how to test for any regressions that may occur.
------------------------------------------------------------------------------>

## Screenshots (if applicable)

No accounts connected have improved UI:
![image](https://github.com/shapeshift/web/assets/125113430/cbb0580d-8d23-4efc-8155-ea6c33688600)

Accounts added show the same UI as previously:
![image](https://github.com/shapeshift/web/assets/125113430/f2c02c6f-8fdc-4ff7-a0c0-ec1a7dfde35e)

Demo of account import persisting with first attempt:

https://github.com/shapeshift/web/assets/125113430/62f779fe-38d9-4c7f-b04f-aa6629640451


