### PR TITLE
perf: remove unnecessary dep

### DIFF
--- a/package.json
+++ b/package.json
@@ -84,7 +84,6 @@
     "@lifi/sdk": "^3.1.5",
     "@lukemorales/query-key-factory": "^1.3.4",
     "@metamask/detect-provider": "^2.0.0",
-    "@react-spring/web": "^9.7.4",
     "@reduxjs/toolkit": "^1.9.7",
     "@sentry-internal/browser-utils": "^8.26.0",
     "@sentry/react": "^8.26.0",

--- a/src/components/Graph/MaxPrice.tsx
+++ b/src/components/Graph/MaxPrice.tsx
@@ -1,4 +1,3 @@
-import { animated, useSpring } from '@react-spring/web'
 export interface LineChartProps {
   width: number
   label: string
@@ -7,13 +6,11 @@ export interface LineChartProps {
 }
 
 export const MaxPrice = ({ label, yText, stroke, width }: LineChartProps) => {
-  const styles = useSpring({ y: yText })
-
   return (
     <g>
-      <animated.text
+      <text
         x={width}
-        y={styles.y}
+        y={yText}
         width={100}
         textAnchor='end'
         fill={stroke}
@@ -22,7 +19,7 @@ export const MaxPrice = ({ label, yText, stroke, width }: LineChartProps) => {
         dx='-0.5rem'
       >
         {label}
-      </animated.text>
+      </text>
     </g>
   )
 }

--- a/src/components/Graph/MinPrice.tsx
+++ b/src/components/Graph/MinPrice.tsx
@@ -1,4 +1,3 @@
-import { animated, useSpring } from '@react-spring/web'
 export interface LineChartProps {
   width: number
   label: string
@@ -7,22 +6,20 @@ export interface LineChartProps {
 }
 
 export const MinPrice = ({ label, yText, stroke, width }: LineChartProps) => {
-  const styles = useSpring({ y: yText })
-
   return (
     <g>
-      <animated.text
+      <text
         x={width}
+        y={yText}
         width={100}
         dy='2.25rem'
         dx='-0.5rem'
         fontSize='12px'
         fill={stroke}
         textAnchor='end'
-        y={styles.y}
       >
         {label}
-      </animated.text>
+      </text>
     </g>
   )
 }

--- a/yarn.lock
+++ b/yarn.lock
@@ -10469,72 +10469,6 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@react-spring/animated@npm:~9.7.4":
-  version: 9.7.4
-  resolution: "@react-spring/animated@npm:9.7.4"
-  dependencies:
-    "@react-spring/shared": ~9.7.4
-    "@react-spring/types": ~9.7.4
-  peerDependencies:
-    react: ^16.8.0 || ^17.0.0 || ^18.0.0
-  checksum: 4de4f0424ccce5eee5916723c080e121cd8488626c4a2e22586b55c5f13c35fe5b9f1a3a636388f9797d9095c94856bd5bce235b43d3452b1c2a06cf61cd2e61
-  languageName: node
-  linkType: hard
-
-"@react-spring/core@npm:~9.7.4":
-  version: 9.7.4
-  resolution: "@react-spring/core@npm:9.7.4"
-  dependencies:
-    "@react-spring/animated": ~9.7.4
-    "@react-spring/shared": ~9.7.4
-    "@react-spring/types": ~9.7.4
-  peerDependencies:
-    react: ^16.8.0 || ^17.0.0 || ^18.0.0
-  checksum: fb00bd70611711873197f80ea0b2d4cd378ef82dd1396602e856268790ad1e330064c7a2174751d2b63fac4a07246b8e1b48deaf9cd6c2d25c89a61ca07b5062
-  languageName: node
-  linkType: hard
-
-"@react-spring/rafz@npm:~9.7.4":
-  version: 9.7.4
-  resolution: "@react-spring/rafz@npm:9.7.4"
-  checksum: 0a2d6af7bd5410030de51826e0e6f879a19a6e7f4f95add97df22973d8f054af9951ad172f5ab80b0538d778548e6342712a4fc76327330c37254a809289fc00
-  languageName: node
-  linkType: hard
-
-"@react-spring/shared@npm:~9.7.4":
-  version: 9.7.4
-  resolution: "@react-spring/shared@npm:9.7.4"
-  dependencies:
-    "@react-spring/rafz": ~9.7.4
-    "@react-spring/types": ~9.7.4
-  peerDependencies:
-    react: ^16.8.0 || ^17.0.0 || ^18.0.0
-  checksum: 2161717c20e66e48159d5a4eddf238317a9fec1cfb113ad4f89acb806f98a762759fd8e5192470ca24408ef2348c40c8d1a3f34c4126e094a7f949837eee6f30
-  languageName: node
-  linkType: hard
-
-"@react-spring/types@npm:~9.7.4":
-  version: 9.7.4
-  resolution: "@react-spring/types@npm:9.7.4"
-  checksum: 9002a0006902d6ec30c487b9670ca1f2820c33510c7025c1e56740b9a6dec347e18dd9ea3aeb7fe4619bfa87c15cc88fedd3d6df6342742872cf36b6c6e43cb5
-  languageName: node
-  linkType: hard
-
-"@react-spring/web@npm:^9.7.4":
-  version: 9.7.4
-  resolution: "@react-spring/web@npm:9.7.4"
-  dependencies:
-    "@react-spring/animated": ~9.7.4
-    "@react-spring/core": ~9.7.4
-    "@react-spring/shared": ~9.7.4
-    "@react-spring/types": ~9.7.4
-  peerDependencies:
-    react: ^16.8.0 || ^17.0.0 || ^18.0.0
-    react-dom: ^16.8.0 || ^17.0.0 || ^18.0.0
-  checksum: 9244bb0078537695054444174dbbd53c2aaf5d6bcd6961fac4a12e368967267622b76e63758f5d8b206b95ba8c1674642b2e74eced649e08b408b5f8dcc7aeb9
-  languageName: node
-  linkType: hard
-
 "@reduxjs/toolkit@npm:^1.9.7":
   version: 1.9.7
   resolution: "@reduxjs/toolkit@npm:1.9.7"
@@ -11485,7 +11419,6 @@ __metadata:
     "@lukemorales/query-key-factory": ^1.3.4
     "@metamask/detect-provider": ^2.0.0
     "@peculiar/webcrypto": ^1.3.3
-    "@react-spring/web": ^9.7.4
     "@reduxjs/toolkit": ^1.9.7
     "@sentry-internal/browser-utils": ^8.26.0
     "@sentry/react": ^8.26.0


### PR DESCRIPTION
## Description

Removes an unnecessary dependency, `@react-spring/web`.

The `MinPrice` and `MaxPrice` components don't need animation on the y coordinate text baseline, as they don't actually move.

## Pull Request Type

- [ ] :bug: Bug fix (Non-breaking Change: Fixes an issue)
- [x] :hammer_and_wrench: Chore (Non-breaking Change: Doc updates, pkg upgrades, typos, etc..)
- [ ] :nail_care: New Feature (Breaking/Non-breaking Change)

## Issue (if applicable)

N/A, raised by @woodenfurniture in https://github.com/shapeshift/web/pull/7582#pullrequestreview-2252187061.

## Risk

Low

> What protocols, transaction types, wallets or contract interactions might be affected by this PR?

None.

## Testing

Navigate to the wallet page, change between time spans on the balance chart, and confirm that the Min and Max text looks sane.

### Engineering

☝️

### Operations
- [ ] :checkered_flag: My feature is behind a flag and doesn't require operations testing (yet)

☝️

## Screenshots (if applicable)

<img width="365" alt="Screenshot 2024-08-22 at 11 46 18 AM" src="https://github.com/user-attachments/assets/b9e456ca-03cf-443b-b842-47fbeae18ae0">