### PR TITLE
chore: use satisfies over assertUnreachable

### DIFF
--- a/packages/swapper/src/constants.ts
+++ b/packages/swapper/src/constants.ts
@@ -1,5 +1,3 @@
-import { assertUnreachable } from '@shapeshiftoss/utils'
-
 import { arbitrumBridgeSwapper } from './swappers/ArbitrumBridgeSwapper/ArbitrumBridgeSwapper'
 import { arbitrumBridgeApi } from './swappers/ArbitrumBridgeSwapper/endpoints'
 import { ARBITRUM_BRIDGE_SUPPORTED_CHAIN_IDS } from './swappers/ArbitrumBridgeSwapper/utils/constants'
@@ -116,6 +114,6 @@ export const getDefaultSlippageDecimalPercentageForSwapper = (
     case SwapperName.ArbitrumBridge:
       return DEFAULT_ARBITRUM_BRIDGE_SLIPPAGE_DECIMAL_PERCENTAGE
     default:
-      assertUnreachable(swapperName)
+      return swapperName satisfies never
   }
 }

--- a/packages/swapper/src/swappers/ArbitrumBridgeSwapper/utils/fetchArbitrumBridgeSwap.ts
+++ b/packages/swapper/src/swappers/ArbitrumBridgeSwapper/utils/fetchArbitrumBridgeSwap.ts
@@ -7,7 +7,7 @@ import type { ChainId } from '@shapeshiftoss/caip'
 import { ethAssetId, ethChainId, fromAssetId } from '@shapeshiftoss/caip'
 import type { EvmChainAdapter, EvmChainId } from '@shapeshiftoss/chain-adapters'
 import { type Asset, KnownChainIds } from '@shapeshiftoss/types'
-import { assertUnreachable, bn } from '@shapeshiftoss/utils'
+import { bn } from '@shapeshiftoss/utils'
 import { getFees } from '@shapeshiftoss/utils/dist/evm'
 import type { ethers as ethersV5 } from 'ethers5'
 import { BigNumber } from 'ethers5'
@@ -189,6 +189,6 @@ export const fetchArbitrumBridgeSwap = async ({
       return { request, networkFeeCryptoBaseUnit, allowanceContract: '0x0' }
     }
     default:
-      assertUnreachable(bridgeType)
+      return bridgeType satisfies never
   }
 }

--- a/packages/swapper/src/swappers/ThorchainSwapper/endpoints.ts
+++ b/packages/swapper/src/swappers/ThorchainSwapper/endpoints.ts
@@ -4,7 +4,7 @@ import { cosmosAssetId, fromAssetId, fromChainId, thorchainAssetId } from '@shap
 import { cosmossdk as cosmossdkChainAdapter } from '@shapeshiftoss/chain-adapters'
 import type { BTCSignTx } from '@shapeshiftoss/hdwallet-core'
 import { cosmossdk, TxStatus } from '@shapeshiftoss/unchained-client'
-import { assertUnreachable, BigNumber, bn, bnOrZero } from '@shapeshiftoss/utils'
+import { BigNumber, bn, bnOrZero } from '@shapeshiftoss/utils'
 import { getFees } from '@shapeshiftoss/utils/dist/evm'
 import { type Result } from '@sniptt/monads/build'
 import assert from 'assert'
@@ -198,7 +198,7 @@ export const thorchainApi: SwapperApi = {
       case TradeType.LongTailToLongTail:
         throw Error(`Unsupported trade type: ${TradeType}`)
       default:
-        assertUnreachable(tradeType)
+        return tradeType satisfies never
     }
   },
 

--- a/packages/swapper/src/swappers/ThorchainSwapper/getThorTradeQuote/getTradeQuote.ts
+++ b/packages/swapper/src/swappers/ThorchainSwapper/getThorTradeQuote/getTradeQuote.ts
@@ -1,4 +1,4 @@
-import { assertUnreachable, bn } from '@shapeshiftoss/utils'
+import { bn } from '@shapeshiftoss/utils'
 import type { Result } from '@sniptt/monads'
 import { Err } from '@sniptt/monads'
 
@@ -127,6 +127,6 @@ export const getThorTradeQuote = async (
     case TradeType.LongTailToLongTail:
       return Err(makeSwapErrorRight({ message: 'Not implemented yet' }))
     default:
-      assertUnreachable(tradeType)
+      return tradeType satisfies never
   }
 }

--- a/packages/swapper/src/swappers/ThorchainSwapper/utils/checkOutputTxConfirmations.ts
+++ b/packages/swapper/src/swappers/ThorchainSwapper/utils/checkOutputTxConfirmations.ts
@@ -1,5 +1,4 @@
 import type { StandardTx } from '@shapeshiftoss/unchained-client'
-import { assertUnreachable } from '@shapeshiftoss/utils'
 import axios from 'axios'
 
 import type { SwapperConfig } from '../../../types'
@@ -45,7 +44,7 @@ export const checkOutboundTxConfirmations = async (
       case ThorchainChain.BSC:
         throw Error(`${latestOutTx.chain} not supported`)
       default:
-        assertUnreachable(latestOutTx.chain)
+        return latestOutTx.chain satisfies never
     }
   })()
 

