### PR TITLE
fix: use latest out tx for all checks

### DIFF
--- a/src/lib/swapper/swappers/ThorchainSwapper/endpoints.ts
+++ b/src/lib/swapper/swappers/ThorchainSwapper/endpoints.ts
@@ -349,11 +349,11 @@ export const thorchainApi: SwapperApi = {
       const latestOutTx = data.out_txs?.[data.out_txs.length - 1]
       const hasOutboundTx = latestOutTx?.chain !== 'THOR'
 
-      const buyTxHash = parseThorBuyTxHash(txHash, data)
+      const buyTxHash = parseThorBuyTxHash(txHash, latestOutTx)
 
       // if we have an outbound transaction (non rune) and associated buyTxHash, check if it's been confirmed on-chain
       if (hasOutboundTx && buyTxHash) {
-        const outboundTxConfirmations = await checkOutboundTxConfirmations(data, buyTxHash)
+        const outboundTxConfirmations = await checkOutboundTxConfirmations(buyTxHash, latestOutTx)
 
         if (outboundTxConfirmations !== undefined && outboundTxConfirmations > 0) {
           return {

--- a/src/lib/swapper/swappers/ThorchainSwapper/types.ts
+++ b/src/lib/swapper/swappers/ThorchainSwapper/types.ts
@@ -145,7 +145,7 @@ type ThorNodeCoinSchema = {
   decimals?: number
 }
 
-type ThorNodeTxSchema = {
+export type ThorNodeTxSchema = {
   id: string
   chain: ThorchainChain
   from_address: string

--- a/src/lib/swapper/swappers/ThorchainSwapper/utils/checkOutputTxConfirmations.ts
+++ b/src/lib/swapper/swappers/ThorchainSwapper/utils/checkOutputTxConfirmations.ts
@@ -3,19 +3,17 @@ import axios from 'axios'
 import { getConfig } from 'config'
 import { assertUnreachable } from 'lib/utils'
 
-import type { ThorNodeStatusResponseSuccess } from '../types'
+import type { ThorNodeTxSchema } from '../types'
 import { ThorchainChain } from '../types'
 
 export const checkOutboundTxConfirmations = async (
-  thorTxData: ThorNodeStatusResponseSuccess,
   buyTxHash: string,
+  latestOutTx: ThorNodeTxSchema | undefined,
 ) => {
-  const outCoinChain: ThorchainChain | undefined = thorTxData.out_txs?.[0]?.chain
-
-  if (!outCoinChain) return
+  if (!latestOutTx) return
 
   const apiUrl = (() => {
-    switch (outCoinChain) {
+    switch (latestOutTx.chain) {
       case ThorchainChain.BTC: {
         return getConfig().REACT_APP_UNCHAINED_BITCOIN_HTTP_URL
       }
@@ -44,9 +42,9 @@ export const checkOutboundTxConfirmations = async (
         return getConfig().REACT_APP_UNCHAINED_COSMOS_HTTP_URL
       }
       case ThorchainChain.BSC:
-        throw Error(`${outCoinChain} not supported`)
+        throw Error(`${latestOutTx.chain} not supported`)
       default:
-        assertUnreachable(outCoinChain)
+        assertUnreachable(latestOutTx.chain)
     }
   })()
 

--- a/src/lib/swapper/swappers/ThorchainSwapper/utils/parseThorBuyTxHash.ts
+++ b/src/lib/swapper/swappers/ThorchainSwapper/utils/parseThorBuyTxHash.ts
@@ -1,13 +1,11 @@
-import type { ThorNodeStatusResponseSuccess } from '../types'
+import type { ThorNodeTxSchema } from '../types'
 
 const THORCHAIN_EVM_CHAINS = ['ETH', 'AVAX', 'BSC'] as const
 
 export const parseThorBuyTxHash = (
   sellTxId: string,
-  response: ThorNodeStatusResponseSuccess,
+  latestOutTx: ThorNodeTxSchema | undefined,
 ): string | undefined => {
-  const latestOutTx = response.out_txs?.[response.out_txs.length - 1]
-
   if (!latestOutTx) return
 
   // outbound rune transactions do not have a txid as they are processed internally, use sell txid


### PR DESCRIPTION
## Description

Follow up on: https://github.com/shapeshift/web/pull/6813

`checkOutboundTxConfirmations` was still using `out_txs[0]` instead of `latestOutTx`, so this change ensures everything is using the same out tx for status checks.

## Pull Request Type

- [x] :bug: Bug fix (Non-breaking Change: Fixes an issue)
- [ ] :hammer_and_wrench: Chore (Non-breaking Change: Doc updates, pkg upgrades, typos, etc..)
- [ ] :nail_care: New Feature (Breaking/Non-breaking Change)

## Issue (if applicable)

<!-----------------------------------------------------------------------------
If applicable, please link to the github issue and put `closes #XXXX` in your comment to auto-close the issue that your PR fixes.
------------------------------------------------------------------------------>

N/A

## Risk
> High Risk PRs Require 2 approvals

<!-----------------------------------------------------------------------------
Outline the scope of your changes and the risk associated with them. You must use your discretion as an engineer to determine the potential impact of your changes.

WARNING: If your PR introduces a new on-chain transaction or modifies an existing one, please add the "High-Risk" label to this PR and ask for 2 reviewers to approve it before merging.

E.g. an upgrade to `hdwallet` or core state management would be considered higher risk, and might require a full regression test. UI or isolated view changes, or something behind a feature flag may have near zero risk. Small bug fixes might require testing isolated to the specific fix.
------------------------------------------------------------------------------>

Medium - changes logic surrounded status updates for swaps

> What protocols, transaction types or contract interactions might be affected by this PR?

Thorchain

## Testing

<!-----------------------------------------------------------------------------
We treat every PR to be merged with the same scrutiny as if we were merging directly to production.

Your PR will not be merged if you do not complete the sections below for our engineering and operations teams to test.
------------------------------------------------------------------------------>

See https://github.com/shapeshift/web/pull/6813

### Engineering

<!-----------------------------------------------------------------------------
Include sufficient information here for an engineer to test your PR. This may include how to test locally, in a built environment, changes to infrastructure etc.
------------------------------------------------------------------------------>

:point_up: 

### Operations

<!-----------------------------------------------------------------------------
If your changes have a user-facing impact, describe how a non-technical QA team can functionally test your changes in a preview environment.

If they are not user-facing please describe how to test for any regressions that may occur.
------------------------------------------------------------------------------>

:point_up: 

## Screenshots (if applicable)
