### PR TITLE
fix: solana token sends to PDAs

### DIFF
--- a/packages/chain-adapters/src/solana/SolanaChainAdapter.ts
+++ b/packages/chain-adapters/src/solana/SolanaChainAdapter.ts
@@ -453,6 +453,7 @@ export class ChainAdapter implements IChainAdapter<KnownChainIds.SolanaMainnet> 
     const destinationTokenAccount = getAssociatedTokenAddressSync(
       new PublicKey(tokenId),
       new PublicKey(to),
+      true,
     )
 
     // check if destination token account exists and add creation instruction if it doesn't
@@ -477,7 +478,7 @@ export class ChainAdapter implements IChainAdapter<KnownChainIds.SolanaMainnet> 
 
     instructions.push(
       createTransferInstruction(
-        getAssociatedTokenAddressSync(new PublicKey(tokenId), new PublicKey(from)),
+        getAssociatedTokenAddressSync(new PublicKey(tokenId), new PublicKey(from), true),
         destinationTokenAccount,
         new PublicKey(from),
         Number(value),


### PR DESCRIPTION
## Description

Does what it says on the box - passes the [`allowOwnerOffCurve`](https://solana-labs.github.io/solana-program-library/token/js/functions/getAssociatedTokenAddressSync.html) param to `getAssociatedTokenAddressSync` so we don't throw anymore when sending to PDAs.

## Issue (if applicable)

<!-----------------------------------------------------------------------------
If applicable, please link to the github issue and put `closes #XXXX` in your comment to auto-close the issue that your PR fixes.
------------------------------------------------------------------------------>

closes https://github.com/shapeshift/web/issues/8124

## Risk

> High Risk PRs Require 2 approvals

<!-----------------------------------------------------------------------------
Outline the scope of your changes and the risk associated with them. You must use your discretion as an engineer to determine the potential impact of your changes.

WARNING: If your PR introduces a new on-chain transaction or modifies an existing one, please add the "High-Risk" label to this PR and ask for 2 reviewers to approve it before merging.

E.g. an upgrade to `hdwallet` or core state management would be considered higher risk, and might require a full regression test. UI or isolated view changes, or something behind a feature flag may have near zero risk. Small bug fixes might require testing isolated to the specific fix.
------------------------------------------------------------------------------>

> What protocols, transaction types, wallets or contract interactions might be affected by this PR?

None, this only passes an additional param to allow send to PDAs.

## Testing

<!-----------------------------------------------------------------------------
We treat every PR to be merged with the same scrutiny as if we were merging directly to production.

Your PR will not be merged if you do not complete the sections below for our engineering and operations teams to test.
------------------------------------------------------------------------------>

- Perform a solana send to `3sFA858AtM7ByJqtxSSgCDj8sr93cvBv3bLx97UFwT49` (PDA account)
- Ensure fees estimation is happy
- Ensure send is happy (note, Solana status detection is borked which is irrelevant to this PR, all we're concerned about is Solana popup popping up, and the Tx being broadcasted)

### Engineering

<!-----------------------------------------------------------------------------
Include sufficient information here for an engineer to test your PR. This may include how to test locally, in a built environment, changes to infrastructure etc.
------------------------------------------------------------------------------>

- ^

### Operations

- [ ] :checkered_flag: My feature is behind a flag and doesn't require operations testing (yet)

<!-----------------------------------------------------------------------------
If your changes have a user-facing impact, describe how a non-technical QA team can functionally test your changes in a preview environment.

If they are not user-facing please describe how to test for any regressions that may occur.
------------------------------------------------------------------------------>

- ^

## Screenshots (if applicable)

- prod/develop

<img width="1027" alt="Screenshot 2024-11-14 at 09 52 49" src="https://github.com/user-attachments/assets/481be557-e240-42f9-bada-849cf1dd09f0">


- this diff

<img width="1454" alt="Screenshot 2024-11-14 at 09 52 14" src="https://github.com/user-attachments/assets/aba5f265-2cde-409d-b3c0-20567c756a13">


<!-- av pr metadata
This information is embedded by the av CLI when creating PRs to track the status of stacks when using Aviator. Please do not delete or edit this section of the PR.
```
{"parent":"develop","parentHead":"","trunk":"develop"}
```
-->
