### PR TITLE
feat: infoAcknowledgement for rFOX bridge

### DIFF
--- a/src/assets/translations/en/main.json
+++ b/src/assets/translations/en/main.json
@@ -163,7 +163,8 @@
       "sortedDesc": "Sorted descending",
       "expandRow": "Expand Row"
     },
-    "featureDisabled": "This feature is temporarily disabled."
+    "featureDisabled": "This feature is temporarily disabled.",
+    "yes": "Yes"
   },
   "consentBanner": {
     "body": {

--- a/src/components/Acknowledgement/Acknowledgement.tsx
+++ b/src/components/Acknowledgement/Acknowledgement.tsx
@@ -85,7 +85,8 @@ type AcknowledgementProps = {
   onAcknowledge: (() => void) | undefined
   shouldShowAcknowledgement: boolean
   setShouldShowAcknowledgement: (shouldShow: boolean) => void
-  colorScheme?: ThemeTypings['colorSchemes']
+  buttonColorScheme?: ThemeTypings['colorSchemes']
+  iconColorScheme?: ThemeTypings['colorSchemes']
   buttonTranslation?: string | [string, InterpolationOptions]
   icon?: ComponentWithAs<'svg', IconProps>
   disableButton?: boolean
@@ -106,7 +107,8 @@ export const Acknowledgement = ({
   onAcknowledge,
   shouldShowAcknowledgement,
   setShouldShowAcknowledgement,
-  colorScheme = 'red',
+  buttonColorScheme = 'red',
+  iconColorScheme = 'red',
   buttonTranslation,
   disableButton,
   icon: CustomIcon,
@@ -114,7 +116,10 @@ export const Acknowledgement = ({
   const translate = useTranslate()
   const [isShowing, setIsShowing] = useState(false)
 
-  const understandHoverProps = useMemo(() => ({ bg: `${colorScheme}.600` }), [colorScheme])
+  const understandHoverProps = useMemo(
+    () => ({ bg: `${buttonColorScheme}.600` }),
+    [buttonColorScheme],
+  )
 
   const handleAcknowledge = useCallback(() => {
     if (!onAcknowledge) return
@@ -162,12 +167,11 @@ export const Acknowledgement = ({
               onAnimationComplete={handleAnimationComplete}
             >
               {CustomIcon ? (
-                <CustomIcon color={`${colorScheme}.500`} boxSize='80px' mb={4} />
+                <CustomIcon color={`${iconColorScheme}.500`} boxSize='80px' mb={4} />
               ) : (
-                <Box as={FiAlertTriangle} color={`${colorScheme}.500`} size='80px' mb={4} />
+                <Box as={FiAlertTriangle} color={`${iconColorScheme}.500`} size='80px' mb={4} />
               )}
               <Text
-                colorScheme={colorScheme}
                 translation={'warningAcknowledgement.attention'}
                 fontWeight='semibold'
                 fontSize='2xl'
@@ -185,7 +189,7 @@ export const Acknowledgement = ({
               <Button
                 size='lg'
                 mb={2}
-                colorScheme={colorScheme}
+                colorScheme={buttonColorScheme}
                 width='full'
                 onClick={handleAcknowledge}
                 isDisabled={disableButton}
@@ -213,7 +217,10 @@ export const Acknowledgement = ({
 }
 
 export const WarningAcknowledgement = (props: AcknowledgementProps) =>
-  Acknowledgement({ ...props, colorScheme: 'red' })
+  Acknowledgement({ ...props, buttonColorScheme: 'red', iconColorScheme: 'red' })
+
+export const InfoAcknowledgement = (props: AcknowledgementProps) =>
+  Acknowledgement({ ...props, buttonColorScheme: 'blue', iconColorScheme: 'yellow' })
 
 export const StreamingAcknowledgement = ({
   estimatedTimeSeconds,
@@ -224,7 +231,7 @@ export const StreamingAcknowledgement = ({
   return (
     <Acknowledgement
       {...restProps}
-      colorScheme='blue'
+      buttonColorScheme='blue'
       buttonTranslation='common.continue'
       message={translate('streamingAcknowledgement.description', {
         estimatedTimeSeconds,

--- a/src/pages/RFOX/components/Stake/StakeInput.tsx
+++ b/src/pages/RFOX/components/Stake/StakeInput.tsx
@@ -385,6 +385,7 @@ export const StakeInput: React.FC<StakeInputProps & StakeRouteProps> = ({
         onAcknowledge={handleSubmit}
         shouldShowAcknowledgement={showWarning}
         setShouldShowAcknowledgement={setShowWarning}
+        buttonTranslation={'common.yes'}
       >
         <FormProvider {...methods}>
           <Stack>

--- a/src/pages/RFOX/components/Stake/StakeInput.tsx
+++ b/src/pages/RFOX/components/Stake/StakeInput.tsx
@@ -6,7 +6,7 @@ import { useCallback, useEffect, useMemo, useState } from 'react'
 import { FormProvider, useForm, useWatch } from 'react-hook-form'
 import { useTranslate } from 'react-polyglot'
 import { useHistory } from 'react-router'
-import { WarningAcknowledgement } from 'components/Acknowledgement/Acknowledgement'
+import { InfoAcknowledgement } from 'components/Acknowledgement/Acknowledgement'
 import { Amount } from 'components/Amount/Amount'
 import { TradeAssetSelect } from 'components/AssetSelection/AssetSelection'
 import { FormDivider } from 'components/FormDivider'
@@ -380,7 +380,7 @@ export const StakeInput: React.FC<StakeInputProps & StakeRouteProps> = ({
 
   return (
     <SlideTransition>
-      <WarningAcknowledgement
+      <InfoAcknowledgement
         message={warningAcknowledgementMessage}
         onAcknowledge={handleSubmit}
         shouldShowAcknowledgement={showWarning}
@@ -483,7 +483,7 @@ export const StakeInput: React.FC<StakeInputProps & StakeRouteProps> = ({
             </Button>
           </CardFooter>
         </FormProvider>
-      </WarningAcknowledgement>
+      </InfoAcknowledgement>
     </SlideTransition>
   )
 }


### PR DESCRIPTION
## Description

Improves the rFOX bridging acknowledgement by replacing "I understand" with "Yes", which makes more sense in the context on the warning.

Also adds (and uses) an `InfoAcknowledgement` component, which has a yellow (instead of red) icon, and a blue button.

Production:

<img width="269" alt="Screenshot 2024-06-26 at 12 32 51 PM" src="https://github.com/shapeshift/web/assets/97164662/d22f5d09-fad1-4b5c-b18a-6b40831908a3">

This PR:

<img width="279" alt="Screenshot 2024-06-26 at 12 48 39 PM" src="https://github.com/shapeshift/web/assets/97164662/076ebd54-2a15-4440-8495-e79eb65131c4">


## Pull Request Type

- [ ] :bug: Bug fix (Non-breaking Change: Fixes an issue)
- [ ] :hammer_and_wrench: Chore (Non-breaking Change: Doc updates, pkg upgrades, typos, etc..)
- [x] :nail_care: New Feature (Breaking/Non-breaking Change)

## Issue (if applicable)

None - fast-follow rFOX stuff.

## Risk

Small

> What protocols, transaction types or contract interactions might be affected by this PR?

None.

## Testing

Ensure `InfoAcknowledgement` shows as expected (as per the screenshot above) when bridging in the rFOX flow).

### Engineering

☝️

### Operations

☝️

## Screenshots (if applicable)

See above.