### PR TITLE
chore: attach unique user id for sentry support assistance

### DIFF
--- a/src/pages/Flags/Debugging.tsx
+++ b/src/pages/Flags/Debugging.tsx
@@ -1,6 +1,7 @@
 import { Button, Card, CardBody, CardFooter, CardHeader, Heading, Stack } from '@chakra-ui/react'
+import { getCurrentScope } from '@sentry/react'
 import axios from 'axios'
-import { useCallback, useEffect, useState } from 'react'
+import { useCallback, useEffect, useMemo, useState } from 'react'
 import { isMobile } from 'react-device-detect'
 import { Row } from 'components/Row/Row'
 import { showDeveloperModal } from 'context/WalletProvider/MobileWallet/mobileMessageHandlers'
@@ -39,6 +40,10 @@ export const Debugging = () => {
     })()
   }, [])
 
+  const sentryUserId = useMemo(() => {
+    return getCurrentScope().getUser()?.id
+  }, [])
+
   return (
     <Stack my={8} spacing={4} flex={1}>
       <Card>
@@ -65,6 +70,14 @@ export const Debugging = () => {
               <Row alignItems='center'>
                 <Row.Label>Latest tag</Row.Label>
                 <Row.Value fontFamily={'monospace'}>{buildMetadata.latestTag}</Row.Value>
+              </Row>
+            </>
+          )}
+          {sentryUserId && (
+            <>
+              <Row alignItems='center'>
+                <Row.Label>Sentry user ID</Row.Label>
+                <Row.Value fontFamily={'monospace'}>{sentryUserId}</Row.Value>
               </Row>
             </>
           )}


### PR DESCRIPTION
## Description

Creates and stores a unique anonymous user ID to allow ops to find events generated by a specific user.

Initially the built-in session ID `sid` from sentry was used however this renews every page reload, so a user with an application crash would be reporting a different `sid` to the one which experienced the crash.

## Pull Request Type

- [ ] :bug: Bug fix (Non-breaking Change: Fixes an issue)
- [x] :hammer_and_wrench: Chore (Non-breaking Change: Doc updates, pkg upgrades, typos, etc..)
- [ ] :nail_care: New Feature (Breaking/Non-breaking Change)

## Issue (if applicable)

<!-----------------------------------------------------------------------------
If applicable, please link to the github issue and put `closes #XXXX` in your comment to auto-close the issue that your PR fixes.
------------------------------------------------------------------------------>

closes #6843

## Risk
> High Risk PRs Require 2 approvals

Very low risk.

> What protocols, transaction types or contract interactions might be affected by this PR?

## Testing

* Check user ID is presented in the "Debug" section in settings, next to feature flags (non-local envs only)
* Check a new user ID is generated when totally clearing the cache (e.g via incognito mode)
* Check any errors you experience are available in sentry by searching `user.id:your-user-id-here`, in the sentry "Discover" page

### Engineering

Monkey patch available to test locally, see comments below.

### Operations

<!-----------------------------------------------------------------------------
If your changes have a user-facing impact, describe how a non-technical QA team can functionally test your changes in a preview environment.

If they are not user-facing please describe how to test for any regressions that may occur.
------------------------------------------------------------------------------>

## Screenshots (if applicable)

Step by step example of causing an app crash, grabbing the user ID and finding it in sentry:

https://github.com/shapeshift/web/assets/125113430/5b6c72f2-aad6-43bb-b40e-af7d35c05033

