### PR TITLE
fix: disconnect native wallet when switching from a different wallet

### DIFF
--- a/src/App.tsx
+++ b/src/App.tsx
@@ -11,7 +11,13 @@ import { IconCircle } from 'components/IconCircle'
 import { useBridgeClaimNotification } from 'hooks/useBridgeClaimNotification/useBridgeClaimNotification'
 import { useHasAppUpdated } from 'hooks/useHasAppUpdated/useHasAppUpdated'
 import { useModal } from 'hooks/useModal/useModal'
-import { selectShowConsentBanner, selectShowWelcomeModal } from 'state/slices/selectors'
+import { useWallet } from 'hooks/useWallet/useWallet'
+import {
+  selectShowConsentBanner,
+  selectShowWelcomeModal,
+  selectWalletId,
+} from 'state/slices/selectors'
+import { useAppSelector } from 'state/store'
 
 const flexGap = { base: 2, md: 3 }
 const flexDir: ResponsiveValue<Property.FlexDirection> = { base: 'column', md: 'row' }
@@ -68,6 +74,19 @@ export const App = () => {
       openNativeOnboard({})
     }
   }, [isNativeOnboardOpen, openNativeOnboard, showWelcomeModal])
+
+  const portfolioWalletId = useAppSelector(selectWalletId)
+
+  const {
+    state: { deviceId: contextDeviceId },
+  } = useWallet()
+
+  useEffect(() => {
+    console.log({
+      portfolioWalletId,
+      contextDeviceId,
+    })
+  }, [contextDeviceId, portfolioWalletId])
 
   return (
     <>

--- a/src/context/WalletProvider/NativeWallet/components/NativeLoad.tsx
+++ b/src/context/WalletProvider/NativeWallet/components/NativeLoad.tsx
@@ -119,6 +119,11 @@ export const NativeLoad = ({ history }: RouteComponentProps) => {
         localWallet.setLocalWallet({ type: KeyManager.Native, deviceId })
         localWallet.setLocalNativeWalletName(item.name)
       } catch (e) {
+        // Clear the pending state of the native wallet on error
+        dispatch({
+          type: WalletActions.SET_NATIVE_PENDING_DEVICE_ID,
+          payload: null,
+        })
         setError('walletProvider.shapeShift.load.error.pair')
       }
     } else {

--- a/src/context/WalletProvider/NativeWallet/components/NativeLoad.tsx
+++ b/src/context/WalletProvider/NativeWallet/components/NativeLoad.tsx
@@ -88,8 +88,7 @@ export const NativeLoad = ({ history }: RouteComponentProps) => {
           payload: deviceId,
         })
         // not calling disconnect from useWallet because we don't want to modify state
