### PR TITLE
chore: show chain not supported on rFOX claim

### DIFF
--- a/src/pages/RFOX/components/Stake/StakeInput.tsx
+++ b/src/pages/RFOX/components/Stake/StakeInput.tsx
@@ -1,6 +1,11 @@
-import { CardFooter, Collapse, Skeleton, Stack } from '@chakra-ui/react'
+import { CardBody, CardFooter, Collapse, Skeleton, Stack } from '@chakra-ui/react'
 import type { AssetId } from '@shapeshiftoss/caip'
-import { foxAssetId, foxOnArbitrumOneAssetId, fromAssetId } from '@shapeshiftoss/caip'
+import {
+  foxAssetId,
+  foxOnArbitrumOneAssetId,
+  fromAccountId,
+  fromAssetId,
+} from '@shapeshiftoss/caip'
 import type { Asset, KnownChainIds } from '@shapeshiftoss/types'
 import noop from 'lodash/noop'
 import { useCallback, useEffect, useMemo, useState } from 'react'
@@ -35,6 +40,7 @@ import {
 import { useAppDispatch, useAppSelector } from 'state/store'
 
 import { AddressSelection } from '../AddressSelection'
+import { ChainNotSupported } from '../Shared/ChainNotSupported'
 import type { RfoxBridgeQuote } from './Bridge/types'
 import { BridgeRoutePaths } from './Bridge/types'
 import { StakeSummary } from './components/StakeSummary'
@@ -206,6 +212,11 @@ export const StakeInput: React.FC<StakeInputProps & StakeRouteProps> = ({
     setStakeTxid: undefined,
     methods,
   })
+
+  const stakingAssetAccountAddress = useMemo(
+    () => (stakingAssetAccountId ? fromAccountId(stakingAssetAccountId).account : undefined),
+    [stakingAssetAccountId],
+  )
 
   const { data: cooldownPeriod } = useCooldownPeriodQuery()
 
@@ -408,6 +419,16 @@ export const StakeInput: React.FC<StakeInputProps & StakeRouteProps> = ({
   }, [isChainSupportedByWallet, translate])
 
   if (!selectedAsset) return null
+
+  if (!stakingAssetAccountAddress)
+    return (
+      <SlideTransition>
+        <Stack>{headerComponent}</Stack>
+        <CardBody py={12}>
+          <ChainNotSupported chainId={stakingAsset?.chainId} />
+        </CardBody>
+      </SlideTransition>
+    )
 
   return (
     <SlideTransition>


### PR DESCRIPTION
## Description

As a follow-up (and inspired by) to https://github.com/shapeshift/web/pull/7600, this PR ensures we show the `<ChainNotSupported />` component when connected to a wallet that does not support arbitrum.

This PR:

<img width="321" alt="Screenshot 2024-08-26 at 9 21 18 AM" src="https://github.com/user-attachments/assets/3e2b6d0b-1b57-480a-ab57-3658bb78a432">


`develop`:

When attempting to stake FOX on Arbitrum without an Arbitrum account connected:

<img width="316" alt="Screenshot 2024-08-26 at 9 05 11 AM" src="https://github.com/user-attachments/assets/8000adcc-0d27-4b60-8a65-f64326dc8263">

When attempting to stake FOX on Ethereum without an Arbitrum account connected (the bridge can never complete because there is no account to sign or pay gas on Arbitrum):

<img width="309" alt="Screenshot 2024-08-26 at 9 23 42 AM" src="https://github.com/user-attachments/assets/5162dd15-3ccb-4f70-80ae-412f43ac66db">

## Issue (if applicable)

Follow-up of https://github.com/shapeshift/web/pull/7600

## Risk

Small

> What protocols, transaction types, wallets or contract interactions might be affected by this PR?

rFOX staking.

## Testing

- Ensure that rFOX staking works as it does in production when an Arbitrum account _is_ connected.
- Ensure that the `<ChainNotSupported />` component shows on the staking tab when an Arbitrum account is _not_ connected.

### Engineering

☝️

### Operations

- [ ] :checkered_flag: My feature is behind a flag and doesn't require operations testing (yet)

☝️

## Screenshots (if applicable)

See above.