### PR TITLE
feat: add isLoaded to UserStakingOpportunityBase

### DIFF
--- a/src/features/defi/providers/thorchain-savers/components/ThorchainSaversManager/Overview/ThorchainSaversOverview.tsx
+++ b/src/features/defi/providers/thorchain-savers/components/ThorchainSaversManager/Overview/ThorchainSaversOverview.tsx
@@ -375,7 +375,7 @@ export const ThorchainSaversOverview: React.FC<OverviewProps> = ({
 
   const handleThorchainSaversEmptyClick = useCallback(() => setHideEmptyState(true), [])
 
-  if ((!earnOpportunityData && maybeAccountId) || isTradingActiveLoading) {
+  if ((!earnOpportunityData?.isLoaded && maybeAccountId) || isTradingActiveLoading) {
     return (
       <Center minW='500px' minH='350px'>
         <CircularProgress />

--- a/src/state/apis/zapper/zapperApi.ts
+++ b/src/state/apis/zapper/zapperApi.ts
@@ -671,6 +671,7 @@ export const zapper = createApi({
             // Prepare payload for upsertUserStakingOpportunities
             if (userStakingId) {
               userStakingUpsertPayload.byId[userStakingId] = {
+                isLoaded: true,
                 stakedAmountCryptoBaseUnit,
                 rewardsCryptoBaseUnit,
                 userStakingId,

--- a/src/state/slices/opportunitiesSlice/opportunitiesSlice.test.ts
+++ b/src/state/slices/opportunitiesSlice/opportunitiesSlice.test.ts
@@ -208,6 +208,7 @@ describe('opportunitiesSlice', () => {
         const payload = {
           byId: {
             [userStakingId]: {
+              isLoaded: true,
               userStakingId,
               stakedAmountCryptoBaseUnit: '42000',
               rewardsCryptoBaseUnit: {
@@ -229,6 +230,7 @@ describe('opportunitiesSlice', () => {
         const insertPayloadOne = {
           byId: {
             [userStakingIdOne]: {
+              isLoaded: true,
               userStakingId: userStakingIdOne,
               stakedAmountCryptoBaseUnit: '42000',
               rewardsCryptoBaseUnit: {
@@ -251,6 +253,7 @@ describe('opportunitiesSlice', () => {
         const insertPayloadTwo = {
           byId: {
             [userStakingIdTwo]: {
+              isLoaded: true,
               userStakingId: userStakingIdTwo,
               stakedAmountCryptoBaseUnit: '42000',
               rewardsCryptoBaseUnit: {

--- a/src/state/slices/opportunitiesSlice/resolvers/cosmosSdk/utils.ts
+++ b/src/state/slices/opportunitiesSlice/resolvers/cosmosSdk/utils.ts
@@ -104,6 +104,7 @@ export const makeAccountUserData = ({
       maybeValidatorUndelegations.length
     ) {
       acc[userStakingId] = {
+        isLoaded: true,
         userStakingId,
         stakedAmountCryptoBaseUnit: maybeValidatorDelegations.toFixed(),
         rewardsCryptoBaseUnit: {

--- a/src/state/slices/opportunitiesSlice/resolvers/ethFoxStaking/index.ts
+++ b/src/state/slices/opportunitiesSlice/resolvers/ethFoxStaking/index.ts
@@ -154,6 +154,7 @@ export const ethFoxStakingUserDataResolver = async ({
   const data = {
     byId: {
       [userStakingId]: {
+        isLoaded: true,
         userStakingId,
         stakedAmountCryptoBaseUnit,
         rewardsCryptoBaseUnit,

--- a/src/state/slices/opportunitiesSlice/resolvers/foxy/index.ts
+++ b/src/state/slices/opportunitiesSlice/resolvers/foxy/index.ts
@@ -154,6 +154,7 @@ export const foxyStakingOpportunitiesUserDataResolver = async ({
     ]
 
     stakingOpportunitiesUserDataByUserStakingId[userStakingId] = {
+      isLoaded: true,
       userStakingId,
       stakedAmountCryptoBaseUnit: balance,
       rewardsCryptoBaseUnit: { amounts: rewardsAmountsCryptoBaseUnit, claimable: true },

--- a/src/state/slices/opportunitiesSlice/resolvers/thorchainsavers/index.ts
+++ b/src/state/slices/opportunitiesSlice/resolvers/thorchainsavers/index.ts
@@ -201,6 +201,7 @@ export const thorchainSaversStakingOpportunitiesUserDataResolver = async ({
       // No position on that pool - either it was never staked in, or fully withdrawn
       if (!accountPosition) {
         stakingOpportunitiesUserDataByUserStakingId[userStakingId] = {
+          isLoaded: true,
           userStakingId,
           stakedAmountCryptoBaseUnit: '0',
           rewardsCryptoBaseUnit: { amounts: ['0'], claimable: false },
@@ -223,6 +224,7 @@ export const thorchainSaversStakingOpportunitiesUserDataResolver = async ({
       ]
 
       stakingOpportunitiesUserDataByUserStakingId[userStakingId] = {
+        isLoaded: true,
         userStakingId,
         stakedAmountCryptoBaseUnit: stakedAmountCryptoBaseUnit.toFixed(),
         rewardsCryptoBaseUnit: { amounts: rewardsAmountsCryptoBaseUnit, claimable: false },

--- a/src/state/slices/opportunitiesSlice/selectors/selectors.test.ts
+++ b/src/state/slices/opportunitiesSlice/selectors/selectors.test.ts
@@ -92,6 +92,7 @@ describe('opportunitiesSlice selectors', () => {
       ],
       byId: {
         [serializeUserStakingId(gomesAccountId, mockStakingContractTwo)]: {
+          isLoaded: true,
           userStakingId: serializeUserStakingId(gomesAccountId, mockStakingContractTwo),
           stakedAmountCryptoBaseUnit: '1337',
           rewardsCryptoBaseUnit: {
@@ -100,11 +101,13 @@ describe('opportunitiesSlice selectors', () => {
           },
         },
         [serializeUserStakingId(gomesAccountId, mockStakingContractOne)]: {
+          isLoaded: true,
           userStakingId: serializeUserStakingId(gomesAccountId, mockStakingContractOne),
           stakedAmountCryptoBaseUnit: '4',
           rewardsCryptoBaseUnit: { amounts: ['3000000000000000000'] as [string], claimable: true },
         },
         [serializeUserStakingId(fauxmesAccountId, mockStakingContractOne)]: {
+          isLoaded: true,
           userStakingId: serializeUserStakingId(fauxmesAccountId, mockStakingContractOne),
           stakedAmountCryptoBaseUnit: '9000',
           rewardsCryptoBaseUnit: { amounts: ['1000000000000000000'] as [string], claimable: true },
@@ -205,6 +208,7 @@ describe('opportunitiesSlice selectors', () => {
       ],
       byId: {
         [serializeUserStakingId(gomesAccountId, mockStakingContractTwo)]: {
+          isLoaded: true,
           userStakingId: serializeUserStakingId(gomesAccountId, mockStakingContractTwo),
           stakedAmountCryptoBaseUnit: '1337',
           rewardsCryptoBaseUnit: {
@@ -213,6 +217,7 @@ describe('opportunitiesSlice selectors', () => {
           },
         },
         [serializeUserStakingId(gomesAccountId, mockStakingContractOne)]: {
+          isLoaded: true,
           userStakingId: serializeUserStakingId(gomesAccountId, mockStakingContractOne),
           stakedAmountCryptoBaseUnit: '4',
           rewardsCryptoBaseUnit: { amounts: ['3000000000000000000'] as [string], claimable: true },
@@ -313,6 +318,7 @@ describe('opportunitiesSlice selectors', () => {
       ],
       byId: {
         [serializeUserStakingId(gomesAccountId, mockStakingContractTwo)]: {
+          isLoaded: true,
           userStakingId: serializeUserStakingId(gomesAccountId, mockStakingContractTwo),
           stakedAmountCryptoBaseUnit: '1337',
           rewardsCryptoBaseUnit: {
@@ -321,11 +327,13 @@ describe('opportunitiesSlice selectors', () => {
           },
         },
         [serializeUserStakingId(catpuccinoAccountId, mockStakingContractTwo)]: {
+          isLoaded: true,
           userStakingId: serializeUserStakingId(catpuccinoAccountId, mockStakingContractTwo),
           stakedAmountCryptoBaseUnit: '100',
           rewardsCryptoBaseUnit: { amounts: ['1000000000000000000'] as [string], claimable: true },
         },
         [serializeUserStakingId(gomesAccountId, mockStakingContractOne)]: {
+          isLoaded: true,
           userStakingId: serializeUserStakingId(gomesAccountId, mockStakingContractOne),
           stakedAmountCryptoBaseUnit: '4',
           rewardsCryptoBaseUnit: { amounts: ['3000000000000000000'] as [string], claimable: true },

--- a/src/state/slices/opportunitiesSlice/selectors/stakingSelectors.ts
+++ b/src/state/slices/opportunitiesSlice/selectors/stakingSelectors.ts
@@ -215,6 +215,7 @@ export const selectUserStakingOpportunityByUserStakingId = createDeepEqualOutput
           | [string],
         claimable: false,
       },
+      isLoaded: false,
       ...userOpportunity,
       ...opportunityMetadata,
       userStakingId,
@@ -592,7 +593,7 @@ export const selectEarnUserStakingOpportunityByUserStakingId = createDeepEqualOu
 
     const earnUserStakingOpportunity: StakingEarnOpportunityType = {
       ...userStakingOpportunity,
-      isLoaded: true,
+      isLoaded: userStakingOpportunity.isLoaded,
       chainId: fromAssetId(userStakingOpportunity.assetId).chainId,
       cryptoAmountBaseUnit: userStakingOpportunity.stakedAmountCryptoBaseUnit ?? '0',
       cryptoAmountPrecision: bnOrZero(userStakingOpportunity.stakedAmountCryptoBaseUnit)

--- a/src/state/slices/opportunitiesSlice/types.ts
+++ b/src/state/slices/opportunitiesSlice/types.ts
@@ -83,6 +83,7 @@ export type OpportunityMetadata = OpportunityMetadataBase | ThorchainSaversStaki
 
 // User-specific values for this opportunity
 export type UserStakingOpportunityBase = {
+  isLoaded: boolean
   userStakingId: UserStakingId
   // The amount of farmed LP tokens
   stakedAmountCryptoBaseUnit: string


### PR DESCRIPTION
## Description

... so we can discriminate *opportunity* loaded and *user data* loaded

## Pull Request Type

- [x] :bug: Bug fix (Non-breaking Change: Fixes an issue)
- [ ] :hammer_and_wrench: Chore (Non-breaking Change: Doc updates, pkg upgrades, typos, etc..)
- [ ] :nail_care: New Feature (Breaking/Non-breaking Change)

## Issue (if applicable)

<!-----------------------------------------------------------------------------
If applicable, please link to the github issue and put `closes #XXXX` in your comment to auto-close the issue that your PR fixes.
------------------------------------------------------------------------------>

closes https://github.com/shapeshift/web/issues/7090

## Risk
> High Risk PRs Require 2 approvals

<!-----------------------------------------------------------------------------
Outline the scope of your changes and the risk associated with them. You must use your discretion as an engineer to determine the potential impact of your changes.

WARNING: If your PR introduces a new on-chain transaction or modifies an existing one, please add the "High-Risk" label to this PR and ask for 2 reviewers to approve it before merging.

E.g. an upgrade to `hdwallet` or core state management would be considered higher risk, and might require a full regression test. UI or isolated view changes, or something behind a feature flag may have near zero risk. Small bug fixes might require testing isolated to the specific fix.
------------------------------------------------------------------------------>

Low, see tests

> What protocols, transaction types or contract interactions might be affected by this PR?

## Testing

<!-----------------------------------------------------------------------------
We treat every PR to be merged with the same scrutiny as if we were merging directly to production.

Your PR will not be merged if you do not complete the sections below for our engineering and operations teams to test.
------------------------------------------------------------------------------>

- DeFi opportunities still load as before
- Using the slow 3g testing criteria of https://github.com/shapeshift/web/issues/7090 (this can take many, many tries before getting it right since requests to `savers` may time out or take forever to be fired), ensure slow 3g doesn't result in empty state first, then proper overview state

### Engineering

<!-----------------------------------------------------------------------------
Include sufficient information here for an engineer to test your PR. This may include how to test locally, in a built environment, changes to infrastructure etc.
------------------------------------------------------------------------------>

- ☝🏽 
- Alternatively, block the request to said the specific saver request for your address e.g on Avalanche, and ensure you get an infinite spinner state (which is correct since things are technically not loaded)

### Operations

<!-----------------------------------------------------------------------------
If your changes have a user-facing impact, describe how a non-technical QA team can functionally test your changes in a preview environment.

If they are not user-facing please describe how to test for any regressions that may occur.
------------------------------------------------------------------------------>

- ☝🏽 

## Screenshots (if applicable)
