### PR TITLE
fix: deadclick on qrcode modal

### DIFF
--- a/src/components/Modals/Send/views/Address.tsx
+++ b/src/components/Modals/Send/views/Address.tsx
@@ -34,6 +34,7 @@ export const Address = () => {
   const address = useWatch<SendInput, SendFormFields.To>({ name: SendFormFields.To })
   const input = useWatch<SendInput, SendFormFields.Input>({ name: SendFormFields.Input })
   const send = useModal('send')
+  const qrCode = useModal('qrCode')
   const assetId = useWatch<SendInput, SendFormFields.AssetId>({ name: SendFormFields.AssetId })
 
   const asset = useAppSelector(state => selectAssetById(state, assetId))
@@ -85,7 +86,11 @@ export const Address = () => {
     [asset, setValue],
   )
 
-  const handleCancel = useCallback(() => send.close(), [send])
+  const handleCancel = useCallback(() => {
+    // Sends may be done from the context of a QR code modal, or a send modal, which are similar, but effectively diff. modal refs
+    send.close?.()
+    qrCode.close?.()
+  }, [send, qrCode])
 
   if (!asset) return null
 

--- a/src/components/Modals/Send/views/Details.tsx
+++ b/src/components/Modals/Send/views/Details.tsx
@@ -92,7 +92,9 @@ export const Details = () => {
     [amountCryptoPrecision, fiatAmount, previousAccountId, setValue],
   )
 
-  const { close: handleClose } = useModal('send')
+  const send = useModal('send')
+  const qrCode = useModal('qrCode')
+
   const {
     balancesLoading,
     fieldName,
@@ -177,6 +179,12 @@ export const Details = () => {
     () => ['modals.send.sendForm.assetMemo', { assetSymbol: asset?.symbol ?? '' }],
     [asset?.symbol],
   )
+
+  const handleClose = useCallback(() => {
+    // Sends may be done from the context of a QR code modal, or a send modal, which are similar, but effectively diff. modal refs
+    send.close?.()
+    qrCode.close?.()
+  }, [send, qrCode])
 
   const handleArrowBackClick = useCallback(() => history.push(SendRoutes.Address), [history])
   const handleAccountCardClick = useCallback(() => history.push('/send/select'), [history])


### PR DESCRIPTION
## Description
This is impossible to click on the cancel button using the QRCode modal

Previously we were using the `send` modal context, but we are actually using the `qrCode` modal context, we should execute both depending on the context

<!-- Please describe your changes -->

## Pull Request Type

- [x] :bug: Bug fix (Non-breaking Change: Fixes an issue)
- [ ] :hammer_and_wrench: Chore (Non-breaking Change: Doc updates, pkg upgrades, typos, etc..)
- [ ] :nail_care: New Feature (Breaking/Non-breaking Change)

## Issue (if applicable)

<!-----------------------------------------------------------------------------
If applicable, please link to the github issue and put `closes #XXXX` in your comment to auto-close the issue that your PR fixes.
------------------------------------------------------------------------------>

closes #7511

## Risk
Low

> What protocols, transaction types, wallets or contract interactions might be affected by this PR?

## Testing
- Use the QR code button in the wallet page
- Scan a QR code 
- Click the cancel button, the modal should close

### Engineering
n/a

### Operations
n/a
- [ ] :checkered_flag: My feature is behind a flag and doesn't require operations testing (yet)

<!-----------------------------------------------------------------------------
If your changes have a user-facing impact, describe how a non-technical QA team can functionally test your changes in a preview environment.

If they are not user-facing please describe how to test for any regressions that may occur.
------------------------------------------------------------------------------>

## Screenshots (if applicable)
See the issue, do the same process! I don't have access to jam on the browser I'm testing the QR code scan... 🙏 