### PR TITLE
chore: swap date-fns with datejs

### DIFF
--- a/src/components/MultiHopTrade/components/MultiHopTradeConfirm/components/TimeRemaining.tsx
+++ b/src/components/MultiHopTrade/components/MultiHopTradeConfirm/components/TimeRemaining.tsx
@@ -1,4 +1,4 @@
-import { format as formatTime } from 'date-fns'
+import dayjs from 'dayjs'
 import { RawText } from 'components/Text'
 
 import { useCountdown } from '../hooks/useCountdown'
@@ -7,6 +7,6 @@ export const TimeRemaining = ({ initialTimeMs }: { initialTimeMs: number }) => {
   const { timeRemainingMs } = useCountdown(initialTimeMs, true)
 
   return timeRemainingMs > 0 ? (
-    <RawText fontWeight='bold'>{formatTime(timeRemainingMs, 'mm:ss')}</RawText>
+    <RawText fontWeight='bold'>{dayjs.duration(timeRemainingMs).format('mm:ss')}</RawText>
   ) : null
 }

--- a/src/pages/RFOX/components/Claim/ClaimSelect.tsx
+++ b/src/pages/RFOX/components/Claim/ClaimSelect.tsx
@@ -7,7 +7,7 @@ import {
 } from '@shapeshiftoss/caip'
 import { foxStakingV1Abi } from 'contracts/abis/FoxStakingV1'
 import { RFOX_PROXY_CONTRACT_ADDRESS } from 'contracts/constants'
-import { formatDistanceToNow } from 'date-fns'
+import dayjs from 'dayjs'
 import { type FC, useCallback, useEffect, useMemo } from 'react'
 import { useTranslate } from 'react-polyglot'
 import type { Address } from 'viem'
@@ -173,9 +173,7 @@ export const ClaimSelect: FC<ClaimSelectProps & ClaimRouteProps> = ({
             const unstakingTimestampMs: number = Number(unstakingRequest.cooldownExpiry) * 1000
             const isAvailable = currentTimestampMs >= unstakingTimestampMs
             const cooldownDeltaMs = unstakingTimestampMs - currentTimestampMs
-            const cooldownPeriodHuman = formatDistanceToNow(Date.now() + cooldownDeltaMs, {
-              addSuffix: true,
-            })
+            const cooldownPeriodHuman = dayjs(Date.now() + cooldownDeltaMs).fromNow()
             const status = isAvailable ? ClaimStatus.Available : ClaimStatus.CoolingDown
             return (
               <ClaimRow


### PR DESCRIPTION
## Description

Raised by @firebomb1 at https://discord.com/channels/554694662431178782/1249691190987722764

Using `dayjs` allows us to use existing translations, so this PR refactors the claim usage to use it.

Also removes all explicit uses of the transient `date-fns` package.

<img width="473" alt="Screenshot 2024-06-11 at 1 16 03 PM" src="https://github.com/shapeshift/web/assets/97164662/8d66b971-5562-4443-9a8f-5089c7e91037">

## Pull Request Type

- [ ] :bug: Bug fix (Non-breaking Change: Fixes an issue)
- [x] :hammer_and_wrench: Chore (Non-breaking Change: Doc updates, pkg upgrades, typos, etc..)
- [ ] :nail_care: New Feature (Breaking/Non-breaking Change)

## Issue (if applicable)

https://discord.com/channels/554694662431178782/1249691190987722764

## Risk

Small

> What protocols, transaction types or contract interactions might be affected by this PR?

None.

## Testing

- When hovering over a claim in the claim view the relative time should still show
- The "time remaining" UI of a trade should continue to work as expected

### Engineering

☝️

### Operations

☝️

## Screenshots (if applicable)

<img width="319" alt="Screenshot 2024-06-11 at 10 29 59 AM" src="https://github.com/shapeshift/web/assets/97164662/442cc264-8a94-4ce2-85eb-7d7b7f90088c">
