### PR TITLE
chore: deny stargateV2

### DIFF
--- a/packages/swapper/src/swappers/LifiSwapper/getTradeQuote/getTradeQuote.ts
+++ b/packages/swapper/src/swappers/LifiSwapper/getTradeQuote/getTradeQuote.ts
@@ -92,7 +92,7 @@ export async function getTradeQuote(
       // used for analytics and affiliate fee - do not change this without considering impact
       integrator: LIFI_INTEGRATOR_ID,
       slippage: Number(slippageTolerancePercentageDecimal),
-      bridges: { deny: ['stargate', 'amarok', 'arbitrum'] },
+      bridges: { deny: ['stargate', 'stargateV2', 'amarok', 'arbitrum'] },
       allowSwitchChain: true,
       fee: affiliateBpsDecimalPercentage.isZero()
         ? undefined


### PR DESCRIPTION
## Description

<!-- Please describe your changes -->

## Issue (if applicable)

Received a heads up from the LiFi team that stargate V1 is being deprecated, and that we should add `stargatev2` if we wish to continue blocking stargate.

<img width="879" alt="Screenshot 2024-09-27 at 07 46 19" src="https://github.com/user-attachments/assets/e88d9ab5-afc0-4528-b877-abe47b566434">

## Risk

> High Risk PRs Require 2 approvals

Small

> What protocols, transaction types, wallets or contract interactions might be affected by this PR?

LiFi trades

## Testing

Ensure we do not see any quotes from Stargate via LiFi.

### Engineering

☝️

### Operations

- [ ] :checkered_flag: My feature is behind a flag and doesn't require operations testing (yet)

☝️

## Screenshots (if applicable)

N/A