### PR TITLE
feat: prompt user to open ledger app on device with single click

### DIFF
--- a/src/components/Modals/LedgerOpenApp/hooks/useLedgerAppDetails.tsx
+++ b/src/components/Modals/LedgerOpenApp/hooks/useLedgerAppDetails.tsx
@@ -1,17 +1,54 @@
 import type { ChainId } from '@shapeshiftoss/caip'
 import { ethAssetId } from '@shapeshiftoss/caip'
 import { isEvmChainId } from '@shapeshiftoss/chain-adapters'
+import { KnownChainIds } from '@shapeshiftoss/types'
+import { assertUnreachable } from '@shapeshiftoss/utils'
 import { useMemo } from 'react'
 import { selectAssetById, selectFeeAssetByChainId } from 'state/slices/selectors'
 import { useAppSelector } from 'state/store'
+
+// Note these are hardcoded to the ledger app names that are currently supported by the Ledger SDK.
+// The name is used by the SDK to prompt the user to open the correct app on their device. A
+// mismatch will cause the this feature to break. Be careful when modifying these, as it could break
+// Ledger device support.
+export const getLedgerAppName = (_chainId: ChainId) => {
+  const chainId = _chainId as KnownChainIds
+  switch (chainId) {
+    case KnownChainIds.ArbitrumMainnet:
+    case KnownChainIds.AvalancheMainnet:
+    case KnownChainIds.ArbitrumNovaMainnet:
+    case KnownChainIds.BaseMainnet:
+    case KnownChainIds.BnbSmartChainMainnet:
+    case KnownChainIds.EthereumMainnet:
+    case KnownChainIds.GnosisMainnet:
+    case KnownChainIds.OptimismMainnet:
+    case KnownChainIds.PolygonMainnet:
+      return 'Ethereum'
+    case KnownChainIds.BitcoinCashMainnet:
+      return 'Bitcoin Cash'
+    case KnownChainIds.BitcoinMainnet:
+      return 'Bitcoin'
+    case KnownChainIds.CosmosMainnet:
+      return 'Cosmos'
+    case KnownChainIds.DogecoinMainnet:
+      return 'Dogecoin'
+    case KnownChainIds.LitecoinMainnet:
+      return 'Litecoin'
+    case KnownChainIds.ThorchainMainnet:
+      return 'THORChain'
+    default:
+      assertUnreachable(chainId)
+  }
+
+  throw Error(`Unsupported chainId: ${chainId}`)
+}
 
 export const useLedgerAppDetails = (chainId: ChainId) => {
   const feeAsset = useAppSelector(state => selectFeeAssetByChainId(state, chainId))
   const ethAsset = useAppSelector(state => selectAssetById(state, ethAssetId))
   const appName = useMemo(() => {
-    if (isEvmChainId(chainId)) return ethAsset?.networkName
-    return feeAsset?.networkName
-  }, [feeAsset?.networkName, chainId, ethAsset?.networkName])
+    return getLedgerAppName(chainId)
+  }, [chainId])
   const appAsset = useMemo(() => {
     if (isEvmChainId(chainId)) return ethAsset
     return feeAsset

--- a/src/hooks/useLedgerOpenApp/useLedgerOpenApp.tsx
+++ b/src/hooks/useLedgerOpenApp/useLedgerOpenApp.tsx
@@ -4,6 +4,7 @@ import { isLedger } from '@shapeshiftoss/hdwallet-ledger'
 import { KnownChainIds } from '@shapeshiftoss/types'
 import { assertUnreachable } from '@shapeshiftoss/utils'
 import { useCallback } from 'react'
+import { getLedgerAppName } from 'components/Modals/LedgerOpenApp/hooks/useLedgerAppDetails'
 import { useModal } from 'hooks/useModal/useModal'
 import { useWallet } from 'hooks/useWallet/useWallet'
 
@@ -98,6 +99,10 @@ export const useLedgerOpenApp = ({ isSigning }: UseLedgerOpenAppProps) => {
           resolve()
           return
         }
+
+        // Prompt the "open app" notification on the device so users can open the correct app with 1 click
+        const ledgerWallet = wallet && isLedger(wallet) ? wallet : undefined
+        ledgerWallet?.openApp(getLedgerAppName(chainId))
 
         // Poll the Ledger every second to see if the correct app is open
         const intervalId = setInterval(async () => {


### PR DESCRIPTION
## Description

Pushes a prompt to the ledger device to open the correct app, allowing them to confirm and have it open immediately without having to navigate to it on the device. This is the same behavior we see in ledger live.

The user must be on the home page on the device for this prompt to appear.

## Issue (if applicable)

<!-----------------------------------------------------------------------------
If applicable, please link to the github issue and put `closes #XXXX` in your comment to auto-close the issue that your PR fixes.
------------------------------------------------------------------------------>

relates to #6814

## Risk

> High Risk PRs Require 2 approvals

Low risk. If the request fails the device ignores the prompt.

> What protocols, transaction types, wallets or contract interactions might be affected by this PR?

## Testing

When getting prompted to "Open the XYZ App" on ledger, check the device displays the same notification on the device.

The user must be on the home page on the device for this prompt to appear.

This should work when:
- managing accounts
- verifying addresses
- signing transactions

### Engineering

<!-----------------------------------------------------------------------------
Include sufficient information here for an engineer to test your PR. This may include how to test locally, in a built environment, changes to infrastructure etc.
------------------------------------------------------------------------------>

### Operations

- [ ] :checkered_flag: My feature is behind a flag and doesn't require operations testing (yet)

<!-----------------------------------------------------------------------------
If your changes have a user-facing impact, describe how a non-technical QA team can functionally test your changes in a preview environment.

If they are not user-facing please describe how to test for any regressions that may occur.
------------------------------------------------------------------------------>

## Screenshots (if applicable)
