### PR TITLE
feat: full limit orders ui layout

### DIFF
--- a/src/assets/translations/en/main.json
+++ b/src/assets/translations/en/main.json
@@ -1011,7 +1011,13 @@
     "placeOrder": "Place Order",
     "viewOrder": "View Order",
     "viewOnChain": "View transaction on chain",
-    "yourOrderHasBeenPlaced": "Your order has been placed."
+    "yourOrderHasBeenPlaced": "Your order has been placed.",
+    "limitPrice": "Limit Price",
+    "provider": "Provider",
+    "expiration": "Expiration",
+    "networkFee":"Network Fee",
+    "confirmInfo": "The limit order may not fill exactly when on-chain prices reach the limit price.",
+    "learnMore": "Learn More"
   },
   "modals": {
     "assetSearch": {

--- a/src/assets/translations/en/main.json
+++ b/src/assets/translations/en/main.json
@@ -1003,7 +1003,15 @@
     }
   },
   "limitOrder": {
-    "heading": "Limit Order"
+    "heading": "Limit Order",
+    "confirm": "Confirm",
+    "placeOrderPending": "Waiting for Confirmation",
+    "placeOrderSuccess": "Success!",
+    "placeOrderFailed": "Something Went Wrong",
+    "placeOrder": "Place Order",
+    "viewOrder": "View Order",
+    "viewOnChain": "View transaction on chain",
+    "yourOrderHasBeenPlaced": "Your order has been placed."
   },
   "modals": {
     "assetSearch": {

--- a/src/assets/translations/en/main.json
+++ b/src/assets/translations/en/main.json
@@ -1018,7 +1018,8 @@
     "networkFee":"Network Fee",
     "confirmInfo": "The limit order may not fill exactly when on-chain prices reach the limit price.",
     "learnMore": "Learn More",
-    "previewOrder": "Preview Order"
+    "previewOrder": "Preview Order",
+    "youGet": "You Get"
   },
   "modals": {
     "assetSearch": {

--- a/src/assets/translations/en/main.json
+++ b/src/assets/translations/en/main.json
@@ -1019,7 +1019,9 @@
     "confirmInfo": "The limit order may not fill exactly when on-chain prices reach the limit price.",
     "learnMore": "Learn More",
     "previewOrder": "Preview Order",
-    "youGet": "You Get"
+    "youGet": "You Get",
+    "whenPriceReaches": "When price reaches",
+    "expiry": "Expiry"
   },
   "modals": {
     "assetSearch": {

--- a/src/assets/translations/en/main.json
+++ b/src/assets/translations/en/main.json
@@ -1017,7 +1017,8 @@
     "expiration": "Expiration",
     "networkFee":"Network Fee",
     "confirmInfo": "The limit order may not fill exactly when on-chain prices reach the limit price.",
-    "learnMore": "Learn More"
+    "learnMore": "Learn More",
+    "previewOrder": "Preview Order"
   },
   "modals": {
     "assetSearch": {

--- a/src/components/AssetToAssetCard/AssetToAssetCard.tsx
+++ b/src/components/AssetToAssetCard/AssetToAssetCard.tsx
@@ -1,0 +1,53 @@
+import { Card, Stack } from '@chakra-ui/react'
+import type { Asset } from '@shapeshiftoss/types'
+import { Amount } from 'components/Amount/Amount'
+import { AssetIcon } from 'components/AssetIcon'
+import { FormDivider } from 'components/FormDivider'
+
+type AssetToAssetCardProps = {
+  sellAsset: Asset | undefined
+  buyAsset: Asset | undefined
+  sellAmountCryptoPrecision: string | undefined
+  sellAmountUserCurrency: string | undefined
+  buyAmountCryptoPrecision: string | undefined
+  buyAmountUserCurrency: string | undefined
+}
+export const AssetToAssetCard = ({
+  sellAsset,
+  buyAsset,
+  sellAmountCryptoPrecision,
+  sellAmountUserCurrency,
+  buyAmountCryptoPrecision,
+  buyAmountUserCurrency,
+}: AssetToAssetCardProps) => {
+  if (!(sellAsset && buyAsset)) return null
+  return (
+    <>
+      <Card
+        display='flex'
+        alignItems='stretch'
+        justifyContent='space-evenly'
+        flexDir='row'
+        gap={4}
+        py={6}
+        px={4}
+      >
+        <Stack alignItems='center'>
+          <AssetIcon size='sm' assetId={sellAsset?.assetId} />
+          <Stack textAlign='center' spacing={0}>
+            <Amount.Crypto value={sellAmountCryptoPrecision} symbol={sellAsset.symbol} />
+            <Amount.Fiat fontSize='sm' color='text.subtle' value={sellAmountUserCurrency} />
+          </Stack>
+        </Stack>
+        <FormDivider my={-6} orientation='vertical' />
+        <Stack alignItems='center'>
+          <AssetIcon size='sm' assetId={buyAsset?.assetId} />
+          <Stack textAlign='center' spacing={0}>
+            <Amount.Crypto value={buyAmountCryptoPrecision} symbol={buyAsset.symbol} />
+            <Amount.Fiat fontSize='sm' color='text.subtle' value={buyAmountUserCurrency} />
+          </Stack>
+        </Stack>
+      </Card>
+    </>
+  )
+}

--- a/src/components/MultiHopTrade/components/LimitOrder/components/LimitOrderBuyAsset.tsx
+++ b/src/components/MultiHopTrade/components/LimitOrder/components/LimitOrderBuyAsset.tsx
@@ -1,4 +1,4 @@
-import { Divider, Flex, FormLabel, Stack } from '@chakra-ui/react'
+import { Flex, FormLabel, Stack } from '@chakra-ui/react'
 import type { AccountId } from '@shapeshiftoss/caip'
 import type { Asset } from '@shapeshiftoss/types'
 import { bnOrZero } from '@shapeshiftoss/utils'
@@ -83,7 +83,7 @@ export const LimitOrderBuyAsset: React.FC<LimitOrderBuyAssetProps> = memo(
     }, [buyAssetSearch, onSetBuyAsset])
 
     return (
-      <Stack>
+      <Stack mt={4}>
         <Flex justifyContent='space-between' alignItems='center' px={6} width='full' mb={2}>
           <Flex alignItems='center'>
             <FormLabel mb={0} fontSize='sm'>

--- a/src/components/MultiHopTrade/components/LimitOrder/components/LimitOrderBuyAsset.tsx
+++ b/src/components/MultiHopTrade/components/LimitOrder/components/LimitOrderBuyAsset.tsx
@@ -1,0 +1,3 @@
+export const LimitOrderBuyAsset = () => {
+  return <> </>
+}

--- a/src/components/MultiHopTrade/components/LimitOrder/components/LimitOrderBuyAsset.tsx
+++ b/src/components/MultiHopTrade/components/LimitOrder/components/LimitOrderBuyAsset.tsx
@@ -1,3 +1,116 @@
-export const LimitOrderBuyAsset = () => {
-  return <> </>
+import { Divider, Flex, FormLabel, Stack } from '@chakra-ui/react'
+import type { AccountId } from '@shapeshiftoss/caip'
+import type { Asset } from '@shapeshiftoss/types'
+import { bnOrZero } from '@shapeshiftoss/utils'
+import React, { memo, useCallback, useMemo } from 'react'
+import { useTranslate } from 'react-polyglot'
+import type { AccountDropdownProps } from 'components/AccountDropdown/AccountDropdown'
+import { AccountDropdown } from 'components/AccountDropdown/AccountDropdown'
+import { TradeAssetSelect } from 'components/AssetSelection/AssetSelection'
+import { Balance } from 'components/DeFi/components/Balance'
+import { Text } from 'components/Text'
+import { useModal } from 'hooks/useModal/useModal'
+import {
+  selectMarketDataByAssetIdUserCurrency,
+  selectPortfolioCryptoPrecisionBalanceByFilter,
+} from 'state/slices/selectors'
+import { useAppSelector } from 'state/store'
+
+export type TradeAmountInputFormValues = {
+  amountFieldInput: string
+  amountCryptoPrecision: string
+  amountUserCurrency: string
 }
+
+const buttonProps = {
+  variant: 'unstyled',
+  display: 'flex',
+  height: 'auto',
+  lineHeight: '1',
+  width: '100%',
+}
+const boxProps = { px: 0, m: 0, maxWidth: '220px' }
+
+export type LimitOrderBuyAssetProps = {
+  asset: Asset
+  accountId?: AccountId
+  isInputtingFiatSellAmount: boolean
+  onAccountIdChange: AccountDropdownProps['onChange']
+  onSetBuyAsset: (asset: Asset) => void
+}
+
+export const LimitOrderBuyAsset: React.FC<LimitOrderBuyAssetProps> = memo(
+  ({ asset, accountId, isInputtingFiatSellAmount, onAccountIdChange, onSetBuyAsset }) => {
+    const translate = useTranslate()
+    const buyAssetSearch = useModal('buyTradeAssetSearch')
+
+    const marketData = useAppSelector(state =>
+      selectMarketDataByAssetIdUserCurrency(state, asset.assetId),
+    )
+
+    const filter = useMemo(
+      () => ({
+        accountId: accountId ?? '',
+        assetId: asset.assetId,
+      }),
+      [accountId, asset],
+    )
+    const balance = useAppSelector(state =>
+      selectPortfolioCryptoPrecisionBalanceByFilter(state, filter),
+    )
+
+    const fiatBalance = bnOrZero(balance).times(marketData.price).toString()
+
+    const accountDropdownLabel = useMemo(
+      () => (
+        <Balance
+          cryptoBalance={balance ?? ''}
+          fiatBalance={fiatBalance ?? ''}
+          symbol={asset.symbol}
+          isFiat={isInputtingFiatSellAmount}
+          label={`${translate('common.balance')}:`}
+          textAlign='right'
+        />
+      ),
+      [asset, balance, fiatBalance, isInputtingFiatSellAmount, translate],
+    )
+
+    const handleAssetClick = useCallback(() => {
+      buyAssetSearch.open({
+        onAssetClick: onSetBuyAsset,
+        title: 'trade.tradeTo',
+      })
+    }, [buyAssetSearch, onSetBuyAsset])
+
+    return (
+      <Stack>
+        <Flex justifyContent='space-between' alignItems='center' px={6} width='full' mb={2}>
+          <Flex alignItems='center'>
+            <FormLabel mb={0} fontSize='sm'>
+              <Text translation='limitOrder.youGet' />
+            </FormLabel>
+          </Flex>
+          {balance && (
+            <AccountDropdown
+              defaultAccountId={accountId}
+              assetId={asset.assetId}
+              onChange={onAccountIdChange}
+              disabled={false}
+              autoSelectHighestBalance={false}
+              buttonProps={buttonProps}
+              boxProps={boxProps}
+              showLabel={false}
+              label={accountDropdownLabel}
+            />
+          )}
+        </Flex>
+        <TradeAssetSelect
+          assetId={asset.assetId}
+          onAssetClick={handleAssetClick}
+          onAssetChange={onSetBuyAsset}
+          onlyConnectedChains={false}
+        />
+      </Stack>
+    )
+  },
+)

--- a/src/components/MultiHopTrade/components/LimitOrder/components/LimitOrderConfig.tsx
+++ b/src/components/MultiHopTrade/components/LimitOrder/components/LimitOrderConfig.tsx
@@ -1,0 +1,149 @@
+import { ChevronDownIcon } from '@chakra-ui/icons'
+import {
+  Button,
+  Flex,
+  Menu,
+  MenuButton,
+  MenuItemOption,
+  MenuList,
+  MenuOptionGroup,
+  Stack,
+} from '@chakra-ui/react'
+import type { Asset } from '@shapeshiftoss/types'
+import { positiveOrZero } from '@shapeshiftoss/utils'
+import { noop } from 'lodash'
+import { useMemo } from 'react'
+import { Amount } from 'components/Amount/Amount'
+import { RawText, Text } from 'components/Text'
+
+// TODO: lol
+const timePeriods = [
+  '1 second',
+  '2 seconds',
+  '3 seconds',
+  '4 seconds',
+  '5 seconds',
+  '6 seconds',
+  '7 seconds',
+  '8 seconds',
+  '9 seconds',
+  '10 seconds',
+  '11 seconds',
+  '12 seconds',
+  '13 seconds',
+  '14 seconds',
+  '15 seconds',
+  '16 seconds',
+  '17 seconds',
+  '18 seconds',
+  '19 seconds',
+  '20 seconds',
+  '21 seconds',
+  '22 seconds',
+  '23 seconds',
+]
+
+const timePeriodRightIcon = <ChevronDownIcon />
+
+type LimitOrderConfigProps = {
+  buyAsset: Asset
+  hasUserEnteredAmount: boolean
+  isInputtingFiatSellAmount: boolean
+  buyAmountAfterFeesCryptoPrecision: string | undefined
+  buyAmountAfterFeesUserCurrency: string | undefined
+}
+
+export const LimitOrderConfig = ({
+  buyAsset,
+  hasUserEnteredAmount,
+  isInputtingFiatSellAmount,
+  buyAmountAfterFeesCryptoPrecision,
+  buyAmountAfterFeesUserCurrency,
+}: LimitOrderConfigProps) => {
+  const cryptoAmount = hasUserEnteredAmount
+    ? positiveOrZero(buyAmountAfterFeesCryptoPrecision).toFixed()
+    : '0'
+
+  const fiatAmount = hasUserEnteredAmount
+    ? positiveOrZero(buyAmountAfterFeesUserCurrency).toFixed()
+    : '0'
+
+  const renderedChains = useMemo(() => {
+    return timePeriods.map(timePeriod => {
+      return (
+        <MenuItemOption value={timePeriod} key={timePeriod}>
+          <RawText>{timePeriod}</RawText>
+        </MenuItemOption>
+      )
+    })
+  }, [])
+
+  const renderedBuyAmount = useMemo(() => {
+    return isInputtingFiatSellAmount ? (
+      <Amount.Crypto value={cryptoAmount} symbol={buyAsset.symbol} size='lg' fontSize='xl' />
+    ) : (
+      <Amount.Fiat value={fiatAmount} size='lg' fontSize='xl' />
+    )
+  }, [buyAsset.symbol, cryptoAmount, fiatAmount, isInputtingFiatSellAmount])
+
+  const renderedAlternateBuyAmount = useMemo(() => {
+    return !isInputtingFiatSellAmount ? (
+      <Amount.Crypto
+        value={cryptoAmount}
+        symbol={buyAsset.symbol}
+        prefix='≈'
+        fontSize='sm'
+        fontWeight='medium'
+        textColor='text.subtle'
+      />
+    ) : (
+      <Amount.Fiat
+        value={fiatAmount}
+        prefix='≈'
+        fontSize='sm'
+        fontWeight='medium'
+        textColor='text.subtle'
+      />
+    )
+  }, [buyAsset.symbol, cryptoAmount, fiatAmount, isInputtingFiatSellAmount])
+
+  return (
+    <Stack spacing={2} px={6}>
+      <Flex justifyContent='space-between' alignItems='center'>
+        <Text translation='limitOrder.whenPriceReaches' />
+        <Flex justifyContent='space-between' alignItems='center'>
+          <Text translation='limitOrder.expiry' mr={4} />
+          <Menu isLazy>
+            <MenuButton as={Button} rightIcon={timePeriodRightIcon}>
+              <RawText>1 hour</RawText>
+            </MenuButton>
+            <MenuList zIndex='modal'>
+              <MenuOptionGroup type='radio' value={'1 hour'} onChange={noop}>
+                {renderedChains}
+              </MenuOptionGroup>
+            </MenuList>
+          </Menu>
+        </Flex>
+      </Flex>
+      {renderedBuyAmount}
+      {renderedAlternateBuyAmount}
+      <Flex justifyContent='space-between' my={4}>
+        <Button variant='ghost' size='sm' isActive>
+          Market
+        </Button>
+        <Button variant='ghost' size='sm'>
+          1% ↑
+        </Button>
+        <Button variant='ghost' size='sm'>
+          2% ↑
+        </Button>
+        <Button variant='ghost' size='sm'>
+          5% ↑
+        </Button>
+        <Button variant='ghost' size='sm'>
+          10% ↑
+        </Button>
+      </Flex>
+    </Stack>
+  )
+}

--- a/src/components/MultiHopTrade/components/LimitOrder/components/LimitOrderConfirm.tsx
+++ b/src/components/MultiHopTrade/components/LimitOrder/components/LimitOrderConfirm.tsx
@@ -1,16 +1,37 @@
-import { Button, Card, CardBody, CardFooter, CardHeader, Heading } from '@chakra-ui/react'
+import { InfoIcon } from '@chakra-ui/icons'
+import {
+  Button,
+  Card,
+  CardBody,
+  CardFooter,
+  CardHeader,
+  Heading,
+  HStack,
+  Link,
+  Stack,
+} from '@chakra-ui/react'
+import { SwapperName } from '@shapeshiftoss/swapper'
 import { useCallback } from 'react'
+import { useTranslate } from 'react-polyglot'
 import { useHistory } from 'react-router'
+import { ethereum, fox } from 'test/mocks/assets'
+import { Amount } from 'components/Amount/Amount'
+import { AssetToAssetCard } from 'components/AssetToAssetCard/AssetToAssetCard'
+import { Row } from 'components/Row/Row'
 import { SlideTransition } from 'components/SlideTransition'
-import { Text } from 'components/Text'
+import { RawText, Text } from 'components/Text'
+import { TransactionDate } from 'components/TransactionHistoryRows/TransactionDate'
 
+import { SwapperIcon } from '../../TradeInput/components/SwapperIcon/SwapperIcon'
 import { WithBackButton } from '../../WithBackButton'
 import { LimitOrderRoutePaths } from '../types'
 
-const cardBorderRadius = { base: 'xl' }
+const cardBorderRadius = { base: '2xl' }
+const learnMoreUrl = ''
 
 export const LimitOrderConfirm = () => {
   const history = useHistory()
+  const translate = useTranslate()
 
   const handleBack = useCallback(() => {
     history.push(LimitOrderRoutePaths.Input)
@@ -28,36 +49,103 @@ export const LimitOrderConfirm = () => {
         width='full'
         variant='dashboard'
         maxWidth='500px'
+        borderColor='border.base'
+        bg='background.surface.raised.base'
       >
-        <CardHeader px={6} pt={4}>
+        <CardHeader px={6} pt={4} borderWidth={0}>
           <WithBackButton onBack={handleBack}>
-            <Heading textAlign='center' fontSize='md'>
+            <Heading textAlign='center' fontSize='lg'>
               <Text translation='limitOrder.confirm' />
             </Heading>
           </WithBackButton>
         </CardHeader>
 
-        <CardBody py={0} px={0}>
-          <></>
+        <CardBody px={6} pt={0} pb={6}>
+          <AssetToAssetCard
+            sellAsset={ethereum}
+            buyAsset={fox}
+            sellAmountCryptoPrecision={'0.103123213'}
+            sellAmountUserCurrency={'123.42234'}
+            buyAmountCryptoPrecision={'123.412323452345412543'}
+            buyAmountUserCurrency={'123.234'}
+          />
         </CardBody>
         <CardFooter
           flexDir='column'
           gap={2}
           px={4}
-          borderTopWidth={1}
-          borderColor='border.base'
-          bg='background.surface.raised.base'
-          borderBottomRadius='md'
+          borderTopWidth={0}
+          bg='background.surface.raised.accent'
+          fontSize='sm'
+          borderBottomRadius={cardBorderRadius}
         >
-          <Button
-            colorScheme={'blue'}
-            size='lg'
-            width='full'
-            onClick={handleConfirm}
-            isLoading={false}
-          >
-            <Text translation={'limitOrder.placeOrder'} />
-          </Button>
+          <Stack spacing={4}>
+            <Row px={2}>
+              <Row.Label>
+                <Text translation='limitOrder.limitPrice' />
+              </Row.Label>
+              <Row.Value textAlign='right'>
+                <HStack>
+                  <Amount.Crypto value={'0.002134'} symbol={'WETH'} />
+                  <RawText>=</RawText>
+                  <Amount.Fiat fiatType='USD' value={'1'} />
+                </HStack>
+              </Row.Value>
+            </Row>
+            <Row px={2}>
+              <Row.Label>
+                <Text translation='limitOrder.provider' />
+              </Row.Label>
+              <Row.Value textAlign='right'>
+                <HStack>
+                  <SwapperIcon swapperName={SwapperName.Zrx} />
+                  <RawText>0x</RawText>
+                </HStack>
+              </Row.Value>
+            </Row>
+            <Row px={2}>
+              <Row.Label>
+                <Text translation='limitOrder.expiration' />
+              </Row.Label>
+              <TransactionDate blockTime={Date.now() / 1000} />
+            </Row>
+            <Row px={2}>
+              <Row.Label>
+                <Text translation='limitOrder.networkFee' />
+              </Row.Label>
+              <Amount.Crypto value={'0.0002134'} symbol={'ETH'} />
+            </Row>
+            <Card bg='background.surface.raised.pressed' borderRadius={6} p={4}>
+              <HStack>
+                <InfoIcon boxSize='1.3em' color='text.info' />
+                <RawText>
+                  {translate('limitOrder.confirmInfo')}{' '}
+                  <Button
+                    as={Link}
+                    href={learnMoreUrl}
+                    variant='link'
+                    colorScheme='blue'
+                    isExternal
+                    fontWeight='normal'
+                    height='auto'
+                    padding={0}
+                    verticalAlign='baseline'
+                  >
+                    <Text as='span' translation='limitOrder.learnMore' />
+                  </Button>
+                </RawText>
+              </HStack>
+            </Card>
+            <Button
+              colorScheme={'blue'}
+              size='lg'
+              width='full'
+              onClick={handleConfirm}
+              isLoading={false}
+            >
+              <Text translation={'limitOrder.placeOrder'} />
+            </Button>
+          </Stack>
         </CardFooter>
       </Card>
     </SlideTransition>

--- a/src/components/MultiHopTrade/components/LimitOrder/components/LimitOrderInput.tsx
+++ b/src/components/MultiHopTrade/components/LimitOrder/components/LimitOrderInput.tsx
@@ -28,7 +28,7 @@ import { useAppSelector } from 'state/store'
 
 import { SharedTradeInput } from '../../SharedTradeInput/SharedTradeInput'
 import { SharedTradeInputBody } from '../../SharedTradeInput/SharedTradeInputBody'
-import { SharedTradeInputFooter } from '../../SharedTradeInput/SharedTradeInputFooter'
+import { SharedTradeInputFooter } from '../../SharedTradeInput/SharedTradeInputFooter/SharedTradeInputFooter'
 import { LimitOrderRoutePaths } from '../types'
 import { LimitOrderBuyAsset } from './LimitOrderBuyAsset'
 import { LimitOrderConfig } from './LimitOrderConfig'

--- a/src/components/MultiHopTrade/components/LimitOrder/components/LimitOrderInput.tsx
+++ b/src/components/MultiHopTrade/components/LimitOrder/components/LimitOrderInput.tsx
@@ -23,7 +23,7 @@ import {
 import {
   selectActiveQuote,
   selectBuyAmountAfterFeesCryptoPrecision,
-  selectBuyAmountAfterFeesUserCurrency,
+  // selectBuyAmountAfterFeesUserCurrency,
   selectIsTradeQuoteRequestAborted,
   selectShouldShowTradeQuoteOrAwaitInput,
 } from 'state/slices/tradeQuoteSlice/selectors'
@@ -33,6 +33,7 @@ import { SharedTradeInput } from '../../SharedTradeInput/SharedTradeInput'
 import { SharedTradeInputBody } from '../../SharedTradeInput/SharedTradeInputBody'
 import { SharedTradeInputFooter } from '../../SharedTradeInput/SharedTradeInputFooter'
 import { LimitOrderRoutePaths } from '../types'
+import { LimitOrderBuyAsset } from './LimitOrderBuyAsset'
 
 const votingPowerParams: { feeModel: ParameterModel } = { feeModel: 'SWAPPER' }
 
@@ -63,8 +64,12 @@ export const LimitOrderInput = ({
   })
 
   // TODO: Don't use the trade account ID hook. This is temporary during scaffolding
-  const { sellAssetAccountId, buyAssetAccountId, setSellAssetAccountId, setBuyAssetAccountId } =
-    useAccountIds()
+  const {
+    sellAssetAccountId,
+    /* buyAssetAccountId, */
+    setSellAssetAccountId,
+    /* setBuyAssetAccountId */
+  } = useAccountIds()
 
   const [isInputtingFiatSellAmount, setIsInputtingFiatSellAmount] = useState(false)
   const [isConfirmationLoading, setIsConfirmationLoading] = useState(false)
@@ -72,7 +77,7 @@ export const LimitOrderInput = ({
   const [sellAmountCryptoPrecision, setSellAmountCryptoPrecision] = useState('0')
 
   const buyAmountAfterFeesCryptoPrecision = useAppSelector(selectBuyAmountAfterFeesCryptoPrecision)
-  const buyAmountAfterFeesUserCurrency = useAppSelector(selectBuyAmountAfterFeesUserCurrency)
+  // const buyAmountAfterFeesUserCurrency = useAppSelector(selectBuyAmountAfterFeesUserCurrency)
   const shouldShowTradeQuoteOrAwaitInput = useAppSelector(selectShouldShowTradeQuoteOrAwaitInput)
   const isSnapshotApiQueriesPending = useAppSelector(selectIsSnapshotApiQueriesPending)
   const isTradeQuoteRequestAborted = useAppSelector(selectIsTradeQuoteRequestAborted)
@@ -128,9 +133,9 @@ export const LimitOrderInput = ({
     return <></>
   }, [])
 
-  const setBuyAsset = useCallback((_asset: Asset) => {
-    // TODO: Implement me
-  }, [])
+  // const setBuyAsset = useCallback((_asset: Asset) => {
+  //   // TODO: Implement me
+  // }, [])
   const setSellAsset = useCallback((_asset: Asset) => {
     // TODO: Implement me
   }, [])
@@ -176,14 +181,9 @@ export const LimitOrderInput = ({
   const bodyContent = useMemo(() => {
     return (
       <SharedTradeInputBody
-        activeQuote={activeQuote}
-        buyAmountAfterFeesCryptoPrecision={buyAmountAfterFeesCryptoPrecision}
-        buyAmountAfterFeesUserCurrency={buyAmountAfterFeesUserCurrency}
         buyAsset={buyAsset}
-        buyAssetAccountId={buyAssetAccountId}
         isInputtingFiatSellAmount={isInputtingFiatSellAmount}
         isLoading={isLoading}
-        manualReceiveAddress={manualReceiveAddress}
         sellAmountCryptoPrecision={sellAmountCryptoPrecision}
         sellAmountUserCurrency={sellAmountUserCurrency}
         sellAsset={sellAsset}
@@ -191,28 +191,21 @@ export const LimitOrderInput = ({
         handleSwitchAssets={handleSwitchAssets}
         onChangeIsInputtingFiatSellAmount={setIsInputtingFiatSellAmount}
         onChangeSellAmountCryptoPrecision={setSellAmountCryptoPrecision}
-        setBuyAsset={setBuyAsset}
-        setBuyAssetAccountId={setBuyAssetAccountId}
         setSellAsset={setSellAsset}
         setSellAssetAccountId={setSellAssetAccountId}
-      />
+      >
+        <LimitOrderBuyAsset />
+      </SharedTradeInputBody>
     )
   }, [
-    activeQuote,
-    buyAmountAfterFeesCryptoPrecision,
-    buyAmountAfterFeesUserCurrency,
     buyAsset,
-    buyAssetAccountId,
     isInputtingFiatSellAmount,
     isLoading,
-    manualReceiveAddress,
     sellAmountCryptoPrecision,
     sellAmountUserCurrency,
     sellAsset,
     sellAssetAccountId,
     handleSwitchAssets,
-    setBuyAsset,
-    setBuyAssetAccountId,
     setSellAsset,
     setSellAssetAccountId,
   ])

--- a/src/components/MultiHopTrade/components/LimitOrder/components/LimitOrderInput.tsx
+++ b/src/components/MultiHopTrade/components/LimitOrder/components/LimitOrderInput.tsx
@@ -12,7 +12,6 @@ import { WarningAcknowledgement } from 'components/Acknowledgement/Acknowledgeme
 import { useAccountIds } from 'components/MultiHopTrade/hooks/useAccountIds'
 import { useReceiveAddress } from 'components/MultiHopTrade/hooks/useReceiveAddress'
 import { TradeInputTab } from 'components/MultiHopTrade/types'
-import { Text } from 'components/Text'
 import { WalletActions } from 'context/WalletProvider/actions'
 import { useErrorHandler } from 'hooks/useErrorToast/useErrorToast'
 import { useWallet } from 'hooks/useWallet/useWallet'
@@ -36,6 +35,7 @@ import { SharedTradeInputBody } from '../../SharedTradeInput/SharedTradeInputBod
 import { SharedTradeInputFooter } from '../../SharedTradeInput/SharedTradeInputFooter'
 import { LimitOrderRoutePaths } from '../types'
 import { LimitOrderBuyAsset } from './LimitOrderBuyAsset'
+import { LimitOrderConfig } from './LimitOrderConfig'
 
 const votingPowerParams: { feeModel: ParameterModel } = { feeModel: 'SWAPPER' }
 
@@ -201,7 +201,13 @@ export const LimitOrderInput = ({
             onSetBuyAsset={setBuyAsset}
           />
           <Divider />
-          <Text translation='limitOrder.whenPriceReaches' />
+          <LimitOrderConfig
+            buyAsset={buyAsset}
+            hasUserEnteredAmount={true}
+            isInputtingFiatSellAmount={isInputtingFiatSellAmount}
+            buyAmountAfterFeesCryptoPrecision={'1123412344123456'}
+            buyAmountAfterFeesUserCurrency={'1.234'}
+          />
         </Stack>
       </SharedTradeInputBody>
     )

--- a/src/components/MultiHopTrade/components/LimitOrder/components/LimitOrderInput.tsx
+++ b/src/components/MultiHopTrade/components/LimitOrder/components/LimitOrderInput.tsx
@@ -1,3 +1,4 @@
+import { Divider, Stack } from '@chakra-ui/react'
 import { isLedger } from '@shapeshiftoss/hdwallet-ledger'
 import { SwapperName } from '@shapeshiftoss/swapper'
 import type { Asset } from '@shapeshiftoss/types'
@@ -11,6 +12,7 @@ import { WarningAcknowledgement } from 'components/Acknowledgement/Acknowledgeme
 import { useAccountIds } from 'components/MultiHopTrade/hooks/useAccountIds'
 import { useReceiveAddress } from 'components/MultiHopTrade/hooks/useReceiveAddress'
 import { TradeInputTab } from 'components/MultiHopTrade/types'
+import { Text } from 'components/Text'
 import { WalletActions } from 'context/WalletProvider/actions'
 import { useErrorHandler } from 'hooks/useErrorToast/useErrorToast'
 import { useWallet } from 'hooks/useWallet/useWallet'
@@ -64,12 +66,8 @@ export const LimitOrderInput = ({
   })
 
   // TODO: Don't use the trade account ID hook. This is temporary during scaffolding
-  const {
-    sellAssetAccountId,
-    /* buyAssetAccountId, */
-    setSellAssetAccountId,
-    /* setBuyAssetAccountId */
-  } = useAccountIds()
+  const { sellAssetAccountId, buyAssetAccountId, setSellAssetAccountId, setBuyAssetAccountId } =
+    useAccountIds()
 
   const [isInputtingFiatSellAmount, setIsInputtingFiatSellAmount] = useState(false)
   const [isConfirmationLoading, setIsConfirmationLoading] = useState(false)
@@ -133,9 +131,9 @@ export const LimitOrderInput = ({
     return <></>
   }, [])
 
-  // const setBuyAsset = useCallback((_asset: Asset) => {
-  //   // TODO: Implement me
-  // }, [])
+  const setBuyAsset = useCallback((_asset: Asset) => {
+    // TODO: Implement me
+  }, [])
   const setSellAsset = useCallback((_asset: Asset) => {
     // TODO: Implement me
   }, [])
@@ -194,7 +192,17 @@ export const LimitOrderInput = ({
         setSellAsset={setSellAsset}
         setSellAssetAccountId={setSellAssetAccountId}
       >
-        <LimitOrderBuyAsset />
+        <Stack>
+          <LimitOrderBuyAsset
+            asset={buyAsset}
+            accountId={buyAssetAccountId}
+            isInputtingFiatSellAmount={isInputtingFiatSellAmount}
+            onAccountIdChange={setBuyAssetAccountId}
+            onSetBuyAsset={setBuyAsset}
+          />
+          <Divider />
+          <Text translation='limitOrder.whenPriceReaches' />
+        </Stack>
       </SharedTradeInputBody>
     )
   }, [
@@ -208,6 +216,9 @@ export const LimitOrderInput = ({
     handleSwitchAssets,
     setSellAsset,
     setSellAssetAccountId,
+    buyAssetAccountId,
+    setBuyAssetAccountId,
+    setBuyAsset,
   ])
 
   const footerContent = useMemo(() => {

--- a/src/components/MultiHopTrade/components/LimitOrder/components/LimitOrderInput.tsx
+++ b/src/components/MultiHopTrade/components/LimitOrder/components/LimitOrderInput.tsx
@@ -17,13 +17,9 @@ import { useErrorHandler } from 'hooks/useErrorToast/useErrorToast'
 import { useWallet } from 'hooks/useWallet/useWallet'
 import type { ParameterModel } from 'lib/fees/parameters/types'
 import { selectIsSnapshotApiQueriesPending, selectVotingPower } from 'state/apis/snapshot/selectors'
-import {
-  selectHasUserEnteredAmount,
-  selectIsAnyAccountMetadataLoadedForChainId,
-} from 'state/slices/selectors'
+import { selectIsAnyAccountMetadataLoadedForChainId } from 'state/slices/selectors'
 import {
   selectActiveQuote,
-  selectBuyAmountAfterFeesCryptoPrecision,
   // selectBuyAmountAfterFeesUserCurrency,
   selectIsTradeQuoteRequestAborted,
   selectShouldShowTradeQuoteOrAwaitInput,
@@ -73,13 +69,11 @@ export const LimitOrderInput = ({
   const [isConfirmationLoading, setIsConfirmationLoading] = useState(false)
   const [shouldShowWarningAcknowledgement, setShouldShowWarningAcknowledgement] = useState(false)
   const [sellAmountCryptoPrecision, setSellAmountCryptoPrecision] = useState('0')
-
-  const buyAmountAfterFeesCryptoPrecision = useAppSelector(selectBuyAmountAfterFeesCryptoPrecision)
   // const buyAmountAfterFeesUserCurrency = useAppSelector(selectBuyAmountAfterFeesUserCurrency)
   const shouldShowTradeQuoteOrAwaitInput = useAppSelector(selectShouldShowTradeQuoteOrAwaitInput)
   const isSnapshotApiQueriesPending = useAppSelector(selectIsSnapshotApiQueriesPending)
   const isTradeQuoteRequestAborted = useAppSelector(selectIsTradeQuoteRequestAborted)
-  const hasUserEnteredAmount = useAppSelector(selectHasUserEnteredAmount)
+  const hasUserEnteredAmount = true
   const votingPower = useAppSelector(state => selectVotingPower(state, votingPowerParams))
   const sellAsset = ethereum // TODO: Implement me
   const buyAsset = fox // TODO: Implement me
@@ -203,7 +197,7 @@ export const LimitOrderInput = ({
           <Divider />
           <LimitOrderConfig
             buyAsset={buyAsset}
-            hasUserEnteredAmount={true}
+            hasUserEnteredAmount={hasUserEnteredAmount}
             isInputtingFiatSellAmount={isInputtingFiatSellAmount}
             buyAmountAfterFeesCryptoPrecision={'1123412344123456'}
             buyAmountAfterFeesUserCurrency={'1.234'}
@@ -225,42 +219,37 @@ export const LimitOrderInput = ({
     buyAssetAccountId,
     setBuyAssetAccountId,
     setBuyAsset,
+    hasUserEnteredAmount,
   ])
 
   const footerContent = useMemo(() => {
     return (
       <SharedTradeInputFooter
-        isCompact={isCompact}
-        isLoading={isLoading}
-        receiveAddress={manualReceiveAddress ?? walletReceiveAddress}
-        inputAmountUsd={'12.34'}
         affiliateBps={'300'}
         affiliateFeeAfterDiscountUserCurrency={'0.01'}
-        quoteStatusTranslation={'trade.previewTrade'}
-        manualAddressEntryDescription={undefined}
-        onRateClick={noop}
-        shouldDisablePreviewButton={false}
-        isError={false}
-        shouldForceManualAddressEntry={false}
-        recipientAddressDescription={undefined}
-        priceImpactPercentage={undefined}
-        swapSource={SwapperName.CowSwap}
-        rate={activeQuote?.rate}
-        swapperName={SwapperName.CowSwap}
-        slippageDecimal={'0.01'}
-        buyAmountAfterFeesCryptoPrecision={buyAmountAfterFeesCryptoPrecision}
-        intermediaryTransactionOutputs={undefined}
         buyAsset={buyAsset}
         hasUserEnteredAmount={hasUserEnteredAmount}
-        totalProtocolFees={undefined}
+        inputAmountUsd={'12.34'}
+        isCompact={isCompact}
+        isError={false}
+        isLoading={isLoading}
+        manualAddressEntryDescription={undefined}
+        onRateClick={noop}
+        quoteStatusTranslation={'trade.previewTrade'}
+        rate={activeQuote?.rate}
+        receiveAddress={manualReceiveAddress ?? walletReceiveAddress}
+        recipientAddressDescription={undefined}
         sellAsset={sellAsset}
         sellAssetAccountId={sellAssetAccountId}
+        shouldDisablePreviewButton={false}
+        shouldForceManualAddressEntry={false}
+        swapperName={SwapperName.CowSwap}
+        swapSource={SwapperName.CowSwap}
         totalNetworkFeeFiatPrecision={'1.1234'}
       />
     )
   }, [
     activeQuote?.rate,
-    buyAmountAfterFeesCryptoPrecision,
     buyAsset,
     hasUserEnteredAmount,
     isCompact,

--- a/src/components/MultiHopTrade/components/LimitOrder/components/LimitOrderStatus.tsx
+++ b/src/components/MultiHopTrade/components/LimitOrder/components/LimitOrderStatus.tsx
@@ -1,17 +1,16 @@
-import { Button, Card, CardBody, CardFooter } from '@chakra-ui/react'
+import { Button, Card, CardBody, CardFooter, Link } from '@chakra-ui/react'
 import { TxStatus } from '@shapeshiftoss/unchained-client'
 import { useCallback, useMemo, useState } from 'react'
 import { useTranslate } from 'react-polyglot'
 import { useHistory } from 'react-router'
 import { ethereum } from 'test/mocks/assets'
-import { Amount } from 'components/Amount/Amount'
 import { SlideTransition } from 'components/SlideTransition'
 import { Text } from 'components/Text'
 
 import { StatusBody } from '../../StatusBody'
 import { LimitOrderRoutePaths } from '../types'
 
-const cardBorderRadius = { base: 'xl' }
+const cardBorderRadius = { base: '2xl' }
 
 const asset = ethereum
 
@@ -38,50 +37,40 @@ export const LimitOrderStatus = () => {
     }
   }, [history, txStatus])
 
-  const amountCryptoPrecision = '0.12420'
+  const handleGoBack = useCallback(() => {
+    history.push(LimitOrderRoutePaths.Input)
+  }, [history])
 
   const statusBody = useMemo(() => {
     if (!asset) return null
-    const renderedAmount = (() => {
+    const statusTranslation = (() => {
       switch (txStatus) {
-        case TxStatus.Pending: {
-          return (
-            <Amount.Crypto
-              prefix={translate('bridge.claimPending')}
-              value={amountCryptoPrecision}
-              symbol={asset.symbol}
-              color='text.subtle'
-            />
-          )
-        }
-        case TxStatus.Confirmed: {
-          return (
-            <Amount.Crypto
-              prefix={translate('bridge.claimSuccess')}
-              value={amountCryptoPrecision}
-              symbol={asset.symbol}
-              color='text.subtle'
-            />
-          )
-        }
-        case TxStatus.Failed: {
-          return (
-            <Amount.Crypto
-              prefix={translate('bridge.claimFailed')}
-              value={amountCryptoPrecision}
-              symbol={asset.symbol}
-              color='text.subtle'
-            />
-          )
-        }
+        case TxStatus.Confirmed:
+          return 'limitOrder.yourOrderHasBeenPlaced'
+        case TxStatus.Failed:
+        case TxStatus.Pending:
         case TxStatus.Unknown:
         default:
           return null
       }
     })()
 
-    return <StatusBody txStatus={txStatus}>{renderedAmount}</StatusBody>
-  }, [amountCryptoPrecision, translate, txStatus])
+    // TODO: get the actual tx link
+    const txLink = 'todo'
+
+    return (
+      <StatusBody txStatus={txStatus}>
+        <>
+          <Text translation={statusTranslation} color='text.subtle' />
+          {Boolean(txLink) && (
+            <Button as={Link} href={txLink} size='sm' variant='link' colorScheme='blue' isExternal>
+              {translate('limitOrder.viewOnChain')}
+            </Button>
+          )}
+        </>
+      </StatusBody>
+    )
+  }, [translate, txStatus])
 
   return (
     <SlideTransition>
@@ -91,25 +80,31 @@ export const LimitOrderStatus = () => {
         width='full'
         variant='dashboard'
         maxWidth='500px'
+        borderColor='border.base'
+        bg='background.surface.raised.base'
       >
         <CardBody py={32}>{statusBody}</CardBody>
-        <CardFooter
-          flexDir='column'
-          gap={2}
-          px={4}
-          borderTopWidth={1}
-          borderColor='border.base'
-          bg='background.surface.raised.base'
-          borderBottomRadius='md'
-        >
+        <CardFooter flexDir='row' gap={4} px={4} borderTopWidth={0}>
+          <Button
+            size='lg'
+            width='full'
+            onClick={handleGoBack}
+            variant='ghost'
+            aria-label='back'
+            isLoading={false}
+            isDisabled={txStatus === TxStatus.Pending}
+          >
+            <Text translation='common.goBack' />
+          </Button>
           <Button
             colorScheme={'blue'}
             size='lg'
             width='full'
             onClick={handleSignAndBroadcast}
             isLoading={false}
+            isDisabled={txStatus === TxStatus.Pending}
           >
-            <Text translation={'limitOrder.signTransaction'} />
+            <Text translation='limitOrder.viewOrder' />
           </Button>
         </CardFooter>
       </Card>

--- a/src/components/MultiHopTrade/components/LimitOrder/components/LimitOrderStatus.tsx
+++ b/src/components/MultiHopTrade/components/LimitOrder/components/LimitOrderStatus.tsx
@@ -1,6 +1,6 @@
 import { Button, Card, CardBody, CardFooter, Link } from '@chakra-ui/react'
 import { TxStatus } from '@shapeshiftoss/unchained-client'
-import { useCallback, useMemo, useState } from 'react'
+import { useCallback, useEffect, useMemo, useState } from 'react'
 import { useTranslate } from 'react-polyglot'
 import { useHistory } from 'react-router'
 import { ethereum } from 'test/mocks/assets'
@@ -18,6 +18,11 @@ export const LimitOrderStatus = () => {
   const history = useHistory()
   const translate = useTranslate()
   const [txStatus, setTxStatus] = useState(TxStatus.Pending)
+
+  // emulate tx executing
+  useEffect(() => {
+    setTimeout(() => setTxStatus(TxStatus.Confirmed), 3000)
+  }, [setTxStatus])
 
   const handleSignAndBroadcast = useCallback(() => {
     switch (txStatus) {

--- a/src/components/MultiHopTrade/components/PriceImpact.tsx
+++ b/src/components/MultiHopTrade/components/PriceImpact.tsx
@@ -1,5 +1,7 @@
+import type { BigNumber } from '@shapeshiftoss/utils'
+import { bnOrZero } from '@shapeshiftoss/utils'
 import type { FC } from 'react'
-import { useCallback } from 'react'
+import { useCallback, useMemo } from 'react'
 import { useTranslate } from 'react-polyglot'
 import { Row } from 'components/Row/Row'
 import { RawText, Text } from 'components/Text'
@@ -7,11 +9,18 @@ import { RawText, Text } from 'components/Text'
 import { usePriceImpactColor } from '../hooks/usePriceImpactColor'
 
 interface PriceImpactProps {
-  priceImpactPercentage: string
+  priceImpactPercentage: BigNumber | undefined
 }
 
-export const PriceImpact: FC<PriceImpactProps> = ({ priceImpactPercentage }) => {
+export const PriceImpact: FC<PriceImpactProps> = ({
+  priceImpactPercentage: priceImpactPercentageBn,
+}) => {
   const translate = useTranslate()
+
+  const priceImpactPercentage = useMemo(
+    () => bnOrZero(priceImpactPercentageBn).toFixed(2),
+    [priceImpactPercentageBn],
+  )
 
   const priceImpactColor = usePriceImpactColor(priceImpactPercentage)
 

--- a/src/components/MultiHopTrade/components/SharedTradeInput/SharedTradeInputFooter.tsx
+++ b/src/components/MultiHopTrade/components/SharedTradeInput/SharedTradeInputFooter.tsx
@@ -1,13 +1,6 @@
 import { CardFooter, useMediaQuery } from '@chakra-ui/react'
-import type { AssetId } from '@shapeshiftoss/caip'
-import type {
-  AmountDisplayMeta,
-  ProtocolFee,
-  SwapperName,
-  SwapSource,
-} from '@shapeshiftoss/swapper'
+import type { SwapperName, SwapSource } from '@shapeshiftoss/swapper'
 import type { Asset } from '@shapeshiftoss/types'
-import type { BigNumber } from '@shapeshiftoss/utils'
 import type { InterpolationOptions } from 'node-polyglot'
 import { useMemo } from 'react'
 import { ButtonWalletPredicate } from 'components/ButtonWalletPredicate/ButtonWalletPredicate'
@@ -28,17 +21,14 @@ import { ManualAddressEntry } from '../TradeInput/components/ManualAddressEntry'
 type SharedTradeInputFooterProps = {
   affiliateBps: string | undefined
   affiliateFeeAfterDiscountUserCurrency: string | undefined
-  buyAmountAfterFeesCryptoPrecision: string | undefined
   buyAsset: Asset
   children?: JSX.Element
   hasUserEnteredAmount: boolean
   inputAmountUsd: string | undefined
-  intermediaryTransactionOutputs: AmountDisplayMeta[] | undefined
   isCompact: boolean | undefined
   isError: boolean
   isLoading: boolean
   manualAddressEntryDescription: string | undefined
-  priceImpactPercentage: BigNumber | undefined
   quoteStatusTranslation: string | [string, InterpolationOptions]
   rate: string | undefined
   receiveAddress: string | undefined
@@ -47,28 +37,24 @@ type SharedTradeInputFooterProps = {
   sellAssetAccountId: string | undefined
   shouldDisablePreviewButton: boolean | undefined
   shouldForceManualAddressEntry: boolean
-  slippageDecimal: string
   swapperName: SwapperName | undefined
   swapSource: SwapSource | undefined
   totalNetworkFeeFiatPrecision: string
-  totalProtocolFees: Record<AssetId, ProtocolFee> | undefined
+  receiveSummaryDetails?: JSX.Element | null
   onRateClick: () => void
 }
 
 export const SharedTradeInputFooter = ({
   affiliateBps,
   affiliateFeeAfterDiscountUserCurrency,
-  buyAmountAfterFeesCryptoPrecision,
   buyAsset,
   children,
   hasUserEnteredAmount,
   inputAmountUsd,
-  intermediaryTransactionOutputs,
   isCompact,
   isError,
   isLoading: isParentLoading,
   manualAddressEntryDescription,
-  priceImpactPercentage,
   quoteStatusTranslation,
   rate,
   receiveAddress,
@@ -77,11 +63,10 @@ export const SharedTradeInputFooter = ({
   sellAssetAccountId,
   shouldDisablePreviewButton: parentShouldDisablePreviewButton,
   shouldForceManualAddressEntry,
-  slippageDecimal,
   swapperName,
   swapSource,
   totalNetworkFeeFiatPrecision,
-  totalProtocolFees,
+  receiveSummaryDetails,
   onRateClick,
 }: SharedTradeInputFooterProps) => {
   const [isSmallerThanXl] = useMediaQuery(`(max-width: ${breakpoints.xl})`, { ssr: false })
@@ -160,19 +145,13 @@ export const SharedTradeInputFooter = ({
           >
             <ReceiveSummary
               isLoading={isLoading}
-              symbol={buyAsset.symbol}
-              amountCryptoPrecision={buyAmountAfterFeesCryptoPrecision ?? '0'}
-              protocolFees={totalProtocolFees}
-              slippageDecimalPercentage={slippageDecimal}
               swapperName={swapperName ?? ''}
-              defaultIsOpen={true}
-              swapSource={swapSource}
-              priceImpact={priceImpactPercentage}
               inputAmountUsd={inputAmountUsd}
               affiliateBps={affiliateBps}
               affiliateFeeAfterDiscountUserCurrency={affiliateFeeAfterDiscountUserCurrency}
-              intermediaryTransactionOutputs={intermediaryTransactionOutputs}
-            />
+            >
+              {receiveSummaryDetails}
+            </ReceiveSummary>
           </RateGasRow>
         )}
       </CardFooter>

--- a/src/components/MultiHopTrade/components/SharedTradeInput/SharedTradeInputFooter/SharedTradeInputFooter.tsx
+++ b/src/components/MultiHopTrade/components/SharedTradeInput/SharedTradeInputFooter/SharedTradeInputFooter.tsx
@@ -5,7 +5,6 @@ import type { InterpolationOptions } from 'node-polyglot'
 import { useMemo } from 'react'
 import { ButtonWalletPredicate } from 'components/ButtonWalletPredicate/ButtonWalletPredicate'
 import { RateGasRow } from 'components/MultiHopTrade/components/RateGasRow'
-import { ReceiveSummary } from 'components/MultiHopTrade/components/TradeInput/components/ReceiveSummary'
 import { RecipientAddress } from 'components/MultiHopTrade/components/TradeInput/components/RecipientAddress'
 import { WithLazyMount } from 'components/MultiHopTrade/components/TradeInput/components/WithLazyMount'
 import { Text } from 'components/Text'
@@ -16,7 +15,8 @@ import { selectFeeAssetById } from 'state/slices/selectors'
 import { useAppSelector } from 'state/store'
 import { breakpoints } from 'theme/theme'
 
-import { ManualAddressEntry } from '../TradeInput/components/ManualAddressEntry'
+import { ManualAddressEntry } from '../../TradeInput/components/ManualAddressEntry'
+import { ReceiveSummary } from './components/ReceiveSummary'
 
 type SharedTradeInputFooterProps = {
   affiliateBps: string | undefined

--- a/src/components/MultiHopTrade/components/SharedTradeInput/SharedTradeInputFooter/SharedTradeInputFooter.tsx
+++ b/src/components/MultiHopTrade/components/SharedTradeInput/SharedTradeInputFooter/SharedTradeInputFooter.tsx
@@ -145,7 +145,8 @@ export const SharedTradeInputFooter = ({
           >
             <ReceiveSummary
               isLoading={isLoading}
-              swapperName={swapperName ?? ''}
+              swapperName={swapperName}
+              swapSource={swapSource}
               inputAmountUsd={inputAmountUsd}
               affiliateBps={affiliateBps}
               affiliateFeeAfterDiscountUserCurrency={affiliateFeeAfterDiscountUserCurrency}

--- a/src/components/MultiHopTrade/components/SharedTradeInput/SharedTradeInputFooter/components/ReceiveSummary.tsx
+++ b/src/components/MultiHopTrade/components/SharedTradeInput/SharedTradeInputFooter/components/ReceiveSummary.tsx
@@ -9,7 +9,7 @@ import { Row, type RowProps } from 'components/Row/Row'
 import { RawText, Text } from 'components/Text'
 import type { TextPropTypes } from 'components/Text/Text'
 
-import { SwapperIcon } from './SwapperIcon/SwapperIcon'
+import { SwapperIcon } from '../../../TradeInput/components/SwapperIcon/SwapperIcon'
 
 type ReceiveSummaryProps = {
   isLoading?: boolean

--- a/src/components/MultiHopTrade/components/SharedTradeInput/SharedTradeInputFooter/components/ReceiveSummary.tsx
+++ b/src/components/MultiHopTrade/components/SharedTradeInput/SharedTradeInputFooter/components/ReceiveSummary.tsx
@@ -1,6 +1,6 @@
 import { QuestionIcon } from '@chakra-ui/icons'
 import { Flex, Stack, useColorModeValue } from '@chakra-ui/react'
-import type { SwapperName } from '@shapeshiftoss/swapper'
+import type { SwapperName, SwapSource } from '@shapeshiftoss/swapper'
 import { type FC, memo, useCallback, useState } from 'react'
 import { useTranslate } from 'react-polyglot'
 import { Amount } from 'components/Amount/Amount'
@@ -13,7 +13,8 @@ import { SwapperIcon } from '../../../TradeInput/components/SwapperIcon/SwapperI
 
 type ReceiveSummaryProps = {
   isLoading?: boolean
-  swapperName: string
+  swapperName: SwapperName | undefined
+  swapSource: SwapSource | undefined
   inputAmountUsd?: string
   affiliateBps?: string
   affiliateFeeAfterDiscountUserCurrency?: string
@@ -30,6 +31,7 @@ const tradeFeeSourceTranslation: TextPropTypes['translation'] = [
 export const ReceiveSummary: FC<ReceiveSummaryProps> = memo(
   ({
     swapperName,
+    swapSource,
     isLoading,
     inputAmountUsd,
     affiliateBps,
@@ -54,10 +56,12 @@ export const ReceiveSummary: FC<ReceiveSummaryProps> = memo(
               {translate('trade.protocol')}
             </Row.Label>
             <Row.Value display='flex' gap={2} alignItems='center'>
-              <SwapperIcon size='2xs' swapperName={swapperName as SwapperName} />
-              <RawText fontWeight='semibold' color={textColor}>
-                {swapSource}
-              </RawText>
+              {swapperName !== undefined && <SwapperIcon size='2xs' swapperName={swapperName} />}
+              {swapSource !== undefined && (
+                <RawText fontWeight='semibold' color={textColor}>
+                  {swapSource}
+                </RawText>
+              )}
             </Row.Value>
           </Row>
 

--- a/src/components/MultiHopTrade/components/TradeInput/components/ConfirmSummary.tsx
+++ b/src/components/MultiHopTrade/components/TradeInput/components/ConfirmSummary.tsx
@@ -1,16 +1,20 @@
-import { Alert, AlertIcon, useMediaQuery } from '@chakra-ui/react'
+import { Alert, AlertIcon, Divider, useColorModeValue, useMediaQuery } from '@chakra-ui/react'
 import { isEvmChainId } from '@shapeshiftoss/chain-adapters'
+import type { AmountDisplayMeta } from '@shapeshiftoss/swapper'
 import { SwapperName } from '@shapeshiftoss/swapper'
-import { isUtxoChainId } from '@shapeshiftoss/utils'
+import { bnOrZero, fromBaseUnit, isSome, isUtxoChainId } from '@shapeshiftoss/utils'
 import type { InterpolationOptions } from 'node-polyglot'
 import { useCallback, useMemo } from 'react'
 import { useTranslate } from 'react-polyglot'
 import { useHistory } from 'react-router'
+import { Amount } from 'components/Amount/Amount'
 import { usePriceImpact } from 'components/MultiHopTrade/hooks/quoteValidation/usePriceImpact'
 import { useAccountIds } from 'components/MultiHopTrade/hooks/useAccountIds'
 import { TradeRoutePaths } from 'components/MultiHopTrade/types'
+import { Row } from 'components/Row/Row'
 import { Text } from 'components/Text'
 import { useAccountsFetchQuery } from 'context/AppProvider/hooks/useAccountsFetchQuery'
+import { getChainAdapterManager } from 'context/PluginProvider/chainAdapterSingleton'
 import { useIsSmartContractAddress } from 'hooks/useIsSmartContractAddress/useIsSmartContractAddress'
 import { useWallet } from 'hooks/useWallet/useWallet'
 import { isToken } from 'lib/utils'
@@ -45,14 +49,20 @@ import {
 import { useAppSelector } from 'state/store'
 import { breakpoints } from 'theme/theme'
 
+import { PriceImpact } from '../../PriceImpact'
 import { SharedTradeInputFooter } from '../../SharedTradeInput/SharedTradeInputFooter'
 import { getQuoteErrorTranslation } from '../getQuoteErrorTranslation'
 import { getQuoteRequestErrorTranslation } from '../getQuoteRequestErrorTranslation'
+import { MaxSlippage } from './MaxSlippage'
 
 type ConfirmSummaryProps = {
   isCompact: boolean | undefined
   isLoading: boolean
   receiveAddress: string | undefined
+}
+
+const ProtocolFeeToolTip = () => {
+  return <Text color='text.subtle' translation={'trade.tooltip.protocolFee'} />
 }
 
 export const ConfirmSummary = ({
@@ -62,6 +72,7 @@ export const ConfirmSummary = ({
 }: ConfirmSummaryProps) => {
   const history = useHistory()
   const translate = useTranslate()
+  const redColor = useColorModeValue('red.500', 'red.300')
   const [isSmallerThanXl] = useMediaQuery(`(max-width: ${breakpoints.xl})`, { ssr: false })
   const {
     state: { isConnected, isDemoWallet },
@@ -72,7 +83,7 @@ export const ConfirmSummary = ({
   const manualReceiveAddressIsValidating = useAppSelector(selectManualReceiveAddressIsValidating)
   const manualReceiveAddressIsEditing = useAppSelector(selectManualReceiveAddressIsEditing)
   const manualReceiveAddressIsValid = useAppSelector(selectManualReceiveAddressIsValid)
-  const slippageDecimal = useAppSelector(selectTradeSlippagePercentageDecimal)
+  const slippagePercentageDecimal = useAppSelector(selectTradeSlippagePercentageDecimal)
   const totalProtocolFees = useAppSelector(selectTotalProtocolFeeByAsset)
   const activeQuoteErrors = useAppSelector(selectActiveQuoteErrors)
   const quoteRequestErrors = useAppSelector(selectTradeQuoteRequestErrors)
@@ -258,6 +269,78 @@ export const ConfirmSummary = ({
     return isParentLoading || isReceiveAddressByteCodeLoading
   }, [isReceiveAddressByteCodeLoading, isParentLoading])
 
+  const receiveSummaryDetails = useMemo(() => {
+    const parseAmountDisplayMeta = (items: AmountDisplayMeta[]) => {
+      return items
+        .filter(({ amountCryptoBaseUnit }) => bnOrZero(amountCryptoBaseUnit).gt(0))
+        .map(({ amountCryptoBaseUnit, asset }: AmountDisplayMeta) => ({
+          symbol: asset.symbol,
+          chainName: getChainAdapterManager().get(asset.chainId)?.getDisplayName(),
+          amountCryptoPrecision: fromBaseUnit(amountCryptoBaseUnit, asset.precision),
+        }))
+    }
+
+    const protocolFeesParsed = totalProtocolFees
+      ? parseAmountDisplayMeta(Object.values(totalProtocolFees).filter(isSome))
+      : undefined
+
+    const intermediaryTransactionOutputs = tradeQuoteStep?.intermediaryTransactionOutputs
+
+    const intermediaryTransactionOutputsParsed = intermediaryTransactionOutputs
+      ? parseAmountDisplayMeta(intermediaryTransactionOutputs)
+      : undefined
+
+    const hasProtocolFees = protocolFeesParsed && protocolFeesParsed.length > 0
+
+    const hasIntermediaryTransactionOutputs =
+      intermediaryTransactionOutputsParsed && intermediaryTransactionOutputsParsed.length > 0
+
+    return (
+      <>
+        <MaxSlippage
+          swapSource={tradeQuoteStep?.source}
+          isLoading={isLoading}
+          symbol={buyAsset.symbol}
+          amountCryptoPrecision={buyAmountAfterFeesCryptoPrecision ?? '0'}
+          slippagePercentageDecimal={slippagePercentageDecimal}
+          hasIntermediaryTransactionOutputs={hasIntermediaryTransactionOutputs}
+          intermediaryTransactionOutputs={intermediaryTransactionOutputs}
+        />
+
+        {priceImpactPercentage && <PriceImpact priceImpactPercentage={priceImpactPercentage} />}
+        <Divider borderColor='border.base' />
+
+        {hasProtocolFees && (
+          <Row Tooltipbody={ProtocolFeeToolTip} isLoading={isLoading}>
+            <Row.Label>
+              <Text translation='trade.protocolFee' />
+            </Row.Label>
+            <Row.Value color='text.base'>
+              {protocolFeesParsed?.map(({ amountCryptoPrecision, symbol }) => (
+                <Amount.Crypto
+                  key={`${amountCryptoPrecision}`}
+                  color={redColor}
+                  value={amountCryptoPrecision}
+                  symbol={symbol}
+                />
+              ))}
+            </Row.Value>
+          </Row>
+        )}
+      </>
+    )
+  }, [
+    buyAmountAfterFeesCryptoPrecision,
+    buyAsset.symbol,
+    isLoading,
+    priceImpactPercentage,
+    redColor,
+    slippagePercentageDecimal,
+    totalProtocolFees,
+    tradeQuoteStep?.intermediaryTransactionOutputs,
+    tradeQuoteStep?.source,
+  ])
+
   return (
     <SharedTradeInputFooter
       isCompact={isCompact}
@@ -275,19 +358,15 @@ export const ConfirmSummary = ({
       recipientAddressDescription={
         disableThorTaprootReceiveAddress ? translate('trade.disableThorTaprootReceive') : undefined
       }
-      priceImpactPercentage={priceImpactPercentage}
       swapSource={tradeQuoteStep?.source}
       rate={activeQuote?.rate}
       swapperName={activeSwapperName}
-      slippageDecimal={slippageDecimal}
-      buyAmountAfterFeesCryptoPrecision={buyAmountAfterFeesCryptoPrecision}
-      intermediaryTransactionOutputs={tradeQuoteStep?.intermediaryTransactionOutputs}
       buyAsset={buyAsset}
       hasUserEnteredAmount={hasUserEnteredAmount}
-      totalProtocolFees={totalProtocolFees}
       sellAsset={sellAsset}
       sellAssetAccountId={sellAssetAccountId}
       totalNetworkFeeFiatPrecision={totalNetworkFeeFiatPrecision}
+      receiveSummaryDetails={receiveSummaryDetails}
     >
       {nativeAssetBridgeWarning ? (
         <Alert status='info' borderRadius='lg'>

--- a/src/components/MultiHopTrade/components/TradeInput/components/ConfirmSummary.tsx
+++ b/src/components/MultiHopTrade/components/TradeInput/components/ConfirmSummary.tsx
@@ -50,7 +50,7 @@ import { useAppSelector } from 'state/store'
 import { breakpoints } from 'theme/theme'
 
 import { PriceImpact } from '../../PriceImpact'
-import { SharedTradeInputFooter } from '../../SharedTradeInput/SharedTradeInputFooter'
+import { SharedTradeInputFooter } from '../../SharedTradeInput/SharedTradeInputFooter/SharedTradeInputFooter'
 import { getQuoteErrorTranslation } from '../getQuoteErrorTranslation'
 import { getQuoteRequestErrorTranslation } from '../getQuoteRequestErrorTranslation'
 import { MaxSlippage } from './MaxSlippage'

--- a/src/components/MultiHopTrade/components/TradeInput/components/MaxSlippage.tsx
+++ b/src/components/MultiHopTrade/components/TradeInput/components/MaxSlippage.tsx
@@ -26,7 +26,7 @@ type MaxSlippageProps = {
   swapSource?: SwapSource
   isLoading?: boolean
   amountCryptoPrecision: string
-  slippageDecimalPercentage: string
+  slippagePercentageDecimal: string
   hasIntermediaryTransactionOutputs?: boolean
   intermediaryTransactionOutputs?: AmountDisplayMeta[]
   symbol: string
@@ -36,7 +36,7 @@ export const MaxSlippage: React.FC<MaxSlippageProps> = ({
   swapSource,
   isLoading,
   amountCryptoPrecision,
-  slippageDecimalPercentage,
+  slippagePercentageDecimal,
   hasIntermediaryTransactionOutputs,
   intermediaryTransactionOutputs,
   symbol,
@@ -52,7 +52,7 @@ export const MaxSlippage: React.FC<MaxSlippageProps> = ({
     [swapSource],
   )
   const userSlippagePercentage = useAppSelector(selectUserSlippagePercentage)
-  const slippageAsPercentageString = bnOrZero(slippageDecimalPercentage).times(100).toString()
+  const slippageAsPercentageString = bnOrZero(slippagePercentageDecimal).times(100).toString()
   const isAmountPositive = bnOrZero(amountCryptoPrecision).gt(0)
 
   const renderSlippageTag = useMemo(() => {
@@ -72,9 +72,9 @@ export const MaxSlippage: React.FC<MaxSlippageProps> = ({
   }, [slippageAsPercentageString, translate, userSlippagePercentage])
 
   const amountAfterSlippage = useMemo(() => {
-    const slippageBps = convertDecimalPercentageToBasisPoints(slippageDecimalPercentage)
+    const slippageBps = convertDecimalPercentageToBasisPoints(slippagePercentageDecimal)
     return isAmountPositive ? subtractBasisPointAmount(amountCryptoPrecision, slippageBps) : '0'
-  }, [amountCryptoPrecision, isAmountPositive, slippageDecimalPercentage])
+  }, [amountCryptoPrecision, isAmountPositive, slippagePercentageDecimal])
 
   const formattedCryptoAmount = useMemo(
     () => toCrypto(amountAfterSlippage, symbol),

--- a/src/components/MultiHopTrade/components/TradeInput/components/ReceiveSummary.tsx
+++ b/src/components/MultiHopTrade/components/TradeInput/components/ReceiveSummary.tsx
@@ -1,44 +1,23 @@
 import { QuestionIcon } from '@chakra-ui/icons'
-import { Divider, Flex, Stack, useColorModeValue } from '@chakra-ui/react'
-import { type AssetId } from '@shapeshiftoss/caip'
-import type {
-  AmountDisplayMeta,
-  ProtocolFee,
-  SwapperName,
-  SwapSource,
-} from '@shapeshiftoss/swapper'
-import type { PartialRecord } from '@shapeshiftoss/types'
-import { type FC, memo, useCallback, useMemo, useState } from 'react'
+import { Flex, Stack, useColorModeValue } from '@chakra-ui/react'
+import type { SwapperName } from '@shapeshiftoss/swapper'
+import { type FC, memo, useCallback, useState } from 'react'
 import { useTranslate } from 'react-polyglot'
 import { Amount } from 'components/Amount/Amount'
 import { FeeModal } from 'components/FeeModal/FeeModal'
 import { Row, type RowProps } from 'components/Row/Row'
 import { RawText, Text } from 'components/Text'
 import type { TextPropTypes } from 'components/Text/Text'
-import { getChainAdapterManager } from 'context/PluginProvider/chainAdapterSingleton'
-import type { BigNumber } from 'lib/bignumber/bignumber'
-import { bnOrZero } from 'lib/bignumber/bignumber'
-import { fromBaseUnit } from 'lib/math'
-import { isSome } from 'lib/utils'
 
-import { PriceImpact } from '../../PriceImpact'
-import { MaxSlippage } from './MaxSlippage'
 import { SwapperIcon } from './SwapperIcon/SwapperIcon'
 
 type ReceiveSummaryProps = {
   isLoading?: boolean
-  symbol: string
-  amountCryptoPrecision: string
-  intermediaryTransactionOutputs: AmountDisplayMeta[] | undefined
-  protocolFees: PartialRecord<AssetId, ProtocolFee> | undefined
-  slippageDecimalPercentage: string
   swapperName: string
-  defaultIsOpen?: boolean
-  swapSource: SwapSource | undefined
-  priceImpact: BigNumber.Value | undefined
-  inputAmountUsd: string | undefined
-  affiliateBps: string | undefined
-  affiliateFeeAfterDiscountUserCurrency: string | undefined
+  inputAmountUsd?: string
+  affiliateBps?: string
+  affiliateFeeAfterDiscountUserCurrency?: string
+  children?: JSX.Element | null
 } & RowProps
 
 const shapeShiftFeeModalRowHover = { textDecoration: 'underline', cursor: 'pointer' }
@@ -50,68 +29,22 @@ const tradeFeeSourceTranslation: TextPropTypes['translation'] = [
 
 export const ReceiveSummary: FC<ReceiveSummaryProps> = memo(
   ({
-    symbol,
-    amountCryptoPrecision,
-    intermediaryTransactionOutputs,
-    protocolFees,
-    slippageDecimalPercentage,
     swapperName,
     isLoading,
-    swapSource,
-    priceImpact,
     inputAmountUsd,
     affiliateBps,
     affiliateFeeAfterDiscountUserCurrency,
+    children,
   }) => {
     const translate = useTranslate()
     const [showFeeModal, setShowFeeModal] = useState(false)
-    const redColor = useColorModeValue('red.500', 'red.300')
+
     const greenColor = useColorModeValue('green.600', 'green.200')
     const textColor = useColorModeValue('gray.800', 'whiteAlpha.900')
-
-    const parseAmountDisplayMeta = useCallback((items: AmountDisplayMeta[]) => {
-      return items
-        .filter(({ amountCryptoBaseUnit }) => bnOrZero(amountCryptoBaseUnit).gt(0))
-        .map(({ amountCryptoBaseUnit, asset }: AmountDisplayMeta) => ({
-          symbol: asset.symbol,
-          chainName: getChainAdapterManager().get(asset.chainId)?.getDisplayName(),
-          amountCryptoPrecision: fromBaseUnit(amountCryptoBaseUnit, asset.precision),
-        }))
-    }, [])
-
-    const protocolFeesParsed = useMemo(
-      () =>
-        protocolFees
-          ? parseAmountDisplayMeta(Object.values(protocolFees).filter(isSome))
-          : undefined,
-      [protocolFees, parseAmountDisplayMeta],
-    )
-
-    const intermediaryTransactionOutputsParsed = useMemo(
-      () =>
-        intermediaryTransactionOutputs
-          ? parseAmountDisplayMeta(intermediaryTransactionOutputs)
-          : undefined,
-      [intermediaryTransactionOutputs, parseAmountDisplayMeta],
-    )
-
-    const hasProtocolFees = useMemo(
-      () => protocolFeesParsed && protocolFeesParsed.length > 0,
-      [protocolFeesParsed],
-    )
-
-    const hasIntermediaryTransactionOutputs = useMemo(
-      () => intermediaryTransactionOutputsParsed && intermediaryTransactionOutputsParsed.length > 0,
-      [intermediaryTransactionOutputsParsed],
-    )
 
     const toggleFeeModal = useCallback(() => {
       setShowFeeModal(!showFeeModal)
     }, [showFeeModal])
-
-    const protocolFeeToolTip = useCallback(() => {
-      return <Text color='text.subtle' translation={'trade.tooltip.protocolFee'} />
-    }, [])
 
     return (
       <>
@@ -128,36 +61,8 @@ export const ReceiveSummary: FC<ReceiveSummaryProps> = memo(
             </Row.Value>
           </Row>
 
-          <MaxSlippage
-            swapSource={swapSource}
-            isLoading={isLoading}
-            symbol={symbol}
-            amountCryptoPrecision={amountCryptoPrecision}
-            slippageDecimalPercentage={slippageDecimalPercentage}
-            hasIntermediaryTransactionOutputs={hasIntermediaryTransactionOutputs}
-            intermediaryTransactionOutputs={intermediaryTransactionOutputs}
-          />
+          {children}
 
-          {priceImpact && <PriceImpact priceImpactPercentage={bnOrZero(priceImpact).toFixed(2)} />}
-          <Divider borderColor='border.base' />
-
-          {hasProtocolFees && (
-            <Row Tooltipbody={protocolFeeToolTip} isLoading={isLoading}>
-              <Row.Label>
-                <Text translation='trade.protocolFee' />
-              </Row.Label>
-              <Row.Value color='text.base'>
-                {protocolFeesParsed?.map(({ amountCryptoPrecision, symbol }) => (
-                  <Amount.Crypto
-                    key={`${amountCryptoPrecision}`}
-                    color={redColor}
-                    value={amountCryptoPrecision}
-                    symbol={symbol}
-                  />
-                ))}
-              </Row.Value>
-            </Row>
-          )}
           <Row isLoading={isLoading}>
             <Row.Label display='flex'>
               <Text translation={tradeFeeSourceTranslation} />

--- a/src/pages/RFOX/components/Stake/Bridge/BridgeConfirm.tsx
+++ b/src/pages/RFOX/components/Stake/Bridge/BridgeConfirm.tsx
@@ -1,7 +1,6 @@
 import { ArrowBackIcon } from '@chakra-ui/icons'
 import {
   Button,
-  Card,
   CardBody,
   CardFooter,
   CardHeader,
@@ -15,8 +14,7 @@ import { type FC, useCallback, useMemo } from 'react'
 import { useTranslate } from 'react-polyglot'
 import { useHistory } from 'react-router'
 import { Amount } from 'components/Amount/Amount'
-import { AssetIcon } from 'components/AssetIcon'
-import { FormDivider } from 'components/FormDivider'
+import { AssetToAssetCard } from 'components/AssetToAssetCard/AssetToAssetCard'
 import { getChainShortName } from 'components/MultiHopTrade/components/MultiHopTradeConfirm/utils/getChainShortName'
 import { Row, type RowProps } from 'components/Row/Row'
 import { SlideTransition } from 'components/SlideTransition'
@@ -115,39 +113,6 @@ export const BridgeConfirm: FC<BridgeRouteProps & BridgeConfirmProps> = ({ confi
     history.push({ pathname: BridgeRoutePaths.Status, state: confirmedQuote })
   }, [confirmedQuote, history, feeAsset, handleApprove, isApprovalRequired])
 
-  const bridgeCard = useMemo(() => {
-    if (!(sellAsset && buyAsset)) return null
-    return (
-      <>
-        <Card
-          display='flex'
-          alignItems='stretch'
-          justifyContent='space-evenly'
-          flexDir='row'
-          gap={4}
-          py={6}
-          px={4}
-        >
-          <Stack alignItems='center'>
-            <AssetIcon size='sm' assetId={sellAsset?.assetId} />
-            <Stack textAlign='center' spacing={0}>
-              <Amount.Crypto value={bridgeAmountCryptoPrecision} symbol={sellAsset.symbol} />
-              <Amount.Fiat fontSize='sm' color='text.subtle' value={bridgeAmountUserCurrency} />
-            </Stack>
-          </Stack>
-          <FormDivider my={-6} orientation='vertical' />
-          <Stack alignItems='center'>
-            <AssetIcon size='sm' assetId={buyAsset?.assetId} />
-            <Stack textAlign='center' spacing={0}>
-              <Amount.Crypto value={bridgeAmountCryptoPrecision} symbol={buyAsset.symbol} />
-              <Amount.Fiat fontSize='sm' color='text.subtle' value={bridgeAmountUserCurrency} />
-            </Stack>
-          </Stack>
-        </Card>
-      </>
-    )
-  }, [sellAsset, buyAsset, bridgeAmountCryptoPrecision, bridgeAmountUserCurrency])
-
   const errorCopy = useMemo(() => {
     if (!hasEnoughFeeBalance)
       return translate('common.insufficientAmountForGas', {
@@ -173,7 +138,14 @@ export const BridgeConfirm: FC<BridgeRouteProps & BridgeConfirmProps> = ({ confi
       </CardHeader>
       <CardBody>
         <Stack spacing={6}>
-          {bridgeCard}
+          <AssetToAssetCard
+            sellAsset={sellAsset}
+            buyAsset={buyAsset}
+            sellAmountCryptoPrecision={bridgeAmountCryptoPrecision}
+            sellAmountUserCurrency={bridgeAmountUserCurrency}
+            buyAmountCryptoPrecision={bridgeAmountCryptoPrecision}
+            buyAmountUserCurrency={bridgeAmountUserCurrency}
+          />
           <Timeline>
             <TimelineItem>
               <CustomRow>


### PR DESCRIPTION
## Description

Implements the limit orders ui layout fully, excluding the order history. This is placeholder UI only and ZERO functionality has been added in this PR.

Some effort has been made to minimise code duplication and complexity:
- Broke out `AssetToAssetCard` from rFOX for re-use in limit orders
- Created a `LimitOrderBuyAsset` which avoids the megalithic dumpster fire that is `TradeAssetInput`. No need to strap on more complexity for what is essentially a couple of drop-downs
- Simplified `LimitOrderStatus` component

## Issue (if applicable)

<!-----------------------------------------------------------------------------
If applicable, please link to the github issue and put `closes #XXXX` in your comment to auto-close the issue that your PR fixes.
------------------------------------------------------------------------------>

closes #6218

## Risk

> High Risk PRs Require 2 approvals

Moderate risk as this has refactored some user-facing components.

> What protocols, transaction types, wallets or contract interactions might be affected by this PR?

## Testing

- Check the Trade input UI still works as expected
- Check the rFOX bridge confirm UI still works as expected

### Engineering

<!-----------------------------------------------------------------------------
Include sufficient information here for an engineer to test your PR. This may include how to test locally, in a built environment, changes to infrastructure etc.
------------------------------------------------------------------------------>

- Trade input UI, namely the receive summary
<img src="https://github.com/user-attachments/assets/06c40b50-e4ea-4ea2-9467-6b8325a31d94" width="100">

- rFOX bridge confirmation UI

### Operations

Limit orders UI is behind a feature flag, but the trade input components have been refactored so testing of trades is required.

- [x] :checkered_flag: My feature is behind a flag and doesn't require operations testing (yet)

<!-----------------------------------------------------------------------------
If your changes have a user-facing impact, describe how a non-technical QA team can functionally test your changes in a preview environment.

If they are not user-facing please describe how to test for any regressions that may occur.
------------------------------------------------------------------------------>

## Screenshots (if applicable)

Demo of the limit orders placeholder UI:
https://jam.dev/c/9aa25c66-6b85-4af3-be84-f78e28510fc8
