### PR TITLE
poc: skipToken type narrowing in useQuery

### DIFF
--- a/package.json
+++ b/package.json
@@ -110,7 +110,7 @@
     "@shapeshiftoss/types": "workspace:^",
     "@shapeshiftoss/unchained-client": "workspace:^",
     "@sniptt/monads": "^0.5.10",
-    "@tanstack/react-query": "^5.0.5",
+    "@tanstack/react-query": "^5.40.0",
     "@uniswap/sdk": "^3.0.3",
     "@uniswap/sdk-core": "^4.0.9",
     "@uniswap/v3-sdk": "^3.10.0",

--- a/src/pages/RFOX/components/Stake/StakeInput.tsx
+++ b/src/pages/RFOX/components/Stake/StakeInput.tsx
@@ -215,40 +215,21 @@ export const StakeInput: React.FC<StakeInputProps & StakeRouteProps> = ({
     [allowanceCryptoPrecision, amountCryptoPrecision, isAllowanceDataSuccess],
   )
 
-  const isGetStakeFeesEnabled = useMemo(
-    () =>
-      Boolean(
-        hasEnoughBalance &&
-          stakingAssetAccountId &&
-          stakingAssetAccountNumber !== undefined &&
-          isValidStakingAmount &&
-          wallet &&
-          stakingAsset &&
-          runeAddress &&
-          callData &&
-          isAllowanceDataSuccess &&
-          !isApprovalRequired &&
-          feeAsset &&
-          feeAssetMarketData &&
-          !Boolean(errors.amountFieldInput || errors.manualRuneAddress),
-      ),
-    [
-      hasEnoughBalance,
-      stakingAssetAccountId,
-      stakingAssetAccountNumber,
-      isValidStakingAmount,
-      wallet,
-      stakingAsset,
-      runeAddress,
-      callData,
-      isAllowanceDataSuccess,
-      isApprovalRequired,
-      feeAsset,
-      feeAssetMarketData,
-      errors.amountFieldInput,
-      errors.manualRuneAddress,
-    ],
-  )
+  // No need to memoize as it evaluates to a primitive (boolean)
+  const isGetStakeFeesEnabled =
+    hasEnoughBalance &&
+    !!stakingAssetAccountId &&
+    stakingAssetAccountNumber !== undefined &&
+    isValidStakingAmount &&
+    !!wallet &&
+    !!stakingAsset &&
+    !!runeAddress &&
+    !!callData &&
+    isAllowanceDataSuccess &&
+    !isApprovalRequired &&
+    !!feeAsset &&
+    !!feeAssetMarketData &&
+    !(errors.amountFieldInput || errors.manualRuneAddress)
 
   const {
     data: stakeFees,

--- a/src/pages/RFOX/components/Stake/StakeInput.tsx
+++ b/src/pages/RFOX/components/Stake/StakeInput.tsx
@@ -1,7 +1,7 @@
 import { Button, CardFooter, Collapse, Skeleton, Stack } from '@chakra-ui/react'
 import type { AssetId } from '@shapeshiftoss/caip'
 import { foxOnArbitrumOneAssetId, fromAccountId, fromAssetId } from '@shapeshiftoss/caip'
-import { useQuery } from '@tanstack/react-query'
+import { skipToken, useQuery } from '@tanstack/react-query'
 import { erc20ABI } from 'contracts/abis/ERC20ABI'
 import { foxStakingV1Abi } from 'contracts/abis/FoxStakingV1'
 import { RFOX_PROXY_CONTRACT_ADDRESS } from 'contracts/constants'
@@ -255,18 +255,22 @@ export const StakeInput: React.FC<StakeInputProps & StakeRouteProps> = ({
     isLoading: isStakeFeesLoading,
     isSuccess: isStakeFeesSuccess,
   } = useQuery({
-    ...reactQueries.common.evmFees({
-      to: RFOX_PROXY_CONTRACT_ADDRESS,
-      from: stakingAssetAccountId ? fromAccountId(stakingAssetAccountId).account : '', // see isGetStakeFeesEnabled
-      accountNumber: stakingAssetAccountNumber!, // see isGetStakeFeesEnabled
-      data: callData!, // see isGetStakeFeesEnabled
-      value: '0', // contract call
-      wallet: wallet!, // see isGetStakeFeesEnabled
-      feeAsset: feeAsset!, // see isGetStakeFeesEnabled
-      feeAssetMarketData: feeAssetMarketData!, // see isGetStakeFeesEnabled
-    }),
+    queryKey: ['stakeFees'],
+    queryFn: isGetStakeFeesEnabled
+      ? () => {
+          return reactQueries.common.evmFees({
+            to: RFOX_PROXY_CONTRACT_ADDRESS,
+            from: stakingAssetAccountId ? fromAccountId(stakingAssetAccountId).account : '',
+            accountNumber: stakingAssetAccountNumber,
+            data: callData,
+            value: '0',
+            wallet: wallet!,
+            feeAsset: feeAsset!,
+            feeAssetMarketData: feeAssetMarketData!,
+          })
+        }
+      : skipToken,
     staleTime: 30_000,
-    enabled: isGetStakeFeesEnabled,
     // Ensures fees are refetched at an interval, including when the app is in the background
     refetchIntervalInBackground: true,
     // Yeah this is arbitrary but come on, Arb is cheap

--- a/yarn.lock
+++ b/yarn.lock
@@ -11127,7 +11127,7 @@ __metadata:
     "@shapeshiftoss/types": "workspace:^"
     "@shapeshiftoss/unchained-client": "workspace:^"
     "@sniptt/monads": ^0.5.10
-    "@tanstack/react-query": ^5.0.5
+    "@tanstack/react-query": ^5.40.0
     "@testing-library/react": ^13.3.0
     "@types/bignumber.js": ^5.0.0
     "@types/bip21": ^2.0.0
@@ -11847,10 +11847,10 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@tanstack/query-core@npm:5.0.5":
-  version: 5.0.5
-  resolution: "@tanstack/query-core@npm:5.0.5"
-  checksum: 8df99b29c136d597b89bd49aba49c26c33f5ffc6d034a7c42e57a85e9be831cbb576822b02472cfdba467f76389dd4e0f8c1d3b2f82f68222f7e3e2ad2b749b9
+"@tanstack/query-core@npm:5.40.0":
+  version: 5.40.0
+  resolution: "@tanstack/query-core@npm:5.40.0"
+  checksum: 3c94bc71dd2f80db1e8fdd6f201d9fed7a008636ad6a6a89d24f54824ceb38bbc8c05b24731b8eb7cd895b9e75e7851962660d0aa5fc0841f3295fe95630d70e
   languageName: node
   linkType: hard
 
@@ -11902,21 +11902,14 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@tanstack/react-query@npm:^5.0.5":
-  version: 5.0.5
-  resolution: "@tanstack/react-query@npm:5.0.5"
+"@tanstack/react-query@npm:^5.40.0":
+  version: 5.40.0
+  resolution: "@tanstack/react-query@npm:5.40.0"
   dependencies:
-    "@tanstack/query-core": 5.0.5
+    "@tanstack/query-core": 5.40.0
   peerDependencies:
     react: ^18.0.0
-    react-dom: ^18.0.0
-    react-native: "*"
-  peerDependenciesMeta:
-    react-dom:
-      optional: true
-    react-native:
-      optional: true
-  checksum: 8c4db91b2dc72e4a9ff94dad1143b2a157fe3516a1f875366ad2dd2e66cde0c37a6613ac828a998401ea21d745591d0c477e6bf62a0676cd6eb3088cae01ec38
+  checksum: 4e1513179a9f2e0d0cf64c6c4bc9ac35129305ea64c86f9dd3735a0a36a48c7dbc6cd37f821a510a66004f45c96b5955db5d0a85a0f259ccf5eebae3a9dc419e
   languageName: node
   linkType: hard
 


### PR DESCRIPTION
@gomesalexandre a little PoC on https://github.com/shapeshift/web/issues/6973.

As far as I can tell the type narrowing still does not work when the "enabled" filter is a `useMemo`.
It did work without it, but obviously we cannot do this.