### PR TITLE
fix: sanitize nft descriptions of hyperlinks

### DIFF
--- a/src/components/Modals/Nfts/components/NftCollection.tsx
+++ b/src/components/Modals/Nfts/components/NftCollection.tsx
@@ -1,7 +1,7 @@
 import { Button, Flex, Link, Text } from '@chakra-ui/react'
 import { useMemo } from 'react'
 import { useTranslate } from 'react-polyglot'
-import { ParsedHtml } from 'components/ParsedHtml/ParsedHtml'
+import { SanitizedHtml } from 'components/SanitizedHtml/SanitizedHtml'
 import { markdownLinkToHTML } from 'lib/utils'
 import type { NftCollectionType } from 'state/apis/nft/types'
 
@@ -38,7 +38,7 @@ export const NftCollection: React.FC<NftCollectionProps> = ({
   return (
     <Flex gap={4} flexDir='column' px={8} py={6}>
       <Text fontWeight='medium'>{translate('nft.aboutCollection', { collectionName })}</Text>
-      <ParsedHtml color='text.subtle' innerHtml={markdownLinkToHTML(description ?? '')} />
+      <SanitizedHtml color='text.subtle' dirtyHtml={markdownLinkToHTML(description)} />
       {socialLinkPills}
     </Flex>
   )

--- a/src/components/Modals/Nfts/components/NftOverview.tsx
+++ b/src/components/Modals/Nfts/components/NftOverview.tsx
@@ -6,8 +6,8 @@ import { useCallback } from 'react'
 import { useTranslate } from 'react-polyglot'
 import { AssetIcon } from 'components/AssetIcon'
 import { MiddleEllipsis } from 'components/MiddleEllipsis/MiddleEllipsis'
-import { ParsedHtml } from 'components/ParsedHtml/ParsedHtml'
 import { Row } from 'components/Row/Row'
+import { SanitizedHtml } from 'components/SanitizedHtml/SanitizedHtml'
 import { Text } from 'components/Text'
 import { getChainAdapterManager } from 'context/PluginProvider/chainAdapterSingleton'
 import { markdownLinkToHTML } from 'lib/utils'
@@ -125,7 +125,7 @@ export const NftOverview: React.FC<NftOverviewProps> = ({ nftItem }) => {
           <Divider />
           <Flex gap={4} flexDir='column' px={8} py={6}>
             <Text translation='nft.description' fontWeight='medium' />
-            <ParsedHtml color='text.subtle' innerHtml={markdownLinkToHTML(description)} />
+            <SanitizedHtml color='text.subtle' dirtyHtml={markdownLinkToHTML(description)} />
           </Flex>
         </>
       )}


### PR DESCRIPTION
## Description

Sanitize hyperlinks in nft descriptions.

## Pull Request Type

- [x] :bug: Bug fix (Non-breaking Change: Fixes an issue)
- [ ] :hammer_and_wrench: Chore (Non-breaking Change: Doc updates, pkg upgrades, typos, etc..)
- [ ] :nail_care: New Feature (Breaking/Non-breaking Change)

## Issue (if applicable)

<!-----------------------------------------------------------------------------
If applicable, please link to the github issue and put `closes #XXXX` in your comment to auto-close the issue that your PR fixes.
------------------------------------------------------------------------------>

N/A

## Risk
> High Risk PRs Require 2 approvals

<!-----------------------------------------------------------------------------
Outline the scope of your changes and the risk associated with them. You must use your discretion as an engineer to determine the potential impact of your changes.

WARNING: If your PR introduces a new on-chain transaction or modifies an existing one, please add the "High-Risk" label to this PR and ask for 2 reviewers to approve it before merging.

E.g. an upgrade to `hdwallet` or core state management would be considered higher risk, and might require a full regression test. UI or isolated view changes, or something behind a feature flag may have near zero risk. Small bug fixes might require testing isolated to the specific fix.
------------------------------------------------------------------------------>

Low

> What protocols, transaction types or contract interactions might be affected by this PR?

## Testing

<!-----------------------------------------------------------------------------
We treat every PR to be merged with the same scrutiny as if we were merging directly to production.

Your PR will not be merged if you do not complete the sections below for our engineering and operations teams to test.
------------------------------------------------------------------------------>

See screen shot. I just hacked an example in place locally to prove it out. You can see the same component being used for asset descriptions (ex. Bitcoin) to view the sanitized links yourself elsewhere.

### Engineering

<!-----------------------------------------------------------------------------
Include sufficient information here for an engineer to test your PR. This may include how to test locally, in a built environment, changes to infrastructure etc.
------------------------------------------------------------------------------>

:point_up:

### Operations

<!-----------------------------------------------------------------------------
If your changes have a user-facing impact, describe how a non-technical QA team can functionally test your changes in a preview environment.

If they are not user-facing please describe how to test for any regressions that may occur.
------------------------------------------------------------------------------>

:point_up:

## Screenshots (if applicable)

![image](https://github.com/shapeshift/web/assets/35275952/cbf6cc72-d483-42e7-9c0e-fbaf80447923)
