### PR TITLE
fix: markets page ghost chains in dropdown

### DIFF
--- a/src/lib/coingecko/utils.ts
+++ b/src/lib/coingecko/utils.ts
@@ -1,6 +1,22 @@
-import { adapters, ASSET_NAMESPACE, bscChainId, toAssetId } from '@shapeshiftoss/caip'
+import {
+  adapters,
+  arbitrumChainId,
+  arbitrumNovaChainId,
+  ASSET_NAMESPACE,
+  avalancheChainId,
+  baseChainId,
+  bscChainId,
+  cosmosChainId,
+  ethChainId,
+  gnosisChainId,
+  optimismChainId,
+  polygonChainId,
+  thorchainChainId,
+  toAssetId,
+} from '@shapeshiftoss/caip'
 import type { CoingeckoAssetPlatform } from '@shapeshiftoss/caip/src/adapters'
 import axios from 'axios'
+import { getConfig } from 'config'
 import { queryClient } from 'context/QueryClientProvider/queryClient'
 import type { CoinGeckoMarketCap } from 'lib/market-service/coingecko/coingecko-types'
 
@@ -117,4 +133,20 @@ export const getCoingeckoMarkets = async (
   await Promise.allSettled(data.map((marketData, i) => getCoinDetails(marketData, i, all)))
 
   return all.filter(mover => Boolean(mover.assetId))
+}
+
+export const getCoingeckoSupportedChainIds = () => {
+  return [
+    ethChainId,
+    avalancheChainId,
+    optimismChainId,
+    bscChainId,
+    polygonChainId,
+    gnosisChainId,
+    arbitrumChainId,
+    baseChainId,
+    cosmosChainId,
+    thorchainChainId,
+    ...(getConfig().REACT_APP_FEATURE_ARBITRUM_NOVA ? [arbitrumNovaChainId] : []),
+  ]
 }

--- a/src/pages/Markets/hooks/useRows.tsx
+++ b/src/pages/Markets/hooks/useRows.tsx
@@ -2,6 +2,7 @@ import type { ChainId } from '@shapeshiftoss/caip'
 import { PORTALS_SUPPORTED_CHAIN_IDS } from '@shapeshiftoss/swapper/dist/swappers/PortalsSwapper/constants'
 import { useMemo } from 'react'
 import { useTranslate } from 'react-polyglot'
+import { getCoingeckoSupportedChainIds } from 'lib/coingecko/utils'
 import { SUPPORTED_THORCHAIN_SAVERS_CHAIN_IDS } from 'state/slices/opportunitiesSlice/resolvers/thorchainsavers/utils'
 
 import { AssetGridWithData } from '../components/AssetGridWithData'
