### PR TITLE
fix: undefined hiddenAccountIds on init

### DIFF
--- a/src/state/slices/common-selectors.ts
+++ b/src/state/slices/common-selectors.ts
@@ -29,7 +29,7 @@ export const selectWalletAccountIds = createDeepEqualOutputSelector(
   (state: ReduxState) => state.portfolio.hiddenAccountIds,
   (walletId, walletById, hiddenAccountIds): AccountId[] => {
     const walletAccountIds = (walletId && walletById[walletId]) ?? []
-    return walletAccountIds.filter(accountId => !hiddenAccountIds.includes(accountId))
+    return walletAccountIds.filter(accountId => !(hiddenAccountIds ?? []).includes(accountId))
   },
 )
 


### PR DESCRIPTION
## Description

Fix `undefined` `hiddenAccountIds` on app load, which is crashing the app.

<img width="1224" alt="Screenshot 2024-05-07 at 1 20 51 PM" src="https://github.com/shapeshift/web/assets/97164662/be771b44-74ed-4cd6-8d89-82126fba8133">

<img width="1167" alt="Screenshot 2024-05-07 at 1 11 51 PM" src="https://github.com/shapeshift/web/assets/97164662/5e7bfada-99ac-4d40-9bd8-264b7bb6988e">

## Pull Request Type

- [x] :bug: Bug fix (Non-breaking Change: Fixes an issue)
- [ ] :hammer_and_wrench: Chore (Non-breaking Change: Doc updates, pkg upgrades, typos, etc..)
- [ ] :nail_care: New Feature (Breaking/Non-breaking Change)

## Issue (if applicable)

N/A - currently in `develop`, which presents when the account management feature flag is on.

## Risk
> High Risk PRs Require 2 approvals

Small

> What protocols, transaction types or contract interactions might be affected by this PR?

N/A

## Testing

Loading the app with the account management feature flag on should be great again.

### Engineering

☝️

### Operations

☝️

## Screenshots (if applicable)

See description.