### PR TITLE
fix: only display wallet connected chains in related asset selection

### DIFF
--- a/src/components/AssetSelection/AssetSelection.tsx
+++ b/src/components/AssetSelection/AssetSelection.tsx
@@ -18,6 +18,7 @@ type TradeAssetSelectBaseProps = {
   assetIds?: AssetId[]
   isLoading?: boolean
   buttonProps?: ButtonProps
+  onlyConnectedChains: boolean
 } & FlexProps
 
 type TradeAssetSelectReadonlyProps = {
@@ -42,6 +43,7 @@ export const TradeAssetSelect: React.FC<TradeAssetSelectProps> = memo(props => {
     assetIds,
     isReadOnly,
     isLoading,
+    onlyConnectedChains,
     buttonProps,
     flexProps,
   } = useMemo(() => {
@@ -52,6 +54,7 @@ export const TradeAssetSelect: React.FC<TradeAssetSelectProps> = memo(props => {
       assetIds,
       isReadOnly,
       isLoading,
+      onlyConnectedChains,
       buttonProps,
       ...flexProps
     } = props
@@ -62,6 +65,7 @@ export const TradeAssetSelect: React.FC<TradeAssetSelectProps> = memo(props => {
       assetIds,
       isReadOnly,
       isLoading,
+      onlyConnectedChains,
       buttonProps,
       flexProps,
     }
@@ -114,6 +118,7 @@ export const TradeAssetSelect: React.FC<TradeAssetSelectProps> = memo(props => {
         onChangeAsset={handleAssetChange}
         isLoading={isLoading}
         buttonProps={combinedButtonProps}
+        onlyConnectedChains={onlyConnectedChains}
       />
     </Flex>
   )

--- a/src/components/AssetSelection/components/AssetChainDropdown/AssetChainDropdown.tsx
+++ b/src/components/AssetSelection/components/AssetChainDropdown/AssetChainDropdown.tsx
@@ -13,10 +13,8 @@ import { memo, useCallback, useMemo } from 'react'
 import { useTranslate } from 'react-polyglot'
 import { useWallet } from 'hooks/useWallet/useWallet'
 import { isAssetSupportedByWallet } from 'state/slices/portfolioSlice/utils'
-import {
-  selectChainDisplayNameByAssetId,
-  selectRelatedAssetIdsInclusiveSorted,
-} from 'state/slices/selectors'
+import { selectRelatedAssetIdsInclusiveSorted } from 'state/slices/related-assets-selectors'
+import { selectChainDisplayNameByAssetId } from 'state/slices/selectors'
 import { useAppSelector } from 'state/store'
 
 import { AssetRowLoading } from '../AssetRowLoading'
@@ -49,7 +47,7 @@ export const AssetChainDropdown: React.FC<AssetChainDropdownProps> = memo(
       return relatedAssetIds.filter(relatedAssetId => assetIds.includes(relatedAssetId))
     }, [assetIds, relatedAssetIds])
 
-    const renderChains = useMemo(() => {
+    const renderedChains = useMemo(() => {
       if (!assetId) return null
       return filteredRelatedAssetIds.map(relatedAssetId => {
         const isSupported = wallet && isAssetSupportedByWallet(relatedAssetId, wallet)
@@ -104,7 +102,7 @@ export const AssetChainDropdown: React.FC<AssetChainDropdownProps> = memo(
         </Tooltip>
         <MenuList zIndex='modal'>
           <MenuOptionGroup type='radio' value={assetId} onChange={handleChangeAsset}>
-            {renderChains}
+            {renderedChains}
           </MenuOptionGroup>
         </MenuList>
       </Menu>

--- a/src/components/AssetSelection/components/AssetChainDropdown/AssetChainDropdown.tsx
+++ b/src/components/AssetSelection/components/AssetChainDropdown/AssetChainDropdown.tsx
@@ -27,10 +27,11 @@ type AssetChainDropdownProps = {
   buttonProps?: ButtonProps
   isLoading?: boolean
   isError?: boolean
+  onlyConnectedChains: boolean
 }
 
 export const AssetChainDropdown: React.FC<AssetChainDropdownProps> = memo(
-  ({ assetId, assetIds, onChangeAsset, buttonProps, isLoading, isError }) => {
+  ({ assetId, assetIds, onChangeAsset, buttonProps, isLoading, isError, onlyConnectedChains }) => {
     const {
       state: { wallet },
     } = useWallet()
@@ -38,8 +39,12 @@ export const AssetChainDropdown: React.FC<AssetChainDropdownProps> = memo(
     const chainDisplayName = useAppSelector(state =>
       selectChainDisplayNameByAssetId(state, assetId ?? ''),
     )
+    const relatedAssetIdsFilter = useMemo(
+      () => ({ assetId, onlyConnectedChains }),
+      [assetId, onlyConnectedChains],
+    )
     const relatedAssetIds = useAppSelector(state =>
-      selectRelatedAssetIdsInclusiveSorted(state, assetId ?? ''),
+      selectRelatedAssetIdsInclusiveSorted(state, relatedAssetIdsFilter),
     )
 
     const filteredRelatedAssetIds = useMemo(() => {

--- a/src/components/MultiHopTrade/components/TradeInput/TradeInput.tsx
+++ b/src/components/MultiHopTrade/components/TradeInput/TradeInput.tsx
@@ -544,6 +544,7 @@ export const TradeInput = memo(({ isCompact }: TradeInputProps) => {
         assetId={sellAsset.assetId}
         onAssetClick={handleSellAssetClick}
         onAssetChange={setSellAsset}
+        onlyConnectedChains={true}
       />
     ),
     [handleSellAssetClick, sellAsset.assetId, setSellAsset],
@@ -555,6 +556,7 @@ export const TradeInput = memo(({ isCompact }: TradeInputProps) => {
         assetId={buyAsset.assetId}
         onAssetClick={handleBuyAssetClick}
         onAssetChange={setBuyAsset}
+        onlyConnectedChains={true}
       />
     ),
     [buyAsset.assetId, handleBuyAssetClick, setBuyAsset],

--- a/src/components/MultiHopTrade/components/TradeInput/TradeInput.tsx
+++ b/src/components/MultiHopTrade/components/TradeInput/TradeInput.tsx
@@ -556,7 +556,7 @@ export const TradeInput = memo(({ isCompact }: TradeInputProps) => {
         assetId={buyAsset.assetId}
         onAssetClick={handleBuyAssetClick}
         onAssetChange={setBuyAsset}
-        onlyConnectedChains={true}
+        onlyConnectedChains={false}
       />
     ),
     [buyAsset.assetId, handleBuyAssetClick, setBuyAsset],

--- a/src/components/RelatedAssets/RelatedAssets.tsx
+++ b/src/components/RelatedAssets/RelatedAssets.tsx
@@ -15,7 +15,10 @@ type RelatedAssetsProps = {
 }
 
 export const RelatedAssets: React.FC<RelatedAssetsProps> = ({ assetId }) => {
-  const relatedAssetIds = useAppSelector(state => selectRelatedAssetIds(state, assetId))
+  const relatedAssetIdsFilter = useMemo(() => ({ assetId }), [assetId])
+  const relatedAssetIds = useAppSelector(state =>
+    selectRelatedAssetIds(state, relatedAssetIdsFilter),
+  )
   const assets = useAppSelector(selectAssets)
   const history = useHistory()
 

--- a/src/components/RelatedAssets/RelatedAssets.tsx
+++ b/src/components/RelatedAssets/RelatedAssets.tsx
@@ -6,7 +6,8 @@ import type { Column, Row } from 'react-table'
 import { ReactTable } from 'components/ReactTable/ReactTable'
 import { AssetCell } from 'components/StakingVaults/Cells'
 import { Text } from 'components/Text'
-import { selectAssets, selectRelatedAssetIds } from 'state/slices/selectors'
+import { selectRelatedAssetIds } from 'state/slices/related-assets-selectors'
+import { selectAssets } from 'state/slices/selectors'
 import { useAppSelector } from 'state/store'
 
 type RelatedAssetsProps = {

--- a/src/pages/Lending/Pool/components/Borrow/BorrowInput.tsx
+++ b/src/pages/Lending/Pool/components/Borrow/BorrowInput.tsx
@@ -419,6 +419,7 @@ export const BorrowInput = ({
         assetId={collateralAssetId}
         isReadOnly
         isLoading={isLendingSupportedAssetsLoading}
+        onlyConnectedChains={true}
       />
     )
   }, [collateralAssetId, isLendingSupportedAssetsLoading])
@@ -431,6 +432,7 @@ export const BorrowInput = ({
         onAssetClick={handleBorrowAssetClick}
         onAssetChange={setBorrowAsset}
         isLoading={isLendingSupportedAssetsLoading}
+        onlyConnectedChains={true}
       />
     )
   }, [

--- a/src/pages/Lending/Pool/components/Repay/RepayInput.tsx
+++ b/src/pages/Lending/Pool/components/Repay/RepayInput.tsx
@@ -346,6 +346,7 @@ export const RepayInput = ({
         // Users have the possibility to repay in any supported asset, not only their collateral/borrowed asset
         // https://docs.thorchain.org/thorchain-finance/lending#loan-repayment-closeflow
         isReadOnly={false}
+        onlyConnectedChains={true}
       />
     )
   }, [setRepaymentAsset, handleRepaymentAssetClick, repaymentAsset?.assetId])
@@ -356,6 +357,7 @@ export const RepayInput = ({
         assetId={collateralAssetId}
         isReadOnly
         isLoading={isLendingSupportedAssetsLoading}
+        onlyConnectedChains={true}
       />
     )
   }, [collateralAssetId, isLendingSupportedAssetsLoading])

--- a/src/pages/ThorChainLP/components/AddLiquidity/AddLiquidityInput.tsx
+++ b/src/pages/ThorChainLP/components/AddLiquidity/AddLiquidityInput.tsx
@@ -1266,6 +1266,7 @@ export const AddLiquidityInput: React.FC<AddLiquidityInputProps> = ({
           isLoading={false}
           mb={0}
           buttonProps={buttonProps}
+          onlyConnectedChains={false}
         />
         <TradeAssetSelect
           assetId={thorchainAssetId}
@@ -1273,6 +1274,7 @@ export const AddLiquidityInput: React.FC<AddLiquidityInputProps> = ({
           isLoading={false}
           mb={0}
           buttonProps={buttonProps}
+          onlyConnectedChains={false}
         />
       </Stack>
     )

--- a/src/state/selectors.ts
+++ b/src/state/selectors.ts
@@ -49,6 +49,7 @@ type ParamFilter = Partial<{
   txStatus: TxStatus
   feeModel: ParameterModel
   timeframe: HistoryTimeframe
+  onlyConnectedChains: boolean
 }>
 
 type ParamFilterKey = keyof ParamFilter
@@ -82,3 +83,4 @@ export const selectSearchQueryFromFilter = selectParamFromFilter('searchQuery')
 export const selectTxStatusParamFromFilter = selectParamFromFilter('txStatus')
 export const selectFeeModelParamFromFilter = selectParamFromFilter('feeModel')
 export const selectTimeframeParamFromFilter = selectParamFromFilter('timeframe')
+export const selectOnlyConnectedChainsParamFromFilter = selectParamFromFilter('onlyConnectedChains')

--- a/src/state/slices/assetsSlice/selectors.ts
+++ b/src/state/slices/assetsSlice/selectors.ts
@@ -1,5 +1,5 @@
 import { createSelector } from '@reduxjs/toolkit'
-import type { AssetId, ChainId } from '@shapeshiftoss/caip'
+import { type AssetId, type ChainId } from '@shapeshiftoss/caip'
 import type { Asset } from '@shapeshiftoss/types'
 import { matchSorter } from 'match-sorter'
 import createCachedSelector from 're-reselect'
@@ -15,27 +15,6 @@ export const selectAssetById = createCachedSelector(
   (state: ReduxState) => state.assets.byId,
   (_state: ReduxState, assetId: AssetId) => assetId,
   (byId, assetId) => byId[assetId] || undefined,
-)((_state: ReduxState, assetId: AssetId | undefined): AssetId => assetId ?? 'undefined')
-
-// selects all related assetIds, inclusive of the asset being queried
-export const selectRelatedAssetIdsInclusive = createCachedSelector(
-  (state: ReduxState) => state.assets.relatedAssetIndex,
-  selectAssetById,
-  (relatedAssetIndex, asset): AssetId[] => {
-    if (!asset) return []
-    const relatedAssetKey = asset.relatedAssetKey
-    if (!relatedAssetKey) return [asset.assetId]
-    return [relatedAssetKey].concat(relatedAssetIndex[relatedAssetKey] ?? [])
-  },
-)((_state: ReduxState, assetId: AssetId | undefined): AssetId => assetId ?? 'undefined')
-
-// selects all related assetIds, exclusive of the asset being queried
-export const selectRelatedAssetIds = createCachedSelector(
-  selectRelatedAssetIdsInclusive,
-  selectAssetById,
-  (relatedAssetIdsInclusive, asset): AssetId[] => {
-    return relatedAssetIdsInclusive.filter(assetId => assetId !== asset?.assetId) ?? []
-  },
 )((_state: ReduxState, assetId: AssetId | undefined): AssetId => assetId ?? 'undefined')
 
 export const selectAssetByFilter = createCachedSelector(

--- a/src/state/slices/portfolioSlice/selectors.ts
+++ b/src/state/slices/portfolioSlice/selectors.ts
@@ -7,7 +7,6 @@ import type {
   BIP44Params,
   PartialRecord,
 } from '@shapeshiftoss/types'
-import { orderBy } from 'lodash'
 import cloneDeep from 'lodash/cloneDeep'
 import entries from 'lodash/entries'
 import keys from 'lodash/keys'
@@ -33,7 +32,6 @@ import {
   selectAssetIdParamFromFilter,
   selectChainIdParamFromFilter,
 } from 'state/selectors'
-import { selectAssets, selectRelatedAssetIdsInclusive } from 'state/slices/assetsSlice/selectors'
 import { selectMarketDataUserCurrency } from 'state/slices/marketDataSlice/selectors'
 import { selectAllEarnUserLpOpportunitiesByFilter } from 'state/slices/opportunitiesSlice/selectors/lpSelectors'
 import {
@@ -49,6 +47,7 @@ import {
 } from 'state/slices/portfolioSlice/utils'
 import { selectBalanceThreshold } from 'state/slices/preferencesSlice/selectors'
 
+import { selectAssets } from '../assetsSlice/selectors'
 import {
   selectPortfolioAccountBalancesBaseUnit,
   selectPortfolioAssetBalancesBaseUnit,
@@ -1078,23 +1077,3 @@ export const selectEquityTotalBalance = createDeepEqualOutputSelector(
     )
   },
 )
-
-export const selectRelatedAssetIdsInclusiveSorted = createCachedSelector(
-  selectRelatedAssetIdsInclusive,
-  selectPortfolioUserCurrencyBalances,
-  (relatedAssetIds, portfolioUserCurrencyBalances) => {
-    const chainAdapterManager = getChainAdapterManager()
-    return orderBy(
-      relatedAssetIds.map(assetId => {
-        const { chainId } = fromAssetId(assetId)
-        return {
-          assetId,
-          balance: Number(portfolioUserCurrencyBalances[assetId] ?? '0'),
-          chainName: chainAdapterManager.get(chainId)?.getDisplayName() ?? '',
-        }
-      }),
-      ['balance', 'chainName'],
-      ['desc', 'asc'],
-    ).map(({ assetId }) => assetId)
-  },
-)((_state: ReduxState, assetId: AssetId | undefined): AssetId => assetId ?? 'undefined')

--- a/src/state/slices/related-assets-selectors.ts
+++ b/src/state/slices/related-assets-selectors.ts
@@ -1,0 +1,62 @@
+import type { AssetId } from '@shapeshiftoss/caip'
+import { fromAssetId } from '@shapeshiftoss/caip'
+import orderBy from 'lodash/orderBy'
+import createCachedSelector from 're-reselect'
+import { getChainAdapterManager } from 'context/PluginProvider/chainAdapterSingleton'
+import type { ReduxState } from 'state/reducer'
+
+import { selectAssetById } from './assetsSlice/selectors'
+import { selectPortfolioUserCurrencyBalances, selectWalletChainIds } from './common-selectors'
+
+/**
+ * Selects all related assetIds, inclusive of the asset being queried.
+ *
+ * Excludes assetIds on chains that are not connected on the wallet.
+ */
+export const selectRelatedAssetIdsInclusive = createCachedSelector(
+  (state: ReduxState) => state.assets.relatedAssetIndex,
+  selectAssetById,
+  selectWalletChainIds,
+  (relatedAssetIndex, asset, walletConnectedChainIds): AssetId[] => {
+    if (!asset) return []
+    const relatedAssetKey = asset.relatedAssetKey
+    if (!relatedAssetKey) return [asset.assetId]
+    return [relatedAssetKey].concat(relatedAssetIndex[relatedAssetKey] ?? []).filter(assetId => {
+      const { chainId } = fromAssetId(assetId)
+      return walletConnectedChainIds.includes(chainId)
+    })
+  },
+)((_state: ReduxState, assetId: AssetId | undefined): AssetId => assetId ?? 'undefined')
+
+/**
+ * Selects all related assetIds, exclusive of the asset being queried.
+ *
+ * Excludes assetIds on chains that are not connected on the wallet.
+ */
+export const selectRelatedAssetIds = createCachedSelector(
+  selectRelatedAssetIdsInclusive,
+  selectAssetById,
+  (relatedAssetIdsInclusive, asset): AssetId[] => {
+    return relatedAssetIdsInclusive.filter(assetId => assetId !== asset?.assetId) ?? []
+  },
+)((_state: ReduxState, assetId: AssetId | undefined): AssetId => assetId ?? 'undefined')
+
+export const selectRelatedAssetIdsInclusiveSorted = createCachedSelector(
+  selectRelatedAssetIdsInclusive,
+  selectPortfolioUserCurrencyBalances,
+  (relatedAssetIds, portfolioUserCurrencyBalances) => {
+    const chainAdapterManager = getChainAdapterManager()
+    return orderBy(
+      relatedAssetIds.map(assetId => {
+        const { chainId } = fromAssetId(assetId)
+        return {
+          assetId,
+          balance: Number(portfolioUserCurrencyBalances[assetId] ?? '0'),
+          chainName: chainAdapterManager.get(chainId)?.getDisplayName() ?? '',
+        }
+      }),
+      ['balance', 'chainName'],
+      ['desc', 'asc'],
+    ).map(({ assetId }) => assetId)
+  },
+)((_state: ReduxState, assetId: AssetId | undefined): AssetId => assetId ?? 'undefined')


### PR DESCRIPTION
## Description

Only displays related assets for chains that are currently connected to the app, except for LP add liquidity which shows all available chains for the selected asset.

## Pull Request Type

- [x] :bug: Bug fix (Non-breaking Change: Fixes an issue)
- [ ] :hammer_and_wrench: Chore (Non-breaking Change: Doc updates, pkg upgrades, typos, etc..)
- [ ] :nail_care: New Feature (Breaking/Non-breaking Change)

## Issue (if applicable)

<!-----------------------------------------------------------------------------
If applicable, please link to the github issue and put `closes #XXXX` in your comment to auto-close the issue that your PR fixes.
------------------------------------------------------------------------------>

closes #6905 

## Risk
> High Risk PRs Require 2 approvals

~~Marking this as high risk, as it makes minor changes to asset selectors. ~~
After discussion, this is actually moderate risk and should not require multiple reviewers.

The change is largely lift-and-shift with the addition of conditionally filtering on wallet connected chains for related assets. The selectors were moved into a different file due to circular deps.

> What protocols, transaction types or contract interactions might be affected by this PR?

## Testing

* Only related assets on chains currently connected to the app appear in trade input chain dropdown
* Only related assets on chains currently connected to the app appear in fiat page chain dropdown
* Only related assets on chains currently connected to the app appear in lending input chain dropdown
* Only related assets on chains currently connected to the app appear in asset page (in wallet page)
* All related assets (regardless of connected chains) appear in LP chain dropdown

### Engineering

<!-----------------------------------------------------------------------------
Include sufficient information here for an engineer to test your PR. This may include how to test locally, in a built environment, changes to infrastructure etc.
------------------------------------------------------------------------------>

### Operations

<!-----------------------------------------------------------------------------
If your changes have a user-facing impact, describe how a non-technical QA team can functionally test your changes in a preview environment.

If they are not user-facing please describe how to test for any regressions that may occur.
------------------------------------------------------------------------------>

## Screenshots (if applicable)

Examples below illustrate behavior with only BTC, ETH and AVAX connected via ledger.

Trade input:
![image](https://github.com/shapeshift/web/assets/125113430/27a6427c-a0d9-407e-9d6c-43bacb45c60d)

Lending:
![image](https://github.com/shapeshift/web/assets/125113430/9b604423-0548-4c9b-898e-9686d3b4ee95)

Fiat page:
![image](https://github.com/shapeshift/web/assets/125113430/b70be767-0b9d-4e18-b8bc-c8710c846602)

Asset page (in wallet page):
![image](https://github.com/shapeshift/web/assets/125113430/2c328cd1-a133-4ce2-8d6b-4ec7f2249d7e)

LP still shows all chains regardless of what's connected (note BNB not connected but appears):
![image](https://github.com/shapeshift/web/assets/125113430/3a5361cf-f305-43de-aa03-0f87d2a7b694)



<!-- av pr metadata
This information is embedded by the av CLI when creating PRs to track the status of stacks when using Aviator. Please do not delete or edit this section of the PR.
```
{"parent":"develop","parentHead":"","trunk":"develop"}
```
-->
