### PR TITLE
fix: gracefully handle swapper account loading

### DIFF
--- a/src/components/MultiHopTrade/components/TradeInput/TradeInput.tsx
+++ b/src/components/MultiHopTrade/components/TradeInput/TradeInput.tsx
@@ -26,7 +26,11 @@ import { getMixPanel } from 'lib/mixpanel/mixPanelSingleton'
 import { MixPanelEvent } from 'lib/mixpanel/types'
 import { isKeplrHDWallet } from 'lib/utils'
 import { selectIsSnapshotApiQueriesPending, selectVotingPower } from 'state/apis/snapshot/selectors'
-import { selectHasUserEnteredAmount, selectInputSellAsset } from 'state/slices/selectors'
+import {
+  selectHasUserEnteredAmount,
+  selectInputSellAsset,
+  selectIsAccountMetadataLoading,
+} from 'state/slices/selectors'
 import {
   selectActiveQuote,
   selectFirstHop,
@@ -77,6 +81,7 @@ export const TradeInput = ({ isCompact, tradeInputRef }: TradeInputProps) => {
   const [shouldShowArbitrumBridgeAcknowledgement, setShouldShowArbitrumBridgeAcknowledgement] =
     useState(false)
   const isKeplr = useMemo(() => !!wallet && isKeplrHDWallet(wallet), [wallet])
+  const isAccountMetadataLoading = useAppSelector(selectIsAccountMetadataLoading)
 
   const sellAsset = useAppSelector(selectInputSellAsset)
   const tradeQuoteStep = useAppSelector(selectFirstHop)
@@ -113,6 +118,7 @@ export const TradeInput = ({ isCompact, tradeInputRef }: TradeInputProps) => {
 
   const isLoading = useMemo(
     () =>
+      isAccountMetadataLoading ||
       (!isAnyTradeQuoteLoaded && !isTradeQuoteRequestAborted) ||
       isConfirmationLoading ||
       // Only consider snapshot API queries as pending if we don't have voting power yet
@@ -124,6 +130,7 @@ export const TradeInput = ({ isCompact, tradeInputRef }: TradeInputProps) => {
       isTradeQuoteRequestAborted,
       isConfirmationLoading,
       isVotingPowerLoading,
+      isAccountMetadataLoading,
     ],
   )
 

--- a/src/components/MultiHopTrade/components/TradeInput/components/ConfirmSummary.tsx
+++ b/src/components/MultiHopTrade/components/TradeInput/components/ConfirmSummary.tsx
@@ -238,6 +238,10 @@ export const ConfirmSummary = ({
     translate,
   ])
 
+  const buttonText = useMemo(() => {
+    return <Text translation={quoteStatusTranslation} />
+  }, [quoteStatusTranslation])
+
   return (
     <>
       <CardFooter
@@ -303,6 +307,8 @@ export const ConfirmSummary = ({
         />
 
         <Button
+          isLoading={isAccountMetadataLoading}
+          loadingText={buttonText}
           type='submit'
           colorScheme={quoteHasError ? 'red' : 'blue'}
           size='lg-multiline'
@@ -310,7 +316,7 @@ export const ConfirmSummary = ({
           isDisabled={shouldDisablePreviewButton}
           mx={-2}
         >
-          <Text translation={quoteStatusTranslation} />
+          {buttonText}
         </Button>
       </CardFooter>
     </>

--- a/src/components/MultiHopTrade/components/TradeInput/components/ManualAddressEntry.tsx
+++ b/src/components/MultiHopTrade/components/TradeInput/components/ManualAddressEntry.tsx
@@ -15,7 +15,7 @@ import { useModal } from 'hooks/useModal/useModal'
 import { useWallet } from 'hooks/useWallet/useWallet'
 import { useWalletSupportsChain } from 'hooks/useWalletSupportsChain/useWalletSupportsChain'
 import { parseAddressInputWithChainId } from 'lib/address/address'
-import { selectAccountIdsByAssetId } from 'state/slices/selectors'
+import { selectAccountIdsByAssetId, selectIsAccountMetadataLoading } from 'state/slices/selectors'
 import { selectInputBuyAsset } from 'state/slices/tradeInputSlice/selectors'
 import { tradeInput } from 'state/slices/tradeInputSlice/tradeInputSlice'
 import { useAppDispatch, useAppSelector } from 'state/store'
@@ -28,6 +28,7 @@ type ManualAddressEntryProps = {
 export const ManualAddressEntry: FC<ManualAddressEntryProps> = memo(
   ({ description, shouldForceManualAddressEntry }: ManualAddressEntryProps): JSX.Element | null => {
     const dispatch = useAppDispatch()
+    const isAccountMetadataLoading = useAppSelector(selectIsAccountMetadataLoading)
 
     const {
       formState: { isValidating },
@@ -57,6 +58,7 @@ export const ManualAddressEntry: FC<ManualAddressEntryProps> = memo(
     const { manualReceiveAddress } = useReceiveAddress(useReceiveAddressArgs)
 
     const shouldShowManualReceiveAddressInput = useMemo(() => {
+      if (isAccountMetadataLoading) return false
       if (shouldForceManualAddressEntry) return true
       if (manualReceiveAddress) return false
       // Ledger "supports" all chains, but may not have them connected
@@ -69,6 +71,7 @@ export const ManualAddressEntry: FC<ManualAddressEntryProps> = memo(
       wallet,
       walletSupportsBuyAssetChain,
       shouldForceManualAddressEntry,
+      isAccountMetadataLoading,
     ])
 
     const chainAdapterManager = getChainAdapterManager()

--- a/src/components/MultiHopTrade/components/TradeInput/components/RecipientAddress.tsx
+++ b/src/components/MultiHopTrade/components/TradeInput/components/RecipientAddress.tsx
@@ -25,7 +25,7 @@ import type { TextPropTypes } from 'components/Text/Text'
 import { useWallet } from 'hooks/useWallet/useWallet'
 import { parseAddressInputWithChainId } from 'lib/address/address'
 import { middleEllipsis } from 'lib/utils'
-import { selectInputBuyAsset } from 'state/slices/selectors'
+import { selectInputBuyAsset, selectIsAccountMetadataLoading } from 'state/slices/selectors'
 import { tradeInput } from 'state/slices/tradeInputSlice/tradeInputSlice'
 import { useAppDispatch, useAppSelector } from 'state/store'
 
@@ -42,6 +42,7 @@ export const RecipientAddress: React.FC<RecipientAddressProps> = ({
 }) => {
   const translate = useTranslate()
   const dispatch = useAppDispatch()
+  const isAccountMetadataLoading = useAppSelector(selectIsAccountMetadataLoading)
   const wallet = useWallet().state.wallet
   const useReceiveAddressArgs = useMemo(
     () => ({
@@ -154,7 +155,7 @@ export const RecipientAddress: React.FC<RecipientAddressProps> = ({
 
   const handleFormSubmit = useMemo(() => handleSubmit(onSubmit), [handleSubmit, onSubmit])
 
-  if (!receiveAddress || shouldForceManualAddressEntry) return null
+  if (!receiveAddress || shouldForceManualAddressEntry || isAccountMetadataLoading) return null
 
   return isRecipientAddressEditing ? (
     <form>

--- a/src/components/MultiHopTrade/components/TradeInput/components/SellAssetInput.tsx
+++ b/src/components/MultiHopTrade/components/TradeInput/components/SellAssetInput.tsx
@@ -24,6 +24,8 @@ export type SellAssetInputProps = {
   onAccountIdChange: AccountDropdownProps['onChange']
   labelPostFix?: TradeAssetInputProps['labelPostFix']
   percentOptions: number[]
+  isReadOnly?: TradeAssetInputProps['isReadOnly']
+  isLoading?: boolean
 }
 
 export const SellAssetInput = memo(
@@ -33,6 +35,7 @@ export const SellAssetInput = memo(
     label,
     onAccountIdChange,
     percentOptions,
+    isLoading,
     ...rest
   }: SellAssetInputProps) => {
     const sellAmountCryptoPrecision = useAppSelector(selectInputSellAmountCryptoPrecision)
@@ -99,8 +102,8 @@ export const SellAssetInput = memo(
         isSendMaxDisabled={false}
         onChange={handleSellAssetInputChange}
         percentOptions={percentOptions}
-        showInputSkeleton={false}
-        showFiatSkeleton={false}
+        showInputSkeleton={isLoading}
+        showFiatSkeleton={isLoading}
         label={label}
         formControlProps={formControlProps}
         onAccountIdChange={onAccountIdChange}

--- a/src/components/MultiHopTrade/components/TradeInput/components/TradeInputBody.tsx
+++ b/src/components/MultiHopTrade/components/TradeInput/components/TradeInputBody.tsx
@@ -150,8 +150,8 @@ export const TradeInputBody = ({
 
   // disable switching assets if the buy asset isn't supported
   const shouldDisableSwitchAssets = useMemo(() => {
-    return !walletSupportsBuyAssetChain
-  }, [walletSupportsBuyAssetChain])
+    return !walletSupportsBuyAssetChain || isLoading
+  }, [walletSupportsBuyAssetChain, isLoading])
 
   return (
     <Stack spacing={0}>
@@ -162,6 +162,7 @@ export const TradeInputBody = ({
         onAccountIdChange={setSellAssetAccountId}
         labelPostFix={sellTradeAssetSelect}
         percentOptions={percentOptions}
+        isLoading={isLoading}
       />
       <Flex alignItems='center' justifyContent='center' my={-2}>
         <Divider />


### PR DESCRIPTION
## Description

- Added some loaders while loading accounts on both inputs and invert assets
- Added a loader in the button of the swapper while loading accounts so it attracts user's eyes to the button, attracting them to read the text
- Brang down the `isAccountsMetadataLoading` one level deeper in `ManualAddressEntry` because there is a world where the component is lazyloaded but accounts are loading afterwhile (see issue's case)

<!-- Please describe your changes -->

## Issue (if applicable)

<!-----------------------------------------------------------------------------
If applicable, please link to the github issue and put `closes #XXXX` in your comment to auto-close the issue that your PR fixes.
------------------------------------------------------------------------------>

closes #7740

## Risk
High because swapper but medium regarding the scope
> High Risk PRs Require 2 approvals

<!-----------------------------------------------------------------------------
Outline the scope of your changes and the risk associated with them. You must use your discretion as an engineer to determine the potential impact of your changes.

WARNING: If your PR introduces a new on-chain transaction or modifies an existing one, please add the "High-Risk" label to this PR and ask for 2 reviewers to approve it before merging.

E.g. an upgrade to `hdwallet` or core state management would be considered higher risk, and might require a full regression test. UI or isolated view changes, or something behind a feature flag may have near zero risk. Small bug fixes might require testing isolated to the specific fix.
------------------------------------------------------------------------------>

> What protocols, transaction types, wallets or contract interactions might be affected by this PR?

## Testing
- Go on the swapper using a native wallet or any big account
- Clear your cache
- Connect again to the wallet
- Look at the gracefully handled accounts loading flow

<!-----------------------------------------------------------------------------
We treat every PR to be merged with the same scrutiny as if we were merging directly to production.

Your PR will not be merged if you do not complete the sections below for our engineering and operations teams to test.
------------------------------------------------------------------------------>

### Engineering
n/a
<!-----------------------------------------------------------------------------
Include sufficient information here for an engineer to test your PR. This may include how to test locally, in a built environment, changes to infrastructure etc.
------------------------------------------------------------------------------>

### Operations
n/a
- [ ] :checkered_flag: My feature is behind a flag and doesn't require operations testing (yet)

<!-----------------------------------------------------------------------------
If your changes have a user-facing impact, describe how a non-technical QA team can functionally test your changes in a preview environment.

If they are not user-facing please describe how to test for any regressions that may occur.
------------------------------------------------------------------------------>

## Screenshots (if applicable)
https://jam.dev/c/b2cb2aee-9ad8-43f5-a182-34b939a0b774