### PR TITLE
fix: invalidate taproot addresses for sends

### DIFF
--- a/src/lib/address/address.ts
+++ b/src/lib/address/address.ts
@@ -252,6 +252,7 @@ type ValidateAddressReturn = boolean
 export type ValidateAddressByChainId = (args: ValidateAddressArgs) => Promise<ValidateAddressReturn>
 
 export const validateAddress: ValidateAddressByChainId = async ({ chainId, maybeAddress }) => {
+  // Invalidate taproot addresses for BTC
   if (chainId === btcChainId && maybeAddress.startsWith('bc1p')) return false
   try {
     const adapter = getChainAdapterManager().get(chainId)

--- a/src/lib/address/address.ts
+++ b/src/lib/address/address.ts
@@ -252,6 +252,7 @@ type ValidateAddressReturn = boolean
 export type ValidateAddressByChainId = (args: ValidateAddressArgs) => Promise<ValidateAddressReturn>
 
 export const validateAddress: ValidateAddressByChainId = async ({ chainId, maybeAddress }) => {
+  if (chainId === btcChainId && maybeAddress.startsWith('bc1p')) return false
   try {
     const adapter = getChainAdapterManager().get(chainId)
     if (!adapter) return false


### PR DESCRIPTION
## Description

Updates the `validateAddress` util to return invalid for BTC Taproot addresses.

A stop-gap to improve user experience relating to https://github.com/shapeshift/web/issues/6761 until we decided how to proceed/unblock that ticket.

## Issue (if applicable)

Relates to https://github.com/shapeshift/web/issues/6761, but does not close it.

## Risk

> High Risk PRs Require 2 approvals

Low

> What protocols, transaction types, wallets or contract interactions might be affected by this PR?

BTC sends

## Testing

Ensure BTC sends to Taproot addresses (e.g. `bc1pxk2u9kjszfzxqmsrcctvst32dn2pqrlptsw0e7wqumhlq9cl35ks9v5kh2` are invalidated):

<img width="327" alt="Screenshot 2024-09-26 at 14 19 27" src="https://github.com/user-attachments/assets/6f1a4efb-2eb0-406e-8fc2-2b58e6362ab2">

Ensure no other sends are affected.

### Engineering

☝️

### Operations

- [ ] :checkered_flag: My feature is behind a flag and doesn't require operations testing (yet)

☝️

## Screenshots (if applicable)

See above.