### PR TITLE
feat: fetch and render limit orders list

### DIFF
--- a/packages/swapper/src/swappers/CowSwapper/utils/helpers/helpers.ts
+++ b/packages/swapper/src/swappers/CowSwapper/utils/helpers/helpers.ts
@@ -1,6 +1,6 @@
 import type { LatestAppDataDocVersion } from '@cowprotocol/app-data'
 import { MetadataApi, stringifyDeterministic } from '@cowprotocol/app-data'
-import type { OrderClass, OrderClass1 } from '@cowprotocol/app-data/dist/generatedTypes/v0.9.0'
+import type { OrderClass, OrderClass1 } from '@cowprotocol/app-data/dist/generatedTypes/v1.3.0'
 import type { ChainId } from '@shapeshiftoss/caip'
 import { fromAssetId } from '@shapeshiftoss/caip'
 import type { Asset } from '@shapeshiftoss/types'

--- a/packages/types/src/cowSwap.ts
+++ b/packages/types/src/cowSwap.ts
@@ -163,7 +163,11 @@ export type OrderMetaData = {
   fullAppData?: string | null
 }
 
-export type Order = OrderCreation & OrderMetaData
+export type Order = OrderCreation &
+  OrderMetaData & {
+    // Not documented in API docs, but exists.
+    status: OrderStatus
+  }
 
 export type OrderParameters = {
   sellToken: Address
@@ -285,10 +289,4 @@ export type Trade = {
   buyAmount: string
   txHash: string | null
   executedProtocolFees?: ExecutedProtocolFee[]
-}
-
-export type GetOrdersRequest = {
-  owner: Address
-  offset?: number
-  limit?: number
 }

--- a/src/assets/translations/en/main.json
+++ b/src/assets/translations/en/main.json
@@ -1065,7 +1065,8 @@
       "cancelled": "Cancelled",
       "expired": "Expired"
     },
