### PR TITLE
chore: release v1.590.0

### DIFF
--- a/.github/workflows/sentry.yml
+++ b/.github/workflows/sentry.yml
@@ -8,7 +8,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Checkout release
-      - uses: actions/checkout@v3
+        uses: actions/checkout@v3
         with: 
           ref: release
       - name: Sentry Release

--- a/src/assets/translations/en/main.json
+++ b/src/assets/translations/en/main.json
@@ -1794,7 +1794,9 @@
     "manageAccounts": {
       "title": "Manage Accounts",
       "description": "These are the chains you have connected and the number of accounts you have imported.",
-      "addChain": "Add another chain"
+      "emptyList": "You have no accounts connected yet. Add a chain to get started.",
+      "addChain": "Add a chain",
+      "addAnotherChain": "Add another chain"
     },
     "selectChain": {
       "title": "Select Chain",

--- a/src/components/Layout/Header/NavBar/Native/NativeMenu.tsx
+++ b/src/components/Layout/Header/NavBar/Native/NativeMenu.tsx
@@ -1,6 +1,6 @@
 import { ChevronRightIcon, EditIcon } from '@chakra-ui/icons'
 import { Button, MenuDivider, MenuItem } from '@chakra-ui/react'
-import { useCallback } from 'react'
+import React, { useCallback } from 'react'
 import { useTranslate } from 'react-polyglot'
 import { Text } from 'components/Text'
 import { useFeatureFlag } from 'hooks/useFeatureFlag/useFeatureFlag'
@@ -8,23 +8,26 @@ import { useModal } from 'hooks/useModal/useModal'
 
 const chevronRightIcon = <ChevronRightIcon />
 const editIcon = <EditIcon />
+type NativeMenuProps = {
+  onClose?: () => void
+}
 
-export const NativeMenu = () => {
+export const NativeMenu: React.FC<NativeMenuProps> = ({ onClose }) => {
   const translate = useTranslate()
   const isAccountManagementEnabled = useFeatureFlag('AccountManagement')
 
   const backupNativePassphrase = useModal('backupNativePassphrase')
   const accountManagementPopover = useModal('manageAccounts')
 
-  const handleBackupMenuItemClick = useCallback(
-    () => backupNativePassphrase.open({}),
-    [backupNativePassphrase],
-  )
+  const handleBackupMenuItemClick = useCallback(() => {
+    onClose && onClose()
+    backupNativePassphrase.open({})
+  }, [backupNativePassphrase, onClose])
 
-  const handleManageAccountsMenuItemClick = useCallback(
-    () => accountManagementPopover.open({}),
-    [accountManagementPopover],
-  )
+  const handleManageAccountsMenuItemClick = useCallback(() => {
+    onClose && onClose()
+    accountManagementPopover.open({})
+  }, [accountManagementPopover, onClose])
 
   return (
     <>

--- a/src/components/Layout/Header/NavBar/NavBar.tsx
+++ b/src/components/Layout/Header/NavBar/NavBar.tsx
@@ -20,7 +20,7 @@ type NavBarProps = {
 const flex = { base: 'none', md: '1 1 0%' }
 
 export const NavBar = (props: NavBarProps) => {
-  const { isCompact, onClick, ...stackProps } = useMemo(() => {
+  const { isCompact, onClick, stackProps } = useMemo(() => {
     const { isCompact, onClick, ...stackProps } = props
     return { isCompact, onClick, stackProps }
     // eslint-disable-next-line react-hooks/exhaustive-deps

--- a/src/components/Layout/Header/NavBar/UserMenu.tsx
+++ b/src/components/Layout/Header/NavBar/UserMenu.tsx
@@ -49,6 +49,7 @@ const NoWallet = ({ onClick }: { onClick: () => void }) => {
 export type WalletConnectedProps = {
   onDisconnect: () => void
   onSwitchProvider: () => void
+  onClose?: () => void
 } & Pick<InitialState, 'walletInfo' | 'isConnected' | 'connectedType'>
 
 export const WalletConnected = (props: WalletConnectedProps) => {
@@ -60,6 +61,7 @@ export const WalletConnected = (props: WalletConnectedProps) => {
         onDisconnect={props.onDisconnect}
         onSwitchProvider={props.onSwitchProvider}
         connectedType={props.connectedType}
+        onClose={props.onClose}
       />
     </MemoryRouter>
   )
@@ -191,6 +193,7 @@ export const UserMenu: React.FC<{ onClick?: () => void }> = memo(({ onClick }) =
                 onDisconnect={disconnect}
                 onSwitchProvider={handleConnect}
                 connectedType={connectedType}
+                onClose={onClick}
               />
             ) : (
               <NoWallet onClick={handleConnect} />

--- a/src/components/Layout/Header/NavBar/WalletConnectedMenu.tsx
+++ b/src/components/Layout/Header/NavBar/WalletConnectedMenu.tsx
@@ -27,6 +27,7 @@ const ConnectedMenu = memo(
     walletInfo,
     onDisconnect,
     onSwitchProvider,
+    onClose,
   }: WalletConnectedProps & {
     connectedWalletMenuRoutes: boolean
   }) => {
@@ -74,7 +75,7 @@ const ConnectedMenu = memo(
               {translate('connectWallet.menu.connecting')}
             </MenuItem>
           )}
-          {ConnectMenuComponent && <ConnectMenuComponent />}
+          {ConnectMenuComponent && <ConnectMenuComponent onClose={onClose} />}
           <MenuDivider />
           <MenuItem icon={repeatIcon} onClick={onSwitchProvider}>
             {translate('connectWallet.menu.switchWallet')}
@@ -94,6 +95,7 @@ export const WalletConnectedMenu = ({
   walletInfo,
   isConnected,
   connectedType,
+  onClose,
 }: WalletConnectedProps) => {
   const location = useLocation()
 
@@ -128,6 +130,7 @@ export const WalletConnectedMenu = ({
               walletInfo={walletInfo}
               onDisconnect={onDisconnect}
               onSwitchProvider={onSwitchProvider}
+              onClose={onClose}
             />
           </SubMenuContainer>
         </Route>

--- a/src/components/ManageAccountsDrawer/components/SelectChain.tsx
+++ b/src/components/ManageAccountsDrawer/components/SelectChain.tsx
@@ -1,19 +1,9 @@
-import { SearchIcon } from '@chakra-ui/icons'
-import {
-  Box,
-  Button,
-  Input,
-  InputGroup,
-  InputLeftElement,
-  SimpleGrid,
-  VStack,
-} from '@chakra-ui/react'
+import { Button, SimpleGrid, Stack, VStack } from '@chakra-ui/react'
 import type { ChainId } from '@shapeshiftoss/caip'
-import type { FormEvent } from 'react'
 import { useCallback, useEffect, useMemo, useState } from 'react'
-import { useForm } from 'react-hook-form'
 import { useTranslate } from 'react-polyglot'
 import { LazyLoadAvatar } from 'components/LazyLoadAvatar'
+import { GlobalFilter } from 'components/StakingVaults/GlobalFilter'
 import { RawText } from 'components/Text'
 import { assertGetChainAdapter, chainIdToFeeAssetId } from 'lib/utils'
 import { selectAssetById, selectWalletSupportedChainIds } from 'state/slices/selectors'
@@ -21,6 +11,8 @@ import { useAppSelector } from 'state/store'
 
 import { filterChainIdsBySearchTerm } from '../helpers'
 import { DrawerContentWrapper } from './DrawerContent'
+
+const inputGroupProps = { size: 'lg' }
 
 export type SelectChainProps = {
   onSelectChainId: (chainId: ChainId) => void
@@ -57,33 +49,24 @@ const ChainButton = ({
 export const SelectChain = ({ onSelectChainId, onClose }: SelectChainProps) => {
   const translate = useTranslate()
   const [searchTermChainIds, setSearchTermChainIds] = useState<ChainId[]>([])
+  const [searchQuery, setSearchQuery] = useState('')
 
   const walletSupportedChainIds = useAppSelector(selectWalletSupportedChainIds)
 
-  const handleSubmit = useCallback((e: FormEvent<unknown>) => e.preventDefault(), [])
-
-  const { register, watch } = useForm<{ search: string }>({
-    mode: 'onChange',
-    defaultValues: {
-      search: '',
-    },
-  })
-  const searchString = watch('search')
-
-  const searching = useMemo(() => searchString.length > 0, [searchString])
+  const isSearching = useMemo(() => searchQuery.length > 0, [searchQuery])
 
   useEffect(() => {
-    if (!searching) return
+    if (!isSearching) return
 
-    setSearchTermChainIds(filterChainIdsBySearchTerm(searchString, walletSupportedChainIds))
-  }, [searchString, searching, walletSupportedChainIds])
+    setSearchTermChainIds(filterChainIdsBySearchTerm(searchQuery, walletSupportedChainIds))
+  }, [searchQuery, isSearching, walletSupportedChainIds])
 
   const chainButtons = useMemo(() => {
-    const listChainIds = searching ? searchTermChainIds : walletSupportedChainIds
+    const listChainIds = isSearching ? searchTermChainIds : walletSupportedChainIds
     return listChainIds.map(chainId => {
       return <ChainButton key={chainId} chainId={chainId} onClick={onSelectChainId} />
     })
-  }, [onSelectChainId, searchTermChainIds, searching, walletSupportedChainIds])
+  }, [onSelectChainId, searchTermChainIds, isSearching, walletSupportedChainIds])
 
   const footer = useMemo(() => {
     return (
@@ -97,31 +80,19 @@ export const SelectChain = ({ onSelectChainId, onClose }: SelectChainProps) => {
 
   const body = useMemo(() => {
     return (
-      <>
-        <Box as='form' mb={3} px={4} visibility='visible' onSubmit={handleSubmit}>
-          <InputGroup size='lg'>
-            {/* Override zIndex to prevent element displaying on overlay components */}
-            <InputLeftElement pointerEvents='none' zIndex={1}>
-              <SearchIcon color='gray.300' />
-            </InputLeftElement>
-            <Input
-              {...register('search')}
-              type={'text'}
-              placeholder={translate('accountManagement.selectChain.searchChains')}
-              pl={10}
-              variant={'filled'}
-              autoComplete={'off'}
-              autoFocus={false}
-              transitionProperty={'none'}
-            />
-          </InputGroup>
-        </Box>
-        <SimpleGrid columns={3} spacing={6}>
+      <Stack spacing={4}>
+        <GlobalFilter
+          setSearchQuery={setSearchQuery}
+          searchQuery={searchQuery}
+          placeholder={translate('accountManagement.selectChain.searchChains')}
+          inputGroupProps={inputGroupProps}
+        />
+        <SimpleGrid columns={3} spacing={4}>
           {chainButtons}
         </SimpleGrid>
-      </>
+      </Stack>
     )
-  }, [chainButtons, handleSubmit, register, translate])
+  }, [chainButtons, searchQuery, translate])
 
   return (
     <DrawerContentWrapper

--- a/src/components/Modals/ManageAccounts/ManageAccountsModal.tsx
+++ b/src/components/Modals/ManageAccounts/ManageAccountsModal.tsx
@@ -23,7 +23,7 @@ import { ManageAccountsDrawer } from 'components/ManageAccountsDrawer/ManageAcco
 import { RawText } from 'components/Text'
 import { useModal } from 'hooks/useModal/useModal'
 import { assertGetChainAdapter, chainIdToFeeAssetId } from 'lib/utils'
-import { selectWalletSupportedChainIds } from 'state/slices/common-selectors'
+import { selectWalletChainIds } from 'state/slices/common-selectors'
 import { selectAccountIdsByChainId, selectAssetById } from 'state/slices/selectors'
 import { useAppSelector } from 'state/store'
 
@@ -82,8 +82,7 @@ export const ManageAccountsModal = ({
     console.log('info clicked')
   }, [])
 
-  // TODO: redux will have to be updated to use the selected chains from this flow
-  const walletSupportedChainIds = useAppSelector(selectWalletSupportedChainIds)
+  const walletConnectedChainIds = useAppSelector(selectWalletChainIds)
 
   const handleClickChain = useCallback(
     (chainId: ChainId) => {
@@ -99,10 +98,10 @@ export const ManageAccountsModal = ({
   }, [handleDrawerOpen])
 
   const connectedChains = useMemo(() => {
-    return walletSupportedChainIds.map(chainId => {
+    return walletConnectedChainIds.map(chainId => {
       return <ConnectedChain key={chainId} chainId={chainId} onClick={handleClickChain} />
     })
-  }, [handleClickChain, walletSupportedChainIds])
+  }, [handleClickChain, walletConnectedChainIds])
 
   const disableAddChain = false // FIXME: walletSupportedChainIds.length === connectedChains.length - blocked on Redux PR
 
@@ -121,7 +120,9 @@ export const ManageAccountsModal = ({
               {translate(title)}
             </RawText>
             <RawText color='text.subtle' fontSize='md' fontWeight='normal'>
-              {translate('accountManagement.manageAccounts.description')}
+              {walletConnectedChainIds.length === 0
+                ? translate('accountManagement.manageAccounts.emptyList')
+                : translate('accountManagement.manageAccounts.description')}
             </RawText>
           </ModalHeader>
           <IconButton
@@ -135,11 +136,13 @@ export const ManageAccountsModal = ({
             onClick={handleInfoClick}
           />
           <ModalCloseButton position='absolute' top={3} right={3} />
-          <ModalBody maxH='400px' overflow='scroll'>
-            <VStack spacing={2} width='full'>
-              {connectedChains}
-            </VStack>
-          </ModalBody>
+          {walletConnectedChainIds.length > 0 && (
+            <ModalBody maxH='400px' overflowY='auto'>
+              <VStack spacing={2} width='full'>
+                {connectedChains}
+              </VStack>
+            </ModalBody>
+          )}
           <ModalFooter justifyContent='center' pb={6}>
             <VStack spacing={2} width='full'>
               <Button
@@ -150,7 +153,9 @@ export const ManageAccountsModal = ({
                 isDisabled={disableAddChain}
                 _disabled={disabledProp}
               >
-                {translate('accountManagement.manageAccounts.addChain')}
+                {walletConnectedChainIds.length === 0
+                  ? translate('accountManagement.manageAccounts.addChain')
+                  : translate('accountManagement.manageAccounts.addAnotherChain')}
               </Button>
               <Button size='lg' colorScheme='gray' onClick={close} width='full'>
                 {translate('common.done')}

--- a/src/components/Modals/ManageAccounts/ManageAccountsModal.tsx
+++ b/src/components/Modals/ManageAccounts/ManageAccountsModal.tsx
@@ -1,6 +1,5 @@
 import { InfoIcon } from '@chakra-ui/icons'
 import {
-  Box,
   Button,
   Flex,
   HStack,
@@ -12,6 +11,7 @@ import {
   ModalFooter,
   ModalHeader,
   ModalOverlay,
+  Tag,
   useDisclosure,
   VStack,
 } from '@chakra-ui/react'
@@ -54,15 +54,13 @@ const ConnectedChain = ({
 
   if (numAccounts === 0 || !feeAsset) return null
   return (
-    <Button width='full' onClick={handleClick} p={2}>
+    <Button width='full' height='auto' onClick={handleClick} p={2} pr={3}>
       <Flex justifyContent='space-between' width='full' alignItems='center'>
         <HStack>
           <LazyLoadAvatar src={feeAsset.networkIcon ?? feeAsset.icon} size='sm' />
           <RawText>{chainAdapter.getDisplayName()}</RawText>
         </HStack>
-        <Box bgColor='gray.600' width='22px' p={1} borderRadius='8px' fontSize='xs'>
-          {numAccounts}
-        </Box>
+        <Tag>{numAccounts}</Tag>
       </Flex>
     </Button>
   )
@@ -115,12 +113,14 @@ export const ManageAccountsModal = ({
         onClose={handleDrawerClose}
         chainId={selectedChainId}
       />
-      <Modal isOpen={isOpen} onClose={close} isCentered size='sm'>
+      <Modal isOpen={isOpen} onClose={close} isCentered size='md'>
         <ModalOverlay />
-        <ModalContent borderRadius='xl' mx={3} maxW='400px'>
-          <ModalHeader textAlign='left' py={12}>
-            <RawText as='h3'>{translate(title)}</RawText>
-            <RawText color='text.subtle' fontSize='md'>
+        <ModalContent>
+          <ModalHeader textAlign='left' pt={14}>
+            <RawText as='h3' fontWeight='semibold'>
+              {translate(title)}
+            </RawText>
+            <RawText color='text.subtle' fontSize='md' fontWeight='normal'>
               {translate('accountManagement.manageAccounts.description')}
             </RawText>
           </ModalHeader>
@@ -146,12 +146,13 @@ export const ManageAccountsModal = ({
                 colorScheme='blue'
                 onClick={handleClickAddChain}
                 width='full'
+                size='lg'
                 isDisabled={disableAddChain}
                 _disabled={disabledProp}
               >
                 {translate('accountManagement.manageAccounts.addChain')}
               </Button>
-              <Button colorScheme='gray' onClick={close} width='full'>
+              <Button size='lg' colorScheme='gray' onClick={close} width='full'>
                 {translate('common.done')}
               </Button>
             </VStack>

--- a/src/context/AppProvider/AppContext.tsx
+++ b/src/context/AppProvider/AppContext.tsx
@@ -154,6 +154,10 @@ export const AppProvider = ({ children }: { children: React.ReactNode }) => {
           walletId: await wallet.getDeviceID(),
         }),
       )
+
+      for (const accountId of Object.keys(accountMetadataByAccountId)) {
+        dispatch(portfolio.actions.enableAccountId(accountId))
+      }
     })()
   }, [dispatch, wallet, supportedChains, isSnapInstalled])
 

--- a/src/context/WalletProvider/Ledger/components/Chains.tsx
+++ b/src/context/WalletProvider/Ledger/components/Chains.tsx
@@ -83,7 +83,10 @@ export const LedgerChains = () => {
 
   const handleConnectClick = useCallback(
     async (chainId: ChainId) => {
-      if (!walletState?.wallet) return
+      if (!walletState?.wallet) {
+        console.error('No wallet found')
+        return
+      }
 
       setLoadingChains(prevLoading => ({ ...prevLoading, [chainId]: true }))
 
@@ -134,6 +137,7 @@ export const LedgerChains = () => {
 
           dispatch(portfolio.actions.upsertAccountMetadata(payload))
           dispatch(portfolio.actions.upsertPortfolio(account))
+          dispatch(portfolio.actions.enableAccountId(accountId))
           return acc
         }, {})
 

--- a/src/lib/swapper/swappers/ThorchainSwapper/endpoints.ts
+++ b/src/lib/swapper/swappers/ThorchainSwapper/endpoints.ts
@@ -35,7 +35,7 @@ import { isNativeEvmAsset } from '../utils/helpers/helpers'
 import { THORCHAIN_OUTBOUND_FEE_RUNE_THOR_UNIT } from './constants'
 import type { ThorEvmTradeQuote } from './getThorTradeQuote/getTradeQuote'
 import { getThorTradeQuote } from './getThorTradeQuote/getTradeQuote'
-import { type MidgardActionsResponse, type ThornodeStatusResponse } from './types'
+import type { ThornodeStatusResponse } from './types'
 import { checkOutboundTxConfirmations } from './utils/checkOutputTxConfirmations'
 import { getLatestThorTxStatusMessage } from './utils/getLatestThorTxStatusMessage'
 import { TradeType } from './utils/longTailHelpers'
@@ -334,16 +334,11 @@ export const thorchainApi: SwapperApi = {
       const thorTxHash = txHash.replace(/^0x/, '')
 
       // not using monadic axios, this is intentional for simplicity in this non-monadic context
-      const [{ data: thorTxData }, { data: thorActionsData }] = await Promise.all([
-        axios.get<ThornodeStatusResponse>(
-          `${getConfig().REACT_APP_THORCHAIN_NODE_URL}/lcd/thorchain/tx/status/${thorTxHash}`,
-        ),
-        axios.get<MidgardActionsResponse>(
-          `${getConfig().REACT_APP_MIDGARD_URL}/actions?txid=${thorTxHash}`,
-        ),
-      ])
+      const { data } = await axios.get<ThornodeStatusResponse>(
+        `${getConfig().REACT_APP_THORCHAIN_NODE_URL}/lcd/thorchain/tx/status/${thorTxHash}`,
+      )
 
-      if ('error' in thorTxData) {
+      if ('error' in data) {
         return {
           buyTxHash: undefined,
           status: TxStatus.Unknown,
@@ -351,14 +346,14 @@ export const thorchainApi: SwapperApi = {
         }
       }
 
-      const outCoinAsset: string | undefined = thorActionsData.actions[0]?.out[0]?.coins[0]?.asset
-      const hasOutboundTx = outCoinAsset !== 'THOR.RUNE'
+      const latestOutTx = data.out_txs?.[data.out_txs.length - 1]
+      const hasOutboundTx = latestOutTx?.chain !== 'THOR'
 
-      const buyTxHash = parseThorBuyTxHash(txHash, thorActionsData)
+      const buyTxHash = parseThorBuyTxHash(txHash, data)
 
-      // if we have a buyTxHash, check if it's been confirmed on-chain
+      // if we have an outbound transaction (non rune) and associated buyTxHash, check if it's been confirmed on-chain
       if (hasOutboundTx && buyTxHash) {
-        const outboundTxConfirmations = await checkOutboundTxConfirmations(thorTxData, buyTxHash)
+        const outboundTxConfirmations = await checkOutboundTxConfirmations(data, buyTxHash)
 
         if (outboundTxConfirmations !== undefined && outboundTxConfirmations > 0) {
           return {
@@ -369,7 +364,7 @@ export const thorchainApi: SwapperApi = {
         }
       }
 
-      const { message, status } = getLatestThorTxStatusMessage(thorTxData, hasOutboundTx)
+      const { message, status } = getLatestThorTxStatusMessage(data, hasOutboundTx)
 
       return {
         buyTxHash,

--- a/src/pages/Accounts/AddAccountModal.tsx
+++ b/src/pages/Accounts/AddAccountModal.tsx
@@ -89,9 +89,10 @@ export const AddAccountModal = () => {
         }),
       )
       const accountIds = Object.keys(accountMetadataByAccountId)
-      accountIds.forEach(accountId =>
-        dispatch(getAccount.initiate({ accountId, upsertOnFetch: true }, opts)),
-      )
+      accountIds.forEach(accountId => {
+        dispatch(getAccount.initiate({ accountId, upsertOnFetch: true }, opts))
+        dispatch(portfolio.actions.enableAccountId(accountId))
+      })
       const assetId = getChainAdapterManager().get(selectedChainId)!.getFeeAssetId()
       const { name } = assets[assetId] ?? {}
       toast({

--- a/src/react-queries/queries/accountManagement.ts
+++ b/src/react-queries/queries/accountManagement.ts
@@ -1,31 +1,7 @@
 import { createQueryKeys } from '@lukemorales/query-key-factory'
 import type { AccountId } from '@shapeshiftoss/caip'
-import { type ChainId, fromAccountId } from '@shapeshiftoss/caip'
-import type { HDWallet } from '@shapeshiftoss/hdwallet-core'
-import type { AccountMetadata } from '@shapeshiftoss/types'
-import { deriveAccountIdsAndMetadata } from 'lib/account/account'
+import { fromAccountId } from '@shapeshiftoss/caip'
 import { assertGetChainAdapter } from 'lib/utils'
-import { checkAccountHasActivity } from 'state/slices/portfolioSlice/utils'
-
-const getAccountIdsWithActivityAndMetadata = async (
-  accountNumber: number,
-  chainId: ChainId,
-  wallet: HDWallet,
-) => {
-  const input = { accountNumber, chainIds: [chainId], wallet }
-  const accountIdsAndMetadata = await deriveAccountIdsAndMetadata(input)
-
-  return Promise.all(
-    Object.entries(accountIdsAndMetadata).map(async ([accountId, accountMetadata]) => {
-      const { account: pubkey } = fromAccountId(accountId)
-      const adapter = assertGetChainAdapter(chainId)
-      const account = await adapter.getAccount(pubkey)
-      const hasActivity = checkAccountHasActivity(account)
-
-      return { accountId, accountMetadata, hasActivity }
-    }),
-  )
-}
 
 export const accountManagement = createQueryKeys('accountManagement', {
   getAccount: (accountId: AccountId) => ({
@@ -35,64 +11,6 @@ export const accountManagement = createQueryKeys('accountManagement', {
       const adapter = assertGetChainAdapter(chainId)
       const account = await adapter.getAccount(pubkey)
       return account
-    },
-  }),
-  accountIdWithActivityAndMetadata: (
-    accountNumber: number,
-    chainId: ChainId,
-    wallet: HDWallet,
-    walletDeviceId: string,
-  ) => ({
-    queryKey: ['accountIdWithActivityAndMetadata', chainId, walletDeviceId, accountNumber],
-    queryFn: () => {
-      return getAccountIdsWithActivityAndMetadata(accountNumber, chainId, wallet)
-    },
-  }),
-  firstAccountIdsWithActivityAndMetadata: (
-    chainId: ChainId,
-    wallet: HDWallet | null,
-    walletDeviceId: string,
-    accountNumberLimit: number,
-  ) => ({
-    queryKey: [
-      'firstAccountIdsWithActivityAndMetadata',
-      chainId,
-      walletDeviceId,
-      accountNumberLimit,
-    ],
-    queryFn: async () => {
-      let accountNumber = 0
-
-      const accounts: {
-        accountId: AccountId
-        accountMetadata: AccountMetadata
-        hasActivity: boolean
-      }[][] = []
-
-      if (!wallet) return []
-
-      while (true) {
-        try {
-          if (accountNumber >= accountNumberLimit) {
-            break
-          }
-
-          const accountResults = await getAccountIdsWithActivityAndMetadata(
-            accountNumber,
-            chainId,
-            wallet,
-          )
-
-          accounts.push(accountResults)
-        } catch (error) {
-          console.error(error)
-          break
-        }
-
-        accountNumber++
-      }
-
-      return accounts
     },
   }),
 })

--- a/src/state/migrations/index.ts
+++ b/src/state/migrations/index.ts
@@ -59,4 +59,5 @@ export const migrations = {
   49: clearAssets,
   50: clearPortfolio,
   51: clearAssets,
+  52: clearPortfolio,
 }

--- a/src/state/slices/common-selectors.ts
+++ b/src/state/slices/common-selectors.ts
@@ -26,10 +26,10 @@ export const selectWalletSupportedChainIds = (state: ReduxState) =>
 export const selectWalletAccountIds = createDeepEqualOutputSelector(
   selectWalletId,
   (state: ReduxState) => state.portfolio.wallet.byId,
-  (state: ReduxState) => state.portfolio.hiddenAccountIds,
-  (walletId, walletById, hiddenAccountIds): AccountId[] => {
+  (state: ReduxState) => state.portfolio.enabledAccountIds,
+  (walletId, walletById, enabledAccountIds): AccountId[] => {
     const walletAccountIds = (walletId && walletById[walletId]) ?? []
-    return walletAccountIds.filter(accountId => !hiddenAccountIds.includes(accountId))
+    return walletAccountIds.filter(accountId => (enabledAccountIds ?? []).includes(accountId))
   },
 )
 

--- a/src/state/slices/opportunitiesSlice/selectors/selectors.test.ts
+++ b/src/state/slices/opportunitiesSlice/selectors/selectors.test.ts
@@ -47,6 +47,7 @@ describe('opportunitiesSlice selectors', () => {
         supportedChainIds: [],
       },
       wallet,
+      enabledAccountIds: [gomesAccountId, fauxmesAccountId, catpuccinoAccountId],
     },
   }
   describe('selects ID/s', () => {
@@ -65,6 +66,7 @@ describe('opportunitiesSlice selectors', () => {
       },
       ids: [gomesAccountId, fauxmesAccountId],
     }
+    const enabledAccountIds = [gomesAccountId, fauxmesAccountId]
     const lp = {
       ...initialState.lp,
       byAccountId: {
@@ -116,6 +118,7 @@ describe('opportunitiesSlice selectors', () => {
         ...mockBaseState.portfolio,
         accountBalances,
         accountMetadata,
+        enabledAccountIds,
       },
       opportunities: {
         ...initialState,

--- a/src/state/slices/portfolioSlice/__snapshots__/portfolioSlice.test.ts.snap
+++ b/src/state/slices/portfolioSlice/__snapshots__/portfolioSlice.test.ts.snap
@@ -29,7 +29,9 @@ exports[`portfolioSlice > reducers > upsertPortfolio > Bitcoin > should update s
       "bip122:000000000019d6689c085ae165831e93:zpub6qk8s2NQsYG6X2Mm6iU2ii3yTAqDb2XqnMu9vo2WjvqwjSvjjiYQQveYXbPxrnRT5Yb5p0x934be745172066EDF795ffc5EA9F28f19b440c637BaBw1wowPwbS8fj7uCfj3UhqhD2LLbvY6Ni1w",
     ],
   },
-  "hiddenAccountIds": [],
+  "enabledAccountIds": [
+    "bip122:000000000019d6689c085ae165831e93:zpub6qk8s2NQsYG6X2Mm6iU2ii3yTAqDb2XqnMu9vo2WjvqwjSvjjiYQQveYXbPxrnRT5Yb5p0x934be745172066EDF795ffc5EA9F28f19b440c637BaBw1wowPwbS8fj7uCfj3UhqhD2LLbvY6Ni1w",
+  ],
   "wallet": {
     "byId": {},
     "ids": [],
@@ -77,7 +79,10 @@ exports[`portfolioSlice > reducers > upsertPortfolio > Bitcoin > should update s
       "bip122:000000000019d6689c085ae165831e93:xpub6qk8s2NQsYG6X2Mm6iU2ii3yTAqDb2XqnMu9vo2WjvqwjSvjjiYQQveYXbPxrnRT5Yb5p0x934be745172066EDF795ffc5EA9F28f19b440c637BaBw1wowPwbS8fj7uCfj3UhqhD2LLbvY6Ni1w",
     ],
   },
-  "hiddenAccountIds": [],
+  "enabledAccountIds": [
+    "bip122:000000000019d6689c085ae165831e93:zpub6qk8s2NQsYG6X2Mm6iU2ii3yTAqDb2XqnMu9vo2WjvqwjSvjjiYQQveYXbPxrnRT5Yb5p0x934be745172066EDF795ffc5EA9F28f19b440c637BaBw1wowPwbS8fj7uCfj3UhqhD2LLbvY6Ni1w",
+    "bip122:000000000019d6689c085ae165831e93:xpub6qk8s2NQsYG6X2Mm6iU2ii3yTAqDb2XqnMu9vo2WjvqwjSvjjiYQQveYXbPxrnRT5Yb5p0x934be745172066EDF795ffc5EA9F28f19b440c637BaBw1wowPwbS8fj7uCfj3UhqhD2LLbvY6Ni1w",
+  ],
   "wallet": {
     "byId": {},
     "ids": [],
@@ -148,7 +153,11 @@ exports[`portfolioSlice > reducers > upsertPortfolio > Ethereum and bitcoin > sh
       "bip122:000000000019d6689c085ae165831e93:zpub6qk8s2NQsYG6X2Mm6iU2ii3yTAqDb2XqnMu9vo2WjvqwjSvjjiYQQveYXbPxrnRT5Yb5p0x934be745172066EDF795ffc5EA9F28f19b440c637BaBw1wowPwbS8fj7uCfj3UhqhD2LLbvY6Ni1w",
     ],
   },
-  "hiddenAccountIds": [],
+  "enabledAccountIds": [
+    "eip155:1:0x9a2d593725045d1727d525dd07a396f9ff079bb1",
+    "eip155:1:0xea674fdde714fd979de3edf0f56aa9716b898ec8",
+    "bip122:000000000019d6689c085ae165831e93:zpub6qk8s2NQsYG6X2Mm6iU2ii3yTAqDb2XqnMu9vo2WjvqwjSvjjiYQQveYXbPxrnRT5Yb5p0x934be745172066EDF795ffc5EA9F28f19b440c637BaBw1wowPwbS8fj7uCfj3UhqhD2LLbvY6Ni1w",
+  ],
   "wallet": {
     "byId": {},
     "ids": [],
@@ -204,7 +213,10 @@ exports[`portfolioSlice > reducers > upsertPortfolio > Ethereum and bitcoin > sh
       "bip122:000000000019d6689c085ae165831e93:zpub6qk8s2NQsYG6X2Mm6iU2ii3yTAqDb2XqnMu9vo2WjvqwjSvjjiYQQveYXbPxrnRT5Yb5p0x934be745172066EDF795ffc5EA9F28f19b440c637BaBw1wowPwbS8fj7uCfj3UhqhD2LLbvY6Ni1w",
     ],
   },
-  "hiddenAccountIds": [],
+  "enabledAccountIds": [
+    "eip155:1:0x6c8a778ef52e121b7dff1154c553662306a970e9",
+    "bip122:000000000019d6689c085ae165831e93:zpub6qk8s2NQsYG6X2Mm6iU2ii3yTAqDb2XqnMu9vo2WjvqwjSvjjiYQQveYXbPxrnRT5Yb5p0x934be745172066EDF795ffc5EA9F28f19b440c637BaBw1wowPwbS8fj7uCfj3UhqhD2LLbvY6Ni1w",
+  ],
   "wallet": {
     "byId": {},
     "ids": [],
@@ -243,7 +255,9 @@ exports[`portfolioSlice > reducers > upsertPortfolio > ethereum > should update 
       "eip155:1:0x9a2d593725045d1727d525dd07a396f9ff079bb1",
     ],
   },
-  "hiddenAccountIds": [],
+  "enabledAccountIds": [
+    "eip155:1:0x9a2d593725045d1727d525dd07a396f9ff079bb1",
+  ],
   "wallet": {
     "byId": {},
     "ids": [],
@@ -295,7 +309,10 @@ exports[`portfolioSlice > reducers > upsertPortfolio > ethereum > should update 
       "eip155:1:0xea674fdde714fd979de3edf0f56aa9716b898ec8",
     ],
   },
-  "hiddenAccountIds": [],
+  "enabledAccountIds": [
+    "eip155:1:0x9a2d593725045d1727d525dd07a396f9ff079bb1",
+    "eip155:1:0xea674fdde714fd979de3edf0f56aa9716b898ec8",
+  ],
   "wallet": {
     "byId": {},
     "ids": [],

--- a/src/state/slices/portfolioSlice/portfolioSlice.test.ts
+++ b/src/state/slices/portfolioSlice/portfolioSlice.test.ts
@@ -63,9 +63,11 @@ describe('portfolioSlice', () => {
             },
           })
 
-          store.dispatch(
-            portfolioSlice.actions.upsertPortfolio(mockUpsertPortfolio([ethAccount], assetIds)),
-          )
+          const portfolio = mockUpsertPortfolio([ethAccount], assetIds)
+          store.dispatch(portfolioSlice.actions.upsertPortfolio(portfolio))
+          for (const accountId of portfolio.accounts.ids) {
+            store.dispatch(portfolioSlice.actions.enableAccountId(accountId))
+          }
 
           expect(store.getState().portfolio).toMatchSnapshot()
         })
@@ -88,11 +90,11 @@ describe('portfolioSlice', () => {
             },
           })
 
-          store.dispatch(
-            portfolioSlice.actions.upsertPortfolio(
-              mockUpsertPortfolio([ethAccount, ethAccount2], assetIds),
-            ),
-          )
+          const portfolio = mockUpsertPortfolio([ethAccount, ethAccount2], assetIds)
+          store.dispatch(portfolioSlice.actions.upsertPortfolio(portfolio))
+          for (const accountId of portfolio.accounts.ids) {
+            store.dispatch(portfolioSlice.actions.enableAccountId(accountId))
+          }
 
           expect(store.getState().portfolio).toMatchSnapshot()
         })
@@ -107,9 +109,11 @@ describe('portfolioSlice', () => {
             },
           })
 
-          store.dispatch(
-            portfolioSlice.actions.upsertPortfolio(mockUpsertPortfolio([btcAccount], assetIds)),
-          )
+          const portfolio = mockUpsertPortfolio([btcAccount], assetIds)
+          store.dispatch(portfolioSlice.actions.upsertPortfolio(portfolio))
+          for (const accountId of portfolio.accounts.ids) {
+            store.dispatch(portfolioSlice.actions.enableAccountId(accountId))
+          }
 
           expect(store.getState().portfolio).toMatchSnapshot()
         })
@@ -129,11 +133,11 @@ describe('portfolioSlice', () => {
             },
           })
 
-          store.dispatch(
-            portfolioSlice.actions.upsertPortfolio(
-              mockUpsertPortfolio([btcAccount, btcAccount2], assetIds),
-            ),
-          )
+          const portfolio = mockUpsertPortfolio([btcAccount, btcAccount2], assetIds)
+          store.dispatch(portfolioSlice.actions.upsertPortfolio(portfolio))
+          for (const accountId of portfolio.accounts.ids) {
+            store.dispatch(portfolioSlice.actions.enableAccountId(accountId))
+          }
 
           expect(store.getState().portfolio).toMatchSnapshot()
         })
@@ -180,11 +184,11 @@ describe('portfolioSlice', () => {
             },
           })
 
-          store.dispatch(
-            portfolioSlice.actions.upsertPortfolio(
-              mockUpsertPortfolio([ethAccount, ethAccount2, btcAccount], assetIds),
-            ),
-          )
+          const portfolio = mockUpsertPortfolio([ethAccount, ethAccount2, btcAccount], assetIds)
+          store.dispatch(portfolioSlice.actions.upsertPortfolio(portfolio))
+          for (const accountId of portfolio.accounts.ids) {
+            store.dispatch(portfolioSlice.actions.enableAccountId(accountId))
+          }
 
           expect(store.getState().portfolio).toMatchSnapshot()
         })
@@ -221,11 +225,11 @@ describe('portfolioSlice', () => {
             },
           })
 
-          store.dispatch(
-            portfolioSlice.actions.upsertPortfolio(
-              mockUpsertPortfolio([ethAccount, btcAccount], assetIds),
-            ),
-          )
+          const portfolio = mockUpsertPortfolio([ethAccount, btcAccount], assetIds)
+          store.dispatch(portfolioSlice.actions.upsertPortfolio(portfolio))
+          for (const accountId of portfolio.accounts.ids) {
+            store.dispatch(portfolioSlice.actions.enableAccountId(accountId))
+          }
 
           expect(store.getState().portfolio).toMatchSnapshot()
         })
@@ -258,11 +262,11 @@ describe('portfolioSlice', () => {
         )
 
         // dispatch portfolio data
-        store.dispatch(
-          portfolioSlice.actions.upsertPortfolio(
-            mockUpsertPortfolio([ethAccount, ethAccount2, btcAccount], assetIds),
-          ),
-        )
+        const portfolio = mockUpsertPortfolio([ethAccount, ethAccount2, btcAccount], assetIds)
+        store.dispatch(portfolioSlice.actions.upsertPortfolio(portfolio))
+        for (const accountId of portfolio.accounts.ids) {
+          store.dispatch(portfolioSlice.actions.enableAccountId(accountId))
+        }
 
         const ethMarketData = mockMarketData()
         const foxMarketData = mockMarketData({ price: '1' })
@@ -311,11 +315,12 @@ describe('portfolioSlice', () => {
         )
 
         // dispatch portfolio data
-        store.dispatch(
-          portfolioSlice.actions.upsertPortfolio(
-            mockUpsertPortfolio([ethAccount, ethAccount2, btcAccount], assetIds),
-          ),
-        )
+        const portfolio = mockUpsertPortfolio([ethAccount, ethAccount2, btcAccount], assetIds)
+        store.dispatch(portfolioSlice.actions.upsertPortfolio(portfolio))
+        for (const accountId of portfolio.accounts.ids) {
+          store.dispatch(portfolioSlice.actions.enableAccountId(accountId))
+        }
+
         const ethMarketData = mockMarketData({ price: null })
         const foxMarketData = mockMarketData({ price: null })
 
@@ -365,11 +370,11 @@ describe('portfolioSlice', () => {
       )
 
       // dispatch portfolio data
-      store.dispatch(
-        portfolioSlice.actions.upsertPortfolio(
-          mockUpsertPortfolio([ethAccount, ethAccount2], assetIds),
-        ),
-      )
+      const portfolio = mockUpsertPortfolio([ethAccount, ethAccount2], assetIds)
+      store.dispatch(portfolioSlice.actions.upsertPortfolio(portfolio))
+      for (const accountId of portfolio.accounts.ids) {
+        store.dispatch(portfolioSlice.actions.enableAccountId(accountId))
+      }
 
       it('can select crypto fiat account balance', () => {
         // dispatch market data
@@ -450,11 +455,11 @@ describe('portfolioSlice', () => {
       )
 
       // dispatch portfolio data
-      store.dispatch(
-        portfolioSlice.actions.upsertPortfolio(
-          mockUpsertPortfolio([btcAccount, btcAccount2, btcAccount3], assetIds),
-        ),
-      )
+      const portfolio = mockUpsertPortfolio([btcAccount, btcAccount2, btcAccount3], assetIds)
+      store.dispatch(portfolioSlice.actions.upsertPortfolio(portfolio))
+      for (const accountId of portfolio.accounts.ids) {
+        store.dispatch(portfolioSlice.actions.enableAccountId(accountId))
+      }
 
       // dispatch market data
       const btcMarketData = mockMarketData({ price: '10000' })
@@ -495,11 +500,11 @@ describe('portfolioSlice', () => {
         }),
       )
       // dispatch portfolio data
-      store.dispatch(
-        portfolioSlice.actions.upsertPortfolio(
-          mockUpsertPortfolio([ethAccount, ethAccount2], assetIds),
-        ),
-      )
+      const portfolio = mockUpsertPortfolio([ethAccount, ethAccount2], assetIds)
+      store.dispatch(portfolioSlice.actions.upsertPortfolio(portfolio))
+      for (const accountId of portfolio.accounts.ids) {
+        store.dispatch(portfolioSlice.actions.enableAccountId(accountId))
+      }
 
       store.dispatch(
         portfolioSlice.actions.upsertAccountMetadata({
@@ -574,11 +579,11 @@ describe('portfolioSlice', () => {
       )
 
       // dispatch portfolio data
-      store.dispatch(
-        portfolioSlice.actions.upsertPortfolio(
-          mockUpsertPortfolio([ethAccount, ethAccount2], assetIds),
-        ),
-      )
+      const portfolio = mockUpsertPortfolio([ethAccount, ethAccount2], assetIds)
+      store.dispatch(portfolioSlice.actions.upsertPortfolio(portfolio))
+      for (const accountId of portfolio.accounts.ids) {
+        store.dispatch(portfolioSlice.actions.enableAccountId(accountId))
+      }
 
       // dispatch market data
       const ethMarketData = mockMarketData({ price: '1000' })
@@ -646,11 +651,11 @@ describe('portfolioSlice', () => {
       )
 
       // dispatch portfolio data
-      store.dispatch(
-        portfolioSlice.actions.upsertPortfolio(
-          mockUpsertPortfolio([ethAccount, ethAccount2], assetIds),
-        ),
-      )
+      const portfolio = mockUpsertPortfolio([ethAccount, ethAccount2], assetIds)
+      store.dispatch(portfolioSlice.actions.upsertPortfolio(portfolio))
+      for (const accountId of portfolio.accounts.ids) {
+        store.dispatch(portfolioSlice.actions.enableAccountId(accountId))
+      }
 
       // dispatch market data
       const ethMarketData = mockMarketData({ price: '1000' })
@@ -697,9 +702,11 @@ describe('portfolioSlice', () => {
       })
 
       // dispatch portfolio data
-      store.dispatch(
-        portfolioSlice.actions.upsertPortfolio(mockUpsertPortfolio([ethAccount], assetIds)),
-      )
+      const portfolio = mockUpsertPortfolio([ethAccount], assetIds)
+      store.dispatch(portfolioSlice.actions.upsertPortfolio(portfolio))
+      for (const accountId of portfolio.accounts.ids) {
+        store.dispatch(portfolioSlice.actions.enableAccountId(accountId))
+      }
 
       // dispatch market data
       const ethMarketData = mockMarketData({ price: '1000' })

--- a/src/state/slices/portfolioSlice/portfolioSlice.ts
+++ b/src/state/slices/portfolioSlice/portfolioSlice.ts
@@ -137,8 +137,17 @@ export const portfolio = createSlice({
       // add the `action.meta[SHOULD_AUTOBATCH]` field the enhancer needs
       prepare: prepareAutoBatched<Portfolio>(),
     },
-    setHiddenAccountIds: (draftState, { payload }: { payload: AccountId[] }) => {
-      draftState.hiddenAccountIds = payload
+    toggleAccountIdHidden: (draftState, { payload: accountId }: { payload: AccountId }) => {
+      const hiddenAccountIdsSet = new Set(draftState.hiddenAccountIds)
+      const isHidden = hiddenAccountIdsSet.has(accountId)
+
+      if (!isHidden) {
+        hiddenAccountIdsSet.add(accountId)
+      } else {
+        hiddenAccountIdsSet.delete(accountId)
+      }
+
+      draftState.hiddenAccountIds = Array.from(hiddenAccountIdsSet)
     },
   },
   extraReducers: builder => builder.addCase(PURGE, () => initialState),

--- a/src/state/slices/portfolioSlice/portfolioSlice.ts
+++ b/src/state/slices/portfolioSlice/portfolioSlice.ts
@@ -137,17 +137,26 @@ export const portfolio = createSlice({
       // add the `action.meta[SHOULD_AUTOBATCH]` field the enhancer needs
       prepare: prepareAutoBatched<Portfolio>(),
     },
-    toggleAccountIdHidden: (draftState, { payload: accountId }: { payload: AccountId }) => {
-      const hiddenAccountIdsSet = new Set(draftState.hiddenAccountIds)
-      const isHidden = hiddenAccountIdsSet.has(accountId)
+    /**
+     * Explicitly enable an account by its `AccountId`. Necessary where `use-strict` toggles twice
+     * during initial load, leading to all auto-detected accounts being disabled.
+     */
+    enableAccountId: (draftState, { payload: accountId }: { payload: AccountId }) => {
+      const enabledAccountIdsSet = new Set(draftState.enabledAccountIds)
+      enabledAccountIdsSet.add(accountId)
+      draftState.enabledAccountIds = Array.from(enabledAccountIdsSet)
+    },
+    toggleAccountIdEnabled: (draftState, { payload: accountId }: { payload: AccountId }) => {
+      const enabledAccountIdsSet = new Set(draftState.enabledAccountIds)
+      const isEnabled = enabledAccountIdsSet.has(accountId)
 
-      if (!isHidden) {
-        hiddenAccountIdsSet.add(accountId)
+      if (isEnabled) {
+        enabledAccountIdsSet.delete(accountId)
       } else {
-        hiddenAccountIdsSet.delete(accountId)
+        enabledAccountIdsSet.add(accountId)
       }
 
-      draftState.hiddenAccountIds = Array.from(hiddenAccountIdsSet)
+      draftState.enabledAccountIds = Array.from(enabledAccountIdsSet)
     },
   },
   extraReducers: builder => builder.addCase(PURGE, () => initialState),

--- a/src/state/slices/portfolioSlice/portfolioSliceCommon.ts
+++ b/src/state/slices/portfolioSlice/portfolioSliceCommon.ts
@@ -61,10 +61,10 @@ export type Portfolio = {
   accounts: PortfolioAccounts
   accountBalances: PortfolioAccountBalances
   /**
-   * The `AccountId[]` that are disabled. Rather than removing the accounts and adding complexity
-   * to the actions and state management, we disable them here and filter them out in the selectors.
+   * The `AccountId[]` that are enabled. Rather than removing the accounts and adding complexity
+   * to the actions and state management, we enable them here and filter them out in the selectors.
    */
-  hiddenAccountIds: AccountId[]
+  enabledAccountIds: AccountId[]
   /**
    * 1:many mapping of a unique wallet id -> multiple account ids
    */
@@ -85,7 +85,7 @@ export const initialState: Portfolio = {
     byId: {},
     ids: [],
   },
-  hiddenAccountIds: [],
+  enabledAccountIds: [],
   wallet: {
     byId: {},
     ids: [],

--- a/src/state/slices/portfolioSlice/selectors.ts
+++ b/src/state/slices/portfolioSlice/selectors.ts
@@ -97,6 +97,15 @@ export const selectIsAccountIdEnabled = createCachedSelector(
   },
 )((_s: ReduxState, filter) => filter?.accountId ?? 'accountId')
 
+export const selectIsAnyAccountIdEnabled = createCachedSelector(
+  selectPortfolioAccounts,
+  (_state: ReduxState, accountIds: AccountId[]) => accountIds,
+  (accountsById, accountIds): boolean => {
+    if (accountIds.length === 0) return false
+    return accountIds.some(accountId => accountsById[accountId] !== undefined)
+  },
+)((_s: ReduxState, accountIds) => JSON.stringify(accountIds))
+
 export const selectPortfolioAssetIds = createDeepEqualOutputSelector(
   selectPortfolioAccountBalancesBaseUnit,
   (accountBalancesById): AssetId[] => {

--- a/src/state/slices/portfolioSlice/utils.ts
+++ b/src/state/slices/portfolioSlice/utils.ts
@@ -66,7 +66,8 @@ export const accountIdToLabel = (accountId: AccountId): string => {
     case bscChainId:
     case arbitrumChainId:
     case arbitrumNovaChainId:
-      // this will be the 0x account
+    case thorchainChainId:
+    case cosmosChainId:
       return firstFourLastFour(pubkey)
     case btcChainId:
       // TODO(0xdef1cafe): translations
@@ -76,10 +77,6 @@ export const accountIdToLabel = (accountId: AccountId): string => {
       return ''
     case bchChainId:
       return 'Bitcoin Cash'
-    case cosmosChainId:
-      return 'Cosmos'
-    case thorchainChainId:
-      return 'Thorchain'
     case dogeChainId:
       return 'Dogecoin'
     case ltcChainId:

--- a/src/test/mocks/store.ts
+++ b/src/test/mocks/store.ts
@@ -55,7 +55,7 @@ export const mockStore: ReduxState = {
       byId: {},
       ids: [],
     },
-    hiddenAccountIds: [],
+    enabledAccountIds: [],
     wallet: {
       byId: {},
       ids: [],


### PR DESCRIPTION
fix: import accounts requiring 2 attempts for account to persist (#6819)
fix: sentry action syntax (#6841)
fix: incorrect stack props on NavBar (#6838)
fix: display thorchain and cosmos account label as the shortened address (#6839)
fix: close sidenav drawer when sub menu item clicked (#6831)
Merge branch 'main' into develop
fix: state corruption of import accounts drawer (#6817)
chore: make account management toggles use toggle functions instead of setters (#6816)
feat: account management wiring progression (#6798)
fix: parse buy txid from midgard actions (#6813)