### PR TITLE
chore: de-risk RFOX_FIRST_EPOCH_START_TIMESTAMP todo

### DIFF
--- a/src/pages/RFOX/hooks/useEpochHistoryQuery.ts
+++ b/src/pages/RFOX/hooks/useEpochHistoryQuery.ts
@@ -17,7 +17,7 @@ type EpochHistoryQueryKey = ['epochHistory']
 // and the correct one after launch (in case we don't action this todo it for any reason).
 // const RFOX_FIRST_EPOCH_START_TIMESTAMP = BigInt(dayjs('2024-07-01T00:00:00Z').unix())
 const RFOX_FIRST_EPOCH_START_TIMESTAMP = BigInt(
-  Math.min(dayjs().subtract(1, 'month').unix(), dayjs('2024-07-01T00:00:00Z').unix()),
+  Math.min(dayjs().startOf('month').unix(), dayjs('2024-07-01T00:00:00Z').unix()),
 )
 
 // The query key excludes the current timestamp so we don't inadvertently end up with stupid things like reactively fetching every second etc.

--- a/src/pages/RFOX/hooks/useEpochHistoryQuery.ts
+++ b/src/pages/RFOX/hooks/useEpochHistoryQuery.ts
@@ -12,9 +12,13 @@ import {
 
 type EpochHistoryQueryKey = ['epochHistory']
 
-// TODO(gomes): revert me -  this obviously won't work until first rewards epoch start
+// TODO: Clean up by removing the Math.min after the first epoch starts.
+// This is a temporary hack to ensure we have an epoch to test with prior to rFOX launch,
+// and the correct one after launch (in case we don't action this todo it for any reason).
 // const RFOX_FIRST_EPOCH_START_TIMESTAMP = BigInt(dayjs('2024-07-01T00:00:00Z').unix())
-const RFOX_FIRST_EPOCH_START_TIMESTAMP = BigInt(dayjs().subtract(1, 'month').unix())
+const RFOX_FIRST_EPOCH_START_TIMESTAMP = BigInt(
+  Math.min(dayjs().subtract(1, 'month').unix(), dayjs('2024-07-01T00:00:00Z').unix()),
+)
 
 // The query key excludes the current timestamp so we don't inadvertently end up with stupid things like reactively fetching every second etc.
 // Instead we will rely on staleTime to refetch at a sensible interval.


### PR DESCRIPTION
## Description

Adds simple logic to ensure that #7224 does not result in a production issue if it doesn't get actioned exactly on time for any reason.

The logic is as follows:
* If we are testing rFOX staking prior to `2024-07-01T00:00:00Z`, we us the start of the current month for the first epoch start date.
* If we are post-launch, the application will use the real start date of `2024-07-01T00:00:00Z`

This allow us to to be as late as we want in actioning #7224 without consequences.

## Pull Request Type

- [ ] :bug: Bug fix (Non-breaking Change: Fixes an issue)
- [x] :hammer_and_wrench: Chore (Non-breaking Change: Doc updates, pkg upgrades, typos, etc..)
- [ ] :nail_care: New Feature (Breaking/Non-breaking Change)

## Issue (if applicable)


realtes to #7224

## Risk
> High Risk PRs Require 2 approvals

Low risk, in fact it reduces risk of the current implementation.

> What protocols, transaction types or contract interactions might be affected by this PR?

## Testing

Engineers test this with a monkey patch.

### Engineering

<!-----------------------------------------------------------------------------
Include sufficient information here for an engineer to test your PR. This may include how to test locally, in a built environment, changes to infrastructure etc.
------------------------------------------------------------------------------>

### Operations

<!-----------------------------------------------------------------------------
If your changes have a user-facing impact, describe how a non-technical QA team can functionally test your changes in a preview environment.

If they are not user-facing please describe how to test for any regressions that may occur.
------------------------------------------------------------------------------>

## Screenshots (if applicable)
