### PR TITLE
fix: unknown gas should be reflected at confirm screen time too

### DIFF
--- a/src/components/MultiHopTrade/components/MultiHopTradeConfirm/components/Footer.tsx
+++ b/src/components/MultiHopTrade/components/MultiHopTradeConfirm/components/Footer.tsx
@@ -21,7 +21,7 @@ import {
   selectConfirmedTradeExecutionState,
   selectLastHopBuyAsset,
   selectQuoteSellAmountUserCurrency,
-  selectTotalNetworkFeeUserCurrencyPrecision,
+  selectTotalNetworkFeeUserCurrency,
 } from 'state/slices/tradeQuoteSlice/selectors'
 import { TradeExecutionState } from 'state/slices/tradeQuoteSlice/types'
 import { useAppSelector } from 'state/store'
@@ -36,7 +36,7 @@ export const Footer: FC<FooterProps> = ({ isLoading, handleSubmit }) => {
   const swapperName = useAppSelector(selectActiveSwapperName)
   const lastHopBuyAsset = useAppSelector(selectLastHopBuyAsset)
   const confirmedTradeExecutionState = useAppSelector(selectConfirmedTradeExecutionState)
-  const networkFeeUserCurrency = useAppSelector(selectTotalNetworkFeeUserCurrencyPrecision)
+  const networkFeeUserCurrency = useAppSelector(selectTotalNetworkFeeUserCurrency)
   const sellAmountBeforeFeesUserCurrency = useAppSelector(selectQuoteSellAmountUserCurrency)
 
   const networkFeeToTradeRatioPercentage = useMemo(

--- a/src/components/MultiHopTrade/components/MultiHopTradeConfirm/components/Hop.tsx
+++ b/src/components/MultiHopTrade/components/MultiHopTradeConfirm/components/Hop.tsx
@@ -27,14 +27,14 @@ import { Amount } from 'components/Amount/Amount'
 import { CircularProgress } from 'components/CircularProgress/CircularProgress'
 import { ProtocolIcon } from 'components/Icons/Protocol'
 import { SlippageIcon } from 'components/Icons/Slippage'
-import { RawText } from 'components/Text'
+import { RawText, Text } from 'components/Text'
 import { useLocaleFormatter } from 'hooks/useLocaleFormatter/useLocaleFormatter'
 import { fromBaseUnit } from 'lib/math'
 import { assertUnreachable } from 'lib/utils'
 import {
   selectActiveQuote,
   selectHopExecutionMetadata,
-  selectHopNetworkFeeUserCurrencyPrecision,
+  selectHopNetworkFeeUserCurrency,
   selectHopTotalProtocolFeesFiatPrecision,
   selectIsActiveQuoteMultiHop,
 } from 'state/slices/tradeQuoteSlice/selectors'
@@ -75,13 +75,13 @@ export const Hop = ({
     number: { toCrypto },
   } = useLocaleFormatter()
   const translate = useTranslate()
-  const hopTotalProtocolFeesFiatPrecisionFilter = useMemo(() => {
+  const hopTotalProtocolFeesFiatUserCurrencyFilter = useMemo(() => {
     return {
       hopIndex,
     }
   }, [hopIndex])
-  const networkFeeFiatPrecision = useAppSelector(state =>
-    selectHopNetworkFeeUserCurrencyPrecision(state, hopTotalProtocolFeesFiatPrecisionFilter),
+  const networkFeeFiatUserCurrency = useAppSelector(state =>
+    selectHopNetworkFeeUserCurrency(state, hopTotalProtocolFeesFiatUserCurrencyFilter),
   )
   const protocolFeeFiatPrecision = useAppSelector(state =>
     selectHopTotalProtocolFeesFiatPrecision(state, hopIndex),
@@ -298,7 +298,13 @@ export const Hop = ({
               <Flex color='text.subtle'>
                 <FaGasPump />
               </Flex>
-              <Amount.Fiat value={networkFeeFiatPrecision ?? '0'} display='inline' />
+              {!networkFeeFiatUserCurrency ? (
+                <Tooltip label={translate('trade.tooltip.continueSwapping')}>
+                  <Text translation={'trade.unknownGas'} fontSize='sm' />
+                </Tooltip>
+              ) : (
+                <Amount.Fiat value={networkFeeFiatUserCurrency} display='inline' />
+              )}
             </Flex>
           </Tooltip>
 

--- a/src/components/MultiHopTrade/components/TradeInput/components/ConfirmSummary.tsx
+++ b/src/components/MultiHopTrade/components/TradeInput/components/ConfirmSummary.tsx
@@ -40,7 +40,7 @@ import {
   selectIsAnySwapperQuoteAvailable,
   selectIsAnyTradeQuoteLoading,
   selectShouldShowTradeQuoteOrAwaitInput,
-  selectTotalNetworkFeeUserCurrencyPrecision,
+  selectTotalNetworkFeeUserCurrency,
   selectTotalProtocolFeeByAsset,
   selectTradeQuoteAffiliateFeeAfterDiscountUserCurrency,
   selectTradeQuoteRequestErrors,
@@ -82,7 +82,7 @@ export const ConfirmSummary = ({
   } = useWallet()
 
   const buyAmountAfterFeesCryptoPrecision = useAppSelector(selectBuyAmountAfterFeesCryptoPrecision)
-  const totalNetworkFeeFiatPrecision = useAppSelector(selectTotalNetworkFeeUserCurrencyPrecision)
+  const totalNetworkFeeFiatPrecision = useAppSelector(selectTotalNetworkFeeUserCurrency)
   const isManualReceiveAddressValidating = useAppSelector(selectIsManualReceiveAddressValidating)
   const isManualReceiveAddressEditing = useAppSelector(selectIsManualReceiveAddressEditing)
   const isManualReceiveAddressValid = useAppSelector(selectIsManualReceiveAddressValid)

--- a/src/state/slices/tradeQuoteSlice/helpers.ts
+++ b/src/state/slices/tradeQuoteSlice/helpers.ts
@@ -12,7 +12,7 @@ import { sumProtocolFeesToDenom } from 'state/slices/tradeQuoteSlice/utils'
 
 import type { ActiveQuoteMeta } from './types'
 
-export const getHopTotalNetworkFeeUserCurrencyPrecision = (
+export const getHopTotalNetworkFeeUserCurrency = (
   networkFeeCryptoBaseUnit: string | undefined,
   feeAsset: Asset,
   getFeeAssetUserCurrencyRate: (feeAssetId: AssetId) => string,
@@ -45,7 +45,7 @@ export const getTotalNetworkFeeUserCurrencyPrecision = (
 
   return quote.steps.reduce((acc, step) => {
     const feeAsset = getFeeAsset(step.sellAsset.assetId)
-    const networkFeeFiatPrecision = getHopTotalNetworkFeeUserCurrencyPrecision(
+    const networkFeeFiatPrecision = getHopTotalNetworkFeeUserCurrency(
       step.feeData.networkFeeCryptoBaseUnit,
       feeAsset,
       getFeeAssetRate,

--- a/src/state/slices/tradeQuoteSlice/selectors.ts
+++ b/src/state/slices/tradeQuoteSlice/selectors.ts
@@ -41,7 +41,7 @@ import {
 import {
   getActiveQuoteMetaOrDefault,
   getBuyAmountAfterFeesCryptoPrecision,
-  getHopTotalNetworkFeeUserCurrencyPrecision,
+  getHopTotalNetworkFeeUserCurrency,
   getHopTotalProtocolFeesFiatPrecision,
   getTotalProtocolFeeByAsset,
   sortTradeQuotes,
@@ -393,81 +393,75 @@ export const selectSecondHopNetworkFeeCryptoBaseUnit: Selector<ReduxState, strin
 export const selectLastHopNetworkFeeCryptoBaseUnit: Selector<ReduxState, string | undefined> =
   createSelector(selectLastHop, lastHop => lastHop?.feeData.networkFeeCryptoBaseUnit)
 
-export const selectFirstHopNetworkFeeUserCurrencyPrecision: Selector<
-  ReduxState,
-  string | undefined
-> = createSelector(
-  selectFirstHop,
-  selectFirstHopSellFeeAsset,
-  selectMarketDataUserCurrency,
-  (tradeQuoteStep, feeAsset, marketData) => {
-    if (!tradeQuoteStep) return
-
-    if (feeAsset === undefined) {
-      throw Error(`missing fee asset for assetId ${tradeQuoteStep.sellAsset.assetId}`)
-    }
-
-    const getFeeAssetUserCurrencyRate = () => {
-      return marketData[feeAsset?.assetId ?? '']?.price ?? '0'
-    }
-
-    return getHopTotalNetworkFeeUserCurrencyPrecision(
-      tradeQuoteStep.feeData.networkFeeCryptoBaseUnit,
-      feeAsset,
-      getFeeAssetUserCurrencyRate,
-    )?.toString()
-  },
-)
-
-export const selectSecondHopNetworkFeeUserCurrencyPrecision: Selector<
-  ReduxState,
-  string | undefined
-> = createSelector(
-  selectSecondHop,
-  selectSecondHopSellFeeAsset,
-  selectMarketDataUserCurrency,
-  (tradeQuoteStep, feeAsset, marketData) => {
-    if (!tradeQuoteStep) return
-
-    if (feeAsset === undefined) {
-      throw Error(`missing fee asset for assetId ${tradeQuoteStep.sellAsset.assetId}`)
-    }
-    const getFeeAssetUserCurrencyRate = () => {
-      return marketData[feeAsset?.assetId ?? '']?.price ?? '0'
-    }
-
-    return getHopTotalNetworkFeeUserCurrencyPrecision(
-      tradeQuoteStep.feeData.networkFeeCryptoBaseUnit,
-      feeAsset,
-      getFeeAssetUserCurrencyRate,
-    )?.toString()
-  },
-)
-
-export const selectHopNetworkFeeUserCurrencyPrecision = createDeepEqualOutputSelector(
-  selectFirstHopNetworkFeeUserCurrencyPrecision,
-  selectSecondHopNetworkFeeUserCurrencyPrecision,
-  selectHopIndexParamFromRequiredFilter,
-  (firstHopNetworkFeeUserCurrencyPrecision, secondHopNetworkFeeUserCurrencyPrecision, hopIndex) => {
-    return hopIndex === 0
-      ? firstHopNetworkFeeUserCurrencyPrecision
-      : secondHopNetworkFeeUserCurrencyPrecision
-  },
-)
-
-export const selectTotalNetworkFeeUserCurrencyPrecision: Selector<ReduxState, string | undefined> =
+export const selectFirstHopNetworkFeeUserCurrency: Selector<ReduxState, string | undefined> =
   createSelector(
-    selectFirstHopNetworkFeeUserCurrencyPrecision,
-    selectSecondHopNetworkFeeUserCurrencyPrecision,
-    (firstHopNetworkFeeUserCurrencyPrecision, secondHopNetworkFeeUserCurrencyPrecision) => {
+    selectFirstHop,
+    selectFirstHopSellFeeAsset,
+    selectMarketDataUserCurrency,
+    (tradeQuoteStep, feeAsset, marketData) => {
+      if (!tradeQuoteStep) return
+
+      if (feeAsset === undefined) {
+        throw Error(`missing fee asset for assetId ${tradeQuoteStep.sellAsset.assetId}`)
+      }
+
+      const getFeeAssetUserCurrencyRate = () => {
+        return marketData[feeAsset?.assetId ?? '']?.price ?? '0'
+      }
+
+      return getHopTotalNetworkFeeUserCurrency(
+        tradeQuoteStep.feeData.networkFeeCryptoBaseUnit,
+        feeAsset,
+        getFeeAssetUserCurrencyRate,
+      )?.toString()
+    },
+  )
+
+export const selectSecondHopNetworkFeeUserCurrency: Selector<ReduxState, string | undefined> =
+  createSelector(
+    selectSecondHop,
+    selectSecondHopSellFeeAsset,
+    selectMarketDataUserCurrency,
+    (tradeQuoteStep, feeAsset, marketData) => {
+      if (!tradeQuoteStep) return
+
+      if (feeAsset === undefined) {
+        throw Error(`missing fee asset for assetId ${tradeQuoteStep.sellAsset.assetId}`)
+      }
+      const getFeeAssetUserCurrencyRate = () => {
+        return marketData[feeAsset?.assetId ?? '']?.price ?? '0'
+      }
+
+      return getHopTotalNetworkFeeUserCurrency(
+        tradeQuoteStep.feeData.networkFeeCryptoBaseUnit,
+        feeAsset,
+        getFeeAssetUserCurrencyRate,
+      )?.toString()
+    },
+  )
+
+export const selectHopNetworkFeeUserCurrency = createDeepEqualOutputSelector(
+  selectFirstHopNetworkFeeUserCurrency,
+  selectSecondHopNetworkFeeUserCurrency,
+  selectHopIndexParamFromRequiredFilter,
+  (firstHopNetworkFeeUserCurrency, secondHopNetworkFeeUserCurrency, hopIndex) => {
+    return hopIndex === 0 ? firstHopNetworkFeeUserCurrency : secondHopNetworkFeeUserCurrency
+  },
+)
+
+export const selectTotalNetworkFeeUserCurrency: Selector<ReduxState, string | undefined> =
+  createSelector(
+    selectFirstHopNetworkFeeUserCurrency,
+    selectSecondHopNetworkFeeUserCurrency,
+    (firstHopNetworkFeeUserCurrency, secondHopNetworkFeeUserCurrency) => {
       if (
-        firstHopNetworkFeeUserCurrencyPrecision === undefined &&
-        secondHopNetworkFeeUserCurrencyPrecision === undefined
+        firstHopNetworkFeeUserCurrency === undefined &&
+        secondHopNetworkFeeUserCurrency === undefined
       )
         return
 
-      return bnOrZero(firstHopNetworkFeeUserCurrencyPrecision)
-        .plus(secondHopNetworkFeeUserCurrencyPrecision ?? 0)
+      return bnOrZero(firstHopNetworkFeeUserCurrency)
+        .plus(secondHopNetworkFeeUserCurrency ?? 0)
         .toString()
     },
   )


### PR DESCRIPTION
## Description

Spotted by @purelycrickets in https://discord.com/channels/554694662431178782/1308774923317022752/1308950457963515945

> [Nitpick] Unknown gas turns to 0.00 gas after you select confirm details

Indeed, we were only doing the `(unknown)` gas when network fee is undefined dance at input time, not at "secondary screen" (a.k.a confirm) time. This PR fixes it.

## Issue (if applicable)

<!-----------------------------------------------------------------------------
If applicable, please link to the github issue and put `closes #XXXX` in your comment to auto-close the issue that your PR fixes.
------------------------------------------------------------------------------>

closes N/A, spotted in and targeted to release

## Risk

> High Risk PRs Require 2 approvals

<!-----------------------------------------------------------------------------
Outline the scope of your changes and the risk associated with them. You must use your discretion as an engineer to determine the potential impact of your changes.

WARNING: If your PR introduces a new on-chain transaction or modifies an existing one, please add the "High-Risk" label to this PR and ask for 2 reviewers to approve it before merging.

E.g. an upgrade to `hdwallet` or core state management would be considered higher risk, and might require a full regression test. UI or isolated view changes, or something behind a feature flag may have near zero risk. Small bug fixes might require testing isolated to the specific fix.
------------------------------------------------------------------------------>

None

> What protocols, transaction types, wallets or contract interactions might be affected by this PR?

## Testing

<!-----------------------------------------------------------------------------
We treat every PR to be merged with the same scrutiny as if we were merging directly to production.

Your PR will not be merged if you do not complete the sections below for our engineering and operations teams to test.
------------------------------------------------------------------------------>

- Select a route for which gas is unknown e.g Portals or THOR
- Ensure it is `(unknown)` both at input and confirm time

### Engineering

<!-----------------------------------------------------------------------------
Include sufficient information here for an engineer to test your PR. This may include how to test locally, in a built environment, changes to infrastructure etc.
------------------------------------------------------------------------------>


### Operations

- [ ] :checkered_flag: My feature is behind a flag and doesn't require operations testing (yet)

<!-----------------------------------------------------------------------------
If your changes have a user-facing impact, describe how a non-technical QA team can functionally test your changes in a preview environment.

If they are not user-facing please describe how to test for any regressions that may occur.
------------------------------------------------------------------------------>

## Screenshots (if applicable)

- release

<img width="525" alt="Screenshot 2024-11-21 at 17 53 16" src="https://github.com/user-attachments/assets/79d0915c-ca10-48cd-8cf3-1c5907687f62">


- this diff

<img width="516" alt="Screenshot 2024-11-21 at 18 01 16" src="https://github.com/user-attachments/assets/85474e31-2f34-4622-b273-a4f2bdf568d1">
