### PR TITLE
fix: dont show render hover state for avilable claim rows with no click handler

### DIFF
--- a/src/components/ClaimRow/ClaimRow.tsx
+++ b/src/components/ClaimRow/ClaimRow.tsx
@@ -17,8 +17,8 @@ export type ClaimRowProps = {
   asset: Asset
   status: ClaimStatus
   statusText: string
-  tooltipText: string
-  onClaimClick: () => void
+  tooltipText?: string
+  onClaimClick?: () => void
 }
 
 export const ClaimRow = ({
@@ -41,7 +41,7 @@ export const ClaimRow = ({
         width='100%'
         variant='unstyled'
         as={Button}
-        isDisabled={status !== ClaimStatus.Available}
+        isDisabled={onClaimClick === undefined || status !== ClaimStatus.Available}
         onClick={onClaimClick}
         _hover={hoverProps}
         _disabled={disabledProps}

--- a/src/components/ClaimRow/ClaimRow.tsx
+++ b/src/components/ClaimRow/ClaimRow.tsx
@@ -8,8 +8,8 @@ import { TransactionTypeIcon } from 'components/TransactionHistory/TransactionTy
 
 import { ClaimStatus } from './types'
 
-const hoverProps = { bg: 'gray.700' }
-const disabledProps = { opacity: 1 }
+const hoverProps = { bg: 'gray.700', cursor: 'default' }
+const disabledProps = { opacity: 1, cursor: 'default' }
 
 export type ClaimRowProps = {
   actionText: string | undefined

--- a/src/components/ClaimRow/ClaimRow.tsx
+++ b/src/components/ClaimRow/ClaimRow.tsx
@@ -1,6 +1,7 @@
 import { Box, Button, Flex, Tooltip } from '@chakra-ui/react'
 import type { Asset } from '@shapeshiftoss/types'
 import { TransferType } from '@shapeshiftoss/unchained-client'
+import { useMemo } from 'react'
 import { Amount } from 'components/Amount/Amount'
 import { AssetIconWithBadge } from 'components/AssetIconWithBadge'
 import { RawText } from 'components/Text'
@@ -8,7 +9,6 @@ import { TransactionTypeIcon } from 'components/TransactionHistory/TransactionTy
 
 import { ClaimStatus } from './types'
 
-const hoverProps = { bg: 'gray.700', cursor: 'default' }
 const disabledProps = { opacity: 1, cursor: 'default' }
 
 export type ClaimRowProps = {
@@ -30,6 +30,14 @@ export const ClaimRow = ({
   tooltipText,
   onClaimClick,
 }: ClaimRowProps) => {
+  const isDisabled = useMemo(
+    () => onClaimClick === undefined || status !== ClaimStatus.Available,
+    [onClaimClick, status],
+  )
+  const hoverProps = useMemo(
+    () => ({ bg: 'gray.700', cursor: isDisabled ? 'default' : undefined }),
+    [isDisabled],
+  )
   return (
     <Tooltip label={tooltipText}>
       <Flex
@@ -41,7 +49,7 @@ export const ClaimRow = ({
         width='100%'
         variant='unstyled'
         as={Button}
-        isDisabled={onClaimClick === undefined || status !== ClaimStatus.Available}
+        isDisabled={isDisabled}
         onClick={onClaimClick}
         _hover={hoverProps}
         _disabled={disabledProps}

--- a/src/pages/RFOX/components/RewardsAndClaims/Claims.tsx
+++ b/src/pages/RFOX/components/RewardsAndClaims/Claims.tsx
@@ -2,9 +2,7 @@ import { Box, CardBody, Skeleton } from '@chakra-ui/react'
 import type { AccountId, AssetId } from '@shapeshiftoss/caip'
 import { fromAccountId } from '@shapeshiftoss/caip'
 import dayjs from 'dayjs'
-import noop from 'lodash/noop'
 import { useCallback, useMemo } from 'react'
-import { useTranslate } from 'react-polyglot'
 import { ClaimStatus } from 'components/ClaimRow/types'
 import { Text } from 'components/Text'
 import { fromBaseUnit } from 'lib/math'
@@ -21,7 +19,6 @@ type ClaimsProps = {
 }
 
 export const Claims = ({ headerComponent, stakingAssetId, stakingAssetAccountId }: ClaimsProps) => {
-  const translate = useTranslate()
   const setConfirmedQuote = useCallback(() => {}, [])
 
   const stakingAsset = useAppSelector(state => selectAssetById(state, stakingAssetId))
@@ -79,10 +76,6 @@ export const Claims = ({ headerComponent, stakingAssetId, stakingAssetAccountId 
           setConfirmedQuote={setConfirmedQuote}
           cooldownPeriodHuman={cooldownPeriodHuman}
           index={index}
-          actionDescription={translate('RFOX.unstakeFrom', {
-            assetSymbol: stakingAsset.symbol,
-          })}
-          onClaimButtonClick={noop}
         />
       )
     })
@@ -95,7 +88,6 @@ export const Claims = ({ headerComponent, stakingAssetId, stakingAssetAccountId 
     setConfirmedQuote,
     stakingAsset,
     stakingAssetId,
-    translate,
     unstakingRequestResponse,
   ])
 


### PR DESCRIPTION
## Description

Fixes a regression where we a hover state is rendered on available claims with no click handler, resulting in dead click (when clicked).

## Pull Request Type

- [x] :bug: Bug fix (Non-breaking Change: Fixes an issue)
- [ ] :hammer_and_wrench: Chore (Non-breaking Change: Doc updates, pkg upgrades, typos, etc..)
- [ ] :nail_care: New Feature (Breaking/Non-breaking Change)

## Issue (if applicable)

NA

## Risk
> High Risk PRs Require 2 approvals

Low risk.

> What protocols, transaction types or contract interactions might be affected by this PR?

## Testing

* Check pending claims are not clickable
* Check available claims on the main dashboard list are not clickable
* Check claim flow on right widget works the same as prod

### Engineering

<!-----------------------------------------------------------------------------
Include sufficient information here for an engineer to test your PR. This may include how to test locally, in a built environment, changes to infrastructure etc.
------------------------------------------------------------------------------>

### Operations

<!-----------------------------------------------------------------------------
If your changes have a user-facing impact, describe how a non-technical QA team can functionally test your changes in a preview environment.

If they are not user-facing please describe how to test for any regressions that may occur.
------------------------------------------------------------------------------>

## Screenshots (if applicable)



https://github.com/user-attachments/assets/20d10f4a-7702-4ff6-ba93-37c5b35fddda




