### PR TITLE
fix: collapsibleQuoteList width

### DIFF
--- a/src/components/MultiHopTrade/components/TradeInput/components/CollapsibleQuoteList.tsx
+++ b/src/components/MultiHopTrade/components/TradeInput/components/CollapsibleQuoteList.tsx
@@ -23,9 +23,8 @@ export const CollapsibleQuoteList: React.FC<CollapsibleQuoteListProps> = ({
     () => ({
       ml,
       height,
-      width,
     }),
-    [ml, height, width],
+    [ml, height],
   )
 
   return (


### PR DESCRIPTION
## Description

Fix the width of the `CollapsibleQuoteList`, currently broken in `release`:

![image](https://github.com/user-attachments/assets/18b2d120-b3c2-4fb5-8f6a-68767adacb3d)

This PR;

<img width="710" alt="Screenshot 2024-11-06 at 12 37 10" src="https://github.com/user-attachments/assets/f841b8f1-53ce-426c-a386-22be0ccb6d4d">


## Issue (if applicable)

N/A - current release issue

## Risk

Small

> What protocols, transaction types, wallets or contract interactions might be affected by this PR?

None

## Testing

The `CollapsibleQuoteList` should be the correct width again, with rounded corners and a full-width scrollbar.

### Engineering

☝️

### Operations

- [ ] :checkered_flag: My feature is behind a flag and doesn't require operations testing (yet)

☝️

## Screenshots (if applicable)

See above.