### PR TITLE
feat: bundle analyzer

### DIFF
--- a/package.json
+++ b/package.json
@@ -9,6 +9,7 @@
     "version": "independent"
   },
   "scripts": {
+    "analyze": "ANALYZE=true yarn build:web",
     "bump": "yarn upgrade-interactive --latest --scope @shapeshiftoss",
     "build:web": "yarn build:packages && NODE_OPTIONS=--max-old-space-size=8192 IMAGE_INLINE_SIZE_LIMIT=0 INLINE_RUNTIME_CHUNK=false DISABLE_ESLINT_PLUGIN=true react-app-rewired --openssl-legacy-provider build && tsx ./scripts/writeHeaders.ts && ./scripts/sha256sums.sh && ./scripts/verifyWebpackHashes.sh && tsx ./scripts/writeBuildMetadata.ts",
     "build:packages": "yarn clean:packages && yarn workspace @shapeshiftoss/unchained-client generate && yarn tsc --build tsconfig.packages.json",
@@ -294,6 +295,7 @@
     "vite-tsconfig-paths": "^4.2.3",
     "vitest": "1.1.1",
     "webpack": "5.94.0",
+    "webpack-bundle-analyzer": "^4.10.2",
     "webpack-subresource-integrity": "^5.0.0",
     "workbox-webpack-plugin": "^7.1.0"
   },

--- a/react-app-rewired.config.js
+++ b/react-app-rewired.config.js
@@ -1,4 +1,6 @@
 const tsNode = require('ts-node')
