### PR TITLE
fix: no more thor tx status spam

### DIFF
--- a/src/context/TransactionsProvider/TransactionsProvider.tsx
+++ b/src/context/TransactionsProvider/TransactionsProvider.tsx
@@ -101,6 +101,8 @@ export const TransactionsProvider: React.FC<TransactionsProviderProps> = ({ chil
         )
       } else if (shouldRefetchSaversOpportunities) {
         ;(async () => {
+          if (data?.parser !== 'thorchain' || data.liquidity?.type !== 'Savers') return
+
           // All we care about here is to have refreshed THOR positions - we don't want to wait for the outbound to be signed/broadcasted
           await waitForThorchainUpdate({ txId: txid, skipOutbound: true }).promise
 


### PR DESCRIPTION
## Description

Currently, we are polling thorchain for tx status on any tx detected over websocket on savers supported chains. To reduce this spam, we can now check the tx metadata and only poll on savers transactions. This is reliable for all savers transactions made through the app. If there is no memo on an external savers transactions (via walletconnect), we would miss the update.

## Pull Request Type

- [x] :bug: Bug fix (Non-breaking Change: Fixes an issue)
- [ ] :hammer_and_wrench: Chore (Non-breaking Change: Doc updates, pkg upgrades, typos, etc..)
- [ ] :nail_care: New Feature (Breaking/Non-breaking Change)

## Issue (if applicable)

<!-----------------------------------------------------------------------------
If applicable, please link to the github issue and put `closes #XXXX` in your comment to auto-close the issue that your PR fixes.
------------------------------------------------------------------------------>

N/A

## Risk
> High Risk PRs Require 2 approvals

<!-----------------------------------------------------------------------------
Outline the scope of your changes and the risk associated with them. You must use your discretion as an engineer to determine the potential impact of your changes.

WARNING: If your PR introduces a new on-chain transaction or modifies an existing one, please add the "High-Risk" label to this PR and ask for 2 reviewers to approve it before merging.

E.g. an upgrade to `hdwallet` or core state management would be considered higher risk, and might require a full regression test. UI or isolated view changes, or something behind a feature flag may have near zero risk. Small bug fixes might require testing isolated to the specific fix.
------------------------------------------------------------------------------>

Low - worst case a refresh is needed for savers opportunity update

> What protocols, transaction types or contract interactions might be affected by this PR?

## Testing

<!-----------------------------------------------------------------------------
We treat every PR to be merged with the same scrutiny as if we were merging directly to production.

Your PR will not be merged if you do not complete the sections below for our engineering and operations teams to test.
------------------------------------------------------------------------------>

- Perform a savers deposit and validate opportunity updates on confirmation
- Perform a savers withdraw and validate opportunity updates on confirmation

### Engineering

<!-----------------------------------------------------------------------------
Include sufficient information here for an engineer to test your PR. This may include how to test locally, in a built environment, changes to infrastructure etc.
------------------------------------------------------------------------------>

:point_up: 

### Operations

<!-----------------------------------------------------------------------------
If your changes have a user-facing impact, describe how a non-technical QA team can functionally test your changes in a preview environment.

If they are not user-facing please describe how to test for any regressions that may occur.
------------------------------------------------------------------------------>

:point_up: 

## Screenshots (if applicable)