--- a/packages/swapper/src/swappers/ThorchainSwapper/utils/getL1quote.ts
+++ b/packages/swapper/src/swappers/ThorchainSwapper/utils/getL1quote.ts
@@ -2,7 +2,6 @@ import type { AssetId } from '@shapeshiftoss/caip'
 import { CHAIN_NAMESPACE, fromAssetId } from '@shapeshiftoss/caip'
 import { bn, bnOrZero } from '@shapeshiftoss/chain-adapters'
 import {
-  assertUnreachable,
   baseUnitToPrecision,
   convertDecimalPercentageToBasisPoints,
   convertPrecision,
@@ -503,6 +502,6 @@ export const getL1quote = async (
     }
 
     default:
-      assertUnreachable(chainNamespace)
+      return chainNamespace satisfies never
   }
 }

--- a/packages/swapper/src/swappers/ThorchainSwapper/utils/getLatestThorTxStatusMessage.ts
+++ b/packages/swapper/src/swappers/ThorchainSwapper/utils/getLatestThorTxStatusMessage.ts
@@ -1,5 +1,4 @@
 import { TxStatus } from '@shapeshiftoss/unchained-client'
-import { assertUnreachable } from '@shapeshiftoss/utils'
 import prettyMilliseconds from 'pretty-ms'
 
 import type { ThorNodeStatusResponseSuccess } from '../types'
@@ -104,7 +103,7 @@ export const getLatestThorTxStatusMessage = (
         }
       }
       default:
-        assertUnreachable(key)
+        return key satisfies never
     }
   }
 

--- a/packages/swapper/src/swappers/ZrxSwapper/utils/helpers/helpers.ts
+++ b/packages/swapper/src/swappers/ZrxSwapper/utils/helpers/helpers.ts
@@ -2,7 +2,6 @@ import type { ChainId } from '@shapeshiftoss/caip'
 import { fromAssetId } from '@shapeshiftoss/caip'
 import type { Asset } from '@shapeshiftoss/types'
 import { KnownChainIds } from '@shapeshiftoss/types'
-import { assertUnreachable } from '@shapeshiftoss/utils'
 
 import type { ZrxSupportedChainId } from '../../types'
 import { zrxSupportedChainIds } from '../../types'
@@ -24,7 +23,7 @@ export const baseUrlFromChainId = (chainId: ZrxSupportedChainId): string => {
     case KnownChainIds.BaseMainnet:
       return 'https://0x.shapeshift.com/base/'
     default:
-      assertUnreachable(chainId)
+      return chainId satisfies never
   }
 }
 

--- a/packages/utils/src/assertUnreachable.ts
+++ b/packages/utils/src/assertUnreachable.ts
@@ -1,3 +1,0 @@
-export const assertUnreachable = (x: never): never => {
-  throw Error(`unhandled case: ${x}`)
-}

--- a/packages/utils/src/chainIdToFeeAssetId.ts
+++ b/packages/utils/src/chainIdToFeeAssetId.ts
@@ -18,8 +18,6 @@ import {
 } from '@shapeshiftoss/caip'
 import { KnownChainIds } from '@shapeshiftoss/types'
 
-import { assertUnreachable } from './assertUnreachable'
-
 export const chainIdToFeeAssetId = (_chainId: ChainId): AssetId => {
   const chainId = _chainId as KnownChainIds
   switch (chainId) {
@@ -54,8 +52,6 @@ export const chainIdToFeeAssetId = (_chainId: ChainId): AssetId => {
     case KnownChainIds.ThorchainMainnet:
       return thorchainAssetId
     default:
-      assertUnreachable(chainId)
+      return chainId satisfies never
   }
-
-  throw Error(`Unsupported chainId: ${chainId}`)
 }

--- a/packages/utils/src/index.ts
+++ b/packages/utils/src/index.ts
@@ -1,7 +1,6 @@
 import { isNull, isUndefined } from 'lodash'
 
 export * from './makeAsset/makeAsset'
-export * from './assertUnreachable'
 export * from './sha256'
 export * from './chainIdToFeeAsset'
 export * from './chainIdToFeeAssetId'

--- a/scripts/generateTradableThorAssetMap/utils.ts
+++ b/scripts/generateTradableThorAssetMap/utils.ts
@@ -56,10 +56,6 @@ const ChainToChainIdMap: Map<ThorchainChain, ChainId> = new Map([
   [ThorchainChain.BSC, bscChainId],
 ])
 
-function assertUnreachable(x: never): never {
-  throw Error(`unhandled case: ${x}`)
-}
-
 export const getFeeAssetFromThorchainChain = (chain: ThorchainChain): AssetId | undefined => {
   switch (chain) {
     case ThorchainChain.BTC:
@@ -83,7 +79,7 @@ export const getFeeAssetFromThorchainChain = (chain: ThorchainChain): AssetId | 
     case ThorchainChain.BSC:
       return bscAssetId
     default:
-      assertUnreachable(chain)
+      return chain satisfies never
   }
 }
 

--- a/src/components/ManageAccountsDrawer/ManageAccountsDrawer.tsx
+++ b/src/components/ManageAccountsDrawer/ManageAccountsDrawer.tsx
@@ -2,7 +2,6 @@ import type { ChainId } from '@shapeshiftoss/caip'
 import { useCallback, useEffect, useMemo, useState } from 'react'
 import { useLedgerOpenApp } from 'hooks/useLedgerOpenApp/useLedgerOpenApp'
 import { useWallet } from 'hooks/useWallet/useWallet'
-import { assertUnreachable } from 'lib/utils'
 
 import { DrawerWrapper } from './components/DrawerWrapper'
 import { ImportAccounts } from './components/ImportAccounts'
@@ -42,7 +41,7 @@ export const ManageAccountsDrawer = ({
         handleClose()
         break
       default:
-        assertUnreachable(step)
+        return step satisfies never
     }
   }, [wallet, step, handleClose])
 
