### PR TITLE
fix: symbol truncation regression

### DIFF
--- a/src/components/AssetSelection/components/AssetMenuButton.tsx
+++ b/src/components/AssetSelection/components/AssetMenuButton.tsx
@@ -39,11 +39,6 @@ export const AssetMenuButton = ({
     if (asset) onAssetClick?.(asset)
   }, [asset, onAssetClick])
 
-  const flexProps = useMemo(
-    () => ({ width: buttonProps?.rightIcon ? 'calc(100% - 32px)' : '100%' }),
-    [buttonProps?.rightIcon],
-  )
-
   if (!assetId || isLoading) return <AssetRowLoading {...buttonProps} />
 
   return (
@@ -55,7 +50,14 @@ export const AssetMenuButton = ({
       isLoading={isLoading}
       {...buttonProps}
     >
-      <Flex alignItems='center' gap={2} {...flexProps}>
+      <Flex
+        alignItems='center'
+        gap={2}
+        width='100%'
+        overflow='hidden'
+        textOverflow='ellisis'
+        whiteSpace='nowrap'
+      >
         {icon}
         <Text as='span' textOverflow='ellipsis' overflow='hidden'>
           {asset?.symbol}

--- a/src/components/AssetSelection/components/AssetMenuButton.tsx
+++ b/src/components/AssetSelection/components/AssetMenuButton.tsx
@@ -50,14 +50,7 @@ export const AssetMenuButton = ({
       isLoading={isLoading}
       {...buttonProps}
     >
-      <Flex
-        alignItems='center'
-        gap={2}
-        width='100%'
-        overflow='hidden'
-        textOverflow='ellisis'
-        whiteSpace='nowrap'
-      >
+      <Flex alignItems='center' gap={2} width='100%' overflow='hidden'>
         {icon}
         <Text as='span' textOverflow='ellipsis' overflow='hidden'>
           {asset?.symbol}


### PR DESCRIPTION
## Description

Fixes regression in https://github.com/shapeshift/web/pull/7491 causing asset symbols to always truncate.

**Production**

<img width="366" alt="Screenshot 2024-08-07 at 1 04 08 PM" src="https://github.com/user-attachments/assets/7ad4b36d-f600-42ac-ab0d-fea1506236bd">

**This PR**

<img width="356" alt="Screenshot 2024-08-07 at 1 03 50 PM" src="https://github.com/user-attachments/assets/d283985f-7b29-4c8e-bd47-37acb023e7cd">

## Pull Request Type

- [x] :bug: Bug fix (Non-breaking Change: Fixes an issue)
- [ ] :hammer_and_wrench: Chore (Non-breaking Change: Doc updates, pkg upgrades, typos, etc..)
- [ ] :nail_care: New Feature (Breaking/Non-breaking Change)

## Issue (if applicable)

Closes https://github.com/shapeshift/web/issues/7499

## Risk

Small

> What protocols, transaction types or contract interactions might be affected by this PR?

None.

## Testing

Ensure the asset symbols on the trade component only truncate when necessary even by zooming to 67% or 110% or any other zoom level

### Engineering

☝️

### Operations

☝️

## Screenshots (if applicable)

See above.