### PR TITLE
feat: add transaction require signing inside ledger ACK componenet

### DIFF
--- a/src/assets/translations/en/main.json
+++ b/src/assets/translations/en/main.json
@@ -1880,7 +1880,8 @@
   },
   "ledgerOpenApp": {
     "title": "Open the %{appName} App",
-    "description": "To continue, you will need to open the %{appName} app on your Ledger device."
+    "description": "To continue, you will need to open the %{appName} app on your Ledger device.",
+    "signingDescription": "Your transaction will require signing on-device after you open the app"
   },
   "loremIpsum": "Lorem ipsum dolor sit amet, consectetur adipiscing elit. Ut sed lectus efficitur, iaculis sapien eu, luctus tellus. Maecenas eget sapien dignissim, finibus mauris nec, mollis ipsum. Donec sodales sit amet felis sagittis vestibulum. Ut in consectetur lacus. Suspendisse potenti. Aenean at massa consequat lectus semper pretium. Cras sed bibendum enim. Mauris euismod sit amet dolor in placerat.",
   "transactionHistory": {

--- a/src/components/ManageAccountsDrawer/ManageAccountsDrawer.tsx
+++ b/src/components/ManageAccountsDrawer/ManageAccountsDrawer.tsx
@@ -25,7 +25,7 @@ export const ManageAccountsDrawer = ({
   const [step, setStep] = useState<ManageAccountsStep>('selectChain')
   const [selectedChainId, setSelectedChainId] = useState<ChainId | null>(null)
 
-  const checkLedgerAppOpenIfLedgerConnected = useLedgerOpenApp()
+  const checkLedgerAppOpenIfLedgerConnected = useLedgerOpenApp({ isSigning: false })
 
   const handleClose = useCallback(() => {
     setStep('selectChain')

--- a/src/components/Modals/LedgerOpenApp/LedgerOpenAppModal.tsx
+++ b/src/components/Modals/LedgerOpenApp/LedgerOpenAppModal.tsx
@@ -21,9 +21,10 @@ import { useLedgerAppDetails } from './hooks/useLedgerAppDetails'
 export type LedgerOpenAppModalProps = {
   chainId: ChainId
   onCancel: () => void
+  isSigning: boolean
 }
 
-export const LedgerOpenAppModal = ({ chainId, onCancel }: LedgerOpenAppModalProps) => {
+export const LedgerOpenAppModal = ({ chainId, onCancel, isSigning }: LedgerOpenAppModalProps) => {
   const { close: closeModal, isOpen } = useModal('ledgerOpenApp')
   const translate = useTranslate()
 
@@ -50,12 +51,17 @@ export const LedgerOpenAppModal = ({ chainId, onCancel }: LedgerOpenAppModalProp
         </ModalHeader>
         <ModalBody>
           <VStack spacing={2}>
-            <RawText color='whiteAlpha.600'>
+            <RawText color='whiteAlpha.600' textAlign='center'>
               {translate('ledgerOpenApp.description', {
                 appName,
               })}
             </RawText>
-            <Spinner size='lg' />
+            {isSigning ? (
+              <RawText color='whiteAlpha.600' textAlign='center'>
+                {translate('ledgerOpenApp.signingDescription')}
+              </RawText>
+            ) : null}
+            <Spinner mt={4} size='lg' />
           </VStack>
         </ModalBody>
         <ModalFooter justifyContent='center' pb={6}>

--- a/src/components/MultiHopTrade/components/MultiHopTradeConfirm/components/ApprovalStep.tsx
+++ b/src/components/MultiHopTrade/components/MultiHopTradeConfirm/components/ApprovalStep.tsx
@@ -123,7 +123,7 @@ const ApprovalStepPending = ({
   // Default to exact allowance for LiFi due to contract vulnerabilities
   const [isExactAllowance, toggleIsExactAllowance] = useToggle(isLifiStep ? true : false)
 
-  const checkLedgerAppOpenIfLedgerConnected = useLedgerOpenApp()
+  const checkLedgerAppOpenIfLedgerConnected = useLedgerOpenApp({ isSigning: true })
   const hopExecutionMetadataFilter = useMemo(() => {
     return {
       tradeId: activeTradeId,

--- a/src/components/MultiHopTrade/components/MultiHopTradeConfirm/components/HopTransactionStep.tsx
+++ b/src/components/MultiHopTrade/components/MultiHopTradeConfirm/components/HopTransactionStep.tsx
@@ -52,7 +52,7 @@ export const HopTransactionStep = ({
   } = useLocaleFormatter()
   const translate = useTranslate()
 
-  const checkLedgerAppOpenIfLedgerConnected = useLedgerOpenApp()
+  const checkLedgerAppOpenIfLedgerConnected = useLedgerOpenApp({ isSigning: true })
 
   const hopExecutionMetadataFilter = useMemo(() => {
     return {

--- a/src/components/MultiHopTrade/components/VerifyAddresses/VerifyAddresses.tsx
+++ b/src/components/MultiHopTrade/components/VerifyAddresses/VerifyAddresses.tsx
@@ -220,7 +220,7 @@ export const VerifyAddresses = () => {
     ],
   )
 
-  const checkLedgerAppOpenIfLedgerConnected = useLedgerOpenApp()
+  const checkLedgerAppOpenIfLedgerConnected = useLedgerOpenApp({ isSigning: true })
 
   const handleBuyVerify = useCallback(async () => {
     // Only proceed to verify the buy address if the promise is resolved, i.e the user has opened

--- a/src/hooks/useLedgerOpenApp/useLedgerOpenApp.tsx
+++ b/src/hooks/useLedgerOpenApp/useLedgerOpenApp.tsx
@@ -50,6 +50,10 @@ export const getSlip44KeyFromChainId = (chainId: ChainId): Slip44Key | undefined
   }
 }
 
+type UseLedgerOpenAppProps = {
+  isSigning: boolean
+}
+
 /**
  * This hook provides a function that can be used to check if the Ledger app is open for the given chainId.
  *
@@ -57,7 +61,7 @@ export const getSlip44KeyFromChainId = (chainId: ChainId): Slip44Key | undefined
  *
  * The function will resolve when the app is open, or reject if the user cancels the request.
  */
-export const useLedgerOpenApp = () => {
+export const useLedgerOpenApp = ({ isSigning }: UseLedgerOpenAppProps) => {
   const { close: closeModal, open: openModal } = useModal('ledgerOpenApp')
 
   const wallet = useWallet().state.wallet
@@ -113,10 +117,10 @@ export const useLedgerOpenApp = () => {
         }
 
         // Display the request to open the Ledger app
-        openModal({ chainId, onCancel })
+        openModal({ chainId, onCancel, isSigning })
       })
     },
-    [checkIsCorrectAppOpen, closeModal, openModal, wallet],
+    [checkIsCorrectAppOpen, closeModal, openModal, wallet, isSigning],
   )
 
   return checkLedgerApp

--- a/src/pages/RFOX/components/ChangeAddress/ChangeAddressConfirm.tsx
+++ b/src/pages/RFOX/components/ChangeAddress/ChangeAddressConfirm.tsx
@@ -71,7 +71,7 @@ export const ChangeAddressConfirm: React.FC<
     () => (feeAsset ? assertGetEvmChainAdapter(fromAssetId(feeAsset.assetId).chainId) : undefined),
     [feeAsset],
   )
-  const checkLedgerAppOpenIfLedgerConnected = useLedgerOpenApp()
+  const checkLedgerAppOpenIfLedgerConnected = useLedgerOpenApp({ isSigning: true })
 
   const stakingAssetAccountAddress = useMemo(
     () => fromAccountId(confirmedQuote.stakingAssetAccountId).account,

--- a/src/pages/RFOX/components/Claim/ClaimConfirm.tsx
+++ b/src/pages/RFOX/components/Claim/ClaimConfirm.tsx
@@ -65,7 +65,7 @@ export const ClaimConfirm: FC<Pick<ClaimRouteProps, 'headerComponent'> & ClaimCo
   const history = useHistory()
   const translate = useTranslate()
   const wallet = useWallet().state.wallet
-  const checkLedgerAppOpenIfLedgerConnected = useLedgerOpenApp()
+  const checkLedgerAppOpenIfLedgerConnected = useLedgerOpenApp({ isSigning: true })
 
   const handleGoBack = useCallback(() => {
     history.push(ClaimRoutePaths.Select)

--- a/src/pages/RFOX/components/Stake/Bridge/BridgeConfirm.tsx
+++ b/src/pages/RFOX/components/Stake/Bridge/BridgeConfirm.tsx
@@ -44,7 +44,7 @@ const CustomRow: React.FC<RowProps> = props => <Row fontSize='sm' fontWeight='me
 export const BridgeConfirm: FC<BridgeRouteProps & BridgeConfirmProps> = ({ confirmedQuote }) => {
   const history = useHistory()
   const translate = useTranslate()
-  const checkLedgerAppOpenIfLedgerConnected = useLedgerOpenApp()
+  const checkLedgerAppOpenIfLedgerConnected = useLedgerOpenApp({ isSigning: true })
 
   const {
     sellAsset,

--- a/src/pages/RFOX/components/Stake/Bridge/BridgeStatus.tsx
+++ b/src/pages/RFOX/components/Stake/Bridge/BridgeStatus.tsx
@@ -20,7 +20,7 @@ export const BridgeStatus: React.FC<BridgeRouteProps & BridgeStatusProps> = ({
 }) => {
   const translate = useTranslate()
   const history = useHistory()
-  const checkLedgerAppOpenIfLedgerConnected = useLedgerOpenApp()
+  const checkLedgerAppOpenIfLedgerConnected = useLedgerOpenApp({ isSigning: true })
 
   const {
     sellAsset,

--- a/src/pages/RFOX/components/Stake/StakeConfirm.tsx
+++ b/src/pages/RFOX/components/Stake/StakeConfirm.tsx
@@ -64,7 +64,7 @@ export const StakeConfirm: React.FC<StakeConfirmProps & StakeRouteProps> = ({
   const queryClient = useQueryClient()
   const history = useHistory()
   const translate = useTranslate()
-  const checkLedgerAppOpenIfLedgerConnected = useLedgerOpenApp()
+  const checkLedgerAppOpenIfLedgerConnected = useLedgerOpenApp({ isSigning: true })
 
   const stakingAsset = useAppSelector(state =>
     selectAssetById(state, confirmedQuote.stakingAssetId),

--- a/src/pages/RFOX/components/Unstake/UnstakeConfirm.tsx
+++ b/src/pages/RFOX/components/Unstake/UnstakeConfirm.tsx
@@ -45,7 +45,7 @@ export const UnstakeConfirm: React.FC<UnstakeRouteProps & UnstakeConfirmProps> =
 }) => {
   const history = useHistory()
   const translate = useTranslate()
-  const checkLedgerAppOpenIfLedgerConnected = useLedgerOpenApp()
+  const checkLedgerAppOpenIfLedgerConnected = useLedgerOpenApp({ isSigning: true })
 
   const stakingAsset = useAppSelector(state =>
     selectAssetById(state, confirmedQuote.stakingAssetId),


### PR DESCRIPTION
## Description

I added a `isSigning` prop to the `useLedgerOpenApp` hook, so that we can display a text explaining that the TX will require signing after opening the app, useful because sometime you open the app then you don't understand what happens, but you have to wait for the signing process to be showing up!

<!-- Please describe your changes -->

## Issue (if applicable)

<!-----------------------------------------------------------------------------
If applicable, please link to the github issue and put `closes #XXXX` in your comment to auto-close the issue that your PR fixes.
------------------------------------------------------------------------------>

follow-up of #7569

## Risk
Low
> High Risk PRs Require 2 approvals

<!-----------------------------------------------------------------------------
Outline the scope of your changes and the risk associated with them. You must use your discretion as an engineer to determine the potential impact of your changes.

WARNING: If your PR introduces a new on-chain transaction or modifies an existing one, please add the "High-Risk" label to this PR and ask for 2 reviewers to approve it before merging.

E.g. an upgrade to `hdwallet` or core state management would be considered higher risk, and might require a full regression test. UI or isolated view changes, or something behind a feature flag may have near zero risk. Small bug fixes might require testing isolated to the specific fix.
------------------------------------------------------------------------------>

> What protocols, transaction types, wallets or contract interactions might be affected by this PR?

## Testing
- Try sign a TX with a ledger not having the app opened in:
-- MultiHop Trades (swapper), (don't forget the approve tx for an asset such as USDC) (should display the signing description)
-- Every rFOX features (should display the signing description)
-- The Manage Account Drawer (should `NOT` display the signing description)

<!-----------------------------------------------------------------------------
We treat every PR to be merged with the same scrutiny as if we were merging directly to production.

Your PR will not be merged if you do not complete the sections below for our engineering and operations teams to test.
------------------------------------------------------------------------------>

### Engineering
n/a
<!-----------------------------------------------------------------------------
Include sufficient information here for an engineer to test your PR. This may include how to test locally, in a built environment, changes to infrastructure etc.
------------------------------------------------------------------------------>

### Operations
n/a
- [ ] :checkered_flag: My feature is behind a flag and doesn't require operations testing (yet)

<!-----------------------------------------------------------------------------
If your changes have a user-facing impact, describe how a non-technical QA team can functionally test your changes in a preview environment.

If they are not user-facing please describe how to test for any regressions that may occur.
------------------------------------------------------------------------------>

## Screenshots (if applicable)
With `isSigning: true` 
![image](https://github.com/user-attachments/assets/6e9db9f2-65b2-4054-ab6a-1c68a910d6ff)

With `isSigning: false` (Account Management Modal) 
![image](https://github.com/user-attachments/assets/14305ea7-ff3e-4cd1-9e3f-b7ebceaa7237)