@@ -86,7 +85,7 @@ export const ManageAccountsDrawer = ({
         if (!selectedChainId) return null
         return <ImportAccounts chainId={selectedChainId} onClose={handleClose} />
       default:
-        assertUnreachable(step)
+        return step satisfies never
     }
   }, [step, handleSelectChainId, handleClose, selectedChainId])
 

--- a/src/components/MultiHopTrade/components/MultiHopTradeConfirm/components/Hop.tsx
+++ b/src/components/MultiHopTrade/components/MultiHopTradeConfirm/components/Hop.tsx
@@ -27,7 +27,6 @@ import { SlippageIcon } from 'components/Icons/Slippage'
 import { RawText } from 'components/Text'
 import { useLocaleFormatter } from 'hooks/useLocaleFormatter/useLocaleFormatter'
 import { fromBaseUnit } from 'lib/math'
-import { assertUnreachable } from 'lib/utils'
 import {
   selectHopExecutionMetadata,
   selectHopNetworkFeeUserCurrencyPrecision,
@@ -154,7 +153,7 @@ export const Hop = ({
       case HopExecutionState.Complete:
         return Infinity
       default:
-        assertUnreachable(hopExecutionState)
+        return hopExecutionState satisfies never
     }
   }, [hopExecutionState, hopIndex])
 

--- a/src/components/MultiHopTrade/components/MultiHopTradeConfirm/components/StatusIcon.tsx
+++ b/src/components/MultiHopTrade/components/MultiHopTradeConfirm/components/StatusIcon.tsx
@@ -4,7 +4,6 @@ import { useMemo } from 'react'
 import { FaThumbsUp } from 'react-icons/fa'
 import { FaRotateRight } from 'react-icons/fa6'
 import { CircularProgress } from 'components/CircularProgress/CircularProgress'
-import { assertUnreachable } from 'lib/utils'
 import { HopExecutionState, TransactionExecutionState } from 'state/slices/tradeQuoteSlice/types'
 
 export const StatusIcon = ({
@@ -37,7 +36,7 @@ export const StatusIcon = ({
     case TransactionExecutionState.AwaitingConfirmation:
       return <Circle size={8}>{defaultIcon}</Circle>
     default:
-      assertUnreachable(txStatus)
+      return txStatus satisfies never
   }
 }
 
@@ -71,7 +70,7 @@ export const ApprovalStatusIcon = ({
       case HopExecutionState.Complete:
         return TransactionExecutionState.Complete
       default:
-        assertUnreachable(hopExecutionState)
+        return hopExecutionState satisfies never
     }
   }, [hopExecutionState, approvalTxState, isAllowanceResetStep])
   return <StatusIcon txStatus={txStatus} defaultIcon={defaultIcon} />

--- a/src/components/MultiHopTrade/components/MultiHopTradeConfirm/hooks/useTradeExecution.tsx
+++ b/src/components/MultiHopTrade/components/MultiHopTradeConfirm/hooks/useTradeExecution.tsx
@@ -19,7 +19,6 @@ import { useErrorHandler } from 'hooks/useErrorToast/useErrorToast'
 import { useWallet } from 'hooks/useWallet/useWallet'
 import { MixPanelEvent } from 'lib/mixpanel/types'
 import { TradeExecution } from 'lib/tradeExecution'
-import { assertUnreachable } from 'lib/utils'
 import { assertGetCosmosSdkChainAdapter } from 'lib/utils/cosmosSdk'
 import { assertGetEvmChainAdapter, signAndBroadcast } from 'lib/utils/evm'
 import { assertGetUtxoChainAdapter } from 'lib/utils/utxo'
@@ -353,7 +352,7 @@ export const useTradeExecution = (
           return
         }
         default:
-          assertUnreachable(stepSellAssetChainNamespace)
+          return stepSellAssetChainNamespace satisfies never
       }
     })
   }, [

--- a/src/components/MultiHopTrade/components/MultiHopTradeConfirm/utils/getChainShortName.ts
+++ b/src/components/MultiHopTrade/components/MultiHopTradeConfirm/utils/getChainShortName.ts
@@ -1,5 +1,4 @@
 import { KnownChainIds } from '@shapeshiftoss/types'
-import { assertUnreachable } from 'lib/utils'
 
 export const getChainShortName = (chainId: KnownChainIds) => {
   switch (chainId) {
@@ -34,7 +33,7 @@ export const getChainShortName = (chainId: KnownChainIds) => {
     case KnownChainIds.LitecoinMainnet:
       return 'LTC'
     default: {
-      assertUnreachable(chainId)
+      return chainId satisfies never
     }
   }
 }

--- a/src/components/MultiHopTrade/components/TradeInput/components/Claim/hooks/useArbitrumClaimsByStatus.tsx
+++ b/src/components/MultiHopTrade/components/TradeInput/components/Claim/hooks/useArbitrumClaimsByStatus.tsx
@@ -8,7 +8,6 @@ import { useMemo } from 'react'
 import { useTranslate } from 'react-polyglot'
 import { ClaimStatus } from 'components/ClaimRow/types'
 import { getEthersV5Provider } from 'lib/ethersProviderSingleton'
-import { assertUnreachable } from 'lib/utils'
 import { selectAssetById } from 'state/slices/selectors'
 import type { Tx } from 'state/slices/txHistorySlice/txHistorySlice'
 import { useAppSelector } from 'state/store'
@@ -93,7 +92,7 @@ export const useArbitrumClaimsByStatus = (txs: Tx[]) => {
                 case ChildToParentMessageStatus.UNCONFIRMED:
                   return ClaimStatus.Pending
                 default:
-                  assertUnreachable(status)
+                  return status satisfies never
               }
             })()
 

