### PR TITLE
feat: temporary workaround to handle multiple ledger devices

### DIFF
--- a/src/assets/translations/en/main.json
+++ b/src/assets/translations/en/main.json
@@ -1421,7 +1421,7 @@
         "pairNewDeviceBody": " Click 'Pair new device' to get started",
         "pairNewDeviceButton": "Pair new device",
         "pairExistingDeviceButton": "Pair existing device",
-        "pairExistingDeviceBody": "Connecting a different Ledger device to last time? Click 'Pair new device' to start fresh."
+        "pairExistingDeviceBody": "Connecting a different Ledger device? Click 'Pair new device' to start fresh."
       },
       "failure": {
         "header": "Error",

--- a/src/assets/translations/en/main.json
+++ b/src/assets/translations/en/main.json
@@ -1418,8 +1418,10 @@
       },
       "connect": {
         "header": "Pair Ledger",
-        "body": "Click Pair then select your Ledger from the popup window",
-        "button": "Pair"
+        "pairNewDeviceBody": " Click 'Pair new device' to get started",
+        "pairNewDeviceButton": "Pair new device",
+        "pairExistingDeviceButton": "Pair existing device",
+        "pairExistingDeviceBody": "Connecting a different Ledger device to last time? Click 'Pair new device' to start fresh."
       },
       "failure": {
         "header": "Error",

--- a/src/context/WalletProvider/Ledger/components/Connect.tsx
+++ b/src/context/WalletProvider/Ledger/components/Connect.tsx
@@ -1,4 +1,6 @@
+import { Button, Spinner } from '@chakra-ui/react'
 import React, { useCallback, useState } from 'react'
+import { useTranslate } from 'react-polyglot'
 import type { RouteComponentProps } from 'react-router-dom'
 import type { ActionTypes } from 'context/WalletProvider/actions'
 import { WalletActions } from 'context/WalletProvider/actions'
@@ -7,6 +9,9 @@ import { useLocalWallet } from 'context/WalletProvider/local-wallet'
 import { removeAccountsAndChainListeners } from 'context/WalletProvider/WalletProvider'
 import { useFeatureFlag } from 'hooks/useFeatureFlag/useFeatureFlag'
 import { useWallet } from 'hooks/useWallet/useWallet'
+import { portfolio, portfolioApi } from 'state/slices/portfolioSlice/portfolioSlice'
+import { selectWalletIdInStore } from 'state/slices/selectors'
+import { useAppDispatch, useAppSelector } from 'state/store'
 
 import { ConnectModal } from '../../components/ConnectModal'
 import { LedgerConfig } from '../config'
@@ -19,22 +24,31 @@ export interface LedgerSetupProps
   dispatch: React.Dispatch<ActionTypes>
 }
 
