### PR TITLE
fix: fox discount ux

### DIFF
--- a/src/components/FeeExplainer/FeeExplainer.tsx
+++ b/src/components/FeeExplainer/FeeExplainer.tsx
@@ -26,7 +26,7 @@ import { calculateFees } from 'lib/fees/model'
 import { FEE_CURVE_PARAMETERS, FEE_MODEL_TO_FEATURE_NAME } from 'lib/fees/parameters'
 import type { ParameterModel } from 'lib/fees/parameters/types'
 import { isSome } from 'lib/utils'
-import { selectVotingPower } from 'state/apis/snapshot/selectors'
+import { selectIsSnapshotApiQueriesPending, selectVotingPower } from 'state/apis/snapshot/selectors'
 import { useAppSelector } from 'state/store'
 
 import { CHART_TRADE_SIZE_MAX_USD } from './common'
@@ -356,6 +356,7 @@ export const FeeExplainer: React.FC<FeeExplainerProps> = ({ stackProps, ...props
   const { FEE_CURVE_NO_FEE_THRESHOLD_USD } = FEE_CURVE_PARAMETERS[props.feeModel]
   const votingPowerParams = useMemo(() => ({ feeModel: props.feeModel }), [props.feeModel])
   const votingPower = useAppSelector(state => selectVotingPower(state, votingPowerParams))
+  const isVotingPowerQueriesPending = useAppSelector(selectIsSnapshotApiQueriesPending)
 
   const [tradeSizeUSD, setTradeSizeUSD] = useState(
     props.inputAmountUsd ? Number.parseFloat(props.inputAmountUsd) : FEE_CURVE_NO_FEE_THRESHOLD_USD,
@@ -384,6 +385,7 @@ export const FeeExplainer: React.FC<FeeExplainerProps> = ({ stackProps, ...props
             setFoxHolding={setFoxHolding}
             currentFoxHoldings={votingPower ?? '0'}
             feeModel={props.feeModel}
+            isLoading={isVotingPowerQueriesPending}
           />
         </CardBody>
       </Card>

--- a/src/components/FeeExplainer/FeeExplainer.tsx
+++ b/src/components/FeeExplainer/FeeExplainer.tsx
@@ -246,16 +246,6 @@ const FeeChart: React.FC<FeeChartProps> = ({ foxHolding, tradeSize, feeModel }) 
   )
 }
 
-export type FeeSlidersProps = {
-  tradeSizeUSD: number
-  setTradeSizeUSD: (val: number) => void
-  foxHolding: number
-  setFoxHolding: (val: number) => void
-  currentFoxHoldings: string
-  isLoading?: boolean
-  feeModel: ParameterModel
-}
-
 type FeeOutputProps = {
   tradeSizeUSD: number
   foxHolding: number
@@ -381,9 +371,9 @@ export const FeeExplainer: React.FC<FeeExplainerProps> = ({ stackProps, ...props
           <FeeSliders
             tradeSizeUSD={tradeSizeUSD}
             setTradeSizeUSD={setTradeSizeUSD}
-            foxHolding={foxHolding}
-            setFoxHolding={setFoxHolding}
-            currentFoxHoldings={votingPower ?? '0'}
+            simulatedFoxHolding={foxHolding}
+            setSimulatedFoxHolding={setFoxHolding}
+            actualFoxHoldings={votingPower ?? '0'}
             feeModel={props.feeModel}
             isLoading={isVotingPowerQueriesPending}
           />

--- a/src/components/FeeExplainer/FeeSliders.tsx
+++ b/src/components/FeeExplainer/FeeSliders.tsx
@@ -87,6 +87,7 @@ export const FeeSliders: React.FC<FeeSlidersProps> = ({
 
   const handleSetSimulatedFoxHolding = useCallback(
     (values: NumberFormatValues) => {
+      setHasUserAdjustedFoxHolding(true)
       setSimulatedFoxHolding(bnOrZero(values.value).toNumber())
     },
     [setSimulatedFoxHolding],

--- a/src/components/FeeExplainer/FeeSliders.tsx
+++ b/src/components/FeeExplainer/FeeSliders.tsx
@@ -27,9 +27,9 @@ import {
   FEE_MODEL_TO_FEATURE_NAME,
   FEE_MODEL_TO_FEATURE_NAME_PLURAL,
 } from 'lib/fees/parameters'
+import type { ParameterModel } from 'lib/fees/parameters/types'
 
 import { CHART_TRADE_SIZE_MAX_FOX, CHART_TRADE_SIZE_MAX_USD, labelStyles } from './common'
-import type { FeeSlidersProps } from './FeeExplainer'
 
 const inputStyle = {
   input: {
@@ -38,29 +38,39 @@ const inputStyle = {
   },
 }
 
+export type FeeSlidersProps = {
+  tradeSizeUSD: number
+  setTradeSizeUSD: (val: number) => void
+  simulatedFoxHolding: number
+  setSimulatedFoxHolding: (val: number) => void
+  actualFoxHoldings: string
+  isLoading?: boolean
+  feeModel: ParameterModel
+}
+
 export const FeeSliders: React.FC<FeeSlidersProps> = ({
   tradeSizeUSD,
   setTradeSizeUSD,
-  foxHolding,
-  setFoxHolding,
+  simulatedFoxHolding,
+  setSimulatedFoxHolding,
   isLoading,
-  currentFoxHoldings,
+  actualFoxHoldings,
   feeModel,
 }) => {
   const [hasUserAdjustedFoxHolding, setHasUserAdjustedFoxHolding] = useState(false)
 
   useEffect(() => {
     if (!hasUserAdjustedFoxHolding) {
-      setFoxHolding(Number(currentFoxHoldings))
+      setSimulatedFoxHolding(Number(actualFoxHoldings))
     }
-  }, [currentFoxHoldings, setFoxHolding, hasUserAdjustedFoxHolding])
+  }, [actualFoxHoldings, setSimulatedFoxHolding, hasUserAdjustedFoxHolding])
 
   const handleSliderChange = useCallback(
     (value: number) => {
       setHasUserAdjustedFoxHolding(true)
-      setFoxHolding(value)
+      setSimulatedFoxHolding(value)
     },
-    [setFoxHolding],
+    [setSimulatedFoxHolding],
   )
 
   const { FEE_CURVE_NO_FEE_THRESHOLD_USD } = FEE_CURVE_PARAMETERS[feeModel]
@@ -75,11 +85,11 @@ export const FeeSliders: React.FC<FeeSlidersProps> = ({
     number: { toFiat, localeParts },
   } = useLocaleFormatter()
 
-  const handleSetFoxHolding = useCallback(
+  const handleSetSimulatedFoxHolding = useCallback(
     (values: NumberFormatValues) => {
-      setFoxHolding(bnOrZero(values.value).toNumber())
+      setSimulatedFoxHolding(bnOrZero(values.value).toNumber())
     },
-    [setFoxHolding],
+    [setSimulatedFoxHolding],
   )
 
   const handleSetTradeSizeUsd = useCallback(
@@ -104,8 +114,8 @@ export const FeeSliders: React.FC<FeeSlidersProps> = ({
                 suffix={' FOX'}
                 decimalSeparator={localeParts.decimal}
                 thousandSeparator={localeParts.group}
-                value={foxHolding}
-                onValueChange={handleSetFoxHolding}
+                value={simulatedFoxHolding}
+                onValueChange={handleSetSimulatedFoxHolding}
               />
             </Box>
           </Skeleton>
@@ -114,8 +124,8 @@ export const FeeSliders: React.FC<FeeSlidersProps> = ({
           <Slider
             min={0}
             max={CHART_TRADE_SIZE_MAX_FOX}
-            value={foxHolding}
-            defaultValue={Number(currentFoxHoldings)}
+            value={simulatedFoxHolding}
+            defaultValue={Number(actualFoxHoldings)}
             onChange={handleSliderChange}
             focusThumbOnChange={false}
           >
@@ -137,9 +147,9 @@ export const FeeSliders: React.FC<FeeSlidersProps> = ({
             </SliderMark>
             <SliderMark
               value={
-                bn(currentFoxHoldings).gt(CHART_TRADE_SIZE_MAX_FOX)
+                bn(actualFoxHoldings).gt(CHART_TRADE_SIZE_MAX_FOX)
                   ? CHART_TRADE_SIZE_MAX_FOX
-                  : Number(currentFoxHoldings)
+                  : Number(actualFoxHoldings)
               }
               top='-14px !important'
               color='yellow.500'
@@ -209,7 +219,7 @@ export const FeeSliders: React.FC<FeeSlidersProps> = ({
           </Flex>
           <Amount.Crypto
             fontWeight='bold'
-            value={currentFoxHoldings}
+            value={actualFoxHoldings}
             symbol='FOX'
             maximumFractionDigits={0}
           />

--- a/src/components/FeeExplainer/FeeSliders.tsx
+++ b/src/components/FeeExplainer/FeeSliders.tsx
@@ -13,7 +13,7 @@ import {
   Stack,
   VStack,
 } from '@chakra-ui/react'
-import { useCallback, useMemo } from 'react'
+import { useCallback, useEffect, useMemo, useState } from 'react'
 import type { NumberFormatValues } from 'react-number-format'
 import NumberFormat from 'react-number-format'
 import { useTranslate } from 'react-polyglot'
@@ -47,6 +47,22 @@ export const FeeSliders: React.FC<FeeSlidersProps> = ({
   currentFoxHoldings,
   feeModel,
 }) => {
+  const [hasUserAdjustedFoxHolding, setHasUserAdjustedFoxHolding] = useState(false)
+
+  useEffect(() => {
+    if (!hasUserAdjustedFoxHolding) {
+      setFoxHolding(Number(currentFoxHoldings))
+    }
+  }, [currentFoxHoldings, setFoxHolding, hasUserAdjustedFoxHolding])
+
+  const handleSliderChange = useCallback(
+    (value: number) => {
+      setHasUserAdjustedFoxHolding(true)
+      setFoxHolding(value)
+    },
+    [setFoxHolding],
+  )
+
   const { FEE_CURVE_NO_FEE_THRESHOLD_USD } = FEE_CURVE_PARAMETERS[feeModel]
   const translate = useTranslate()
   const feature = translate(FEE_MODEL_TO_FEATURE_NAME[feeModel])
@@ -78,7 +94,7 @@ export const FeeSliders: React.FC<FeeSlidersProps> = ({
       <Stack spacing={4} width='full'>
         <Flex width='full' justifyContent='space-between' alignItems='center' fontWeight='medium'>
           <Text translation='foxDiscounts.foxPower' />
-          <Skeleton isLoaded={!isLoading} width='35%'>
+          <Skeleton isLoaded={!isLoading || hasUserAdjustedFoxHolding} width='35%'>
             <Box sx={inputStyle}>
               <NumberFormat
                 decimalScale={2}
@@ -100,7 +116,7 @@ export const FeeSliders: React.FC<FeeSlidersProps> = ({
             max={CHART_TRADE_SIZE_MAX_FOX}
             value={foxHolding}
             defaultValue={Number(currentFoxHoldings)}
-            onChange={setFoxHolding}
+            onChange={handleSliderChange}
             focusThumbOnChange={false}
           >
             <SliderTrack>


### PR DESCRIPTION
## Description

On the `fox` route:

- Ensures the FOX power value updates as the value in the store updates
- Prevents the FOX power value from refreshing if the `FeeSliders` have already been interacted with (i.e. once you interact with it you're in override mode)
- Adds a loading skeleton on the amount input when the `selectIsSnapshotApiQueriesPending` selector returns `true`
- Improves the naming inside the component

## Issue (if applicable)

Closes https://github.com/shapeshift/web/issues/8123

## Risk

Small (UI changes only)

> What protocols, transaction types, wallets or contract interactions might be affected by this PR?

None

## Testing

- Whilst connect to a wallet with some FOX, load the `/fox` route with a fresh cache. The FOX Power value should have a loading skeleton whilst it is doing so. Once a value is fetched the value should be shown (instead of the previous, bug of showing 0).

<img width="759" alt="Screenshot 2024-11-18 at 07 49 05" src="https://github.com/user-attachments/assets/b0715f0f-b376-4bca-a5d0-03a98fa309f3">


### Engineering

☝️

### Operations

- [ ] :checkered_flag: My feature is behind a flag and doesn't require operations testing (yet)

☝️

## Screenshots (if applicable)

See testing step.