### PR TITLE
fix: empty loan state

### DIFF
--- a/src/pages/Lending/hooks/useAllLendingPositionsData.tsx
+++ b/src/pages/Lending/hooks/useAllLendingPositionsData.tsx
@@ -115,7 +115,23 @@ export const useAllLendingPositionsData = ({ assetId }: UseAllLendingPositionsDa
   )
 
   const isLoading = useMemo(() => positions.some(position => position.isLoading), [positions])
-  const isActive = useMemo(() => positions.some(position => position.data), [positions])
+
+  const isActive = useMemo(() => {
+    return positions.some(position => {
+      const data = position.data
+      if (!data) return false
+      const {
+        collateralBalanceCryptoPrecision,
+        collateralBalanceFiatUserCurrency,
+        debtBalanceFiatUserCurrency,
+      } = data
+      return (
+        (collateralBalanceCryptoPrecision && parseFloat(collateralBalanceCryptoPrecision) > 0) ||
+        (collateralBalanceFiatUserCurrency && parseFloat(collateralBalanceFiatUserCurrency) > 0) ||
+        (debtBalanceFiatUserCurrency && parseFloat(debtBalanceFiatUserCurrency) > 0)
+      )
+    })
+  }, [positions])
 
   return {
     debtValueUserCurrency,

--- a/src/pages/Lending/hooks/useAllLendingPositionsData.tsx
+++ b/src/pages/Lending/hooks/useAllLendingPositionsData.tsx
@@ -120,16 +120,8 @@ export const useAllLendingPositionsData = ({ assetId }: UseAllLendingPositionsDa
     return positions.some(position => {
       const data = position.data
       if (!data) return false
-      const {
-        collateralBalanceCryptoPrecision,
-        collateralBalanceFiatUserCurrency,
-        debtBalanceFiatUserCurrency,
-      } = data
-      return (
-        (collateralBalanceCryptoPrecision && parseFloat(collateralBalanceCryptoPrecision) > 0) ||
-        (collateralBalanceFiatUserCurrency && parseFloat(collateralBalanceFiatUserCurrency) > 0) ||
-        (debtBalanceFiatUserCurrency && parseFloat(debtBalanceFiatUserCurrency) > 0)
-      )
+      const { collateralBalanceCryptoPrecision } = data
+      return collateralBalanceCryptoPrecision && parseFloat(collateralBalanceCryptoPrecision) > 0
     })
   }, [positions])
 


### PR DESCRIPTION
## Description

Properly handles no loan state.

`develop`:

<img width="897" alt="Screenshot 2024-09-24 at 12 33 12" src="https://github.com/user-attachments/assets/681d769c-fad0-4fc4-a129-eb4084951414">

This PR:

<img width="912" alt="Screenshot 2024-09-24 at 12 31 28" src="https://github.com/user-attachments/assets/c9968fe6-5d65-4ca6-9caf-f7d455e61027">

This change is needed as we can still have `data` on a position without an actual loan:

<img width="450" alt="Screenshot 2024-09-24 at 12 12 26" src="https://github.com/user-attachments/assets/b06df190-b2ab-4089-8b2b-05706a0dc563">


## Issue (if applicable)

N/A, discovered by @gomesalexandre in a recent review: https://github.com/shapeshift/web/pull/7753#pullrequestreview-2306156963

## Risk

Low

> What protocols, transaction types, wallets or contract interactions might be affected by this PR?

None

## Testing

- When connected to a wallet with no loans, the placeholder component is shown as in the screenshot above.
- When connect to w wallet with loans, the loans are still shown

### Engineering

☝️

### Operations

- [ ] :checkered_flag: My feature is behind a flag and doesn't require operations testing (yet)

☝️

## Screenshots (if applicable)

See above.