### PR TITLE
feat: defi section ledger open app gate

### DIFF
--- a/src/features/defi/providers/foxy/components/FoxyManager/Deposit/components/Approve.tsx
+++ b/src/features/defi/providers/foxy/components/FoxyManager/Deposit/components/Approve.tsx
@@ -12,6 +12,7 @@ import { useCallback, useContext, useMemo } from 'react'
 import { useTranslate } from 'react-polyglot'
 import { useHistory } from 'react-router-dom'
 import type { StepComponentProps } from 'components/DeFi/components/Steps'
+import { useLedgerOpenApp } from 'hooks/useLedgerOpenApp/useLedgerOpenApp'
 import { usePoll } from 'hooks/usePoll/usePoll'
 import { useWallet } from 'hooks/useWallet/useWallet'
 import { bn, bnOrZero } from 'lib/bignumber/bignumber'
@@ -27,6 +28,7 @@ import { DepositContext } from '../DepositContext'
 type ApproveProps = StepComponentProps & { accountId: AccountId | undefined }
 
 export const Approve: React.FC<ApproveProps> = ({ accountId, onNext }) => {
+  const checkLedgerAppOpenIfLedgerConnected = useLedgerOpenApp({ isSigning: true })
   const { poll } = usePoll()
   const foxyApi = getFoxyApi()
   const { state, dispatch } = useContext(DepositContext)
@@ -99,7 +101,8 @@ export const Approve: React.FC<ApproveProps> = ({ accountId, onNext }) => {
         foxyApi &&
         dispatch &&
         bip44Params &&
-        state
+        state &&
+        feeAsset
       )
     )
       return
