### PR TITLE
feat: placeholder ui for limit orders development

### DIFF
--- a/.env.develop
+++ b/.env.develop
@@ -1,4 +1,5 @@
 # feature flags
+REACT_APP_FEATURE_LIMIT_ORDERS=true
 
 # mixpanel
 REACT_APP_MIXPANEL_TOKEN=1c1369f6ea23a6404bac41b42817cc4b

--- a/src/assets/translations/en/main.json
+++ b/src/assets/translations/en/main.json
@@ -987,6 +987,9 @@
       "slippage": "Slippage: %{slippageFormatted}"
     }
   },
+  "limitOrder": {
+    "heading": "Limit Order"
+  },
   "modals": {
     "assetSearch": {
       "myAssets": "My Assets",

--- a/src/components/MultiHopTrade/MultiHopTrade.tsx
+++ b/src/components/MultiHopTrade/MultiHopTrade.tsx
@@ -9,6 +9,7 @@ import { tradeInput } from 'state/slices/tradeInputSlice/tradeInputSlice'
 import { tradeQuoteSlice } from 'state/slices/tradeQuoteSlice/tradeQuoteSlice'
 import { useAppDispatch, useAppSelector } from 'state/store'
 
+import { LimitOrder } from './components/LimitOrder/LimitOrder'
 import { MultiHopTradeConfirm } from './components/MultiHopTradeConfirm/MultiHopTradeConfirm'
 import { QuoteListRoute } from './components/QuoteList/QuoteListRoute'
 import { Claim } from './components/TradeInput/components/Claim/Claim'
@@ -23,6 +24,7 @@ const TradeRouteEntries = [
   TradeRoutePaths.VerifyAddresses,
   TradeRoutePaths.QuoteList,
   TradeRoutePaths.Claim,
+  TradeRoutePaths.LimitOrder,
 ]
 
 export type TradeCardProps = {
@@ -110,6 +112,9 @@ const TradeRoutes = memo(({ isCompact }: TradeRoutesProps) => {
         case TradeInputTab.Trade:
           history.push(TradeRoutePaths.Input)
           break
+        case TradeInputTab.LimitOrder:
+          history.push(TradeRoutePaths.LimitOrder)
+          break
         case TradeInputTab.Claim:
           history.push(TradeRoutePaths.Claim)
           break
@@ -145,6 +150,13 @@ const TradeRoutes = memo(({ isCompact }: TradeRoutesProps) => {
           </Route>
           <Route key={TradeRoutePaths.Claim} path={TradeRoutePaths.Claim}>
             <Claim onChangeTab={handleChangeTab} />
+          </Route>
+          <Route key={TradeRoutePaths.LimitOrder} path={TradeRoutePaths.LimitOrder}>
+            <LimitOrder
+              isCompact={isCompact}
+              tradeInputRef={tradeInputRef}
+              onChangeTab={handleChangeTab}
+            />
           </Route>
         </Switch>
       </AnimatePresence>

--- a/src/components/MultiHopTrade/components/LimitOrder/LimitOrder.tsx
+++ b/src/components/MultiHopTrade/components/LimitOrder/LimitOrder.tsx
@@ -1,0 +1,194 @@
+import { isLedger } from '@shapeshiftoss/hdwallet-ledger'
+import type { Asset } from '@shapeshiftoss/types'
+import type { FormEvent } from 'react'
+import { useCallback, useMemo, useState } from 'react'
+import { useFormContext } from 'react-hook-form'
+import { ethereum, fox } from 'test/mocks/assets'
+import { WarningAcknowledgement } from 'components/Acknowledgement/Acknowledgement'
+import { useReceiveAddress } from 'components/MultiHopTrade/hooks/useReceiveAddress'
+import { TradeInputTab } from 'components/MultiHopTrade/types'
+import { WalletActions } from 'context/WalletProvider/actions'
+import { useErrorHandler } from 'hooks/useErrorToast/useErrorToast'
+import { useWallet } from 'hooks/useWallet/useWallet'
+import type { ParameterModel } from 'lib/fees/parameters/types'
+import { selectIsSnapshotApiQueriesPending, selectVotingPower } from 'state/apis/snapshot/selectors'
+import {
+  selectHasUserEnteredAmount,
+  selectIsAnyAccountMetadataLoadedForChainId,
+} from 'state/slices/selectors'
+import {
+  selectActiveQuote,
+  selectBuyAmountAfterFeesCryptoPrecision,
+  selectBuyAmountAfterFeesUserCurrency,
+  selectIsTradeQuoteRequestAborted,
+  selectShouldShowTradeQuoteOrAwaitInput,
+} from 'state/slices/tradeQuoteSlice/selectors'
+import { useAppSelector } from 'state/store'
+
+import { useAccountIds } from '../../hooks/useAccountIds'
+import { SharedTradeInput } from '../SharedTradeInput/SharedTradeInput'
+
+const votingPowerParams: { feeModel: ParameterModel } = { feeModel: 'SWAPPER' }
+const acknowledgementBoxProps = {
+  display: 'flex',
+  justifyContent: 'center',
+}
+
+type LimitOrderProps = {
+  tradeInputRef: React.MutableRefObject<HTMLDivElement | null>
+  isCompact?: boolean
+  onChangeTab: (newTab: TradeInputTab) => void
+}
+
+// TODO: Implement me
+const CollapsibleLimitOrderList = () => <></>
+
+export const LimitOrder = ({ isCompact, tradeInputRef, onChangeTab }: LimitOrderProps) => {
+  const {
+    dispatch: walletDispatch,
+    state: { isConnected, isDemoWallet, wallet },
+  } = useWallet()
+
+  const { handleSubmit } = useFormContext()
+  const { showErrorToast } = useErrorHandler()
+  const { manualReceiveAddress, walletReceiveAddress } = useReceiveAddress({
+    fetchUnchainedAddress: Boolean(wallet && isLedger(wallet)),
+  })
+  const { sellAssetAccountId, buyAssetAccountId, setSellAssetAccountId, setBuyAssetAccountId } =
+    useAccountIds()
+
+  const [isConfirmationLoading, setIsConfirmationLoading] = useState(false)
+  const [shouldShowWarningAcknowledgement, setShouldShowWarningAcknowledgement] = useState(false)
+
+  const buyAmountAfterFeesCryptoPrecision = useAppSelector(selectBuyAmountAfterFeesCryptoPrecision)
+  const buyAmountAfterFeesUserCurrency = useAppSelector(selectBuyAmountAfterFeesUserCurrency)
+  const shouldShowTradeQuoteOrAwaitInput = useAppSelector(selectShouldShowTradeQuoteOrAwaitInput)
+  const isSnapshotApiQueriesPending = useAppSelector(selectIsSnapshotApiQueriesPending)
+  const isTradeQuoteRequestAborted = useAppSelector(selectIsTradeQuoteRequestAborted)
+  const hasUserEnteredAmount = useAppSelector(selectHasUserEnteredAmount)
+  const votingPower = useAppSelector(state => selectVotingPower(state, votingPowerParams))
+  const sellAsset = ethereum // TODO: Implement me
+  const buyAsset = fox // TODO: Implement me
+  const activeQuote = useAppSelector(selectActiveQuote)
+  const isAnyAccountMetadataLoadedForChainIdFilter = useMemo(
+    () => ({ chainId: sellAsset.chainId }),
+    [sellAsset.chainId],
+  )
+  const isAnyAccountMetadataLoadedForChainId = useAppSelector(state =>
+    selectIsAnyAccountMetadataLoadedForChainId(state, isAnyAccountMetadataLoadedForChainIdFilter),
+  )
+
+  const isVotingPowerLoading = useMemo(
+    () => isSnapshotApiQueriesPending && votingPower === undefined,
+    [isSnapshotApiQueriesPending, votingPower],
+  )
+
+  const isLoading = useMemo(
+    () =>
+      // No account meta loaded for that chain
+      !isAnyAccountMetadataLoadedForChainId ||
+      (!shouldShowTradeQuoteOrAwaitInput && !isTradeQuoteRequestAborted) ||
+      isConfirmationLoading ||
+      // Only consider snapshot API queries as pending if we don't have voting power yet
+      // if we do, it means we have persisted or cached (both stale) data, which is enough to let the user continue
+      // as we are optimistic and don't want to be waiting for a potentially very long time for the snapshot API to respond
+      isVotingPowerLoading,
+    [
+      isAnyAccountMetadataLoadedForChainId,
+      shouldShowTradeQuoteOrAwaitInput,
+      isTradeQuoteRequestAborted,
+      isConfirmationLoading,
+      isVotingPowerLoading,
+    ],
+  )
+
+  const warningAcknowledgementMessage = useMemo(() => {
+    // TODO: Implement me
+    return ''
+  }, [])
+
+  const headerRightContent = useMemo(() => {
+    // TODO: Implement me
+    return <></>
+  }, [])
+
+  const setBuyAsset = useCallback((_asset: Asset) => {
+    // TODO: Implement me
+  }, [])
+  const setSellAsset = useCallback((_asset: Asset) => {
+    // TODO: Implement me
+  }, [])
+  const handleSwitchAssets = useCallback(() => {
+    // TODO: Implement me
+  }, [])
+
+  const handleConnect = useCallback(() => {
+    walletDispatch({ type: WalletActions.SET_WALLET_MODAL, payload: true })
+  }, [walletDispatch])
+
+  const onSubmit = useCallback(() => {
+    // No preview happening if wallet isn't connected i.e is using the demo wallet
+    if (!isConnected || isDemoWallet) {
+      return handleConnect()
+    }
+
+    setIsConfirmationLoading(true)
+    try {
+      // TODO: Implement me
+    } catch (e) {
+      showErrorToast(e)
+    }
+
+    setIsConfirmationLoading(false)
+  }, [handleConnect, isConnected, isDemoWallet, showErrorToast])
+
+  const handleFormSubmit = useMemo(() => handleSubmit(onSubmit), [handleSubmit, onSubmit])
+
+  const handleWarningAcknowledgementSubmit = useCallback(() => {
+    handleFormSubmit()
+  }, [handleFormSubmit])
+
+  const handleTradeQuoteConfirm = useCallback(
+    (e: FormEvent<unknown>) => {
+      e.preventDefault()
+      handleFormSubmit()
+    },
+    [handleFormSubmit],
+  )
+
+  return (
+    <WarningAcknowledgement
+      message={warningAcknowledgementMessage}
+      onAcknowledge={handleWarningAcknowledgementSubmit}
+      shouldShowAcknowledgement={shouldShowWarningAcknowledgement}
+      setShouldShowAcknowledgement={setShouldShowWarningAcknowledgement}
+      boxProps={acknowledgementBoxProps}
+    >
+      <SharedTradeInput
+        activeQuote={activeQuote}
+        buyAmountAfterFeesCryptoPrecision={buyAmountAfterFeesCryptoPrecision}
+        buyAmountAfterFeesUserCurrency={buyAmountAfterFeesUserCurrency}
+        buyAsset={buyAsset}
+        hasUserEnteredAmount={hasUserEnteredAmount}
+        headerRightContent={headerRightContent}
+        buyAssetAccountId={buyAssetAccountId}
+        sellAssetAccountId={sellAssetAccountId}
+        isCompact={isCompact}
+        isLoading={isLoading}
+        manualReceiveAddress={manualReceiveAddress}
+        sellAsset={sellAsset}
+        sideComponent={CollapsibleLimitOrderList}
+        tradeInputRef={tradeInputRef}
+        tradeInputTab={TradeInputTab.LimitOrder}
+        walletReceiveAddress={walletReceiveAddress}
+        handleSwitchAssets={handleSwitchAssets}
+        onSubmit={handleTradeQuoteConfirm}
+        setBuyAsset={setBuyAsset}
+        setBuyAssetAccountId={setBuyAssetAccountId}
+        setSellAsset={setSellAsset}
+        setSellAssetAccountId={setSellAssetAccountId}
+        onChangeTab={onChangeTab}
+      />
+    </WarningAcknowledgement>
+  )
+}

--- a/src/components/MultiHopTrade/components/SharedTradeInput/SharedTradeInput.tsx
+++ b/src/components/MultiHopTrade/components/SharedTradeInput/SharedTradeInput.tsx
@@ -3,7 +3,7 @@ import type { AccountId } from '@shapeshiftoss/caip'
 import type { TradeQuote } from '@shapeshiftoss/swapper'
 import type { Asset } from '@shapeshiftoss/types'
 import type { FormEvent } from 'react'
-import { TradeInputTab } from 'components/MultiHopTrade/types'
+import type { TradeInputTab } from 'components/MultiHopTrade/types'
 import { breakpoints } from 'theme/theme'
 
 import { SharedTradeInputBody } from '../SharedTradeInput/SharedTradeInputBody'
@@ -27,6 +27,7 @@ type SharedTradeInputProps = {
   sellAsset: Asset
   sideComponent: React.ComponentType<any>
   tradeInputRef: React.RefObject<HTMLDivElement>
+  tradeInputTab: TradeInputTab
   walletReceiveAddress: string | undefined
   handleSwitchAssets: () => void
   onChangeTab: (newTab: TradeInputTab) => void
@@ -51,6 +52,7 @@ export const SharedTradeInput: React.FC<SharedTradeInputProps> = ({
   manualReceiveAddress,
   sellAsset,
   sideComponent,
+  tradeInputTab,
   tradeInputRef,
   walletReceiveAddress,
   handleSwitchAssets,
@@ -81,7 +83,7 @@ export const SharedTradeInput: React.FC<SharedTradeInputProps> = ({
           onSubmit={onSubmit}
         >
           <SharedTradeInputHeader
-            initialTab={TradeInputTab.Trade}
+            initialTab={tradeInputTab}
             rightContent={headerRightContent}
             onChangeTab={onChangeTab}
           />

--- a/src/components/MultiHopTrade/components/SharedTradeInput/SharedTradeInputHeader.tsx
+++ b/src/components/MultiHopTrade/components/SharedTradeInput/SharedTradeInputHeader.tsx
@@ -20,6 +20,7 @@ export const SharedTradeInputHeader = ({
   const [selectedTab, setSelectedTab] = useState<TradeInputTab>(initialTab)
 
   const enableBridgeClaims = useFeatureFlag('ArbitrumBridgeClaims')
+  const enableLimitOrders = useFeatureFlag('LimitOrders')
 
   const handleChangeTab = useCallback(
     (newTab: TradeInputTab) => {
@@ -31,6 +32,10 @@ export const SharedTradeInputHeader = ({
 
   const handleClickTrade = useCallback(() => {
     handleChangeTab(TradeInputTab.Trade)
+  }, [handleChangeTab])
+
+  const handleClickLimitOrder = useCallback(() => {
+    handleChangeTab(TradeInputTab.LimitOrder)
   }, [handleChangeTab])
 
   const handleClickClaim = useCallback(() => {
@@ -50,6 +55,17 @@ export const SharedTradeInputHeader = ({
           >
             {translate('navBar.trade')}
           </Heading>
+          {enableLimitOrders && (
+            <Heading
+              as='h5'
+              fontSize='md'
+              color={selectedTab !== TradeInputTab.LimitOrder ? 'text.subtle' : undefined}
+              onClick={handleClickLimitOrder}
+              cursor={selectedTab !== TradeInputTab.LimitOrder ? 'pointer' : undefined}
+            >
+              {translate('limitOrder.heading')}
+            </Heading>
+          )}
           {enableBridgeClaims && (
             <Heading
               as='h5'

--- a/src/components/MultiHopTrade/components/TradeInput/TradeInput.tsx
+++ b/src/components/MultiHopTrade/components/TradeInput/TradeInput.tsx
@@ -15,8 +15,7 @@ import {
 import { MessageOverlay } from 'components/MessageOverlay/MessageOverlay'
 import { getMixpanelEventData } from 'components/MultiHopTrade/helpers'
 import { useReceiveAddress } from 'components/MultiHopTrade/hooks/useReceiveAddress'
-import type { TradeInputTab } from 'components/MultiHopTrade/types'
-import { TradeRoutePaths } from 'components/MultiHopTrade/types'
+import { TradeInputTab, TradeRoutePaths } from 'components/MultiHopTrade/types'
 import { WalletActions } from 'context/WalletProvider/actions'
 import { useErrorHandler } from 'hooks/useErrorToast/useErrorToast'
 import { useWallet } from 'hooks/useWallet/useWallet'
@@ -304,6 +303,7 @@ export const TradeInput = ({ isCompact, tradeInputRef, onChangeTab }: TradeInput
               sellAsset={sellAsset}
               sideComponent={CollapsibleQuoteList}
               tradeInputRef={tradeInputRef}
+              tradeInputTab={TradeInputTab.Trade}
               walletReceiveAddress={walletReceiveAddress}
               handleSwitchAssets={handleSwitchAssets}
               onSubmit={handleTradeQuoteConfirm}

--- a/src/components/MultiHopTrade/types.ts
+++ b/src/components/MultiHopTrade/types.ts
@@ -9,6 +9,7 @@ export enum TradeRoutePaths {
   VerifyAddresses = '/trade/verify-addresses',
   QuoteList = '/trade/quote-list',
   Claim = '/trade/claim',
+  LimitOrder = '/trade/limit-order',
 }
 
 export type GetReceiveAddressArgs = {
@@ -35,4 +36,5 @@ export type TradeQuoteInputCommonArgs = Pick<
 export enum TradeInputTab {
   Trade = 'trade',
   Claim = 'claim',
+  LimitOrder = 'limitOrder',
 }

--- a/src/config.ts
+++ b/src/config.ts
@@ -177,6 +177,7 @@ const validators = {
   REACT_APP_FEATURE_FOX_PAGE: bool({ default: false }),
   REACT_APP_FEATURE_FOX_PAGE_RFOX: bool({ default: false }),
   REACT_APP_FEATURE_FOX_PAGE_FOX_SECTION: bool({ default: true }),
+  REACT_APP_FEATURE_LIMIT_ORDERS: bool({ default: false }),
 }
 
 function reporter<T>({ errors }: envalid.ReporterOptions<T>) {

--- a/src/state/slices/preferencesSlice/preferencesSlice.ts
+++ b/src/state/slices/preferencesSlice/preferencesSlice.ts
@@ -67,6 +67,7 @@ export type FeatureFlags = {
   FoxPage: boolean
   FoxPageRFOX: boolean
   FoxPageFoxSection: boolean
+  LimitOrders: boolean
 }
 
 export type Flag = keyof FeatureFlags
@@ -159,6 +160,7 @@ const initialState: Preferences = {
     FoxPage: getConfig().REACT_APP_FEATURE_FOX_PAGE,
     FoxPageRFOX: getConfig().REACT_APP_FEATURE_FOX_PAGE_RFOX,
     FoxPageFoxSection: getConfig().REACT_APP_FEATURE_FOX_PAGE_FOX_SECTION,
+    LimitOrders: getConfig().REACT_APP_FEATURE_LIMIT_ORDERS,
   },
   selectedLocale: simpleLocale(),
   balanceThreshold: '0',

--- a/src/test/mocks/store.ts
+++ b/src/test/mocks/store.ts
@@ -124,6 +124,7 @@ export const mockStore: ReduxState = {
       FoxPage: false,
       FoxPageRFOX: false,
       FoxPageFoxSection: false,
+      LimitOrders: false,
     },
     selectedLocale: 'en',
     balanceThreshold: '0',


### PR DESCRIPTION
## Description

Adds a placeholder UI to enable multiple contributors in the development of limit orders.

Includes a feature flag.

## Issue (if applicable)

<!-----------------------------------------------------------------------------
If applicable, please link to the github issue and put `closes #XXXX` in your comment to auto-close the issue that your PR fixes.
------------------------------------------------------------------------------>

Progresses #6218
Unblocks #6206

## Risk

> High Risk PRs Require 2 approvals

Low risk

> What protocols, transaction types, wallets or contract interactions might be affected by this PR?

## Testing

Mostly not required. A sanity check of trades would be wise.

### Engineering

<!-----------------------------------------------------------------------------
Include sufficient information here for an engineer to test your PR. This may include how to test locally, in a built environment, changes to infrastructure etc.
------------------------------------------------------------------------------>

### Operations

- [x] :checkered_flag: My feature is behind a flag and doesn't require operations testing (yet)

<!-----------------------------------------------------------------------------
If your changes have a user-facing impact, describe how a non-technical QA team can functionally test your changes in a preview environment.

If they are not user-facing please describe how to test for any regressions that may occur.
------------------------------------------------------------------------------>

## Screenshots (if applicable)