-        state.wallet?.disconnect?.()
-
+        await state.wallet?.disconnect?.()
         const wallet = await adapter.pairDevice(deviceId)
         if (!(await wallet?.isInitialized())) {
           // This will trigger the password modal and the modal will set the wallet on state
@@ -119,12 +118,9 @@ export const NativeLoad = ({ history }: RouteComponentProps) => {
         localWallet.setLocalWallet({ type: KeyManager.Native, deviceId })
         localWallet.setLocalNativeWalletName(item.name)
       } catch (e) {
-        // Clear the pending state of the native wallet on error
-        dispatch({
-          type: WalletActions.SET_NATIVE_PENDING_DEVICE_ID,
-          payload: null,
-        })
         setError('walletProvider.shapeShift.load.error.pair')
+      } finally {
+        dispatch({ type: WalletActions.RESET_NATIVE_PENDING_DEVICE_ID })
       }
     } else {
       setError('walletProvider.shapeShift.load.error.pair')

--- a/src/context/WalletProvider/NativeWallet/components/NativeLoad.tsx
+++ b/src/context/WalletProvider/NativeWallet/components/NativeLoad.tsx
@@ -41,7 +41,7 @@ const walletButtonLeftIcon = (
 )
 
 export const NativeLoad = ({ history }: RouteComponentProps) => {
-  const { getAdapter, dispatch } = useWallet()
+  const { getAdapter, dispatch, state } = useWallet()
   const localWallet = useLocalWallet()
   const [error, setError] = useState<string | null>(null)
   const [wallets, setWallets] = useState<VaultInfo[]>([])
@@ -81,6 +81,15 @@ export const NativeLoad = ({ history }: RouteComponentProps) => {
     if (adapter) {
       const { name, icon } = NativeConfig
       try {
+        // Set a pending device ID so the event handler doesn't redirect the user to password input
+        // for the previous wallet
+        dispatch({
+          type: WalletActions.SET_NATIVE_PENDING_DEVICE_ID,
+          payload: deviceId,
+        })
+        // not calling disconnect from useWallet because we don't want to modify state
+        state.wallet?.disconnect?.()
+
         const wallet = await adapter.pairDevice(deviceId)
         if (!(await wallet?.isInitialized())) {
           // This will trigger the password modal and the modal will set the wallet on state

--- a/src/context/WalletProvider/NativeWallet/hooks/useNativeEventHandler.ts
+++ b/src/context/WalletProvider/NativeWallet/hooks/useNativeEventHandler.ts
@@ -14,15 +14,15 @@ export const useNativeEventHandler = (state: InitialState, dispatch: Dispatch<Ac
     const handleEvent = (e: [deviceId: string, message: Event]) => {
       const deviceId = e[0]
       const messageType = e[1].message_type as NativeEvents
-      console.log(e)
       switch (messageType) {
         case NativeEvents.MNEMONIC_REQUIRED:
           if (!deviceId) break
-          console.log('handleEvent', { deviceId })
 
-          // Don't handle events from previously disconnected wallets, unless there isn't a pending
-          // wallet to connect (i.e via "switch wallet")
-          if (deviceId !== state.nativeWalletPendingDeviceId) {
+          // Don't show password input for previous wallet when switching
+          if (
+            state.nativeWalletPendingDeviceId !== null &&
+            deviceId !== state.nativeWalletPendingDeviceId
+          ) {
             break
           }
 

--- a/src/context/WalletProvider/WalletProvider.tsx
+++ b/src/context/WalletProvider/WalletProvider.tsx
@@ -153,6 +153,7 @@ const reducer = (state: InitialState, action: ActionTypes): InitialState => {
       return {
         ...state,
         deviceId,
+        nativeWalletPendingDeviceId: null,
         isDemoWallet: Boolean(isDemoWallet),
         wallet,
         connectedType,
@@ -227,7 +228,6 @@ const reducer = (state: InitialState, action: ActionTypes): InitialState => {
         modalType: KeyManager.Native,
         showBackButton: !state.isLoadingLocalWallet,
         deviceId: action.payload.deviceId,
-        nativeWalletPendingDeviceId: null,
         walletInfo: null,
         initialRoute: NativeWalletRoutes.EnterPassword,
       }

--- a/src/context/WalletProvider/WalletProvider.tsx
+++ b/src/context/WalletProvider/WalletProvider.tsx
@@ -153,7 +153,6 @@ const reducer = (state: InitialState, action: ActionTypes): InitialState => {
       return {
         ...state,
         deviceId,
-        nativeWalletPendingDeviceId: null,
         isDemoWallet: Boolean(isDemoWallet),
         wallet,
         connectedType,
@@ -219,9 +218,6 @@ const reducer = (state: InitialState, action: ActionTypes): InitialState => {
       }
       return newState
     case WalletActions.NATIVE_PASSWORD_OPEN:
-      // reset wallet meta in redux store
-      store.dispatch(localWalletSlice.actions.clearLocalWallet())
-      store.dispatch(portfolioSlice.actions.setWalletMeta(undefined))
       return {
         ...state,
         modal: action.payload.modal,
@@ -329,9 +325,19 @@ const reducer = (state: InitialState, action: ActionTypes): InitialState => {
         initialRoute: KeepKeyRoutes.Disconnect,
       }
     case WalletActions.SET_NATIVE_PENDING_DEVICE_ID:
+      store.dispatch(localWalletSlice.actions.clearLocalWallet())
+      store.dispatch(portfolioSlice.actions.setWalletMeta(undefined))
       return {
         ...state,
+        isConnected: false,
+        deviceId: '',
+        walletInfo: null,
         nativeWalletPendingDeviceId: action.payload,
+      }
+    case WalletActions.RESET_NATIVE_PENDING_DEVICE_ID:
+      return {
+        ...state,
+        nativeWalletPendingDeviceId: null,
       }
     default:
       return state

--- a/src/context/WalletProvider/actions.ts
+++ b/src/context/WalletProvider/actions.ts
@@ -110,5 +110,5 @@ export type ActionTypes =
   | { type: WalletActions.OPEN_KEEPKEY_DISCONNECT }
   | {
       type: WalletActions.SET_NATIVE_PENDING_DEVICE_ID
-      payload: string
+      payload: string | null
     }

--- a/src/context/WalletProvider/actions.ts
+++ b/src/context/WalletProvider/actions.ts
@@ -29,6 +29,7 @@ export enum WalletActions {
   OPEN_KEEPKEY_CHARACTER_REQUEST = 'OPEN_KEEPKEY_CHARACTER_REQUEST',
   DOWNLOAD_UPDATER = 'DOWNLOAD_UPDATER',
   SET_NATIVE_PENDING_DEVICE_ID = 'SET_NATIVE_PENDING_DEVICE_ID',
+  RESET_NATIVE_PENDING_DEVICE_ID = 'RESET_NATIVE_PENDING_DEVICE_ID',
 }
 
 export type ActionTypes =
@@ -112,3 +113,4 @@ export type ActionTypes =
       type: WalletActions.SET_NATIVE_PENDING_DEVICE_ID
       payload: string | null
     }
+  | { type: WalletActions.RESET_NATIVE_PENDING_DEVICE_ID }

--- a/src/context/WalletProvider/actions.ts
+++ b/src/context/WalletProvider/actions.ts
@@ -28,6 +28,7 @@ export enum WalletActions {
   OPEN_KEEPKEY_RECOVERY = 'OPEN_KEEPKEY_RECOVERY',
   OPEN_KEEPKEY_CHARACTER_REQUEST = 'OPEN_KEEPKEY_CHARACTER_REQUEST',
   DOWNLOAD_UPDATER = 'DOWNLOAD_UPDATER',
+  SET_NATIVE_PENDING_DEVICE_ID = 'SET_NATIVE_PENDING_DEVICE_ID',
 }
 
 export type ActionTypes =
@@ -107,3 +108,7 @@ export type ActionTypes =
       }
     }
   | { type: WalletActions.OPEN_KEEPKEY_DISCONNECT }
+  | {
+      type: WalletActions.SET_NATIVE_PENDING_DEVICE_ID
+      payload: string
+    }


### PR DESCRIPTION
## Description

Patch for state corruption in wallet provider when user backs out of switching wallet. See #7904 for context.

The fix here is a patch to prevent corrupt state by preventing "back-out" of native connect into corrupt state by forcing the previous wallet to first disconnect before the password prompt is displayed.

Previous issue in simplified terms:
1. User is connected to native wallet
2. User clicks "switch wallet"
3. User clicks different native wallet and is presented with password prompt
4. WalletProvider updates the `deviceId` with the new wallet device ID
5. User exits the password prompt without entering the password
6. WalletProvider now has the wrong `deviceId` until they reconnect the wallet

This PR:

(tl;dr is that cancelling when switching wallet takes you to the splash screen with cleared wallet state in Redux and WalletProvider)

1. User is connected to native wallet
2. User clicks "switch wallet"
3. User clicks different native wallet
4. `handleWalletSelect` clears previous wallet `deviceId` and `walletInfo`, and sets the `nativeWalletPendingDeviceId` with the new wallet device ID via `WalletActions.SET_NATIVE_PENDING_DEVICE_ID`
5. `handleWalletSelect` disconnects the currently connected wallet
6. If the user continues to connect the wallet:
7. `handleEvent` in `useNativeEventHandler` sees the `NativeEvents.MNEMONIC_REQUIRED` event for the previous wallet, and ignores it to prevent opening the password prompt for the previous wallet
8. `handleEvent` in `useNativeEventHandler` sees the `NativeEvents.MNEMONIC_REQUIRED` event for the pending wallet, and opens the password prompt for the pending wallet
9. User is presented with the password prompt for the pending wallet
10. If the user continues to connect:
  a. On completion or error (wrong password or otherwise), `handleWalletSelect` resets the `nativeWalletPendingDeviceId` via `WalletActions.RESET_NATIVE_PENDING_DEVICE_ID`.
  b. `handleWalletSelect` sets the wallet via `WalletActions.SET_WALLET`
  c. App proceeds to load with full wallet state aligned between WalletProvider and Redux
11. If the user exits the password prompt without entering the password:
  a. `handleWalletSelect` resets the `nativeWalletPendingDeviceId` via `WalletActions.RESET_NATIVE_PENDING_DEVICE_ID`.
  b. User is left on the splash screen to connect a wallet. WalletProvider and Redux wallet states are empty.

## Issue (if applicable)

<!-----------------------------------------------------------------------------
If applicable, please link to the github issue and put `closes #XXXX` in your comment to auto-close the issue that your PR fixes.
------------------------------------------------------------------------------>

closes #7904

## Risk

> High Risk PRs Require 2 approvals

High risk because it modifies WalletProvider and could theoretically result in inability to open a wallet. Realistically the changes are simple and have a low risk to user funds and ability to open a wallet.

> What protocols, transaction types, wallets or contract interactions might be affected by this PR?

## Testing

Thoroughly test opening/closing/switching wallets, with more emphasis on native wallet.
Sanity check signin, broadcasting, trading etc is not somehow unexpectedly broken.

### Engineering

<!-----------------------------------------------------------------------------
Include sufficient information here for an engineer to test your PR. This may include how to test locally, in a built environment, changes to infrastructure etc.
------------------------------------------------------------------------------>

### Operations

- [ ] :checkered_flag: My feature is behind a flag and doesn't require operations testing (yet)

<!-----------------------------------------------------------------------------
If your changes have a user-facing impact, describe how a non-technical QA team can functionally test your changes in a preview environment.

If they are not user-facing please describe how to test for any regressions that may occur.
------------------------------------------------------------------------------>

## Screenshots (if applicable)
