### PR TITLE
fix: asset balance regression

### DIFF
--- a/src/components/Equity/Equity.tsx
+++ b/src/components/Equity/Equity.tsx
@@ -14,6 +14,7 @@ import { useMemo } from 'react'
 import { useTranslate } from 'react-polyglot'
 import { useSelector } from 'react-redux'
 import { Amount } from 'components/Amount/Amount'
+import { useWallet } from 'hooks/useWallet/useWallet'
 import type { LpId, OpportunityId } from 'state/slices/opportunitiesSlice/types'
 import { AssetEquityType } from 'state/slices/portfolioSlice/portfolioSliceCommon'
 import {
@@ -44,6 +45,9 @@ export const Equity = ({ assetId, accountId }: EquityProps) => {
   const portfolioLoading = useSelector(selectIsPortfolioLoading)
   const opportunitiesLoading = useAppSelector(selectOpportunityApiPending)
   const isLoading = portfolioLoading || opportunitiesLoading
+  const {
+    state: { isConnected },
+  } = useWallet()
   const assets = useAppSelector(selectAssets)
   const asset = assets[assetId]
   const borderColor = useColorModeValue('blackAlpha.50', 'whiteAlpha.50')
@@ -142,7 +146,7 @@ export const Equity = ({ assetId, accountId }: EquityProps) => {
     [borderColor],
   )
 
-  if (!asset || !accountId) return null
+  if (!asset || !isConnected) return null
 
   return (
     <Card variant='dashboard'>


### PR DESCRIPTION
## Description

Fixes a regression where the `Equity.tsx` component would not render, as we actually don't pass an `accountId` down from `Asset.tsx`, and so this value is _always_ undefined.

## Issue (if applicable)

Closes https://github.com/shapeshift/web/issues/7874

## Risk

Small

> What protocols, transaction types, wallets or contract interactions might be affected by this PR?

None

## Testing

On the asset page we should see the "Your balance" section again:

<img width="726" alt="Screenshot 2024-10-03 at 16 05 58" src="https://github.com/user-attachments/assets/97e4b8fd-c42c-4de3-951c-ad2b01c61f88">

### Engineering

☝️

### Operations

- [ ] :checkered_flag: My feature is behind a flag and doesn't require operations testing (yet)

You will never actually see this bug, as it was both caused and fixed in this release.

## Screenshots (if applicable)

See above.