### PR TITLE
fix: deny stargateV2Bus in lifi swapper

### DIFF
--- a/packages/swapper/src/swappers/LifiSwapper/getTradeQuote/getTradeQuote.ts
+++ b/packages/swapper/src/swappers/LifiSwapper/getTradeQuote/getTradeQuote.ts
@@ -101,7 +101,13 @@ export async function getTradeQuote(
       // used for analytics and affiliate fee - do not change this without considering impact
       integrator: LIFI_INTEGRATOR_ID,
       slippage: Number(slippageTolerancePercentageDecimal),
-      bridges: { deny: ['stargate', 'stargateV2', 'amarok', 'arbitrum'] },
+      // Routes via Stargate or Amarok can always be executed in one step, as LiFi can make those
+      // bridges swap into any requested token on the destination chain. Other bridges my require
+      // two steps. As such, additional balance checks on the destination chain are required which
+      // are currently incompatible with our fee calculations, leading to incorrect fee display,
+      // reverts, partial swaps, wrong received tokens (due to out-of-gas mid-trade), etc. For now,
+      // these bridges are disabled.
+      bridges: { deny: ['stargate', 'stargateV2', 'stargateV2Bus', 'amarok', 'arbitrum'] },
       allowSwitchChain: true,
       fee: affiliateBpsDecimalPercentage.isZero()
         ? undefined


### PR DESCRIPTION
## Description

Disables `Stargate V2 (Economy Mode)` bridge in lifi swapper. Stargate should have been disabled due to incompatibility with our fee calculations, but economy mode seems to have slipped through the cracks.

See https://li.quest/v1/tools for list of bridges:
![image](https://github.com/user-attachments/assets/e0d1526e-2bf6-4bf7-8ea7-935a67446d05)


Added a comment with some context.

## Issue (if applicable)

<!-----------------------------------------------------------------------------
If applicable, please link to the github issue and put `closes #XXXX` in your comment to auto-close the issue that your PR fixes.
------------------------------------------------------------------------------>

closes #7988

## Risk

> High Risk PRs Require 2 approvals

Very low risk.

> What protocols, transaction types, wallets or contract interactions might be affected by this PR?

## Testing

Check Stargate routes are not available in the app.

### Engineering

<!-----------------------------------------------------------------------------
Include sufficient information here for an engineer to test your PR. This may include how to test locally, in a built environment, changes to infrastructure etc.
------------------------------------------------------------------------------>

### Operations

- [ ] :checkered_flag: My feature is behind a flag and doesn't require operations testing (yet)

<!-----------------------------------------------------------------------------
If your changes have a user-facing impact, describe how a non-technical QA team can functionally test your changes in a preview environment.

If they are not user-facing please describe how to test for any regressions that may occur.
------------------------------------------------------------------------------>

## Screenshots (if applicable)
