### PR TITLE
fix: temporary workaround for thorchain and cosmos ledger app check missing in hdwallet

### DIFF
--- a/src/assets/translations/en/main.json
+++ b/src/assets/translations/en/main.json
@@ -1811,6 +1811,12 @@
     "ledgerOpenApp": {
       "title": "Open the %{appName} App",
       "description": "To connect this chain, you will need to open the Ledger app on your device."
+    },
+    "errors": {
+      "accountMetadataFailedToFetch": {
+        "title": "Account Metadata Fetch Failed",
+        "description": "Something went wrong fetching account metadata."
+      }
     }
   },
   "loremIpsum": "Lorem ipsum dolor sit amet, consectetur adipiscing elit. Ut sed lectus efficitur, iaculis sapien eu, luctus tellus. Maecenas eget sapien dignissim, finibus mauris nec, mollis ipsum. Donec sodales sit amet felis sagittis vestibulum. Ut in consectetur lacus. Suspendisse potenti. Aenean at massa consequat lectus semper pretium. Cras sed bibendum enim. Mauris euismod sit amet dolor in placerat.",

--- a/src/components/ManageAccountsDrawer/components/ImportAccounts.tsx
+++ b/src/components/ManageAccountsDrawer/components/ImportAccounts.tsx
@@ -209,7 +209,7 @@ export const ImportAccounts = ({ chainId, onClose }: ImportAccountsProps) => {
             status: 'error',
             duration: 9000,
             isClosable: true,
-            position: 'top-left',
+            position: 'top-right',
           })
         } else {
           toast({
@@ -220,22 +220,24 @@ export const ImportAccounts = ({ chainId, onClose }: ImportAccountsProps) => {
             status: 'error',
             duration: 9000,
             isClosable: true,
-            position: 'top-left',
+            position: 'top-right',
           })
         }
 
-        return { accountNumber, accountIdWithActivityAndMetadata: [] }
+        // rethrow error to prevent paging thru error state
+        throw error
       }
     },
     initialPageParam: 0,
     getNextPageParam: lastPage => {
       return lastPage.accountNumber + 1
     },
+    retry: false,
   })
 
   // Handle initial automatic loading
   useEffect(() => {
-    if (!autoFetching || !accounts) return
+    if (isLoading || !autoFetching || !accounts) return
 
     // Account numbers are 0-indexed, so we need to add 1 to the highest account number.
     // Add additional empty accounts to show more accounts without having to load more.
@@ -247,7 +249,7 @@ export const ImportAccounts = ({ chainId, onClose }: ImportAccountsProps) => {
       // Stop auto-fetching and switch to manual mode
       setAutoFetching(false)
     }
-  }, [accounts, highestAccountNumber, fetchNextPage, autoFetching])
+  }, [accounts, highestAccountNumber, fetchNextPage, autoFetching, isLoading])
 
   const handleLoadMore = useCallback(() => {
     if (isLoading || autoFetching) return

--- a/src/components/ManageAccountsDrawer/components/LedgerOpenApp.tsx
+++ b/src/components/ManageAccountsDrawer/components/LedgerOpenApp.tsx
@@ -108,6 +108,10 @@ export const LedgerOpenApp = ({ chainId, onClose, onNext }: LedgerOpenAppProps) 
   }, [asset, chainId, ethAsset])
 
   useEffect(() => {
+    // TEMP: Support for app checks one THORChain and Cosmos are currently missing in hdwallet,
+    // so skip the check and make the user confirm the app is open themselves.
+    if (chainId === thorchainChainId || chainId === cosmosChainId) return
+
     // Poll the Ledger every second to see if the correct app is open
     const intervalId = setInterval(async () => {
       const isValidApp = await isCorrectAppOpen()
@@ -118,9 +122,16 @@ export const LedgerOpenApp = ({ chainId, onClose, onNext }: LedgerOpenAppProps) 
     }, 1000)
 
     return () => clearInterval(intervalId) // Clean up on component unmount
-  }, [isCorrectAppOpen, onNext])
+  }, [chainId, isCorrectAppOpen, onNext])
 
   const maybeNext = useCallback(async () => {
+    // TEMP: Support for app checks one THORChain and Cosmos are currently missing in hdwallet,
+    // so skip the check and make the user confirm the app is open themselves.
+    if (chainId === thorchainChainId || chainId === cosmosChainId) {
+      onNext()
+      return
+    }
+
     const isValidApp = await isCorrectAppOpen()
     if (isValidApp) {
       onNext()
@@ -136,7 +147,7 @@ export const LedgerOpenApp = ({ chainId, onClose, onNext }: LedgerOpenAppProps) 
         position: 'top-right',
       })
     }
