### PR TITLE
fix: use feature-flagged chainIds to determine use in the app

### DIFF
--- a/src/context/AppProvider/AppContext.tsx
+++ b/src/context/AppProvider/AppContext.tsx
@@ -5,7 +5,6 @@ import { isLedger } from '@shapeshiftoss/hdwallet-ledger'
 import { MetaMaskShapeShiftMultiChainHDWallet } from '@shapeshiftoss/hdwallet-shapeshift-multichain'
 import type { AccountMetadataById } from '@shapeshiftoss/types'
 import { useQuery } from '@tanstack/react-query'
-import { knownChainIds } from 'constants/chains'
 import { DEFAULT_HISTORY_TIMEFRAME } from 'constants/Config'
 import { LanguageTypeEnum } from 'constants/LanguageTypeEnum'
 import difference from 'lodash/difference'
@@ -92,11 +91,11 @@ export const AppProvider = ({ children }: { children: React.ReactNode }) => {
   const accountIdsByChainId = useAppSelector(selectAccountIdsByChainId)
   useEffect(() => {
     if (!wallet) return
-    const walletSupportedChainIds = knownChainIds.filter(chainId => {
+    const walletSupportedChainIds = supportedChains.filter(chainId => {
       return walletDeviceSupportsChain({ chainId, wallet, isSnapInstalled })
     })
     dispatch(portfolio.actions.setWalletSupportedChainIds(walletSupportedChainIds))
-  }, [accountIdsByChainId, dispatch, isSnapInstalled, wallet])
+  }, [accountIdsByChainId, dispatch, isSnapInstalled, wallet, supportedChains])
 
   // Initial account and portfolio fetch for non-ledger wallets
   useEffect(() => {

--- a/src/state/migrations/index.ts
+++ b/src/state/migrations/index.ts
@@ -71,4 +71,5 @@ export const migrations = {
   61: clearOpportunities,
   62: clearAssets,
   63: clearAssets,
+  64: clearPortfolio,
 }


### PR DESCRIPTION
## Description

Ensures the chainIds available in the app include the feature-flagged chainIds from 

## Pull Request Type

- [x] :bug: Bug fix (Non-breaking Change: Fixes an issue)
- [ ] :hammer_and_wrench: Chore (Non-breaking Change: Doc updates, pkg upgrades, typos, etc..)
- [ ] :nail_care: New Feature (Breaking/Non-breaking Change)

## Issue (if applicable)

<!-----------------------------------------------------------------------------
If applicable, please link to the github issue and put `closes #XXXX` in your comment to auto-close the issue that your PR fixes.
------------------------------------------------------------------------------>

closes #

Fixes https://discord.com/channels/554694662431178782/1247718768558477323/1247741645886062602

## Risk
> High Risk PRs Require 2 approvals

Moderate risk - getting this wrong would mean its possible to interact with chains that are not toggled on (e.g base chain), but this should actually improve things rather than break them.

> What protocols, transaction types or contract interactions might be affected by this PR?

## Testing

Test available chains in the app are as expected.

### Engineering

See `src/context/PluginProvider/PluginProvider.tsx` for origin of `const { supportedChains } = usePlugins()`:
![image](https://github.com/shapeshift/web/assets/125113430/1797f91b-b1b7-4af6-9053-2fe403865152)


### Operations

<!-----------------------------------------------------------------------------
If your changes have a user-facing impact, describe how a non-technical QA team can functionally test your changes in a preview environment.

If they are not user-facing please describe how to test for any regressions that may occur.
------------------------------------------------------------------------------>

## Screenshots (if applicable)
