### PR TITLE
fix: dead click on same wallet selection after clicking back

### DIFF
--- a/src/context/WalletProvider/WalletViewsSwitch.tsx
+++ b/src/context/WalletProvider/WalletViewsSwitch.tsx
@@ -23,6 +23,8 @@ import { SelectModal } from './SelectModal'
 
 const arrowBackIcon = <ArrowBackIcon />
 
+const INITIAL_WALLET_MODAL_ROUTE = '/'
+
 export const WalletViewsSwitch = () => {
   const history = useHistory()
   const location = useLocation()
@@ -62,7 +64,7 @@ export const WalletViewsSwitch = () => {
       store.dispatch(localWalletSlice.actions.clearLocalWallet())
       dispatch({ type: WalletActions.OPEN_KEEPKEY_DISCONNECT })
     } else {
-      history.replace('/')
+      history.replace(INITIAL_WALLET_MODAL_ROUTE)
       if (disconnectOnCloseModal) {
         disconnect()
         dispatch({ type: WalletActions.RESET_STATE })
@@ -86,7 +88,7 @@ export const WalletViewsSwitch = () => {
     history.goBack()
     // If we're back at the select wallet modal, remove the initial route
     // otherwise clicking the button for the same wallet doesn't do anything
-    if (history.location.pathname === '/select') {
+    if (history.location.pathname === INITIAL_WALLET_MODAL_ROUTE) {
       dispatch({ type: WalletActions.SET_INITIAL_ROUTE, payload: '' })
     }
     await cancelWalletRequests()
@@ -152,7 +154,7 @@ export const WalletViewsSwitch = () => {
             <SlideTransition key={location.key}>
               <Switch key={location.pathname} location={location}>
                 {walletRoutesList}
-                <Route path={'/'} children={renderSelectModal} />
+                <Route path={INITIAL_WALLET_MODAL_ROUTE} children={renderSelectModal} />
               </Switch>
             </SlideTransition>
           </AnimatePresence>


### PR DESCRIPTION
## Description

If you clean on a wallet inside the wallet modal, then go back, you can't click on the same wallet...

The fix doesn't really look healthy tbh as it's probably the third time we are fixing this bug already in the same way

Putting it in a variable makes it a bit more robust, but if we add another route between the initial routes and wallet routes, it might break again

<!-- Please describe your changes -->

## Pull Request Type

- [x] :bug: Bug fix (Non-breaking Change: Fixes an issue)
- [ ] :hammer_and_wrench: Chore (Non-breaking Change: Doc updates, pkg upgrades, typos, etc..)
- [ ] :nail_care: New Feature (Breaking/Non-breaking Change)

## Issue (if applicable)

## Risk
> High Risk PRs Require 2 approvals

<!-----------------------------------------------------------------------------
Outline the scope of your changes and the risk associated with them. You must use your discretion as an engineer to determine the potential impact of your changes.

WARNING: If your PR introduces a new on-chain transaction or modifies an existing one, please add the "High-Risk" label to this PR and ask for 2 reviewers to approve it before merging.

E.g. an upgrade to `hdwallet` or core state management would be considered higher risk, and might require a full regression test. UI or isolated view changes, or something behind a feature flag may have near zero risk. Small bug fixes might require testing isolated to the specific fix.
------------------------------------------------------------------------------>

> What protocols, transaction types or contract interactions might be affected by this PR?

## Testing

Verify that this bug is not happening anymore:

https://jam.dev/c/fcccf421-f247-4981-98f4-37f2e24b6c0f

<!-----------------------------------------------------------------------------
We treat every PR to be merged with the same scrutiny as if we were merging directly to production.

Your PR will not be merged if you do not complete the sections below for our engineering and operations teams to test.
------------------------------------------------------------------------------>

### Engineering

<!-----------------------------------------------------------------------------
Include sufficient information here for an engineer to test your PR. This may include how to test locally, in a built environment, changes to infrastructure etc.
------------------------------------------------------------------------------>

### Operations

<!-----------------------------------------------------------------------------
If your changes have a user-facing impact, describe how a non-technical QA team can functionally test your changes in a preview environment.

If they are not user-facing please describe how to test for any regressions that may occur.
------------------------------------------------------------------------------>

## Screenshots (if applicable)
