### PR TITLE
chore: refactor rFOX hooks to consume reactive queries appropriately

### DIFF
--- a/src/pages/RFOX/hooks/useCurrentEpochRewardsQuery.ts
+++ b/src/pages/RFOX/hooks/useCurrentEpochRewardsQuery.ts
@@ -1,5 +1,6 @@
-import { skipToken, useQuery, useQueryClient } from '@tanstack/react-query'
-import { useMemo } from 'react'
+import type { UseQueryResult } from '@tanstack/react-query'
+import { useQueries } from '@tanstack/react-query'
+import { useCallback } from 'react'
 
 import type { EpochMetadata } from '../types'
 import { calcEpochRewardForAccountRuneBaseUnit } from './helpers'
@@ -17,63 +18,72 @@ export const useCurrentEpochRewardsQuery = ({
   stakingAssetAccountAddress,
   epochMetadata,
 }: UseCurrentEpochRewardsQueryProps) => {
-  const queryClient = useQueryClient()
+  const combineResults = useCallback(
+    (results: [UseQueryResult<bigint, Error>, UseQueryResult<bigint, Error>]) => {
+      const isLoading = results.some(result => result.isLoading)
+      const isPending = results.some(result => result.isError || result.isLoading)
+      const isError = results.some(result => result.isError)
 
-  const queryKey = useMemo(
-    () => [
-      'lifetimeRewards',
+      if (isLoading || isPending) {
+        return {
+          data: undefined,
+          isLoading: true,
+          isError: false,
+        }
+      }
+
+      if (isError) {
+        return {
+          data: undefined,
+          isLoading: false,
+          isError: true,
+        }
+      }
+
+      const [previousEpochEarned, currentEpochEarned] = results.map(result => result.data)
+
+      const epochEarningsForAccount =
+        (currentEpochEarned as bigint) - (previousEpochEarned as bigint)
+
+      const epochRewardRuneBaseUnit = calcEpochRewardForAccountRuneBaseUnit(
+        epochEarningsForAccount,
+        epochMetadata,
+      )
+
+      return {
+        data: epochRewardRuneBaseUnit,
+        isLoading: false,
+        isError: false,
+      }
+    },
+    [epochMetadata],
+  )
+
+  const combinedQueries = useQueries({
+    queries: [
       {
-        stakingAssetAccountAddress,
+        queryKey: getEarnedQueryKey({
+          stakingAssetAccountAddress,
+          blockNumber: epochMetadata.startBlockNumber - 1n,
+        }),
+        queryFn: getEarnedQueryFn({
+          stakingAssetAccountAddress,
+          blockNumber: epochMetadata.startBlockNumber - 1n,
+        }),
+      },
+      {
+        queryKey: getEarnedQueryKey({
+          stakingAssetAccountAddress,
+          blockNumber: undefined,
+        }),
+        queryFn: getEarnedQueryFn({
+          stakingAssetAccountAddress,
+          blockNumber: undefined,
+        }),
       },
     ],
-    [stakingAssetAccountAddress],
-  )
-
-  const queryFn = useMemo(
-    () =>
-      stakingAssetAccountAddress
-        ? async () => {
-            const [previousEpochEarned, currentEpochEarned] = await Promise.all([
-              queryClient.fetchQuery({
-                queryKey: getEarnedQueryKey({
-                  stakingAssetAccountAddress,
-                  blockNumber: epochMetadata.startBlockNumber - 1n,
-                }),
-                queryFn: getEarnedQueryFn({
-                  stakingAssetAccountAddress,
-                  blockNumber: epochMetadata.startBlockNumber - 1n,
-                }),
-              }),
-              queryClient.fetchQuery({
-                queryKey: getEarnedQueryKey({
-                  stakingAssetAccountAddress,
-                  blockNumber: undefined,
-                }),
-                queryFn: getEarnedQueryFn({
-                  stakingAssetAccountAddress,
-                  blockNumber: undefined,
-                }),
-              }),
-            ])
-
-            const epochEarningsForAccount =
-              (currentEpochEarned as bigint) - (previousEpochEarned as bigint)
-
-            const epochRewardRuneBaseUnit = calcEpochRewardForAccountRuneBaseUnit(
-              epochEarningsForAccount,
-              epochMetadata,
-            )
-
-            return epochRewardRuneBaseUnit
-          }
-        : skipToken,
-    [epochMetadata, queryClient, stakingAssetAccountAddress],
-  )
-
-  const epochEarnedHistoryQuery = useQuery({
-    queryKey,
-    queryFn,
+    combine: combineResults,
   })
 
-  return epochEarnedHistoryQuery
+  return combinedQueries
 }

--- a/src/pages/RFOX/hooks/useCurrentEpochRewardsQuery.ts
+++ b/src/pages/RFOX/hooks/useCurrentEpochRewardsQuery.ts
@@ -70,6 +70,7 @@ export const useCurrentEpochRewardsQuery = ({
           stakingAssetAccountAddress,
           blockNumber: epochMetadata.startBlockNumber - 1n,
         }),
+        staleTime: 60 * 1000, // 1 minute in milliseconds
       },
       {
         queryKey: getEarnedQueryKey({
@@ -80,6 +81,7 @@ export const useCurrentEpochRewardsQuery = ({
           stakingAssetAccountAddress,
           blockNumber: undefined,
         }),
+        staleTime: 60 * 1000, // 1 minute in milliseconds
       },
     ],
     combine: combineResults,

--- a/src/pages/RFOX/hooks/useLifetimeRewardsQuery.ts
+++ b/src/pages/RFOX/hooks/useLifetimeRewardsQuery.ts
@@ -31,6 +31,7 @@ export const useLifetimeRewardsQuery = ({
     () =>
       stakingAssetAccountAddress
         ? async () => {
+            // using queryClient.fetchQuery here is ok because historical epoch metadata does not change so reactivity is not needed
             const epochHistory = await queryClient.fetchQuery({
               queryKey: getEpochHistoryQueryKey(),
               queryFn: epochHistoryQueryFn,
@@ -38,6 +39,7 @@ export const useLifetimeRewardsQuery = ({
 
             const earnedByEpoch = await Promise.all(
               epochHistory.map(async epochMetadata => {
+                // using queryClient.fetchQuery here is ok because historical earnings do not change so reactivity is not needed
                 const earned = await queryClient.fetchQuery({
                   queryKey: getEarnedQueryKey({
                     stakingAssetAccountAddress,

--- a/src/react-queries/helpers.ts
+++ b/src/react-queries/helpers.ts
@@ -1,0 +1,62 @@
+import type { UseQueryResult } from '@tanstack/react-query'
+
+/**
+ * Merges react-query outputs into a into a single output. Use with `useQueries` and `combine`.
+ *
+ * @param queryOutputs The react-query `useQueries` outputs to merge.
+ * @param combineResults The function to combine the result data of the queries.
+ * @returns The merged react-query output.
+ */
+export const mergeQueryOutputs = <QueryOutputType, QueryErrorType, MergedOutputType>(
+  queryOutputs: UseQueryResult<QueryOutputType, QueryErrorType>[],
+  combineResults: (results: QueryOutputType[]) => MergedOutputType,
+): UseQueryResult<MergedOutputType, QueryErrorType[]> => {
+  const isLoading = queryOutputs.some(result => result.isLoading)
+  const isPending = queryOutputs.some(result => result.isError || result.isLoading)
+  const isError = queryOutputs.some(result => result.isError)
+  const isLoadingError = queryOutputs.some(result => result.isLoadingError)
+  const isRefetchError = queryOutputs.some(result => result.isRefetchError)
+  const isSuccess = queryOutputs.every(result => result.isSuccess)
+
+  const errors = queryOutputs.reduce<QueryErrorType[]>((a, v) => {
+    if (v.error) {
+      a.push(v.error)
+    }
+
+    return a
+  }, [])
+
+  const error = errors.length > 0 ? errors : null
+
+  const status = (() => {
+    if (isLoading || isPending) return 'loading'
+    if (isError) return 'error'
+    return 'success'
+  })()
+
+  if (isLoading || isPending || isError) {
+    return {
+      data: undefined,
+      error,
+      isLoading,
+      isPending,
+      isError,
+      isLoadingError,
+      isRefetchError,
+      isSuccess,
+      status,
+    } as UseQueryResult<MergedOutputType, QueryErrorType[]>
+  }
+
+  return {
+    data: combineResults(queryOutputs.map(result => result.data as QueryOutputType)),
+    error: null,
+    isLoading,
+    isPending,
+    isError,
+    isLoadingError,
+    isRefetchError,
+    isSuccess,
+    status,
+  } as UseQueryResult<MergedOutputType, QueryErrorType[]>
+}


### PR DESCRIPTION
## Description

Refactors rFOX hooks (where required) to consume other queries using `useQueries` along with `combine` to ensure the result is reactive and will respond to changes upstream where appropriate. Refer to #7171 to details of the issue.

## Pull Request Type

- [ ] :bug: Bug fix (Non-breaking Change: Fixes an issue)
- [x] :hammer_and_wrench: Chore (Non-breaking Change: Doc updates, pkg upgrades, typos, etc..)
- [ ] :nail_care: New Feature (Breaking/Non-breaking Change)

## Issue (if applicable)

<!-----------------------------------------------------------------------------
If applicable, please link to the github issue and put `closes #XXXX` in your comment to auto-close the issue that your PR fixes.
------------------------------------------------------------------------------>

closes #7171

## Risk
> High Risk PRs Require 2 approvals

Low risk, actually fixes a theoretical issue where the data fetch by these hooks would no trigger when upstream dependencies change.

> What protocols, transaction types or contract interactions might be affected by this PR?

## Testing

Not possible without a monkey path or several days staring at the page (see below) - engineers please sanity check as you see fit.

Only affects `useCurrentEpochRewardsQuery` which fetches the current rewards for the user. Ensure the current rewards are appearing correctly, and that staking rewards update after changed staking balance in another tab - you'll need to wait for the `staleTime` of 1 minute, and then several days for the epoch reward to actually accumulate and change (please dont do this 💀).

### Engineering

<!-----------------------------------------------------------------------------
Include sufficient information here for an engineer to test your PR. This may include how to test locally, in a built environment, changes to infrastructure etc.
------------------------------------------------------------------------------>

### Operations

<!-----------------------------------------------------------------------------
If your changes have a user-facing impact, describe how a non-technical QA team can functionally test your changes in a preview environment.

If they are not user-facing please describe how to test for any regressions that may occur.
------------------------------------------------------------------------------>

## Screenshots (if applicable)
