### PR TITLE
chore: make limit order list scrollable

### DIFF
--- a/src/components/MultiHopTrade/components/LimitOrder/LimitOrderList.tsx
+++ b/src/components/MultiHopTrade/components/LimitOrder/LimitOrderList.tsx
@@ -56,9 +56,9 @@ export const LimitOrderList: FC<LimitOrderListProps> = ({ cardProps }) => {
 
   return (
     <Card {...cardProps}>
-      <CardHeader px={6} pt={4}>
-        <Tabs variant='unstyled'>
-          <TabList gap={4}>
+      <CardHeader px={0} pt={4} h='full'>
+        <Tabs variant='unstyled' display='flex' flexDirection='column' h='full'>
+          <TabList gap={4} flex='0 0 auto' mb={2} ml={6}>
             <Tab
               p={0}
               fontSize='md'
@@ -79,7 +79,7 @@ export const LimitOrderList: FC<LimitOrderListProps> = ({ cardProps }) => {
             </Tab>
           </TabList>
 
-          <TabPanels>
+          <TabPanels flex='1' overflowY='auto' minH={0} px={2}>
             <TabPanel px={0}>
               <CardBody px={0} overflowY='auto' flex='1 1 auto'>
                 {Array.from({ length: 3 }).map((_, index) => (


### PR DESCRIPTION
## Description

Makes the limit order list scrollable.

## Issue (if applicable)

Contributes to https://github.com/shapeshift/web/issues/6206

## Risk

Small

> What protocols, transaction types, wallets or contract interactions might be affected by this PR?

None

## Testing

Ensure that the hardcoded limit order list is scrollable.

### Engineering

☝️

### Operations

- [x] :checkered_flag: My feature is behind a flag and doesn't require operations testing (yet)

Not required.

## Screenshots (if applicable)

<img width="713" alt="Screenshot 2024-11-04 at 14 18 24" src="https://github.com/user-attachments/assets/f7994946-1061-4259-ac67-cc885fe3eb46">

