### PR TITLE
fix: ledger approval signing

### DIFF
--- a/src/components/MultiHopTrade/components/MultiHopTradeConfirm/components/ApprovalStep.tsx
+++ b/src/components/MultiHopTrade/components/MultiHopTradeConfirm/components/ApprovalStep.tsx
@@ -160,6 +160,8 @@ const ApprovalStepPending = ({
       await approveMutation.mutateAsync()
     } catch (error) {
       console.error(error)
+    } finally {
+      setFeeQueryEnabled(true)
     }
   }, [approveMutation, checkLedgerAppOpenIfLedgerConnected, tradeQuoteStep.sellAsset.chainId])
 

--- a/src/components/MultiHopTrade/components/MultiHopTradeConfirm/components/ApprovalStep.tsx
+++ b/src/components/MultiHopTrade/components/MultiHopTradeConfirm/components/ApprovalStep.tsx
@@ -12,7 +12,7 @@ import {
 } from '@chakra-ui/react'
 import type { TradeQuoteStep } from '@shapeshiftoss/swapper'
 import { SwapperName } from '@shapeshiftoss/swapper'
-import { useCallback, useMemo } from 'react'
+import { useCallback, useEffect, useMemo, useState } from 'react'
 import { FaInfoCircle } from 'react-icons/fa'
 import { useTranslate } from 'react-polyglot'
 import { MiddleEllipsis } from 'components/MiddleEllipsis/MiddleEllipsis'
