### PR TITLE
chore: initial rune change address wiring

### DIFF
--- a/src/assets/translations/en/main.json
+++ b/src/assets/translations/en/main.json
@@ -2452,6 +2452,11 @@
     "stakeSuccess": "You have successfully staked %{amount} %{symbol}",
     "stakePending": "Staking %{amount} %{symbol}...",
     "unstakePending": "Requesting withdraw of %{amount} %{symbol}",
-    "unstakeSuccess": "Once the %{cooldownPeriod} have elapsed, you will be able to claim your %{amount} %{symbol}"
+    "unstakeSuccess": "Once the %{cooldownPeriod} have elapsed, you will be able to claim your %{amount} %{symbol}",
+    "currentRewardAddress": "Current Reward Address",
+    "newRewardAddress": "New Address",
+    "rewardCycleExplainer": "This will update for the next reward cycle",
+    "addressUpdateActionPending": "Change Reward Address...",
+    "addressUpdateSucces": "You have successfully updated your Thorchain Reward Address"
   }
 }

--- a/src/assets/translations/en/main.json
+++ b/src/assets/translations/en/main.json
@@ -2455,7 +2455,7 @@
     "unstakeSuccess": "Once the %{cooldownPeriod} have elapsed, you will be able to claim your %{amount} %{symbol}",
     "currentRewardAddress": "Current Reward Address",
     "newRewardAddress": "New Address",
-    "rewardCycleExplainer": "This will update for the next reward cycle",
+    "rewardCycleExplainer": "This will update for the next reward cycle.",
     "addressUpdateActionPending": "Change Reward Address...",
     "addressUpdateSucces": "You have successfully updated your Thorchain Reward Address"
   }

--- a/src/pages/RFOX/RFOX.tsx
+++ b/src/pages/RFOX/RFOX.tsx
@@ -4,6 +4,7 @@ import { useCallback, useMemo, useState } from 'react'
 import { useTranslate } from 'react-polyglot'
 import { Main } from 'components/Layout/Main'
 
+import { ChangeAddress } from './components/ChangeAddress/ChangeAddress'
 import { Stake } from './components/Stake/Stake'
 import { Unstake } from './components/Unstake/Unstake'
 
@@ -50,6 +51,9 @@ const FormHeader: React.FC<FormHeaderProps> = ({ setStepIndex, activeIndex }) =>
       <FormHeaderTab index={1} onClick={handleClick} isActive={activeIndex === 1}>
         {translate('RFOX.unstake')}
       </FormHeaderTab>
+      <FormHeaderTab index={2} onClick={handleClick} isActive={activeIndex === 2}>
+        {translate('RFOX.changeAddress')}
+      </FormHeaderTab>
     </Flex>
   )
 }
