### PR TITLE
fix: corrupted trade execution state due to incoming quotes during trade execution

### DIFF
--- a/src/components/MultiHopTrade/MultiHopTrade.tsx
+++ b/src/components/MultiHopTrade/MultiHopTrade.tsx
@@ -1,6 +1,6 @@
 import type { AssetId } from '@shapeshiftoss/caip'
 import { AnimatePresence } from 'framer-motion'
-import { memo, useEffect, useRef } from 'react'
+import { memo, useEffect, useMemo, useRef } from 'react'
 import { FormProvider, useForm } from 'react-hook-form'
 import { MemoryRouter, Route, Switch, useLocation, useParams } from 'react-router-dom'
 import { selectAssetById } from 'state/slices/assetsSlice/selectors'
@@ -30,6 +30,12 @@ export type TradeCardProps = {
 type MatchParams = {
   chainId?: string
   assetSubId?: string
+}
+
+// dummy component to allow us to mount or unmount the `useGetTradeQuotes` hook conditionally
+const GetTradeQuotes = () => {
+  useGetTradeQuotes()
+  return <></>
 }
 
 export const MultiHopTrade = memo(({ defaultBuyAssetId, isCompact }: TradeCardProps) => {
@@ -62,7 +68,6 @@ type TradeRoutesProps = {
 const TradeRoutes = memo(({ isCompact }: TradeRoutesProps) => {
   const location = useLocation()
   const dispatch = useAppDispatch()
-  useGetTradeQuotes()
 
   useEffect(() => {
     return () => {
@@ -76,25 +81,38 @@ const TradeRoutes = memo(({ isCompact }: TradeRoutesProps) => {
 
   const tradeInputRef = useRef<HTMLDivElement | null>(null)
 
+  const shouldUseTradeQuotes = useMemo(() => {
+    // We only want to fetch quotes when the user is on the trade input or quote list route
+    return [TradeRoutePaths.Input, TradeRoutePaths.QuoteList].includes(
+      location.pathname as TradeRoutePaths,
+    )
+  }, [location.pathname])
+
   return (
-    <AnimatePresence mode='wait' initial={false}>
-      <Switch location={location}>
-        <Route key={TradeRoutePaths.Input} path={TradeRoutePaths.Input}>
-          <TradeInput isCompact={isCompact} tradeInputRef={tradeInputRef} />
-        </Route>
-        <Route key={TradeRoutePaths.Confirm} path={TradeRoutePaths.Confirm}>
-          <MultiHopTradeConfirm />
-        </Route>
-        <Route key={TradeRoutePaths.VerifyAddresses} path={TradeRoutePaths.VerifyAddresses}>
-          <VerifyAddresses />
-        </Route>
-        <Route key={TradeRoutePaths.QuoteList} path={TradeRoutePaths.QuoteList}>
-          <QuoteListRoute
-            height={tradeInputRef.current?.offsetHeight ?? '500px'}
-            width={tradeInputRef.current?.offsetWidth ?? 'full'}
-          />
-        </Route>
-      </Switch>
-    </AnimatePresence>
+    <>
+      <AnimatePresence mode='wait' initial={false}>
+        <Switch location={location}>
+          <Route key={TradeRoutePaths.Input} path={TradeRoutePaths.Input}>
+            <TradeInput isCompact={isCompact} tradeInputRef={tradeInputRef} />
+          </Route>
+          <Route key={TradeRoutePaths.Confirm} path={TradeRoutePaths.Confirm}>
+            <MultiHopTradeConfirm />
+          </Route>
+          <Route key={TradeRoutePaths.VerifyAddresses} path={TradeRoutePaths.VerifyAddresses}>
+            <VerifyAddresses />
+          </Route>
+          <Route key={TradeRoutePaths.QuoteList} path={TradeRoutePaths.QuoteList}>
+            <QuoteListRoute
+              height={tradeInputRef.current?.offsetHeight ?? '500px'}
+              width={tradeInputRef.current?.offsetWidth ?? 'full'}
+            />
+          </Route>
+        </Switch>
+      </AnimatePresence>
+      {/* Stop polling for quotes by unmounting the hook. This prevents trade execution getting */}
+      {/* corrupted from state being mutated during trade execution. */}
+      {/* TODO: move the hook into a react-query or similar and pass a flag  */}
+      {shouldUseTradeQuotes ? <GetTradeQuotes /> : null}
+    </>
   )
 })


### PR DESCRIPTION
## Description

Fixes major state corruption due to quote polling during trade execution. Solved by unmounting the `useGetTradeQuotes` hook for trade UI routes that dont require quote polling.

## Pull Request Type

- [x] :bug: Bug fix (Non-breaking Change: Fixes an issue)
- [ ] :hammer_and_wrench: Chore (Non-breaking Change: Doc updates, pkg upgrades, typos, etc..)
- [ ] :nail_care: New Feature (Breaking/Non-breaking Change)

## Issue (if applicable)

closes #7347

## Risk
> High Risk PRs Require 2 approvals

Moderate risk of this introducing a new issue which could break trades, though the fix here is very obvious and greatly reduces the impact to users.

> What protocols, transaction types or contract interactions might be affected by this PR?

## Testing

The key to reproducing this issue is to be fast at previewing the quote, and slow at confirming it.

1. Get a trade quote on metamask wallet
2. Immediately click "preview trade" with no wait
3. click "confirm" and click "sign transaction"
4. In metamask, dont actually sign the transaction, and instead wait.
5. Quote polling will provide a new quote and will delete the one in progress, resulting in absolute MADNESS
6. If you're feeling crazy, continue thru the flow further and see what happens.

### Engineering

<!-----------------------------------------------------------------------------
Include sufficient information here for an engineer to test your PR. This may include how to test locally, in a built environment, changes to infrastructure etc.
------------------------------------------------------------------------------>

### Operations

<!-----------------------------------------------------------------------------
If your changes have a user-facing impact, describe how a non-technical QA team can functionally test your changes in a preview environment.

If they are not user-facing please describe how to test for any regressions that may occur.
------------------------------------------------------------------------------>

## Screenshots (if applicable)

Before fix:

https://github.com/shapeshift/web/assets/125113430/06c49ca3-4d67-486a-9f05-15d18a2bd43d

Before fix, another style of the issue:

https://github.com/shapeshift/web/assets/125113430/16a52c09-04ae-40a8-97fa-b46bfb082806



After fix:


https://github.com/shapeshift/web/assets/125113430/a0fe92f8-d515-404e-8750-51e783726023