--- a/src/components/MultiHopTrade/components/TradeInput/components/SwapperIcon/SwapperIcon.tsx
+++ b/src/components/MultiHopTrade/components/TradeInput/components/SwapperIcon/SwapperIcon.tsx
@@ -2,7 +2,6 @@ import type { AvatarProps } from '@chakra-ui/react'
 import { SwapperName } from '@shapeshiftoss/swapper'
 import { useMemo } from 'react'
 import { LazyLoadAvatar } from 'components/LazyLoadAvatar'
-import { assertUnreachable } from 'lib/utils'
 
 import ZrxIcon from './0x-icon.png'
 import OneInchIcon from './1inch-icon.png'
@@ -38,7 +37,7 @@ export const SwapperIcon = ({
       case SwapperName.Test:
         return ''
       default:
-        assertUnreachable(swapperName)
+        return swapperName satisfies never
     }
   }, [swapperName])
 

--- a/src/components/MultiHopTrade/components/TradeInput/components/TradeInputHeader.tsx
+++ b/src/components/MultiHopTrade/components/TradeInput/components/TradeInputHeader.tsx
@@ -1,6 +1,5 @@
 import { CardHeader, Flex, Heading, useMediaQuery } from '@chakra-ui/react'
 import { DEFAULT_GET_TRADE_QUOTE_POLLING_INTERVAL, swappers } from '@shapeshiftoss/swapper'
-import { assertUnreachable } from '@shapeshiftoss/utils'
 import { useCallback, useMemo, useState } from 'react'
 import { useTranslate } from 'react-polyglot'
 import { useFeatureFlag } from 'hooks/useFeatureFlag/useFeatureFlag'
@@ -83,7 +82,7 @@ export const TradeInputHeader = ({
         case TradeInputTab.Claim:
           return null
         default:
-          assertUnreachable(selectedTab)
+          return selectedTab satisfies never
       }
     })()
   }, [selectedTab, isLoading, isCompact])

--- a/src/components/MultiHopTrade/components/TradeInput/getQuoteErrorTranslation.ts
+++ b/src/components/MultiHopTrade/components/TradeInput/getQuoteErrorTranslation.ts
@@ -1,6 +1,5 @@
 import { TradeQuoteError as SwapperTradeQuoteError } from '@shapeshiftoss/swapper'
 import type { InterpolationOptions } from 'node-polyglot'
-import { assertUnreachable } from 'lib/utils'
 import type { ErrorWithMeta } from 'state/apis/swapper/types'
 import { type TradeQuoteError, TradeQuoteValidationError } from 'state/apis/swapper/types'
 
@@ -52,7 +51,7 @@ export const getQuoteErrorTranslation = (
       case TradeQuoteValidationError.QuoteSellAmountInvalid:
         return 'trade.errors.quoteError'
       default:
-        assertUnreachable(error)
+        return error satisfies never
     }
   })()
 

--- a/src/components/MultiHopTrade/components/TradeInput/getQuoteRequestErrorTranslation.ts
+++ b/src/components/MultiHopTrade/components/TradeInput/getQuoteRequestErrorTranslation.ts
@@ -1,5 +1,4 @@
 import type { InterpolationOptions } from 'node-polyglot'
-import { assertUnreachable } from 'lib/utils'
 import type { ErrorWithMeta } from 'state/apis/swapper/types'
 import { TradeQuoteRequestError } from 'state/apis/swapper/types'
 
@@ -22,7 +21,7 @@ export const getQuoteRequestErrorTranslation = (
       case TradeQuoteRequestError.NoReceiveAddress:
         return 'trade.errors.noReceiveAddress'
       default:
-        assertUnreachable(error)
+        return error satisfies never
     }
   })()
 

--- a/src/components/MultiHopTrade/hooks/useGetTradeQuotes/getTradeQuoteInput.ts
+++ b/src/components/MultiHopTrade/hooks/useGetTradeQuotes/getTradeQuoteInput.ts
@@ -6,7 +6,6 @@ import type { GetTradeQuoteInput } from '@shapeshiftoss/swapper'
 import type { Asset, UtxoAccountType } from '@shapeshiftoss/types'
 import type { TradeQuoteInputCommonArgs } from 'components/MultiHopTrade/types'
 import { toBaseUnit } from 'lib/math'
-import { assertUnreachable } from 'lib/utils'
 import { assertGetCosmosSdkChainAdapter } from 'lib/utils/cosmosSdk'
 import { assertGetEvmChainAdapter } from 'lib/utils/evm'
 import { assertGetUtxoChainAdapter } from 'lib/utils/utxo'
@@ -120,6 +119,6 @@ export const getTradeQuoteInput = async ({
       }
     }
     default:
-      assertUnreachable(chainNamespace)
+      return chainNamespace satisfies never
   }
 }

--- a/src/hooks/queries/useApprovalFees.ts
+++ b/src/hooks/queries/useApprovalFees.ts
@@ -2,7 +2,6 @@ import type { AssetId } from '@shapeshiftoss/caip'
 import { fromAssetId } from '@shapeshiftoss/caip'
 import { MAX_ALLOWANCE } from '@shapeshiftoss/swapper/src/swappers/utils/constants'
 import { useMemo } from 'react'
