### PR TITLE
feat: don't refetch approval/stake fees when mutation is pending

### DIFF
--- a/src/pages/RFOX/components/Stake/StakeConfirm.tsx
+++ b/src/pages/RFOX/components/Stake/StakeConfirm.tsx
@@ -436,12 +436,11 @@ export const StakeConfirm: React.FC<StakeConfirmProps & StakeRouteProps> = ({
   const handleSubmit = useCallback(async () => {
     if (isApprovalRequired) return handleApprove()
 
-    await handleStake()
+    await handleStake() // This isn't a mistake - we invalidate as a cleanup operation before unmount to avoid current subscribers refetching with wrong args, hence making invalidation useless
+    history.push(StakeRoutePaths.Status)
 
     await queryClient.invalidateQueries({ queryKey: userStakingBalanceOfCryptoBaseUnitQueryKey })
     await queryClient.invalidateQueries({ queryKey: newContractBalanceOfCryptoBaseUnitQueryKey })
-
-    history.push(StakeRoutePaths.Status)
   }, [
     handleApprove,
     handleStake,


### PR DESCRIPTION
## Description

Tackles the jumpy issue spotted by @0xApotheosis in https://github.com/shapeshift/web/pull/6925#pullrequestreview-2075415898:

- [x]  Approval gas estimate changes after confirming quote
- [x]  Approval fee fiat amount spans two lines

## Pull Request Type

- [ ] :bug: Bug fix (Non-breaking Change: Fixes an issue)
- [ ] :hammer_and_wrench: Chore (Non-breaking Change: Doc updates, pkg upgrades, typos, etc..)
- [x] :nail_care: New Feature (Breaking/Non-breaking Change)

## Issue (if applicable)

<!-----------------------------------------------------------------------------
If applicable, please link to the github issue and put `closes #XXXX` in your comment to auto-close the issue that your PR fixes.
------------------------------------------------------------------------------>

- relates to the closed https://github.com/shapeshift/web/issues/6737

## Risk
> High Risk PRs Require 2 approvals

<!-----------------------------------------------------------------------------
Outline the scope of your changes and the risk associated with them. You must use your discretion as an engineer to determine the potential impact of your changes.

WARNING: If your PR introduces a new on-chain transaction or modifies an existing one, please add the "High-Risk" label to this PR and ask for 2 reviewers to approve it before merging.

E.g. an upgrade to `hdwallet` or core state management would be considered higher risk, and might require a full regression test. UI or isolated view changes, or something behind a feature flag may have near zero risk. Small bug fixes might require testing isolated to the specific fix.
------------------------------------------------------------------------------>

> What protocols, transaction types or contract interactions might be affected by this PR?

## Testing

<!-----------------------------------------------------------------------------
We treat every PR to be merged with the same scrutiny as if we were merging directly to production.

Your PR will not be merged if you do not complete the sections below for our engineering and operations teams to test.
------------------------------------------------------------------------------>

- Using MM, fire click either the approve or stake button depending on whether or not an approval is needed
- Wait something like 15-30s before confirming the Tx in wallet (node is currently turbo slow so things can take a v. long time to respond back)
- Ensure the gas fee is not refetched after you clicked the confirm button in app 
- Ensure the fas fee is still not refetched after confirming in MM, and before we route to status

### Engineering

<!-----------------------------------------------------------------------------
Include sufficient information here for an engineer to test your PR. This may include how to test locally, in a built environment, changes to infrastructure etc.
------------------------------------------------------------------------------>

- ^

### Operations

<!-----------------------------------------------------------------------------
If your changes have a user-facing impact, describe how a non-technical QA team can functionally test your changes in a preview environment.

If they are not user-facing please describe how to test for any regressions that may occur.
------------------------------------------------------------------------------>

- ^

## Screenshots (if applicable)

https://jam.dev/c/eea90cea-e428-4c00-9400-d3151ac6e32b

<!-- av pr metadata
This information is embedded by the av CLI when creating PRs to track the status of stacks when using Aviator. Please do not delete or edit this section of the PR.
```
{"parent":"develop","parentHead":"","trunk":"develop"}
```
-->
