### PR TITLE
fix: display lending positions post-hardfork shenanigans

### DIFF
--- a/src/lib/utils/thorchain/lending.ts
+++ b/src/lib/utils/thorchain/lending.ts
@@ -159,7 +159,7 @@ export const getThorchainLendingPosition = async ({
 
     const allPositions = lendingPositionsResponse
     if (!allPositions.length) {
-      throw new Error(`No lending positions found for asset ID: ${assetId}`)
+      return null
     }
 
     const accountAddresses = await getAccountAddresses(accountId)

--- a/src/pages/Lending/YourLoans.tsx
+++ b/src/pages/Lending/YourLoans.tsx
@@ -207,7 +207,10 @@ export const YourLoans = () => {
   const translate = useTranslate()
   const lendingHeader = useMemo(() => <LendingHeader />, [])
 
-  const { data: lendingSupportedAssets } = useLendingSupportedAssets({ type: 'collateral' })
+  const { data: lendingSupportedAssets } = useLendingSupportedAssets({
+    type: 'collateral',
+    hasLoanCollateral: false,
+  })
 
   const history = useHistory()
 

--- a/src/pages/Lending/hooks/useAllLendingPositionsData.tsx
+++ b/src/pages/Lending/hooks/useAllLendingPositionsData.tsx
@@ -20,7 +20,10 @@ type UseAllLendingPositionsDataProps = {
 }
 
 export const useAllLendingPositionsData = ({ assetId }: UseAllLendingPositionsDataProps = {}) => {
-  const { data: lendingSupportedAssets } = useLendingSupportedAssets({ type: 'collateral' })
+  const { data: lendingSupportedAssets } = useLendingSupportedAssets({
+    type: 'collateral',
+    hasLoanCollateral: false,
+  })
 
   const accountIds = useAppSelector(selectWalletAccountIds)
   const accounts = useMemo(

--- a/src/pages/Lending/hooks/useLendingSupportedAssets/index.ts
+++ b/src/pages/Lending/hooks/useLendingSupportedAssets/index.ts
@@ -28,9 +28,11 @@ const queryKey = ['lendingSupportedAssets']
 export const useLendingSupportedAssets = ({
   type,
   statusFilter = 'Available',
+  hasLoanCollateral = true,
 }: {
   type: 'collateral' | 'borrow'
   statusFilter?: ThornodePoolStatuses | 'All'
+  hasLoanCollateral?: boolean
 }) => {
   const wallet = useWallet().state.wallet
   const { isSnapInstalled } = useIsSnapInstalled()
@@ -66,9 +68,11 @@ export const useLendingSupportedAssets = ({
   const selectSupportedAssets = useCallback(
     (data: ThornodePoolResponse[] | undefined) => {
       if (!data) return []
-      const pools = (availablePools ?? []).filter(
-        pool => type === 'borrow' || bnOrZero(pool.loan_collateral).gt(0),
-      )
+      const pools = (availablePools ?? []).filter(pool => {
+        if (type === 'borrow') return true
+        if (type === 'collateral') return !hasLoanCollateral || bnOrZero(pool.loan_collateral).gt(0)
+        return false
+      })
 
       const supportedAssets = pools
         .map(pool => {
@@ -99,7 +103,7 @@ export const useLendingSupportedAssets = ({
       }
       return supportedAssets
     },
-    [availablePools, type, wallet, walletChainIds, walletSupportChains],
+    [availablePools, hasLoanCollateral, type, wallet, walletChainIds, walletSupportChains],
   )
 
   const lendingSupportedAssetsQuery = useQuery({


### PR DESCRIPTION
## Description

Does precisely what it says on the box.
NOTE: While this fixes displaying positions, repays still can't be done because of close endpoint shenanigans: https://discord.com/channels/838986635756044328/1283906886051172427/1284230662517424254

## Issue (if applicable)

<!-----------------------------------------------------------------------------
If applicable, please link to the github issue and put `closes #XXXX` in your comment to auto-close the issue that your PR fixes.
------------------------------------------------------------------------------>

closes N/A

## Risk

> High Risk PRs Require 2 approvals

<!-----------------------------------------------------------------------------
Outline the scope of your changes and the risk associated with them. You must use your discretion as an engineer to determine the potential impact of your changes.

WARNING: If your PR introduces a new on-chain transaction or modifies an existing one, please add the "High-Risk" label to this PR and ask for 2 reviewers to approve it before merging.

E.g. an upgrade to `hdwallet` or core state management would be considered higher risk, and might require a full regression test. UI or isolated view changes, or something behind a feature flag may have near zero risk. Small bug fixes might require testing isolated to the specific fix.
------------------------------------------------------------------------------>

> What protocols, transaction types, wallets or contract interactions might be affected by this PR?

Low - ensure "Available Pools" is still displaying no pools

## Testing

<!-----------------------------------------------------------------------------
We treat every PR to be merged with the same scrutiny as if we were merging directly to production.

Your PR will not be merged if you do not complete the sections below for our engineering and operations teams to test.
------------------------------------------------------------------------------>

- "Available Pools" is still empty
- With a frame (or rather, Rabby watch-only address as Frame MM injection is currently borked following upstream changes) and a known borrower from the borrowers endpoint (https://paw.pt/i39K7GP3), lending positions are displayed

### Engineering

<!-----------------------------------------------------------------------------
Include sufficient information here for an engineer to test your PR. This may include how to test locally, in a built environment, changes to infrastructure etc.
------------------------------------------------------------------------------>

- ^

### Operations

- [ ] :checkered_flag: My feature is behind a flag and doesn't require operations testing (yet)

<!-----------------------------------------------------------------------------
If your changes have a user-facing impact, describe how a non-technical QA team can functionally test your changes in a preview environment.

If they are not user-facing please describe how to test for any regressions that may occur.
------------------------------------------------------------------------------>

- ^

## Screenshots (if applicable)

<!-- av pr metadata
This information is embedded by the av CLI when creating PRs to track the status of stacks when using Aviator. Please do not delete or edit this section of the PR.
```
{"parent":"develop","parentHead":"","trunk":"develop"}
```
-->

- develop

<img width="1112" alt="Screenshot 2024-09-13 at 20 20 00" src="https://github.com/user-attachments/assets/87cc1f37-3ab4-41e1-920a-849cc6f7cf8a">

- this diff

<img width="1428" alt="Screenshot 2024-09-13 at 21 22 37" src="https://github.com/user-attachments/assets/69a5d9a2-dcc8-48e6-9600-bcb4481bd232">



<!-- av pr metadata
This information is embedded by the av CLI when creating PRs to track the status of stacks when using Aviator. Please do not delete or edit this section of the PR.
```
{"parent":"develop","parentHead":"","trunk":"develop"}
```
-->
