### PR TITLE
fix: big content shift on rfox tabs

### DIFF
--- a/src/pages/RFOX/components/ChangeAddress/ChangeAddress.tsx
+++ b/src/pages/RFOX/components/ChangeAddress/ChangeAddress.tsx
@@ -11,12 +11,17 @@ import { ChangeAddressRoutePaths } from './types'
 
 const suspenseFallback = <div>Loading...</div>
 
+const defaultBoxSpinnerStyle = {
+  height: '500px',
+}
+
 const ChangeAddressInput = makeSuspenseful(
   lazy(() =>
     import('./ChangeAddressInput').then(({ ChangeAddressInput }) => ({
       default: ChangeAddressInput,
     })),
   ),
+  defaultBoxSpinnerStyle,
 )
 
 const ChangeAddressConfirm = makeSuspenseful(
@@ -25,6 +30,7 @@ const ChangeAddressConfirm = makeSuspenseful(
       default: ChangeAddressConfirm,
     })),
   ),
+  defaultBoxSpinnerStyle,
 )
 
 const ChangeAddressStatus = makeSuspenseful(
@@ -33,6 +39,7 @@ const ChangeAddressStatus = makeSuspenseful(
       default: ChangeAddressStatus,
     })),
   ),
+  defaultBoxSpinnerStyle,
 )
 
 const ChangeAddressEntries = [

--- a/src/pages/RFOX/components/Claim/Claim.tsx
+++ b/src/pages/RFOX/components/Claim/Claim.tsx
@@ -12,12 +12,17 @@ import { ClaimRoutePaths, type ClaimRouteProps } from './types'
 
 const suspenseFallback = <div>Loading...</div>
 
+const defaultBoxSpinnerStyle = {
+  height: '500px',
+}
+
 const ClaimSelect = makeSuspenseful(
   lazy(() =>
     import('./ClaimSelect').then(({ ClaimSelect }) => ({
       default: ClaimSelect,
     })),
   ),
+  defaultBoxSpinnerStyle,
 )
 
 const ClaimConfirm = makeSuspenseful(
@@ -26,6 +31,7 @@ const ClaimConfirm = makeSuspenseful(
       default: ClaimConfirm,
     })),
   ),
+  defaultBoxSpinnerStyle,
 )
 
 const ClaimStatus = makeSuspenseful(
@@ -34,6 +40,7 @@ const ClaimStatus = makeSuspenseful(
       default: ClaimStatus,
     })),
   ),
+  defaultBoxSpinnerStyle,
 )
 
 const ClaimEntries = [ClaimRoutePaths.Select, ClaimRoutePaths.Confirm, ClaimRoutePaths.Status]

--- a/src/pages/RFOX/components/Stake/Stake.tsx
+++ b/src/pages/RFOX/components/Stake/Stake.tsx
@@ -15,12 +15,17 @@ const suspenseFallback = <div>Loading...</div>
 
 const stakingAssetId = foxOnArbitrumOneAssetId
 
+const defaultBoxSpinnerStyle = {
+  height: '500px',
+}
+
 const StakeInput = makeSuspenseful(
   lazy(() =>
     import('./StakeInput').then(({ StakeInput }) => ({
       default: StakeInput,
     })),
   ),
+  defaultBoxSpinnerStyle,
 )
 
 const StakeConfirm = makeSuspenseful(
@@ -29,6 +34,7 @@ const StakeConfirm = makeSuspenseful(
       default: StakeConfirm,
     })),
   ),
+  defaultBoxSpinnerStyle,
 )
 
 const StakeStatus = makeSuspenseful(
@@ -37,6 +43,7 @@ const StakeStatus = makeSuspenseful(
       default: StakeStatus,
     })),
   ),
+  defaultBoxSpinnerStyle,
 )
 
 const BridgeConfirm = makeSuspenseful(
@@ -45,6 +52,7 @@ const BridgeConfirm = makeSuspenseful(
       default: BridgeConfirm,
     })),
   ),
+  defaultBoxSpinnerStyle,
 )
 
 const BridgeStatus = makeSuspenseful(
@@ -53,6 +61,7 @@ const BridgeStatus = makeSuspenseful(
       default: BridgeStatus,
     })),
   ),
+  defaultBoxSpinnerStyle,
 )
 
 const StakeEntries = [StakeRoutePaths.Input, StakeRoutePaths.Confirm, StakeRoutePaths.Status]

--- a/src/pages/RFOX/components/Unstake/Unstake.tsx
+++ b/src/pages/RFOX/components/Unstake/Unstake.tsx
@@ -15,12 +15,17 @@ import { UnstakeRoutePaths } from './types'
 
 const suspenseFallback = <div>Loading...</div>
 
