### PR TITLE
fix: unrecognised collateralDecreaseAmountCryptoPrecision

### DIFF
--- a/src/pages/Lending/Pool/components/LoanSummary.tsx
+++ b/src/pages/Lending/Pool/components/LoanSummary.tsx
@@ -85,6 +85,7 @@ export const LoanSummary: React.FC<LoanSummaryProps> = ({
   collateralAccountId,
   borrowAccountId,
   confirmedQuote,
+  collateralDecreaseAmountCryptoPrecision,
   ...rest
 }) => {
   const translate = useTranslate()


### PR DESCRIPTION
## Description

Fixes a bug where we are passing an unrecognised prop, `collateralDecreaseAmountCryptoPrecision`, to a DOM element.

<img width="1272" alt="Screenshot 2024-08-22 at 12 23 09 PM" src="https://github.com/user-attachments/assets/cdce8fa1-53b2-485d-abcd-8ad075873205">


## Pull Request Type

- [x] :bug: Bug fix (Non-breaking Change: Fixes an issue)
- [ ] :hammer_and_wrench: Chore (Non-breaking Change: Doc updates, pkg upgrades, typos, etc..)
- [ ] :nail_care: New Feature (Breaking/Non-breaking Change)

## Issue (if applicable)

N/A

## Risk

Very small.

> What protocols, transaction types, wallets or contract interactions might be affected by this PR?

None.

## Testing

Console warning should no longer show when opening a lending position.

### Engineering

☝️

### Operations
- [ ] :checkered_flag: My feature is behind a flag and doesn't require operations testing (yet)

☝️

## Screenshots (if applicable)

See above.
