### PR TITLE
fix: claim cooldown spacing

### DIFF
--- a/src/pages/RFOX/components/Claim/ClaimRow.tsx
+++ b/src/pages/RFOX/components/Claim/ClaimRow.tsx
@@ -145,7 +145,7 @@ export const ClaimRow: FC<ClaimRowProps> = ({
               color={status === ClaimStatus.Available ? 'green.300' : 'yellow.300'}
               align={'end'}
             >
-              {statusText}
+              {onClaimButtonClick ? statusText : status}
             </RawText>
             <RawText fontSize='xl' fontWeight='bold' color='white' align={'end'}>
               <Amount.Crypto value={amountCryptoPrecision} symbol={stakingAssetSymbol ?? ''} />


### PR DESCRIPTION
## Description

Fixes the claim cooldown text spacing issue by only showing it outside the tooltip when rendered inside the "Claims" component.

## Pull Request Type

- [ ] :bug: Bug fix (Non-breaking Change: Fixes an issue)
- [x] :hammer_and_wrench: Chore (Non-breaking Change: Doc updates, pkg upgrades, typos, etc..)
- [ ] :nail_care: New Feature (Breaking/Non-breaking Change)

## Issue (if applicable)

Closes https://github.com/shapeshift/web/issues/7219

## Risk

Small

> What protocols, transaction types or contract interactions might be affected by this PR?

None

## Testing

See screenshot below.

- Claim status should be shown in the Claim tab, with the cooldown shown as a tooltip
- Claim cooldown should be shown in the Claims component

### Engineering

☝️

### Operations

☝️

## Screenshots (if applicable)

<img width="1044" alt="Screenshot 2024-06-25 at 4 52 30 PM" src="https://github.com/shapeshift/web/assets/97164662/35259dda-a29e-4d90-ba70-0b30031019dd">