### PR TITLE
feat: wire up limit orders UI to RTK query

### DIFF
--- a/packages/caip/src/assetId/assetId.ts
+++ b/packages/caip/src/assetId/assetId.ts
@@ -132,7 +132,7 @@ type FromAssetIdReturn = {
   chainReference: ChainReference
   chainId: ChainId
   assetNamespace: AssetNamespace
-  assetReference: AssetReference | string
+  assetReference: AssetReference
 }
 
 export type FromAssetId = (assetId: AssetId) => FromAssetIdReturn
@@ -171,7 +171,7 @@ export const fromAssetId: FromAssetId = (assetId: string) => {
     chainNamespace: chainNamespace as ChainNamespace,
     chainReference: chainReference as ChainReference,
     assetNamespace: assetNamespace as AssetNamespace,
-    assetReference: assetReferenceNormalized,
+    assetReference: assetReferenceNormalized as AssetReference,
   }
 }
 

--- a/packages/caip/src/constants.ts
+++ b/packages/caip/src/constants.ts
@@ -27,6 +27,7 @@ export const foxatarAssetId: AssetId =
 export const foxyAssetId: AssetId = 'eip155:1/erc20:0xdc49108ce5c57bc3408c3a5e95f3d864ec386ed3'
 
 export const usdtAssetId: AssetId = 'eip155:1/erc20:0xdac17f958d2ee523a2206206994597c13d831ec7'
+export const usdcAssetId: AssetId = 'eip155:1/erc20:0xa0b86991c6218b36c1d19d4a2e9eb0ce3606eb48'
 
 export const cosmosAssetId: AssetId = 'cosmos:cosmoshub-4/slip44:118'
 export const thorchainAssetId: AssetId = 'cosmos:thorchain-1/slip44:931'

