### PR TITLE
chore: improve UX when account drawer is open

### DIFF
--- a/src/components/ManageAccountsDrawer/components/DrawerWrapper.tsx
+++ b/src/components/ManageAccountsDrawer/components/DrawerWrapper.tsx
@@ -10,7 +10,7 @@ export type DrawerWrapperProps = {
 export const DrawerWrapper = ({ children, isOpen, onClose, variant }: DrawerWrapperProps) => {
   return (
     <Drawer isOpen={isOpen} size='lg' placement='right' onClose={onClose} variant={variant}>
-      <DrawerOverlay />
+      <DrawerOverlay zIndex='modal' />
       <DrawerContent>
         <DrawerCloseButton />
         {children}

--- a/src/components/Modals/ManageAccounts/ManageAccountsModal.tsx
+++ b/src/components/Modals/ManageAccounts/ManageAccountsModal.tsx
@@ -157,6 +157,7 @@ export const ManageAccountsModal = () => {
                 onClick={handleClickAddChain}
                 width='full'
                 size='lg'
+                isLoading={isDrawerOpen}
                 isDisabled={disableAddChain}
                 _disabled={disabledProp}
               >
@@ -164,7 +165,13 @@ export const ManageAccountsModal = () => {
                   ? translate('accountManagement.manageAccounts.addChain')
                   : translate('accountManagement.manageAccounts.addAnotherChain')}
               </Button>
-              <Button size='lg' colorScheme='gray' onClick={close} width='full'>
+              <Button
+                size='lg'
+                colorScheme='gray'
+                onClick={close}
+                isDisabled={isDrawerOpen}
+                width='full'
+              >
                 {translate('common.done')}
               </Button>
             </VStack>


### PR DESCRIPTION
## Description

Improve UX when the account management drawer is open.

Before:

<img width="803" alt="Screenshot 2024-05-24 at 1 07 59 PM" src="https://github.com/shapeshift/web/assets/97164662/0d7626f0-305e-49f0-84b2-b0ddffc6ddea">

After:

<img width="797" alt="Screenshot 2024-05-24 at 1 07 40 PM" src="https://github.com/shapeshift/web/assets/97164662/5e8a98a7-ac4d-4723-9a20-d8ddf62d43b2">


## Pull Request Type

- [ ] :bug: Bug fix (Non-breaking Change: Fixes an issue)
- [x] :hammer_and_wrench: Chore (Non-breaking Change: Doc updates, pkg upgrades, typos, etc..)
- [ ] :nail_care: New Feature (Breaking/Non-breaking Change)

## Issue (if applicable)

N/A - UX improvement prior to feature launch.

## Risk
Low

> What protocols, transaction types or contract interactions might be affected by this PR?

None.

## Testing

When the account management drawer is open, we should now set the "Add Chain" button to a loading state, and disable the "Done" button.

This states should revert when the drawer is closed.

### Engineering

☝️

### Operations

☝️

## Screenshots (if applicable)

N/A