### PR TITLE
fix: disconnect wallet before clearing cache on mobile to avoid pw prompt

### DIFF
--- a/src/components/Modals/Settings/ClearCache.tsx
+++ b/src/components/Modals/Settings/ClearCache.tsx
@@ -17,6 +17,7 @@ import { useHistory } from 'react-router-dom'
 import { SlideTransition } from 'components/SlideTransition'
 import { RawText } from 'components/Text'
 import { reloadWebview } from 'context/WalletProvider/MobileWallet/mobileMessageHandlers'
+import { useWallet } from 'hooks/useWallet/useWallet'
 import { isMobile as isMobileApp } from 'lib/globals'
 import { selectWalletAccountIds } from 'state/slices/selectors'
 import { txHistory, txHistoryApi } from 'state/slices/txHistorySlice/txHistorySlice'
@@ -58,10 +59,13 @@ export const ClearCache = ({ appHistory }: ClearCacheProps) => {
   const requestedAccountIds = useAppSelector(selectWalletAccountIds)
   const translate = useTranslate()
   const history = useHistory()
+  const { disconnect } = useWallet()
   const { goBack } = history
 
   const handleClearCacheClick = useCallback(async () => {
     try {
+      // First disconnect the wallet so the mobile users won't be asked for a password
+      disconnect()
       // clear store
       await persistor.purge()
       // send them back to the connect wallet route in case the bug was something to do with the current page
@@ -70,7 +74,7 @@ export const ClearCache = ({ appHistory }: ClearCacheProps) => {
       // reload the page
       isMobileApp ? reloadWebview() : window.location.reload()
     } catch (e) {}
-  }, [appHistory])
+  }, [appHistory, disconnect])
 
   const handleClearTxHistory = useCallback(() => {
     dispatch(txHistory.actions.clear())

--- a/src/components/Modals/Settings/ClearCache.tsx
+++ b/src/components/Modals/Settings/ClearCache.tsx
@@ -64,8 +64,10 @@ export const ClearCache = ({ appHistory }: ClearCacheProps) => {
 
   const handleClearCacheClick = useCallback(async () => {
     try {
-      // First disconnect the wallet so the mobile users won't be asked for a password
-      disconnect()
+      // First disconnect the wallet so the mobile users won't be asked for a password because of the WalletProvider effects
+      if (isMobileApp) {
+        disconnect()
+      }
       // clear store
       await persistor.purge()
       // send them back to the connect wallet route in case the bug was something to do with the current page

--- a/src/context/WalletProvider/WalletProvider.tsx
+++ b/src/context/WalletProvider/WalletProvider.tsx
@@ -976,11 +976,7 @@ export const WalletProvider = ({ children }: { children: React.ReactNode }): JSX
     })
   }, [])
 
-  useEffect(() => {
-    alert('is loading')
-
-    load()
-  }, [load, state.keyring])
+  useEffect(() => load(), [load, state.keyring])
 
   useKeyringEventHandler(state)
   useNativeEventHandler(state, dispatch)

--- a/src/context/WalletProvider/WalletProvider.tsx
+++ b/src/context/WalletProvider/WalletProvider.tsx
@@ -976,7 +976,11 @@ export const WalletProvider = ({ children }: { children: React.ReactNode }): JSX
     })
   }, [])
 
-  useEffect(() => load(), [load, state.keyring])
+  useEffect(() => {
+    alert('is loading')
+
+    load()
+  }, [load, state.keyring])
 
   useKeyringEventHandler(state)
   useNativeEventHandler(state, dispatch)


### PR DESCRIPTION
## Description
I'm not so used to the complexity of the WalletProvider for now but as the state is cleared when the cache is cleared, it's not anymore set to "mobile", meaning that `load` will be rerun because of an effect contained in `WalletProvider` but with `localWalletType` !== than `mobile`, and so the password prompt will be shown

By disconnecting the wallet before, we ensure that the user won't trigger this load effect and ensure he will need to connect the wallet again
<!-- Please describe your changes -->

## Pull Request Type

- [x] :bug: Bug fix (Non-breaking Change: Fixes an issue)
- [ ] :hammer_and_wrench: Chore (Non-breaking Change: Doc updates, pkg upgrades, typos, etc..)
- [ ] :nail_care: New Feature (Breaking/Non-breaking Change)

## Issue (if applicable)

<!-----------------------------------------------------------------------------
If applicable, please link to the github issue and put `closes #XXXX` in your comment to auto-close the issue that your PR fixes.
------------------------------------------------------------------------------>

closes #7333

## Risk
Low

## Testing
- You can test on `gome` using the mobile app, selecting the `gome` environment
- Try to clear the cache, you shouldn't be prompted to enter a password
<!-----------------------------------------------------------------------------
We treat every PR to be merged with the same scrutiny as if we were merging directly to production.

Your PR will not be merged if you do not complete the sections below for our engineering and operations teams to test.
------------------------------------------------------------------------------>

### Engineering
n/a
<!-----------------------------------------------------------------------------
Include sufficient information here for an engineer to test your PR. This may include how to test locally, in a built environment, changes to infrastructure etc.
------------------------------------------------------------------------------>

### Operations
n/a
<!-----------------------------------------------------------------------------
If your changes have a user-facing impact, describe how a non-technical QA team can functionally test your changes in a preview environment.

If they are not user-facing please describe how to test for any regressions that may occur.
------------------------------------------------------------------------------>

## Screenshots (if applicable)
