### PR TITLE
fix: zapper zod types

### DIFF
--- a/src/state/apis/zapper/validators.ts
+++ b/src/state/apis/zapper/validators.ts
@@ -140,7 +140,7 @@ type ZapperToken = {
   price?: number
   supply?: number
   symbol: string
-  decimals: number
+  decimals: string | number
   dataProps?: Infer<typeof ZapperDataPropsSchema>
   displayProps?: Infer<typeof ZapperDisplayPropsSchema>
   pricePerShare?: (string | number)[]
@@ -155,7 +155,7 @@ const ZapperTokenSchema: Type<ZapperToken> = z
     type: z.literals('base-token', 'app-token'),
     network: SupportedZapperNetworks,
     address: z.string(),
-    decimals: z.number(),
+    decimals: z.union([z.string(), z.number()]),
     symbol: z.string(),
     price: z.number(),
     metaType: z.literals('claimable', 'supplied', 'borrowed').optional(),

--- a/src/state/apis/zapper/zapperApi.ts
+++ b/src/state/apis/zapper/zapperApi.ts
@@ -411,7 +411,7 @@ export const zapper = createApi({
                         symbol: token.symbol,
                         // No dice here, there's no name property
                         name: token.symbol,
-                        precision: token.decimals,
+                        precision: bnOrZero(token.decimals).toNumber(),
                         icon: token.displayProps?.images[i] ?? '',
                       })
                       acc.ids = acc.ids.concat(rewardAssetId)
@@ -545,7 +545,7 @@ export const zapper = createApi({
                         symbol: asset.tokens[i].symbol,
                         // No dice here, there's no name property
                         name: asset.tokens[i].symbol,
-                        precision: asset.tokens[i].decimals,
+                        precision: bnOrZero(asset.tokens[i].decimals).toNumber(),
                         icon: asset.displayProps?.images[i] ?? '',
                       })
                       acc.ids = acc.ids.concat(underlyingAssetId)
@@ -580,7 +580,10 @@ export const zapper = createApi({
                         ? bn(reserveBaseUnit).div(totalSupplyBaseUnit).toString()
                         : undefined
                       if (bnOrZero(tokenPoolRatio).isZero()) return '0'
-                      const ratio = toBaseUnit(tokenPoolRatio, asset.tokens[i].decimals)
+                      const ratio = toBaseUnit(
+                        tokenPoolRatio,
+                        bnOrZero(asset.tokens[i].decimals).toNumber(),
+                      )
                       return ratio
                     },
                   )

--- a/src/state/slices/opportunitiesSlice/resolvers/uniV2/index.ts
+++ b/src/state/slices/opportunitiesSlice/resolvers/uniV2/index.ts
@@ -127,8 +127,8 @@ export const uniV2LpOpportunitiesMetadataResolver = async ({
         }
       }
 
-      token0Decimals = zapperAppBalanceData.tokens?.[0].decimals!
-      token1Decimals = zapperAppBalanceData.tokens?.[1].decimals!
+      token0Decimals = bnOrZero(zapperAppBalanceData.tokens?.[0].decimals!).toNumber()
+      token1Decimals = bnOrZero(zapperAppBalanceData.tokens?.[1].decimals!).toNumber()
       token0Reserves = bnOrZero(zapperAppBalanceData.dataProps?.reserves?.[0])!
       token1Reserves = bnOrZero(zapperAppBalanceData.dataProps?.reserves?.[1])!
       token0Address = getAddress(zapperAppBalanceData?.tokens?.[0].address!)


### PR DESCRIPTION
## Description

Fixes zod types for the `https://api.zapper.xyz/v2/balances/apps?addresses` endpoint.

<img width="929" alt="Screenshot 2024-08-22 at 12 53 07 PM" src="https://github.com/user-attachments/assets/c1178698-7d76-432d-9d16-8bc919842c38">

Token decimals can be either a `string` or a `number` in the response data.

<img width="860" alt="Screenshot 2024-08-22 at 12 35 58 PM" src="https://github.com/user-attachments/assets/8c32a0c6-cc0c-4dea-83c6-04a559ebb9f3">
<img width="859" alt="Screenshot 2024-08-22 at 12 50 17 PM" src="https://github.com/user-attachments/assets/99670fe7-d2fa-40f0-8cc7-9833ad801168">

## Pull Request Type

- [x] :bug: Bug fix (Non-breaking Change: Fixes an issue)
- [ ] :hammer_and_wrench: Chore (Non-breaking Change: Doc updates, pkg upgrades, typos, etc..)
- [ ] :nail_care: New Feature (Breaking/Non-breaking Change)

## Issue (if applicable)

N/A

## Risk

Small

> What protocols, transaction types, wallets or contract interactions might be affected by this PR?

None.

## Testing

When loading the "Earn" page we should no longer get the above zod type error.

### Engineering

☝️

### Operations
- [ ] :checkered_flag: My feature is behind a flag and doesn't require operations testing (yet)

☝️

## Screenshots (if applicable)

See above.