### PR TITLE
feat: bring back splash page

### DIFF
--- a/src/Routes/PrivateRoute.tsx
+++ b/src/Routes/PrivateRoute.tsx
@@ -1,0 +1,34 @@
+import { useMemo } from 'react'
+import type { RouteProps } from 'react-router-dom'
+import { Redirect, Route, Switch } from 'react-router-dom'
+
+type PrivateRouteProps = {
+  hasWallet: boolean
+} & RouteProps
+
+export const PrivateRoute = ({ hasWallet, ...rest }: PrivateRouteProps) => {
+  const { location } = rest
+
+  const to = useMemo(
+    () => ({
+      pathname: '/connect-wallet',
+      search: `returnUrl=${location?.pathname ?? '/trade'}`,
+    }),
+    [location],
+  )
+
+  return (
+    <Switch location={location}>
+      <Route {...rest} path='/markets' />
+      <Route {...rest} path='/assets' />
+      <Route {...rest} path='/rfox' />
+      <Route {...rest} path='/explore' />
+      <Route {...rest} path='/pools' />
+      <Route {...rest} path='/earn' />
+      <Route {...rest} path='/buy-crypto' />
+      <Route {...rest} path='/assets' />
+      <Route {...rest} path='/flags' />
+      {hasWallet ? <Route {...rest} /> : <Redirect to={to} />}
+    </Switch>
+  )
+}

--- a/src/Routes/Routes.tsx
+++ b/src/Routes/Routes.tsx
@@ -8,10 +8,11 @@ import { Layout } from 'components/Layout/Layout'
 import { useBrowserRouter } from 'hooks/useBrowserRouter/useBrowserRouter'
 import { useQuery } from 'hooks/useQuery/useQuery'
 import { useWallet } from 'hooks/useWallet/useWallet'
-import { isMobile } from 'lib/globals'
 import { preferences } from 'state/slices/preferencesSlice/preferencesSlice'
 import { selectSelectedLocale } from 'state/slices/selectors'
 import { useAppSelector } from 'state/store'
