### PR TITLE
feat: ui scaffolding for limit orders pending design changes

### DIFF
--- a/src/components/MultiHopTrade/components/LimitOrder/LimitOrder.tsx
+++ b/src/components/MultiHopTrade/components/LimitOrder/LimitOrder.tsx
@@ -1,38 +1,18 @@
-import { isLedger } from '@shapeshiftoss/hdwallet-ledger'
-import { SwapperName } from '@shapeshiftoss/swapper'
-import type { Asset } from '@shapeshiftoss/types'
-import { noop } from 'lodash'
-import type { FormEvent } from 'react'
-import { useCallback, useMemo, useState } from 'react'
-import { useFormContext } from 'react-hook-form'
-import { ethereum, fox } from 'test/mocks/assets'
-import { WarningAcknowledgement } from 'components/Acknowledgement/Acknowledgement'
-import { useReceiveAddress } from 'components/MultiHopTrade/hooks/useReceiveAddress'
-import { TradeInputTab } from 'components/MultiHopTrade/types'
-import { WalletActions } from 'context/WalletProvider/actions'
-import { useErrorHandler } from 'hooks/useErrorToast/useErrorToast'
-import { useWallet } from 'hooks/useWallet/useWallet'
-import type { ParameterModel } from 'lib/fees/parameters/types'
-import { selectIsSnapshotApiQueriesPending, selectVotingPower } from 'state/apis/snapshot/selectors'
-import {
-  selectHasUserEnteredAmount,
-  selectIsAnyAccountMetadataLoadedForChainId,
-} from 'state/slices/selectors'
-import {
-  selectActiveQuote,
-  selectBuyAmountAfterFeesCryptoPrecision,
-  selectBuyAmountAfterFeesUserCurrency,
-  selectIsTradeQuoteRequestAborted,
-  selectShouldShowTradeQuoteOrAwaitInput,
-} from 'state/slices/tradeQuoteSlice/selectors'
-import { useAppSelector } from 'state/store'
+import { Box } from '@chakra-ui/react'
+import { useCallback } from 'react'
+import { MemoryRouter, Route, Switch, useLocation } from 'react-router'
+import type { TradeInputTab } from 'components/MultiHopTrade/types'
 
-import { useAccountIds } from '../../hooks/useAccountIds'
-import { SharedTradeInput } from '../SharedTradeInput/SharedTradeInput'
-import { SharedTradeInputBody } from '../SharedTradeInput/SharedTradeInputBody'
-import { SharedTradeInputFooter } from '../SharedTradeInput/SharedTradeInputFooter'
+import { LimitOrderConfirm } from './components/LimitOrderConfirm'
+import { LimitOrderInput } from './components/LimitOrderInput'
+import { LimitOrderStatus } from './components/LimitOrderStatus'
+import { LimitOrderRoutePaths } from './types'
 
