### PR TITLE
fix: no account copy

### DIFF
--- a/src/assets/translations/en/main.json
+++ b/src/assets/translations/en/main.json
@@ -919,7 +919,7 @@
     "unknownGas": "(unknown)",
     "numHops": "This trade includes %{numHops} hops",
     "receiveAddress": "Receive Address",
-    "receiveAddressDescription": "No %{chainName} address found from connected wallet. Manually enter an address or",
+    "receiveAddressDescription": "No %{chainName} address found from connected wallet. Manually enter an address",
     "smartContractReceiveAddressDescription": "We detected you are swapping from a smart contract whose address may not exist on the destination chain. Please verify and manually enter desired recipient address on %{chainName}",
     "toContinue": "to continue.",
     "addressPlaceholder": "%{chainName} address",

--- a/src/components/MultiHopTrade/components/TradeInput/components/ManualAddressEntry.tsx
+++ b/src/components/MultiHopTrade/components/TradeInput/components/ManualAddressEntry.tsx
@@ -141,7 +141,8 @@ export const ManualAddressEntry: FC<ManualAddressEntryProps> = memo(
               translate('trade.receiveAddressDescription', { chainName: buyAssetChainName })}
             {!isSnapInstalled && isSnapEnabled && wallet && isMetaMask(wallet) && (
               <Link textDecor='underline' ml={1} onClick={handleEnableShapeShiftSnap}>
-                {translate('trade.enableMetaMaskSnap')}
+                {translate('trade.or')}
+                &nbsp;{translate('trade.enableMetaMaskSnap')}
               </Link>
             )}
             {wallet && isLedger(wallet) && (


### PR DESCRIPTION
## Description

Fixes no account copy.

## Pull Request Type

- [ ] :bug: Bug fix (Non-breaking Change: Fixes an issue)
- [ ] :hammer_and_wrench: Chore (Non-breaking Change: Doc updates, pkg upgrades, typos, etc..)
- [ ] :nail_care: New Feature (Breaking/Non-breaking Change)

## Issue (if applicable)

Closes https://github.com/shapeshift/web/issues/7487

## Risk

Very low

> What protocols, transaction types or contract interactions might be affected by this PR?

None.

## Testing

When connected to a wallet that is missing an account that is not MetaMask:

<img width="349" alt="Screenshot 2024-08-07 at 1 28 30 PM" src="https://github.com/user-attachments/assets/d401c57c-d3f6-4cd1-aef5-d658be088e78">

When connected to a wallet that _is_ MetaMask with snaps available:

<img width="343" alt="Screenshot 2024-08-07 at 1 28 26 PM" src="https://github.com/user-attachments/assets/19c5235a-91ff-4298-9a6b-dd3982574af7">

### Engineering

☝️

### Operations

☝️

## Screenshots (if applicable)

See above.