### PR TITLE
feat: improve send modal flow

### DIFF
--- a/src/assets/translations/en/main.json
+++ b/src/assets/translations/en/main.json
@@ -1044,7 +1044,7 @@
         "tooltip": "Send funds to a single address for THORChain compatibility.",
         "consolidateFunds": "Consolidate"
       },
-      "getBalanceError": "Error getting wallet balances",
+      "getfeesError": "Error getting fees",
       "broadcastingTransaction": "Broadcasting Transaction",
       "youHaveSent": "You have successfully sent %{amount} %{symbol}",
       "tokenAddress": "To Address",

--- a/src/assets/translations/en/main.json
+++ b/src/assets/translations/en/main.json
@@ -1044,7 +1044,7 @@
         "tooltip": "Send funds to a single address for THORChain compatibility.",
         "consolidateFunds": "Consolidate"
       },
-      "getfeesError": "Error getting fees",
+      "getFeesError": "Error getting fees",
       "broadcastingTransaction": "Broadcasting Transaction",
       "youHaveSent": "You have successfully sent %{amount} %{symbol}",
       "tokenAddress": "To Address",

--- a/src/components/Modals/Send/hooks/useSendDetails/useSendDetails.tsx
+++ b/src/components/Modals/Send/hooks/useSendDetails/useSendDetails.tsx
@@ -153,7 +153,7 @@ export const useSendDetails = (): UseSendDetailsReturnType => {
       if (bnOrZero(amountCryptoPrecision).lt(0)) return null
       if (!asset || !accountId) return null
 
-      const hasValidBalance = bnOrZero(cryptoHumanBalance).gte(amountCryptoPrecision)
+      const hasValidBalance = bnOrZero(cryptoHumanBalance).gte(bnOrZero(amountCryptoPrecision))
 
       // No point to estimate fees if it is guaranteed to fail due to insufficient balance
       if (!hasValidBalance) {
@@ -312,6 +312,12 @@ export const useSendDetails = (): UseSendDetailsReturnType => {
     // Since we are debouncing the query, ensure reverting back to an empty input doesn't end up in the previous error being displayed
     if (!hasEnteredPositiveAmount) return setValue(SendFormFields.AmountFieldError, '')
 
+    // openapi-generator error-handling https://github.com/OpenAPITools/openapi-generator/blob/8357cc313be5a099f994c4ffaf56146f40dba911/samples/client/petstore/typescript-fetch/builds/enum/runtime.ts#L221
+    if (
+      error?.message ===
+      'The request failed and the interceptors did not return an alternative response'
+    )
+      return setValue(SendFormFields.AmountFieldError, 'modals.send.getfeesError')
     setValue(SendFormFields.AmountFieldError, error?.message ? error.message : '')
   }, [error, hasEnteredPositiveAmount, setValue])
 

--- a/src/components/Modals/Send/hooks/useSendDetails/useSendDetails.tsx
+++ b/src/components/Modals/Send/hooks/useSendDetails/useSendDetails.tsx
@@ -317,7 +317,7 @@ export const useSendDetails = (): UseSendDetailsReturnType => {
       error?.message ===
       'The request failed and the interceptors did not return an alternative response'
     )
-      return setValue(SendFormFields.AmountFieldError, 'modals.send.getfeesError')
+      return setValue(SendFormFields.AmountFieldError, 'modals.send.getFeesError')
     setValue(SendFormFields.AmountFieldError, error?.message ? error.message : '')
   }, [error, hasEnteredPositiveAmount, setValue])
 


### PR DESCRIPTION
## Description

This improves two bits in the send flow:

1. Initial flash of "Insufficient funds" error state on max send, caused by `amountCryptoPrecision` not being casted as 0 by bignumber.js in:

https://github.com/shapeshift/web/blob/1eb71c3c109d2c7febfe0a2ef2746f7769ba1b60/src/components/Modals/Send/hooks/useSendDetails/useSendDetails.tsx#L156

2. Failed XHR errors being wrongly surfaced to the user

## Pull Request Type

- [ ] :bug: Bug fix (Non-breaking Change: Fixes an issue)
- [ ] :hammer_and_wrench: Chore (Non-breaking Change: Doc updates, pkg upgrades, typos, etc..)
- [x] :nail_care: New Feature (Breaking/Non-breaking Change)

## Issue (if applicable)

<!-----------------------------------------------------------------------------
If applicable, please link to the github issue and put `closes #XXXX` in your comment to auto-close the issue that your PR fixes.
------------------------------------------------------------------------------>

closes https://github.com/shapeshift/web/issues/7084

## Risk
> High Risk PRs Require 2 approvals

<!-----------------------------------------------------------------------------
Outline the scope of your changes and the risk associated with them. You must use your discretion as an engineer to determine the potential impact of your changes.

WARNING: If your PR introduces a new on-chain transaction or modifies an existing one, please add the "High-Risk" label to this PR and ask for 2 reviewers to approve it before merging.

E.g. an upgrade to `hdwallet` or core state management would be considered higher risk, and might require a full regression test. UI or isolated view changes, or something behind a feature flag may have near zero risk. Small bug fixes might require testing isolated to the specific fix.
------------------------------------------------------------------------------>

> What protocols, transaction types or contract interactions might be affected by this PR?

Low

## Testing

<!-----------------------------------------------------------------------------
We treat every PR to be merged with the same scrutiny as if we were merging directly to production.

Your PR will not be merged if you do not complete the sections below for our engineering and operations teams to test.
------------------------------------------------------------------------------>

### Network failure message surfaced to the user


1. Let BTC `fees` request fail for a max send (it's currently failing often enough to test this)
2. Ensure the network fetch error isn't surfaced to the user but "Error getting fees" is instead

### Flash of Insufficient Fundus

1. Click max send on BTC
2. Ensure there is no flash of 'Insufficient funds'


### Engineering

<!-----------------------------------------------------------------------------
Include sufficient information here for an engineer to test your PR. This may include how to test locally, in a built environment, changes to infrastructure etc.
------------------------------------------------------------------------------>

- ^

### Operations

<!-----------------------------------------------------------------------------
If your changes have a user-facing impact, describe how a non-technical QA team can functionally test your changes in a preview environment.

If they are not user-facing please describe how to test for any regressions that may occur.
------------------------------------------------------------------------------>

- ^

## Screenshots (if applicable)

### Error getting fees

<img width="476" alt="image" src="https://github.com/shapeshift/web/assets/17035424/a58dd7f4-d46d-436b-98fa-8a05ed65c4d4">

### No flash of "Insufficient Funds" on max sends

https://jam.dev/c/3470841b-a42d-4ed3-a753-2747767e4399

<!-- av pr metadata
This information is embedded by the av CLI when creating PRs to track the status of stacks when using Aviator. Please do not delete or edit this section of the PR.
```
{"parent":"develop","parentHead":"","trunk":"develop"}
```
-->