-const votingPowerParams: { feeModel: ParameterModel } = { feeModel: 'SWAPPER' }
+const LimitOrderRouteEntries = [
+  LimitOrderRoutePaths.Input,
+  LimitOrderRoutePaths.Confirm,
+  LimitOrderRoutePaths.Status,
+]
 
 type LimitOrderProps = {
   tradeInputRef: React.MutableRefObject<HTMLDivElement | null>
@@ -40,238 +20,48 @@ type LimitOrderProps = {
   onChangeTab: (newTab: TradeInputTab) => void
 }
 
-// TODO: Implement me
-const CollapsibleLimitOrderList = () => <></>
-
 export const LimitOrder = ({ isCompact, tradeInputRef, onChangeTab }: LimitOrderProps) => {
-  const {
-    dispatch: walletDispatch,
-    state: { isConnected, isDemoWallet, wallet },
-  } = useWallet()
+  const location = useLocation()
 
-  const { handleSubmit } = useFormContext()
-  const { showErrorToast } = useErrorHandler()
-  const { manualReceiveAddress, walletReceiveAddress } = useReceiveAddress({
-    fetchUnchainedAddress: Boolean(wallet && isLedger(wallet)),
-  })
-  const { sellAssetAccountId, buyAssetAccountId, setSellAssetAccountId, setBuyAssetAccountId } =
-    useAccountIds()
-
-  const [isInputtingFiatSellAmount, setIsInputtingFiatSellAmount] = useState(false)
-  const [isConfirmationLoading, setIsConfirmationLoading] = useState(false)
-  const [shouldShowWarningAcknowledgement, setShouldShowWarningAcknowledgement] = useState(false)
-  const [sellAmountCryptoPrecision, setSellAmountCryptoPrecision] = useState('0')
-
-  const buyAmountAfterFeesCryptoPrecision = useAppSelector(selectBuyAmountAfterFeesCryptoPrecision)
-  const buyAmountAfterFeesUserCurrency = useAppSelector(selectBuyAmountAfterFeesUserCurrency)
-  const shouldShowTradeQuoteOrAwaitInput = useAppSelector(selectShouldShowTradeQuoteOrAwaitInput)
-  const isSnapshotApiQueriesPending = useAppSelector(selectIsSnapshotApiQueriesPending)
-  const isTradeQuoteRequestAborted = useAppSelector(selectIsTradeQuoteRequestAborted)
-  const hasUserEnteredAmount = useAppSelector(selectHasUserEnteredAmount)
-  const votingPower = useAppSelector(state => selectVotingPower(state, votingPowerParams))
-  const sellAsset = ethereum // TODO: Implement me
-  const buyAsset = fox // TODO: Implement me
-  const activeQuote = useAppSelector(selectActiveQuote)
-  const isAnyAccountMetadataLoadedForChainIdFilter = useMemo(
-    () => ({ chainId: sellAsset.chainId }),
-    [sellAsset.chainId],
-  )
-  const isAnyAccountMetadataLoadedForChainId = useAppSelector(state =>
-    selectIsAnyAccountMetadataLoadedForChainId(state, isAnyAccountMetadataLoadedForChainIdFilter),
-  )
-
-  const isVotingPowerLoading = useMemo(
-    () => isSnapshotApiQueriesPending && votingPower === undefined,
-    [isSnapshotApiQueriesPending, votingPower],
-  )
-
-  const isLoading = useMemo(
-    () =>
-      // No account meta loaded for that chain
-      !isAnyAccountMetadataLoadedForChainId ||
-      (!shouldShowTradeQuoteOrAwaitInput && !isTradeQuoteRequestAborted) ||
-      isConfirmationLoading ||
-      // Only consider snapshot API queries as pending if we don't have voting power yet
-      // if we do, it means we have persisted or cached (both stale) data, which is enough to let the user continue
-      // as we are optimistic and don't want to be waiting for a potentially very long time for the snapshot API to respond
-      isVotingPowerLoading,
-    [
-      isAnyAccountMetadataLoadedForChainId,
-      shouldShowTradeQuoteOrAwaitInput,
-      isTradeQuoteRequestAborted,
-      isConfirmationLoading,
-      isVotingPowerLoading,
-    ],
-  )
-
-  const sellAmountUserCurrency = useMemo(() => {
-    // TODO: Implement me
-    return '0'
-  }, [])
-
-  const warningAcknowledgementMessage = useMemo(() => {
-    // TODO: Implement me
-    return ''
-  }, [])
-
-  const headerRightContent = useMemo(() => {
-    // TODO: Implement me
-    return <></>
-  }, [])
-
-  const setBuyAsset = useCallback((_asset: Asset) => {
-    // TODO: Implement me
-  }, [])
-  const setSellAsset = useCallback((_asset: Asset) => {
-    // TODO: Implement me
-  }, [])
-  const handleSwitchAssets = useCallback(() => {
-    // TODO: Implement me
-  }, [])
-
-  const handleConnect = useCallback(() => {
-    walletDispatch({ type: WalletActions.SET_WALLET_MODAL, payload: true })
-  }, [walletDispatch])
-
-  const onSubmit = useCallback(() => {
-    // No preview happening if wallet isn't connected i.e is using the demo wallet
-    if (!isConnected || isDemoWallet) {
-      return handleConnect()
-    }
-
-    setIsConfirmationLoading(true)
-    try {
-      // TODO: Implement me
-    } catch (e) {
-      showErrorToast(e)
-    }
-
-    setIsConfirmationLoading(false)
-  }, [handleConnect, isConnected, isDemoWallet, showErrorToast])
-
-  const handleFormSubmit = useMemo(() => handleSubmit(onSubmit), [handleSubmit, onSubmit])
-
-  const handleWarningAcknowledgementSubmit = useCallback(() => {
-    handleFormSubmit()
-  }, [handleFormSubmit])
-
-  const handleTradeQuoteConfirm = useCallback(
-    (e: FormEvent<unknown>) => {
-      e.preventDefault()
-      handleFormSubmit()
-    },
-    [handleFormSubmit],
-  )
-
-  const bodyContent = useMemo(() => {
+  const renderLimitOrderInput = useCallback(() => {
     return (
-      <SharedTradeInputBody
-        activeQuote={activeQuote}
-        buyAmountAfterFeesCryptoPrecision={buyAmountAfterFeesCryptoPrecision}
-        buyAmountAfterFeesUserCurrency={buyAmountAfterFeesUserCurrency}
-        buyAsset={buyAsset}
-        buyAssetAccountId={buyAssetAccountId}
-        isInputtingFiatSellAmount={isInputtingFiatSellAmount}
-        isLoading={isLoading}
-        manualReceiveAddress={manualReceiveAddress}
-        sellAmountCryptoPrecision={sellAmountCryptoPrecision}
-        sellAmountUserCurrency={sellAmountUserCurrency}
-        sellAsset={sellAsset}
-        sellAssetAccountId={sellAssetAccountId}
-        handleSwitchAssets={handleSwitchAssets}
-        onChangeIsInputtingFiatSellAmount={setIsInputtingFiatSellAmount}
-        onChangeSellAmountCryptoPrecision={setSellAmountCryptoPrecision}
-        setBuyAsset={setBuyAsset}
-        setBuyAssetAccountId={setBuyAssetAccountId}
-        setSellAsset={setSellAsset}
-        setSellAssetAccountId={setSellAssetAccountId}
-      />
-    )
-  }, [
-    activeQuote,
-    buyAmountAfterFeesCryptoPrecision,
-    buyAmountAfterFeesUserCurrency,
-    buyAsset,
-    buyAssetAccountId,
-    isInputtingFiatSellAmount,
-    isLoading,
-    manualReceiveAddress,
-    sellAmountCryptoPrecision,
-    sellAmountUserCurrency,
-    sellAsset,
-    sellAssetAccountId,
-    handleSwitchAssets,
-    setBuyAsset,
-    setBuyAssetAccountId,
-    setSellAsset,
-    setSellAssetAccountId,
-  ])
-
-  const footerContent = useMemo(() => {
-    return (
-      <SharedTradeInputFooter
+      <LimitOrderInput
         isCompact={isCompact}
-        isLoading={isLoading}
-        receiveAddress={manualReceiveAddress ?? walletReceiveAddress}
-        inputAmountUsd={'12.34'}
-        affiliateBps={'300'}
-        affiliateFeeAfterDiscountUserCurrency={'0.01'}
-        quoteStatusTranslation={'trade.previewTrade'}
-        manualAddressEntryDescription={undefined}
-        onRateClick={noop}
-        shouldDisablePreviewButton={false}
-        isError={false}
-        shouldForceManualAddressEntry={false}
-        recipientAddressDescription={undefined}
-        priceImpactPercentage={undefined}
-        swapSource={SwapperName.CowSwap}
-        rate={activeQuote?.rate}
-        swapperName={SwapperName.CowSwap}
-        slippageDecimal={'0.01'}
-        buyAmountAfterFeesCryptoPrecision={buyAmountAfterFeesCryptoPrecision}
-        intermediaryTransactionOutputs={undefined}
-        buyAsset={buyAsset}
-        hasUserEnteredAmount={hasUserEnteredAmount}
-        totalProtocolFees={undefined}
-        sellAsset={sellAsset}
-        sellAssetAccountId={sellAssetAccountId}
-        totalNetworkFeeFiatPrecision={'1.1234'}
-      />
-    )
-  }, [
-    activeQuote?.rate,
-    buyAmountAfterFeesCryptoPrecision,
-    buyAsset,
-    hasUserEnteredAmount,
-    isCompact,
-    isLoading,
-    manualReceiveAddress,
-    sellAsset,
-    sellAssetAccountId,
-    walletReceiveAddress,
-  ])
-
-  return (
-    <>
-      <WarningAcknowledgement
-        message={warningAcknowledgementMessage}
-        onAcknowledge={handleWarningAcknowledgementSubmit}
-        shouldShowAcknowledgement={shouldShowWarningAcknowledgement}
-        setShouldShowAcknowledgement={setShouldShowWarningAcknowledgement}
-      />
-      <SharedTradeInput
-        bodyContent={bodyContent}
-        footerContent={footerContent}
-        hasUserEnteredAmount={hasUserEnteredAmount}
-        headerRightContent={headerRightContent}
-        isCompact={isCompact}
-        isLoading={isLoading}
-        sideComponent={CollapsibleLimitOrderList}
         tradeInputRef={tradeInputRef}
-        tradeInputTab={TradeInputTab.LimitOrder}
-        onSubmit={handleTradeQuoteConfirm}
         onChangeTab={onChangeTab}
       />
-    </>
+    )
+  }, [isCompact, onChangeTab, tradeInputRef])
+
+  const renderLimitOrderConfirm = useCallback(() => {
+    return <LimitOrderConfirm />
+  }, [])
+
+  const renderLimitOrderStatus = useCallback(() => {
+    return <LimitOrderStatus />
+  }, [])
+
+  return (
+    <MemoryRouter initialEntries={LimitOrderRouteEntries} initialIndex={0}>
+      <Switch location={location}>
+        <Box flex={1} width='full' maxWidth='500px'>
+          <Route
+            key={LimitOrderRoutePaths.Input}
+            path={LimitOrderRoutePaths.Input}
+            render={renderLimitOrderInput}
+          />
+          <Route
+            key={LimitOrderRoutePaths.Confirm}
+            path={LimitOrderRoutePaths.Confirm}
+            render={renderLimitOrderConfirm}
+          />
+          <Route
+            key={LimitOrderRoutePaths.Status}
+            path={LimitOrderRoutePaths.Status}
+            render={renderLimitOrderStatus}
+          />
+        </Box>
+      </Switch>
+    </MemoryRouter>
   )
 }

--- a/src/components/MultiHopTrade/components/LimitOrder/components/LimitOrderConfirm.tsx
+++ b/src/components/MultiHopTrade/components/LimitOrder/components/LimitOrderConfirm.tsx
@@ -1,0 +1,65 @@
+import { Button, Card, CardBody, CardFooter, CardHeader, Heading } from '@chakra-ui/react'
+import { useCallback } from 'react'
+import { useHistory } from 'react-router'
+import { SlideTransition } from 'components/SlideTransition'
+import { Text } from 'components/Text'
+
+import { WithBackButton } from '../../WithBackButton'
+import { LimitOrderRoutePaths } from '../types'
+
+const cardBorderRadius = { base: 'xl' }
+
+export const LimitOrderConfirm = () => {
+  const history = useHistory()
+
+  const handleBack = useCallback(() => {
+    history.push(LimitOrderRoutePaths.Input)
+  }, [history])
+
+  const handleConfirm = useCallback(() => {
+    history.push(LimitOrderRoutePaths.Status)
+  }, [history])
+
+  return (
+    <SlideTransition>
+      <Card
+        flex={1}
+        borderRadius={cardBorderRadius}
+        width='full'
+        variant='dashboard'
+        maxWidth='500px'
+      >
+        <CardHeader px={6} pt={4}>
+          <WithBackButton onBack={handleBack}>
+            <Heading textAlign='center' fontSize='md'>
+              <Text translation='limitOrder.confirm' />
+            </Heading>
+          </WithBackButton>
+        </CardHeader>
+
+        <CardBody py={0} px={0}>
+          <></>
+        </CardBody>
+        <CardFooter
+          flexDir='column'
+          gap={2}
+          px={4}
+          borderTopWidth={1}
+          borderColor='border.base'
+          bg='background.surface.raised.base'
+          borderBottomRadius='md'
+        >
+          <Button
+            colorScheme={'blue'}
+            size='lg'
+            width='full'
+            onClick={handleConfirm}
+            isLoading={false}
+          >
+            <Text translation={'limitOrder.placeOrder'} />
+          </Button>
+        </CardFooter>
+      </Card>
+    </SlideTransition>
+  )
+}

--- a/src/components/MultiHopTrade/components/LimitOrder/components/LimitOrderInput.tsx
+++ b/src/components/MultiHopTrade/components/LimitOrder/components/LimitOrderInput.tsx
@@ -1,0 +1,287 @@
+import { isLedger } from '@shapeshiftoss/hdwallet-ledger'
+import { SwapperName } from '@shapeshiftoss/swapper'
+import type { Asset } from '@shapeshiftoss/types'
+import { noop } from 'lodash'
+import type { FormEvent } from 'react'
+import { useCallback, useMemo, useState } from 'react'
+import { useFormContext } from 'react-hook-form'
+import { useHistory } from 'react-router'
+import { ethereum, fox } from 'test/mocks/assets'
+import { WarningAcknowledgement } from 'components/Acknowledgement/Acknowledgement'
+import { useAccountIds } from 'components/MultiHopTrade/hooks/useAccountIds'
+import { useReceiveAddress } from 'components/MultiHopTrade/hooks/useReceiveAddress'
+import { TradeInputTab } from 'components/MultiHopTrade/types'
+import { WalletActions } from 'context/WalletProvider/actions'
+import { useErrorHandler } from 'hooks/useErrorToast/useErrorToast'
+import { useWallet } from 'hooks/useWallet/useWallet'
+import type { ParameterModel } from 'lib/fees/parameters/types'
+import { selectIsSnapshotApiQueriesPending, selectVotingPower } from 'state/apis/snapshot/selectors'
+import {
+  selectHasUserEnteredAmount,
+  selectIsAnyAccountMetadataLoadedForChainId,
+} from 'state/slices/selectors'
+import {
+  selectActiveQuote,
+  selectBuyAmountAfterFeesCryptoPrecision,
+  selectBuyAmountAfterFeesUserCurrency,
+  selectIsTradeQuoteRequestAborted,
+  selectShouldShowTradeQuoteOrAwaitInput,
+} from 'state/slices/tradeQuoteSlice/selectors'
+import { useAppSelector } from 'state/store'
+
+import { SharedTradeInput } from '../../SharedTradeInput/SharedTradeInput'
+import { SharedTradeInputBody } from '../../SharedTradeInput/SharedTradeInputBody'
+import { SharedTradeInputFooter } from '../../SharedTradeInput/SharedTradeInputFooter'
+import { LimitOrderRoutePaths } from '../types'
+
+const votingPowerParams: { feeModel: ParameterModel } = { feeModel: 'SWAPPER' }
+
+type LimitOrderInputProps = {
+  tradeInputRef: React.MutableRefObject<HTMLDivElement | null>
+  isCompact?: boolean
+  onChangeTab: (newTab: TradeInputTab) => void
+}
+
+// TODO: Implement me
+const CollapsibleLimitOrderList = () => <></>
+
+export const LimitOrderInput = ({
+  isCompact,
+  tradeInputRef,
+  onChangeTab,
+}: LimitOrderInputProps) => {
+  const {
+    dispatch: walletDispatch,
+    state: { isConnected, isDemoWallet, wallet },
+  } = useWallet()
+
+  const history = useHistory()
+  const { handleSubmit } = useFormContext()
+  const { showErrorToast } = useErrorHandler()
+  const { manualReceiveAddress, walletReceiveAddress } = useReceiveAddress({
+    fetchUnchainedAddress: Boolean(wallet && isLedger(wallet)),
+  })
+
+  // TODO: Don't use the trade account ID hook. This is temporary during scaffolding
+  const { sellAssetAccountId, buyAssetAccountId, setSellAssetAccountId, setBuyAssetAccountId } =
+    useAccountIds()
+
+  const [isInputtingFiatSellAmount, setIsInputtingFiatSellAmount] = useState(false)
+  const [isConfirmationLoading, setIsConfirmationLoading] = useState(false)
+  const [shouldShowWarningAcknowledgement, setShouldShowWarningAcknowledgement] = useState(false)
+  const [sellAmountCryptoPrecision, setSellAmountCryptoPrecision] = useState('0')
+
+  const buyAmountAfterFeesCryptoPrecision = useAppSelector(selectBuyAmountAfterFeesCryptoPrecision)
+  const buyAmountAfterFeesUserCurrency = useAppSelector(selectBuyAmountAfterFeesUserCurrency)
+  const shouldShowTradeQuoteOrAwaitInput = useAppSelector(selectShouldShowTradeQuoteOrAwaitInput)
+  const isSnapshotApiQueriesPending = useAppSelector(selectIsSnapshotApiQueriesPending)
+  const isTradeQuoteRequestAborted = useAppSelector(selectIsTradeQuoteRequestAborted)
+  const hasUserEnteredAmount = useAppSelector(selectHasUserEnteredAmount)
+  const votingPower = useAppSelector(state => selectVotingPower(state, votingPowerParams))
+  const sellAsset = ethereum // TODO: Implement me
+  const buyAsset = fox // TODO: Implement me
+  const activeQuote = useAppSelector(selectActiveQuote)
+  const isAnyAccountMetadataLoadedForChainIdFilter = useMemo(
+    () => ({ chainId: sellAsset.chainId }),
+    [sellAsset.chainId],
+  )
+  const isAnyAccountMetadataLoadedForChainId = useAppSelector(state =>
+    selectIsAnyAccountMetadataLoadedForChainId(state, isAnyAccountMetadataLoadedForChainIdFilter),
+  )
+
+  const isVotingPowerLoading = useMemo(
+    () => isSnapshotApiQueriesPending && votingPower === undefined,
+    [isSnapshotApiQueriesPending, votingPower],
+  )
+
+  const isLoading = useMemo(
+    () =>
+      // No account meta loaded for that chain
+      !isAnyAccountMetadataLoadedForChainId ||
+      (!shouldShowTradeQuoteOrAwaitInput && !isTradeQuoteRequestAborted) ||
+      isConfirmationLoading ||
+      // Only consider snapshot API queries as pending if we don't have voting power yet
+      // if we do, it means we have persisted or cached (both stale) data, which is enough to let the user continue
+      // as we are optimistic and don't want to be waiting for a potentially very long time for the snapshot API to respond
+      isVotingPowerLoading,
+    [
+      isAnyAccountMetadataLoadedForChainId,
+      shouldShowTradeQuoteOrAwaitInput,
+      isTradeQuoteRequestAborted,
+      isConfirmationLoading,
+      isVotingPowerLoading,
+    ],
+  )
+
+  const sellAmountUserCurrency = useMemo(() => {
+    // TODO: Implement me
+    return '0'
+  }, [])
+
+  const warningAcknowledgementMessage = useMemo(() => {
+    // TODO: Implement me
+    return ''
+  }, [])
+
+  const headerRightContent = useMemo(() => {
+    // TODO: Implement me
+    return <></>
+  }, [])
+
+  const setBuyAsset = useCallback((_asset: Asset) => {
+    // TODO: Implement me
+  }, [])
+  const setSellAsset = useCallback((_asset: Asset) => {
+    // TODO: Implement me
+  }, [])
+  const handleSwitchAssets = useCallback(() => {
+    // TODO: Implement me
+  }, [])
+
+  const handleConnect = useCallback(() => {
+    walletDispatch({ type: WalletActions.SET_WALLET_MODAL, payload: true })
+  }, [walletDispatch])
+
+  const onSubmit = useCallback(() => {
+    // No preview happening if wallet isn't connected i.e is using the demo wallet
+    if (!isConnected || isDemoWallet) {
+      return handleConnect()
+    }
+
+    setIsConfirmationLoading(true)
+    try {
+      // TODO: Implement any async logic here
+      history.push(LimitOrderRoutePaths.Confirm)
+    } catch (e) {
+      showErrorToast(e)
+    }
+
+    setIsConfirmationLoading(false)
+  }, [handleConnect, history, isConnected, isDemoWallet, showErrorToast])
+
+  const handleFormSubmit = useMemo(() => handleSubmit(onSubmit), [handleSubmit, onSubmit])
+
+  const handleWarningAcknowledgementSubmit = useCallback(() => {
+    handleFormSubmit()
+  }, [handleFormSubmit])
+
+  const handleTradeQuoteConfirm = useCallback(
+    (e: FormEvent<unknown>) => {
+      e.preventDefault()
+      handleFormSubmit()
+    },
+    [handleFormSubmit],
+  )
+
+  const bodyContent = useMemo(() => {
+    return (
+      <SharedTradeInputBody
+        activeQuote={activeQuote}
+        buyAmountAfterFeesCryptoPrecision={buyAmountAfterFeesCryptoPrecision}
+        buyAmountAfterFeesUserCurrency={buyAmountAfterFeesUserCurrency}
+        buyAsset={buyAsset}
+        buyAssetAccountId={buyAssetAccountId}
+        isInputtingFiatSellAmount={isInputtingFiatSellAmount}
+        isLoading={isLoading}
+        manualReceiveAddress={manualReceiveAddress}
+        sellAmountCryptoPrecision={sellAmountCryptoPrecision}
+        sellAmountUserCurrency={sellAmountUserCurrency}
+        sellAsset={sellAsset}
+        sellAssetAccountId={sellAssetAccountId}
+        handleSwitchAssets={handleSwitchAssets}
+        onChangeIsInputtingFiatSellAmount={setIsInputtingFiatSellAmount}
+        onChangeSellAmountCryptoPrecision={setSellAmountCryptoPrecision}
+        setBuyAsset={setBuyAsset}
+        setBuyAssetAccountId={setBuyAssetAccountId}
+        setSellAsset={setSellAsset}
+        setSellAssetAccountId={setSellAssetAccountId}
+      />
+    )
+  }, [
+    activeQuote,
+    buyAmountAfterFeesCryptoPrecision,
+    buyAmountAfterFeesUserCurrency,
+    buyAsset,
+    buyAssetAccountId,
+    isInputtingFiatSellAmount,
+    isLoading,
+    manualReceiveAddress,
+    sellAmountCryptoPrecision,
+    sellAmountUserCurrency,
+    sellAsset,
+    sellAssetAccountId,
+    handleSwitchAssets,
+    setBuyAsset,
+    setBuyAssetAccountId,
+    setSellAsset,
+    setSellAssetAccountId,
+  ])
+
+  const footerContent = useMemo(() => {
+    return (
+      <SharedTradeInputFooter
+        isCompact={isCompact}
+        isLoading={isLoading}
+        receiveAddress={manualReceiveAddress ?? walletReceiveAddress}
+        inputAmountUsd={'12.34'}
+        affiliateBps={'300'}
+        affiliateFeeAfterDiscountUserCurrency={'0.01'}
+        quoteStatusTranslation={'trade.previewTrade'}
+        manualAddressEntryDescription={undefined}
+        onRateClick={noop}
+        shouldDisablePreviewButton={false}
+        isError={false}
+        shouldForceManualAddressEntry={false}
+        recipientAddressDescription={undefined}
+        priceImpactPercentage={undefined}
+        swapSource={SwapperName.CowSwap}
+        rate={activeQuote?.rate}
+        swapperName={SwapperName.CowSwap}
+        slippageDecimal={'0.01'}
+        buyAmountAfterFeesCryptoPrecision={buyAmountAfterFeesCryptoPrecision}
+        intermediaryTransactionOutputs={undefined}
+        buyAsset={buyAsset}
+        hasUserEnteredAmount={hasUserEnteredAmount}
+        totalProtocolFees={undefined}
+        sellAsset={sellAsset}
+        sellAssetAccountId={sellAssetAccountId}
+        totalNetworkFeeFiatPrecision={'1.1234'}
+      />
+    )
+  }, [
+    activeQuote?.rate,
+    buyAmountAfterFeesCryptoPrecision,
+    buyAsset,
+    hasUserEnteredAmount,
+    isCompact,
+    isLoading,
+    manualReceiveAddress,
+    sellAsset,
+    sellAssetAccountId,
+    walletReceiveAddress,
+  ])
+
+  return (
+    <>
+      <WarningAcknowledgement
+        message={warningAcknowledgementMessage}
+        onAcknowledge={handleWarningAcknowledgementSubmit}
+        shouldShowAcknowledgement={shouldShowWarningAcknowledgement}
+        setShouldShowAcknowledgement={setShouldShowWarningAcknowledgement}
+      />
+      <SharedTradeInput
+        bodyContent={bodyContent}
+        footerContent={footerContent}
+        hasUserEnteredAmount={hasUserEnteredAmount}
+        headerRightContent={headerRightContent}
+        isCompact={isCompact}
+        isLoading={isLoading}
+        sideComponent={CollapsibleLimitOrderList}
+        tradeInputRef={tradeInputRef}
+        tradeInputTab={TradeInputTab.LimitOrder}
+        onSubmit={handleTradeQuoteConfirm}
+        onChangeTab={onChangeTab}
+      />
+    </>
+  )
+}

--- a/src/components/MultiHopTrade/components/LimitOrder/components/LimitOrderStatus.tsx
+++ b/src/components/MultiHopTrade/components/LimitOrder/components/LimitOrderStatus.tsx
@@ -1,0 +1,118 @@
+import { Button, Card, CardBody, CardFooter } from '@chakra-ui/react'
+import { TxStatus } from '@shapeshiftoss/unchained-client'
+import { useCallback, useMemo, useState } from 'react'
+import { useTranslate } from 'react-polyglot'
+import { useHistory } from 'react-router'
+import { ethereum } from 'test/mocks/assets'
+import { Amount } from 'components/Amount/Amount'
+import { SlideTransition } from 'components/SlideTransition'
+import { Text } from 'components/Text'
+
+import { StatusBody } from '../../StatusBody'
+import { LimitOrderRoutePaths } from '../types'
+
+const cardBorderRadius = { base: 'xl' }
+
+const asset = ethereum
+
+export const LimitOrderStatus = () => {
+  const history = useHistory()
+  const translate = useTranslate()
+  const [txStatus, setTxStatus] = useState(TxStatus.Pending)
+
+  const handleSignAndBroadcast = useCallback(() => {
+    switch (txStatus) {
+      case TxStatus.Pending:
+        setTxStatus(TxStatus.Confirmed)
+        return
+      case TxStatus.Confirmed:
+        setTxStatus(TxStatus.Failed)
+        return
+      case TxStatus.Failed:
+        setTxStatus(TxStatus.Unknown)
+        return
+      case TxStatus.Unknown:
+      default:
+        history.push(LimitOrderRoutePaths.Input)
+        return
+    }
+  }, [history, txStatus])
+
+  const amountCryptoPrecision = '0.12420'
+
+  const statusBody = useMemo(() => {
+    if (!asset) return null
+    const renderedAmount = (() => {
+      switch (txStatus) {
+        case TxStatus.Pending: {
+          return (
+            <Amount.Crypto
+              prefix={translate('bridge.claimPending')}
+              value={amountCryptoPrecision}
+              symbol={asset.symbol}
+              color='text.subtle'
+            />
+          )
+        }
+        case TxStatus.Confirmed: {
+          return (
+            <Amount.Crypto
+              prefix={translate('bridge.claimSuccess')}
+              value={amountCryptoPrecision}
+              symbol={asset.symbol}
+              color='text.subtle'
+            />
+          )
+        }
+        case TxStatus.Failed: {
+          return (
+            <Amount.Crypto
+              prefix={translate('bridge.claimFailed')}
+              value={amountCryptoPrecision}
+              symbol={asset.symbol}
+              color='text.subtle'
+            />
+          )
+        }
+        case TxStatus.Unknown:
+        default:
+          return null
+      }
+    })()
+
+    return <StatusBody txStatus={txStatus}>{renderedAmount}</StatusBody>
+  }, [amountCryptoPrecision, translate, txStatus])
+
+  return (
+    <SlideTransition>
+      <Card
+        flex={1}
+        borderRadius={cardBorderRadius}
+        width='full'
+        variant='dashboard'
+        maxWidth='500px'
+      >
+        <CardBody py={32}>{statusBody}</CardBody>
+        <CardFooter
+          flexDir='column'
+          gap={2}
+          px={4}
+          borderTopWidth={1}
+          borderColor='border.base'
+          bg='background.surface.raised.base'
+          borderBottomRadius='md'
+        >
+          <Button
+            colorScheme={'blue'}
+            size='lg'
+            width='full'
+            onClick={handleSignAndBroadcast}
+            isLoading={false}
+          >
+            <Text translation={'limitOrder.signTransaction'} />
+          </Button>
+        </CardFooter>
+      </Card>
+    </SlideTransition>
+  )
+}

--- a/src/components/MultiHopTrade/components/LimitOrder/types.ts
+++ b/src/components/MultiHopTrade/components/LimitOrder/types.ts
@@ -1,0 +1,5 @@
+export enum LimitOrderRoutePaths {
+  Input = '/trade/limit-order/input',
+  Confirm = '/trade/limit-order/confirm',
+  Status = '/trade/limit-order/status',
+}

--- a/src/components/MultiHopTrade/components/StatusBody.tsx
+++ b/src/components/MultiHopTrade/components/StatusBody.tsx
@@ -1,0 +1,50 @@
+import { CheckCircleIcon, WarningTwoIcon } from '@chakra-ui/icons'
+import { Center, Heading, Stack } from '@chakra-ui/react'
+import { TxStatus } from '@shapeshiftoss/unchained-client'
+import { useMemo } from 'react'
+import { useTranslate } from 'react-polyglot'
+import { CircularProgress } from 'components/CircularProgress/CircularProgress'
+import { SlideTransitionY } from 'components/SlideTransitionY'
+
+type StatusBodyProps = {
+  txStatus: TxStatus
+  children?: JSX.Element | null
+}
+
+const pendingIcon = <CircularProgress size='24' />
+const confirmedIcon = <CheckCircleIcon color='text.success' boxSize='24' />
+const failedIcon = <WarningTwoIcon color='red.500' boxSize='24' />
+
+export const StatusBody = ({ txStatus, children }: StatusBodyProps) => {
+  const translate = useTranslate()
+
+  const { title, icon } = useMemo(() => {
+    switch (txStatus) {
+      case TxStatus.Pending:
+        return { title: translate('pools.waitingForConfirmation'), icon: pendingIcon }
+      case TxStatus.Confirmed:
+        return { title: translate('common.success'), icon: confirmedIcon }
+      case TxStatus.Failed:
+        return { title: translate('common.somethingWentWrong'), icon: failedIcon }
+      case TxStatus.Unknown:
+      default:
+        return { title: '', icon: null }
+    }
+  }, [txStatus, translate])
+
+  if (txStatus === TxStatus.Unknown) {
+    return null
+  }
+
+  return (
+    <SlideTransitionY key={txStatus}>
+      <Center flexDir='column' gap={4}>
+        {icon}
+        <Stack spacing={2} alignItems='center'>
+          <Heading as='h4'>{title}</Heading>
+          {Boolean(children) && children}
+        </Stack>
+      </Center>
+    </SlideTransitionY>
+  )
+}

--- a/src/components/MultiHopTrade/components/TradeInput/components/Claim/ClaimStatus.tsx
+++ b/src/components/MultiHopTrade/components/TradeInput/components/Claim/ClaimStatus.tsx
@@ -1,14 +1,12 @@
-import { CheckCircleIcon, WarningTwoIcon } from '@chakra-ui/icons'
-import { Button, CardBody, CardFooter, Center, Heading, Link, Stack } from '@chakra-ui/react'
+import { Button, CardBody, CardFooter, Link } from '@chakra-ui/react'
 import { TxStatus } from '@shapeshiftoss/unchained-client'
 import { AnimatePresence } from 'framer-motion'
 import React, { useCallback, useMemo } from 'react'
 import { useTranslate } from 'react-polyglot'
 import { useHistory } from 'react-router'
 import { Amount } from 'components/Amount/Amount'
-import { CircularProgress } from 'components/CircularProgress/CircularProgress'
+import { StatusBody } from 'components/MultiHopTrade/components/StatusBody'
 import { SlideTransition } from 'components/SlideTransition'
-import { SlideTransitionY } from 'components/SlideTransitionY'
 import { useSafeTxQuery } from 'hooks/queries/useSafeTx'
 import { getTxLink } from 'lib/getTxLink'
 import { fromBaseUnit } from 'lib/math'
@@ -17,43 +15,6 @@ import { useAppSelector } from 'state/store'
 
 import type { ClaimDetails } from './hooks/useArbitrumClaimsByStatus'
 import { ClaimRoutePaths } from './types'
-
-type ClaimStatusBodyProps = {
-  amountCryptoPrecision: string
-  description: string
-  icon: JSX.Element
-  status: TxStatus
-  symbol: string
-  title: string
-}
-
-export const ClaimStatusBody: React.FC<ClaimStatusBodyProps> = ({
-  amountCryptoPrecision,
-  description,
-  icon,
-  status,
-  symbol,
-  title,
-}) => {
-  return (
-    <SlideTransitionY key={status}>
-      <CardBody py={32}>
-        <Center flexDir='column' gap={4}>
-          {icon}
-          <Stack spacing={2} alignItems='center'>
-            <Heading as='h4'>{title}</Heading>
-            <Amount.Crypto
-              prefix={description}
-              value={amountCryptoPrecision}
-              symbol={symbol}
-              color='text.subtle'
-            />
-          </Stack>
-        </Center>
-      </CardBody>
-    </SlideTransitionY>
-  )
-}
 
 type ClaimStatusProps = {
   activeClaim: ClaimDetails
@@ -79,53 +40,47 @@ export const ClaimStatus: React.FC<ClaimStatusProps> = ({
     return fromBaseUnit(activeClaim.amountCryptoBaseUnit, asset?.precision ?? 0)
   }, [asset, activeClaim])
 
-  const StatusBody = useMemo(() => {
+  const statusBody = useMemo(() => {
     if (!asset) return null
+    const renderedAmount = (() => {
+      switch (claimTxStatus) {
+        case TxStatus.Pending: {
+          return (
+            <Amount.Crypto
+              prefix={translate('bridge.claimPending')}
+              value={amountCryptoPrecision}
+              symbol={asset.symbol}
+              color='text.subtle'
+            />
+          )
+        }
+        case TxStatus.Confirmed: {
+          return (
+            <Amount.Crypto
+              prefix={translate('bridge.claimSuccess')}
+              value={amountCryptoPrecision}
+              symbol={asset.symbol}
+              color='text.subtle'
+            />
+          )
+        }
+        case TxStatus.Failed: {
+          return (
+            <Amount.Crypto
+              prefix={translate('bridge.claimFailed')}
+              value={amountCryptoPrecision}
+              symbol={asset.symbol}
+              color='text.subtle'
+            />
+          )
+        }
+        case TxStatus.Unknown:
+        default:
+          return null
+      }
+    })()
 
-    switch (claimTxStatus) {
-      case TxStatus.Pending: {
-        return (
-          <ClaimStatusBody
-            amountCryptoPrecision={amountCryptoPrecision}
-            description={translate('bridge.claimPending')}
-            // eslint-disable-next-line react-memo/require-usememo
-            icon={<CircularProgress size='24' />}
-            status={TxStatus.Pending}
-            symbol={asset.symbol}
-            title={translate('pools.waitingForConfirmation')}
-          />
-        )
-      }
-      case TxStatus.Confirmed: {
-        return (
-          <ClaimStatusBody
-            amountCryptoPrecision={amountCryptoPrecision}
-            description={translate('bridge.claimSuccess')}
-            // eslint-disable-next-line react-memo/require-usememo
-            icon={<CheckCircleIcon color='text.success' boxSize='24' />}
-            status={TxStatus.Confirmed}
-            symbol={asset.symbol}
-            title={translate('common.success')}
-          />
-        )
-      }
-      case TxStatus.Failed: {
-        return (
-          <ClaimStatusBody
-            amountCryptoPrecision={amountCryptoPrecision}
-            description={translate('bridge.claimFailed')}
-            // eslint-disable-next-line react-memo/require-usememo
-            icon={<WarningTwoIcon color='red.500' boxSize='24' />}
-            status={TxStatus.Failed}
-            symbol={asset.symbol}
-            title={translate('common.somethingWentWrong')}
-          />
-        )
-      }
-      case TxStatus.Unknown:
-      default:
-        return null
-    }
+    return <StatusBody txStatus={claimTxStatus}>{renderedAmount}</StatusBody>
   }, [amountCryptoPrecision, asset, translate, claimTxStatus])
 
   const { data: maybeSafeTx } = useSafeTxQuery({
@@ -144,7 +99,9 @@ export const ClaimStatus: React.FC<ClaimStatusProps> = ({
 
   return (
     <SlideTransition>
-      <AnimatePresence mode='wait'>{StatusBody}</AnimatePresence>
+      <AnimatePresence mode='wait'>
+        <CardBody py={32}>{statusBody}</CardBody>
+      </AnimatePresence>
       <CardFooter flexDir='column' gap={2}>
         <Button as={Link} href={txLink} size='lg' colorScheme='blue' variant='ghost' isExternal>
           {translate('trade.viewTransaction')}

--- a/src/components/MultiHopTrade/components/TradeInput/components/Claim/ClaimStatus.tsx
+++ b/src/components/MultiHopTrade/components/TradeInput/components/Claim/ClaimStatus.tsx
@@ -42,45 +42,30 @@ export const ClaimStatus: React.FC<ClaimStatusProps> = ({
 
   const statusBody = useMemo(() => {
     if (!asset) return null
-    const renderedAmount = (() => {
+    const prefix = (() => {
       switch (claimTxStatus) {
-        case TxStatus.Pending: {
-          return (
-            <Amount.Crypto
-              prefix={translate('bridge.claimPending')}
-              value={amountCryptoPrecision}
-              symbol={asset.symbol}
-              color='text.subtle'
-            />
-          )
-        }
-        case TxStatus.Confirmed: {
-          return (
-            <Amount.Crypto
-              prefix={translate('bridge.claimSuccess')}
-              value={amountCryptoPrecision}
-              symbol={asset.symbol}
-              color='text.subtle'
-            />
-          )
-        }
-        case TxStatus.Failed: {
-          return (
-            <Amount.Crypto
-              prefix={translate('bridge.claimFailed')}
-              value={amountCryptoPrecision}
-              symbol={asset.symbol}
-              color='text.subtle'
-            />
-          )
-        }
+        case TxStatus.Pending:
+          return translate('bridge.claimPending')
+        case TxStatus.Confirmed:
+          return translate('bridge.claimSuccess')
+        case TxStatus.Failed:
+          return translate('bridge.claimFailed')
         case TxStatus.Unknown:
         default:
           return null
       }
     })()
 
-    return <StatusBody txStatus={claimTxStatus}>{renderedAmount}</StatusBody>
+    return (
+      <StatusBody txStatus={claimTxStatus}>
+        <Amount.Crypto
+          prefix={prefix}
+          value={amountCryptoPrecision}
+          symbol={asset.symbol}
+          color='text.subtle'
+        />
+      </StatusBody>
+    )
   }, [amountCryptoPrecision, asset, translate, claimTxStatus])
 
   const { data: maybeSafeTx } = useSafeTxQuery({


### PR DESCRIPTION
## Description

Adds some minimal interactive scaffolding as a placeholder for limit orders UI flow, ahead of some incoming design changes. The UI here is intended to anchor discussion and provide a way to rapidly view parts of the limit orders UI and transitions between the routes.

## Issue (if applicable)

<!-----------------------------------------------------------------------------
If applicable, please link to the github issue and put `closes #XXXX` in your comment to auto-close the issue that your PR fixes.
------------------------------------------------------------------------------>

Progresses #6218

## Risk

> High Risk PRs Require 2 approvals

Low risk, UI only

> What protocols, transaction types, wallets or contract interactions might be affected by this PR?

Arbitrum bridge claim status UI.

## Testing

Sanity check of Arbitrum bridge claim status UI, check the correct status is rendered (circular progress, green check, red alert icon).

### Engineering

<!-----------------------------------------------------------------------------
Include sufficient information here for an engineer to test your PR. This may include how to test locally, in a built environment, changes to infrastructure etc.
------------------------------------------------------------------------------>

### Operations

Limit orders are behind feature flag, but please test arbitrum bridge claims UI as this is impacted.

- [ ] :checkered_flag: My feature is behind a flag and doesn't require operations testing (yet)

<!-----------------------------------------------------------------------------
If your changes have a user-facing impact, describe how a non-technical QA team can functionally test your changes in a preview environment.

If they are not user-facing please describe how to test for any regressions that may occur.
------------------------------------------------------------------------------>

## Screenshots (if applicable)

![image](https://github.com/user-attachments/assets/9e23aed1-3037-49a7-ad98-8576b0bd6f5d)

