### PR TITLE
feat: implemented ui state management in limit orders input

### DIFF
--- a/src/assets/translations/en/main.json
+++ b/src/assets/translations/en/main.json
@@ -1021,7 +1021,15 @@
     "previewOrder": "Preview Order",
     "youGet": "You Get",
     "whenPriceReaches": "When price reaches",
-    "expiry": "Expiry"
+    "expiry": "Expiry",
+    "expiryOption": {
+      "oneHour": "1 hour",
+      "oneDay": "1 day",
+      "threeDays": "3 days",
+      "sevenDays": "7 days",
+      "twentyEightDays": "28 days",
+      "custom": "Custom"
+    }
   },
   "modals": {
     "assetSearch": {

--- a/src/components/MultiHopTrade/components/LimitOrder/components/LimitOrderConfig.tsx
+++ b/src/components/MultiHopTrade/components/LimitOrder/components/LimitOrderConfig.tsx
@@ -255,7 +255,6 @@ export const LimitOrderConfig = ({
         </Flex>
       </Flex>
       <HStack width='full' justify='space-between'>
-        {/* <Amount.Crypto value={priceCryptoPrecision} symbol='' size='lg' fontSize='xl' /> */}
         <NumberFormat
           customInput={AmountInput}
           decimalScale={priceAsset.precision}

--- a/src/components/MultiHopTrade/components/LimitOrder/components/LimitOrderConfig.tsx
+++ b/src/components/MultiHopTrade/components/LimitOrder/components/LimitOrderConfig.tsx
@@ -12,31 +12,21 @@ import {
 } from '@chakra-ui/react'
 import type { Asset } from '@shapeshiftoss/types'
 import { bn, bnOrZero } from '@shapeshiftoss/utils'
-import { noop } from 'lodash'
-import { useCallback, useMemo, useState } from 'react'
-import { Amount } from 'components/Amount/Amount'
+import { useCallback, useMemo, useRef, useState } from 'react'
+import type { NumberFormatValues } from 'react-number-format'
+import NumberFormat from 'react-number-format'
 import { StyledAssetMenuButton } from 'components/AssetSelection/components/AssetMenuButton'
 import { SwapIcon } from 'components/Icons/SwapIcon'
-import { RawText, Text } from 'components/Text'
+import { Text } from 'components/Text'
+import { useLocaleFormatter } from 'hooks/useLocaleFormatter/useLocaleFormatter'
+import { assertUnreachable } from 'lib/utils'
+import { allowedDecimalSeparators } from 'state/slices/preferencesSlice/preferencesSlice'
 
-const EXPIRY_TIME_PERIODS = ['1 hour', '1 day', '3 days', '7 days', '28 days'] as const
-
-const timePeriodRightIcon = <ChevronDownIcon />
-const swapIcon = <SwapIcon />
-
-const swapPriceButtonProps = { pr: 4 }
-
-type LimitOrderConfigProps = {
-  sellAsset: Asset
-  buyAsset: Asset
-  marketPriceBuyAssetCryptoPrecision: string
-  limitPriceBuyAssetCryptoPrecision: string
-  setLimitPriceBuyAssetCryptoPrecision: (priceBuyAssetCryptoPrecision: string) => void
-}
+import { AmountInput } from '../../TradeAmountInput'
 
 enum PriceDirection {
-  Sell = 'sell',
-  Buy = 'buy',
+  Default = 'default',
+  Reversed = 'reversed',
 }
 
 enum PresetLimit {
@@ -47,6 +37,56 @@ enum PresetLimit {
   TenPercent = 'tenPercent',
 }
 
+enum ExpiryOption {
+  OneHour = '1 hour',
+  OneDay = '1 day',
+  ThreeDays = '3 days',
+  SevenDays = '7 days',
+  TwentyEightDays = '28 days',
+  // TODO: implement custom expiry
+  // Custom = 'custom',
+}
+
+const EXPIRY_OPTIONS = [
+  ExpiryOption.OneHour,
+  ExpiryOption.OneDay,
+  ExpiryOption.ThreeDays,
+  ExpiryOption.SevenDays,
+  ExpiryOption.TwentyEightDays,
+] as const
+
+const getExpiryOptionTranslation = (expiryOption: ExpiryOption) => {
+  switch (expiryOption) {
+    case ExpiryOption.OneHour:
+      return 'limitOrder.expiryOption.oneHour'
+    case ExpiryOption.OneDay:
+      return 'limitOrder.expiryOption.oneDay'
+    case ExpiryOption.ThreeDays:
+      return 'limitOrder.expiryOption.threeDays'
+    case ExpiryOption.SevenDays:
+      return 'limitOrder.expiryOption.sevenDays'
+    case ExpiryOption.TwentyEightDays:
+      return 'limitOrder.expiryOption.twentyEightDays'
+    // TODO: implement custom expiry
+    // case ExpiryOption.Custom:
+    //   return 'limitOrder.expiryOption.custom'
+    default:
+      assertUnreachable(expiryOption)
+  }
+}
+
+const timePeriodRightIcon = <ChevronDownIcon />
+const swapIcon = <SwapIcon />
+const swapPriceButtonProps = { pr: 4 }
+
+type LimitOrderConfigProps = {
+  sellAsset: Asset
+  buyAsset: Asset
+  marketPriceBuyAssetCryptoPrecision: string
+  limitPriceBuyAssetCryptoPrecision: string
+  setLimitPriceBuyAssetCryptoPrecision: (priceBuyAssetCryptoPrecision: string) => void
+}
+
 export const LimitOrderConfig = ({
   sellAsset,
   buyAsset,
@@ -54,71 +94,143 @@ export const LimitOrderConfig = ({
   limitPriceBuyAssetCryptoPrecision,
   setLimitPriceBuyAssetCryptoPrecision,
 }: LimitOrderConfigProps) => {
-  const [priceDirection, setPriceDirection] = useState(PriceDirection.Sell)
-  const [presetLimit, setPresetLimit] = useState(PresetLimit.Market)
+  const priceAmountRef = useRef<string | null>(null)
 
-  const renderedChains = useMemo(() => {
-    return EXPIRY_TIME_PERIODS.map(timePeriod => {
+  const [priceDirection, setPriceDirection] = useState(PriceDirection.Default)
+  const [presetLimit, setPresetLimit] = useState<PresetLimit | undefined>(PresetLimit.Market)
+  const [expiryOption, setExpiryOption] = useState(ExpiryOption.SevenDays)
+
+  const {
+    number: { localeParts },
+  } = useLocaleFormatter()
+
+  const expiryOptions = useMemo(() => {
+    return EXPIRY_OPTIONS.map(expiryOption => {
       return (
-        <MenuItemOption value={timePeriod} key={timePeriod}>
-          <RawText>{timePeriod}</RawText>
+        <MenuItemOption value={expiryOption} key={expiryOption}>
+          <Text translation={getExpiryOptionTranslation(expiryOption)} />
         </MenuItemOption>
       )
     })
   }, [])
 
   const priceAsset = useMemo(() => {
-    return priceDirection === PriceDirection.Sell ? sellAsset : buyAsset
+    return priceDirection === PriceDirection.Default ? buyAsset : sellAsset
   }, [buyAsset, priceDirection, sellAsset])
 
-  const priceCryptoPrecision = useMemo(() => {
-    if (bnOrZero(limitPriceBuyAssetCryptoPrecision).isZero()) {
-      return '0'
-    }
+  // Lower the decimal places when the integer is greater than 8 significant digits for better UI
+  const priceCryptoFormatted = useMemo(() => {
+    const cryptoAmountIntegerCount = bnOrZero(
+      bnOrZero(limitPriceBuyAssetCryptoPrecision).toFixed(0),
+    ).precision(true)
 
-    return priceDirection === PriceDirection.Sell
-      ? bn(1).div(limitPriceBuyAssetCryptoPrecision).toFixed()
-      : limitPriceBuyAssetCryptoPrecision
-  }, [limitPriceBuyAssetCryptoPrecision, priceDirection])
-
-  const handleTogglePriceDirection = useCallback(() => {
-    setPriceDirection(
-      priceDirection === PriceDirection.Sell ? PriceDirection.Buy : PriceDirection.Sell,
-    )
-  }, [priceDirection])
+    return cryptoAmountIntegerCount <= 8
+      ? limitPriceBuyAssetCryptoPrecision
+      : bnOrZero(limitPriceBuyAssetCryptoPrecision).toFixed(3)
+  }, [limitPriceBuyAssetCryptoPrecision])
 
   const arrow = useMemo(() => {
-    return priceDirection === PriceDirection.Sell ? '↑' : '↓'
+    return priceDirection === PriceDirection.Default ? '↑' : '↓'
   }, [priceDirection])
 
+  const handleSetPresetLimit = useCallback(
+    (presetLimit: PresetLimit, priceDirection: PriceDirection) => {
+      setPresetLimit(presetLimit)
+      const multiplier = (() => {
+        switch (presetLimit) {
+          case PresetLimit.Market:
+            return '1.00'
+          case PresetLimit.OnePercent:
+            return '1.01'
+          case PresetLimit.TwoPercent:
+            return '1.02'
+          case PresetLimit.FivePercent:
+            return '1.05'
+          case PresetLimit.TenPercent:
+            return '1.10'
+          default:
+            assertUnreachable(presetLimit)
+        }
+      })()
+      const adjustedLimitPrice = bn(marketPriceBuyAssetCryptoPrecision).times(multiplier).toFixed()
+      const maybeReversedPrice =
+        priceDirection === PriceDirection.Reversed
+          ? bn(1).div(adjustedLimitPrice).toFixed()
+          : adjustedLimitPrice
+      setLimitPriceBuyAssetCryptoPrecision(maybeReversedPrice)
+    },
+    [marketPriceBuyAssetCryptoPrecision, setLimitPriceBuyAssetCryptoPrecision],
+  )
+
   const handleSetMarketLimit = useCallback(() => {
-    setPresetLimit(PresetLimit.Market)
-    setLimitPriceBuyAssetCryptoPrecision(marketPriceBuyAssetCryptoPrecision)
-  }, [marketPriceBuyAssetCryptoPrecision, setLimitPriceBuyAssetCryptoPrecision])
+    handleSetPresetLimit(PresetLimit.Market, priceDirection)
+  }, [handleSetPresetLimit, priceDirection])
 
   const handleSetOnePercentLimit = useCallback(() => {
-    setPresetLimit(PresetLimit.OnePercent)
-    const price = bn(marketPriceBuyAssetCryptoPrecision).div('1.01').toFixed()
-    setLimitPriceBuyAssetCryptoPrecision(price)
-  }, [marketPriceBuyAssetCryptoPrecision, setLimitPriceBuyAssetCryptoPrecision])
+    handleSetPresetLimit(PresetLimit.OnePercent, priceDirection)
+  }, [handleSetPresetLimit, priceDirection])
 
   const handleSetTwoPercentLimit = useCallback(() => {
-    setPresetLimit(PresetLimit.TwoPercent)
-    const price = bn(marketPriceBuyAssetCryptoPrecision).div('1.02').toFixed()
-    setLimitPriceBuyAssetCryptoPrecision(price)
-  }, [marketPriceBuyAssetCryptoPrecision, setLimitPriceBuyAssetCryptoPrecision])
+    handleSetPresetLimit(PresetLimit.TwoPercent, priceDirection)
+  }, [handleSetPresetLimit, priceDirection])
 
   const handleSetFivePercentLimit = useCallback(() => {
-    setPresetLimit(PresetLimit.FivePercent)
-    const price = bn(marketPriceBuyAssetCryptoPrecision).div('1.05').toFixed()
-    setLimitPriceBuyAssetCryptoPrecision(price)
-  }, [marketPriceBuyAssetCryptoPrecision, setLimitPriceBuyAssetCryptoPrecision])
+    handleSetPresetLimit(PresetLimit.FivePercent, priceDirection)
+  }, [handleSetPresetLimit, priceDirection])
 
   const handleSetTenPercentLimit = useCallback(() => {
-    setPresetLimit(PresetLimit.TenPercent)
-    const price = bn(marketPriceBuyAssetCryptoPrecision).div('1.10').toFixed()
-    setLimitPriceBuyAssetCryptoPrecision(price)
-  }, [marketPriceBuyAssetCryptoPrecision, setLimitPriceBuyAssetCryptoPrecision])
+    handleSetPresetLimit(PresetLimit.TenPercent, priceDirection)
+  }, [handleSetPresetLimit, priceDirection])
+
+  const handleTogglePriceDirection = useCallback(() => {
+    const newPriceDirection =
+      priceDirection === PriceDirection.Default ? PriceDirection.Reversed : PriceDirection.Default
+    setPriceDirection(newPriceDirection)
+
+    const isCustomLimit = presetLimit === undefined
+
+    if (isCustomLimit) {
+      // For custom limit, just take the reciprocal as we don't know what the original input value was
+      setLimitPriceBuyAssetCryptoPrecision(bn(1).div(limitPriceBuyAssetCryptoPrecision).toFixed())
+    } else {
+      // Otherwise set it to the precise value based on the original market price
+      handleSetPresetLimit(presetLimit, newPriceDirection)
+    }
+  }, [
+    handleSetPresetLimit,
+    limitPriceBuyAssetCryptoPrecision,
+    presetLimit,
+    priceDirection,
+    setLimitPriceBuyAssetCryptoPrecision,
+  ])
+
+  const handlePriceChange = useCallback(() => {
+    // onChange will send us the formatted value
+    // To get around this we need to get the value from the onChange using a ref
+    // Now when the max buttons are clicked the onChange will not fire
+    setLimitPriceBuyAssetCryptoPrecision(priceAmountRef.current ?? '0')
+
+    // Unset the preset limit, as this is a custom value
+    setPresetLimit(undefined)
+  }, [setLimitPriceBuyAssetCryptoPrecision])
+
+  const handleValueChange = useCallback(
+    (values: NumberFormatValues) => {
+      // This fires anytime value changes including setting it on max click
+      // Store the value in a ref to send when we actually want the onChange to fire
+      priceAmountRef.current = values.value
+      setLimitPriceBuyAssetCryptoPrecision(values.value)
+    },
+    [setLimitPriceBuyAssetCryptoPrecision],
+  )
+
+  const expiryOptionTranslation = useMemo(() => {
+    return getExpiryOptionTranslation(expiryOption)
+  }, [expiryOption])
+
+  const handleChangeExpiryOption = useCallback((newExpiry: string | string[]) => {
+    setExpiryOption(newExpiry as ExpiryOption)
+  }, [])
 
   return (
     <Stack spacing={4} px={6} py={4}>
@@ -128,18 +240,34 @@ export const LimitOrderConfig = ({
           <Text translation='limitOrder.expiry' mr={4} />
           <Menu isLazy>
             <MenuButton as={Button} rightIcon={timePeriodRightIcon}>
-              <RawText>1 hour</RawText>
+              <Text translation={expiryOptionTranslation} />
             </MenuButton>
             <MenuList zIndex='modal'>
-              <MenuOptionGroup type='radio' value={'1 hour'} onChange={noop}>
-                {renderedChains}
+              <MenuOptionGroup
+                type='radio'
+                value={expiryOption}
+                onChange={handleChangeExpiryOption}
+              >
+                {expiryOptions}
               </MenuOptionGroup>
             </MenuList>
           </Menu>
         </Flex>
       </Flex>
       <HStack width='full' justify='space-between'>
-        <Amount.Crypto value={priceCryptoPrecision} symbol='' size='lg' fontSize='xl' />
+        {/* <Amount.Crypto value={priceCryptoPrecision} symbol='' size='lg' fontSize='xl' /> */}
+        <NumberFormat
+          customInput={AmountInput}
+          decimalScale={priceAsset.precision}
+          isNumericString={true}
+          decimalSeparator={localeParts.decimal}
+          inputMode='decimal'
+          allowedDecimalSeparators={allowedDecimalSeparators}
+          thousandSeparator={localeParts.group}
+          value={priceCryptoFormatted}
+          onValueChange={handleValueChange}
+          onChange={handlePriceChange}
+        />
         <StyledAssetMenuButton
           rightIcon={swapIcon}
           assetId={priceAsset.assetId}

--- a/src/components/MultiHopTrade/components/LimitOrder/components/LimitOrderConfig.tsx
+++ b/src/components/MultiHopTrade/components/LimitOrder/components/LimitOrderConfig.tsx
@@ -38,11 +38,11 @@ enum PresetLimit {
 }
 
 enum ExpiryOption {
-  OneHour = '1 hour',
-  OneDay = '1 day',
-  ThreeDays = '3 days',
-  SevenDays = '7 days',
-  TwentyEightDays = '28 days',
+  OneHour = 'oneHour',
+  OneDay = 'oneDay',
+  ThreeDays = 'threeDays',
+  SevenDays = 'sevenDays',
+  TwentyEightDays = 'twentyEightDays',
   // TODO: implement custom expiry
   // Custom = 'custom',
 }
@@ -58,18 +58,18 @@ const EXPIRY_OPTIONS = [
 const getExpiryOptionTranslation = (expiryOption: ExpiryOption) => {
   switch (expiryOption) {
     case ExpiryOption.OneHour:
-      return 'limitOrder.expiryOption.oneHour'
+      return `limitOrder.expiryOption.${expiryOption}`
     case ExpiryOption.OneDay:
-      return 'limitOrder.expiryOption.oneDay'
+      return `limitOrder.expiryOption.${expiryOption}`
     case ExpiryOption.ThreeDays:
-      return 'limitOrder.expiryOption.threeDays'
+      return `limitOrder.expiryOption.${expiryOption}`
     case ExpiryOption.SevenDays:
-      return 'limitOrder.expiryOption.sevenDays'
+      return `limitOrder.expiryOption.${expiryOption}`
     case ExpiryOption.TwentyEightDays:
-      return 'limitOrder.expiryOption.twentyEightDays'
+      return `limitOrder.expiryOption.${expiryOption}`
     // TODO: implement custom expiry
     // case ExpiryOption.Custom:
-    //   return 'limitOrder.expiryOption.custom'
+    //   return `limitOrder.expiryOption.${expiryOption}`
     default:
       assertUnreachable(expiryOption)
   }

--- a/src/components/MultiHopTrade/components/TradeAmountInput.tsx
+++ b/src/components/MultiHopTrade/components/TradeAmountInput.tsx
@@ -61,7 +61,7 @@ const buttonProps = {
 const boxProps = { px: 0, m: 0, maxWidth: '220px' }
 const numberFormatDisabled = { opacity: 1, cursor: 'not-allowed' }
 
-const AmountInput = (props: InputProps) => {
+export const AmountInput = (props: InputProps) => {
   const translate = useTranslate()
   return (
     <Input


### PR DESCRIPTION
## Description

Adds some state management to the limit orders input, in prep for making requests to the RTK query.

This is an incremental change intended to minimise review surface area/noise, and increase focus on important changes once RTK query is wired up.

- Adds translations where needed
- Implements the ridiculous logic on input handling for limit price, combined with preset values etc

## Issue (if applicable)

<!-----------------------------------------------------------------------------
If applicable, please link to the github issue and put `closes #XXXX` in your comment to auto-close the issue that your PR fixes.
------------------------------------------------------------------------------>

progresses  #8032

## Risk

> High Risk PRs Require 2 approvals

Low risk.

> What protocols, transaction types, wallets or contract interactions might be affected by this PR?

## Testing

Not required at this stage.

### Engineering

<!-----------------------------------------------------------------------------
Include sufficient information here for an engineer to test your PR. This may include how to test locally, in a built environment, changes to infrastructure etc.
------------------------------------------------------------------------------>

### Operations

- [x] :checkered_flag: My feature is behind a flag and doesn't require operations testing (yet)

<!-----------------------------------------------------------------------------
If your changes have a user-facing impact, describe how a non-technical QA team can functionally test your changes in a preview environment.

If they are not user-facing please describe how to test for any regressions that may occur.
------------------------------------------------------------------------------>

## Screenshots (if applicable)

Quick demo of the clicky fun times.
https://jam.dev/c/fb7ae4d3-9124-47a1-87f8-af2fa5b39afb
