### PR TITLE
fix: portals fees denominated in wrong asset

### DIFF
--- a/packages/swapper/src/swappers/PortalsSwapper/getPortalsTradeQuote/getPortalsTradeQuote.ts
+++ b/packages/swapper/src/swappers/PortalsSwapper/getPortalsTradeQuote/getPortalsTradeQuote.ts
@@ -217,9 +217,9 @@ export async function getPortalsTradeQuote(
             networkFeeCryptoBaseUnit,
             // Protocol fees are always denominated in buy asset here, this is the downside on the swap
             protocolFees: {
-              [buyAsset.assetId]: {
+              [sellAsset.assetId]: {
                 amountCryptoBaseUnit: feeAmount,
-                asset: buyAsset,
+                asset: sellAsset,
                 requiresBalance: false,
               },
             },

--- a/packages/swapper/src/swappers/PortalsSwapper/getPortalsTradeQuote/getPortalsTradeQuote.ts
+++ b/packages/swapper/src/swappers/PortalsSwapper/getPortalsTradeQuote/getPortalsTradeQuote.ts
@@ -215,7 +215,7 @@ export async function getPortalsTradeQuote(
             input.sellAmountIncludingProtocolFeesCryptoBaseUnit,
           feeData: {
             networkFeeCryptoBaseUnit,
-            // Protocol fees are always denominated in buy asset here, this is the downside on the swap
+            // Protocol fees are always denominated in sell asset here
             protocolFees: {
               [sellAsset.assetId]: {
                 amountCryptoBaseUnit: feeAmount,


### PR DESCRIPTION
## Description

Ensures Portals fees are denominated in sellAsset, vs. buyAsset previously.
<!-- Please describe your changes -->

## Issue (if applicable)

<!-----------------------------------------------------------------------------
If applicable, please link to the github issue and put `closes #XXXX` in your comment to auto-close the issue that your PR fixes.
------------------------------------------------------------------------------>

closes https://github.com/shapeshift/web/issues/7651

## Risk

> High Risk PRs Require 2 approvals

<!-----------------------------------------------------------------------------
Outline the scope of your changes and the risk associated with them. You must use your discretion as an engineer to determine the potential impact of your changes.

WARNING: If your PR introduces a new on-chain transaction or modifies an existing one, please add the "High-Risk" label to this PR and ask for 2 reviewers to approve it before merging.

E.g. an upgrade to `hdwallet` or core state management would be considered higher risk, and might require a full regression test. UI or isolated view changes, or something behind a feature flag may have near zero risk. Small bug fixes might require testing isolated to the specific fix.
------------------------------------------------------------------------------>

Low

> What protocols, transaction types, wallets or contract interactions might be affected by this PR?

## Testing

<!-----------------------------------------------------------------------------
We treat every PR to be merged with the same scrutiny as if we were merging directly to production.

Your PR will not be merged if you do not complete the sections below for our engineering and operations teams to test.
------------------------------------------------------------------------------>

- Portals protocol fees look sane (and mostly on par with other swappers for non-LP pairs, since they use 0x and the like under the hood for these)

### Engineering

<!-----------------------------------------------------------------------------
Include sufficient information here for an engineer to test your PR. This may include how to test locally, in a built environment, changes to infrastructure etc.
------------------------------------------------------------------------------>

- ^

### Operations

- [ ] :checkered_flag: My feature is behind a flag and doesn't require operations testing (yet)

<!-----------------------------------------------------------------------------
If your changes have a user-facing impact, describe how a non-technical QA team can functionally test your changes in a preview environment.

If they are not user-facing please describe how to test for any regressions that may occur.
------------------------------------------------------------------------------>

- ^

## Screenshots (if applicable)

<!-- av pr metadata
This information is embedded by the av CLI when creating PRs to track the status of stacks when using Aviator. Please do not delete or edit this section of the PR.
```
{"parent":"develop","parentHead":"","trunk":"develop"}
```
-->

- develop

<img width="1071" alt="Screenshot 2024-08-30 at 12 30 43" src="https://github.com/user-attachments/assets/9f2b1afc-8a24-48dc-bdca-61ef1d5b46f2">
<img width="583" alt="Screenshot 2024-08-30 at 12 30 49" src="https://github.com/user-attachments/assets/bac6e774-0de5-453e-a151-42ce370f040c">

- this diff

<img width="1050" alt="Screenshot 2024-08-30 at 12 31 51" src="https://github.com/user-attachments/assets/6aa622d6-1345-4849-9009-46ee879f3cce">
<img width="631" alt="Screenshot 2024-08-30 at 12 31 59" src="https://github.com/user-attachments/assets/6481ba79-887e-400e-8c4e-fe6cc0c509ed">
