### PR TITLE
feat: add market page filters and sort

### DIFF
--- a/src/assets/translations/en/main.json
+++ b/src/assets/translations/en/main.json
@@ -240,6 +240,7 @@
       "balance": "Balance",
       "price": "Price",
       "value": "Value",
+      "apy": "APY",
       "priceChange": "Price Change",
       "allocation": "Allocation",
       "marketCap": "Market Cap",

--- a/src/assets/translations/en/main.json
+++ b/src/assets/translations/en/main.json
@@ -1,5 +1,7 @@
 {
   "common": {
+    "ascending": "Ascending",
+    "descending": "Descending",
     "free": "Free",
     "trade": "Trade",
     "trades": "Trades",
@@ -159,6 +161,9 @@
     "import": "Import",
     "accountsLoading": "Loading Accounts",
     "noAccounts": "No accounts for the selected filters.",
+    "sortBy": "Sort By",
+    "orderBy": "Order By",
+    "filterBy": "Filter By",
     "carousel": {
       "next": "Next",
       "prev": "Previous",

--- a/src/components/OrderDropdown/OrderDropdown.tsx
+++ b/src/components/OrderDropdown/OrderDropdown.tsx
@@ -1,5 +1,5 @@
 import { ChevronDownIcon } from '@chakra-ui/icons'
-import type { ButtonProps, MenuProps } from '@chakra-ui/react'
+import type { ButtonProps } from '@chakra-ui/react'
 import {
   Button,
   Flex,
@@ -13,59 +13,43 @@ import {
 import { useCallback, useMemo } from 'react'
 import { useTranslate } from 'react-polyglot'
 
-import { type OrderOption, OrderOptionsKeys } from './types'
+import { OrderDirection } from './types'
 
 type OrderDropdownProps = {
-  value: OrderOptionsKeys
-  onClick: (arg: OrderOptionsKeys) => void
+  value: OrderDirection
+  onClick: (arg: OrderDirection) => void
   buttonProps?: ButtonProps
-} & Omit<MenuProps, 'children'>
-
-const orderOptions: OrderOption[] = [
-  {
-    key: OrderOptionsKeys.ASCENDING,
-    label: 'common.ascending',
-  },
-  {
-    key: OrderOptionsKeys.DESCENDING,
-    label: 'common.descending',
-  },
-]
+}
 
 const width = { base: 'full', md: 'auto' }
 
 const chevronDownIcon = <ChevronDownIcon />
 
-export const OrderDropdown: React.FC<OrderDropdownProps> = ({
-  onClick,
-  value,
-  buttonProps,
-  ...menuProps
-}) => {
+export const OrderDropdown: React.FC<OrderDropdownProps> = ({ onClick, value, buttonProps }) => {
   const translate = useTranslate()
 
   const renderOptions = useMemo(() => {
-    return orderOptions.map(option => (
-      <MenuItemOption value={option.key} key={option.key}>
-        {translate(option.label)}
+    return Object.values(OrderDirection).map(option => (
+      <MenuItemOption value={option} key={option}>
+        {translate(`common.${option}`)}
       </MenuItemOption>
     ))
   }, [translate])
 
   const onChange = useCallback(
-    (value: string | string[]) => onClick(value as OrderOptionsKeys),
+    (value: string | string[]) => onClick(value as OrderDirection),
     [onClick],
   )
 
   const selectedLabel = useMemo(() => {
-    const selectedOption = orderOptions.find(option => option.key === value)
-    return selectedOption ? translate(selectedOption.label) : ''
+    const selectedOption = Object.values(OrderDirection).find(option => option === value)
+    return selectedOption ? translate(`common.${selectedOption}`) : ''
   }, [translate, value])
 
   return (
     <Flex alignItems='center' mx={2}>
       <Text me={4}>{translate('common.orderBy')}</Text>
-      <Menu {...menuProps}>
+      <Menu>
         <MenuButton width={width} as={Button} rightIcon={chevronDownIcon} {...buttonProps}>
           {selectedLabel}
         </MenuButton>

--- a/src/components/OrderDropdown/OrderDropdown.tsx
+++ b/src/components/OrderDropdown/OrderDropdown.tsx
@@ -1,0 +1,80 @@
+import { ChevronDownIcon } from '@chakra-ui/icons'
+import type { ButtonProps, MenuProps } from '@chakra-ui/react'
+import {
+  Button,
+  Flex,
+  Menu,
+  MenuButton,
+  MenuItemOption,
+  MenuList,
+  MenuOptionGroup,
+  Text,
+} from '@chakra-ui/react'
+import { useCallback, useMemo } from 'react'
+import { useTranslate } from 'react-polyglot'
+
+import { type OrderOption, OrderOptionsKeys } from './types'
+
+type OrderDropdownProps = {
+  value: OrderOptionsKeys
+  onClick: (arg: OrderOptionsKeys) => void
+  buttonProps?: ButtonProps
+} & Omit<MenuProps, 'children'>
+
+const orderOptions: OrderOption[] = [
+  {
+    key: OrderOptionsKeys.ASCENDING,
+    label: 'common.ascending',
+  },
+  {
+    key: OrderOptionsKeys.DESCENDING,
+    label: 'common.descending',
+  },
+]
+
+const width = { base: 'full', md: 'auto' }
+
+const chevronDownIcon = <ChevronDownIcon />
+
+export const OrderDropdown: React.FC<OrderDropdownProps> = ({
+  onClick,
+  value,
+  buttonProps,
+  ...menuProps
+}) => {
+  const translate = useTranslate()
+
+  const renderOptions = useMemo(() => {
+    return orderOptions.map(option => (
+      <MenuItemOption value={option.key} key={option.key}>
+        {translate(option.label)}
+      </MenuItemOption>
+    ))
+  }, [translate])
+
+  const onChange = useCallback(
+    (value: string | string[]) => onClick(value as OrderOptionsKeys),
+    [onClick],
+  )
+
+  const selectedLabel = useMemo(() => {
+    const selectedOption = orderOptions.find(option => option.key === value)
+    return selectedOption ? translate(selectedOption.label) : ''
+  }, [translate, value])
+
+  return (
+    <Flex alignItems='center' mx={2}>
+      <Text me={4}>{translate('common.orderBy')}</Text>
+      <Menu {...menuProps}>
+        <MenuButton width={width} as={Button} rightIcon={chevronDownIcon} {...buttonProps}>
+          {selectedLabel}
+        </MenuButton>
+        <MenuList zIndex='banner'>
+          <MenuOptionGroup type='radio' value={value} onChange={onChange}>
+            {renderOptions}
+          </MenuOptionGroup>
+        </MenuList>
+      </Menu>
+    </Flex>
+  )
+}

--- a/src/components/OrderDropdown/types.ts
+++ b/src/components/OrderDropdown/types.ts
@@ -1,9 +1,4 @@
-export enum OrderOptionsKeys {
-  ASCENDING = 'Ascending',
-  DESCENDING = 'Descending',
-}
-
-export type OrderOption = {
-  key: OrderOptionsKeys
-  label: string
+export enum OrderDirection {
+  Ascending = 'ascending',
+  Descending = 'descending',
 }

--- a/src/components/OrderDropdown/types.ts
+++ b/src/components/OrderDropdown/types.ts
@@ -1,0 +1,9 @@
+export enum OrderOptionsKeys {
+  ASCENDING = 'Ascending',
+  DESCENDING = 'Descending',
+}
+
+export type OrderOption = {
+  key: OrderOptionsKeys
+  label: string
+}

--- a/src/components/SortDropdown/SortDropdown.tsx
+++ b/src/components/SortDropdown/SortDropdown.tsx
@@ -1,5 +1,5 @@
 import { ChevronDownIcon } from '@chakra-ui/icons'
-import type { ButtonProps, MenuProps } from '@chakra-ui/react'
+import type { ButtonProps } from '@chakra-ui/react'
 import {
   Button,
   Flex,
@@ -13,14 +13,14 @@ import {
 import { useCallback, useMemo } from 'react'
 import { useTranslate } from 'react-polyglot'
 
-import type { SortOption, SortOptionsKeys } from './types'
+import type { SortOptionsKeys } from './types'
 
 type SortDropdownProps = {
   value: SortOptionsKeys
   onClick: (arg: SortOptionsKeys) => void
   buttonProps?: ButtonProps
-  options: SortOption[]
-} & Omit<MenuProps, 'children'>
+  options: SortOptionsKeys[]
+}
 
 const width = { base: 'full', md: 'auto' }
 
@@ -31,14 +31,13 @@ export const SortDropdown: React.FC<SortDropdownProps> = ({
   value,
   buttonProps,
   options,
-  ...menuProps
 }) => {
   const translate = useTranslate()
 
   const renderOptions = useMemo(() => {
     return options.map(option => (
-      <MenuItemOption value={option.key} key={option.key}>
-        {translate(option.label)}
+      <MenuItemOption value={option} key={option}>
+        {translate(`dashboard.portfolio.${option}`)}
       </MenuItemOption>
     ))
   }, [translate, options])
@@ -49,14 +48,14 @@ export const SortDropdown: React.FC<SortDropdownProps> = ({
   )
 
   const selectedLabel = useMemo(() => {
-    const selectedOption = options.find(option => option.key === value)
-    return selectedOption ? translate(selectedOption.label) : ''
+    const selectedOption = options.find(option => option === value)
+    return selectedOption ? translate(`dashboard.portfolio.${selectedOption}`) : ''
   }, [translate, value, options])
 
   return (
     <Flex alignItems='center' mx={2}>
       <Text me={4}>{translate('common.sortBy')}</Text>
-      <Menu {...menuProps}>
+      <Menu>
         <MenuButton width={width} as={Button} rightIcon={chevronDownIcon} {...buttonProps}>
           {selectedLabel}
         </MenuButton>

--- a/src/components/SortDropdown/SortDropdown.tsx
+++ b/src/components/SortDropdown/SortDropdown.tsx
@@ -13,29 +13,14 @@ import {
 import { useCallback, useMemo } from 'react'
 import { useTranslate } from 'react-polyglot'
 
-import type { SortOption } from './types'
-import { SortOptionsKeys } from './types'
+import type { SortOption, SortOptionsKeys } from './types'
 
 type SortDropdownProps = {
   value: SortOptionsKeys
   onClick: (arg: SortOptionsKeys) => void
   buttonProps?: ButtonProps
+  options: SortOption[]
 } & Omit<MenuProps, 'children'>
-
-const sortOptions: SortOption[] = [
-  {
-    key: SortOptionsKeys.VOLUME,
-    label: 'dashboard.portfolio.volume',
-  },
-  {
-    key: SortOptionsKeys.PRICE_CHANGE,
-    label: 'dashboard.portfolio.priceChange',
-  },
-  {
-    key: SortOptionsKeys.MARKET_CAP,
-    label: 'dashboard.portfolio.marketCap',
-  },
-]
 
 const width = { base: 'full', md: 'auto' }
 
@@ -45,17 +30,18 @@ export const SortDropdown: React.FC<SortDropdownProps> = ({
   onClick,
   value,
   buttonProps,
+  options,
   ...menuProps
 }) => {
   const translate = useTranslate()
 
   const renderOptions = useMemo(() => {
-    return sortOptions.map(option => (
+    return options.map(option => (
       <MenuItemOption value={option.key} key={option.key}>
         {translate(option.label)}
       </MenuItemOption>
     ))
-  }, [translate])
+  }, [translate, options])
 
   const onChange = useCallback(
     (value: string | string[]) => onClick(value as SortOptionsKeys),
@@ -63,9 +49,9 @@ export const SortDropdown: React.FC<SortDropdownProps> = ({
   )
 
   const selectedLabel = useMemo(() => {
-    const selectedOption = sortOptions.find(option => option.key === value)
+    const selectedOption = options.find(option => option.key === value)
     return selectedOption ? translate(selectedOption.label) : ''
-  }, [translate, value])
+  }, [translate, value, options])
 
   return (
     <Flex alignItems='center' mx={2}>

--- a/src/components/SortDropdown/SortDropdown.tsx
+++ b/src/components/SortDropdown/SortDropdown.tsx
@@ -1,0 +1,85 @@
+import { ChevronDownIcon } from '@chakra-ui/icons'
+import type { ButtonProps, MenuProps } from '@chakra-ui/react'
+import {
+  Button,
+  Flex,
+  Menu,
+  MenuButton,
+  MenuItemOption,
+  MenuList,
+  MenuOptionGroup,
+  Text,
+} from '@chakra-ui/react'
+import { useCallback, useMemo } from 'react'
+import { useTranslate } from 'react-polyglot'
+
+import type { SortOption } from './types'
+import { SortOptionsKeys } from './types'
+
+type SortDropdownProps = {
+  value: SortOptionsKeys
+  onClick: (arg: SortOptionsKeys) => void
+  buttonProps?: ButtonProps
+} & Omit<MenuProps, 'children'>
+
+const sortOptions: SortOption[] = [
+  {
+    key: SortOptionsKeys.VOLUME,
+    label: 'dashboard.portfolio.volume',
+  },
+  {
+    key: SortOptionsKeys.PRICE_CHANGE,
+    label: 'dashboard.portfolio.priceChange',
+  },
+  {
+    key: SortOptionsKeys.MARKET_CAP,
+    label: 'dashboard.portfolio.marketCap',
+  },
+]
+
+const width = { base: 'full', md: 'auto' }
+
+const chevronDownIcon = <ChevronDownIcon />
+
+export const SortDropdown: React.FC<SortDropdownProps> = ({
+  onClick,
+  value,
+  buttonProps,
+  ...menuProps
+}) => {
+  const translate = useTranslate()
+
+  const renderOptions = useMemo(() => {
+    return sortOptions.map(option => (
+      <MenuItemOption value={option.key} key={option.key}>
+        {translate(option.label)}
+      </MenuItemOption>
+    ))
+  }, [translate])
+
+  const onChange = useCallback(
+    (value: string | string[]) => onClick(value as SortOptionsKeys),
+    [onClick],
+  )
+
+  const selectedLabel = useMemo(() => {
+    const selectedOption = sortOptions.find(option => option.key === value)
+    return selectedOption ? translate(selectedOption.label) : ''
+  }, [translate, value])
+
+  return (
+    <Flex alignItems='center' mx={2}>
+      <Text me={4}>{translate('common.sortBy')}</Text>
+      <Menu {...menuProps}>
+        <MenuButton width={width} as={Button} rightIcon={chevronDownIcon} {...buttonProps}>
+          {selectedLabel}
+        </MenuButton>
+        <MenuList zIndex='banner'>
+          <MenuOptionGroup type='radio' value={value} onChange={onChange}>
+            {renderOptions}
+          </MenuOptionGroup>
+        </MenuList>
+      </Menu>
+    </Flex>
+  )
+}

--- a/src/components/SortDropdown/types.ts
+++ b/src/components/SortDropdown/types.ts
@@ -1,11 +1,6 @@
 export enum SortOptionsKeys {
-  APY = 'APY',
-  VOLUME = 'Volume',
-  MARKET_CAP = 'Market Cap',
-  PRICE_CHANGE = 'Price Change',
-}
-
-export type SortOption = {
-  key: SortOptionsKeys
-  label: string
+  Apy = 'apy',
+  Volume = 'volume',
+  MarketCap = 'marketCap',
+  PriceChange = 'priceChange',
 }

--- a/src/components/SortDropdown/types.ts
+++ b/src/components/SortDropdown/types.ts
@@ -1,4 +1,5 @@
 export enum SortOptionsKeys {
+  APY = 'APY',
   VOLUME = 'Volume',
   MARKET_CAP = 'Market Cap',
   PRICE_CHANGE = 'Price Change',

--- a/src/components/SortDropdown/types.ts
+++ b/src/components/SortDropdown/types.ts
@@ -1,0 +1,10 @@
+export enum SortOptionsKeys {
+  VOLUME = 'Volume',
+  MARKET_CAP = 'Market Cap',
+  PRICE_CHANGE = 'Price Change',
+}
+
+export type SortOption = {
+  key: SortOptionsKeys
+  label: string
+}

--- a/src/lib/coingecko/utils.ts
+++ b/src/lib/coingecko/utils.ts
@@ -122,7 +122,13 @@ export const getCoingeckoRecentlyAdded = async (): Promise<CoingeckoAsset[]> => 
 }
 
 export const getCoingeckoMarkets = async (
-  order: 'market_cap_desc' | 'volume_desc',
+  order:
+    | 'market_cap_asc'
+    | 'market_cap_desc'
+    | 'volume_desc'
+    | 'volume_asc'
+    | 'price_change_percentage_24h_desc'
+    | 'price_change_percentage_24h_asc',
 ): Promise<CoingeckoAsset[]> => {
   const { data } = await axios.get<CoinGeckoMarketCap[]>(
     `${coingeckoBaseUrl}/coins/markets?vs_currency=usd&order=${order}`,

--- a/src/pages/Markets/Category.tsx
+++ b/src/pages/Markets/Category.tsx
@@ -22,6 +22,15 @@ export const Category: React.FC = () => {
   const allRows = useRows({ limit: ASSETS_LIMIT })
   const row = allRows[params.category]
 
+  const shouldShowSortFilter = useMemo(() => {
+    if (!params.category) return false
+
+    if (params.category === 'tradingVolume') return false
+    if (params.category === 'marketCap') return false
+
+    return true
+  }, [params.category])
+
   const body = useMemo(
     () => (
       <MarketsRow
@@ -29,11 +38,20 @@ export const Category: React.FC = () => {
         subtitle={row.subtitle}
         supportedChainIds={row.supportedChainIds}
         category={row.category}
+        showOrderFilter
+        showSortFilter={shouldShowSortFilter}
       >
         {row.component}
       </MarketsRow>
     ),
-    [row.category, row.component, row.subtitle, row.supportedChainIds, row.title],
+    [
+      row.category,
+      row.component,
+      row.subtitle,
+      row.supportedChainIds,
+      row.title,
+      shouldShowSortFilter,
+    ],
   )
 
   return (

--- a/src/pages/Markets/Category.tsx
+++ b/src/pages/Markets/Category.tsx
@@ -6,7 +6,7 @@ import { Main } from 'components/Layout/Main'
 import { SEO } from 'components/Layout/Seo'
 
 import { MarketsRow } from './components/MarketsRow'
-import type { MARKETS_CATEGORIES } from './constants'
+import type { MarketsCategories } from './constants'
 import { sortOptionsByCategory } from './constants'
 import { useRows } from './hooks/useRows'
 import { MarketsHeader } from './MarketsHeader'
@@ -16,7 +16,7 @@ const containerPaddingX = { base: 4, xl: 0 }
 const ASSETS_LIMIT = 100
 
 export const Category: React.FC = () => {
-  const params = useParams<{ category: MARKETS_CATEGORIES }>()
+  const params = useParams<{ category: MarketsCategories }>()
   const translate = useTranslate()
   const headerComponent = useMemo(() => <MarketsHeader />, [])
 

--- a/src/pages/Markets/Category.tsx
+++ b/src/pages/Markets/Category.tsx
@@ -6,7 +6,8 @@ import { Main } from 'components/Layout/Main'
 import { SEO } from 'components/Layout/Seo'
 
 import { MarketsRow } from './components/MarketsRow'
-import { type MARKETS_CATEGORIES, sortOptionsByCategory } from './constants'
+import type { MARKETS_CATEGORIES } from './constants'
+import { sortOptionsByCategory } from './constants'
 import { useRows } from './hooks/useRows'
 import { MarketsHeader } from './MarketsHeader'
 

--- a/src/pages/Markets/Category.tsx
+++ b/src/pages/Markets/Category.tsx
@@ -6,7 +6,7 @@ import { Main } from 'components/Layout/Main'
 import { SEO } from 'components/Layout/Seo'
 
 import { MarketsRow } from './components/MarketsRow'
-import type { MARKETS_CATEGORIES } from './constants'
+import { type MARKETS_CATEGORIES, sortOptionsByCategory } from './constants'
 import { useRows } from './hooks/useRows'
 import { MarketsHeader } from './MarketsHeader'
 
@@ -23,10 +23,7 @@ export const Category: React.FC = () => {
   const row = allRows[params.category]
 
   const shouldShowSortFilter = useMemo(() => {
-    if (!params.category) return false
-
-    if (params.category === 'tradingVolume') return false
-    if (params.category === 'marketCap') return false
+    if (!sortOptionsByCategory[params.category]) return false
 
     return true
   }, [params.category])

--- a/src/pages/Markets/components/AssetGridWithData.tsx
+++ b/src/pages/Markets/components/AssetGridWithData.tsx
@@ -1,4 +1,6 @@
 import { useInView } from 'react-intersection-observer'
+import type { OrderOptionsKeys } from 'components/OrderDropdown/types'
+import type { SortOptionsKeys } from 'components/SortDropdown/types'
 
 import type { MARKETS_CATEGORIES } from '../constants'
 import { CATEGORY_TO_QUERY_HOOK } from '../hooks/useCoingeckoData'
@@ -12,6 +14,7 @@ export const AssetGridWithData = ({
   showMarketCap,
   category,
   orderBy,
+  sortBy,
 }: RowProps & {
   limit: number
   category: Exclude<
@@ -19,7 +22,8 @@ export const AssetGridWithData = ({
     MARKETS_CATEGORIES.ONE_CLICK_DEFI | MARKETS_CATEGORIES.THORCHAIN_DEFI
   >
   showMarketCap?: boolean
-  orderBy?: 'market_cap_desc' | 'volume_desc'
+  orderBy?: OrderOptionsKeys
+  sortBy?: SortOptionsKeys
 }) => {
   const { ref, inView } = useInView()
   const dataQuery = CATEGORY_TO_QUERY_HOOK[category]
@@ -31,7 +35,8 @@ export const AssetGridWithData = ({
   } = dataQuery({
     enabled: inView,
     // ts isn't smart enough to narrow this down, and we don't want to pass it for all categories where this does not apply
-    orderBy: orderBy!,
+    orderBy,
+    sortBy,
   })
 
   return (

--- a/src/pages/Markets/components/AssetGridWithData.tsx
+++ b/src/pages/Markets/components/AssetGridWithData.tsx
@@ -1,5 +1,5 @@
 import { useInView } from 'react-intersection-observer'
-import type { OrderOptionsKeys } from 'components/OrderDropdown/types'
+import type { OrderDirection } from 'components/OrderDropdown/types'
 import type { SortOptionsKeys } from 'components/SortDropdown/types'
 
 import type { MARKETS_CATEGORIES } from '../constants'
@@ -22,7 +22,7 @@ export const AssetGridWithData = ({
     MARKETS_CATEGORIES.ONE_CLICK_DEFI | MARKETS_CATEGORIES.THORCHAIN_DEFI
   >
   showMarketCap?: boolean
-  orderBy?: OrderOptionsKeys
+  orderBy?: OrderDirection
   sortBy?: SortOptionsKeys
 }) => {
   const { ref, inView } = useInView()
@@ -34,7 +34,6 @@ export const AssetGridWithData = ({
     isPending: isMarketCapDataPending,
   } = dataQuery({
     enabled: inView,
-    // ts isn't smart enough to narrow this down, and we don't want to pass it for all categories where this does not apply
     orderBy,
     sortBy,
   })

--- a/src/pages/Markets/components/AssetGridWithData.tsx
+++ b/src/pages/Markets/components/AssetGridWithData.tsx
@@ -2,7 +2,7 @@ import { useInView } from 'react-intersection-observer'
 import type { OrderDirection } from 'components/OrderDropdown/types'
 import type { SortOptionsKeys } from 'components/SortDropdown/types'
 
-import type { MARKETS_CATEGORIES } from '../constants'
+import type { MarketsCategories } from '../constants'
 import { CATEGORY_TO_QUERY_HOOK } from '../hooks/useCoingeckoData'
 import type { RowProps } from '../hooks/useRows'
 import { AssetsGrid } from './AssetsGrid'
@@ -18,8 +18,8 @@ export const AssetGridWithData = ({
 }: RowProps & {
   limit: number
   category: Exclude<
-    MARKETS_CATEGORIES,
-    MARKETS_CATEGORIES.ONE_CLICK_DEFI | MARKETS_CATEGORIES.THORCHAIN_DEFI
+    MarketsCategories,
+    MarketsCategories.OneClickDefi | MarketsCategories.ThorchainDefi
   >
   showMarketCap?: boolean
   orderBy?: OrderDirection

--- a/src/pages/Markets/components/LpGrid.tsx
+++ b/src/pages/Markets/components/LpGrid.tsx
@@ -45,6 +45,8 @@ export const LpGrid: React.FC<{
   const { data: portalsAssets } = usePortalsAssetsQuery({
     chainIds: selectedChainId ? [selectedChainId] : undefined,
     enabled: inView,
+    sortBy,
+    orderBy,
   })
 
   const filteredAssetIds = useMemo(
@@ -79,6 +81,7 @@ export const LpGrid: React.FC<{
           )
         }
 
+        // @TODO: Remove this when portals assets are accessible from the opportunities slices
         const maybePortalsFirstAssetApy = portalsAssets?.byId[firstAssetId]?.metrics.apy
         const maybePortalsSecondAssetApy = portalsAssets?.byId[secondAssetId]?.metrics.apy
 

--- a/src/pages/Markets/components/LpGrid.tsx
+++ b/src/pages/Markets/components/LpGrid.tsx
@@ -5,7 +5,7 @@ import { useCallback, useEffect, useMemo } from 'react'
 import { RiExchangeFundsLine } from 'react-icons/ri'
 import { useInView } from 'react-intersection-observer'
 import { useHistory } from 'react-router'
-import { OrderOptionsKeys } from 'components/OrderDropdown/types'
+import { OrderDirection } from 'components/OrderDropdown/types'
 import { ResultsEmpty } from 'components/ResultsEmpty'
 import type { SortOptionsKeys } from 'components/SortDropdown/types'
 import { bnOrZero } from 'lib/bignumber/bignumber'
@@ -31,7 +31,7 @@ export const LpGrid: React.FC<{
   selectedChainId?: ChainId
   isLoading: boolean
   limit: number
-  orderBy?: OrderOptionsKeys
+  orderBy?: OrderDirection
   sortBy?: SortOptionsKeys
 }> = ({ assetIds, selectedChainId, isLoading, limit, orderBy, sortBy }) => {
   const { ref, inView } = useInView()
@@ -63,14 +63,15 @@ export const LpGrid: React.FC<{
 
     return filteredAssetIds.sort((a, b) => {
       const dataKey = marketDataBySortKey[sortBy]
-      const firstAssetId = orderBy === OrderOptionsKeys.ASCENDING ? a : b
-      const secondAssetId = orderBy === OrderOptionsKeys.ASCENDING ? b : a
+      const firstAssetId = orderBy === OrderDirection.Ascending ? a : b
+      const secondAssetId = orderBy === OrderDirection.Ascending ? b : a
+      const state = store.getState()
 
       if (dataKey === 'apy') {
-        const firstAssetOpportunityData = selectStakingOpportunityByFilter(store.getState(), {
+        const firstAssetOpportunityData = selectStakingOpportunityByFilter(state, {
           assetId: firstAssetId,
         })
-        const secondAssetOpportunityData = selectStakingOpportunityByFilter(store.getState(), {
+        const secondAssetOpportunityData = selectStakingOpportunityByFilter(state, {
           assetId: secondAssetId,
         })
 
@@ -91,11 +92,8 @@ export const LpGrid: React.FC<{
         )
       }
 
-      const assetAMarketData = selectMarketDataByAssetIdUserCurrency(store.getState(), firstAssetId)
-      const assetBMarketData = selectMarketDataByAssetIdUserCurrency(
-        store.getState(),
-        secondAssetId,
-      )
+      const assetAMarketData = selectMarketDataByAssetIdUserCurrency(state, firstAssetId)
+      const assetBMarketData = selectMarketDataByAssetIdUserCurrency(state, secondAssetId)
 
       return (
         bnOrZero(assetAMarketData?.[dataKey] ?? 0).toNumber() -
@@ -135,7 +133,7 @@ export const LpGrid: React.FC<{
 export const OneClickDefiAssets: React.FC<{
   selectedChainId: ChainId | undefined
   limit: number
-  orderBy?: OrderOptionsKeys
+  orderBy?: OrderDirection
   sortBy?: SortOptionsKeys
 }> = ({ limit, selectedChainId, orderBy, sortBy }) => {
   const { ref, inView } = useInView()
@@ -161,7 +159,7 @@ export const OneClickDefiAssets: React.FC<{
 export const ThorchainAssets: React.FC<{
   selectedChainId: ChainId | undefined
   limit: number
-  orderBy?: OrderOptionsKeys
+  orderBy?: OrderDirection
   sortBy?: SortOptionsKeys
 }> = ({ limit, selectedChainId, orderBy, sortBy }) => {
   const { ref, inView } = useInView()

--- a/src/pages/Markets/components/LpGrid.tsx
+++ b/src/pages/Markets/components/LpGrid.tsx
@@ -5,7 +5,9 @@ import { useCallback, useEffect, useMemo } from 'react'
 import { RiExchangeFundsLine } from 'react-icons/ri'
 import { useInView } from 'react-intersection-observer'
 import { useHistory } from 'react-router'
+import type { OrderOptionsKeys } from 'components/OrderDropdown/types'
 import { ResultsEmpty } from 'components/ResultsEmpty'
+import type { SortOptionsKeys } from 'components/SortDropdown/types'
 import { opportunitiesApi } from 'state/slices/opportunitiesSlice/opportunitiesApiSlice'
 import { thorchainSaversOpportunityIdsResolver } from 'state/slices/opportunitiesSlice/resolvers/thorchainsavers'
 import { DefiProvider, DefiType } from 'state/slices/opportunitiesSlice/types'
@@ -23,7 +25,9 @@ export const LpGrid: React.FC<{
   selectedChainId?: ChainId
   isLoading: boolean
   limit: number
-}> = ({ assetIds, selectedChainId, isLoading, limit }) => {
+  orderBy?: OrderOptionsKeys
+  sortBy?: SortOptionsKeys
+}> = ({ assetIds, selectedChainId, isLoading, limit, orderBy, sortBy }) => {
   const { ref, inView } = useInView()
   const history = useHistory()
   const handleCardClick = useCallback(
@@ -77,7 +81,9 @@ export const LpGrid: React.FC<{
 export const OneClickDefiAssets: React.FC<{
   selectedChainId: ChainId | undefined
   limit: number
-}> = ({ limit, selectedChainId }) => {
+  orderBy?: OrderOptionsKeys
+  sortBy?: SortOptionsKeys
+}> = ({ limit, selectedChainId, orderBy, sortBy }) => {
   const { ref, inView } = useInView()
   const { data: portalsAssets, isLoading: isPortalsAssetsLoading } = usePortalsAssetsQuery({
     chainIds: selectedChainId ? [selectedChainId] : undefined,
@@ -91,6 +97,8 @@ export const OneClickDefiAssets: React.FC<{
         selectedChainId={selectedChainId}
         isLoading={isPortalsAssetsLoading}
         limit={limit}
+        orderBy={orderBy}
+        sortBy={sortBy}
       />
     </div>
   )
@@ -99,7 +107,9 @@ export const OneClickDefiAssets: React.FC<{
 export const ThorchainAssets: React.FC<{
   selectedChainId: ChainId | undefined
   limit: number
-}> = ({ limit, selectedChainId }) => {
+  orderBy?: OrderOptionsKeys
+  sortBy?: SortOptionsKeys
+}> = ({ limit, selectedChainId, orderBy, sortBy }) => {
   const { ref, inView } = useInView()
   const dispatch = useAppDispatch()
   const { data: thorchainAssetIdsData, isLoading: isThorchainAssetIdsDataLoading } = useQuery({
@@ -143,6 +153,8 @@ export const ThorchainAssets: React.FC<{
         selectedChainId={selectedChainId}
         isLoading={isThorchainAssetIdsDataLoading}
         limit={limit}
+        orderBy={orderBy}
+        sortBy={sortBy}
       />
     </div>
   )

--- a/src/pages/Markets/components/MarketGrid.tsx
+++ b/src/pages/Markets/components/MarketGrid.tsx
@@ -3,10 +3,10 @@ import type { PropsWithChildren } from 'react'
 import { useParams } from 'react-router'
 import { Display } from 'components/Display'
 
-import type { MARKETS_CATEGORIES } from '../constants'
+import type { MarketsCategories } from '../constants'
 
 export const MarketGrid: React.FC<PropsWithChildren> = ({ children }) => {
-  const params: { category?: MARKETS_CATEGORIES } = useParams()
+  const params: { category?: MarketsCategories } = useParams()
   const isCategoryRoute = params.category
 
   if (isCategoryRoute) {

--- a/src/pages/Markets/components/MarketsRow.tsx
+++ b/src/pages/Markets/components/MarketsRow.tsx
@@ -50,7 +50,9 @@ export const MarketsRow: React.FC<MarketsRowProps> = ({
   const isCategoryRoute = params.category
   const [selectedChainId, setSelectedChainId] = useState<ChainId | undefined>(undefined)
   const [selectedOrder, setSelectedOrder] = useState<OrderOptionsKeys>(OrderOptionsKeys.DESCENDING)
-  const [selectedSort, setSelectedSort] = useState<SortOptionsKeys>(SortOptionsKeys.PRICE_CHANGE)
+  const [selectedSort, setSelectedSort] = useState<SortOptionsKeys>(
+    (params.category && sortOptionsByCategory[params.category]?.[0].key) ?? SortOptionsKeys.VOLUME,
+  )
   const isArbitrumNovaEnabled = useAppSelector(state => selectFeatureFlag(state, 'ArbitrumNova'))
 
   const chainIds = useMemo(() => {

--- a/src/pages/Markets/components/MarketsRow.tsx
+++ b/src/pages/Markets/components/MarketsRow.tsx
@@ -8,7 +8,7 @@ import { useTranslate } from 'react-polyglot'
 import { Link, useHistory, useParams } from 'react-router-dom'
 import { ChainDropdown } from 'components/ChainDropdown/ChainDropdown'
 import { OrderDropdown } from 'components/OrderDropdown/OrderDropdown'
-import { OrderOptionsKeys } from 'components/OrderDropdown/types'
+import { OrderDirection } from 'components/OrderDropdown/types'
 import { SortDropdown } from 'components/SortDropdown/SortDropdown'
 import { SortOptionsKeys } from 'components/SortDropdown/types'
 import { selectFeatureFlag } from 'state/slices/selectors'
@@ -49,9 +49,9 @@ export const MarketsRow: React.FC<MarketsRowProps> = ({
   const handleBack = history.goBack
   const isCategoryRoute = params.category
   const [selectedChainId, setSelectedChainId] = useState<ChainId | undefined>(undefined)
-  const [selectedOrder, setSelectedOrder] = useState<OrderOptionsKeys>(OrderOptionsKeys.DESCENDING)
+  const [selectedOrder, setSelectedOrder] = useState<OrderDirection>(OrderDirection.Descending)
   const [selectedSort, setSelectedSort] = useState<SortOptionsKeys>(
-    (params.category && sortOptionsByCategory[params.category]?.[0].key) ?? SortOptionsKeys.VOLUME,
+    (params.category && sortOptionsByCategory[params.category]?.[0]) ?? SortOptionsKeys.Volume,
   )
   const isArbitrumNovaEnabled = useAppSelector(state => selectFeatureFlag(state, 'ArbitrumNova'))
 

--- a/src/pages/Markets/components/MarketsRow.tsx
+++ b/src/pages/Markets/components/MarketsRow.tsx
@@ -14,7 +14,7 @@ import { SortOptionsKeys } from 'components/SortDropdown/types'
 import { selectFeatureFlag } from 'state/slices/selectors'
 import { useAppSelector } from 'state/store'
 
-import { type MARKETS_CATEGORIES, sortOptionsByCategory } from '../constants'
+import { type MarketsCategories, sortOptionsByCategory } from '../constants'
 import type { RowProps } from '../hooks/useRows'
 
 const flexAlign = { base: 'flex-start', md: 'flex-end' }
@@ -24,7 +24,7 @@ type MarketsRowProps = {
   title?: string
   subtitle?: string
   supportedChainIds: ChainId[] | undefined
-  category?: MARKETS_CATEGORIES
+  category?: MarketsCategories
   showSparkline?: boolean
   showOrderFilter?: boolean
   showSortFilter?: boolean
@@ -43,7 +43,7 @@ export const MarketsRow: React.FC<MarketsRowProps> = ({
   showOrderFilter,
   showSortFilter,
 }) => {
-  const params: { category?: MARKETS_CATEGORIES } = useParams()
+  const params: { category?: MarketsCategories } = useParams()
   const translate = useTranslate()
   const history = useHistory()
   const handleBack = history.goBack

--- a/src/pages/Markets/components/MarketsRow.tsx
+++ b/src/pages/Markets/components/MarketsRow.tsx
@@ -14,7 +14,7 @@ import { SortOptionsKeys } from 'components/SortDropdown/types'
 import { selectFeatureFlag } from 'state/slices/selectors'
 import { useAppSelector } from 'state/store'
 
-import type { MARKETS_CATEGORIES } from '../constants'
+import { type MARKETS_CATEGORIES, sortOptionsByCategory } from '../constants'
 import type { RowProps } from '../hooks/useRows'
 
 const flexAlign = { base: 'flex-start', md: 'flex-end' }
@@ -124,7 +124,13 @@ export const MarketsRow: React.FC<MarketsRowProps> = ({
           {Subtitle}
         </Box>
         <Flex alignItems='center' mx={-2}>
-          {showSortFilter ? <SortDropdown value={selectedSort} onClick={setSelectedSort} /> : null}
+          {showSortFilter && params.category ? (
+            <SortDropdown
+              options={sortOptionsByCategory[params.category] ?? []}
+              value={selectedSort}
+              onClick={setSelectedSort}
+            />
+          ) : null}
           {showOrderFilter ? (
             <OrderDropdown value={selectedOrder} onClick={setSelectedOrder} />
           ) : null}

--- a/src/pages/Markets/constants.ts
+++ b/src/pages/Markets/constants.ts
@@ -14,20 +14,7 @@ export enum MARKETS_CATEGORIES {
 
 export const sortOptionsByCategory: Record<MARKETS_CATEGORIES, SortOption[] | undefined> = {
   [MARKETS_CATEGORIES.TRADING_VOLUME]: undefined,
-  [MARKETS_CATEGORIES.MARKET_CAP]: [
-    {
-      key: SortOptionsKeys.VOLUME,
-      label: 'dashboard.portfolio.volume',
-    },
-    {
-      key: SortOptionsKeys.PRICE_CHANGE,
-      label: 'dashboard.portfolio.priceChange',
-    },
-    {
-      key: SortOptionsKeys.MARKET_CAP,
-      label: 'dashboard.portfolio.marketCap',
-    },
-  ],
+  [MARKETS_CATEGORIES.MARKET_CAP]: undefined,
   [MARKETS_CATEGORIES.TRENDING]: [
     {
       key: SortOptionsKeys.VOLUME,

--- a/src/pages/Markets/constants.ts
+++ b/src/pages/Markets/constants.ts
@@ -1,40 +1,40 @@
 import type { MarketData } from '@shapeshiftoss/types'
 import { SortOptionsKeys } from 'components/SortDropdown/types'
 
-export enum MARKETS_CATEGORIES {
-  TRADING_VOLUME = 'tradingVolume',
-  MARKET_CAP = 'marketCap',
-  TRENDING = 'trending',
-  TOP_MOVERS = 'topMovers',
-  RECENTLY_ADDED = 'recentlyAdded',
-  ONE_CLICK_DEFI = 'oneClickDefiAssets',
-  THORCHAIN_DEFI = 'thorchainDefi',
+export enum MarketsCategories {
+  TradingVolume = 'tradingVolume',
+  MarketCap = 'marketCap',
+  Trending = 'trending',
+  TopMovers = 'topMovers',
+  RecentlyAdded = 'recentlyAdded',
+  OneClickDefi = 'oneClickDefiAssets',
+  ThorchainDefi = 'thorchainDefi',
 }
 
-export const sortOptionsByCategory: Record<MARKETS_CATEGORIES, SortOptionsKeys[] | undefined> = {
-  [MARKETS_CATEGORIES.TRADING_VOLUME]: undefined,
-  [MARKETS_CATEGORIES.MARKET_CAP]: undefined,
-  [MARKETS_CATEGORIES.TRENDING]: [
+export const sortOptionsByCategory: Record<MarketsCategories, SortOptionsKeys[] | undefined> = {
+  [MarketsCategories.TradingVolume]: undefined,
+  [MarketsCategories.MarketCap]: undefined,
+  [MarketsCategories.Trending]: [
     SortOptionsKeys.Volume,
     SortOptionsKeys.PriceChange,
     SortOptionsKeys.MarketCap,
   ],
-  [MARKETS_CATEGORIES.TOP_MOVERS]: [
+  [MarketsCategories.TopMovers]: [
     SortOptionsKeys.Volume,
     SortOptionsKeys.PriceChange,
     SortOptionsKeys.MarketCap,
   ],
-  [MARKETS_CATEGORIES.RECENTLY_ADDED]: [
+  [MarketsCategories.RecentlyAdded]: [
     SortOptionsKeys.Volume,
     SortOptionsKeys.PriceChange,
     SortOptionsKeys.MarketCap,
   ],
-  [MARKETS_CATEGORIES.ONE_CLICK_DEFI]: [
+  [MarketsCategories.OneClickDefi]: [
     SortOptionsKeys.Apy,
     SortOptionsKeys.Volume,
     SortOptionsKeys.MarketCap,
   ],
-  [MARKETS_CATEGORIES.THORCHAIN_DEFI]: [
+  [MarketsCategories.ThorchainDefi]: [
     SortOptionsKeys.Apy,
     SortOptionsKeys.Volume,
     SortOptionsKeys.MarketCap,

--- a/src/pages/Markets/constants.ts
+++ b/src/pages/Markets/constants.ts
@@ -1,5 +1,4 @@
 import type { MarketData } from '@shapeshiftoss/types'
-import type { SortOption } from 'components/SortDropdown/types'
 import { SortOptionsKeys } from 'components/SortDropdown/types'
 
 export enum MARKETS_CATEGORIES {
@@ -12,84 +11,39 @@ export enum MARKETS_CATEGORIES {
   THORCHAIN_DEFI = 'thorchainDefi',
 }
 
-export const sortOptionsByCategory: Record<MARKETS_CATEGORIES, SortOption[] | undefined> = {
+export const sortOptionsByCategory: Record<MARKETS_CATEGORIES, SortOptionsKeys[] | undefined> = {
   [MARKETS_CATEGORIES.TRADING_VOLUME]: undefined,
   [MARKETS_CATEGORIES.MARKET_CAP]: undefined,
   [MARKETS_CATEGORIES.TRENDING]: [
-    {
-      key: SortOptionsKeys.VOLUME,
-      label: 'dashboard.portfolio.volume',
-    },
-    {
-      key: SortOptionsKeys.PRICE_CHANGE,
-      label: 'dashboard.portfolio.priceChange',
-    },
-    {
-      key: SortOptionsKeys.MARKET_CAP,
-      label: 'dashboard.portfolio.marketCap',
-    },
+    SortOptionsKeys.Volume,
+    SortOptionsKeys.PriceChange,
+    SortOptionsKeys.MarketCap,
   ],
   [MARKETS_CATEGORIES.TOP_MOVERS]: [
-    {
-      key: SortOptionsKeys.VOLUME,
-      label: 'dashboard.portfolio.volume',
-    },
-    {
-      key: SortOptionsKeys.PRICE_CHANGE,
-      label: 'dashboard.portfolio.priceChange',
-    },
-    {
-      key: SortOptionsKeys.MARKET_CAP,
-      label: 'dashboard.portfolio.marketCap',
-    },
+    SortOptionsKeys.Volume,
+    SortOptionsKeys.PriceChange,
+    SortOptionsKeys.MarketCap,
   ],
   [MARKETS_CATEGORIES.RECENTLY_ADDED]: [
-    {
-      key: SortOptionsKeys.VOLUME,
-      label: 'dashboard.portfolio.volume',
-    },
-    {
-      key: SortOptionsKeys.PRICE_CHANGE,
-      label: 'dashboard.portfolio.priceChange',
-    },
-    {
-      key: SortOptionsKeys.MARKET_CAP,
-      label: 'dashboard.portfolio.marketCap',
-    },
+    SortOptionsKeys.Volume,
+    SortOptionsKeys.PriceChange,
+    SortOptionsKeys.MarketCap,
   ],
   [MARKETS_CATEGORIES.ONE_CLICK_DEFI]: [
-    {
-      key: SortOptionsKeys.APY,
-      label: 'common.apy',
-    },
-    {
-      key: SortOptionsKeys.VOLUME,
-      label: 'dashboard.portfolio.volume',
-    },
-    {
-      key: SortOptionsKeys.MARKET_CAP,
-      label: 'dashboard.portfolio.marketCap',
-    },
+    SortOptionsKeys.Apy,
+    SortOptionsKeys.Volume,
+    SortOptionsKeys.MarketCap,
   ],
   [MARKETS_CATEGORIES.THORCHAIN_DEFI]: [
-    {
-      key: SortOptionsKeys.APY,
-      label: 'common.apy',
-    },
-    {
-      key: SortOptionsKeys.VOLUME,
-      label: 'dashboard.portfolio.volume',
-    },
-    {
-      key: SortOptionsKeys.MARKET_CAP,
-      label: 'dashboard.portfolio.marketCap',
-    },
+    SortOptionsKeys.Apy,
+    SortOptionsKeys.Volume,
+    SortOptionsKeys.MarketCap,
   ],
 }
 
 export const marketDataBySortKey: Record<SortOptionsKeys, keyof MarketData | 'apy'> = {
-  [SortOptionsKeys.APY]: 'apy',
-  [SortOptionsKeys.MARKET_CAP]: 'marketCap',
-  [SortOptionsKeys.VOLUME]: 'volume',
-  [SortOptionsKeys.PRICE_CHANGE]: 'changePercent24Hr',
+  [SortOptionsKeys.Apy]: 'apy',
+  [SortOptionsKeys.MarketCap]: 'marketCap',
+  [SortOptionsKeys.Volume]: 'volume',
+  [SortOptionsKeys.PriceChange]: 'changePercent24Hr',
 }

--- a/src/pages/Markets/constants.ts
+++ b/src/pages/Markets/constants.ts
@@ -1,3 +1,7 @@
+import type { MarketData } from '@shapeshiftoss/types'
+import type { SortOption } from 'components/SortDropdown/types'
+import { SortOptionsKeys } from 'components/SortDropdown/types'
+
 export enum MARKETS_CATEGORIES {
   TRADING_VOLUME = 'tradingVolume',
   MARKET_CAP = 'marketCap',
@@ -6,4 +10,99 @@ export enum MARKETS_CATEGORIES {
   RECENTLY_ADDED = 'recentlyAdded',
   ONE_CLICK_DEFI = 'oneClickDefiAssets',
   THORCHAIN_DEFI = 'thorchainDefi',
+}
+
+export const sortOptionsByCategory: Record<MARKETS_CATEGORIES, SortOption[] | undefined> = {
+  [MARKETS_CATEGORIES.TRADING_VOLUME]: undefined,
+  [MARKETS_CATEGORIES.MARKET_CAP]: [
+    {
+      key: SortOptionsKeys.VOLUME,
+      label: 'dashboard.portfolio.volume',
+    },
+    {
+      key: SortOptionsKeys.PRICE_CHANGE,
+      label: 'dashboard.portfolio.priceChange',
+    },
+    {
+      key: SortOptionsKeys.MARKET_CAP,
+      label: 'dashboard.portfolio.marketCap',
+    },
+  ],
+  [MARKETS_CATEGORIES.TRENDING]: [
+    {
+      key: SortOptionsKeys.VOLUME,
+      label: 'dashboard.portfolio.volume',
+    },
+    {
+      key: SortOptionsKeys.PRICE_CHANGE,
+      label: 'dashboard.portfolio.priceChange',
+    },
+    {
+      key: SortOptionsKeys.MARKET_CAP,
+      label: 'dashboard.portfolio.marketCap',
+    },
+  ],
+  [MARKETS_CATEGORIES.TOP_MOVERS]: [
+    {
+      key: SortOptionsKeys.VOLUME,
+      label: 'dashboard.portfolio.volume',
+    },
+    {
+      key: SortOptionsKeys.PRICE_CHANGE,
+      label: 'dashboard.portfolio.priceChange',
+    },
+    {
+      key: SortOptionsKeys.MARKET_CAP,
+      label: 'dashboard.portfolio.marketCap',
+    },
+  ],
+  [MARKETS_CATEGORIES.RECENTLY_ADDED]: [
+    {
+      key: SortOptionsKeys.VOLUME,
+      label: 'dashboard.portfolio.volume',
+    },
+    {
+      key: SortOptionsKeys.PRICE_CHANGE,
+      label: 'dashboard.portfolio.priceChange',
+    },
+    {
+      key: SortOptionsKeys.MARKET_CAP,
+      label: 'dashboard.portfolio.marketCap',
+    },
+  ],
+  [MARKETS_CATEGORIES.ONE_CLICK_DEFI]: [
+    {
+      key: SortOptionsKeys.APY,
+      label: 'common.apy',
+    },
+    {
+      key: SortOptionsKeys.VOLUME,
+      label: 'dashboard.portfolio.volume',
+    },
+    {
+      key: SortOptionsKeys.MARKET_CAP,
+      label: 'dashboard.portfolio.marketCap',
+    },
+  ],
+  [MARKETS_CATEGORIES.THORCHAIN_DEFI]: [
+    {
+      key: SortOptionsKeys.APY,
+      label: 'common.apy',
+    },
+    {
+      key: SortOptionsKeys.VOLUME,
+      label: 'dashboard.portfolio.volume',
+    },
+    {
+      key: SortOptionsKeys.MARKET_CAP,
+      label: 'dashboard.portfolio.marketCap',
+    },
+  ],
+}
+
+export const marketDataBySortKey: Record<SortOptionsKeys, keyof MarketData | 'apy'> = {
+  [SortOptionsKeys.APY]: 'apy',
+  [SortOptionsKeys.MARKET_CAP]: 'marketCap',
+  [SortOptionsKeys.VOLUME]: 'volume',
+  [SortOptionsKeys.PRICE_CHANGE]: 'changePercent24Hr',
 }

--- a/src/pages/Markets/hooks/useCoingeckoData.ts
+++ b/src/pages/Markets/hooks/useCoingeckoData.ts
@@ -3,6 +3,8 @@ import type { AssetsByIdPartial, MarketData } from '@shapeshiftoss/types'
 import { makeAsset } from '@shapeshiftoss/utils'
 import { skipToken, useQuery } from '@tanstack/react-query'
 import { DEFAULT_HISTORY_TIMEFRAME } from 'constants/Config'
+import { OrderOptionsKeys } from 'components/OrderDropdown/types'
+import { SortOptionsKeys } from 'components/SortDropdown/types'
 import type { CoingeckoAsset, CoingeckoList } from 'lib/coingecko/types'
 import {
   getCoingeckoMarkets,
@@ -93,7 +95,15 @@ const selectCoingeckoAssets = (
   )
 }
 
-export const useTopMoversQuery = ({ enabled = true }: { enabled?: boolean }) => {
+export const useTopMoversQuery = ({
+  enabled = true,
+  orderBy,
+  sortBy,
+}: {
+  enabled?: boolean
+  sortBy?: SortOptionsKeys
+  orderBy?: OrderOptionsKeys
+}) => {
   const dispatch = useAppDispatch()
   const assets = useAppSelector(selectAssets)
 
@@ -107,7 +117,16 @@ export const useTopMoversQuery = ({ enabled = true }: { enabled?: boolean }) => 
   return topMoversQuery
 }
 
-export const useTrendingQuery = ({ enabled = true }: { enabled?: boolean }) => {
+export const useTrendingQuery = ({
+  enabled = true,
+  orderBy,
+  sortBy,
+}: {
+  enabled?: boolean
+
+  sortBy?: SortOptionsKeys
+  orderBy?: OrderOptionsKeys
+}) => {
   const dispatch = useAppDispatch()
   const assets = useAppSelector(selectAssets)
 
@@ -121,7 +140,15 @@ export const useTrendingQuery = ({ enabled = true }: { enabled?: boolean }) => {
   return trendingQuery
 }
 
-export const useRecentlyAddedQuery = ({ enabled = true }: { enabled?: boolean }) => {
+export const useRecentlyAddedQuery = ({
+  enabled = true,
+  orderBy,
+  sortBy,
+}: {
+  enabled?: boolean
+  sortBy?: SortOptionsKeys
+  orderBy?: OrderOptionsKeys
+}) => {
   const dispatch = useAppDispatch()
   const assets = useAppSelector(selectAssets)
 
@@ -138,16 +165,50 @@ export const useRecentlyAddedQuery = ({ enabled = true }: { enabled?: boolean })
 export const useMarketsQuery = ({
   enabled = true,
   orderBy,
+  sortBy,
 }: {
-  orderBy: 'market_cap_desc' | 'volume_desc'
+  orderBy?: OrderOptionsKeys
+  sortBy?: SortOptionsKeys
   enabled?: boolean
 }) => {
   const dispatch = useAppDispatch()
   const assets = useAppSelector(selectAssets)
 
+  const prefixOrderBy = (() => {
+    switch (sortBy) {
+      case SortOptionsKeys.PRICE_CHANGE:
+        return 'price_change_percentage_24h'
+      case SortOptionsKeys.MARKET_CAP:
+        return 'market_cap'
+      case SortOptionsKeys.VOLUME:
+        return 'volume'
+      default:
+        return 'volume'
+    }
+  })()
+
+  const sort = (() => {
+    switch (orderBy) {
+      case OrderOptionsKeys.ASCENDING:
+        return 'asc'
+      case OrderOptionsKeys.DESCENDING:
+        return 'desc'
+      default:
+        return 'desc'
+    }
+  })()
+
+  const order = `${prefixOrderBy}_${sort}` as
+    | 'market_cap_asc'
+    | 'market_cap_desc'
+    | 'volume_desc'
+    | 'volume_asc'
+    | 'price_change_percentage_24h_desc'
+    | 'price_change_percentage_24h_asc'
+
   const recentlyAddedQuery = useQuery({
-    queryKey: ['coinGeckoMarkets', orderBy],
-    queryFn: enabled ? () => getCoingeckoMarkets(orderBy) : skipToken,
+    queryKey: ['coinGeckoMarkets', order],
+    queryFn: enabled ? () => getCoingeckoMarkets(order) : skipToken,
     staleTime: Infinity,
     select: data => selectCoingeckoAssets(data, dispatch, assets),
   })

--- a/src/pages/Markets/hooks/useCoingeckoData.ts
+++ b/src/pages/Markets/hooks/useCoingeckoData.ts
@@ -23,7 +23,7 @@ import {
 import type { AppDispatch } from 'state/store'
 import { store, useAppDispatch, useAppSelector } from 'state/store'
 
-import { marketDataBySortKey, MARKETS_CATEGORIES } from '../constants'
+import { marketDataBySortKey, MarketsCategories } from '../constants'
 
 const selectCoingeckoAssets = (
   data: CoingeckoAsset[],
@@ -251,9 +251,9 @@ export const useMarketsQuery = ({
 }
 
 export const CATEGORY_TO_QUERY_HOOK = {
-  [MARKETS_CATEGORIES.TOP_MOVERS]: useTopMoversQuery,
-  [MARKETS_CATEGORIES.TRENDING]: useTrendingQuery,
-  [MARKETS_CATEGORIES.RECENTLY_ADDED]: useRecentlyAddedQuery,
-  [MARKETS_CATEGORIES.MARKET_CAP]: useMarketsQuery,
-  [MARKETS_CATEGORIES.TRADING_VOLUME]: useMarketsQuery,
+  [MarketsCategories.TopMovers]: useTopMoversQuery,
+  [MarketsCategories.Trending]: useTrendingQuery,
+  [MarketsCategories.RecentlyAdded]: useRecentlyAddedQuery,
+  [MarketsCategories.MarketCap]: useMarketsQuery,
+  [MarketsCategories.TradingVolume]: useMarketsQuery,
 }

--- a/src/pages/Markets/hooks/usePortalsAssetsQuery.ts
+++ b/src/pages/Markets/hooks/usePortalsAssetsQuery.ts
@@ -1,6 +1,8 @@
 import type { AssetId, ChainId } from '@shapeshiftoss/caip'
 import { ASSET_NAMESPACE, bscChainId, toAssetId } from '@shapeshiftoss/caip'
 import { skipToken, useQuery } from '@tanstack/react-query'
+import { OrderOptionsKeys } from 'components/OrderDropdown/types'
+import { SortOptionsKeys } from 'components/SortDropdown/types'
 import { PORTALS_NETWORK_TO_CHAIN_ID } from 'lib/portals/constants'
 import type { TokenInfo } from 'lib/portals/types'
 import { fetchPortalsPlatforms, fetchPortalsTokens, portalTokenToAsset } from 'lib/portals/utils'
@@ -18,9 +20,13 @@ export type PortalsAssets = {
 export const usePortalsAssetsQuery = ({
   enabled,
   chainIds,
+  sortBy,
+  orderBy,
 }: {
   enabled: boolean
   chainIds: ChainId[] | undefined
+  sortBy?: SortOptionsKeys
+  orderBy?: OrderOptionsKeys
 }) => {
   const dispatch = useAppDispatch()
   const assets = useAppSelector(selectAssets)
@@ -32,15 +38,18 @@ export const usePortalsAssetsQuery = ({
   })
 
   return useQuery({
-    queryKey: ['portalsAssets', { chainIds }],
+    queryKey: ['portalsAssets', { chainIds, orderBy, sortBy }],
     queryFn:
       enabled && portalsPlatformsData
         ? () =>
             fetchPortalsTokens({
               limit: 10,
               chainIds,
-              sortBy: 'apy',
-              sortDirection: 'desc',
+              sortBy: sortBy === SortOptionsKeys.VOLUME ? 'volumeUsd1d' : 'apy',
+              sortDirection:
+                orderBy === OrderOptionsKeys.ASCENDING && sortBy !== SortOptionsKeys.MARKET_CAP
+                  ? 'asc'
+                  : 'desc',
             })
         : skipToken,
     gcTime: 60 * 1000 * 5,

--- a/src/pages/Markets/hooks/usePortalsAssetsQuery.ts
+++ b/src/pages/Markets/hooks/usePortalsAssetsQuery.ts
@@ -1,7 +1,7 @@
 import type { AssetId, ChainId } from '@shapeshiftoss/caip'
 import { ASSET_NAMESPACE, bscChainId, toAssetId } from '@shapeshiftoss/caip'
 import { skipToken, useQuery } from '@tanstack/react-query'
-import { OrderOptionsKeys } from 'components/OrderDropdown/types'
+import { OrderDirection } from 'components/OrderDropdown/types'
 import { SortOptionsKeys } from 'components/SortDropdown/types'
 import { PORTALS_NETWORK_TO_CHAIN_ID } from 'lib/portals/constants'
 import type { TokenInfo } from 'lib/portals/types'
@@ -26,7 +26,7 @@ export const usePortalsAssetsQuery = ({
   enabled: boolean
   chainIds: ChainId[] | undefined
   sortBy?: SortOptionsKeys
-  orderBy?: OrderOptionsKeys
+  orderBy?: OrderDirection
 }) => {
   const dispatch = useAppDispatch()
   const assets = useAppSelector(selectAssets)
@@ -45,9 +45,9 @@ export const usePortalsAssetsQuery = ({
             fetchPortalsTokens({
               limit: 10,
               chainIds,
-              sortBy: sortBy === SortOptionsKeys.VOLUME ? 'volumeUsd1d' : 'apy',
+              sortBy: sortBy === SortOptionsKeys.Volume ? 'volumeUsd1d' : 'apy',
               sortDirection:
-                orderBy === OrderOptionsKeys.ASCENDING && sortBy !== SortOptionsKeys.MARKET_CAP
+                orderBy === OrderDirection.Ascending && sortBy !== SortOptionsKeys.MarketCap
                   ? 'asc'
                   : 'desc',
             })

--- a/src/pages/Markets/hooks/useRows.tsx
+++ b/src/pages/Markets/hooks/useRows.tsx
@@ -9,7 +9,7 @@ import { SUPPORTED_THORCHAIN_SAVERS_CHAIN_IDS } from 'state/slices/opportunities
 
 import { AssetGridWithData } from '../components/AssetGridWithData'
 import { OneClickDefiAssets, ThorchainAssets } from '../components/LpGrid'
-import { MARKETS_CATEGORIES } from '../constants'
+import { MarketsCategories } from '../constants'
 
 export type RowProps = {
   selectedChainId: ChainId | undefined
@@ -24,9 +24,9 @@ export const useRows = ({ limit }: { limit: number }) => {
   const coingeckoSupportedChainIds = useMemo(() => getCoingeckoSupportedChainIds(), [])
 
   const MARKETS_CATEGORY_TO_ROW: Record<
-    MARKETS_CATEGORIES,
+    MarketsCategories,
     {
-      category: MARKETS_CATEGORIES
+      category: MarketsCategories
       title: string
       subtitle?: string
       component: (props: RowProps) => JSX.Element
@@ -34,14 +34,14 @@ export const useRows = ({ limit }: { limit: number }) => {
     }
   > = useMemo(
     () => ({
-      [MARKETS_CATEGORIES.TRADING_VOLUME]: {
-        category: MARKETS_CATEGORIES.TRADING_VOLUME,
-        title: translate(`markets.categories.${MARKETS_CATEGORIES.TRADING_VOLUME}.title`),
-        subtitle: translate(`markets.categories.${MARKETS_CATEGORIES.TRADING_VOLUME}.subtitle`),
+      [MarketsCategories.TradingVolume]: {
+        category: MarketsCategories.TradingVolume,
+        title: translate(`markets.categories.${MarketsCategories.TradingVolume}.title`),
+        subtitle: translate(`markets.categories.${MarketsCategories.TradingVolume}.subtitle`),
         supportedChainIds: coingeckoSupportedChainIds,
         component: ({ selectedChainId, showSparkline, sortBy, orderBy }: RowProps) => (
           <AssetGridWithData
-            category={MARKETS_CATEGORIES.TRADING_VOLUME}
+            category={MarketsCategories.TradingVolume}
             selectedChainId={selectedChainId}
             showSparkline={showSparkline}
             limit={limit}
@@ -50,14 +50,14 @@ export const useRows = ({ limit }: { limit: number }) => {
           />
         ),
       },
-      [MARKETS_CATEGORIES.MARKET_CAP]: {
-        category: MARKETS_CATEGORIES.MARKET_CAP,
-        title: translate(`markets.categories.${MARKETS_CATEGORIES.MARKET_CAP}.title`),
-        subtitle: translate(`markets.categories.${MARKETS_CATEGORIES.MARKET_CAP}.subtitle`),
+      [MarketsCategories.MarketCap]: {
+        category: MarketsCategories.MarketCap,
+        title: translate(`markets.categories.${MarketsCategories.MarketCap}.title`),
+        subtitle: translate(`markets.categories.${MarketsCategories.MarketCap}.subtitle`),
         supportedChainIds: coingeckoSupportedChainIds,
         component: ({ selectedChainId, showSparkline, orderBy, sortBy }: RowProps) => (
           <AssetGridWithData
-            category={MARKETS_CATEGORIES.MARKET_CAP}
+            category={MarketsCategories.MarketCap}
             selectedChainId={selectedChainId}
             showSparkline={showSparkline}
             limit={limit}
@@ -67,14 +67,14 @@ export const useRows = ({ limit }: { limit: number }) => {
           />
         ),
       },
-      [MARKETS_CATEGORIES.TRENDING]: {
-        category: MARKETS_CATEGORIES.TRENDING,
-        title: translate(`markets.categories.${MARKETS_CATEGORIES.TRENDING}.title`),
-        subtitle: translate(`markets.categories.${MARKETS_CATEGORIES.TRENDING}.subtitle`),
+      [MarketsCategories.Trending]: {
+        category: MarketsCategories.Trending,
+        title: translate(`markets.categories.${MarketsCategories.Trending}.title`),
+        subtitle: translate(`markets.categories.${MarketsCategories.Trending}.subtitle`),
         supportedChainIds: coingeckoSupportedChainIds,
         component: ({ selectedChainId, showSparkline, orderBy, sortBy }: RowProps) => (
           <AssetGridWithData
-            category={MARKETS_CATEGORIES.TRENDING}
+            category={MarketsCategories.Trending}
             selectedChainId={selectedChainId}
             showSparkline={showSparkline}
             limit={limit}
@@ -83,16 +83,16 @@ export const useRows = ({ limit }: { limit: number }) => {
           />
         ),
       },
-      [MARKETS_CATEGORIES.TOP_MOVERS]: {
-        category: MARKETS_CATEGORIES.TOP_MOVERS,
-        title: translate(`markets.categories.${MARKETS_CATEGORIES.TOP_MOVERS}.title`),
-        subtitle: translate(`markets.categories.${MARKETS_CATEGORIES.TOP_MOVERS}.subtitle`, {
+      [MarketsCategories.TopMovers]: {
+        category: MarketsCategories.TopMovers,
+        title: translate(`markets.categories.${MarketsCategories.TopMovers}.title`),
+        subtitle: translate(`markets.categories.${MarketsCategories.TopMovers}.subtitle`, {
           percentage: '10',
         }),
         supportedChainIds: coingeckoSupportedChainIds,
         component: ({ selectedChainId, showSparkline, orderBy, sortBy }: RowProps) => (
           <AssetGridWithData
-            category={MARKETS_CATEGORIES.TOP_MOVERS}
+            category={MarketsCategories.TopMovers}
             selectedChainId={selectedChainId}
             showSparkline={showSparkline}
             limit={limit}
@@ -101,14 +101,14 @@ export const useRows = ({ limit }: { limit: number }) => {
           />
         ),
       },
-      [MARKETS_CATEGORIES.RECENTLY_ADDED]: {
-        category: MARKETS_CATEGORIES.RECENTLY_ADDED,
-        title: translate(`markets.categories.${MARKETS_CATEGORIES.RECENTLY_ADDED}.title`),
-        subtitle: translate(`markets.categories.${MARKETS_CATEGORIES.RECENTLY_ADDED}.subtitle`),
+      [MarketsCategories.RecentlyAdded]: {
+        category: MarketsCategories.RecentlyAdded,
+        title: translate(`markets.categories.${MarketsCategories.RecentlyAdded}.title`),
+        subtitle: translate(`markets.categories.${MarketsCategories.RecentlyAdded}.subtitle`),
         supportedChainIds: coingeckoSupportedChainIds,
         component: ({ selectedChainId, showSparkline, orderBy, sortBy }: RowProps) => (
           <AssetGridWithData
-            category={MARKETS_CATEGORIES.RECENTLY_ADDED}
+            category={MarketsCategories.RecentlyAdded}
             selectedChainId={selectedChainId}
             showSparkline={showSparkline}
             limit={limit}
@@ -117,10 +117,10 @@ export const useRows = ({ limit }: { limit: number }) => {
           />
         ),
       },
-      [MARKETS_CATEGORIES.ONE_CLICK_DEFI]: {
-        category: MARKETS_CATEGORIES.ONE_CLICK_DEFI,
-        title: translate(`markets.categories.${MARKETS_CATEGORIES.ONE_CLICK_DEFI}.title`),
-        subtitle: translate(`markets.categories.${MARKETS_CATEGORIES.ONE_CLICK_DEFI}.subtitle`),
+      [MarketsCategories.OneClickDefi]: {
+        category: MarketsCategories.OneClickDefi,
+        title: translate(`markets.categories.${MarketsCategories.OneClickDefi}.title`),
+        subtitle: translate(`markets.categories.${MarketsCategories.OneClickDefi}.subtitle`),
         component: ({ selectedChainId, orderBy, sortBy }: RowProps) => (
           <OneClickDefiAssets
             selectedChainId={selectedChainId}
@@ -131,10 +131,10 @@ export const useRows = ({ limit }: { limit: number }) => {
         ),
         supportedChainIds: PORTALS_SUPPORTED_CHAIN_IDS.buy,
       },
-      [MARKETS_CATEGORIES.THORCHAIN_DEFI]: {
-        category: MARKETS_CATEGORIES.THORCHAIN_DEFI,
-        title: translate(`markets.categories.${MARKETS_CATEGORIES.THORCHAIN_DEFI}.title`),
-        subtitle: translate(`markets.categories.${MARKETS_CATEGORIES.THORCHAIN_DEFI}.subtitle`),
+      [MarketsCategories.ThorchainDefi]: {
+        category: MarketsCategories.ThorchainDefi,
+        title: translate(`markets.categories.${MarketsCategories.ThorchainDefi}.title`),
+        subtitle: translate(`markets.categories.${MarketsCategories.ThorchainDefi}.subtitle`),
         component: ({ selectedChainId, orderBy, sortBy }: RowProps) => (
           <ThorchainAssets
             selectedChainId={selectedChainId}

--- a/src/pages/Markets/hooks/useRows.tsx
+++ b/src/pages/Markets/hooks/useRows.tsx
@@ -2,7 +2,7 @@ import type { ChainId } from '@shapeshiftoss/caip'
 import { PORTALS_SUPPORTED_CHAIN_IDS } from '@shapeshiftoss/swapper/dist/swappers/PortalsSwapper/constants'
 import { useMemo } from 'react'
 import { useTranslate } from 'react-polyglot'
-import { OrderOptionsKeys } from 'components/OrderDropdown/types'
+import { OrderDirection } from 'components/OrderDropdown/types'
 import { SortOptionsKeys } from 'components/SortDropdown/types'
 import { getCoingeckoSupportedChainIds } from 'lib/coingecko/utils'
 import { SUPPORTED_THORCHAIN_SAVERS_CHAIN_IDS } from 'state/slices/opportunitiesSlice/resolvers/thorchainsavers/utils'
@@ -15,7 +15,7 @@ export type RowProps = {
   selectedChainId: ChainId | undefined
   showSparkline?: boolean
   sortBy?: SortOptionsKeys
-  orderBy?: OrderOptionsKeys
+  orderBy?: OrderDirection
 }
 
 export const useRows = ({ limit }: { limit: number }) => {
@@ -45,8 +45,8 @@ export const useRows = ({ limit }: { limit: number }) => {
             selectedChainId={selectedChainId}
             showSparkline={showSparkline}
             limit={limit}
-            orderBy={orderBy ?? OrderOptionsKeys.DESCENDING}
-            sortBy={sortBy ?? SortOptionsKeys.VOLUME}
+            orderBy={orderBy ?? OrderDirection.Descending}
+            sortBy={sortBy ?? SortOptionsKeys.Volume}
           />
         ),
       },
@@ -62,8 +62,8 @@ export const useRows = ({ limit }: { limit: number }) => {
             showSparkline={showSparkline}
             limit={limit}
             showMarketCap
-            orderBy={orderBy ?? OrderOptionsKeys.DESCENDING}
-            sortBy={sortBy ?? SortOptionsKeys.MARKET_CAP}
+            orderBy={orderBy ?? OrderDirection.Descending}
+            sortBy={sortBy ?? SortOptionsKeys.MarketCap}
           />
         ),
       },

--- a/src/pages/Markets/hooks/useRows.tsx
+++ b/src/pages/Markets/hooks/useRows.tsx
@@ -2,6 +2,8 @@ import type { ChainId } from '@shapeshiftoss/caip'
 import { PORTALS_SUPPORTED_CHAIN_IDS } from '@shapeshiftoss/swapper/dist/swappers/PortalsSwapper/constants'
 import { useMemo } from 'react'
 import { useTranslate } from 'react-polyglot'
+import { OrderOptionsKeys } from 'components/OrderDropdown/types'
+import { SortOptionsKeys } from 'components/SortDropdown/types'
 import { getCoingeckoSupportedChainIds } from 'lib/coingecko/utils'
 import { SUPPORTED_THORCHAIN_SAVERS_CHAIN_IDS } from 'state/slices/opportunitiesSlice/resolvers/thorchainsavers/utils'
 
@@ -12,6 +14,8 @@ import { MARKETS_CATEGORIES } from '../constants'
 export type RowProps = {
   selectedChainId: ChainId | undefined
   showSparkline?: boolean
+  sortBy?: SortOptionsKeys
+  orderBy?: OrderOptionsKeys
 }
 
 export const useRows = ({ limit }: { limit: number }) => {
@@ -35,13 +39,14 @@ export const useRows = ({ limit }: { limit: number }) => {
         title: translate(`markets.categories.${MARKETS_CATEGORIES.TRADING_VOLUME}.title`),
         subtitle: translate(`markets.categories.${MARKETS_CATEGORIES.TRADING_VOLUME}.subtitle`),
         supportedChainIds: coingeckoSupportedChainIds,
-        component: ({ selectedChainId, showSparkline }: RowProps) => (
+        component: ({ selectedChainId, showSparkline, sortBy, orderBy }: RowProps) => (
           <AssetGridWithData
             category={MARKETS_CATEGORIES.TRADING_VOLUME}
             selectedChainId={selectedChainId}
             showSparkline={showSparkline}
             limit={limit}
-            orderBy='volume_desc'
+            orderBy={orderBy ?? OrderOptionsKeys.DESCENDING}
+            sortBy={sortBy ?? SortOptionsKeys.VOLUME}
           />
         ),
       },
@@ -50,14 +55,15 @@ export const useRows = ({ limit }: { limit: number }) => {
         title: translate(`markets.categories.${MARKETS_CATEGORIES.MARKET_CAP}.title`),
         subtitle: translate(`markets.categories.${MARKETS_CATEGORIES.MARKET_CAP}.subtitle`),
         supportedChainIds: coingeckoSupportedChainIds,
-        component: ({ selectedChainId, showSparkline }: RowProps) => (
+        component: ({ selectedChainId, showSparkline, orderBy, sortBy }: RowProps) => (
           <AssetGridWithData
             category={MARKETS_CATEGORIES.MARKET_CAP}
-            orderBy='market_cap_desc'
             selectedChainId={selectedChainId}
             showSparkline={showSparkline}
             limit={limit}
             showMarketCap
+            orderBy={orderBy ?? OrderOptionsKeys.DESCENDING}
+            sortBy={sortBy ?? SortOptionsKeys.MARKET_CAP}
           />
         ),
       },
@@ -66,12 +72,14 @@ export const useRows = ({ limit }: { limit: number }) => {
         title: translate(`markets.categories.${MARKETS_CATEGORIES.TRENDING}.title`),
         subtitle: translate(`markets.categories.${MARKETS_CATEGORIES.TRENDING}.subtitle`),
         supportedChainIds: coingeckoSupportedChainIds,
-        component: ({ selectedChainId, showSparkline }: RowProps) => (
+        component: ({ selectedChainId, showSparkline, orderBy, sortBy }: RowProps) => (
           <AssetGridWithData
             category={MARKETS_CATEGORIES.TRENDING}
             selectedChainId={selectedChainId}
             showSparkline={showSparkline}
             limit={limit}
+            orderBy={orderBy}
+            sortBy={sortBy}
           />
         ),
       },
@@ -82,12 +90,14 @@ export const useRows = ({ limit }: { limit: number }) => {
           percentage: '10',
         }),
         supportedChainIds: coingeckoSupportedChainIds,
-        component: ({ selectedChainId, showSparkline }: RowProps) => (
+        component: ({ selectedChainId, showSparkline, orderBy, sortBy }: RowProps) => (
           <AssetGridWithData
             category={MARKETS_CATEGORIES.TOP_MOVERS}
             selectedChainId={selectedChainId}
             showSparkline={showSparkline}
             limit={limit}
+            orderBy={orderBy}
+            sortBy={sortBy}
           />
         ),
       },
@@ -96,12 +106,14 @@ export const useRows = ({ limit }: { limit: number }) => {
         title: translate(`markets.categories.${MARKETS_CATEGORIES.RECENTLY_ADDED}.title`),
         subtitle: translate(`markets.categories.${MARKETS_CATEGORIES.RECENTLY_ADDED}.subtitle`),
         supportedChainIds: coingeckoSupportedChainIds,
-        component: ({ selectedChainId, showSparkline }: RowProps) => (
+        component: ({ selectedChainId, showSparkline, orderBy, sortBy }: RowProps) => (
           <AssetGridWithData
             category={MARKETS_CATEGORIES.RECENTLY_ADDED}
             selectedChainId={selectedChainId}
             showSparkline={showSparkline}
             limit={limit}
+            orderBy={orderBy}
+            sortBy={sortBy}
           />
         ),
       },
@@ -109,8 +121,13 @@ export const useRows = ({ limit }: { limit: number }) => {
         category: MARKETS_CATEGORIES.ONE_CLICK_DEFI,
         title: translate(`markets.categories.${MARKETS_CATEGORIES.ONE_CLICK_DEFI}.title`),
         subtitle: translate(`markets.categories.${MARKETS_CATEGORIES.ONE_CLICK_DEFI}.subtitle`),
-        component: ({ selectedChainId }: RowProps) => (
-          <OneClickDefiAssets selectedChainId={selectedChainId} limit={limit} />
+        component: ({ selectedChainId, orderBy, sortBy }: RowProps) => (
+          <OneClickDefiAssets
+            selectedChainId={selectedChainId}
+            limit={limit}
+            orderBy={orderBy}
+            sortBy={sortBy}
+          />
         ),
         supportedChainIds: PORTALS_SUPPORTED_CHAIN_IDS.buy,
       },
@@ -118,9 +135,15 @@ export const useRows = ({ limit }: { limit: number }) => {
         category: MARKETS_CATEGORIES.THORCHAIN_DEFI,
         title: translate(`markets.categories.${MARKETS_CATEGORIES.THORCHAIN_DEFI}.title`),
         subtitle: translate(`markets.categories.${MARKETS_CATEGORIES.THORCHAIN_DEFI}.subtitle`),
-        component: ({ selectedChainId }: RowProps) => (
-          <ThorchainAssets selectedChainId={selectedChainId} limit={limit} />
+        component: ({ selectedChainId, orderBy, sortBy }: RowProps) => (
+          <ThorchainAssets
+            selectedChainId={selectedChainId}
+            limit={limit}
+            orderBy={orderBy}
+            sortBy={sortBy}
+          />
         ),
+
         supportedChainIds: SUPPORTED_THORCHAIN_SAVERS_CHAIN_IDS,
       },
     }),


### PR DESCRIPTION
## Description

- Coingecko assets are using the API sorting parameters so we get new data for the Market Cap and Volume categories
-- Other are using sorting on the already fetched data
- Portal assets and Thorchain pools are using the same sorting thing inside effects, minus the price change, plus APY sorting as it's cleaner for our users to be able to sort by APY
-- Portals is refetching using the API sorting if it's using APY or Volume so we get a bigger chunk of data


<!-- Please describe your changes -->

## Issue (if applicable)

<!-----------------------------------------------------------------------------
If applicable, please link to the github issue and put `closes #XXXX` in your comment to auto-close the issue that your PR fixes.
------------------------------------------------------------------------------>

closes #7919

## Risk
Low
> High Risk PRs Require 2 approvals

<!-----------------------------------------------------------------------------
Outline the scope of your changes and the risk associated with them. You must use your discretion as an engineer to determine the potential impact of your changes.

WARNING: If your PR introduces a new on-chain transaction or modifies an existing one, please add the "High-Risk" label to this PR and ask for 2 reviewers to approve it before merging.

E.g. an upgrade to `hdwallet` or core state management would be considered higher risk, and might require a full regression test. UI or isolated view changes, or something behind a feature flag may have near zero risk. Small bug fixes might require testing isolated to the specific fix.
------------------------------------------------------------------------------>

> What protocols, transaction types, wallets or contract interactions might be affected by this PR?

## Testing
- Play with filters on every pages of the market page, filters should work accordingly
- Base categories should display assets as expected without showing the filters
- Thorchain and Portals should use the APY filter instead of the price change filter
- Make sure Volume and Market Cap categories are not having the sort dropdowns
- Additionnaly for Engineer, verify extra requests on portals for APY and volume, extra request for coingecko market cap and volume categories

<!-----------------------------------------------------------------------------
We treat every PR to be merged with the same scrutiny as if we were merging directly to production.

Your PR will not be merged if you do not complete the sections below for our engineering and operations teams to test.
------------------------------------------------------------------------------>

### Engineering
n/a
<!-----------------------------------------------------------------------------
Include sufficient information here for an engineer to test your PR. This may include how to test locally, in a built environment, changes to infrastructure etc.
------------------------------------------------------------------------------>

### Operations

- [ ] :checkered_flag: My feature is behind a flag and doesn't require operations testing (yet)

<!-----------------------------------------------------------------------------
If your changes have a user-facing impact, describe how a non-technical QA team can functionally test your changes in a preview environment.

If they are not user-facing please describe how to test for any regressions that may occur.
------------------------------------------------------------------------------>

## Screenshots (if applicable)
https://jam.dev/c/275edc08-d6a3-4e96-83b4-795d0d58b02b
https://jam.dev/c/18ee9265-56b8-42b1-b7f3-6487eee1217f