### PR TITLE
feat: notify users when arbitrum bridge claim is ready

### DIFF
--- a/packages/chain-adapters/src/evm/EvmBaseAdapter.ts
+++ b/packages/chain-adapters/src/evm/EvmBaseAdapter.ts
@@ -657,7 +657,7 @@ export abstract class EvmBaseAdapter<T extends EvmChainId> implements IChainAdap
     } as FeeDataEstimate<T>
   }
 
-  private async parseTx(tx: unchained.evm.types.Tx, pubkey: string): Promise<Transaction> {
+  async parseTx(tx: unchained.evm.types.Tx, pubkey: string): Promise<Transaction> {
     const { address: _, ...parsedTx } = await this.parser.parse(tx, pubkey)
 
     return {

--- a/packages/chain-adapters/src/evm/EvmBaseAdapter.ts
+++ b/packages/chain-adapters/src/evm/EvmBaseAdapter.ts
@@ -657,7 +657,7 @@ export abstract class EvmBaseAdapter<T extends EvmChainId> implements IChainAdap
     } as FeeDataEstimate<T>
   }
 
-  async parseTx(tx: unchained.evm.types.Tx, pubkey: string): Promise<Transaction> {
+  private async parseTx(tx: unchained.evm.types.Tx, pubkey: string): Promise<Transaction> {
     const { address: _, ...parsedTx } = await this.parser.parse(tx, pubkey)
 
     return {

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -8,6 +8,7 @@ import { useSelector } from 'react-redux'
 import { Routes } from 'Routes/Routes'
 import { ConsentBanner } from 'components/ConsentBanner'
 import { IconCircle } from 'components/IconCircle'
+import { useBridgeClaimNotification } from 'hooks/useBridgeClaimNotification/useBridgeClaimNotification'
 import { useHasAppUpdated } from 'hooks/useHasAppUpdated/useHasAppUpdated'
 import { useModal } from 'hooks/useModal/useModal'
 import { selectShowConsentBanner, selectShowWelcomeModal } from 'state/slices/selectors'
@@ -25,6 +26,8 @@ export const App = () => {
   const showWelcomeModal = useSelector(selectShowWelcomeModal)
   const showConsentBanner = useSelector(selectShowConsentBanner)
   const { isOpen: isNativeOnboardOpen, open: openNativeOnboard } = useModal('nativeOnboard')
+
+  useBridgeClaimNotification()
 
   const handleCtaClick = useCallback(() => window.location.reload(), [])
 

--- a/src/assets/translations/en/main.json
+++ b/src/assets/translations/en/main.json
@@ -802,7 +802,9 @@
     "pendingClaims": "Pending",
     "noPendingClaims": "No claims pending",
     "availableIn": "Available in %{time}",
-    "confirmAndClaim": "Confirm & Claim"
+    "confirmAndClaim": "Confirm & Claim",
+    "viewClaims": "View Claims",
+    "availableClaimsNotification": "You have bridge claims ready!"
   },
   "trade": {
     "trade": "Trade",

--- a/src/components/MultiHopTrade/MultiHopTrade.tsx
+++ b/src/components/MultiHopTrade/MultiHopTrade.tsx
@@ -122,7 +122,7 @@ const TradeRoutes = memo(({ isCompact }: TradeRoutesProps) => {
             />
           </Route>
           <Route key={TradeRoutePaths.Claim} path={TradeRoutePaths.Claim}>
-            <Claim />
+            <Claim isCompact={isCompact} />
           </Route>
         </Switch>
       </AnimatePresence>

--- a/src/components/MultiHopTrade/MultiHopTrade.tsx
+++ b/src/components/MultiHopTrade/MultiHopTrade.tsx
@@ -1,6 +1,6 @@
 import type { AssetId } from '@shapeshiftoss/caip'
 import { AnimatePresence } from 'framer-motion'
-import { memo, useEffect, useMemo, useRef } from 'react'
+import { memo, useEffect, useMemo, useRef, useState } from 'react'
 import { FormProvider, useForm } from 'react-hook-form'
 import { MemoryRouter, Route, Switch, useLocation, useParams } from 'react-router-dom'
 import { selectAssetById } from 'state/slices/assetsSlice/selectors'
@@ -10,6 +10,7 @@ import { useAppDispatch, useAppSelector } from 'state/store'
 
 import { MultiHopTradeConfirm } from './components/MultiHopTradeConfirm/MultiHopTradeConfirm'
 import { QuoteListRoute } from './components/QuoteList/QuoteListRoute'
+import { Claim } from './components/TradeInput/components/Claim/Claim'
 import { TradeInput } from './components/TradeInput/TradeInput'
 import { VerifyAddresses } from './components/VerifyAddresses/VerifyAddresses'
 import { useGetTradeQuotes } from './hooks/useGetTradeQuotes/useGetTradeQuotes'
@@ -20,6 +21,7 @@ const TradeRouteEntries = [
   TradeRoutePaths.Confirm,
   TradeRoutePaths.VerifyAddresses,
   TradeRoutePaths.QuoteList,
+  TradeRoutePaths.Claim,
 ]
 
 export type TradeCardProps = {
@@ -39,12 +41,21 @@ const GetTradeQuotes = () => {
 }
 
 export const MultiHopTrade = memo(({ defaultBuyAssetId, isCompact }: TradeCardProps) => {
+  const location = useLocation()
   const dispatch = useAppDispatch()
   const methods = useForm({ mode: 'onChange' })
   const { assetSubId, chainId } = useParams<MatchParams>()
+  const [initialIndex, setInitialIndex] = useState<number | undefined>()
 
   const routeBuyAsset = useAppSelector(state => selectAssetById(state, `${chainId}/${assetSubId}`))
   const defaultBuyAsset = useAppSelector(state => selectAssetById(state, defaultBuyAssetId ?? ''))
+
+  // Handle deep linked route from other pages
+  useEffect(() => {
+    if (initialIndex !== undefined) return
+    const incomingIndex = TradeRouteEntries.indexOf(location.pathname as TradeRoutePaths)
+    setInitialIndex(incomingIndex === -1 ? 0 : incomingIndex)
+  }, [initialIndex, location])
 
   useEffect(() => {
     dispatch(tradeInput.actions.clear())
@@ -52,9 +63,12 @@ export const MultiHopTrade = memo(({ defaultBuyAssetId, isCompact }: TradeCardPr
     else if (defaultBuyAsset) dispatch(tradeInput.actions.setBuyAsset(defaultBuyAsset))
   }, [defaultBuyAsset, defaultBuyAssetId, dispatch, routeBuyAsset])
 
+  // Prevent default behavior overriding deep linked route
+  if (initialIndex === undefined) return null
+
   return (
     <FormProvider {...methods}>
-      <MemoryRouter initialEntries={TradeRouteEntries} initialIndex={0}>
+      <MemoryRouter initialEntries={TradeRouteEntries} initialIndex={initialIndex}>
         <TradeRoutes isCompact={isCompact} />
       </MemoryRouter>
     </FormProvider>
@@ -106,6 +120,9 @@ const TradeRoutes = memo(({ isCompact }: TradeRoutesProps) => {
               height={tradeInputRef.current?.offsetHeight ?? '500px'}
               width={tradeInputRef.current?.offsetWidth ?? 'full'}
             />
+          </Route>
+          <Route key={TradeRoutePaths.Claim} path={TradeRoutePaths.Claim}>
+            <Claim />
           </Route>
         </Switch>
       </AnimatePresence>

--- a/src/components/MultiHopTrade/components/TradeInput/TradeInput.tsx
+++ b/src/components/MultiHopTrade/components/TradeInput/TradeInput.tsx
@@ -15,8 +15,8 @@ import {
 import { MessageOverlay } from 'components/MessageOverlay/MessageOverlay'
 import { getMixpanelEventData } from 'components/MultiHopTrade/helpers'
 import { useReceiveAddress } from 'components/MultiHopTrade/hooks/useReceiveAddress'
-import { TradeSlideTransition } from 'components/MultiHopTrade/TradeSlideTransition'
 import { TradeInputTab, TradeRoutePaths } from 'components/MultiHopTrade/types'
+import { SlideTransition } from 'components/SlideTransition'
 import { WalletActions } from 'context/WalletProvider/actions'
 import { useErrorHandler } from 'hooks/useErrorToast/useErrorToast'
 import { useWallet } from 'hooks/useWallet/useWallet'
@@ -256,43 +256,43 @@ export const TradeInput = ({ isCompact, tradeInputRef }: TradeInputProps) => {
   })()
 
   return (
-    <TradeSlideTransition>
-      <MessageOverlay show={isKeplr} title={overlayTitle}>
-        <Flex
-          width='full'
-          justifyContent='center'
-          maxWidth={isCompact || isSmallerThanXl ? '500px' : undefined}
-        >
-          <Center width='inherit'>
-            <Card flex={1} width='full' maxWidth='500px' ref={tradeInputRef}>
-              <ArbitrumBridgeAcknowledgement
+    <MessageOverlay show={isKeplr} title={overlayTitle}>
+      <Flex
+        width='full'
+        justifyContent='center'
+        maxWidth={isCompact || isSmallerThanXl ? '500px' : undefined}
+      >
+        <Center width='inherit'>
+          <Card flex={1} width='full' maxWidth='500px' ref={tradeInputRef}>
+            <ArbitrumBridgeAcknowledgement
+              onAcknowledge={handleFormSubmit}
+              shouldShowAcknowledgement={shouldShowArbitrumBridgeAcknowledgement}
+              setShouldShowAcknowledgement={setShouldShowArbitrumBridgeAcknowledgement}
+            >
+              <StreamingAcknowledgement
                 onAcknowledge={handleFormSubmit}
-                shouldShowAcknowledgement={shouldShowArbitrumBridgeAcknowledgement}
-                setShouldShowAcknowledgement={setShouldShowArbitrumBridgeAcknowledgement}
+                shouldShowAcknowledgement={shouldShowStreamingAcknowledgement}
+                setShouldShowAcknowledgement={setShouldShowStreamingAcknowledgement}
+                estimatedTimeMs={
+                  tradeQuoteStep?.estimatedExecutionTimeMs
+                    ? tradeQuoteStep.estimatedExecutionTimeMs
+                    : 0
+                }
               >
-                <StreamingAcknowledgement
-                  onAcknowledge={handleFormSubmit}
-                  shouldShowAcknowledgement={shouldShowStreamingAcknowledgement}
-                  setShouldShowAcknowledgement={setShouldShowStreamingAcknowledgement}
-                  estimatedTimeMs={
-                    tradeQuoteStep?.estimatedExecutionTimeMs
-                      ? tradeQuoteStep.estimatedExecutionTimeMs
-                      : 0
-                  }
+                <WarningAcknowledgement
+                  message={warningAcknowledgementMessage}
+                  onAcknowledge={handleWarningAcknowledgementSubmit}
+                  shouldShowAcknowledgement={shouldShowWarningAcknowledgement}
+                  setShouldShowAcknowledgement={setShouldShowWarningAcknowledgement}
                 >
-                  <WarningAcknowledgement
-                    message={warningAcknowledgementMessage}
-                    onAcknowledge={handleWarningAcknowledgementSubmit}
-                    shouldShowAcknowledgement={shouldShowWarningAcknowledgement}
-                    setShouldShowAcknowledgement={setShouldShowWarningAcknowledgement}
-                  >
-                    <Stack spacing={0} as='form' onSubmit={handleTradeQuoteConfirm}>
-                      <TradeInputHeader
-                        initialTab={TradeInputTab.Trade}
-                        onChangeTab={handleChangeTab}
-                        isLoading={isLoading}
-                        isCompact={isCompact}
-                      />
+                  <Stack spacing={0} as='form' onSubmit={handleTradeQuoteConfirm}>
+                    <TradeInputHeader
+                      initialTab={TradeInputTab.Trade}
+                      onChangeTab={handleChangeTab}
+                      isLoading={isLoading}
+                      isCompact={isCompact}
+                    />
+                    <SlideTransition>
                       <Box ref={bodyRef}>
                         <TradeInputBody
                           isLoading={isLoading}
@@ -308,24 +308,24 @@ export const TradeInput = ({ isCompact, tradeInputRef }: TradeInputProps) => {
                           receiveAddress={manualReceiveAddress ?? walletReceiveAddress}
                         />
                       </Box>
-                    </Stack>
-                  </WarningAcknowledgement>
-                </StreamingAcknowledgement>
-              </ArbitrumBridgeAcknowledgement>
-            </Card>
+                    </SlideTransition>
+                  </Stack>
+                </WarningAcknowledgement>
+              </StreamingAcknowledgement>
+            </ArbitrumBridgeAcknowledgement>
+          </Card>
 
-            <WithLazyMount
-              shouldUse={!isCompact && !isSmallerThanXl}
-              component={CollapsibleQuoteList}
-              isOpen={!isCompact && !isSmallerThanXl && hasUserEnteredAmount}
-              isLoading={isLoading}
-              width={tradeInputRef.current?.offsetWidth ?? 'full'}
-              height={totalHeight ?? 'full'}
-              ml={4}
-            />
-          </Center>
-        </Flex>
-      </MessageOverlay>
-    </TradeSlideTransition>
+          <WithLazyMount
+            shouldUse={!isCompact && !isSmallerThanXl}
+            component={CollapsibleQuoteList}
+            isOpen={!isCompact && !isSmallerThanXl && hasUserEnteredAmount}
+            isLoading={isLoading}
+            width={tradeInputRef.current?.offsetWidth ?? 'full'}
+            height={totalHeight ?? 'full'}
+            ml={4}
+          />
+        </Center>
+      </Flex>
+    </MessageOverlay>
   )
 }

--- a/src/components/MultiHopTrade/components/TradeInput/TradeInput.tsx
+++ b/src/components/MultiHopTrade/components/TradeInput/TradeInput.tsx
@@ -43,7 +43,6 @@ import { useAppDispatch, useAppSelector } from 'state/store'
 import { breakpoints } from 'theme/theme'
 
 import { useAccountIds } from '../../hooks/useAccountIds'
-import { Claim } from './components/Claim/Claim'
 import { CollapsibleQuoteList } from './components/CollapsibleQuoteList'
 import { ConfirmSummary } from './components/ConfirmSummary'
 import { TradeInputBody } from './components/TradeInputBody'
@@ -73,7 +72,6 @@ export const TradeInput = ({ isCompact, tradeInputRef }: TradeInputProps) => {
   const mixpanel = getMixPanel()
   const history = useHistory()
   const { showErrorToast } = useErrorHandler()
-  const [selectedTab, setSelectedTab] = useState<TradeInputTab>(TradeInputTab.Trade)
   const [isConfirmationLoading, setIsConfirmationLoading] = useState(false)
   const [shouldShowWarningAcknowledgement, setShouldShowWarningAcknowledgement] = useState(false)
   const [shouldShowStreamingAcknowledgement, setShouldShowStreamingAcknowledgement] =
@@ -210,6 +208,15 @@ export const TradeInput = ({ isCompact, tradeInputRef }: TradeInputProps) => {
 
   const handleFormSubmit = useMemo(() => handleSubmit(onSubmit), [handleSubmit, onSubmit])
 
+  const handleChangeTab = useCallback(
+    (newTab: TradeInputTab) => {
+      if (newTab === TradeInputTab.Claim) {
+        history.push(TradeRoutePaths.Claim)
+      }
+    },
+    [history],
+  )
+
   // If the warning acknowledgement is shown, we need to handle the submit differently because we might want to show the streaming acknowledgement
   const handleWarningAcknowledgementSubmit = useCallback(() => {
     if (activeQuote?.isStreaming && isEstimatedExecutionTimeOverThreshold)
@@ -281,29 +288,26 @@ export const TradeInput = ({ isCompact, tradeInputRef }: TradeInputProps) => {
                   >
                     <Stack spacing={0} as='form' onSubmit={handleTradeQuoteConfirm}>
                       <TradeInputHeader
-                        initialTab={selectedTab}
-                        onChangeTab={setSelectedTab}
+                        initialTab={TradeInputTab.Trade}
+                        onChangeTab={handleChangeTab}
                         isLoading={isLoading}
                         isCompact={isCompact}
                       />
-                      {selectedTab === TradeInputTab.Trade && (
-                        <Box ref={bodyRef}>
-                          <TradeInputBody
-                            isLoading={isLoading}
-                            manualReceiveAddress={manualReceiveAddress}
-                            initialSellAssetAccountId={initialSellAssetAccountId}
-                            initialBuyAssetAccountId={initialBuyAssetAccountId}
-                            setSellAssetAccountId={setSellAssetAccountId}
-                            setBuyAssetAccountId={setBuyAssetAccountId}
-                          />
-                          <ConfirmSummary
-                            isCompact={isCompact}
-                            isLoading={isLoading}
-                            receiveAddress={manualReceiveAddress ?? walletReceiveAddress}
-                          />
-                        </Box>
-                      )}
-                      {selectedTab === TradeInputTab.Claim && <Claim />}
+                      <Box ref={bodyRef}>
+                        <TradeInputBody
+                          isLoading={isLoading}
+                          manualReceiveAddress={manualReceiveAddress}
+                          initialSellAssetAccountId={initialSellAssetAccountId}
+                          initialBuyAssetAccountId={initialBuyAssetAccountId}
+                          setSellAssetAccountId={setSellAssetAccountId}
+                          setBuyAssetAccountId={setBuyAssetAccountId}
+                        />
+                        <ConfirmSummary
+                          isCompact={isCompact}
+                          isLoading={isLoading}
+                          receiveAddress={manualReceiveAddress ?? walletReceiveAddress}
+                        />
+                      </Box>
                     </Stack>
                   </WarningAcknowledgement>
                 </StreamingAcknowledgement>
@@ -313,12 +317,7 @@ export const TradeInput = ({ isCompact, tradeInputRef }: TradeInputProps) => {
             <WithLazyMount
               shouldUse={!isCompact && !isSmallerThanXl}
               component={CollapsibleQuoteList}
-              isOpen={
-                selectedTab === TradeInputTab.Trade &&
-                !isCompact &&
-                !isSmallerThanXl &&
-                hasUserEnteredAmount
-              }
+              isOpen={!isCompact && !isSmallerThanXl && hasUserEnteredAmount}
               isLoading={isLoading}
               width={tradeInputRef.current?.offsetWidth ?? 'full'}
               height={totalHeight ?? 'full'}

--- a/src/components/MultiHopTrade/components/TradeInput/components/Claim/Claim.tsx
+++ b/src/components/MultiHopTrade/components/TradeInput/components/Claim/Claim.tsx
@@ -1,8 +1,9 @@
+import { Card } from '@chakra-ui/react'
 import type { TxStatus } from '@shapeshiftoss/unchained-client'
-import { AnimatePresence } from 'framer-motion'
 import { lazy, Suspense, useCallback, useState } from 'react'
 import { MemoryRouter, Route, Switch, useLocation } from 'react-router'
 import { makeSuspenseful } from 'utils/makeSuspenseful'
+import { TradeSlideTransition } from 'components/MultiHopTrade/TradeSlideTransition'
 
 import type { ClaimDetails } from './hooks/useArbitrumClaimsByStatus'
 import { ClaimRoutePaths } from './types'
@@ -34,14 +35,6 @@ const ClaimStatus = makeSuspenseful(
 const ClaimRouteEntries = [ClaimRoutePaths.Select, ClaimRoutePaths.Confirm, ClaimRoutePaths.Status]
 
 export const Claim: React.FC = () => {
-  return (
-    <MemoryRouter initialEntries={ClaimRouteEntries} initialIndex={0}>
-      <ClaimRoutes />
-    </MemoryRouter>
-  )
-}
-
-export const ClaimRoutes: React.FC = () => {
   const location = useLocation()
 
   const [activeClaim, setActiveClaim] = useState<ClaimDetails | undefined>()
@@ -79,26 +72,30 @@ export const ClaimRoutes: React.FC = () => {
   }, [activeClaim, claimTxHash, claimTxStatus])
 
   return (
-    <AnimatePresence mode='wait' initial={false}>
-      <Switch location={location}>
-        <Suspense>
-          <Route
-            key={ClaimRoutePaths.Select}
-            path={ClaimRoutePaths.Select}
-            render={renderClaimSelect}
-          />
-          <Route
-            key={ClaimRoutePaths.Confirm}
-            path={ClaimRoutePaths.Confirm}
-            render={renderClaimConfirm}
-          />
-          <Route
-            key={ClaimRoutePaths.Status}
-            path={ClaimRoutePaths.Status}
-            render={renderClaimStatus}
-          />
-        </Suspense>
-      </Switch>
-    </AnimatePresence>
+    <TradeSlideTransition>
+      <MemoryRouter initialEntries={ClaimRouteEntries} initialIndex={0}>
+        <Switch location={location}>
+          <Card flex={1} width='full' maxWidth='500px'>
+            <Suspense>
+              <Route
+                key={ClaimRoutePaths.Select}
+                path={ClaimRoutePaths.Select}
+                render={renderClaimSelect}
+              />
+              <Route
+                key={ClaimRoutePaths.Confirm}
+                path={ClaimRoutePaths.Confirm}
+                render={renderClaimConfirm}
+              />
+              <Route
+                key={ClaimRoutePaths.Status}
+                path={ClaimRoutePaths.Status}
+                render={renderClaimStatus}
+              />
+            </Suspense>
+          </Card>
+        </Switch>
+      </MemoryRouter>
+    </TradeSlideTransition>
   )
 }

--- a/src/components/MultiHopTrade/components/TradeInput/components/Claim/Claim.tsx
+++ b/src/components/MultiHopTrade/components/TradeInput/components/Claim/Claim.tsx
@@ -1,38 +1,15 @@
 import { Card } from '@chakra-ui/react'
 import type { TxStatus } from '@shapeshiftoss/unchained-client'
-import { lazy, Suspense, useCallback, useState } from 'react'
+import { useCallback, useState } from 'react'
 import { MemoryRouter, Route, Switch, useHistory, useLocation } from 'react-router'
-import { makeSuspenseful } from 'utils/makeSuspenseful'
-import { TradeSlideTransition } from 'components/MultiHopTrade/TradeSlideTransition'
 import { TradeInputTab, TradeRoutePaths } from 'components/MultiHopTrade/types'
 
 import { TradeInputHeader } from '../TradeInputHeader'
+import { ClaimConfirm } from './ClaimConfirm'
+import { ClaimSelect } from './ClaimSelect'
+import { ClaimStatus } from './ClaimStatus'
 import type { ClaimDetails } from './hooks/useArbitrumClaimsByStatus'
 import { ClaimRoutePaths } from './types'
-
-const ClaimSelect = makeSuspenseful(
-  lazy(() =>
-    import('./ClaimSelect').then(({ ClaimSelect }) => ({
-      default: ClaimSelect,
-    })),
-  ),
-)
-
-const ClaimConfirm = makeSuspenseful(
-  lazy(() =>
-    import('./ClaimConfirm').then(({ ClaimConfirm }) => ({
-      default: ClaimConfirm,
-    })),
-  ),
-)
-
-const ClaimStatus = makeSuspenseful(
-  lazy(() =>
-    import('./ClaimStatus').then(({ ClaimStatus }) => ({
-      default: ClaimStatus,
-    })),
-  ),
-)
 
 const ClaimRouteEntries = [ClaimRoutePaths.Select, ClaimRoutePaths.Confirm, ClaimRoutePaths.Status]
 
@@ -84,36 +61,32 @@ export const Claim = ({ isCompact }: { isCompact?: boolean }) => {
   }, [activeClaim, claimTxHash, claimTxStatus])
 
   return (
-    <TradeSlideTransition>
-      <MemoryRouter initialEntries={ClaimRouteEntries} initialIndex={0}>
-        <Switch location={location}>
-          <Card flex={1} width='full' maxWidth='500px'>
-            <TradeInputHeader
-              initialTab={TradeInputTab.Claim}
-              onChangeTab={handleChangeTab}
-              isLoading={false}
-              isCompact={isCompact}
-            />
-            <Suspense>
-              <Route
-                key={ClaimRoutePaths.Select}
-                path={ClaimRoutePaths.Select}
-                render={renderClaimSelect}
-              />
-              <Route
-                key={ClaimRoutePaths.Confirm}
-                path={ClaimRoutePaths.Confirm}
-                render={renderClaimConfirm}
-              />
-              <Route
-                key={ClaimRoutePaths.Status}
-                path={ClaimRoutePaths.Status}
-                render={renderClaimStatus}
-              />
-            </Suspense>
-          </Card>
-        </Switch>
-      </MemoryRouter>
-    </TradeSlideTransition>
+    <MemoryRouter initialEntries={ClaimRouteEntries} initialIndex={0}>
+      <Switch location={location}>
+        <Card flex={1} width='full' maxWidth='500px'>
+          <TradeInputHeader
+            initialTab={TradeInputTab.Claim}
+            onChangeTab={handleChangeTab}
+            isLoading={false}
+            isCompact={isCompact}
+          />
+          <Route
+            key={ClaimRoutePaths.Select}
+            path={ClaimRoutePaths.Select}
+            render={renderClaimSelect}
+          />
+          <Route
+            key={ClaimRoutePaths.Confirm}
+            path={ClaimRoutePaths.Confirm}
+            render={renderClaimConfirm}
+          />
+          <Route
+            key={ClaimRoutePaths.Status}
+            path={ClaimRoutePaths.Status}
+            render={renderClaimStatus}
+          />
+        </Card>
+      </Switch>
+    </MemoryRouter>
   )
 }

--- a/src/components/MultiHopTrade/components/TradeInput/components/Claim/Claim.tsx
+++ b/src/components/MultiHopTrade/components/TradeInput/components/Claim/Claim.tsx
@@ -1,10 +1,12 @@
 import { Card } from '@chakra-ui/react'
 import type { TxStatus } from '@shapeshiftoss/unchained-client'
 import { lazy, Suspense, useCallback, useState } from 'react'
-import { MemoryRouter, Route, Switch, useLocation } from 'react-router'
+import { MemoryRouter, Route, Switch, useHistory, useLocation } from 'react-router'
 import { makeSuspenseful } from 'utils/makeSuspenseful'
 import { TradeSlideTransition } from 'components/MultiHopTrade/TradeSlideTransition'
+import { TradeInputTab, TradeRoutePaths } from 'components/MultiHopTrade/types'
 
+import { TradeInputHeader } from '../TradeInputHeader'
 import type { ClaimDetails } from './hooks/useArbitrumClaimsByStatus'
 import { ClaimRoutePaths } from './types'
 
@@ -34,12 +36,22 @@ const ClaimStatus = makeSuspenseful(
 
 const ClaimRouteEntries = [ClaimRoutePaths.Select, ClaimRoutePaths.Confirm, ClaimRoutePaths.Status]
 
-export const Claim: React.FC = () => {
+export const Claim = ({ isCompact }: { isCompact?: boolean }) => {
   const location = useLocation()
+  const history = useHistory()
 
   const [activeClaim, setActiveClaim] = useState<ClaimDetails | undefined>()
   const [claimTxHash, setClaimTxHash] = useState<string | undefined>()
   const [claimTxStatus, setClaimTxStatus] = useState<TxStatus | undefined>()
+
+  const handleChangeTab = useCallback(
+    (newTab: TradeInputTab) => {
+      if (newTab === TradeInputTab.Trade) {
+        history.push(TradeRoutePaths.Input)
+      }
+    },
+    [history],
+  )
 
   const renderClaimSelect = useCallback(() => {
     return <ClaimSelect setActiveClaim={setActiveClaim} />
@@ -76,6 +88,12 @@ export const Claim: React.FC = () => {
       <MemoryRouter initialEntries={ClaimRouteEntries} initialIndex={0}>
         <Switch location={location}>
           <Card flex={1} width='full' maxWidth='500px'>
+            <TradeInputHeader
+              initialTab={TradeInputTab.Claim}
+              onChangeTab={handleChangeTab}
+              isLoading={false}
+              isCompact={isCompact}
+            />
             <Suspense>
               <Route
                 key={ClaimRoutePaths.Select}

--- a/src/components/MultiHopTrade/components/TradeInput/components/Claim/ClaimSelect.tsx
+++ b/src/components/MultiHopTrade/components/TradeInput/components/Claim/ClaimSelect.tsx
@@ -2,6 +2,7 @@ import { Box, CardBody, Skeleton } from '@chakra-ui/react'
 import { useCallback, useMemo } from 'react'
 import { useHistory } from 'react-router'
 import { ClaimStatus } from 'components/ClaimRow/types'
+import { SlideTransition } from 'components/SlideTransition'
 import { Text } from 'components/Text'
 
 import { ClaimRow } from './ClaimRow'
@@ -57,15 +58,17 @@ export const ClaimSelect: React.FC<ClaimSelectProps> = ({ setActiveClaim }) => {
   }, [claimsByStatus.Pending, isLoading, handleClaimClick])
 
   return (
-    <CardBody px={6}>
-      <Box mb={6}>
-        <Text as='h5' fontSize='md' translation='bridge.availableClaims' />
-        {AvailableClaims}
-      </Box>
-      <Box>
-        <Text as='h5' fontSize='md' translation='bridge.pendingClaims' />
-        {PendingClaims}
-      </Box>
-    </CardBody>
+    <SlideTransition>
+      <CardBody px={6}>
+        <Box mb={6}>
+          <Text as='h5' fontSize='md' translation='bridge.availableClaims' />
+          {AvailableClaims}
+        </Box>
+        <Box>
+          <Text as='h5' fontSize='md' translation='bridge.pendingClaims' />
+          {PendingClaims}
+        </Box>
+      </CardBody>
+    </SlideTransition>
   )
 }

--- a/src/components/MultiHopTrade/components/TradeInput/components/Claim/ClaimSelect.tsx
+++ b/src/components/MultiHopTrade/components/TradeInput/components/Claim/ClaimSelect.tsx
@@ -24,7 +24,7 @@ export const ClaimSelect: React.FC<ClaimSelectProps> = ({ setActiveClaim }) => {
     [history, setActiveClaim],
   )
 
-  const { claimsByStatus, isLoading } = useArbitrumClaimsByStatus()
+  const { claimsByStatus, isLoading } = useArbitrumClaimsByStatus(true)
 
   const AvailableClaims = useMemo(() => {
     if (isLoading) return <Skeleton height={16} />

--- a/src/components/MultiHopTrade/components/TradeInput/components/Claim/ClaimSelect.tsx
+++ b/src/components/MultiHopTrade/components/TradeInput/components/Claim/ClaimSelect.tsx
@@ -24,7 +24,7 @@ export const ClaimSelect: React.FC<ClaimSelectProps> = ({ setActiveClaim }) => {
     [history, setActiveClaim],
   )
 
-  const { claimsByStatus, isLoading } = useArbitrumClaimsByStatus(true)
+  const { claimsByStatus, isLoading } = useArbitrumClaimsByStatus()
 
   const AvailableClaims = useMemo(() => {
     if (isLoading) return <Skeleton height={16} />

--- a/src/components/MultiHopTrade/components/TradeInput/components/Claim/ClaimSelect.tsx
+++ b/src/components/MultiHopTrade/components/TradeInput/components/Claim/ClaimSelect.tsx
@@ -3,8 +3,6 @@ import { useCallback, useMemo } from 'react'
 import { useHistory } from 'react-router'
 import { ClaimStatus } from 'components/ClaimRow/types'
 import { Text } from 'components/Text'
-import { selectArbitrumWithdrawTxs } from 'state/slices/selectors'
-import { useAppSelector } from 'state/store'
 
 import { ClaimRow } from './ClaimRow'
 import type { ClaimDetails } from './hooks/useArbitrumClaimsByStatus'
@@ -18,8 +16,6 @@ type ClaimSelectProps = {
 export const ClaimSelect: React.FC<ClaimSelectProps> = ({ setActiveClaim }) => {
   const history = useHistory()
 
-  const arbitrumWithdrawTxs = useAppSelector(selectArbitrumWithdrawTxs)
-
   const handleClaimClick = useCallback(
     (claim: ClaimDetails) => {
       setActiveClaim(claim)
@@ -28,7 +24,7 @@ export const ClaimSelect: React.FC<ClaimSelectProps> = ({ setActiveClaim }) => {
     [history, setActiveClaim],
   )
 
-  const { claimsByStatus, isLoading } = useArbitrumClaimsByStatus(arbitrumWithdrawTxs)
+  const { claimsByStatus, isLoading } = useArbitrumClaimsByStatus()
 
   const AvailableClaims = useMemo(() => {
     if (isLoading) return <Skeleton height={16} />

--- a/src/components/MultiHopTrade/components/TradeInput/components/Claim/hooks/useArbitrumClaimsByStatus.tsx
+++ b/src/components/MultiHopTrade/components/TradeInput/components/Claim/hooks/useArbitrumClaimsByStatus.tsx
@@ -59,7 +59,7 @@ const getArbitrumTx = async (txHash: string) => {
   return txData
 }
 
-export const useArbitrumClaimsByStatus = () => {
+export const useArbitrumClaimsByStatus = (isEnabled: boolean) => {
   const translate = useTranslate()
 
   const enabledWalletAccountIds = useAppSelector(selectEnabledWalletAccountIds)
@@ -106,6 +106,7 @@ export const useArbitrumClaimsByStatus = () => {
             )
           },
           refetchInterval: 60_000,
+          isEnabled,
         }
       }),
       combine: (
@@ -118,7 +119,7 @@ export const useArbitrumClaimsByStatus = () => {
         >[],
       ) => mergeQueryOutputs(queries, results => results.flat()),
     }
-  }, [addresses, l2Provider])
+  }, [addresses, isEnabled, l2Provider])
 
   const { data: txs, isLoading: isLoadingTxs } = useQueries(arbitrumBridgeTxQueries)
 
@@ -184,10 +185,11 @@ export const useArbitrumClaimsByStatus = () => {
             }
           },
           refetchInterval: 60_000,
+          isEnabled,
         }
       }),
     }
-  }, [l1Provider, l2Provider, txs])
+  }, [isEnabled, l1Provider, l2Provider, txs])
 
   const claimStatuses = useQueries(queries)
 

--- a/src/components/MultiHopTrade/components/TradeInput/components/Claim/hooks/useArbitrumClaimsByStatus.tsx
+++ b/src/components/MultiHopTrade/components/TradeInput/components/Claim/hooks/useArbitrumClaimsByStatus.tsx
@@ -1,40 +1,25 @@
 import type { ChildToParentMessageReader, ChildToParentTransactionEvent } from '@arbitrum/sdk'
 import { ChildToParentMessageStatus, ChildTransactionReceipt } from '@arbitrum/sdk'
 import type { AccountId, AssetId, ChainId } from '@shapeshiftoss/caip'
-import {
-  arbitrumChainId,
-  ethAssetId,
-  ethChainId,
-  fromAccountId,
-  toAccountId,
-} from '@shapeshiftoss/caip'
-import type { Transaction } from '@shapeshiftoss/chain-adapters'
+import { arbitrumChainId, ethAssetId, ethChainId, toAccountId } from '@shapeshiftoss/caip'
 import { getEthersV5Provider } from '@shapeshiftoss/contracts'
 import { KnownChainIds } from '@shapeshiftoss/types'
-import type { evm } from '@shapeshiftoss/unchained-client'
-import type { UseQueryResult } from '@tanstack/react-query'
 import { useQueries } from '@tanstack/react-query'
-import axios from 'axios'
-import { getConfig } from 'config'
 import { useMemo } from 'react'
 import { useTranslate } from 'react-polyglot'
-import { mergeQueryOutputs } from 'react-queries/helpers'
 import { ClaimStatus } from 'components/ClaimRow/types'
 import { assertUnreachable } from 'lib/utils'
-import { assertGetEvmChainAdapter } from 'lib/utils/evm'
-import { selectAssetById, selectEnabledWalletAccountIds } from 'state/slices/selectors'
+import { selectArbitrumWithdrawTxs, selectAssetById } from 'state/slices/selectors'
 import type { Tx } from 'state/slices/txHistorySlice/txHistorySlice'
 import { useAppSelector } from 'state/store'
 
 const AVERAGE_BLOCK_TIME_BLOCKS = 1000
-
 type ClaimStatusResult = {
   event: ChildToParentTransactionEvent
   message: ChildToParentMessageReader
   status: ChildToParentMessageStatus
   timeRemainingSeconds: number | undefined
 }
-
 export type ClaimDetails = Omit<ClaimStatusResult, 'status'> & {
   accountId: AccountId
   amountCryptoBaseUnit: string
@@ -49,112 +34,40 @@ export type ClaimDetails = Omit<ClaimStatusResult, 'status'> & {
 
 type ClaimsByStatus = Record<ClaimStatus, ClaimDetails[]>
 
-const getArbitrumTx = async (txHash: string) => {
-  const apiUrl = getConfig().REACT_APP_UNCHAINED_ETHEREUM_HTTP_URL
-  // using a timeout because if unchained hasn't seen a tx it will hang until eventual 520
-  const { data: txData } = await axios.get<evm.types.Tx>(`${apiUrl}/api/v1/tx/${txHash}`, {
-    timeout: 2000,
-  })
-
-  return txData
-}
-
-export const useArbitrumClaimsByStatus = (isEnabled: boolean) => {
+export const useArbitrumClaimsByStatus = (props?: { isDisabled?: boolean }) => {
   const translate = useTranslate()
 
-  const enabledWalletAccountIds = useAppSelector(selectEnabledWalletAccountIds)
   const ethAsset = useAppSelector(state => selectAssetById(state, ethAssetId))
+  const arbitrumWithdrawTxs = useAppSelector(selectArbitrumWithdrawTxs)
 
   const l1Provider = getEthersV5Provider(KnownChainIds.EthereumMainnet)
   const l2Provider = getEthersV5Provider(KnownChainIds.ArbitrumMainnet)
 
-  const addresses = useMemo(() => {
-    const arbitrumAccountIds = enabledWalletAccountIds.filter(
-      accountId => fromAccountId(accountId).chainId === KnownChainIds.ArbitrumMainnet,
-    )
-
-    return arbitrumAccountIds.map(accountId => fromAccountId(accountId).account)
-  }, [enabledWalletAccountIds])
-
-  const arbitrumBridgeTxQueries = useMemo(() => {
-    return {
-      queries: (addresses ?? []).map(address => {
-        return {
-          queryKey: ['arbitrumBridgeTxs', { address }],
-          queryFn: async () => {
-            // `cast sig-event "event L2ToL1Tx(address,address indexed,uint256 indexed,uint256 indexed,uint256,uint256,uint256,uint256,bytes)"`
-            const eventSig = '0x3e7aafa77dbf186b7fd488006beff893744caa3c4f6f299e8a709fa2087374fc'
-
-            const arbitrumChainAdapter = assertGetEvmChainAdapter(KnownChainIds.ArbitrumMainnet)
-
-            const filter = {
-              address,
-              topics: [eventSig],
-            }
-            const logs = await l2Provider.getLogs(filter)
-
-            return Promise.all(
-              logs.map(async log => {
-                const [receipt, tx] = await Promise.all([
-                  l2Provider.getTransactionReceipt(log.transactionHash),
-                  getArbitrumTx(log.transactionHash).then(tx =>
-                    arbitrumChainAdapter.parseTx(tx, address),
-                  ),
-                ])
-                return { receipt, tx }
-              }),
-            )
-          },
-          refetchInterval: 60_000,
-          isEnabled,
-        }
-      }),
-      combine: (
-        queries: UseQueryResult<
-          {
-            tx: Transaction
-            receipt: Awaited<ReturnType<typeof l2Provider.getTransactionReceipt>>
-          }[],
-          unknown
-        >[],
-      ) => mergeQueryOutputs(queries, results => results.flat()),
-    }
-  }, [addresses, isEnabled, l2Provider])
-
-  const { data: txs, isLoading: isLoadingTxs } = useQueries(arbitrumBridgeTxQueries)
-
   const queries = useMemo(() => {
     return {
-      queries: (txs ?? []).map(({ tx, receipt }) => {
+      queries: arbitrumWithdrawTxs.map(tx => {
         return {
           queryKey: ['claimStatus', { txid: tx.txid }],
           queryFn: async () => {
+            const receipt = await l2Provider.getTransactionReceipt(tx.txid)
             const l2Receipt = new ChildTransactionReceipt(receipt)
             const events = l2Receipt.getChildToParentEvents()
             const messages = await l2Receipt.getChildToParentMessages(l1Provider)
-
             const event = events[0]
             const message = messages[0]
-
             const status = await message.status(l2Provider)
             const block = (await message.getFirstExecutableBlock(l2Provider))?.toNumber()
-
             const timeRemainingSeconds = await (async () => {
               if (!block) return
-
               const latestBlock = await l1Provider.getBlock('latest')
               const historicalBlock = await l1Provider.getBlock(
                 latestBlock.number - AVERAGE_BLOCK_TIME_BLOCKS,
               )
-
               const averageBlockTimeSeconds =
                 (latestBlock.timestamp - historicalBlock.timestamp) / AVERAGE_BLOCK_TIME_BLOCKS
-
               const remainingBlocks = block - latestBlock.number
-
               return remainingBlocks * averageBlockTimeSeconds
             })()
-
             return {
               event,
               message,
@@ -175,7 +88,6 @@ export const useArbitrumClaimsByStatus = (isEnabled: boolean) => {
                   assertUnreachable(status)
               }
             })()
-
             return {
               tx,
               event,
@@ -185,11 +97,11 @@ export const useArbitrumClaimsByStatus = (isEnabled: boolean) => {
             }
           },
           refetchInterval: 60_000,
-          isEnabled,
+          isEnabled: !props?.isDisabled,
         }
       }),
     }
-  }, [isEnabled, l1Provider, l2Provider, txs])
+  }, [props?.isDisabled, l1Provider, l2Provider, arbitrumWithdrawTxs])
 
   const claimStatuses = useQueries(queries)
 
@@ -199,12 +111,10 @@ export const useArbitrumClaimsByStatus = (isEnabled: boolean) => {
         if (!data) return prev
         if (!ethAsset) return prev
         if (!data.tx.transfers.length) return prev
-
         if (data.tx.data?.parser === 'arbitrumBridge') {
           if (!data.tx.data.value) return prev
           if (!data.tx.data.destinationAddress) return prev
           if (!data.tx.data.destinationAssetId) return prev
-
           prev[data.claimStatus].push({
             tx: data.tx,
             accountId: toAccountId({
@@ -223,7 +133,6 @@ export const useArbitrumClaimsByStatus = (isEnabled: boolean) => {
             description: translate('bridge.arbitrum.description'),
           })
         }
-
         return prev
       },
       {
@@ -236,6 +145,6 @@ export const useArbitrumClaimsByStatus = (isEnabled: boolean) => {
 
   return {
     claimsByStatus,
-    isLoading: isLoadingTxs || claimStatuses.some(claimStatus => claimStatus.isLoading),
+    isLoading: claimStatuses.some(claimStatus => claimStatus.isLoading),
   }
 }

--- a/src/components/MultiHopTrade/components/TradeInput/components/Claim/hooks/useArbitrumClaimsByStatus.tsx
+++ b/src/components/MultiHopTrade/components/TradeInput/components/Claim/hooks/useArbitrumClaimsByStatus.tsx
@@ -34,7 +34,7 @@ export type ClaimDetails = Omit<ClaimStatusResult, 'status'> & {
 
 type ClaimsByStatus = Record<ClaimStatus, ClaimDetails[]>
 
-export const useArbitrumClaimsByStatus = (props?: { isDisabled?: boolean }) => {
+export const useArbitrumClaimsByStatus = (props?: { skip?: boolean }) => {
   const translate = useTranslate()
 
   const ethAsset = useAppSelector(state => selectAssetById(state, ethAssetId))
@@ -97,11 +97,11 @@ export const useArbitrumClaimsByStatus = (props?: { isDisabled?: boolean }) => {
             }
           },
           refetchInterval: 60_000,
-          isEnabled: !props?.isDisabled,
+          isEnabled: !Boolean(props?.skip),
         }
       }),
     }
-  }, [props?.isDisabled, l1Provider, l2Provider, arbitrumWithdrawTxs])
+  }, [arbitrumWithdrawTxs, props?.skip, l2Provider, l1Provider])
 
   const claimStatuses = useQueries(queries)
 

--- a/src/components/MultiHopTrade/types.ts
+++ b/src/components/MultiHopTrade/types.ts
@@ -8,6 +8,7 @@ export enum TradeRoutePaths {
   Quotes = '/trade/quotes',
   VerifyAddresses = '/trade/verify-addresses',
   QuoteList = '/trade/quote-list',
+  Claim = '/trade/claim',
 }
 
 export type GetReceiveAddressArgs = {

--- a/src/hooks/useBridgeClaimNotification/useBridgeClaimNotification.tsx
+++ b/src/hooks/useBridgeClaimNotification/useBridgeClaimNotification.tsx
@@ -2,7 +2,7 @@ import { Alert, AlertDescription, Button, CloseButton, Flex, useToast } from '@c
 import type { ResponsiveValue } from '@chakra-ui/system'
 import type { Property } from 'csstype'
 import { useCallback, useEffect, useState } from 'react'
-import { FaSync } from 'react-icons/fa'
+import { FaInfoCircle } from 'react-icons/fa'
 import { useTranslate } from 'react-polyglot'
 import { useHistory } from 'react-router'
 import { IconCircle } from 'components/IconCircle'
@@ -17,43 +17,44 @@ export const useBridgeClaimNotification = () => {
   const toast = useToast()
   const history = useHistory()
   const translate = useTranslate()
-  const [isEnabled, setIsEnabled] = useState(true)
-  const { claimsByStatus, isLoading } = useArbitrumClaimsByStatus(isEnabled)
+  const [isDisabled, setIsDisabled] = useState(false)
+
+  const { claimsByStatus, isLoading } = useArbitrumClaimsByStatus({ isDisabled })
 
   const handleCtaClick = useCallback(() => history.push(ClaimRoutePaths.Select), [history])
 
   useEffect(() => {
-    if (isLoading) return
-    if (claimsByStatus.Available.length > 0) {
-      // trigger a toast
-      toast({
-        render: ({ onClose }) => {
-          return (
-            <Alert status='info' variant='update-box' borderRadius='lg' gap={3}>
-              <IconCircle boxSize={8} color='text.subtle'>
-                <FaSync />
-              </IconCircle>
-              <Flex gap={flexGap} flexDir={flexDir} alignItems={flexAlignItems}>
-                <AlertDescription letterSpacing='0.02em'>
-                  {translate('beard.help.me.out.body.translation')}
-                </AlertDescription>
+    if (isLoading || isDisabled) return
+    if (claimsByStatus.Available.length === 0) return
 
-                <Button colorScheme='blue' size='sm' onClick={handleCtaClick}>
-                  {translate('beard.help.me.out.cta.translation')}
-                </Button>
-              </Flex>
-              <CloseButton onClick={onClose} size='sm' />
-            </Alert>
-          )
-        },
-        id: 'bridge-claim',
-        duration: null,
-        isClosable: true,
-        position: 'bottom-right',
-      })
+    // trigger a toast
+    toast({
+      render: ({ onClose }) => {
+        return (
+          <Alert status='info' variant='update-box' borderRadius='lg' gap={3}>
+            <IconCircle boxSize={8} color='text.subtle'>
+              <FaInfoCircle />
+            </IconCircle>
+            <Flex gap={flexGap} flexDir={flexDir} alignItems={flexAlignItems}>
+              <AlertDescription letterSpacing='0.02em'>
+                {translate('bridge.availableClaimsNotification')}
+              </AlertDescription>
 
-      // don't spam user
-      setIsEnabled(false)
-    }
-  }, [claimsByStatus.Available.length, handleCtaClick, isLoading, toast, translate])
+              <Button colorScheme='blue' size='sm' onClick={handleCtaClick}>
+                {translate('bridge.viewClaims')}
+              </Button>
+            </Flex>
+            <CloseButton onClick={onClose} size='sm' />
+          </Alert>
+        )
+      },
+      id: 'bridge-claim',
+      duration: null,
+      isClosable: true,
+      position: 'bottom-right',
+    })
+
+    // don't spam user
+    setIsDisabled(true)
+  }, [claimsByStatus.Available.length, handleCtaClick, isDisabled, isLoading, toast, translate])
 }

--- a/src/hooks/useBridgeClaimNotification/useBridgeClaimNotification.tsx
+++ b/src/hooks/useBridgeClaimNotification/useBridgeClaimNotification.tsx
@@ -1,0 +1,59 @@
+import { Alert, AlertDescription, Button, CloseButton, Flex, useToast } from '@chakra-ui/react'
+import type { ResponsiveValue } from '@chakra-ui/system'
+import type { Property } from 'csstype'
+import { useCallback, useEffect, useState } from 'react'
+import { FaSync } from 'react-icons/fa'
+import { useTranslate } from 'react-polyglot'
+import { useHistory } from 'react-router'
+import { IconCircle } from 'components/IconCircle'
+import { useArbitrumClaimsByStatus } from 'components/MultiHopTrade/components/TradeInput/components/Claim/hooks/useArbitrumClaimsByStatus'
+import { ClaimRoutePaths } from 'pages/RFOX/components/Claim/types'
+
+const flexGap = { base: 2, md: 3 }
+const flexDir: ResponsiveValue<Property.FlexDirection> = { base: 'column', md: 'row' }
+const flexAlignItems = { base: 'flex-start', md: 'center' }
+
+export const useBridgeClaimNotification = () => {
+  const toast = useToast()
+  const history = useHistory()
+  const translate = useTranslate()
+  const [isEnabled, setIsEnabled] = useState(true)
+  const { claimsByStatus, isLoading } = useArbitrumClaimsByStatus(isEnabled)
+
+  const handleCtaClick = useCallback(() => history.push(ClaimRoutePaths.Select), [history])
+
+  useEffect(() => {
+    if (isLoading) return
+    if (claimsByStatus.Available.length > 0) {
+      // trigger a toast
+      toast({
+        render: ({ onClose }) => {
+          return (
+            <Alert status='info' variant='update-box' borderRadius='lg' gap={3}>
+              <IconCircle boxSize={8} color='text.subtle'>
+                <FaSync />
+              </IconCircle>
+              <Flex gap={flexGap} flexDir={flexDir} alignItems={flexAlignItems}>
+                <AlertDescription letterSpacing='0.02em'>
+                  {translate('beard.help.me.out.body.translation')}
+                </AlertDescription>
+
+                <Button colorScheme='blue' size='sm' onClick={handleCtaClick}>
+                  {translate('beard.help.me.out.cta.translation')}
+                </Button>
+              </Flex>
+              <CloseButton onClick={onClose} size='sm' />
+            </Alert>
+          )
+        },
+        id: 'bridge-claim',
+        duration: null,
+        isClosable: true,
+        position: 'bottom-right',
+      })
+
+      // don't spam user
+      setIsEnabled(false)
+    }
+  }, [claimsByStatus.Available.length, handleCtaClick, isLoading, toast, translate])
+}

--- a/src/hooks/useBridgeClaimNotification/useBridgeClaimNotification.tsx
+++ b/src/hooks/useBridgeClaimNotification/useBridgeClaimNotification.tsx
@@ -13,17 +13,39 @@ const flexGap = { base: 2, md: 3 }
 const flexDir: ResponsiveValue<Property.FlexDirection> = { base: 'column', md: 'row' }
 const flexAlignItems = { base: 'flex-start', md: 'center' }
 
-export const useBridgeClaimNotification = () => {
-  const toast = useToast()
+const BridgeClaimNotification = ({ onClose }: { onClose: () => void }) => {
   const history = useHistory()
   const translate = useTranslate()
-  const [isDisabled, setIsDisabled] = useState(false)
-
-  const { claimsByStatus, isLoading } = useArbitrumClaimsByStatus({ isDisabled })
 
   const handleCtaClick = useCallback(() => {
     history.push(TradeRoutePaths.Claim)
-  }, [history])
+    onClose()
+  }, [history, onClose])
+
+  return (
+    <Alert status='info' variant='update-box' borderRadius='lg' gap={3}>
+      <IconCircle boxSize={8} color='text.subtle'>
+        <FaInfoCircle />
+      </IconCircle>
+      <Flex gap={flexGap} flexDir={flexDir} alignItems={flexAlignItems}>
+        <AlertDescription letterSpacing='0.02em'>
+          {translate('bridge.availableClaimsNotification')}
+        </AlertDescription>
+
+        <Button colorScheme='blue' size='sm' onClick={handleCtaClick}>
+          {translate('bridge.viewClaims')}
+        </Button>
+      </Flex>
+      <CloseButton onClick={onClose} size='sm' />
+    </Alert>
+  )
+}
+
+export const useBridgeClaimNotification = () => {
+  const toast = useToast()
+  const [isDisabled, setIsDisabled] = useState(false)
+
+  const { claimsByStatus, isLoading } = useArbitrumClaimsByStatus({ isDisabled })
 
   useEffect(() => {
     if (isLoading || isDisabled) return
@@ -32,23 +54,7 @@ export const useBridgeClaimNotification = () => {
     // trigger a toast
     toast({
       render: ({ onClose }) => {
-        return (
-          <Alert status='info' variant='update-box' borderRadius='lg' gap={3}>
-            <IconCircle boxSize={8} color='text.subtle'>
-              <FaInfoCircle />
-            </IconCircle>
-            <Flex gap={flexGap} flexDir={flexDir} alignItems={flexAlignItems}>
-              <AlertDescription letterSpacing='0.02em'>
-                {translate('bridge.availableClaimsNotification')}
-              </AlertDescription>
-
-              <Button colorScheme='blue' size='sm' onClick={handleCtaClick}>
-                {translate('bridge.viewClaims')}
-              </Button>
-            </Flex>
-            <CloseButton onClick={onClose} size='sm' />
-          </Alert>
-        )
+        return <BridgeClaimNotification onClose={onClose} />
       },
       id: 'bridge-claim',
       duration: null,
@@ -58,5 +64,5 @@ export const useBridgeClaimNotification = () => {
 
     // don't spam user
     setIsDisabled(true)
-  }, [claimsByStatus.Available.length, handleCtaClick, isDisabled, isLoading, toast, translate])
+  }, [claimsByStatus.Available.length, isDisabled, isLoading, toast])
 }

--- a/src/hooks/useBridgeClaimNotification/useBridgeClaimNotification.tsx
+++ b/src/hooks/useBridgeClaimNotification/useBridgeClaimNotification.tsx
@@ -1,7 +1,7 @@
 import { Alert, AlertDescription, Button, CloseButton, Flex, useToast } from '@chakra-ui/react'
 import type { ResponsiveValue } from '@chakra-ui/system'
 import type { Property } from 'csstype'
-import { useCallback, useEffect, useState } from 'react'
+import { useEffect, useState } from 'react'
 import { FaInfoCircle } from 'react-icons/fa'
 import { useTranslate } from 'react-polyglot'
 import { useHistory } from 'react-router'
@@ -13,36 +13,10 @@ const flexGap = { base: 2, md: 3 }
 const flexDir: ResponsiveValue<Property.FlexDirection> = { base: 'column', md: 'row' }
 const flexAlignItems = { base: 'flex-start', md: 'center' }
 
-const BridgeClaimNotification = ({ onClose }: { onClose: () => void }) => {
-  const history = useHistory()
-  const translate = useTranslate()
-
-  const handleCtaClick = useCallback(() => {
-    history.push(TradeRoutePaths.Claim)
-    onClose()
-  }, [history, onClose])
-
-  return (
-    <Alert status='info' variant='update-box' borderRadius='lg' gap={3}>
-      <IconCircle boxSize={8} color='text.subtle'>
-        <FaInfoCircle />
-      </IconCircle>
-      <Flex gap={flexGap} flexDir={flexDir} alignItems={flexAlignItems}>
-        <AlertDescription letterSpacing='0.02em'>
-          {translate('bridge.availableClaimsNotification')}
-        </AlertDescription>
-
-        <Button colorScheme='blue' size='sm' onClick={handleCtaClick}>
-          {translate('bridge.viewClaims')}
-        </Button>
-      </Flex>
-      <CloseButton onClick={onClose} size='sm' />
-    </Alert>
-  )
-}
-
 export const useBridgeClaimNotification = () => {
   const toast = useToast()
+  const history = useHistory()
+  const translate = useTranslate()
   const [isDisabled, setIsDisabled] = useState(false)
 
   const { claimsByStatus, isLoading } = useArbitrumClaimsByStatus({ isDisabled })
@@ -54,7 +28,34 @@ export const useBridgeClaimNotification = () => {
     // trigger a toast
     toast({
       render: ({ onClose }) => {
-        return <BridgeClaimNotification onClose={onClose} />
+        const handleCtaClick = () => {
+          history.push(TradeRoutePaths.Claim)
+          onClose()
+        }
+
+        return (
+          <Alert status='info' variant='update-box' borderRadius='lg' gap={3}>
+            <IconCircle boxSize={8} color='text.subtle'>
+              <FaInfoCircle />
+            </IconCircle>
+            <Flex gap={flexGap} flexDir={flexDir} alignItems={flexAlignItems}>
+              <AlertDescription letterSpacing='0.02em'>
+                {translate('bridge.availableClaimsNotification')}
+              </AlertDescription>
+
+              <Button
+                colorScheme='blue'
+                size='sm'
+                // translate and history undefined if this component split out, so cannot properly memoize
+                // eslint-disable-next-line react-memo/require-usememo
+                onClick={handleCtaClick}
+              >
+                {translate('bridge.viewClaims')}
+              </Button>
+            </Flex>
+            <CloseButton onClick={onClose} size='sm' />
+          </Alert>
+        )
       },
       id: 'bridge-claim',
       duration: null,
@@ -64,5 +65,5 @@ export const useBridgeClaimNotification = () => {
 
     // don't spam user
     setIsDisabled(true)
-  }, [claimsByStatus.Available.length, isDisabled, isLoading, toast])
+  }, [claimsByStatus.Available.length, history, isDisabled, isLoading, toast, translate])
 }

--- a/src/hooks/useBridgeClaimNotification/useBridgeClaimNotification.tsx
+++ b/src/hooks/useBridgeClaimNotification/useBridgeClaimNotification.tsx
@@ -8,6 +8,7 @@ import { useHistory } from 'react-router'
 import { IconCircle } from 'components/IconCircle'
 import { useArbitrumClaimsByStatus } from 'components/MultiHopTrade/components/TradeInput/components/Claim/hooks/useArbitrumClaimsByStatus'
 import { TradeRoutePaths } from 'components/MultiHopTrade/types'
+import { useWallet } from 'hooks/useWallet/useWallet'
 
 const flexGap = { base: 2, md: 3 }
 const flexDir: ResponsiveValue<Property.FlexDirection> = { base: 'column', md: 'row' }
@@ -19,7 +20,16 @@ export const useBridgeClaimNotification = () => {
   const translate = useTranslate()
   const [isDisabled, setIsDisabled] = useState(false)
 
+  const {
+    state: { deviceId: walletDeviceId },
+  } = useWallet()
+
   const { claimsByStatus, isLoading } = useArbitrumClaimsByStatus({ skip: isDisabled })
+
+  // Re-enable the notification when wallet changes
+  useEffect(() => {
+    setIsDisabled(false)
+  }, [walletDeviceId])
 
   useEffect(() => {
     if (isLoading || isDisabled) return

--- a/src/hooks/useBridgeClaimNotification/useBridgeClaimNotification.tsx
+++ b/src/hooks/useBridgeClaimNotification/useBridgeClaimNotification.tsx
@@ -7,7 +7,7 @@ import { useTranslate } from 'react-polyglot'
 import { useHistory } from 'react-router'
 import { IconCircle } from 'components/IconCircle'
 import { useArbitrumClaimsByStatus } from 'components/MultiHopTrade/components/TradeInput/components/Claim/hooks/useArbitrumClaimsByStatus'
-import { ClaimRoutePaths } from 'pages/RFOX/components/Claim/types'
+import { TradeRoutePaths } from 'components/MultiHopTrade/types'
 
 const flexGap = { base: 2, md: 3 }
 const flexDir: ResponsiveValue<Property.FlexDirection> = { base: 'column', md: 'row' }
@@ -21,7 +21,9 @@ export const useBridgeClaimNotification = () => {
 
   const { claimsByStatus, isLoading } = useArbitrumClaimsByStatus({ isDisabled })
 
-  const handleCtaClick = useCallback(() => history.push(ClaimRoutePaths.Select), [history])
+  const handleCtaClick = useCallback(() => {
+    history.push(TradeRoutePaths.Claim)
+  }, [history])
 
   useEffect(() => {
     if (isLoading || isDisabled) return

--- a/src/hooks/useBridgeClaimNotification/useBridgeClaimNotification.tsx
+++ b/src/hooks/useBridgeClaimNotification/useBridgeClaimNotification.tsx
@@ -19,7 +19,7 @@ export const useBridgeClaimNotification = () => {
   const translate = useTranslate()
   const [isDisabled, setIsDisabled] = useState(false)
 
-  const { claimsByStatus, isLoading } = useArbitrumClaimsByStatus({ isDisabled })
+  const { claimsByStatus, isLoading } = useArbitrumClaimsByStatus({ skip: isDisabled })
 
   useEffect(() => {
     if (isLoading || isDisabled) return


### PR DESCRIPTION
## Description

Triggers a one-off toast if ready arbitrum claims are detected. Includes changes to trade page routing (necessary for deep redirect) and improvements transition animations (nice to have).

~Additional effort was made to negate reliance on tx history per #7872 (i.e dig up stupid https://www.youtube.com/watch?v=b97zJxKEqAk )~ Nope we cannot do this yet.

## Issue (if applicable)

<!-----------------------------------------------------------------------------
If applicable, please link to the github issue and put `closes #XXXX` in your comment to auto-close the issue that your PR fixes.
------------------------------------------------------------------------------>

closes #7835

## Risk

> High Risk PRs Require 2 approvals

Moderate risk, changes to trade page routing should be the main focus when reviewing.

> What protocols, transaction types, wallets or contract interactions might be affected by this PR?

## Testing

- Can trade without issues
- Can initiate a bridge without issues
- Can claim without issues
- Notification works and button redirects you to the clam page
- Notification only fires once per page load

### Engineering

<!-----------------------------------------------------------------------------
Include sufficient information here for an engineer to test your PR. This may include how to test locally, in a built environment, changes to infrastructure etc.
------------------------------------------------------------------------------>

### Operations

- [ ] :checkered_flag: My feature is behind a flag and doesn't require operations testing (yet)

<!-----------------------------------------------------------------------------
If your changes have a user-facing impact, describe how a non-technical QA team can functionally test your changes in a preview environment.

If they are not user-facing please describe how to test for any regressions that may occur.
------------------------------------------------------------------------------>

## Screenshots (if applicable)

Notification with redirect:

https://jam.dev/c/1bcb434c-0dd1-4657-8a07-05374e154e87

Transition animations hyperactive ADHD clickfest:

https://github.com/user-attachments/assets/6a6ac32c-de01-46c4-96b9-0b13053f4c4c

