### PR TITLE
fix: unrug Li.Fi trades

### DIFF
--- a/src/components/MultiHopTrade/hooks/useGetTradeQuotes/hooks/useGetSwapperTradeQuoteOrRate.tsx
+++ b/src/components/MultiHopTrade/hooks/useGetTradeQuotes/hooks/useGetSwapperTradeQuoteOrRate.tsx
@@ -29,9 +29,6 @@ export const useGetSwapperTradeQuoteOrRate = ({
     () => ({
       skip,
       pollingInterval,
-      // If we don't refresh on arg change might select a cached result with an old "started_at" timestamp
-      // We can remove refetchOnMountOrArgChange if we want to make better use of the cache, and we have a better way to select from the cache.
-      refetchOnMountOrArgChange: true,
     }),
     [pollingInterval, skip],
   )

--- a/src/state/apis/swapper/swapperApi.ts
+++ b/src/state/apis/swapper/swapperApi.ts
@@ -88,7 +88,13 @@ export const swapperApi = createApi({
                 ...tradeQuoteInput,
                 // Receive address should always be undefined for trade *rates*, however, we *do* pass it to check for cross-account support
                 // so we have to ensure it is gone by the time we call getTradeRates
-                receiveAddress: undefined,
+                receiveAddress:
+                  // Ok, we may have lied just before. Li.Fi is the odd one, and we don't want to fetch a final quote for it.
+                  // The reason is Li.Fi routes are very fragile and from one request to the other, it's more likely than not a tool may not be returned anymore, resulting in early null returns
+                  // in swapper, i.e a totally broken state.
+                  // By keeping the receiveAddress in all the way through, and returning it in LIFI's `getTradeRate()`, the rate becomes an effective, quote, and the
+                  // `shouldFetchTradeQuote = isExecutableTradeQuote(activeTrade)` never becomes true, meaning we keep the rate as a quote.
+                  swapperName === SwapperName.LIFI ? tradeQuoteInput.receiveAddress : undefined,
                 affiliateBps,
               } as GetTradeRateInput,
               swapperName,

--- a/src/state/apis/swapper/swapperApi.ts
+++ b/src/state/apis/swapper/swapperApi.ts
@@ -92,7 +92,7 @@ export const swapperApi = createApi({
                   // Ok, we may have lied just before. Li.Fi is the odd one, and we don't want to fetch a final quote for it.
                   // The reason is Li.Fi routes are very fragile and from one request to the other, it's more likely than not a tool may not be returned anymore, resulting in early null returns
                   // in swapper, i.e a totally broken state.
-                  // By keeping the receiveAddress in all the way through, and returning it in LIFI's `getTradeRate()`, the rate becomes an effective, quote, and the
+                  // By keeping the receiveAddress in all the way through, and returning it in LIFI's `getTradeRate()`, the rate becomes an effective quote, and the
                   // `shouldFetchTradeQuote = isExecutableTradeQuote(activeTrade)` never becomes true, meaning we keep the rate as a quote.
                   swapperName === SwapperName.LIFI ? tradeQuoteInput.receiveAddress : undefined,
                 affiliateBps,


### PR DESCRIPTION
## Description

The one big risk we were affraid of for Li.Fi *did* produce a regression. Tyvm @0xean for your bad luck with web and encountering those bugs in place of users.

Commentaries repeated code should be pretty self-explanatory, but writing this in the PR as well:

Li.Fi is a flaky one, and making the exact same request to its routes endpoints a sec later may yield very different routes. Some may be missing from previous call, new ones may be present, and you may even end up with no routes at all. 
This is an issue with the rates vs. quotes split, as we would otherwise fetch a final quote at pre-signing time, but we absolutely can *not* do that, as, depending on the underlying Li.Fi tool used, you're more than likely to not see the same route a few seconds later. Examples of routes that almost consistently disappear are: Kyberswap, Paraswap, 1inch, UNI-V2. 

## Issue (if applicable)

<!-----------------------------------------------------------------------------
If applicable, please link to the github issue and put `closes #XXXX` in your comment to auto-close the issue that your PR fixes.
------------------------------------------------------------------------------>

closes N,A, spotted in release by @0xean and @purelycrickets 

## Risk

> High Risk PRs Require 2 approvals

<!-----------------------------------------------------------------------------
Outline the scope of your changes and the risk associated with them. You must use your discretion as an engineer to determine the potential impact of your changes.

WARNING: If your PR introduces a new on-chain transaction or modifies an existing one, please add the "High-Risk" label to this PR and ask for 2 reviewers to approve it before merging.

E.g. an upgrade to `hdwallet` or core state management would be considered higher risk, and might require a full regression test. UI or isolated view changes, or something behind a feature flag may have near zero risk. Small bug fixes might require testing isolated to the specific fix.
------------------------------------------------------------------------------>

Medium - theoretically scoped to Li.Fi

> What protocols, transaction types, wallets or contract interactions might be affected by this PR?

## Testing

<!-----------------------------------------------------------------------------
We treat every PR to be merged with the same scrutiny as if we were merging directly to production.

Your PR will not be merged if you do not complete the sections below for our engineering and operations teams to test.
------------------------------------------------------------------------------>

- Get a rate which includes Li.Fi routes e.g ETH -> FOX
- Select any route which is not the Li.Fi DEX aggregator one e.g Kyberswap, Paraswap, 1inch, UNI-V2
- Ensure you can proceed to Tx signing without seeing any weird empty state in swapper
- Back off and try again with a few Li.Fi tools and confirm we're still happy 

### Engineering

<!-----------------------------------------------------------------------------
Include sufficient information here for an engineer to test your PR. This may include how to test locally, in a built environment, changes to infrastructure etc.
------------------------------------------------------------------------------>

- ☝🏽 
- Filter out requests by li.quest and paranoia check we're not doing a final `routes` at secondary confirm screen 

### Operations

- [ ] :checkered_flag: My feature is behind a flag and doesn't require operations testing (yet)

<!-----------------------------------------------------------------------------
If your changes have a user-facing impact, describe how a non-technical QA team can functionally test your changes in a preview environment.

If they are not user-facing please describe how to test for any regressions that may occur.
------------------------------------------------------------------------------>

- ☝🏽 

## Screenshots (if applicable)

https://jam.dev/c/1996f770-531a-4cee-b3f5-d38bf9a198f1
