### PR TITLE
chore: update agreeRunePool string

### DIFF
--- a/src/assets/translations/en/main.json
+++ b/src/assets/translations/en/main.json
@@ -443,7 +443,7 @@
         "cannotWithdrawWhilePendingTx": "Cannot withdraw while Txs are pending",
         "dangerousWithdrawWarning": "THORChain fee could result in the total loss of the funds being withdrawn. Consider withdrawing a higher amount to avoid this issue.",
         "agreeRunePool": {
-          "1": "I understand that RUNEPool has both a 90 day minimum lockup and a heightened risk of impermanent loss."
+          "1": "I understand that RUNEPool has both a 30 day minimum lockup and a heightened risk of impermanent loss."
         }
       }
     },


### PR DESCRIPTION
## Description

Updates the RUNEPool lockup copy from `90` to `30` days.

## Issue (if applicable)

Closes https://github.com/shapeshift/web/issues/7884

## Risk

Small

> What protocols, transaction types, wallets or contract interactions might be affected by this PR?

None

## Testing

Ensure copy updated as expected.

### Engineering

☝️

### Operations

- [ ] :checkered_flag: My feature is behind a flag and doesn't require operations testing (yet)

☝️

## Screenshots (if applicable)

N/A