### PR TITLE
feat: dont clear trade input when previewing and going back

### DIFF
--- a/src/components/MultiHopTrade/components/MultiHopTradeConfirm/MultiHopTradeConfirm.tsx
+++ b/src/components/MultiHopTrade/components/MultiHopTradeConfirm/MultiHopTradeConfirm.tsx
@@ -46,10 +46,18 @@ export const MultiHopTradeConfirm = memo(() => {
     dispatch(tradeQuoteSlice.actions.setTradeInitialized())
   }, [dispatch, isLoading])
 
+  const isTradeComplete = useMemo(
+    () => tradeExecutionState === TradeExecutionState.TradeComplete,
+    [tradeExecutionState],
+  )
+
   const handleBack = useCallback(() => {
-    dispatch(tradeQuoteSlice.actions.clear())
+    if (isTradeComplete) {
+      dispatch(tradeQuoteSlice.actions.clear())
+    }
+
     history.push(TradeRoutePaths.Input)
-  }, [dispatch, history])
+  }, [dispatch, history, isTradeComplete])
 
   const { isOpen: isFirstHopOpen, onToggle: onToggleFirstHop } = useDisclosure(useDisclosureProps)
   const { isOpen: isSecondHopOpen, onToggle: onToggleSecondHop } = useDisclosure(useDisclosureProps)
@@ -71,11 +79,6 @@ export const MultiHopTradeConfirm = memo(() => {
     previousTradeExecutionState,
     tradeExecutionState,
   ])