-import { assertUnreachable } from 'lib/utils'
 import { getApproveContractData } from 'lib/utils/evm'
 
 import { useEvmFees } from './useEvmFees'
@@ -87,6 +86,6 @@ export const getApprovalAmountCryptoBaseUnit = (
     case AllowanceType.Reset:
       return '0'
     default:
-      assertUnreachable(allowanceType)
+      return allowanceType satisfies never
   }
 }

--- a/src/hooks/useLedgerOpenApp/useLedgerOpenApp.tsx
+++ b/src/hooks/useLedgerOpenApp/useLedgerOpenApp.tsx
@@ -2,7 +2,6 @@ import type { ChainId } from '@shapeshiftoss/caip'
 import type { slip44Table } from '@shapeshiftoss/hdwallet-core'
 import { isLedger } from '@shapeshiftoss/hdwallet-ledger'
 import { KnownChainIds } from '@shapeshiftoss/types'
-import { assertUnreachable } from '@shapeshiftoss/utils'
 import { useCallback } from 'react'
 import { useModal } from 'hooks/useModal/useModal'
 import { useWallet } from 'hooks/useWallet/useWallet'
@@ -46,7 +45,7 @@ export const getSlip44KeyFromChainId = (chainId: ChainId): Slip44Key | undefined
     case KnownChainIds.CosmosMainnet:
       return 'Atom'
     default:
-      assertUnreachable(knownChainId)
+      return knownChainId satisfies never
   }
 }
 

--- a/src/lib/ethersProviderSingleton.ts
+++ b/src/lib/ethersProviderSingleton.ts
@@ -5,8 +5,6 @@ import { getConfig } from 'config'
 import { JsonRpcProvider } from 'ethers'
 import { ethers as ethersV5 } from 'ethers5'
 
-import { assertUnreachable } from './utils'
-
 export const rpcUrlByChainId = (chainId: EvmChainId): string => {
   switch (chainId) {
     case KnownChainIds.AvalancheMainnet:
@@ -28,7 +26,7 @@ export const rpcUrlByChainId = (chainId: EvmChainId): string => {
     case KnownChainIds.BaseMainnet:
       return getConfig().REACT_APP_BASE_NODE_URL
     default:
-      assertUnreachable(chainId)
+      return chainId satisfies never
   }
 }
 

--- a/src/lib/market-service/coincap/coincap.ts
+++ b/src/lib/market-service/coincap/coincap.ts
@@ -12,7 +12,7 @@ import Axios from 'axios'
 import { setupCache } from 'axios-cache-interceptor'
 import omit from 'lodash/omit'
 import { bn, bnOrZero } from 'lib/bignumber/bignumber'
-import { assertUnreachable, getTimeFrameBounds } from 'lib/utils'
+import { getTimeFrameBounds } from 'lib/utils'
 
 import type { MarketService } from '../api'
 import { DEFAULT_CACHE_TTL_MS } from '../config'
@@ -116,7 +116,7 @@ export class CoinCapMarketService implements MarketService {
         case HistoryTimeframe.ALL:
           return 'd1'
         default:
-          assertUnreachable(timeframe)
+          return timeframe satisfies never
       }
     })()
 

--- a/src/lib/market-service/portals/portals.ts
+++ b/src/lib/market-service/portals/portals.ts
@@ -17,7 +17,7 @@ import dayjs from 'dayjs'
 import qs from 'qs'
 import { zeroAddress } from 'viem'
 import { bn, bnOrZero } from 'lib/bignumber/bignumber'
-import { assertUnreachable, getTimeFrameBounds, isToken } from 'lib/utils'
+import { getTimeFrameBounds, isToken } from 'lib/utils'
 
 import generatedAssetData from '../../asset-service/service/generatedAssetData.json'
 import type { MarketService } from '../api'
@@ -190,7 +190,7 @@ export class PortalsMarketService implements MarketService {
         case HistoryTimeframe.ALL:
           return '1d'
         default:
-          assertUnreachable(timeframe)
+          return timeframe satisfies never
       }
     })()
 

--- a/src/lib/market-service/zerion/zerion.ts
+++ b/src/lib/market-service/zerion/zerion.ts
@@ -21,7 +21,7 @@ import { setupCache } from 'axios-cache-interceptor'
 import { getConfig } from 'config'
 import qs from 'qs'
 import { bnOrZero } from 'lib/bignumber/bignumber'
-import { assertUnreachable, isToken } from 'lib/utils'
+import { isToken } from 'lib/utils'
 
 import type { MarketService } from '../api'
 import { DEFAULT_CACHE_TTL_MS } from '../config'
@@ -84,7 +84,7 @@ export class ZerionMarketService implements MarketService {
         case HistoryTimeframe.ALL:
           return 'max'
         default:
-          assertUnreachable(timeframe)
+          return timeframe satisfies never
       }
     })()
 

--- a/src/lib/utils/index.ts
+++ b/src/lib/utils/index.ts
@@ -174,10 +174,6 @@ export const isResolvedErr = <U, V, T extends Result<U, V>>(
 export const setTimeoutAsync = (waitMs: number) =>
   new Promise(resolve => setTimeout(resolve, waitMs))
 
-export function assertUnreachable(x: never): never {
-  throw Error(`unhandled case: ${x}`)
-}
-
 export function assertIsDefined<T>(x: T | undefined | null): asserts x is T {
   if (x === undefined || x === null) throw Error(`unexpected undefined or null`)
 }
@@ -277,7 +273,7 @@ export const getTimeFrameBounds = (timeframe: HistoryTimeframe): { start: Dayjs;
     case HistoryTimeframe.ALL:
       return { end, start: end.subtract(20, 'years') }
     default:
-      assertUnreachable(timeframe)
+      return timeframe satisfies never
   }
 }
 

