### PR TITLE
feat: action beard feedback on limit orders ui

### DIFF
--- a/src/assets/translations/en/main.json
+++ b/src/assets/translations/en/main.json
@@ -1003,7 +1003,7 @@
     }
   },
   "limitOrder": {
-    "heading": "Limit Order",
+    "heading": "Limit",
     "confirm": "Confirm",
     "placeOrderPending": "Waiting for Confirmation",
     "placeOrderSuccess": "Success!",

--- a/src/components/AssetSelection/AssetSelection.tsx
+++ b/src/components/AssetSelection/AssetSelection.tsx
@@ -8,10 +8,8 @@ import { Text } from 'components/Text'
 import { selectAssets } from 'state/slices/selectors'
 import { useAppSelector } from 'state/store'
 
-import { AssetChainDropdown } from './components/AssetChainDropdown/AssetChainDropdown'
-import { AssetMenuButton } from './components/AssetMenuButton'
-
-const disabledStyle = { cursor: 'not-allowed' }
+import { StyledAssetChainDropdown } from './components/AssetChainDropdown/AssetChainDropdown'
+import { StyledAssetMenuButton } from './components/AssetMenuButton'
 
 type TradeAssetSelectBaseProps = {
   assetId?: AssetId
@@ -85,42 +83,26 @@ export const TradeAssetSelect: React.FC<TradeAssetSelectProps> = memo(props => {
   )
 
   const rightIcon = useMemo(() => (isReadOnly ? undefined : <ChevronDownIcon />), [isReadOnly])
-  const combinedButtonProps = useMemo(() => {
-    return Object.assign(
-      {
-        height: '40px',
-        justifyContent: 'flex-end',
-        pl: 2,
-        pr: isReadOnly ? 4 : 2,
-        py: 2,
-        gap: 2,
-        size: 'sm',
-        borderRadius: 'full',
-        rightIcon,
-        maxWidth: '50%',
-        _disabled: disabledStyle,
-      },
-      buttonProps,
-    )
-  }, [isReadOnly, rightIcon, buttonProps])
 
   return (
     <Flex px={4} mb={4} alignItems='center' gap={2} {...flexProps}>
-      <AssetMenuButton
+      <StyledAssetMenuButton
         assetId={assetId}
         onAssetClick={onAssetClick}
-        buttonProps={combinedButtonProps}
+        buttonProps={buttonProps}
         isLoading={isLoading}
         isDisabled={Boolean(isReadOnly)}
+        rightIcon={rightIcon}
       />
       <Text flex='0 1 auto' translation='trade.on' color='text.subtle' fontSize='sm' />
-      <AssetChainDropdown
+      <StyledAssetChainDropdown
         assetId={assetId}
         assetIds={assetIds}
         onChangeAsset={handleAssetChange}
         isLoading={isLoading}
         isDisabled={Boolean(isReadOnly)}
-        buttonProps={combinedButtonProps}
+        buttonProps={buttonProps}
+        rightIcon={rightIcon}
         onlyConnectedChains={onlyConnectedChains}
       />
     </Flex>

--- a/src/components/AssetSelection/components/AssetChainDropdown/AssetChainDropdown.tsx
+++ b/src/components/AssetSelection/components/AssetChainDropdown/AssetChainDropdown.tsx
@@ -11,6 +11,7 @@ import {
 import type { AssetId } from '@shapeshiftoss/caip'
 import { memo, useCallback, useMemo } from 'react'
 import { useTranslate } from 'react-polyglot'
+import { getStyledMenuButtonProps } from 'components/AssetSelection/helpers'
 import { useWallet } from 'hooks/useWallet/useWallet'
 import { isAssetSupportedByWallet } from 'state/slices/portfolioSlice/utils'
 import { selectRelatedAssetIdsInclusiveSorted } from 'state/slices/related-assets-selectors'
@@ -132,3 +133,17 @@ export const AssetChainDropdown: React.FC<AssetChainDropdownProps> = memo(
     )
   },
 )
+
+export const StyledAssetChainDropdown = ({
+  isDisabled,
+  rightIcon,
+  buttonProps,
+  ...rest
+}: AssetChainDropdownProps & { rightIcon?: React.ReactElement }) => {
+  const combinedButtonProps = useMemo(
+    () => getStyledMenuButtonProps({ isDisabled, rightIcon, buttonProps }),
+    [isDisabled, rightIcon, buttonProps],
+  )
+
+  return <AssetChainDropdown {...rest} buttonProps={combinedButtonProps} isDisabled={isDisabled} />
+}

--- a/src/components/AssetSelection/components/AssetMenuButton.tsx
+++ b/src/components/AssetSelection/components/AssetMenuButton.tsx
@@ -8,12 +8,13 @@ import { AssetIcon } from 'components/AssetIcon'
 import { selectAssetById } from 'state/slices/selectors'
 import { useAppSelector } from 'state/store'
 
+import { getStyledMenuButtonProps } from '../helpers'
 import { AssetRowLoading } from './AssetRowLoading'
 
 export type AssetMenuButtonProps = {
   assetId?: AssetId
   onAssetClick?: (asset: Asset) => void
-  isDisabled: boolean
+  isDisabled?: boolean
   buttonProps?: ButtonProps
   isLoading?: boolean
   showNetworkIcon?: boolean
@@ -58,4 +59,18 @@ export const AssetMenuButton = ({
       </Flex>
     </Button>
   )
+}
+
+export const StyledAssetMenuButton = ({
+  isDisabled,
+  rightIcon,
+  buttonProps,
+  ...rest
+}: AssetMenuButtonProps & { rightIcon?: React.ReactElement }) => {
+  const combinedButtonProps = useMemo(
+    () => getStyledMenuButtonProps({ isDisabled, rightIcon, buttonProps }),
+    [isDisabled, rightIcon, buttonProps],
+  )
+
+  return <AssetMenuButton {...rest} buttonProps={combinedButtonProps} isDisabled={isDisabled} />
 }

--- a/src/components/AssetSelection/helpers.ts
+++ b/src/components/AssetSelection/helpers.ts
@@ -1,0 +1,30 @@
+import type { ButtonProps } from '@chakra-ui/react'
+
+const disabledStyle = { cursor: 'not-allowed' }
+
+export const getStyledMenuButtonProps = ({
+  isDisabled,
+  buttonProps,
+  rightIcon,
+}: {
+  isDisabled?: boolean
+  buttonProps?: ButtonProps
+  rightIcon?: React.ReactElement
+}) => {
+  return Object.assign(
+    {
+      height: '40px',
+      justifyContent: 'flex-end',
+      pl: 2,
+      pr: isDisabled ? 4 : 2,
+      py: 2,
+      gap: 2,
+      size: 'sm',
+      borderRadius: 'full',
+      rightIcon,
+      maxWidth: '50%',
+      _disabled: disabledStyle,
+    },
+    buttonProps,
+  )
+}

--- a/src/components/MultiHopTrade/components/LimitOrder/components/LimitOrderInput.tsx
+++ b/src/components/MultiHopTrade/components/LimitOrder/components/LimitOrderInput.tsx
@@ -170,6 +170,11 @@ export const LimitOrderInput = ({
     [handleFormSubmit],
   )
 
+  const marketPriceBuyAssetCryptoPrecision = '123423'
+  const [limitPriceBuyAssetCryptoPrecision, setLimitPriceBuyAssetCryptoPrecision] = useState(
+    marketPriceBuyAssetCryptoPrecision,
+  )
+
   const bodyContent = useMemo(() => {
     return (
       <SharedTradeInputBody
@@ -196,11 +201,11 @@ export const LimitOrderInput = ({
           />
           <Divider />
           <LimitOrderConfig
+            sellAsset={sellAsset}
             buyAsset={buyAsset}
-            hasUserEnteredAmount={hasUserEnteredAmount}
-            isInputtingFiatSellAmount={isInputtingFiatSellAmount}
-            buyAmountAfterFeesCryptoPrecision={'1123412344123456'}
-            buyAmountAfterFeesUserCurrency={'1.234'}
+            marketPriceBuyAssetCryptoPrecision={marketPriceBuyAssetCryptoPrecision}
+            limitPriceBuyAssetCryptoPrecision={limitPriceBuyAssetCryptoPrecision}
+            setLimitPriceBuyAssetCryptoPrecision={setLimitPriceBuyAssetCryptoPrecision}
           />
         </Stack>
       </SharedTradeInputBody>
@@ -219,7 +224,7 @@ export const LimitOrderInput = ({
     buyAssetAccountId,
     setBuyAssetAccountId,
     setBuyAsset,
-    hasUserEnteredAmount,
+    limitPriceBuyAssetCryptoPrecision,
   ])
 
   const footerContent = useMemo(() => {


### PR DESCRIPTION
## Description

Actions feedback on the limit orders input UI.

- Breaks out the menu buttons for asset and chain selection for re-use in limit orders
- Fixes minor deviations from the product spec
- Adds interactions to set the limit, and to swap the price
- Updates the expiry dropdown items to match the design

All data is placeholder and is not wired up to anything meaningful.

## Issue (if applicable)

NA

## Risk

> High Risk PRs Require 2 approvals

Low risk

> What protocols, transaction types, wallets or contract interactions might be affected by this PR?

## Testing

Check the chain and asset menus in the trade input are still styled correctly.

### Engineering

<!-----------------------------------------------------------------------------
Include sufficient information here for an engineer to test your PR. This may include how to test locally, in a built environment, changes to infrastructure etc.
------------------------------------------------------------------------------>

### Operations

Check the chain and asset menus in the trade input are still styled correctly.

- [x] :checkered_flag: My feature is behind a flag and doesn't require operations testing (yet)

<!-----------------------------------------------------------------------------
If your changes have a user-facing impact, describe how a non-technical QA team can functionally test your changes in a preview environment.

If they are not user-facing please describe how to test for any regressions that may occur.
------------------------------------------------------------------------------>

## Screenshots (if applicable)

https://jam.dev/c/c4c2efd2-9cfa-41cf-bd3c-b21d2c901a5c