### PR TITLE
chore: use drawer flow for ledger initial connection

### DIFF
--- a/src/context/WalletProvider/Ledger/components/Connect.tsx
+++ b/src/context/WalletProvider/Ledger/components/Connect.tsx
@@ -61,7 +61,7 @@ export const LedgerConnect = ({ history }: LedgerSetupProps) => {
         localWallet.setLocalWalletTypeAndDeviceId(KeyManager.Ledger, deviceId)
 
         // If account management is enabled, exit the WalletProvider context, which doesn't have access to the ModalProvider
-        // The Account drawer will be opened in the further down the tree
+        // The Account drawer will be opened further down the tree
         if (isAccountManagementEnabled && isLedgerAccountManagementEnabled) {
           walletDispatch({ type: WalletActions.SET_WALLET_MODAL, payload: false })
         } else {

--- a/src/context/WalletProvider/Ledger/components/LedgerMenu.tsx
+++ b/src/context/WalletProvider/Ledger/components/LedgerMenu.tsx
@@ -1,6 +1,6 @@
 import { EditIcon } from '@chakra-ui/icons'
 import { MenuDivider, MenuItem } from '@chakra-ui/react'
-import { useCallback } from 'react'
+import { useCallback, useEffect, useState } from 'react'
 import { useTranslate } from 'react-polyglot'
 import { WalletActions } from 'context/WalletProvider/actions'
 import { SUPPORTED_WALLETS } from 'context/WalletProvider/config'
@@ -12,11 +12,32 @@ import { useWallet } from 'hooks/useWallet/useWallet'
 const editIcon = <EditIcon />
 
 export const LedgerMenu = () => {
-  const { dispatch } = useWallet()
+  const { dispatch, state } = useWallet()
   const translate = useTranslate()
   const isAccountManagementEnabled = useFeatureFlag('AccountManagement')
-
+  const isLedgerAccountManagementEnabled = useFeatureFlag('AccountManagementLedger')
   const accountManagementPopover = useModal('manageAccounts')
+
+  const [hasCompletedChainInit, setHasCompletedChainInit] = useState(false)
+
+  // We want this to run just once, upon Ledger connection, to show the user their connected chains and accounts
+  useEffect(() => {
+    if (
+      state.modalType === KeyManager.Ledger &&
+      !hasCompletedChainInit &&
+      isAccountManagementEnabled &&
+      isLedgerAccountManagementEnabled
+    ) {
+      accountManagementPopover.open({})
+      setHasCompletedChainInit(true)
+    }
+  }, [
+    accountManagementPopover,
+    hasCompletedChainInit,
+    isAccountManagementEnabled,
+    isLedgerAccountManagementEnabled,
+    state,
+  ])
 
   const handleChainsClick = useCallback(() => {
     const ledgerRoutes = SUPPORTED_WALLETS[KeyManager.Ledger].routes
@@ -43,9 +64,12 @@ export const LedgerMenu = () => {
         </MenuItem>
       )}
       {/* TODO: Remove the below menu item once the new flow is added, and before the feature flag is enabled */}
-      <MenuItem justifyContent='space-between' onClick={handleChainsClick}>
-        {translate('walletProvider.ledger.chains.header')}
-      </MenuItem>
+      {!isAccountManagementEnabled ||
+        (!isLedgerAccountManagementEnabled && (
+          <MenuItem justifyContent='space-between' onClick={handleChainsClick}>
+            {translate('walletProvider.ledger.chains.header')}
+          </MenuItem>
+        ))}
     </>
   )
 }


### PR DESCRIPTION
## Description

When the `AccountManagement` and `AccountManagementLedger` feature flags are enabled, use the new drawer flow for Ledger connection.

## Pull Request Type

- [ ] :bug: Bug fix (Non-breaking Change: Fixes an issue)
- [x] :hammer_and_wrench: Chore (Non-breaking Change: Doc updates, pkg upgrades, typos, etc..)
- [ ] :nail_care: New Feature (Breaking/Non-breaking Change)

## Issue (if applicable)

Closes https://github.com/shapeshift/web/issues/6808

## Risk

Medium - could bork Ledger connection if Implemented incorrectly.
 
> What protocols, transaction types or contract interactions might be affected by this PR?

None.

## Testing

Test connecting to a Ledger with both with and without the feature flags enabled.

- When they are disabled, we should use the existing flow upon connection.
- When they are enabled, upon connection we should open the new account management modal showing the currently connected accounts and chains, and allow adding more via the drawer flow.

### Engineering

☝️

### Operations

☝️

## Screenshots (if applicable)

N/A