### PR TITLE
fix: bump chakra-ui-steps

### DIFF
--- a/package.json
+++ b/package.json
@@ -135,7 +135,7 @@
     "browserify-fs": "^1.0.0",
     "browserify-zlib": "^0.2.0",
     "bs58check": "^2.1.2",
-    "chakra-ui-steps": "^1.7.3",
+    "chakra-ui-steps": "^2.1.0",
     "crypto-browserify": "^3.12.0",
     "dayjs": "^1.11.3",
     "dompurify": "^2.3.8",

--- a/src/components/Steps.theme.tsx
+++ b/src/components/Steps.theme.tsx
@@ -1,18 +1,18 @@
 import type { StyleFunctionProps } from '@chakra-ui/theme-tools'
 import { mode } from '@chakra-ui/theme-tools'
-import { StepsStyleConfig } from 'chakra-ui-steps'
+import { StepsTheme } from 'chakra-ui-steps'
 
 export const StepsStyle = {
-  ...StepsStyleConfig,
+  ...StepsTheme,
   baseStyle: (props: StyleFunctionProps) => {
     return {
-      ...StepsStyleConfig.baseStyle(props),
+      ...StepsTheme.baseStyle(props),
       stepIconContainer: {
-        ...StepsStyleConfig.baseStyle(props).stepIconContainer,
+        ...StepsTheme.baseStyle(props).stepIconContainer,
         bg: 'transparent',
       },
       labelContainer: {
-        ...StepsStyleConfig.baseStyle(props).labelContainer,
+        ...StepsTheme.baseStyle(props).labelContainer,
         '& span': {
           color: 'text.subtle',
         },
@@ -28,7 +28,7 @@ export const StepsStyle = {
         },
       },
       connector: {
-        ...StepsStyleConfig.baseStyle(props).connector,
+        ...StepsTheme.baseStyle(props).connector,
         borderColor: 'transparent',
       },
     }

--- a/src/components/VerticalStepper/VerticalStepper.tsx
+++ b/src/components/VerticalStepper/VerticalStepper.tsx
@@ -23,7 +23,7 @@ export const VerticalStepper = ({ state, activeStep, steps }: VerticalStepperPro
         state={state}
         activeStep={activeStep}
         orientation='horizontal'
-        labelOrientation='vertical'
+        variant='circles-alt'
         size='sm'
       >
         {steps.map(step => (

--- a/yarn.lock
+++ b/yarn.lock
@@ -11854,7 +11854,7 @@ __metadata:
     browserify-fs: ^1.0.0
     browserify-zlib: ^0.2.0
     bs58check: ^2.1.2
-    chakra-ui-steps: ^1.7.3
+    chakra-ui-steps: ^2.1.0
     chalk: 5.3.0
     circular-dependency-plugin: ^5.2.2
     cli-progress: ^3.12.0
@@ -19194,16 +19194,16 @@ __metadata:
   languageName: node
   linkType: hard
 
-"chakra-ui-steps@npm:^1.7.3":
-  version: 1.7.3
-  resolution: "chakra-ui-steps@npm:1.7.3"
+"chakra-ui-steps@npm:^2.1.0":
+  version: 2.1.0
+  resolution: "chakra-ui-steps@npm:2.1.0"
   peerDependencies:
-    "@chakra-ui/react": ">=1.6.7"
-    "@emotion/react": ^11
-    "@emotion/styled": ^11
-    framer-motion: ^6
-    react: ">=16"
-  checksum: 680807d64900fa27d29808828923da1a7dafbf8bb3086ac8fd30e48dcdd2a7f4c489a7779b38892c08f482dba9759c30212ff7a6bebd2ecf5eaffaf783fe251d
+    "@chakra-ui/react": ^2.0.0
+    "@emotion/react": ^11.4.1
+    "@emotion/styled": ^11.3.0
+    framer-motion: ^7.0.0
+    react: ^18.0.0
+  checksum: 007fb70235f0801eeab95868148eb3053421d1e056244d4b9917d37d35e8aad2f3f2497180bbbd720a4fd453616c670469816708c5ed1723f714600cc6057dc5
   languageName: node
   linkType: hard
 


### PR DESCRIPTION
## Description

Bumps `chakra-ui-steps` to fix a bug caused by the previous version of this package using a deprecated version of `framer-motion`.

<img width="359" alt="Screenshot 2024-10-01 at 12 10 12" src="https://github.com/user-attachments/assets/b16df2e8-61e1-48cf-97a6-46898f7bfd8d">

Note a small visual change from prod due to the library now using an updated version of Chakra.

<img width="355" alt="Screenshot 2024-10-01 at 12 32 47" src="https://github.com/user-attachments/assets/beb8ed19-a055-4d6f-8c97-0b772615c14e">

As an aside, I don't know why we even use this library - we should be able to do the same thing with native Chakra? Not for this PR, but TODO.

## Issue (if applicable)

Closes https://github.com/shapeshift/web/issues/7843

## Risk

> High Risk PRs Require 2 approvals

Small

> What protocols, transaction types, wallets or contract interactions might be affected by this PR?

None.

## Testing

Click the FOX reward and confirm no crashy.

### Engineering

☝️

### Operations

- [ ] :checkered_flag: My feature is behind a flag and doesn't require operations testing (yet)

☝️

## Screenshots (if applicable)

See above.