### PR TITLE
Fix Typo in Hook Testing Section Update testing.md

### DIFF
--- a/docs/testing.md
+++ b/docs/testing.md
@@ -62,7 +62,7 @@ describe('useIsComponentMounted hook', () => {
     expect(result.current.current).toBe(true)
   })
 
-  it('should false on unmount', () => {
+  it('should by false on unmount', () => {
     const { result, unmount } = setup()
     unmount()
     expect(result.current.current).toBe(false)


### PR DESCRIPTION
**Description:**  
This pull request corrects a minor but important typo in the "Hook Testing" section. Specifically, the test description:

```js
it('should false on unmount', () => {
```

has been updated to the correct form:

```js
it('should be false on unmount', () => {
```

**Importance of the Fix:**  
Correcting this typo enhances readability and clarity within the test suite, making it easier for developers to understand the purpose of the test. Descriptive accuracy in test names is crucial for maintenance and collaboration, especially in larger projects. Clear test names help convey the expected behavior and outcome, aiding in debugging and further development.

**Additional Context:**  
This is a minor but meaningful fix that will improve the codebase’s quality and usability.