### PR TITLE
feat: don't derive address on-device when estimating Ledger fees

### DIFF
--- a/src/components/MultiHopTrade/components/MultiHopTradeConfirm/hooks/helpers.ts
+++ b/src/components/MultiHopTrade/components/MultiHopTradeConfirm/hooks/helpers.ts
@@ -1,43 +1,7 @@
-import { fromAssetId } from '@shapeshiftoss/caip'
 import type { HDWallet } from '@shapeshiftoss/hdwallet-core'
 import type { TradeQuote } from '@shapeshiftoss/swapper'
 import { type AllowanceType, getApprovalAmountCryptoBaseUnit } from 'hooks/queries/useApprovalFees'
-import { assertGetEvmChainAdapter, getApproveContractData, getFeesWithWallet } from 'lib/utils/evm'
 import { approve } from 'lib/utils/evm/approve'
-
-export const getApprovalNetworkFeeCryptoBaseUnit = async ({
-  tradeQuoteStep,
-  wallet,
-  allowanceType,
-}: {
-  tradeQuoteStep: TradeQuote['steps'][number]
-  wallet: HDWallet
-  allowanceType: AllowanceType
-}): Promise<string> => {
-  const adapter = assertGetEvmChainAdapter(tradeQuoteStep.sellAsset.chainId)
-  const { assetReference: to } = fromAssetId(tradeQuoteStep.sellAsset.assetId)
-
-  const data = getApproveContractData({
-    approvalAmountCryptoBaseUnit: getApprovalAmountCryptoBaseUnit(
-      tradeQuoteStep.sellAmountIncludingProtocolFeesCryptoBaseUnit,
-      allowanceType,
-    ),
-    spender: tradeQuoteStep.allowanceContract,
-    to,
-    chainId: tradeQuoteStep.sellAsset.chainId,
-  })
-
-  const { networkFeeCryptoBaseUnit } = await getFeesWithWallet({
-    accountNumber: tradeQuoteStep.accountNumber,
-    adapter,
-    data,
-    to,
-    value: '0',
-    wallet,
-  })
-
-  return networkFeeCryptoBaseUnit
-}
 
 export const approveTrade = async ({
   tradeQuoteStep,

--- a/src/features/defi/providers/thorchain-savers/components/ThorchainSaversManager/Deposit/components/Deposit.tsx
+++ b/src/features/defi/providers/thorchain-savers/components/ThorchainSaversManager/Deposit/components/Deposit.tsx
@@ -1,6 +1,7 @@
 import { Skeleton, useToast } from '@chakra-ui/react'
 import type { AccountId } from '@shapeshiftoss/caip'
 import { fromAccountId, fromAssetId, thorchainAssetId, toAssetId } from '@shapeshiftoss/caip'
+import { isLedger } from '@shapeshiftoss/hdwallet-ledger'
 import type { Asset } from '@shapeshiftoss/types'
 import { useQueryClient } from '@tanstack/react-query'
 import { getOrCreateContractByType } from 'contracts/contractManager'
@@ -295,6 +296,11 @@ export const Deposit: React.FC<DepositProps> = ({
   const { data: isSweepNeeded, isLoading: isSweepNeededLoading } =
     useIsSweepNeededQuery(isSweepNeededArgs)
 
+  const pubKey = useMemo(
+    () => (wallet && isLedger(wallet) && userAddress ? userAddress : undefined),
+    [userAddress, wallet],
+  )
+
   const handleContinue = useCallback(
     async (formValues: DepositValues) => {
       if (!feeAsset) return
@@ -347,6 +353,7 @@ export const Deposit: React.FC<DepositProps> = ({
             adapter,
             data,
             to: fromAssetId(assetId).assetReference,
+            pubKey,
             value: '0',
             wallet,
           })
@@ -389,23 +396,24 @@ export const Deposit: React.FC<DepositProps> = ({
       }
     },
     [
-      userAddress,
-      opportunityData,
-      inputValues,
-      accountId,
-      contextDispatch,
       feeAsset,
-      chainId,
+      accountId,
+      userAddress,
+      inputValues,
+      opportunityData,
+      contextDispatch,
+      isApprovalRequired,
       estimatedFeesData,
       onNext,
       isSweepNeeded,
       assetId,
       assets,
-      isApprovalRequired,
       inboundAddress,
       accountNumber,
       wallet,
       asset.chainId,
+      chainId,
+      pubKey,
       toast,
       translate,
     ],

--- a/src/hooks/mutations/useApprove.ts
+++ b/src/hooks/mutations/useApprove.ts
@@ -1,5 +1,6 @@
 import { fromAssetId } from '@shapeshiftoss/caip'
 import { isEvmChainId } from '@shapeshiftoss/chain-adapters'
+import { isLedger } from '@shapeshiftoss/hdwallet-ledger'
 import { useMutation, useQueryClient } from '@tanstack/react-query'
 import { erc20ABI } from 'contracts/abis/ERC20ABI'
 import { useMemo, useState } from 'react'
@@ -43,15 +44,21 @@ export const useApprove = ({ onSuccess: handleSuccess, ...input }: UseApprovePro
     [approvalCallData, input, wallet],
   )
 
+  const pubKey = useMemo(
+    () => (wallet && isLedger(wallet) && input.from ? input.from : undefined),
+    [input.from, wallet],
+  )
+
   const approvalFeesQueryInput = useMemo(
     () => ({
       value: '0',
+      pubKey,
       accountNumber: input.accountNumber,
       to: input.assetId ? fromAssetId(input.assetId).assetReference : undefined,
       data: approvalCallData,
       chainId,
     }),
-    [approvalCallData, chainId, input.accountNumber, input.assetId],
+    [approvalCallData, chainId, input.accountNumber, input.assetId, pubKey],
   )
 
   const allowanceDataQuery = useAllowance({

--- a/src/hooks/queries/useApprovalFees.ts
+++ b/src/hooks/queries/useApprovalFees.ts
@@ -1,7 +1,9 @@
 import type { AssetId } from '@shapeshiftoss/caip'
 import { fromAssetId } from '@shapeshiftoss/caip'
+import { isLedger } from '@shapeshiftoss/hdwallet-ledger'
 import { MAX_ALLOWANCE } from '@shapeshiftoss/swapper/src/swappers/utils/constants'
 import { useMemo } from 'react'
+import { useWallet } from 'hooks/useWallet/useWallet'
 import { assertUnreachable } from 'lib/utils'
 import { getApproveContractData } from 'lib/utils/evm'
 
@@ -33,6 +35,9 @@ export const useApprovalFees = ({
   spender,
   enabled,
 }: UseApprovalFeesInput) => {
+  const {
+    state: { wallet },
+  } = useWallet()
   const { assetReference: to, chainId } = useMemo(() => {
     return fromAssetId(assetId)
   }, [assetId])
@@ -58,9 +63,15 @@ export const useApprovalFees = ({
     })
   }, [allowanceType, amountCryptoBaseUnit, chainId, spender, to])
 
+  const pubKey = useMemo(
+    () => (wallet && isLedger(wallet) && from ? from : undefined),
+    [from, wallet],
+  )
+
   const evmFeesResult = useEvmFees({
     accountNumber,
     to,
+    pubKey,
     value: '0',
     chainId,
     data: approveContractData,

--- a/src/hooks/queries/useEvmFees.ts
+++ b/src/hooks/queries/useEvmFees.ts
@@ -15,6 +15,7 @@ import { useAppSelector } from 'state/store'
 
 type UseEvmFeesProps = {
   accountNumber: number | undefined
+  pubKey: string | undefined
   chainId: ChainId | undefined
   data: string | undefined
   enabled?: boolean
@@ -27,6 +28,7 @@ type UseEvmFeesProps = {
 
 export const useEvmFees = ({
   accountNumber,
+  pubKey,
   chainId,
   data,
   refetchInterval,
@@ -48,11 +50,12 @@ export const useEvmFees = ({
   )
 
   const getFeesWithWalletInput: MaybeGetFeesWithWalletArgs = useMemo(() => {
-    return { accountNumber, adapter, data, to, value, wallet }
-  }, [accountNumber, adapter, data, to, value, wallet])
+    return { accountNumber, adapter, data, to, value, pubKey, wallet }
+  }, [accountNumber, adapter, data, pubKey, to, value, wallet])
 
   const query = useQuery({
-    queryKey: reactQueries.common.evmFees({ chainId, value, accountNumber, data, to }).queryKey,
+    queryKey: reactQueries.common.evmFees({ chainId, value, accountNumber, data, pubKey, to })
+      .queryKey,
     queryFn:
       isGetFeesWithWalletArgs(getFeesWithWalletInput) && enabled
         ? () => getFeesWithWallet(getFeesWithWalletInput)

--- a/src/lib/utils/evm/index.ts
+++ b/src/lib/utils/evm/index.ts
@@ -78,11 +78,12 @@ type GetFeesCommonArgs = {
 export type GetFeesWithWalletArgs = GetFeesCommonArgs & {
   accountNumber: number
   wallet: HDWallet
+  pubKey: string | undefined
 }
 
 export type MaybeGetFeesWithWalletArgs = PartialFields<
   Omit<GetFeesWithWalletArgs, 'wallet'>,
-  'adapter' | 'accountNumber' | 'data' | 'to'
+  'adapter' | 'accountNumber' | 'data' | 'to' | 'pubKey'
 > & {
   wallet: HDWallet | null
 }
@@ -95,9 +96,9 @@ export const isGetFeesWithWalletArgs = (
   )
 
 export const getFeesWithWallet = async (args: GetFeesWithWalletArgs): Promise<Fees> => {
-  const { accountNumber, adapter, wallet, ...rest } = args
+  const { accountNumber, adapter, wallet, pubKey, ...rest } = args
 
-  const from = await adapter.getAddress({ accountNumber, wallet })
+  const from = await adapter.getAddress({ accountNumber, pubKey, wallet })
   const supportsEIP1559 = supportsETH(wallet) && (await wallet.ethSupportsEIP1559())
 
   return getFees({ ...rest, adapter, from, supportsEIP1559 })
@@ -106,7 +107,7 @@ export const getFeesWithWallet = async (args: GetFeesWithWalletArgs): Promise<Fe
 export const createBuildCustomTxInput = async (
   args: CreateBuildCustomTxInputArgs,
 ): Promise<evm.BuildCustomTxInput> => {
-  const fees = await getFeesWithWallet(args)
+  const fees = await getFeesWithWallet({ ...args, pubKey: undefined })
   return { ...args, ...fees }
 }
 

--- a/src/pages/RFOX/components/ChangeAddress/ChangeAddressConfirm.tsx
+++ b/src/pages/RFOX/components/ChangeAddress/ChangeAddressConfirm.tsx
@@ -12,6 +12,7 @@ import {
 } from '@chakra-ui/react'
 import { fromAccountId, fromAssetId } from '@shapeshiftoss/caip'
 import { CONTRACT_INTERACTION } from '@shapeshiftoss/chain-adapters'
+import { isLedger } from '@shapeshiftoss/hdwallet-ledger'
 import { useMutation } from '@tanstack/react-query'
 import { foxStakingV1Abi } from 'contracts/abis/FoxStakingV1'
 import { RFOX_PROXY_CONTRACT_ADDRESS } from 'contracts/constants'
@@ -93,15 +94,24 @@ export const ChangeAddressConfirm: React.FC<
     })
   }, [confirmedQuote.newRuneAddress])
 
+  const pubKey = useMemo(
+    () =>
+      wallet && isLedger(wallet) && stakingAssetAccountAddress
+        ? stakingAssetAccountAddress
+        : undefined,
+    [stakingAssetAccountAddress, wallet],
+  )
+
   const changeAddressFeesQueryInput = useMemo(
     () => ({
       to: RFOX_PROXY_CONTRACT_ADDRESS,
+      pubKey,
       chainId: fromAssetId(confirmedQuote.stakingAssetId).chainId,
       accountNumber: stakingAssetAccountNumber,
       data: callData,
       value: '0',
     }),
-    [callData, confirmedQuote.stakingAssetId, stakingAssetAccountNumber],
+    [callData, confirmedQuote.stakingAssetId, pubKey, stakingAssetAccountNumber],
   )
 
   const {

--- a/src/pages/RFOX/components/ChangeAddress/ChangeAddressInput.tsx
+++ b/src/pages/RFOX/components/ChangeAddress/ChangeAddressInput.tsx
@@ -1,5 +1,6 @@
 import { Box, Button, CardFooter, Collapse, Flex, Input, Skeleton, Stack } from '@chakra-ui/react'
 import { fromAccountId, fromAssetId } from '@shapeshiftoss/caip'
+import { isLedger } from '@shapeshiftoss/hdwallet-ledger'
 import { foxStakingV1Abi } from 'contracts/abis/FoxStakingV1'
 import { RFOX_PROXY_CONTRACT_ADDRESS } from 'contracts/constants'
 import { type FC, useCallback, useEffect, useMemo } from 'react'
@@ -125,16 +126,25 @@ export const ChangeAddressInput: FC<ChangeAddressRouteProps & ChangeAddressInput
     [currentRuneAddress, errors.manualRuneAddress, errors.newRuneAddress, newRuneAddress],
   )
 
+  const pubKey = useMemo(
+    () =>
+      wallet && isLedger(wallet) && stakingAssetAccountAddress
+        ? stakingAssetAccountAddress
+        : undefined,
+    [stakingAssetAccountAddress, wallet],
+  )
+
   const changeAddressFeesQueryInput = useMemo(
     () => ({
       to: RFOX_PROXY_CONTRACT_ADDRESS,
+      pubKey,
       from: stakingAssetAccountAddress ?? '',
       chainId: fromAssetId(stakingAssetId).chainId,
       accountNumber: stakingAssetAccountNumber,
       data: callData,
       value: '0',
     }),
-    [callData, stakingAssetAccountAddress, stakingAssetAccountNumber, stakingAssetId],
+    [callData, pubKey, stakingAssetAccountAddress, stakingAssetAccountNumber, stakingAssetId],
   )
 
   const getFeesWithWalletInput = useMemo(

--- a/src/pages/RFOX/components/Claim/ClaimConfirm.tsx
+++ b/src/pages/RFOX/components/Claim/ClaimConfirm.tsx
@@ -12,6 +12,7 @@ import {
 } from '@chakra-ui/react'
 import { fromAccountId, fromAssetId } from '@shapeshiftoss/caip'
 import { CONTRACT_INTERACTION } from '@shapeshiftoss/chain-adapters'
+import { isLedger } from '@shapeshiftoss/hdwallet-ledger'
 import { useMutation } from '@tanstack/react-query'
 import { foxStakingV1Abi } from 'contracts/abis/FoxStakingV1'
 import { RFOX_PROXY_CONTRACT_ADDRESS } from 'contracts/constants'
@@ -113,6 +114,14 @@ export const ClaimConfirm: FC<Pick<ClaimRouteProps, 'headerComponent'> & ClaimCo
     })
   }, [stakingAsset, claimQuote.index])
 
+  const pubKey = useMemo(
+    () =>
+      wallet && isLedger(wallet) && stakingAssetAccountAddress
+        ? stakingAssetAccountAddress
+        : undefined,
+    [stakingAssetAccountAddress, wallet],
+  )
+
   const {
     mutateAsync: handleClaim,
     isIdle: isClaimMutationIdle,
@@ -153,12 +162,13 @@ export const ClaimConfirm: FC<Pick<ClaimRouteProps, 'headerComponent'> & ClaimCo
   const claimFeesQueryInput = useMemo(
     () => ({
       to: RFOX_PROXY_CONTRACT_ADDRESS,
+      pubKey,
       chainId: fromAssetId(claimQuote.stakingAssetId).chainId,
       accountNumber: stakingAssetAccountNumber,
       data: callData,
       value: '0',
     }),
-    [callData, claimQuote.stakingAssetId, stakingAssetAccountNumber],
+    [callData, claimQuote.stakingAssetId, pubKey, stakingAssetAccountNumber],
   )
 
   const {

--- a/src/pages/RFOX/components/Stake/Bridge/hooks/useRfoxBridgeApproval.tsx
+++ b/src/pages/RFOX/components/Stake/Bridge/hooks/useRfoxBridgeApproval.tsx
@@ -1,6 +1,7 @@
 import { ExternalLinkIcon } from '@chakra-ui/icons'
 import { Link, Text, useToast } from '@chakra-ui/react'
 import { fromAccountId, fromAssetId } from '@shapeshiftoss/caip'
+import { isLedger } from '@shapeshiftoss/hdwallet-ledger'
 import { TxStatus } from '@shapeshiftoss/unchained-client'
 import type { EvmFees } from '@shapeshiftoss/utils/dist/evm'
 import { useMutation, useQueryClient, type UseQueryResult } from '@tanstack/react-query'
@@ -114,11 +115,20 @@ export const useRfoxBridgeApproval = ({
     [isApprovalRequired],
   )
 
+  const pubKey = useMemo(
+    () =>
+      wallet && isLedger(wallet)
+        ? fromAccountId(confirmedQuote.sellAssetAccountId).account
+        : undefined,
+    [confirmedQuote.sellAssetAccountId, wallet],
+  )
+
   const approvalFeesQueryInput = useMemo(
     () => ({
       value: '0',
       accountNumber: sellAssetAccountNumber,
       to: fromAssetId(confirmedQuote.sellAssetId).assetReference,
+      pubKey,
       from: fromAccountId(confirmedQuote.sellAssetAccountId).account,
       data: approvalCallData,
       chainId: fromAssetId(confirmedQuote.sellAssetId).chainId,
@@ -127,6 +137,7 @@ export const useRfoxBridgeApproval = ({
       approvalCallData,
       confirmedQuote.sellAssetAccountId,
       confirmedQuote.sellAssetId,
+      pubKey,
       sellAssetAccountNumber,
     ],
   )

--- a/src/react-queries/queries/common.ts
+++ b/src/react-queries/queries/common.ts
@@ -94,12 +94,13 @@ export const common = createQueryKeys('common', {
     to,
     value,
     chainId,
+    pubKey,
   }: PartialFields<
     Omit<GetFeesWithWalletArgs, 'wallet' | 'adapter'>,
-    'accountNumber' | 'data' | 'to'
+    'accountNumber' | 'data' | 'to' | 'pubKey'
   > & {
     chainId: ChainId | undefined
   }) => ({
-    queryKey: ['evmFees', to, chainId, accountNumber, data, value],
+    queryKey: ['evmFees', to, chainId, accountNumber, data, value, pubKey],
   }),
 })


### PR DESCRIPTION
## Description

Ensures pubKey gets passed to `adapter.getAddress()`, so that Ledger signing is still borked, but borked correctly.
Read: Things will now be happy up to signing time and won't get rugged earlier at fees estimation time, meaning we now have the groundwork ready to properly add Ledger "Open App" gate at signing time.

## Pull Request Type

- [ ] :bug: Bug fix (Non-breaking Change: Fixes an issue)
- [ ] :hammer_and_wrench: Chore (Non-breaking Change: Doc updates, pkg upgrades, typos, etc..)
- [x] :nail_care: New Feature (Breaking/Non-breaking Change)

## Issue (if applicable)

<!-----------------------------------------------------------------------------
If applicable, please link to the github issue and put `closes #XXXX` in your comment to auto-close the issue that your PR fixes.
------------------------------------------------------------------------------>

- closes https://github.com/shapeshift/web/issues/7567
- closes https://github.com/shapeshift/web/issues/7575

## Risk
> High Risk PRs Require 2 approvals

<!-----------------------------------------------------------------------------
Outline the scope of your changes and the risk associated with them. You must use your discretion as an engineer to determine the potential impact of your changes.

WARNING: If your PR introduces a new on-chain transaction or modifies an existing one, please add the "High-Risk" label to this PR and ask for 2 reviewers to approve it before merging.

E.g. an upgrade to `hdwallet` or core state management would be considered higher risk, and might require a full regression test. UI or isolated view changes, or something behind a feature flag may have near zero risk. Small bug fixes might require testing isolated to the specific fix.
------------------------------------------------------------------------------>

> What protocols, transaction types, wallets or contract interactions might be affected by this PR?

Low/Medium - this should only affect fees estimation for Ledger and be a no-op diff for all others.

## Testing
<!-----------------------------------------------------------------------------
We treat every PR to be merged with the same scrutiny as if we were merging directly to production.

Your PR will not be merged if you do not complete the sections below for our engineering and operations teams to test.
------------------------------------------------------------------------------>

**Test the below with a Ledger connected, but without the relevant app open (i.e for the sake of simplicity, don't have any app open)

- Fees estimation are happy for THORChain LP Add/Remove Liquidity and Approve with Ledger, and users are able to continue up to signing (which will currently fail)
- Fees estimation are happy for RFOX stake, unstake, claim and change address with Ledger, and users are able to continue up to signing (which will currently fail)
- Fees estimation are happy for UNI-V2 deposits and withdraws, and users are able to continue up to signing (which will currently fail)
- Fees estimation are happy for FOX Farming deposits and withdraws, and users are able to continue up to signing (which will currently fail)
- Fees estimation are happy for THORChain savers deposits and withdraws, and users are able to continue up to signing (which will currently fail)
- Fees estimation are happy for FOXy withdraws, and users are able to continue up to signing (which will currently fail)

### Engineering

<!-----------------------------------------------------------------------------
Include sufficient information here for an engineer to test your PR. This may include how to test locally, in a built environment, changes to infrastructure etc.
------------------------------------------------------------------------------>

- ^

### Operations
- [ ] :checkered_flag: My feature is behind a flag and doesn't require operations testing (yet)

<!-----------------------------------------------------------------------------
If your changes have a user-facing impact, describe how a non-technical QA team can functionally test your changes in a preview environment.

If they are not user-facing please describe how to test for any regressions that may occur.
------------------------------------------------------------------------------>

- ^

## Screenshots (if applicable)

## Fees estimation are happy for RFOX stake, unstake, claim and change address with Ledger, and users are able to continue up to signing (which will currently fail)

### Stake

https://jam.dev/c/8378a9a7-7aaf-4945-92ec-0822979ac1ba

### Unstake

https://jam.dev/c/fb852d54-4369-410e-b1a6-3a9ee93ab5ad

### Claim

https://jam.dev/c/5ffa5941-3ff2-4b45-8c4e-44d6dc6108e9

### Change Addy

https://jam.dev/c/214c3669-4f45-4309-bfb6-57bfe27c2ba3

## Fees estimation are happy for THORChain saversdeposits and withdraws, and users are able to continue up to signing (which will currently fail)

### Deposit

https://jam.dev/c/4546486d-9b97-417c-9e34-659ba816978e

### Withdraw

https://jam.dev/c/e15916d5-c30d-4075-8640-01bd605036d1

## Fees estimation are happy for FOX Farming deposits and withdraws, and users are able to continue up to signing (which will currently fail)

### Deposit

https://jam.dev/c/c37a7531-e7ca-422d-9f1d-18b221fefd97

### Withdraw

https://jam.dev/c/90f3ea47-a3c6-49e8-b17a-4fabc4d22a23

## Fees estimation are happy for UNI-V2 savers deposits and withdraws, and users are able to continue up to signing (which will currently fail)

### Deposit

https://jam.dev/c/50b3931b-3bdd-4662-a1d8-2148250352ba

### Withdraw

https://jam.dev/c/def15ddd-4c02-4225-949f-7089212629a9

## Fees estimation are happy for FOXy withdraws, and users are able to continue up to signing (which will currently fail)

https://jam.dev/c/afd86c86-b1c2-41e3-9d05-16049f621557

## Fees estimation are happy for THORChain LP Add/Remove Liquidity and Approve with Ledger, and users are able to continue up to signing (which will currently fail)

### Add Liquidity

https://jam.dev/c/4060b4cd-61a8-43f6-ab07-e70240bb6358

### Remove Liquidity

https://jam.dev/c/357b8501-94f2-427b-ac91-8d77f168de9e

### Approve

https://jam.dev/c/464f188a-1bcb-4f11-8de4-1df64e5d773d

<!-- av pr metadata
This information is embedded by the av CLI when creating PRs to track the status of stacks when using Aviator. Please do not delete or edit this section of the PR.
```
{"parent":"develop","parentHead":"","trunk":"develop"}
```
-->
