### PR TITLE
fix: re-fetch epoch metadata on hash change

### DIFF
--- a/src/pages/RFOX/hooks/useCurrentEpochMetadataQuery.ts
+++ b/src/pages/RFOX/hooks/useCurrentEpochMetadataQuery.ts
@@ -4,10 +4,11 @@ import axios from 'axios'
 import { CURRENT_EPOCH_IPFS_HASH, IPFS_GATEWAY } from '../constants'
 import type { CurrentEpochMetadata } from '../types'
 
-type CurrentEpochMetadataQueryKey = ['currentEpochMetadata']
+type CurrentEpochMetadataQueryKey = ['currentEpochMetadata', string]
 
 export const getCurrentEpochMetadataQueryKey = (): CurrentEpochMetadataQueryKey => [
   'currentEpochMetadata',
+  CURRENT_EPOCH_IPFS_HASH,
 ]
 
 export const fetchCurrentEpochMetadata = async (): Promise<CurrentEpochMetadata> => {


### PR DESCRIPTION
## Description

Re-fetch the current epoch metadata on epoch hash change.

## Issue (if applicable)

Addresses release feedback: https://discord.com/channels/554694662431178782/1302763664868376627/1302776944957460510

Relates to https://github.com/shapeshift/web/pull/8066

## Risk

Small

> What protocols, transaction types, wallets or contract interactions might be affected by this PR?

None

## Testing

Ensure we re-fetch the epoch metadata on the rFOX on first load after a hash change.

### Engineering

☝️

### Operations

- [ ] :checkered_flag: My feature is behind a flag and doesn't require operations testing (yet)

☝️

## Screenshots (if applicable)

N/A