### PR TITLE
fix: handle long asset names in send input

### DIFF
--- a/src/components/AccountCard.tsx
+++ b/src/components/AccountCard.tsx
@@ -1,10 +1,9 @@
 import { ChevronRightIcon } from '@chakra-ui/icons'
 import type { ButtonProps } from '@chakra-ui/react'
-import { Button, SkeletonCircle, SkeletonText, Tooltip } from '@chakra-ui/react'
+import { Box, Button, SkeletonCircle, SkeletonText, Tooltip } from '@chakra-ui/react'
 import type { Asset } from '@shapeshiftoss/types'
-import { useMemo } from 'react'
+import { useCallback, useMemo, useState } from 'react'
 import { useTranslate } from 'react-polyglot'
-import { trimWithEndEllipsis } from 'lib/utils'
 
 import { Amount } from './Amount/Amount'
 import { AssetIcon } from './AssetIcon'
@@ -19,8 +18,9 @@ type AccountCardProps = {
   onClick?: () => void
 } & ButtonProps
 
-const chevronRightIcon = <ChevronRightIcon boxSize={6} />
-const maxLabelLength = 40
+const leftIconBoxSize = '40px'
+const rightIconBoxSize = 6
+const chevronRightIcon = <ChevronRightIcon boxSize={rightIconBoxSize} />
 
 export const AccountCard = ({
   asset,
@@ -34,14 +34,21 @@ export const AccountCard = ({
   const translate = useTranslate()
   const buttonLeftIcon = useMemo(
     () => (
-      <SkeletonCircle isLoaded={isLoaded} boxSize='40px'>
-        <AssetIcon assetId={asset.assetId} boxSize='40px' />
+      <SkeletonCircle isLoaded={isLoaded} boxSize={leftIconBoxSize}>
+        <AssetIcon assetId={asset.assetId} boxSize={leftIconBoxSize} />
       </SkeletonCircle>
     ),
     [asset.assetId, isLoaded],
   )
 
-  const willOverflow = useMemo(() => asset.name.length > maxLabelLength, [asset.name])
+  const [willOverflow, setWillOverflow] = useState(false)
+
+  const checkOverflow = useCallback((el: HTMLElement | null) => {
+    if (el) {
+      const isOverflowing = el.scrollWidth > el.clientWidth
+      setWillOverflow(isOverflowing)
+    }
+  }, [])
 
   return (
     <Button
@@ -55,11 +62,27 @@ export const AccountCard = ({
       rightIcon={chevronRightIcon}
       {...rest}
     >
-      <SkeletonText noOfLines={2} isLoaded={isLoaded} mr='auto'>
+      <SkeletonText
+        noOfLines={2}
+        isLoaded={isLoaded}
+        mr='auto'
+        flexGrow={1}
+        width={`calc(100% - ${leftIconBoxSize} - var(--chakra-sizes-${rightIconBoxSize}))`}
+      >
         <Tooltip label={asset.name} isDisabled={!willOverflow}>
-          <RawText lineHeight='1' mb={1} data-test='account-card-asset-name-label'>
-            {trimWithEndEllipsis(asset.name, maxLabelLength)}
-          </RawText>
+          <Box overflow='hidden'>
+            <RawText
+              lineHeight='1'
+              mb={1}
+              data-test='account-card-asset-name-label'
+              overflow='hidden'
+              textOverflow='ellipsis'
+              whiteSpace='nowrap'
+              ref={checkOverflow}
+            >
+              {asset.name}
+            </RawText>
+          </Box>
         </Tooltip>
         {showCrypto ? (
           <Amount.Crypto

--- a/src/components/AccountCard.tsx
+++ b/src/components/AccountCard.tsx
@@ -1,9 +1,12 @@
 import { ChevronRightIcon } from '@chakra-ui/icons'
 import type { ButtonProps } from '@chakra-ui/react'
-import { Button, SkeletonCircle, SkeletonText } from '@chakra-ui/react'
+import { Box, Button, SkeletonCircle, SkeletonText } from '@chakra-ui/react'
 import type { Asset } from '@shapeshiftoss/types'
-import { useMemo } from 'react'
+import { motion } from 'framer-motion'
+import type { RefCallback } from 'react'
+import { useCallback, useMemo, useState } from 'react'
 import { useTranslate } from 'react-polyglot'
+import { trimWithEndEllipsis } from 'lib/utils'
 
 import { Amount } from './Amount/Amount'
 import { AssetIcon } from './AssetIcon'
@@ -19,6 +22,11 @@ type AccountCardProps = {
 } & ButtonProps
 
 const chevronRightIcon = <ChevronRightIcon boxSize={6} />
+const labelInitialProps = { x: 0 }
+const hoverProps = {
+  x: 'var(--x-offset)',
+  transition: { duration: 1, type: 'linear', ease: 'linear' },
+}
 
 export const AccountCard = ({
   asset,
@@ -39,6 +47,34 @@ export const AccountCard = ({
     [asset.assetId, isLoaded],
   )
 
+  const [showEllipsis, setShowEllipsis] = useState(false)
+
+  const getXOffset: RefCallback<HTMLDivElement> = useCallback(element => {
+    if (element) {
+      const parent = element.parentElement?.parentElement?.parentElement
+      const prevSibling = parent?.previousElementSibling
+      const nextSibling = parent?.nextElementSibling
+      const widthAvailable =
+        (parent?.parentElement?.clientWidth ?? 0) -
+        (prevSibling?.clientWidth ?? 0) -
+        (nextSibling?.clientWidth ?? 0) -
+        32 // padding in the parent div
+      const textWidth = element.firstElementChild?.clientWidth ?? 0
+      const isOverflowing = textWidth > widthAvailable
+
+      if (isOverflowing) {
+        setShowEllipsis(true)
+      }
+
+      element.style.setProperty(
+        '--x-offset',
+        isOverflowing ? `-${textWidth - widthAvailable}px` : '0px',
+      )
+
+      element.style.setProperty('--x-target-width', `${widthAvailable}px`)
+    }
+  }, [])
+
   return (
     <Button
       onClick={onClick}
@@ -51,10 +87,26 @@ export const AccountCard = ({
       rightIcon={chevronRightIcon}
       {...rest}
     >
-      <SkeletonText noOfLines={2} isLoaded={isLoaded} mr='auto'>
-        <RawText lineHeight='1' mb={1} data-test='account-card-asset-name-label'>
-          {asset.name}
-        </RawText>
+      <SkeletonText noOfLines={2} isLoaded={isLoaded} mr='auto' width='full'>
+        {/* <Flex> */}
+        <Box overflow='hidden' whiteSpace='nowrap' position='relative'>
+          <Box
+            as={motion.div}
+            initial={labelInitialProps}
+            whileTap={labelInitialProps}
+            whileHover={hoverProps}
+            width='var(--x-target-width)'
+            onHoverStart={() => setShowEllipsis(false)}
+            onHoverEnd={() => setShowEllipsis(true)}
+            ref={getXOffset}
+          >
+            <RawText lineHeight='1.5' data-test='account-card-asset-name-label' width='max-content'>
+              {showEllipsis ? trimWithEndEllipsis(asset.name, 40) : asset.name}
+            </RawText>
+          </Box>
+        </Box>
+        {/* {showEllipsis && <RawText lineHeight='1.5'>...</RawText>} */}
+        {/* </Flex> */}
 
         {showCrypto ? (
           <Amount.Crypto

--- a/src/components/AccountCard.tsx
+++ b/src/components/AccountCard.tsx
@@ -55,9 +55,9 @@ export const AccountCard = ({
       rightIcon={chevronRightIcon}
       {...rest}
     >
-      <SkeletonText noOfLines={2} isLoaded={isLoaded} mr='auto' width='full'>
+      <SkeletonText noOfLines={2} isLoaded={isLoaded} mr='auto'>
         <Tooltip label={asset.name} isDisabled={!willOverflow}>
-          <RawText lineHeight='1.5' data-test='account-card-asset-name-label' width='max-content'>
+          <RawText lineHeight='1' mb={1} data-test='account-card-asset-name-label'>
             {trimWithEndEllipsis(asset.name, maxLabelLength)}
           </RawText>
         </Tooltip>

--- a/src/components/AccountCard.tsx
+++ b/src/components/AccountCard.tsx
@@ -93,6 +93,9 @@ export const AccountCard = ({
             value={cryptoAmountAvailable}
             suffix={translate('common.available')}
             data-test='account-card-crypto-label'
+            overflow='hidden'
+            textOverflow='ellipsis'
+            whiteSpace='nowrap'
           />
         ) : (
           <Amount.Fiat
@@ -101,6 +104,9 @@ export const AccountCard = ({
             color='text.subtle'
             suffix={translate('common.available')}
             data-test='account-card-fiat-label'
+            overflow='hidden'
+            textOverflow='ellipsis'
+            whiteSpace='nowrap'
           />
         )}
       </SkeletonText>


### PR DESCRIPTION
## Description

Fixes text overflow of asset label in send input.

Adds a ellipsis for overflow with tooltip.'

Opted to use `trimWithEndEllipsis` intead of CSS ellipsis so we can predictably and simly detect an overflow render the tooltip accordingly.

## Issue (if applicable)

<!-----------------------------------------------------------------------------
If applicable, please link to the github issue and put `closes #XXXX` in your comment to auto-close the issue that your PR fixes.
------------------------------------------------------------------------------>

closes #7720

## Risk

> High Risk PRs Require 2 approvals

Low risk - display concern only.

> What protocols, transaction types, wallets or contract interactions might be affected by this PR?

## Testing

Check normal length asset names are rendered correctly without a tooltip.
Check very long asset names are truncated with an ellipsis and have a tooltip with the full asset name.

### Engineering

<!-----------------------------------------------------------------------------
Include sufficient information here for an engineer to test your PR. This may include how to test locally, in a built environment, changes to infrastructure etc.
------------------------------------------------------------------------------>

### Operations

- [ ] :checkered_flag: My feature is behind a flag and doesn't require operations testing (yet)

<!-----------------------------------------------------------------------------
If your changes have a user-facing impact, describe how a non-technical QA team can functionally test your changes in a preview environment.

If they are not user-facing please describe how to test for any regressions that may occur.
------------------------------------------------------------------------------>

## Screenshots (if applicable)


https://github.com/user-attachments/assets/02d9119a-5301-42a4-b0d8-33bf28a15cc8

