### PR TITLE
fix: infinit rerender loop on remove liquidity

### DIFF
--- a/src/components/DeFi/components/AssetInput.tsx
+++ b/src/components/DeFi/components/AssetInput.tsx
@@ -73,6 +73,7 @@ export type AssetInputProps = {
   showFiatSkeleton?: boolean
   formControlProps?: FormControlProps
   accountSelectionDisabled?: boolean
+  revalidateOnValueChange?: boolean
 } & PropsWithChildren
 
 export const AssetInput: React.FC<AssetInputProps> = ({
@@ -99,6 +100,7 @@ export const AssetInput: React.FC<AssetInputProps> = ({
   showFiatSkeleton,
   formControlProps,
   accountSelectionDisabled,
+  revalidateOnValueChange = true,
 }) => {
   const {
     number: { localeParts },
@@ -142,9 +144,12 @@ export const AssetInput: React.FC<AssetInputProps> = ({
       // This fires anytime value changes including setting it on max click
       // Store the value in a ref to send when we actually want the onChange to fire
       amountRef.current = values.value
-      handleChange()
+
+      if (revalidateOnValueChange) {
+        handleChange()
+      }
     },
-    [handleChange],
+    [handleChange, revalidateOnValueChange],
   )
 
   return (

--- a/src/pages/ThorChainLP/components/RemoveLiquidity/RemoveLiquidityInput.tsx
+++ b/src/pages/ThorChainLP/components/RemoveLiquidity/RemoveLiquidityInput.tsx
@@ -761,6 +761,7 @@ export const RemoveLiquidityInput: React.FC<RemoveLiquidityInputProps> = ({
               accountId={accountId}
               cryptoAmount={cryptoAmount}
               onChange={handleRemoveLiquidityInputChange}
+              revalidateOnValueChange={false}
               fiatAmount={fiatAmount}
               showFiatAmount
               assetId={asset.assetId}


### PR DESCRIPTION
## Description
[This guy](https://github.com/shapeshift/web/commit/0e553d83624d68578e9fe947bc3fe369d761c232#diff-225bad65687ba44270edf5d0d7e3b1edb8d8fcc7a17f263552c5d608f0f47001R145-R147) introduced an infinit rerender loop on LP withdrawals

As it fire the `handleChange` everytime the value changes (including the initial render), it ends up infinitely changing the value again and then rerendering and 💥 

This PR act as a quickwin to make liquidity withdrawals great again but it might be worth investigating how to refactor this part in `RemoveLiquidityInput`, like maybe we could avoid the effect or find a different pattern

## Pull Request Type

- [x] :bug: Bug fix (Non-breaking Change: Fixes an issue)
- [ ] :hammer_and_wrench: Chore (Non-breaking Change: Doc updates, pkg upgrades, typos, etc..)
- [ ] :nail_care: New Feature (Breaking/Non-breaking Change)

## Issue (if applicable)

closes #7181

## Risk
High as LP withdrawals could be strange but it's a hotfix so it should do the contrary

## Testing
- Try to withdraw some LP like AVAX/RUNE pool

### Engineering
n/a
<!-----------------------------------------------------------------------------
Include sufficient information here for an engineer to test your PR. This may include how to test locally, in a built environment, changes to infrastructure etc.
------------------------------------------------------------------------------>

### Operations
n/a
<!-----------------------------------------------------------------------------
If your changes have a user-facing impact, describe how a non-technical QA team can functionally test your changes in a preview environment.

If they are not user-facing please describe how to test for any regressions that may occur.
------------------------------------------------------------------------------>

## Screenshots (if applicable)

## Develop without this [guy](https://github.com/shapeshift/web/commit/0e553d83624d68578e9fe947bc3fe369d761c232#diff-225bad65687ba44270edf5d0d7e3b1edb8d8fcc7a17f263552c5d608f0f47001R145-R147)
![image](https://github.com/shapeshift/web/assets/14963751/604a236f-d768-4d08-917f-4cfd9856599a)

## This branch:
![image](https://github.com/shapeshift/web/assets/14963751/e31ba479-5c32-4298-b269-01fcba8118af)
![image](https://github.com/shapeshift/web/assets/14963751/ffb65a54-2210-486e-8bfd-ac792b21dff6)



