### PR TITLE
fix: make fiat ramp market-data madness sufficiently happy

### DIFF
--- a/src/components/ReactTable/ReactTable.tsx
+++ b/src/components/ReactTable/ReactTable.tsx
@@ -14,7 +14,7 @@ import {
   useColorModeValue,
 } from '@chakra-ui/react'
 import type { ReactNode } from 'react'
-import { Fragment, useCallback, useMemo, useRef } from 'react'
+import { Fragment, useCallback, useEffect, useMemo, useRef } from 'react'
 import { useTranslate } from 'react-polyglot'
 import type { Cell, Column, ColumnInstance, Row, TableState } from 'react-table'
 import { useExpanded, usePagination, useSortBy, useTable } from 'react-table'
@@ -32,6 +32,7 @@ type ReactTableProps<T extends {}> = {
   renderEmptyComponent?: () => ReactNode
   isLoading?: boolean
   variant?: TableProps['variant']
+  onPageChange?: (page: Row<T>[]) => void
 }
 
 const tdStyle = { padding: 0 }
@@ -126,6 +127,7 @@ export const ReactTable = <T extends {}>({
   renderEmptyComponent,
   isLoading = false,
   variant = 'default',
+  onPageChange,
 }: ReactTableProps<T>) => {
   const translate = useTranslate()
   const tableRef = useRef<HTMLTableElement | null>(null)
@@ -166,6 +168,12 @@ export const ReactTable = <T extends {}>({
     useExpanded,
     usePagination,
   )
+
+  useEffect(() => {
+    if (!onPageChange) return
+
+    onPageChange(page)
+  }, [onPageChange, page])
 
   const renderedRows = useMemo(() => {
     return page.map(row => {

--- a/src/pages/Buy/Buy.tsx
+++ b/src/pages/Buy/Buy.tsx
@@ -16,7 +16,6 @@ import type { TextPropTypes } from 'components/Text/Text'
 import { WalletActions } from 'context/WalletProvider/actions'
 import { useWallet } from 'hooks/useWallet/useWallet'
 import { useGetFiatRampsQuery } from 'state/apis/fiatRamps/fiatRamps'
-import { useFetchFiatAssetMarketData } from 'state/apis/fiatRamps/hooks'
 import { selectFiatRampChainCount } from 'state/apis/fiatRamps/selectors'
 import { useAppSelector } from 'state/store'
 
@@ -54,7 +53,6 @@ export const Buy = () => {
     state: { isConnected, isDemoWallet },
   } = useWallet()
   const translate = useTranslate()
-  useFetchFiatAssetMarketData()
 
   const chainCount = useAppSelector(selectFiatRampChainCount)
 

--- a/src/pages/Buy/TopAssets.tsx
+++ b/src/pages/Buy/TopAssets.tsx
@@ -1,5 +1,6 @@
 import { Box, Button, Heading } from '@chakra-ui/react'
-import { useCallback, useMemo } from 'react'
+import type { AssetId } from '@shapeshiftoss/caip'
+import { useCallback, useMemo, useState } from 'react'
 import { useTranslate } from 'react-polyglot'
 import { useSelector } from 'react-redux'
 import type { Column, Row } from 'react-table'
@@ -27,8 +28,9 @@ export const TopAssets: React.FC = () => {
   const fiatRamps = useModal('fiatRamps')
   const translate = useTranslate()
   const fiatRampBuyAssetsWithMarketData = useSelector(selectFiatRampBuyAssetsWithMarketData)
+  const [pageAssetIds, setPageAssetIds] = useState<AssetId[]>([])
 
-  useFetchFiatAssetMarketData()
+  useFetchFiatAssetMarketData(pageAssetIds)
 
   const columns: Column<AssetWithMarketData>[] = useMemo(
     () => [
@@ -93,6 +95,11 @@ export const TopAssets: React.FC = () => {
     [fiatRamps],
   )
 
+  const handlePageChange = useCallback((page: Row<AssetWithMarketData>[]) => {
+    const assetIds = page.map(row => row.original.assetId)
+    setPageAssetIds(assetIds)
+  }, [])
+
   return (
     <Box>
       <PageContainer
@@ -111,6 +118,7 @@ export const TopAssets: React.FC = () => {
           data={fiatRampBuyAssetsWithMarketData}
           initialState={reactTableInitialState}
           onRowClick={handleClick}
+          onPageChange={handlePageChange}
           rowDataTestKey='name'
           rowDataTestPrefix='fiat-ramp'
         />

--- a/src/pages/Buy/TopAssets.tsx
+++ b/src/pages/Buy/TopAssets.tsx
@@ -10,6 +10,7 @@ import { AssetCell } from 'components/StakingVaults/Cells'
 import { Text } from 'components/Text'
 import { useModal } from 'hooks/useModal/useModal'
 import { bnOrZero } from 'lib/bignumber/bignumber'
+import { useFetchFiatAssetMarketData } from 'state/apis/fiatRamps/hooks'
 import { selectFiatRampBuyAssetsWithMarketData } from 'state/apis/fiatRamps/selectors'
 
 import { PageContainer } from './components/PageContainer'
@@ -26,6 +27,8 @@ export const TopAssets: React.FC = () => {
   const fiatRamps = useModal('fiatRamps')
   const translate = useTranslate()
   const fiatRampBuyAssetsWithMarketData = useSelector(selectFiatRampBuyAssetsWithMarketData)
+
+  useFetchFiatAssetMarketData()
 
   const columns: Column<AssetWithMarketData>[] = useMemo(
     () => [

--- a/src/state/apis/fiatRamps/hooks.ts
+++ b/src/state/apis/fiatRamps/hooks.ts
@@ -1,20 +1,17 @@
+import type { AssetId } from '@shapeshiftoss/caip'
 import { HistoryTimeframe } from '@shapeshiftoss/types'
 import { useEffect } from 'react'
 import { marketApi } from 'state/slices/marketDataSlice/marketDataSlice'
-import { useAppDispatch, useAppSelector } from 'state/store'
+import { useAppDispatch } from 'state/store'
 
-import { fiatRampApi } from './fiatRamps'
-
-export const useFetchFiatAssetMarketData = (): void => {
-  const { data } = useAppSelector(fiatRampApi.endpoints.getFiatRamps.select())
+export const useFetchFiatAssetMarketData = (assetIds: AssetId[]): void => {
   const dispatch = useAppDispatch()
   useEffect(() => {
     const timeframe = HistoryTimeframe.DAY
-    const assetIds = Object.keys(data?.byAssetId ?? {})
 
     if (assetIds.length > 0) {
       dispatch(marketApi.endpoints.findPriceHistoryByAssetIds.initiate({ assetIds, timeframe }))
       dispatch(marketApi.endpoints.findByAssetIds.initiate(assetIds))
     }
-  }, [data, dispatch])
+  }, [assetIds, dispatch])
 }


### PR DESCRIPTION
## Description

i.e actually fixes things, but a follow-up is expected to make things *even* better.

A PR in two steps:

1. Bring `useFetchFiatAssetMarketData` down to where it's actually needed for spot/historical data i.e `<TopAssets />`
2. Only pass down the current page assets

A follow-up will be authored making RTK caching of findPriceHistoryByAssetIds and `findByAssetIds` better i.e 
- splitting `findPriceHistoryByAssetIds` with a more granular `findPriceHistoryByAssetId`, to ensure caching of existing requests (i.e different consumers may request the same assetId and timeFrame, but as part of a different assetIds array, which would be a new reference and would trigger a refetch of said assetId)
- splitting `findByAssetIds` and leveraging `findByAssetId` the same way

## Issue (if applicable)

<!-----------------------------------------------------------------------------
If applicable, please link to the github issue and put `closes #XXXX` in your comment to auto-close the issue that your PR fixes.
------------------------------------------------------------------------------>

https://github.com/shapeshift/web/issues/7599

## Risk

> High Risk PRs Require 2 approvals

<!-----------------------------------------------------------------------------
Outline the scope of your changes and the risk associated with them. You must use your discretion as an engineer to determine the potential impact of your changes.

WARNING: If your PR introduces a new on-chain transaction or modifies an existing one, please add the "High-Risk" label to this PR and ask for 2 reviewers to approve it before merging.

E.g. an upgrade to `hdwallet` or core state management would be considered higher risk, and might require a full regression test. UI or isolated view changes, or something behind a feature flag may have near zero risk. Small bug fixes might require testing isolated to the specific fix.
------------------------------------------------------------------------------>

> What protocols, transaction types, wallets or contract interactions might be affected by this PR?

Low to none

## Testing

<!-----------------------------------------------------------------------------
We treat every PR to be merged with the same scrutiny as if we were merging directly to production.

Your PR will not be merged if you do not complete the sections below for our engineering and operations teams to test.
------------------------------------------------------------------------------>

- Enure fiat ramps page is great again without 1000s of market-data XHRs spew
- Ensure clicking on next fetches spot/historical market-data for the next page
- Ensure market data is still happy in fiat ramps page asset selection

### Engineering

<!-----------------------------------------------------------------------------
Include sufficient information here for an engineer to test your PR. This may include how to test locally, in a built environment, changes to infrastructure etc.
------------------------------------------------------------------------------>

- ^

### Operations

- [ ] :checkered_flag: My feature is behind a flag and doesn't require operations testing (yet)

<!-----------------------------------------------------------------------------
If your changes have a user-facing impact, describe how a non-technical QA team can functionally test your changes in a preview environment.

If they are not user-facing please describe how to test for any regressions that may occur.
------------------------------------------------------------------------------>

- ^

## Screenshots (if applicable)

- Prod

https://jam.dev/c/37130b2b-67aa-4852-8b8c-0b18485ec360

- this diff

https://jam.dev/c/cfab79c2-fe92-4637-922c-1d22d40ff439

<!-- av pr metadata
This information is embedded by the av CLI when creating PRs to track the status of stacks when using Aviator. Please do not delete or edit this section of the PR.
```
{"parent":"develop","parentHead":"","trunk":"develop"}
```
-->
