### PR TITLE
feat: remove MinOut safety from THOR repays

### DIFF
--- a/src/lib/utils/thorchain/memo/assertAndProcessMemo.test.ts
+++ b/src/lib/utils/thorchain/memo/assertAndProcessMemo.test.ts
@@ -674,13 +674,5 @@ describe('assertAndProcessMemo', () => {
       const memo = '$-:BTC.BTC::9786345:ss:0'
       expect(() => assertAndProcessMemo(memo)).toThrow()
     })
-
-    it('should throw on invalid min out', () => {
-      let memo = '$-:BTC.BTC:bc1q85pgumgwvaw26j47xqt6dup5l995a9ecte9sfq::bad:0'
-      expect(() => assertAndProcessMemo(memo)).toThrow()
-
-      memo = '$-:BTC.BTC:bc1q85pgumgwvaw26j47xqt6dup5l995a9ecte9sfq:0:bad:0'
-      expect(() => assertAndProcessMemo(memo)).not.toThrow()
-    })
   })
 })

--- a/src/lib/utils/thorchain/memo/assertAndProcessMemo.ts
+++ b/src/lib/utils/thorchain/memo/assertAndProcessMemo.ts
@@ -40,10 +40,6 @@ function assertMemoHasAction(action: string | undefined, memo: string): asserts 
   if (!action) throw new Error(`action is required in memo: ${memo}`)
 }
 
