### PR TITLE
feat: send modal status step

### DIFF
--- a/packages/chain-adapters/src/evm/EvmBaseAdapter.ts
+++ b/packages/chain-adapters/src/evm/EvmBaseAdapter.ts
@@ -523,7 +523,6 @@ export abstract class EvmBaseAdapter<T extends EvmChainId> implements IChainAdap
       throw new Error(`wallet does not support ${this.getDisplayName()}`)
     }
 
-    await this.assertSwitchChain(wallet)
     await verifyLedgerAppOpen(this.chainId, wallet)
 
     const address = await (wallet as ETHWallet).ethGetAddress({

--- a/src/assets/translations/en/main.json
+++ b/src/assets/translations/en/main.json
@@ -1147,6 +1147,9 @@
         "average": "Average",
         "fast": "Fast",
         "enterAmount": "Enter Amount"
+      },
+      "status": {
+        "pendingBody": "Sending %{amount} %{symbol}"
       }
     },
     "receive": {

--- a/src/components/Modals/QrCode/Form.tsx
+++ b/src/components/Modals/QrCode/Form.tsx
@@ -24,6 +24,7 @@ import { SendFormFields, SendRoutes } from '../Send/SendCommon'
 import { Address } from '../Send/views/Address'
 import { Confirm } from '../Send/views/Confirm'
 import { Details } from '../Send/views/Details'
+import { Status } from '../Send/views/Status'
 
 type QrCodeFormProps = {
   assetId?: AssetId
@@ -70,6 +71,16 @@ export const Form: React.FC<QrCodeFormProps> = ({ accountId }) => {
     setAddressError(null)
     history.goBack()
   }, [history])
+
+  const handleSubmit = useCallback(
+    async (data: SendInput) => {
+      const txHash = await handleFormSend(data)
+      if (!txHash) return
+      methods.setValue(SendFormFields.TxHash, txHash)
+      history.push(SendRoutes.Status)
+    },
+    [handleFormSend, history, methods],
+  )
 
   const checkKeyDown = useCallback((event: React.KeyboardEvent<HTMLFormElement>) => {
     if (event.key === 'Enter') event.preventDefault()
@@ -142,7 +153,7 @@ export const Form: React.FC<QrCodeFormProps> = ({ accountId }) => {
   return (
     <FormProvider {...methods}>
       {/* eslint-disable-next-line jsx-a11y/no-noninteractive-element-interactions */}
-      <form onSubmit={methods.handleSubmit(handleFormSend)} onKeyDown={checkKeyDown}>
+      <form onSubmit={methods.handleSubmit(handleSubmit)} onKeyDown={checkKeyDown}>
         <AnimatePresence mode='wait' initial={false}>
           <Switch location={location} key={location.key}>
             <Route path={SendRoutes.Select}>
@@ -163,6 +174,9 @@ export const Form: React.FC<QrCodeFormProps> = ({ accountId }) => {
             </Route>
             <Route path={SendRoutes.Confirm}>
               <Confirm />
+            </Route>
+            <Route path={SendRoutes.Status}>
+              <Status />
             </Route>
             <Redirect exact from='/' to={SendRoutes.Scan} />
           </Switch>

--- a/src/components/Modals/Send/Form.tsx
+++ b/src/components/Modals/Send/Form.tsx
@@ -20,6 +20,7 @@ import { SendFormFields, SendRoutes } from './SendCommon'
 import { Address } from './views/Address'
 import { Confirm } from './views/Confirm'
 import { Details } from './views/Details'
+import { Status } from './views/Status'
 
 export type SendInput<T extends ChainId = ChainId> = {
   [SendFormFields.AccountId]: AccountId
@@ -37,6 +38,7 @@ export type SendInput<T extends ChainId = ChainId> = {
   [SendFormFields.SendMax]: boolean
   [SendFormFields.VanityAddress]: string
   [SendFormFields.CustomNonce]?: string
+  [SendFormFields.TxHash]?: string
 }
 
 const formStyle = { height: '100%' }
@@ -67,8 +69,19 @@ export const Form: React.FC<SendFormProps> = ({ initialAssetId, input = '', acco
       amountCryptoPrecision: '',
       fiatAmount: '',
       fiatSymbol: selectedCurrency,
+      txHash: '',
     },
   })
+
+  const handleSubmit = useCallback(
+    async (data: SendInput) => {
+      const txHash = await handleFormSend(data)
+      if (!txHash) return
+      methods.setValue(SendFormFields.TxHash, txHash)
+      history.push(SendRoutes.Status)
+    },
+    [handleFormSend, history, methods],
+  )
 
   const handleAssetSelect = useCallback(
     (assetId: AssetId) => {
@@ -141,7 +154,7 @@ export const Form: React.FC<SendFormProps> = ({ initialAssetId, input = '', acco
       {/* eslint-disable-next-line jsx-a11y/no-noninteractive-element-interactions */}
       <form
         style={formStyle}
-        onSubmit={methods.handleSubmit(handleFormSend)}
+        onSubmit={methods.handleSubmit(handleSubmit)}
         onKeyDown={checkKeyDown}
       >
         <AnimatePresence mode='wait' initial={false}>
@@ -164,6 +177,9 @@ export const Form: React.FC<SendFormProps> = ({ initialAssetId, input = '', acco
             </Route>
             <Route path={SendRoutes.Confirm}>
               <Confirm />
+            </Route>
+            <Route path={SendRoutes.Status}>
+              <Status />
             </Route>
             <Redirect exact from='/' to={SendRoutes.Select} />
           </Switch>

--- a/src/components/Modals/Send/SendCommon.tsx
+++ b/src/components/Modals/Send/SendCommon.tsx
@@ -2,6 +2,7 @@ export enum SendRoutes {
   Address = '/send/address',
   Details = '/send/details',
   Confirm = '/send/confirm',
+  Status = '/send/status',
   Select = '/send/select',
   Scan = '/send/scan',
 }
@@ -23,4 +24,5 @@ export enum SendFormFields {
   AmountFieldError = 'amountFieldError',
   SendMax = 'sendMax',
   CustomNonce = 'customNonce',
+  TxHash = 'txHash',
 }

--- a/src/components/Modals/Send/hooks/useFormSend/useFormSend.tsx
+++ b/src/components/Modals/Send/hooks/useFormSend/useFormSend.tsx
@@ -17,7 +17,7 @@ export const useFormSend = () => {
   } = useWallet()
 
   const handleFormSend = useCallback(
-    async (sendInput: SendInput): Promise<string> => {
+    async (sendInput: SendInput): Promise<string | undefined> => {
       try {
         const asset = selectAssetById(store.getState(), sendInput.assetId)
         if (!asset) throw new Error(`No asset found for assetId ${sendInput.assetId}`)
@@ -65,7 +65,6 @@ export const useFormSend = () => {
           isClosable: true,
           position: 'top-right',
         })
-        return ''
       }
     },
     [toast, translate, wallet],

--- a/src/components/Modals/Send/hooks/useFormSend/useFormSend.tsx
+++ b/src/components/Modals/Send/hooks/useFormSend/useFormSend.tsx
@@ -2,7 +2,6 @@ import { ExternalLinkIcon } from '@chakra-ui/icons'
 import { Link, Text, useToast } from '@chakra-ui/react'
 import { useCallback } from 'react'
 import { useTranslate } from 'react-polyglot'
-import { useModal } from 'hooks/useModal/useModal'
 import { useWallet } from 'hooks/useWallet/useWallet'
 import { selectAssetById } from 'state/slices/selectors'
 import { store } from 'state/store'
@@ -13,14 +12,12 @@ import { handleSend } from '../../utils'
 export const useFormSend = () => {
   const toast = useToast()
   const translate = useTranslate()
-  const send = useModal('send')
-  const qrCode = useModal('qrCode')
   const {
     state: { wallet },
   } = useWallet()
 
   const handleFormSend = useCallback(
-    async (sendInput: SendInput) => {
+    async (sendInput: SendInput): Promise<string> => {
       try {
         const asset = selectAssetById(store.getState(), sendInput.assetId)
         if (!asset) throw new Error(`No asset found for assetId ${sendInput.assetId}`)
@@ -52,6 +49,8 @@ export const useFormSend = () => {
             position: 'top-right',
           })
         }, 5000)
+
+        return broadcastTXID
       } catch (e) {
         // If we're here, we know asset is defined
         const asset = selectAssetById(store.getState(), sendInput.assetId)!
@@ -66,13 +65,10 @@ export const useFormSend = () => {
           isClosable: true,
           position: 'top-right',
         })
-      } finally {
-        // Sends may be done from the context of a QR code modal, or a send modal, which are similar, but effectively diff. modal refs
-        qrCode.close()
-        send.close()
+        return ''
       }
     },
-    [qrCode, send, toast, translate, wallet],
+    [toast, translate, wallet],
   )
 
   return {

--- a/src/components/Modals/Send/hooks/useSendDetails/useSendDetails.tsx
+++ b/src/components/Modals/Send/hooks/useSendDetails/useSendDetails.tsx
@@ -4,7 +4,6 @@ import type { FeeDataEstimate } from '@shapeshiftoss/chain-adapters'
 import { useQuery } from '@tanstack/react-query'
 import { useCallback, useEffect, useMemo, useState } from 'react'
 import { useFormContext, useWatch } from 'react-hook-form'
-import { useHistory } from 'react-router-dom'
 import { estimateFees } from 'components/Modals/Send/utils'
 import { getChainAdapterManager } from 'context/PluginProvider/chainAdapterSingleton'
 import { useDebounce } from 'hooks/useDebounce/useDebounce'
@@ -24,7 +23,7 @@ import {
 import { useAppSelector } from 'state/store'
 
 import type { SendInput } from '../../Form'
-import { SendFormFields, SendRoutes } from '../../SendCommon'
+import { SendFormFields } from '../../SendCommon'
 
 type AmountFieldName = SendFormFields.FiatAmount | SendFormFields.AmountCryptoPrecision
 
@@ -32,7 +31,6 @@ type UseSendDetailsReturnType = {
   balancesLoading: boolean
   fieldName: AmountFieldName
   handleInputChange(inputValue: string): void
-  handleNextClick(): void
   handleSendMax(): Promise<void>
   isLoading: boolean
   toggleIsFiat(): void
@@ -44,7 +42,6 @@ type UseSendDetailsReturnType = {
 // i.e. you don't send from an asset, you send from an account containing an asset
 export const useSendDetails = (): UseSendDetailsReturnType => {
   const [fieldName, setFieldName] = useState<AmountFieldName>(SendFormFields.AmountCryptoPrecision)
-  const history = useHistory()
   const { setValue } = useFormContext<SendInput>()
   const assetId = useWatch<SendInput, SendFormFields.AssetId>({
     name: SendFormFields.AssetId,
@@ -328,8 +325,6 @@ export const useSendDetails = (): UseSendDetailsReturnType => {
     setValue(SendFormFields.EstimatedFees, estimatedFees)
   }, [estimatedFees, sendMax, setValue])
 
-  const handleNextClick = () => history.push(SendRoutes.Confirm)
-
   const handleSendMax = useCallback(async () => {
     setValue(SendFormFields.SendMax, true)
     // Clear existing amount errors.
@@ -412,7 +407,6 @@ export const useSendDetails = (): UseSendDetailsReturnType => {
     fieldName,
     cryptoHumanBalance,
     fiatBalance: userCurrencyBalance,
-    handleNextClick,
     handleSendMax,
     handleInputChange,
     isLoading: isEstimatedFormFeesLoading,

--- a/src/components/Modals/Send/views/Details.tsx
+++ b/src/components/Modals/Send/views/Details.tsx
@@ -65,6 +65,8 @@ export const Details = () => {
   const history = useHistory()
   const translate = useTranslate()
 
+  const handleNextClick = useCallback(() => history.push(SendRoutes.Confirm), [history])
+
   const {
     accountId,
     amountFieldError,
@@ -103,7 +105,6 @@ export const Details = () => {
     fieldName,
     cryptoHumanBalance,
     fiatBalance,
-    handleNextClick,
     handleSendMax,
     handleInputChange,
     isLoading,

--- a/src/components/Modals/Send/views/Status.tsx
+++ b/src/components/Modals/Send/views/Status.tsx
@@ -1,0 +1,100 @@
+import { CheckCircleIcon, WarningIcon } from '@chakra-ui/icons'
+import { Card } from '@chakra-ui/react'
+import { TxStatus } from '@shapeshiftoss/unchained-client'
+import React, { useCallback, useMemo } from 'react'
+import { useWatch } from 'react-hook-form'
+import { CircularProgress } from 'components/CircularProgress/CircularProgress'
+import { useModal } from 'hooks/useModal/useModal'
+import { useTxStatus } from 'hooks/useTxStatus/useTxStatus'
+import { getTxLink } from 'lib/getTxLink'
+import { SharedStatus } from 'pages/RFOX/components/Shared/SharedStatus'
+import { selectAssetById } from 'state/slices/selectors'
+import { useAppSelector } from 'state/store'
+
+import type { SendInput } from '../Form'
+import { SendFormFields } from '../SendCommon'
+
+type BodyContent = {
+  key: TxStatus
+  title: string
+  body: string | [string, Record<string, string | number>]
+  element: JSX.Element
+}
+
+export const Status: React.FC = () => {
+  const send = useModal('send')
+  const qrCode = useModal('qrCode')
+
+  const handleClose = useCallback(() => {
+    send.close()
+    qrCode.close()
+  }, [qrCode, send])
+
+  const txHash = useWatch<SendInput, SendFormFields.TxHash>({ name: SendFormFields.TxHash })
+  const assetId = useWatch<SendInput, SendFormFields.AssetId>({ name: SendFormFields.AssetId })
+  const amountCryptoPrecision = useWatch<SendInput, SendFormFields.AmountCryptoPrecision>({
+    name: SendFormFields.AmountCryptoPrecision,
+  })
+  const accountId = useWatch<SendInput, SendFormFields.AccountId>({
+    name: SendFormFields.AccountId,
+  })
+  const asset = useAppSelector(state => selectAssetById(state, assetId ?? ''))
+
+  const txStatus = useTxStatus({
+    accountId,
+    txHash: txHash || null,
+  })
+
+  const bodyContent: BodyContent | null = useMemo(() => {
+    if (!asset) return null
+    switch (txStatus) {
+      case undefined:
+      case TxStatus.Pending:
+        return {
+          key: TxStatus.Pending,
+          title: 'pools.waitingForConfirmation',
+          body: [
+            'modals.send.status.pendingBody',
+            {
+              amount: amountCryptoPrecision,
+              symbol: asset.symbol,
+            },
+          ],
+          element: <CircularProgress size='75px' />,
+        }
+      case TxStatus.Confirmed:
+        return {
+          key: TxStatus.Confirmed,
+          title: 'common.success',
+          body: [
+            'modals.send.youHaveSent',
+            {
+              amount: amountCryptoPrecision,
+              symbol: asset.symbol,
+            },
+          ],
+          element: <CheckCircleIcon color='green.500' boxSize='75px' />,
+        }
+      case TxStatus.Failed:
+        return {
+          key: TxStatus.Failed,
+          title: 'transactionRow.failed',
+          body: 'common.transactionFailedBody',
+          element: <WarningIcon color='red.500' boxSize='75px' />,
+        }
+      default:
+        return null
+    }
+  }, [txStatus, amountCryptoPrecision, asset])
+
+  const txLink = useMemo(
+    () => getTxLink({ txId: txHash ?? '', defaultExplorerBaseUrl: asset?.explorerTxLink ?? '' }),
+    [asset?.explorerTxLink, txHash],
+  )
+
+  return (
+    <Card width='full'>
+      <SharedStatus txLink={txLink} body={bodyContent} onClose={handleClose} />
+    </Card>
+  )
+}

--- a/src/components/Modals/Send/views/Status.tsx
+++ b/src/components/Modals/Send/views/Status.tsx
@@ -83,7 +83,18 @@ export const Status: React.FC = () => {
           element: <WarningIcon color='red.500' boxSize='75px' />,
         }
       default:
-        return null
+        return {
+          key: TxStatus.Pending,
+          title: 'pools.waitingForConfirmation',
+          body: [
+            'modals.send.status.pendingBody',
+            {
+              amount: amountCryptoPrecision,
+              symbol: asset.symbol,
+            },
+          ],
+          element: <CircularProgress size='75px' />,
+        }
     }
   }, [txStatus, amountCryptoPrecision, asset])
 

--- a/src/pages/RFOX/components/Shared/SharedStatus.tsx
+++ b/src/pages/RFOX/components/Shared/SharedStatus.tsx
@@ -18,9 +18,10 @@ type SharedStatusProps = {
   body: SharedBodyContent | null
   txLink?: string
   onBack?: () => void
+  onClose?: () => void
 }
 
-export const SharedStatus: React.FC<SharedStatusProps> = ({ body, txLink, onBack }) => {
+export const SharedStatus: React.FC<SharedStatusProps> = ({ body, txLink, onBack, onClose }) => {
   const translate = useTranslate()
   return (
     <SlideTransition>
@@ -43,9 +44,16 @@ export const SharedStatus: React.FC<SharedStatusProps> = ({ body, txLink, onBack
         <Button as={Link} href={txLink} size='lg' variant='ghost' isExternal>
           {translate('trade.viewTransaction')}
         </Button>
-        <Button size='lg' colorScheme='blue' onClick={onBack}>
-          {translate('common.goBack')}
-        </Button>
+        {onBack && (
+          <Button size='lg' colorScheme='blue' onClick={onBack}>
+            {translate('common.goBack')}
+          </Button>
+        )}
+        {onClose && (
+          <Button size='lg' variant='outline' onClick={onClose}>
+            {translate('common.close')}
+          </Button>
+        )}
       </CardFooter>
     </SlideTransition>
   )


### PR DESCRIPTION
## Description

Does what it says on the box - adds a new status step in send modal, following the status UX across the app, and preparing for SAFE status detection in sends.

## Issue (if applicable)

<!-----------------------------------------------------------------------------
If applicable, please link to the github issue and put `closes #XXXX` in your comment to auto-close the issue that your PR fixes.
------------------------------------------------------------------------------>

closes https://github.com/shapeshift/web/issues/7696

## Risk

> High Risk PRs Require 2 approvals

<!-----------------------------------------------------------------------------
Outline the scope of your changes and the risk associated with them. You must use your discretion as an engineer to determine the potential impact of your changes.

WARNING: If your PR introduces a new on-chain transaction or modifies an existing one, please add the "High-Risk" label to this PR and ask for 2 reviewers to approve it before merging.

E.g. an upgrade to `hdwallet` or core state management would be considered higher risk, and might require a full regression test. UI or isolated view changes, or something behind a feature flag may have near zero risk. Small bug fixes might require testing isolated to the specific fix.
------------------------------------------------------------------------------>

> What protocols, transaction types, wallets or contract interactions might be affected by this PR?

Medium - both send and QR modal could be borked, test accordingly

## Testing

<!-----------------------------------------------------------------------------
We treat every PR to be merged with the same scrutiny as if we were merging directly to production.

Your PR will not be merged if you do not complete the sections below for our engineering and operations teams to test.
------------------------------------------------------------------------------>

- In send modal, the new status step is happy with status detection working 
- In QR code modal, the new status step is happy with status detection working 

### Engineering

<!-----------------------------------------------------------------------------
Include sufficient information here for an engineer to test your PR. This may include how to test locally, in a built environment, changes to infrastructure etc.
------------------------------------------------------------------------------>

- ^

### Operations

- [ ] :checkered_flag: My feature is behind a flag and doesn't require operations testing (yet)

<!-----------------------------------------------------------------------------
If your changes have a user-facing impact, describe how a non-technical QA team can functionally test your changes in a preview environment.

If they are not user-facing please describe how to test for any regressions that may occur.
------------------------------------------------------------------------------>

- ^

## Screenshots (if applicable)

<!-- av pr metadata
This information is embedded by the av CLI when creating PRs to track the status of stacks when using Aviator. Please do not delete or edit this section of the PR.
```
{"parent":"develop","parentHead":"","trunk":"develop"}
```
-->


<img width="561" alt="image" src="https://github.com/user-attachments/assets/850268ff-4533-480a-b9cb-85a24ba4f22d">

- Send Modal

https://jam.dev/c/67262476-c922-473d-ade4-3a1d52ba933a

- QR code modal 

https://jam.dev/c/14ce90aa-7256-4741-867c-410088cab4ee