### PR TITLE
fix: network icon size

### DIFF
--- a/src/components/ChainMenu.tsx
+++ b/src/components/ChainMenu.tsx
@@ -70,7 +70,7 @@ const ChainMenuItem = <T extends ChainId | 'All'>({
 
     return {
       chainName: adapter?.getDisplayName(),
-      assetIcon: <ChainIcon chainId={chainId} width='6' height='auto' />,
+      assetIcon: <ChainIcon chainId={chainId} boxSize='6' />,
     }
   }, [chainId])
 
@@ -116,7 +116,7 @@ const MenuIcon = <T extends ChainId | 'All'>({
     return translate('common.all')
   }
 
-  return <ChainIcon chainId={activeChainId} width='6' height='auto' />
+  return <ChainIcon chainId={activeChainId} boxSize='6' />
 }
 
 const GenericChainMenu = <T extends ChainId | 'All'>({


### PR DESCRIPTION
## Description
Since we migrated our AssetIcon to be LazyLoaded, we have some places where icons are not really well size-adapted

The network icon is one of these places, I basically changed some properties to use the properties we usually use to size the icon, boxSize is prefered over width with a height: auto for this place

<!-- Please describe your changes -->

## Pull Request Type

- [x] :bug: Bug fix (Non-breaking Change: Fixes an issue)
- [ ] :hammer_and_wrench: Chore (Non-breaking Change: Doc updates, pkg upgrades, typos, etc..)
- [ ] :nail_care: New Feature (Breaking/Non-breaking Change)

## Issue (if applicable)

<!-----------------------------------------------------------------------------
If applicable, please link to the github issue and put `closes #XXXX` in your comment to auto-close the issue that your PR fixes.
------------------------------------------------------------------------------>
No issue, discovered it while fixing another thing

## Risk
Very low

> What protocols, transaction types, wallets or contract interactions might be affected by this PR?

## Testing
<!-----------------------------------------------------------------------------
We treat every PR to be merged with the same scrutiny as if we were merging directly to production.

Your PR will not be merged if you do not complete the sections below for our engineering and operations teams to test.
------------------------------------------------------------------------------>

### Engineering
n/a

<!-----------------------------------------------------------------------------
Include sufficient information here for an engineer to test your PR. This may include how to test locally, in a built environment, changes to infrastructure etc.
------------------------------------------------------------------------------>

### Operations
n/a
- [ ] :checkered_flag: My feature is behind a flag and doesn't require operations testing (yet)

<!-----------------------------------------------------------------------------
If your changes have a user-facing impact, describe how a non-technical QA team can functionally test your changes in a preview environment.

If they are not user-facing please describe how to test for any regressions that may occur.
------------------------------------------------------------------------------>

## Screenshots (if applicable)
After
<img width="206" alt="image" src="https://github.com/user-attachments/assets/b6a6692e-520b-4963-985f-0069f122321b">

Before
<img width="176" alt="image" src="https://github.com/user-attachments/assets/c05d5d6a-0c2a-4d8f-ba34-4b86aa1e0d4d">
