### PR TITLE
fix: dont display loading state when completed quote request has no results

### DIFF
--- a/src/components/MultiHopTrade/components/TradeInput/TradeInput.tsx
+++ b/src/components/MultiHopTrade/components/TradeInput/TradeInput.tsx
@@ -34,9 +34,9 @@ import {
 import {
   selectActiveQuote,
   selectFirstHop,
-  selectIsAnyTradeQuoteLoaded,
   selectIsTradeQuoteRequestAborted,
   selectIsUnsafeActiveQuote,
+  selectShouldShowTradeQuoteOrAwaitInput,
 } from 'state/slices/tradeQuoteSlice/selectors'
 import { tradeQuoteSlice } from 'state/slices/tradeQuoteSlice/tradeQuoteSlice'
 import { useAppDispatch, useAppSelector } from 'state/store'
@@ -87,7 +87,7 @@ export const TradeInput = ({ isCompact, tradeInputRef }: TradeInputProps) => {
   const tradeQuoteStep = useAppSelector(selectFirstHop)
   const isUnsafeQuote = useAppSelector(selectIsUnsafeActiveQuote)
 
-  const isAnyTradeQuoteLoaded = useAppSelector(selectIsAnyTradeQuoteLoaded)
+  const shouldShowTradeQuoteOrAwaitInput = useAppSelector(selectShouldShowTradeQuoteOrAwaitInput)
   const isTradeQuoteRequestAborted = useAppSelector(selectIsTradeQuoteRequestAborted)
   const hasUserEnteredAmount = useAppSelector(selectHasUserEnteredAmount)
   const activeQuote = useAppSelector(selectActiveQuote)
@@ -119,14 +119,14 @@ export const TradeInput = ({ isCompact, tradeInputRef }: TradeInputProps) => {
   const isLoading = useMemo(
     () =>
       isAccountMetadataLoading ||
-      (!isAnyTradeQuoteLoaded && !isTradeQuoteRequestAborted) ||
+      (!shouldShowTradeQuoteOrAwaitInput && !isTradeQuoteRequestAborted) ||
       isConfirmationLoading ||
       // Only consider snapshot API queries as pending if we don't have voting power yet
       // if we do, it means we have persisted or cached (both stale) data, which is enough to let the user continue
       // as we are optimistic and don't want to be waiting for a potentially very long time for the snapshot API to respond
       isVotingPowerLoading,
     [
-      isAnyTradeQuoteLoaded,
+      shouldShowTradeQuoteOrAwaitInput,
       isTradeQuoteRequestAborted,
       isConfirmationLoading,
       isVotingPowerLoading,

--- a/src/components/MultiHopTrade/components/TradeInput/components/ConfirmSummary.tsx
+++ b/src/components/MultiHopTrade/components/TradeInput/components/ConfirmSummary.tsx
@@ -32,8 +32,8 @@ import {
   selectBuyAmountBeforeFeesCryptoPrecision,
   selectFirstHop,
   selectIsAnySwapperQuoteAvailable,
-  selectIsAnyTradeQuoteLoaded,
   selectIsAnyTradeQuoteLoading,
+  selectShouldShowTradeQuoteOrAwaitInput,
   selectTotalNetworkFeeUserCurrencyPrecision,
   selectTotalProtocolFeeByAsset,
   selectTradeQuoteRequestErrors,
@@ -79,7 +79,7 @@ export const ConfirmSummary = ({
   const activeQuoteErrors = useAppSelector(selectActiveQuoteErrors)
   const quoteRequestErrors = useAppSelector(selectTradeQuoteRequestErrors)
   const quoteResponseErrors = useAppSelector(selectTradeQuoteResponseErrors)
-  const isAnyTradeQuoteLoaded = useAppSelector(selectIsAnyTradeQuoteLoaded)
+  const shouldShowTradeQuoteOrAwaitInput = useAppSelector(selectShouldShowTradeQuoteOrAwaitInput)
   const isTradeQuoteApiQueryPending = useAppSelector(selectIsTradeQuoteApiQueryPending)
   const isAnyTradeQuoteLoading = useAppSelector(selectIsAnyTradeQuoteLoading)
   const isAnySwapperQuoteAvailable = useAppSelector(selectIsAnySwapperQuoteAvailable)
@@ -144,14 +144,14 @@ export const ConfirmSummary = ({
   }, [isAccountMetadataLoading, walletSupportsBuyAssetChain, disableThorNativeSmartContractReceive])
 
   const quoteHasError = useMemo(() => {
-    if (!isAnyTradeQuoteLoaded) return false
+    if (!shouldShowTradeQuoteOrAwaitInput) return false
     if (hasUserEnteredAmount && !isAnyTradeQuoteLoading && !isAnySwapperQuoteAvailable) return true
     return !!activeQuoteErrors?.length || !!quoteRequestErrors?.length
   }, [
     activeQuoteErrors?.length,
     hasUserEnteredAmount,
     isAnySwapperQuoteAvailable,
-    isAnyTradeQuoteLoaded,
+    shouldShowTradeQuoteOrAwaitInput,
     isAnyTradeQuoteLoading,
     quoteRequestErrors?.length,
   ])
@@ -205,7 +205,7 @@ export const ConfirmSummary = ({
     switch (true) {
       case isAccountMetadataLoading:
         return 'common.accountsLoading'
-      case !isAnyTradeQuoteLoaded:
+      case !shouldShowTradeQuoteOrAwaitInput:
       case !hasUserEnteredAmount:
         return 'trade.previewTrade'
       case !!quoteRequestError:
@@ -227,7 +227,7 @@ export const ConfirmSummary = ({
     quoteResponseErrors,
     activeQuoteErrors,
     isAccountMetadataLoading,
-    isAnyTradeQuoteLoaded,
+    shouldShowTradeQuoteOrAwaitInput,
     hasUserEnteredAmount,
     isAnyTradeQuoteLoading,
     isAnySwapperQuoteAvailable,

--- a/src/components/MultiHopTrade/components/TradeInput/components/ConfirmSummary.tsx
+++ b/src/components/MultiHopTrade/components/TradeInput/components/ConfirmSummary.tsx
@@ -31,7 +31,9 @@ import {
   selectBuyAmountAfterFeesCryptoPrecision,
   selectBuyAmountBeforeFeesCryptoPrecision,
   selectFirstHop,
+  selectIsAnySwapperQuoteAvailable,
   selectIsAnyTradeQuoteLoaded,
+  selectIsAnyTradeQuoteLoading,
   selectTotalNetworkFeeUserCurrencyPrecision,
   selectTotalProtocolFeeByAsset,
   selectTradeQuoteRequestErrors,
@@ -79,6 +81,8 @@ export const ConfirmSummary = ({
   const quoteResponseErrors = useAppSelector(selectTradeQuoteResponseErrors)
   const isAnyTradeQuoteLoaded = useAppSelector(selectIsAnyTradeQuoteLoaded)
   const isTradeQuoteApiQueryPending = useAppSelector(selectIsTradeQuoteApiQueryPending)
+  const isAnyTradeQuoteLoading = useAppSelector(selectIsAnyTradeQuoteLoading)
+  const isAnySwapperQuoteAvailable = useAppSelector(selectIsAnySwapperQuoteAvailable)
   const hasUserEnteredAmount = useAppSelector(selectHasUserEnteredAmount)
   const activeSwapperName = useAppSelector(selectActiveSwapperName)
   const sellAsset = useAppSelector(selectInputSellAsset)
@@ -141,8 +145,16 @@ export const ConfirmSummary = ({
 
   const quoteHasError = useMemo(() => {
     if (!isAnyTradeQuoteLoaded) return false
+    if (hasUserEnteredAmount && !isAnyTradeQuoteLoading && !isAnySwapperQuoteAvailable) return true
     return !!activeQuoteErrors?.length || !!quoteRequestErrors?.length
-  }, [activeQuoteErrors?.length, isAnyTradeQuoteLoaded, quoteRequestErrors?.length])
+  }, [
+    activeQuoteErrors?.length,
+    hasUserEnteredAmount,
+    isAnySwapperQuoteAvailable,
+    isAnyTradeQuoteLoaded,
+    isAnyTradeQuoteLoading,
+    quoteRequestErrors?.length,
+  ])
 
   const isLoading = useMemo(() => {
     return isParentLoading || isReceiveAddressByteCodeLoading || !buyAssetFeeAsset
@@ -202,6 +214,8 @@ export const ConfirmSummary = ({
         return getQuoteRequestErrorTranslation(quoteResponseError)
       case !!tradeQuoteError:
         return getQuoteErrorTranslation(tradeQuoteError!)
+      case !isAnyTradeQuoteLoading && !isAnySwapperQuoteAvailable:
+        return 'trade.noRateAvailable'
       case !isConnected || isDemoWallet:
         // We got a happy path quote, but we may still be in the context of the demo wallet
         return 'common.connectWallet'
@@ -212,11 +226,13 @@ export const ConfirmSummary = ({
     quoteRequestErrors,
     quoteResponseErrors,
     activeQuoteErrors,
+    isAccountMetadataLoading,
     isAnyTradeQuoteLoaded,
     hasUserEnteredAmount,
+    isAnyTradeQuoteLoading,
+    isAnySwapperQuoteAvailable,
     isConnected,
     isDemoWallet,
-    isAccountMetadataLoading,
   ])
 
   const handleOpenCompactQuoteList = useCallback(() => {

--- a/src/state/slices/tradeQuoteSlice/selectors.ts
+++ b/src/state/slices/tradeQuoteSlice/selectors.ts
@@ -118,6 +118,13 @@ const selectIsSwapperQuoteAvailable = createSelector(
   },
 )
 
+export const selectIsAnySwapperQuoteAvailable = createSelector(
+  selectIsSwapperQuoteAvailable,
+  isSwapperQuoteAvailable => {
+    return Object.values(isSwapperQuoteAvailable).some(identity)
+  },
+)
+
 // Returns the top-level errors related to the request for a trade quote. Not related to individual
 // quote responses.
 export const selectTradeQuoteRequestErrors = createDeepEqualOutputSelector(
@@ -725,6 +732,18 @@ export const selectIsAnyTradeQuoteLoading = createSelector(
 export const selectIsAnyTradeQuoteLoaded = createSelector(
   selectIsSwapperQuoteAvailable,
   selectHasUserEnteredAmount,
-  (isSwapperQuoteAvailable, hasUserEnteredAmount) =>
-    !hasUserEnteredAmount || Object.values(isSwapperQuoteAvailable).some(identity),
+  selectIsAnyTradeQuoteLoading,
+  (isSwapperQuoteAvailable, hasUserEnteredAmount, isAnyTradeQuoteLoading) => {
+    if (!hasUserEnteredAmount) {
+      return true
+    }
+
+    // If we're still loading, return true if there is any quote available
+    if (isAnyTradeQuoteLoading) {
+      return Object.values(isSwapperQuoteAvailable).some(identity)
+    }
+
+    // Otherwise, an empty result should default to true to allow the app to stop loading state.
+    return true
+  },
 )

--- a/src/state/slices/tradeQuoteSlice/selectors.ts
+++ b/src/state/slices/tradeQuoteSlice/selectors.ts
@@ -733,14 +733,20 @@ export const selectIsAnyTradeQuoteLoaded = createSelector(
   selectIsSwapperQuoteAvailable,
   selectHasUserEnteredAmount,
   selectIsAnyTradeQuoteLoading,
-  (isSwapperQuoteAvailable, hasUserEnteredAmount, isAnyTradeQuoteLoading) => {
+  selectIsAnySwapperQuoteAvailable,
+  (
+    isSwapperQuoteAvailable,
+    hasUserEnteredAmount,
+    isAnyTradeQuoteLoading,
+    isAnySwapperQuoteAvailable,
+  ) => {
     if (!hasUserEnteredAmount) {
       return true
     }
 
     // If we're still loading, return true if there is any quote available
     if (isAnyTradeQuoteLoading) {
-      return Object.values(isSwapperQuoteAvailable).some(identity)
+      return isAnySwapperQuoteAvailable
     }
 
     // Otherwise, an empty result should default to true to allow the app to stop loading state.

--- a/src/state/slices/tradeQuoteSlice/selectors.ts
+++ b/src/state/slices/tradeQuoteSlice/selectors.ts
@@ -729,11 +729,12 @@ export const selectIsAnyTradeQuoteLoading = createSelector(
   },
 )
 
-export const selectIsAnyTradeQuoteLoaded = createSelector(
+export const selectShouldShowTradeQuoteOrAwaitInput = createSelector(
   selectHasUserEnteredAmount,
   selectIsAnyTradeQuoteLoading,
   selectIsAnySwapperQuoteAvailable,
   (hasUserEnteredAmount, isAnyTradeQuoteLoading, isAnySwapperQuoteAvailable) => {
+    // Paranoia - if no amount entered, we're still awaiting input
     if (!hasUserEnteredAmount) {
       return true
     }
@@ -743,7 +744,8 @@ export const selectIsAnyTradeQuoteLoaded = createSelector(
       return isAnySwapperQuoteAvailable
     }
 
-    // Otherwise, an empty result should default to true to allow the app to stop loading state.
+    // Otherwise, the quotes are fully loaded and ready to display, or we have an empty result which
+    // should default to true to allow the app to stop loading state.
     return true
   },
 )

--- a/src/state/slices/tradeQuoteSlice/selectors.ts
+++ b/src/state/slices/tradeQuoteSlice/selectors.ts
@@ -730,16 +730,10 @@ export const selectIsAnyTradeQuoteLoading = createSelector(
 )
 
 export const selectIsAnyTradeQuoteLoaded = createSelector(
-  selectIsSwapperQuoteAvailable,
   selectHasUserEnteredAmount,
   selectIsAnyTradeQuoteLoading,
   selectIsAnySwapperQuoteAvailable,
-  (
-    isSwapperQuoteAvailable,
-    hasUserEnteredAmount,
-    isAnyTradeQuoteLoading,
-    isAnySwapperQuoteAvailable,
-  ) => {
+  (hasUserEnteredAmount, isAnyTradeQuoteLoading, isAnySwapperQuoteAvailable) => {
     if (!hasUserEnteredAmount) {
       return true
     }


### PR DESCRIPTION
## Description

Resolves state issue in trade UI where lack of non-errored quoted is treated as loading state, resulting in infinite spinner when all swappers failed to return a quote.

## Issue (if applicable)

<!-----------------------------------------------------------------------------
If applicable, please link to the github issue and put `closes #XXXX` in your comment to auto-close the issue that your PR fixes.
------------------------------------------------------------------------------>

closes #7789

## Risk

> High Risk PRs Require 2 approvals

Low risk, though considering the massive usage of the swapper feature we should review it with added caution.

<!-----------------------------------------------------------------------------
Outline the scope of your changes and the risk associated with them. You must use your discretion as an engineer to determine the potential impact of your changes.

WARNING: If your PR introduces a new on-chain transaction or modifies an existing one, please add the "High-Risk" label to this PR and ask for 2 reviewers to approve it before merging.

E.g. an upgrade to `hdwallet` or core state management would be considered higher risk, and might require a full regression test. UI or isolated view changes, or something behind a feature flag may have near zero risk. Small bug fixes might require testing isolated to the specific fix.
------------------------------------------------------------------------------>

> What protocols, transaction types, wallets or contract interactions might be affected by this PR?

Affects quotes and loading state.

## Testing

<!-----------------------------------------------------------------------------
We treat every PR to be merged with the same scrutiny as if we were merging directly to production.

Your PR will not be merged if you do not complete the sections below for our engineering and operations teams to test.
------------------------------------------------------------------------------>

The easiest way to test this is by trying to get a quote with assets which are THOR only (e.g UTXOs, or  UTXO<->ATOM would work too), and then blocking the `swap*` domain.
To do so, proceed as follow:

- Try and get a first quote, which should go through
- Then, filter network requests by `thor swap`. You'll notice request/s matching the `swap?amount=` pattern, click on any
- Block request *URL*, not *domain* for the request
  <img width="420" alt="image" src="https://github.com/user-attachments/assets/fe22799d-c864-4bc3-b4a3-23af5de8b195">
- In your list of filtered network requests, click edit, and replace everything after *swap* with a star:
  <img width="415" alt="image" src="https://github.com/user-attachments/assets/0c9c62dd-6492-44fb-a2d1-89754ae66726">
- Ensure the next time you try and get a quote (or after auto-refetch timeout), you see the "No Rate Available" copy instead of infinite loading state previously
  <img width="1462" alt="image" src="https://github.com/user-attachments/assets/455719b0-1c01-43c4-a00d-bac0c4c8bd0d">
- You can do the same in develop/prod as a sanity check
- ⚠️ Don't forget to remove the network request blocking after you've done testing this, or your THOR requests will be perma-rugged until you do

### Engineering

<!-----------------------------------------------------------------------------
Include sufficient information here for an engineer to test your PR. This may include how to test locally, in a built environment, changes to infrastructure etc.
------------------------------------------------------------------------------>

### Operations

- [ ] :checkered_flag: My feature is behind a flag and doesn't require operations testing (yet)

<!-----------------------------------------------------------------------------
If your changes have a user-facing impact, describe how a non-technical QA team can functionally test your changes in a preview environment.

If they are not user-facing please describe how to test for any regressions that may occur.
------------------------------------------------------------------------------>

## Screenshots (if applicable)

Demo using monkey patch to force simulated thorchain swapper error:

https://jam.dev/c/39fb191a-25b1-4f15-8505-c02454b8a60a