+const { BundleAnalyzerPlugin } = require('webpack-bundle-analyzer')
+
 tsNode.register({
   extends: './tsconfig.web.json',
   include: ['src'],
@@ -8,4 +10,22 @@ tsNode.register({
   },
 })
 
-module.exports = require('./react-app-rewired').default
+const rewiredConfig = require('./react-app-rewired').default
+
+module.exports = function override(config, env) {
+  // Apply the existing rewired configuration
+  config = rewiredConfig(config, env)
+
+  // Add the BundleAnalyzerPlugin if ANALYZE is true
+  if (process.env.ANALYZE === 'true') {
+    config.plugins.push(
+      new BundleAnalyzerPlugin({
+        analyzerMode: 'server',
+        analyzerPort: 8888,
+        openAnalyzer: true,
+      }),
+    )
+  }
+
+  return config
+}

--- a/react-app-rewired.config.js
+++ b/react-app-rewired.config.js
@@ -1,5 +1,4 @@
 const tsNode = require('ts-node')
-const { BundleAnalyzerPlugin } = require('webpack-bundle-analyzer')
 
 tsNode.register({
   extends: './tsconfig.web.json',
@@ -10,22 +9,4 @@ tsNode.register({
   },
 })
 
-const rewiredConfig = require('./react-app-rewired').default
-
-module.exports = function override(config, env) {
-  // Apply the existing rewired configuration
-  config = rewiredConfig(config, env)
-
-  // Add the BundleAnalyzerPlugin if ANALYZE is true
-  if (process.env.ANALYZE === 'true') {
-    config.plugins.push(
-      new BundleAnalyzerPlugin({
-        analyzerMode: 'server',
-        analyzerPort: 8888,
-        openAnalyzer: true,
-      }),
-    )
-  }
-
-  return config
-}
+module.exports = require('./react-app-rewired').default

--- a/react-app-rewired/index.ts
+++ b/react-app-rewired/index.ts
@@ -15,6 +15,8 @@ import WorkBoxPlugin from 'workbox-webpack-plugin'
 import { cspMeta, headers, serializeCsp } from './headers'
 import { progressPlugin } from './progress'
 
+const BundleAnalyzerPlugin = require('webpack-bundle-analyzer').BundleAnalyzerPlugin
+
 type DevServerConfigFunction = (
   proxy: unknown,
   allowedHost: unknown,
@@ -367,6 +369,19 @@ const reactAppRewireConfig = {
         // bundles all imports from this package. This plugin silences the warning.
         // https://webpack.js.org/guides/dependency-management/#require-with-expression
         new ContextReplacementPlugin(/@cowprotocol\/app-data/),
+      ],
+    })
+
+    // Set up the BundleAnalyzerPlugin for analyzing the bundle size
+    _.merge(config, {
+      plugins: [
+        ...(config.plugins ?? []),
+        process.env.ANALYZE === 'true' &&
+          new BundleAnalyzerPlugin({
+            analyzerMode: 'server',
+            analyzerPort: 8888,
+            openAnalyzer: true,
+          }),
       ],
     })
 

--- a/yarn.lock
+++ b/yarn.lock
@@ -6243,6 +6243,13 @@ __metadata:
   languageName: node
   linkType: hard
 
+"@discoveryjs/json-ext@npm:0.5.7":
+  version: 0.5.7
+  resolution: "@discoveryjs/json-ext@npm:0.5.7"
+  checksum: 2176d301cc258ea5c2324402997cf8134ebb212469c0d397591636cea8d3c02f2b3cf9fd58dcb748c7a0dade77ebdc1b10284fa63e608c033a1db52fddc69918
+  languageName: node
+  linkType: hard
+
 "@eivifj/dot@npm:^1.0.1":
   version: 1.0.3
   resolution: "@eivifj/dot@npm:1.0.3"
@@ -10105,6 +10112,13 @@ __metadata:
   languageName: node
   linkType: hard
 
+"@polka/url@npm:^1.0.0-next.24":
+  version: 1.0.0-next.28
+  resolution: "@polka/url@npm:1.0.0-next.28"
+  checksum: 7402aaf1de781d0eb0870d50cbcd394f949aee11b38a267a5c3b4e3cfee117e920693e6e93ce24c87ae2d477a59634f39d9edde8e86471cae756839b07c79af7
+  languageName: node
+  linkType: hard
+
 "@polkadot/keyring@npm:^8.4.1":
   version: 8.7.1
   resolution: "@polkadot/keyring@npm:8.7.1"
@@ -11968,6 +11982,7 @@ __metadata:
     wagmi: ^2.9.2
     web-vitals: ^2.1.4
     webpack: 5.94.0
+    webpack-bundle-analyzer: ^4.10.2
     webpack-subresource-integrity: ^5.0.0
     workbox-webpack-plugin: ^7.1.0
   peerDependencies:
@@ -16660,6 +16675,15 @@ __metadata:
   languageName: node
   linkType: hard
 
+"acorn-walk@npm:^8.0.0":
+  version: 8.3.4
+  resolution: "acorn-walk@npm:8.3.4"
+  dependencies:
+    acorn: ^8.11.0
+  checksum: 4ff03f42323e7cf90f1683e08606b0f460e1e6ac263d2730e3df91c7665b6f64e696db6ea27ee4bed18c2599569be61f28a8399fa170c611161a348c402ca19c
+  languageName: node
+  linkType: hard
+
 "acorn-walk@npm:^8.1.1":
   version: 8.3.3
   resolution: "acorn-walk@npm:8.3.3"
@@ -16685,21 +16709,21 @@ __metadata:
   languageName: node
   linkType: hard
 
+"acorn@npm:^8.0.4, acorn@npm:^8.11.0, acorn@npm:^8.4.1":
+  version: 8.12.1
+  resolution: "acorn@npm:8.12.1"
+  bin:
+    acorn: bin/acorn
+  checksum: 677880034aee5bdf7434cc2d25b641d7bedb0b5ef47868a78dadabedccf58e1c5457526d9d8249cd253f2df087e081c3fe7d903b448d8e19e5131a3065b83c07
+  languageName: node
+  linkType: hard
+
 "acorn@npm:^8.10.0, acorn@npm:^8.8.2":
   version: 8.11.2
   resolution: "acorn@npm:8.11.2"
   bin:
     acorn: bin/acorn
   checksum: 818450408684da89423e3daae24e4dc9b68692db8ab49ea4569c7c5abb7a3f23669438bf129cc81dfdada95e1c9b944ee1bfca2c57a05a4dc73834a612fbf6a7
-  languageName: node
-  linkType: hard
-
-"acorn@npm:^8.11.0, acorn@npm:^8.4.1":
-  version: 8.12.1
-  resolution: "acorn@npm:8.12.1"
-  bin:
-    acorn: bin/acorn
-  checksum: 677880034aee5bdf7434cc2d25b641d7bedb0b5ef47868a78dadabedccf58e1c5457526d9d8249cd253f2df087e081c3fe7d903b448d8e19e5131a3065b83c07
   languageName: node
   linkType: hard
 
@@ -21031,7 +21055,7 @@ __metadata:
   languageName: node
   linkType: hard
 
-"debounce@npm:^1.2.0":
+"debounce@npm:^1.2.0, debounce@npm:^1.2.1":
   version: 1.2.1
   resolution: "debounce@npm:1.2.1"
   checksum: 682a89506d9e54fb109526f4da255c5546102fbb8e3ae75eef3b04effaf5d4853756aee97475cd4650641869794e44f410eeb20ace2b18ea592287ab2038519e
@@ -25508,7 +25532,7 @@ __metadata:
   languageName: node
   linkType: hard
 
-"html-escaper@npm:^2.0.0":
+"html-escaper@npm:^2.0.0, html-escaper@npm:^2.0.2":
   version: 2.0.2
   resolution: "html-escaper@npm:2.0.2"
   checksum: d2df2da3ad40ca9ee3a39c5cc6475ef67c8f83c234475f24d8e9ce0dc80a2c82df8e1d6fa78ddd1e9022a586ea1bd247a615e80a5cd9273d90111ddda7d9e974
@@ -29625,6 +29649,13 @@ __metadata:
   languageName: node
   linkType: hard
 
+"mrmime@npm:^2.0.0":
+  version: 2.0.0
+  resolution: "mrmime@npm:2.0.0"
+  checksum: f6fe11ec667c3d96f1ce5fd41184ed491d5f0a5f4045e82446a471ccda5f84c7f7610dff61d378b73d964f73a320bd7f89788f9e6b9403e32cc4be28ba99f569
+  languageName: node
+  linkType: hard
+
 "ms@npm:2.0.0":
   version: 2.0.0
   resolution: "ms@npm:2.0.0"
@@ -30668,6 +30699,15 @@ __metadata:
     is-inside-container: ^1.0.0
     is-wsl: ^2.2.0
   checksum: 3993c0f61d51fed8ac290e99c9c3cf45d3b6cfb3e2aa2b74cafd312c3486c22fd81df16ac8f3ab91dd8a4e3e729a16fc2480cfc406c4833416cf908acf1ae7c9
+  languageName: node
+  linkType: hard
+
+"opener@npm:^1.5.2":
+  version: 1.5.2
+  resolution: "opener@npm:1.5.2"
+  bin:
+    opener: bin/opener-bin.js
+  checksum: 33b620c0d53d5b883f2abc6687dd1c5fd394d270dbe33a6356f2d71e0a2ec85b100d5bac94694198ccf5c30d592da863b2292c5539009c715a9c80c697b4f6cc
   languageName: node
   linkType: hard
 
@@ -35580,6 +35620,17 @@ pvutils@latest:
   languageName: node
   linkType: hard
 
+"sirv@npm:^2.0.3":
+  version: 2.0.4
+  resolution: "sirv@npm:2.0.4"
+  dependencies:
+    "@polka/url": ^1.0.0-next.24
+    mrmime: ^2.0.0
+    totalist: ^3.0.0
+  checksum: 6853384a51d6ee9377dd657e2b257e0e98b29abbfbfa6333e105197f0f100c8c56a4520b47028b04ab1833cf2312526206f38fcd4f891c6df453f40da1a15a57
+  languageName: node
+  linkType: hard
+
 "sisteransi@npm:^1.0.5":
   version: 1.0.5
   resolution: "sisteransi@npm:1.0.5"
@@ -37206,6 +37257,13 @@ pvutils@latest:
   version: 2.3.6
   resolution: "toml@npm:2.3.6"
   checksum: e1be1ec9dad3049459d0c81e5b7b40ce8356ca5fc27d23cab101551447e22af7fe6d903d19162389ffd50cb3ff4e986374992d4c293da84166fa6307c7c1b5cf
+  languageName: node
+  linkType: hard
+
+"totalist@npm:^3.0.0":
+  version: 3.0.1
+  resolution: "totalist@npm:3.0.1"
+  checksum: 5132d562cf88ff93fd710770a92f31dbe67cc19b5c6ccae2efc0da327f0954d211bbfd9456389655d726c624f284b4a23112f56d1da931ca7cfabbe1f45e778a
   languageName: node
   linkType: hard
 
@@ -39367,6 +39425,28 @@ pvutils@latest:
   languageName: node
   linkType: hard
 
+"webpack-bundle-analyzer@npm:^4.10.2":
+  version: 4.10.2
+  resolution: "webpack-bundle-analyzer@npm:4.10.2"
+  dependencies:
+    "@discoveryjs/json-ext": 0.5.7
+    acorn: ^8.0.4
+    acorn-walk: ^8.0.0
+    commander: ^7.2.0
+    debounce: ^1.2.1
+    escape-string-regexp: ^4.0.0
+    gzip-size: ^6.0.0
+    html-escaper: ^2.0.2
+    opener: ^1.5.2
+    picocolors: ^1.0.0
+    sirv: ^2.0.3
+    ws: ^7.3.1
+  bin:
+    webpack-bundle-analyzer: lib/bin/analyzer.js
+  checksum: 4f0275e7d87bb6203a618ca5d2d4953943979d986fa2b91be1bf1ad0bcd22bec13398803273d11699f9fbcf106896311208a72d63fe5f8a47b687a226e598dc1
+  languageName: node
+  linkType: hard
+
 "webpack-dev-middleware@npm:^5.3.1":
   version: 5.3.1
   resolution: "webpack-dev-middleware@npm:5.3.1"
@@ -40218,7 +40298,7 @@ pvutils@latest:
   languageName: node
   linkType: hard
 
-"ws@npm:^7.5.10":
+"ws@npm:^7.3.1, ws@npm:^7.5.10":
   version: 7.5.10
   resolution: "ws@npm:7.5.10"
   peerDependencies:


### PR DESCRIPTION
## Description

Adds a `yarn analyze` script, which creates a build and uses `webpack-bundle-analyzer` to start a webserver showing bundle size information.

## Issue (if applicable)

Relates to https://github.com/shapeshift/web/issues/7768

## Risk

Low

> What protocols, transaction types, wallets or contract interactions might be affected by this PR?

None

## Testing

- `yarn dev` should work as expected
- `yarn build:web` should work as expected
- `yarn analyze` should build web and then start a local webserver to analyze the bundle

### Engineering

☝️

### Operations

- [ ] :checkered_flag: My feature is behind a flag and doesn't require operations testing (yet)

No ops testing required.

## Screenshots (if applicable)

<img width="739" alt="Screenshot 2024-10-01 at 15 59 30" src="https://github.com/user-attachments/assets/a4c5fed6-58c1-4b57-9329-e2a8b0055a94">

<img width="861" alt="Screenshot 2024-10-01 at 15 59 57" src="https://github.com/user-attachments/assets/59f4e00f-292a-410a-bb65-ea273bb17d1d">
