### PR TITLE
fix: arbitrum bridge withdraw status copies and button

### DIFF
--- a/src/assets/translations/en/main.json
+++ b/src/assets/translations/en/main.json
@@ -793,7 +793,11 @@
       "description": "Bridge via Arbitrum",
       "waitWarning": "Arbitrum’s native bridge is more secure but can take up to a week to claim.",
       "waitCta": "I understand that it will take ~7 days before I can claim funds on Ethereum",
-      "claimCta": "I understand that after claiming my funds, I’ll have to send another transaction with a fee"
+      "claimCta": "I understand that after claiming my funds, I’ll have to send another transaction with a fee",
+      "success": {
+        "tradeSuccess": "Bridge initiated",
+        "tradeComplete": "Successfully initiated bridging %{symbol} to %{chainName}."
+      }
     },
     "claim": "Claim",
     "claimReceiveAddress": "Claim Receive Address",
@@ -807,6 +811,7 @@
     "availableIn": "Available in %{time}",
     "confirmAndClaim": "Confirm & Claim",
     "viewClaims": "View Claims",
+    "viewClaimStatus": "View Claim Status",
     "availableClaimsNotification": "You have bridge claims ready!"
   },
   "trade": {

--- a/src/assets/translations/en/main.json
+++ b/src/assets/translations/en/main.json
@@ -796,7 +796,7 @@
       "claimCta": "I understand that after claiming my funds, I’ll have to send another transaction with a fee",
       "success": {
         "tradeSuccess": "Bridge initiated",
-        "tradeComplete": "Successfully initiated bridging %{symbol} to %{chainName}."
+        "withdrawComplete": "Successfully initiated bridging %{symbol} to %{chainName}."
       }
     },
     "claim": "Claim",

