### PR TITLE
fix: remove duplicate arbitrum entry

### DIFF
--- a/packages/swapper/src/swappers/PortalsSwapper/types.ts
+++ b/packages/swapper/src/swappers/PortalsSwapper/types.ts
@@ -8,7 +8,6 @@ export const PortalsSupportedChainIds = [
   KnownChainIds.PolygonMainnet,
   KnownChainIds.BnbSmartChainMainnet,
   KnownChainIds.OptimismMainnet,
-  KnownChainIds.ArbitrumMainnet,
   KnownChainIds.GnosisMainnet,
   KnownChainIds.BaseMainnet,
 ] as const


### PR DESCRIPTION
## Description

Removes the duplicated `ArbitrumMainnet` entry in the `PortalsSupportedChainIds` constant, which was causing the chain to appear twice in filters.

## Issue (if applicable)

Closes https://github.com/shapeshift/web/issues/7890

## Risk

Small

> What protocols, transaction types, wallets or contract interactions might be affected by this PR?

None

## Testing

On the markets page ensure that when then filter is selected for the "One click DeFi assets" section that the Arbitrum one chain is only shown once.

### Engineering 

☝️

### Operations

- [ ] :checkered_flag: My feature is behind a flag and doesn't require operations testing (yet)

☝️

## Screenshots (if applicable)

<img width="1320" alt="Screenshot 2024-10-04 at 12 07 02" src="https://github.com/user-attachments/assets/83652171-31b9-4eb2-ba84-f36a4ce9b810">
