### PR TITLE
fix: fee explainer modal close button

### DIFF
--- a/src/components/FeeModal/FeeModal.tsx
+++ b/src/components/FeeModal/FeeModal.tsx
@@ -1,5 +1,6 @@
 import {
   Modal,
+  ModalBody,
   ModalCloseButton,
   ModalContent,
   ModalOverlay,
@@ -35,26 +36,28 @@ export const FeeModal = ({
       <ModalOverlay />
       <ModalContent>
         <ModalCloseButton />
-        <Tabs variant='button'>
-          <TabList px={6} py={4} borderBottomWidth={1} borderColor='border.base'>
-            <Tab color='text.subtle'>{translate('foxDiscounts.feeSummary')}</Tab>
-            <Tab color='text.subtle'>{translate('foxDiscounts.simulateFee')}</Tab>
-          </TabList>
-          <TabPanels>
-            <TabPanel p={0}>
-              <FeeBreakdown feeModel={feeModel} inputAmountUsd={inputAmountUsd} />
-            </TabPanel>
-            <TabPanel px={0} py={0}>
-              <FeeExplainer
-                inputAmountUsd={inputAmountUsd}
-                borderRadius='none'
-                bg='transparent'
-                boxShadow='none'
-                feeModel={feeModel}
-              />
-            </TabPanel>
-          </TabPanels>
-        </Tabs>
+        <ModalBody>
+          <Tabs variant='button'>
+            <TabList px={6} py={4} borderBottomWidth={1} borderColor='border.base'>
+              <Tab color='text.subtle'>{translate('foxDiscounts.feeSummary')}</Tab>
+              <Tab color='text.subtle'>{translate('foxDiscounts.simulateFee')}</Tab>
+            </TabList>
+            <TabPanels>
+              <TabPanel p={0}>
+                <FeeBreakdown feeModel={feeModel} inputAmountUsd={inputAmountUsd} />
+              </TabPanel>
+              <TabPanel px={0} py={0}>
+                <FeeExplainer
+                  inputAmountUsd={inputAmountUsd}
+                  borderRadius='none'
+                  bg='transparent'
+                  boxShadow='none'
+                  feeModel={feeModel}
+                />
+              </TabPanel>
+            </TabPanels>
+          </Tabs>
+        </ModalBody>
       </ModalContent>
     </Modal>
   )

--- a/src/components/FeeModal/FeeModal.tsx
+++ b/src/components/FeeModal/FeeModal.tsx
@@ -35,8 +35,8 @@ export const FeeModal = ({
     <Modal isOpen={isOpen} onClose={handleClose} size='lg'>
       <ModalOverlay />
       <ModalContent>
-        <ModalCloseButton />
-        <ModalBody>
+        <ModalCloseButton zIndex='1' />
+        <ModalBody p={0}>
           <Tabs variant='button'>
             <TabList px={6} py={4} borderBottomWidth={1} borderColor='border.base'>
               <Tab color='text.subtle'>{translate('foxDiscounts.feeSummary')}</Tab>


### PR DESCRIPTION
## Description

Fixes the dead click on the fee explainer close modal, likely caused by the Chakra package bump due to our incorrect usage (or lack thereof) of `<ModalBody>.

<img width="350" alt="Screenshot 2024-08-23 at 10 57 22 AM" src="https://github.com/user-attachments/assets/4af01fdb-705d-4852-aeab-25eb83ac404f">


## Issue (if applicable)

Closes https://github.com/shapeshift/web/issues/7610

## Risk

> High Risk PRs Require 2 approvals

Low

> What protocols, transaction types, wallets or contract interactions might be affected by this PR?

None

## Testing

Ensure that the fee explainer can be closed using the close button (not just clicking the background).

### Engineering

☝️

### Operations

- [ ] :checkered_flag: My feature is behind a flag and doesn't require operations testing (yet)

☝️

## Screenshots (if applicable)

See above.