### PR TITLE
feat: prompt add ledger account

### DIFF
--- a/src/assets/translations/en/main.json
+++ b/src/assets/translations/en/main.json
@@ -878,6 +878,7 @@
     "addressPlaceholder": "%{chainName} address",
     "priceImpactWarning": "Due to the size of this trade relative to available liquidity, the expected price impact of this trade is %{priceImpactPercentage}%. Are you sure you want to trade?",
     "enableMetaMaskSnap": "use the multichain snap",
+    "connectChain": "connect %{chainName}",
     "approvalGasFee": "Approval gas fee %{fee}",
     "approvalFailed": "A problem occurred during allowance approval",
     "tradeComplete": "You now have %{cryptoAmountFormatted} in your wallet on %{chainName}.",

--- a/src/components/MultiHopTrade/components/TradeInput/components/ManualAddressEntry.tsx
+++ b/src/components/MultiHopTrade/components/TradeInput/components/ManualAddressEntry.tsx
@@ -1,5 +1,6 @@
 import { FormControl, FormLabel, Link } from '@chakra-ui/react'
 import { isLedger } from '@shapeshiftoss/hdwallet-ledger'
+import { isMetaMask } from '@shapeshiftoss/hdwallet-metamask'
 import type { FC } from 'react'
 import { memo, useCallback, useEffect, useMemo } from 'react'
 import { useFormContext } from 'react-hook-form'
@@ -31,6 +32,7 @@ export const ManualAddressEntry: FC = memo((): JSX.Element | null => {
   const translate = useTranslate()
   const isSnapEnabled = useFeatureFlag('Snaps')
   const { open: openSnapsModal } = useModal('snaps')
+  const { open: openManageAccountsModal } = useModal('manageAccounts')
 
   const wallet = useWallet().state.wallet
   const { chainId: buyAssetChainId, assetId: buyAssetAssetId } = useAppSelector(selectInputBuyAsset)
@@ -110,15 +112,21 @@ export const ManualAddressEntry: FC = memo((): JSX.Element | null => {
   )
 
   const handleEnableShapeShiftSnap = useCallback(() => openSnapsModal({}), [openSnapsModal])
+  const handleAddAccount = useCallback(() => openManageAccountsModal({}), [openManageAccountsModal])
 
   const ManualReceiveAddressEntry: JSX.Element = useMemo(() => {
     return (
       <FormControl>
         <FormLabel color='yellow.400'>
           {translate('trade.receiveAddressDescription', { chainName: buyAssetChainName })}
-          {!isSnapInstalled && isSnapEnabled && (
+          {!isSnapInstalled && isSnapEnabled && wallet && isMetaMask(wallet) && (
             <Link textDecor='underline' ml={1} onClick={handleEnableShapeShiftSnap}>
               {translate('trade.enableMetaMaskSnap')}
+            </Link>
+          )}
+          {wallet && isLedger(wallet) && (
+            <Link textDecor='underline' ml={1} onClick={handleAddAccount}>
+              {translate('trade.connectChain', { chainName: buyAssetChainName })}
             </Link>
           )}
           &nbsp;{translate('trade.toContinue')}
@@ -134,11 +142,13 @@ export const ManualAddressEntry: FC = memo((): JSX.Element | null => {
     )
   }, [
     buyAssetChainName,
+    handleAddAccount,
     handleEnableShapeShiftSnap,
     isSnapEnabled,
     isSnapInstalled,
     rules,
     translate,
+    wallet,
   ])
 
   return shouldShowManualReceiveAddressInput ? ManualReceiveAddressEntry : null


### PR DESCRIPTION
## Description

Improve UI and UX when attempting to trade into a non-connected chain.

This affects Ledger specifically by showing the correct "add account" copy, which brings up the Account Management modal, and also improves copy for non-MetaMask wallets by _not_ prompting for a Snap installation unless MetaMask is connected.

## Pull Request Type

- [x] :bug: Bug fix (Non-breaking Change: Fixes an issue)
- [ ] :hammer_and_wrench: Chore (Non-breaking Change: Doc updates, pkg upgrades, typos, etc..)
- [x] :nail_care: New Feature (Breaking/Non-breaking Change)

## Issue (if applicable)

Closes https://github.com/shapeshift/web/issues/6914, specifically via the approach mentioned in https://github.com/shapeshift/web/issues/6914#issuecomment-2116265947.

## Risk

Small - copy change and link to an existing modal.

> What protocols, transaction types or contract interactions might be affected by this PR?

None.

## Testing

When connected to MetaMask and attempting to trade into a missing chain, the UI should look and behave as it currently does:

<img width="353" alt="Screenshot 2024-05-20 at 11 35 08 AM" src="https://github.com/shapeshift/web/assets/97164662/edc71c28-845c-45b4-bff3-2f2ef76273b2">

When connected to a Ledger and attempting to trade into a missing chain, the UI should now prompt the user to connect the chain, which will open the manage accounts modal:

<img width="346" alt="Screenshot 2024-05-20 at 12 09 35 PM" src="https://github.com/shapeshift/web/assets/97164662/42c44a42-e601-4ac2-984d-c78c6f6c3bac">

When connected to any other wallet and attempting to trade into a missing chain, we'll no longer prompt the user to install the MetaMask Snap (as it does not make sense when connected to any wallet other than MetaMask), and instead simply ask for an address to be entered manually:

<img width="350" alt="Screenshot 2024-05-20 at 12 24 28 PM" src="https://github.com/shapeshift/web/assets/97164662/a205042a-9b0d-43ea-be16-0c78dec34ab4">

### Engineering

☝️

### Operations

☝️

## Screenshots (if applicable)

See screenshots in the testing instructions.