-    "orders": "Orders"
+    "orders": "Orders",
+    "loadingOrderList": "Loading your limit orders..."
   },
   "modals": {
     "assetSearch": {

--- a/src/assets/translations/en/main.json
+++ b/src/assets/translations/en/main.json
@@ -1040,6 +1040,8 @@
     "youGet": "You Get",
     "whenPriceReaches": "When price reaches",
     "expiry": "Expiry",
+    "noOpenOrders": "No open orders yet.",
+    "noHistoricalOrders": "No historical orders yet.",
     "expiryOption": {
       "oneHour": "1 hour",
       "oneDay": "1 day",
@@ -1053,7 +1055,17 @@
       "insufficientValidTo": "Order expiry too soon",
       "excessiveValidTo": "Order expiry too far into the future",
       "insufficientLiquidity": "Insufficient liquidity"
-    }
+    },
+    "expiresIn": "Expires In",
+    "openOrders": "Open Orders",
+    "orderHistory": "Order History",
+    "status": {
+      "open": "Open",
+      "fulfilled": "Fulfilled",
+      "cancelled": "Cancelled",
+      "expired": "Expired"
+    },
+    "orders": "Orders"
   },
   "modals": {
     "assetSearch": {
@@ -2722,21 +2734,6 @@
       "noActiveProposals": "No active proposals available",
       "noClosedProposals": "No closed proposals available"
     }
-  },
-  "limitOrders": {
-    "listTitle": "Limit Orders",
-    "limitPrice": "Limit Price",
-    "expiresIn": "Expires In",
-    "filled": "Filled",
-    "openOrders": "Open Orders",
-    "orderHistory": "Order History",
-    "status": {
-      "open": "Open",
-      "filled": "Filled",
-      "cancelled": "Cancelled",
-      "expired": "Expired"
-    },
-    "orders": "Orders"
   },
   "thorFees": {
     "title": "Here from THORSwap?",

--- a/src/components/MultiHopTrade/components/LimitOrder/LimitOrder.tsx
+++ b/src/components/MultiHopTrade/components/LimitOrder/LimitOrder.tsx
@@ -6,8 +6,8 @@ import type { TradeInputTab } from 'components/MultiHopTrade/types'
 import { SlideTransitionRoute } from '../SlideTransitionRoute'
 import { LimitOrderConfirm } from './components/LimitOrderConfirm'
 import { LimitOrderInput } from './components/LimitOrderInput'
-import { PlaceLimitOrder } from './components/PlaceLimitOrder'
 import { LimitOrderList } from './components/LimitOrderList'
+import { PlaceLimitOrder } from './components/PlaceLimitOrder'
 import { LimitOrderRoutePaths } from './types'
 
 const LimitOrderRouteEntries = [

--- a/src/components/MultiHopTrade/components/LimitOrder/LimitOrder.tsx
+++ b/src/components/MultiHopTrade/components/LimitOrder/LimitOrder.tsx
@@ -7,7 +7,7 @@ import { SlideTransitionRoute } from '../SlideTransitionRoute'
 import { LimitOrderConfirm } from './components/LimitOrderConfirm'
 import { LimitOrderInput } from './components/LimitOrderInput'
 import { PlaceLimitOrder } from './components/PlaceLimitOrder'
-import { LimitOrderList } from './LimitOrderList'
+import { LimitOrderList } from './components/LimitOrderList'
 import { LimitOrderRoutePaths } from './types'
 
 const LimitOrderRouteEntries = [

--- a/src/components/MultiHopTrade/components/LimitOrder/components/CollapsibleLimitOrderList.tsx
+++ b/src/components/MultiHopTrade/components/LimitOrder/components/CollapsibleLimitOrderList.tsx
@@ -2,7 +2,7 @@ import type { CardProps } from '@chakra-ui/react'
 import { useMemo } from 'react'
 
 import { HorizontalCollapse } from '../../TradeInput/components/HorizontalCollapse'
-import { LimitOrderList } from '../LimitOrderList'
+import { LimitOrderList } from './LimitOrderList'
 
 export type CollapsibleLimitOrderListProps = {
   isOpen: boolean

--- a/src/components/MultiHopTrade/components/LimitOrder/components/LimitOrderCard.tsx
+++ b/src/components/MultiHopTrade/components/LimitOrder/components/LimitOrderCard.tsx
@@ -1,5 +1,8 @@
 import { Box, Button, Center, Flex, Progress, Tag } from '@chakra-ui/react'
 import type { AssetId } from '@shapeshiftoss/caip'
+import { OrderStatus } from '@shapeshiftoss/types/dist/cowSwap'
+import { bn, fromBaseUnit } from '@shapeshiftoss/utils'
+import { formatDistanceToNow } from 'date-fns'
 import type { FC } from 'react'
 import { useCallback, useMemo } from 'react'
 import { useTranslate } from 'react-polyglot'
@@ -9,9 +12,6 @@ import { SwapBoldIcon } from 'components/Icons/SwapBold'
 import { RawText, Text } from 'components/Text'
 import { selectAssetById } from 'state/slices/selectors'
 import { useAppSelector } from 'state/store'
-import { OrderStatus } from '@shapeshiftoss/types/dist/cowSwap'
-import { bn, fromBaseUnit } from '@shapeshiftoss/utils'
-import {formatDistanceToNow} from 'date-fns'
 
 export interface LimitOrderCardProps {
   id: string

--- a/src/components/MultiHopTrade/components/LimitOrder/components/LimitOrderCard.tsx
+++ b/src/components/MultiHopTrade/components/LimitOrder/components/LimitOrderCard.tsx
@@ -9,18 +9,19 @@ import { SwapBoldIcon } from 'components/Icons/SwapBold'
 import { RawText, Text } from 'components/Text'
 import { selectAssetById } from 'state/slices/selectors'
 import { useAppSelector } from 'state/store'
-
-import { LimitOrderStatus } from '../types'
+import { OrderStatus } from '@shapeshiftoss/types/dist/cowSwap'
+import { bn, fromBaseUnit } from '@shapeshiftoss/utils'
+import {formatDistanceToNow} from 'date-fns'
 
 export interface LimitOrderCardProps {
   id: string
-  buyAmount: number
-  sellAmount: number
+  buyAmountCryptoBaseUnit: string
+  sellAmountCryptoBaseUnit: string
   buyAssetId: AssetId
   sellAssetId: AssetId
-  expiry: number
+  validTo?: number
   filledDecimalPercentage: number
-  status: LimitOrderStatus
+  status: OrderStatus
 }
 
 const buttonBgHover = {
@@ -29,11 +30,11 @@ const buttonBgHover = {
 
 export const LimitOrderCard: FC<LimitOrderCardProps> = ({
   id,
-  buyAmount,
-  sellAmount,
+  buyAmountCryptoBaseUnit,
+  sellAmountCryptoBaseUnit,
   buyAssetId,
   sellAssetId,
-  expiry,
+  validTo,
   filledDecimalPercentage,
   status,
 }) => {
@@ -47,17 +48,30 @@ export const LimitOrderCard: FC<LimitOrderCardProps> = ({
   }, [id])
 
   const formattedPercentage = (filledDecimalPercentage * 100).toFixed(2)
-  const limitPrice = (buyAmount / sellAmount).toFixed(6)
+
+  const sellAmountCryptoPrecision = useMemo(
+    () => fromBaseUnit(sellAmountCryptoBaseUnit, sellAsset?.precision ?? 0),
+    [sellAmountCryptoBaseUnit, sellAsset?.precision],
+  )
+
+  const buyAmountCryptoPrecision = useMemo(
+    () => fromBaseUnit(buyAmountCryptoBaseUnit, buyAsset?.precision ?? 0),
+    [buyAmountCryptoBaseUnit, buyAsset?.precision],
+  )
+
+  const limitPrice = useMemo(() => {
+    return bn(buyAmountCryptoPrecision).div(sellAmountCryptoPrecision).toString()
+  }, [buyAmountCryptoPrecision, sellAmountCryptoPrecision])
 
   const tagColorScheme = useMemo(() => {
     switch (status) {
-      case LimitOrderStatus.Open:
+      case OrderStatus.OPEN:
         return 'blue'
-      case LimitOrderStatus.Filled:
+      case OrderStatus.FULFILLED:
         return 'green'
-      case LimitOrderStatus.Cancelled:
+      case OrderStatus.CANCELLED:
         return 'red'
-      case LimitOrderStatus.Expired:
+      case OrderStatus.EXPIRED:
         return 'yellow'
       default:
         return 'gray'
@@ -66,17 +80,27 @@ export const LimitOrderCard: FC<LimitOrderCardProps> = ({
 
   const barColorScheme = useMemo(() => {
     switch (status) {
-      case LimitOrderStatus.Open:
-      case LimitOrderStatus.Filled:
+      case OrderStatus.OPEN:
+      case OrderStatus.FULFILLED:
         return 'green'
-      case LimitOrderStatus.Cancelled:
+      case OrderStatus.CANCELLED:
         return 'red'
-      case LimitOrderStatus.Expired:
+      case OrderStatus.EXPIRED:
         return 'yellow'
       default:
         return 'gray'
     }
   }, [status])
+
+  const expiryText = useMemo(
+    () =>
+      validTo
+        ? formatDistanceToNow(validTo * 1000, {
+            addSuffix: true,
+          })
+        : undefined,
+    [validTo],
+  )
 
   if (!buyAsset || !sellAsset) return null
 
@@ -101,35 +125,41 @@ export const LimitOrderCard: FC<LimitOrderCardProps> = ({
             </AssetIconWithBadge>
             <Flex direction='column' align='flex-start' ml={4}>
               <Amount.Crypto
-                value={sellAmount.toString()}
+                value={sellAmountCryptoPrecision}
                 symbol={sellAsset.symbol}
                 color='gray.500'
                 fontSize='xl'
               />
-              <Amount.Crypto value={buyAmount.toString()} symbol={buyAsset.symbol} fontSize='xl' />
+              <Amount.Crypto
+                value={buyAmountCryptoPrecision}
+                symbol={buyAsset.symbol}
+                fontSize='xl'
+              />
             </Flex>
           </Flex>
-          <Tag colorScheme={tagColorScheme}>{translate(`limitOrders.status.${status}`)}</Tag>
+          <Tag colorScheme={tagColorScheme}>{translate(`limitOrder.status.${status}`)}</Tag>
         </Flex>
 
         {/* Price row */}
         <Flex justify='space-between' align='center'>
-          <Text color='gray.500' translation='limitOrders.limitPrice' />
+          <Text color='gray.500' translation='limitOrder.limitPrice' />
           <Flex justify='flex-end'>
             <RawText mr={1}>{`1 ${sellAsset.symbol} =`}</RawText>
             <Amount.Crypto value={limitPrice} symbol={buyAsset.symbol} />
           </Flex>
         </Flex>
 
-        {/* Expiry row */}
-        <Flex justify='space-between' align='center'>
-          <Text color='gray.500' translation='limitOrders.expiresIn' />
-          <RawText>{`${expiry} days`}</RawText>
-        </Flex>
+        {/* Expiry row - excluded for historical orders*/}
+        {Boolean(expiryText) && (
+          <Flex justify='space-between' align='center'>
+            <Text color='gray.500' translation='limitOrder.expiresIn' />
+            <RawText>{expiryText}</RawText>
+          </Flex>
+        )}
 
         {/* Filled row */}
         <Flex justify='space-between' align='center'>
-          <Text color='gray.500' translation='limitOrders.filled' />
+          <Text color='gray.500' translation='limitOrder.status.fulfilled' />
           <Flex align='center' gap={4} width='60%'>
             <Progress
               value={filledDecimalPercentage * 100}
@@ -142,7 +172,7 @@ export const LimitOrderCard: FC<LimitOrderCardProps> = ({
         </Flex>
 
         {/* Cancel button */}
-        {status === LimitOrderStatus.Open && (
+        {status === OrderStatus.OPEN && (
           <Button
             colorScheme='red'
             width='100%'

--- a/src/components/MultiHopTrade/components/LimitOrder/components/LimitOrderList.tsx
+++ b/src/components/MultiHopTrade/components/LimitOrder/components/LimitOrderList.tsx
@@ -6,11 +6,13 @@ import {
   Center,
   Flex,
   Heading,
+  Spinner,
   Tab,
   TabList,
   TabPanel,
   TabPanels,
   Tabs,
+  VStack,
 } from '@chakra-ui/react'
 import type { ChainId } from '@shapeshiftoss/caip'
 import { ASSET_NAMESPACE, fromAccountId, fromChainId, toAssetId } from '@shapeshiftoss/caip'
@@ -62,7 +64,7 @@ export const LimitOrderList: FC<LimitOrderListProps> = ({ cardProps, onBack }) =
     }
   }, [onBack])
 
-  const { data: ordersResponse } = useGetLimitOrdersQuery()
+  const { data: ordersResponse, isLoading } = useGetLimitOrdersQuery()
 
   const [openLimitOrders, historicalLimitOrders] = useMemo(() => {
     if (!ordersResponse) return []
@@ -128,7 +130,18 @@ export const LimitOrderList: FC<LimitOrderListProps> = ({ cardProps, onBack }) =
           <TabPanels>
             <TabPanel px={0} py={0}>
               <CardBody px={0} overflowY='auto' flex='1 1 auto'>
-                {openLimitOrders !== undefined && openLimitOrders.length > 0 ? (
+                {isLoading && (
+                  // subtract height of tab header
+                  <Center width='full' height={`calc(${cardProps?.height}px - 40px)`}>
+                    <VStack>
+                      <Spinner />
+
+                      <Text color='text.subtle' translation='limitOrder.loadingOrderList' />
+                    </VStack>
+                  </Center>
+                )}
+                {openLimitOrders !== undefined &&
+                  openLimitOrders.length > 0 &&
                   openLimitOrders.map(({ sellAssetId, buyAssetId, order }) => (
                     <LimitOrderCard
                       key={order.uid}
@@ -143,8 +156,8 @@ export const LimitOrderList: FC<LimitOrderListProps> = ({ cardProps, onBack }) =
                         .toNumber()}
                       status={order.status}
                     />
-                  ))
-                ) : (
+                  ))}
+                {!isLoading && (openLimitOrders === undefined || openLimitOrders.length === 0) && (
                   <Center h='full'>
                     <Text color='text.subtle' translation='limitOrder.noOpenOrders' />
                   </Center>

--- a/src/components/MultiHopTrade/components/LimitOrder/components/LimitOrderList.tsx
+++ b/src/components/MultiHopTrade/components/LimitOrder/components/LimitOrderList.tsx
@@ -12,14 +12,18 @@ import {
   Tabs,
 } from '@chakra-ui/react'
 import { foxAssetId } from '@shapeshiftoss/caip'
+import { useQuery } from '@tanstack/react-query'
+import { getConfig } from 'config'
 import type { FC } from 'react'
 import { useMemo } from 'react'
 import { usdcAssetId } from 'test/mocks/accounts'
 import { Text } from 'components/Text'
+import { selectAccountIdsByChainId, selectEvmAccountIds } from 'state/slices/selectors'
+import { useAppSelector } from 'state/store'
 
-import { WithBackButton } from '../WithBackButton'
-import { LimitOrderCard } from './components/LimitOrderCard'
-import { LimitOrderStatus } from './types'
+import { WithBackButton } from '../../WithBackButton'
+import { LimitOrderStatus } from '../types'
+import { LimitOrderCard } from './LimitOrderCard'
 
 type LimitOrderListProps = {
   isLoading: boolean
@@ -39,6 +43,8 @@ export const LimitOrderList: FC<LimitOrderListProps> = ({ cardProps, onBack }) =
       }),
     }
   }, [onBack])
+
+  const evmAccountIds = useAppSelector(selectEvmAccountIds)
 
   // FIXME: Use real data
   const MockOpenOrderCard = () => (

--- a/src/components/MultiHopTrade/components/LimitOrder/components/LimitOrderList.tsx
+++ b/src/components/MultiHopTrade/components/LimitOrder/components/LimitOrderList.tsx
@@ -36,7 +36,7 @@ type LimitOrderListProps = {
 
 const cowSwapTokenToAssetId = (chainId: ChainId, cowSwapToken: Address) => {
   const { chainNamespace, chainReference } = fromChainId(chainId)
-  return cowSwapToken === COW_SWAP_NATIVE_ASSET_MARKER_ADDRESS
+  return cowSwapToken.toLowerCase() === COW_SWAP_NATIVE_ASSET_MARKER_ADDRESS.toLowerCase()
     ? toAssetId({
         chainId,
         assetNamespace: 'slip44',

--- a/src/components/MultiHopTrade/components/LimitOrder/hooks/useGetLimitOrdersForAccountQuery.tsx
+++ b/src/components/MultiHopTrade/components/LimitOrder/hooks/useGetLimitOrdersForAccountQuery.tsx
@@ -1,0 +1,56 @@
+import { type AccountId, fromAccountId } from '@shapeshiftoss/caip'
+import { getCowswapNetwork } from '@shapeshiftoss/swapper'
+import type { Order } from '@shapeshiftoss/types/dist/cowSwap'
+import { useQueries } from '@tanstack/react-query'
+import axios from 'axios'
+import { getConfig } from 'config'
+import { useCallback } from 'react'
+import { mergeQueryOutputs } from 'react-queries/helpers'
+import { selectEvmAccountIds } from 'state/slices/common-selectors'
+import { useAppSelector } from 'state/store'
+
+type CustomTokenQueryKey = ['getLimitOrdersForAccount', AccountId]
+
+const getLimitOrdersForAccountQueryKey = (accountId: AccountId): CustomTokenQueryKey => [
+  'getLimitOrdersForAccount',
+  accountId,
+]
+
+export const useGetLimitOrdersQuery = () => {
+  const evmAccountIds = useAppSelector(selectEvmAccountIds)
+
+  const getQueryFn = useCallback(
+    (accountId: AccountId) => async () => {
+      const { account, chainId } = fromAccountId(accountId)
+      const maybeNetwork = getCowswapNetwork(chainId)
+      if (maybeNetwork.isErr()) throw maybeNetwork.unwrapErr()
+      const network = maybeNetwork.unwrap()
+      const config = getConfig()
+      const baseUrl = config.REACT_APP_COWSWAP_BASE_URL
+      const result = await axios.get<Order[]>(
+        // TODO: Implement paging for users with >1000 orders
+        `${baseUrl}/${network}/api/v1/account/${account}/orders?limit=1000`,
+      )
+
+      return result.data.map(order => {
+        return { order, accountId }
+      })
+    },
+    [],
+  )
+
+  const customTokenQueries = useQueries({
+    queries: evmAccountIds
+      .filter(accountId => {
+        const { chainId } = fromAccountId(accountId)
+        return getCowswapNetwork(chainId).isOk()
+      })
+      .map(accountId => ({
+        queryKey: getLimitOrdersForAccountQueryKey(accountId),
+        queryFn: getQueryFn(accountId),
+      })),
+    combine: queries => mergeQueryOutputs(queries, results => results.flat()),
+  })
+
+  return customTokenQueries
+}

--- a/src/components/MultiHopTrade/components/LimitOrder/hooks/useGetLimitOrdersForAccountQuery.tsx
+++ b/src/components/MultiHopTrade/components/LimitOrder/hooks/useGetLimitOrdersForAccountQuery.tsx
@@ -1,4 +1,5 @@
-import { type AccountId, fromAccountId } from '@shapeshiftoss/caip'
+import type { AccountId } from '@shapeshiftoss/caip'
+import { fromAccountId } from '@shapeshiftoss/caip'
 import { getCowswapNetwork } from '@shapeshiftoss/swapper'
 import type { Order } from '@shapeshiftoss/types/dist/cowSwap'
 import { useQueries } from '@tanstack/react-query'

--- a/src/components/MultiHopTrade/components/LimitOrder/types.ts
+++ b/src/components/MultiHopTrade/components/LimitOrder/types.ts
@@ -5,10 +5,3 @@ export enum LimitOrderRoutePaths {
   PlaceOrder = '/trade/limit-order/place-order',
   Orders = '/trade/limit-order/orders',
 }
-
-export enum LimitOrderStatus {
-  Open = 'open',
-  Filled = 'filled',
-  Cancelled = 'cancelled',
-  Expired = 'expired',
-}

--- a/src/state/apis/limit-orders/limitOrderApi.ts
+++ b/src/state/apis/limit-orders/limitOrderApi.ts
@@ -41,9 +41,7 @@ import { zeroAddress } from 'viem'
 import { assertGetEvmChainAdapter } from 'lib/utils/evm'
 import type { ReduxState } from 'state/reducer'
 import { selectConfirmedLimitOrder } from 'state/slices/limitOrderSlice/selectors'
-import {
-  selectPortfolioAccountMetadataByAccountId,
-} from 'state/slices/selectors'
+import { selectPortfolioAccountMetadataByAccountId } from 'state/slices/selectors'
 
 import { BASE_RTK_CREATE_API_CONFIG } from '../const'
 

--- a/src/state/apis/limit-orders/limitOrderApi.ts
+++ b/src/state/apis/limit-orders/limitOrderApi.ts
@@ -25,6 +25,7 @@ import type {
   Trade,
 } from '@shapeshiftoss/types/dist/cowSwap'
 import {
+  OrderClass,
   OrderQuoteSideKindSell,
   PriceQuality,
   SellTokenSource,
@@ -90,7 +91,7 @@ export const limitOrderApi = createApi({
         const { appData, appDataHash } = await getFullAppData(
           slippageTolerancePercentageDecimal,
           affiliateAppDataFragment,
-          'limit',
+          OrderClass.LIMIT,
         )
 
         const limitOrderQuoteRequest: OrderQuoteRequest = {

--- a/src/state/apis/limit-orders/limitOrderApi.ts
+++ b/src/state/apis/limit-orders/limitOrderApi.ts
@@ -291,4 +291,5 @@ export const limitOrderApi = createApi({
   }),
 })
 
-export const { useQuoteLimitOrderQuery, usePlaceLimitOrderMutation } = limitOrderApi
+export const { useQuoteLimitOrderQuery, useGetOrdersQuery, usePlaceLimitOrderMutation } =
+  limitOrderApi

--- a/src/state/apis/limit-orders/limitOrderApi.ts
+++ b/src/state/apis/limit-orders/limitOrderApi.ts
@@ -1,6 +1,6 @@
 import { createApi, fakeBaseQuery } from '@reduxjs/toolkit/dist/query/react'
-import type { AssetId, ChainId } from '@shapeshiftoss/caip'
-import { fromAssetId, fromChainId } from '@shapeshiftoss/caip'
+import type { AccountId, AssetId, ChainId } from '@shapeshiftoss/caip'
+import { fromAccountId, fromAssetId, fromChainId } from '@shapeshiftoss/caip'
 import type { SignTypedDataInput } from '@shapeshiftoss/chain-adapters'
 import { toAddressNList } from '@shapeshiftoss/chain-adapters'
 import type { ETHSignTypedData, HDWallet } from '@shapeshiftoss/hdwallet-core'
@@ -15,7 +15,6 @@ import {
 } from '@shapeshiftoss/swapper/dist/swappers/CowSwapper/utils/helpers/helpers'
 import { isNativeEvmAsset } from '@shapeshiftoss/swapper/dist/swappers/utils/helpers/helpers'
 import type {
-  GetOrdersRequest,
   Order,
   OrderCancellation,
   OrderCreation,
@@ -42,7 +41,9 @@ import { zeroAddress } from 'viem'
 import { assertGetEvmChainAdapter } from 'lib/utils/evm'
 import type { ReduxState } from 'state/reducer'
 import { selectConfirmedLimitOrder } from 'state/slices/limitOrderSlice/selectors'
-import { selectPortfolioAccountMetadataByAccountId } from 'state/slices/selectors'
+import {
+  selectPortfolioAccountMetadataByAccountId,
+} from 'state/slices/selectors'
 
 import { BASE_RTK_CREATE_API_CONFIG } from '../const'
 
@@ -252,18 +253,39 @@ export const limitOrderApi = createApi({
         return { data: result.data }
       },
     }),
-    getOrders: build.query<Order[], { payload: GetOrdersRequest; chainId: ChainId }>({
-      queryFn: async ({ payload, chainId }) => {
+    getOrders: build.query<{ orders: Order[]; failedAccountIds: AccountId[] }, AccountId[]>({
+      queryFn: async (evmAccountIds: AccountId[]) => {
         const config = getConfig()
         const baseUrl = config.REACT_APP_COWSWAP_BASE_URL
-        const maybeNetwork = getCowswapNetwork(chainId)
-        if (maybeNetwork.isErr()) throw maybeNetwork.unwrapErr()
-        const network = maybeNetwork.unwrap()
-        const result = await axios.post<Order[]>(
-          `${baseUrl}/${network}/api/v1/account/${payload.owner}/orders`,
-          { limit: payload.limit, offset: payload.offset },
+
+        const promiseSettledResults = await Promise.allSettled(
+          evmAccountIds.map(async accountId => {
+            const { account, chainId } = fromAccountId(accountId)
+            const maybeNetwork = getCowswapNetwork(chainId)
+            if (maybeNetwork.isErr()) throw maybeNetwork.unwrapErr()
+            const network = maybeNetwork.unwrap()
+            const result = await axios.get<Order[]>(
+              // TODO: Implement paging for users with >1000 orders
+              `${baseUrl}/${network}/api/v1/account/${account}/orders?limit=1000`,
+            )
+
+            return result.data
+          }),
         )
-        return { data: result.data }
+
+        const orders = []
+        const failedAccountIds = []
+
+        for (let i = 0; i < promiseSettledResults.length; i++) {
+          const promiseSettledResult = promiseSettledResults[i]
+          if (promiseSettledResult.status === 'rejected') {
+            failedAccountIds.push(evmAccountIds[i])
+          } else {
+            orders.push(...promiseSettledResult.value)
+          }
+        }
+
+        return { data: { orders, failedAccountIds } }
       },
     }),
   }),


### PR DESCRIPTION
## Description

Fetches all limit orders for all connected accounts, and renders them in the appropriate list.

## Issue (if applicable)

<!-----------------------------------------------------------------------------
If applicable, please link to the github issue and put `closes #XXXX` in your comment to auto-close the issue that your PR fixes.
------------------------------------------------------------------------------>

closes #8170

## Risk

> High Risk PRs Require 2 approvals

Low risk. Isolated to limit orders aside from a types package version bump.

> What protocols, transaction types, wallets or contract interactions might be affected by this PR?

## Testing

TIP: Head over to the [cowswap app](https://swap.cow.fi/#/) to create some limit orders to test.

- Quick sanity check to ensure cowswap spot trades arent broken, as types package version on an import was bumped.
- Local sanity check of limit orders list loading, data etc.

### Engineering

<!-----------------------------------------------------------------------------
Include sufficient information here for an engineer to test your PR. This may include how to test locally, in a built environment, changes to infrastructure etc.
------------------------------------------------------------------------------>

### Operations

- [x] :checkered_flag: My feature is behind a flag and doesn't require operations testing (yet)

<!-----------------------------------------------------------------------------
If your changes have a user-facing impact, describe how a non-technical QA team can functionally test your changes in a preview environment.

If they are not user-facing please describe how to test for any regressions that may occur.
------------------------------------------------------------------------------>

## Screenshots (if applicable)

Demo of limit orders list loading etc.
https://jam.dev/c/fab8042c-b947-44df-89f1-88657e82ad00