--- a/src/lib/utils/thorchain/hooks/useSendThorTx.tsx
+++ b/src/lib/utils/thorchain/hooks/useSendThorTx.tsx
@@ -19,7 +19,7 @@ import { useWallet } from 'hooks/useWallet/useWallet'
 import { bn, bnOrZero } from 'lib/bignumber/bignumber'
 import { getTxLink } from 'lib/getTxLink'
 import { fromBaseUnit, toBaseUnit } from 'lib/math'
-import { assertUnreachable, isToken } from 'lib/utils'
+import { isToken } from 'lib/utils'
 import { assertGetThorchainChainAdapter } from 'lib/utils/cosmosSdk'
 import {
   assertGetEvmChainAdapter,
@@ -127,7 +127,7 @@ export const useSendThorTx = ({
       case 'Send':
         return inboundAddressData?.address
       default:
-        assertUnreachable(transactionType)
+        return transactionType satisfies never
     }
   }, [inboundAddressData, transactionType])
 
@@ -227,7 +227,7 @@ export const useSendThorTx = ({
         }
       }
       default:
-        assertUnreachable(transactionType)
+        return transactionType satisfies never
     }
   }, [
     accountId,
@@ -378,7 +378,7 @@ export const useSendThorTx = ({
           }
         }
         default:
-          assertUnreachable(transactionType)
+          return transactionType satisfies never
       }
     })()
 

--- a/src/pages/ThorChainLP/components/AddLiquidity/AddLiquidityInput.tsx
+++ b/src/pages/ThorChainLP/components/AddLiquidity/AddLiquidityInput.tsx
@@ -61,13 +61,7 @@ import type { ParameterModel } from 'lib/fees/parameters/types'
 import { fromBaseUnit, toBaseUnit } from 'lib/math'
 import { getMixPanel } from 'lib/mixpanel/mixPanelSingleton'
 import { MixPanelEvent } from 'lib/mixpanel/types'
-import {
-  assertUnreachable,
-  chainIdToChainDisplayName,
-  isNonEmptyString,
-  isSome,
-  isToken,
-} from 'lib/utils'
+import { chainIdToChainDisplayName, isNonEmptyString, isSome, isToken } from 'lib/utils'
 import { getSupportedEvmChainIds } from 'lib/utils/evm'
 import { THOR_PRECISION } from 'lib/utils/thorchain/constants'
 import { useSendThorTx } from 'lib/utils/thorchain/hooks/useSendThorTx'
@@ -863,7 +857,7 @@ export const AddLiquidityInput: React.FC<AddLiquidityInputProps> = ({
         return poolAssetGasFeeFiatUserCurrency.plus(runeGasFeeFiatUserCurrency)
       }
       default:
-        assertUnreachable(opportunityType)
+        return opportunityType satisfies never
     }
   }, [
     opportunityType,
@@ -1092,7 +1086,7 @@ export const AddLiquidityInput: React.FC<AddLiquidityInputProps> = ({
         case 'sym':
           return [poolAsset, runeAsset]
         default:
-          assertUnreachable(opportunityType)
+          return opportunityType satisfies never
       }
     })()
 

--- a/src/pages/ThorChainLP/components/LpType.tsx
+++ b/src/pages/ThorChainLP/components/LpType.tsx
@@ -8,7 +8,6 @@ import { useTranslate } from 'react-polyglot'
 import { Amount } from 'components/Amount/Amount'
 import { AssetSymbol } from 'components/AssetSymbol'
 import { RawText } from 'components/Text'
-import { assertUnreachable } from 'lib/utils'
 import { AsymSide } from 'lib/utils/thorchain/lp/types'
 import { selectAssetById } from 'state/slices/selectors'
 import { useAppSelector } from 'state/store'
@@ -149,7 +148,7 @@ export const LpType = ({
         case 'sym':
           return [assetId, thorchainAssetId]
         default:
-          assertUnreachable(value)
+          return value satisfies never
       }
     },
     [assetId],

--- a/src/pages/ThorChainLP/components/RemoveLiquidity/RemoveLiquidityInput.tsx
+++ b/src/pages/ThorChainLP/components/RemoveLiquidity/RemoveLiquidityInput.tsx
@@ -49,7 +49,6 @@ import { bn, bnOrZero, convertPrecision } from 'lib/bignumber/bignumber'
 import { fromBaseUnit, toBaseUnit } from 'lib/math'
 import { getMixPanel } from 'lib/mixpanel/mixPanelSingleton'
 import { MixPanelEvent } from 'lib/mixpanel/types'
-import { assertUnreachable } from 'lib/utils'
 import { fromThorBaseUnit } from 'lib/utils/thorchain'
 import { THOR_PRECISION } from 'lib/utils/thorchain/constants'
 import { useSendThorTx } from 'lib/utils/thorchain/hooks/useSendThorTx'
@@ -212,7 +211,7 @@ export const RemoveLiquidityInput: React.FC<RemoveLiquidityInputProps> = ({
       case AsymSide.Rune:
         return '0'
       default:
-        assertUnreachable(withdrawType)
+        return withdrawType satisfies never
     }
   }, [withdrawType, virtualAssetWithdrawAmountCryptoPrecision])
 