+
+import { PrivateRoute } from './PrivateRoute'
 
 const Flags = makeSuspenseful(
   lazy(() => import('pages/Flags/Flags').then(({ Flags }) => ({ default: Flags }))),
@@ -110,19 +111,15 @@ export const Routes = memo(() => {
     () =>
       appRoutes.map(route => {
         const MainComponent = route.main
-        if (isMobile && !state.isConnected) {
-          const to = {
-            pathname: '/connect-wallet',
-            search: `returnUrl=${location?.pathname ?? '/trade'}`,
-          }
 
-          // eslint-disable-next-line react-memo/require-usememo
-          return <Redirect to={to} />
-        }
         return (
-          <Route key={isUnstableRoute ? Date.now() : 'route'} path={route.path}>
+          <PrivateRoute
+            key={isUnstableRoute ? Date.now() : 'privateRoute'}
+            path={route.path}
+            hasWallet={hasWallet}
+          >
             {MainComponent && <MainComponent />}
-          </Route>
+          </PrivateRoute>
         )
       }),
     // We *actually* want to be reactive on the location.pathname reference

--- a/src/Routes/RoutesCommon.tsx
+++ b/src/Routes/RoutesCommon.tsx
@@ -15,7 +15,7 @@ import { WalletIcon } from 'components/Icons/WalletIcon'
 import { assetIdPaths } from 'hooks/useRouteAssetId/useRouteAssetId'
 import { RFOX } from 'pages/RFOX/RFOX'
 
-import type { Route as NestedRoute } from './helpers'
+import type { Route } from './helpers'
 import { RouteCategory } from './helpers'
 
 const Home = makeSuspenseful(
@@ -130,7 +130,7 @@ const TransactionHistory = makeSuspenseful(
  * THIS IS CRITICAL FOR MIXPANEL TO NOT COLLECT USER ADDRESSES
  */
 
-export const routes: NestedRoute[] = [
+export const routes: Route[] = [
   {
     path: '/home',
     label: 'navBar.home',

--- a/src/pages/Dashboard/Dashboard.tsx
+++ b/src/pages/Dashboard/Dashboard.tsx
@@ -1,6 +1,6 @@
 import type { FlexProps, TabProps } from '@chakra-ui/react'
 import { Flex, Tab, TabIndicator, TabList, Tabs, useMediaQuery } from '@chakra-ui/react'
-import { memo, useCallback, useEffect, useMemo, useState } from 'react'
+import { memo, useCallback, useMemo, useState } from 'react'
 import { useTranslate } from 'react-polyglot'
 import { Route, Switch, useHistory, useRouteMatch } from 'react-router'
 import SwipeableViews from 'react-swipeable-views'
@@ -10,9 +10,7 @@ import { Main } from 'components/Layout/Main'
 import { SEO } from 'components/Layout/Seo'
 import { NftTable } from 'components/Nfts/NftTable'
 import { RawText } from 'components/Text'
-import { WalletActions } from 'context/WalletProvider/actions'
 import { useFeatureFlag } from 'hooks/useFeatureFlag/useFeatureFlag'
-import { useWallet } from 'hooks/useWallet/useWallet'
 import { isMobile } from 'lib/globals'
 import { Accounts } from 'pages/Accounts/Accounts'
 import { TransactionHistory } from 'pages/TransactionHistory/TransactionHistory'
@@ -64,10 +62,6 @@ enum MobileTab {
 }
 
 export const Dashboard = memo(() => {
-  const {
-    dispatch: walletDispatch,
-    state: { isConnected },
-  } = useWallet()
   const translate = useTranslate()
   const [slideIndex, setSlideIndex] = useState(0)
   const [isLargerThanMd] = useMediaQuery(`(min-width: ${breakpoints['md']})`, { ssr: false })
@@ -75,11 +69,6 @@ export const Dashboard = memo(() => {
   const isNftsEnabled = useFeatureFlag('Jaypegz')
   const appIsMobile = isMobile || !isLargerThanMd
   const history = useHistory()
-
-  useEffect(() => {
-    if (!isConnected && !isMobile)
-      walletDispatch({ type: WalletActions.SET_WALLET_MODAL, payload: true })
-  }, [isConnected, walletDispatch])
 
   const handleSlideIndexChange = useCallback(
     (index: number) => {


### PR DESCRIPTION
## Description

Brings back splash page for trade and wallet routes following https://github.com/shapeshift/web/pull/7848, which went too deep in exposing previously private routes and feels weird for wallet and trade routes, especially for the latter.

## Issue (if applicable)

<!-----------------------------------------------------------------------------
If applicable, please link to the github issue and put `closes #XXXX` in your comment to auto-close the issue that your PR fixes.
------------------------------------------------------------------------------>

closes https://github.com/shapeshift/web/issues/7837

## Risk

> High Risk PRs Require 2 approvals

<!-----------------------------------------------------------------------------
Outline the scope of your changes and the risk associated with them. You must use your discretion as an engineer to determine the potential impact of your changes.

WARNING: If your PR introduces a new on-chain transaction or modifies an existing one, please add the "High-Risk" label to this PR and ask for 2 reviewers to approve it before merging.

E.g. an upgrade to `hdwallet` or core state management would be considered higher risk, and might require a full regression test. UI or isolated view changes, or something behind a feature flag may have near zero risk. Small bug fixes might require testing isolated to the specific fix.
------------------------------------------------------------------------------>

> What protocols, transaction types, wallets or contract interactions might be affected by this PR?

Low - this brings back previous behaviour.

## Testing

<!-----------------------------------------------------------------------------
We treat every PR to be merged with the same scrutiny as if we were merging directly to production.

Your PR will not be merged if you do not complete the sections below for our engineering and operations teams to test.
------------------------------------------------------------------------------>

- Connecting to the app root route (i.e release.shapeshift.com if testing this in release or localhost:3000) routes to the splash page
- Disconnecting your wallet from wallet or trade route routes back to the splash page 
- Trying to access `/#/trade` or `/#/wallet` directly routes back to the splash page
- Going to any other route with a wallet connected, then disconnecting it doesn't boot back to splash page
- Trying to access any other route directly without a wallet connected doesn't boot back to splash page
- Redirect URLs are still appended in the URL (see Jam)
- Mobile app splash page is still happy

### Engineering

<!-----------------------------------------------------------------------------
Include sufficient information here for an engineer to test your PR. This may include how to test locally, in a built environment, changes to infrastructure etc.
------------------------------------------------------------------------------>

- ☝🏽 

### Operations

- [ ] :checkered_flag: My feature is behind a flag and doesn't require operations testing (yet)

<!-----------------------------------------------------------------------------
If your changes have a user-facing impact, describe how a non-technical QA team can functionally test your changes in a preview environment.

If they are not user-facing please describe how to test for any regressions that may occur.
------------------------------------------------------------------------------>

- ☝🏽 

## Screenshots (if applicable)

- Desktop

https://jam.dev/c/d5420b46-49d3-4bd2-9976-fa1c552a7343

- Mobile

https://github.com/user-attachments/assets/0ea4b385-5d16-4e7d-a445-498163430c0a

