### PR TITLE
fix: display thorchain and cosmos account label as the shortened address

### DIFF
--- a/src/state/slices/portfolioSlice/utils.ts
+++ b/src/state/slices/portfolioSlice/utils.ts
@@ -66,7 +66,8 @@ export const accountIdToLabel = (accountId: AccountId): string => {
     case bscChainId:
     case arbitrumChainId:
     case arbitrumNovaChainId:
-      // this will be the 0x account
+    case thorchainChainId:
+    case cosmosChainId:
       return firstFourLastFour(pubkey)
     case btcChainId:
       // TODO(0xdef1cafe): translations
@@ -76,10 +77,6 @@ export const accountIdToLabel = (accountId: AccountId): string => {
       return ''
     case bchChainId:
       return 'Bitcoin Cash'
-    case cosmosChainId:
-      return 'Cosmos'
-    case thorchainChainId:
-      return 'Thorchain'
     case dogeChainId:
       return 'Dogecoin'
     case ltcChainId:


### PR DESCRIPTION
## Description

Updates the account label for cosmos and thorchain accounts to be the shortened "first four, last four" address, as is done with EVMs. This change was triggered by #6837 and expanded to be app-wide since it has actual utility UX-wise (see screenshots)

## Pull Request Type

- [x] :bug: Bug fix (Non-breaking Change: Fixes an issue)
- [ ] :hammer_and_wrench: Chore (Non-breaking Change: Doc updates, pkg upgrades, typos, etc..)
- [ ] :nail_care: New Feature (Breaking/Non-breaking Change)

## Issue (if applicable)

closes #6837

## Risk
> High Risk PRs Require 2 approvals

Low risk, only related to account labels which are presumably already wired up correctly.

> What protocols, transaction types or contract interactions might be affected by this PR?

## Testing

Check account labels around the app are correct and that displaying thorchain and cosmos account labels as a shortened address makes sense. So far all known occurrences or thorchain and cosmos account labels DO make sense to be displayed as an address (see screenshots).

### Engineering

<!-----------------------------------------------------------------------------
Include sufficient information here for an engineer to test your PR. This may include how to test locally, in a built environment, changes to infrastructure etc.
------------------------------------------------------------------------------>

### Operations

<!-----------------------------------------------------------------------------
If your changes have a user-facing impact, describe how a non-technical QA team can functionally test your changes in a preview environment.

If they are not user-facing please describe how to test for any regressions that may occur.
------------------------------------------------------------------------------>

## Screenshots (if applicable)

Import accounts, borked account label:

<img src="https://github.com/shapeshift/web/assets/125113430/8649ea54-dd15-4ac9-a371-897823c9ee40" width="400">

Updated to behave like single-address accounts (EVMs):

<img src="https://github.com/shapeshift/web/assets/125113430/02319191-5e16-4f39-b515-aad6703baae0" width="400">

---

Account selection in swapper, prod:

<img src="https://github.com/shapeshift/web/assets/125113430/4199af69-1ec8-4803-a4a1-81689638c1e3" width="400">

Updated to behave like single-address accounts (EVMs):

<img src="https://github.com/shapeshift/web/assets/125113430/18b93816-cee5-42c0-b79c-492321b066b2" width="400">

---

EVM accounts have address in back button:

<img src="https://github.com/shapeshift/web/assets/125113430/2d0b35f0-cf39-4835-b5a7-873b38914ec7" width="400">

Thorchain / Cosmos do not:

<img src="https://github.com/shapeshift/web/assets/125113430/9906343d-6774-412b-828e-6a831d2f5c9d" width="400">

Fixed:

<img src="https://github.com/shapeshift/web/assets/125113430/7e2dbed0-b7e9-4d15-84bc-7d4583a2c774" width="400">
