### PR TITLE
fix: generate color map before asset data

### DIFF
--- a/.github/workflows/generate.yml
+++ b/.github/workflows/generate.yml
@@ -33,6 +33,9 @@ jobs:
       - name: Generate CAIP adapters
         run: yarn generate:caip-adapters
 
+      - name: Generate color map
+        run: yarn run generate:color-map
+
       - name: Generate asset data
         env:
           ZERION_API_KEY: ${{ secrets.ZERION_API_KEY }}
@@ -43,9 +46,6 @@ jobs:
 
       - name: Generate THOR long-tail assets
         run: yarn run generate:thor-longtail-tokens
-
-      - name: Generate color map
-        run: yarn run generate:color-map
 
       - name: Create new feature branch
         run: git checkout -B feat_regenerate_asset_data


### PR DESCRIPTION
## Description

I noticed the color map was being generated after the asset data. While not a huge problem, the correct flow is to generate the color map first which will be used in the subsequent asset data generation.

## Pull Request Type

- [x] :bug: Bug fix (Non-breaking Change: Fixes an issue)
- [ ] :hammer_and_wrench: Chore (Non-breaking Change: Doc updates, pkg upgrades, typos, etc..)
- [ ] :nail_care: New Feature (Breaking/Non-breaking Change)

## Issue (if applicable)

<!-----------------------------------------------------------------------------
If applicable, please link to the github issue and put `closes #XXXX` in your comment to auto-close the issue that your PR fixes.
------------------------------------------------------------------------------>

N/A

## Risk
> High Risk PRs Require 2 approvals

<!-----------------------------------------------------------------------------
Outline the scope of your changes and the risk associated with them. You must use your discretion as an engineer to determine the potential impact of your changes.

WARNING: If your PR introduces a new on-chain transaction or modifies an existing one, please add the "High-Risk" label to this PR and ask for 2 reviewers to approve it before merging.

E.g. an upgrade to `hdwallet` or core state management would be considered higher risk, and might require a full regression test. UI or isolated view changes, or something behind a feature flag may have near zero risk. Small bug fixes might require testing isolated to the specific fix.
------------------------------------------------------------------------------>

None

> What protocols, transaction types or contract interactions might be affected by this PR?

## Testing

<!-----------------------------------------------------------------------------
We treat every PR to be merged with the same scrutiny as if we were merging directly to production.

Your PR will not be merged if you do not complete the sections below for our engineering and operations teams to test.
------------------------------------------------------------------------------>

- Asset data will include newly generated colors if there are changes

### Engineering

<!-----------------------------------------------------------------------------
Include sufficient information here for an engineer to test your PR. This may include how to test locally, in a built environment, changes to infrastructure etc.
------------------------------------------------------------------------------>

:point_up: 

### Operations

<!-----------------------------------------------------------------------------
If your changes have a user-facing impact, describe how a non-technical QA team can functionally test your changes in a preview environment.

If they are not user-facing please describe how to test for any regressions that may occur.
------------------------------------------------------------------------------>

N/A

## Screenshots (if applicable)
