### PR TITLE
fix: tx history

### DIFF
--- a/src/config.ts
+++ b/src/config.ts
@@ -176,7 +176,7 @@ const validators = {
   REACT_APP_FEATURE_ACCOUNT_MANAGEMENT_LEDGER: bool({ default: false }),
   REACT_APP_FEATURE_RFOX: bool({ default: false }),
   REACT_APP_FEATURE_RFOX_REWARDS_TX_HISTORY: bool({ default: false }),
-  REACT_APP_FEATURE_RFOX_MOCK_REWARDS_TX_HISTORY: bool({ default: true }),
+  REACT_APP_FEATURE_RFOX_MOCK_REWARDS_TX_HISTORY: bool({ default: false }),
   REACT_APP_RFOX_REWARDS_MOCK_RUNE_ADDRESS: str(),
 }
 


### PR DESCRIPTION
## Description

Disables the `REACT_APP_FEATURE_RFOX_MOCK_REWARDS_TX_HISTORY` feature flag added in https://github.com/shapeshift/web/pull/7308 as it breaks the ability to fetch TX history app-wide.

## Pull Request Type

- [x] :bug: Bug fix (Non-breaking Change: Fixes an issue)
- [ ] :hammer_and_wrench: Chore (Non-breaking Change: Doc updates, pkg upgrades, typos, etc..)
- [ ] :nail_care: New Feature (Breaking/Non-breaking Change)

## Issue (if applicable)

N/A - production issue.

## Risk

Small

> What protocols, transaction types or contract interactions might be affected by this PR?

TX history.

## Testing

TX should load. Easiest way to test this is to clear TX history cache and see it re-fetch.

### Engineering

☝️

### Operations

☝️

## Screenshots (if applicable)

N/A