### PR TITLE
feat: use portals auto slippage

### DIFF
--- a/packages/swapper/src/constants.ts
+++ b/packages/swapper/src/constants.ts
@@ -91,6 +91,7 @@ export const swappers: Record<
 // Slippage defaults. Don't export these to ensure the getDefaultSlippageDecimalPercentageForSwapper helper function is used.
 const DEFAULT_SLIPPAGE_DECIMAL_PERCENTAGE = '0.002' // .2%
 const DEFAULT_COWSWAP_SLIPPAGE_DECIMAL_PERCENTAGE = '0.005' // .5%
+const DEFAULT_PORTALS_SLIPPAGE_DECIMAL_PERCENTAGE = '0.01' // 1%
 const DEFAULT_LIFI_SLIPPAGE_DECIMAL_PERCENTAGE = '0.005' // .5%
 const DEFAULT_THOR_SLIPPAGE_DECIMAL_PERCENTAGE = '0.01' // 1%
 const DEFAULT_ARBITRUM_BRIDGE_SLIPPAGE_DECIMAL_PERCENTAGE = '0' // no slippage for Arbitrum Bridge, so no slippage tolerance
@@ -102,13 +103,14 @@ export const getDefaultSlippageDecimalPercentageForSwapper = (
   switch (swapperName) {
     case SwapperName.Zrx:
     case SwapperName.OneInch:
-    case SwapperName.Portals:
     case SwapperName.Test:
       return DEFAULT_SLIPPAGE_DECIMAL_PERCENTAGE
     case SwapperName.LIFI:
       return DEFAULT_LIFI_SLIPPAGE_DECIMAL_PERCENTAGE
     case SwapperName.CowSwap:
       return DEFAULT_COWSWAP_SLIPPAGE_DECIMAL_PERCENTAGE
+    case SwapperName.Portals:
+      return DEFAULT_PORTALS_SLIPPAGE_DECIMAL_PERCENTAGE
     case SwapperName.Thorchain:
       return DEFAULT_THOR_SLIPPAGE_DECIMAL_PERCENTAGE
     case SwapperName.ArbitrumBridge:

--- a/packages/swapper/src/constants.ts
+++ b/packages/swapper/src/constants.ts
@@ -91,7 +91,6 @@ export const swappers: Record<
 // Slippage defaults. Don't export these to ensure the getDefaultSlippageDecimalPercentageForSwapper helper function is used.
 const DEFAULT_SLIPPAGE_DECIMAL_PERCENTAGE = '0.002' // .2%
 const DEFAULT_COWSWAP_SLIPPAGE_DECIMAL_PERCENTAGE = '0.005' // .5%
-const DEFAULT_PORTALS_SLIPPAGE_DECIMAL_PERCENTAGE = '0.01' // 1%
 const DEFAULT_LIFI_SLIPPAGE_DECIMAL_PERCENTAGE = '0.005' // .5%
 const DEFAULT_THOR_SLIPPAGE_DECIMAL_PERCENTAGE = '0.01' // 1%
 const DEFAULT_ARBITRUM_BRIDGE_SLIPPAGE_DECIMAL_PERCENTAGE = '0' // no slippage for Arbitrum Bridge, so no slippage tolerance
@@ -103,14 +102,13 @@ export const getDefaultSlippageDecimalPercentageForSwapper = (
   switch (swapperName) {
     case SwapperName.Zrx:
     case SwapperName.OneInch:
+    case SwapperName.Portals:
     case SwapperName.Test:
       return DEFAULT_SLIPPAGE_DECIMAL_PERCENTAGE
     case SwapperName.LIFI:
       return DEFAULT_LIFI_SLIPPAGE_DECIMAL_PERCENTAGE
     case SwapperName.CowSwap:
       return DEFAULT_COWSWAP_SLIPPAGE_DECIMAL_PERCENTAGE
-    case SwapperName.Portals:
-      return DEFAULT_PORTALS_SLIPPAGE_DECIMAL_PERCENTAGE
     case SwapperName.Thorchain:
       return DEFAULT_THOR_SLIPPAGE_DECIMAL_PERCENTAGE
     case SwapperName.ArbitrumBridge:

--- a/packages/swapper/src/swappers/PortalsSwapper/getPortalsTradeQuote/getPortalsTradeQuote.ts
+++ b/packages/swapper/src/swappers/PortalsSwapper/getPortalsTradeQuote/getPortalsTradeQuote.ts
@@ -8,6 +8,7 @@ import type { Result } from '@sniptt/monads'
 import { Err, Ok } from '@sniptt/monads'
 import { zeroAddress } from 'viem'
 
+import { getDefaultSlippageDecimalPercentageForSwapper } from '../../..'
 import type { SwapperConfig } from '../../../types'
 import {
   type GetEvmTradeQuoteInput,
@@ -144,7 +145,6 @@ export async function getPortalsTradeQuote(
       })
         .then(({ context }) => ({
           maybeGasLimit: context.gasLimit,
-          autoSlippageTolerancePercentage: context.slippageTolerancePercentage,
         }))
         .catch(e => {
           console.info('failed to get Portals quote with validation enabled using dummy address', e)
@@ -158,7 +158,9 @@ export async function getPortalsTradeQuote(
         inputAmount: sellAmountIncludingProtocolFeesCryptoBaseUnit,
         slippageTolerancePercentage:
           maybeSlippageTolerancePercentageOverride ??
-          dummyOrderResponse?.autoSlippageTolerancePercentage,
+          bnOrZero(getDefaultSlippageDecimalPercentageForSwapper(SwapperName.Portals))
+            .times(100)
+            .toNumber(),
         partner: getTreasuryAddressFromChainId(sellAsset.chainId),
         feePercentage: affiliateBpsPercentage,
         validate: false,

--- a/packages/swapper/src/swappers/PortalsSwapper/getPortalsTradeQuote/getPortalsTradeQuote.ts
+++ b/packages/swapper/src/swappers/PortalsSwapper/getPortalsTradeQuote/getPortalsTradeQuote.ts
@@ -200,7 +200,7 @@ export async function getPortalsTradeQuote(
       affiliateBps,
       potentialAffiliateBps,
       rate,
-      slippageTolerancePercentageDecimal: bnOrZero(slippageTolerancePercentage).div(100).toString(),
+      slippageTolerancePercentageDecimal: bnOrZero(slippageTolerancePercentage).div(100).toFixed(2), // Portals API allows for maximum 2 decimal places
       steps: [
         {
           accountNumber,

--- a/packages/swapper/src/swappers/PortalsSwapper/getPortalsTradeQuote/getPortalsTradeQuote.ts
+++ b/packages/swapper/src/swappers/PortalsSwapper/getPortalsTradeQuote/getPortalsTradeQuote.ts
@@ -78,6 +78,10 @@ export async function getPortalsTradeQuote(
     .times(100)
     .toNumber()
 
+  const maybeSlippageTolerancePercentageOverride = input.slippageTolerancePercentageDecimal
+    ? Number(input.slippageTolerancePercentageDecimal) * 100
+    : undefined // Use auto slippage if no override provided
+
   try {
     if (!sendAddress) return Err(makeSwapErrorRight({ message: 'missing sendAddress' }))
 
@@ -109,7 +113,7 @@ export async function getPortalsTradeQuote(
       inputToken,
       outputToken,
       inputAmount: sellAmountIncludingProtocolFeesCryptoBaseUnit,
-      slippageTolerancePercentage: undefined, // Use auto slippage,
+      slippageTolerancePercentage: maybeSlippageTolerancePercentageOverride,
       partner: getTreasuryAddressFromChainId(sellAsset.chainId),
       feePercentage: affiliateBpsPercentage,
       validate: true,
@@ -132,7 +136,7 @@ export async function getPortalsTradeQuote(
         inputToken: dummyInputToken,
         outputToken: dummyOutputToken,
         inputAmount: dummyQuoteParams.sellAmountCryptoBaseUnit,
-        slippageTolerancePercentage: undefined, // Use auto slippage,
+        slippageTolerancePercentage: maybeSlippageTolerancePercentageOverride,
         partner: getTreasuryAddressFromChainId(sellAsset.chainId),
         feePercentage: affiliateBpsPercentage,
         validate: true,
@@ -149,7 +153,7 @@ export async function getPortalsTradeQuote(
         inputToken,
         outputToken,
         inputAmount: sellAmountIncludingProtocolFeesCryptoBaseUnit,
-        slippageTolerancePercentage: undefined, // Use auto slippage,
+        slippageTolerancePercentage: maybeSlippageTolerancePercentageOverride,
         partner: getTreasuryAddressFromChainId(sellAsset.chainId),
         feePercentage: affiliateBpsPercentage,
         validate: false,

--- a/packages/swapper/src/swappers/PortalsSwapper/getPortalsTradeQuote/getPortalsTradeQuote.ts
+++ b/packages/swapper/src/swappers/PortalsSwapper/getPortalsTradeQuote/getPortalsTradeQuote.ts
@@ -8,7 +8,6 @@ import type { Result } from '@sniptt/monads'
 import { Err, Ok } from '@sniptt/monads'
 import { zeroAddress } from 'viem'
 
-import { getDefaultSlippageDecimalPercentageForSwapper } from '../../../constants'
 import type { SwapperConfig } from '../../../types'
 import {
   type GetEvmTradeQuoteInput,
@@ -79,10 +78,6 @@ export async function getPortalsTradeQuote(
     .times(100)
     .toNumber()
 
-  const slippageTolerancePercentageDecimal =
-    input.slippageTolerancePercentageDecimal ??
-    getDefaultSlippageDecimalPercentageForSwapper(SwapperName.Portals)
-
   try {
     if (!sendAddress) return Err(makeSwapErrorRight({ message: 'missing sendAddress' }))
 
@@ -114,7 +109,7 @@ export async function getPortalsTradeQuote(
       inputToken,
       outputToken,
       inputAmount: sellAmountIncludingProtocolFeesCryptoBaseUnit,
-      slippageTolerancePercentage: Number(slippageTolerancePercentageDecimal) * 100,
+      slippageTolerancePercentage: undefined, // Use auto slippage,
       partner: getTreasuryAddressFromChainId(sellAsset.chainId),
       feePercentage: affiliateBpsPercentage,
       validate: true,
@@ -137,7 +132,7 @@ export async function getPortalsTradeQuote(
         inputToken: dummyInputToken,
         outputToken: dummyOutputToken,
         inputAmount: dummyQuoteParams.sellAmountCryptoBaseUnit,
-        slippageTolerancePercentage: 10, // hardcoded high slippage tolerance for the dummy quote, the actual one will use the correct one
+        slippageTolerancePercentage: undefined, // Use auto slippage,
         partner: getTreasuryAddressFromChainId(sellAsset.chainId),
         feePercentage: affiliateBpsPercentage,
         validate: true,
@@ -154,7 +149,7 @@ export async function getPortalsTradeQuote(
         inputToken,
         outputToken,
         inputAmount: sellAmountIncludingProtocolFeesCryptoBaseUnit,
-        slippageTolerancePercentage: Number(slippageTolerancePercentageDecimal) * 100,
+        slippageTolerancePercentage: undefined, // Use auto slippage,
         partner: getTreasuryAddressFromChainId(sellAsset.chainId),
         feePercentage: affiliateBpsPercentage,
         validate: false,

--- a/packages/swapper/src/swappers/PortalsSwapper/getPortalsTradeQuote/getPortalsTradeQuote.ts
+++ b/packages/swapper/src/swappers/PortalsSwapper/getPortalsTradeQuote/getPortalsTradeQuote.ts
@@ -200,7 +200,7 @@ export async function getPortalsTradeQuote(
       affiliateBps,
       potentialAffiliateBps,
       rate,
-      slippageTolerancePercentageDecimal: (slippageTolerancePercentage / 100).toString(),
+      slippageTolerancePercentageDecimal: bnOrZero(slippageTolerancePercentage).div(100).toString(),
       steps: [
         {
           accountNumber,

--- a/packages/swapper/src/swappers/PortalsSwapper/getPortalsTradeQuote/getPortalsTradeQuote.ts
+++ b/packages/swapper/src/swappers/PortalsSwapper/getPortalsTradeQuote/getPortalsTradeQuote.ts
@@ -79,9 +79,9 @@ export async function getPortalsTradeQuote(
     .times(100)
     .toNumber()
 
-  const maybeSlippageTolerancePercentageOverride = input.slippageTolerancePercentageDecimal
+  const userSlippageTolerancePercentageDecimalOrDefault = input.slippageTolerancePercentageDecimal
     ? Number(input.slippageTolerancePercentageDecimal) * 100
-    : undefined // Use auto slippage if no override provided
+    : undefined // Use auto slippage if no user preference is provided
 
   try {
     if (!sendAddress) return Err(makeSwapErrorRight({ message: 'missing sendAddress' }))
@@ -114,7 +114,7 @@ export async function getPortalsTradeQuote(
       inputToken,
       outputToken,
       inputAmount: sellAmountIncludingProtocolFeesCryptoBaseUnit,
-      slippageTolerancePercentage: maybeSlippageTolerancePercentageOverride,
+      slippageTolerancePercentage: userSlippageTolerancePercentageDecimalOrDefault,
       partner: getTreasuryAddressFromChainId(sellAsset.chainId),
       feePercentage: affiliateBpsPercentage,
       validate: true,
@@ -137,7 +137,7 @@ export async function getPortalsTradeQuote(
         inputToken: dummyInputToken,
         outputToken: dummyOutputToken,
         inputAmount: dummyQuoteParams.sellAmountCryptoBaseUnit,
-        slippageTolerancePercentage: maybeSlippageTolerancePercentageOverride,
+        slippageTolerancePercentage: userSlippageTolerancePercentageDecimalOrDefault,
         partner: getTreasuryAddressFromChainId(sellAsset.chainId),
         feePercentage: affiliateBpsPercentage,
         validate: true,
@@ -157,7 +157,7 @@ export async function getPortalsTradeQuote(
         outputToken,
         inputAmount: sellAmountIncludingProtocolFeesCryptoBaseUnit,
         slippageTolerancePercentage:
-          maybeSlippageTolerancePercentageOverride ??
+          userSlippageTolerancePercentageDecimalOrDefault ??
           bnOrZero(getDefaultSlippageDecimalPercentageForSwapper(SwapperName.Portals))
             .times(100)
             .toNumber(),

--- a/packages/swapper/src/swappers/PortalsSwapper/utils/fetchPortalsTradeOrder.ts
+++ b/packages/swapper/src/swappers/PortalsSwapper/utils/fetchPortalsTradeOrder.ts
@@ -73,7 +73,7 @@ export const fetchPortalsTradeOrder = async ({
   })
 
   if (slippageTolerancePercentage !== undefined) {
-    params.append('slippageTolerancePercentage', slippageTolerancePercentage.toString())
+    params.append('slippageTolerancePercentage', slippageTolerancePercentage.toFixed(2)) // Portals API expects a string with at most 2 decimal places
   }
 
   if (feePercentage) {

--- a/src/components/MultiHopTrade/components/SlippagePopover.tsx
+++ b/src/components/MultiHopTrade/components/SlippagePopover.tsx
@@ -27,7 +27,10 @@ import { Text } from 'components/Text'
 import { useFeatureFlag } from 'hooks/useFeatureFlag/useFeatureFlag'
 import { selectUserSlippagePercentage } from 'state/slices/tradeInputSlice/selectors'
 import { tradeInput } from 'state/slices/tradeInputSlice/tradeInputSlice'
-import { selectDefaultSlippagePercentage } from 'state/slices/tradeQuoteSlice/selectors'
+import {
+  selectDefaultSlippagePercentage,
+  selectQuoteSlippageTolerancePercentage,
+} from 'state/slices/tradeQuoteSlice/selectors'
 import { useAppDispatch, useAppSelector } from 'state/store'
 
 enum SlippageType {
@@ -49,6 +52,8 @@ type SlippagePopoverProps = {
 export const SlippagePopover: FC<SlippagePopoverProps> = memo(
   ({ tooltipTranslation, isDisabled }) => {
     const defaultSlippagePercentage = useAppSelector(selectDefaultSlippagePercentage)
+    const quoteSlippagePercentage = useAppSelector(selectQuoteSlippageTolerancePercentage)
+
     const userSlippagePercentage = useAppSelector(selectUserSlippagePercentage)
 
     const [slippageType, setSlippageType] = useState<SlippageType>(SlippageType.Auto)
@@ -68,11 +73,11 @@ export const SlippagePopover: FC<SlippagePopoverProps> = memo(
         setSlippageAmount(userSlippagePercentage)
       } else {
         setSlippageType(SlippageType.Auto)
-        setSlippageAmount(defaultSlippagePercentage)
+        setSlippageAmount(quoteSlippagePercentage ?? defaultSlippagePercentage)
       }
       // We only want this to run on mount, though not to be reactive to userSlippagePercentage
       // eslint-disable-next-line react-hooks/exhaustive-deps
-    }, [defaultSlippagePercentage])
+    }, [defaultSlippagePercentage, quoteSlippagePercentage])
 
     const handleChange = useCallback((e: React.ChangeEvent<HTMLInputElement>) => {
       const value = e.target.value

--- a/src/components/MultiHopTrade/components/TradeInput/components/MaxSlippage.tsx
+++ b/src/components/MultiHopTrade/components/TradeInput/components/MaxSlippage.tsx
@@ -20,7 +20,6 @@ import { getChainAdapterManager } from 'context/PluginProvider/chainAdapterSingl
 import { useLocaleFormatter } from 'hooks/useLocaleFormatter/useLocaleFormatter'
 import { fromBaseUnit } from 'lib/math'
 import { selectUserSlippagePercentage } from 'state/slices/tradeInputSlice/selectors'
-import { selectDefaultSlippagePercentage } from 'state/slices/tradeQuoteSlice/selectors'
 import { useAppSelector } from 'state/store'
 
 type MaxSlippageProps = {
@@ -52,28 +51,25 @@ export const MaxSlippage: React.FC<MaxSlippageProps> = ({
       swapSource !== THORCHAIN_LONGTAIL_STREAMING_SWAP_SOURCE,
     [swapSource],
   )
-  const defaultSlippagePercentage = useAppSelector(selectDefaultSlippagePercentage)
   const userSlippagePercentage = useAppSelector(selectUserSlippagePercentage)
   const slippageAsPercentageString = bnOrZero(slippageDecimalPercentage).times(100).toString()
   const isAmountPositive = bnOrZero(amountCryptoPrecision).gt(0)
 
   const renderSlippageTag = useMemo(() => {
-    if (bnOrZero(defaultSlippagePercentage).eq(bnOrZero(slippageAsPercentageString))) {
-      return (
-        <Tag colorScheme='blue' size='sm'>
-          {translate('trade.slippage.auto')}
-        </Tag>
-      )
-    }
-
     if (bnOrZero(slippageAsPercentageString).eq(bnOrZero(userSlippagePercentage))) {
       return (
         <Tag colorScheme='purple' size='sm'>
           {translate('trade.slippage.custom')}
         </Tag>
       )
+    } else {
+      return (
+        <Tag colorScheme='blue' size='sm'>
+          {translate('trade.slippage.auto')}
+        </Tag>
+      )
     }
-  }, [defaultSlippagePercentage, slippageAsPercentageString, translate, userSlippagePercentage])
+  }, [slippageAsPercentageString, translate, userSlippagePercentage])
 
   const amountAfterSlippage = useMemo(() => {
     const slippageBps = convertDecimalPercentageToBasisPoints(slippageDecimalPercentage)

--- a/src/state/slices/tradeQuoteSlice/selectors.ts
+++ b/src/state/slices/tradeQuoteSlice/selectors.ts
@@ -241,6 +241,23 @@ export const selectActiveQuote: Selector<ReduxState, TradeQuote | undefined> =
     },
   )
 
+export const selectQuoteSlippageTolerancePercentageDecimal: Selector<
+  ReduxState,
+  string | undefined
+> = createSelector(
+  selectActiveQuote,
+  activeQuote => activeQuote?.slippageTolerancePercentageDecimal,
+)
+
+export const selectQuoteSlippageTolerancePercentage: Selector<ReduxState, string | undefined> =
+  createSelector(
+    selectQuoteSlippageTolerancePercentageDecimal,
+    slippageTolerancePercentageDecimal =>
+      slippageTolerancePercentageDecimal
+        ? bn(slippageTolerancePercentageDecimal).times(100).toString()
+        : undefined,
+  )
+
 export const selectConfirmedQuoteTradeId: Selector<ReduxState, string | undefined> = createSelector(
   selectConfirmedQuote,
   confirmedQuote => confirmedQuote?.id,
@@ -514,10 +531,12 @@ export const selectDefaultSlippagePercentage: Selector<ReduxState, string> = cre
 
 export const selectTradeSlippagePercentageDecimal: Selector<ReduxState, string> = createSelector(
   selectActiveSwapperName,
+  selectQuoteSlippageTolerancePercentageDecimal,
   selectUserSlippagePercentageDecimal,
-  (activeSwapperName, slippagePreferencePercentage) => {
+  (activeSwapperName, quoteSlippageTolerancePercentage, slippagePreferencePercentage) => {
     return (
       slippagePreferencePercentage ??
+      quoteSlippageTolerancePercentage ??
       getDefaultSlippageDecimalPercentageForSwapper(activeSwapperName)
     )
   },

--- a/src/state/slices/tradeQuoteSlice/selectors.ts
+++ b/src/state/slices/tradeQuoteSlice/selectors.ts
@@ -244,18 +244,18 @@ export const selectActiveQuote: Selector<ReduxState, TradeQuote | undefined> =
 export const selectQuoteSlippageTolerancePercentageDecimal: Selector<
   ReduxState,
   string | undefined
-> = createSelector(
-  selectActiveQuote,
-  activeQuote => activeQuote?.slippageTolerancePercentageDecimal,
-)
+> = createSelector(selectActiveQuote, activeQuote => {
+  return activeQuote?.slippageTolerancePercentageDecimal
+})
 
 export const selectQuoteSlippageTolerancePercentage: Selector<ReduxState, string | undefined> =
   createSelector(
     selectQuoteSlippageTolerancePercentageDecimal,
-    slippageTolerancePercentageDecimal =>
-      slippageTolerancePercentageDecimal
+    slippageTolerancePercentageDecimal => {
+      return slippageTolerancePercentageDecimal
         ? bn(slippageTolerancePercentageDecimal).times(100).toString()
-        : undefined,
+        : undefined
+    },
   )
 
 export const selectConfirmedQuoteTradeId: Selector<ReduxState, string | undefined> = createSelector(

--- a/src/state/slices/tradeQuoteSlice/selectors.ts
+++ b/src/state/slices/tradeQuoteSlice/selectors.ts
@@ -529,6 +529,7 @@ export const selectDefaultSlippagePercentage: Selector<ReduxState, string> = cre
     bn(getDefaultSlippageDecimalPercentageForSwapper(activeSwapperName)).times(100).toString(),
 )
 
+// Returns the trade slippage in priority order: user preference (override), quote derived, default
 export const selectTradeSlippagePercentageDecimal: Selector<ReduxState, string> = createSelector(
   selectActiveSwapperName,
   selectQuoteSlippageTolerancePercentageDecimal,

--- a/src/state/slices/tradeQuoteSlice/selectors.ts
+++ b/src/state/slices/tradeQuoteSlice/selectors.ts
@@ -241,12 +241,10 @@ export const selectActiveQuote: Selector<ReduxState, TradeQuote | undefined> =
     },
   )
 
-export const selectQuoteSlippageTolerancePercentageDecimal: Selector<
-  ReduxState,
-  string | undefined
-> = createSelector(selectActiveQuote, activeQuote => {
-  return activeQuote?.slippageTolerancePercentageDecimal
-})
+const selectQuoteSlippageTolerancePercentageDecimal: Selector<ReduxState, string | undefined> =
+  createSelector(selectActiveQuote, activeQuote => {
+    return activeQuote?.slippageTolerancePercentageDecimal
+  })
 
 export const selectQuoteSlippageTolerancePercentage: Selector<ReduxState, string | undefined> =
   createSelector(

--- a/src/state/slices/tradeQuoteSlice/selectors.ts
+++ b/src/state/slices/tradeQuoteSlice/selectors.ts
@@ -527,7 +527,7 @@ export const selectDefaultSlippagePercentage: Selector<ReduxState, string> = cre
     bn(getDefaultSlippageDecimalPercentageForSwapper(activeSwapperName)).times(100).toString(),
 )
 
-// Returns the trade slippage in priority order: user preference (override), quote derived, default
+// Returns the trade slippage in priority order: user preference, quote derived, default
 export const selectTradeSlippagePercentageDecimal: Selector<ReduxState, string> = createSelector(
   selectActiveSwapperName,
   selectQuoteSlippageTolerancePercentageDecimal,


### PR DESCRIPTION
## Description

Use Portals auto-slippage by omitting the `slippageTolerancePercentage` param from the request.
Portals will then find the best route with the optimal slippage (up to 2.5%), and return that value - we then consume that value in our quote for execution.

Note, this still allows for manual override via the slippage popover.

In the below image we see that the auto slippage provided by Portals in the quote response for this trade is 1.04%, which we then populate in the UI.

<img width="1237" alt="Screenshot 2024-08-30 at 11 39 03 AM" src="https://github.com/user-attachments/assets/9c6197cd-8659-4d59-815e-94c0e24903f1">

## Issue (if applicable)

Partially addresses https://github.com/shapeshift/web/issues/7650 by using automated slippage for quotes that can be validated.

## Risk

> High Risk PRs Require 2 approvals

Medium

> What protocols, transaction types, wallets or contract interactions might be affected by this PR?

- Portals swap quotes and execution
- Slippage functionality of all swaps (auto & manual)

## Testing

Ensure that when no manual slippage is provided:

1. The Portals quote request is sent without a `slippageTolerancePercentage` value
2. The Portals quote response includes a value between 0 and 2.5
3. The value in the quote response is shown in the UI in the "Max slippage" section, and the "Auto" section
4. The Portals trade executes as expected
5. The slippage value updates when the quote refreshes

Ensure that when a manual slippage override is provided:

1. The provided slippage value is set as the `slippageTolerancePercentage` in the Portals quote request
2. The provided slippage value is returned in the `slippageTolerancePercentage` value of the Portals quote response
3. The Portals trade executes as expected

### Engineering

☝️

### Operations

- [ ] :checkered_flag: My feature is behind a flag and doesn't require operations testing (yet)

☝️

## Screenshots (if applicable)
<img width="481" alt="Screenshot 2024-08-29 at 7 03 29 PM" src="https://github.com/user-attachments/assets/b43aab83-badb-49b9-b65b-c79db2354c8b">

<img width="485" alt="Screenshot 2024-08-29 at 7 01 42 PM" src="https://github.com/user-attachments/assets/d32f7873-5a5a-441f-9c3f-8e7b52185a65">

