### PR TITLE
fix: p tag descendants

### DIFF
--- a/src/features/defi/providers/cosmos/components/CosmosManager/Overview/CosmosEmpty.tsx
+++ b/src/features/defi/providers/cosmos/components/CosmosManager/Overview/CosmosEmpty.tsx
@@ -1,4 +1,4 @@
-import { Button, Skeleton, Stack, Text as CText, VStack } from '@chakra-ui/react'
+import { Button, Skeleton, Stack, VStack } from '@chakra-ui/react'
 import type { Asset } from '@shapeshiftoss/types'
 import { DefiModalContent } from 'features/defi/components/DefiModal/DefiModalContent'
 import { EmptyOverview } from 'features/defi/components/EmptyOverview/EmptyOverview'
@@ -41,11 +41,9 @@ export const CosmosEmpty = ({ assets, apy, onStakeClick, onLearnMoreClick }: Cos
       <EmptyOverview assets={assets} footer={emptyOverviewFooter}>
         <Stack direction='row' spacing={1} justifyContent='center' mb={4}>
           <Text translation={getStartedHeaderTranslation} />
-          <CText color='green.500'>
-            <Skeleton isLoaded={Boolean(apy)}>
-              <Amount.Percent value={apy ?? ''} suffix='APR' />
-            </Skeleton>
-          </CText>
+          <Skeleton isLoaded={Boolean(apy)}>
+            <Amount.Percent color='green.500' value={apy ?? ''} suffix='APR' />
+          </Skeleton>
         </Stack>
         <Text color='text.subtle' translation='defi.modals.getStarted.body' />
         <Text color='text.subtle' translation='defi.modals.getStarted.userProtectionInfo' />

--- a/src/features/defi/providers/fox-farming/components/FoxFarmingManager/Overview/FoxFarmingEmpty.tsx
+++ b/src/features/defi/providers/fox-farming/components/FoxFarmingManager/Overview/FoxFarmingEmpty.tsx
@@ -1,4 +1,4 @@
-import { Button, Skeleton, Stack, Text as CText } from '@chakra-ui/react'
+import { Button, Skeleton, Stack } from '@chakra-ui/react'
 import type { Asset } from '@shapeshiftoss/types'
 import { DefiModalContent } from 'features/defi/components/DefiModal/DefiModalContent'
 import { EmptyOverview } from 'features/defi/components/EmptyOverview/EmptyOverview'
@@ -39,11 +39,9 @@ export const FoxFarmingEmpty = ({
       <EmptyOverview assets={assets} footer={footer}>
         <Stack spacing={1} justifyContent='center' mb={4}>
           <Text translation={foxFarmingOverviewHeaderTranslation} />
-          <CText color='green.500'>
-            <Skeleton isLoaded={Boolean(apy)}>
-              <Amount.Percent value={apy ?? ''} suffix='APR' />
-            </Skeleton>
-          </CText>
+          <Skeleton isLoaded={Boolean(apy)}>
+            <Amount.Percent color='green.500' value={apy ?? ''} suffix='APR' />
+          </Skeleton>
         </Stack>
         <Text color='text.subtle' translation='defi.modals.foxFarmingOverview.body' />
         <Text color='text.subtle' translation='defi.modals.foxFarmingOverview.rewards' />


### PR DESCRIPTION
## Description

Fixes console spew in the DeFi section when clicking opportunities in the carousel (see video below).

The cause was `div` and `p` tags appearing as descendants of a `p` tag (`Text`, imported as `CText`).

## Pull Request Type

- [x] :bug: Bug fix (Non-breaking Change: Fixes an issue)
- [ ] :hammer_and_wrench: Chore (Non-breaking Change: Doc updates, pkg upgrades, typos, etc..)
- [ ] :nail_care: New Feature (Breaking/Non-breaking Change)

## Issue (if applicable)

N/A

## Risk

Small

> What protocols, transaction types or contract interactions might be affected by this PR?

None.

## Testing

Click an opportunity in the carousel, as per the video below, and observe no log spew 😌 

### Engineering

☝️

### Operations

☝️

## Screenshots (if applicable)

https://github.com/shapeshift/web/assets/97164662/b735360e-d9b5-4569-93eb-65985030a6e4

