### PR TITLE
fix: empty string LP input

### DIFF
--- a/src/lib/utils/index.ts
+++ b/src/lib/utils/index.ts
@@ -107,6 +107,9 @@ export const tokenOrUndefined = (assetReference: AssetReference | string) =>
 export const isSome = <T>(option: T | null | undefined): option is T =>
   !isUndefined(option) && !isNull(option)
 
+export const isNonEmptyString = (value: string | undefined): value is string =>
+  typeof value === 'string' && value.length > 0
+
 // export const isTruthy = <T>(value: T | false): value is T => Boolean(value)
 
 type Falsy = false | null | undefined | '' | 0

--- a/src/pages/ThorChainLP/components/AddLiquidity/AddLiquidityInput.tsx
+++ b/src/pages/ThorChainLP/components/AddLiquidity/AddLiquidityInput.tsx
@@ -61,7 +61,13 @@ import {
   assetIdToPoolAssetId,
   poolAssetIdToAssetId,
 } from 'lib/swapper/swappers/ThorchainSwapper/utils/poolAssetHelpers/poolAssetHelpers'
-import { assertUnreachable, chainIdToChainDisplayName, isSome, isToken } from 'lib/utils'
+import {
+  assertUnreachable,
+  chainIdToChainDisplayName,
+  isNonEmptyString,
+  isSome,
+  isToken,
+} from 'lib/utils'
 import { getSupportedEvmChainIds } from 'lib/utils/evm'
 import { THOR_PRECISION } from 'lib/utils/thorchain/constants'
 import { useSendThorTx } from 'lib/utils/thorchain/hooks/useSendThorTx'
@@ -1124,8 +1130,8 @@ export const AddLiquidityInput: React.FC<AddLiquidityInputProps> = ({
               onChange={handleAddLiquidityInputChange}
               onToggleIsFiat={isRune ? handleToggleRuneIsFiat : handleTogglePoolAssetIsFiat}
               isFiat={isRune ? runeIsFiat : poolAssetIsFiat}
-              cryptoAmount={cryptoAmount ?? '0'}
-              fiatAmount={fiatAmount ?? '0'}
+              cryptoAmount={isNonEmptyString(cryptoAmount) ? cryptoAmount : '0'}
+              fiatAmount={isNonEmptyString(fiatAmount) ? fiatAmount : '0'}
             />
           )
         })}


### PR DESCRIPTION
## Description

Fixes this issue in the current release (and prod, so not a regression) found by @MBMaria: https://jam.dev/c/2fae7632-7e26-40a5-b271-8f1a6805dcd1, where the crypto amount gets set to `NAN` on asset change due to the `cryptoAmount` being set to an empty string `''` on asset change.

## Pull Request Type

- [x] :bug: Bug fix (Non-breaking Change: Fixes an issue)
- [ ] :hammer_and_wrench: Chore (Non-breaking Change: Doc updates, pkg upgrades, typos, etc..)
- [ ] :nail_care: New Feature (Breaking/Non-breaking Change)

## Issue (if applicable)

N/A, noted in current release thread: https://discord.com/channels/554694662431178782/1257135461030170669/1257148185231491192

## Risk

Small

> What protocols, transaction types or contract interactions might be affected by this PR?

LP deposit input amounts.

## Testing

See the jam and ensure the flow doesn't result in a `NAN` showing.

1. Select fiat input
2. Change asset
3. Ensure `0` crypto amount is shown

### Engineering

☝️

### Operations

☝️

## Screenshots (if applicable)

N/A