### PR TITLE
fix: non-ledger wallets unable to import accounts

### DIFF
--- a/src/components/ManageAccountsDrawer/components/ImportAccounts.tsx
+++ b/src/components/ManageAccountsDrawer/components/ImportAccounts.tsx
@@ -200,11 +200,16 @@ export const ImportAccounts = ({ chainId, onClose }: ImportAccountsProps) => {
     enabled: queryEnabled,
   })
 
-  // Reset paging on mount for ledger wallet since the state and cache are not aware of what app is
-  // open on the device. This is to prevent the cache from creating invalid state where the app on
-  // the device is not open but the cache thinks it is.
   useEffect(() => {
-    if (!isLedgerWallet || queryEnabled) return
+    if (!isLedgerWallet || queryEnabled) {
+      setAutoFetching(true)
+      setQueryEnabled(true)
+      return
+    }
+
+    // Reset paging on mount for ledger wallet since the state and cache are not aware of what app
+    // is open on the device. This is to prevent the cache from creating invalid state where the app
+    // on the device is not open but the cache thinks it is.
     queryClient.resetQueries({ queryKey: ['accountIdWithActivityAndMetadata'] }).then(() => {
       setAutoFetching(true)
       setQueryEnabled(true)

--- a/src/components/ManageAccountsDrawer/components/ImportAccounts.tsx
+++ b/src/components/ManageAccountsDrawer/components/ImportAccounts.tsx
@@ -201,7 +201,9 @@ export const ImportAccounts = ({ chainId, onClose }: ImportAccountsProps) => {
   })
 
   useEffect(() => {
-    if (!isLedgerWallet || queryEnabled) {
+    if (queryEnabled) return
+
+    if (!isLedgerWallet) {
       setAutoFetching(true)
       setQueryEnabled(true)
       return


### PR DESCRIPTION
## Description

Fixes non-ledger wallets (e.g native) unable to load any accounts in "import accounts" in account management.

## Pull Request Type

- [x] :bug: Bug fix (Non-breaking Change: Fixes an issue)
- [ ] :hammer_and_wrench: Chore (Non-breaking Change: Doc updates, pkg upgrades, typos, etc..)
- [ ] :nail_care: New Feature (Breaking/Non-breaking Change)

## Issue (if applicable)

closes #6906 

## Risk
> High Risk PRs Require 2 approvals

Low risk.

> What protocols, transaction types or contract interactions might be affected by this PR?

## Testing

Check non-ledger wallets can load accounts in import accounts drawer in account management (metamask excluded)

### Engineering

<!-----------------------------------------------------------------------------
Include sufficient information here for an engineer to test your PR. This may include how to test locally, in a built environment, changes to infrastructure etc.
------------------------------------------------------------------------------>

### Operations

<!-----------------------------------------------------------------------------
If your changes have a user-facing impact, describe how a non-technical QA team can functionally test your changes in a preview environment.

If they are not user-facing please describe how to test for any regressions that may occur.
------------------------------------------------------------------------------>

## Screenshots (if applicable)


https://github.com/shapeshift/web/assets/125113430/26670856-1690-44ca-a7b7-7464f4982ec0

