### PR TITLE
fix: twirly toggle

### DIFF
--- a/src/components/MultiHopTrade/components/TradeSuccess/TradeSuccess.tsx
+++ b/src/components/MultiHopTrade/components/TradeSuccess/TradeSuccess.tsx
@@ -25,7 +25,7 @@ const pairProps = { showFirst: true }
 export const TradeSuccess = ({ handleBack, children }: TradeSuccessProps) => {
   const translate = useTranslate()
 
-  const { isOpen, onToggle } = useDisclosure({
+  const { isOpen, onToggle: handleToggle } = useDisclosure({
     defaultIsOpen: false,
   })
 
@@ -68,10 +68,10 @@ export const TradeSuccess = ({ handleBack, children }: TradeSuccessProps) => {
             {translate('trade.doAnotherTrade')}
           </Button>
           <HStack width='full' justifyContent='space-between' mt={4}>
-            <Button variant='link' onClick={onToggle} px={2}>
+            <Button variant='link' onClick={handleToggle} px={2}>
               {translate('trade.showDetails')}
             </Button>
-            <TwirlyToggle isOpen={isOpen} onToggle={onToggle} />
+            <TwirlyToggle isOpen={isOpen} onToggle={handleToggle} />
           </HStack>
           <Box mx={-4}>
             <Collapse in={isOpen}>{children}</Collapse>

--- a/src/components/MultiHopTrade/components/TwirlyToggle.tsx
+++ b/src/components/MultiHopTrade/components/TwirlyToggle.tsx
@@ -13,7 +13,7 @@ export const TwirlyToggle = ({ isOpen, onToggle, ...boxProps }: TwirlyToggleProp
     () => (
       <Circle size={8} bgColor='background.surface.raised.base' borderWidth={0}>
         <ChevronUpIcon
-          transform={isOpen ? 'rotate(180deg)' : 'rotate(0deg)'}
+          transform={isOpen ? 'rotate(0deg)' : 'rotate(180deg)'}
           transition='transform 0.2s ease-in-out'
           boxSize='16px'
         />


### PR DESCRIPTION
## Description

Fixes the twirly toggle arrow direction.

## Issue (if applicable)

Closes https://github.com/shapeshift/web/issues/7804

## Risk

> High Risk PRs Require 2 approvals

Low

> What protocols, transaction types, wallets or contract interactions might be affected by this PR?

None

## Testing

On the trade completion success model the arrow should be pointing down when its closed, and point up when open.

### Engineering

☝️

### Operations

- [ ] :checkered_flag: My feature is behind a flag and doesn't require operations testing (yet)

☝️

## Screenshots (if applicable)
<img width="343" alt="Screenshot 2024-10-01 at 15 47 57" src="https://github.com/user-attachments/assets/e03f395f-b5a4-4fe5-a4f8-b5e49e8ccdca">

<img width="348" alt="Screenshot 2024-10-01 at 15 48 03" src="https://github.com/user-attachments/assets/254b5ad7-4bfb-49a8-a724-c51ad8fbccae">