@@ -72,6 +76,9 @@ export const RFOX: React.FC = () => {
               </TabPanel>
               <TabPanel px={0} py={0}>
                 <Unstake headerComponent={TabHeader} />
+              </TabPanel>
+              <TabPanel px={0} py={0}>
+                <ChangeAddress headerComponent={TabHeader} />
               </TabPanel>
             </TabPanels>
           </Tabs>

--- a/src/pages/RFOX/components/AddressSelection.tsx
+++ b/src/pages/RFOX/components/AddressSelection.tsx
@@ -8,10 +8,14 @@ import {
   Select,
   Stack,
 } from '@chakra-ui/react'
-import { useCallback, useMemo, useState } from 'react'
+import { type FC, useCallback, useMemo, useState } from 'react'
 import { useTranslate } from 'react-polyglot'
 
-export const AddressSelection = () => {
+type AddressSelectionProps = {
+  isNewAddress?: boolean
+}
+
+export const AddressSelection: FC<AddressSelectionProps> = ({ isNewAddress }) => {
   const translate = useTranslate()
   const [isManualAddress, setIsManualAddress] = useState(false)
 
@@ -30,12 +34,25 @@ export const AddressSelection = () => {
       </Select>
     )
   }, [isManualAddress])
+
+  const addressSelectionLabel = useMemo(
+    () =>
+      isNewAddress ? translate('RFOX.newRewardAddress') : translate('RFOX.thorchainRewardAddress'),
+    [isNewAddress, translate],
+  )
+
+  const addressSelectionDescription = useMemo(
+    () =>
+      isNewAddress ? translate('RFOX.rewardCycleExplainer') : translate('RFOX.rewardAddressHelper'),
+    [isNewAddress, translate],
+  )
+
   return (
     <FormControl>
       <Stack px={6} py={4}>
         <Flex alignItems='center' justifyContent='space-between' mb={2}>
           <FormLabel fontSize='sm' mb={0}>
-            {translate('RFOX.thorchainRewardAddress')}
+            {addressSelectionLabel}
           </FormLabel>
           <Button variant='link' colorScheme='blue' size='sm' onClick={handleToggleInputMethod}>
             {isManualAddress
@@ -44,7 +61,7 @@ export const AddressSelection = () => {
           </Button>
         </Flex>
         {renderSelection}
-        <FormHelperText>{translate('RFOX.rewardAddressHelper')}</FormHelperText>
+        <FormHelperText>{addressSelectionDescription}</FormHelperText>
       </Stack>
     </FormControl>
   )

--- a/src/pages/RFOX/components/ChangeAddress/ChangeAddress.tsx
+++ b/src/pages/RFOX/components/ChangeAddress/ChangeAddress.tsx
@@ -1,0 +1,87 @@
+import { AnimatePresence } from 'framer-motion'
+import React, { lazy, Suspense, useCallback } from 'react'
+import { MemoryRouter, Route, Switch, useLocation } from 'react-router'
+import { makeSuspenseful } from 'utils/makeSuspenseful'
+
+import type { ChangeAddressRouteProps } from './types'
+import { ChangeAddressRoutePaths } from './types'
+
+const suspenseFallback = <div>Loading...</div>
+
+const ChangeAddressInput = makeSuspenseful(
+  lazy(() =>
+    import('./ChangeAddressInput').then(({ ChangeAddressInput }) => ({
+      default: ChangeAddressInput,
+    })),
+  ),
+)
+
+const ChangeAddressConfirm = makeSuspenseful(
+  lazy(() =>
+    import('./ChangeAddressConfirm').then(({ ChangeAddressConfirm }) => ({
+      default: ChangeAddressConfirm,
+    })),
+  ),
+)
+
+const ChangeAddressStatus = makeSuspenseful(
+  lazy(() =>
+    import('./ChangeAddressStatus').then(({ ChangeAddressStatus }) => ({
+      default: ChangeAddressStatus,
+    })),
+  ),
+)
+
+const ChangeAddressEntries = [
+  ChangeAddressRoutePaths.Input,
+  ChangeAddressRoutePaths.Confirm,
+  ChangeAddressRoutePaths.Status,
+]
+
+export const ChangeAddress: React.FC<ChangeAddressRouteProps> = ({ headerComponent }) => {
+  return (
+    <MemoryRouter initialEntries={ChangeAddressEntries} initialIndex={0}>
+      <StakeRoutes headerComponent={headerComponent} />
+    </MemoryRouter>
+  )
+}
+
+export const StakeRoutes: React.FC<ChangeAddressRouteProps> = ({ headerComponent }) => {
+  const location = useLocation()
+
+  const renderChangeAddressInput = useCallback(() => {
+    return <ChangeAddressInput headerComponent={headerComponent} />
+  }, [headerComponent])
+
+  const renderChangeAddressConfirm = useCallback(() => {
+    return <ChangeAddressConfirm headerComponent={headerComponent} />
+  }, [headerComponent])
+
+  const renderChangeAddressStatus = useCallback(() => {
+    return <ChangeAddressStatus headerComponent={headerComponent} />
+  }, [headerComponent])
+
+  return (
+    <AnimatePresence mode='wait' initial={false}>
+      <Switch location={location}>
+        <Suspense fallback={suspenseFallback}>
+          <Route
+            key={ChangeAddressRoutePaths.Input}
+            path={ChangeAddressRoutePaths.Input}
+            render={renderChangeAddressInput}
+          />
+          <Route
+            key={ChangeAddressRoutePaths.Confirm}
+            path={ChangeAddressRoutePaths.Confirm}
+            render={renderChangeAddressConfirm}
+          />
+          <Route
+            key={ChangeAddressRoutePaths.Status}
+            path={ChangeAddressRoutePaths.Status}
+            render={renderChangeAddressStatus}
+          />
+        </Suspense>
+      </Switch>
+    </AnimatePresence>
+  )
+}

--- a/src/pages/RFOX/components/ChangeAddress/ChangeAddressConfirm.tsx
+++ b/src/pages/RFOX/components/ChangeAddress/ChangeAddressConfirm.tsx
@@ -1,0 +1,142 @@
+import { ArrowBackIcon } from '@chakra-ui/icons'
+import {
+  Button,
+  Card,
+  CardBody,
+  CardFooter,
+  CardHeader,
+  Flex,
+  IconButton,
+  Stack,
+} from '@chakra-ui/react'
+import { foxAssetId } from '@shapeshiftoss/caip'
+import { useCallback, useMemo } from 'react'
+import { useTranslate } from 'react-polyglot'
+import { useHistory } from 'react-router'
+import { Amount } from 'components/Amount/Amount'
+import { AssetIcon } from 'components/AssetIcon'
+import type { RowProps } from 'components/Row/Row'
+import { Row } from 'components/Row/Row'
+import { SlideTransition } from 'components/SlideTransition'
+import { Timeline, TimelineItem } from 'components/Timeline/Timeline'
+import { middleEllipsis } from 'lib/utils'
+import { selectAssetById } from 'state/slices/selectors'
+import { useAppSelector } from 'state/store'
+
+import { ChangeAddressRoutePaths, type ChangeAddressRouteProps } from './types'
+
+const CustomRow: React.FC<RowProps> = props => <Row fontSize='sm' fontWeight='medium' {...props} />
+const backIcon = <ArrowBackIcon />
+
+export const ChangeAddressConfirm: React.FC<ChangeAddressRouteProps> = () => {
+  const history = useHistory()
+  const translate = useTranslate()
+  const asset = useAppSelector(state => selectAssetById(state, foxAssetId))
+
+  const handleGoBack = useCallback(() => {
+    history.push(ChangeAddressRoutePaths.Input)
+  }, [history])
+
+  const handleSubmit = useCallback(() => {
+    history.push(ChangeAddressRoutePaths.Status)
+  }, [history])
+
+  const stakeCards = useMemo(() => {
+    if (!asset) return null
+    return (
+      <Card
+        display='flex'
+        alignItems='center'
+        justifyContent='center'
+        flexDir='column'
+        gap={4}
+        py={6}
+        px={4}
+        flex={1}
+        mx={-2}
+      >
+        <AssetIcon size='sm' assetId={asset?.assetId} />
+        <Stack textAlign='center' spacing={0}>
+          <Amount.Crypto value='0.0' symbol={asset?.symbol} />
+          <Amount.Fiat fontSize='sm' color='text.subtle' value='0.0' />
+        </Stack>
+      </Card>
+    )
+  }, [asset])
+
+  return (
+    <SlideTransition>
+      <CardHeader display='flex' alignItems='center' gap={2}>
+        <Flex flex={1}>
+          <IconButton onClick={handleGoBack} variant='ghost' aria-label='back' icon={backIcon} />
+        </Flex>
+        <Flex textAlign='center'>{translate('common.confirm')}</Flex>
+        <Flex flex={1}></Flex>
+      </CardHeader>
+      <CardBody>
+        <Stack spacing={6}>
+          {stakeCards}
+          <Timeline>
+            <TimelineItem>
+              <CustomRow>
+                <Row.Label>{translate('RFOX.shapeShiftFee')}</Row.Label>
+                <Row.Value>Free</Row.Value>
+              </CustomRow>
+            </TimelineItem>
+            <TimelineItem>
+              <CustomRow>
+                <Row.Label>{translate('RFOX.approvalFee')}</Row.Label>
+                <Row.Value>
+                  <Amount.Fiat value='0.0001' />
+                </Row.Value>
+              </CustomRow>
+            </TimelineItem>
+            <TimelineItem>
+              <CustomRow>
+                <Row.Label>{translate('RFOX.networkFee')}</Row.Label>
+                <Row.Value>
+                  <Amount.Fiat value='0.0001' />
+                </Row.Value>
+              </CustomRow>
+            </TimelineItem>
+            <TimelineItem>
+              <CustomRow>
+                <Row.Label>{translate('RFOX.shareOfPool')}</Row.Label>
+                <Row.Value>
+                  <Amount.Percent value='0.0' />
+                </Row.Value>
+              </CustomRow>
+            </TimelineItem>
+          </Timeline>
+        </Stack>
+      </CardBody>
+      <CardFooter
+        borderTopWidth={1}
+        borderColor='border.subtle'
+        flexDir='column'
+        gap={4}
+        px={6}
+        py={4}
+        bg='background.surface.raised.accent'
+      >
+        <CustomRow>
+          <Row.Label>{translate('RFOX.thorchainRewardAddress')}</Row.Label>
+          <Row.Value>{middleEllipsis('123455667765')}</Row.Value>
+        </CustomRow>
+      </CardFooter>
+      <CardFooter
+        borderTopWidth={1}
+        borderColor='border.subtle'
+        flexDir='column'
+        gap={4}
+        px={6}
+        bg='background.surface.raised.accent'
+        borderBottomRadius='xl'
+      >
+        <Button size='lg' mx={-2} colorScheme='blue' onClick={handleSubmit}>
+          {translate('RFOX.confirmAndStake')}
+        </Button>
+      </CardFooter>
+    </SlideTransition>
+  )
+}

--- a/src/pages/RFOX/components/ChangeAddress/ChangeAddressInput.tsx
+++ b/src/pages/RFOX/components/ChangeAddress/ChangeAddressInput.tsx
@@ -1,13 +1,8 @@
-import { Button, CardFooter, Collapse, Stack } from '@chakra-ui/react'
+import { Button, CardFooter, Stack } from '@chakra-ui/react'
 import { foxAssetId } from '@shapeshiftoss/caip'
 import { useCallback, useMemo, useState } from 'react'
 import { useTranslate } from 'react-polyglot'
 import { useHistory } from 'react-router'
-import { Amount } from 'components/Amount/Amount'
-import { TradeAssetSelect } from 'components/AssetSelection/AssetSelection'
-import { FormDivider } from 'components/FormDivider'
-import { TradeAssetInput } from 'components/MultiHopTrade/components/TradeAssetInput'
-import { Row } from 'components/Row/Row'
 import { SlideTransition } from 'components/SlideTransition'
 import { WarningAcknowledgement } from 'components/WarningAcknowledgement/WarningAcknowledgement'
 import { selectAssetById } from 'state/slices/selectors'
@@ -16,35 +11,14 @@ import { useAppSelector } from 'state/store'
 import { AddressSelection } from '../AddressSelection'
 import { ChangeAddressRoutePaths, type ChangeAddressRouteProps } from './types'
 
-const formControlProps = {
-  borderRadius: 0,
-  background: 'transparent',
-  borderWidth: 0,
-  paddingBottom: 0,
-  paddingTop: 0,
-}
-
 export const ChangeAddressInput: React.FC<ChangeAddressRouteProps> = ({ headerComponent }) => {
   const translate = useTranslate()
   const history = useHistory()
   const asset = useAppSelector(state => selectAssetById(state, foxAssetId))
   const [showWarning, setShowWarning] = useState(false)
-  const percentOptions = useMemo(() => [1], [])
-  const [cryptoAmount, setCryptoAmount] = useState('')
-  const [fiatAmount, setFiatAmount] = useState('')
+  const [newAddress, setNewAddress] = useState<string | null>()
 
-  const handleAccountIdChange = useCallback(() => {}, [])
-
-  // @TODO: Need to add a fiat toggle for the input field
-  const hasEnteredValue = useMemo(() => !!fiatAmount || !!cryptoAmount, [cryptoAmount, fiatAmount])
-
-  const handleChange = useCallback((value: string, isFiat?: boolean) => {
-    if (isFiat) {
-      setFiatAmount(value)
-    } else {
-      setCryptoAmount(value)
-    }
-  }, [])
+  const hasEnteredAddress = useMemo(() => !!newAddress, [newAddress])
 
   const handleWarning = useCallback(() => {
     setShowWarning(true)
@@ -53,10 +27,6 @@ export const ChangeAddressInput: React.FC<ChangeAddressRouteProps> = ({ headerCo
   const handleSubmit = useCallback(() => {
     history.push(ChangeAddressRoutePaths.Confirm)
   }, [history])
-
-  const assetSelectComponent = useMemo(() => {
-    return <TradeAssetSelect assetId={asset?.assetId} isReadOnly onlyConnectedChains={true} />
-  }, [asset?.assetId])
 
   if (!asset) return null
 
@@ -72,47 +42,7 @@ export const ChangeAddressInput: React.FC<ChangeAddressRouteProps> = ({ headerCo
       >
         <Stack>
           {headerComponent}
-          <TradeAssetInput
-            assetId={asset?.assetId}
-            assetSymbol={asset?.symbol ?? ''}
-            assetIcon={asset?.icon ?? ''}
-            percentOptions={percentOptions}
-            onAccountIdChange={handleAccountIdChange}
-            formControlProps={formControlProps}
-            layout='inline'
-            label={translate('transactionRow.amount')}
-            labelPostFix={assetSelectComponent}
-            isSendMaxDisabled={false}
-            onChange={handleChange}
-            cryptoAmount={cryptoAmount}
-            fiatAmount={fiatAmount}
-          />
-          <FormDivider />
           <AddressSelection />
-          <Collapse in={hasEnteredValue}>
-            <CardFooter
-              borderTopWidth={1}
-              borderColor='border.subtle'
-              flexDir='column'
-              gap={4}
-              px={6}
-              py={4}
-              bg='background.surface.raised.accent'
-            >
-              <Row fontSize='sm' fontWeight='medium'>
-                <Row.Label>{translate('common.gasFee')}</Row.Label>
-                <Row.Value>
-                  <Amount.Fiat value='10' />
-                </Row.Value>
-              </Row>
-              <Row fontSize='sm' fontWeight='medium'>
-                <Row.Label>{translate('common.fees')}</Row.Label>
-                <Row.Value>
-                  <Amount.Fiat value='0.0' />
-                </Row.Value>
-              </Row>
-            </CardFooter>
-          </Collapse>
         </Stack>
         <CardFooter
           borderTopWidth={1}
@@ -128,7 +58,7 @@ export const ChangeAddressInput: React.FC<ChangeAddressRouteProps> = ({ headerCo
             mx={-2}
             onClick={handleWarning}
             colorScheme='blue'
-            isDisabled={!hasEnteredValue}
+            isDisabled={!hasEnteredAddress}
           >
             {translate('RFOX.stake')}
           </Button>

--- a/src/pages/RFOX/components/ChangeAddress/ChangeAddressInput.tsx
+++ b/src/pages/RFOX/components/ChangeAddress/ChangeAddressInput.tsx
@@ -1,9 +1,10 @@
-import { Button, CardFooter, Stack } from '@chakra-ui/react'
+import { Button, CardFooter, Flex, Stack } from '@chakra-ui/react'
 import { foxAssetId } from '@shapeshiftoss/caip'
-import { useCallback, useMemo, useState } from 'react'
+import { type FC, useCallback, useMemo, useState } from 'react'
 import { useTranslate } from 'react-polyglot'
 import { useHistory } from 'react-router'
 import { SlideTransition } from 'components/SlideTransition'
+import { RawText, Text } from 'components/Text'
 import { WarningAcknowledgement } from 'components/WarningAcknowledgement/WarningAcknowledgement'
 import { selectAssetById } from 'state/slices/selectors'
 import { useAppSelector } from 'state/store'
@@ -11,7 +12,7 @@ import { useAppSelector } from 'state/store'
 import { AddressSelection } from '../AddressSelection'
 import { ChangeAddressRoutePaths, type ChangeAddressRouteProps } from './types'
 
-export const ChangeAddressInput: React.FC<ChangeAddressRouteProps> = ({ headerComponent }) => {
+export const ChangeAddressInput: FC<ChangeAddressRouteProps> = ({ headerComponent }) => {
   const translate = useTranslate()
   const history = useHistory()
   const asset = useAppSelector(state => selectAssetById(state, foxAssetId))
@@ -26,6 +27,7 @@ export const ChangeAddressInput: React.FC<ChangeAddressRouteProps> = ({ headerCo
 
   const handleSubmit = useCallback(() => {
     history.push(ChangeAddressRoutePaths.Confirm)
+    setNewAddress('1234')
   }, [history])
 
   if (!asset) return null
@@ -42,7 +44,13 @@ export const ChangeAddressInput: React.FC<ChangeAddressRouteProps> = ({ headerCo
       >
         <Stack>
           {headerComponent}
-          <AddressSelection />
+          <Stack px={6} py={4}>
+            <Flex justifyContent='space-between' mb={2} flexDir={'column'}>
+              <Text translation={'RFOX.currentRewardAddress'} fontWeight={'bold'} mb={2} />
+              <RawText as={'h4'}>1234</RawText>
+            </Flex>
+          </Stack>
+          <AddressSelection isNewAddress />
         </Stack>
         <CardFooter
           borderTopWidth={1}

--- a/src/pages/RFOX/components/ChangeAddress/ChangeAddressInput.tsx
+++ b/src/pages/RFOX/components/ChangeAddress/ChangeAddressInput.tsx
@@ -1,0 +1,139 @@
+import { Button, CardFooter, Collapse, Stack } from '@chakra-ui/react'
+import { foxAssetId } from '@shapeshiftoss/caip'
+import { useCallback, useMemo, useState } from 'react'
+import { useTranslate } from 'react-polyglot'
+import { useHistory } from 'react-router'
+import { Amount } from 'components/Amount/Amount'
+import { TradeAssetSelect } from 'components/AssetSelection/AssetSelection'
+import { FormDivider } from 'components/FormDivider'
+import { TradeAssetInput } from 'components/MultiHopTrade/components/TradeAssetInput'
+import { Row } from 'components/Row/Row'
+import { SlideTransition } from 'components/SlideTransition'
+import { WarningAcknowledgement } from 'components/WarningAcknowledgement/WarningAcknowledgement'
+import { selectAssetById } from 'state/slices/selectors'
+import { useAppSelector } from 'state/store'
+
+import { AddressSelection } from '../AddressSelection'
+import { ChangeAddressRoutePaths, type ChangeAddressRouteProps } from './types'
+
+const formControlProps = {
+  borderRadius: 0,
+  background: 'transparent',
+  borderWidth: 0,
+  paddingBottom: 0,
+  paddingTop: 0,
+}
+
+export const ChangeAddressInput: React.FC<ChangeAddressRouteProps> = ({ headerComponent }) => {
+  const translate = useTranslate()
+  const history = useHistory()
+  const asset = useAppSelector(state => selectAssetById(state, foxAssetId))
+  const [showWarning, setShowWarning] = useState(false)
+  const percentOptions = useMemo(() => [1], [])
+  const [cryptoAmount, setCryptoAmount] = useState('')
+  const [fiatAmount, setFiatAmount] = useState('')
+
+  const handleAccountIdChange = useCallback(() => {}, [])
+
+  // @TODO: Need to add a fiat toggle for the input field
+  const hasEnteredValue = useMemo(() => !!fiatAmount || !!cryptoAmount, [cryptoAmount, fiatAmount])
+
+  const handleChange = useCallback((value: string, isFiat?: boolean) => {
+    if (isFiat) {
+      setFiatAmount(value)
+    } else {
+      setCryptoAmount(value)
+    }
+  }, [])
+
+  const handleWarning = useCallback(() => {
+    setShowWarning(true)
+  }, [])
+
+  const handleSubmit = useCallback(() => {
+    history.push(ChangeAddressRoutePaths.Confirm)
+  }, [history])
+
+  const assetSelectComponent = useMemo(() => {
+    return <TradeAssetSelect assetId={asset?.assetId} isReadOnly onlyConnectedChains={true} />
+  }, [asset?.assetId])
+
+  if (!asset) return null
+
+  return (
+    <SlideTransition>
+      <WarningAcknowledgement
+        message={translate('RFOX.stakeWarning', {
+          cooldownPeriod: '28-days',
+        })}
+        onAcknowledge={handleSubmit}
+        shouldShowWarningAcknowledgement={showWarning}
+        setShouldShowWarningAcknowledgement={setShowWarning}
+      >
+        <Stack>
+          {headerComponent}
+          <TradeAssetInput
+            assetId={asset?.assetId}
+            assetSymbol={asset?.symbol ?? ''}
+            assetIcon={asset?.icon ?? ''}
+            percentOptions={percentOptions}
+            onAccountIdChange={handleAccountIdChange}
+            formControlProps={formControlProps}
+            layout='inline'
+            label={translate('transactionRow.amount')}
+            labelPostFix={assetSelectComponent}
+            isSendMaxDisabled={false}
+            onChange={handleChange}
+            cryptoAmount={cryptoAmount}
+            fiatAmount={fiatAmount}
+          />
+          <FormDivider />
+          <AddressSelection />
+          <Collapse in={hasEnteredValue}>
+            <CardFooter
+              borderTopWidth={1}
+              borderColor='border.subtle'
+              flexDir='column'
+              gap={4}
+              px={6}
+              py={4}
+              bg='background.surface.raised.accent'
+            >
+              <Row fontSize='sm' fontWeight='medium'>
+                <Row.Label>{translate('common.gasFee')}</Row.Label>
+                <Row.Value>
+                  <Amount.Fiat value='10' />
+                </Row.Value>
+              </Row>
+              <Row fontSize='sm' fontWeight='medium'>
+                <Row.Label>{translate('common.fees')}</Row.Label>
+                <Row.Value>
+                  <Amount.Fiat value='0.0' />
+                </Row.Value>
+              </Row>
+            </CardFooter>
+          </Collapse>
+        </Stack>
+        <CardFooter
+          borderTopWidth={1}
+          borderColor='border.subtle'
+          flexDir='column'
+          gap={4}
+          px={6}
+          bg='background.surface.raised.accent'
+          borderBottomRadius='xl'
+        >
+          <Button
+            size='lg'
+            mx={-2}
+            onClick={handleWarning}
+            colorScheme='blue'
+            isDisabled={!hasEnteredValue}
+          >
+            {translate('RFOX.stake')}
+          </Button>
+        </CardFooter>
+      </WarningAcknowledgement>
+    </SlideTransition>
+  )
+}

--- a/src/pages/RFOX/components/ChangeAddress/ChangeAddressStatus.tsx
+++ b/src/pages/RFOX/components/ChangeAddress/ChangeAddressStatus.tsx
@@ -1,0 +1,91 @@
+import { CheckCircleIcon, WarningIcon } from '@chakra-ui/icons'
+import { Button, CardBody, CardFooter, Center, Heading, Stack } from '@chakra-ui/react'
+import { TxStatus } from '@shapeshiftoss/unchained-client'
+import { AnimatePresence } from 'framer-motion'
+import React, { useCallback, useMemo, useState } from 'react'
+import { useTranslate } from 'react-polyglot'
+import { useHistory } from 'react-router'
+import { CircularProgress } from 'components/CircularProgress/CircularProgress'
+import { SlideTransition } from 'components/SlideTransition'
+import { SlideTransitionY } from 'components/SlideTransitionY'
+import { Text } from 'components/Text'
+import type { TextPropTypes } from 'components/Text/Text'
+
+import { ChangeAddressRoutePaths, type ChangeAddressRouteProps } from './types'
+
+type BodyContent = {
+  key: TxStatus
+  title: string
+  body: TextPropTypes['translation']
+  element: JSX.Element
+}
+
+export const ChangeAddressStatus: React.FC<ChangeAddressRouteProps> = () => {
+  const [status, setStatus] = useState<TxStatus>(TxStatus.Pending)
+  const history = useHistory()
+  const translate = useTranslate()
+
+  const handleGoBack = useCallback(() => {
+    history.push(ChangeAddressRoutePaths.Input)
+  }, [history])
+
+  const handleFakeStatus = useCallback(() => {
+    setStatus(TxStatus.Confirmed)
+  }, [])
+
+  const bodyContent: BodyContent | null = useMemo(() => {
+    switch (status) {
+      case TxStatus.Pending:
+        return {
+          key: TxStatus.Pending,
+          title: 'pools.waitingForConfirmation',
+          body: ['RFOX.stakePending', { amount: '1,500', symbol: 'FOX' }],
+          element: <CircularProgress size='75px' />,
+        }
+      case TxStatus.Confirmed:
+        return {
+          key: TxStatus.Confirmed,
+          title: 'common.success',
+          body: ['RFOX.stakeSuccess', { amount: '1,500', symbol: 'FOX' }],
+          element: <CheckCircleIcon color='text.success' boxSize='75px' />,
+        }
+      case TxStatus.Failed:
+        return {
+          key: TxStatus.Failed,
+          title: 'common.somethingWentWrong',
+          body: 'Show error message here',
+          element: <WarningIcon color='text.error' boxSize='75px' />,
+        }
+      default:
+        return null
+    }
+  }, [status])
+
+  return (
+    <SlideTransition>
+      {bodyContent && (
+        <AnimatePresence mode='wait'>
+          <SlideTransitionY key={bodyContent.key}>
+            <CardBody py={12} onClick={handleFakeStatus}>
+              <Center flexDir='column' gap={4}>
+                {bodyContent.element}
+                <Stack spacing={0} alignItems='center'>
+                  <Heading as='h4'>{translate(bodyContent.title)}</Heading>
+                  <Text translation={bodyContent.body} />
+                </Stack>
+              </Center>
+            </CardBody>
+          </SlideTransitionY>
+        </AnimatePresence>
+      )}
+      <CardFooter flexDir='column' gap={2}>
+        <Button size='lg' variant='ghost'>
+          {translate('trade.viewTransaction')}
+        </Button>
+        <Button size='lg' colorScheme='blue' onClick={handleGoBack}>
+          {translate('common.goBack')}
+        </Button>
+      </CardFooter>
+    </SlideTransition>
+  )
+}

--- a/src/pages/RFOX/components/ChangeAddress/types.ts
+++ b/src/pages/RFOX/components/ChangeAddress/types.ts
@@ -1,0 +1,9 @@
+export enum ChangeAddressRoutePaths {
+  Input = '/change-address/input',
+  Confirm = '/change-address/confirm',
+  Status = '/change-address/status',
+}
+
+export type ChangeAddressRouteProps = {
+  headerComponent?: JSX.Element
+}


### PR DESCRIPTION
## Description

Adds wiring for RFOX change RUNE address.

Keeping this PR small to prevent merge conflicts - it's only meant to add wiring and stub out the new tab.

## Pull Request Type

- [ ] :bug: Bug fix (Non-breaking Change: Fixes an issue)
- [x] :hammer_and_wrench: Chore (Non-breaking Change: Doc updates, pkg upgrades, typos, etc..)
- [ ] :nail_care: New Feature (Breaking/Non-breaking Change)

## Issue (if applicable)

Contributes to https://github.com/shapeshift/web/issues/6947

## Risk

Small

> What protocols, transaction types or contract interactions might be affected by this PR?

None.

## Testing

With the RFOX flag one, confirm we have a new "Change address tab" with mock data (nothing is functional yet).

<img width="322" alt="Screenshot 2024-05-22 at 10 00 04 AM" src="https://github.com/shapeshift/web/assets/97164662/7b11917f-a903-4530-b959-bd9481c108af">

### Engineering

☝️

### Operations

☝️

## Screenshots (if applicable)

See above.