-function assertMemoHasMinOut(minOut: string | undefined, memo: string): asserts minOut is string {
-  if (!minOut) throw new Error(`minOut is required in memo: ${memo}`)
-}
-
 const assertIsValidLimit = (limit: string | undefined, memo: string) => {
   assertMemoHasLimit(limit, memo)
 
@@ -59,19 +55,6 @@ const assertIsValidLimit = (limit: string | undefined, memo: string) => {
   }
 
   if (!bn(limit).gt(0)) throw new Error(`positive limit is required in memo: ${memo}`)
-}
-
-// const assertIsValidPositiveMinOut = (minOut: string | undefined, memo: string) => {
-// assertMemoHasMinOut(minOut, memo)
-//
-// if (!bn(minOut).isInteger()) throw new Error(`minOut must be an integer in memo: ${memo}`)
-// if (!bn(minOut).gt(0)) throw new Error(`positive minOut is required in memo: ${memo}`)
-// }
-
-const assertIsValidMinOut = (minOut: string | undefined, memo: string) => {
-  assertMemoHasMinOut(minOut, memo)
-
-  if (!bn(minOut).isInteger()) throw new Error(`minOut must be an integer in memo: ${memo}`)
 }
 
 function assertIsValidBasisPoints(
@@ -159,8 +142,6 @@ export const assertAndProcessMemo = (memo: string): string => {
 
       assertMemoHasAsset(asset, memo)
       assertMemoHasDestAddr(destAddr, memo)
-      // Disable until we implement minout in borrows
-      // assertIsValidPositiveMinOut(minOut, memo)
 
       return `${_action}:${asset}:${destAddr}:${minOut ?? ''}:${THORCHAIN_AFFILIATE_NAME}:${
         fee || 0
@@ -173,8 +154,6 @@ export const assertAndProcessMemo = (memo: string): string => {
 
       assertMemoHasAsset(asset, memo)
       assertMemoHasDestAddr(destAddr, memo)
-      // MinOut doesn't have to be positive - 0 is perfectly valid for partial repayments since no collateral refund is triggered
-      assertIsValidMinOut(minOut, memo)
 
       return `${_action}:${asset}:${destAddr}:${minOut ?? ''}:${THORCHAIN_AFFILIATE_NAME}:0`
     }

--- a/src/pages/Lending/Pool/components/Repay/RepayConfirm.tsx
+++ b/src/pages/Lending/Pool/components/Repay/RepayConfirm.tsx
@@ -47,7 +47,7 @@ import { isToken } from 'lib/utils'
 import { waitForThorchainUpdate } from 'lib/utils/thorchain'
 import { useSendThorTx } from 'lib/utils/thorchain/hooks/useSendThorTx'
 import type { LendingQuoteClose } from 'lib/utils/thorchain/lending/types'
-import { addLimitToMemo } from 'lib/utils/thorchain/memo/addLimitToMemo'
+import { assertAndProcessMemo } from 'lib/utils/thorchain/memo'
 import { useLendingQuoteCloseQuery } from 'pages/Lending/hooks/useLendingCloseQuery'
 import { useLendingPositionData } from 'pages/Lending/hooks/useLendingPositionData'
 import {
@@ -249,9 +249,7 @@ export const RepayConfirm = ({
   const memo = useMemo(() => {
     if (!confirmedQuote) return null
 
-    // No need for slippage deduction here - quoteWithdrawnAmountAfterFeesThorBaseUnit (expected_amount_out) already is quote.fees.slippage_bps deducted
-    const minCollateralOut = confirmedQuote.quoteWithdrawnAmountAfterFeesThorBaseUnit
-    return addLimitToMemo({ memo: confirmedQuote.quoteMemo, limit: minCollateralOut })
+    return assertAndProcessMemo(confirmedQuote.quoteMemo)
   }, [confirmedQuote])
 
   const {

--- a/src/pages/Lending/Pool/components/Repay/RepayInput.tsx
+++ b/src/pages/Lending/Pool/components/Repay/RepayInput.tsx
@@ -46,7 +46,7 @@ import { isToken } from 'lib/utils'
 import { getSupportedEvmChainIds } from 'lib/utils/evm'
 import { useSendThorTx } from 'lib/utils/thorchain/hooks/useSendThorTx'
 import type { LendingQuoteClose } from 'lib/utils/thorchain/lending/types'
-import { addLimitToMemo } from 'lib/utils/thorchain/memo/addLimitToMemo'
+import { assertAndProcessMemo } from 'lib/utils/thorchain/memo'
 import { useLendingQuoteCloseQuery } from 'pages/Lending/hooks/useLendingCloseQuery'
 import { useLendingPositionData } from 'pages/Lending/hooks/useLendingPositionData'
 import { useLendingSupportedAssets } from 'pages/Lending/hooks/useLendingSupportedAssets'
@@ -383,10 +383,10 @@ export const RepayInput = ({
   const memo = useMemo(() => {
     if (!confirmedQuote) return null
 
-    // No need for slippage deduction here - quoteWithdrawnAmountAfterFeesThorBaseUnit (expected_amount_out) already is quote.fees.slippage_bps deducted
-    const minCollateralOut = confirmedQuote.quoteWithdrawnAmountAfterFeesThorBaseUnit
-    return addLimitToMemo({ memo: confirmedQuote.quoteMemo, limit: minCollateralOut })
+    return assertAndProcessMemo(confirmedQuote.quoteMemo)
   }, [confirmedQuote])
+
+  debugger
 
   const { estimatedFeesData, isEstimatedFeesDataLoading, isEstimatedFeesDataError } = useSendThorTx(
     {

--- a/src/pages/Lending/Pool/components/Repay/RepayInput.tsx
+++ b/src/pages/Lending/Pool/components/Repay/RepayInput.tsx
@@ -386,8 +386,6 @@ export const RepayInput = ({
     return assertAndProcessMemo(confirmedQuote.quoteMemo)
   }, [confirmedQuote])
 
-  debugger
-
   const { estimatedFeesData, isEstimatedFeesDataLoading, isEstimatedFeesDataError } = useSendThorTx(
     {
       assetId: repaymentAsset?.assetId ?? '',


### PR DESCRIPTION
## Description

Ensures we benefit from automagical streaming loan closes, so that users don't end up with reverts and get the best rate possible on their collateral refund.

## Pull Request Type

- [x] :bug: Bug fix (Non-breaking Change: Fixes an issue)
- [ ] :hammer_and_wrench: Chore (Non-breaking Change: Doc updates, pkg upgrades, typos, etc..)
- [ ] :nail_care: New Feature (Breaking/Non-breaking Change)

## Issue (if applicable)

<!-----------------------------------------------------------------------------
If applicable, please link to the github issue and put `closes #XXXX` in your comment to auto-close the issue that your PR fixes.
------------------------------------------------------------------------------>

N/A, spotted in https://discord.com/channels/554694662431178782/876953436908822568/1244772064590561280

## Risk
> High Risk PRs Require 2 approvals

<!-----------------------------------------------------------------------------
Outline the scope of your changes and the risk associated with them. You must use your discretion as an engineer to determine the potential impact of your changes.

WARNING: If your PR introduces a new on-chain transaction or modifies an existing one, please add the "High-Risk" label to this PR and ask for 2 reviewers to approve it before merging.

E.g. an upgrade to `hdwallet` or core state management would be considered higher risk, and might require a full regression test. UI or isolated view changes, or something behind a feature flag may have near zero risk. Small bug fixes might require testing isolated to the specific fix.
------------------------------------------------------------------------------>

Low, we now honor the THOR-returned memo. If something is wrong here, then something is wrong in the quote.

> What protocols, transaction types or contract interactions might be affected by this PR?

## Testing

<!-----------------------------------------------------------------------------
We treat every PR to be merged with the same scrutiny as if we were merging directly to production.

Your PR will not be merged if you do not complete the sections below for our engineering and operations teams to test.
------------------------------------------------------------------------------>

- Test with either your own loan or a frame injected known borrower
- Get a quote for 100% repay and note the memo in the `close` request (see screenshots)
- Ensure that the actual memo in the calldata (either on the on-chain Tx, or in frame if testing with Frame) is the same as the quote one, except it has affiliate name and fees slapped to it


### Engineering

<!-----------------------------------------------------------------------------
Include sufficient information here for an engineer to test your PR. This may include how to test locally, in a built environment, changes to infrastructure etc.
------------------------------------------------------------------------------>

- ^

### Operations

<!-----------------------------------------------------------------------------
If your changes have a user-facing impact, describe how a non-technical QA team can functionally test your changes in a preview environment.

If they are not user-facing please describe how to test for any regressions that may occur.
------------------------------------------------------------------------------>

- ^

## Screenshots (if applicable)


- Quote and `close` request

<img width="982" alt="Screenshot 2024-05-28 at 09 46 59" src="https://github.com/shapeshift/web/assets/17035424/32c39fbe-626d-49e8-a419-540bc6f83b00">



- Actual memo: `$-:ETH.ETH:0x0e1799c427da1881a72912840d40495769b94f6f::ss:0`

<img width="361" alt="Screenshot 2024-05-28 at 09 47 30" src="https://github.com/shapeshift/web/assets/17035424/f3133b61-b01f-4b6f-9c85-b2fd5bff38e0">


<!-- av pr metadata
This information is embedded by the av CLI when creating PRs to track the status of stacks when using Aviator. Please do not delete or edit this section of the PR.
```
{"parent":"develop","parentHead":"","trunk":"develop"}
```
-->