+const defaultBoxSpinnerStyle = {
+  height: '500px',
+}
+
 const UnstakeInput = makeSuspenseful(
   lazy(() =>
     import('./UnstakeInput').then(({ UnstakeInput }) => ({
       default: UnstakeInput,
     })),
   ),
+  defaultBoxSpinnerStyle,
 )
 
 const UnstakeConfirm = makeSuspenseful(
@@ -29,6 +34,7 @@ const UnstakeConfirm = makeSuspenseful(
       default: UnstakeConfirm,
     })),
   ),
+  defaultBoxSpinnerStyle,
 )
 
 const UnstakeStatus = makeSuspenseful(
@@ -37,6 +43,7 @@ const UnstakeStatus = makeSuspenseful(
       default: UnstakeStatus,
     })),
   ),
+  defaultBoxSpinnerStyle,
 )
 
 const UnstakeEntries = [

--- a/src/utils/makeSuspenseful.tsx
+++ b/src/utils/makeSuspenseful.tsx
@@ -1,3 +1,4 @@
+import type { BoxProps } from '@chakra-ui/react'
 import { Box } from '@chakra-ui/react'
 import type { ComponentProps, FC } from 'react'
 import { Suspense, useMemo } from 'react'
@@ -12,15 +13,17 @@ const suspenseSpinnerStyle = {
   height: '100vh',
 }
 
-export function makeSuspenseful<T extends FC<any>>(Component: T) {
+export function makeSuspenseful<T extends FC<any>>(Component: T, spinnerStyle: BoxProps = {}) {
   return (props: ComponentProps<T>) => {
+    const boxSpinnerStyle = useMemo(() => ({ ...suspenseSpinnerStyle, ...spinnerStyle }), [])
+
     const suspenseSpinner = useMemo(
       () => (
-        <Box style={suspenseSpinnerStyle}>
+        <Box sx={boxSpinnerStyle}>
           <CircularProgress />
         </Box>
       ),
-      [],
+      [boxSpinnerStyle],
     )
 
     return (


### PR DESCRIPTION
## Description

There was a big content shift on rfox tabs because the makeSuspensful box returns a box with a height of 100vh which is correct for most of our usage but incorrect for rFOX as it's not using on a whole view but on small components parts

I added a parameter to the makeSuspenful function to push custom style to this box and fixed it in every rFOX components

<!-- Please describe your changes -->

## Issue (if applicable)
None
<!-----------------------------------------------------------------------------
If applicable, please link to the github issue and put `closes #XXXX` in your comment to auto-close the issue that your PR fixes.
------------------------------------------------------------------------------>

## Risk
Low
> High Risk PRs Require 2 approvals

<!-----------------------------------------------------------------------------
Outline the scope of your changes and the risk associated with them. You must use your discretion as an engineer to determine the potential impact of your changes.

WARNING: If your PR introduces a new on-chain transaction or modifies an existing one, please add the "High-Risk" label to this PR and ask for 2 reviewers to approve it before merging.

E.g. an upgrade to `hdwallet` or core state management would be considered higher risk, and might require a full regression test. UI or isolated view changes, or something behind a feature flag may have near zero risk. Small bug fixes might require testing isolated to the specific fix.
------------------------------------------------------------------------------>

> What protocols, transaction types, wallets or contract interactions might be affected by this PR?

## Testing
- Load the rFOX page directly, you should see the loader shouldn't be too big but the regular widget height
- Also switch to any other tabs and the height should be the same

<!-----------------------------------------------------------------------------
We treat every PR to be merged with the same scrutiny as if we were merging directly to production.

Your PR will not be merged if you do not complete the sections below for our engineering and operations teams to test.
------------------------------------------------------------------------------>

### Engineering
n/a
<!-----------------------------------------------------------------------------
Include sufficient information here for an engineer to test your PR. This may include how to test locally, in a built environment, changes to infrastructure etc.
------------------------------------------------------------------------------>

### Operations
n/a
- [ ] :checkered_flag: My feature is behind a flag and doesn't require operations testing (yet)

<!-----------------------------------------------------------------------------
If your changes have a user-facing impact, describe how a non-technical QA team can functionally test your changes in a preview environment.

If they are not user-facing please describe how to test for any regressions that may occur.
------------------------------------------------------------------------------>

## Screenshots (if applicable)
### Fix
![image](https://github.com/user-attachments/assets/dda75817-fb3d-44de-a9f5-b8ed27b46e69)
### Develop
![image](https://github.com/user-attachments/assets/0399ce09-d477-4029-84c5-4312de6a01a1)
