### PR TITLE
fix: swapper state corruption

### DIFF
--- a/src/components/MultiHopTrade/components/MultiHopTradeConfirm/MultiHopTradeConfirm.tsx
+++ b/src/components/MultiHopTrade/components/MultiHopTradeConfirm/MultiHopTradeConfirm.tsx
@@ -41,10 +41,10 @@ export const MultiHopTradeConfirm = memo(() => {
   const { isLoading } = useIsApprovalInitiallyNeeded()
 
   useEffect(() => {
-    if (isLoading) return
+    if (isLoading || !activeQuote) return
 
-    dispatch(tradeQuoteSlice.actions.setTradeInitialized())
-  }, [dispatch, isLoading])
+    dispatch(tradeQuoteSlice.actions.setTradeInitialized(activeQuote.id))
+  }, [dispatch, isLoading, activeQuote])
 
   const isTradeComplete = useMemo(
     () => tradeExecutionState === TradeExecutionState.TradeComplete,
@@ -81,8 +81,9 @@ export const MultiHopTradeConfirm = memo(() => {
   ])
 
   const handleTradeConfirm = useCallback(() => {
-    dispatch(tradeQuoteSlice.actions.confirmTrade())
-  }, [dispatch])
+    if (!activeQuote) return
+    dispatch(tradeQuoteSlice.actions.confirmTrade(activeQuote.id))
+  }, [dispatch, activeQuote])
 
   const handleSubmit = useCallback(() => {
     if (isModeratePriceImpact) {
@@ -91,6 +92,8 @@ export const MultiHopTradeConfirm = memo(() => {
       handleTradeConfirm()
     }
   }, [handleTradeConfirm, isModeratePriceImpact])
+
+  if (!tradeExecutionState) return null
 
   return (
     <TradeSlideTransition>

--- a/src/components/MultiHopTrade/components/MultiHopTradeConfirm/MultiHopTradeConfirm.tsx
+++ b/src/components/MultiHopTrade/components/MultiHopTradeConfirm/MultiHopTradeConfirm.tsx
@@ -11,7 +11,7 @@ import { Text } from 'components/Text'
 import { bnOrZero } from 'lib/bignumber/bignumber'
 import {
   selectActiveQuote,
-  selectTradeExecutionState,
+  selectConfirmedTradeExecutionState,
 } from 'state/slices/tradeQuoteSlice/selectors'
 import { tradeQuoteSlice } from 'state/slices/tradeQuoteSlice/tradeQuoteSlice'
 import { TradeExecutionState } from 'state/slices/tradeQuoteSlice/types'
@@ -30,8 +30,8 @@ const useDisclosureProps = {
 export const MultiHopTradeConfirm = memo(() => {
   const dispatch = useAppDispatch()
   const translate = useTranslate()
-  const tradeExecutionState = useAppSelector(selectTradeExecutionState)
-  const previousTradeExecutionState = usePrevious(tradeExecutionState)
+  const confirmedTradeExecutionState = useAppSelector(selectConfirmedTradeExecutionState)
+  const previousTradeExecutionState = usePrevious(confirmedTradeExecutionState)
   const history = useHistory()
 
   const [shouldShowWarningAcknowledgement, setShouldShowWarningAcknowledgement] = useState(false)
@@ -47,8 +47,8 @@ export const MultiHopTradeConfirm = memo(() => {
   }, [dispatch, isLoading, activeQuote])
 
   const isTradeComplete = useMemo(
-    () => tradeExecutionState === TradeExecutionState.TradeComplete,
-    [tradeExecutionState],
+    () => confirmedTradeExecutionState === TradeExecutionState.TradeComplete,
+    [confirmedTradeExecutionState],
   )
 
   const handleBack = useCallback(() => {
@@ -65,7 +65,7 @@ export const MultiHopTradeConfirm = memo(() => {
   // toggle hop open states as we transition to the next hop
   useEffect(() => {
     if (
-      previousTradeExecutionState !== tradeExecutionState &&
+      previousTradeExecutionState !== confirmedTradeExecutionState &&
       previousTradeExecutionState === TradeExecutionState.FirstHop
     ) {
       if (isFirstHopOpen) onToggleFirstHop()
@@ -77,7 +77,7 @@ export const MultiHopTradeConfirm = memo(() => {
     onToggleFirstHop,
     onToggleSecondHop,
     previousTradeExecutionState,
-    tradeExecutionState,
+    confirmedTradeExecutionState,
   ])
 
   const handleTradeConfirm = useCallback(() => {
@@ -93,7 +93,7 @@ export const MultiHopTradeConfirm = memo(() => {
     }
   }, [handleTradeConfirm, isModeratePriceImpact])
 
-  if (!tradeExecutionState) return null
+  if (!confirmedTradeExecutionState) return null
 
   return (
     <TradeSlideTransition>
@@ -118,7 +118,7 @@ export const MultiHopTradeConfirm = memo(() => {
                 <Text
                   translation={
                     [TradeExecutionState.Initializing, TradeExecutionState.Previewing].includes(
-                      tradeExecutionState,
+                      confirmedTradeExecutionState,
                     )
                       ? 'trade.confirmDetails'
                       : 'trade.trade'

--- a/src/components/MultiHopTrade/components/MultiHopTradeConfirm/components/ApprovalStep.tsx
+++ b/src/components/MultiHopTrade/components/MultiHopTradeConfirm/components/ApprovalStep.tsx
@@ -39,7 +39,7 @@ export type ApprovalStepProps = {
   isLastStep?: boolean
   isLoading?: boolean
   isAllowanceResetStep: boolean
-  tradeId: TradeQuote['id']
+  activeTradeId: TradeQuote['id']
 }
 
 type ApprovalDescriptionProps = {
@@ -108,7 +108,7 @@ const ApprovalStepPending = ({
   isLastStep,
   isLoading,
   isAllowanceResetStep,
-  tradeId,
+  activeTradeId,
 }: ApprovalStepProps) => {
   const {
     number: { toCrypto },
@@ -126,7 +126,7 @@ const ApprovalStepPending = ({
   const checkLedgerAppOpenIfLedgerConnected = useLedgerOpenApp()
 
   const { state, allowanceReset, approval } = useAppSelector(state =>
-    selectHopExecutionMetadata(state, tradeId, hopIndex),
+    selectHopExecutionMetadata(state, activeTradeId, hopIndex),
   )
 
   const isAwaitingReset = useMemo(() => {
@@ -147,7 +147,7 @@ const ApprovalStepPending = ({
     approveMutation,
     approvalNetworkFeeCryptoBaseUnit,
     isLoading: isAllowanceApprovalLoading,
-  } = useAllowanceApproval(tradeQuoteStep, hopIndex, allowanceType, feeQueryEnabled, tradeId)
+  } = useAllowanceApproval(tradeQuoteStep, hopIndex, allowanceType, feeQueryEnabled, activeTradeId)
 
   const isApprovalStep = useMemo(() => {
     return !isAllowanceResetStep && state === HopExecutionState.AwaitingApproval
@@ -371,11 +371,11 @@ const ApprovalStepComplete = ({
   isLastStep,
   isLoading,
   isAllowanceResetStep,
-  tradeId,
+  activeTradeId,
 }: ApprovalStepProps) => {
   const translate = useTranslate()
   const { state, allowanceReset, approval } = useAppSelector(state =>
-    selectHopExecutionMetadata(state, tradeId, hopIndex),
+    selectHopExecutionMetadata(state, activeTradeId, hopIndex),
   )
 
   const stepIndicator = useMemo(() => {
@@ -451,9 +451,11 @@ export const ApprovalStep = ({
   isLastStep,
   isLoading,
   isAllowanceResetStep,
-  tradeId,
+  activeTradeId,
 }: ApprovalStepProps) => {
-  const { state } = useAppSelector(state => selectHopExecutionMetadata(state, tradeId, hopIndex))
+  const { state } = useAppSelector(state =>
+    selectHopExecutionMetadata(state, activeTradeId, hopIndex),
+  )
 
   const isComplete = useMemo(() => {
     switch (isAllowanceResetStep) {
@@ -477,7 +479,7 @@ export const ApprovalStep = ({
       isLastStep={isLastStep}
       isLoading={isLoading}
       isAllowanceResetStep={isAllowanceResetStep}
-      tradeId={tradeId}
+      activeTradeId={activeTradeId}
     />
   ) : (
     <ApprovalStepPending
@@ -487,7 +489,7 @@ export const ApprovalStep = ({
       isLastStep={isLastStep}
       isLoading={isLoading}
       isAllowanceResetStep={isAllowanceResetStep}
-      tradeId={tradeId}
+      activeTradeId={activeTradeId}
     />
   )
 }

--- a/src/components/MultiHopTrade/components/MultiHopTradeConfirm/components/ApprovalStep.tsx
+++ b/src/components/MultiHopTrade/components/MultiHopTradeConfirm/components/ApprovalStep.tsx
@@ -10,7 +10,7 @@ import {
   Tooltip,
   VStack,
 } from '@chakra-ui/react'
-import type { TradeQuoteStep } from '@shapeshiftoss/swapper'
+import type { TradeQuote, TradeQuoteStep } from '@shapeshiftoss/swapper'
 import { SwapperName } from '@shapeshiftoss/swapper'
 import { useCallback, useEffect, useMemo, useState } from 'react'
 import { FaInfoCircle } from 'react-icons/fa'
@@ -39,6 +39,7 @@ export type ApprovalStepProps = {
   isLastStep?: boolean
   isLoading?: boolean
   isAllowanceResetStep: boolean
+  tradeId: TradeQuote['id']
 }
 
 type ApprovalDescriptionProps = {
@@ -107,6 +108,7 @@ const ApprovalStepPending = ({
   isLastStep,
   isLoading,
   isAllowanceResetStep,
+  tradeId,
 }: ApprovalStepProps) => {
   const {
     number: { toCrypto },
@@ -124,7 +126,7 @@ const ApprovalStepPending = ({
   const checkLedgerAppOpenIfLedgerConnected = useLedgerOpenApp()
 
   const { state, allowanceReset, approval } = useAppSelector(state =>
-    selectHopExecutionMetadata(state, hopIndex),
+    selectHopExecutionMetadata(state, tradeId, hopIndex),
   )
 
   const isAwaitingReset = useMemo(() => {
@@ -145,7 +147,7 @@ const ApprovalStepPending = ({
     approveMutation,
     approvalNetworkFeeCryptoBaseUnit,
     isLoading: isAllowanceApprovalLoading,
-  } = useAllowanceApproval(tradeQuoteStep, hopIndex, allowanceType, feeQueryEnabled)
+  } = useAllowanceApproval(tradeQuoteStep, hopIndex, allowanceType, feeQueryEnabled, tradeId)
 
   const isApprovalStep = useMemo(() => {
     return !isAllowanceResetStep && state === HopExecutionState.AwaitingApproval
@@ -369,10 +371,11 @@ const ApprovalStepComplete = ({
   isLastStep,
   isLoading,
   isAllowanceResetStep,
+  tradeId,
 }: ApprovalStepProps) => {
   const translate = useTranslate()
   const { state, allowanceReset, approval } = useAppSelector(state =>
-    selectHopExecutionMetadata(state, hopIndex),
+    selectHopExecutionMetadata(state, tradeId, hopIndex),
   )
 
   const stepIndicator = useMemo(() => {
@@ -448,8 +451,9 @@ export const ApprovalStep = ({
   isLastStep,
   isLoading,
   isAllowanceResetStep,
+  tradeId,
 }: ApprovalStepProps) => {
-  const { state } = useAppSelector(state => selectHopExecutionMetadata(state, hopIndex))
+  const { state } = useAppSelector(state => selectHopExecutionMetadata(state, tradeId, hopIndex))
 
   const isComplete = useMemo(() => {
     switch (isAllowanceResetStep) {
@@ -473,6 +477,7 @@ export const ApprovalStep = ({
       isLastStep={isLastStep}
       isLoading={isLoading}
       isAllowanceResetStep={isAllowanceResetStep}
+      tradeId={tradeId}
     />
   ) : (
     <ApprovalStepPending
@@ -482,6 +487,7 @@ export const ApprovalStep = ({
       isLastStep={isLastStep}
       isLoading={isLoading}
       isAllowanceResetStep={isAllowanceResetStep}
+      tradeId={tradeId}
     />
   )
 }

--- a/src/components/MultiHopTrade/components/MultiHopTradeConfirm/components/Footer.tsx
+++ b/src/components/MultiHopTrade/components/MultiHopTradeConfirm/components/Footer.tsx
@@ -18,10 +18,10 @@ import type { TextPropTypes } from 'components/Text/Text'
 import { bnOrZero } from 'lib/bignumber/bignumber'
 import {
   selectActiveSwapperName,
+  selectConfirmedTradeExecutionState,
   selectLastHopBuyAsset,
   selectQuoteSellAmountUserCurrency,
   selectTotalNetworkFeeUserCurrencyPrecision,
-  selectTradeExecutionState,
 } from 'state/slices/tradeQuoteSlice/selectors'
 import { TradeExecutionState } from 'state/slices/tradeQuoteSlice/types'
 import { useAppSelector } from 'state/store'
@@ -35,7 +35,7 @@ export const Footer: FC<FooterProps> = ({ isLoading, handleSubmit }) => {
   const translate = useTranslate()
   const swapperName = useAppSelector(selectActiveSwapperName)
   const lastHopBuyAsset = useAppSelector(selectLastHopBuyAsset)
-  const tradeExecutionState = useAppSelector(selectTradeExecutionState)
+  const confirmedTradeExecutionState = useAppSelector(selectConfirmedTradeExecutionState)
   const networkFeeUserCurrency = useAppSelector(selectTotalNetworkFeeUserCurrencyPrecision)
   const sellAmountBeforeFeesUserCurrency = useAppSelector(selectQuoteSellAmountUserCurrency)
 
@@ -103,10 +103,10 @@ export const Footer: FC<FooterProps> = ({ isLoading, handleSubmit }) => {
     )
   }, [swapperName, lastHopBuyAsset, translate])
 
-  if (!tradeExecutionState) return null
+  if (!confirmedTradeExecutionState) return null
 
   return [TradeExecutionState.Initializing, TradeExecutionState.Previewing].includes(
-    tradeExecutionState,
+    confirmedTradeExecutionState,
   ) ? (
     <CardFooter
       flexDir='column'
@@ -137,7 +137,7 @@ export const Footer: FC<FooterProps> = ({ isLoading, handleSubmit }) => {
         size='lg'
         width='full'
         onClick={handleSubmit}
-        isLoading={isLoading || tradeExecutionState === TradeExecutionState.Initializing}
+        isLoading={isLoading || confirmedTradeExecutionState === TradeExecutionState.Initializing}
       >
         <Text translation={'trade.confirmAndTrade'} />
       </Button>

--- a/src/components/MultiHopTrade/components/MultiHopTradeConfirm/components/Footer.tsx
+++ b/src/components/MultiHopTrade/components/MultiHopTradeConfirm/components/Footer.tsx
@@ -103,6 +103,8 @@ export const Footer: FC<FooterProps> = ({ isLoading, handleSubmit }) => {
     )
   }, [swapperName, lastHopBuyAsset, translate])
 
+  if (!tradeExecutionState) return null
+
   return [TradeExecutionState.Initializing, TradeExecutionState.Previewing].includes(
     tradeExecutionState,
   ) ? (

--- a/src/components/MultiHopTrade/components/MultiHopTradeConfirm/components/Hop.tsx
+++ b/src/components/MultiHopTrade/components/MultiHopTradeConfirm/components/Hop.tsx
@@ -13,6 +13,7 @@ import {
 import type {
   SupportedTradeQuoteStepIndex,
   SwapperName,
+  TradeQuote,
   TradeQuoteStep,
 } from '@shapeshiftoss/swapper'
 import prettyMilliseconds from 'pretty-ms'
@@ -56,6 +57,7 @@ export const Hop = ({
   isOpen,
   slippageTolerancePercentageDecimal,
   onToggleIsOpen,
+  tradeId,
 }: {
   swapperName: SwapperName
   tradeQuoteStep: TradeQuoteStep
@@ -63,6 +65,7 @@ export const Hop = ({
   isOpen: boolean
   slippageTolerancePercentageDecimal: string | undefined
   onToggleIsOpen?: () => void
+  tradeId: TradeQuote['id']
 }) => {
   const {
     number: { toCrypto },
@@ -81,7 +84,7 @@ export const Hop = ({
     approval,
     swap,
     allowanceReset,
-  } = useAppSelector(state => selectHopExecutionMetadata(state, hopIndex))
+  } = useAppSelector(state => selectHopExecutionMetadata(state, tradeId, hopIndex))
 
   const isError = useMemo(
     () => [approval.state, swap.state].includes(TransactionExecutionState.Failed),
@@ -211,6 +214,7 @@ export const Hop = ({
                 hopIndex={hopIndex}
                 isActive={hopExecutionState === HopExecutionState.AwaitingApprovalReset}
                 isAllowanceResetStep={true}
+                tradeId={tradeId}
               />
             )}
           </Collapse>
@@ -221,6 +225,7 @@ export const Hop = ({
                 hopIndex={hopIndex}
                 isActive={hopExecutionState === HopExecutionState.AwaitingApproval}
                 isAllowanceResetStep={false}
+                tradeId={tradeId}
               />
             )}
           </Collapse>
@@ -230,6 +235,7 @@ export const Hop = ({
             isActive={hopExecutionState === HopExecutionState.AwaitingSwap}
             hopIndex={hopIndex}
             isLastStep={!shouldRenderFinalSteps}
+            tradeId={tradeId}
           />
           {shouldRenderFinalSteps ? <FeeStep /> : null}
           {shouldRenderFinalSteps && (

--- a/src/components/MultiHopTrade/components/MultiHopTradeConfirm/components/Hop.tsx
+++ b/src/components/MultiHopTrade/components/MultiHopTradeConfirm/components/Hop.tsx
@@ -57,7 +57,7 @@ export const Hop = ({
   isOpen,
   slippageTolerancePercentageDecimal,
   onToggleIsOpen,
-  tradeId,
+  activeTradeId,
 }: {
   swapperName: SwapperName
   tradeQuoteStep: TradeQuoteStep
@@ -65,7 +65,7 @@ export const Hop = ({
   isOpen: boolean
   slippageTolerancePercentageDecimal: string | undefined
   onToggleIsOpen?: () => void
-  tradeId: TradeQuote['id']
+  activeTradeId: TradeQuote['id']
 }) => {
   const {
     number: { toCrypto },
@@ -84,7 +84,7 @@ export const Hop = ({
     approval,
     swap,
     allowanceReset,
-  } = useAppSelector(state => selectHopExecutionMetadata(state, tradeId, hopIndex))
+  } = useAppSelector(state => selectHopExecutionMetadata(state, activeTradeId, hopIndex))
 
   const isError = useMemo(
     () => [approval.state, swap.state].includes(TransactionExecutionState.Failed),
@@ -214,7 +214,7 @@ export const Hop = ({
                 hopIndex={hopIndex}
                 isActive={hopExecutionState === HopExecutionState.AwaitingApprovalReset}
                 isAllowanceResetStep={true}
-                tradeId={tradeId}
+                activeTradeId={activeTradeId}
               />
             )}
           </Collapse>
@@ -225,7 +225,7 @@ export const Hop = ({
                 hopIndex={hopIndex}
                 isActive={hopExecutionState === HopExecutionState.AwaitingApproval}
                 isAllowanceResetStep={false}
-                tradeId={tradeId}
+                activeTradeId={activeTradeId}
               />
             )}
           </Collapse>
@@ -235,7 +235,7 @@ export const Hop = ({
             isActive={hopExecutionState === HopExecutionState.AwaitingSwap}
             hopIndex={hopIndex}
             isLastStep={!shouldRenderFinalSteps}
-            tradeId={tradeId}
+            activeTradeId={activeTradeId}
           />
           {shouldRenderFinalSteps ? <FeeStep /> : null}
           {shouldRenderFinalSteps && (

--- a/src/components/MultiHopTrade/components/MultiHopTradeConfirm/components/HopTransactionStep.tsx
+++ b/src/components/MultiHopTrade/components/MultiHopTradeConfirm/components/HopTransactionStep.tsx
@@ -36,7 +36,7 @@ export type HopTransactionStepProps = {
   isActive: boolean
   hopIndex: SupportedTradeQuoteStepIndex
   isLastStep?: boolean
-  tradeId: TradeQuote['id']
+  activeTradeId: TradeQuote['id']
 }
 
 export const HopTransactionStep = ({
@@ -45,7 +45,7 @@ export const HopTransactionStep = ({
   isActive,
   hopIndex,
   isLastStep,
-  tradeId,
+  activeTradeId,
 }: HopTransactionStepProps) => {
   const {
     number: { toCrypto },
@@ -56,11 +56,11 @@ export const HopTransactionStep = ({
 
   const {
     swap: { state: swapTxState, sellTxHash, buyTxHash, message },
-  } = useAppSelector(state => selectHopExecutionMetadata(state, tradeId, hopIndex))
+  } = useAppSelector(state => selectHopExecutionMetadata(state, activeTradeId, hopIndex))
 
   const isError = useMemo(() => swapTxState === TransactionExecutionState.Failed, [swapTxState])
 
-  const executeTrade = useTradeExecution(hopIndex, tradeId)
+  const executeTrade = useTradeExecution(hopIndex, activeTradeId)
 
   const handleSignTx = useCallback(async () => {
     if (swapTxState !== TransactionExecutionState.AwaitingConfirmation) {
@@ -147,7 +147,7 @@ export const HopTransactionStep = ({
       return (
         <Card width='full'>
           <CardBody px={2} py={2}>
-            <StreamingSwap hopIndex={hopIndex} tradeId={tradeId} />
+            <StreamingSwap hopIndex={hopIndex} activeTradeId={activeTradeId} />
           </CardBody>
         </Card>
       )
@@ -158,7 +158,7 @@ export const HopTransactionStep = ({
     isActive,
     sellTxHash,
     swapTxState,
-    tradeId,
+    activeTradeId,
     tradeQuoteStep.source,
     translate,
   ])

--- a/src/components/MultiHopTrade/components/MultiHopTradeConfirm/components/HopTransactionStep.tsx
+++ b/src/components/MultiHopTrade/components/MultiHopTradeConfirm/components/HopTransactionStep.tsx
@@ -1,5 +1,9 @@
 import { Button, Card, CardBody, Link, Tooltip, VStack } from '@chakra-ui/react'
-import type { SupportedTradeQuoteStepIndex, TradeQuoteStep } from '@shapeshiftoss/swapper'
+import type {
+  SupportedTradeQuoteStepIndex,
+  TradeQuote,
+  TradeQuoteStep,
+} from '@shapeshiftoss/swapper'
 import { SwapperName } from '@shapeshiftoss/swapper'
 import {
   THORCHAIN_LONGTAIL_STREAMING_SWAP_SOURCE,
@@ -32,6 +36,7 @@ export type HopTransactionStepProps = {
   isActive: boolean
   hopIndex: SupportedTradeQuoteStepIndex
   isLastStep?: boolean
+  tradeId: TradeQuote['id']
 }
 
 export const HopTransactionStep = ({
@@ -40,6 +45,7 @@ export const HopTransactionStep = ({
   isActive,
   hopIndex,
   isLastStep,
+  tradeId,
 }: HopTransactionStepProps) => {
   const {
     number: { toCrypto },
@@ -50,11 +56,11 @@ export const HopTransactionStep = ({
 
   const {
     swap: { state: swapTxState, sellTxHash, buyTxHash, message },
-  } = useAppSelector(state => selectHopExecutionMetadata(state, hopIndex))
+  } = useAppSelector(state => selectHopExecutionMetadata(state, tradeId, hopIndex))
 
   const isError = useMemo(() => swapTxState === TransactionExecutionState.Failed, [swapTxState])
 
-  const executeTrade = useTradeExecution(hopIndex)
+  const executeTrade = useTradeExecution(hopIndex, tradeId)
 
   const handleSignTx = useCallback(async () => {
     if (swapTxState !== TransactionExecutionState.AwaitingConfirmation) {
@@ -141,12 +147,21 @@ export const HopTransactionStep = ({
       return (
         <Card width='full'>
           <CardBody px={2} py={2}>
-            <StreamingSwap hopIndex={hopIndex} />
+            <StreamingSwap hopIndex={hopIndex} tradeId={tradeId} />
           </CardBody>
         </Card>
       )
     }
-  }, [handleSignTx, hopIndex, isActive, sellTxHash, swapTxState, tradeQuoteStep.source, translate])
+  }, [
+    handleSignTx,
+    hopIndex,
+    isActive,
+    sellTxHash,
+    swapTxState,
+    tradeId,
+    tradeQuoteStep.source,
+    translate,
+  ])
 
   const description = useMemo(() => {
     const sellChainSymbol = getChainShortName(tradeQuoteStep.sellAsset.chainId as KnownChainIds)

--- a/src/components/MultiHopTrade/components/MultiHopTradeConfirm/components/Hops.tsx
+++ b/src/components/MultiHopTrade/components/MultiHopTradeConfirm/components/Hops.tsx
@@ -33,6 +33,8 @@ export const Hops = memo((props: HopsProps) => {
 
   if (!activeQuote || !firstHop || !swapperName) return null
 
+  const tradeId = activeQuote.id
+
   return (
     <Stack spacing={0} divider={divider} borderColor='border.base'>
       <Hop
@@ -42,6 +44,7 @@ export const Hops = memo((props: HopsProps) => {
         isOpen={isFirstHopOpen}
         onToggleIsOpen={onToggleFirstHop}
         slippageTolerancePercentageDecimal={activeQuote.slippageTolerancePercentageDecimal}
+        tradeId={tradeId}
       />
       {isMultiHopTrade && lastHop && (
         <Hop
@@ -51,6 +54,7 @@ export const Hops = memo((props: HopsProps) => {
           isOpen={isSecondHopOpen}
           onToggleIsOpen={onToggleSecondHop}
           slippageTolerancePercentageDecimal={activeQuote.slippageTolerancePercentageDecimal}
+          tradeId={tradeId}
         />
       )}
     </Stack>

--- a/src/components/MultiHopTrade/components/MultiHopTradeConfirm/components/Hops.tsx
+++ b/src/components/MultiHopTrade/components/MultiHopTradeConfirm/components/Hops.tsx
@@ -33,7 +33,7 @@ export const Hops = memo((props: HopsProps) => {
 
   if (!activeQuote || !firstHop || !swapperName) return null
 
-  const tradeId = activeQuote.id
+  const activeTradeId = activeQuote.id
 
   return (
     <Stack spacing={0} divider={divider} borderColor='border.base'>
@@ -44,7 +44,7 @@ export const Hops = memo((props: HopsProps) => {
         isOpen={isFirstHopOpen}
         onToggleIsOpen={onToggleFirstHop}
         slippageTolerancePercentageDecimal={activeQuote.slippageTolerancePercentageDecimal}
-        tradeId={tradeId}
+        activeTradeId={activeTradeId}
       />
       {isMultiHopTrade && lastHop && (
         <Hop
@@ -54,7 +54,7 @@ export const Hops = memo((props: HopsProps) => {
           isOpen={isSecondHopOpen}
           onToggleIsOpen={onToggleSecondHop}
           slippageTolerancePercentageDecimal={activeQuote.slippageTolerancePercentageDecimal}
-          tradeId={tradeId}
+          activeTradeId={activeTradeId}
         />
       )}
     </Stack>

--- a/src/components/MultiHopTrade/components/MultiHopTradeConfirm/components/StreamingSwap.tsx
+++ b/src/components/MultiHopTrade/components/MultiHopTradeConfirm/components/StreamingSwap.tsx
@@ -1,5 +1,6 @@
 import { WarningIcon } from '@chakra-ui/icons'
 import { Progress, Stack } from '@chakra-ui/react'
+import type { TradeQuote } from '@shapeshiftoss/swapper'
 import { useTranslate } from 'react-polyglot'
 import { Row } from 'components/Row/Row'
 
@@ -7,15 +8,18 @@ import { useThorStreamingProgress } from '../hooks/useThorStreamingProgress'
 
 export type StreamingSwapProps = {
   hopIndex: number
+  tradeId: TradeQuote['id']
 }
 
 export const StreamingSwap = (props: StreamingSwapProps) => {
-  const { hopIndex } = props
+  const { hopIndex, tradeId } = props
 
   const translate = useTranslate()
 
-  const { totalSwapCount, attemptedSwapCount, isComplete, failedSwaps } =
-    useThorStreamingProgress(hopIndex)
+  const { totalSwapCount, attemptedSwapCount, isComplete, failedSwaps } = useThorStreamingProgress(
+    hopIndex,
+    tradeId,
+  )
 
   return (
     <Stack px={4}>

--- a/src/components/MultiHopTrade/components/MultiHopTradeConfirm/components/StreamingSwap.tsx
+++ b/src/components/MultiHopTrade/components/MultiHopTradeConfirm/components/StreamingSwap.tsx
@@ -8,17 +8,17 @@ import { useThorStreamingProgress } from '../hooks/useThorStreamingProgress'
 
 export type StreamingSwapProps = {
   hopIndex: number
-  tradeId: TradeQuote['id']
+  activeTradeId: TradeQuote['id']
 }
 
 export const StreamingSwap = (props: StreamingSwapProps) => {
-  const { hopIndex, tradeId } = props
+  const { hopIndex, activeTradeId } = props
 
   const translate = useTranslate()
 
   const { totalSwapCount, attemptedSwapCount, isComplete, failedSwaps } = useThorStreamingProgress(
     hopIndex,
-    tradeId,
+    activeTradeId,
   )
 
   return (

--- a/src/components/MultiHopTrade/components/MultiHopTradeConfirm/hooks/useAllowanceApproval.tsx
+++ b/src/components/MultiHopTrade/components/MultiHopTradeConfirm/hooks/useAllowanceApproval.tsx
@@ -22,7 +22,7 @@ export const useAllowanceApproval = (
   hopIndex: number,
   allowanceType: AllowanceType,
   feeQueryEnabled: boolean,
-  tradeId: TradeQuote['id'],
+  confirmedTradeId: TradeQuote['id'],
 ) => {
   const dispatch = useAppDispatch()
   const { showErrorToast } = useErrorHandler()
@@ -47,8 +47,8 @@ export const useAllowanceApproval = (
     // Mark the approval step complete if adequate allowance was found.
     // This is deliberately disjoint to the approval transaction orchestration to allow users to
     // complete an approval externally and have the app respond to the updated allowance on chain.
-    dispatch(tradeQuoteSlice.actions.setApprovalStepComplete({ hopIndex, id: tradeId }))
-  }, [dispatch, hopIndex, isApprovalRequired, tradeId])
+    dispatch(tradeQuoteSlice.actions.setApprovalStepComplete({ hopIndex, id: confirmedTradeId }))
+  }, [dispatch, hopIndex, isApprovalRequired, confirmedTradeId])
 
   const approveMutation = useMutation({
     ...reactQueries.mutations.approve({
@@ -62,20 +62,31 @@ export const useAllowanceApproval = (
       wallet,
     }),
     onMutate() {
-      dispatch(tradeQuoteSlice.actions.setApprovalTxPending({ hopIndex, isReset, id: tradeId }))
+      dispatch(
+        tradeQuoteSlice.actions.setApprovalTxPending({ hopIndex, isReset, id: confirmedTradeId }),
+      )
     },
     async onSuccess(txHash) {
       dispatch(
-        tradeQuoteSlice.actions.setApprovalTxHash({ hopIndex, txHash, isReset, id: tradeId }),
+        tradeQuoteSlice.actions.setApprovalTxHash({
+          hopIndex,
+          txHash,
+          isReset,
+          id: confirmedTradeId,
+        }),
       )
 
       const publicClient = assertGetViemClient(tradeQuoteStep.sellAsset.chainId)
       await publicClient.waitForTransactionReceipt({ hash: txHash as Hash })
 
-      dispatch(tradeQuoteSlice.actions.setApprovalTxComplete({ hopIndex, isReset, id: tradeId }))
+      dispatch(
+        tradeQuoteSlice.actions.setApprovalTxComplete({ hopIndex, isReset, id: confirmedTradeId }),
+      )
     },
     onError(err) {
-      dispatch(tradeQuoteSlice.actions.setApprovalTxFailed({ hopIndex, isReset, id: tradeId }))
+      dispatch(
+        tradeQuoteSlice.actions.setApprovalTxFailed({ hopIndex, isReset, id: confirmedTradeId }),
+      )
       showErrorToast(err)
     },
   })

--- a/src/components/MultiHopTrade/components/MultiHopTradeConfirm/hooks/useIsApprovalInitiallyNeeded.tsx
+++ b/src/components/MultiHopTrade/components/MultiHopTradeConfirm/hooks/useIsApprovalInitiallyNeeded.tsx
@@ -86,9 +86,11 @@ export const useIsApprovalInitiallyNeeded = () => {
 
   useEffect(() => {
     if (isFirstHopLoading || (secondHop !== undefined && isSecondHopLoading)) return
+    if (!activeQuote?.id) return
 
     dispatch(
       tradeQuoteSlice.actions.setInitialApprovalRequirements({
+        id: activeQuote.id,
         firstHop: isApprovalInitiallyNeededForFirstHop ?? false,
         secondHop: isApprovalInitiallyNeededForSecondHop ?? false,
       }),
@@ -96,11 +98,13 @@ export const useIsApprovalInitiallyNeeded = () => {
 
     dispatch(
       tradeQuoteSlice.actions.setAllowanceResetRequirements({
+        id: activeQuote.id,
         firstHop: isAllowanceResetNeededForFirstHop ?? false,
         secondHop: isAllowanceResetNeededForSecondHop ?? false,
       }),
     )
   }, [
+    activeQuote?.id,
     dispatch,
     isAllowanceResetNeededForFirstHop,
     isAllowanceResetNeededForSecondHop,

--- a/src/components/MultiHopTrade/components/MultiHopTradeConfirm/hooks/useThorStreamingProgress.tsx
+++ b/src/components/MultiHopTrade/components/MultiHopTradeConfirm/hooks/useThorStreamingProgress.tsx
@@ -57,7 +57,7 @@ const getStreamingSwapMetadata = (
 
 export const useThorStreamingProgress = (
   hopIndex: number,
-  tradeId: TradeQuote['id'],
+  confirmedTradeId: TradeQuote['id'],
 ): {
   isComplete: boolean
   attemptedSwapCount: number
@@ -70,7 +70,7 @@ export const useThorStreamingProgress = (
   const dispatch = useAppDispatch()
   const {
     swap: { sellTxHash, streamingSwap: streamingSwapMeta },
-  } = useAppSelector(state => selectHopExecutionMetadata(state, tradeId, hopIndex))
+  } = useAppSelector(state => selectHopExecutionMetadata(state, confirmedTradeId, hopIndex))
 
   useEffect(() => {
     // don't start polling until we have a tx
@@ -99,7 +99,7 @@ export const useThorStreamingProgress = (
             tradeQuoteSlice.actions.setStreamingSwapMeta({
               hopIndex,
               streamingSwapMetadata: getStreamingSwapMetadata(completedStreamingSwapData),
-              id: tradeId,
+              id: confirmedTradeId,
             }),
           )
 
@@ -112,7 +112,7 @@ export const useThorStreamingProgress = (
           tradeQuoteSlice.actions.setStreamingSwapMeta({
             hopIndex,
             streamingSwapMetadata: getStreamingSwapMetadata(updatedStreamingSwapData),
-            id: tradeId,
+            id: confirmedTradeId,
           }),
         )
         return updatedStreamingSwapData
@@ -127,7 +127,7 @@ export const useThorStreamingProgress = (
 
     // stop polling on dismount
     return cancelPolling
-  }, [cancelPolling, dispatch, hopIndex, poll, sellTxHash, tradeId])
+  }, [cancelPolling, dispatch, hopIndex, poll, sellTxHash, confirmedTradeId])
 
   const result = useMemo(() => {
     const isComplete =

--- a/src/components/MultiHopTrade/components/MultiHopTradeConfirm/hooks/useThorStreamingProgress.tsx
+++ b/src/components/MultiHopTrade/components/MultiHopTradeConfirm/hooks/useThorStreamingProgress.tsx
@@ -1,3 +1,4 @@
+import type { TradeQuote } from '@shapeshiftoss/swapper'
 import axios from 'axios'
 import { getConfig } from 'config'
 import { useEffect, useMemo, useRef } from 'react'
@@ -56,6 +57,7 @@ const getStreamingSwapMetadata = (
 
 export const useThorStreamingProgress = (
   hopIndex: number,
+  tradeId: TradeQuote['id'],
 ): {
   isComplete: boolean
   attemptedSwapCount: number
@@ -68,7 +70,7 @@ export const useThorStreamingProgress = (
   const dispatch = useAppDispatch()
   const {
     swap: { sellTxHash, streamingSwap: streamingSwapMeta },
-  } = useAppSelector(state => selectHopExecutionMetadata(state, hopIndex))
+  } = useAppSelector(state => selectHopExecutionMetadata(state, tradeId, hopIndex))
 
   useEffect(() => {
     // don't start polling until we have a tx
@@ -97,6 +99,7 @@ export const useThorStreamingProgress = (
             tradeQuoteSlice.actions.setStreamingSwapMeta({
               hopIndex,
               streamingSwapMetadata: getStreamingSwapMetadata(completedStreamingSwapData),
+              id: tradeId,
             }),
           )
 
@@ -109,6 +112,7 @@ export const useThorStreamingProgress = (
           tradeQuoteSlice.actions.setStreamingSwapMeta({
             hopIndex,
             streamingSwapMetadata: getStreamingSwapMetadata(updatedStreamingSwapData),
+            id: tradeId,
           }),
         )
         return updatedStreamingSwapData
@@ -123,7 +127,7 @@ export const useThorStreamingProgress = (
 
     // stop polling on dismount
     return cancelPolling
-  }, [cancelPolling, dispatch, hopIndex, poll, sellTxHash])
+  }, [cancelPolling, dispatch, hopIndex, poll, sellTxHash, tradeId])
 
   const result = useMemo(() => {
     const isComplete =

--- a/src/state/slices/tradeQuoteSlice/constants.ts
+++ b/src/state/slices/tradeQuoteSlice/constants.ts
@@ -22,7 +22,7 @@ export const initialState: TradeQuoteSliceState = {
   activeQuoteMeta: undefined,
   confirmedQuote: undefined,
   activeStep: undefined,
-  tradeExecution: initialTradeExecutionState,
+  tradeExecution: {},
   tradeQuotes: {},
   tradeQuoteDisplayCache: [],
   isTradeQuoteRequestAborted: false,

--- a/src/state/slices/tradeQuoteSlice/selectors.ts
+++ b/src/state/slices/tradeQuoteSlice/selectors.ts
@@ -237,6 +237,11 @@ export const selectActiveQuote: Selector<ReduxState, TradeQuote | undefined> =
     },
   )
 
+export const selectConfirmedQuoteTradeId: Selector<ReduxState, string | undefined> = createSelector(
+  selectConfirmedQuote,
+  confirmedQuote => confirmedQuote?.id,
+)
+
 export const selectIsLastStep: Selector<ReduxState, boolean> = createSelector(
   selectActiveStepOrDefault,
   selectActiveQuote,
@@ -630,7 +635,11 @@ export const selectTradeQuoteAffiliateFeeAfterDiscountUserCurrency = createSelec
 
 export const selectTradeExecutionState = createSelector(
   selectTradeQuoteSlice,
-  swappers => swappers.tradeExecution.state,
+  selectConfirmedQuoteTradeId,
+  (swappers, tradeId) => {
+    if (!tradeId) return
+    return swappers.tradeExecution[tradeId].state
+  },
 )
 
 // selects the account ID we're selling from for the given hop
@@ -645,9 +654,12 @@ export const selectHopSellAccountId = createSelector(
 
 export const selectHopExecutionMetadata = createDeepEqualOutputSelector(
   selectTradeQuoteSlice,
-  (_state: ReduxState, hopIndex: number) => hopIndex,
-  (swappers, hopIndex) => {
-    return hopIndex === 0 ? swappers.tradeExecution.firstHop : swappers.tradeExecution.secondHop
+  (_state: ReduxState, tradeId: TradeQuote['id']) => tradeId,
+  (_state: ReduxState, _tradeId: TradeQuote['id'], hopIndex: number) => hopIndex,
+  (swappers, tradeId, hopIndex) => {
+    return hopIndex === 0
+      ? swappers.tradeExecution[tradeId].firstHop
+      : swappers.tradeExecution[tradeId].secondHop
   },
 )
 

--- a/src/state/slices/tradeQuoteSlice/selectors.ts
+++ b/src/state/slices/tradeQuoteSlice/selectors.ts
@@ -636,9 +636,9 @@ export const selectTradeQuoteAffiliateFeeAfterDiscountUserCurrency = createSelec
 export const selectConfirmedTradeExecutionState = createSelector(
   selectTradeQuoteSlice,
   selectConfirmedQuoteTradeId,
-  (swappers, tradeId) => {
-    if (!tradeId) return
-    return swappers.tradeExecution[tradeId].state
+  (swappers, confirmedTradeId) => {
+    if (!confirmedTradeId) return
+    return swappers.tradeExecution[confirmedTradeId].state
   },
 )
 

--- a/src/state/slices/tradeQuoteSlice/selectors.ts
+++ b/src/state/slices/tradeQuoteSlice/selectors.ts
@@ -633,7 +633,7 @@ export const selectTradeQuoteAffiliateFeeAfterDiscountUserCurrency = createSelec
   },
 )
 
-export const selectTradeExecutionState = createSelector(
+export const selectConfirmedTradeExecutionState = createSelector(
   selectTradeQuoteSlice,
   selectConfirmedQuoteTradeId,
   (swappers, tradeId) => {

--- a/src/state/slices/tradeQuoteSlice/tradeQuoteSlice.ts
+++ b/src/state/slices/tradeQuoteSlice/tradeQuoteSlice.ts
@@ -18,7 +18,10 @@ export const tradeQuoteSlice = createSlice({
   name: 'tradeQuote',
   initialState,
   reducers: {
-    clear: () => initialState,
+    clear: state => ({
+      ...initialState,
+      tradeExecution: state.tradeExecution, // Leave the trade execution state alone
+    }),
     setIsTradeQuoteRequestAborted: (state, action: PayloadAction<boolean>) => {
       state.isTradeQuoteRequestAborted = action.payload
     },

--- a/src/state/slices/tradeQuoteSlice/tradeQuoteSlice.ts
+++ b/src/state/slices/tradeQuoteSlice/tradeQuoteSlice.ts
@@ -43,26 +43,10 @@ export const tradeQuoteSlice = createSlice({
         }
       }
     },
-    incrementStep: state => {
-      const activeQuote = state.confirmedQuote
-      const activeStepOrDefault = state.activeStep ?? 0
-      if (!activeQuote) return // This should never happen as we shouldn't call this without an active quote, but double wrap never hurts for swapper
-      if (activeStepOrDefault === activeQuote.steps.length - 1) return // No-op: we're on the last step - don't increment
-      state.activeStep = activeStepOrDefault + 1
-    },
-    resetActiveStep: state => {
-      state.activeStep = undefined
-    },
-    resetActiveQuote: state => {
-      state.activeQuoteMeta = undefined
-    },
     setConfirmedQuote: (state, action: PayloadAction<TradeQuote | undefined>) => {
       state.confirmedQuote = action.payload
       state.tradeExecution = initialTradeExecutionState
     },
-    resetConfirmedQuote: state => {
-      state.confirmedQuote = undefined
-      state.tradeExecution = initialTradeExecutionState
     },
     setTradeInitialized: state => {
       state.tradeExecution.state = TradeExecutionState.Previewing

--- a/src/state/slices/tradeQuoteSlice/tradeQuoteSlice.ts
+++ b/src/state/slices/tradeQuoteSlice/tradeQuoteSlice.ts
@@ -43,27 +43,27 @@ export const tradeQuoteSlice = createSlice({
         }
       }
     },
-    setConfirmedQuote: (state, action: PayloadAction<TradeQuote | undefined>) => {
+    setConfirmedQuote: (state, action: PayloadAction<TradeQuote>) => {
       state.confirmedQuote = action.payload
-      state.tradeExecution = initialTradeExecutionState
+      state.tradeExecution[action.payload.id] = initialTradeExecutionState
     },
+    setTradeInitialized: (state, action: PayloadAction<TradeQuote['id']>) => {
+      state.tradeExecution[action.payload].state = TradeExecutionState.Previewing
     },
-    setTradeInitialized: state => {
-      state.tradeExecution.state = TradeExecutionState.Previewing
-    },
-    confirmTrade: state => {
-      if (state.tradeExecution.state !== TradeExecutionState.Previewing) {
-        if (state.tradeExecution.state === TradeExecutionState.Initializing) {
+    confirmTrade: (state, action: PayloadAction<TradeQuote['id']>) => {
+      if (state.tradeExecution[action.payload].state !== TradeExecutionState.Previewing) {
+        if (state.tradeExecution[action.payload].state === TradeExecutionState.Initializing) {
           console.error('attempted to confirm an uninitialized trade')
         } else {
           console.error('attempted to confirm an in-progress trade')
         }
         return
       }
-      state.tradeExecution.state = TradeExecutionState.FirstHop
-      const allowanceResetRequired = state.tradeExecution.firstHop.allowanceReset.isRequired
-      const approvalRequired = state.tradeExecution.firstHop.approval.isRequired
-      state.tradeExecution.firstHop.state = allowanceResetRequired
+      state.tradeExecution[action.payload].state = TradeExecutionState.FirstHop
+      const allowanceResetRequired =
+        state.tradeExecution[action.payload].firstHop.allowanceReset.isRequired
+      const approvalRequired = state.tradeExecution[action.payload].firstHop.approval.isRequired
+      state.tradeExecution[action.payload].firstHop.state = allowanceResetRequired
         ? HopExecutionState.AwaitingApprovalReset
         : approvalRequired
         ? HopExecutionState.AwaitingApproval
@@ -71,60 +71,79 @@ export const tradeQuoteSlice = createSlice({
     },
     setApprovalTxPending: (
       state,
-      action: PayloadAction<{ hopIndex: number; isReset: boolean }>,
+      action: PayloadAction<{ hopIndex: number; isReset: boolean; id: TradeQuote['id'] }>,
     ) => {
       const { hopIndex, isReset } = action.payload
       const hopKey = hopIndex === 0 ? HopKey.FirstHop : HopKey.SecondHop
       const allowanceKey = isReset ? AllowanceKey.AllowanceReset : AllowanceKey.Approval
-      state.tradeExecution[hopKey][allowanceKey].state = TransactionExecutionState.Pending
+      state.tradeExecution[action.payload.id][hopKey][allowanceKey].state =
+        TransactionExecutionState.Pending
     },
-    setApprovalTxFailed: (state, action: PayloadAction<{ hopIndex: number; isReset: boolean }>) => {
+    setApprovalTxFailed: (
+      state,
+      action: PayloadAction<{ hopIndex: number; isReset: boolean; id: TradeQuote['id'] }>,
+    ) => {
       const { hopIndex, isReset } = action.payload
       const hopKey = hopIndex === 0 ? HopKey.FirstHop : HopKey.SecondHop
       const allowanceKey = isReset ? AllowanceKey.AllowanceReset : AllowanceKey.Approval
-      state.tradeExecution[hopKey][allowanceKey].state = TransactionExecutionState.Failed
+      state.tradeExecution[action.payload.id][hopKey][allowanceKey].state =
+        TransactionExecutionState.Failed
       if (allowanceKey === AllowanceKey.AllowanceReset) {
-        state.tradeExecution[hopKey].state = HopExecutionState.AwaitingApproval
+        state.tradeExecution[action.payload.id][hopKey].state = HopExecutionState.AwaitingApproval
       }
     },
     // marks the approval tx as complete, but the allowance check needs to pass before proceeding to swap step
     setApprovalTxComplete: (
       state,
-      action: PayloadAction<{ hopIndex: number; isReset: boolean }>,
+      action: PayloadAction<{ hopIndex: number; isReset: boolean; id: TradeQuote['id'] }>,
     ) => {
       const { hopIndex, isReset } = action.payload
       const hopKey = hopIndex === 0 ? HopKey.FirstHop : HopKey.SecondHop
       const allowanceKey = isReset ? AllowanceKey.AllowanceReset : AllowanceKey.Approval
-      state.tradeExecution[hopKey][allowanceKey].state = TransactionExecutionState.Complete
+      state.tradeExecution[action.payload.id][hopKey][allowanceKey].state =
+        TransactionExecutionState.Complete
       if (allowanceKey === AllowanceKey.AllowanceReset) {
-        state.tradeExecution[hopKey].state = HopExecutionState.AwaitingApproval
+        state.tradeExecution[action.payload.id][hopKey].state = HopExecutionState.AwaitingApproval
       }
     },
     // progresses the hop to the swap step after the allowance check has passed
-    setApprovalStepComplete: (state, action: PayloadAction<{ hopIndex: number }>) => {
+    setApprovalStepComplete: (
+      state,
+      action: PayloadAction<{ hopIndex: number; id: TradeQuote['id'] }>,
+    ) => {
       const { hopIndex } = action.payload
       const key = hopIndex === 0 ? HopKey.FirstHop : HopKey.SecondHop
-      state.tradeExecution[key].state = HopExecutionState.AwaitingSwap
+      state.tradeExecution[action.payload.id][key].state = HopExecutionState.AwaitingSwap
     },
-    setSwapTxPending: (state, action: PayloadAction<{ hopIndex: number }>) => {
+    setSwapTxPending: (
+      state,
+      action: PayloadAction<{ hopIndex: number; id: TradeQuote['id'] }>,
+    ) => {
       const { hopIndex } = action.payload
       const key = hopIndex === 0 ? HopKey.FirstHop : HopKey.SecondHop
-      state.tradeExecution[key].swap.state = TransactionExecutionState.Pending
+      state.tradeExecution[action.payload.id][key].swap.state = TransactionExecutionState.Pending
     },
-    setSwapTxFailed: (state, action: PayloadAction<{ hopIndex: number }>) => {
+    setSwapTxFailed: (state, action: PayloadAction<{ hopIndex: number; id: TradeQuote['id'] }>) => {
       const { hopIndex } = action.payload
       const key = hopIndex === 0 ? HopKey.FirstHop : HopKey.SecondHop
-      state.tradeExecution[key].swap.state = TransactionExecutionState.Failed
+      state.tradeExecution[action.payload.id][key].swap.state = TransactionExecutionState.Failed
     },
     setSwapTxMessage: (
       state,
-      action: PayloadAction<{ hopIndex: number; message: string | undefined }>,
+      action: PayloadAction<{
+        id: TradeQuote['id']
+        hopIndex: number
+        message: string | undefined
+      }>,
     ) => {
       const { hopIndex, message } = action.payload
       const key = hopIndex === 0 ? HopKey.FirstHop : HopKey.SecondHop
-      state.tradeExecution[key].swap.message = message
+      state.tradeExecution[action.payload.id][key].swap.message = message
     },
-    setSwapTxComplete: (state, action: PayloadAction<{ hopIndex: number }>) => {
+    setSwapTxComplete: (
+      state,
+      action: PayloadAction<{ hopIndex: number; id: TradeQuote['id'] }>,
+    ) => {
       const { hopIndex } = action.payload
       const isMultiHopTrade =
         state.confirmedQuote !== undefined && state.confirmedQuote.steps.length > 1
@@ -132,74 +151,97 @@ export const tradeQuoteSlice = createSlice({
 
       if (isFirstHop) {
         // complete the first hop
-        state.tradeExecution.firstHop.swap.state = TransactionExecutionState.Complete
-        state.tradeExecution.firstHop.swap.message = undefined
-        state.tradeExecution.firstHop.state = HopExecutionState.Complete
+        state.tradeExecution[action.payload.id].firstHop.swap.state =
+          TransactionExecutionState.Complete
+        state.tradeExecution[action.payload.id].firstHop.swap.message = undefined
+        state.tradeExecution[action.payload.id].firstHop.state = HopExecutionState.Complete
 
         if (isMultiHopTrade) {
           // first hop of multi hop trade - begin second hop
-          state.tradeExecution.state = TradeExecutionState.SecondHop
-          const allowanceResetRequired = state.tradeExecution.secondHop.allowanceReset.isRequired
-          const approvalRequired = state.tradeExecution.secondHop.approval.isRequired
-          state.tradeExecution.secondHop.state = allowanceResetRequired
+          state.tradeExecution[action.payload.id].state = TradeExecutionState.SecondHop
+          const allowanceResetRequired =
+            state.tradeExecution[action.payload.id].secondHop.allowanceReset.isRequired
+          const approvalRequired =
+            state.tradeExecution[action.payload.id].secondHop.approval.isRequired
+          state.tradeExecution[action.payload.id].secondHop.state = allowanceResetRequired
             ? HopExecutionState.AwaitingApprovalReset
             : approvalRequired
             ? HopExecutionState.AwaitingApproval
             : HopExecutionState.AwaitingSwap
         } else {
           // first hop of single hop trade - trade complete
-          state.tradeExecution.state = TradeExecutionState.TradeComplete
+          state.tradeExecution[action.payload.id].state = TradeExecutionState.TradeComplete
         }
       } else {
         // complete the second hop
-        state.tradeExecution.secondHop.swap.state = TransactionExecutionState.Complete
-        state.tradeExecution.secondHop.swap.message = undefined
-        state.tradeExecution.secondHop.state = HopExecutionState.Complete
+        state.tradeExecution[action.payload.id].secondHop.swap.state =
+          TransactionExecutionState.Complete
+        state.tradeExecution[action.payload.id].secondHop.swap.message = undefined
+        state.tradeExecution[action.payload.id].secondHop.state = HopExecutionState.Complete
 
         // second hop of multi-hop trade - trade complete
-        state.tradeExecution.state = TradeExecutionState.TradeComplete
+        state.tradeExecution[action.payload.id].state = TradeExecutionState.TradeComplete
       }
     },
     setInitialApprovalRequirements: (
       state,
-      action: PayloadAction<{ firstHop: boolean; secondHop: boolean } | undefined>,
+      action: PayloadAction<{ firstHop: boolean; secondHop: boolean; id: TradeQuote['id'] }>,
     ) => {
-      state.tradeExecution.firstHop.approval.isRequired = action.payload?.firstHop
-      state.tradeExecution.secondHop.approval.isRequired = action.payload?.secondHop
+      state.tradeExecution[action.payload.id].firstHop.approval.isRequired =
+        action.payload?.firstHop
+      state.tradeExecution[action.payload.id].secondHop.approval.isRequired =
+        action.payload?.secondHop
     },
     setAllowanceResetRequirements: (
       state,
-      action: PayloadAction<{ firstHop: boolean; secondHop: boolean } | undefined>,
+      action: PayloadAction<{ firstHop: boolean; secondHop: boolean; id: TradeQuote['id'] }>,
     ) => {
-      state.tradeExecution.firstHop.allowanceReset.isRequired = action.payload?.firstHop
-      state.tradeExecution.secondHop.allowanceReset.isRequired = action.payload?.secondHop
+      state.tradeExecution[action.payload.id].firstHop.allowanceReset.isRequired =
+        action.payload?.firstHop
+      state.tradeExecution[action.payload.id].secondHop.allowanceReset.isRequired =
+        action.payload?.secondHop
     },
     setApprovalTxHash: (
       state,
-      action: PayloadAction<{ hopIndex: number; txHash: string; isReset: boolean }>,
+      action: PayloadAction<{
+        hopIndex: number
+        txHash: string
+        isReset: boolean
+        id: TradeQuote['id']
+      }>,
     ) => {
       const { hopIndex, txHash, isReset } = action.payload
       const hopKey = hopIndex === 0 ? HopKey.FirstHop : HopKey.SecondHop
       const allowanceKey = isReset ? AllowanceKey.AllowanceReset : AllowanceKey.Approval
-      state.tradeExecution[hopKey][allowanceKey].txHash = txHash
+      state.tradeExecution[action.payload.id][hopKey][allowanceKey].txHash = txHash
     },
-    setSwapSellTxHash: (state, action: PayloadAction<{ hopIndex: number; sellTxHash: string }>) => {
+    setSwapSellTxHash: (
+      state,
+      action: PayloadAction<{ hopIndex: number; sellTxHash: string; id: TradeQuote['id'] }>,
+    ) => {
       const { hopIndex, sellTxHash } = action.payload
       const key = hopIndex === 0 ? HopKey.FirstHop : HopKey.SecondHop
-      state.tradeExecution[key].swap.sellTxHash = sellTxHash
+      state.tradeExecution[action.payload.id][key].swap.sellTxHash = sellTxHash
     },
-    setSwapBuyTxHash: (state, action: PayloadAction<{ hopIndex: number; buyTxHash: string }>) => {
+    setSwapBuyTxHash: (
+      state,
+      action: PayloadAction<{ hopIndex: number; buyTxHash: string; id: TradeQuote['id'] }>,
+    ) => {
       const { hopIndex, buyTxHash } = action.payload
       const key = hopIndex === 0 ? HopKey.FirstHop : HopKey.SecondHop
-      state.tradeExecution[key].swap.buyTxHash = buyTxHash
+      state.tradeExecution[action.payload.id][key].swap.buyTxHash = buyTxHash
     },
     setStreamingSwapMeta: (
       state,
-      action: PayloadAction<{ hopIndex: number; streamingSwapMetadata: StreamingSwapMetadata }>,
+      action: PayloadAction<{
+        hopIndex: number
+        streamingSwapMetadata: StreamingSwapMetadata
+        id: TradeQuote['id']
+      }>,
     ) => {
       const { hopIndex, streamingSwapMetadata } = action.payload
       const key = hopIndex === 0 ? HopKey.FirstHop : HopKey.SecondHop
-      state.tradeExecution[key].swap.streamingSwap = streamingSwapMetadata
+      state.tradeExecution[action.payload.id][key].swap.streamingSwap = streamingSwapMetadata
     },
     updateTradeQuoteDisplayCache: (
       state,

--- a/src/state/slices/tradeQuoteSlice/types.ts
+++ b/src/state/slices/tradeQuoteSlice/types.ts
@@ -8,7 +8,7 @@ export type TradeQuoteSliceState = {
   activeStep: number | undefined // Make sure to actively check for undefined vs. falsy here. 0 is the first step, undefined means no active step yet
   activeQuoteMeta: ActiveQuoteMeta | undefined // the selected quote metadata used to find the active quote in the api responses
   confirmedQuote: TradeQuote | undefined // the quote being executed
-  tradeExecution: Record<string, TradeExecutionMetadata>
+  tradeExecution: Record<TradeQuote['id'], TradeExecutionMetadata>
   tradeQuotes: PartialRecord<SwapperName, Record<string, ApiQuote>> // mapping from swapperName to quoteId to ApiQuote
   tradeQuoteDisplayCache: ApiQuote[]
   isTradeQuoteRequestAborted: boolean // used to conditionally render results and loading state

--- a/src/state/slices/tradeQuoteSlice/types.ts
+++ b/src/state/slices/tradeQuoteSlice/types.ts
@@ -8,7 +8,7 @@ export type TradeQuoteSliceState = {
   activeStep: number | undefined // Make sure to actively check for undefined vs. falsy here. 0 is the first step, undefined means no active step yet
   activeQuoteMeta: ActiveQuoteMeta | undefined // the selected quote metadata used to find the active quote in the api responses
   confirmedQuote: TradeQuote | undefined // the quote being executed
-  tradeExecution: TradeExecutionMetadata
+  tradeExecution: Record<string, TradeExecutionMetadata>
   tradeQuotes: PartialRecord<SwapperName, Record<string, ApiQuote>> // mapping from swapperName to quoteId to ApiQuote
   tradeQuoteDisplayCache: ApiQuote[]
   isTradeQuoteRequestAborted: boolean // used to conditionally render results and loading state

--- a/src/test/mocks/store.ts
+++ b/src/test/mocks/store.ts
@@ -2,7 +2,6 @@ import { DEFAULT_HISTORY_TIMEFRAME } from 'constants/Config'
 import type { ReduxState } from 'state/reducer'
 import { defaultAsset } from 'state/slices/assetsSlice/assetsSlice'
 import { CurrencyFormats, HomeMarketView } from 'state/slices/preferencesSlice/preferencesSlice'
-import { initialTradeExecutionState } from 'state/slices/tradeQuoteSlice/constants'
 
 const mockApiFactory = <T extends unknown>(reducerPath: T) => ({
   queries: {},
@@ -202,7 +201,7 @@ export const mockStore: ReduxState = {
     activeQuoteMeta: undefined,
     confirmedQuote: undefined,
     activeStep: undefined,
-    tradeExecution: initialTradeExecutionState,
+    tradeExecution: {},
     tradeQuotes: {},
     tradeQuoteDisplayCache: [],
     isTradeQuoteRequestAborted: false,


### PR DESCRIPTION
## Description

This PR updates the `tradeExecution` state in the `tradeQuoteSlice` to be keyed by the trade id (`Record<TradeQuote['id'], TradeExecutionMetadata>`).

All components in the context of a confirmed trade now use the `id` of the confirmed trade ensuring there is no state corruption in the UI during the execution flow.

This PR lays the groundwork, though does not implement, the ability to resume a multi-hop trade, view past trades (so long as the Redux slice state persists, at least) etc

## Pull Request Type

- [ ] :bug: Bug fix (Non-breaking Change: Fixes an issue)
- [x] :hammer_and_wrench: Chore (Non-breaking Change: Doc updates, pkg upgrades, typos, etc..)
- [ ] :nail_care: New Feature (Breaking/Non-breaking Change)

## Issue (if applicable)

Closes https://github.com/shapeshift/web/issues/7161

## Risk
> High Risk PRs Require 2 approvals

High - touches the `tradeQuoteSlice` which directly affects the swapping flow.

> What protocols, transaction types, wallets or contract interactions might be affected by this PR?

All trades.

## Testing

- Swaps should work as expected
- Cases where we previously saw state corruption should no longer occur - e.g. BTC -> RUNE then RUNE -> BTC in quick succession - see the issue this PR closes.

### Engineering

Check that the slice state is happy. We should expect to see execution state, keyed by trade id, persisting after trades.

<img width="775" alt="Screenshot 2024-08-14 at 6 10 13 PM" src="https://github.com/user-attachments/assets/e4d8c217-933b-4aa9-aa85-40558c73cb57">

Note, I think we should make better use of `undefined` with the way we currently populate the second hop with data when it is not required, but that's another matter...

### Operations
- [ ] :checkered_flag: My feature is behind a flag and doesn't require operations testing (yet)

☝️

## Screenshots (if applicable)

N/A