### PR TITLE
feat: add ledger app detection loading spinner

### DIFF
--- a/src/components/ManageAccountsDrawer/components/LedgerOpenApp.tsx
+++ b/src/components/ManageAccountsDrawer/components/LedgerOpenApp.tsx
@@ -1,4 +1,4 @@
-import { Button, Center, Flex, useToast } from '@chakra-ui/react'
+import { Button, Center, Flex, Spinner, useToast } from '@chakra-ui/react'
 import {
   arbitrumChainId,
   arbitrumNovaChainId,
@@ -153,6 +153,9 @@ export const LedgerOpenApp = ({ chainId, onClose, onNext }: LedgerOpenAppProps) 
             translation={'accountManagement.ledgerOpenApp.description'}
             color={'whiteAlpha.600'}
           />
+          <Center>
+            <Spinner mt={10} speed='0.65s' size={'xxl'} thickness='8px' />
+          </Center>
         </Flex>
       </Center>
     )


### PR DESCRIPTION
## Description

Addresses feedback from @woodenfurniture on https://github.com/shapeshift/web/pull/6847, where the Ledger app detection component does not have a loading state, and so can appear glitchy when jumping between screens on app detection.

> We could use some kind of spinner or something while it's auto-detecting, otherwise it looks like a glitch as it jumps page quickly (I was about to raise it as a bug)
>
> https://github.com/shapeshift/web/assets/125113430/06c4b6f6-8950-4190-9cd7-9bee56ad6cf4

## Pull Request Type

- [ ] :bug: Bug fix (Non-breaking Change: Fixes an issue)
- [ ] :hammer_and_wrench: Chore (Non-breaking Change: Doc updates, pkg upgrades, typos, etc..)
- [x] :nail_care: New Feature (Breaking/Non-breaking Change)

## Issue (if applicable)

N/A

## Risk

Very small.

> What protocols, transaction types or contract interactions might be affected by this PR?

None.

## Testing

When connected to a Ledger, navigate through the chain add workflow, both with and without the app already open.
It should look a little less jank with the loading spinner now in place.

### Engineering

☝️

### Operations

☝️

## Screenshots (if applicable)

https://github.com/shapeshift/web/assets/97164662/365e6305-ad34-4d38-b2f5-c11fcbd1d70e