@@ -228,7 +227,7 @@ export const RemoveLiquidityInput: React.FC<RemoveLiquidityInputProps> = ({
       case AsymSide.Asset:
         return '0'
       default:
-        assertUnreachable(withdrawType)
+        return withdrawType satisfies never
     }
   }, [withdrawType, virtualRuneWithdrawAmountCryptoPrecision])
 
@@ -244,7 +243,7 @@ export const RemoveLiquidityInput: React.FC<RemoveLiquidityInputProps> = ({
       case AsymSide.Rune:
         return '0'
       default:
-        assertUnreachable(withdrawType)
+        return withdrawType satisfies never
     }
   }, [withdrawType, virtualAssetWithdrawAmountFiatUserCurrency])
 
@@ -260,7 +259,7 @@ export const RemoveLiquidityInput: React.FC<RemoveLiquidityInputProps> = ({
       case AsymSide.Asset:
         return '0'
       default:
-        assertUnreachable(withdrawType)
+        return withdrawType satisfies never
     }
   }, [withdrawType, virtualRuneWithdrawAmountFiatUserCurrency])
 
@@ -292,7 +291,7 @@ export const RemoveLiquidityInput: React.FC<RemoveLiquidityInputProps> = ({
       case AsymSide.Asset:
         return bnOrZero(virtualAssetWithdrawAmountCryptoPrecision).gt(0)
       default:
-        assertUnreachable(withdrawType)
+        return withdrawType satisfies never
     }
   }, [
     incompleteSide,
@@ -726,7 +725,7 @@ export const RemoveLiquidityInput: React.FC<RemoveLiquidityInputProps> = ({
         case 'sym':
           return [poolAsset, runeAsset]
         default:
-          assertUnreachable(withdrawType)
+          return withdrawType satisfies never
       }
     })()
 

--- a/src/pages/ThorChainLP/components/ReusableLpConfirm.tsx
+++ b/src/pages/ThorChainLP/components/ReusableLpConfirm.tsx
@@ -27,7 +27,6 @@ import { RawText } from 'components/Text'
 import { Timeline, TimelineItem } from 'components/Timeline/Timeline'
 import { getChainAdapterManager } from 'context/PluginProvider/chainAdapterSingleton'
 import { bn, bnOrZero } from 'lib/bignumber/bignumber'
-import { assertUnreachable } from 'lib/utils'
 import type { LpConfirmedWithdrawalQuote } from 'lib/utils/thorchain/lp/types'
 import { AsymSide, type LpConfirmedDepositQuote } from 'lib/utils/thorchain/lp/types'
 import {
@@ -130,7 +129,7 @@ export const ReusableLpConfirm: React.FC<ReusableLpConfirmProps> = ({
         case 'sym':
           return [baseAsset, poolAsset]
         default:
-          assertUnreachable(actionSide)
+          return actionSide satisfies never
       }
     })()
 

--- a/src/pages/ThorChainLP/components/ReusableLpStatus/ReusableLpStatus.tsx
+++ b/src/pages/ThorChainLP/components/ReusableLpStatus/ReusableLpStatus.tsx
@@ -26,7 +26,6 @@ import { SlideTransition } from 'components/SlideTransition'
 import { RawText, Text } from 'components/Text'
 import { getMixPanel } from 'lib/mixpanel/mixPanelSingleton'
 import { MixPanelEvent } from 'lib/mixpanel/types'
-import { assertUnreachable } from 'lib/utils'
 import type {
   LpConfirmedDepositQuote,
   LpConfirmedWithdrawalQuote,
@@ -76,7 +75,7 @@ export const ReusableLpStatus: React.FC<ReusableLpStatusProps> = ({
       case AsymSide.Asset:
         return [poolAsset]
       default:
-        assertUnreachable(actionSide)
+        return actionSide satisfies never
     }
   }, [poolAsset, baseAsset, actionSide])
 
@@ -91,7 +90,7 @@ export const ReusableLpStatus: React.FC<ReusableLpStatusProps> = ({
       case AsymSide.Asset:
         return [poolAsset]
       default:
-        assertUnreachable(actionSide)
+        return actionSide satisfies never
     }
   }, [poolAsset, baseAsset, actionSide, action])
 

--- a/src/plugins/walletConnectToDapps/WalletConnectModalManager.tsx
+++ b/src/plugins/walletConnectToDapps/WalletConnectModalManager.tsx
@@ -37,7 +37,6 @@ import { type Dispatch, type FC, useCallback, useMemo, useRef } from 'react'
 import { WalletConnectIcon } from 'components/Icons/WalletConnectIcon'
 import { Text } from 'components/Text'
 import { useWallet } from 'hooks/useWallet/useWallet'
-import { assertUnreachable } from 'lib/utils'
 import { assertGetCosmosSdkChainAdapter } from 'lib/utils/cosmosSdk'
 import { assertGetEvmChainAdapter } from 'lib/utils/evm'
 
