### PR TITLE
feat: make time of streaming acknowledgement human readable

### DIFF
--- a/src/assets/translations/en/main.json
+++ b/src/assets/translations/en/main.json
@@ -2370,7 +2370,7 @@
     "unsafeTrade": "This trade may be unsafe or below the recommended minimum size, proceed with caution."
   },
   "streamingAcknowledgement": {
-    "description": "This is a streaming swap, while you get a better price it can take up to %{estimatedTimeSeconds} to complete."
+    "description": "This is a streaming swap, while you get a better price it can take up to %{estimatedTimeHuman} to complete."
   },
   "watchlist": {
     "empty": {

--- a/src/assets/translations/en/main.json
+++ b/src/assets/translations/en/main.json
@@ -2370,7 +2370,7 @@
     "unsafeTrade": "This trade may be unsafe or below the recommended minimum size, proceed with caution."
   },
   "streamingAcknowledgement": {
-    "description": "This is a streaming swap, while you get a better price it can take up to %{estimatedTimeSeconds}s to complete."
+    "description": "This is a streaming swap, while you get a better price it can take up to %{estimatedTimeSeconds} to complete."
   },
   "watchlist": {
     "empty": {

--- a/src/components/Acknowledgement/Acknowledgement.tsx
+++ b/src/components/Acknowledgement/Acknowledgement.tsx
@@ -9,6 +9,7 @@ import { FiAlertTriangle } from 'react-icons/fi'
 import { useTranslate } from 'react-polyglot'
 import { StreamIcon } from 'components/Icons/Stream'
 import { RawText, Text } from 'components/Text'
+import { formatSecondsToDuration } from 'lib/utils/time'
 
 const initialProps = { opacity: 0 }
 const animateProps = { opacity: 1 }
@@ -93,7 +94,7 @@ type AcknowledgementProps = {
 }
 
 type StreamingAcknowledgementProps = Omit<AcknowledgementProps, 'message'> & {
-  estimatedTimeSeconds: string
+  estimatedTimeSeconds: number
 }
 type ArbitrumAcknowledgementProps = Omit<AcknowledgementProps, 'message'>
 
@@ -234,7 +235,7 @@ export const StreamingAcknowledgement = ({
       buttonColorScheme='blue'
       buttonTranslation='common.continue'
       message={translate('streamingAcknowledgement.description', {
-        estimatedTimeSeconds,
+        estimatedTimeSeconds: formatSecondsToDuration(estimatedTimeSeconds),
       })}
       icon={StreamIcon}
     />

--- a/src/components/Acknowledgement/Acknowledgement.tsx
+++ b/src/components/Acknowledgement/Acknowledgement.tsx
@@ -94,7 +94,7 @@ type AcknowledgementProps = {
 }
 
 type StreamingAcknowledgementProps = Omit<AcknowledgementProps, 'message'> & {
-  estimatedTimeSeconds: number
+  estimatedTimeMs: number
 }
 type ArbitrumAcknowledgementProps = Omit<AcknowledgementProps, 'message'>
 
@@ -224,7 +224,7 @@ export const InfoAcknowledgement = (props: AcknowledgementProps) =>
   Acknowledgement({ ...props, buttonColorScheme: 'blue', iconColorScheme: 'yellow' })
 
 export const StreamingAcknowledgement = ({
-  estimatedTimeSeconds,
+  estimatedTimeMs,
   ...restProps
 }: StreamingAcknowledgementProps) => {
   const translate = useTranslate()
@@ -235,7 +235,7 @@ export const StreamingAcknowledgement = ({
       buttonColorScheme='blue'
       buttonTranslation='common.continue'
       message={translate('streamingAcknowledgement.description', {
-        estimatedTimeSeconds: formatSecondsToDuration(estimatedTimeSeconds),
+        estimatedTimeHuman: formatSecondsToDuration(estimatedTimeMs / 1000),
       })}
       icon={StreamIcon}
     />

--- a/src/components/MultiHopTrade/components/TradeInput/TradeInput.tsx
+++ b/src/components/MultiHopTrade/components/TradeInput/TradeInput.tsx
@@ -702,9 +702,9 @@ export const TradeInput = ({ isCompact }: TradeInputProps) => {
                   onAcknowledge={handleFormSubmit}
                   shouldShowAcknowledgement={shouldShowStreamingAcknowledgement}
                   setShouldShowAcknowledgement={setShouldShowStreamingAcknowledgement}
-                  estimatedTimeSeconds={
+                  estimatedTimeMs={
                     tradeQuoteStep?.estimatedExecutionTimeMs
-                      ? tradeQuoteStep?.estimatedExecutionTimeMs / 1000
+                      ? tradeQuoteStep.estimatedExecutionTimeMs
                       : 0
                   }
                 >

--- a/src/components/MultiHopTrade/components/TradeInput/TradeInput.tsx
+++ b/src/components/MultiHopTrade/components/TradeInput/TradeInput.tsx
@@ -704,8 +704,8 @@ export const TradeInput = ({ isCompact }: TradeInputProps) => {
                   setShouldShowAcknowledgement={setShouldShowStreamingAcknowledgement}
                   estimatedTimeSeconds={
                     tradeQuoteStep?.estimatedExecutionTimeMs
-                      ? `${tradeQuoteStep?.estimatedExecutionTimeMs / 1000}`
-                      : ''
+                      ? tradeQuoteStep?.estimatedExecutionTimeMs / 1000
+                      : 0
                   }
                 >
                   <WarningAcknowledgement

--- a/src/components/MultiHopTrade/components/TradeInput/TradeInput.tsx
+++ b/src/components/MultiHopTrade/components/TradeInput/TradeInput.tsx
@@ -594,7 +594,7 @@ export const TradeInput = ({ isCompact }: TradeInputProps) => {
   const isEstimatedExecutionTimeOverTreshold = useMemo(() => {
     if (!tradeQuoteStep?.estimatedExecutionTimeMs) return false
 
-    if (tradeQuoteStep?.estimatedExecutionTimeMs > STREAM_ACKNOWLEDGEMENT_MINIMUM_TIME_TRESHOLD)
+    if (tradeQuoteStep?.estimatedExecutionTimeMs >= STREAM_ACKNOWLEDGEMENT_MINIMUM_TIME_TRESHOLD)
       return true
 
     return false


### PR DESCRIPTION
## Description

The time was displayed using seconds, we know use a human readable sentence
<!-- Please describe your changes -->

## Pull Request Type

- [ ] :bug: Bug fix (Non-breaking Change: Fixes an issue)
- [ ] :hammer_and_wrench: Chore (Non-breaking Change: Doc updates, pkg upgrades, typos, etc..)
- [x] :nail_care: New Feature (Breaking/Non-breaking Change)

## Issue (if applicable)

<!-----------------------------------------------------------------------------
If applicable, please link to the github issue and put `closes #XXXX` in your comment to auto-close the issue that your PR fixes.
------------------------------------------------------------------------------>

n/a

## Risk
Low risk

## Testing

<!-----------------------------------------------------------------------------
We treat every PR to be merged with the same scrutiny as if we were merging directly to production.

Your PR will not be merged if you do not complete the sections below for our engineering and operations teams to test.
------------------------------------------------------------------------------>

### Engineering
n/a
<!-----------------------------------------------------------------------------
Include sufficient information here for an engineer to test your PR. This may include how to test locally, in a built environment, changes to infrastructure etc.
------------------------------------------------------------------------------>

### Operations
n/a
<!-----------------------------------------------------------------------------
If your changes have a user-facing impact, describe how a non-technical QA team can functionally test your changes in a preview environment.

If they are not user-facing please describe how to test for any regressions that may occur.
------------------------------------------------------------------------------>

## Screenshots (if applicable)
![image](https://github.com/shapeshift/web/assets/14963751/bcc33b1d-425f-4658-a8f2-aa1392288dda)