--- a/packages/swapper/src/swappers/CowSwapper/endpoints.ts
+++ b/packages/swapper/src/swappers/CowSwapper/endpoints.ts
@@ -121,6 +121,7 @@ export const cowApi: SwapperApi = {
     const { appData, appDataHash } = await getFullAppData(
       slippageTolerancePercentageDecimal,
       affiliateAppDataFragment,
+      'market',
     )
     // https://api.cow.fi/docs/#/default/post_api_v1_quote
     const maybeQuoteResponse = await cowService.post<CowSwapQuoteResponse>(

--- a/packages/swapper/src/swappers/CowSwapper/getCowSwapTradeQuote/getCowSwapTradeQuote.ts
+++ b/packages/swapper/src/swappers/CowSwapper/getCowSwapTradeQuote/getCowSwapTradeQuote.ts
@@ -76,6 +76,7 @@ async function _getCowSwapTradeQuote(
   const { appData, appDataHash } = await getFullAppData(
     slippageTolerancePercentageDecimal,
     affiliateAppDataFragment,
+    'market',
   )
 
   // https://api.cow.fi/docs/#/default/post_api_v1_quote

--- a/packages/swapper/src/swappers/CowSwapper/getCowSwapTradeQuote/getCowSwapTradeQuote.ts
+++ b/packages/swapper/src/swappers/CowSwapper/getCowSwapTradeQuote/getCowSwapTradeQuote.ts
@@ -205,6 +205,7 @@ async function _getCowSwapTradeRate(
   const { appData, appDataHash } = await getFullAppData(
     slippageTolerancePercentageDecimal,
     affiliateAppDataFragment,
+    'market',
   )
 
   // https://api.cow.fi/docs/#/default/post_api_v1_quote

--- a/packages/swapper/src/swappers/CowSwapper/types.ts
+++ b/packages/swapper/src/swappers/CowSwapper/types.ts
@@ -20,10 +20,12 @@ export type CowSwapQuoteResponse = {
 }
 
 // Most likely non-exhaustive, see https://github.com/cowprotocol/contracts/blob/aaffdc55b2a13738b7c32de96f487d3eb5b4f8c6/src/ts/api.ts#L110
-// But we only handle SellAmountDoesNotCoverFee for now so that's fine. Add other errors here as needed.
-enum CowSwapQuoteErrorType {
+// But we only handle a few of them for now so that's fine. Add other errors here as needed.
+export enum CowSwapQuoteErrorType {
   SellAmountDoesNotCoverFee = 'SellAmountDoesNotCoverFee',
   NoLiquidity = 'NoLiquidity',
+  ZeroAmount = 'ZeroAmount',
+  UnsupportedToken = 'UnsupportedToken',
 }
 
 export type CowSwapQuoteError = {

--- a/packages/swapper/src/swappers/CowSwapper/utils/helpers/helpers.test.ts
+++ b/packages/swapper/src/swappers/CowSwapper/utils/helpers/helpers.test.ts
@@ -41,7 +41,11 @@ describe('utils', () => {
       const slippageTolerancePercentage = '0.005' // 0.5%
       const affiliateAppDataFragment = {} // no affiliate fee
 
-      const result = await getFullAppData(slippageTolerancePercentage, affiliateAppDataFragment)
+      const result = await getFullAppData(
+        slippageTolerancePercentage,
+        affiliateAppDataFragment,
+        'market',
+      )
 
       expect(result).toHaveProperty('appDataHash')
       expect(result).toHaveProperty('appData')
@@ -60,7 +64,11 @@ describe('utils', () => {
         },
       }
 
-      const result = await getFullAppData(slippageTolerancePercentage, affiliateAppDataFragment)
+      const result = await getFullAppData(
+        slippageTolerancePercentage,
+        affiliateAppDataFragment,
+        'market',
+      )
 
       expect(result).toHaveProperty('appDataHash')
       expect(result).toHaveProperty('appData')

--- a/packages/swapper/src/swappers/CowSwapper/utils/helpers/helpers.ts
+++ b/packages/swapper/src/swappers/CowSwapper/utils/helpers/helpers.ts
@@ -1,6 +1,6 @@
 import type { LatestAppDataDocVersion } from '@cowprotocol/app-data'
 import { MetadataApi, stringifyDeterministic } from '@cowprotocol/app-data'
-import type { OrderClass } from '@cowprotocol/app-data/dist/generatedTypes/v0.9.0'
+import type { OrderClass, OrderClass1 } from '@cowprotocol/app-data/dist/generatedTypes/v0.9.0'
 import type { ChainId } from '@shapeshiftoss/caip'
 import { fromAssetId } from '@shapeshiftoss/caip'
 import type { Asset } from '@shapeshiftoss/types'
@@ -262,9 +262,10 @@ const metadataApi = new MetadataApi()
 export const getFullAppData = async (
   slippageTolerancePercentage: string,
   affiliateAppDataFragment: AffiliateAppDataFragment,
+  orderClass1: OrderClass1,
 ) => {
   const APP_CODE = 'shapeshift'
-  const orderClass: OrderClass = { orderClass: 'market' }
+  const orderClass: OrderClass = { orderClass: orderClass1 }
   const quote = {
     slippageBips: convertDecimalPercentageToBasisPoints(slippageTolerancePercentage).toString(),
   }

--- a/src/components/MultiHopTrade/components/LimitOrder/components/LimitOrderInput.tsx
+++ b/src/components/MultiHopTrade/components/LimitOrder/components/LimitOrderInput.tsx
@@ -15,6 +15,7 @@ import type { FormEvent } from 'react'
 import { useCallback, useEffect, useMemo, useState } from 'react'
 import { useFormContext } from 'react-hook-form'
 import { useHistory } from 'react-router'
+import { zeroAddress } from 'viem'
 import { WarningAcknowledgement } from 'components/Acknowledgement/Acknowledgement'
 import { useReceiveAddress } from 'components/MultiHopTrade/hooks/useReceiveAddress'
 import { TradeInputTab } from 'components/MultiHopTrade/types'
@@ -220,7 +221,7 @@ export const LimitOrderInput = ({
 
   const limitOrderQuoteParams = useMemo(() => {
     // Return skipToken if any required params are missing
-    if (!sellAccountAddress || bnOrZero(sellAmountCryptoBaseUnit).isZero()) {
+    if (bnOrZero(sellAmountCryptoBaseUnit).isZero()) {
       return skipToken
     }
 
@@ -228,10 +229,10 @@ export const LimitOrderInput = ({
       sellToken: fromAssetId(sellAsset.assetId).assetReference,
       buyToken: fromAssetId(buyAsset.assetId).assetReference,
       receiver: undefined, // TODO: implement useReceiveAddress
-      appData: undefined, // will be generated using this quote!
-      appDataHash: undefined, // will be generated using this quote!
+      appData: undefined, // TODO: create this for limit order!
+      appDataHash: undefined, // TODO: create this for limit order!
       sellTokenBalance: CoWSwapSellTokenSource.ERC20,
-      from: sellAccountAddress,
+      from: sellAccountAddress ?? zeroAddress,
       priceQuality: PriceQuality.Optimal,
       signingScheme: CoWSwapSigningScheme.EIP712,
       onChainOrder: undefined,
@@ -251,13 +252,16 @@ export const LimitOrderInput = ({
     sellAsset.chainId,
   ])
 
-  const { data } = useQuoteLimitOrderQuery(limitOrderQuoteParams)
+  const { data, error } = useQuoteLimitOrderQuery(limitOrderQuoteParams)
 
   useEffect(() => {
-    console.log('limit order:', data)
-  }, [data])
+    console.log('limit order response:', data)
+    console.log('limit order error:', error)
+  }, [data, error])
 
   const marketPriceBuyAssetCryptoPrecision = '123423'
+
+  // TODO: debounce this with `useDebounce` when including in the query
   const [limitPriceBuyAssetCryptoPrecision, setLimitPriceBuyAssetCryptoPrecision] = useState(
     marketPriceBuyAssetCryptoPrecision,
   )

--- a/src/state/apis/limit-orders/limitOrderApi.ts
+++ b/src/state/apis/limit-orders/limitOrderApi.ts
@@ -1,22 +1,47 @@
 import { createApi } from '@reduxjs/toolkit/dist/query/react'
-import type { ChainId } from '@shapeshiftoss/caip'
+import type { AssetId } from '@shapeshiftoss/caip'
+import { type ChainId, fromAssetId } from '@shapeshiftoss/caip'
 import type { CowSwapQuoteError } from '@shapeshiftoss/swapper'
-import { CowSwapQuoteErrorType, getCowswapNetwork, TradeQuoteError } from '@shapeshiftoss/swapper'
+import {
+  CoWSwapOrderKind,
+  CowSwapQuoteErrorType,
+  CoWSwapSellTokenSource,
+  CoWSwapSigningScheme,
+  getCowswapNetwork,
+  TradeQuoteError,
+} from '@shapeshiftoss/swapper'
+import {
+  getAffiliateAppDataFragmentByChainId,
+  getFullAppData,
+} from '@shapeshiftoss/swapper/dist/swappers/CowSwapper/utils/helpers/helpers'
 import type { AxiosError } from 'axios'
 import axios from 'axios'
 import { getConfig } from 'config'
+import type { Address } from 'viem'
+import { zeroAddress } from 'viem'
 
 import { BASE_RTK_CREATE_API_CONFIG } from '../const'
-import type {
-  CancelLimitOrdersRequest,
-  CompetitionOrderStatus,
-  GetOrdersRequest,
-  LimitOrder,
-  LimitOrderId,
-  LimitOrderQuoteRequest,
-  Order,
-  Trade,
+import {
+  type CancelLimitOrdersRequest,
+  type CompetitionOrderStatus,
+  type GetOrdersRequest,
+  type LimitOrder,
+  type LimitOrderId,
+  type LimitOrderQuoteRequest,
+  type Order,
+  PriceQuality,
+  type Trade,
 } from './types'
+
+export type LimitOrderQuoteParams = {
+  sellAssetId: AssetId
+  buyAssetId: AssetId
+  chainId: ChainId
+  slippageTolerancePercentageDecimal: string
+  affiliateBps: string
+  sellAccountAddress: Address | undefined
+  sellAmountCryptoBaseUnit: string
+}
 
 export const limitOrderApi = createApi({
   ...BASE_RTK_CREATE_API_CONFIG,
@@ -24,16 +49,51 @@ export const limitOrderApi = createApi({
   keepUnusedDataFor: Number.MAX_SAFE_INTEGER, // never clear, we will manage this
   tagTypes: ['LimitOrder'],
   endpoints: build => ({
-    quoteLimitOrder: build.query<
-      LimitOrder,
-      { limitOrderQuoteRequest: LimitOrderQuoteRequest; chainId: ChainId }
-    >({
-      queryFn: async ({ limitOrderQuoteRequest, chainId }) => {
+    quoteLimitOrder: build.query<LimitOrder, LimitOrderQuoteParams>({
+      queryFn: async ({
+        sellAssetId,
+        buyAssetId,
+        chainId,
+        slippageTolerancePercentageDecimal,
+        affiliateBps,
+        sellAccountAddress,
+        sellAmountCryptoBaseUnit,
+      }: LimitOrderQuoteParams) => {
         const config = getConfig()
         const baseUrl = config.REACT_APP_COWSWAP_BASE_URL
         const maybeNetwork = getCowswapNetwork(chainId)
         if (maybeNetwork.isErr()) throw maybeNetwork.unwrapErr()
         const network = maybeNetwork.unwrap()
+
+        const affiliateAppDataFragment = getAffiliateAppDataFragmentByChainId({
+          affiliateBps,
+          chainId,
+        })
+
+        const { appData, appDataHash } = await getFullAppData(
+          slippageTolerancePercentageDecimal,
+          affiliateAppDataFragment,
+          'limit',
+        )
+
+        const limitOrderQuoteRequest: LimitOrderQuoteRequest = {
+          sellToken: fromAssetId(sellAssetId).assetReference,
+          buyToken: fromAssetId(buyAssetId).assetReference,
+          receiver: undefined, // TODO: implement useReceiveAddress
+
+          sellTokenBalance: CoWSwapSellTokenSource.ERC20,
+          from: sellAccountAddress ?? zeroAddress,
+          priceQuality: PriceQuality.Optimal,
+          signingScheme: CoWSwapSigningScheme.EIP712,
+          onChainOrder: undefined,
+          kind: CoWSwapOrderKind.Sell,
+          sellAmountBeforeFee: sellAmountCryptoBaseUnit,
+          appData,
+          appDataHash,
+        }
+
+        limitOrderQuoteRequest.appData = appData
+        limitOrderQuoteRequest.appDataHash = appDataHash
 
         try {
           const result = await axios.post<LimitOrder>(

--- a/src/state/apis/limit-orders/types.ts
+++ b/src/state/apis/limit-orders/types.ts
@@ -1,4 +1,4 @@
-import type { AssetReference, ChainId } from '@shapeshiftoss/caip'
+import type { AssetReference, ChainId, Nominal } from '@shapeshiftoss/caip'
 import type {
   CoWSwapBuyTokenDestination,
   CoWSwapOrderKind,
@@ -6,8 +6,31 @@ import type {
   CoWSwapSigningScheme,
 } from '@shapeshiftoss/swapper'
 
-export type LimitOrder = string
-export type LimitOrderRequest = {
+export enum PriceQuality {
+  Fast = 'fast',
+  Optimal = 'optimal',
+  Verified = 'verified',
+}
+
+export type LimitOrderId = Nominal<string, 'LimitOrderId'>
+export type LimitOrderQuoteId = Nominal<number, 'LimitOrderQuoteId'>
+export type LimitOrderQuoteRequest = {
+  sellToken: AssetReference
+  buyToken: AssetReference
+  receiver?: string
+  appData?: string
+  appDataHash?: string
+  sellTokenBalance?: CoWSwapSellTokenSource
+  buyTokenBalance?: CoWSwapBuyTokenDestination
+  from: string
+  priceQuality?: PriceQuality
+  signingScheme?: CoWSwapSigningScheme
+  onChainOrder?: boolean
+  kind: CoWSwapOrderKind.Sell
+  sellAmountBeforeFee: string
+}
+
+export type LimitOrder = {
   sellToken: AssetReference
   buyToken: AssetReference
   receiver?: string
@@ -22,17 +45,15 @@ export type LimitOrderRequest = {
   signingScheme: CoWSwapSigningScheme
   signature: string
   from?: string
-  quoteId?: number
+  quoteId?: LimitOrderQuoteId
   appData: string
   appDataHash?: string
-  chainId: ChainId
 }
 
 export type CancelLimitOrdersRequest = {
   orderUids?: string[]
   signature: string
   signingScheme: CoWSwapSigningScheme
-  chainId: ChainId
 }
 
 export type OrderExecutionStatus =

--- a/src/state/reducer.ts
+++ b/src/state/reducer.ts
@@ -7,6 +7,7 @@ import { abiApi } from './apis/abi/abiApi'
 import { covalentApi } from './apis/covalent/covalentApi'
 import { fiatRampApi } from './apis/fiatRamps/fiatRamps'
 import { foxyApi } from './apis/foxy/foxyApi'
+import { limitOrderApi } from './apis/limit-orders/limitOrderApi'
 import type { NftState } from './apis/nft/nftApi'
 import { nft, nftApi } from './apis/nft/nftApi'
 import type { SnapshotState } from './apis/snapshot/snapshot'
@@ -151,6 +152,7 @@ export const apiSlices = {
   covalentApi,
   opportunitiesApi,
   abiApi,
+  limitOrderApi,
 }
 
 export const apiReducers = {
@@ -168,6 +170,7 @@ export const apiReducers = {
   [zapper.reducerPath]: zapper.reducer,
   [opportunitiesApi.reducerPath]: opportunitiesApi.reducer,
   [abiApi.reducerPath]: abiApi.reducer,
+  [limitOrderApi.reducerPath]: limitOrderApi.reducer,
 }
 
 export const reducer = combineReducers(Object.assign({}, sliceReducers, apiReducers))

--- a/src/state/slices/opportunitiesSlice/resolvers/ethFoxStaking/index.ts
+++ b/src/state/slices/opportunitiesSlice/resolvers/ethFoxStaking/index.ts
@@ -1,5 +1,9 @@
 import { foxAssetId, fromAccountId, fromAssetId } from '@shapeshiftoss/caip'
-import type { FoxEthStakingContract, FoxEthStakingContractAbi } from '@shapeshiftoss/contracts'
+import type {
+  FoxEthStakingContract,
+  FoxEthStakingContractAbi,
+  KnownContractAddress,
+} from '@shapeshiftoss/contracts'
 import {
   ETH_FOX_POOL_CONTRACT,
   fetchUniV2PairData,
@@ -55,7 +59,7 @@ export const ethFoxStakingMetadataResolver = async ({
 
   assertIsFoxEthStakingContractAddress(contractAddress)
   const foxFarmingContract = getOrCreateContractByAddress(
-    contractAddress,
+    contractAddress as KnownContractAddress,
   ) as FoxEthStakingContract<FoxEthStakingContractAbi>
   const uniV2LPContract = getOrCreateContractByAddress(ETH_FOX_POOL_CONTRACT)
 
@@ -138,7 +142,7 @@ export const ethFoxStakingUserDataResolver = async ({
   )
   const lpTokenPrice = lpTokenMarketData?.price
 
-  const { assetReference: contractAddress } = fromAssetId(opportunityId)
+  const { assetReference } = fromAssetId(opportunityId)
   const { account } = fromAccountId(accountId)
   const accountAddress = getAddress(account)
 
@@ -146,9 +150,11 @@ export const ethFoxStakingUserDataResolver = async ({
     throw new Error(`Market data not ready for ${foxEthLpAssetId}`)
   }
 
-  assertIsFoxEthStakingContractAddress(contractAddress)
+  const maybeContractAddress = assetReference as string
 
-  const foxFarmingContract = getOrCreateContractByAddress(contractAddress)
+  assertIsFoxEthStakingContractAddress(maybeContractAddress)
+
+  const foxFarmingContract = getOrCreateContractByAddress(maybeContractAddress)
 
   const stakedBalance = await foxFarmingContract.read.balanceOf([accountAddress])
   const earned = await foxFarmingContract.read.earned([accountAddress])

--- a/src/state/store.ts
+++ b/src/state/store.ts
@@ -9,6 +9,7 @@ import { abiApi } from './apis/abi/abiApi'
 import { covalentApi } from './apis/covalent/covalentApi'
 import { fiatRampApi } from './apis/fiatRamps/fiatRamps'
 import { foxyApi } from './apis/foxy/foxyApi'
+import { limitOrderApi } from './apis/limit-orders/limitOrderApi'
 import { nftApi } from './apis/nft/nftApi'
 import { snapshotApi } from './apis/snapshot/snapshot'
 import { swapperApi } from './apis/swapper/swapperApi'
@@ -39,6 +40,7 @@ const apiMiddleware = [
   covalentApi.middleware,
   opportunitiesApi.middleware,
   abiApi.middleware,
+  limitOrderApi.middleware,
 ]
 
 const subscriptionMiddleware = createSubscriptionMiddleware()

--- a/src/test/mocks/store.ts
+++ b/src/test/mocks/store.ts
@@ -26,6 +26,12 @@ const mockSwapperApi = Object.assign(mockApiFactory('swapperApi' as const), {
   },
 })
 
+const mockLimitOrderApi = Object.assign(mockApiFactory('limitOrderApi' as const), {
+  provided: {
+    LimitOrder: {},
+  },
+})
+
 export const mockStore: ReduxState = {
   assetApi: mockApiFactory('assetApi' as const),
   portfolioApi: mockApiFactory('portfolioApi' as const),
@@ -41,6 +47,7 @@ export const mockStore: ReduxState = {
   snapshotApi: mockApiFactory('snapshotApi' as const),
   opportunitiesApi: mockApiFactory('opportunitiesApi' as const),
   abiApi: mockApiFactory('abiApi' as const),
+  limitOrderApi: mockLimitOrderApi,
   portfolio: {
     _persist: {
       version: 0,


### PR DESCRIPTION
## Description

Wires up part of the limit orders ui to RTK for limit order quotes. Note that the quotes provide a market rate only and do not actually return any relevant info in terms of limit orders.

Also note that receive address will have to be implement as a separate task as it's likely much more involved than estimated in this ticked.

Further wiring to come in follow-ups.

## Issue (if applicable)

<!-----------------------------------------------------------------------------
If applicable, please link to the github issue and put `closes #XXXX` in your comment to auto-close the issue that your PR fixes.
------------------------------------------------------------------------------>

closes #8032

## Risk

> High Risk PRs Require 2 approvals

Very very low risk, not user facing.

> What protocols, transaction types, wallets or contract interactions might be affected by this PR?

## Testing



### Engineering

Check that a limit order quote (or an error) appears in the terminal per the console logs when getting a quote.

### Operations

- [x] :checkered_flag: My feature is behind a flag and doesn't require operations testing (yet)

<!-----------------------------------------------------------------------------
If your changes have a user-facing impact, describe how a non-technical QA team can functionally test your changes in a preview environment.

If they are not user-facing please describe how to test for any regressions that may occur.
------------------------------------------------------------------------------>

## Screenshots (if applicable)

![image](https://github.com/user-attachments/assets/2ace6063-c7c7-47bb-aad4-42e1a860ab65)
