### PR TITLE
fix: dont default user currency balances to crypto amounts when fiat pricing is not available

### DIFF
--- a/src/state/slices/common-selectors.ts
+++ b/src/state/slices/common-selectors.ts
@@ -139,26 +139,26 @@ export const selectPortfolioUserCurrencyBalancesByAccountId = createDeepEqualOut
   selectPortfolioAccountBalancesBaseUnit,
   selectMarketDataUserCurrency,
   (assetsById, accounts, marketData) => {
-    return Object.entries(accounts).reduce(
+    return Object.entries(accounts).reduce<Record<AccountId, Record<AssetId, string>>>(
       (acc, [accountId, balanceObj]) => {
-        acc[accountId] = Object.entries(balanceObj).reduce(
-          (acc, [assetId, cryptoBalance]) => {
+        acc[accountId] = Object.entries(balanceObj).reduce<Record<AssetId, string>>(
+          (balanceByAssetId, [assetId, cryptoBalance]) => {
             const asset = assetsById[assetId]
-            if (!asset) return acc
+            if (!asset) return balanceByAssetId
             const precision = asset.precision
             const price = marketData[assetId]?.price ?? 0
             const cryptoValue = fromBaseUnit(bnOrZero(cryptoBalance), precision)
             const userCurrencyBalance = bnOrZero(bn(cryptoValue).times(price)).toFixed(2)
-            acc[assetId] = userCurrencyBalance
+            balanceByAssetId[assetId] = userCurrencyBalance
 
-            return acc
+            return balanceByAssetId
           },
-          { ...balanceObj },
+          {},
         )
 
         return acc
       },
-      { ...accounts },
+      {},
     )
   },
 )

--- a/src/state/slices/common-selectors.ts
+++ b/src/state/slices/common-selectors.ts
@@ -1,7 +1,7 @@
 import type { ChainId } from '@shapeshiftoss/caip'
 import { type AccountId, type AssetId, fromAccountId, isNft } from '@shapeshiftoss/caip'
 import { isEvmChainId } from '@shapeshiftoss/chain-adapters'
-import type { Asset } from '@shapeshiftoss/types'
+import type { Asset, PartialRecord } from '@shapeshiftoss/types'
 import orderBy from 'lodash/orderBy'
 import pickBy from 'lodash/pickBy'
 import createCachedSelector from 're-reselect'
@@ -139,27 +139,26 @@ export const selectPortfolioUserCurrencyBalancesByAccountId = createDeepEqualOut
   selectPortfolioAccountBalancesBaseUnit,
   selectMarketDataUserCurrency,
   (assetsById, accounts, marketData) => {
-    return Object.entries(accounts).reduce<Record<AccountId, Record<AssetId, string>>>(
-      (acc, [accountId, balanceObj]) => {
-        acc[accountId] = Object.entries(balanceObj).reduce<Record<AssetId, string>>(
-          (balanceByAssetId, [assetId, cryptoBalance]) => {
-            const asset = assetsById[assetId]
-            if (!asset) return balanceByAssetId
-            const precision = asset.precision
-            const price = marketData[assetId]?.price ?? 0
-            const cryptoValue = fromBaseUnit(bnOrZero(cryptoBalance), precision)
-            const userCurrencyBalance = bnOrZero(bn(cryptoValue).times(price)).toFixed(2)
-            balanceByAssetId[assetId] = userCurrencyBalance
+    return Object.entries(accounts).reduce<
+      PartialRecord<AccountId, PartialRecord<AssetId, string>>
+    >((acc, [accountId, balanceObj]) => {
+      acc[accountId] = Object.entries(balanceObj).reduce<PartialRecord<AssetId, string>>(
+        (balanceByAssetId, [assetId, cryptoBalance]) => {
+          const asset = assetsById[assetId]
+          if (!asset) return balanceByAssetId
+          const precision = asset.precision
+          const price = marketData[assetId]?.price ?? 0
+          const cryptoValue = fromBaseUnit(bnOrZero(cryptoBalance), precision)
+          const userCurrencyBalance = bnOrZero(bn(cryptoValue).times(price)).toFixed(2)
+          balanceByAssetId[assetId] = userCurrencyBalance
 
-            return balanceByAssetId
-          },
-          {},
-        )
+          return balanceByAssetId
+        },
+        {},
+      )
 
-        return acc
-      },
-      {},
-    )
+      return acc
+    }, {})
   },
 )
 

--- a/src/state/slices/portfolioSlice/selectors.ts
+++ b/src/state/slices/portfolioSlice/selectors.ts
@@ -275,7 +275,7 @@ export const selectPortfolioUserCurrencyBalanceByFilter = createCachedSelector(
     if (!assetId && accountId) {
       const accountBalances = portfolioAccountUserCurrencyBalances[accountId]
       const totalAccountBalances =
-        Object.values(accountBalances).reduce((totalBalance, userCurrencyBalance) => {
+        Object.values(accountBalances ?? {}).reduce((totalBalance, userCurrencyBalance) => {
           return bnOrZero(totalBalance).plus(bnOrZero(userCurrencyBalance)).toFixed(2)
         }, '0') ?? '0'
       return totalAccountBalances
@@ -409,7 +409,7 @@ export const selectPortfolioAssetAccountBalancesSortedUserCurrency = createDeepE
     return Object.entries(
       portfolioUserCurrencyAccountBalances,
     ).reduce<PortfolioAccountBalancesById>((acc, [accountId, assetBalanceObj]) => {
-      const sortedAssetsByUserCurrencyBalances = Object.entries(assetBalanceObj)
+      const sortedAssetsByUserCurrencyBalances = Object.entries(assetBalanceObj ?? {})
         .sort(([_, a], [__, b]) => (bnOrZero(a).gte(bnOrZero(b)) ? -1 : 1))
         .reduce<{ [k: AssetId]: string }>((acc, [assetId, assetUserCurrencyBalance]) => {
           if (bnOrZero(assetUserCurrencyBalance).lt(bnOrZero(balanceThreshold))) return acc
@@ -452,7 +452,7 @@ export const selectPortfolioAllocationPercentByFilter = createCachedSelector(
       [k: AccountId]: number
     }>((acc, [currentAccountId, assetAccountUserCurrencyBalance]) => {
       const allocation = bnOrZero(
-        bnOrZero(assetAccountUserCurrencyBalance[assetId])
+        bnOrZero(assetAccountUserCurrencyBalance?.[assetId])
           .div(totalAssetUserCurrencyBalance)
           .times(100),
       ).toNumber()
@@ -787,7 +787,7 @@ export const selectAccountIdsByAssetIdAboveBalanceThreshold = createCachedSelect
     const aboveThreshold = Object.entries(accountBalances).reduce<AccountId[]>(
       (acc, [accountId, balanceObj]) => {
         if (accounts.includes(accountId)) {
-          const totalAccountUserCurrencyBalance = Object.values(balanceObj).reduce(
+          const totalAccountUserCurrencyBalance = Object.values(balanceObj ?? {}).reduce(
             (totalBalance, currentBalance) => {
               return bnOrZero(bn(totalBalance).plus(bnOrZero(currentBalance)))
             },
@@ -989,7 +989,7 @@ export const selectAssetEquityItemsByFilter = createDeepEqualOutputSelector(
     const asset = assets[assetId]
     const accounts = accountIds.map(accountId => {
       const userCurrencyAmount = bnOrZero(
-        portfolioUserCurrencyBalances[accountId][assetId],
+        portfolioUserCurrencyBalances?.[accountId]?.[assetId],
       ).toString()
       const cryptoAmountBaseUnit = bnOrZero(
         portfolioCryptoBalancesBaseUnit[accountId][assetId],


### PR DESCRIPTION
## Description

Fixes bug in `selectPortfolioUserCurrencyBalancesByAccountId` selector where user currency balances default to crypto base unit values when fiat prices are missing for a given asset.

## Pull Request Type

- [x] :bug: Bug fix (Non-breaking Change: Fixes an issue)
- [ ] :hammer_and_wrench: Chore (Non-breaking Change: Doc updates, pkg upgrades, typos, etc..)
- [ ] :nail_care: New Feature (Breaking/Non-breaking Change)

## Issue (if applicable)

NA

## Risk
> High Risk PRs Require 2 approvals

High risk. While the change resolves a severe issue in balance tracking, the impact of getting this wrong is high.

> What protocols, transaction types or contract interactions might be affected by this PR?

## Testing

Check fiat balances and functionality relating to fiat balances (e.g sorting of accounts based on fiat balance etc).

Check app to ensure there is no change from production, or if there is, it resolves an issue stemming from incorrect user balances.

### Engineering

<!-----------------------------------------------------------------------------
Include sufficient information here for an engineer to test your PR. This may include how to test locally, in a built environment, changes to infrastructure etc.
------------------------------------------------------------------------------>

### Operations

<!-----------------------------------------------------------------------------
If your changes have a user-facing impact, describe how a non-technical QA team can functionally test your changes in a preview environment.

If they are not user-facing please describe how to test for any regressions that may occur.
------------------------------------------------------------------------------>

## Screenshots (if applicable)

Before:
![image](https://github.com/shapeshift/web/assets/125113430/5155c0e1-0d0e-4e7a-bdcb-73abecc6547b)

After:
![image](https://github.com/shapeshift/web/assets/125113430/2c4583cd-d4ae-4b29-903e-d219c816f134)
