### PR TITLE
fix: use fox as default asset on solana asset pages

### DIFF
--- a/src/components/MultiHopTrade/MultiHopTrade.tsx
+++ b/src/components/MultiHopTrade/MultiHopTrade.tsx
@@ -1,4 +1,5 @@
 import type { AssetId } from '@shapeshiftoss/caip'
+import { KnownChainIds } from '@shapeshiftoss/types'
 import { assertUnreachable } from '@shapeshiftoss/utils'
 import { AnimatePresence } from 'framer-motion'
 import { memo, useCallback, useEffect, useMemo, useRef, useState } from 'react'
@@ -62,8 +63,19 @@ export const MultiHopTrade = memo(({ defaultBuyAssetId, isCompact }: TradeCardPr
 
   useEffect(() => {
     dispatch(tradeInput.actions.clear())
-    if (routeBuyAsset) dispatch(tradeInput.actions.setBuyAsset(routeBuyAsset))
-    else if (defaultBuyAsset) dispatch(tradeInput.actions.setBuyAsset(defaultBuyAsset))
+
+    if (
+      routeBuyAsset?.chainId === KnownChainIds.SolanaMainnet ||
+      defaultBuyAsset?.chainId === KnownChainIds.SolanaMainnet
+    ) {
+      return
+    }
+
+    if (routeBuyAsset) {
+      dispatch(tradeInput.actions.setBuyAsset(routeBuyAsset))
+    } else if (defaultBuyAsset) {
+      dispatch(tradeInput.actions.setBuyAsset(defaultBuyAsset))
+    }
   }, [defaultBuyAsset, defaultBuyAssetId, dispatch, routeBuyAsset])
 
   // Prevent default behavior overriding deep linked route


### PR DESCRIPTION
## Description

Another case where solana assets were showing in the trade input component. Use FOX as the default buy asset when on a solana asset page.

## Issue (if applicable)

<!-----------------------------------------------------------------------------
If applicable, please link to the github issue and put `closes #XXXX` in your comment to auto-close the issue that your PR fixes.
------------------------------------------------------------------------------>

closes https://github.com/shapeshift/web/issues/8016

## Risk

> High Risk PRs Require 2 approvals

<!-----------------------------------------------------------------------------
Outline the scope of your changes and the risk associated with them. You must use your discretion as an engineer to determine the potential impact of your changes.

WARNING: If your PR introduces a new on-chain transaction or modifies an existing one, please add the "High-Risk" label to this PR and ask for 2 reviewers to approve it before merging.

E.g. an upgrade to `hdwallet` or core state management would be considered higher risk, and might require a full regression test. UI or isolated view changes, or something behind a feature flag may have near zero risk. Small bug fixes might require testing isolated to the specific fix.
------------------------------------------------------------------------------>

> What protocols, transaction types, wallets or contract interactions might be affected by this PR?

Low

## Testing

<!-----------------------------------------------------------------------------
We treat every PR to be merged with the same scrutiny as if we were merging directly to production.

Your PR will not be merged if you do not complete the sections below for our engineering and operations teams to test.
------------------------------------------------------------------------------>

- Ensure solana assets are showing in the trade input component when on a solana asset page
- Ensure default buy asset behavior is not changed for non solana assets

### Engineering

<!-----------------------------------------------------------------------------
Include sufficient information here for an engineer to test your PR. This may include how to test locally, in a built environment, changes to infrastructure etc.
------------------------------------------------------------------------------>

:point_up:

### Operations

- [ ] :checkered_flag: My feature is behind a flag and doesn't require operations testing (yet)

<!-----------------------------------------------------------------------------
If your changes have a user-facing impact, describe how a non-technical QA team can functionally test your changes in a preview environment.

If they are not user-facing please describe how to test for any regressions that may occur.
------------------------------------------------------------------------------>

:point_up:

## Screenshots (if applicable)

![image](https://github.com/user-attachments/assets/0859d225-7da4-4794-806f-691b693fa633)
