### PR TITLE
fix: undefined LP input

### DIFF
--- a/src/pages/ThorChainLP/components/AddLiquidity/AddLiquidityInput.tsx
+++ b/src/pages/ThorChainLP/components/AddLiquidity/AddLiquidityInput.tsx
@@ -1122,8 +1122,8 @@ export const AddLiquidityInput: React.FC<AddLiquidityInputProps> = ({
               onChange={handleAddLiquidityInputChange}
               onToggleIsFiat={isRune ? handleToggleRuneIsFiat : handleTogglePoolAssetIsFiat}
               isFiat={isRune ? runeIsFiat : poolAssetIsFiat}
-              cryptoAmount={cryptoAmount}
-              fiatAmount={fiatAmount}
+              cryptoAmount={cryptoAmount ?? '0'}
+              fiatAmount={fiatAmount ?? '0'}
             />
           )
         })}


### PR DESCRIPTION
## Description

Fixes a recent regression (possibly from https://github.com/shapeshift/web/pull/7246) where we no longer gracefully handle switching to fiat input before a value has been entered (i.e. when the crypto and fiat values are `undefined`.

The only place this seems to have an impact is the LP add liquidity component, which has been fixed in this PR.

## Pull Request Type

- [x] :bug: Bug fix (Non-breaking Change: Fixes an issue)
- [ ] :hammer_and_wrench: Chore (Non-breaking Change: Doc updates, pkg upgrades, typos, etc..)
- [ ] :nail_care: New Feature (Breaking/Non-breaking Change)

## Issue (if applicable)

Closes https://github.com/shapeshift/web/issues/7266

## Risk

Small.

> What protocols, transaction types or contract interactions might be affected by this PR?

LP quote input.

## Testing

Ensure that when selecting a fiat amount on initial LP quote component load we get 0 instead of N/A for the crypto amount.

See the ticket that this closes for the sad case.

### Engineering

☝️

### Operations

☝️

## Screenshots (if applicable)

We now load with an actual value pre-filled (0) instead of a placeholder resulting from an `undefined` value.

<img width="317" alt="Screenshot 2024-06-28 at 4 18 52 PM" src="https://github.com/shapeshift/web/assets/97164662/2fba9d16-3f91-47ba-a3dc-0c73236a1c99">
