### PR TITLE
feat: limit orders quote wiring

### DIFF
--- a/src/components/MultiHopTrade/components/LimitOrder/components/LimitOrderConfig.tsx
+++ b/src/components/MultiHopTrade/components/LimitOrder/components/LimitOrderConfig.tsx
@@ -82,17 +82,17 @@ const swapPriceButtonProps = { pr: 4 }
 type LimitOrderConfigProps = {
   sellAsset: Asset
   buyAsset: Asset
-  marketPriceBuyAssetCryptoPrecision: string
-  limitPriceBuyAssetCryptoPrecision: string
-  setLimitPriceBuyAssetCryptoPrecision: (priceBuyAssetCryptoPrecision: string) => void
+  marketPriceBuyAsset: string
+  limitPriceBuyAsset: string
+  setLimitPriceBuyAsset: (newLimitPriceBuyAsset: string) => void
 }
 
 export const LimitOrderConfig = ({
   sellAsset,
   buyAsset,
-  marketPriceBuyAssetCryptoPrecision,
-  limitPriceBuyAssetCryptoPrecision,
-  setLimitPriceBuyAssetCryptoPrecision,
+  marketPriceBuyAsset,
+  limitPriceBuyAsset,
+  setLimitPriceBuyAsset,
 }: LimitOrderConfigProps) => {
   const priceAmountRef = useRef<string | null>(null)
 
@@ -120,14 +120,14 @@ export const LimitOrderConfig = ({
 
   // Lower the decimal places when the integer is greater than 8 significant digits for better UI
   const priceCryptoFormatted = useMemo(() => {
-    const cryptoAmountIntegerCount = bnOrZero(
-      bnOrZero(limitPriceBuyAssetCryptoPrecision).toFixed(0),
-    ).precision(true)
+    const cryptoAmountIntegerCount = bnOrZero(bnOrZero(limitPriceBuyAsset).toFixed(0)).precision(
+      true,
+    )
 
     return cryptoAmountIntegerCount <= 8
-      ? limitPriceBuyAssetCryptoPrecision
-      : bnOrZero(limitPriceBuyAssetCryptoPrecision).toFixed(3)
-  }, [limitPriceBuyAssetCryptoPrecision])
+      ? limitPriceBuyAsset
+      : bnOrZero(limitPriceBuyAsset).toFixed(3)
+  }, [limitPriceBuyAsset])
 
   const arrow = useMemo(() => {
     return priceDirection === PriceDirection.Default ? '↑' : '↓'
@@ -152,14 +152,14 @@ export const LimitOrderConfig = ({
             assertUnreachable(presetLimit)
         }
       })()
-      const adjustedLimitPrice = bn(marketPriceBuyAssetCryptoPrecision).times(multiplier).toFixed()
+      const adjustedLimitPrice = bn(marketPriceBuyAsset).times(multiplier).toFixed()
       const maybeReversedPrice =
         priceDirection === PriceDirection.Reversed
           ? bn(1).div(adjustedLimitPrice).toFixed()
           : adjustedLimitPrice
-      setLimitPriceBuyAssetCryptoPrecision(maybeReversedPrice)
+      setLimitPriceBuyAsset(maybeReversedPrice)
     },
-    [marketPriceBuyAssetCryptoPrecision, setLimitPriceBuyAssetCryptoPrecision],
+    [marketPriceBuyAsset, setLimitPriceBuyAsset],
   )
 
   const handleSetMarketLimit = useCallback(() => {
@@ -191,37 +191,31 @@ export const LimitOrderConfig = ({
 
     if (isCustomLimit) {
       // For custom limit, just take the reciprocal as we don't know what the original input value was
-      setLimitPriceBuyAssetCryptoPrecision(bn(1).div(limitPriceBuyAssetCryptoPrecision).toFixed())
+      setLimitPriceBuyAsset(bn(1).div(limitPriceBuyAsset).toFixed())
     } else {
       // Otherwise set it to the precise value based on the original market price
       handleSetPresetLimit(presetLimit, newPriceDirection)
     }
-  }, [
-    handleSetPresetLimit,
-    limitPriceBuyAssetCryptoPrecision,
-    presetLimit,
-    priceDirection,
-    setLimitPriceBuyAssetCryptoPrecision,
-  ])
+  }, [handleSetPresetLimit, limitPriceBuyAsset, presetLimit, priceDirection, setLimitPriceBuyAsset])
 
   const handlePriceChange = useCallback(() => {
     // onChange will send us the formatted value
     // To get around this we need to get the value from the onChange using a ref
     // Now when the max buttons are clicked the onChange will not fire
-    setLimitPriceBuyAssetCryptoPrecision(priceAmountRef.current ?? '0')
+    setLimitPriceBuyAsset(priceAmountRef.current ?? '0')
 
     // Unset the preset limit, as this is a custom value
     setPresetLimit(undefined)
-  }, [setLimitPriceBuyAssetCryptoPrecision])
+  }, [setLimitPriceBuyAsset])
 
   const handleValueChange = useCallback(
     (values: NumberFormatValues) => {
       // This fires anytime value changes including setting it on max click
       // Store the value in a ref to send when we actually want the onChange to fire
       priceAmountRef.current = values.value
-      setLimitPriceBuyAssetCryptoPrecision(values.value)
+      setLimitPriceBuyAsset(values.value)
     },
-    [setLimitPriceBuyAssetCryptoPrecision],
+    [setLimitPriceBuyAsset],
   )
 
   const expiryOptionTranslation = useMemo(() => {

--- a/src/components/MultiHopTrade/components/LimitOrder/components/LimitOrderConfig.tsx
+++ b/src/components/MultiHopTrade/components/LimitOrder/components/LimitOrderConfig.tsx
@@ -12,7 +12,7 @@ import {
 } from '@chakra-ui/react'
 import type { Asset } from '@shapeshiftoss/types'
 import { bn, bnOrZero } from '@shapeshiftoss/utils'
-import { useCallback, useMemo, useRef, useState } from 'react'
+import { useCallback, useEffect, useMemo, useRef, useState } from 'react'
 import type { NumberFormatValues } from 'react-number-format'
 import NumberFormat from 'react-number-format'
 import { StyledAssetMenuButton } from 'components/AssetSelection/components/AssetMenuButton'
@@ -99,6 +99,20 @@ export const LimitOrderConfig = ({
   const [priceDirection, setPriceDirection] = useState(PriceDirection.Default)
   const [presetLimit, setPresetLimit] = useState<PresetLimit | undefined>(PresetLimit.Market)
   const [expiryOption, setExpiryOption] = useState(ExpiryOption.SevenDays)
+
+  // Reset the user config when the assets change
+  useEffect(
+    () => {
+      setPriceDirection(PriceDirection.Default)
+      setPresetLimit(PresetLimit.Market)
+      setExpiryOption(ExpiryOption.SevenDays)
+      setLimitPriceBuyAsset(marketPriceBuyAsset)
+    },
+    // NOTE: we DO NOT want to react to `marketPriceBuyAsset` here, because polling will reset it
+    // every time!
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+    [sellAsset, buyAsset, setLimitPriceBuyAsset],
+  )
 
   const {
     number: { localeParts },

--- a/src/components/MultiHopTrade/components/LimitOrder/components/LimitOrderConfig.tsx
+++ b/src/components/MultiHopTrade/components/LimitOrder/components/LimitOrderConfig.tsx
@@ -8,6 +8,7 @@ import {
   MenuItemOption,
   MenuList,
   MenuOptionGroup,
+  Skeleton,
   Stack,
 } from '@chakra-ui/react'
 import type { Asset } from '@shapeshiftoss/types'
@@ -77,11 +78,13 @@ const getExpiryOptionTranslation = (expiryOption: ExpiryOption) => {
 
 const timePeriodRightIcon = <ChevronDownIcon />
 const swapIcon = <SwapIcon />
-const swapPriceButtonProps = { pr: 4 }
+const disabledProps = { opacity: 0.5, cursor: 'not-allowed', userSelect: 'none' }
+const swapPriceButtonProps = { pr: 4, _disabled: disabledProps }
 
 type LimitOrderConfigProps = {
   sellAsset: Asset
   buyAsset: Asset
+  isLoading: boolean
   marketPriceBuyAsset: string
   limitPriceBuyAsset: string
   setLimitPriceBuyAsset: (newLimitPriceBuyAsset: string) => void
@@ -90,6 +93,7 @@ type LimitOrderConfigProps = {
 export const LimitOrderConfig = ({
   sellAsset,
   buyAsset,
+  isLoading,
   marketPriceBuyAsset,
   limitPriceBuyAsset,
   setLimitPriceBuyAsset,
@@ -247,7 +251,7 @@ export const LimitOrderConfig = ({
         <Flex justifyContent='space-between' alignItems='center'>
           <Text translation='limitOrder.expiry' mr={4} />
           <Menu isLazy>
-            <MenuButton as={Button} rightIcon={timePeriodRightIcon}>
+            <MenuButton as={Button} rightIcon={timePeriodRightIcon} isDisabled={isLoading}>
               <Text translation={expiryOptionTranslation} />
             </MenuButton>
             <MenuList zIndex='modal'>
@@ -263,23 +267,26 @@ export const LimitOrderConfig = ({
         </Flex>
       </Flex>
       <HStack width='full' justify='space-between'>
-        <NumberFormat
-          customInput={AmountInput}
-          decimalScale={priceAsset.precision}
-          isNumericString={true}
-          decimalSeparator={localeParts.decimal}
-          inputMode='decimal'
-          allowedDecimalSeparators={allowedDecimalSeparators}
-          thousandSeparator={localeParts.group}
-          value={priceCryptoFormatted}
-          onValueChange={handleValueChange}
-          onChange={handlePriceChange}
-        />
+        <Skeleton height={6} isLoaded={!isLoading}>
+          <NumberFormat
+            customInput={AmountInput}
+            decimalScale={priceAsset.precision}
+            isNumericString={true}
+            decimalSeparator={localeParts.decimal}
+            inputMode='decimal'
+            allowedDecimalSeparators={allowedDecimalSeparators}
+            thousandSeparator={localeParts.group}
+            value={priceCryptoFormatted}
+            onValueChange={handleValueChange}
+            onChange={handlePriceChange}
+          />
+        </Skeleton>
         <StyledAssetMenuButton
           rightIcon={swapIcon}
           assetId={priceAsset.assetId}
           buttonProps={swapPriceButtonProps}
           onAssetClick={handleTogglePriceDirection}
+          isDisabled={isLoading}
         />
       </HStack>
       <Flex justifyContent='space-between'>
@@ -288,6 +295,7 @@ export const LimitOrderConfig = ({
           size='sm'
           isActive={presetLimit === PresetLimit.Market}
           onClick={handleSetMarketLimit}
+          isDisabled={isLoading}
         >
           Market
         </Button>
@@ -296,6 +304,7 @@ export const LimitOrderConfig = ({
           size='sm'
           isActive={presetLimit === PresetLimit.OnePercent}
           onClick={handleSetOnePercentLimit}
+          isDisabled={isLoading}
         >
           1% {arrow}
         </Button>
@@ -304,6 +313,7 @@ export const LimitOrderConfig = ({
           size='sm'
           isActive={presetLimit === PresetLimit.TwoPercent}
           onClick={handleSetTwoPercentLimit}
+          isDisabled={isLoading}
         >
           2% {arrow}
         </Button>
@@ -312,6 +322,7 @@ export const LimitOrderConfig = ({
           size='sm'
           isActive={presetLimit === PresetLimit.FivePercent}
           onClick={handleSetFivePercentLimit}
+          isDisabled={isLoading}
         >
           5% {arrow}
         </Button>
@@ -320,6 +331,7 @@ export const LimitOrderConfig = ({
           size='sm'
           isActive={presetLimit === PresetLimit.TenPercent}
           onClick={handleSetTenPercentLimit}
+          isDisabled={isLoading}
         >
           10% {arrow}
         </Button>

--- a/src/components/MultiHopTrade/components/LimitOrder/components/LimitOrderInput.tsx
+++ b/src/components/MultiHopTrade/components/LimitOrder/components/LimitOrderInput.tsx
@@ -378,7 +378,7 @@ export const LimitOrderInput = ({
         inputAmountUsd={sellAmountUsd}
         isError={Boolean(error)}
         isLoading={isLoading}
-        quoteStatusTranslation={'trade.previewTrade'}
+        quoteStatusTranslation={'limitOrder.previewOrder'}
         rate={bnOrZero(limitPriceBuyAsset).isZero() ? undefined : limitPriceBuyAsset}
         sellAccountId={sellAccountId}
         shouldDisableGasRateRowClick

--- a/src/components/MultiHopTrade/components/LimitOrder/components/LimitOrderInput.tsx
+++ b/src/components/MultiHopTrade/components/LimitOrder/components/LimitOrderInput.tsx
@@ -342,6 +342,7 @@ export const LimitOrderInput = ({
           <LimitOrderConfig
             sellAsset={sellAsset}
             buyAsset={buyAsset}
+            isLoading={isLoading}
             marketPriceBuyAsset={marketPriceBuyAsset}
             limitPriceBuyAsset={limitPriceBuyAsset}
             setLimitPriceBuyAsset={setLimitPriceBuyAsset}

--- a/src/components/MultiHopTrade/components/LimitOrder/components/LimitOrderInput.tsx
+++ b/src/components/MultiHopTrade/components/LimitOrder/components/LimitOrderInput.tsx
@@ -124,25 +124,6 @@ export const LimitOrderInput = ({
     [isSnapshotApiQueriesPending, votingPower],
   )
 
-  const isLoading = useMemo(
-    () =>
-      // No account meta loaded for that chain
-      !isAnyAccountMetadataLoadedForChainId ||
-      (!shouldShowTradeQuoteOrAwaitInput && !isTradeQuoteRequestAborted) ||
-      isConfirmationLoading ||
-      // Only consider snapshot API queries as pending if we don't have voting power yet
-      // if we do, it means we have persisted or cached (both stale) data, which is enough to let the user continue
-      // as we are optimistic and don't want to be waiting for a potentially very long time for the snapshot API to respond
-      isVotingPowerLoading,
-    [
-      isAnyAccountMetadataLoadedForChainId,
-      shouldShowTradeQuoteOrAwaitInput,
-      isTradeQuoteRequestAborted,
-      isConfirmationLoading,
-      isVotingPowerLoading,
-    ],
-  )
-
   const sellAssetMarketDataUserCurrency = useAppSelector(state =>
     selectMarketDataByAssetIdUserCurrency(state, sellAsset.assetId),
   )
@@ -284,7 +265,8 @@ export const LimitOrderInput = ({
   // price. When submitting a limit order, the buyAmount is (optionally) modified based on the user
   // input, and then re-attached to the `LimitOrder` before signing and submitting via our
   // `placeLimitOrder` endpoint in limitOrderApi
-  const { data } = useQuoteLimitOrderQuery(limitOrderQuoteParams)
+  const { data, isFetching: isLimitOrderQuoteFetching } =
+    useQuoteLimitOrderQuery(limitOrderQuoteParams)
 
   const marketPriceBuyAsset = useMemo(() => {
     if (!data) return '0'
@@ -299,6 +281,27 @@ export const LimitOrderInput = ({
   useEffect(() => {
     setLimitPriceBuyAsset(marketPriceBuyAsset)
   }, [marketPriceBuyAsset])
+
+  const isLoading = useMemo(() => {
+    return (
+      isLimitOrderQuoteFetching ||
+      // No account meta loaded for that chain
+      !isAnyAccountMetadataLoadedForChainId ||
+      (!shouldShowTradeQuoteOrAwaitInput && !isTradeQuoteRequestAborted) ||
+      isConfirmationLoading ||
+      // Only consider snapshot API queries as pending if we don't have voting power yet
+      // if we do, it means we have persisted or cached (both stale) data, which is enough to let the user continue
+      // as we are optimistic and don't want to be waiting for a potentially very long time for the snapshot API to respond
+      isVotingPowerLoading
+    )
+  }, [
+    isAnyAccountMetadataLoadedForChainId,
+    isConfirmationLoading,
+    isLimitOrderQuoteFetching,
+    isTradeQuoteRequestAborted,
+    isVotingPowerLoading,
+    shouldShowTradeQuoteOrAwaitInput,
+  ])
 
   const headerRightContent = useMemo(() => {
     return (

--- a/src/components/MultiHopTrade/components/LimitOrder/components/LimitOrderInput.tsx
+++ b/src/components/MultiHopTrade/components/LimitOrder/components/LimitOrderInput.tsx
@@ -360,7 +360,6 @@ export const LimitOrderInput = ({
     handleSwitchAssets,
   ])
 
-  // TODO: Remove me as this is dummy data from spot trade not limit orders
   const { feeUsd } = useAppSelector(state =>
     selectCalculatedFees(state, { feeModel: 'SWAPPER', inputAmountUsd: sellAmountUsd }),
   )

--- a/src/components/MultiHopTrade/components/SharedTradeInput/SharedSlippagePopover.tsx
+++ b/src/components/MultiHopTrade/components/SharedTradeInput/SharedSlippagePopover.tsx
@@ -1,0 +1,212 @@
+import {
+  Alert,
+  AlertDescription,
+  AlertIcon,
+  Box,
+  Button,
+  ButtonGroup,
+  FormControl,
+  IconButton,
+  Input,
+  InputGroup,
+  InputRightElement,
+  Popover,
+  PopoverBody,
+  PopoverContent,
+  PopoverTrigger,
+  Tooltip,
+} from '@chakra-ui/react'
+import { bnOrZero } from '@shapeshiftoss/chain-adapters'
+import type { FC } from 'react'
+import { memo, useCallback, useEffect, useMemo, useRef, useState } from 'react'
+import { FaGear } from 'react-icons/fa6'
+import { useTranslate } from 'react-polyglot'
+import { HelperTooltip } from 'components/HelperTooltip/HelperTooltip'
+import { Row } from 'components/Row/Row'
+import { Text } from 'components/Text'
+import { useFeatureFlag } from 'hooks/useFeatureFlag/useFeatureFlag'
+
+enum SlippageType {
+  Auto = 'Auto',
+  Custom = 'Custom',
+}
+
+const maxSlippagePercentage = '30'
+
+const focusStyle = { '&[aria-invalid=true]': { borderColor: 'red.500' } }
+
+const faGear = <FaGear />
+
+type SharedSlippagePopoverProps = {
+  defaultSlippagePercentage: string
+  isDisabled?: boolean
+  quoteSlippagePercentage: string | undefined
+  tooltipTranslation?: string
+  userSlippagePercentage: string | undefined
+  setUserSlippagePercentage: (slippagePercentage: string | undefined) => void
+}
+
+export const SharedSlippagePopover: FC<SharedSlippagePopoverProps> = memo(
+  ({
+    defaultSlippagePercentage,
+    isDisabled,
+    quoteSlippagePercentage,
+    tooltipTranslation,
+    userSlippagePercentage,
+    setUserSlippagePercentage,
+  }) => {
+    const [slippageType, setSlippageType] = useState<SlippageType>(SlippageType.Auto)
+    const [slippageAmount, setSlippageAmount] = useState<string | undefined>(
+      defaultSlippagePercentage,
+    )
+    const [isInvalid, setIsInvalid] = useState(false)
+    const translate = useTranslate()
+    const inputRef = useRef<HTMLInputElement>(null)
+    const isAdvancedSlippageEnabled = useFeatureFlag('AdvancedSlippage')
+
+    useEffect(() => {
+      // Handles re-opening the slippage popover and/or going back to input step
+      if (userSlippagePercentage) {
+        setSlippageType(SlippageType.Custom)
+        setSlippageAmount(userSlippagePercentage)
+      } else {
+        setSlippageType(SlippageType.Auto)
+        setSlippageAmount(quoteSlippagePercentage ?? defaultSlippagePercentage)
+      }
+      // We only want this to run on mount, though not to be reactive to userSlippagePercentage
+      // eslint-disable-next-line react-hooks/exhaustive-deps
+    }, [defaultSlippagePercentage, quoteSlippagePercentage])
+
+    const handleChange = useCallback((e: React.ChangeEvent<HTMLInputElement>) => {
+      const value = e.target.value
+      if (bnOrZero(value).gt(maxSlippagePercentage)) {
+        setIsInvalid(true)
+      } else {
+        setIsInvalid(false)
+      }
+      setSlippageAmount(value)
+      setSlippageType(SlippageType.Custom)
+    }, [])
+
+    const handleClose = useCallback(() => {
+      if (slippageType === SlippageType.Custom && !isInvalid)
+        setUserSlippagePercentage(slippageAmount)
+      else if (slippageType === SlippageType.Auto) setUserSlippagePercentage(undefined)
+    }, [setUserSlippagePercentage, isInvalid, slippageAmount, slippageType])
+
+    const handleSlippageTypeChange = useCallback(
+      (type: SlippageType) => {
+        if (type === SlippageType.Auto) {
+          setSlippageAmount(defaultSlippagePercentage)
+          setIsInvalid(false)
+        } else {
+          inputRef && inputRef.current && inputRef.current.focus()
+          setSlippageAmount(slippageAmount)
+        }
+        setSlippageType(type)
+      },
+      [defaultSlippagePercentage, slippageAmount],
+    )
+
+    const handleAutoSlippageTypeChange = useCallback(
+      () => handleSlippageTypeChange(SlippageType.Auto),
+      [handleSlippageTypeChange],
+    )
+
+    const handleCustomSlippageTypeChange = useCallback(
+      () => handleSlippageTypeChange(SlippageType.Custom),
+      [handleSlippageTypeChange],
+    )
+
+    const isHighSlippage = useMemo(() => bnOrZero(slippageAmount).gt(1), [slippageAmount])
+    const isLowSlippage = useMemo(() => bnOrZero(slippageAmount).lt(0.05), [slippageAmount])
+
+    if (!isAdvancedSlippageEnabled) return null
+
+    return (
+      <Popover isLazy placement='bottom-end' onClose={handleClose}>
+        <Tooltip isDisabled={!isDisabled} label={translate(tooltipTranslation)}>
+          <Box display='inline-block'>
+            <PopoverTrigger>
+              <IconButton
+                aria-label={translate('trade.tradeSettings')}
+                icon={faGear}
+                variant='ghost'
+                isDisabled={isDisabled}
+              />
+            </PopoverTrigger>
+          </Box>
+        </Tooltip>
+        <PopoverContent>
+          <PopoverBody>
+            <Row>
+              <Row.Label>
+                <HelperTooltip label={translate('trade.slippageInfo')}>
+                  <Text translation='trade.slippage.maxSlippage' />
+                </HelperTooltip>
+              </Row.Label>
+              <Row.Value>{slippageType === SlippageType.Auto && 'Auto'}</Row.Value>
+            </Row>
+            <Row py={2} gap={2} mt={2}>
+              <Row.Value>
+                <ButtonGroup
+                  size='sm'
+                  bg='background.input.base'
+                  px={1}
+                  py={1}
+                  borderRadius='xl'
+                  variant='ghost'
+                >
+                  <Button
+                    onClick={handleAutoSlippageTypeChange}
+                    isActive={slippageType === SlippageType.Auto}
+                  >
+                    {translate('trade.slippage.auto')}
+                  </Button>
+                  <Button
+                    onClick={handleCustomSlippageTypeChange}
+                    isActive={slippageType === SlippageType.Custom}
+                  >
+                    {translate('trade.slippage.custom')}
+                  </Button>
+                </ButtonGroup>
+              </Row.Value>
+              <Row.Value>
+                <FormControl isInvalid={isInvalid}>
+                  <InputGroup variant='filled'>
+                    <Input
+                      placeholder={slippageAmount}
+                      value={slippageAmount}
+                      type='number'
+                      _focus={focusStyle}
+                      onChange={handleChange}
+                      ref={inputRef}
+                      isDisabled={slippageType === SlippageType.Auto}
+                    />
+                    <InputRightElement>%</InputRightElement>
+                  </InputGroup>
+                </FormControl>
+              </Row.Value>
+            </Row>
+            {isHighSlippage && (
+              <Alert mt={2} fontSize='sm' status='warning' bg='transparent' px={0} py={0}>
+                <AlertIcon />
+                <AlertDescription lineHeight='1.5'>
+                  {translate('trade.slippage.warning')}
+                </AlertDescription>
+              </Alert>
+            )}
+            {isLowSlippage && (
+              <Alert mt={2} fontSize='sm' status='warning' bg='transparent' px={0} py={0}>
+                <AlertIcon />
+                <AlertDescription lineHeight='1.5'>
+                  {translate('trade.slippage.lowSlippage')}
+                </AlertDescription>
+              </Alert>
+            )}
+          </PopoverBody>
+        </PopoverContent>
+      </Popover>
+    )
+  },
+)

--- a/src/components/MultiHopTrade/components/SharedTradeInput/SharedTradeInputFooter/SharedTradeInputFooter.tsx
+++ b/src/components/MultiHopTrade/components/SharedTradeInput/SharedTradeInputFooter/SharedTradeInputFooter.tsx
@@ -1,4 +1,4 @@
-import { CardFooter, useMediaQuery } from '@chakra-ui/react'
+import { CardFooter } from '@chakra-ui/react'
 import type { SwapperName, SwapSource } from '@shapeshiftoss/swapper'
 import type { Asset } from '@shapeshiftoss/types'
 import type { InterpolationOptions } from 'node-polyglot'
@@ -9,7 +9,6 @@ import { Text } from 'components/Text'
 import { useAccountsFetchQuery } from 'context/AppProvider/hooks/useAccountsFetchQuery'
 import { selectFeeAssetById } from 'state/slices/selectors'
 import { useAppSelector } from 'state/store'
-import { breakpoints } from 'theme/theme'
 
 import { ReceiveSummary } from './components/ReceiveSummary'
 
@@ -20,19 +19,19 @@ type SharedTradeInputFooterProps = {
   children?: JSX.Element
   hasUserEnteredAmount: boolean
   inputAmountUsd: string | undefined
-  isCompact: boolean | undefined
   isError: boolean
   isLoading: boolean
   quoteStatusTranslation: string | [string, InterpolationOptions]
   rate: string | undefined
-  sellAsset: Asset
+  receiveSummaryDetails?: JSX.Element | null
   sellAccountId: string | undefined
+  sellAsset: Asset
+  shouldDisableGasRateRowClick?: boolean
   shouldDisablePreviewButton: boolean | undefined
   swapperName: SwapperName | undefined
   swapSource: SwapSource | undefined
-  totalNetworkFeeFiatPrecision: string
-  receiveSummaryDetails?: JSX.Element | null
-  onRateClick: () => void
+  totalNetworkFeeFiatPrecision: string | undefined
+  onGasRateRowClick?: () => void
 }
 
 export const SharedTradeInputFooter = ({
@@ -42,22 +41,20 @@ export const SharedTradeInputFooter = ({
   children,
   hasUserEnteredAmount,
   inputAmountUsd,
-  isCompact,
   isError,
   isLoading: isParentLoading,
   quoteStatusTranslation,
   rate,
-  sellAsset,
+  receiveSummaryDetails,
   sellAccountId,
+  sellAsset,
+  shouldDisableGasRateRowClick,
   shouldDisablePreviewButton: parentShouldDisablePreviewButton,
   swapperName,
   swapSource,
   totalNetworkFeeFiatPrecision,
-  receiveSummaryDetails,
-  onRateClick,
+  onGasRateRowClick,
 }: SharedTradeInputFooterProps) => {
-  const [isSmallerThanXl] = useMediaQuery(`(max-width: ${breakpoints.xl})`, { ssr: false })
-
   const buyAssetFeeAsset = useAppSelector(state =>
     selectFeeAssetById(state, buyAsset?.assetId ?? ''),
   )
@@ -101,15 +98,15 @@ export const SharedTradeInputFooter = ({
       >
         {hasUserEnteredAmount && (
           <RateGasRow
-            sellSymbol={sellAsset.symbol}
-            buySymbol={buyAsset.symbol}
-            gasFee={totalNetworkFeeFiatPrecision ?? 'unknown'}
+            buyAssetSymbol={buyAsset.symbol}
+            sellAssetSymbol={sellAsset.symbol}
+            isDisabled={shouldDisableGasRateRowClick}
             rate={rate}
             isLoading={isLoading}
+            totalNetworkFeeFiatPrecision={totalNetworkFeeFiatPrecision}
             swapperName={swapperName}
             swapSource={swapSource}
-            onRateClick={onRateClick}
-            allowSelectQuote={Boolean(isSmallerThanXl || isCompact)}
+            onClick={onGasRateRowClick}
           >
             <ReceiveSummary
               isLoading={isLoading}

--- a/src/components/MultiHopTrade/components/SlippagePopover.tsx
+++ b/src/components/MultiHopTrade/components/SlippagePopover.tsx
@@ -1,30 +1,5 @@
-import {
-  Alert,
-  AlertDescription,
-  AlertIcon,
-  Box,
-  Button,
-  ButtonGroup,
-  FormControl,
-  IconButton,
-  Input,
-  InputGroup,
-  InputRightElement,
-  Popover,
-  PopoverBody,
-  PopoverContent,
-  PopoverTrigger,
-  Tooltip,
-} from '@chakra-ui/react'
-import { bnOrZero } from '@shapeshiftoss/chain-adapters'
 import type { FC } from 'react'
-import { memo, useCallback, useEffect, useMemo, useRef, useState } from 'react'
-import { FaGear } from 'react-icons/fa6'
-import { useTranslate } from 'react-polyglot'
-import { HelperTooltip } from 'components/HelperTooltip/HelperTooltip'
-import { Row } from 'components/Row/Row'
-import { Text } from 'components/Text'
-import { useFeatureFlag } from 'hooks/useFeatureFlag/useFeatureFlag'
+import { memo, useCallback } from 'react'
 import { selectUserSlippagePercentage } from 'state/slices/tradeInputSlice/selectors'
 import { tradeInput } from 'state/slices/tradeInputSlice/tradeInputSlice'
 import {
@@ -33,16 +8,7 @@ import {
 } from 'state/slices/tradeQuoteSlice/selectors'
 import { useAppDispatch, useAppSelector } from 'state/store'
 
-enum SlippageType {
-  Auto = 'Auto',
-  Custom = 'Custom',
-}
-
-const maxSlippagePercentage = '30'
-
-const focusStyle = { '&[aria-invalid=true]': { borderColor: 'red.500' } }
-
-const faGear = <FaGear />
+import { SharedSlippagePopover } from './SharedTradeInput/SharedSlippagePopover'
 
 type SlippagePopoverProps = {
   isDisabled?: boolean
@@ -51,165 +17,27 @@ type SlippagePopoverProps = {
 
 export const SlippagePopover: FC<SlippagePopoverProps> = memo(
   ({ tooltipTranslation, isDisabled }) => {
+    const dispatch = useAppDispatch()
     const defaultSlippagePercentage = useAppSelector(selectDefaultSlippagePercentage)
     const quoteSlippagePercentage = useAppSelector(selectQuoteSlippageTolerancePercentage)
-
     const userSlippagePercentage = useAppSelector(selectUserSlippagePercentage)
 
-    const [slippageType, setSlippageType] = useState<SlippageType>(SlippageType.Auto)
-    const [slippageAmount, setSlippageAmount] = useState<string | undefined>(
-      defaultSlippagePercentage,
-    )
-    const [isInvalid, setIsInvalid] = useState(false)
-    const translate = useTranslate()
-    const inputRef = useRef<HTMLInputElement>(null)
-    const isAdvancedSlippageEnabled = useFeatureFlag('AdvancedSlippage')
-    const dispatch = useAppDispatch()
-
-    useEffect(() => {
-      // Handles re-opening the slippage popover and/or going back to input step
-      if (userSlippagePercentage) {
-        setSlippageType(SlippageType.Custom)
-        setSlippageAmount(userSlippagePercentage)
-      } else {
-        setSlippageType(SlippageType.Auto)
-        setSlippageAmount(quoteSlippagePercentage ?? defaultSlippagePercentage)
-      }
-      // We only want this to run on mount, though not to be reactive to userSlippagePercentage
-      // eslint-disable-next-line react-hooks/exhaustive-deps
-    }, [defaultSlippagePercentage, quoteSlippagePercentage])
-
-    const handleChange = useCallback((e: React.ChangeEvent<HTMLInputElement>) => {
-      const value = e.target.value
-      if (bnOrZero(value).gt(maxSlippagePercentage)) {
-        setIsInvalid(true)
-      } else {
-        setIsInvalid(false)
-      }
-      setSlippageAmount(value)
-      setSlippageType(SlippageType.Custom)
-    }, [])
-
-    const handleClose = useCallback(() => {
-      if (slippageType === SlippageType.Custom && !isInvalid)
-        dispatch(tradeInput.actions.setSlippagePreferencePercentage(slippageAmount))
-      else if (slippageType === SlippageType.Auto)
-        dispatch(tradeInput.actions.setSlippagePreferencePercentage(undefined))
-    }, [dispatch, isInvalid, slippageAmount, slippageType])
-
-    const handleSlippageTypeChange = useCallback(
-      (type: SlippageType) => {
-        if (type === SlippageType.Auto) {
-          setSlippageAmount(defaultSlippagePercentage)
-          setIsInvalid(false)
-        } else {
-          inputRef && inputRef.current && inputRef.current.focus()
-          setSlippageAmount(slippageAmount)
-        }
-        setSlippageType(type)
+    const setSlippagePreferencePercentage = useCallback(
+      (slippagePercentage: string | undefined) => {
+        dispatch(tradeInput.actions.setSlippagePreferencePercentage(slippagePercentage))
       },
-      [defaultSlippagePercentage, slippageAmount],
+      [dispatch],
     )
-
-    const handleAutoSlippageTypeChange = useCallback(
-      () => handleSlippageTypeChange(SlippageType.Auto),
-      [handleSlippageTypeChange],
-    )
-
-    const handleCustomSlippageTypeChange = useCallback(
-      () => handleSlippageTypeChange(SlippageType.Custom),
-      [handleSlippageTypeChange],
-    )
-
-    const isHighSlippage = useMemo(() => bnOrZero(slippageAmount).gt(1), [slippageAmount])
-    const isLowSlippage = useMemo(() => bnOrZero(slippageAmount).lt(0.05), [slippageAmount])
-
-    if (!isAdvancedSlippageEnabled) return null
 
     return (
-      <Popover isLazy placement='bottom-end' onClose={handleClose}>
-        <Tooltip isDisabled={!isDisabled} label={translate(tooltipTranslation)}>
-          <Box display='inline-block'>
-            <PopoverTrigger>
-              <IconButton
-                aria-label={translate('trade.tradeSettings')}
-                icon={faGear}
-                variant='ghost'
-                isDisabled={isDisabled}
-              />
-            </PopoverTrigger>
-          </Box>
-        </Tooltip>
-        <PopoverContent>
-          <PopoverBody>
-            <Row>
-              <Row.Label>
-                <HelperTooltip label={translate('trade.slippageInfo')}>
-                  <Text translation='trade.slippage.maxSlippage' />
-                </HelperTooltip>
-              </Row.Label>
-              <Row.Value>{slippageType === SlippageType.Auto && 'Auto'}</Row.Value>
-            </Row>
-            <Row py={2} gap={2} mt={2}>
-              <Row.Value>
-                <ButtonGroup
-                  size='sm'
-                  bg='background.input.base'
-                  px={1}
-                  py={1}
-                  borderRadius='xl'
-                  variant='ghost'
-                >
-                  <Button
-                    onClick={handleAutoSlippageTypeChange}
-                    isActive={slippageType === SlippageType.Auto}
-                  >
-                    {translate('trade.slippage.auto')}
-                  </Button>
-                  <Button
-                    onClick={handleCustomSlippageTypeChange}
-                    isActive={slippageType === SlippageType.Custom}
-                  >
-                    {translate('trade.slippage.custom')}
-                  </Button>
-                </ButtonGroup>
-              </Row.Value>
-              <Row.Value>
-                <FormControl isInvalid={isInvalid}>
-                  <InputGroup variant='filled'>
-                    <Input
-                      placeholder={slippageAmount}
-                      value={slippageAmount}
-                      type='number'
-                      _focus={focusStyle}
-                      onChange={handleChange}
-                      ref={inputRef}
-                      isDisabled={slippageType === SlippageType.Auto}
-                    />
-                    <InputRightElement>%</InputRightElement>
-                  </InputGroup>
-                </FormControl>
-              </Row.Value>
-            </Row>
-            {isHighSlippage && (
-              <Alert mt={2} fontSize='sm' status='warning' bg='transparent' px={0} py={0}>
-                <AlertIcon />
-                <AlertDescription lineHeight='1.5'>
-                  {translate('trade.slippage.warning')}
-                </AlertDescription>
-              </Alert>
-            )}
-            {isLowSlippage && (
-              <Alert mt={2} fontSize='sm' status='warning' bg='transparent' px={0} py={0}>
-                <AlertIcon />
-                <AlertDescription lineHeight='1.5'>
-                  {translate('trade.slippage.lowSlippage')}
-                </AlertDescription>
-              </Alert>
-            )}
-          </PopoverBody>
-        </PopoverContent>
-      </Popover>
+      <SharedSlippagePopover
+        defaultSlippagePercentage={defaultSlippagePercentage}
+        isDisabled={isDisabled}
+        quoteSlippagePercentage={quoteSlippagePercentage}
+        tooltipTranslation={tooltipTranslation}
+        userSlippagePercentage={userSlippagePercentage}
+        setUserSlippagePercentage={setSlippagePreferencePercentage}
+      />
     )
   },
 )

--- a/src/components/MultiHopTrade/components/SwapperIcons.tsx
+++ b/src/components/MultiHopTrade/components/SwapperIcons.tsx
@@ -1,0 +1,52 @@
+import { Center } from '@chakra-ui/react'
+import type { SwapperName, SwapSource } from '@shapeshiftoss/swapper'
+import {
+  THORCHAIN_LONGTAIL_STREAMING_SWAP_SOURCE,
+  THORCHAIN_STREAM_SWAP_SOURCE,
+} from '@shapeshiftoss/swapper/dist/swappers/ThorchainSwapper/constants'
+import { AnimatePresence } from 'framer-motion'
+import { StreamIcon } from 'components/Icons/Stream'
+import { SlideTransitionX } from 'components/SlideTransitionX'
+
+import { SwapperIcon } from './TradeInput/components/SwapperIcon/SwapperIcon'
+
+type SwapperIconsProps = {
+  swapSource: SwapSource | undefined
+  swapperName: SwapperName | undefined
+}
+
+export const SwapperIcons = ({ swapSource, swapperName }: SwapperIconsProps) => {
+  const isStreaming =
+    swapSource === THORCHAIN_STREAM_SWAP_SOURCE ||
+    swapSource === THORCHAIN_LONGTAIL_STREAMING_SWAP_SOURCE
+  return (
+    <AnimatePresence>
+      {isStreaming && (
+        <SlideTransitionX key={swapSource ?? swapperName}>
+          <Center
+            className='quote-icon'
+            bg='background.surface.raised.base'
+            borderRadius='md'
+            borderWidth={1}
+            p='2px'
+            borderColor='border.base'
+            boxShadow='0 1px 2px rgba(0,0,0,.2)'
+          >
+            <StreamIcon color='text.success' />
+          </Center>
+        </SlideTransitionX>
+      )}
+      <Center
+        className='quote-icon'
+        bg='background.surface.raised.base'
+        borderRadius='md'
+        borderWidth={1}
+        p='2px'
+        borderColor='border.base'
+        boxShadow='0 1px 2px rgba(0,0,0,.2)'
+      >
+        {swapperName && <SwapperIcon size='2xs' swapperName={swapperName} />}
+      </Center>
+    </AnimatePresence>
+  )
+}

--- a/src/components/MultiHopTrade/components/TradeInput/components/ConfirmSummary.tsx
+++ b/src/components/MultiHopTrade/components/TradeInput/components/ConfirmSummary.tsx
@@ -363,24 +363,24 @@ export const ConfirmSummary = ({
 
   return (
     <SharedTradeInputFooter
-      isCompact={isCompact}
-      isLoading={isLoading}
-      inputAmountUsd={inputAmountUsd}
       affiliateBps={affiliateBps}
       affiliateFeeAfterDiscountUserCurrency={affiliateFeeAfterDiscountUserCurrency}
-      quoteStatusTranslation={quoteStatusTranslation}
-      onRateClick={handleOpenCompactQuoteList}
-      shouldDisablePreviewButton={shouldDisablePreviewButton}
-      isError={quoteHasError}
-      swapSource={tradeQuoteStep?.source}
-      rate={activeQuote?.rate}
-      swapperName={activeSwapperName}
       buyAsset={buyAsset}
       hasUserEnteredAmount={hasUserEnteredAmount}
-      sellAsset={sellAsset}
-      sellAccountId={sellAssetAccountId}
-      totalNetworkFeeFiatPrecision={totalNetworkFeeFiatPrecision}
+      inputAmountUsd={inputAmountUsd}
+      isError={quoteHasError}
+      isLoading={isLoading}
+      onGasRateRowClick={handleOpenCompactQuoteList}
+      quoteStatusTranslation={quoteStatusTranslation}
+      rate={activeQuote?.rate}
       receiveSummaryDetails={receiveSummaryDetails}
+      sellAccountId={sellAssetAccountId}
+      sellAsset={sellAsset}
+      shouldDisableGasRateRowClick={!Boolean(isSmallerThanXl || isCompact)}
+      shouldDisablePreviewButton={shouldDisablePreviewButton}
+      swapperName={activeSwapperName}
+      swapSource={tradeQuoteStep?.source}
+      totalNetworkFeeFiatPrecision={totalNetworkFeeFiatPrecision}
     >
       <>
         {nativeAssetBridgeWarning ? (

--- a/src/state/apis/limit-orders/limitOrderApi.ts
+++ b/src/state/apis/limit-orders/limitOrderApi.ts
@@ -21,6 +21,7 @@ import type { Address } from 'viem'
 import { zeroAddress } from 'viem'
 
 import { BASE_RTK_CREATE_API_CONFIG } from '../const'
+import type { LimitOrderQuoteResponse } from './types'
 import {
   type CancelLimitOrdersRequest,
   type CompetitionOrderStatus,
@@ -50,7 +51,7 @@ export const limitOrderApi = createApi({
   keepUnusedDataFor: Number.MAX_SAFE_INTEGER, // never clear, we will manage this
   tagTypes: ['LimitOrder'],
   endpoints: build => ({
-    quoteLimitOrder: build.query<LimitOrder, LimitOrderQuoteParams>({
+    quoteLimitOrder: build.query<LimitOrderQuoteResponse, LimitOrderQuoteParams>({
       queryFn: async ({
         sellAssetId,
         buyAssetId,
@@ -97,7 +98,7 @@ export const limitOrderApi = createApi({
         limitOrderQuoteRequest.appDataHash = appDataHash
 
         try {
-          const result = await axios.post<LimitOrder>(
+          const result = await axios.post<LimitOrderQuoteResponse>(
             `${baseUrl}/${network}/api/v1/quote/`,
             limitOrderQuoteRequest,
           )

--- a/src/state/apis/limit-orders/types.ts
+++ b/src/state/apis/limit-orders/types.ts
@@ -5,6 +5,7 @@ import type {
   CoWSwapSellTokenSource,
   CoWSwapSigningScheme,
 } from '@shapeshiftoss/swapper'
+import type { Address } from 'viem'
 
 export enum PriceQuality {
   Fast = 'fast',
@@ -28,6 +29,33 @@ export type LimitOrderQuoteRequest = {
   onChainOrder?: boolean
   kind: CoWSwapOrderKind.Sell
   sellAmountBeforeFee: string
+}
+
+export type LimitOrderQuote = {
+  sellToken: AssetReference
+  buyToken: AssetReference
+  receiver?: string
+  sellAmount: string
+  buyAmount: string
+  validTo: number
+  feeAmount: string
+  kind: CoWSwapOrderKind
+  partiallyFillable: boolean
+  sellTokenBalance?: CoWSwapSellTokenSource
+  buyTokenBalance?: CoWSwapBuyTokenDestination
+  signingScheme: CoWSwapSigningScheme
+  signature: string
+  from?: string
+  appData: string
+  appDataHash?: string
+}
+
+export type LimitOrderQuoteResponse = {
+  expiration: string
+  from: Address
+  id: LimitOrderQuoteId
+  quote: LimitOrderQuote
+  verified: boolean
 }
 
 export type LimitOrder = {

--- a/src/state/slices/tradeQuoteSlice/selectors.ts
+++ b/src/state/slices/tradeQuoteSlice/selectors.ts
@@ -555,6 +555,8 @@ type AffiliateFeesProps = {
   inputAmountUsd: string | undefined
 }
 
+// TODO: Move out of tradeQuoteSlice as this is used for limit orders also, and is not spot
+// specific
 export const selectCalculatedFees: Selector<ReduxState, CalculateFeeBpsReturn> =
   createCachedSelector(
     (_state: ReduxState, { feeModel }: AffiliateFeesProps) => feeModel,


### PR DESCRIPTION
## Description

Wires up the limit order quote query to the input and config UIs to display the result of the quote in the UI.

Includes:
- Wiring up estimated affiliate fee and fee modal
- Wiring up custom slippage
- Wiring up quoted market price to UI
- Resets limit orders config when assets change (i.e resets the rate, expiry and `%` input - not the input UI). Config is not reset when amounts or quote changes to avoid annoying users during polling (polling yet to be implemented)
- Adds loading state to limit orders input, config, and receive summary

Excludes the following which are coming in follow-ups:
- Submission of limit orders
- Error handling or display (will be done in https://github.com/shapeshift/web/issues/8109)
- Reset of amount and receive address state on asset change (will be done in https://github.com/shapeshift/web/issues/8109)

## Issue (if applicable)

<!-----------------------------------------------------------------------------
If applicable, please link to the github issue and put `closes #XXXX` in your comment to auto-close the issue that your PR fixes.
------------------------------------------------------------------------------>

closes #8033

## Risk

> High Risk PRs Require 2 approvals

Majority of the change is behind a feature flag and is low risk, but as this refactors trade UI (`ConfirmSummary` and `SlippagePopover`) this technically has to be marked as high risk.

> What protocols, transaction types, wallets or contract interactions might be affected by this PR?

- Trade quotes for all protocols
- Trade slippage input for all protocols

## Testing

Testing should be focused on regressions for trades:
- Custom slippage input is correctly applied to trades
- Summary of fees in `ConfirmSummary` is correct

### Engineering

<!-----------------------------------------------------------------------------
Include sufficient information here for an engineer to test your PR. This may include how to test locally, in a built environment, changes to infrastructure etc.
------------------------------------------------------------------------------>

### Operations

- [ ] :checkered_flag: My feature is behind a flag and doesn't require operations testing (yet)

<!-----------------------------------------------------------------------------
If your changes have a user-facing impact, describe how a non-technical QA team can functionally test your changes in a preview environment.

If they are not user-facing please describe how to test for any regressions that may occur.
------------------------------------------------------------------------------>

## Screenshots (if applicable)

https://jam.dev/c/18e12936-6779-4a97-a2f7-181406ab0098