### PR TITLE
fix: truncate the symbols when there are multiple

### DIFF
--- a/src/components/TransactionHistoryRows/TransactionGenericRow.tsx
+++ b/src/components/TransactionHistoryRows/TransactionGenericRow.tsx
@@ -333,7 +333,17 @@ export const TransactionGenericRow = ({
 
     if (hasManyReceiveAssets) {
       const symbols = transfersByType.Receive.map(transfer => transfer.asset.symbol)
-      return <RawText color='text.subtle'>{symbols.join(' + ')}</RawText>
+      return (
+        <RawText
+          color='text.subtle'
+          textOverflow='ellipsis'
+          overflow='hidden'
+          maxWidth='200px'
+          whiteSpace='nowrap'
+        >
+          {symbols.join(' + ')}
+        </RawText>
+      )
     }
   }, [
     hasNoReceiveAssets,


### PR DESCRIPTION
## Description

in The TX history when we have multiple symbols, we should truncate it down to a max width of 200px.

## Issue (if applicable)

<!-----------------------------------------------------------------------------
If applicable, please link to the github issue and put `closes #XXXX` in your comment to auto-close the issue that your PR fixes.
------------------------------------------------------------------------------>

closes #7926 

## Risk

> High Risk PRs Require 2 approvals

<!-----------------------------------------------------------------------------
Outline the scope of your changes and the risk associated with them. You must use your discretion as an engineer to determine the potential impact of your changes.

WARNING: If your PR introduces a new on-chain transaction or modifies an existing one, please add the "High-Risk" label to this PR and ask for 2 reviewers to approve it before merging.

E.g. an upgrade to `hdwallet` or core state management would be considered higher risk, and might require a full regression test. UI or isolated view changes, or something behind a feature flag may have near zero risk. Small bug fixes might require testing isolated to the specific fix.
------------------------------------------------------------------------------>

> What protocols, transaction types, wallets or contract interactions might be affected by this PR?

## Testing

<!-----------------------------------------------------------------------------
We treat every PR to be merged with the same scrutiny as if we were merging directly to production.

Your PR will not be merged if you do not complete the sections below for our engineering and operations teams to test.
------------------------------------------------------------------------------>

### Engineering

<!-----------------------------------------------------------------------------
Include sufficient information here for an engineer to test your PR. This may include how to test locally, in a built environment, changes to infrastructure etc.
------------------------------------------------------------------------------>

### Operations

- [ ] :checkered_flag: My feature is behind a flag and doesn't require operations testing (yet)

<!-----------------------------------------------------------------------------
If your changes have a user-facing impact, describe how a non-technical QA team can functionally test your changes in a preview environment.

If they are not user-facing please describe how to test for any regressions that may occur.
------------------------------------------------------------------------------>
You'll need a cosmos claim to see this. Inside activity or recent transactions the right side of the row should truncate showing ...

## Screenshots (if applicable)
![Screenshot 2024-10-29 at 3 47 06 PM](https://github.com/user-attachments/assets/150047ea-c5b5-49ef-a23b-dfeb80089888)
![Screenshot 2024-10-29 at 3 47 16 PM](https://github.com/user-attachments/assets/1e51bf24-c860-44cb-b1e8-d7f2a94925c0)
