### PR TITLE
fix: translation & claim alignment

### DIFF
--- a/src/pages/RFOX/components/Claim/ClaimSelect.tsx
+++ b/src/pages/RFOX/components/Claim/ClaimSelect.tsx
@@ -112,7 +112,7 @@ const ClaimRow: FC<ClaimRowProps> = ({
           </Box>
           <Box mr={4}>
             <RawText fontSize='sm' color='gray.400' align={'start'}>
-              {translate('RFOX.unstakeFrom', { assetSymbol: stakingAssetSymbol })}
+              {translate('RFOX.claim', { assetSymbol: stakingAssetSymbol })}
             </RawText>
             <RawText fontSize='xl' fontWeight='bold' color='white' align={'start'}>
               {stakingAssetSymbol}


### PR DESCRIPTION
## Description

- We are claiming, not unstaking on the claim list - updates text accordingly
- Conveniently fixes the alignment issue

`develop`:

<img width="314" alt="Screenshot 2024-06-07 at 4 30 44 PM" src="https://github.com/shapeshift/web/assets/97164662/2c8e600b-70ee-4844-97b6-f06996b952d0">


This PR:

<img width="318" alt="Screenshot 2024-06-07 at 4 31 37 PM" src="https://github.com/shapeshift/web/assets/97164662/f6e2ce10-2299-4c1a-9e91-20e66a57705a">


## Pull Request Type

- [x] :bug: Bug fix (Non-breaking Change: Fixes an issue)
- [ ] :hammer_and_wrench: Chore (Non-breaking Change: Doc updates, pkg upgrades, typos, etc..)
- [ ] :nail_care: New Feature (Breaking/Non-breaking Change)

## Issue (if applicable)

N/A - rFOX fix.

## Risk

Very small.

> What protocols, transaction types or contract interactions might be affected by this PR?

None.

## Testing

See screenshots above of expected state.

### Engineering

☝️

### Operations

☝️

## Screenshots (if applicable)

See above.