### PR TITLE
feat: use ledger ack for every rfox action and avoid infinit skeletons

### DIFF
--- a/src/pages/RFOX/components/ChangeAddress/ChangeAddressConfirm.tsx
+++ b/src/pages/RFOX/components/ChangeAddress/ChangeAddressConfirm.tsx
@@ -25,6 +25,7 @@ import { Row } from 'components/Row/Row'
 import { SlideTransition } from 'components/SlideTransition'
 import { RawText } from 'components/Text'
 import { useEvmFees } from 'hooks/queries/useEvmFees'
+import { useLedgerOpenApp } from 'hooks/useLedgerOpenApp/useLedgerOpenApp'
 import { useWallet } from 'hooks/useWallet/useWallet'
 import { middleEllipsis } from 'lib/utils'
 import {
@@ -69,6 +70,7 @@ export const ChangeAddressConfirm: React.FC<
     () => (feeAsset ? assertGetEvmChainAdapter(fromAssetId(feeAsset.assetId).chainId) : undefined),
     [feeAsset],
   )
+  const checkLedgerAppOpenIfLedgerConnected = useLedgerOpenApp()
 
   const stakingAssetAccountAddress = useMemo(
     () => fromAccountId(confirmedQuote.stakingAssetAccountId).account,
@@ -167,10 +169,16 @@ export const ChangeAddressConfirm: React.FC<
   })
 
   const handleSubmit = useCallback(async () => {
-    await handleChangeAddress()
+    if (!stakingAsset) return
 
-    history.push(ChangeAddressRoutePaths.Status)
-  }, [history, handleChangeAddress])
+    await checkLedgerAppOpenIfLedgerConnected(stakingAsset.chainId)
+      .then(async () => {
+        await handleChangeAddress()
+
+        history.push(ChangeAddressRoutePaths.Status)
+      })
+      .catch(console.error)
+  }, [history, handleChangeAddress, stakingAsset, checkLedgerAppOpenIfLedgerConnected])
 
   const changeAddressTx = useAppSelector(gs => selectTxById(gs, serializedChangeAddressTxIndex))
   const isChangeAddressTxPending = useMemo(

--- a/src/pages/RFOX/components/ChangeAddress/ChangeAddressConfirm.tsx
+++ b/src/pages/RFOX/components/ChangeAddress/ChangeAddressConfirm.tsx
@@ -184,7 +184,6 @@ export const ChangeAddressConfirm: React.FC<
     await checkLedgerAppOpenIfLedgerConnected(stakingAsset.chainId)
       .then(async () => {
         await handleChangeAddress()
-
         history.push(ChangeAddressRoutePaths.Status)
       })
       .catch(console.error)

--- a/src/pages/RFOX/components/Claim/ClaimConfirm.tsx
+++ b/src/pages/RFOX/components/Claim/ClaimConfirm.tsx
@@ -219,11 +219,11 @@ export const ClaimConfirm: FC<Pick<ClaimRouteProps, 'headerComponent'> & ClaimCo
     if (!stakingAsset) return
 
     await checkLedgerAppOpenIfLedgerConnected(stakingAsset.chainId)
-      .then(() => {
-        handleClaim()
+      .then(async () => {
+        await handleClaim()
+        history.push(ClaimRoutePaths.Status)
       })
       .catch(console.error)
-    history.push(ClaimRoutePaths.Status)
   }, [handleClaim, history, checkLedgerAppOpenIfLedgerConnected, stakingAsset])
 
   const claimTx = useAppSelector(gs => selectTxById(gs, serializedClaimTxIndex))

--- a/src/pages/RFOX/components/Claim/ClaimConfirm.tsx
+++ b/src/pages/RFOX/components/Claim/ClaimConfirm.tsx
@@ -25,6 +25,7 @@ import { Row, type RowProps } from 'components/Row/Row'
 import { SlideTransition } from 'components/SlideTransition'
 import { Timeline, TimelineItem } from 'components/Timeline/Timeline'
 import { useEvmFees } from 'hooks/queries/useEvmFees'
+import { useLedgerOpenApp } from 'hooks/useLedgerOpenApp/useLedgerOpenApp'
 import { useWallet } from 'hooks/useWallet/useWallet'
 import { bnOrZero } from 'lib/bignumber/bignumber'
 import { fromBaseUnit } from 'lib/math'
@@ -63,6 +64,7 @@ export const ClaimConfirm: FC<Pick<ClaimRouteProps, 'headerComponent'> & ClaimCo
   const history = useHistory()
   const translate = useTranslate()
   const wallet = useWallet().state.wallet
+  const checkLedgerAppOpenIfLedgerConnected = useLedgerOpenApp()
 
   const handleGoBack = useCallback(() => {
     history.push(ClaimRoutePaths.Select)
@@ -204,9 +206,15 @@ export const ClaimConfirm: FC<Pick<ClaimRouteProps, 'headerComponent'> & ClaimCo
   }, [stakingAsset, stakingAmountCryptoPrecision, claimAmountUserCurrency])
 
   const handleSubmit = useCallback(async () => {
-    await handleClaim()
+    if (!stakingAsset) return
+
+    await checkLedgerAppOpenIfLedgerConnected(stakingAsset.chainId)
+      .then(() => {
+        handleClaim()
+      })
+      .catch(console.error)
     history.push(ClaimRoutePaths.Status)
-  }, [handleClaim, history])
+  }, [handleClaim, history, checkLedgerAppOpenIfLedgerConnected, stakingAsset])
 
   const claimTx = useAppSelector(gs => selectTxById(gs, serializedClaimTxIndex))
   const isClaimTxPending = useMemo(

--- a/src/pages/RFOX/components/Overview/Overview.tsx
+++ b/src/pages/RFOX/components/Overview/Overview.tsx
@@ -29,9 +29,7 @@ export const Overview: React.FC = () => {
 
   const stakingBalanceCryptoBaseUnitLoading = useMemo(() => {
     return (
-      stakingBalanceCryptoBaseUnitResult.isLoading ||
-      stakingBalanceCryptoBaseUnitResult.isPaused ||
-      stakingBalanceCryptoBaseUnitResult.isPending
+      stakingBalanceCryptoBaseUnitResult.isLoading || stakingBalanceCryptoBaseUnitResult.isFetching
     )
   }, [stakingBalanceCryptoBaseUnitResult])
 

--- a/src/pages/RFOX/components/Overview/StakingInfo.tsx
+++ b/src/pages/RFOX/components/Overview/StakingInfo.tsx
@@ -59,8 +59,7 @@ export const StakingInfo: React.FC<StakingInfoProps> = ({
           amountCryptoBaseUnit={currentEpochRewardsCryptoBaseUnitResult.data?.toString()}
           isLoading={
             currentEpochRewardsCryptoBaseUnitResult.isLoading ||
-            currentEpochRewardsCryptoBaseUnitResult.isPaused ||
-            currentEpochRewardsCryptoBaseUnitResult.isPending
+            currentEpochRewardsCryptoBaseUnitResult.isFetching
           }
         />
         <StakingInfoItem
@@ -70,19 +69,14 @@ export const StakingInfo: React.FC<StakingInfoProps> = ({
           amountCryptoBaseUnit={lifetimeRewardsCryptoBaseUnitResult.data?.toString()}
           isLoading={
             lifetimeRewardsCryptoBaseUnitResult.isLoading ||
-            lifetimeRewardsCryptoBaseUnitResult.isPaused ||
-            lifetimeRewardsCryptoBaseUnitResult.isPaused
+            lifetimeRewardsCryptoBaseUnitResult.isFetching
           }
         />
         <StakingInfoItem
           informationDescription='RFOX.timeInPool'
           helperTranslation='RFOX.timeInPoolHelper'
-          value={timeInPoolHumanResult.data}
-          isLoading={
-            timeInPoolHumanResult.isLoading ||
-            timeInPoolHumanResult.isPaused ||
-            timeInPoolHumanResult.isPending
-          }
+          value={timeInPoolHumanResult.data ?? 'N/A'}
+          isLoading={timeInPoolHumanResult.isLoading || timeInPoolHumanResult.isFetching}
         />
       </SimpleGrid>
     </Box>

--- a/src/pages/RFOX/components/Stake/Bridge/BridgeConfirm.tsx
+++ b/src/pages/RFOX/components/Stake/Bridge/BridgeConfirm.tsx
@@ -21,6 +21,7 @@ import { getChainShortName } from 'components/MultiHopTrade/components/MultiHopT
 import { Row, type RowProps } from 'components/Row/Row'
 import { SlideTransition } from 'components/SlideTransition'
 import { Timeline, TimelineItem } from 'components/Timeline/Timeline'
+import { useLedgerOpenApp } from 'hooks/useLedgerOpenApp/useLedgerOpenApp'
 import { bnOrZero } from 'lib/bignumber/bignumber'
 import { toBaseUnit } from 'lib/math'
 import { selectPortfolioCryptoPrecisionBalanceByFilter } from 'state/slices/selectors'
@@ -43,6 +44,7 @@ const CustomRow: React.FC<RowProps> = props => <Row fontSize='sm' fontWeight='me
 export const BridgeConfirm: FC<BridgeRouteProps & BridgeConfirmProps> = ({ confirmedQuote }) => {
   const history = useHistory()
   const translate = useTranslate()
+  const checkLedgerAppOpenIfLedgerConnected = useLedgerOpenApp()
 
   const {
     sellAsset,
@@ -108,8 +110,25 @@ export const BridgeConfirm: FC<BridgeRouteProps & BridgeConfirmProps> = ({ confi
   }, [history])
 
   const handleSubmit = useCallback(() => {
+    if (!feeAsset) return
+
+    if (isApprovalRequired) {
+      return checkLedgerAppOpenIfLedgerConnected(feeAsset.chainId)
+        .then(() => {
+          handleApprove()
+        })
+        .catch(console.error)
+    }
+
     history.push({ pathname: BridgeRoutePaths.Status, state: confirmedQuote })
-  }, [confirmedQuote, history])
+  }, [
+    confirmedQuote,
+    history,
+    feeAsset,
+    checkLedgerAppOpenIfLedgerConnected,
+    handleApprove,
+    isApprovalRequired,
+  ])
 
   const bridgeCard = useMemo(() => {
     if (!(sellAsset && buyAsset)) return null
@@ -242,7 +261,7 @@ export const BridgeConfirm: FC<BridgeRouteProps & BridgeConfirmProps> = ({ confi
             isQuoteLoading
           }
           isDisabled={!hasEnoughFeeBalance || isAllowanceDataLoading || isQuoteLoading}
-          onClick={isApprovalRequired ? handleApprove : handleSubmit}
+          onClick={handleSubmit}
         >
           {submitCopy}
         </Button>

--- a/src/pages/RFOX/components/Stake/Bridge/BridgeStatus.tsx
+++ b/src/pages/RFOX/components/Stake/Bridge/BridgeStatus.tsx
@@ -3,6 +3,7 @@ import React, { useCallback, useMemo } from 'react'
 import { useTranslate } from 'react-polyglot'
 import { useHistory } from 'react-router'
 import { Amount } from 'components/Amount/Amount'
+import { useLedgerOpenApp } from 'hooks/useLedgerOpenApp/useLedgerOpenApp'
 
 import type { MultiStepStatusStep } from '../../Shared/SharedMultiStepStatus'
 import { SharedMultiStepStatus } from '../../Shared/SharedMultiStepStatus'
@@ -19,6 +20,7 @@ export const BridgeStatus: React.FC<BridgeRouteProps & BridgeStatusProps> = ({
 }) => {
   const translate = useTranslate()
   const history = useHistory()
+  const checkLedgerAppOpenIfLedgerConnected = useLedgerOpenApp()
 
   const {
     sellAsset,
@@ -37,6 +39,18 @@ export const BridgeStatus: React.FC<BridgeRouteProps & BridgeStatusProps> = ({
     history.push({ pathname: BridgeRoutePaths.Confirm, state: confirmedQuote })
   }, [confirmedQuote, history])
 
+  const handleSignAndBroadcast = useCallback(async () => {
+    if (!sellAsset) return undefined
+
+    try {
+      await checkLedgerAppOpenIfLedgerConnected(sellAsset.chainId)
+
+      return handleBridge()
+    } catch (e) {
+      console.error(e)
+    }
+  }, [handleBridge, checkLedgerAppOpenIfLedgerConnected, sellAsset])
+
   const steps: MultiStepStatusStep[] = useMemo(() => {
     if (!(sellAsset && buyAsset)) return []
 
@@ -51,7 +65,7 @@ export const BridgeStatus: React.FC<BridgeRouteProps & BridgeStatusProps> = ({
           />
         ),
         isActionable: true,
-        onSignAndBroadcast: handleBridge,
+        onSignAndBroadcast: handleSignAndBroadcast,
         serializedTxIndex: serializedL1TxIndex,
       },
       {
@@ -66,9 +80,9 @@ export const BridgeStatus: React.FC<BridgeRouteProps & BridgeStatusProps> = ({
     buyAsset,
     translate,
     bridgeAmountCryptoPrecision,
-    handleBridge,
     serializedL1TxIndex,
     serializedL2TxIndex,
+    handleSignAndBroadcast,
   ])
 
   return (

--- a/src/pages/RFOX/components/Stake/StakeConfirm.tsx
+++ b/src/pages/RFOX/components/Stake/StakeConfirm.tsx
@@ -273,11 +273,11 @@ export const StakeConfirm: React.FC<StakeConfirmProps & StakeRouteProps> = ({
     }
 
     await checkLedgerAppOpenIfLedgerConnected(stakingAsset.chainId)
-      .then(() => {
-        handleStake()
+      .then(async () => {
+        await handleStake()
+        history.push(StakeRoutePaths.Status)
       })
       .catch(console.error)
-    history.push(StakeRoutePaths.Status)
   }, [
     handleStake,
     history,

--- a/src/pages/RFOX/components/Stake/StakeConfirm.tsx
+++ b/src/pages/RFOX/components/Stake/StakeConfirm.tsx
@@ -26,6 +26,7 @@ import type { RowProps } from 'components/Row/Row'
 import { Row } from 'components/Row/Row'
 import { SlideTransition } from 'components/SlideTransition'
 import { Timeline, TimelineItem } from 'components/Timeline/Timeline'
+import { useLedgerOpenApp } from 'hooks/useLedgerOpenApp/useLedgerOpenApp'
 import { bnOrZero } from 'lib/bignumber/bignumber'
 import { fromBaseUnit, toBaseUnit } from 'lib/math'
 import { middleEllipsis } from 'lib/utils'
@@ -63,6 +64,7 @@ export const StakeConfirm: React.FC<StakeConfirmProps & StakeRouteProps> = ({
   const queryClient = useQueryClient()
   const history = useHistory()
   const translate = useTranslate()
+  const checkLedgerAppOpenIfLedgerConnected = useLedgerOpenApp()
 
   const stakingAsset = useAppSelector(state =>
     selectAssetById(state, confirmedQuote.stakingAssetId),
@@ -261,11 +263,29 @@ export const StakeConfirm: React.FC<StakeConfirmProps & StakeRouteProps> = ({
   }, [history])
 
   const handleSubmit = useCallback(async () => {
-    if (isApprovalRequired) return handleApprove()
+    if (!stakingAsset) return
+    if (isApprovalRequired) {
+      return checkLedgerAppOpenIfLedgerConnected(stakingAsset.chainId)
+        .then(() => {
+          handleApprove()
+        })
+        .catch(console.error)
+    }
 
-    await handleStake()
+    await checkLedgerAppOpenIfLedgerConnected(stakingAsset.chainId)
+      .then(() => {
+        handleStake()
+      })
+      .catch(console.error)
     history.push(StakeRoutePaths.Status)
-  }, [handleStake, history, isApprovalRequired, handleApprove])
+  }, [
+    handleStake,
+    history,
+    isApprovalRequired,
+    handleApprove,
+    stakingAsset,
+    checkLedgerAppOpenIfLedgerConnected,
+  ])
 
   const stakeCards = useMemo(() => {
     if (!stakingAsset) return null

--- a/src/pages/RFOX/components/Unstake/UnstakeConfirm.tsx
+++ b/src/pages/RFOX/components/Unstake/UnstakeConfirm.tsx
@@ -119,12 +119,11 @@ export const UnstakeConfirm: React.FC<UnstakeRouteProps & UnstakeConfirmProps> =
     if (!stakingAsset) return
 
     await checkLedgerAppOpenIfLedgerConnected(stakingAsset.chainId)
-      .then(() => {
-        handleUnstake()
+      .then(async () => {
+        await handleUnstake()
+        history.push(UnstakeRoutePaths.Status)
       })
       .catch(console.error)
-
-    history.push(UnstakeRoutePaths.Status)
   }, [handleUnstake, history, stakingAsset, checkLedgerAppOpenIfLedgerConnected])
 
   return (

--- a/src/pages/RFOX/components/Unstake/UnstakeConfirm.tsx
+++ b/src/pages/RFOX/components/Unstake/UnstakeConfirm.tsx
@@ -19,6 +19,7 @@ import type { RowProps } from 'components/Row/Row'
 import { Row } from 'components/Row/Row'
 import { SlideTransition } from 'components/SlideTransition'
 import { Timeline, TimelineItem } from 'components/Timeline/Timeline'
+import { useLedgerOpenApp } from 'hooks/useLedgerOpenApp/useLedgerOpenApp'
 import { bnOrZero } from 'lib/bignumber/bignumber'
 import { fromBaseUnit } from 'lib/math'
 import { selectAssetById, selectMarketDataByAssetIdUserCurrency } from 'state/slices/selectors'
@@ -44,6 +45,7 @@ export const UnstakeConfirm: React.FC<UnstakeRouteProps & UnstakeConfirmProps> =
 }) => {
   const history = useHistory()
   const translate = useTranslate()
+  const checkLedgerAppOpenIfLedgerConnected = useLedgerOpenApp()
 
   const stakingAsset = useAppSelector(state =>
     selectAssetById(state, confirmedQuote.stakingAssetId),
@@ -114,10 +116,16 @@ export const UnstakeConfirm: React.FC<UnstakeRouteProps & UnstakeConfirmProps> =
   }, [stakingAsset, unstakingAmountCryptoPrecision, unstakingAmountUserCurrency])
 
   const handleSubmit = useCallback(async () => {
-    await handleUnstake()
+    if (!stakingAsset) return
+
+    await checkLedgerAppOpenIfLedgerConnected(stakingAsset.chainId)
+      .then(() => {
+        handleUnstake()
+      })
+      .catch(console.error)
 
     history.push(UnstakeRoutePaths.Status)
-  }, [handleUnstake, history])
+  }, [handleUnstake, history, stakingAsset, checkLedgerAppOpenIfLedgerConnected])
 
   return (
     <SlideTransition>


### PR DESCRIPTION
## Description
When signing briding, stack, unstake, claim and changing address using rFOX, if you don't have the ledger app enabled, the ledger ACK flow should be opening.

Also, if you didn't add the arbitrum chain, every informations should be zeroed out instead of having an infinit loading

I also noticed that `Unstake` and `Change address` are loading if the chain is not supported, it was not included in the initial ticket and would require another decision, happy to fix it in a follow up if it's really needed (users should have understand that the chain is not supported at this point considering the fact that the default view is `Stake` telling it)

<!-- Please describe your changes -->

## Pull Request Type

- [ ] :bug: Bug fix (Non-breaking Change: Fixes an issue)
- [ ] :hammer_and_wrench: Chore (Non-breaking Change: Doc updates, pkg upgrades, typos, etc..)
- [x] :nail_care: New Feature (Breaking/Non-breaking Change)

## Issue (if applicable)

<!-----------------------------------------------------------------------------
If applicable, please link to the github issue and put `closes #XXXX` in your comment to auto-close the issue that your PR fixes.
------------------------------------------------------------------------------>

closes #7374

## Risk
> High Risk PRs Require 2 approvals

<!-----------------------------------------------------------------------------
Outline the scope of your changes and the risk associated with them. You must use your discretion as an engineer to determine the potential impact of your changes.

WARNING: If your PR introduces a new on-chain transaction or modifies an existing one, please add the "High-Risk" label to this PR and ask for 2 reviewers to approve it before merging.

E.g. an upgrade to `hdwallet` or core state management would be considered higher risk, and might require a full regression test. UI or isolated view changes, or something behind a feature flag may have near zero risk. Small bug fixes might require testing isolated to the specific fix.
------------------------------------------------------------------------------>

> What protocols, transaction types, wallets or contract interactions might be affected by this PR?

## Testing
For all thoses tests cases, use a ledger without the app opened, the ACK flow should be opening, and you can continue through the end of the flow after opening the app: 

- Try to Bridge
- Try to Claim (I couldn't because I don't have any claims available on my testing ledger)
- Try to Stake
- Try to Unstake
- Try to change the reward address

<!-----------------------------------------------------------------------------
We treat every PR to be merged with the same scrutiny as if we were merging directly to production.

Your PR will not be merged if you do not complete the sections below for our engineering and operations teams to test.
------------------------------------------------------------------------------>

### Engineering
n/a
<!-----------------------------------------------------------------------------
Include sufficient information here for an engineer to test your PR. This may include how to test locally, in a built environment, changes to infrastructure etc.
------------------------------------------------------------------------------>

### Operations
n/a
- [ ] :checkered_flag: My feature is behind a flag and doesn't require operations testing (yet)

<!-----------------------------------------------------------------------------
If your changes have a user-facing impact, describe how a non-technical QA team can functionally test your changes in a preview environment.

If they are not user-facing please describe how to test for any regressions that may occur.
------------------------------------------------------------------------------>

## Screenshots (if applicable)
https://jam.dev/c/ed752829-9ddb-422e-8b32-6086f7ef9d76

If the chain is not supported by the wallet (zero values)
![image](https://github.com/user-attachments/assets/8a3a19c7-4e01-4bd2-a4f7-afe571d4c9eb)
