### PR TITLE
feat: dont be too smart handling asset selection when wallet disconnects a chain

### DIFF
--- a/src/pages/Lending/Pool/components/Borrow/BorrowInput.tsx
+++ b/src/pages/Lending/Pool/components/Borrow/BorrowInput.tsx
@@ -50,7 +50,6 @@ import {
   selectFeeAssetById,
   selectPortfolioAccountMetadataByAccountId,
   selectPortfolioCryptoBalanceBaseUnitByFilter,
-  selectWalletConnectedChainIds,
 } from 'state/slices/selectors'
 import { store, useAppSelector } from 'state/store'
 
@@ -130,7 +129,6 @@ export const BorrowInput = ({
   const isThorchainLendingBorrowEnabled = useFeatureFlag('ThorchainLendingBorrow')
 
   const collateralAsset = useAppSelector(state => selectAssetById(state, collateralAssetId))
-  const walletConnectedChainIds = useAppSelector(selectWalletConnectedChainIds)
 
   useEffect(() => {
     if (!(collateralAsset && borrowAssets)) return
@@ -138,15 +136,6 @@ export const BorrowInput = ({
 
     if (!borrowAsset) setBorrowAsset(collateralAsset)
   }, [borrowAsset, borrowAssets, collateralAsset, setBorrowAsset])
-
-  // If the user disconnects the chain for the currently selected borrow asset, default to the collateral asset
-  useEffect(() => {
-    if (!collateralAsset || !borrowAsset) return
-
-    if (!walletConnectedChainIds.includes(borrowAsset.chainId)) {
-      setBorrowAsset(collateralAsset)
-    }
-  }, [collateralAsset, borrowAsset, setBorrowAsset, walletConnectedChainIds])
 
   const swapIcon = useMemo(() => <ArrowDownIcon />, [])
 

--- a/src/pages/Lending/Pool/components/Repay/RepayInput.tsx
+++ b/src/pages/Lending/Pool/components/Repay/RepayInput.tsx
@@ -57,7 +57,6 @@ import {
   selectFeeAssetById,
   selectPortfolioCryptoBalanceBaseUnitByFilter,
   selectTxById,
-  selectWalletConnectedChainIds,
 } from 'state/slices/selectors'
 import { serializeTxIndex } from 'state/slices/txHistorySlice/utils'
 import { store, useAppSelector } from 'state/store'
@@ -117,7 +116,6 @@ export const RepayInput = ({
     selectFeeAssetById(state, repaymentAsset?.assetId ?? ''),
   )
   const collateralFeeAsset = useAppSelector(state => selectFeeAssetById(state, collateralAssetId))
-  const walletConnectedChainIds = useAppSelector(selectWalletConnectedChainIds)
 
   const userAddress = useMemo(() => {
     if (!repaymentAccountId) return ''
@@ -333,15 +331,6 @@ export const RepayInput = ({
 
     setRepaymentAsset(collateralAsset)
   }, [collateralAsset, supportedRepaymentAssets, repaymentAsset, setRepaymentAsset])
-
-  // If the user disconnects the chain for the currently selected borrow asset, default to the collateral asset
-  useEffect(() => {
-    if (!collateralAsset || !repaymentAsset) return
-
-    if (!walletConnectedChainIds.includes(repaymentAsset.chainId)) {
-      setRepaymentAsset(collateralAsset)
-    }
-  }, [collateralAsset, repaymentAsset, setRepaymentAsset, walletConnectedChainIds])
 
   const buyAssetSearch = useModal('buyAssetSearch')
 


### PR DESCRIPTION
## Description

Reverts behavior introduced in #7029 of lending asset selection when a wallet chain is disconnected. Basically we were being "too helpful" to the point the behavior was somewhat confusing and not really of use to a user.

The behavior now is to do nothing in borrow/repay asset selection when the wallet disconnects the chain for the currently selected asset, and its now up to the user to select the correct one.

## Pull Request Type

- [ ] :bug: Bug fix (Non-breaking Change: Fixes an issue)
- [ ] :hammer_and_wrench: Chore (Non-breaking Change: Doc updates, pkg upgrades, typos, etc..)
- [ ] :nail_care: New Feature (Breaking/Non-breaking Change)

## Issue (if applicable)

<!-----------------------------------------------------------------------------
If applicable, please link to the github issue and put `closes #XXXX` in your comment to auto-close the issue that your PR fixes.
------------------------------------------------------------------------------>

Addresses feedback in
https://github.com/shapeshift/web/pull/7029/files#r1622050051
and
https://github.com/shapeshift/web/pull/7029/files#r1622042222

## Risk
> High Risk PRs Require 2 approvals

Low risk, this actually brings us back to behavior that was already in production and not flagged as broken.

> What protocols, transaction types or contract interactions might be affected by this PR?

## Testing

Test behavior of asset selection in borrow and repay UI flows - the selected asset should not change to a default of any kind when the wallet disconnects the chain for that asset - it should stay as-in until the user selects a different one manually.

### Engineering

<!-----------------------------------------------------------------------------
Include sufficient information here for an engineer to test your PR. This may include how to test locally, in a built environment, changes to infrastructure etc.
------------------------------------------------------------------------------>

### Operations

<!-----------------------------------------------------------------------------
If your changes have a user-facing impact, describe how a non-technical QA team can functionally test your changes in a preview environment.

If they are not user-facing please describe how to test for any regressions that may occur.
------------------------------------------------------------------------------>

## Screenshots (if applicable)


https://github.com/shapeshift/web/assets/125113430/e9276626-f0bd-4717-aea8-8679cefabe85


https://github.com/shapeshift/web/assets/125113430/c0fd7b36-971c-4014-8aaf-f54783a5eded

