### PR TITLE
feat: limit order asset icon support

### DIFF
--- a/src/components/AssetIconWithBadge.tsx
+++ b/src/components/AssetIconWithBadge.tsx
@@ -20,6 +20,7 @@ import {
 type AssetIconWithBadgeProps = {
   size?: AvatarProps['size']
   assetId?: AssetId
+  secondaryAssetId?: AssetId
   transfersByType?: Record<TransferType, Transfer[]>
   type?: string
 } & PropsWithChildren
@@ -96,6 +97,7 @@ const TransferIcon: React.FC<{
 export const AssetIconWithBadge: React.FC<AssetIconWithBadgeProps> = ({
   size,
   assetId,
+  secondaryAssetId,
   transfersByType,
   type,
   children,
@@ -104,6 +106,34 @@ export const AssetIconWithBadge: React.FC<AssetIconWithBadgeProps> = ({
   const webIcon = <LuGlobe />
 
   const renderContent = () => {
+    if (assetId && secondaryAssetId) {
+      return (
+        <>
+          <Box>
+            <Image
+              src={FlipShadow}
+              position='absolute'
+              width='100%'
+              height='100%'
+              left={0}
+              top={0}
+              zIndex={2}
+            />
+            <AssetIcon
+              showNetworkIcon={false}
+              assetId={secondaryAssetId}
+              clipPath={bottomClipPath}
+              size={size}
+              position='absolute'
+              left={0}
+              top={0}
+            />
+          </Box>
+          <AssetIcon showNetworkIcon={false} assetId={assetId} clipPath={topClipPath} size={size} />
+        </>
+      )
+    }
+
     if (assetId) {
       return (
         <AssetIcon

--- a/src/components/AssetIconWithBadge.tsx
+++ b/src/components/AssetIconWithBadge.tsx
@@ -121,7 +121,7 @@ export const AssetIconWithBadge: React.FC<AssetIconWithBadgeProps> = ({
             />
             <AssetIcon
               showNetworkIcon={false}
-              assetId={secondaryAssetId}
+              assetId={assetId}
               clipPath={bottomClipPath}
               size={size}
               position='absolute'
@@ -129,7 +129,12 @@ export const AssetIconWithBadge: React.FC<AssetIconWithBadgeProps> = ({
               top={0}
             />
           </Box>
-          <AssetIcon showNetworkIcon={false} assetId={assetId} clipPath={topClipPath} size={size} />
+          <AssetIcon
+            showNetworkIcon={false}
+            assetId={secondaryAssetId}
+            clipPath={topClipPath}
+            size={size}
+          />
         </>
       )
     }

--- a/src/components/MultiHopTrade/components/LimitOrder/components/LimitOrderCard.tsx
+++ b/src/components/MultiHopTrade/components/LimitOrder/components/LimitOrderCard.tsx
@@ -1,6 +1,6 @@
 import { Box, Button, Center, Flex, Progress, Tag } from '@chakra-ui/react'
 import type { AssetId } from '@shapeshiftoss/caip'
-import { ethAssetId } from '@shapeshiftoss/caip'
+import { avalancheAssetId, ethAssetId } from '@shapeshiftoss/caip'
 import { type FC, useCallback, useMemo } from 'react'
 import { useTranslate } from 'react-polyglot'
 import { Amount } from 'components/Amount/Amount'
@@ -94,7 +94,7 @@ export const LimitOrderCard: FC<LimitOrderCardProps> = ({
         {/* Asset amounts row */}
         <Flex justify='space-between' align='flex-start'>
           <Flex>
-            <AssetIconWithBadge size='lg' assetId={ethAssetId}>
+            <AssetIconWithBadge size='lg' assetId={ethAssetId} secondaryAssetId={avalancheAssetId}>
               <Center borderRadius='full' boxSize='100%' bg='purple.500'>
                 <SwapBoldIcon boxSize='100%' />
               </Center>

--- a/src/components/MultiHopTrade/components/LimitOrder/components/LimitOrderCard.tsx
+++ b/src/components/MultiHopTrade/components/LimitOrder/components/LimitOrderCard.tsx
@@ -94,7 +94,7 @@ export const LimitOrderCard: FC<LimitOrderCardProps> = ({
         {/* Asset amounts row */}
         <Flex justify='space-between' align='flex-start'>
           <Flex>
-            <AssetIconWithBadge size='lg' assetId={ethAssetId} secondaryAssetId={avalancheAssetId}>
+            <AssetIconWithBadge size='lg' assetId={buyAssetId} secondaryAssetId={sellAssetId}>
               <Center borderRadius='full' boxSize='100%' bg='purple.500'>
                 <SwapBoldIcon boxSize='100%' />
               </Center>

--- a/src/components/MultiHopTrade/components/LimitOrder/components/LimitOrderCard.tsx
+++ b/src/components/MultiHopTrade/components/LimitOrder/components/LimitOrderCard.tsx
@@ -1,6 +1,5 @@
 import { Box, Button, Center, Flex, Progress, Tag } from '@chakra-ui/react'
 import type { AssetId } from '@shapeshiftoss/caip'
-import { avalancheAssetId, ethAssetId } from '@shapeshiftoss/caip'
 import { type FC, useCallback, useMemo } from 'react'
 import { useTranslate } from 'react-polyglot'
 import { Amount } from 'components/Amount/Amount'


### PR DESCRIPTION
## Description

Adds an optional `secondaryAssetId` prop to the `AssetIconWithBadge` component such that if a `secondaryAssetId` is provided we render the `secondaryAssetId` icon pealing off the `assetId` icon.

This is required for the limit order UI (see screenshot below).

## Issue (if applicable)

Contributes to https://github.com/shapeshift/web/issues/6206

## Risk

Small

> What protocols, transaction types, wallets or contract interactions might be affected by this PR?

None

## Testing

- ensure that icons, particularly those in the transaction history, show no regressions

### Engineering

With the limit order flag on ensure that in the order history the icons render correctly (sell asset icon pealing off the buy asset icon).

### Operations

- [x] :checkered_flag: My feature is behind a flag and doesn't require operations testing (yet)

Only a regression check on the icons needed.

## Screenshots (if applicable)

<img width="695" alt="Screenshot 2024-11-04 at 16 11 03" src="https://github.com/user-attachments/assets/ea10fac2-1396-41d1-bef2-ae4fe3e88c0b">

<img width="190" alt="Screenshot 2024-11-04 at 16 11 14" src="https://github.com/user-attachments/assets/394f808d-58f5-4de7-8bbd-fd48de69ef9e">

