### PR TITLE
fix: swapper warning acks

### DIFF
--- a/src/components/MultiHopTrade/components/SharedTradeInput/SharedTradeInput.tsx
+++ b/src/components/MultiHopTrade/components/SharedTradeInput/SharedTradeInput.tsx
@@ -2,7 +2,7 @@ import { Card, Center, Flex, useMediaQuery } from '@chakra-ui/react'
 import type { AccountId } from '@shapeshiftoss/caip'
 import type { TradeQuote } from '@shapeshiftoss/swapper'
 import type { Asset } from '@shapeshiftoss/types'
-import type { FormEvent } from 'react'
+import { type FormEvent, type PropsWithChildren, useMemo } from 'react'
 import type { TradeInputTab } from 'components/MultiHopTrade/types'
 import { breakpoints } from 'theme/theme'
 
@@ -36,6 +36,7 @@ type SharedTradeInputProps = {
   setBuyAssetAccountId: (accountId: string) => void
   setSellAsset: (asset: Asset) => void
   setSellAssetAccountId: (accountId: string) => void
+  inputAcknowledgementParentComponent?: React.FC<PropsWithChildren>
 }
 
 export const SharedTradeInput: React.FC<SharedTradeInputProps> = ({
@@ -62,9 +63,63 @@ export const SharedTradeInput: React.FC<SharedTradeInputProps> = ({
   setBuyAssetAccountId,
   setSellAsset,
   setSellAssetAccountId,
+  inputAcknowledgementParentComponent: InputAcknowledgementParentComponent,
 }) => {
   const totalHeight = useSharedHeight(tradeInputRef)
   const [isSmallerThanXl] = useMediaQuery(`(max-width: ${breakpoints.xl})`, { ssr: false })
+
+  const tradeInput = useMemo(() => {
+    return (
+      <>
+        <SharedTradeInputHeader
+          initialTab={tradeInputTab}
+          rightContent={headerRightContent}
+          onChangeTab={onChangeTab}
+        />
+        <SharedTradeInputBody
+          activeQuote={activeQuote}
+          buyAmountAfterFeesCryptoPrecision={buyAmountAfterFeesCryptoPrecision}
+          buyAmountAfterFeesUserCurrency={buyAmountAfterFeesUserCurrency}
+          buyAsset={buyAsset}
+          buyAssetAccountId={buyAssetAccountId}
+          sellAssetAccountId={sellAssetAccountId}
+          isLoading={isLoading}
+          manualReceiveAddress={manualReceiveAddress}
+          sellAsset={sellAsset}
+          handleSwitchAssets={handleSwitchAssets}
+          setBuyAsset={setBuyAsset}
+          setBuyAssetAccountId={setBuyAssetAccountId}
+          setSellAsset={setSellAsset}
+          setSellAssetAccountId={setSellAssetAccountId}
+        />
+        <ConfirmSummary
+          isCompact={isCompact}
+          isLoading={isLoading}
+          receiveAddress={manualReceiveAddress ?? walletReceiveAddress}
+        />
+      </>
+    )
+  }, [
+    tradeInputTab,
+    headerRightContent,
+    onChangeTab,
+    activeQuote,
+    buyAmountAfterFeesCryptoPrecision,
+    buyAmountAfterFeesUserCurrency,
+    buyAsset,
+    buyAssetAccountId,
+    sellAssetAccountId,
+    isLoading,
+    manualReceiveAddress,
+    sellAsset,
+    handleSwitchAssets,
+    setBuyAsset,
+    setBuyAssetAccountId,
+    setSellAsset,
+    setSellAssetAccountId,
+    isCompact,
+    walletReceiveAddress,
+  ])
 
   return (
     <Flex
@@ -82,32 +137,11 @@ export const SharedTradeInput: React.FC<SharedTradeInputProps> = ({
           as='form'
           onSubmit={onSubmit}
         >
-          <SharedTradeInputHeader
-            initialTab={tradeInputTab}
-            rightContent={headerRightContent}
-            onChangeTab={onChangeTab}
-          />
-          <SharedTradeInputBody
-            activeQuote={activeQuote}
-            buyAmountAfterFeesCryptoPrecision={buyAmountAfterFeesCryptoPrecision}
-            buyAmountAfterFeesUserCurrency={buyAmountAfterFeesUserCurrency}
-            buyAsset={buyAsset}
-            buyAssetAccountId={buyAssetAccountId}
-            sellAssetAccountId={sellAssetAccountId}
-            isLoading={isLoading}
-            manualReceiveAddress={manualReceiveAddress}
-            sellAsset={sellAsset}
-            handleSwitchAssets={handleSwitchAssets}
-            setBuyAsset={setBuyAsset}
-            setBuyAssetAccountId={setBuyAssetAccountId}
-            setSellAsset={setSellAsset}
-            setSellAssetAccountId={setSellAssetAccountId}
-          />
-          <ConfirmSummary
-            isCompact={isCompact}
-            isLoading={isLoading}
-            receiveAddress={manualReceiveAddress ?? walletReceiveAddress}
-          />
+          {InputAcknowledgementParentComponent ? (
+            <InputAcknowledgementParentComponent>{tradeInput}</InputAcknowledgementParentComponent>
+          ) : (
+            tradeInput
+          )}
         </Card>
         <WithLazyMount
           shouldUse={!isCompact && !isSmallerThanXl}

--- a/src/components/MultiHopTrade/components/TradeInput/TradeInput.tsx
+++ b/src/components/MultiHopTrade/components/TradeInput/TradeInput.tsx
@@ -2,7 +2,7 @@ import { isLedger } from '@shapeshiftoss/hdwallet-ledger'
 import { isArbitrumBridgeTradeQuote } from '@shapeshiftoss/swapper/dist/swappers/ArbitrumBridgeSwapper/getTradeQuote/getTradeQuote'
 import type { ThorTradeQuote } from '@shapeshiftoss/swapper/dist/swappers/ThorchainSwapper/getThorTradeQuote/getTradeQuote'
 import type { Asset } from '@shapeshiftoss/types'
-import type { FormEvent } from 'react'
+import type { FC, FormEvent, PropsWithChildren } from 'react'
 import { useCallback, useEffect, useMemo, useState } from 'react'
 import { useFormContext } from 'react-hook-form'
 import { useTranslate } from 'react-polyglot'
@@ -50,10 +50,6 @@ import { CollapsibleQuoteList } from './components/CollapsibleQuoteList'
 import { TradeSettingsMenu } from './components/TradeSettingsMenu'
 
 const votingPowerParams: { feeModel: ParameterModel } = { feeModel: 'SWAPPER' }
-const acknowledgementBoxProps = {
-  display: 'flex',
-  justifyContent: 'center',
-}
 
 const STREAM_ACKNOWLEDGEMENT_MINIMUM_TIME_THRESHOLD = 1_000 * 60 * 5
 
@@ -264,13 +260,12 @@ export const TradeInput = ({ isCompact, tradeInputRef, onChangeTab }: TradeInput
     [isUnsafeQuote, activeQuote, isEstimatedExecutionTimeOverThreshold, handleFormSubmit],
   )
 
-  return (
-    <MessageOverlay show={isKeplr} title={overlayTitle}>
+  const inputAcknowledgementParentComponent: FC<PropsWithChildren> = useMemo(() => {
+    return ({ children }) => (
       <ArbitrumBridgeAcknowledgement
         onAcknowledge={handleFormSubmit}
         shouldShowAcknowledgement={shouldShowArbitrumBridgeAcknowledgement}
         setShouldShowAcknowledgement={setShouldShowArbitrumBridgeAcknowledgement}
-        boxProps={acknowledgementBoxProps}
       >
         <StreamingAcknowledgement
           onAcknowledge={handleFormSubmit}
@@ -279,43 +274,56 @@ export const TradeInput = ({ isCompact, tradeInputRef, onChangeTab }: TradeInput
           estimatedTimeMs={
             tradeQuoteStep?.estimatedExecutionTimeMs ? tradeQuoteStep.estimatedExecutionTimeMs : 0
           }
-          boxProps={acknowledgementBoxProps}
         >
           <WarningAcknowledgement
             message={warningAcknowledgementMessage}
             onAcknowledge={handleWarningAcknowledgementSubmit}
             shouldShowAcknowledgement={shouldShowWarningAcknowledgement}
             setShouldShowAcknowledgement={setShouldShowWarningAcknowledgement}
-            boxProps={acknowledgementBoxProps}
           >
-            <SharedTradeInput
-              activeQuote={activeQuote}
-              buyAmountAfterFeesCryptoPrecision={buyAmountAfterFeesCryptoPrecision}
-              buyAmountAfterFeesUserCurrency={buyAmountAfterFeesUserCurrency}
-              buyAsset={buyAsset}
-              hasUserEnteredAmount={hasUserEnteredAmount}
-              headerRightContent={headerRightContent}
-              buyAssetAccountId={buyAssetAccountId}
-              sellAssetAccountId={sellAssetAccountId}
-              isCompact={isCompact}
-              isLoading={isLoading}
-              manualReceiveAddress={manualReceiveAddress}
-              sellAsset={sellAsset}
-              sideComponent={CollapsibleQuoteList}
-              tradeInputRef={tradeInputRef}
-              tradeInputTab={TradeInputTab.Trade}
-              walletReceiveAddress={walletReceiveAddress}
-              handleSwitchAssets={handleSwitchAssets}
-              onSubmit={handleTradeQuoteConfirm}
-              setBuyAsset={setBuyAsset}
-              setBuyAssetAccountId={setBuyAssetAccountId}
-              setSellAsset={setSellAsset}
-              setSellAssetAccountId={setSellAssetAccountId}
-              onChangeTab={onChangeTab}
-            />
+            {children}
           </WarningAcknowledgement>
         </StreamingAcknowledgement>
       </ArbitrumBridgeAcknowledgement>
+    )
+  }, [
+    handleFormSubmit,
+    shouldShowArbitrumBridgeAcknowledgement,
+    shouldShowStreamingAcknowledgement,
+    tradeQuoteStep?.estimatedExecutionTimeMs,
+    warningAcknowledgementMessage,
+    handleWarningAcknowledgementSubmit,
+    shouldShowWarningAcknowledgement,
+  ])
+
+  return (
+    <MessageOverlay show={isKeplr} title={overlayTitle}>
+      <SharedTradeInput
+        activeQuote={activeQuote}
+        buyAmountAfterFeesCryptoPrecision={buyAmountAfterFeesCryptoPrecision}
+        buyAmountAfterFeesUserCurrency={buyAmountAfterFeesUserCurrency}
+        buyAsset={buyAsset}
+        hasUserEnteredAmount={hasUserEnteredAmount}
+        headerRightContent={headerRightContent}
+        buyAssetAccountId={buyAssetAccountId}
+        sellAssetAccountId={sellAssetAccountId}
+        isCompact={isCompact}
+        isLoading={isLoading}
+        manualReceiveAddress={manualReceiveAddress}
+        sellAsset={sellAsset}
+        sideComponent={CollapsibleQuoteList}
+        tradeInputRef={tradeInputRef}
+        tradeInputTab={TradeInputTab.Trade}
+        walletReceiveAddress={walletReceiveAddress}
+        handleSwitchAssets={handleSwitchAssets}
+        onSubmit={handleTradeQuoteConfirm}
+        setBuyAsset={setBuyAsset}
+        setBuyAssetAccountId={setBuyAssetAccountId}
+        setSellAsset={setSellAsset}
+        setSellAssetAccountId={setSellAssetAccountId}
+        onChangeTab={onChangeTab}
+        inputAcknowledgementParentComponent={inputAcknowledgementParentComponent}
+      />
     </MessageOverlay>
   )
 }


### PR DESCRIPTION
## Description

Fixes a regression from https://github.com/shapeshift/web/pull/7912 related to the acknowledgment component.

Updates the `SharedTradeInput` component to take an optional `inputAcknowledgementParentComponent`, which can be used to pass one or more parent acknowledgement wrappers.

⚠️ Still in draft as there is a weird height bug.

## Issue (if applicable)

Closes https://github.com/shapeshift/web/issues/7946

## Risk

Medium

> What protocols, transaction types, wallets or contract interactions might be affected by this PR?

None

## Testing

Trigger a warning acknowledgement and ensure it renders as it does in prod (not spanning the full width).

### Engineering

☝️

### Operations

- [ ] :checkered_flag: My feature is behind a flag and doesn't require operations testing (yet)

☝️

## Screenshots (if applicable)

<img width="693" alt="Screenshot 2024-10-16 at 14 28 36" src="https://github.com/user-attachments/assets/fd8fd4c6-ae1e-4a45-b47e-47732f09c05e">
