### PR TITLE
fix: onClick borked in non-read only DeFi opportunities

### DIFF
--- a/src/components/EarnDashboard/components/ProviderDetails/OpportunityRow.tsx
+++ b/src/components/EarnDashboard/components/ProviderDetails/OpportunityRow.tsx
@@ -86,7 +86,7 @@ export const OpportunityRow: React.FC<
 
   const handleClick = useCallback(
     (action: DefiAction) => {
-      if (asset?.isPool) {
+      if (asset?.isPool && opportunity.isReadOnly) {
         return history.push(`/trade/${assetId}`)
       }
       if (opportunity.isReadOnly) {
@@ -96,7 +96,7 @@ export const OpportunityRow: React.FC<
       }
       onClick(opportunity, action)
     },
-    [asset?.isPool, assetId, history, onClick, opportunity],
+    [asset, assetId, history, onClick, opportunity],
   )
 
   const handleClaimClick = useCallback(() => handleClick(DefiAction.Claim), [handleClick])
@@ -140,7 +140,7 @@ export const OpportunityRow: React.FC<
             <NestedAsset
               key={rewardAssetId}
               isClaimableRewards={isClaimableRewards}
-              isExternal={opportunity.isReadOnly}
+              isExternal={opportunity.isReadOnly && !asset?.isPool}
               assetId={rewardAssetId}
               balances={rewardBalance}
               onClick={handleClaimClick}
@@ -174,6 +174,7 @@ export const OpportunityRow: React.FC<
     underlyingAssetBalances,
     isClaimableRewards,
     opportunity.isReadOnly,
+    asset?.isPool,
     handleClaimClick,
     translate,
     assetId,
@@ -218,7 +219,7 @@ export const OpportunityRow: React.FC<
             icons={icons}
             subText={assetCellSubText}
             justifyContent='flex-start'
-            isExternal={opportunity.isReadOnly}
+            isExternal={opportunity.isReadOnly && !asset?.isPool}
             opportunityName={opportunity.opportunityName}
           />
           <Amount.Crypto


### PR DESCRIPTION
## Description

<!-- Please describe your changes -->

Fast-follow of https://github.com/shapeshift/web/pull/7678, which borked onClick handlers for natively supported DeFi opportunities:

https://jam.dev/c/44cff944-f6df-488b-804d-09cb6a2e10d9


## Issue (if applicable)

<!-----------------------------------------------------------------------------
If applicable, please link to the github issue and put `closes #XXXX` in your comment to auto-close the issue that your PR fixes.
------------------------------------------------------------------------------>

closes N/A

## Risk

> High Risk PRs Require 2 approvals

<!-----------------------------------------------------------------------------
Outline the scope of your changes and the risk associated with them. You must use your discretion as an engineer to determine the potential impact of your changes.

WARNING: If your PR introduces a new on-chain transaction or modifies an existing one, please add the "High-Risk" label to this PR and ask for 2 reviewers to approve it before merging.

E.g. an upgrade to `hdwallet` or core state management would be considered higher risk, and might require a full regression test. UI or isolated view changes, or something behind a feature flag may have near zero risk. Small bug fixes might require testing isolated to the specific fix.
------------------------------------------------------------------------------>

> What protocols, transaction types, wallets or contract interactions might be affected by this PR?

Low, immediate fix of an introduced bug

## Testing

<!-----------------------------------------------------------------------------
We treat every PR to be merged with the same scrutiny as if we were merging directly to production.

Your PR will not be merged if you do not complete the sections below for our engineering and operations teams to test.
------------------------------------------------------------------------------>

- Natively supported DeFi opportunities are clickable and route to the correct place
- Frankenstein opportunities (read: technically read-only as we don't have first-class DeFi modal for them, but we actually support them in Portals) route to swapper
- RFOX still route to RFOX page
- Actual read-only opportunities if held (e.g Idle) route to dApp page

### Engineering

<!-----------------------------------------------------------------------------
Include sufficient information here for an engineer to test your PR. This may include how to test locally, in a built environment, changes to infrastructure etc.
------------------------------------------------------------------------------>

- ^

### Operations

- [ ] :checkered_flag: My feature is behind a flag and doesn't require operations testing (yet)

<!-----------------------------------------------------------------------------
If your changes have a user-facing impact, describe how a non-technical QA team can functionally test your changes in a preview environment.

If they are not user-facing please describe how to test for any regressions that may occur.
------------------------------------------------------------------------------>

- ^

## Screenshots (if applicable)

https://jam.dev/c/85a2e92c-6e9c-491c-b35f-f622e464da16

<!-- av pr metadata
This information is embedded by the av CLI when creating PRs to track the status of stacks when using Aviator. Please do not delete or edit this section of the PR.
```
{"parent":"develop","parentHead":"","trunk":"develop"}
```
-->
