### PR TITLE
fix: arbitrum bridge confirm precision loss

### DIFF
--- a/src/components/MultiHopTrade/components/TradeInput/components/Claim/ClaimConfirm.tsx
+++ b/src/components/MultiHopTrade/components/TradeInput/components/Claim/ClaimConfirm.tsx
@@ -92,6 +92,15 @@ export const ClaimConfirm: React.FC<ClaimConfirmProps> = ({
   )
 
   const amountCryptoPrecision = useMemo(() => {
+    const _amountCryptoPrecision = fromBaseUnit(
+      activeClaim.amountCryptoBaseUnit,
+      asset?.precision ?? 0,
+    )
+    if (asset?.precision === destinationAsset?.precision) {
+      return _amountCryptoPrecision
+    }
+
+    // Precision shouldn't be different between an asset and its bridge flavour but...
     return convertPrecision({
       value: fromBaseUnit(activeClaim.amountCryptoBaseUnit, asset?.precision ?? 0),
       inputExponent: asset?.precision,

--- a/src/components/MultiHopTrade/components/TradeInput/components/Claim/ClaimConfirm.tsx
+++ b/src/components/MultiHopTrade/components/TradeInput/components/Claim/ClaimConfirm.tsx
@@ -12,7 +12,6 @@ import {
 } from '@chakra-ui/react'
 import type { KnownChainIds } from '@shapeshiftoss/types'
 import type { TxStatus } from '@shapeshiftoss/unchained-client'
-import { convertPrecision } from '@shapeshiftoss/utils'
 import { useCallback, useMemo } from 'react'
 import { useTranslate } from 'react-polyglot'
 import { useHistory } from 'react-router'
@@ -91,22 +90,10 @@ export const ClaimConfirm: React.FC<ClaimConfirmProps> = ({
     selectPortfolioCryptoPrecisionBalanceByFilter(state, destinationFeeAssetBalanceFilter),
   )
 
-  const amountCryptoPrecision = useMemo(() => {
-    const _amountCryptoPrecision = fromBaseUnit(
-      activeClaim.amountCryptoBaseUnit,
-      asset?.precision ?? 0,
-    )
-    if (asset?.precision === destinationAsset?.precision) {
-      return _amountCryptoPrecision
-    }
-
-    // Precision shouldn't be different between an asset and its bridge flavour but...
-    return convertPrecision({
-      value: fromBaseUnit(activeClaim.amountCryptoBaseUnit, asset?.precision ?? 0),
-      inputExponent: asset?.precision,
-      outputExponent: destinationAsset?.precision,
-    }).toFixed()
-  }, [activeClaim.amountCryptoBaseUnit, asset, destinationAsset])
+  const amountCryptoPrecision = useMemo(
+    () => fromBaseUnit(activeClaim.amountCryptoBaseUnit, asset?.precision ?? 0),
+    [activeClaim.amountCryptoBaseUnit, asset],
+  )
 
   const amountUserCurrency = useMemo(() => {
     const price =


### PR DESCRIPTION
## Description

Does what it says on the box, see screenshots

## Issue (if applicable)

<!-----------------------------------------------------------------------------
If applicable, please link to the github issue and put `closes #XXXX` in your comment to auto-close the issue that your PR fixes.
------------------------------------------------------------------------------>

N/A, spotted in Arb flag toggle PR i.e https://github.com/shapeshift/web/pull/7637#pullrequestreview-2266232738

## Risk

> High Risk PRs Require 2 approvals

<!-----------------------------------------------------------------------------
Outline the scope of your changes and the risk associated with them. You must use your discretion as an engineer to determine the potential impact of your changes.

WARNING: If your PR introduces a new on-chain transaction or modifies an existing one, please add the "High-Risk" label to this PR and ask for 2 reviewers to approve it before merging.

E.g. an upgrade to `hdwallet` or core state management would be considered higher risk, and might require a full regression test. UI or isolated view changes, or something behind a feature flag may have near zero risk. Small bug fixes might require testing isolated to the specific fix.
------------------------------------------------------------------------------>

> What protocols, transaction types, wallets or contract interactions might be affected by this PR?

None - previous branch is still here.
Though I've spotted that `convertPrecision` loses precision while implementing this, so if we ever hit the very edge case of an asset having different precision in its Ethereum Mainnet and Arbitrum One, with a smol withdraw, then the bug would still be here... but this branch will realistically never be hit.

## Testing

<!-----------------------------------------------------------------------------
We treat every PR to be merged with the same scrutiny as if we were merging directly to production.

Your PR will not be merged if you do not complete the sections below for our engineering and operations teams to test.
------------------------------------------------------------------------------>

- Have a smol Arbitrum Bridge withdraw available (or eng. test with the monkey patch below)
- Ensure it doesn't show up as 0 in confirm step

### Engineering

<!-----------------------------------------------------------------------------
Include sufficient information here for an engineer to test your PR. This may include how to test locally, in a built environment, changes to infrastructure etc.
------------------------------------------------------------------------------>

- Test with the monkey patch below

```diff
diff --git a/src/components/ClaimRow/ClaimRow.tsx b/src/components/ClaimRow/ClaimRow.tsx
index cf59b43418..b9dd5ae35d 100644
--- a/src/components/ClaimRow/ClaimRow.tsx
+++ b/src/components/ClaimRow/ClaimRow.tsx
@@ -30,10 +30,7 @@ export const ClaimRow = ({
   tooltipText,
   onClaimClick,
 }: ClaimRowProps) => {
-  const isDisabled = useMemo(
-    () => onClaimClick === undefined || status !== ClaimStatus.Available,
-    [onClaimClick, status],
-  )
+  const isDisabled = useMemo(() => false, [])
   const hoverProps = useMemo(
     () => ({ bg: 'gray.700', cursor: isDisabled ? 'default' : undefined }),
     [isDisabled],
diff --git a/src/components/MultiHopTrade/components/TradeInput/components/Claim/ClaimConfirm.tsx b/src/components/MultiHopTrade/components/TradeInput/components/Claim/ClaimConfirm.tsx
index 730bf728ea..307c97b7ff 100644
--- a/src/components/MultiHopTrade/components/TradeInput/components/Claim/ClaimConfirm.tsx
+++ b/src/components/MultiHopTrade/components/TradeInput/components/Claim/ClaimConfirm.tsx
@@ -92,19 +92,18 @@ export const ClaimConfirm: React.FC<ClaimConfirmProps> = ({
   )
 
   const amountCryptoPrecision = useMemo(() => {
-    const _amountCryptoPrecision = fromBaseUnit(
-      activeClaim.amountCryptoBaseUnit,
-      asset?.precision ?? 0,
-    )
-    if (asset?.precision === destinationAsset?.precision) {
+    if (!asset || !destinationAsset) return '0'
+
+    const _amountCryptoPrecision = fromBaseUnit(activeClaim.amountCryptoBaseUnit, asset.precision)
+    if (asset.precision === destinationAsset.precision) {
       return _amountCryptoPrecision
     }
 
     // Precision shouldn't be different between an asset and its bridge flavour but...
     return convertPrecision({
-      value: fromBaseUnit(activeClaim.amountCryptoBaseUnit, asset?.precision ?? 0),
-      inputExponent: asset?.precision,
-      outputExponent: destinationAsset?.precision,
+      value: _amountCryptoPrecision,
+      inputExponent: asset.precision,
+      outputExponent: destinationAsset.precision,
     }).toFixed()
   }, [activeClaim.amountCryptoBaseUnit, asset, destinationAsset])
 
diff --git a/src/pages/RFOX/components/Claim/ClaimSelect.tsx b/src/pages/RFOX/components/Claim/ClaimSelect.tsx
index 411e545435..2e22e16bf5 100644
--- a/src/pages/RFOX/components/Claim/ClaimSelect.tsx
+++ b/src/pages/RFOX/components/Claim/ClaimSelect.tsx
@@ -99,7 +99,7 @@ export const ClaimSelect: FC<ClaimSelectProps & ClaimRouteProps> = ({
       )
       const currentTimestampMs: number = Date.now()
       const unstakingTimestampMs: number = Number(unstakingRequest.cooldownExpiry) * 1000
-      const isAvailable = currentTimestampMs >= unstakingTimestampMs
+      const isAvailable = true
       const cooldownDeltaMs = unstakingTimestampMs - currentTimestampMs
       const cooldownPeriodHuman = dayjs(Date.now() + cooldownDeltaMs).fromNow()
       const status = isAvailable ? ClaimStatus.Available : ClaimStatus.Pending
diff --git a/src/pages/RFOX/components/RewardsAndClaims/Claims.tsx b/src/pages/RFOX/components/RewardsAndClaims/Claims.tsx
index ea4298bb19..fd2998e8ec 100644
--- a/src/pages/RFOX/components/RewardsAndClaims/Claims.tsx
+++ b/src/pages/RFOX/components/RewardsAndClaims/Claims.tsx
@@ -48,7 +48,7 @@ export const Claims = ({ headerComponent }: ClaimsProps) => {
 
       const currentTimestampMs = Date.now()
       const unstakingTimestampMs = Number(unstakingRequest.cooldownExpiry) * 1000
-      const isAvailable = currentTimestampMs >= unstakingTimestampMs
+      const isAvailable = true
       const cooldownDeltaMs = unstakingTimestampMs - currentTimestampMs
       const cooldownPeriodHuman = dayjs(currentTimestampMs + cooldownDeltaMs).fromNow()
       const status = isAvailable ? ClaimStatus.Available : ClaimStatus.Pending
```

### Operations

- [ ] :checkered_flag: My feature is behind a flag and doesn't require operations testing (yet)

<!-----------------------------------------------------------------------------
If your changes have a user-facing impact, describe how a non-technical QA team can functionally test your changes in a preview environment.

If they are not user-facing please describe how to test for any regressions that may occur.
------------------------------------------------------------------------------>

- ^

## Screenshots (if applicable)

<img width="486" alt="Screenshot 2024-08-28 at 16 06 39" src="https://github.com/user-attachments/assets/adbd41f3-735d-4dad-acc5-673637a0a572">

- Develop

<img width="555" alt="Screenshot 2024-08-28 at 16 05 20" src="https://github.com/user-attachments/assets/4959fbb2-7651-44e9-a028-c848e5c84a2a">


- This diff

<img width="578" alt="Screenshot 2024-08-28 at 16 06 26" src="https://github.com/user-attachments/assets/8a5b3813-ae01-443d-8991-ef5df4618506">


<!-- av pr metadata
This information is embedded by the av CLI when creating PRs to track the status of stacks when using Aviator. Please do not delete or edit this section of the PR.
```
{"parent":"develop","parentHead":"","trunk":"develop"}
```
-->


<!-- av pr metadata
This information is embedded by the av CLI when creating PRs to track the status of stacks when using Aviator. Please do not delete or edit this section of the PR.
```
{"parent":"develop","parentHead":"","trunk":"develop"}
```
-->
