### PR TITLE
fix: close sidenav drawer when sub menu item clicked

### DIFF
--- a/src/components/Layout/Header/NavBar/Native/NativeMenu.tsx
+++ b/src/components/Layout/Header/NavBar/Native/NativeMenu.tsx
@@ -1,6 +1,6 @@
 import { ChevronRightIcon, EditIcon } from '@chakra-ui/icons'
 import { Button, MenuDivider, MenuItem } from '@chakra-ui/react'
-import { useCallback } from 'react'
+import React, { useCallback } from 'react'
 import { useTranslate } from 'react-polyglot'
 import { Text } from 'components/Text'
 import { useFeatureFlag } from 'hooks/useFeatureFlag/useFeatureFlag'
@@ -8,23 +8,26 @@ import { useModal } from 'hooks/useModal/useModal'
 
 const chevronRightIcon = <ChevronRightIcon />
 const editIcon = <EditIcon />
+type NativeMenuProps = {
+  onClose?: () => void
+}
 
-export const NativeMenu = () => {
+export const NativeMenu: React.FC<NativeMenuProps> = ({ onClose }) => {
   const translate = useTranslate()
   const isAccountManagementEnabled = useFeatureFlag('AccountManagement')
 
   const backupNativePassphrase = useModal('backupNativePassphrase')
   const accountManagementPopover = useModal('manageAccounts')
 
-  const handleBackupMenuItemClick = useCallback(
-    () => backupNativePassphrase.open({}),
-    [backupNativePassphrase],
-  )
+  const handleBackupMenuItemClick = useCallback(() => {
+    onClose && onClose()
+    backupNativePassphrase.open({})
+  }, [backupNativePassphrase, onClose])
 
-  const handleManageAccountsMenuItemClick = useCallback(
-    () => accountManagementPopover.open({}),
-    [accountManagementPopover],
-  )
+  const handleManageAccountsMenuItemClick = useCallback(() => {
+    onClose && onClose()
+    accountManagementPopover.open({})
+  }, [accountManagementPopover, onClose])
 
   return (
     <>

--- a/src/components/Layout/Header/NavBar/UserMenu.tsx
+++ b/src/components/Layout/Header/NavBar/UserMenu.tsx
@@ -49,6 +49,7 @@ const NoWallet = ({ onClick }: { onClick: () => void }) => {
 export type WalletConnectedProps = {
   onDisconnect: () => void
   onSwitchProvider: () => void
+  onClose?: () => void
 } & Pick<InitialState, 'walletInfo' | 'isConnected' | 'connectedType'>
 
 export const WalletConnected = (props: WalletConnectedProps) => {
@@ -60,6 +61,7 @@ export const WalletConnected = (props: WalletConnectedProps) => {
         onDisconnect={props.onDisconnect}
         onSwitchProvider={props.onSwitchProvider}
         connectedType={props.connectedType}
+        onClose={props.onClose}
       />
     </MemoryRouter>
   )
@@ -191,6 +193,7 @@ export const UserMenu: React.FC<{ onClick?: () => void }> = memo(({ onClick }) =
                 onDisconnect={disconnect}
                 onSwitchProvider={handleConnect}
                 connectedType={connectedType}
+                onClose={onClick}
               />
             ) : (
               <NoWallet onClick={handleConnect} />

--- a/src/components/Layout/Header/NavBar/WalletConnectedMenu.tsx
+++ b/src/components/Layout/Header/NavBar/WalletConnectedMenu.tsx
@@ -27,6 +27,7 @@ const ConnectedMenu = memo(
     walletInfo,
     onDisconnect,
     onSwitchProvider,
+    onClose,
   }: WalletConnectedProps & {
     connectedWalletMenuRoutes: boolean
   }) => {
@@ -74,7 +75,7 @@ const ConnectedMenu = memo(
               {translate('connectWallet.menu.connecting')}
             </MenuItem>
           )}
-          {ConnectMenuComponent && <ConnectMenuComponent />}
+          {ConnectMenuComponent && <ConnectMenuComponent onClose={onClose} />}
           <MenuDivider />
           <MenuItem icon={repeatIcon} onClick={onSwitchProvider}>
             {translate('connectWallet.menu.switchWallet')}
@@ -94,6 +95,7 @@ export const WalletConnectedMenu = ({
   walletInfo,
   isConnected,
   connectedType,
+  onClose,
 }: WalletConnectedProps) => {
   const location = useLocation()
 
@@ -128,6 +130,7 @@ export const WalletConnectedMenu = ({
               walletInfo={walletInfo}
               onDisconnect={onDisconnect}
               onSwitchProvider={onSwitchProvider}
+              onClose={onClose}
             />
           </SubMenuContainer>
         </Route>


### PR DESCRIPTION
## Description

- When you opened a sub menu item the drawer would not collapse on native wallets
- This adds the onClose callback to the nested menu items

## Pull Request Type

- [x] :bug: Bug fix (Non-breaking Change: Fixes an issue)
- [ ] :hammer_and_wrench: Chore (Non-breaking Change: Doc updates, pkg upgrades, typos, etc..)
- [ ] :nail_care: New Feature (Breaking/Non-breaking Change)

## Issue (if applicable)

<!-----------------------------------------------------------------------------
If applicable, please link to the github issue and put `closes #XXXX` in your comment to auto-close the issue that your PR fixes.
------------------------------------------------------------------------------>

closes #6617 

## Risk
> High Risk PRs Require 2 approvals

<!-----------------------------------------------------------------------------
Outline the scope of your changes and the risk associated with them. You must use your discretion as an engineer to determine the potential impact of your changes.

WARNING: If your PR introduces a new on-chain transaction or modifies an existing one, please add the "High-Risk" label to this PR and ask for 2 reviewers to approve it before merging.

E.g. an upgrade to `hdwallet` or core state management would be considered higher risk, and might require a full regression test. UI or isolated view changes, or something behind a feature flag may have near zero risk. Small bug fixes might require testing isolated to the specific fix.
------------------------------------------------------------------------------>
mild

> What protocols, transaction types or contract interactions might be affected by this PR?

## Testing

<!-----------------------------------------------------------------------------
We treat every PR to be merged with the same scrutiny as if we were merging directly to production.

Your PR will not be merged if you do not complete the sections below for our engineering and operations teams to test.
------------------------------------------------------------------------------>

### Engineering

<!-----------------------------------------------------------------------------
Include sufficient information here for an engineer to test your PR. This may include how to test locally, in a built environment, changes to infrastructure etc.
------------------------------------------------------------------------------>

### Operations

<!-----------------------------------------------------------------------------
If your changes have a user-facing impact, describe how a non-technical QA team can functionally test your changes in a preview environment.

If they are not user-facing please describe how to test for any regressions that may occur.
------------------------------------------------------------------------------>
When on mobile, open the drawer and expand the wallet dropdown. 
Select the backup my wallet
Enter password
You should be able to scroll the modal vertically to see the buttons and your full seed phrase.

## Screenshots (if applicable)
