### PR TITLE
fix: solana banxa fiat onramp

### DIFF
--- a/packages/caip/src/adapters/banxa/index.ts
+++ b/packages/caip/src/adapters/banxa/index.ts
@@ -1,5 +1,4 @@
 import entries from 'lodash/entries'
-import toLower from 'lodash/toLower'
 
 import type { AssetId } from '../../assetId/assetId'
 import type { ChainId } from '../../chainId/chainId'
@@ -24,6 +23,7 @@ import {
   optimismChainId,
   polygonAssetId,
   polygonChainId,
+  solanaChainId,
   solAssetId,
   thorchainAssetId,
   thorchainChainId,
@@ -106,8 +106,8 @@ export const getSupportedBanxaAssets = () =>
     ticker,
   }))
 
-export const assetIdToBanxaTicker = (assetId: string): string | undefined =>
-  AssetIdToBanxaTickerMap[toLower(assetId)]
+export const assetIdToBanxaTicker = (assetId: AssetId): string | undefined =>
+  AssetIdToBanxaTickerMap[assetId]
 
 /**
  * map ChainIds to Banxa blockchain codes (ETH, BTC, COSMOS),
@@ -129,7 +129,7 @@ const chainIdToBanxaBlockchainCodeMap: Record<ChainId, string> = {
   [arbitrumChainId]: 'ARB',
   [baseChainId]: 'BASE',
   [thorchainChainId]: 'THORCHAIN',
-  [solAssetId]: 'SOL',
+  [solanaChainId]: 'SOL',
 } as const
 
 /**


### PR DESCRIPTION
## Description

Fixes an issue with Banxa onramp logic not correctly parsing `AssetId`s. 2 issues:

- `AssetId`s are case sensitive, and so `toLower` causes the key match in `AssetIdToBanxaTickerMap` to fail
- We were checking the `ChainId` against `solAssetId` instead of `solanaChainId` 💀 

## Issue (if applicable)

Closes https://github.com/shapeshift/web/issues/8053

## Risk

Small

> What protocols, transaction types, wallets or contract interactions might be affected by this PR?

Banxa onramping.

## Testing

Ensure we can instigate a Banxa onramp flow for Solana, and ensure other assets still work as expected.

### Engineering

☝️

### Operations

- [ ] :checkered_flag: My feature is behind a flag and doesn't require operations testing (yet)

☝️

## Screenshots (if applicable)

<img width="635" alt="Screenshot 2024-10-31 at 13 57 37" src="https://github.com/user-attachments/assets/356f1a0e-a7ea-4034-8c58-814ebfca0529">
