### PR TITLE
fix: first load lp deposit approval

### DIFF
--- a/src/pages/ThorChainLP/components/AddLiquidity/AddLiquidityInput.tsx
+++ b/src/pages/ThorChainLP/components/AddLiquidity/AddLiquidityInput.tsx
@@ -1550,7 +1550,7 @@ export const AddLiquidityInput: React.FC<AddLiquidityInputProps> = ({
               !hasEnoughAssetBalance ||
               !hasEnoughRuneBalance ||
               isApprovalTxPending ||
-              (isSweepNeededEnabled && isSweepNeeded === undefined) ||
+              (isSweepNeededEnabled && isSweepNeeded === undefined && !isApprovalRequired) ||
               isSweepNeededError ||
               isEstimatedPoolAssetFeesDataError ||
               isEstimatedRuneFeesDataError ||
@@ -1568,7 +1568,7 @@ export const AddLiquidityInput: React.FC<AddLiquidityInputProps> = ({
               isSmartContractAccountAddressLoading ||
               isAllowanceDataLoading ||
               isApprovalTxPending ||
-              (isSweepNeeded === undefined && isSweepNeededLoading) ||
+              (isSweepNeeded === undefined && isSweepNeededLoading && !isApprovalRequired) ||
               (runeTxFeeCryptoBaseUnit === undefined && isEstimatedPoolAssetFeesDataLoading)
             }
             onClick={handleDepositSubmit}


### PR DESCRIPTION
## Description

Fixes the "Approve" button being greyed out for LP deposits on first quote request.

<img width="321" alt="Screenshot 2024-06-20 at 1 45 11 PM" src="https://github.com/shapeshift/web/assets/97164662/9b20e17c-db45-4241-a565-8bf8b4fb313e">

A 2-liner fix with a slightly longer explantation on what was going on:

We are skipping the query to get `estimatedPoolAssetFeesData` if an approval was required (makes sense - wait until we need to do the query before making it).

https://github.com/shapeshift/web/blob/481de89af6188c1642a95826e06f1c8e3b370fef/src/pages/ThorChainLP/components/AddLiquidity/AddLiquidityInput.tsx#L528-L532

This means that `isSweepNeeded` is (rightly) equal to `undefined` when an approval is required on first quote request, as on first load we do not have a value for `txFeeCryptoBaseUnit` (we haven't yet done a request to get `estimatedPoolAssetFeesData.txFeeCryptoBaseUnit`), and so the `isGetSweepNeededInput` check fails, causing `useIsSweepNeededQuery` to return `undefined`.

This PR fixes the issue by only caring about the `isSweepNeededEnabled && isSweepNeeded` button conditions if no approval is required (and so we are going to do a deposit).

## Pull Request Type

- [x] :bug: Bug fix (Non-breaking Change: Fixes an issue)
- [ ] :hammer_and_wrench: Chore (Non-breaking Change: Doc updates, pkg upgrades, typos, etc..)
- [ ] :nail_care: New Feature (Breaking/Non-breaking Change)

## Issue (if applicable)

Closes https://github.com/shapeshift/web/issues/7189

## Risk

Small

> What protocols, transaction types or contract interactions might be affected by this PR?

LP deposits, specifically those requiring an approval.

## Testing

For an LP deposit requiring an approval, open the deposit flow, select the asset, and then request a quote for an amount that requires an approval.

The first request here should no longer fail.,

### Engineering

☝️

### Operations

☝️

## Screenshots (if applicable)

Also see Max's Jam is this not working in production: https://jam.dev/c/daa30016-7b8a-43c2-85a6-4b3ef729dd1c