### PR TITLE
fix: dont display other wallet accounts in tx history degraded popover

### DIFF
--- a/src/state/slices/txHistorySlice/selectors.ts
+++ b/src/state/slices/txHistorySlice/selectors.ts
@@ -24,7 +24,7 @@ import {
 } from 'state/selectors'
 
 import { selectAssets } from '../assetsSlice/selectors'
-import { selectWalletAccountIds } from '../common-selectors'
+import { selectWalletAccountIds, selectWalletEnabledAccountIds } from '../common-selectors'
 import { selectPortfolioAccountMetadata } from '../portfolioSlice/selectors'
 import type { Tx, TxId, TxIdsByAccountIdAssetId } from './txHistorySlice'
 
@@ -314,9 +314,11 @@ export const selectIsTxHistoryAvailableByFilter = createCachedSelector(
 
 export const selectErroredTxHistoryAccounts = createDeepEqualOutputSelector(
   (state: ReduxState) => state.txHistory.hydrationMeta,
-  hydrationMeta => {
+  selectWalletEnabledAccountIds,
+  (hydrationMeta, walletEnabledAccountIds) => {
     return Object.entries(hydrationMeta)
       .filter(([_accountId, hydrationMetaForAccountId]) => hydrationMetaForAccountId?.isErrored)
       .map(([accountId, _hydrationMetaForAccountId]) => accountId)
+      .filter(accountId => walletEnabledAccountIds.includes(accountId))
   },
 )


### PR DESCRIPTION
## Description

Fixes `ErroredTxHistoryAccounts` popover displaying previously connected accounts.

## Pull Request Type

- [x] :bug: Bug fix (Non-breaking Change: Fixes an issue)
- [ ] :hammer_and_wrench: Chore (Non-breaking Change: Doc updates, pkg upgrades, typos, etc..)
- [ ] :nail_care: New Feature (Breaking/Non-breaking Change)

## Issue (if applicable)

<!-----------------------------------------------------------------------------
If applicable, please link to the github issue and put `closes #XXXX` in your comment to auto-close the issue that your PR fixes.
------------------------------------------------------------------------------>

closes #6971

## Risk
> High Risk PRs Require 2 approvals

Low risk - a display concern only.

> What protocols, transaction types or contract interactions might be affected by this PR?

## Testing

As this issue is only visible while one of our nodes is degraded, testing best done locally by engineers with monkey patch (see PR comment for exactly how).

### Engineering

<!-----------------------------------------------------------------------------
Include sufficient information here for an engineer to test your PR. This may include how to test locally, in a built environment, changes to infrastructure etc.
------------------------------------------------------------------------------>

### Operations

<!-----------------------------------------------------------------------------
If your changes have a user-facing impact, describe how a non-technical QA team can functionally test your changes in a preview environment.

If they are not user-facing please describe how to test for any regressions that may occur.
------------------------------------------------------------------------------>

## Screenshots (if applicable)

Monkey patch was applied to display all accounts as errored.

Issue reproduced with money patch:
![image](https://github.com/shapeshift/web/assets/125113430/eba5e55f-d564-43d5-9492-bfa391111d96)

Fix with monkey patch:
![image](https://github.com/shapeshift/web/assets/125113430/91547268-f22c-4f04-92d1-184af907383a)
