### PR TITLE
fix: runepool checkbox visibility using light mode

### DIFF
--- a/src/features/defi/providers/thorchain-savers/components/ThorchainSaversManager/Overview/ThorchainSaversEmpty.tsx
+++ b/src/features/defi/providers/thorchain-savers/components/ThorchainSaversManager/Overview/ThorchainSaversEmpty.tsx
@@ -53,7 +53,17 @@ export const ThorchainSaversEmpty = ({ assetId, onClick }: ThorchainSaversEmptyP
     '--chakra-colors-blackAlpha-400',
   )
   const backgroundColor = useColorModeValue('gray.100', 'darkNeutralAlpha.700')
+  const checkboxBackground = useColorModeValue('white', 'transparent')
   const isRunePool = assetId === thorchainAssetId
+
+  const checkboxStyles = useMemo(
+    () => ({
+      '.chakra-checkbox__control:not([data-checked])': {
+        background: checkboxBackground,
+      },
+    }),
+    [checkboxBackground],
+  )
 
   const [hasAgreed, setHasAgreed] = useState(false)
 
@@ -103,7 +113,7 @@ export const ThorchainSaversEmpty = ({ assetId, onClick }: ThorchainSaversEmptyP
         </Alert>
         {isRunePool ? (
           <Box borderRadius='xl' background={backgroundColor}>
-            <Checkbox isChecked={hasAgreed} onChange={handleHasAgreed} p={4}>
+            <Checkbox sx={checkboxStyles} isChecked={hasAgreed} onChange={handleHasAgreed} p={4}>
               {translate('defi.modals.saversVaults.agreeRunePool.1')}
             </Checkbox>
           </Box>
@@ -134,6 +144,7 @@ export const ThorchainSaversEmpty = ({ assetId, onClick }: ThorchainSaversEmptyP
     backgroundColor,
     isRunePool,
     onClick,
+    checkboxStyles,
   ])
 
   // @TODO: update the RUNEPool link a better article exists


### PR DESCRIPTION
## Description
On light mode, the runepool checkbox was hard to see, I changed its background to white on light mode and kept transparent on dark mode
<!-- Please describe your changes -->

## Pull Request Type

- [x] :bug: Bug fix (Non-breaking Change: Fixes an issue)
- [ ] :hammer_and_wrench: Chore (Non-breaking Change: Doc updates, pkg upgrades, typos, etc..)
- [ ] :nail_care: New Feature (Breaking/Non-breaking Change)

## Issue (if applicable)

<!-----------------------------------------------------------------------------
If applicable, please link to the github issue and put `closes #XXXX` in your comment to auto-close the issue that your PR fixes.
------------------------------------------------------------------------------>

No issue

## Risk
> High Risk PRs Require 2 approvals

<!-----------------------------------------------------------------------------
Outline the scope of your changes and the risk associated with them. You must use your discretion as an engineer to determine the potential impact of your changes.

WARNING: If your PR introduces a new on-chain transaction or modifies an existing one, please add the "High-Risk" label to this PR and ask for 2 reviewers to approve it before merging.

E.g. an upgrade to `hdwallet` or core state management would be considered higher risk, and might require a full regression test. UI or isolated view changes, or something behind a feature flag may have near zero risk. Small bug fixes might require testing isolated to the specific fix.
------------------------------------------------------------------------------>

> What protocols, transaction types, wallets or contract interactions might be affected by this PR?

## Testing
Open the runepool overview page if you don't have any liquidity in it and look at the checkbox using both light and dark mode, checked and not checked
<!-----------------------------------------------------------------------------
We treat every PR to be merged with the same scrutiny as if we were merging directly to production.

Your PR will not be merged if you do not complete the sections below for our engineering and operations teams to test.
------------------------------------------------------------------------------>

### Engineering
n/a
<!-----------------------------------------------------------------------------
Include sufficient information here for an engineer to test your PR. This may include how to test locally, in a built environment, changes to infrastructure etc.
------------------------------------------------------------------------------>

### Operations
n/a

- [ ] :checkered_flag: My feature is behind a flag and doesn't require operations testing (yet)

<!-----------------------------------------------------------------------------
If your changes have a user-facing impact, describe how a non-technical QA team can functionally test your changes in a preview environment.

If they are not user-facing please describe how to test for any regressions that may occur.
------------------------------------------------------------------------------>

## Screenshots (if applicable)
Before
![image](https://github.com/user-attachments/assets/fa6406dd-e52c-4a70-8ecd-859e1d1b35dd)

After
![image](https://github.com/user-attachments/assets/566cff61-b89f-47a3-9bf6-6074b100d5f2)
![image](https://github.com/user-attachments/assets/4a5e0f76-f7f7-4ca4-853d-1be75ed41de6)
![image](https://github.com/user-attachments/assets/67efac05-a893-4c21-b81d-c54097afd70e)
![image](https://github.com/user-attachments/assets/43357e5f-9c69-4f1b-8c90-9353545162c6)
