### PR TITLE
fix: use correct address in outputAddress in csv export

### DIFF
--- a/src/assets/translations/en/main.json
+++ b/src/assets/translations/en/main.json
@@ -708,6 +708,7 @@
         "out": "Outbound Received",
         "refund": "Refund",
         "swapOut": "Swap Received",
+        "swap": "Trade",
         "swapRefund": "Swap Refund",
         "withdraw": "Withdraw Requested",
         "withdrawNative": "Withdraw",

--- a/src/pages/TransactionHistory/DownloadButton.tsx
+++ b/src/pages/TransactionHistory/DownloadButton.tsx
@@ -106,7 +106,7 @@ export const DownloadButton = ({ txIds }: { txIds: TxId[] }) => {
           ? bnOrZero(fromBaseUnit(receive.value, receive.asset?.precision ?? 18)).toFixed()
           : '-',
         outputCurrency: receive?.asset?.symbol ?? receive?.assetId ?? '-',
-        outputAddresses: receive ? `"${receive?.from.join('\n')}"` : '-',
+        outputAddresses: receive ? `"${receive?.to.join('\n')}"` : '-',
       })
     }
 


### PR DESCRIPTION
## Description

Fixes the incorrect output address appearing in the CSV export. 

Also adds label for `transactionRow.parser.thorchain.swap` as `Trade` to match rest of the swaps in the export.

## Pull Request Type

- [x] :bug: Bug fix (Non-breaking Change: Fixes an issue)
- [ ] :hammer_and_wrench: Chore (Non-breaking Change: Doc updates, pkg upgrades, typos, etc..)
- [ ] :nail_care: New Feature (Breaking/Non-breaking Change)

## Issue (if applicable)

<!-----------------------------------------------------------------------------
If applicable, please link to the github issue and put `closes #XXXX` in your comment to auto-close the issue that your PR fixes.
------------------------------------------------------------------------------>

closes #7260

## Risk
> High Risk PRs Require 2 approvals

Low risk. No risk to user funds.

> What protocols, transaction types, wallets or contract interactions might be affected by this PR?

## Testing
Specifically to the issue reported:
- Check `trades` have the same input and output address (unless a manual receive address was used)
- Check `sends` show the wallet address as the input address, and show the destination wallet address as the output address
- Check `receives` show the senders wallet address as the input address, and show the wallet address as the output address

Also check that thorchain swaps are labelled as `Trade` instead of `transactionRow.parser.thorchain.swap`.

### Engineering

<!-----------------------------------------------------------------------------
Include sufficient information here for an engineer to test your PR. This may include how to test locally, in a built environment, changes to infrastructure etc.
------------------------------------------------------------------------------>

### Operations
- [ ] :checkered_flag: My feature is behind a flag and doesn't require operations testing (yet)

<!-----------------------------------------------------------------------------
If your changes have a user-facing impact, describe how a non-technical QA team can functionally test your changes in a preview environment.

If they are not user-facing please describe how to test for any regressions that may occur.
------------------------------------------------------------------------------>

## Screenshots (if applicable)

Prod
![image](https://github.com/user-attachments/assets/01c428c3-1145-4588-b428-bfcfbe8db64d)

This PR
![image](https://github.com/user-attachments/assets/817791bb-c95e-4e7e-86bf-1c04575625d7)