-  }, [appName, isCorrectAppOpen, onNext, toast, translate])
+  }, [appName, chainId, isCorrectAppOpen, onNext, toast, translate])
 
   const body = useMemo(() => {
     if (!renderedAsset) return null

--- a/src/components/ManageAccountsDrawer/helpers.ts
+++ b/src/components/ManageAccountsDrawer/helpers.ts
@@ -35,7 +35,7 @@ export const getAccountIdsWithActivityAndMetadata = async (
   wallet: HDWallet | null,
 ) => {
   if (!wallet) return []
-  const input = { accountNumber, chainIds: [chainId], wallet }
+  const input = { accountNumber, chainIds: [chainId], wallet, throwOnReject: true }
   const accountIdsAndMetadata = await deriveAccountIdsAndMetadata(input)
 
   return Promise.all(

--- a/src/lib/account/account.ts
+++ b/src/lib/account/account.ts
@@ -19,6 +19,7 @@ export type DeriveAccountIdsAndMetadataArgs = {
   accountNumber: number
   chainIds: ChainId[]
   wallet: HDWallet
+  throwOnReject?: boolean
 }
 export type DeriveAccountIdsAndMetadataReturn = Promise<AccountMetadataById>
 export type DeriveAccountIdsAndMetadata = (
@@ -26,7 +27,7 @@ export type DeriveAccountIdsAndMetadata = (
 ) => DeriveAccountIdsAndMetadataReturn
 
 export const deriveAccountIdsAndMetadata: DeriveAccountIdsAndMetadata = async args => {
-  const { accountNumber, chainIds, wallet } = args
+  const { accountNumber, chainIds, wallet, throwOnReject } = args
   if (!Number.isInteger(accountNumber) || accountNumber < 0)
     throw new Error('invalid accountNumber')
   type ChainNamespaceKey = (typeof CHAIN_NAMESPACE)[keyof typeof CHAIN_NAMESPACE]
@@ -51,6 +52,7 @@ export const deriveAccountIdsAndMetadata: DeriveAccountIdsAndMetadata = async ar
         accountNumber,
         chainIds,
         wallet,
+        throwOnReject,
       }),
     ),
   )
@@ -58,7 +60,11 @@ export const deriveAccountIdsAndMetadata: DeriveAccountIdsAndMetadata = async ar
   const fulfilledAccountIdsAndMetadata = settledAccountIdsAndMetadata.reduce<AccountMetadataById[]>(
     (acc, result) => {
       if (isRejected(result)) {
-        console.error(result.reason)
+        if (throwOnReject) {
+          throw Error(result.reason)
+        } else {
+          console.error(result.reason)
+        }
       } else if (isFulfilled(result)) {
         acc.push(result.value)
       }


### PR DESCRIPTION
## Description

When attempting to manage accounts for thorchain or cosmos, the app crashes due to missing support for `validateCurrentApp` on these chains. When calling `validateCurrentApp`, the promise is rejected with `Unable to find associated app name for coin: ${coin}` because support for these chains is actually missing from hdwallet.

This issue never presented in web previously because we never attempt to validate the correct app being open on ledger, and instead swallow errors (hence the requirement for the new `throwOnReject` flag added in this PR. 

The workaround here is to bypass this check and allow the user to attempt to proceed, then display an error toast if account fetching fails.

We'll have to follow up with a fix in hdwallet and remove this temporary patch.

## Pull Request Type

- [x] :bug: Bug fix (Non-breaking Change: Fixes an issue)
- [ ] :hammer_and_wrench: Chore (Non-breaking Change: Doc updates, pkg upgrades, typos, etc..)
- [ ] :nail_care: New Feature (Breaking/Non-breaking Change)

## Issue (if applicable)

<!-----------------------------------------------------------------------------
If applicable, please link to the github issue and put `closes #XXXX` in your comment to auto-close the issue that your PR fixes.
------------------------------------------------------------------------------>

progresses #6806  - will not be closed until hdwallet is updated to support these chains and the patch removed from web.

## Risk
> High Risk PRs Require 2 approvals

Low risk

> What protocols, transaction types or contract interactions might be affected by this PR?

## Testing

Attempt to manage thorchain or cosmos accounts without the corresponding ledger app being open on the device. A toast should appear with an appropriate error message.

Managing an account with the corresponding ledger app open should not show error toast, but should behave normally.

### Engineering


### Operations

<!-----------------------------------------------------------------------------
If your changes have a user-facing impact, describe how a non-technical QA team can functionally test your changes in a preview environment.

If they are not user-facing please describe how to test for any regressions that may occur.
------------------------------------------------------------------------------>

## Screenshots (if applicable)


https://github.com/shapeshift/web/assets/125113430/e7f40b23-607b-445f-8a55-c85bd6f41f21




