### PR TITLE
fix: deposit rugged validation on percent option click

### DIFF
--- a/package.json
+++ b/package.json
@@ -180,7 +180,7 @@
     "react-dom": "^18.2.0",
     "react-error-boundary": "^3.1.4",
     "react-helmet-async": "^1.3.0",
-    "react-hook-form": "^7.33.1",
+    "react-hook-form": "^7.51.5",
     "react-icons": "^4.10.1",
     "react-infinite-scroll-component": "^6.1.0",
     "react-multi-ref": "^1.0.1",

--- a/src/components/DeFi/components/AssetInput.tsx
+++ b/src/components/DeFi/components/AssetInput.tsx
@@ -113,28 +113,41 @@ export const AssetInput: React.FC<AssetInputProps> = ({
   const asset = useAppSelector(state => selectAssetById(state, assetId))
 
   // Lower the decimal places when the integer is greater than 8 significant digits for better UI
-  const cryptoAmountIntegerCount = bnOrZero(bnOrZero(cryptoAmount).toFixed(0)).precision(true)
-  const formattedCryptoAmount = bnOrZero(cryptoAmountIntegerCount).isLessThanOrEqualTo(8)
-    ? cryptoAmount
-    : bnOrZero(cryptoAmount).toFixed(3)
+  const cryptoAmountIntegerCount = useMemo(
+    () => bnOrZero(bnOrZero(cryptoAmount).toFixed(0)).precision(true),
+    [cryptoAmount],
+  )
+  const formattedCryptoAmount = useMemo(
+    () =>
+      bnOrZero(cryptoAmountIntegerCount).isLessThanOrEqualTo(8)
+        ? cryptoAmount
+        : bnOrZero(cryptoAmount).toFixed(3),
+    [cryptoAmount, cryptoAmountIntegerCount],
+  )
 
   const formControlHover = useMemo(
     () => ({ bg: isReadOnly ? 'background.input.base' : 'background.input.hover' }),
     [isReadOnly],
   )
 
-  const handleValueChange = useCallback((values: NumberFormatValues) => {
-    // This fires anytime value changes including setting it on max click
-    // Store the value in a ref to send when we actually want the onChange to fire
-    amountRef.current = values.value
-  }, [])
-
   const handleChange = useCallback(() => {
     // onChange will send us the formatted value
     // To get around this we need to get the value from the onChange using a ref
     // Now when the max buttons are clicked the onChange will not fire
+    debugger
     onChange(amountRef.current ?? '', isFiat)
   }, [isFiat, onChange])
+
+  const handleValueChange = useCallback(
+    (values: NumberFormatValues) => {
+      // This fires anytime value changes including setting it on max click
+      // Store the value in a ref to send when we actually want the onChange to fire
+      debugger
+      amountRef.current = values.value
+      handleChange()
+    },
+    [handleChange],
+  )
 
   return (
     <FormControl

--- a/src/components/DeFi/components/AssetInput.tsx
+++ b/src/components/DeFi/components/AssetInput.tsx
@@ -134,7 +134,6 @@ export const AssetInput: React.FC<AssetInputProps> = ({
     // onChange will send us the formatted value
     // To get around this we need to get the value from the onChange using a ref
     // Now when the max buttons are clicked the onChange will not fire
-    debugger
     onChange(amountRef.current ?? '', isFiat)
   }, [isFiat, onChange])
 
@@ -142,7 +141,6 @@ export const AssetInput: React.FC<AssetInputProps> = ({
     (values: NumberFormatValues) => {
       // This fires anytime value changes including setting it on max click
       // Store the value in a ref to send when we actually want the onChange to fire
-      debugger
       amountRef.current = values.value
       handleChange()
     },

--- a/src/features/defi/components/Deposit/Deposit.tsx
+++ b/src/features/defi/components/Deposit/Deposit.tsx
@@ -121,8 +121,6 @@ export const Deposit = ({
   const fiatError = get(errors, 'fiatAmount.message', null)
   const fieldError = cryptoError || fiatError
 
-  console.log({ errors })
-
   const handleInputChange = useCallback(
     (value: string, isFiat?: boolean) => {
       if (isFiat) {

--- a/src/features/defi/components/Deposit/Deposit.tsx
+++ b/src/features/defi/components/Deposit/Deposit.tsx
@@ -107,12 +107,12 @@ export const Deposit = ({
   const handleMaxClick = useCallback(() => onMaxClick!(setValue), [onMaxClick, setValue])
 
   const values = useWatch({ control })
-  const { field: cryptoAmount } = useController({
+  const { field: cryptoAmount } = useController<DepositValues>({
     name: 'cryptoAmount',
     control,
     rules: cryptoInputValidation,
   })
-  const { field: fiatAmount } = useController({
+  const { field: fiatAmount } = useController<DepositValues>({
     name: 'fiatAmount',
     control,
     rules: fiatInputValidation,
@@ -120,6 +120,8 @@ export const Deposit = ({
   const cryptoError = get(errors, 'cryptoAmount.message', null)
   const fiatError = get(errors, 'fiatAmount.message', null)
   const fieldError = cryptoError || fiatError
+
+  console.log({ errors })
 
   const handleInputChange = useCallback(
     (value: string, isFiat?: boolean) => {

--- a/src/features/defi/components/Deposit/PairDeposit.tsx
+++ b/src/features/defi/components/Deposit/PairDeposit.tsx
@@ -111,22 +111,22 @@ export const PairDeposit = ({
   })
 
   const values = useWatch({ control })
-  const { field: cryptoAmount0 } = useController({
+  const { field: cryptoAmount0 } = useController<DepositValues>({
     name: 'cryptoAmount0',
     control,
     rules: cryptoInputValidation0,
   })
-  const { field: cryptoAmount1 } = useController({
+  const { field: cryptoAmount1 } = useController<DepositValues>({
     name: 'cryptoAmount1',
     control,
     rules: cryptoInputValidation1,
   })
-  const { field: fiatAmount0 } = useController({
+  const { field: fiatAmount0 } = useController<DepositValues>({
     name: 'fiatAmount0',
     control,
     rules: fiatInputValidation0,
   })
-  const { field: fiatAmount1 } = useController({
+  const { field: fiatAmount1 } = useController<DepositValues>({
     name: 'fiatAmount1',
     control,
     rules: fiatInputValidation1,

--- a/src/features/defi/providers/thorchain-savers/components/ThorchainSaversManager/Deposit/components/Deposit.tsx
+++ b/src/features/defi/providers/thorchain-savers/components/ThorchainSaversManager/Deposit/components/Deposit.tsx
@@ -488,14 +488,9 @@ export const Deposit: React.FC<DepositProps> = ({
       if (!contextDispatch) return
 
       contextDispatch({ type: ThorchainSaversDepositActionType.SET_LOADING, payload: true })
-      return _validateCryptoAmount(value)
-        .then(x => {
-          debugger
-          return x
-        })
-        .finally(() => {
-          contextDispatch({ type: ThorchainSaversDepositActionType.SET_LOADING, payload: false })
-        })
+      return _validateCryptoAmount(value).finally(() => {
+        contextDispatch({ type: ThorchainSaversDepositActionType.SET_LOADING, payload: false })
+      })
     },
     [_validateCryptoAmount, contextDispatch],
   )

--- a/src/features/defi/providers/thorchain-savers/components/ThorchainSaversManager/Deposit/components/Deposit.tsx
+++ b/src/features/defi/providers/thorchain-savers/components/ThorchainSaversManager/Deposit/components/Deposit.tsx
@@ -417,7 +417,7 @@ export const Deposit: React.FC<DepositProps> = ({
   }, [outboundFeeCryptoBaseUnit, assetPriceInFeeAsset, asset, feeAsset])
 
   const _validateCryptoAmount = useCallback(
-    async (value: string) => {
+    async (value: string): Promise<string | boolean | undefined> => {
       if (!accountId) return
       if (state?.loading) return
 
@@ -488,9 +488,14 @@ export const Deposit: React.FC<DepositProps> = ({
       if (!contextDispatch) return
 
       contextDispatch({ type: ThorchainSaversDepositActionType.SET_LOADING, payload: true })
-      return _validateCryptoAmount(value).finally(() => {
-        contextDispatch({ type: ThorchainSaversDepositActionType.SET_LOADING, payload: false })
-      })
+      return _validateCryptoAmount(value)
+        .then(x => {
+          debugger
+          return x
+        })
+        .finally(() => {
+          contextDispatch({ type: ThorchainSaversDepositActionType.SET_LOADING, payload: false })
+        })
     },
     [_validateCryptoAmount, contextDispatch],
   )
@@ -501,7 +506,7 @@ export const Deposit: React.FC<DepositProps> = ({
   )
 
   const _validateFiatAmount = useCallback(
-    async (value: string) => {
+    async (value: string): Promise<string | boolean | undefined> => {
       if (!accountId) return
       if (state?.loading) return
       const valueCryptoPrecision = bnOrZero(value).div(assetMarketData.price)

--- a/src/features/defi/providers/thorchain-savers/components/ThorchainSaversManager/Deposit/components/Deposit.tsx
+++ b/src/features/defi/providers/thorchain-savers/components/ThorchainSaversManager/Deposit/components/Deposit.tsx
@@ -417,7 +417,7 @@ export const Deposit: React.FC<DepositProps> = ({
   }, [outboundFeeCryptoBaseUnit, assetPriceInFeeAsset, asset, feeAsset])
 
   const _validateCryptoAmount = useCallback(
-    async (value: string): Promise<string | boolean | undefined> => {
+    async (value: string) => {
       if (!accountId) return
       if (state?.loading) return
 
@@ -501,7 +501,7 @@ export const Deposit: React.FC<DepositProps> = ({
   )
 
   const _validateFiatAmount = useCallback(
-    async (value: string): Promise<string | boolean | undefined> => {
+    async (value: string) => {
       if (!accountId) return
       if (state?.loading) return
       const valueCryptoPrecision = bnOrZero(value).div(assetMarketData.price)

--- a/yarn.lock
+++ b/yarn.lock
@@ -11344,7 +11344,7 @@ __metadata:
     react-dom: ^18.2.0
     react-error-boundary: ^3.1.4
     react-helmet-async: ^1.3.0
-    react-hook-form: ^7.33.1
+    react-hook-form: ^7.51.5
     react-icons: ^4.10.1
     react-infinite-scroll-component: ^6.1.0
     react-multi-ref: ^1.0.1
@@ -32412,12 +32412,12 @@ pvutils@latest:
   languageName: node
   linkType: hard
 
-"react-hook-form@npm:^7.33.1":
-  version: 7.33.1
-  resolution: "react-hook-form@npm:7.33.1"
+"react-hook-form@npm:^7.51.5":
+  version: 7.51.5
+  resolution: "react-hook-form@npm:7.51.5"
   peerDependencies:
     react: ^16.8.0 || ^17 || ^18
-  checksum: ec8f938b5af32148956edc9a87b6a0a99cc305617925608961cf4352ad1a786daea9fdc4d15106aea2821937d27367a69ab525882f07c0bb7ea45fba5dbf8ff2
+  checksum: 6b6a56b6520ddb68d491e2f07791538aa611c13fcd76052a499ba10bdaf7f77f4a5f7191e6ca9d9ab0af739bf07171c6e8d97f6c4da06f576aa74caed71828f1
   languageName: node
   linkType: hard
 


### PR DESCRIPTION
## Description

Fixes validation being triggered, but not surfaced on percent option click for deposits (spotted with THORChain savers deposits)

## Pull Request Type

- [x] :bug: Bug fix (Non-breaking Change: Fixes an issue)
- [ ] :hammer_and_wrench: Chore (Non-breaking Change: Doc updates, pkg upgrades, typos, etc..)
- [ ] :nail_care: New Feature (Breaking/Non-breaking Change)

## Issue (if applicable)

<!-----------------------------------------------------------------------------
If applicable, please link to the github issue and put `closes #XXXX` in your comment to auto-close the issue that your PR fixes.
------------------------------------------------------------------------------>

closes https://github.com/shapeshift/web/issues/7105

## Risk
> High Risk PRs Require 2 approvals

<!-----------------------------------------------------------------------------
Outline the scope of your changes and the risk associated with them. You must use your discretion as an engineer to determine the potential impact of your changes.

WARNING: If your PR introduces a new on-chain transaction or modifies an existing one, please add the "High-Risk" label to this PR and ask for 2 reviewers to approve it before merging.

E.g. an upgrade to `hdwallet` or core state management would be considered higher risk, and might require a full regression test. UI or isolated view changes, or something behind a feature flag may have near zero risk. Small bug fixes might require testing isolated to the specific fix.
------------------------------------------------------------------------------>

Low - ensure validation still works on input, and now properly works on percent option change for THORChain savers deposits.

> What protocols, transaction types or contract interactions might be affected by this PR?

## Testing

<!-----------------------------------------------------------------------------
We treat every PR to be merged with the same scrutiny as if we were merging directly to production.

Your PR will not be merged if you do not complete the sections below for our engineering and operations teams to test.
------------------------------------------------------------------------------>

- THORChain savers deposits validation is now happy on percent option click
- THORChain savers deposits validation is still happy on input

### Engineering

<!-----------------------------------------------------------------------------
Include sufficient information here for an engineer to test your PR. This may include how to test locally, in a built environment, changes to infrastructure etc.
------------------------------------------------------------------------------>

- ^

### Operations

<!-----------------------------------------------------------------------------
If your changes have a user-facing impact, describe how a non-technical QA team can functionally test your changes in a preview environment.

If they are not user-facing please describe how to test for any regressions that may occur.
------------------------------------------------------------------------------>

- ^

## Screenshots (if applicable)

https://jam.dev/c/234119a4-be46-4ed6-9f7f-6a1ba96c0ade

<!-- av pr metadata
This information is embedded by the av CLI when creating PRs to track the status of stacks when using Aviator. Please do not delete or edit this section of the PR.
```
{"parent":"develop","parentHead":"","trunk":"develop"}
```
-->


<!-- av pr metadata
This information is embedded by the av CLI when creating PRs to track the status of stacks when using Aviator. Please do not delete or edit this section of the PR.
```
{"parent":"develop","parentHead":"","trunk":"develop"}
```
-->
