### PR TITLE
feat: change 'add accounts' button to 'manage accounts' when account management is enabled

### DIFF
--- a/src/components/Modals/ManageAccounts/ManageAccountsModal.tsx
+++ b/src/components/Modals/ManageAccounts/ManageAccountsModal.tsx
@@ -27,10 +27,6 @@ import { selectWalletChainIds } from 'state/slices/common-selectors'
 import { selectAccountIdsByChainId, selectAssetById } from 'state/slices/selectors'
 import { useAppSelector } from 'state/store'
 
-export type ManageAccountsModalProps = {
-  title?: string
-}
-
 const infoIcon = <InfoIcon />
 const disabledProp = { opacity: 0.5, cursor: 'not-allowed', userSelect: 'none' }
 
@@ -66,9 +62,7 @@ const ConnectedChain = ({
   )
 }
 
-export const ManageAccountsModal = ({
-  title = 'accountManagement.manageAccounts.title',
-}: ManageAccountsModalProps) => {
+export const ManageAccountsModal = () => {
   const translate = useTranslate()
   const [selectedChainId, setSelectedChainId] = useState<ChainId | null>(null)
   const { close, isOpen } = useModal('manageAccounts')
@@ -117,7 +111,7 @@ export const ManageAccountsModal = ({
         <ModalContent>
           <ModalHeader textAlign='left' pt={14}>
             <RawText as='h3' fontWeight='semibold'>
-              {translate(title)}
+              {translate('accountManagement.manageAccounts.title')}
             </RawText>
             <RawText color='text.subtle' fontSize='md' fontWeight='normal'>
               {walletConnectedChainIds.length === 0

--- a/src/context/ModalProvider/types.ts
+++ b/src/context/ModalProvider/types.ts
@@ -2,7 +2,6 @@ import type { FC } from 'react'
 import type { BackupPassphraseModalProps } from 'components/Layout/Header/NavBar/Native/BackupPassphraseModal/BackupPassphraseModal'
 import type { AssetSearchModalProps } from 'components/Modals/AssetSearch/AssetSearchModal'
 import type { FiatRampsModalProps } from 'components/Modals/FiatRamps/FiatRampsModal'
-import type { ManageAccountsModalProps } from 'components/Modals/ManageAccounts/ManageAccountsModal'
 import type { NftModalProps } from 'components/Modals/Nfts/NftModal'
 import type { PopupWindowModalProps } from 'components/Modals/PopupWindowModal'
 import type { QrCodeModalProps } from 'components/Modals/QrCode/QrCode'
@@ -33,7 +32,7 @@ export type Modals = {
   nft: FC<NftModalProps>
   feedbackSupport: FC<{}>
   snaps: FC<SnapsModalProps>
-  manageAccounts: FC<ManageAccountsModalProps>
+  manageAccounts: FC<{}>
 }
 
 export type ModalActions<T extends keyof Modals> = OpenModalType<T> | CloseModalType

--- a/src/pages/Accounts/Accounts.tsx
+++ b/src/pages/Accounts/Accounts.tsx
@@ -1,4 +1,4 @@
-import { AddIcon } from '@chakra-ui/icons'
+import { AddIcon, EditIcon } from '@chakra-ui/icons'
 import { Button, Heading, List, Skeleton, Stack } from '@chakra-ui/react'
 import { useEffect, useMemo, useState } from 'react'
 import { useTranslate } from 'react-polyglot'
@@ -6,6 +6,7 @@ import { useSelector } from 'react-redux'
 import { Route, Switch, useRouteMatch } from 'react-router'
 import { SEO } from 'components/Layout/Seo'
 import { Text } from 'components/Text'
+import { useFeatureFlag } from 'hooks/useFeatureFlag/useFeatureFlag'
 import { useModal } from 'hooks/useModal/useModal'
 import { useWallet } from 'hooks/useWallet/useWallet'
 import {
@@ -19,10 +20,12 @@ import { Account } from './Account'
 import { ChainRow } from './components/ChainRow'
 
 const addIcon = <AddIcon />
+const editIcon = <EditIcon />
 const pxProps = { base: 4, xl: 0 }
 
 const AccountHeader = ({ isLoading }: { isLoading?: boolean }) => {
   const translate = useTranslate()
+  const isAccountManagementEnabled = useFeatureFlag('AccountManagement')
   const {
     state: { wallet },
   } = useWallet()
@@ -33,7 +36,8 @@ const AccountHeader = ({ isLoading }: { isLoading?: boolean }) => {
     setIsMultiAccountWallet(wallet.supportsBip44Accounts())
   }, [wallet])
 
-  const { open } = useModal('addAccount')
+  const { open: openAddAccountModal } = useModal('addAccount')
+  const { open: openManageAccountsModal } = useModal('manageAccounts')
 
   return (
     <Stack px={pxProps} direction='row' justifyContent='space-between' alignItems='center' pb={6}>
@@ -43,17 +47,31 @@ const AccountHeader = ({ isLoading }: { isLoading?: boolean }) => {
           <Text translation='accounts.accounts' />
         </Heading>
       </Skeleton>
-      {isMultiAccountWallet && (
+      {!isAccountManagementEnabled && isMultiAccountWallet && (
         <Skeleton isLoaded={!isLoading}>
           <Button
             loadingText={translate('accounts.addAccount')}
             leftIcon={addIcon}
             colorScheme='blue'
-            onClick={open}
+            onClick={openAddAccountModal}
             size='sm'
             data-test='add-account-button'
           >
             <Text translation='accounts.addAccount' />
+          </Button>
+        </Skeleton>
+      )}
+      {isAccountManagementEnabled && isMultiAccountWallet && (
+        <Skeleton isLoaded={!isLoading}>
+          <Button
+            loadingText={translate('accountManagement.menuTitle')}
+            leftIcon={editIcon}
+            colorScheme='blue'
+            onClick={openManageAccountsModal}
+            size='sm'
+            data-test='manage-accounts-button'
+          >
+            <Text translation='accountManagement.menuTitle' />
           </Button>
         </Skeleton>
       )}


### PR DESCRIPTION
## Description

Changes the 'add account' button to 'manage accounts' when account management feature is flagged on.

## Pull Request Type

- [ ] :bug: Bug fix (Non-breaking Change: Fixes an issue)
- [ ] :hammer_and_wrench: Chore (Non-breaking Change: Doc updates, pkg upgrades, typos, etc..)
- [x] :nail_care: New Feature (Breaking/Non-breaking Change)

## Issue (if applicable)

<!-----------------------------------------------------------------------------
If applicable, please link to the github issue and put `closes #XXXX` in your comment to auto-close the issue that your PR fixes.
------------------------------------------------------------------------------>

Context: https://discord.com/channels/554694662431178782/885616186623148062/1237300175907590165

## Risk
> High Risk PRs Require 2 approvals

Very low risk.

> What protocols, transaction types or contract interactions might be affected by this PR?

## Testing

* When account management is DISABLED, clicking "add account" show behave same as prod
* When account management is ENABLED, the button should say "manage accounts" and should open the manage accounts drawer when clicked
* Note ledger support is still WIP with feature flag enabled
* Only affects multi-account supported wallets and metamask should not show the button at all (prod and this PR)

### Engineering

<!-----------------------------------------------------------------------------
Include sufficient information here for an engineer to test your PR. This may include how to test locally, in a built environment, changes to infrastructure etc.
------------------------------------------------------------------------------>

### Operations

<!-----------------------------------------------------------------------------
If your changes have a user-facing impact, describe how a non-technical QA team can functionally test your changes in a preview environment.

If they are not user-facing please describe how to test for any regressions that may occur.
------------------------------------------------------------------------------>

## Screenshots (if applicable)

![image](https://github.com/shapeshift/web/assets/125113430/b73d548a-5bf4-401b-b832-780265858584)
![image](https://github.com/shapeshift/web/assets/125113430/a52146b0-2e9a-46db-b31c-464acdfd74aa)