@@ -163,7 +162,7 @@ export const WalletConnectModalManager: FC<WalletConnectModalManagerProps> = ({
       case undefined:
         break
       default:
-        assertUnreachable(activeModal)
+        return activeModal satisfies never
     }
 
     handleClose()
@@ -235,7 +234,7 @@ export const WalletConnectModalManager: FC<WalletConnectModalManagerProps> = ({
           />
         )
       default:
-        assertUnreachable(activeModal)
+        return activeModal satisfies never
     }
   }, [
     activeModal,

--- a/src/react-queries/hooks/selectors/index.ts
+++ b/src/react-queries/hooks/selectors/index.ts
@@ -1,6 +1,5 @@
 import type { Result } from '@sniptt/monads'
 import { GetAllowanceErr } from 'react-queries/types'
-import { assertUnreachable } from 'lib/utils'
 
 export const selectAllowanceCryptoBaseUnit = (data: Result<string, GetAllowanceErr>) => {
   if (data.isErr()) {
@@ -19,7 +18,7 @@ export const selectAllowanceCryptoBaseUnit = (data: Result<string, GetAllowanceE
         // - magic chain-level transfers for which we use 0x0 as a placeholder
         return undefined
       default:
-        assertUnreachable(error)
+        return error satisfies never
     }
   }
 

--- a/src/state/apis/swapper/helpers/getInputOutputRatioFromQuote.test.ts
+++ b/src/state/apis/swapper/helpers/getInputOutputRatioFromQuote.test.ts
@@ -5,7 +5,6 @@ import { ethereum } from 'test/mocks/assets'
 import { mockMarketData } from 'test/mocks/marketData'
 import { mockStore } from 'test/mocks/store'
 import { describe, expect, it, vi } from 'vitest'
-import { assertUnreachable } from 'lib/utils'
 import { getInputOutputRatioFromQuote } from 'state/apis/swapper/helpers/getInputOutputRatioFromQuote'
 import {
   cowQuote,
@@ -29,7 +28,7 @@ vi.mock('state/slices/assetsSlice/selectors', async importActual => {
         case foxAssetId:
           return ethereum
         default:
-          assertUnreachable(assetId as never)
+          return assetId as never satisfies never
       }
     }),
   }
@@ -53,7 +52,7 @@ vi.mock('state/slices/marketDataSlice/selectors', async importActual => {
         case usdcAssetId:
           return '1'
         default:
-          assertUnreachable(assetId as never)
+          return assetId as never satisfies never
       }
     }),
   }

--- a/src/state/apis/swapper/helpers/validateTradeQuote.ts
+++ b/src/state/apis/swapper/helpers/validateTradeQuote.ts
@@ -11,7 +11,7 @@ import { getChainShortName } from 'components/MultiHopTrade/components/MultiHopT
 import { isMultiHopTradeQuote } from 'components/MultiHopTrade/utils'
 import { baseUnitToHuman, bn, bnOrZero } from 'lib/bignumber/bignumber'
 import { fromBaseUnit } from 'lib/math'
-import { assertGetChainAdapter, assertUnreachable, isTruthy } from 'lib/utils'
+import { assertGetChainAdapter, isTruthy } from 'lib/utils'
 import type { ReduxState } from 'state/reducer'
 import {
   selectPortfolioAccountBalancesBaseUnit,
@@ -104,7 +104,7 @@ export const validateTradeQuote = (
           // We didn't recognize the error, use a generic error message
           return { error: SwapperTradeQuoteError.UnknownError }
         default:
-          assertUnreachable(errorCode)
+          return errorCode satisfies never
       }
     })()
 

--- a/src/state/helpers.ts
+++ b/src/state/helpers.ts
@@ -1,6 +1,5 @@
 import { SwapperName } from '@shapeshiftoss/swapper'
 
-import { assertUnreachable } from '../lib/utils'
 import type { FeatureFlags } from './slices/preferencesSlice/preferencesSlice'
 
 export const isCrossAccountTradeSupported = (swapperName: SwapperName) => {
@@ -17,7 +16,7 @@ export const isCrossAccountTradeSupported = (swapperName: SwapperName) => {
       // Technically supported for Arbitrum Bridge, but we disable it for the sake of simplicity for now
       return false
     default:
-      assertUnreachable(swapperName)
+      return swapperName satisfies never
   }
 }
 

--- a/src/state/slices/portfolioSlice/utils.ts
+++ b/src/state/slices/portfolioSlice/utils.ts
@@ -45,7 +45,7 @@ import cloneDeep from 'lodash/cloneDeep'
 import maxBy from 'lodash/maxBy'
 import type { BigNumber } from 'lib/bignumber/bignumber'
 import { bn, bnOrZero } from 'lib/bignumber/bignumber'
-import { assertUnreachable, firstFourLastFour } from 'lib/utils'
+import { firstFourLastFour } from 'lib/utils'
 import { isSpammyNftText } from 'state/apis/nft/constants'
 import type { NftCollectionType } from 'state/apis/nft/types'
 
@@ -227,7 +227,7 @@ export const accountToPortfolio: AccountToPortfolio = ({
         break
       }
       default:
-        assertUnreachable(chainNamespace)
+        return chainNamespace satisfies never
     }
   })
 
@@ -268,7 +268,7 @@ export const checkAccountHasActivity = (account: Account<ChainId>) => {
       return hasActivity
     }
     default:
-      assertUnreachable(chainNamespace)
+      return chainNamespace satisfies never
   }
 }
 


### PR DESCRIPTION
## Description

We can replace our `assertUnreachable` util with native TS via the `satisfies` operator.
This PR does just that.

Ref: https://stackoverflow.com/a/75217377/5623388 and https://www.typescriptlang.org/docs/handbook/release-notes/typescript-4-9.html#the-satisfies-operator

## Issue (if applicable)

N/A, developer experience.

## Risk

> High Risk PRs Require 2 approvals

Small - only type-level changes.

> What protocols, transaction types, wallets or contract interactions might be affected by this PR?

None

## Testing

App should build as normal, with no errors.

### Engineering

☝️

### Operations

- [ ] :checkered_flag: My feature is behind a flag and doesn't require operations testing (yet)

General smoke test.

## Screenshots (if applicable)

N/A