+const spinner = <Spinner color='white' />
+
 export const LedgerConnect = ({ history }: LedgerSetupProps) => {
   const { dispatch: walletDispatch, getAdapter } = useWallet()
   const localWallet = useLocalWallet()
-  const [loading, setLoading] = useState(false)
+  const translate = useTranslate()
+  const dispatch = useAppDispatch()
+  const [isLoading, setIsLoading] = useState(false)
   const [error, setError] = useState<string | null>(null)
   const isAccountManagementEnabled = useFeatureFlag('AccountManagement')
   const isLedgerAccountManagementEnabled = useFeatureFlag('AccountManagementLedger')
 
   const setErrorLoading = useCallback((e: string | null) => {
     setError(e)
-    setLoading(false)
+    setIsLoading(false)
   }, [])
 
-  const pairDevice = useCallback(async () => {
+  // TEMP: This is a temporary solution to check if a Ledger device is cached. We can hardcode the
+  // device ID as it's the same for all Ledger devices.
+  // See https://github.com/shapeshift/web/issues/6814
+  const isLedgerDeviceCached = useAppSelector(state => selectWalletIdInStore(state, '0001'))
+
+  const handlePair = useCallback(async () => {
     setError(null)
-    setLoading(true)
+    setIsLoading(true)
 
     const adapter = await getAdapter(KeyManager.Ledger)
     if (adapter) {
@@ -50,7 +64,8 @@ export const LedgerConnect = ({ history }: LedgerSetupProps) => {
         }
 
         const { name, icon } = LedgerConfig
-        // TODO(gomes): this is most likely wrong, all Ledger devices get the same device ID
+        // NOTE: All Ledger devices get the same device ID, i.e '0001', but we fetch it from the
+        // device anyway
         const deviceId = await wallet.getDeviceID()
 
         walletDispatch({
@@ -73,7 +88,7 @@ export const LedgerConnect = ({ history }: LedgerSetupProps) => {
         history.push('/ledger/failure')
       }
     }
-    setLoading(false)
+    setIsLoading(false)
   }, [
     getAdapter,
     history,
@@ -84,14 +99,48 @@ export const LedgerConnect = ({ history }: LedgerSetupProps) => {
     walletDispatch,
   ])
 
+  const handleClearPortfolio = useCallback(() => {
+    dispatch(portfolio.actions.clear())
+    dispatch(portfolioApi.util.resetApiState())
+  }, [dispatch])
+
+  const handleClearCacheAndPair = useCallback(async () => {
+    handleClearPortfolio()
+    await handlePair()
+  }, [handleClearPortfolio, handlePair])
+
   return (
     <ConnectModal
       headerText={'walletProvider.ledger.connect.header'}
-      bodyText={'walletProvider.ledger.connect.body'}
-      buttonText={'walletProvider.ledger.connect.button'}
-      onPairDeviceClick={pairDevice}
-      loading={loading}
+      bodyText={
+        isLedgerDeviceCached
+          ? 'walletProvider.ledger.connect.pairExistingDeviceBody'
+          : 'walletProvider.ledger.connect.pairNewDeviceBody'
+      }
+      buttonText={
+        isLedgerDeviceCached
+          ? 'walletProvider.ledger.connect.pairExistingDeviceButton'
+          : 'walletProvider.ledger.connect.pairNewDeviceButton'
+      }
+      onPairDeviceClick={handlePair}
+      loading={isLoading}
       error={error}
-    />
+    >
+      {isLedgerDeviceCached && (
+        <Button
+          onClick={handleClearCacheAndPair}
+          mt={2}
+          width='full'
+          colorScheme='blue'
+          variant='outline'
+          isLoading={isLoading}
+          loadingText='Pairing Wallet'
+          spinner={spinner}
+          isDisabled={isLoading}
+        >
+          {translate('walletProvider.ledger.connect.pairNewDeviceButton')}
+        </Button>
+      )}
+    </ConnectModal>
   )
 }

--- a/src/context/WalletProvider/Ledger/components/Connect.tsx
+++ b/src/context/WalletProvider/Ledger/components/Connect.tsx
@@ -46,53 +46,52 @@ export const LedgerConnect = ({ history }: LedgerSetupProps) => {
     selectWalletIdInStore(state, '0001'),
   )
 
-  const handlePair = useCallback(() => {
+  const handlePair = useCallback(async () => {
     setError(null)
     setIsLoading(true)
-    ;(async () => {
-      const adapter = await getAdapter(KeyManager.Ledger)
-      if (adapter) {
-        try {
-          // Remove all provider event listeners from previously connected wallets
-          await removeAccountsAndChainListeners()
 
-          const wallet = await adapter.pairDevice()
+    const adapter = await getAdapter(KeyManager.Ledger)
+    if (adapter) {
+      try {
+        // Remove all provider event listeners from previously connected wallets
+        await removeAccountsAndChainListeners()
 
-          if (!wallet) {
-            setErrorLoading('walletProvider.errors.walletNotFound')
-            throw new Error('Call to hdwallet-ledger::pairDevice returned null or undefined')
-          }
+        const wallet = await adapter.pairDevice()
 
-          const { name, icon } = LedgerConfig
-          // NOTE: All Ledger devices get the same device ID, i.e '0001', but we fetch it from the
-          // device anyway
-          const deviceId = await wallet.getDeviceID()
-
-          walletDispatch({
-            type: WalletActions.SET_WALLET,
-            payload: { wallet, name, icon, deviceId, connectedType: KeyManager.Ledger },
-          })
-          walletDispatch({ type: WalletActions.SET_IS_CONNECTED, payload: true })
-          localWallet.setLocalWalletTypeAndDeviceId(KeyManager.Ledger, deviceId)
-
-          // If account management is enabled, exit the WalletProvider context, which doesn't have access to the ModalProvider
-          // The Account drawer will be opened further down the tree
-          if (isAccountManagementEnabled && isLedgerAccountManagementEnabled) {
-            walletDispatch({ type: WalletActions.SET_WALLET_MODAL, payload: false })
-          } else {
-            history.push('/ledger/chains')
-          }
-        } catch (e: any) {
-          console.error(e)
-          setErrorLoading(e?.message || 'walletProvider.ledger.errors.unknown')
-          history.push('/ledger/failure')
+        if (!wallet) {
+          setErrorLoading('walletProvider.errors.walletNotFound')
+          throw new Error('Call to hdwallet-ledger::pairDevice returned null or undefined')
         }
-      }
 
-      // Don't set isLoading to false to prevent UI glitching during pairing.
-      // Loading state will be reset when the component is remounted
-      // setIsLoading(false)
-    })()
+        const { name, icon } = LedgerConfig
+        // NOTE: All Ledger devices get the same device ID, i.e '0001', but we fetch it from the
+        // device anyway
+        const deviceId = await wallet.getDeviceID()
+
+        walletDispatch({
+          type: WalletActions.SET_WALLET,
+          payload: { wallet, name, icon, deviceId, connectedType: KeyManager.Ledger },
+        })
+        walletDispatch({ type: WalletActions.SET_IS_CONNECTED, payload: true })
+        localWallet.setLocalWalletTypeAndDeviceId(KeyManager.Ledger, deviceId)
+
+        // If account management is enabled, exit the WalletProvider context, which doesn't have access to the ModalProvider
+        // The Account drawer will be opened further down the tree
+        if (isAccountManagementEnabled && isLedgerAccountManagementEnabled) {
+          walletDispatch({ type: WalletActions.SET_WALLET_MODAL, payload: false })
+        } else {
+          history.push('/ledger/chains')
+        }
+      } catch (e: any) {
+        console.error(e)
+        setErrorLoading(e?.message || 'walletProvider.ledger.errors.unknown')
+        history.push('/ledger/failure')
+      }
+    }
+
+    // Don't set isLoading to false to prevent UI glitching during pairing.
+    // Loading state will be reset when the component is remounted
+    // setIsLoading(false)
   }, [
     getAdapter,
     history,
@@ -108,9 +107,9 @@ export const LedgerConnect = ({ history }: LedgerSetupProps) => {
     dispatch(portfolioApi.util.resetApiState())
   }, [dispatch])
 
-  const handleClearCacheAndPair = useCallback(() => {
+  const handleClearCacheAndPair = useCallback(async () => {
     handleClearPortfolio()
-    handlePair()
+    await handlePair()
   }, [handleClearPortfolio, handlePair])
 
   return (

--- a/src/context/WalletProvider/Ledger/components/Connect.tsx
+++ b/src/context/WalletProvider/Ledger/components/Connect.tsx
@@ -10,11 +10,12 @@ import { removeAccountsAndChainListeners } from 'context/WalletProvider/WalletPr
 import { useFeatureFlag } from 'hooks/useFeatureFlag/useFeatureFlag'
 import { useWallet } from 'hooks/useWallet/useWallet'
 import { portfolio, portfolioApi } from 'state/slices/portfolioSlice/portfolioSlice'
-import { selectWalletIdInStore } from 'state/slices/selectors'
+import { selectPortfolioHasWalletId } from 'state/slices/selectors'
 import { useAppDispatch, useAppSelector } from 'state/store'
 
 import { ConnectModal } from '../../components/ConnectModal'
 import { LedgerConfig } from '../config'
+import { LEDGER_DEVICE_ID } from '../constants'
 
 export interface LedgerSetupProps
   extends RouteComponentProps<
@@ -43,7 +44,7 @@ export const LedgerConnect = ({ history }: LedgerSetupProps) => {
   // device ID as it's the same for all Ledger devices.
   // See https://github.com/shapeshift/web/issues/6814
   const isPreviousLedgerDeviceDetected = useAppSelector(state =>
-    selectWalletIdInStore(state, '0001'),
+    selectPortfolioHasWalletId(state, LEDGER_DEVICE_ID),
   )
 
   const handlePair = useCallback(async () => {

--- a/src/context/WalletProvider/Ledger/constants.ts
+++ b/src/context/WalletProvider/Ledger/constants.ts
@@ -11,6 +11,8 @@ import {
 import { uniq } from 'lodash'
 import { getSupportedEvmChainIds } from 'lib/utils/evm'
 
+export const LEDGER_DEVICE_ID = '0001'
+
 /*
   The top-level fee assets supported by Ledger, which can be mapped to a specific Ledger app.
   The Ethereum app supports all EVM chains, so we don't need to list them all here.

--- a/src/context/WalletProvider/components/ConnectModal.tsx
+++ b/src/context/WalletProvider/components/ConnectModal.tsx
@@ -29,6 +29,7 @@ export const ConnectModal: React.FC<ConnectModalProps> = ({
   headerText,
   loading,
   onPairDeviceClick: handlePairDeviceClick,
+  children,
 }) => {
   return (
     <>
@@ -37,6 +38,14 @@ export const ConnectModal: React.FC<ConnectModalProps> = ({
       </ModalHeader>
       <ModalBody>
         <Text mb={4} color='text.subtle' translation={bodyText} />
+        {error && (
+          <Alert status='info' mt={4}>
+            <AlertIcon />
+            <AlertDescription>
+              <Text translation={error} />
+            </AlertDescription>
+          </Alert>
+        )}
         {loading ? (
           <Button
             width='full'
@@ -59,14 +68,7 @@ export const ConnectModal: React.FC<ConnectModalProps> = ({
             <Text translation={buttonText || 'walletProvider.keepKey.connect.button'} />
           </Button>
         )}
-        {error && (
-          <Alert status='info' mt={4}>
-            <AlertIcon />
-            <AlertDescription>
-              <Text translation={error} />
-            </AlertDescription>
-          </Alert>
-        )}
+        {children}
       </ModalBody>
     </>
   )

--- a/src/state/slices/portfolioSlice/selectors.ts
+++ b/src/state/slices/portfolioSlice/selectors.ts
@@ -74,6 +74,7 @@ import type {
   AssetEquityItem,
   PortfolioAccountBalancesById,
   PortfolioAccounts,
+  WalletId,
 } from './portfolioSliceCommon'
 import { AssetEquityType } from './portfolioSliceCommon'
 import { findAccountsByAssetId } from './utils'
@@ -1088,4 +1089,10 @@ export const selectEquityTotalBalance = createDeepEqualOutputSelector(
       initial,
     )
   },
+)
+
+export const selectWalletIdInStore = createSelector(
+  (state: ReduxState) => state.portfolio.wallet.ids,
+  (_state: ReduxState, walletId: WalletId) => walletId,
+  (storeWalletIds, walletId): boolean => storeWalletIds.includes(walletId),
 )

--- a/src/state/slices/portfolioSlice/selectors.ts
+++ b/src/state/slices/portfolioSlice/selectors.ts
@@ -1091,7 +1091,7 @@ export const selectEquityTotalBalance = createDeepEqualOutputSelector(
   },
 )
 
-export const selectWalletIdInStore = createSelector(
+export const selectPortfolioHasWalletId = createSelector(
   (state: ReduxState) => state.portfolio.wallet.ids,
   (_state: ReduxState, walletId: WalletId) => walletId,
   (storeWalletIds, walletId): boolean => storeWalletIds.includes(walletId),


### PR DESCRIPTION
## Description

Adds temporary user flow to detect and handle the case where a user may connect a different ledger device.

- If the app detects a previously connected ledger, UI prompts the user to either proceed with the current device, or to connect a new device.
- If the user proceeds with the current device, the portfolio cache is used to maintain their configured chains
- If the user decides to connect a new device, the portfolio cache is nuked and the user can configure their new ledger without fear of cache corruption.

Note this workaround is temporary until we can follow up with solution yet to be determined in https://github.com/shapeshift/web/issues/6814

## Pull Request Type

- [ ] :bug: Bug fix (Non-breaking Change: Fixes an issue)
- [ ] :hammer_and_wrench: Chore (Non-breaking Change: Doc updates, pkg upgrades, typos, etc..)
- [x] :nail_care: New Feature (Breaking/Non-breaking Change)

## Issue (if applicable)

relates to #6814

## Risk
> High Risk PRs Require 2 approvals

Moderate risk, if cache clearing is borked or missing in a user flow its possible for users to end up with bad redux state for their wallet. The impact of this is debatably low, as theoretically would only result in the UI allowing users to make invalid asset selections when trading etc for chains that are not connected to the wallet, resulting in errors.

> What protocols, transaction types or contract interactions might be affected by this PR?

## Testing

Note, you dont need multiple ledgers to test this. We can pretend 💁‍♀️

- Sanity check other wallet connecting flows are still working
- Sanity check ledger initial wallet connecting flow is working (with and without account management enabled)
- Check previous config is correct when reconnecting to previous device (with and without account management enabled)
- Check ledger wallet state is reset when connecting a new device via the "pair new device" button  (with and without account management enabled) 

### Engineering

Note we are using hardcoded `deviceId` "0001" for ledger which appears to be valid. This will be removed when follow-up is ready.

### Operations

<!-----------------------------------------------------------------------------
If your changes have a user-facing impact, describe how a non-technical QA team can functionally test your changes in a preview environment.

If they are not user-facing please describe how to test for any regressions that may occur.
------------------------------------------------------------------------------>

## Screenshots (if applicable)

Fresh connect to ledger:

https://github.com/shapeshift/web/assets/125113430/7cbb8054-2d95-4745-aa3b-08b6f72035f6

Reconnect to same ledger device after page refresh:

https://github.com/shapeshift/web/assets/125113430/2f7f882f-819d-4b64-9968-a693ca5f9fd6

Connecting a new ledger device when a ledger was previously connected:

https://github.com/shapeshift/web/assets/125113430/16029daf-ca27-4ee1-b47b-eca08e3d335e

The same flow is used when switching wallet provider:

https://github.com/shapeshift/web/assets/125113430/2134be8a-8a36-457e-9fec-1132502d9e12


