### PR TITLE
refactor: simplify active trading

### DIFF
--- a/src/components/MultiHopTrade/components/TradeInput/TradeInput.tsx
+++ b/src/components/MultiHopTrade/components/TradeInput/TradeInput.tsx
@@ -184,8 +184,6 @@ export const TradeInput = ({ isCompact }: TradeInputProps) => {
       case !!quoteResponseError:
         return getQuoteRequestErrorTranslation(quoteResponseError)
       case !!tradeQuoteError:
-        // this should never occur because users shouldn't be able to select an errored quote
-        // but just in case
         return getQuoteErrorTranslation(tradeQuoteError!)
       case !isConnected || isDemoWallet:
         // We got a happy path quote, but we may still be in the context of the demo wallet

--- a/src/components/MultiHopTrade/components/TradeInput/components/TradeQuotes/TradeQuote.tsx
+++ b/src/components/MultiHopTrade/components/TradeInput/components/TradeQuotes/TradeQuote.tsx
@@ -5,7 +5,6 @@ import { TradeQuoteError as SwapperTradeQuoteError } from '@shapeshiftoss/swappe
 import type { FC } from 'react'
 import { memo, useCallback, useMemo } from 'react'
 import { useTranslate } from 'react-polyglot'
-import { useIsTradingActive } from 'react-queries/hooks/useIsTradingActive'
 import { Amount } from 'components/Amount/Amount'
 import { SlippageIcon } from 'components/Icons/Slippage'
 import { getQuoteErrorTranslation } from 'components/MultiHopTrade/components/TradeInput/getQuoteErrorTranslation'

--- a/src/components/MultiHopTrade/components/TradeInput/components/TradeQuotes/TradeQuote.tsx
+++ b/src/components/MultiHopTrade/components/TradeInput/components/TradeQuotes/TradeQuote.tsx
@@ -68,16 +68,6 @@ export const TradeQuote: FC<TradeQuoteProps> = memo(
 
     const buyAsset = useAppSelector(selectInputBuyAsset)
     const sellAsset = useAppSelector(selectInputSellAsset)
-    const { isTradingActive: isTradingActiveOnBuyPool } = useIsTradingActive({
-      assetId: buyAsset.assetId,
-      swapperName,
-    })
-    const { isTradingActive: isTradingActiveOnSellPool } = useIsTradingActive({
-      assetId: sellAsset.assetId,
-      swapperName,
-    })
-
-    const isTradingActive = Boolean(isTradingActiveOnBuyPool && isTradingActiveOnSellPool)
 
     const userSlippagePercentageDecimal = useAppSelector(selectUserSlippagePercentageDecimal)
 
@@ -332,7 +322,7 @@ export const TradeQuote: FC<TradeQuoteProps> = memo(
         bodyContent={bodyContent}
         onClick={handleQuoteSelection}
         isActive={isActive}
-        isActionable={isTradingActive && hasAmountWithPositiveReceive && errors.length === 0}
+        isActionable={hasAmountWithPositiveReceive && errors.length === 0}
         isDisabled={isDisabled}
       />
     ) : null


### PR DESCRIPTION
## Description

We already know about the trading halt status in the trade quote scope as the `validateTradeQuote` is called by the `swapperApi` upstream, which in turn already calls the `inboundAddresses` endpoint.

This PR ensures we have one source of truth, the `swapperApi`, for when a quote is valid and not halted.

## Pull Request Type

- [ ] :bug: Bug fix (Non-breaking Change: Fixes an issue)
- [x] :hammer_and_wrench: Chore (Non-breaking Change: Doc updates, pkg upgrades, typos, etc..)
- [ ] :nail_care: New Feature (Breaking/Non-breaking Change)

## Issue (if applicable)

Closes https://github.com/shapeshift/web/issues/7154

## Risk

Medium - there should be no behaviour change here, though getting it wrong could mean allowing a user to execute a trade on a halted pool.

> What protocols, transaction types or contract interactions might be affected by this PR?

Swaps. Specifically, THORChain swaps.

## Testing

Get some quotes and ensure that both THORChain and non-THORChain quotes can be moved to the confirm step.

### Engineering

Monkey patch the inbound address response processing logic to make all pools halted. Then confirm that THORChain trades show as halted, and that the user cannot proceed with them.

```diff
diff --git a/src/react-queries/queries/thornode.ts b/src/react-queries/queries/thornode.ts
--- a/src/react-queries/queries/thornode.ts
+++ b/src/react-queries/queries/thornode.ts
@@ -72,7 +72,7 @@ export const thornode = createQueryKeys('thornode', {
             )
           ).andThen(({ data: inboundAddresses }) => {
             // Exclude halted
-            const activeInboundAddresses = inboundAddresses.filter(a => !a.halted)
+            const activeInboundAddresses = inboundAddresses.filter(a => a.halted)
             return Ok(activeInboundAddresses)
           })
         )
```

### Operations

See testing steps above.

## Screenshots (if applicable)

N/A