### PR TITLE
fix: icon alignment in earn withdraw and deposit statuses

### DIFF
--- a/src/features/defi/providers/cosmos/components/CosmosManager/Deposit/components/Status.tsx
+++ b/src/features/defi/providers/cosmos/components/CosmosManager/Deposit/components/Status.tsx
@@ -108,7 +108,7 @@ export const Status = () => {
         }
       default:
         return {
-          statusIcon: <AssetIcon size='xs' src={asset?.icon} />,
+          statusIcon: <AssetIcon size='xs' src={asset?.icon} justifyContent='center' />,
           statusText: StatusTextEnum.pending,
           statusBody: translate('modals.stake.status.pending'),
           statusBg: 'transparent',

--- a/src/features/defi/providers/cosmos/components/CosmosManager/Withdraw/components/Status.tsx
+++ b/src/features/defi/providers/cosmos/components/CosmosManager/Withdraw/components/Status.tsx
@@ -126,7 +126,7 @@ export const Status: React.FC<StatusProps> = ({ accountId }) => {
         }
       default:
         return {
-          statusIcon: <AssetIcon size='xs' src={asset?.icon} />,
+          statusIcon: <AssetIcon size='xs' src={asset?.icon} justifyContent='center' />,
           statusText: StatusTextEnum.pending,
           statusBg: 'transparent',
           statusBody: translate('modals.withdraw.status.pending'),

--- a/src/features/defi/providers/foxy/components/FoxyManager/Deposit/components/Status.tsx
+++ b/src/features/defi/providers/foxy/components/FoxyManager/Deposit/components/Status.tsx
@@ -57,7 +57,7 @@ export const Status = () => {
         }
       default:
         return {
-          statusIcon: <AssetIcon size='xs' src={asset?.icon} />,
+          statusIcon: <AssetIcon size='xs' src={asset?.icon} justifyContent='center' />,
           statusText: StatusTextEnum.pending,
           statusBody: translate('modals.deposit.status.pending'),
           statusBg: 'transparent',

--- a/src/features/defi/providers/foxy/components/FoxyManager/Withdraw/components/Status.tsx
+++ b/src/features/defi/providers/foxy/components/FoxyManager/Withdraw/components/Status.tsx
@@ -71,7 +71,7 @@ export const Status: React.FC<StatusProps> = ({ accountId }) => {
         }
       default:
         return {
-          statusIcon: <AssetIcon size='xs' src={underlyingAsset?.icon} />,
+          statusIcon: <AssetIcon size='xs' src={underlyingAsset?.icon} justifyContent='center' />,
           statusText: StatusTextEnum.pending,
           statusBg: 'transparent',
           statusBody: translate('modals.withdraw.status.pending'),

--- a/src/features/defi/providers/thorchain-savers/components/ThorchainSaversManager/Withdraw/components/Status.tsx
+++ b/src/features/defi/providers/thorchain-savers/components/ThorchainSaversManager/Withdraw/components/Status.tsx
@@ -157,7 +157,7 @@ export const Status: React.FC<StatusProps> = ({ accountId }) => {
         }
       default:
         return {
-          statusIcon: <AssetIcon size='xs' src={asset?.icon} />,
+          statusIcon: <AssetIcon size='xs' src={asset?.icon} justifyContent='center' />,
           statusText: StatusTextEnum.pending,
           statusBg: 'transparent',
           statusBody: translate('modals.withdraw.status.pending'),


### PR DESCRIPTION
## Description

I fixed this bug for THORChain deposits but I noticed it was everywhere in the earn section (foxy, cosmos and thorchain savers...)

The asset icon was not centered in the loader

The actual bug: https://jam.dev/c/db8d6aee-40ee-44e6-a55d-4aef9116c7c7

<!-- Please describe your changes -->

## Issue (if applicable)

<!-----------------------------------------------------------------------------
If applicable, please link to the github issue and put `closes #XXXX` in your comment to auto-close the issue that your PR fixes.
------------------------------------------------------------------------------>
No issue

## Risk
Low risk
> High Risk PRs Require 2 approvals

<!-----------------------------------------------------------------------------
Outline the scope of your changes and the risk associated with them. You must use your discretion as an engineer to determine the potential impact of your changes.

WARNING: If your PR introduces a new on-chain transaction or modifies an existing one, please add the "High-Risk" label to this PR and ask for 2 reviewers to approve it before merging.

E.g. an upgrade to `hdwallet` or core state management would be considered higher risk, and might require a full regression test. UI or isolated view changes, or something behind a feature flag may have near zero risk. Small bug fixes might require testing isolated to the specific fix.
------------------------------------------------------------------------------>

> What protocols, transaction types, wallets or contract interactions might be affected by this PR?

## Testing
Mainly for Cosmos, FOXy and THORChain savers:
- Try to deposit, the asset icon should be centered properly
- Try to withdraw, the asset icon should be centered properly

<!-----------------------------------------------------------------------------
We treat every PR to be merged with the same scrutiny as if we were merging directly to production.

Your PR will not be merged if you do not complete the sections below for our engineering and operations teams to test.
------------------------------------------------------------------------------>

### Engineering
n/a
<!-----------------------------------------------------------------------------
Include sufficient information here for an engineer to test your PR. This may include how to test locally, in a built environment, changes to infrastructure etc.
------------------------------------------------------------------------------>

### Operations
n/a
- [ ] :checkered_flag: My feature is behind a flag and doesn't require operations testing (yet)

<!-----------------------------------------------------------------------------
If your changes have a user-facing impact, describe how a non-technical QA team can functionally test your changes in a preview environment.

If they are not user-facing please describe how to test for any regressions that may occur.
------------------------------------------------------------------------------>

## Screenshots (if applicable)
https://jam.dev/c/23628c9f-2160-4337-87eb-255d21ff0cc2