### PR TITLE
fix: empty related assets

### DIFF
--- a/src/components/RelatedAssets/RelatedAssets.tsx
+++ b/src/components/RelatedAssets/RelatedAssets.tsx
@@ -20,6 +20,10 @@ export const RelatedAssets: React.FC<RelatedAssetsProps> = ({ assetId }) => {
     selectRelatedAssetIds(state, relatedAssetIdsFilter),
   )
   const assets = useAppSelector(selectAssets)
+  const knownRelatedAssetIds = useMemo(() => {
+    return relatedAssetIds.filter(id => assets[id])
+  }, [assets, relatedAssetIds])
+
   const history = useHistory()
 
   const columns: Column<AssetId>[] = useMemo(
@@ -48,7 +52,7 @@ export const RelatedAssets: React.FC<RelatedAssetsProps> = ({ assetId }) => {
     [history],
   )
 
-  if (!relatedAssetIds.length) return null
+  if (!knownRelatedAssetIds.length) return null
 
   return (
     <Card variant='dashboard'>
@@ -60,7 +64,7 @@ export const RelatedAssets: React.FC<RelatedAssetsProps> = ({ assetId }) => {
       <CardBody px={2} pt={0}>
         <ReactTable
           columns={columns}
-          data={relatedAssetIds}
+          data={knownRelatedAssetIds}
           onRowClick={handleRowClick}
           variant='clickable'
         />

--- a/src/components/RelatedAssets/RelatedAssets.tsx
+++ b/src/components/RelatedAssets/RelatedAssets.tsx
@@ -20,7 +20,6 @@ export const RelatedAssets: React.FC<RelatedAssetsProps> = ({ assetId }) => {
     selectRelatedAssetIds(state, relatedAssetIdsFilter),
   )
   const assets = useAppSelector(selectAssets)
-
   const history = useHistory()
 
   const columns: Column<AssetId>[] = useMemo(

--- a/src/components/RelatedAssets/RelatedAssets.tsx
+++ b/src/components/RelatedAssets/RelatedAssets.tsx
@@ -20,9 +20,6 @@ export const RelatedAssets: React.FC<RelatedAssetsProps> = ({ assetId }) => {
     selectRelatedAssetIds(state, relatedAssetIdsFilter),
   )
   const assets = useAppSelector(selectAssets)
-  const knownRelatedAssetIds = useMemo(() => {
-    return relatedAssetIds.filter(id => assets[id])
-  }, [assets, relatedAssetIds])
 
   const history = useHistory()
 
@@ -52,7 +49,7 @@ export const RelatedAssets: React.FC<RelatedAssetsProps> = ({ assetId }) => {
     [history],
   )
 
-  if (!knownRelatedAssetIds.length) return null
+  if (!relatedAssetIds.length) return null
 
   return (
     <Card variant='dashboard'>
@@ -64,7 +61,7 @@ export const RelatedAssets: React.FC<RelatedAssetsProps> = ({ assetId }) => {
       <CardBody px={2} pt={0}>
         <ReactTable
           columns={columns}
-          data={knownRelatedAssetIds}
+          data={relatedAssetIds}
           onRowClick={handleRowClick}
           variant='clickable'
         />

--- a/src/state/slices/related-assets-selectors.ts
+++ b/src/state/slices/related-assets-selectors.ts
@@ -16,7 +16,7 @@ import {
  * Selects all related assetIds, inclusive of the asset being queried.
  *
  * Excludes assetIds on chains that are not connected on the wallet.
- * Excludes assetIds that are not in the assets store.
+ * Excludes assetIds that are not in the assets slice.
  */
 export const selectRelatedAssetIdsInclusive = createCachedSelector(
   (state: ReduxState) => state.assets.relatedAssetIndex,


### PR DESCRIPTION
## Description

Filters out related assets that we don't have in our asset store, fixing the render of `null` table rows.

## Issue (if applicable)

Closes https://github.com/shapeshift/web/issues/7432

## Risk

> High Risk PRs Require 2 approvals

Small

> What protocols, transaction types, wallets or contract interactions might be affected by this PR?

None

## Testing

Ensure that he related asset section no longer has empty rows (Ethereum is a good asset to use for testing).

### Engineering

☝️

### Operations

- [ ] :checkered_flag: My feature is behind a flag and doesn't require operations testing (yet)

☝️

## Screenshots (if applicable)

N/A