@@ -15,6 +16,8 @@ export type RowProps = {
 
 export const useRows = ({ limit }: { limit: number }) => {
   const translate = useTranslate()
+
+  const coingeckoSupportedChainIds = useMemo(() => getCoingeckoSupportedChainIds(), [])
 
   const MARKETS_CATEGORY_TO_ROW: Record<
     MARKETS_CATEGORIES,
@@ -31,6 +34,7 @@ export const useRows = ({ limit }: { limit: number }) => {
         category: MARKETS_CATEGORIES.TRADING_VOLUME,
         title: translate(`markets.categories.${MARKETS_CATEGORIES.TRADING_VOLUME}.title`),
         subtitle: translate(`markets.categories.${MARKETS_CATEGORIES.TRADING_VOLUME}.subtitle`),
+        supportedChainIds: coingeckoSupportedChainIds,
         component: ({ selectedChainId, showSparkline }: RowProps) => (
           <AssetGridWithData
             category={MARKETS_CATEGORIES.TRADING_VOLUME}
@@ -45,6 +49,7 @@ export const useRows = ({ limit }: { limit: number }) => {
         category: MARKETS_CATEGORIES.MARKET_CAP,
         title: translate(`markets.categories.${MARKETS_CATEGORIES.MARKET_CAP}.title`),
         subtitle: translate(`markets.categories.${MARKETS_CATEGORIES.MARKET_CAP}.subtitle`),
+        supportedChainIds: coingeckoSupportedChainIds,
         component: ({ selectedChainId, showSparkline }: RowProps) => (
           <AssetGridWithData
             category={MARKETS_CATEGORIES.MARKET_CAP}
@@ -60,6 +65,7 @@ export const useRows = ({ limit }: { limit: number }) => {
         category: MARKETS_CATEGORIES.TRENDING,
         title: translate(`markets.categories.${MARKETS_CATEGORIES.TRENDING}.title`),
         subtitle: translate(`markets.categories.${MARKETS_CATEGORIES.TRENDING}.subtitle`),
+        supportedChainIds: coingeckoSupportedChainIds,
         component: ({ selectedChainId, showSparkline }: RowProps) => (
           <AssetGridWithData
             category={MARKETS_CATEGORIES.TRENDING}
@@ -75,6 +81,7 @@ export const useRows = ({ limit }: { limit: number }) => {
         subtitle: translate(`markets.categories.${MARKETS_CATEGORIES.TOP_MOVERS}.subtitle`, {
           percentage: '10',
         }),
+        supportedChainIds: coingeckoSupportedChainIds,
         component: ({ selectedChainId, showSparkline }: RowProps) => (
           <AssetGridWithData
             category={MARKETS_CATEGORIES.TOP_MOVERS}
@@ -88,6 +95,7 @@ export const useRows = ({ limit }: { limit: number }) => {
         category: MARKETS_CATEGORIES.RECENTLY_ADDED,
         title: translate(`markets.categories.${MARKETS_CATEGORIES.RECENTLY_ADDED}.title`),
         subtitle: translate(`markets.categories.${MARKETS_CATEGORIES.RECENTLY_ADDED}.subtitle`),
+        supportedChainIds: coingeckoSupportedChainIds,
         component: ({ selectedChainId, showSparkline }: RowProps) => (
           <AssetGridWithData
             category={MARKETS_CATEGORIES.RECENTLY_ADDED}
@@ -116,7 +124,7 @@ export const useRows = ({ limit }: { limit: number }) => {
         supportedChainIds: SUPPORTED_THORCHAIN_SAVERS_CHAIN_IDS,
       },
     }),
-    [limit, translate],
+    [coingeckoSupportedChainIds, limit, translate],
   )
 
   return MARKETS_CATEGORY_TO_ROW


### PR DESCRIPTION
## Description

Narrows down Coingecko categories (i.e all except the two last LP ones) to Coingecko supported ChainIds, which we were missing as a concept. This effectively removes the ghost chain (Arbitrum Nova) from the list. 

## Issue (if applicable)

<!-----------------------------------------------------------------------------
If applicable, please link to the github issue and put `closes #XXXX` in your comment to auto-close the issue that your PR fixes.
------------------------------------------------------------------------------>

closes https://github.com/shapeshift/web/issues/7885

## Risk

> High Risk PRs Require 2 approvals

<!-----------------------------------------------------------------------------
Outline the scope of your changes and the risk associated with them. You must use your discretion as an engineer to determine the potential impact of your changes.

WARNING: If your PR introduces a new on-chain transaction or modifies an existing one, please add the "High-Risk" label to this PR and ask for 2 reviewers to approve it before merging.

E.g. an upgrade to `hdwallet` or core state management would be considered higher risk, and might require a full regression test. UI or isolated view changes, or something behind a feature flag may have near zero risk. Small bug fixes might require testing isolated to the specific fix.
------------------------------------------------------------------------------>

Low

> What protocols, transaction types, wallets or contract interactions might be affected by this PR?

## Testing

<!-----------------------------------------------------------------------------
We treat every PR to be merged with the same scrutiny as if we were merging directly to production.

Your PR will not be merged if you do not complete the sections below for our engineering and operations teams to test.
------------------------------------------------------------------------------>

- Coingecko categories chain drop down does not have a ghost option
- THORChain LP and Portals categories chain dropdown is the same as in release

### Engineering

<!-----------------------------------------------------------------------------
Include sufficient information here for an engineer to test your PR. This may include how to test locally, in a built environment, changes to infrastructure etc.
------------------------------------------------------------------------------>

### Operations

- [ ] :checkered_flag: My feature is behind a flag and doesn't require operations testing (yet)

<!-----------------------------------------------------------------------------
If your changes have a user-facing impact, describe how a non-technical QA team can functionally test your changes in a preview environment.

If they are not user-facing please describe how to test for any regressions that may occur.
------------------------------------------------------------------------------>

## Screenshots (if applicable)

Tested against release (right)

- Coingecko categories

<img width="1649" alt="Screenshot 2024-10-04 at 00 58 22" src="https://github.com/user-attachments/assets/6c37d0c1-431c-4403-948a-41f9a20f32f5">

- Portals category

<img width="1644" alt="Screenshot 2024-10-04 at 00 58 35" src="https://github.com/user-attachments/assets/83362df8-778c-4b1e-a945-ab70b653279b">

- THORChain LP category

<img width="1675" alt="Screenshot 2024-10-04 at 00 58 42" src="https://github.com/user-attachments/assets/6677c1b1-e80b-468b-aed3-771cef9f3ba4">