--- a/src/components/MultiHopTrade/components/MultiHopTradeConfirm/MultiHopTradeConfirm.tsx
+++ b/src/components/MultiHopTrade/components/MultiHopTradeConfirm/MultiHopTradeConfirm.tsx
@@ -139,7 +139,7 @@ export const MultiHopTradeConfirm = memo(() => {
               isArbitrumBridgeWithdraw ? 'bridge.arbitrum.success.tradeSuccess' : undefined
             }
             descriptionTranslation={
-              isArbitrumBridgeWithdraw ? 'bridge.arbitrum.success.tradeComplete' : undefined
+              isArbitrumBridgeWithdraw ? 'bridge.arbitrum.success.withdrawComplete' : undefined
             }
           >
             <Hops isFirstHopOpen isSecondHopOpen />

--- a/src/components/MultiHopTrade/components/MultiHopTradeConfirm/MultiHopTradeConfirm.tsx
+++ b/src/components/MultiHopTrade/components/MultiHopTradeConfirm/MultiHopTradeConfirm.tsx
@@ -1,4 +1,5 @@
 import { Card, CardBody, CardHeader, Heading, useDisclosure, usePrevious } from '@chakra-ui/react'
+import { isArbitrumBridgeTradeQuote } from '@shapeshiftoss/swapper/dist/swappers/ArbitrumBridgeSwapper/getTradeQuote/getTradeQuote'
 import { memo, useCallback, useEffect, useMemo, useState } from 'react'
 import { useTranslate } from 'react-polyglot'
 import { useHistory } from 'react-router-dom'
@@ -39,6 +40,10 @@ export const MultiHopTradeConfirm = memo(() => {
   const { isModeratePriceImpact, priceImpactPercentage } = usePriceImpact(activeQuote)
 
   const { isLoading } = useIsApprovalInitiallyNeeded()
+
+  const isArbitrumBridgeWithdraw = useMemo(() => {
+    return isArbitrumBridgeTradeQuote(activeQuote) && activeQuote.direction === 'withdrawal'
+  }, [activeQuote])
 
   useEffect(() => {
     if (isLoading || !activeQuote) return
@@ -128,7 +133,15 @@ export const MultiHopTradeConfirm = memo(() => {
           </WithBackButton>
         </CardHeader>
         {isTradeComplete ? (
-          <TradeSuccess handleBack={handleBack}>
+          <TradeSuccess
+            handleBack={handleBack}
+            titleTranslation={
+              isArbitrumBridgeWithdraw ? 'bridge.arbitrum.success.tradeSuccess' : undefined
+            }
+            descriptionTranslation={
+              isArbitrumBridgeWithdraw ? 'bridge.arbitrum.success.tradeComplete' : undefined
+            }
+          >
             <Hops isFirstHopOpen isSecondHopOpen />
           </TradeSuccess>
         ) : (

--- a/src/components/MultiHopTrade/components/MultiHopTradeConfirm/components/AssetSummaryStep.tsx
+++ b/src/components/MultiHopTrade/components/MultiHopTradeConfirm/components/AssetSummaryStep.tsx
@@ -18,12 +18,14 @@ export type AssetSummaryStepProps = {
   asset: Asset
   amountCryptoBaseUnit: string
   isLastStep?: boolean
+  button?: JSX.Element
 }
 
 export const AssetSummaryStep = ({
   asset,
   amountCryptoBaseUnit,
   isLastStep,
+  button,
 }: AssetSummaryStepProps) => {
   const translate = useTranslate()
   const {
@@ -68,6 +70,7 @@ export const AssetSummaryStep = ({
       }
       stepIndicator={assetIcon}
       isLastStep={isLastStep}
+      button={button}
     />
   )
 }

--- a/src/components/MultiHopTrade/components/MultiHopTradeConfirm/components/Hop.tsx
+++ b/src/components/MultiHopTrade/components/MultiHopTradeConfirm/components/Hop.tsx
@@ -226,7 +226,7 @@ export const Hop = ({
   }, [hopExecutionState, hopIndex, isError])
 
   const LastStepArbitrumBridgeButton = useCallback(() => {
-    if (hopExecutionState !== HopExecutionState.Complete) return
+    if (hopExecutionState !== HopExecutionState.Complete) return null
 
     const handleClick = () => {
       history.push('/trade/claim')

--- a/src/components/MultiHopTrade/components/MultiHopTradeConfirm/components/Hop.tsx
+++ b/src/components/MultiHopTrade/components/MultiHopTradeConfirm/components/Hop.tsx
@@ -226,6 +226,8 @@ export const Hop = ({
   }, [hopExecutionState, hopIndex, isError])
 
   const LastStepArbitrumBridgeButton = useCallback(() => {
+    if (hopExecutionState !== HopExecutionState.Complete) return
+
     const handleClick = () => {
       history.push('/trade/claim')
     }
@@ -236,7 +238,7 @@ export const Hop = ({
         {translate('bridge.viewClaimStatus')}
       </Button>
     )
-  }, [translate, history])
+  }, [translate, history, hopExecutionState])
 
   return (
     <Card flex={1} bg='transparent' borderWidth={0} borderRadius={0} width='full' boxShadow='none'>

--- a/src/components/MultiHopTrade/components/MultiHopTradeConfirm/components/StepperStep.tsx
+++ b/src/components/MultiHopTrade/components/MultiHopTradeConfirm/components/StepperStep.tsx
@@ -1,6 +1,7 @@
 import type { BoxProps, StepTitleProps, SystemStyleObject } from '@chakra-ui/react'
 import {
   Box,
+  Flex,
   SkeletonCircle,
   SkeletonText,
   Spacer,
@@ -30,6 +31,7 @@ export type StepperStepProps = {
   titleProps?: StepTitleProps
   descriptionProps?: BoxProps
   isPending?: boolean
+  button?: JSX.Element
 }
 
 const LastStepTag = () => {
@@ -58,6 +60,7 @@ export const StepperStep = ({
   titleProps,
   descriptionProps,
   isPending,
+  button,
 }: StepperStepProps) => {
   const { indicator: styles } = useStyleConfig('Stepper', {
     variant: isError ? 'error' : 'default',
@@ -69,27 +72,30 @@ export const StepperStep = ({
         {isLoading ? <SkeletonCircle /> : stepIndicator}
       </StepIndicator>
 
-      <Box flex={1}>
-        <StepTitle {...titleProps}>
-          <SkeletonText noOfLines={1} skeletonHeight={6} isLoaded={!isLoading}>
-            {title}
-          </SkeletonText>
-        </StepTitle>
-        {description && (
-          <>
-            <StepDescription as={Box} {...descriptionProps}>
-              {isLoading ? (
-                <SkeletonText mt={2} noOfLines={1} skeletonHeight={3} isLoaded={!isLoading} />
-              ) : (
-                description
-              )}
-            </StepDescription>
-            {isLastStep ? <LastStepTag /> : null}
-          </>
-        )}
-        {content !== undefined && <Box mt={2}>{content}</Box>}
-        {!isLastStep && <Spacer height={6} />}
-      </Box>
+      <Flex alignItems='center' flex={1}>
+        <Box width='100%' flex={1}>
+          <StepTitle {...titleProps}>
+            <SkeletonText noOfLines={1} skeletonHeight={6} isLoaded={!isLoading}>
+              {title}
+            </SkeletonText>
+          </StepTitle>
+          {description && (
+            <>
+              <StepDescription as={Box} {...descriptionProps}>
+                {isLoading ? (
+                  <SkeletonText mt={2} noOfLines={1} skeletonHeight={3} isLoaded={!isLoading} />
+                ) : (
+                  description
+                )}
+              </StepDescription>
+              {isLastStep ? <LastStepTag /> : null}
+            </>
+          )}
+          {content !== undefined && <Box mt={2}>{content}</Box>}
+          {!isLastStep && <Spacer height={6} />}
+        </Box>
+        {button}
+      </Flex>
       {!isLastStep && <StepSeparator />}
     </Step>
   )

--- a/src/components/MultiHopTrade/components/TradeInput/TradeInput.tsx
+++ b/src/components/MultiHopTrade/components/TradeInput/TradeInput.tsx
@@ -281,7 +281,6 @@ export const TradeInput = ({ isCompact, tradeInputRef, onChangeTab }: TradeInput
     },
     [dispatch],
   )
-  console.log({ buyAsset })
 
   const bodyContent = useMemo(() => {
     return (

--- a/src/components/MultiHopTrade/components/TradeInput/TradeInput.tsx
+++ b/src/components/MultiHopTrade/components/TradeInput/TradeInput.tsx
@@ -281,6 +281,7 @@ export const TradeInput = ({ isCompact, tradeInputRef, onChangeTab }: TradeInput
     },
     [dispatch],
   )
+  console.log({ buyAsset })
 
   const bodyContent = useMemo(() => {
     return (

--- a/src/components/MultiHopTrade/components/TradeSuccess/TradeSuccess.tsx
+++ b/src/components/MultiHopTrade/components/TradeSuccess/TradeSuccess.tsx
@@ -7,6 +7,7 @@ import {
   HStack,
   useDisclosure,
 } from '@chakra-ui/react'
+import type { InterpolationOptions } from 'node-polyglot'
 import { useMemo } from 'react'
 import { useTranslate } from 'react-polyglot'
 import { AssetIcon } from 'components/AssetIcon'
@@ -21,8 +22,8 @@ import { TwirlyToggle } from '../TwirlyToggle'
 export type TradeSuccessProps = {
   handleBack: () => void
   children: JSX.Element
-  titleTranslation?: string
-  descriptionTranslation?: string
+  titleTranslation?: string | [string, InterpolationOptions]
+  descriptionTranslation?: string | [string, InterpolationOptions]
 }
 
 const pairProps = { showFirst: true }
@@ -52,10 +53,12 @@ export const TradeSuccess = ({
     const chainName = adapter.getDisplayName()
 
     if (descriptionTranslation)
-      return translate(descriptionTranslation, {
-        symbol: lastHop.buyAsset.symbol,
-        chainName,
-      })
+      return typeof descriptionTranslation === 'string'
+        ? translate(descriptionTranslation, {
+            symbol: lastHop.buyAsset.symbol,
+            chainName,
+          })
+        : translate(...descriptionTranslation)
 
     return translate('trade.temp.tradeComplete', {
       symbol: lastHop.buyAsset.symbol,

--- a/src/components/MultiHopTrade/components/TradeSuccess/TradeSuccess.tsx
+++ b/src/components/MultiHopTrade/components/TradeSuccess/TradeSuccess.tsx
@@ -18,11 +18,21 @@ import { useAppSelector } from 'state/store'
 
 import { TwirlyToggle } from '../TwirlyToggle'
 
-export type TradeSuccessProps = { handleBack: () => void; children: JSX.Element }
+export type TradeSuccessProps = {
+  handleBack: () => void
+  children: JSX.Element
+  titleTranslation?: string
+  descriptionTranslation?: string
+}
 
 const pairProps = { showFirst: true }
 
-export const TradeSuccess = ({ handleBack, children }: TradeSuccessProps) => {
+export const TradeSuccess = ({
+  handleBack,
+  titleTranslation,
+  descriptionTranslation,
+  children,
+}: TradeSuccessProps) => {
   const translate = useTranslate()
 
   const { isOpen, onToggle: handleToggle } = useDisclosure({
@@ -41,11 +51,17 @@ export const TradeSuccess = ({ handleBack, children }: TradeSuccessProps) => {
 
     const chainName = adapter.getDisplayName()
 
+    if (descriptionTranslation)
+      return translate(descriptionTranslation, {
+        symbol: lastHop.buyAsset.symbol,
+        chainName,
+      })
+
     return translate('trade.temp.tradeComplete', {
       symbol: lastHop.buyAsset.symbol,
       chainName,
     })
-  }, [lastHop, translate])
+  }, [lastHop, translate, descriptionTranslation])
 
   if (!lastHop) return null
 
@@ -55,7 +71,7 @@ export const TradeSuccess = ({ handleBack, children }: TradeSuccessProps) => {
         <SlideTransition>
           <Box textAlign='center' py={4}>
             <AssetIcon assetId={lastHop.buyAsset.assetId} mb={2} pairProps={pairProps} />
-            <Text translation='trade.temp.tradeSuccess' />
+            <Text translation={titleTranslation ?? 'trade.temp.tradeSuccess'} />
             <RawText fontSize='md' color='gray.500' mt={2}>
               {subText}
             </RawText>


### PR DESCRIPTION
## Description

Updated copies inside `TradeSuccess`, made it agnostic so we could change it if we have another specific bridge in the future

Also added a button prop to `StepperStep` so we can pass a button as a prop that will be shown on the right

<!-- Please describe your changes -->

## Issue (if applicable)

<!-----------------------------------------------------------------------------
If applicable, please link to the github issue and put `closes #XXXX` in your comment to auto-close the issue that your PR fixes.
------------------------------------------------------------------------------>

closes #7894

## Risk

> High Risk PRs Require 2 approvals

<!-----------------------------------------------------------------------------
Outline the scope of your changes and the risk associated with them. You must use your discretion as an engineer to determine the potential impact of your changes.

WARNING: If your PR introduces a new on-chain transaction or modifies an existing one, please add the "High-Risk" label to this PR and ask for 2 reviewers to approve it before merging.

E.g. an upgrade to `hdwallet` or core state management would be considered higher risk, and might require a full regression test. UI or isolated view changes, or something behind a feature flag may have near zero risk. Small bug fixes might require testing isolated to the specific fix.
------------------------------------------------------------------------------>

> What protocols, transaction types, wallets or contract interactions might be affected by this PR?

## Testing
- Verify a regular swap that is not an arbitrum swap (verify the TradeSuccess screen copies and buttons)
- Do an arbitrum withdraw, check copies and click on the claim button to see if you are redirected to the claim view
- Ensure Arbitrum deposits (ETH -> ARB direction) do not display the claim CTA nor the Arbitrum withdraw specific copies

<!-----------------------------------------------------------------------------
We treat every PR to be merged with the same scrutiny as if we were merging directly to production.

Your PR will not be merged if you do not complete the sections below for our engineering and operations teams to test.
------------------------------------------------------------------------------>

### Engineering
n/a
<!-----------------------------------------------------------------------------
Include sufficient information here for an engineer to test your PR. This may include how to test locally, in a built environment, changes to infrastructure etc.
------------------------------------------------------------------------------>

### Operations
n/a

- [ ] :checkered_flag: My feature is behind a flag and doesn't require operations testing (yet)

<!-----------------------------------------------------------------------------
If your changes have a user-facing impact, describe how a non-technical QA team can functionally test your changes in a preview environment.

If they are not user-facing please describe how to test for any regressions that may occur.
------------------------------------------------------------------------------>

## Screenshots (if applicable)
![image](https://github.com/user-attachments/assets/319eefe3-9bc9-4f7a-b7b7-81957d444eeb)
![image](https://github.com/user-attachments/assets/a117f10c-0e4f-485d-92a2-f54142577113)


### Regular
![image](https://github.com/user-attachments/assets/5ee887c0-85d5-49be-b7f8-ae19c28887c4)
![image](https://github.com/user-attachments/assets/ba8b4f32-2b11-4593-abab-1d67aa3898b3)
![image](https://github.com/user-attachments/assets/eb493a7c-54ef-44b6-885e-0cdc65beebc8)
