### PR TITLE
fix: claim skeleton keys

### DIFF
--- a/src/pages/RFOX/components/Claim/ClaimSelect.tsx
+++ b/src/pages/RFOX/components/Claim/ClaimSelect.tsx
@@ -110,7 +110,7 @@ export const ClaimSelect: FC<ClaimSelectProps & ClaimRouteProps> = ({
       isUnstakingRequestPaused ||
       isUnstakingRequestRefetching
     )
-      return new Array(2).fill(null).map(() => <Skeleton height={16} my={2} />)
+      return new Array(2).fill(null).map((_, index) => <Skeleton key={index} height={16} my={2} />)
     if (isUnstakingRequestError || !unstakingRequestResponse.length)
       return <NoClaimsAvailable isError={isUnstakingRequestError} setStepIndex={setStepIndex} />
 


### PR DESCRIPTION
## Description

Adds keys to the `Skeleton` components in the `ClaimSelect` component for best practice and to avoid log spew.

<img width="1100" alt="Screenshot 2024-08-22 at 11 02 35 AM" src="https://github.com/user-attachments/assets/c5932d04-9e3b-4f78-9699-d1085bd90500">

## Pull Request Type

- [x] :bug: Bug fix (Non-breaking Change: Fixes an issue)
- [ ] :hammer_and_wrench: Chore (Non-breaking Change: Doc updates, pkg upgrades, typos, etc..)
- [ ] :nail_care: New Feature (Breaking/Non-breaking Change)

## Issue (if applicable)

N/A

## Risk

Very small.

> What protocols, transaction types, wallets or contract interactions might be affected by this PR?

None.

## Testing

Check the console when selecting the claims tab on the rFOX route, we should no longer see the above warning.

### Engineering

☝️

### Operations
- [ ] :checkered_flag: My feature is behind a flag and doesn't require operations testing (yet)

☝️

## Screenshots (if applicable)

See above.