### PR TITLE
fix: add solana to unsupported zapper opportunities

### DIFF
--- a/src/state/apis/zapper/validators.ts
+++ b/src/state/apis/zapper/validators.ts
@@ -69,6 +69,7 @@ enum SupportedZapperNetworkIncludeUnsupported {
   Blast = 'blast',
   Degen = 'degen',
   ZkSync = 'zksync',
+  Solana = 'solana',
 }
 
 export const ZAPPER_NETWORKS_TO_CHAIN_ID_MAP: Record<SupportedZapperNetwork, ChainId> = {


### PR DESCRIPTION
## Description

Add Solana to unsupported Zapper networks to resolve log spew.

## Pull Request Type

- [ ] :bug: Bug fix (Non-breaking Change: Fixes an issue)
- [x] :hammer_and_wrench: Chore (Non-breaking Change: Doc updates, pkg upgrades, typos, etc..)
- [ ] :nail_care: New Feature (Breaking/Non-breaking Change)

## Issue (if applicable)

N/A - QOL.

## Risk

Low

> What protocols, transaction types or contract interactions might be affected by this PR?

None

## Testing

This should no longer show when loading DiFi positions.

<img width="725" alt="Screenshot 2024-07-11 at 11 09 17 AM" src="https://github.com/shapeshift/web/assets/97164662/be463913-bd39-4d14-a490-c4bfe1f936c3">

### Engineering

☝️

### Operations

☝️

## Screenshots (if applicable)

See testing section.