### PR TITLE
feat: fetch claims from rFOX contract

### DIFF
--- a/src/assets/translations/en/main.json
+++ b/src/assets/translations/en/main.json
@@ -2452,7 +2452,9 @@
       "stakeAmount": "This is the amount of FOX you will stake",
       "unstakeAmount": "This is amount of FOX you will unstake",
       "lockupPeriod": "This is how long you will have to wait after unstaking to claim your FOX",
-      "shareOfPool": "This is your percentage of the fees, you'll earn."
+      "shareOfPool": "This is your percentage of the fees, you'll earn.",
+      "unstakePendingCooldown": "Claim available %{cooldownPeriodHuman}",
+      "cooldownComplete": "Cooldown finished %{cooldownPeriodHuman}"
     },
     "stakeSuccess": "You have successfully staked %{amount} %{symbol}",
     "stakePending": "Staking %{amount} %{symbol}...",

--- a/src/assets/translations/en/main.json
+++ b/src/assets/translations/en/main.json
@@ -2452,7 +2452,7 @@
       "stakeAmount": "This is the amount of FOX you will stake",
       "unstakeAmount": "This is amount of FOX you will unstake",
       "lockupPeriod": "This is how long you will have to wait after unstaking to claim your FOX",
-      "shareOfPool": "This is your percentage of the fees, you'll earn.",
+      "shareOfPool": "This is your percentage of the fees you'll earn.",
       "unstakePendingCooldown": "Claim available %{cooldownPeriodHuman}",
       "cooldownComplete": "Cooldown finished %{cooldownPeriodHuman}"
     },

