### PR TITLE
fix: transaction row overflowing in rfox bridge status modal

### DIFF
--- a/src/pages/RFOX/components/Shared/SharedMultiStepStatus.tsx
+++ b/src/pages/RFOX/components/Shared/SharedMultiStepStatus.tsx
@@ -143,7 +143,7 @@ export const SharedMultiStepStatus: React.FC<SharedMultiStepStatusProps> = ({
 
     return (
       <CardBody textAlign='center'>
-        <Center my={8}>
+        <Center mb={8}>
           <CircularProgress
             size='100px'
             thickness={4}
@@ -222,11 +222,11 @@ export const SharedMultiStepStatus: React.FC<SharedMultiStepStatusProps> = ({
       {renderBody}
       <CardFooter flexDir='column' px={4}>
         {assetCards}
-        {/* {isComplete && ( */}
-        <Button mt={4} onClick={handleContinue}>
-          {translate('common.continue')}
-        </Button>
-        {/* )} */}
+        {isComplete && (
+          <Button mt={4} onClick={handleContinue}>
+            {translate('common.continue')}
+          </Button>
+        )}
       </CardFooter>
     </SlideTransition>
   )

--- a/src/pages/RFOX/components/Shared/SharedMultiStepStatus.tsx
+++ b/src/pages/RFOX/components/Shared/SharedMultiStepStatus.tsx
@@ -222,7 +222,11 @@ export const SharedMultiStepStatus: React.FC<SharedMultiStepStatusProps> = ({
       {renderBody}
       <CardFooter flexDir='column' px={4}>
         {assetCards}
-        {isComplete && <Button onClick={handleContinue}>{translate('common.continue')}</Button>}
+        {/* {isComplete && ( */}
+        <Button mt={4} onClick={handleContinue}>
+          {translate('common.continue')}
+        </Button>
+        {/* )} */}
       </CardFooter>
     </SlideTransition>
   )

--- a/src/pages/RFOX/components/Shared/TransactionRow.tsx
+++ b/src/pages/RFOX/components/Shared/TransactionRow.tsx
@@ -123,11 +123,11 @@ export const TransactionRow: React.FC<TransactionRowProps> = ({
         <AssetIcon size='xs' assetId={asset.assetId} />
         <Text>{headerCopy}</Text>
         <Flex ml='auto' alignItems='center' gap={2}>
-          {/* {txIdLink && ( */}
-          <Button as={Link} isExternal href={txIdLink} size='xs'>
-            {translate('common.seeDetails')}
-          </Button>
-          {/* )} */}
+          {txIdLink && (
+            <Button as={Link} isExternal href={txIdLink} size='xs'>
+              {translate('common.seeDetails')}
+            </Button>
+          )}
           {txStatusIndicator}
         </Flex>
       </CardHeader>

--- a/src/pages/RFOX/components/Shared/TransactionRow.tsx
+++ b/src/pages/RFOX/components/Shared/TransactionRow.tsx
@@ -119,15 +119,15 @@ export const TransactionRow: React.FC<TransactionRowProps> = ({
 
   return (
     <Card>
-      <CardHeader gap={2} display='flex' flexDir='row' alignItems='center'>
+      <CardHeader gap={2} display='flex' flexDir='row' alignItems='center' flexWrap='wrap'>
         <AssetIcon size='xs' assetId={asset.assetId} />
         <Text>{headerCopy}</Text>
         <Flex ml='auto' alignItems='center' gap={2}>
-          {txIdLink && (
-            <Button as={Link} isExternal href={txIdLink} size='xs'>
-              {translate('common.seeDetails')}
-            </Button>
-          )}
+          {/* {txIdLink && ( */}
+          <Button as={Link} isExternal href={txIdLink} size='xs'>
+            {translate('common.seeDetails')}
+          </Button>
+          {/* )} */}
           {txStatusIndicator}
         </Flex>
       </CardHeader>


### PR DESCRIPTION
## Description
- The circle progress on the top margin top spacing was a big too big
- Made the elements wrapping under if there are not enough space on the tx statuses rows of the bridge modal
- Added some spacing on the continue button

<!-- Please describe your changes -->

## Pull Request Type

- [x] :bug: Bug fix (Non-breaking Change: Fixes an issue)
- [ ] :hammer_and_wrench: Chore (Non-breaking Change: Doc updates, pkg upgrades, typos, etc..)
- [ ] :nail_care: New Feature (Breaking/Non-breaking Change)

## Issue (if applicable)

<!-----------------------------------------------------------------------------
If applicable, please link to the github issue and put `closes #XXXX` in your comment to auto-close the issue that your PR fixes.
------------------------------------------------------------------------------>

n/a

## Risk
Low risk

## Testing

- Try to bridge using the rfox bridge
- Or monkey patch like I did in [bee0db4f231c49c1a70a1ff54711ba6ae223eed6](https://github.com/shapeshift/web/commit/bee0db4f231c49c1a70a1ff54711ba6ae223eed6)

<!-----------------------------------------------------------------------------
We treat every PR to be merged with the same scrutiny as if we were merging directly to production.

Your PR will not be merged if you do not complete the sections below for our engineering and operations teams to test.
------------------------------------------------------------------------------>

### Engineering
n/a
<!-----------------------------------------------------------------------------
Include sufficient information here for an engineer to test your PR. This may include how to test locally, in a built environment, changes to infrastructure etc.
------------------------------------------------------------------------------>

### Operations
n/a
<!-----------------------------------------------------------------------------
If your changes have a user-facing impact, describe how a non-technical QA team can functionally test your changes in a preview environment.

If they are not user-facing please describe how to test for any regressions that may occur.
------------------------------------------------------------------------------>

## Screenshots (if applicable)
### Before
![image](https://github.com/shapeshift/web/assets/14963751/a508490b-02d1-4f94-9588-ffd2ebe7e38f)

### After
![image](https://github.com/shapeshift/web/assets/14963751/b861cd3d-b089-4141-9be7-d338aeee265b)

