### PR TITLE
fix: ensure ui waits for streaming swap to complete

### DIFF
--- a/src/components/MultiHopTrade/components/MultiHopTradeConfirm/hooks/useThorStreamingProgress.tsx
+++ b/src/components/MultiHopTrade/components/MultiHopTradeConfirm/hooks/useThorStreamingProgress.tsx
@@ -132,19 +132,32 @@ export const useThorStreamingProgress = (
   }, [cancelPolling, dispatch, hopIndex, isStreaming, poll, sellTxHash])
 
   const isComplete = useMemo(() => {
+    if (!isStreaming) return true
     return (
       streamingSwapMeta !== undefined &&
       streamingSwapMeta.attemptedSwapCount === streamingSwapMeta.totalSwapCount
     )
-  }, [streamingSwapMeta])
+  }, [isStreaming, streamingSwapMeta])
+
+  const isCompleteRef = useRef(isComplete)
+  isCompleteRef.current = isComplete
 
   const waitForStreamingSwapCompletion = useCallback(() => {
     return new Promise<void>(resolve => {
-      if (!isStreaming || isComplete) {
+      if (isCompleteRef.current) {
         resolve()
+      } else {
+        const checkCompletion = () => {
+          if (isCompleteRef.current) {
+            resolve()
+          } else {
+            setTimeout(checkCompletion, 1000) // Check every second
+          }
+        }
+        checkCompletion()
       }
     })
-  }, [isStreaming, isComplete])
+  }, [])
 
   const result = useMemo(() => {
     return {


### PR DESCRIPTION
## Description

This PR ensures that if we are executing a streaming swap we wait until the stream is complete before we fire the `setSwapTxComplete` action. This fixes the UI prematurely updating to say that the trade is complete when the initiating transaction is detected on chain.

## Pull Request Type

- [x] :bug: Bug fix (Non-breaking Change: Fixes an issue)
- [ ] :hammer_and_wrench: Chore (Non-breaking Change: Doc updates, pkg upgrades, typos, etc..)
- [ ] :nail_care: New Feature (Breaking/Non-breaking Change)

## Issue (if applicable)

Closes https://github.com/shapeshift/web/issues/7371

## Risk
> High Risk PRs Require 2 approvals

Small

> What protocols, transaction types, wallets or contract interactions might be affected by this PR?

- Streaming swaps in particular
- The status of all swaps may be affected if incorrectly implemented

## Testing

Perform a streaming swap and ensure that the trade is not marked as complete until the stream is complete. 

### Engineering

☝️

### Operations
- [ ] :checkered_flag: My feature is behind a flag and doesn't require operations testing (yet)

☝️

## Screenshots (if applicable)

TODO