### PR TITLE
fix: swapper last step tag display quote receive address over wallet one

### DIFF
--- a/src/components/MultiHopTrade/components/MultiHopTradeConfirm/components/StepperStep.tsx
+++ b/src/components/MultiHopTrade/components/MultiHopTradeConfirm/components/StepperStep.tsx
@@ -1,7 +1,6 @@
 import type { BoxProps, StepTitleProps, SystemStyleObject } from '@chakra-ui/react'
 import {
   Box,
-  Skeleton,
   SkeletonCircle,
   SkeletonText,
   Spacer,
@@ -13,11 +12,9 @@ import {
   Tag,
   useStyleConfig,
 } from '@chakra-ui/react'
-import { isLedger } from '@shapeshiftoss/hdwallet-ledger'
-import { useMemo } from 'react'
 import { MiddleEllipsis } from 'components/MiddleEllipsis/MiddleEllipsis'
-import { useReceiveAddress } from 'components/MultiHopTrade/hooks/useReceiveAddress'
-import { useWallet } from 'hooks/useWallet/useWallet'
+import { selectActiveQuote } from 'state/slices/tradeQuoteSlice/selectors'
+import { useAppSelector } from 'state/store'
 
 const width = { width: '100%' }
 
@@ -35,23 +32,15 @@ export type StepperStepProps = {
 }
 
 const LastStepTag = () => {
-  const wallet = useWallet().state.wallet
-  const useReceiveAddressArgs = useMemo(
-    () => ({
-      fetchUnchainedAddress: Boolean(wallet && isLedger(wallet)),
-    }),
-    [wallet],
-  )
+  const activeQuote = useAppSelector(selectActiveQuote)
+  const receiveAddress = activeQuote?.receiveAddress
 
-  const { manualReceiveAddress, walletReceiveAddress } = useReceiveAddress(useReceiveAddressArgs)
-  const receiveAddress = manualReceiveAddress ?? walletReceiveAddress
+  if (!receiveAddress) return null
 
   return (
-    <Skeleton isLoaded={!!receiveAddress}>
-      <Tag size='md' colorScheme='blue'>
-        <MiddleEllipsis value={receiveAddress ?? ''} />
-      </Tag>
-    </Skeleton>
+    <Tag size='md' colorScheme='blue'>
+      <MiddleEllipsis value={receiveAddress} />
+    </Tag>
   )
 }
 export const StepperStep = ({


### PR DESCRIPTION
## Description

Does what it says on the box - ensure we are not reactive in displaying next UTXO receive address in the `<LastStepTag />`.

## Pull Request Type

- [x] :bug: Bug fix (Non-breaking Change: Fixes an issue)
- [ ] :hammer_and_wrench: Chore (Non-breaking Change: Doc updates, pkg upgrades, typos, etc..)
- [ ] :nail_care: New Feature (Breaking/Non-breaking Change)

## Issue (if applicable)

<!-----------------------------------------------------------------------------
If applicable, please link to the github issue and put `closes #XXXX` in your comment to auto-close the issue that your PR fixes.
------------------------------------------------------------------------------>

closes https://github.com/shapeshift/web/issues/7172

## Risk
> High Risk PRs Require 2 approvals

<!-----------------------------------------------------------------------------
Outline the scope of your changes and the risk associated with them. You must use your discretion as an engineer to determine the potential impact of your changes.

WARNING: If your PR introduces a new on-chain transaction or modifies an existing one, please add the "High-Risk" label to this PR and ask for 2 reviewers to approve it before merging.

E.g. an upgrade to `hdwallet` or core state management would be considered higher risk, and might require a full regression test. UI or isolated view changes, or something behind a feature flag may have near zero risk. Small bug fixes might require testing isolated to the specific fix.
------------------------------------------------------------------------------>

> What protocols, transaction types or contract interactions might be affected by this PR?

Low - if we don't have a receive address in the quote, we have much, much bigger problems

## Testing

<!-----------------------------------------------------------------------------
We treat every PR to be merged with the same scrutiny as if we were merging directly to production.

Your PR will not be merged if you do not complete the sections below for our engineering and operations teams to test.
------------------------------------------------------------------------------>

- Do a THOR swap into any UTXO
- Ensure the displayed receive address doesn't change after the outbound Tx is broadcasted (in other words, it should always be the same from input to confirmed states)

### Engineering

<!-----------------------------------------------------------------------------
Include sufficient information here for an engineer to test your PR. This may include how to test locally, in a built environment, changes to infrastructure etc.
------------------------------------------------------------------------------>

- ^

### Operations

<!-----------------------------------------------------------------------------
If your changes have a user-facing impact, describe how a non-technical QA team can functionally test your changes in a preview environment.

If they are not user-facing please describe how to test for any regressions that may occur.
------------------------------------------------------------------------------>

- ^

## Screenshots (if applicable)

https://jam.dev/c/974a8b54-db38-4be6-af1e-fed43bc177b2

<!-- av pr metadata
This information is embedded by the av CLI when creating PRs to track the status of stacks when using Aviator. Please do not delete or edit this section of the PR.
```
{"parent":"develop","parentHead":"","trunk":"develop"}
```
-->
