### PR TITLE
fix: thorchain LP sym withdraw RUNE support detection

### DIFF
--- a/src/lib/utils/thorchain/hooks/useSendThorTx.tsx
+++ b/src/lib/utils/thorchain/hooks/useSendThorTx.tsx
@@ -270,8 +270,10 @@ export const useSendThorTx = ({
     if (!accountId) return
     if (!transactionType) return
     if (!estimateFeesArgs) return
-    if (accountNumber === undefined) return
     if (isToken(asset.assetId) && !inboundAddressData) return
+
+    await checkLedgerAppOpenIfLedgerConnected(asset.chainId)
+    if (accountNumber === undefined) return
 
     if (
       action !== 'withdrawRunepool' &&
@@ -279,8 +281,6 @@ export const useSendThorTx = ({
       !bn(amountOrDustCryptoBaseUnit).gt(0)
     )
       throw new Error('invalid amount specified')
-
-    await checkLedgerAppOpenIfLedgerConnected(asset.chainId)
 
     const { account } = fromAccountId(accountId)
 

--- a/src/lib/utils/thorchain/hooks/useSendThorTx.tsx
+++ b/src/lib/utils/thorchain/hooks/useSendThorTx.tsx
@@ -270,10 +270,8 @@ export const useSendThorTx = ({
     if (!accountId) return
     if (!transactionType) return
     if (!estimateFeesArgs) return
-    if (isToken(asset.assetId) && !inboundAddressData) return
-
-    await checkLedgerAppOpenIfLedgerConnected(asset.chainId)
     if (accountNumber === undefined) return
+    if (isToken(asset.assetId) && !inboundAddressData) return
 
     if (
       action !== 'withdrawRunepool' &&
@@ -281,6 +279,8 @@ export const useSendThorTx = ({
       !bn(amountOrDustCryptoBaseUnit).gt(0)
     )
       throw new Error('invalid amount specified')
+
+    await checkLedgerAppOpenIfLedgerConnected(asset.chainId)
 
     const { account } = fromAccountId(accountId)
 

--- a/src/lib/utils/thorchain/hooks/useSendThorTx.tsx
+++ b/src/lib/utils/thorchain/hooks/useSendThorTx.tsx
@@ -270,10 +270,10 @@ export const useSendThorTx = ({
     if (!accountId) return
     if (!transactionType) return
     if (!estimateFeesArgs) return
+    if (accountNumber === undefined) return
     if (isToken(asset.assetId) && !inboundAddressData) return
 
     await checkLedgerAppOpenIfLedgerConnected(asset.chainId)
-    if (accountNumber === undefined) return
 
     if (
       action !== 'withdrawRunepool' &&

--- a/src/pages/ThorChainLP/components/RemoveLiquidity/RemoveLiquidityInput.tsx
+++ b/src/pages/ThorChainLP/components/RemoveLiquidity/RemoveLiquidityInput.tsx
@@ -825,9 +825,9 @@ export const RemoveLiquidityInput: React.FC<RemoveLiquidityInputProps> = ({
     [isSnapInstalled, runeAccountIds, wallet],
   )
 
-  const isUnsupportedSymWithdraw = useMemo(
-    () => withdrawType === 'sym' && !walletSupportsRune,
-    [withdrawType, walletSupportsRune],
+  const isUnsupportedWithdraw = useMemo(
+    () => currentAccountIdByChainId[thorchainChainId] && !walletSupportsRune,
+    [currentAccountIdByChainId, walletSupportsRune],
   )
 
   const hasEnoughPoolAssetFeeAssetBalanceForTx = useMemo(() => {
@@ -901,7 +901,7 @@ export const RemoveLiquidityInput: React.FC<RemoveLiquidityInputProps> = ({
   ])
 
   const errorCopy = useMemo(() => {
-    if (isUnsupportedSymWithdraw) return translate('common.unsupportedNetwork')
+    if (isUnsupportedWithdraw) return translate('common.unsupportedNetwork')
     if (isTradingActive === false) return translate('common.poolHalted')
     if (!isThorchainLpWithdrawEnabled) return translate('common.poolDisabled')
     if (poolAssetFeeAsset && !hasEnoughPoolAssetFeeAssetBalanceForTx)
@@ -918,7 +918,7 @@ export const RemoveLiquidityInput: React.FC<RemoveLiquidityInputProps> = ({
     hasEnoughRuneBalanceForTx,
     isThorchainLpWithdrawEnabled,
     isTradingActive,
-    isUnsupportedSymWithdraw,
+    isUnsupportedWithdraw,
     poolAssetFeeAsset,
     runeAsset,
     translate,
@@ -926,7 +926,7 @@ export const RemoveLiquidityInput: React.FC<RemoveLiquidityInputProps> = ({
 
   const maybeOpportunityNotSupportedExplainer = useMemo(() => {
     if (!poolAsset || !runeAsset) return null
-    if (!isUnsupportedSymWithdraw) return null
+    if (!isUnsupportedWithdraw) return null
 
     return (
       <Alert status='error' mx={-2} width='auto'>
@@ -936,7 +936,7 @@ export const RemoveLiquidityInput: React.FC<RemoveLiquidityInputProps> = ({
         </AlertDescription>
       </Alert>
     )
-  }, [isUnsupportedSymWithdraw, poolAsset, runeAsset, translate])
+  }, [isUnsupportedWithdraw, poolAsset, runeAsset, translate])
 
   const confirmCopy = useMemo(() => {
     if (errorCopy) return errorCopy
@@ -1074,7 +1074,7 @@ export const RemoveLiquidityInput: React.FC<RemoveLiquidityInputProps> = ({
             colorScheme={errorCopy ? 'red' : 'blue'}
             onClick={handleSubmitIntent}
             isDisabled={
-              isUnsupportedSymWithdraw ||
+              isUnsupportedWithdraw ||
               isTradingActive === false ||
               !isThorchainLpWithdrawEnabled ||
               !hasEnoughPoolAssetFeeAssetBalanceForTx ||


### PR DESCRIPTION
## Description

Fixes the case where there *is* a RUNE position address for a withdraw (i.e, it's a sym position), but no RUNE account in the portfolio (i.e, withdrawing asymmetrically on the asset side, while having accounts for the asset connected)

## Issue (if applicable)

<!-----------------------------------------------------------------------------
If applicable, please link to the github issue and put `closes #XXXX` in your comment to auto-close the issue that your PR fixes.
------------------------------------------------------------------------------>

closes https://github.com/shapeshift/web/issues/7634

## Risk

> High Risk PRs Require 2 approvals

<!-----------------------------------------------------------------------------
Outline the scope of your changes and the risk associated with them. You must use your discretion as an engineer to determine the potential impact of your changes.

WARNING: If your PR introduces a new on-chain transaction or modifies an existing one, please add the "High-Risk" label to this PR and ask for 2 reviewers to approve it before merging.

E.g. an upgrade to `hdwallet` or core state management would be considered higher risk, and might require a full regression test. UI or isolated view changes, or something behind a feature flag may have near zero risk. Small bug fixes might require testing isolated to the specific fix.
------------------------------------------------------------------------------>

Low to none

> What protocols, transaction types, wallets or contract interactions might be affected by this PR?

## Testing

<!-----------------------------------------------------------------------------
We treat every PR to be merged with the same scrutiny as if we were merging directly to production.

Your PR will not be merged if you do not complete the sections below for our engineering and operations teams to test.
------------------------------------------------------------------------------>

Ensure asym asset withdraws of a sym position correctly guard against RUNE chain not supported

### Engineering

<!-----------------------------------------------------------------------------
Include sufficient information here for an engineer to test your PR. This may include how to test locally, in a built environment, changes to infrastructure etc.
------------------------------------------------------------------------------>

- ^

### Operations

- [ ] :checkered_flag: My feature is behind a flag and doesn't require operations testing (yet)

<!-----------------------------------------------------------------------------
If your changes have a user-facing impact, describe how a non-technical QA team can functionally test your changes in a preview environment.

If they are not user-facing please describe how to test for any regressions that may occur.
------------------------------------------------------------------------------>

- ^

## Screenshots (if applicable)

<!-- av pr metadata
This information is embedded by the av CLI when creating PRs to track the status of stacks when using Aviator. Please do not delete or edit this section of the PR.
```
{"parent":"feat_ledger_ack_lp","parentHead":"6016809c57fd76581389f3e016a34ed670712176","parentPull":7632,"trunk":"develop"}
```
-->

<img width="528" alt="Screenshot 2024-08-27 at 18 52 21" src="https://github.com/user-attachments/assets/5168a8e5-f53b-4681-80dd-763bcd671d3c">
<img width="495" alt="Screenshot 2024-08-27 at 18 52 08" src="https://github.com/user-attachments/assets/f47a1438-8f1e-448b-ac05-e8227a529c69">



<!-- av pr metadata
This information is embedded by the av CLI when creating PRs to track the status of stacks when using Aviator. Please do not delete or edit this section of the PR.
```
{"parent":"develop","parentHead":"","trunk":"develop"}
```
-->
