### PR TITLE
fix: use fee asset for dust amount conversion

### DIFF
--- a/src/features/defi/providers/thorchain-savers/components/ThorchainSaversManager/Withdraw/components/Confirm.tsx
+++ b/src/features/defi/providers/thorchain-savers/components/ThorchainSaversManager/Withdraw/components/Confirm.tsx
@@ -221,9 +221,7 @@ export const Confirm: React.FC<ConfirmProps> = ({ accountId, onNext }) => {
           toBaseUnit(fromThorBaseUnit(protocolFeeCryptoThorBaseUnit), asset.precision),
         )
         setDustAmountCryptoBaseUnit(
-          bnOrZero(toBaseUnit(fromThorBaseUnit(dust_amount), asset.precision)).toFixed(
-            asset.precision,
-          ),
+          bnOrZero(toBaseUnit(fromThorBaseUnit(dust_amount), feeAsset.precision)).toFixed(),
         )
         const percentage = bnOrZero(slippage_bps).div(BASE_BPS_POINTS).times(100)
         // total downside (slippage going into position) - 0.007 ETH for 5 ETH deposit
@@ -241,6 +239,7 @@ export const Confirm: React.FC<ConfirmProps> = ({ accountId, onNext }) => {
     accountId,
     asset,
     dustAmountCryptoBaseUnit,
+    feeAsset,
     opportunity?.apy,
     opportunityData?.rewardsCryptoBaseUnit,
     opportunityData?.stakedAmountCryptoBaseUnit,

--- a/src/lib/utils/thorchain/balance.ts
+++ b/src/lib/utils/thorchain/balance.ts
@@ -139,13 +139,19 @@ export const fetchHasEnoughBalanceForTxPlusFeesPlusSweep = async ({
         throw new Error('Invalid type')
     }
   })()
+
   const amountCryptoPrecision =
     type === 'deposit'
       ? _amountCryptoPrecision
       : fromThorBaseUnit(
           (quote as ThorchainSaversWithdrawQuoteResponseSuccess).dust_amount,
         ).toFixed()
-  const amountCryptoBaseUnit = toBaseUnit(amountCryptoPrecision, asset.precision)
+
+  const amountCryptoBaseUnit = toBaseUnit(
+    amountCryptoPrecision,
+    type === 'deposit' ? asset.precision : feeAsset?.precision ?? 0,
+  )
+
   const estimatedFeesQueryArgs = {
     estimateFeesInput: {
       amountCryptoPrecision,


### PR DESCRIPTION
## Description

Use `feeAsset` to convert dust amount to ensure the correct amount of dust sent for savers withdrawal transactions.

## Issue (if applicable)

<!-----------------------------------------------------------------------------
If applicable, please link to the github issue and put `closes #XXXX` in your comment to auto-close the issue that your PR fixes.
------------------------------------------------------------------------------>

https://discord.com/channels/554694662431178782/886041582422356018/1309237779984551997

## Risk

> High Risk PRs Require 2 approvals

<!-----------------------------------------------------------------------------
Outline the scope of your changes and the risk associated with them. You must use your discretion as an engineer to determine the potential impact of your changes.

WARNING: If your PR introduces a new on-chain transaction or modifies an existing one, please add the "High-Risk" label to this PR and ask for 2 reviewers to approve it before merging.

E.g. an upgrade to `hdwallet` or core state management would be considered higher risk, and might require a full regression test. UI or isolated view changes, or something behind a feature flag may have near zero risk. Small bug fixes might require testing isolated to the specific fix.
------------------------------------------------------------------------------>

Low - savers withdrawals should succeed again (usdc/usdt)

> What protocols, transaction types, wallets or contract interactions might be affected by this PR?

## Testing

<!-----------------------------------------------------------------------------
We treat every PR to be merged with the same scrutiny as if we were merging directly to production.

Your PR will not be merged if you do not complete the sections below for our engineering and operations teams to test.
------------------------------------------------------------------------------>

- Ensure you can withdraw usdc and usdt positions on ethereum
- Ensure the correct dust amount fee is displayed to the user

### Engineering

<!-----------------------------------------------------------------------------
Include sufficient information here for an engineer to test your PR. This may include how to test locally, in a built environment, changes to infrastructure etc.
------------------------------------------------------------------------------>

:point_up:

### Operations

- [ ] :checkered_flag: My feature is behind a flag and doesn't require operations testing (yet)

<!-----------------------------------------------------------------------------
If your changes have a user-facing impact, describe how a non-technical QA team can functionally test your changes in a preview environment.

If they are not user-facing please describe how to test for any regressions that may occur.
------------------------------------------------------------------------------>

:point_up:

## Screenshots (if applicable)
![image](https://github.com/user-attachments/assets/de4d0731-b5a8-4531-9070-b2fb6b9e8df3)
![image](https://github.com/user-attachments/assets/212bccaf-7e70-4ea4-9742-c8ef418fd6ca)
![image](https://github.com/user-attachments/assets/c4cf7aff-540c-46ac-9f66-84983c296ab4)
![image](https://github.com/user-attachments/assets/cf3884bd-f271-4e0d-9e57-cafef541f878)

https://etherscan.io/tx/0x3b9976d9770edd28de241588cfb0f1af258b5c9c8fcb284261664fcc187ea56b
https://viewblock.io/thorchain/tx/3b9976d9770edd28de241588cfb0f1af258b5c9c8fcb284261664fcc187ea56b
https://indexer.thorchain.shapeshift.com/v2/actions?txid=3b9976d9770edd28de241588cfb0f1af258b5c9c8fcb284261664fcc187ea56b