--- a/src/pages/RFOX/components/Claim/ClaimSelect.tsx
+++ b/src/pages/RFOX/components/Claim/ClaimSelect.tsx
@@ -231,6 +231,11 @@ export const ClaimSelect: FC<ClaimSelectProps & ClaimRouteProps> = ({
   } = useReadContracts({
     contracts,
     allowFailure: false,
+    query: {
+      refetchOnMount: true,
+      refetchOnWindowFocus: true,
+      refetchInterval: 60000, // 1 minute
+    },
   })
 
   if (!stakingAssetAccountAddress) return null

--- a/src/pages/RFOX/components/Claim/ClaimSelect.tsx
+++ b/src/pages/RFOX/components/Claim/ClaimSelect.tsx
@@ -207,21 +207,25 @@ export const ClaimSelect: FC<ClaimSelectProps & ClaimRouteProps> = ({
     [isUnstakingRequestCountSuccess, unstakingRequestCountResponse],
   )
 
-  const contracts = Array.from(
-    { length: Number(unstakingRequestCountResponse) },
-    (_, index) =>
-      ({
-        abi: foxStakingV1Abi,
-        address: RFOX_PROXY_CONTRACT_ADDRESS,
-        functionName: 'getUnstakingRequest',
-        args: [
-          stakingAssetAccountAddress
-            ? getAddress(stakingAssetAccountAddress)
-            : ('' as Address, BigInt(index)),
-          index,
-        ],
-        chainId: arbitrum.id,
-      }) as const,
+  const contracts = useMemo(
+    () =>
+      Array.from(
+        { length: Number(unstakingRequestCountResponse) },
+        (_, index) =>
+          ({
+            abi: foxStakingV1Abi,
+            address: RFOX_PROXY_CONTRACT_ADDRESS,
+            functionName: 'getUnstakingRequest',
+            args: [
+              stakingAssetAccountAddress
+                ? getAddress(stakingAssetAccountAddress)
+                : ('' as Address, BigInt(index)),
+              index,
+            ],
+            chainId: arbitrum.id,
+          }) as const,
+      ),
+    [stakingAssetAccountAddress, unstakingRequestCountResponse],
   )
 
   const {

--- a/src/pages/RFOX/components/Claim/ClaimSelect.tsx
+++ b/src/pages/RFOX/components/Claim/ClaimSelect.tsx
@@ -1,4 +1,4 @@
-import { Box, Button, CardBody, Center, Flex, Skeleton, Stack } from '@chakra-ui/react'
+import { Box, Button, CardBody, Center, Flex, Skeleton, Stack, Tooltip } from '@chakra-ui/react'
 import {
   type AssetId,
   foxAssetId,
@@ -9,6 +9,7 @@ import { bnOrZero } from '@shapeshiftoss/chain-adapters'
 import { TransferType } from '@shapeshiftoss/unchained-client'
 import { foxStakingV1Abi } from 'contracts/abis/FoxStakingV1'
 import { RFOX_PROXY_CONTRACT_ADDRESS } from 'contracts/constants'
+import { formatDistanceToNow } from 'date-fns'
 import { type FC, useCallback, useMemo } from 'react'
 import { useTranslate } from 'react-polyglot'
 import { useHistory } from 'react-router'
@@ -22,7 +23,7 @@ import { AssetIconWithBadge } from 'components/AssetIconWithBadge'
 import { SlideTransition } from 'components/SlideTransition'
 import { RawText, Text } from 'components/Text'
 import { TransactionTypeIcon } from 'components/TransactionHistory/TransactionTypeIcon'
-import { toBaseUnit } from 'lib/math'
+import { fromBaseUnit, toBaseUnit } from 'lib/math'
 import { TabIndex } from 'pages/RFOX/RFOX'
 import { selectAssetById, selectFirstAccountIdByChainId } from 'state/slices/selectors'
 import { useAppSelector } from 'state/store'
@@ -30,11 +31,17 @@ import { useAppSelector } from 'state/store'
 import type { RfoxClaimQuote } from './types'
 import { ClaimRoutePaths, type ClaimRouteProps } from './types'
 
+enum ClaimStatus {
+  Available = 'Available',
+  CoolingDown = 'Cooling down',
+}
+
 type ClaimRowProps = {
   stakingAssetId: AssetId
   amountCryptoPrecision: string
-  status: string
+  status: ClaimStatus
   setConfirmedQuote: (quote: RfoxClaimQuote) => void
+  cooldownPeriodHuman: string
 }
 
 const hoverProps = { bg: 'gray.700' }
@@ -44,6 +51,7 @@ const ClaimRow: FC<ClaimRowProps> = ({
   amountCryptoPrecision,
   status,
   setConfirmedQuote,
+  cooldownPeriodHuman,
 }) => {
   const translate = useTranslate()
   const history = useHistory()
@@ -75,38 +83,59 @@ const ClaimRow: FC<ClaimRowProps> = ({
   }, [claimQuote, history, setConfirmedQuote])
 
   return (
-    <Flex
-      as={Button}
-      align='center'
-      variant='unstyled'
-      p={8}
-      borderRadius='md'
-      width='100%'
-      onClick={handleClick}
-      _hover={hoverProps}
+    <Tooltip
+      label={translate(
+        status === ClaimStatus.Available
+          ? 'RFOX.tooltips.cooldownComplete'
+          : 'RFOX.tooltips.unstakePendingCooldown',
+        { cooldownPeriodHuman },
+      )}
     >
-      <Box mr={4}>
-        <AssetIconWithBadge assetId={foxAssetId}>
-          <TransactionTypeIcon type={TransferType.Receive} />
-        </AssetIconWithBadge>
-      </Box>
-      <Box mr={4}>
-        <RawText fontSize='sm' color='gray.400' align={'start'}>
-          {translate('RFOX.unstakeFrom', { assetSymbol: stakingAssetSymbol })}
-        </RawText>
-        <RawText fontSize='xl' fontWeight='bold' color='white' align={'start'}>
-          {stakingAssetSymbol}
-        </RawText>
-      </Box>
-      <Box flex='1' alignItems={'end'}>
-        <RawText fontSize='sm' fontWeight='bold' color='green.300' align={'end'}>
-          {status}
-        </RawText>
-        <RawText fontSize='xl' fontWeight='bold' color='white' align={'end'}>
-          <Amount.Crypto value={amountCryptoPrecision} symbol={stakingAssetSymbol ?? ''} />
-        </RawText>
-      </Box>
-    </Flex>
+      <Flex
+        as={Button}
+        justifyContent={'space-between'}
+        mt={2}
+        align='center'
+        variant='unstyled'
+        p={8}
+        borderRadius='md'
+        width='100%'
+        onClick={handleClick}
+        isDisabled={status !== ClaimStatus.Available}
+        _hover={hoverProps}
+      >
+        <Flex>
+          <Box mr={4}>
+            <AssetIconWithBadge assetId={foxAssetId}>
+              <TransactionTypeIcon type={TransferType.Receive} />
+            </AssetIconWithBadge>
+          </Box>
+          <Box mr={4}>
+            <RawText fontSize='sm' color='gray.400' align={'start'}>
+              {translate('RFOX.unstakeFrom', { assetSymbol: stakingAssetSymbol })}
+            </RawText>
+            <RawText fontSize='xl' fontWeight='bold' color='white' align={'start'}>
+              {stakingAssetSymbol}
+            </RawText>
+          </Box>
+        </Flex>
+        <Flex justifyContent={'flex-end'}>
+          <Box flexGrow={1} alignItems={'end'}>
+            <RawText
+              fontSize='sm'
+              fontWeight='bold'
+              color={status === ClaimStatus.Available ? 'green.300' : 'yellow.300'}
+              align={'end'}
+            >
+              {status}
+            </RawText>
+            <RawText fontSize='xl' fontWeight='bold' color='white' align={'end'}>
+              <Amount.Crypto value={amountCryptoPrecision} symbol={stakingAssetSymbol ?? ''} />
+            </RawText>
+          </Box>
+        </Flex>
+      </Flex>
+    </Tooltip>
   )
 }
 
@@ -189,6 +218,7 @@ export const ClaimSelect: FC<ClaimSelectProps & ClaimRouteProps> = ({
           stakingAssetAccountAddress
             ? getAddress(stakingAssetAccountAddress)
             : ('' as Address, BigInt(index)),
+          index,
         ],
         chainId: arbitrum.id,
       }) as const,
@@ -211,17 +241,28 @@ export const ClaimSelect: FC<ClaimSelectProps & ClaimRouteProps> = ({
       <CardBody py={12}>
         <Skeleton isLoaded={!isUnstakingRequestCountLoading && !isUnstakingRequestLoading}>
           <Flex flexDir='column' gap={4}>
-            {hasClaims ? (
+            {hasClaims && isUnstakingRequestSuccess ? (
               unstakingRequestResponse?.map(unstakingRequest => {
-                const amountCryptoPrecision = unstakingRequest.unstakingBalance
-                const status = 'Available'
+                const amountCryptoPrecision = fromBaseUnit(
+                  unstakingRequest.unstakingBalance.toString() ?? '',
+                  stakingAsset?.precision ?? 0,
+                )
+                const currentTimestampMs: number = Date.now()
+                const unstakingTimestampMs: number = Number(unstakingRequest.cooldownExpiry) * 1000
+                const isAvailable = currentTimestampMs >= unstakingTimestampMs
+                const cooldownDeltaMs = unstakingTimestampMs - currentTimestampMs
+                const cooldownPeriodHuman = formatDistanceToNow(Date.now() + cooldownDeltaMs, {
+                  addSuffix: true,
+                })
+                const status = isAvailable ? ClaimStatus.Available : ClaimStatus.CoolingDown
                 return (
                   <ClaimRow
                     key={unstakingRequest.cooldownExpiry.toString()}
                     stakingAssetId={foxAssetId}
-                    amountCryptoPrecision={amountCryptoPrecision.toString()}
+                    amountCryptoPrecision={amountCryptoPrecision?.toString() ?? ''}
                     status={status}
                     setConfirmedQuote={setConfirmedQuote}
+                    cooldownPeriodHuman={cooldownPeriodHuman}
                   />
                 )
               })


### PR DESCRIPTION
## Description

Fetches claims from rFOX contract showing them in the claims tab.

Note, this PR is not expected to populate the claim confirm flow when a `ClaimRow` is selected - only to show available claims.
Also note, the UI is a little borked with respect to the flex end alignment. Wasted a decent chunk of time trying to fix, will address as a follow-up.

## Pull Request Type

- [ ] :bug: Bug fix (Non-breaking Change: Fixes an issue)
- [ ] :hammer_and_wrench: Chore (Non-breaking Change: Doc updates, pkg upgrades, typos, etc..)
- [x] :nail_care: New Feature (Breaking/Non-breaking Change)

## Issue (if applicable)

Contributes to https://github.com/shapeshift/web/issues/6899

## Risk

Small, contract reads and UI only.

> What protocols, transaction types or contract interactions might be affected by this PR?

rFOX contract reads.

## Testing

- Loading the "Claim" rFOX tab should show all available claims for the connected account, and unavailable claims greyed out. On hover, the relative cooldown period should be shown in a tooltip.
- Connecting to an account with no available claims shows "No claims available" UI

### Engineering

☝️

### Operations

☝️

## Screenshots (if applicable)

<img width="324" alt="Screenshot 2024-05-31 at 10 00 45 AM" src="https://github.com/shapeshift/web/assets/97164662/12accfc2-d1c4-4482-b222-589cc8be626f">

<img width="334" alt="Screenshot 2024-05-31 at 10 00 52 AM" src="https://github.com/shapeshift/web/assets/97164662/6515af2c-2210-4d94-8d4d-dbaa7c2d2a9f">

<img width="321" alt="Screenshot 2024-05-31 at 10 11 11 AM" src="https://github.com/shapeshift/web/assets/97164662/693f2e0b-e40d-4391-9311-9b21005d92a6">
