### PR TITLE
fix: modal cross deadclick on wallet connect mobile scan

### DIFF
--- a/src/plugins/walletConnectToDapps/components/modals/connect/Connect.tsx
+++ b/src/plugins/walletConnectToDapps/components/modals/connect/Connect.tsx
@@ -62,7 +62,7 @@ const Connect = ({ initialUri, isOpen, onClose }: Props) => {
         minWidth={minWidthProp}
         maxWidth={maxWidthProp}
       >
-        <ModalCloseButton position='absolute' color='text.subtle' />
+        <ModalCloseButton zIndex='1' position='absolute' color='text.subtle' />
         <ConnectContent initialUri={initialUri} handleConnect={handleConnectV2} />
       </ModalContent>
     </Modal>


### PR DESCRIPTION
## Description

The parent modal cross was under the dialog header of the qr scanner dialog component, by adding a zIndex 1 to it, it will be over because it's older in the tree

<!-- Please describe your changes -->

## Pull Request Type

- [ ] :bug: Bug fix (Non-breaking Change: Fixes an issue)
- [ ] :hammer_and_wrench: Chore (Non-breaking Change: Doc updates, pkg upgrades, typos, etc..)
- [ ] :nail_care: New Feature (Breaking/Non-breaking Change)

## Issue (if applicable)

<!-----------------------------------------------------------------------------
If applicable, please link to the github issue and put `closes #XXXX` in your comment to auto-close the issue that your PR fixes.
------------------------------------------------------------------------------>

closes #7334

## Risk
Low risk

## Testing
Try to scan a QR code to connect with wallet connect on mobile, then hit the close cross, it should work

<!-----------------------------------------------------------------------------
We treat every PR to be merged with the same scrutiny as if we were merging directly to production.

Your PR will not be merged if you do not complete the sections below for our engineering and operations teams to test.
------------------------------------------------------------------------------>

### Engineering
n/a
<!-----------------------------------------------------------------------------
Include sufficient information here for an engineer to test your PR. This may include how to test locally, in a built environment, changes to infrastructure etc.
------------------------------------------------------------------------------>

### Operations
n/a
<!-----------------------------------------------------------------------------
If your changes have a user-facing impact, describe how a non-technical QA team can functionally test your changes in a preview environment.

If they are not user-facing please describe how to test for any regressions that may occur.
------------------------------------------------------------------------------>

## Screenshots (if applicable)
https://jam.dev/c/c2e4b25f-f1d0-409e-90ef-f89a6d7bf9f6