### PR TITLE
fix: handle crypto and fiat amounts properly instead of displaying NaN

### DIFF
--- a/src/components/Modals/Send/views/Details.tsx
+++ b/src/components/Modals/Send/views/Details.tsx
@@ -245,17 +245,13 @@ export const Details = () => {
             >
               {fieldName === SendFormFields.FiatAmount ? (
                 <Amount.Crypto
-                  value={bnOrZero(amountCryptoPrecision).gt(0) ? amountCryptoPrecision : '0'}
+                  value={bnOrZero(amountCryptoPrecision).toString()}
                   symbol={asset.symbol}
                   prefix='≈'
                 />
               ) : (
                 <Flex>
-                  <Amount.Fiat
-                    value={bnOrZero(fiatAmount).gt(0) ? fiatAmount : '0'}
-                    mr={1}
-                    prefix='≈'
-                  />{' '}
+                  <Amount.Fiat value={bnOrZero(fiatAmount).toString()} mr={1} prefix='≈' />{' '}
                   {fiatSymbol}
                 </Flex>
               )}

--- a/src/components/Modals/Send/views/Details.tsx
+++ b/src/components/Modals/Send/views/Details.tsx
@@ -244,10 +244,19 @@ export const Details = () => {
               _hover={formHelperTextHoverStyle}
             >
               {fieldName === SendFormFields.FiatAmount ? (
-                <Amount.Crypto value={amountCryptoPrecision} symbol={asset.symbol} prefix='≈' />
+                <Amount.Crypto
+                  value={bnOrZero(amountCryptoPrecision).gt(0) ? amountCryptoPrecision : '0'}
+                  symbol={asset.symbol}
+                  prefix='≈'
+                />
               ) : (
                 <Flex>
-                  <Amount.Fiat value={fiatAmount} mr={1} prefix='≈' /> {fiatSymbol}
+                  <Amount.Fiat
+                    value={bnOrZero(fiatAmount).gt(0) ? fiatAmount : '0'}
+                    mr={1}
+                    prefix='≈'
+                  />{' '}
+                  {fiatSymbol}
                 </Flex>
               )}
             </FormHelperText>

--- a/src/components/MultiHopTrade/components/TradeAmountInput.tsx
+++ b/src/components/MultiHopTrade/components/TradeAmountInput.tsx
@@ -216,9 +216,13 @@ export const TradeAmountInput: React.FC<TradeAmountInputProps> = memo(
 
     const oppositeCurrency = useMemo(() => {
       return isFiat ? (
-        <Amount.Crypto value={cryptoAmount ?? ''} symbol={assetSymbol} prefix='≈' />
+        <Amount.Crypto
+          value={bnOrZero(cryptoAmount).gt(0) ? cryptoAmount : '0'}
+          symbol={assetSymbol}
+          prefix='≈'
+        />
       ) : (
-        <Amount.Fiat value={fiatAmount ?? ''} prefix='≈' />
+        <Amount.Fiat value={bnOrZero(fiatAmount).gt(0) ? fiatAmount : '0'} prefix='≈' />
       )
     }, [assetSymbol, cryptoAmount, fiatAmount, isFiat])
 

--- a/src/components/MultiHopTrade/components/TradeAmountInput.tsx
+++ b/src/components/MultiHopTrade/components/TradeAmountInput.tsx
@@ -216,13 +216,9 @@ export const TradeAmountInput: React.FC<TradeAmountInputProps> = memo(
 
     const oppositeCurrency = useMemo(() => {
       return isFiat ? (
-        <Amount.Crypto
-          value={bnOrZero(cryptoAmount).gt(0) ? cryptoAmount : '0'}
-          symbol={assetSymbol}
-          prefix='≈'
-        />
+        <Amount.Crypto value={bnOrZero(cryptoAmount).toString()} symbol={assetSymbol} prefix='≈' />
       ) : (
-        <Amount.Fiat value={bnOrZero(fiatAmount).gt(0) ? fiatAmount : '0'} prefix='≈' />
+        <Amount.Fiat value={bnOrZero(fiatAmount).toString()} prefix='≈' />
       )
     }, [assetSymbol, cryptoAmount, fiatAmount, isFiat])
 

--- a/src/features/defi/providers/thorchain-savers/components/ThorchainSaversManager/Withdraw/components/Withdraw.tsx
+++ b/src/features/defi/providers/thorchain-savers/components/ThorchainSaversManager/Withdraw/components/Withdraw.tsx
@@ -581,7 +581,7 @@ export const Withdraw: React.FC<WithdrawProps> = ({ accountId, fromAddress, onNe
           <Row.Label>{translate('common.slippage')}</Row.Label>
           <Row.Value>
             <Skeleton isLoaded={!quoteLoading}>
-              <Amount.Crypto value={slippageCryptoAmountPrecision ?? ''} symbol={asset.symbol} />
+              <Amount.Crypto value={slippageCryptoAmountPrecision ?? '0'} symbol={asset.symbol} />
             </Skeleton>
           </Row.Value>
         </Row>


### PR DESCRIPTION
## Description

Sometime we still send an empty string to the `Amount` component, resulting to a display of NaN instead of a proper number. Identified a few parts by searching: 
- Inside the Send modal thanks to https://github.com/shapeshift/web/issues/7266#issuecomment-2205014022
- Inside the swapper crypto value
- Inside the slippage of the withdraw component of the THORChain savers

<!-- Please describe your changes -->

## Pull Request Type

- [x] :bug: Bug fix (Non-breaking Change: Fixes an issue)
- [ ] :hammer_and_wrench: Chore (Non-breaking Change: Doc updates, pkg upgrades, typos, etc..)
- [ ] :nail_care: New Feature (Breaking/Non-breaking Change)

## Issue (if applicable)

<!-----------------------------------------------------------------------------
If applicable, please link to the github issue and put `closes #XXXX` in your comment to auto-close the issue that your PR fixes.
------------------------------------------------------------------------------>

closes #7266

## Risk
Low risk

## Testing

- Go to the Send modal, switch the value to USD and see that the value of the crypto component is not NaN anymore but 0
- Go to the swapper, remove the 0, switch to USD value, see that the crypto value is !== than NaN
- Go to any thorchain savers, click withdraw, wait for the slippage to display, its not NaN anymore


<!-----------------------------------------------------------------------------
We treat every PR to be merged with the same scrutiny as if we were merging directly to production.

Your PR will not be merged if you do not complete the sections below for our engineering and operations teams to test.
------------------------------------------------------------------------------>

### Engineering
n/a
<!-----------------------------------------------------------------------------
Include sufficient information here for an engineer to test your PR. This may include how to test locally, in a built environment, changes to infrastructure etc.
------------------------------------------------------------------------------>

### Operations
n/a
<!-----------------------------------------------------------------------------
If your changes have a user-facing impact, describe how a non-technical QA team can functionally test your changes in a preview environment.

If they are not user-facing please describe how to test for any regressions that may occur.
------------------------------------------------------------------------------>

## Screenshots (if applicable)
### Before
![image](https://github.com/shapeshift/web/assets/14963751/5782b280-983b-4456-aac2-b74a917a2892)
Notice the `NaN ETH`

![image](https://github.com/shapeshift/web/assets/14963751/20c0f787-2d94-417a-8411-9036a19ccac8)
Notice the `NaN ATOM`

![image](https://github.com/shapeshift/web/assets/14963751/af91504b-0b5f-4e28-bdf1-fab2f8a9234d)
Notice the `NaN USDC`

### After
![image](https://github.com/shapeshift/web/assets/14963751/d46bfe0a-6f33-4c2a-972f-478ffcc492ba)

![image](https://github.com/shapeshift/web/assets/14963751/94de6485-7c5b-467d-bce0-897968b2db06)

![image](https://github.com/shapeshift/web/assets/14963751/8c492359-0f49-4f6e-b473-97fa286a5681)