@@ -108,6 +111,8 @@ export const Approve: React.FC<ApproveProps> = ({ accountId, onNext }) => {
 
       if (!supportsETH(walletState.wallet))
         throw new Error(`handleApprove: wallet does not support ethereum`)
+
+      await checkLedgerAppOpenIfLedgerConnected(feeAsset.chainId)
 
       await foxyApi.approve({
         tokenContractAddress: assetReference,
@@ -163,6 +168,8 @@ export const Approve: React.FC<ApproveProps> = ({ accountId, onNext }) => {
     dispatch,
     bip44Params,
     state,
+    feeAsset,
+    checkLedgerAppOpenIfLedgerConnected,
     contractAddress,
     asset.precision,
     poll,

--- a/src/features/defi/providers/foxy/components/FoxyManager/Withdraw/components/Confirm.tsx
+++ b/src/features/defi/providers/foxy/components/FoxyManager/Withdraw/components/Confirm.tsx
@@ -17,6 +17,7 @@ import type { StepComponentProps } from 'components/DeFi/components/Steps'
 import { Row } from 'components/Row/Row'
 import { RawText, Text } from 'components/Text'
 import type { TextPropTypes } from 'components/Text/Text'
+import { useLedgerOpenApp } from 'hooks/useLedgerOpenApp/useLedgerOpenApp'
 import { usePoll } from 'hooks/usePoll/usePoll'
 import { useWallet } from 'hooks/useWallet/useWallet'
 import { bn, bnOrZero } from 'lib/bignumber/bignumber'
@@ -34,6 +35,7 @@ export const Confirm: React.FC<StepComponentProps & { accountId?: AccountId | un
   onNext,
   accountId,
 }) => {
+  const checkLedgerAppOpenIfLedgerConnected = useLedgerOpenApp({ isSigning: true })
   const { poll } = usePoll<TransactionReceipt | null>()
   const foxyApi = getFoxyApi()
   const { state, dispatch } = useContext(WithdrawContext)
@@ -78,7 +80,8 @@ export const Confirm: React.FC<StepComponentProps & { accountId?: AccountId | un
           walletState.wallet &&
           foxyApi &&
           dispatch &&
-          bip44Params
+          bip44Params &&
+          feeAsset
         )
       )
         return
@@ -86,6 +89,8 @@ export const Confirm: React.FC<StepComponentProps & { accountId?: AccountId | un
 
       if (!supportsETH(walletState.wallet))
         throw new Error(`handleConfirm: wallet does not support ethereum`)
+
+      await checkLedgerAppOpenIfLedgerConnected(feeAsset.chainId)
 
       const txid = await foxyApi.withdraw({
         tokenContractAddress: rewardId,
@@ -131,6 +136,8 @@ export const Confirm: React.FC<StepComponentProps & { accountId?: AccountId | un
     foxyApi,
     dispatch,
     bip44Params,
+    feeAsset,
+    checkLedgerAppOpenIfLedgerConnected,
     contractAddress,
     underlyingAsset.precision,
     onNext,

--- a/src/features/defi/providers/thorchain-savers/components/ThorchainSaversManager/Deposit/components/Approve.tsx
+++ b/src/features/defi/providers/thorchain-savers/components/ThorchainSaversManager/Deposit/components/Approve.tsx
@@ -21,6 +21,7 @@ import { encodeFunctionData, getAddress } from 'viem'
 import type { StepComponentProps } from 'components/DeFi/components/Steps'
 import { useBrowserRouter } from 'hooks/useBrowserRouter/useBrowserRouter'
 import { useErrorHandler } from 'hooks/useErrorToast/useErrorToast'
+import { useLedgerOpenApp } from 'hooks/useLedgerOpenApp/useLedgerOpenApp'
 import { usePoll } from 'hooks/usePoll/usePoll'
 import { useWallet } from 'hooks/useWallet/useWallet'
 import { bnOrZero } from 'lib/bignumber/bignumber'
@@ -54,6 +55,7 @@ import { DepositContext } from '../DepositContext'
 type ApproveProps = StepComponentProps & { accountId: AccountId | undefined }
 
 export const Approve: React.FC<ApproveProps> = ({ accountId, onNext }) => {
+  const checkLedgerAppOpenIfLedgerConnected = useLedgerOpenApp({ isSigning: true })
   const { poll } = usePoll()
   const { state, dispatch } = useContext(DepositContext)
   const estimatedGasCryptoPrecision = state?.approve.estimatedGasCryptoPrecision
@@ -156,6 +158,9 @@ export const Approve: React.FC<ApproveProps> = ({ accountId, onNext }) => {
       })
 
       const adapter = assertGetEvmChainAdapter(chainId)
+
+      await checkLedgerAppOpenIfLedgerConnected(asset.chainId)
+
       const buildCustomTxInput = await createBuildCustomTxInput({
         accountNumber,
         from: fromAccountId(accountId).account,
@@ -205,10 +210,13 @@ export const Approve: React.FC<ApproveProps> = ({ accountId, onNext }) => {
   }, [
     accountId,
     accountNumber,
-    asset,
+    asset.assetId,
+    asset.chainId,
+    asset.precision,
     assetId,
     assets,
     chainId,
+    checkLedgerAppOpenIfLedgerConnected,
     dispatch,
     inboundAddress,
     onNext,

--- a/src/lib/utils/thorchain/hooks/useSendThorTx.tsx
+++ b/src/lib/utils/thorchain/hooks/useSendThorTx.tsx
@@ -15,6 +15,7 @@ import { selectInboundAddressData } from 'react-queries/selectors'
 import { getAddress, zeroAddress } from 'viem'
 import type { SendInput } from 'components/Modals/Send/Form'
 import { estimateFees, handleSend } from 'components/Modals/Send/utils'
+import { useLedgerOpenApp } from 'hooks/useLedgerOpenApp/useLedgerOpenApp'
 import { useWallet } from 'hooks/useWallet/useWallet'
 import { bn, bnOrZero } from 'lib/bignumber/bignumber'
 import { getTxLink } from 'lib/getTxLink'
@@ -75,6 +76,7 @@ export const useSendThorTx = ({
   const [txId, setTxId] = useState<string | null>(null)
   const [serializedTxIndex, setSerializedTxIndex] = useState<string | null>(null)
 
+  const checkLedgerAppOpenIfLedgerConnected = useLedgerOpenApp({ isSigning: true })
   const wallet = useWallet().state.wallet
   const toast = useToast()
   const translate = useTranslate()
@@ -333,6 +335,8 @@ export const useSendThorTx = ({
             wallet,
           })
 
+          await checkLedgerAppOpenIfLedgerConnected(asset.chainId)
+
           const _txId = await buildAndBroadcast({
             adapter,
             buildCustomTxInput,
@@ -408,22 +412,23 @@ export const useSendThorTx = ({
 
     return _txId
   }, [
-    accountId,
-    accountNumber,
-    amountOrDustCryptoBaseUnit,
-    asset,
-    depositWithExpiryInputData,
-    estimateFeesArgs,
-    fromAddress,
-    inboundAddressData,
     memo,
-    selectedCurrency,
-    shouldUseDustAmount,
-    toast,
-    transactionType,
-    translate,
+    asset,
     wallet,
+    accountId,
+    transactionType,
+    estimateFeesArgs,
+    accountNumber,
+    inboundAddressData,
     action,
+    shouldUseDustAmount,
+    amountOrDustCryptoBaseUnit,
+    toast,
+    translate,
+    depositWithExpiryInputData,
+    checkLedgerAppOpenIfLedgerConnected,
+    fromAddress,
+    selectedCurrency,
   ])
 
   return {

--- a/src/lib/utils/thorchain/hooks/useSendThorTx.tsx
+++ b/src/lib/utils/thorchain/hooks/useSendThorTx.tsx
@@ -280,6 +280,8 @@ export const useSendThorTx = ({
     )
       throw new Error('invalid amount specified')
 
+    await checkLedgerAppOpenIfLedgerConnected(asset.chainId)
+
     const { account } = fromAccountId(accountId)
 
     const { _txId, _serializedTxIndex } = await (async () => {
@@ -334,8 +336,6 @@ export const useSendThorTx = ({
             to: inboundAddressData.router,
             wallet,
           })
-
-          await checkLedgerAppOpenIfLedgerConnected(asset.chainId)
 
           const _txId = await buildAndBroadcast({
             adapter,


### PR DESCRIPTION
## Description

This PR implements Ledger over all DeFi section signing actions.

## Issue (if applicable)

<!-----------------------------------------------------------------------------
If applicable, please link to the github issue and put `closes #XXXX` in your comment to auto-close the issue that your PR fixes.
------------------------------------------------------------------------------>

closes https://github.com/shapeshift/web/issues/7579

## Risk

> High Risk PRs Require 2 approvals

<!-----------------------------------------------------------------------------
Outline the scope of your changes and the risk associated with them. You must use your discretion as an engineer to determine the potential impact of your changes.

WARNING: If your PR introduces a new on-chain transaction or modifies an existing one, please add the "High-Risk" label to this PR and ask for 2 reviewers to approve it before merging.

E.g. an upgrade to `hdwallet` or core state management would be considered higher risk, and might require a full regression test. UI or isolated view changes, or something behind a feature flag may have near zero risk. Small bug fixes might require testing isolated to the specific fix.
------------------------------------------------------------------------------>

> What protocols, transaction types, wallets or contract interactions might be affected by this PR?

Low to none

## Testing

<!-----------------------------------------------------------------------------
We treat every PR to be merged with the same scrutiny as if we were merging directly to production.

Your PR will not be merged if you do not complete the sections below for our engineering and operations teams to test.
------------------------------------------------------------------------------>

- Ensure all signing actions across the DeFi section (deposit, withdraw, claim) are properly guarded by the Ledger Open App gate, i.e pop up a modal to open the relevant Ledger app if no/wrong app is opened
- Test this over:
  - ETH/FOX (UNI-V2)
  - FOX Farming
  - FOXy
  - THORChain savers
  - Cosmos SDK

### Engineering

<!-----------------------------------------------------------------------------
Include sufficient information here for an engineer to test your PR. This may include how to test locally, in a built environment, changes to infrastructure etc.
------------------------------------------------------------------------------>

- ^

### Operations

- [ ] :checkered_flag: My feature is behind a flag and doesn't require operations testing (yet)

<!-----------------------------------------------------------------------------
If your changes have a user-facing impact, describe how a non-technical QA team can functionally test your changes in a preview environment.

If they are not user-facing please describe how to test for any regressions that may occur.
------------------------------------------------------------------------------>

- ^

## Screenshots (if applicable)

<!-- av pr metadata
This information is embedded by the av CLI when creating PRs to track the status of stacks when using Aviator. Please do not delete or edit this section of the PR.
```
{"parent":"develop","parentHead":"","trunk":"develop"}
```
-->

- UNI-V2

<img width="584" alt="Screenshot 2024-08-27 at 09 14 58" src="https://github.com/user-attachments/assets/e5fb43ca-35bd-4257-b3e2-70ef792a68ba">
<img width="577" alt="Screenshot 2024-08-27 at 09 14 41" src="https://github.com/user-attachments/assets/80a0ea96-d43a-44e7-8057-b2f368a2794e">
<img width="554" alt="Screenshot 2024-08-27 at 09 13 59" src="https://github.com/user-attachments/assets/83fb4a0d-a385-481c-81ac-eed3ec4a4b9b">
<img width="666" alt="Screenshot 2024-08-27 at 09 13 50" src="https://github.com/user-attachments/assets/37ed5e93-4dcc-4bd6-8643-0da48047d637">
<img width="572" alt="Screenshot 2024-08-27 at 09 12 50" src="https://github.com/user-attachments/assets/10119c7c-0f61-4e2d-a052-1011af5e282d">
<img width="651" alt="Screenshot 2024-08-27 at 09 12 29" src="https://github.com/user-attachments/assets/227dfcae-2411-41f0-8cc4-8b08f94ee7d7">

- FOX Farming

<img width="587" alt="Screenshot 2024-08-27 at 09 28 09" src="https://github.com/user-attachments/assets/269ace53-310f-4b87-a6e5-1967bfa5f084">
<img width="603" alt="Screenshot 2024-08-27 at 09 27 39" src="https://github.com/user-attachments/assets/beb6de76-be3f-4610-a4e8-b0b9359231aa">


- FOXy


<img width="627" alt="Screenshot 2024-08-27 at 10 16 31" src="https://github.com/user-attachments/assets/57d44e3f-d99a-4955-acd0-b69e0dc3a8a2">
<img width="593" alt="Screenshot 2024-08-27 at 10 07 03" src="https://github.com/user-attachments/assets/f2bb0154-9d5c-468b-8c30-f296a6a8f318">

- THORChain Savers

 
<img width="529" alt="Screenshot 2024-08-27 at 10 19 34" src="https://github.com/user-attachments/assets/f55e029b-0162-4f5e-90e6-db294ebb31af">
<img width="546" alt="Screenshot 2024-08-27 at 10 18 35" src="https://github.com/user-attachments/assets/f28e4f45-fff1-4508-85b5-b81239e71e48">

- Cosmos SDK

<img width="596" alt="image" src="https://github.com/user-attachments/assets/85ffe4b4-7e94-4f9c-b28d-9a3abe7948df">
<img width="551" alt="image" src="https://github.com/user-attachments/assets/46ea762b-075b-4179-a1d8-7b0d61ff40f3">
<img width="572" alt="image" src="https://github.com/user-attachments/assets/a081ea83-d7d4-4281-ab06-0922e5a1e0fc">

<!-- av pr metadata
This information is embedded by the av CLI when creating PRs to track the status of stacks when using Aviator. Please do not delete or edit this section of the PR.
```
{"parent":"develop","parentHead":"","trunk":"develop"}
```
-->
