### PR TITLE
fix: send modal handle zero and negative amounts gracefully

### DIFF
--- a/src/components/Modals/Send/views/Details.tsx
+++ b/src/components/Modals/Send/views/Details.tsx
@@ -74,6 +74,8 @@ export const Details = () => {
     control,
   }) as Partial<SendInput>
 
+  const hasEnteredPositiveAmount = bnOrZero(amountCryptoPrecision).plus(bnOrZero(fiatAmount)).gt(0)
+
   const previousAccountId = usePrevious(accountId)
 
   const handleAccountChange = useCallback(
@@ -309,7 +311,7 @@ export const Details = () => {
           <Button
             width='full'
             isDisabled={
-              !(amountCryptoPrecision ?? fiatAmount) ||
+              !hasEnteredPositiveAmount ||
               !!amountFieldError ||
               isLoading ||
               Boolean(memoFieldError)


### PR DESCRIPTION
## Description

Spotted by @woodenfurniture in https://github.com/shapeshift/web/pull/6876.

> 🚫 Allows user to send 0 amount
> 🚫 Allows user to enter negative amount, displays Insufficient Funds:

See this jam for develop and prod repros as well as this PR fixed behavior:

https://jam.dev/c/542c2419-7c78-4339-a27e-77f63666e490

<!-- Please describe your changes -->

## Pull Request Type

- [x] :bug: Bug fix (Non-breaking Change: Fixes an issue)
- [ ] :hammer_and_wrench: Chore (Non-breaking Change: Doc updates, pkg upgrades, typos, etc..)
- [ ] :nail_care: New Feature (Breaking/Non-breaking Change)

## Issue (if applicable)

<!-----------------------------------------------------------------------------
If applicable, please link to the github issue and put `closes #XXXX` in your comment to auto-close the issue that your PR fixes.
------------------------------------------------------------------------------>

closes N/A, spotted in https://github.com/shapeshift/web/pull/6876.

## Risk
> High Risk PRs Require 2 approvals

<!-----------------------------------------------------------------------------
Outline the scope of your changes and the risk associated with them. You must use your discretion as an engineer to determine the potential impact of your changes.

WARNING: If your PR introduces a new on-chain transaction or modifies an existing one, please add the "High-Risk" label to this PR and ask for 2 reviewers to approve it before merging.

E.g. an upgrade to `hdwallet` or core state management would be considered higher risk, and might require a full regression test. UI or isolated view changes, or something behind a feature flag may have near zero risk. Small bug fixes might require testing isolated to the specific fix.
------------------------------------------------------------------------------>

> What protocols, transaction types or contract interactions might be affected by this PR?

Low - testing steps to be added. Mostly related to current negative amounts error messaging when sending max with a low UTXO balance

## Testing

<!-----------------------------------------------------------------------------
We treat every PR to be merged with the same scrutiny as if we were merging directly to production.

Your PR will not be merged if you do not complete the sections below for our engineering and operations teams to test.
------------------------------------------------------------------------------>

### Engineering

<!-----------------------------------------------------------------------------
Include sufficient information here for an engineer to test your PR. This may include how to test locally, in a built environment, changes to infrastructure etc.
------------------------------------------------------------------------------>

### Operations

<!-----------------------------------------------------------------------------
If your changes have a user-facing impact, describe how a non-technical QA team can functionally test your changes in a preview environment.

If they are not user-facing please describe how to test for any regressions that may occur.
------------------------------------------------------------------------------>

## Screenshots (if applicable)

https://jam.dev/c/542c2419-7c78-4339-a27e-77f63666e490

<!-- av pr metadata
This information is embedded by the av CLI when creating PRs to track the status of stacks when using Aviator. Please do not delete or edit this section of the PR.
```
{"parent":"feat_bail_out_estimate_insufficient_send_funds","parentHead":"271e1adb9e0e7a0ac13d3f2c8320c47c98932d34","parentPull":6876,"trunk":"develop"}
```
-->
