### PR TITLE
feat: single click MM update CTA

### DIFF
--- a/src/assets/translations/en/main.json
+++ b/src/assets/translations/en/main.json
@@ -1538,7 +1538,7 @@
       },
       "update": {
         "title": "Multichain Snap needs updating",
-        "subtitle": "Uninstall the ShapeShift multichain Snap and click 'Update' to keep using ShapeShifts multichain features with MetaMask!"
+        "subtitle": "Click 'Update' to continue using ShapeShift's multichain features with MetaMask!"
       },
       "secondaryTitle": "The best Multichain experience for MetaMask: Powered by ShapeShift",
       "secondaryBody": "Send, receive, track, trade, and earn with the ShapeShift Multichain Snap on the following chains:",
@@ -1551,6 +1551,7 @@
     },
     "metaMaskSnapConfirm": {
       "title": "Install Multichain Snap",
+      "updateTitle": "Update Multichain Snap",
       "warningExperimental": "The ShapeShift Multichain Snap is a new, experimental feature, provided \"as is\"",
       "warningBackup": "Ensure you have backed up your MetaMask seed phrase. Any funds you send to non-EVM chains using this Snap will be directed to the default account you set up with MetaMask.",
       "agreeIntro": "Before continuing please read the following:",
@@ -1564,7 +1565,8 @@
       "agreeItem4": "By enabling the ShapeShift Multichain Snap, you acknowledge you are using it at your own risk",
       "readAndUnderstood": "I have read and understand",
       "seedBackedUp": "I have backed up my MetaMask seed phrase",
-      "acceptInstall": "Confirm & Install"
+      "acceptInstall": "Confirm & Install",
+      "acceptUpdate": "Confirm & Update"
     },
     "coinbase": {
       "errors": {

--- a/src/components/Modals/Snaps/SnapConfirm.tsx
+++ b/src/components/Modals/Snaps/SnapConfirm.tsx
@@ -16,6 +16,7 @@ import { useTranslate } from 'react-polyglot'
 import { enableShapeShiftSnap } from 'utils/snaps'
 import { CircularProgress } from 'components/CircularProgress/CircularProgress'
 import { RawText } from 'components/Text'
+import { useIsSnapInstalled } from 'hooks/useIsSnapInstalled/useIsSnapInstalled'
 import { getMixPanel } from 'lib/mixpanel/mixPanelSingleton'
 import { MixPanelEvent } from 'lib/mixpanel/types'
 
@@ -24,6 +25,7 @@ type SnapConfirmProps = {
 }
 
 export const SnapConfirm: React.FC<SnapConfirmProps> = ({ onClose }) => {
+  const { isSnapInstalled, isCorrectVersion } = useIsSnapInstalled()
   const [isInstalling, setIsInstalling] = useState(false)
   const [hasAgreed, setHasAgreed] = useState(false)
   const [hasPinkySworeSeedPhraseIsBackedUp, setHasPinkySworeSeedPhraseIsBackedUp] = useState(false)
@@ -69,7 +71,13 @@ export const SnapConfirm: React.FC<SnapConfirmProps> = ({ onClose }) => {
   return (
     <>
       <ModalHeader textAlign='center'>
-        <Heading as='h4'>{translate('walletProvider.metaMaskSnapConfirm.title')}</Heading>
+        <Heading as='h4'>
+          {translate(
+            isSnapInstalled && !isCorrectVersion
+              ? 'walletProvider.metaMaskSnapConfirm.updateTitle'
+              : 'walletProvider.metaMaskSnapConfirm.title',
+          )}
+        </Heading>
       </ModalHeader>
       <ModalBody>
         <Alert status='warning' borderRadius='lg' mb={4}>
@@ -116,7 +124,11 @@ export const SnapConfirm: React.FC<SnapConfirmProps> = ({ onClose }) => {
           isDisabled={!(hasAgreed && hasPinkySworeSeedPhraseIsBackedUp)}
           onClick={handleAddSnap}
         >
-          {translate('walletProvider.metaMaskSnapConfirm.acceptInstall')}
+          {translate(
+            isSnapInstalled && !isCorrectVersion
+              ? 'walletProvider.metaMaskSnapConfirm.acceptUpdate'
+              : 'walletProvider.metaMaskSnapConfirm.acceptInstall',
+          )}
         </Button>
       </ModalFooter>
     </>

--- a/src/hooks/useIsSnapInstalled/useIsSnapInstalled.tsx
+++ b/src/hooks/useIsSnapInstalled/useIsSnapInstalled.tsx
@@ -166,7 +166,6 @@ export const useIsSnapInstalled = (): {
     return () => clearInterval(intervalId)
   }, [checkSnapInstallation, wallet])
 
-  console.log({ isSnapInstalled, isCorrectVersion })
   return { isSnapInstalled, isCorrectVersion }
 }
 

--- a/src/hooks/useIsSnapInstalled/useIsSnapInstalled.tsx
+++ b/src/hooks/useIsSnapInstalled/useIsSnapInstalled.tsx
@@ -166,6 +166,7 @@ export const useIsSnapInstalled = (): {
     return () => clearInterval(intervalId)
   }, [checkSnapInstallation, wallet])
 
+  console.log({ isSnapInstalled, isCorrectVersion })
   return { isSnapInstalled, isCorrectVersion }
 }
 

--- a/src/utils/snaps.ts
+++ b/src/utils/snaps.ts
@@ -1,5 +1,4 @@
 import detectEthereumProvider from '@metamask/detect-provider'
-import { enableShapeShiftSnap as _enableShapeShiftSnap } from '@shapeshiftoss/metamask-snaps-adapter'
 import assert from 'assert'
 import { getConfig } from 'config'
 import type { Eip1193Provider } from 'ethers'
@@ -22,11 +21,21 @@ type GetSnapsResult = Record<
 >
 
 export const enableShapeShiftSnap = async (): Promise<void> => {
+  const provider = (await detectEthereumProvider()) as Eip1193Provider
+
   const snapVersion = getConfig().REACT_APP_SNAP_VERSION
   const isSnapFeatureEnabled = getConfig().REACT_APP_EXPERIMENTAL_MM_SNAPPY_FINGERS
   assert(isSnapFeatureEnabled, 'Snap feature flag is disabled')
   const snapId = getConfig().REACT_APP_SNAP_ID
-  await _enableShapeShiftSnap(snapId, snapVersion)
+
+  await provider.request({
+    method: 'wallet_requestSnaps',
+    params: {
+      [snapId]: {
+        version: snapVersion,
+      },
+    },
+  })
 }
 
 export const getSnapVersion = async (): Promise<string | null> => {


### PR DESCRIPTION
## Description

As it turns out, we *can* do this, but the snap adapter itself is borked, as it early returns if the snap is already installed:
![image](https://github.com/user-attachments/assets/021ab3a9-688a-4d8b-b4b9-f7e9bf7d2892)
Decided *not* to go with updating checks there, and rather implement the JSON-RPC call in web, as this is where such methods should live (or in hdwallet/chain-adapters) anyway.

## Issue (if applicable)

<!-----------------------------------------------------------------------------
If applicable, please link to the github issue and put `closes #XXXX` in your comment to auto-close the issue that your PR fixes.
------------------------------------------------------------------------------>

N/A, though relates to the closed https://github.com/shapeshift/web/issues/7725

## Risk

> High Risk PRs Require 2 approvals

<!-----------------------------------------------------------------------------
Outline the scope of your changes and the risk associated with them. You must use your discretion as an engineer to determine the potential impact of your changes.

WARNING: If your PR introduces a new on-chain transaction or modifies an existing one, please add the "High-Risk" label to this PR and ask for 2 reviewers to approve it before merging.

E.g. an upgrade to `hdwallet` or core state management would be considered higher risk, and might require a full regression test. UI or isolated view changes, or something behind a feature flag may have near zero risk. Small bug fixes might require testing isolated to the specific fix.
------------------------------------------------------------------------------>

> What protocols, transaction types, wallets or contract interactions might be affected by this PR?

Low

## Testing

<!-----------------------------------------------------------------------------
We treat every PR to be merged with the same scrutiny as if we were merging directly to production.

Your PR will not be merged if you do not complete the sections below for our engineering and operations teams to test.
------------------------------------------------------------------------------>

- Install the old version of the snap (eng., this can be done by monkey patching `snapVersion` to `1.0.0` in `enableShapeShiftSnap` and installing the snap (don't forget to revert this change and refresh the page before continuing here):
https://github.com/shapeshift/web/blob/37722b38a5ebcbd8004024270de236fea58e0c4d/src/utils/snaps.ts#L25
- Confirm update now only requires one click, and the header, title, body, and confirm buttons reflect the update flow
- Confirm uninstalling the snap is still detected and happy
- Confirm *not* having the snap installed is still detected and happy


### Engineering

<!-----------------------------------------------------------------------------
Include sufficient information here for an engineer to test your PR. This may include how to test locally, in a built environment, changes to infrastructure etc.
------------------------------------------------------------------------------>

- ^

### Operations

- [ ] :checkered_flag: My feature is behind a flag and doesn't require operations testing (yet)

<!-----------------------------------------------------------------------------
If your changes have a user-facing impact, describe how a non-technical QA team can functionally test your changes in a preview environment.

If they are not user-facing please describe how to test for any regressions that may occur.
------------------------------------------------------------------------------>

- If you have the previous version of the snap installed, you can also test this out. Else, this can only be monkey-patched in code so can't be tested, but we can focus on regression testing here

## Screenshots (if applicable)

https://jam.dev/c/dd665da3-fc04-4a6b-ae84-826eb824137d

<!-- av pr metadata
This information is embedded by the av CLI when creating PRs to track the status of stacks when using Aviator. Please do not delete or edit this section of the PR.
```
{"parent":"develop","parentHead":"","trunk":"develop"}
```
-->