@@ -112,6 +112,8 @@ const ApprovalStepPending = ({
     number: { toCrypto },
   } = useLocaleFormatter()
 
+  const [feeQueryEnabled, setFeeQueryEnabled] = useState(true)
+
   const isLifiStep = useMemo(() => {
     return tradeQuoteStep.source.startsWith(SwapperName.LIFI)
   }, [tradeQuoteStep.source])
@@ -134,11 +136,16 @@ const ApprovalStepPending = ({
     return isExactAllowance ? AllowanceType.Exact : AllowanceType.Unlimited
   }, [isAllowanceResetStep, isExactAllowance])
 
+  // Ensure only one fee query is made at a time (reset or approval) to avoid race conditions with Ledger
+  useEffect(() => {
+    setFeeQueryEnabled(!isAllowanceResetStep && !isAwaitingReset)
+  }, [isAllowanceResetStep, isAwaitingReset])
+
   const {
     approveMutation,
     approvalNetworkFeeCryptoBaseUnit,
     isLoading: isAllowanceApprovalLoading,
-  } = useAllowanceApproval(tradeQuoteStep, hopIndex, allowanceType)
+  } = useAllowanceApproval(tradeQuoteStep, hopIndex, allowanceType, feeQueryEnabled)
 
   const isApprovalStep = useMemo(() => {
     return !isAllowanceResetStep && state === HopExecutionState.AwaitingApproval
@@ -147,9 +154,13 @@ const ApprovalStepPending = ({
   const handleSignAllowanceApproval = useCallback(async () => {
     // Only proceed to execute the approval if the promise is resolved, i.e the user has opened the
     // Ledger app without cancelling
-    await checkLedgerAppOpenIfLedgerConnected(tradeQuoteStep.sellAsset.chainId)
-      .then(() => approveMutation.mutateAsync())
-      .catch(console.error)
+    try {
+      await checkLedgerAppOpenIfLedgerConnected(tradeQuoteStep.sellAsset.chainId)
+      setFeeQueryEnabled(false)
+      await approveMutation.mutateAsync()
+    } catch (error) {
+      console.error(error)
+    }
   }, [approveMutation, checkLedgerAppOpenIfLedgerConnected, tradeQuoteStep.sellAsset.chainId])
 
   const feeAsset = useAppSelector(state =>

--- a/src/components/MultiHopTrade/components/MultiHopTradeConfirm/hooks/useAllowanceApproval.tsx
+++ b/src/components/MultiHopTrade/components/MultiHopTradeConfirm/hooks/useAllowanceApproval.tsx
@@ -21,6 +21,7 @@ export const useAllowanceApproval = (
   tradeQuoteStep: TradeQuoteStep,
   hopIndex: number,
   allowanceType: AllowanceType,
+  feeQueryEnabled: boolean,
 ) => {
   const dispatch = useAppDispatch()
   const { showErrorToast } = useErrorHandler()
@@ -36,6 +37,7 @@ export const useAllowanceApproval = (
     from: sellAssetAccountId ? fromAccountId(sellAssetAccountId).account : undefined,
     allowanceType,
     spender: tradeQuoteStep.allowanceContract,
+    enabled: feeQueryEnabled,
   })
 
   useEffect(() => {

--- a/src/hooks/queries/useApprovalFees.ts
+++ b/src/hooks/queries/useApprovalFees.ts
@@ -58,7 +58,6 @@ export const useApprovalFees = ({
     })
   }, [allowanceType, amountCryptoBaseUnit, chainId, spender, to])
 
-  console.log('xxx useApprovalFees useEvmFees', enabled, allowanceType)
   const evmFeesResult = useEvmFees({
     accountNumber,
     to,

--- a/src/hooks/queries/useApprovalFees.ts
+++ b/src/hooks/queries/useApprovalFees.ts
@@ -21,6 +21,7 @@ type UseApprovalFeesInput = {
   spender: string
   amountCryptoBaseUnit: string
   allowanceType: AllowanceType
+  enabled: boolean
 }
 
 export const useApprovalFees = ({
@@ -30,6 +31,7 @@ export const useApprovalFees = ({
   from,
   allowanceType,
   spender,
+  enabled,
 }: UseApprovalFeesInput) => {
   const { assetReference: to, chainId } = useMemo(() => {
     return fromAssetId(assetId)
@@ -56,13 +58,14 @@ export const useApprovalFees = ({
     })
   }, [allowanceType, amountCryptoBaseUnit, chainId, spender, to])
 
+  console.log('xxx useApprovalFees useEvmFees', enabled, allowanceType)
   const evmFeesResult = useEvmFees({
     accountNumber,
     to,
     value: '0',
     chainId,
     data: approveContractData,
-    enabled: Boolean(isApprovalRequired),
+    enabled: Boolean(isApprovalRequired && enabled),
     refetchIntervalInBackground: true,
     refetchInterval: isApprovalRequired ? 15_000 : false,
   })


### PR DESCRIPTION
## Description

Fixes an regression in https://github.com/shapeshift/web/pull/7392 that prevented us from signing approvals/resets on Ledger devices.

The new `useEvmFees` hook was periodically firing the `evmFees` query which hijacked the Ledger adapter's call to `adapter.signTransaction` whilst we were waiting for the user to confirm the TX on their Ledger.

This PR disables the offending query once the signing request has been initiated so no more calls are made to the adapter until the transaction is signed.

## Pull Request Type

- [x] :bug: Bug fix (Non-breaking Change: Fixes an issue)
- [ ] :hammer_and_wrench: Chore (Non-breaking Change: Doc updates, pkg upgrades, typos, etc..)
- [ ] :nail_care: New Feature (Breaking/Non-breaking Change)

## Issue (if applicable)

Closes https://github.com/shapeshift/web/issues/7537

## Risk

Medium - relates to fees and signing.

> What protocols, transaction types, wallets or contract interactions might be affected by this PR?

Signing approvals and resets with a Ledger.

## Testing

- With a Ledger connected ensure that both resets and approvals work as expected. You should be able to leave the signing request open on the Ledger for more than a couple of seconds without being rugged.

- Other wallets should work as expected

### Engineering

☝️

### Operations
- [ ] :checkered_flag: My feature is behind a flag and doesn't require operations testing (yet)

☝️

## Screenshots (if applicable)

N/A