### PR TITLE
Typo Update testing.md

### DIFF
--- a/docs/testing.md
+++ b/docs/testing.md
@@ -62,7 +62,7 @@ describe('useIsComponentMounted hook', () => {
     expect(result.current.current).toBe(true)
   })
 
-  it('should false on unmount', () => {
+  it('should be false on unmount', () => {
     const { result, unmount } = setup()
     unmount()
     expect(result.current.current).toBe(false)


### PR DESCRIPTION
## Description

This pull request addresses a typographical error in the **Hook Testing** section of the documentation, which affects the readability and clarity of the test description.

#### Fixed Issue:

- In the **Hook Testing** section, the test description **"it('should false on unmount', () => {...})"** has been corrected to **"it('should be false on unmount', () => {...})"**.
- **Importance**: The missing word **"be"** made the sentence grammatically incorrect, which could potentially cause confusion for readers and developers reviewing the test. Adding the word "be" ensures the sentence is grammatically correct and clear, improving the documentation's overall quality and readability.

Please review and consider merging this fix. Thank you!


