### PR TITLE
fix: lp fiat toggle

### DIFF
--- a/src/pages/ThorChainLP/components/AddLiquidity/AddLiquidityInput.tsx
+++ b/src/pages/ThorChainLP/components/AddLiquidity/AddLiquidityInput.tsx
@@ -157,8 +157,7 @@ export const AddLiquidityInput: React.FC<AddLiquidityInputProps> = ({
   const translate = useTranslate()
   const { history: browserHistory } = useBrowserRouter()
   const history = useHistory()
-  const [runeIsFiat, toggleRuneIsFiat] = useToggle(false)
-  const [poolAssetIsFiat, togglePoolAssetIsFiat] = useToggle(false)
+  const [isFiat, toggleIsFiat] = useToggle(false)
 
   const accountIdsByChainId = useAppSelector(selectAccountIdsByChainId)
   const userCurrencyToUsdRate = useAppSelector(selectUserCurrencyToUsdRate)
@@ -471,17 +470,11 @@ export const AddLiquidityInput: React.FC<AddLiquidityInputProps> = ({
     if (opportunityType === AsymSide.Asset) return walletSupportsAsset
   }, [opportunityType, walletSupportsAsset, walletSupportsRune, isDemoWallet])
 
-  const handleToggleRuneIsFiat = useCallback(
+  const handleToggleIsFiat = useCallback(
     (_isFiat: boolean) => {
-      toggleRuneIsFiat()
+      toggleIsFiat()
     },
-    [toggleRuneIsFiat],
-  )
-  const handleTogglePoolAssetIsFiat = useCallback(
-    (_isFiat: boolean) => {
-      togglePoolAssetIsFiat()
-    },
-    [togglePoolAssetIsFiat],
+    [toggleIsFiat],
   )
 
   const handleBackClick = useCallback(() => {
@@ -1153,8 +1146,8 @@ export const AddLiquidityInput: React.FC<AddLiquidityInputProps> = ({
               rightComponent={ReadOnlyAsset}
               formControlProps={formControlProps}
               onChange={handleAddLiquidityInputChange}
-              onToggleIsFiat={isRune ? handleToggleRuneIsFiat : handleTogglePoolAssetIsFiat}
-              isFiat={isRune ? runeIsFiat : poolAssetIsFiat}
+              onToggleIsFiat={handleToggleIsFiat}
+              isFiat={isFiat}
               cryptoAmount={isNonEmptyString(cryptoAmount) ? cryptoAmount : '0'}
               fiatAmount={isNonEmptyString(fiatAmount) ? fiatAmount : '0'}
             />
@@ -1167,19 +1160,17 @@ export const AddLiquidityInput: React.FC<AddLiquidityInputProps> = ({
     createHandleAddLiquidityInputChange,
     currentAccountIdByChainId,
     handleAccountIdChange,
-    handleTogglePoolAssetIsFiat,
-    handleToggleRuneIsFiat,
+    handleToggleIsFiat,
     incompleteSide,
     opportunityType,
     pairDivider,
     percentOptions,
     poolAsset,
-    poolAssetIsFiat,
+    isFiat,
     poolAssetMarketData,
     position,
     previousOpportunityId,
     runeAsset,
-    runeIsFiat,
     runeMarketData,
     virtualAssetDepositAmountCryptoPrecision,
     virtualAssetDepositAmountFiatUserCurrency,


### PR DESCRIPTION
## Description

Fixes an issue where the "is fiat" state was not in sync between RUNE aysm input and the asset asym and sym inputs.

## Pull Request Type

- [x] :bug: Bug fix (Non-breaking Change: Fixes an issue)
- [ ] :hammer_and_wrench: Chore (Non-breaking Change: Doc updates, pkg upgrades, typos, etc..)
- [ ] :nail_care: New Feature (Breaking/Non-breaking Change)

## Issue (if applicable)

Closes https://github.com/shapeshift/web/issues/7433

## Risk

Low

> What protocols, transaction types, wallets or contract interactions might be affected by this PR?

LP input.

## Testing

Confirm that the behaviour in this video is no longer occurring (input state should stay in sync):

https://github.com/user-attachments/assets/17ece723-35e9-453c-87bc-518360722ba2

### Engineering

☝️

### Operations
- [ ] :checkered_flag: My feature is behind a flag and doesn't require operations testing (yet)

☝️

## Screenshots (if applicable)

N/A