-
-  const isTradeComplete = useMemo(
-    () => tradeExecutionState === TradeExecutionState.TradeComplete,
-    [tradeExecutionState],
-  )
 
   const handleTradeConfirm = useCallback(() => {
     dispatch(tradeQuoteSlice.actions.confirmTrade())

--- a/src/components/MultiHopTrade/components/MultiHopTradeConfirm/MultiHopTradeConfirm.tsx
+++ b/src/components/MultiHopTrade/components/MultiHopTradeConfirm/MultiHopTradeConfirm.tsx
@@ -17,7 +17,7 @@ import { tradeQuoteSlice } from 'state/slices/tradeQuoteSlice/tradeQuoteSlice'
 import { TradeExecutionState } from 'state/slices/tradeQuoteSlice/types'
 import { useAppDispatch, useAppSelector } from 'state/store'
 
-import { TradeSuccessTemp } from '../TradeSuccess/TradeSuccessTemp'
+import { TradeSuccess } from '../TradeSuccess/TradeSuccess'
 import { Footer } from './components/Footer'
 import { Hops } from './components/Hops'
 import { useIsApprovalInitiallyNeeded } from './hooks/useIsApprovalInitiallyNeeded'
@@ -122,9 +122,9 @@ export const MultiHopTradeConfirm = memo(() => {
             </WithBackButton>
           </CardHeader>
           {isTradeComplete ? (
-            <TradeSuccessTemp handleBack={handleBack}>
+            <TradeSuccess handleBack={handleBack}>
               <Hops isFirstHopOpen isSecondHopOpen />
-            </TradeSuccessTemp>
+            </TradeSuccess>
           ) : (
             <>
               <CardBody py={0} px={0}>

--- a/src/components/MultiHopTrade/components/TradeInput/components/SellAssetInput.tsx
+++ b/src/components/MultiHopTrade/components/TradeInput/components/SellAssetInput.tsx
@@ -37,8 +37,10 @@ export const SellAssetInput = memo(
   }: SellAssetInputProps) => {
     const sellAmountCryptoPrecision = useAppSelector(selectInputSellAmountCryptoPrecision)
     const sellAmountUserCurrency = useAppSelector(selectInputSellAmountUserCurrency)
-    const [rawSellAmountCryptoPrecision, setRawSellAmountCryptoPrecision] = useState('')
-    const [rawSellAmountUserCurrency, setRawSellAmountUserCurrency] = useState('')
+    const [rawSellAmountCryptoPrecision, setRawSellAmountCryptoPrecision] =
+      useState(sellAmountCryptoPrecision)
+    const [rawSellAmountUserCurrency, setRawSellAmountUserCurrency] =
+      useState(sellAmountUserCurrency)
     const debouncedSellAmountCryptoPrecision = useDebounce(rawSellAmountCryptoPrecision, 500)
     const isInputtingFiatSellAmount = useAppSelector(selectIsInputtingFiatSellAmount)
 
@@ -52,8 +54,7 @@ export const SellAssetInput = memo(
     useEffect(() => {
       setRawSellAmountCryptoPrecision(sellAmountCryptoPrecision)
       setRawSellAmountUserCurrency(sellAmountUserCurrency ?? '0')
-      // eslint-disable-next-line react-hooks/exhaustive-deps
-    }, [])
+    }, [sellAmountCryptoPrecision, sellAmountUserCurrency])
 
     // sync redux with local state
     useEffect(() => {
@@ -63,13 +64,6 @@ export const SellAssetInput = memo(
         ),
       )
     }, [debouncedSellAmountCryptoPrecision, dispatch])
-
-    // reset input value on asset change
-    useEffect(() => {
-      setRawSellAmountCryptoPrecision('0')
-      setRawSellAmountUserCurrency('0')
-      // eslint-disable-next-line react-hooks/exhaustive-deps
-    }, [asset])
 
     const handleSellAssetInputChange = useCallback(
       (value: string, isFiat: boolean | undefined) => {

--- a/src/components/MultiHopTrade/components/TradeSuccess/TradeSuccess.tsx
+++ b/src/components/MultiHopTrade/components/TradeSuccess/TradeSuccess.tsx
@@ -20,7 +20,7 @@ import { TwirlyToggle } from '../TwirlyToggle'
 
 export type TradeSuccessProps = { handleBack: () => void; children: JSX.Element }
 
-export const TradeSuccessTemp = ({ handleBack, children }: TradeSuccessProps) => {
+export const TradeSuccess = ({ handleBack, children }: TradeSuccessProps) => {
   const translate = useTranslate()
 
   const { isOpen, onToggle } = useDisclosure({

--- a/src/state/slices/tradeInputSlice/tradeInputSlice.ts
+++ b/src/state/slices/tradeInputSlice/tradeInputSlice.ts
@@ -46,14 +46,28 @@ export const tradeInput = createSlice({
     setBuyAsset: (state, action: PayloadAction<Asset>) => {
       const asset = action.payload
 
+      // Prevent doodling state when no change is made
+      if (asset.assetId === state.buyAsset.assetId) {
+        return
+      }
+
       // Handle the user selecting the same asset for both buy and sell
       const isSameAsSellAsset = asset.assetId === state.sellAsset.assetId
-      if (isSameAsSellAsset) state.sellAsset = state.buyAsset
+      if (isSameAsSellAsset) {
+        state.sellAsset = state.buyAsset
+        // clear the sell amount when switching assets
+        state.sellAmountCryptoPrecision = '0'
+      }
 
       state.buyAsset = asset
     },
     setSellAsset: (state, action: PayloadAction<Asset>) => {
       const asset = action.payload
+
+      // Prevent doodling state when no change is made
+      if (asset.assetId === state.sellAsset.assetId) {
+        return
+      }
 
       // Handle the user selecting the same asset for both buy and sell
       const isSameAsBuyAsset = asset.assetId === state.buyAsset.assetId


### PR DESCRIPTION
## Description

Persists the trade input state when previewing a trade, and then going back. Includes fixes:
* Clicking the same sell asset as the current one was causing the quotes to disappear

## Pull Request Type

- [ ] :bug: Bug fix (Non-breaking Change: Fixes an issue)
- [ ] :hammer_and_wrench: Chore (Non-breaking Change: Doc updates, pkg upgrades, typos, etc..)
- [x] :nail_care: New Feature (Breaking/Non-breaking Change)

## Issue (if applicable)

<!-----------------------------------------------------------------------------
If applicable, please link to the github issue and put `closes #XXXX` in your comment to auto-close the issue that your PR fixes.
------------------------------------------------------------------------------>

closes #7026

## Risk
> High Risk PRs Require 2 approvals

* Low risk of state corruption leading to incorrect input amounts, with high impact.
* Moderate risk of state corruption leading to general jankiness in the trade input, with low impact.

> What protocols, transaction types or contract interactions might be affected by this PR?

## Testing

* Check use can set up a quote, preview it and click back and have their input state persist
* Check sell amount interactions combined with changing buy/sell assets consistently gives correct sell amounts and correct state without state corruption or incorrect quotes
* Ensure. sell amounts are correct after various interactions and going back and forth between preview and trade input pages

### Engineering

<!-----------------------------------------------------------------------------
Include sufficient information here for an engineer to test your PR. This may include how to test locally, in a built environment, changes to infrastructure etc.
------------------------------------------------------------------------------>

### Operations

<!-----------------------------------------------------------------------------
If your changes have a user-facing impact, describe how a non-technical QA team can functionally test your changes in a preview environment.

If they are not user-facing please describe how to test for any regressions that may occur.
------------------------------------------------------------------------------>

## Screenshots (if applicable)

User input persists between previewing and going back:

https://github.com/shapeshift/web/assets/125113430/a3ccc6c9-1000-4c0c-b929-3051e13dccae

Example of bug in prod:

https://github.com/shapeshift/web/assets/125113430/e8638611-729a-44fe-b153-7c63a65c1e81

Example of the bug fixed in this PR:

https://github.com/shapeshift/web/assets/125113430/ebae8799-26e8-45ff-8318-b5c94bb5e96a




