### PR TITLE
fix: language selector on very small mobiles and homepage margin

### DIFF
--- a/src/pages/ConnectWallet/ConnectWallet.tsx
+++ b/src/pages/ConnectWallet/ConnectWallet.tsx
@@ -51,12 +51,16 @@ const containerPt = { base: 8, lg: 0 }
 const flexAlign = { base: 'center', lg: 'flex-start' }
 const flexRightAlign = { base: 'center', lg: 'flex-end' }
 const textAlign: ResponsiveValue<any> = { base: 'center', lg: 'left' }
-const margin = { base: 0, lg: '130px' }
+const margin = { base: 0, lg: 'auto' }
 const spacing = { base: 6, lg: 8 }
 const display = { base: 'none', lg: 'flex' }
 const width = { base: '100%', lg: 'auto' }
 const maxWidth = { base: '100%', lg: '500px' }
 const hover = { color: 'white' }
+const langSelectorMarginTop = {
+  base: -3,
+  md: 6,
+}
 
 const metamaskIcon = <MetaMaskIcon />
 
@@ -162,13 +166,8 @@ export const ConnectWallet = () => {
           p={6}
           pt={containerPt}
         >
-          <Flex
-            position='absolute'
-            // Account for iOS UI elements such as the Notch or Dynamic Island for top positioning
-            top='calc(var(--chakra-space-6) + env(safe-area-inset-top))'
-            right={6}
-          >
-            <LanguageSelector size='sm' />
+          <Flex justifyContent='flex-end' marginTop={langSelectorMarginTop} width='100%' mb={3}>
+            <LanguageSelector width='auto' size='sm' />
           </Flex>
           <Stack
             alignItems='center'


### PR DESCRIPTION
## Description
- Fixed the very small mobile language selector going over the text, it might add a scroll bar but on very small mobile I feel like it's a nice trade off and the scrollbar isn't so big
- Also changed the margin of the login component

<!-- Please describe your changes -->

## Pull Request Type

- [x] :bug: Bug fix (Non-breaking Change: Fixes an issue)
- [ ] :hammer_and_wrench: Chore (Non-breaking Change: Doc updates, pkg upgrades, typos, etc..)
- [ ] :nail_care: New Feature (Breaking/Non-breaking Change)

## Issue (if applicable)

<!-----------------------------------------------------------------------------
If applicable, please link to the github issue and put `closes #XXXX` in your comment to auto-close the issue that your PR fixes.
------------------------------------------------------------------------------>

closes #7062

## Risk
Low risk

## Testing
- Inspect and open the homepage with a really small mobile view like `iPhone SE`, the lang selector should not be over the text anymore
- The margin of the login component should be equal from left to right
<!-----------------------------------------------------------------------------
We treat every PR to be merged with the same scrutiny as if we were merging directly to production.

Your PR will not be merged if you do not complete the sections below for our engineering and operations teams to test.
------------------------------------------------------------------------------>

### Engineering
n/a

<!-----------------------------------------------------------------------------
Include sufficient information here for an engineer to test your PR. This may include how to test locally, in a built environment, changes to infrastructure etc.
------------------------------------------------------------------------------>

### Operations
n/a
<!-----------------------------------------------------------------------------
If your changes have a user-facing impact, describe how a non-technical QA team can functionally test your changes in a preview environment.

If they are not user-facing please describe how to test for any regressions that may occur.
------------------------------------------------------------------------------>

## Screenshots (if applicable)
![image](https://github.com/shapeshift/web/assets/14963751/cec0d14f-c794-41f4-bf8a-894ca2a8ebed)
<img width="309" alt="image" src="https://github.com/shapeshift/web/assets/14963751/3781842e-3482-4648-a254-21468e0c8709">
