### PR TITLE
fix: hide assets page and change markets icon

### DIFF
--- a/src/Routes/RoutesCommon.tsx
+++ b/src/Routes/RoutesCommon.tsx
@@ -1,7 +1,8 @@
 import { getConfig } from 'config'
 import { lazy } from 'react'
-import { FaChartArea, FaCreditCard, FaFlag } from 'react-icons/fa'
+import { FaCreditCard, FaFlag } from 'react-icons/fa'
 import { RiExchangeFundsLine } from 'react-icons/ri'
+import { TbGraph } from 'react-icons/tb'
 import { makeSuspenseful } from 'utils/makeSuspenseful'
 import { AssetsIcon } from 'components/Icons/Assets'
 import { DefiIcon } from 'components/Icons/DeFi'
@@ -199,7 +200,7 @@ export const routes: Route[] = [
   {
     path: '/markets',
     label: 'navBar.markets',
-    icon: <FaChartArea />,
+    icon: <TbGraph />,
     main: MarketsPage,
     category: RouteCategory.Featured,
     priority: 4,
@@ -253,6 +254,7 @@ export const routes: Route[] = [
     path: '/assets',
     label: 'navBar.assets',
     main: Assets,
+    hide: true,
     icon: <AssetsIcon />,
     category: RouteCategory.Explore,
     routes: assetIdPaths.map(assetIdPath => ({


### PR DESCRIPTION
## Description

- Now that we have the markets page we don't need the assets page. Its only hidden we because we use that route to route to the asset details page
- Updated the markets icon to be something more inline with the style of our other icons

## Issue (if applicable)

<!-----------------------------------------------------------------------------
If applicable, please link to the github issue and put `closes #XXXX` in your comment to auto-close the issue that your PR fixes.
------------------------------------------------------------------------------>

closes #7918 

## Risk

> High Risk PRs Require 2 approvals

<!-----------------------------------------------------------------------------
Outline the scope of your changes and the risk associated with them. You must use your discretion as an engineer to determine the potential impact of your changes.

WARNING: If your PR introduces a new on-chain transaction or modifies an existing one, please add the "High-Risk" label to this PR and ask for 2 reviewers to approve it before merging.

E.g. an upgrade to `hdwallet` or core state management would be considered higher risk, and might require a full regression test. UI or isolated view changes, or something behind a feature flag may have near zero risk. Small bug fixes might require testing isolated to the specific fix.
------------------------------------------------------------------------------>
Minimal risk

> What protocols, transaction types, wallets or contract interactions might be affected by this PR?

## Testing

<!-----------------------------------------------------------------------------
We treat every PR to be merged with the same scrutiny as if we were merging directly to production.

Your PR will not be merged if you do not complete the sections below for our engineering and operations teams to test.
------------------------------------------------------------------------------>

### Engineering

<!-----------------------------------------------------------------------------
Include sufficient information here for an engineer to test your PR. This may include how to test locally, in a built environment, changes to infrastructure etc.
------------------------------------------------------------------------------>

### Operations

- [ ] :checkered_flag: My feature is behind a flag and doesn't require operations testing (yet)

<!-----------------------------------------------------------------------------
If your changes have a user-facing impact, describe how a non-technical QA team can functionally test your changes in a preview environment.

If they are not user-facing please describe how to test for any regressions that may occur.
------------------------------------------------------------------------------>
When you navigate to the app, there will no longer be an assets page on the navbar.

The markets icon should now match the rest of the icons.

## Screenshots (if applicable)
![Screenshot 2024-10-10 at 11 23 04 AM](https://github.com/user-attachments/assets/29913dde-28ad-4428-8470-35fe74cbdd1d)
