### PR TITLE
feat: staking deposit account improvements

### DIFF
--- a/src/features/defi/providers/cosmos/components/CosmosManager/Claim/CosmosClaim.tsx
+++ b/src/features/defi/providers/cosmos/components/CosmosManager/Claim/CosmosClaim.tsx
@@ -22,7 +22,7 @@ import {
   selectAssetById,
   selectEarnUserStakingOpportunityByUserStakingId,
   selectFirstAccountIdByChainId,
-  selectHighestBalanceAccountIdByStakingId,
+  selectHighestStakingBalanceAccountIdByStakingId,
 } from 'state/slices/selectors'
 import { useAppSelector } from 'state/store'
 
@@ -82,7 +82,7 @@ export const CosmosClaim: React.FC<CosmosClaimProps> = ({
 
   const highestBalanceAccountIdFilter = useMemo(() => ({ stakingId: validatorId }), [validatorId])
   const highestBalanceAccountId = useAppSelector(state =>
-    selectHighestBalanceAccountIdByStakingId(state, highestBalanceAccountIdFilter),
+    selectHighestStakingBalanceAccountIdByStakingId(state, highestBalanceAccountIdFilter),
   )
   const defaultAccountId = useAppSelector(state => selectFirstAccountIdByChainId(state, chainId))
   const maybeAccountId = useMemo(

--- a/src/features/defi/providers/cosmos/components/CosmosManager/Overview/CosmosOverview.tsx
+++ b/src/features/defi/providers/cosmos/components/CosmosManager/Overview/CosmosOverview.tsx
@@ -33,7 +33,7 @@ import {
   selectAssetById,
   selectAssets,
   selectHasClaimByUserStakingId,
-  selectHighestBalanceAccountIdByStakingId,
+  selectHighestStakingBalanceAccountIdByStakingId,
   selectMarketDataByAssetIdUserCurrency,
   selectSelectedLocale,
   selectStakingOpportunityByFilter,
@@ -67,7 +67,7 @@ export const CosmosOverview: React.FC<CosmosOverviewProps> = ({
 
   const highestBalanceAccountIdFilter = useMemo(() => ({ stakingId: validatorId }), [validatorId])
   const highestBalanceAccountId = useAppSelector(state =>
-    selectHighestBalanceAccountIdByStakingId(state, highestBalanceAccountIdFilter),
+    selectHighestStakingBalanceAccountIdByStakingId(state, highestBalanceAccountIdFilter),
   )
   const maybeAccountId = useMemo(
     () => accountId ?? routeAccountId ?? highestBalanceAccountId,

--- a/src/features/defi/providers/fox-farming/components/FoxFarmingManager/Claim/ClaimRoutes.tsx
+++ b/src/features/defi/providers/fox-farming/components/FoxFarmingManager/Claim/ClaimRoutes.tsx
@@ -18,7 +18,7 @@ import { serializeUserStakingId, toOpportunityId } from 'state/slices/opportunit
 import {
   selectAssets,
   selectFirstAccountIdByChainId,
-  selectHighestBalanceAccountIdByStakingId,
+  selectHighestStakingBalanceAccountIdByStakingId,
   selectUserStakingOpportunityByUserStakingId,
 } from 'state/slices/selectors'
 import { useAppSelector } from 'state/store'
@@ -88,7 +88,7 @@ export const ClaimRoutes = ({
     [opportunityId],
   )
   const highestBalanceAccountId = useAppSelector(state =>
-    selectHighestBalanceAccountIdByStakingId(state, highestBalanceAccountIdFilter),
+    selectHighestStakingBalanceAccountIdByStakingId(state, highestBalanceAccountIdFilter),
   )
   const defaultAccountId = useAppSelector(state => selectFirstAccountIdByChainId(state, chainId))
   const maybeAccountId = useMemo(

--- a/src/features/defi/providers/fox-farming/components/FoxFarmingManager/Overview/FoxFarmingOverview.tsx
+++ b/src/features/defi/providers/fox-farming/components/FoxFarmingManager/Overview/FoxFarmingOverview.tsx
@@ -29,7 +29,7 @@ import {
   selectAssetById,
   selectAssets,
   selectFirstAccountIdByChainId,
-  selectHighestBalanceAccountIdByStakingId,
+  selectHighestStakingBalanceAccountIdByStakingId,
   selectMarketDataUserCurrency,
   selectUnderlyingStakingAssetsWithBalancesAndIcons,
   selectUserStakingOpportunityByUserStakingId,
@@ -67,7 +67,7 @@ export const FoxFarmingOverview: React.FC<FoxFarmingOverviewProps> = ({
     [opportunityId],
   )
   const highestBalanceAccountId = useAppSelector(state =>
-    selectHighestBalanceAccountIdByStakingId(state, highestBalanceAccountIdFilter),
+    selectHighestStakingBalanceAccountIdByStakingId(state, highestBalanceAccountIdFilter),
   )
 
   const opportunityDataFilter = useMemo(

--- a/src/features/defi/providers/foxy/components/FoxyManager/Overview/FoxyOverview.tsx
+++ b/src/features/defi/providers/foxy/components/FoxyManager/Overview/FoxyOverview.tsx
@@ -29,7 +29,7 @@ import {
 import {
   selectEarnUserStakingOpportunityByUserStakingId,
   selectFirstAccountIdByChainId,
-  selectHighestBalanceAccountIdByStakingId,
+  selectHighestStakingBalanceAccountIdByStakingId,
   selectMarketDataByAssetIdUserCurrency,
   selectSelectedLocale,
 } from 'state/slices/selectors'
@@ -68,7 +68,7 @@ export const FoxyOverview: React.FC<FoxyOverviewProps> = ({
     [assetId],
   )
   const highestBalanceAccountId = useAppSelector(state =>
-    selectHighestBalanceAccountIdByStakingId(state, highestBalanceAccountIdFilter),
+    selectHighestStakingBalanceAccountIdByStakingId(state, highestBalanceAccountIdFilter),
   )
 
   const translate = useTranslate()

--- a/src/features/defi/providers/thorchain-savers/components/ThorchainSaversManager/Deposit/ThorchainSaversDeposit.tsx
+++ b/src/features/defi/providers/thorchain-savers/components/ThorchainSaversManager/Deposit/ThorchainSaversDeposit.tsx
@@ -28,7 +28,7 @@ import { serializeUserStakingId, toOpportunityId } from 'state/slices/opportunit
 import {
   selectAssetById,
   selectEarnUserStakingOpportunityByUserStakingId,
-  selectHighestBalanceAccountIdByStakingId,
+  selectHighestStakingBalanceAccountIdByStakingId,
   selectMarketDataByAssetIdUserCurrency,
   selectPortfolioAccountMetadataByAccountId,
   selectPortfolioLoading,
@@ -79,17 +79,17 @@ export const ThorchainSaversDeposit: React.FC<YearnDepositProps> = ({
     () => ({ stakingId: opportunityId }),
     [opportunityId],
   )
-  const highestBalanceAccountId = useAppSelector(state =>
-    selectHighestBalanceAccountIdByStakingId(state, highestBalanceAccountIdFilter),
+  const highestStakingBalanceAccountId = useAppSelector(state =>
+    selectHighestStakingBalanceAccountIdByStakingId(state, highestBalanceAccountIdFilter),
   )
   const opportunityDataFilter = useMemo(
     () => ({
       userStakingId: serializeUserStakingId(
-        accountId ?? highestBalanceAccountId ?? '',
+        accountId ?? highestStakingBalanceAccountId ?? '',
         opportunityId ?? '',
       ),
     }),
-    [accountId, highestBalanceAccountId, opportunityId],
+    [accountId, highestStakingBalanceAccountId, opportunityId],
   )
   const opportunityData = useAppSelector(state =>
     selectEarnUserStakingOpportunityByUserStakingId(state, opportunityDataFilter),

--- a/src/features/defi/providers/thorchain-savers/components/ThorchainSaversManager/Deposit/components/Deposit.tsx
+++ b/src/features/defi/providers/thorchain-savers/components/ThorchainSaversManager/Deposit/components/Deposit.tsx
@@ -57,7 +57,7 @@ import {
   selectAssets,
   selectEarnUserStakingOpportunityByUserStakingId,
   selectFeeAssetById,
-  selectHighestBalanceAccountIdByStakingId,
+  selectHighestStakingBalanceAccountIdByStakingId,
   selectMarketDataByAssetIdUserCurrency,
   selectPortfolioCryptoBalanceBaseUnitByFilter,
 } from 'state/slices/selectors'
@@ -126,7 +126,7 @@ export const Deposit: React.FC<DepositProps> = ({
     [opportunityId],
   )
   const highestBalanceAccountId = useAppSelector(state =>
-    selectHighestBalanceAccountIdByStakingId(state, highestBalanceAccountIdFilter),
+    selectHighestStakingBalanceAccountIdByStakingId(state, highestBalanceAccountIdFilter),
   )
   const opportunityDataFilter = useMemo(
     () => ({

--- a/src/features/defi/providers/thorchain-savers/components/ThorchainSaversManager/Overview/ThorchainSaversOverview.tsx
+++ b/src/features/defi/providers/thorchain-savers/components/ThorchainSaversManager/Overview/ThorchainSaversOverview.tsx
@@ -53,7 +53,7 @@ import {
   selectAssets,
   selectEarnUserStakingOpportunityByUserStakingId,
   selectFirstAccountIdByChainId,
-  selectHighestBalanceAccountIdByStakingId,
+  selectHighestStakingBalanceAccountIdByStakingId,
   selectMarketDataByAssetIdUserCurrency,
   selectOpportunitiesApiQueriesByFilter,
   selectStakingOpportunityByFilter,
@@ -113,7 +113,7 @@ export const ThorchainSaversOverview: React.FC<OverviewProps> = ({
     [opportunityId],
   )
   const highestBalanceAccountId = useAppSelector(state =>
-    selectHighestBalanceAccountIdByStakingId(state, highestBalanceAccountIdFilter),
+    selectHighestStakingBalanceAccountIdByStakingId(state, highestBalanceAccountIdFilter),
   )
   const defaultAccountId = useAppSelector(state => selectFirstAccountIdByChainId(state, chainId))
   const maybeAccountId = useMemo(

--- a/src/features/defi/providers/thorchain-savers/components/ThorchainSaversManager/Overview/ThorchainSaversOverview.tsx
+++ b/src/features/defi/providers/thorchain-savers/components/ThorchainSaversManager/Overview/ThorchainSaversOverview.tsx
@@ -54,6 +54,7 @@ import {
   selectEarnUserStakingOpportunityByUserStakingId,
   selectFirstAccountIdByChainId,
   selectHighestStakingBalanceAccountIdByStakingId,
+  selectHighestUserCurrencyBalanceAccountByAssetId,
   selectMarketDataByAssetIdUserCurrency,
   selectOpportunitiesApiQueriesByFilter,
   selectStakingOpportunityByFilter,
@@ -112,13 +113,13 @@ export const ThorchainSaversOverview: React.FC<OverviewProps> = ({
     () => ({ stakingId: opportunityId }),
     [opportunityId],
   )
-  const highestBalanceAccountId = useAppSelector(state =>
+  const highestStakingBalanceAccountId = useAppSelector(state =>
     selectHighestStakingBalanceAccountIdByStakingId(state, highestBalanceAccountIdFilter),
   )
   const defaultAccountId = useAppSelector(state => selectFirstAccountIdByChainId(state, chainId))
   const maybeAccountId = useMemo(
-    () => accountId ?? highestBalanceAccountId ?? defaultAccountId,
-    [accountId, defaultAccountId, highestBalanceAccountId],
+    () => accountId ?? highestStakingBalanceAccountId ?? defaultAccountId,
+    [accountId, defaultAccountId, highestStakingBalanceAccountId],
   )
 
   const { isTradingActive, isLoading: isTradingActiveLoading } = useIsTradingActive({
@@ -154,6 +155,24 @@ export const ThorchainSaversOverview: React.FC<OverviewProps> = ({
       ? selectEarnUserStakingOpportunityByUserStakingId(state, opportunityDataFilter)
       : undefined,
   )
+
+  const hasStakedBalance = useMemo(() => {
+    return bnOrZero(earnOpportunityData?.stakedAmountCryptoBaseUnit).gt(0)
+  }, [earnOpportunityData?.stakedAmountCryptoBaseUnit])
+
+  const highestAssetBalanceFilter = useMemo(
+    () => ({
+      assetId,
+    }),
+    [assetId],
+  )
+  const highestAssetBalanceAccountId = useAppSelector(state =>
+    selectHighestUserCurrencyBalanceAccountByAssetId(state, highestAssetBalanceFilter),
+  )
+
+  const highestStakedOrAssetBalanceAccountId = hasStakedBalance
+    ? maybeAccountId
+    : highestAssetBalanceAccountId
 
   const opportunityMetadataFilter = useMemo(() => ({ stakingId: assetId as StakingId }), [assetId])
   const opportunityMetadata = useAppSelector(state =>
@@ -366,7 +385,7 @@ export const ThorchainSaversOverview: React.FC<OverviewProps> = ({
   const handleThorchainSaversEmptyClick = useCallback(() => setHideEmptyState(true), [])
 
   if (
-    (!earnOpportunityData?.isLoaded && maybeAccountId) ||
+    (!earnOpportunityData?.isLoaded && highestStakedOrAssetBalanceAccountId) ||
     isTradingActiveLoading ||
     isMockDepositQuoteLoading
   ) {
@@ -381,14 +400,14 @@ export const ThorchainSaversOverview: React.FC<OverviewProps> = ({
     return <ThorchainSaversEmpty assetId={assetId} onClick={handleThorchainSaversEmptyClick} />
   }
 
-  if (!(maybeAccountId && opportunityDataFilter)) return null
+  if (!(highestStakedOrAssetBalanceAccountId && opportunityDataFilter)) return null
   if (!asset) return null
   if (!underlyingAssetsWithBalancesAndIcons) return null
   if (!earnOpportunityData) return null
 
   return (
     <Overview
-      accountId={maybeAccountId}
+      accountId={highestStakedOrAssetBalanceAccountId}
       onAccountIdChange={handleAccountIdChange}
       asset={asset}
       name={earnOpportunityData.name ?? ''}

--- a/src/features/defi/providers/thorchain-savers/components/ThorchainSaversManager/Withdraw/ThorchainSaversWithdraw.tsx
+++ b/src/features/defi/providers/thorchain-savers/components/ThorchainSaversManager/Withdraw/ThorchainSaversWithdraw.tsx
@@ -25,7 +25,7 @@ import { serializeUserStakingId, toOpportunityId } from 'state/slices/opportunit
 import {
   selectAssetById,
   selectEarnUserStakingOpportunityByUserStakingId,
-  selectHighestBalanceAccountIdByStakingId,
+  selectHighestStakingBalanceAccountIdByStakingId,
   selectMarketDataByAssetIdUserCurrency,
   selectPortfolioAccountMetadataByAccountId,
 } from 'state/slices/selectors'
@@ -68,7 +68,7 @@ export const ThorchainSaversWithdraw: React.FC<WithdrawProps> = ({ accountId }) 
     [opportunityId],
   )
   const highestBalanceAccountId = useAppSelector(state =>
-    selectHighestBalanceAccountIdByStakingId(state, highestBalanceAccountIdFilter),
+    selectHighestStakingBalanceAccountIdByStakingId(state, highestBalanceAccountIdFilter),
   )
   const opportunityDataFilter = useMemo(
     () => ({

--- a/src/features/defi/providers/thorchain-savers/components/ThorchainSaversManager/Withdraw/components/Confirm.tsx
+++ b/src/features/defi/providers/thorchain-savers/components/ThorchainSaversManager/Withdraw/components/Confirm.tsx
@@ -57,7 +57,7 @@ import {
   selectBIP44ParamsByAccountId,
   selectEarnUserStakingOpportunityByUserStakingId,
   selectFeeAssetById,
-  selectHighestBalanceAccountIdByStakingId,
+  selectHighestStakingBalanceAccountIdByStakingId,
   selectMarketDataByAssetIdUserCurrency,
   selectPortfolioCryptoBalanceBaseUnitByFilter,
 } from 'state/slices/selectors'
@@ -104,7 +104,7 @@ export const Confirm: React.FC<ConfirmProps> = ({ accountId, onNext }) => {
   )
 
   const highestBalanceAccountId = useAppSelector(state =>
-    selectHighestBalanceAccountIdByStakingId(state, highestBalanceAccountIdFilter),
+    selectHighestStakingBalanceAccountIdByStakingId(state, highestBalanceAccountIdFilter),
   )
   const opportunityDataFilter = useMemo(
     () => ({

--- a/src/features/defi/providers/thorchain-savers/components/ThorchainSaversManager/Withdraw/components/Withdraw.tsx
+++ b/src/features/defi/providers/thorchain-savers/components/ThorchainSaversManager/Withdraw/components/Withdraw.tsx
@@ -42,7 +42,7 @@ import {
   selectAssets,
   selectEarnUserStakingOpportunityByUserStakingId,
   selectFeeAssetById,
-  selectHighestBalanceAccountIdByStakingId,
+  selectHighestStakingBalanceAccountIdByStakingId,
   selectMarketDataByAssetIdUserCurrency,
   selectPortfolioCryptoBalanceBaseUnitByFilter,
 } from 'state/slices/selectors'
@@ -93,7 +93,7 @@ export const Withdraw: React.FC<WithdrawProps> = ({ accountId, fromAddress, onNe
     [opportunityId],
   )
   const highestBalanceAccountId = useAppSelector(state =>
-    selectHighestBalanceAccountIdByStakingId(state, highestBalanceAccountIdFilter),
+    selectHighestStakingBalanceAccountIdByStakingId(state, highestBalanceAccountIdFilter),
   )
 
   const opportunityDataFilter = useMemo(

--- a/src/state/slices/opportunitiesSlice/selectors/selectors.test.ts
+++ b/src/state/slices/opportunitiesSlice/selectors/selectors.test.ts
@@ -23,7 +23,7 @@ import { initialState } from '../opportunitiesSlice'
 import {
   selectAggregatedUserStakingOpportunityByStakingId,
   selectHighestBalanceAccountIdByLpId,
-  selectHighestBalanceAccountIdByStakingId,
+  selectHighestStakingBalanceAccountIdByStakingId,
   selectUserStakingOpportunityByUserStakingId,
 } from '../selectors'
 import { serializeUserStakingId } from '../utils'
@@ -132,7 +132,7 @@ describe('opportunitiesSlice selectors', () => {
     }
     describe('selectHighestBalanceLpUserStakingIdByStakingId', () => {
       it('can get the highest balance AccountId for a given StakingId', () => {
-        const result = selectHighestBalanceAccountIdByStakingId(mockState, {
+        const result = selectHighestStakingBalanceAccountIdByStakingId(mockState, {
           stakingId: mockStakingContractOne,
         })
 

--- a/src/state/slices/opportunitiesSlice/selectors/stakingSelectors.ts
+++ b/src/state/slices/opportunitiesSlice/selectors/stakingSelectors.ts
@@ -631,7 +631,7 @@ export const selectAggregatedEarnUserStakingEligibleOpportunities = createDeepEq
 )
 
 // Useful when multiple accounts are staked on the same opportunity, so we can detect the highest staked balance one
-export const selectHighestBalanceAccountIdByStakingId = createSelector(
+export const selectHighestStakingBalanceAccountIdByStakingId = createSelector(
   selectUserStakingOpportunitiesById,
   selectStakingIdParamFromFilter,
   (userStakingOpportunities, stakingId): AccountId | undefined => {


### PR DESCRIPTION
## Description

When opening the savers overview we currently select the account with the highest staked balance.

If the user has no staking balance for any accounts for that `assetId` we'll select the last account in the list (from `selectUserStakingOpportunitiesById`).

This is perhaps counter-intuitive to a user.

This PR selects the account with the highest balance if the user has no opportunities for that asset.

## Pull Request Type

- [ ] :bug: Bug fix (Non-breaking Change: Fixes an issue)
- [ ] :hammer_and_wrench: Chore (Non-breaking Change: Doc updates, pkg upgrades, typos, etc..)
- [x] :nail_care: New Feature (Breaking/Non-breaking Change)

## Issue (if applicable)

Closes https://github.com/shapeshift/web/issues/7167

## Risk

Small

> What protocols, transaction types or contract interactions might be affected by this PR?

THORChain savers.

## Testing

Click on a UTXO with multiple derivations (e.g. LTC, BTC).

- If the wallet has opportunities for the asset, the account with the highest balance opportunity should be selected.
- If the wallet does not have opportunities for the asset, the account with the highest asset balance should be selected.

### Engineering

☝️

### Operations

☝️

## Screenshots (if applicable)

N/A