### PR TITLE
feat: loading state for account import

### DIFF
--- a/src/components/ManageAccountsDrawer/components/ImportAccounts.tsx
+++ b/src/components/ManageAccountsDrawer/components/ImportAccounts.tsx
@@ -213,7 +213,7 @@ export const ImportAccounts = ({ chainId, onClose }: ImportAccountsProps) => {
 
   // Handle initial automatic loading
   useEffect(() => {
-    if (isLoading || !autoFetching || !accounts) return
+    if (isLoading || !autoFetching || !accounts || !queryEnabled) return
 
     // Account numbers are 0-indexed, so we need to add 1 to the highest account number.
     // Add additional empty accounts to show more accounts without having to load more.
@@ -225,7 +225,7 @@ export const ImportAccounts = ({ chainId, onClose }: ImportAccountsProps) => {
       // Stop auto-fetching and switch to manual mode
       setAutoFetching(false)
     }
-  }, [accounts, highestAccountNumber, fetchNextPage, autoFetching, isLoading])
+  }, [accounts, highestAccountNumber, fetchNextPage, autoFetching, isLoading, queryEnabled])
 
   const handleLoadMore = useCallback(() => {
     if (isLoading || autoFetching) return

--- a/src/components/ManageAccountsDrawer/components/ImportAccounts.tsx
+++ b/src/components/ManageAccountsDrawer/components/ImportAccounts.tsx
@@ -248,6 +248,11 @@ export const ImportAccounts = ({ chainId, onClose }: ImportAccountsProps) => {
   }, [])
 
   const handleDone = useCallback(async () => {
+    if (!accounts) {
+      console.error('Missing accounts data')
+      return
+    }
+
     setIsSubmitting(true)
 
     // For every new account that is active, fetch the account and upsert it into the redux state
@@ -262,12 +267,6 @@ export const ImportAccounts = ({ chainId, onClose }: ImportAccountsProps) => {
         )
       }),
     )
-
-    if (!accounts) {
-      console.error('Missing accounts data')
-      setIsSubmitting(false)
-      return
-    }
 
     const accountMetadataByAccountId = accounts.pages.reduce((accumulator, accounts) => {
       const obj = accounts.accountIdWithActivityAndMetadata.reduce(
@@ -343,7 +342,7 @@ export const ImportAccounts = ({ chainId, onClose }: ImportAccountsProps) => {
           <Button
             colorScheme='blue'
             onClick={handleDone}
-            isDisabled={isLoading || autoFetching || isSubmitting}
+            isDisabled={isLoading || autoFetching || isSubmitting || !accounts}
             _disabled={disabledProps}
           >
             {translate('common.done')}


### PR DESCRIPTION
## Description

Adds loading state to account import in the manage accounts drawer.

## Pull Request Type

- [ ] :bug: Bug fix (Non-breaking Change: Fixes an issue)
- [ ] :hammer_and_wrench: Chore (Non-breaking Change: Doc updates, pkg upgrades, typos, etc..)
- [x] :nail_care: New Feature (Breaking/Non-breaking Change)

## Issue (if applicable)

closes #6849

## Risk
> High Risk PRs Require 2 approvals

Moderate risk. This is intended to prevent getting into invalid app state during account import, when opening and closing the account management drawer.

> What protocols, transaction types or contract interactions might be affected by this PR?

## Testing

Check that it's not possible to corrupt the state of the app by importing an account and opening/closing the account management drawer, and also rapidly adding/removing accounts. 

### Engineering


### Operations

<!-----------------------------------------------------------------------------
If your changes have a user-facing impact, describe how a non-technical QA team can functionally test your changes in a preview environment.

If they are not user-facing please describe how to test for any regressions that may occur.
------------------------------------------------------------------------------>

## Screenshots (if applicable)

Original issue:

https://github.com/shapeshift/web/assets/125113430/c3dea3d3-b6cb-4cbc-9981-9e29ac882efa

Fixed:

https://github.com/shapeshift/web/assets/125113430/623aa190-9c89-410b-af76-566fd57028e0

