### PR TITLE
chore: cleanup rfox epoch start timestamp

### DIFF
--- a/src/pages/RFOX/hooks/useEpochHistoryQuery.ts
+++ b/src/pages/RFOX/hooks/useEpochHistoryQuery.ts
@@ -13,13 +13,7 @@ import {
 
 type EpochHistoryQueryKey = ['epochHistory']
 
-// TODO: Clean up by removing the Math.min after the first epoch starts.
-// This is a temporary hack to ensure we have an epoch to test with prior to rFOX launch,
-// and the correct one after launch (in case we don't action this todo it for any reason).
-// const RFOX_FIRST_EPOCH_START_TIMESTAMP = BigInt(dayjs('2024-07-01T00:00:00Z').unix())
-const RFOX_FIRST_EPOCH_START_TIMESTAMP = BigInt(
-  Math.min(dayjs().startOf('month').unix(), dayjs('2024-07-01T00:00:00Z').unix()),
-)
+const RFOX_FIRST_EPOCH_START_TIMESTAMP = BigInt(dayjs('2024-07-01T00:00:00Z').unix())
 
 // This looks weird but isn't - "now" isn't now, it's "now" when this module was first evaluated
 // This allows all calculations against now to be consistent, since our current monkey patch subtracts 2 epochs (60 days) from the same "now"


### PR DESCRIPTION
## Description

Removes the temporary hack to make rFOX reward calculation work for testing prior to rFOX launch.

## Pull Request Type

- [ ] :bug: Bug fix (Non-breaking Change: Fixes an issue)
- [x] :hammer_and_wrench: Chore (Non-breaking Change: Doc updates, pkg upgrades, typos, etc..)
- [ ] :nail_care: New Feature (Breaking/Non-breaking Change)

## Issue (if applicable)

<!-----------------------------------------------------------------------------
If applicable, please link to the github issue and put `closes #XXXX` in your comment to auto-close the issue that your PR fixes.
------------------------------------------------------------------------------>

closes #7224

## Risk
> High Risk PRs Require 2 approvals

Low risk as this should have zero impact on calculations.

> What protocols, transaction types or contract interactions might be affected by this PR?

## Testing

Ensure lifetime rewards on rFOX dashboard are identical to production.

### Engineering

<!-----------------------------------------------------------------------------
Include sufficient information here for an engineer to test your PR. This may include how to test locally, in a built environment, changes to infrastructure etc.
------------------------------------------------------------------------------>

### Operations

<!-----------------------------------------------------------------------------
If your changes have a user-facing impact, describe how a non-technical QA team can functionally test your changes in a preview environment.

If they are not user-facing please describe how to test for any regressions that may occur.
------------------------------------------------------------------------------>

## Screenshots (if applicable)
