### PR TITLE
feat: type-safe useIsTradingActive

### DIFF
--- a/src/components/MultiHopTrade/components/TradeInput/components/TradeQuotes/TradeQuote.tsx
+++ b/src/components/MultiHopTrade/components/TradeInput/components/TradeQuotes/TradeQuote.tsx
@@ -71,12 +71,10 @@ export const TradeQuote: FC<TradeQuoteProps> = memo(
     const { isTradingActive: isTradingActiveOnBuyPool } = useIsTradingActive({
       assetId: buyAsset.assetId,
       swapperName,
-      enabled: true,
     })
     const { isTradingActive: isTradingActiveOnSellPool } = useIsTradingActive({
       assetId: sellAsset.assetId,
       swapperName,
-      enabled: true,
     })
 
     const isTradingActive = Boolean(isTradingActiveOnBuyPool && isTradingActiveOnSellPool)

--- a/src/features/defi/providers/thorchain-savers/components/ThorchainSaversManager/Deposit/components/Confirm.tsx
+++ b/src/features/defi/providers/thorchain-savers/components/ThorchainSaversManager/Deposit/components/Confirm.tsx
@@ -216,7 +216,6 @@ export const Confirm: React.FC<ConfirmProps> = ({ accountId, onNext }) => {
 
   const { isTradingActive, refetch: refetchIsTradingActive } = useIsTradingActive({
     assetId,
-    enabled: !!assetId,
     swapperName: SwapperName.Thorchain,
   })
 

--- a/src/features/defi/providers/thorchain-savers/components/ThorchainSaversManager/Overview/ThorchainSaversOverview.tsx
+++ b/src/features/defi/providers/thorchain-savers/components/ThorchainSaversManager/Overview/ThorchainSaversOverview.tsx
@@ -123,7 +123,6 @@ export const ThorchainSaversOverview: React.FC<OverviewProps> = ({
 
   const { isTradingActive, isLoading: isTradingActiveLoading } = useIsTradingActive({
     assetId,
-    enabled: !!assetId,
     swapperName: SwapperName.Thorchain,
   })
 

--- a/src/features/defi/providers/thorchain-savers/components/ThorchainSaversManager/Withdraw/components/Confirm.tsx
+++ b/src/features/defi/providers/thorchain-savers/components/ThorchainSaversManager/Withdraw/components/Confirm.tsx
@@ -293,7 +293,6 @@ export const Confirm: React.FC<ConfirmProps> = ({ accountId, onNext }) => {
 
   const { isTradingActive, refetch: refetchIsTradingActive } = useIsTradingActive({
     assetId,
-    enabled: !!assetId,
     swapperName: SwapperName.Thorchain,
   })
 

--- a/src/pages/ThorChainLP/AvailablePools.tsx
+++ b/src/pages/ThorChainLP/AvailablePools.tsx
@@ -58,7 +58,6 @@ export const AvailablePools = () => {
 
           const { isTradingActive, isLoading: isTradingActiveLoading } = useIsTradingActive({
             assetId: pool?.assetId,
-            enabled: !!pool,
             swapperName: SwapperName.Thorchain,
           })
 

--- a/src/pages/ThorChainLP/Pool/Pool.tsx
+++ b/src/pages/ThorChainLP/Pool/Pool.tsx
@@ -118,7 +118,6 @@ export const Pool = () => {
 
   const { isTradingActive, isLoading: isTradingActiveLoading } = useIsTradingActive({
     assetId,
-    enabled: Boolean(assetId),
     swapperName: SwapperName.Thorchain,
   })
 

--- a/src/pages/ThorChainLP/components/AddLiquidity/AddLiquidityInput.tsx
+++ b/src/pages/ThorChainLP/components/AddLiquidity/AddLiquidityInput.tsx
@@ -551,7 +551,6 @@ export const AddLiquidityInput: React.FC<AddLiquidityInputProps> = ({
 
   const { isTradingActive, isLoading: isTradingActiveLoading } = useIsTradingActive({
     assetId: poolAsset?.assetId,
-    enabled: Boolean(poolAsset?.assetId),
     swapperName: SwapperName.Thorchain,
   })
 

--- a/src/pages/ThorChainLP/components/RemoveLiquidity/RemoveLiquidityInput.tsx
+++ b/src/pages/ThorChainLP/components/RemoveLiquidity/RemoveLiquidityInput.tsx
@@ -177,7 +177,6 @@ export const RemoveLiquidityInput: React.FC<RemoveLiquidityInputProps> = ({
 
   const { isTradingActive, isLoading: isTradingActiveLoading } = useIsTradingActive({
     assetId: poolAsset?.assetId,
-    enabled: !!poolAsset,
     swapperName: SwapperName.Thorchain,
   })
 

--- a/src/pages/ThorChainLP/components/ReusableLpConfirm.tsx
+++ b/src/pages/ThorChainLP/components/ReusableLpConfirm.tsx
@@ -89,7 +89,6 @@ export const ReusableLpConfirm: React.FC<ReusableLpConfirmProps> = ({
 
   const { isTradingActive, isLoading: isTradingActiveLoading } = useIsTradingActive({
     assetId: poolAsset?.assetId,
-    enabled: !!poolAsset,
     swapperName: SwapperName.Thorchain,
   })
 


### PR DESCRIPTION
## Description

This PR:

- removes the assetId type-narrowing from consumers (i.e `enabled={assetId}`)
- makes `useIsTradingActive` itself handle the undefined `assetId` case, ensuring we don't run the mimir query if there's no need to (i.e no `assetId` means we can't get inbound address data, hence can't select trading active alongside with mimir)

## Pull Request Type

- [ ] :bug: Bug fix (Non-breaking Change: Fixes an issue)
- [ ] :hammer_and_wrench: Chore (Non-breaking Change: Doc updates, pkg upgrades, typos, etc..)
- [x] :nail_care: New Feature (Breaking/Non-breaking Change)

## Issue (if applicable)

<!-----------------------------------------------------------------------------
If applicable, please link to the github issue and put `closes #XXXX` in your comment to auto-close the issue that your PR fixes.
------------------------------------------------------------------------------>

- loosely contributes to https://github.com/shapeshift/web/issues/6996

## Risk
> High Risk PRs Require 2 approvals

<!-----------------------------------------------------------------------------
Outline the scope of your changes and the risk associated with them. You must use your discretion as an engineer to determine the potential impact of your changes.

WARNING: If your PR introduces a new on-chain transaction or modifies an existing one, please add the "High-Risk" label to this PR and ask for 2 reviewers to approve it before merging.

E.g. an upgrade to `hdwallet` or core state management would be considered higher risk, and might require a full regression test. UI or isolated view changes, or something behind a feature flag may have near zero risk. Small bug fixes might require testing isolated to the specific fix.
------------------------------------------------------------------------------>

Low - ensure trading active checks are still happy across the app (swapper, savers, LP...)

> What protocols, transaction types or contract interactions might be affected by this PR?

## Testing

<!-----------------------------------------------------------------------------
We treat every PR to be merged with the same scrutiny as if we were merging directly to production.

Your PR will not be merged if you do not complete the sections below for our engineering and operations teams to test.
------------------------------------------------------------------------------>

- Trading active checks are still happy across swapper, savers and LP

### Engineering

<!-----------------------------------------------------------------------------
Include sufficient information here for an engineer to test your PR. This may include how to test locally, in a built environment, changes to infrastructure etc.
------------------------------------------------------------------------------>

- ^
- For paranoia purposes, trading inactive can also be tested with this diff

```diff
diff --git a/src/react-queries/selectors/index.ts b/src/react-queries/selectors/index.ts
index a40a04c40e..f87730a160 100644
--- a/src/react-queries/selectors/index.ts
+++ b/src/react-queries/selectors/index.ts
@@ -35,6 +35,7 @@ export const selectIsTradingActive = ({
   mimir: Record<string, unknown> | undefined
   inboundAddressResponse: InboundAddressResponse | undefined
 }): boolean => {
+  return false
   switch (swapperName) {
     case SwapperName.Thorchain: {
       if (!assetId) return false
```

### Operations

<!-----------------------------------------------------------------------------
If your changes have a user-facing impact, describe how a non-technical QA team can functionally test your changes in a preview environment.

If they are not user-facing please describe how to test for any regressions that may occur.
------------------------------------------------------------------------------>

- ^

## Screenshots (if applicable)

### Trading active

<img width="853" alt="image" src="https://github.com/shapeshift/web/assets/17035424/a910922c-2618-4c99-a62d-80c36f8b7e42">
<img width="462" alt="image" src="https://github.com/shapeshift/web/assets/17035424/a936ae43-0493-45af-ade1-74e82643b65f">
<img width="406" alt="image" src="https://github.com/shapeshift/web/assets/17035424/4f92b35b-5223-42e2-b36b-2791b3a04b4a">

### Trading inactive

<img width="413" alt="image" src="https://github.com/shapeshift/web/assets/17035424/5d5682f1-01ce-488d-919c-b675b7ac22ef">
<img width="846" alt="image" src="https://github.com/shapeshift/web/assets/17035424/c50b1b43-006f-49c8-b10a-917769b25649">
<img width="496" alt="image" src="https://github.com/shapeshift/web/assets/17035424/98c43a48-5abc-4391-bab0-740db01bf251">

<!-- av pr metadata
This information is embedded by the av CLI when creating PRs to track the status of stacks when using Aviator. Please do not delete or edit this section of the PR.
```
{"parent":"develop","parentHead":"","trunk":"develop"}
```
-->


<!-- av pr metadata
This information is embedded by the av CLI when creating PRs to track the status of stacks when using Aviator. Please do not delete or edit this section of the PR.
```
{"parent":"develop","parentHead":"","trunk":"develop"}
```
-->
