### PR TITLE
feat: make env vars great again in builds

### DIFF
--- a/react-app-rewired/index.ts
+++ b/react-app-rewired/index.ts
@@ -232,7 +232,15 @@ const reactAppRewireConfig = {
                     }
                     const definitions = Object.fromEntries(
                       Object.entries(env)
-                        .filter(([k]) => !k.startsWith('REACT_APP_'))
+                        .filter(
+                          ([k]) =>
+                            // Keep only REACT_APP_* env var entries we are using in packages. We *cannot* remove these, else
+                            // consuming them in packages will result in these being undefined
+                            [
+                              'REACT_APP_FEATURE_NFT_METADATA',
+                              'REACT_APP_RFOX_PROXY_CONTRACT_ADDRESS',
+                            ].includes(k) || !k.startsWith('REACT_APP_'),
+                        )
                         .sort((a, b) => {
                           if (a[0] < b[0]) return -1
                           if (a[0] > b[0]) return 1


### PR DESCRIPTION
## Description

This PR tackles RFOX unchained-client parser not working after https://github.com/shapeshift/web/pull/7158 went in, by fixing a long-lasting issue with env vars not being available outside of web in builds.

See debugger in current unchained-client, after setting `REACT_APP_FEATURE_NFT_METADATA` to true for context.
I've turned the env var expression into a var and console.logged it for debugging purposes, since local scope tends to be borked in builds.

- When running the app with webserver, this guy is defined

<img width="1713" alt="develop 2" src="https://github.com/shapeshift/web/assets/17035424/7836347b-0ad2-40c9-8324-6dedd3dea598">


- However, when building the app and serving it, it immediately becomes rugged:

<img width="1727" alt="build 1" src="https://github.com/shapeshift/web/assets/17035424/6f044843-564f-471b-aede-4549b3297250">
<img width="152" alt="build 2" src="https://github.com/shapeshift/web/assets/17035424/82ba82cd-8ddf-4ad7-8de3-39be4730f529">


Same goes for RFOX proxy contract address env vars:

- When running the app with webserver, this guy is defined

<img width="1713" alt="develop 2" src="https://github.com/shapeshift/web/assets/17035424/1ba8a822-eb52-431e-9545-12e9ddcbb8d6">


- However, when building the app and serving it, it immediately becomes rugged:

<img width="1715" alt="build 3" src="https://github.com/shapeshift/web/assets/17035424/cb74e66f-022d-437e-abd2-52c8a4000548">


## Pull Request Type

- [ ] :bug: Bug fix (Non-breaking Change: Fixes an issue)
- [ ] :hammer_and_wrench: Chore (Non-breaking Change: Doc updates, pkg upgrades, typos, etc..)
- [x] :nail_care: New Feature (Breaking/Non-breaking Change)

## Issue (if applicable)

<!-----------------------------------------------------------------------------
If applicable, please link to the github issue and put `closes #XXXX` in your comment to auto-close the issue that your PR fixes.
------------------------------------------------------------------------------>

closes N/A, spotted in https://discord.com/channels/554694662431178782/1252410161163931730/1252513695741902928

## Risk
> High Risk PRs Require 2 approvals

<!-----------------------------------------------------------------------------
Outline the scope of your changes and the risk associated with them. You must use your discretion as an engineer to determine the potential impact of your changes.

WARNING: If your PR introduces a new on-chain transaction or modifies an existing one, please add the "High-Risk" label to this PR and ask for 2 reviewers to approve it before merging.

E.g. an upgrade to `hdwallet` or core state management would be considered higher risk, and might require a full regression test. UI or isolated view changes, or something behind a feature flag may have near zero risk. Small bug fixes might require testing isolated to the specific fix.
------------------------------------------------------------------------------>

> What protocols, transaction types or contract interactions might be affected by this PR?

Low

## Testing

<!-----------------------------------------------------------------------------
We treat every PR to be merged with the same scrutiny as if we were merging directly to production.

Your PR will not be merged if you do not complete the sections below for our engineering and operations teams to test.
------------------------------------------------------------------------------>

### Engineering

<!-----------------------------------------------------------------------------
Include sufficient information here for an engineer to test your PR. This may include how to test locally, in a built environment, changes to infrastructure etc.
------------------------------------------------------------------------------>

Test *every single one* of the cases below.

For each of them, the most straightforward way is to do an unstake, which will allow you to both
  - confirm that the cooldown period is the one of the relevant contract for the env (i.e 10mn for dev envs, a month for prod)
  - confirm that Tx parsing is happy, since, if you enable the RFOX dashboard flag, you will get to see it in the same view without needing to click anything else :fridaydog:

- localhost with dev server and env dev is happy
- localhost with dev server and app env (with monkey patched fox feature flag to true) is happy
- local *build* with env dev is happy
- local *build* with app dev (with monkey patch fox feature flag to true) is happy
- build deployed in gome is happy (note, gome is using dev env)
- build deployed in release is happy (note, release is using app env)

### Operations

<!-----------------------------------------------------------------------------
If your changes have a user-facing impact, describe how a non-technical QA team can functionally test your changes in a preview environment.

If they are not user-facing please describe how to test for any regressions that may occur.
------------------------------------------------------------------------------>

- rfox Tx parsing is happy in the release you're testing (i.e release for this PR getting out, and gome for RFOX feature testing)

## Screenshots (if applicable)

- localhost with dev server and env dev is happy

<img width="1728" alt="Screenshot 2024-06-18 at 10 37 55" src="https://github.com/shapeshift/web/assets/17035424/ca8aa68a-827f-48f3-b809-1e620b49229f">

- localhost with dev server and app env (with monkey patched fox feature flag to true) is happy

<img width="1723" alt="Screenshot 2024-06-18 at 10 35 03" src="https://github.com/shapeshift/web/assets/17035424/3e15c05c-a757-4c8a-8cd0-fcea097c9b34">

- local *build* with env dev is happy

<img width="1728" alt="Screenshot 2024-06-18 at 10 39 37" src="https://github.com/shapeshift/web/assets/17035424/3782382f-a1a7-4761-93cc-134b9b48d3f4">

- local *build* with app dev (with monkey patch fox feature flag to true) is happy

<img width="1728" alt="Screenshot 2024-06-18 at 10 43 13" src="https://github.com/shapeshift/web/assets/17035424/aff17b44-6d1d-45d7-b6f9-0126520904e5">

- build deployed in gome is happy (note, gome is using dev env)

<img width="1719" alt="Screenshot 2024-06-18 at 10 20 53" src="https://github.com/shapeshift/web/assets/17035424/5e29ee3f-31d7-4b17-8de1-cebbc6337e84">

- build deployed in release is happy (note, release is using app env)

<img width="1722" alt="image" src="https://github.com/shapeshift/web/assets/17035424/454c85f2-4dee-4a2a-aa60-1e854ceef134">


<!-- av pr metadata
This information is embedded by the av CLI when creating PRs to track the status of stacks when using Aviator. Please do not delete or edit this section of the PR.
```
{"parent":"develop","parentHead":"","trunk":"develop"}
```
-->
