### PR TITLE
fix: show existing account ids in store

### DIFF
--- a/src/components/ManageAccountsDrawer/components/ImportAccounts.tsx
+++ b/src/components/ManageAccountsDrawer/components/ImportAccounts.tsx
@@ -29,6 +29,7 @@ import { isUtxoAccountId } from 'lib/utils/utxo'
 import { portfolio, portfolioApi } from 'state/slices/portfolioSlice/portfolioSlice'
 import { accountIdToLabel } from 'state/slices/portfolioSlice/utils'
 import {
+  selectAccountIdsByChainId,
   selectFeeAssetByChainId,
   selectIsAccountIdEnabled,
   selectIsAnyAccountIdEnabled,
@@ -224,6 +225,9 @@ export const ImportAccounts = ({ chainId, onClose }: ImportAccountsProps) => {
     })
   }, [queryEnabled, isLedgerWallet, isMetaMaskMultichainWallet, isSnapInstalled, queryClient])
 
+  const accountIdsByChainId = useAppSelector(selectAccountIdsByChainId)
+  const existingAccountIdsForChain = accountIdsByChainId[chainId]
+
   // Handle initial automatic loading
   useEffect(() => {
     if (isFetching || isLoading || !autoFetching || !accounts || !queryEnabled) return
@@ -233,14 +237,26 @@ export const ImportAccounts = ({ chainId, onClose }: ImportAccountsProps) => {
       accounts.pages.length - 1
     ].accountIdWithActivityAndMetadata.some(account => account.hasActivity)
 
+    const isLastAccountInStore = existingAccountIdsForChain?.includes(
+      accounts.pages[accounts.pages.length - 1].accountIdWithActivityAndMetadata[0].accountId,
+    )
+
     // Keep fetching until we find an account without activity
-    if (isLastAccountActive) {
+    if (isLastAccountActive || isLastAccountInStore) {
       fetchNextPage()
     } else {
       // Stop auto-fetching and switch to manual mode
       setAutoFetching(false)
     }
-  }, [accounts, fetchNextPage, autoFetching, isFetching, isLoading, queryEnabled])
+  }, [
+    accounts,
+    fetchNextPage,
+    autoFetching,
+    isFetching,
+    isLoading,
+    queryEnabled,
+    existingAccountIdsForChain,
+  ])
 
   const handleLoadMore = useCallback(() => {
     if (isFetching || isLoading || autoFetching) return


### PR DESCRIPTION
## Description

Fixes an issue where existing accountIds in the store (that have been enabled) would not show in the new account management "add account" drawer if the previous account did not have a balance.

E.g. if account 0 has no balance, but accounts 0 and 1 have been added for a chain, only account 0 would show in the drawer:

<img width="797" alt="Screenshot 2024-05-31 at 3 46 18 PM" src="https://github.com/shapeshift/web/assets/97164662/8b5bfb84-a0fb-4563-be58-d104cd75a59b">

## Pull Request Type

- [x] :bug: Bug fix (Non-breaking Change: Fixes an issue)
- [ ] :hammer_and_wrench: Chore (Non-breaking Change: Doc updates, pkg upgrades, typos, etc..)
- [ ] :nail_care: New Feature (Breaking/Non-breaking Change)

## Issue (if applicable)

N/A - discovered whilst testing.

## Risk

Small

> What protocols, transaction types or contract interactions might be affected by this PR?

None.

## Testing

See example of when this bug occurs in the description.

### Engineering

☝️

### Operations

☝️

## Screenshots (if applicable)

See above.