### PR TITLE
feat: handle accounts loading gracefully

### DIFF
--- a/src/assets/translations/en/main.json
+++ b/src/assets/translations/en/main.json
@@ -155,7 +155,7 @@
     "symmetric": "Symmetric",
     "asymmetric": "Asymmetric (%{assetSymbol})",
     "import": "Import",
-    "accountsLoading": "Accounts are currently loading",
+    "accountsLoading": "Loading Accounts",
     "carousel": {
       "next": "Next",
       "prev": "Previous",

--- a/src/assets/translations/en/main.json
+++ b/src/assets/translations/en/main.json
@@ -155,6 +155,7 @@
     "symmetric": "Symmetric",
     "asymmetric": "Asymmetric (%{assetSymbol})",
     "import": "Import",
+    "loadingAccounts": "Loading Accounts",
     "carousel": {
       "next": "Next",
       "prev": "Previous",

--- a/src/assets/translations/en/main.json
+++ b/src/assets/translations/en/main.json
@@ -155,7 +155,7 @@
     "symmetric": "Symmetric",
     "asymmetric": "Asymmetric (%{assetSymbol})",
     "import": "Import",
-    "loadingAccounts": "Loading Accounts",
+    "accountsLoading": "Accounts are currently loading",
     "carousel": {
       "next": "Next",
       "prev": "Previous",

--- a/src/components/MultiHopTrade/components/TradeInput/components/ConfirmSummary.tsx
+++ b/src/components/MultiHopTrade/components/TradeInput/components/ConfirmSummary.tsx
@@ -18,7 +18,7 @@ import {
   selectHasUserEnteredAmount,
   selectInputBuyAsset,
   selectInputSellAsset,
-  selectIsAccountsLoading,
+  selectIsAccountMetadataLoading,
   selectManualReceiveAddressIsEditing,
   selectManualReceiveAddressIsValid,
   selectManualReceiveAddressIsValidating,
@@ -90,7 +90,7 @@ export const ConfirmSummary = ({
   const buyAssetFeeAsset = useAppSelector(state =>
     selectFeeAssetById(state, buyAsset?.assetId ?? ''),
   )
-  const isAccountsLoading = useAppSelector(selectIsAccountsLoading)
+  const isAccountMetadataLoading = useAppSelector(selectIsAccountMetadataLoading)
 
   const { priceImpactPercentage } = usePriceImpact(activeQuote)
   const walletSupportsBuyAssetChain = useWalletSupportsChain(buyAsset.chainId, wallet)
@@ -117,12 +117,14 @@ export const ConfirmSummary = ({
     buyAsset.chainId,
     buyAsset.assetId,
   ])
-  const displayManualAddressEntry = useMemo(() => {
-    // If accounts have finished loading, *and* there is no runtime chain support for the buy asset, display manual address entry
-    if (!walletSupportsBuyAssetChain) return !isAccountsLoading
 
-    return disableThorNativeSmartContractReceive === true
-  }, [walletSupportsBuyAssetChain, disableThorNativeSmartContractReceive, isAccountsLoading])
+  const displayManualAddressEntry = useMemo(() => {
+    if (isAccountMetadataLoading) return false
+    if (!walletSupportsBuyAssetChain) return true
+    if (disableThorNativeSmartContractReceive) return true
+
+    return false
+  }, [walletSupportsBuyAssetChain, disableThorNativeSmartContractReceive, isAccountMetadataLoading])
 
   const quoteHasError = useMemo(() => {
     if (!isAnyTradeQuoteLoaded) return false
@@ -135,6 +137,7 @@ export const ConfirmSummary = ({
 
   const shouldDisablePreviewButton = useMemo(() => {
     return (
+      isAccountMetadataLoading ||
       // don't allow executing a quote with errors
       quoteHasError ||
       // don't execute trades while address is validating
@@ -164,6 +167,7 @@ export const ConfirmSummary = ({
     hasUserEnteredAmount,
     activeSwapperName,
     isTradeQuoteApiQueryPending,
+    isAccountMetadataLoading,
   ])
 
   const quoteStatusTranslation = useMemo(() => {
@@ -171,7 +175,7 @@ export const ConfirmSummary = ({
     const quoteResponseError = quoteResponseErrors[0]
     const tradeQuoteError = activeQuoteErrors?.[0]
     switch (true) {
-      case isAccountsLoading:
+      case isAccountMetadataLoading:
         return 'common.accountsLoading'
       case !isAnyTradeQuoteLoaded:
       case !hasUserEnteredAmount:
@@ -196,7 +200,7 @@ export const ConfirmSummary = ({
     hasUserEnteredAmount,
     isConnected,
     isDemoWallet,
-    isAccountsLoading,
+    isAccountMetadataLoading,
   ])
 
   const handleOpenCompactQuoteList = useCallback(() => {

--- a/src/components/MultiHopTrade/components/TradeInput/components/ConfirmSummary.tsx
+++ b/src/components/MultiHopTrade/components/TradeInput/components/ConfirmSummary.tsx
@@ -18,6 +18,7 @@ import {
   selectHasUserEnteredAmount,
   selectInputBuyAsset,
   selectInputSellAsset,
+  selectIsAccountLoading,
   selectManualReceiveAddressIsEditing,
   selectManualReceiveAddressIsValid,
   selectManualReceiveAddressIsValidating,
@@ -89,6 +90,7 @@ export const ConfirmSummary = ({
   const buyAssetFeeAsset = useAppSelector(state =>
     selectFeeAssetById(state, buyAsset?.assetId ?? ''),
   )
+  const isAccountLoading = useAppSelector(selectIsAccountLoading)
 
   const { priceImpactPercentage } = usePriceImpact(activeQuote)
   const walletSupportsBuyAssetChain = useWalletSupportsChain(buyAsset.chainId, wallet)
@@ -162,6 +164,8 @@ export const ConfirmSummary = ({
     const quoteResponseError = quoteResponseErrors[0]
     const tradeQuoteError = activeQuoteErrors?.[0]
     switch (true) {
+      case isAccountLoading:
+        return 'common.loadingAccounts'
       case !isAnyTradeQuoteLoaded:
       case !hasUserEnteredAmount:
         return 'trade.previewTrade'
@@ -185,6 +189,7 @@ export const ConfirmSummary = ({
     hasUserEnteredAmount,
     isConnected,
     isDemoWallet,
+    isAccountLoading,
   ])
 
   const handleOpenCompactQuoteList = useCallback(() => {
@@ -280,7 +285,11 @@ export const ConfirmSummary = ({
           component={RecipientAddress}
         />
         <WithLazyMount
-          shouldUse={!walletSupportsBuyAssetChain || disableThorNativeSmartContractReceive === true}
+          shouldUse={
+            Boolean(
+              !walletSupportsBuyAssetChain || disableThorNativeSmartContractReceive === true,
+            ) && !isAccountLoading
+          }
           shouldForceManualAddressEntry={disableThorNativeSmartContractReceive}
           component={ManualAddressEntry}
           description={manualAddressEntryDescription}

--- a/src/context/AppProvider/AppContext.tsx
+++ b/src/context/AppProvider/AppContext.tsx
@@ -100,7 +100,7 @@ export const AppProvider = ({ children }: { children: React.ReactNode }) => {
 
   // Initial account and portfolio fetch for non-ledger wallets
   useEffect(() => {
-    dispatch(portfolio.actions.setIsAccountLoading(true))
+    dispatch(portfolio.actions.setIsAccountsLoading(true))
 
     const hasManagedAccounts = (() => {
       // MM without snap doesn't allow account management - if the user just installed the snap, we know they don't have managed accounts
@@ -122,12 +122,12 @@ export const AppProvider = ({ children }: { children: React.ReactNode }) => {
           )
         })
 
-        dispatch(portfolio.actions.setIsAccountLoading(false))
+        dispatch(portfolio.actions.setIsAccountsLoading(false))
         return
       }
 
       if (!wallet) {
-        dispatch(portfolio.actions.setIsAccountLoading(false))
+        dispatch(portfolio.actions.setIsAccountsLoading(false))
 
         return
       }
@@ -218,7 +218,7 @@ export const AppProvider = ({ children }: { children: React.ReactNode }) => {
       for (const accountId of Object.keys(accountMetadataByAccountId)) {
         dispatch(portfolio.actions.enableAccountId(accountId))
       }
-      dispatch(portfolio.actions.setIsAccountLoading(false))
+      dispatch(portfolio.actions.setIsAccountsLoading(false))
     })()
   }, [
     dispatch,

--- a/src/context/AppProvider/AppContext.tsx
+++ b/src/context/AppProvider/AppContext.tsx
@@ -100,6 +100,8 @@ export const AppProvider = ({ children }: { children: React.ReactNode }) => {
 
   // Initial account and portfolio fetch for non-ledger wallets
   useEffect(() => {
+    dispatch(portfolio.actions.setIsAccountLoading(true))
+
     const hasManagedAccounts = (() => {
       // MM without snap doesn't allow account management - if the user just installed the snap, we know they don't have managed accounts
       if (!previousIsSnapInstalled && isSnapInstalled) return false
@@ -119,10 +121,16 @@ export const AppProvider = ({ children }: { children: React.ReactNode }) => {
             ),
           )
         })
+
+        dispatch(portfolio.actions.setIsAccountLoading(false))
         return
       }
 
-      if (!wallet) return
+      if (!wallet) {
+        dispatch(portfolio.actions.setIsAccountLoading(false))
+
+        return
+      }
 
       let chainIds = supportedChains.filter(chainId => {
         return walletSupportsChain({
@@ -210,6 +218,7 @@ export const AppProvider = ({ children }: { children: React.ReactNode }) => {
       for (const accountId of Object.keys(accountMetadataByAccountId)) {
         dispatch(portfolio.actions.enableAccountId(accountId))
       }
+      dispatch(portfolio.actions.setIsAccountLoading(false))
     })()
   }, [
     dispatch,

--- a/src/pages/RFOX/components/Stake/StakeInput.tsx
+++ b/src/pages/RFOX/components/Stake/StakeInput.tsx
@@ -33,7 +33,7 @@ import { marketApi } from 'state/slices/marketDataSlice/marketDataSlice'
 import {
   selectAssetById,
   selectFeeAssetByChainId,
-  selectIsAccountsLoading,
+  selectIsAccountMetadataLoading,
   selectMarketDataByAssetIdUserCurrency,
   selectMarketDataByFilter,
   selectPortfolioCryptoPrecisionBalanceByFilter,
@@ -84,7 +84,7 @@ export const StakeInput: React.FC<StakeInputProps & StakeRouteProps> = ({
   const { selectedAssetId, setSelectedAssetId, selectedAssetAccountId, stakingAssetAccountId } =
     useRFOXContext()
 
-  const isAccountsLoading = useAppSelector(selectIsAccountsLoading)
+  const isAccountMetadataLoading = useAppSelector(selectIsAccountMetadataLoading)
   const isBridgeRequired = stakingAssetId !== selectedAssetId
   const dispatch = useAppDispatch()
   const translate = useTranslate()
@@ -421,7 +421,7 @@ export const StakeInput: React.FC<StakeInputProps & StakeRouteProps> = ({
   }, [isChainSupportedByWallet, translate])
 
   const submitButtonText = useMemo(() => {
-    if (isAccountsLoading) return translate('common.accountsLoading')
+    if (isAccountMetadataLoading) return translate('common.accountsLoading')
 
     return (
       errors.amountFieldInput?.message ||
@@ -434,12 +434,12 @@ export const StakeInput: React.FC<StakeInputProps & StakeRouteProps> = ({
     errors.amountFieldInput,
     errors.manualRuneAddress,
     translate,
-    isAccountsLoading,
+    isAccountMetadataLoading,
   ])
 
   if (!selectedAsset) return null
 
-  if (!stakingAssetAccountAddress && !isAccountsLoading)
+  if (!stakingAssetAccountAddress && !isAccountMetadataLoading)
     return (
       <SlideTransition>
         <Stack>{headerComponent}</Stack>
@@ -536,13 +536,13 @@ export const StakeInput: React.FC<StakeInputProps & StakeRouteProps> = ({
             borderBottomRadius='xl'
           >
             <ButtonWalletPredicate
-              isValidWallet={Boolean(isChainSupportedByWallet && !isAccountsLoading)}
+              isValidWallet={Boolean(isChainSupportedByWallet || isAccountMetadataLoading)}
               isDisabled={Boolean(
                 errors.amountFieldInput ||
                   !runeAddress ||
                   !isValidStakingAmount ||
                   !(isStakeFeesSuccess || isGetApprovalFeesSuccess) ||
-                  isAccountsLoading ||
+                  isAccountMetadataLoading ||
                   !cooldownPeriod,
               )}
               size='lg'
@@ -550,7 +550,8 @@ export const StakeInput: React.FC<StakeInputProps & StakeRouteProps> = ({
               onClick={handleWarning}
               isLoading={isGetApprovalFeesLoading || isStakeFeesLoading}
               colorScheme={
-                Boolean(errors.amountFieldInput || errors.manualRuneAddress) && !isAccountsLoading
+                Boolean(errors.amountFieldInput || errors.manualRuneAddress) &&
+                !isAccountMetadataLoading
                   ? 'red'
                   : 'blue'
               }

--- a/src/pages/RFOX/components/Stake/StakeInput.tsx
+++ b/src/pages/RFOX/components/Stake/StakeInput.tsx
@@ -33,6 +33,7 @@ import { marketApi } from 'state/slices/marketDataSlice/marketDataSlice'
 import {
   selectAssetById,
   selectFeeAssetByChainId,
+  selectIsAccountLoading,
   selectMarketDataByAssetIdUserCurrency,
   selectMarketDataByFilter,
   selectPortfolioCryptoPrecisionBalanceByFilter,
@@ -83,6 +84,7 @@ export const StakeInput: React.FC<StakeInputProps & StakeRouteProps> = ({
   const { selectedAssetId, setSelectedAssetId, selectedAssetAccountId, stakingAssetAccountId } =
     useRFOXContext()
 
+  const isAccountLoading = useAppSelector(selectIsAccountLoading)
   const isBridgeRequired = stakingAssetId !== selectedAssetId
   const dispatch = useAppDispatch()
   const translate = useTranslate()
@@ -418,9 +420,26 @@ export const StakeInput: React.FC<StakeInputProps & StakeRouteProps> = ({
     return translate('RFOX.chainNotSupportedByWallet')
   }, [isChainSupportedByWallet, translate])
 
+  const submitButtonText = useMemo(() => {
+    if (isAccountLoading) return translate('common.loadingAccounts')
+
+    return (
+      errors.amountFieldInput?.message ||
+      errors.manualRuneAddress?.message ||
+      chainNotSupportedByWalletCopy ||
+      translate('RFOX.stake')
+    )
+  }, [
+    chainNotSupportedByWalletCopy,
+    errors.amountFieldInput,
+    errors.manualRuneAddress,
+    translate,
+    isAccountLoading,
+  ])
+
   if (!selectedAsset) return null
 
-  if (!stakingAssetAccountAddress)
+  if (!stakingAssetAccountAddress && !isAccountLoading)
     return (
       <SlideTransition>
         <Stack>{headerComponent}</Stack>
@@ -517,12 +536,13 @@ export const StakeInput: React.FC<StakeInputProps & StakeRouteProps> = ({
             borderBottomRadius='xl'
           >
             <ButtonWalletPredicate
-              isValidWallet={Boolean(isChainSupportedByWallet)}
+              isValidWallet={Boolean(isChainSupportedByWallet && !isAccountLoading)}
               isDisabled={Boolean(
                 errors.amountFieldInput ||
                   !runeAddress ||
                   !isValidStakingAmount ||
                   !(isStakeFeesSuccess || isGetApprovalFeesSuccess) ||
+                  isAccountLoading ||
                   !cooldownPeriod,
               )}
               size='lg'
@@ -530,13 +550,12 @@ export const StakeInput: React.FC<StakeInputProps & StakeRouteProps> = ({
               onClick={handleWarning}
               isLoading={isGetApprovalFeesLoading || isStakeFeesLoading}
               colorScheme={
-                Boolean(errors.amountFieldInput || errors.manualRuneAddress) ? 'red' : 'blue'
+                Boolean(errors.amountFieldInput || errors.manualRuneAddress) && !isAccountLoading
+                  ? 'red'
+                  : 'blue'
               }
             >
-              {errors.amountFieldInput?.message ||
-                errors.manualRuneAddress?.message ||
-                chainNotSupportedByWalletCopy ||
-                translate('RFOX.stake')}
+              {submitButtonText}
             </ButtonWalletPredicate>
           </CardFooter>
         </FormProvider>

--- a/src/pages/RFOX/components/Stake/StakeInput.tsx
+++ b/src/pages/RFOX/components/Stake/StakeInput.tsx
@@ -33,7 +33,7 @@ import { marketApi } from 'state/slices/marketDataSlice/marketDataSlice'
 import {
   selectAssetById,
   selectFeeAssetByChainId,
-  selectIsAccountLoading,
+  selectIsAccountsLoading,
   selectMarketDataByAssetIdUserCurrency,
   selectMarketDataByFilter,
   selectPortfolioCryptoPrecisionBalanceByFilter,
@@ -84,7 +84,7 @@ export const StakeInput: React.FC<StakeInputProps & StakeRouteProps> = ({
   const { selectedAssetId, setSelectedAssetId, selectedAssetAccountId, stakingAssetAccountId } =
     useRFOXContext()
 
-  const isAccountLoading = useAppSelector(selectIsAccountLoading)
+  const isAccountsLoading = useAppSelector(selectIsAccountsLoading)
   const isBridgeRequired = stakingAssetId !== selectedAssetId
   const dispatch = useAppDispatch()
   const translate = useTranslate()
@@ -421,7 +421,7 @@ export const StakeInput: React.FC<StakeInputProps & StakeRouteProps> = ({
   }, [isChainSupportedByWallet, translate])
 
   const submitButtonText = useMemo(() => {
-    if (isAccountLoading) return translate('common.loadingAccounts')
+    if (isAccountsLoading) return translate('common.accountsLoading')
 
     return (
       errors.amountFieldInput?.message ||
@@ -434,12 +434,12 @@ export const StakeInput: React.FC<StakeInputProps & StakeRouteProps> = ({
     errors.amountFieldInput,
     errors.manualRuneAddress,
     translate,
-    isAccountLoading,
+    isAccountsLoading,
   ])
 
   if (!selectedAsset) return null
 
-  if (!stakingAssetAccountAddress && !isAccountLoading)
+  if (!stakingAssetAccountAddress && !isAccountsLoading)
     return (
       <SlideTransition>
         <Stack>{headerComponent}</Stack>
@@ -536,13 +536,13 @@ export const StakeInput: React.FC<StakeInputProps & StakeRouteProps> = ({
             borderBottomRadius='xl'
           >
             <ButtonWalletPredicate
-              isValidWallet={Boolean(isChainSupportedByWallet && !isAccountLoading)}
+              isValidWallet={Boolean(isChainSupportedByWallet && !isAccountsLoading)}
               isDisabled={Boolean(
                 errors.amountFieldInput ||
                   !runeAddress ||
                   !isValidStakingAmount ||
                   !(isStakeFeesSuccess || isGetApprovalFeesSuccess) ||
-                  isAccountLoading ||
+                  isAccountsLoading ||
                   !cooldownPeriod,
               )}
               size='lg'
@@ -550,7 +550,7 @@ export const StakeInput: React.FC<StakeInputProps & StakeRouteProps> = ({
               onClick={handleWarning}
               isLoading={isGetApprovalFeesLoading || isStakeFeesLoading}
               colorScheme={
-                Boolean(errors.amountFieldInput || errors.manualRuneAddress) && !isAccountLoading
+                Boolean(errors.amountFieldInput || errors.manualRuneAddress) && !isAccountsLoading
                   ? 'red'
                   : 'blue'
               }

--- a/src/state/slices/portfolioSlice/__snapshots__/portfolioSlice.test.ts.snap
+++ b/src/state/slices/portfolioSlice/__snapshots__/portfolioSlice.test.ts.snap
@@ -30,7 +30,7 @@ exports[`portfolioSlice > reducers > upsertPortfolio > Bitcoin > should update s
     ],
   },
   "enabledAccountIds": {},
-  "isAccountLoading": false,
+  "isAccountsLoading": false,
   "wallet": {
     "byId": {},
     "ids": [],
@@ -79,7 +79,7 @@ exports[`portfolioSlice > reducers > upsertPortfolio > Bitcoin > should update s
     ],
   },
   "enabledAccountIds": {},
-  "isAccountLoading": false,
+  "isAccountsLoading": false,
   "wallet": {
     "byId": {},
     "ids": [],
@@ -151,7 +151,7 @@ exports[`portfolioSlice > reducers > upsertPortfolio > Ethereum and bitcoin > sh
     ],
   },
   "enabledAccountIds": {},
-  "isAccountLoading": false,
+  "isAccountsLoading": false,
   "wallet": {
     "byId": {},
     "ids": [],
@@ -208,7 +208,7 @@ exports[`portfolioSlice > reducers > upsertPortfolio > Ethereum and bitcoin > sh
     ],
   },
   "enabledAccountIds": {},
-  "isAccountLoading": false,
+  "isAccountsLoading": false,
   "wallet": {
     "byId": {},
     "ids": [],
@@ -248,7 +248,7 @@ exports[`portfolioSlice > reducers > upsertPortfolio > ethereum > should update 
     ],
   },
   "enabledAccountIds": {},
-  "isAccountLoading": false,
+  "isAccountsLoading": false,
   "wallet": {
     "byId": {},
     "ids": [],
@@ -301,7 +301,7 @@ exports[`portfolioSlice > reducers > upsertPortfolio > ethereum > should update 
     ],
   },
   "enabledAccountIds": {},
-  "isAccountLoading": false,
+  "isAccountsLoading": false,
   "wallet": {
     "byId": {},
     "ids": [],

--- a/src/state/slices/portfolioSlice/__snapshots__/portfolioSlice.test.ts.snap
+++ b/src/state/slices/portfolioSlice/__snapshots__/portfolioSlice.test.ts.snap
@@ -151,7 +151,7 @@ exports[`portfolioSlice > reducers > upsertPortfolio > Ethereum and bitcoin > sh
     ],
   },
   "enabledAccountIds": {},
-  "isAccountLoading": false, 
+  "isAccountLoading": false,
   "wallet": {
     "byId": {},
     "ids": [],
@@ -208,7 +208,7 @@ exports[`portfolioSlice > reducers > upsertPortfolio > Ethereum and bitcoin > sh
     ],
   },
   "enabledAccountIds": {},
-  "isAccountLoading": false, 
+  "isAccountLoading": false,
   "wallet": {
     "byId": {},
     "ids": [],
@@ -248,7 +248,7 @@ exports[`portfolioSlice > reducers > upsertPortfolio > ethereum > should update 
     ],
   },
   "enabledAccountIds": {},
-  "isAccountLoading": false, 
+  "isAccountLoading": false,
   "wallet": {
     "byId": {},
     "ids": [],
@@ -301,7 +301,7 @@ exports[`portfolioSlice > reducers > upsertPortfolio > ethereum > should update 
     ],
   },
   "enabledAccountIds": {},
-  "isAccountLoading": false, 
+  "isAccountLoading": false,
   "wallet": {
     "byId": {},
     "ids": [],

--- a/src/state/slices/portfolioSlice/__snapshots__/portfolioSlice.test.ts.snap
+++ b/src/state/slices/portfolioSlice/__snapshots__/portfolioSlice.test.ts.snap
@@ -30,6 +30,7 @@ exports[`portfolioSlice > reducers > upsertPortfolio > Bitcoin > should update s
     ],
   },
   "enabledAccountIds": {},
+  "isAccountLoading": false,
   "wallet": {
     "byId": {},
     "ids": [],
@@ -78,6 +79,7 @@ exports[`portfolioSlice > reducers > upsertPortfolio > Bitcoin > should update s
     ],
   },
   "enabledAccountIds": {},
+  "isAccountLoading": false,
   "wallet": {
     "byId": {},
     "ids": [],
@@ -149,6 +151,7 @@ exports[`portfolioSlice > reducers > upsertPortfolio > Ethereum and bitcoin > sh
     ],
   },
   "enabledAccountIds": {},
+  "isAccountLoading": false, 
   "wallet": {
     "byId": {},
     "ids": [],
@@ -205,6 +208,7 @@ exports[`portfolioSlice > reducers > upsertPortfolio > Ethereum and bitcoin > sh
     ],
   },
   "enabledAccountIds": {},
+  "isAccountLoading": false, 
   "wallet": {
     "byId": {},
     "ids": [],
@@ -244,6 +248,7 @@ exports[`portfolioSlice > reducers > upsertPortfolio > ethereum > should update 
     ],
   },
   "enabledAccountIds": {},
+  "isAccountLoading": false, 
   "wallet": {
     "byId": {},
     "ids": [],
@@ -296,6 +301,7 @@ exports[`portfolioSlice > reducers > upsertPortfolio > ethereum > should update 
     ],
   },
   "enabledAccountIds": {},
+  "isAccountLoading": false, 
   "wallet": {
     "byId": {},
     "ids": [],

--- a/src/state/slices/portfolioSlice/__snapshots__/portfolioSlice.test.ts.snap
+++ b/src/state/slices/portfolioSlice/__snapshots__/portfolioSlice.test.ts.snap
@@ -30,7 +30,7 @@ exports[`portfolioSlice > reducers > upsertPortfolio > Bitcoin > should update s
     ],
   },
   "enabledAccountIds": {},
-  "isAccountsLoading": false,
+  "isAccountMetadataLoading": false,
   "wallet": {
     "byId": {},
     "ids": [],
@@ -79,7 +79,7 @@ exports[`portfolioSlice > reducers > upsertPortfolio > Bitcoin > should update s
     ],
   },
   "enabledAccountIds": {},
-  "isAccountsLoading": false,
+  "isAccountMetadataLoading": false,
   "wallet": {
     "byId": {},
     "ids": [],
@@ -151,7 +151,7 @@ exports[`portfolioSlice > reducers > upsertPortfolio > Ethereum and bitcoin > sh
     ],
   },
   "enabledAccountIds": {},
-  "isAccountsLoading": false,
+  "isAccountMetadataLoading": false,
   "wallet": {
     "byId": {},
     "ids": [],
@@ -208,7 +208,7 @@ exports[`portfolioSlice > reducers > upsertPortfolio > Ethereum and bitcoin > sh
     ],
   },
   "enabledAccountIds": {},
-  "isAccountsLoading": false,
+  "isAccountMetadataLoading": false,
   "wallet": {
     "byId": {},
     "ids": [],
@@ -248,7 +248,7 @@ exports[`portfolioSlice > reducers > upsertPortfolio > ethereum > should update 
     ],
   },
   "enabledAccountIds": {},
-  "isAccountsLoading": false,
+  "isAccountMetadataLoading": false,
   "wallet": {
     "byId": {},
     "ids": [],
@@ -301,7 +301,7 @@ exports[`portfolioSlice > reducers > upsertPortfolio > ethereum > should update 
     ],
   },
   "enabledAccountIds": {},
-  "isAccountsLoading": false,
+  "isAccountMetadataLoading": false,
   "wallet": {
     "byId": {},
     "ids": [],

--- a/src/state/slices/portfolioSlice/portfolioSlice.ts
+++ b/src/state/slices/portfolioSlice/portfolioSlice.ts
@@ -36,8 +36,8 @@ export const portfolio = createSlice({
     clear: () => {
       return initialState
     },
-    setIsAccountsLoading: (state, { payload }: { payload: boolean }) => {
-      state.isAccountsLoading = payload
+    setIsAccountMetadataLoading: (state, { payload }: { payload: boolean }) => {
+      state.isAccountMetadataLoading = payload
     },
     setWalletMeta: (
       state,

--- a/src/state/slices/portfolioSlice/portfolioSlice.ts
+++ b/src/state/slices/portfolioSlice/portfolioSlice.ts
@@ -36,8 +36,8 @@ export const portfolio = createSlice({
     clear: () => {
       return initialState
     },
-    setIsAccountLoading: (state, { payload }: { payload: boolean }) => {
-      state.isAccountLoading = payload
+    setIsAccountsLoading: (state, { payload }: { payload: boolean }) => {
+      state.isAccountsLoading = payload
     },
     setWalletMeta: (
       state,

--- a/src/state/slices/portfolioSlice/portfolioSlice.ts
+++ b/src/state/slices/portfolioSlice/portfolioSlice.ts
@@ -36,6 +36,9 @@ export const portfolio = createSlice({
     clear: () => {
       return initialState
     },
+    setIsAccountLoading: (state, { payload }: { payload: boolean }) => {
+      state.isAccountLoading = payload
+    },
     setWalletMeta: (
       state,
       { payload }: { payload: Omit<WalletMetaPayload, 'walletSupportedChainIds'> | undefined },

--- a/src/state/slices/portfolioSlice/portfolioSliceCommon.ts
+++ b/src/state/slices/portfolioSlice/portfolioSliceCommon.ts
@@ -58,7 +58,7 @@ export type Portfolio = {
    * The app can run account discovery taking a lot of time and slowing down the portfolio initialization,
    * we use this key to gracefully handle this state in any part of the app
    */
-  isAccountLoading: boolean
+  isAccountsLoading: boolean
   /**
    * lookup of accountId -> accountMetadata
    */
@@ -78,7 +78,7 @@ export type Portfolio = {
 }
 
 export const initialState: Portfolio = {
-  isAccountLoading: false,
+  isAccountsLoading: false,
   accounts: {
     byId: {},
     ids: [],

--- a/src/state/slices/portfolioSlice/portfolioSliceCommon.ts
+++ b/src/state/slices/portfolioSlice/portfolioSliceCommon.ts
@@ -54,11 +54,7 @@ export type ConnectWallet = {
 }
 
 export type Portfolio = {
-  /**
-   * The app can run account discovery taking a lot of time and slowing down the portfolio initialization,
-   * we use this key to gracefully handle this state in any part of the app
-   */
-  isAccountsLoading: boolean
+  isAccountMetadataLoading: boolean
   /**
    * lookup of accountId -> accountMetadata
    */
@@ -78,7 +74,7 @@ export type Portfolio = {
 }
 
 export const initialState: Portfolio = {
-  isAccountsLoading: false,
+  isAccountMetadataLoading: false,
   accounts: {
     byId: {},
     ids: [],

--- a/src/state/slices/portfolioSlice/portfolioSliceCommon.ts
+++ b/src/state/slices/portfolioSlice/portfolioSliceCommon.ts
@@ -55,6 +55,11 @@ export type ConnectWallet = {
 
 export type Portfolio = {
   /**
+   * The app can run account discovery taking a lot of time and slowing down the portfolio initialization,
+   * we use this key to gracefully handle this state in any part of the app
+   */
+  isAccountLoading: boolean
+  /**
    * lookup of accountId -> accountMetadata
    */
   accountMetadata: PortfolioAccountMetadata
@@ -73,6 +78,7 @@ export type Portfolio = {
 }
 
 export const initialState: Portfolio = {
+  isAccountLoading: false,
   accounts: {
     byId: {},
     ids: [],

--- a/src/state/slices/portfolioSlice/selectors.ts
+++ b/src/state/slices/portfolioSlice/selectors.ts
@@ -1108,4 +1108,4 @@ export const selectWalletConnectedChainIdsSorted = createDeepEqualOutputSelector
   },
 )
 
-export const selectIsAccountLoading = (state: ReduxState) => state.portfolio.isAccountLoading
+export const selectIsAccountsLoading = (state: ReduxState) => state.portfolio.isAccountsLoading

--- a/src/state/slices/portfolioSlice/selectors.ts
+++ b/src/state/slices/portfolioSlice/selectors.ts
@@ -1107,3 +1107,5 @@ export const selectWalletConnectedChainIdsSorted = createDeepEqualOutputSelector
     ).map(({ chainId }) => chainId)
   },
 )
+
+export const selectIsAccountLoading = (state: ReduxState) => state.portfolio.isAccountLoading

--- a/src/state/slices/portfolioSlice/selectors.ts
+++ b/src/state/slices/portfolioSlice/selectors.ts
@@ -1108,4 +1108,5 @@ export const selectWalletConnectedChainIdsSorted = createDeepEqualOutputSelector
   },
 )
 
-export const selectIsAccountsLoading = (state: ReduxState) => state.portfolio.isAccountsLoading
+export const selectIsAccountMetadataLoading = (state: ReduxState) =>
+  state.portfolio.isAccountMetadataLoading

--- a/src/test/mocks/store.ts
+++ b/src/test/mocks/store.ts
@@ -42,7 +42,7 @@ export const mockStore: ReduxState = {
   opportunitiesApi: mockApiFactory('opportunitiesApi' as const),
   abiApi: mockApiFactory('abiApi' as const),
   portfolio: {
-    isAccountLoading: false,
+    isAccountsLoading: false,
     accounts: {
       byId: {},
       ids: [],

--- a/src/test/mocks/store.ts
+++ b/src/test/mocks/store.ts
@@ -42,7 +42,7 @@ export const mockStore: ReduxState = {
   opportunitiesApi: mockApiFactory('opportunitiesApi' as const),
   abiApi: mockApiFactory('abiApi' as const),
   portfolio: {
-    isAccountsLoading: false,
+    isAccountMetadataLoading: false,
     accounts: {
       byId: {},
       ids: [],

--- a/src/test/mocks/store.ts
+++ b/src/test/mocks/store.ts
@@ -42,6 +42,7 @@ export const mockStore: ReduxState = {
   opportunitiesApi: mockApiFactory('opportunitiesApi' as const),
   abiApi: mockApiFactory('abiApi' as const),
   portfolio: {
+    isAccountLoading: false,
     accounts: {
       byId: {},
       ids: [],


### PR DESCRIPTION
## Description

- I added a prop to the portfolio slice: `isAccountLoading`
- This prop is turned to true at the start of the account discovery effect, then turned false when it ends
- Consumed it in the swapper and rfox to disable the button and adapt the text if we are actually running account discovery

<!-- Please describe your changes -->

## Issue (if applicable)

<!-----------------------------------------------------------------------------
If applicable, please link to the github issue and put `closes #XXXX` in your comment to auto-close the issue that your PR fixes.
------------------------------------------------------------------------------>

closes #7419

## Risk
Let's say high risk because swapper button is disabled in case this is buggy

> High Risk PRs Require 2 approvals

<!-----------------------------------------------------------------------------
Outline the scope of your changes and the risk associated with them. You must use your discretion as an engineer to determine the potential impact of your changes.

WARNING: If your PR introduces a new on-chain transaction or modifies an existing one, please add the "High-Risk" label to this PR and ask for 2 reviewers to approve it before merging.

E.g. an upgrade to `hdwallet` or core state management would be considered higher risk, and might require a full regression test. UI or isolated view changes, or something behind a feature flag may have near zero risk. Small bug fixes might require testing isolated to the specific fix.
------------------------------------------------------------------------------>

> What protocols, transaction types, wallets or contract interactions might be affected by this PR?

## Testing
- Go to Swapper (and rFOX)
- Clear you chrome cache manually and refresh the page
- Import a native wallet
- check the button of the swapper and stake component of rFOX, it should be disabled and showing `Loading Accounts`

<!-----------------------------------------------------------------------------
We treat every PR to be merged with the same scrutiny as if we were merging directly to production.

Your PR will not be merged if you do not complete the sections below for our engineering and operations teams to test.
------------------------------------------------------------------------------>

### Engineering
n/a
<!-----------------------------------------------------------------------------
Include sufficient information here for an engineer to test your PR. This may include how to test locally, in a built environment, changes to infrastructure etc.
------------------------------------------------------------------------------>

### Operations
n/a
- [ ] :checkered_flag: My feature is behind a flag and doesn't require operations testing (yet)

<!-----------------------------------------------------------------------------
If your changes have a user-facing impact, describe how a non-technical QA team can functionally test your changes in a preview environment.

If they are not user-facing please describe how to test for any regressions that may occur.
------------------------------------------------------------------------------>

## Screenshots (if applicable)

rFOX
https://jam.dev/c/e28afd3a-84dd-4d7f-9630-72534531b49b

Swapper
https://jam.dev/c/ce72a79e-e372-4cea-bdba-0926d26b005c
